### PR TITLE
fix(objectio): recreate stopped blockio pipeline

### DIFF
--- a/pkg/objectio/ioutil/pipeline.go
+++ b/pkg/objectio/ioutil/pipeline.go
@@ -35,6 +35,8 @@ import (
 )
 
 var (
+	pipelineLifecycleMu sync.Mutex
+
 	_jobPool = sync.Pool{
 		New: func() any {
 			return new(tasks.Job)
@@ -117,9 +119,12 @@ func putReader(reader *objectio.ObjectReader) {
 type IOJobFactory func(context.Context, fetchParams) *tasks.Job
 
 func Start(sid string) {
+	pipelineLifecycleMu.Lock()
+	defer pipelineLifecycleMu.Unlock()
+
 	r := rt.ServiceRuntime(sid)
-	_, ok := r.GetGlobalVariables("blockio")
-	if ok {
+	value, ok := r.GetGlobalVariables("blockio")
+	if ok && value.(*IoPipeline).active.Load() {
 		return
 	}
 
@@ -131,6 +136,9 @@ func Start(sid string) {
 }
 
 func Stop(sid string) {
+	pipelineLifecycleMu.Lock()
+	defer pipelineLifecycleMu.Unlock()
+
 	val, ok := rt.ServiceRuntime(sid).GetGlobalVariables("blockio")
 	if !ok {
 		return

--- a/pkg/objectio/ioutil/pipeline_test.go
+++ b/pkg/objectio/ioutil/pipeline_test.go
@@ -21,12 +21,14 @@ import (
 	"testing"
 	"time"
 
+	rt "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logstore/sm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tasks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func makeIOPipelineOptions(depth int) Option {
@@ -97,6 +99,24 @@ func TestNewIOPipeline(t *testing.T) {
 	// step 4: close pipeline
 	p.Stop()
 
+}
+
+func TestStartAfterStopCreatesActivePipeline(t *testing.T) {
+	const sid = "pipeline-restart"
+	rt.SetupServiceBasedRuntime(sid, rt.DefaultRuntime())
+
+	Start(sid)
+	first := MustGetPipeline(sid)
+	require.True(t, first.active.Load())
+
+	Stop(sid)
+	require.False(t, first.active.Load())
+
+	Start(sid)
+	second := MustGetPipeline(sid)
+	t.Cleanup(func() { Stop(sid) })
+	require.NotSame(t, first, second)
+	require.True(t, second.active.Load())
 }
 
 func TestIoPipeline_Prefetch(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25693

## What this PR does / why we need it:

`ioutil.Stop(sid)` permanently stops the blockio pipeline queues but leaves the pipeline in the service runtime. `ioutil.Start(sid)` previously treated the mere presence of the `blockio` global as proof that startup had completed, so restarting a TN/CN with the same UUID reused the inactive pipeline and its closed queues.

This PR serializes the global pipeline lifecycle and makes `Start` reuse only an active pipeline. When the cached pipeline is stopped, `Start` constructs, starts, and publishes a fresh pipeline. The lifecycle lock also closes the check/stop/start race so a concurrent restart cannot publish a pipeline while the prior stop is still draining it.

The regression test exercises the complete `Start -> Stop -> Start` sequence and verifies that the second pipeline is a different active instance.

Validation:

- `go test ./pkg/objectio/ioutil -count=1`
- `go test -race ./pkg/objectio/ioutil -run '^TestStartAfterStopCreatesActivePipeline$' -count=3`
- `go build ./pkg/objectio/ioutil`
- `go vet ./pkg/objectio/ioutil`
- `go test ./pkg/tnservice -run '^TestNewAndStartAndCloseService$' -count=1`
