### PR TITLE
fix: preserve multi-cn for small ivf_search entry scans

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -5136,6 +5136,10 @@ func shouldScanOnCurrentCN(c *Compile, node *plan.Node, forceSingle bool) bool {
 		return true
 	}
 
+	if plan2.IsIvfSearchEntriesInternalScan(node) {
+		return false
+	}
+
 	if !plan2.GetForceScanOnMultiCN() &&
 		node.Stats.BlockNum <= int32(plan2.BlockThresholdForOneCN) {
 		return true

--- a/pkg/sql/compile/max_dop_test.go
+++ b/pkg/sql/compile/max_dop_test.go
@@ -17,6 +17,7 @@ package compile
 import (
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -83,6 +84,116 @@ func TestGenerateNodesCapsByCNMcpuWhenDOPIsLarger(t *testing.T) {
 	require.Len(t, nodes, 2)
 	require.Equal(t, 3, nodes[0].Mcpu)
 	require.Equal(t, 4, nodes[1].Mcpu)
+}
+
+func TestGenerateNodesUsesMultiCNForSmallIvfEntriesInternalScan(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.e = newStubEngineForGenerateNodes("testdb", "idx_entries")
+	c.cnList = engine.Nodes{
+		{Id: "cn1", Addr: "cn-local:6001", Mcpu: 4},
+		{Id: "cn2", Addr: "cn-local:6001", Mcpu: 4},
+	}
+
+	node := &plan.Node{
+		NodeType: plan.Node_TABLE_SCAN,
+		ObjRef: &plan.ObjectRef{
+			SchemaName: "testdb",
+			ObjName:    "idx_entries",
+		},
+		TableDef: &plan.TableDef{
+			Name:      "idx_entries",
+			TableType: catalog.SystemSI_IVFFLAT_TblType_Entries,
+		},
+		Stats: &plan.Stats{
+			BlockNum: 1,
+			Dop:      1,
+		},
+		IndexReaderParam: &plan.IndexReaderParam{
+			OrderBy: []*plan.OrderBySpec{{Expr: &plan.Expr{}}},
+			Limit: &plan.Expr{
+				Expr: &plan.Expr_Lit{
+					Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 10}},
+				},
+			},
+		},
+	}
+
+	nodes, err := c.generateNodes(node)
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+	require.Equal(t, int32(2), nodes[0].CNCNT)
+	require.Equal(t, int32(0), nodes[0].CNIDX)
+	require.Equal(t, int32(2), nodes[1].CNCNT)
+	require.Equal(t, int32(1), nodes[1].CNIDX)
+}
+
+func TestGenerateNodesKeepsForceOneCNIvfEntriesInternalScanOnCurrentCN(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.e = newStubEngineForGenerateNodes("testdb", "idx_entries")
+	c.cnList = engine.Nodes{
+		{Id: "cn1", Addr: "cn-local:6001", Mcpu: 4},
+		{Id: "cn2", Addr: "cn-local:6001", Mcpu: 4},
+	}
+
+	node := &plan.Node{
+		NodeType: plan.Node_TABLE_SCAN,
+		ObjRef: &plan.ObjectRef{
+			SchemaName: "testdb",
+			ObjName:    "idx_entries",
+		},
+		TableDef: &plan.TableDef{
+			Name:      "idx_entries",
+			TableType: catalog.SystemSI_IVFFLAT_TblType_Entries,
+		},
+		Stats: &plan.Stats{
+			BlockNum:   1,
+			Dop:        1,
+			ForceOneCN: true,
+		},
+		IndexReaderParam: &plan.IndexReaderParam{
+			OrderBy: []*plan.OrderBySpec{{Expr: &plan.Expr{}}},
+			Limit: &plan.Expr{
+				Expr: &plan.Expr_Lit{
+					Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 10}},
+				},
+			},
+		},
+	}
+
+	nodes, err := c.generateNodes(node)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, int32(1), nodes[0].CNCNT)
+}
+
+func TestGenerateNodesKeepsSmallNonIvfScanOnCurrentCN(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.e = newStubEngineForGenerateNodes("testdb", "t")
+	c.cnList = engine.Nodes{
+		{Id: "cn1", Addr: "cn-local:6001", Mcpu: 4},
+		{Id: "cn2", Addr: "cn-local:6001", Mcpu: 4},
+	}
+
+	node := &plan.Node{
+		NodeType: plan.Node_TABLE_SCAN,
+		ObjRef: &plan.ObjectRef{
+			SchemaName: "testdb",
+			ObjName:    "t",
+		},
+		TableDef: &plan.TableDef{Name: "t"},
+		Stats: &plan.Stats{
+			BlockNum: 1,
+			Dop:      1,
+		},
+	}
+
+	nodes, err := c.generateNodes(node)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, int32(1), nodes[0].CNCNT)
 }
 
 func newStubEngineForGenerateNodes(dbName, tblName string) *stubEngine {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -37,7 +37,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
-	ivfflatplan "github.com/matrixorigin/matrixone/pkg/vectorindex/ivfflat/plugin/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -2085,7 +2084,6 @@ func GetExecType(qry *plan.Query, txnHaveDDL bool, isPrepare bool) ExecType {
 			break
 		}
 	}
-	hasIvfSearchWithLimit := queryHasIvfSearchWithLimit(qry)
 	canUseMultiCN := !txnHaveDDL && !hasExprBasedShuffle
 	ret := ExecTypeTP
 	for _, node := range qry.GetNodes() {
@@ -2116,7 +2114,7 @@ func GetExecType(qry *plan.Query, txnHaveDDL bool, isPrepare bool) ExecType {
 			}
 		}
 		if node.NodeType == plan.Node_TABLE_SCAN && node.TableDef != nil {
-			if isIvfSearchEntriesScan(node, hasIvfSearchWithLimit) {
+			if IsIvfSearchEntriesInternalScan(node) {
 				execType := ExecTypeAP_MULTICN
 				if !canUseMultiCN {
 					execType = ExecTypeAP_ONECN
@@ -2143,32 +2141,6 @@ func GetExecType(qry *plan.Query, txnHaveDDL bool, isPrepare bool) ExecType {
 		}
 	}
 	return ret
-}
-
-func queryHasIvfSearchWithLimit(qry *plan.Query) bool {
-	for _, node := range qry.GetNodes() {
-		if isIvfSearchWithLimitNode(node) {
-			return true
-		}
-	}
-	return false
-}
-
-func isIvfSearchWithLimitNode(node *plan.Node) bool {
-	if node == nil || node.NodeType != plan.Node_FUNCTION_SCAN {
-		return false
-	}
-	if node.GetIndexReaderParam().GetLimit() == nil {
-		return false
-	}
-	return node.GetTableDef().GetTblFunc().GetName() == ivfflatplan.IVFFLATSearchFuncName
-}
-
-func isIvfSearchEntriesScan(node *plan.Node, queryHasIvfSearchWithLimit bool) bool {
-	if !isIvfSearchEntriesTableScan(node) {
-		return false
-	}
-	return queryHasIvfSearchWithLimit || isIvfEntriesIndexReaderScan(node)
 }
 
 func isIvfSearchEntriesTableScan(node *plan.Node) bool {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	ivfflatplan "github.com/matrixorigin/matrixone/pkg/vectorindex/ivfflat/plugin/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -2056,6 +2057,9 @@ func GetExecType(qry *plan.Query, txnHaveDDL bool, isPrepare bool) ExecType {
 	// the equi-join condition is a function expression (not a plain column ref), it's expr-based.
 	hasExprBasedShuffle := false
 	for _, node := range qry.GetNodes() {
+		if node == nil {
+			continue
+		}
 		if node.Stats == nil || node.Stats.HashmapStats == nil {
 			continue
 		}
@@ -2081,8 +2085,13 @@ func GetExecType(qry *plan.Query, txnHaveDDL bool, isPrepare bool) ExecType {
 			break
 		}
 	}
+	hasIvfSearchWithLimit := queryHasIvfSearchWithLimit(qry)
+	canUseMultiCN := !txnHaveDDL && !hasExprBasedShuffle
 	ret := ExecTypeTP
 	for _, node := range qry.GetNodes() {
+		if node == nil {
+			continue
+		}
 		switch node.NodeType {
 		case plan.Node_RECURSIVE_CTE, plan.Node_RECURSIVE_SCAN:
 			ret = ExecTypeAP_ONECN
@@ -2106,14 +2115,27 @@ func GetExecType(qry *plan.Query, txnHaveDDL bool, isPrepare bool) ExecType {
 				ret = ExecTypeAP_ONECN
 			}
 		}
-		if node.NodeType == plan.Node_TABLE_SCAN &&
+		if node.NodeType == plan.Node_TABLE_SCAN && node.TableDef != nil {
+			if isIvfSearchEntriesScan(node, hasIvfSearchWithLimit) {
+				execType := ExecTypeAP_MULTICN
+				if !canUseMultiCN {
+					execType = ExecTypeAP_ONECN
+				}
+				if execType > ret {
+					ret = execType
+				}
+			}
 			// due to the inaccuracy of stats.Rowsize, currently only vector index tables are supported
-			(node.TableDef.TableType == catalog.SystemSI_IVFFLAT_TblType_Entries || node.TableDef.TableType == catalog.Hnsw_TblType_Storage) &&
-			stats.Rowsize > RowSizeThreshold &&
-			stats.BlockNum > LargeBlockThresholdForOneCN {
-			ret = ExecTypeAP_ONECN
-			if stats.BlockNum > LargeBlockThresholdForMultiCN {
-				ret = ExecTypeAP_MULTICN
+			if (node.TableDef.TableType == catalog.SystemSI_IVFFLAT_TblType_Entries || node.TableDef.TableType == catalog.Hnsw_TblType_Storage) &&
+				stats.Rowsize > RowSizeThreshold &&
+				stats.BlockNum > LargeBlockThresholdForOneCN {
+				execType := ExecTypeAP_ONECN
+				if stats.BlockNum > LargeBlockThresholdForMultiCN && canUseMultiCN {
+					execType = ExecTypeAP_MULTICN
+				}
+				if execType > ret {
+					ret = execType
+				}
 			}
 		}
 		if node.NodeType != plan.Node_TABLE_SCAN && stats.HashmapStats != nil && stats.HashmapStats.Shuffle {
@@ -2121,6 +2143,51 @@ func GetExecType(qry *plan.Query, txnHaveDDL bool, isPrepare bool) ExecType {
 		}
 	}
 	return ret
+}
+
+func queryHasIvfSearchWithLimit(qry *plan.Query) bool {
+	for _, node := range qry.GetNodes() {
+		if isIvfSearchWithLimitNode(node) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIvfSearchWithLimitNode(node *plan.Node) bool {
+	if node == nil || node.NodeType != plan.Node_FUNCTION_SCAN {
+		return false
+	}
+	if node.GetIndexReaderParam().GetLimit() == nil {
+		return false
+	}
+	return node.GetTableDef().GetTblFunc().GetName() == ivfflatplan.IVFFLATSearchFuncName
+}
+
+func isIvfSearchEntriesScan(node *plan.Node, queryHasIvfSearchWithLimit bool) bool {
+	if !isIvfSearchEntriesTableScan(node) {
+		return false
+	}
+	return queryHasIvfSearchWithLimit || isIvfEntriesIndexReaderScan(node)
+}
+
+func isIvfSearchEntriesTableScan(node *plan.Node) bool {
+	return node != nil &&
+		node.NodeType == plan.Node_TABLE_SCAN &&
+		node.GetTableDef().GetTableType() == catalog.SystemSI_IVFFLAT_TblType_Entries
+}
+
+// IsIvfSearchEntriesInternalScan reports the internal entries table scan issued by ivf_search.
+func IsIvfSearchEntriesInternalScan(node *plan.Node) bool {
+	return isIvfSearchEntriesTableScan(node) && isIvfEntriesIndexReaderScan(node)
+}
+
+func isIvfEntriesIndexReaderScan(node *plan.Node) bool {
+	param := node.GetIndexReaderParam()
+	if param.GetLimit() == nil {
+		return false
+	}
+	return param.GetOrigFuncName() != "" || len(param.GetOrderBy()) > 0
 }
 
 func GetPlanTitle(qry *plan.Query, txnHaveDDL bool) string {

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -24,6 +24,7 @@ import (
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	ivfflatplan "github.com/matrixorigin/matrixone/pkg/vectorindex/ivfflat/plugin/plan"
 	index2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/stretchr/testify/require"
 )
@@ -286,6 +287,45 @@ func makeQueryWithScan(tableType string, rowsize float64, blockNum int32) *planp
 	}
 }
 
+func makeQueryWithScanStats(tableType string, rowsize float64, tableCnt float64, blockNum int32, nodes ...*planpb.Node) *planpb.Query {
+	scan := &planpb.Node{
+		NodeType: planpb.Node_TABLE_SCAN,
+		TableDef: &planpb.TableDef{TableType: tableType},
+		Stats: &planpb.Stats{
+			Rowsize:  rowsize,
+			TableCnt: tableCnt,
+			BlockNum: blockNum,
+		},
+	}
+	qryNodes := append([]*planpb.Node{scan}, nodes...)
+	return &planpb.Query{
+		Nodes: qryNodes,
+		Steps: []int32{0},
+	}
+}
+
+func makeLimitExprForStatsTest() *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_Lit{
+			Lit: &planpb.Literal{
+				Value: &planpb.Literal_U64Val{U64Val: 10},
+			},
+		},
+	}
+}
+
+func makeFunctionScanForStatsTest(funcName string, limit *planpb.Expr) *planpb.Node {
+	return &planpb.Node{
+		NodeType: planpb.Node_FUNCTION_SCAN,
+		Stats:    &planpb.Stats{},
+		TableDef: &planpb.TableDef{
+			TblFunc: &planpb.TableFunction{Name: funcName},
+		},
+		IndexReaderParam: &planpb.IndexReaderParam{Limit: limit},
+		Children:         []int32{0},
+	}
+}
+
 func TestGetExecType_VectorIndex_WideRows_OneCN(t *testing.T) {
 	// rowsize just above threshold, blockNum between oneCN and multiCN thresholds
 	q := makeQueryWithScan(catalog.SystemSI_IVFFLAT_TblType_Entries, float64(RowSizeThreshold+1), LargeBlockThresholdForOneCN+1)
@@ -303,12 +343,448 @@ func TestGetExecType_VectorIndex_WideRows_MultiCN(t *testing.T) {
 	}
 }
 
+func TestGetExecType_VectorIndex_WideRows_MultiCNCappedForDDL(t *testing.T) {
+	q := makeQueryWithScan(catalog.Hnsw_TblType_Storage, float64(RowSizeThreshold+1), LargeBlockThresholdForMultiCN+1)
+	got := GetExecType(q, true, false)
+	require.Equal(t, ExecTypeAP_ONECN, got)
+}
+
 func TestGetExecType_NonVectorTable_NotForcedByRowsize(t *testing.T) {
 	// Non-vector tables should not trigger rowsize shortcut; with small blockNum, expect TP
 	q := makeQueryWithScan("normal_table", float64(RowSizeThreshold+10), LargeBlockThresholdForOneCN)
 	got := GetExecType(q, false, false)
 	if got != ExecTypeTP {
 		t.Fatalf("expected ExecTypeTP for non-vector table, got %v", got)
+	}
+}
+
+func TestGetExecType_IvfSearchEntries_FunctionSearchUsesMultiCNEvenWithTinyStats(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	q := makeQueryWithScanStats(
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
+		1,
+		1,
+		1,
+		searchNode,
+	)
+
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeAP_MULTICN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_FunctionSearchDoesNotRequireStatsEstimate(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	q := makeQueryWithScanStats(
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
+		0,
+		0,
+		1,
+		searchNode,
+	)
+
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeAP_MULTICN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_RowsizeShortcutDoesNotDowngradeMultiCN(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	q := makeQueryWithScanStats(
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
+		float64(RowSizeThreshold+1),
+		1,
+		LargeBlockThresholdForOneCN+1,
+		searchNode,
+	)
+
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeAP_MULTICN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_SearchMultiCNCappedForDDL(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	q := makeQueryWithScanStats(
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
+		1,
+		1,
+		1,
+		searchNode,
+	)
+
+	got := GetExecType(q, true, false)
+
+	require.Equal(t, ExecTypeAP_ONECN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_MultiCNCappedForExprBasedShuffle(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	q := makeQueryWithScanStats(
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
+		1,
+		1,
+		1,
+		searchNode,
+		&planpb.Node{
+			NodeType: planpb.Node_JOIN,
+			Stats: &planpb.Stats{
+				HashmapStats: &planpb.HashMapStats{
+					Shuffle:       true,
+					ShuffleColIdx: 0,
+				},
+			},
+			OnList: []*planpb.Expr{
+				{
+					Expr: &planpb.Expr_F{
+						F: &planpb.Function{
+							Args: []*planpb.Expr{
+								{
+									Expr: &planpb.Expr_Col{
+										Col: &planpb.ColRef{ColPos: 0},
+									},
+								},
+								{
+									Expr: &planpb.Expr_Lit{
+										Lit: &planpb.Literal{Value: &planpb.Literal_U64Val{U64Val: 1}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeAP_ONECN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_MultiCNCappedForDDLEvenWithManyBlocks(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	q := makeQueryWithScanStats(
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
+		float64(RowSizeThreshold+1),
+		500*1024,
+		LargeBlockThresholdForMultiCN+1,
+		searchNode,
+	)
+
+	got := GetExecType(q, true, false)
+
+	require.Equal(t, ExecTypeAP_ONECN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_MultiCNRequiresSearchLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		node *planpb.Node
+	}{
+		{
+			name: "no function scan",
+		},
+		{
+			name: "wrong function",
+			node: makeFunctionScanForStatsTest("not_ivf_search", makeLimitExprForStatsTest()),
+		},
+		{
+			name: "missing limit",
+			node: makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var nodes []*planpb.Node
+			if tt.node != nil {
+				nodes = append(nodes, tt.node)
+			}
+			q := makeQueryWithScanStats(
+				catalog.SystemSI_IVFFLAT_TblType_Entries,
+				1,
+				1,
+				1,
+				nodes...,
+			)
+
+			got := GetExecType(q, false, false)
+
+			require.Equal(t, ExecTypeTP, got)
+		})
+	}
+}
+
+func TestGetExecType_IvfSearchEntries_SearchDetectionDoesNotDependOnFunctionScanChildren(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	// ivf_search.Children carries the vector provider side for join-through queries,
+	// not the hidden IVF entries table scan.
+	searchNode.Children = []int32{1}
+	q := &planpb.Query{
+		Nodes: []*planpb.Node{
+			{
+				NodeType: planpb.Node_TABLE_SCAN,
+				TableDef: &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
+				Stats: &planpb.Stats{
+					Rowsize:  1,
+					TableCnt: 1,
+					BlockNum: 1,
+				},
+			},
+			{
+				NodeType: planpb.Node_VALUE_SCAN,
+				Stats:    &planpb.Stats{},
+			},
+			searchNode,
+		},
+		Steps: []int32{2},
+	}
+
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeAP_MULTICN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanUsesMultiCNEvenWithTinyStats(t *testing.T) {
+	q := makeQueryWithScanStats(
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
+		1,
+		1,
+		1,
+	)
+	q.Nodes[0].IndexReaderParam = &planpb.IndexReaderParam{
+		OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}},
+		Limit:   makeLimitExprForStatsTest(),
+	}
+
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeAP_MULTICN, got)
+}
+
+func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanRequiresSearchShape(t *testing.T) {
+	tests := []struct {
+		name  string
+		param *planpb.IndexReaderParam
+	}{
+		{
+			name: "nil index reader param",
+		},
+		{
+			name:  "limit only is not enough",
+			param: &planpb.IndexReaderParam{Limit: makeLimitExprForStatsTest()},
+		},
+		{
+			name:  "order only is not enough",
+			param: &planpb.IndexReaderParam{OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := makeQueryWithScanStats(
+				catalog.SystemSI_IVFFLAT_TblType_Entries,
+				1,
+				1,
+				1,
+			)
+			q.Nodes[0].IndexReaderParam = tt.param
+
+			got := GetExecType(q, false, false)
+
+			require.Equal(t, ExecTypeTP, got)
+		})
+	}
+}
+
+func TestGetExecType_IvfSearchMultiCN_DoesNotApplyToOtherTableTypes(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+	q := makeQueryWithScanStats(
+		catalog.Hnsw_TblType_Storage,
+		1,
+		1,
+		1,
+		searchNode,
+	)
+
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeTP, got)
+}
+
+func TestIsIvfSearchWithLimitNode_UnhappyPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		node *planpb.Node
+		want bool
+	}{
+		{
+			name: "nil node",
+			want: false,
+		},
+		{
+			name: "non function scan",
+			node: &planpb.Node{NodeType: planpb.Node_VALUE_SCAN},
+			want: false,
+		},
+		{
+			name: "nil table def",
+			node: &planpb.Node{
+				NodeType:         planpb.Node_FUNCTION_SCAN,
+				Stats:            &planpb.Stats{},
+				IndexReaderParam: &planpb.IndexReaderParam{Limit: makeLimitExprForStatsTest()},
+			},
+			want: false,
+		},
+		{
+			name: "nil table function",
+			node: &planpb.Node{
+				NodeType:         planpb.Node_FUNCTION_SCAN,
+				Stats:            &planpb.Stats{},
+				TableDef:         &planpb.TableDef{},
+				IndexReaderParam: &planpb.IndexReaderParam{Limit: makeLimitExprForStatsTest()},
+			},
+			want: false,
+		},
+		{
+			name: "valid",
+			node: makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest()),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isIvfSearchWithLimitNode(tt.node))
+		})
+	}
+}
+
+func TestQueryHasIvfSearchWithLimit_UnhappyPaths(t *testing.T) {
+	require.False(t, queryHasIvfSearchWithLimit(nil))
+	require.False(t, queryHasIvfSearchWithLimit(&planpb.Query{Nodes: []*planpb.Node{nil}}))
+	require.False(t, queryHasIvfSearchWithLimit(&planpb.Query{Nodes: []*planpb.Node{
+		makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, nil),
+	}}))
+	require.True(t, queryHasIvfSearchWithLimit(&planpb.Query{Nodes: []*planpb.Node{
+		makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest()),
+	}}))
+}
+
+func TestIsIvfSearchEntriesScan_UnhappyPaths(t *testing.T) {
+	require.False(t, isIvfSearchEntriesScan(nil, true))
+	require.False(t, isIvfSearchEntriesScan(&planpb.Node{NodeType: planpb.Node_VALUE_SCAN}, true))
+	require.False(t, isIvfSearchEntriesScan(&planpb.Node{
+		NodeType: planpb.Node_TABLE_SCAN,
+		TableDef: &planpb.TableDef{TableType: catalog.Hnsw_TblType_Storage},
+	}, true))
+
+	scanNode := &planpb.Node{
+		NodeType: planpb.Node_TABLE_SCAN,
+		TableDef: &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
+	}
+	require.True(t, isIvfSearchEntriesScan(scanNode, true))
+	require.False(t, isIvfSearchEntriesScan(scanNode, false))
+
+	scanNode.IndexReaderParam = &planpb.IndexReaderParam{
+		Limit:        makeLimitExprForStatsTest(),
+		OrigFuncName: "l2_distance",
+	}
+	require.True(t, isIvfSearchEntriesScan(scanNode, false))
+}
+
+func TestIsIvfEntriesIndexReaderScan_UnhappyPaths(t *testing.T) {
+	require.False(t, isIvfEntriesIndexReaderScan(&planpb.Node{}))
+	require.False(t, isIvfEntriesIndexReaderScan(&planpb.Node{
+		IndexReaderParam: &planpb.IndexReaderParam{Limit: makeLimitExprForStatsTest()},
+	}))
+	require.False(t, isIvfEntriesIndexReaderScan(&planpb.Node{
+		IndexReaderParam: &planpb.IndexReaderParam{OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}}},
+	}))
+	require.True(t, isIvfEntriesIndexReaderScan(&planpb.Node{
+		IndexReaderParam: &planpb.IndexReaderParam{
+			OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}},
+			Limit:   makeLimitExprForStatsTest(),
+		},
+	}))
+	require.True(t, isIvfEntriesIndexReaderScan(&planpb.Node{
+		IndexReaderParam: &planpb.IndexReaderParam{
+			Limit:        makeLimitExprForStatsTest(),
+			OrigFuncName: "l2_distance",
+		},
+	}))
+}
+
+func TestIsIvfSearchEntriesInternalScan(t *testing.T) {
+	tests := []struct {
+		name string
+		node *planpb.Node
+		want bool
+	}{
+		{
+			name: "nil node",
+		},
+		{
+			name: "wrong table type",
+			node: &planpb.Node{
+				NodeType: planpb.Node_TABLE_SCAN,
+				TableDef: &planpb.TableDef{TableType: catalog.Hnsw_TblType_Storage},
+				IndexReaderParam: &planpb.IndexReaderParam{
+					OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}},
+					Limit:   makeLimitExprForStatsTest(),
+				},
+			},
+		},
+		{
+			name: "not table scan",
+			node: &planpb.Node{
+				NodeType: planpb.Node_VALUE_SCAN,
+				TableDef: &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
+				IndexReaderParam: &planpb.IndexReaderParam{
+					OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}},
+					Limit:   makeLimitExprForStatsTest(),
+				},
+			},
+		},
+		{
+			name: "limit only is not internal search",
+			node: &planpb.Node{
+				NodeType:         planpb.Node_TABLE_SCAN,
+				TableDef:         &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
+				IndexReaderParam: &planpb.IndexReaderParam{Limit: makeLimitExprForStatsTest()},
+			},
+		},
+		{
+			name: "valid order by limit",
+			node: &planpb.Node{
+				NodeType: planpb.Node_TABLE_SCAN,
+				TableDef: &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
+				IndexReaderParam: &planpb.IndexReaderParam{
+					OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}},
+					Limit:   makeLimitExprForStatsTest(),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "valid original distance function",
+			node: &planpb.Node{
+				NodeType: planpb.Node_TABLE_SCAN,
+				TableDef: &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
+				IndexReaderParam: &planpb.IndexReaderParam{
+					Limit:        makeLimitExprForStatsTest(),
+					OrigFuncName: "l2_distance",
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsIvfSearchEntriesInternalScan(tt.node))
+		})
 	}
 }
 

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -24,7 +24,6 @@ import (
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
-	ivfflatplan "github.com/matrixorigin/matrixone/pkg/vectorindex/ivfflat/plugin/plan"
 	index2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/stretchr/testify/require"
 )
@@ -326,6 +325,13 @@ func makeFunctionScanForStatsTest(funcName string, limit *planpb.Expr) *planpb.N
 	}
 }
 
+func makeIvfEntriesOrderByLimitParamForStatsTest() *planpb.IndexReaderParam {
+	return &planpb.IndexReaderParam{
+		OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}},
+		Limit:   makeLimitExprForStatsTest(),
+	}
+}
+
 func TestGetExecType_VectorIndex_WideRows_OneCN(t *testing.T) {
 	// rowsize just above threshold, blockNum between oneCN and multiCN thresholds
 	q := makeQueryWithScan(catalog.SystemSI_IVFFLAT_TblType_Entries, float64(RowSizeThreshold+1), LargeBlockThresholdForOneCN+1)
@@ -358,30 +364,28 @@ func TestGetExecType_NonVectorTable_NotForcedByRowsize(t *testing.T) {
 	}
 }
 
-func TestGetExecType_IvfSearchEntries_FunctionSearchUsesMultiCNEvenWithTinyStats(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanUsesMultiCNEvenWithTinyStats(t *testing.T) {
 	q := makeQueryWithScanStats(
 		catalog.SystemSI_IVFFLAT_TblType_Entries,
 		1,
 		1,
 		1,
-		searchNode,
 	)
+	q.Nodes[0].IndexReaderParam = makeIvfEntriesOrderByLimitParamForStatsTest()
 
 	got := GetExecType(q, false, false)
 
 	require.Equal(t, ExecTypeAP_MULTICN, got)
 }
 
-func TestGetExecType_IvfSearchEntries_FunctionSearchDoesNotRequireStatsEstimate(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanDoesNotRequireStatsEstimate(t *testing.T) {
 	q := makeQueryWithScanStats(
 		catalog.SystemSI_IVFFLAT_TblType_Entries,
 		0,
 		0,
 		1,
-		searchNode,
 	)
+	q.Nodes[0].IndexReaderParam = makeIvfEntriesOrderByLimitParamForStatsTest()
 
 	got := GetExecType(q, false, false)
 
@@ -389,29 +393,27 @@ func TestGetExecType_IvfSearchEntries_FunctionSearchDoesNotRequireStatsEstimate(
 }
 
 func TestGetExecType_IvfSearchEntries_RowsizeShortcutDoesNotDowngradeMultiCN(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
 	q := makeQueryWithScanStats(
 		catalog.SystemSI_IVFFLAT_TblType_Entries,
 		float64(RowSizeThreshold+1),
 		1,
 		LargeBlockThresholdForOneCN+1,
-		searchNode,
 	)
+	q.Nodes[0].IndexReaderParam = makeIvfEntriesOrderByLimitParamForStatsTest()
 
 	got := GetExecType(q, false, false)
 
 	require.Equal(t, ExecTypeAP_MULTICN, got)
 }
 
-func TestGetExecType_IvfSearchEntries_SearchMultiCNCappedForDDL(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanMultiCNCappedForDDL(t *testing.T) {
 	q := makeQueryWithScanStats(
 		catalog.SystemSI_IVFFLAT_TblType_Entries,
 		1,
 		1,
 		1,
-		searchNode,
 	)
+	q.Nodes[0].IndexReaderParam = makeIvfEntriesOrderByLimitParamForStatsTest()
 
 	got := GetExecType(q, true, false)
 
@@ -419,13 +421,11 @@ func TestGetExecType_IvfSearchEntries_SearchMultiCNCappedForDDL(t *testing.T) {
 }
 
 func TestGetExecType_IvfSearchEntries_MultiCNCappedForExprBasedShuffle(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
 	q := makeQueryWithScanStats(
 		catalog.SystemSI_IVFFLAT_TblType_Entries,
 		1,
 		1,
 		1,
-		searchNode,
 		&planpb.Node{
 			NodeType: planpb.Node_JOIN,
 			Stats: &planpb.Stats{
@@ -456,6 +456,7 @@ func TestGetExecType_IvfSearchEntries_MultiCNCappedForExprBasedShuffle(t *testin
 			},
 		},
 	)
+	q.Nodes[0].IndexReaderParam = makeIvfEntriesOrderByLimitParamForStatsTest()
 
 	got := GetExecType(q, false, false)
 
@@ -463,104 +464,17 @@ func TestGetExecType_IvfSearchEntries_MultiCNCappedForExprBasedShuffle(t *testin
 }
 
 func TestGetExecType_IvfSearchEntries_MultiCNCappedForDDLEvenWithManyBlocks(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
 	q := makeQueryWithScanStats(
 		catalog.SystemSI_IVFFLAT_TblType_Entries,
 		float64(RowSizeThreshold+1),
 		500*1024,
 		LargeBlockThresholdForMultiCN+1,
-		searchNode,
 	)
+	q.Nodes[0].IndexReaderParam = makeIvfEntriesOrderByLimitParamForStatsTest()
 
 	got := GetExecType(q, true, false)
 
 	require.Equal(t, ExecTypeAP_ONECN, got)
-}
-
-func TestGetExecType_IvfSearchEntries_MultiCNRequiresSearchLimit(t *testing.T) {
-	tests := []struct {
-		name string
-		node *planpb.Node
-	}{
-		{
-			name: "no function scan",
-		},
-		{
-			name: "wrong function",
-			node: makeFunctionScanForStatsTest("not_ivf_search", makeLimitExprForStatsTest()),
-		},
-		{
-			name: "missing limit",
-			node: makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, nil),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var nodes []*planpb.Node
-			if tt.node != nil {
-				nodes = append(nodes, tt.node)
-			}
-			q := makeQueryWithScanStats(
-				catalog.SystemSI_IVFFLAT_TblType_Entries,
-				1,
-				1,
-				1,
-				nodes...,
-			)
-
-			got := GetExecType(q, false, false)
-
-			require.Equal(t, ExecTypeTP, got)
-		})
-	}
-}
-
-func TestGetExecType_IvfSearchEntries_SearchDetectionDoesNotDependOnFunctionScanChildren(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
-	// ivf_search.Children carries the vector provider side for join-through queries,
-	// not the hidden IVF entries table scan.
-	searchNode.Children = []int32{1}
-	q := &planpb.Query{
-		Nodes: []*planpb.Node{
-			{
-				NodeType: planpb.Node_TABLE_SCAN,
-				TableDef: &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
-				Stats: &planpb.Stats{
-					Rowsize:  1,
-					TableCnt: 1,
-					BlockNum: 1,
-				},
-			},
-			{
-				NodeType: planpb.Node_VALUE_SCAN,
-				Stats:    &planpb.Stats{},
-			},
-			searchNode,
-		},
-		Steps: []int32{2},
-	}
-
-	got := GetExecType(q, false, false)
-
-	require.Equal(t, ExecTypeAP_MULTICN, got)
-}
-
-func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanUsesMultiCNEvenWithTinyStats(t *testing.T) {
-	q := makeQueryWithScanStats(
-		catalog.SystemSI_IVFFLAT_TblType_Entries,
-		1,
-		1,
-		1,
-	)
-	q.Nodes[0].IndexReaderParam = &planpb.IndexReaderParam{
-		OrderBy: []*planpb.OrderBySpec{{Expr: &planpb.Expr{}}},
-		Limit:   makeLimitExprForStatsTest(),
-	}
-
-	got := GetExecType(q, false, false)
-
-	require.Equal(t, ExecTypeAP_MULTICN, got)
 }
 
 func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanRequiresSearchShape(t *testing.T) {
@@ -598,10 +512,10 @@ func TestGetExecType_IvfSearchEntries_InternalIndexReaderScanRequiresSearchShape
 	}
 }
 
-func TestGetExecType_IvfSearchMultiCN_DoesNotApplyToOtherTableTypes(t *testing.T) {
-	searchNode := makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest())
+func TestGetExecType_IvfSearchEntries_FunctionScanDoesNotPromoteUnrelatedEntriesScan(t *testing.T) {
+	searchNode := makeFunctionScanForStatsTest("ivf_search", makeLimitExprForStatsTest())
 	q := makeQueryWithScanStats(
-		catalog.Hnsw_TblType_Storage,
+		catalog.SystemSI_IVFFLAT_TblType_Entries,
 		1,
 		1,
 		1,
@@ -613,85 +527,31 @@ func TestGetExecType_IvfSearchMultiCN_DoesNotApplyToOtherTableTypes(t *testing.T
 	require.Equal(t, ExecTypeTP, got)
 }
 
-func TestIsIvfSearchWithLimitNode_UnhappyPaths(t *testing.T) {
-	tests := []struct {
-		name string
-		node *planpb.Node
-		want bool
-	}{
-		{
-			name: "nil node",
-			want: false,
-		},
-		{
-			name: "non function scan",
-			node: &planpb.Node{NodeType: planpb.Node_VALUE_SCAN},
-			want: false,
-		},
-		{
-			name: "nil table def",
-			node: &planpb.Node{
-				NodeType:         planpb.Node_FUNCTION_SCAN,
-				Stats:            &planpb.Stats{},
-				IndexReaderParam: &planpb.IndexReaderParam{Limit: makeLimitExprForStatsTest()},
-			},
-			want: false,
-		},
-		{
-			name: "nil table function",
-			node: &planpb.Node{
-				NodeType:         planpb.Node_FUNCTION_SCAN,
-				Stats:            &planpb.Stats{},
-				TableDef:         &planpb.TableDef{},
-				IndexReaderParam: &planpb.IndexReaderParam{Limit: makeLimitExprForStatsTest()},
-			},
-			want: false,
-		},
-		{
-			name: "valid",
-			node: makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest()),
-			want: true,
-		},
-	}
+func TestGetExecType_IvfSearchMultiCN_DoesNotApplyToOtherTableTypes(t *testing.T) {
+	q := makeQueryWithScanStats(
+		catalog.Hnsw_TblType_Storage,
+		1,
+		1,
+		1,
+	)
+	q.Nodes[0].IndexReaderParam = makeIvfEntriesOrderByLimitParamForStatsTest()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, isIvfSearchWithLimitNode(tt.node))
-		})
-	}
+	got := GetExecType(q, false, false)
+
+	require.Equal(t, ExecTypeTP, got)
 }
 
-func TestQueryHasIvfSearchWithLimit_UnhappyPaths(t *testing.T) {
-	require.False(t, queryHasIvfSearchWithLimit(nil))
-	require.False(t, queryHasIvfSearchWithLimit(&planpb.Query{Nodes: []*planpb.Node{nil}}))
-	require.False(t, queryHasIvfSearchWithLimit(&planpb.Query{Nodes: []*planpb.Node{
-		makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, nil),
-	}}))
-	require.True(t, queryHasIvfSearchWithLimit(&planpb.Query{Nodes: []*planpb.Node{
-		makeFunctionScanForStatsTest(ivfflatplan.IVFFLATSearchFuncName, makeLimitExprForStatsTest()),
-	}}))
-}
-
-func TestIsIvfSearchEntriesScan_UnhappyPaths(t *testing.T) {
-	require.False(t, isIvfSearchEntriesScan(nil, true))
-	require.False(t, isIvfSearchEntriesScan(&planpb.Node{NodeType: planpb.Node_VALUE_SCAN}, true))
-	require.False(t, isIvfSearchEntriesScan(&planpb.Node{
+func TestIsIvfSearchEntriesTableScan_UnhappyPaths(t *testing.T) {
+	require.False(t, isIvfSearchEntriesTableScan(nil))
+	require.False(t, isIvfSearchEntriesTableScan(&planpb.Node{NodeType: planpb.Node_VALUE_SCAN}))
+	require.False(t, isIvfSearchEntriesTableScan(&planpb.Node{
 		NodeType: planpb.Node_TABLE_SCAN,
 		TableDef: &planpb.TableDef{TableType: catalog.Hnsw_TblType_Storage},
-	}, true))
-
-	scanNode := &planpb.Node{
+	}))
+	require.True(t, isIvfSearchEntriesTableScan(&planpb.Node{
 		NodeType: planpb.Node_TABLE_SCAN,
 		TableDef: &planpb.TableDef{TableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
-	}
-	require.True(t, isIvfSearchEntriesScan(scanNode, true))
-	require.False(t, isIvfSearchEntriesScan(scanNode, false))
-
-	scanNode.IndexReaderParam = &planpb.IndexReaderParam{
-		Limit:        makeLimitExprForStatsTest(),
-		OrigFuncName: "l2_distance",
-	}
-	require.True(t, isIvfSearchEntriesScan(scanNode, false))
+	}))
 }
 
 func TestIsIvfEntriesIndexReaderScan_UnhappyPaths(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fix #25454

## What this PR does / why we need it:

This change keeps `ivf_search` entries scans on Multi-CN even when estimated stats are tiny.

It fixes two scheduling regressions in the IVF search path:
- planner side: prevent the vector rowsize shortcut from downgrading an already Multi-CN IVF search decision back to One-CN
- compile side: prevent small internal IVF entries scans from being forced onto the current CN by the generic small-block shortcut

Behavior kept unchanged:
- explicit `ForceOneCN` still wins
- small non-IVF scans still stay on the current CN
- DDL / expr-based shuffle guards still cap execution to One-CN where required

This improves execution stability and CN cache reuse for vector search workloads. It does not change the current object-level dispatch model, so a single-object table can still end up executing on one CN.

## Testing

- `go test ./pkg/sql/plan`
- `go test ./pkg/sql/compile`
- `go build ./pkg/sql/plan ./pkg/sql/compile`
- `go vet ./pkg/sql/plan ./pkg/sql/compile`
- `git diff --check`