### PR TITLE
[4.1] fix: support BLOB columns in data branch merge

### DIFF
--- a/pkg/frontend/data_branch_helpers.go
+++ b/pkg/frontend/data_branch_helpers.go
@@ -463,7 +463,7 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 
 	switch t.Oid {
 	case types.T_varchar, types.T_text, types.T_json, types.T_char, types.
-		T_varbinary, types.T_binary:
+		T_varbinary, types.T_binary, types.T_blob:
 		if t.Oid == types.T_json {
 			var strVal string
 			switch x := val.(type) {
@@ -488,11 +488,15 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 			writeEscapedSQLString(buf, jsonLiteral)
 			return nil
 		}
+		writeBytes := writeEscapedSQLString
+		if t.Oid == types.T_binary || t.Oid == types.T_varbinary || t.Oid == types.T_blob {
+			writeBytes = writeSQLHexLiteral
+		}
 		switch x := val.(type) {
 		case []byte:
-			writeEscapedSQLString(buf, x)
+			writeBytes(buf, x)
 		case string:
-			writeEscapedSQLString(buf, []byte(x))
+			writeBytes(buf, []byte(x))
 		default:
 			return moerr.NewInternalErrorNoCtxf("formatValIntoString: unexpected string type %T", val)
 		}
@@ -555,6 +559,19 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 	}
 
 	return nil
+}
+
+func writeSQLHexLiteral(buf *bytes.Buffer, b []byte) {
+	const hexDigits = "0123456789abcdef"
+
+	// Hex literals preserve every byte; SQL string escapes are not reversible for all control bytes.
+	buf.Grow(2*len(b) + 3)
+	buf.WriteString("x'")
+	for _, c := range b {
+		buf.WriteByte(hexDigits[c>>4])
+		buf.WriteByte(hexDigits[c&0x0f])
+	}
+	buf.WriteByte('\'')
 }
 
 func extractDataBranchSQLRowValue(

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -67,13 +67,23 @@ func TestFormatValIntoString_StringEscaping(t *testing.T) {
 	require.Equal(t, `'a\'b"c\\\n\t\r\Z\0'`, buf.String())
 }
 
-func TestFormatValIntoString_ByteEscaping(t *testing.T) {
-	var buf bytes.Buffer
-	ses := &Session{}
-
+func TestFormatValIntoString_BinaryHexLiteral(t *testing.T) {
 	val := []byte{'x', 0x00, '\\', 0x07, '\''}
-	require.NoError(t, formatValIntoString(ses, val, types.New(types.T_varbinary, 0, 0), &buf))
-	require.Equal(t, `'x\0\\\x07\''`, buf.String())
+	for _, oid := range []types.T{types.T_binary, types.T_varbinary, types.T_blob} {
+		t.Run(oid.String(), func(t *testing.T) {
+			var buf bytes.Buffer
+			require.NoError(t, formatValIntoString(&Session{}, val, types.New(oid, 0, 0), &buf))
+			require.Equal(t, `x'78005c0727'`, buf.String())
+
+			buf.Reset()
+			require.NoError(t, formatValIntoString(&Session{}, []byte{}, types.New(oid, 0, 0), &buf))
+			require.Equal(t, `x''`, buf.String())
+
+			buf.Reset()
+			require.NoError(t, formatValIntoString(&Session{}, "x\x00", types.New(oid, 0, 0), &buf))
+			require.Equal(t, `x'7800'`, buf.String())
+		})
+	}
 }
 
 func TestFormatValIntoString_Time(t *testing.T) {

--- a/test/distributed/cases/git4data/branch/merge/merge_9.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_9.result
@@ -1,0 +1,31 @@
+drop database if exists data_branch_blob_merge;
+create database data_branch_blob_merge;
+use data_branch_blob_merge;
+create table t_src (
+id bigint primary key,
+v int,
+bin binary(5),
+vbin varbinary(5),
+b blob
+);
+insert into t_src values
+(1, 10, x'61005c27ff', x'61005c27ff', x'61005c27ff'),
+(2, 20, x'000102', x'000102', x'000102'),
+(3, 30, null, null, null),
+(4, 40, x'', x'', x'');
+data branch create table t_branch from t_src;
+update t_branch set v = v + 1 where id in (1, 2, 4);
+data branch diff t_branch against t_src output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+3
+data branch merge t_branch into t_src when conflict accept;
+select id, v, hex(bin), hex(vbin), hex(b), ifnull(length(b), -1) as b_len from t_src order by id;
+➤ id[-5,64,0]  ¦  v[4,32,0]  ¦  hex(bin)[12,-1,0]  ¦  hex(vbin)[12,-1,0]  ¦  hex(b)[12,-1,0]  ¦  b_len[-5,64,0]  𝄀
+1  ¦  11  ¦  61005C27FF  ¦  61005C27FF  ¦  61005C27FF  ¦  5  𝄀
+2  ¦  21  ¦  000102  ¦  000102  ¦  000102  ¦  3  𝄀
+3  ¦  30  ¦  null  ¦  null  ¦  null  ¦  -1  𝄀
+4  ¦  41  ¦    ¦    ¦    ¦  0
+data branch diff t_branch against t_src output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+0
+drop database data_branch_blob_merge;

--- a/test/distributed/cases/git4data/branch/merge/merge_9.sql
+++ b/test/distributed/cases/git4data/branch/merge/merge_9.sql
@@ -1,0 +1,30 @@
+-- Regression for issue #24927: merge must preserve BLOB values while applying
+-- changes to other columns in the same rows.
+drop database if exists data_branch_blob_merge;
+create database data_branch_blob_merge;
+use data_branch_blob_merge;
+
+create table t_src (
+    id bigint primary key,
+    v int,
+    bin binary(5),
+    vbin varbinary(5),
+    b blob
+);
+
+insert into t_src values
+    (1, 10, x'61005c27ff', x'61005c27ff', x'61005c27ff'),
+    (2, 20, x'000102', x'000102', x'000102'),
+    (3, 30, null, null, null),
+    (4, 40, x'', x'', x'');
+
+data branch create table t_branch from t_src;
+update t_branch set v = v + 1 where id in (1, 2, 4);
+
+data branch diff t_branch against t_src output count;
+data branch merge t_branch into t_src when conflict accept;
+
+select id, v, hex(bin), hex(vbin), hex(b), ifnull(length(b), -1) as b_len from t_src order by id;
+data branch diff t_branch against t_src output count;
+
+drop database data_branch_blob_merge;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24927

Port of #25568 to `4.1-dev`.

## What this PR does / why we need it:

`DATA BRANCH MERGE` failed when a table contained a `BLOB` column because the shared SQL literal formatter did not support `T_blob`.

This PR:

- adds `T_blob` to the shared data branch value formatter;
- serializes `BINARY`, `VARBINARY`, and `BLOB` values as hexadecimal SQL literals so arbitrary bytes are preserved exactly;
- keeps character and JSON values on their existing escaped-string paths;
- adds unit coverage for control bytes, empty values, and both byte-slice and string inputs;
- adds a data branch merge BVT covering fixed and variable-length binary values, BLOB values, `NULL`, empty bytes, and post-merge diff convergence.

Using escaped SQL strings for binary values is not lossless: control bytes represented as `\\xNN` are parsed as text rather than converted back to the original byte. Hexadecimal literals avoid that corruption and work consistently for all binary-family types.

The BVT result was generated and independently verified on `4.1-dev`; it intentionally reflects this branch's existing `BINARY` display behavior rather than copying the `main` result.

## Validation

- `make -j8 build`
- `go build ./pkg/frontend`
- `go vet ./pkg/frontend`
- full `go test -v -count=1 -timeout 300s ./pkg/frontend`
- `merge_9` BVT: 12/12 statements passed, 100% success rate
- independent SQL verification: diff count changed from 3 before merge to 0 after merge, with all binary values verified through `HEX()` and `LENGTH()`
