### PR TITLE
fix: preserve workspace files after unknown commit

### DIFF
--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -912,7 +912,7 @@ func (tc *txnOperator) Rollback(ctx context.Context) (err error) {
 	txnMeta := tc.getTxnMeta(false)
 	util.LogTxnRollback(tc.logger, txnMeta)
 
-	if tc.reset.workspace != nil && !tc.reset.cannotCleanWorkspace {
+	if tc.reset.workspace != nil && tc.canCleanWorkspace() {
 		if err = tc.reset.workspace.Rollback(ctx); err != nil {
 			tc.logger.Error("rollback workspace failed",
 				util.TxnIDField(txnMeta), zap.Error(err))
@@ -1223,8 +1223,20 @@ func (tc *txnOperator) doWrite(
 	resp, err = tc.trimResponses(tc.handleError(ctx, result, err))
 	if err != nil && commit {
 		tc.reset.commitErr = err
+		if moerr.IsMoErrCode(err, moerr.ErrTxnUnknown) {
+			// The commit may have reached TN. Connection cleanup calls Rollback
+			// after Commit returns, so preserve prepared workspace files until an
+			// authoritative outcome is available.
+			tc.reset.cannotCleanWorkspace = true
+		}
 	}
 	return resp, err
+}
+
+func (tc *txnOperator) canCleanWorkspace() bool {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
+	return !tc.reset.cannotCleanWorkspace
 }
 
 func (tc *txnOperator) updateWritePartitions(requests []txn.TxnRequest, locked bool) {

--- a/pkg/txn/client/operator_test.go
+++ b/pkg/txn/client/operator_test.go
@@ -316,6 +316,7 @@ func TestCommitKeepsPreparedWorkspaceAfterTxnUnknown(t *testing.T) {
 
 		err := tc.Commit(ctx)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrTxnUnknown))
+		require.NoError(t, tc.Rollback(ctx))
 		require.Equal(t, 1, ws.commitCount)
 		require.Zero(t, ws.finalizeCount)
 		require.Equal(t, 1, ws.unknownCount)

--- a/pkg/txn/rpc/sender.go
+++ b/pkg/txn/rpc/sender.go
@@ -136,6 +136,7 @@ func (s *sender) Send(ctx context.Context, requests []txn.TxnRequest) (*SendResu
 	}
 
 	sr.reset(requests)
+	var commitRequest *txn.TxnRequest
 	for idx := range requests {
 		tn := requests[idx].GetTargetTN()
 		st := sr.getStream(tn.ShardID)
@@ -150,9 +151,15 @@ func (s *sender) Send(ctx context.Context, requests []txn.TxnRequest) (*SendResu
 		}
 
 		requests[idx].RequestID = st.ID()
+		if requests[idx].Method == txn.TxnMethod_Commit {
+			// Once Send is entered, the commit may reach TN even if the
+			// transport reports an error. Its result must be treated as unknown
+			// so the caller does not discard committed workspace files.
+			commitRequest = &requests[idx]
+		}
 		if err := st.Send(ctx, &requests[idx]); err != nil {
 			sr.Release()
-			return nil, err
+			return nil, unknownCommitResult(ctx, commitRequest, err)
 		}
 	}
 
@@ -161,11 +168,12 @@ func (s *sender) Send(ctx context.Context, requests []txn.TxnRequest) (*SendResu
 		c, err := st.Receive()
 		if err != nil {
 			sr.Release()
-			return nil, err
+			return nil, unknownCommitResult(ctx, commitRequest, err)
 		}
 		v, ok := <-c
-		if !ok {
-			return nil, moerr.NewStreamClosedNoCtx()
+		if !ok || v == nil {
+			sr.Release()
+			return nil, unknownCommitResult(ctx, commitRequest, moerr.NewStreamClosedNoCtx())
 		}
 		resp := v.(*txn.TxnResponse)
 		sr.setResponse(resp, idx)
@@ -235,21 +243,24 @@ func (s *sender) doSend(ctx context.Context, request txn.TxnRequest) (txn.TxnRes
 	defer f.Close()
 	v, err := f.Get()
 	if err != nil {
-		// if the error is io.EOF or "connection is reset by peer",
-		// means the connection to TN node is ended, but no response
-		// is returned from TN txn service. In this case, the result
-		// of the txn status is unknown.
-		if errors.Is(err, io.EOF) ||
-			strings.Contains(err.Error(), "connection reset by peer") {
-			return txn.TxnResponse{},
-				moerr.NewTxnUnknown(
-					ctx,
-					hex.EncodeToString(request.Txn.ID),
-				)
-		}
-		return txn.TxnResponse{}, err
+		return txn.TxnResponse{}, unknownCommitResult(ctx, &request, err)
 	}
 	return *(v.(*txn.TxnResponse)), nil
+}
+
+func unknownCommitResult(ctx context.Context, request *txn.TxnRequest, err error) error {
+	if request == nil {
+		return err
+	}
+	if request.Method == txn.TxnMethod_Commit {
+		return moerr.NewTxnUnknown(ctx, hex.EncodeToString(request.Txn.ID))
+	}
+	// Keep the existing handling for non-commit RPCs. A lost response leaves
+	// their result unknown as well, while other errors are returned unchanged.
+	if errors.Is(err, io.EOF) || strings.Contains(err.Error(), "connection reset by peer") {
+		return moerr.NewTxnUnknown(ctx, hex.EncodeToString(request.Txn.ID))
+	}
+	return err
 }
 
 type backendRetryState struct {

--- a/pkg/txn/rpc/sender_test.go
+++ b/pkg/txn/rpc/sender_test.go
@@ -663,6 +663,85 @@ func TestSendWithTxnUnknown(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestCommitResponseTimeoutReturnsTxnUnknown(t *testing.T) {
+	s := newTestTxnServer(t, testTN1Addr, nil)
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+	s.RegisterRequestHandler(func(
+		ctx context.Context,
+		request morpc.RPCMessage,
+		sequence uint64,
+		cs morpc.ClientSession) error {
+		return moerr.NewInternalError(ctx, "read tcp: i/o timeout")
+	})
+
+	sd, err := NewSender(Config{}, newTestRuntime(newTestClock(), nil))
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, sd.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	result, err := sd.Send(ctx, []txn.TxnRequest{newCommitRequest(testTN1Addr)})
+	assert.Nil(t, result)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrTxnUnknown))
+}
+
+func TestStreamCommitResponseLossReturnsTxnUnknown(t *testing.T) {
+	s := newTestTxnServer(t, testTN1Addr, nil)
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+	s.RegisterRequestHandler(func(
+		ctx context.Context,
+		request morpc.RPCMessage,
+		sequence uint64,
+		cs morpc.ClientSession) error {
+		req := request.Message.(*txn.TxnRequest)
+		if req.Method == txn.TxnMethod_Commit {
+			return moerr.NewInternalError(ctx, "read tcp: i/o timeout")
+		}
+		return cs.Write(ctx, &txn.TxnResponse{RequestID: req.RequestID, Method: req.Method})
+	})
+
+	sd, err := NewSender(Config{}, newTestRuntime(newTestClock(), nil))
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, sd.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	requests := []txn.TxnRequest{
+		{
+			Method: txn.TxnMethod_Write,
+			CNRequest: &txn.CNOpRequest{
+				Target: metadata.TNShard{Address: testTN1Addr},
+			},
+		},
+		newCommitRequest(testTN1Addr),
+	}
+	result, err := sd.Send(ctx, requests)
+	assert.Nil(t, result)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrTxnUnknown))
+}
+
+func newCommitRequest(address string) txn.TxnRequest {
+	return txn.TxnRequest{
+		Method: txn.TxnMethod_Commit,
+		Txn: txn.TxnMeta{
+			ID: []byte("commit-response-lost"),
+			TNShards: []metadata.TNShard{
+				{Address: address},
+			},
+		},
+	}
+}
+
 func newTestTxnServer(
 	t assert.TestingT,
 	addr string,


### PR DESCRIPTION
## Summary

Fixes #25591.

- Classify every post-dispatch commit RPC failure as `ErrTxnUnknown`, including raw read timeouts, for both single-request and stream sends.
- Preserve prepared workspace files when a commit outcome is unknown, including the frontend's subsequent transaction cleanup rollback.
- Add sender coverage for timeout and stream response loss, and extend the operator unknown-commit test through cleanup rollback.

## Root cause

TN can commit a transaction after CN has prepared workspace files, while the commit response is lost. Raw timeout errors were not consistently classified as an unknown commit result. Even when classified, connection cleanup invoked `TxnOperator.Rollback`, which rolled back the workspace before recognizing that the operator had already closed, deleting files that a committed transaction still referenced.

## Validation

- `go test ./pkg/txn/rpc ./pkg/txn/client -count=1` on 50
- `go vet ./pkg/txn/rpc ./pkg/txn/client` on 50
- `go test -race ./pkg/txn/client -run 'TestCommitKeepsPreparedWorkspaceAfterTxnUnknown$' -count=1` on 50
- `go test -race ./pkg/txn/rpc -run 'Test(CommitResponseTimeoutReturnsTxnUnknown|StreamCommitResponseLossReturnsTxnUnknown)$' -count=1` on 50
- Isolated two-CN chaos regression on 50: after TN committed 20,000 rows and its response to CN1 was dropped, `syncCommit` plus a CN2 restart still cold-read all 20,000 rows (`sum(id)=200010000`), with no `GC-WORKSPACE-FILES` entry.
