### PR TITLE
[4.1] fix publication table lookup for quoted database names

### DIFF
--- a/pkg/frontend/publication_subscription.go
+++ b/pkg/frontend/publication_subscription.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/cdc"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/pubsub"
+	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/publication"
@@ -2151,7 +2152,7 @@ func getDbIdAndTypeForAccount(ctx context.Context, bh BackgroundExec, dbName str
 }
 
 func showTablesFromDb(ctx context.Context, bh BackgroundExec, dbName string) (tables map[string]bool, err error) {
-	sql := "show tables from " + dbName
+	sql := "show tables from " + sqlquote.Ident(dbName)
 
 	bh.ClearExecResultSet()
 	if err = bh.Exec(ctx, sql); err != nil {

--- a/pkg/frontend/publication_subscription_test.go
+++ b/pkg/frontend/publication_subscription_test.go
@@ -115,6 +115,46 @@ func Test_doCreatePublication(t *testing.T) {
 	})
 }
 
+func Test_showTablesFromDbQuotesDatabaseName(t *testing.T) {
+	testCases := []struct {
+		name        string
+		dbName      string
+		expectedSQL string
+	}{
+		{
+			name:        "chinese database name",
+			dbName:      "目标数据",
+			expectedSQL: "show tables from `目标数据`",
+		},
+		{
+			name:        "database name with backtick",
+			dbName:      "a`b",
+			expectedSQL: "show tables from `a``b`",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			bh := mock_frontend.NewMockBackgroundExec(ctrl)
+			bh.EXPECT().ClearExecResultSet()
+			bh.EXPECT().Exec(gomock.Any(), tc.expectedSQL).Return(nil)
+
+			er := mock_frontend.NewMockExecResult(ctrl)
+			er.EXPECT().GetRowCount().Return(uint64(1)).AnyTimes()
+			er.EXPECT().GetString(gomock.Any(), uint64(0), uint64(0)).Return("resume_data", nil).AnyTimes()
+			bh.EXPECT().GetExecResultSet().Return([]interface{}{er})
+
+			tables, err := showTablesFromDb(ctx, bh, tc.dbName)
+			require.NoError(t, err)
+			require.True(t, tables["resume_data"])
+		})
+	}
+}
+
 func Test_doAlterPublication(t *testing.T) {
 	mockedAccountsResults := func(ctrl *gomock.Controller) []interface{} {
 		er := mock_frontend.NewMockExecResult(ctrl)

--- a/test/distributed/cases/publication_subscription/pub_sub_chinese_db_table.result
+++ b/test/distributed/cases/publication_subscription/pub_sub_chinese_db_table.result
@@ -1,0 +1,34 @@
+drop account if exists acc_cn_pub_bvt;
+create account acc_cn_pub_bvt admin_name = 'test_account' identified by '111';
+drop publication if exists pub_cn_table_bvt;
+drop database if exists `目标数据_bvt`;
+create database `目标数据_bvt`;
+use `目标数据_bvt`;
+create table resume_data (id int primary key, name varchar(20));
+create table extra_data (id int primary key, note varchar(20));
+create table hidden_data (id int primary key, note varchar(20));
+insert into resume_data values (1, 'alice'), (2, 'bob');
+insert into extra_data values (7, 'extra');
+insert into hidden_data values (99, 'hidden');
+create publication pub_cn_table_bvt database `目标数据_bvt` table resume_data account acc_cn_pub_bvt;
+alter publication pub_cn_table_bvt database `目标数据_bvt` table resume_data, extra_data;
+drop database if exists sub_cn_table_bvt;
+create database sub_cn_table_bvt from sys publication pub_cn_table_bvt;
+use sub_cn_table_bvt;
+show tables;
+➤ Tables_in_sub_cn_table_bvt[12,-1,0]  𝄀
+extra_data  𝄀
+resume_data
+select * from hidden_data;
+SQL parser error: table "hidden_data" does not exist
+select * from resume_data order by id;
+➤ id[4,32,0]  ¦  name[12,-1,0]  𝄀
+1  ¦  alice  𝄀
+2  ¦  bob
+select * from extra_data order by id;
+➤ id[4,32,0]  ¦  note[12,-1,0]  𝄀
+7  ¦  extra
+drop database sub_cn_table_bvt;
+drop publication pub_cn_table_bvt;
+drop database `目标数据_bvt`;
+drop account acc_cn_pub_bvt;

--- a/test/distributed/cases/publication_subscription/pub_sub_chinese_db_table.sql
+++ b/test/distributed/cases/publication_subscription/pub_sub_chinese_db_table.sql
@@ -1,0 +1,32 @@
+-- table-level publication should work when the source database name needs identifier quoting
+drop account if exists acc_cn_pub_bvt;
+create account acc_cn_pub_bvt admin_name = 'test_account' identified by '111';
+
+drop publication if exists pub_cn_table_bvt;
+drop database if exists `目标数据_bvt`;
+create database `目标数据_bvt`;
+use `目标数据_bvt`;
+create table resume_data (id int primary key, name varchar(20));
+create table extra_data (id int primary key, note varchar(20));
+create table hidden_data (id int primary key, note varchar(20));
+insert into resume_data values (1, 'alice'), (2, 'bob');
+insert into extra_data values (7, 'extra');
+insert into hidden_data values (99, 'hidden');
+
+create publication pub_cn_table_bvt database `目标数据_bvt` table resume_data account acc_cn_pub_bvt;
+alter publication pub_cn_table_bvt database `目标数据_bvt` table resume_data, extra_data;
+
+-- @session:id=1&user=acc_cn_pub_bvt:test_account&password=111
+drop database if exists sub_cn_table_bvt;
+create database sub_cn_table_bvt from sys publication pub_cn_table_bvt;
+use sub_cn_table_bvt;
+show tables;
+select * from hidden_data;
+select * from resume_data order by id;
+select * from extra_data order by id;
+drop database sub_cn_table_bvt;
+-- @session
+
+drop publication pub_cn_table_bvt;
+drop database `目标数据_bvt`;
+drop account acc_cn_pub_bvt;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue matrixorigin/matrixflow#11551

4.1-dev port of matrixorigin/matrixone#25518.

## What this PR does / why we need it:

This ports the publication/subscription fix to 4.1-dev.

Root cause: table-level publication refresh builds `show tables from <db>` by raw string concatenation. Database names that require identifier quoting, such as Chinese database names or names containing backticks, produce invalid SQL or the wrong identifier.

Changes:
- Quote the database name in `showTablesFromDb` with `sqlquote.Ident`.
- Add a unit test covering Chinese database names and embedded backticks.
- Add a BVT case for table-level publication from a Chinese-named source database, including table filtering checks so unpublished tables remain hidden.

Validation:
- `make build`
- `go test -v -count=1 -timeout 120s ./pkg/frontend -run 'Test_showTablesFromDbQuotesDatabaseName'` with MatrixOne CGo flags
- `git diff --check upstream/4.1-dev...HEAD`

Note: local BVT execution against a temporary 4.1 MO did not complete because the local temporary MO process exited during mo-tester cleanup. The added BVT case itself already passed on the main PR CI/local run, and this PR includes it for 4.1 CI coverage.
