### PR TITLE
chore: improve MatrixOne agent skills

### DIFF
--- a/.agents/skills/mo-bug-triage/SKILL.md
+++ b/.agents/skills/mo-bug-triage/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: mo-bug-triage
-description: Systematic triage and classification of MatrixOne kind/bug issues — calibrated severity assessment, batched GitHub metadata updates (milestone, severity, project), rollback-safe batch processing, and drift prevention. Use when asked to triage, classify, or bulk-update MO bugs.
-compatibility: Designed for Codex CLI and compatible agents. Requires GitHub CLI (gh) with authenticated access (5000 req/hr) and repo write scope.
+description: Systematic MatrixOne kind/bug lifecycle triage — intake normalization with `needs-triage`, conservative promotion to active severity (`severity/s-1`, `severity/s0`, `severity/s1`), immediate downgrade to `deferred` with explanatory comments, optional five-level AI effort labeling (`ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual`) only when explicitly requested for issues/PRs, batched GitHub metadata updates, rollback-safe processing, and drift prevention. Use when asked to triage, classify, review, downgrade, defer, label, AI-effort-assess, or bulk-update MO bugs and related PRs.
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone
   workflow: bug-triage
 ---
 
+Compatibility: designed for Codex CLI and compatible agents. Requires GitHub CLI (`gh`) with authenticated access (5000 req/hr) and repo write scope.
+
 ## Enforcement Gates
 
 | Gate | When | Action |
 |------|------|--------|
+| **G-INTAKE** | When handling new bugs | New `kind/bug` issues enter `needs-triage`. Do not assign active severity during intake unless a maintainer explicitly confirms emergency impact. |
+| **G-PROMOTION** | Before applying `severity/s-1`, `severity/s0`, or active `severity/s1` | Evidence must show confirmed urgency/impact or a committed owner. Record the rationale in the report or issue comment. |
+| **G-DEFER-COMMENT** | Before applying `deferred` | Add an explicit comment explaining why the issue should not continue as s0/s1 active work. |
+| **G-AI-REQUEST** | Before assessing or applying any AI effort label | User must explicitly request AI effort assessment, or the run mode must be `ai-assess`/`ai-final`. Plain `needs-triage` intake must not infer or apply `ai-*`. |
+| **G-AI-SOURCE** | Before applying any AI effort label | Record assessment stage (`issue-initial`, `pr-review`, or `user-assisted`), confidence, and one-sentence rationale. |
+| **G-AI-FINAL** | During explicit `ai-final` or PR AI-label review | Recheck five-level AI effort against actual implementation effort and update issue + PR labels if stale. |
 | **G-STANDARDS** | Before any GitHub write | STANDARDS.md must exist with `Approved: true`. Scripts exit(1) if missing. |
 | **G-SNAPSHOT** | Before batch update | `batch_N_before_snapshot.json` must be saved. Rollback requires it. |
 | **G-DRYRUN** | Before full batch update | First 5 issues updated + verified. Mismatch → stop. |
@@ -22,15 +29,23 @@ metadata:
 ## TL;DR
 
 ```
+Default lifecycle
+  → New bug: kind/bug + needs-triage; no priority promise at entry
+  → Analysis: verify repro, impact, owner, dependency, duplicates
+  → Execute: promote only confirmed urgent/high-impact work to s-1/s0
+  → Active non-emergency work: use s1 only when owned and committed
+  → Downgrade: if not s0/s1 active work, move to deferred + comment
+  → AI effort: do not run by default; assess only on explicit request or ai-* mode
+
 Phase 1: LOCK STANDARDS   (~15min, 0 writes)
-  → Sample 8-12 bugs by domain → user approves STANDARDS.md → gate locked
+  → Sample 8-12 bugs by domain → lock lifecycle/severity/defer rules
 
 Phase 2: BATCHED PROCESS  (~5min per batch of 50)
-  → Each batch: fetch→classify→report→snapshot→dry-run→update→progress
+  → Each batch: fetch→classify action→report→snapshot→dry-run→update→progress
   → Batch N failure never touches Batch 1..N-1 (already committed)
 
 Phase 3: FINAL VERIFY      (~10min)
-  → Domain audit + severity cross-check + batch spot-check + sampled API verify
+  → Lifecycle audit + label count cross-check + defer-comment check; AI-label checks only for explicit AI modes
 ```
 
 ~310 issues ≈ 7 batches ≈ **30-45 min** (limited by GitHub rate limit: 5000 req/hr).
@@ -39,33 +54,58 @@ Phase 3: FINAL VERIFY      (~10min)
 
 ## Core Rules
 
+### Current GitHub Bug Workflow
+
+| Stage | Required Behavior |
+|-------|-------------------|
+| **Intake** | Label new bugs as `kind/bug` + `needs-triage`. Treat this as the candidate pool, not a priority commitment. Do not pre-assign `severity/s0`, `severity/s1`, or `severity/s-1` from title keywords alone. |
+| **Execution** | Promote only confirmed urgent or broad-impact issues to `severity/s0` or `severity/s-1`. Use `severity/s1` only for owned, committed near-term bug work that should stay active but is not s0/s-1. |
+| **Downgrade** | After analysis, if an issue should not continue as s0/s1 active work, immediately remove active severity/`needs-triage`, add `deferred`, and comment with the concrete reason. |
+| **AI Labels** | Do not apply AI effort labels during default `needs-triage`. Apply exactly one AI effort label (`ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual`) only when the user asks for AI effort assessment or when running explicit `ai-assess`/`ai-final`. |
+| **Ownership** | Each owner is responsible for their own issues and PRs: keep labels, comments, linked PRs, and closure status current without waiting to be driven. |
+
+### Lifecycle Labels
+
+| Label | Meaning | Write Rule |
+|-------|---------|------------|
+| `needs-triage` | Candidate pool for newly reported or not-yet-analyzed bugs. | Add at entry; remove only when promoted, deferred, closed, or explicitly excluded. Do not add `ai-*` during intake. |
+| `severity/s-1` | Confirmed project emergency. | Use only for multi-tenant isolation/data exposure or explicit maintainer-confirmed emergency. If confirmed serious but not s-1 → `severity/s0`; if evidence is incomplete → `needs-triage`. |
+| `severity/s0` | Confirmed urgent/high-impact active work. | Requires evidence: stable repro or production signal plus broad impact, data integrity risk, crash/hang/OOM/leak, common-path breakage, or release blocker. |
+| `severity/s1` | Confirmed active work that is important but not emergency. | Requires an owner or near-term commitment. Do not use as a parking lot for unconfirmed bugs. |
+| `deferred` | Analyzed but not active s0/s1 work. | Requires a comment explaining why and what signal would justify reopening/promoting. Prefer this over creating new `severity/s2` triage unless explicitly requested. |
+| `ai-easy` | AI can directly implement; human review is mostly a quick scan. Suitable for batch/parallel AI execution. | Use for clear, localized, low-risk fixes with deterministic validation. |
+| `ai-light` | AI can produce a good draft or plan; human must tune details or make a small decision. | Use when scope is bounded but there is minor ambiguity in expected behavior, tests, or local integration. |
+| `ai-medium` | Human and AI likely need several rounds, with roughly shared effort. | Use when root cause or fix shape is partially unclear, or the change crosses a few modules. |
+| `ai-heavy` | AI can assist with research, snippets, tests, or log analysis; core logic stays human-owned. | Use for broad, risky, or subsystem-level work where human design/debug judgment dominates. |
+| `ai-manual` | AI is unlikely to help beyond clerical support. | Use when work depends on unavailable environments/data, security-sensitive access, product decisions, or human-only operational context. |
+
 ### Severity Hierarchy
 
 | Severity | Criteria | Examples |
 |----------|----------|----------|
-| **s-1** | **MUST be conservative.** Only: multi-tenant isolation breach. Refer to existing project s-1 count (≤5). If unsure → s0. | #15972 tenant isolation break |
-| **s0** | **THE MAIN BUCKET** (~70%). Panic/crash, hung/deadlock, OOM/memory exhaustion, data integrity violation, resource leak, commonly-used feature broken, performance regression on core paths. | INSERT panic, subquery hung, LOAD DATA OOM, lockservice leak, ORDER BY wrong, Prisma compat |
-| **s1** | **Lower priority** (~20%). Partition bugs, streaming bugs, cold/infrequently-used features, edge-case functions, subtasks of larger features. | partition pruning, streaming CTE, collation, SP, backup/restore, role admin, REPLACE subtasks |
-| **s2** | **Very low priority** (~10%). Feature requests mislabeled as bugs, tech debt, typos, non-functional cleanup. | "support X", refactor internal API, doc fix |
+| **s-1** | **MUST be conservative.** Multi-tenant isolation/data exposure, cross-tenant corruption, or explicitly confirmed project emergency. Refer to existing project s-1 count (≤5). If confirmed serious but not s-1 → s0; if evidence is incomplete → needs-triage. | tenant isolation break, cross-account data exposure |
+| **s0** | Confirmed urgent/high-impact active bug: panic/crash, hung/deadlock, OOM/memory exhaustion, data integrity violation, resource leak, commonly-used feature broken, performance regression on core paths, release blocker. | INSERT panic, subquery hung, LOAD DATA OOM, lockservice leak, ORDER BY wrong, Prisma compat |
+| **s1** | Confirmed active non-emergency bug with owner/commitment. Lower-impact partition/streaming/cold-feature bugs can be s1 only when they should be worked soon. | planned partition pruning fix, assigned streaming CTE bug, owned backup/restore issue |
+| **deferred** | Not active s0/s1 work after analysis. Use for unstable repro, missing dependencies, non-critical paths, duplicate/consolidated work, feature requests mislabeled as bugs, tech debt, typos, or cleanup. | repro not stable, blocked by dependency, merge into existing issue, cold feature not planned |
 
 ### Domain Downgrade Table
 
-These domains are **auto-downgraded** UNLESS a higher-severity trigger fires:
+These domains default to `deferred` after analysis unless a higher-severity trigger is confirmed or an owner commits to near-term work:
 
-| Domain | Default | Exception (keeps original severity) |
+| Domain | Default | Exception |
 |--------|---------|-------------------------------------|
-| Partition | s1 | Panic/crash → s0; data integrity → s0 |
-| Streaming | s1 | Panic/crash → s0; data integrity → s0 |
-| Cold features | s1 | Panic/crash → s0; data integrity → s0 |
+| Partition | `deferred` | Confirmed panic/crash/data integrity → s0; owned near-term work → s1 |
+| Streaming | `deferred` | Confirmed panic/crash/data integrity → s0; owned near-term work → s1 |
+| Cold features | `deferred` | Confirmed panic/crash/data integrity → s0; owned near-term work → s1 |
 | Feature Request | **exclude** | N/A — skip bug triage entirely |
 
 **Cold features list**: stored procedures, CTE, window functions, collation, fulltext, backup/restore, role/DCL (GRANT/REVOKE), REPLACE INTO, trigger, event scheduler.
 
-> **Note**: `LOAD DATA` and `import` are NOT cold features — they are commonly-used ETL paths. Their bugs default to s0.
+> **Note**: `LOAD DATA` and `import` are NOT cold features — they are commonly-used ETL paths. Confirmed breakage can justify s0, but intake still starts at `needs-triage`.
 
-### s0 Triggers (override domain downgrade)
+### s0 Investigation Triggers
 
-A bug hits s0 if the title+body contains ANY of these keywords:
+These keywords are investigation triggers. They justify a closer look, not automatic promotion from `needs-triage`.
 
 | Trigger | Keywords |
 |---------|----------|
@@ -78,15 +118,33 @@ A bug hits s0 if the title+body contains ANY of these keywords:
 ### Classification Algorithm
 
 1. Extract `title` (lowercase), `body` (lowercase) from issue JSON
-2. Check s-1: `"tenant isolation"` or `"cross-tenant"` in title → `severity/s-1`
-3. Detect domains: is_partition, is_streaming, is_cold_feature (keyword matching)
-4. Check s0 triggers in title+body (panic/hung/OOM/data-integrity/resource-leak)
-5. **If ANY s0 trigger fires → `severity/s0` regardless of domain**
-6. Else if partition/streaming/cold-feature → `severity/s1`
-7. Else → `severity/s0` (default common feature)
-8. Project: `MOEngine-Compute` default; `MOEngine-Storage` if `logservice|tn|wal|replica|storage` in title
+2. If the issue is new/untriaged: ensure `kind/bug` + `needs-triage`; do not add active severity yet
+3. Detect domains: is_partition, is_streaming, is_cold_feature, is_feature_request, duplicate/consolidation candidate
+4. Detect evidence flags: panic/hung/OOM/data-integrity/resource-leak/common-path/release-blocker
+5. Decide action:
+   - `promote-s-1`: confirmed multi-tenant isolation/data exposure or explicit maintainer emergency
+   - `promote-s0`: confirmed urgent/high-impact active bug with evidence and owner path
+   - `promote-s1`: confirmed active non-emergency bug with owner/near-term commitment
+   - `defer`: analyzed but not active s0/s1 work; requires comment
+   - `keep-needs-triage`: insufficient information and no owner analysis yet
+   - `exclude`: feature request or non-bug; remove from bug triage path per repo convention
+6. Skip AI effort assessment by default. If and only if explicitly requested or running `ai-assess`/`ai-final`, estimate one AI effort label and record stage (`issue-initial`, `pr-review`, or `user-assisted`), confidence, and evidence in the report
+7. Project: `MOEngine-Compute` default; `MOEngine-Storage` if `logservice|tn|wal|replica|storage` in title
+8. If the user requested `ai-final` or PR AI-label review, re-evaluate AI label using actual code changes/tests/review complexity and update issue + PR labels
 
-**Key invariant**: s0 trigger (panic/hung/OOM/integrity/leak) always wins over domain downgrade.
+**Key invariant**: no issue leaves `needs-triage` for active severity without evidence and an owner/impact rationale. Keywords alone are never sufficient.
+
+### Deferred Comment Template
+
+When moving to `deferred`, write a short, concrete comment:
+
+```markdown
+Deferred after triage.
+
+Reason: <unstable repro | missing dependency | non-critical path | consolidated into #NNNNN | feature request / not a bug | insufficient impact signal>
+Current evidence: <one sentence>
+To promote later: <specific signal needed, owner action, or linked issue/PR>
+```
 
 ### Skip List
 
@@ -96,9 +154,43 @@ Skip entirely — do not classify, do not update:
 
 ### Severity Inflation Guard
 
-- Before s-1: verify **exactly** matches multi-tenant isolation breach. If unsure → s0.
-- Before s0: verify actual panic/hung/OOM/integrity/common-function-break. If only partition/streaming/cold-feature → s1.
-- Default for any ambiguity → **one tier lower** than instinct.
+- Before s-1: verify **exactly** matches multi-tenant isolation breach or explicit maintainer emergency. If serious but not s-1 and confirmed → s0; if unconfirmed → keep `needs-triage`.
+- Before s0: verify actual panic/hung/OOM/integrity/common-function-break plus urgency/impact. If evidence is only title keywords → keep `needs-triage`.
+- Before s1: verify there is an owner or near-term commitment. If not → `deferred` after analysis or keep `needs-triage` before analysis.
+- Default for any post-analysis ambiguity → `deferred` with a clear reopen/promote condition.
+
+### AI Effort Assessment
+
+Use AI labels to estimate **how much human involvement is required**, not severity or business priority. This is an opt-in assessment, not part of default `needs-triage`. Normalize spelling to lowercase: use `ai-medium`, not `ai-Medium`.
+
+| Label | Meaning | Strong Signals |
+|-------|---------|----------------|
+| `ai-easy` | AI directly handles it; human only scans the result. Can be batched and run in parallel. | Clear repro, obvious expected behavior, localized fix, deterministic test, no data/security/consensus risk. |
+| `ai-light` | AI writes a useful first draft or plan; human adjusts details or makes one bounded decision. | Localized bug with minor ambiguity, test needs adaptation, existing pattern is clear but exact choice needs review. |
+| `ai-medium` | Human and AI iterate for several rounds; roughly half the work is human judgment/debugging. | Root cause not fully isolated, fix touches several files/modules, requires repro refinement, test strategy is non-trivial. |
+| `ai-heavy` | AI is support only; core logic and decisions remain human-owned. | Cross-subsystem impact, concurrency/transaction/storage semantics, data correctness risk, production-only symptom, significant design/debug judgment. |
+| `ai-manual` | AI mostly cannot help beyond clerical tasks. | Requires private/unavailable environment or data, sensitive access, human-only operational/product decision, unclear report with no actionable evidence. |
+
+Assessment stages:
+
+- `issue-initial`: rough label from issue title/body/logs/repro. Prefer `ai-medium` or `ai-heavy` when evidence is thin.
+- `pr-review`: revise using linked PR diff, tests, review comments, files changed, and actual debugging burden.
+- `user-assisted`: combine issue/PR evidence with user-provided context such as owner knowledge, hidden dependency, production signal, or known fix plan.
+
+Assessment rules:
+
+- Do not infer AI effort during plain intake or default `kind/bug,needs-triage` triage. Leave all `ai-*` labels untouched unless the user requested AI assessment.
+- Apply at most one AI effort label at a time; remove the other four when updating.
+- Record `ai_label_stage`, `ai_confidence` (`low`, `medium`, `high`), and one-sentence `ai_rationale` in reports.
+- Escalate the label when correctness/security/consensus/storage/transaction risk is present, even if the diff looks small.
+- De-escalate only with evidence: linked PR proved localized, deterministic tests pass, or user confirms a simple known fix.
+- Near PR close, revise labels based on actual work rather than the initial estimate when an AI label exists or the user asks for `ai-final`.
+
+### Ownership Rule
+
+- For issues/PRs assigned to you or linked to your work, update labels/comments proactively.
+- Link PRs to issues, keep existing/requested issue and PR AI labels consistent near close, and close or defer issues explicitly.
+- Do not wait for another person to drive routine status, downgrade, AI label correction, or closure hygiene.
 
 ---
 
@@ -112,14 +204,16 @@ gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 1 --json tot
 
 Record `total_count`. Plan batches: `ceil(total_count / 50)`.
 
-### Step 1.2: Query Existing Severity Distribution
+### Step 1.2: Query Existing Lifecycle Distribution
 
 ```bash
 gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 500 --json labels \
-  --jq '.[].labels[].name' | grep '^severity/' | sort | uniq -c | sort -rn
+  --jq '.[].labels[].name' \
+  | grep -E '^(needs-triage|deferred|severity/|ai-easy|ai-light|ai-medium|ai-heavy|ai-manual)$' \
+  | sort | uniq -c | sort -rn
 ```
 
-Your output must roughly match: s-1 ≤ 5, s0 ~70%, s1 ~20%, s2 ~10%.
+Do not force a target ratio. Treat high active severity counts as an audit signal: `severity/s-1` must remain rare, `severity/s0`/`severity/s1` must have evidence/owners, and new work should accumulate in `needs-triage` until analyzed.
 
 ### Step 1.3: Domain-Stratified Sampling
 
@@ -147,21 +241,21 @@ gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 100 \
 
 ### Step 1.4: STANDARDS.md → User Approval Gate
 
-Present sampled issues with proposed severities. Produce file:
+Present sampled issues with proposed lifecycle actions. Produce file:
 
 ```markdown
 # MO Bug Triage Standards — [Date]
 
 ## Approved: false   ← MUST be set to true before Phase 2
 
-## Severity Rules (locked after approval)
+## Lifecycle + Severity Rules (locked after approval)
 ... (Core Rules tables above)
 
 ## Sampled Examples (user-confirmed)
-| # | Issue | Domain | Proposed | User Decision |
-|---|-------|--------|----------|---------------|
-| 1 | ... | DML | s0 | ✅ |
-| 2 | ... | Partition | s1 | ✅ |
+| # | Issue | Domain | Proposed Action | AI Estimate | Deferred Comment Required | User Decision |
+|---|-------|--------|-----------------|-------------|---------------------------|---------------|
+| 1 | ... | DML | promote-s0 | not requested | no | approved |
+| 2 | ... | Partition | defer | not requested | yes: non-critical path, no owner | approved |
 ```
 
 **Wait for explicit user "approved"/"looks good"**, then:
@@ -186,15 +280,26 @@ if not m or m.group(1) != "true":
 
 ## Phase 2: BATCHED PROCESS (~5 min/batch)
 
-Each batch is a sealed unit: fetch → classify → report → **snapshot** → dry-run → update → progress. Batch N failure never touches 1..N-1.
+Each batch is a sealed unit: fetch → classify action → report → **snapshot** → dry-run → update → progress. Batch N failure never touches Batch 1..N-1.
 
-### Step 2a: Fetch One Batch
+### Step 2a: Select Mode + Fetch One Batch
+
+Choose the mode explicitly:
+
+| Mode | Use When | Label Query |
+|------|----------|-------------|
+| `intake` | Normalize new bugs into the candidate pool | `kind/bug` then filter out issues already carrying `needs-triage`, `deferred`, or active severity |
+| `triage` | Analyze the candidate pool; do not assess AI effort unless explicitly requested | `kind/bug,needs-triage` |
+| `active-review` | Audit active work for downgrade or stale labels | Run separate batches for `kind/bug,severity/s0` and `kind/bug,severity/s1` |
+| `ai-assess` | User explicitly asks to estimate AI effort for issues | Query the user-requested issue set; may include `needs-triage` but must not be implicit |
+| `ai-final` | Recheck PR-close AI labels | Run separate linked issue/PR batches for `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, and `ai-manual` |
 
 ```bash
 PAGE=$1
+LABEL_QUERY="${LABEL_QUERY:-kind/bug,needs-triage}"
 gh api -H "Accept: application/vnd.github+json" \
-  "/repos/matrixorigin/matrixone/issues?state=open&labels=kind/bug&per_page=50&page=${PAGE}&sort=created&direction=desc" \
-  --jq '.[] | {number,title,body,labels:[.labels[].name],assignee:.assignee.login,state}' \
+  "/repos/matrixorigin/matrixone/issues?state=open&labels=${LABEL_QUERY}&per_page=50&page=${PAGE}&sort=created&direction=desc" \
+  --jq '.[] | {number,title,body,labels:[.labels[].name],assignees:[.assignees[].login],state,comments:.comments}' \
   > batch_${PAGE}_raw.json
 ```
 
@@ -204,7 +309,19 @@ gh api -H "Accept: application/vnd.github+json" \
 
 ### Step 2b: Classify This Batch
 
-Apply the Classification Algorithm from Core Rules. Companion script `scripts/classify.py` implements the keyword matching. Output: `batch_N_classified.json`.
+Apply the Classification Algorithm from Core Rules. Output `batch_N_classified.json` with:
+
+- `action`: `keep-needs-triage`, `promote-s-1`, `promote-s0`, `promote-s1`, `defer`, or `exclude`
+- `add_labels` and `remove_labels`: exact lifecycle/severity label delta. Include AI label deltas only in explicit `ai-assess`/`ai-final` mode.
+- `rationale`: one sentence explaining evidence and owner/impact reasoning
+- `deferred_comment`: required when `action == "defer"`
+
+Only when AI assessment is explicitly enabled, also output:
+
+- `ai_label`: `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual`, or `unknown`
+- `ai_label_stage`: `issue-initial`, `pr-review`, `user-assisted`, or `unknown`
+- `ai_confidence`: `low`, `medium`, or `high`
+- `ai_rationale`: one sentence explaining expected human vs AI effort
 
 **Skip checking**: filter out heni02 and Ariznawlll issues before classification.
 
@@ -222,21 +339,36 @@ Apply the Classification Algorithm from Core Rules. Companion script `scripts/cl
 | Range | #25260 → #24997 |
 | Total fetched | 50 |
 | Skipped (heni02/Ariznawlll) | 3 |
-| Classified | 47 |
+| Classified actions | 47 |
 
-## Severity Distribution
-| Severity | Count |
-|----------|-------|
-| s-1 | 0 |
-| s0 | 35 |
-| s1 | 10 |
-| s2 | 2 |
+## Action Distribution
+| Action | Count |
+|--------|-------|
+| keep-needs-triage | 18 |
+| promote-s-1 | 0 |
+| promote-s0 | 4 |
+| promote-s1 | 6 |
+| defer | 19 |
+| exclude | 0 |
+
+## AI Effort Distribution (only when explicitly requested)
+| Label | issue-initial | pr-review | user-assisted | unknown |
+|-------|---------------|-----------|---------------|---------|
+| ai-easy | 5 | 0 | 0 | 0 |
+| ai-light | 7 | 0 | 0 | 0 |
+| ai-medium | 16 | 0 | 0 | 0 |
+| ai-heavy | 8 | 0 | 0 | 0 |
+| ai-manual | 5 | 0 | 0 | 0 |
+| unknown | 6 | 0 | 0 | 6 |
 
 ## Issue Details
-| # | Title | Severity | Project | Milestone | Difficulty | Notes |
-|---|-------|----------|---------|-----------|------------|-------|
-| 25260 | ... | severity/s0 | MOEngine-Compute | MO-202607 | Hard | panic on INSERT |
+| # | Title | Action | Labels Delta | AI Effort | Project | Deferred Comment | Rationale |
+|---|-------|--------|--------------|-----------|---------|------------------|-----------|
+| 25260 | ... | promote-s0 | +severity/s0 -needs-triage | not requested | MOEngine-Compute | no | confirmed INSERT panic on common path |
+| 25261 | ... | defer | +deferred -needs-triage | not requested | MOEngine-Compute | yes | repro unstable; needs isolated testcase |
 ```
+
+When AI assessment is explicitly enabled, replace `AI Effort` with `ai-medium/issue-initial/medium` style values and include `ai_rationale`.
 
 Include `generated_at` timestamp + file checksum for drift detection.
 
@@ -248,20 +380,27 @@ Fetch current GitHub state for every issue in this batch → `batch_N_before_sna
 {
   "generated_at": "2026-07-01T10:23:45Z",
   "issues": [
-    {"number": 25260, "old_milestone": "MO-v1.1", "old_severity_labels": ["severity/s1"]}
+    {
+      "number": 25260,
+      "old_milestone": "MO-v1.1",
+      "old_labels": ["kind/bug", "needs-triage"],
+      "old_assignees": ["owner"],
+      "old_comments_count": 3
+    }
   ]
 }
 ```
 
 ### Step 2e: Dry-Run (5 issues)
 
-Update first 5 issues. Verify 2 of them:
+Update first 5 issues. Verify labels and deferred comments on 2 of them:
 
 ```bash
-gh issue view 25260 --json milestone,labels --jq '{milestone:.milestone.title,severity:[.labels[].name|select(startswith("severity/"))]}'
+gh issue view 25260 --json milestone,labels,comments \
+  --jq '{milestone:.milestone.title,labels:[.labels[].name],last_comment:(.comments[-1].body // "")}'
 ```
 
-**Mismatch → stop batch, investigate. Do not proceed.**
+**Mismatch, missing deferred comment, or stale AI label in explicit AI mode → stop batch, investigate. Do not proceed.**
 
 ### Step 2f: Full Batch Update + Progress
 
@@ -271,7 +410,7 @@ After update completes, mandatory progress display:
 ========================================
 BATCH 3 COMPLETE  ✅
 Progress: ████████████████░░░░ 57%  (4/7 batches)
-Running totals: s-1:1  s0:89  s1:48  s2:12
+Running totals: needs-triage:118  deferred:42  s-1:1  s0:17  s1:28
 Next: Batch 4 (#24510 → #24320)
 ========================================
 ```
@@ -279,69 +418,95 @@ Next: Batch 4 (#24510 → #24320)
 ### Rollback Procedure (batch fails mid-update)
 
 1. Read `batch_N_before_snapshot.json`
-2. Restore each already-updated issue's old milestone + severity labels
-3. **Never "fix forward"** — always rollback and restart batch from clean state
+2. Restore each already-updated issue's old milestone and labels exactly
+3. If the update log recorded newly-created deferred comment IDs, delete those comments; if deletion is not permitted, append a correction comment and stop
+4. **Never "fix forward"** — always rollback and restart batch from clean state
 
 ```bash
 # Restore old milestone
 gh api -X PATCH /repos/matrixorigin/matrixone/issues/$NUMBER -f milestone="$OLD_MILESTONE"
 
-# Restore old severity (remove new, add old)
-gh issue edit $NUMBER --remove-label "severity/s0" --add-label "$OLD_SEVERITY"
+# Restore labels: compute existing labels first, then remove labels not in snapshot and add labels from snapshot
+gh issue edit $NUMBER --remove-label "$LABELS_TO_REMOVE" --add-label "$LABELS_TO_ADD"
+
+# Delete a comment created by this failed batch when comment_id was logged
+gh api -X DELETE /repos/matrixorigin/matrixone/issues/comments/$COMMENT_ID
 ```
 
 ---
 
 ## Phase 3: FINAL VERIFY (Read-Only, ~10 min)
 
-### Step 3a: Domain Clustering Audit
+### Step 3a: Lifecycle Audit
 
-Automated: does any domain anomalously cluster in wrong tier?
+Automated checks:
 
-- **Alert** if >30% of s1 issues are non-downgrade domains
-- **Alert** if >10% of s0 issues are partition/streaming without panic/hung/OOM trigger
-- **Alert** if cold-feature issues appear in s0 without trigger
+- **Alert** if open `kind/bug` has none of `needs-triage`, `deferred`, `severity/s-1`, `severity/s0`, `severity/s1`
+- **Alert** if `severity/s0`/`severity/s1` issues lack owner/impact rationale in report
+- **Alert** if `deferred` issues created in this run lack a comment matching the Deferred Comment Template
+- **Alert** if partition/streaming/cold-feature issues remain active without confirmed trigger or owner commitment
+- **Alert** if `needs-triage` items are old enough to indicate the candidate pool is not being drained
+- **Alert** in explicit AI modes if an issue/PR has more than one AI effort label or an AI effort label without stage/confidence/rationale in the report
 
-### Step 3b: Severity Count Cross-Validation
+### Step 3b: Label Count Cross-Validation
 
-**Assert**: `count(severity/X in reports) == count(severity/X on GitHub)` for s-1, s0, s1, s2.
+**Assert**: report counts match GitHub for `needs-triage`, `deferred`, `severity/s-1`, `severity/s0`, and `severity/s1`. In explicit AI modes, also assert counts for `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, and `ai-manual`.
 
 Mismatch → drift → regenerate + re-update affected batches.
 
 ### Step 3c: Full Batch Spot-Check
 
-Scan ALL 50 issues in one complete batch report. 100% of one batch catches systematic patterns that random 5-issue sampling misses.
+Scan ALL 50 issues in one complete batch report. 100% of one batch catches systematic patterns that random 5-issue sampling misses: premature severity, missing comments, or owner gaps. In explicit AI modes, also check incorrect AI estimates.
 
 ### Step 3d: Sampled API Verify
 
 ```bash
 for num in $(shuf -e <all_numbers> | head -5); do
   gh issue view $num --json milestone,labels \
-    --jq '{milestone:.milestone.title,severity:[.labels[].name|select(startswith("severity/"))]}'
+    --jq '{milestone:.milestone.title,labels:[.labels[].name]}'
 done
 ```
 
-### Step 3e: Drift Detection
+### Step 3e: AI Effort Final Check (explicit AI modes only)
+
+Run this only when the user requests AI effort review or when existing AI labels are in scope. For PRs close to merge/close, compare issue and PR labels:
+
+- If AI handled the fix directly and human review was only a scan, ensure `ai-easy`.
+- If AI produced a useful draft but human tuned or made a bounded decision, ensure `ai-light`.
+- If human and AI iterated with shared effort, ensure `ai-medium`.
+- If AI only assisted and core logic stayed human-owned, ensure `ai-heavy`.
+- If AI provided little practical help, ensure `ai-manual`.
+- Remove the other four AI effort labels so only one remains.
+
+### Step 3f: Drift Detection
 
 Compare `generated_at` in report headers vs file mtime. If file was edited after generation (mtime > generated_at + 5min) → the file was manually tampered → re-run classifier, re-update GitHub.
 
-### Step 3f: Final Summary
+### Step 3g: Final Summary
 
 ```
 ========================================
 TRIAGE COMPLETE
 ========================================
 Total open kind/bug: NNN
-Classified:          NNN
+Actions applied:     NNN
 Skipped:              XX (heni02/Ariznawlll)
 
-Severity Distribution (on GitHub):
-  s-1:    N
-  s0:    NNN
-  s1:     NN
-  s2:     NN
+Lifecycle Distribution (on GitHub):
+  needs-triage: NNN
+  deferred:      NN
+  s-1:            N
+  s0:            NN
+  s1:            NN
 
-All updated: milestone=MO-202607, type=Bug
+AI Effort Distribution (only if explicit AI mode ran):
+  ai-easy:       NN
+  ai-light:      NN
+  ai-medium:     NN
+  ai-heavy:      NN
+  ai-manual:     NN
+
+All updated issues have explicit lifecycle state; deferred issues have comments; active severity issues have rationale. AI effort labels are unchanged unless explicit AI mode ran.
 ========================================
 ```
 
@@ -358,14 +523,25 @@ All updated: milestone=MO-202607, type=Bug
 
 300 issues × 2 calls = 600 requests. **Realistic: 15-20 min** with batch overhead.
 
-### Set Milestone + Severity
+### Set Lifecycle Labels + Milestone
 
 ```bash
 # Set milestone
 gh issue edit $NUMBER --milestone "MO-202607"
 
-# Replace severity label
-gh issue edit $NUMBER --add-label "severity/s0" --remove-label "severity/s1"
+# Intake normalization
+gh issue edit $NUMBER --add-label "kind/bug,needs-triage"
+
+# Promote to active severity: remove only labels that are actually present
+gh issue edit $NUMBER --add-label "severity/s0" --remove-label "needs-triage,deferred,severity/s-1,severity/s1"
+
+# Defer after analysis
+gh issue edit $NUMBER --add-label "deferred" --remove-label "needs-triage,severity/s0,severity/s1,severity/s-1"
+gh issue comment $NUMBER --body-file deferred_comment_${NUMBER}.md
+
+# Revise AI effort label on issue or PR: add one, remove the other four
+gh issue edit $NUMBER --add-label "ai-medium" --remove-label "ai-easy,ai-light,ai-heavy,ai-manual"
+gh pr edit $PR_NUMBER --add-label "ai-medium" --remove-label "ai-easy,ai-light,ai-heavy,ai-manual"
 ```
 
 > `gh issue edit` with `--add-label`/`--remove-label` is simpler than REST PATCH. Prefer it.
@@ -402,9 +578,9 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 | # | Pitfall | Symptom | Root Cause | Fix |
 |---|---------|---------|------------|-----|
 | 1 | **Page size mismatch** | 139 issues silently missed | per_page=50 vs 100 misalignment | Phase 1: query total_count first. Fallback 50→30 |
-| 2 | **Severity inflation** | 8 s-1 assigned, project has 4 | No calibration against existing usage | Phase 1.2: query distribution. Force conservative s-1 |
+| 2 | **Severity inflation** | New bugs jump straight to s0/s1 | Title keywords treated as priority commitment | G-INTAKE + G-PROMOTION: start with `needs-triage`, promote only after evidence |
 | 3 | **Whole-batch failure** | User changes rule → all 300+ redone | No rule lock-in before writes | Phase 1 gate: STANDARDS.md approval first |
-| 4 | **Severity drift** | Reports say s0, GitHub says s1 | Manual edits after generation | generated_at + checksum. Phase 3e drift detection |
+| 4 | **Severity drift** | Reports say s0, GitHub says s1 | Manual edits after generation | generated_at + checksum. Phase 3f drift detection |
 | 5 | **Half-updated batch** | 23/50 updated, 27 not | No rollback safety | Step 2d: before_snapshot. Rollback procedure |
 | 6 | **Rate limit blind spot** | Script hangs, user thinks stuck | No rate limit estimation | Progress display. 300 issues ≈ 15-20 min |
 | 7 | **Project writes fail** | Token missing `project` scope | Did not verify scope | Document requirement. Fallback: mark in report |
@@ -412,6 +588,10 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 | 9 | **Cross-batch duplicates** | Same issue in batch 3 and 5 | Pagination race during triage | Track seen numbers globally. Deduplicate |
 | 10 | **No progress visibility** | User cancels early | Silent between batches | Phase 2f: mandatory progress bar |
 | 11 | **Rule change w/o impact** | User says "降级" → 40 change | No blast radius preview | Show impact analysis before applying |
+| 12 | **Silent deferral** | Issue gets `deferred` but nobody knows why | Label changed without comment | G-DEFER-COMMENT: comment with reason and promote condition |
+| 13 | **Stale AI label** | PR closes as `ai-easy` after manual design/debug | Existing/requested AI estimate never revised | G-AI-FINAL during explicit AI review; final label should reflect actual human effort |
+| 14 | **Owner waits for drive-by triage** | Assigned issues/PRs stay stale | Responsibility not explicit | Ownership Rule: update own labels, comments, linked PRs, and closure state proactively |
+| 15 | **Candidate pool bypass** | Open bug has neither `needs-triage` nor active/deferred label | Intake normalization skipped | Phase 3a lifecycle audit |
 
 ---
 
@@ -420,12 +600,17 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 Scripts accompanying this skill must:
 
 - [ ] Check `STANDARDS.md` `Approved: true` gate before any GitHub write
+- [ ] Normalize new `kind/bug` issues into `needs-triage` before assigning priority labels
+- [ ] Require promotion rationale before adding `severity/s-1`, `severity/s0`, or `severity/s1`
+- [ ] Require a deferred comment body before adding `deferred`
+- [ ] Leave `ai-*` untouched during normal `needs-triage`; only in explicit AI modes, track exactly one of `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual` with stage/confidence/rationale
 - [ ] Accept `--dry-run` flag (default: first 5 issues per batch)
 - [ ] Save `batch_N_before_snapshot.json` before updating each batch
 - [ ] Print progress bar + running totals after each batch
 - [ ] Detect `generated_at` vs file mtime drift (warn, don't block)
-- [ ] Cross-validate severity counts (reports vs GitHub) in Phase 3
+- [ ] Cross-validate lifecycle label counts in Phase 3; cross-validate AI label counts only for explicit AI modes
 - [ ] Support `--rollback batch_N` to restore from snapshot
+- [ ] Log created comment IDs so rollback can delete or correct failed-batch comments
 - [ ] Log every API call to `triage_YYYYMMDD.log`
 
 ---
@@ -437,13 +622,14 @@ Scripts accompanying this skill must:
 3. **Show preview**, get user confirmation:
 
 ```
-⚠️  Rule change: "partition bugs → s1 instead of s0"
+⚠️  Rule change: "partition bugs without owner → deferred instead of s1"
     Affected batches: 1, 3, 5 (already processed)
     Issues to re-classify: 18
-    Severity changes: 13 (s0→s1) + 2 (s0 stays, has panic) + 3 (no change)
+    Action changes: 13 (promote-s1→defer) + 2 (promote-s0 stays, confirmed panic) + 3 (no change)
+    New comments required: 13
     Proceed? [y/N]
 ```
 
 4. **Re-classify affected batches** only, regenerate reports (new timestamps)
-5. **Re-update GitHub** for affected batches (snapshot → update → verify)
+5. **Re-update GitHub** for affected batches (snapshot → update labels/comments → verify)
 6. **Resume** from next unprocessed batch

--- a/.agents/skills/mo-dev/SKILL.md
+++ b/.agents/skills/mo-dev/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: mo-dev
 description: MatrixOne database kernel development - CGo build/test environment setup, GPU builds (MO_CL_CUDA=1 / cuVS), operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy, and the vector/fulltext index-plugin framework (pkg/indexplugin AlgoPlugin registry). Use when modifying colexec operators, process signal types, compile pipeline construction, adding or editing an index algorithm (HNSW/IVFFLAT/IVF-PQ/CAGRA/fulltext), or debugging CGo link errors (undefined symbols, missing headers, library not found).
-compatibility: Designed for Codex CLI and compatible agents. Requires Go 1.22+, GNU Make, C/C++ toolchain (gcc/clang), and pre-built thirdparties.
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone
@@ -9,594 +8,124 @@ metadata:
   cgo: true
 ---
 
+Compatibility: designed for Codex CLI and compatible agents. Requires Go 1.22+, GNU Make, C/C++ toolchain (gcc/clang), and pre-built thirdparties.
+
+## Resource Map
+
+Load only the reference needed for the task:
+
+| Need | Read |
+|------|------|
+| CGo link/header/runtime errors, layered testing, "pre-existing" test claims, GPU/cuVS/CUDA builds | [references/cgo-build-test.md](references/cgo-build-test.md) |
+| `colexec` operator edits, `process` signal types, pipeline spools, Call/Reset cleanup, hung tests | [references/operator-pipeline.md](references/operator-pipeline.md) |
+| Vector/fulltext index algorithm work, plugin registry, GPU-only algorithm registration, index-plugin review | [references/index-plugin.md](references/index-plugin.md) |
+
 ## Enforcement Gates
 
-This skill gates seven decision points. Consult the corresponding section before acting:
+Consult the referenced material before acting:
 
 | Gate | When | Action |
 |------|------|--------|
-| **G-MODIFY** | Before editing any `colexec` operator or `process` signal type | Read §3 (operator contract) + §7 (forbidden patterns) |
-| **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, or `dyld:`/`error while loading shared libraries:` | Read §2.2 (symptom table) + §2.4 (stash protocol) |
-| **G-GPU** | Before a GPU build/test (`MO_CL_CUDA=1`), or on CUDA/cuVS errors (`CONDA_PREFIX`, `nvcc`, `-lcuvs`/`-lcudart`, `unsupported index type: ivfpq\|cagra`) | Read §2.5 (GPU build) |
-| **G-IDXPLUGIN** | Before adding/editing an index-algorithm plugin, OR adding any `switch`/`if` that branches on an index **algo** name (`IsIvfIndexAlgo`, `== "ivfpq"`, `KeyType`, …) in `pkg/sql/{compile,plan}` or `pkg/catalog` | Read §8 (index-plugin framework) — route through the registry; new algo switches are forbidden |
-| **G-IDXREVIEW** | When **reviewing** a diff (yours or `/code-review`) that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/` / `pkg/fulltext/plugin`, or `pkg/indexplugin` | Read §9 (index-plugin review checklist) — run each grep before approving |
-| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.2 (completion gate) — all 5 boxes MUST be checked |
-| **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read §5 (diagnosis) + §2.4 (stash protocol) before attributing cause |
+| **G-MODIFY** | Before editing any `colexec` operator or `process` signal type | Read [operator-pipeline.md](references/operator-pipeline.md). |
+| **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, `dyld:`, or `error while loading shared libraries:` | Read [cgo-build-test.md](references/cgo-build-test.md) sections 2 and 4 before blaming code. |
+| **G-GPU** | Before a GPU build/test (`MO_CL_CUDA=1`), or on CUDA/cuVS errors (`CONDA_PREFIX`, `nvcc`, `-lcuvs`/`-lcudart`, `unsupported index type: ivfpq\|cagra`) | Read [cgo-build-test.md](references/cgo-build-test.md) section 5. |
+| **G-IDXPLUGIN** | Before adding/editing an index-algorithm plugin, OR adding any `switch`/`if` on an index **algo** name in `pkg/sql/{compile,plan}` or `pkg/catalog` | Read [index-plugin.md](references/index-plugin.md). Route through `pkg/indexplugin`; new algo switches are forbidden. |
+| **G-IDXREVIEW** | Reviewing a diff that touches index-algorithm dispatch, `pkg/vectorindex/<algo>/plugin/`, `pkg/fulltext/plugin`, or `pkg/indexplugin` | Read [index-plugin.md](references/index-plugin.md) section 9 and run its greps. |
+| **G-DONE** | Before declaring "done"/"complete"/"passes" | Apply the completion gate below. |
+| **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read [operator-pipeline.md](references/operator-pipeline.md) section 4 and [cgo-build-test.md](references/cgo-build-test.md) section 4 before attributing cause. |
 
----
-
-## 1. Project Structure
+## Project Structure
 
 ```
-pkg/sql/compile/       ← DAG compilation, operator instantiation, pipeline build, launch
-pkg/sql/colexec/       ← execution operators (connector/dispatch/merge/join/scan/...)
-pkg/vm/process/        ← execution context (Process), WaitRegister, signal channels
-pkg/vm/pipeline/       ← Pipeline lifecycle management
-pkg/container/         ← Batch/Vector/pSpool and other base data structures
-pkg/frontend/          ← MySQL protocol compatibility layer
-pkg/txn/               ← transaction management and MVCC
-pkg/sql/plan/          ← query plan construction
-cgo/                   ← CGo adapter layer (libmo.dylib / libmo.so)
+pkg/sql/compile/       <- DAG compilation, operator instantiation, pipeline build, launch
+pkg/sql/colexec/       <- execution operators (connector/dispatch/merge/join/scan/...)
+pkg/vm/process/        <- execution context (Process), WaitRegister, signal channels
+pkg/vm/pipeline/       <- Pipeline lifecycle management
+pkg/container/         <- Batch/Vector/pSpool and other base data structures
+pkg/frontend/          <- MySQL protocol compatibility layer
+pkg/txn/               <- transaction management and MVCC
+pkg/sql/plan/          <- query plan construction
+cgo/                   <- CGo adapter layer (libmo.dylib / libmo.so)
 ```
 
-**Operator file convention** under `pkg/sql/colexec/<op>/`:
-- `types.go` — Arg struct definition
-- `<op>.go` — main logic (Prepare/Call/Reset)
+Operator file convention under `pkg/sql/colexec/<op>/`:
+
+- `types.go`: Arg struct definition
+- `<op>.go`: main logic (`Prepare`/`Call`/`Reset`)
 - Optional `sendfunc.go`/`dispatch.go` helpers
 
-**Key dependency chain**: `compile` instantiates operators → `colexec` executes → `process` manages context and signals → `container` carries data.
+Key dependency chain: `compile` instantiates operators -> `colexec` executes -> `process` manages context and signals -> `container` carries data.
 
----
+## Quick Test Commands
 
-## 2. Build, Test, Verify
-
-### 2.1 Basic Commands
+For ordinary package checks:
 
 ```bash
-# Compile check
 go build ./pkg/target/...
-
-# Static analysis
 go vet ./pkg/target/...
-
-# Run tests (-count=1 disables cache)
-go test -v -count=1 ./pkg/target/...
-
-# Single test
+go test -v -count=1 -timeout 120s ./pkg/target/...
 go test -v -count=1 -run TestXxx ./pkg/target/...
-
-# Timeout control (integration tests can be slow)
-go test -v -count=1 -timeout 120s ./pkg/target/...
 ```
 
-### 2.2 CGo Environment (Three-Layer Variables)
+For CGo-transitive or CGo-direct packages, do not guess flags. Read [references/cgo-build-test.md](references/cgo-build-test.md).
 
-MO's CGo involves three independent layers: **compilation** (headers), **linking own lib** (`libmo`), and **third-party libs** (`libusearch_c`).
+Rule: "`go build` passes" does not mean "`go test` will pass." Test binaries link more CGo.
 
-```makefile
-# Makefile:203 — header paths for compilation
-CGO_OPTS := CGO_CFLAGS="-I$(CGO_DIR) -I$(THIRDPARTIES_INSTALL_DIR)/include"
+## Operator / Pipeline Rules
 
-# Makefile:204-207 — link libmo (rpath varies by OS)
-# Linux:   -Wl,-rpath,$$ORIGIN/lib
-# macOS:   -Wl,-rpath,@executable_path/lib
-GOLDFLAGS := -ldflags="-extldflags '-L$(CGO_DIR) -lmo -L$(THIRDPARTIES_INSTALL_DIR)/lib $(RPATH)'"
-```
+Read [references/operator-pipeline.md](references/operator-pipeline.md) before changing these paths.
 
-**Note**: Makefile does **not** set `CGO_LDFLAGS` — `libmo` link flags all go through `-ldflags` → `-extldflags`. However, the `usearch` Go module ships its own `#cgo LDFLAGS: -lusearch_c`, causing the linker to prefer system paths. `CGO_LDFLAGS` overrides this.
+- `Call()` processes one batch. It must not send terminal signals (`End`, `Error`, `Abort`).
+- `Reset()` performs cleanup and notifies downstream completion.
+- If explicit typed signals replaced implicit nil-batch end-of-stream, use `Abort()` instead of `CloseWithTimeout()`.
+- `CloseWithTimeout()` waits for nil batches; with typed signals it can wait for something that will never arrive.
+- When sending terminal signals into bounded channels, record terminal state even if the channel send fails.
 
-#### macOS vs Linux
+## Index-Plugin Rules
 
-| Aspect | macOS | Linux |
-|--------|-------|-------|
-| Dynamic library | `libmo.dylib` | `libmo.so` |
-| Runtime path env | `DYLD_LIBRARY_PATH` | `LD_LIBRARY_PATH` |
-| rpath flag | `-Wl,-rpath,@executable_path/lib` | `-Wl,-rpath,\$ORIGIN/lib` |
-| C header flags | `CGO_CFLAGS="-I{root}/cgo -I{root}/thirdparties/install/include"` | Same |
-| usearch link flags | `CGO_LDFLAGS="-L{root}/thirdparties/install/lib -lusearch_c"` | Same |
+Read [references/index-plugin.md](references/index-plugin.md) before touching vector/fulltext index algorithm dispatch.
 
-#### Full Test Commands
+- Work through `pkg/indexplugin.Get(algo)` and hook interfaces.
+- Do not add new per-algorithm `switch` / `if IsXxxIndexAlgo || ...` in SQL/catalog layers.
+- Do not import `pkg/sql/plan` or `pkg/sql/compile` from plugin packages.
+- Register CPU-safe plugins in `pkg/indexplugin/all/all.go`; register GPU-only plugins in `all_gpu.go`.
+- Keep `var _ AlgoPlugin` and `var _ Hooks` compile-time assertions intact.
+- Add CPU-runnable unit tests for plan/schema/runtime hooks; GPU-gated BVT alone can fail coverage gates.
 
-**macOS:**
-```bash
-CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
-CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
-DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
-go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
-  -v -count=1 -timeout 120s ./pkg/target/...
-```
+## Completion Gate
 
-**Linux:**
-```bash
-CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
-CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
-LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
-go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib'" \
-  -v -count=1 -timeout 120s ./pkg/target/...
-```
-
-#### Symptom → Root Cause
-
-| Symptom | Missing Variable | Root Cause |
-|---------|-----------------|------------|
-| `fatal error: 'xxhash.h' file not found` | `CGO_CFLAGS` | Compiler can't find thirdparties headers |
-| `Undefined symbols: _usearch_hardware_acceleration_*` (macOS) or `undefined symbol:` (Linux) | `CGO_LDFLAGS` | usearch module's `#cgo LDFLAGS` found old `libusearch_c` |
-| `ld: library 'mo' not found` (macOS) or `cannot find -lmo` (Linux) | `-ldflags="-extldflags '-L... -lmo'"` | Linker can't find `libmo` |
-| `dyld: Library not loaded: libmo.dylib` (macOS) or `error while loading shared libraries: libmo.so` (Linux) | `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Runtime can't find dynamic library |
-
-### 2.3 Layered Testing Strategy
-
-| Layer | Example Packages | CGo Behavior | Variables Needed |
-|-------|-----------------|-------------|-----------------|
-| **Pure Go** | `pkg/vm/process`, `pkg/container/pSpool`, `pkg/vm/pipeline` | Zero CGo in transitive closure | None |
-| **CGo-transitive** | `pkg/sql/colexec/connector`, `dispatch`, `merge` | Test binary links usearch Go module | `CGO_CFLAGS` + `CGO_LDFLAGS` |
-| **CGo-direct** | `pkg/sql/compile` | Test binary directly links `libmo` + `libusearch_c` | All four: CGO_CFLAGS + CGO_LDFLAGS + ldflags + DYLD/LD_LIBRARY_PATH |
-| **Integration** | `pkg/frontend`, cmd packages | Full MO binary, needs external services | All + services |
-
-**Copy-paste per layer:**
-
-Layer 1 (Pure Go):
-```bash
-go test -v -count=1 -timeout 120s ./pkg/vm/process/... ./pkg/container/pSpool/...
-```
-
-Layer 2 (CGo-transitive, macOS):
-```bash
-export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
-export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
-go test -v -count=1 -timeout 120s ./pkg/sql/colexec/connector/... ./pkg/sql/colexec/dispatch/...
-```
-
-Layer 3 (CGo-direct, macOS):
-```bash
-export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
-export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
-export DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib"
-go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
-  -v -count=1 -timeout 120s ./pkg/sql/compile/...
-```
-
-#### Variable → Purpose
-
-| Variable | What It Does | When Needed |
-|---------|-------------|-------------|
-| `CGO_CFLAGS` | Tells C compiler where to find headers | Package in transitive closure has CGo C code |
-| `CGO_LDFLAGS` | Overrides usearch module's own `#cgo LDFLAGS` path | usearch Go module is linked |
-| `-ldflags "-extldflags ..."` | Tells external linker where to find `libmo` + sets rpath | Package directly links `libmo` |
-| `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Tells OS runtime loader where to find `.dylib` / `.so` | Test binary loads `libmo` at runtime |
-
-**Why bottom-up matters**: Pure Go tests finish in seconds with zero env setup. If they fail, the problem is in your code — not CGo. Debug top-down wastes time chasing link errors when there's a real bug.
-
-#### 2.3.1 `go build` vs `go test` — Not Equivalent
-
-| Command | CGo Behavior |
-|---------|-------------|
-| `go build ./pkg/sql/colexec/connector/...` | May succeed without CGo flags (compiles package only, no test binary linking) |
-| `go test ./pkg/sql/colexec/connector/...` | Compiles AND links test binary — full CGo path fires |
-
-**Rule**: "`go build` passes" does not mean "`go test` will pass." Always verify with `go test`.
-
-### 2.4 Stash Protocol — Verify "Pre-existing" Claims
-
-**Hard rule**: Never claim a test failure is "pre-existing" without proving it.
-
-```bash
-# 1. Stash current changes
-git stash
-
-# 2. Run the same test from clean state
-go test -v -count=1 -timeout 120s ./pkg/target/...
-
-# 3. If it fails: genuinely pre-existing — document it
-# 4. If it passes: YOUR code caused it — investigate
-git stash pop
-```
-
-### 2.5 GPU Build (`MO_CL_CUDA=1`) — cuVS / CUDA
-
-GPU support compiles the CUDA-backed vector index algorithms (**CAGRA**, **IVF-PQ**) into `libmo` and turns on the `gpu` Go build tag. **Linux x86_64 only** — the macOS `Makefile` branch (`Makefile:234-236`) carries no CUDA flags, so **macOS builds are always CPU-only**. Do not try to enable it on Darwin.
-
-**Prerequisites (one-time):**
-1. CUDA toolkit 12.0 / 13.0+ installed under `/usr/local/cuda`.
-2. cuVS Go bindings installed via conda (`rapidsai/cuvs`), then the env **activated** so `CONDA_PREFIX` is exported:
-   ```bash
-   conda env create --name go -f conda/environments/go_cuda-130_arch-$(uname -m).yaml
-   conda activate go     # exports CONDA_PREFIX — every GPU build/test hard-errors without it
-   ```
-
-**Build:**
-```bash
-MO_CL_CUDA=1 make -j8
-```
-
-**What `MO_CL_CUDA=1` flips** (vs. the default CPU build):
-
-| Layer | CPU build | GPU build (`MO_CL_CUDA=1`) |
-|-------|-----------|----------------------------|
-| Go build tag | none | `-tags gpu` (`Makefile:224`) — registers CAGRA + IVF-PQ, compiles `*_gpu.go` |
-| `cgo/` compiler | `gcc`/`clang` | `/usr/local/cuda/bin/nvcc` (`cgo/Makefile:31`, multi-arch `sm_75…sm_90`) |
-| `libmo` objects | C objects only | + `cuda/*.o` + `cuvs/*.o` |
-| Link flags | `-lusearch_c -lroaring` | + `-lcuvs -lcuvs_c -lcudart -lcuda -lrmm -lstdc++` |
-| Header/lib roots | thirdparties only | + `$CONDA_PREFIX/{include,lib}`, `/usr/local/cuda/...` |
-
-**Guardrails baked into the Makefiles:**
-- **`CONDA_PREFIX env variable not found`** → conda env not activated. Run `conda activate <env>` first. Both `Makefile:217` and `cgo/Makefile:28` hard-error on this — it is *not* a code bug.
-- **`libmo` is re-linked on every GPU build** (`cgo/Makefile` order-only `cuda_objs`/`cuvs_objs` prereqs). Deliberate: `mo-service` loads `libmo.so` **dynamically**, so a stale `.so` silently runs old C++ (hours of "my fix didn't take"). The old `rm -f cgo/libmo.so cgo/libmo.a` workaround is no longer needed.
-
-**The `gpu` tag gates index-plugin registration — memorize this.** CAGRA and IVF-PQ register **only** under `//go:build gpu` (`pkg/indexplugin/all/all_gpu.go`). On a CPU binary their plugins are absent from the registry, so `CREATE INDEX … USING ivfpq|cagra` fails cleanly at plan-build with `unsupported index type: <algo>` — **before** any hidden table is created. This is intentional. Do **not** "fix" it by moving those imports into `all.go` (see §8.6).
-
-**Prerequisite — the linked `libmo` must itself be GPU-built:** run `MO_CL_CUDA=1 make -j8 cgo` first. A CPU `libmo` lacks the `cuda/`+`cuvs/` objects, so `gpu`-tagged Go (which cgo-includes `cgo/cuvs/*.h` via `pkg/cuvs`) fails to link with undefined `cuvs_*` / `cuda*` symbols — this is a *stale-library* error, not a flag error, so re-check §2.2 before chasing `CGO_LDFLAGS`.
-
-**GPU tests** — add `-tags gpu` plus the CUDA search paths (mirror the Makefile's `CUDA_CFLAGS`/`CUDA_LDFLAGS`, `Makefile:220-223`); Linux only:
-```bash
-CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include -I$CONDA_PREFIX/include -I/usr/local/cuda/include" \
-CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c -L$CONDA_PREFIX/lib -lcuvs -lcuvs_c" \
-LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$CONDA_PREFIX/lib:/usr/local/cuda/lib64" \
-go test -tags gpu \
-  -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib -fopenmp'" \
-  -v -count=1 -timeout 300s ./pkg/vectorindex/ivfpq/...
-```
-The **authoritative** flag source is the `Makefile` (`CUDA_CFLAGS`/`CUDA_LDFLAGS`), not this snippet — if a GPU link error appears, diff your flags against those lines.
-
-**Tag-split test files are a trap:** `*_gpu.go` / `//go:build gpu` tests (e.g. `pkg/vectorindex/ivfpq/search_test.go`, `model_test.go`) compile **only** under `-tags gpu`. A plain `go test ./pkg/vectorindex/ivfpq/...` runs the `//go:build !gpu` / `*_cpu.go` stubs instead. **"CPU tests pass" ≠ "GPU path tested."**
-
----
-
-## 3. Operator Lifecycle Contracts
-
-### 3.1 Call() vs Reset() — Hard Boundary
-
-| Method | Purpose | Must NOT Do |
-|--------|---------|-------------|
-| `Call()` | Process one batch. Receive from upstream, compute, send downstream. | Send terminal signals (End/Error/Abort). That's `Reset()`'s job. |
-| `Reset()` | Cleanup. Notify downstream the operator is done. | Block waiting for receiver acknowledgment. Use Abort(), not CloseWithTimeout(). |
-
-**This is the single most common source of subtle bugs.** Violating it causes: premature pipeline termination, spurious timeouts, dead receivers.
-
-### 3.2 PipelineSpool Lifecycle
-
-| Method | Behavior | Use When |
-|--------|---------|---------|
-| `Close()` | Wait for all consumers to acknowledge end of stream (consumes nil batches from spool) | Graceful completion path |
-| `CloseWithTimeout()` | Same as `Close()` but with timeout | Legacy cleanup — deprecated for typed signals |
-| `ForceCleanup()` / `Abort()` | Synchronous release of all un-consumed slots. No waiting. Idempotent (`sync.Once`). | Cleanup path with explicit terminal signals |
-
-**Critical rule**: If you replaced implicit nil-batch end-of-stream with explicit typed signals (EventEnd/EventError/EventAbort), use `Abort()` instead of `CloseWithTimeout()`. `CloseWithTimeout()` waits for nil batches that will never arrive.
-
-### 3.3 Pipeline Signal Types (Explicit Protocol)
-
-| Signal | Constructor | Meaning |
-|--------|------------|---------|
-| `EventData` | `NewDataSignal(batch)` | Normal data batch |
-| `EventEnd` | `NewEndSignal()` | Graceful end of stream |
-| `EventError` | `NewErrorSignal(err)` | Operator encountered an error |
-| `EventAbort` | `NewAbortSignal()` | Forceful termination |
-
-**Dual-protocol compatibility**: `GetNextBatch` handles both explicit typed signals AND legacy nil-batch convention (`content == nil`). Old operators using implicit nil-batch continue to work.
-
----
-
-## 4. Post-Modification Verification
-
-### 4.1 Test Freshness
-
-Test output must be **from the current turn**. Verify:
-1. `go test` command appears in current turn's bash calls
-2. Exit code 0 (not "it compiled" or "trust me")
-3. Timestamp is after the last `str_replace`/`write_file`
-
-### 4.2 Completion Gate (G-DONE)
-
-Before declaring any change "done", all 5 boxes must be checked:
+Before declaring any MatrixOne code change done, check all boxes:
 
 ```
-□ go build ./pkg/.../modified_package...    → exit 0
-□ go vet ./pkg/.../modified_package...      → exit 0
-□ go test -v -count=1 ./pkg/.../...         → exit 0, no hangs
-□ git diff --stat                            → inspected, no unintended files
+□ go build ./pkg/.../modified_package...    -> exit 0
+□ go vet ./pkg/.../modified_package...      -> exit 0
+□ go test -v -count=1 ./pkg/.../...         -> exit 0, no hangs
+□ git diff --stat                            -> inspected, no unintended files
 □ Regression: at least one test from dependent package passes
 ```
 
-**Hang = failure**: If `go test` produces >10s of no output → the test is hung, not "still running." Investigate.
+Hang = failure. If `go test` produces >10s of no output, investigate instead of calling it slow.
 
----
+Hard rule: never claim a failure is "pre-existing" without proving it from clean HEAD. Use the stash protocol in [references/cgo-build-test.md](references/cgo-build-test.md) section 4.
 
-## 5. Fault Diagnosis
+## Common Diagnosis Shortcuts
 
-| Symptom | Look At |
-|---------|---------|
-| Test hangs exactly 30s | `CloseWithTimeout` waiting for nil-batch that never arrives. Check if typed signals are being sent instead. |
-| Test hangs >5s, no output | Deadlock or blocking channel send. Check: is `done` channel closed? Is `sendSignal` using a non-blocking `select`? |
-| `context deadline exceeded` after 30s | `WaitingEndWithTimeout` timed out. Check: did all senders call `Reset()`? Did they send typed terminal signals? |
-| `CGO_CFLAGS` not working | Run `go env CGO_CFLAGS` to verify. Use `export` (not inline without export) if the package has sub-packages. |
+| Symptom | First Place To Look |
+|---------|---------------------|
+| Test hangs exactly 30s | `CloseWithTimeout` waiting for nil-batch that never arrives. Read [operator-pipeline.md](references/operator-pipeline.md). |
+| Test hangs >5s, no output | Deadlock or blocking channel send. Check `done` channel and non-blocking `select`. |
+| `context deadline exceeded` after 30s | Did all senders call `Reset()` and send typed terminal signals? |
+| `fatal error: 'xxhash.h' file not found` | `CGO_CFLAGS`; read [cgo-build-test.md](references/cgo-build-test.md). |
+| `Undefined symbols` / `undefined symbol:` | `CGO_LDFLAGS` and stale `libusearch_c`; read [cgo-build-test.md](references/cgo-build-test.md). |
+| `cannot find -lmo` / `ld: library 'mo' not found` | `-ldflags="-extldflags '-L... -lmo'"`; read [cgo-build-test.md](references/cgo-build-test.md). |
+| `unsupported index type: ivfpq|cagra` | CPU binary lacks GPU plugin registration; read [index-plugin.md](references/index-plugin.md) and GPU notes. |
 
----
+## Forbidden Patterns
 
-## 6. Common Pitfalls
-
-### 6.1 Structural Changes — Check Both Ends
-When changing the communication protocol between operators (connector ↔ merge, dispatch ↔ merge), both sender and receiver must be updated. A sender change without the corresponding receiver change causes deadlock.
-
-**Identification**: exact 30s timeout in cleanup → `CloseWithTimeout` + typed signal mismatch.
-
-### 6.2 CGo Link Errors — Verify the Third Party Build
-CGo link errors (`Undefined symbols`, `cannot find -lmo`) are environment issues, not code bugs. The C shared libraries (`libmo.dylib`, `libusearch_c.dylib`) must be pre-built via `make cgo` and `make thirdparties`.
-
-### 6.3 Pipeline Cleanup — Abort, Don't Wait
-During pipeline cleanup, operators should use non-blocking or timeout-gated communication. Never block waiting for a receiver that may have already exited.
-
-### 6.4 Channel Full Edge Cases
-When sending terminal signals into a bounded channel, the send may fail because the channel is full. Ensure the terminal state is still recorded even when the channel send fails — the `done` channel must close regardless of delivery success.
-
----
-
-## 7. Forbidden Patterns
-
-1. **Never send terminal signals (End/Error/Abort) from `Call()`.** Only `Reset()` sends terminal signals.
-2. **Never call `sp.CloseWithTimeout()` after switching to explicit typed terminal signals.** Use `sp.Abort()`.
-3. **Never claim "pre-existing" without `git stash` proof.** Run the test on clean HEAD first.
-4. **Never declare done without fresh test output.** All 5 completion gate boxes must be checked.
-5. **Never assume `go build` success means `go test` will pass.** Build only compiles packages; test compiles AND links test binaries.
-6. **Never skip bottom-up testing.** Start with pure Go packages, then CGo-transitive, then CGo-direct.
-7. **Never add a per-algorithm `switch`/`if` on an index algo name in the SQL layer.** Route through `indexplugin.Get(algo)` — see §8.
-
----
-
-## 8. Vector / Fulltext Index-Plugin Framework
-
-### 8.1 Why this exists (and what NOT to undo)
-
-Adding a vector index used to mean editing 8+ files across `pkg/sql/compile`,
-`pkg/sql/plan`, `pkg/catalog`, and `pkg/vectorindex`, wired through ~6
-switch/if-chain seams. Miss one seam → the algorithm silently misbehaves. The
-`pkg/indexplugin` framework collapses those seams into **one registry lookup**:
-an algorithm registers **one** `AlgoPlugin`, and the compiler enforces every
-required hook exists.
-
-**The guarded failure mode:** a change that re-introduces a per-algorithm
-`switch algo` / `if IsXxxIndexAlgo || …` in the SQL layer, or otherwise bypasses
-the registry, quietly re-opens the "forgot a seam" bug class. Work **through**
-the framework — do not route around it.
-
-### 8.2 Architecture
-
-`pkg/indexplugin` is the framework. It must **not** import `pkg/sql/{compile,plan}`;
-hook methods receive narrow `Context` interfaces the SQL layer satisfies.
-
-```
-pkg/indexplugin/
-├── plugin.go          -- AlgoPlugin interface; Register/Get/All; IsVectorIndexAlgo/IsFullTextIndexAlgo/IsPluginAlgo
-├── catalog/hooks.go   -- catalog.Hooks   (metadata: params, hidden tables, op/vector/pk types, quantization)
-├── compile/hooks.go   -- compile.Hooks   (DDL execution: create/reindex/drop/restore) + CompileContext
-├── plan/hooks.go      -- plan.Hooks      (schema defs + tablefunc + thin ANN redirects) + PlanBuilder/CompilerContext
-├── idxcron/hooks.go   -- idxcron.Hooks   (scheduled-rebuild gating: Updatable)
-└── all/
-    ├── all.go         -- blank-imports CPU-safe plugins (fulltext, hnsw, ivfflat)
-    └── all_gpu.go     -- //go:build gpu — blank-imports GPU-only plugins (cagra, ivfpq)
-
-pkg/vectorindex/<algo>/plugin/   -- one dir per algorithm; assembles the hooks into an AlgoPlugin
-pkg/fulltext/plugin/             -- fulltext is a plugin too (kind = fulltext, not vector)
-```
-
-**Dispatch flow** — every SQL-layer site that used to `switch algo` now does:
-
-```go
-p, ok := indexplugin.Get(algo)      // case-insensitive, trims whitespace
-if ok { return p.Compile().HandleCreateIndex(cctx, defs) }
-```
-
-`indexplugin.IsVectorIndexAlgo(algo)` replaces the
-`IsIvfIndexAlgo || IsHnswIndexAlgo || IsCagraIndexAlgo || IsIvfpqIndexAlgo`
-chain. Use `IsFullTextIndexAlgo` for fulltext, `IsPluginAlgo` for "registered at
-all (vector OR fulltext)". Live dispatch sites already exist in
-`pkg/sql/plan/build_ddl.go` (`indexplugin.Get(...KeyType.ToString())` →
-`unsupported index type: %s`) and `pkg/sql/plan/apply_indices.go`
-(`p.Plan().CanApply`).
-
-### 8.3 Registry contract — the compiler is the safety net
-
-```go
-// pkg/indexplugin/plugin.go
-type AlgoPlugin interface {
-    Algo() string                       // must == catalog.MoIndex<X>Algo.ToString() (lower-cased)
-    Catalog() catalogplugin.Hooks
-    Compile() compileplugin.Hooks
-    Plan()    planplugin.Hooks
-    Idxcron() idxcronplugin.Hooks
-}
-func Register(p AlgoPlugin)              // panics on duplicate Algo(); call from init()
-func Get(algo string) (AlgoPlugin, bool)
-```
-
-Each plugin keeps compile-time interface assertions:
-
-```go
-var _ plugin.AlgoPlugin = (*Plugin)(nil)   // in <algo>/plugin/plugin.go
-var _ Hooks = Hooks{}                        // in each hooks sub-package impl
-```
-
-If `AlgoPlugin` or a `Hooks` interface gains a method and a plugin isn't updated,
-these lines **stop the build**. That compile error *is* the "did I miss a seam?"
-answer. **Never delete or `//nolint` these assertions to green a build** —
-implement the missing method.
-
-### 8.4 Plugin package layout (canonical: IVF-PQ)
-
-`pkg/vectorindex/ivfpq/plugin/plugin.go` is the **authoritative walkthrough** —
-read its package doc before adding an algorithm. A full plugin (see
-`pkg/vectorindex/ivfflat/plugin/`) is:
-
-```
-pkg/vectorindex/<algo>/plugin/
-├── plugin.go            -- assembles the 4 Hooks into one Plugin; init() { plugin.Register(New()) }
-├── runtime/runtime.go   -- catalog.Hooks impl  (algorithm metadata constants)
-├── compile/compile.go   -- compile.Hooks impl  (CREATE/ALTER/DROP/REINDEX execution)
-├── plan/
-│   ├── plan.go          -- plan.Hooks: thin ApplyForSort/CanApply redirect (~10 LoC) into *plan.QueryBuilder
-│   ├── schema.go        -- BuildSecondaryIndexDefs body (hidden-table TableDefs + IndexDefs)
-│   └── tablefunc.go     -- <algo>_create / <algo>_search FUNCTION_SCAN builder registrations
-├── idxcron/idxcron.go   -- idxcron.Hooks impl  (Updatable: scheduled-rebuild gating)
-└── iscp/iscp.go         -- CDC / import sync (may be //go:build gpu for GPU algos)
-```
-
-**Which sub-package gets lifted code:** from `pkg/sql/compile/*.go` → `compile/`;
-from `pkg/sql/plan/*.go` → `plan/`; algorithm-metadata constants → `runtime/`
-(lifted code goes in the sub-package matching `pkg/sql/<layer>` of the call site).
-
-### 8.5 Adding a new algorithm — steps
-
-Follow `pkg/vectorindex/ivfpq/plugin/plugin.go`'s doc. Summary:
-
-1. **Catalog constants.** Add `MoIndex<X>Algo` in
-   `pkg/catalog/secondary_index_utils.go`; hidden-table-type constants in
-   `pkg/catalog/types.go` (one per hidden table). A `tree.INDEX_TYPE_<X>` parser
-   keyword only if it needs new CREATE INDEX syntax.
-2. **Copy** `pkg/vectorindex/ivfpq/plugin/` → `pkg/vectorindex/<x>/plugin/`;
-   rename packages/imports.
-3. **Implement the four Hooks** (let the `var _ Hooks = …` assertions tell you
-   what's missing):
-   - `catalog.Hooks` — `HiddenTableTypes`, `ParamsFromTree`, `DefaultOptions`,
-     `SupportedOpTypes`, `SupportedVectorTypes`, `SupportedPrimaryKeyTypes`,
-     `SupportedIncludeColumnTypes`, `ValidQuantization`, `ExperimentalFlag`,
-     `AlterTableCloneBehavior`, `RestoreBehavior`, `BuildSessionVars`,
-     `ShouldTruncateHiddenTable`, `SyncDescriptor`.
-   - `compile.Hooks` — `HandleCreateIndex`, `HandleReindex`,
-     `ValidateReindexParams`, `HandleDropIndex`, `RestoreInitSQL`,
-     `IdxcronMetadata`.
-   - `plan.Hooks` — `BuildSecondaryIndexDefs`, `BuildFullTextIndexDefs`,
-     `CanApply`, `ApplyForSort`.
-   - `idxcron.Hooks` — `Updatable` (return "always yes" if the algo has no
-     minimum-size / cadence constraint).
-4. **ANN rewrite body** (only if the algo supports `ORDER BY <distfn>(col,v)
-   LIMIT k`): add `applyIndicesForSortUsing<X>` + `prepare<X>IndexContext` in
-   `pkg/sql/plan/apply_indices_<x>.go`, redirect methods on `*QueryBuilder` in
-   `pkg/sql/plan/plugin_builder.go`, and the dispatch case in
-   `pkg/sql/plan/apply_indices.go` (which calls `p.Plan().CanApply`).
-5. **Register:** `init()` in `plugin.go` calls `plugin.Register(New())`. Add
-   **one** blank-import line to `pkg/indexplugin/all/all.go` — **or**
-   `all_gpu.go` if GPU-only (§8.6). That aggregator is the *only* wiring edit;
-   `pkg/sql/plan` and `pkg/sql/compile` already blank-import `.../all`.
-6. **SQL test** under `test/distributed/cases/vector/` exercising CREATE INDEX,
-   `ORDER BY <distfn>(col,v) LIMIT k`, ALTER REINDEX, DROP INDEX, DROP TABLE.
-
-> If the plugin compiles and every hook is implemented, you did **not** miss a
-> dispatch site. Do not add manual dispatch "to be safe."
-
-### 8.6 CPU vs GPU registration (ties to §2.5)
-
-| File | Build tag | Registers | Rationale |
-|------|-----------|-----------|-----------|
-| `pkg/indexplugin/all/all.go` | (none) | fulltext, hnsw, ivfflat | CPU-safe algorithms |
-| `pkg/indexplugin/all/all_gpu.go` | `//go:build gpu` | cagra, ivfpq | CUDA-backed table functions exist only under `gpu` |
-
-CAGRA / IVF-PQ have `cagra_create` / `ivfpq_create` table functions implemented
-**only** under `//go:build gpu`. Registering them on a CPU binary would let
-`CREATE INDEX … USING cagra|ivfpq` proceed until the BUILD SQL fails mid-flight —
-after hidden tables are created and DELETEs run. Gating registration behind the
-`gpu` tag makes plan-build return `unsupported index type: <algo>` **before any
-DDL side effect**. The `gpu` tag is enabled by `MO_CL_CUDA=1 make` (§2.5).
-
-**Pairing rule:** an algo with `build_gpu.go` (`//go:build gpu`) must have a
-`//go:build !gpu` CPU counterpart (`*_cpu.go` stub) so the package still compiles
-on CPU, *and* its plugin blank-import belongs in `all_gpu.go`, never `all.go`.
-
-### 8.7 Forbidden patterns (index-plugin)
-
-1. **Never re-introduce per-algorithm dispatch in the SQL layer.** A new
-   `switch idx.IndexAlgo`, `if catalog.IsIvfIndexAlgo(a) || …`, or `case
-   MoIndex<X>Algo:` in `pkg/sql/{compile,plan}` / `pkg/catalog` re-opens the bug
-   class the framework closed. Need a new per-algo decision? Add a **method to
-   the relevant `Hooks` interface** (compiler forces every algo to answer) — not
-   a switch.
-2. **Never import `pkg/sql/plan` or `pkg/sql/compile` from a plugin package.**
-   Those packages blank-import the plugins for `init()` registration → an import
-   cycle. Plugins receive `compile.CompileContext` / `plan.PlanBuilder` /
-   `plan.CompilerContext` and call *through* them. `plan/` bodies that need
-   `*QueryBuilder` internals live in `pkg/sql/plan/apply_indices_<x>.go`, reached
-   via the thin redirect (§8.5 step 4).
-3. **Never register a GPU-only algo in `all.go`** — use `all_gpu.go` (§8.6).
-4. **Never weaken the `var _ AlgoPlugin` / `var _ Hooks` assertions** to green a
-   build. Implement the missing method.
-5. **Keep runtime out of the plugin.** The plugin owns compile + plan + catalog +
-   idxcron metadata only. Real build/search kernels stay in
-   `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`, invoked from
-   `pkg/sql/colexec/table_function/<algo>_*.go`. Do not copy kernel logic in.
-6. **Never pollute `pkg/indexplugin` with algorithm-specific code — it is
-   interfaces + metadata only.** The framework package holds only the interfaces
-   (`AlgoPlugin`, the `Hooks` + `Context` interfaces), the registry, and
-   *algorithm-agnostic* shared helpers/metadata (e.g. `AlgoParamInt`,
-   `IdxcronVarSpec` / `BuildIdxcronMetadata` — generic, zero algo branching).
-   Every concrete hook body and per-algo constant lives in
-   `pkg/vectorindex/<algo>/plugin/` (or `pkg/fulltext/plugin/`). Do **not** add a
-   `switch algo` / `if IsXxxIndexAlgo`, a concrete `Hooks` implementation, or any
-   algorithm-named symbol under `pkg/indexplugin/*`. The *only* files there that
-   may name a concrete algorithm are the `all/` and `iscp/` aggregators — and
-   only as blank imports.
-
-### 8.8 Testing & completion (index-plugin)
-
-Index-plugin changes have a **coverage trap**: the end-to-end BVT cases under
-`test/distributed/cases/vector/` are GPU-gated (skipped in non-GPU CI), so
-`plan.go` / `schema.go` read **0% coverage** and fail the 0.75 gate unless you
-add CPU-runnable unit tests (tablefunc_test / runtime_test style — see
-`pkg/vectorindex/ivfflat/plugin/{runtime,idxcron}/*_test.go`). On top of the §4.2
-completion gate:
-
-```
-□ CPU unit tests exist for plan/schema/runtime hooks (not just GPU-gated BVT)  → run, exit 0
-□ GPU-only hooks also run with `-tags gpu` per §2.5                            → exit 0
-□ grep: NO new `switch algo` / `IsXxxIndexAlgo ||` added in pkg/sql/*
-□ git diff --stat: the ONLY all.go/all_gpu.go edit is one blank import
-```
-
-**Known in-progress seams — do not add NEW ones.** A few DML-sync sites still
-call `catalog.IsIvfIndexAlgo` directly (`pkg/sql/plan/build_dml_util.go`,
-`pkg/sql/plan/bind_insert.go`) — the IVFFLAT-hardcoded resolution is mid-migration
-into `plan.Hooks`. These are **legacy**, not a license to add more. When you
-touch one, prefer moving it behind a hook; never model a *new* algorithm on them.
-
----
-
-## 9. Reviewing an index-plugin change (G-IDXREVIEW)
-
-Apply this when reviewing a diff — your own before "done", or via `/code-review`
-— that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/`,
-`pkg/fulltext/plugin`, or `pkg/indexplugin`. Each item maps to a §8.7 forbidden
-pattern; the grep is the fast check. **Request changes if any check fails**, and
-cite the §8.7 rule number in the finding.
-
-1. **No new per-algo dispatch** (§8.7 #1). The diff adds no `switch …IndexAlgo`,
-   `case MoIndex<X>Algo:`, or `IsIvfIndexAlgo || …` in `pkg/sql/{compile,plan}` /
-   `pkg/catalog`. Legacy holdouts (`build_dml_util.go`, `bind_insert.go`) may
-   remain — but **no new ones**.
-   ```bash
-   git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
-     | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
-   ```
-2. **No import cycle** (§8.7 #2). No plugin sub-package imports `pkg/sql/plan` or
-   `pkg/sql/compile`.
-   ```bash
-   git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
-     | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'   # expect empty
-   ```
-3. **`indexplugin` not polluted** (§8.7 #6). No file under `pkg/indexplugin/`
-   (except `all/`, `iscp/`) imports a concrete algo package or gains
-   algorithm-named / `switch algo` code.
-   ```bash
-   git diff pkg/indexplugin \
-     | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'  # only all*.go / iscp allowed
-   ```
-4. **GPU registration correct** (§8.6, §8.7 #3). A GPU-only algo's blank import is
-   in `all_gpu.go` (`//go:build gpu`), not `all.go`; each `build_gpu.go` has a
-   `//go:build !gpu` CPU counterpart.
-5. **Assertions intact** (§8.7 #4). The diff does not delete / comment /
-   `//nolint` any `var _ AlgoPlugin` or `var _ Hooks` line.
-   ```bash
-   git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'   # expect empty
-   ```
-6. **Runtime kept out** (§8.7 #5). No build/search kernel logic copied into the
-   plugin; it still calls `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`.
-7. **New-algo completeness** (§8.5, §8.8). If a new algorithm: blank-imported in
-   `all/` or `all_gpu/`, has an SQL case under `test/distributed/cases/vector/`,
-   and CPU unit tests cover the plan/schema/runtime hooks (not just GPU-gated
-   BVT).
+1. Never send terminal signals (`End`, `Error`, `Abort`) from `Call()`.
+2. Never call `sp.CloseWithTimeout()` after switching to explicit typed terminal signals.
+3. Never claim "pre-existing" without `git stash` proof.
+4. Never declare done without fresh test output.
+5. Never assume `go build` success means `go test` will pass.
+6. Never skip bottom-up testing: pure Go -> CGo-transitive -> CGo-direct.
+7. Never add a per-algorithm `switch`/`if` on an index algo name in the SQL layer. Route through `indexplugin.Get(algo)`.

--- a/.agents/skills/mo-dev/references/cgo-build-test.md
+++ b/.agents/skills/mo-dev/references/cgo-build-test.md
@@ -1,0 +1,210 @@
+# CGo, Build, Test, And GPU Reference
+
+## Contents
+
+- [1. Basic Commands](#1-basic-commands)
+- [2. CGo Environment (Three-Layer Variables)](#2-cgo-environment-three-layer-variables)
+- [3. Layered Testing Strategy](#3-layered-testing-strategy)
+- [4. Stash Protocol For "Pre-existing" Claims](#4-stash-protocol-for-pre-existing-claims)
+- [5. GPU Build (`MO_CL_CUDA=1`) -- cuVS / CUDA](#5-gpu-build-mo_cl_cuda1----cuvs--cuda)
+
+## 1. Basic Commands
+
+```bash
+# Compile check
+go build ./pkg/target/...
+
+# Static analysis
+go vet ./pkg/target/...
+
+# Run tests (-count=1 disables cache)
+go test -v -count=1 ./pkg/target/...
+
+# Single test
+go test -v -count=1 -run TestXxx ./pkg/target/...
+
+# Timeout control (integration tests can be slow)
+go test -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+## 2. CGo Environment (Three-Layer Variables)
+
+MO's CGo involves three independent layers: **compilation** (headers), **linking own lib** (`libmo`), and **third-party libs** (`libusearch_c`).
+
+```makefile
+# Makefile:203 -- header paths for compilation
+CGO_OPTS := CGO_CFLAGS="-I$(CGO_DIR) -I$(THIRDPARTIES_INSTALL_DIR)/include"
+
+# Makefile:204-207 -- link libmo (rpath varies by OS)
+# Linux:   -Wl,-rpath,$$ORIGIN/lib
+# macOS:   -Wl,-rpath,@executable_path/lib
+GOLDFLAGS := -ldflags="-extldflags '-L$(CGO_DIR) -lmo -L$(THIRDPARTIES_INSTALL_DIR)/lib $(RPATH)'"
+```
+
+Note: Makefile does **not** set `CGO_LDFLAGS`; `libmo` link flags all go through `-ldflags` -> `-extldflags`. The `usearch` Go module ships its own `#cgo LDFLAGS: -lusearch_c`, so `CGO_LDFLAGS` is needed to force the intended thirdparty path.
+
+### macOS vs Linux
+
+| Aspect | macOS | Linux |
+|--------|-------|-------|
+| Dynamic library | `libmo.dylib` | `libmo.so` |
+| Runtime path env | `DYLD_LIBRARY_PATH` | `LD_LIBRARY_PATH` |
+| rpath flag | `-Wl,-rpath,@executable_path/lib` | `-Wl,-rpath,\$ORIGIN/lib` |
+| C header flags | `CGO_CFLAGS="-I{root}/cgo -I{root}/thirdparties/install/include"` | Same |
+| usearch link flags | `CGO_LDFLAGS="-L{root}/thirdparties/install/lib -lusearch_c"` | Same |
+
+### Full Test Commands
+
+macOS:
+
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+Linux:
+
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+### Symptom -> Root Cause
+
+| Symptom | Missing Variable | Root Cause |
+|---------|-----------------|------------|
+| `fatal error: 'xxhash.h' file not found` | `CGO_CFLAGS` | Compiler cannot find thirdparties headers |
+| `Undefined symbols: _usearch_hardware_acceleration_*` (macOS) or `undefined symbol:` (Linux) | `CGO_LDFLAGS` | usearch module's `#cgo LDFLAGS` found old `libusearch_c` |
+| `ld: library 'mo' not found` (macOS) or `cannot find -lmo` (Linux) | `-ldflags="-extldflags '-L... -lmo'"` | Linker cannot find `libmo` |
+| `dyld: Library not loaded: libmo.dylib` (macOS) or `error while loading shared libraries: libmo.so` (Linux) | `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Runtime cannot find dynamic library |
+
+## 3. Layered Testing Strategy
+
+| Layer | Example Packages | CGo Behavior | Variables Needed |
+|-------|------------------|--------------|------------------|
+| **Pure Go** | `pkg/vm/process`, `pkg/container/pSpool`, `pkg/vm/pipeline` | Zero CGo in transitive closure | None |
+| **CGo-transitive** | `pkg/sql/colexec/connector`, `dispatch`, `merge` | Test binary links usearch Go module | `CGO_CFLAGS` + `CGO_LDFLAGS` |
+| **CGo-direct** | `pkg/sql/compile` | Test binary directly links `libmo` + `libusearch_c` | All four: CGO_CFLAGS + CGO_LDFLAGS + ldflags + DYLD/LD_LIBRARY_PATH |
+| **Integration** | `pkg/frontend`, cmd packages | Full MO binary, needs external services | All + services |
+
+Layer 1, pure Go:
+
+```bash
+go test -v -count=1 -timeout 120s ./pkg/vm/process/... ./pkg/container/pSpool/...
+```
+
+Layer 2, CGo-transitive on macOS:
+
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+go test -v -count=1 -timeout 120s ./pkg/sql/colexec/connector/... ./pkg/sql/colexec/dispatch/...
+```
+
+Layer 3, CGo-direct on macOS:
+
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+export DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib"
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/sql/compile/...
+```
+
+| Variable | What It Does | When Needed |
+|----------|--------------|-------------|
+| `CGO_CFLAGS` | Tells C compiler where to find headers | Package in transitive closure has CGo C code |
+| `CGO_LDFLAGS` | Overrides usearch module's own `#cgo LDFLAGS` path | usearch Go module is linked |
+| `-ldflags "-extldflags ..."` | Tells external linker where to find `libmo` + sets rpath | Package directly links `libmo` |
+| `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Tells OS runtime loader where to find `.dylib` / `.so` | Test binary loads `libmo` at runtime |
+
+Bottom-up testing matters: pure Go tests finish in seconds with zero env setup. If they fail, the problem is in code, not CGo.
+
+### `go build` vs `go test` Is Not Equivalent
+
+| Command | CGo Behavior |
+|---------|--------------|
+| `go build ./pkg/sql/colexec/connector/...` | May succeed without CGo flags because it compiles package code only |
+| `go test ./pkg/sql/colexec/connector/...` | Compiles and links a test binary; full CGo path fires |
+
+Always verify with `go test`.
+
+## 4. Stash Protocol For "Pre-existing" Claims
+
+Never claim a test failure is pre-existing without proof.
+
+```bash
+# 1. Stash current changes
+git stash
+
+# 2. Run the same test from clean state
+go test -v -count=1 -timeout 120s ./pkg/target/...
+
+# 3. If it fails: genuinely pre-existing -- document it
+# 4. If it passes: YOUR code caused it -- investigate
+git stash pop
+```
+
+## 5. GPU Build (`MO_CL_CUDA=1`) -- cuVS / CUDA
+
+GPU support compiles the CUDA-backed vector index algorithms (**CAGRA**, **IVF-PQ**) into `libmo` and turns on the `gpu` Go build tag. Linux x86_64 only. The macOS Makefile branch carries no CUDA flags, so macOS builds are CPU-only. Do not try to enable it on Darwin.
+
+Prerequisites:
+
+1. CUDA toolkit 12.0 / 13.0+ installed under `/usr/local/cuda`.
+2. cuVS Go bindings installed via conda and the env activated so `CONDA_PREFIX` is exported:
+
+```bash
+conda env create --name go -f conda/environments/go_cuda-130_arch-$(uname -m).yaml
+conda activate go
+```
+
+Build:
+
+```bash
+MO_CL_CUDA=1 make -j8
+```
+
+What `MO_CL_CUDA=1` flips:
+
+| Layer | CPU build | GPU build (`MO_CL_CUDA=1`) |
+|-------|-----------|----------------------------|
+| Go build tag | none | `-tags gpu` -- registers CAGRA + IVF-PQ, compiles `*_gpu.go` |
+| `cgo/` compiler | `gcc`/`clang` | `/usr/local/cuda/bin/nvcc` |
+| `libmo` objects | C objects only | + `cuda/*.o` + `cuvs/*.o` |
+| Link flags | `-lusearch_c -lroaring` | + `-lcuvs -lcuvs_c -lcudart -lcuda -lrmm -lstdc++` |
+| Header/lib roots | thirdparties only | + `$CONDA_PREFIX/{include,lib}`, `/usr/local/cuda/...` |
+
+Guardrails:
+
+- `CONDA_PREFIX env variable not found`: conda env not activated. Run `conda activate <env>` first. This is not a code bug.
+- `libmo` is re-linked on every GPU build deliberately because `mo-service` loads `libmo.so` dynamically. A stale `.so` silently runs old C++.
+
+The `gpu` tag gates index-plugin registration. CAGRA and IVF-PQ register only under `//go:build gpu` (`pkg/indexplugin/all/all_gpu.go`). On a CPU binary their plugins are absent from the registry, so `CREATE INDEX ... USING ivfpq|cagra` fails cleanly at plan-build with `unsupported index type: <algo>` before hidden table creation. Do not move those imports into `all.go`.
+
+The linked `libmo` must itself be GPU-built:
+
+```bash
+MO_CL_CUDA=1 make -j8 cgo
+```
+
+GPU tests need `-tags gpu` plus CUDA search paths. Linux only:
+
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include -I$CONDA_PREFIX/include -I/usr/local/cuda/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c -L$CONDA_PREFIX/lib -lcuvs -lcuvs_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$CONDA_PREFIX/lib:/usr/local/cuda/lib64" \
+go test -tags gpu \
+  -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib -fopenmp'" \
+  -v -count=1 -timeout 300s ./pkg/vectorindex/ivfpq/...
+```
+
+The authoritative flag source is the Makefile (`CUDA_CFLAGS` / `CUDA_LDFLAGS`), not this snippet. If a GPU link error appears, diff your flags against those lines.
+
+Tag-split test files are a trap: `*_gpu.go` / `//go:build gpu` tests compile only under `-tags gpu`. A plain `go test ./pkg/vectorindex/ivfpq/...` runs `//go:build !gpu` / `*_cpu.go` stubs instead. CPU tests passing does not test the GPU path.

--- a/.agents/skills/mo-dev/references/index-plugin.md
+++ b/.agents/skills/mo-dev/references/index-plugin.md
@@ -1,0 +1,194 @@
+# Vector / Fulltext Index-Plugin Reference
+
+## Contents
+
+- [1. Why The Framework Exists](#1-why-the-framework-exists)
+- [2. Architecture](#2-architecture)
+- [3. Registry Contract](#3-registry-contract)
+- [4. Plugin Package Layout](#4-plugin-package-layout)
+- [5. Adding A New Algorithm](#5-adding-a-new-algorithm)
+- [6. CPU vs GPU Registration](#6-cpu-vs-gpu-registration)
+- [7. Forbidden Patterns](#7-forbidden-patterns)
+- [8. Testing And Completion](#8-testing-and-completion)
+- [9. Reviewing An Index-Plugin Change](#9-reviewing-an-index-plugin-change)
+
+## 1. Why The Framework Exists
+
+Adding a vector index used to mean editing many files across `pkg/sql/compile`, `pkg/sql/plan`, `pkg/catalog`, and `pkg/vectorindex`, wired through repeated switch/if chains. Miss one site and the algorithm silently misbehaves.
+
+`pkg/indexplugin` collapses those sites into one registry lookup. An algorithm registers one `AlgoPlugin`, and compile-time interface assertions enforce required hooks.
+
+Guarded failure mode: re-introducing per-algorithm `switch algo` / `if IsXxxIndexAlgo || ...` in SQL/catalog layers bypasses the registry and re-opens the "forgot a dispatch site" bug class.
+
+## 2. Architecture
+
+`pkg/indexplugin` is the framework. It must not import `pkg/sql/{compile,plan}`. Hook methods receive narrow `Context` interfaces implemented by SQL-layer code.
+
+```
+pkg/indexplugin/
+├── plugin.go          -- AlgoPlugin interface; Register/Get/All; IsVectorIndexAlgo/IsFullTextIndexAlgo/IsPluginAlgo
+├── catalog/hooks.go   -- catalog.Hooks   (metadata: params, hidden tables, op/vector/pk types, quantization)
+├── compile/hooks.go   -- compile.Hooks   (DDL execution: create/reindex/drop/restore) + CompileContext
+├── plan/hooks.go      -- plan.Hooks      (schema defs + tablefunc + thin ANN redirects) + PlanBuilder/CompilerContext
+├── idxcron/hooks.go   -- idxcron.Hooks   (scheduled-rebuild gating: Updatable)
+└── all/
+    ├── all.go         -- blank-imports CPU-safe plugins (fulltext, hnsw, ivfflat)
+    └── all_gpu.go     -- //go:build gpu -- blank-imports GPU-only plugins (cagra, ivfpq)
+
+pkg/vectorindex/<algo>/plugin/   -- one dir per algorithm; assembles hooks into an AlgoPlugin
+pkg/fulltext/plugin/             -- fulltext is a plugin too (kind = fulltext, not vector)
+```
+
+Dispatch flow:
+
+```go
+p, ok := indexplugin.Get(algo) // case-insensitive, trims whitespace
+if ok { return p.Compile().HandleCreateIndex(cctx, defs) }
+```
+
+Use:
+
+- `indexplugin.IsVectorIndexAlgo(algo)` instead of `IsIvfIndexAlgo || IsHnswIndexAlgo || ...`
+- `indexplugin.IsFullTextIndexAlgo(algo)` for fulltext
+- `indexplugin.IsPluginAlgo(algo)` for registered vector or fulltext algorithms
+
+Live dispatch sites include `pkg/sql/plan/build_ddl.go` and `pkg/sql/plan/apply_indices.go`.
+
+## 3. Registry Contract
+
+```go
+type AlgoPlugin interface {
+    Algo() string
+    Catalog() catalogplugin.Hooks
+    Compile() compileplugin.Hooks
+    Plan()    planplugin.Hooks
+    Idxcron() idxcronplugin.Hooks
+}
+func Register(p AlgoPlugin)
+func Get(algo string) (AlgoPlugin, bool)
+```
+
+Each plugin keeps compile-time interface assertions:
+
+```go
+var _ plugin.AlgoPlugin = (*Plugin)(nil)
+var _ Hooks = Hooks{}
+```
+
+If `AlgoPlugin` or a `Hooks` interface gains a method and a plugin is not updated, these assertions stop the build. Never delete or `//nolint` them to make the build green. Implement the missing method.
+
+## 4. Plugin Package Layout
+
+Canonical walkthrough: `pkg/vectorindex/ivfpq/plugin/plugin.go`.
+
+Full plugin layout:
+
+```
+pkg/vectorindex/<algo>/plugin/
+├── plugin.go            -- assembles 4 Hooks into one Plugin; init() { plugin.Register(New()) }
+├── runtime/runtime.go   -- catalog.Hooks impl
+├── compile/compile.go   -- compile.Hooks impl
+├── plan/
+│   ├── plan.go          -- thin ApplyForSort/CanApply redirect into *plan.QueryBuilder
+│   ├── schema.go        -- BuildSecondaryIndexDefs body
+│   └── tablefunc.go     -- <algo>_create / <algo>_search FUNCTION_SCAN builder registrations
+├── idxcron/idxcron.go   -- idxcron.Hooks impl
+└── iscp/iscp.go         -- CDC / import sync; may be //go:build gpu
+```
+
+Lift code into the sub-package matching the original SQL layer:
+
+- `pkg/sql/compile/*.go` -> `plugin/compile/`
+- `pkg/sql/plan/*.go` -> `plugin/plan/`
+- Algorithm metadata constants -> `plugin/runtime/`
+
+## 5. Adding A New Algorithm
+
+1. Add catalog constants:
+   - `MoIndex<X>Algo` in `pkg/catalog/secondary_index_utils.go`
+   - hidden-table-type constants in `pkg/catalog/types.go`
+   - parser keyword only if syntax needs it
+2. Copy `pkg/vectorindex/ivfpq/plugin/` to `pkg/vectorindex/<x>/plugin/`, then rename packages/imports.
+3. Implement four hooks:
+   - `catalog.Hooks`: hidden table types, params, defaults, supported types, quantization, clone/restore behavior, session vars, sync descriptor.
+   - `compile.Hooks`: create, reindex, validate reindex params, drop, restore init SQL, idxcron metadata.
+   - `plan.Hooks`: secondary/fulltext index defs, `CanApply`, `ApplyForSort`.
+   - `idxcron.Hooks`: `Updatable`.
+4. If ANN rewrite is supported, add `applyIndicesForSortUsing<X>` + `prepare<X>IndexContext` in `pkg/sql/plan/apply_indices_<x>.go`, redirect methods in `pkg/sql/plan/plugin_builder.go`, and dispatch via `p.Plan().CanApply`.
+5. Register in `plugin.go` with `plugin.Register(New())`.
+6. Add exactly one blank import:
+   - CPU-safe algo -> `pkg/indexplugin/all/all.go`
+   - GPU-only algo -> `pkg/indexplugin/all/all_gpu.go`
+7. Add SQL tests under `test/distributed/cases/vector/` for create, ANN query, reindex, drop index, and drop table.
+
+If the plugin compiles and all hooks are implemented, you did not miss a dispatch site. Do not add manual dispatch "to be safe."
+
+## 6. CPU vs GPU Registration
+
+| File | Build tag | Registers | Rationale |
+|------|-----------|-----------|-----------|
+| `pkg/indexplugin/all/all.go` | none | fulltext, hnsw, ivfflat | CPU-safe algorithms |
+| `pkg/indexplugin/all/all_gpu.go` | `//go:build gpu` | cagra, ivfpq | CUDA-backed table functions exist only under `gpu` |
+
+CAGRA / IVF-PQ table functions exist only under `//go:build gpu`. Registering them on CPU would let `CREATE INDEX ... USING cagra|ivfpq` proceed until BUILD SQL fails mid-flight after hidden table side effects. GPU-tagged registration makes plan-build fail cleanly with `unsupported index type: <algo>`.
+
+Pairing rule: an algo with `build_gpu.go` must have a `//go:build !gpu` CPU counterpart stub, and the plugin blank import belongs in `all_gpu.go`, never `all.go`.
+
+## 7. Forbidden Patterns
+
+1. Never re-introduce per-algorithm dispatch in SQL/catalog layers. A new `switch idx.IndexAlgo`, `case MoIndex<X>Algo:`, or `if catalog.IsIvfIndexAlgo(a) || ...` re-opens the bug class the framework closed. Add a method to a hook interface instead.
+2. Never import `pkg/sql/plan` or `pkg/sql/compile` from a plugin package. Plugins receive narrow interfaces and call through them.
+3. Never register a GPU-only algo in `all.go`; use `all_gpu.go`.
+4. Never weaken `var _ AlgoPlugin` / `var _ Hooks` assertions.
+5. Keep runtime kernels out of the plugin. Build/search kernels stay in `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go` and are invoked from table functions.
+6. Never pollute `pkg/indexplugin` with algorithm-specific code. It is interfaces, registry, and algorithm-agnostic metadata only. The only files there that may name concrete algorithms are `all/` and `iscp/` aggregators, and only as blank imports.
+
+## 8. Testing And Completion
+
+Index-plugin changes have a coverage trap: end-to-end BVT cases under `test/distributed/cases/vector/` are GPU-gated, so `plan.go` / `schema.go` can read 0% coverage in non-GPU CI. Add CPU-runnable unit tests like `tablefunc_test` / `runtime_test` style tests, not just GPU-gated BVT.
+
+Completion checklist:
+
+```
+□ CPU unit tests exist for plan/schema/runtime hooks  -> run, exit 0
+□ GPU-only hooks also run with `-tags gpu`             -> exit 0
+□ grep: NO new `switch algo` / `IsXxxIndexAlgo ||` added in pkg/sql/*
+□ git diff --stat: the ONLY all.go/all_gpu.go edit is one blank import
+```
+
+Known in-progress seams: a few DML-sync sites still call `catalog.IsIvfIndexAlgo` directly (`pkg/sql/plan/build_dml_util.go`, `pkg/sql/plan/bind_insert.go`). These are legacy, not a license to add more. When touching one, prefer moving it behind a hook.
+
+## 9. Reviewing An Index-Plugin Change
+
+Apply this when reviewing a diff that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/`, `pkg/fulltext/plugin`, or `pkg/indexplugin`. Request changes if a check fails.
+
+1. No new per-algo dispatch:
+
+```bash
+git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
+  | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
+```
+
+2. No import cycle:
+
+```bash
+git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
+  | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'
+```
+
+3. `indexplugin` not polluted:
+
+```bash
+git diff pkg/indexplugin \
+  | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'
+```
+
+4. GPU registration correct: GPU-only imports in `all_gpu.go`, not `all.go`; each `build_gpu.go` has CPU counterpart.
+5. Assertions intact:
+
+```bash
+git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'
+```
+
+6. Runtime kept out: no build/search kernel logic copied into plugin.
+7. New-algo completeness: registered in `all/` or `all_gpu/`, SQL case added under `test/distributed/cases/vector/`, CPU unit tests cover plan/schema/runtime hooks.

--- a/.agents/skills/mo-dev/references/operator-pipeline.md
+++ b/.agents/skills/mo-dev/references/operator-pipeline.md
@@ -1,0 +1,96 @@
+# Operator And Pipeline Reference
+
+## 1. Operator Lifecycle Contracts
+
+### Call() vs Reset()
+
+| Method | Purpose | Must NOT Do |
+|--------|---------|-------------|
+| `Call()` | Process one batch. Receive from upstream, compute, send downstream. | Send terminal signals (`End`, `Error`, `Abort`). That is `Reset()`'s job. |
+| `Reset()` | Cleanup. Notify downstream the operator is done. | Block waiting for receiver acknowledgment. Use `Abort()`, not `CloseWithTimeout()`. |
+
+This is the most common source of subtle operator bugs: premature pipeline termination, spurious timeouts, dead receivers.
+
+### PipelineSpool Lifecycle
+
+| Method | Behavior | Use When |
+|--------|----------|----------|
+| `Close()` | Wait for all consumers to acknowledge end of stream by consuming nil batches from spool | Graceful completion path |
+| `CloseWithTimeout()` | Same as `Close()` but with timeout | Legacy cleanup; deprecated for typed signals |
+| `ForceCleanup()` / `Abort()` | Synchronous release of all un-consumed slots. No waiting. Idempotent (`sync.Once`) | Cleanup path with explicit terminal signals |
+
+Critical rule: if implicit nil-batch end-of-stream was replaced with explicit typed signals (`EventEnd`, `EventError`, `EventAbort`), use `Abort()` instead of `CloseWithTimeout()`. `CloseWithTimeout()` waits for nil batches that will never arrive.
+
+### Pipeline Signal Types
+
+| Signal | Constructor | Meaning |
+|--------|-------------|---------|
+| `EventData` | `NewDataSignal(batch)` | Normal data batch |
+| `EventEnd` | `NewEndSignal()` | Graceful end of stream |
+| `EventError` | `NewErrorSignal(err)` | Operator encountered an error |
+| `EventAbort` | `NewAbortSignal()` | Forceful termination |
+
+Dual-protocol compatibility: `GetNextBatch` handles both explicit typed signals and legacy nil-batch convention (`content == nil`). Old operators using implicit nil-batch continue to work.
+
+## 2. Post-Modification Verification
+
+### Test Freshness
+
+Test output must be from the current turn:
+
+1. `go test` command appears in current turn's tool calls.
+2. Exit code is 0.
+3. Timestamp is after the last edit.
+
+### Completion Gate
+
+Before declaring a change done, all boxes must be checked:
+
+```
+□ go build ./pkg/.../modified_package...    -> exit 0
+□ go vet ./pkg/.../modified_package...      -> exit 0
+□ go test -v -count=1 ./pkg/.../...         -> exit 0, no hangs
+□ git diff --stat                            -> inspected, no unintended files
+□ Regression: at least one test from dependent package passes
+```
+
+Hang = failure. If `go test` produces more than 10s of no output, investigate.
+
+## 3. Fault Diagnosis
+
+| Symptom | Look At |
+|---------|---------|
+| Test hangs exactly 30s | `CloseWithTimeout` waiting for nil-batch that never arrives. Check if typed signals are being sent instead. |
+| Test hangs >5s, no output | Deadlock or blocking channel send. Check whether `done` channel is closed and whether `sendSignal` uses non-blocking `select`. |
+| `context deadline exceeded` after 30s | `WaitingEndWithTimeout` timed out. Check whether all senders called `Reset()` and sent typed terminal signals. |
+| `CGO_CFLAGS` not working | Run `go env CGO_CFLAGS` to verify. Use `export` if the package has sub-packages. |
+
+## 4. Common Pitfalls
+
+### Structural Changes Need Both Ends
+
+When changing communication protocol between operators, such as connector <-> merge or dispatch <-> merge, update both sender and receiver. A sender-only change can deadlock.
+
+Identification: exact 30s timeout in cleanup usually points to `CloseWithTimeout` + typed signal mismatch.
+
+### CGo Link Errors Are Usually Environment
+
+CGo link errors (`Undefined symbols`, `cannot find -lmo`) are environment issues until proven otherwise. The C shared libraries (`libmo.dylib`, `libusearch_c.dylib`) must be pre-built via `make cgo` and `make thirdparties`.
+
+### Pipeline Cleanup: Abort, Do Not Wait
+
+During pipeline cleanup, operators should use non-blocking or timeout-gated communication. Never block waiting for a receiver that may have already exited.
+
+### Channel Full Edge Cases
+
+When sending terminal signals into a bounded channel, the send may fail because the channel is full. Ensure the terminal state is still recorded even when channel send fails; the `done` channel must close regardless of delivery success.
+
+## 5. Forbidden Patterns
+
+1. Never send terminal signals (`End`, `Error`, `Abort`) from `Call()`. Only `Reset()` sends terminal signals.
+2. Never call `sp.CloseWithTimeout()` after switching to explicit typed terminal signals. Use `sp.Abort()`.
+3. Never claim "pre-existing" without `git stash` proof.
+4. Never declare done without fresh test output.
+5. Never assume `go build` success means `go test` will pass.
+6. Never skip bottom-up testing.
+7. Never add per-algorithm `switch`/`if` on index algo names in the SQL layer. Route through `indexplugin.Get(algo)`.

--- a/.agents/skills/mo-self-review/SKILL.md
+++ b/.agents/skills/mo-self-review/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: mo-self-review
 description: Pre-push self-review gate for MatrixOne changes — a systematic, multi-angle, first-principles review of your OWN diff with complete functional-closure investigation and unhappy-path coverage, calibrated to the merge bar. Run BEFORE pushing / opening / updating a PR so the human or bot PR review finds nothing new — breaking the review→modify loop. Use before declaring a change "done", before push, or when a PR keeps drawing new review rounds. Complements unhappy-path-audit (Q1–Q3 depth) and /code-review.
-compatibility: Designed for Codex CLI and compatible agents. Requires a git working tree with a diff vs the base branch and the unhappy-path-audit skill (for Q1-Q3 depth).
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone
   language: go
 ---
+
+Compatibility: designed for Codex CLI and compatible agents. Requires a git working tree with a diff vs the base branch and the unhappy-path-audit skill (for Q1-Q3 depth).
 
 ## Running this skill IS the review (don't retype the long prompt)
 

--- a/.agents/skills/unhappy-path-audit/SKILL.md
+++ b/.agents/skills/unhappy-path-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unhappy-path-audit
-description: Full-codebase unhappy-path audit (hung, leak, OOM) using the Q1-Q3 three-proposition framework to produce structured risk reports.
+description: Full-codebase MatrixOne unhappy-path audit for leak, hung, and OOM risks using the Q1-Q3 three-proposition framework. Use when asked to audit resource lifecycle, waits, goroutines, lock/connection cleanup, unbounded growth, or to produce structured risk reports / bug candidates for MatrixOne code.
 ---
 
 # Unhappy Path Audit Skill
@@ -294,7 +294,3 @@ Common false positive: variable is reset in a function you haven't read yet (e.g
 | See append/push without bound in current scope → report OOM | Grep variable + `= nil` — cleanup function in sibling file may reset it | G3 |
 | See function call that "might" panic → report fd leak on panic path | Open function body — nil-check+assign or simple arithmetic cannot panic | G2 |
 | See `SendMessage` return error → assume upstream state machine doesn't clean up | Re-read the exact line where state is set — it may be unconditional | G4 |
-
-## Recent user feedback
-<!-- auto-recorded at t=1782710864 -->
-- User directive: 不要管。继续下一个task

--- a/.claude/skills/mo-bug-triage/SKILL.md
+++ b/.claude/skills/mo-bug-triage/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: mo-bug-triage
-description: Systematic triage and classification of MatrixOne kind/bug issues — calibrated severity assessment, batched GitHub metadata updates (milestone, severity, project), rollback-safe batch processing, and drift prevention. Use when asked to triage, classify, or bulk-update MO bugs.
-compatibility:
-  agents: Codex CLI and compatible agents
-  requires:
-    - GitHub CLI (gh) with authenticated access (5000 req/hr)
-    - repo write scope
+description: Systematic MatrixOne kind/bug lifecycle triage — intake normalization with `needs-triage`, conservative promotion to active severity (`severity/s-1`, `severity/s0`, `severity/s1`), immediate downgrade to `deferred` with explanatory comments, optional five-level AI effort labeling (`ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual`) only when explicitly requested for issues/PRs, batched GitHub metadata updates, rollback-safe processing, and drift prevention. Use when asked to triage, classify, review, downgrade, defer, label, AI-effort-assess, or bulk-update MO bugs and related PRs.
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone
   workflow: bug-triage
 ---
 
+Compatibility: designed for Codex CLI and compatible agents. Requires GitHub CLI (`gh`) with authenticated access (5000 req/hr) and repo write scope.
+
 ## Enforcement Gates
 
 | Gate | When | Action |
 |------|------|--------|
+| **G-INTAKE** | When handling new bugs | New `kind/bug` issues enter `needs-triage`. Do not assign active severity during intake unless a maintainer explicitly confirms emergency impact. |
+| **G-PROMOTION** | Before applying `severity/s-1`, `severity/s0`, or active `severity/s1` | Evidence must show confirmed urgency/impact or a committed owner. Record the rationale in the report or issue comment. |
+| **G-DEFER-COMMENT** | Before applying `deferred` | Add an explicit comment explaining why the issue should not continue as s0/s1 active work. |
+| **G-AI-REQUEST** | Before assessing or applying any AI effort label | User must explicitly request AI effort assessment, or the run mode must be `ai-assess`/`ai-final`. Plain `needs-triage` intake must not infer or apply `ai-*`. |
+| **G-AI-SOURCE** | Before applying any AI effort label | Record assessment stage (`issue-initial`, `pr-review`, or `user-assisted`), confidence, and one-sentence rationale. |
+| **G-AI-FINAL** | During explicit `ai-final` or PR AI-label review | Recheck five-level AI effort against actual implementation effort and update issue + PR labels if stale. |
 | **G-STANDARDS** | Before any GitHub write | STANDARDS.md must exist with `Approved: true`. Scripts exit(1) if missing. |
 | **G-SNAPSHOT** | Before batch update | `batch_N_before_snapshot.json` must be saved. Rollback requires it. |
 | **G-DRYRUN** | Before full batch update | First 5 issues updated + verified. Mismatch → stop. |
@@ -26,15 +29,23 @@ metadata:
 ## TL;DR
 
 ```
+Default lifecycle
+  → New bug: kind/bug + needs-triage; no priority promise at entry
+  → Analysis: verify repro, impact, owner, dependency, duplicates
+  → Execute: promote only confirmed urgent/high-impact work to s-1/s0
+  → Active non-emergency work: use s1 only when owned and committed
+  → Downgrade: if not s0/s1 active work, move to deferred + comment
+  → AI effort: do not run by default; assess only on explicit request or ai-* mode
+
 Phase 1: LOCK STANDARDS   (~15min, 0 writes)
-  → Sample 8-12 bugs by domain → user approves STANDARDS.md → gate locked
+  → Sample 8-12 bugs by domain → lock lifecycle/severity/defer rules
 
 Phase 2: BATCHED PROCESS  (~5min per batch of 50)
-  → Each batch: fetch→classify→report→snapshot→dry-run→update→progress
+  → Each batch: fetch→classify action→report→snapshot→dry-run→update→progress
   → Batch N failure never touches Batch 1..N-1 (already committed)
 
 Phase 3: FINAL VERIFY      (~10min)
-  → Domain audit + severity cross-check + batch spot-check + sampled API verify
+  → Lifecycle audit + label count cross-check + defer-comment check; AI-label checks only for explicit AI modes
 ```
 
 ~310 issues ≈ 7 batches ≈ **30-45 min** (limited by GitHub rate limit: 5000 req/hr).
@@ -43,33 +54,58 @@ Phase 3: FINAL VERIFY      (~10min)
 
 ## Core Rules
 
+### Current GitHub Bug Workflow
+
+| Stage | Required Behavior |
+|-------|-------------------|
+| **Intake** | Label new bugs as `kind/bug` + `needs-triage`. Treat this as the candidate pool, not a priority commitment. Do not pre-assign `severity/s0`, `severity/s1`, or `severity/s-1` from title keywords alone. |
+| **Execution** | Promote only confirmed urgent or broad-impact issues to `severity/s0` or `severity/s-1`. Use `severity/s1` only for owned, committed near-term bug work that should stay active but is not s0/s-1. |
+| **Downgrade** | After analysis, if an issue should not continue as s0/s1 active work, immediately remove active severity/`needs-triage`, add `deferred`, and comment with the concrete reason. |
+| **AI Labels** | Do not apply AI effort labels during default `needs-triage`. Apply exactly one AI effort label (`ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual`) only when the user asks for AI effort assessment or when running explicit `ai-assess`/`ai-final`. |
+| **Ownership** | Each owner is responsible for their own issues and PRs: keep labels, comments, linked PRs, and closure status current without waiting to be driven. |
+
+### Lifecycle Labels
+
+| Label | Meaning | Write Rule |
+|-------|---------|------------|
+| `needs-triage` | Candidate pool for newly reported or not-yet-analyzed bugs. | Add at entry; remove only when promoted, deferred, closed, or explicitly excluded. Do not add `ai-*` during intake. |
+| `severity/s-1` | Confirmed project emergency. | Use only for multi-tenant isolation/data exposure or explicit maintainer-confirmed emergency. If confirmed serious but not s-1 → `severity/s0`; if evidence is incomplete → `needs-triage`. |
+| `severity/s0` | Confirmed urgent/high-impact active work. | Requires evidence: stable repro or production signal plus broad impact, data integrity risk, crash/hang/OOM/leak, common-path breakage, or release blocker. |
+| `severity/s1` | Confirmed active work that is important but not emergency. | Requires an owner or near-term commitment. Do not use as a parking lot for unconfirmed bugs. |
+| `deferred` | Analyzed but not active s0/s1 work. | Requires a comment explaining why and what signal would justify reopening/promoting. Prefer this over creating new `severity/s2` triage unless explicitly requested. |
+| `ai-easy` | AI can directly implement; human review is mostly a quick scan. Suitable for batch/parallel AI execution. | Use for clear, localized, low-risk fixes with deterministic validation. |
+| `ai-light` | AI can produce a good draft or plan; human must tune details or make a small decision. | Use when scope is bounded but there is minor ambiguity in expected behavior, tests, or local integration. |
+| `ai-medium` | Human and AI likely need several rounds, with roughly shared effort. | Use when root cause or fix shape is partially unclear, or the change crosses a few modules. |
+| `ai-heavy` | AI can assist with research, snippets, tests, or log analysis; core logic stays human-owned. | Use for broad, risky, or subsystem-level work where human design/debug judgment dominates. |
+| `ai-manual` | AI is unlikely to help beyond clerical support. | Use when work depends on unavailable environments/data, security-sensitive access, product decisions, or human-only operational context. |
+
 ### Severity Hierarchy
 
 | Severity | Criteria | Examples |
 |----------|----------|----------|
-| **s-1** | **MUST be conservative.** Only: multi-tenant isolation breach. Refer to existing project s-1 count (≤5). If unsure → s0. | #15972 tenant isolation break |
-| **s0** | **THE MAIN BUCKET** (~70%). Panic/crash, hung/deadlock, OOM/memory exhaustion, data integrity violation, resource leak, commonly-used feature broken, performance regression on core paths. | INSERT panic, subquery hung, LOAD DATA OOM, lockservice leak, ORDER BY wrong, Prisma compat |
-| **s1** | **Lower priority** (~20%). Partition bugs, streaming bugs, cold/infrequently-used features, edge-case functions, subtasks of larger features. | partition pruning, streaming CTE, collation, SP, backup/restore, role admin, REPLACE subtasks |
-| **s2** | **Very low priority** (~10%). Feature requests mislabeled as bugs, tech debt, typos, non-functional cleanup. | "support X", refactor internal API, doc fix |
+| **s-1** | **MUST be conservative.** Multi-tenant isolation/data exposure, cross-tenant corruption, or explicitly confirmed project emergency. Refer to existing project s-1 count (≤5). If confirmed serious but not s-1 → s0; if evidence is incomplete → needs-triage. | tenant isolation break, cross-account data exposure |
+| **s0** | Confirmed urgent/high-impact active bug: panic/crash, hung/deadlock, OOM/memory exhaustion, data integrity violation, resource leak, commonly-used feature broken, performance regression on core paths, release blocker. | INSERT panic, subquery hung, LOAD DATA OOM, lockservice leak, ORDER BY wrong, Prisma compat |
+| **s1** | Confirmed active non-emergency bug with owner/commitment. Lower-impact partition/streaming/cold-feature bugs can be s1 only when they should be worked soon. | planned partition pruning fix, assigned streaming CTE bug, owned backup/restore issue |
+| **deferred** | Not active s0/s1 work after analysis. Use for unstable repro, missing dependencies, non-critical paths, duplicate/consolidated work, feature requests mislabeled as bugs, tech debt, typos, or cleanup. | repro not stable, blocked by dependency, merge into existing issue, cold feature not planned |
 
 ### Domain Downgrade Table
 
-These domains are **auto-downgraded** UNLESS a higher-severity trigger fires:
+These domains default to `deferred` after analysis unless a higher-severity trigger is confirmed or an owner commits to near-term work:
 
-| Domain | Default | Exception (keeps original severity) |
+| Domain | Default | Exception |
 |--------|---------|-------------------------------------|
-| Partition | s1 | Panic/crash → s0; data integrity → s0 |
-| Streaming | s1 | Panic/crash → s0; data integrity → s0 |
-| Cold features | s1 | Panic/crash → s0; data integrity → s0 |
+| Partition | `deferred` | Confirmed panic/crash/data integrity → s0; owned near-term work → s1 |
+| Streaming | `deferred` | Confirmed panic/crash/data integrity → s0; owned near-term work → s1 |
+| Cold features | `deferred` | Confirmed panic/crash/data integrity → s0; owned near-term work → s1 |
 | Feature Request | **exclude** | N/A — skip bug triage entirely |
 
 **Cold features list**: stored procedures, CTE, window functions, collation, fulltext, backup/restore, role/DCL (GRANT/REVOKE), REPLACE INTO, trigger, event scheduler.
 
-> **Note**: `LOAD DATA` and `import` are NOT cold features — they are commonly-used ETL paths. Their bugs default to s0.
+> **Note**: `LOAD DATA` and `import` are NOT cold features — they are commonly-used ETL paths. Confirmed breakage can justify s0, but intake still starts at `needs-triage`.
 
-### s0 Triggers (override domain downgrade)
+### s0 Investigation Triggers
 
-A bug hits s0 if the title+body contains ANY of these keywords:
+These keywords are investigation triggers. They justify a closer look, not automatic promotion from `needs-triage`.
 
 | Trigger | Keywords |
 |---------|----------|
@@ -82,15 +118,33 @@ A bug hits s0 if the title+body contains ANY of these keywords:
 ### Classification Algorithm
 
 1. Extract `title` (lowercase), `body` (lowercase) from issue JSON
-2. Check s-1: `"tenant isolation"` or `"cross-tenant"` in title → `severity/s-1`
-3. Detect domains: is_partition, is_streaming, is_cold_feature (keyword matching)
-4. Check s0 triggers in title+body (panic/hung/OOM/data-integrity/resource-leak)
-5. **If ANY s0 trigger fires → `severity/s0` regardless of domain**
-6. Else if partition/streaming/cold-feature → `severity/s1`
-7. Else → `severity/s0` (default common feature)
-8. Project: `MOEngine-Compute` default; `MOEngine-Storage` if `logservice|tn|wal|replica|storage` in title
+2. If the issue is new/untriaged: ensure `kind/bug` + `needs-triage`; do not add active severity yet
+3. Detect domains: is_partition, is_streaming, is_cold_feature, is_feature_request, duplicate/consolidation candidate
+4. Detect evidence flags: panic/hung/OOM/data-integrity/resource-leak/common-path/release-blocker
+5. Decide action:
+   - `promote-s-1`: confirmed multi-tenant isolation/data exposure or explicit maintainer emergency
+   - `promote-s0`: confirmed urgent/high-impact active bug with evidence and owner path
+   - `promote-s1`: confirmed active non-emergency bug with owner/near-term commitment
+   - `defer`: analyzed but not active s0/s1 work; requires comment
+   - `keep-needs-triage`: insufficient information and no owner analysis yet
+   - `exclude`: feature request or non-bug; remove from bug triage path per repo convention
+6. Skip AI effort assessment by default. If and only if explicitly requested or running `ai-assess`/`ai-final`, estimate one AI effort label and record stage (`issue-initial`, `pr-review`, or `user-assisted`), confidence, and evidence in the report
+7. Project: `MOEngine-Compute` default; `MOEngine-Storage` if `logservice|tn|wal|replica|storage` in title
+8. If the user requested `ai-final` or PR AI-label review, re-evaluate AI label using actual code changes/tests/review complexity and update issue + PR labels
 
-**Key invariant**: s0 trigger (panic/hung/OOM/integrity/leak) always wins over domain downgrade.
+**Key invariant**: no issue leaves `needs-triage` for active severity without evidence and an owner/impact rationale. Keywords alone are never sufficient.
+
+### Deferred Comment Template
+
+When moving to `deferred`, write a short, concrete comment:
+
+```markdown
+Deferred after triage.
+
+Reason: <unstable repro | missing dependency | non-critical path | consolidated into #NNNNN | feature request / not a bug | insufficient impact signal>
+Current evidence: <one sentence>
+To promote later: <specific signal needed, owner action, or linked issue/PR>
+```
 
 ### Skip List
 
@@ -100,9 +154,43 @@ Skip entirely — do not classify, do not update:
 
 ### Severity Inflation Guard
 
-- Before s-1: verify **exactly** matches multi-tenant isolation breach. If unsure → s0.
-- Before s0: verify actual panic/hung/OOM/integrity/common-function-break. If only partition/streaming/cold-feature → s1.
-- Default for any ambiguity → **one tier lower** than instinct.
+- Before s-1: verify **exactly** matches multi-tenant isolation breach or explicit maintainer emergency. If serious but not s-1 and confirmed → s0; if unconfirmed → keep `needs-triage`.
+- Before s0: verify actual panic/hung/OOM/integrity/common-function-break plus urgency/impact. If evidence is only title keywords → keep `needs-triage`.
+- Before s1: verify there is an owner or near-term commitment. If not → `deferred` after analysis or keep `needs-triage` before analysis.
+- Default for any post-analysis ambiguity → `deferred` with a clear reopen/promote condition.
+
+### AI Effort Assessment
+
+Use AI labels to estimate **how much human involvement is required**, not severity or business priority. This is an opt-in assessment, not part of default `needs-triage`. Normalize spelling to lowercase: use `ai-medium`, not `ai-Medium`.
+
+| Label | Meaning | Strong Signals |
+|-------|---------|----------------|
+| `ai-easy` | AI directly handles it; human only scans the result. Can be batched and run in parallel. | Clear repro, obvious expected behavior, localized fix, deterministic test, no data/security/consensus risk. |
+| `ai-light` | AI writes a useful first draft or plan; human adjusts details or makes one bounded decision. | Localized bug with minor ambiguity, test needs adaptation, existing pattern is clear but exact choice needs review. |
+| `ai-medium` | Human and AI iterate for several rounds; roughly half the work is human judgment/debugging. | Root cause not fully isolated, fix touches several files/modules, requires repro refinement, test strategy is non-trivial. |
+| `ai-heavy` | AI is support only; core logic and decisions remain human-owned. | Cross-subsystem impact, concurrency/transaction/storage semantics, data correctness risk, production-only symptom, significant design/debug judgment. |
+| `ai-manual` | AI mostly cannot help beyond clerical tasks. | Requires private/unavailable environment or data, sensitive access, human-only operational/product decision, unclear report with no actionable evidence. |
+
+Assessment stages:
+
+- `issue-initial`: rough label from issue title/body/logs/repro. Prefer `ai-medium` or `ai-heavy` when evidence is thin.
+- `pr-review`: revise using linked PR diff, tests, review comments, files changed, and actual debugging burden.
+- `user-assisted`: combine issue/PR evidence with user-provided context such as owner knowledge, hidden dependency, production signal, or known fix plan.
+
+Assessment rules:
+
+- Do not infer AI effort during plain intake or default `kind/bug,needs-triage` triage. Leave all `ai-*` labels untouched unless the user requested AI assessment.
+- Apply at most one AI effort label at a time; remove the other four when updating.
+- Record `ai_label_stage`, `ai_confidence` (`low`, `medium`, `high`), and one-sentence `ai_rationale` in reports.
+- Escalate the label when correctness/security/consensus/storage/transaction risk is present, even if the diff looks small.
+- De-escalate only with evidence: linked PR proved localized, deterministic tests pass, or user confirms a simple known fix.
+- Near PR close, revise labels based on actual work rather than the initial estimate when an AI label exists or the user asks for `ai-final`.
+
+### Ownership Rule
+
+- For issues/PRs assigned to you or linked to your work, update labels/comments proactively.
+- Link PRs to issues, keep existing/requested issue and PR AI labels consistent near close, and close or defer issues explicitly.
+- Do not wait for another person to drive routine status, downgrade, AI label correction, or closure hygiene.
 
 ---
 
@@ -116,14 +204,16 @@ gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 1 --json tot
 
 Record `total_count`. Plan batches: `ceil(total_count / 50)`.
 
-### Step 1.2: Query Existing Severity Distribution
+### Step 1.2: Query Existing Lifecycle Distribution
 
 ```bash
 gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 500 --json labels \
-  --jq '.[].labels[].name' | grep '^severity/' | sort | uniq -c | sort -rn
+  --jq '.[].labels[].name' \
+  | grep -E '^(needs-triage|deferred|severity/|ai-easy|ai-light|ai-medium|ai-heavy|ai-manual)$' \
+  | sort | uniq -c | sort -rn
 ```
 
-Your output must roughly match: s-1 ≤ 5, s0 ~70%, s1 ~20%, s2 ~10%.
+Do not force a target ratio. Treat high active severity counts as an audit signal: `severity/s-1` must remain rare, `severity/s0`/`severity/s1` must have evidence/owners, and new work should accumulate in `needs-triage` until analyzed.
 
 ### Step 1.3: Domain-Stratified Sampling
 
@@ -151,21 +241,21 @@ gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 100 \
 
 ### Step 1.4: STANDARDS.md → User Approval Gate
 
-Present sampled issues with proposed severities. Produce file:
+Present sampled issues with proposed lifecycle actions. Produce file:
 
 ```markdown
 # MO Bug Triage Standards — [Date]
 
 ## Approved: false   ← MUST be set to true before Phase 2
 
-## Severity Rules (locked after approval)
+## Lifecycle + Severity Rules (locked after approval)
 ... (Core Rules tables above)
 
 ## Sampled Examples (user-confirmed)
-| # | Issue | Domain | Proposed | User Decision |
-|---|-------|--------|----------|---------------|
-| 1 | ... | DML | s0 | ✅ |
-| 2 | ... | Partition | s1 | ✅ |
+| # | Issue | Domain | Proposed Action | AI Estimate | Deferred Comment Required | User Decision |
+|---|-------|--------|-----------------|-------------|---------------------------|---------------|
+| 1 | ... | DML | promote-s0 | not requested | no | approved |
+| 2 | ... | Partition | defer | not requested | yes: non-critical path, no owner | approved |
 ```
 
 **Wait for explicit user "approved"/"looks good"**, then:
@@ -190,15 +280,26 @@ if not m or m.group(1) != "true":
 
 ## Phase 2: BATCHED PROCESS (~5 min/batch)
 
-Each batch is a sealed unit: fetch → classify → report → **snapshot** → dry-run → update → progress. Batch N failure never touches 1..N-1.
+Each batch is a sealed unit: fetch → classify action → report → **snapshot** → dry-run → update → progress. Batch N failure never touches Batch 1..N-1.
 
-### Step 2a: Fetch One Batch
+### Step 2a: Select Mode + Fetch One Batch
+
+Choose the mode explicitly:
+
+| Mode | Use When | Label Query |
+|------|----------|-------------|
+| `intake` | Normalize new bugs into the candidate pool | `kind/bug` then filter out issues already carrying `needs-triage`, `deferred`, or active severity |
+| `triage` | Analyze the candidate pool; do not assess AI effort unless explicitly requested | `kind/bug,needs-triage` |
+| `active-review` | Audit active work for downgrade or stale labels | Run separate batches for `kind/bug,severity/s0` and `kind/bug,severity/s1` |
+| `ai-assess` | User explicitly asks to estimate AI effort for issues | Query the user-requested issue set; may include `needs-triage` but must not be implicit |
+| `ai-final` | Recheck PR-close AI labels | Run separate linked issue/PR batches for `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, and `ai-manual` |
 
 ```bash
 PAGE=$1
+LABEL_QUERY="${LABEL_QUERY:-kind/bug,needs-triage}"
 gh api -H "Accept: application/vnd.github+json" \
-  "/repos/matrixorigin/matrixone/issues?state=open&labels=kind/bug&per_page=50&page=${PAGE}&sort=created&direction=desc" \
-  --jq '.[] | {number,title,body,labels:[.labels[].name],assignee:.assignee.login,state}' \
+  "/repos/matrixorigin/matrixone/issues?state=open&labels=${LABEL_QUERY}&per_page=50&page=${PAGE}&sort=created&direction=desc" \
+  --jq '.[] | {number,title,body,labels:[.labels[].name],assignees:[.assignees[].login],state,comments:.comments}' \
   > batch_${PAGE}_raw.json
 ```
 
@@ -208,7 +309,19 @@ gh api -H "Accept: application/vnd.github+json" \
 
 ### Step 2b: Classify This Batch
 
-Apply the Classification Algorithm from Core Rules. Companion script `scripts/classify.py` implements the keyword matching. Output: `batch_N_classified.json`.
+Apply the Classification Algorithm from Core Rules. Output `batch_N_classified.json` with:
+
+- `action`: `keep-needs-triage`, `promote-s-1`, `promote-s0`, `promote-s1`, `defer`, or `exclude`
+- `add_labels` and `remove_labels`: exact lifecycle/severity label delta. Include AI label deltas only in explicit `ai-assess`/`ai-final` mode.
+- `rationale`: one sentence explaining evidence and owner/impact reasoning
+- `deferred_comment`: required when `action == "defer"`
+
+Only when AI assessment is explicitly enabled, also output:
+
+- `ai_label`: `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual`, or `unknown`
+- `ai_label_stage`: `issue-initial`, `pr-review`, `user-assisted`, or `unknown`
+- `ai_confidence`: `low`, `medium`, or `high`
+- `ai_rationale`: one sentence explaining expected human vs AI effort
 
 **Skip checking**: filter out heni02 and Ariznawlll issues before classification.
 
@@ -226,21 +339,36 @@ Apply the Classification Algorithm from Core Rules. Companion script `scripts/cl
 | Range | #25260 → #24997 |
 | Total fetched | 50 |
 | Skipped (heni02/Ariznawlll) | 3 |
-| Classified | 47 |
+| Classified actions | 47 |
 
-## Severity Distribution
-| Severity | Count |
-|----------|-------|
-| s-1 | 0 |
-| s0 | 35 |
-| s1 | 10 |
-| s2 | 2 |
+## Action Distribution
+| Action | Count |
+|--------|-------|
+| keep-needs-triage | 18 |
+| promote-s-1 | 0 |
+| promote-s0 | 4 |
+| promote-s1 | 6 |
+| defer | 19 |
+| exclude | 0 |
+
+## AI Effort Distribution (only when explicitly requested)
+| Label | issue-initial | pr-review | user-assisted | unknown |
+|-------|---------------|-----------|---------------|---------|
+| ai-easy | 5 | 0 | 0 | 0 |
+| ai-light | 7 | 0 | 0 | 0 |
+| ai-medium | 16 | 0 | 0 | 0 |
+| ai-heavy | 8 | 0 | 0 | 0 |
+| ai-manual | 5 | 0 | 0 | 0 |
+| unknown | 6 | 0 | 0 | 6 |
 
 ## Issue Details
-| # | Title | Severity | Project | Milestone | Difficulty | Notes |
-|---|-------|----------|---------|-----------|------------|-------|
-| 25260 | ... | severity/s0 | MOEngine-Compute | MO-202607 | Hard | panic on INSERT |
+| # | Title | Action | Labels Delta | AI Effort | Project | Deferred Comment | Rationale |
+|---|-------|--------|--------------|-----------|---------|------------------|-----------|
+| 25260 | ... | promote-s0 | +severity/s0 -needs-triage | not requested | MOEngine-Compute | no | confirmed INSERT panic on common path |
+| 25261 | ... | defer | +deferred -needs-triage | not requested | MOEngine-Compute | yes | repro unstable; needs isolated testcase |
 ```
+
+When AI assessment is explicitly enabled, replace `AI Effort` with `ai-medium/issue-initial/medium` style values and include `ai_rationale`.
 
 Include `generated_at` timestamp + file checksum for drift detection.
 
@@ -252,20 +380,27 @@ Fetch current GitHub state for every issue in this batch → `batch_N_before_sna
 {
   "generated_at": "2026-07-01T10:23:45Z",
   "issues": [
-    {"number": 25260, "old_milestone": "MO-v1.1", "old_severity_labels": ["severity/s1"]}
+    {
+      "number": 25260,
+      "old_milestone": "MO-v1.1",
+      "old_labels": ["kind/bug", "needs-triage"],
+      "old_assignees": ["owner"],
+      "old_comments_count": 3
+    }
   ]
 }
 ```
 
 ### Step 2e: Dry-Run (5 issues)
 
-Update first 5 issues. Verify 2 of them:
+Update first 5 issues. Verify labels and deferred comments on 2 of them:
 
 ```bash
-gh issue view 25260 --json milestone,labels --jq '{milestone:.milestone.title,severity:[.labels[].name|select(startswith("severity/"))]}'
+gh issue view 25260 --json milestone,labels,comments \
+  --jq '{milestone:.milestone.title,labels:[.labels[].name],last_comment:(.comments[-1].body // "")}'
 ```
 
-**Mismatch → stop batch, investigate. Do not proceed.**
+**Mismatch, missing deferred comment, or stale AI label in explicit AI mode → stop batch, investigate. Do not proceed.**
 
 ### Step 2f: Full Batch Update + Progress
 
@@ -275,7 +410,7 @@ After update completes, mandatory progress display:
 ========================================
 BATCH 3 COMPLETE  ✅
 Progress: ████████████████░░░░ 57%  (4/7 batches)
-Running totals: s-1:1  s0:89  s1:48  s2:12
+Running totals: needs-triage:118  deferred:42  s-1:1  s0:17  s1:28
 Next: Batch 4 (#24510 → #24320)
 ========================================
 ```
@@ -283,69 +418,95 @@ Next: Batch 4 (#24510 → #24320)
 ### Rollback Procedure (batch fails mid-update)
 
 1. Read `batch_N_before_snapshot.json`
-2. Restore each already-updated issue's old milestone + severity labels
-3. **Never "fix forward"** — always rollback and restart batch from clean state
+2. Restore each already-updated issue's old milestone and labels exactly
+3. If the update log recorded newly-created deferred comment IDs, delete those comments; if deletion is not permitted, append a correction comment and stop
+4. **Never "fix forward"** — always rollback and restart batch from clean state
 
 ```bash
 # Restore old milestone
 gh api -X PATCH /repos/matrixorigin/matrixone/issues/$NUMBER -f milestone="$OLD_MILESTONE"
 
-# Restore old severity (remove new, add old)
-gh issue edit $NUMBER --remove-label "severity/s0" --add-label "$OLD_SEVERITY"
+# Restore labels: compute existing labels first, then remove labels not in snapshot and add labels from snapshot
+gh issue edit $NUMBER --remove-label "$LABELS_TO_REMOVE" --add-label "$LABELS_TO_ADD"
+
+# Delete a comment created by this failed batch when comment_id was logged
+gh api -X DELETE /repos/matrixorigin/matrixone/issues/comments/$COMMENT_ID
 ```
 
 ---
 
 ## Phase 3: FINAL VERIFY (Read-Only, ~10 min)
 
-### Step 3a: Domain Clustering Audit
+### Step 3a: Lifecycle Audit
 
-Automated: does any domain anomalously cluster in wrong tier?
+Automated checks:
 
-- **Alert** if >30% of s1 issues are non-downgrade domains
-- **Alert** if >10% of s0 issues are partition/streaming without panic/hung/OOM trigger
-- **Alert** if cold-feature issues appear in s0 without trigger
+- **Alert** if open `kind/bug` has none of `needs-triage`, `deferred`, `severity/s-1`, `severity/s0`, `severity/s1`
+- **Alert** if `severity/s0`/`severity/s1` issues lack owner/impact rationale in report
+- **Alert** if `deferred` issues created in this run lack a comment matching the Deferred Comment Template
+- **Alert** if partition/streaming/cold-feature issues remain active without confirmed trigger or owner commitment
+- **Alert** if `needs-triage` items are old enough to indicate the candidate pool is not being drained
+- **Alert** in explicit AI modes if an issue/PR has more than one AI effort label or an AI effort label without stage/confidence/rationale in the report
 
-### Step 3b: Severity Count Cross-Validation
+### Step 3b: Label Count Cross-Validation
 
-**Assert**: `count(severity/X in reports) == count(severity/X on GitHub)` for s-1, s0, s1, s2.
+**Assert**: report counts match GitHub for `needs-triage`, `deferred`, `severity/s-1`, `severity/s0`, and `severity/s1`. In explicit AI modes, also assert counts for `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, and `ai-manual`.
 
 Mismatch → drift → regenerate + re-update affected batches.
 
 ### Step 3c: Full Batch Spot-Check
 
-Scan ALL 50 issues in one complete batch report. 100% of one batch catches systematic patterns that random 5-issue sampling misses.
+Scan ALL 50 issues in one complete batch report. 100% of one batch catches systematic patterns that random 5-issue sampling misses: premature severity, missing comments, or owner gaps. In explicit AI modes, also check incorrect AI estimates.
 
 ### Step 3d: Sampled API Verify
 
 ```bash
 for num in $(shuf -e <all_numbers> | head -5); do
   gh issue view $num --json milestone,labels \
-    --jq '{milestone:.milestone.title,severity:[.labels[].name|select(startswith("severity/"))]}'
+    --jq '{milestone:.milestone.title,labels:[.labels[].name]}'
 done
 ```
 
-### Step 3e: Drift Detection
+### Step 3e: AI Effort Final Check (explicit AI modes only)
+
+Run this only when the user requests AI effort review or when existing AI labels are in scope. For PRs close to merge/close, compare issue and PR labels:
+
+- If AI handled the fix directly and human review was only a scan, ensure `ai-easy`.
+- If AI produced a useful draft but human tuned or made a bounded decision, ensure `ai-light`.
+- If human and AI iterated with shared effort, ensure `ai-medium`.
+- If AI only assisted and core logic stayed human-owned, ensure `ai-heavy`.
+- If AI provided little practical help, ensure `ai-manual`.
+- Remove the other four AI effort labels so only one remains.
+
+### Step 3f: Drift Detection
 
 Compare `generated_at` in report headers vs file mtime. If file was edited after generation (mtime > generated_at + 5min) → the file was manually tampered → re-run classifier, re-update GitHub.
 
-### Step 3f: Final Summary
+### Step 3g: Final Summary
 
 ```
 ========================================
 TRIAGE COMPLETE
 ========================================
 Total open kind/bug: NNN
-Classified:          NNN
+Actions applied:     NNN
 Skipped:              XX (heni02/Ariznawlll)
 
-Severity Distribution (on GitHub):
-  s-1:    N
-  s0:    NNN
-  s1:     NN
-  s2:     NN
+Lifecycle Distribution (on GitHub):
+  needs-triage: NNN
+  deferred:      NN
+  s-1:            N
+  s0:            NN
+  s1:            NN
 
-All updated: milestone=MO-202607, type=Bug
+AI Effort Distribution (only if explicit AI mode ran):
+  ai-easy:       NN
+  ai-light:      NN
+  ai-medium:     NN
+  ai-heavy:      NN
+  ai-manual:     NN
+
+All updated issues have explicit lifecycle state; deferred issues have comments; active severity issues have rationale. AI effort labels are unchanged unless explicit AI mode ran.
 ========================================
 ```
 
@@ -362,14 +523,25 @@ All updated: milestone=MO-202607, type=Bug
 
 300 issues × 2 calls = 600 requests. **Realistic: 15-20 min** with batch overhead.
 
-### Set Milestone + Severity
+### Set Lifecycle Labels + Milestone
 
 ```bash
 # Set milestone
 gh issue edit $NUMBER --milestone "MO-202607"
 
-# Replace severity label
-gh issue edit $NUMBER --add-label "severity/s0" --remove-label "severity/s1"
+# Intake normalization
+gh issue edit $NUMBER --add-label "kind/bug,needs-triage"
+
+# Promote to active severity: remove only labels that are actually present
+gh issue edit $NUMBER --add-label "severity/s0" --remove-label "needs-triage,deferred,severity/s-1,severity/s1"
+
+# Defer after analysis
+gh issue edit $NUMBER --add-label "deferred" --remove-label "needs-triage,severity/s0,severity/s1,severity/s-1"
+gh issue comment $NUMBER --body-file deferred_comment_${NUMBER}.md
+
+# Revise AI effort label on issue or PR: add one, remove the other four
+gh issue edit $NUMBER --add-label "ai-medium" --remove-label "ai-easy,ai-light,ai-heavy,ai-manual"
+gh pr edit $PR_NUMBER --add-label "ai-medium" --remove-label "ai-easy,ai-light,ai-heavy,ai-manual"
 ```
 
 > `gh issue edit` with `--add-label`/`--remove-label` is simpler than REST PATCH. Prefer it.
@@ -406,9 +578,9 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 | # | Pitfall | Symptom | Root Cause | Fix |
 |---|---------|---------|------------|-----|
 | 1 | **Page size mismatch** | 139 issues silently missed | per_page=50 vs 100 misalignment | Phase 1: query total_count first. Fallback 50→30 |
-| 2 | **Severity inflation** | 8 s-1 assigned, project has 4 | No calibration against existing usage | Phase 1.2: query distribution. Force conservative s-1 |
+| 2 | **Severity inflation** | New bugs jump straight to s0/s1 | Title keywords treated as priority commitment | G-INTAKE + G-PROMOTION: start with `needs-triage`, promote only after evidence |
 | 3 | **Whole-batch failure** | User changes rule → all 300+ redone | No rule lock-in before writes | Phase 1 gate: STANDARDS.md approval first |
-| 4 | **Severity drift** | Reports say s0, GitHub says s1 | Manual edits after generation | generated_at + checksum. Phase 3e drift detection |
+| 4 | **Severity drift** | Reports say s0, GitHub says s1 | Manual edits after generation | generated_at + checksum. Phase 3f drift detection |
 | 5 | **Half-updated batch** | 23/50 updated, 27 not | No rollback safety | Step 2d: before_snapshot. Rollback procedure |
 | 6 | **Rate limit blind spot** | Script hangs, user thinks stuck | No rate limit estimation | Progress display. 300 issues ≈ 15-20 min |
 | 7 | **Project writes fail** | Token missing `project` scope | Did not verify scope | Document requirement. Fallback: mark in report |
@@ -416,6 +588,10 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 | 9 | **Cross-batch duplicates** | Same issue in batch 3 and 5 | Pagination race during triage | Track seen numbers globally. Deduplicate |
 | 10 | **No progress visibility** | User cancels early | Silent between batches | Phase 2f: mandatory progress bar |
 | 11 | **Rule change w/o impact** | User says "降级" → 40 change | No blast radius preview | Show impact analysis before applying |
+| 12 | **Silent deferral** | Issue gets `deferred` but nobody knows why | Label changed without comment | G-DEFER-COMMENT: comment with reason and promote condition |
+| 13 | **Stale AI label** | PR closes as `ai-easy` after manual design/debug | Existing/requested AI estimate never revised | G-AI-FINAL during explicit AI review; final label should reflect actual human effort |
+| 14 | **Owner waits for drive-by triage** | Assigned issues/PRs stay stale | Responsibility not explicit | Ownership Rule: update own labels, comments, linked PRs, and closure state proactively |
+| 15 | **Candidate pool bypass** | Open bug has neither `needs-triage` nor active/deferred label | Intake normalization skipped | Phase 3a lifecycle audit |
 
 ---
 
@@ -424,12 +600,17 @@ curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
 Scripts accompanying this skill must:
 
 - [ ] Check `STANDARDS.md` `Approved: true` gate before any GitHub write
+- [ ] Normalize new `kind/bug` issues into `needs-triage` before assigning priority labels
+- [ ] Require promotion rationale before adding `severity/s-1`, `severity/s0`, or `severity/s1`
+- [ ] Require a deferred comment body before adding `deferred`
+- [ ] Leave `ai-*` untouched during normal `needs-triage`; only in explicit AI modes, track exactly one of `ai-easy`, `ai-light`, `ai-medium`, `ai-heavy`, `ai-manual` with stage/confidence/rationale
 - [ ] Accept `--dry-run` flag (default: first 5 issues per batch)
 - [ ] Save `batch_N_before_snapshot.json` before updating each batch
 - [ ] Print progress bar + running totals after each batch
 - [ ] Detect `generated_at` vs file mtime drift (warn, don't block)
-- [ ] Cross-validate severity counts (reports vs GitHub) in Phase 3
+- [ ] Cross-validate lifecycle label counts in Phase 3; cross-validate AI label counts only for explicit AI modes
 - [ ] Support `--rollback batch_N` to restore from snapshot
+- [ ] Log created comment IDs so rollback can delete or correct failed-batch comments
 - [ ] Log every API call to `triage_YYYYMMDD.log`
 
 ---
@@ -441,13 +622,14 @@ Scripts accompanying this skill must:
 3. **Show preview**, get user confirmation:
 
 ```
-⚠️  Rule change: "partition bugs → s1 instead of s0"
+⚠️  Rule change: "partition bugs without owner → deferred instead of s1"
     Affected batches: 1, 3, 5 (already processed)
     Issues to re-classify: 18
-    Severity changes: 13 (s0→s1) + 2 (s0 stays, has panic) + 3 (no change)
+    Action changes: 13 (promote-s1→defer) + 2 (promote-s0 stays, confirmed panic) + 3 (no change)
+    New comments required: 13
     Proceed? [y/N]
 ```
 
 4. **Re-classify affected batches** only, regenerate reports (new timestamps)
-5. **Re-update GitHub** for affected batches (snapshot → update → verify)
+5. **Re-update GitHub** for affected batches (snapshot → update labels/comments → verify)
 6. **Resume** from next unprocessed batch

--- a/.claude/skills/mo-dev/SKILL.md
+++ b/.claude/skills/mo-dev/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: mo-dev
 description: MatrixOne database kernel development - CGo build/test environment setup, GPU builds (MO_CL_CUDA=1 / cuVS), operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy, and the vector/fulltext index-plugin framework (pkg/indexplugin AlgoPlugin registry). Use when modifying colexec operators, process signal types, compile pipeline construction, adding or editing an index algorithm (HNSW/IVFFLAT/IVF-PQ/CAGRA/fulltext), or debugging CGo link errors (undefined symbols, missing headers, library not found).
-compatibility:
-  agents: Codex CLI and compatible agents
-  requires:
-    - Go 1.22+
-    - GNU Make
-    - C/C++ toolchain (gcc/clang)
-    - pre-built thirdparties
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone
@@ -15,594 +8,124 @@ metadata:
   cgo: true
 ---
 
+Compatibility: designed for Codex CLI and compatible agents. Requires Go 1.22+, GNU Make, C/C++ toolchain (gcc/clang), and pre-built thirdparties.
+
+## Resource Map
+
+Load only the reference needed for the task:
+
+| Need | Read |
+|------|------|
+| CGo link/header/runtime errors, layered testing, "pre-existing" test claims, GPU/cuVS/CUDA builds | [references/cgo-build-test.md](references/cgo-build-test.md) |
+| `colexec` operator edits, `process` signal types, pipeline spools, Call/Reset cleanup, hung tests | [references/operator-pipeline.md](references/operator-pipeline.md) |
+| Vector/fulltext index algorithm work, plugin registry, GPU-only algorithm registration, index-plugin review | [references/index-plugin.md](references/index-plugin.md) |
+
 ## Enforcement Gates
 
-This skill gates seven decision points. Consult the corresponding section before acting:
+Consult the referenced material before acting:
 
 | Gate | When | Action |
 |------|------|--------|
-| **G-MODIFY** | Before editing any `colexec` operator or `process` signal type | Read §3 (operator contract) + §7 (forbidden patterns) |
-| **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, or `dyld:`/`error while loading shared libraries:` | Read §2.2 (symptom table) + §2.4 (stash protocol) |
-| **G-GPU** | Before a GPU build/test (`MO_CL_CUDA=1`), or on CUDA/cuVS errors (`CONDA_PREFIX`, `nvcc`, `-lcuvs`/`-lcudart`, `unsupported index type: ivfpq\|cagra`) | Read §2.5 (GPU build) |
-| **G-IDXPLUGIN** | Before adding/editing an index-algorithm plugin, OR adding any `switch`/`if` that branches on an index **algo** name (`IsIvfIndexAlgo`, `== "ivfpq"`, `KeyType`, …) in `pkg/sql/{compile,plan}` or `pkg/catalog` | Read §8 (index-plugin framework) — route through the registry; new algo switches are forbidden |
-| **G-IDXREVIEW** | When **reviewing** a diff (yours or `/code-review`) that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/` / `pkg/fulltext/plugin`, or `pkg/indexplugin` | Read §9 (index-plugin review checklist) — run each grep before approving |
-| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.2 (completion gate) — all 5 boxes MUST be checked |
-| **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read §5 (diagnosis) + §2.4 (stash protocol) before attributing cause |
+| **G-MODIFY** | Before editing any `colexec` operator or `process` signal type | Read [operator-pipeline.md](references/operator-pipeline.md). |
+| **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, `dyld:`, or `error while loading shared libraries:` | Read [cgo-build-test.md](references/cgo-build-test.md) sections 2 and 4 before blaming code. |
+| **G-GPU** | Before a GPU build/test (`MO_CL_CUDA=1`), or on CUDA/cuVS errors (`CONDA_PREFIX`, `nvcc`, `-lcuvs`/`-lcudart`, `unsupported index type: ivfpq\|cagra`) | Read [cgo-build-test.md](references/cgo-build-test.md) section 5. |
+| **G-IDXPLUGIN** | Before adding/editing an index-algorithm plugin, OR adding any `switch`/`if` on an index **algo** name in `pkg/sql/{compile,plan}` or `pkg/catalog` | Read [index-plugin.md](references/index-plugin.md). Route through `pkg/indexplugin`; new algo switches are forbidden. |
+| **G-IDXREVIEW** | Reviewing a diff that touches index-algorithm dispatch, `pkg/vectorindex/<algo>/plugin/`, `pkg/fulltext/plugin`, or `pkg/indexplugin` | Read [index-plugin.md](references/index-plugin.md) section 9 and run its greps. |
+| **G-DONE** | Before declaring "done"/"complete"/"passes" | Apply the completion gate below. |
+| **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read [operator-pipeline.md](references/operator-pipeline.md) section 4 and [cgo-build-test.md](references/cgo-build-test.md) section 4 before attributing cause. |
 
----
-
-## 1. Project Structure
+## Project Structure
 
 ```
-pkg/sql/compile/       ← DAG compilation, operator instantiation, pipeline build, launch
-pkg/sql/colexec/       ← execution operators (connector/dispatch/merge/join/scan/...)
-pkg/vm/process/        ← execution context (Process), WaitRegister, signal channels
-pkg/vm/pipeline/       ← Pipeline lifecycle management
-pkg/container/         ← Batch/Vector/pSpool and other base data structures
-pkg/frontend/          ← MySQL protocol compatibility layer
-pkg/txn/               ← transaction management and MVCC
-pkg/sql/plan/          ← query plan construction
-cgo/                   ← CGo adapter layer (libmo.dylib / libmo.so)
+pkg/sql/compile/       <- DAG compilation, operator instantiation, pipeline build, launch
+pkg/sql/colexec/       <- execution operators (connector/dispatch/merge/join/scan/...)
+pkg/vm/process/        <- execution context (Process), WaitRegister, signal channels
+pkg/vm/pipeline/       <- Pipeline lifecycle management
+pkg/container/         <- Batch/Vector/pSpool and other base data structures
+pkg/frontend/          <- MySQL protocol compatibility layer
+pkg/txn/               <- transaction management and MVCC
+pkg/sql/plan/          <- query plan construction
+cgo/                   <- CGo adapter layer (libmo.dylib / libmo.so)
 ```
 
-**Operator file convention** under `pkg/sql/colexec/<op>/`:
-- `types.go` — Arg struct definition
-- `<op>.go` — main logic (Prepare/Call/Reset)
+Operator file convention under `pkg/sql/colexec/<op>/`:
+
+- `types.go`: Arg struct definition
+- `<op>.go`: main logic (`Prepare`/`Call`/`Reset`)
 - Optional `sendfunc.go`/`dispatch.go` helpers
 
-**Key dependency chain**: `compile` instantiates operators → `colexec` executes → `process` manages context and signals → `container` carries data.
+Key dependency chain: `compile` instantiates operators -> `colexec` executes -> `process` manages context and signals -> `container` carries data.
 
----
+## Quick Test Commands
 
-## 2. Build, Test, Verify
-
-### 2.1 Basic Commands
+For ordinary package checks:
 
 ```bash
-# Compile check
 go build ./pkg/target/...
-
-# Static analysis
 go vet ./pkg/target/...
-
-# Run tests (-count=1 disables cache)
-go test -v -count=1 ./pkg/target/...
-
-# Single test
+go test -v -count=1 -timeout 120s ./pkg/target/...
 go test -v -count=1 -run TestXxx ./pkg/target/...
-
-# Timeout control (integration tests can be slow)
-go test -v -count=1 -timeout 120s ./pkg/target/...
 ```
 
-### 2.2 CGo Environment (Three-Layer Variables)
+For CGo-transitive or CGo-direct packages, do not guess flags. Read [references/cgo-build-test.md](references/cgo-build-test.md).
 
-MO's CGo involves three independent layers: **compilation** (headers), **linking own lib** (`libmo`), and **third-party libs** (`libusearch_c`).
+Rule: "`go build` passes" does not mean "`go test` will pass." Test binaries link more CGo.
 
-```makefile
-# Makefile:203 — header paths for compilation
-CGO_OPTS := CGO_CFLAGS="-I$(CGO_DIR) -I$(THIRDPARTIES_INSTALL_DIR)/include"
+## Operator / Pipeline Rules
 
-# Makefile:204-207 — link libmo (rpath varies by OS)
-# Linux:   -Wl,-rpath,$$ORIGIN/lib
-# macOS:   -Wl,-rpath,@executable_path/lib
-GOLDFLAGS := -ldflags="-extldflags '-L$(CGO_DIR) -lmo -L$(THIRDPARTIES_INSTALL_DIR)/lib $(RPATH)'"
-```
+Read [references/operator-pipeline.md](references/operator-pipeline.md) before changing these paths.
 
-**Note**: Makefile does **not** set `CGO_LDFLAGS` — `libmo` link flags all go through `-ldflags` → `-extldflags`. However, the `usearch` Go module ships its own `#cgo LDFLAGS: -lusearch_c`, causing the linker to prefer system paths. `CGO_LDFLAGS` overrides this.
+- `Call()` processes one batch. It must not send terminal signals (`End`, `Error`, `Abort`).
+- `Reset()` performs cleanup and notifies downstream completion.
+- If explicit typed signals replaced implicit nil-batch end-of-stream, use `Abort()` instead of `CloseWithTimeout()`.
+- `CloseWithTimeout()` waits for nil batches; with typed signals it can wait for something that will never arrive.
+- When sending terminal signals into bounded channels, record terminal state even if the channel send fails.
 
-#### macOS vs Linux
+## Index-Plugin Rules
 
-| Aspect | macOS | Linux |
-|--------|-------|-------|
-| Dynamic library | `libmo.dylib` | `libmo.so` |
-| Runtime path env | `DYLD_LIBRARY_PATH` | `LD_LIBRARY_PATH` |
-| rpath flag | `-Wl,-rpath,@executable_path/lib` | `-Wl,-rpath,\$ORIGIN/lib` |
-| C header flags | `CGO_CFLAGS="-I{root}/cgo -I{root}/thirdparties/install/include"` | Same |
-| usearch link flags | `CGO_LDFLAGS="-L{root}/thirdparties/install/lib -lusearch_c"` | Same |
+Read [references/index-plugin.md](references/index-plugin.md) before touching vector/fulltext index algorithm dispatch.
 
-#### Full Test Commands
+- Work through `pkg/indexplugin.Get(algo)` and hook interfaces.
+- Do not add new per-algorithm `switch` / `if IsXxxIndexAlgo || ...` in SQL/catalog layers.
+- Do not import `pkg/sql/plan` or `pkg/sql/compile` from plugin packages.
+- Register CPU-safe plugins in `pkg/indexplugin/all/all.go`; register GPU-only plugins in `all_gpu.go`.
+- Keep `var _ AlgoPlugin` and `var _ Hooks` compile-time assertions intact.
+- Add CPU-runnable unit tests for plan/schema/runtime hooks; GPU-gated BVT alone can fail coverage gates.
 
-**macOS:**
-```bash
-CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
-CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
-DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
-go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
-  -v -count=1 -timeout 120s ./pkg/target/...
-```
+## Completion Gate
 
-**Linux:**
-```bash
-CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
-CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
-LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
-go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib'" \
-  -v -count=1 -timeout 120s ./pkg/target/...
-```
-
-#### Symptom → Root Cause
-
-| Symptom | Missing Variable | Root Cause |
-|---------|-----------------|------------|
-| `fatal error: 'xxhash.h' file not found` | `CGO_CFLAGS` | Compiler can't find thirdparties headers |
-| `Undefined symbols: _usearch_hardware_acceleration_*` (macOS) or `undefined symbol:` (Linux) | `CGO_LDFLAGS` | usearch module's `#cgo LDFLAGS` found old `libusearch_c` |
-| `ld: library 'mo' not found` (macOS) or `cannot find -lmo` (Linux) | `-ldflags="-extldflags '-L... -lmo'"` | Linker can't find `libmo` |
-| `dyld: Library not loaded: libmo.dylib` (macOS) or `error while loading shared libraries: libmo.so` (Linux) | `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Runtime can't find dynamic library |
-
-### 2.3 Layered Testing Strategy
-
-| Layer | Example Packages | CGo Behavior | Variables Needed |
-|-------|-----------------|-------------|-----------------|
-| **Pure Go** | `pkg/vm/process`, `pkg/container/pSpool`, `pkg/vm/pipeline` | Zero CGo in transitive closure | None |
-| **CGo-transitive** | `pkg/sql/colexec/connector`, `dispatch`, `merge` | Test binary links usearch Go module | `CGO_CFLAGS` + `CGO_LDFLAGS` |
-| **CGo-direct** | `pkg/sql/compile` | Test binary directly links `libmo` + `libusearch_c` | All four: CGO_CFLAGS + CGO_LDFLAGS + ldflags + DYLD/LD_LIBRARY_PATH |
-| **Integration** | `pkg/frontend`, cmd packages | Full MO binary, needs external services | All + services |
-
-**Copy-paste per layer:**
-
-Layer 1 (Pure Go):
-```bash
-go test -v -count=1 -timeout 120s ./pkg/vm/process/... ./pkg/container/pSpool/...
-```
-
-Layer 2 (CGo-transitive, macOS):
-```bash
-export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
-export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
-go test -v -count=1 -timeout 120s ./pkg/sql/colexec/connector/... ./pkg/sql/colexec/dispatch/...
-```
-
-Layer 3 (CGo-direct, macOS):
-```bash
-export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
-export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
-export DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib"
-go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
-  -v -count=1 -timeout 120s ./pkg/sql/compile/...
-```
-
-#### Variable → Purpose
-
-| Variable | What It Does | When Needed |
-|---------|-------------|-------------|
-| `CGO_CFLAGS` | Tells C compiler where to find headers | Package in transitive closure has CGo C code |
-| `CGO_LDFLAGS` | Overrides usearch module's own `#cgo LDFLAGS` path | usearch Go module is linked |
-| `-ldflags "-extldflags ..."` | Tells external linker where to find `libmo` + sets rpath | Package directly links `libmo` |
-| `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Tells OS runtime loader where to find `.dylib` / `.so` | Test binary loads `libmo` at runtime |
-
-**Why bottom-up matters**: Pure Go tests finish in seconds with zero env setup. If they fail, the problem is in your code — not CGo. Debug top-down wastes time chasing link errors when there's a real bug.
-
-#### 2.3.1 `go build` vs `go test` — Not Equivalent
-
-| Command | CGo Behavior |
-|---------|-------------|
-| `go build ./pkg/sql/colexec/connector/...` | May succeed without CGo flags (compiles package only, no test binary linking) |
-| `go test ./pkg/sql/colexec/connector/...` | Compiles AND links test binary — full CGo path fires |
-
-**Rule**: "`go build` passes" does not mean "`go test` will pass." Always verify with `go test`.
-
-### 2.4 Stash Protocol — Verify "Pre-existing" Claims
-
-**Hard rule**: Never claim a test failure is "pre-existing" without proving it.
-
-```bash
-# 1. Stash current changes
-git stash
-
-# 2. Run the same test from clean state
-go test -v -count=1 -timeout 120s ./pkg/target/...
-
-# 3. If it fails: genuinely pre-existing — document it
-# 4. If it passes: YOUR code caused it — investigate
-git stash pop
-```
-
-### 2.5 GPU Build (`MO_CL_CUDA=1`) — cuVS / CUDA
-
-GPU support compiles the CUDA-backed vector index algorithms (**CAGRA**, **IVF-PQ**) into `libmo` and turns on the `gpu` Go build tag. **Linux x86_64 only** — the macOS `Makefile` branch (`Makefile:234-236`) carries no CUDA flags, so **macOS builds are always CPU-only**. Do not try to enable it on Darwin.
-
-**Prerequisites (one-time):**
-1. CUDA toolkit 12.0 / 13.0+ installed under `/usr/local/cuda`.
-2. cuVS Go bindings installed via conda (`rapidsai/cuvs`), then the env **activated** so `CONDA_PREFIX` is exported:
-   ```bash
-   conda env create --name go -f conda/environments/go_cuda-130_arch-$(uname -m).yaml
-   conda activate go     # exports CONDA_PREFIX — every GPU build/test hard-errors without it
-   ```
-
-**Build:**
-```bash
-MO_CL_CUDA=1 make -j8
-```
-
-**What `MO_CL_CUDA=1` flips** (vs. the default CPU build):
-
-| Layer | CPU build | GPU build (`MO_CL_CUDA=1`) |
-|-------|-----------|----------------------------|
-| Go build tag | none | `-tags gpu` (`Makefile:224`) — registers CAGRA + IVF-PQ, compiles `*_gpu.go` |
-| `cgo/` compiler | `gcc`/`clang` | `/usr/local/cuda/bin/nvcc` (`cgo/Makefile:31`, multi-arch `sm_75…sm_90`) |
-| `libmo` objects | C objects only | + `cuda/*.o` + `cuvs/*.o` |
-| Link flags | `-lusearch_c -lroaring` | + `-lcuvs -lcuvs_c -lcudart -lcuda -lrmm -lstdc++` |
-| Header/lib roots | thirdparties only | + `$CONDA_PREFIX/{include,lib}`, `/usr/local/cuda/...` |
-
-**Guardrails baked into the Makefiles:**
-- **`CONDA_PREFIX env variable not found`** → conda env not activated. Run `conda activate <env>` first. Both `Makefile:217` and `cgo/Makefile:28` hard-error on this — it is *not* a code bug.
-- **`libmo` is re-linked on every GPU build** (`cgo/Makefile` order-only `cuda_objs`/`cuvs_objs` prereqs). Deliberate: `mo-service` loads `libmo.so` **dynamically**, so a stale `.so` silently runs old C++ (hours of "my fix didn't take"). The old `rm -f cgo/libmo.so cgo/libmo.a` workaround is no longer needed.
-
-**The `gpu` tag gates index-plugin registration — memorize this.** CAGRA and IVF-PQ register **only** under `//go:build gpu` (`pkg/indexplugin/all/all_gpu.go`). On a CPU binary their plugins are absent from the registry, so `CREATE INDEX … USING ivfpq|cagra` fails cleanly at plan-build with `unsupported index type: <algo>` — **before** any hidden table is created. This is intentional. Do **not** "fix" it by moving those imports into `all.go` (see §8.6).
-
-**Prerequisite — the linked `libmo` must itself be GPU-built:** run `MO_CL_CUDA=1 make -j8 cgo` first. A CPU `libmo` lacks the `cuda/`+`cuvs/` objects, so `gpu`-tagged Go (which cgo-includes `cgo/cuvs/*.h` via `pkg/cuvs`) fails to link with undefined `cuvs_*` / `cuda*` symbols — this is a *stale-library* error, not a flag error, so re-check §2.2 before chasing `CGO_LDFLAGS`.
-
-**GPU tests** — add `-tags gpu` plus the CUDA search paths (mirror the Makefile's `CUDA_CFLAGS`/`CUDA_LDFLAGS`, `Makefile:220-223`); Linux only:
-```bash
-CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include -I$CONDA_PREFIX/include -I/usr/local/cuda/include" \
-CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c -L$CONDA_PREFIX/lib -lcuvs -lcuvs_c" \
-LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$CONDA_PREFIX/lib:/usr/local/cuda/lib64" \
-go test -tags gpu \
-  -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib -fopenmp'" \
-  -v -count=1 -timeout 300s ./pkg/vectorindex/ivfpq/...
-```
-The **authoritative** flag source is the `Makefile` (`CUDA_CFLAGS`/`CUDA_LDFLAGS`), not this snippet — if a GPU link error appears, diff your flags against those lines.
-
-**Tag-split test files are a trap:** `*_gpu.go` / `//go:build gpu` tests (e.g. `pkg/vectorindex/ivfpq/search_test.go`, `model_test.go`) compile **only** under `-tags gpu`. A plain `go test ./pkg/vectorindex/ivfpq/...` runs the `//go:build !gpu` / `*_cpu.go` stubs instead. **"CPU tests pass" ≠ "GPU path tested."**
-
----
-
-## 3. Operator Lifecycle Contracts
-
-### 3.1 Call() vs Reset() — Hard Boundary
-
-| Method | Purpose | Must NOT Do |
-|--------|---------|-------------|
-| `Call()` | Process one batch. Receive from upstream, compute, send downstream. | Send terminal signals (End/Error/Abort). That's `Reset()`'s job. |
-| `Reset()` | Cleanup. Notify downstream the operator is done. | Block waiting for receiver acknowledgment. Use Abort(), not CloseWithTimeout(). |
-
-**This is the single most common source of subtle bugs.** Violating it causes: premature pipeline termination, spurious timeouts, dead receivers.
-
-### 3.2 PipelineSpool Lifecycle
-
-| Method | Behavior | Use When |
-|--------|---------|---------|
-| `Close()` | Wait for all consumers to acknowledge end of stream (consumes nil batches from spool) | Graceful completion path |
-| `CloseWithTimeout()` | Same as `Close()` but with timeout | Legacy cleanup — deprecated for typed signals |
-| `ForceCleanup()` / `Abort()` | Synchronous release of all un-consumed slots. No waiting. Idempotent (`sync.Once`). | Cleanup path with explicit terminal signals |
-
-**Critical rule**: If you replaced implicit nil-batch end-of-stream with explicit typed signals (EventEnd/EventError/EventAbort), use `Abort()` instead of `CloseWithTimeout()`. `CloseWithTimeout()` waits for nil batches that will never arrive.
-
-### 3.3 Pipeline Signal Types (Explicit Protocol)
-
-| Signal | Constructor | Meaning |
-|--------|------------|---------|
-| `EventData` | `NewDataSignal(batch)` | Normal data batch |
-| `EventEnd` | `NewEndSignal()` | Graceful end of stream |
-| `EventError` | `NewErrorSignal(err)` | Operator encountered an error |
-| `EventAbort` | `NewAbortSignal()` | Forceful termination |
-
-**Dual-protocol compatibility**: `GetNextBatch` handles both explicit typed signals AND legacy nil-batch convention (`content == nil`). Old operators using implicit nil-batch continue to work.
-
----
-
-## 4. Post-Modification Verification
-
-### 4.1 Test Freshness
-
-Test output must be **from the current turn**. Verify:
-1. `go test` command appears in current turn's bash calls
-2. Exit code 0 (not "it compiled" or "trust me")
-3. Timestamp is after the last `str_replace`/`write_file`
-
-### 4.2 Completion Gate (G-DONE)
-
-Before declaring any change "done", all 5 boxes must be checked:
+Before declaring any MatrixOne code change done, check all boxes:
 
 ```
-□ go build ./pkg/.../modified_package...    → exit 0
-□ go vet ./pkg/.../modified_package...      → exit 0
-□ go test -v -count=1 ./pkg/.../...         → exit 0, no hangs
-□ git diff --stat                            → inspected, no unintended files
+□ go build ./pkg/.../modified_package...    -> exit 0
+□ go vet ./pkg/.../modified_package...      -> exit 0
+□ go test -v -count=1 ./pkg/.../...         -> exit 0, no hangs
+□ git diff --stat                            -> inspected, no unintended files
 □ Regression: at least one test from dependent package passes
 ```
 
-**Hang = failure**: If `go test` produces >10s of no output → the test is hung, not "still running." Investigate.
+Hang = failure. If `go test` produces >10s of no output, investigate instead of calling it slow.
 
----
+Hard rule: never claim a failure is "pre-existing" without proving it from clean HEAD. Use the stash protocol in [references/cgo-build-test.md](references/cgo-build-test.md) section 4.
 
-## 5. Fault Diagnosis
+## Common Diagnosis Shortcuts
 
-| Symptom | Look At |
-|---------|---------|
-| Test hangs exactly 30s | `CloseWithTimeout` waiting for nil-batch that never arrives. Check if typed signals are being sent instead. |
-| Test hangs >5s, no output | Deadlock or blocking channel send. Check: is `done` channel closed? Is `sendSignal` using a non-blocking `select`? |
-| `context deadline exceeded` after 30s | `WaitingEndWithTimeout` timed out. Check: did all senders call `Reset()`? Did they send typed terminal signals? |
-| `CGO_CFLAGS` not working | Run `go env CGO_CFLAGS` to verify. Use `export` (not inline without export) if the package has sub-packages. |
+| Symptom | First Place To Look |
+|---------|---------------------|
+| Test hangs exactly 30s | `CloseWithTimeout` waiting for nil-batch that never arrives. Read [operator-pipeline.md](references/operator-pipeline.md). |
+| Test hangs >5s, no output | Deadlock or blocking channel send. Check `done` channel and non-blocking `select`. |
+| `context deadline exceeded` after 30s | Did all senders call `Reset()` and send typed terminal signals? |
+| `fatal error: 'xxhash.h' file not found` | `CGO_CFLAGS`; read [cgo-build-test.md](references/cgo-build-test.md). |
+| `Undefined symbols` / `undefined symbol:` | `CGO_LDFLAGS` and stale `libusearch_c`; read [cgo-build-test.md](references/cgo-build-test.md). |
+| `cannot find -lmo` / `ld: library 'mo' not found` | `-ldflags="-extldflags '-L... -lmo'"`; read [cgo-build-test.md](references/cgo-build-test.md). |
+| `unsupported index type: ivfpq|cagra` | CPU binary lacks GPU plugin registration; read [index-plugin.md](references/index-plugin.md) and GPU notes. |
 
----
+## Forbidden Patterns
 
-## 6. Common Pitfalls
-
-### 6.1 Structural Changes — Check Both Ends
-When changing the communication protocol between operators (connector ↔ merge, dispatch ↔ merge), both sender and receiver must be updated. A sender change without the corresponding receiver change causes deadlock.
-
-**Identification**: exact 30s timeout in cleanup → `CloseWithTimeout` + typed signal mismatch.
-
-### 6.2 CGo Link Errors — Verify the Third Party Build
-CGo link errors (`Undefined symbols`, `cannot find -lmo`) are environment issues, not code bugs. The C shared libraries (`libmo.dylib`, `libusearch_c.dylib`) must be pre-built via `make cgo` and `make thirdparties`.
-
-### 6.3 Pipeline Cleanup — Abort, Don't Wait
-During pipeline cleanup, operators should use non-blocking or timeout-gated communication. Never block waiting for a receiver that may have already exited.
-
-### 6.4 Channel Full Edge Cases
-When sending terminal signals into a bounded channel, the send may fail because the channel is full. Ensure the terminal state is still recorded even when the channel send fails — the `done` channel must close regardless of delivery success.
-
----
-
-## 7. Forbidden Patterns
-
-1. **Never send terminal signals (End/Error/Abort) from `Call()`.** Only `Reset()` sends terminal signals.
-2. **Never call `sp.CloseWithTimeout()` after switching to explicit typed terminal signals.** Use `sp.Abort()`.
-3. **Never claim "pre-existing" without `git stash` proof.** Run the test on clean HEAD first.
-4. **Never declare done without fresh test output.** All 5 completion gate boxes must be checked.
-5. **Never assume `go build` success means `go test` will pass.** Build only compiles packages; test compiles AND links test binaries.
-6. **Never skip bottom-up testing.** Start with pure Go packages, then CGo-transitive, then CGo-direct.
-7. **Never add a per-algorithm `switch`/`if` on an index algo name in the SQL layer.** Route through `indexplugin.Get(algo)` — see §8.
-
----
-
-## 8. Vector / Fulltext Index-Plugin Framework
-
-### 8.1 Why this exists (and what NOT to undo)
-
-Adding a vector index used to mean editing 8+ files across `pkg/sql/compile`,
-`pkg/sql/plan`, `pkg/catalog`, and `pkg/vectorindex`, wired through ~6
-switch/if-chain seams. Miss one seam → the algorithm silently misbehaves. The
-`pkg/indexplugin` framework collapses those seams into **one registry lookup**:
-an algorithm registers **one** `AlgoPlugin`, and the compiler enforces every
-required hook exists.
-
-**The guarded failure mode:** a change that re-introduces a per-algorithm
-`switch algo` / `if IsXxxIndexAlgo || …` in the SQL layer, or otherwise bypasses
-the registry, quietly re-opens the "forgot a seam" bug class. Work **through**
-the framework — do not route around it.
-
-### 8.2 Architecture
-
-`pkg/indexplugin` is the framework. It must **not** import `pkg/sql/{compile,plan}`;
-hook methods receive narrow `Context` interfaces the SQL layer satisfies.
-
-```
-pkg/indexplugin/
-├── plugin.go          -- AlgoPlugin interface; Register/Get/All; IsVectorIndexAlgo/IsFullTextIndexAlgo/IsPluginAlgo
-├── catalog/hooks.go   -- catalog.Hooks   (metadata: params, hidden tables, op/vector/pk types, quantization)
-├── compile/hooks.go   -- compile.Hooks   (DDL execution: create/reindex/drop/restore) + CompileContext
-├── plan/hooks.go      -- plan.Hooks      (schema defs + tablefunc + thin ANN redirects) + PlanBuilder/CompilerContext
-├── idxcron/hooks.go   -- idxcron.Hooks   (scheduled-rebuild gating: Updatable)
-└── all/
-    ├── all.go         -- blank-imports CPU-safe plugins (fulltext, hnsw, ivfflat)
-    └── all_gpu.go     -- //go:build gpu — blank-imports GPU-only plugins (cagra, ivfpq)
-
-pkg/vectorindex/<algo>/plugin/   -- one dir per algorithm; assembles the hooks into an AlgoPlugin
-pkg/fulltext/plugin/             -- fulltext is a plugin too (kind = fulltext, not vector)
-```
-
-**Dispatch flow** — every SQL-layer site that used to `switch algo` now does:
-
-```go
-p, ok := indexplugin.Get(algo)      // case-insensitive, trims whitespace
-if ok { return p.Compile().HandleCreateIndex(cctx, defs) }
-```
-
-`indexplugin.IsVectorIndexAlgo(algo)` replaces the
-`IsIvfIndexAlgo || IsHnswIndexAlgo || IsCagraIndexAlgo || IsIvfpqIndexAlgo`
-chain. Use `IsFullTextIndexAlgo` for fulltext, `IsPluginAlgo` for "registered at
-all (vector OR fulltext)". Live dispatch sites already exist in
-`pkg/sql/plan/build_ddl.go` (`indexplugin.Get(...KeyType.ToString())` →
-`unsupported index type: %s`) and `pkg/sql/plan/apply_indices.go`
-(`p.Plan().CanApply`).
-
-### 8.3 Registry contract — the compiler is the safety net
-
-```go
-// pkg/indexplugin/plugin.go
-type AlgoPlugin interface {
-    Algo() string                       // must == catalog.MoIndex<X>Algo.ToString() (lower-cased)
-    Catalog() catalogplugin.Hooks
-    Compile() compileplugin.Hooks
-    Plan()    planplugin.Hooks
-    Idxcron() idxcronplugin.Hooks
-}
-func Register(p AlgoPlugin)              // panics on duplicate Algo(); call from init()
-func Get(algo string) (AlgoPlugin, bool)
-```
-
-Each plugin keeps compile-time interface assertions:
-
-```go
-var _ plugin.AlgoPlugin = (*Plugin)(nil)   // in <algo>/plugin/plugin.go
-var _ Hooks = Hooks{}                        // in each hooks sub-package impl
-```
-
-If `AlgoPlugin` or a `Hooks` interface gains a method and a plugin isn't updated,
-these lines **stop the build**. That compile error *is* the "did I miss a seam?"
-answer. **Never delete or `//nolint` these assertions to green a build** —
-implement the missing method.
-
-### 8.4 Plugin package layout (canonical: IVF-PQ)
-
-`pkg/vectorindex/ivfpq/plugin/plugin.go` is the **authoritative walkthrough** —
-read its package doc before adding an algorithm. A full plugin (see
-`pkg/vectorindex/ivfflat/plugin/`) is:
-
-```
-pkg/vectorindex/<algo>/plugin/
-├── plugin.go            -- assembles the 4 Hooks into one Plugin; init() { plugin.Register(New()) }
-├── runtime/runtime.go   -- catalog.Hooks impl  (algorithm metadata constants)
-├── compile/compile.go   -- compile.Hooks impl  (CREATE/ALTER/DROP/REINDEX execution)
-├── plan/
-│   ├── plan.go          -- plan.Hooks: thin ApplyForSort/CanApply redirect (~10 LoC) into *plan.QueryBuilder
-│   ├── schema.go        -- BuildSecondaryIndexDefs body (hidden-table TableDefs + IndexDefs)
-│   └── tablefunc.go     -- <algo>_create / <algo>_search FUNCTION_SCAN builder registrations
-├── idxcron/idxcron.go   -- idxcron.Hooks impl  (Updatable: scheduled-rebuild gating)
-└── iscp/iscp.go         -- CDC / import sync (may be //go:build gpu for GPU algos)
-```
-
-**Which sub-package gets lifted code:** from `pkg/sql/compile/*.go` → `compile/`;
-from `pkg/sql/plan/*.go` → `plan/`; algorithm-metadata constants → `runtime/`
-(lifted code goes in the sub-package matching `pkg/sql/<layer>` of the call site).
-
-### 8.5 Adding a new algorithm — steps
-
-Follow `pkg/vectorindex/ivfpq/plugin/plugin.go`'s doc. Summary:
-
-1. **Catalog constants.** Add `MoIndex<X>Algo` in
-   `pkg/catalog/secondary_index_utils.go`; hidden-table-type constants in
-   `pkg/catalog/types.go` (one per hidden table). A `tree.INDEX_TYPE_<X>` parser
-   keyword only if it needs new CREATE INDEX syntax.
-2. **Copy** `pkg/vectorindex/ivfpq/plugin/` → `pkg/vectorindex/<x>/plugin/`;
-   rename packages/imports.
-3. **Implement the four Hooks** (let the `var _ Hooks = …` assertions tell you
-   what's missing):
-   - `catalog.Hooks` — `HiddenTableTypes`, `ParamsFromTree`, `DefaultOptions`,
-     `SupportedOpTypes`, `SupportedVectorTypes`, `SupportedPrimaryKeyTypes`,
-     `SupportedIncludeColumnTypes`, `ValidQuantization`, `ExperimentalFlag`,
-     `AlterTableCloneBehavior`, `RestoreBehavior`, `BuildSessionVars`,
-     `ShouldTruncateHiddenTable`, `SyncDescriptor`.
-   - `compile.Hooks` — `HandleCreateIndex`, `HandleReindex`,
-     `ValidateReindexParams`, `HandleDropIndex`, `RestoreInitSQL`,
-     `IdxcronMetadata`.
-   - `plan.Hooks` — `BuildSecondaryIndexDefs`, `BuildFullTextIndexDefs`,
-     `CanApply`, `ApplyForSort`.
-   - `idxcron.Hooks` — `Updatable` (return "always yes" if the algo has no
-     minimum-size / cadence constraint).
-4. **ANN rewrite body** (only if the algo supports `ORDER BY <distfn>(col,v)
-   LIMIT k`): add `applyIndicesForSortUsing<X>` + `prepare<X>IndexContext` in
-   `pkg/sql/plan/apply_indices_<x>.go`, redirect methods on `*QueryBuilder` in
-   `pkg/sql/plan/plugin_builder.go`, and the dispatch case in
-   `pkg/sql/plan/apply_indices.go` (which calls `p.Plan().CanApply`).
-5. **Register:** `init()` in `plugin.go` calls `plugin.Register(New())`. Add
-   **one** blank-import line to `pkg/indexplugin/all/all.go` — **or**
-   `all_gpu.go` if GPU-only (§8.6). That aggregator is the *only* wiring edit;
-   `pkg/sql/plan` and `pkg/sql/compile` already blank-import `.../all`.
-6. **SQL test** under `test/distributed/cases/vector/` exercising CREATE INDEX,
-   `ORDER BY <distfn>(col,v) LIMIT k`, ALTER REINDEX, DROP INDEX, DROP TABLE.
-
-> If the plugin compiles and every hook is implemented, you did **not** miss a
-> dispatch site. Do not add manual dispatch "to be safe."
-
-### 8.6 CPU vs GPU registration (ties to §2.5)
-
-| File | Build tag | Registers | Rationale |
-|------|-----------|-----------|-----------|
-| `pkg/indexplugin/all/all.go` | (none) | fulltext, hnsw, ivfflat | CPU-safe algorithms |
-| `pkg/indexplugin/all/all_gpu.go` | `//go:build gpu` | cagra, ivfpq | CUDA-backed table functions exist only under `gpu` |
-
-CAGRA / IVF-PQ have `cagra_create` / `ivfpq_create` table functions implemented
-**only** under `//go:build gpu`. Registering them on a CPU binary would let
-`CREATE INDEX … USING cagra|ivfpq` proceed until the BUILD SQL fails mid-flight —
-after hidden tables are created and DELETEs run. Gating registration behind the
-`gpu` tag makes plan-build return `unsupported index type: <algo>` **before any
-DDL side effect**. The `gpu` tag is enabled by `MO_CL_CUDA=1 make` (§2.5).
-
-**Pairing rule:** an algo with `build_gpu.go` (`//go:build gpu`) must have a
-`//go:build !gpu` CPU counterpart (`*_cpu.go` stub) so the package still compiles
-on CPU, *and* its plugin blank-import belongs in `all_gpu.go`, never `all.go`.
-
-### 8.7 Forbidden patterns (index-plugin)
-
-1. **Never re-introduce per-algorithm dispatch in the SQL layer.** A new
-   `switch idx.IndexAlgo`, `if catalog.IsIvfIndexAlgo(a) || …`, or `case
-   MoIndex<X>Algo:` in `pkg/sql/{compile,plan}` / `pkg/catalog` re-opens the bug
-   class the framework closed. Need a new per-algo decision? Add a **method to
-   the relevant `Hooks` interface** (compiler forces every algo to answer) — not
-   a switch.
-2. **Never import `pkg/sql/plan` or `pkg/sql/compile` from a plugin package.**
-   Those packages blank-import the plugins for `init()` registration → an import
-   cycle. Plugins receive `compile.CompileContext` / `plan.PlanBuilder` /
-   `plan.CompilerContext` and call *through* them. `plan/` bodies that need
-   `*QueryBuilder` internals live in `pkg/sql/plan/apply_indices_<x>.go`, reached
-   via the thin redirect (§8.5 step 4).
-3. **Never register a GPU-only algo in `all.go`** — use `all_gpu.go` (§8.6).
-4. **Never weaken the `var _ AlgoPlugin` / `var _ Hooks` assertions** to green a
-   build. Implement the missing method.
-5. **Keep runtime out of the plugin.** The plugin owns compile + plan + catalog +
-   idxcron metadata only. Real build/search kernels stay in
-   `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`, invoked from
-   `pkg/sql/colexec/table_function/<algo>_*.go`. Do not copy kernel logic in.
-6. **Never pollute `pkg/indexplugin` with algorithm-specific code — it is
-   interfaces + metadata only.** The framework package holds only the interfaces
-   (`AlgoPlugin`, the `Hooks` + `Context` interfaces), the registry, and
-   *algorithm-agnostic* shared helpers/metadata (e.g. `AlgoParamInt`,
-   `IdxcronVarSpec` / `BuildIdxcronMetadata` — generic, zero algo branching).
-   Every concrete hook body and per-algo constant lives in
-   `pkg/vectorindex/<algo>/plugin/` (or `pkg/fulltext/plugin/`). Do **not** add a
-   `switch algo` / `if IsXxxIndexAlgo`, a concrete `Hooks` implementation, or any
-   algorithm-named symbol under `pkg/indexplugin/*`. The *only* files there that
-   may name a concrete algorithm are the `all/` and `iscp/` aggregators — and
-   only as blank imports.
-
-### 8.8 Testing & completion (index-plugin)
-
-Index-plugin changes have a **coverage trap**: the end-to-end BVT cases under
-`test/distributed/cases/vector/` are GPU-gated (skipped in non-GPU CI), so
-`plan.go` / `schema.go` read **0% coverage** and fail the 0.75 gate unless you
-add CPU-runnable unit tests (tablefunc_test / runtime_test style — see
-`pkg/vectorindex/ivfflat/plugin/{runtime,idxcron}/*_test.go`). On top of the §4.2
-completion gate:
-
-```
-□ CPU unit tests exist for plan/schema/runtime hooks (not just GPU-gated BVT)  → run, exit 0
-□ GPU-only hooks also run with `-tags gpu` per §2.5                            → exit 0
-□ grep: NO new `switch algo` / `IsXxxIndexAlgo ||` added in pkg/sql/*
-□ git diff --stat: the ONLY all.go/all_gpu.go edit is one blank import
-```
-
-**Known in-progress seams — do not add NEW ones.** A few DML-sync sites still
-call `catalog.IsIvfIndexAlgo` directly (`pkg/sql/plan/build_dml_util.go`,
-`pkg/sql/plan/bind_insert.go`) — the IVFFLAT-hardcoded resolution is mid-migration
-into `plan.Hooks`. These are **legacy**, not a license to add more. When you
-touch one, prefer moving it behind a hook; never model a *new* algorithm on them.
-
----
-
-## 9. Reviewing an index-plugin change (G-IDXREVIEW)
-
-Apply this when reviewing a diff — your own before "done", or via `/code-review`
-— that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/`,
-`pkg/fulltext/plugin`, or `pkg/indexplugin`. Each item maps to a §8.7 forbidden
-pattern; the grep is the fast check. **Request changes if any check fails**, and
-cite the §8.7 rule number in the finding.
-
-1. **No new per-algo dispatch** (§8.7 #1). The diff adds no `switch …IndexAlgo`,
-   `case MoIndex<X>Algo:`, or `IsIvfIndexAlgo || …` in `pkg/sql/{compile,plan}` /
-   `pkg/catalog`. Legacy holdouts (`build_dml_util.go`, `bind_insert.go`) may
-   remain — but **no new ones**.
-   ```bash
-   git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
-     | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
-   ```
-2. **No import cycle** (§8.7 #2). No plugin sub-package imports `pkg/sql/plan` or
-   `pkg/sql/compile`.
-   ```bash
-   git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
-     | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'   # expect empty
-   ```
-3. **`indexplugin` not polluted** (§8.7 #6). No file under `pkg/indexplugin/`
-   (except `all/`, `iscp/`) imports a concrete algo package or gains
-   algorithm-named / `switch algo` code.
-   ```bash
-   git diff pkg/indexplugin \
-     | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'  # only all*.go / iscp allowed
-   ```
-4. **GPU registration correct** (§8.6, §8.7 #3). A GPU-only algo's blank import is
-   in `all_gpu.go` (`//go:build gpu`), not `all.go`; each `build_gpu.go` has a
-   `//go:build !gpu` CPU counterpart.
-5. **Assertions intact** (§8.7 #4). The diff does not delete / comment /
-   `//nolint` any `var _ AlgoPlugin` or `var _ Hooks` line.
-   ```bash
-   git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'   # expect empty
-   ```
-6. **Runtime kept out** (§8.7 #5). No build/search kernel logic copied into the
-   plugin; it still calls `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`.
-7. **New-algo completeness** (§8.5, §8.8). If a new algorithm: blank-imported in
-   `all/` or `all_gpu/`, has an SQL case under `test/distributed/cases/vector/`,
-   and CPU unit tests cover the plan/schema/runtime hooks (not just GPU-gated
-   BVT).
+1. Never send terminal signals (`End`, `Error`, `Abort`) from `Call()`.
+2. Never call `sp.CloseWithTimeout()` after switching to explicit typed terminal signals.
+3. Never claim "pre-existing" without `git stash` proof.
+4. Never declare done without fresh test output.
+5. Never assume `go build` success means `go test` will pass.
+6. Never skip bottom-up testing: pure Go -> CGo-transitive -> CGo-direct.
+7. Never add a per-algorithm `switch`/`if` on an index algo name in the SQL layer. Route through `indexplugin.Get(algo)`.

--- a/.claude/skills/mo-dev/references/cgo-build-test.md
+++ b/.claude/skills/mo-dev/references/cgo-build-test.md
@@ -1,0 +1,210 @@
+# CGo, Build, Test, And GPU Reference
+
+## Contents
+
+- [1. Basic Commands](#1-basic-commands)
+- [2. CGo Environment (Three-Layer Variables)](#2-cgo-environment-three-layer-variables)
+- [3. Layered Testing Strategy](#3-layered-testing-strategy)
+- [4. Stash Protocol For "Pre-existing" Claims](#4-stash-protocol-for-pre-existing-claims)
+- [5. GPU Build (`MO_CL_CUDA=1`) -- cuVS / CUDA](#5-gpu-build-mo_cl_cuda1----cuvs--cuda)
+
+## 1. Basic Commands
+
+```bash
+# Compile check
+go build ./pkg/target/...
+
+# Static analysis
+go vet ./pkg/target/...
+
+# Run tests (-count=1 disables cache)
+go test -v -count=1 ./pkg/target/...
+
+# Single test
+go test -v -count=1 -run TestXxx ./pkg/target/...
+
+# Timeout control (integration tests can be slow)
+go test -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+## 2. CGo Environment (Three-Layer Variables)
+
+MO's CGo involves three independent layers: **compilation** (headers), **linking own lib** (`libmo`), and **third-party libs** (`libusearch_c`).
+
+```makefile
+# Makefile:203 -- header paths for compilation
+CGO_OPTS := CGO_CFLAGS="-I$(CGO_DIR) -I$(THIRDPARTIES_INSTALL_DIR)/include"
+
+# Makefile:204-207 -- link libmo (rpath varies by OS)
+# Linux:   -Wl,-rpath,$$ORIGIN/lib
+# macOS:   -Wl,-rpath,@executable_path/lib
+GOLDFLAGS := -ldflags="-extldflags '-L$(CGO_DIR) -lmo -L$(THIRDPARTIES_INSTALL_DIR)/lib $(RPATH)'"
+```
+
+Note: Makefile does **not** set `CGO_LDFLAGS`; `libmo` link flags all go through `-ldflags` -> `-extldflags`. The `usearch` Go module ships its own `#cgo LDFLAGS: -lusearch_c`, so `CGO_LDFLAGS` is needed to force the intended thirdparty path.
+
+### macOS vs Linux
+
+| Aspect | macOS | Linux |
+|--------|-------|-------|
+| Dynamic library | `libmo.dylib` | `libmo.so` |
+| Runtime path env | `DYLD_LIBRARY_PATH` | `LD_LIBRARY_PATH` |
+| rpath flag | `-Wl,-rpath,@executable_path/lib` | `-Wl,-rpath,\$ORIGIN/lib` |
+| C header flags | `CGO_CFLAGS="-I{root}/cgo -I{root}/thirdparties/install/include"` | Same |
+| usearch link flags | `CGO_LDFLAGS="-L{root}/thirdparties/install/lib -lusearch_c"` | Same |
+
+### Full Test Commands
+
+macOS:
+
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+Linux:
+
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+### Symptom -> Root Cause
+
+| Symptom | Missing Variable | Root Cause |
+|---------|-----------------|------------|
+| `fatal error: 'xxhash.h' file not found` | `CGO_CFLAGS` | Compiler cannot find thirdparties headers |
+| `Undefined symbols: _usearch_hardware_acceleration_*` (macOS) or `undefined symbol:` (Linux) | `CGO_LDFLAGS` | usearch module's `#cgo LDFLAGS` found old `libusearch_c` |
+| `ld: library 'mo' not found` (macOS) or `cannot find -lmo` (Linux) | `-ldflags="-extldflags '-L... -lmo'"` | Linker cannot find `libmo` |
+| `dyld: Library not loaded: libmo.dylib` (macOS) or `error while loading shared libraries: libmo.so` (Linux) | `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Runtime cannot find dynamic library |
+
+## 3. Layered Testing Strategy
+
+| Layer | Example Packages | CGo Behavior | Variables Needed |
+|-------|------------------|--------------|------------------|
+| **Pure Go** | `pkg/vm/process`, `pkg/container/pSpool`, `pkg/vm/pipeline` | Zero CGo in transitive closure | None |
+| **CGo-transitive** | `pkg/sql/colexec/connector`, `dispatch`, `merge` | Test binary links usearch Go module | `CGO_CFLAGS` + `CGO_LDFLAGS` |
+| **CGo-direct** | `pkg/sql/compile` | Test binary directly links `libmo` + `libusearch_c` | All four: CGO_CFLAGS + CGO_LDFLAGS + ldflags + DYLD/LD_LIBRARY_PATH |
+| **Integration** | `pkg/frontend`, cmd packages | Full MO binary, needs external services | All + services |
+
+Layer 1, pure Go:
+
+```bash
+go test -v -count=1 -timeout 120s ./pkg/vm/process/... ./pkg/container/pSpool/...
+```
+
+Layer 2, CGo-transitive on macOS:
+
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+go test -v -count=1 -timeout 120s ./pkg/sql/colexec/connector/... ./pkg/sql/colexec/dispatch/...
+```
+
+Layer 3, CGo-direct on macOS:
+
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+export DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib"
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/sql/compile/...
+```
+
+| Variable | What It Does | When Needed |
+|----------|--------------|-------------|
+| `CGO_CFLAGS` | Tells C compiler where to find headers | Package in transitive closure has CGo C code |
+| `CGO_LDFLAGS` | Overrides usearch module's own `#cgo LDFLAGS` path | usearch Go module is linked |
+| `-ldflags "-extldflags ..."` | Tells external linker where to find `libmo` + sets rpath | Package directly links `libmo` |
+| `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Tells OS runtime loader where to find `.dylib` / `.so` | Test binary loads `libmo` at runtime |
+
+Bottom-up testing matters: pure Go tests finish in seconds with zero env setup. If they fail, the problem is in code, not CGo.
+
+### `go build` vs `go test` Is Not Equivalent
+
+| Command | CGo Behavior |
+|---------|--------------|
+| `go build ./pkg/sql/colexec/connector/...` | May succeed without CGo flags because it compiles package code only |
+| `go test ./pkg/sql/colexec/connector/...` | Compiles and links a test binary; full CGo path fires |
+
+Always verify with `go test`.
+
+## 4. Stash Protocol For "Pre-existing" Claims
+
+Never claim a test failure is pre-existing without proof.
+
+```bash
+# 1. Stash current changes
+git stash
+
+# 2. Run the same test from clean state
+go test -v -count=1 -timeout 120s ./pkg/target/...
+
+# 3. If it fails: genuinely pre-existing -- document it
+# 4. If it passes: YOUR code caused it -- investigate
+git stash pop
+```
+
+## 5. GPU Build (`MO_CL_CUDA=1`) -- cuVS / CUDA
+
+GPU support compiles the CUDA-backed vector index algorithms (**CAGRA**, **IVF-PQ**) into `libmo` and turns on the `gpu` Go build tag. Linux x86_64 only. The macOS Makefile branch carries no CUDA flags, so macOS builds are CPU-only. Do not try to enable it on Darwin.
+
+Prerequisites:
+
+1. CUDA toolkit 12.0 / 13.0+ installed under `/usr/local/cuda`.
+2. cuVS Go bindings installed via conda and the env activated so `CONDA_PREFIX` is exported:
+
+```bash
+conda env create --name go -f conda/environments/go_cuda-130_arch-$(uname -m).yaml
+conda activate go
+```
+
+Build:
+
+```bash
+MO_CL_CUDA=1 make -j8
+```
+
+What `MO_CL_CUDA=1` flips:
+
+| Layer | CPU build | GPU build (`MO_CL_CUDA=1`) |
+|-------|-----------|----------------------------|
+| Go build tag | none | `-tags gpu` -- registers CAGRA + IVF-PQ, compiles `*_gpu.go` |
+| `cgo/` compiler | `gcc`/`clang` | `/usr/local/cuda/bin/nvcc` |
+| `libmo` objects | C objects only | + `cuda/*.o` + `cuvs/*.o` |
+| Link flags | `-lusearch_c -lroaring` | + `-lcuvs -lcuvs_c -lcudart -lcuda -lrmm -lstdc++` |
+| Header/lib roots | thirdparties only | + `$CONDA_PREFIX/{include,lib}`, `/usr/local/cuda/...` |
+
+Guardrails:
+
+- `CONDA_PREFIX env variable not found`: conda env not activated. Run `conda activate <env>` first. This is not a code bug.
+- `libmo` is re-linked on every GPU build deliberately because `mo-service` loads `libmo.so` dynamically. A stale `.so` silently runs old C++.
+
+The `gpu` tag gates index-plugin registration. CAGRA and IVF-PQ register only under `//go:build gpu` (`pkg/indexplugin/all/all_gpu.go`). On a CPU binary their plugins are absent from the registry, so `CREATE INDEX ... USING ivfpq|cagra` fails cleanly at plan-build with `unsupported index type: <algo>` before hidden table creation. Do not move those imports into `all.go`.
+
+The linked `libmo` must itself be GPU-built:
+
+```bash
+MO_CL_CUDA=1 make -j8 cgo
+```
+
+GPU tests need `-tags gpu` plus CUDA search paths. Linux only:
+
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include -I$CONDA_PREFIX/include -I/usr/local/cuda/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c -L$CONDA_PREFIX/lib -lcuvs -lcuvs_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$CONDA_PREFIX/lib:/usr/local/cuda/lib64" \
+go test -tags gpu \
+  -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib -fopenmp'" \
+  -v -count=1 -timeout 300s ./pkg/vectorindex/ivfpq/...
+```
+
+The authoritative flag source is the Makefile (`CUDA_CFLAGS` / `CUDA_LDFLAGS`), not this snippet. If a GPU link error appears, diff your flags against those lines.
+
+Tag-split test files are a trap: `*_gpu.go` / `//go:build gpu` tests compile only under `-tags gpu`. A plain `go test ./pkg/vectorindex/ivfpq/...` runs `//go:build !gpu` / `*_cpu.go` stubs instead. CPU tests passing does not test the GPU path.

--- a/.claude/skills/mo-dev/references/index-plugin.md
+++ b/.claude/skills/mo-dev/references/index-plugin.md
@@ -1,0 +1,194 @@
+# Vector / Fulltext Index-Plugin Reference
+
+## Contents
+
+- [1. Why The Framework Exists](#1-why-the-framework-exists)
+- [2. Architecture](#2-architecture)
+- [3. Registry Contract](#3-registry-contract)
+- [4. Plugin Package Layout](#4-plugin-package-layout)
+- [5. Adding A New Algorithm](#5-adding-a-new-algorithm)
+- [6. CPU vs GPU Registration](#6-cpu-vs-gpu-registration)
+- [7. Forbidden Patterns](#7-forbidden-patterns)
+- [8. Testing And Completion](#8-testing-and-completion)
+- [9. Reviewing An Index-Plugin Change](#9-reviewing-an-index-plugin-change)
+
+## 1. Why The Framework Exists
+
+Adding a vector index used to mean editing many files across `pkg/sql/compile`, `pkg/sql/plan`, `pkg/catalog`, and `pkg/vectorindex`, wired through repeated switch/if chains. Miss one site and the algorithm silently misbehaves.
+
+`pkg/indexplugin` collapses those sites into one registry lookup. An algorithm registers one `AlgoPlugin`, and compile-time interface assertions enforce required hooks.
+
+Guarded failure mode: re-introducing per-algorithm `switch algo` / `if IsXxxIndexAlgo || ...` in SQL/catalog layers bypasses the registry and re-opens the "forgot a dispatch site" bug class.
+
+## 2. Architecture
+
+`pkg/indexplugin` is the framework. It must not import `pkg/sql/{compile,plan}`. Hook methods receive narrow `Context` interfaces implemented by SQL-layer code.
+
+```
+pkg/indexplugin/
+├── plugin.go          -- AlgoPlugin interface; Register/Get/All; IsVectorIndexAlgo/IsFullTextIndexAlgo/IsPluginAlgo
+├── catalog/hooks.go   -- catalog.Hooks   (metadata: params, hidden tables, op/vector/pk types, quantization)
+├── compile/hooks.go   -- compile.Hooks   (DDL execution: create/reindex/drop/restore) + CompileContext
+├── plan/hooks.go      -- plan.Hooks      (schema defs + tablefunc + thin ANN redirects) + PlanBuilder/CompilerContext
+├── idxcron/hooks.go   -- idxcron.Hooks   (scheduled-rebuild gating: Updatable)
+└── all/
+    ├── all.go         -- blank-imports CPU-safe plugins (fulltext, hnsw, ivfflat)
+    └── all_gpu.go     -- //go:build gpu -- blank-imports GPU-only plugins (cagra, ivfpq)
+
+pkg/vectorindex/<algo>/plugin/   -- one dir per algorithm; assembles hooks into an AlgoPlugin
+pkg/fulltext/plugin/             -- fulltext is a plugin too (kind = fulltext, not vector)
+```
+
+Dispatch flow:
+
+```go
+p, ok := indexplugin.Get(algo) // case-insensitive, trims whitespace
+if ok { return p.Compile().HandleCreateIndex(cctx, defs) }
+```
+
+Use:
+
+- `indexplugin.IsVectorIndexAlgo(algo)` instead of `IsIvfIndexAlgo || IsHnswIndexAlgo || ...`
+- `indexplugin.IsFullTextIndexAlgo(algo)` for fulltext
+- `indexplugin.IsPluginAlgo(algo)` for registered vector or fulltext algorithms
+
+Live dispatch sites include `pkg/sql/plan/build_ddl.go` and `pkg/sql/plan/apply_indices.go`.
+
+## 3. Registry Contract
+
+```go
+type AlgoPlugin interface {
+    Algo() string
+    Catalog() catalogplugin.Hooks
+    Compile() compileplugin.Hooks
+    Plan()    planplugin.Hooks
+    Idxcron() idxcronplugin.Hooks
+}
+func Register(p AlgoPlugin)
+func Get(algo string) (AlgoPlugin, bool)
+```
+
+Each plugin keeps compile-time interface assertions:
+
+```go
+var _ plugin.AlgoPlugin = (*Plugin)(nil)
+var _ Hooks = Hooks{}
+```
+
+If `AlgoPlugin` or a `Hooks` interface gains a method and a plugin is not updated, these assertions stop the build. Never delete or `//nolint` them to make the build green. Implement the missing method.
+
+## 4. Plugin Package Layout
+
+Canonical walkthrough: `pkg/vectorindex/ivfpq/plugin/plugin.go`.
+
+Full plugin layout:
+
+```
+pkg/vectorindex/<algo>/plugin/
+├── plugin.go            -- assembles 4 Hooks into one Plugin; init() { plugin.Register(New()) }
+├── runtime/runtime.go   -- catalog.Hooks impl
+├── compile/compile.go   -- compile.Hooks impl
+├── plan/
+│   ├── plan.go          -- thin ApplyForSort/CanApply redirect into *plan.QueryBuilder
+│   ├── schema.go        -- BuildSecondaryIndexDefs body
+│   └── tablefunc.go     -- <algo>_create / <algo>_search FUNCTION_SCAN builder registrations
+├── idxcron/idxcron.go   -- idxcron.Hooks impl
+└── iscp/iscp.go         -- CDC / import sync; may be //go:build gpu
+```
+
+Lift code into the sub-package matching the original SQL layer:
+
+- `pkg/sql/compile/*.go` -> `plugin/compile/`
+- `pkg/sql/plan/*.go` -> `plugin/plan/`
+- Algorithm metadata constants -> `plugin/runtime/`
+
+## 5. Adding A New Algorithm
+
+1. Add catalog constants:
+   - `MoIndex<X>Algo` in `pkg/catalog/secondary_index_utils.go`
+   - hidden-table-type constants in `pkg/catalog/types.go`
+   - parser keyword only if syntax needs it
+2. Copy `pkg/vectorindex/ivfpq/plugin/` to `pkg/vectorindex/<x>/plugin/`, then rename packages/imports.
+3. Implement four hooks:
+   - `catalog.Hooks`: hidden table types, params, defaults, supported types, quantization, clone/restore behavior, session vars, sync descriptor.
+   - `compile.Hooks`: create, reindex, validate reindex params, drop, restore init SQL, idxcron metadata.
+   - `plan.Hooks`: secondary/fulltext index defs, `CanApply`, `ApplyForSort`.
+   - `idxcron.Hooks`: `Updatable`.
+4. If ANN rewrite is supported, add `applyIndicesForSortUsing<X>` + `prepare<X>IndexContext` in `pkg/sql/plan/apply_indices_<x>.go`, redirect methods in `pkg/sql/plan/plugin_builder.go`, and dispatch via `p.Plan().CanApply`.
+5. Register in `plugin.go` with `plugin.Register(New())`.
+6. Add exactly one blank import:
+   - CPU-safe algo -> `pkg/indexplugin/all/all.go`
+   - GPU-only algo -> `pkg/indexplugin/all/all_gpu.go`
+7. Add SQL tests under `test/distributed/cases/vector/` for create, ANN query, reindex, drop index, and drop table.
+
+If the plugin compiles and all hooks are implemented, you did not miss a dispatch site. Do not add manual dispatch "to be safe."
+
+## 6. CPU vs GPU Registration
+
+| File | Build tag | Registers | Rationale |
+|------|-----------|-----------|-----------|
+| `pkg/indexplugin/all/all.go` | none | fulltext, hnsw, ivfflat | CPU-safe algorithms |
+| `pkg/indexplugin/all/all_gpu.go` | `//go:build gpu` | cagra, ivfpq | CUDA-backed table functions exist only under `gpu` |
+
+CAGRA / IVF-PQ table functions exist only under `//go:build gpu`. Registering them on CPU would let `CREATE INDEX ... USING cagra|ivfpq` proceed until BUILD SQL fails mid-flight after hidden table side effects. GPU-tagged registration makes plan-build fail cleanly with `unsupported index type: <algo>`.
+
+Pairing rule: an algo with `build_gpu.go` must have a `//go:build !gpu` CPU counterpart stub, and the plugin blank import belongs in `all_gpu.go`, never `all.go`.
+
+## 7. Forbidden Patterns
+
+1. Never re-introduce per-algorithm dispatch in SQL/catalog layers. A new `switch idx.IndexAlgo`, `case MoIndex<X>Algo:`, or `if catalog.IsIvfIndexAlgo(a) || ...` re-opens the bug class the framework closed. Add a method to a hook interface instead.
+2. Never import `pkg/sql/plan` or `pkg/sql/compile` from a plugin package. Plugins receive narrow interfaces and call through them.
+3. Never register a GPU-only algo in `all.go`; use `all_gpu.go`.
+4. Never weaken `var _ AlgoPlugin` / `var _ Hooks` assertions.
+5. Keep runtime kernels out of the plugin. Build/search kernels stay in `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go` and are invoked from table functions.
+6. Never pollute `pkg/indexplugin` with algorithm-specific code. It is interfaces, registry, and algorithm-agnostic metadata only. The only files there that may name concrete algorithms are `all/` and `iscp/` aggregators, and only as blank imports.
+
+## 8. Testing And Completion
+
+Index-plugin changes have a coverage trap: end-to-end BVT cases under `test/distributed/cases/vector/` are GPU-gated, so `plan.go` / `schema.go` can read 0% coverage in non-GPU CI. Add CPU-runnable unit tests like `tablefunc_test` / `runtime_test` style tests, not just GPU-gated BVT.
+
+Completion checklist:
+
+```
+□ CPU unit tests exist for plan/schema/runtime hooks  -> run, exit 0
+□ GPU-only hooks also run with `-tags gpu`             -> exit 0
+□ grep: NO new `switch algo` / `IsXxxIndexAlgo ||` added in pkg/sql/*
+□ git diff --stat: the ONLY all.go/all_gpu.go edit is one blank import
+```
+
+Known in-progress seams: a few DML-sync sites still call `catalog.IsIvfIndexAlgo` directly (`pkg/sql/plan/build_dml_util.go`, `pkg/sql/plan/bind_insert.go`). These are legacy, not a license to add more. When touching one, prefer moving it behind a hook.
+
+## 9. Reviewing An Index-Plugin Change
+
+Apply this when reviewing a diff that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/`, `pkg/fulltext/plugin`, or `pkg/indexplugin`. Request changes if a check fails.
+
+1. No new per-algo dispatch:
+
+```bash
+git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
+  | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
+```
+
+2. No import cycle:
+
+```bash
+git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
+  | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'
+```
+
+3. `indexplugin` not polluted:
+
+```bash
+git diff pkg/indexplugin \
+  | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'
+```
+
+4. GPU registration correct: GPU-only imports in `all_gpu.go`, not `all.go`; each `build_gpu.go` has CPU counterpart.
+5. Assertions intact:
+
+```bash
+git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'
+```
+
+6. Runtime kept out: no build/search kernel logic copied into plugin.
+7. New-algo completeness: registered in `all/` or `all_gpu/`, SQL case added under `test/distributed/cases/vector/`, CPU unit tests cover plan/schema/runtime hooks.

--- a/.claude/skills/mo-dev/references/operator-pipeline.md
+++ b/.claude/skills/mo-dev/references/operator-pipeline.md
@@ -1,0 +1,96 @@
+# Operator And Pipeline Reference
+
+## 1. Operator Lifecycle Contracts
+
+### Call() vs Reset()
+
+| Method | Purpose | Must NOT Do |
+|--------|---------|-------------|
+| `Call()` | Process one batch. Receive from upstream, compute, send downstream. | Send terminal signals (`End`, `Error`, `Abort`). That is `Reset()`'s job. |
+| `Reset()` | Cleanup. Notify downstream the operator is done. | Block waiting for receiver acknowledgment. Use `Abort()`, not `CloseWithTimeout()`. |
+
+This is the most common source of subtle operator bugs: premature pipeline termination, spurious timeouts, dead receivers.
+
+### PipelineSpool Lifecycle
+
+| Method | Behavior | Use When |
+|--------|----------|----------|
+| `Close()` | Wait for all consumers to acknowledge end of stream by consuming nil batches from spool | Graceful completion path |
+| `CloseWithTimeout()` | Same as `Close()` but with timeout | Legacy cleanup; deprecated for typed signals |
+| `ForceCleanup()` / `Abort()` | Synchronous release of all un-consumed slots. No waiting. Idempotent (`sync.Once`) | Cleanup path with explicit terminal signals |
+
+Critical rule: if implicit nil-batch end-of-stream was replaced with explicit typed signals (`EventEnd`, `EventError`, `EventAbort`), use `Abort()` instead of `CloseWithTimeout()`. `CloseWithTimeout()` waits for nil batches that will never arrive.
+
+### Pipeline Signal Types
+
+| Signal | Constructor | Meaning |
+|--------|-------------|---------|
+| `EventData` | `NewDataSignal(batch)` | Normal data batch |
+| `EventEnd` | `NewEndSignal()` | Graceful end of stream |
+| `EventError` | `NewErrorSignal(err)` | Operator encountered an error |
+| `EventAbort` | `NewAbortSignal()` | Forceful termination |
+
+Dual-protocol compatibility: `GetNextBatch` handles both explicit typed signals and legacy nil-batch convention (`content == nil`). Old operators using implicit nil-batch continue to work.
+
+## 2. Post-Modification Verification
+
+### Test Freshness
+
+Test output must be from the current turn:
+
+1. `go test` command appears in current turn's tool calls.
+2. Exit code is 0.
+3. Timestamp is after the last edit.
+
+### Completion Gate
+
+Before declaring a change done, all boxes must be checked:
+
+```
+□ go build ./pkg/.../modified_package...    -> exit 0
+□ go vet ./pkg/.../modified_package...      -> exit 0
+□ go test -v -count=1 ./pkg/.../...         -> exit 0, no hangs
+□ git diff --stat                            -> inspected, no unintended files
+□ Regression: at least one test from dependent package passes
+```
+
+Hang = failure. If `go test` produces more than 10s of no output, investigate.
+
+## 3. Fault Diagnosis
+
+| Symptom | Look At |
+|---------|---------|
+| Test hangs exactly 30s | `CloseWithTimeout` waiting for nil-batch that never arrives. Check if typed signals are being sent instead. |
+| Test hangs >5s, no output | Deadlock or blocking channel send. Check whether `done` channel is closed and whether `sendSignal` uses non-blocking `select`. |
+| `context deadline exceeded` after 30s | `WaitingEndWithTimeout` timed out. Check whether all senders called `Reset()` and sent typed terminal signals. |
+| `CGO_CFLAGS` not working | Run `go env CGO_CFLAGS` to verify. Use `export` if the package has sub-packages. |
+
+## 4. Common Pitfalls
+
+### Structural Changes Need Both Ends
+
+When changing communication protocol between operators, such as connector <-> merge or dispatch <-> merge, update both sender and receiver. A sender-only change can deadlock.
+
+Identification: exact 30s timeout in cleanup usually points to `CloseWithTimeout` + typed signal mismatch.
+
+### CGo Link Errors Are Usually Environment
+
+CGo link errors (`Undefined symbols`, `cannot find -lmo`) are environment issues until proven otherwise. The C shared libraries (`libmo.dylib`, `libusearch_c.dylib`) must be pre-built via `make cgo` and `make thirdparties`.
+
+### Pipeline Cleanup: Abort, Do Not Wait
+
+During pipeline cleanup, operators should use non-blocking or timeout-gated communication. Never block waiting for a receiver that may have already exited.
+
+### Channel Full Edge Cases
+
+When sending terminal signals into a bounded channel, the send may fail because the channel is full. Ensure the terminal state is still recorded even when channel send fails; the `done` channel must close regardless of delivery success.
+
+## 5. Forbidden Patterns
+
+1. Never send terminal signals (`End`, `Error`, `Abort`) from `Call()`. Only `Reset()` sends terminal signals.
+2. Never call `sp.CloseWithTimeout()` after switching to explicit typed terminal signals. Use `sp.Abort()`.
+3. Never claim "pre-existing" without `git stash` proof.
+4. Never declare done without fresh test output.
+5. Never assume `go build` success means `go test` will pass.
+6. Never skip bottom-up testing.
+7. Never add per-algorithm `switch`/`if` on index algo names in the SQL layer. Route through `indexplugin.Get(algo)`.

--- a/.claude/skills/mo-self-review/SKILL.md
+++ b/.claude/skills/mo-self-review/SKILL.md
@@ -1,16 +1,13 @@
 ---
 name: mo-self-review
 description: Pre-push self-review gate for MatrixOne changes — a systematic, multi-angle, first-principles review of your OWN diff with complete functional-closure investigation and unhappy-path coverage, calibrated to the merge bar. Run BEFORE pushing / opening / updating a PR so the human or bot PR review finds nothing new — breaking the review→modify loop. Use before declaring a change "done", before push, or when a PR keeps drawing new review rounds. Complements unhappy-path-audit (Q1–Q3 depth) and /code-review.
-compatibility:
-  agents: Codex CLI and compatible agents
-  requires:
-    - git working tree with a diff vs the base branch
-    - unhappy-path-audit skill (for Q1–Q3 depth)
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone
   language: go
 ---
+
+Compatibility: designed for Codex CLI and compatible agents. Requires a git working tree with a diff vs the base branch and the unhappy-path-audit skill (for Q1-Q3 depth).
 
 ## Running this skill IS the review (don't retype the long prompt)
 

--- a/.claude/skills/unhappy-path-audit/SKILL.md
+++ b/.claude/skills/unhappy-path-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unhappy-path-audit
-description: Full-codebase unhappy-path audit (hung, leak, OOM) using the Q1-Q3 three-proposition framework to produce structured risk reports.
+description: Full-codebase MatrixOne unhappy-path audit for leak, hung, and OOM risks using the Q1-Q3 three-proposition framework. Use when asked to audit resource lifecycle, waits, goroutines, lock/connection cleanup, unbounded growth, or to produce structured risk reports / bug candidates for MatrixOne code.
 ---
 
 # Unhappy Path Audit Skill
@@ -294,7 +294,3 @@ Common false positive: variable is reset in a function you haven't read yet (e.g
 | See append/push without bound in current scope → report OOM | Grep variable + `= nil` — cleanup function in sibling file may reset it | G3 |
 | See function call that "might" panic → report fd leak on panic path | Open function body — nil-check+assign or simple arithmetic cannot panic | G2 |
 | See `SendMessage` return error → assume upstream state machine doesn't clean up | Re-read the exact line where state is set — it may be unconditional | G4 |
-
-## Recent user feedback
-<!-- auto-recorded at t=1782710864 -->
-- User directive: 不要管。继续下一个task

--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,9 @@ etc/docker-multi-cn-local-disk/*.toml
 # python
 **/__pycache__/
 *.pyc
-.agents/
+.agents/*
+!.agents/skills/
+!.agents/skills/*/
+!.agents/skills/*/SKILL.md
+!.agents/skills/*/references/
+!.agents/skills/*/references/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 .idea/
 .kiro/
 .cursor/
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/*/
+!.claude/skills/*/SKILL.md
+!.claude/skills/*/references/
+!.claude/skills/*/references/*.md
 /CLAUDE.md
 *.o
 *.a


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [x] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25267

## What this PR does / why we need it:

- Updates `mo-bug-triage` with the current bug lifecycle: `needs-triage` intake, conservative promotion, `deferred` downgrade comments, and opt-in AI effort labels.
- Splits `mo-dev` into focused references for CGo/GPU build guidance, operator/pipeline contracts, and index-plugin rules.
- Mirrors the same skill updates under `.claude/skills`, including `mo-dev` references, so Claude and Codex skill surfaces stay in sync.
- Fixes skill frontmatter validation for `mo-dev` and `mo-self-review`, and removes stale generated feedback from `unhappy-path-audit`.
- Updates `.gitignore` so tracked skill docs and references under `.agents/skills` and `.claude/skills` can be committed.

Validation:
- `quick_validate.py` passed for all updated `.agents` and `.claude` skills.
- `git diff --check` passed for `.agents/skills`, `.claude/skills`, and `.gitignore`.
