### PR TITLE
fix(tnservice): serialize and cancel replica creation

### DIFF
--- a/pkg/tnservice/replica.go
+++ b/pkg/tnservice/replica.go
@@ -24,58 +24,124 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/service"
+	"github.com/matrixorigin/matrixone/pkg/txn/storage"
 	"github.com/matrixorigin/matrixone/pkg/txn/util"
 )
 
 // replica tn shard replica.
 type replica struct {
-	rt       runtime.Runtime
-	logger   *log.MOLogger
-	shard    metadata.TNShard
-	service  service.TxnService
-	startedC chan struct{}
+	rt           runtime.Runtime
+	logger       *log.MOLogger
+	shard        metadata.TNShard
+	service      service.TxnService
+	startedC     chan struct{}
+	createCtx    context.Context
+	cancelCreate context.CancelFunc
+	startedOnce  sync.Once
 
 	mu struct {
 		sync.RWMutex
-		starting bool
+		starting        bool
+		cancelled       bool
+		destroyOnCancel bool
+		startErr        error
 	}
 }
 
 func newReplica(shard metadata.TNShard, rt runtime.Runtime) *replica {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &replica{
-		rt:       rt,
-		shard:    shard,
-		logger:   rt.Logger().With(util.TxnTNShardField(shard)),
-		startedC: make(chan struct{}),
+		rt:           rt,
+		shard:        shard,
+		logger:       rt.Logger().With(util.TxnTNShardField(shard)),
+		startedC:     make(chan struct{}),
+		createCtx:    ctx,
+		cancelCreate: cancel,
 	}
 }
 
 func (r *replica) start(txnService service.TxnService) error {
+	if !r.reserveStart() {
+		return r.createCtx.Err()
+	}
+	return r.startReserved(txnService)
+}
+
+func (r *replica) reserveStart() bool {
 	r.mu.Lock()
-	if r.mu.starting {
-		r.mu.Unlock()
-		return nil
+	defer r.mu.Unlock()
+	if r.mu.starting || r.mu.cancelled {
+		return false
 	}
 	r.mu.starting = true
+	return true
+}
+
+func (r *replica) startReserved(txnService service.TxnService) error {
+	r.mu.Lock()
+	if !r.mu.starting {
+		r.mu.Unlock()
+		return context.Canceled
+	}
+	r.service = txnService
 	r.mu.Unlock()
 
-	defer close(r.startedC)
-	r.service = txnService
-	return r.service.Start()
+	err := txnService.Start()
+	r.finishStart(err)
+	return err
+}
+
+func (r *replica) finishStart(err error) {
+	r.startedOnce.Do(func() {
+		r.mu.Lock()
+		r.mu.startErr = err
+		r.mu.Unlock()
+		close(r.startedC)
+	})
+}
+
+func (r *replica) cancelStart(destroy bool) {
+	r.mu.Lock()
+	r.mu.cancelled = true
+	r.mu.destroyOnCancel = r.mu.destroyOnCancel || destroy
+	r.mu.Unlock()
+	r.cancelCreate()
+}
+
+func (r *replica) closeStorage(txnStorage storage.TxnStorage) error {
+	r.mu.RLock()
+	destroy := r.mu.destroyOnCancel
+	r.mu.RUnlock()
+	if destroy {
+		return txnStorage.Destroy(context.Background())
+	}
+	return txnStorage.Close(context.Background())
+}
+
+func (r *replica) waitStartCompleted() {
+	<-r.startedC
 }
 
 func (r *replica) close(destroy bool) error {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if !r.mu.starting {
+	starting := r.mu.starting
+	r.mu.RUnlock()
+	if !starting {
 		return nil
 	}
-	r.waitStarted()
-	return r.service.Close(destroy)
+	if err := r.waitStarted(context.Background()); err != nil {
+		return err
+	}
+	r.mu.RLock()
+	txnService := r.service
+	r.mu.RUnlock()
+	return txnService.Close(destroy)
 }
 
 func (r *replica) handleLocalRequest(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r.waitStarted()
+	if err := r.waitStarted(ctx); err != nil {
+		return err
+	}
 	prepareResponse(request, response)
 
 	switch request.Method {
@@ -92,6 +158,13 @@ func (r *replica) handleLocalRequest(ctx context.Context, request *txn.TxnReques
 	}
 }
 
-func (r *replica) waitStarted() {
-	<-r.startedC
+func (r *replica) waitStarted(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-r.startedC:
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return r.mu.startErr
+	}
 }

--- a/pkg/tnservice/replica.go
+++ b/pkg/tnservice/replica.go
@@ -16,6 +16,7 @@ package tnservice
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
@@ -129,13 +130,14 @@ func (r *replica) close(destroy bool) error {
 	if !starting {
 		return nil
 	}
-	if err := r.waitStarted(context.Background()); err != nil {
-		return err
-	}
+	startErr := r.waitStarted(context.Background())
 	r.mu.RLock()
 	txnService := r.service
 	r.mu.RUnlock()
-	return txnService.Close(destroy)
+	if txnService == nil {
+		return startErr
+	}
+	return errors.Join(startErr, txnService.Close(destroy))
 }
 
 func (r *replica) handleLocalRequest(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {

--- a/pkg/tnservice/replica_test.go
+++ b/pkg/tnservice/replica_test.go
@@ -43,7 +43,7 @@ func TestWaitStarted(t *testing.T) {
 	r := newReplica(newTestTNShard(1, 2, 3), runtime.DefaultRuntime())
 	c := make(chan struct{})
 	go func() {
-		r.waitStarted()
+		assert.NoError(t, r.waitStarted(context.Background()))
 		c <- struct{}{}
 	}()
 

--- a/pkg/tnservice/replica_test.go
+++ b/pkg/tnservice/replica_test.go
@@ -16,14 +16,40 @@ package tnservice
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/service"
+	"github.com/matrixorigin/matrixone/pkg/txn/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type startErrorStorage struct {
+	storage.TxnStorage
+	startErr     error
+	closeErr     error
+	destroyErr   error
+	closeCalls   int
+	destroyCalls int
+}
+
+func (s *startErrorStorage) Start() error {
+	return s.startErr
+}
+
+func (s *startErrorStorage) Close(context.Context) error {
+	s.closeCalls++
+	return s.closeErr
+}
+
+func (s *startErrorStorage) Destroy(context.Context) error {
+	s.destroyCalls++
+	return s.destroyErr
+}
 
 func TestNewReplica(t *testing.T) {
 	r := newReplica(newTestTNShard(1, 2, 3), runtime.DefaultRuntime())
@@ -37,6 +63,52 @@ func TestNewReplica(t *testing.T) {
 func TestCloseNotStartedReplica(t *testing.T) {
 	r := newReplica(newTestTNShard(1, 2, 3), runtime.DefaultRuntime())
 	assert.NoError(t, r.close(false))
+}
+
+func TestCloseFailedStartReplica(t *testing.T) {
+	startErr := errors.New("storage start failed")
+	runtime.SetupServiceBasedRuntime("test", runtime.DefaultRuntime())
+	for _, test := range []struct {
+		name    string
+		destroy bool
+	}{
+		{name: "close", destroy: false},
+		{name: "destroy", destroy: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cleanupErr := errors.New("storage cleanup failed")
+			storage := &startErrorStorage{startErr: startErr}
+			if test.destroy {
+				storage.destroyErr = cleanupErr
+			} else {
+				storage.closeErr = cleanupErr
+			}
+			txnService := service.NewTxnService(
+				"test", newTestTNShard(1, 2, 3), storage, service.NewTestSender(), time.Hour, nil)
+			r := newReplica(newTestTNShard(1, 2, 3), runtime.DefaultRuntime())
+
+			require.ErrorIs(t, r.start(txnService), startErr)
+			closed := make(chan error, 1)
+			go func() {
+				closed <- r.close(test.destroy)
+			}()
+
+			select {
+			case err := <-closed:
+				require.ErrorIs(t, err, startErr)
+				require.ErrorIs(t, err, cleanupErr)
+				if test.destroy {
+					require.Equal(t, 0, storage.closeCalls)
+					require.Equal(t, 1, storage.destroyCalls)
+				} else {
+					require.Equal(t, 1, storage.closeCalls)
+					require.Equal(t, 0, storage.destroyCalls)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("close hung after failed start")
+			}
+		})
+	}
 }
 
 func TestWaitStarted(t *testing.T) {

--- a/pkg/tnservice/store.go
+++ b/pkg/tnservice/store.go
@@ -259,6 +259,9 @@ func (s *store) Close() error {
 		}
 		return true
 	})
+	if s.queryClient != nil {
+		err = errors.Join(err, s.queryClient.Close())
+	}
 	s.task.RLock()
 	ts := s.task.serviceHolder
 	s.task.RUnlock()

--- a/pkg/tnservice/store.go
+++ b/pkg/tnservice/store.go
@@ -253,6 +253,7 @@ func (s *store) Close() error {
 	)
 	s.replicas.Range(func(_, value any) bool {
 		r := value.(*replica)
+		r.cancelStart(false)
 		if e := r.close(false); e != nil {
 			err = errors.Join(e, err)
 		}
@@ -270,11 +271,15 @@ func (s *store) Close() error {
 }
 
 func (s *store) StartTNReplica(shard metadata.TNShard) error {
-	return s.createReplica(shard)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.createReplicaLocked(shard)
 }
 
 func (s *store) CloseTNReplica(shard metadata.TNShard) error {
-	return s.removeReplica(shard.ShardID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.removeReplicaLocked(shard.ShardID)
 }
 
 func (s *store) startTNShards() error {
@@ -282,7 +287,7 @@ func (s *store) startTNShards() error {
 	defer s.mu.Unlock()
 
 	for _, shard := range s.mu.metadata.Shards {
-		if err := s.createReplica(shard); err != nil {
+		if err := s.createReplicaLocked(shard); err != nil {
 			return err
 		}
 	}
@@ -302,7 +307,7 @@ func (s *store) getTNShardInfo() []logservicepb.TNShardInfo {
 	return shards
 }
 
-func (s *store) createReplica(shard metadata.TNShard) error {
+func (s *store) createReplicaLocked(shard metadata.TNShard) error {
 	r := newReplica(shard, s.rt)
 	v, ok := s.replicas.LoadOrStore(shard.ShardID, r)
 	if ok {
@@ -312,21 +317,49 @@ func (s *store) createReplica(shard metadata.TNShard) error {
 		return nil
 	}
 
-	err := s.stopper.RunTask(func(ctx context.Context) {
+	err := s.stopper.RunTask(func(stopperCtx context.Context) {
+		stopCancelPropagation := context.AfterFunc(stopperCtx, func() {
+			r.cancelStart(false)
+		})
+		defer stopCancelPropagation()
+
 		for {
 			select {
-			case <-ctx.Done():
+			case <-stopperCtx.Done():
+				r.cancelStart(false)
+				r.finishStart(stopperCtx.Err())
+				return
+			case <-r.createCtx.Done():
+				r.finishStart(r.createCtx.Err())
 				return
 			default:
-				storage, err := s.createTxnStorage(ctx, shard, s.server)
+				storage, err := s.createTxnStorage(r.createCtx, shard, s.server)
 				if err != nil {
 					r.logger.Error("start DNShard failed",
 						zap.Error(err))
-					time.Sleep(retryCreateStorageInterval)
+					if err := waitCreateRetry(stopperCtx, r.createCtx); err != nil {
+						if stopperCtx.Err() != nil {
+							r.cancelStart(false)
+						}
+						r.finishStart(err)
+						return
+					}
 					continue
 				}
 
-				err = r.start(
+				if stopperCtx.Err() != nil {
+					r.cancelStart(false)
+				}
+				if !r.reserveStart() {
+					if err := r.closeStorage(storage); err != nil {
+						r.logger.Error("close canceled DNShard storage failed",
+							zap.Error(err))
+					}
+					r.finishStart(r.createCtx.Err())
+					return
+				}
+
+				err = r.startReserved(
 					service.NewTxnService(
 						s.cfg.UUID,
 						shard,
@@ -345,6 +378,9 @@ func (s *store) createReplica(shard metadata.TNShard) error {
 		}
 	})
 	if err != nil {
+		r.cancelStart(false)
+		r.finishStart(err)
+		s.replicas.CompareAndDelete(shard.ShardID, r)
 		return err
 	}
 
@@ -352,11 +388,26 @@ func (s *store) createReplica(shard metadata.TNShard) error {
 	return nil
 }
 
-func (s *store) removeReplica(tnShardID uint64) error {
+func waitCreateRetry(stopperCtx, createCtx context.Context) error {
+	timer := time.NewTimer(retryCreateStorageInterval)
+	defer timer.Stop()
+	select {
+	case <-stopperCtx.Done():
+		return stopperCtx.Err()
+	case <-createCtx.Done():
+		return createCtx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (s *store) removeReplicaLocked(tnShardID uint64) error {
 	if r := s.getReplica(tnShardID); r != nil {
+		r.cancelStart(true)
+		r.waitStartCompleted()
 		err := r.close(true)
-		s.replicas.Delete(tnShardID)
-		s.removeTNShard(tnShardID)
+		s.replicas.CompareAndDelete(tnShardID, r)
+		s.removeTNShardLocked(tnShardID)
 		return err
 	}
 	return nil

--- a/pkg/tnservice/store_heartbeat.go
+++ b/pkg/tnservice/store_heartbeat.go
@@ -117,7 +117,7 @@ func (s *store) handleAddReplica(cmd logservicepb.ScheduleCommand) {
 	logShardID := cmd.ConfigChange.Replica.LogShardID
 	replicaID := cmd.ConfigChange.Replica.ReplicaID
 	address := s.cfg.ServiceAddress
-	if err := s.createReplica(metadata.TNShard{
+	if err := s.StartTNReplica(metadata.TNShard{
 		TNShardRecord: metadata.TNShardRecord{
 			ShardID:    shardID,
 			LogShardID: logShardID,
@@ -131,7 +131,9 @@ func (s *store) handleAddReplica(cmd logservicepb.ScheduleCommand) {
 
 func (s *store) handleRemoveReplica(cmd logservicepb.ScheduleCommand) {
 	shardID := cmd.ConfigChange.Replica.ShardID
-	if err := s.removeReplica(shardID); err != nil {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.removeReplicaLocked(shardID); err != nil {
 		s.rt.Logger().Error("failed to remove replica", zap.Error(err))
 	}
 }

--- a/pkg/tnservice/store_metadata.go
+++ b/pkg/tnservice/store_metadata.go
@@ -65,10 +65,7 @@ func (s *store) addTNShardLocked(shard metadata.TNShard) {
 	s.mustUpdateMetadataLocked()
 }
 
-func (s *store) removeTNShard(id uint64) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+func (s *store) removeTNShardLocked(id uint64) {
 	var newShards []metadata.TNShard
 	for _, tn := range s.mu.metadata.Shards {
 		if tn.ShardID != id {

--- a/pkg/tnservice/store_rpc_handler.go
+++ b/pkg/tnservice/store_rpc_handler.go
@@ -69,48 +69,27 @@ func (s *store) handleDebug(ctx context.Context, request *txn.TxnRequest, respon
 }
 
 func (s *store) doRead(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.Read(ctx, request, response)
 }
 
 func (s *store) doWrite(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.Write(ctx, request, response)
 }
 
 func (s *store) doDebug(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.Debug(ctx, request, response)
@@ -121,96 +100,54 @@ func (s *store) handleCommit(ctx context.Context, request *txn.TxnRequest, respo
 		trace.WithKind(trace.SpanKindStatement))
 	defer span.End()
 
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.Commit(ctx, request, response)
 }
 
 func (s *store) handleRollback(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.Rollback(ctx, request, response)
 }
 
 func (s *store) handlePrepare(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.Prepare(ctx, request, response)
 }
 
 func (s *store) handleCommitTNShard(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.CommitTNShard(ctx, request, response)
 }
 
 func (s *store) handleRollbackTNShard(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.RollbackTNShard(ctx, request, response)
 }
 
 func (s *store) handleGetStatus(ctx context.Context, request *txn.TxnRequest, response *txn.TxnResponse) error {
-	r := s.validTNShard(ctx, request, response)
-	if r == nil {
-		return nil
-	}
-	started, err := s.waitTNReplicaStarted(ctx, r, response)
-	if err != nil {
+	r, err := s.startedTNReplica(ctx, request, response)
+	if err != nil || r == nil {
 		return err
-	}
-	if !started {
-		return nil
 	}
 	prepareResponse(request, response)
 	return r.service.GetStatus(ctx, request, response)
@@ -227,22 +164,26 @@ func (s *store) validTNShard(ctx context.Context, request *txn.TxnRequest, respo
 	return r
 }
 
-func (s *store) waitTNReplicaStarted(
+func (s *store) startedTNReplica(
 	ctx context.Context,
-	r *replica,
+	request *txn.TxnRequest,
 	response *txn.TxnResponse,
-) (bool, error) {
+) (*replica, error) {
+	r := s.validTNShard(ctx, request, response)
+	if r == nil {
+		return nil, nil
+	}
 	if err := r.waitStarted(ctx); err != nil {
 		if ctx.Err() != nil {
-			return false, ctx.Err()
+			return nil, ctx.Err()
 		}
 		response.TxnError = txn.WrapError(
 			moerr.NewTNShardNotFound(ctx, s.cfg.UUID, r.shard.ShardID),
 			0,
 		)
-		return false, nil
+		return nil, nil
 	}
-	return true, nil
+	return r, nil
 }
 
 func prepareResponse(request *txn.TxnRequest, response *txn.TxnResponse) {

--- a/pkg/tnservice/store_rpc_handler.go
+++ b/pkg/tnservice/store_rpc_handler.go
@@ -73,8 +73,13 @@ func (s *store) doRead(ctx context.Context, request *txn.TxnRequest, response *t
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
-
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.Read(ctx, request, response)
 }
@@ -84,7 +89,13 @@ func (s *store) doWrite(ctx context.Context, request *txn.TxnRequest, response *
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.Write(ctx, request, response)
 }
@@ -94,8 +105,13 @@ func (s *store) doDebug(ctx context.Context, request *txn.TxnRequest, response *
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
-
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.Debug(ctx, request, response)
 }
@@ -109,8 +125,13 @@ func (s *store) handleCommit(ctx context.Context, request *txn.TxnRequest, respo
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
-
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.Commit(ctx, request, response)
 }
@@ -120,7 +141,13 @@ func (s *store) handleRollback(ctx context.Context, request *txn.TxnRequest, res
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.Rollback(ctx, request, response)
 }
@@ -130,7 +157,13 @@ func (s *store) handlePrepare(ctx context.Context, request *txn.TxnRequest, resp
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.Prepare(ctx, request, response)
 }
@@ -140,7 +173,13 @@ func (s *store) handleCommitTNShard(ctx context.Context, request *txn.TxnRequest
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.CommitTNShard(ctx, request, response)
 }
@@ -150,7 +189,13 @@ func (s *store) handleRollbackTNShard(ctx context.Context, request *txn.TxnReque
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.RollbackTNShard(ctx, request, response)
 }
@@ -160,7 +205,13 @@ func (s *store) handleGetStatus(ctx context.Context, request *txn.TxnRequest, re
 	if r == nil {
 		return nil
 	}
-	r.waitStarted()
+	started, err := s.waitTNReplicaStarted(ctx, r, response)
+	if err != nil {
+		return err
+	}
+	if !started {
+		return nil
+	}
 	prepareResponse(request, response)
 	return r.service.GetStatus(ctx, request, response)
 }
@@ -174,6 +225,24 @@ func (s *store) validTNShard(ctx context.Context, request *txn.TxnRequest, respo
 		return nil
 	}
 	return r
+}
+
+func (s *store) waitTNReplicaStarted(
+	ctx context.Context,
+	r *replica,
+	response *txn.TxnResponse,
+) (bool, error) {
+	if err := r.waitStarted(ctx); err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		response.TxnError = txn.WrapError(
+			moerr.NewTNShardNotFound(ctx, s.cfg.UUID, r.shard.ShardID),
+			0,
+		)
+		return false, nil
+	}
+	return true, nil
 }
 
 func prepareResponse(request *txn.TxnRequest, response *txn.TxnResponse) {

--- a/pkg/tnservice/store_rpc_handler_test.go
+++ b/pkg/tnservice/store_rpc_handler_test.go
@@ -16,14 +16,139 @@ package tnservice
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/service"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestStartedTNReplicaLifecycle(t *testing.T) {
+	newStore := func() *store {
+		return &store{cfg: &Config{UUID: "test"}, replicas: &sync.Map{}}
+	}
+	newRequest := func(shardID, replicaID uint64) txn.TxnRequest {
+		req := service.NewTestReadRequest(1, service.NewTestTxn(1, 1, shardID), shardID)
+		req.CNRequest.Target.ReplicaID = replicaID
+		return req
+	}
+	newReadyReplica := func(t *testing.T, shardID, replicaID uint64) *replica {
+		r := newReplica(newTestTNShard(shardID, replicaID, shardID), runtime.DefaultRuntime())
+		require.True(t, r.reserveStart())
+		r.finishStart(nil)
+		return r
+	}
+	requireNotFound := func(t *testing.T, response *txn.TxnResponse) {
+		require.NotNil(t, response.TxnError)
+		require.Equal(t, uint32(moerr.ErrTNShardNotFound), response.TxnError.Code)
+	}
+
+	t.Run("ready", func(t *testing.T) {
+		s := newStore()
+		r := newReadyReplica(t, 1, 2)
+		s.replicas.Store(uint64(1), r)
+		req := newRequest(1, 2)
+
+		got, err := s.startedTNReplica(context.Background(), &req, &txn.TxnResponse{})
+		require.NoError(t, err)
+		require.Same(t, r, got)
+	})
+
+	t.Run("wait then ready", func(t *testing.T) {
+		s := newStore()
+		r := newReplica(newTestTNShard(1, 2, 1), runtime.DefaultRuntime())
+		require.True(t, r.reserveStart())
+		s.replicas.Store(uint64(1), r)
+		req := newRequest(1, 2)
+		entered := make(chan struct{})
+		result := make(chan *replica, 1)
+		errC := make(chan error, 1)
+		go func() {
+			close(entered)
+			got, err := s.startedTNReplica(context.Background(), &req, &txn.TxnResponse{})
+			result <- got
+			errC <- err
+		}()
+
+		<-entered
+		r.finishStart(nil)
+		require.Same(t, r, <-result)
+		require.NoError(t, <-errC)
+	})
+
+	t.Run("caller cancel", func(t *testing.T) {
+		s := newStore()
+		r := newReplica(newTestTNShard(1, 2, 1), runtime.DefaultRuntime())
+		require.True(t, r.reserveStart())
+		s.replicas.Store(uint64(1), r)
+		req := newRequest(1, 2)
+		ctx, cancel := context.WithCancel(context.Background())
+		entered := make(chan struct{})
+		errC := make(chan error, 1)
+		go func() {
+			close(entered)
+			_, err := s.startedTNReplica(ctx, &req, &txn.TxnResponse{})
+			errC <- err
+		}()
+
+		<-entered
+		cancel()
+		require.ErrorIs(t, <-errC, context.Canceled)
+	})
+
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "terminal start failure", err: errors.New("start failed")},
+		{name: "terminal start cancellation", err: context.Canceled},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newStore()
+			r := newReplica(newTestTNShard(1, 2, 1), runtime.DefaultRuntime())
+			require.True(t, r.reserveStart())
+			r.finishStart(test.err)
+			s.replicas.Store(uint64(1), r)
+			req := newRequest(1, 2)
+			response := &txn.TxnResponse{}
+
+			got, err := s.startedTNReplica(context.Background(), &req, response)
+			require.NoError(t, err)
+			require.Nil(t, got)
+			requireNotFound(t, response)
+		})
+	}
+
+	t.Run("remove and re-add generation", func(t *testing.T) {
+		s := newStore()
+		oldReplica := newReadyReplica(t, 1, 2)
+		s.replicas.Store(uint64(1), oldReplica)
+		oldRequest := newRequest(1, 2)
+		got, err := s.startedTNReplica(context.Background(), &oldRequest, &txn.TxnResponse{})
+		require.NoError(t, err)
+		require.Same(t, oldReplica, got)
+
+		s.replicas.Delete(uint64(1))
+		replacement := newReadyReplica(t, 1, 4)
+		s.replicas.Store(uint64(1), replacement)
+		oldResponse := &txn.TxnResponse{}
+		got, err = s.startedTNReplica(context.Background(), &oldRequest, oldResponse)
+		require.NoError(t, err)
+		require.Nil(t, got)
+		requireNotFound(t, oldResponse)
+
+		newRequest := newRequest(1, 4)
+		got, err = s.startedTNReplica(context.Background(), &newRequest, &txn.TxnResponse{})
+		require.NoError(t, err)
+		require.Same(t, replacement, got)
+	})
+}
 
 func TestHandleRead(t *testing.T) {
 	runTNStoreTest(t, func(s *store) {

--- a/pkg/tnservice/store_test.go
+++ b/pkg/tnservice/store_test.go
@@ -16,6 +16,7 @@ package tnservice
 
 import (
 	"context"
+	"errors"
 	"math"
 	"os"
 	"sync"
@@ -34,6 +35,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/service"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/mem"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -125,7 +127,7 @@ func TestStartReplica(t *testing.T) {
 	runTNStoreTest(t, func(s *store) {
 		assert.NoError(t, s.StartTNReplica(newTestTNShard(1, 2, 3)))
 		r := s.getReplica(1)
-		r.waitStarted()
+		assert.NoError(t, r.waitStarted(context.Background()))
 		assert.Equal(t, newTestTNShard(1, 2, 3), r.shard)
 	})
 }
@@ -134,7 +136,7 @@ func TestRemoveReplica(t *testing.T) {
 	runTNStoreTest(t, func(s *store) {
 		assert.NoError(t, s.StartTNReplica(newTestTNShard(1, 2, 3)))
 		r := s.getReplica(1)
-		r.waitStarted()
+		assert.NoError(t, r.waitStarted(context.Background()))
 
 		thc := s.hakeeperClient.(*testHAKeeperClient)
 		thc.setCommandBatch(logservicepb.CommandBatch{
@@ -168,11 +170,124 @@ func TestCloseReplica(t *testing.T) {
 		shard := newTestTNShard(1, 2, 3)
 		assert.NoError(t, s.StartTNReplica(shard))
 		r := s.getReplica(1)
-		r.waitStarted()
+		assert.NoError(t, r.waitStarted(context.Background()))
 		assert.Equal(t, shard, r.shard)
 
 		assert.NoError(t, s.CloseTNReplica(shard))
 		assert.Nil(t, s.getReplica(1))
+	})
+}
+
+func TestRemoveReplicaCancelsStorageCreation(t *testing.T) {
+	oldInterval := retryCreateStorageInterval
+	retryCreateStorageInterval = 10 * time.Millisecond
+	t.Cleanup(func() { retryCreateStorageInterval = oldInterval })
+
+	var allowCreate atomic.Bool
+	createAttempted := make(chan struct{}, 1)
+	runTNStoreTest(t, func(s *store) {
+		s.options.logServiceClientFactory = func(metadata.TNShard) (logservice.Client, error) {
+			if !allowCreate.Load() {
+				select {
+				case createAttempted <- struct{}{}:
+				default:
+				}
+				return nil, errors.New("injected log client creation failure")
+			}
+			return mem.NewMemLog(), nil
+		}
+
+		shard := newTestTNShard(101, 201, 301)
+		require.NoError(t, s.StartTNReplica(shard))
+		removed := s.getReplica(shard.ShardID)
+		require.NotNil(t, removed)
+		select {
+		case <-createAttempted:
+		case <-time.After(time.Second):
+			t.Fatal("storage creation was not attempted")
+		}
+
+		require.NoError(t, s.CloseTNReplica(shard))
+		require.Nil(t, s.getReplica(shard.ShardID))
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.ErrorIs(t, removed.waitStarted(ctx), context.Canceled)
+		removed.mu.RLock()
+		require.Nil(t, removed.service)
+		removed.mu.RUnlock()
+
+		require.NoError(t, s.StartTNReplica(shard))
+		replacement := s.getReplica(shard.ShardID)
+		require.NotNil(t, replacement)
+		require.NotSame(t, removed, replacement)
+		allowCreate.Store(true)
+		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, replacement.waitStarted(ctx))
+
+		time.Sleep(5 * retryCreateStorageInterval)
+		removed.mu.RLock()
+		require.Nil(t, removed.service)
+		removed.mu.RUnlock()
+	})
+}
+
+func TestReplicaCreateRetryStopsPromptly(t *testing.T) {
+	oldInterval := retryCreateStorageInterval
+	retryCreateStorageInterval = time.Second
+	t.Cleanup(func() { retryCreateStorageInterval = oldInterval })
+
+	createAttempted := make(chan struct{}, 1)
+	runTNStoreTest(t, func(s *store) {
+		s.options.logServiceClientFactory = func(metadata.TNShard) (logservice.Client, error) {
+			select {
+			case createAttempted <- struct{}{}:
+			default:
+			}
+			return nil, errors.New("injected log client creation failure")
+		}
+
+		require.NoError(t, s.StartTNReplica(newTestTNShard(102, 202, 302)))
+		select {
+		case <-createAttempted:
+		case <-time.After(time.Second):
+			t.Fatal("storage creation was not attempted")
+		}
+
+		start := time.Now()
+		s.stopper.Stop()
+		require.Less(t, time.Since(start), 500*time.Millisecond)
+	})
+}
+
+func TestConcurrentStartTNReplicaPersistsAllShards(t *testing.T) {
+	const replicaCount = 24
+	runTNStoreTest(t, func(s *store) {
+		var wg sync.WaitGroup
+		errs := make(chan error, replicaCount)
+		for i := 0; i < replicaCount; i++ {
+			shardID := uint64(1000 + i)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errs <- s.StartTNReplica(newTestTNShard(shardID, shardID+1000, shardID+2000))
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
+
+		s.mu.RLock()
+		shards := append([]metadata.TNShard(nil), s.mu.metadata.Shards...)
+		s.mu.RUnlock()
+		require.Len(t, shards, replicaCount)
+		seen := make(map[uint64]struct{}, replicaCount)
+		for _, shard := range shards {
+			seen[shard.ShardID] = struct{}{}
+		}
+		require.Len(t, seen, replicaCount)
 	})
 }
 
@@ -264,7 +379,7 @@ func addTestReplica(t *testing.T, s *store, shardID, replicaID, logShardID uint6
 	for {
 		r := s.getReplica(1)
 		if r != nil {
-			r.waitStarted()
+			assert.NoError(t, r.waitStarted(context.Background()))
 			assert.Equal(t, newTestTNShard(shardID, replicaID, logShardID), r.shard)
 			return
 		}

--- a/pkg/tnservice/store_test.go
+++ b/pkg/tnservice/store_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	logservicepb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/txn/service"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/mem"
@@ -42,6 +43,16 @@ var (
 	testTNStoreAddr      = "unix:///tmp/test-dnstore.sock"
 	testTNLogtailAddress = "127.0.0.1:22001"
 )
+
+type storeQueryClient struct {
+	client.QueryClient
+	closeCalls int
+}
+
+func (c *storeQueryClient) Close() error {
+	c.closeCalls++
+	return nil
+}
 
 func TestNewAndStartAndCloseService(t *testing.T) {
 	runTNStoreTest(t, func(s *store) {
@@ -229,6 +240,18 @@ func TestRemoveReplicaCancelsStorageCreation(t *testing.T) {
 		removed.mu.RLock()
 		require.Nil(t, removed.service)
 		removed.mu.RUnlock()
+	})
+}
+
+func TestStoreCloseClosesSharedQueryClient(t *testing.T) {
+	sharedClient := &storeQueryClient{}
+	runTNStoreTest(t, func(s *store) {
+		realClient := s.queryClient
+		s.queryClient = sharedClient
+		require.NoError(t, realClient.Close())
+		t.Cleanup(func() {
+			require.Equal(t, 1, sharedClient.closeCalls)
+		})
 	})
 }
 

--- a/pkg/txn/service/service.go
+++ b/pkg/txn/service/service.go
@@ -64,6 +64,7 @@ type service struct {
 	zombieTimeout time.Duration
 	pool          sync.Pool
 	recoveryC     chan struct{}
+	recoveryOnce  sync.Once
 	txnC          chan txn.TxnMeta
 }
 
@@ -109,6 +110,7 @@ func (s *service) Shard() metadata.TNShard {
 
 func (s *service) Start() error {
 	if err := s.storage.Start(); err != nil {
+		s.finishRecovery()
 		return err
 	}
 	s.logger.Info("txn.service.start.recovery")

--- a/pkg/txn/service/service_recovery.go
+++ b/pkg/txn/service/service_recovery.go
@@ -90,7 +90,7 @@ func (s *service) addLog(txnMeta txn.TxnMeta) {
 }
 
 func (s *service) end() {
-	defer close(s.recoveryC)
+	defer s.finishRecovery()
 	s.transactions.Range(func(_, value any) bool {
 		txnCtx := value.(*txnContext)
 		txnMeta := txnCtx.getTxn()
@@ -115,6 +115,12 @@ func (s *service) end() {
 			s.removeTxn(txnMeta.ID)
 		}
 		return true
+	})
+}
+
+func (s *service) finishRecovery() {
+	s.recoveryOnce.Do(func() {
+		close(s.recoveryC)
 	})
 }
 

--- a/pkg/txn/storage/tae/storage.go
+++ b/pkg/txn/storage/tae/storage.go
@@ -37,7 +37,10 @@ import (
 type taeStorage struct {
 	shard         metadata.TNShard
 	taeHandler    rpchandle.Handler
-	logtailServer *service.LogtailServer
+	logtailServer interface {
+		Start() error
+		Close() error
+	}
 }
 
 var _ storage.TxnStorage = (*taeStorage)(nil)
@@ -56,13 +59,16 @@ func NewTAEStorage(
 	if rt.ServiceUUID() != opt.SID {
 		panic(fmt.Sprintf("service uuid mismatch, %s != %s", rt.ServiceUUID(), opt.SID))
 	}
-	taeHandler := rpc.NewTAEHandle(ctx, dataDir, client, opt)
+	taeHandler, err := rpc.NewTAEHandleWithError(ctx, dataDir, client, opt)
+	if err != nil {
+		return nil, err
+	}
 	tae := taeHandler.GetDB()
 	tae.TxnServer = txnServer
 	logtailer := logtail.NewLogtailer(ctx, tae, tae.LogtailMgr, tae.Catalog)
 	server, err := service.NewLogtailServer(logtailServerAddr, logtailServerCfg, logtailer, rt, nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, taeHandler.HandleClose(ctx))
 	}
 
 	ss, ok := rt.GetGlobalVariables(runtime.StatusServer)
@@ -104,7 +110,7 @@ func (s *taeStorage) Committing(ctx context.Context, txnMeta txn.TxnMeta) error 
 
 // Destroy implements storage.TxnTAEStorage
 func (s *taeStorage) Destroy(ctx context.Context) error {
-	return s.taeHandler.HandleDestroy(ctx)
+	return errors.Join(s.Close(ctx), s.taeHandler.HandleDestroy(ctx))
 }
 
 // Prepare implements storage.TxnTAEStorage

--- a/pkg/txn/storage/tae/storage.go
+++ b/pkg/txn/storage/tae/storage.go
@@ -18,15 +18,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
 
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
 	rpc2 "github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage"
 	"github.com/matrixorigin/matrixone/pkg/util/status"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/rpchandle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail/service"
@@ -34,13 +35,36 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/rpc"
 )
 
+type logtailServer interface {
+	Start() error
+	Close() error
+}
+
+type taeHandle interface {
+	rpchandle.Handler
+	GetDB() *db.DB
+}
+
+type taeStorageDependencies struct {
+	newTAEHandle func(
+		context.Context,
+		string,
+		client.QueryClient,
+		*options.Options,
+	) (taeHandle, error)
+	newLogtailServer func(
+		context.Context,
+		*db.DB,
+		string,
+		*options.LogtailServerCfg,
+		runtime.Runtime,
+	) (*service.LogtailServer, error)
+}
+
 type taeStorage struct {
 	shard         metadata.TNShard
 	taeHandler    rpchandle.Handler
-	logtailServer interface {
-		Start() error
-		Close() error
-	}
+	logtailServer logtailServer
 }
 
 var _ storage.TxnStorage = (*taeStorage)(nil)
@@ -56,17 +80,42 @@ func NewTAEStorage(
 	txnServer rpc2.TxnServer,
 	client client.QueryClient,
 ) (storage.TxnStorage, error) {
+	return newTAEStorage(
+		ctx,
+		dataDir,
+		opt,
+		shard,
+		rt,
+		logtailServerAddr,
+		logtailServerCfg,
+		txnServer,
+		client,
+		defaultTAEStorageDependencies,
+	)
+}
+
+func newTAEStorage(
+	ctx context.Context,
+	dataDir string,
+	opt *options.Options,
+	shard metadata.TNShard,
+	rt runtime.Runtime,
+	logtailServerAddr string,
+	logtailServerCfg *options.LogtailServerCfg,
+	txnServer rpc2.TxnServer,
+	client client.QueryClient,
+	deps taeStorageDependencies,
+) (storage.TxnStorage, error) {
 	if rt.ServiceUUID() != opt.SID {
 		panic(fmt.Sprintf("service uuid mismatch, %s != %s", rt.ServiceUUID(), opt.SID))
 	}
-	taeHandler, err := rpc.NewTAEHandleWithError(ctx, dataDir, client, opt)
+	taeHandler, err := deps.newTAEHandle(ctx, dataDir, client, opt)
 	if err != nil {
 		return nil, err
 	}
 	tae := taeHandler.GetDB()
 	tae.TxnServer = txnServer
-	logtailer := logtail.NewLogtailer(ctx, tae, tae.LogtailMgr, tae.Catalog)
-	server, err := service.NewLogtailServer(logtailServerAddr, logtailServerCfg, logtailer, rt, nil)
+	server, err := deps.newLogtailServer(ctx, tae, logtailServerAddr, logtailServerCfg, rt)
 	if err != nil {
 		return nil, errors.Join(err, taeHandler.HandleClose(ctx))
 	}
@@ -81,6 +130,31 @@ func NewTAEStorage(
 		taeHandler:    taeHandler,
 		logtailServer: server,
 	}, nil
+}
+
+var defaultTAEStorageDependencies = taeStorageDependencies{
+	newTAEHandle:     openTAEHandle,
+	newLogtailServer: newTAELogtailServer,
+}
+
+func openTAEHandle(
+	ctx context.Context,
+	dataDir string,
+	client client.QueryClient,
+	opt *options.Options,
+) (taeHandle, error) {
+	return rpc.NewTAEHandleWithError(ctx, dataDir, client, opt)
+}
+
+func newTAELogtailServer(
+	ctx context.Context,
+	tae *db.DB,
+	address string,
+	cfg *options.LogtailServerCfg,
+	rt runtime.Runtime,
+) (*service.LogtailServer, error) {
+	logtailer := logtail.NewLogtailer(ctx, tae, tae.LogtailMgr, tae.Catalog)
+	return service.NewLogtailServer(address, cfg, logtailer, rt, nil)
 }
 
 // Start starts logtail push service.

--- a/pkg/txn/storage/tae/storage_lifecycle_test.go
+++ b/pkg/txn/storage/tae/storage_lifecycle_test.go
@@ -19,7 +19,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
+	txnstorage "github.com/matrixorigin/matrixone/pkg/txn/storage"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/rpchandle"
+	logtailservice "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail/service"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,11 +44,14 @@ func (s *lifecycleTestLogtailServer) Close() error {
 
 type lifecycleTestHandler struct {
 	rpchandle.Handler
+	db           *db.DB
 	closeErr     error
 	destroyErr   error
 	closeCalls   int
 	destroyCalls int
 }
+
+func (h *lifecycleTestHandler) GetDB() *db.DB { return h.db }
 
 func (h *lifecycleTestHandler) HandleClose(context.Context) error {
 	h.closeCalls++
@@ -66,4 +76,91 @@ func TestDestroyClosesTAEStorage(t *testing.T) {
 	require.Equal(t, 1, server.closeCalls)
 	require.Equal(t, 1, handler.closeCalls)
 	require.Equal(t, 1, handler.destroyCalls)
+}
+
+func TestNewTAEStorageHandleCreationFailure(t *testing.T) {
+	primaryErr := errors.New("handle creation failed")
+	handleCalls := 0
+	serverCalls := 0
+	deps := taeStorageDependencies{
+		newTAEHandle: func(
+			context.Context,
+			string,
+			client.QueryClient,
+			*options.Options,
+		) (taeHandle, error) {
+			handleCalls++
+			return nil, primaryErr
+		},
+		newLogtailServer: func(
+			context.Context,
+			*db.DB,
+			string,
+			*options.LogtailServerCfg,
+			runtime.Runtime,
+		) (*logtailservice.LogtailServer, error) {
+			serverCalls++
+			return nil, nil
+		},
+	}
+
+	storage, err := newTAEStorageForTest(t, deps)
+	require.Nil(t, storage)
+	require.ErrorIs(t, err, primaryErr)
+	require.Equal(t, 1, handleCalls)
+	require.Equal(t, 0, serverCalls)
+}
+
+func TestNewTAEStorageLogtailServerFailureClosesHandle(t *testing.T) {
+	primaryErr := errors.New("logtail server creation failed")
+	cleanupErr := errors.New("handle close failed")
+	handler := &lifecycleTestHandler{db: &db.DB{}, closeErr: cleanupErr}
+	serverCalls := 0
+	deps := taeStorageDependencies{
+		newTAEHandle: func(
+			context.Context,
+			string,
+			client.QueryClient,
+			*options.Options,
+		) (taeHandle, error) {
+			return handler, nil
+		},
+		newLogtailServer: func(
+			context.Context,
+			*db.DB,
+			string,
+			*options.LogtailServerCfg,
+			runtime.Runtime,
+		) (*logtailservice.LogtailServer, error) {
+			serverCalls++
+			return nil, primaryErr
+		},
+	}
+
+	storage, err := newTAEStorageForTest(t, deps)
+	require.Nil(t, storage)
+	require.ErrorIs(t, err, primaryErr)
+	require.ErrorIs(t, err, cleanupErr)
+	require.Equal(t, 1, serverCalls)
+	require.Equal(t, 1, handler.closeCalls)
+}
+
+func newTAEStorageForTest(
+	t *testing.T,
+	deps taeStorageDependencies,
+) (txnstorage.TxnStorage, error) {
+	t.Helper()
+	rt := runtime.DefaultRuntime()
+	return newTAEStorage(
+		context.Background(),
+		t.TempDir(),
+		&options.Options{SID: rt.ServiceUUID()},
+		metadata.TNShard{},
+		rt,
+		"",
+		&options.LogtailServerCfg{},
+		nil,
+		nil,
+		deps,
+	)
 }

--- a/pkg/txn/storage/tae/storage_lifecycle_test.go
+++ b/pkg/txn/storage/tae/storage_lifecycle_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taestorage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/rpchandle"
+	"github.com/stretchr/testify/require"
+)
+
+type lifecycleTestLogtailServer struct {
+	closeErr   error
+	closeCalls int
+}
+
+func (s *lifecycleTestLogtailServer) Start() error { return nil }
+
+func (s *lifecycleTestLogtailServer) Close() error {
+	s.closeCalls++
+	return s.closeErr
+}
+
+type lifecycleTestHandler struct {
+	rpchandle.Handler
+	closeErr     error
+	destroyErr   error
+	closeCalls   int
+	destroyCalls int
+}
+
+func (h *lifecycleTestHandler) HandleClose(context.Context) error {
+	h.closeCalls++
+	return h.closeErr
+}
+
+func (h *lifecycleTestHandler) HandleDestroy(context.Context) error {
+	h.destroyCalls++
+	return h.destroyErr
+}
+
+func TestDestroyClosesTAEStorage(t *testing.T) {
+	closeErr := errors.New("close failed")
+	destroyErr := errors.New("destroy failed")
+	server := &lifecycleTestLogtailServer{closeErr: closeErr}
+	handler := &lifecycleTestHandler{destroyErr: destroyErr}
+	s := &taeStorage{logtailServer: server, taeHandler: handler}
+
+	err := s.Destroy(context.Background())
+	require.ErrorIs(t, err, closeErr)
+	require.ErrorIs(t, err, destroyErr)
+	require.Equal(t, 1, server.closeCalls)
+	require.Equal(t, 1, handler.closeCalls)
+	require.Equal(t, 1, handler.destroyCalls)
+}

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -76,7 +76,8 @@ type Handle struct {
 
 	interceptMatchRegexp atomic.Pointer[regexp.Regexp]
 
-	client client.QueryClient
+	client           client.QueryClient
+	closeQueryClient bool
 }
 
 var _ rpchandle.Handler = (*Handle)(nil)
@@ -109,7 +110,7 @@ func openTAE(ctx context.Context, targetDir string, opt *options.Options) (tae *
 }
 
 func NewTAEHandle(ctx context.Context, path string, client client.QueryClient, opt *options.Options) *Handle {
-	h, err := NewTAEHandleWithError(ctx, path, client, opt)
+	h, err := newTAEHandle(ctx, path, client, opt, true)
 	if err != nil {
 		panic(err)
 	}
@@ -117,12 +118,23 @@ func NewTAEHandle(ctx context.Context, path string, client client.QueryClient, o
 }
 
 // NewTAEHandleWithError opens a TAE handle and returns open failures to callers
-// that can handle them, such as service startup and cancellation paths.
+// that can handle them, such as service startup and cancellation paths. The
+// caller retains ownership of client.
 func NewTAEHandleWithError(
 	ctx context.Context,
 	path string,
 	client client.QueryClient,
 	opt *options.Options,
+) (*Handle, error) {
+	return newTAEHandle(ctx, path, client, opt, false)
+}
+
+func newTAEHandle(
+	ctx context.Context,
+	path string,
+	client client.QueryClient,
+	opt *options.Options,
+	closeQueryClient bool,
 ) (*Handle, error) {
 	if path == "" {
 		path = "./store"
@@ -133,8 +145,9 @@ func NewTAEHandleWithError(
 	}
 
 	h := &Handle{
-		db:     tae,
-		client: client,
+		db:               tae,
+		client:           client,
+		closeQueryClient: closeQueryClient,
 	}
 
 	RegisterManifestHTTP(tae)
@@ -646,7 +659,7 @@ func (h *Handle) HandleClose(ctx context.Context) (err error) {
 	//if h.GCJob != nil {
 	//	h.GCJob.Stop()
 	//}
-	if h.client != nil {
+	if h.closeQueryClient && h.client != nil {
 		err = h.client.Close()
 	}
 	return errors.Join(err, h.db.Close())

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -109,12 +109,27 @@ func openTAE(ctx context.Context, targetDir string, opt *options.Options) (tae *
 }
 
 func NewTAEHandle(ctx context.Context, path string, client client.QueryClient, opt *options.Options) *Handle {
+	h, err := NewTAEHandleWithError(ctx, path, client, opt)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
+// NewTAEHandleWithError opens a TAE handle and returns open failures to callers
+// that can handle them, such as service startup and cancellation paths.
+func NewTAEHandleWithError(
+	ctx context.Context,
+	path string,
+	client client.QueryClient,
+	opt *options.Options,
+) (*Handle, error) {
 	if path == "" {
 		path = "./store"
 	}
 	tae, err := openTAE(ctx, path, opt)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	h := &Handle{
@@ -124,7 +139,7 @@ func NewTAEHandle(ctx context.Context, path string, client client.QueryClient, o
 
 	RegisterManifestHTTP(tae)
 
-	return h
+	return h, nil
 }
 
 //#endregion Open
@@ -633,11 +648,8 @@ func (h *Handle) HandleClose(ctx context.Context) (err error) {
 	//}
 	if h.client != nil {
 		err = h.client.Close()
-		if err != nil {
-			return err
-		}
 	}
-	return h.db.Close()
+	return errors.Join(err, h.db.Close())
 }
 
 func (h *Handle) HandleDestroy(ctx context.Context) (err error) {

--- a/pkg/vm/engine/tae/rpc/handle_test.go
+++ b/pkg/vm/engine/tae/rpc/handle_test.go
@@ -30,10 +30,12 @@ type closeErrorQueryClient struct {
 	client.QueryClient
 	err        error
 	closeCalls int
+	closed     bool
 }
 
 func (c *closeErrorQueryClient) Close() error {
 	c.closeCalls++
+	c.closed = true
 	return c.err
 }
 
@@ -55,13 +57,28 @@ func TestNewTAEHandleWithErrorReturnsCanceled(t *testing.T) {
 }
 
 func TestHandleCloseClosesDBWhenQueryClientCloseFails(t *testing.T) {
-	h := mockTAEHandle(context.Background(), t, &options.Options{})
 	clientErr := errors.New("query client close failed")
 	c := &closeErrorQueryClient{err: clientErr}
-	h.client = c
+	h := NewTAEHandle(context.Background(), t.TempDir(), c, &options.Options{})
 
 	err := h.HandleClose(context.Background())
 	require.ErrorIs(t, err, clientErr)
 	require.Equal(t, 1, c.closeCalls)
 	require.NotNil(t, h.db.Closed.Load())
+}
+
+func TestHandleCloseKeepsSharedQueryClientOpen(t *testing.T) {
+	sharedClient := &closeErrorQueryClient{}
+	existing, err := NewTAEHandleWithError(
+		context.Background(), t.TempDir(), sharedClient, &options.Options{})
+	require.NoError(t, err)
+	canceled, err := NewTAEHandleWithError(
+		context.Background(), t.TempDir(), sharedClient, &options.Options{})
+	require.NoError(t, err)
+
+	require.NoError(t, canceled.HandleClose(context.Background()))
+	require.Equal(t, 0, sharedClient.closeCalls)
+	require.False(t, sharedClient.closed)
+
+	require.NoError(t, existing.HandleClose(context.Background()))
 }

--- a/pkg/vm/engine/tae/rpc/handle_test.go
+++ b/pkg/vm/engine/tae/rpc/handle_test.go
@@ -16,13 +16,26 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	apipb "github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/stretchr/testify/require"
 )
+
+type closeErrorQueryClient struct {
+	client.QueryClient
+	err        error
+	closeCalls int
+}
+
+func (c *closeErrorQueryClient) Close() error {
+	c.closeCalls++
+	return c.err
+}
 
 func TestHandlePrecommitWrite_Deprecated(t *testing.T) {
 	h := mockTAEHandle(context.Background(), t, &options.Options{})
@@ -30,4 +43,25 @@ func TestHandlePrecommitWrite_Deprecated(t *testing.T) {
 	// HandlePreCommitWrite is deprecated and does nothing
 	err := h.HandlePreCommitWrite(context.Background(), txn.TxnMeta{}, &apipb.PrecommitWriteCmd{}, &apipb.TNStringResponse{})
 	require.NoError(t, err)
+}
+
+func TestNewTAEHandleWithErrorReturnsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	h, err := NewTAEHandleWithError(ctx, t.TempDir(), nil, &options.Options{})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, h)
+}
+
+func TestHandleCloseClosesDBWhenQueryClientCloseFails(t *testing.T) {
+	h := mockTAEHandle(context.Background(), t, &options.Options{})
+	clientErr := errors.New("query client close failed")
+	c := &closeErrorQueryClient{err: clientErr}
+	h.client = c
+
+	err := h.HandleClose(context.Background())
+	require.ErrorIs(t, err, clientErr)
+	require.Equal(t, 1, c.closeCalls)
+	require.NotNil(t, h.db.Closed.Load())
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25663
Fixes #25667

## What this PR does / why we need it:

There were two gaps in the TN replica lifecycle:

- Public and heartbeat-driven `StartTNReplica` paths reached `addTNShardLocked` without holding `store.mu`. Concurrent additions could mutate `metadata.Shards` while another goroutine marshaled it, causing races, lost metadata, and protobuf marshal panics.
- The retrying storage-create task belonged only to the store stopper. Removing a not-yet-started replica made `replica.close` return immediately, deleted the map entry, and left the task alive. Once its transient failure recovered, it could start an orphan TxnService alongside a replacement for the same shard. Its fixed `time.Sleep` also delayed stopper cancellation.

This PR makes the complete replica map/metadata add and remove operations serialize under `store.mu`. Each replica now owns a cancelable creation context and a single completion signal. Removal cancels and joins creation before deleting the map/metadata entry; stopper cancellation reaches the same context; retry waiting observes both cancellation sources. Storage created after cancellation is closed or destroyed before ownership can be lost.

If cancellation wins before TxnService startup is reserved, the old replica completes with an error and never receives a service. If startup has already entered the existing non-cancelable recovery API, removal joins it and then closes it before returning. In both cases a replacement cannot overlap with an orphan. RPCs already waiting on the old replica are released and receive `TNShardNotFound` instead of waiting forever.

Regression tests cover concurrent metadata persistence, remove/re-add during injected storage failures, and prompt stopper cancellation of retry waits.

Validation:

- `go test ./pkg/tnservice -count=1`
- `go test -race ./pkg/tnservice -run '^Test(RemoveReplicaCancelsStorageCreation|ReplicaCreateRetryStopsPromptly|ConcurrentStartTNReplicaPersistsAllShards)$' -count=3`
- `go build ./pkg/tnservice`
- `go vet ./pkg/tnservice`
- `go test ./cmd/mo-service -run '^TestParseTNConfig$' -count=1`
