### PR TITLE
fix: guard regular index ordered limit pushdown

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -522,6 +522,15 @@ func canUseRegularIndexHiddenSortKey(scanNode *plan.Node, orderByCol *plan.ColRe
 	return isRegularIndexFullPrefixEquality(scanNode.FilterList[0], numKeyParts)
 }
 
+func canPushRegularIndexOrderedLimit(scanNode *plan.Node) bool {
+	if scanNode == nil || len(scanNode.IndexScanInfo.Parts) < 2 || len(scanNode.FilterList) != 1 {
+		return false
+	}
+	// Static limit pushdown is valid only when index scan candidates exactly match the SQL filter.
+	numKeyParts := len(scanNode.IndexScanInfo.Parts) - 1
+	return isRegularIndexFullPrefixEquality(scanNode.FilterList[0], numKeyParts)
+}
+
 func isRegularIndexFullPrefixEquality(expr *plan.Expr, numKeyParts int) bool {
 	if numKeyParts <= 0 || expr == nil {
 		return false
@@ -567,7 +576,9 @@ func (builder *QueryBuilder) applyRegularIndexTopSort(ctx *regularIndexTopSortCo
 		Expr: scanHiddenKeyExpr,
 		Flag: ctx.sortNode.OrderBy[0].Flag,
 	})
-	applyRegularIndexBlockTop(ctx.scanNode, ctx.scanNode.OrderBy[len(ctx.scanNode.OrderBy)-1], ctx.sortNode.Limit)
+	if ctx.sortNode.Offset == nil && ctx.sortNode.RankOption == nil && canPushRegularIndexOrderedLimit(ctx.scanNode) {
+		applyRegularIndexBlockTop(ctx.scanNode, ctx.scanNode.OrderBy[len(ctx.scanNode.OrderBy)-1], ctx.sortNode.Limit)
+	}
 
 	if !hasTopValueMessage(ctx.sortNode) {
 		msgHeader := plan.MsgHeader{

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -670,6 +670,23 @@ func makeTestRegularIndexPrefixEq(t *testing.T, numArgs int) *planpb.Expr {
 	return prefixExpr
 }
 
+func makeTestRegularIndexPKLessThan(t *testing.T, value int64) *planpb.Expr {
+	t.Helper()
+	expr, err := BindFuncExprImplByPlanExpr(context.Background(), "<", []*planpb.Expr{
+		GetColExpr(planpb.Type{Id: int32(types.T_int64)}, 100, 1),
+		{
+			Typ: planpb.Type{Id: int32(types.T_int64)},
+			Expr: &planpb.Expr_Lit{
+				Lit: &planpb.Literal{
+					Value: &planpb.Literal_I64Val{I64Val: value},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return expr
+}
+
 func makeTestRegularIndexProjectBuilder(
 	t *testing.T,
 	prefixArgCount int,
@@ -891,6 +908,28 @@ func TestApplyIndicesForProjectPushesTopValueThroughRegularIndexPKOrderAsc(t *te
 	assert.Equal(t, catalog.IndexTableIndexColName, scanNode.BlockOrderBy[0].Expr.GetCol().Name)
 }
 
+func TestApplyIndicesForProjectSkipsBlockTopWithResidualPKFilter(t *testing.T) {
+	builder, rootNodeID := makeTestRegularIndexProjectBuilder(
+		t,
+		2,
+		GetColExpr(planpb.Type{Id: int32(types.T_int64)}, 100, 1),
+		planpb.OrderBySpec_DESC,
+	)
+	scanNode := builder.qry.Nodes[0]
+	scanNode.FilterList = append(scanNode.FilterList, makeTestRegularIndexPKLessThan(t, 4900))
+
+	_, err := builder.applyIndicesForProject(rootNodeID, builder.qry.Nodes[rootNodeID], map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+	require.NoError(t, err)
+
+	sortNode := builder.qry.Nodes[2]
+	require.Len(t, sortNode.SendMsgList, 1)
+	require.Len(t, scanNode.RecvMsgList, 1)
+	require.Len(t, scanNode.OrderBy, 1)
+	assert.Equal(t, catalog.IndexTableIndexColName, scanNode.OrderBy[0].Expr.GetCol().Name)
+	assert.Empty(t, scanNode.BlockOrderBy)
+	assert.Nil(t, scanNode.BlockLimit)
+}
+
 func TestHandleMessageFromTopToScanRewritesRegularIndexPKOrderToHiddenKey(t *testing.T) {
 	builder, rootNodeID := makeTestRegularIndexMessageBuilder(t, 2, 1, planpb.OrderBySpec_DESC)
 
@@ -966,6 +1005,22 @@ func TestHandleMessageFromTopToScanSkipsBlockTopWithOffsetOrRank(t *testing.T) {
 			assert.Nil(t, scanNode.BlockLimit)
 		})
 	}
+}
+
+func TestHandleMessageFromTopToScanSkipsBlockTopWithResidualPKFilter(t *testing.T) {
+	builder, rootNodeID := makeTestRegularIndexMessageBuilder(t, 2, 1, planpb.OrderBySpec_DESC)
+	scanNode := builder.qry.Nodes[0]
+	scanNode.FilterList = append(scanNode.FilterList, makeTestRegularIndexPKLessThan(t, 4900))
+
+	builder.handleMessageFromTopToScan(rootNodeID)
+
+	sortNode := builder.qry.Nodes[1]
+	require.Len(t, sortNode.SendMsgList, 1)
+	require.Len(t, scanNode.RecvMsgList, 1)
+	require.Len(t, scanNode.OrderBy, 1)
+	assert.Equal(t, catalog.IndexTableIndexColName, scanNode.OrderBy[0].Expr.GetCol().Name)
+	assert.Empty(t, scanNode.BlockOrderBy)
+	assert.Nil(t, scanNode.BlockLimit)
 }
 
 func TestHandleMessageFromTopToScanKeepsPKOrderWhenPrefixIncomplete(t *testing.T) {

--- a/pkg/sql/plan/message.go
+++ b/pkg/sql/plan/message.go
@@ -90,7 +90,7 @@ func (builder *QueryBuilder) handleMessageFromTopToScan(nodeID int32) {
 			Expr: scanHiddenKeyExpr,
 			Flag: node.OrderBy[0].Flag,
 		}
-		enableBlockTop = node.Offset == nil && node.RankOption == nil
+		enableBlockTop = node.Offset == nil && node.RankOption == nil && canPushRegularIndexOrderedLimit(scanNode)
 	}
 	if orderByCol.RelPos != scanNode.BindingTags[0] {
 		return

--- a/test/distributed/cases/optimizer/regular_index_order_limit_cursor.result
+++ b/test/distributed/cases/optimizer/regular_index_order_limit_cursor.result
@@ -1,0 +1,62 @@
+drop database if exists regular_index_order_limit_cursor;
+create database regular_index_order_limit_cursor;
+use regular_index_order_limit_cursor;
+create table t (
+id varchar(64) primary key,
+user_id varchar(64) not null,
+is_active tinyint default 1,
+content text,
+key idx_user(user_id, is_active)
+);
+insert into t
+select
+concat('id_', lpad(result, 8, '0')),
+'u1',
+1,
+concat('content_', result)
+from generate_series(1, 50) g;
+select case when mo_ctl('dn', 'flush', 'regular_index_order_limit_cursor.t') is not null then 1 else 0 end as flushed;
+flushed
+1
+select Sleep(1);
+Sleep(1)
+0
+select id
+from t
+where user_id = 'u1'
+and is_active = 1
+and id < 'id_00000040'
+order by id desc
+limit 5;
+id
+id_00000039
+id_00000038
+id_00000037
+id_00000036
+id_00000035
+select id
+from t
+where user_id = 'u1'
+and is_active = 1
+and id > 'id_00000010'
+order by id asc
+limit 5;
+id
+id_00000011
+id_00000012
+id_00000013
+id_00000014
+id_00000015
+select id
+from t
+where user_id = 'u1'
+and is_active = 1
+and id < 'id_00000005'
+order by id desc
+limit 10;
+id
+id_00000004
+id_00000003
+id_00000002
+id_00000001
+drop database regular_index_order_limit_cursor;

--- a/test/distributed/cases/optimizer/regular_index_order_limit_cursor.sql
+++ b/test/distributed/cases/optimizer/regular_index_order_limit_cursor.sql
@@ -1,0 +1,53 @@
+-- @suite
+-- @case
+-- @desc: regression for regular secondary index ORDER BY PK LIMIT with cursor filter
+-- @label:bvt
+
+drop database if exists regular_index_order_limit_cursor;
+create database regular_index_order_limit_cursor;
+use regular_index_order_limit_cursor;
+
+create table t (
+  id varchar(64) primary key,
+  user_id varchar(64) not null,
+  is_active tinyint default 1,
+  content text,
+  key idx_user(user_id, is_active)
+);
+
+insert into t
+select
+  concat('id_', lpad(result, 8, '0')),
+  'u1',
+  1,
+  concat('content_', result)
+from generate_series(1, 50) g;
+
+select case when mo_ctl('dn', 'flush', 'regular_index_order_limit_cursor.t') is not null then 1 else 0 end as flushed;
+select Sleep(1);
+
+select id
+from t
+where user_id = 'u1'
+  and is_active = 1
+  and id < 'id_00000040'
+order by id desc
+limit 5;
+
+select id
+from t
+where user_id = 'u1'
+  and is_active = 1
+  and id > 'id_00000010'
+order by id asc
+limit 5;
+
+select id
+from t
+where user_id = 'u1'
+  and is_active = 1
+  and id < 'id_00000005'
+order by id desc
+limit 10;
+
+drop database regular_index_order_limit_cursor;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23965

## What this PR does / why we need it:

The regular secondary index ORDER BY primary-key LIMIT optimization can push a static scan-side limit when the secondary-index prefix is fixed.
With an extra primary-key cursor predicate, for example `id < ...`, the scan candidates no longer exactly match the SQL filter. Applying the static limit before the residual filter can return too few rows, or even zero rows.

This PR keeps the hidden-key ordering rewrite and TopValue message path, but only enables BlockTop/static limit pushdown when the index scan filter list is exactly the full-prefix equality filter.
Residual filters continue to be applied before the final LIMIT semantics are observed.

Added a BVT regression case:
`test/distributed/cases/optimizer/regular_index_order_limit_cursor.sql`

Tested with:

`env GOCACHE=/private/tmp/mo-go-build-cache-30 CGO_CFLAGS='-I/Users/shenjiangwei/Work/code/view/matrixone/cgo -I/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/include' CGO_LDFLAGS='-Wl,-w,-rpath,/Users/shenjiangwei/Work/code/view/matrixone/cgo -Wl,-rpath,/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/lib -L/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/lib -L/Users/shenjiangwei/Work/code/view/matrixone/cgo -lmo' go test ./pkg/sql/plan -count=1`
