### PR TITLE
fix(parser): quote FULLTEXT MATCH...AGAINST pattern on the default deparse path 

### DIFF
--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -3530,27 +3530,27 @@ var (
 		},
 		{
 			input:  "select * from t1 where MATCH (body, title) AGAINST ('abc dfc ghc')",
-			output: "select * from t1 where MATCH (body, title) AGAINST (abc dfc ghc)",
+			output: "select * from t1 where MATCH (body, title) AGAINST ('abc dfc ghc')",
 		},
 		{
 			input:  "select * from t1 where MATCH (body, title) AGAINST ('abc- +abc' IN BOOLEAN MODE)",
-			output: "select * from t1 where MATCH (body, title) AGAINST (abc- +abc IN BOOLEAN MODE)",
+			output: "select * from t1 where MATCH (body, title) AGAINST ('abc- +abc' IN BOOLEAN MODE)",
 		},
 		{
 			input:  "select * from t1 where MATCH (body, title) AGAINST ('abc%' IN NATURAL LANGUAGE MODE)",
-			output: "select * from t1 where MATCH (body, title) AGAINST (abc% IN NATURAL LANGUAGE MODE)",
+			output: "select * from t1 where MATCH (body, title) AGAINST ('abc%' IN NATURAL LANGUAGE MODE)",
 		},
 		{
 			input:  "select * from t1 where MATCH (body, title) AGAINST ('abc gg*' WITH QUERY EXPANSION)",
-			output: "select * from t1 where MATCH (body, title) AGAINST (abc gg* WITH QUERY EXPANSION)",
+			output: "select * from t1 where MATCH (body, title) AGAINST ('abc gg*' WITH QUERY EXPANSION)",
 		},
 		{
 			input:  "select * from t1 where MATCH (body, title) AGAINST ('abc' IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION)",
-			output: "select * from t1 where MATCH (body, title) AGAINST (abc IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION)",
+			output: "select * from t1 where MATCH (body, title) AGAINST ('abc' IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION)",
 		},
 		{
 			input:  "select MATCH (body, title) AGAINST ('abc' IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION) from t1",
-			output: "select MATCH (body, title) AGAINST (abc IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION) from t1",
+			output: "select MATCH (body, title) AGAINST ('abc' IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION) from t1",
 		},
 		{
 			input:  "alter user user1 unlock",
@@ -3707,6 +3707,35 @@ func TestValid(t *testing.T) {
 			t.Errorf("Parsing failed. \nExpected/Got:\n%s\n%s", tcase.output, out)
 		}
 		ast.StmtKind()
+	}
+}
+
+// TestFullTextMatchDeparseRoundTrip is the #24823 regression on the DEFAULT tree.String path
+// (not only the WithSingleQuoteString path): MATCH(...) AGAINST('...') must deparse to a
+// quoted, re-parseable string literal so re-serialized statements (CREATE TABLE AS SELECT,
+// view expansion, etc.) round-trip. Before the fix the default path emitted the pattern bare
+// (AGAINST (防水 ...)) which is invalid SQL.
+func TestFullTextMatchDeparseRoundTrip(t *testing.T) {
+	ctx := context.TODO()
+	cases := []string{
+		"select * from t where MATCH (body) AGAINST ('防水' IN BOOLEAN MODE)",
+		"select * from t where MATCH (a, b) AGAINST ('abc dfc')",
+		"select MATCH (body) AGAINST ('abc%' IN NATURAL LANGUAGE MODE) from t",
+		// embedded single quote must survive escaping on the default path
+		"select * from t where MATCH (body) AGAINST ('it''s a test')",
+	}
+	for _, sql := range cases {
+		ast, err := ParseOne(ctx, sql, 1)
+		require.NoError(t, err, sql)
+
+		// DEFAULT path (no WithSingleQuoteString / WithQuoteString).
+		out := tree.String(ast, dialect.MYSQL)
+		require.Contains(t, out, "AGAINST ('", "default deparse must quote the pattern, got: "+out)
+
+		// The deparsed SQL must re-parse and be idempotent under further deparse.
+		ast2, err := ParseOne(ctx, out, 1)
+		require.NoError(t, err, "deparsed SQL must re-parse: "+out)
+		require.Equal(t, out, tree.String(ast2, dialect.MYSQL), "deparse must be idempotent")
 	}
 }
 

--- a/pkg/sql/parsers/tree/expr.go
+++ b/pkg/sql/parsers/tree/expr.go
@@ -1927,7 +1927,15 @@ func (node *FullTextMatchExpr) Format(ctx *FmtCtx) {
 	}
 	ctx.WriteString(") ")
 	ctx.WriteString("AGAINST (")
-	ctx.WriteString(node.Pattern)
+	// Pattern is ALWAYS a string literal and is stored unquoted (search_pattern: STRING strips
+	// the surrounding quotes). Emit it as a single-quoted, escaped SQL string literal
+	// UNCONDITIONALLY. Writing it bare produced invalid SQL that failed to re-parse whenever a
+	// statement is re-serialized (CREATE TABLE AS SELECT, view expansion, or any other deparse)
+	// (#24823). Unconditional quoting is correct here precisely because the pattern is never a
+	// number/null/bool (unlike the polymorphic NumVal) — bare output is never valid SQL.
+	ctx.WriteString("'")
+	ctx.WriteString(strings.ReplaceAll(FormatString(node.Pattern), "'", "''"))
+	ctx.WriteString("'")
 
 	if node.Mode != FULLTEXT_DEFAULT {
 		ctx.WriteString(" ")


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/24823

## What this PR does / why we need it:

FullTextMatchExpr.Format wrote the AGAINST pattern bare (ctx.WriteString(node.Pattern)), so any re-serialization through tree.String (CREATE TABLE AS SELECT, view expansion, etc.) produced invalid, un-reparseable SQL (AGAINST (防水 ...)).

The pattern is ALWAYS a string literal (unlike the polymorphic NumVal), so emit it single-quoted and escaped unconditionally. The node now round-trips on every formatter path.

Regression coverage on the DEFAULT path: correct the six validSQL expectations in TestValid (which run through tree.String) from bare to quoted, and add TestFullTextMatchDeparseRoundTrip (default-path deparse -> re-parse -> idempotent), covering CJK and an embedded single quote.
