### PR TITLE
fix: register local dispatches below remote scopes

### DIFF
--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -292,7 +292,10 @@ func registerLocalDispatchReceivers(scopes []*Scope, localAddr string) (*remoteD
 		if _, ok := s.RootOp.(*dispatch.Dispatch); ok {
 			return registerDispatchReceiverRoot
 		}
-		return skipDispatchReceivers
+		// The tree runs on another CN, so its own operators must not be
+		// registered here. Its descendants can still RemoteRun back to this CN;
+		// visit them to publish those local return dispatches early.
+		return traverseDispatchReceiverChildren
 	})
 }
 
@@ -302,6 +305,7 @@ const (
 	skipDispatchReceivers dispatchReceiverRegistrationMode = iota
 	registerDispatchReceiverRoot
 	registerDispatchReceiverTree
+	traverseDispatchReceiverChildren
 )
 
 func registerDispatchReceivers(
@@ -348,10 +352,10 @@ func registerDispatchReceivers(
 		}
 
 		if mode == registerDispatchReceiverRoot {
-			return registerDispatch(s.RootOp.(*dispatch.Dispatch))
-		}
-
-		if s.RootOp != nil {
+			if err := registerDispatch(s.RootOp.(*dispatch.Dispatch)); err != nil {
+				return err
+			}
+		} else if mode == registerDispatchReceiverTree && s.RootOp != nil {
 			if err := vm.HandleAllOp(s.RootOp, func(_ vm.Operator, op vm.Operator) error {
 				d, ok := op.(*dispatch.Dispatch)
 				if !ok {

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -1026,6 +1026,53 @@ func TestRegisterLocalDispatchReceiversRegistersRetainedRemoteRootOnly(t *testin
 	require.Nil(t, notifyCh)
 }
 
+func TestRegisterLocalDispatchReceiversTraversesRemoteAncestorForNestedLocalReturn(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	for _, tc := range []struct {
+		name string
+		root vm.Operator
+	}{
+		{name: "remote non-dispatch root", root: merge.NewArgument()},
+		{name: "retained remote dispatch root", root: dispatch.NewArgument()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			uid, err := uuid.NewV7()
+			require.NoError(t, err)
+			rootProc := testutil.NewProcess(t)
+			outerProc := rootProc.NewNoContextChildProc(0)
+			localProc := rootProc.NewNoContextChildProc(0)
+			localDispatch := dispatch.NewArgument()
+			localDispatch.FuncId = dispatch.SendToAllFunc
+			localDispatch.RemoteRegs = []colexec.ReceiveInfo{{Uuid: uid}}
+			localReturn := &Scope{
+				Magic:    Remote,
+				Proc:     localProc,
+				RootOp:   localDispatch,
+				NodeInfo: engine.Node{Addr: "local-cn:6002"},
+			}
+			outerRemote := &Scope{
+				Magic:     Remote,
+				Proc:      outerProc,
+				RootOp:    tc.root,
+				NodeInfo:  engine.Node{Addr: "remote-cn:6002"},
+				PreScopes: []*Scope{localReturn},
+			}
+			// The remote tree is valid to execute on remote-cn. When it does, its child
+			// RemoteRun comes back to local-cn and needs this dispatch receiver before
+			// the remote sender can notify it.
+			require.True(t, checkPipelineStandaloneExecutableAtRemote(outerRemote))
+
+			registrations, err := registerLocalDispatchReceivers([]*Scope{outerRemote}, "local-cn:6002")
+			require.NoError(t, err)
+			defer registrations.cleanup()
+			registeredProc, _, ok := colexec.Get().GetProcByUuid(uid, false)
+			require.True(t, ok)
+			require.Same(t, localProc, registeredProc)
+		})
+	}
+}
+
 func TestRegisterLocalDispatchReceiversSkipsGuaranteedRemoteRunFailures(t *testing.T) {
 	_ = colexec.NewServer(nil)
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25211

Fixes #25211

## What this PR does / why we need it:

The early dispatch-receiver registration pass stops at a Remote scope when that tree can execute independently on another CN and its root is not a Dispatch. Such a remote tree can still contain a child Remote scope that returns execution to the coordinator CN. Its local dispatch receiver is therefore never published, and the remote sender retries `TryGetProcByUuid` until the 30-second timeout.

Keep the outer remote operator tree remote-only, but continue walking its `PreScopes`. This publishes only dispatch receivers that will execute locally after a nested return RemoteRun. Retained remote Dispatch roots also continue to their child scopes.

Regression coverage exercises both a remote non-Dispatch root and a retained remote Dispatch root with a nested local-return scope.

## Tests:

- `go test -race ./pkg/sql/compile -run "^TestRegisterLocalDispatchReceiversTraversesRemoteAncestorForNestedLocalReturn$" -count=1`
- `go test ./pkg/sql/compile -count=1`