### PR TITLE
fix(tae): propagate debug request errors

### DIFF
--- a/pkg/txn/storage/tae/storage_debug.go
+++ b/pkg/txn/storage/tae/storage_debug.go
@@ -32,7 +32,7 @@ func (s *taeStorage) Debug(ctx context.Context,
 	data []byte) ([]byte, error) {
 	switch opCode {
 	case uint32(api.OpCode_OpPing):
-		return s.handlePing(data), nil
+		return s.handlePing(data)
 	case uint32(api.OpCode_OpFlush):
 		_, err := handleRead(ctx, txnMeta, data, s.taeHandler.HandleFlushTable)
 		if err != nil {
@@ -107,7 +107,10 @@ func (s *taeStorage) Debug(ctx context.Context,
 		return []byte(ret), nil
 
 	case uint32(api.OpCode_OpStorageUsage):
-		resp, _ := handleRead(ctx, txnMeta, data, s.taeHandler.HandleStorageUsage)
+		resp, err := handleRead(ctx, txnMeta, data, s.taeHandler.HandleStorageUsage)
+		if err != nil {
+			return nil, err
+		}
 		return resp.Read()
 	case uint32(api.OpCode_OpSnapshotRead):
 		resp, err := handleRead(ctx, txnMeta, data, s.taeHandler.HandleSnapshotRead)
@@ -154,14 +157,16 @@ func (s *taeStorage) Debug(ctx context.Context,
 	}
 }
 
-func (s *taeStorage) handlePing(data []byte) []byte {
+func (s *taeStorage) handlePing(data []byte) ([]byte, error) {
 	req := api.TNPingRequest{}
-	protoc.MustUnmarshal(&req, data)
+	if err := req.Unmarshal(data); err != nil {
+		return nil, err
+	}
 
-	return protoc.MustMarshal(&api.TNPingResponse{
+	return (&api.TNPingResponse{
 		ShardID:        s.shard.ShardID,
 		ReplicaID:      s.shard.ReplicaID,
 		LogShardID:     s.shard.LogShardID,
 		ServiceAddress: s.shard.Address,
-	})
+	}).Marshal()
 }

--- a/pkg/txn/storage/tae/storage_debug_test.go
+++ b/pkg/txn/storage/tae/storage_debug_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taestorage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/api"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/cmd_util"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/rpchandle"
+	"github.com/stretchr/testify/require"
+)
+
+var errStorageUsage = errors.New("storage usage failed")
+
+type storageUsageErrorHandler struct {
+	rpchandle.Handler
+}
+
+func (h *storageUsageErrorHandler) HandleStorageUsage(
+	context.Context,
+	txn.TxnMeta,
+	*cmd_util.StorageUsageReq,
+	*cmd_util.StorageUsageResp_V3,
+) (func(), error) {
+	return nil, errStorageUsage
+}
+
+func TestDebugStorageUsageReturnsHandlerError(t *testing.T) {
+	payload, err := (&cmd_util.StorageUsageReq{}).MarshalBinary()
+	require.NoError(t, err)
+
+	s := &taeStorage{taeHandler: &storageUsageErrorHandler{}}
+	resp, err := s.Debug(
+		context.Background(),
+		txn.TxnMeta{},
+		uint32(api.OpCode_OpStorageUsage),
+		payload,
+	)
+	require.ErrorIs(t, err, errStorageUsage)
+	require.Nil(t, resp)
+}
+
+func TestDebugStorageUsageReturnsDecodeError(t *testing.T) {
+	s := &taeStorage{taeHandler: &storageUsageErrorHandler{}}
+	resp, err := s.Debug(
+		context.Background(),
+		txn.TxnMeta{},
+		uint32(api.OpCode_OpStorageUsage),
+		[]byte{0xff},
+	)
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestDebugPingReturnsDecodeError(t *testing.T) {
+	s := &taeStorage{}
+	resp, err := s.Debug(
+		context.Background(),
+		txn.TxnMeta{},
+		uint32(api.OpCode_OpPing),
+		[]byte{0xff},
+	)
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestDebugPing(t *testing.T) {
+	shard := metadata.TNShard{
+		TNShardRecord: metadata.TNShardRecord{
+			ShardID:    1,
+			LogShardID: 2,
+		},
+		ReplicaID: 3,
+		Address:   "tn-address",
+	}
+	s := &taeStorage{shard: shard}
+	payload, err := (&api.TNPingRequest{}).Marshal()
+	require.NoError(t, err)
+
+	data, err := s.Debug(
+		context.Background(),
+		txn.TxnMeta{},
+		uint32(api.OpCode_OpPing),
+		payload,
+	)
+	require.NoError(t, err)
+	resp := &api.TNPingResponse{}
+	require.NoError(t, resp.Unmarshal(data))
+	require.Equal(t, shard.ShardID, resp.ShardID)
+	require.Equal(t, shard.LogShardID, resp.LogShardID)
+	require.Equal(t, shard.ReplicaID, resp.ReplicaID)
+	require.Equal(t, shard.Address, resp.ServiceAddress)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25673
Fixes #25674

## What this PR does / why we need it:

Two TAE debug RPC branches turned ordinary request failures into TN process failures:

- `OpStorageUsage` discarded the error from `handleRead` and unconditionally called `Read` on its nil result. A request decode error or handler error therefore became a nil-pointer panic.
- `OpPing` decoded RPC-controlled bytes with `github.com/fagongzi/util/protoc.MustUnmarshal`. That helper calls `log.Fatalf` on malformed protobuf data, terminating TN instead of returning an RPC error.

This PR propagates the `OpStorageUsage` error before reading the result and changes ping decode/encode to the generated error-returning protobuf methods. Valid ping responses keep the same wire format.

Regression tests cover malformed ping data, malformed storage-usage data, a handler-returned storage-usage error, and the normal ping response.

Validation:

- `go test ./pkg/txn/storage/tae -count=1`
- `go test -race ./pkg/txn/storage/tae -run '^TestDebug(StorageUsage|Ping)' -count=3`
- `go build ./pkg/txn/storage/tae`
- `go vet ./pkg/txn/storage/tae`
- `go test ./pkg/tnservice -run '^TestNewAndStartAndCloseService$' -count=1`
