### PR TITLE
fix: harden ReadRows whole-result handling in system paths (#25456)

### DIFF
--- a/pkg/bootstrap/service_test.go
+++ b/pkg/bootstrap/service_test.go
@@ -412,7 +412,7 @@ func newBootstrapStringResult(values ...string) executor.Result {
 	memRes := executor.NewMemResult(
 		[]types.Type{types.New(types.T_varchar, 2, 0)},
 		mpool.MustNewZero())
-	memRes.NewBatch()
+	memRes.NewBatchWithRowCount(len(values))
 	executor.AppendStringRows(memRes, 0, values)
 	return memRes.GetResult()
 }
@@ -455,7 +455,7 @@ func TestDoCheckUpgrade(t *testing.T) {
 					memRes := executor.NewMemResult(
 						[]types.Type{types.New(types.T_varchar, 2, 0)},
 						mpool.MustNewZero())
-					memRes.NewBatch()
+					memRes.NewBatchWithRowCount(1)
 					executor.AppendStringRows(memRes, 0, []string{bootstrappedCheckerDB})
 					return memRes.GetResult(), nil
 				}
@@ -470,7 +470,7 @@ func TestDoCheckUpgrade(t *testing.T) {
 					memRes := executor.NewMemResult(
 						typs,
 						mpool.MustNewZero())
-					memRes.NewBatch()
+					memRes.NewBatchWithRowCount(1)
 					executor.AppendStringRows(memRes, 0, []string{"1.2.3"})
 					executor.AppendFixedRows(memRes, 1, []uint32{10})
 					executor.AppendFixedRows(memRes, 2, []int32{0})
@@ -517,7 +517,7 @@ func TestDoCheckUpgrade(t *testing.T) {
 					memRes := executor.NewMemResult(
 						[]types.Type{types.New(types.T_varchar, 2, 0)},
 						mpool.MustNewZero())
-					memRes.NewBatch()
+					memRes.NewBatchWithRowCount(1)
 					executor.AppendStringRows(memRes, 0, []string{bootstrappedCheckerDB})
 					return memRes.GetResult(), nil
 				}
@@ -532,7 +532,7 @@ func TestDoCheckUpgrade(t *testing.T) {
 					memRes := executor.NewMemResult(
 						typs,
 						mpool.MustNewZero())
-					memRes.NewBatch()
+					memRes.NewBatchWithRowCount(1)
 					executor.AppendStringRows(memRes, 0, []string{"2.0.0"})
 					executor.AppendFixedRows(memRes, 1, []uint32{1})
 					executor.AppendFixedRows(memRes, 2, []int32{0})

--- a/pkg/bootstrap/versions/readrows_guard_test.go
+++ b/pkg/bootstrap/versions/readrows_guard_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versions
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSingleRowAcceptsSingleRow(t *testing.T) {
+	result, mp := newSingleStringResult(t, [][]string{{"v1.0.0"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	var got string
+	loaded, rows := readSingleRow(result, func(cols []*vector.Vector) {
+		got = cols[0].GetStringAt(0)
+	})
+	require.True(t, loaded)
+	require.Equal(t, 1, rows)
+	require.Equal(t, "v1.0.0", got)
+}
+
+func TestReadSingleRowCountsRowsAcrossBatches(t *testing.T) {
+	result, mp := newSingleStringResult(t, [][]string{{"v1.0.0"}, {"v2.0.0"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	var got string
+	loaded, rows := readSingleRow(result, func(cols []*vector.Vector) {
+		got = cols[0].GetStringAt(0)
+	})
+	require.True(t, loaded)
+	require.Equal(t, 2, rows)
+	require.Equal(t, "v1.0.0", got)
+}
+
+func newSingleStringResult(t *testing.T, batches [][]string) (executor.Result, *mpool.MPool) {
+	t.Helper()
+
+	mp := mpool.MustNewZero()
+	memRes := executor.NewMemResult([]types.Type{types.T_varchar.ToType()}, mp)
+	for _, batch := range batches {
+		memRes.NewBatchWithRowCount(len(batch))
+		require.NoError(t, executor.AppendStringRows(memRes, 0, batch))
+	}
+	return memRes.GetResult(), mp
+}

--- a/pkg/bootstrap/versions/upgrade_tenant_task.go
+++ b/pkg/bootstrap/versions/upgrade_tenant_task.go
@@ -201,10 +201,12 @@ func GetTenantCreateVersionForUpdate(
 	}
 	defer res.Close()
 	version := ""
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+	_, rows := readSingleRow(res, func(cols []*vector.Vector) {
 		version = cols[0].GetStringAt(0)
-		return true
 	})
+	if rows > 1 {
+		return "", moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", rows))
+	}
 	if version == "" {
 		getLogger(txn.Txn().TxnOptions().CN).Fatal(fmt.Sprintf("BUG: missing tenant: %d", tenantID))
 	}
@@ -244,10 +246,12 @@ func GetTenantVersion(
 	}
 	defer res.Close()
 	version := ""
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+	_, rows := readSingleRow(res, func(cols []*vector.Vector) {
 		version = cols[0].GetStringAt(0)
-		return true
 	})
+	if rows > 1 {
+		return "", moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", rows))
+	}
 	if version == "" {
 		getLogger(txn.Txn().TxnOptions().CN).Fatal(fmt.Sprintf("BUG: missing tenant: %d", tenantID))
 	}

--- a/pkg/bootstrap/versions/version.go
+++ b/pkg/bootstrap/versions/version.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fagongzi/util/format"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 )
@@ -81,12 +82,17 @@ func GetLatestVersion(txn executor.TxnExecutor) (Version, error) {
 	defer res.Close()
 
 	var version Version
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+	loaded, rows := readSingleRow(res, func(cols []*vector.Vector) {
 		version.Version = cols[0].GetStringAt(0)
 		version.VersionOffset = vector.GetFixedAtWithTypeCheck[uint32](cols[1], 0)
 		version.State = vector.GetFixedAtWithTypeCheck[int32](cols[2], 0)
-		return true
 	})
+	if rows > 1 {
+		return Version{}, moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", rows))
+	}
+	if !loaded {
+		return Version{}, nil
+	}
 	return version, nil
 }
 
@@ -101,10 +107,15 @@ func GetLatestUpgradeVersion(txn executor.TxnExecutor) (Version, error) {
 	defer res.Close()
 
 	var version Version
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+	loaded, rows := readSingleRow(res, func(cols []*vector.Vector) {
 		version.Version = cols[0].GetStringAt(0)
-		return true
 	})
+	if rows > 1 {
+		return Version{}, moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", rows))
+	}
+	if !loaded {
+		return Version{}, nil
+	}
 	return version, nil
 }
 
@@ -123,10 +134,12 @@ func MustGetLatestReadyVersion(
 	defer res.Close()
 
 	version := ""
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+	_, rows := readSingleRow(res, func(cols []*vector.Vector) {
 		version = cols[0].GetStringAt(0)
-		return true
 	})
+	if rows > 1 {
+		return "", moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", rows))
+	}
 	if version == "" {
 		getLogger(txn.Txn().TxnOptions().CN).Fatal("missing latest ready version")
 	}
@@ -155,16 +168,11 @@ func GetVersionState(
 	defer res.Close()
 
 	state := int32(0)
-	loaded := false
-	n := 0
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+	loaded, rows := readSingleRow(res, func(cols []*vector.Vector) {
 		state = vector.GetFixedAtWithTypeCheck[int32](cols[0], 0)
-		loaded = true
-		n++
-		return true
 	})
-	if loaded && n > 1 {
-		getLogger(txn.Txn().TxnOptions().CN).Fatal("BUG: missing version " + version)
+	if rows > 1 {
+		getLogger(txn.Txn().TxnOptions().CN).Fatal(fmt.Sprintf("BUG: duplicate version state for %s, rows=%d", version, rows))
 	}
 	return state, loaded, nil
 }
@@ -185,6 +193,22 @@ func UpdateVersionState(
 	}
 	res.Close()
 	return nil
+}
+
+func readSingleRow(res executor.Result, onRow func(cols []*vector.Vector)) (loaded bool, totalRows int) {
+	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		if rows == 0 {
+			return true
+		}
+		totalRows += rows
+		if totalRows > 1 {
+			return false
+		}
+		onRow(cols)
+		loaded = true
+		return true
+	})
+	return
 }
 
 func Compare(v1, v2 string) int {

--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -139,13 +139,7 @@ func (s *sqlStore) Allocate(
 				if err != nil {
 					return err
 				}
-				rows := 0
-				res.ReadRows(func(_ int, cols []*vector.Vector) bool {
-					current = executor.GetFixedRows[uint64](cols[0])[0]
-					step = executor.GetFixedRows[uint64](cols[1])[0]
-					rows++
-					return true
-				})
+				current, step, rows := readSingleOffsetStep(res)
 				res.Close()
 
 				if rows != 1 {
@@ -254,6 +248,23 @@ func (s *sqlStore) Allocate(
 		commitTs = snapshotTs
 	}
 	return from, to, commitTs, nil
+}
+
+func readSingleOffsetStep(res executor.Result) (current, step uint64, rows int) {
+	res.ReadRows(func(batchRows int, cols []*vector.Vector) bool {
+		if batchRows == 0 {
+			return true
+		}
+		offsets := executor.GetFixedRows[uint64](cols[0])
+		steps := executor.GetFixedRows[uint64](cols[1])
+		if rows == 0 {
+			current = offsets[0]
+			step = steps[0]
+		}
+		rows += batchRows
+		return rows < 2
+	})
+	return
 }
 
 func (s *sqlStore) UpdateMinValue(

--- a/pkg/incrservice/store_sql_readrows_test.go
+++ b/pkg/incrservice/store_sql_readrows_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package incrservice
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSingleOffsetStepReturnsSingleRow(t *testing.T) {
+	result, mp := newOffsetStepResult(t, [][]uint64{{10}}, [][]uint64{{2}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	current, step, rows := readSingleOffsetStep(result)
+	require.Equal(t, uint64(10), current)
+	require.Equal(t, uint64(2), step)
+	require.Equal(t, 1, rows)
+}
+
+func TestReadSingleOffsetStepCountsRowsAcrossBatches(t *testing.T) {
+	result, mp := newOffsetStepResult(t, [][]uint64{{10}, {20}}, [][]uint64{{2}, {4}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	current, step, rows := readSingleOffsetStep(result)
+	require.Equal(t, uint64(10), current)
+	require.Equal(t, uint64(2), step)
+	require.Equal(t, 2, rows)
+}
+
+func newOffsetStepResult(t *testing.T, offsetBatches, stepBatches [][]uint64) (executor.Result, *mpool.MPool) {
+	t.Helper()
+	require.Len(t, offsetBatches, len(stepBatches))
+
+	mp := mpool.MustNewZero()
+	memRes := executor.NewMemResult([]types.Type{types.T_uint64.ToType(), types.T_uint64.ToType()}, mp)
+	for i := range offsetBatches {
+		require.Len(t, offsetBatches[i], len(stepBatches[i]))
+		memRes.NewBatchWithRowCount(len(offsetBatches[i]))
+		require.NoError(t, executor.AppendFixedRows(memRes, 0, offsetBatches[i]))
+		require.NoError(t, executor.AppendFixedRows(memRes, 1, stepBatches[i]))
+	}
+	return memRes.GetResult(), mp
+}

--- a/pkg/incrservice/store_sql_test.go
+++ b/pkg/incrservice/store_sql_test.go
@@ -400,7 +400,7 @@ func Test_Allocate(t *testing.T) {
 						memRes := executor.NewMemResult(
 							typs,
 							mpool.MustNewZero())
-						memRes.NewBatch()
+						memRes.NewBatchWithRowCount(1)
 						executor.AppendFixedRows(memRes, 0, []uint64{1})
 						executor.AppendFixedRows(memRes, 1, []uint64{1})
 						return memRes.GetResult(), nil
@@ -458,7 +458,7 @@ func TestAllocateWithEmptyCommitTS(t *testing.T) {
 						memRes := executor.NewMemResult(
 							typs,
 							mpool.MustNewZero())
-						memRes.NewBatch()
+						memRes.NewBatchWithRowCount(1)
 						executor.AppendFixedRows(memRes, 0, []uint64{1})
 						executor.AppendFixedRows(memRes, 1, []uint64{1})
 						return memRes.GetResult(), nil
@@ -519,7 +519,7 @@ func TestAllocateWithValidCommitTS(t *testing.T) {
 						memRes := executor.NewMemResult(
 							typs,
 							mpool.MustNewZero())
-						memRes.NewBatch()
+						memRes.NewBatchWithRowCount(1)
 						executor.AppendFixedRows(memRes, 0, []uint64{1})
 						executor.AppendFixedRows(memRes, 1, []uint64{1})
 						return memRes.GetResult(), nil
@@ -584,7 +584,7 @@ func Test_Allocate_Retry_When_Rows_Count_Invalid(t *testing.T) {
 				memRes := executor.NewMemResult(
 					typs,
 					mpool.MustNewZero())
-				memRes.NewBatch()
+				memRes.NewBatchWithRowCount(1)
 				executor.AppendFixedRows(memRes, 0, []uint64{1})
 				executor.AppendFixedRows(memRes, 1, []uint64{1})
 				return memRes.GetResult(), nil
@@ -630,7 +630,7 @@ func Test_Allocate_Retry_When_AffectedRows_Invalid(t *testing.T) {
 				memRes := executor.NewMemResult(
 					typs,
 					mpool.MustNewZero())
-				memRes.NewBatch()
+				memRes.NewBatchWithRowCount(1)
 				executor.AppendFixedRows(memRes, 0, []uint64{1})
 				executor.AppendFixedRows(memRes, 1, []uint64{1})
 				return memRes.GetResult(), nil

--- a/pkg/iscp/iteration.go
+++ b/pkg/iscp/iteration.go
@@ -670,7 +670,13 @@ var GetJobSpecs = func(
 	return
 }
 
-var errPermanent = errors.New("permanent error")
+type permanentError struct{}
+
+func (permanentError) Error() string {
+	return "permanent error"
+}
+
+var errPermanent error = permanentError{}
 
 func FlushPermanentErrorMessage(
 	ctx context.Context,
@@ -716,7 +722,8 @@ func FlushPermanentErrorMessage(
 }
 
 func isPermanentError(err error) bool {
-	return err != nil && (errors.Is(err, errPermanent) || err.Error() == errPermanent.Error())
+	var target permanentError
+	return errors.As(err, &target)
 }
 
 func (status *JobStatus) SetError(err error) {

--- a/pkg/iscp/iteration.go
+++ b/pkg/iscp/iteration.go
@@ -102,6 +102,9 @@ func ExecuteIteration(
 		iterCtx.jobIDs,
 	)
 	if err != nil {
+		if isPermanentError(err) {
+			return nil
+		}
 		return
 	}
 	preLSN := make([]uint64, len(iterCtx.jobNames))
@@ -476,7 +479,7 @@ var FlushJobStatusOnIterationState = func(
 	state int8,
 	prevLSN []uint64,
 ) (err error) {
-
+	jobStatuses = normalizeJobStatuses(jobStatuses, lsns)
 	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
@@ -502,7 +505,6 @@ var FlushJobStatusOnIterationState = func(
 		}
 	}()
 	for i := range jobNames {
-		jobStatuses[i].LSN = lsns[i]
 		err = FlushStatus(
 			ctx,
 			cnUUID,
@@ -558,6 +560,21 @@ func FlushStatus(
 	return
 }
 
+func normalizeJobStatuses(jobStatuses []*JobStatus, lsns []uint64) []*JobStatus {
+	if len(jobStatuses) != len(lsns) {
+		normalized := make([]*JobStatus, len(lsns))
+		copy(normalized, jobStatuses)
+		jobStatuses = normalized
+	}
+	for i := range lsns {
+		if jobStatuses[i] == nil {
+			jobStatuses[i] = &JobStatus{}
+		}
+		jobStatuses[i].LSN = lsns[i]
+	}
+	return jobStatuses
+}
+
 var GetJobSpecs = func(
 	ctx context.Context,
 	cnUUID string,
@@ -573,7 +590,7 @@ var GetJobSpecs = func(
 	jobIDs []uint64,
 ) (jobSpec []*JobSpec, prevStatus []*JobStatus, err error) {
 	var buf bytes.Buffer
-	buf.WriteString("SELECT job_spec, job_status FROM mo_catalog.mo_iscp_log WHERE")
+	buf.WriteString("SELECT job_name, job_id, job_spec, job_status FROM mo_catalog.mo_iscp_log WHERE")
 	for i, jobName := range jobName {
 		if i > 0 {
 			buf.WriteString(" OR")
@@ -591,41 +608,69 @@ var GetJobSpecs = func(
 		prevLSNs[i] = lsns[i] - 1
 	}
 	defer execResult.Close()
+	expectedJobs := make(map[JobKey]int, len(jobName))
+	for i := range jobName {
+		expectedJobs[JobKey{JobName: jobName[i], JobID: jobIDs[i]}] = i
+	}
 	jobSpec = make([]*JobSpec, len(jobName))
 	prevStatus = make([]*JobStatus, len(jobName))
+	var foundRows int
+	var permanentErrMsg string
 	execResult.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		if rows != len(jobName) {
-			errMsg := fmt.Sprintf("invalid rows %d, expected %d", rows, len(jobName))
-			FlushPermanentErrorMessage(
-				ctx,
-				cnUUID,
-				cnEngine,
-				cnTxnClient,
-				tenantId,
-				tableID,
-				jobName,
-				jobIDs,
-				lsns,
-				jobStatuses,
-				types.MaxTs(),
-				errMsg,
-				prevLSNs,
-			)
-		}
+		currentJobNames := executor.GetStringRows(cols[0])
+		currentJobIDs := vector.MustFixedColWithTypeCheck[uint64](cols[1])
 		for i := 0; i < rows; i++ {
-			jobSpec[i], err = UnmarshalJobSpec([]byte(cols[0].GetStringAt(i)))
-			if err != nil {
+			jobIdx, ok := expectedJobs[JobKey{JobName: currentJobNames[i], JobID: currentJobIDs[i]}]
+			if !ok {
+				permanentErrMsg = fmt.Sprintf("unexpected job %s/%d", currentJobNames[i], currentJobIDs[i])
 				return false
 			}
-			prevStatus[i], err = UnmarshalJobStatus([]byte(cols[1].GetStringAt(i)))
-			if err != nil {
+			if jobSpec[jobIdx] != nil || prevStatus[jobIdx] != nil {
+				permanentErrMsg = fmt.Sprintf("duplicate job %s/%d", currentJobNames[i], currentJobIDs[i])
 				return false
 			}
+			jobSpec[jobIdx], err = UnmarshalJobSpec([]byte(cols[2].GetStringAt(i)))
+			if err != nil {
+				permanentErrMsg = err.Error()
+				return false
+			}
+			prevStatus[jobIdx], err = UnmarshalJobStatus([]byte(cols[3].GetStringAt(i)))
+			if err != nil {
+				permanentErrMsg = err.Error()
+				return false
+			}
+			foundRows++
 		}
 		return true
 	})
+	if permanentErrMsg == "" && foundRows != len(jobName) {
+		permanentErrMsg = fmt.Sprintf("invalid rows %d, expected %d", foundRows, len(jobName))
+	}
+	if permanentErrMsg != "" {
+		err = FlushPermanentErrorMessage(
+			ctx,
+			cnUUID,
+			cnEngine,
+			cnTxnClient,
+			tenantId,
+			tableID,
+			jobName,
+			jobIDs,
+			lsns,
+			jobStatuses,
+			types.MaxTs(),
+			permanentErrMsg,
+			prevLSNs,
+		)
+		if err == nil {
+			err = errPermanent
+		}
+		return nil, nil, err
+	}
 	return
 }
+
+var errPermanent = errors.New("permanent error")
 
 func FlushPermanentErrorMessage(
 	ctx context.Context,
@@ -652,6 +697,7 @@ func FlushPermanentErrorMessage(
 	)
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
+	jobStatuses = normalizeJobStatuses(jobStatuses, lsns)
 	return FlushJobStatusOnIterationState(
 		ctx,
 		cnUUID,
@@ -669,9 +715,8 @@ func FlushPermanentErrorMessage(
 	)
 }
 
-// TODO
 func isPermanentError(err error) bool {
-	return err.Error() == "permanent error"
+	return err != nil && (errors.Is(err, errPermanent) || err.Error() == errPermanent.Error())
 }
 
 func (status *JobStatus) SetError(err error) {

--- a/pkg/iscp/iteration_test.go
+++ b/pkg/iscp/iteration_test.go
@@ -1,0 +1,209 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iscp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/stretchr/testify/require"
+)
+
+type iscpLogBatch struct {
+	jobNames   []string
+	jobIDs     []uint64
+	jobSpecs   []string
+	jobStatuss []string
+}
+
+func TestGetJobSpecsReadsAcrossBatchesAndMatchesJobsByKey(t *testing.T) {
+	oldExecWithResult := ExecWithResult
+	defer func() {
+		ExecWithResult = oldExecWithResult
+	}()
+
+	result, mp := newISCPLogResult(t, []iscpLogBatch{
+		{
+			jobNames:   []string{"index_idx02"},
+			jobIDs:     []uint64{2},
+			jobSpecs:   []string{mustMarshalJobSpec(t, "idx02")},
+			jobStatuss: []string{mustMarshalJobStatus(t, 22, JobStage_Running)},
+		},
+		{
+			jobNames:   []string{"index_idx01"},
+			jobIDs:     []uint64{3},
+			jobSpecs:   []string{mustMarshalJobSpec(t, "idx01")},
+			jobStatuss: []string{mustMarshalJobStatus(t, 33, JobStage_Init)},
+		},
+	})
+	defer func() {
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	ExecWithResult = func(context.Context, string, string, client.TxnOperator) (executor.Result, error) {
+		return result, nil
+	}
+
+	jobSpecs, prevStatuses, err := GetJobSpecs(
+		context.Background(),
+		"",
+		nil,
+		nil,
+		nil,
+		0,
+		42,
+		[]string{"index_idx01", "index_idx02"},
+		[]uint64{101, 202},
+		types.TS{},
+		[]*JobStatus{{}, {}},
+		[]uint64{3, 2},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "idx01", jobSpecs[0].IndexName)
+	require.Equal(t, "idx02", jobSpecs[1].IndexName)
+	require.Equal(t, uint64(33), prevStatuses[0].LSN)
+	require.Equal(t, uint64(22), prevStatuses[1].LSN)
+}
+
+func TestGetJobSpecsMissingJobFlushesPermanentErrorWithoutNilStatuses(t *testing.T) {
+	oldExecWithResult := ExecWithResult
+	oldFlushJobStatusOnIterationState := FlushJobStatusOnIterationState
+	defer func() {
+		ExecWithResult = oldExecWithResult
+		FlushJobStatusOnIterationState = oldFlushJobStatusOnIterationState
+	}()
+
+	result, mp := newISCPLogResult(t, []iscpLogBatch{
+		{
+			jobNames:   []string{"index_idx02"},
+			jobIDs:     []uint64{2},
+			jobSpecs:   []string{mustMarshalJobSpec(t, "idx02")},
+			jobStatuss: []string{mustMarshalJobStatus(t, 22, JobStage_Running)},
+		},
+	})
+	defer func() {
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	ExecWithResult = func(context.Context, string, string, client.TxnOperator) (executor.Result, error) {
+		return result, nil
+	}
+
+	var capturedStatuses []*JobStatus
+	FlushJobStatusOnIterationState = func(
+		_ context.Context,
+		_ string,
+		_ engine.Engine,
+		_ client.TxnClient,
+		_ uint32,
+		_ uint64,
+		_ []string,
+		_ []uint64,
+		_ []uint64,
+		jobStatuses []*JobStatus,
+		_ types.TS,
+		_ int8,
+		_ []uint64,
+	) error {
+		capturedStatuses = jobStatuses
+		return nil
+	}
+
+	_, _, err := GetJobSpecs(
+		context.Background(),
+		"",
+		nil,
+		nil,
+		nil,
+		0,
+		42,
+		[]string{"index_idx01", "index_idx02"},
+		[]uint64{101, 202},
+		types.TS{},
+		make([]*JobStatus, 2),
+		[]uint64{3, 2},
+	)
+	require.Error(t, err)
+	require.True(t, isPermanentError(err))
+	require.Len(t, capturedStatuses, 2)
+	require.NotNil(t, capturedStatuses[0])
+	require.NotNil(t, capturedStatuses[1])
+	require.Equal(t, uint64(101), capturedStatuses[0].LSN)
+	require.Equal(t, uint64(202), capturedStatuses[1].LSN)
+}
+
+func newISCPLogResult(t *testing.T, batches []iscpLogBatch) (executor.Result, *mpool.MPool) {
+	t.Helper()
+
+	mp := mpool.MustNewZero()
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.T_varchar.ToType(),
+			types.T_uint64.ToType(),
+			types.T_json.ToType(),
+			types.T_json.ToType(),
+		},
+		mp,
+	)
+	for _, batch := range batches {
+		memRes.NewBatchWithRowCount(len(batch.jobNames))
+		require.NoError(t, executor.AppendStringRows(memRes, 0, batch.jobNames))
+		require.NoError(t, executor.AppendFixedRows(memRes, 1, batch.jobIDs))
+		require.NoError(t, executor.AppendBytesRows(memRes, 2, encodeJSONRows(t, batch.jobSpecs)))
+		require.NoError(t, executor.AppendBytesRows(memRes, 3, encodeJSONRows(t, batch.jobStatuss)))
+	}
+	return memRes.GetResult(), mp
+}
+
+func mustMarshalJobSpec(t *testing.T, indexName string) string {
+	t.Helper()
+	jobSpec, err := MarshalJobSpec(&JobSpec{
+		ConsumerInfo: ConsumerInfo{
+			IndexName: indexName,
+		},
+	})
+	require.NoError(t, err)
+	return jobSpec
+}
+
+func mustMarshalJobStatus(t *testing.T, lsn uint64, stage int8) string {
+	t.Helper()
+	jobStatus, err := json.Marshal(&JobStatus{
+		LSN:   lsn,
+		Stage: stage,
+	})
+	require.NoError(t, err)
+	return string(jobStatus)
+}
+
+func encodeJSONRows(t *testing.T, rows []string) [][]byte {
+	t.Helper()
+	encodedRows := make([][]byte, len(rows))
+	for i, row := range rows {
+		byteJSON, err := types.ParseStringToByteJson(row)
+		require.NoError(t, err)
+		encodedRows[i], err = types.EncodeJson(byteJSON)
+		require.NoError(t, err)
+	}
+	return encodedRows
+}

--- a/pkg/iscp/util.go
+++ b/pkg/iscp/util.go
@@ -39,6 +39,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
@@ -445,26 +446,43 @@ func checkLease(
 		return
 	}
 	defer result.Close()
-	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		if rows != 1 {
-			err = moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", rows))
-			return false
-		}
-		runner := cols[0].GetStringAt(0)
-		if runner == "" {
-			err = moerr.NewInternalErrorNoCtx("task runner is null")
-			return false
-		}
-		if runner == cnUUID {
-			ok = true
-		} else {
-			logutil.Errorf(
-				"ISCP-Task check lease failed, runner: %s, expected: %s",
-				runner,
-				cnUUID,
-			)
-		}
-		return false
-	})
+	var runner string
+	runner, err = readSingleTaskRunner(result)
+	if err != nil {
+		return
+	}
+	if runner == "" {
+		return
+	}
+	if runner == cnUUID {
+		ok = true
+	} else {
+		logutil.Errorf(
+			"ISCP-Task check lease failed, runner: %s, expected: %s",
+			runner,
+			cnUUID,
+		)
+	}
 	return
+}
+
+func readSingleTaskRunner(result executor.Result) (string, error) {
+	runners := make([]string, 0, 1)
+	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		if rows == 0 {
+			return true
+		}
+		runners = append(runners, executor.GetStringRows(cols[0])...)
+		return len(runners) < 2
+	})
+	if len(runners) == 0 {
+		return "", nil
+	}
+	if len(runners) != 1 {
+		return "", moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", len(runners)))
+	}
+	if runners[0] == "" {
+		return "", moerr.NewInternalErrorNoCtx("task runner is null")
+	}
+	return runners[0], nil
 }

--- a/pkg/iscp/util_readrows_test.go
+++ b/pkg/iscp/util_readrows_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iscp
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSingleTaskRunnerAcceptsSingleRunner(t *testing.T) {
+	result, mp := newTaskRunnerResult(t, [][]string{{"cn0"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	runner, err := readSingleTaskRunner(result)
+	require.NoError(t, err)
+	require.Equal(t, "cn0", runner)
+}
+
+func TestReadSingleTaskRunnerCountsRowsAcrossBatches(t *testing.T) {
+	result, mp := newTaskRunnerResult(t, [][]string{{"cn0"}, {"cn1"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	runner, err := readSingleTaskRunner(result)
+	require.Error(t, err)
+	require.Empty(t, runner)
+	require.Contains(t, err.Error(), "unexpected rows count: 2")
+}
+
+func newTaskRunnerResult(t *testing.T, batches [][]string) (executor.Result, *mpool.MPool) {
+	t.Helper()
+
+	mp := mpool.MustNewZero()
+	memRes := executor.NewMemResult([]types.Type{types.T_varchar.ToType()}, mp)
+	for _, batch := range batches {
+		memRes.NewBatchWithRowCount(len(batch))
+		require.NoError(t, executor.AppendStringRows(memRes, 0, batch))
+	}
+	return memRes.GetResult(), mp
+}

--- a/pkg/iscp/watermark_updater.go
+++ b/pkg/iscp/watermark_updater.go
@@ -621,15 +621,18 @@ func getTableID(
 		return
 	}
 	defer result.Close()
+	totalRows := 0
 	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		if rows != 1 {
-			err = moerr.NewInternalErrorNoCtx(fmt.Sprintf("invalid rows %d", rows))
+		if rows == 0 {
+			return true
+		}
+		totalRows += rows
+		if totalRows > 1 {
+			err = moerr.NewInternalErrorNoCtx(fmt.Sprintf("invalid rows %d", totalRows))
 			return false
 		}
-		for i := 0; i < rows; i++ {
-			tableID = vector.MustFixedColWithTypeCheck[uint64](cols[0])[i]
-			dbID = vector.MustFixedColWithTypeCheck[uint64](cols[1])[i]
-		}
+		tableID = vector.MustFixedColWithTypeCheck[uint64](cols[0])[0]
+		dbID = vector.MustFixedColWithTypeCheck[uint64](cols[1])[0]
 		return true
 	})
 	if err != nil {

--- a/pkg/iscp/watermark_updater_readrows_test.go
+++ b/pkg/iscp/watermark_updater_readrows_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iscp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTableIDCountsRowsAcrossBatches(t *testing.T) {
+	oldExecWithResult := ExecWithResult
+	defer func() {
+		ExecWithResult = oldExecWithResult
+	}()
+
+	result, mp := newTableIDResult(t, [][]uint64{{10}, {20}}, [][]uint64{{100}, {200}})
+	defer func() {
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	ExecWithResult = func(context.Context, string, string, client.TxnOperator) (executor.Result, error) {
+		return result, nil
+	}
+
+	_, _, err := getTableID(context.Background(), "", nil, 0, "db", "tbl")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid rows 2")
+}
+
+func newTableIDResult(t *testing.T, tableIDBatches, dbIDBatches [][]uint64) (executor.Result, *mpool.MPool) {
+	t.Helper()
+	require.Len(t, tableIDBatches, len(dbIDBatches))
+
+	mp := mpool.MustNewZero()
+	memRes := executor.NewMemResult([]types.Type{types.T_uint64.ToType(), types.T_uint64.ToType()}, mp)
+	for i := range tableIDBatches {
+		require.Len(t, tableIDBatches[i], len(dbIDBatches[i]))
+		memRes.NewBatchWithRowCount(len(tableIDBatches[i]))
+		require.NoError(t, executor.AppendFixedRows(memRes, 0, tableIDBatches[i]))
+		require.NoError(t, executor.AppendFixedRows(memRes, 1, dbIDBatches[i]))
+	}
+	return memRes.GetResult(), mp
+}

--- a/pkg/publication/util.go
+++ b/pkg/publication/util.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
@@ -75,26 +76,43 @@ func checkLease(
 		return
 	}
 	defer result.Close()
-	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		if rows != 1 {
-			err = moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", rows))
-			return false
-		}
-		runner := cols[0].GetStringAt(0)
-		if runner == "" {
-			err = moerr.NewInternalErrorNoCtx("task runner is null")
-			return false
-		}
-		if runner == cnUUID {
-			ok = true
-		} else {
-			logutil.Errorf(
-				"Publication-Task check lease failed, runner: %s, expected: %s",
-				runner,
-				cnUUID,
-			)
-		}
-		return false
-	})
+	var runner string
+	runner, err = readSingleTaskRunner(result)
+	if err != nil {
+		return
+	}
+	if runner == "" {
+		return
+	}
+	if runner == cnUUID {
+		ok = true
+	} else {
+		logutil.Errorf(
+			"Publication-Task check lease failed, runner: %s, expected: %s",
+			runner,
+			cnUUID,
+		)
+	}
 	return
+}
+
+func readSingleTaskRunner(result executor.Result) (string, error) {
+	runners := make([]string, 0, 1)
+	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		if rows == 0 {
+			return true
+		}
+		runners = append(runners, executor.GetStringRows(cols[0])...)
+		return len(runners) < 2
+	})
+	if len(runners) == 0 {
+		return "", nil
+	}
+	if len(runners) != 1 {
+		return "", moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", len(runners)))
+	}
+	if runners[0] == "" {
+		return "", moerr.NewInternalErrorNoCtx("task runner is null")
+	}
+	return runners[0], nil
 }

--- a/pkg/publication/util_readrows_test.go
+++ b/pkg/publication/util_readrows_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publication
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSingleTaskRunnerAcceptsSingleRunner(t *testing.T) {
+	result, mp := newTaskRunnerResult(t, [][]string{{"cn0"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	runner, err := readSingleTaskRunner(result)
+	require.NoError(t, err)
+	require.Equal(t, "cn0", runner)
+}
+
+func TestReadSingleTaskRunnerCountsRowsAcrossBatches(t *testing.T) {
+	result, mp := newTaskRunnerResult(t, [][]string{{"cn0"}, {"cn1"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	runner, err := readSingleTaskRunner(result)
+	require.Error(t, err)
+	require.Empty(t, runner)
+	require.Contains(t, err.Error(), "unexpected rows count: 2")
+}
+
+func newTaskRunnerResult(t *testing.T, batches [][]string) (executor.Result, *mpool.MPool) {
+	t.Helper()
+
+	mp := mpool.MustNewZero()
+	memRes := executor.NewMemResult([]types.Type{types.T_varchar.ToType()}, mp)
+	for _, batch := range batches {
+		memRes.NewBatchWithRowCount(len(batch))
+		require.NoError(t, executor.AppendStringRows(memRes, 0, batch))
+	}
+	return memRes.GetResult(), mp
+}

--- a/pkg/sql/plan/function/func_feature_upsert.go
+++ b/pkg/sql/plan/function/func_feature_upsert.go
@@ -77,7 +77,7 @@ func moFeatureEscapeSQLString(s string) string {
 func moFeatureRegistryQueryOne(exec executor.SQLExecutor, proc *process.Process, featureCode string) (*featureRegistryRow, error) {
 	featureCode = strings.ToUpper(strings.TrimSpace(featureCode))
 	sql := fmt.Sprintf(
-		"select feature_code, description, scope_spec, enabled from %s.%s where feature_code = '%s'",
+		"select feature_code, description, scope_spec, enabled from %s.%s where feature_code = '%s' limit 2",
 		moCatalog, catalog.MO_FEATURE_REGISTRY, moFeatureEscapeSQLString(featureCode),
 	)
 	res, err := exec.Exec(proc.Ctx, sql, moFeatureInternalExecOpts(proc))
@@ -90,11 +90,7 @@ func moFeatureRegistryQueryOne(exec executor.SQLExecutor, proc *process.Process,
 		found bool
 		row   featureRegistryRow
 	)
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		if rows <= 0 {
-			return true
-		}
-		found = true
+	found, err = readSingleResultRow(res, func(cols []*vector.Vector) {
 		row.FeatureCode = string(cols[0].GetBytesAt(0))
 		row.Description = string(cols[1].GetBytesAt(0))
 		scopeSpecBytes := cols[2].GetBytesAt(0)
@@ -108,8 +104,10 @@ func moFeatureRegistryQueryOne(exec executor.SQLExecutor, proc *process.Process,
 		}
 		row.ScopeSpec = append(row.ScopeSpec[:0], scopeSpecBytes...)
 		row.Enabled = vector.GetFixedAtNoTypeCheck[bool](cols[3], 0)
-		return true
 	})
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, nil
 	}
@@ -119,7 +117,7 @@ func moFeatureRegistryQueryOne(exec executor.SQLExecutor, proc *process.Process,
 func moFeatureLimitQueryOne(exec executor.SQLExecutor, proc *process.Process, accountID int64, featureCode, scope string) (*featureLimitRow, error) {
 	featureCode = strings.ToUpper(strings.TrimSpace(featureCode))
 	sql := fmt.Sprintf(
-		"select quota from %s.%s where account_id = %d and feature_code = '%s' and scope = '%s'",
+		"select quota from %s.%s where account_id = %d and feature_code = '%s' and scope = '%s' limit 2",
 		moCatalog,
 		catalog.MO_FEATURE_LIMIT,
 		accountID,
@@ -136,21 +134,37 @@ func moFeatureLimitQueryOne(exec executor.SQLExecutor, proc *process.Process, ac
 		found bool
 		row   featureLimitRow
 	)
-	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		if rows <= 0 {
-			return true
-		}
-		found = true
+	found, err = readSingleResultRow(res, func(cols []*vector.Vector) {
 		row.AccountID = accountID
 		row.FeatureCode = featureCode
 		row.Scope = scope
 		row.Quota = vector.GetFixedAtNoTypeCheck[int64](cols[0], 0)
-		return true
 	})
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, nil
 	}
 	return &row, nil
+}
+
+func readSingleResultRow(res executor.Result, onRow func(cols []*vector.Vector)) (found bool, err error) {
+	totalRows := 0
+	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		if rows == 0 {
+			return true
+		}
+		totalRows += rows
+		if totalRows > 1 {
+			err = moerr.NewInternalErrorNoCtx(fmt.Sprintf("unexpected rows count: %d", totalRows))
+			return false
+		}
+		onRow(cols)
+		found = true
+		return true
+	})
+	return
 }
 
 func moFeatureRequireSysAccount(proc *process.Process) error {

--- a/pkg/sql/plan/function/func_feature_upsert_readrows_test.go
+++ b/pkg/sql/plan/function/func_feature_upsert_readrows_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSingleResultRowAcceptsSingleRow(t *testing.T) {
+	result, mp := newFeatureSingleRowResult(t, [][]string{{"feature-a"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	var got string
+	found, err := readSingleResultRow(result, func(cols []*vector.Vector) {
+		got = string(cols[0].GetBytesAt(0))
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "feature-a", got)
+}
+
+func TestReadSingleResultRowCountsRowsAcrossBatches(t *testing.T) {
+	result, mp := newFeatureSingleRowResult(t, [][]string{{"feature-a"}, {"feature-b"}})
+	defer func() {
+		result.Close()
+		require.Equal(t, int64(0), mp.CurrNB())
+		mpool.DeleteMPool(mp)
+	}()
+
+	found, err := readSingleResultRow(result, func(cols []*vector.Vector) {})
+	require.Error(t, err)
+	require.True(t, found)
+	require.Contains(t, err.Error(), "unexpected rows count: 2")
+}
+
+func newFeatureSingleRowResult(t *testing.T, batches [][]string) (executor.Result, *mpool.MPool) {
+	t.Helper()
+
+	mp := mpool.MustNewZero()
+	memRes := executor.NewMemResult([]types.Type{types.T_varchar.ToType()}, mp)
+	for _, batch := range batches {
+		memRes.NewBatchWithRowCount(len(batch))
+		require.NoError(t, executor.AppendStringRows(memRes, 0, batch))
+	}
+	return memRes.GetResult(), mp
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #25456

## What this PR does / why we need it:

This PR fixes a real bug class in internal SQL readers that use
`executor.Result.ReadRows`.

`ReadRows` is batch-oriented: the callback may be invoked multiple times, once
per batch. Several production paths were assuming callback-local `rows`
described the whole result set, which caused two different failure modes:

1. **False/fragile row-count checks**
   - treating per-batch row counts as whole-result counts
   - counting callbacks instead of total rows

2. **State corruption / crash on unhappy paths**
   - ISCP `GetJobSpecs()` treated a multi-batch result as a missing-row error
   - the permanent-error flush path then dereferenced nil `JobStatus` entries
   - in vector HNSW CI this crashed a CN and surfaced later as
     `backend connection closed`

### Fixes in this PR

#### 1. ISCP multi-job status loading
- `pkg/iscp/iteration.go`
- load `job_name` and `job_id` together with `job_spec` / `job_status`
- accumulate across all `ReadRows` batches
- map rows by `JobKey` instead of per-batch positional assumptions
- normalize nil `JobStatus` slices before permanent-error flushing
- stop the local execution path cleanly once a permanent error has already been flushed

#### 2. System-path whole-result row counting
- `pkg/iscp/util.go`
- `pkg/publication/util.go`
- `pkg/incrservice/store_sql.go`

These paths now validate total rows across all batches instead of using
callback-local `rows`.

#### 3. Additional single-row hardening
- `pkg/iscp/watermark_updater.go`
- `pkg/sql/plan/function/func_feature_upsert.go`
- `pkg/bootstrap/versions/version.go`
- `pkg/bootstrap/versions/upgrade_tenant_task.go`

These readers now use whole-result semantics for single-row contracts. Where a
duplicate row would represent a terminal invariant break (for example version
state lookup), the code remains fail-fast.

### Tests
- Added focused regression tests for:
  - multi-batch `ReadRows` handling in ISCP job loading
  - nil `JobStatus` permanent-error flushing
  - single-row task-runner readers across batches
  - incrservice offset/step readers across batches
  - ISCP `getTableID()` across batches
  - feature-upsert single-row readers across batches
  - bootstrap/version single-row helper behavior

### Why this matters
The visible CI failure happened in vector HNSW BVT, but the root cause was a
broader internal-reader bug class. Fixing only the panic site would still leave
other internal paths batch-sensitive and fragile. This PR closes the root cause
and hardens the nearby production readers that use the same pattern.
