### PR TITLE
refactor(schedule): decouple current CN placement policy

### DIFF
--- a/pkg/sql/compile/scheduler.go
+++ b/pkg/sql/compile/scheduler.go
@@ -15,7 +15,6 @@
 package compile
 
 import (
-	"sort"
 	"sync"
 	"time"
 
@@ -50,22 +49,41 @@ func (c *Compile) scheduleQueryWorkers() (engine.Nodes, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !placement.Satisfied {
+		getQueryScheduleLogger().WarnWithConfig(
+			"query-schedule-unsatisfied-placement",
+			"query schedule cannot satisfy placement",
+			queryScheduleLogRateLimit,
+			c.querySchedulePlacementFields(placement)...)
+		return nil, moerr.NewInternalErrorNoCtxf(
+			"query schedule cannot satisfy placement, reason %s, current CN policy %s",
+			placement.Reason,
+			placement.CurrentCNPolicy.String())
+	}
 	nodes := toEngineNodes(placement.Workers)
 	if c.execType == plan2.ExecTypeAP_MULTICN {
-		// Fixed CN order keeps downstream CNCNT/CNIDX assignment deterministic.
-		sort.Slice(nodes, func(i, j int) bool { return nodes[i].Addr < nodes[j].Addr })
 		if placement.Reason == schedule.ReasonNoCandidateCN {
 			getQueryScheduleLogger().WarnWithConfig(
 				"query-schedule-no-candidate-cn",
 				"query schedule falls back to local CN",
 				queryScheduleLogRateLimit,
-				zap.String("reason", placement.Reason),
-				zap.String("local-address", c.addr),
-				zap.Int("worker-count", len(nodes)),
-				zap.Bool("is-internal", c.isInternal))
+				c.querySchedulePlacementFields(placement)...)
 		}
 	}
 	return nodes, nil
+}
+
+func (c *Compile) querySchedulePlacementFields(placement schedule.QueryDecision) []zap.Field {
+	currentCN := c.currentCNWorker()
+	return []zap.Field{
+		zap.String("reason", placement.Reason),
+		zap.String("current-cn-policy", placement.CurrentCNPolicy.String()),
+		zap.String("exec-type", queryExecTypeString(c.execType)),
+		zap.String("current-cn-id", currentCN.ID),
+		zap.String("current-cn-address", currentCN.Addr),
+		zap.Int("worker-count", len(placement.Workers)),
+		zap.Bool("is-internal", c.isInternal),
+	}
 }
 
 func (c *Compile) getCandidateCNs() (engine.Nodes, error) {
@@ -76,10 +94,11 @@ func (c *Compile) getCandidateCNs() (engine.Nodes, error) {
 }
 
 func (c *Compile) decideQueryPlacement() (schedule.QueryDecision, error) {
-	localNode := getEngineNode(c)
+	currentCN := c.currentCNWorker()
 	req := schedule.QueryRequest{
-		ExecKind:    toScheduleExecKind(c.execType),
-		LocalWorker: toScheduleWorker(localNode),
+		ExecKind:        toScheduleExecKind(c.execType),
+		CurrentCN:       currentCN,
+		CurrentCNPolicy: c.currentCNPolicy(),
 	}
 	if c.execType != plan2.ExecTypeAP_MULTICN {
 		return schedule.DecideQueryPlacement(req), nil
@@ -99,14 +118,28 @@ func (c *Compile) decideQueryPlacement() (schedule.QueryDecision, error) {
 			queryScheduleLogRateLimit,
 			zap.Int("candidate-count", rawCandidateCount),
 			zap.Int("routable-count", len(req.Candidates)),
+			zap.String("current-cn-policy", req.CurrentCNPolicy.String()),
+			zap.String("exec-type", queryExecTypeString(c.execType)),
+			zap.String("current-cn-id", req.CurrentCN.ID),
+			zap.String("current-cn-address", req.CurrentCN.Addr),
 			zap.Bool("is-internal", c.isInternal))
 	}
-	req.RequireLocal = c.proc != nil && c.proc.Base.QueryClient != nil
-	if req.RequireLocal {
-		localNode.Id = c.proc.GetService()
-		req.LocalWorker = toScheduleWorker(localNode)
-	}
 	return schedule.DecideQueryPlacement(req), nil
+}
+
+func (c *Compile) currentCNWorker() schedule.Worker {
+	currentCN := getEngineNode(c)
+	if c.proc != nil {
+		currentCN.Id = c.proc.GetService()
+	}
+	return toScheduleWorker(currentCN)
+}
+
+func (c *Compile) currentCNPolicy() schedule.CurrentCNPolicy {
+	if c.proc != nil && c.proc.Base.QueryClient != nil {
+		return schedule.CurrentCNRequired
+	}
+	return schedule.CurrentCNAllowed
 }
 
 func toScheduleExecKind(execType plan2.ExecType) schedule.QueryExecKind {
@@ -117,6 +150,19 @@ func toScheduleExecKind(execType plan2.ExecType) schedule.QueryExecKind {
 		return schedule.QueryExecAPOneCN
 	default:
 		return schedule.QueryExecAPMultiCN
+	}
+}
+
+func queryExecTypeString(execType plan2.ExecType) string {
+	switch execType {
+	case plan2.ExecTypeTP:
+		return "tp"
+	case plan2.ExecTypeAP_ONECN:
+		return "ap-one-cn"
+	case plan2.ExecTypeAP_MULTICN:
+		return "ap-multi-cn"
+	default:
+		return "unknown"
 	}
 }
 

--- a/pkg/sql/compile/scheduler_test.go
+++ b/pkg/sql/compile/scheduler_test.go
@@ -119,6 +119,24 @@ func TestScheduleQueryWorkersForwardsCandidateFilters(t *testing.T) {
 	require.Equal(t, map[string]string{"role": "ap"}, e.cnLabel)
 }
 
+func TestScheduleQueryWorkersRequiredLocalExecWithoutRouteReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const localID = "local-cn"
+	for _, execType := range []plan2.ExecType{plan2.ExecTypeTP, plan2.ExecTypeAP_ONECN} {
+		c := NewMockCompile(t)
+		c.execType = execType
+		c.proc.Base.QueryClient = fakeQueryClient{}
+		lockSvc := mock_lock.NewMockLockService(ctrl)
+		lockSvc.EXPECT().GetConfig().Return(lockservice.Config{ServiceID: localID}).AnyTimes()
+		c.proc.Base.LockService = lockSvc
+
+		_, err := c.scheduleQueryWorkers()
+		require.ErrorContains(t, err, schedule.ReasonCurrentCNUnavailable)
+	}
+}
+
 func TestScheduleQueryWorkersFallsBackToLocalWhenNoCandidate(t *testing.T) {
 	c := NewMockCompile(t)
 	c.addr = "local:6001"
@@ -220,10 +238,10 @@ func TestScheduleQueryWorkersDeduplicatesRequiredLocalByAddress(t *testing.T) {
 
 	decision, err := c.decideQueryPlacement()
 	require.NoError(t, err)
-	require.Equal(t, schedule.ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, schedule.ReasonRequiredCurrentCN, decision.Reason)
 	require.Equal(t, 2, len(decision.Workers))
-	require.Equal(t, "remote:6001", decision.Workers[0].Addr)
-	require.Equal(t, "local:6001", decision.Workers[1].Addr)
+	require.Equal(t, "local:6001", decision.Workers[0].Addr)
+	require.Equal(t, "remote:6001", decision.Workers[1].Addr)
 }
 
 func TestScheduleQueryWorkersDeduplicatesRequiredLocalByServiceID(t *testing.T) {
@@ -254,9 +272,9 @@ func TestScheduleQueryWorkersDeduplicatesRequiredLocalByServiceID(t *testing.T) 
 
 	decision, err := c.decideQueryPlacement()
 	require.NoError(t, err)
-	require.Equal(t, schedule.ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, schedule.ReasonRequiredCurrentCN, decision.Reason)
 	require.Equal(t, 2, len(decision.Workers))
-	require.Equal(t, localID, decision.Workers[1].ID)
+	require.Equal(t, localID, decision.Workers[0].ID)
 }
 
 func TestScheduleQueryWorkersDeduplicatesRequiredLocalByAddressWhenServiceIDDifferent(t *testing.T) {
@@ -287,10 +305,10 @@ func TestScheduleQueryWorkersDeduplicatesRequiredLocalByAddressWhenServiceIDDiff
 
 	decision, err := c.decideQueryPlacement()
 	require.NoError(t, err)
-	require.Equal(t, schedule.ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, schedule.ReasonRequiredCurrentCN, decision.Reason)
 	require.Equal(t, 2, len(decision.Workers))
-	require.Equal(t, "stale-local", decision.Workers[1].ID)
-	require.Equal(t, "local:6001", decision.Workers[1].Addr)
+	require.Equal(t, "stale-local", decision.Workers[0].ID)
+	require.Equal(t, "local:6001", decision.Workers[0].Addr)
 }
 
 func TestScheduleQueryWorkersReturnsCandidateError(t *testing.T) {

--- a/pkg/sql/schedule/placement.go
+++ b/pkg/sql/schedule/placement.go
@@ -14,11 +14,18 @@
 
 package schedule
 
+import "sort"
+
 const (
-	ReasonLocalExecType   = "local-exec-type"
-	ReasonMultiCN         = "multi-cn"
-	ReasonNoCandidateCN   = "no-candidate-cn"
-	ReasonRequiredLocalCN = "required-local-cn"
+	ReasonLocalExecType            = "local-exec-type"
+	ReasonMultiCN                  = "multi-cn"
+	ReasonNoCandidateCN            = "no-candidate-cn"
+	ReasonRequiredCurrentCN        = "required-current-cn"
+	ReasonPreferredCurrentCN       = "preferred-current-cn"
+	ReasonExcludedCurrentCN        = "excluded-current-cn"
+	ReasonCurrentCNMissingIdentity = "current-cn-missing-identity"
+	ReasonCurrentCNUnavailable     = "current-cn-unavailable"
+	ReasonInvalidCurrentCNPolicy   = "invalid-current-cn-policy"
 )
 
 type QueryExecKind uint8
@@ -29,61 +36,244 @@ const (
 	QueryExecAPMultiCN
 )
 
+type CurrentCNPolicy uint8
+
+const (
+	CurrentCNAllowed CurrentCNPolicy = iota
+	CurrentCNRequired
+	CurrentCNPreferred
+	CurrentCNExcluded
+)
+
+func (p CurrentCNPolicy) String() string {
+	switch p {
+	case CurrentCNAllowed:
+		return "allowed"
+	case CurrentCNRequired:
+		return "required"
+	case CurrentCNPreferred:
+		return "preferred"
+	case CurrentCNExcluded:
+		return "excluded"
+	default:
+		return "unknown"
+	}
+}
+
 type QueryRequest struct {
-	ExecKind     QueryExecKind
-	LocalWorker  Worker
-	Candidates   Workers
-	RequireLocal bool
+	ExecKind        QueryExecKind
+	CurrentCN       Worker
+	Candidates      Workers
+	CurrentCNPolicy CurrentCNPolicy
 }
 
 type QueryDecision struct {
-	ExecKind QueryExecKind
-	Workers  Workers
-	Reason   string
+	ExecKind        QueryExecKind
+	Workers         Workers
+	Reason          string
+	CurrentCNPolicy CurrentCNPolicy
+	Satisfied       bool
 }
 
 func DecideQueryPlacement(req QueryRequest) QueryDecision {
+	if !req.CurrentCNPolicy.Valid() {
+		return queryDecision(req, nil, ReasonInvalidCurrentCNPolicy, false)
+	}
 	if req.ExecKind == QueryExecTP || req.ExecKind == QueryExecAPOneCN {
-		return QueryDecision{
-			ExecKind: req.ExecKind,
-			Workers:  Workers{req.LocalWorker},
-			Reason:   ReasonLocalExecType,
-		}
+		return decideLocalQueryPlacement(req)
 	}
 
-	workers := cloneWorkers(req.Candidates)
+	workers := dedupeWorkers(req.Candidates)
+	if req.CurrentCNPolicy == CurrentCNRequired && !hasWorkerIdentity(req.CurrentCN) {
+		return queryDecision(req, workers, ReasonCurrentCNMissingIdentity, false)
+	}
+	if req.CurrentCNPolicy == CurrentCNExcluded {
+		if !hasWorkerIdentity(req.CurrentCN) {
+			return queryDecision(req, workers, ReasonCurrentCNMissingIdentity, false)
+		}
+		workers = removeCurrentWorker(workers, req.CurrentCN)
+		if len(workers) == 0 {
+			return queryDecision(req, workers, ReasonExcludedCurrentCN, false)
+		}
+		return queryDecision(req, workers, ReasonExcludedCurrentCN, true)
+	}
+
 	reason := ReasonMultiCN
 	if len(workers) == 0 {
-		workers = ensureLocalWorker(workers, req.LocalWorker)
+		workers = ensureCurrentWorker(workers, req.CurrentCN)
 		reason = ReasonNoCandidateCN
-	} else if req.RequireLocal {
-		workers = ensureLocalWorker(workers, req.LocalWorker)
-		reason = ReasonRequiredLocalCN
+		if req.CurrentCNPolicy == CurrentCNRequired && len(workers) == 0 {
+			return queryDecision(req, workers, ReasonCurrentCNUnavailable, false)
+		}
+		return queryDecision(req, workers, reason, len(workers) > 0)
 	}
-	return QueryDecision{
-		ExecKind: req.ExecKind,
-		Workers:  workers,
-		Reason:   reason,
+
+	switch req.CurrentCNPolicy {
+	case CurrentCNRequired:
+		workers = ensureCurrentWorker(workers, req.CurrentCN)
+		if !containsRoutableWorker(workers, req.CurrentCN) {
+			return queryDecision(req, workers, ReasonCurrentCNUnavailable, false)
+		}
+		reason = ReasonRequiredCurrentCN
+	case CurrentCNPreferred:
+		if preferredWorkers, ok := preferCurrentWorker(workers, req.CurrentCN); ok {
+			workers = preferredWorkers
+			reason = ReasonPreferredCurrentCN
+		}
+	}
+	return queryDecision(req, workers, reason, true)
+}
+
+func decideLocalQueryPlacement(req QueryRequest) QueryDecision {
+	if req.CurrentCNPolicy == CurrentCNExcluded {
+		return queryDecision(req, nil, ReasonExcludedCurrentCN, false)
+	}
+	if req.CurrentCNPolicy == CurrentCNRequired && !hasWorkerIdentity(req.CurrentCN) {
+		return queryDecision(req, nil, ReasonCurrentCNMissingIdentity, false)
+	}
+	workers := ensureCurrentWorker(nil, req.CurrentCN)
+	if len(workers) == 0 {
+		return queryDecision(req, workers, ReasonCurrentCNUnavailable, false)
+	}
+	return queryDecision(req, workers, ReasonLocalExecType, true)
+}
+
+func (p CurrentCNPolicy) Valid() bool {
+	switch p {
+	case CurrentCNAllowed, CurrentCNRequired, CurrentCNPreferred, CurrentCNExcluded:
+		return true
+	default:
+		return false
 	}
 }
 
-func ensureLocalWorker(workers Workers, local Worker) Workers {
-	if local.ID == "" && local.Addr == "" {
+func queryDecision(req QueryRequest, workers Workers, reason string, satisfied bool) QueryDecision {
+	workers = orderDecisionWorkers(req, workers, reason)
+	return QueryDecision{
+		ExecKind:        req.ExecKind,
+		Workers:         workers,
+		Reason:          reason,
+		CurrentCNPolicy: req.CurrentCNPolicy,
+		Satisfied:       satisfied,
+	}
+}
+
+func orderDecisionWorkers(req QueryRequest, workers Workers, reason string) Workers {
+	workers = cloneWorkers(workers)
+	if req.ExecKind != QueryExecAPMultiCN || len(workers) < 2 {
+		return workers
+	}
+	if reason == ReasonPreferredCurrentCN {
+		sortWorkersByAddr(workers[1:])
+		return workers
+	}
+	sortWorkersByAddr(workers)
+	return workers
+}
+
+func sortWorkersByAddr(workers Workers) {
+	sort.Slice(workers, func(i, j int) bool {
+		return workers[i].Addr < workers[j].Addr
+	})
+}
+
+func ensureCurrentWorker(workers Workers, current Worker) Workers {
+	if !hasWorkerRoute(current) {
 		return workers
 	}
 	for _, worker := range workers {
-		if sameWorker(worker, local) {
+		if sameWorker(worker, current) {
 			return workers
 		}
 	}
-	return append(workers, local)
+	return append(workers, current)
 }
 
-func sameWorker(worker Worker, local Worker) bool {
-	if worker.ID != "" && local.ID != "" && worker.ID == local.ID {
+func removeCurrentWorker(workers Workers, current Worker) Workers {
+	if !hasWorkerIdentity(current) {
+		return workers
+	}
+	filtered := workers[:0]
+	for _, worker := range workers {
+		if sameWorker(worker, current) {
+			continue
+		}
+		filtered = append(filtered, worker)
+	}
+	return filtered
+}
+
+func preferCurrentWorker(workers Workers, current Worker) (Workers, bool) {
+	if !hasWorkerIdentity(current) {
+		return workers, false
+	}
+	for idx, worker := range workers {
+		if !sameWorker(worker, current) {
+			continue
+		}
+		if !hasWorkerRoute(worker) {
+			continue
+		}
+		if idx == 0 {
+			return workers, true
+		}
+		preferred := make(Workers, 0, len(workers))
+		preferred = append(preferred, worker)
+		preferred = append(preferred, workers[:idx]...)
+		preferred = append(preferred, workers[idx+1:]...)
+		return preferred, true
+	}
+	return workers, false
+}
+
+func dedupeWorkers(workers Workers) Workers {
+	if len(workers) == 0 {
+		return nil
+	}
+	deduped := make(Workers, 0, len(workers))
+	for _, worker := range workers {
+		if !hasWorkerRoute(worker) {
+			continue
+		}
+		if containsWorker(deduped, worker) {
+			continue
+		}
+		deduped = append(deduped, worker)
+	}
+	return deduped
+}
+
+func containsWorker(workers Workers, target Worker) bool {
+	for _, worker := range workers {
+		if sameWorker(worker, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRoutableWorker(workers Workers, target Worker) bool {
+	for _, worker := range workers {
+		if hasWorkerRoute(worker) && sameWorker(worker, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWorkerIdentity(worker Worker) bool {
+	return worker.ID != "" || worker.Addr != ""
+}
+
+func hasWorkerRoute(worker Worker) bool {
+	return worker.Addr != ""
+}
+
+func sameWorker(worker Worker, current Worker) bool {
+	if worker.ID != "" && current.ID != "" && worker.ID == current.ID {
 		return true
 	}
-	if worker.Addr != "" && local.Addr != "" && worker.Addr == local.Addr {
+	if worker.Addr != "" && current.Addr != "" && worker.Addr == current.Addr {
 		return true
 	}
 	return false

--- a/pkg/sql/schedule/placement_test.go
+++ b/pkg/sql/schedule/placement_test.go
@@ -26,14 +26,101 @@ func TestDecideQueryPlacementKeepsLocalExecTypesLocal(t *testing.T) {
 
 	for _, execKind := range []QueryExecKind{QueryExecTP, QueryExecAPOneCN} {
 		decision := DecideQueryPlacement(QueryRequest{
-			ExecKind:    execKind,
-			LocalWorker: local,
-			Candidates:  candidates,
+			ExecKind:   execKind,
+			CurrentCN:  local,
+			Candidates: candidates,
 		})
 
 		require.Equal(t, execKind, decision.ExecKind)
 		require.Equal(t, ReasonLocalExecType, decision.Reason)
 		require.Equal(t, Workers{local}, decision.Workers)
+		require.True(t, decision.Satisfied)
+	}
+}
+
+func TestDecideQueryPlacementRejectsInvalidCurrentCNPolicy(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+
+	for _, execKind := range []QueryExecKind{QueryExecTP, QueryExecAPOneCN, QueryExecAPMultiCN} {
+		decision := DecideQueryPlacement(QueryRequest{
+			ExecKind:        execKind,
+			CurrentCN:       local,
+			Candidates:      Workers{{ID: "remote", Addr: "remote:6001", Mcpu: 16}},
+			CurrentCNPolicy: CurrentCNPolicy(99),
+		})
+
+		require.Equal(t, execKind, decision.ExecKind)
+		require.Equal(t, ReasonInvalidCurrentCNPolicy, decision.Reason)
+		require.Empty(t, decision.Workers)
+		require.False(t, decision.Satisfied)
+		require.Equal(t, "unknown", decision.CurrentCNPolicy.String())
+	}
+}
+
+func TestDecideQueryPlacementRejectsExcludedCurrentCNForLocalExecTypes(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+
+	for _, execKind := range []QueryExecKind{QueryExecTP, QueryExecAPOneCN} {
+		decision := DecideQueryPlacement(QueryRequest{
+			ExecKind:        execKind,
+			CurrentCN:       local,
+			CurrentCNPolicy: CurrentCNExcluded,
+		})
+
+		require.Equal(t, execKind, decision.ExecKind)
+		require.Equal(t, ReasonExcludedCurrentCN, decision.Reason)
+		require.Empty(t, decision.Workers)
+		require.False(t, decision.Satisfied)
+	}
+}
+
+func TestDecideQueryPlacementKeepsRequiredAndPreferredLocalExecTypesLocal(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+
+	for _, policy := range []CurrentCNPolicy{CurrentCNRequired, CurrentCNPreferred} {
+		for _, execKind := range []QueryExecKind{QueryExecTP, QueryExecAPOneCN} {
+			decision := DecideQueryPlacement(QueryRequest{
+				ExecKind:        execKind,
+				CurrentCN:       local,
+				CurrentCNPolicy: policy,
+			})
+
+			require.Equal(t, execKind, decision.ExecKind)
+			require.Equal(t, ReasonLocalExecType, decision.Reason)
+			require.Equal(t, Workers{local}, decision.Workers)
+			require.True(t, decision.Satisfied)
+		}
+	}
+}
+
+func TestDecideQueryPlacementRejectsRequiredLocalExecTypeWithoutRoute(t *testing.T) {
+	local := Worker{ID: "local", Mcpu: 8}
+
+	for _, execKind := range []QueryExecKind{QueryExecTP, QueryExecAPOneCN} {
+		decision := DecideQueryPlacement(QueryRequest{
+			ExecKind:        execKind,
+			CurrentCN:       local,
+			CurrentCNPolicy: CurrentCNRequired,
+		})
+
+		require.Equal(t, execKind, decision.ExecKind)
+		require.Equal(t, ReasonCurrentCNUnavailable, decision.Reason)
+		require.Empty(t, decision.Workers)
+		require.False(t, decision.Satisfied)
+	}
+}
+
+func TestDecideQueryPlacementRejectsRequiredLocalExecTypeWithoutIdentity(t *testing.T) {
+	for _, execKind := range []QueryExecKind{QueryExecTP, QueryExecAPOneCN} {
+		decision := DecideQueryPlacement(QueryRequest{
+			ExecKind:        execKind,
+			CurrentCNPolicy: CurrentCNRequired,
+		})
+
+		require.Equal(t, execKind, decision.ExecKind)
+		require.Equal(t, ReasonCurrentCNMissingIdentity, decision.Reason)
+		require.Empty(t, decision.Workers)
+		require.False(t, decision.Satisfied)
 	}
 }
 
@@ -45,17 +132,53 @@ func TestDecideQueryPlacementUsesCandidatesForMultiCN(t *testing.T) {
 	}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:    QueryExecAPMultiCN,
-		LocalWorker: local,
-		Candidates:  candidates,
+		ExecKind:   QueryExecAPMultiCN,
+		CurrentCN:  local,
+		Candidates: candidates,
 	})
 
 	require.Equal(t, QueryExecAPMultiCN, decision.ExecKind)
 	require.Equal(t, ReasonMultiCN, decision.Reason)
-	require.Equal(t, candidates, decision.Workers)
+	require.Equal(t, Workers{candidates[1], candidates[0]}, decision.Workers)
+	require.Equal(t, CurrentCNAllowed, decision.CurrentCNPolicy)
+	require.True(t, decision.Satisfied)
 
 	decision.Workers[0].Mcpu = 1
+	require.Equal(t, 12, candidates[1].Mcpu)
 	require.Equal(t, 16, candidates[0].Mcpu)
+}
+
+func TestDecideQueryPlacementDropsUnroutableCandidates(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+	candidates := Workers{
+		{ID: "missing-addr", Mcpu: 12},
+		{ID: "remote", Addr: "remote:6001", Mcpu: 16},
+	}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:   QueryExecAPMultiCN,
+		CurrentCN:  local,
+		Candidates: candidates,
+	})
+
+	require.Equal(t, Workers{candidates[1]}, decision.Workers)
+	require.Equal(t, ReasonMultiCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementFallsBackWhenAllCandidatesUnroutable(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+	candidates := Workers{{ID: "missing-addr", Mcpu: 12}}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:   QueryExecAPMultiCN,
+		CurrentCN:  local,
+		Candidates: candidates,
+	})
+
+	require.Equal(t, Workers{local}, decision.Workers)
+	require.Equal(t, ReasonNoCandidateCN, decision.Reason)
+	require.True(t, decision.Satisfied)
 }
 
 func TestDecideQueryPlacementCanRequireCurrentCN(t *testing.T) {
@@ -63,27 +186,42 @@ func TestDecideQueryPlacementCanRequireCurrentCN(t *testing.T) {
 	candidates := Workers{{ID: "remote", Addr: "remote:6001", Mcpu: 16}}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:     QueryExecAPMultiCN,
-		LocalWorker:  local,
-		Candidates:   candidates,
-		RequireLocal: true,
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
 	})
 
-	require.Equal(t, Workers{candidates[0], local}, decision.Workers)
-	require.Equal(t, ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, Workers{local, candidates[0]}, decision.Workers)
+	require.Equal(t, ReasonRequiredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
 }
 
 func TestDecideQueryPlacementFallsBackToLocalWhenCandidatesEmpty(t *testing.T) {
 	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:    QueryExecAPMultiCN,
-		LocalWorker: local,
+		ExecKind:  QueryExecAPMultiCN,
+		CurrentCN: local,
 	})
 
 	require.Equal(t, QueryExecAPMultiCN, decision.ExecKind)
 	require.Equal(t, ReasonNoCandidateCN, decision.Reason)
 	require.Equal(t, Workers{local}, decision.Workers)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementRejectsFallbackWhenCurrentCNHasNoRoute(t *testing.T) {
+	local := Worker{ID: "local", Mcpu: 8}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:  QueryExecAPMultiCN,
+		CurrentCN: local,
+	})
+
+	require.Equal(t, ReasonNoCandidateCN, decision.Reason)
+	require.Empty(t, decision.Workers)
+	require.False(t, decision.Satisfied)
 }
 
 func TestDecideQueryPlacementDoesNotDuplicateRequiredCurrentCN(t *testing.T) {
@@ -94,14 +232,34 @@ func TestDecideQueryPlacementDoesNotDuplicateRequiredCurrentCN(t *testing.T) {
 	}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:     QueryExecAPMultiCN,
-		LocalWorker:  local,
-		Candidates:   candidates,
-		RequireLocal: true,
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
 	})
 
-	require.Equal(t, candidates, decision.Workers)
-	require.Equal(t, ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, Workers{candidates[1], candidates[0]}, decision.Workers)
+	require.Equal(t, ReasonRequiredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementUsesRoutableCandidateForRequiredCurrentCNByServiceID(t *testing.T) {
+	local := Worker{ID: "local", Mcpu: 8}
+	candidates := Workers{
+		{ID: "remote", Addr: "remote:6001", Mcpu: 16},
+		{ID: "local", Addr: "local:6001", Mcpu: 12},
+	}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
+	})
+
+	require.Equal(t, Workers{candidates[1], candidates[0]}, decision.Workers)
+	require.Equal(t, ReasonRequiredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
 }
 
 func TestDecideQueryPlacementDeduplicatesRequiredCurrentCNByAddressWhenIDMissing(t *testing.T) {
@@ -109,14 +267,15 @@ func TestDecideQueryPlacementDeduplicatesRequiredCurrentCNByAddressWhenIDMissing
 	candidates := Workers{{Addr: "local:6001", Mcpu: 16}}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:     QueryExecAPMultiCN,
-		LocalWorker:  local,
-		Candidates:   candidates,
-		RequireLocal: true,
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
 	})
 
 	require.Equal(t, candidates, decision.Workers)
-	require.Equal(t, ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, ReasonRequiredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
 }
 
 func TestDecideQueryPlacementDeduplicatesRequiredCurrentCNByAddressWhenIDDifferent(t *testing.T) {
@@ -124,14 +283,15 @@ func TestDecideQueryPlacementDeduplicatesRequiredCurrentCNByAddressWhenIDDiffere
 	candidates := Workers{{ID: "stale-local", Addr: "local:6001", Mcpu: 16}}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:     QueryExecAPMultiCN,
-		LocalWorker:  local,
-		Candidates:   candidates,
-		RequireLocal: true,
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
 	})
 
 	require.Equal(t, candidates, decision.Workers)
-	require.Equal(t, ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, ReasonRequiredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
 }
 
 func TestDecideQueryPlacementAppendsRequiredCurrentCNWhenIDMissingAndAddressDiffers(t *testing.T) {
@@ -139,25 +299,205 @@ func TestDecideQueryPlacementAppendsRequiredCurrentCNWhenIDMissingAndAddressDiff
 	candidates := Workers{{Addr: "remote:6001", Mcpu: 16}}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:     QueryExecAPMultiCN,
-		LocalWorker:  local,
-		Candidates:   candidates,
-		RequireLocal: true,
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
 	})
 
-	require.Equal(t, Workers{candidates[0], local}, decision.Workers)
-	require.Equal(t, ReasonRequiredLocalCN, decision.Reason)
+	require.Equal(t, Workers{local, candidates[0]}, decision.Workers)
+	require.Equal(t, ReasonRequiredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
 }
 
 func TestDecideQueryPlacementFallsBackToLocalWhenRequiredCandidatesEmpty(t *testing.T) {
 	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
 
 	decision := DecideQueryPlacement(QueryRequest{
-		ExecKind:     QueryExecAPMultiCN,
-		LocalWorker:  local,
-		RequireLocal: true,
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		CurrentCNPolicy: CurrentCNRequired,
 	})
 
 	require.Equal(t, Workers{local}, decision.Workers)
 	require.Equal(t, ReasonNoCandidateCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementRejectsRequiredFallbackWithoutIdentity(t *testing.T) {
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCNPolicy: CurrentCNRequired,
+	})
+
+	require.Empty(t, decision.Workers)
+	require.Equal(t, ReasonCurrentCNMissingIdentity, decision.Reason)
+	require.False(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementRejectsRequiredFallbackWithoutRoute(t *testing.T) {
+	local := Worker{ID: "local", Mcpu: 8}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		CurrentCNPolicy: CurrentCNRequired,
+	})
+
+	require.Empty(t, decision.Workers)
+	require.Equal(t, ReasonCurrentCNUnavailable, decision.Reason)
+	require.False(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementDeduplicatesCandidateWorkers(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+	candidates := Workers{
+		{ID: "cn1", Addr: "cn1:6001", Mcpu: 12},
+		{ID: "cn1", Addr: "stale-cn1:6001", Mcpu: 4},
+		{ID: "stale-cn2", Addr: "cn2:6001", Mcpu: 6},
+		{ID: "cn2", Addr: "cn2:6001", Mcpu: 16},
+	}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:   QueryExecAPMultiCN,
+		CurrentCN:  local,
+		Candidates: candidates,
+	})
+
+	require.Equal(t, Workers{candidates[0], candidates[2]}, decision.Workers)
+	require.Equal(t, ReasonMultiCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementPrefersCurrentCNWhenCandidateAllowed(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+	candidates := Workers{
+		{ID: "remote", Addr: "remote:6001", Mcpu: 16},
+		{ID: "local", Addr: "local:6001", Mcpu: 8},
+	}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNPreferred,
+	})
+
+	require.Equal(t, Workers{candidates[1], candidates[0]}, decision.Workers)
+	require.Equal(t, ReasonPreferredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementKeepsPreferredCurrentCNFirstAndSortsTail(t *testing.T) {
+	local := Worker{ID: "local", Addr: "m:6001", Mcpu: 8}
+	candidates := Workers{
+		{ID: "local", Addr: "m:6001", Mcpu: 8},
+		{ID: "remote-z", Addr: "z:6001", Mcpu: 16},
+		{ID: "remote-a", Addr: "a:6001", Mcpu: 12},
+	}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNPreferred,
+	})
+
+	require.Equal(t, Workers{candidates[0], candidates[2], candidates[1]}, decision.Workers)
+	require.Equal(t, ReasonPreferredCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementDoesNotForcePreferredCurrentCN(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+	candidates := Workers{{ID: "remote", Addr: "remote:6001", Mcpu: 16}}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNPreferred,
+	})
+
+	require.Equal(t, candidates, decision.Workers)
+	require.Equal(t, ReasonMultiCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementExcludesCurrentCN(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+	candidates := Workers{
+		{ID: "local", Addr: "local:6001", Mcpu: 8},
+		{ID: "remote", Addr: "remote:6001", Mcpu: 16},
+	}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNExcluded,
+	})
+
+	require.Equal(t, Workers{candidates[1]}, decision.Workers)
+	require.Equal(t, ReasonExcludedCurrentCN, decision.Reason)
+	require.True(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementRejectsExcludedCurrentCNWhenNoOtherCandidate(t *testing.T) {
+	local := Worker{ID: "local", Addr: "local:6001", Mcpu: 8}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      Workers{local},
+		CurrentCNPolicy: CurrentCNExcluded,
+	})
+
+	require.Empty(t, decision.Workers)
+	require.Equal(t, ReasonExcludedCurrentCN, decision.Reason)
+	require.False(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementRejectsExcludedCurrentCNWithoutIdentity(t *testing.T) {
+	candidates := Workers{{ID: "remote", Addr: "remote:6001", Mcpu: 16}}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNExcluded,
+	})
+
+	require.Equal(t, candidates, decision.Workers)
+	require.Equal(t, ReasonCurrentCNMissingIdentity, decision.Reason)
+	require.False(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementRejectsRequiredCurrentCNWithoutIdentity(t *testing.T) {
+	candidates := Workers{{ID: "remote", Addr: "remote:6001", Mcpu: 16}}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
+	})
+
+	require.Equal(t, candidates, decision.Workers)
+	require.Equal(t, ReasonCurrentCNMissingIdentity, decision.Reason)
+	require.False(t, decision.Satisfied)
+}
+
+func TestDecideQueryPlacementRejectsRequiredCurrentCNWithoutRoute(t *testing.T) {
+	local := Worker{ID: "local", Mcpu: 8}
+	candidates := Workers{{ID: "remote", Addr: "remote:6001", Mcpu: 16}}
+
+	decision := DecideQueryPlacement(QueryRequest{
+		ExecKind:        QueryExecAPMultiCN,
+		CurrentCN:       local,
+		Candidates:      candidates,
+		CurrentCNPolicy: CurrentCNRequired,
+	})
+
+	require.Equal(t, candidates, decision.Workers)
+	require.Equal(t, ReasonCurrentCNUnavailable, decision.Reason)
+	require.False(t, decision.Satisfied)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #25451

## What this PR does / why we need it:

Decouples the implicit `RequireLocal bool` + `LocalWorker` model into an explicit `CurrentCNPolicy` four-strategy enum:

### New Model

```
CurrentCNAllowed   // currentCN may participate (default, equivalent to old RequireLocal=false)
CurrentCNRequired  // must schedule on currentCN, explicit failure otherwise (new semantic)
CurrentCNPreferred // prefer currentCN, fall back to other CNs (new semantic)
CurrentCNExcluded  // exclude currentCN, execute on other CNs only (new semantic)
```

### Core Changes

- **`pkg/sql/schedule/placement.go`**:
  - Added `CurrentCNPolicy` enum + `Valid()` / `String()`
  - `QueryRequest.RequireLocal` → `CurrentCNPolicy`, `LocalWorker` → `CurrentCN`
  - `QueryDecision` gains `Satisfied` field for explicit placement success/failure
  - New Reason constants to distinguish failure modes
  - New helpers: `dedupeWorkers`, `preferCurrentWorker`, `removeCurrentWorker`, `orderDecisionWorkers`
  - Separated `decideLocalQueryPlacement` for TP/APOneCN single-CN logic
- **`pkg/sql/compile/scheduler.go`**: New scheduling facade `scheduleQueryWorkers`, checks `Satisfied` and propagates errors
- **Test coverage**: 12 ExecKind×Policy combinations + edge cases (nil/duplicates/single-element/no identity/no route)

### Behavioral Change

| Scenario | Old Behavior | New Behavior |
|----------|-------------|--------------|
| Required + currentCN has no route | Silent success | Explicit error: `cannot satisfy placement` |
| Required + currentCN has no identity | Silent success | Explicit error |
| Excluded (new policy) | N/A | Excludes currentCN, executes on other CNs |

### Design Decisions

1. `Satisfied` field shifts from "never fails" to "explicit failure" — errors propagate correctly through `scheduleQueryWorkers` → `compileQuery`
2. `dedupeWorkers` + `orderDecisionWorkers` ensure deterministic results (sorted by Addr)
3. All allocations are pure-function returns with no leak/hung/OOM risks (race detector passed)