### PR TITLE
[4.1] fix data branch edge cases

### DIFF
--- a/pkg/container/types/tuple.go
+++ b/pkg/container/types/tuple.go
@@ -485,6 +485,13 @@ func decodeTupleTo(b []byte, t Tuple, schema []T) (Tuple, int, []T, error) {
 		el, off := decodeFn(code, b[i+1:])
 		return el, off + 1, nil
 	}
+	decodeEnumWithOffset := func(i int) (any, int, error) {
+		if err := checkBytes(i, 3); err != nil { // enum code + uint16 code + at least 1 byte data
+			return nil, 0, err
+		}
+		el, off := decodeUint(uint16Code, b[i+2:])
+		return Enum(el.(uint16)), off + 2, nil
+	}
 
 	i := 0
 	for i < len(b) {
@@ -599,7 +606,7 @@ func decodeTupleTo(b []byte, t Tuple, schema []T) (Tuple, int, []T, error) {
 
 		case enumCode:
 			schema = append(schema, T_enum)
-			el, off, err = decodeWithOffset(i, decodeUint, uint16Code)
+			el, off, err = decodeEnumWithOffset(i)
 
 		case uuidCode:
 			if err = checkBytes(i, 17); err != nil {
@@ -663,6 +670,13 @@ func UnpackNthElement(b []byte, n int) (any, T, error) {
 		}
 		el, off := decodeFn(code, b[i+1:])
 		return el, off + 1, nil
+	}
+	decodeEnumWithOffset := func(i int) (any, int, error) {
+		if err := checkBytes(i, 3); err != nil {
+			return nil, 0, err
+		}
+		el, off := decodeUint(uint16Code, b[i+2:])
+		return Enum(el.(uint16)), off + 2, nil
 	}
 
 	idx := 0
@@ -755,7 +769,7 @@ func UnpackNthElement(b []byte, n int) (any, T, error) {
 			el, off, err = decodeWithOffset(i, decodeUint, uint64Code)
 		case enumCode:
 			schema = T_enum
-			el, off, err = decodeWithOffset(i, decodeUint, uint16Code)
+			el, off, err = decodeEnumWithOffset(i)
 		case uuidCode:
 			if err = checkBytes(i, 17); err != nil {
 				return nil, 0, err

--- a/pkg/container/types/tuple_test.go
+++ b/pkg/container/types/tuple_test.go
@@ -1140,6 +1140,7 @@ func TestUnpackNthElement(t *testing.T) {
 		{"time", func(pk *Packer) { pk.EncodeTime(Time(400)); pk.EncodeNull() }, 0, T_time, Time(400)},
 		{"year", func(pk *Packer) { pk.EncodeMoYear(MoYear(2024)); pk.EncodeNull() }, 0, T_year, MoYear(2024)},
 		{"bit", func(pk *Packer) { pk.EncodeBit(0xBEEF); pk.EncodeNull() }, 0, T_bit, uint64(0xBEEF)},
+		{"enum", func(pk *Packer) { pk.EncodeEnum(Enum(2)); pk.EncodeNull() }, 0, T_enum, Enum(2)},
 		{"objectid", func(pk *Packer) { pk.EncodeObjectid(&oid); pk.EncodeNull() }, 0, T_Objectid, oid},
 	}
 	for _, c := range cases {
@@ -1160,4 +1161,24 @@ func TestUnpackNthElement(t *testing.T) {
 	// Empty input
 	_, _, err = UnpackNthElement([]byte{}, 0)
 	require.Error(t, err)
+}
+
+func TestEncodeEnumKeepsStablePackedFormat(t *testing.T) {
+	enumPacked := NewPacker()
+	enumPacked.EncodeEnum(Enum(2))
+
+	legacyPacked := NewPacker()
+	legacyPacked.putByte(enumCode)
+	legacyPacked.EncodeUint16(uint16(2))
+	require.Equal(t, legacyPacked.GetBuf(), enumPacked.GetBuf())
+
+	tuple, schema, err := UnpackWithSchema(enumPacked.GetBuf())
+	require.NoError(t, err)
+	require.Equal(t, []T{T_enum}, schema)
+	require.Equal(t, Tuple{Enum(2)}, tuple)
+
+	el, typ, err := UnpackNthElement(enumPacked.GetBuf(), 0)
+	require.NoError(t, err)
+	require.Equal(t, T_enum, typ)
+	require.Equal(t, Enum(2), el)
 }

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -557,7 +557,6 @@ func rewriteCloneViewInfos(
 			info.createSql,
 			srcDBName,
 			dstDBName,
-			isSystemDatabaseName(srcDBName),
 		)
 		if err != nil {
 			return nil, nil, err
@@ -572,7 +571,7 @@ func rewriteCloneViewInfos(
 	return rewrittenViewMap, rewrittenViews, nil
 }
 
-func rewriteCloneCreateSQL(sql, srcDBName, dstDBName string, quoteIdentifiers bool) (string, error) {
+func rewriteCloneCreateSQL(sql, srcDBName, dstDBName string) (string, error) {
 	if srcDBName == "" || srcDBName == dstDBName {
 		return sql, nil
 	}
@@ -588,24 +587,12 @@ func rewriteCloneCreateSQL(sql, srcDBName, dstDBName string, quoteIdentifiers bo
 
 	applyRemapDb([]tree.Statement{createView}, map[string]string{srcDBName: dstDBName})
 
-	opts := []tree.FmtCtxOption{tree.WithSingleQuoteString()}
-	if quoteIdentifiers {
-		opts = append(opts, tree.WithQuoteIdentifier())
-	}
+	opts := []tree.FmtCtxOption{tree.WithSingleQuoteString(), tree.WithQuoteIdentifier()}
 	rewritten := tree.StringWithOpts(createView, dialect.MYSQL, opts...)
 	if !strings.HasSuffix(strings.TrimSpace(rewritten), ";") {
 		rewritten += ";"
 	}
 	return rewritten, nil
-}
-
-func isSystemDatabaseName(name string) bool {
-	for _, dbName := range catalog.SystemDatabases {
-		if strings.EqualFold(name, dbName) {
-			return true
-		}
-	}
-	return false
 }
 
 func tryToIncreaseTxnPhysicalTS(

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	plan2 "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
@@ -493,9 +494,14 @@ func handleCloneDatabaseWithSource(
 			return
 		}
 
-		rewrittenViewMap, rewrittenViews := rewriteCloneViewInfos(
+		var rewrittenViewMap map[string]*tableInfo
+		var rewrittenViews []string
+		rewrittenViewMap, rewrittenViews, err = rewriteCloneViewInfos(
 			source.viewMap, sortedViews, source.srcResolveDBName, stmt.DstDatabase.String(),
 		)
+		if err != nil {
+			return
+		}
 
 		if err = restoreViews(reqCtx, ses, bh, "", rewrittenViewMap, source.toAccountId, rewrittenViews, true); err != nil {
 			return
@@ -525,7 +531,7 @@ func rewriteCloneViewInfos(
 	sortedViews []string,
 	srcDBName string,
 	dstDBName string,
-) (map[string]*tableInfo, []string) {
+) (map[string]*tableInfo, []string, error) {
 	rewrittenViews := make([]string, 0, len(sortedViews))
 	for _, key := range sortedViews {
 		dbName, tblName := splitKey(key)
@@ -547,14 +553,59 @@ func rewriteCloneViewInfos(
 		} else if dbName == srcDBName {
 			key = genKey(dstDBName, tblName)
 		}
+		createSQL, err := rewriteCloneCreateSQL(
+			info.createSql,
+			srcDBName,
+			dstDBName,
+			isSystemDatabaseName(srcDBName),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		clonedInfo := *info
 		clonedInfo.dbName = dstDBName
-		clonedInfo.createSql = strings.ReplaceAll(info.createSql, srcDBName, dstDBName)
+		clonedInfo.createSql = createSQL
 		rewrittenViewMap[key] = &clonedInfo
 	}
 
-	return rewrittenViewMap, rewrittenViews
+	return rewrittenViewMap, rewrittenViews, nil
+}
+
+func rewriteCloneCreateSQL(sql, srcDBName, dstDBName string, quoteIdentifiers bool) (string, error) {
+	if srcDBName == "" || srcDBName == dstDBName {
+		return sql, nil
+	}
+
+	stmt, err := parsers.ParseOne(context.Background(), dialect.MYSQL, sql, 1)
+	if err != nil {
+		return "", err
+	}
+	createView, ok := stmt.(*tree.CreateView)
+	if !ok {
+		return "", moerr.NewInternalErrorNoCtxf("clone view SQL is %T, expected *tree.CreateView", stmt)
+	}
+
+	applyRemapDb([]tree.Statement{createView}, map[string]string{srcDBName: dstDBName})
+
+	opts := []tree.FmtCtxOption{tree.WithSingleQuoteString()}
+	if quoteIdentifiers {
+		opts = append(opts, tree.WithQuoteIdentifier())
+	}
+	rewritten := tree.StringWithOpts(createView, dialect.MYSQL, opts...)
+	if !strings.HasSuffix(strings.TrimSpace(rewritten), ";") {
+		rewritten += ";"
+	}
+	return rewritten, nil
+}
+
+func isSystemDatabaseName(name string) bool {
+	for _, dbName := range catalog.SystemDatabases {
+		if strings.EqualFold(name, dbName) {
+			return true
+		}
+	}
+	return false
 }
 
 func tryToIncreaseTxnPhysicalTS(

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -57,7 +57,7 @@ func Test_rewriteCloneViewInfos(t *testing.T) {
 			dbName:    "pub_db",
 			tblName:   "v1",
 			typ:       view,
-			createSql: "create view `pub_db`.`v1` as select * from `pub_db`.`t1`",
+			createSql: "create view `pub_db`.`v1` as select 'pub_db' as marker, a from `pub_db`.`t1`",
 		},
 		fallbackKey: {
 			dbName:    "pub_db",
@@ -72,7 +72,8 @@ func Test_rewriteCloneViewInfos(t *testing.T) {
 		genKey("pub_db", "v1"),
 	}
 
-	rewrittenViewMap, rewrittenViews := rewriteCloneViewInfos(viewMap, sortedViews, "pub_db", "clone_db")
+	rewrittenViewMap, rewrittenViews, err := rewriteCloneViewInfos(viewMap, sortedViews, "pub_db", "clone_db")
+	require.NoError(t, err)
 	require.Equal(t, []string{
 		genKey("other_db", "dep_v"),
 		"clone_db#",
@@ -82,15 +83,80 @@ func Test_rewriteCloneViewInfos(t *testing.T) {
 	info, ok := rewrittenViewMap[genKey("clone_db", "v1")]
 	require.True(t, ok)
 	require.Equal(t, "clone_db", info.dbName)
-	require.Equal(t, "create view `clone_db`.`v1` as select * from `clone_db`.`t1`", info.createSql)
+	require.Equal(t, "create view clone_db.v1 as select 'pub_db' as marker, a from clone_db.t1;", info.createSql)
 
 	fallbackInfo, ok := rewrittenViewMap["clone_db#"]
 	require.True(t, ok)
 	require.Equal(t, "clone_db", fallbackInfo.dbName)
-	require.Equal(t, "create view `clone_db`.`legacy_v` as select 1", fallbackInfo.createSql)
+	require.Equal(t, "create view clone_db.legacy_v as select 1;", fallbackInfo.createSql)
 
 	require.Equal(t, "pub_db", viewMap[genKey("pub_db", "v1")].dbName)
-	require.Equal(t, "create view `pub_db`.`v1` as select * from `pub_db`.`t1`", viewMap[genKey("pub_db", "v1")].createSql)
+	require.Equal(t, "create view `pub_db`.`v1` as select 'pub_db' as marker, a from `pub_db`.`t1`", viewMap[genKey("pub_db", "v1")].createSql)
 	require.Equal(t, "pub_db", viewMap[fallbackKey].dbName)
 	require.Equal(t, "create view `pub_db`.`legacy_v` as select 1", viewMap[fallbackKey].createSql)
+}
+
+func Test_rewriteCloneCreateSQL_RewritesOnlyTableNames(t *testing.T) {
+	got, err := rewriteCloneCreateSQL(
+		`create view pub_db.v as
+			with c as (select * from pub_db.cte_t)
+			select pub_db as pub_db,
+			       (select max(id) from pub_db.proj_t) as m,
+			       case when exists (select 1 from pub_db.case_t) then 1 else 0 end as c,
+			       ((select max(id) from pub_db.null_t) is null) as n
+			  from c
+			  join pub_db.join_t as j on j.id in (select id from pub_db.on_t)
+			 where exists (select 1 from pub_db.where_t)
+			 group by pub_db
+			having count(*) > (select count(*) from pub_db.having_t)`,
+		"pub_db",
+		"clone_db",
+		false,
+	)
+	require.NoError(t, err)
+	require.Contains(t, got, "create view clone_db.v")
+	require.Contains(t, got, "from clone_db.cte_t")
+	require.Contains(t, got, "from clone_db.proj_t")
+	require.Contains(t, got, "from clone_db.case_t")
+	require.Contains(t, got, "from clone_db.null_t")
+	require.Contains(t, got, "join clone_db.join_t")
+	require.Contains(t, got, "from clone_db.on_t")
+	require.Contains(t, got, "from clone_db.where_t")
+	require.Contains(t, got, "from clone_db.having_t")
+	require.NotContains(t, got, "pub_db.cte_t")
+	require.NotContains(t, got, "pub_db.proj_t")
+	require.NotContains(t, got, "pub_db.case_t")
+	require.NotContains(t, got, "pub_db.null_t")
+	require.NotContains(t, got, "pub_db.join_t")
+	require.NotContains(t, got, "pub_db.on_t")
+	require.NotContains(t, got, "pub_db.where_t")
+	require.NotContains(t, got, "pub_db.having_t")
+	require.NotContains(t, got, "select clone_db as")
+	require.Contains(t, got, "as pub_db")
+}
+
+func Test_rewriteCloneCreateSQL_PreservesUnqualifiedViewFormat(t *testing.T) {
+	got, err := rewriteCloneCreateSQL(
+		"create view v1 as select * from t1;",
+		"pub_db",
+		"clone_db",
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "create view v1 as select * from t1;", got)
+}
+
+func Test_rewriteCloneCreateSQL_QuotesSystemViewIdentifiers(t *testing.T) {
+	got, err := rewriteCloneCreateSQL(
+		"create view information_schema.v as select mt.`constraint` from mo_catalog.mo_tables as mt",
+		"information_schema",
+		"information_schema_new",
+		true,
+	)
+	require.NoError(t, err)
+	require.Contains(t, got, "`mt`.`constraint`")
+	require.NotContains(t, got, "mt.constraint")
+
+	_, err = rewriteCloneCreateSQL(got, "information_schema_new", "information_schema_next", true)
+	require.NoError(t, err)
 }

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -134,6 +134,21 @@ func Test_rewriteCloneCreateSQL_RewritesOnlyTableNames(t *testing.T) {
 	require.Contains(t, got, "as pub_db")
 }
 
+func Test_rewriteCloneCreateSQL_RewritesQualifiedColumnsAndOrderingSubqueries(t *testing.T) {
+	got, err := rewriteCloneCreateSQL(
+		"create view src.v as select src.t.a from src.t order by (select max(b) from src.u)",
+		"src",
+		"dst",
+	)
+	require.NoError(t, err)
+	require.Contains(t, got, "create view `dst`.`v`")
+	require.Contains(t, got, "select `dst`.`t`.`a` from `dst`.`t`")
+	require.Contains(t, got, "from `dst`.`u`")
+	require.NotContains(t, got, "`src`.`t`.`a`")
+	require.NotContains(t, got, "from `src`.`t`")
+	require.NotContains(t, got, "from `src`.`u`")
+}
+
 func Test_rewriteCloneCreateSQL_PreservesUnqualifiedViewFormat(t *testing.T) {
 	got, err := rewriteCloneCreateSQL(
 		"create view v1 as select * from t1;",

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -83,12 +83,12 @@ func Test_rewriteCloneViewInfos(t *testing.T) {
 	info, ok := rewrittenViewMap[genKey("clone_db", "v1")]
 	require.True(t, ok)
 	require.Equal(t, "clone_db", info.dbName)
-	require.Equal(t, "create view clone_db.v1 as select 'pub_db' as marker, a from clone_db.t1;", info.createSql)
+	require.Equal(t, "create view `clone_db`.`v1` as select 'pub_db' as marker, `a` from `clone_db`.`t1`;", info.createSql)
 
 	fallbackInfo, ok := rewrittenViewMap["clone_db#"]
 	require.True(t, ok)
 	require.Equal(t, "clone_db", fallbackInfo.dbName)
-	require.Equal(t, "create view clone_db.legacy_v as select 1;", fallbackInfo.createSql)
+	require.Equal(t, "create view `clone_db`.`legacy_v` as select 1;", fallbackInfo.createSql)
 
 	require.Equal(t, "pub_db", viewMap[genKey("pub_db", "v1")].dbName)
 	require.Equal(t, "create view `pub_db`.`v1` as select 'pub_db' as marker, a from `pub_db`.`t1`", viewMap[genKey("pub_db", "v1")].createSql)
@@ -99,8 +99,8 @@ func Test_rewriteCloneViewInfos(t *testing.T) {
 func Test_rewriteCloneCreateSQL_RewritesOnlyTableNames(t *testing.T) {
 	got, err := rewriteCloneCreateSQL(
 		`create view pub_db.v as
-			with c as (select * from pub_db.cte_t)
-			select pub_db as pub_db,
+				with c as (select * from pub_db.cte_t)
+				select pub_db as pub_db,
 			       (select max(id) from pub_db.proj_t) as m,
 			       case when exists (select 1 from pub_db.case_t) then 1 else 0 end as c,
 			       ((select max(id) from pub_db.null_t) is null) as n
@@ -111,27 +111,26 @@ func Test_rewriteCloneCreateSQL_RewritesOnlyTableNames(t *testing.T) {
 			having count(*) > (select count(*) from pub_db.having_t)`,
 		"pub_db",
 		"clone_db",
-		false,
 	)
 	require.NoError(t, err)
-	require.Contains(t, got, "create view clone_db.v")
-	require.Contains(t, got, "from clone_db.cte_t")
-	require.Contains(t, got, "from clone_db.proj_t")
-	require.Contains(t, got, "from clone_db.case_t")
-	require.Contains(t, got, "from clone_db.null_t")
-	require.Contains(t, got, "join clone_db.join_t")
-	require.Contains(t, got, "from clone_db.on_t")
-	require.Contains(t, got, "from clone_db.where_t")
-	require.Contains(t, got, "from clone_db.having_t")
-	require.NotContains(t, got, "pub_db.cte_t")
-	require.NotContains(t, got, "pub_db.proj_t")
-	require.NotContains(t, got, "pub_db.case_t")
-	require.NotContains(t, got, "pub_db.null_t")
-	require.NotContains(t, got, "pub_db.join_t")
-	require.NotContains(t, got, "pub_db.on_t")
-	require.NotContains(t, got, "pub_db.where_t")
-	require.NotContains(t, got, "pub_db.having_t")
-	require.NotContains(t, got, "select clone_db as")
+	require.Contains(t, got, "create view `clone_db`.`v`")
+	require.Contains(t, got, "from `clone_db`.`cte_t`")
+	require.Contains(t, got, "from `clone_db`.`proj_t`")
+	require.Contains(t, got, "from `clone_db`.`case_t`")
+	require.Contains(t, got, "from `clone_db`.`null_t`")
+	require.Contains(t, got, "join `clone_db`.`join_t`")
+	require.Contains(t, got, "from `clone_db`.`on_t`")
+	require.Contains(t, got, "from `clone_db`.`where_t`")
+	require.Contains(t, got, "from `clone_db`.`having_t`")
+	require.NotContains(t, got, "`pub_db`.`cte_t`")
+	require.NotContains(t, got, "`pub_db`.`proj_t`")
+	require.NotContains(t, got, "`pub_db`.`case_t`")
+	require.NotContains(t, got, "`pub_db`.`null_t`")
+	require.NotContains(t, got, "`pub_db`.`join_t`")
+	require.NotContains(t, got, "`pub_db`.`on_t`")
+	require.NotContains(t, got, "`pub_db`.`where_t`")
+	require.NotContains(t, got, "`pub_db`.`having_t`")
+	require.NotContains(t, got, "select `clone_db` as")
 	require.Contains(t, got, "as pub_db")
 }
 
@@ -140,10 +139,22 @@ func Test_rewriteCloneCreateSQL_PreservesUnqualifiedViewFormat(t *testing.T) {
 		"create view v1 as select * from t1;",
 		"pub_db",
 		"clone_db",
-		false,
 	)
 	require.NoError(t, err)
-	require.Equal(t, "create view v1 as select * from t1;", got)
+	require.Equal(t, "create view `v1` as select * from `t1`;", got)
+}
+
+func Test_rewriteCloneCreateSQL_QuotesUserViewIdentifiers(t *testing.T) {
+	got, err := rewriteCloneCreateSQL(
+		"create view `quote'db`.`quote view` as select `quote col` from `quote'db`.`quote table`",
+		"quote'db",
+		"clone db",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "create view `clone db`.`quote view` as select `quote col` from `clone db`.`quote table`;", got)
+
+	_, err = rewriteCloneCreateSQL(got, "clone db", "next db")
+	require.NoError(t, err)
 }
 
 func Test_rewriteCloneCreateSQL_QuotesSystemViewIdentifiers(t *testing.T) {
@@ -151,12 +162,11 @@ func Test_rewriteCloneCreateSQL_QuotesSystemViewIdentifiers(t *testing.T) {
 		"create view information_schema.v as select mt.`constraint` from mo_catalog.mo_tables as mt",
 		"information_schema",
 		"information_schema_new",
-		true,
 	)
 	require.NoError(t, err)
 	require.Contains(t, got, "`mt`.`constraint`")
 	require.NotContains(t, got, "mt.constraint")
 
-	_, err = rewriteCloneCreateSQL(got, "information_schema_new", "information_schema_next", true)
+	_, err = rewriteCloneCreateSQL(got, "information_schema_new", "information_schema_next")
 	require.NoError(t, err)
 }

--- a/pkg/frontend/data_branch_hashdiff.go
+++ b/pkg/frontend/data_branch_hashdiff.go
@@ -1584,10 +1584,13 @@ func appendTupleValueToVector(vec *vector.Vector, val any, mp *mpool.MPool) erro
 	}
 	if raw, ok := val.([]byte); ok {
 		if !vec.GetType().IsVarlen() {
-			return moerr.NewInternalErrorNoCtxf(
-				"unexpected byte slice for fixed-width column type %s",
-				vec.GetType().String(),
-			)
+			if len(raw) != vec.GetType().Oid.FixedLength() {
+				return moerr.NewInternalErrorNoCtxf(
+					"unexpected byte slice for fixed-width column type %s",
+					vec.GetType().String(),
+				)
+			}
+			return vector.AppendAny(vec, types.DecodeValue(raw, vec.GetType().Oid), false, mp)
 		}
 		return vector.AppendBytes(vec, raw, false, mp)
 	}

--- a/pkg/frontend/data_branch_helpers.go
+++ b/pkg/frontend/data_branch_helpers.go
@@ -462,8 +462,8 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 	}
 
 	switch t.Oid {
-	case types.T_varchar, types.T_text, types.T_json, types.T_char, types.
-		T_varbinary, types.T_binary, types.T_blob:
+	case types.T_varchar, types.T_text, types.T_json, types.T_char, types.T_datalink, types.T_geometry, types.T_geometry32,
+		types.T_varbinary, types.T_binary, types.T_blob:
 		if t.Oid == types.T_json {
 			var strVal string
 			switch x := val.(type) {
@@ -516,6 +516,17 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 		buf.WriteString("'")
 		buf.WriteString(val.(types.Date).String())
 		buf.WriteString("'")
+	case types.T_uuid:
+		buf.WriteString("'")
+		switch x := val.(type) {
+		case types.Uuid:
+			buf.WriteString(x.String())
+		case string:
+			buf.WriteString(x)
+		default:
+			return moerr.NewInternalErrorNoCtxf("formatValIntoString: unexpected uuid type %T", val)
+		}
+		buf.WriteString("'")
 	case types.T_year:
 		buf.WriteString(val.(types.MoYear).String())
 	case types.T_decimal64:
@@ -534,6 +545,10 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 		writeUint(uint64(val.(uint32)))
 	case types.T_uint64:
 		writeUint(val.(uint64))
+	case types.T_bit:
+		writeUint(val.(uint64))
+	case types.T_enum:
+		writeUint(uint64(val.(types.Enum)))
 	case types.T_int8:
 		writeInt(int64(val.(int8)))
 	case types.T_int16:

--- a/pkg/frontend/data_branch_helpers.go
+++ b/pkg/frontend/data_branch_helpers.go
@@ -488,17 +488,21 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 			writeEscapedSQLString(buf, jsonLiteral)
 			return nil
 		}
-		writeBytes := writeEscapedSQLString
-		if t.Oid == types.T_binary || t.Oid == types.T_varbinary || t.Oid == types.T_blob {
-			writeBytes = writeSQLHexLiteral
-		}
+		var bytesVal []byte
 		switch x := val.(type) {
 		case []byte:
-			writeBytes(buf, x)
+			bytesVal = x
 		case string:
-			writeBytes(buf, []byte(x))
+			bytesVal = []byte(x)
 		default:
 			return moerr.NewInternalErrorNoCtxf("formatValIntoString: unexpected string type %T", val)
+		}
+		if t.Oid == types.T_geometry32 {
+			writeSQLGeometry32Literal(buf, bytesVal, t)
+		} else if t.Oid == types.T_binary || t.Oid == types.T_varbinary || t.Oid == types.T_blob {
+			writeSQLHexLiteral(buf, bytesVal)
+		} else {
+			writeEscapedSQLString(buf, bytesVal)
 		}
 	case types.T_timestamp:
 		buf.WriteString("'")
@@ -574,6 +578,17 @@ func formatValIntoString(ses *Session, val any, t types.Type, buf *bytes.Buffer)
 	}
 
 	return nil
+}
+
+func writeSQLGeometry32Literal(buf *bytes.Buffer, b []byte, t types.Type) {
+	buf.WriteString("st_geomfromtext(")
+	writeEscapedSQLString(buf, b)
+	// Geometry types encode a declared SRID as Width = SRID + 1; zero means unspecified.
+	if t.Width > 0 {
+		buf.WriteByte(',')
+		buf.WriteString(strconv.FormatInt(int64(t.Width-1), 10))
+	}
+	buf.WriteByte(')')
 }
 
 func writeSQLHexLiteral(buf *bytes.Buffer, b []byte) {
@@ -770,7 +785,7 @@ func compareSingleValInVector(
 			vector.GetFixedAtNoTypeCheck[float64](vec1, rowIdx1),
 			vector.GetFixedAtNoTypeCheck[float64](vec2, rowIdx2),
 		), nil
-	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_binary, types.T_varbinary, types.T_datalink, types.T_geometry:
+	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_binary, types.T_varbinary, types.T_datalink, types.T_geometry, types.T_geometry32:
 		return bytes.Compare(
 			vec1.GetBytesAt(rowIdx1),
 			vec2.GetBytesAt(rowIdx2),

--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/big"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1164,9 +1165,49 @@ func numericGap(a, b []byte, pkType types.Type) float64 {
 		va := types.Decimal128ToFloat64(types.DecodeDecimal128(a), pkType.Scale)
 		vb := types.Decimal128ToFloat64(types.DecodeDecimal128(b), pkType.Scale)
 		return math.Abs(vb - va)
+	case types.T_decimal256:
+		return decimal256AbsGap(
+			types.DecodeDecimal256(a),
+			types.DecodeDecimal256(b),
+			pkType.Scale,
+		)
 	default:
 		return 0
 	}
+}
+
+func decimal256AbsGap(a, b types.Decimal256, scale int32) float64 {
+	ai := decimal256ToBigInt(a)
+	bi := decimal256ToBigInt(b)
+	diff := new(big.Int).Sub(bi, ai)
+	diff.Abs(diff)
+
+	f := new(big.Float).SetPrec(256).SetInt(diff)
+	if scale > 0 {
+		divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
+		f.Quo(f, new(big.Float).SetPrec(256).SetInt(divisor))
+	}
+	v, _ := f.Float64()
+	return v
+}
+
+func decimal256ToBigInt(x types.Decimal256) *big.Int {
+	negative := x.Sign()
+	if negative {
+		x = x.Minus()
+	}
+
+	n := new(big.Int).SetUint64(x.B192_255)
+	n.Lsh(n, 64)
+	n.Add(n, new(big.Int).SetUint64(x.B128_191))
+	n.Lsh(n, 64)
+	n.Add(n, new(big.Int).SetUint64(x.B64_127))
+	n.Lsh(n, 64)
+	n.Add(n, new(big.Int).SetUint64(x.B0_63))
+	if negative {
+		n.Neg(n)
+	}
+	return n
 }
 
 func isNumericType(oid types.T) bool {
@@ -1174,7 +1215,7 @@ func isNumericType(oid types.T) bool {
 	case types.T_int8, types.T_int16, types.T_int32, types.T_int64,
 		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
 		types.T_float32, types.T_float64,
-		types.T_decimal64, types.T_decimal128:
+		types.T_decimal64, types.T_decimal128, types.T_decimal256:
 		return true
 	default:
 		return false

--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -33,6 +33,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/compile"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -56,10 +57,16 @@ func resolveBetweenSnapshots(ses *Session, fromName, toName string) (from, to *t
 
 	fromSnap, err := resolveSnapshot(ses, fromAtTs)
 	if err != nil {
+		if plan2.IsSnapshotNotFound(err) {
+			return nil, nil, moerr.NewInvalidInputNoCtxf("snapshot '%s' not found", fromName)
+		}
 		return nil, nil, moerr.NewInvalidInputNoCtxf("cannot resolve snapshot '%s': %v", fromName, err)
 	}
 	toSnap, err := resolveSnapshot(ses, toAtTs)
 	if err != nil {
+		if plan2.IsSnapshotNotFound(err) {
+			return nil, nil, moerr.NewInvalidInputNoCtxf("snapshot '%s' not found", toName)
+		}
 		return nil, nil, moerr.NewInvalidInputNoCtxf("cannot resolve snapshot '%s': %v", toName, err)
 	}
 	if fromSnap == nil || fromSnap.TS == nil {
@@ -346,7 +353,7 @@ func extractPKAsString(
 func extractPKVal(vec *vector.Vector, rowIdx int) any {
 	switch vec.GetType().Oid {
 	case types.T_datetime, types.T_timestamp, types.T_decimal64,
-		types.T_decimal128, types.T_time:
+		types.T_decimal128, types.T_decimal256, types.T_time:
 		return types.DecodeValue(vec.GetRawBytesAt(rowIdx), vec.GetType().Oid)
 	case types.T_bool:
 		return vector.GetFixedAtNoTypeCheck[bool](vec, rowIdx)
@@ -374,6 +381,8 @@ func extractPKVal(vec *vector.Vector, rowIdx int) any {
 		return vector.GetFixedAtNoTypeCheck[float64](vec, rowIdx)
 	case types.T_date:
 		return vector.GetFixedAtNoTypeCheck[types.Date](vec, rowIdx)
+	case types.T_year:
+		return vector.GetFixedAtNoTypeCheck[types.MoYear](vec, rowIdx)
 	case types.T_uuid:
 		return vector.GetFixedAtNoTypeCheck[types.Uuid](vec, rowIdx)
 	case types.T_enum:
@@ -613,8 +622,12 @@ func formatPickKeyVectorValueAsString(ses *Session, vec *vector.Vector, rowIdx i
 		return vector.GetFixedAtNoTypeCheck[types.Decimal64](vec, rowIdx).Format(vec.GetType().Scale), nil
 	case types.T_decimal128:
 		return vector.GetFixedAtNoTypeCheck[types.Decimal128](vec, rowIdx).Format(vec.GetType().Scale), nil
+	case types.T_decimal256:
+		return vector.GetFixedAtNoTypeCheck[types.Decimal256](vec, rowIdx).Format(vec.GetType().Scale), nil
 	case types.T_date:
 		return vector.GetFixedAtNoTypeCheck[types.Date](vec, rowIdx).String(), nil
+	case types.T_year:
+		return vector.GetFixedAtNoTypeCheck[types.MoYear](vec, rowIdx).String(), nil
 	case types.T_datetime:
 		return vector.GetFixedAtNoTypeCheck[types.Datetime](vec, rowIdx).String(), nil
 	case types.T_timestamp:
@@ -694,13 +707,29 @@ func materializeSubqueryUnified(
 	if stmt.Keys.Select == nil {
 		return nil, moerr.NewInvalidInputNoCtx("KEYS subquery is nil")
 	}
-	if _, err = buildPlanWithAuthorization(ctx, ses, ses.GetTxnCompileCtx(), stmt.Keys.Select); err != nil {
+	subqueryPlan, err := buildPlanWithAuthorization(ctx, ses, ses.GetTxnCompileCtx(), stmt.Keys.Select)
+	if err != nil {
 		return nil, err
 	}
 
 	pkType := tblStuff.def.colTypes[tblStuff.def.pkColIdx]
 	isComposite := tblStuff.def.pkKind == compositeKind
 	nPKCols := len(tblStuff.def.pkColIdxes)
+	subqueryCols := 0
+	if subqueryPlan != nil && subqueryPlan.GetQuery() != nil {
+		subqueryCols = len(subqueryPlan.GetQuery().GetHeadings())
+	}
+	if isComposite {
+		if subqueryCols != nPKCols {
+			return nil, moerr.NewInvalidInputNoCtxf(
+				"KEYS subquery returns %d columns but composite primary key has %d columns",
+				subqueryCols, nPKCols)
+		}
+	} else if subqueryCols != 1 {
+		return nil, moerr.NewInvalidInputNoCtxf(
+			"KEYS subquery returns %d columns but table has a single-column primary key",
+			subqueryCols)
+	}
 
 	// Compose the subquery SQL: wrap the user's SELECT with ORDER BY for
 	// streaming sorted results.  For composite PKs we ORDER BY all component
@@ -1269,8 +1298,20 @@ func appendNumericStringToVec(vec *vector.Vector, s string, pkType types.Type, t
 			return err
 		}
 		return vector.AppendFixed(vec, v, false, mp)
+	case types.T_decimal256:
+		v, err := types.ParseDecimal256(s, pkType.Width, pkType.Scale)
+		if err != nil {
+			return err
+		}
+		return vector.AppendFixed(vec, v, false, mp)
 	case types.T_date:
 		v, err := types.ParseDateCast(s)
+		if err != nil {
+			return err
+		}
+		return vector.AppendFixed(vec, v, false, mp)
+	case types.T_year:
+		v, err := types.ParseMoYear(s)
 		if err != nil {
 			return err
 		}
@@ -1312,46 +1353,8 @@ func appendNumericStringToVec(vec *vector.Vector, s string, pkType types.Type, t
 }
 
 // appendStrValToVec handles string literal values for typed PK columns.
-// For varlen types (varchar, char, text, blob) it appends raw bytes directly.
-// For fixed-width types (date, datetime, timestamp, time, uuid) it parses the
-// string into the correct typed value before appending.
 func appendStrValToVec(vec *vector.Vector, s string, pkType types.Type, tz *time.Location, mp *mpool.MPool) error {
-	switch pkType.Oid {
-	case types.T_varchar, types.T_char, types.T_text, types.T_blob:
-		return vector.AppendBytes(vec, []byte(s), false, mp)
-	case types.T_date:
-		v, err := types.ParseDateCast(s)
-		if err != nil {
-			return err
-		}
-		return vector.AppendFixed(vec, v, false, mp)
-	case types.T_datetime:
-		v, err := types.ParseDatetime(s, pkType.Scale)
-		if err != nil {
-			return err
-		}
-		return vector.AppendFixed(vec, v, false, mp)
-	case types.T_timestamp:
-		v, err := types.ParseTimestamp(normalizePickTimeZone(tz), s, pkType.Scale)
-		if err != nil {
-			return err
-		}
-		return vector.AppendFixed(vec, v, false, mp)
-	case types.T_time:
-		v, err := types.ParseTime(s, pkType.Scale)
-		if err != nil {
-			return err
-		}
-		return vector.AppendFixed(vec, v, false, mp)
-	case types.T_uuid:
-		v, err := types.ParseUuid(s)
-		if err != nil {
-			return err
-		}
-		return vector.AppendFixed(vec, v, false, mp)
-	default:
-		return moerr.NewInvalidInputNoCtxf("unsupported PK type for string literal: %s", pkType.Oid.String())
-	}
+	return appendNumericStringToVec(vec, s, pkType, tz, mp)
 }
 
 // freePKFilter is a no-op retained for call-site compatibility.

--- a/pkg/frontend/data_branch_pick_test.go
+++ b/pkg/frontend/data_branch_pick_test.go
@@ -1102,6 +1102,16 @@ func TestMaterializeSubqueryUnified_RejectsNilSelect(t *testing.T) {
 	require.Nil(t, pkFilter)
 }
 
+func newPickSubqueryPlanForTest(cols ...string) *plan2.Plan {
+	return &plan2.Plan{
+		Plan: &plan2.Plan_Query{
+			Query: &plan2.Query{
+				Headings: cols,
+			},
+		},
+	}
+}
+
 func TestMaterializeSubqueryUnified_SinglePKSuccessBuildsFilterAndHashmap(t *testing.T) {
 	ses := newValidateSession(t)
 	stmtNode, err := parsers.ParseOne(
@@ -1125,7 +1135,7 @@ func TestMaterializeSubqueryUnified_SinglePKSuccessBuildsFilterAndHashmap(t *tes
 		ctx plan2.CompilerContext,
 		stmt tree.Statement,
 	) (*plan2.Plan, error) {
-		return nil, nil
+		return newPickSubqueryPlanForTest("k"), nil
 	}
 
 	tblStuff := tableStuff{}
@@ -1202,7 +1212,7 @@ func TestMaterializeSubqueryUnified_PreservesStringLiteralQuotes(t *testing.T) {
 		ctx plan2.CompilerContext,
 		stmt tree.Statement,
 	) (*plan2.Plan, error) {
-		return nil, nil
+		return newPickSubqueryPlanForTest("order_id"), nil
 	}
 
 	tblStuff := tableStuff{}
@@ -1267,7 +1277,7 @@ func TestMaterializeSubqueryUnified_CompositePKOrdersAllColumns(t *testing.T) {
 		ctx plan2.CompilerContext,
 		stmt tree.Statement,
 	) (*plan2.Plan, error) {
-		return nil, nil
+		return newPickSubqueryPlanForTest("k1", "k2"), nil
 	}
 
 	tblStuff := tableStuff{}
@@ -1332,7 +1342,7 @@ func TestMaterializeSubqueryUnified_PropagatesStreamingError(t *testing.T) {
 		ctx plan2.CompilerContext,
 		stmt tree.Statement,
 	) (*plan2.Plan, error) {
-		return nil, nil
+		return newPickSubqueryPlanForTest("k"), nil
 	}
 	wantErr := moerr.NewInternalErrorNoCtx("subquery failed")
 	bh := newPickStreamingBackExecForTest(t, ses, &pickStreamingExecutor{err: wantErr})
@@ -1378,7 +1388,12 @@ func TestFormatPickKeyVectorValueAsString_AllSupportedKinds(t *testing.T) {
 	dec128Type := types.New(types.T_decimal128, 20, 3)
 	dec128Val, err := types.ParseDecimal128("200.125", dec128Type.Width, dec128Type.Scale)
 	require.NoError(t, err)
+	dec256Type := types.New(types.T_decimal256, 65, 30)
+	dec256Val, err := types.ParseDecimal256("300.125000000000000000000000000000", dec256Type.Width, dec256Type.Scale)
+	require.NoError(t, err)
 	dateVal, err := types.ParseDateCast("2025-01-03")
+	require.NoError(t, err)
+	yearVal, err := types.ParseMoYear("2025")
 	require.NoError(t, err)
 	datetimeType := types.New(types.T_datetime, 0, 0)
 	datetimeVal, err := types.ParseDatetime("2025-01-03 12:30:45", datetimeType.Scale)
@@ -1527,12 +1542,28 @@ func TestFormatPickKeyVectorValueAsString_AllSupportedKinds(t *testing.T) {
 			want: dec128Val.Format(dec128Type.Scale),
 		},
 		{
+			name: "decimal256",
+			typ:  dec256Type,
+			append: func(vec *vector.Vector) {
+				require.NoError(t, vector.AppendFixed(vec, dec256Val, false, mp))
+			},
+			want: dec256Val.Format(dec256Type.Scale),
+		},
+		{
 			name: "date",
 			typ:  types.T_date.ToType(),
 			append: func(vec *vector.Vector) {
 				require.NoError(t, vector.AppendFixed(vec, dateVal, false, mp))
 			},
 			want: dateVal.String(),
+		},
+		{
+			name: "year",
+			typ:  types.T_year.ToType(),
+			append: func(vec *vector.Vector) {
+				require.NoError(t, vector.AppendFixed(vec, yearVal, false, mp))
+			},
+			want: yearVal.String(),
 		},
 		{
 			name: "datetime",
@@ -1602,6 +1633,45 @@ func TestFormatPickKeyVectorValueAsString_AllSupportedKinds(t *testing.T) {
 	}
 }
 
+func TestPickKeyDecimal256AndYearPaths(t *testing.T) {
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+	defer mp.Free(nil)
+
+	ses := newValidateSession(t)
+	decType := types.New(types.T_decimal256, 65, 30)
+	decVal, err := types.ParseDecimal256("42.000000000000000000000000000000", decType.Width, decType.Scale)
+	require.NoError(t, err)
+	yearVal, err := types.ParseMoYear("2025")
+	require.NoError(t, err)
+
+	decVec := vector.NewVec(decType)
+	defer decVec.Free(mp)
+	require.NoError(t, appendNumericStringToVec(decVec, decVal.Format(decType.Scale), decType, time.UTC, mp))
+	require.Equal(t, decVal, extractPKVal(decVec, 0))
+	decString, err := formatPickKeyVectorValueAsString(ses, decVec, 0)
+	require.NoError(t, err)
+	require.Equal(t, decVal.Format(decType.Scale), decString)
+
+	decStrVec := vector.NewVec(decType)
+	defer decStrVec.Free(mp)
+	require.NoError(t, appendStrValToVec(decStrVec, decVal.Format(decType.Scale), decType, time.UTC, mp))
+	require.Equal(t, decVal, extractPKVal(decStrVec, 0))
+
+	yearVec := vector.NewVec(types.T_year.ToType())
+	defer yearVec.Free(mp)
+	require.NoError(t, appendNumericStringToVec(yearVec, yearVal.String(), types.T_year.ToType(), time.UTC, mp))
+	require.Equal(t, yearVal, extractPKVal(yearVec, 0))
+	yearString, err := formatPickKeyVectorValueAsString(ses, yearVec, 0)
+	require.NoError(t, err)
+	require.Equal(t, yearVal.String(), yearString)
+
+	yearStrVec := vector.NewVec(types.T_year.ToType())
+	defer yearStrVec.Free(mp)
+	require.NoError(t, appendStrValToVec(yearStrVec, "2025", types.T_year.ToType(), time.UTC, mp))
+	require.Equal(t, yearVal, extractPKVal(yearStrVec, 0))
+}
+
 type pickStreamingExecutor struct {
 	result executor.Result
 	err    error
@@ -1663,6 +1733,10 @@ func buildPickStreamingBatch(t *testing.T, mp *mpool.MPool, colTypes []types.Typ
 		for colIdx, val := range row {
 			switch typed := val.(type) {
 			case int64:
+				require.NoError(t, vector.AppendFixed(bat.Vecs[colIdx], typed, false, mp))
+			case types.Decimal256:
+				require.NoError(t, vector.AppendFixed(bat.Vecs[colIdx], typed, false, mp))
+			case types.MoYear:
 				require.NoError(t, vector.AppendFixed(bat.Vecs[colIdx], typed, false, mp))
 			case string:
 				require.NoError(t, vector.AppendBytes(bat.Vecs[colIdx], []byte(typed), false, mp))

--- a/pkg/frontend/data_branch_pick_test.go
+++ b/pkg/frontend/data_branch_pick_test.go
@@ -120,6 +120,23 @@ func TestSegmentBuilder_StringType_CountBased(t *testing.T) {
 	require.Equal(t, types.T_varchar, zm.GetType())
 }
 
+func TestSegmentBuilder_Decimal256GapBased(t *testing.T) {
+	pkType := types.New(types.T_decimal256, 39, 4)
+	sb := newSegmentBuilder(pkType)
+	require.True(t, sb.isNumeric)
+
+	for _, text := range []string{
+		"1.0000", "2.0000", "3.0000", "4.0000", "5.0000", "1000000.0000",
+	} {
+		value, err := types.ParseDecimal256(text, pkType.Width, pkType.Scale)
+		require.NoError(t, err)
+		sb.observe(types.EncodeDecimal256(&value))
+	}
+
+	segments := sb.finalize()
+	require.Len(t, segments, 2)
+}
+
 func TestBuildSegmentsFromSortedVec_Int32(t *testing.T) {
 	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
 	require.NoError(t, err)
@@ -264,6 +281,11 @@ func TestNumericGap_AllTypes(t *testing.T) {
 			b, _ := types.ParseDecimal128("200.75", 20, 2)
 			return types.EncodeDecimal128(&a), types.EncodeDecimal128(&b)
 		}, 100.50},
+		{"decimal256", types.T_decimal256, types.New(types.T_decimal256, 39, 4), func() ([]byte, []byte) {
+			a, _ := types.ParseDecimal256("1234567890123456789012345678901230.0001", 39, 4)
+			b, _ := types.ParseDecimal256("1234567890123456789012345678901232.0001", 39, 4)
+			return types.EncodeDecimal256(&a), types.EncodeDecimal256(&b)
+		}, 2.0},
 		{"varchar_returns_zero", types.T_varchar, types.Type{}, func() ([]byte, []byte) {
 			return []byte("aaa"), []byte("zzz")
 		}, 0.0},
@@ -287,7 +309,7 @@ func TestIsNumericType(t *testing.T) {
 		types.T_int8, types.T_int16, types.T_int32, types.T_int64,
 		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
 		types.T_float32, types.T_float64,
-		types.T_decimal64, types.T_decimal128,
+		types.T_decimal64, types.T_decimal128, types.T_decimal256,
 	}
 	for _, oid := range numeric {
 		require.True(t, isNumericType(oid), "expected numeric: %s", oid)

--- a/pkg/frontend/data_branch_snapshot.go
+++ b/pkg/frontend/data_branch_snapshot.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/frontend/databranchutils"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -220,23 +221,21 @@ func createBranchProtectSnapshot(
 	// existing insertIntoMoSnapshots format does not carry the kind column
 	// (it relies on the 'user' default), so this path uses its own insert.
 	//
-	// Values are interpolated via fmt.Sprintf because every user-
-	// controllable string here (account name, db/table name) has already
-	// passed through the MO parser/catalog path, so it is a legal MySQL
-	// identifier and never carries a quote that could break the literal.
+	// Identifiers can contain apostrophes when quoted with backticks, so every
+	// value interpolated as a SQL string literal must be escaped explicitly.
 	insertSQL := fmt.Sprintf(
 		`insert into %s.%s(snapshot_id, sname, ts, level, account_name, database_name, table_name, obj_id, kind) `+
 			`values ('%s', '%s', %d, '%s', '%s', '%s', '%s', %d, '%s')`,
 		catalog.MO_CATALOG, catalog.MO_SNAPSHOTS,
-		newUUID.String(),
-		sname,
+		sqlquote.EscapeString(newUUID.String()),
+		sqlquote.EscapeString(sname),
 		receipt.snapshotTS,
-		dataBranchLevel_Table,
-		parentAccountName,
-		receipt.srcDb,
-		receipt.srcTbl,
+		sqlquote.EscapeString(dataBranchLevel_Table),
+		sqlquote.EscapeString(parentAccountName),
+		sqlquote.EscapeString(receipt.srcDb),
+		sqlquote.EscapeString(receipt.srcTbl),
 		receipt.srcTableID,
-		branchSnapshotKind,
+		sqlquote.EscapeString(branchSnapshotKind),
 	)
 
 	// Execute as sys so the row can be written into the parent's account

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -97,6 +97,31 @@ func TestFormatValIntoString_Time(t *testing.T) {
 	require.Equal(t, `'12:34:56.123456'`, buf.String())
 }
 
+func TestFormatValIntoString_Bit(t *testing.T) {
+	var buf bytes.Buffer
+	ses := &Session{}
+
+	require.NoError(t, formatValIntoString(ses, uint64(7), types.New(types.T_bit, 0, 0), &buf))
+	require.Equal(t, "7", buf.String())
+}
+
+func TestFormatValIntoString_UUID(t *testing.T) {
+	var buf bytes.Buffer
+	ses := &Session{}
+	uuidValue := types.Uuid{0x1b, 0x50, 0xc1, 0x37, 0x2d, 0xba, 0x11, 0xed, 0x94, 0x0f, 0x00, 0x0c, 0x29, 0x84, 0x79, 0x04}
+
+	require.NoError(t, formatValIntoString(ses, uuidValue, types.New(types.T_uuid, 0, 0), &buf))
+	require.Equal(t, "'1b50c137-2dba-11ed-940f-000c29847904'", buf.String())
+}
+
+func TestFormatValIntoString_GeometryText(t *testing.T) {
+	var buf bytes.Buffer
+	ses := &Session{}
+
+	require.NoError(t, formatValIntoString(ses, []byte("POINT(2 2)"), types.New(types.T_geometry, 0, 0), &buf))
+	require.Equal(t, "'POINT(2 2)'", buf.String())
+}
+
 func TestFormatValIntoString_JSONEscaping(t *testing.T) {
 	var buf bytes.Buffer
 	ses := &Session{}
@@ -193,8 +218,14 @@ func TestAppendTupleValueToVector_VarlenaAndNull(t *testing.T) {
 	require.Equal(t, 2, varcharVec.Length())
 	require.True(t, varcharVec.GetNulls().Contains(1))
 
+	decimalVec := vector.NewVec(types.New(types.T_decimal256, 65, 30))
+	decimalValue, err := types.ParseDecimal256("42.000000000000000000000000000000", 65, 30)
+	require.NoError(t, err)
+	require.NoError(t, appendTupleValueToVector(decimalVec, types.EncodeDecimal256(&decimalValue), mp))
+	require.Equal(t, decimalValue, vector.GetFixedAtNoTypeCheck[types.Decimal256](decimalVec, 0))
+
 	datetimeVec := vector.NewVec(types.New(types.T_datetime, 0, 6))
-	err := appendTupleValueToVector(datetimeVec, []byte("not-raw-fixed"), mp)
+	err = appendTupleValueToVector(datetimeVec, []byte("not-raw-fixed"), mp)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected byte slice for fixed-width column")
 }

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -120,6 +120,14 @@ func TestFormatValIntoString_GeometryText(t *testing.T) {
 
 	require.NoError(t, formatValIntoString(ses, []byte("POINT(2 2)"), types.New(types.T_geometry, 0, 0), &buf))
 	require.Equal(t, "'POINT(2 2)'", buf.String())
+
+	buf.Reset()
+	require.NoError(t, formatValIntoString(ses, []byte("POINT(2 2)"), types.New(types.T_geometry32, 0, 0), &buf))
+	require.Equal(t, "st_geomfromtext('POINT(2 2)')", buf.String())
+
+	buf.Reset()
+	require.NoError(t, formatValIntoString(ses, []byte("POINT(2 2)"), types.New(types.T_geometry32, 4326+1, 0), &buf))
+	require.Equal(t, "st_geomfromtext('POINT(2 2)',4326)", buf.String())
 }
 
 func TestFormatValIntoString_JSONEscaping(t *testing.T) {
@@ -445,6 +453,16 @@ func TestCompareSingleValInVector_AllTypes(t *testing.T) {
 			build: func(t *testing.T, mp *mpool.MPool) (*vector.Vector, *vector.Vector, int) {
 				typ := types.T_datalink.ToType()
 				leftVal, rightVal := []byte("link-a"), []byte("link-b")
+				leftVec := buildBytesVector(t, mp, typ, leftVal)
+				rightVec := buildBytesVector(t, mp, typ, rightVal)
+				return leftVec, rightVec, types.CompareValue(leftVal, rightVal)
+			},
+		},
+		{
+			name: "geometry32",
+			build: func(t *testing.T, mp *mpool.MPool) (*vector.Vector, *vector.Vector, int) {
+				typ := types.T_geometry32.ToType()
+				leftVal, rightVal := []byte{0x01, 0x02, 0x03}, []byte{0x01, 0x02, 0x04}
 				leftVec := buildBytesVector(t, mp, typ, leftVal)
 				rightVec := buildBytesVector(t, mp, typ, rightVal)
 				return leftVec, rightVec, types.CompareValue(leftVal, rightVal)

--- a/pkg/frontend/databranchutils/branch_hashmap.go
+++ b/pkg/frontend/databranchutils/branch_hashmap.go
@@ -1797,12 +1797,7 @@ func encodeDecodedValue(p *types.Packer, typ types.Type, v any) error {
 		}
 		p.EncodeDecimal128(val)
 	case types.T_decimal256:
-		val, ok := v.(types.Decimal256)
-		if !ok {
-			return moerr.NewInvalidInputNoCtx("expected decimal256 value")
-		}
-		raw := types.EncodeDecimal256(&val)
-		p.EncodeStringType(raw)
+		return encodeDecodedDecimal256(p, v)
 	case types.T_uuid:
 		val, ok := v.(types.Uuid)
 		if !ok {
@@ -1844,6 +1839,21 @@ func encodeDecodedValue(p *types.Packer, typ types.Type, v any) error {
 			return moerr.NewInvalidInputNoCtx("expected byte slice value")
 		}
 		p.EncodeStringType(bytesVal)
+	}
+	return nil
+}
+
+func encodeDecodedDecimal256(p *types.Packer, v any) error {
+	switch val := v.(type) {
+	case types.Decimal256:
+		p.EncodeStringType(types.EncodeDecimal256(&val))
+	case []byte:
+		if len(val) != types.Decimal256Size {
+			return moerr.NewInvalidInputNoCtxf("expected decimal256 raw bytes length %d, got %d", types.Decimal256Size, len(val))
+		}
+		p.EncodeStringType(val)
+	default:
+		return moerr.NewInvalidInputNoCtx("expected decimal256 value")
 	}
 	return nil
 }

--- a/pkg/frontend/databranchutils/branch_hashmap.go
+++ b/pkg/frontend/databranchutils/branch_hashmap.go
@@ -1796,6 +1796,13 @@ func encodeDecodedValue(p *types.Packer, typ types.Type, v any) error {
 			return moerr.NewInvalidInputNoCtx("expected decimal128 value")
 		}
 		p.EncodeDecimal128(val)
+	case types.T_decimal256:
+		val, ok := v.(types.Decimal256)
+		if !ok {
+			return moerr.NewInvalidInputNoCtx("expected decimal256 value")
+		}
+		raw := types.EncodeDecimal256(&val)
+		p.EncodeStringType(raw)
 	case types.T_uuid:
 		val, ok := v.(types.Uuid)
 		if !ok {
@@ -1811,12 +1818,18 @@ func encodeDecodedValue(p *types.Packer, typ types.Type, v any) error {
 	case types.T_enum:
 		switch val := v.(type) {
 		case types.Enum:
-			p.EncodeUint16(uint16(val))
+			p.EncodeEnum(val)
 		case uint16:
-			p.EncodeUint16(val)
+			p.EncodeEnum(types.Enum(val))
 		default:
 			return moerr.NewInvalidInputNoCtx("expected enum value")
 		}
+	case types.T_year:
+		val, ok := v.(types.MoYear)
+		if !ok {
+			return moerr.NewInvalidInputNoCtx("expected year value")
+		}
+		p.EncodeMoYear(val)
 	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_json,
 		types.T_binary, types.T_varbinary, types.T_datalink,
 		types.T_array_float32, types.T_array_float64, types.T_TS:
@@ -1888,6 +1901,11 @@ func encodeValue(p *types.Packer, vec *vector.Vector, row int) error {
 	case types.T_decimal128:
 		v := vector.GetFixedAtNoTypeCheck[types.Decimal128](vec, row)
 		p.EncodeDecimal128(v)
+	case types.T_decimal256:
+		raw := vec.GetRawBytesAt(row)
+		tmp := make([]byte, len(raw))
+		copy(tmp, raw)
+		p.EncodeStringType(tmp)
 	case types.T_uuid:
 		v := vector.GetFixedAtNoTypeCheck[types.Uuid](vec, row)
 		p.EncodeUuid(v)
@@ -1896,7 +1914,10 @@ func encodeValue(p *types.Packer, vec *vector.Vector, row int) error {
 		p.EncodeBit(v)
 	case types.T_enum:
 		v := vector.GetFixedAtNoTypeCheck[types.Enum](vec, row)
-		p.EncodeUint16(uint16(v))
+		p.EncodeEnum(v)
+	case types.T_year:
+		v := vector.GetFixedAtNoTypeCheck[types.MoYear](vec, row)
+		p.EncodeMoYear(v)
 	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_json,
 		types.T_binary, types.T_varbinary, types.T_datalink,
 		types.T_array_float32, types.T_array_float64:

--- a/pkg/frontend/databranchutils/branch_hashmap_test.go
+++ b/pkg/frontend/databranchutils/branch_hashmap_test.go
@@ -450,6 +450,108 @@ func TestBranchHashmapProjectChangeKey(t *testing.T) {
 	require.Equal(t, []byte("c"), row[1])
 }
 
+func TestBranchHashmapDecimal256DecodedReencodePaths(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	decimalTyp := types.New(types.T_decimal256, 65, 30)
+	amountA := mustParseDecimal256(t, decimalTyp, "12345678901234567890123456789012345.123456789012345678901234567890")
+	amountB := mustParseDecimal256(t, decimalTyp, "-22345678901234567890123456789012345.123456789012345678901234567890")
+
+	t.Run("project", func(t *testing.T) {
+		idVec := buildInt64Vector(t, mp, []int64{1, 2})
+		amountVec := buildDecimal256Vector(t, mp, decimalTyp, []types.Decimal256{amountA, amountB})
+		payloadVec := buildStringVector(t, mp, []string{"a", "b"})
+		defer idVec.Free(mp)
+		defer amountVec.Free(mp)
+		defer payloadVec.Free(mp)
+
+		bh, err := NewBranchHashmap()
+		require.NoError(t, err)
+		defer bh.Close()
+
+		require.NoError(t, bh.PutByVectors([]*vector.Vector{idVec, amountVec, payloadVec}, []int{0}))
+
+		projected, err := bh.Project([]int{1}, 1)
+		require.NoError(t, err)
+		defer projected.Close()
+
+		probe := buildDecimal256Vector(t, mp, decimalTyp, []types.Decimal256{amountA})
+		defer probe.Free(mp)
+
+		results, err := projected.GetByVectors([]*vector.Vector{probe})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.True(t, results[0].Exists)
+		require.Len(t, results[0].Rows, 1)
+
+		tuple, _, err := projected.DecodeRow(results[0].Rows[0])
+		require.NoError(t, err)
+		require.Equal(t, types.EncodeDecimal256(&amountA), tuple[1])
+	})
+
+	t.Run("pop full value", func(t *testing.T) {
+		amountVec := buildDecimal256Vector(t, mp, decimalTyp, []types.Decimal256{amountA, amountB})
+		payloadVec := buildStringVector(t, mp, []string{"a", "b"})
+		defer amountVec.Free(mp)
+		defer payloadVec.Free(mp)
+
+		bh, err := NewBranchHashmap()
+		require.NoError(t, err)
+		defer bh.Close()
+
+		require.NoError(t, bh.PutByVectors([]*vector.Vector{amountVec, payloadVec}, []int{0}))
+
+		probe := buildDecimal256Vector(t, mp, decimalTyp, []types.Decimal256{amountA})
+		defer probe.Free(mp)
+
+		results, err := bh.GetByVectors([]*vector.Vector{probe})
+		require.NoError(t, err)
+		require.True(t, results[0].Exists)
+		require.Len(t, results[0].Rows, 1)
+
+		removed, err := bh.PopByEncodedFullValue(results[0].Rows[0], true)
+		require.NoError(t, err)
+		require.True(t, removed.Exists)
+		require.Len(t, removed.Rows, 1)
+
+		after, err := bh.GetByVectors([]*vector.Vector{probe})
+		require.NoError(t, err)
+		require.False(t, after[0].Exists)
+	})
+
+	t.Run("pop exact full value", func(t *testing.T) {
+		amountVec := buildDecimal256Vector(t, mp, decimalTyp, []types.Decimal256{amountA, amountA})
+		payloadVec := buildStringVector(t, mp, []string{"one", "two"})
+		defer amountVec.Free(mp)
+		defer payloadVec.Free(mp)
+
+		bh, err := NewBranchHashmap()
+		require.NoError(t, err)
+		defer bh.Close()
+
+		require.NoError(t, bh.PutByVectors([]*vector.Vector{amountVec, payloadVec}, []int{0}))
+
+		probe := buildDecimal256Vector(t, mp, decimalTyp, []types.Decimal256{amountA})
+		defer probe.Free(mp)
+
+		results, err := bh.GetByVectors([]*vector.Vector{probe})
+		require.NoError(t, err)
+		require.True(t, results[0].Exists)
+		require.Len(t, results[0].Rows, 2)
+
+		valueCopy := append([]byte(nil), results[0].Rows[0]...)
+		removed, err := bh.PopByEncodedFullValueExact(valueCopy, false)
+		require.NoError(t, err)
+		require.Equal(t, 1, removed)
+
+		after, err := bh.GetByVectors([]*vector.Vector{probe})
+		require.NoError(t, err)
+		require.True(t, after[0].Exists)
+		require.Len(t, after[0].Rows, 1)
+	})
+}
+
 func TestBranchHashmapPopByEncodedFullValues(t *testing.T) {
 	mp := mpool.MustNewZero()
 	defer mpool.DeleteMPool(mp)
@@ -1762,6 +1864,20 @@ func buildInt32Vector(tb testing.TB, mp *mpool.MPool, values []int32) *vector.Ve
 	return vec
 }
 
+func buildDecimal256Vector(tb testing.TB, mp *mpool.MPool, typ types.Type, values []types.Decimal256) *vector.Vector {
+	tb.Helper()
+	vec := vector.NewVec(typ)
+	require.NoError(tb, vector.AppendFixedList(vec, values, nil, mp))
+	return vec
+}
+
+func mustParseDecimal256(tb testing.TB, typ types.Type, s string) types.Decimal256 {
+	tb.Helper()
+	val, err := types.ParseDecimal256(s, typ.Width, typ.Scale)
+	require.NoError(tb, err)
+	return val
+}
+
 type limitedAllocator struct {
 	mu    sync.Mutex
 	limit uint64
@@ -2081,6 +2197,10 @@ func TestEncodeDecodedValue_AllTypes(t *testing.T) {
 	p := types.NewPacker()
 	defer p.Close()
 
+	decimal256Typ := types.New(types.T_decimal256, 65, 30)
+	decimal256Val := mustParseDecimal256(t, decimal256Typ, "12345678901234567890123456789012345.123456789012345678901234567890")
+	decimal256Raw := append([]byte(nil), types.EncodeDecimal256(&decimal256Val)...)
+
 	stringTypeOids := []types.T{
 		types.T_char,
 		types.T_varchar,
@@ -2118,6 +2238,8 @@ func TestEncodeDecodedValue_AllTypes(t *testing.T) {
 		{name: "timestamp", typ: types.T_timestamp.ToType(), value: types.Timestamp(456), expect: types.Timestamp(456)},
 		{name: "decimal64", typ: types.T_decimal64.ToType(), value: types.Decimal64(123456), expect: types.Decimal64(123456)},
 		{name: "decimal128", typ: types.T_decimal128.ToType(), value: types.Decimal128{B0_63: 1, B64_127: 2}, expect: types.Decimal128{B0_63: 1, B64_127: 2}},
+		{name: "decimal256_typed", typ: decimal256Typ, value: decimal256Val, expect: decimal256Raw},
+		{name: "decimal256_raw", typ: decimal256Typ, value: decimal256Raw, expect: decimal256Raw},
 		{name: "uuid", typ: types.T_uuid.ToType(), value: types.Uuid{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, expect: types.Uuid{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
 		{name: "bit", typ: types.T_bit.ToType(), value: uint64(10), expect: uint64(10)},
 		{name: "enum_value", typ: types.T_enum.ToType(), value: types.Enum(7), expect: types.Enum(7)},
@@ -2164,6 +2286,7 @@ func TestEncodeDecodedValue_TypeMismatch(t *testing.T) {
 		{name: "int8_from_int16", typ: types.T_int8.ToType(), value: int16(1)},
 		{name: "string_from_string", typ: types.T_varchar.ToType(), value: "not-bytes"},
 		{name: "enum_invalid_type", typ: types.T_enum.ToType(), value: int32(3)},
+		{name: "decimal256_invalid_raw", typ: types.New(types.T_decimal256, 65, 30), value: []byte{1, 2, 3}},
 	}
 
 	for _, tc := range cases {

--- a/pkg/frontend/databranchutils/branch_hashmap_test.go
+++ b/pkg/frontend/databranchutils/branch_hashmap_test.go
@@ -1650,7 +1650,7 @@ func TestEncodeRowCoversManyTypes(t *testing.T) {
 				require.NoError(t, vector.AppendFixed(vec, types.Enum(42), false, mp))
 			},
 			assert: func(v any) {
-				require.Equal(t, uint16(42), uint16(v.(uint16)))
+				require.Equal(t, types.Enum(42), v.(types.Enum))
 			},
 		},
 		{
@@ -2120,8 +2120,8 @@ func TestEncodeDecodedValue_AllTypes(t *testing.T) {
 		{name: "decimal128", typ: types.T_decimal128.ToType(), value: types.Decimal128{B0_63: 1, B64_127: 2}, expect: types.Decimal128{B0_63: 1, B64_127: 2}},
 		{name: "uuid", typ: types.T_uuid.ToType(), value: types.Uuid{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, expect: types.Uuid{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
 		{name: "bit", typ: types.T_bit.ToType(), value: uint64(10), expect: uint64(10)},
-		{name: "enum_value", typ: types.T_enum.ToType(), value: types.Enum(7), expect: uint16(7)},
-		{name: "enum_uint16", typ: types.T_enum.ToType(), value: uint16(9), expect: uint16(9)},
+		{name: "enum_value", typ: types.T_enum.ToType(), value: types.Enum(7), expect: types.Enum(7)},
+		{name: "enum_uint16", typ: types.T_enum.ToType(), value: uint16(9), expect: types.Enum(9)},
 		{name: "ts_bytes", typ: types.T_TS.ToType(), value: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, expect: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
 		{name: "default_bytes", typ: types.T_any.ToType(), value: []byte("fallback"), expect: []byte("fallback")},
 	}

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -175,21 +176,21 @@ func getSqlForCheckDupPitrFormat(accountId, objId uint64) string {
 }
 
 func getPubInfoWithPitr(ts int64, accountId uint32, dbName string) string {
-	return fmt.Sprintf(getPubInfoWithPitrFormat, ts, accountId, dbName)
+	return fmt.Sprintf(getPubInfoWithPitrFormat, ts, accountId, sqlquote.EscapeString(dbName))
 }
 
 func getSqlForUpdateMoPitrAccountObjectId(accountName string, objId uint64, ts int64) string {
-	return fmt.Sprintf(updateMoPitrAccountObjectIdFmt, ts, accountName, objId)
+	return fmt.Sprintf(updateMoPitrAccountObjectIdFmt, ts, sqlquote.EscapeString(accountName), objId)
 }
 
 func getSqlForGetLengthAndUnitFmt(accountId uint32, level, accName, dbName, tblName string) string {
 	sql := fmt.Sprintf(getLengthAndUnitFmt, accountId, level)
 	if level == "account" {
-		sql += fmt.Sprintf(" and account_name = '%s'", accName)
+		sql += fmt.Sprintf(" and account_name = '%s'", sqlquote.EscapeString(accName))
 	} else if level == "database" {
-		sql += fmt.Sprintf(" and database_name = '%s'", dbName)
+		sql += fmt.Sprintf(" and database_name = '%s'", sqlquote.EscapeString(dbName))
 	} else if level == "table" {
-		sql += fmt.Sprintf(" and table_name = '%s'", tblName)
+		sql += fmt.Sprintf(" and table_name = '%s'", sqlquote.EscapeString(tblName))
 	}
 	return sql
 }
@@ -232,14 +233,14 @@ func getSqlForCheckPitrDup(createAccount string, createAccountId uint64, stmt *t
 		return getSqlForCheckDupPitrFormat(createAccountId, math.MaxUint64)
 	case tree.PITRLEVELACCOUNT:
 		if len(stmt.AccountName) > 0 {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", stmt.AccountName)
+			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", sqlquote.EscapeString(string(stmt.AccountName)))
 		} else {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", createAccount)
+			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", sqlquote.EscapeString(createAccount))
 		}
 	case tree.PITRLEVELDATABASE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1;", stmt.DatabaseName)
+		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1;", sqlquote.EscapeString(string(stmt.DatabaseName)))
 	case tree.PITRLEVELTABLE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1;", stmt.DatabaseName, stmt.TableName)
+		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1;", sqlquote.EscapeString(string(stmt.DatabaseName)), sqlquote.EscapeString(string(stmt.TableName)))
 	}
 	return sql
 }
@@ -2132,9 +2133,9 @@ func getFkDepsInPitrRestore(
 		sql += fmt.Sprintf(" {MO_TS = %d}", ts)
 	}
 	if len(dbName) > 0 {
-		sql += fmt.Sprintf(" where db_name = '%s'", dbName)
+		sql += fmt.Sprintf(" where db_name = '%s'", sqlquote.EscapeString(dbName))
 		if len(tblName) > 0 {
-			sql += fmt.Sprintf(" and table_name = '%s'", tblName)
+			sql += fmt.Sprintf(" and table_name = '%s'", sqlquote.EscapeString(tblName))
 		}
 	}
 

--- a/pkg/frontend/remap_db.go
+++ b/pkg/frontend/remap_db.go
@@ -18,12 +18,13 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
 
-// applyRemapDb substitutes the database of qualified table references in the
-// parsed statements (db.table -> remap[db].table). It runs after parsing and
-// before privilege checks / planning, which otherwise resolve the original
-// database and would reject a remapped-away database before the planner sees it.
-// It covers SELECT and INSERT/UPDATE/DELETE (including their target tables,
-// read sources, INSERT ... SELECT bodies and CTE bodies).
+// applyRemapDb substitutes the database of qualified table and column
+// references in parsed statements (db.table -> remap[db].table and
+// db.table.column -> remap[db].table.column). It runs after parsing and before
+// privilege checks / planning, which otherwise resolve the original database
+// and would reject a remapped-away database before the planner sees it. It
+// covers SELECT and INSERT/UPDATE/DELETE (including their target tables, read
+// sources, expression containers, INSERT ... SELECT bodies and CTE bodies).
 //
 // Only QUALIFIED references are rewritten. An unqualified name may be a CTE or
 // derived-table alias rather than a base table, so attaching a database to it
@@ -53,23 +54,30 @@ func remapDbInStmt(stmt tree.Statement, remap map[string]string) {
 		if s.Rows != nil {
 			remapDbInSelect(s.Rows, remap)
 		}
+		remapDbInUpdateExprs(s.OnDuplicateUpdate, remap)
 	case *tree.Update:
 		remapDbInWith(s.With, remap)
 		remapDbInTableExprs(s.Tables, remap)
 		if s.From != nil {
 			remapDbInTableExprs(s.From.Tables, remap)
 		}
-		for _, ue := range s.Exprs {
-			if ue != nil {
-				remapDbInExpr(ue.Expr, remap)
-			}
-		}
+		remapDbInUpdateExprs(s.Exprs, remap)
 		remapDbInWhere(s.Where, remap)
+		remapDbInOrderBy(s.OrderBy, remap)
+		remapDbInLimit(s.Limit, remap)
 	case *tree.Delete:
 		remapDbInWith(s.With, remap)
 		remapDbInTableExprs(s.Tables, remap)
 		remapDbInTableExprs(s.TableRefs, remap)
 		remapDbInWhere(s.Where, remap)
+		remapDbInOrderBy(s.OrderBy, remap)
+		remapDbInLimit(s.Limit, remap)
+	case *tree.ValuesStatement:
+		for _, row := range s.Rows {
+			remapDbInExprs(row, remap)
+		}
+		remapDbInOrderBy(s.OrderBy, remap)
+		remapDbInLimit(s.Limit, remap)
 
 	// Table-level DDL: the target table/view/index is a table-level object, so a
 	// qualified <src>.t is remapped. CREATE/ALTER ... AS SELECT bodies are walked
@@ -142,6 +150,9 @@ func remapDbInSelect(sel *tree.Select, remap map[string]string) {
 	}
 	remapDbInWith(sel.With, remap)
 	remapDbInSelectStatement(sel.Select, remap)
+	remapDbInTimeWindow(sel.TimeWindow, remap)
+	remapDbInOrderBy(sel.OrderBy, remap)
+	remapDbInLimit(sel.Limit, remap)
 }
 
 func remapDbInSelectStatement(s tree.SelectStatement, remap map[string]string) {
@@ -168,6 +179,10 @@ func remapDbInSelectStatement(s tree.SelectStatement, remap map[string]string) {
 		remapDbInSelect(c.Select, remap)
 	case *tree.Select:
 		remapDbInSelect(c, remap)
+	case *tree.ValuesClause:
+		for _, row := range c.Rows {
+			remapDbInExprs(row, remap)
+		}
 	}
 }
 
@@ -219,15 +234,59 @@ func remapDbInExprs(exprs tree.Exprs, remap map[string]string) {
 	}
 }
 
-// remapDbInExpr walks an expression looking for nested sub-selects (a
-// *tree.Subquery, e.g. WHERE id IN (SELECT ... FROM dbx.t) or EXISTS (...)) and
-// remaps the qualified table references inside them. It recurses through the
-// expression containers that can wrap another expression. Keep this aligned
-// with pkg/sql/parsers/tree/expr.go when adding new expression wrappers.
+func remapDbInOrderBy(orderBy tree.OrderBy, remap map[string]string) {
+	for _, order := range orderBy {
+		if order != nil {
+			remapDbInExpr(order.Expr, remap)
+		}
+	}
+}
+
+func remapDbInLimit(limit *tree.Limit, remap map[string]string) {
+	if limit == nil {
+		return
+	}
+	remapDbInExpr(limit.Offset, remap)
+	remapDbInExpr(limit.Count, remap)
+}
+
+func remapDbInTimeWindow(timeWindow *tree.TimeWindow, remap map[string]string) {
+	if timeWindow == nil {
+		return
+	}
+	if timeWindow.Interval != nil {
+		remapColumnName(timeWindow.Interval.Col, remap)
+		remapDbInExpr(timeWindow.Interval.Val, remap)
+	}
+	if timeWindow.Sliding != nil {
+		remapDbInExpr(timeWindow.Sliding.Val, remap)
+	}
+	if timeWindow.Fill != nil {
+		remapDbInExpr(timeWindow.Fill.Val, remap)
+	}
+}
+
+func remapDbInUpdateExprs(updateExprs tree.UpdateExprs, remap map[string]string) {
+	for _, updateExpr := range updateExprs {
+		if updateExpr == nil {
+			continue
+		}
+		for _, name := range updateExpr.Names {
+			remapColumnName(name, remap)
+		}
+		remapDbInExpr(updateExpr.Expr, remap)
+	}
+}
+
+// remapDbInExpr walks expressions and their nested sub-selects (for example,
+// WHERE id IN (SELECT ... FROM dbx.t)). Keep this aligned with
+// pkg/sql/parsers/tree/expr.go when adding an expression wrapper with children.
 func remapDbInExpr(expr tree.Expr, remap map[string]string) {
 	switch e := expr.(type) {
 	case nil:
 		return
+	case *tree.UnresolvedName:
+		remapColumnName(e, remap)
 	case *tree.Subquery:
 		remapDbInSelectStatement(e.Select, remap)
 	case *tree.ExprList:
@@ -289,6 +348,8 @@ func remapDbInExpr(expr tree.Expr, remap map[string]string) {
 		remapDbInExpr(e.Expr, remap)
 	case *tree.FuncExpr:
 		remapDbInExprs(e.Exprs, remap)
+		remapDbInOrderBy(e.OrderBy, remap)
+		remapDbInWindowSpec(e.WindowSpec, remap)
 	case *tree.Tuple:
 		remapDbInExprs(e.Exprs, remap)
 	case *tree.CaseExpr:
@@ -301,17 +362,71 @@ func remapDbInExpr(expr tree.Expr, remap map[string]string) {
 			remapDbInExpr(when.Val, remap)
 		}
 		remapDbInExpr(e.Else, remap)
+	case tree.SampleExpr:
+		columns, _ := e.GetColumns()
+		remapDbInExprs(columns, remap)
+	case *tree.SampleExpr:
+		columns, _ := e.GetColumns()
+		remapDbInExprs(columns, remap)
+	case *tree.FullTextMatchExpr:
+		for _, keyPart := range e.KeyParts {
+			if keyPart == nil {
+				continue
+			}
+			remapColumnName(keyPart.ColName, remap)
+			remapDbInExpr(keyPart.Expr, remap)
+		}
+	}
+}
+
+func remapDbInWindowSpec(windowSpec *tree.WindowSpec, remap map[string]string) {
+	if windowSpec == nil {
+		return
+	}
+	remapDbInExprs(windowSpec.PartitionBy, remap)
+	remapDbInOrderBy(windowSpec.OrderBy, remap)
+	remapDbInFrameClause(windowSpec.Frame, remap)
+}
+
+func remapDbInFrameClause(frame *tree.FrameClause, remap map[string]string) {
+	if frame == nil {
+		return
+	}
+	remapDbInFrameBound(frame.Start, remap)
+	remapDbInFrameBound(frame.End, remap)
+}
+
+func remapDbInFrameBound(bound *tree.FrameBound, remap map[string]string) {
+	if bound != nil {
+		remapDbInExpr(bound.Expr, remap)
 	}
 }
 
 // remapTableName substitutes the database of a qualified table reference. An
 // unqualified reference (no explicit schema) is left untouched.
 func remapTableName(tn *tree.TableName, remap map[string]string) {
-	if tn == nil || !tn.ExplicitSchema {
+	if tn == nil {
 		return
 	}
-	if target, ok := remap[string(tn.SchemaName)]; ok {
-		tn.SchemaName = tree.Identifier(target)
+	if tn.ExplicitSchema {
+		if target, ok := remap[string(tn.SchemaName)]; ok {
+			tn.SchemaName = tree.Identifier(target)
+		}
+	}
+	if tn.AtTsExpr != nil {
+		remapDbInExpr(tn.AtTsExpr.Expr, remap)
+	}
+}
+
+// remapColumnName substitutes only the database component of a fully-qualified
+// column name. Two-part names are table/alias.column and must remain unchanged:
+// the first part can be a derived-table or CTE alias rather than a database.
+func remapColumnName(name *tree.UnresolvedName, remap map[string]string) {
+	if name == nil || name.NumParts < 3 {
+		return
+	}
+	if target, ok := remap[name.DbName()]; ok {
+		name.CStrParts[2] = tree.NewCStr(target, 1)
 	}
 }
 

--- a/pkg/frontend/remap_db.go
+++ b/pkg/frontend/remap_db.go
@@ -1,0 +1,328 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+)
+
+// applyRemapDb substitutes the database of qualified table references in the
+// parsed statements (db.table -> remap[db].table). It runs after parsing and
+// before privilege checks / planning, which otherwise resolve the original
+// database and would reject a remapped-away database before the planner sees it.
+// It covers SELECT and INSERT/UPDATE/DELETE (including their target tables,
+// read sources, INSERT ... SELECT bodies and CTE bodies).
+//
+// Only QUALIFIED references are rewritten. An unqualified name may be a CTE or
+// derived-table alias rather than a base table, so attaching a database to it
+// could change its meaning; the current-database case is instead handled by
+// remapping USE (the session lands on the target database and unqualified names
+// resolve there naturally). Sub-selects nested in expressions (e.g. WHERE id IN
+// (SELECT ... FROM dbx.t), EXISTS (...), join ON, projections, GROUP/HAVING) are
+// also walked so their qualified references are remapped.
+func applyRemapDb(stmts []tree.Statement, remap map[string]string) {
+	if len(remap) == 0 {
+		return
+	}
+	for _, stmt := range stmts {
+		remapDbInStmt(stmt, remap)
+	}
+}
+
+func remapDbInStmt(stmt tree.Statement, remap map[string]string) {
+	switch s := stmt.(type) {
+	case *tree.Select:
+		remapDbInSelect(s, remap)
+	case *tree.ParenSelect:
+		remapDbInSelect(s.Select, remap)
+	case *tree.Insert:
+		remapDbInWith(s.With, remap)
+		remapDbInTableExpr(s.Table, remap)
+		if s.Rows != nil {
+			remapDbInSelect(s.Rows, remap)
+		}
+	case *tree.Update:
+		remapDbInWith(s.With, remap)
+		remapDbInTableExprs(s.Tables, remap)
+		if s.From != nil {
+			remapDbInTableExprs(s.From.Tables, remap)
+		}
+		for _, ue := range s.Exprs {
+			if ue != nil {
+				remapDbInExpr(ue.Expr, remap)
+			}
+		}
+		remapDbInWhere(s.Where, remap)
+	case *tree.Delete:
+		remapDbInWith(s.With, remap)
+		remapDbInTableExprs(s.Tables, remap)
+		remapDbInTableExprs(s.TableRefs, remap)
+		remapDbInWhere(s.Where, remap)
+
+	// Table-level DDL: the target table/view/index is a table-level object, so a
+	// qualified <src>.t is remapped. CREATE/ALTER ... AS SELECT bodies are walked
+	// too, as are TRUNCATE TABLE and RENAME TABLE. Database-level DDL
+	// (CREATE/DROP/ALTER DATABASE, USE) is intentionally absent here and never
+	// remapped.
+	case *tree.CreateTable:
+		remapTableName(&s.Table, remap)
+		remapTableName(&s.LikeTableName, remap)
+		if s.AsSource != nil {
+			remapDbInSelect(s.AsSource, remap)
+		}
+	case *tree.CreateView:
+		remapTableName(s.Name, remap)
+		if s.AsSource != nil {
+			remapDbInSelect(s.AsSource, remap)
+		}
+	case *tree.CreateIndex:
+		remapTableName(s.Table, remap)
+	case *tree.AlterTable:
+		remapTableName(s.Table, remap)
+	case *tree.AlterView:
+		remapTableName(s.Name, remap)
+		if s.AsSource != nil {
+			remapDbInSelect(s.AsSource, remap)
+		}
+	case *tree.DropTable:
+		for _, n := range s.Names {
+			remapTableName(n, remap)
+		}
+	case *tree.DropView:
+		for _, n := range s.Names {
+			remapTableName(n, remap)
+		}
+	case *tree.DropIndex:
+		remapTableName(s.TableName, remap)
+	case *tree.TruncateTable:
+		remapTableName(s.Name, remap)
+	case *tree.RenameTable:
+		// rename src.a to src.b, ... : both the source table and the rename
+		// destination are qualified table-level references, so remap each.
+		for _, at := range s.AlterTables {
+			if at == nil {
+				continue
+			}
+			remapTableName(at.Table, remap)
+			for _, opt := range at.Options {
+				if rn, ok := opt.(*tree.AlterOptionTableName); ok {
+					remapObjectName(rn.Name, remap)
+				}
+			}
+		}
+	}
+}
+
+func remapDbInWith(w *tree.With, remap map[string]string) {
+	if w == nil {
+		return
+	}
+	for _, cte := range w.CTEs {
+		if cte != nil {
+			remapDbInStmt(cte.Stmt, remap)
+		}
+	}
+}
+
+func remapDbInSelect(sel *tree.Select, remap map[string]string) {
+	if sel == nil {
+		return
+	}
+	remapDbInWith(sel.With, remap)
+	remapDbInSelectStatement(sel.Select, remap)
+}
+
+func remapDbInSelectStatement(s tree.SelectStatement, remap map[string]string) {
+	switch c := s.(type) {
+	case *tree.SelectClause:
+		if c.From != nil {
+			remapDbInTableExprs(c.From.Tables, remap)
+		}
+		for _, se := range c.Exprs {
+			remapDbInExpr(se.Expr, remap)
+		}
+		remapDbInWhere(c.Where, remap)
+		remapDbInWhere(c.Having, remap)
+		if c.GroupBy != nil {
+			for _, exprs := range c.GroupBy.GroupByExprsList {
+				remapDbInExprs(exprs, remap)
+			}
+			remapDbInExprs(c.GroupBy.GroupingSet, remap)
+		}
+	case *tree.UnionClause:
+		remapDbInSelectStatement(c.Left, remap)
+		remapDbInSelectStatement(c.Right, remap)
+	case *tree.ParenSelect:
+		remapDbInSelect(c.Select, remap)
+	case *tree.Select:
+		remapDbInSelect(c, remap)
+	}
+}
+
+func remapDbInWhere(w *tree.Where, remap map[string]string) {
+	if w != nil {
+		remapDbInExpr(w.Expr, remap)
+	}
+}
+
+func remapDbInTableExprs(tes tree.TableExprs, remap map[string]string) {
+	for _, te := range tes {
+		remapDbInTableExpr(te, remap)
+	}
+}
+
+func remapDbInTableExpr(te tree.TableExpr, remap map[string]string) {
+	switch t := te.(type) {
+	case *tree.TableName:
+		remapTableName(t, remap)
+	case *tree.AliasedTableExpr:
+		remapDbInTableExpr(t.Expr, remap)
+	case *tree.JoinTableExpr:
+		remapDbInTableExpr(t.Left, remap)
+		remapDbInTableExpr(t.Right, remap)
+		if on, ok := t.Cond.(*tree.OnJoinCond); ok {
+			remapDbInExpr(on.Expr, remap)
+		}
+	case *tree.ApplyTableExpr:
+		remapDbInTableExpr(t.Left, remap)
+		remapDbInTableExpr(t.Right, remap)
+	case *tree.ParenTableExpr:
+		remapDbInTableExpr(t.Expr, remap)
+	case *tree.Select:
+		remapDbInSelect(t, remap)
+	case *tree.ParenSelect:
+		remapDbInSelect(t.Select, remap)
+	case *tree.Subquery:
+		remapDbInSelectStatement(t.Select, remap)
+	case *tree.StatementSource:
+		if t.Statement != nil {
+			remapDbInStmt(t.Statement, remap)
+		}
+	}
+}
+
+func remapDbInExprs(exprs tree.Exprs, remap map[string]string) {
+	for _, e := range exprs {
+		remapDbInExpr(e, remap)
+	}
+}
+
+// remapDbInExpr walks an expression looking for nested sub-selects (a
+// *tree.Subquery, e.g. WHERE id IN (SELECT ... FROM dbx.t) or EXISTS (...)) and
+// remaps the qualified table references inside them. It recurses through the
+// expression containers that can wrap another expression. Keep this aligned
+// with pkg/sql/parsers/tree/expr.go when adding new expression wrappers.
+func remapDbInExpr(expr tree.Expr, remap map[string]string) {
+	switch e := expr.(type) {
+	case nil:
+		return
+	case *tree.Subquery:
+		remapDbInSelectStatement(e.Select, remap)
+	case *tree.ExprList:
+		remapDbInExprs(e.Exprs, remap)
+	case *tree.ParenExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.NotExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsNullExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsNotNullExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsUnknownExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsNotUnknownExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsTrueExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsNotTrueExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsFalseExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.IsNotFalseExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.AndExpr:
+		remapDbInExpr(e.Left, remap)
+		remapDbInExpr(e.Right, remap)
+	case *tree.OrExpr:
+		remapDbInExpr(e.Left, remap)
+		remapDbInExpr(e.Right, remap)
+	case *tree.XorExpr:
+		remapDbInExpr(e.Left, remap)
+		remapDbInExpr(e.Right, remap)
+	case *tree.ComparisonExpr:
+		remapDbInExpr(e.Left, remap)
+		remapDbInExpr(e.Right, remap)
+		remapDbInExpr(e.Escape, remap)
+	case *tree.RangeCond:
+		remapDbInExpr(e.Left, remap)
+		remapDbInExpr(e.From, remap)
+		remapDbInExpr(e.To, remap)
+	case *tree.UnaryExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.BinaryExpr:
+		remapDbInExpr(e.Left, remap)
+		remapDbInExpr(e.Right, remap)
+	case *tree.CastExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.BitCastExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.SerialExtractExpr:
+		remapDbInExpr(e.SerialExpr, remap)
+		remapDbInExpr(e.IndexExpr, remap)
+	case *tree.IntervalExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.DefaultVal:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.VarExpr:
+		remapDbInExpr(e.Expr, remap)
+	case *tree.FuncExpr:
+		remapDbInExprs(e.Exprs, remap)
+	case *tree.Tuple:
+		remapDbInExprs(e.Exprs, remap)
+	case *tree.CaseExpr:
+		remapDbInExpr(e.Expr, remap)
+		for _, when := range e.Whens {
+			if when == nil {
+				continue
+			}
+			remapDbInExpr(when.Cond, remap)
+			remapDbInExpr(when.Val, remap)
+		}
+		remapDbInExpr(e.Else, remap)
+	}
+}
+
+// remapTableName substitutes the database of a qualified table reference. An
+// unqualified reference (no explicit schema) is left untouched.
+func remapTableName(tn *tree.TableName, remap map[string]string) {
+	if tn == nil || !tn.ExplicitSchema {
+		return
+	}
+	if target, ok := remap[string(tn.SchemaName)]; ok {
+		tn.SchemaName = tree.Identifier(target)
+	}
+}
+
+// remapObjectName substitutes the database of a qualified object name (used for
+// the destination of RENAME TABLE, carried as an UnresolvedObjectName). Parts[1]
+// holds the schema and is only present when NumParts >= 2 (i.e. it is qualified).
+func remapObjectName(on *tree.UnresolvedObjectName, remap map[string]string) {
+	if on == nil || on.NumParts < 2 {
+		return
+	}
+	if target, ok := remap[on.Parts[1]]; ok {
+		on.Parts[1] = target
+	}
+}

--- a/pkg/frontend/remap_db_test.go
+++ b/pkg/frontend/remap_db_test.go
@@ -1,0 +1,227 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// applyRemapDbToSQL parses sql, runs applyRemapDb with the given remap, and
+// returns the re-stringified statement.
+func applyRemapDbToSQL(t *testing.T, sql string, remap map[string]string) string {
+	ctx := context.Background()
+	stmts, err := parsers.Parse(ctx, dialect.MYSQL, sql, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	applyRemapDb(stmts, remap)
+	return tree.String(stmts[0], dialect.MYSQL)
+}
+
+func TestApplyRemapDb(t *testing.T) {
+	remap := map[string]string{"dbxxx": "dbyyy"}
+
+	t.Run("qualified ref", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from dbxxx.t", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("join both sides", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from dbxxx.a join dbxxx.b on a.id = b.id", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("from subquery", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from (select * from dbxxx.t) x", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("union", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select id from dbxxx.a union select id from dbxxx.b", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("cte name is not remapped, body is", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "with c as (select * from dbxxx.t) select * from c", remap)
+		require.Contains(t, out, "dbyyy.t") // body remapped
+		require.Contains(t, out, "from c")  // CTE reference untouched
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("unqualified ref untouched", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from t", remap)
+		require.Contains(t, out, "from t")
+		require.NotContains(t, out, "dbyyy")
+	})
+
+	t.Run("non-mapped db untouched", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from other.t", remap)
+		require.Contains(t, out, "other.t")
+	})
+
+	t.Run("insert target and select source", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "insert into dbxxx.t select * from dbxxx.u", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.Contains(t, out, "dbyyy.u")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("insert values", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "insert into dbxxx.t values (1)", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("update", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "update dbxxx.t set v = 1 where id = 2", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "delete from dbxxx.t where id = 2", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("where IN subquery", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from dbxxx.a where id in (select id from dbxxx.b)", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("where EXISTS subquery", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from dbxxx.a where exists (select 1 from dbxxx.b where b.id = a.id)", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("having subquery", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select id from dbxxx.a group by id having count(*) > (select count(*) from dbxxx.b)", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("projection scalar subquery", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select (select max(id) from dbxxx.b) from dbxxx.a", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("join ON subquery", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "select * from dbxxx.a join dbxxx.c on a.id in (select id from dbxxx.b)", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.Contains(t, out, "dbyyy.c")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("delete with IN subquery source", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "delete from dbxxx.t where id in (select id from dbxxx.s)", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.Contains(t, out, "dbyyy.s")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	// table-level DDL: the qualified target is remapped
+	t.Run("create table", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "create table dbxxx.t(id int)", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+	t.Run("create table as select", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "create table dbxxx.t as select * from dbxxx.s", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.Contains(t, out, "dbyyy.s")
+		require.NotContains(t, out, "dbxxx")
+	})
+	t.Run("create view", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "create view dbxxx.v as select * from dbxxx.t", remap)
+		require.Contains(t, out, "dbyyy.v")
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+	t.Run("create index", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "create index ix on dbxxx.t(id)", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+	t.Run("alter table", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "alter table dbxxx.t add column c int", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+	t.Run("drop table multi", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "drop table dbxxx.t, dbxxx.s", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.Contains(t, out, "dbyyy.s")
+		require.NotContains(t, out, "dbxxx")
+	})
+	t.Run("drop view", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "drop view dbxxx.v", remap)
+		require.Contains(t, out, "dbyyy.v")
+		require.NotContains(t, out, "dbxxx")
+	})
+	t.Run("drop index", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "drop index ix on dbxxx.t", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("truncate table", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "truncate table dbxxx.t", remap)
+		require.Contains(t, out, "dbyyy.t")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("rename table remaps source and destination", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "rename table dbxxx.a to dbxxx.b", remap)
+		require.Contains(t, out, "dbyyy.a")
+		require.Contains(t, out, "dbyyy.b")
+		require.NotContains(t, out, "dbxxx")
+	})
+
+	t.Run("rename table unqualified untouched", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "rename table a to b", remap)
+		require.NotContains(t, out, "dbyyy")
+	})
+
+	// database-level DDL is NOT remapped
+	t.Run("create database is not remapped", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "create database dbxxx", map[string]string{"dbxxx": "dbyyy"})
+		require.Contains(t, out, "dbxxx")
+		require.NotContains(t, out, "dbyyy")
+	})
+	t.Run("drop database is not remapped", func(t *testing.T) {
+		out := applyRemapDbToSQL(t, "drop database dbxxx", map[string]string{"dbxxx": "dbyyy"})
+		require.Contains(t, out, "dbxxx")
+		require.NotContains(t, out, "dbyyy")
+	})
+}

--- a/pkg/frontend/remap_db_test.go
+++ b/pkg/frontend/remap_db_test.go
@@ -32,7 +32,7 @@ func applyRemapDbToSQL(t *testing.T, sql string, remap map[string]string) string
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
 	applyRemapDb(stmts, remap)
-	return tree.String(stmts[0], dialect.MYSQL)
+	return tree.StringWithOpts(stmts[0], dialect.MYSQL, tree.WithSingleQuoteString())
 }
 
 func TestApplyRemapDb(t *testing.T) {
@@ -224,4 +224,98 @@ func TestApplyRemapDb(t *testing.T) {
 		require.Contains(t, out, "dbxxx")
 		require.NotContains(t, out, "dbyyy")
 	})
+}
+
+func TestApplyRemapDbExpressionContainers(t *testing.T) {
+	remap := map[string]string{"src": "dst"}
+	tests := []struct {
+		name     string
+		sql      string
+		contains []string
+		absent   []string
+	}{
+		{
+			name:     "qualified column in view body",
+			sql:      "create view src.v as select src.t.a from src.t",
+			contains: []string{"create view dst.v", "dst.t.a", "from dst.t"},
+			absent:   []string{"src.t.a", "from src.t"},
+		},
+		{
+			name:     "top level order by subquery",
+			sql:      "create view src.v as select a from src.t order by (select max(b) from src.u)",
+			contains: []string{"from dst.t", "from dst.u"},
+			absent:   []string{"from src.t", "from src.u"},
+		},
+		{
+			name:     "aggregate order by subquery",
+			sql:      "create view src.v as select group_concat(a order by (select max(b) from src.u)) from src.t",
+			contains: []string{"from dst.t", "from dst.u"},
+			absent:   []string{"from src.t", "from src.u"},
+		},
+		{
+			name:     "window order by subquery",
+			sql:      "create view src.v as select row_number() over (order by (select max(b) from src.u)) from src.t",
+			contains: []string{"from dst.t", "from dst.u"},
+			absent:   []string{"from src.t", "from src.u"},
+		},
+		{
+			name:     "cte union nested select and join",
+			sql:      "create view src.v as with c as (select src.cte_t.a from src.cte_t) select a from c union select x.a from (select src.nested_t.a from src.nested_t) x join src.join_t j on x.a = j.a",
+			contains: []string{"dst.cte_t.a", "from dst.cte_t", "dst.nested_t.a", "from dst.nested_t", "join dst.join_t"},
+			absent:   []string{"src.cte_t.a", "from src.cte_t", "src.nested_t.a", "from src.nested_t", "join src.join_t"},
+		},
+		{
+			name:     "aliases and string literals are unchanged",
+			sql:      "create view src.v as select src.a, 'src.t.a' as literal from src.t as src",
+			contains: []string{"src.a", "'src.t.a'", "from dst.t as src"},
+			absent:   []string{"from src.t"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := applyRemapDbToSQL(t, tt.sql, remap)
+			for _, expected := range tt.contains {
+				require.Contains(t, out, expected)
+			}
+			for _, unexpected := range tt.absent {
+				require.NotContains(t, out, unexpected)
+			}
+		})
+	}
+}
+
+func TestApplyRemapDbDMLExpressionContainers(t *testing.T) {
+	remap := map[string]string{"src": "dst"}
+	tests := []struct {
+		name     string
+		sql      string
+		contains []string
+		absent   []string
+	}{
+		{
+			name:     "update order by subquery",
+			sql:      "update src.t set a = (select max(b) from src.u) order by (select max(c) from src.o) limit 1",
+			contains: []string{"update dst.t", "from dst.u", "from dst.o"},
+			absent:   []string{"update src.t", "from src.u", "from src.o"},
+		},
+		{
+			name:     "delete order by subquery",
+			sql:      "delete from src.t order by (select max(b) from src.u) limit 1",
+			contains: []string{"delete from dst.t", "from dst.u"},
+			absent:   []string{"delete from src.t", "from src.u"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := applyRemapDbToSQL(t, tt.sql, remap)
+			for _, expected := range tt.contains {
+				require.Contains(t, out, expected)
+			}
+			for _, unexpected := range tt.absent {
+				require.NotContains(t, out, unexpected)
+			}
+		})
+	}
 }

--- a/pkg/frontend/show_recovery_window.go
+++ b/pkg/frontend/show_recovery_window.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/frontend/databranchutils"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -161,7 +162,7 @@ func constructRecoveryWindow(
 
 		snapPitrSearchCond = fmt.Sprintf(
 			"account_name = '%s'",
-			accountName,
+			sqlquote.EscapeString(accountName),
 		)
 	case tree.RECOVERYWINDOWLEVELDATABASE:
 		levelStr = "database"
@@ -169,8 +170,8 @@ func constructRecoveryWindow(
 		snapPitrSearchCond = fmt.Sprintf(
 			"(account_name = '%s' AND database_name = '') OR "+
 				"(account_name = '%s' AND database_name = '%s')",
-			accountName,
-			accountName, databaseName,
+			sqlquote.EscapeString(accountName),
+			sqlquote.EscapeString(accountName), sqlquote.EscapeString(databaseName),
 		)
 	case tree.RECOVERYWINDOWLEVELTABLE:
 		levelStr = "table"
@@ -179,9 +180,9 @@ func constructRecoveryWindow(
 			"(account_name = '%s' AND database_name = '') OR "+
 				"(account_name = '%s' AND database_name = '%s' AND table_name = '') OR "+
 				"(account_name = '%s' AND database_name = '%s' AND table_name = '%s')",
-			accountName,
-			accountName, databaseName,
-			accountName, databaseName, tableName,
+			sqlquote.EscapeString(accountName),
+			sqlquote.EscapeString(accountName), sqlquote.EscapeString(databaseName),
+			sqlquote.EscapeString(accountName), sqlquote.EscapeString(databaseName), sqlquote.EscapeString(tableName),
 		)
 
 	default:

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/pubsub"
+	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -2208,9 +2209,9 @@ func getFkDeps(
 	}
 
 	if len(dbName) > 0 {
-		sql += fmt.Sprintf(" where db_name = '%s'", dbName)
+		sql += fmt.Sprintf(" where db_name = '%s'", sqlquote.EscapeString(dbName))
 		if len(tblName) > 0 {
-			sql += fmt.Sprintf(" and table_name = '%s'", tblName)
+			sql += fmt.Sprintf(" and table_name = '%s'", sqlquote.EscapeString(tblName))
 		}
 	}
 

--- a/pkg/frontend/stmt_kind.go
+++ b/pkg/frontend/stmt_kind.go
@@ -248,7 +248,9 @@ func statementCanBeExecutedInUncommittedTransaction(
 		*tree.DataBranchCreateTable,
 		*tree.DataBranchCreateDatabase,
 		*tree.DataBranchDeleteTable,
-		*tree.DataBranchDeleteDatabase:
+		*tree.DataBranchDeleteDatabase,
+		*tree.DataBranchDiff,
+		*tree.DataBranchMerge:
 		return true, nil
 	case *tree.DataBranchPick:
 		return false, nil

--- a/pkg/objectio/mergeutil/types.go
+++ b/pkg/objectio/mergeutil/types.go
@@ -83,6 +83,9 @@ func MergeSortBatches(
 	case types.T_date:
 		ds := &fixedDataSlice[types.Date]{getFixedCols[types.Date](batches, sortKeyIdx)}
 		merge = newMerge(sort.GenericLess[types.Date], ds, nulls)
+	case types.T_year:
+		ds := &fixedDataSlice[types.MoYear]{getFixedCols[types.MoYear](batches, sortKeyIdx)}
+		merge = newMerge(sort.GenericLess[types.MoYear], ds, nulls)
 	case types.T_datetime:
 		ds := &fixedDataSlice[types.Datetime]{getFixedCols[types.Datetime](batches, sortKeyIdx)}
 		merge = newMerge(sort.GenericLess[types.Datetime], ds, nulls)

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -5580,15 +5580,13 @@ func (c *Compile) checkPitrGranularity(
 		}
 
 		checkDBByName := func(nameLower string) (bool, error) {
-			qDB := fmt.Sprintf(`select pitr_length,pitr_unit from %s.%s where level='database' and lower(database_name) = '%s' and account_id = %d`,
-				catalog.MO_CATALOG, catalog.MO_PITR, nameLower, accountId)
+			qDB := getPitrDatabaseGranularitySql(nameLower, accountId, true)
 			if ok, err := checkQuery(qDB); err != nil {
 				return false, err
 			} else if ok {
 				return true, nil
 			}
-			qDB2 := fmt.Sprintf(`select pitr_length,pitr_unit from %s.%s where level='database' and lower(database_name) = '%s'`,
-				catalog.MO_CATALOG, catalog.MO_PITR, nameLower)
+			qDB2 := getPitrDatabaseGranularitySql(nameLower, accountId, false)
 			return checkQuery(qDB2)
 		}
 
@@ -5625,8 +5623,7 @@ func (c *Compile) checkPitrGranularity(
 
 		// 3) table level only for table pattern
 		if !isDB {
-			qTbl := fmt.Sprintf(`select pitr_length,pitr_unit from %s.%s where level='table' and lower(database_name)='%s' and lower(table_name)='%s' and account_id = %d`,
-				catalog.MO_CATALOG, catalog.MO_PITR, dbNameLower, tblNameLower, accountId)
+			qTbl := getPitrTableGranularitySql(dbNameLower, tblNameLower, accountId)
 			if ok, err := checkQuery(qTbl); err != nil {
 				return err
 			} else if ok {
@@ -5638,6 +5635,22 @@ func (c *Compile) checkPitrGranularity(
 			"PITR config of %s.%s insufficient (<%dh)", pt.Source.Database, pt.Source.Table, minPitrLen)
 	}
 	return nil
+}
+
+func getPitrDatabaseGranularitySql(nameLower string, accountId uint32, withAccount bool) string {
+	nameLit := sqlquote.EscapeString(nameLower)
+	if withAccount {
+		return fmt.Sprintf(`select pitr_length,pitr_unit from %s.%s where level='database' and lower(database_name) = '%s' and account_id = %d`,
+			catalog.MO_CATALOG, catalog.MO_PITR, nameLit, accountId)
+	}
+	return fmt.Sprintf(`select pitr_length,pitr_unit from %s.%s where level='database' and lower(database_name) = '%s'`,
+		catalog.MO_CATALOG, catalog.MO_PITR, nameLit)
+}
+
+func getPitrTableGranularitySql(dbNameLower, tblNameLower string, accountId uint32) string {
+	return fmt.Sprintf(`select pitr_length,pitr_unit from %s.%s where level='table' and lower(database_name)='%s' and lower(table_name)='%s' and account_id = %d`,
+		catalog.MO_CATALOG, catalog.MO_PITR,
+		sqlquote.EscapeString(dbNameLower), sqlquote.EscapeString(tblNameLower), accountId)
 }
 
 func toHours(val int64, unit string) int64 {

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -285,7 +285,7 @@ func (s *Scope) DropDatabase(c *Compile) error {
 			catalog.MO_PITR_CHANGED_TIME, now,
 
 			catalog.MO_PITR_ACCOUNT_ID, accountId,
-			catalog.MO_PITR_DB_NAME, dbName,
+			catalog.MO_PITR_DB_NAME, sqlquote.EscapeString(dbName),
 			catalog.MO_PITR_STATUS, 1,
 			catalog.MO_PITR_OBJECT_ID, database.GetDatabaseId(c.proc.Ctx),
 		)
@@ -3263,8 +3263,8 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 			catalog.MO_PITR_CHANGED_TIME, now,
 
 			catalog.MO_PITR_ACCOUNT_ID, accountID,
-			catalog.MO_PITR_DB_NAME, dbName,
-			catalog.MO_PITR_TABLE_NAME, tblName,
+			catalog.MO_PITR_DB_NAME, sqlquote.EscapeString(dbName),
+			catalog.MO_PITR_TABLE_NAME, sqlquote.EscapeString(tblName),
 			catalog.MO_PITR_STATUS, 1,
 			catalog.MO_PITR_OBJECT_ID, tblID,
 		)
@@ -4492,21 +4492,21 @@ func (s *Scope) CreatePitr(c *Compile) error {
                                table_name,
                                obj_id,
                                pitr_length,
-                               pitr_unit,
-                               pitr_status_changed_time) values ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', %d, %d, '%s', %d)`,
+	                               pitr_unit,
+	                               pitr_status_changed_time) values ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', %d, %d, '%s', %d)`,
 		newUUid,
-		pitrName,
+		sqlquote.EscapeString(pitrName),
 		createPitr.GetCurrentAccountId(),
 		now,
 		now,
-		pitrLevel.String(),
+		sqlquote.EscapeString(pitrLevel.String()),
 		createPitr.GetCurrentAccountId(),
-		createPitr.GetAccountName(),
-		createPitr.GetDatabaseName(),
-		createPitr.GetTableName(),
+		sqlquote.EscapeString(createPitr.GetAccountName()),
+		sqlquote.EscapeString(createPitr.GetDatabaseName()),
+		sqlquote.EscapeString(createPitr.GetTableName()),
 		getPitrObjectId(createPitr),
 		createPitr.GetPitrValue(),
-		createPitr.GetPitrUnit(),
+		sqlquote.EscapeString(createPitr.GetPitrUnit()),
 		now,
 	)
 
@@ -4640,7 +4640,7 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 1. Check if PITR exists
-	checkSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", pitrName, accountId)
+	checkSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", sqlquote.EscapeString(pitrName), accountId)
 	res, err := c.runSqlWithResultAndOptions(checkSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
@@ -4654,7 +4654,7 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 2. Delete PITR record
-	deleteSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", pitrName, accountId)
+	deleteSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", sqlquote.EscapeString(pitrName), accountId)
 	err = c.runSqlWithAccountIdAndOptions(deleteSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
@@ -4702,14 +4702,14 @@ func getSqlForCheckPitrDup(
 		return getSqlForCheckDupPitrFormat(createPitr.CurrentAccountId, math.MaxUint64)
 	case tree.PITRLEVELACCOUNT:
 		if createPitr.OriginAccountName {
-			return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND account_name = '%s' AND level = 'account' AND pitr_status = 1;", createPitr.AccountName)
+			return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND account_name = '%s' AND level = 'account' AND pitr_status = 1;", sqlquote.EscapeString(createPitr.AccountName))
 		} else {
-			return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND account_name = '%s' AND level = 'account' AND pitr_status = 1;", createPitr.CurrentAccount)
+			return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND account_name = '%s' AND level = 'account' AND pitr_status = 1;", sqlquote.EscapeString(createPitr.CurrentAccount))
 		}
 	case tree.PITRLEVELDATABASE:
-		return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND database_name = '%s' AND level = 'database' AND pitr_status = 1;", createPitr.DatabaseName)
+		return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND database_name = '%s' AND level = 'database' AND pitr_status = 1;", sqlquote.EscapeString(createPitr.DatabaseName))
 	case tree.PITRLEVELTABLE:
-		return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND database_name = '%s' AND table_name = '%s' AND level = 'table' AND pitr_status = 1;", createPitr.DatabaseName, createPitr.TableName)
+		return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" AND database_name = '%s' AND table_name = '%s' AND level = 'table' AND pitr_status = 1;", sqlquote.EscapeString(createPitr.DatabaseName), sqlquote.EscapeString(createPitr.TableName))
 	}
 	return sql
 }
@@ -4783,7 +4783,7 @@ func CheckSysMoCatalogPitrResult(ctx context.Context, vecs []*vector.Vector, new
 }
 
 func getSqlForCheckPitrExists(pitrName string, accountId uint32) string {
-	return fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d ORDER BY pitr_id", pitrName, accountId)
+	return fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d ORDER BY pitr_id", sqlquote.EscapeString(pitrName), accountId)
 }
 
 func (s *Scope) CreateCDC(c *Compile) error {

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -811,6 +811,24 @@ func Test_getSqlForCheckPitrDup(t *testing.T) {
 	assert.Contains(t, getSqlForCheckPitrDup(mk(int32(tree.PITRLEVELTABLE), false)), "table_name = 'tb'")
 }
 
+func TestPitrInternalSQLEscapesStringLiterals(t *testing.T) {
+	assert.Contains(
+		t,
+		getSqlForCheckPitrExists("pi'tr\\name", 7),
+		"pitr_name = 'pi''tr\\\\name'",
+	)
+
+	p := &plan2.CreatePitr{
+		Level:            int32(tree.PITRLEVELTABLE),
+		CurrentAccountId: 1,
+		DatabaseName:     "db'name",
+		TableName:        "tb\\name",
+	}
+	sql := getSqlForCheckPitrDup(p)
+	assert.Contains(t, sql, "database_name = 'db''name'")
+	assert.Contains(t, sql, "table_name = 'tb\\\\name'")
+}
+
 func TestCheckSysMoCatalogPitrResult(t *testing.T) {
 	mp := mpool.MustNewZero()
 	ctx := context.Background()

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -983,6 +983,21 @@ func Test_toHours(t *testing.T) {
 	}
 }
 
+func TestPitrGranularitySqlEscapesStringLiterals(t *testing.T) {
+	dbWithAccount := getPitrDatabaseGranularitySql("db'name", 7, true)
+	require.Contains(t, dbWithAccount, "lower(database_name) = 'db''name'")
+	require.Contains(t, dbWithAccount, "account_id = 7")
+
+	dbWithoutAccount := getPitrDatabaseGranularitySql("db\\name", 7, false)
+	require.Contains(t, dbWithoutAccount, "lower(database_name) = 'db\\\\name'")
+	require.NotContains(t, dbWithoutAccount, "account_id")
+
+	tbl := getPitrTableGranularitySql("db'name", "tbl\\name", 9)
+	require.Contains(t, tbl, "lower(database_name)='db''name'")
+	require.Contains(t, tbl, "lower(table_name)='tbl\\\\name'")
+	require.Contains(t, tbl, "account_id = 9")
+}
+
 // TestDropDatabase_SnapshotAdvanceAndRestore verifies that DropDatabase
 // unconditionally advances SnapshotTS via UpdateSnapshot(HLC Now) after
 // acquiring the exclusive lock, and restores the original SnapshotTS

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -146,6 +146,16 @@ func TestDataBranchCreateTableParsesWithLeadingComment(t *testing.T) {
 	require.Equal(t, tree.Identifier("src"), branchStmt.SrcTable.ObjectName)
 }
 
+func TestDataBranchCreateTablePreservesQuotedApostropheIdentifier(t *testing.T) {
+	stmt, err := ParseOne(context.TODO(), "data branch create table `quote'dst` from `quote'src`", 1)
+	require.NoError(t, err)
+
+	branchStmt, ok := stmt.(*tree.DataBranchCreateTable)
+	require.True(t, ok)
+	require.Equal(t, tree.Identifier("quote'dst"), branchStmt.CreateTable.Table.ObjectName)
+	require.Equal(t, tree.Identifier("quote'src"), branchStmt.SrcTable.ObjectName)
+}
+
 func TestDataBranchDiffOutputModes(t *testing.T) {
 	stmt, err := ParseOne(context.TODO(), `data branch diff t1{snapshot="sp1"} against t2{snapshot="sp2"} output summary`, 1)
 	require.NoError(t, err)

--- a/pkg/sql/parsers/tree/data_branch.go
+++ b/pkg/sql/parsers/tree/data_branch.go
@@ -154,8 +154,20 @@ func (d *DataBranchCreateTable) StmtKind() StmtKind {
 }
 
 func (d *DataBranchCreateTable) Format(ctx *FmtCtx) {
-	//TODO implement me
-	panic("implement me")
+	ctx.WriteString("data branch create table ")
+	quoteIdentifier := ctx.quoteIdentifier
+	ctx.quoteIdentifier = true
+	d.CreateTable.Table.Format(ctx)
+	ctx.quoteIdentifier = quoteIdentifier
+	ctx.WriteString(" from ")
+	quoteIdentifier = ctx.quoteIdentifier
+	ctx.quoteIdentifier = true
+	d.SrcTable.Format(ctx)
+	ctx.quoteIdentifier = quoteIdentifier
+	if d.ToAccountOpt != nil {
+		ctx.WriteByte(' ')
+		d.ToAccountOpt.Format(ctx)
+	}
 }
 
 func (d *DataBranchCreateTable) String() string {
@@ -171,8 +183,7 @@ func (d *DataBranchCreateTable) GetQueryType() string {
 }
 
 func (d *DataBranchCreateTable) TypeName() string {
-	//TODO implement me
-	panic("implement me")
+	return "data branch create table"
 }
 
 func (d *DataBranchCreateTable) Free() {

--- a/pkg/sql/parsers/tree/data_branch_test.go
+++ b/pkg/sql/parsers/tree/data_branch_test.go
@@ -37,12 +37,12 @@ func TestDataBranchCreateTableLifecycle(t *testing.T) {
 	require.Nil(t, stmt.ToAccountOpt)
 	require.False(t, stmt.CreateTable.IfNotExists)
 
-	require.Panics(t, func() {
-		stmt.Format(nil)
-	})
-	require.Panics(t, func() {
-		stmt.TypeName()
-	})
+	stmt.CreateTable.Table.ObjectName = Identifier("quote'dst")
+	stmt.SrcTable.ObjectName = Identifier("quote'src")
+	ctx := NewFmtCtx(dialect.MYSQL, WithQuoteIdentifier())
+	stmt.Format(ctx)
+	require.Equal(t, "data branch create table `quote'dst` from `quote'src`", ctx.String())
+	require.Equal(t, "data branch create table", stmt.TypeName())
 
 	stmt.Free()
 }

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -782,8 +782,8 @@ func buildCreateTable(
 		var err error
 		oldTable := stmt.LikeTableName
 		newTable := stmt.Table
-		tblName := formatStr(string(oldTable.ObjectName))
-		dbName := formatStr(string(oldTable.SchemaName))
+		tblName := string(oldTable.ObjectName)
+		dbName := string(oldTable.SchemaName)
 
 		snapshot := ctx.GetSnapshot()
 

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3521,7 +3521,7 @@ func getSqlForAddFk(db, table string, data *FkData) string {
 					sb.WriteByte(',')
 				}
 				sb.WriteByte('\'')
-				sb.WriteString(col)
+				sb.WriteString(sqlquote.EscapeString(col))
 				sb.WriteByte('\'')
 			}
 			sb.WriteByte(')')
@@ -3602,7 +3602,8 @@ func getSqlForRenameColumn(db, table, oldName, newName string) (ret []string) {
 func getSqlForCheckHasDBRefersTo(db string) string {
 	sb := strings.Builder{}
 	sb.WriteString("select count(*) > 0 from `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and db_name != '%s';", db, db))
+	dbLit := sqlquote.EscapeString(db)
+	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and db_name != '%s';", dbLit, dbLit))
 	return sb.String()
 }
 

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -3393,6 +3394,8 @@ func (fk FkReferDef) String() string {
 // GetSqlForFkReferredTo returns the query that retrieves the fk relationships
 // that refer to the table
 func GetSqlForFkReferredTo(db, table string) string {
+	dbLit := sqlquote.EscapeString(db)
+	tableLit := sqlquote.EscapeString(table)
 	return fmt.Sprintf(
 		"select "+
 			"db_name, "+
@@ -3409,7 +3412,7 @@ func GetSqlForFkReferredTo(db, table string) string {
 			" and "+
 			"(db_name != '%s' or db_name = '%s' and table_name != '%s') "+
 			"order by db_name, table_name, constraint_name;",
-		db, table, db, db, table)
+		dbLit, tableLit, dbLit, dbLit, tableLit)
 }
 
 // GetFkReferredTo returns the foreign key relationships that refer to the table
@@ -3533,7 +3536,8 @@ func getSqlForDeleteTable(db, tbl string) string {
 	sb := strings.Builder{}
 	sb.WriteString("delete from `mo_catalog`.`mo_foreign_keys` where ")
 	sb.WriteString(fmt.Sprintf(
-		"db_name = '%s' and table_name = '%s'", db, tbl))
+		"db_name = '%s' and table_name = '%s'",
+		sqlquote.EscapeString(db), sqlquote.EscapeString(tbl)))
 	return sb.String()
 }
 
@@ -3544,7 +3548,7 @@ func getSqlForDeleteConstraint(db, tbl, constraint string) string {
 	sb.WriteString("delete from `mo_catalog`.`mo_foreign_keys` where ")
 	sb.WriteString(fmt.Sprintf(
 		"constraint_name = '%s' and db_name = '%s' and table_name = '%s'",
-		constraint, db, tbl))
+		sqlquote.EscapeString(constraint), sqlquote.EscapeString(db), sqlquote.EscapeString(tbl)))
 	return sb.String()
 }
 
@@ -3553,7 +3557,7 @@ func getSqlForDeleteConstraint(db, tbl, constraint string) string {
 func getSqlForDeleteDB(db string) string {
 	sb := strings.Builder{}
 	sb.WriteString("delete from `mo_catalog`.`mo_foreign_keys` where ")
-	sb.WriteString(fmt.Sprintf("db_name = '%s'", db))
+	sb.WriteString(fmt.Sprintf("db_name = '%s'", sqlquote.EscapeString(db)))
 	return sb.String()
 }
 
@@ -3561,14 +3565,16 @@ func getSqlForDeleteDB(db string) string {
 func getSqlForRenameTable(db, oldName, newName string) (ret []string) {
 	sb := strings.Builder{}
 	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set table_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("where db_name = '%s' and table_name = '%s' ; ", db, oldName))
+	sb.WriteString(fmt.Sprintf("set table_name = '%s' ", sqlquote.EscapeString(newName)))
+	sb.WriteString(fmt.Sprintf("where db_name = '%s' and table_name = '%s' ; ",
+		sqlquote.EscapeString(db), sqlquote.EscapeString(oldName)))
 	ret = append(ret, sb.String())
 
 	sb.Reset()
 	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set refer_table_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and refer_table_name = '%s' ; ", db, oldName))
+	sb.WriteString(fmt.Sprintf("set refer_table_name = '%s' ", sqlquote.EscapeString(newName)))
+	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and refer_table_name = '%s' ; ",
+		sqlquote.EscapeString(db), sqlquote.EscapeString(oldName)))
 	ret = append(ret, sb.String())
 	return
 }
@@ -3577,16 +3583,16 @@ func getSqlForRenameTable(db, oldName, newName string) (ret []string) {
 func getSqlForRenameColumn(db, table, oldName, newName string) (ret []string) {
 	sb := strings.Builder{}
 	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set column_name = '%s' ", newName))
+	sb.WriteString(fmt.Sprintf("set column_name = '%s' ", sqlquote.EscapeString(newName)))
 	sb.WriteString(fmt.Sprintf("where db_name = '%s' and table_name = '%s' and column_name = '%s' ; ",
-		db, table, oldName))
+		sqlquote.EscapeString(db), sqlquote.EscapeString(table), sqlquote.EscapeString(oldName)))
 	ret = append(ret, sb.String())
 
 	sb.Reset()
 	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set refer_column_name = '%s' ", newName))
+	sb.WriteString(fmt.Sprintf("set refer_column_name = '%s' ", sqlquote.EscapeString(newName)))
 	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and refer_table_name = '%s' and refer_column_name = '%s' ; ",
-		db, table, oldName))
+		sqlquote.EscapeString(db), sqlquote.EscapeString(table), sqlquote.EscapeString(oldName)))
 	ret = append(ret, sb.String())
 	return
 }

--- a/pkg/sql/plan/build_dml_util_test.go
+++ b/pkg/sql/plan/build_dml_util_test.go
@@ -64,6 +64,35 @@ func TestGetSqlForFkReferredToEscapesStringLiterals(t *testing.T) {
 	require.Contains(t, sql, "table_name != 'quote''src'")
 }
 
+func TestGetSqlForAddFkEscapesStringLiterals(t *testing.T) {
+	fkData := &FkData{
+		Def: &plan.ForeignKeyDef{
+			Name:     "fk'child",
+			OnDelete: plan.ForeignKeyDef_CASCADE,
+			OnUpdate: plan.ForeignKeyDef_RESTRICT,
+		},
+		Cols:            &plan.FkColName{Cols: []string{"child'col"}},
+		ColsReferred:    &plan.FkColName{Cols: []string{"parent'col"}},
+		ParentDbName:    "parent\\db",
+		ParentTableName: "parent'table",
+	}
+
+	sql := getSqlForAddFk("child'db", "child\\table", fkData)
+	require.Contains(t, sql, "'fk''child'")
+	require.Contains(t, sql, "'child''db'")
+	require.Contains(t, sql, "'child\\\\table'")
+	require.Contains(t, sql, "'child''col'")
+	require.Contains(t, sql, "'parent\\\\db'")
+	require.Contains(t, sql, "'parent''table'")
+	require.Contains(t, sql, "'parent''col'")
+}
+
+func TestGetSqlForCheckHasDBRefersToEscapesStringLiterals(t *testing.T) {
+	sql := getSqlForCheckHasDBRefersTo("db'name")
+	require.Contains(t, sql, "refer_db_name = 'db''name'")
+	require.Contains(t, sql, "db_name != 'db''name'")
+}
+
 func Test_buildPreDeleteFullTextIndexAsync(t *testing.T) {
 	{
 		//invalid json

--- a/pkg/sql/plan/build_dml_util_test.go
+++ b/pkg/sql/plan/build_dml_util_test.go
@@ -57,6 +57,13 @@ func Test_runSql(t *testing.T) {
 	require.Error(t, err, "internal error: no account id in context")
 }
 
+func TestGetSqlForFkReferredToEscapesStringLiterals(t *testing.T) {
+	sql := GetSqlForFkReferredTo("db\\name", "quote'src")
+	require.Contains(t, sql, "refer_db_name = 'db\\\\name'")
+	require.Contains(t, sql, "refer_table_name = 'quote''src'")
+	require.Contains(t, sql, "table_name != 'quote''src'")
+}
+
 func Test_buildPreDeleteFullTextIndexAsync(t *testing.T) {
 	{
 		//invalid json

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/partition"
@@ -50,9 +51,9 @@ func ConstructCreateTableSQL(
 
 	tblName := tableDef.Name
 	schemaName := tableDef.DbName
-	dbTblName := fmt.Sprintf("`%s`", formatStr(tblName))
+	dbTblName := sqlquote.Ident(tblName)
 	if useDbName {
-		dbTblName = fmt.Sprintf("`%s`.`%s`", formatStr(schemaName), formatStr(tblName))
+		dbTblName = sqlquote.QualifiedIdent(schemaName, tblName)
 	}
 
 	if tableDef.TableType == catalog.SystemExternalRel {
@@ -111,7 +112,7 @@ func ConstructCreateTableSQL(
 		} else {
 			typeStr = strings.ToLower(typeStr)
 		}
-		fmt.Fprintf(buf, "  `%s` %s", formatStr(colNameOrigin), typeStr)
+		fmt.Fprintf(buf, "  %s %s", sqlquote.Ident(colNameOrigin), typeStr)
 
 		//-------------------------------------------------------------------------------------------------------------
 		if col.GeneratedCol != nil && col.GeneratedCol.Expr != nil {
@@ -170,9 +171,9 @@ func ConstructCreateTableSQL(
 		for i, def := range pkDefs {
 			def = colNameToOriginName[def]
 			if i == len(pkDefs)-1 {
-				pkStr += fmt.Sprintf("`%s`)", formatStr(def))
+				pkStr += fmt.Sprintf("%s)", sqlquote.Ident(def))
 			} else {
-				pkStr += fmt.Sprintf("`%s`,", formatStr(def))
+				pkStr += fmt.Sprintf("%s,", sqlquote.Ident(def))
 			}
 		}
 		if rowCount != 0 {
@@ -202,7 +203,7 @@ func ConstructCreateTableSQL(
 				indexStr += " FULLTEXT "
 
 				if len(indexdef.IndexName) > 0 {
-					indexStr += fmt.Sprintf("`%s`", formatStr(indexdef.IndexName))
+					indexStr += sqlquote.Ident(indexdef.IndexName)
 				}
 				indexStr += "("
 				i := 0
@@ -215,7 +216,7 @@ func ConstructCreateTableSQL(
 					}
 
 					part = colNameToOriginName[part]
-					indexStr += fmt.Sprintf("`%s`", formatStr(part))
+					indexStr += sqlquote.Ident(part)
 					i++
 				}
 
@@ -264,8 +265,8 @@ func ConstructCreateTableSQL(
 					indexStr = "  KEY "
 					rewriteIndexStr = "  KEY "
 				}
-				indexStr += fmt.Sprintf("`%s` ", formatStr(indexdef.IndexName))
-				rewriteIndexStr += fmt.Sprintf("`%s` ", formatStr(indexdef.IndexName))
+				indexStr += fmt.Sprintf("%s ", sqlquote.Ident(indexdef.IndexName))
+				rewriteIndexStr += fmt.Sprintf("%s ", sqlquote.Ident(indexdef.IndexName))
 				if !catalog.IsNullIndexAlgo(indexdef.IndexAlgo) && !catalog.IsRTreeIndexAlgo(indexdef.IndexAlgo) {
 					indexStr += fmt.Sprintf("USING %s ", indexdef.IndexAlgo)
 				}
@@ -289,8 +290,8 @@ func ConstructCreateTableSQL(
 					}
 
 					originPart := colNameToOriginName[part]
-					indexStr += fmt.Sprintf("`%s`", formatStr(originPart))
-					rewriteIndexStr += fmt.Sprintf("`%s`", formatStr(originPart))
+					indexStr += sqlquote.Ident(originPart)
+					rewriteIndexStr += sqlquote.Ident(originPart)
 					if length, ok := prefixLengths[part]; ok {
 						prefixLength := fmt.Sprintf("(%d)", length)
 						indexStr += prefixLength
@@ -455,12 +456,12 @@ func ConstructCreateTableSQL(
 			createStr += ",\n"
 		}
 
-		fkRefDbTblName := fmt.Sprintf("`%s`", formatStr(fkTableDef.Name))
+		fkRefDbTblName := sqlquote.Ident(fkTableDef.Name)
 		if cloneStmt != nil || tableDef.DbName != fkTableDef.DbName {
-			fkRefDbTblName = fmt.Sprintf("`%s`.`%s`", formatStr(fkTableDef.DbName), formatStr(fkTableDef.Name))
+			fkRefDbTblName = sqlquote.QualifiedIdent(fkTableDef.DbName, fkTableDef.Name)
 		}
-		createStr += fmt.Sprintf("  CONSTRAINT `%s` FOREIGN KEY (`%s`) REFERENCES %s (`%s`) ON DELETE %s ON UPDATE %s",
-			formatStr(fk.Name), strings.Join(colOriginNames, "`,`"), fkRefDbTblName, strings.Join(fkColOriginNames, "`,`"), strings.ReplaceAll(fk.OnDelete.String(), "_", " "), strings.ReplaceAll(fk.OnUpdate.String(), "_", " "))
+		createStr += fmt.Sprintf("  CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) ON DELETE %s ON UPDATE %s",
+			sqlquote.Ident(fk.Name), joinQuotedIdentifiers(colOriginNames), fkRefDbTblName, joinQuotedIdentifiers(fkColOriginNames), strings.ReplaceAll(fk.OnDelete.String(), "_", " "), strings.ReplaceAll(fk.OnUpdate.String(), "_", " "))
 	}
 
 	for _, checkDef := range checkDefs {
@@ -563,14 +564,14 @@ func ConstructCreateTableSQL(
 			cbNames := util.SplitCompositeClusterByColumnName(tableDef.ClusterBy.Name)
 			for i, cbName := range cbNames {
 				if i != 0 {
-					clusterby += fmt.Sprintf(", `%s`", formatStr(cbName))
+					clusterby += fmt.Sprintf(", %s", sqlquote.Ident(cbName))
 				} else {
-					clusterby += fmt.Sprintf("`%s`", formatStr(cbName))
+					clusterby += sqlquote.Ident(cbName)
 				}
 			}
 		} else {
 			//single column cluster by
-			clusterby += fmt.Sprintf("`%s`", formatStr(tableDef.ClusterBy.Name))
+			clusterby += sqlquote.Ident(tableDef.ClusterBy.Name)
 		}
 		clusterby += ")"
 		createStr += clusterby
@@ -683,6 +684,14 @@ func extractTopLevelCheckDefs(tableDef *plan.TableDef) []string {
 		}
 	}
 	return checks
+}
+
+func joinQuotedIdentifiers(names []string) string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = sqlquote.Ident(name)
+	}
+	return strings.Join(quoted, ",")
 }
 
 func extractCreateTableDefsSection(createSQL string) (string, bool) {

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -17,6 +17,7 @@ package plan
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -40,6 +41,26 @@ import (
 
 	planplugin "github.com/matrixorigin/matrixone/pkg/indexplugin/plan"
 )
+
+type snapshotNotFoundError struct {
+	cause error
+}
+
+func (e *snapshotNotFoundError) Error() string {
+	if e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+func (e *snapshotNotFoundError) Unwrap() error {
+	return e.cause
+}
+
+func IsSnapshotNotFound(err error) bool {
+	var target *snapshotNotFoundError
+	return errors.As(err, &target)
+}
 
 func NewQueryBuilder(queryType plan.Query_StatementType, ctx CompilerContext, isPrepareStatement bool, skipStats bool) *QueryBuilder {
 	//
@@ -5712,7 +5733,11 @@ func (builder *QueryBuilder) ResolveTsHint(tsExpr *tree.AtTimeStamp) (snapshot *
 				snapshot = &Snapshot{TS: &timestamp.Timestamp{PhysicalTime: tsNano}, Tenant: tenant}
 			}
 		} else if tsExpr.Type == tree.ATTIMESTAMPSNAPSHOT {
-			return builder.compCtx.ResolveSnapshotWithSnapshotName(lit.Sval)
+			snapshot, err = builder.compCtx.ResolveSnapshotWithSnapshotName(lit.Sval)
+			if err != nil && strings.Contains(err.Error(), "find 0 snapshot records") {
+				err = &snapshotNotFoundError{cause: err}
+			}
+			return
 		} else if tsExpr.Type == tree.ATMOTIMESTAMP {
 			// try human-readable datetime first, fall back to debug timestamp format
 			if ts, err2 := time.Parse("2006-01-02 15:04:05.999999999", lit.Sval); err2 == nil {

--- a/pkg/vm/engine/disttae/logtailreplay/change_handle.go
+++ b/pkg/vm/engine/disttae/logtailreplay/change_handle.go
@@ -2489,6 +2489,8 @@ func appendFromEntry(src, vec *vector.Vector, offset int, mp *mpool.MPool) {
 			val = vector.GetFixedAtNoTypeCheck[types.Decimal64](src, offset)
 		case types.T_decimal128:
 			val = vector.GetFixedAtNoTypeCheck[types.Decimal128](src, offset)
+		case types.T_decimal256:
+			val = vector.GetFixedAtNoTypeCheck[types.Decimal256](src, offset)
 		case types.T_uuid:
 			val = vector.GetFixedAtNoTypeCheck[types.Uuid](src, offset)
 		case types.T_float32:
@@ -2497,6 +2499,8 @@ func appendFromEntry(src, vec *vector.Vector, offset int, mp *mpool.MPool) {
 			val = vector.GetFixedAtNoTypeCheck[float64](src, offset)
 		case types.T_date:
 			val = vector.GetFixedAtNoTypeCheck[types.Date](src, offset)
+		case types.T_year:
+			val = vector.GetFixedAtNoTypeCheck[types.MoYear](src, offset)
 		case types.T_time:
 			val = vector.GetFixedAtNoTypeCheck[types.Time](src, offset)
 		case types.T_datetime:
@@ -2512,7 +2516,7 @@ func appendFromEntry(src, vec *vector.Vector, offset int, mp *mpool.MPool) {
 		case types.T_Blockid:
 			val = vector.GetFixedAtNoTypeCheck[types.Blockid](src, offset)
 		case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_json, types.T_blob, types.T_text,
-			types.T_array_float32, types.T_array_float64, types.T_datalink:
+			types.T_array_float32, types.T_array_float64, types.T_datalink, types.T_geometry, types.T_geometry32:
 			val = src.GetBytesAt(offset)
 		default:
 			//return vector.ErrVecTypeNotSupport

--- a/pkg/vm/engine/disttae/txn_table_combined.go
+++ b/pkg/vm/engine/disttae/txn_table_combined.go
@@ -280,10 +280,72 @@ func (t *combinedTxnTable) EstimateCommittedTombstoneCount(ctx context.Context) 
 func (t *combinedTxnTable) CollectChanges(
 	ctx context.Context,
 	from, to types.TS,
-	_ bool,
+	skipDeletes bool,
 	mp *mpool.MPool,
 ) (engine.ChangesHandle, error) {
-	panic("not implemented")
+	tables, err := t.tablesFunc()
+	if err != nil {
+		return nil, err
+	}
+
+	handle := &combinedChangesHandle{}
+	for _, rel := range tables {
+		partitionHandle, err := rel.CollectChanges(ctx, from, to, skipDeletes, mp)
+		if err != nil {
+			_ = handle.Close()
+			return nil, err
+		}
+		if partitionHandle != nil {
+			handle.handles = append(handle.handles, partitionHandle)
+		}
+	}
+	return handle, nil
+}
+
+type combinedChangesHandle struct {
+	handles []engine.ChangesHandle
+	idx     int
+	closed  bool
+}
+
+func (h *combinedChangesHandle) Next(
+	ctx context.Context,
+	mp *mpool.MPool,
+) (data *batch.Batch, tombstone *batch.Batch, hint engine.ChangesHandle_Hint, err error) {
+	for h.idx < len(h.handles) {
+		data, tombstone, hint, err = h.handles[h.idx].Next(ctx, mp)
+		if err != nil {
+			return nil, nil, hint, err
+		}
+		if data != nil || tombstone != nil {
+			return data, tombstone, hint, nil
+		}
+		if err = h.handles[h.idx].Close(); err != nil {
+			h.idx++
+			_ = h.closeRemaining()
+			return nil, nil, hint, err
+		}
+		h.idx++
+	}
+	return nil, nil, engine.ChangesHandle_Tail_done, nil
+}
+
+func (h *combinedChangesHandle) Close() error {
+	if h.closed {
+		return nil
+	}
+	return h.closeRemaining()
+}
+
+func (h *combinedChangesHandle) closeRemaining() error {
+	h.closed = true
+	var firstErr error
+	for ; h.idx < len(h.handles); h.idx++ {
+		if err := h.handles[h.idx].Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (t *combinedTxnTable) CollectObjectList(

--- a/pkg/vm/engine/disttae/txn_table_combined_test.go
+++ b/pkg/vm/engine/disttae/txn_table_combined_test.go
@@ -17,6 +17,7 @@ package disttae
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -61,15 +62,91 @@ func TestCombinedTxnTable_BuildShardingReaders(t *testing.T) {
 func TestCombinedTxnTable_CollectChanges(t *testing.T) {
 	table := newMockCombinedTxnTable()
 
-	assert.PanicsWithValue(t, "not implemented", func() {
-		table.CollectChanges(
-			context.Background(),
-			types.TS{},
-			types.TS{},
-			false,
-			&mpool.MPool{},
-		)
-	})
+	handle, err := table.CollectChanges(
+		context.Background(),
+		types.TS{},
+		types.TS{},
+		false,
+		&mpool.MPool{},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, handle)
+
+	data, tombstone, hint, err := handle.Next(context.Background(), &mpool.MPool{})
+	assert.NoError(t, err)
+	assert.Nil(t, data)
+	assert.Nil(t, tombstone)
+	assert.Equal(t, engine.ChangesHandle_Tail_done, hint)
+	assert.NoError(t, handle.Close())
+}
+
+func TestCombinedTxnTable_CollectChangesIteratesPartitions(t *testing.T) {
+	first := batch.NewWithSize(0)
+	second := batch.NewWithSize(0)
+	table := newMockCombinedTxnTable()
+	table.tablesFunc = func() ([]engine.Relation, error) {
+		return []engine.Relation{
+			&mockRelation{collectChangesFunc: func(context.Context, types.TS, types.TS, bool, *mpool.MPool) (engine.ChangesHandle, error) {
+				return &mockChangesHandle{data: []*batch.Batch{first}}, nil
+			}},
+			&mockRelation{collectChangesFunc: func(context.Context, types.TS, types.TS, bool, *mpool.MPool) (engine.ChangesHandle, error) {
+				return &mockChangesHandle{data: []*batch.Batch{second}}, nil
+			}},
+		}, nil
+	}
+
+	handle, err := table.CollectChanges(context.Background(), types.TS{}, types.TS{}, false, &mpool.MPool{})
+	assert.NoError(t, err)
+
+	data, tombstone, _, err := handle.Next(context.Background(), &mpool.MPool{})
+	assert.NoError(t, err)
+	assert.Same(t, first, data)
+	assert.Nil(t, tombstone)
+
+	data, tombstone, _, err = handle.Next(context.Background(), &mpool.MPool{})
+	assert.NoError(t, err)
+	assert.Same(t, second, data)
+	assert.Nil(t, tombstone)
+
+	data, tombstone, hint, err := handle.Next(context.Background(), &mpool.MPool{})
+	assert.NoError(t, err)
+	assert.Nil(t, data)
+	assert.Nil(t, tombstone)
+	assert.Equal(t, engine.ChangesHandle_Tail_done, hint)
+}
+
+func TestCombinedChangesHandle_CloseClosesAllHandlesOnError(t *testing.T) {
+	errFirst := errors.New("first close failed")
+	errSecond := errors.New("second close failed")
+	first := &mockChangesHandle{closeErr: errFirst}
+	second := &mockChangesHandle{closeErr: errSecond}
+	third := &mockChangesHandle{}
+	handle := &combinedChangesHandle{handles: []engine.ChangesHandle{first, second, third}}
+
+	err := handle.Close()
+	assert.ErrorIs(t, err, errFirst)
+	assert.Equal(t, 1, first.closeCount)
+	assert.Equal(t, 1, second.closeCount)
+	assert.Equal(t, 1, third.closeCount)
+	assert.True(t, first.closed)
+	assert.True(t, second.closed)
+	assert.True(t, third.closed)
+}
+
+func TestCombinedChangesHandle_NextCloseErrorClosesRemainingHandles(t *testing.T) {
+	errFirst := errors.New("first close failed")
+	first := &mockChangesHandle{closeErr: errFirst}
+	second := &mockChangesHandle{}
+	handle := &combinedChangesHandle{handles: []engine.ChangesHandle{first, second}}
+
+	data, tombstone, _, err := handle.Next(context.Background(), &mpool.MPool{})
+	assert.ErrorIs(t, err, errFirst)
+	assert.Nil(t, data)
+	assert.Nil(t, tombstone)
+	assert.Equal(t, 1, first.closeCount)
+	assert.Equal(t, 1, second.closeCount)
+	assert.True(t, first.closed)
+	assert.True(t, second.closed)
 }
 
 func TestCombinedTxnTable_MergeObjects(t *testing.T) {
@@ -1239,6 +1316,29 @@ type mockTombstoner struct {
 	mergeFunc                   func(other engine.Tombstoner) error
 }
 
+type mockChangesHandle struct {
+	data       []*batch.Batch
+	idx        int
+	closed     bool
+	closeErr   error
+	closeCount int
+}
+
+func (m *mockChangesHandle) Next(context.Context, *mpool.MPool) (*batch.Batch, *batch.Batch, engine.ChangesHandle_Hint, error) {
+	if m.idx >= len(m.data) {
+		return nil, nil, engine.ChangesHandle_Tail_done, nil
+	}
+	bat := m.data[m.idx]
+	m.idx++
+	return bat, nil, engine.ChangesHandle_Tail_wip, nil
+}
+
+func (m *mockChangesHandle) Close() error {
+	m.closed = true
+	m.closeCount++
+	return m.closeErr
+}
+
 func (m *mockTombstoner) Type() engine.TombstoneType {
 	return engine.TombstoneData
 }
@@ -1328,6 +1428,7 @@ type mockRelation struct {
 	rowsFunc                            func(ctx context.Context) (uint64, error)
 	starCountFunc                       func(ctx context.Context) (uint64, error)
 	estimateCommittedTombstoneCountFunc func(ctx context.Context) (int, error)
+	collectChangesFunc                  func(ctx context.Context, from, to types.TS, skipDeletes bool, mp *mpool.MPool) (engine.ChangesHandle, error)
 	buildReadersFunc                    func(ctx context.Context, proc any, expr *plan.Expr, relData engine.RelData, num int, txnOffset int, orderBy bool, policy engine.TombstoneApplyPolicy, filterHint engine.FilterHint) ([]engine.Reader, error)
 }
 
@@ -1386,7 +1487,10 @@ func (m *mockRelation) EstimateCommittedTombstoneCount(ctx context.Context) (int
 	return 0, nil
 }
 
-func (m *mockRelation) CollectChanges(ctx context.Context, from, to types.TS, _ bool, mp *mpool.MPool) (engine.ChangesHandle, error) {
+func (m *mockRelation) CollectChanges(ctx context.Context, from, to types.TS, skipDeletes bool, mp *mpool.MPool) (engine.ChangesHandle, error) {
+	if m.collectChangesFunc != nil {
+		return m.collectChangesFunc(ctx, from, to, skipDeletes, mp)
+	}
 	return nil, nil
 }
 

--- a/pkg/vm/engine/disttae/txn_table_delegate_test.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate_test.go
@@ -31,15 +31,16 @@ func TestTxnTableDelegate_CollectChanges(t *testing.T) {
 	table.combined.is = true
 	table.combined.tbl = newMockCombinedTxnTable()
 
-	assert.PanicsWithValue(t, "not implemented", func() {
-		table.CollectChanges(
-			context.Background(),
-			types.TS{},
-			types.TS{},
-			false,
-			&mpool.MPool{},
-		)
-	})
+	handle, err := table.CollectChanges(
+		context.Background(),
+		types.TS{},
+		types.TS{},
+		false,
+		&mpool.MPool{},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, handle)
+	assert.NoError(t, handle.Close())
 }
 
 func TestTxnTableDelegate_MergeObjects(t *testing.T) {

--- a/test/distributed/cases/git4data/branch/edge/branch_edge_cases.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_edge_cases.sql
@@ -138,7 +138,6 @@ insert into txn_merge_src values (3, 'three');
 delete from txn_merge_src where a = 1;
 
 -- Regression for #24924: DIFF/MERGE should honor explicit transaction boundaries.
--- @bvt:issue#24924
 begin;
 data branch diff txn_merge_src against txn_merge_dst output count;
 rollback;
@@ -150,7 +149,6 @@ begin;
 data branch merge txn_merge_src into txn_merge_dst when conflict accept;
 commit;
 select a, b from txn_merge_dst order by a;
--- @bvt:issue
 
 data branch create database br_txn_dst from br_txn_src;
 select count(*) as dst_tables

--- a/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.result
@@ -43,7 +43,7 @@ vbin = x'090a0b0c',
 e = 'green',
 bl = 'blob-updated',
 dl = 'file:///tmp/mo_branch_type_updated.csv',
-g = 'POINT(2 2)',
+g = st_geomfromtext('POINT(2 2)'),
 vf = '[7.7,8.8,9.9]'
 where id = 1;
 insert into wide_branch values
@@ -52,14 +52,33 @@ cast('7.000000000000000000000000000000' as decimal(65,30)),
 2000, '3ddf7b28-2dba-11ed-940f-000c29847904', 'gh', x'0d0e0f10',
 'red', 'blob-new', 'file:///tmp/mo_branch_type_new.csv', 'POINT(3 3)', '[0.1,0.2,0.3]');
 delete from wide_branch where id = 2;
+data branch diff wide_branch against wide_base output summary;
+➤ metric[12,0,0]  ¦  wide_branch[-5,0,0]  ¦  wide_base[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
 data branch merge wide_branch into wide_base;
 select count(*) as wide_rows from wide_base;
-wide_rows
+➤ wide_rows[-5,64,0]  𝄀
 2
 select id, cast(b as int) as bit_i, u8, u16, u32, u64, y, e from wide_base order by id;
-id    bit_i    u8    u16    u32    u64    y    e
-1    7    251    65001    4000000001    9000000000000000001    2025    green
-3    1    2    3    4    5    2000    red
+➤ id[4,32,0]  ¦  bit_i[4,32,0]  ¦  u8[-6,8,0]  ¦  u16[5,16,0]  ¦  u32[4,32,0]  ¦  u64[-5,64,0]  ¦  y[91,2147483647,0]  ¦  e[12,-1,0]  𝄀
+1  ¦  7  ¦  251  ¦  65001  ¦  4000000001  ¦  9000000000000000001  ¦  2025-01-01  ¦  green  𝄀
+3  ¦  1  ¦  2  ¦  3  ¦  4  ¦  5  ¦  2000-01-01  ¦  red
+select id, d256, st_astext(g) as g from wide_base order by id;
+➤ id[4,32,0]  ¦  d256[3,65,30]  ¦  g[12,-1,0]  𝄀
+1  ¦  42.000000000000000000000000000000  ¦  POINT(2 2)  𝄀
+3  ¦  7.000000000000000000000000000000  ¦  POINT(3 3)
+create table pick_year_base(y year primary key, v int);
+insert into pick_year_base values (2024, 1), (2025, 2);
+data branch create table pick_year_dst from pick_year_base;
+data branch create table pick_year_src from pick_year_base;
+update pick_year_src set v = 20250 where y = 2025;
+data branch pick pick_year_src into pick_year_dst keys('2025') when conflict accept;
+select y, v from pick_year_dst order by y;
+➤ y[91,2147483647,0]  ¦  v[4,32,0]  𝄀
+2024-01-01  ¦  1  𝄀
+2025-01-01  ¦  20250
 drop database br_matrix_types;
 drop database if exists br_matrix_constraints;
 create database br_matrix_constraints;
@@ -84,16 +103,16 @@ insert into child_branch(parent_id, code, qty) values (1, null, 1.00);
 constraint violation: Column 'code' cannot be null
 insert into child_branch(parent_id, code, qty) values (1, 'base-a', 1.00);
 -- @regex("Duplicate entry 'base-a'", true)
-Duplicate entry 'base-a' for key 'uq_code'
+Duplicate entry 'base-a' for key 'code'
 insert into child_branch(parent_id, code, qty) values (99, 'bad-fk', 1.00);
 -- @regex("foreign key constraint fails", true)
 internal error: Cannot add or update a child row: a foreign key constraint fails
 data branch merge child_branch into child;
 select count(*) as child_rows from child;
-child_rows
+➤ child_rows[-5,64,0]  𝄀
 3
 select code from child where parent_id = 2 and qty = 77.75;
-code
+➤ code[12,-1,0]  𝄀
 seed
 create table clustered_base(
 tenant int not null comment 'cluster tenant',
@@ -107,13 +126,13 @@ insert into clustered_branch(tenant, payload) values (3, 'default-seq');
 delete from clustered_branch where tenant = 2;
 data branch merge clustered_branch into clustered_base;
 select count(*) as clustered_rows from clustered_base;
-clustered_rows
+➤ clustered_rows[-5,64,0]  𝄀
 3
 select tenant, seq, payload from clustered_base order by tenant, seq;
-tenant    seq    payload
-1    1    base
-1    2    new
-3    0    default-seq
+➤ tenant[4,32,0]  ¦  seq[4,32,0]  ¦  payload[12,-1,0]  𝄀
+1  ¦  1  ¦  base  𝄀
+1  ¦  2  ¦  new  𝄀
+3  ¦  0  ¦  default-seq
 drop database br_matrix_constraints;
 drop database if exists br_matrix_tables_copy;
 drop database if exists br_matrix_tables;
@@ -134,22 +153,28 @@ insert into part_branch values (2, 20, 'new-p0'), (21, 210, 'new-p1');
 delete from part_branch where id = 12;
 data branch merge part_branch into part_base;
 select id, val, note from part_base order by id;
-id    val    note
-1    10    p0
-2    20    new-p0
-11    111    p1
-21    210    new-p1
+➤ id[4,32,0]  ¦  val[4,32,0]  ¦  note[12,-1,0]  𝄀
+1  ¦  10  ¦  p0  𝄀
+2  ¦  20  ¦  new-p0  𝄀
+11  ¦  111  ¦  p1  𝄀
+21  ¦  210  ¦  new-p1
 create table view_base(id int primary key, val int);
 insert into view_base values (1, 10), (2, 20), (3, 30);
 create view v_active as select id, val from view_base where val >= 20;
+create table view_identifier_base(br_matrix_tables int primary key, marker int);
+insert into view_identifier_base values (10, 100);
+create view v_identifier as select br_matrix_tables as br_matrix_tables from view_identifier_base;
 data branch create database br_matrix_tables_copy from br_matrix_tables;
 insert into view_base values (4, 40);
 select count(*) as copied_view_rows from br_matrix_tables_copy.v_active;
-copied_view_rows
+➤ copied_view_rows[-5,64,0]  𝄀
 2
+select br_matrix_tables from br_matrix_tables_copy.v_identifier;
+➤ br_matrix_tables[4,32,0]  𝄀
+10
 insert into br_matrix_tables_copy.view_base values (5, 50);
 select count(*) as copied_view_rows_after_insert from br_matrix_tables_copy.v_active;
-copied_view_rows_after_insert
+➤ copied_view_rows_after_insert[-5,64,0]  𝄀
 3
 create external table ext_branch_base(id int) infile{"filepath"='$resources/external_table_file/extable.csv'} fields terminated by ',' lines terminated by '\n';
 data branch create table ext_branch_copy from ext_branch_base;
@@ -162,7 +187,7 @@ insert into br_cluster_branch_base values (1, 0), (2, 0);
 use br_matrix_tables;
 data branch create table cluster_branch_copy from mo_catalog.br_cluster_branch_base;
 select count(*) as cluster_rows from cluster_branch_copy;
-cluster_rows
+➤ cluster_rows[-5,64,0]  𝄀
 2
 drop table mo_catalog.br_cluster_branch_base;
 drop database br_matrix_tables_copy;
@@ -174,13 +199,16 @@ create table `base table`(a int primary key, b varchar(20));
 insert into `base table` values (1, 'space-name'), (2, 'space-name');
 data branch create table `branch table` from `base table`;
 select count(*) as quoted_space_rows from `branch table`;
-quoted_space_rows
+➤ quoted_space_rows[-5,64,0]  𝄀
 2
 create table `quote'src`(a int primary key, b varchar(20));
 insert into `quote'src` values (1, 'single-quote');
 data branch create table `quote'dst` from `quote'src`;
-select count(*) as quoted_apostrophe_rows from `quote'dst`;
-quoted_apostrophe_rows
+set @quote_sql = 'select count(*) as quoted_apostrophe_rows from `quote''dst`';
+prepare quote_stmt from @quote_sql;
+execute quote_stmt;
+➤ quoted_apostrophe_rows[-5,64,0]  𝄀
 1
+deallocate prepare quote_stmt;
 use mo_catalog;
 drop database if exists br_matrix_quoted;

--- a/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.result
@@ -17,17 +17,20 @@ e enum('red','blue','green'),
 bl blob,
 dl datalink,
 g geometry,
+g32 geometry32,
 vf vecf64(3)
 );
 insert into wide_base values
 (1, b'101', 250, 65000, 4000000000, 9000000000000000000,
 cast('12345678901234567890123456789012345.123456789012345678901234567890' as decimal(65,30)),
 2024, '6d1b1f73-2dbf-11ed-940f-000c29847904', 'ab', x'01020304',
-'red', 'blob-base', 'file:///tmp/mo_branch_type_base.csv', 'POINT(1 1)', '[1.1,2.2,3.3]'),
+'red', 'blob-base', 'file:///tmp/mo_branch_type_base.csv', 'POINT(1 1)',
+cast('POINT(1 1)' as geometry32), '[1.1,2.2,3.3]'),
 (2, b'010', 1, 2, 3, 4,
 cast('-0.000000000000000000000000000001' as decimal(65,30)),
 1999, 'ad9f809f-2dbd-11ed-940f-000c29847904', 'cd', x'05060708',
-'blue', 'blob-two', 'file:///tmp/mo_branch_type_two.csv', 'LINESTRING(0 0,1 1)', '[4.4,5.5,6.6]');
+'blue', 'blob-two', 'file:///tmp/mo_branch_type_two.csv', 'LINESTRING(0 0,1 1)',
+cast('LINESTRING(0 0,1 1)' as geometry32), '[4.4,5.5,6.6]');
 data branch create table wide_branch from wide_base;
 update wide_branch set
 b = b'111',
@@ -44,13 +47,15 @@ e = 'green',
 bl = 'blob-updated',
 dl = 'file:///tmp/mo_branch_type_updated.csv',
 g = st_geomfromtext('POINT(2 2)'),
+g32 = cast('POINT(2 2)' as geometry32),
 vf = '[7.7,8.8,9.9]'
 where id = 1;
 insert into wide_branch values
 (3, b'001', 2, 3, 4, 5,
 cast('7.000000000000000000000000000000' as decimal(65,30)),
 2000, '3ddf7b28-2dba-11ed-940f-000c29847904', 'gh', x'0d0e0f10',
-'red', 'blob-new', 'file:///tmp/mo_branch_type_new.csv', 'POINT(3 3)', '[0.1,0.2,0.3]');
+'red', 'blob-new', 'file:///tmp/mo_branch_type_new.csv', 'POINT(3 3)',
+cast('POINT(3 3)' as geometry32), '[0.1,0.2,0.3]');
 delete from wide_branch where id = 2;
 data branch diff wide_branch against wide_base output summary;
 ➤ metric[12,0,0]  ¦  wide_branch[-5,0,0]  ¦  wide_base[-5,0,0]  𝄀
@@ -65,10 +70,55 @@ select id, cast(b as int) as bit_i, u8, u16, u32, u64, y, e from wide_base order
 ➤ id[4,32,0]  ¦  bit_i[4,32,0]  ¦  u8[-6,8,0]  ¦  u16[5,16,0]  ¦  u32[4,32,0]  ¦  u64[-5,64,0]  ¦  y[91,2147483647,0]  ¦  e[12,-1,0]  𝄀
 1  ¦  7  ¦  251  ¦  65001  ¦  4000000001  ¦  9000000000000000001  ¦  2025-01-01  ¦  green  𝄀
 3  ¦  1  ¦  2  ¦  3  ¦  4  ¦  5  ¦  2000-01-01  ¦  red
-select id, d256, st_astext(g) as g from wide_base order by id;
-➤ id[4,32,0]  ¦  d256[3,65,30]  ¦  g[12,-1,0]  𝄀
-1  ¦  42.000000000000000000000000000000  ¦  POINT(2 2)  𝄀
-3  ¦  7.000000000000000000000000000000  ¦  POINT(3 3)
+select id, d256, st_astext(g) as g, st_astext(g32) as g32 from wide_base order by id;
+➤ id[4,32,0]  ¦  d256[3,65,30]  ¦  g[12,-1,0]  ¦  g32[12,-1,0]  𝄀
+1  ¦  42.000000000000000000000000000000  ¦  POINT(2 2)  ¦  POINT(2 2)  𝄀
+3  ¦  7.000000000000000000000000000000  ¦  POINT(3 3)  ¦  POINT(3 3)
+create table geometry32_base(
+id int primary key,
+g geometry32,
+p point32,
+geog geography32,
+g3857 geometry32 srid 3857
+);
+insert into geometry32_base values (
+1,
+cast('POINT(1 1)' as geometry32),
+cast(st_point32(1, 1) as point32),
+cast('POINT(1 1)' as geography32),
+st_geomfromtext('POINT(1 1)', 3857)
+);
+data branch create table geometry32_branch from geometry32_base;
+update geometry32_base set
+g = cast('POINT(2 2)' as geometry32),
+p = cast(st_point32(2, 2) as point32),
+geog = cast('POINT(2 2)' as geography32),
+g3857 = st_geomfromtext('POINT(2 2)', 3857)
+where id = 1;
+update geometry32_branch set
+g = cast('POINT(3 3)' as geometry32),
+p = cast(st_point32(3, 3) as point32),
+geog = cast('POINT(3 3)' as geography32),
+g3857 = st_geomfromtext('POINT(3 3)', 3857)
+where id = 1;
+data branch diff geometry32_branch against geometry32_base output summary;
+➤ metric[12,0,0]  ¦  geometry32_branch[-5,0,0]  ¦  geometry32_base[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch merge geometry32_branch into geometry32_base;
+internal error: conflict: geometry32_branch DELETE and geometry32_base DELETE on pk(1) with different values
+data branch merge geometry32_branch into geometry32_base when conflict accept;
+select id,
+st_astext(g) as g,
+st_astext(p) as p,
+st_astext(geog) as geog,
+st_srid(geog) as geog_srid,
+st_astext(g3857) as g3857,
+st_srid(g3857) as g3857_srid
+from geometry32_base order by id;
+➤ id[4,32,0]  ¦  g[12,-1,0]  ¦  p[12,-1,0]  ¦  geog[12,-1,0]  ¦  geog_srid[4,32,0]  ¦  g3857[12,-1,0]  ¦  g3857_srid[4,32,0]  𝄀
+1  ¦  POINT(3 3)  ¦  POINT(3 3)  ¦  POINT(3 3)  ¦  4326  ¦  POINT(3 3)  ¦  3857
 create table pick_year_base(y year primary key, v int);
 insert into pick_year_base values (2024, 1);
 data branch create table pick_year_dst from pick_year_base;

--- a/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.result
@@ -70,10 +70,10 @@ select id, d256, st_astext(g) as g from wide_base order by id;
 1  ¦  42.000000000000000000000000000000  ¦  POINT(2 2)  𝄀
 3  ¦  7.000000000000000000000000000000  ¦  POINT(3 3)
 create table pick_year_base(y year primary key, v int);
-insert into pick_year_base values (2024, 1), (2025, 2);
+insert into pick_year_base values (2024, 1);
 data branch create table pick_year_dst from pick_year_base;
 data branch create table pick_year_src from pick_year_base;
-update pick_year_src set v = 20250 where y = 2025;
+insert into pick_year_src values (2025, 20250);
 data branch pick pick_year_src into pick_year_dst keys('2025') when conflict accept;
 select y, v from pick_year_dst order by y;
 ➤ y[91,2147483647,0]  ¦  v[4,32,0]  𝄀

--- a/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.sql
@@ -65,10 +65,10 @@ select id, cast(b as int) as bit_i, u8, u16, u32, u64, y, e from wide_base order
 select id, d256, st_astext(g) as g from wide_base order by id;
 
 create table pick_year_base(y year primary key, v int);
-insert into pick_year_base values (2024, 1), (2025, 2);
+insert into pick_year_base values (2024, 1);
 data branch create table pick_year_dst from pick_year_base;
 data branch create table pick_year_src from pick_year_base;
-update pick_year_src set v = 20250 where y = 2025;
+insert into pick_year_src values (2025, 20250);
 data branch pick pick_year_src into pick_year_dst keys('2025') when conflict accept;
 select y, v from pick_year_dst order by y;
 drop database br_matrix_types;

--- a/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.sql
@@ -21,6 +21,7 @@ create table wide_base(
   bl blob,
   dl datalink,
   g geometry,
+  g32 geometry32,
   vf vecf64(3)
 );
 
@@ -28,11 +29,13 @@ insert into wide_base values
   (1, b'101', 250, 65000, 4000000000, 9000000000000000000,
    cast('12345678901234567890123456789012345.123456789012345678901234567890' as decimal(65,30)),
    2024, '6d1b1f73-2dbf-11ed-940f-000c29847904', 'ab', x'01020304',
-   'red', 'blob-base', 'file:///tmp/mo_branch_type_base.csv', 'POINT(1 1)', '[1.1,2.2,3.3]'),
+   'red', 'blob-base', 'file:///tmp/mo_branch_type_base.csv', 'POINT(1 1)',
+   cast('POINT(1 1)' as geometry32), '[1.1,2.2,3.3]'),
   (2, b'010', 1, 2, 3, 4,
    cast('-0.000000000000000000000000000001' as decimal(65,30)),
    1999, 'ad9f809f-2dbd-11ed-940f-000c29847904', 'cd', x'05060708',
-   'blue', 'blob-two', 'file:///tmp/mo_branch_type_two.csv', 'LINESTRING(0 0,1 1)', '[4.4,5.5,6.6]');
+   'blue', 'blob-two', 'file:///tmp/mo_branch_type_two.csv', 'LINESTRING(0 0,1 1)',
+   cast('LINESTRING(0 0,1 1)' as geometry32), '[4.4,5.5,6.6]');
 
 data branch create table wide_branch from wide_base;
 update wide_branch set
@@ -49,20 +52,63 @@ update wide_branch set
   e = 'green',
   bl = 'blob-updated',
   dl = 'file:///tmp/mo_branch_type_updated.csv',
-g = st_geomfromtext('POINT(2 2)'),
+  g = st_geomfromtext('POINT(2 2)'),
+  g32 = cast('POINT(2 2)' as geometry32),
   vf = '[7.7,8.8,9.9]'
 where id = 1;
 insert into wide_branch values
   (3, b'001', 2, 3, 4, 5,
    cast('7.000000000000000000000000000000' as decimal(65,30)),
    2000, '3ddf7b28-2dba-11ed-940f-000c29847904', 'gh', x'0d0e0f10',
-   'red', 'blob-new', 'file:///tmp/mo_branch_type_new.csv', 'POINT(3 3)', '[0.1,0.2,0.3]');
+   'red', 'blob-new', 'file:///tmp/mo_branch_type_new.csv', 'POINT(3 3)',
+   cast('POINT(3 3)' as geometry32), '[0.1,0.2,0.3]');
 delete from wide_branch where id = 2;
 data branch diff wide_branch against wide_base output summary;
 data branch merge wide_branch into wide_base;
 select count(*) as wide_rows from wide_base;
 select id, cast(b as int) as bit_i, u8, u16, u32, u64, y, e from wide_base order by id;
-select id, d256, st_astext(g) as g from wide_base order by id;
+select id, d256, st_astext(g) as g, st_astext(g32) as g32 from wide_base order by id;
+
+-- Concurrent GEOMETRY32 updates must reach row conflict comparison instead of
+-- failing type dispatch with unsupported type 68.
+create table geometry32_base(
+  id int primary key,
+  g geometry32,
+  p point32,
+  geog geography32,
+  g3857 geometry32 srid 3857
+);
+insert into geometry32_base values (
+  1,
+  cast('POINT(1 1)' as geometry32),
+  cast(st_point32(1, 1) as point32),
+  cast('POINT(1 1)' as geography32),
+  st_geomfromtext('POINT(1 1)', 3857)
+);
+data branch create table geometry32_branch from geometry32_base;
+update geometry32_base set
+  g = cast('POINT(2 2)' as geometry32),
+  p = cast(st_point32(2, 2) as point32),
+  geog = cast('POINT(2 2)' as geography32),
+  g3857 = st_geomfromtext('POINT(2 2)', 3857)
+where id = 1;
+update geometry32_branch set
+  g = cast('POINT(3 3)' as geometry32),
+  p = cast(st_point32(3, 3) as point32),
+  geog = cast('POINT(3 3)' as geography32),
+  g3857 = st_geomfromtext('POINT(3 3)', 3857)
+where id = 1;
+data branch diff geometry32_branch against geometry32_base output summary;
+data branch merge geometry32_branch into geometry32_base;
+data branch merge geometry32_branch into geometry32_base when conflict accept;
+select id,
+  st_astext(g) as g,
+  st_astext(p) as p,
+  st_astext(geog) as geog,
+  st_srid(geog) as geog_srid,
+  st_astext(g3857) as g3857,
+  st_srid(g3857) as g3857_srid
+from geometry32_base order by id;
 
 create table pick_year_base(y year primary key, v int);
 insert into pick_year_base values (2024, 1);

--- a/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_matrix_coverage.sql
@@ -35,7 +35,6 @@ insert into wide_base values
    'blue', 'blob-two', 'file:///tmp/mo_branch_type_two.csv', 'LINESTRING(0 0,1 1)', '[4.4,5.5,6.6]');
 
 data branch create table wide_branch from wide_base;
--- @bvt:issue#24924
 update wide_branch set
   b = b'111',
   u8 = 251,
@@ -50,7 +49,7 @@ update wide_branch set
   e = 'green',
   bl = 'blob-updated',
   dl = 'file:///tmp/mo_branch_type_updated.csv',
-  g = 'POINT(2 2)',
+g = st_geomfromtext('POINT(2 2)'),
   vf = '[7.7,8.8,9.9]'
 where id = 1;
 insert into wide_branch values
@@ -59,10 +58,19 @@ insert into wide_branch values
    2000, '3ddf7b28-2dba-11ed-940f-000c29847904', 'gh', x'0d0e0f10',
    'red', 'blob-new', 'file:///tmp/mo_branch_type_new.csv', 'POINT(3 3)', '[0.1,0.2,0.3]');
 delete from wide_branch where id = 2;
+data branch diff wide_branch against wide_base output summary;
 data branch merge wide_branch into wide_base;
 select count(*) as wide_rows from wide_base;
 select id, cast(b as int) as bit_i, u8, u16, u32, u64, y, e from wide_base order by id;
--- @bvt:issue
+select id, d256, st_astext(g) as g from wide_base order by id;
+
+create table pick_year_base(y year primary key, v int);
+insert into pick_year_base values (2024, 1), (2025, 2);
+data branch create table pick_year_dst from pick_year_base;
+data branch create table pick_year_src from pick_year_base;
+update pick_year_src set v = 20250 where y = 2025;
+data branch pick pick_year_src into pick_year_dst keys('2025') when conflict accept;
+select y, v from pick_year_dst order by y;
 drop database br_matrix_types;
 
 -- Case 2: core column constraints remain effective on a branch.
@@ -106,11 +114,9 @@ data branch create table clustered_branch from clustered_base;
 update clustered_branch set payload = 'new' where tenant = 1 and seq = 2;
 insert into clustered_branch(tenant, payload) values (3, 'default-seq');
 delete from clustered_branch where tenant = 2;
--- @bvt:issue#24924
 data branch merge clustered_branch into clustered_base;
 select count(*) as clustered_rows from clustered_base;
 select tenant, seq, payload from clustered_base order by tenant, seq;
--- @bvt:issue
 drop database br_matrix_constraints;
 
 -- Case 3: representative table types.
@@ -132,17 +138,19 @@ data branch create table part_branch from part_base;
 update part_branch set val = val + 1 where id = 11;
 insert into part_branch values (2, 20, 'new-p0'), (21, 210, 'new-p1');
 delete from part_branch where id = 12;
--- @bvt:issue#24924
 data branch merge part_branch into part_base;
 select id, val, note from part_base order by id;
--- @bvt:issue
 
 create table view_base(id int primary key, val int);
 insert into view_base values (1, 10), (2, 20), (3, 30);
 create view v_active as select id, val from view_base where val >= 20;
+create table view_identifier_base(br_matrix_tables int primary key, marker int);
+insert into view_identifier_base values (10, 100);
+create view v_identifier as select br_matrix_tables as br_matrix_tables from view_identifier_base;
 data branch create database br_matrix_tables_copy from br_matrix_tables;
 insert into view_base values (4, 40);
 select count(*) as copied_view_rows from br_matrix_tables_copy.v_active;
+select br_matrix_tables from br_matrix_tables_copy.v_identifier;
 insert into br_matrix_tables_copy.view_base values (5, 50);
 select count(*) as copied_view_rows_after_insert from br_matrix_tables_copy.v_active;
 
@@ -164,7 +172,6 @@ drop database br_matrix_tables;
 
 -- Case 4: quoted identifiers must not break data branch bookkeeping.
 drop database if exists br_matrix_quoted;
--- @bvt:issue#24924
 create database br_matrix_quoted;
 use br_matrix_quoted;
 
@@ -178,8 +185,10 @@ select count(*) as quoted_space_rows from `branch table`;
 create table `quote'src`(a int primary key, b varchar(20));
 insert into `quote'src` values (1, 'single-quote');
 data branch create table `quote'dst` from `quote'src`;
-select count(*) as quoted_apostrophe_rows from `quote'dst`;
+set @quote_sql = 'select count(*) as quoted_apostrophe_rows from `quote''dst`';
+prepare quote_stmt from @quote_sql;
+execute quote_stmt;
+deallocate prepare quote_stmt;
 
 use mo_catalog;
 drop database if exists br_matrix_quoted;
--- @bvt:issue

--- a/test/distributed/cases/git4data/branch/edge/branch_unhappy_path.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_unhappy_path.result
@@ -38,9 +38,6 @@ insert into single_pk values (1, 10), (2, 20);
 data branch create table single_left from single_pk;
 data branch create table single_right from single_pk;
 insert into single_right values (3, 30);
-data branch pick single_right into single_left;
--- @regex("requires a KEYS or BETWEEN SNAPSHOT clause", true)
-invalid input: DATA BRANCH PICK requires a KEYS or BETWEEN SNAPSHOT clause
 data branch pick single_right into single_left keys((3, 3));
 -- @regex("single-column primary key; use scalar values", true)
 invalid input: KEYS contains tuples but table has a single-column primary key; use scalar values
@@ -103,6 +100,6 @@ create view v_literal as select 'br_view_literal_src' as marker, a from t;
 data branch create database br_view_literal_copy from br_view_literal_src;
 select marker from br_view_literal_copy.v_literal;
 marker
-br_view_literal_copy
+br_view_literal_src
 drop database br_view_literal_copy;
 drop database br_view_literal_src;

--- a/test/distributed/cases/git4data/branch/edge/branch_unhappy_path.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_unhappy_path.sql
@@ -15,14 +15,10 @@ data branch create table missing_branch from missing_base;
 data branch create table br from base;
 -- @regex("column \"missing\" not found",true)
 data branch diff br against base columns (missing);
--- @bvt:issue#24924
 -- @regex("table \"missing_branch\" does not exist",true)
 data branch diff missing_branch against base;
--- @bvt:issue
--- @bvt:issue#24924
 -- @regex("table \"missing_base\" does not exist",true)
 data branch diff br against missing_base;
--- @bvt:issue
 
 alter table br add column c int default 0;
 -- @regex("schema is not equivalent",true)
@@ -41,18 +37,12 @@ insert into single_pk values (1, 10), (2, 20);
 data branch create table single_left from single_pk;
 data branch create table single_right from single_pk;
 insert into single_right values (3, 30);
--- @bvt:issue#24924
--- @regex("requires a KEYS or BETWEEN SNAPSHOT clause",true)
-data branch pick single_right into single_left;
--- @bvt:issue
 -- @regex("single-column primary key; use scalar values",true)
 data branch pick single_right into single_left keys((3, 3));
 -- @regex("KEYS subquery returned NULL",true)
 data branch pick single_right into single_left keys(select cast(null as int));
--- @bvt:issue#24924
 -- @regex("KEYS subquery returns 2 columns but table has a single-column primary key",true)
 data branch pick single_right into single_left keys(select a, b from single_right);
--- @bvt:issue
 create snapshot br_unhappy_single_sp for table br_unhappy single_left;
 -- @regex("destination snapshot option is not supported",true)
 data branch pick single_right into single_left{snapshot='br_unhappy_single_sp'} keys(3);
@@ -67,10 +57,8 @@ data branch pick comp_right into comp_left keys(3);
 -- @regex("KEYS tuple has 3 elements but composite primary key has 2 columns",true)
 data branch pick comp_right into comp_left keys((3, 3, 3));
 
--- @bvt:issue#24924
 -- @regex("snapshot 'missing_from' not found",true)
 data branch pick single_right into single_left between snapshot missing_from and missing_to keys(3);
--- @bvt:issue
 
 create table exists_base(a int primary key);
 create table exists_target(a int primary key);
@@ -103,8 +91,6 @@ create table t(a int primary key);
 insert into t values (1);
 create view v_literal as select 'br_view_literal_src' as marker, a from t;
 data branch create database br_view_literal_copy from br_view_literal_src;
--- @bvt:issue#24924
 select marker from br_view_literal_copy.v_literal;
--- @bvt:issue
 drop database br_view_literal_copy;
 drop database br_view_literal_src;

--- a/test/distributed/cases/pessimistic_transaction/clone/clone.result
+++ b/test/distributed/cases/pessimistic_transaction/clone/clone.result
@@ -879,7 +879,7 @@ select * from v1;
 a
 show create table v1;
 View    Create View    character_set_client    collation_connection
-v1    create view v1 as select * from t1;    utf8mb4    utf8mb4_general_ci
+v1    create view `v1` as select * from `t1`;    utf8mb4    utf8mb4_general_ci
 select * from v2;
 a    b    c
 use test09_table;
@@ -954,7 +954,7 @@ select * from v1;
 a
 show create table v1;
 View    Create View    character_set_client    collation_connection
-v1    create view v1 as select * from t1;    utf8mb4    utf8mb4_general_ci
+v1    create view `v1` as select * from `t1`;    utf8mb4    utf8mb4_general_ci
 select * from v2;
 a    b    c
 use test09_table;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24924

## What this PR does / why we need it:

Backports #25471 to `4.1-dev`.

This PR adds and fixes BVT coverage for data branch edge cases from #24924, then fixes the underlying failures found by those cases.

Root causes covered include unsafe clone SQL rewriting for string literals and quoted identifiers, unescaped internal SQL literals for apostrophe identifiers, missing data branch diff/merge/PICK support for decimal256/year/geometry/enum and other edge types, incomplete GEOMETRY32 comparison and SQL write-back support, partitioned table change collection panics, unstable PICK validation errors, and explicit transaction rejection for DATA BRANCH DIFF/MERGE.

GEOMETRY32 is now handled as varlena data in data branch comparisons. SQL write-back uses `st_geomfromtext(WKT[, SRID])` so generic GEOMETRY32, POINT32, GEOGRAPHY32, and explicitly SRID-constrained columns retain subtype validation, float32 WKB conversion, and SRID metadata. The BVT exercises diff, concurrent-update conflict detection, and `WHEN CONFLICT ACCEPT` merge for all four forms.

The changes also update `branch_matrix_coverage` and `branch_unhappy_path` expected results after checking that the generated results match the intended semantics. The invalid `DATA BRANCH PICK src INTO dst` grammar extension is removed; incomplete PICK syntax remains rejected by the parser.

4.1-specific adaptation:

- Includes the standalone AST database-remap module and its upstream unit-test suite required by clone-view rewriting. `4.1-dev` does not contain the session-level remap wiring from #25185, and this PR does not add that feature surface.
- Carries the current #25471 clone-view conflict resolution so identifiers are quoted for both user and system database view definitions.
- Keeps the decimal256/year dependency fixes because `4.1-dev` does not contain the corresponding main-branch refactors.
- Is rebased onto #25569 and reuses its shared binary/BLOB hex-literal formatter and tests; this PR only layers the remaining data-branch edge types on top.
- Adapts the GEOMETRY32 comparison fix to 4.1's monolithic comparison helper while preserving the same SQL write-back and BVT semantics as #25471.

Validation:

- `make build`
- `git diff --check upstream/4.1-dev...HEAD`
- `go test -count=1 ./pkg/frontend`
- `go vet ./pkg/frontend`
- Fresh `go build`, `go vet`, and `go test -count=1` for container/types, frontend, databranchutils, objectio/mergeutil, parser tree/mysql, sql/plan, sql/compile, and disttae
- Conservative CI coverage replay after rebasing: 230/288 changed blocks covered (79.86%, threshold 75%)
- No `@bvt:issue` / `@skip` tags in the three data-branch acceptance BVT files
- mo-tester `branch_matrix_coverage`: 108/108 passed, ignored: 0
- mo-tester `branch_unhappy_path`: 63/63 passed, ignored: 0
- mo-tester `branch_edge_cases`: 109/109 passed, ignored: 0
- mo-tester pessimistic clone suite: 614/614 passed, ignored: 0

## Review follow-up

Addresses XuPeng-SH's review of the clone-view AST rewrite.

- Rewrites the database component of fully-qualified column names, while preserving two-part table or CTE aliases and string literals.
- Traverses every relevant expression container: top-level SELECT ORDER BY and LIMIT, VALUES, aggregate ORDER BY, window partition, order and frame expressions, time windows, INSERT duplicate updates, UPDATE and DELETE ordering and limits, and nested subqueries.
- Adds table-driven coverage for qualified columns; top-level, aggregate and window ordering subqueries; CTE, UNION, nested SELECT and JOIN; alias and literal negatives; and UPDATE and DELETE ordering paths. An end-to-end clone-view test verifies quoted output.
- Also completes the 4.1 Decimal256 PICK segmentation path already present on main: exact 256-bit gap calculation restores adaptive ZoneMap splitting instead of falling back to count-only segmentation.

Follow-up validation:

- go test with the MatrixOne CGo library paths for the remap, clone-view, Decimal256 gap, and numeric-type tests
- go build and go vet for pkg/frontend
- git diff --check
