### PR TITLE
fix: isolate account FK cleanup and UDF database checks

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -1344,7 +1344,8 @@ const (
        									    and privilege_id = %d 
        									    and privilege_level = "%s";`
 
-	checkDatabaseFormat = `select dat_id from mo_catalog.mo_database where datname = "%s";`
+	checkDatabaseFormat          = `select dat_id from mo_catalog.mo_database where datname = "%s";`
+	checkDatabaseByAccountFormat = `select dat_id from mo_catalog.mo_database where datname = "%s" and account_id = %d;`
 
 	checkDatabaseWithOwnerFormat = `select dat_id, owner from mo_catalog.mo_database where datname = "%s" and account_id = %d;`
 
@@ -2086,6 +2087,18 @@ func getSqlForCheckDatabase(ctx context.Context, dbName string) (string, error) 
 		return "", err
 	}
 	return fmt.Sprintf(checkDatabaseFormat, dbName), nil
+}
+
+func getSqlForCheckDatabaseByAccount(ctx context.Context, dbName string) (string, error) {
+	err := inputNameIsInvalid(ctx, dbName)
+	if err != nil {
+		return "", err
+	}
+	accountID, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(checkDatabaseByAccountFormat, dbName, accountID), nil
 }
 
 func getSqlForCheckDatabaseWithOwner(ctx context.Context, dbName string, accountId int64) (string, error) {
@@ -4360,6 +4373,12 @@ func doDropAccount(ctx context.Context, bh BackgroundExec, ses *Session, da *dro
 
 		return rtnErr
 	}
+
+	// The whole account is being removed, so cross-database foreign key
+	// metadata does not need to be rewritten while each database is dropped.
+	// Rewriting it can create a delete+insert catalog pair for a table in a
+	// database that will be dropped later in this transaction.
+	ctx = context.WithValue(ctx, defines.IgnoreForeignKey{}, true)
 
 	// disable foreign key checks
 	ctx = context.WithValue(ctx, defines.DisableFkCheck{}, true)
@@ -9743,7 +9762,7 @@ func checkDatabaseExistsOrNot(ctx context.Context, bh BackgroundExec, dbName str
 	var err error
 	ctx, span := trace.Debug(ctx, "checkTenantExistsOrNot")
 	defer span.End()
-	sqlForCheckDatabase, err = getSqlForCheckDatabase(ctx, dbName)
+	sqlForCheckDatabase, err = getSqlForCheckDatabaseByAccount(ctx, dbName)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -296,6 +296,7 @@ func Test_checkDatabaseExistsOrNot(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
+		ctx = defines.AttachAccountId(ctx, 0)
 
 		bh := mock_frontend.NewMockBackgroundExec(ctrl)
 		bh.EXPECT().Close().Return().AnyTimes()
@@ -314,6 +315,20 @@ func Test_checkDatabaseExistsOrNot(t *testing.T) {
 		convey.So(exists, convey.ShouldBeTrue)
 		convey.So(err, convey.ShouldBeNil)
 	})
+}
+
+func TestGetSqlForCheckDatabaseByAccountUsesAccountID(t *testing.T) {
+	ctx := defines.AttachAccountId(context.Background(), 42)
+
+	sql, err := getSqlForCheckDatabaseByAccount(ctx, "db1")
+	require.NoError(t, err)
+	require.Equal(t,
+		`select dat_id from mo_catalog.mo_database where datname = "db1" and account_id = 42;`,
+		sql,
+	)
+
+	_, err = getSqlForCheckDatabaseByAccount(context.Background(), "db1")
+	require.Error(t, err)
 }
 
 func Test_createTablesInMoCatalogOfGeneralTenant(t *testing.T) {
@@ -10530,7 +10545,8 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result[sql] = newMrsForSqlForGetSubs([][]interface{}{})
 
 		sql = "show databases;"
-		bh.sql2result[sql] = newMrsForSqlForShowDatabases([][]interface{}{})
+		bh.sql2result[sql] = newMrsForSqlForShowDatabases([][]interface{}{{"db1"}})
+		bh.sql2result["drop database if exists `db1`;"] = nil
 
 		bh.sql2result["show tables from mo_catalog;"] = newMrsForShowTables([][]interface{}{})
 
@@ -10539,6 +10555,7 @@ func Test_doDropAccount(t *testing.T) {
 			Name:     mustUnboxExprStr(stmt.Name),
 		})
 		convey.So(err, convey.ShouldBeNil)
+		convey.So(bh.dropDatabaseIgnoresForeignKeys, convey.ShouldBeTrue)
 	})
 	convey.Convey("drop account (if exists)", t, func() {
 		ctrl := gomock.NewController(t)
@@ -11134,10 +11151,11 @@ func newBh(ctrl *gomock.Controller, sql2result map[string]ExecResult) Background
 }
 
 type backgroundExecTest struct {
-	currentSql   string
-	sql2result   map[string]ExecResult
-	sql2err      map[string]error
-	executedSQLs []string
+	currentSql                     string
+	sql2result                     map[string]ExecResult
+	sql2err                        map[string]error
+	executedSQLs                   []string
+	dropDatabaseIgnoresForeignKeys bool
 }
 
 func (bt *backgroundExecTest) ExecStmt(ctx context.Context, statement tree.Statement) error {
@@ -11174,6 +11192,9 @@ func (bt *backgroundExecTest) GetExecStatsArray() statistic.StatsArray {
 func (bt *backgroundExecTest) Exec(ctx context.Context, s string) error {
 	bt.currentSql = s
 	bt.executedSQLs = append(bt.executedSQLs, s)
+	if strings.HasPrefix(s, "drop database if exists ") {
+		bt.dropDatabaseIgnoresForeignKeys, _ = ctx.Value(defines.IgnoreForeignKey{}).(bool)
+	}
 	return bt.sql2err[s]
 }
 

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -179,10 +179,16 @@ func (s *Scope) DropDatabase(c *Compile) error {
 		}
 	}
 
-	// whether foreign_key_checks = 0 or 1
-	err = s.removeFkeysRelationships(c, dbName)
-	if err != nil {
-		return err
+	// Internal callers such as DROP ACCOUNT remove every database in the
+	// account. In that case, rewriting cross-database FK metadata is both
+	// unnecessary and unsafe: a later DROP can observe both catalog versions
+	// produced by the rewrite in this transaction.
+	ignoreForeignKey, _ := c.proc.Ctx.Value(defines.IgnoreForeignKey{}).(bool)
+	if !ignoreForeignKey {
+		err = s.removeFkeysRelationships(c, dbName)
+		if err != nil {
+			return err
+		}
 	}
 
 	database, err := c.e.Database(c.proc.Ctx, dbName, c.proc.GetTxnOperator())

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -1261,6 +1261,58 @@ func TestDropDatabaseSkipsDeletedRelationsWhenCollectingTables(t *testing.T) {
 	require.ErrorIs(t, s.DropDatabase(c), deleteStopErr)
 }
 
+func TestDropDatabaseSkipsForeignKeyCleanupWhenIgnored(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := testutil.NewProcess(t)
+	proc.Base.SessionInfo.Buf = buffer.New()
+	ctx := defines.AttachAccountId(context.Background(), sysAccountId)
+	ctx = context.WithValue(ctx, defines.IgnoreForeignKey{}, true)
+	proc.Ctx = ctx
+	proc.ReplaceTopCtx(ctx)
+
+	txnMeta := txn.TxnMeta{}
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().Txn().Return(txnMeta).AnyTimes()
+	txnOp.EXPECT().SnapshotTS().Return(timestamp.Timestamp{}).AnyTimes()
+	txnOp.EXPECT().SetSnapshotTS(gomock.Any()).AnyTimes()
+	txnOp.EXPECT().GetWorkspace().Return(&Ws{}).AnyTimes()
+	proc.Base.TxnOperator = txnOp
+
+	stopErr := moerr.NewInternalError(ctx, "stop after FK cleanup check")
+	mockDb := mock_frontend.NewMockDatabase(ctrl)
+	mockDb.EXPECT().IsSubscription(gomock.Any()).Return(false).AnyTimes()
+	mockDb.EXPECT().GetDatabaseId(gomock.Any()).Return("invalid").AnyTimes()
+	mockDb.EXPECT().Relations(gomock.Any()).Return(nil, stopErr).Times(1)
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	// The first lookup opens the database; the second collects its tables.
+	// A third lookup would mean removeFkeysRelationships was not skipped.
+	eng.EXPECT().Database(gomock.Any(), "db1", gomock.Any()).Return(mockDb, nil).Times(2)
+
+	lockMoDb := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error {
+		return nil
+	})
+	defer lockMoDb.Reset()
+
+	dropDbDef := &plan2.DropDatabase{Database: "db1"}
+	cplan := &plan.Plan{
+		Plan: &plan2.Plan_Ddl{
+			Ddl: &plan2.DataDefinition{
+				DdlType: plan2.DataDefinition_DROP_DATABASE,
+				Definition: &plan2.DataDefinition_DropDatabase{
+					DropDatabase: dropDbDef,
+				},
+			},
+		},
+	}
+	s := &Scope{Magic: DropDatabase, Plan: cplan}
+	c := NewCompile("test", "test", "drop database db1", "", "", eng, proc, nil, false, nil, time.Now())
+
+	require.ErrorIs(t, s.DropDatabase(c), stopErr)
+}
+
 func TestDropDatabaseReturnsInternalRelationErrorWhenCollectingTables(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25680

## What this PR does / why we need it:

`DROP ACCOUNT` disables foreign-key enforcement but still rewrites cross-database FK metadata while dropping each database. Because the databases are collected in a Go map, a referenced database can be dropped before its child database. That rewrite leaves a delete+insert catalog pair for the child table in the same transaction, and the later table drop can read both versions and panic in `disttae.deleteTable`.

This change marks account-wide cleanup with `IgnoreForeignKey` and makes `DropDatabase` skip FK relationship rewrites for that internal path. All databases in the account are being removed, so no surviving relation needs the metadata update.

The failed account drop also exposed a second tenant-isolation issue: UDF database existence checks queried `mo_database` by name only, so sys could mistake another tenant's database for its own. The UDF-specific check now includes the current `account_id`.

Regression tests verify that the flag is propagated from `DROP ACCOUNT` into database drops, that `DropDatabase` skips FK cleanup only when requested, and that UDF database checks include the tenant ID.

Tested with:

`go test -count=1 -timeout 180s ./pkg/frontend`

`go test -count=1 -timeout 180s ./pkg/sql/compile`

`go build ./pkg/frontend ./pkg/sql/compile`

`go vet ./pkg/frontend ./pkg/sql/compile`
