### PR TITLE
fix(txn): finalize unknown commits without rollback GC

### DIFF
--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -592,6 +592,11 @@ func (th *TxnHandler) commitUnsafe(execCtx *ExecCtx) error {
 		}
 		execCtx.ses.updateLastCommitTS(commitTs)
 		if commitResultUnknown {
+			// ErrTxnUnknown is terminal for this frontend handle. The operator
+			// has already finalized its workspace non-destructively; retaining it
+			// lets later rollback/connection cleanup reach destructive cleanup.
+			th.invalidateTxnUnsafe()
+			execCtx.ses.SetTxnId(dumpUUID[:])
 			return err
 		}
 	}

--- a/pkg/frontend/txn_test.go
+++ b/pkg/frontend/txn_test.go
@@ -786,8 +786,8 @@ func Test_commit(t *testing.T) {
 	})
 }
 
-func TestCommitTxnUnknownPreservesTxnOperatorForLaterCleanup(t *testing.T) {
-	convey.Convey("commit ErrTxnUnknown keeps txn operator reachable", t, func() {
+func TestCommitTxnUnknownInvalidatesTxnOperator(t *testing.T) {
+	convey.Convey("commit ErrTxnUnknown invalidates the frontend txn operator", t, func() {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -818,7 +818,8 @@ func TestCommitTxnUnknownPreservesTxnOperatorForLaterCleanup(t *testing.T) {
 		convey.So(moerr.IsMoErrCode(err, moerr.ErrTxnUnknown), convey.ShouldBeTrue)
 		convey.So(txnOp.commitCalls, convey.ShouldEqual, 1)
 		convey.So(txnOp.rollbackCalls, convey.ShouldEqual, 0)
-		convey.So(ses.GetTxnHandler().GetTxn(), convey.ShouldEqual, txnOp)
+		convey.So(ses.GetTxnHandler().GetTxn(), convey.ShouldBeNil)
+		convey.So(ses.GetTxnHandler().InActiveTxn(), convey.ShouldBeFalse)
 	})
 }
 

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -300,7 +300,7 @@ type txnOperator struct {
 		createAt             time.Time
 		commitAt             time.Time
 		createTs             timestamp.Timestamp
-		cannotCleanWorkspace bool
+		cannotCleanWorkspace atomic.Bool
 		workspace            Workspace
 		commitCounter        counter
 		rollbackCounter      counter
@@ -538,7 +538,7 @@ func (tc *txnOperator) initReset() {
 	tc.reset.createAt = time.Time{}
 	tc.reset.commitAt = time.Time{}
 	tc.reset.createTs = timestamp.Timestamp{}
-	tc.reset.cannotCleanWorkspace = false
+	tc.reset.cannotCleanWorkspace.Store(false)
 	tc.reset.workspace = nil
 	tc.reset.commitCounter = counter{}
 	tc.reset.rollbackCounter = counter{}
@@ -912,7 +912,7 @@ func (tc *txnOperator) Rollback(ctx context.Context) (err error) {
 	txnMeta := tc.getTxnMeta(false)
 	util.LogTxnRollback(tc.logger, txnMeta)
 
-	if tc.reset.workspace != nil && !tc.reset.cannotCleanWorkspace {
+	if tc.reset.workspace != nil && !tc.reset.cannotCleanWorkspace.Load() {
 		if err = tc.reset.workspace.Rollback(ctx); err != nil {
 			tc.logger.Error("rollback workspace failed",
 				util.TxnIDField(txnMeta), zap.Error(err))
@@ -1145,6 +1145,7 @@ func (tc *txnOperator) doWrite(
 				}
 				if err != nil {
 					if moerr.IsMoErrCode(err, moerr.ErrTxnUnknown) {
+						tc.reset.cannotCleanWorkspace.Store(true)
 						tc.reset.workspace.FinalizeCommitWithUnknownResult(ctx)
 						return
 					}
@@ -1160,6 +1161,12 @@ func (tc *txnOperator) doWrite(
 		}
 		tc.mu.Lock()
 		defer func() {
+			// Set the guard before releasing the operator lock. A later Rollback
+			// must not delete objects when the Commit result is unknown and TN
+			// may already have committed them.
+			if moerr.IsMoErrCode(err, moerr.ErrTxnUnknown) {
+				tc.reset.cannotCleanWorkspace.Store(true)
+			}
 			if err != nil && tc.reset.commitErr == nil {
 				tc.reset.commitErr = err
 			}
@@ -1633,7 +1640,10 @@ func (tc *txnOperator) needUnlockLocked() bool {
 func (tc *txnOperator) closeLocked(ctx context.Context) {
 	if !tc.mu.closed {
 		tc.mu.closed = true
-		if tc.reset.commitErr != nil {
+		// ErrTxnUnknown only describes the CN's observation of Commit. TN may
+		// already have committed, so do not rewrite the status to Aborted.
+		if tc.reset.commitErr != nil &&
+			!moerr.IsMoErrCode(tc.reset.commitErr, moerr.ErrTxnUnknown) {
 			tc.mu.txn.Status = txn.TxnStatus_Aborted
 		}
 		tc.triggerEventLocked(

--- a/pkg/txn/client/operator_test.go
+++ b/pkg/txn/client/operator_test.go
@@ -304,7 +304,7 @@ func TestCommitRollsBackPreparedWorkspaceAfterCommitSendError(t *testing.T) {
 	})
 }
 
-func TestCommitKeepsPreparedWorkspaceAfterTxnUnknown(t *testing.T) {
+func TestCommitFinalizesPreparedWorkspaceWithoutRollbackAfterTxnUnknown(t *testing.T) {
 	runOperatorTests(t, func(ctx context.Context, tc *txnOperator, ts *testTxnSender) {
 		ws := &trackingWorkspace{
 			commitRequests: []txn.TxnRequest{newTNRequest(1, 1)},
@@ -320,7 +320,14 @@ func TestCommitKeepsPreparedWorkspaceAfterTxnUnknown(t *testing.T) {
 		require.Zero(t, ws.finalizeCount)
 		require.Equal(t, 1, ws.unknownCount)
 		require.Zero(t, ws.rollbackCount)
-		require.Equal(t, txn.TxnStatus_Aborted, tc.mu.txn.Status)
+		require.Equal(t, txn.TxnStatus_Active, tc.mu.txn.Status)
+		require.True(t, tc.reset.cannotCleanWorkspace.Load())
+
+		// A retained direct handle must still be unable to run workspace
+		// rollback after an unknown finalization.
+		require.NoError(t, tc.Rollback(ctx))
+		require.Zero(t, ws.rollbackCount)
+		require.Equal(t, txn.TxnStatus_Active, tc.mu.txn.Status)
 	})
 }
 

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -270,9 +270,9 @@ type Workspace interface {
 
 	Commit(ctx context.Context) ([]txn.TxnRequest, error)
 	FinalizeCommit(ctx context.Context)
-	// FinalizeCommitWithUnknownResult is called after the commit request may
-	// have reached TN, but the final commit result is unknown. It must not run
-	// rollback cleanup, because the transaction may have committed.
+	// FinalizeCommitWithUnknownResult releases CN-local resources after a Commit
+	// request may have reached TN but no final response was received. It must
+	// not perform rollback object GC, because TN may have committed.
 	FinalizeCommitWithUnknownResult(ctx context.Context)
 	Rollback(ctx context.Context) error
 

--- a/pkg/txn/rpc/sender.go
+++ b/pkg/txn/rpc/sender.go
@@ -174,6 +174,10 @@ func (s *sender) Send(ctx context.Context, requests []txn.TxnRequest) (*SendResu
 	return sr, nil
 }
 
+func newTxnUnknownError(ctx context.Context, txnID []byte) error {
+	return moerr.NewTxnUnknown(ctx, hex.EncodeToString(txnID))
+}
+
 func (s *sender) doSend(ctx context.Context, request txn.TxnRequest) (txn.TxnResponse, error) {
 	ctx, span := trace.Debug(ctx, "sender.doSend")
 	defer span.End()
@@ -235,17 +239,19 @@ func (s *sender) doSend(ctx context.Context, request txn.TxnRequest) (txn.TxnRes
 	defer f.Close()
 	v, err := f.Get()
 	if err != nil {
+		// Once morpc accepted a Commit and returned a Future, a transport or
+		// response-wait error cannot prove whether TN applied it. This includes a
+		// context deadline after the request was written, not only EOF/reset.
+		if request.Method == txn.TxnMethod_Commit {
+			return txn.TxnResponse{}, newTxnUnknownError(ctx, request.Txn.ID)
+		}
 		// if the error is io.EOF or "connection is reset by peer",
 		// means the connection to TN node is ended, but no response
 		// is returned from TN txn service. In this case, the result
 		// of the txn status is unknown.
 		if errors.Is(err, io.EOF) ||
 			strings.Contains(err.Error(), "connection reset by peer") {
-			return txn.TxnResponse{},
-				moerr.NewTxnUnknown(
-					ctx,
-					hex.EncodeToString(request.Txn.ID),
-				)
+			return txn.TxnResponse{}, newTxnUnknownError(ctx, request.Txn.ID)
 		}
 		return txn.TxnResponse{}, err
 	}

--- a/pkg/txn/rpc/sender_test.go
+++ b/pkg/txn/rpc/sender_test.go
@@ -663,6 +663,44 @@ func TestSendWithTxnUnknown(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestSendCommitDeadlineReturnsTxnUnknown(t *testing.T) {
+	s := newTestTxnServer(t, testTN2Addr, nil)
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+	s.RegisterRequestHandler(func(
+		context.Context,
+		morpc.RPCMessage,
+		uint64,
+		morpc.ClientSession,
+	) error {
+		// Accept the request but intentionally do not send a response.
+		return nil
+	})
+
+	sd, err := NewSender(Config{}, newTestRuntime(newTestClock(), nil))
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, sd.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	txnMeta := txn.TxnMeta{
+		ID: []byte("commit-deadline"),
+		TNShards: []metadata.TNShard{{
+			Address: testTN2Addr,
+		}},
+	}
+	result, err := sd.Send(ctx, []txn.TxnRequest{{
+		Method:        txn.TxnMethod_Commit,
+		Txn:           txnMeta,
+		CommitRequest: &txn.TxnCommitRequest{},
+	}})
+	assert.Nil(t, result)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrTxnUnknown))
+}
+
 func newTestTxnServer(
 	t assert.TestingT,
 	addr string,

--- a/pkg/vm/engine/disttae/ccpr_txn_cache_extra_test.go
+++ b/pkg/vm/engine/disttae/ccpr_txn_cache_extra_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 )
 
@@ -133,6 +134,7 @@ func TestCCPRTxnCache_OnTxnUnknownResultRemovesTrackingWithoutGC(t *testing.T) {
 
 func TestTransactionFinalizeCommitUnknownCleansCCPRCache(t *testing.T) {
 	ctx := context.Background()
+	colexec.NewServer(nil)
 	fs := newCleanFS(t)
 	gcPool, err := ants.NewPool(2)
 	require.NoError(t, err)

--- a/pkg/vm/engine/disttae/table_meta_reader_test.go
+++ b/pkg/vm/engine/disttae/table_meta_reader_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/panjf2000/ants/v2"
@@ -340,8 +341,9 @@ func TestCloneTxnTablesInVainGCKeepsLiveTxnLocalSharedObject(t *testing.T) {
 	liveBat.Clean(proc.Mp())
 }
 
-func TestCloneTxnUnknownCommitPreservesRollbackCleanup(t *testing.T) {
+func TestCloneTxnUnknownCommitReleasesLocalStateWithoutObjectGC(t *testing.T) {
 	ctx := context.Background()
+	colexec.NewServer(nil)
 	fs := newCleanFS(t)
 
 	gcPool, err := ants.NewPool(1)
@@ -379,14 +381,11 @@ func TestCloneTxnUnknownCommitPreservesRollbackCleanup(t *testing.T) {
 	})
 
 	txn.FinalizeCommitWithUnknownResult(ctx)
+	require.True(t, txn.removed)
 	require.NotNil(t, txn.writes[0].bat)
-	require.True(t, txn.engine.cloneTxnCache.IsTxnLocalSharedFile(txn.op.Txn().ID, name))
-	require.NoError(t, txn.gcObjsByIdxRange(0, 0, cloneGCTxnRollback))
-	require.Eventually(t, func() bool {
-		return !objectExistsInFS(ctx, fs, name)
-	}, time.Second, 10*time.Millisecond)
-	txn.writes[0].bat.Clean(proc.Mp())
-	txn.writes[0].bat = nil
+	require.Empty(t, txn.writes[0].bat.Vecs)
+	require.False(t, txn.engine.cloneTxnCache.IsTxnLocalSharedFile(txn.op.Txn().ID, name))
+	require.True(t, objectExistsInFS(ctx, fs, name))
 }
 
 func cloneObjectStatsBatchForTest(

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2151,9 +2151,10 @@ func (txn *Transaction) FinalizeCommitWithUnknownResult(context.Context) {
 	if txn.isCCPRTxn && txn.engine.ccprTxnCache != nil {
 		txn.engine.ccprTxnCache.OnTxnUnknownResult(txn.op.Txn().ID)
 	}
-	// Keep workspace/object-stat metadata intact. If the outer commit result is
-	// later known to be aborted, Rollback still needs the metadata to GC
-	// txn-local CN objects. If it actually committed, rollback GC must not run.
+	// The Commit may have reached TN. delTransaction releases only CN-local
+	// state and intentionally does not run gcObjsByIdxRange or delete shared
+	// object-storage data.
+	txn.delTransaction()
 }
 
 func (txn *Transaction) transferTombstonesByStatement(


### PR DESCRIPTION
## Summary

- make ErrTxnUnknown a terminal, non-destructive workspace finalization path
- classify every single-request Commit response/transport failure, including context deadline, as ErrTxnUnknown
- release CN-local batches, caches, worker pools, clone tracking, and workspace quota through delTransaction
- atomically fence any later Rollback from running workspace object GC
- invalidate the frontend transaction handle after returning ErrTxnUnknown
- keep the transaction outcome unknown instead of rewriting it to Aborted

## Safety invariant

A missing Commit response does not prove abort. This PR never deletes transaction objects on the unknown path because TN may already have committed metadata that references them.

## Known remaining gaps

If TN actually aborted and never checkpointed a CN-created object, existing TN checkpoint GC cannot discover it. Such objects can remain indefinitely and accumulate until a durable unknown-object candidate manifest and TN consumer are implemented. This PR is the immediate data-safety and CN-resource fix, not complete orphan-object lifecycle closure.

The multi-request WriteAndCommit sender path does not yet classify every response failure as unknown. No production caller was found. Fixing that API safely needs stream-generation or in-flight fencing so a late response cannot be delivered after a pooled stream is reused.

## Tests

- full pkg/txn/rpc, pkg/txn/client, pkg/frontend, and pkg/vm/engine/disttae
- repeated Commit deadline and EOF/reset classification tests
- race tests for response-deadline classification and unknown finalization followed by direct rollback

Fixes #25198