### PR TITLE
fix: avoid FOR UPDATE CTE union limit panic

### DIFF
--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -914,6 +914,7 @@ func TestUnionSqlBuilder(t *testing.T) {
 		"(select n_name from nation for update) union all (select n_name from nation2 for update)",
 		"(select n_name from nation for update) union all (select n_name from nation2)",
 		"with qn as (select n_nationkey from nation union all select n_nationkey from nation2) select * from qn for update",
+		"with qn as (select n_nationkey from nation union all select n_nationkey from nation2) select * from qn limit 6 for update",
 	}
 	runTestShouldPass(mock, t, sqls, false, false)
 
@@ -928,6 +929,10 @@ func TestUnionSqlBuilder(t *testing.T) {
 	cteOuterForUpdatePlan, err := runOneStmt(mock, t, "with qn as (select n_nationkey from nation union all select n_nationkey from nation2) select * from qn for update")
 	require.NoError(t, err)
 	require.Equal(t, 0, countLockOpNodes(cteOuterForUpdatePlan))
+
+	cteOuterForUpdateLimitPlan, err := runOneStmt(mock, t, "with qn as (select n_nationkey from nation union all select n_nationkey from nation2) select * from qn limit 6 for update")
+	require.NoError(t, err)
+	require.Equal(t, 0, countLockOpNodes(cteOuterForUpdateLimitPlan))
 
 	// should error
 	sqls = []string{

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -3163,7 +3163,7 @@ func (builder *QueryBuilder) bindSelect(stmt *tree.Select, ctx *BindContext, isR
 			return
 		}
 
-		if astLimit != nil && builder.isForUpdate {
+		if astLimit != nil && lockNode != nil {
 			lockNode.Children[0] = nodeID
 			nodeID = builder.appendNode(lockNode, ctx)
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23134

## What this PR does / why we need it:

Fix planner panic when an outer `FOR UPDATE` over a CTE/UNION has `LIMIT` but no lock targets.

The CTE/UNION case intentionally produces no `LOCK_OP` for the CTE body. The LIMIT path still tried to rewrite `lockNode.Children` unconditionally, causing a nil pointer panic.

Verified with:

- `go test ./pkg/sql/plan -run TestUnionSqlBuilder`
- `bash /home/mo/test.sh --post-pr`