### PR TITLE
[4.0-dev] fix data branch Decimal256 tuple normalization

### DIFF
--- a/pkg/frontend/data_branch_hashdiff_test.go
+++ b/pkg/frontend/data_branch_hashdiff_test.go
@@ -208,6 +208,58 @@ func TestCompareTupleValueWithVectorNormalizesValues(t *testing.T) {
 		require.Zero(t, cmp)
 	})
 
+	t.Run("decimal256 accepts raw DecodeRow bytes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		decimalTyp := types.New(types.T_decimal256, 40, 4)
+		amount, err := types.ParseDecimal256("12345678901234567890123456789012345.1234", decimalTyp.Width, decimalTyp.Scale)
+		require.NoError(t, err)
+
+		tblStuff := newTestBranchTableStuff(ctrl)
+		tblStuff.def.colNames = []string{"id", "amount"}
+		tblStuff.def.colTypes = []types.Type{types.T_int64.ToType(), decimalTyp}
+		tblStuff.def.visibleIdxes = []int{0, 1}
+		tblStuff.def.pkColIdx = 0
+		tblStuff.def.pkColIdxes = []int{0}
+
+		hm := buildTestBranchHashmap(
+			t,
+			mp,
+			tblStuff.def.colTypes,
+			[][]any{{int64(1), amount}},
+		)
+		defer func() {
+			require.NoError(t, hm.Close())
+		}()
+
+		probe := buildFixedVector(t, mp, types.T_int64.ToType(), int64(1))
+		defer probe.Free(mp)
+
+		results, err := hm.GetByVectors([]*vector.Vector{probe})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.True(t, results[0].Exists)
+		require.Len(t, results[0].Rows, 1)
+
+		tuple, _, err := hm.DecodeRow(results[0].Rows[0])
+		require.NoError(t, err)
+		require.Len(t, tuple, 2)
+		rawAmount, ok := tuple[1].([]byte)
+		require.True(t, ok)
+		require.Equal(t, types.EncodeFixed(amount), rawAmount)
+
+		bat := batch.NewWithSize(2)
+		defer bat.Clean(mp)
+		bat.Vecs[0] = buildFixedVector(t, mp, types.T_int64.ToType(), int64(1))
+		bat.Vecs[1] = buildFixedVector(t, mp, decimalTyp, amount)
+		bat.SetRowCount(1)
+
+		cmp, err := compareTupleWithBatchRow(tblStuff, tuple, bat, 0, false)
+		require.NoError(t, err)
+		require.Zero(t, cmp)
+	})
+
 	t.Run("enum accepts uint16", func(t *testing.T) {
 		vec := vector.NewVec(types.T_enum.ToType())
 		defer vec.Free(mp)

--- a/pkg/frontend/data_branch_helpers.go
+++ b/pkg/frontend/data_branch_helpers.go
@@ -777,6 +777,8 @@ func normalizeCompareValue(typ types.Type, val any) (any, error) {
 		case []byte:
 			return types.BytesToArray[float64](v), nil
 		}
+	case types.T_decimal256:
+		return normalizeFixedCompareValue[types.Decimal256](typ, val)
 	case types.T_Rowid:
 		return normalizeFixedCompareValue[types.Rowid](typ, val)
 	case types.T_Blockid:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #23751
Follow-up to #25159
Syncs #25149 review fix to 4.0-dev

## What this PR does / why we need it:

Fixes the Decimal256 no-op update suppression path for data branch diff on 4.0-dev.

`BranchHashmap.DecodeRow` can return Decimal256 values as raw bytes when the hashmap stores values through the raw fixed-width fallback. `compareTupleWithBatchRow` compares that decoded tuple against the LCA batch row, so raw Decimal256 bytes must be normalized to `types.Decimal256` before comparing with the typed vector value. Without this, restored Decimal256 rows can fail with a mismatched-type error instead of being suppressed as no-op updates.

Changes:
- Normalize raw `T_decimal256` tuple values with the existing fixed-width normalization helper.
- Add regression coverage using real `BranchHashmap.GetByVectors`/`DecodeRow` output before comparing against a typed Decimal256 batch row.

## Tests

- `git diff --check HEAD~1..HEAD`
- `CGO_CFLAGS="-I$PWD/cgo -I$PWD/thirdparties/install/include" CGO_LDFLAGS="-L$PWD/cgo -lmo -L$PWD/thirdparties/install/lib -Wl,-rpath,$PWD/cgo -Wl,-rpath,$PWD/thirdparties/install/lib" DYLD_LIBRARY_PATH="$PWD/cgo:$PWD/thirdparties/install/lib" go test ./pkg/frontend -run 'TestCompareTupleValueWithVectorNormalizesValues|TestCompareTupleValueWithVectorDecimal256|TestCompareSingleValInVector_AllTypes|TestNormalizeCompareValueSupportedForms|TestDataBranchCompareValueErrors' -count=1`
