### PR TITLE
fix: skip HDFS test without namenode

### DIFF
--- a/pkg/fileservice/hdfs_test.go
+++ b/pkg/fileservice/hdfs_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	hdfsDefaultNamenodeAddr = "hdfs://hadoop-namenode.hadoop.svc.cluster.local:9820"
 	hdfsNamenodeAddrEnv     = "HDFS_NAMENODE_ADDR"
 	hdfsNamenodeDialTimeout = 5 * time.Second
 )
@@ -146,7 +147,7 @@ func getHDFSTestAddr(t *testing.T) string {
 
 	addr := os.Getenv(hdfsNamenodeAddrEnv)
 	if addr == "" {
-		t.Skipf("set %s to run HDFS integration test", hdfsNamenodeAddrEnv)
+		addr = hdfsDefaultNamenodeAddr
 	}
 
 	if !strings.HasPrefix(addr, "hdfs://") {

--- a/pkg/fileservice/hdfs_test.go
+++ b/pkg/fileservice/hdfs_test.go
@@ -18,8 +18,17 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"net"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
+	"time"
+)
+
+const (
+	hdfsNamenodeAddrEnv     = "HDFS_NAMENODE_ADDR"
+	hdfsNamenodeDialTimeout = 5 * time.Second
 )
 
 func TestHDFS(t *testing.T) {
@@ -29,14 +38,16 @@ func TestHDFS(t *testing.T) {
 		Path string
 	}
 
+	addr := getHDFSTestAddr(t)
+
 	cases := []Case{
 		{
-			Addr: "hdfs://hadoop-namenode.hadoop.svc.cluster.local:9820",
+			Addr: addr,
 			User: "root",
 			Path: "user/root/mo-test/",
 		},
 		{
-			Addr: "hdfs://hadoop-namenode.hadoop.svc.cluster.local:9820",
+			Addr: addr,
 			User: "runner",
 			Path: "user/runner/mo-test/",
 		},
@@ -128,4 +139,35 @@ func TestHDFS(t *testing.T) {
 		})
 	}
 
+}
+
+func getHDFSTestAddr(t *testing.T) string {
+	t.Helper()
+
+	addr := os.Getenv(hdfsNamenodeAddrEnv)
+	if addr == "" {
+		t.Skipf("set %s to run HDFS integration test", hdfsNamenodeAddrEnv)
+	}
+
+	if !strings.HasPrefix(addr, "hdfs://") {
+		addr = "hdfs://" + addr
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		t.Fatalf("invalid %s: %v", hdfsNamenodeAddrEnv, err)
+	}
+	if u.Host == "" {
+		t.Fatalf("invalid %s: missing namenode host", hdfsNamenodeAddrEnv)
+	}
+
+	conn, err := net.DialTimeout("tcp", u.Host, hdfsNamenodeDialTimeout)
+	if err != nil {
+		t.Skipf("HDFS namenode %q is unavailable: %v", u.Host, err)
+	}
+	if conn != nil {
+		_ = conn.Close()
+	}
+
+	return addr
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25480

## What this PR does / why we need it:

`TestHDFS` hard-codes `hadoop-namenode.hadoop.svc.cluster.local:9820`, which is a Kubernetes-internal HDFS namenode. GitHub Actions runners cannot rely on that service being reachable, so the test can hang until the package-level timeout instead of skipping cleanly.

This change keeps the existing default namenode address so environments with the in-tree HDFS service still run the integration test by default. It also allows overriding the namenode with `HDFS_NAMENODE_ADDR` and adds a short TCP reachability check before constructing the HDFS client. External CI runners now skip quickly when the namenode is unavailable, without silently removing the default in-tree HDFS coverage.