### PR TITLE
fix: prune unused set, aggregate and window columns

### DIFF
--- a/pkg/sql/plan/explain/column_prune_test.go
+++ b/pkg/sql/plan/explain/column_prune_test.go
@@ -636,6 +636,13 @@ func TestColumnPruneSemanticBoundaries(t *testing.T) {
 			},
 		},
 		{
+			name: "order sensitive aggregate retains input window order",
+			sql:  "select n_regionkey, json_arrayagg(n_name) from (select n_regionkey, n_name, row_number() over (partition by n_regionkey order by n_comment) as rn from nation) w group by n_regionkey",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name", "n_regionkey", "n_comment"}},
+			},
+		},
+		{
 			name: "having keeps only its aggregate input",
 			sql:  "select c_custkey from (select c_custkey, count(c_comment) as cnt, sum(c_acctbal) as total from customer group by c_custkey having sum(c_acctbal) > 0) g",
 			wantTableCol: []Entry[string, []string]{
@@ -810,6 +817,57 @@ func TestColumnPruneOperatorShape(t *testing.T) {
 			}
 		}
 		require.True(t, windowFound)
+	})
+
+	t.Run("order sensitive aggregate retains window without exposing its output", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select n_regionkey, json_arrayagg(n_name) from (select n_regionkey, n_name, row_number() over (partition by n_regionkey order by n_comment) as rn from nation) w group by n_regionkey",
+		)
+		require.NoError(t, err)
+
+		windowFound := false
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType == plan.Node_WINDOW {
+				windowFound = true
+			}
+			if node.NodeType == plan.Node_AGG {
+				require.Len(t, node.ProjectList, 2)
+			}
+		}
+		require.True(t, windowFound)
+	})
+
+	t.Run("discarded order sensitive carrier does not retain window order", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select 1 from (select json_arrayagg(n_name) from (select n_name, row_number() over (order by n_comment) as rn from nation) w) g",
+		)
+		require.NoError(t, err)
+
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			require.NotEqual(t, plan.Node_WINDOW, node.NodeType)
+			require.NotEqual(t, plan.Node_PARTITION, node.NodeType)
+		}
+	})
+
+	t.Run("order sensitive aggregate retains stacked windows", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select json_arrayagg(n_name) from (select n_name, row_number() over (order by n_regionkey) as rn1, row_number() over (order by n_comment) as rn2 from nation) w",
+		)
+		require.NoError(t, err)
+
+		windowCount := 0
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType == plan.Node_WINDOW {
+				windowCount++
+			}
+		}
+		require.Equal(t, 2, windowCount)
 	})
 
 	t.Run("cte consumers expose only referenced columns", func(t *testing.T) {

--- a/pkg/sql/plan/explain/column_prune_test.go
+++ b/pkg/sql/plan/explain/column_prune_test.go
@@ -500,7 +500,7 @@ func TestDerivedTableQueryPrune(t *testing.T) {
 			wantTableCol: []Entry[string, []string]{
 				{
 					tableName: "customer",
-					colNames:  []string{"c_custkey", "c_nationkey"},
+					colNames:  []string{"c_custkey"},
 				},
 				{
 					tableName: "nation",
@@ -553,6 +553,305 @@ func TestDerivedTableQueryPrune(t *testing.T) {
 		})
 	}
 
+}
+
+func TestColumnPruneSemanticBoundaries(t *testing.T) {
+	cases := []struct {
+		name         string
+		sql          string
+		wantTableCol []Entry[string, []string]
+	}{
+		{
+			name: "derived distinct keeps unprojected dedup keys",
+			sql:  "select n_name from (select distinct n_name, n_comment from nation) d",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name", "n_comment"}},
+			},
+		},
+		{
+			name: "union all prunes unprojected columns",
+			sql:  "select n_name from (select n_name, n_comment from nation union all select r_name, r_comment from region) u",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name"}},
+				{tableName: "region", colNames: []string{"r_name"}},
+			},
+		},
+		{
+			name: "union all compacts a retained nonzero position",
+			sql:  "select n_comment from (select n_name, n_comment from nation union all select r_name, r_comment from region) u",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_comment"}},
+				{tableName: "region", colNames: []string{"r_comment"}},
+			},
+		},
+		{
+			name: "union distinct keeps unprojected dedup keys",
+			sql:  "select n_name from (select n_name, n_comment from nation union select r_name, r_comment from region) u",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name", "n_comment"}},
+				{tableName: "region", colNames: []string{"r_name", "r_comment"}},
+			},
+		},
+		{
+			name: "intersect keeps unprojected set keys",
+			sql:  "select n_name from (select n_name, n_comment from nation intersect select r_name, r_comment from region) u",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name", "n_comment"}},
+				{tableName: "region", colNames: []string{"r_name", "r_comment"}},
+			},
+		},
+		{
+			name: "grouped aggregate prunes unused aggregate input",
+			sql:  "select c_custkey from (select c_custkey, count(c_comment) as cnt from customer group by c_custkey) g",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "customer", colNames: []string{"c_custkey"}},
+			},
+		},
+		{
+			name: "scalar aggregate compacts a retained nonzero position",
+			sql:  "select total from (select count(c_comment) as cnt, sum(c_acctbal) as total from customer) g",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "customer", colNames: []string{"c_acctbal"}},
+			},
+		},
+		{
+			name: "grouped aggregate keeps unprojected grouping keys",
+			sql:  "select n_regionkey from (select n_regionkey, n_name from nation group by n_regionkey, n_name) g",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name", "n_regionkey"}},
+			},
+		},
+		{
+			name: "unused window output prunes window-only inputs",
+			sql:  "select n_name from (select n_name, row_number() over (partition by n_regionkey order by n_comment) as rn from nation) w",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name"}},
+			},
+		},
+		{
+			name: "used window output keeps partition and order inputs",
+			sql:  "select rn from (select row_number() over (partition by n_regionkey order by n_comment) as rn from nation) w",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_regionkey", "n_comment"}},
+			},
+		},
+		{
+			name: "having keeps only its aggregate input",
+			sql:  "select c_custkey from (select c_custkey, count(c_comment) as cnt, sum(c_acctbal) as total from customer group by c_custkey having sum(c_acctbal) > 0) g",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "customer", colNames: []string{"c_custkey", "c_acctbal"}},
+			},
+		},
+		{
+			name: "scalar aggregate keeps a row-producing carrier",
+			sql:  "select 1 from (select sum(c_acctbal) as total from customer) g",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "customer", colNames: []string{"c_acctbal"}},
+			},
+		},
+		{
+			name: "having without aggregate keeps row semantics",
+			sql:  "select 1 from nation having true",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_nationkey"}},
+			},
+		},
+		{
+			name: "window post filter keeps window inputs",
+			sql:  "select n_name from (select n_name, row_number() over (partition by n_regionkey order by n_comment) as rn from nation) w where rn = 1",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name", "n_regionkey", "n_comment"}},
+			},
+		},
+		{
+			name: "unused first window does not retain its inputs",
+			sql:  "select rn2 from (select row_number() over (partition by n_regionkey order by n_comment) as rn1, row_number() over (order by n_name) as rn2 from nation) w",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name"}},
+			},
+		},
+		{
+			name: "union all constant projection keeps one row carrier",
+			sql:  "select 1 from (select n_name, n_comment from nation union all select r_name, r_comment from region) u",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name"}},
+				{tableName: "region", colNames: []string{"r_name"}},
+			},
+		},
+		{
+			name: "order by below limit retains its input",
+			sql:  "select n_name from (select n_name, n_comment from nation order by n_comment limit 10) d",
+			wantTableCol: []Entry[string, []string]{
+				{tableName: "nation", colNames: []string{"n_name", "n_comment"}},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mock := plan2.NewMockOptimizer(false)
+			logicPlan, err := buildOneStmt(mock, t, c.sql)
+			require.NoError(t, err)
+			columns, err := getPrunedTableColumns(logicPlan)
+			require.NoError(t, err)
+			require.Equal(t, c.wantTableCol, columns)
+		})
+	}
+}
+
+func TestColumnPruneOperatorShape(t *testing.T) {
+	t.Run("union all compacts output positions", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select n_name from (select n_name, n_comment from nation union all select r_name, r_comment from region) u",
+		)
+		require.NoError(t, err)
+
+		var unionAll *plan.Node
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType == plan.Node_UNION_ALL {
+				unionAll = node
+				break
+			}
+		}
+		require.NotNil(t, unionAll)
+		require.Len(t, unionAll.ProjectList, 1)
+	})
+
+	t.Run("union all retains side-effecting positions", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select a from (select n_name as a, sleep(0) as side_effect from nation union all select r_name, sleep(0) from region) u",
+		)
+		require.NoError(t, err)
+
+		var unionAll *plan.Node
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType == plan.Node_UNION_ALL {
+				unionAll = node
+				break
+			}
+		}
+		require.NotNil(t, unionAll)
+		require.Len(t, unionAll.ProjectList, 2)
+	})
+
+	t.Run("aggregate compacts having slots", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select c_custkey from (select c_custkey, count(c_comment) as cnt, sum(c_acctbal) as total from customer group by c_custkey having sum(c_acctbal) > 0) g",
+		)
+		require.NoError(t, err)
+
+		var agg *plan.Node
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType == plan.Node_AGG && len(node.FilterList) > 0 {
+				agg = node
+				break
+			}
+		}
+		require.NotNil(t, agg)
+		require.Len(t, agg.AggList, 1)
+		require.Equal(t, "sum", agg.AggList[0].GetF().Func.ObjName)
+		col := agg.FilterList[0].GetF().Args[0].GetCol()
+		require.NotNil(t, col)
+		require.Equal(t, int32(-2), col.RelPos)
+		require.Equal(t, int32(1), col.ColPos, "group column occupies slot 0; compacted sum occupies slot 1")
+	})
+
+	t.Run("aggregate retains side-effecting inputs", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select c_custkey from (select c_custkey, sum(sleep(0)) as side_effect from customer group by c_custkey) g",
+		)
+		require.NoError(t, err)
+
+		var agg *plan.Node
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType == plan.Node_AGG {
+				agg = node
+				break
+			}
+		}
+		require.NotNil(t, agg)
+		require.Len(t, agg.AggList, 1)
+	})
+
+	t.Run("unused window operators are unreachable", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select n_name from (select n_name, row_number() over (partition by n_regionkey order by n_comment) as rn from nation) w",
+		)
+		require.NoError(t, err)
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			require.NotEqual(t, plan.Node_WINDOW, node.NodeType)
+			require.NotEqual(t, plan.Node_PARTITION, node.NodeType)
+		}
+	})
+
+	t.Run("unused window with side effects remains reachable", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select n_name from (select n_name, row_number() over (order by sleep(0)) as rn from nation) w",
+		)
+		require.NoError(t, err)
+
+		windowFound := false
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType == plan.Node_WINDOW {
+				windowFound = true
+				break
+			}
+		}
+		require.True(t, windowFound)
+	})
+
+	t.Run("cte consumers expose only referenced columns", func(t *testing.T) {
+		logicPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"with c as (select n_name, n_comment from nation) select x.n_name from c x join c y on x.n_name = y.n_name",
+		)
+		require.NoError(t, err)
+
+		scanCount := 0
+		for _, node := range reachablePlanNodes(logicPlan.GetQuery()) {
+			if node.NodeType != plan.Node_TABLE_SCAN {
+				continue
+			}
+			scanCount++
+			require.Len(t, node.TableDef.Cols, 1)
+			require.Equal(t, "n_name", node.TableDef.Cols[0].Name)
+		}
+		require.Equal(t, 2, scanCount)
+	})
+}
+
+func reachablePlanNodes(query *plan.Query) []*plan.Node {
+	visited := make(map[int32]struct{}, len(query.Nodes))
+	nodes := make([]*plan.Node, 0, len(query.Nodes))
+	var visit func(int32)
+	visit = func(nodeID int32) {
+		if _, ok := visited[nodeID]; ok {
+			return
+		}
+		visited[nodeID] = struct{}{}
+		node := query.Nodes[nodeID]
+		nodes = append(nodes, node)
+		for _, childID := range node.Children {
+			visit(childID)
+		}
+	}
+	for _, rootID := range query.Steps {
+		visit(rootID)
+	}
+	return nodes
 }
 
 func buildOneStmt(opt plan2.Optimizer, t *testing.T, sql string) (*plan.Plan, error) {

--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -239,6 +240,26 @@ func exprCanRemoveProject(expr *Expr) bool {
 				return canRemove
 			}
 		}
+	case *plan.Expr_List:
+		for _, item := range ne.List.List {
+			if !exprCanRemoveProject(item) {
+				return false
+			}
+		}
+	case *plan.Expr_W:
+		if !exprCanRemoveProject(ne.W.WindowFunc) {
+			return false
+		}
+		for _, partitionBy := range ne.W.PartitionBy {
+			if !exprCanRemoveProject(partitionBy) {
+				return false
+			}
+		}
+		for _, orderBy := range ne.W.OrderBy {
+			if !exprCanRemoveProject(orderBy.Expr) {
+				return false
+			}
+		}
 	}
 	return true
 }
@@ -361,23 +382,71 @@ func (builder *QueryBuilder) swapJoinChildren(nodeID int32) {
 	}
 }
 
-func (builder *QueryBuilder) remapHavingClause(expr *plan.Expr, groupTag, aggregateTag int32, groupSize int32) {
+func (builder *QueryBuilder) remapHavingClause(
+	expr *plan.Expr,
+	groupTag, aggregateTag int32,
+	groupSize, aggregateSize int32,
+	aggPos []int32,
+) error {
 	switch exprImpl := expr.Expr.(type) {
 	case *plan.Expr_Col:
 		if exprImpl.Col.RelPos == groupTag {
+			if exprImpl.Col.ColPos < 0 || exprImpl.Col.ColPos >= groupSize {
+				return moerr.NewInternalErrorf(
+					builder.GetContext(),
+					"invalid group column %d in HAVING during column pruning",
+					exprImpl.Col.ColPos,
+				)
+			}
 			exprImpl.Col.Name = builder.nameByColRef[[2]int32{groupTag, exprImpl.Col.ColPos}]
 			exprImpl.Col.RelPos = -1
-		} else {
-			exprImpl.Col.Name = builder.nameByColRef[[2]int32{aggregateTag, exprImpl.Col.ColPos}]
+		} else if exprImpl.Col.RelPos == aggregateTag {
+			oldPos := exprImpl.Col.ColPos
+			if oldPos < 0 || oldPos >= aggregateSize {
+				return moerr.NewInternalErrorf(
+					builder.GetContext(),
+					"invalid aggregate column %d in HAVING during column pruning",
+					oldPos,
+				)
+			}
+			newPos := oldPos
+			if aggPos != nil {
+				if int(oldPos) >= len(aggPos) || aggPos[oldPos] < 0 {
+					return moerr.NewInternalErrorf(
+						builder.GetContext(),
+						"invalid aggregate column %d in HAVING during column pruning",
+						oldPos,
+					)
+				}
+				newPos = aggPos[oldPos]
+			}
+			exprImpl.Col.Name = builder.nameByColRef[[2]int32{aggregateTag, oldPos}]
 			exprImpl.Col.RelPos = -2
-			exprImpl.Col.ColPos += groupSize
+			exprImpl.Col.ColPos = newPos + groupSize
+		} else {
+			return moerr.NewInternalErrorf(
+				builder.GetContext(),
+				"invalid relation tag %d in HAVING during column pruning",
+				exprImpl.Col.RelPos,
+			)
 		}
 
 	case *plan.Expr_F:
 		for _, arg := range exprImpl.F.Args {
-			builder.remapHavingClause(arg, groupTag, aggregateTag, groupSize)
+			if err := builder.remapHavingClause(arg, groupTag, aggregateTag, groupSize, aggregateSize, aggPos); err != nil {
+				return err
+			}
+		}
+
+	case *plan.Expr_List:
+		for _, item := range exprImpl.List.List {
+			if err := builder.remapHavingClause(item, groupTag, aggregateTag, groupSize, aggregateSize, aggPos); err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
 func (builder *QueryBuilder) remapWindowClause(

--- a/pkg/sql/plan/opt_misc_test.go
+++ b/pkg/sql/plan/opt_misc_test.go
@@ -283,6 +283,63 @@ func TestRemapWindowClause(t *testing.T) {
 	})
 }
 
+func TestRemapHavingClause(t *testing.T) {
+	b := &QueryBuilder{
+		compCtx: &MockCompilerContext{ctx: context.Background()},
+		nameByColRef: map[[2]int32]string{
+			{1, 0}: "group_key",
+			{2, 2}: "kept_aggregate",
+		},
+	}
+
+	t.Run("remaps compacted aggregate inside list", func(t *testing.T) {
+		expr := &plan.Expr{Expr: &plan.Expr_List{List: &plan.ExprList{List: []*plan.Expr{
+			GetColExpr(plan.Type{Id: int32(types.T_int64)}, 1, 0),
+			GetColExpr(plan.Type{Id: int32(types.T_int64)}, 2, 2),
+		}}}}
+
+		err := b.remapHavingClause(expr, 1, 2, 1, 3, []int32{-1, -1, 0})
+		require.NoError(t, err)
+		require.Equal(t, int32(-1), expr.GetList().List[0].GetCol().RelPos)
+		require.Equal(t, int32(0), expr.GetList().List[0].GetCol().ColPos)
+		require.Equal(t, int32(-2), expr.GetList().List[1].GetCol().RelPos)
+		require.Equal(t, int32(1), expr.GetList().List[1].GetCol().ColPos)
+	})
+
+	for _, tc := range []struct {
+		name string
+		expr *plan.Expr
+	}{
+		{
+			name: "rejects out of range aggregate slot",
+			expr: GetColExpr(plan.Type{Id: int32(types.T_int64)}, 2, 3),
+		},
+		{
+			name: "rejects pruned aggregate slot",
+			expr: GetColExpr(plan.Type{Id: int32(types.T_int64)}, 2, 0),
+		},
+		{
+			name: "rejects invalid group slot",
+			expr: GetColExpr(plan.Type{Id: int32(types.T_int64)}, 1, 1),
+		},
+		{
+			name: "rejects unknown relation tag",
+			expr: GetColExpr(plan.Type{Id: int32(types.T_int64)}, 3, 0),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := b.remapHavingClause(tc.expr, 1, 2, 1, 3, []int32{-1, -1, 0})
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("rejects inconsistent aggregate position map", func(t *testing.T) {
+		expr := GetColExpr(plan.Type{Id: int32(types.T_int64)}, 2, 2)
+		err := b.remapHavingClause(expr, 1, 2, 1, 3, []int32{0})
+		require.Error(t, err)
+	})
+}
+
 func TestBuildWindowFilterOnNonProjectedColumns(t *testing.T) {
 	mock := NewMockOptimizer(false)
 

--- a/pkg/sql/plan/opt_misc_test.go
+++ b/pkg/sql/plan/opt_misc_test.go
@@ -340,6 +340,21 @@ func TestRemapHavingClause(t *testing.T) {
 	})
 }
 
+func TestAggregateDependsOnInputOrder(t *testing.T) {
+	makeAgg := func(name string) *plan.Expr {
+		return &plan.Expr{Expr: &plan.Expr_F{F: &plan.Function{Func: &plan.ObjectRef{ObjName: name}}}}
+	}
+
+	for _, name := range []string{"group_concat", "json_arrayagg", "json_objectagg"} {
+		t.Run(name, func(t *testing.T) {
+			require.True(t, aggregateDependsOnInputOrder(makeAgg(name)))
+		})
+	}
+	require.False(t, aggregateDependsOnInputOrder(makeAgg("sum")))
+	require.False(t, aggregateDependsOnInputOrder(GetColExpr(plan.Type{Id: int32(types.T_int64)}, 1, 0)))
+	require.False(t, aggregateDependsOnInputOrder(&plan.Expr{Expr: &plan.Expr_F{F: &plan.Function{}}}))
+}
+
 func TestBuildWindowFilterOnNonProjectedColumns(t *testing.T) {
 	mock := NewMockOptimizer(false)
 

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -345,6 +345,62 @@ func (builder *QueryBuilder) copyNode(ctx *BindContext, nodeId int32) int32 {
 	return newNodeId
 }
 
+func aggregateDependsOnInputOrder(expr *plan.Expr) bool {
+	fn := expr.GetF()
+	if fn == nil || fn.Func == nil {
+		return false
+	}
+	switch fn.Func.ObjName {
+	case "group_concat", "json_arrayagg", "json_objectagg":
+		return true
+	default:
+		return false
+	}
+}
+
+// retainInputOrder keeps windows on each order-transparent input path.
+// Order-sensitive aggregates expose the input sequence in their result, even
+// when a window's own output column is not referenced. Stacked windows must all
+// remain because an earlier ordering can determine tie order in a later one.
+// The returned references are temporary and must be released after child
+// remapping.
+func (builder *QueryBuilder) retainInputOrder(nodeID int32, colRefCnt map[[2]int32]int, refs [][2]int32) [][2]int32 {
+	node := builder.qry.Nodes[nodeID]
+	switch node.NodeType {
+	case plan.Node_WINDOW:
+		if len(node.BindingTags) > 0 {
+			ref := [2]int32{node.BindingTags[0], node.GetWindowIdx()}
+			if colRefCnt[ref] == 0 {
+				colRefCnt[ref]++
+				refs = append(refs, ref)
+			}
+		}
+		if len(node.Children) == 1 {
+			refs = builder.retainInputOrder(node.Children[0], colRefCnt, refs)
+		}
+		return refs
+
+	case plan.Node_PROJECT, plan.Node_FILTER, plan.Node_MATERIAL, plan.Node_PARTITION:
+		if len(node.Children) == 1 {
+			return builder.retainInputOrder(node.Children[0], colRefCnt, refs)
+		}
+
+	case plan.Node_UNION_ALL:
+		for _, childID := range node.Children {
+			refs = builder.retainInputOrder(childID, colRefCnt, refs)
+		}
+		return refs
+	}
+
+	return refs
+}
+
+func releaseRetainedOrderRefs(colRefCnt map[[2]int32]int, refs [][2]int32) {
+	for _, ref := range refs {
+		colRefCnt[ref]--
+	}
+}
+
 func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt map[[2]int32]int, colRefBool map[[2]int32]bool, sinkColRef map[[2]int32]int) (*ColRefRemapping, error) {
 	node := builder.qry.Nodes[nodeID]
 
@@ -987,7 +1043,24 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 			}
 		}
 
+		var retainedOrderRefs [][2]int32
+		for i, expr := range node.AggList {
+			if pruneAgg && aggPos[i] < 0 {
+				continue
+			}
+			// A scalar aggregate can be retained only as a row-count carrier.
+			// Its discarded value cannot observe input order.
+			if colRefCnt[[2]int32{aggregateTag, int32(i)}] == 0 {
+				continue
+			}
+			if aggregateDependsOnInputOrder(expr) {
+				retainedOrderRefs = builder.retainInputOrder(node.Children[0], colRefCnt, retainedOrderRefs)
+				break
+			}
+		}
+
 		childRemapping, err := builder.remapAllColRefs(node.Children[0], step, colRefCnt, colRefBool, sinkColRef)
+		releaseRetainedOrderRefs(colRefCnt, retainedOrderRefs)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -656,23 +656,67 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		thisTag := node.BindingTags[0]
 		leftID := node.Children[0]
 		rightID := node.Children[1]
-		for i, expr := range node.ProjectList {
-			increaseRefCnt(expr, 1, colRefCnt)
-			globalRef := [2]int32{thisTag, int32(i)}
-			remapping.addColRef(globalRef)
+		leftNode := builder.qry.Nodes[leftID]
+		rightNode := builder.qry.Nodes[rightID]
+		pruneOutput := node.NodeType == plan.Node_UNION_ALL
+		var neededProj []int
+		if pruneOutput {
+			neededProj = make([]int, 0, len(node.ProjectList))
+			for i, expr := range node.ProjectList {
+				globalRef := [2]int32{thisTag, int32(i)}
+				// UNION ALL only concatenates rows, so an unreferenced position
+				// can be removed from both children unless evaluating that
+				// position has an observable side effect.
+				canPrune := colRefCnt[globalRef] == 0
+				if i < len(leftNode.ProjectList) && !exprCanRemoveProject(leftNode.ProjectList[i]) {
+					canPrune = false
+				}
+				if i < len(rightNode.ProjectList) && !exprCanRemoveProject(rightNode.ProjectList[i]) {
+					canPrune = false
+				}
+				if canPrune {
+					continue
+				}
+				neededProj = append(neededProj, i)
+				increaseRefCnt(expr, 1, colRefCnt)
+				remapping.addColRef(globalRef)
+			}
+			if len(neededProj) == 0 && len(node.ProjectList) > 0 {
+				neededProj = append(neededProj, 0)
+				increaseRefCnt(node.ProjectList[0], 1, colRefCnt)
+				remapping.addColRef([2]int32{thisTag, 0})
+			}
+		} else {
+			// The other set operators use every input column to determine
+			// duplicate counts or set membership.
+			for i, expr := range node.ProjectList {
+				increaseRefCnt(expr, 1, colRefCnt)
+				remapping.addColRef([2]int32{thisTag, int32(i)})
+			}
 		}
 
-		rightNode := builder.qry.Nodes[rightID]
 		if rightNode.NodeType == plan.Node_PROJECT {
 			projectTag := rightNode.BindingTags[0]
-			for i := range rightNode.ProjectList {
-				increaseRefCnt(&plan.Expr{
-					Expr: &plan.Expr_Col{
-						Col: &plan.ColRef{
-							RelPos: projectTag,
-							ColPos: int32(i),
-						},
-					}}, 1, colRefCnt)
+			if pruneOutput {
+				for _, i := range neededProj {
+					increaseRefCnt(&plan.Expr{
+						Expr: &plan.Expr_Col{
+							Col: &plan.ColRef{
+								RelPos: projectTag,
+								ColPos: int32(i),
+							},
+						}}, 1, colRefCnt)
+				}
+			} else {
+				for i := range rightNode.ProjectList {
+					increaseRefCnt(&plan.Expr{
+						Expr: &plan.Expr_Col{
+							Col: &plan.ColRef{
+								RelPos: projectTag,
+								ColPos: int32(i),
+							},
+						}}, 1, colRefCnt)
+				}
 			}
 		}
 
@@ -687,12 +731,26 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		}
 
 		remapInfo.tip = "ProjectList"
-		for idx, expr := range node.ProjectList {
-			increaseRefCnt(expr, -1, colRefCnt)
-			remapInfo.srcExprIdx = idx
-			err := builder.remapColRefForExpr(expr, leftRemapping.globalToLocal, &remapInfo)
-			if err != nil {
-				return nil, err
+		if pruneOutput {
+			newProjectList := node.ProjectList[:0]
+			for _, needed := range neededProj {
+				expr := node.ProjectList[needed]
+				increaseRefCnt(expr, -1, colRefCnt)
+				remapInfo.srcExprIdx = needed
+				if err := builder.remapColRefForExpr(expr, leftRemapping.globalToLocal, &remapInfo); err != nil {
+					return nil, err
+				}
+				newProjectList = append(newProjectList, expr)
+			}
+			clear(node.ProjectList[len(newProjectList):])
+			node.ProjectList = newProjectList
+		} else {
+			for idx, expr := range node.ProjectList {
+				increaseRefCnt(expr, -1, colRefCnt)
+				remapInfo.srcExprIdx = idx
+				if err := builder.remapColRefForExpr(expr, leftRemapping.globalToLocal, &remapInfo); err != nil {
+					return nil, err
+				}
 			}
 		}
 
@@ -868,12 +926,65 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		}
 
 	case plan.Node_AGG:
+		groupTag := node.BindingTags[0]
+		aggregateTag := node.BindingTags[1]
+		groupSize := int32(len(node.GroupBy))
+
+		// HAVING is evaluated inside the aggregate node, so its output refs are
+		// consumers even when the outer projection does not expose them.
+		for _, expr := range node.FilterList {
+			increaseRefCnt(expr, 1, colRefCnt)
+		}
+
+		neededAggCount := int32(0)
+		firstNeededAgg := int32(-1)
+		for i, expr := range node.AggList {
+			if colRefCnt[[2]int32{aggregateTag, int32(i)}] > 0 || !exprCanRemoveProject(expr) {
+				neededAggCount++
+				if firstNeededAgg < 0 {
+					firstNeededAgg = int32(i)
+				}
+			}
+		}
+		// A scalar aggregate must still produce exactly one row, including for
+		// empty input. Keep one aggregate as the row-producing carrier when its
+		// value is discarded by an outer constant projection.
+		keepCarrier := false
+		if groupSize == 0 && len(node.AggList) > 0 && neededAggCount == 0 {
+			neededAggCount = 1
+			firstNeededAgg = 0
+			keepCarrier = true
+		}
+
+		// Allocate a position map only when aggregate slots are actually
+		// compacted. The common no-pruning path keeps the original zero-allocation
+		// remapping behavior.
+		pruneAgg := int(neededAggCount) < len(node.AggList)
+		var aggPos []int32
+		if pruneAgg {
+			aggPos = make([]int32, len(node.AggList))
+			for i := range aggPos {
+				aggPos[i] = -1
+			}
+			newPos := int32(0)
+			for i := range node.AggList {
+				globalRef := [2]int32{aggregateTag, int32(i)}
+				if colRefCnt[globalRef] == 0 && exprCanRemoveProject(node.AggList[i]) && !(keepCarrier && i == 0) {
+					continue
+				}
+				aggPos[i] = newPos
+				newPos++
+			}
+		}
+
 		for _, expr := range node.GroupBy {
 			increaseRefCnt(expr, 1, colRefCnt)
 		}
 
-		for _, expr := range node.AggList {
-			increaseRefCnt(expr, 1, colRefCnt)
+		for i, expr := range node.AggList {
+			if !pruneAgg || aggPos[i] >= 0 {
+				increaseRefCnt(expr, 1, colRefCnt)
+			}
 		}
 
 		childRemapping, err := builder.remapAllColRefs(node.Children[0], step, colRefCnt, colRefBool, sinkColRef)
@@ -881,12 +992,11 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 			return nil, err
 		}
 
-		groupTag := node.BindingTags[0]
-		aggregateTag := node.BindingTags[1]
-		groupSize := int32(len(node.GroupBy))
-
 		for _, expr := range node.FilterList {
-			builder.remapHavingClause(expr, groupTag, aggregateTag, groupSize)
+			increaseRefCnt(expr, -1, colRefCnt)
+			if err = builder.remapHavingClause(expr, groupTag, aggregateTag, groupSize, int32(len(node.AggList)), aggPos); err != nil {
+				return nil, err
+			}
 		}
 
 		remapInfo.tip = "GroupBy"
@@ -918,13 +1028,19 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		}
 
 		remapInfo.tip = "AggList"
+		newAggList := node.AggList[:0]
 		for idx, expr := range node.AggList {
+			if pruneAgg && aggPos[idx] < 0 {
+				continue
+			}
 			increaseRefCnt(expr, -1, colRefCnt)
 			remapInfo.srcExprIdx = idx
 			err := builder.remapColRefForExpr(expr, childRemapping.globalToLocal, &remapInfo)
 			if err != nil {
 				return nil, err
 			}
+			newAggIdx := int32(len(newAggList))
+			newAggList = append(newAggList, expr)
 
 			globalRef := [2]int32{aggregateTag, int32(idx)}
 			if colRefCnt[globalRef] == 0 {
@@ -938,12 +1054,14 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 				Expr: &plan.Expr_Col{
 					Col: &ColRef{
 						RelPos: -2,
-						ColPos: int32(idx) + groupSize,
+						ColPos: newAggIdx + groupSize,
 						Name:   builder.nameByColRef[globalRef],
 					},
 				},
 			})
 		}
+		clear(node.AggList[len(newAggList):])
+		node.AggList = newAggList
 
 		if len(node.ProjectList) == 0 {
 			if groupSize > 0 {
@@ -961,7 +1079,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 					},
 				})
 			} else {
-				globalRef := [2]int32{aggregateTag, 0}
+				globalRef := [2]int32{aggregateTag, firstNeededAgg}
 				remapping.addColRef(globalRef)
 
 				node.ProjectList = append(node.ProjectList, &plan.Expr{
@@ -1007,7 +1125,9 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		}
 
 		for _, expr := range node.FilterList {
-			builder.remapHavingClause(expr, groupTag, sampleTag, int32(len(node.GroupBy)))
+			if err = builder.remapHavingClause(expr, groupTag, sampleTag, int32(len(node.GroupBy)), int32(len(node.AggList)), nil); err != nil {
+				return nil, err
+			}
 		}
 
 		remapInfo.tip = "GroupBy"
@@ -1219,6 +1339,79 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		for _, expr := range node.FilterList {
 			increaseRefCnt(expr, 1, colRefCnt)
 		}
+
+		windowTag := node.BindingTags[0]
+		windowRef := [2]int32{windowTag, node.GetWindowIdx()}
+		canPruneWindow := colRefCnt[windowRef] == 0
+		for _, expr := range node.WinSpecList {
+			if !exprCanRemoveProject(expr) {
+				canPruneWindow = false
+				break
+			}
+		}
+		if canPruneWindow {
+			// The window result is neither projected nor consumed by a post-window
+			// filter. Bypass both the window and its dedicated PARTITION node so
+			// partition/order-only columns do not reach the scan.
+			childID := node.Children[0]
+			child := builder.qry.Nodes[childID]
+			if child.NodeType == plan.Node_PARTITION && len(child.Children) == 1 {
+				childID = child.Children[0]
+				node.Children[0] = childID
+			}
+			childRemapping, err := builder.remapAllColRefs(childID, step, colRefCnt, colRefBool, sinkColRef)
+			if err != nil {
+				return nil, err
+			}
+
+			remapInfo.tip = "FilterList"
+			for idx, expr := range node.FilterList {
+				increaseRefCnt(expr, -1, colRefCnt)
+				remapInfo.srcExprIdx = idx
+				if err = builder.remapColRefForExpr(expr, childRemapping.globalToLocal, &remapInfo); err != nil {
+					return nil, err
+				}
+			}
+
+			childProjList := builder.qry.Nodes[childID].ProjectList
+			node.ProjectList = nil
+			for i, globalRef := range childRemapping.localToGlobal {
+				if colRefCnt[globalRef] == 0 {
+					continue
+				}
+				remapping.addColRef(globalRef)
+				node.ProjectList = append(node.ProjectList, &plan.Expr{
+					Typ: childProjList[i].Typ,
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: 0,
+						ColPos: int32(i),
+						Name:   builder.nameByColRef[globalRef],
+					}},
+				})
+			}
+			if len(node.ProjectList) == 0 && len(childRemapping.localToGlobal) > 0 {
+				globalRef := childRemapping.localToGlobal[0]
+				remapping.addColRef(globalRef)
+				node.ProjectList = append(node.ProjectList, &plan.Expr{
+					Typ: childProjList[0].Typ,
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: 0,
+						ColPos: 0,
+						Name:   builder.nameByColRef[globalRef],
+					}},
+				})
+			}
+
+			node.WinSpecList = nil
+			if len(node.FilterList) == 0 {
+				node.NodeType = plan.Node_PROJECT
+			} else {
+				node.NodeType = plan.Node_FILTER
+			}
+			node.BindingTags = nil
+			return remapping, nil
+		}
+
 		for _, expr := range node.WinSpecList {
 			increaseRefCnt(expr, 1, colRefCnt)
 		}
@@ -1230,7 +1423,6 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		}
 
 		childProjList := builder.qry.Nodes[node.Children[0]].ProjectList
-		windowTag := node.BindingTags[0]
 		l := len(childProjList)
 
 		// In the window function node,

--- a/test/distributed/cases/optimizer/column_pruning.result
+++ b/test/distributed/cases/optimizer/column_pruning.result
@@ -1,0 +1,58 @@
+drop database if exists column_pruning;
+create database column_pruning;
+use column_pruning;
+create table l(a int, b int, payload varchar(100));
+create table r(a int, b int, payload varchar(100));
+insert into l values (1, 10, 'x'), (1, 10, 'y'), (1, 20, 'w'), (2, 30, 'z');
+insert into r values (1, 10, 'u'), (3, 40, 'v');
+select a from (select a, b from l union all select a, b from r) u order by a;
+a
+1
+1
+1
+1
+2
+3
+select b from (select a, b from l union all select a, b from r) u order by b;
+b
+10
+10
+10
+20
+30
+40
+select a from (select a, b from l union select a, b from r) u order by a;
+a
+1
+1
+2
+3
+select a from (select a, count(payload) as unused_count, sum(b) as total from l group by a having sum(b) > 0) g order by a;
+a
+1
+2
+select total from (select count(payload) as unused_count, sum(b) as total from l) g;
+total
+70
+select a from (select a, row_number() over(partition by b order by payload) as rn from l) w order by a;
+a
+1
+1
+1
+2
+select a, rn from (select a, row_number() over(partition by b order by payload) as rn from l) w order by a, rn;
+a    rn
+1    1
+1    1
+1    2
+2    1
+create table empty_t(v int);
+select 1 from (select sum(v) as discarded from empty_t) s;
+1
+1
+create table tw(ts timestamp, v int);
+insert into tw values ('2024-01-01 00:00:00', 1), ('2024-01-01 12:00:00', 2);
+select _wend, max(v) from tw interval(ts, 1, day);
+_wend    max(v)
+2024-01-02 00:00:00    2
+drop database column_pruning;

--- a/test/distributed/cases/optimizer/column_pruning.result
+++ b/test/distributed/cases/optimizer/column_pruning.result
@@ -46,6 +46,10 @@ a    rn
 1    1
 1    2
 2    1
+select a, json_arrayagg(payload) from (select a, payload, row_number() over(partition by a order by b desc, payload) as rn from l) w group by a order by a;
+a    json_arrayagg(payload)
+1    ["w", "x", "y"]
+2    ["z"]
 create table empty_t(v int);
 select 1 from (select sum(v) as discarded from empty_t) s;
 1

--- a/test/distributed/cases/optimizer/column_pruning.test
+++ b/test/distributed/cases/optimizer/column_pruning.test
@@ -1,0 +1,44 @@
+drop database if exists column_pruning;
+create database column_pruning;
+use column_pruning;
+
+create table l(a int, b int, payload varchar(100));
+create table r(a int, b int, payload varchar(100));
+insert into l values (1, 10, 'x'), (1, 10, 'y'), (1, 20, 'w'), (2, 30, 'z');
+insert into r values (1, 10, 'u'), (3, 40, 'v');
+
+-- UNION ALL can prune unused positions but must preserve every input row.
+select a from (select a, b from l union all select a, b from r) u order by a;
+
+-- Retaining only a nonzero UNION ALL position must compact it to output slot 0.
+select b from (select a, b from l union all select a, b from r) u order by b;
+
+-- UNION DISTINCT must retain the unprojected b key: (1,10) and (1,20)
+-- remain two rows after the outer projection removes b.
+select a from (select a, b from l union select a, b from r) u order by a;
+
+-- count(payload) is unused and may be removed. sum(b), although not projected,
+-- is still required by HAVING and exercises aggregate slot compaction.
+select a from (select a, count(payload) as unused_count, sum(b) as total from l group by a having sum(b) > 0) g order by a;
+
+-- The retained aggregate starts at logical slot 1 and must be remapped to
+-- physical aggregate slot 0 after count(payload) is removed.
+select total from (select count(payload) as unused_count, sum(b) as total from l) g;
+
+-- An unused window result must not change rows; a used result must retain its
+-- partition/order inputs and keep the compact output slot correct.
+select a from (select a, row_number() over(partition by b order by payload) as rn from l) w order by a;
+select a, rn from (select a, row_number() over(partition by b order by payload) as rn from l) w order by a, rn;
+
+-- A scalar aggregate with a discarded value still produces one row on empty
+-- input, so pruning must retain a row-producing aggregate carrier.
+create table empty_t(v int);
+select 1 from (select sum(v) as discarded from empty_t) s;
+
+-- _wstart is deliberately unprojected. Column pruning must continue and keep
+-- _wend instead of leaving the time-window remapping incomplete.
+create table tw(ts timestamp, v int);
+insert into tw values ('2024-01-01 00:00:00', 1), ('2024-01-01 12:00:00', 2);
+select _wend, max(v) from tw interval(ts, 1, day);
+
+drop database column_pruning;

--- a/test/distributed/cases/optimizer/column_pruning.test
+++ b/test/distributed/cases/optimizer/column_pruning.test
@@ -30,6 +30,10 @@ select total from (select count(payload) as unused_count, sum(b) as total from l
 select a from (select a, row_number() over(partition by b order by payload) as rn from l) w order by a;
 select a, rn from (select a, row_number() over(partition by b order by payload) as rn from l) w order by a, rn;
 
+-- An order-sensitive aggregate observes its input sequence. The window result
+-- is unused, but its ordering cannot be removed without changing the JSON array.
+select a, json_arrayagg(payload) from (select a, payload, row_number() over(partition by a order by b desc, payload) as rn from l) w group by a order by a;
+
 -- A scalar aggregate with a discarded value still produces one row on empty
 -- input, so pruning must retain a row-producing aggregate carrier.
 create table empty_t(v int);


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25611

Related to #25612 and #14077.

## What this PR does / why we need it:

Column pruning previously retained three categories of unused physical work:

- every aligned `UNION ALL` position on both branches;
- every aggregate expression and input, including results unused by both the parent and `HAVING`;
- an unused window function together with its `PARTITION` operator and partition/order-only columns.

This PR:

- compacts only `UNION ALL` output positions while retaining complete keys for `UNION DISTINCT`, `INTERSECT`, and `MINUS`;
- compacts aggregate expressions and remaps `HAVING` plus parent-visible physical slots;
- preserves one scalar-aggregate carrier so an empty input still produces one row;
- bypasses unused window/partition operators and their exclusive scan inputs;
- retains otherwise-unused windows when `GROUP_CONCAT`, `JSON_ARRAYAGG`, or `JSON_OBJECTAGG` consumes their input order;
- preserves side-effecting expressions such as `sleep()` across all new pruning paths;
- validates malformed `HAVING` relation/slot mappings and returns an internal planner error instead of panicking;
- avoids new allocations on unchanged set/aggregate paths, reuses one bounded slice for the rare order-retention path, and clears stale slice-tail references after in-place compaction.

Correctness coverage includes DISTINCT/set/grouping keys, `HAVING`, empty scalar aggregates, window post-filters, stacked windows, order-sensitive aggregates, nonzero slot compaction, CTE consumers, ORDER BY below LIMIT, and side effects. Plan-shape tests verify that the intended physical operators and columns are actually removed; result-based BVT verifies execution semantics.

## Testing

- `make build`
- `go test ./pkg/sql/plan/... -count=1` with the repository CGo linker flags
- `go vet ./pkg/sql/plan/...` with the repository CGo linker flags
- focused `go test -race` for column-pruning and `HAVING` remapping tests
- mo-tester: `func_arrayagg.sql`, 57/57 passed
- mo-tester: `column_pruning.test`, 21/21 passed

## Review decision log

- DISTINCT/set operators and every grouping key remain unpruned because they determine row multiplicity or membership.
- Input ordering remains observable for MatrixOne's existing order-sensitive aggregate behavior, so an unused window is retained along order-transparent input paths when the aggregate result is consumed.
- Unreachable optimizer-history nodes remain in `Query.Nodes`; execution and shape assertions traverse only `Query.Steps`. Their lifetime is bounded by one plan.
- `SAMPLE`, `TIME_WINDOW`, and cost-based row-carrier selection are intentionally tracked separately in #25612 because their row-count and special-slot contracts require an execution-layer design.
