### PR TITLE
fix(disttae): reclaim superseded workspace entries

### DIFF
--- a/pkg/vm/engine/disttae/table_meta_reader_test.go
+++ b/pkg/vm/engine/disttae/table_meta_reader_test.go
@@ -269,7 +269,7 @@ func TestCloneTxnTablesInVainGCDeletesUnreferencedTxnLocalSharedObject(t *testin
 	require.NoError(t, writeObjectToFS(ctx, fs, name))
 	txn.engine.cloneTxnCache.AddTxnLocalSharedFile(txn.op.Txn().ID, name)
 
-	txn.writes = append(txn.writes, Entry{
+	txn.appendWorkspaceEntryLocked(Entry{
 		typ:      INSERT,
 		tableId:  42,
 		fileName: name,
@@ -277,7 +277,8 @@ func TestCloneTxnTablesInVainGCDeletesUnreferencedTxnLocalSharedObject(t *testin
 	})
 
 	require.NoError(t, txn.mergeTxnWorkspaceLocked(ctx))
-	require.Nil(t, txn.writes[0].bat)
+	require.Empty(t, txn.writes)
+	require.Zero(t, txn.workspaceSize)
 	require.False(t, txn.engine.cloneTxnCache.IsTxnLocalSharedFile(txn.op.Txn().ID, name))
 	require.Eventually(t, func() bool {
 		return !objectExistsInFS(ctx, fs, name)
@@ -317,24 +318,24 @@ func TestCloneTxnTablesInVainGCKeepsLiveTxnLocalSharedObject(t *testing.T) {
 	txn.engine.cloneTxnCache.AddTxnLocalSharedFile(txn.op.Txn().ID, name)
 
 	liveBat := cloneObjectStatsBatchForTest(t, proc.Mp(), stats...)
-	txn.writes = append(txn.writes,
-		Entry{
-			typ:      INSERT,
-			tableId:  42,
-			fileName: name,
-			bat:      cloneObjectStatsBatchForTest(t, proc.Mp(), stats...),
-		},
-		Entry{
-			typ:      INSERT,
-			tableId:  43,
-			fileName: name,
-			bat:      liveBat,
-		},
-	)
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:      INSERT,
+		tableId:  42,
+		fileName: name,
+		bat:      cloneObjectStatsBatchForTest(t, proc.Mp(), stats...),
+	})
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:      INSERT,
+		tableId:  43,
+		fileName: name,
+		bat:      liveBat,
+	})
 
 	require.NoError(t, txn.mergeTxnWorkspaceLocked(ctx))
-	require.Nil(t, txn.writes[0].bat)
-	require.NotNil(t, txn.writes[1].bat)
+	require.Len(t, txn.writes, 1)
+	require.Equal(t, uint64(43), txn.writes[0].tableId)
+	require.Same(t, liveBat, txn.writes[0].bat)
+	require.Equal(t, uint64(liveBat.Size()), txn.workspaceSize)
 	require.True(t, txn.engine.cloneTxnCache.IsTxnLocalSharedFile(txn.op.Txn().ID, name))
 	require.True(t, objectExistsInFS(ctx, fs, name))
 

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -76,6 +77,169 @@ import (
 // detecting whether a transaction is a read-only transaction
 func (txn *Transaction) ReadOnly() bool {
 	return txn.readOnly.Load()
+}
+
+func (txn *Transaction) addWorkspaceEntryAccountingLocked(entry *Entry) {
+	if entry.bat == nil {
+		entry.accountedSize = 0
+		return
+	}
+
+	size := uint64(entry.bat.Size())
+	rows := entry.bat.RowCount()
+	entry.accountedSize = size
+	txn.workspaceSize += size
+
+	if entry.fileName != "" || catalog.IsSystemTable(entry.tableId) {
+		return
+	}
+
+	switch entry.typ {
+	case INSERT:
+		txn.approximateInMemInsertSize += size
+		txn.approximateInMemInsertCnt += rows
+	case DELETE:
+		txn.approximateInMemDeleteCnt += rows
+	}
+}
+
+func (txn *Transaction) removeWorkspaceEntryAccountingLocked(
+	entry *Entry,
+	size uint64,
+	rows int,
+) {
+	if size > entry.accountedSize {
+		panic("BUG: workspace entry size accounting underflow")
+	}
+	if txn.workspaceSize < size {
+		panic("BUG: workspace size accounting underflow")
+	}
+	entry.accountedSize -= size
+	txn.workspaceSize -= size
+
+	if entry.fileName != "" || catalog.IsSystemTable(entry.tableId) {
+		return
+	}
+
+	switch entry.typ {
+	case INSERT:
+		if txn.approximateInMemInsertSize < size || txn.approximateInMemInsertCnt < rows {
+			panic("BUG: in-memory insert accounting underflow")
+		}
+		txn.approximateInMemInsertSize -= size
+		txn.approximateInMemInsertCnt -= rows
+	case DELETE:
+		if txn.approximateInMemDeleteCnt < rows {
+			panic("BUG: in-memory delete accounting underflow")
+		}
+		txn.approximateInMemDeleteCnt -= rows
+	}
+}
+
+func (txn *Transaction) appendWorkspaceEntryLocked(entry Entry) {
+	txn.addWorkspaceEntryAccountingLocked(&entry)
+	txn.writes = append(txn.writes, entry)
+}
+
+func (txn *Transaction) releaseWorkspaceEntryBatchLocked(idx int) {
+	entry := &txn.writes[idx]
+	if entry.bat == nil {
+		return
+	}
+
+	bat := entry.bat
+	txn.removeWorkspaceEntryAccountingLocked(
+		entry,
+		entry.accountedSize,
+		bat.RowCount(),
+	)
+	delete(txn.batchSelectList, bat)
+	bat.Clean(txn.proc.GetMPool())
+	entry.bat = nil
+}
+
+func (txn *Transaction) shrinkWorkspaceEntryBatchLocked(idx int, sels []int64) {
+	entry := &txn.writes[idx]
+	if entry.bat == nil {
+		return
+	}
+	bat := entry.bat
+	if len(sels) == 0 {
+		delete(txn.batchSelectList, bat)
+		return
+	}
+
+	slices.Sort(sels)
+	sels = slices.Compact(sels)
+
+	beforeRows := bat.RowCount()
+	shrinkBatchWithRowids(bat, sels)
+
+	afterRows := bat.RowCount()
+	releasedSize := uint64(0)
+	if afterRows == 0 {
+		releasedSize = entry.accountedSize
+	}
+
+	txn.removeWorkspaceEntryAccountingLocked(
+		entry,
+		releasedSize,
+		beforeRows-afterRows,
+	)
+	if afterRows == 0 {
+		bat.Clean(txn.proc.GetMPool())
+		entry.bat = nil
+	}
+	delete(txn.batchSelectList, bat)
+}
+
+func (txn *Transaction) mergeWorkspaceEntryBatchesLocked(
+	ctx context.Context,
+	dstIdx int64,
+	srcIdx int64,
+) error {
+	dst := &txn.writes[dstIdx]
+	src := &txn.writes[srcIdx]
+	dstSize := dst.accountedSize
+	dstRows := dst.bat.RowCount()
+	srcSize := src.accountedSize
+	srcRows := src.bat.RowCount()
+
+	// Batch.Append can grow some destination vectors before a later vector
+	// returns an allocation error. Remove the old destination accounting first,
+	// then always restore it from the batch's actual post-Append state.
+	txn.removeWorkspaceEntryAccountingLocked(dst, dstSize, dstRows)
+	if _, err := dst.bat.Append(ctx, txn.proc.Mp(), src.bat); err != nil {
+		txn.addWorkspaceEntryAccountingLocked(dst)
+		return err
+	}
+
+	// Replace the two source batches with the merged batch in the accounting.
+	// Batch.Append may change capacity and varlena-area size non-additively.
+	txn.removeWorkspaceEntryAccountingLocked(src, srcSize, srcRows)
+	txn.addWorkspaceEntryAccountingLocked(dst)
+
+	delete(txn.batchSelectList, src.bat)
+	src.bat.Clean(txn.proc.GetMPool())
+	src.bat = nil
+	return nil
+}
+
+func (txn *Transaction) compactWorkspaceEntriesLocked() {
+	n := 0
+	for i := range txn.writes {
+		if txn.writes[i].bat != nil && txn.writes[i].bat.IsEmpty() {
+			txn.releaseWorkspaceEntryBatchLocked(i)
+		}
+		if txn.writes[i].bat == nil {
+			continue
+		}
+		txn.writes[n] = txn.writes[i]
+		n++
+	}
+
+	clear(txn.writes[n:])
+	txn.writes = txn.writes[:n]
 }
 
 // WriteBatch used to write data to the transaction buffer
@@ -174,14 +338,6 @@ func (txn *Transaction) WriteBatch(
 		}
 		bat.InsertVector(0, objectio.PhysicalAddr_Attr, genRowidVec)
 
-		if !catalog.IsSystemTable(tableId) {
-			txn.approximateInMemInsertSize += uint64(bat.Size())
-			txn.approximateInMemInsertCnt += bat.RowCount()
-		}
-	}
-
-	if typ == DELETE && !catalog.IsSystemTable(tableId) {
-		txn.approximateInMemDeleteCnt += bat.RowCount()
 	}
 
 	if injected, logLevel := objectio.LogWorkspaceInjected(
@@ -247,9 +403,8 @@ func (txn *Transaction) WriteBatch(
 		pkCheckPos:   pkCheckPos,
 		pkCheckReady: pkCheckReady,
 	}
-	txn.writes = append(txn.writes, e)
+	txn.appendWorkspaceEntryLocked(e)
 	txn.pkCount += bat.RowCount()
-	txn.workspaceSize += uint64(bat.Size())
 
 	trace.GetService(txn.proc.GetService()).TxnWrite(txn.op, tableId, typesNames[typ], bat)
 	return
@@ -697,7 +852,6 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 				return nil
 			}
 		}
-		size = 0
 	}
 	if offset < txn.adjustWriteOffset {
 		txn.adjustWriteOffset = offset
@@ -713,7 +867,7 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 		return err
 	}
 
-	if err := txn.dumpInsertBatchLocked(ctx, fs, offset, &size, &pkCount); err != nil {
+	if err := txn.dumpInsertBatchLocked(ctx, fs, offset, &pkCount); err != nil {
 		return err
 	}
 	// release the extra quota
@@ -731,7 +885,7 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 
 	if dumpAll {
 		if txn.approximateInMemDeleteCnt >= txn.engine.config.insertEntryMaxCount {
-			if err := txn.dumpDeleteBatchLocked(ctx, fs, offset, &size); err != nil {
+			if err := txn.dumpDeleteBatchLocked(ctx, fs, offset); err != nil {
 				return err
 			}
 			//After flushing inserts/deletes in memory into S3, the entries in txn.writes will be unordered,
@@ -740,23 +894,13 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 				return err
 			}
 		}
-		txn.approximateInMemDeleteCnt = 0
-		txn.approximateInMemInsertSize = 0
 		txn.pkCount -= pkCount
 		// modifies txn.writes.
-		writes := txn.writes[:0]
-		for i, write := range txn.writes {
-			if write.bat != nil {
-				writes = append(writes, txn.writes[i])
-			}
-		}
-		txn.writes = writes
+		txn.compactWorkspaceEntriesLocked()
 	} else {
-		txn.approximateInMemInsertSize -= size
 		txn.pkCount -= pkCount
 	}
 
-	txn.workspaceSize -= size
 	return nil
 }
 
@@ -764,7 +908,6 @@ func (txn *Transaction) dumpInsertBatchLocked(
 	ctx context.Context,
 	fs fileservice.FileService,
 	offset int,
-	size *uint64,
 	pkCount *int,
 ) error {
 
@@ -840,8 +983,12 @@ func (txn *Transaction) dumpInsertBatchLocked(
 				name:       txn.writes[i].tableName,
 			}
 			bat := txn.writes[i].bat
-			*size += uint64(bat.Size())
 			*pkCount += bat.RowCount()
+			txn.removeWorkspaceEntryAccountingLocked(
+				&txn.writes[i],
+				txn.writes[i].accountedSize,
+				bat.RowCount(),
+			)
 			// skip rowid
 			newBatch := batch.NewWithSize(len(bat.Vecs) - 1)
 			newBatch.SetAttributes(bat.Attrs[1:])
@@ -859,6 +1006,7 @@ func (txn *Transaction) dumpInsertBatchLocked(
 		}
 	}
 
+	clear(writes[lastWriteIndex:])
 	txn.writes = writes[:lastWriteIndex]
 
 	var (
@@ -934,7 +1082,6 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 	ctx context.Context,
 	fs fileservice.FileService,
 	offset int,
-	size *uint64,
 ) error {
 
 	deleteCnt := 0
@@ -963,7 +1110,11 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 			}
 			bat := txn.writes[i].bat
 			deleteCnt += bat.RowCount()
-			*size += uint64(bat.Size())
+			txn.removeWorkspaceEntryAccountingLocked(
+				&txn.writes[i],
+				txn.writes[i].accountedSize,
+				bat.RowCount(),
+			)
 
 			newBat := batch.NewWithSize(len(bat.Vecs))
 			newBat.SetAttributes(bat.Attrs)
@@ -982,6 +1133,7 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 		}
 	}
 
+	clear(writes[lastWriteIndex:])
 	txn.writes = writes[:lastWriteIndex]
 
 	var (
@@ -1211,7 +1363,6 @@ func (txn *Transaction) WriteFileLocked(
 	}
 
 	txn.readOnly.Store(false)
-	txn.workspaceSize += uint64(copied.Size())
 
 	if typ == DELETE {
 		col, area := vector.MustVarlenaRawData(copied.Vecs[0])
@@ -1235,7 +1386,7 @@ func (txn *Transaction) WriteFileLocked(
 		pkCheckReady: true,
 	}
 
-	txn.writes = append(txn.writes, entry)
+	txn.appendWorkspaceEntryLocked(entry)
 
 	return nil
 }
@@ -1277,7 +1428,6 @@ func (txn *Transaction) WriteFileLockedSkipTransfer(
 	}
 
 	txn.readOnly.Store(false)
-	txn.workspaceSize += uint64(copied.Size())
 
 	if typ == DELETE {
 		col, area := vector.MustVarlenaRawData(copied.Vecs[0])
@@ -1300,7 +1450,7 @@ func (txn *Transaction) WriteFileLockedSkipTransfer(
 		skipTransfer: true,
 	}
 
-	txn.writes = append(txn.writes, entry)
+	txn.appendWorkspaceEntryLocked(entry)
 
 	return nil
 }
@@ -1533,14 +1683,10 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 	txn.restoreTxnTableFunc = txn.restoreTxnTableFunc[:0]
 
 	if len(txn.batchSelectList) > 0 {
-		for _, e := range txn.writes {
-			if sels, ok := txn.batchSelectList[e.bat]; ok {
-				txn.approximateInMemInsertCnt -= len(sels)
-				sort.Slice(sels, func(i, j int) bool {
-					return sels[i] < (sels[j])
-				})
-				shrinkBatchWithRowids(e.bat, sels)
-				delete(txn.batchSelectList, e.bat)
+		for i := range txn.writes {
+			bat := txn.writes[i].bat
+			if sels, ok := txn.batchSelectList[bat]; ok {
+				txn.shrinkWorkspaceEntryBatchLocked(i, sels)
 			}
 		}
 	}
@@ -1561,8 +1707,7 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 					)
 					_ = txn.GCObjsByIdxRange(i, i)
 				}
-				e.bat.Clean(txn.proc.GetMPool())
-				txn.writes[i].bat = nil
+				txn.releaseWorkspaceEntryBatchLocked(i)
 			}
 		}
 	}
@@ -1570,6 +1715,7 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 	if err := txn.compactDeletionOnObjsLocked(ctx); err != nil {
 		return err
 	}
+	txn.compactWorkspaceEntriesLocked()
 
 	inserts := objectio.GetReusableBitmap()
 	deletes := objectio.GetReusableBitmap()
@@ -1614,12 +1760,9 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 				if b.bat != nil && a.tableId == b.tableId && a.databaseId == b.databaseId &&
 					a.bat.RowCount()+b.bat.RowCount() <= objectio.BlockMaxRows {
 					merged = true
-					if _, err = a.bat.Append(ctx, txn.proc.Mp(), b.bat); err != nil {
+					if err = txn.mergeWorkspaceEntryBatchesLocked(ctx, idxes[i], idxes[j]); err != nil {
 						return err
 					}
-
-					b.bat.Clean(txn.proc.GetMPool())
-					b.bat = nil
 				}
 
 				if a.bat.RowCount() == objectio.BlockMaxRows {
@@ -1670,16 +1813,7 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 			return err
 		}
 
-		n := 0
-		for i := range txn.writes {
-			if txn.writes[i].bat == nil {
-				continue
-			}
-			txn.writes[n] = txn.writes[i]
-			n++
-		}
-
-		txn.writes = txn.writes[:n]
+		txn.compactWorkspaceEntriesLocked()
 
 		var sortBuf []int64
 		var shuffleBuf []byte
@@ -1866,8 +2000,7 @@ func (txn *Transaction) compactDeletionOnObjsLocked(ctx context.Context) error {
 			offset += int(stats.BlkCnt())
 		}
 
-		txn.writes[i].bat.Clean(txn.proc.GetMPool())
-		txn.writes[i].bat = nil
+		txn.releaseWorkspaceEntryBatchLocked(i)
 	}
 
 	if txn.compactWorker == nil {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1786,32 +1786,32 @@ func (tbl *txnTable) AlterTable(ctx context.Context, c *engine.ConstraintDef, re
 	if createdInTxn {
 		// 3. adjust writes for the table
 		txn.Lock()
+		defer txn.Unlock()
 		for i, n := 0, len(txn.writes); i < n; i++ {
 			if cur := txn.writes[i]; cur.tableId == tbl.tableId && cur.bat != nil && cur.bat.RowCount() > 0 {
 				if sels, exist := txn.batchSelectList[cur.bat]; exist && len(sels) == cur.bat.RowCount() {
 					continue
 				}
-				txn.writes = append(txn.writes, txn.writes[i]) // copy by value
-				transfered := &txn.writes[len(txn.writes)-1]
-				transfered.tableName = tbl.tableName // in case renaming
-				transfered.bat, err = cur.bat.Dup(txn.proc.Mp())
-				if len(renameColMap) > 0 {
-					for i, attr := range transfered.bat.Attrs {
-						if newName, ok := renameColMap[attr]; ok {
-							transfered.bat.Attrs[i] = newName
-						}
-					}
-				}
+				transferred := cur
+				transferred.tableName = tbl.tableName // in case renaming
+				transferred.bat, err = cur.bat.Dup(txn.proc.Mp())
 				if err != nil {
 					return err
 				}
+				if len(renameColMap) > 0 {
+					for i, attr := range transferred.bat.Attrs {
+						if newName, ok := renameColMap[attr]; ok {
+							transferred.bat.Attrs[i] = newName
+						}
+					}
+				}
+				txn.appendWorkspaceEntryLocked(transferred)
 				for j := 0; j < cur.bat.RowCount(); j++ {
 					txn.batchSelectList[cur.bat] = append(txn.batchSelectList[cur.bat], int64(j))
 				}
 
 			}
 		}
-		txn.Unlock()
 	}
 
 	return nil
@@ -2104,7 +2104,10 @@ func (tbl *txnTable) SoftDeleteObject(ctx context.Context, objID *objectio.Objec
 		fileName:     makeSoftDeleteFileName(isTombstone),
 	}
 
-	tbl.getTxn().writes = append(tbl.getTxn().writes, entry)
+	txn := tbl.getTxn()
+	txn.Lock()
+	defer txn.Unlock()
+	txn.appendWorkspaceEntryLocked(entry)
 	return nil
 }
 

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -17,6 +17,7 @@ package disttae
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"sync"
@@ -475,12 +476,10 @@ func TestResolvePKCheckPosForWriteEarlyExit(t *testing.T) {
 
 func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 	proc := testutil.NewProc(t)
-	txn := &Transaction{
-		op:          newTxnOperatorForTest(t),
-		proc:        proc,
-		tableOps:    newTableOps(),
-		databaseOps: newDbOps(),
-	}
+	txn := newWorkspaceCompactionTxnForTest(proc)
+	txn.op = newTxnOperatorForTest(t)
+	txn.tableOps = newTableOps()
+	txn.databaseOps = newDbOps()
 
 	const (
 		dbID            = uint64(7)
@@ -489,10 +488,11 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 
 	defer func() {
 		for i := range txn.writes {
-			if txn.writes[i].bat != nil {
-				txn.writes[i].bat.Clean(proc.Mp())
-			}
+			txn.releaseWorkspaceEntryBatchLocked(i)
 		}
+		require.Zero(t, txn.workspaceSize)
+		require.Zero(t, txn.approximateInMemInsertSize)
+		require.Zero(t, txn.approximateInMemInsertCnt)
 	}()
 
 	// Two entries on the same table are enough to create a nil hole during merge.
@@ -503,7 +503,7 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 		if i == 1 {
 			tableID = 1000
 		}
-		txn.writes = append(txn.writes, Entry{
+		txn.appendWorkspaceEntryLocked(Entry{
 			typ:          INSERT,
 			tableId:      tableID,
 			databaseId:   dbID,
@@ -513,7 +513,7 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 		})
 	}
 
-	txn.writes = append(txn.writes, Entry{
+	txn.appendWorkspaceEntryLocked(Entry{
 		typ:          INSERT,
 		tableId:      catalog.MO_TABLES_ID,
 		databaseId:   catalog.MO_CATALOG_ID,
@@ -522,7 +522,7 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 		note:         noteForCreate(criticalTableID, "critical"),
 		bat:          newInt64BatchForTest(t, proc, []string{"pk"}, []int64{1}),
 	})
-	txn.writes = append(txn.writes, Entry{
+	txn.appendWorkspaceEntryLocked(Entry{
 		typ:          INSERT,
 		tableId:      criticalTableID,
 		databaseId:   dbID,
@@ -545,6 +545,284 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 	require.NotEqual(t, -1, createIdx)
 	require.NotEqual(t, -1, dataIdx)
 	require.Less(t, createIdx, dataIdx)
+}
+
+func TestMergeTxnWorkspaceReclaimsSupersededEntries(t *testing.T) {
+	proc := testutil.NewProc(t)
+	baseline := proc.Mp().CurrNB()
+	txn := newWorkspaceCompactionTxnForTest(proc)
+
+	var live *batch.Batch
+	var steadyStateBytes int64
+	for i := 0; i < 1000; i++ {
+		next := newInsertBatchWithRowIDForTest(t, proc, []int64{int64(i)})
+		txn.appendWorkspaceEntryLocked(Entry{
+			typ:        INSERT,
+			databaseId: 7,
+			tableId:    42,
+			bat:        next,
+		})
+		if live != nil {
+			txn.batchSelectList[live] = []int64{0}
+		}
+
+		require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+		require.Len(t, txn.writes, 1)
+		require.Same(t, next, txn.writes[0].bat)
+		require.Equal(t, uint64(next.Size()), txn.workspaceSize)
+		require.Equal(t, uint64(next.Size()), txn.approximateInMemInsertSize)
+		require.Equal(t, next.RowCount(), txn.approximateInMemInsertCnt)
+		require.Empty(t, txn.batchSelectList)
+
+		if i == 0 {
+			steadyStateBytes = proc.Mp().CurrNB()
+		} else {
+			require.Equal(t, steadyStateBytes, proc.Mp().CurrNB())
+		}
+		live = next
+	}
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+	require.Equal(t, baseline, proc.Mp().CurrNB())
+}
+
+func TestMergeTxnWorkspaceDeduplicatesSelections(t *testing.T) {
+	proc := testutil.NewProc(t)
+	txn := newWorkspaceCompactionTxnForTest(proc)
+	bat := newInsertBatchWithRowIDForTest(t, proc, []int64{1, 2, 3})
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:        INSERT,
+		databaseId: 7,
+		tableId:    42,
+		bat:        bat,
+	})
+	accountedSize := txn.workspaceSize
+	txn.batchSelectList[bat] = []int64{1, 1}
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Len(t, txn.writes, 1)
+	require.Equal(t, 2, bat.RowCount())
+	require.Equal(t, accountedSize, txn.workspaceSize)
+	require.Equal(t, accountedSize, txn.approximateInMemInsertSize)
+	require.Equal(t, 2, txn.approximateInMemInsertCnt)
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+}
+
+func TestMergeTxnWorkspaceReclaimsTablesInVainEntries(t *testing.T) {
+	proc := testutil.NewProc(t)
+	baseline := proc.Mp().CurrNB()
+	txn := newWorkspaceCompactionTxnForTest(proc)
+	bat := newInsertBatchWithRowIDForTest(t, proc, []int64{1, 2, 3})
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:        INSERT,
+		databaseId: 7,
+		tableId:    42,
+		bat:        bat,
+	})
+	txn.tablesInVain[42] = 1
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Empty(t, txn.writes)
+	require.Zero(t, txn.workspaceSize)
+	require.Zero(t, txn.approximateInMemInsertSize)
+	require.Zero(t, txn.approximateInMemInsertCnt)
+	require.Equal(t, baseline, proc.Mp().CurrNB())
+}
+
+func TestMergeTxnWorkspacePreservesTransferredEntryAccounting(t *testing.T) {
+	proc := testutil.NewProc(t)
+	baseline := proc.Mp().CurrNB()
+	txn := newWorkspaceCompactionTxnForTest(proc)
+	original := newInsertBatchWithRowIDForTest(t, proc, []int64{1, 2, 3})
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:        INSERT,
+		databaseId: 7,
+		tableId:    42,
+		tableName:  "before_alter",
+		bat:        original,
+	})
+
+	transferred, err := original.Dup(proc.Mp())
+	require.NoError(t, err)
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:        INSERT,
+		databaseId: 7,
+		tableId:    42,
+		tableName:  "after_alter",
+		bat:        transferred,
+	})
+	txn.batchSelectList[original] = []int64{0, 1, 2}
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Len(t, txn.writes, 1)
+	require.Same(t, transferred, txn.writes[0].bat)
+	require.Equal(t, "after_alter", txn.writes[0].tableName)
+	require.Equal(t, uint64(transferred.Size()), txn.workspaceSize)
+	require.Equal(t, uint64(transferred.Size()), txn.approximateInMemInsertSize)
+	require.Equal(t, transferred.RowCount(), txn.approximateInMemInsertCnt)
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+	require.Equal(t, baseline, proc.Mp().CurrNB())
+}
+
+func TestMergeTxnWorkspacePreservesAccountingWhenCombiningBatches(t *testing.T) {
+	proc := testutil.NewProc(t)
+	baseline := proc.Mp().CurrNB()
+	txn := newWorkspaceCompactionTxnForTest(proc)
+
+	for i := 0; i < 30; i++ {
+		txn.appendWorkspaceEntryLocked(Entry{
+			typ:        INSERT,
+			databaseId: 7,
+			tableId:    42,
+			bat:        newInsertBatchWithRowIDForTest(t, proc, []int64{int64(i)}),
+		})
+	}
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Len(t, txn.writes, 1)
+	require.Equal(t, 30, txn.writes[0].bat.RowCount())
+	require.Equal(t, uint64(txn.writes[0].bat.Size()), txn.workspaceSize)
+	require.Equal(t, uint64(txn.writes[0].bat.Size()), txn.approximateInMemInsertSize)
+	require.Equal(t, 30, txn.approximateInMemInsertCnt)
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+	require.Equal(t, baseline, proc.Mp().CurrNB())
+}
+
+func TestMergeWorkspaceEntryBatchesRestoresAccountingOnError(t *testing.T) {
+	proc := testutil.NewProc(t)
+	baseline := proc.Mp().CurrNB()
+	txn := newWorkspaceCompactionTxnForTest(proc)
+	dst := newInsertBatchWithRowIDForTest(t, proc, []int64{1})
+	src := newInt64BatchForTest(t, proc, []string{"pk"}, []int64{2})
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: dst})
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: src})
+	wantSize := txn.workspaceSize
+	wantRows := txn.approximateInMemInsertCnt
+
+	require.Error(t, txn.mergeWorkspaceEntryBatchesLocked(context.Background(), 0, 1))
+	require.Equal(t, wantSize, txn.workspaceSize)
+	require.Equal(t, wantSize, txn.approximateInMemInsertSize)
+	require.Equal(t, wantRows, txn.approximateInMemInsertCnt)
+	require.NotNil(t, txn.writes[0].bat)
+	require.NotNil(t, txn.writes[1].bat)
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+	txn.releaseWorkspaceEntryBatchLocked(1)
+	require.Equal(t, baseline, proc.Mp().CurrNB())
+}
+
+func TestSoftDeleteObjectUsesWorkspaceAccounting(t *testing.T) {
+	proc := testutil.NewProc(t)
+	baseline := proc.Mp().CurrNB()
+	txn := newWorkspaceCompactionTxnForTest(proc)
+	txn.tnStores = []DNStore{{}}
+	op := newTxnOperatorForTestWithWorkspace(t, txn)
+	op.EXPECT().IsSnapOp().Return(false)
+	txn.op = op
+	tbl := &txnTable{
+		accountId: 1,
+		tableId:   42,
+		tableName: "tbl",
+		db: &txnDatabase{
+			op:           op,
+			databaseId:   7,
+			databaseName: "db",
+		},
+	}
+	rowID := types.RandomRowid()
+
+	require.NoError(t, tbl.SoftDeleteObject(
+		context.Background(),
+		rowID.BorrowObjectID(),
+		false,
+	))
+	require.Len(t, txn.writes, 1)
+	require.Equal(t, SOFT_DELETE_OBJECT, txn.writes[0].typ)
+	require.Equal(t, uint64(txn.writes[0].bat.Size()), txn.workspaceSize)
+	require.Zero(t, txn.approximateInMemInsertSize)
+	require.Zero(t, txn.approximateInMemInsertCnt)
+	require.Zero(t, txn.approximateInMemDeleteCnt)
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+	require.Equal(t, baseline, proc.Mp().CurrNB())
+}
+
+func TestRollbackLastStatementRestoresWorkspaceAccounting(t *testing.T) {
+	proc := testutil.NewProc(t)
+	op := newTxnOperatorForTest(t)
+	op.EXPECT().EnterRollbackStmt()
+	op.EXPECT().ExitRollbackStmt()
+	txn := newWorkspaceCompactionTxnForTest(proc)
+	txn.op = op
+	txn.tableCache = new(sync.Map)
+	txn.tableOps = newTableOps()
+	txn.databaseOps = newDbOps()
+	txn.isCCPRTxn = true
+
+	committed := newInsertBatchWithRowIDForTest(t, proc, []int64{1, 2})
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: committed})
+	committedSize := uint64(committed.Size())
+	txn.statementID = 1
+	txn.offsets = []int{1}
+
+	rolledBack := newInsertBatchWithRowIDForTest(t, proc, []int64{3, 4, 5})
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: rolledBack})
+	rolledBackDelete := newDeleteBatchForTest(t, proc, []int64{1, 2})
+	txn.appendWorkspaceEntryLocked(Entry{typ: DELETE, databaseId: 7, tableId: 42, bat: rolledBackDelete})
+
+	require.NoError(t, txn.RollbackLastStatement(context.Background()))
+	require.Len(t, txn.writes, 1)
+	require.Same(t, committed, txn.writes[0].bat)
+	require.Equal(t, committedSize, txn.workspaceSize)
+	require.Equal(t, committedSize, txn.approximateInMemInsertSize)
+	require.Equal(t, committed.RowCount(), txn.approximateInMemInsertCnt)
+	require.Zero(t, txn.approximateInMemDeleteCnt)
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+}
+
+func BenchmarkMergeTxnWorkspaceRepeatedMutation(b *testing.B) {
+	for _, statements := range []int{1000, 5000, 10000, 30000} {
+		b.Run(fmt.Sprintf("statements=%d", statements), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				proc := testutil.NewProc(b)
+				txn := newWorkspaceCompactionTxnForTest(proc)
+				var live *batch.Batch
+				for i := 0; i < statements; i++ {
+					next := newInsertBatchWithRowIDForTest(b, proc, []int64{int64(i)})
+					txn.appendWorkspaceEntryLocked(Entry{
+						typ:        INSERT,
+						databaseId: 7,
+						tableId:    42,
+						bat:        next,
+					})
+					if live != nil {
+						txn.batchSelectList[live] = []int64{0}
+					}
+					if err := txn.mergeTxnWorkspaceLocked(context.Background()); err != nil {
+						b.Fatal(err)
+					}
+					live = next
+				}
+				txn.releaseWorkspaceEntryBatchLocked(0)
+			}
+		})
+	}
+}
+
+func newWorkspaceCompactionTxnForTest(proc *process.Process) *Transaction {
+	txn := &Transaction{
+		proc:            proc,
+		batchSelectList: make(map[*batch.Batch][]int64),
+		tablesInVain:    make(map[uint64]int),
+		deletedBlocks:   &deletedBlocks{offsets: make(map[types.Blockid][]int64)},
+	}
+	txn.currentRowId.SetSegment(colexec.TxnWorkspaceSegment)
+	return txn
 }
 
 func TestResolvePKCheckPosForWriteWithActiveTxnTable(t *testing.T) {
@@ -1167,7 +1445,7 @@ func newDeleteBatchForTest(
 }
 
 func newInsertBatchWithRowIDForTest(
-	t *testing.T,
+	t testing.TB,
 	proc *process.Process,
 	pks []int64,
 ) *batch.Batch {

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -1015,9 +1015,9 @@ func (txn *Transaction) RollbackLastStatement(ctx context.Context) error {
 			if txn.writes[i].bat == nil {
 				continue
 			}
-			txn.workspaceSize -= uint64(txn.writes[i].bat.Size())
-			txn.writes[i].bat.Clean(txn.proc.Mp())
+			txn.releaseWorkspaceEntryBatchLocked(i)
 		}
+		clear(txn.writes[end:])
 		txn.writes = txn.writes[:end]
 		txn.offsets = txn.offsets[:txn.statementID]
 
@@ -1105,9 +1105,12 @@ type Entry struct {
 	// blockName for s3 file
 	fileName string
 	//tuples would be applied to the table which belongs to the tenant(accountId)
-	bat       *batch.Batch
-	tnStore   DNStore
-	pkChkByTN int8
+	bat *batch.Batch
+	// accountedSize is retained across an in-place partial shrink because
+	// vector backing buffers are not released until the batch is cleaned.
+	accountedSize uint64
+	tnStore       DNStore
+	pkChkByTN     int8
 
 	// skipTransfer indicates this entry should skip transfer processing
 	// Used by CCPR to avoid transfer errors for cross-cluster tombstones


### PR DESCRIPTION

## What type of PR is this?

- [x] BUG
- [x] Improvement

## Which issue(s) this PR fixes:

Fixes #25590

## What this PR does / why we need it:

### Root cause

At every statement boundary, `mergeTxnWorkspaceLocked` could fully supersede an in-memory batch, clean it, and leave an `Entry` with a nil batch in `txn.writes`. The logical working set therefore stayed small, but the transaction history slice kept growing. Later statement processing repeatedly scanned that dead history, causing the super-linear latency reported in #25590.

### Change

- Centralize workspace-entry append, release, shrink, merge, and compaction accounting.
- Compact fully selected, merged, and table-in-vain entries immediately after they become dead. `txn.writes` now represents live workspace entries rather than accumulated dead history.
- Keep `workspaceSize` and in-memory insert/delete thresholds correct across partial shrink, batch merge, S3 dump, statement rollback, ALTER table transfer, file-backed writes, and soft-delete entries.
- Clear discarded slice elements and remove stale `batchSelectList` keys so superseded batches are no longer retained through either path.

The change removes only batches that are fully selected or otherwise already invalidated. Live writes retain their original order and contents.

### Regression coverage

- `TestMergeTxnWorkspaceReclaimsSupersededEntries` runs 1,000 repeated supersessions and asserts one live entry plus a steady `MPool` allocation.
- Added accounting coverage for duplicate selections, table-in-vain cleanup, ALTER transfer, batch-append failure, soft-delete, S3 dump related behavior, and statement rollback.
- `BenchmarkMergeTxnWorkspaceRepeatedMutation` is committed with 1k/5k/10k/30k statement sizes. It isolates the repeated append -> supersede previous -> merge cycle.

### Benchmark on 50

The before/after comparison used the same one-row repeated-UPDATE workspace harness on the same 50 host and image. Each iteration writes a new version, fully supersedes the previous version, then merges the workspace. `live entries` is measured after the final merge.

| Statements | Before | After | Speedup | Live entries |
|---:|---:|---:|---:|---:|
| 1k | 14.22 ms | 7.14 ms | 2.0x | 1000 -> 1 |
| 5k | 189.63 ms | 12.90 ms | 14.7x | 5000 -> 1 |
| 10k | 730.28 ms | 20.00 ms | 36.5x | 10000 -> 1 |
| 30k | 7553.53 ms | 49.78 ms | 151.8x | 30000 -> 1 |

Before the fix, increasing statements 30x increased total time 531x; per-statement cost rose from 14.2 us to 251.8 us. After the fix, the live entry count remains one and the incremental cost is about 1.47 us per statement after fixed setup overhead.

The committed direct microbenchmark on the fixed branch reports 2.22 ms, 9.73 ms, 18.27 ms, and 55.38 ms for 1k, 5k, 10k, and 30k respectively. The comparison harness additionally includes the normal write path, so its absolute values are intentionally reported separately.

### Validation

All validation below ran on 10.222.1.50 against the exact source hashes in this branch.

- Targeted disttae regression tests: PASS.
- `go test -race` for reclaim, merge accounting, rollback, and soft-delete coverage: PASS.
- `BenchmarkMergeTxnWorkspaceRepeatedMutation -benchtime=1x`: PASS.
- End-to-end 30k repeated UPDATE reproduction: first-quarter mean 0.371 ms, last-quarter mean 0.367 ms, ratio 0.989. The pre-fix issue reproduction measured 0.770 ms and 3.991 ms, ratio 5.18.
