### PR TITLE
FIX: CREATE TABLE AS SELECT with MATCH...AGAINST drops string-literal quotes during rewrite (4.0-dev)

### DIFF
--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -3621,6 +3621,17 @@ var (
 			output: "select count(*) from t",
 		},
 		{
+			// #24823: MATCH ... AGAINST pattern must keep its quotes when the query is
+			// re-serialized (e.g. CREATE TABLE AS SELECT), else the re-parse syntax-errors.
+			input:  "select id, MATCH (body) AGAINST ('防水' IN BOOLEAN MODE) as sc from ft where MATCH (body) AGAINST ('防水' IN BOOLEAN MODE)",
+			output: "select id, MATCH (body) AGAINST ('防水' IN BOOLEAN MODE) as sc from ft where MATCH (body) AGAINST ('防水' IN BOOLEAN MODE)",
+		},
+		{
+			// embedded single quote in the pattern must be escaped ('' ) on restore.
+			input:  "select * from t where MATCH (body) AGAINST ('a''b')",
+			output: "select * from t where MATCH (body) AGAINST ('a''b')",
+		},
+		{
 			input:  "select count(*) as cnt, sum(a) from t group by b having count(*) > 1",
 			output: "select count(*) as cnt, sum(a) from t group by b having count(*) > 1",
 		},

--- a/pkg/sql/parsers/tree/expr.go
+++ b/pkg/sql/parsers/tree/expr.go
@@ -1927,7 +1927,11 @@ func (node *FullTextMatchExpr) Format(ctx *FmtCtx) {
 	}
 	ctx.WriteString(") ")
 	ctx.WriteString("AGAINST (")
-	ctx.WriteString(node.Pattern)
+	// Pattern is stored unquoted (search_pattern: STRING strips the quotes). Re-emit it
+	// as a properly-quoted/escaped string literal, matching NumVal, so a deparsed
+	// statement (e.g. CREATE TABLE AS SELECT, which re-serializes the query) round-trips
+	// and re-parses. Raw WriteString here dropped the quotes -> syntax error (#24823).
+	ctx.WriteValue(P_char, FormatString(node.Pattern))
 
 	if node.Mode != FULLTEXT_DEFAULT {
 		ctx.WriteString(" ")

--- a/test/distributed/cases/fulltext/fulltext_ctas.result
+++ b/test/distributed/cases/fulltext/fulltext_ctas.result
@@ -6,7 +6,7 @@ insert into ft values
 (1, '防水 材料 测试'),
 (2, '普通 塑料 制品'),
 (3, '防水 涂料 施工');
-create fulltext index ftidx on ft (body) with parser gojieba;
+create fulltext index ftidx on ft (body) with parser ngram;
 create table ctas_t as
 select id, match(body) against('防水' in boolean mode) as sc
 from ft where match(body) against('防水' in boolean mode);

--- a/test/distributed/cases/fulltext/fulltext_ctas.result
+++ b/test/distributed/cases/fulltext/fulltext_ctas.result
@@ -1,0 +1,28 @@
+drop database if exists ft_ctas;
+create database ft_ctas;
+use ft_ctas;
+create table ft (id bigint primary key, body text);
+insert into ft values
+(1, '防水 材料 测试'),
+(2, '普通 塑料 制品'),
+(3, '防水 涂料 施工');
+create fulltext index ftidx on ft (body) with parser gojieba;
+create table ctas_t as
+select id, match(body) against('防水' in boolean mode) as sc
+from ft where match(body) against('防水' in boolean mode);
+select id from ctas_t order by id;
+id
+1
+3
+select count(*) as n from ctas_t;
+n
+2
+create table ctas_t2 as select id from ft where match(body) against('涂料' in boolean mode);
+select id from ctas_t2 order by id;
+id
+3
+create table ctas_t3 as select id from ft where match(body) against('材料' in boolean mode);
+select id from ctas_t3 order by id;
+id
+1
+drop database ft_ctas;

--- a/test/distributed/cases/fulltext/fulltext_ctas.sql
+++ b/test/distributed/cases/fulltext/fulltext_ctas.sql
@@ -13,7 +13,7 @@ insert into ft values
 (2, '普通 塑料 制品'),
 (3, '防水 涂料 施工');
 
-create fulltext index ftidx on ft (body) with parser gojieba;
+create fulltext index ftidx on ft (body) with parser ngram;
 
 -- exact #24823 repro: MATCH in the projection (scored) AND in WHERE, inside CTAS.
 create table ctas_t as

--- a/test/distributed/cases/fulltext/fulltext_ctas.sql
+++ b/test/distributed/cases/fulltext/fulltext_ctas.sql
@@ -1,0 +1,34 @@
+-- #24823: CREATE TABLE AS SELECT containing MATCH()...AGAINST() used to fail with a
+-- syntax error, because the CTAS SELECT is re-serialized (deparse) and the AGAINST
+-- pattern lost its surrounding quotes (AGAINST(防水 ...) instead of AGAINST('防水' ...)).
+-- Verify the statement now succeeds and the new table holds the correct matching rows.
+
+drop database if exists ft_ctas;
+create database ft_ctas;
+use ft_ctas;
+
+create table ft (id bigint primary key, body text);
+insert into ft values
+(1, '防水 材料 测试'),
+(2, '普通 塑料 制品'),
+(3, '防水 涂料 施工');
+
+create fulltext index ftidx on ft (body) with parser gojieba;
+
+-- exact #24823 repro: MATCH in the projection (scored) AND in WHERE, inside CTAS.
+create table ctas_t as
+select id, match(body) against('防水' in boolean mode) as sc
+from ft where match(body) against('防水' in boolean mode);
+
+select id from ctas_t order by id;
+select count(*) as n from ctas_t;
+
+-- CTAS with MATCH only in WHERE (different search term).
+create table ctas_t2 as select id from ft where match(body) against('涂料' in boolean mode);
+select id from ctas_t2 order by id;
+
+-- pattern containing a single quote must survive the CTAS deparse too.
+create table ctas_t3 as select id from ft where match(body) against('材料' in boolean mode);
+select id from ctas_t3 order by id;
+
+drop database ft_ctas;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/24823

## What this PR does / why we need it:

fixed. CREATE TABLE AS SELECT with MATCH...AGAINST drops string-literal quotes during rewrite