### PR TITLE
fix: wait for remote receivers on empty dispatch

### DIFF
--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -136,6 +136,15 @@ func (dispatch *Dispatch) Call(proc *process.Process) (vm.CallResult, error) {
 
 	whichToSend := result.Batch
 	if result.Batch == nil {
+		// A remote dispatch must attach every receiver even when its child
+		// produces no batches. Otherwise an early NotRegistered response can
+		// outlive this pipeline: cleanup removes the registration before the
+		// client's next retry, which then retries until the query timeout.
+		if dispatch.ctr.isRemote && !dispatch.ctr.prepared {
+			if _, err = dispatch.waitRemoteRegsReady(proc); err != nil {
+				return result, err
+			}
+		}
 		result.Status = vm.ExecStop
 		printShuffleResult(dispatch)
 		return result, nil

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -30,9 +30,21 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/value_scan"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+type emptyDispatchChild struct {
+	*value_scan.ValueScan
+	called chan struct{}
+}
+
+func (child *emptyDispatchChild) Call(*process.Process) (vm.CallResult, error) {
+	close(child.called)
+	return vm.NewCallResult(), nil
+}
 
 func TestPrepareRemote(t *testing.T) {
 	_ = colexec.NewServer(nil)
@@ -264,6 +276,106 @@ func TestWaitRemoteRegsReadyPropagatesCancelCause(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("waitRemoteRegsReady did not return after proc cancellation")
 	}
+}
+
+func TestDispatchEmptyInputWaitsForRemoteReceiver(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	proc := testutil.NewProcess(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	proc.Ctx = ctx
+
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	child := &emptyDispatchChild{
+		ValueScan: value_scan.NewArgument(),
+		called:    make(chan struct{}),
+	}
+	defer child.Release()
+	require.NoError(t, child.Prepare(proc))
+
+	d := NewArgument()
+	defer d.Release()
+	d.FuncId = SendToAllFunc
+	d.RemoteRegs = []colexec.ReceiveInfo{{Uuid: uid}}
+	d.AppendChild(child)
+
+	registration, err := d.RegisterRemoteReceiversWithHandle(proc)
+	require.NoError(t, err)
+	require.NotNil(t, registration)
+	defer registration.Cleanup()
+	require.NoError(t, d.Prepare(proc))
+
+	attached := make(chan struct{})
+	go func() {
+		select {
+		case <-child.called:
+		case <-ctx.Done():
+			return
+		}
+		registeredProc, notifyCh, ok := colexec.Get().GetProcByUuid(uid, false)
+		if !ok || registeredProc != proc {
+			return
+		}
+		select {
+		case notifyCh <- &process.WrapCs{Uid: uid, Err: make(chan error, 1)}:
+			close(attached)
+		case <-ctx.Done():
+		}
+	}()
+
+	result, err := d.Call(proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, result.Status)
+	require.True(t, d.ctr.prepared)
+	require.Len(t, d.ctr.remoteReceivers, 1)
+	select {
+	case <-attached:
+	default:
+		t.Fatal("empty dispatch returned before its remote receiver attached")
+	}
+}
+
+func TestDispatchEmptyInputRemoteWaitPropagatesCancellation(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	proc := testutil.NewProcess(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	proc.Ctx = ctx
+	proc.Cancel = cancel
+
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	child := &emptyDispatchChild{
+		ValueScan: value_scan.NewArgument(),
+		called:    make(chan struct{}),
+	}
+	defer child.Release()
+	require.NoError(t, child.Prepare(proc))
+
+	d := NewArgument()
+	defer d.Release()
+	d.FuncId = SendToAllFunc
+	d.RemoteRegs = []colexec.ReceiveInfo{{Uuid: uid}}
+	d.AppendChild(child)
+
+	registration, err := d.RegisterRemoteReceiversWithHandle(proc)
+	require.NoError(t, err)
+	require.NotNil(t, registration)
+	defer registration.Cleanup()
+	require.NoError(t, d.Prepare(proc))
+
+	want := moerr.NewInternalErrorNoCtx("query canceled while waiting for remote receiver")
+	go func() {
+		<-child.called
+		cancel(want)
+	}()
+
+	result, err := d.Call(proc)
+	require.ErrorIs(t, err, want)
+	require.Nil(t, result.Batch)
+	require.True(t, d.ctr.prepared)
 }
 
 func TestDispatchAdoptCleanupState_TransfersOwnership(t *testing.T) {

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -1308,6 +1308,141 @@ func TestSendNotifyMessageRetriesUntilRemoteDispatchRegistered(t *testing.T) {
 	require.Equal(t, 2, attempts)
 }
 
+func TestRemoteNotifyRetryAttachesToEmptyDispatchBeforeCompletion(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	proc := testutil.NewProcess(t)
+	proc.BuildPipelineContext(ctx)
+	scopeProc := proc.NewContextChildProc(1)
+
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	s := &Scope{
+		Proc: scopeProc,
+		RemoteReceivRegInfos: []RemoteReceivRegInfo{
+			{Idx: 0, Uuid: uid, FromAddr: "remote-cn"},
+		},
+	}
+
+	firstLookupDone := make(chan struct{})
+	allowFirstResponse := make(chan struct{})
+	var attempts atomic.Int32
+	factory := func(
+		ctx context.Context,
+		sid string,
+		toAddr string,
+		mp *mpool.MPool,
+		analyzeModule *AnalyzeModule,
+	) (*messageSenderOnClient, error) {
+		receiveCh := make(chan morpc.Message, 1)
+		receiver := &messageReceiverOnServer{
+			connectionCtx: ctx,
+			messageCtx:    ctx,
+		}
+		if attempts.Add(1) == 1 {
+			_, _, lookupErr := receiver.TryGetProcByUuid(uid)
+			close(firstLookupDone)
+			if lookupErr == nil {
+				unexpected := errors.New("first remote notify unexpectedly found the registration")
+				cancel()
+				return nil, unexpected
+			}
+			select {
+			case <-allowFirstResponse:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			msg := &pipeline.Message{Sid: pipeline.Status_MessageEnd}
+			msg.SetMoError(ctx, lookupErr)
+			receiveCh <- msg
+		} else {
+			dispatchProc, notifyCh, lookupErr := receiver.TryGetProcByUuid(uid)
+			if lookupErr != nil {
+				cancel()
+				return nil, lookupErr
+			}
+			if dispatchProc == nil {
+				unexpected := errors.New("registered remote dispatch returned a nil process")
+				cancel()
+				return nil, unexpected
+			}
+			wrap := &process.WrapCs{Uid: uid, Err: make(chan error, 1)}
+			go func() {
+				select {
+				case notifyCh <- wrap:
+				case <-ctx.Done():
+					return
+				}
+				select {
+				case terminalErr := <-wrap.Err:
+					msg := &pipeline.Message{Sid: pipeline.Status_MessageEnd}
+					if terminalErr != nil {
+						msg.SetMoError(ctx, terminalErr)
+					}
+					receiveCh <- msg
+				case <-ctx.Done():
+				}
+			}()
+		}
+		return &messageSenderOnClient{
+			ctx:          ctx,
+			mp:           mp,
+			streamSender: &fakeStreamSender{},
+			receiveCh:    receiveCh,
+			safeToClose:  true,
+		}, nil
+	}
+
+	var wg sync.WaitGroup
+	resultCh := make(chan notifyMessageResult, 1)
+	s.sendNotifyMessageWithFactory(&wg, resultCh, factory)
+	select {
+	case <-firstLookupDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first remote notify did not observe the absent registration")
+	}
+
+	child := value_scan.NewArgument()
+	defer child.Release()
+	require.NoError(t, child.Prepare(proc))
+	dispatchOp := dispatch.NewArgument()
+	defer dispatchOp.Release()
+	dispatchOp.FuncId = dispatch.SendToAllFunc
+	dispatchOp.RemoteRegs = []colexec.ReceiveInfo{{Uuid: uid}}
+	dispatchOp.AppendChild(child)
+	registration, err := dispatchOp.RegisterRemoteReceiversWithHandle(proc)
+	require.NoError(t, err)
+	require.NotNil(t, registration)
+	defer registration.Cleanup()
+	require.NoError(t, dispatchOp.Prepare(proc))
+	close(allowFirstResponse)
+
+	callResult, err := dispatchOp.Call(proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, callResult.Status)
+	dispatchOp.Reset(proc, false, nil)
+
+	select {
+	case result := <-resultCh:
+		result.clean(scopeProc)
+		require.NoError(t, result.err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("remote notify did not complete after the empty dispatch registered")
+	}
+	select {
+	case signal := <-scopeProc.Reg.MergeReceivers[0].Ch2:
+		bat, signalErr := signal.Action()
+		require.NoError(t, signalErr)
+		require.Nil(t, bat)
+	case <-time.After(5 * time.Second):
+		t.Fatal("remote receiver did not observe the empty dispatch terminal signal")
+	}
+	wg.Wait()
+	require.Equal(t, int32(2), attempts.Load())
+}
+
 func TestSendNotifyMessageWrapperWithNoRemoteReceivers(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	proc.BuildPipelineContext(context.Background())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25687

## What this PR does / why we need it:

A remote dispatch currently waits for receiver attachment only when a data batch reaches its send function. If the child produces no batches, Dispatch.Call returns ExecStop immediately. An early RemoteDispatchNotRegistered response can then outlive the producer: cleanup removes the newly published UUID before the client's 200 ms retry, and all later retries fail until the 30-second timeout.

This PR restores the remote-dispatch lifecycle invariant at the producer boundary: successful terminal completion waits for all remote receivers even when the input is empty. It reuses the existing receiver barrier, context cancellation, and 30-second upper bound.

The production change is intentionally limited to the zero-batch remote path:

- non-empty dispatch is unchanged;
- local-only dispatch is unchanged;
- an already attached empty dispatch adds only two boolean checks;
- a racing registration waits for the existing notify retry instead of failing after 30 seconds;
- cancellation and unreachable receivers return through the existing bounded error paths;
- no protocol, lock, goroutine, retry interval, or retained state is added.

The regression tests cover direct empty-input attachment, cancellation-cause propagation, and the exact end-to-end interleaving where the first notify misses registration, the producer registers and becomes empty, and the retry must attach before terminal cleanup. The direct test was also run with the production fix removed and failed immediately, proving that it detects the original bug.

## Testing

- make -j12
- make dev-build
- go test ./pkg/sql/colexec/dispatch
- go test ./pkg/sql/compile
- go test -race for the empty-dispatch tests
- go test -race for TestRemoteNotifyRetryAttachesToEmptyDispatchBeforeCompletion
- go vet ./pkg/sql/colexec/dispatch ./pkg/sql/compile
- go vet with molint for both affected packages
- golangci-lint run -c .golangci.yml ./pkg/sql/colexec/dispatch ./pkg/sql/compile
- Multi-CN Docker reproduction with 5M, 4M, and 1M-row tables: expected result 499999
  - concurrency 8: 200/200 passed; unfixed code failed 4/200
  - concurrency 16: 100/100 passed
