### PR TITLE
fix(disttae): fence latest logtail reads with pending table apply 

### DIFF
--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -377,6 +377,69 @@ func (c *PushClient) validLogTailMustApplied(snapshotTS timestamp.Timestamp) {
 		ts))
 }
 
+func (c *PushClient) canServeTableSnapshot(
+	dbId, tblId uint64,
+	ps *logtailreplay.PartitionState,
+	snapshot timestamp.Timestamp,
+) bool {
+	canServe, _ := c.canServeTableSnapshotNoWait(dbId, tblId, ps, snapshot)
+	return canServe
+}
+
+func (c *PushClient) waitCanServeTableSnapshot(
+	ctx context.Context,
+	accId, dbId, tblId uint64,
+	ps *logtailreplay.PartitionState,
+	snapshot timestamp.Timestamp,
+) (*logtailreplay.PartitionState, bool, error) {
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		canServe, needWait := c.canServeTableSnapshotNoWait(dbId, tblId, ps, snapshot)
+		if canServe || !needWait {
+			return ps, canServe, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-ticker.C:
+			ps = c.eng.GetOrCreateLatestPart(ctx, accId, dbId, tblId).Snapshot()
+		}
+	}
+}
+
+func (c *PushClient) canServeTableSnapshotNoWait(
+	dbId, tblId uint64,
+	ps *logtailreplay.PartitionState,
+	snapshot timestamp.Timestamp,
+) (canServe bool, needWait bool) {
+	snapshotTS := types.TimestampToTS(snapshot)
+	if ps == nil || !ps.CanServe(snapshotTS) {
+		return false, false
+	}
+	if snapshot.IsEmpty() {
+		return true, false
+	}
+
+	visibleTS := types.TimestampToTS(snapshot.Prev())
+	appliedTo := ps.GetAppliedTo()
+	if !appliedTo.IsEmpty() && appliedTo.GE(&visibleTS) {
+		return true, false
+	}
+
+	// If no update for this table is queued or being applied, the global
+	// logtail waiter already proves this snapshot is within the CN applied
+	// waterline. Only block the latest-state fast path when this table has a
+	// known pending update and the current state has not applied up to the
+	// statement snapshot yet.
+	if c.subscribed.hasPendingUpdate(dbId, tblId) {
+		return false, true
+	}
+	return true, false
+}
+
 func (c *PushClient) skipSubIfSubscribed(
 	ctx context.Context,
 	acctId uint64,
@@ -1193,9 +1256,10 @@ type subscribedTable struct {
 
 // subEntry holds subscription state with atomic timestamp for lock-free updates.
 type subEntry struct {
-	dbID   uint64
-	state  SubscribeState
-	lastTs atomic.Int64 // UnixNano, for GC to check if table is still in use
+	dbID      uint64
+	state     SubscribeState
+	lastTs    atomic.Int64 // UnixNano, for GC to check if table is still in use
+	pendingTo atomic.Pointer[timestamp.Timestamp]
 }
 
 // SubTableStatus is used for external API compatibility (e.g., GetState).
@@ -1284,6 +1348,54 @@ func (s *subscribedTable) isSubscribed(dbId, tblId uint64) bool {
 	}
 	s.rw.RUnlock()
 	return false
+}
+
+func (s *subscribedTable) setTablePendingUpdate(dbId, tblId uint64, to timestamp.Timestamp) {
+	if to.IsEmpty() {
+		return
+	}
+	s.rw.RLock()
+	ent, exist := s.m[tblId]
+	if exist && ent.dbID == dbId && ent.state == Subscribed {
+		ts := to
+		ent.pendingTo.Store(&ts)
+	}
+	s.rw.RUnlock()
+}
+
+func (s *subscribedTable) clearTablePendingUpdate(dbId, tblId uint64, applied timestamp.Timestamp) {
+	if applied.IsEmpty() {
+		return
+	}
+	s.rw.RLock()
+	ent, exist := s.m[tblId]
+	if !exist || ent.dbID != dbId {
+		s.rw.RUnlock()
+		return
+	}
+	s.rw.RUnlock()
+
+	for {
+		pending := ent.pendingTo.Load()
+		if pending == nil || pending.Greater(applied) {
+			return
+		}
+		if ent.pendingTo.CompareAndSwap(pending, nil) {
+			return
+		}
+	}
+}
+
+func (s *subscribedTable) hasPendingUpdate(dbId, tblId uint64) bool {
+	s.rw.RLock()
+	ent, exist := s.m[tblId]
+	if !exist || ent.dbID != dbId || ent.state != Subscribed {
+		s.rw.RUnlock()
+		return false
+	}
+	pending := ent.pendingTo.Load()
+	s.rw.RUnlock()
+	return pending != nil
 }
 
 // consumeLatestCkp consume the latest checkpoint of the table if not consumed, and return the latest partition state.
@@ -1893,7 +2005,7 @@ func dispatchUpdateResponse(
 	for i := 0; i < len(list); i++ {
 		table := list[i].Table
 		if table.TbId == catalog.MO_DATABASE_ID {
-			if err := e.consumeUpdateLogTail(ctx, list[i], false, receiveAt); err != nil {
+			if err := e.consumeUpdateLogTail(ctx, list[i], false, receiveAt, *response.To); err != nil {
 				return err
 			}
 		}
@@ -1901,7 +2013,7 @@ func dispatchUpdateResponse(
 	for i := 0; i < len(list); i++ {
 		table := list[i].Table
 		if table.TbId == catalog.MO_TABLES_ID {
-			if err := e.consumeUpdateLogTail(ctx, list[i], false, receiveAt); err != nil {
+			if err := e.consumeUpdateLogTail(ctx, list[i], false, receiveAt, *response.To); err != nil {
 				return err
 			}
 		}
@@ -1909,7 +2021,7 @@ func dispatchUpdateResponse(
 	for i := 0; i < len(list); i++ {
 		table := list[i].Table
 		if table.TbId == catalog.MO_COLUMNS_ID {
-			if err := e.consumeUpdateLogTail(ctx, list[i], false, receiveAt); err != nil {
+			if err := e.consumeUpdateLogTail(ctx, list[i], false, receiveAt, *response.To); err != nil {
 				return err
 			}
 		}
@@ -1937,6 +2049,7 @@ func dispatchUpdateResponse(
 		}
 		recIndex := table.TbId % consumerNumber
 		hasLogtail[recIndex] = true
+		e.pClient.subscribed.setTablePendingUpdate(table.DbId, table.TbId, *response.To)
 		recRoutines[recIndex].sendTableLogTailWithTimestamp(
 			list[index],
 			*response.To,
@@ -2169,8 +2282,12 @@ func (cmd *cmdToConsumeLog) action(ctx context.Context, e *Engine, ctrl *routine
 		ctrl.cmdLogPool.Put(cmd)
 	}()
 	response := cmd.log
-	if err := e.consumeUpdateLogTail(ctx, response, true, cmd.receiveAt); err != nil {
+	if err := e.consumeUpdateLogTail(ctx, response, true, cmd.receiveAt, cmd.applied); err != nil {
 		return err
+	}
+	table := response.GetTable()
+	if table != nil {
+		e.pClient.subscribed.clearTablePendingUpdate(table.DbId, table.TbId, cmd.applied)
 	}
 	if cmd.notifyApplied {
 		e.pClient.receivedLogTailTime.updateTimestamp(ctrl.routineId, cmd.applied, cmd.receiveAt)
@@ -2197,15 +2314,20 @@ func (e *Engine) consumeSubscribeResponse(
 	lazyLoad bool,
 	receiveAt time.Time) error {
 	lt := rp.GetLogtail()
-	return updatePartitionOfPush(ctx, e, &lt, lazyLoad, receiveAt, true)
+	applied := timestamp.Timestamp{}
+	if lt.Ts != nil {
+		applied = *lt.Ts
+	}
+	return updatePartitionOfPush(ctx, e, &lt, lazyLoad, receiveAt, true, applied)
 }
 
 func (e *Engine) consumeUpdateLogTail(
 	ctx context.Context,
 	rp logtail.TableLogtail,
 	lazyLoad bool,
-	receiveAt time.Time) error {
-	return updatePartitionOfPush(ctx, e, &rp, lazyLoad, receiveAt, false)
+	receiveAt time.Time,
+	applied timestamp.Timestamp) error {
+	return updatePartitionOfPush(ctx, e, &rp, lazyLoad, receiveAt, false, applied)
 }
 
 // updatePartitionOfPush is the partition update method of log tail push model.
@@ -2215,7 +2337,8 @@ func updatePartitionOfPush(
 	tl *logtail.TableLogtail,
 	lazyLoad bool,
 	receiveAt time.Time,
-	isSub bool) (err error) {
+	isSub bool,
+	applied timestamp.Timestamp) (err error) {
 	start := time.Now()
 	v2.LogTailApplyLatencyDurationHistogram.Observe(start.Sub(receiveAt).Seconds())
 	defer func() {
@@ -2324,6 +2447,11 @@ func updatePartitionOfPush(
 			// }
 		}
 	}
+
+	if applied.IsEmpty() && tl.Ts != nil {
+		applied = *tl.Ts
+	}
+	state.UpdateAppliedTo(types.TimestampToTS(applied))
 
 	doneMutate()
 

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -1046,6 +1046,13 @@ func TestDispatchUpdateResponseAdvancesTimestampAfterLastLogtail(t *testing.T) {
 		globalStats: &GlobalStats{tailC: make(chan *logtail.TableLogtail, 8)},
 		skipConsume: true,
 	}
+	e.pClient.subscribed = subscribedTable{
+		eng: e,
+		m: map[uint64]*subEntry{
+			101: {dbID: 10, state: Subscribed},
+			105: {dbID: 10, state: Subscribed},
+		},
+	}
 	e.pClient.receivedLogTailTime.initLogTailTimestamp(tw)
 
 	recRoutines := newTestRoutineControllers(8)
@@ -1058,20 +1065,100 @@ func TestDispatchUpdateResponseAdvancesTimestampAfterLastLogtail(t *testing.T) {
 		},
 	}
 	require.NoError(t, dispatchUpdateResponse(ctx, e, response, recRoutines, time.Now()))
+	assert.True(t, e.pClient.subscribed.hasPendingUpdate(10, 101))
+	assert.True(t, e.pClient.subscribed.hasPendingUpdate(10, 105))
 
 	cmd := (<-recRoutines[1].signalChan).(*cmdToConsumeLog)
 	require.False(t, cmd.notifyApplied)
 	require.NoError(t, cmd.action(ctx, e, recRoutines[1]))
+	assert.False(t, e.pClient.subscribed.hasPendingUpdate(10, 101))
+	assert.True(t, e.pClient.subscribed.hasPendingUpdate(10, 105))
+	expectedApplied := types.TimestampToTS(to)
+	applied := e.GetOrCreateLatestPart(ctx, 0, 10, 101).Snapshot().GetAppliedTo()
+	assert.True(t, applied.EQ(&expectedApplied))
 	assert.Equal(t, timestamp.Timestamp{}, e.pClient.receivedLogTailTime.tList[1].Load().(timestamp.Timestamp))
 
 	cmd = (<-recRoutines[1].signalChan).(*cmdToConsumeLog)
 	require.True(t, cmd.notifyApplied)
 	require.NoError(t, cmd.action(ctx, e, recRoutines[1]))
+	assert.False(t, e.pClient.subscribed.hasPendingUpdate(10, 105))
+	applied = e.GetOrCreateLatestPart(ctx, 0, 10, 105).Snapshot().GetAppliedTo()
+	assert.True(t, applied.EQ(&expectedApplied))
 	assert.Equal(t, to, e.pClient.receivedLogTailTime.tList[1].Load().(timestamp.Timestamp))
 
 	timeCmd := (<-recRoutines[0].signalChan).(*cmdToUpdateTime)
 	require.NoError(t, timeCmd.action(ctx, e, recRoutines[0]))
 	assert.Equal(t, to, e.pClient.receivedLogTailTime.tList[0].Load().(timestamp.Timestamp))
+}
+
+func TestCanServeTableSnapshotBlocksPendingUpdate(t *testing.T) {
+	e := &Engine{}
+	e.pClient.subscribed = subscribedTable{
+		eng: e,
+		m: map[uint64]*subEntry{
+			42: {dbID: 10, state: Subscribed},
+		},
+	}
+
+	ps := logtailreplay.NewPartitionState("test", false, 42, false)
+	ps.UpdateDuration(types.TS{}, types.MaxTs())
+
+	snapshot := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 1}
+	pendingTo := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 0}
+
+	assert.True(t, e.pClient.canServeTableSnapshot(10, 42, ps, snapshot))
+
+	e.pClient.subscribed.setTablePendingUpdate(10, 42, pendingTo)
+	assert.False(t, e.pClient.canServeTableSnapshot(10, 42, ps, snapshot))
+
+	newerPending := timestamp.Timestamp{PhysicalTime: 101, LogicalTime: 0}
+	e.pClient.subscribed.setTablePendingUpdate(10, 42, newerPending)
+	e.pClient.subscribed.clearTablePendingUpdate(10, 42, pendingTo)
+	assert.True(t, e.pClient.subscribed.hasPendingUpdate(10, 42))
+
+	ps.UpdateAppliedTo(types.TimestampToTS(snapshot.Prev()))
+	assert.True(t, e.pClient.canServeTableSnapshot(10, 42, ps, snapshot))
+}
+
+func TestWaitCanServeTableSnapshotWaitsForPendingUpdate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	e := &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{tailC: make(chan *logtail.TableLogtail, 8)},
+	}
+	e.pClient.eng = e
+	e.pClient.subscribed = subscribedTable{
+		eng: e,
+		m: map[uint64]*subEntry{
+			42: {dbID: 10, state: Subscribed},
+		},
+	}
+
+	part := e.GetOrCreateLatestPart(ctx, 0, 10, 42)
+	state, done := part.MutateState()
+	state.UpdateDuration(types.TS{}, types.MaxTs())
+	done()
+
+	snapshot := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 1}
+	pendingTo := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 0}
+	e.pClient.subscribed.setTablePendingUpdate(10, 42, pendingTo)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		state, done := part.MutateState()
+		state.UpdateAppliedTo(types.TimestampToTS(snapshot.Prev()))
+		done()
+	}()
+
+	ps, ok, err := e.pClient.waitCanServeTableSnapshot(ctx, 0, 10, 42, part.Snapshot(), snapshot)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, ps)
+	expectedApplied := types.TimestampToTS(snapshot.Prev())
+	applied := ps.GetAppliedTo()
+	assert.True(t, applied.EQ(&expectedApplied))
 }
 
 func newTestRoutineControllers(buffer int) []*routineController {

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -67,6 +67,10 @@ type PartitionState struct {
 	//current partitionState can serve snapshot read only if start <= ts <= end
 	start types.TS
 	end   types.TS
+	// appliedTo is the latest logtail timestamp that has been fully applied
+	// to this state. Duration end can be MaxTs for subscribed latest states,
+	// so it is not a physical applied watermark.
+	appliedTo types.TS
 
 	// index
 
@@ -858,6 +862,7 @@ func (p *PartitionState) Copy() *PartitionState {
 		lastFlushTimestamp:        p.lastFlushTimestamp,
 		start:                     p.start,
 		end:                       p.end,
+		appliedTo:                 p.appliedTo,
 		prefetch:                  p.prefetch,
 	}
 	if len(p.checkpoints) > 0 {
@@ -1185,6 +1190,19 @@ func (p *PartitionState) UpdateDuration(start types.TS, end types.TS) {
 
 func (p *PartitionState) GetDuration() (types.TS, types.TS) {
 	return p.start, p.end
+}
+
+func (p *PartitionState) UpdateAppliedTo(ts types.TS) {
+	if ts.IsEmpty() {
+		return
+	}
+	if p.appliedTo.IsEmpty() || p.appliedTo.LT(&ts) {
+		p.appliedTo = ts
+	}
+}
+
+func (p *PartitionState) GetAppliedTo() types.TS {
+	return p.appliedTo
 }
 
 func (p *PartitionState) IsValid() bool {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2499,8 +2499,22 @@ func (tbl *txnTable) getPartitionState(
 			return nil, err
 		}
 
-	} else if ps != nil && ps.CanServe(types.TimestampToTS(tbl.db.op.SnapshotTS())) {
-		return
+	} else {
+		var ok bool
+		ps, ok, err = eng.PushClient().waitCanServeTableSnapshot(
+			ctx,
+			uint64(tbl.accountId),
+			tbl.db.databaseId,
+			tbl.tableId,
+			ps,
+			tbl.db.op.SnapshotTS(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return
+		}
 	}
 
 	//Try to create a snapshot partition state for the table through consume the history checkpoints.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25232

## What this PR does / why we need it:

When a CN receives a logtail update response, the global logtail timestamp can advance before every table logtail in that response has been applied to its latest `PartitionState`. The latest subscribed table state can still have a `[start, MaxTs]` serving range, so checking only `CanServe(snapshot)` can let a read use a table state that has not applied updates below `snapshot.Prev()`. In a cross-table consistency check, this can expose one updated table and one stale table from the same committed transaction.

This PR fences that latest-state fast path:

- tracks a per-table `appliedTo` watermark in `PartitionState`
- marks subscribed tables as pending when an update response contains their logtail
- clears the pending mark only after that table logtail has been consumed
- makes `txnTable.getPartitionState` wait for the latest table state to apply through `snapshot.Prev()` when that table has a known pending update
- preserves the original fast path when there is no pending update, and preserves snapshot checkpoint fallback when the latest state truly cannot serve the snapshot

Validation:

- `git diff --check base/main...HEAD`
- `go test -v -count=1 -run 'TestCanServeTableSnapshotBlocksPendingUpdate|TestWaitCanServeTableSnapshotWaitsForPendingUpdate|TestDispatchUpdateResponseAdvancesTimestampAfterLastLogtail|TestDispatchUpdateResponseCoalescesTimestampCommands' ./pkg/vm/engine/disttae`
- `go test -race -v -count=1 -run 'TestCanServeTableSnapshotBlocksPendingUpdate|TestWaitCanServeTableSnapshotWaitsForPendingUpdate|TestDispatchUpdateResponseAdvancesTimestampAfterLastLogtail|TestDispatchUpdateResponseCoalescesTimestampCommands' ./pkg/vm/engine/disttae`
- verified on a 2-CN dev cluster with temporary fault-injection hooks that force the global logtail timestamp to advance before table apply; 3 runs all hit the new pending-table wait path and returned consistent `20/20` counts

Note: full `./pkg/vm/engine/disttae` package test was also attempted locally, but the sandbox cannot bind the unix socket used by `TestWaitServerReady/ok` (`operation not permitted`), so it timed out on that unrelated test.