### PR TITLE
test(proxy): stabilize early handshake failure test

### DIFF
--- a/pkg/proxy/server_conn_test.go
+++ b/pkg/proxy/server_conn_test.go
@@ -600,20 +600,66 @@ func TestServerConn_HandleHandshakeEarlyReadFailureIsNotTimeout(t *testing.T) {
 	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
 	tp := newTestProxyHandler(t)
 	defer tp.closeFn()
+	backendAccepted := make(chan struct{})
+	allowBackendClose := make(chan struct{})
+	backendClosed := make(chan struct{})
 	stopFn := startTestCNServer(t, tp.ctx, addr, nil, withHandle(func(h *testHandler) {
-		// Simulate an immediate post-dial backend failure before the CN sends
-		// its initial handshake.
+		// startTestCNServer probes readiness without sending ExtraInfo. The
+		// connection opened by newServerConn does send it, so decode the wire
+		// protocol instead of relying on handler goroutine scheduling order.
+		rawConn := h.conn.RawConn()
+		if err := rawConn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+			h.close()
+			return
+		}
+		reader := bufio.NewReader(rawConn)
+		extraInfo := proxy.ExtraInfo{}
+		if err := extraInfo.Decode(reader); err != nil {
+			h.close()
+			return
+		}
+		if err := rawConn.SetReadDeadline(time.Time{}); err != nil {
+			h.close()
+			return
+		}
+
+		close(backendAccepted)
+		select {
+		case <-allowBackendClose:
+		case <-tp.ctx.Done():
+		}
 		h.close()
+		close(backendClosed)
 	}))
+	var releaseBackendOnce sync.Once
+	releaseBackend := func() {
+		releaseBackendOnce.Do(func() {
+			close(allowBackendClose)
+		})
+	}
 	defer func() {
+		releaseBackend()
 		require.NoError(t, stopFn())
 	}()
+	waitSignal := func(c <-chan struct{}, message string) {
+		t.Helper()
+		select {
+		case <-c:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, message)
+		}
+	}
 
 	sc, err := newServerConn(cn1, nil, tp.re, 0)
 	require.NoError(t, err)
 	require.NotNil(t, sc)
 	defer sc.Close()
 
+	// Close only after newServerConn has sent ExtraInfo successfully, then make
+	// HandleHandshake observe the intended pre-handshake backend failure.
+	waitSignal(backendAccepted, "timed out waiting for test CN connection")
+	releaseBackend()
+	waitSignal(backendClosed, "timed out closing test CN connection")
 	_, err = sc.HandleHandshake(&frontend.Packet{Payload: []byte{1}}, time.Second)
 	require.Error(t, err)
 	require.False(t, isTimeoutErr(err), "early backend close must not be reclassified as timeout/busy")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #24919

## What this PR does / why we need it:

Stabilize `TestServerConn_HandleHandshakeEarlyReadFailureIsNotTimeout` without changing its intended coverage.

The test CN readiness probe and the real proxy connection both invoke the custom handler. Closing every accepted connection made the readiness probe race with the real connection, so `newServerConn` could fail while writing `ExtraInfo` with `broken pipe` before the test reached `HandleHandshake`.

This change:

- identifies the real proxy connection by decoding its `ExtraInfo` instead of relying on accept or goroutine order;
- lets `newServerConn` finish, then closes the CN before it sends the initial MySQL handshake;
- continues to assert that the first `HandleHandshake` read returns a real error that is not classified as timeout/busy;
- bounds all test waits and protocol reads and releases the handler on cleanup.

Validation:

- target test repeated 200 times;
- target test under the race detector, repeated 50 times;
- full `pkg/proxy` test package.
