### PR TITLE
fix(frontend): force recompile on each prepared binary execute to prevent hang

### DIFF
--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -461,7 +461,7 @@ func initExecuteStmtParam(execCtx *ExecCtx, ses *Session, cwft *TxnComputationWr
 		}
 	}
 
-	// rebuild and recompile
+	// rebuild plan when schema changed
 	if change {
 		originPrepareStmt := &tree.PrepareStmt{
 			Name: tree.Identifier(prepareStmt.Name),
@@ -471,37 +471,35 @@ func initExecuteStmtParam(execCtx *ExecCtx, ses *Session, cwft *TxnComputationWr
 		if err != nil {
 			return nil, nil, nil, "", err
 		}
-
-		if prepareStmt.compile != nil {
-			prepareStmt.compile.FreeOperator()
-			prepareStmt.compile.SetIsPrepare(false)
-			prepareStmt.compile.Release()
-			prepareStmt.compile = nil // set nil and recompile later
-		}
-
 		preparePlan = newPlan.GetDcl().GetPrepare()
-		if _, ok := preparePlan.Plan.Plan.(*plan.Plan_Query); ok {
-			//only DQL & DML will pre compile
-			comp, err := createCompile(execCtx, ses, ses.proc, originSQL, prepareStmt.PrepareStmt, preparePlan.Plan, ses.GetOutputCallback(execCtx), true)
-			if err != nil {
-				if !moerr.IsMoErrCode(err, moerr.ErrCantCompileForPrepare) {
-					return nil, nil, nil, "", err
-				}
-			}
-			// do not save ap query now()
-			if comp != nil && !comp.IsTpQuery() {
-				comp.SetIsPrepare(false)
-				comp.Release()
-				comp = nil
-			}
-			prepareStmt.compile = comp
-
-		}
 		prepareStmt.PreparePlan = newPlan
-
 		prepareStmt.Ts = timestamp.Timestamp{PhysicalTime: time.Now().Unix()}
 	}
-
+	
+	// Always recreate the compile to avoid stale operator state (e.g. hashbuild ctr,
+	// dispatch channels) from previous executions when the plan is reused.
+	// See: https://github.com/matrixorigin/mo/issues/25526
+	if prepareStmt.compile != nil {
+		prepareStmt.compile.FreeOperator()
+		prepareStmt.compile.SetIsPrepare(false)
+		prepareStmt.compile.Release()
+		prepareStmt.compile = nil
+	}
+	if _, ok := preparePlan.Plan.Plan.(*plan.Plan_Query); ok {
+		comp, err := createCompile(execCtx, ses, ses.proc, originSQL, prepareStmt.PrepareStmt, preparePlan.Plan, ses.GetOutputCallback(execCtx), true)
+		if err != nil {
+			if !moerr.IsMoErrCode(err, moerr.ErrCantCompileForPrepare) {
+				return nil, nil, nil, "", err
+			}
+		}
+		// do not save ap query now()
+		if comp != nil && !comp.IsTpQuery() {
+			comp.SetIsPrepare(false)
+			comp.Release()
+			comp = nil
+		}
+		prepareStmt.compile = comp
+	}
 	numParams := len(preparePlan.ParamTypes)
 	if prepareStmt.params != nil && prepareStmt.params.Length() > 0 { // use binary protocol
 		if prepareStmt.params.Length() != numParams {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -75,6 +75,7 @@ import (
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/rule"
+	"github.com/matrixorigin/matrixone/pkg/sql/schedule"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	mokafka "github.com/matrixorigin/matrixone/pkg/stream/adapter/kafka"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
@@ -264,6 +265,7 @@ func (c *Compile) clear() {
 	c.proc = nil
 
 	c.cnList = c.cnList[:0]
+	c.queryPlacement = schedule.QueryDecision{}
 	c.stmt = nil
 	c.startAt = time.Time{}
 	c.needLockMeta = false
@@ -1387,6 +1389,12 @@ func (c *Compile) constructScopeForExternal(addr string, parallel bool) *Scope {
 	return ds
 }
 
+func (c *Compile) constructScopeForExternalNode(node engine.Node, parallel bool) *Scope {
+	scope := c.constructScopeForExternal(node.Addr, parallel)
+	scope.NodeInfo.Id = node.Id
+	return scope
+}
+
 func (c *Compile) constructLoadMergeScope() *Scope {
 	ds := c.newEmptyMergeScope()
 	ds.Proc = c.proc.NewNoContextChildProc(1)
@@ -1972,6 +1980,7 @@ func (c *Compile) compileExternScanWholeFileFanout(node *plan.Node, param *tree.
 	}
 
 	ss := make([]*Scope, 0, len(shards))
+	stageNodes := c.queryWorkerStageNodes()
 	currentFirstFlag := c.anal.isFirst
 	for i := range shards {
 		shard := shards[i]
@@ -1982,8 +1991,8 @@ func (c *Compile) compileExternScanWholeFileFanout(node *plan.Node, param *tree.
 		// preserving Extern.Filepath as the Hive base path for partition fills.
 		shardParam.Parallel = false
 
-		remote := param.ScanType == tree.S3 && len(c.cnList) > 0
-		scope := c.constructScopeForExternal(shard.node.Addr, remote)
+		remote := param.ScanType == tree.S3 && len(stageNodes) > 0
+		scope := c.constructScopeForExternalNode(shard.node, remote)
 		scope.NodeInfo.Mcpu = 1
 		scope.IsLoad = true
 		op := constructExternal(
@@ -2020,6 +2029,7 @@ func (c *Compile) compileExternScanParquetRowGroupFanout(
 	}
 
 	ss := make([]*Scope, 0, len(shards))
+	stageNodes := c.queryWorkerStageNodes()
 	currentFirstFlag := c.anal.isFirst
 	for i := range shards {
 		shard := shards[i]
@@ -2027,8 +2037,8 @@ func (c *Compile) compileExternScanParquetRowGroupFanout(
 		*shardParam = *param
 		shardParam.Parallel = false
 
-		remote := param.ScanType == tree.S3 && len(c.cnList) > 0
-		scope := c.constructScopeForExternal(shard.node.Addr, remote)
+		remote := param.ScanType == tree.S3 && len(stageNodes) > 0
+		scope := c.constructScopeForExternalNode(shard.node, remote)
 		scope.NodeInfo.Mcpu = 1
 		scope.IsLoad = true
 		op := constructExternal(
@@ -2233,9 +2243,10 @@ func (c *Compile) getHiveFileFanoutNodes(param *tree.ExternParam, fileCount int)
 	if fileCount <= 0 {
 		return nil
 	}
-	if param.ScanType == tree.S3 && len(c.cnList) > 0 {
+	stageNodes := c.queryWorkerStageNodes()
+	if param.ScanType == tree.S3 && len(stageNodes) > 0 {
 		nodes := make([]engine.Node, 0, fileCount)
-		for _, node := range c.cnList {
+		for _, node := range stageNodes {
 			mcpu := node.Mcpu
 			if mcpu <= 0 {
 				mcpu = 1
@@ -2474,21 +2485,25 @@ func (c *Compile) compileExternScanParallelReadWrite(node *plan.Node, param *tre
 
 	var mcpu int
 	var ID2Addr map[int]int = make(map[int]int, 0)
+	stageNodes := c.queryWorkerStageNodes()
+	if len(stageNodes) == 0 {
+		return nil, moerr.NewInternalErrorNoCtx("external scan stage has no query workers")
+	}
 
 	if param.ScanType == tree.S3 {
-		for i := 0; i < len(c.cnList); i++ {
+		for i := 0; i < len(stageNodes); i++ {
 			tmp := mcpu
-			if c.cnList[i].Mcpu > external.S3ParallelMaxnum {
+			if stageNodes[i].Mcpu > external.S3ParallelMaxnum {
 				mcpu += external.S3ParallelMaxnum
 			} else {
-				mcpu += c.cnList[i].Mcpu
+				mcpu += stageNodes[i].Mcpu
 			}
 			ID2Addr[i] = mcpu - tmp
 		}
 	} else {
-		for i := 0; i < len(c.cnList); i++ {
+		for i := 0; i < len(stageNodes); i++ {
 			tmp := mcpu
-			mcpu += c.cnList[i].Mcpu
+			mcpu += stageNodes[i].Mcpu
 			ID2Addr[i] = mcpu - tmp
 		}
 	}
@@ -2508,8 +2523,8 @@ func (c *Compile) compileExternScanParallelReadWrite(node *plan.Node, param *tre
 	var ss []*Scope
 	pre := 0
 	currentFirstFlag := c.anal.isFirst
-	for i := 0; i < len(c.cnList); i++ {
-		scope := c.constructScopeForExternal(c.cnList[i].Addr, param.Parallel)
+	for i := 0; i < len(stageNodes); i++ {
+		scope := c.constructScopeForExternalNode(stageNodes[i], param.Parallel)
 		ss = append(ss, scope)
 		scope.IsLoad = true
 		count := min(parallelSize, ID2Addr[i])
@@ -2531,7 +2546,7 @@ func (c *Compile) compileExternScanParallelReadWrite(node *plan.Node, param *tre
 				fileOffsetTmp[j].Offset = append(fileOffsetTmp[j].Offset, fileOffset[j][2*preIndex:2*preIndex+2*count]...)
 			}
 		}
-		logutil.Infof("compileExternScanParallelReadWrite, len of cnList is %d, cn addr is %s, mcpu is %d, filepath is %s, file size is %d", len(c.cnList), c.cnList[i].Addr, scope.NodeInfo.Mcpu, param.ExParamConst.Filepath, param.ExParamConst.FileSize)
+		logutil.Infof("compileExternScanParallelReadWrite, len of cnList is %d, cn addr is %s, mcpu is %d, filepath is %s, file size is %d", len(stageNodes), stageNodes[i].Addr, scope.NodeInfo.Mcpu, param.ExParamConst.Filepath, param.ExParamConst.FileSize)
 		logutil.Infof("compileExternScanParallelReadWrite, %v\n", fileOffsetTmp)
 		op := constructExternal(node, param, c.proc.Ctx, fileList, fileSize, fileOffsetTmp, strictSqlMode)
 		op.SetAnalyzeControl(c.anal.curNodeIdx, currentFirstFlag)
@@ -3040,7 +3055,7 @@ func (c *Compile) compileUnion(node *plan.Node, left []*Scope, right []*Scope) [
 }
 
 func (c *Compile) compileTpMinusAndIntersect(left []*Scope, right []*Scope, nodeType plan.Node_NodeType) []*Scope {
-	rs := c.newScopeListOnCurrentCN(2, 1)
+	rs := c.newScopeListOnSingleWorkerStage(2, 1)
 	rs[0].PreScopes = append(rs[0].PreScopes, left[0], right[0])
 
 	connectLeftArg := connector.NewArgument().WithReg(rs[0].Proc.Reg.MergeReceivers[0])
@@ -3082,7 +3097,7 @@ func (c *Compile) compileMinusAndIntersect(node *plan.Node, left []*Scope, right
 	if c.IsSingleScope(left) && c.IsSingleScope(right) {
 		return c.compileTpMinusAndIntersect(left, right, nodeType)
 	}
-	rs := c.newScopeListOnCurrentCN(2, int(node.Stats.Dop))
+	rs := c.newScopeListOnSingleWorkerStage(2, int(node.Stats.Dop))
 	rs = c.newScopeListForMinusAndIntersect(rs, left, right, node)
 
 	c.hasMergeOp = true
@@ -3137,7 +3152,8 @@ func (c *Compile) compileUnionAll(node *plan.Node, ss []*Scope, children []*Scop
 
 func (c *Compile) compileJoin(node, left, right *plan.Node, probeScopes, buildScopes []*Scope) []*Scope {
 	if node.Stats.HashmapStats.Shuffle {
-		if len(c.cnList) == 1 {
+		stageNodes := c.queryWorkerStageNodes()
+		if len(stageNodes) == 1 {
 			if node.JoinType == plan.Node_DEDUP && node.Stats.HashmapStats.ShuffleType == plan.ShuffleType_Hash {
 				logutil.Infof("not support shuffle v2 for dedup join now")
 			} else if probeScopes[0].NodeInfo.Mcpu != int(left.Stats.Dop) || buildScopes[0].NodeInfo.Mcpu != int(right.Stats.Dop) {
@@ -3162,7 +3178,7 @@ func (c *Compile) compileShuffleJoinV2(node, left, right *plan.Node, leftscopes,
 	}
 
 	reuse := node.Stats.HashmapStats.ShuffleMethod == plan.ShuffleMethod_Reuse
-	bucketNum := len(c.cnList) * int(node.Stats.Dop)
+	bucketNum := len(c.queryWorkerStageNodes()) * int(node.Stats.Dop)
 	for i := range leftscopes {
 		leftscopes[i].PreScopes = append(leftscopes[i].PreScopes, rightscopes[i])
 		if !reuse {
@@ -3425,7 +3441,7 @@ func (c *Compile) compileBuildSideForBroadcastJoin(node *plan.Node, rs, buildSco
 
 	buildScopeAttached := false
 	for i := range rs {
-		if isSameCN(rs[i].NodeInfo.Addr, buildScopes[0].NodeInfo.Addr) {
+		if sameExecutionNode(rs[i].NodeInfo, buildScopes[0].NodeInfo) {
 			rs[i].PreScopes = append(rs[i].PreScopes, buildScopes[0])
 			buildScopeAttached = true
 			break
@@ -3435,13 +3451,14 @@ func (c *Compile) compileBuildSideForBroadcastJoin(node *plan.Node, rs, buildSco
 		rs[0].PreScopes = append(rs[0].PreScopes, buildScopes[0])
 	}
 
-	buildOpScopes := make([]*Scope, 0, len(c.cnList))
-	probeScopeGroups := c.groupBroadcastProbeScopesByCN(rs)
+	stageNodes := c.queryWorkerStageNodes()
+	buildOpScopes := make([]*Scope, 0, len(stageNodes))
+	probeScopeGroups := c.groupBroadcastProbeScopesByCN(rs, stageNodes)
 
-	if len(rs) > len(c.cnList) || hasMultiScopeGroup(probeScopeGroups) { // probe side is shuffle scopes
+	if len(rs) > len(stageNodes) || hasMultiScopeGroup(probeScopeGroups) { // probe side is shuffle scopes
 		for _, tmp := range probeScopeGroups {
 			bs := newScope(Remote)
-			bs.NodeInfo = engine.Node{Addr: tmp[0].NodeInfo.Addr, Mcpu: 1}
+			bs.NodeInfo = scopeNodeWithMcpu(tmp[0].NodeInfo, 1)
 			bs.Proc = c.proc.NewNoContextChildProc(0)
 			edge := process.NewPipelineEdge(10, 0)
 			bs.Proc.Reg.MergeReceivers = append(bs.Proc.Reg.MergeReceivers, edge)
@@ -3464,7 +3481,7 @@ func (c *Compile) compileBuildSideForBroadcastJoin(node *plan.Node, rs, buildSco
 
 	for i := range rs {
 		bs := newScope(Remote)
-		bs.NodeInfo = engine.Node{Addr: rs[i].NodeInfo.Addr, Mcpu: 1}
+		bs.NodeInfo = scopeNodeWithMcpu(rs[i].NodeInfo, 1)
 		bs.Proc = c.proc.NewNoContextChildProc(0)
 		edge := process.NewPipelineEdge(10, 0)
 		bs.Proc.Reg.MergeReceivers = append(bs.Proc.Reg.MergeReceivers, edge)
@@ -3484,14 +3501,14 @@ func (c *Compile) compileBuildSideForBroadcastJoin(node *plan.Node, rs, buildSco
 	return rs
 }
 
-func (c *Compile) groupBroadcastProbeScopesByCN(rs []*Scope) [][]*Scope {
+func (c *Compile) groupBroadcastProbeScopesByCN(rs []*Scope, stageNodes engine.Nodes) [][]*Scope {
 	groups := make([][]*Scope, 0, len(rs))
 	used := make([]bool, len(rs))
 
-	for _, cn := range c.cnList {
+	for _, cn := range stageNodes {
 		var group []*Scope
 		for i := range rs {
-			if !used[i] && isSameCN(cn.Addr, rs[i].NodeInfo.Addr) {
+			if !used[i] && sameExecutionNode(cn, rs[i].NodeInfo) {
 				group = append(group, rs[i])
 				used[i] = true
 			}
@@ -3508,7 +3525,7 @@ func (c *Compile) groupBroadcastProbeScopesByCN(rs []*Scope) [][]*Scope {
 		group := []*Scope{rs[i]}
 		used[i] = true
 		for j := i + 1; j < len(rs); j++ {
-			if !used[j] && isSameCN(rs[i].NodeInfo.Addr, rs[j].NodeInfo.Addr) {
+			if !used[j] && sameExecutionNode(rs[i].NodeInfo, rs[j].NodeInfo) {
 				group = append(group, rs[j])
 				used[j] = true
 			}
@@ -3983,7 +4000,8 @@ func (c *Compile) compileShuffleGroupV2(node *plan.Node, inputSS []*Scope, nodes
 }
 
 func (c *Compile) compileShuffleGroup(node *plan.Node, inputSS []*Scope, nodes []*plan.Node) []*Scope {
-	if len(c.cnList) == 1 {
+	stageNodes := c.queryWorkerStageNodes()
+	if len(stageNodes) == 1 {
 		return c.compileShuffleGroupV2(node, inputSS, nodes)
 	}
 
@@ -3999,7 +4017,7 @@ func (c *Compile) compileShuffleGroup(node *plan.Node, inputSS []*Scope, nodes [
 	}
 
 	inputSS = c.mergeShuffleScopesIfNeeded(inputSS, true)
-	if len(c.cnList) > 1 {
+	if len(stageNodes) > 1 {
 		// merge here to avoid bugs, delete this in the future
 		for i := range inputSS {
 			if inputSS[i].NodeInfo.Mcpu > 1 {
@@ -4008,10 +4026,10 @@ func (c *Compile) compileShuffleGroup(node *plan.Node, inputSS []*Scope, nodes [
 		}
 	}
 
-	shuffleGroups := make([]*Scope, 0, len(c.cnList))
+	shuffleGroups := make([]*Scope, 0, len(stageNodes))
 	dop := int(node.Stats.Dop)
-	for _, cn := range c.cnList {
-		scopes := c.newScopeListWithNode(dop, len(inputSS), cn.Addr)
+	for _, cn := range stageNodes {
+		scopes := c.newScopeListWithNode(dop, len(inputSS), cn)
 		for _, s := range scopes {
 			for _, rr := range s.Proc.Reg.MergeReceivers {
 				rr.ResetForReuse(shuffleChannelBufferSize, rr.NilBatchCnt)
@@ -4025,7 +4043,7 @@ func (c *Compile) compileShuffleGroup(node *plan.Node, inputSS []*Scope, nodes [
 		shuffleArg := constructShuffleArgForGroup(shuffleGroups, node)
 		shuffleArg.SetAnalyzeControl(c.anal.curNodeIdx, false)
 		inputSS[i].setRootOperator(shuffleArg)
-		if len(c.cnList) > 1 && inputSS[i].NodeInfo.Mcpu > 1 { // merge here to avoid bugs, delete this in the future
+		if len(stageNodes) > 1 && inputSS[i].NodeInfo.Mcpu > 1 { // merge here to avoid bugs, delete this in the future
 			inputSS[i] = c.newMergeScopeByCN([]*Scope{inputSS[i]}, inputSS[i].NodeInfo)
 		}
 		dispatchArg := constructDispatch(j, shuffleGroups, inputSS[i], node, false)
@@ -4044,22 +4062,22 @@ func (c *Compile) compileShuffleGroup(node *plan.Node, inputSS []*Scope, nodes [
 	c.anal.isFirst = false
 
 	//append prescopes
-	c.appendPrescopes(shuffleGroups, inputSS)
+	c.appendPrescopes(shuffleGroups, inputSS, stageNodes)
 	return shuffleGroups
 
 }
 
-func (c *Compile) appendPrescopes(parents, children []*Scope) {
-	for _, cn := range c.cnList {
+func (c *Compile) appendPrescopes(parents, children []*Scope, stageNodes engine.Nodes) {
+	for _, cn := range stageNodes {
 		index := 0
 		for i := range parents {
-			if isSameCN(cn.Addr, parents[i].NodeInfo.Addr) {
+			if sameExecutionNode(cn, parents[i].NodeInfo) {
 				index = i
 				break
 			}
 		}
 		for i := range children {
-			if isSameCN(cn.Addr, children[i].NodeInfo.Addr) {
+			if sameExecutionNode(cn, children[i].NodeInfo) {
 				parents[index].PreScopes = append(parents[index].PreScopes, children[i])
 			}
 		}
@@ -4100,8 +4118,9 @@ func (c *Compile) compileInsert(nodes []*plan.Node, node *plan.Node, ss []*Scope
 			// use unique filename directives (%U / %<n>N), so they are safe
 			// to keep unmerged.
 			var localSS, remoteSS []*Scope
+			currentNode := toEngineNode(c.currentCNWorker())
 			for _, s := range ss {
-				if isSameCN(s.NodeInfo.Addr, c.addr) {
+				if sameExecutionNode(s.NodeInfo, currentNode) {
 					localSS = append(localSS, s)
 				} else {
 					remoteSS = append(remoteSS, s)
@@ -4267,7 +4286,7 @@ func (c *Compile) compileMultiUpdate(node *plan.Node, ss []*Scope) ([]*Scope, er
 					mergeArg.SetAnalyzeControl(c.anal.curNodeIdx, currentFirstFlag)
 					ss[i].setRootOperator(mergeArg)
 					ss[i].Proc = c.proc.NewNoContextChildProc(1)
-					ss[i].NodeInfo = engine.Node{Addr: oldScope.NodeInfo.Addr, Mcpu: 1}
+					ss[i].NodeInfo = scopeNodeWithMcpu(oldScope.NodeInfo, 1)
 				}
 				_, dispatchOp := constructDispatchLocalAndRemote(0, ss, oldScope)
 				dispatchOp.FuncId = dispatch.SendToAnyLocalFunc
@@ -4553,7 +4572,7 @@ func (c *Compile) newDeleteMergeScope(arg *deletion.Deletion, ss []*Scope, node 
 	rs := make([]*Scope, len(ss))
 	for i := 0; i < len(ss); i++ {
 		rs[i] = newScope(Remote)
-		rs[i].NodeInfo = engine.Node{Addr: ss[i].NodeInfo.Addr, Mcpu: 1}
+		rs[i].NodeInfo = scopeNodeWithMcpu(ss[i].NodeInfo, 1)
 		rs[i].PreScopes = append(rs[i].PreScopes, ss[i])
 		rs[i].Proc = c.proc.NewNoContextChildProc(len(ss))
 		mergeOp := merge.NewArgument()
@@ -4583,7 +4602,7 @@ func (c *Compile) newDeleteMergeScope(arg *deletion.Deletion, ss []*Scope, node 
 
 func (c *Compile) newEmptyMergeScope() *Scope {
 	rs := newScope(Merge)
-	rs.NodeInfo = engine.Node{Addr: c.addr, Mcpu: 1} //merge scope is single parallel by default
+	rs.NodeInfo = scopeNodeWithMcpu(toEngineNode(c.currentCNWorker()), 1) //merge scope is single parallel by default
 	return rs
 }
 
@@ -4606,7 +4625,7 @@ func (c *Compile) newMergeScope(ss []*Scope) *Scope {
 	j := 0
 	for i := range ss {
 		nilBatchCnt := 1
-		if isSameCN(rs.NodeInfo.Addr, ss[i].NodeInfo.Addr) {
+		if sameExecutionNode(rs.NodeInfo, ss[i].NodeInfo) {
 			nilBatchCnt = ss[i].NodeInfo.Mcpu
 		}
 		rs.Proc.Reg.MergeReceivers[j].ResetForReuse(ss[i].NodeInfo.Mcpu, nilBatchCnt)
@@ -4620,20 +4639,46 @@ func (c *Compile) newMergeScope(ss []*Scope) *Scope {
 	return rs
 }
 
-// newScopeListOnCurrentCN traverse the cnList and only generate Scope list for the current CN node
-// waing: newScopeListOnCurrentCN result is only used to build Scope and add one merge operator.
+// newScopeListOnSingleWorkerStage builds a single-worker stage. If query
+// placement already collapsed to one worker, inherit that worker; otherwise
+// keep the legacy current-CN coordinator for multi-CN stages.
+//
+// waing: newScopeListOnSingleWorkerStage result is only used to build Scope and add one merge operator.
 // If other operators are added, please let @qingxinhome know
-func (c *Compile) newScopeListOnCurrentCN(childrenCount int, mcpu int) []*Scope {
-	node := getEngineNode(c)
-	ss := c.newScopeListWithNode(mcpu, childrenCount, node.Addr)
+func (c *Compile) newScopeListOnSingleWorkerStage(childrenCount int, mcpu int) []*Scope {
+	node := c.singleWorkerStageNode()
+	ss := c.newScopeListWithNode(mcpu, childrenCount, node)
 	return ss
+}
+
+func (c *Compile) singleWorkerStageNode() engine.Node {
+	decision := schedule.DecideSingleWorkerStagePlacement(schedule.StageRequest{
+		QueryWorkers: c.scheduledQueryWorkers(),
+		CurrentCN:    c.currentCNWorker(),
+	})
+	return c.materializeScheduledWorker(decision.Worker)
+}
+
+func (c *Compile) queryWorkerStageNodes() engine.Nodes {
+	decision := schedule.DecideQueryWorkerStagePlacement(schedule.StageRequest{
+		QueryWorkers: c.scheduledQueryWorkers(),
+		CurrentCN:    c.currentCNWorker(),
+	})
+	return c.materializeScheduledWorkers(decision.Workers)
+}
+
+func scopeNodeWithMcpu(node engine.Node, mcpu int) engine.Node {
+	return engine.Node{
+		Id:   node.Id,
+		Addr: node.Addr,
+		Mcpu: normalizeMcpu(mcpu),
+	}
 }
 
 // all scopes in ss are on the same CN
 func (c *Compile) newMergeScopeByCN(ss []*Scope, nodeinfo engine.Node) *Scope {
 	rs := newScope(Remote)
-	rs.NodeInfo.Addr = nodeinfo.Addr
-	rs.NodeInfo.Mcpu = 1 // merge scope is single parallel by default
+	rs.NodeInfo = scopeNodeWithMcpu(nodeinfo, 1) // merge scope is single parallel by default
 	rs.PreScopes = ss
 	rs.Proc = c.proc.NewNoContextChildProc(1)
 	nilBatchCnt := 0
@@ -4661,13 +4706,12 @@ func (c *Compile) newMergeScopeByCN(ss []*Scope, nodeinfo engine.Node) *Scope {
 
 // waing: newScopeListWithNode only used to build Scope with cpuNum and add one merge operator.
 // If other operators are added, please let @qingxinhome know
-func (c *Compile) newScopeListWithNode(mcpu, childrenCount int, addr string) []*Scope {
+func (c *Compile) newScopeListWithNode(mcpu, childrenCount int, node engine.Node) []*Scope {
 	ss := make([]*Scope, mcpu)
 	for i := range ss {
 		ss[i] = newScope(Remote)
 		ss[i].Magic = Remote
-		ss[i].NodeInfo.Addr = addr
-		ss[i].NodeInfo.Mcpu = 1 // ss is already the mcpu length so we don't need to parallel it
+		ss[i].NodeInfo = scopeNodeWithMcpu(node, 1) // ss is already the mcpu length so we don't need to parallel it
 		ss[i].Proc = c.proc.NewNoContextChildProc(childrenCount)
 
 		// The merge operator does not act as First/Last, It needs to handle its analyze status
@@ -4702,10 +4746,11 @@ func (c *Compile) newScopeListForMinusAndIntersect(rs, left, right []*Scope, nod
 }
 
 func (c *Compile) mergeShuffleScopesIfNeeded(ss []*Scope, force bool) []*Scope {
-	if len(c.cnList) == 1 && !force {
+	stageNodes := c.queryWorkerStageNodes()
+	if len(stageNodes) == 1 && !force {
 		return ss
 	}
-	if len(ss) <= len(c.cnList) {
+	if len(ss) <= len(stageNodes) {
 		return ss
 	}
 	for i := range ss {
@@ -4713,7 +4758,7 @@ func (c *Compile) mergeShuffleScopesIfNeeded(ss []*Scope, force bool) []*Scope {
 			return ss
 		}
 	}
-	rs := c.mergeScopesByCN(ss)
+	rs := c.mergeScopesByStageNodes(ss, stageNodes)
 	for i := range rs {
 		for _, rr := range rs[i].Proc.Reg.MergeReceivers {
 			rr.ResetForReuse(shuffleChannelBufferSize, rr.NilBatchCnt)
@@ -4770,7 +4815,8 @@ func scopeTreeHasCrossCNDispatch(s *Scope) bool {
 // doSetRootOperator) appends a connector *on top of* that existing root using AppendChild
 // semantics, so the caller's operator is preserved as the connector's child, not replaced.
 func (c *Compile) groupShuffleBucketsByCNIfNeeded(ss []*Scope) []*Scope {
-	if len(c.cnList) <= 1 || len(ss) <= len(c.cnList) {
+	stageNodes := c.queryWorkerStageNodes()
+	if len(stageNodes) <= 1 || len(ss) <= len(stageNodes) {
 		return ss
 	}
 	hasCrossCNDispatch := false
@@ -4783,16 +4829,16 @@ func (c *Compile) groupShuffleBucketsByCNIfNeeded(ss []*Scope) []*Scope {
 	if !hasCrossCNDispatch {
 		return ss
 	}
-	return c.mergeScopesByCN(ss)
+	return c.mergeScopesByStageNodes(ss, stageNodes)
 }
 
-func (c *Compile) mergeScopesByCN(ss []*Scope) []*Scope {
-	rs := make([]*Scope, 0, len(c.cnList))
-	for i := range c.cnList {
-		cn := c.cnList[i]
+func (c *Compile) mergeScopesByStageNodes(ss []*Scope, stageNodes engine.Nodes) []*Scope {
+	rs := make([]*Scope, 0, len(stageNodes))
+	for i := range stageNodes {
+		cn := stageNodes[i]
 		currentSS := make([]*Scope, 0, cn.Mcpu)
 		for j := range ss {
-			if isSameCN(ss[j].NodeInfo.Addr, cn.Addr) {
+			if sameExecutionNode(ss[j].NodeInfo, cn) {
 				currentSS = append(currentSS, ss[j])
 			}
 		}
@@ -4806,7 +4852,7 @@ func (c *Compile) mergeScopesByCN(ss []*Scope) []*Scope {
 }
 
 func (c *Compile) newShuffleJoinScopeList(probeScopes, buildScopes []*Scope, node *plan.Node) []*Scope {
-	cnlist := c.cnList
+	cnlist := c.queryWorkerStageNodes()
 	if len(cnlist) <= 1 {
 		node.Stats.HashmapStats.ShuffleTypeForMultiCN = plan.ShuffleTypeForMultiCN_Simple
 	}
@@ -4840,8 +4886,7 @@ func (c *Compile) newShuffleJoinScopeList(probeScopes, buildScopes []*Scope, nod
 			builds := make([]*Scope, dop)
 			for i := range probes {
 				probes[i] = newScope(Remote)
-				probes[i].NodeInfo.Addr = cn.Addr
-				probes[i].NodeInfo.Mcpu = 1
+				probes[i].NodeInfo = scopeNodeWithMcpu(cn, 1)
 				probes[i].Proc = c.proc.NewNoContextChildProc(lenLeft)
 
 				builds[i] = newScope(Remote)
@@ -4893,7 +4938,7 @@ func (c *Compile) newShuffleJoinScopeList(probeScopes, buildScopes []*Scope, nod
 			probeScopes[i].IsEnd = true
 
 			for _, js := range shuffleProbes {
-				if isSameCN(js.NodeInfo.Addr, probeScopes[i].NodeInfo.Addr) {
+				if sameExecutionNode(js.NodeInfo, probeScopes[i].NodeInfo) {
 					js.PreScopes = append(js.PreScopes, probeScopes[i])
 					break
 				}
@@ -4918,7 +4963,7 @@ func (c *Compile) newShuffleJoinScopeList(probeScopes, buildScopes []*Scope, nod
 		buildScopes[i].IsEnd = true
 
 		for _, js := range shuffleBuilds {
-			if isSameCN(js.NodeInfo.Addr, buildScopes[i].NodeInfo.Addr) {
+			if sameExecutionNode(js.NodeInfo, buildScopes[i].NodeInfo) {
 				js.PreScopes = append(js.PreScopes, buildScopes[i])
 				break
 			}
@@ -5474,6 +5519,34 @@ func (c *Compile) evalAggOptimize(node *plan.Node, blk *objectio.BlockInfo, part
 
 func dupType(typ *plan.Type) types.Type {
 	return types.New(types.T(typ.Id), typ.Width, typ.Scale)
+}
+
+func sameExecutionNode(left, right engine.Node) bool {
+	if left.Id != "" && right.Id != "" && left.Id == right.Id {
+		return true
+	}
+	if left.Addr == "" || right.Addr == "" {
+		if left.Addr != "" || right.Addr != "" {
+			return false
+		}
+		if left.Id != "" && right.Id != "" {
+			return left.Id == right.Id
+		}
+		return true
+	}
+	return sameExecutionAddr(left.Addr, right.Addr)
+}
+
+func sameExecutionAddr(addr string, currentCNAddr string) bool {
+	if addr == "" || currentCNAddr == "" {
+		return addr == currentCNAddr
+	}
+	parts1 := strings.Split(addr, ":")
+	parts2 := strings.Split(currentCNAddr, ":")
+	if len(parts1) != 2 || len(parts2) != 2 {
+		return addr == currentCNAddr
+	}
+	return parts1[0] == parts2[0] && parts1[1] == parts2[1]
 }
 
 func isSameCN(addr string, currentCNAddr string) bool {

--- a/pkg/sql/compile/max_dop_test.go
+++ b/pkg/sql/compile/max_dop_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/schedule"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
 	"github.com/stretchr/testify/require"
@@ -50,6 +51,228 @@ func TestForceSingleScanDistinctAgg(t *testing.T) {
 	node.AggList[0].Expr.(*plan.Expr_F).F.Func.Obj = -9223372036854775808
 
 	require.True(t, forceSingleScan(node))
+}
+
+func TestToScheduledQueryWorkersKeepsLocalIdentityWithoutRoute(t *testing.T) {
+	workers := toScheduledQueryWorkers(engine.Nodes{
+		{Id: "cn-local", Mcpu: 4},
+		{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+		{},
+	})
+
+	require.Equal(t, schedule.Workers{
+		{ID: "cn-local", Mcpu: 4},
+		{ID: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+	}, workers)
+}
+
+func TestToScheduledQueryWorkersKeepsLocalSentinel(t *testing.T) {
+	workers := toScheduledQueryWorkers(engine.Nodes{
+		{Mcpu: 1},
+		{},
+	})
+
+	require.Equal(t, schedule.Workers{{Mcpu: 1}}, workers)
+}
+
+func TestScheduledQueryWorkersDoesNotMaterializeLocalRoute(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.cnList = engine.Nodes{
+		{Id: "cn-local", Mcpu: 4},
+	}
+
+	require.Equal(t, schedule.Workers{{ID: "cn-local", Mcpu: 4}}, c.scheduledQueryWorkers())
+}
+
+func TestMaterializeScheduledWorkerUsesLocalRouteAtExecutionBoundary(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+
+	node := c.materializeScheduledWorker(schedule.Worker{ID: "cn-local", Mcpu: 4})
+	require.Equal(t, engine.Node{Id: "cn-local", Addr: "cn-local:6001", Mcpu: 4}, node)
+
+	remote := c.materializeScheduledWorker(schedule.Worker{ID: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8})
+	require.Equal(t, engine.Node{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8}, remote)
+}
+
+func TestShouldWarnScanPlacement(t *testing.T) {
+	for _, reason := range []string{
+		schedule.ReasonScanNoWorkers,
+		schedule.ReasonScanMissingStats,
+		schedule.ReasonScanSingleWorker,
+		schedule.ReasonScanQueryLocalExec,
+		schedule.ReasonScanQueryFallbackCN,
+	} {
+		require.True(t, shouldWarnScanPlacement(reason), reason)
+	}
+
+	for _, reason := range []string{
+		schedule.ReasonScanSmallBlocks,
+		schedule.ReasonScanForceOneCN,
+		schedule.ReasonScanForceSingle,
+		schedule.ReasonScanMultiCN,
+	} {
+		require.False(t, shouldWarnScanPlacement(reason), reason)
+	}
+}
+
+func TestSingleWorkerStageNodePrefersSingleScheduledWorker(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.cnList = engine.Nodes{
+		{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+	}
+
+	node := c.singleWorkerStageNode()
+	require.Equal(t, "cn-remote", node.Id)
+	require.Equal(t, "cn-remote:6001", node.Addr)
+}
+
+func TestSingleWorkerStageNodeFallsBackToCurrentCNForMultiCNQuery(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.cnList = engine.Nodes{
+		{Id: "cn-a", Addr: "cn-a:6001", Mcpu: 4},
+		{Id: "cn-b", Addr: "cn-b:6001", Mcpu: 4},
+	}
+
+	node := c.singleWorkerStageNode()
+	require.Equal(t, "cn-local:6001", node.Addr)
+}
+
+func TestQueryWorkerStageNodesKeepsScheduledWorkers(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.cnList = engine.Nodes{
+		{Id: "cn-local", Mcpu: 0},
+		{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+	}
+
+	nodes := c.queryWorkerStageNodes()
+	require.Equal(t, engine.Nodes{
+		{Id: "cn-local", Addr: "cn-local:6001", Mcpu: 1},
+		{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+	}, nodes)
+}
+
+func TestQueryWorkerStageNodesCanonicalizesCurrentCNAddress(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.cnList = engine.Nodes{
+		{Addr: "cn-remote:6001", Mcpu: 8},
+		{Id: "cn-local", Mcpu: 4},
+	}
+
+	nodes := c.queryWorkerStageNodes()
+	require.Equal(t, engine.Nodes{
+		{Addr: "cn-remote:6001", Mcpu: 8},
+		{Id: "cn-local", Addr: "cn-local:6001", Mcpu: 4},
+	}, nodes)
+}
+
+func TestQueryWorkerStageNodesKeepsLocalSentinel(t *testing.T) {
+	c := NewMockCompile(t)
+	c.cnList = engine.Nodes{{Mcpu: 1}}
+
+	nodes := c.queryWorkerStageNodes()
+	require.Equal(t, engine.Nodes{{Mcpu: 1}}, nodes)
+}
+
+func TestNewScopeListOnSingleWorkerStageKeepsRemoteSingleWorker(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.anal = &AnalyzeModule{}
+	c.cnList = engine.Nodes{
+		{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+	}
+
+	scopes := c.newScopeListOnSingleWorkerStage(2, 2)
+	require.Len(t, scopes, 2)
+	for _, s := range scopes {
+		require.Equal(t, "cn-remote", s.NodeInfo.Id)
+		require.Equal(t, "cn-remote:6001", s.NodeInfo.Addr)
+		require.Equal(t, 1, s.NodeInfo.Mcpu)
+	}
+}
+
+func TestScopeNodeWithMcpuKeepsWorkerIdentity(t *testing.T) {
+	node := scopeNodeWithMcpu(engine.Node{
+		Id:   "cn-1",
+		Addr: "cn-1:6001",
+		Mcpu: 8,
+	}, 0)
+
+	require.Equal(t, "cn-1", node.Id)
+	require.Equal(t, "cn-1:6001", node.Addr)
+	require.Equal(t, 1, node.Mcpu)
+}
+
+func TestConstructScopeForExternalNodeKeepsWorkerIdentity(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "local:6001"
+	c.anal = &AnalyzeModule{qry: &plan.Query{}}
+
+	scope := c.constructScopeForExternalNode(engine.Node{
+		Id:   "remote",
+		Addr: "remote:6001",
+		Mcpu: 8,
+	}, true)
+
+	require.Equal(t, "remote", scope.NodeInfo.Id)
+	require.Equal(t, "remote:6001", scope.NodeInfo.Addr)
+	require.Equal(t, 1, scope.NodeInfo.Mcpu)
+}
+
+func TestSameExecutionNodeUsesIdentityAndDoesNotMatchEmptyAddressToRemote(t *testing.T) {
+	require.True(t, sameExecutionNode(
+		engine.Node{Id: "cn-local", Mcpu: 1},
+		engine.Node{Id: "cn-local", Addr: "stale:6001", Mcpu: 1},
+	))
+	require.False(t, sameExecutionNode(
+		engine.Node{Id: "cn-local", Mcpu: 1},
+		engine.Node{Id: "cn-remote", Addr: "remote:6001", Mcpu: 1},
+	))
+	require.False(t, sameExecutionNode(
+		engine.Node{Mcpu: 1},
+		engine.Node{Addr: "remote:6001", Mcpu: 1},
+	))
+}
+
+func TestMergeScopesByStageNodesUsesExecutionIdentity(t *testing.T) {
+	c := NewMockCompile(t)
+	c.anal = &AnalyzeModule{}
+	local := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Id: "cn-local", Mcpu: 1},
+		Proc:     c.proc.NewNoContextChildProc(0),
+	}
+	remote := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Id: "cn-remote", Addr: "remote:6001", Mcpu: 1},
+		Proc:     c.proc.NewNoContextChildProc(0),
+	}
+
+	grouped := c.mergeScopesByStageNodes([]*Scope{local, remote}, engine.Nodes{
+		{Id: "cn-local", Mcpu: 1},
+		{Id: "cn-remote", Addr: "remote:6001", Mcpu: 1},
+	})
+
+	require.Len(t, grouped, 2)
+	require.Equal(t, "cn-local", grouped[0].NodeInfo.Id)
+	require.Len(t, grouped[0].PreScopes, 1)
+	require.Equal(t, "cn-local", grouped[0].PreScopes[0].NodeInfo.Id)
+	require.Equal(t, "cn-remote", grouped[1].NodeInfo.Id)
+	require.Len(t, grouped[1].PreScopes, 1)
+	require.Equal(t, "cn-remote", grouped[1].PreScopes[0].NodeInfo.Id)
+}
+
+func TestScopeIpAddrMatchDoesNotTreatEmptyLocalAddressAsRemoteMatch(t *testing.T) {
+	scope := &Scope{NodeInfo: engine.Node{Addr: "remote:6001"}}
+	require.False(t, scope.ipAddrMatch(""))
+
+	scope.NodeInfo.Addr = ""
+	require.True(t, scope.ipAddrMatch(""))
 }
 
 func TestGenerateNodesRespectsNodeDOPOnMultiCN(t *testing.T) {
@@ -263,6 +486,7 @@ func TestGenerateNodesKeepsSmallNonIvfScanOnCurrentCN(t *testing.T) {
 	nodes, err := c.generateNodes(node)
 	require.NoError(t, err)
 	require.Equal(t, engine.Nodes{{
+		Id:    "cn1",
 		Addr:  "cn-local:6001",
 		Mcpu:  4,
 		CNCNT: 1,
@@ -298,6 +522,46 @@ func TestGenerateNodesKeepsLargeScanOnCurrentCNWhenNoWorkers(t *testing.T) {
 	}}, nodes)
 }
 
+func TestGenerateNodesKeepsSingleRemoteQueryWorkerForLocalOnlyScan(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-local:6001"
+	c.e = newStubEngineForGenerateNodes("testdb", "t")
+	c.cnList = engine.Nodes{
+		{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+	}
+	c.queryPlacement = schedule.QueryDecision{
+		ExecKind:  schedule.QueryExecAPMultiCN,
+		Workers:   schedule.Workers{{ID: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8}},
+		Reason:    schedule.ReasonMultiCN,
+		Satisfied: true,
+	}
+
+	node := &plan.Node{
+		NodeType: plan.Node_TABLE_SCAN,
+		ObjRef: &plan.ObjectRef{
+			SchemaName: "testdb",
+			ObjName:    "t",
+		},
+		TableDef: &plan.TableDef{
+			Name: "t",
+		},
+		Stats: &plan.Stats{
+			BlockNum: int32(plan2.BlockThresholdForOneCN + 1),
+			Dop:      4,
+		},
+	}
+
+	nodes, err := c.generateNodes(node)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, "cn-remote", nodes[0].Id)
+	require.Equal(t, "cn-remote:6001", nodes[0].Addr)
+	require.Equal(t, 4, nodes[0].Mcpu)
+	require.Equal(t, int32(1), nodes[0].CNCNT)
+	require.Equal(t, int32(0), nodes[0].CNIDX)
+	require.NotNil(t, nodes[0].Data)
+}
+
 func TestGenerateNodesKeepsLocalScanMcpuAtLeastOne(t *testing.T) {
 	for _, dop := range []int32{0, -2} {
 		c := NewMockCompile(t)
@@ -326,6 +590,7 @@ func TestGenerateNodesKeepsLocalScanMcpuAtLeastOne(t *testing.T) {
 		nodes, err := c.generateNodes(node)
 		require.NoError(t, err)
 		require.Equal(t, engine.Nodes{{
+			Id:    "cn-local",
 			Addr:  "cn-local:6001",
 			Mcpu:  1,
 			CNCNT: 1,
@@ -361,6 +626,7 @@ func TestGenerateNodesKeepsForceOneCNOnCurrentCN(t *testing.T) {
 	nodes, err := c.generateNodes(node)
 	require.NoError(t, err)
 	require.Equal(t, engine.Nodes{{
+		Id:    "cn1",
 		Addr:  "cn-local:6001",
 		Mcpu:  6,
 		CNCNT: 1,
@@ -394,6 +660,7 @@ func TestGenerateNodesKeepsTableCloneOnCurrentCN(t *testing.T) {
 	nodes, err := c.generateNodes(node)
 	require.NoError(t, err)
 	require.Equal(t, engine.Nodes{{
+		Id:    "cn-local",
 		Addr:  "cn-local:6001",
 		Mcpu:  1,
 		CNCNT: 1,

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -1524,7 +1524,7 @@ func constructDispatchLocalAndRemote(idx int, target []*Scope, source *Scope) (b
 	hasRemote := false
 
 	for _, s := range target {
-		if !isSameCN(s.NodeInfo.Addr, source.NodeInfo.Addr) {
+		if !sameExecutionNode(s.NodeInfo, source.NodeInfo) {
 			hasRemote = true
 			break
 		}
@@ -1534,7 +1534,7 @@ func constructDispatchLocalAndRemote(idx int, target []*Scope, source *Scope) (b
 	}
 
 	for i, s := range target {
-		if isSameCN(s.NodeInfo.Addr, source.NodeInfo.Addr) {
+		if sameExecutionNode(s.NodeInfo, source.NodeInfo) {
 			// Local reg.
 			// Put them into arg.LocalRegs
 			s.Proc.Reg.MergeReceivers[idx].SetNilBatchCntForReuse(source.NodeInfo.Mcpu)

--- a/pkg/sql/compile/scan_scheduler.go
+++ b/pkg/sql/compile/scan_scheduler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/schedule"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
+	"go.uber.org/zap"
 )
 
 func (c *Compile) generateNodes(node *plan.Node) (engine.Nodes, error) {
@@ -36,14 +37,17 @@ func (c *Compile) generateNodes(node *plan.Node) (engine.Nodes, error) {
 
 	stats := toScheduleScanStats(node)
 	scanPlacement := schedule.DecideScanPlacement(schedule.ScanRequest{
-		QueryWorkers:        toScheduleScanWorkers(c.cnList),
-		Stats:               stats,
-		ForceSingle:         forceSingle,
-		ForceMultiCN:        plan2.GetForceScanOnMultiCN() || plan2.IsIvfSearchEntriesInternalScan(node),
-		OneCNBlockThreshold: int32(plan2.BlockThresholdForOneCN),
+		QueryWorkers:         c.scheduledQueryWorkers(),
+		CurrentCN:            c.currentCNWorker(),
+		QueryPlacementReason: c.queryPlacement.Reason,
+		Stats:                stats,
+		ForceSingle:          forceSingle,
+		ForceMultiCN:         plan2.GetForceScanOnMultiCN() || plan2.IsIvfSearchEntriesInternalScan(node),
+		OneCNBlockThreshold:  int32(plan2.BlockThresholdForOneCN),
 	})
+	c.maybeLogScanPlacement(scanPlacement, stats, forceSingle)
 	if scanPlacement.LocalOnly {
-		return c.localScanNodes(stats, forceSingle), nil
+		return c.localScanNodes(scanPlacement.Workers, stats, forceSingle, node, rel)
 	}
 
 	return c.materializeScanNodes(scanPlacement.Workers, stats, node, rel)
@@ -70,7 +74,13 @@ func forceSingleScan(node *plan.Node) bool {
 	return false
 }
 
-func (c *Compile) localScanNodes(stats *schedule.ScanStats, forceSingle bool) engine.Nodes {
+func (c *Compile) localScanNodes(
+	workers schedule.Workers,
+	stats *schedule.ScanStats,
+	forceSingle bool,
+	node *plan.Node,
+	rel engine.Relation,
+) (engine.Nodes, error) {
 	mcpu := 1
 	if stats != nil && stats.Dop > 0 {
 		mcpu = int(stats.Dop)
@@ -78,11 +88,29 @@ func (c *Compile) localScanNodes(stats *schedule.ScanStats, forceSingle bool) en
 	if forceSingle {
 		mcpu = 1
 	}
-	return engine.Nodes{{
-		Addr:  c.addr,
-		Mcpu:  normalizeMcpu(mcpu),
-		CNCNT: 1,
-	}}
+	if len(workers) == 0 {
+		return engine.Nodes{{
+			Addr:  c.addr,
+			Mcpu:  normalizeMcpu(mcpu),
+			CNCNT: 1,
+		}}, nil
+	}
+
+	engNode := c.materializeScheduledWorker(workers[0])
+	engNode.Mcpu = normalizeMcpu(mcpu)
+	engNode.CNCNT = 1
+	engNode.CNIDX = 0
+	if engNode.Addr != "" && engNode.Addr != c.addr {
+		remoteTombstones := remoteScanTombstoneAttacher{
+			c:    c,
+			node: node,
+			rel:  rel,
+		}
+		if err := remoteTombstones.attach(&engNode); err != nil {
+			return nil, err
+		}
+	}
+	return engine.Nodes{engNode}, nil
 }
 
 func (c *Compile) materializeScanNodes(
@@ -102,13 +130,10 @@ func (c *Compile) materializeScanNodes(
 		if stats != nil && stats.Dop > 0 {
 			mcpu = min(mcpu, int(stats.Dop))
 		}
-		engNode := engine.Node{
-			Id:    workers[i].ID,
-			Addr:  workers[i].Addr,
-			Mcpu:  mcpu,
-			CNCNT: int32(len(workers)),
-			CNIDX: int32(i),
-		}
+		engNode := c.materializeScheduledWorker(workers[i])
+		engNode.Mcpu = mcpu
+		engNode.CNCNT = int32(len(workers))
+		engNode.CNIDX = int32(i)
 		if engNode.Addr != c.addr {
 			if err := remoteTombstones.attach(&engNode); err != nil {
 				return nil, err
@@ -152,20 +177,60 @@ func toScheduleScanStats(node *plan.Node) *schedule.ScanStats {
 	}
 }
 
-func toScheduleScanWorkers(nodes engine.Nodes) schedule.Workers {
-	if len(nodes) == 0 {
-		return nil
+func (c *Compile) maybeLogScanPlacement(
+	decision schedule.ScanDecision,
+	stats *schedule.ScanStats,
+	forceSingle bool,
+) {
+	if c.execType != plan2.ExecTypeAP_MULTICN || !decision.LocalOnly || !shouldWarnScanPlacement(decision.Reason) {
+		return
 	}
-	workers := make(schedule.Workers, 0, len(nodes))
-	for _, node := range nodes {
-		worker := toScheduleWorker(node)
-		if worker.ID == "" && worker.Addr == "" {
-			continue
-		}
-		workers = append(workers, worker)
+
+	fields := []zap.Field{
+		zap.String("reason", decision.Reason),
+		zap.String("query-placement-reason", c.queryPlacement.Reason),
+		zap.String("exec-type", queryExecTypeString(c.execType)),
+		zap.String("current-cn-policy", c.queryPlacement.CurrentCNPolicy.String()),
+		zap.Int("query-worker-count", len(c.cnList)),
+		zap.Int("scan-worker-count", len(decision.Workers)),
+		zap.Bool("force-single", forceSingle),
+		zap.Bool("is-internal", c.isInternal),
 	}
-	if len(workers) == 0 {
-		return nil
+	currentCN := c.currentCNWorker()
+	fields = append(fields,
+		zap.String("current-cn-id", currentCN.ID),
+		zap.String("current-cn-address", currentCN.Addr),
+	)
+	if stats != nil {
+		fields = append(fields,
+			zap.Int32("block-num", stats.BlockNum),
+			zap.Int32("dop", stats.Dop),
+			zap.Bool("force-one-cn", stats.ForceOneCN),
+		)
 	}
-	return workers
+	if len(decision.Workers) > 0 {
+		fields = append(fields,
+			zap.String("selected-worker-id", decision.Workers[0].ID),
+			zap.String("selected-worker-address", decision.Workers[0].Addr),
+		)
+	}
+
+	getQueryScheduleLogger().WarnWithConfig(
+		"scan-schedule-local-only-"+decision.Reason,
+		"scan schedule kept execution on a single CN",
+		queryScheduleLogRateLimit,
+		fields...)
+}
+
+func shouldWarnScanPlacement(reason string) bool {
+	switch reason {
+	case schedule.ReasonScanNoWorkers,
+		schedule.ReasonScanMissingStats,
+		schedule.ReasonScanSingleWorker,
+		schedule.ReasonScanQueryLocalExec,
+		schedule.ReasonScanQueryFallbackCN:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/sql/compile/scheduler.go
+++ b/pkg/sql/compile/scheduler.go
@@ -49,6 +49,7 @@ func (c *Compile) scheduleQueryWorkers() (engine.Nodes, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.queryPlacement = placement
 	if !placement.Satisfied {
 		getQueryScheduleLogger().WarnWithConfig(
 			"query-schedule-unsatisfied-placement",
@@ -60,7 +61,7 @@ func (c *Compile) scheduleQueryWorkers() (engine.Nodes, error) {
 			placement.Reason,
 			placement.CurrentCNPolicy.String())
 	}
-	nodes := toEngineNodes(placement.Workers)
+	nodes := c.materializeScheduledWorkers(placement.Workers)
 	if c.execType == plan2.ExecTypeAP_MULTICN {
 		if placement.Reason == schedule.ReasonNoCandidateCN {
 			getQueryScheduleLogger().WarnWithConfig(
@@ -69,6 +70,9 @@ func (c *Compile) scheduleQueryWorkers() (engine.Nodes, error) {
 				queryScheduleLogRateLimit,
 				c.querySchedulePlacementFields(placement)...)
 		}
+	}
+	if err := c.validateScheduledQueryRoutes(nodes, placement); err != nil {
+		return nil, err
 	}
 	return nodes, nil
 }
@@ -84,6 +88,28 @@ func (c *Compile) querySchedulePlacementFields(placement schedule.QueryDecision)
 		zap.Int("worker-count", len(placement.Workers)),
 		zap.Bool("is-internal", c.isInternal),
 	}
+}
+
+func (c *Compile) validateScheduledQueryRoutes(nodes engine.Nodes, placement schedule.QueryDecision) error {
+	if c.execType != plan2.ExecTypeAP_MULTICN || len(nodes) <= 1 {
+		return nil
+	}
+	for _, node := range nodes {
+		if node.Addr != "" {
+			continue
+		}
+		getQueryScheduleLogger().WarnWithConfig(
+			"query-schedule-unroutable-selected-worker",
+			"query schedule selected a worker without route for multi-CN execution",
+			queryScheduleLogRateLimit,
+			append(c.querySchedulePlacementFields(placement),
+				zap.String("worker-id", node.Id),
+				zap.Int("worker-mcpu", node.Mcpu))...)
+		return moerr.NewInternalErrorNoCtxf(
+			"query schedule selected worker %s without address for multi-CN execution",
+			node.Id)
+	}
+	return nil
 }
 
 func (c *Compile) getCandidateCNs() (engine.Nodes, error) {
@@ -110,7 +136,7 @@ func (c *Compile) decideQueryPlacement() (schedule.QueryDecision, error) {
 	}
 
 	rawCandidateCount := len(candidates)
-	req.Candidates = toScheduleWorkers(candidates)
+	req.Candidates = toScheduleCandidateWorkers(candidates)
 	if len(req.Candidates) < rawCandidateCount {
 		getQueryScheduleLogger().WarnWithConfig(
 			"query-schedule-unroutable-cn",
@@ -174,7 +200,10 @@ func toScheduleWorker(node engine.Node) schedule.Worker {
 	}
 }
 
-func toScheduleWorkers(nodes engine.Nodes) schedule.Workers {
+// toScheduleCandidateWorkers converts engine discovery results into schedulable
+// candidates. Candidate workers without a route cannot be selected for remote
+// execution, so they are dropped here.
+func toScheduleCandidateWorkers(nodes engine.Nodes) schedule.Workers {
 	if len(nodes) == 0 {
 		return nil
 	}
@@ -192,6 +221,31 @@ func toScheduleWorkers(nodes engine.Nodes) schedule.Workers {
 	return workers
 }
 
+// toScheduledQueryWorkers converts already-scheduled query workers into stage
+// or scan workers. Unlike candidate discovery, a worker with only local identity
+// and no remote route is still a valid single-CN execution target and must be kept.
+func toScheduledQueryWorkers(nodes engine.Nodes) schedule.Workers {
+	if len(nodes) == 0 {
+		return nil
+	}
+	workers := make(schedule.Workers, 0, len(nodes))
+	for _, node := range nodes {
+		if node.Id == "" && node.Addr == "" && node.Mcpu == 0 {
+			continue
+		}
+		worker := toScheduleWorker(node)
+		workers = append(workers, worker)
+	}
+	if len(workers) == 0 {
+		return nil
+	}
+	return workers
+}
+
+func (c *Compile) scheduledQueryWorkers() schedule.Workers {
+	return toScheduledQueryWorkers(c.cnList)
+}
+
 func toEngineNode(worker schedule.Worker) engine.Node {
 	return engine.Node{
 		Id:   worker.ID,
@@ -200,15 +254,30 @@ func toEngineNode(worker schedule.Worker) engine.Node {
 	}
 }
 
-func toEngineNodes(workers schedule.Workers) engine.Nodes {
+func (c *Compile) materializeScheduledWorker(worker schedule.Worker) engine.Node {
+	node := toEngineNode(worker)
+	if node.Addr == "" && c.canUseLocalExecutionRoute(worker) {
+		node.Addr = c.addr
+	}
+	return node
+}
+
+func (c *Compile) materializeScheduledWorkers(workers schedule.Workers) engine.Nodes {
 	if len(workers) == 0 {
 		return nil
 	}
 	nodes := make(engine.Nodes, 0, len(workers))
 	for _, worker := range workers {
-		nodes = append(nodes, toEngineNode(worker))
+		nodes = append(nodes, c.materializeScheduledWorker(worker))
 	}
 	return nodes
+}
+
+func (c *Compile) canUseLocalExecutionRoute(worker schedule.Worker) bool {
+	// At this materialization boundary, an empty Addr in already-scheduled
+	// workers can only represent the local current CN: candidate discovery drops
+	// unroutable remote workers, and multi-CN query output is route-validated.
+	return c.addr != "" && worker.Addr == ""
 }
 
 func normalizeMcpu(mcpu int) int {

--- a/pkg/sql/compile/scheduler_test.go
+++ b/pkg/sql/compile/scheduler_test.go
@@ -235,7 +235,7 @@ func TestScheduleQueryWorkersIncludesLocalWhenQueryClientExists(t *testing.T) {
 	require.Equal(t, []string{"local:6001", "remote:6001"}, []string{nodes[0].Addr, nodes[1].Addr})
 }
 
-func TestScheduleQueryWorkersIncludesRequiredCurrentCNWithoutAddress(t *testing.T) {
+func TestScheduleQueryWorkersRejectsRequiredCurrentCNWithoutAddressForMultiCN(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -251,12 +251,27 @@ func TestScheduleQueryWorkersIncludesRequiredCurrentCNWithoutAddress(t *testing.
 		nodes: engine.Nodes{{Id: "remote", Addr: "remote:6001", Mcpu: 4}},
 	}
 
+	_, err := c.scheduleQueryWorkers()
+	require.ErrorContains(t, err, "without address for multi-CN execution")
+}
+
+func TestScheduleQueryWorkersAllowsRequiredCurrentCNWithoutAddressForLocalFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const localID = "local-cn"
+	c := NewMockCompile(t)
+	c.ncpu = 6
+	c.execType = plan2.ExecTypeAP_MULTICN
+	c.proc.Base.QueryClient = fakeQueryClient{}
+	lockSvc := mock_lock.NewMockLockService(ctrl)
+	lockSvc.EXPECT().GetConfig().Return(lockservice.Config{ServiceID: localID}).AnyTimes()
+	c.proc.Base.LockService = lockSvc
+	c.e = &schedulerTestEngine{}
+
 	nodes, err := c.scheduleQueryWorkers()
 	require.NoError(t, err)
-	require.Equal(t, engine.Nodes{
-		{Id: localID, Mcpu: 6},
-		{Id: "remote", Addr: "remote:6001", Mcpu: 4},
-	}, nodes)
+	require.Equal(t, engine.Nodes{{Id: localID, Mcpu: 6}}, nodes)
 }
 
 func TestScheduleQueryWorkersReturnsErrorWhenRequiredCurrentCNMissingIdentity(t *testing.T) {

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -32,6 +32,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/group"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/schedule"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -209,6 +210,9 @@ func (s *Scope) ipAddrMatch(local string) bool {
 	if len(s.NodeInfo.Addr) == 0 {
 		return true
 	}
+	if len(local) == 0 {
+		return false
+	}
 	return isSameCN(s.NodeInfo.Addr, local)
 }
 
@@ -283,7 +287,8 @@ type Compile struct {
 
 	MessageBoard *message.MessageBoard
 
-	cnList engine.Nodes
+	cnList         engine.Nodes
+	queryPlacement schedule.QueryDecision
 	// ast
 	stmt tree.Statement
 

--- a/pkg/sql/schedule/scan.go
+++ b/pkg/sql/schedule/scan.go
@@ -15,21 +15,25 @@
 package schedule
 
 const (
-	ReasonScanNoWorkers    = "no-workers"
-	ReasonScanSingleWorker = "single-worker"
-	ReasonScanMissingStats = "missing-stats"
-	ReasonScanForceOneCN   = "force-one-cn"
-	ReasonScanForceSingle  = "force-single"
-	ReasonScanSmallBlocks  = "small-blocks"
-	ReasonScanMultiCN      = "multi-cn-scan"
+	ReasonScanNoWorkers       = "no-workers"
+	ReasonScanSingleWorker    = "single-worker"
+	ReasonScanMissingStats    = "missing-stats"
+	ReasonScanForceOneCN      = "force-one-cn"
+	ReasonScanForceSingle     = "force-single"
+	ReasonScanSmallBlocks     = "small-blocks"
+	ReasonScanMultiCN         = "multi-cn-scan"
+	ReasonScanQueryLocalExec  = "query-local-exec-type"
+	ReasonScanQueryFallbackCN = "query-no-candidate-cn"
 )
 
 type ScanRequest struct {
-	QueryWorkers        Workers
-	Stats               *ScanStats
-	ForceSingle         bool
-	ForceMultiCN        bool
-	OneCNBlockThreshold int32
+	QueryWorkers         Workers
+	CurrentCN            Worker
+	QueryPlacementReason string
+	Stats                *ScanStats
+	ForceSingle          bool
+	ForceMultiCN         bool
+	OneCNBlockThreshold  int32
 }
 
 type ScanStats struct {
@@ -45,23 +49,26 @@ type ScanDecision struct {
 }
 
 func DecideScanPlacement(req ScanRequest) ScanDecision {
+	if reason, ok := inheritedLocalScanReason(req.QueryPlacementReason); ok {
+		return localScanDecision(reason, pickLocalScanWorkers(req.QueryWorkers, req.CurrentCN))
+	}
 	if len(req.QueryWorkers) == 1 {
-		return localScanDecision(ReasonScanSingleWorker)
+		return localScanDecision(ReasonScanSingleWorker, pickLocalScanWorkers(req.QueryWorkers, req.CurrentCN))
 	}
 	if req.Stats == nil {
-		return localScanDecision(ReasonScanMissingStats)
+		return localScanDecision(ReasonScanMissingStats, pickLocalScanWorkers(req.QueryWorkers, req.CurrentCN))
 	}
 	if req.Stats.ForceOneCN {
-		return localScanDecision(ReasonScanForceOneCN)
+		return localScanDecision(ReasonScanForceOneCN, pickLocalScanWorkers(req.QueryWorkers, req.CurrentCN))
 	}
 	if req.ForceSingle {
-		return localScanDecision(ReasonScanForceSingle)
+		return localScanDecision(ReasonScanForceSingle, pickLocalScanWorkers(req.QueryWorkers, req.CurrentCN))
 	}
 	if !req.ForceMultiCN && req.Stats.BlockNum <= req.OneCNBlockThreshold {
-		return localScanDecision(ReasonScanSmallBlocks)
+		return localScanDecision(ReasonScanSmallBlocks, pickLocalScanWorkers(req.QueryWorkers, req.CurrentCN))
 	}
 	if len(req.QueryWorkers) == 0 {
-		return localScanDecision(ReasonScanNoWorkers)
+		return localScanDecision(ReasonScanNoWorkers, nil)
 	}
 	return ScanDecision{
 		Workers: cloneWorkers(req.QueryWorkers),
@@ -69,9 +76,35 @@ func DecideScanPlacement(req ScanRequest) ScanDecision {
 	}
 }
 
-func localScanDecision(reason string) ScanDecision {
+func localScanDecision(reason string, workers Workers) ScanDecision {
 	return ScanDecision{
+		Workers:   workers,
 		LocalOnly: true,
 		Reason:    reason,
 	}
+}
+
+func inheritedLocalScanReason(reason string) (string, bool) {
+	switch reason {
+	case ReasonLocalExecType:
+		return ReasonScanQueryLocalExec, true
+	case ReasonNoCandidateCN:
+		return ReasonScanQueryFallbackCN, true
+	default:
+		return "", false
+	}
+}
+
+func pickLocalScanWorkers(workers Workers, current Worker) Workers {
+	if len(workers) == 0 {
+		return nil
+	}
+	if hasWorkerIdentity(current) {
+		for _, worker := range workers {
+			if sameWorker(worker, current) {
+				return cloneWorkers(Workers{worker})
+			}
+		}
+	}
+	return cloneWorkers(workers[:1])
 }

--- a/pkg/sql/schedule/scan_test.go
+++ b/pkg/sql/schedule/scan_test.go
@@ -21,26 +21,29 @@ import (
 )
 
 func TestDecideScanPlacementKeepsSingleWorkerLocal(t *testing.T) {
+	workers := Workers{{ID: "local", Addr: "local:6001"}}
 	decision := DecideScanPlacement(ScanRequest{
-		QueryWorkers: Workers{{ID: "local", Addr: "local:6001"}},
+		QueryWorkers: workers,
 		Stats:        scanStats(100, 4, false),
 	})
 
 	require.True(t, decision.LocalOnly)
 	require.Equal(t, ReasonScanSingleWorker, decision.Reason)
-	require.Nil(t, decision.Workers)
+	require.Equal(t, workers, decision.Workers)
 }
 
 func TestDecideScanPlacementKeepsMissingStatsLocal(t *testing.T) {
+	workers := Workers{
+		{ID: "remote", Addr: "remote:6001"},
+		{ID: "local", Addr: "local:6001"},
+	}
 	decision := DecideScanPlacement(ScanRequest{
-		QueryWorkers: Workers{
-			{ID: "local", Addr: "local:6001"},
-			{ID: "remote", Addr: "remote:6001"},
-		},
+		QueryWorkers: workers,
 	})
 
 	require.True(t, decision.LocalOnly)
 	require.Equal(t, ReasonScanMissingStats, decision.Reason)
+	require.Equal(t, workers[:1], decision.Workers)
 }
 
 func TestDecideScanPlacementKeepsForcedScanLocal(t *testing.T) {
@@ -56,6 +59,7 @@ func TestDecideScanPlacementKeepsForcedScanLocal(t *testing.T) {
 
 	require.True(t, decision.LocalOnly)
 	require.Equal(t, ReasonScanForceOneCN, decision.Reason)
+	require.Equal(t, workers[:1], decision.Workers)
 
 	decision = DecideScanPlacement(ScanRequest{
 		QueryWorkers: workers,
@@ -65,6 +69,7 @@ func TestDecideScanPlacementKeepsForcedScanLocal(t *testing.T) {
 
 	require.True(t, decision.LocalOnly)
 	require.Equal(t, ReasonScanForceSingle, decision.Reason)
+	require.Equal(t, workers[:1], decision.Workers)
 }
 
 func TestDecideScanPlacementKeepsSmallScansLocal(t *testing.T) {
@@ -79,6 +84,7 @@ func TestDecideScanPlacementKeepsSmallScansLocal(t *testing.T) {
 
 	require.True(t, decision.LocalOnly)
 	require.Equal(t, ReasonScanSmallBlocks, decision.Reason)
+	require.Equal(t, Workers{{ID: "local", Addr: "local:6001"}}, decision.Workers)
 }
 
 func TestDecideScanPlacementCanForceSmallScansToMultiCN(t *testing.T) {
@@ -128,6 +134,47 @@ func TestDecideScanPlacementKeepsLargeScanLocalWhenNoWorkers(t *testing.T) {
 	require.True(t, decision.LocalOnly)
 	require.Equal(t, ReasonScanNoWorkers, decision.Reason)
 	require.Nil(t, decision.Workers)
+}
+
+func TestDecideScanPlacementPreservesQueryFallbackReason(t *testing.T) {
+	workers := Workers{{ID: "local", Addr: "local:6001"}}
+	decision := DecideScanPlacement(ScanRequest{
+		QueryWorkers:         workers,
+		QueryPlacementReason: ReasonNoCandidateCN,
+		Stats:                scanStats(100, 4, false),
+	})
+
+	require.True(t, decision.LocalOnly)
+	require.Equal(t, ReasonScanQueryFallbackCN, decision.Reason)
+	require.Equal(t, workers, decision.Workers)
+}
+
+func TestDecideScanPlacementPreservesQueryLocalExecReason(t *testing.T) {
+	workers := Workers{{ID: "local", Addr: "local:6001"}}
+	decision := DecideScanPlacement(ScanRequest{
+		QueryWorkers:         workers,
+		QueryPlacementReason: ReasonLocalExecType,
+		Stats:                scanStats(100, 4, false),
+	})
+
+	require.True(t, decision.LocalOnly)
+	require.Equal(t, ReasonScanQueryLocalExec, decision.Reason)
+	require.Equal(t, workers, decision.Workers)
+}
+
+func TestDecideScanPlacementPrefersCurrentCNForLocalOnlyScan(t *testing.T) {
+	workers := Workers{
+		{ID: "remote", Addr: "remote:6001"},
+		{ID: "local", Addr: "local:6001"},
+	}
+	decision := DecideScanPlacement(ScanRequest{
+		QueryWorkers: workers,
+		CurrentCN:    Worker{ID: "local", Addr: "local:6001"},
+	})
+
+	require.True(t, decision.LocalOnly)
+	require.Equal(t, ReasonScanMissingStats, decision.Reason)
+	require.Equal(t, Workers{{ID: "local", Addr: "local:6001"}}, decision.Workers)
 }
 
 func scanStats(blockNum int32, dop int32, forceOneCN bool) *ScanStats {

--- a/pkg/sql/schedule/stage.go
+++ b/pkg/sql/schedule/stage.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule
+
+const (
+	ReasonStageSingleQueryWorker  = "single-query-worker"
+	ReasonStageQueryWorkers       = "query-workers"
+	ReasonStageNoQueryWorkers     = "no-query-workers"
+	ReasonStageCurrentCoordinator = "current-cn-coordinator"
+)
+
+type StageRequest struct {
+	QueryWorkers Workers
+	CurrentCN    Worker
+}
+
+type StageDecision struct {
+	Worker Worker
+	Reason string
+}
+
+type StageWorkerSetDecision struct {
+	Workers Workers
+	Reason  string
+}
+
+func DecideSingleWorkerStagePlacement(req StageRequest) StageDecision {
+	if len(req.QueryWorkers) == 1 {
+		return StageDecision{
+			Worker: req.QueryWorkers[0],
+			Reason: ReasonStageSingleQueryWorker,
+		}
+	}
+	return StageDecision{
+		Worker: req.CurrentCN,
+		Reason: ReasonStageCurrentCoordinator,
+	}
+}
+
+func DecideQueryWorkerStagePlacement(req StageRequest) StageWorkerSetDecision {
+	if len(req.QueryWorkers) == 0 {
+		return StageWorkerSetDecision{
+			Reason: ReasonStageNoQueryWorkers,
+		}
+	}
+	return StageWorkerSetDecision{
+		Workers: cloneWorkers(req.QueryWorkers),
+		Reason:  ReasonStageQueryWorkers,
+	}
+}

--- a/pkg/sql/schedule/stage_test.go
+++ b/pkg/sql/schedule/stage_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecideSingleWorkerStagePlacementUsesSingleQueryWorker(t *testing.T) {
+	queryWorkers := Workers{{ID: "remote", Addr: "remote:6001", Mcpu: 8}}
+	decision := DecideSingleWorkerStagePlacement(StageRequest{
+		QueryWorkers: queryWorkers,
+		CurrentCN:    Worker{ID: "local", Addr: "local:6001", Mcpu: 4},
+	})
+
+	require.Equal(t, ReasonStageSingleQueryWorker, decision.Reason)
+	require.Equal(t, queryWorkers[0], decision.Worker)
+
+	decision.Worker.Mcpu = 1
+	require.Equal(t, 8, queryWorkers[0].Mcpu)
+}
+
+func TestDecideSingleWorkerStagePlacementKeepsLocalIdentityWithoutRoute(t *testing.T) {
+	decision := DecideSingleWorkerStagePlacement(StageRequest{
+		QueryWorkers: Workers{{ID: "local", Mcpu: 4}},
+		CurrentCN:    Worker{ID: "local", Addr: "local:6001", Mcpu: 4},
+	})
+
+	require.Equal(t, ReasonStageSingleQueryWorker, decision.Reason)
+	require.Equal(t, Worker{ID: "local", Mcpu: 4}, decision.Worker)
+}
+
+func TestDecideSingleWorkerStagePlacementUsesCurrentCNCoordinator(t *testing.T) {
+	current := Worker{ID: "local", Addr: "local:6001", Mcpu: 4}
+	for _, workers := range []Workers{
+		nil,
+		{
+			{ID: "remote-a", Addr: "remote-a:6001", Mcpu: 8},
+			{ID: "remote-b", Addr: "remote-b:6001", Mcpu: 8},
+		},
+	} {
+		decision := DecideSingleWorkerStagePlacement(StageRequest{
+			QueryWorkers: workers,
+			CurrentCN:    current,
+		})
+
+		require.Equal(t, ReasonStageCurrentCoordinator, decision.Reason)
+		require.Equal(t, current, decision.Worker)
+	}
+}
+
+func TestDecideQueryWorkerStagePlacementUsesQueryWorkers(t *testing.T) {
+	queryWorkers := Workers{
+		{ID: "local", Mcpu: 4},
+		{ID: "remote", Addr: "remote:6001", Mcpu: 8},
+	}
+	decision := DecideQueryWorkerStagePlacement(StageRequest{
+		QueryWorkers: queryWorkers,
+		CurrentCN:    Worker{ID: "current", Addr: "current:6001", Mcpu: 2},
+	})
+
+	require.Equal(t, ReasonStageQueryWorkers, decision.Reason)
+	require.Equal(t, queryWorkers, decision.Workers)
+
+	decision.Workers[0].Mcpu = 1
+	require.Equal(t, 4, queryWorkers[0].Mcpu)
+}
+
+func TestDecideQueryWorkerStagePlacementKeepsNoWorkerExplicit(t *testing.T) {
+	decision := DecideQueryWorkerStagePlacement(StageRequest{
+		CurrentCN: Worker{ID: "current", Addr: "current:6001", Mcpu: 2},
+	})
+
+	require.Equal(t, ReasonStageNoQueryWorkers, decision.Reason)
+	require.Nil(t, decision.Workers)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25526

## What this PR does / why we need it:

Fix prepared UPDATE...JOIN hanging on second execution through binary protocol
(COM_STMT_EXECUTE). First execution succeeds, second hangs forever.

**Root Cause**: The `initExecuteStmtParam` function caches and reuses a compiled
scope tree (`prepareStmt.compile`) across executions when no schema change is
detected. After the first execution, operators in the cached compile retain stale
state (e.g. hashbuild ctr, dispatch channels) from the `isPrepare=true` cleanup
path that skips `Free()`. On re-execution, hashbuild operators enter `Call` but
stall in `build()` → never reach `handleRuntimeFilter` → never send runtime
filter messages → scan receivers block forever in `waitForRuntimeFilters`
(confirmed via goroutine dump).

**Fix**: Restructure `initExecuteStmtParam` to always release the cached compile
(via `FreeOperator` + `SetIsPrepare(false)` + `Release`) and create a fresh one
with `isPrepare=true` on every execution. This follows the same pattern the
`change=true` path already used. The plan remains cached and reused; only the
compile (lightweight scope tree) is rebuilt. This avoids:

- Resource leaks (proper release before replacement)
- Execution path drift (`isPrepare=true` preserved for `GetExecType`)
- Side effects in read paths (consistent recreation for all callers)

**Verification**: Reproduced with Go driver (`interpolateParams=false`) on
single-node mo-service. Goroutine dump confirmed scan receivers blocked in
`MessageReceiver.ReceiveMessage` with hashbuild never sending runtime filters.
After fix: both executions complete normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)