### PR TITLE
fix: validate empty parquet before row-group fanout

### DIFF
--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -446,10 +446,13 @@ func (l *LocalETLFS) List(ctx context.Context, dirPath string) iter.Seq2[*DirEnt
 			if strings.HasPrefix(name, ".") {
 				continue
 			}
-			info, err := entry.Info()
+			info, ok, err := localDirEntryInfo(entry)
 			if err != nil {
 				yield(nil, err)
 				return
+			}
+			if !ok {
+				continue
 			}
 			isDir, err := entryIsDir(nativePath, name, info)
 			if err != nil {

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -800,10 +800,13 @@ func (l *LocalFS) List(ctx context.Context, dirPath string) iter.Seq2[*DirEntry,
 			if strings.HasPrefix(name, ".") {
 				continue
 			}
-			info, err := entry.Info()
+			info, ok, err := localDirEntryInfo(entry)
 			if err != nil {
 				yield(nil, err)
 				return
+			}
+			if !ok {
+				continue
 			}
 			fileSize := info.Size()
 			nBlock := ceilingDiv(fileSize, _BlockSize)
@@ -1253,6 +1256,17 @@ func (l *LocalFS) Cost() *CostAttr {
 	return &CostAttr{
 		List: CostLow,
 	}
+}
+
+func localDirEntryInfo(entry os.DirEntry) (fs.FileInfo, bool, error) {
+	info, err := entry.Info()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return info, true, nil
 }
 
 func entryIsDir(path string, name string, entry fs.FileInfo) (bool, error) {

--- a/pkg/fileservice/local_fs_test.go
+++ b/pkg/fileservice/local_fs_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"os"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
@@ -118,6 +120,38 @@ func TestLocalFS(t *testing.T) {
 		}
 	})
 
+}
+
+func TestLocalDirEntryInfoSkipsMissingEntries(t *testing.T) {
+	info, ok, err := localDirEntryInfo(fakeDirEntryInfo{
+		err: &os.PathError{Op: "lstat", Path: "/tmp/ccTEST.cdtor.c", Err: os.ErrNotExist},
+	})
+	assert.Nil(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, info)
+
+	_, _, err = localDirEntryInfo(fakeDirEntryInfo{err: fs.ErrPermission})
+	assert.ErrorIs(t, err, fs.ErrPermission)
+}
+
+type fakeDirEntryInfo struct {
+	err error
+}
+
+func (f fakeDirEntryInfo) Name() string {
+	return "transient"
+}
+
+func (f fakeDirEntryInfo) IsDir() bool {
+	return false
+}
+
+func (f fakeDirEntryInfo) Type() fs.FileMode {
+	return 0
+}
+
+func (f fakeDirEntryInfo) Info() (fs.FileInfo, error) {
+	return nil, f.err
 }
 
 func BenchmarkLocalFS(b *testing.B) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25357 

## What this PR does / why we need it:

fix: validate empty parquet before row-group fanout