### PR TITLE
chore: update moerr codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,7 +64,7 @@
 /pkg/common/async @XuPeng-SH
 /pkg/common/bitmap @aunjgr @XuPeng-SH
 /pkg/common/hashmap @aunjgr
-/pkg/common/moerr @xzxiong @XuPeng-SH
+/pkg/common/moerr @XuPeng-SH
 /pkg/common/morpc @XuPeng-SH
 /pkg/common/moprobe @fengttt
 /pkg/common/stopper @XuPeng-SH


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # N/A

## What this PR does / why we need it:

This PR updates the CODEOWNERS entry for `/pkg/common/moerr` by removing `@xzxiong` and keeping `@XuPeng-SH` as the owner.

Verification:
- `git diff --check mo/main...HEAD`
- Confirmed `/pkg/common/moerr` still has a valid CODEOWNER entry: `@XuPeng-SH`