### PR TITLE
fix(lockservice): release forwarded txn before async wait

### DIFF
--- a/pkg/lockservice/service_forward_test.go
+++ b/pkg/lockservice/service_forward_test.go
@@ -59,6 +59,53 @@ func TestForwardLock(t *testing.T) {
 	)
 }
 
+func TestForwardLockWaiterCanResumeAfterConflict(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1", "s2"},
+		func(alloc *lockTableAllocator, s []*service) {
+			tableID := uint64(10)
+
+			l1 := s[0]
+			l2 := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			_, err := l2.getLockTableWithCreate(0, tableID, nil, pb.Sharding_None)
+			require.NoError(t, err)
+
+			holderTxn := []byte("holder")
+			waiterTxn := []byte("waiter")
+			row := []byte{1}
+
+			mustAddTestLock(t, ctx, l2, tableID, holderTxn, [][]byte{row}, pb.Granularity_Row)
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := l1.Lock(ctx, tableID, [][]byte{row}, waiterTxn, pb.LockOptions{
+					Granularity: pb.Granularity_Row,
+					Mode:        pb.LockMode_Exclusive,
+					Policy:      pb.WaitPolicy_Wait,
+					ForwardTo:   "s2",
+				})
+				done <- err
+			}()
+
+			waitWaiters(t, l2, tableID, row, 1)
+			require.NoError(t, l2.Unlock(ctx, holderTxn, timestamp.Timestamp{}))
+
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(time.Second * 3):
+				t.Fatal("forward lock waiter did not resume after holder unlock")
+			}
+
+			require.NoError(t, l1.Unlock(ctx, waiterTxn, timestamp.Timestamp{}))
+		},
+	)
+}
+
 func TestDeadLockWithForward(t *testing.T) {
 	runLockServiceTests(
 		t,

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -268,13 +268,12 @@ func (s *service) handleForwardLock(
 	s.activeTxnHolder.keepRemoteLockBindActive(req.Lock.ServiceID, req.LockTable)
 	txn := s.activeTxnHolder.getActiveTxn(req.Lock.TxnID, true, req.Lock.ServiceID)
 	txn.Lock()
+	defer txn.Unlock()
 	if !bytes.Equal(txn.txnID, req.Lock.TxnID) {
-		txn.Unlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrTxnNotFound, cs, defaultRPCWriteTimeout, remoteLockResponseLogFields(req))
 		return
 	}
 	if txn.deadlockFound {
-		txn.Unlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrDeadLockDetected, cs, defaultRPCWriteTimeout, remoteLockResponseLogFields(req))
 		return
 	}
@@ -303,7 +302,6 @@ func (s *service) handleForwardLock(
 			remoteLockOwnerWaitTimeout: s.cfg.RemoteLockOwnerWaitTimeout.Duration,
 		},
 		func(result pb.Result, err error) {
-			txn.Unlock()
 			lockErr = err
 			resp.Lock.Result = result
 			_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout, logFields)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #25466
Related to #25297
Related to #25278
Related to #25279

## What this PR does / why we need it:

PR #25466 backported #25447 to 3.0-dev, but `handleForwardLock` still held the active txn mutex until the async callback.

When a forwarded lock request hits an async conflict, `l.lock` returns after queueing the waiter, while the callback is not called yet. Later the waiter worker retries by locking the same txn first, so it can block forever on the mutex that only the callback would release.

This PR aligns `handleForwardLock` with the safe ownership pattern used by `handleRemoteLock`: the handler releases the txn mutex with `defer`, and the async callback no longer owns that unlock.

It also adds a regression test that verifies a forwarded waiter resumes after the holder unlocks.

## Validation:

```text
go test ./pkg/lockservice -run 'TestForwardLockWaiterCanResumeAfterConflict|TestForwardLock|TestDeadLockWithForward|TestHandleForwardLockRejectsWhenServiceCannotLock' -count=1
ok  	github.com/matrixorigin/matrixone/pkg/lockservice	0.485s
```

A full package run on the same lockservice fix state also passed:

```text
go test ./pkg/lockservice -count=1 -timeout=20m
ok  	github.com/matrixorigin/matrixone/pkg/lockservice	568.838s
```
