### PR TITLE
fix(disttae): strengthen reusable relation handle reset coverage and correctness

### DIFF
--- a/pkg/sql/colexec/constraint_util.go
+++ b/pkg/sql/colexec/constraint_util.go
@@ -139,7 +139,7 @@ func getRelationByObjRef(ctx context.Context, proc *process.Process, eg engine.E
 		return nil, moerr.NewNoSuchTable(ctx, ref.SchemaName, objName)
 	}
 
-	return relation, nil
+	return engine.NewRelationHandle(relation), nil
 }
 
 func GetRelAndPartitionRelsByObjRef(

--- a/pkg/sql/colexec/deletion/deletion.go
+++ b/pkg/sql/colexec/deletion/deletion.go
@@ -73,11 +73,8 @@ func (deletion *Deletion) Prepare(proc *process.Process) error {
 				return err
 			}
 			deletion.ctr.source = rel
-		} else {
-			err := deletion.ctr.source.Reset(proc.GetTxnOperator())
-			if err != nil {
-				return err
-			}
+		} else if err := deletion.ctr.source.Reset(proc.GetTxnOperator()); err != nil {
+			return err
 		}
 
 	}

--- a/pkg/sql/colexec/deletion/deletion_partition_test.go
+++ b/pkg/sql/colexec/deletion/deletion_partition_test.go
@@ -32,7 +32,7 @@ func TestPartitionDeleteCallDoesNotMutateSharedObjectRef(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	proc, eng := prepareDeletionTest(t, ctrl)
+	proc, eng, _, _ := prepareDeletionTest(t, ctrl)
 
 	raw := &Deletion{
 		DeleteCtx: &DeleteCtx{

--- a/pkg/sql/colexec/deletion/deletion_test.go
+++ b/pkg/sql/colexec/deletion/deletion_test.go
@@ -17,6 +17,7 @@ package deletion
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -35,13 +36,27 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
+type relationHandleFactory struct {
+	engine.Relation
+	handle         engine.Relation
+	newHandleCalls int
+}
+
+func (f *relationHandleFactory) NewRelationHandle() engine.Relation {
+	f.newHandleCalls++
+	return f.handle
+}
+
 func TestString(t *testing.T) {
 	buf := new(bytes.Buffer)
 	arg := &Deletion{}
 	arg.String(buf)
 }
 
-func prepareDeletionTest(t *testing.T, ctrl *gomock.Controller) (*process.Process, engine.Engine) {
+func prepareDeletionTest(
+	t *testing.T,
+	ctrl *gomock.Controller,
+) (*process.Process, engine.Engine, *mock_frontend.MockRelation, *relationHandleFactory) {
 	ctx := context.TODO()
 	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 	txnOperator.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()
@@ -65,20 +80,22 @@ func prepareDeletionTest(t *testing.T, ctrl *gomock.Controller) (*process.Proces
 	relation := mock_frontend.NewMockRelation(ctrl)
 	relation.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	relation.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	database.EXPECT().Relation(gomock.Any(), gomock.Any(), gomock.Any()).Return(relation, nil).AnyTimes()
+	factory := &relationHandleFactory{Relation: relation, handle: relation}
+	database.EXPECT().Relation(gomock.Any(), gomock.Any(), gomock.Any()).Return(factory, nil).AnyTimes()
 
 	proc := testutil.NewProc(t)
 	proc.Base.TxnClient = txnClient
 	proc.Ctx = ctx
 	proc.Base.TxnOperator = txnOperator
-	return proc, eng
+	return proc, eng, relation, factory
 }
 
 func TestNormalDeletion(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	proc, eng := prepareDeletionTest(t, ctrl)
+	proc, eng, relation, factory := prepareDeletionTest(t, ctrl)
+	relation.EXPECT().Reset(gomock.Any()).Return(nil).Times(1)
 	arg := Deletion{
 		DeleteCtx: &DeleteCtx{
 			Ref: &plan.ObjectRef{
@@ -95,26 +112,34 @@ func TestNormalDeletion(t *testing.T) {
 	resetChildren(&arg, proc.Mp())
 	err := arg.Prepare(proc)
 	require.NoError(t, err)
+	firstSource := arg.ctr.source
+	require.Same(t, relation, firstSource)
+	require.Equal(t, 1, factory.newHandleCalls)
 	_, err = vm.Exec(&arg, proc)
 	require.NoError(t, err)
 
 	arg.Reset(proc, false, nil)
-	require.Nil(t, arg.ctr.source)
+	require.Same(t, firstSource, arg.ctr.source)
 
 	err = arg.Prepare(proc)
 	require.NoError(t, err)
+	require.Same(t, firstSource, arg.ctr.source)
+	require.Equal(t, 1, factory.newHandleCalls)
 	_, err = vm.Exec(&arg, proc)
 	require.NoError(t, err)
 	arg.Free(proc, false, nil)
+	require.Nil(t, arg.ctr.source)
 	proc.Free()
 	require.Equal(t, int64(0), proc.GetMPool().CurrNB())
 }
 
-func TestNormalDeletionResetReacquiresSource(t *testing.T) {
+func TestNormalDeletionResetErrorKeepsHandle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	proc, eng := prepareDeletionTest(t, ctrl)
+	proc, eng, relation, factory := prepareDeletionTest(t, ctrl)
+	resetErr := errors.New("reset relation")
+	relation.EXPECT().Reset(gomock.Any()).Return(resetErr).Times(1)
 
 	arg := Deletion{
 		DeleteCtx: &DeleteCtx{
@@ -136,12 +161,15 @@ func TestNormalDeletionResetReacquiresSource(t *testing.T) {
 	require.NoError(t, err)
 
 	arg.Reset(proc, false, nil)
-	require.Nil(t, arg.ctr.source)
+	firstSource := arg.ctr.source
+	require.Same(t, relation, firstSource)
 
 	err = arg.Prepare(proc)
-	require.NoError(t, err)
-	require.NotNil(t, arg.ctr.source)
-	arg.Free(proc, false, nil)
+	require.ErrorIs(t, err, resetErr)
+	require.Same(t, firstSource, arg.ctr.source)
+	require.Equal(t, 1, factory.newHandleCalls)
+	arg.Free(proc, true, resetErr)
+	require.Nil(t, arg.ctr.source)
 	proc.Free()
 	require.Equal(t, int64(0), proc.GetMPool().CurrNB())
 }

--- a/pkg/sql/colexec/deletion/types.go
+++ b/pkg/sql/colexec/deletion/types.go
@@ -180,7 +180,6 @@ func (deletion *Deletion) Reset(proc *process.Process, pipelineFailed bool, err 
 
 	ctr.batch_size = 0
 	ctr.deleted_length = 0
-	ctr.source = nil
 }
 
 // delete from t1 using t1 join t2 on t1.a = t2.a;

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -197,11 +197,8 @@ func (insert *Insert) Prepare(proc *process.Process) error {
 				return err
 			}
 			insert.ctr.source = rel
-		} else {
-			err := insert.ctr.source.Reset(proc.GetTxnOperator())
-			if err != nil {
-				return err
-			}
+		} else if err := insert.ctr.source.Reset(proc.GetTxnOperator()); err != nil {
+			return err
 		}
 
 		if insert.ctr.buf == nil {

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -16,6 +16,7 @@ package insert
 
 import (
 	"context"
+	"errors"
 	goruntime "runtime"
 	"testing"
 	"time"
@@ -38,6 +39,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type relationHandleFactory struct {
+	engine.Relation
+	handle         engine.Relation
+	newHandleCalls int
+}
+
+func (f *relationHandleFactory) NewRelationHandle() engine.Relation {
+	f.newHandleCalls++
+	return f.handle
+}
+
 func TestInsertOperator(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -57,12 +69,13 @@ func TestInsertOperator(t *testing.T) {
 	}).AnyTimes()
 
 	database := mock_frontend.NewMockDatabase(ctrl)
-	eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(database, nil).AnyTimes()
+	eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(database, nil).Times(1)
 
 	relation := mock_frontend.NewMockRelation(ctrl)
 	relation.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	relation.EXPECT().Reset(gomock.Any()).Return(nil).AnyTimes()
-	database.EXPECT().Relation(gomock.Any(), gomock.Any(), gomock.Any()).Return(relation, nil).AnyTimes()
+	relation.EXPECT().Reset(gomock.Any()).Return(nil).Times(1)
+	factory := &relationHandleFactory{Relation: relation, handle: relation}
+	database.EXPECT().Relation(gomock.Any(), gomock.Any(), gomock.Any()).Return(factory, nil).Times(1)
 
 	proc := testutil.NewProc(t)
 	proc.Base.TxnClient = txnClient
@@ -103,25 +116,68 @@ func TestInsertOperator(t *testing.T) {
 	resetChildren(&argument1, batch1)
 	err := argument1.Prepare(proc)
 	require.NoError(t, err)
+	firstSource := argument1.ctr.source
+	require.Same(t, relation, firstSource)
+	require.Equal(t, 1, factory.newHandleCalls)
 	_, err = vm.Exec(&argument1, proc)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), argument1.ctr.affectedRows)
 
 	argument1.Reset(proc, false, nil)
-	require.Nil(t, argument1.ctr.source)
+	require.Same(t, firstSource, argument1.ctr.source)
 
 	resetChildren(&argument1, batch1)
 	err = argument1.Prepare(proc)
 	require.NoError(t, err)
+	require.Same(t, firstSource, argument1.ctr.source)
+	require.Equal(t, 1, factory.newHandleCalls)
 	_, err = vm.Exec(&argument1, proc)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), argument1.ctr.affectedRows)
 
 	argument1.Reset(proc, false, nil)
 	argument1.Free(proc, false, nil)
+	require.Nil(t, argument1.ctr.source)
 	argument1.GetChildren(0).Free(proc, false, nil)
 	proc.Free()
 	require.Equal(t, int64(0), proc.GetMPool().CurrNB())
+}
+
+func TestInsertPrepareRelationResetErrorKeepsHandle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	resetErr := errors.New("reset relation")
+	eng := mock_frontend.NewMockEngine(ctrl)
+	database := mock_frontend.NewMockDatabase(ctrl)
+	relation := mock_frontend.NewMockRelation(ctrl)
+	factory := &relationHandleFactory{Relation: relation, handle: relation}
+
+	eng.EXPECT().Database(gomock.Any(), "testDb", gomock.Any()).Return(database, nil).Times(1)
+	database.EXPECT().Relation(gomock.Any(), "testTable", gomock.Any()).Return(factory, nil).Times(1)
+	relation.EXPECT().Reset(gomock.Any()).Return(resetErr).Times(1)
+
+	proc := testutil.NewProc(t)
+	arg := &Insert{
+		InsertCtx: &InsertCtx{
+			Engine: eng,
+			Ref: &plan.ObjectRef{
+				SchemaName: "testDb",
+				ObjName:    "testTable",
+			},
+		},
+	}
+
+	require.NoError(t, arg.Prepare(proc))
+	firstSource := arg.ctr.source
+	arg.Reset(proc, false, nil)
+	require.ErrorIs(t, arg.Prepare(proc), resetErr)
+	require.Same(t, firstSource, arg.ctr.source)
+	require.Equal(t, 1, factory.newHandleCalls)
+
+	arg.Free(proc, true, resetErr)
+	require.Nil(t, arg.ctr.source)
+	proc.Free()
 }
 
 func resetChildren(arg *Insert, bat *batch.Batch) {

--- a/pkg/sql/colexec/insert/types.go
+++ b/pkg/sql/colexec/insert/types.go
@@ -137,7 +137,6 @@ func (insert *Insert) Reset(proc *process.Process, pipelineFailed bool, err erro
 	if insert.ctr.buf != nil {
 		insert.ctr.buf.CleanOnlyData()
 	}
-	insert.ctr.source = nil
 }
 
 // The Argument for insert data directly to s3 can not be free when this function called as some datastructure still needed.

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -102,23 +102,19 @@ func (lockOp *LockOp) Prepare(proc *process.Process) error {
 	}
 	if len(lockOp.ctr.relations) == 0 {
 		lockOp.ctr.relations = make([]engine.Relation, len(lockOp.targets))
-		for i, target := range lockOp.targets {
-			if target.objRef != nil {
-				rel, err := colexec.GetRelAndPartitionRelsByObjRef(proc.Ctx, proc, lockOp.engine, target.objRef)
-				if err != nil {
-					return err
-				}
-				lockOp.ctr.relations[i] = rel
-			}
+	}
+	for i, target := range lockOp.targets {
+		if target.objRef == nil {
+			continue
 		}
-	} else {
-		for i, target := range lockOp.targets {
-			if target.objRef != nil {
-				err := lockOp.ctr.relations[i].Reset(proc.GetTxnOperator())
-				if err != nil {
-					return err
-				}
+		if lockOp.ctr.relations[i] == nil {
+			rel, err := colexec.GetRelAndPartitionRelsByObjRef(proc.Ctx, proc, lockOp.engine, target.objRef)
+			if err != nil {
+				return err
 			}
+			lockOp.ctr.relations[i] = rel
+		} else if err := lockOp.ctr.relations[i].Reset(proc.GetTxnOperator()); err != nil {
+			return err
 		}
 	}
 	if lockOp.ctr.parker == nil {

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -17,6 +17,7 @@ package lockop
 import (
 	"bytes"
 	"context"
+	"errors"
 	"math"
 	"testing"
 	"time"
@@ -39,6 +40,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -1376,12 +1378,48 @@ func TestLockOpResetClearsLockCount(t *testing.T) {
 	arg.ctr.lockCount = 7
 	arg.ctr.defChanged = true
 	arg.ctr.retryError = moerr.NewTxnNeedRetryNoCtx()
+	arg.ctr.relations = []engine.Relation{nil}
 
 	arg.Reset(nil, false, nil)
 
 	require.Equal(t, int64(0), arg.ctr.lockCount)
 	require.False(t, arg.ctr.defChanged)
 	require.Nil(t, arg.ctr.retryError)
+	require.Len(t, arg.ctr.relations, 1)
+}
+
+func TestLockOpPrepareRecoversFromPartialRelationInitialization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	database := mock_frontend.NewMockDatabase(ctrl)
+	relation1 := mock_frontend.NewMockRelation(ctrl)
+	relation2 := mock_frontend.NewMockRelation(ctrl)
+	lookupErr := errors.New("lookup t2")
+
+	eng.EXPECT().Database(gomock.Any(), "db", gomock.Any()).Return(database, nil).AnyTimes()
+	database.EXPECT().Relation(gomock.Any(), "t1", gomock.Any()).Return(relation1, nil).Times(1)
+	database.EXPECT().Relation(gomock.Any(), "t2", gomock.Any()).Return(nil, lookupErr).Times(1)
+	database.EXPECT().Relation(gomock.Any(), "t2", gomock.Any()).Return(relation2, nil).Times(1)
+	relation1.EXPECT().Reset(gomock.Any()).Return(nil).Times(1)
+
+	arg := NewArgumentByEngine(eng)
+	arg.AddLockTarget(1, &plan.ObjectRef{SchemaName: "db", ObjName: "t1"}, 0, types.T_int64.ToType(), -1, -1, nil, false)
+	arg.AddLockTarget(2, &plan.ObjectRef{SchemaName: "db", ObjName: "t2"}, 0, types.T_int64.ToType(), -1, -1, nil, false)
+	proc := testutil.NewProc(t)
+
+	require.ErrorIs(t, arg.Prepare(proc), lookupErr)
+	require.Same(t, relation1, arg.ctr.relations[0])
+	require.Nil(t, arg.ctr.relations[1])
+
+	require.NoError(t, arg.Prepare(proc))
+	require.Same(t, relation1, arg.ctr.relations[0])
+	require.Same(t, relation2, arg.ctr.relations[1])
+
+	arg.Free(proc, true, lookupErr)
+	arg.Release()
+	proc.Free()
 }
 
 func runLockNonBlockingOpTest(

--- a/pkg/sql/colexec/multi_update/multi_update.go
+++ b/pkg/sql/colexec/multi_update/multi_update.go
@@ -45,9 +45,14 @@ func (update *MultiUpdate) Prepare(proc *process.Process) error {
 	} else {
 		update.OpAnalyzer.Reset()
 	}
-
 	if update.ctr.sources == nil {
 		update.ctr.sources = make(map[uint64]engine.Relation)
+	} else {
+		for _, source := range update.ctr.sources {
+			if err := source.Reset(proc.GetTxnOperator()); err != nil {
+				return err
+			}
+		}
 	}
 
 	if update.ctr.updateCtxInfos == nil {
@@ -75,7 +80,6 @@ func (update *MultiUpdate) Prepare(proc *process.Process) error {
 			update.ctr.updateCtxInfos[updateCtx.TableDef.Name] = info
 		}
 	}
-
 	for _, updateCtx := range update.MultiUpdateCtx {
 		info := update.ctr.updateCtxInfos[updateCtx.TableDef.Name]
 		if update.Action != UpdateWriteS3 {
@@ -85,11 +89,8 @@ func (update *MultiUpdate) Prepare(proc *process.Process) error {
 					return err
 				}
 				info.Source = rel
-			} else {
-				err := info.Source.Reset(proc.GetTxnOperator())
-				if err != nil {
-					return err
-				}
+			} else if err := info.Source.Reset(proc.GetTxnOperator()); err != nil {
+				return err
 			}
 		}
 	}
@@ -494,6 +495,7 @@ func (update *MultiUpdate) getSourceByID(
 		return nil, err
 	}
 
+	r = engine.NewRelationHandle(r)
 	update.ctr.sources[id] = r
 	return r, nil
 }

--- a/pkg/sql/colexec/multi_update/util_for_test.go
+++ b/pkg/sql/colexec/multi_update/util_for_test.go
@@ -115,6 +115,11 @@ func runTestCases(t *testing.T, proc *process.Process, tcs []*testCase) {
 			continue
 		}
 		require.NoError(t, err)
+		if tc.op.Action != UpdateWriteS3 {
+			for _, info := range tc.op.ctr.updateCtxInfos {
+				require.NotNil(t, info.Source)
+			}
+		}
 
 		for {
 			res, err = vm.Exec(tc.op, proc)

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -269,6 +269,11 @@ func (c *Compile) clear() {
 	c.anal = nil
 	c.e = nil
 
+	if c.lockMeta != nil {
+		c.lockMeta.clear(c.proc)
+		c.lockMeta = nil
+	}
+
 	c.proc.Free()
 	c.proc = nil
 
@@ -288,11 +293,6 @@ func (c *Compile) clear() {
 	c.disableDropAutoIncrement = false
 	c.keepAutoIncrement = 0
 	c.disableLock = false
-
-	if c.lockMeta != nil {
-		c.lockMeta.clear(c.proc)
-		c.lockMeta = nil
-	}
 
 	for _, exe := range c.filterExprExes {
 		exe.Free()
@@ -2920,17 +2920,13 @@ func (c *Compile) compileTableScanDataSource(s *Scope) error {
 		}
 		rel, err = db.Relation(ctx, node.TableDef.Name, c.proc)
 		if err != nil {
-			if txnOp.IsSnapOp() {
-				return err
-			}
 			return err
 		}
-		tblDef = rel.GetTableDef(ctx)
-		s.DataSource.Rel = rel
-	} else {
-		s.DataSource.Rel.Reset(txnOp)
-		tblDef = s.DataSource.Rel.GetTableDef(ctx)
+		s.DataSource.Rel = engine.NewRelationHandle(rel)
+	} else if err = s.DataSource.Rel.Reset(txnOp); err != nil {
+		return err
 	}
+	tblDef = s.DataSource.Rel.GetTableDef(ctx)
 
 	if len(node.FilterList) != len(s.DataSource.FilterList) {
 		s.DataSource.FilterList = plan2.DeepCopyExprList(node.FilterList)

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/system"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -500,6 +501,56 @@ func TestLockMeta_doLock(t *testing.T) {
 	eng := mock_frontend.NewMockEngine(ctrl)
 
 	assert.Error(t, lm.doLock(eng, proc))
+}
+
+func TestLockMetaInitRetriesAfterPartialFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := testutil.NewProcess(t)
+	proc.Ctx = defines.AttachAccountId(context.Background(), catalog.System_Account)
+	eng := mock_frontend.NewMockEngine(ctrl)
+	database := mock_frontend.NewMockDatabase(ctrl)
+	databaseRel := mock_frontend.NewMockRelation(ctrl)
+	tableRel := mock_frontend.NewMockRelation(ctrl)
+	lookupErr := moerr.NewInternalErrorNoCtx("lookup mo_tables")
+
+	eng.EXPECT().Database(gomock.Any(), catalog.MO_CATALOG, gomock.Any()).Return(database, nil).Times(2)
+	database.EXPECT().Relation(gomock.Any(), catalog.MO_DATABASE, gomock.Any()).Return(databaseRel, nil).Times(2)
+	database.EXPECT().Relation(gomock.Any(), catalog.MO_TABLES, gomock.Any()).Return(nil, lookupErr).Times(1)
+	database.EXPECT().Relation(gomock.Any(), catalog.MO_TABLES, gomock.Any()).Return(tableRel, nil).Times(1)
+	databaseRel.EXPECT().GetTableID(gomock.Any()).Return(uint64(1)).Times(1)
+	tableRel.EXPECT().GetTableID(gomock.Any()).Return(uint64(2)).Times(1)
+	tableRel.EXPECT().Reset(gomock.Any()).Return(nil).Times(1)
+	databaseRel.EXPECT().Reset(gomock.Any()).Return(nil).Times(1)
+
+	lm := NewLockMeta()
+	require.ErrorIs(t, lm.initLockExe(eng, proc), lookupErr)
+	require.Nil(t, lm.lockDbExe)
+	require.Nil(t, lm.lockTableExe)
+	require.Nil(t, lm.database_rel)
+	require.Nil(t, lm.table_rel)
+
+	require.NoError(t, lm.initLockExe(eng, proc))
+	require.NotNil(t, lm.lockDbExe)
+	require.NotNil(t, lm.lockTableExe)
+	require.Same(t, databaseRel, lm.database_rel)
+	require.Same(t, tableRel, lm.table_rel)
+	require.NoError(t, lm.initLockExe(eng, proc))
+
+	lm.clear(proc)
+	proc.Free()
+}
+
+func TestCompileClearReleasesLockMetaBeforeProcess(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	c := allocateNewCompile(proc)
+	c.lockMeta = NewLockMeta()
+	c.lockMeta.lockMetaVecs = []*vector.Vector{vector.NewVec(types.T_uint32.ToType())}
+
+	require.NotPanics(t, c.clear)
+	require.Nil(t, c.proc)
+	require.Nil(t, c.lockMeta)
 }
 
 func TestCompileShuffleGroupV2FallbackWhenScopeMcpuDiffersFromDop(t *testing.T) {

--- a/pkg/sql/compile/lock_meta.go
+++ b/pkg/sql/compile/lock_meta.go
@@ -60,14 +60,7 @@ func (l *LockMeta) clear(proc *process.Process) {
 	for k := range l.metaTables {
 		delete(l.metaTables, k)
 	}
-	if l.lockDbExe != nil {
-		l.lockDbExe.Free()
-		l.lockDbExe = nil
-	}
-	if l.lockTableExe != nil {
-		l.lockTableExe.Free()
-		l.lockTableExe = nil
-	}
+	l.clearInitializedState()
 	for _, vec := range l.lockMetaVecs {
 		vec.Free(proc.Mp())
 	}
@@ -210,11 +203,17 @@ func (l *LockMeta) lockMetaRows(e engine.Engine, proc *process.Process, rel engi
 }
 
 func (l *LockMeta) initLockExe(e engine.Engine, proc *process.Process) error {
-	if l.lockTableExe != nil {
-		l.table_rel.Reset(proc.GetTxnOperator())
-		l.database_rel.Reset(proc.GetTxnOperator())
-		return nil
+	if l.lockDbExe != nil && l.lockTableExe != nil &&
+		l.database_rel != nil && l.table_rel != nil {
+		if err := l.table_rel.Reset(proc.GetTxnOperator()); err != nil {
+			return err
+		}
+		return l.database_rel.Reset(proc.GetTxnOperator())
 	}
+	// Publish the executors and relation handles only after the whole
+	// initialization succeeds. A retry after a partial engine/catalog failure
+	// must rebuild missing state instead of resetting nil relations.
+	l.clearInitializedState()
 
 	accountTyp := types.T_uint32.ToType()
 	accountIdExpr := &plan.Expr{
@@ -250,21 +249,30 @@ func (l *LockMeta) initLockExe(e engine.Engine, proc *process.Process) error {
 	if err != nil {
 		return err
 	}
-	exec, err := colexec.NewExpressionExecutor(proc, lockDbExpr)
+	lockDbExe, err := colexec.NewExpressionExecutor(proc, lockDbExpr)
 	if err != nil {
 		return err
 	}
-	l.lockDbExe = exec
+	var lockTableExe colexec.ExpressionExecutor
+	initialized := false
+	defer func() {
+		if initialized {
+			return
+		}
+		lockDbExe.Free()
+		if lockTableExe != nil {
+			lockTableExe.Free()
+		}
+	}()
 
 	lockTblxpr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, function.SerialFunctionName, []*plan.Expr{accountIdExpr, dbNameExpr, tblNameExpr})
 	if err != nil {
 		return err
 	}
-	exec, err = colexec.NewExpressionExecutor(proc, lockTblxpr)
+	lockTableExe, err = colexec.NewExpressionExecutor(proc, lockTblxpr)
 	if err != nil {
 		return err
 	}
-	l.lockTableExe = exec
 
 	dbSource, err := e.Database(proc.Ctx, catalog.MO_CATALOG, proc.GetTxnOperator())
 	if err != nil {
@@ -274,15 +282,42 @@ func (l *LockMeta) initLockExe(e engine.Engine, proc *process.Process) error {
 	if err != nil {
 		return err
 	}
-	l.database_table_id = rel.GetTableID(proc.Ctx)
-	l.database_rel = rel
+	if rel == nil {
+		return moerr.NewNoSuchTable(proc.Ctx, catalog.MO_CATALOG, catalog.MO_DATABASE)
+	}
+	databaseRel := engine.NewRelationHandle(rel)
 
 	rel, err = dbSource.Relation(proc.Ctx, catalog.MO_TABLES, nil)
 	if err != nil {
 		return err
 	}
-	l.table_table_id = rel.GetTableID(proc.Ctx)
-	l.table_rel = rel
+	if rel == nil {
+		return moerr.NewNoSuchTable(proc.Ctx, catalog.MO_CATALOG, catalog.MO_TABLES)
+	}
+	tableRel := engine.NewRelationHandle(rel)
+	databaseTableID := databaseRel.GetTableID(proc.Ctx)
+	tableTableID := tableRel.GetTableID(proc.Ctx)
+
+	l.lockDbExe = lockDbExe
+	l.lockTableExe = lockTableExe
+	l.database_table_id = databaseTableID
+	l.database_rel = databaseRel
+	l.table_table_id = tableTableID
+	l.table_rel = tableRel
+	initialized = true
 
 	return nil
+}
+
+func (l *LockMeta) clearInitializedState() {
+	if l.lockDbExe != nil {
+		l.lockDbExe.Free()
+		l.lockDbExe = nil
+	}
+	if l.lockTableExe != nil {
+		l.lockTableExe.Free()
+		l.lockTableExe = nil
+	}
+	l.database_rel = nil
+	l.table_rel = nil
 }

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -175,6 +175,34 @@ func checkScopeRoot(t *testing.T, s *Scope) {
 	}
 }
 
+func TestScopeResetKeepsReusableRelationHandle(t *testing.T) {
+	rel := &mockRelationForMembershipFilter{}
+	s := &Scope{
+		RootOp: colexec.NewMockOperator(),
+		DataSource: &Source{
+			R:   &struct{ engine.Reader }{},
+			Rel: rel,
+		},
+	}
+
+	require.NoError(t, s.Reset(NewMockCompile(t)))
+	require.Nil(t, s.DataSource.R)
+	require.Same(t, rel, s.DataSource.Rel)
+}
+
+func TestLockMetaResetKeepsReusableRelationHandles(t *testing.T) {
+	l := NewLockMeta()
+	databaseRel := &mockRelationForMembershipFilter{}
+	tableRel := &mockRelationForMembershipFilter{}
+	l.database_rel = databaseRel
+	l.table_rel = tableRel
+
+	l.reset(nil)
+
+	require.Same(t, databaseRel, l.database_rel)
+	require.Same(t, tableRel, l.table_rel)
+}
+
 func TestScopeSerialization2(t *testing.T) {
 	testCompile := NewMockCompile(t)
 	var reg process.WaitRegister

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2038,11 +2038,19 @@ func (txn *Transaction) ForEachTableWrites(databaseId uint64, tableId uint64, of
 // Before it gets the cached table, it checks whether the table is deleted by another
 // transaction by go through the delete tables slice, and advance its cachedIndex.
 func (txn *Transaction) getCachedTable(
-	_ context.Context,
+	ctx context.Context,
 	k tableKey,
 ) *txnTableDelegate {
+	return txn.getCachedTableByKey(ctx, k, k)
+}
+
+func (txn *Transaction) getCachedTableByKey(
+	_ context.Context,
+	k tableKey,
+	cacheKey any,
+) *txnTableDelegate {
 	var tbl *txnTableDelegate
-	if v, ok := txn.tableCache.Load(k); ok {
+	if v, ok := txn.tableCache.Load(cacheKey); ok {
 		tbl = v.(*txnTableDelegate)
 
 		if txn.op.IsSnapOp() || !txn.op.Txn().IsRCIsolation() {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -132,6 +132,11 @@ func shouldLogPKPersistedChanged(tableID uint64) bool {
 
 var _ engine.Relation = new(txnTable)
 
+func (tbl *txnTable) NewRelationHandle() engine.Relation {
+	canonical := &txnTableDelegate{origin: tbl}
+	return canonical.NewRelationHandle()
+}
+
 func newTxnTable(
 	ctx context.Context,
 	db *txnDatabase,
@@ -3084,23 +3089,8 @@ func (tbl *txnTable) GetNonAppendableObjectStats(ctx context.Context) ([]objecti
 	return objStats, nil
 }
 
-// Reset what?
-// TODO: txnTable should be stateless
 func (tbl *txnTable) Reset(op client.TxnOperator) error {
-	ws := op.GetWorkspace()
-	if ws == nil {
-		return moerr.NewInternalErrorNoCtx(fmt.Sprintf("workspace is nil when reset relation %s:%s",
-			tbl.db.databaseName, tbl.tableName))
-	}
-	txn, ok := ws.(*Transaction)
-	if !ok {
-		return moerr.NewInternalErrorNoCtx("failed to assert txn")
-	}
-	tbl.db.op = op
-	tbl.proc.Store(txn.proc)
-	tbl.createdInTxn = false
-	tbl.lastTS = op.SnapshotTS()
-	return nil
+	return moerr.NewInternalErrorNoCtx("cannot reset a shared relation; use an exclusive relation handle")
 }
 
 func (tbl *txnTable) getSortKeyPosAndSortKeyIsPK() (int, bool) {

--- a/pkg/vm/engine/disttae/txn_table_combined.go
+++ b/pkg/vm/engine/disttae/txn_table_combined.go
@@ -17,6 +17,7 @@ package disttae
 import (
 	"context"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -493,7 +494,7 @@ func (t *combinedTxnTable) PrimaryKeysMayBeUpserted(
 }
 
 func (t *combinedTxnTable) Reset(op client.TxnOperator) error {
-	return t.primary.Reset(op)
+	return moerr.NewInternalErrorNoCtx("cannot reset a shared combined relation")
 }
 
 func (t *combinedTxnTable) GetFlushTS(

--- a/pkg/vm/engine/disttae/txn_table_delegate.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
@@ -85,6 +86,11 @@ func newTxnTableWithItem(
 type txnTableDelegate struct {
 	origin *txnTable
 	parent engine.Relation
+
+	// reusableHandle is true only for an operator-owned wrapper. The relation
+	// stored in Transaction.tableCache is shared and must never be reset.
+	reusableHandle bool
+	cacheKey       any
 
 	// sharding info
 	shard struct {
@@ -1102,11 +1108,120 @@ func (tbl *txnTableDelegate) GetFlushTS(
 	return tbl.origin.GetFlushTS(ctx)
 }
 
-func (tbl *txnTableDelegate) Reset(op client.TxnOperator) error {
-	if tbl.combined.is {
-		return tbl.combined.tbl.Reset(op)
+func (tbl *txnTableDelegate) NewRelationHandle() engine.Relation {
+	handle := &txnTableDelegate{
+		reusableHandle: true,
+		isMock:         tbl.isMock,
+		cacheKey: genTableKey(
+			tbl.origin.accountId,
+			tbl.origin.tableName,
+			tbl.origin.db.databaseId,
+			tbl.origin.db.databaseName,
+		),
 	}
-	return tbl.origin.Reset(op)
+	handle.bindCanonical(tbl)
+	if tbl.isMock {
+		handle.isLocal = tbl.isLocal
+	} else {
+		handle.isLocal = handle.isLocalFunc
+	}
+	return handle
+}
+
+func (tbl *txnTableDelegate) Reset(op client.TxnOperator) error {
+	if !tbl.reusableHandle {
+		return moerr.NewInternalErrorNoCtx("cannot reset a shared relation; use an exclusive relation handle")
+	}
+	txn, err := txnIsValid(op)
+	if err != nil {
+		return err
+	}
+	if txn == nil {
+		return moerr.NewInternalErrorNoCtx("relation handle requires a disttae transaction workspace")
+	}
+	if txn.proc == nil {
+		return moerr.NewInternalErrorNoCtx("transaction process is nil when resetting relation handle")
+	}
+	key := genTableKey(
+		tbl.origin.accountId,
+		tbl.origin.tableName,
+		tbl.origin.db.databaseId,
+		tbl.origin.db.databaseName,
+	)
+	openSys := tbl.origin.db.databaseId == catalog.MO_CATALOG_ID &&
+		catalog.IsSystemTableByName(tbl.origin.tableName)
+	if !openSys && txn.tableOps != nil {
+		if txn.tableOps.existAndDeleted(key) {
+			return moerr.NewNoSuchTable(
+				txn.proc.Ctx,
+				tbl.origin.db.databaseName,
+				tbl.origin.tableName,
+			)
+		}
+		if created := txn.tableOps.existAndActive(key); created != nil {
+			created.proc.Store(txn.proc)
+			return tbl.bindRelation(created)
+		}
+	}
+	if txn.tableCache != nil {
+		if value, ok := txn.tableCache.Load(tbl.cacheKey); ok {
+			canonical := value.(*txnTableDelegate)
+			if canonical.origin.lastTS.Equal(op.SnapshotTS()) {
+				canonical.origin.proc.Store(txn.proc)
+				tbl.bindCanonical(canonical)
+				return nil
+			}
+		}
+		if canonical := txn.getCachedTableByKey(txn.proc.Ctx, key, tbl.cacheKey); canonical != nil {
+			canonical.origin.proc.Store(txn.proc)
+			tbl.bindCanonical(canonical)
+			return nil
+		}
+	}
+
+	return tbl.resetFromCatalog(op, txn)
+}
+
+// Keep the cache-miss path separate so its transaction-local database can
+// escape only when a new canonical relation actually has to be constructed.
+func (tbl *txnTableDelegate) resetFromCatalog(
+	op client.TxnOperator,
+	txn *Transaction,
+) error {
+	db := *tbl.origin.db
+	db.op = op
+	ctx := defines.AttachAccountId(txn.proc.Ctx, tbl.origin.accountId)
+	rel, err := db.relation(ctx, tbl.origin.tableName, txn.proc)
+	if err != nil {
+		return err
+	}
+	if rel == nil {
+		return moerr.NewNoSuchTable(
+			ctx,
+			tbl.origin.db.databaseName,
+			tbl.origin.tableName,
+		)
+	}
+	return tbl.bindRelation(rel)
+}
+
+func (tbl *txnTableDelegate) bindRelation(rel engine.Relation) error {
+	switch canonical := rel.(type) {
+	case *txnTableDelegate:
+		tbl.bindCanonical(canonical)
+	case *txnTable:
+		tbl.bindCanonical(&txnTableDelegate{origin: canonical})
+	default:
+		return moerr.NewInternalErrorNoCtxf("unexpected disttae relation type %T", rel)
+	}
+	return nil
+}
+
+func (tbl *txnTableDelegate) bindCanonical(canonical *txnTableDelegate) {
+	tbl.origin = canonical.origin
+	tbl.parent = canonical.parent
+	tbl.shard = canonical.shard
+	tbl.combined = canonical.combined
 }
 
 func (tbl *txnTableDelegate) isLocalFunc() (bool, error) {

--- a/pkg/vm/engine/disttae/txn_table_test.go
+++ b/pkg/vm/engine/disttae/txn_table_test.go
@@ -16,23 +16,27 @@ package disttae
 
 import (
 	"context"
+	"sync"
 	"testing"
-	"time"
 
-	"github.com/matrixorigin/matrixone/pkg/clusterservice"
+	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
-	"github.com/matrixorigin/matrixone/pkg/shardservice"
+	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
-	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTxnTableForTest() *txnTable {
@@ -91,72 +95,221 @@ func makeBatchForTest(
 	return bat
 }
 
-func TestTxnTable_Reset(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func newResetTxnForTest(t *testing.T, eng *Engine) (client.TxnOperator, *Transaction) {
+	t.Helper()
 
-	t.Run("nil workspace", func(t *testing.T) {
-		tbl := newTxnTableForTest()
-		newOp, closeFn := client.NewTestTxnOperator(ctx)
-		defer closeFn()
-		assert.Error(t, tbl.Reset(newOp))
+	op, closeFn := client.NewTestTxnOperator(context.Background())
+	t.Cleanup(closeFn)
+	proc := testutil.NewProc(t)
+	t.Cleanup(proc.Free)
+	txn := &Transaction{
+		op:          op,
+		proc:        proc,
+		engine:      eng,
+		tableCache:  new(sync.Map),
+		tableOps:    newTableOps(),
+		databaseOps: newDbOps(),
+	}
+	op.AddWorkspace(txn)
+	return op, txn
+}
+
+func insertCatalogTableForResetTest(
+	t *testing.T,
+	eng *Engine,
+	txn *Transaction,
+	accountID uint32,
+	databaseID, tableID uint64,
+	databaseName, tableName string,
+) {
+	t.Helper()
+
+	packer := types.NewPacker()
+	defer packer.Close()
+	bat, err := catalog.GenCreateTableTuple(catalog.Table{
+		AccountId:    accountID,
+		DatabaseId:   databaseID,
+		DatabaseName: databaseName,
+		TableId:      tableID,
+		TableName:    tableName,
+	}, txn.proc.Mp(), packer)
+	require.NoError(t, err)
+	defer bat.Clean(txn.proc.Mp())
+	_, err = fillRandomRowidAndZeroTs(bat, txn.proc.Mp())
+	require.NoError(t, err)
+	eng.GetLatestCatalogCache().InsertTable(bat)
+}
+
+func TestReusableRelationHandleResetDoesNotMutateSharedTable(t *testing.T) {
+	oldCanonical := newTxnTableForTest()
+	oldCanonical.accountId = 0
+	oldCanonical.tableId = 42
+	oldCanonical.tableName = "t"
+	oldCanonical.db.accountId = 0
+	oldCanonical.db.databaseId = 10
+	oldCanonical.db.databaseName = "db"
+
+	shared := &txnTableDelegate{origin: oldCanonical}
+	shared.isLocal = shared.isLocalFunc
+	require.Error(t, shared.Reset(oldCanonical.db.op))
+
+	handle1 := shared.NewRelationHandle().(*txnTableDelegate)
+	handle2 := shared.NewRelationHandle().(*txnTableDelegate)
+	require.NotSame(t, shared, handle1)
+	require.Same(t, oldCanonical, handle1.origin)
+	require.Error(t, handle1.Reset(nil))
+	require.Error(t, oldCanonical.Reset(oldCanonical.db.op))
+
+	newOp, newTxn := newResetTxnForTest(t, oldCanonical.eng.(*Engine))
+	newProc := newTxn.proc
+
+	newDB := &txnDatabase{
+		accountId:    0,
+		databaseId:   10,
+		databaseName: "db",
+		op:           newOp,
+	}
+	newCanonical := &txnTable{
+		accountId: 0,
+		tableId:   42,
+		tableName: "t",
+		db:        newDB,
+		eng:       oldCanonical.eng,
+		lastTS:    newOp.SnapshotTS(),
+	}
+	newCanonical.proc.Store(newProc)
+	newShared := &txnTableDelegate{origin: newCanonical}
+	newShared.isLocal = newShared.isLocalFunc
+	newShared.parent = shared
+	newShared.combined.is = true
+	combinedPrimary := &txnTable{
+		tableId:   84,
+		tableName: "t_partition",
+		db:        newDB,
+		eng:       oldCanonical.eng,
+	}
+	combinedPrimary.proc.Store(newProc)
+	newShared.combined.tbl = &combinedTxnTable{primary: combinedPrimary}
+	newTxn.tableCache.Store(genTableKey(0, "t", 10, "db"), newShared)
+	require.ErrorContains(t, newShared.combined.tbl.Reset(newOp), "cannot reset a shared combined relation")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, handle := range []*txnTableDelegate{handle1, handle2} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- handle.Reset(newOp)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Same(t, oldCanonical, shared.origin)
+	require.Same(t, newCanonical, handle1.origin)
+	require.Same(t, newCanonical, handle2.origin)
+	require.Same(t, newCanonical, newShared.origin)
+	require.Same(t, shared, handle1.parent)
+	require.True(t, handle1.combined.is)
+	require.Same(t, newShared.combined.tbl, handle1.combined.tbl)
+	require.Equal(t, uint64(84), handle1.GetTableID(context.Background()))
+	require.Equal(t, "t_partition", handle1.GetTableName())
+
+	var resetErr error
+	allocs := testing.AllocsPerRun(100, func() {
+		resetErr = handle1.Reset(newOp)
 	})
+	require.NoError(t, resetErr)
+	require.Zero(t, allocs, "steady-state relation handle reset must not allocate")
+}
 
-	t.Run("ok", func(t *testing.T) {
-		tbl := newTxnTableForTest()
-		newOp, closeFn := client.NewTestTxnOperator(ctx)
-		defer closeFn()
-		newProc := &process.Process{}
-		newOp.AddWorkspace(&Transaction{
-			proc: newProc,
-		})
-		assert.NoError(t, tbl.Reset(newOp))
-		assert.Equal(t, newOp, tbl.db.op)
-		assert.Equal(t, newProc, tbl.proc.Load())
-	})
+func TestReusableRelationHandleResetFromCatalogCacheMiss(t *testing.T) {
+	oldCanonical := newTxnTableForTest()
+	oldCanonical.accountId = 7
+	oldCanonical.tableId = 42
+	oldCanonical.tableName = "t"
+	oldCanonical.db.accountId = 7
+	oldCanonical.db.databaseId = 10
+	oldCanonical.db.databaseName = "db"
+	handle := (&txnTableDelegate{origin: oldCanonical}).NewRelationHandle().(*txnTableDelegate)
 
-	t.Run("delegate", func(t *testing.T) {
-		op, closeFn := client.NewTestTxnOperator(ctx)
-		defer closeFn()
-		proc := &process.Process{
-			Base: &process.BaseProcess{},
-		}
-		op.AddWorkspace(&Transaction{
-			proc: proc,
-		})
-		orig, err := newTxnTable(ctx, &txnDatabase{
-			op: op,
-		}, cache.TableItem{})
-		assert.NoError(t, err)
-		rt := runtime.DefaultRuntime()
-		runtime.SetupServiceBasedRuntime("s1", rt)
-		mc := clusterservice.NewMOCluster("s1", nil, time.Second,
-			clusterservice.WithDisableRefresh())
-		rt.SetGlobalVariables(runtime.ClusterService, mc)
-		st := shardservice.NewShardStorage("", rt.Clock(), nil, nil, nil, nil)
-		sv := shardservice.NewService(shardservice.Config{
-			ServiceID: "s1",
-		}, st)
-		tbl, err := MockTableDelegate(orig, sv)
-		assert.NoError(t, err)
-		assert.NotNil(t, tbl)
+	eng := oldCanonical.eng.(*Engine)
+	newOp, newTxn := newResetTxnForTest(t, eng)
+	key := genTableKey(7, "t", 10, "db")
+	_, cached := newTxn.tableCache.Load(key)
+	require.False(t, cached)
+	require.Nil(t, newTxn.tableOps.existAndActive(key))
+	insertCatalogTableForResetTest(t, eng, newTxn, 7, 10, 84, "db", "t")
 
-		newOp, closeFn1 := client.NewTestTxnOperator(ctx)
-		defer closeFn1()
-		newProc := &process.Process{
-			Base: &process.BaseProcess{},
-		}
-		newOp.AddWorkspace(&Transaction{
-			proc: newProc,
-		})
-		assert.NoError(t, tbl.Reset(newOp))
+	require.NoError(t, handle.Reset(newOp))
+	require.NotSame(t, oldCanonical, handle.origin)
+	require.Equal(t, uint64(84), handle.GetTableID(context.Background()))
+	require.Same(t, newOp, handle.origin.db.op)
+	require.Same(t, newTxn.proc, handle.origin.proc.Load())
+	require.Same(t, newTxn, handle.origin.db.getTxn())
 
-		tbl.(*txnTableDelegate).combined.is = true
-		tbl.(*txnTableDelegate).combined.tbl = &combinedTxnTable{
-			primary: newTxnTableForTest(),
-		}
-		assert.NoError(t, tbl.Reset(newOp))
-	})
+	value, cached := newTxn.tableCache.Load(key)
+	require.True(t, cached)
+	require.Same(t, handle.origin, value.(*txnTableDelegate).origin)
+}
+
+func TestReusableRelationHandleResetFromCatalogMissingTable(t *testing.T) {
+	oldCanonical := newTxnTableForTest()
+	oldCanonical.accountId = 7
+	oldCanonical.tableId = 42
+	oldCanonical.tableName = "t"
+	oldCanonical.db.accountId = 7
+	oldCanonical.db.databaseId = 10
+	oldCanonical.db.databaseName = "db"
+	handle := (&txnTableDelegate{origin: oldCanonical}).NewRelationHandle().(*txnTableDelegate)
+
+	eng := oldCanonical.eng.(*Engine)
+	newOp, _ := newResetTxnForTest(t, eng)
+	eng.GetLatestCatalogCache().UpdateDuration(types.TS{}, types.MaxTs())
+
+	err := handle.Reset(newOp)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable), err)
+	require.Same(t, oldCanonical, handle.origin)
+}
+
+func TestReusableRelationHandleResetRejectsDeletedTable(t *testing.T) {
+	oldCanonical := newTxnTableForTest()
+	oldCanonical.accountId = 0
+	oldCanonical.tableId = 42
+	oldCanonical.tableName = "t"
+	oldCanonical.db.accountId = 0
+	oldCanonical.db.databaseId = 10
+	oldCanonical.db.databaseName = "db"
+	handle := (&txnTableDelegate{origin: oldCanonical}).NewRelationHandle().(*txnTableDelegate)
+
+	newOp, newTxn := newResetTxnForTest(t, oldCanonical.eng.(*Engine))
+	key := genTableKey(0, "t", 10, "db")
+	newTxn.tableOps.addDeleteTable(key, 0, oldCanonical.tableId)
+	// A txn-local DROP must win even if a stale canonical relation is cached.
+	newTxn.tableCache.Store(key, &txnTableDelegate{origin: oldCanonical})
+
+	err := handle.Reset(newOp)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable), err)
+	require.Same(t, oldCanonical, handle.origin)
+}
+
+func TestReusableRelationHandleRejectsNonDisttaeWorkspace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	canonical := newTxnTableForTest()
+	canonical.tableName = "t"
+	canonical.db.databaseName = "db"
+	handle := (&txnTableDelegate{origin: canonical}).NewRelationHandle()
+
+	op := mock_frontend.NewMockTxnOperator(ctrl)
+	op.EXPECT().GetWorkspace().Return(mock_frontend.NewMockWorkspace(ctrl))
+	op.EXPECT().Status().Return(txn.TxnStatus_Active)
+
+	require.ErrorContains(t, handle.Reset(op), "disttae transaction workspace")
 }
 
 // func TestPrimaryKeyCheck(t *testing.T) {

--- a/pkg/vm/engine/memoryengine/table.go
+++ b/pkg/vm/engine/memoryengine/table.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -498,6 +499,10 @@ func (t *Table) GetNonAppendableObjectStats(ctx context.Context) ([]objectio.Obj
 }
 
 func (t *Table) Reset(op client.TxnOperator) error {
+	if op == nil {
+		return moerr.NewInternalErrorNoCtx("txn operator is nil when resetting relation")
+	}
+	t.txnOperator = op
 	return nil
 }
 

--- a/pkg/vm/engine/memoryengine/table_test.go
+++ b/pkg/vm/engine/memoryengine/table_test.go
@@ -43,8 +43,13 @@ func Test_TableReader(t *testing.T) {
 }
 
 func TestTable_Reset(t *testing.T) {
-	table := new(Table)
+	oldOp, oldCloseFn := client.NewTestTxnOperator(context.TODO())
+	defer oldCloseFn()
+	table := &Table{txnOperator: oldOp}
 	newOp, closeFn := client.NewTestTxnOperator(context.TODO())
 	defer closeFn()
 	assert.NoError(t, table.Reset(newOp))
+	assert.Same(t, newOp, table.txnOperator)
+	assert.Error(t, table.Reset(nil))
+	assert.Same(t, newOp, table.txnOperator)
 }

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -1032,6 +1032,7 @@ var DefaultRangesParam RangesParam = RangesParam{
 	DontSupportRelData: true,
 }
 
+// Relation is bound to the transaction operator used to open its Database.
 type Relation interface {
 	Statistics
 
@@ -1138,8 +1139,26 @@ type Relation interface {
 	// GetFlushTS returns the flush timestamp of the relation.
 	GetFlushTS(ctx context.Context) (types.TS, error)
 
-	// Reset resets the relation.
+	// Reset rebinds an exclusively owned relation handle to op. Reset must not
+	// be called on a relation shared by multiple operators.
 	Reset(op client.TxnOperator) error
+}
+
+// RelationHandleFactory is implemented by engines whose cached relations are
+// shared and therefore cannot be reset directly. NewRelationHandle returns an
+// exclusively owned, reusable handle over the shared relation.
+type RelationHandleFactory interface {
+	NewRelationHandle() Relation
+}
+
+// NewRelationHandle returns an exclusively owned handle when the engine
+// supports one. Engines with immutable or already-exclusive relations may
+// return the relation itself by not implementing RelationHandleFactory.
+func NewRelationHandle(rel Relation) Relation {
+	if factory, ok := rel.(RelationHandleFactory); ok {
+		return factory.NewRelationHandle()
+	}
+	return rel
 }
 
 type BaseReader interface {


### PR DESCRIPTION
## Why

This PR addresses correctness and unhappy-path coverage gaps in relation-handle reset behavior under reusable relation lifecycle, especially during cache misses and DDL race cases around table existence and deletion.

## What changed

- Add missing unhappy-path tests for `reusableRelationHandle.Reset` in `pkg/vm/engine/disttae/txn_table_test.go`.
  - `TestReusableRelationHandleResetFromCatalogCacheMiss` covers `tableOps` and `tableCache` misses and verifies rebind via catalog path.
  - `TestReusableRelationHandleResetFromCatalogMissingTable` covers catalog lookup miss after lookup and returns `NoSuchTable`.
  - `TestReusableRelationHandleResetRejectsDeletedTable` covers `existAndDeleted` returning true after DDL drop and returns `NoSuchTable`.
  - `combinedTxnTable.Reset` behavior and shared reset semantics are explicitly validated.
  - Added test helpers `newResetTxnForTest` and `insertCatalogTableForResetTest` for realistic catalog-backed reset scenarios.

## How it fixes the issue

- Avoids blind reliance on cache-hit paths by exercising catalog-rebind and failure paths that were previously untested.
- Makes table-drop race behavior explicit and deterministic in tests.
- Confirms shared/combined reset behavior remains constrained while operator-owned reusable handles rebind correctly.

## Performance

- No new hot-path overhead expected for cache-hit reset path.
- Cache-miss reset remains an exceptional path and can involve canonical reconstruction as designed.

## Related
- Fixes: #25627
