### PR TITLE
fix(lockservice): defer active txn retries to next sweep

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -186,7 +186,28 @@ func (l *lockTableAllocator) FinishCommit(serviceID string, txnID []byte) {
 }
 
 func (l *lockTableAllocator) AddInvalidService(serviceID string) {
-	l.inactiveService.Store(serviceID, time.Now())
+	l.markInactiveService(serviceID)
+}
+
+func (l *lockTableAllocator) markInactiveService(serviceID string) {
+	// Retention starts at the first failure in the current disconnected epoch.
+	// Repeated probes must not extend it forever. ResumeInvalidCN deletes the
+	// marker, so a later disconnect naturally starts a new epoch.
+	l.inactiveService.LoadOrStore(serviceID, time.Now())
+}
+
+func (l *lockTableAllocator) expireInactiveService(
+	serviceID string,
+	inactiveAt time.Time,
+	now time.Time,
+	retention time.Duration,
+) bool {
+	if now.Sub(inactiveAt) <= retention {
+		return false
+	}
+	// Only delete the epoch observed by the expiry sweep. The service may have
+	// resumed and disconnected again after the marker was loaded.
+	return l.inactiveService.CompareAndDelete(serviceID, inactiveAt)
 }
 
 func (l *lockTableAllocator) HasInvalidService(serviceID string) bool {
@@ -651,13 +672,18 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 			})
 			l.ctlMu.RUnlock()
 
+			now := time.Now()
 			l.inactiveService.Range(func(key, value any) bool {
-				if time.Since(value.(time.Time)) > removeDisconnectDuration {
-					sid := key.(string)
+				sid := key.(string)
+				if l.expireInactiveService(
+					sid,
+					value.(time.Time),
+					now,
+					removeDisconnectDuration,
+				) {
 					l.logger.Error("remove inactive service",
 						zap.String("serviceID", sid))
 					expiredUnknownServices[sid] = struct{}{}
-					l.inactiveService.Delete(key)
 				}
 				return true
 			})
@@ -710,7 +736,7 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 				l.logger.Error("get active txn failed",
 					zap.String("serviceID", sid),
 					zap.Error(err))
-				l.inactiveService.Store(sid, time.Now())
+				l.markInactiveService(sid)
 				unknownServices = append(unknownServices, sid)
 			}
 

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -48,10 +48,15 @@ type lockTableAllocator struct {
 	address         string
 	server          Server
 	client          Client
-	inactiveService sync.Map // lock service id -> inactive time
-	ctl             sync.Map // lock service id -> *commitCtl
-	ctlMu           sync.RWMutex
-	allocatorID     string
+	// inactiveService contains *inactiveServiceEpoch values. The mutex makes an
+	// expiry decision and the corresponding commit-state cleanup one lifecycle
+	// transition: a resumed service that disconnects again must start a new epoch
+	// before an older one can be expired.
+	inactiveService   sync.Map // lock service id -> *inactiveServiceEpoch
+	inactiveServiceMu sync.Mutex
+	ctl               sync.Map // lock service id -> *commitCtl
+	ctlMu             sync.RWMutex
+	allocatorID       string
 	// version is the allocator process epoch. It is set once when the
 	// allocator is constructed; production code must not mutate it at runtime.
 	version uint64
@@ -69,6 +74,10 @@ type lockTableAllocator struct {
 }
 
 type AllocatorOption func(*lockTableAllocator)
+
+type inactiveServiceEpoch struct {
+	inactiveAt time.Time
+}
 
 // NewLockTableAllocator create a memory based lock table allocator.
 func NewLockTableAllocator(
@@ -193,21 +202,33 @@ func (l *lockTableAllocator) markInactiveService(serviceID string) {
 	// Retention starts at the first failure in the current disconnected epoch.
 	// Repeated probes must not extend it forever. ResumeInvalidCN deletes the
 	// marker, so a later disconnect naturally starts a new epoch.
-	l.inactiveService.LoadOrStore(serviceID, time.Now())
+	l.inactiveServiceMu.Lock()
+	defer l.inactiveServiceMu.Unlock()
+	l.inactiveService.LoadOrStore(serviceID, &inactiveServiceEpoch{
+		inactiveAt: time.Now(),
+	})
 }
 
 func (l *lockTableAllocator) expireInactiveService(
 	serviceID string,
-	inactiveAt time.Time,
+	epoch *inactiveServiceEpoch,
 	now time.Time,
 	retention time.Duration,
 ) bool {
-	if now.Sub(inactiveAt) <= retention {
+	if now.Sub(epoch.inactiveAt) <= retention {
 		return false
 	}
 	// Only delete the epoch observed by the expiry sweep. The service may have
 	// resumed and disconnected again after the marker was loaded.
-	return l.inactiveService.CompareAndDelete(serviceID, inactiveAt)
+	l.inactiveServiceMu.Lock()
+	defer l.inactiveServiceMu.Unlock()
+	return l.inactiveService.CompareAndDelete(serviceID, epoch)
+}
+
+func (l *lockTableAllocator) resumeInactiveService(serviceID string) {
+	l.inactiveServiceMu.Lock()
+	defer l.inactiveServiceMu.Unlock()
+	l.inactiveService.Delete(serviceID)
 }
 
 func (l *lockTableAllocator) HasInvalidService(serviceID string) bool {
@@ -663,7 +684,7 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 			var unknownServices []string
 			activeTxnMap := make(map[string]map[string]struct{})
 			cleanupWatermarks := make(map[string]uint64)
-			expiredUnknownServices := make(map[string]struct{})
+			expiredInactiveEpochs := make(map[string]*inactiveServiceEpoch)
 
 			l.ctlMu.RLock()
 			l.ctl.Range(func(key, value any) bool {
@@ -673,20 +694,16 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 			l.ctlMu.RUnlock()
 
 			now := time.Now()
+			l.inactiveServiceMu.Lock()
 			l.inactiveService.Range(func(key, value any) bool {
 				sid := key.(string)
-				if l.expireInactiveService(
-					sid,
-					value.(time.Time),
-					now,
-					removeDisconnectDuration,
-				) {
-					l.logger.Error("remove inactive service",
-						zap.String("serviceID", sid))
-					expiredUnknownServices[sid] = struct{}{}
+				epoch := value.(*inactiveServiceEpoch)
+				if now.Sub(epoch.inactiveAt) > removeDisconnectDuration {
+					expiredInactiveEpochs[sid] = epoch
 				}
 				return true
 			})
+			l.inactiveServiceMu.Unlock()
 
 			for _, sid := range services {
 				if ctx.Err() != nil {
@@ -724,10 +741,10 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 					l.logger.Error("retry to check service if alive on next sweep",
 						zap.String("serviceID", sid),
 						zap.Error(err))
-					if _, expired := expiredUnknownServices[sid]; expired {
+					if _, expired := expiredInactiveEpochs[sid]; expired {
 						// The disconnected-service retention already elapsed before this
-						// probe. Preserve the existing expiry policy even if the current
-						// probe failed with a retryable error.
+						// probe. The final cleanup rechecks that this exact epoch is still
+						// current before applying the expiry policy.
 						unknownServices = append(unknownServices, sid)
 					}
 					continue
@@ -738,6 +755,20 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 					zap.Error(err))
 				l.markInactiveService(sid)
 				unknownServices = append(unknownServices, sid)
+			}
+
+			// Keep expiry and cleanup in the same inactive-service lifecycle
+			// transition. In particular, if the service resumed and disconnected
+			// again while a probe was in flight, its new epoch prevents cleanup of
+			// tombstones retained for that disconnect.
+			l.inactiveServiceMu.Lock()
+			expiredUnknownServices := make(map[string]struct{}, len(expiredInactiveEpochs))
+			for sid, epoch := range expiredInactiveEpochs {
+				if l.inactiveService.CompareAndDelete(sid, epoch) {
+					l.logger.Error("remove inactive service",
+						zap.String("serviceID", sid))
+					expiredUnknownServices[sid] = struct{}{}
+				}
 			}
 
 			l.ctlMu.Lock()
@@ -755,6 +786,7 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 				l.cleanCtlLocked(sid, activeTxns, false, cleanupWatermarks[sid])
 			}
 			l.ctlMu.Unlock()
+			l.inactiveServiceMu.Unlock()
 
 			timer.Reset(l.keepBindTimeout * 2)
 		}
@@ -1088,7 +1120,7 @@ func (l *lockTableAllocator) handleResumeInvalidCN(
 	resp *pb.Response,
 	cs morpc.ClientSession,
 ) {
-	l.inactiveService.Delete(req.ResumeInvalidCN.ServiceID)
+	l.resumeInactiveService(req.ResumeInvalidCN.ServiceID)
 	writeResponse(l.logger, cancel, resp, nil, cs)
 }
 

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -63,7 +63,7 @@ type lockTableAllocator struct {
 
 	// for test
 	options struct {
-		getActiveTxnFunc         func(sid string) (bool, [][]byte, error)
+		getActiveTxnFunc         func(context.Context, string) (bool, [][]byte, error)
 		removeDisconnectDuration time.Duration
 	}
 }
@@ -601,8 +601,8 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 
 	getActiveTxnFunc := l.options.getActiveTxnFunc
 	if getActiveTxnFunc == nil {
-		getActiveTxnFunc = func(sid string) (bool, [][]byte, error) {
-			ctx, cancel := context.WithTimeoutCause(context.Background(), defaultRPCTimeout, moerr.CauseCleanCommitState)
+		getActiveTxnFunc = func(ctx context.Context, sid string) (bool, [][]byte, error) {
+			ctx, cancel := context.WithTimeoutCause(ctx, defaultRPCTimeout, moerr.CauseCleanCommitState)
 			defer cancel()
 
 			req := acquireRequest()
@@ -662,48 +662,50 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 				return true
 			})
 
-			retryCount := math.MaxInt - 1
-
 			for _, sid := range services {
-				for i := 0; i < retryCount+1; i++ {
-					// The active-txn response can only classify control states that
-					// existed before this request started.
-					watermark, ok := l.getCtlGeneration(sid)
-					if !ok {
-						break
-					}
-					cleanupWatermarks[sid] = watermark
-					valid, actives, err := getActiveTxnFunc(sid)
-					if err == nil {
-						if !valid {
-							invalidServices = append(invalidServices, sid)
-						} else {
-							m := make(map[string]struct{}, len(actives))
-							for _, txn := range actives {
-								m[util.UnsafeBytesToString(txn)] = struct{}{}
-							}
-							activeTxnMap[sid] = m
-						}
-					} else if isRetryError(err) {
-						// retry err
-						l.logger.Error("retry to check service if alive",
-							zap.String("serviceID", sid),
-							zap.Error(err))
-						if i < retryCount {
-							continue
-						}
-						l.inactiveService.Store(sid, time.Now())
-						unknownServices = append(unknownServices, sid)
-					} else {
-						// is not retry err
-						l.logger.Error("get active txn failed",
-							zap.String("serviceID", sid),
-							zap.Error(err))
-						l.inactiveService.Store(sid, time.Now())
-						unknownServices = append(unknownServices, sid)
-					}
-					break
+				if ctx.Err() != nil {
+					return
 				}
+
+				// The active-txn response can only classify control states that
+				// existed before this request started.
+				watermark, ok := l.getCtlGeneration(sid)
+				if !ok {
+					continue
+				}
+				cleanupWatermarks[sid] = watermark
+
+				valid, actives, err := getActiveTxnFunc(ctx, sid)
+				if err == nil {
+					if !valid {
+						invalidServices = append(invalidServices, sid)
+					} else {
+						m := make(map[string]struct{}, len(actives))
+						for _, txn := range actives {
+							m[util.UnsafeBytesToString(txn)] = struct{}{}
+						}
+						activeTxnMap[sid] = m
+					}
+					continue
+				}
+
+				if ctx.Err() != nil {
+					return
+				}
+				if isRetryError(err) {
+					// Keep the commit state and retry on the next timer sweep. Retrying
+					// this service in-place can starve all later services forever.
+					l.logger.Error("retry to check service if alive on next sweep",
+						zap.String("serviceID", sid),
+						zap.Error(err))
+					continue
+				}
+
+				l.logger.Error("get active txn failed",
+					zap.String("serviceID", sid),
+					zap.Error(err))
+				l.inactiveService.Store(sid, time.Now())
+				unknownServices = append(unknownServices, sid)
 			}
 
 			l.ctlMu.Lock()

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -698,6 +698,12 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 					l.logger.Error("retry to check service if alive on next sweep",
 						zap.String("serviceID", sid),
 						zap.Error(err))
+					if _, expired := expiredUnknownServices[sid]; expired {
+						// The disconnected-service retention already elapsed before this
+						// probe. Preserve the existing expiry policy even if the current
+						// probe failed with a retryable error.
+						unknownServices = append(unknownServices, sid)
+					}
 					continue
 				}
 

--- a/pkg/lockservice/lock_table_allocator_stale_snapshot_test.go
+++ b/pkg/lockservice/lock_table_allocator_stale_snapshot_test.go
@@ -15,6 +15,7 @@
 package lockservice
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -92,6 +93,7 @@ func TestCleanerDoesNotDeleteTombstoneCreatedAfterServiceSnapshot(
 		},
 		func(a *lockTableAllocator) {
 			a.options.getActiveTxnFunc = func(
+				_ context.Context,
 				serviceID string,
 			) (bool, [][]byte, error) {
 				switch queryCalls.Add(1) {

--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -15,9 +15,12 @@
 package lockservice
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -357,11 +360,104 @@ func TestCleanerPreservesCannotCommitOnActiveTxnQueryError(t *testing.T) {
 		},
 		func(lta *lockTableAllocator) {
 			lta.keepBindTimeout = time.Millisecond * 20
-			lta.options.getActiveTxnFunc = func(string) (bool, [][]byte, error) {
+			lta.options.getActiveTxnFunc = func(context.Context, string) (bool, [][]byte, error) {
 				<-ready
 				return false, nil, moerr.NewBackendClosedNoCtx()
 			}
 		})
+}
+
+func TestCleanCommitStateDefersRetryableErrorToNextSweep(t *testing.T) {
+	runtime.RunTest("", func(_ runtime.Runtime) {
+		lta := &lockTableAllocator{
+			logger:          getLogger("").Named("clean-commit-state-test"),
+			keepBindTimeout: 100 * time.Millisecond,
+		}
+		retryCtl := lta.getCtl("retry-service")
+		require.Equal(t, cannotCommitState, retryCtl.tryCannotCommit("t1"))
+		healthyCtl := lta.getCtl("healthy-service")
+		require.Equal(t, cannotCommitState, healthyCtl.tryCannotCommit("t2"))
+
+		var retryCalls atomic.Int64
+		var healthyCalls atomic.Int64
+		lta.options.getActiveTxnFunc = func(_ context.Context, sid string) (bool, [][]byte, error) {
+			switch sid {
+			case "retry-service":
+				retryCalls.Add(1)
+				return false, nil, assert.AnError
+			case "healthy-service":
+				healthyCalls.Add(1)
+				return true, [][]byte{[]byte("t2")}, nil
+			default:
+				panic("unexpected service: " + sid)
+			}
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			lta.cleanCommitState(ctx)
+		}()
+
+		require.Eventually(t, func() bool {
+			return retryCalls.Load() > 0 && healthyCalls.Load() > 0
+		}, time.Second, 5*time.Millisecond)
+
+		retryCount := retryCalls.Load()
+		healthyCount := healthyCalls.Load()
+		time.Sleep(25 * time.Millisecond)
+		require.Equal(t, retryCount, retryCalls.Load())
+		require.Equal(t, healthyCount, healthyCalls.Load())
+		state, exists := retryCtl.getCommitState("t1")
+		require.True(t, exists)
+		require.Equal(t, cannotCommitState, state.state)
+		require.False(t, lta.HasInvalidService("retry-service"))
+
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cleanCommitState did not stop after cancellation")
+		}
+	})
+}
+
+func TestCleanCommitStateCancelsInFlightProbe(t *testing.T) {
+	runtime.RunTest("", func(_ runtime.Runtime) {
+		lta := &lockTableAllocator{
+			logger:          getLogger("").Named("clean-commit-state-cancel-test"),
+			keepBindTimeout: time.Millisecond,
+		}
+		lta.getCtl("s1").tryCannotCommit("t1")
+
+		started := make(chan struct{})
+		var once sync.Once
+		lta.options.getActiveTxnFunc = func(ctx context.Context, _ string) (bool, [][]byte, error) {
+			once.Do(func() { close(started) })
+			<-ctx.Done()
+			return false, nil, ctx.Err()
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			lta.cleanCommitState(ctx)
+		}()
+
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("cleanCommitState did not start the probe")
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cleanCommitState did not stop after context cancellation")
+		}
+	})
 }
 
 func TestCannotCommitGenerationRefresh(t *testing.T) {
@@ -478,7 +574,7 @@ func TestCtlCanRemovedByInvalidService(t *testing.T) {
 		},
 		func(lta *lockTableAllocator) {
 			lta.keepBindTimeout = time.Millisecond * 100
-			lta.options.getActiveTxnFunc = func(sid string) (bool, [][]byte, error) {
+			lta.options.getActiveTxnFunc = func(_ context.Context, sid string) (bool, [][]byte, error) {
 				<-ch
 				return false, nil, nil
 			}
@@ -503,7 +599,7 @@ func TestCtlCanRemovedByNotActiveTxn(t *testing.T) {
 		},
 		func(lta *lockTableAllocator) {
 			lta.keepBindTimeout = time.Millisecond * 100
-			lta.options.getActiveTxnFunc = func(sid string) (bool, [][]byte, error) {
+			lta.options.getActiveTxnFunc = func(_ context.Context, sid string) (bool, [][]byte, error) {
 				<-ch
 				return true, [][]byte{[]byte("t2")}, nil
 			}

--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -394,6 +394,7 @@ func TestCleanCommitStateDefersRetryableErrorToNextSweep(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
@@ -495,6 +496,68 @@ func TestCleanCommitStateExpiresRetryableServiceState(t *testing.T) {
 			t.Fatal("cleanCommitState did not stop after cancellation")
 		}
 	})
+}
+
+func TestCleanCommitStateExpiresPersistentDisconnectState(t *testing.T) {
+	runtime.RunTest("", func(_ runtime.Runtime) {
+		lta := &lockTableAllocator{
+			logger:          getLogger("").Named("clean-commit-state-disconnect-expiry-test"),
+			keepBindTimeout: time.Millisecond,
+		}
+		lta.options.removeDisconnectDuration = 20 * time.Millisecond
+		ctl := lta.getCtl("disconnected-service")
+		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("t1"))
+
+		var calls atomic.Int64
+		lta.options.getActiveTxnFunc = func(context.Context, string) (bool, [][]byte, error) {
+			calls.Add(1)
+			return false, nil, moerr.NewBackendClosedNoCtx()
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			lta.cleanCommitState(ctx)
+		}()
+
+		require.Eventually(t, func() bool {
+			_, exists := lta.ctl.Load("disconnected-service")
+			return calls.Load() > 1 && !exists
+		}, time.Second, 5*time.Millisecond)
+
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cleanCommitState did not stop after cancellation")
+		}
+	})
+}
+
+func TestExpireInactiveServicePreservesFreshDisconnectEpoch(t *testing.T) {
+	lta := &lockTableAllocator{}
+	sid := "reconnected-service"
+	oldInactiveAt := time.Now().Add(-time.Hour)
+	lta.inactiveService.Store(sid, oldInactiveAt)
+
+	// The expiry sweep observed the old epoch, then the service resumed and
+	// disconnected again before the sweep attempted to delete its marker.
+	observed, ok := lta.inactiveService.Load(sid)
+	require.True(t, ok)
+	lta.inactiveService.Delete(sid)
+	lta.markInactiveService(sid)
+
+	require.False(t, lta.expireInactiveService(
+		sid,
+		observed.(time.Time),
+		time.Now(),
+		time.Minute,
+	))
+	fresh, ok := lta.inactiveService.Load(sid)
+	require.True(t, ok)
+	require.True(t, fresh.(time.Time).After(oldInactiveAt))
 }
 
 func TestCannotCommitGenerationRefresh(t *testing.T) {

--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -470,7 +470,9 @@ func TestCleanCommitStateExpiresRetryableServiceState(t *testing.T) {
 		lta.options.removeDisconnectDuration = 10 * time.Millisecond
 		ctl := lta.getCtl("expired-service")
 		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("t1"))
-		lta.inactiveService.Store("expired-service", time.Now().Add(-time.Second))
+		lta.inactiveService.Store("expired-service", &inactiveServiceEpoch{
+			inactiveAt: time.Now().Add(-time.Second),
+		})
 		lta.options.getActiveTxnFunc = func(context.Context, string) (bool, [][]byte, error) {
 			return false, nil, assert.AnError
 		}
@@ -540,24 +542,96 @@ func TestExpireInactiveServicePreservesFreshDisconnectEpoch(t *testing.T) {
 	lta := &lockTableAllocator{}
 	sid := "reconnected-service"
 	oldInactiveAt := time.Now().Add(-time.Hour)
-	lta.inactiveService.Store(sid, oldInactiveAt)
+	lta.inactiveService.Store(sid, &inactiveServiceEpoch{
+		inactiveAt: oldInactiveAt,
+	})
 
 	// The expiry sweep observed the old epoch, then the service resumed and
 	// disconnected again before the sweep attempted to delete its marker.
 	observed, ok := lta.inactiveService.Load(sid)
 	require.True(t, ok)
-	lta.inactiveService.Delete(sid)
+	lta.resumeInactiveService(sid)
 	lta.markInactiveService(sid)
 
 	require.False(t, lta.expireInactiveService(
 		sid,
-		observed.(time.Time),
+		observed.(*inactiveServiceEpoch),
 		time.Now(),
 		time.Minute,
 	))
 	fresh, ok := lta.inactiveService.Load(sid)
 	require.True(t, ok)
-	require.True(t, fresh.(time.Time).After(oldInactiveAt))
+	require.True(t, fresh.(*inactiveServiceEpoch).inactiveAt.After(oldInactiveAt))
+}
+
+func TestCleanCommitStatePreservesTombstoneForFreshDisconnectEpoch(t *testing.T) {
+	for name, probeErr := range map[string]error{
+		"retryable":     assert.AnError,
+		"non-retryable": moerr.NewBackendClosedNoCtx(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			runtime.RunTest("", func(_ runtime.Runtime) {
+				lta := &lockTableAllocator{
+					logger:          getLogger("").Named("clean-commit-state-epoch-test"),
+					keepBindTimeout: time.Millisecond,
+				}
+				lta.options.removeDisconnectDuration = time.Minute
+				const sid = "reconnected-service"
+				ctl := lta.getCtl(sid)
+				require.Equal(t, cannotCommitState, ctl.tryCannotCommit("t1"))
+				oldEpoch := &inactiveServiceEpoch{inactiveAt: time.Now().Add(-time.Hour)}
+				lta.inactiveService.Store(sid, oldEpoch)
+
+				var calls atomic.Int64
+				releaseLaterProbes := make(chan struct{})
+				lta.options.getActiveTxnFunc = func(ctx context.Context, _ string) (bool, [][]byte, error) {
+					if calls.Add(1) == 1 {
+						// This is the race: the old epoch expired before the probe,
+						// then the service resumed and disconnected again while it
+						// was in flight.
+						lta.resumeInactiveService(sid)
+						lta.markInactiveService(sid)
+						return false, nil, probeErr
+					}
+					select {
+					case <-releaseLaterProbes:
+						return false, nil, probeErr
+					case <-ctx.Done():
+						return false, nil, ctx.Err()
+					}
+				}
+
+				ctx, cancel := context.WithCancel(context.Background())
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					lta.cleanCommitState(ctx)
+				}()
+				defer func() {
+					cancel()
+					select {
+					case <-done:
+					case <-time.After(time.Second):
+						t.Fatal("cleanCommitState did not stop after cancellation")
+					}
+				}()
+
+				// A second probe cannot begin until the first sweep has completed
+				// its final cleanup. Hold it so later sweeps cannot affect the
+				// assertion.
+				require.Eventually(t, func() bool {
+					return calls.Load() >= 2
+				}, time.Second, time.Millisecond)
+
+				state, ok := ctl.getCommitState("t1")
+				require.True(t, ok, "fresh epoch must retain the existing tombstone")
+				require.Equal(t, cannotCommitState, state.state)
+				current, ok := lta.inactiveService.Load(sid)
+				require.True(t, ok, "fresh disconnect marker must remain")
+				require.NotSame(t, oldEpoch, current)
+			})
+		})
+	}
 }
 
 func TestCannotCommitGenerationRefresh(t *testing.T) {

--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -460,6 +460,43 @@ func TestCleanCommitStateCancelsInFlightProbe(t *testing.T) {
 	})
 }
 
+func TestCleanCommitStateExpiresRetryableServiceState(t *testing.T) {
+	runtime.RunTest("", func(_ runtime.Runtime) {
+		lta := &lockTableAllocator{
+			logger:          getLogger("").Named("clean-commit-state-expiry-test"),
+			keepBindTimeout: time.Millisecond,
+		}
+		lta.options.removeDisconnectDuration = 10 * time.Millisecond
+		ctl := lta.getCtl("expired-service")
+		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("t1"))
+		lta.inactiveService.Store("expired-service", time.Now().Add(-time.Second))
+		lta.options.getActiveTxnFunc = func(context.Context, string) (bool, [][]byte, error) {
+			return false, nil, assert.AnError
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			lta.cleanCommitState(ctx)
+		}()
+
+		require.Eventually(t, func() bool {
+			_, exists := lta.ctl.Load("expired-service")
+			return !exists
+		}, time.Second, 5*time.Millisecond)
+		require.False(t, lta.HasInvalidService("expired-service"))
+
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cleanCommitState did not stop after cancellation")
+		}
+	})
+}
+
 func TestCannotCommitGenerationRefresh(t *testing.T) {
 	c := &commitCtl{}
 	require.Equal(t, cannotCommitState, c.tryCannotCommit("refreshed"))

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -3282,7 +3282,9 @@ func TestResumeInvalidService(t *testing.T) {
 		t,
 		[]string{"s1"},
 		func(alloc *lockTableAllocator, s []*service) {
-			alloc.inactiveService.Store(s[0].serviceID, time.Now())
+			alloc.inactiveService.Store(s[0].serviceID, &inactiveServiceEpoch{
+				inactiveAt: time.Now(),
+			})
 			_, err := alloc.Valid(s[0].serviceID, []byte("testTxn"), nil)
 			require.True(t, moerr.IsMoErrCode(err, moerr.ErrCannotCommitOnInvalidCN))
 


### PR DESCRIPTION
## Summary

- remove the effectively unbounded same-service retry loop from cleanCommitState
- probe each service at most once per timer sweep so one retryable failure cannot starve later services
- derive the GetActiveTxn RPC timeout from the cleaner task context so allocator shutdown cancels an in-flight probe
- retain unexpired commit-control state on retryable errors and retry on the next sweep
- honor inactive-service retention expiry even when the current probe is retryable
- preserve generation-watermark protection and disconnected-service tombstone semantics

## Tests

- retryable and healthy services both make progress in one sweep
- retryable state is retained and no tight retry loop occurs
- cancellation releases an in-flight probe
- expired retryable service state is cleaned with watermark protection for newer state
- existing stale-snapshot and disconnected-service behavior remains covered
- full pkg/lockservice
- targeted repeated and race tests

Fixes #25206