### PR TITLE
fix(disttae): prevent sync.Mutex reentrant deadlock in dumpBatch (cherry-pick #25561)

### DIFF
--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -1254,6 +1254,20 @@ func (mr *MockWorkspaceMockRecorder) GetSyncProtectionJobID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncProtectionJobID", reflect.TypeOf((*MockWorkspace)(nil).GetSyncProtectionJobID))
 }
 
+// WriteOffset mocks base method.
+func (m *MockWorkspace) WriteOffset() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteOffset")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// WriteOffset indicates an expected call of WriteOffset.
+func (mr *MockWorkspaceMockRecorder) WriteOffset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteOffset", reflect.TypeOf((*MockWorkspace)(nil).WriteOffset))
+}
+
 // IncrSQLCount mocks base method.
 func (m *MockWorkspace) IncrSQLCount() {
 	m.ctrl.T.Helper()

--- a/pkg/objectio/injects.go
+++ b/pkg/objectio/injects.go
@@ -76,6 +76,20 @@ const (
 	FJ_CNCLONEFailed                    = "fj/cn/clone_fails"
 	FJ_CNCommitAfterWorkspaceDumpFailed = "fj/cn/commit_after_workspace_dump_fails"
 	FJ_CNNeedRetryError                 = "fj/cn/need_retry_error"
+
+	// FJ_CNReenterSnapshotOffsetOnGetTable is a test-only fault that makes
+	// Transaction.getTable reenter UpdateSnapshotWriteOffset, deterministically
+	// simulating the internal-SQL leg of the issue #25557 deadlock:
+	// getTable -> Engine.Database -> loadDatabaseFromStorage -> execReadSql
+	// -> NewCompile -> UpdateSnapshotWriteOffset.
+	FJ_CNReenterSnapshotOffsetOnGetTable = "fj/cn/reenter_snapshot_offset_on_get_table"
+
+	// FJ_CNDumpResolveWindowWait is a test-only orchestration point inside the
+	// unlocked table-resolution window of a workspace dump. Armed with the
+	// WAIT action, it parks the dumping goroutine right before the transaction
+	// lock is re-acquired, so a test can deterministically mutate the
+	// workspace from another goroutine while the window is open.
+	FJ_CNDumpResolveWindowWait = "fj/cn/dump_resolve_window_wait"
 )
 
 const (
@@ -310,6 +324,32 @@ func SimpleInject(key string) (rmFault func(), err error) {
 func SimpleInjected(key string) bool {
 	_, _, injected := fault.TriggerFault(key)
 	return injected
+}
+
+// CNReenterSnapshotOffsetOnGetTableInjected reports whether the
+// FJ_CNReenterSnapshotOffsetOnGetTable fault is active. When it is,
+// Transaction.getTable simulates the internal-SQL leg of the issue #25557
+// deadlock chain (taking the transaction lock and capturing the workspace
+// write offset). The iarg selects the variant:
+//
+//	0 (the SimpleInject default): fail with an injected error afterwards;
+//	1: continue the normal lookup;
+//	2: additionally call UpdateSnapshotWriteOffset — a rogue boundary
+//	   advance that the fixed internal SQL never performs — then fail with
+//	   the injected error.
+func CNReenterSnapshotOffsetOnGetTableInjected() (injected bool, rogueUpdate bool, errorOut bool) {
+	iarg, _, injected := fault.TriggerFault(FJ_CNReenterSnapshotOffsetOnGetTable)
+	if !injected {
+		return false, false, false
+	}
+	return true, iarg == 2, iarg != 1
+}
+
+// CNDumpResolveWindowWait triggers FJ_CNDumpResolveWindowWait. With the WAIT
+// action armed it blocks until a test notifies the fault point; when the
+// fault is not registered it is a no-op.
+func CNDumpResolveWindowWait() {
+	fault.TriggerFault(FJ_CNDumpResolveWindowWait)
 }
 
 // inject log reader and partition state

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -133,16 +133,32 @@ func NewCompile(
 	c.disableRetry = false
 	c.ncpu = system.GoMaxProcs()
 	c.lockMeta = NewLockMeta()
-	if c.proc.GetTxnOperator() != nil {
-		// TODO: The action of updating the WriteOffset logic should be executed in the `func (c *Compile) Run(_ uint64)` method.
-		// However, considering that the delay ranges are not completed yet, the UpdateSnapshotWriteOffset() and
-		// the assignment of `Compile.TxnOffset` should be moved into the `func (c *Compile) Run(_ uint64)` method in the later stage.
-		c.proc.GetTxnOperator().GetWorkspace().UpdateSnapshotWriteOffset()
-		c.TxnOffset = c.proc.GetTxnOperator().GetWorkspace().GetSnapshotWriteOffset()
-	} else {
-		c.TxnOffset = 0
-	}
+	// TODO: The action of updating the WriteOffset logic should be executed in the `func (c *Compile) Run(_ uint64)` method.
+	// However, considering that the delay ranges are not completed yet, the UpdateSnapshotWriteOffset() and
+	// the assignment of `Compile.TxnOffset` should be moved into the `func (c *Compile) Run(_ uint64)` method in the later stage.
+	c.TxnOffset = txnOffsetOfCompile(c.proc)
 	return c
+}
+
+// txnOffsetOfCompile returns the workspace write offset a new compile reads
+// with. Compiling a user statement advances the statement boundary of the
+// workspace and reads with it. An internal sub-sql of the current statement
+// (DisableIncrStatement, marked on the process) instead captures the current
+// end of the workspace — it reads everything its caller has written so far,
+// but it opens no statement, so it must not advance the shared boundary:
+// moving the boundary mid-statement breaks the positional visibility of the
+// caller's workspace entries (issue #25557).
+func txnOffsetOfCompile(proc *process.Process) int {
+	op := proc.GetTxnOperator()
+	if op == nil {
+		return 0
+	}
+	ws := op.GetWorkspace()
+	if proc.IncrStatementDisabled() {
+		return int(ws.WriteOffset())
+	}
+	ws.UpdateSnapshotWriteOffset()
+	return ws.GetSnapshotWriteOffset()
 }
 
 func (c *Compile) Release() {
@@ -214,9 +230,8 @@ func (c *Compile) Reset(proc *process.Process, startAt time.Time, fill func(*bat
 		f.reset()
 	}
 	c.startAt = startAt
+	c.TxnOffset = txnOffsetOfCompile(c.proc)
 	if c.proc.GetTxnOperator() != nil {
-		c.proc.GetTxnOperator().GetWorkspace().UpdateSnapshotWriteOffset()
-		c.TxnOffset = c.proc.GetTxnOperator().GetWorkspace().GetSnapshotWriteOffset()
 		// all scopes should update the txn offset, or the reader will receive a 0 txnOffset,
 		// that cause a dml statement can not see the previous statements' operations.
 		if len(c.scopes) > 0 {
@@ -224,8 +239,6 @@ func (c *Compile) Reset(proc *process.Process, startAt time.Time, fill func(*bat
 				UpdateScopeTxnOffset(c.scopes[i], c.TxnOffset)
 			}
 		}
-	} else {
-		c.TxnOffset = 0
 	}
 
 	// A reused prepared pipeline runs directly after Reset. Only retries compile

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -128,6 +128,10 @@ func (w *Ws) GetSnapshotWriteOffset() int {
 	return 0
 }
 
+func (w *Ws) WriteOffset() uint64 {
+	return 0
+}
+
 func (w *Ws) Adjust(_ uint64) error {
 	return nil
 }
@@ -656,4 +660,48 @@ func hasOperatorType(op vm.Operator, opType vm.OpType) bool {
 		}
 	}
 	return false
+}
+
+// TestNewCompileTxnOffsetForInternalSql verifies the statement-boundary
+// contract of NewCompile and Compile.Reset (issue #25557): a compile of a
+// user statement advances the workspace snapshot write offset, while an
+// internal sub-sql compile (DisableIncrStatement, marked on the process)
+// must not touch the shared boundary — it captures the current end of the
+// workspace as its own TxnOffset instead.
+func TestNewCompileTxnOffsetForInternalSql(t *testing.T) {
+	t.Run("user statement advances the boundary", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ws := mock_frontend.NewMockWorkspace(ctrl)
+		ws.EXPECT().UpdateSnapshotWriteOffset().Times(1)
+		ws.EXPECT().GetSnapshotWriteOffset().Return(3).Times(1)
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		txnOp.EXPECT().GetWorkspace().Return(ws).AnyTimes()
+
+		proc := testutil.NewProcess(t)
+		proc.Base.TxnOperator = txnOp
+
+		c := NewCompile("test", "test", "select 1", "", "", nil, proc, nil, false, nil, time.Now())
+		require.Equal(t, 3, c.TxnOffset)
+	})
+
+	t.Run("internal sub-sql must not advance the boundary", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ws := mock_frontend.NewMockWorkspace(ctrl)
+		// no UpdateSnapshotWriteOffset expectation: the mock controller
+		// fails the test if the internal compile advances the boundary
+		ws.EXPECT().WriteOffset().Return(uint64(7)).Times(1)
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		txnOp.EXPECT().GetWorkspace().Return(ws).AnyTimes()
+
+		proc := testutil.NewProcess(t)
+		proc.Base.TxnOperator = txnOp
+		proc.SetIncrStatementDisabled(true)
+
+		c := NewCompile("test", "test", "select 1", "", "", nil, proc, nil, false, nil, time.Now())
+		require.Equal(t, 7, c.TxnOffset)
+	})
 }

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -374,6 +374,10 @@ func (exec *txnExecutor) Exec(
 	// Attach original frontend session to support session-scoped metadata
 	// (e.g. temporary-table alias mapping) in internal SQL compilation.
 	proc.Session = getInternalExecutorSession(exec.ctx)
+	// A DisableIncrStatement execution runs on the caller's transaction
+	// without opening a statement, so its compile must not advance the
+	// workspace snapshot write offset (the statement boundary).
+	proc.SetIncrStatementDisabled(exec.opts.DisableIncrStatement())
 	proc.SetResolveVariableFunc(exec.opts.ResolveVariableFunc())
 
 	if exec.opts.ResolveVariableFunc() != nil {

--- a/pkg/txn/client/operator_test.go
+++ b/pkg/txn/client/operator_test.go
@@ -102,6 +102,10 @@ func (w *trackingWorkspace) GetSnapshotWriteOffset() int {
 	return w.snapshotOffset
 }
 
+func (w *trackingWorkspace) WriteOffset() uint64 {
+	return uint64(len(w.commitRequests))
+}
+
 func (w *trackingWorkspace) Adjust(uint64) error {
 	return nil
 }

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -262,8 +262,18 @@ type Workspace interface {
 	// RollbackLastStatement rollback the last statement.
 	RollbackLastStatement(ctx context.Context) error
 
+	// UpdateSnapshotWriteOffset advances the statement boundary of the
+	// workspace to its current end. Only statement-boundary callers may use
+	// it (compiling a new user statement); internal sub-sql executions must
+	// not move the caller's boundary.
 	UpdateSnapshotWriteOffset()
+	// GetSnapshotWriteOffset returns the current statement boundary.
 	GetSnapshotWriteOffset() int
+	// WriteOffset returns the current end of the workspace write list. An
+	// internal sub-sql (DisableIncrStatement) compiles against this value to
+	// see everything its caller has written so far without touching the
+	// shared statement boundary.
+	WriteOffset() uint64
 
 	// Adjust adjust workspace, adjust update's delete+insert to correct order and merge workspace.
 	Adjust(writeOffset uint64) error

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -811,6 +811,17 @@ func (txn *Transaction) dumpInsertBatchLocked(
 		}
 	}
 
+	// Resolve every table that will be flushed BEFORE mutating txn.writes:
+	// getTable must never run while this goroutine holds the lock. See
+	// resolveDumpTablesLocked for the window contract.
+	tables, ok, err := txn.resolveDumpTablesLocked(offset, skipTable, INSERT)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
 	lastWriteIndex := offset
 	writes := txn.writes
 	mp := make(map[tableKey][]*batch.Batch)
@@ -839,18 +850,24 @@ func (txn *Transaction) dumpInsertBatchLocked(
 				dbName:     txn.writes[i].databaseName,
 				name:       txn.writes[i].tableName,
 			}
-			bat := txn.writes[i].bat
-			*size += uint64(bat.Size())
-			*pkCount += bat.RowCount()
-			// skip rowid
-			newBatch := batch.NewWithSize(len(bat.Vecs) - 1)
-			newBatch.SetAttributes(bat.Attrs[1:])
-			newBatch.Vecs = bat.Vecs[1:]
-			newBatch.SetRowCount(bat.Vecs[0].Length())
-			mp[tbKey] = append(mp[tbKey], newBatch)
-			defer bat.Clean(txn.proc.GetMPool())
+			// Tables not resolved in the pre-resolution pass were appended
+			// to the workspace while the lock was released; keep them in
+			// memory for the next dump instead of calling getTable with
+			// the lock held.
+			if _, ok := tables[tbKey]; ok {
+				bat := txn.writes[i].bat
+				*size += uint64(bat.Size())
+				*pkCount += bat.RowCount()
+				// skip rowid
+				newBatch := batch.NewWithSize(len(bat.Vecs) - 1)
+				newBatch.SetAttributes(bat.Attrs[1:])
+				newBatch.Vecs = bat.Vecs[1:]
+				newBatch.SetRowCount(bat.Vecs[0].Length())
+				mp[tbKey] = append(mp[tbKey], newBatch)
+				defer bat.Clean(txn.proc.GetMPool())
 
-			keepElement = false
+				keepElement = false
+			}
 		}
 
 		if keepElement {
@@ -876,10 +893,7 @@ func (txn *Transaction) dumpInsertBatchLocked(
 
 	for tbKey := range mp {
 		// scenario 2 for cn write s3, more info in the comment of S3Writer
-		tbl, err := txn.getTable(tbKey.accountId, tbKey.dbName, tbKey.name)
-		if err != nil {
-			return err
-		}
+		tbl := tables[tbKey]
 
 		tableDef := tbl.GetTableDef(txn.proc.Ctx)
 		s3Writer = colexec.NewCNS3DataWriter(
@@ -937,6 +951,16 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 	size *uint64,
 ) error {
 
+	// See the comment in dumpInsertBatchLocked: tables must be resolved
+	// while txn.writes is still consistent, with the lock released.
+	tables, ok, err := txn.resolveDumpTablesLocked(offset, nil, DELETE)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
 	deleteCnt := 0
 	lastWriteIndex := offset
 	writes := txn.writes
@@ -961,19 +985,25 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 				dbName:     txn.writes[i].databaseName,
 				name:       txn.writes[i].tableName,
 			}
-			bat := txn.writes[i].bat
-			deleteCnt += bat.RowCount()
-			*size += uint64(bat.Size())
+			// Tables not resolved in the pre-resolution pass were appended
+			// to the workspace while the lock was released; keep them in
+			// memory for the next dump instead of calling getTable with
+			// the lock held.
+			if _, ok := tables[tbKey]; ok {
+				bat := txn.writes[i].bat
+				deleteCnt += bat.RowCount()
+				*size += uint64(bat.Size())
 
-			newBat := batch.NewWithSize(len(bat.Vecs))
-			newBat.SetAttributes(bat.Attrs)
-			newBat.Vecs = bat.Vecs
-			newBat.SetRowCount(bat.Vecs[0].Length())
+				newBat := batch.NewWithSize(len(bat.Vecs))
+				newBat.SetAttributes(bat.Attrs)
+				newBat.Vecs = bat.Vecs
+				newBat.SetRowCount(bat.Vecs[0].Length())
 
-			mp[tbKey] = append(mp[tbKey], newBat)
-			defer bat.Clean(txn.proc.GetMPool())
+				mp[tbKey] = append(mp[tbKey], newBat)
+				defer bat.Clean(txn.proc.GetMPool())
 
-			keepElement = false
+				keepElement = false
+			}
 		}
 
 		if keepElement {
@@ -1001,10 +1031,7 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 
 	for tbKey := range mp {
 		// scenario 2 for cn write s3, more info in the comment of S3Writer
-		tbl, err := txn.getTable(tbKey.accountId, tbKey.dbName, tbKey.name)
-		if err != nil {
-			return err
-		}
+		tbl := tables[tbKey]
 
 		pkCol = plan2.PkColByTableDef(tbl.GetTableDef(txn.proc.Ctx))
 		s3Writer = colexec.NewCNS3TombstoneWriter(
@@ -1056,6 +1083,80 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 	return nil
 }
 
+// resolveDumpTablesLocked resolves the engine.Relation of every table whose
+// workspace entries (of the given type, not yet flushed to a file) a dump is
+// about to flush. It must run BEFORE the dump mutates txn.writes: getTable
+// may run internal SQL (Engine.Database -> execReadSql -> NewCompile) whose
+// read pipeline locks the workspace, so the lock is released around the
+// getTable calls, and that is only safe while the workspace is still
+// consistent. The lock is re-acquired before returning, also on error.
+//
+// While the lock is released other goroutines may mutate the workspace. The
+// caller must therefore treat the resolved map as the complete allowlist of
+// what this dump may flush (entries of unresolved tables stay raw), and must
+// give up when ok is false: a rollback truncated txn.writes below the dump
+// offset during the window, so there is nothing left this dump round may
+// safely touch.
+func (txn *Transaction) resolveDumpTablesLocked(
+	offset int,
+	skipTable map[uint64]bool,
+	typ int,
+) (tables map[tableKey]engine.Relation, ok bool, err error) {
+	var keys []tableKey
+	seen := make(map[tableKey]bool)
+	for i := offset; i < len(txn.writes); i++ {
+		e := &txn.writes[i]
+		if skipTable != nil && skipTable[e.tableId] {
+			continue
+		}
+		if e.isCatalog() {
+			continue
+		}
+		if e.bat == nil || e.bat.RowCount() == 0 {
+			continue
+		}
+		if e.typ != typ || e.fileName != "" {
+			continue
+		}
+		k := tableKey{
+			accountId:  e.accountId,
+			databaseId: e.databaseId,
+			dbName:     e.databaseName,
+			name:       e.tableName,
+		}
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+
+	tables = make(map[tableKey]engine.Relation, len(keys))
+	if len(keys) == 0 {
+		return tables, true, nil
+	}
+
+	txn.Unlock()
+	for _, k := range keys {
+		tbl, terr := txn.getTable(k.accountId, k.dbName, k.name)
+		if terr != nil {
+			txn.Lock()
+			return nil, false, terr
+		}
+		tables[k] = tbl
+	}
+	// Test-only orchestration: park here (lock released) so a test can mutate
+	// the workspace while the resolution window is open.
+	objectio.CNDumpResolveWindowWait()
+	txn.Lock()
+
+	if offset > len(txn.writes) {
+		// the workspace was truncated below the dump offset while the lock
+		// was released (statement rollback): nothing to dump this round
+		return nil, false, nil
+	}
+	return tables, true, nil
+}
+
 func (txn *Transaction) getTable(
 	id uint32,
 	dbName string,
@@ -1063,6 +1164,26 @@ func (txn *Transaction) getTable(
 ) (engine.Relation, error) {
 	if txn.engine == nil {
 		return nil, moerr.NewInternalErrorNoCtx("disttae txn engine is nil")
+	}
+
+	if injected, rogueUpdate, errorOut := objectio.CNReenterSnapshotOffsetOnGetTableInjected(); injected {
+		// Test-only fault: deterministically simulate the internal-SQL leg
+		// of the issue #25557 deadlock (getTable -> Engine.Database ->
+		// loadDatabaseFromStorage -> execReadSql -> NewCompile) without
+		// requiring a catalog cache miss. The internal SQL's compile captures
+		// the workspace write offset — WriteOffset takes txn.Lock, so this
+		// self-deadlocks (and the test times out) whenever getTable is
+		// reached with the lock held.
+		_ = txn.WriteOffset()
+		if rogueUpdate {
+			// simulate a rogue statement-boundary advance that internal SQL
+			// must never perform; kept to pin down the damage it would cause
+			txn.UpdateSnapshotWriteOffset()
+		}
+		if errorOut {
+			return nil, moerr.NewInternalErrorNoCtx(
+				"fault injection: reenter snapshot write offset on getTable")
+		}
 	}
 
 	var txnOp client.TxnOperator
@@ -1696,9 +1817,66 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 	return nil
 }
 
+// resolveCompactTablesLocked resolves the engine.Relation of every table
+// that object-deletion compaction will rewrite. The compaction workers must
+// never call getTable themselves: they run while this goroutine holds
+// txn.Lock and waits for them, and getTable may run internal SQL whose read
+// pipeline locks the workspace — the worker would then wait for the lock
+// owner that waits for the worker. So all tables are resolved up front, with
+// the lock released around the getTable calls (same contract as
+// resolveDumpTablesLocked). Because other goroutines may add deletions while
+// the lock is released, the scan-resolve cycle repeats until every table
+// referenced by txn.deletedBlocks is resolved.
+func (txn *Transaction) resolveCompactTablesLocked() (map[tableKey]engine.Relation, error) {
+	tables := make(map[tableKey]engine.Relation)
+	for {
+		var missing []tableKey
+		seen := make(map[tableKey]bool)
+		txn.deletedBlocks.iter(
+			func(blkId *types.Blockid, offsets []int64) bool {
+				summary := txn.cnObjsSummary[*blkId.Object()]
+				k := tableKey{
+					accountId: summary.accountId,
+					dbName:    summary.dbName,
+					name:      summary.tbName,
+				}
+				if _, ok := tables[k]; !ok && !seen[k] {
+					seen[k] = true
+					missing = append(missing, k)
+				}
+				return true
+			})
+		if len(missing) == 0 {
+			return tables, nil
+		}
+
+		txn.Unlock()
+		for _, k := range missing {
+			tbl, err := txn.getTable(k.accountId, k.dbName, k.name)
+			if err != nil {
+				txn.Lock()
+				return nil, err
+			}
+			tables[k] = tbl
+		}
+		txn.Lock()
+	}
+}
+
 // CN blocks compaction for txn
 func (txn *Transaction) compactDeletionOnObjsLocked(ctx context.Context) error {
 
+	if txn.deletedBlocks.size() == 0 {
+		return nil
+	}
+
+	// resolve every affected table BEFORE building the compaction state and
+	// spawning workers; workers must not call getTable (see
+	// resolveCompactTablesLocked)
+	tables, err := txn.resolveCompactTablesLocked()
+	if err != nil {
+		return err
+	}
 	if txn.deletedBlocks.size() == 0 {
 		return nil
 	}
@@ -1762,9 +1940,12 @@ func (txn *Transaction) compactDeletionOnObjsLocked(ctx context.Context) error {
 			)
 		}
 
-		rel, err := txn.getTable(tbKey.accountId, tbKey.dbName, tbKey.name)
-		if err != nil {
-			panicWhenFailed(err, "get table failed")
+		// resolveCompactTablesLocked guarantees every table referenced by
+		// txn.deletedBlocks is in the map
+		rel, ok := tables[tbKey]
+		if !ok {
+			panicWhenFailed(moerr.NewInternalErrorNoCtx(
+				"table not pre-resolved for object compaction"), "get table failed")
 		}
 
 		tbl, ok := rel.(*txnTable)
@@ -2022,7 +2203,9 @@ func (txn *Transaction) forEachTableHasDeletesLocked(
 func (txn *Transaction) ForEachTableWrites(databaseId uint64, tableId uint64, offset int, f func(Entry)) {
 	txn.Lock()
 	defer txn.Unlock()
-	for i := 0; i < offset; i++ {
+	// defensive: an offset captured before a workspace compaction may exceed
+	// the current length; never index past the end
+	for i := 0; i < offset && i < len(txn.writes); i++ {
 		e := txn.writes[i]
 		if e.databaseId != databaseId {
 			continue
@@ -2095,12 +2278,21 @@ func (txn *Transaction) Commit(ctx context.Context) (reqs []txn.TxnRequest, err 
 		return nil, err
 	}
 
+	// mergeTxnWorkspaceLocked (and the compactDeletionOnObjsLocked call
+	// inside it) mutates txn.writes and may release/re-acquire the lock
+	// around metadata resolution, so it must run with the lock held — same
+	// as the IncrStatementID path.
+	txn.Lock()
 	if err := txn.mergeTxnWorkspaceLocked(ctx); err != nil {
+		txn.Unlock()
 		return nil, err
 	}
 	if err := txn.dumpBatchLocked(ctx, -1); err != nil {
+		txn.Unlock()
 		return nil, err
 	}
+	txn.Unlock()
+
 	if msg, injected := objectio.CNCommitAfterWorkspaceDumpFailedInjected(); injected {
 		if msg == "" {
 			msg = "injected commit failure after workspace dump"
@@ -2333,17 +2525,23 @@ func (txn *Transaction) clearTableCache() {
 	})
 }
 
+// GetSnapshotWriteOffset returns the current statement boundary of
+// txn.writes. It is lock-free on purpose: internal SQL spawned while the
+// transaction lock is held (e.g. a catalog read inside a workspace dump)
+// reads the boundary without re-entering the lock.
 func (txn *Transaction) GetSnapshotWriteOffset() int {
-	txn.Lock()
-	defer txn.Unlock()
-	return txn.snapshotWriteOffset
+	return int(txn.snapshotWriteOffset.Load())
 }
 
+// UpdateSnapshotWriteOffset advances the statement boundary to the current
+// end of txn.writes. Only statement-boundary callers may use it (a new
+// compile of a user statement); internal SQL must never advance the
+// boundary, or a mid-statement dump can compact entries covered by it.
 func (txn *Transaction) UpdateSnapshotWriteOffset() {
 	txn.Lock()
 	defer txn.Unlock()
-	txn.snapshotWriteOffset = len(txn.writes)
-	txn.adjustWriteOffset = txn.snapshotWriteOffset
+	txn.snapshotWriteOffset.Store(int64(len(txn.writes)))
+	txn.adjustWriteOffset = len(txn.writes)
 }
 
 // ApproximateInMemInsertSize returns the approximate total size of in-memory

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -35,6 +36,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -1326,4 +1328,341 @@ func TestDupVectorWithoutNulls_ConcurrentSafety(t *testing.T) {
 	// Original should be unchanged
 	require.Equal(t, 5, orig.Length())
 	require.True(t, orig.HasNull())
+}
+
+// TestSnapshotWriteOffset_NormalPath verifies that the normal (non-reentrant)
+// code path still works with correct locking.
+func TestSnapshotWriteOffset_NormalPath(t *testing.T) {
+	t.Run("Update", func(t *testing.T) {
+		txn := &Transaction{
+			writes: []Entry{{}, {}, {}, {}},
+		}
+		txn.UpdateSnapshotWriteOffset()
+		require.Equal(t, 4, txn.GetSnapshotWriteOffset())
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		txn := &Transaction{}
+		txn.snapshotWriteOffset.Store(99)
+		offset := txn.GetSnapshotWriteOffset()
+		require.Equal(t, 99, offset)
+	})
+}
+
+// TestSnapshotWriteOffset_BlocksWhenAnotherGoroutineHoldsLock verifies that
+// a non-holder goroutine blocks on Lock() instead of bypassing it. Run with
+// -race.
+func TestSnapshotWriteOffset_BlocksWhenAnotherGoroutineHoldsLock(t *testing.T) {
+	txn := &Transaction{
+		writes: make([]Entry, 3),
+	}
+
+	locked := make(chan struct{})
+	blocking := make(chan struct{})
+	holderFinished := make(chan struct{})
+
+	go func() {
+		txn.Lock()
+		close(locked)
+		// Signal that we're about to wait; the Sleep gives the main goroutine
+		// time to reach Lock(). This is a best-effort synchronization and a
+		// false test pass is acceptable (the test would still prove
+		// UpdateSnapshotWriteOffset returns the correct final offset).
+		close(blocking)
+		time.Sleep(200 * time.Millisecond)
+		txn.writes = txn.writes[:1]
+		close(holderFinished)
+		txn.Unlock()
+	}()
+
+	<-locked
+	<-blocking
+	txn.UpdateSnapshotWriteOffset()
+	<-holderFinished
+
+	require.Equal(t, 1, txn.GetSnapshotWriteOffset(),
+		"non-holder must capture offset after holder's mutation")
+}
+
+// TestSnapshotWriteOffset_ConcurrentAccess verifies that concurrent accessor
+// calls from many goroutines are race-free. Run with -race.
+func TestSnapshotWriteOffset_ConcurrentAccess(t *testing.T) {
+	txn := &Transaction{
+		writes: make([]Entry, 10),
+	}
+	txn.snapshotWriteOffset.Store(5)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			offset := txn.GetSnapshotWriteOffset()
+			require.GreaterOrEqual(t, offset, 0)
+			txn.UpdateSnapshotWriteOffset()
+		}()
+	}
+
+	wg.Wait()
+	require.Equal(t, 10, txn.GetSnapshotWriteOffset())
+}
+
+// enableReenterSnapshotOffsetFault turns on the fault that makes getTable
+// simulate the internal-SQL leg of the issue #25557 deadlock chain (locking
+// the transaction and capturing the workspace write offset) and then fail
+// with an injected error.
+func enableReenterSnapshotOffsetFault(t *testing.T) {
+	fault.Enable()
+	t.Cleanup(func() {
+		// Fault injection is a process-level global switch. Removing the
+		// fault point alone does not turn it off; subsequent tests would
+		// run with injection still active, causing order-dependent
+		// failures.
+		fault.Disable()
+	})
+	rmFault, err := objectio.SimpleInject(objectio.FJ_CNReenterSnapshotOffsetOnGetTable)
+	require.NoError(t, err)
+	t.Cleanup(rmFault)
+}
+
+// enableRogueUpdateOnGetTableFault turns on the iarg=2 variant of the fault:
+// besides the internal-SQL simulation, getTable performs a rogue
+// UpdateSnapshotWriteOffset — a statement-boundary advance the fixed
+// internal SQL never does — and then fails with the injected error.
+func enableRogueUpdateOnGetTableFault(t *testing.T) {
+	fault.Enable()
+	t.Cleanup(func() {
+		fault.Disable()
+	})
+	require.NoError(t, fault.AddFaultPoint(
+		context.Background(), objectio.FJ_CNReenterSnapshotOffsetOnGetTable,
+		":::", "echo", 2, "", false))
+	t.Cleanup(func() {
+		_, _ = fault.RemoveFaultPoint(
+			context.Background(), objectio.FJ_CNReenterSnapshotOffsetOnGetTable)
+	})
+}
+
+// newDumpableTxnForTest builds a minimal Transaction whose workspace holds
+// one user-table INSERT entry that dumpBatchLocked will try to flush,
+// reaching getTable. The zero-valued engine config (all thresholds 0)
+// guarantees the entry is not skipped.
+func newDumpableTxnForTest(t *testing.T) *Transaction {
+	proc := testutil.NewProc(t)
+	txn := &Transaction{
+		proc:   proc,
+		engine: &Engine{},
+		writes: []Entry{
+			{
+				typ:          INSERT,
+				accountId:    0,
+				tableId:      42, // must not be a catalog table id
+				databaseId:   7,
+				tableName:    "tbl",
+				databaseName: "db",
+				bat:          newInt64BatchForTest(t, proc, []string{"pk"}, []int64{1, 2}),
+			},
+		},
+	}
+	t.Cleanup(func() {
+		// If the dump aborts before consuming the entries, their batches
+		// are still owned by the workspace; release them here.
+		for i := range txn.writes {
+			if txn.writes[i].bat != nil {
+				txn.writes[i].bat.Clean(proc.Mp())
+			}
+		}
+	})
+	return txn
+}
+
+// requireBoundaryUntouched asserts that the internal SQL simulated inside
+// the dump did not advance the statement boundary: boundary advances are
+// statement-boundary actions, and an advance during a dump can cover
+// workspace entries the compaction is about to rewrite.
+func requireBoundaryUntouched(t *testing.T, txn *Transaction) {
+	t.Helper()
+	require.Equal(t, 0, txn.GetSnapshotWriteOffset(),
+		"internal SQL must not advance snapshotWriteOffset")
+}
+
+// TestIssue25557_DumpBatchReentrantGetTableDoesNotDeadlock covers the
+// original issue #25557 entry point:
+//
+//	txnTable.Write -> dumpBatch [acquires txn.Lock()]
+//	  -> dumpBatchLocked -> dumpInsertBatchLocked -> getTable
+//	    -> internal SQL -> NewCompile [locks the workspace]
+//
+// The fault point makes the internal-SQL leg deterministic. Before the fix
+// the internal SQL re-entered txn.Lock() on the same goroutine and
+// self-deadlocked.
+func TestIssue25557_DumpBatchReentrantGetTableDoesNotDeadlock(t *testing.T) {
+	enableReenterSnapshotOffsetFault(t)
+	txn := newDumpableTxnForTest(t)
+	preDumpLen := len(txn.writes)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- txn.dumpBatch(context.Background(), 0)
+	}()
+
+	select {
+	case err := <-errCh:
+		// The injected error proves getTable was reached and the simulated
+		// internal SQL locked the workspace instead of deadlocking.
+		require.ErrorContains(t, err, "reenter snapshot write offset")
+		requireBoundaryUntouched(t, txn)
+		require.Len(t, txn.writes, preDumpLen,
+			"an aborted dump must leave the workspace untouched")
+	case <-time.After(10 * time.Second):
+		t.Fatal("dumpBatch deadlocked when getTable ran the internal-SQL " +
+			"leg with txn.Lock held")
+	}
+}
+
+// TestIssue25557_LockedDumpInsertBatchReentrantGetTableDoesNotDeadlock covers
+// the locked entry points that call dumpBatchLocked directly without going
+// through the dumpBatch wrapper (IncrStatementID, commit):
+//
+//	IncrStatementID [acquires txn.Lock()]
+//	  -> dumpBatchLocked -> dumpInsertBatchLocked -> getTable
+//	    -> internal SQL -> NewCompile [locks the workspace]
+//
+// This is the reproducer shape from the PR #25560 review: a fix scoped to
+// the dumpBatch wrapper does not cover this path.
+func TestIssue25557_LockedDumpInsertBatchReentrantGetTableDoesNotDeadlock(t *testing.T) {
+	enableReenterSnapshotOffsetFault(t)
+	txn := newDumpableTxnForTest(t)
+	preDumpLen := len(txn.writes)
+
+	fs, err := colexec.GetSharedFSFromProc(txn.proc)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		txn.Lock()
+		defer txn.Unlock()
+		var size uint64
+		var pkCount int
+		errCh <- txn.dumpInsertBatchLocked(
+			context.Background(), fs, 0, &size, &pkCount)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "reenter snapshot write offset")
+		requireBoundaryUntouched(t, txn)
+		require.Len(t, txn.writes, preDumpLen,
+			"an aborted dump must leave the workspace untouched")
+	case <-time.After(10 * time.Second):
+		t.Fatal("dumpInsertBatchLocked deadlocked when getTable ran the " +
+			"internal-SQL leg with txn.Lock held")
+	}
+}
+
+// TestIssue25557_DumpDeleteBatchReentrantGetTableDoesNotDeadlock covers the
+// delete flush path, which has the same getTable -> internal SQL shape as
+// the insert path.
+func TestIssue25557_DumpDeleteBatchReentrantGetTableDoesNotDeadlock(t *testing.T) {
+	enableReenterSnapshotOffsetFault(t)
+
+	proc := testutil.NewProc(t)
+	txn := &Transaction{
+		proc:   proc,
+		engine: &Engine{},
+		writes: []Entry{
+			{
+				typ:          DELETE,
+				accountId:    0,
+				tableId:      42, // must not be a catalog table id
+				databaseId:   7,
+				tableName:    "tbl",
+				databaseName: "db",
+				bat:          newDeleteBatchForTest(t, proc, []int64{1, 2}),
+			},
+		},
+	}
+	t.Cleanup(func() {
+		for i := range txn.writes {
+			if txn.writes[i].bat != nil {
+				txn.writes[i].bat.Clean(proc.Mp())
+			}
+		}
+	})
+	preDumpLen := len(txn.writes)
+
+	fs, err := colexec.GetSharedFSFromProc(txn.proc)
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		txn.Lock()
+		defer txn.Unlock()
+		var size uint64
+		errCh <- txn.dumpDeleteBatchLocked(context.Background(), fs, 0, &size)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "reenter snapshot write offset")
+		requireBoundaryUntouched(t, txn)
+		require.Len(t, txn.writes, preDumpLen,
+			"an aborted dump must leave the workspace untouched")
+	case <-time.After(10 * time.Second):
+		t.Fatal("dumpDeleteBatchLocked deadlocked when getTable ran the " +
+			"internal-SQL leg with txn.Lock held")
+	}
+}
+
+// TestIssue25557_RogueBoundaryAdvanceCapturesConsistentState pins down the
+// defense-in-depth property of the resolution window: even if some code did
+// advance the statement boundary inside the window (which the fixed internal
+// SQL never does — simulated here by the iarg=2 fault variant), it can only
+// capture a consistent pre-compaction workspace, because the dump does not
+// mutate txn.writes before the window closes.
+func TestIssue25557_RogueBoundaryAdvanceCapturesConsistentState(t *testing.T) {
+	enableRogueUpdateOnGetTableFault(t)
+	txn := newDumpableTxnForTest(t)
+	preDumpLen := len(txn.writes)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- txn.dumpBatch(context.Background(), 0)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "reenter snapshot write offset")
+		require.Equal(t, preDumpLen, txn.GetSnapshotWriteOffset(),
+			"a boundary advanced inside the window must cover the complete "+
+				"pre-dump workspace")
+		require.Len(t, txn.writes, preDumpLen)
+		// the captured boundary must be safe for every reader
+		seen := 0
+		txn.ForEachTableWrites(7, 42, txn.GetSnapshotWriteOffset(), func(Entry) {
+			seen++
+		})
+		require.Equal(t, preDumpLen, seen)
+	case <-time.After(10 * time.Second):
+		t.Fatal("dumpBatch deadlocked on the rogue-update fault variant")
+	}
+}
+
+// TestForEachTableWrites_StaleOffsetBeyondLengthIsSafe verifies the
+// defensive bounds check: an offset captured before a workspace compaction
+// may exceed the current length of txn.writes and must not panic.
+func TestForEachTableWrites_StaleOffsetBeyondLengthIsSafe(t *testing.T) {
+	txn := &Transaction{
+		writes: []Entry{
+			{databaseId: 7, tableId: 42},
+		},
+	}
+
+	seen := 0
+	require.NotPanics(t, func() {
+		txn.ForEachTableWrites(7, 42, 3, func(Entry) {
+			seen++
+		})
+	})
+	require.Equal(t, 1, seen)
 }

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -374,8 +374,12 @@ type Transaction struct {
 	approximateInMemInsertCnt int
 	// the approximation of total row count for delete entries
 	approximateInMemDeleteCnt int
-	// the last snapshot write offset
-	snapshotWriteOffset int
+	// snapshotWriteOffset is the statement boundary of txn.writes: readers of
+	// this transaction iterate the [0, snapshotWriteOffset) prefix. It is
+	// advanced under txn.Lock at statement boundaries only (a new compile of
+	// a user statement), never by internal SQL, and mid-statement dumps only
+	// compact entries at or after the boundary; reading it is lock-free.
+	snapshotWriteOffset atomic.Int64
 	// the earliest write offset that Adjust must still consider for the current SQL
 	// after in-place workspace compaction shifts surviving writes to the left.
 	adjustWriteOffset int
@@ -623,7 +627,7 @@ func (txn *Transaction) PPString() string {
 		}),
 		stringifySyncMap(txn.tableCache),
 		txn.approximateInMemInsertCnt,
-		txn.snapshotWriteOffset,
+		txn.snapshotWriteOffset.Load(),
 		txn.rollbackCount,
 		txn.statementID,
 		stringifySlice(txn.offsets, func(a any) string { return fmt.Sprintf("%v", a) }),

--- a/pkg/vm/engine/test/workspace_test.go
+++ b/pkg/vm/engine/test/workspace_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	catalog2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
@@ -262,6 +263,694 @@ func Test_BasicS3InsertDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 5, ret.RowCount())
+	require.NoError(t, txn.Commit(ctx))
+}
+
+// Test_Issue25557MidTxnDumpKeepsWorkspaceVisibility drives the full
+// issue #25557 chain against a real engine:
+//
+//	relation.Write -> dumpBatch [txn.Lock()]
+//	  -> dumpInsertBatchLocked -> getTable
+//	    -> (fault-injected) internal SQL [locks the workspace]
+//
+// A tiny write-workspace threshold and an exhausted quota pool force the
+// dump in the middle of the statement, and the fault point makes getTable
+// run the internal-SQL leg exactly like a compile hitting the dump window.
+// The internal SQL must not advance the statement boundary, so the
+// statement keeps not seeing its own writes, and after the statement ends
+// the flushed rows are fully visible.
+func Test_Issue25557MidTxnDumpKeepsWorkspaceVisibility(t *testing.T) {
+	var (
+		err          error
+		mp           *mpool.MPool
+		txn          client.TxnOperator
+		accountId    = catalog.System_Account
+		tableName    = "test_table"
+		databaseName = "test_database"
+
+		primaryKeyIdx = 3
+
+		relation engine.Relation
+
+		taeEngine     *testutil.TestTxnStorage
+		rpcAgent      *testutil.MockRPCAgent
+		disttaeEngine *testutil.TestDisttaeEngine
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
+	schema.Name = tableName
+
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
+		ctx,
+		testutil.TestOptions{},
+		t,
+		// force the dump in the middle of the write statement
+		testutil.WithDisttaeEngineWriteWorkspaceThreshold(1),
+		testutil.WithDisttaeEngineCommitWorkspaceThreshold(1),
+		// an exhausted quota pool so the dump cannot be postponed
+		testutil.WithDisttaeEngineQuota(1),
+	)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeEngine.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	_, _, err = disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableName, schema)
+	require.NoError(t, err)
+
+	// Make getTable run the internal-SQL leg (iarg 1: keep the normal lookup
+	// working afterwards).
+	fault.Enable()
+	defer fault.Disable()
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable, ":::", "echo", 1, "", false))
+	defer func() {
+		_, err := fault.RemoveFaultPoint(
+			ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable)
+		require.NoError(t, err)
+	}()
+
+	rowsCount := 10
+	bat := catalog2.MockBatch(schema, rowsCount)
+	bat1 := containers.ToCNBatch(bat)
+
+	_, relation, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableName)
+	require.NoError(t, err)
+
+	// Do NOT end the statement yet: the boundary must stay at the statement
+	// start even though the dump ran an internal SQL in between.
+	require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat1, false, false))
+
+	// the internal SQL must not advance the statement boundary, so the
+	// statement keeps not seeing its own writes
+	require.Equal(t, 0, txn.GetWorkspace().GetSnapshotWriteOffset(),
+		"internal SQL must not advance snapshotWriteOffset")
+	require.Equal(t, 0, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relation, schema, primaryKeyIdx, mp),
+		"a statement must not see its own writes")
+
+	// the write workspace threshold guarantees the insert was flushed to S3
+	// during the statement; once the statement ends, the flushed rows must
+	// be visible to this transaction
+	require.NoError(t, testutil.EndThisStatement(ctx, txn))
+	require.Equal(t, rowsCount, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relation, schema, primaryKeyIdx, mp),
+		"rows flushed by the mid-statement dump must stay visible "+
+			"to reads of the same transaction")
+	require.NoError(t, txn.Commit(ctx))
+
+	// the committed data must be complete
+	_, relation, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableName)
+	require.NoError(t, err)
+	require.Equal(t, rowsCount, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relation, schema, primaryKeyIdx, mp))
+	require.NoError(t, txn.Commit(ctx))
+}
+
+// issue25557ReadRowCount reads every row of the relation visible to txn and
+// returns the total row count.
+func issue25557ReadRowCount(
+	t *testing.T,
+	ctx context.Context,
+	e *testutil.TestDisttaeEngine,
+	txn client.TxnOperator,
+	relation engine.Relation,
+	schema *catalog2.Schema,
+	primaryKeyIdx int,
+	mp *mpool.MPool,
+) int {
+	reader, err := testutil.GetRelationReader(ctx, e, txn, relation, nil, mp, t)
+	require.NoError(t, err)
+	total := 0
+	ret := testutil.EmptyBatchFromSchema(schema, primaryKeyIdx)
+	for {
+		done, err := reader.Read(ctx, ret.Attrs, nil, mp, ret)
+		require.NoError(t, err)
+		total += ret.RowCount()
+		if done {
+			break
+		}
+	}
+	reader.Close()
+	return total
+}
+
+// Test_Issue25557MultiEntryDumpCompaction covers the many-to-one workspace
+// compaction case: two raw INSERT entries of one table, written in the same
+// statement, are merged into a single S3 entry by a mid-statement dump. A
+// snapshot offset captured by the (fault-injected) internal SQL inside the
+// dump-resolution window must not exceed the compacted workspace: on the
+// broken code the captured offset is 2 while one entry remains, and the
+// same-transaction read panics with index out of range in
+// ForEachTableWrites.
+func Test_Issue25557MultiEntryDumpCompaction(t *testing.T) {
+	var (
+		err          error
+		mp           *mpool.MPool
+		txn          client.TxnOperator
+		accountId    = catalog.System_Account
+		tableName    = "test_table"
+		databaseName = "test_database"
+
+		primaryKeyIdx = 3
+
+		relation engine.Relation
+
+		taeEngine     *testutil.TestTxnStorage
+		rpcAgent      *testutil.MockRPCAgent
+		disttaeEngine *testutil.TestDisttaeEngine
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
+	schema.Name = tableName
+
+	totalRows := 210
+	bat := containers.ToCNBatch(catalog2.MockBatch(schema, totalRows))
+	bat1, err := bat.Window(0, 10)
+	require.NoError(t, err)
+	bat2, err := bat.Window(10, totalRows)
+	require.NoError(t, err)
+
+	// The first write must stay below the dump threshold and the second one
+	// must cross it, so that the dump sees two raw entries of one table. The
+	// in-memory entry of a write is its batch plus a generated rowid vector,
+	// so bat1's entry stays below bat1.Size()+bat2.Size() while both entries
+	// together always cross it.
+	dumpThreshold := uint64(bat1.Size() + bat2.Size())
+
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
+		ctx,
+		testutil.TestOptions{},
+		t,
+		testutil.WithDisttaeEngineWriteWorkspaceThreshold(dumpThreshold),
+		testutil.WithDisttaeEngineCommitWorkspaceThreshold(1),
+		// an exhausted quota pool so the dump cannot be postponed
+		testutil.WithDisttaeEngineQuota(1),
+	)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeEngine.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	_, _, err = disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableName, schema)
+	require.NoError(t, err)
+
+	// getTable runs three times: the write-time PK resolution of each write,
+	// then the dump-side table resolution. Only the last one must simulate
+	// the internal-SQL leg, exactly like a compile hitting the dump window.
+	fault.Enable()
+	defer fault.Disable()
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable, "3:3::", "echo", 1, "", false))
+	defer func() {
+		_, err := fault.RemoveFaultPoint(
+			ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable)
+		require.NoError(t, err)
+	}()
+
+	_, relation, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableName)
+	require.NoError(t, err)
+
+	txn.GetWorkspace().StartStatement()
+	require.NoError(t, relation.Write(ctx, bat1))
+	// crosses the threshold: the dump compacts both raw entries into one S3
+	// entry while the fault-injected internal SQL runs in the resolution
+	// window
+	require.NoError(t, relation.Write(ctx, bat2))
+
+	// Reads inside the writing statement must not observe the statement's own
+	// writes; on the broken code this read panics with index out of range
+	// because the captured offset (2) exceeds the compacted workspace (1).
+	require.Equal(t, 0, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relation, schema, primaryKeyIdx, mp),
+		"a statement must not see its own writes")
+
+	// the internal SQL must not advance the statement boundary
+	require.Equal(t, 0, txn.GetWorkspace().GetSnapshotWriteOffset(),
+		"internal SQL must not advance snapshotWriteOffset")
+
+	require.NoError(t, testutil.EndThisStatement(ctx, txn))
+	require.Equal(t, totalRows, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relation, schema, primaryKeyIdx, mp),
+		"rows flushed by the mid-statement dump must be visible after the statement ends")
+	require.NoError(t, txn.Commit(ctx))
+
+	// the committed data must be complete
+	_, relation, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableName)
+	require.NoError(t, err)
+	require.Equal(t, totalRows, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relation, schema, primaryKeyIdx, mp))
+	require.NoError(t, txn.Commit(ctx))
+}
+
+// Test_Issue25557DumpWindowAppendKeepsPrefix orchestrates a workspace append
+// while the dump-resolution window is open: table A's dump parks inside the
+// window (WAIT fault), table B is written meanwhile, and the dump then
+// compacts A only. Any statement boundary captured around the window must
+// keep excluding both in-flight writes: on the broken code the reentrant
+// update inside the window sets the boundary to 1, and after compaction the
+// prefix [0, 1) is the raw entry of B instead of A — B becomes visible to
+// its own statement and A's rows disappear.
+func Test_Issue25557DumpWindowAppendKeepsPrefix(t *testing.T) {
+	var (
+		err          error
+		mp           *mpool.MPool
+		txn          client.TxnOperator
+		accountId    = catalog.System_Account
+		tableAName   = "test_table_a"
+		tableBName   = "test_table_b"
+		databaseName = "test_database"
+
+		primaryKeyIdx = 3
+
+		taeEngine     *testutil.TestTxnStorage
+		rpcAgent      *testutil.MockRPCAgent
+		disttaeEngine *testutil.TestDisttaeEngine
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	schemaA := catalog2.MockSchemaAll(4, primaryKeyIdx)
+	schemaA.Name = tableAName
+	schemaB := catalog2.MockSchemaAll(4, primaryKeyIdx)
+	schemaB.Name = tableBName
+
+	rowsA := 200
+	rowsB := 5
+	batA := containers.ToCNBatch(catalog2.MockBatch(schemaA, rowsA))
+	batB := containers.ToCNBatch(catalog2.MockBatch(schemaB, rowsB))
+
+	// table A's write crosses the threshold on its own (its entry includes
+	// the generated rowid vector on top of batA), while table B's small
+	// write alone stays below it
+	dumpThreshold := uint64(batA.Size())
+
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
+		ctx,
+		testutil.TestOptions{},
+		t,
+		testutil.WithDisttaeEngineWriteWorkspaceThreshold(dumpThreshold),
+		testutil.WithDisttaeEngineCommitWorkspaceThreshold(1),
+		testutil.WithDisttaeEngineQuota(1),
+	)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeEngine.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	_, _, err = disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableAName, schemaA)
+	require.NoError(t, err)
+	_, _, err = disttaeEngine.CreateDatabaseAndTable(ctx, databaseName+"_b", tableBName, schemaB)
+	require.NoError(t, err)
+
+	fault.Enable()
+	defer fault.Disable()
+	// every getTable simulates the internal-SQL leg
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable, ":::", "echo", 1, "", false))
+	defer func() {
+		_, err := fault.RemoveFaultPoint(
+			ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable)
+		require.NoError(t, err)
+	}()
+	// only the first dump (table A's) parks inside its resolution window
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, objectio.FJ_CNDumpResolveWindowWait, "1:1::", "WAIT", 0, "", false))
+	defer func() {
+		_, _ = fault.RemoveFaultPoint(ctx, objectio.FJ_CNDumpResolveWindowWait)
+	}()
+	const waitersProbe = "issue25557_window_waiters"
+	const windowNotify = "issue25557_window_notify"
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, waitersProbe, ":::", "GETWAITERS", 0, objectio.FJ_CNDumpResolveWindowWait, false))
+	defer func() {
+		_, _ = fault.RemoveFaultPoint(ctx, waitersProbe)
+	}()
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, windowNotify, ":::", "NOTIFYALL", 0, objectio.FJ_CNDumpResolveWindowWait, false))
+	defer func() {
+		_, _ = fault.RemoveFaultPoint(ctx, windowNotify)
+	}()
+
+	_, relationA, txn, err := disttaeEngine.GetTable(ctx, databaseName, tableAName)
+	require.NoError(t, err)
+	dbB, err := disttaeEngine.Engine.Database(ctx, databaseName+"_b", txn)
+	require.NoError(t, err)
+	relationB, err := dbB.Relation(ctx, tableBName, nil)
+	require.NoError(t, err)
+
+	txn.GetWorkspace().StartStatement()
+
+	// table A's write triggers the dump, which parks inside the resolution
+	// window with the transaction lock released
+	writeADone := make(chan error, 1)
+	go func() {
+		writeADone <- relationA.Write(ctx, batA)
+	}()
+
+	waitDeadline := time.Now().Add(10 * time.Second)
+	for {
+		n, _, ok := fault.TriggerFault(waitersProbe)
+		require.True(t, ok)
+		if n >= 1 {
+			break
+		}
+		require.True(t, time.Now().Before(waitDeadline),
+			"table A's dump never reached the resolution window")
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// append table B's write while the window is open
+	require.NoError(t, relationB.Write(ctx, batB))
+
+	// resume table A's dump
+	_, _, ok := fault.TriggerFault(windowNotify)
+	require.True(t, ok)
+
+	select {
+	case err = <-writeADone:
+		require.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("table A's write did not finish: dump deadlocked")
+	}
+
+	// the statement boundary must still be at the statement start: table B's
+	// raw entry must not have slipped into the visible prefix
+	require.Equal(t, 0, txn.GetWorkspace().GetSnapshotWriteOffset(),
+		"internal SQL must not advance snapshotWriteOffset")
+	require.Equal(t, 0, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relationB, schemaB, primaryKeyIdx, mp),
+		"a statement must not see its own writes (table B)")
+	require.Equal(t, 0, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relationA, schemaA, primaryKeyIdx, mp),
+		"a statement must not see its own writes (table A)")
+
+	require.NoError(t, testutil.EndThisStatement(ctx, txn))
+	require.Equal(t, rowsA, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relationA, schemaA, primaryKeyIdx, mp))
+	require.Equal(t, rowsB, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relationB, schemaB, primaryKeyIdx, mp))
+	require.NoError(t, txn.Commit(ctx))
+
+	// the committed data must be complete for both tables
+	_, relationA, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableAName)
+	require.NoError(t, err)
+	require.Equal(t, rowsA, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relationA, schemaA, primaryKeyIdx, mp))
+	require.NoError(t, txn.Commit(ctx))
+
+	_, relationB, txn, err = disttaeEngine.GetTable(ctx, databaseName+"_b", tableBName)
+	require.NoError(t, err)
+	require.Equal(t, rowsB, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relationB, schemaB, primaryKeyIdx, mp))
+	require.NoError(t, txn.Commit(ctx))
+}
+
+// Test_Issue25557ObjectCompactionNoDeadlock covers the object-deletion
+// compaction leg of issue #25557: a transaction dumps an insert to S3,
+// deletes a row of the uncommitted block, and commits. The commit runs
+// IncrStatementID -> mergeTxnWorkspaceLocked -> compactDeletionOnObjsLocked
+// while holding the transaction lock; on the broken code the compaction
+// workers call getTable, whose (fault-injected) internal SQL waits for the
+// same lock while the lock owner waits for the workers — a cross-goroutine
+// deadlock.
+func Test_Issue25557ObjectCompactionNoDeadlock(t *testing.T) {
+	var (
+		err          error
+		mp           *mpool.MPool
+		accountId    = catalog.System_Account
+		tableName    = "test_table"
+		databaseName = "test_database"
+
+		primaryKeyIdx = 3
+
+		taeEngine     *testutil.TestTxnStorage
+		rpcAgent      *testutil.MockRPCAgent
+		disttaeEngine *testutil.TestDisttaeEngine
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	_ = colexec.NewServer(nil)
+
+	schema := catalog2.MockSchemaEnhanced(4, primaryKeyIdx, 9)
+	schema.Name = tableName
+
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
+		ctx,
+		testutil.TestOptions{},
+		t,
+		testutil.WithDisttaeEngineInsertEntryMaxCount(1),
+		testutil.WithDisttaeEngineCommitWorkspaceThreshold(1),
+		testutil.WithDisttaeEngineWriteWorkspaceThreshold(1),
+		testutil.WithDisttaeEngineQuota(1),
+	)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeEngine.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	_, _, err = disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableName, schema)
+	require.NoError(t, err)
+
+	fault.Enable()
+	defer fault.Disable()
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable, ":::", "echo", 1, "", false))
+	defer func() {
+		_, err := fault.RemoveFaultPoint(
+			ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable)
+		require.NoError(t, err)
+	}()
+
+	insertCnt := 150
+	deleteCnt := 1
+	var tombstoneBat *batch.Batch
+
+	_, table, txn, err := disttaeEngine.GetTable(ctx, databaseName, tableName)
+	require.NoError(t, err)
+
+	// the tiny write threshold flushes the insert to S3 during the write
+	bat := catalog2.MockBatch(schema, insertCnt)
+	require.NoError(t, table.Write(ctx, containers.ToCNBatch(bat)))
+
+	entryCnt := 0
+	txn.GetWorkspace().(*disttae.Transaction).ForEachTableWrites(
+		table.GetDBID(ctx), table.GetTableID(ctx), 1, func(entry disttae.Entry) {
+			if entry.Bat() == nil ||
+				entry.Bat().RowCount() == 0 ||
+				entry.FileName() == "" {
+				return
+			}
+			entryCnt++
+
+			tombstoneBat = batch.NewWithSize(1)
+			tombstoneBat.Attrs = append(tombstoneBat.Attrs, catalog.Row_ID)
+			tombstoneBat.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+
+			blk := objectio.DecodeBlockInfo(entry.Bat().GetVector(0).GetBytesAt(0))
+			for i := 0; i < deleteCnt; i++ {
+				rid := types.NewRowid(&blk.BlockID, uint32(i))
+				require.NoError(t, vector.AppendFixed[types.Rowid](
+					tombstoneBat.Vecs[0], rid, false, mp))
+			}
+			tombstoneBat.SetRowCount(deleteCnt)
+		})
+	require.Equal(t, 1, entryCnt)
+
+	// deleting rows of the uncommitted block feeds txn.deletedBlocks, so the
+	// commit must compact the dumped object
+	require.NoError(t, table.Delete(ctx, tombstoneBat, catalog.Row_ID))
+
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- txn.Commit(ctx)
+	}()
+	select {
+	case err = <-commitDone:
+		require.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("commit did not finish: object-deletion compaction deadlocked")
+	}
+
+	// the committed data must be complete
+	{
+		_, _, reader, err := testutil.GetTableTxnReader(
+			ctx,
+			disttaeEngine,
+			databaseName,
+			tableName,
+			nil,
+			mp,
+			t,
+		)
+		require.NoError(t, err)
+
+		ret := testutil.EmptyBatchFromSchema(schema, primaryKeyIdx)
+		_, err = reader.Read(ctx, ret.Attrs, nil, mp, ret)
+		require.NoError(t, err)
+		require.Equal(t, insertCnt-deleteCnt, ret.RowCount())
+	}
+}
+
+// Test_Issue25557MultiEntryDeleteDumpAtCommit covers the DELETE twin of the
+// many-to-one compaction case: two raw DELETE entries of one table are
+// merged into a single tombstone object by the commit-time dump, with the
+// fault-injected internal SQL running in the dump-resolution window.
+func Test_Issue25557MultiEntryDeleteDumpAtCommit(t *testing.T) {
+	var (
+		err          error
+		mp           *mpool.MPool
+		txn          client.TxnOperator
+		accountId    = catalog.System_Account
+		tableName    = "test_table"
+		databaseName = "test_database"
+
+		primaryKeyIdx = 3
+
+		relation engine.Relation
+
+		taeEngine     *testutil.TestTxnStorage
+		rpcAgent      *testutil.MockRPCAgent
+		disttaeEngine *testutil.TestDisttaeEngine
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
+	schema.Name = tableName
+
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
+		ctx,
+		testutil.TestOptions{},
+		t,
+		// force the commit-time dump of the delete entries
+		testutil.WithDisttaeEngineInsertEntryMaxCount(5),
+	)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeEngine.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	_, _, err = disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableName, schema)
+	require.NoError(t, err)
+
+	rowsCount := 20
+	bat := containers.ToCNBatch(catalog2.MockBatch(schema, rowsCount))
+
+	// insert and commit the rows the deletes will target
+	{
+		_, relation, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableName)
+		require.NoError(t, err)
+		require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat, false, true))
+		require.NoError(t, txn.Commit(ctx))
+	}
+
+	fault.Enable()
+	defer fault.Disable()
+	require.NoError(t, fault.AddFaultPoint(
+		ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable, ":::", "echo", 1, "", false))
+	defer func() {
+		_, err := fault.RemoveFaultPoint(
+			ctx, objectio.FJ_CNReenterSnapshotOffsetOnGetTable)
+		require.NoError(t, err)
+	}()
+
+	// collect the rowids and pks of the first 10 rows
+	deleteRows := 10
+	tombstoneBat := batch.NewWithSize(2)
+	tombstoneBat.Attrs = []string{catalog.Row_ID, schema.GetPrimaryKey().Name}
+	tombstoneBat.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	tombstoneBat.Vecs[1] = vector.NewVec(schema.GetPrimaryKey().Type)
+
+	_, relation, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableName)
+	require.NoError(t, err)
+	{
+		reader, err := testutil.GetRelationReader(
+			ctx, disttaeEngine, txn, relation, nil, mp, t)
+		require.NoError(t, err)
+
+		ret := batch.NewWithSize(2)
+		ret.Attrs = []string{schema.GetPrimaryKey().Name, catalog.Row_ID}
+		ret.Vecs = []*vector.Vector{
+			vector.NewVec(schema.GetPrimaryKey().Type),
+			vector.NewVec(types.T_Rowid.ToType()),
+		}
+		for {
+			done, err := reader.Read(ctx, ret.Attrs, nil, mp, ret)
+			require.NoError(t, err)
+			if done {
+				break
+			}
+			for i := 0; i < ret.RowCount() && tombstoneBat.Vecs[0].Length() < deleteRows; i++ {
+				require.NoError(t, vector.AppendFixed[types.Rowid](
+					tombstoneBat.Vecs[0],
+					vector.GetFixedAtWithTypeCheck[types.Rowid](ret.Vecs[1], i),
+					false, mp))
+				require.NoError(t, vector.AppendFixed[int64](
+					tombstoneBat.Vecs[1],
+					vector.GetFixedAtWithTypeCheck[int64](ret.Vecs[0], i),
+					false, mp))
+			}
+		}
+		tombstoneBat.SetRowCount(tombstoneBat.Vecs[0].Length())
+		require.Equal(t, deleteRows, tombstoneBat.RowCount())
+	}
+
+	// two DELETE entries of one table in the same transaction
+	tb1, err := tombstoneBat.Window(0, deleteRows/2)
+	require.NoError(t, err)
+	tb2, err := tombstoneBat.Window(deleteRows/2, deleteRows)
+	require.NoError(t, err)
+	require.NoError(t, relation.Delete(ctx, tb1, catalog.Row_ID))
+	require.NoError(t, relation.Delete(ctx, tb2, catalog.Row_ID))
+
+	// the commit-time dump merges both entries into one tombstone object
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- txn.Commit(ctx)
+	}()
+	select {
+	case err = <-commitDone:
+		require.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("commit did not finish: delete dump deadlocked")
+	}
+
+	// the committed data must be complete
+	_, relation, txn, err = disttaeEngine.GetTable(ctx, databaseName, tableName)
+	require.NoError(t, err)
+	require.Equal(t, rowsCount-deleteRows, issue25557ReadRowCount(
+		t, ctx, disttaeEngine, txn, relation, schema, primaryKeyIdx, mp))
 	require.NoError(t, txn.Commit(ctx))
 }
 

--- a/pkg/vm/process/types.go
+++ b/pkg/vm/process/types.go
@@ -336,6 +336,13 @@ type BaseProcess struct {
 	logger              *log.MOLogger
 	TxnOperator         client.TxnOperator
 	CloneTxnOperator    client.TxnOperator
+	// incrStatementDisabled marks a process that executes internal SQL on a
+	// caller-owned transaction without opening a statement of its own
+	// (executor.Options.WithDisableIncrStatement). Compiles on such a process
+	// must not advance the workspace snapshot write offset: that is a
+	// statement-boundary action, and moving the boundary mid-statement breaks
+	// the positional visibility of the caller's workspace entries.
+	incrStatementDisabled bool
 
 	// post dml sqls run right after all pipelines finished.
 	PostDmlSqlList *threadsafe.Slice[string]
@@ -453,6 +460,19 @@ func (proc *Process) GetPrepareParamsAt(i int) ([]byte, error) {
 		val := proc.Base.prepareParams.GetRawBytesAt(i)
 		return val, nil
 	}
+}
+
+// SetIncrStatementDisabled marks this process (and every child process
+// sharing its BaseProcess) as running internal SQL that must not advance the
+// workspace snapshot write offset. See BaseProcess.incrStatementDisabled.
+func (proc *Process) SetIncrStatementDisabled(disabled bool) {
+	proc.Base.incrStatementDisabled = disabled
+}
+
+// IncrStatementDisabled reports whether compiles on this process must skip
+// advancing the workspace snapshot write offset.
+func (proc *Process) IncrStatementDisabled() bool {
+	return proc.Base.incrStatementDisabled
 }
 
 func (proc *Process) SetResolveVariableFunc(f func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error)) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #25557

## What this PR does / why we need it:

Cherry-pick of #25561 (base: 3.0-dev) onto main, squashed to the branch's net diff since the source PR is still open and its history contains superseded intermediate approaches.

Internal SQL executed from workspace-dump paths (`getTable` → `Engine.Database` → `loadDatabaseFromStorage` → `execReadSql` → `NewCompile`) used to re-enter `txn.Lock()` and store to the shared `snapshotWriteOffset`, corrupting the positional statement boundary of `txn.writes` (reentrant deadlock, mid-statement visibility corruption, and an `index out of range` panic under many-to-one workspace compaction).

### Fix

- Internal sub-sql compiles (`DisableIncrStatement`, marked on the process) capture a transient `Workspace.WriteOffset()` as their own `TxnOffset` and never advance the shared statement boundary.
- `snapshotWriteOffset` becomes an `atomic.Int64`: reads are lock-free, stores stay under `txn.Lock` at statement boundaries only.
- Workspace dumps resolve target tables before mutating `txn.writes`, releasing the lock around `getTable` and re-validating the offset after relock.
- `compactDeletionOnObjsLocked` pre-resolves tables so workers never call `getTable` while the parent holds the lock (commit deadlock).
- `Transaction.Commit` runs `mergeTxnWorkspaceLocked` + the final dump under one lock block.
- Fault-injection hooks + regressions (unit and e2e) cover multi-entry compaction, resolution-window append, object-compaction deadlock, and rogue boundary advance.

### Main-specific adaptations

- `UpdateSnapshotWriteOffset` keeps main's `adjustWriteOffset` in sync (`= len(txn.writes)`).
- Kept main's `txn.engine == nil` guard at the top of `getTable`.
- The `CNCommitAfterWorkspaceDumpFailed` injection now runs after the new `Commit` lock block.

Verified the net diff of this branch vs `main` matches the net diff of #25561 vs `3.0-dev` except for the adaptations above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)