### PR TITLE
fix(pipeline): preserve terminal errors across spool abort

### DIFF
--- a/pkg/container/pSpool/sender.go
+++ b/pkg/container/pSpool/sender.go
@@ -252,10 +252,15 @@ func (ps *PipelineSpool) ForceCleanupAfterTerminalSignal() {
 
 // Abort terminates the spool without waiting for receiver acknowledgement.
 // Pending, not-yet-consumed slots are released immediately. Slots already handed
-// to receivers stay valid until their receiver calls ReleaseCurrent.
-func (ps *PipelineSpool) Abort() {
+// to receivers stay valid until their receiver calls ReleaseCurrent. The first
+// abort cause is returned to receivers whose queued spool signals race with the
+// terminal signal. A nil cause falls back to ErrPipelineSpoolAborted.
+func (ps *PipelineSpool) Abort(cause error) {
 	if ps == nil {
 		return
+	}
+	if cause == nil {
+		cause = ErrPipelineSpoolAborted
 	}
 
 	ps.abortOnce.Do(func() {
@@ -263,7 +268,7 @@ func (ps *PipelineSpool) Abort() {
 		defer ps.mu.Unlock()
 
 		ps.aborted = true
-		ps.abortErr = ErrPipelineSpoolAborted
+		ps.abortErr = cause
 		close(ps.abortDone)
 		ps.abortLocked()
 	})

--- a/pkg/container/pSpool/sender_test.go
+++ b/pkg/container/pSpool/sender_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -232,15 +233,31 @@ func TestPipelineSpoolAbortReleasesPendingBatch(t *testing.T) {
 	require.False(t, queryDone)
 	require.Greater(t, mp.CurrNB(), int64(0))
 
-	sp.Abort()
+	sp.Abort(nil)
 	require.Equal(t, int64(0), mp.CurrNB())
 
 	got, info := sp.ReceiveBatch(0)
 	require.Nil(t, got)
-	require.ErrorIs(t, info, ErrPipelineSpoolAborted)
+	require.Same(t, ErrPipelineSpoolAborted, info)
 
-	sp.Abort()
+	sp.Abort(moerr.NewInternalErrorNoCtx("ignored second abort"))
 	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolAbortPreservesFirstCause(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+
+	sp := InitMyPipelineSpool(mp, 1)
+	firstCause := moerr.NewCheckRecursiveLevel(context.Background())
+	sp.Abort(firstCause)
+	sp.Abort(moerr.NewInternalErrorNoCtx("ignored second abort"))
+
+	got, info := sp.ReceiveBatch(0)
+	require.Nil(t, got)
+	require.Same(t, firstCause, info)
 }
 
 func TestPipelineSpoolAbortDefersCurrentBatchRelease(t *testing.T) {
@@ -268,7 +285,7 @@ func TestPipelineSpoolAbortDefersCurrentBatchRelease(t *testing.T) {
 	require.Equal(t, 1024, got.RowCount())
 	require.Greater(t, mp.CurrNB(), int64(0))
 
-	sp.Abort()
+	sp.Abort(nil)
 	require.Greater(t, mp.CurrNB(), int64(0))
 	require.Equal(t, 1024, got.RowCount())
 
@@ -311,7 +328,7 @@ func TestPipelineSpoolAbortUnblocksSendBatchWaitingForFreeSlot(t *testing.T) {
 		done <- nil
 	}()
 
-	sp.Abort()
+	sp.Abort(nil)
 	select {
 	case err := <-done:
 		require.NoError(t, err)
@@ -348,7 +365,7 @@ func TestPipelineSpoolAbortWaitsForAllCurrentBroadcastReceivers(t *testing.T) {
 	require.NotNil(t, got1)
 	require.Greater(t, mp.CurrNB(), int64(0))
 
-	sp.Abort()
+	sp.Abort(nil)
 	require.Greater(t, mp.CurrNB(), int64(0))
 
 	sp.ReleaseCurrent(0)

--- a/pkg/sql/colexec/connector/types.go
+++ b/pkg/sql/colexec/connector/types.go
@@ -93,11 +93,13 @@ func (connector *Connector) Reset(proc *process.Process, pipelineFailed bool, er
 		if terminalSignal.EventType == process.EventEnd && terminalDelivered {
 			connector.cleanupSpool = sp
 		} else {
+			abortErr := terminalErr
 			if terminalSignal.EventType == process.EventEnd && !terminalDelivered {
 				fallbackErr := process.ErrPipelineEndSignalDeliveryFailed
 				connector.sendTerminalWithLog(signalCtx, proc, process.NewAbortSignal(fallbackErr), true, fallbackErr)
+				abortErr = fallbackErr
 			}
-			sp.Abort()
+			sp.Abort(abortErr)
 			connector.cleanupSpool = nil
 		}
 		connector.ctr.sp = nil

--- a/pkg/sql/colexec/connector/types_test.go
+++ b/pkg/sql/colexec/connector/types_test.go
@@ -60,10 +60,11 @@ func TestConnectorResetAbortsSpoolWhenTerminalSignalCannotBeDelivered(t *testing
 	reg.Ch2 <- process.NewPipelineSignalToGetFromSpool(sp, 0)
 	conn := &Connector{Reg: reg}
 	conn.ctr.sp = sp
+	sourceErr := moerr.NewCheckRecursiveLevel(context.Background())
 
 	done := make(chan struct{})
 	go func() {
-		conn.Reset(nil, true, moerr.NewInternalErrorNoCtx("cleanup"))
+		conn.Reset(nil, true, sourceErr)
 		close(done)
 	}()
 
@@ -83,7 +84,41 @@ func TestConnectorResetAbortsSpoolWhenTerminalSignalCannotBeDelivered(t *testing
 	staleSignal := <-reg.Ch2
 	got, info := staleSignal.Action()
 	require.Nil(t, got)
-	require.ErrorIs(t, info, pSpool.ErrPipelineSpoolAborted)
+	require.Same(t, sourceErr, info)
+}
+
+func TestConnectorResetPreservesErrorAheadOfDeliveredTerminal(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newConnectorSpoolTestBatch(t, srcMP, 1)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := pSpool.InitMyPipelineSpool(mp, 1)
+	queryDone, err := sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+
+	reg := process.NewPipelineEdge(2, 0)
+	reg.Ch2 <- process.NewPipelineSignalToGetFromSpool(sp, 0)
+	conn := &Connector{Reg: reg}
+	conn.ctr.sp = sp
+	sourceErr := moerr.NewCheckRecursiveLevel(context.Background())
+
+	conn.Reset(nil, true, sourceErr)
+
+	receiver := process.InitPipelineSignalReceiver(context.Background(), []*process.WaitRegister{reg})
+	got, info := receiver.GetNextBatch(nil)
+	require.Nil(t, got)
+	require.Same(t, sourceErr, info)
+	require.Equal(t, int64(0), mp.CurrNB())
 }
 
 func TestConnectorResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing.T) {
@@ -141,7 +176,7 @@ func TestConnectorResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing
 	staleSignal := <-reg.Ch2
 	got, info := staleSignal.Action()
 	require.Nil(t, got)
-	require.ErrorIs(t, info, pSpool.ErrPipelineSpoolAborted)
+	require.Same(t, process.ErrPipelineEndSignalDeliveryFailed, info)
 }
 
 func TestConnectorResetUsesSharedTerminalSendBudget(t *testing.T) {

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -417,10 +417,11 @@ func TestDispatchResetAbortsSpoolWhenSomeLocalRegIsFull(t *testing.T) {
 		ctr:       &container{sp: sp},
 		LocalRegs: []*process.WaitRegister{fullReg, healthyReg},
 	}
+	sourceErr := moerr.NewCheckRecursiveLevel(context.Background())
 
 	done := make(chan struct{})
 	go func() {
-		d.Reset(nil, true, moerr.NewInternalErrorNoCtx("cleanup"))
+		d.Reset(nil, true, sourceErr)
 		close(done)
 	}()
 
@@ -445,7 +446,7 @@ func TestDispatchResetAbortsSpoolWhenSomeLocalRegIsFull(t *testing.T) {
 	staleSignal := <-fullReg.Ch2
 	got, info := staleSignal.Action()
 	require.Nil(t, got)
-	require.ErrorIs(t, info, pSpool.ErrPipelineSpoolAborted)
+	require.Same(t, sourceErr, info)
 
 	select {
 	case signal := <-healthyReg.Ch2:
@@ -520,12 +521,12 @@ func TestDispatchResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing.
 	staleSignal := <-fullReg.Ch2
 	got, info := staleSignal.Action()
 	require.Nil(t, got)
-	require.ErrorIs(t, info, pSpool.ErrPipelineSpoolAborted)
+	require.Same(t, process.ErrPipelineEndSignalDeliveryFailed, info)
 
 	staleSignal = <-healthyReg.Ch2
 	got, info = staleSignal.Action()
 	require.Nil(t, got)
-	require.ErrorIs(t, info, pSpool.ErrPipelineSpoolAborted)
+	require.Same(t, process.ErrPipelineEndSignalDeliveryFailed, info)
 
 	terminalSignal := <-healthyReg.Ch2
 	require.Equal(t, process.EventEnd, terminalSignal.EventType)

--- a/pkg/sql/colexec/dispatch/types.go
+++ b/pkg/sql/colexec/dispatch/types.go
@@ -265,11 +265,13 @@ func (dispatch *Dispatch) Reset(proc *process.Process, pipelineFailed bool, err 
 		if terminalSignal.EventType == process.EventEnd && allTerminalSignalsDelivered(terminalDelivered) {
 			dispatch.cleanupSpool = sp
 		} else {
+			abortErr := terminalErr
 			if terminalSignal.EventType == process.EventEnd {
 				fallbackErr := process.ErrPipelineEndSignalDeliveryFailed
 				sendAbortSignalsToFailedLocalRegs(signalCtx, proc, dispatch.LocalRegs, terminalDelivered, fallbackErr)
+				abortErr = fallbackErr
 			}
-			sp.Abort()
+			sp.Abort(abortErr)
 			dispatch.cleanupSpool = nil
 		}
 		dispatch.ctr.sp = nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24971

## What this PR does / why we need it:

A failing producer pipeline sends its typed terminal error and then aborts its pipeline spool to reclaim queued batches. If a receiver already has a `GetFromSpool` signal ahead of the terminal signal, that signal observes the aborted spool first. The spool previously returned the generic `pipeline spool aborted` sentinel, masking the producer's real error. This was observed when a recursive CTE correctly raised `recursive level out of range`, but the client intermittently received the generic spool error.

This PR makes the spool's abort cause explicit and first-wins:

- `PipelineSpool.Abort(cause)` preserves the original terminal cause; nil retains the generic sentinel fallback.
- Connector and dispatch pass the execution error on failed pipelines.
- A graceful End delivery failure uses `ErrPipelineEndSignalDeliveryFailed`.
- Regression tests cover queued data before both delivered and undeliverable terminal signals, shared dispatch spools, nil causes, and repeated Abort calls.

The change is cleanup-only: it adds no goroutines, waits, allocations, or data-path branches.

Validation:

- `go test -count=1` and `go test -race -count=1` for `pSpool`, `connector`, and `dispatch`
- dependent tests for `process`, `pipeline`, `merge`, and `mergecte`
- `go build`, `go vet`, `molint`, and `make err-check`
- full `make build`
- online recursive CTE error reproduced 100 times with the expected error
- `recursive_cte.sql` BVT: 45/45 passed
