### PR TITLE
fix(lockservice): recover active txn checks after CN recreation

### DIFF
--- a/pkg/clusterservice/cluster.go
+++ b/pkg/clusterservice/cluster.go
@@ -162,7 +162,8 @@ func WithDisableRefresh() Option {
 type cluster struct {
 	logger          *log.MOLogger
 	stopper         *stopper.Stopper
-	mu              sync.Mutex
+	refreshGateOnce sync.Once
+	refreshGateC    chan struct{}
 	client          ClusterClient
 	refreshInterval time.Duration
 	forceRefreshC   chan struct{}
@@ -307,7 +308,7 @@ func (c *cluster) ForceRefresh(sync bool) {
 		return
 	}
 	if sync {
-		c.refresh()
+		c.refreshAndLog(context.Background())
 		return
 	}
 
@@ -315,6 +316,25 @@ func (c *cluster) ForceRefresh(sync bool) {
 	case c.forceRefreshC <- struct{}{}:
 	default:
 	}
+}
+
+// Refresh obtains and publishes a new HAKeeper snapshot, or returns the reason
+// why freshness could not be established. Unlike ForceRefresh, this method is
+// suitable for callers whose correctness depends on a successful refresh.
+func (c *cluster) Refresh(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if c.options.disableRefresh {
+		// WithDisableRefresh makes the supplied static snapshot authoritative.
+		return nil
+	}
+	ctx, cancel := context.WithTimeoutCause(ctx, c.refreshInterval, moerr.CauseRefresh)
+	defer cancel()
+	return c.refreshWithContext(ctx)
 }
 
 func (c *cluster) Close() {
@@ -430,32 +450,36 @@ func (c *cluster) refreshTask(ctx context.Context) {
 			c.logger.Info("refresh cluster details task stopped")
 			return
 		case <-timer.C:
-			c.refresh()
+			c.refreshAndLog(ctx)
 			timer.Reset(c.refreshInterval)
 		case <-c.forceRefreshC:
-			c.refresh()
+			c.refreshAndLog(ctx)
 		}
 	}
 }
 
-func (c *cluster) refresh() {
+func (c *cluster) refreshAndLog(parent context.Context) {
+	if err := c.Refresh(parent); err != nil {
+		c.logger.Error("failed to refresh cluster details from hakeeper",
+			zap.Error(err))
+	}
+}
+
+func (c *cluster) refreshWithContext(ctx context.Context) error {
 	defer c.logger.LogAction("refresh from hakeeper",
 		log.DefaultLogOptions().WithLevel(zap.DebugLevel))()
 
-	// There is data race as ForceRefresh and refreshTask may call this function
-	// at the same time, which will cause inconsistent CN services.
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	ctx, cancel := context.WithTimeoutCause(context.Background(), c.refreshInterval, moerr.CauseRefresh)
-	defer cancel()
+	// Serialize snapshots so an older concurrent HAKeeper response cannot
+	// overwrite a newer one. Admission is context-aware: freshness callers must
+	// not wait past their own deadline behind another refresh.
+	if err := c.acquireRefresh(ctx); err != nil {
+		return moerr.AttachCause(ctx, err)
+	}
+	defer c.releaseRefresh()
 
 	details, err := c.client.GetClusterDetails(ctx)
 	if err != nil {
-		err = moerr.AttachCause(ctx, err)
-		c.logger.Error("failed to refresh cluster details from hakeeper",
-			zap.Error(err))
-		return
+		return moerr.AttachCause(ctx, err)
 	}
 
 	c.logger.Debug("refresh cluster details from hakeeper",
@@ -491,6 +515,24 @@ func (c *cluster) refresh() {
 		c.ready.Store(true)
 		close(c.readyC)
 	})
+	return nil
+}
+
+func (c *cluster) acquireRefresh(ctx context.Context) error {
+	c.refreshGateOnce.Do(func() {
+		c.refreshGateC = make(chan struct{}, 1)
+		c.refreshGateC <- struct{}{}
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.refreshGateC:
+		return nil
+	}
+}
+
+func (c *cluster) releaseRefresh() {
+	c.refreshGateC <- struct{}{}
 }
 
 func (c *cluster) copyServices() *services {

--- a/pkg/clusterservice/cluster_test.go
+++ b/pkg/clusterservice/cluster_test.go
@@ -16,6 +16,7 @@ package clusterservice
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -87,6 +88,61 @@ func TestClusterForceRefresh(t *testing.T) {
 			c.GetCNService(NewServiceIDSelector("cn0"), apply)
 			assert.Equal(t, 1, cnt)
 		})
+}
+
+func TestClusterRefreshReportsFailureAndPreservesSnapshot(t *testing.T) {
+	runClusterTest(
+		time.Hour,
+		func(hc *testHAKeeperClient, c *cluster) {
+			hc.addCN("cn-old")
+			require.NoError(t, c.Refresh(context.Background()))
+
+			refreshErr := errors.New("injected hakeeper failure")
+			hc.Lock()
+			hc.err = refreshErr
+			hc.value.CNStores = nil
+			hc.Unlock()
+
+			require.ErrorIs(t, c.Refresh(context.Background()), refreshErr)
+			var ids []string
+			c.GetCNServiceWithoutWorkingState(
+				NewSelector(),
+				func(service metadata.CNService) bool {
+					ids = append(ids, service.ServiceID)
+					return true
+				},
+			)
+			require.Equal(t, []string{"cn-old"}, ids)
+		},
+	)
+}
+
+func TestClusterRefreshHonorsCanceledContext(t *testing.T) {
+	runClusterTest(
+		time.Hour,
+		func(_ *testHAKeeperClient, c *cluster) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			require.ErrorIs(t, c.Refresh(ctx), context.Canceled)
+		},
+	)
+}
+
+func TestClusterRefreshWaitHonorsContext(t *testing.T) {
+	runClusterTest(
+		time.Hour,
+		func(_ *testHAKeeperClient, c *cluster) {
+			require.NoError(t, c.acquireRefresh(context.Background()))
+			defer c.releaseRefresh()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+			started := time.Now()
+			err := c.Refresh(ctx)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.Less(t, time.Since(started), time.Second)
+		},
+	)
 }
 
 func TestClusterRefresh(t *testing.T) {

--- a/pkg/clusterservice/types.go
+++ b/pkg/clusterservice/types.go
@@ -109,6 +109,14 @@ type MOCluster interface {
 	UpdateCN(metadata.CNService)
 }
 
+// AuthoritativeRefresher is an optional capability for callers that must know
+// whether a synchronous cluster snapshot refresh actually succeeded. The
+// legacy ForceRefresh API intentionally has no result and is unsuitable for
+// correctness decisions based on freshness.
+type AuthoritativeRefresher interface {
+	Refresh(context.Context) error
+}
+
 type ClusterClient interface {
 	GetClusterDetails(ctx context.Context) (logpb.ClusterDetails, error)
 }

--- a/pkg/common/moerr/cause.go
+++ b/pkg/common/moerr/cause.go
@@ -109,6 +109,7 @@ var (
 	CauseDoGetLock                 = NewInternalError(context.Background(), "doGetLock")
 	CauseInitRemote1               = NewInternalError(context.Background(), "initRemote 1")
 	CauseInitRemote2               = NewInternalError(context.Background(), "initRemote 2")
+	CauseResetLockServiceBackend   = NewInternalError(context.Background(), "resetLockServiceBackend")
 	CauseGetTxnWaitingListOnRemote = NewInternalError(context.Background(), "getTxnWaitingListOnRemote")
 	CauseGetLockTableBind          = NewInternalError(context.Background(), "getLockTableBind")
 	CauseAbortRemoteDeadlockTxn    = NewInternalError(context.Background(), "abortRemoteDeadlockTxn")

--- a/pkg/common/moerr/cause_test.go
+++ b/pkg/common/moerr/cause_test.go
@@ -101,6 +101,7 @@ var causeArray = []error{
 	CauseDoGetLock,
 	CauseInitRemote1,
 	CauseInitRemote2,
+	CauseResetLockServiceBackend,
 	CauseGetTxnWaitingListOnRemote,
 	CauseGetLockTableBind,
 

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -1132,9 +1132,13 @@ func (b *testBackend) Locked() bool {
 }
 
 func (b *testBackend) active() {
+	b.setActiveTime(time.Now())
+}
+
+func (b *testBackend) setActiveTime(value time.Time) {
 	b.RWMutex.Lock()
 	defer b.RWMutex.Unlock()
-	b.activeTime = time.Now()
+	b.activeTime = value
 }
 
 type testMessage struct {

--- a/pkg/common/morpc/circuit_breaker.go
+++ b/pkg/common/morpc/circuit_breaker.go
@@ -300,6 +300,79 @@ type CircuitBreakerManager struct {
 	breakers map[string]*CircuitBreaker
 }
 
+// circuitBreakerHandle pins one breaker incarnation for the lifetime of an
+// RPC attempt. A targeted backend reset removes the address from the manager;
+// results from requests that still hold the old handle must update only that
+// detached breaker, never recreate or poison the replacement incarnation.
+type circuitBreakerHandle struct {
+	manager *CircuitBreakerManager
+	backend string
+	breaker *CircuitBreaker
+}
+
+func (m *CircuitBreakerManager) newHandle(backend string) circuitBreakerHandle {
+	return circuitBreakerHandle{
+		manager: m,
+		backend: backend,
+		breaker: m.GetBreaker(backend),
+	}
+}
+
+func (h circuitBreakerHandle) Allow() bool {
+	return h.breaker.Allow()
+}
+
+func (h circuitBreakerHandle) Error() error {
+	if !h.breaker.config.Enabled {
+		return nil
+	}
+	switch h.breaker.State() {
+	case CircuitOpen:
+		return ErrCircuitOpen
+	case CircuitHalfOpen:
+		return ErrCircuitHalfOpen
+	default:
+		return nil
+	}
+}
+
+func (h circuitBreakerHandle) RecordSuccess() {
+	oldState := h.breaker.State()
+	h.breaker.RecordSuccess()
+	h.reportStateChange(oldState, h.breaker.State(), false)
+}
+
+func (h circuitBreakerHandle) RecordFailure() {
+	oldState := h.breaker.State()
+	h.breaker.RecordFailure()
+	h.reportStateChange(oldState, h.breaker.State(), true)
+}
+
+func (h circuitBreakerHandle) reportStateChange(
+	oldState, newState CircuitState,
+	failure bool,
+) {
+	if oldState == newState || !h.manager.isCurrent(h.backend, h.breaker) {
+		return
+	}
+	h.manager.reportStateChange(h.backend, newState)
+	if failure && oldState == CircuitClosed && newState == CircuitOpen {
+		h.manager.reportTrip(h.backend)
+	}
+}
+
+func (m *CircuitBreakerManager) isCurrent(
+	backend string,
+	breaker *CircuitBreaker,
+) bool {
+	if !m.config.Enabled {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.breakers[backend] == breaker
+}
+
 // NewCircuitBreakerManager creates a new CircuitBreakerManager.
 func NewCircuitBreakerManager(name string, config CircuitBreakerConfig, logger *zap.Logger) *CircuitBreakerManager {
 	return &CircuitBreakerManager{

--- a/pkg/common/morpc/circuit_breaker_test.go
+++ b/pkg/common/morpc/circuit_breaker_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -293,6 +294,26 @@ func TestCircuitBreakerManagerRemoveBreaker(t *testing.T) {
 
 	// New breaker should be created in closed state
 	assert.True(t, manager.Allow("backend1"))
+}
+
+func TestDetachedCircuitBreakerHandleCannotPoisonReplacement(t *testing.T) {
+	manager := NewCircuitBreakerManager("test-client", CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    1,
+		ResetTimeout:        time.Minute,
+		HalfOpenMaxRequests: 1,
+	}, zap.NewNop())
+
+	old := manager.newHandle("backend1")
+	manager.RemoveBreaker("backend1")
+	replacement := manager.newHandle("backend1")
+	require.NotSame(t, old.breaker, replacement.breaker)
+
+	// Simulate an old-generation request completing after targeted reset.
+	old.RecordFailure()
+	require.False(t, old.Allow())
+	require.True(t, replacement.Allow())
+	require.Equal(t, CircuitClosed, manager.Stats()["backend1"].State)
 }
 
 func TestCircuitBreakerManagerDisabled(t *testing.T) {

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -309,10 +309,10 @@ type client struct {
 		closed   bool // true when Close() is completed
 		backends map[string][]Backend
 		ops      map[string]*op
-		// backendEpoch invalidates asynchronous create requests queued before a
-		// targeted backend reset. Without it, an old request can repopulate the
-		// pool after CloseBackendFor returns.
-		backendEpoch map[string]uint64
+		// backendGeneration invalidates create requests captured before a
+		// targeted reset. Pointer identity avoids ABA when an entry is evicted
+		// and later recreated for the same remote.
+		backendGeneration map[string]*backendGeneration
 	}
 
 	circuitBreakers *CircuitBreakerManager
@@ -346,7 +346,7 @@ func NewClient(
 	}
 	c.mu.backends = make(map[string][]Backend)
 	c.mu.ops = make(map[string]*op)
-	c.mu.backendEpoch = make(map[string]uint64)
+	c.mu.backendGeneration = make(map[string]*backendGeneration)
 
 	for _, opt := range options {
 		opt(c)
@@ -848,7 +848,7 @@ func (c *client) CloseBackend() error {
 func (c *client) CloseBackendFor(remote string) error {
 	c.mu.Lock()
 	backends := c.mu.backends[remote]
-	c.mu.backendEpoch[remote]++
+	delete(c.mu.backendGeneration, remote)
 	delete(c.mu.backends, remote)
 	delete(c.mu.ops, remote)
 	c.updatePoolSizeMetricsLocked()
@@ -884,9 +884,12 @@ func (c *client) getBackend(backend string, lock bool) (Backend, error) {
 
 	// No backend available in pool
 	canCreate := c.canCreateLocked(backend)
-	backendEpoch := c.mu.backendEpoch[backend]
 	enableAutoCreate := c.options.enableAutoCreate
 	hasBackends := poolSize > 0
+	var generation *backendGeneration
+	if canCreate && enableAutoCreate {
+		generation = c.backendGenerationLocked(backend)
+	}
 	c.mu.Unlock() // Release lock before any potentially blocking operation
 
 	// If pool has backends but all are busy, wait for one to become available
@@ -905,9 +908,9 @@ func (c *client) getBackend(backend string, lock bool) (Backend, error) {
 	creationQueued := false
 	if canCreate {
 		// Try to enqueue creation task with backpressure handling
-		if !globalClientGC.triggerCreateAtEpoch(c, backend, backendEpoch) {
+		if !globalClientGC.triggerCreateAtGeneration(c, backend, generation) {
 			// Queue is full - fallback to existing creation path with proper bookkeeping
-			return c.createBackendWithBookkeeping(backend, lock)
+			return c.createBackendWithBookkeepingAtGeneration(backend, lock, generation)
 		}
 		creationQueued = true
 	}
@@ -999,10 +1002,25 @@ func (c *client) tryCreate(backend string) bool {
 		return false
 	}
 
-	return globalClientGC.triggerCreateAtEpoch(c, backend, c.mu.backendEpoch[backend])
+	return globalClientGC.triggerCreateAtGeneration(
+		c,
+		backend,
+		c.backendGenerationLocked(backend),
+	)
 }
 
 func (c *client) createBackendWithBookkeeping(backend string, lock bool) (Backend, error) {
+	c.mu.Lock()
+	generation := c.backendGenerationLocked(backend)
+	c.mu.Unlock()
+	return c.createBackendWithBookkeepingAtGeneration(backend, lock, generation)
+}
+
+func (c *client) createBackendWithBookkeepingAtGeneration(
+	backend string,
+	lock bool,
+	generation *backendGeneration,
+) (Backend, error) {
 	// Use existing creation path with proper bookkeeping, but avoid holding the lock
 	// during network I/O. We double-check limits after creation to avoid overfilling
 	// if another goroutine created a backend in the meantime.
@@ -1011,11 +1029,14 @@ func (c *client) createBackendWithBookkeeping(backend string, lock bool) (Backen
 		c.mu.Unlock()
 		return nil, moerr.NewClientClosedNoCtx()
 	}
+	if c.mu.backendGeneration[backend] != generation {
+		c.mu.Unlock()
+		return nil, moerr.NewBackendClosedNoCtx()
+	}
 	if !c.canCreateLocked(backend) {
 		c.mu.Unlock()
 		return nil, moerr.NewBackendClosedNoCtx()
 	}
-	backendEpoch := c.mu.backendEpoch[backend]
 	c.mu.Unlock()
 
 	// Create backend using factory with metrics (same as doCreate) without holding the lock.
@@ -1032,7 +1053,7 @@ func (c *client) createBackendWithBookkeeping(backend string, lock bool) (Backen
 		b.Close()
 		return nil, moerr.NewClientClosedNoCtx()
 	}
-	if c.mu.backendEpoch[backend] != backendEpoch {
+	if c.mu.backendGeneration[backend] != generation {
 		b.Close()
 		return nil, moerr.NewBackendClosedNoCtx()
 	}
@@ -1059,6 +1080,35 @@ func (c *client) createBackendWithBookkeeping(backend string, lock bool) (Backen
 	c.updatePoolSizeMetricsLocked()
 
 	return b, nil
+}
+
+const maxBackendGenerationEntries = 4096
+
+type backendGeneration struct {
+	// Keep the allocation non-zero-sized so distinct generations always have
+	// distinct pointer identities.
+	value byte
+}
+
+func (c *client) backendGenerationLocked(remote string) *backendGeneration {
+	if c.mu.backendGeneration == nil {
+		c.mu.backendGeneration = make(map[string]*backendGeneration)
+	}
+	if generation := c.mu.backendGeneration[remote]; generation != nil {
+		return generation
+	}
+	if len(c.mu.backendGeneration) >= maxBackendGenerationEntries {
+		// Eviction invalidates outstanding creates for the victim. A later request
+		// allocates a distinct token, so an evicted stale request cannot be
+		// re-admitted even when the same address returns (no ABA).
+		for victim := range c.mu.backendGeneration {
+			delete(c.mu.backendGeneration, victim)
+			break
+		}
+	}
+	generation := &backendGeneration{}
+	c.mu.backendGeneration[remote] = generation
+	return generation
 }
 
 func (c *client) triggerGCInactive(remote string) {

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -309,6 +309,10 @@ type client struct {
 		closed   bool // true when Close() is completed
 		backends map[string][]Backend
 		ops      map[string]*op
+		// backendEpoch invalidates asynchronous create requests queued before a
+		// targeted backend reset. Without it, an old request can repopulate the
+		// pool after CloseBackendFor returns.
+		backendEpoch map[string]uint64
 	}
 
 	circuitBreakers *CircuitBreakerManager
@@ -342,6 +346,7 @@ func NewClient(
 	}
 	c.mu.backends = make(map[string][]Backend)
 	c.mu.ops = make(map[string]*op)
+	c.mu.backendEpoch = make(map[string]uint64)
 
 	for _, opt := range options {
 		opt(c)
@@ -838,6 +843,26 @@ func (c *client) CloseBackend() error {
 	return nil
 }
 
+// CloseBackendFor synchronously detaches one remote and invalidates any
+// asynchronous create requests queued before this call.
+func (c *client) CloseBackendFor(remote string) error {
+	c.mu.Lock()
+	backends := c.mu.backends[remote]
+	c.mu.backendEpoch[remote]++
+	delete(c.mu.backends, remote)
+	delete(c.mu.ops, remote)
+	c.updatePoolSizeMetricsLocked()
+	c.mu.Unlock()
+
+	// Close outside c.mu: backend shutdown can wait for worker goroutines, and
+	// no new caller should be blocked from creating the replacement meanwhile.
+	for _, backend := range backends {
+		backend.Close()
+	}
+	c.circuitBreakers.RemoveBreaker(remote)
+	return nil
+}
+
 func (c *client) getBackend(backend string, lock bool) (Backend, error) {
 	// Fast-fail: check circuit breaker before acquiring lock
 	// This prevents blocking on lock acquisition for known-bad backends
@@ -859,6 +884,7 @@ func (c *client) getBackend(backend string, lock bool) (Backend, error) {
 
 	// No backend available in pool
 	canCreate := c.canCreateLocked(backend)
+	backendEpoch := c.mu.backendEpoch[backend]
 	enableAutoCreate := c.options.enableAutoCreate
 	hasBackends := poolSize > 0
 	c.mu.Unlock() // Release lock before any potentially blocking operation
@@ -879,7 +905,7 @@ func (c *client) getBackend(backend string, lock bool) (Backend, error) {
 	creationQueued := false
 	if canCreate {
 		// Try to enqueue creation task with backpressure handling
-		if !globalClientGC.triggerCreate(c, backend) {
+		if !globalClientGC.triggerCreateAtEpoch(c, backend, backendEpoch) {
 			// Queue is full - fallback to existing creation path with proper bookkeeping
 			return c.createBackendWithBookkeeping(backend, lock)
 		}
@@ -973,7 +999,7 @@ func (c *client) tryCreate(backend string) bool {
 		return false
 	}
 
-	return globalClientGC.triggerCreate(c, backend)
+	return globalClientGC.triggerCreateAtEpoch(c, backend, c.mu.backendEpoch[backend])
 }
 
 func (c *client) createBackendWithBookkeeping(backend string, lock bool) (Backend, error) {
@@ -989,6 +1015,7 @@ func (c *client) createBackendWithBookkeeping(backend string, lock bool) (Backen
 		c.mu.Unlock()
 		return nil, moerr.NewBackendClosedNoCtx()
 	}
+	backendEpoch := c.mu.backendEpoch[backend]
 	c.mu.Unlock()
 
 	// Create backend using factory with metrics (same as doCreate) without holding the lock.
@@ -1004,6 +1031,10 @@ func (c *client) createBackendWithBookkeeping(backend string, lock bool) (Backen
 	if c.mu.closed {
 		b.Close()
 		return nil, moerr.NewClientClosedNoCtx()
+	}
+	if c.mu.backendEpoch[backend] != backendEpoch {
+		b.Close()
+		return nil, moerr.NewBackendClosedNoCtx()
 	}
 	if !c.canCreateLocked(backend) {
 		// Another goroutine may have filled the pool while we were creating.

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -313,6 +313,9 @@ type client struct {
 		// targeted reset. Pointer identity avoids ABA when an entry is evicted
 		// and later recreated for the same remote.
 		backendGeneration map[string]*backendGeneration
+		// creating deduplicates factory I/O per remote generation without
+		// holding mu across DNS or network connection work.
+		creating map[string]*backendGeneration
 	}
 
 	circuitBreakers *CircuitBreakerManager
@@ -347,6 +350,7 @@ func NewClient(
 	c.mu.backends = make(map[string][]Backend)
 	c.mu.ops = make(map[string]*op)
 	c.mu.backendGeneration = make(map[string]*backendGeneration)
+	c.mu.creating = make(map[string]*backendGeneration)
 
 	for _, opt := range options {
 		opt(c)
@@ -433,9 +437,11 @@ func (c *client) Send(ctx context.Context, backend string, request Message) (*Fu
 		panic("client Send nil context")
 	}
 
-	// Check circuit breaker before attempting
-	if !c.circuitBreakers.Allow(backend) {
-		return nil, c.circuitBreakers.GetError(backend)
+	// Pin the breaker incarnation for this request. A targeted backend reset
+	// detaches it, so a late result cannot affect the replacement generation.
+	breaker := c.circuitBreakers.newHandle(backend)
+	if !breaker.Allow() {
+		return nil, breaker.Error()
 	}
 
 	policy := c.options.retryPolicy
@@ -445,9 +451,9 @@ func (c *client) Send(ctx context.Context, backend string, request Message) (*Fu
 
 	for {
 		// Check circuit breaker before each retry attempt
-		if !c.circuitBreakers.Allow(backend) {
+		if !breaker.Allow() {
 			// Don't record failure - circuit is already open
-			return nil, c.circuitBreakers.GetError(backend)
+			return nil, breaker.Error()
 		}
 
 		b, err := c.getBackend(backend, false)
@@ -468,7 +474,7 @@ func (c *client) Send(ctx context.Context, backend string, request Message) (*Fu
 				shouldContinue, waitErr := c.handleAutoCreateWait(ctx, backend, &creationStart, retryCount)
 				if !shouldContinue {
 					// Record circuit breaker failure on timeout
-					c.circuitBreakers.RecordFailure(backend)
+					breaker.RecordFailure()
 					return nil, waitErr
 				}
 
@@ -480,7 +486,7 @@ func (c *client) Send(ctx context.Context, backend string, request Message) (*Fu
 						zap.Int("retries", retryCount),
 						zap.Error(err))
 					// Record circuit breaker failure on max retries
-					c.circuitBreakers.RecordFailure(backend)
+					breaker.RecordFailure()
 					return nil, err
 				}
 
@@ -499,14 +505,14 @@ func (c *client) Send(ctx context.Context, backend string, request Message) (*Fu
 			// Don't count client-level errors (like ErrClientClosed) as circuit breaker failures
 			// Only count backend-related errors
 			if !moerr.IsMoErrCode(err, moerr.ErrClientClosed) {
-				c.circuitBreakers.RecordFailure(backend)
+				breaker.RecordFailure()
 			}
 			return nil, err
 		}
 
 		f, err := b.Send(ctx, request)
 		if err != nil && err == backendClosed {
-			c.circuitBreakers.RecordFailure(backend)
+			breaker.RecordFailure()
 			retryCount++
 			// Check if max retries exceeded (0 means unlimited)
 			if policy.MaxRetries > 0 && retryCount >= policy.MaxRetries {
@@ -518,8 +524,8 @@ func (c *client) Send(ctx context.Context, backend string, request Message) (*Fu
 			}
 
 			// Check circuit breaker after failure
-			if !c.circuitBreakers.Allow(backend) {
-				return nil, c.circuitBreakers.GetError(backend)
+			if !breaker.Allow() {
+				return nil, breaker.Error()
 			}
 
 			// Calculate next backoff with jitter
@@ -541,9 +547,9 @@ func (c *client) Send(ctx context.Context, backend string, request Message) (*Fu
 			continue
 		}
 		if err == nil {
-			c.circuitBreakers.RecordSuccess(backend)
+			breaker.RecordSuccess()
 		} else {
-			c.circuitBreakers.RecordFailure(backend)
+			breaker.RecordFailure()
 		}
 		return f, err
 	}
@@ -554,9 +560,9 @@ func (c *client) NewStream(ctx context.Context, backend string, lock bool) (Stre
 		panic("client NewStream nil context")
 	}
 
-	// Check circuit breaker before attempting
-	if !c.circuitBreakers.Allow(backend) {
-		return nil, c.circuitBreakers.GetError(backend)
+	breaker := c.circuitBreakers.newHandle(backend)
+	if !breaker.Allow() {
+		return nil, breaker.Error()
 	}
 
 	policy := c.options.retryPolicy
@@ -566,9 +572,9 @@ func (c *client) NewStream(ctx context.Context, backend string, lock bool) (Stre
 
 	for {
 		// Check circuit breaker before each retry attempt
-		if !c.circuitBreakers.Allow(backend) {
+		if !breaker.Allow() {
 			// Don't record failure - circuit is already open
-			return nil, c.circuitBreakers.GetError(backend)
+			return nil, breaker.Error()
 		}
 
 		// Check context before attempting
@@ -596,7 +602,7 @@ func (c *client) NewStream(ctx context.Context, backend string, lock bool) (Stre
 				shouldContinue, waitErr := c.handleAutoCreateWait(ctx, backend, &creationStart, retryCount)
 				if !shouldContinue {
 					// Record circuit breaker failure on timeout
-					c.circuitBreakers.RecordFailure(backend)
+					breaker.RecordFailure()
 					return nil, waitErr
 				}
 
@@ -608,7 +614,7 @@ func (c *client) NewStream(ctx context.Context, backend string, lock bool) (Stre
 						zap.Int("retries", retryCount),
 						zap.Error(err))
 					// Record circuit breaker failure on max retries
-					c.circuitBreakers.RecordFailure(backend)
+					breaker.RecordFailure()
 					return nil, err
 				}
 
@@ -626,14 +632,14 @@ func (c *client) NewStream(ctx context.Context, backend string, lock bool) (Stre
 
 			// Don't count client-level errors (like ErrClientClosed) as circuit breaker failures
 			if !moerr.IsMoErrCode(err, moerr.ErrClientClosed) {
-				c.circuitBreakers.RecordFailure(backend)
+				breaker.RecordFailure()
 			}
 			return nil, err
 		}
 
 		st, err := b.NewStream(lock)
 		if err != nil && err == backendClosed {
-			c.circuitBreakers.RecordFailure(backend)
+			breaker.RecordFailure()
 			retryCount++
 			// Check if max retries exceeded
 			if policy.MaxRetries > 0 && retryCount >= policy.MaxRetries {
@@ -645,8 +651,8 @@ func (c *client) NewStream(ctx context.Context, backend string, lock bool) (Stre
 			}
 
 			// Check circuit breaker after failure
-			if !c.circuitBreakers.Allow(backend) {
-				return nil, c.circuitBreakers.GetError(backend)
+			if !breaker.Allow() {
+				return nil, breaker.Error()
 			}
 
 			// Calculate next backoff with jitter
@@ -668,9 +674,9 @@ func (c *client) NewStream(ctx context.Context, backend string, lock bool) (Stre
 			continue
 		}
 		if err == nil {
-			c.circuitBreakers.RecordSuccess(backend)
+			breaker.RecordSuccess()
 		} else {
-			c.circuitBreakers.RecordFailure(backend)
+			breaker.RecordFailure()
 		}
 		return st, err
 	}
@@ -681,9 +687,9 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 		panic("client Ping nil context")
 	}
 
-	// Check circuit breaker before attempting
-	if !c.circuitBreakers.Allow(backend) {
-		return c.circuitBreakers.GetError(backend)
+	breaker := c.circuitBreakers.newHandle(backend)
+	if !breaker.Allow() {
+		return breaker.Error()
 	}
 
 	policy := c.options.retryPolicy
@@ -710,7 +716,7 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 				shouldContinue, waitErr := c.handleAutoCreateWait(ctx, backend, &creationStart, retryCount)
 				if !shouldContinue {
 					// Record circuit breaker failure on timeout
-					c.circuitBreakers.RecordFailure(backend)
+					breaker.RecordFailure()
 					return waitErr
 				}
 
@@ -722,7 +728,7 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 						zap.Int("retries", retryCount),
 						zap.Error(err))
 					// Record circuit breaker failure on max retries
-					c.circuitBreakers.RecordFailure(backend)
+					breaker.RecordFailure()
 					return err
 				}
 
@@ -740,7 +746,7 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 
 			// Don't count client-level errors (like ErrClientClosed) as circuit breaker failures
 			if !moerr.IsMoErrCode(err, moerr.ErrClientClosed) {
-				c.circuitBreakers.RecordFailure(backend)
+				breaker.RecordFailure()
 			}
 			return err
 		}
@@ -748,7 +754,7 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 		f, err := b.SendInternal(ctx, &flagOnlyMessage{flag: flagPing})
 		if err != nil {
 			if err == backendClosed {
-				c.circuitBreakers.RecordFailure(backend)
+				breaker.RecordFailure()
 				retryCount++
 				// Check if max retries exceeded
 				if policy.MaxRetries > 0 && retryCount >= policy.MaxRetries {
@@ -760,8 +766,8 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 				}
 
 				// Check circuit breaker after failure
-				if !c.circuitBreakers.Allow(backend) {
-					return c.circuitBreakers.GetError(backend)
+				if !breaker.Allow() {
+					return breaker.Error()
 				}
 
 				// Calculate next backoff with jitter
@@ -782,15 +788,15 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 				}
 				continue
 			}
-			c.circuitBreakers.RecordFailure(backend)
+			breaker.RecordFailure()
 			return err
 		}
 		_, err = f.Get()
 		f.Close()
 		if err == nil {
-			c.circuitBreakers.RecordSuccess(backend)
+			breaker.RecordSuccess()
 		} else {
-			c.circuitBreakers.RecordFailure(backend)
+			breaker.RecordFailure()
 		}
 		return err
 	}
@@ -849,9 +855,14 @@ func (c *client) CloseBackendFor(remote string) error {
 	c.mu.Lock()
 	backends := c.mu.backends[remote]
 	delete(c.mu.backendGeneration, remote)
+	delete(c.mu.creating, remote)
 	delete(c.mu.backends, remote)
 	delete(c.mu.ops, remote)
 	c.updatePoolSizeMetricsLocked()
+	// Detach breaker state in the same reset critical section as the backend
+	// generation. A request either captures the complete old incarnation or a
+	// complete new one, never a new backend generation with the old breaker.
+	c.circuitBreakers.RemoveBreaker(remote)
 	c.mu.Unlock()
 
 	// Close outside c.mu: backend shutdown can wait for worker goroutines, and
@@ -859,7 +870,6 @@ func (c *client) CloseBackendFor(remote string) error {
 	for _, backend := range backends {
 		backend.Close()
 	}
-	c.circuitBreakers.RemoveBreaker(remote)
 	return nil
 }
 
@@ -1002,7 +1012,7 @@ func (c *client) tryCreate(backend string) bool {
 		return false
 	}
 
-	return globalClientGC.triggerCreateAtGeneration(
+	return globalClientGC.triggerCreateAtGenerationLocked(
 		c,
 		backend,
 		c.backendGenerationLocked(backend),
@@ -1021,11 +1031,11 @@ func (c *client) createBackendWithBookkeepingAtGeneration(
 	lock bool,
 	generation *backendGeneration,
 ) (Backend, error) {
-	// Use existing creation path with proper bookkeeping, but avoid holding the lock
-	// during network I/O. We double-check limits after creation to avoid overfilling
-	// if another goroutine created a backend in the meantime.
+	if generation == nil {
+		return nil, moerr.NewBackendClosedNoCtx()
+	}
 	c.mu.Lock()
-	if c.mu.closed {
+	if c.mu.closing || c.mu.closed {
 		c.mu.Unlock()
 		return nil, moerr.NewClientClosedNoCtx()
 	}
@@ -1033,7 +1043,47 @@ func (c *client) createBackendWithBookkeepingAtGeneration(
 		c.mu.Unlock()
 		return nil, moerr.NewBackendClosedNoCtx()
 	}
+	if c.mu.creating == nil {
+		c.mu.creating = make(map[string]*backendGeneration)
+	}
+	if c.mu.creating[backend] != nil {
+		c.mu.Unlock()
+		return nil, ErrBackendCreating
+	}
 	if !c.canCreateLocked(backend) {
+		c.mu.Unlock()
+		return nil, moerr.NewBackendClosedNoCtx()
+	}
+	c.mu.creating[backend] = generation
+	c.mu.Unlock()
+	return c.createBackendForClaimedGeneration(backend, lock, generation)
+}
+
+// createBackendForClaimedGeneration performs factory I/O for a create request
+// that already owns the queued/in-flight slot for this remote generation.
+func (c *client) createBackendForClaimedGeneration(
+	backend string,
+	lock bool,
+	generation *backendGeneration,
+) (Backend, error) {
+	if generation == nil {
+		return nil, moerr.NewBackendClosedNoCtx()
+	}
+	c.mu.Lock()
+	if c.mu.closing || c.mu.closed {
+		if c.mu.creating[backend] == generation {
+			delete(c.mu.creating, backend)
+		}
+		c.mu.Unlock()
+		return nil, moerr.NewClientClosedNoCtx()
+	}
+	if c.mu.backendGeneration[backend] != generation ||
+		c.mu.creating[backend] != generation {
+		c.mu.Unlock()
+		return nil, moerr.NewBackendClosedNoCtx()
+	}
+	if !c.canCreateLocked(backend) {
+		delete(c.mu.creating, backend)
 		c.mu.Unlock()
 		return nil, moerr.NewBackendClosedNoCtx()
 	}
@@ -1041,24 +1091,30 @@ func (c *client) createBackendWithBookkeepingAtGeneration(
 
 	// Create backend using factory with metrics (same as doCreate) without holding the lock.
 	b, err := c.doCreate(backend)
-	if err != nil {
-		return nil, err
-	}
 
 	// Re-acquire lock to add to pool, validating limits again.
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	if c.mu.creating[backend] == generation {
+		delete(c.mu.creating, backend)
+	}
+	if err != nil {
+		c.mu.Unlock()
+		return nil, err
+	}
 
-	if c.mu.closed {
+	if c.mu.closing || c.mu.closed {
+		c.mu.Unlock()
 		b.Close()
 		return nil, moerr.NewClientClosedNoCtx()
 	}
 	if c.mu.backendGeneration[backend] != generation {
+		c.mu.Unlock()
 		b.Close()
 		return nil, moerr.NewBackendClosedNoCtx()
 	}
 	if !c.canCreateLocked(backend) {
 		// Another goroutine may have filled the pool while we were creating.
+		c.mu.Unlock()
 		b.Close()
 		return nil, moerr.NewBackendClosedNoCtx()
 	}
@@ -1078,8 +1134,17 @@ func (c *client) createBackendWithBookkeepingAtGeneration(
 
 	// Update metrics (same as existing creation path)
 	c.updatePoolSizeMetricsLocked()
+	c.mu.Unlock()
 
 	return b, nil
+}
+
+func (c *client) releaseBackendCreate(backend string, generation *backendGeneration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.mu.creating[backend] == generation {
+		delete(c.mu.creating, backend)
+	}
 }
 
 const maxBackendGenerationEntries = 4096
@@ -1087,7 +1152,7 @@ const maxBackendGenerationEntries = 4096
 type backendGeneration struct {
 	// Keep the allocation non-zero-sized so distinct generations always have
 	// distinct pointer identities.
-	value byte
+	_ byte
 }
 
 func (c *client) backendGenerationLocked(remote string) *backendGeneration {
@@ -1103,6 +1168,7 @@ func (c *client) backendGenerationLocked(remote string) *backendGeneration {
 		// re-admitted even when the same address returns (no ABA).
 		for victim := range c.mu.backendGeneration {
 			delete(c.mu.backendGeneration, victim)
+			delete(c.mu.creating, victim)
 			break
 		}
 	}

--- a/pkg/common/morpc/client_gc.go
+++ b/pkg/common/morpc/client_gc.go
@@ -179,6 +179,7 @@ type gcInactiveRequest struct {
 type createRequest struct {
 	c       *client
 	backend string
+	epoch   uint64
 }
 
 func newClientGCManager() *clientGCManager {
@@ -299,9 +300,9 @@ func (m *clientGCManager) triggerGCInactive(c *client, remote string) {
 
 // triggerCreate triggers create task for a specific client and backend.
 // Returns true if the request was successfully queued, false if channel was full.
-func (m *clientGCManager) triggerCreate(c *client, backend string) bool {
+func (m *clientGCManager) triggerCreateAtEpoch(c *client, backend string, epoch uint64) bool {
 	select {
-	case m.createC <- createRequest{c: c, backend: backend}:
+	case m.createC <- createRequest{c: c, backend: backend, epoch: epoch}:
 		return true
 	default:
 		// Channel is full, skip to avoid blocking
@@ -432,7 +433,7 @@ func (m *clientGCManager) runCreateLoop() {
 			if registered {
 				// createBackendLocked is called under lock, check closed there
 				req.c.mu.Lock()
-				if !req.c.mu.closed {
+				if !req.c.mu.closed && req.c.mu.backendEpoch[req.backend] == req.epoch {
 					if _, err := req.c.createBackendLocked(req.backend); err != nil {
 						req.c.logger.Error("create backend failed",
 							zap.String("backend", req.backend),

--- a/pkg/common/morpc/client_gc.go
+++ b/pkg/common/morpc/client_gc.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -298,17 +299,43 @@ func (m *clientGCManager) triggerGCInactive(c *client, remote string) {
 	}
 }
 
-// triggerCreate triggers create task for a specific client and backend.
-// Returns true if the request was successfully queued, false if channel was full.
+// triggerCreateAtGeneration records demand for a client/backend generation.
+// It returns true when creation is already pending or newly queued. It returns
+// false when admission is invalid or the queue is full; a caller may then retry
+// or use the synchronous fallback.
 func (m *clientGCManager) triggerCreateAtGeneration(
 	c *client,
 	backend string,
 	generation *backendGeneration,
 ) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return m.triggerCreateAtGenerationLocked(c, backend, generation)
+}
+
+// triggerCreateAtGenerationLocked admits at most one queued or in-flight
+// factory call for a remote generation. The caller must hold c.mu.
+func (m *clientGCManager) triggerCreateAtGenerationLocked(
+	c *client,
+	backend string,
+	generation *backendGeneration,
+) bool {
+	if generation == nil || c.mu.closing || c.mu.closed ||
+		c.mu.backendGeneration[backend] != generation ||
+		!c.canCreateLocked(backend) {
+		return false
+	}
+	if pending := c.mu.creating[backend]; pending != nil {
+		// An existing request for this generation already represents the
+		// caller's demand. A different generation must never be coalesced.
+		return pending == generation
+	}
+	c.mu.creating[backend] = generation
 	select {
 	case m.createC <- createRequest{c: c, backend: backend, generation: generation}:
 		return true
 	default:
+		delete(c.mu.creating, backend)
 		// Channel is full, skip to avoid blocking
 		// This is acceptable because create will be retried when needed
 		m.createDropCounter.Inc()
@@ -435,19 +462,25 @@ func (m *clientGCManager) runCreateLoop() {
 			_, registered := m.clients[req.c]
 			m.mu.RUnlock()
 			if registered {
-				// createBackendLocked is called under lock, check closed there
-				req.c.mu.Lock()
-				if !req.c.mu.closed && req.generation != nil &&
-					req.c.mu.backendGeneration[req.backend] == req.generation {
-					if _, err := req.c.createBackendLocked(req.backend); err != nil {
+				// Factory.Create may perform DNS and network I/O. The bookkeeping
+				// path validates the captured generation both before and after that
+				// I/O without holding c.mu, so targeted reset remains responsive.
+				if _, err := req.c.createBackendForClaimedGeneration(
+					req.backend,
+					false,
+					req.generation,
+				); err != nil {
+					if !moerr.IsMoErrCode(err, moerr.ErrBackendClosed) &&
+						!moerr.IsMoErrCode(err, moerr.ErrClientClosed) {
 						req.c.logger.Error("create backend failed",
 							zap.String("backend", req.backend),
 							zap.Error(err))
-					} else {
-						m.createProcessedCounter.Inc()
 					}
+				} else {
+					m.createProcessedCounter.Inc()
 				}
-				req.c.mu.Unlock()
+			} else {
+				req.c.releaseBackendCreate(req.backend, req.generation)
 			}
 		}
 	}

--- a/pkg/common/morpc/client_gc.go
+++ b/pkg/common/morpc/client_gc.go
@@ -177,9 +177,9 @@ type gcInactiveRequest struct {
 }
 
 type createRequest struct {
-	c       *client
-	backend string
-	epoch   uint64
+	c          *client
+	backend    string
+	generation *backendGeneration
 }
 
 func newClientGCManager() *clientGCManager {
@@ -300,9 +300,13 @@ func (m *clientGCManager) triggerGCInactive(c *client, remote string) {
 
 // triggerCreate triggers create task for a specific client and backend.
 // Returns true if the request was successfully queued, false if channel was full.
-func (m *clientGCManager) triggerCreateAtEpoch(c *client, backend string, epoch uint64) bool {
+func (m *clientGCManager) triggerCreateAtGeneration(
+	c *client,
+	backend string,
+	generation *backendGeneration,
+) bool {
 	select {
-	case m.createC <- createRequest{c: c, backend: backend, epoch: epoch}:
+	case m.createC <- createRequest{c: c, backend: backend, generation: generation}:
 		return true
 	default:
 		// Channel is full, skip to avoid blocking
@@ -433,7 +437,8 @@ func (m *clientGCManager) runCreateLoop() {
 			if registered {
 				// createBackendLocked is called under lock, check closed there
 				req.c.mu.Lock()
-				if !req.c.mu.closed && req.c.mu.backendEpoch[req.backend] == req.epoch {
+				if !req.c.mu.closed && req.generation != nil &&
+					req.c.mu.backendGeneration[req.backend] == req.generation {
 					if _, err := req.c.createBackendLocked(req.backend); err != nil {
 						req.c.logger.Error("create backend failed",
 							zap.String("backend", req.backend),

--- a/pkg/common/morpc/client_gc_test.go
+++ b/pkg/common/morpc/client_gc_test.go
@@ -200,7 +200,7 @@ func TestGlobalClientGC_CreateLoop(t *testing.T) {
 	assert.Equal(t, 0, len(backends))
 
 	// Trigger create
-	mgr.triggerCreate(client, "b1")
+	mgr.triggerCreateAtEpoch(client, "b1", 0)
 
 	// Wait for processing
 	time.Sleep(time.Millisecond * 100)
@@ -213,6 +213,54 @@ func TestGlobalClientGC_CreateLoop(t *testing.T) {
 
 	mgr.unregister(client)
 	mgr.stop()
+}
+
+func TestGlobalClientGC_DropsCreateQueuedBeforeBackendReset(t *testing.T) {
+	mgr := newClientGCManager()
+	factory := &createNotifyFactory{
+		inner:   newTestBackendFactory(),
+		created: make(chan struct{}, 2),
+	}
+	rc, err := NewClient("test-stale-create",
+		factory,
+		WithClientMaxBackendPerHost(2),
+		WithClientEnableAutoCreateBackend())
+	require.NoError(t, err)
+	client := rc.(*client)
+	defer func() {
+		mgr.unregister(client)
+		mgr.stop()
+		require.NoError(t, client.Close())
+	}()
+	mgr.register(client)
+
+	// A reset advances b1 to epoch 1. Simulate a create request that was
+	// already queued with epoch 0, then use another remote as a FIFO barrier.
+	require.NoError(t, client.CloseBackendFor("b1"))
+	require.True(t, mgr.triggerCreateAtEpoch(client, "b1", 0))
+	require.True(t, mgr.triggerCreateAtEpoch(client, "barrier", 0))
+	select {
+	case <-factory.created:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for create-loop barrier")
+	}
+
+	client.mu.Lock()
+	require.Empty(t, client.mu.backends["b1"])
+	require.Len(t, client.mu.backends["barrier"], 1)
+	epoch := client.mu.backendEpoch["b1"]
+	client.mu.Unlock()
+
+	// A request from the current epoch is still admitted normally.
+	require.True(t, mgr.triggerCreateAtEpoch(client, "b1", epoch))
+	select {
+	case <-factory.created:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for current-epoch create")
+	}
+	client.mu.Lock()
+	require.Len(t, client.mu.backends["b1"], 1)
+	client.mu.Unlock()
 }
 
 func TestGlobalClientGC_ConcurrentClients(t *testing.T) {
@@ -273,7 +321,7 @@ func TestGlobalClientGC_ChannelFull(t *testing.T) {
 	// Fill up the channels
 	for i := 0; i < 1025; i++ {
 		mgr.triggerGCInactive(client, "b1")
-		mgr.triggerCreate(client, "b1")
+		mgr.triggerCreateAtEpoch(client, "b1", 0)
 	}
 
 	// Should not block or panic
@@ -298,7 +346,7 @@ func TestGlobalClientGC_UnregisteredClientIgnored(t *testing.T) {
 
 	// Try to trigger GC on unregistered client
 	mgr.triggerGCInactive(client, "b1")
-	mgr.triggerCreate(client, "b1")
+	mgr.triggerCreateAtEpoch(client, "b1", 0)
 
 	// Wait a bit
 	time.Sleep(time.Millisecond * 100)
@@ -479,7 +527,7 @@ func TestGlobalClientGC_StressTest(t *testing.T) {
 			for j := 0; j < numOpsPerClient; j++ {
 				mgr.triggerGCInactive(client, "b1")
 				atomic.AddInt64(&opsCount, 1)
-				mgr.triggerCreate(client, "b1")
+				mgr.triggerCreateAtEpoch(client, "b1", 0)
 				atomic.AddInt64(&opsCount, 1)
 			}
 		}(i)
@@ -513,19 +561,19 @@ func TestGlobalClientGC_TriggerCreateReturnValue(t *testing.T) {
 	mgr.register(client)
 
 	// First request should succeed (channel is empty)
-	ok := mgr.triggerCreate(client, "b1")
+	ok := mgr.triggerCreateAtEpoch(client, "b1", 0)
 	assert.True(t, ok, "first triggerCreate should succeed")
 
 	// Fill up the channel to test failure case
 	channelCap := cap(mgr.createC)
 	for i := 0; i < channelCap-1; i++ {
-		mgr.triggerCreate(client, "b1")
+		mgr.triggerCreateAtEpoch(client, "b1", 0)
 	}
 
 	// Now channel should be full, next request should fail
 	// Note: we need to ensure the channel is full by filling it completely
 	for i := 0; i < channelCap; i++ {
-		mgr.triggerCreate(client, "b1")
+		mgr.triggerCreateAtEpoch(client, "b1", 0)
 	}
 
 	// The last few should have returned false (channel full)
@@ -838,7 +886,7 @@ func TestGlobalClientGC_CreateOnClosedClient(t *testing.T) {
 	client.mu.Unlock()
 
 	// Trigger create - should be safely ignored
-	mgr.triggerCreate(client, "b1")
+	mgr.triggerCreateAtEpoch(client, "b1", 0)
 
 	// Give time for the create loop to process
 	time.Sleep(time.Millisecond * 50)

--- a/pkg/common/morpc/client_gc_test.go
+++ b/pkg/common/morpc/client_gc_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func triggerCreateForTest(mgr *clientGCManager, c *client, backend string) bool {
+	c.mu.Lock()
+	generation := c.backendGenerationLocked(backend)
+	c.mu.Unlock()
+	return mgr.triggerCreateAtGeneration(c, backend, generation)
+}
+
 // Helper function to get backend with retry for async creation
 func getBackendWithRetry(t *testing.T, client *client, backend string, lock bool) Backend {
 	var b Backend
@@ -200,7 +207,7 @@ func TestGlobalClientGC_CreateLoop(t *testing.T) {
 	assert.Equal(t, 0, len(backends))
 
 	// Trigger create
-	mgr.triggerCreateAtEpoch(client, "b1", 0)
+	triggerCreateForTest(mgr, client, "b1")
 
 	// Wait for processing
 	time.Sleep(time.Millisecond * 100)
@@ -234,11 +241,14 @@ func TestGlobalClientGC_DropsCreateQueuedBeforeBackendReset(t *testing.T) {
 	}()
 	mgr.register(client)
 
-	// A reset advances b1 to epoch 1. Simulate a create request that was
-	// already queued with epoch 0, then use another remote as a FIFO barrier.
+	client.mu.Lock()
+	staleGeneration := client.backendGenerationLocked("b1")
+	client.mu.Unlock()
+	// Reset removes the captured token. Simulate a request that was already
+	// queued with that stale token, then use another remote as a FIFO barrier.
 	require.NoError(t, client.CloseBackendFor("b1"))
-	require.True(t, mgr.triggerCreateAtEpoch(client, "b1", 0))
-	require.True(t, mgr.triggerCreateAtEpoch(client, "barrier", 0))
+	require.True(t, mgr.triggerCreateAtGeneration(client, "b1", staleGeneration))
+	require.True(t, triggerCreateForTest(mgr, client, "barrier"))
 	select {
 	case <-factory.created:
 	case <-time.After(5 * time.Second):
@@ -248,11 +258,10 @@ func TestGlobalClientGC_DropsCreateQueuedBeforeBackendReset(t *testing.T) {
 	client.mu.Lock()
 	require.Empty(t, client.mu.backends["b1"])
 	require.Len(t, client.mu.backends["barrier"], 1)
-	epoch := client.mu.backendEpoch["b1"]
 	client.mu.Unlock()
 
-	// A request from the current epoch is still admitted normally.
-	require.True(t, mgr.triggerCreateAtEpoch(client, "b1", epoch))
+	// A request with a fresh generation is still admitted normally.
+	require.True(t, triggerCreateForTest(mgr, client, "b1"))
 	select {
 	case <-factory.created:
 	case <-time.After(5 * time.Second):
@@ -321,7 +330,7 @@ func TestGlobalClientGC_ChannelFull(t *testing.T) {
 	// Fill up the channels
 	for i := 0; i < 1025; i++ {
 		mgr.triggerGCInactive(client, "b1")
-		mgr.triggerCreateAtEpoch(client, "b1", 0)
+		triggerCreateForTest(mgr, client, "b1")
 	}
 
 	// Should not block or panic
@@ -346,7 +355,7 @@ func TestGlobalClientGC_UnregisteredClientIgnored(t *testing.T) {
 
 	// Try to trigger GC on unregistered client
 	mgr.triggerGCInactive(client, "b1")
-	mgr.triggerCreateAtEpoch(client, "b1", 0)
+	triggerCreateForTest(mgr, client, "b1")
 
 	// Wait a bit
 	time.Sleep(time.Millisecond * 100)
@@ -527,7 +536,7 @@ func TestGlobalClientGC_StressTest(t *testing.T) {
 			for j := 0; j < numOpsPerClient; j++ {
 				mgr.triggerGCInactive(client, "b1")
 				atomic.AddInt64(&opsCount, 1)
-				mgr.triggerCreateAtEpoch(client, "b1", 0)
+				triggerCreateForTest(mgr, client, "b1")
 				atomic.AddInt64(&opsCount, 1)
 			}
 		}(i)
@@ -561,19 +570,19 @@ func TestGlobalClientGC_TriggerCreateReturnValue(t *testing.T) {
 	mgr.register(client)
 
 	// First request should succeed (channel is empty)
-	ok := mgr.triggerCreateAtEpoch(client, "b1", 0)
+	ok := triggerCreateForTest(mgr, client, "b1")
 	assert.True(t, ok, "first triggerCreate should succeed")
 
 	// Fill up the channel to test failure case
 	channelCap := cap(mgr.createC)
 	for i := 0; i < channelCap-1; i++ {
-		mgr.triggerCreateAtEpoch(client, "b1", 0)
+		triggerCreateForTest(mgr, client, "b1")
 	}
 
 	// Now channel should be full, next request should fail
 	// Note: we need to ensure the channel is full by filling it completely
 	for i := 0; i < channelCap; i++ {
-		mgr.triggerCreateAtEpoch(client, "b1", 0)
+		triggerCreateForTest(mgr, client, "b1")
 	}
 
 	// The last few should have returned false (channel full)
@@ -886,7 +895,7 @@ func TestGlobalClientGC_CreateOnClosedClient(t *testing.T) {
 	client.mu.Unlock()
 
 	// Trigger create - should be safely ignored
-	mgr.triggerCreateAtEpoch(client, "b1", 0)
+	triggerCreateForTest(mgr, client, "b1")
 
 	// Give time for the create loop to process
 	time.Sleep(time.Millisecond * 50)

--- a/pkg/common/morpc/client_gc_test.go
+++ b/pkg/common/morpc/client_gc_test.go
@@ -244,10 +244,10 @@ func TestGlobalClientGC_DropsCreateQueuedBeforeBackendReset(t *testing.T) {
 	client.mu.Lock()
 	staleGeneration := client.backendGenerationLocked("b1")
 	client.mu.Unlock()
-	// Reset removes the captured token. Simulate a request that was already
-	// queued with that stale token, then use another remote as a FIFO barrier.
+	// Reset removes the captured token. Inject a request that was admitted before
+	// reset directly into the worker queue, then use another remote as a FIFO barrier.
 	require.NoError(t, client.CloseBackendFor("b1"))
-	require.True(t, mgr.triggerCreateAtGeneration(client, "b1", staleGeneration))
+	mgr.createC <- createRequest{c: client, backend: "b1", generation: staleGeneration}
 	require.True(t, triggerCreateForTest(mgr, client, "barrier"))
 	select {
 	case <-factory.created:
@@ -255,10 +255,12 @@ func TestGlobalClientGC_DropsCreateQueuedBeforeBackendReset(t *testing.T) {
 		t.Fatal("timed out waiting for create-loop barrier")
 	}
 
-	client.mu.Lock()
-	require.Empty(t, client.mu.backends["b1"])
-	require.Len(t, client.mu.backends["barrier"], 1)
-	client.mu.Unlock()
+	require.Eventually(t, func() bool {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		return len(client.mu.backends["b1"]) == 0 &&
+			len(client.mu.backends["barrier"]) == 1
+	}, 5*time.Second, 10*time.Millisecond)
 
 	// A request with a fresh generation is still admitted normally.
 	require.True(t, triggerCreateForTest(mgr, client, "b1"))
@@ -267,9 +269,111 @@ func TestGlobalClientGC_DropsCreateQueuedBeforeBackendReset(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for current-epoch create")
 	}
+	require.Eventually(t, func() bool {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		return len(client.mu.backends["b1"]) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestGlobalClientGC_ResetDoesNotWaitForQueuedFactoryIO(t *testing.T) {
+	mgr := newClientGCManager()
+	factory := &blockingCreateFactory{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		backend: &testBackend{id: 1, activeTime: time.Now()},
+	}
+	rc, err := NewClient(
+		"test-reset-during-gc-create",
+		factory,
+		WithClientMaxBackendPerHost(1),
+	)
+	require.NoError(t, err)
+	client := rc.(*client)
+	defer func() {
+		select {
+		case <-factory.release:
+		default:
+			close(factory.release)
+		}
+		mgr.unregister(client)
+		mgr.stop()
+		require.NoError(t, client.Close())
+	}()
+	mgr.register(client)
+
+	require.True(t, triggerCreateForTest(mgr, client, "b1"))
+	select {
+	case <-factory.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued factory create did not start")
+	}
+
+	resetDone := make(chan error, 1)
+	go func() { resetDone <- client.CloseBackendFor("b1") }()
+	select {
+	case err := <-resetDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("targeted reset blocked behind queued factory I/O")
+	}
+
+	close(factory.release)
+	require.Eventually(t, func() bool {
+		factory.backend.RWMutex.RLock()
+		defer factory.backend.RWMutex.RUnlock()
+		return factory.backend.closed
+	}, 5*time.Second, 10*time.Millisecond)
 	client.mu.Lock()
-	require.Len(t, client.mu.backends["b1"], 1)
+	backendCount := len(client.mu.backends["b1"])
 	client.mu.Unlock()
+	require.Zero(t, backendCount)
+}
+
+func TestGlobalClientGC_DeduplicatesQueuedAndInflightCreate(t *testing.T) {
+	mgr := newClientGCManager()
+	factory := &blockingCreateFactory{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		backend: &testBackend{id: 1, activeTime: time.Now()},
+	}
+	rc, err := NewClient(
+		"test-deduplicate-create",
+		factory,
+		WithClientMaxBackendPerHost(2),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	client := rc.(*client)
+	defer func() {
+		select {
+		case <-factory.release:
+		default:
+			close(factory.release)
+		}
+		mgr.unregister(client)
+		mgr.stop()
+		require.NoError(t, client.Close())
+	}()
+	mgr.register(client)
+
+	require.True(t, triggerCreateForTest(mgr, client, "b1"))
+	select {
+	case <-factory.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued factory create did not start")
+	}
+	for i := 0; i < 100; i++ {
+		require.True(t, triggerCreateForTest(mgr, client, "b1"))
+	}
+	require.Empty(t, mgr.createC, "duplicate demand must not enqueue duplicate factory calls")
+
+	close(factory.release)
+	require.Eventually(t, func() bool {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		return len(client.mu.backends["b1"]) == 1 && client.mu.creating["b1"] == nil
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestGlobalClientGC_ConcurrentClients(t *testing.T) {
@@ -558,6 +662,8 @@ func TestGlobalClientGC_StressTest(t *testing.T) {
 
 func TestGlobalClientGC_TriggerCreateReturnValue(t *testing.T) {
 	mgr := newClientGCManager()
+	// Keep the manager stopped and use a tiny queue so admission is deterministic.
+	mgr.createC = make(chan createRequest, 1)
 
 	c, err := NewClient("test-client",
 		newTestBackendFactory(),
@@ -567,30 +673,23 @@ func TestGlobalClientGC_TriggerCreateReturnValue(t *testing.T) {
 	defer c.Close()
 
 	client := c.(*client)
-	mgr.register(client)
 
 	// First request should succeed (channel is empty)
-	ok := triggerCreateForTest(mgr, client, "b1")
-	assert.True(t, ok, "first triggerCreate should succeed")
+	require.True(t, triggerCreateForTest(mgr, client, "b1"))
+	// Duplicate demand is coalesced and does not consume another queue slot.
+	require.True(t, triggerCreateForTest(mgr, client, "b1"))
+	require.Len(t, mgr.createC, 1)
 
-	// Fill up the channel to test failure case
-	channelCap := cap(mgr.createC)
-	for i := 0; i < channelCap-1; i++ {
-		triggerCreateForTest(mgr, client, "b1")
-	}
+	// A distinct request observes the full queue and releases its admission slot.
+	require.False(t, triggerCreateForTest(mgr, client, "b2"))
+	client.mu.Lock()
+	pending := client.mu.creating["b2"]
+	client.mu.Unlock()
+	require.Nil(t, pending)
 
-	// Now channel should be full, next request should fail
-	// Note: we need to ensure the channel is full by filling it completely
-	for i := 0; i < channelCap; i++ {
-		triggerCreateForTest(mgr, client, "b1")
-	}
-
-	// The last few should have returned false (channel full)
-	// We can't easily verify this without pausing the consumer goroutine
-	// So we just verify no panic and the function returns
-
-	mgr.unregister(client)
-	mgr.stop()
+	queued := <-mgr.createC
+	queued.c.releaseBackendCreate(queued.backend, queued.generation)
+	require.True(t, triggerCreateForTest(mgr, client, "b2"))
 }
 
 func TestGlobalClientGC_InitGlobalGCManagerConcurrent(t *testing.T) {
@@ -702,7 +801,9 @@ func TestGlobalClientGC_TryCreateReturnsCorrectValue(t *testing.T) {
 	cli1 := c1.(*client)
 
 	// tryCreate should return true when auto-create is enabled and channel has space
+	cli1.mu.Lock()
 	ok := cli1.tryCreate("b1")
+	cli1.mu.Unlock()
 	assert.True(t, ok, "tryCreate should return true when successful")
 
 	// Create a client with auto-create explicitly disabled
@@ -716,7 +817,9 @@ func TestGlobalClientGC_TryCreateReturnsCorrectValue(t *testing.T) {
 	cli2 := c2.(*client)
 
 	// tryCreate should return false when auto-create is disabled
+	cli2.mu.Lock()
 	ok = cli2.tryCreate("b1")
+	cli2.mu.Unlock()
 	assert.False(t, ok, "tryCreate should return false when auto-create is disabled")
 }
 

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -540,12 +540,9 @@ func TestGetBackendWithCreateBackend(t *testing.T) {
 }
 
 func TestCloseIdleBackends(t *testing.T) {
-	// Event-driven: factory signals on Create so we wait for 2 backends without Sleep.
-	created := make(chan struct{}, 2)
-	factory := &createNotifyFactory{inner: newTestBackendFactory(), created: created}
 	rc, err := NewClient(
 		"",
-		factory,
+		newTestBackendFactory(),
 		WithClientMaxBackendPerHost(2),
 		WithClientMaxBackendMaxIdleDuration(time.Millisecond*100),
 		WithClientCreateTaskChanSize(1),
@@ -570,29 +567,18 @@ func TestCloseIdleBackends(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, b, "timeout waiting for first backend")
 
-	// Trigger second create; wait for two Create() completions (event-driven, with timeout)
-	_, _ = c.getBackend("b1", false)
-	for _, ch := range []chan struct{}{created, created} {
-		select {
-		case <-ch:
-		case <-time.After(10 * time.Second):
-			t.Fatal("timeout waiting for backend create (second backend may not have been created)")
-		}
-	}
+	// Create the second backend synchronously through the complete bookkeeping
+	// path. A factory-level Create notification is too early for this assertion:
+	// the backend is published to the pool only after Create returns and the
+	// client re-acquires c.mu.
+	activeBackend, err := c.createBackendWithBookkeeping("b1", false)
+	require.NoError(t, err)
+	require.NotNil(t, activeBackend)
+	require.NotSame(t, b, activeBackend)
 	c.mu.Lock()
 	backendCount := len(c.mu.backends["b1"])
-	// b is the locked backend returned by getBackend; find the active (non-b) backend
-	// without assuming slice order, since concurrent creation may append in any order.
-	var activeBackend Backend
-	for _, bk := range c.mu.backends["b1"] {
-		if bk != b {
-			activeBackend = bk
-			break
-		}
-	}
 	c.mu.Unlock()
 	require.Equal(t, 2, backendCount, "second backend must be created")
-	require.NotNil(t, activeBackend, "active backend not found")
 
 	// b is the idle backend: unlock it and zero activeTime so GC will close it
 	b.Unlock()

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -16,6 +16,7 @@ package morpc
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -179,6 +180,81 @@ func TestCloseBackendForRejectsConcurrentSynchronousCreate(t *testing.T) {
 	factory.backend.RWMutex.RLock()
 	require.True(t, factory.backend.closed)
 	factory.backend.RWMutex.RUnlock()
+}
+
+func TestQueueFullFallbackRejectsGenerationCapturedBeforeReset(t *testing.T) {
+	factory := &createNotifyFactory{
+		inner:   newTestBackendFactory(),
+		created: make(chan struct{}, 1),
+	}
+	rc, err := NewClient("", factory, WithClientMaxBackendPerHost(1))
+	require.NoError(t, err)
+	c := rc.(*client)
+	defer func() { require.NoError(t, c.Close()) }()
+
+	c.mu.Lock()
+	staleGeneration := c.backendGenerationLocked("target")
+	c.mu.Unlock()
+	require.NoError(t, c.CloseBackendFor("target"))
+
+	_, err = c.createBackendWithBookkeepingAtGeneration(
+		"target",
+		false,
+		staleGeneration,
+	)
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendClosed))
+	select {
+	case <-factory.created:
+		t.Fatal("stale queue-full fallback reached backend factory")
+	default:
+	}
+	c.mu.Lock()
+	require.Empty(t, c.mu.backends["target"])
+	c.mu.Unlock()
+}
+
+func TestBackendGenerationIsBoundedAndDoesNotABA(t *testing.T) {
+	rc, err := NewClient("", newTestBackendFactory(), WithClientMaxBackendPerHost(1))
+	require.NoError(t, err)
+	c := rc.(*client)
+	defer func() { require.NoError(t, c.Close()) }()
+
+	c.mu.Lock()
+	old := c.backendGenerationLocked("target")
+	c.mu.Unlock()
+	require.NoError(t, c.CloseBackendFor("target"))
+	c.mu.Lock()
+	current := c.backendGenerationLocked("target")
+	require.NotSame(t, old, current)
+	c.mu.backendGeneration = make(map[string]*backendGeneration)
+	generations := make(map[string]*backendGeneration, maxBackendGenerationEntries)
+	for i := 0; i < maxBackendGenerationEntries; i++ {
+		remote := fmt.Sprintf("remote-%d", i)
+		generations[remote] = c.backendGenerationLocked(remote)
+	}
+	c.backendGenerationLocked("overflow")
+	require.LessOrEqual(t, len(c.mu.backendGeneration), maxBackendGenerationEntries)
+	var evictedRemote string
+	var evictedGeneration *backendGeneration
+	for remote, generation := range generations {
+		if c.mu.backendGeneration[remote] != generation {
+			evictedRemote = remote
+			evictedGeneration = generation
+			break
+		}
+	}
+	c.mu.Unlock()
+	require.NotEmpty(t, evictedRemote)
+
+	_, err = c.createBackendWithBookkeepingAtGeneration(
+		evictedRemote,
+		false,
+		evictedGeneration,
+	)
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendClosed),
+		"evicted generation was re-admitted")
 }
 
 // TestGetBackendLockedDoesNotCreateWhenAvailable covers the fix: maybeCreateLocked must only

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -511,9 +511,9 @@ func TestCloseIdleBackends(t *testing.T) {
 	// b is the idle backend: unlock it and zero activeTime so GC will close it
 	b.Unlock()
 	tb := b.(*testBackend)
-	tb.Lock()
+	tb.RWMutex.Lock()
 	tb.activeTime = time.Time{}
-	tb.Unlock()
+	tb.RWMutex.Unlock()
 
 	gcDeadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(gcDeadline) {
@@ -570,7 +570,10 @@ func TestLockedBackendCannotClosedWithGCIdleTask(t *testing.T) {
 	assert.NotNil(t, b)
 	assert.True(t, b.Locked())
 	b.(*testBackend).RWMutex.Lock()
-	b.(*testBackend).activeTime = time.Time{}
+	tb := b.(*testBackend)
+	tb.RWMutex.Lock()
+	tb.activeTime = time.Time{}
+	tb.RWMutex.Unlock()
 	b.(*testBackend).RWMutex.Unlock()
 
 	time.Sleep(time.Second * 1)

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -511,9 +511,7 @@ func TestCloseIdleBackends(t *testing.T) {
 	// b is the idle backend: unlock it and zero activeTime so GC will close it
 	b.Unlock()
 	tb := b.(*testBackend)
-	tb.RWMutex.Lock()
-	tb.activeTime = time.Time{}
-	tb.RWMutex.Unlock()
+	tb.setActiveTime(time.Time{})
 
 	gcDeadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(gcDeadline) {
@@ -548,35 +546,26 @@ func TestLockedBackendCannotClosedWithGCIdleTask(t *testing.T) {
 		"",
 		newTestBackendFactory(),
 		WithClientMaxBackendPerHost(2),
-		WithClientMaxBackendMaxIdleDuration(time.Millisecond*100),
-		WithClientCreateTaskChanSize(1),
-		WithClientEnableAutoCreateBackend())
+		WithClientMaxBackendMaxIdleDuration(time.Millisecond*100))
 	assert.NoError(t, err)
 	c := rc.(*client)
 	defer func() {
 		assert.NoError(t, c.Close())
 	}()
+	// This unit test exercises idle GC directly. Do not let the independent
+	// global inactive-GC loop remove the zero-active-time backend first.
+	globalClientGC.unregister(c)
 
-	// Get backend with lock, may need retry
-	var b Backend
-	for i := 0; i < 10; i++ {
-		b, err = c.getBackend("b1", true)
-		if err == nil && b != nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	c.mu.Lock()
+	b, err := c.createBackendLocked("b1")
+	c.mu.Unlock()
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
+	b.Lock()
 	assert.True(t, b.Locked())
-	b.(*testBackend).RWMutex.Lock()
-	tb := b.(*testBackend)
-	tb.RWMutex.Lock()
-	tb.activeTime = time.Time{}
-	tb.RWMutex.Unlock()
-	b.(*testBackend).RWMutex.Unlock()
+	b.(*testBackend).setActiveTime(time.Time{})
 
-	time.Sleep(time.Second * 1)
+	assert.Zero(t, c.closeIdleBackends())
 	c.mu.Lock()
 	assert.Equal(t, 1, len(c.mu.backends["b1"]))
 	c.mu.Unlock()
@@ -605,7 +594,7 @@ func TestGetBackendsWithAllInactiveAndWillCreateNew(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
 
-	b.(*testBackend).activeTime = time.Time{}
+	b.(*testBackend).setActiveTime(time.Time{})
 
 	// Backend is now inactive, next call triggers async recreation
 	b, err = c.getBackend("b1", false)

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -40,6 +40,18 @@ func (f *createNotifyFactory) Create(backend string, opts ...BackendOption) (Bac
 	return b, err
 }
 
+type blockingCreateFactory struct {
+	entered chan struct{}
+	release chan struct{}
+	backend *testBackend
+}
+
+func (f *blockingCreateFactory) Create(string, ...BackendOption) (Backend, error) {
+	close(f.entered)
+	<-f.release
+	return f.backend, nil
+}
+
 func TestCreateBackendLocked(t *testing.T) {
 	rc, err := NewClient("", newTestBackendFactory(), WithClientMaxBackendPerHost(1))
 	assert.NoError(t, err)
@@ -81,6 +93,92 @@ func TestGetBackendLockedWithEmptyBackends(t *testing.T) {
 	b, err := c.getBackendLocked("b1", false)
 	assert.NoError(t, err)
 	assert.Nil(t, b)
+}
+
+func TestCloseBackendForSynchronouslyDetachesOnlyTarget(t *testing.T) {
+	rc, err := NewClient("", newTestBackendFactory(), WithClientMaxBackendPerHost(1))
+	require.NoError(t, err)
+	c := rc.(*client)
+	defer func() { require.NoError(t, c.Close()) }()
+
+	target := &testBackend{id: 1, activeTime: time.Now()}
+	other := &testBackend{id: 2, activeTime: time.Now()}
+	c.mu.Lock()
+	c.mu.backends["target"] = []Backend{target}
+	c.mu.backends["other"] = []Backend{other}
+	c.mu.ops["target"] = &op{}
+	c.mu.ops["other"] = &op{}
+	c.mu.Unlock()
+	c.circuitBreakers.RecordFailure("target")
+
+	require.NoError(t, c.CloseBackendFor("target"))
+
+	c.mu.Lock()
+	require.Empty(t, c.mu.backends["target"])
+	require.Nil(t, c.mu.ops["target"])
+	require.Equal(t, []Backend{other}, c.mu.backends["other"])
+	c.mu.Unlock()
+	require.NotContains(t, c.circuitBreakers.Stats(), "target")
+
+	target.RWMutex.RLock()
+	require.True(t, target.closed)
+	target.RWMutex.RUnlock()
+	other.RWMutex.RLock()
+	require.False(t, other.closed)
+	other.RWMutex.RUnlock()
+
+	c.mu.Lock()
+	replacement, err := c.createBackendLocked("target")
+	c.mu.Unlock()
+	require.NoError(t, err)
+	require.NotNil(t, replacement)
+}
+
+func TestCloseBackendForRejectsConcurrentSynchronousCreate(t *testing.T) {
+	factory := &blockingCreateFactory{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		backend: &testBackend{id: 1, activeTime: time.Now()},
+	}
+	defer func() {
+		select {
+		case <-factory.release:
+		default:
+			close(factory.release)
+		}
+	}()
+	rc, err := NewClient("", factory, WithClientMaxBackendPerHost(1))
+	require.NoError(t, err)
+	c := rc.(*client)
+	defer func() { require.NoError(t, c.Close()) }()
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := c.createBackendWithBookkeeping("target", false)
+		result <- err
+	}()
+	select {
+	case <-factory.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend creation did not start")
+	}
+
+	require.NoError(t, c.CloseBackendFor("target"))
+	close(factory.release)
+	select {
+	case err := <-result:
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendClosed))
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend creation did not finish")
+	}
+
+	c.mu.Lock()
+	require.Empty(t, c.mu.backends["target"])
+	c.mu.Unlock()
+	factory.backend.RWMutex.RLock()
+	require.True(t, factory.backend.closed)
+	factory.backend.RWMutex.RUnlock()
 }
 
 // TestGetBackendLockedDoesNotCreateWhenAvailable covers the fix: maybeCreateLocked must only

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -115,18 +115,23 @@ func TestCloseBackendForSynchronouslyDetachesOnlyTarget(t *testing.T) {
 	require.NoError(t, c.CloseBackendFor("target"))
 
 	c.mu.Lock()
-	require.Empty(t, c.mu.backends["target"])
-	require.Nil(t, c.mu.ops["target"])
-	require.Equal(t, []Backend{other}, c.mu.backends["other"])
+	targetBackends := append([]Backend(nil), c.mu.backends["target"]...)
+	targetOp := c.mu.ops["target"]
+	otherBackends := append([]Backend(nil), c.mu.backends["other"]...)
 	c.mu.Unlock()
+	require.Empty(t, targetBackends)
+	require.Nil(t, targetOp)
+	require.Equal(t, []Backend{other}, otherBackends)
 	require.NotContains(t, c.circuitBreakers.Stats(), "target")
 
 	target.RWMutex.RLock()
-	require.True(t, target.closed)
+	targetClosed := target.closed
 	target.RWMutex.RUnlock()
 	other.RWMutex.RLock()
-	require.False(t, other.closed)
+	otherClosed := other.closed
 	other.RWMutex.RUnlock()
+	require.True(t, targetClosed)
+	require.False(t, otherClosed)
 
 	c.mu.Lock()
 	replacement, err := c.createBackendLocked("target")
@@ -175,11 +180,13 @@ func TestCloseBackendForRejectsConcurrentSynchronousCreate(t *testing.T) {
 	}
 
 	c.mu.Lock()
-	require.Empty(t, c.mu.backends["target"])
+	targetBackends := append([]Backend(nil), c.mu.backends["target"]...)
 	c.mu.Unlock()
 	factory.backend.RWMutex.RLock()
-	require.True(t, factory.backend.closed)
+	backendClosed := factory.backend.closed
 	factory.backend.RWMutex.RUnlock()
+	require.Empty(t, targetBackends)
+	require.True(t, backendClosed)
 }
 
 func TestQueueFullFallbackRejectsGenerationCapturedBeforeReset(t *testing.T) {
@@ -210,8 +217,9 @@ func TestQueueFullFallbackRejectsGenerationCapturedBeforeReset(t *testing.T) {
 	default:
 	}
 	c.mu.Lock()
-	require.Empty(t, c.mu.backends["target"])
+	targetBackends := append([]Backend(nil), c.mu.backends["target"]...)
 	c.mu.Unlock()
+	require.Empty(t, targetBackends)
 }
 
 func TestBackendGenerationIsBoundedAndDoesNotABA(t *testing.T) {
@@ -226,7 +234,6 @@ func TestBackendGenerationIsBoundedAndDoesNotABA(t *testing.T) {
 	require.NoError(t, c.CloseBackendFor("target"))
 	c.mu.Lock()
 	current := c.backendGenerationLocked("target")
-	require.NotSame(t, old, current)
 	c.mu.backendGeneration = make(map[string]*backendGeneration)
 	generations := make(map[string]*backendGeneration, maxBackendGenerationEntries)
 	for i := 0; i < maxBackendGenerationEntries; i++ {
@@ -234,7 +241,7 @@ func TestBackendGenerationIsBoundedAndDoesNotABA(t *testing.T) {
 		generations[remote] = c.backendGenerationLocked(remote)
 	}
 	c.backendGenerationLocked("overflow")
-	require.LessOrEqual(t, len(c.mu.backendGeneration), maxBackendGenerationEntries)
+	generationCount := len(c.mu.backendGeneration)
 	var evictedRemote string
 	var evictedGeneration *backendGeneration
 	for remote, generation := range generations {
@@ -245,6 +252,8 @@ func TestBackendGenerationIsBoundedAndDoesNotABA(t *testing.T) {
 		}
 	}
 	c.mu.Unlock()
+	require.NotSame(t, old, current)
+	require.LessOrEqual(t, generationCount, maxBackendGenerationEntries)
 	require.NotEmpty(t, evictedRemote)
 
 	_, err = c.createBackendWithBookkeepingAtGeneration(
@@ -571,7 +580,7 @@ func TestCloseIdleBackends(t *testing.T) {
 		}
 	}
 	c.mu.Lock()
-	require.Equal(t, 2, len(c.mu.backends["b1"]), "second backend must be created")
+	backendCount := len(c.mu.backends["b1"])
 	// b is the locked backend returned by getBackend; find the active (non-b) backend
 	// without assuming slice order, since concurrent creation may append in any order.
 	var activeBackend Backend
@@ -582,6 +591,7 @@ func TestCloseIdleBackends(t *testing.T) {
 		}
 	}
 	c.mu.Unlock()
+	require.Equal(t, 2, backendCount, "second backend must be created")
 	require.NotNil(t, activeBackend, "active backend not found")
 
 	// b is the idle backend: unlock it and zero activeTime so GC will close it

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -747,7 +747,7 @@ func (l *lockTableAllocator) cleanCommitStateOnce(
 					// the wrong process. Refresh the endpoint once before treating
 					// a successful negative response as authoritative.
 					if attempt == 1 {
-						if l.resetActiveTxnBackend(sid) == backendResetSucceeded {
+						if l.resetActiveTxnBackend(ctx, sid) == backendResetSucceeded {
 							continue
 						}
 						// Reset failure and unsupported reset both leave the
@@ -784,7 +784,7 @@ func (l *lockTableAllocator) cleanCommitStateOnce(
 			// getter attaches its context cause, and some MORPC failures are only
 			// recognizable through that wrapped error. Resetting inside the getter
 			// can therefore miss exactly the BackendClosed path we are recovering.
-			l.resetActiveTxnBackend(sid)
+			l.resetActiveTxnBackend(ctx, sid)
 
 			l.logger.Error("get active txn failed",
 				zap.String("serviceID", sid),
@@ -831,14 +831,17 @@ const (
 	backendResetFailed
 )
 
-func (l *lockTableAllocator) resetActiveTxnBackend(serviceID string) backendResetResult {
+func (l *lockTableAllocator) resetActiveTxnBackend(
+	ctx context.Context,
+	serviceID string,
+) backendResetResult {
 	resetter, ok := l.client.(interface {
-		ResetBackend(string) error
+		ResetBackend(context.Context, string) error
 	})
 	if !ok {
 		return backendResetUnsupported
 	}
-	if err := resetter.ResetBackend(serviceID); err != nil {
+	if err := resetter.ResetBackend(ctx, serviceID); err != nil {
 		l.logger.Error("reset active-txn backend failed",
 			zap.String("serviceID", serviceID),
 			zap.Error(err))

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -746,8 +746,14 @@ func (l *lockTableAllocator) cleanCommitStateOnce(
 					// Valid=false for this incarnation, but the response came from
 					// the wrong process. Refresh the endpoint once before treating
 					// a successful negative response as authoritative.
-					if attempt == 1 && l.resetActiveTxnBackend(sid) {
-						continue
+					if attempt == 1 {
+						if l.resetActiveTxnBackend(sid) == backendResetSucceeded {
+							continue
+						}
+						// Reset failure and unsupported reset both leave the
+						// observation tied to a potentially stale endpoint. Its
+						// negative reply is not evidence that the service is inactive.
+						break
 					}
 					invalidServices = append(invalidServices, sid)
 				} else {
@@ -817,19 +823,28 @@ func (l *lockTableAllocator) cleanCommitStateOnce(
 	l.ctlMu.Unlock()
 }
 
-func (l *lockTableAllocator) resetActiveTxnBackend(serviceID string) bool {
+type backendResetResult uint8
+
+const (
+	backendResetUnsupported backendResetResult = iota
+	backendResetSucceeded
+	backendResetFailed
+)
+
+func (l *lockTableAllocator) resetActiveTxnBackend(serviceID string) backendResetResult {
 	resetter, ok := l.client.(interface {
 		ResetBackend(string) error
 	})
 	if !ok {
-		return false
+		return backendResetUnsupported
 	}
 	if err := resetter.ResetBackend(serviceID); err != nil {
 		l.logger.Error("reset active-txn backend failed",
 			zap.String("serviceID", serviceID),
 			zap.Error(err))
+		return backendResetFailed
 	}
-	return true
+	return backendResetSucceeded
 }
 
 // serviceBinds an instance of serviceBinds, recording the bindings of a lockservice

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -39,6 +39,11 @@ import (
 // network jitter while still bounding how long dead services retain lock tables.
 const keepBindGraceFactor = 2
 
+const (
+	getActiveTxnMaxAttempts = 3
+	getActiveTxnRetryDelay  = 100 * time.Millisecond
+)
+
 type lockTableAllocator struct {
 	service         string
 	logger          *log.MOLogger
@@ -49,6 +54,7 @@ type lockTableAllocator struct {
 	server          Server
 	client          Client
 	inactiveService sync.Map // lock service id -> inactive time
+	inactiveMu      sync.RWMutex
 	ctl             sync.Map // lock service id -> *commitCtl
 	ctlMu           sync.RWMutex
 	allocatorID     string
@@ -63,7 +69,7 @@ type lockTableAllocator struct {
 
 	// for test
 	options struct {
-		getActiveTxnFunc         func(sid string) (bool, [][]byte, error)
+		getActiveTxnFunc         func(context.Context, string) (bool, [][]byte, error)
 		removeDisconnectDuration time.Duration
 	}
 }
@@ -186,12 +192,57 @@ func (l *lockTableAllocator) FinishCommit(serviceID string, txnID []byte) {
 }
 
 func (l *lockTableAllocator) AddInvalidService(serviceID string) {
-	l.inactiveService.Store(serviceID, time.Now())
+	l.markServiceInactive(serviceID, nil, 0, false)
 }
 
 func (l *lockTableAllocator) HasInvalidService(serviceID string) bool {
 	_, ok := l.inactiveService.Load(serviceID)
 	return ok
+}
+
+func (l *lockTableAllocator) markServiceInactive(
+	serviceID string,
+	ctl *commitCtl,
+	expectedEpoch uint64,
+	conditional bool,
+) bool {
+	l.inactiveMu.Lock()
+	defer l.inactiveMu.Unlock()
+	if conditional {
+		current, ok := l.ctl.Load(serviceID)
+		if !ok || current != ctl || expectedEpoch == math.MaxUint64 ||
+			ctl.currentRecoveryEpoch() != expectedEpoch {
+			return false
+		}
+	}
+	l.inactiveService.Store(serviceID, time.Now())
+	return true
+}
+
+func (l *lockTableAllocator) resumeService(serviceID string) {
+	ctl := l.getCtl(serviceID)
+	l.inactiveMu.Lock()
+	defer l.inactiveMu.Unlock()
+	ctl.advanceRecoveryEpoch()
+	l.inactiveService.Delete(serviceID)
+}
+
+func (l *lockTableAllocator) removeInactiveServiceIfExpired(
+	serviceID string,
+	observedAt time.Time,
+	removeDisconnectDuration time.Duration,
+) bool {
+	if time.Since(observedAt) <= removeDisconnectDuration {
+		return false
+	}
+	l.inactiveMu.Lock()
+	defer l.inactiveMu.Unlock()
+	current, ok := l.inactiveService.Load(serviceID)
+	if !ok || current.(time.Time) != observedAt {
+		return false
+	}
+	l.inactiveService.Delete(serviceID)
+	return true
 }
 
 func (l *lockTableAllocator) Valid(
@@ -222,6 +273,13 @@ func (l *lockTableAllocator) Valid(
 		return invalid, nil
 	}
 
+	// Admission and commit registration must be atomic with respect to fencing.
+	// Otherwise cleanup can mark the service inactive after this check but
+	// before beginCommit, allowing one commit to start after the fence.
+	l.ctlMu.RLock()
+	defer l.ctlMu.RUnlock()
+	l.inactiveMu.RLock()
+	defer l.inactiveMu.RUnlock()
 	if _, ok := l.inactiveService.Load(serviceID); ok {
 		l.logger.Info("inactive service",
 			zap.String("serviceID", serviceID),
@@ -229,8 +287,6 @@ func (l *lockTableAllocator) Valid(
 		return nil, moerr.NewCannotCommitOnInvalidCNNoCtx()
 	}
 
-	l.ctlMu.RLock()
-	defer l.ctlMu.RUnlock()
 	c := l.getCtl(serviceID)
 	state := c.beginCommit(util.UnsafeBytesToString(txnID))
 	if state == cannotCommitState {
@@ -601,8 +657,8 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 
 	getActiveTxnFunc := l.options.getActiveTxnFunc
 	if getActiveTxnFunc == nil {
-		getActiveTxnFunc = func(sid string) (bool, [][]byte, error) {
-			ctx, cancel := context.WithTimeoutCause(context.Background(), defaultRPCTimeout, moerr.CauseCleanCommitState)
+		getActiveTxnFunc = func(parent context.Context, sid string) (bool, [][]byte, error) {
+			ctx, cancel := context.WithTimeoutCause(parent, defaultRPCTimeout, moerr.CauseCleanCommitState)
 			defer cancel()
 
 			req := acquireRequest()
@@ -636,95 +692,144 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 			return
 		case <-timer.C:
 			l.logger.Info("clean commit state")
-
-			var services []string
-			var invalidServices []string
-			var unknownServices []string
-			activeTxnMap := make(map[string]map[string]struct{})
-			cleanupWatermarks := make(map[string]uint64)
-			expiredUnknownServices := make(map[string]struct{})
-
-			l.ctlMu.RLock()
-			l.ctl.Range(func(key, value any) bool {
-				services = append(services, key.(string))
-				return true
-			})
-			l.ctlMu.RUnlock()
-
-			l.inactiveService.Range(func(key, value any) bool {
-				if time.Since(value.(time.Time)) > removeDisconnectDuration {
-					sid := key.(string)
-					l.logger.Error("remove inactive service",
-						zap.String("serviceID", sid))
-					expiredUnknownServices[sid] = struct{}{}
-					l.inactiveService.Delete(key)
-				}
-				return true
-			})
-
-			retryCount := math.MaxInt - 1
-
-			for _, sid := range services {
-				for i := 0; i < retryCount+1; i++ {
-					// The active-txn response can only classify control states that
-					// existed before this request started.
-					watermark, ok := l.getCtlGeneration(sid)
-					if !ok {
-						break
-					}
-					cleanupWatermarks[sid] = watermark
-					valid, actives, err := getActiveTxnFunc(sid)
-					if err == nil {
-						if !valid {
-							invalidServices = append(invalidServices, sid)
-						} else {
-							m := make(map[string]struct{}, len(actives))
-							for _, txn := range actives {
-								m[util.UnsafeBytesToString(txn)] = struct{}{}
-							}
-							activeTxnMap[sid] = m
-						}
-					} else if isRetryError(err) {
-						// retry err
-						l.logger.Error("retry to check service if alive",
-							zap.String("serviceID", sid),
-							zap.Error(err))
-						if i < retryCount {
-							continue
-						}
-						l.inactiveService.Store(sid, time.Now())
-						unknownServices = append(unknownServices, sid)
-					} else {
-						// is not retry err
-						l.logger.Error("get active txn failed",
-							zap.String("serviceID", sid),
-							zap.Error(err))
-						l.inactiveService.Store(sid, time.Now())
-						unknownServices = append(unknownServices, sid)
-					}
-					break
-				}
-			}
-
-			l.ctlMu.Lock()
-			for _, sid := range invalidServices {
-				l.cleanCtlLocked(sid, nil, false, cleanupWatermarks[sid])
-			}
-			for _, sid := range unknownServices {
-				// An RPC error is not proof that a fenced txn can commit again.
-				// Keep cannot-commit tombstones until the service state is known
-				// or the existing disconnected-service retention expires.
-				_, expired := expiredUnknownServices[sid]
-				l.cleanCtlLocked(sid, nil, !expired, cleanupWatermarks[sid])
-			}
-			for sid, activeTxns := range activeTxnMap {
-				l.cleanCtlLocked(sid, activeTxns, false, cleanupWatermarks[sid])
-			}
-			l.ctlMu.Unlock()
+			l.cleanCommitStateOnce(ctx, getActiveTxnFunc, removeDisconnectDuration)
 
 			timer.Reset(l.keepBindTimeout * 2)
 		}
 	}
+}
+
+func (l *lockTableAllocator) cleanCommitStateOnce(
+	ctx context.Context,
+	getActiveTxnFunc func(context.Context, string) (bool, [][]byte, error),
+	removeDisconnectDuration time.Duration,
+) {
+	var services []string
+	var invalidServices []string
+	var unknownServices []string
+	activeTxnMap := make(map[string]map[string]struct{})
+	cleanupWatermarks := make(map[string]uint64)
+	expiredUnknownServices := make(map[string]struct{})
+
+	l.ctlMu.RLock()
+	l.ctl.Range(func(key, value any) bool {
+		services = append(services, key.(string))
+		return true
+	})
+	l.ctlMu.RUnlock()
+
+	l.inactiveService.Range(func(key, value any) bool {
+		sid := key.(string)
+		if l.removeInactiveServiceIfExpired(sid, value.(time.Time), removeDisconnectDuration) {
+			l.logger.Error("remove inactive service", zap.String("serviceID", sid))
+			expiredUnknownServices[sid] = struct{}{}
+		}
+		return true
+	})
+
+	for _, sid := range services {
+		if ctx.Err() != nil {
+			break
+		}
+		ctl, watermark, epoch, ok := l.getCtlCleanupSnapshot(sid)
+		if !ok {
+			continue
+		}
+		cleanupWatermarks[sid] = watermark
+
+		for attempt := 1; attempt <= getActiveTxnMaxAttempts; attempt++ {
+			valid, actives, err := getActiveTxnFunc(ctx, sid)
+			if err == nil {
+				if !valid {
+					// A recovery endpoint can have been reassigned to another CN
+					// after a later hot recreate. That CN legitimately replies
+					// Valid=false for this incarnation, but the response came from
+					// the wrong process. Refresh the endpoint once before treating
+					// a successful negative response as authoritative.
+					if attempt == 1 && l.resetActiveTxnBackend(sid) {
+						continue
+					}
+					invalidServices = append(invalidServices, sid)
+				} else {
+					m := make(map[string]struct{}, len(actives))
+					for _, txn := range actives {
+						m[util.UnsafeBytesToString(txn)] = struct{}{}
+					}
+					activeTxnMap[sid] = m
+				}
+				break
+			}
+
+			// The parent was cancelled while the RPC was in flight. Shutdown must
+			// not reset connections or change admission state based on an
+			// incomplete observation.
+			if ctx.Err() != nil {
+				return
+			}
+
+			if !morpc.IsConnectionError(err) {
+				// The service state is unknown. Leave both the admission state and
+				// cannot-commit tombstones unchanged and retry on the next cycle.
+				l.logger.Error("check active txn state failed",
+					zap.String("serviceID", sid), zap.Error(err))
+				break
+			}
+			// Classify and reset after getActiveTxnFunc returns. The production
+			// getter attaches its context cause, and some MORPC failures are only
+			// recognizable through that wrapped error. Resetting inside the getter
+			// can therefore miss exactly the BackendClosed path we are recovering.
+			l.resetActiveTxnBackend(sid)
+
+			l.logger.Error("get active txn failed",
+				zap.String("serviceID", sid),
+				zap.Int("attempt", attempt),
+				zap.Error(err))
+			if attempt == getActiveTxnMaxAttempts {
+				if l.markServiceInactive(sid, ctl, epoch, true) {
+					unknownServices = append(unknownServices, sid)
+				}
+				continue
+			}
+
+			timer := time.NewTimer(getActiveTxnRetryDelay)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return
+			case <-timer.C:
+			}
+		}
+	}
+
+	l.ctlMu.Lock()
+	for _, sid := range invalidServices {
+		l.cleanCtlLocked(sid, nil, false, cleanupWatermarks[sid])
+	}
+	for _, sid := range unknownServices {
+		_, expired := expiredUnknownServices[sid]
+		l.cleanCtlLocked(sid, nil, !expired, cleanupWatermarks[sid])
+	}
+	for sid, activeTxns := range activeTxnMap {
+		l.cleanCtlLocked(sid, activeTxns, false, cleanupWatermarks[sid])
+	}
+	l.ctlMu.Unlock()
+}
+
+func (l *lockTableAllocator) resetActiveTxnBackend(serviceID string) bool {
+	resetter, ok := l.client.(interface {
+		ResetBackend(string) error
+	})
+	if !ok {
+		return false
+	}
+	if err := resetter.ResetBackend(serviceID); err != nil {
+		l.logger.Error("reset active-txn backend failed",
+			zap.String("serviceID", serviceID),
+			zap.Error(err))
+	}
+	return true
 }
 
 // serviceBinds an instance of serviceBinds, recording the bindings of a lockservice
@@ -1054,7 +1159,7 @@ func (l *lockTableAllocator) handleResumeInvalidCN(
 	resp *pb.Response,
 	cs morpc.ClientSession,
 ) {
-	l.inactiveService.Delete(req.ResumeInvalidCN.ServiceID)
+	l.resumeService(req.ResumeInvalidCN.ServiceID)
 	writeResponse(l.logger, cancel, resp, nil, cs)
 }
 
@@ -1110,9 +1215,10 @@ var (
 )
 
 type commitCtl struct {
-	mu         sync.Mutex
-	generation uint64
-	states     map[string]commitState
+	mu            sync.Mutex
+	generation    uint64
+	recoveryEpoch uint64
+	states        map[string]commitState
 }
 
 type commitState struct {
@@ -1256,6 +1362,33 @@ func (c *commitCtl) currentGeneration() uint64 {
 	return c.generation
 }
 
+func (c *commitCtl) currentRecoveryEpoch() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.recoveryEpoch
+}
+
+func (c *commitCtl) advanceRecoveryEpoch() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.recoveryEpoch < math.MaxUint64 {
+		c.recoveryEpoch++
+	}
+}
+
+func (l *lockTableAllocator) getCtlCleanupSnapshot(
+	serviceID string,
+) (*commitCtl, uint64, uint64, bool) {
+	value, ok := l.ctl.Load(serviceID)
+	if !ok {
+		return nil, 0, 0, false
+	}
+	ctl := value.(*commitCtl)
+	ctl.mu.Lock()
+	defer ctl.mu.Unlock()
+	return ctl, ctl.generation, ctl.recoveryEpoch, true
+}
+
 func (l *lockTableAllocator) getCtlGeneration(serviceID string) (uint64, bool) {
 	l.ctlMu.RLock()
 	defer l.ctlMu.RUnlock()
@@ -1278,6 +1411,11 @@ func (l *lockTableAllocator) cleanCtlLocked(
 	}
 	c := value.(*commitCtl)
 	c.clean(activeTxns, preserveCannotCommit, maxGeneration, l.logger)
+	// Serialize removal with Resume and conditional inactive marking. This
+	// prevents an old cleanup from passing an identity check while its ctl is
+	// concurrently replaced (ABA).
+	l.inactiveMu.Lock()
+	defer l.inactiveMu.Unlock()
 	if c.empty() {
 		l.ctl.CompareAndDelete(serviceID, c)
 	}

--- a/pkg/lockservice/lock_table_allocator_recovery_test.go
+++ b/pkg/lockservice/lock_table_allocator_recovery_test.go
@@ -32,7 +32,7 @@ type resetTrackingClient struct {
 	resetErr error
 }
 
-func (c *resetTrackingClient) ResetBackend(string) error {
+func (c *resetTrackingClient) ResetBackend(context.Context, string) error {
 	c.resets.Add(1)
 	return c.resetErr
 }

--- a/pkg/lockservice/lock_table_allocator_recovery_test.go
+++ b/pkg/lockservice/lock_table_allocator_recovery_test.go
@@ -28,12 +28,13 @@ import (
 
 type resetTrackingClient struct {
 	Client
-	resets atomic.Int32
+	resets   atomic.Int32
+	resetErr error
 }
 
 func (c *resetTrackingClient) ResetBackend(string) error {
 	c.resets.Add(1)
-	return nil
+	return c.resetErr
 }
 
 func (c *resetTrackingClient) Close() error { return nil }
@@ -116,6 +117,32 @@ func TestCleanCommitStateAcceptsConfirmedInvalidService(t *testing.T) {
 		require.Equal(t, int32(1), client.resets.Load())
 		_, ok := ctl.getCommitState("old")
 		require.False(t, ok)
+	})
+}
+
+func TestCleanCommitStatePreservesStateWhenNegativeConfirmationResetFails(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		client := &resetTrackingClient{resetErr: moerr.NewBackendClosedNoCtx()}
+		require.NoError(t, a.client.Close())
+		a.client = client
+		ctl := a.getCtl("s1")
+		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("live"))
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(context.Context, string) (bool, [][]byte, error) {
+				calls.Add(1)
+				return false, nil, nil
+			},
+			time.Hour,
+		)
+
+		require.Equal(t, int32(1), calls.Load())
+		require.Equal(t, int32(1), client.resets.Load())
+		require.False(t, a.HasInvalidService("s1"))
+		_, ok := ctl.getCommitState("live")
+		require.True(t, ok, "failed reset must leave control state unknown")
 	})
 }
 

--- a/pkg/lockservice/lock_table_allocator_recovery_test.go
+++ b/pkg/lockservice/lock_table_allocator_recovery_test.go
@@ -1,0 +1,399 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lockservice
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	"github.com/stretchr/testify/require"
+)
+
+type resetTrackingClient struct {
+	Client
+	resets atomic.Int32
+}
+
+func (c *resetTrackingClient) ResetBackend(string) error {
+	c.resets.Add(1)
+	return nil
+}
+
+func (c *resetTrackingClient) Close() error { return nil }
+
+func TestCleanCommitStateRetriesTransientBackendClose(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		client := &resetTrackingClient{}
+		require.NoError(t, a.client.Close())
+		a.client = client
+		c := a.getCtl("s1")
+		require.Equal(t, cannotCommitState, c.tryCannotCommit("active"))
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(context.Context, string) (bool, [][]byte, error) {
+				if calls.Add(1) == 1 {
+					return false, nil, moerr.NewBackendClosedNoCtx()
+				}
+				return true, [][]byte{[]byte("active")}, nil
+			},
+			time.Hour,
+		)
+
+		require.Equal(t, int32(2), calls.Load())
+		require.Equal(t, int32(1), client.resets.Load())
+		require.False(t, a.HasInvalidService("s1"))
+		_, ok := c.getCommitState("active")
+		require.True(t, ok)
+	})
+}
+
+func TestCleanCommitStateConfirmsInvalidAfterEndpointReset(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		client := &resetTrackingClient{}
+		require.NoError(t, a.client.Close())
+		a.client = client
+		ctl := a.getCtl("s1")
+		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("active"))
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(context.Context, string) (bool, [][]byte, error) {
+				if calls.Add(1) == 1 {
+					// Simulate a stale recovery IP now owned by another CN.
+					return false, nil, nil
+				}
+				return true, [][]byte{[]byte("active")}, nil
+			},
+			time.Hour,
+		)
+
+		require.Equal(t, int32(2), calls.Load())
+		require.Equal(t, int32(1), client.resets.Load())
+		_, ok := ctl.getCommitState("active")
+		require.True(t, ok, "a response from the stale endpoint deleted live state")
+	})
+}
+
+func TestCleanCommitStateAcceptsConfirmedInvalidService(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		client := &resetTrackingClient{}
+		require.NoError(t, a.client.Close())
+		a.client = client
+		ctl := a.getCtl("s1")
+		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("old"))
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(context.Context, string) (bool, [][]byte, error) {
+				calls.Add(1)
+				return false, nil, nil
+			},
+			time.Hour,
+		)
+
+		require.Equal(t, int32(2), calls.Load())
+		require.Equal(t, int32(1), client.resets.Load())
+		_, ok := ctl.getCommitState("old")
+		require.False(t, ok)
+	})
+}
+
+func TestCleanCommitStateFencesAfterBoundedConnectionFailures(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		c := a.getCtl("s1")
+		require.Equal(t, cannotCommitState, c.tryCannotCommit("orphan"))
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(context.Context, string) (bool, [][]byte, error) {
+				calls.Add(1)
+				return false, nil, moerr.NewBackendCannotConnectNoCtx("s1")
+			},
+			time.Hour,
+		)
+
+		require.Equal(t, int32(getActiveTxnMaxAttempts), calls.Load())
+		require.True(t, a.HasInvalidService("s1"))
+		_, ok := c.getCommitState("orphan")
+		require.True(t, ok, "unknown service must retain cannot-commit tombstones")
+	})
+}
+
+func TestCleanCommitStateRetriesDeadlineExceeded(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		client := &resetTrackingClient{}
+		require.NoError(t, a.client.Close())
+		a.client = client
+		a.getCtl("s1")
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(context.Context, string) (bool, [][]byte, error) {
+				calls.Add(1)
+				return false, nil, context.DeadlineExceeded
+			},
+			time.Hour,
+		)
+
+		require.Equal(t, int32(getActiveTxnMaxAttempts), calls.Load())
+		require.Equal(t, int32(getActiveTxnMaxAttempts), client.resets.Load())
+		require.True(t, a.HasInvalidService("s1"))
+	})
+}
+
+func TestCleanCommitStateDoesNotLoopOnUnknownError(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		c := a.getCtl("s1")
+		require.Equal(t, cannotCommitState, c.tryCannotCommit("orphan"))
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(context.Context, string) (bool, [][]byte, error) {
+				calls.Add(1)
+				return false, nil, moerr.NewInternalErrorNoCtx("injected jitter")
+			},
+			time.Hour,
+		)
+
+		require.Equal(t, int32(1), calls.Load())
+		require.False(t, a.HasInvalidService("s1"))
+		_, ok := c.getCommitState("orphan")
+		require.True(t, ok)
+	})
+}
+
+func TestCleanCommitStateCannotRefenceAfterResume(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		a.getCtl("s1")
+		a.AddInvalidService("s1")
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		done := make(chan struct{})
+		var once sync.Once
+		go func() {
+			defer close(done)
+			a.cleanCommitStateOnce(
+				context.Background(),
+				func(context.Context, string) (bool, [][]byte, error) {
+					once.Do(func() { close(entered) })
+					<-release
+					return false, nil, moerr.NewBackendClosedNoCtx()
+				},
+				time.Hour,
+			)
+		}()
+
+		<-entered
+		a.resumeService("s1")
+		close(release)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cleanup did not terminate")
+		}
+		require.False(t, a.HasInvalidService("s1"),
+			"a pre-resume cleanup result fenced the resumed incarnation")
+	})
+}
+
+func TestCleanCommitStateHonorsCanceledContext(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		a.getCtl("s1")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var calls atomic.Int32
+		a.cleanCommitStateOnce(
+			ctx,
+			func(context.Context, string) (bool, [][]byte, error) {
+				calls.Add(1)
+				return true, nil, nil
+			},
+			time.Hour,
+		)
+		require.Zero(t, calls.Load())
+	})
+}
+
+func TestCleanCommitStateCancellationStopsConnectionRetries(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		a.getCtl("s1")
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var calls atomic.Int32
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			a.cleanCommitStateOnce(
+				ctx,
+				func(context.Context, string) (bool, [][]byte, error) {
+					calls.Add(1)
+					cancel()
+					return false, nil, moerr.NewBackendClosedNoCtx()
+				},
+				time.Hour,
+			)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("cleanup did not stop after context cancellation")
+		}
+		require.Equal(t, int32(1), calls.Load())
+		require.False(t, a.HasInvalidService("s1"))
+	})
+}
+
+func TestCleanCommitStateIsolatesServices(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		a.getCtl("healthy")
+		a.getCtl("disconnected")
+
+		var mu sync.Mutex
+		calls := make(map[string]int)
+		a.cleanCommitStateOnce(
+			context.Background(),
+			func(_ context.Context, sid string) (bool, [][]byte, error) {
+				mu.Lock()
+				calls[sid]++
+				mu.Unlock()
+				if sid == "disconnected" {
+					return false, nil, moerr.NewBackendClosedNoCtx()
+				}
+				return true, nil, nil
+			},
+			time.Hour,
+		)
+
+		require.False(t, a.HasInvalidService("healthy"))
+		require.True(t, a.HasInvalidService("disconnected"))
+		require.Equal(t, 1, calls["healthy"])
+		require.Equal(t, getActiveTxnMaxAttempts, calls["disconnected"])
+	})
+}
+
+func TestResumeEpochIsScopedToService(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		ctl1 := a.getCtl("s1")
+		ctl2 := a.getCtl("s2")
+		epoch1 := ctl1.currentRecoveryEpoch()
+		epoch2 := ctl2.currentRecoveryEpoch()
+
+		a.resumeService("s1")
+
+		require.False(t, a.markServiceInactive("s1", ctl1, epoch1, true))
+		require.True(t, a.markServiceInactive("s2", ctl2, epoch2, true))
+		require.False(t, a.HasInvalidService("s1"))
+		require.True(t, a.HasInvalidService("s2"))
+	})
+}
+
+func TestRecoveryEpochOverflowFailsOpen(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		ctl := a.getCtl("s1")
+		ctl.mu.Lock()
+		ctl.recoveryEpoch = ^uint64(0)
+		ctl.mu.Unlock()
+
+		a.AddInvalidService("s1")
+		a.resumeService("s1")
+		require.False(t, a.markServiceInactive("s1", ctl, ^uint64(0), true))
+		require.False(t, a.HasInvalidService("s1"))
+	})
+}
+
+func TestFenceCannotInterleaveCommitAdmission(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		ctl := a.getCtl("s1")
+		ctl.mu.Lock()
+		ctlLocked := true
+		defer func() {
+			if ctlLocked {
+				ctl.mu.Unlock()
+			}
+		}()
+
+		validDone := make(chan error, 1)
+		go func() {
+			_, err := a.Valid("s1", []byte("txn"), nil)
+			validDone <- err
+		}()
+
+		// Valid holds the recovery read lock while waiting to register its
+		// commit. This proves fencing cannot linearize between the admission
+		// check and beginCommit.
+		require.Eventually(t, func() bool {
+			if !a.inactiveMu.TryLock() {
+				return true
+			}
+			a.inactiveMu.Unlock()
+			return false
+		}, 5*time.Second, time.Millisecond)
+
+		fenceStarted := make(chan struct{})
+		fenceDone := make(chan struct{})
+		go func() {
+			close(fenceStarted)
+			a.AddInvalidService("s1")
+			close(fenceDone)
+		}()
+		<-fenceStarted
+
+		ctl.mu.Unlock()
+		ctlLocked = false
+		select {
+		case err := <-validDone:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("commit admission did not finish")
+		}
+		select {
+		case <-fenceDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("fence did not finish")
+		}
+		require.True(t, a.HasInvalidService("s1"))
+		require.True(t, ctl.finishCommit("txn"))
+	})
+}
+
+func BenchmarkValidDuringRecoveryChanges(b *testing.B) {
+	a := &lockTableAllocator{}
+	a.mu.services = make(map[string]*serviceBinds)
+	a.mu.lockTables = make(map[uint32]map[uint64]pb.LockTable)
+	txnID := []byte("txn")
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := a.Valid("s1", txnID, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/pkg/lockservice/lock_table_allocator_stale_snapshot_test.go
+++ b/pkg/lockservice/lock_table_allocator_stale_snapshot_test.go
@@ -15,6 +15,7 @@
 package lockservice
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -92,6 +93,7 @@ func TestCleanerDoesNotDeleteTombstoneCreatedAfterServiceSnapshot(
 		},
 		func(a *lockTableAllocator) {
 			a.options.getActiveTxnFunc = func(
+				_ context.Context,
 				serviceID string,
 			) (bool, [][]byte, error) {
 				switch queryCalls.Add(1) {

--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -15,6 +15,7 @@
 package lockservice
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -357,7 +358,7 @@ func TestCleanerPreservesCannotCommitOnActiveTxnQueryError(t *testing.T) {
 		},
 		func(lta *lockTableAllocator) {
 			lta.keepBindTimeout = time.Millisecond * 20
-			lta.options.getActiveTxnFunc = func(string) (bool, [][]byte, error) {
+			lta.options.getActiveTxnFunc = func(context.Context, string) (bool, [][]byte, error) {
 				<-ready
 				return false, nil, moerr.NewBackendClosedNoCtx()
 			}
@@ -478,7 +479,7 @@ func TestCtlCanRemovedByInvalidService(t *testing.T) {
 		},
 		func(lta *lockTableAllocator) {
 			lta.keepBindTimeout = time.Millisecond * 100
-			lta.options.getActiveTxnFunc = func(sid string) (bool, [][]byte, error) {
+			lta.options.getActiveTxnFunc = func(context.Context, string) (bool, [][]byte, error) {
 				<-ch
 				return false, nil, nil
 			}
@@ -503,7 +504,7 @@ func TestCtlCanRemovedByNotActiveTxn(t *testing.T) {
 		},
 		func(lta *lockTableAllocator) {
 			lta.keepBindTimeout = time.Millisecond * 100
-			lta.options.getActiveTxnFunc = func(sid string) (bool, [][]byte, error) {
+			lta.options.getActiveTxnFunc = func(context.Context, string) (bool, [][]byte, error) {
 				<-ch
 				return true, [][]byte{[]byte("t2")}, nil
 			}

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -402,22 +402,30 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) error {
 		return moerr.NewInternalErrorNoCtx("morpc client does not support targeted backend reset")
 	}
 
-	lookupAddress := func() string {
+	lookupAddress := func() (string, error) {
 		var address string
-		c.cluster.GetCNServiceWithoutWorkingState(
+		err := clusterservice.GetCNServiceWithoutWorkingStateWithContext(
+			ctx,
+			c.cluster,
 			clusterservice.NewServiceIDSelector(sid),
 			func(s metadata.CNService) bool {
 				address = s.LockServiceAddress
 				return false
 			})
-		return address
+		if err != nil {
+			return "", moerr.AttachCause(ctx, err)
+		}
+		return address, nil
 	}
 
 	// A negative response proves that the route used for the first check may be
 	// stale even when the cached address is non-empty. Refresh synchronously so
 	// the confirming request cannot be sent to an old CN address after a hot
 	// recreate or address reassignment.
-	staleAddress := lookupAddress()
+	staleAddress, err := lookupAddress()
+	if err != nil {
+		return err
+	}
 	refresher, ok := c.cluster.(clusterservice.AuthoritativeRefresher)
 	if !ok {
 		return moerr.NewInternalErrorNoCtx(
@@ -426,7 +434,10 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) error {
 	if err := refresher.Refresh(ctx); err != nil {
 		return err
 	}
-	address := lookupAddress()
+	address, err := lookupAddress()
+	if err != nil {
+		return err
+	}
 
 	var endpoint string
 	var resolveErr error

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -80,6 +80,7 @@ type client struct {
 	// interrupt concurrent Lock/Unlock traffic on the normal client.
 	activeTxnClient morpc.RPCClient
 
+	recoveryResetMu  sync.Mutex // serializes slow reset work without blocking request reads
 	recoveryMu       sync.RWMutex
 	recoveryBackends map[string]recoveryBackend // CN UUID -> recovery endpoint
 	resolveBackend   func(context.Context, string) (string, error)
@@ -376,25 +377,12 @@ func (c *client) activeTxnTransport() morpc.RPCClient {
 // refresh alone is insufficient to prevent reuse of the stale backend.
 func (c *client) ResetBackend(serviceID string) error {
 	sid := getUUIDFromServiceIdentifier(serviceID)
-	var address string
-	for i := 0; i < 2; i++ {
-		c.cluster.GetCNServiceWithoutWorkingState(
-			clusterservice.NewServiceIDSelector(sid),
-			func(s metadata.CNService) bool {
-				address = s.LockServiceAddress
-				return false
-			})
-		if address != "" {
-			break
-		}
-		c.cluster.ForceRefresh(true)
-	}
-	if address == "" {
-		return moerr.NewInternalErrorNoCtx("cannot find lockservice address for " + sid)
-	}
 
-	c.recoveryMu.Lock()
-	defer c.recoveryMu.Unlock()
+	// Discovery refresh, DNS, and backend shutdown can all be slow. Serialize
+	// resets separately so active-txn sends never wait on those operations while
+	// acquiring recoveryMu for their read-only route lookup.
+	c.recoveryResetMu.Lock()
+	defer c.recoveryResetMu.Unlock()
 	resetter, ok := c.activeTxnTransport().(interface {
 		CloseBackendFor(string) error
 	})
@@ -402,20 +390,24 @@ func (c *client) ResetBackend(serviceID string) error {
 		return moerr.NewInternalErrorNoCtx("morpc client does not support targeted backend reset")
 	}
 
-	// Detach both forms: requests normally use the discovered hostname, while
-	// a prior recovery may have pinned the then-current IP endpoint.
-	if err := resetter.CloseBackendFor(address); err != nil {
-		return err
+	lookupAddress := func() string {
+		var address string
+		c.cluster.GetCNServiceWithoutWorkingState(
+			clusterservice.NewServiceIDSelector(sid),
+			func(s metadata.CNService) bool {
+				address = s.LockServiceAddress
+				return false
+			})
+		return address
 	}
-	if old, ok := c.recoveryBackends[sid]; ok {
-		delete(c.recoveryBackends, sid)
-		endpoint := old.endpoint
-		if endpoint != address {
-			if err := resetter.CloseBackendFor(endpoint); err != nil {
-				return err
-			}
-		}
-	}
+
+	// A negative response proves that the route used for the first check may be
+	// stale even when the cached address is non-empty. Refresh synchronously so
+	// the confirming request cannot be sent to an old CN address after a hot
+	// recreate or address reassignment.
+	staleAddress := lookupAddress()
+	c.cluster.ForceRefresh(true)
+	address := lookupAddress()
 
 	ctx, cancel := context.WithTimeoutCause(
 		context.Background(),
@@ -423,20 +415,61 @@ func (c *client) ResetBackend(serviceID string) error {
 		moerr.CauseResetLockServiceBackend,
 	)
 	defer cancel()
-	if c.resolveBackend == nil {
-		return moerr.NewInternalErrorNoCtx("lockservice recovery resolver is not configured")
+	var endpoint string
+	var resolveErr error
+	if address != "" {
+		if c.resolveBackend == nil {
+			resolveErr = moerr.NewInternalErrorNoCtx("lockservice recovery resolver is not configured")
+		} else {
+			endpoint, resolveErr = c.resolveBackend(ctx, address)
+		}
 	}
-	endpoint, err := c.resolveBackend(ctx, address)
-	if err != nil {
-		return err
+
+	// Detach every route that may still identify this CN incarnation: the
+	// pre-refresh address, the refreshed address, and a prior pinned recovery
+	// endpoint. Continue after individual close failures so reset performs as
+	// much cleanup as possible, then preserve the indeterminate result.
+	c.recoveryMu.Lock()
+	old, hadOld := c.recoveryBackends[sid]
+	if hadOld {
+		delete(c.recoveryBackends, sid)
 	}
+	c.recoveryMu.Unlock()
+	candidates := []string{staleAddress, address}
+	if hadOld {
+		candidates = append(candidates, old.discovered, old.endpoint)
+	}
+	seen := make(map[string]struct{}, len(candidates))
+	var closeErr error
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		closeErr = errors.Join(closeErr, resetter.CloseBackendFor(candidate))
+	}
+	if address == "" {
+		return errors.Join(
+			closeErr,
+			moerr.NewInternalErrorNoCtx("cannot find lockservice address for "+sid),
+		)
+	}
+	if resolveErr != nil || closeErr != nil {
+		return errors.Join(resolveErr, closeErr)
+	}
+
 	if endpoint == address {
 		return nil
 	}
+	c.recoveryMu.Lock()
 	c.storeRecoveryBackendLocked(sid, recoveryBackend{
 		discovered: address,
 		endpoint:   endpoint,
 	})
+	c.recoveryMu.Unlock()
 	return nil
 }
 

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -41,6 +41,7 @@ import (
 var (
 	defaultRPCTimeout          = time.Second * 10
 	defaultRPCWriteTimeout     = time.Second * 3
+	defaultRPCEnqueueTimeout   = time.Second * 5
 	defaultHandleWorkers       = 12
 	defaultHandleGetTxnWorkers = 4
 	// Recovery endpoints are hints: eviction safely falls back to service
@@ -376,8 +377,34 @@ func (c *client) activeTxnTransport() morpc.RPCClient {
 // ResetBackend detaches the pooled connection for one CN incarnation. The
 // address can remain unchanged across a hot recreate, so service discovery
 // refresh alone is insufficient to prevent reuse of the stale backend.
-func (c *client) ResetBackend(parent context.Context, serviceID string) error {
+func (c *client) ResetBackend(parent context.Context, serviceID string) (err error) {
 	sid := getUUIDFromServiceIdentifier(serviceID)
+	started := time.Now()
+	var staleAddress, address, endpoint string
+	defer func() {
+		result := "success"
+		if err != nil {
+			result = "failure"
+		}
+		v2.TxnLockActiveTxnRecoveryCounter.WithLabelValues("backend-reset-" + result).Inc()
+		if c.logger == nil {
+			return
+		}
+		fields := []zap.Field{
+			zap.String("service-id", serviceID),
+			zap.String("cn-id", sid),
+			zap.String("stale-address", staleAddress),
+			zap.String("discovered-address", address),
+			zap.String("resolved-endpoint", endpoint),
+			zap.Duration("duration", time.Since(started)),
+		}
+		if err != nil {
+			c.logger.Warn("active-txn recovery backend reset failed",
+				append(fields, zap.Error(err))...)
+			return
+		}
+		c.logger.Info("active-txn recovery backend reset completed", fields...)
+	}()
 	if parent == nil {
 		parent = context.Background()
 	}
@@ -422,7 +449,7 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) error {
 	// stale even when the cached address is non-empty. Refresh synchronously so
 	// the confirming request cannot be sent to an old CN address after a hot
 	// recreate or address reassignment.
-	staleAddress, err := lookupAddress()
+	staleAddress, err = lookupAddress()
 	if err != nil {
 		return err
 	}
@@ -434,12 +461,11 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) error {
 	if err := refresher.Refresh(ctx); err != nil {
 		return err
 	}
-	address, err := lookupAddress()
+	address, err = lookupAddress()
 	if err != nil {
 		return err
 	}
 
-	var endpoint string
 	var resolveErr error
 	if address != "" {
 		if c.resolveBackend == nil {
@@ -604,9 +630,10 @@ type server struct {
 	rpc      morpc.RPCServer
 	handlers map[pb.Method]RequestHandleFunc
 
-	requests             chan requestCtx
-	getActiveTxnRequests chan requestCtx
-	stopper              *stopper.Stopper
+	requests              chan requestCtx
+	getActiveTxnRequests  chan requestCtx
+	requestEnqueueTimeout time.Duration
+	stopper               *stopper.Stopper
 
 	options struct {
 		filter func(*pb.Request) bool
@@ -622,12 +649,13 @@ func NewServer(
 ) (Server, error) {
 	logger := getLogger(service)
 	s := &server{
-		logger:               logger,
-		cfg:                  &cfg,
-		address:              address,
-		handlers:             make(map[pb.Method]RequestHandleFunc),
-		requests:             make(chan requestCtx, 10240),
-		getActiveTxnRequests: make(chan requestCtx, 10240),
+		logger:                logger,
+		cfg:                   &cfg,
+		address:               address,
+		handlers:              make(map[pb.Method]RequestHandleFunc),
+		requests:              make(chan requestCtx, 10240),
+		getActiveTxnRequests:  make(chan requestCtx, 10240),
+		requestEnqueueTimeout: defaultRPCEnqueueTimeout,
 		stopper: stopper.NewStopper("lock-service-rpc-server",
 			stopper.WithLogger(logger.RawLogger())),
 	}
@@ -662,6 +690,8 @@ func (s *server) Close() error {
 		return err
 	}
 	s.stopper.Stop()
+	releaseQueuedRequests(s.requests)
+	releaseQueuedRequests(s.getActiveTxnRequests)
 	close(s.requests)
 	close(s.getActiveTxnRequests)
 	return nil
@@ -727,6 +757,9 @@ func (s *server) onMessage(
 			s.logger.Debug("skip request by timeout",
 				zap.String("request", req.DebugString()))
 		}
+		if msg.Cancel != nil {
+			msg.Cancel()
+		}
 		releaseRequest(req)
 		return nil
 	default:
@@ -737,15 +770,77 @@ func (s *server) onMessage(
 		req.Method == pb.Method_CheckActiveTxn {
 		c = s.getActiveTxnRequests
 	}
-	c <- requestCtx{
+	queuedRequest := requestCtx{
 		req:     req,
 		handler: handler,
 		cs:      cs,
 		cancel:  msg.Cancel,
 		ctx:     ctx,
 	}
-	v2.TxnLockRPCQueueSizeGauge.Set(float64(len(s.requests) + len(s.getActiveTxnRequests)))
-	return nil
+	select {
+	case c <- queuedRequest:
+		v2.TxnLockRPCQueueSizeGauge.Set(float64(len(s.requests) + len(s.getActiveTxnRequests)))
+		return nil
+	default:
+	}
+
+	// Keep the connection read goroutine bounded when all workers and the
+	// request queue are saturated. Returning an error from this handler would
+	// close the shared MORPC session, so reject only this request with a normal
+	// RPC error response instead.
+	timer := time.NewTimer(s.requestEnqueueTimeout)
+	defer timer.Stop()
+	var sessionDone <-chan struct{}
+	if sessionCtx := cs.SessionCtx(); sessionCtx != nil {
+		sessionDone = sessionCtx.Done()
+	}
+	select {
+	case c <- queuedRequest:
+		v2.TxnLockRPCQueueSizeGauge.Set(float64(len(s.requests) + len(s.getActiveTxnRequests)))
+		return nil
+	case <-ctx.Done():
+		v2.TxnLockRPCQueueRejectCounter.WithLabelValues("request-canceled").Inc()
+		if msg.Cancel != nil {
+			msg.Cancel()
+		}
+		releaseRequest(req)
+		return nil
+	case <-sessionDone:
+		v2.TxnLockRPCQueueRejectCounter.WithLabelValues("session-closed").Inc()
+		if msg.Cancel != nil {
+			msg.Cancel()
+		}
+		releaseRequest(req)
+		return nil
+	case <-timer.C:
+		v2.TxnLockRPCQueueRejectCounter.WithLabelValues("queue-timeout").Inc()
+		writeResponse(
+			s.logger,
+			msg.Cancel,
+			getResponse(req),
+			moerr.NewInternalErrorNoCtx("lock service request queue full"),
+			cs,
+		)
+		releaseRequest(req)
+		return nil
+	}
+}
+
+func releaseQueuedRequests(requests chan requestCtx) {
+	for {
+		select {
+		case request, ok := <-requests:
+			if !ok {
+				return
+			}
+			if request.cancel != nil {
+				request.cancel()
+			}
+			releaseRequest(request.req)
+		default:
+			return
+		}
+	}
 }
 
 func (s *server) handle(

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -75,6 +75,10 @@ type client struct {
 	cfg     *morpc.Config
 	cluster clusterservice.MOCluster
 	client  morpc.RPCClient
+	// Active-txn identity probes may deliberately reset their transport after
+	// detecting a stale CN incarnation. Keep them isolated so recovery cannot
+	// interrupt concurrent Lock/Unlock traffic on the normal client.
+	activeTxnClient morpc.RPCClient
 
 	recoveryMu       sync.RWMutex
 	recoveryBackends map[string]recoveryBackend // CN UUID -> recovery endpoint
@@ -138,6 +142,15 @@ func NewClient(
 		return nil, err
 	}
 	c.client = client
+	activeTxnClient, err := c.cfg.NewClient(
+		service,
+		"lock-active-txn-client",
+		func() morpc.Message { return acquireResponse() })
+	if err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+	c.activeTxnClient = activeTxnClient
 	return c, nil
 }
 
@@ -273,11 +286,12 @@ func (c *client) AsyncSend(ctx context.Context, request *pb.Request) (*morpc.Fut
 			zap.String("request", request.DebugString()))
 
 	}
-	if request.Method == pb.Method_GetActiveTxn ||
-		request.Method == pb.Method_CheckActiveTxn {
+	transport := c.client
+	if isActiveTxnMethod(request.Method) {
 		address = c.activeTxnBackend(sid, address)
+		transport = c.activeTxnTransport()
 	}
-	f, err := c.client.Send(ctx, address, request)
+	f, err := transport.Send(ctx, address, request)
 	if err != nil {
 		observeLockserviceRemoteRPCError(request.Method, err)
 	}
@@ -334,7 +348,27 @@ func lockserviceRemoteRPCErrorType(err error) string {
 }
 
 func (c *client) Close() error {
-	return c.client.Close()
+	var normalErr, activeTxnErr error
+	if c.client != nil {
+		normalErr = c.client.Close()
+	}
+	if c.activeTxnClient != nil && c.activeTxnClient != c.client {
+		activeTxnErr = c.activeTxnClient.Close()
+	}
+	return errors.Join(normalErr, activeTxnErr)
+}
+
+func isActiveTxnMethod(method pb.Method) bool {
+	return method == pb.Method_GetActiveTxn || method == pb.Method_CheckActiveTxn
+}
+
+func (c *client) activeTxnTransport() morpc.RPCClient {
+	if c.activeTxnClient != nil {
+		return c.activeTxnClient
+	}
+	// Preserve compatibility for tests and embedders that construct client
+	// directly. Production NewClient always installs the isolated transport.
+	return c.client
 }
 
 // ResetBackend detaches the pooled connection for one CN incarnation. The
@@ -361,7 +395,7 @@ func (c *client) ResetBackend(serviceID string) error {
 
 	c.recoveryMu.Lock()
 	defer c.recoveryMu.Unlock()
-	resetter, ok := c.client.(interface {
+	resetter, ok := c.activeTxnTransport().(interface {
 		CloseBackendFor(string) error
 	})
 	if !ok {
@@ -442,6 +476,14 @@ func (c *client) activeTxnBackend(serviceID, discovered string) string {
 }
 
 func resolveTCP4Endpoint(ctx context.Context, address string) (string, error) {
+	return resolveTCP4EndpointWithLookup(ctx, address, recoveryResolver.LookupIP)
+}
+
+func resolveTCP4EndpointWithLookup(
+	ctx context.Context,
+	address string,
+	lookup func(context.Context, string, string) ([]net.IP, error),
+) (string, error) {
 	if strings.Contains(address, "://") {
 		return address, nil
 	}
@@ -449,17 +491,28 @@ func resolveTCP4Endpoint(ctx context.Context, address string) (string, error) {
 	if err != nil || net.ParseIP(host) != nil {
 		return address, err
 	}
-	ips, err := recoveryResolver.LookupIP(ctx, "ip4", host)
-	if err != nil || len(ips) == 0 {
+	ips, err := lookup(ctx, "ip4", host)
+	if err != nil {
 		return address, err
 	}
-	// A multi-address name is commonly a load-balanced service. Pinning one
-	// member would discard net.Dial's fallback semantics and can make recovery
-	// worse, so only incarnation-pin an unambiguous endpoint.
+	// Without a concrete service-identity endpoint, a second Valid=false may
+	// still come from a stale or different CN behind the same multi-A name.
+	// Preserve the caller's unknown state instead of claiming reset success.
 	if len(ips) != 1 {
-		return address, nil
+		return address, moerr.NewInternalErrorNoCtxf(
+			"lockservice recovery requires one IPv4 endpoint for %s, got %d",
+			host,
+			len(ips),
+		)
 	}
-	return net.JoinHostPort(ips[0].String(), port), nil
+	ip := ips[0].To4()
+	if ip == nil {
+		return address, moerr.NewInternalErrorNoCtxf(
+			"lockservice recovery requires a valid IPv4 endpoint for %s",
+			host,
+		)
+	}
+	return net.JoinHostPort(ip.String(), port), nil
 }
 
 // WithServerMessageFilter set filter func. Requests can be modified or filtered out by the filter

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -80,10 +80,11 @@ type client struct {
 	// interrupt concurrent Lock/Unlock traffic on the normal client.
 	activeTxnClient morpc.RPCClient
 
-	recoveryResetMu  sync.Mutex // serializes slow reset work without blocking request reads
-	recoveryMu       sync.RWMutex
-	recoveryBackends map[string]recoveryBackend // CN UUID -> recovery endpoint
-	resolveBackend   func(context.Context, string) (string, error)
+	recoveryResetOnce sync.Once
+	recoveryResetC    chan struct{} // context-aware serialization of slow reset work
+	recoveryMu        sync.RWMutex
+	recoveryBackends  map[string]recoveryBackend // CN UUID -> recovery endpoint
+	resolveBackend    func(context.Context, string) (string, error)
 }
 
 type recoveryBackend struct {
@@ -375,14 +376,25 @@ func (c *client) activeTxnTransport() morpc.RPCClient {
 // ResetBackend detaches the pooled connection for one CN incarnation. The
 // address can remain unchanged across a hot recreate, so service discovery
 // refresh alone is insufficient to prevent reuse of the stale backend.
-func (c *client) ResetBackend(serviceID string) error {
+func (c *client) ResetBackend(parent context.Context, serviceID string) error {
 	sid := getUUIDFromServiceIdentifier(serviceID)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeoutCause(
+		parent,
+		defaultRPCTimeout,
+		moerr.CauseResetLockServiceBackend,
+	)
+	defer cancel()
 
 	// Discovery refresh, DNS, and backend shutdown can all be slow. Serialize
-	// resets separately so active-txn sends never wait on those operations while
-	// acquiring recoveryMu for their read-only route lookup.
-	c.recoveryResetMu.Lock()
-	defer c.recoveryResetMu.Unlock()
+	// resets separately and context-aware, so one slow recovery cannot make
+	// later probes wait past their own deadline.
+	if err := c.acquireRecoveryReset(ctx); err != nil {
+		return moerr.AttachCause(ctx, err)
+	}
+	defer c.releaseRecoveryReset()
 	resetter, ok := c.activeTxnTransport().(interface {
 		CloseBackendFor(string) error
 	})
@@ -406,15 +418,16 @@ func (c *client) ResetBackend(serviceID string) error {
 	// the confirming request cannot be sent to an old CN address after a hot
 	// recreate or address reassignment.
 	staleAddress := lookupAddress()
-	c.cluster.ForceRefresh(true)
+	refresher, ok := c.cluster.(clusterservice.AuthoritativeRefresher)
+	if !ok {
+		return moerr.NewInternalErrorNoCtx(
+			"cluster service does not support authoritative refresh")
+	}
+	if err := refresher.Refresh(ctx); err != nil {
+		return err
+	}
 	address := lookupAddress()
 
-	ctx, cancel := context.WithTimeoutCause(
-		context.Background(),
-		time.Second,
-		moerr.CauseResetLockServiceBackend,
-	)
-	defer cancel()
 	var endpoint string
 	var resolveErr error
 	if address != "" {
@@ -471,6 +484,23 @@ func (c *client) ResetBackend(serviceID string) error {
 	})
 	c.recoveryMu.Unlock()
 	return nil
+}
+
+func (c *client) acquireRecoveryReset(ctx context.Context) error {
+	c.recoveryResetOnce.Do(func() {
+		c.recoveryResetC = make(chan struct{}, 1)
+		c.recoveryResetC <- struct{}{}
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.recoveryResetC:
+		return nil
+	}
+}
+
+func (c *client) releaseRecoveryReset() {
+	c.recoveryResetC <- struct{}{}
 }
 
 func (c *client) storeRecoveryBackendLocked(serviceID string, backend recoveryBackend) {

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -273,7 +273,8 @@ func (c *client) AsyncSend(ctx context.Context, request *pb.Request) (*morpc.Fut
 			zap.String("request", request.DebugString()))
 
 	}
-	if request.Method == pb.Method_GetActiveTxn {
+	if request.Method == pb.Method_GetActiveTxn ||
+		request.Method == pb.Method_CheckActiveTxn {
 		address = c.activeTxnBackend(sid, address)
 	}
 	f, err := c.client.Send(ctx, address, request)
@@ -382,7 +383,11 @@ func (c *client) ResetBackend(serviceID string) error {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeoutCause(
+		context.Background(),
+		time.Second,
+		moerr.CauseResetLockServiceBackend,
+	)
 	defer cancel()
 	if c.resolveBackend == nil {
 		return moerr.NewInternalErrorNoCtx("lockservice recovery resolver is not configured")

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -429,6 +429,34 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) (err err
 		return moerr.NewInternalErrorNoCtx("morpc client does not support targeted backend reset")
 	}
 
+	// A reset is triggered only after the current active-txn route has become
+	// suspect. Remove the pinned override before any discovery operation that
+	// can fail, so an early return cannot keep routing later probes to a
+	// known-stale endpoint.
+	c.recoveryMu.Lock()
+	old, hadOld := c.recoveryBackends[sid]
+	if hadOld {
+		delete(c.recoveryBackends, sid)
+	}
+	c.recoveryMu.Unlock()
+
+	seen := make(map[string]struct{}, 5)
+	var closeErr error
+	closeCandidate := func(candidate string) {
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		closeErr = errors.Join(closeErr, resetter.CloseBackendFor(candidate))
+	}
+	if hadOld {
+		closeCandidate(old.discovered)
+		closeCandidate(old.endpoint)
+	}
+
 	lookupAddress := func() (string, error) {
 		var address string
 		err := clusterservice.GetCNServiceWithoutWorkingStateWithContext(
@@ -451,19 +479,25 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) (err err
 	// recreate or address reassignment.
 	staleAddress, err = lookupAddress()
 	if err != nil {
-		return err
+		return errors.Join(closeErr, err)
 	}
+	// Detach the pre-refresh hostname backend before refreshing. Even without a
+	// pinned IP, the first negative response proves this connection is suspect.
+	closeCandidate(staleAddress)
 	refresher, ok := c.cluster.(clusterservice.AuthoritativeRefresher)
 	if !ok {
-		return moerr.NewInternalErrorNoCtx(
-			"cluster service does not support authoritative refresh")
+		return errors.Join(
+			closeErr,
+			moerr.NewInternalErrorNoCtx(
+				"cluster service does not support authoritative refresh"),
+		)
 	}
 	if err := refresher.Refresh(ctx); err != nil {
-		return err
+		return errors.Join(closeErr, err)
 	}
 	address, err = lookupAddress()
 	if err != nil {
-		return err
+		return errors.Join(closeErr, err)
 	}
 
 	var resolveErr error
@@ -475,32 +509,11 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) (err err
 		}
 	}
 
-	// Detach every route that may still identify this CN incarnation: the
-	// pre-refresh address, the refreshed address, and a prior pinned recovery
-	// endpoint. Continue after individual close failures so reset performs as
-	// much cleanup as possible, then preserve the indeterminate result.
-	c.recoveryMu.Lock()
-	old, hadOld := c.recoveryBackends[sid]
-	if hadOld {
-		delete(c.recoveryBackends, sid)
-	}
-	c.recoveryMu.Unlock()
-	candidates := []string{staleAddress, address}
-	if hadOld {
-		candidates = append(candidates, old.discovered, old.endpoint)
-	}
-	seen := make(map[string]struct{}, len(candidates))
-	var closeErr error
-	for _, candidate := range candidates {
-		if candidate == "" {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
-		closeErr = errors.Join(closeErr, resetter.CloseBackendFor(candidate))
-	}
+	// Detach both names accepted by MORPC before publishing the replacement
+	// override. The resolved endpoint can already have a pooled backend from an
+	// earlier recovery, even when it is not the currently cached hint.
+	closeCandidate(address)
+	closeCandidate(endpoint)
 	if address == "" {
 		return errors.Join(
 			closeErr,

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
@@ -42,6 +43,14 @@ var (
 	defaultRPCWriteTimeout     = time.Second * 3
 	defaultHandleWorkers       = 12
 	defaultHandleGetTxnWorkers = 4
+	// Recovery endpoints are hints: eviction safely falls back to service
+	// discovery and the negative-response confirmation path. Keep a hard bound
+	// so historical CN UUID churn cannot grow the client for its whole lifetime.
+	maxRecoveryBackendEntries = 4096
+	// The system resolver may retain a container hostname across endpoint
+	// recreation in a long-lived CGO process. Recovery must query DNS again;
+	// the pure-Go resolver has no cross-request result cache.
+	recoveryResolver = &net.Resolver{PreferGo: true, StrictErrors: true}
 )
 
 func acquireRequest() *pb.Request {
@@ -66,6 +75,15 @@ type client struct {
 	cfg     *morpc.Config
 	cluster clusterservice.MOCluster
 	client  morpc.RPCClient
+
+	recoveryMu       sync.RWMutex
+	recoveryBackends map[string]recoveryBackend // CN UUID -> recovery endpoint
+	resolveBackend   func(context.Context, string) (string, error)
+}
+
+type recoveryBackend struct {
+	discovered string
+	endpoint   string
 }
 
 type ClientOption func(c *client)
@@ -82,10 +100,12 @@ func NewClient(
 	opts ...ClientOption,
 ) (Client, error) {
 	c := &client{
-		logger:  getLogger(service),
-		service: service,
-		cfg:     &cfg,
+		logger:           getLogger(service),
+		service:          service,
+		cfg:              &cfg,
+		recoveryBackends: make(map[string]recoveryBackend),
 	}
+	c.resolveBackend = resolveTCP4Endpoint
 	for _, applyFn := range opts {
 		applyFn(c)
 	}
@@ -253,6 +273,9 @@ func (c *client) AsyncSend(ctx context.Context, request *pb.Request) (*morpc.Fut
 			zap.String("request", request.DebugString()))
 
 	}
+	if request.Method == pb.Method_GetActiveTxn {
+		address = c.activeTxnBackend(sid, address)
+	}
 	f, err := c.client.Send(ctx, address, request)
 	if err != nil {
 		observeLockserviceRemoteRPCError(request.Method, err)
@@ -311,6 +334,127 @@ func lockserviceRemoteRPCErrorType(err error) string {
 
 func (c *client) Close() error {
 	return c.client.Close()
+}
+
+// ResetBackend detaches the pooled connection for one CN incarnation. The
+// address can remain unchanged across a hot recreate, so service discovery
+// refresh alone is insufficient to prevent reuse of the stale backend.
+func (c *client) ResetBackend(serviceID string) error {
+	sid := getUUIDFromServiceIdentifier(serviceID)
+	var address string
+	for i := 0; i < 2; i++ {
+		c.cluster.GetCNServiceWithoutWorkingState(
+			clusterservice.NewServiceIDSelector(sid),
+			func(s metadata.CNService) bool {
+				address = s.LockServiceAddress
+				return false
+			})
+		if address != "" {
+			break
+		}
+		c.cluster.ForceRefresh(true)
+	}
+	if address == "" {
+		return moerr.NewInternalErrorNoCtx("cannot find lockservice address for " + sid)
+	}
+
+	c.recoveryMu.Lock()
+	defer c.recoveryMu.Unlock()
+	resetter, ok := c.client.(interface {
+		CloseBackendFor(string) error
+	})
+	if !ok {
+		return moerr.NewInternalErrorNoCtx("morpc client does not support targeted backend reset")
+	}
+
+	// Detach both forms: requests normally use the discovered hostname, while
+	// a prior recovery may have pinned the then-current IP endpoint.
+	if err := resetter.CloseBackendFor(address); err != nil {
+		return err
+	}
+	if old, ok := c.recoveryBackends[sid]; ok {
+		delete(c.recoveryBackends, sid)
+		endpoint := old.endpoint
+		if endpoint != address {
+			if err := resetter.CloseBackendFor(endpoint); err != nil {
+				return err
+			}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if c.resolveBackend == nil {
+		return moerr.NewInternalErrorNoCtx("lockservice recovery resolver is not configured")
+	}
+	endpoint, err := c.resolveBackend(ctx, address)
+	if err != nil {
+		return err
+	}
+	if endpoint == address {
+		return nil
+	}
+	c.storeRecoveryBackendLocked(sid, recoveryBackend{
+		discovered: address,
+		endpoint:   endpoint,
+	})
+	return nil
+}
+
+func (c *client) storeRecoveryBackendLocked(serviceID string, backend recoveryBackend) {
+	if c.recoveryBackends == nil {
+		c.recoveryBackends = make(map[string]recoveryBackend)
+	}
+	if _, exists := c.recoveryBackends[serviceID]; !exists &&
+		len(c.recoveryBackends) >= maxRecoveryBackendEntries {
+		// Any victim is safe: this cache is only a recovery hint, and a miss
+		// re-enters discovery plus the reset/confirmation path.
+		for victim := range c.recoveryBackends {
+			delete(c.recoveryBackends, victim)
+			break
+		}
+	}
+	c.recoveryBackends[serviceID] = backend
+}
+
+func (c *client) activeTxnBackend(serviceID, discovered string) string {
+	c.recoveryMu.RLock()
+	backend, ok := c.recoveryBackends[serviceID]
+	if ok && backend.discovered == discovered {
+		endpoint := backend.endpoint
+		c.recoveryMu.RUnlock()
+		return endpoint
+	}
+	c.recoveryMu.RUnlock()
+	if ok {
+		c.recoveryMu.Lock()
+		if current, exists := c.recoveryBackends[serviceID]; exists && current == backend {
+			delete(c.recoveryBackends, serviceID)
+		}
+		c.recoveryMu.Unlock()
+	}
+	return discovered
+}
+
+func resolveTCP4Endpoint(ctx context.Context, address string) (string, error) {
+	if strings.Contains(address, "://") {
+		return address, nil
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil || net.ParseIP(host) != nil {
+		return address, err
+	}
+	ips, err := recoveryResolver.LookupIP(ctx, "ip4", host)
+	if err != nil || len(ips) == 0 {
+		return address, err
+	}
+	// A multi-address name is commonly a load-balanced service. Pinning one
+	// member would discard net.Dial's fallback semantics and can make recovery
+	// worse, so only incarnation-pin an unambiguous endpoint.
+	if len(ips) != 1 {
+		return address, nil
+	}
+	return net.JoinHostPort(ips[0].String(), port), nil
 }
 
 // WithServerMessageFilter set filter func. Requests can be modified or filtered out by the filter

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -40,6 +40,16 @@ const rpcTestResponseTimeout = 10 * time.Second
 type closeTrackingRPCClient struct {
 	morpc.RPCClient
 	closed []string
+	sent   []string
+}
+
+func (c *closeTrackingRPCClient) Send(
+	_ context.Context,
+	remote string,
+	_ morpc.Message,
+) (*morpc.Future, error) {
+	c.sent = append(c.sent, remote)
+	return nil, nil
 }
 
 func (c *closeTrackingRPCClient) CloseBackendFor(remote string) error {
@@ -566,6 +576,14 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 	require.NoError(t, c.ResetBackend(serviceID))
 	require.Equal(t, "10.0.0.1:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
 	require.Equal(t, []string{"cn.example:18101"}, rpcClient.closed)
+	_, err := c.AsyncSend(context.Background(), &lock.Request{
+		Method: lock.Method_CheckActiveTxn,
+		CheckActiveTxn: lock.CheckActiveTxnRequest{
+			ServiceID: serviceID,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"10.0.0.1:18101"}, rpcClient.sent)
 
 	endpoint = "10.0.0.2:18101"
 	require.NoError(t, c.ResetBackend(serviceID))

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -53,6 +53,7 @@ type refreshOnDemandCluster struct {
 	synchronous bool
 	refreshing  chan struct{}
 	refreshDone chan struct{}
+	refreshErr  error
 }
 
 func (c *refreshOnDemandCluster) GetCNServiceWithoutWorkingState(
@@ -68,11 +69,24 @@ func (c *refreshOnDemandCluster) GetCNServiceWithoutWorkingState(
 
 func (c *refreshOnDemandCluster) ForceRefresh(sync bool) {
 	c.synchronous = sync
+	_ = c.Refresh(context.Background())
+}
+
+func (c *refreshOnDemandCluster) Refresh(ctx context.Context) error {
+	c.synchronous = true
 	if c.refreshing != nil {
 		close(c.refreshing)
-		<-c.refreshDone
+		select {
+		case <-c.refreshDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if c.refreshErr != nil {
+		return c.refreshErr
 	}
 	c.refreshed = true
+	return nil
 }
 
 func (c *closeTrackingRPCClient) Send(
@@ -607,7 +621,7 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 	}
 	serviceID := "0000000000000000000cn-id"
 
-	require.NoError(t, c.ResetBackend(serviceID))
+	require.NoError(t, c.ResetBackend(context.Background(), serviceID))
 	require.Equal(t, "10.0.0.1:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
 	require.Empty(t, normalRPCClient.closed)
 	require.Equal(t, []string{"cn.example:18101"}, activeTxnRPCClient.closed)
@@ -629,7 +643,7 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 	require.Equal(t, []string{"cn.example:18101"}, normalRPCClient.sent)
 
 	endpoint = "10.0.0.2:18101"
-	require.NoError(t, c.ResetBackend(serviceID))
+	require.NoError(t, c.ResetBackend(context.Background(), serviceID))
 	require.Equal(t, "10.0.0.2:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
 	require.Empty(t, normalRPCClient.closed)
 	require.Equal(t, []string{
@@ -669,7 +683,7 @@ func TestResetBackendRefreshesNonEmptyStaleAddress(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, c.ResetBackend("0000000000000000000cn-id"))
+	require.NoError(t, c.ResetBackend(context.Background(), "0000000000000000000cn-id"))
 	require.Equal(t, "new.example:18101", resolvedAddress)
 	require.True(t, cluster.refreshed)
 	require.True(t, cluster.synchronous)
@@ -681,6 +695,58 @@ func TestResetBackendRefreshesNonEmptyStaleAddress(t *testing.T) {
 		"10.0.0.2:18101",
 		c.activeTxnBackend("cn-id", "new.example:18101"),
 	)
+}
+
+func TestResetBackendRejectsFailedDiscoveryRefresh(t *testing.T) {
+	refreshErr := moerr.NewInternalErrorNoCtx("injected refresh failure")
+	cluster := &refreshOnDemandCluster{
+		before: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "stale.example:18101",
+		},
+		after: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "new.example:18101",
+		},
+		refreshErr: refreshErr,
+	}
+	activeTxnRPCClient := &closeTrackingRPCClient{}
+	c := &client{
+		cluster:         cluster,
+		activeTxnClient: activeTxnRPCClient,
+		recoveryBackends: map[string]recoveryBackend{
+			"cn-id": {
+				discovered: "stale.example:18101",
+				endpoint:   "10.0.0.1:18101",
+			},
+		},
+		resolveBackend: func(context.Context, string) (string, error) {
+			t.Fatal("resolver must not run after a failed authoritative refresh")
+			return "", nil
+		},
+	}
+
+	err := c.ResetBackend(context.Background(), "0000000000000000000cn-id")
+	require.ErrorIs(t, err, refreshErr)
+	require.Empty(t, activeTxnRPCClient.closed)
+	require.Equal(t,
+		"10.0.0.1:18101",
+		c.activeTxnBackend("cn-id", "stale.example:18101"),
+		"a failed refresh must not publish a successful reset state",
+	)
+}
+
+func TestResetBackendWaitHonorsContext(t *testing.T) {
+	c := &client{}
+	require.NoError(t, c.acquireRecoveryReset(context.Background()))
+	defer c.releaseRecoveryReset()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := c.ResetBackend(ctx, "0000000000000000000cn-id")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(started), time.Second)
 }
 
 func TestResetBackendSlowRefreshDoesNotBlockActiveTxnRouteLookup(t *testing.T) {
@@ -713,7 +779,7 @@ func TestResetBackendSlowRefreshDoesNotBlockActiveTxnRouteLookup(t *testing.T) {
 
 	resetDone := make(chan error, 1)
 	go func() {
-		resetDone <- c.ResetBackend("0000000000000000000cn-id")
+		resetDone <- c.ResetBackend(context.Background(), "0000000000000000000cn-id")
 	}()
 	select {
 	case <-refreshing:
@@ -772,7 +838,7 @@ func TestResetBackendCloseFailureAttemptsAllRoutesAndClearsCache(t *testing.T) {
 		},
 	}
 
-	err := c.ResetBackend("0000000000000000000cn-id")
+	err := c.ResetBackend(context.Background(), "0000000000000000000cn-id")
 	require.ErrorIs(t, err, closeErr)
 	require.Equal(t, []string{
 		"old.example:18101",

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -40,8 +40,39 @@ const rpcTestResponseTimeout = 10 * time.Second
 
 type closeTrackingRPCClient struct {
 	morpc.RPCClient
-	closed []string
-	sent   []string
+	closed      []string
+	closeErrors map[string]error
+	sent        []string
+}
+
+type refreshOnDemandCluster struct {
+	clusterservice.MOCluster
+	before      metadata.CNService
+	after       metadata.CNService
+	refreshed   bool
+	synchronous bool
+	refreshing  chan struct{}
+	refreshDone chan struct{}
+}
+
+func (c *refreshOnDemandCluster) GetCNServiceWithoutWorkingState(
+	_ clusterservice.Selector,
+	apply func(metadata.CNService) bool,
+) {
+	service := c.before
+	if c.refreshed {
+		service = c.after
+	}
+	apply(service)
+}
+
+func (c *refreshOnDemandCluster) ForceRefresh(sync bool) {
+	c.synchronous = sync
+	if c.refreshing != nil {
+		close(c.refreshing)
+		<-c.refreshDone
+	}
+	c.refreshed = true
 }
 
 func (c *closeTrackingRPCClient) Send(
@@ -55,7 +86,7 @@ func (c *closeTrackingRPCClient) Send(
 
 func (c *closeTrackingRPCClient) CloseBackendFor(remote string) error {
 	c.closed = append(c.closed, remote)
-	return nil
+	return c.closeErrors[remote]
 }
 
 type testClientSession struct {
@@ -615,6 +646,146 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestResetBackendRefreshesNonEmptyStaleAddress(t *testing.T) {
+	cluster := &refreshOnDemandCluster{
+		before: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "old.example:18101",
+		},
+		after: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "new.example:18101",
+		},
+	}
+	activeTxnRPCClient := &closeTrackingRPCClient{}
+	var resolvedAddress string
+	c := &client{
+		cluster:          cluster,
+		activeTxnClient:  activeTxnRPCClient,
+		recoveryBackends: make(map[string]recoveryBackend),
+		resolveBackend: func(_ context.Context, address string) (string, error) {
+			resolvedAddress = address
+			return "10.0.0.2:18101", nil
+		},
+	}
+
+	require.NoError(t, c.ResetBackend("0000000000000000000cn-id"))
+	require.Equal(t, "new.example:18101", resolvedAddress)
+	require.True(t, cluster.refreshed)
+	require.True(t, cluster.synchronous)
+	require.Equal(t, []string{
+		"old.example:18101",
+		"new.example:18101",
+	}, activeTxnRPCClient.closed)
+	require.Equal(t,
+		"10.0.0.2:18101",
+		c.activeTxnBackend("cn-id", "new.example:18101"),
+	)
+}
+
+func TestResetBackendSlowRefreshDoesNotBlockActiveTxnRouteLookup(t *testing.T) {
+	refreshing := make(chan struct{})
+	refreshDone := make(chan struct{})
+	cluster := &refreshOnDemandCluster{
+		before: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "old.example:18101",
+		},
+		after: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "new.example:18101",
+		},
+		refreshing:  refreshing,
+		refreshDone: refreshDone,
+	}
+	c := &client{
+		cluster:          cluster,
+		activeTxnClient:  &closeTrackingRPCClient{},
+		recoveryBackends: make(map[string]recoveryBackend),
+		resolveBackend: func(_ context.Context, address string) (string, error) {
+			return address, nil
+		},
+	}
+	c.recoveryBackends["cn-id"] = recoveryBackend{
+		discovered: "old.example:18101",
+		endpoint:   "10.0.0.1:18101",
+	}
+
+	resetDone := make(chan error, 1)
+	go func() {
+		resetDone <- c.ResetBackend("0000000000000000000cn-id")
+	}()
+	select {
+	case <-refreshing:
+	case <-time.After(time.Second):
+		close(refreshDone)
+		t.Fatal("reset did not enter discovery refresh")
+	}
+
+	lookupDone := make(chan string, 1)
+	go func() {
+		lookupDone <- c.activeTxnBackend("cn-id", "old.example:18101")
+	}()
+	select {
+	case endpoint := <-lookupDone:
+		require.Equal(t, "10.0.0.1:18101", endpoint)
+	case <-time.After(time.Second):
+		close(refreshDone)
+		t.Fatal("active-txn route lookup blocked on slow discovery refresh")
+	}
+
+	close(refreshDone)
+	select {
+	case err := <-resetDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("reset did not finish after discovery refresh completed")
+	}
+}
+
+func TestResetBackendCloseFailureAttemptsAllRoutesAndClearsCache(t *testing.T) {
+	cluster := &refreshOnDemandCluster{
+		before: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "old.example:18101",
+		},
+		after: metadata.CNService{
+			ServiceID:          "cn-id",
+			LockServiceAddress: "new.example:18101",
+		},
+	}
+	closeErr := moerr.NewInternalErrorNoCtx("injected close failure")
+	activeTxnRPCClient := &closeTrackingRPCClient{
+		closeErrors: map[string]error{"old.example:18101": closeErr},
+	}
+	c := &client{
+		cluster:         cluster,
+		activeTxnClient: activeTxnRPCClient,
+		recoveryBackends: map[string]recoveryBackend{
+			"cn-id": {
+				discovered: "prior.example:18101",
+				endpoint:   "10.0.0.1:18101",
+			},
+		},
+		resolveBackend: func(_ context.Context, _ string) (string, error) {
+			return "10.0.0.2:18101", nil
+		},
+	}
+
+	err := c.ResetBackend("0000000000000000000cn-id")
+	require.ErrorIs(t, err, closeErr)
+	require.Equal(t, []string{
+		"old.example:18101",
+		"new.example:18101",
+		"prior.example:18101",
+		"10.0.0.1:18101",
+	}, activeTxnRPCClient.closed)
+	c.recoveryMu.RLock()
+	_, cached := c.recoveryBackends["cn-id"]
+	c.recoveryMu.RUnlock()
+	require.False(t, cached, "failed reset must not retain a stale recovery route")
+}
+
 func TestResolveTCP4EndpointRequiresOneValidIPv4(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -675,9 +846,10 @@ func TestRecoveryBackendCacheIsBounded(t *testing.T) {
 		discovered: "new.example:18101",
 		endpoint:   "10.0.0.2:18101",
 	})
-	require.LessOrEqual(t, len(c.recoveryBackends), maxRecoveryBackendEntries)
+	cacheSize := len(c.recoveryBackends)
 	_, ok := c.recoveryBackends["new-cn"]
 	c.recoveryMu.Unlock()
+	require.LessOrEqual(t, cacheSize, maxRecoveryBackendEntries)
 	require.True(t, ok)
 }
 

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/pb/lock"
+	logpb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +55,24 @@ type refreshOnDemandCluster struct {
 	refreshing  chan struct{}
 	refreshDone chan struct{}
 	refreshErr  error
+}
+
+type blockedClusterClient struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *blockedClusterClient) GetClusterDetails(ctx context.Context) (logpb.ClusterDetails, error) {
+	select {
+	case c.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-c.release:
+		return logpb.ClusterDetails{}, nil
+	case <-ctx.Done():
+		return logpb.ClusterDetails{}, ctx.Err()
+	}
 }
 
 func (c *refreshOnDemandCluster) GetCNServiceWithoutWorkingState(
@@ -747,6 +766,48 @@ func TestResetBackendWaitHonorsContext(t *testing.T) {
 	err := c.ResetBackend(ctx, "0000000000000000000cn-id")
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Less(t, time.Since(started), time.Second)
+}
+
+func TestResetBackendClusterStartupWaitHonorsContext(t *testing.T) {
+	service := t.Name()
+	runtime.SetupServiceBasedRuntime(service, runtime.DefaultRuntime())
+	hakeeper := &blockedClusterClient{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	cluster := clusterservice.NewMOCluster(service, hakeeper, time.Hour)
+	defer func() {
+		close(hakeeper.release)
+		cluster.Close()
+	}()
+
+	select {
+	case <-hakeeper.started:
+	case <-time.After(time.Second):
+		t.Fatal("cluster refresh did not start")
+	}
+
+	activeTxnRPCClient := &closeTrackingRPCClient{}
+	c := &client{
+		cluster:         cluster,
+		activeTxnClient: activeTxnRPCClient,
+		resolveBackend: func(context.Context, string) (string, error) {
+			t.Fatal("resolver must not run before the cluster snapshot is ready")
+			return "", nil
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := c.ResetBackend(ctx, "0000000000000000000cn-id")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(started), time.Second)
+	require.Empty(t, activeTxnRPCClient.closed)
+
+	gateCtx, gateCancel := context.WithTimeout(context.Background(), time.Second)
+	defer gateCancel()
+	require.NoError(t, c.acquireRecoveryReset(gateCtx), "failed reset must release the global slot")
+	c.releaseRecoveryReset()
 }
 
 func TestResetBackendSlowRefreshDoesNotBlockActiveTxnRouteLookup(t *testing.T) {

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -725,7 +725,10 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 	require.NoError(t, c.ResetBackend(context.Background(), serviceID))
 	require.Equal(t, "10.0.0.1:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
 	require.Empty(t, normalRPCClient.closed)
-	require.Equal(t, []string{"cn.example:18101"}, activeTxnRPCClient.closed)
+	require.Equal(t, []string{
+		"cn.example:18101",
+		"10.0.0.1:18101",
+	}, activeTxnRPCClient.closed)
 	_, err := c.AsyncSend(context.Background(), &lock.Request{
 		Method: lock.Method_CheckActiveTxn,
 		CheckActiveTxn: lock.CheckActiveTxnRequest{
@@ -749,8 +752,10 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 	require.Empty(t, normalRPCClient.closed)
 	require.Equal(t, []string{
 		"cn.example:18101",
+		"10.0.0.1:18101",
 		"cn.example:18101",
 		"10.0.0.1:18101",
+		"10.0.0.2:18101",
 	}, activeTxnRPCClient.closed)
 
 	// A service-discovery address change invalidates the recovery override.
@@ -791,6 +796,7 @@ func TestResetBackendRefreshesNonEmptyStaleAddress(t *testing.T) {
 	require.Equal(t, []string{
 		"old.example:18101",
 		"new.example:18101",
+		"10.0.0.2:18101",
 	}, activeTxnRPCClient.closed)
 	require.Equal(t,
 		"10.0.0.2:18101",
@@ -829,11 +835,14 @@ func TestResetBackendRejectsFailedDiscoveryRefresh(t *testing.T) {
 
 	err := c.ResetBackend(context.Background(), "0000000000000000000cn-id")
 	require.ErrorIs(t, err, refreshErr)
-	require.Empty(t, activeTxnRPCClient.closed)
-	require.Equal(t,
+	require.Equal(t, []string{
+		"stale.example:18101",
 		"10.0.0.1:18101",
+	}, activeTxnRPCClient.closed)
+	require.Equal(t,
+		"stale.example:18101",
 		c.activeTxnBackend("cn-id", "stale.example:18101"),
-		"a failed refresh must not publish a successful reset state",
+		"a failed refresh must preserve unknown state without a stale route override",
 	)
 }
 
@@ -873,6 +882,12 @@ func TestResetBackendClusterStartupWaitHonorsContext(t *testing.T) {
 	c := &client{
 		cluster:         cluster,
 		activeTxnClient: activeTxnRPCClient,
+		recoveryBackends: map[string]recoveryBackend{
+			"cn-id": {
+				discovered: "stale.example:18101",
+				endpoint:   "10.0.0.1:18101",
+			},
+		},
 		resolveBackend: func(context.Context, string) (string, error) {
 			t.Fatal("resolver must not run before the cluster snapshot is ready")
 			return "", nil
@@ -884,7 +899,14 @@ func TestResetBackendClusterStartupWaitHonorsContext(t *testing.T) {
 	err := c.ResetBackend(ctx, "0000000000000000000cn-id")
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Less(t, time.Since(started), time.Second)
-	require.Empty(t, activeTxnRPCClient.closed)
+	require.Equal(t, []string{
+		"stale.example:18101",
+		"10.0.0.1:18101",
+	}, activeTxnRPCClient.closed)
+	require.Equal(t,
+		"stale.example:18101",
+		c.activeTxnBackend("cn-id", "stale.example:18101"),
+	)
 
 	gateCtx, gateCancel := context.WithTimeout(context.Background(), time.Second)
 	defer gateCancel()
@@ -937,7 +959,7 @@ func TestResetBackendSlowRefreshDoesNotBlockActiveTxnRouteLookup(t *testing.T) {
 	}()
 	select {
 	case endpoint := <-lookupDone:
-		require.Equal(t, "10.0.0.1:18101", endpoint)
+		require.Equal(t, "old.example:18101", endpoint)
 	case <-time.After(time.Second):
 		close(refreshDone)
 		t.Fatal("active-txn route lookup blocked on slow discovery refresh")
@@ -984,10 +1006,11 @@ func TestResetBackendCloseFailureAttemptsAllRoutesAndClearsCache(t *testing.T) {
 	err := c.ResetBackend(context.Background(), "0000000000000000000cn-id")
 	require.ErrorIs(t, err, closeErr)
 	require.Equal(t, []string{
-		"old.example:18101",
-		"new.example:18101",
 		"prior.example:18101",
 		"10.0.0.1:18101",
+		"old.example:18101",
+		"new.example:18101",
+		"10.0.0.2:18101",
 	}, activeTxnRPCClient.closed)
 	c.recoveryMu.RLock()
 	_, cached := c.recoveryBackends["cn-id"]

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -561,11 +562,13 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 			nil))
 	defer cluster.Close()
 
-	rpcClient := &closeTrackingRPCClient{}
+	normalRPCClient := &closeTrackingRPCClient{}
+	activeTxnRPCClient := &closeTrackingRPCClient{}
 	endpoint := "10.0.0.1:18101"
 	c := &client{
 		cluster:          cluster,
-		client:           rpcClient,
+		client:           normalRPCClient,
+		activeTxnClient:  activeTxnRPCClient,
 		recoveryBackends: make(map[string]recoveryBackend),
 		resolveBackend: func(context.Context, string) (string, error) {
 			return endpoint, nil
@@ -575,7 +578,8 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 
 	require.NoError(t, c.ResetBackend(serviceID))
 	require.Equal(t, "10.0.0.1:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
-	require.Equal(t, []string{"cn.example:18101"}, rpcClient.closed)
+	require.Empty(t, normalRPCClient.closed)
+	require.Equal(t, []string{"cn.example:18101"}, activeTxnRPCClient.closed)
 	_, err := c.AsyncSend(context.Background(), &lock.Request{
 		Method: lock.Method_CheckActiveTxn,
 		CheckActiveTxn: lock.CheckActiveTxnRequest{
@@ -583,16 +587,25 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, []string{"10.0.0.1:18101"}, rpcClient.sent)
+	require.Empty(t, normalRPCClient.sent)
+	require.Equal(t, []string{"10.0.0.1:18101"}, activeTxnRPCClient.sent)
+
+	_, err = c.AsyncSend(context.Background(), &lock.Request{
+		Method:    lock.Method_Unlock,
+		LockTable: lock.LockTable{ServiceID: serviceID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cn.example:18101"}, normalRPCClient.sent)
 
 	endpoint = "10.0.0.2:18101"
 	require.NoError(t, c.ResetBackend(serviceID))
 	require.Equal(t, "10.0.0.2:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
+	require.Empty(t, normalRPCClient.closed)
 	require.Equal(t, []string{
 		"cn.example:18101",
 		"cn.example:18101",
 		"10.0.0.1:18101",
-	}, rpcClient.closed)
+	}, activeTxnRPCClient.closed)
 
 	// A service-discovery address change invalidates the recovery override.
 	require.Equal(t, "other.example:18101", c.activeTxnBackend("cn-id", "other.example:18101"))
@@ -600,6 +613,53 @@ func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
 	_, ok := c.recoveryBackends["cn-id"]
 	c.recoveryMu.RUnlock()
 	require.False(t, ok)
+}
+
+func TestResolveTCP4EndpointRequiresOneValidIPv4(t *testing.T) {
+	tests := []struct {
+		name     string
+		ips      []net.IP
+		expected string
+		wantErr  bool
+	}{
+		{name: "no address", wantErr: true},
+		{
+			name: "multiple addresses",
+			ips: []net.IP{
+				net.ParseIP("10.0.0.1"),
+				net.ParseIP("10.0.0.2"),
+			},
+			wantErr: true,
+		},
+		{
+			name:    "non IPv4 address",
+			ips:     []net.IP{net.ParseIP("2001:db8::1")},
+			wantErr: true,
+		},
+		{
+			name:     "one IPv4 address",
+			ips:      []net.IP{net.ParseIP("10.0.0.1")},
+			expected: "10.0.0.1:18101",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, err := resolveTCP4EndpointWithLookup(
+				context.Background(),
+				"cn.example:18101",
+				func(context.Context, string, string) ([]net.IP, error) {
+					return test.ips, nil
+				},
+			)
+			if test.wantErr {
+				require.Equal(t, "cn.example:18101", endpoint)
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, endpoint)
+		})
+	}
 }
 
 func TestRecoveryBackendCacheIsBounded(t *testing.T) {

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -37,6 +37,16 @@ import (
 
 const rpcTestResponseTimeout = 10 * time.Second
 
+type closeTrackingRPCClient struct {
+	morpc.RPCClient
+	closed []string
+}
+
+func (c *closeTrackingRPCClient) CloseBackendFor(remote string) error {
+	c.closed = append(c.closed, remote)
+	return nil
+}
+
 type testClientSession struct {
 	ctx         context.Context
 	writeCtx    context.Context
@@ -524,6 +534,73 @@ func TestNewClientWithMOCluster(t *testing.T) {
 	defer func() {
 		assert.NoError(t, c.Close())
 	}()
+}
+
+func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {
+	runtime.SetupServiceBasedRuntime("reset-backend-test", runtime.DefaultRuntime())
+	cluster := clusterservice.NewMOCluster(
+		"reset-backend-test",
+		nil,
+		0,
+		clusterservice.WithDisableRefresh(),
+		clusterservice.WithServices(
+			[]metadata.CNService{{
+				ServiceID:          "cn-id",
+				LockServiceAddress: "cn.example:18101",
+			}},
+			nil))
+	defer cluster.Close()
+
+	rpcClient := &closeTrackingRPCClient{}
+	endpoint := "10.0.0.1:18101"
+	c := &client{
+		cluster:          cluster,
+		client:           rpcClient,
+		recoveryBackends: make(map[string]recoveryBackend),
+		resolveBackend: func(context.Context, string) (string, error) {
+			return endpoint, nil
+		},
+	}
+	serviceID := "0000000000000000000cn-id"
+
+	require.NoError(t, c.ResetBackend(serviceID))
+	require.Equal(t, "10.0.0.1:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
+	require.Equal(t, []string{"cn.example:18101"}, rpcClient.closed)
+
+	endpoint = "10.0.0.2:18101"
+	require.NoError(t, c.ResetBackend(serviceID))
+	require.Equal(t, "10.0.0.2:18101", c.activeTxnBackend("cn-id", "cn.example:18101"))
+	require.Equal(t, []string{
+		"cn.example:18101",
+		"cn.example:18101",
+		"10.0.0.1:18101",
+	}, rpcClient.closed)
+
+	// A service-discovery address change invalidates the recovery override.
+	require.Equal(t, "other.example:18101", c.activeTxnBackend("cn-id", "other.example:18101"))
+	c.recoveryMu.RLock()
+	_, ok := c.recoveryBackends["cn-id"]
+	c.recoveryMu.RUnlock()
+	require.False(t, ok)
+}
+
+func TestRecoveryBackendCacheIsBounded(t *testing.T) {
+	c := &client{recoveryBackends: make(map[string]recoveryBackend)}
+	c.recoveryMu.Lock()
+	for i := 0; i < maxRecoveryBackendEntries; i++ {
+		c.recoveryBackends[fmt.Sprintf("cn-%d", i)] = recoveryBackend{
+			discovered: "cn.example:18101",
+			endpoint:   "10.0.0.1:18101",
+		}
+	}
+	c.storeRecoveryBackendLocked("new-cn", recoveryBackend{
+		discovered: "new.example:18101",
+		endpoint:   "10.0.0.2:18101",
+	})
+	require.LessOrEqual(t, len(c.recoveryBackends), maxRecoveryBackendEntries)
+	_, ok := c.recoveryBackends["new-cn"]
+	c.recoveryMu.Unlock()
+	require.True(t, ok)
 }
 
 func runRPCTests(

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -130,6 +130,7 @@ type testClientSession struct {
 	writeCalled bool
 	asyncCalled bool
 	closeCalled bool
+	response    morpc.Message
 }
 
 func TestLockserviceRemoteRPCErrorType(t *testing.T) {
@@ -164,7 +165,88 @@ func (s *testClientSession) SessionCtx() context.Context { return s.ctx }
 func (s *testClientSession) Write(ctx context.Context, response morpc.Message) error {
 	s.writeCtx = ctx
 	s.writeCalled = true
+	s.response = response
 	return s.writeErr
+}
+
+func TestServerQueueAdmissionTimeoutIsBounded(t *testing.T) {
+	requests := make(chan requestCtx, 1)
+	requests <- requestCtx{}
+	s := &server{
+		logger:                getLogger(""),
+		handlers:              map[lock.Method]RequestHandleFunc{lock.Method_Lock: func(context.Context, context.CancelFunc, *lock.Request, *lock.Response, morpc.ClientSession) {}},
+		requests:              requests,
+		getActiveTxnRequests:  make(chan requestCtx, 1),
+		requestEnqueueTimeout: 10 * time.Millisecond,
+	}
+	req := acquireRequest()
+	req.Method = lock.Method_Lock
+	var canceled bool
+	cs := &testClientSession{ctx: context.Background()}
+	started := time.Now()
+	err := s.onMessage(
+		context.Background(),
+		morpc.RPCMessage{
+			Message: req,
+			Cancel:  func() { canceled = true },
+		},
+		0,
+		cs,
+	)
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), time.Second)
+	require.True(t, canceled)
+	require.True(t, cs.writeCalled)
+	require.False(t, cs.closeCalled, "one saturated request must not close the shared session")
+	resp := cs.response.(*lock.Response)
+	require.ErrorContains(t, resp.UnwrapError(), "request queue full")
+	releaseResponse(resp)
+}
+
+func TestServerQueueAdmissionStopsWithSession(t *testing.T) {
+	requests := make(chan requestCtx, 1)
+	requests <- requestCtx{}
+	s := &server{
+		logger:                getLogger(""),
+		handlers:              map[lock.Method]RequestHandleFunc{lock.Method_Lock: func(context.Context, context.CancelFunc, *lock.Request, *lock.Response, morpc.ClientSession) {}},
+		requests:              requests,
+		getActiveTxnRequests:  make(chan requestCtx, 1),
+		requestEnqueueTimeout: time.Second,
+	}
+	sessionCtx, closeSession := context.WithCancel(context.Background())
+	closeSession()
+	cs := &testClientSession{ctx: sessionCtx}
+	req := acquireRequest()
+	req.Method = lock.Method_Lock
+	var canceled bool
+
+	require.NoError(t, s.onMessage(
+		context.Background(),
+		morpc.RPCMessage{
+			Message: req,
+			Cancel:  func() { canceled = true },
+		},
+		0,
+		cs,
+	))
+	require.True(t, canceled)
+	require.False(t, cs.writeCalled)
+	require.Len(t, requests, 1)
+}
+
+func TestReleaseQueuedRequestsCancelsAndDrains(t *testing.T) {
+	requests := make(chan requestCtx, 2)
+	var canceled int
+	for range 2 {
+		requests <- requestCtx{
+			req:    acquireRequest(),
+			cancel: func() { canceled++ },
+		}
+	}
+
+	releaseQueuedRequests(requests)
+	require.Equal(t, 2, canceled)
+	require.Empty(t, requests)
 }
 
 func (s *testClientSession) AsyncWrite(response morpc.Message) error {

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 )
 
 var methodVersions = map[pb.Method]int64{
@@ -150,14 +151,31 @@ func checkRemoteActiveTxn(client Client, txn pb.WaitTxn) (bool, error) {
 	for attempt := 0; attempt < 2; attempt++ {
 		valid, active, err := sendRemoteActiveTxnCheck(ctx, client, txn)
 		if err != nil {
+			if attempt > 0 {
+				v2.TxnLockActiveTxnRecoveryCounter.WithLabelValues("confirmation-failure").Inc()
+			}
 			return false, moerr.AttachCause(ctx, err)
 		}
 		if valid {
+			if attempt > 0 {
+				result := "confirmed-inactive"
+				if active {
+					result = "confirmed-active"
+				}
+				v2.TxnLockActiveTxnRecoveryCounter.WithLabelValues(result).Inc()
+			}
 			return active, nil
 		}
 		if attempt == 1 {
+			// A lockservice identifier includes the process start version. After
+			// authoritative discovery and a fresh connection, another identity
+			// mismatch means that the old incarnation which owned this txn has
+			// been replaced. This relies on the process manager terminating the
+			// old listener before publishing its replacement.
+			v2.TxnLockActiveTxnRecoveryCounter.WithLabelValues("incarnation-replaced").Inc()
 			return false, nil
 		}
+		v2.TxnLockActiveTxnRecoveryCounter.WithLabelValues("confirmation-started").Inc()
 		resetter, ok := client.(interface {
 			ResetBackend(context.Context, string) error
 		})

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -103,52 +103,7 @@ func (s *service) initRemote() {
 			return resp.CannotCommit, nil
 		},
 		func(txn pb.WaitTxn) (bool, error) {
-			req := acquireRequest()
-			defer releaseRequest(req)
-
-			req.Method = pb.Method_CheckActiveTxn
-			req.CheckActiveTxn.ServiceID = txn.CreatedOn
-			req.CheckActiveTxn.Txn = txn.TxnID
-
-			ctx, cancel := context.WithTimeoutCause(context.Background(), defaultRPCTimeout, moerr.CauseInitRemote2)
-			defer cancel()
-
-			resp, err := s.remote.client.Send(ctx, req)
-			if err != nil {
-				if moerr.IsMoErrCode(err, moerr.ErrNotSupported) {
-					req = acquireRequest()
-					defer releaseRequest(req)
-
-					req.Method = pb.Method_GetActiveTxn
-					req.GetActiveTxn.ServiceID = txn.CreatedOn
-
-					resp, err = s.remote.client.Send(ctx, req)
-					if err != nil {
-						return false, moerr.AttachCause(ctx, err)
-					}
-					defer releaseResponse(resp)
-
-					if !resp.GetActiveTxn.Valid {
-						return false, nil
-					}
-
-					for _, v := range resp.GetActiveTxn.Txn {
-						if bytes.Equal(v, txn.TxnID) {
-							return true, nil
-						}
-					}
-					return false, nil
-				}
-				return false, moerr.AttachCause(ctx, err)
-			}
-			defer releaseResponse(resp)
-
-			// cn restarted
-			if !resp.CheckActiveTxn.Valid {
-				return false, nil
-			}
-
-			return resp.CheckActiveTxn.Active, nil
+			return checkRemoteActiveTxn(s.remote.client, txn)
 		},
 	)
 
@@ -178,6 +133,91 @@ func (s *service) initRemote() {
 	if err := s.stopper.RunTask(s.unlockTimeoutRemoteTxn); err != nil {
 		panic(err)
 	}
+}
+
+// checkRemoteActiveTxn treats a service-identity mismatch as a routing signal,
+// not as proof that the transaction is inactive. A negative identity response
+// becomes authoritative only after the old backend was successfully detached
+// and the request was repeated through freshly resolved routing.
+func checkRemoteActiveTxn(client Client, txn pb.WaitTxn) (bool, error) {
+	ctx, cancel := context.WithTimeoutCause(
+		context.Background(),
+		defaultRPCTimeout,
+		moerr.CauseInitRemote2,
+	)
+	defer cancel()
+
+	for attempt := 0; attempt < 2; attempt++ {
+		valid, active, err := sendRemoteActiveTxnCheck(ctx, client, txn)
+		if err != nil {
+			return false, moerr.AttachCause(ctx, err)
+		}
+		if valid {
+			return active, nil
+		}
+		if attempt == 1 {
+			return false, nil
+		}
+		resetter, ok := client.(interface {
+			ResetBackend(string) error
+		})
+		if !ok {
+			return false, moerr.NewInternalErrorNoCtx(
+				"lockservice client does not support active-txn backend reset")
+		}
+		if err := resetter.ResetBackend(txn.CreatedOn); err != nil {
+			// Normalize reset failures to an indeterminate/retryable lockservice
+			// error. In particular, a BackendClosed reset error must not flow into
+			// isValidRemoteTxn's definitive-inactive branch.
+			return false, moerr.NewInternalErrorNoCtx(
+				"failed to reset active-txn backend: " + err.Error())
+		}
+	}
+	return false, nil
+}
+
+func sendRemoteActiveTxnCheck(
+	ctx context.Context,
+	client Client,
+	txn pb.WaitTxn,
+) (bool, bool, error) {
+	req := acquireRequest()
+	req.Method = pb.Method_CheckActiveTxn
+	req.CheckActiveTxn.ServiceID = txn.CreatedOn
+	req.CheckActiveTxn.Txn = txn.TxnID
+	resp, err := client.Send(ctx, req)
+	releaseRequest(req)
+	if err == nil {
+		valid, active := resp.CheckActiveTxn.Valid, resp.CheckActiveTxn.Active
+		releaseResponse(resp)
+		return valid, active, nil
+	}
+	if !moerr.IsMoErrCode(err, moerr.ErrNotSupported) {
+		return false, false, err
+	}
+
+	// Older peers do not support CheckActiveTxn. GetActiveTxn has the same
+	// service-identity bit, so it follows the same reset-and-confirm contract.
+	req = acquireRequest()
+	req.Method = pb.Method_GetActiveTxn
+	req.GetActiveTxn.ServiceID = txn.CreatedOn
+	resp, err = client.Send(ctx, req)
+	releaseRequest(req)
+	if err != nil {
+		return false, false, err
+	}
+	valid := resp.GetActiveTxn.Valid
+	active := false
+	if valid {
+		for _, txnID := range resp.GetActiveTxn.Txn {
+			if bytes.Equal(txnID, txn.TxnID) {
+				active = true
+				break
+			}
+		}
+	}
+	releaseResponse(resp)
+	return valid, active, nil
 }
 
 func (s *service) initRemoteHandler() {

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -159,13 +159,13 @@ func checkRemoteActiveTxn(client Client, txn pb.WaitTxn) (bool, error) {
 			return false, nil
 		}
 		resetter, ok := client.(interface {
-			ResetBackend(string) error
+			ResetBackend(context.Context, string) error
 		})
 		if !ok {
 			return false, moerr.NewInternalErrorNoCtx(
 				"lockservice client does not support active-txn backend reset")
 		}
-		if err := resetter.ResetBackend(txn.CreatedOn); err != nil {
+		if err := resetter.ResetBackend(ctx, txn.CreatedOn); err != nil {
 			// Normalize reset failures to an indeterminate/retryable lockservice
 			// error. In particular, a BackendClosed reset error must not flow into
 			// isValidRemoteTxn's definitive-inactive branch.

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -458,7 +458,7 @@ func (c *scriptedActiveTxnClient) Send(
 	return resp, nil
 }
 
-func (c *scriptedActiveTxnClient) ResetBackend(string) error {
+func (c *scriptedActiveTxnClient) ResetBackend(context.Context, string) error {
 	c.resets.Add(1)
 	return c.resetErr
 }

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -433,6 +433,94 @@ func TestValidRemoteTxnUsesCheckActiveTxn(t *testing.T) {
 	)
 }
 
+type scriptedActiveTxnClient struct {
+	Client
+	calls      atomic.Int32
+	resets     atomic.Int32
+	resetErr   error
+	afterReset pb.CheckActiveTxnResponse
+}
+
+func (c *scriptedActiveTxnClient) Send(
+	_ context.Context,
+	req *pb.Request,
+) (*pb.Response, error) {
+	if req.Method != pb.Method_CheckActiveTxn {
+		return nil, moerr.NewInternalErrorNoCtx("unexpected active-txn method")
+	}
+	resp := acquireResponse()
+	if c.calls.Add(1) == 1 {
+		// The stale endpoint belongs to a different CN incarnation.
+		resp.CheckActiveTxn.Valid = false
+		return resp, nil
+	}
+	resp.CheckActiveTxn = c.afterReset
+	return resp, nil
+}
+
+func (c *scriptedActiveTxnClient) ResetBackend(string) error {
+	c.resets.Add(1)
+	return c.resetErr
+}
+
+func (c *scriptedActiveTxnClient) Close() error { return nil }
+
+func TestValidRemoteTxnRecoversStaleCheckActiveTxnEndpoint(t *testing.T) {
+	client := &scriptedActiveTxnClient{
+		afterReset: pb.CheckActiveTxnResponse{Valid: true, Active: true},
+	}
+	var notified atomic.Int32
+	holder := newMapBasedTxnHandler(
+		"source",
+		getLogger(""),
+		newFixedSlicePool(16),
+		func(string) (bool, error) { return true, nil },
+		func([]pb.OrphanTxn) (pb.CannotCommitResponse, error) {
+			notified.Add(1)
+			return pb.CannotCommitResponse{}, nil
+		},
+		func(txn pb.WaitTxn) (bool, error) {
+			return checkRemoteActiveTxn(client, txn)
+		},
+	).(*mapBasedTxnHolder)
+	defer holder.close()
+
+	require.True(t, holder.isValidRemoteTxn(pb.WaitTxn{
+		TxnID:     []byte("live"),
+		CreatedOn: "target",
+	}))
+	require.Equal(t, int32(2), client.calls.Load())
+	require.Equal(t, int32(1), client.resets.Load())
+	require.Zero(t, notified.Load(), "recovered live txn reached unlock fencing")
+}
+
+func TestValidRemoteTxnStaysLiveWhenEndpointResetFails(t *testing.T) {
+	client := &scriptedActiveTxnClient{resetErr: moerr.NewBackendClosedNoCtx()}
+	var notified atomic.Int32
+	holder := newMapBasedTxnHandler(
+		"source",
+		getLogger(""),
+		newFixedSlicePool(16),
+		func(string) (bool, error) { return true, nil },
+		func([]pb.OrphanTxn) (pb.CannotCommitResponse, error) {
+			notified.Add(1)
+			return pb.CannotCommitResponse{}, nil
+		},
+		func(txn pb.WaitTxn) (bool, error) {
+			return checkRemoteActiveTxn(client, txn)
+		},
+	).(*mapBasedTxnHolder)
+	defer holder.close()
+
+	require.True(t, holder.isValidRemoteTxn(pb.WaitTxn{
+		TxnID:     []byte("live"),
+		CreatedOn: "target",
+	}))
+	require.Equal(t, int32(1), client.calls.Load())
+	require.Equal(t, int32(1), client.resets.Load())
+	require.Zero(t, notified.Load(), "unknown routing must not reach unlock fencing")
+}
+
 func TestValidRemoteTxnFallsBackToGetActiveTxn(t *testing.T) {
 	runLockServiceTests(
 		t,

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -150,6 +150,8 @@ func initTxnMetrics() {
 	registry.MustRegister(TxnDeadlockDetectorEnqueueCounter)
 	registry.MustRegister(TxnDeadlockOwnerLocalCounter)
 	registry.MustRegister(TxnRemoteLockOwnerTimeoutCounter)
+	registry.MustRegister(TxnLockActiveTxnRecoveryCounter)
+	registry.MustRegister(TxnLockRPCQueueRejectCounter)
 	registry.MustRegister(txnPKChangeCheckCounter)
 	registry.MustRegister(txnPKMayBeChangedCounter)
 

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -116,6 +116,22 @@ var (
 			Help:      "Total number of remote lock owner-side wait timeouts.",
 		}, []string{"granularity", "mode"})
 
+	TxnLockActiveTxnRecoveryCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "lockservice",
+			Name:      "active_txn_recovery_total",
+			Help:      "Total number of active transaction recovery events.",
+		}, []string{"result"})
+
+	TxnLockRPCQueueRejectCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "lockservice",
+			Name:      "rpc_queue_rejected_total",
+			Help:      "Total number of lockservice RPC requests rejected before worker admission.",
+		}, []string{"reason"})
+
 	txnPKChangeCheckCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "mo",


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25650

## What this PR does / why we need it:

Fixes TN-side lockservice recovery after CN hot recreation without restarting TN.

- Adds MORPC targeted backend detachment with per-remote epochs, preventing queued or in-flight pre-reset backend creation from repopulating a stale pool.
- Uses a bounded pure-Go DNS lookup only on the `GetActiveTxn` recovery path, avoiding stale long-lived CGO hostname resolution while leaving normal lock/transaction hot paths unchanged.
- Confirms the first successful `Valid=false` response after resetting the endpoint, preventing a stale IP reassigned to another CN from being treated as an authoritative response.
- Makes cleanup retries bounded and context-aware; handles timeouts, EOF, network errors, unavailable backends, and cancellation through MORPC error classification.
- Linearizes `Valid` commit admission with invalid-CN fencing and protects `Resume` from stale cleanup re-fencing.
- Bounds the recovery endpoint cache and preserves public MORPC interface compatibility.

Validation:

- `go test ./pkg/common/morpc -count=1`
- `go test ./pkg/lockservice -count=1`
- Focused race tests (`-race`, repeated 10/20 times)
- `make dev-build` with typecheck
- `BenchmarkValidDuringRecoveryChanges`: 125-145 ns/op, 0 B/op, 0 allocs/op
- Docker hot-recreate reproduction: no post-ready 20708 in the observed cleanup window.