### PR TITLE
fix(task): make worker shutdown race-free

### DIFF
--- a/pkg/iscp/consumer_entry.go
+++ b/pkg/iscp/consumer_entry.go
@@ -34,6 +34,23 @@ func NewJobEntry(
 	tableInfo *TableEntry,
 	jobName string,
 	jobSpec *JobSpec,
+	jobID uint64,
+	watermark types.TS,
+	state int8,
+	dropAt types.Timestamp,
+) *JobEntry {
+	return NewJobEntryWithStatus(
+		tableInfo, jobName, jobSpec, nil, jobID, watermark, state, dropAt,
+	)
+}
+
+// NewJobEntryWithStatus restores an entry from both catalog state and its
+// durable progress. NewJobEntry remains as the source-compatible constructor
+// for callers that do not have persisted status.
+func NewJobEntryWithStatus(
+	tableInfo *TableEntry,
+	jobName string,
+	jobSpec *JobSpec,
 	jobStatus *JobStatus,
 	jobID uint64,
 	watermark types.TS,

--- a/pkg/iscp/consumer_entry.go
+++ b/pkg/iscp/consumer_entry.go
@@ -34,11 +34,16 @@ func NewJobEntry(
 	tableInfo *TableEntry,
 	jobName string,
 	jobSpec *JobSpec,
+	jobStatus *JobStatus,
 	jobID uint64,
 	watermark types.TS,
 	state int8,
 	dropAt types.Timestamp,
 ) *JobEntry {
+	var currentLSN uint64
+	if jobStatus != nil {
+		currentLSN = jobStatus.LSN
+	}
 	jobEntry := &JobEntry{
 		tableInfo:          tableInfo,
 		jobName:            jobName,
@@ -48,6 +53,7 @@ func NewJobEntry(
 		persistedWatermark: watermark,
 		state:              state,
 		dropAt:             dropAt,
+		currentLSN:         currentLSN,
 	}
 	return jobEntry
 }

--- a/pkg/iscp/executor.go
+++ b/pkg/iscp/executor.go
@@ -108,6 +108,7 @@ func ISCPTaskExecutorFactory(
 		if err != nil {
 			return
 		}
+		defer exec.terminateLifetime()
 		if err = attachToTask(ctx, task.GetID(), exec); err != nil {
 			return
 		}
@@ -172,10 +173,11 @@ func NewISCPTaskExecutor(
 		)
 	}()
 	option = fillDefaultOption(option)
+	ownerCtx, terminate := context.WithCancel(ctx)
 	exec = &ISCPTaskExecutor{
-		ownerCtx:    ctx,
-		terminated:  make(chan struct{}),
-		ctx:         ctx,
+		ownerCtx:    ownerCtx,
+		terminate:   terminate,
+		ctx:         ownerCtx,
 		packer:      types.NewPacker(),
 		tables:      newISCPTableTree(),
 		cnUUID:      cdUUID,
@@ -238,9 +240,12 @@ func (exec *ISCPTaskExecutor) Pause() error {
 	return nil
 }
 func (exec *ISCPTaskExecutor) Cancel() error {
+	// Broadcast lifetime termination before waiting for the state lock. Start
+	// may hold the lock while doing recovery I/O; its generation context is
+	// derived from ownerCtx and must remain cancelable during that wait.
+	exec.terminateLifetime()
 	exec.runningMu.Lock()
 	defer exec.runningMu.Unlock()
-	exec.terminate()
 	exec.stopLocked()
 	return nil
 }
@@ -274,28 +279,24 @@ func (exec *ISCPTaskExecutor) Start() error {
 }
 
 func (exec *ISCPTaskExecutor) waitForTermination(ctx context.Context) {
+	var ownerDone <-chan struct{}
+	if exec.ownerCtx != nil {
+		ownerDone = exec.ownerCtx.Done()
+	}
 	select {
 	case <-ctx.Done():
-	case <-exec.terminated:
+	case <-ownerDone:
 	}
 }
 
-func (exec *ISCPTaskExecutor) terminate() {
-	if exec.terminated != nil {
-		exec.terminateOnce.Do(func() { close(exec.terminated) })
+func (exec *ISCPTaskExecutor) terminateLifetime() {
+	if exec.terminate != nil {
+		exec.terminate()
 	}
 }
 
 func (exec *ISCPTaskExecutor) isTerminated() bool {
-	if exec.terminated == nil {
-		return false
-	}
-	select {
-	case <-exec.terminated:
-		return true
-	default:
-		return false
-	}
+	return exec.ownerCtx != nil && exec.ownerCtx.Err() != nil
 }
 
 func (exec *ISCPTaskExecutor) initStateLocked(parent context.Context) (err error) {
@@ -562,6 +563,21 @@ func (exec *ISCPTaskExecutor) GetWatermark(accountID uint32, srcTableID uint64, 
 	}
 	watermark, ok = table.GetWatermark(jobName)
 	return
+}
+
+// GetJobState returns the scheduler's in-memory LSN and state. It is used by
+// diagnostics and lifecycle tests to distinguish admitted work from durable
+// progress.
+func (exec *ISCPTaskExecutor) GetJobState(
+	accountID uint32,
+	srcTableID uint64,
+	jobName string,
+) (lsn uint64, state int8, ok bool) {
+	table, ok := exec.getTable(accountID, srcTableID)
+	if !ok {
+		return 0, ISCPJobState_Invalid, false
+	}
+	return table.getJobState(jobName)
 }
 
 // For UT

--- a/pkg/iscp/executor.go
+++ b/pkg/iscp/executor.go
@@ -16,10 +16,10 @@ package iscp
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"sync/atomic"
-
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -73,6 +73,10 @@ type ISCPExecutorOption struct {
 	FlushWatermarkInterval time.Duration
 	FlushWatermarkTTL      time.Duration
 	RetryTimes             int
+}
+
+func newISCPTableTree() *btree.BTreeG[*TableEntry] {
+	return btree.NewBTreeGOptions(tableInfoLess, btree.Options{NoLocks: true})
 }
 
 func ISCPTaskExecutorFactory(
@@ -173,7 +177,7 @@ func NewISCPTaskExecutor(
 		terminated:  make(chan struct{}),
 		ctx:         ctx,
 		packer:      types.NewPacker(),
-		tables:      btree.NewBTreeGOptions(tableInfoLess, btree.Options{NoLocks: true}),
+		tables:      newISCPTableTree(),
 		cnUUID:      cdUUID,
 		txnEngine:   txnEngine,
 		cnTxnClient: cnTxnClient,
@@ -305,10 +309,14 @@ func (exec *ISCPTaskExecutor) initStateLocked(parent context.Context) (err error
 		}
 	}()
 
+	// Repair abandoned durable states before loading the next generation.
+	// A stopped generation may have persisted Running, or may only have
+	// advanced its in-memory LSN before cancellation. The database is the
+	// generation boundary's source of truth.
 	err = retry(
 		ctx,
 		func() error {
-			return exec.replay(ctx)
+			return exec.repairAbandonedJobs(ctx)
 		},
 		exec.option.RetryTimes,
 		DefaultRetryInterval,
@@ -320,7 +328,7 @@ func (exec *ISCPTaskExecutor) initStateLocked(parent context.Context) (err error
 	err = retry(
 		ctx,
 		func() error {
-			return exec.initState(ctx)
+			return exec.rebuildState(ctx)
 		},
 		exec.option.RetryTimes,
 		DefaultRetryInterval,
@@ -362,7 +370,7 @@ func (exec *ISCPTaskExecutor) stopLocked() {
 	exec.worker = nil
 }
 
-func (exec *ISCPTaskExecutor) initState(ctx context.Context) (err error) {
+func (exec *ISCPTaskExecutor) repairAbandonedJobs(ctx context.Context) (err error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
 	sql := fmt.Sprintf(
@@ -382,7 +390,13 @@ func (exec *ISCPTaskExecutor) initState(ctx context.Context) (err error) {
 		0)
 	txnOp, err := exec.cnTxnClient.New(ctxWithTimeout, nowTs, createByOpt)
 	if txnOp != nil {
-		defer txnOp.Commit(ctxWithTimeout)
+		defer func() {
+			if err != nil {
+				err = errors.Join(err, txnOp.Rollback(ctxWithTimeout))
+				return
+			}
+			err = txnOp.Commit(ctxWithTimeout)
+		}()
 	}
 	if err != nil {
 		return
@@ -482,35 +496,19 @@ func (exec *ISCPTaskExecutor) run(ctx context.Context, worker Worker) {
 				} else {
 					_, ok = tables[iter.tableID]
 				}
-				table, ok2 := exec.getTable(iter.accountID, iter.tableID)
+				table, tableExists := exec.getTable(iter.accountID, iter.tableID)
+				if !tableExists {
+					logutil.Error(
+						"ISCP-Task get table failed",
+						zap.Uint32("accountID", iter.accountID),
+						zap.Uint64("tableID", iter.tableID),
+					)
+					continue
+				}
 				if ok {
-					// The update on mo_iscp_log may not be available in the next applyISCPLog,
-					// so update the in-memory state directly to prevent repeated triggering of the iteration.
-					for i, jobName := range iter.jobNames {
-						job := table.jobs[JobKey{
-							JobName: jobName,
-							JobID:   iter.jobIDs[i],
-						}]
-						job.currentLSN++
-						job.state = ISCPJobState_Pending
-					}
-					onErrorFn := func(err error) {
-						for i, jobName := range iter.jobNames {
-							job := table.jobs[JobKey{
-								JobName: jobName,
-								JobID:   iter.jobIDs[i],
-							}]
-							job.currentLSN--
-							job.state = ISCPJobState_Completed
-						}
-						logutil.Error(
-							"ISCP-Task submit iteration failed",
-							zap.Error(err),
-						)
-					}
 					ok, err := CheckLeaseWithRetry(ctx, exec.cnUUID, exec.txnEngine, exec.cnTxnClient)
 					if err != nil {
-						onErrorFn(err)
+						logutil.Error("ISCP-Task check lease failed", zap.Error(err))
 						continue
 					}
 					if !ok {
@@ -519,18 +517,19 @@ func (exec *ISCPTaskExecutor) run(ctx context.Context, worker Worker) {
 					}
 					err = worker.Submit(iter)
 					if err != nil {
-						onErrorFn(err)
+						logutil.Error("ISCP-Task submit iteration failed", zap.Error(err))
 						continue
+					}
+					// Admission is the linearization point. The worker now owns the
+					// iteration, so hide it from the next candidate scan.
+					if err = table.markIterationPending(iter); err != nil {
+						logutil.Error("ISCP-Task mark admitted iteration failed", zap.Error(err))
+						// The accepted iteration cannot be retracted safely. Cancel this
+						// generation; the next Start repairs and rebuilds its state.
+						go exec.Cancel()
+						return
 					}
 				} else {
-					if !ok2 {
-						logutil.Error(
-							"ISCP-Task get table failed",
-							zap.Uint32("accountID", iter.accountID),
-							zap.Uint64("tableID", iter.tableID),
-						)
-						continue
-					}
 					table.UpdateWatermark(iter)
 				}
 			}
@@ -738,7 +737,26 @@ func (exec *ISCPTaskExecutor) applyISCPLogWithRel(ctx context.Context, rel engin
 	return
 }
 
-func (exec *ISCPTaskExecutor) replay(ctx context.Context) (err error) {
+type replayApplyFunc func(
+	accountID uint32,
+	tableID uint64,
+	jobName string,
+	jobID uint64,
+	state int8,
+	watermarkStr string,
+	jobSpecStr []byte,
+	jobStatusStr []byte,
+	dropAt types.Timestamp,
+	notPrint bool,
+) error
+
+// loadReplay reads one authoritative storage snapshot. The caller decides
+// whether to merge it into the current generation or publish it as a fresh
+// generation state.
+func (exec *ISCPTaskExecutor) loadReplay(
+	ctx context.Context,
+	apply replayApplyFunc,
+) (tableID uint64, watermark types.TS, err error) {
 	// injection is for ut
 	if msg, injected := objectio.ISCPExecutorInjected(); injected && msg == "replay" {
 		err = moerr.NewInternalErrorNoCtx(msg)
@@ -765,13 +783,18 @@ func (exec *ISCPTaskExecutor) replay(ctx context.Context) (err error) {
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
-	defer txn.Commit(ctx)
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, txn.Rollback(ctx))
+			return
+		}
+		err = txn.Commit(ctx)
+	}()
 
-	tid, _, err := getTableID(ctx, exec.cnUUID, txn, catalog.System_Account, catalog.MO_CATALOG, catalog.MO_ISCP_LOG)
+	tableID, _, err = getTableID(ctx, exec.cnUUID, txn, catalog.System_Account, catalog.MO_CATALOG, catalog.MO_ISCP_LOG)
 	if err != nil {
 		return
 	}
-	exec.prevISCPTableID = tid
 
 	sql := cdc.CDCSQLBuilder.ISCPLogSelectSQL()
 	result, err := ExecWithResult(ctx, sql, exec.cnUUID, txn)
@@ -800,7 +823,7 @@ func (exec *ISCPTaskExecutor) replay(ctx context.Context) (err error) {
 			if !dropAtVector.IsNull(uint64(i)) {
 				dropAt = dropAts[i]
 			}
-			err = exec.addOrUpdateJob(
+			err = apply(
 				accountIDs[i],
 				tableIDs[i],
 				jobNameVector.GetStringAt(i),
@@ -818,9 +841,94 @@ func (exec *ISCPTaskExecutor) replay(ctx context.Context) (err error) {
 		}
 		return true
 	})
-	exec.iscpLogWm = types.TimestampToTS(txn.SnapshotTS())
+	if err != nil {
+		return
+	}
+	watermark = types.TimestampToTS(txn.SnapshotTS())
 
 	return
+}
+
+// replay incrementally merges a storage snapshot into the running generation.
+// Monotonic merge is required here so an older snapshot cannot overwrite an
+// iteration that is concurrently becoming durable.
+func (exec *ISCPTaskExecutor) replay(ctx context.Context) error {
+	tableID, watermark, err := exec.loadReplay(ctx, exec.addOrUpdateJob)
+	if err != nil {
+		return err
+	}
+	exec.prevISCPTableID = tableID
+	exec.iscpLogWm = watermark
+	return nil
+}
+
+func (exec *ISCPTaskExecutor) addOrUpdateRecoveredJob(
+	accountID uint32,
+	tableID uint64,
+	jobName string,
+	jobID uint64,
+	state int8,
+	watermarkStr string,
+	jobSpecStr []byte,
+	jobStatusStr []byte,
+	dropAt types.Timestamp,
+	notPrint bool,
+) error {
+	// The repair transaction may commit before its logtail is visible to the
+	// next read snapshot. Normalize the same states in memory so correctness
+	// does not depend on asynchronous logtail catch-up.
+	if state == ISCPJobState_Pending || state == ISCPJobState_Running {
+		state = ISCPJobState_Completed
+	}
+	return exec.addOrUpdateJob(
+		accountID,
+		tableID,
+		jobName,
+		jobID,
+		state,
+		watermarkStr,
+		jobSpecStr,
+		jobStatusStr,
+		dropAt,
+		notPrint,
+	)
+}
+
+// rebuildState closes the generation boundary by constructing state off to the
+// side and publishing it only after the complete storage snapshot succeeds.
+// Unlike replay, startup must not retain optimistic LSN/state from a stopped
+// generation: no worker from that generation remains that can make it durable.
+func (exec *ISCPTaskExecutor) rebuildState(ctx context.Context) error {
+	snapshot := &ISCPTaskExecutor{
+		ctx:         ctx,
+		tables:      newISCPTableTree(),
+		cnUUID:      exec.cnUUID,
+		txnEngine:   exec.txnEngine,
+		cnTxnClient: exec.cnTxnClient,
+		option:      exec.option,
+	}
+	tableID, watermark, err := exec.loadReplay(ctx, snapshot.addOrUpdateRecoveredJob)
+	if err != nil {
+		return err
+	}
+	exec.publishRebuiltState(snapshot, tableID, watermark)
+	return nil
+}
+
+func (exec *ISCPTaskExecutor) publishRebuiltState(
+	snapshot *ISCPTaskExecutor,
+	tableID uint64,
+	watermark types.TS,
+) {
+	for _, table := range snapshot.tables.Items() {
+		table.exec = exec
+	}
+
+	exec.tableMu.Lock()
+	exec.tables = snapshot.tables
+	exec.prevISCPTableID = tableID
+	exec.iscpLogWm = watermark
+	exec.tableMu.Unlock()
 }
 
 func (exec *ISCPTaskExecutor) addOrUpdateJob(

--- a/pkg/iscp/executor.go
+++ b/pkg/iscp/executor.go
@@ -90,6 +90,7 @@ func ISCPTaskExecutorFactory(
 			logutil.Error("ISCPTaskExecutor is already running")
 			return moerr.NewErrExecutorRunning(ctx, "ISCPTaskExecutor")
 		}
+		defer running.Store(false)
 
 		ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
 		exec, err = NewISCPTaskExecutor(
@@ -103,19 +104,22 @@ func ISCPTaskExecutorFactory(
 		if err != nil {
 			return
 		}
-		attachToTask(ctx, task.GetID(), exec)
-
-		exec.runningMu.Lock()
-		defer exec.runningMu.Unlock()
-		if exec.running {
+		if err = attachToTask(ctx, task.GetID(), exec); err != nil {
 			return
 		}
-		err = exec.initStateLocked()
+
+		exec.runningMu.Lock()
+		if exec.running {
+			exec.runningMu.Unlock()
+			return
+		}
+		err = exec.initStateLocked(ctx)
+		exec.runningMu.Unlock()
 		if err != nil {
 			return
 		}
-		exec.run(ctx)
-		<-ctx.Done()
+		exec.run(exec.ctx, exec.worker)
+		exec.Stop()
 		return
 	}
 }
@@ -252,28 +256,29 @@ func (exec *ISCPTaskExecutor) Start() error {
 	if exec.running {
 		return nil
 	}
-	err := exec.initStateLocked()
+	err := exec.initStateLocked(context.Background())
 	if err != nil {
 		return err
 	}
-	go exec.run(context.Background())
+	go exec.run(exec.ctx, exec.worker)
 	return nil
 }
 
-func (exec *ISCPTaskExecutor) initStateLocked() error {
-	exec.running = true
-	logutil.Info(
-		"ISCP-Task Start",
-	)
-	ctx, cancel := context.WithCancel(context.Background())
-	worker := NewWorker(exec.cnUUID, exec.txnEngine, exec.cnTxnClient, exec.mp)
-	exec.worker = worker
+func (exec *ISCPTaskExecutor) initStateLocked(parent context.Context) (err error) {
+	ctx, cancel := context.WithCancel(parent)
 	exec.ctx = ctx
 	exec.cancel = cancel
-	err := retry(
+	defer func() {
+		if err != nil {
+			cancel()
+			exec.ctx, exec.cancel = nil, nil
+		}
+	}()
+
+	err = retry(
 		ctx,
 		func() error {
-			return exec.replay(exec.ctx)
+			return exec.replay(ctx)
 		},
 		exec.option.RetryTimes,
 		DefaultRetryInterval,
@@ -285,7 +290,7 @@ func (exec *ISCPTaskExecutor) initStateLocked() error {
 	err = retry(
 		ctx,
 		func() error {
-			return exec.initState()
+			return exec.initState(ctx)
 		},
 		exec.option.RetryTimes,
 		DefaultRetryInterval,
@@ -294,7 +299,15 @@ func (exec *ISCPTaskExecutor) initStateLocked() error {
 	if err != nil {
 		return err
 	}
+
+	// Publish a fully initialized generation only after replay and state repair
+	// have both succeeded. NewWorker seals all worker goroutines before return.
+	exec.worker = NewWorker(exec.cnUUID, exec.txnEngine, exec.cnTxnClient, exec.mp)
 	exec.wg.Add(1)
+	exec.running = true
+	logutil.Info(
+		"ISCP-Task Start",
+	)
 	return nil
 }
 
@@ -308,15 +321,15 @@ func (exec *ISCPTaskExecutor) Stop() {
 	logutil.Info(
 		"ISCP-Task Stop",
 	)
-	exec.worker.Stop()
 	exec.cancel()
+	exec.worker.Stop()
 	exec.wg.Wait()
 	exec.ctx, exec.cancel = nil, nil
 	exec.worker = nil
 }
 
-func (exec *ISCPTaskExecutor) initState() (err error) {
-	ctxWithTimeout, cancel := context.WithTimeout(exec.ctx, time.Minute*5)
+func (exec *ISCPTaskExecutor) initState(ctx context.Context) (err error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
 	sql := fmt.Sprintf(
 		`UPDATE mo_catalog.mo_iscp_log
@@ -358,7 +371,7 @@ func (exec *ISCPTaskExecutor) IsRunning() bool {
 	return exec.running
 }
 
-func (exec *ISCPTaskExecutor) run(ctx context.Context) {
+func (exec *ISCPTaskExecutor) run(ctx context.Context, worker Worker) {
 	logutil.Info(
 		"ISCP-Task Run",
 	)
@@ -369,24 +382,25 @@ func (exec *ISCPTaskExecutor) run(ctx context.Context) {
 	}()
 	defer exec.wg.Done()
 	syncTaskTrigger := time.NewTicker(exec.option.SyncTaskInterval)
+	defer syncTaskTrigger.Stop()
 	flushWatermarkTrigger := time.NewTicker(exec.option.FlushWatermarkInterval)
+	defer flushWatermarkTrigger.Stop()
 	gcTrigger := time.NewTicker(exec.option.GCInterval)
+	defer gcTrigger.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case <-exec.ctx.Done():
 			return
 		case <-syncTaskTrigger.C:
 			// apply iscp log
 			from := exec.iscpLogWm.Next()
 			to := types.TimestampToTS(exec.txnEngine.LatestLogtailAppliedTime())
-			err := exec.applyISCPLog(exec.ctx, from, to)
+			err := exec.applyISCPLog(ctx, from, to)
 			if err == nil {
 				exec.iscpLogWm = to
 			}
 			if err != nil && moerr.IsMoErrCode(err, moerr.ErrStaleRead) {
-				err = exec.replay(exec.ctx)
+				err = exec.replay(ctx)
 			}
 			if err != nil {
 				logutil.Error(
@@ -403,7 +417,7 @@ func (exec *ISCPTaskExecutor) run(ctx context.Context) {
 				continue
 			}
 			// check if there are any dirty tables
-			tables, toTS, minTS, err := exec.getDirtyTables(exec.ctx, candidateTables, fromTSs, exec.cnUUID, exec.txnEngine)
+			tables, toTS, minTS, err := exec.getDirtyTables(ctx, candidateTables, fromTSs, exec.cnUUID, exec.txnEngine)
 			// injection is for ut
 			if msg, injected := objectio.ISCPExecutorInjected(); injected && msg == "getDirtyTables" {
 				err = moerr.NewInternalErrorNoCtx(msg)
@@ -460,7 +474,7 @@ func (exec *ISCPTaskExecutor) run(ctx context.Context) {
 							zap.Error(err),
 						)
 					}
-					ok, err := CheckLeaseWithRetry(exec.ctx, exec.cnUUID, exec.txnEngine, exec.cnTxnClient)
+					ok, err := CheckLeaseWithRetry(ctx, exec.cnUUID, exec.txnEngine, exec.cnTxnClient)
 					if err != nil {
 						onErrorFn(err)
 						continue
@@ -469,7 +483,7 @@ func (exec *ISCPTaskExecutor) run(ctx context.Context) {
 						go exec.Stop()
 						break
 					}
-					err = exec.worker.Submit(iter)
+					err = worker.Submit(iter)
 					if err != nil {
 						onErrorFn(err)
 						continue

--- a/pkg/iscp/executor.go
+++ b/pkg/iscp/executor.go
@@ -108,17 +108,10 @@ func ISCPTaskExecutorFactory(
 			return
 		}
 
-		exec.runningMu.Lock()
-		if exec.running {
-			exec.runningMu.Unlock()
+		if err = exec.Start(); err != nil {
 			return
 		}
-		err = exec.initStateLocked(ctx)
-		exec.runningMu.Unlock()
-		if err != nil {
-			return
-		}
-		exec.run(exec.ctx, exec.worker)
+		exec.waitForTermination(ctx)
 		exec.Stop()
 		return
 	}
@@ -176,6 +169,8 @@ func NewISCPTaskExecutor(
 	}()
 	option = fillDefaultOption(option)
 	exec = &ISCPTaskExecutor{
+		ownerCtx:    ctx,
+		terminated:  make(chan struct{}),
 		ctx:         ctx,
 		packer:      types.NewPacker(),
 		tables:      btree.NewBTreeGOptions(tableInfoLess, btree.Options{NoLocks: true}),
@@ -239,7 +234,10 @@ func (exec *ISCPTaskExecutor) Pause() error {
 	return nil
 }
 func (exec *ISCPTaskExecutor) Cancel() error {
-	exec.Stop()
+	exec.runningMu.Lock()
+	defer exec.runningMu.Unlock()
+	exec.terminate()
+	exec.stopLocked()
 	return nil
 }
 func (exec *ISCPTaskExecutor) Restart() error {
@@ -253,15 +251,47 @@ func (exec *ISCPTaskExecutor) Restart() error {
 func (exec *ISCPTaskExecutor) Start() error {
 	exec.runningMu.Lock()
 	defer exec.runningMu.Unlock()
+	if exec.isTerminated() {
+		return moerr.NewInternalErrorNoCtx("ISCP-Task Executor is canceled")
+	}
 	if exec.running {
 		return nil
 	}
-	err := exec.initStateLocked(context.Background())
+	parent := exec.ownerCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	err := exec.initStateLocked(parent)
 	if err != nil {
 		return err
 	}
 	go exec.run(exec.ctx, exec.worker)
 	return nil
+}
+
+func (exec *ISCPTaskExecutor) waitForTermination(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-exec.terminated:
+	}
+}
+
+func (exec *ISCPTaskExecutor) terminate() {
+	if exec.terminated != nil {
+		exec.terminateOnce.Do(func() { close(exec.terminated) })
+	}
+}
+
+func (exec *ISCPTaskExecutor) isTerminated() bool {
+	if exec.terminated == nil {
+		return false
+	}
+	select {
+	case <-exec.terminated:
+		return true
+	default:
+		return false
+	}
 }
 
 func (exec *ISCPTaskExecutor) initStateLocked(parent context.Context) (err error) {
@@ -314,6 +344,10 @@ func (exec *ISCPTaskExecutor) initStateLocked(parent context.Context) (err error
 func (exec *ISCPTaskExecutor) Stop() {
 	exec.runningMu.Lock()
 	defer exec.runningMu.Unlock()
+	exec.stopLocked()
+}
+
+func (exec *ISCPTaskExecutor) stopLocked() {
 	if !exec.running {
 		return
 	}
@@ -480,7 +514,7 @@ func (exec *ISCPTaskExecutor) run(ctx context.Context, worker Worker) {
 						continue
 					}
 					if !ok {
-						go exec.Stop()
+						go exec.Cancel()
 						break
 					}
 					err = worker.Submit(iter)

--- a/pkg/iscp/executor_factory_test.go
+++ b/pkg/iscp/executor_factory_test.go
@@ -46,7 +46,8 @@ func TestExecutorFactoryReturnsAttachErrorAndReleasesAdmission(t *testing.T) {
 }
 
 func TestExecutorLifetimeSurvivesPauseAndEndsOnCancel(t *testing.T) {
-	exec := &ISCPTaskExecutor{terminated: make(chan struct{})}
+	ownerCtx, terminate := context.WithCancel(context.Background())
+	exec := &ISCPTaskExecutor{ownerCtx: ownerCtx, terminate: terminate}
 	returned := make(chan struct{})
 	started := make(chan struct{})
 	go func() {
@@ -73,8 +74,8 @@ func TestExecutorLifetimeSurvivesPauseAndEndsOnCancel(t *testing.T) {
 }
 
 func TestExecutorLifetimeEndsWithOwnerContext(t *testing.T) {
-	exec := &ISCPTaskExecutor{terminated: make(chan struct{})}
 	ctx, cancel := context.WithCancel(context.Background())
+	exec := &ISCPTaskExecutor{ownerCtx: ctx}
 	returned := make(chan struct{})
 	go func() {
 		exec.waitForTermination(ctx)
@@ -86,5 +87,36 @@ func TestExecutorLifetimeEndsWithOwnerContext(t *testing.T) {
 	case <-returned:
 	case <-time.After(time.Second):
 		t.Fatal("owner cancellation did not terminate the daemon executor lifetime")
+	}
+}
+
+func TestCancelSignalsLifetimeBeforeWaitingForStateLock(t *testing.T) {
+	ownerCtx, terminate := context.WithCancel(context.Background())
+	exec := &ISCPTaskExecutor{ownerCtx: ownerCtx, terminate: terminate}
+	exec.runningMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			exec.runningMu.Unlock()
+		}
+	}()
+
+	returned := make(chan struct{})
+	go func() {
+		_ = exec.Cancel()
+		close(returned)
+	}()
+
+	select {
+	case <-ownerCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("cancel waited for the state lock before signaling termination")
+	}
+	exec.runningMu.Unlock()
+	locked = false
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not finish after the state lock was released")
 	}
 }

--- a/pkg/iscp/executor_factory_test.go
+++ b/pkg/iscp/executor_factory_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
@@ -41,5 +42,49 @@ func TestExecutorFactoryReturnsAttachErrorAndReleasesAdmission(t *testing.T) {
 
 	for range 2 {
 		require.ErrorIs(t, factory(context.Background(), &task.DaemonTask{}), attachErr)
+	}
+}
+
+func TestExecutorLifetimeSurvivesPauseAndEndsOnCancel(t *testing.T) {
+	exec := &ISCPTaskExecutor{terminated: make(chan struct{})}
+	returned := make(chan struct{})
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		exec.waitForTermination(context.Background())
+		close(returned)
+	}()
+	<-started
+
+	require.NoError(t, exec.Pause())
+	select {
+	case <-returned:
+		t.Fatal("pause terminated the daemon executor lifetime")
+	default:
+	}
+
+	require.NoError(t, exec.Cancel())
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not terminate the daemon executor lifetime")
+	}
+	require.Error(t, exec.Start())
+}
+
+func TestExecutorLifetimeEndsWithOwnerContext(t *testing.T) {
+	exec := &ISCPTaskExecutor{terminated: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	returned := make(chan struct{})
+	go func() {
+		exec.waitForTermination(ctx)
+		close(returned)
+	}()
+	cancel()
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("owner cancellation did not terminate the daemon executor lifetime")
 	}
 }

--- a/pkg/iscp/executor_factory_test.go
+++ b/pkg/iscp/executor_factory_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iscp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/task"
+	"github.com/matrixorigin/matrixone/pkg/taskservice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorFactoryReturnsAttachErrorAndReleasesAdmission(t *testing.T) {
+	running.Store(false)
+	t.Cleanup(func() { running.Store(false) })
+
+	attachErr := errors.New("attach failed")
+	factory := ISCPTaskExecutorFactory(
+		nil,
+		nil,
+		func(context.Context, uint64, taskservice.ActiveRoutine) error {
+			return attachErr
+		},
+		"",
+		nil,
+	)
+
+	for range 2 {
+		require.ErrorIs(t, factory(context.Background(), &task.DaemonTask{}), attachErr)
+	}
+}

--- a/pkg/iscp/executor_test.go
+++ b/pkg/iscp/executor_test.go
@@ -119,6 +119,14 @@ func TestNewJobEntryRestoresPersistedLSN(t *testing.T) {
 	table := NewTableEntry(exec, 1, 2, 3, "db", "table")
 	spec := &JobSpec{}
 	status := &JobStatus{LSN: 5}
+	legacy := NewJobEntry(
+		table, "legacy", spec, 3, types.BuildTS(9, 0), ISCPJobState_Completed, 0,
+	)
+	require.Zero(t, legacy.currentLSN)
+	restored := NewJobEntryWithStatus(
+		table, "restored", spec, status, 4, types.BuildTS(10, 0), ISCPJobState_Completed, 0,
+	)
+	require.Equal(t, uint64(5), restored.currentLSN)
 
 	table.AddOrUpdateSinker(
 		context.Background(),

--- a/pkg/iscp/executor_test.go
+++ b/pkg/iscp/executor_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -111,4 +112,148 @@ func TestUnregisterJobReturnsCanceledContextBeforeFirstAttempt(t *testing.T) {
 
 	require.False(t, ok)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestNewJobEntryRestoresPersistedLSN(t *testing.T) {
+	exec := &ISCPTaskExecutor{}
+	table := NewTableEntry(exec, 1, 2, 3, "db", "table")
+	spec := &JobSpec{}
+	status := &JobStatus{LSN: 5}
+
+	table.AddOrUpdateSinker(
+		context.Background(),
+		"job",
+		spec,
+		status,
+		4,
+		types.BuildTS(10, 0),
+		ISCPJobState_Completed,
+		0,
+	)
+
+	job := table.jobs[JobKey{JobName: "job", JobID: 4}]
+	require.Equal(t, uint64(5), job.currentLSN)
+}
+
+func TestPublishRebuiltStateReplacesAbandonedGeneration(t *testing.T) {
+	exec := &ISCPTaskExecutor{tables: newISCPTableTree()}
+	oldTable := NewTableEntry(exec, 1, 2, 3, "db", "table")
+	oldTable.AddOrUpdateSinker(
+		context.Background(),
+		"job",
+		&JobSpec{},
+		&JobStatus{LSN: 6},
+		4,
+		types.BuildTS(20, 0),
+		ISCPJobState_Pending,
+		0,
+	)
+	exec.tables.Set(oldTable)
+	exec.tables.Set(NewTableEntry(exec, 1, 5, 6, "stale-db", "stale-table"))
+
+	snapshot := &ISCPTaskExecutor{tables: newISCPTableTree()}
+	persistedTable := NewTableEntry(snapshot, 1, 2, 3, "db", "table")
+	persistedWatermark := types.BuildTS(10, 0)
+	persistedTable.AddOrUpdateSinker(
+		context.Background(),
+		"job",
+		&JobSpec{},
+		&JobStatus{LSN: 5},
+		4,
+		persistedWatermark,
+		ISCPJobState_Completed,
+		0,
+	)
+	snapshot.tables.Set(persistedTable)
+
+	replayWatermark := types.BuildTS(30, 0)
+	exec.publishRebuiltState(snapshot, 42, replayWatermark)
+
+	table, ok := exec.getTable(1, 3)
+	require.True(t, ok)
+	require.NotSame(t, oldTable, table)
+	require.Same(t, exec, table.exec)
+	job := table.jobs[JobKey{JobName: "job", JobID: 4}]
+	require.Equal(t, uint64(5), job.currentLSN)
+	require.Equal(t, ISCPJobState_Completed, job.state)
+	require.True(t, job.watermark.EQ(&persistedWatermark))
+	require.Equal(t, uint64(42), exec.prevISCPTableID)
+	require.True(t, exec.iscpLogWm.EQ(&replayWatermark))
+	_, ok = exec.getTable(1, 6)
+	require.False(t, ok)
+}
+
+func TestMarkIterationPendingIsAtomic(t *testing.T) {
+	exec := &ISCPTaskExecutor{}
+	table := NewTableEntry(exec, 1, 2, 3, "db", "table")
+	for i, name := range []string{"job-1", "job-2"} {
+		table.AddOrUpdateSinker(
+			context.Background(),
+			name,
+			&JobSpec{},
+			&JobStatus{LSN: uint64(i + 5)},
+			uint64(i+1),
+			types.BuildTS(10, 0),
+			ISCPJobState_Completed,
+			0,
+		)
+	}
+
+	invalid := &IterationContext{
+		jobNames: []string{"job-1", "job-2"},
+		jobIDs:   []uint64{1, 2},
+		lsn:      []uint64{6, 99},
+	}
+	require.Error(t, table.markIterationPending(invalid))
+	require.Equal(t, uint64(5), table.jobs[JobKey{JobName: "job-1", JobID: 1}].currentLSN)
+	require.Equal(t, ISCPJobState_Completed, table.jobs[JobKey{JobName: "job-1", JobID: 1}].state)
+	require.Equal(t, uint64(6), table.jobs[JobKey{JobName: "job-2", JobID: 2}].currentLSN)
+	require.Equal(t, ISCPJobState_Completed, table.jobs[JobKey{JobName: "job-2", JobID: 2}].state)
+
+	valid := &IterationContext{
+		jobNames: []string{"job-1", "job-2"},
+		jobIDs:   []uint64{1, 2},
+		lsn:      []uint64{6, 7},
+	}
+	require.NoError(t, table.markIterationPending(valid))
+	require.Equal(t, uint64(6), table.jobs[JobKey{JobName: "job-1", JobID: 1}].currentLSN)
+	require.Equal(t, ISCPJobState_Pending, table.jobs[JobKey{JobName: "job-1", JobID: 1}].state)
+	require.Equal(t, uint64(7), table.jobs[JobKey{JobName: "job-2", JobID: 2}].currentLSN)
+	require.Equal(t, ISCPJobState_Pending, table.jobs[JobKey{JobName: "job-2", JobID: 2}].state)
+}
+
+func TestISCPRecoveryNormalizesPreRepairSnapshot(t *testing.T) {
+	exec := &ISCPTaskExecutor{
+		ctx:    context.Background(),
+		tables: newISCPTableTree(),
+	}
+	spec, err := MarshalJobSpec(&JobSpec{
+		ConsumerInfo: ConsumerInfo{
+			SrcTable: TableInfo{DBID: 2, TableID: 3, DBName: "db", TableName: "table"},
+		},
+	})
+	require.NoError(t, err)
+	status, err := MarshalJobStatus(&JobStatus{LSN: 5})
+	require.NoError(t, err)
+	encodeJSON := func(value string) []byte {
+		byteJSON, encodeErr := types.ParseStringToByteJson(value)
+		require.NoError(t, encodeErr)
+		encoded, encodeErr := types.EncodeJson(byteJSON)
+		require.NoError(t, encodeErr)
+		return encoded
+	}
+
+	require.NoError(t, exec.addOrUpdateRecoveredJob(
+		1, 3, "pending", 4, ISCPJobState_Pending, "10-0",
+		encodeJSON(spec), encodeJSON(status), 0, true,
+	))
+	require.NoError(t, exec.addOrUpdateRecoveredJob(
+		1, 3, "error", 5, ISCPJobState_Error, "10-0",
+		encodeJSON(spec), encodeJSON(status), 0, true,
+	))
+
+	table, ok := exec.getTable(1, 3)
+	require.True(t, ok)
+	require.Equal(t, ISCPJobState_Completed, table.jobs[JobKey{JobName: "pending", JobID: 4}].state)
+	require.Equal(t, ISCPJobState_Error, table.jobs[JobKey{JobName: "error", JobID: 5}].state)
 }

--- a/pkg/iscp/table_entry.go
+++ b/pkg/iscp/table_entry.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
@@ -69,7 +70,7 @@ func (t *TableEntry) AddOrUpdateSinker(
 	jobEntry, ok := t.jobs[key]
 	if !ok || jobEntry.jobID < jobID {
 		newCreate = true
-		jobEntry = NewJobEntry(t, jobName, jobSpec, jobID, watermark, state, dropAt)
+		jobEntry = NewJobEntry(t, jobName, jobSpec, jobStatus, jobID, watermark, state, dropAt)
 		t.jobs[key] = jobEntry
 		return
 	}
@@ -188,6 +189,41 @@ func (t *TableEntry) getCandidate() (iter []*IterationContext, minFromTS types.T
 		}
 	}
 	return iterations, minFromTS
+}
+
+// markIterationPending records ownership only after a worker accepts the
+// iteration. Validate the complete shared iteration before changing any job so
+// the in-memory transition is all-or-nothing.
+func (t *TableEntry) markIterationPending(iter *IterationContext) error {
+	if iter == nil || len(iter.jobNames) != len(iter.jobIDs) || len(iter.jobNames) != len(iter.lsn) {
+		return moerr.NewInternalErrorNoCtx("invalid ISCP iteration")
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	jobs := make([]*JobEntry, len(iter.jobNames))
+	for i, jobName := range iter.jobNames {
+		job := t.jobs[JobKey{JobName: jobName, JobID: iter.jobIDs[i]}]
+		if job == nil {
+			return moerr.NewInternalErrorNoCtxf("ISCP job %s/%d no longer exists", jobName, iter.jobIDs[i])
+		}
+		if job.state != ISCPJobState_Completed || job.currentLSN+1 != iter.lsn[i] {
+			return moerr.NewInternalErrorNoCtxf(
+				"ISCP job %s/%d changed before admission: state %d, lsn %d, iteration lsn %d",
+				jobName,
+				iter.jobIDs[i],
+				job.state,
+				job.currentLSN,
+				iter.lsn[i],
+			)
+		}
+		jobs[i] = job
+	}
+	for i, job := range jobs {
+		job.currentLSN = iter.lsn[i]
+		job.state = ISCPJobState_Pending
+	}
+	return nil
 }
 
 func (t *TableEntry) UpdateWatermark(iter *IterationContext) {

--- a/pkg/iscp/table_entry.go
+++ b/pkg/iscp/table_entry.go
@@ -93,6 +93,17 @@ func (t *TableEntry) GetWatermark(jobName string) (watermark types.TS, ok bool) 
 	return types.TS{}, false
 }
 
+func (t *TableEntry) getJobState(jobName string) (lsn uint64, state int8, ok bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for _, job := range t.jobs {
+		if job.jobName == jobName && job.dropAt == 0 {
+			return job.currentLSN, job.state, true
+		}
+	}
+	return 0, ISCPJobState_Invalid, false
+}
+
 func (t *TableEntry) IsEmpty() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/pkg/iscp/table_entry.go
+++ b/pkg/iscp/table_entry.go
@@ -70,7 +70,7 @@ func (t *TableEntry) AddOrUpdateSinker(
 	jobEntry, ok := t.jobs[key]
 	if !ok || jobEntry.jobID < jobID {
 		newCreate = true
-		jobEntry = NewJobEntry(t, jobName, jobSpec, jobStatus, jobID, watermark, state, dropAt)
+		jobEntry = NewJobEntryWithStatus(t, jobName, jobSpec, jobStatus, jobID, watermark, state, dropAt)
 		t.jobs[key] = jobEntry
 		return
 	}

--- a/pkg/iscp/types.go
+++ b/pkg/iscp/types.go
@@ -149,8 +149,11 @@ type ISCPTaskExecutor struct {
 	) (func(), error) // for test
 	option *ISCPExecutorOption
 
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx           context.Context
+	cancel        context.CancelFunc
+	ownerCtx      context.Context
+	terminated    chan struct{}
+	terminateOnce sync.Once
 
 	worker Worker
 	wg     sync.WaitGroup

--- a/pkg/iscp/types.go
+++ b/pkg/iscp/types.go
@@ -149,11 +149,10 @@ type ISCPTaskExecutor struct {
 	) (func(), error) // for test
 	option *ISCPExecutorOption
 
-	ctx           context.Context
-	cancel        context.CancelFunc
-	ownerCtx      context.Context
-	terminated    chan struct{}
-	terminateOnce sync.Once
+	ctx       context.Context
+	cancel    context.CancelFunc
+	ownerCtx  context.Context
+	terminate context.CancelFunc
 
 	worker Worker
 	wg     sync.WaitGroup

--- a/pkg/iscp/util.go
+++ b/pkg/iscp/util.go
@@ -17,6 +17,7 @@ package iscp
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -392,7 +393,7 @@ func getTxn(
 	}
 	err = cnEngine.New(ctx, op)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, op.Rollback(ctx))
 	}
 	return op, nil
 }

--- a/pkg/iscp/worker.go
+++ b/pkg/iscp/worker.go
@@ -37,7 +37,9 @@ const (
 
 type Worker interface {
 	Submit(iteration *IterationContext) error
-	// Stop cancels running work and discards work that has not started.
+	// Stop cancels running work and discards work that has not started. The
+	// executor repairs and reloads durable state before publishing a successor
+	// generation, so abandoned optimistic state cannot cross that boundary.
 	Stop()
 }
 

--- a/pkg/iscp/worker.go
+++ b/pkg/iscp/worker.go
@@ -37,6 +37,7 @@ const (
 
 type Worker interface {
 	Submit(iteration *IterationContext) error
+	// Stop cancels running work and discards work that has not started.
 	Stop()
 }
 
@@ -50,6 +51,39 @@ type worker struct {
 	cancel      context.CancelFunc
 	ctx         context.Context
 	closed      atomic.Bool
+	stopOnce    sync.Once
+	admissions  workerAdmissionGate
+}
+
+type workerAdmissionGate struct {
+	mu sync.RWMutex
+	wg sync.WaitGroup
+}
+
+// enter registers a sender before it can block. seal excludes new senders,
+// cancels blocked ones, and waits until no sender can arrive after draining.
+func (g *workerAdmissionGate) enter(closed *atomic.Bool) bool {
+	if closed.Load() {
+		return false
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if closed.Load() {
+		return false
+	}
+	g.wg.Add(1)
+	return true
+}
+
+func (g *workerAdmissionGate) leave() {
+	g.wg.Done()
+}
+
+func (g *workerAdmissionGate) seal(cancel context.CancelFunc) {
+	g.mu.Lock()
+	cancel()
+	g.mu.Unlock()
+	g.wg.Wait()
 }
 
 func NewWorker(cnUUID string, cnEngine engine.Engine, cnTxnClient client.TxnClient, mp *mpool.MPool) Worker {
@@ -95,9 +129,10 @@ func (w *worker) Submit(iteration *IterationContext) error {
 	if iteration == nil {
 		return moerr.NewInternalErrorNoCtx("cannot submit a nil ISCP iteration")
 	}
-	if w.closed.Load() {
+	if !w.admissions.enter(&w.closed) {
 		return moerr.NewInternalErrorNoCtx("ISCP-Worker is closed")
 	}
+	defer w.admissions.leave()
 	select {
 	case w.taskChan <- iteration:
 		return nil
@@ -176,9 +211,16 @@ func (w *worker) onItem(iterCtx *IterationContext) {
 }
 
 func (w *worker) Stop() {
-	if !w.closed.CompareAndSwap(false, true) {
-		return
-	}
-	w.cancel()
-	w.wg.Wait()
+	w.stopOnce.Do(func() {
+		w.closed.Store(true)
+		w.admissions.seal(w.cancel)
+		w.wg.Wait()
+		for {
+			select {
+			case <-w.taskChan:
+			default:
+				return
+			}
+		}
+	})
 }

--- a/pkg/iscp/worker.go
+++ b/pkg/iscp/worker.go
@@ -61,13 +61,15 @@ func NewWorker(cnUUID string, cnEngine engine.Engine, cnTxnClient client.TxnClie
 		mp:          mp,
 	}
 	worker.ctx, worker.cancel = context.WithCancel(context.Background())
-	go worker.Run()
+	worker.start()
 	return worker
 }
 
-func (w *worker) Run() {
+// start seals the worker generation before NewWorker publishes it. Stop must
+// never observe a zero WaitGroup while worker goroutines can still be created.
+func (w *worker) start() {
+	w.wg.Add(ISCPWorkerThread)
 	for i := 0; i < ISCPWorkerThread; i++ {
-		w.wg.Add(1)
 		go func() {
 			defer w.wg.Done()
 			for {
@@ -75,6 +77,13 @@ func (w *worker) Run() {
 				case <-w.ctx.Done():
 					return
 				case task := <-w.taskChan:
+					// Cancellation wins over queued work. This keeps Stop bounded
+					// and prevents a stopped generation from starting new tasks.
+					select {
+					case <-w.ctx.Done():
+						return
+					default:
+					}
 					w.onItem(task)
 				}
 			}
@@ -83,15 +92,18 @@ func (w *worker) Run() {
 }
 
 func (w *worker) Submit(iteration *IterationContext) error {
-	status := make([]*JobStatus, len(iteration.jobNames))
-	for i := range status {
-		status[i] = &JobStatus{}
+	if iteration == nil {
+		return moerr.NewInternalErrorNoCtx("cannot submit a nil ISCP iteration")
 	}
 	if w.closed.Load() {
-		return moerr.NewInternalError(context.Background(), "ISCP-Worker is closed")
+		return moerr.NewInternalErrorNoCtx("ISCP-Worker is closed")
 	}
-	w.taskChan <- iteration
-	return nil
+	select {
+	case w.taskChan <- iteration:
+		return nil
+	case <-w.ctx.Done():
+		return moerr.NewInternalErrorNoCtx("ISCP-Worker is closed")
+	}
 }
 
 func (w *worker) onItem(iterCtx *IterationContext) {
@@ -164,8 +176,9 @@ func (w *worker) onItem(iterCtx *IterationContext) {
 }
 
 func (w *worker) Stop() {
-	w.closed.Store(true)
+	if !w.closed.CompareAndSwap(false, true) {
+		return
+	}
 	w.cancel()
 	w.wg.Wait()
-	close(w.taskChan)
 }

--- a/pkg/iscp/worker_test.go
+++ b/pkg/iscp/worker_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iscp
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerStopImmediatelyAfterConstruction(t *testing.T) {
+	previous := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previous)
+
+	for range 32 {
+		worker := NewWorker("", nil, nil, nil)
+		worker.Stop()
+		runtime.Gosched()
+	}
+}
+
+func TestWorkerStopIsIdempotent(t *testing.T) {
+	worker := NewWorker("", nil, nil, nil)
+
+	var stops sync.WaitGroup
+	for range 8 {
+		stops.Add(1)
+		go func() {
+			defer stops.Done()
+			worker.Stop()
+		}()
+	}
+	stops.Wait()
+}
+
+func TestWorkerRejectsInvalidOrClosedSubmissions(t *testing.T) {
+	worker := NewWorker("", nil, nil, nil)
+	require.Error(t, worker.Submit(nil))
+
+	worker.Stop()
+	require.Error(t, worker.Submit(&IterationContext{}))
+}
+
+func TestWorkerCancellationUnblocksSubmit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	tasks := make(chan *IterationContext, 1)
+	tasks <- &IterationContext{}
+	w := &worker{
+		taskChan: tasks,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+
+	cancel()
+	require.Error(t, w.Submit(&IterationContext{}))
+}

--- a/pkg/publication/accepted_job_batch_test.go
+++ b/pkg/publication/accepted_job_batch_test.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publication
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/stretchr/testify/require"
+)
+
+var errAdmissionSealed = errors.New("admission sealed")
+
+type controlledAcceptedJob struct {
+	canceled chan struct{}
+	release  chan struct{}
+}
+
+func newControlledAcceptedJob() *controlledAcceptedJob {
+	return &controlledAcceptedJob{
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+}
+
+func (c *controlledAcceptedJob) completeAfterCancellation(ctx context.Context, job Job) {
+	go func() {
+		<-ctx.Done()
+		close(c.canceled)
+		<-c.release
+		failAcceptedJob(job, ctx.Err())
+	}()
+}
+
+func assertCancelAndJoin(t *testing.T, canceled <-chan struct{}, release chan struct{}, returned <-chan error) {
+	t.Helper()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("accepted job was not canceled")
+	}
+	select {
+	case err := <-returned:
+		t.Fatalf("owner returned before joining the accepted job: %v", err)
+	default:
+	}
+	close(release)
+	select {
+	case err := <-returned:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("owner did not return after the accepted job completed")
+	}
+}
+
+type prefixRejectGetChunkWorker struct {
+	controlled *controlledAcceptedJob
+	chunks     int
+}
+
+func (w *prefixRejectGetChunkWorker) SubmitGetChunk(job Job) error {
+	switch job := job.(type) {
+	case *GetMetaJob:
+		job.Execute()
+		return nil
+	case *GetChunkJob:
+		w.chunks++
+		if w.chunks > 1 {
+			return errAdmissionSealed
+		}
+		w.controlled.completeAfterCancellation(job.ctx, job)
+		return nil
+	default:
+		return errors.New("unexpected job type")
+	}
+}
+
+func (*prefixRejectGetChunkWorker) Stop() {}
+
+func newTwoChunkMetadataExecutor() SQLExecutor {
+	return &mockSQLExecutorForJob{execFn: func(
+		context.Context,
+		*ActiveRoutine,
+		uint32,
+		string,
+		bool,
+		bool,
+		time.Duration,
+	) (*Result, context.CancelFunc, error) {
+		return newMockResult(&mockScanner{
+			nextFn: func() bool { return true },
+			scanFn: func(dest ...interface{}) error {
+				*dest[0].(*[]byte) = nil
+				*dest[1].(*int64) = 2
+				*dest[2].(*int64) = 0
+				*dest[3].(*int64) = 2
+				*dest[4].(*bool) = false
+				return nil
+			},
+			closeFn: func() error { return nil },
+			errFn:   func() error { return nil },
+		}), noopCancel, nil
+	}}
+}
+
+func TestGetObjectJoinsAcceptedPrefixWhenChunkAdmissionIsSealed(t *testing.T) {
+	controlled := newControlledAcceptedJob()
+	worker := &prefixRejectGetChunkWorker{controlled: controlled}
+	returned := make(chan error, 1)
+	go func() {
+		_, err := GetObjectFromUpstreamWithWorker(
+			context.Background(), newTwoChunkMetadataExecutor(), "object", worker, "account", "publication",
+		)
+		returned <- err
+	}()
+
+	assertCancelAndJoin(t, controlled.canceled, controlled.release, returned)
+}
+
+type resultFailureGetChunkWorker struct {
+	controlled *controlledAcceptedJob
+	chunks     int
+}
+
+func (w *resultFailureGetChunkWorker) SubmitGetChunk(job Job) error {
+	switch job := job.(type) {
+	case *GetMetaJob:
+		job.Execute()
+		return nil
+	case *GetChunkJob:
+		w.chunks++
+		switch w.chunks {
+		case 1:
+			failAcceptedJob(job, errors.New("chunk failed"))
+			return nil
+		case 2:
+			w.controlled.completeAfterCancellation(job.ctx, job)
+			return nil
+		default:
+			// Reject the retry for chunk one. The already accepted second
+			// chunk must still be canceled and joined before return.
+			return errAdmissionSealed
+		}
+	default:
+		return errors.New("unexpected job type")
+	}
+}
+
+func (*resultFailureGetChunkWorker) Stop() {}
+
+func TestGetObjectJoinsRemainingChunksAfterResultFailure(t *testing.T) {
+	controlled := newControlledAcceptedJob()
+	worker := &resultFailureGetChunkWorker{controlled: controlled}
+	returned := make(chan error, 1)
+	go func() {
+		_, err := GetObjectFromUpstreamWithWorker(
+			context.Background(), newTwoChunkMetadataExecutor(), "object", worker, "account", "publication",
+		)
+		returned <- err
+	}()
+
+	assertCancelAndJoin(t, controlled.canceled, controlled.release, returned)
+}
+
+type controlledFilterWorker struct {
+	controlled      *controlledAcceptedJob
+	accepted        int
+	rejectAfter     int
+	failFirstResult bool
+}
+
+func (w *controlledFilterWorker) SubmitFilterObject(job Job) error {
+	w.accepted++
+	if w.rejectAfter > 0 && w.accepted > w.rejectAfter {
+		return errAdmissionSealed
+	}
+	filterJob := job.(*FilterObjectJob)
+	if w.failFirstResult && w.accepted == 1 {
+		failAcceptedJob(job, errors.New("filter failed"))
+		return nil
+	}
+	w.controlled.completeAfterCancellation(filterJob.ctx, job)
+	return nil
+}
+
+func (*controlledFilterWorker) Stop() {}
+
+func makeFilterObjectMap(tombstone bool) map[objectio.ObjectId]*ObjectWithTableInfo {
+	objects := make(map[objectio.ObjectId]*ObjectWithTableInfo, 2)
+	for i := byte(1); i <= 2; i++ {
+		var id objectio.ObjectId
+		id[0] = i
+		objects[id] = &ObjectWithTableInfo{
+			IsTombstone: tombstone,
+			DBName:      "db",
+			TableName:   "table",
+		}
+	}
+	return objects
+}
+
+func runApplyObjects(t *testing.T, objects map[objectio.ObjectId]*ObjectWithTableInfo, worker FilterObjectWorker) <-chan error {
+	t.Helper()
+	returned := make(chan error, 1)
+	go func() {
+		returned <- ApplyObjects(
+			context.Background(), "task", 0, nil, objects,
+			nil, nil, types.TS{}, nil, nil, nil, nil,
+			worker, nil, nil, "account", "publication", nil, nil, nil,
+		)
+	}()
+	return returned
+}
+
+func TestApplyObjectsJoinsAcceptedPrefixWhenFilterAdmissionIsSealed(t *testing.T) {
+	for _, tombstone := range []bool{false, true} {
+		name := "data"
+		if tombstone {
+			name = "tombstone"
+		}
+		t.Run(name, func(t *testing.T) {
+			controlled := newControlledAcceptedJob()
+			worker := &controlledFilterWorker{
+				controlled:  controlled,
+				rejectAfter: 1,
+			}
+			returned := runApplyObjects(t, makeFilterObjectMap(tombstone), worker)
+			assertCancelAndJoin(t, controlled.canceled, controlled.release, returned)
+		})
+	}
+}
+
+func TestApplyObjectsJoinsRemainingJobsAfterResultFailure(t *testing.T) {
+	for _, tombstone := range []bool{false, true} {
+		name := "data"
+		if tombstone {
+			name = "tombstone"
+		}
+		t.Run(name, func(t *testing.T) {
+			controlled := newControlledAcceptedJob()
+			worker := &controlledFilterWorker{
+				controlled:      controlled,
+				failFirstResult: true,
+			}
+			returned := runApplyObjects(t, makeFilterObjectMap(tombstone), worker)
+			assertCancelAndJoin(t, controlled.canceled, controlled.release, returned)
+		})
+	}
+}

--- a/pkg/publication/executor.go
+++ b/pkg/publication/executor.go
@@ -156,6 +156,10 @@ func fillDefaultOption(option *PublicationExecutorOption) *PublicationExecutorOp
 	return option
 }
 
+func newPublicationTaskTree() *btree.BTreeG[TaskEntry] {
+	return btree.NewBTreeGOptions(taskEntryLess, btree.Options{NoLocks: true})
+}
+
 func NewPublicationTaskExecutor(
 	ctx context.Context,
 	txnEngine engine.Engine,
@@ -187,7 +191,7 @@ func NewPublicationTaskExecutor(
 		ownerCtx:                 ctx,
 		terminated:               make(chan struct{}),
 		ctx:                      ctx,
-		tasks:                    btree.NewBTreeGOptions(taskEntryLess, btree.Options{NoLocks: true}),
+		tasks:                    newPublicationTaskTree(),
 		cnUUID:                   cdUUID,
 		txnEngine:                txnEngine,
 		cnTxnClient:              cnTxnClient,
@@ -321,28 +325,32 @@ func (exec *PublicationTaskExecutor) initStateLocked(parent context.Context) err
 		"Publication-Task Start",
 	)
 	ctx, cancel := context.WithCancel(parent)
-	worker := NewWorker(exec.cnUUID, exec.txnEngine, exec.cnTxnClient, exec.mp, exec.upstreamSQLHelperFactory)
+	// A stopped generation can leave accepted top-level tasks in memory as
+	// Pending, or in storage as Running. Repair storage first, then build the
+	// next generation entirely from that authoritative snapshot.
 	err := retryPublication(
 		ctx,
 		func() error {
-			return exec.replay(ctx)
+			return exec.repairAbandonedTasks(ctx)
 		},
 		exec.option.RetryOption,
 	)
 	if err != nil {
-		worker.Stop()
 		cancel()
 		return err
 	}
-	// Update tasks with state != error and drop_at is empty to complete
-	err = exec.updateNonErrorTasksToComplete(ctx)
+	err = retryPublication(
+		ctx,
+		func() error {
+			return exec.rebuildState(ctx)
+		},
+		exec.option.RetryOption,
+	)
 	if err != nil {
-		logutil.Error(
-			"Publication-Task update non-error tasks to complete failed",
-			zap.Error(err),
-		)
-		// Don't return error, continue execution
+		cancel()
+		return err
 	}
+	worker := NewWorker(exec.cnUUID, exec.txnEngine, exec.cnTxnClient, exec.mp, exec.upstreamSQLHelperFactory)
 	exec.worker = worker
 	exec.ctx = ctx
 	exec.cancel = cancel
@@ -436,9 +444,6 @@ func (exec *PublicationTaskExecutor) run(ctx context.Context, worker Worker) {
 				return
 			}
 			for _, task := range candidateTasks {
-				task.State = IterationStatePending
-				exec.setTask(task)
-				// Only trigger tasks that are not completed
 				err = worker.Submit(task.TaskID, task.LSN, task.State)
 				if err != nil {
 					logutil.Error(
@@ -450,6 +455,10 @@ func (exec *PublicationTaskExecutor) run(ctx context.Context, worker Worker) {
 					)
 					continue
 				}
+				// Admission is the linearization point. Mark the task pending only
+				// after the worker owns it; rejected work remains a candidate.
+				task.State = IterationStatePending
+				exec.setTask(task)
 			}
 		case <-gcTrigger.C:
 			err := GC(ctx, exec.txnEngine, exec.cnTxnClient, exec.cnUUID, exec.upstreamSQLHelperFactory, exec.option.GCTTL)
@@ -659,7 +668,18 @@ func (exec *PublicationTaskExecutor) applyCcprLogWithRel(ctx context.Context, re
 	return
 }
 
-func (exec *PublicationTaskExecutor) replay(ctx context.Context) (err error) {
+type publicationReplayApplyFunc func(
+	taskID string,
+	lsn uint64,
+	state int8,
+	subscriptionState int8,
+	dropAt *time.Time,
+) error
+
+func (exec *PublicationTaskExecutor) loadReplay(
+	ctx context.Context,
+	apply publicationReplayApplyFunc,
+) (watermark types.TS, err error) {
 	defer func() {
 		var logger func(msg string, fields ...zap.Field)
 		if err != nil {
@@ -680,7 +700,13 @@ func (exec *PublicationTaskExecutor) replay(ctx context.Context) (err error) {
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
-	defer txn.Commit(ctx)
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, txn.Rollback(ctx))
+			return
+		}
+		err = txn.Commit(ctx)
+	}()
 	result, err := ExecWithResult(ctx, sql, exec.cnUUID, txn)
 	if err != nil {
 		return
@@ -711,7 +737,7 @@ func (exec *PublicationTaskExecutor) replay(ctx context.Context) (err error) {
 				t := dt.ConvertToGoTime(time.UTC)
 				dropAt = &t
 			}
-			err = exec.addOrUpdateTask(
+			err = apply(
 				taskIDs[i].String(),
 				uint64(lsns[i]),
 				states[i],
@@ -724,8 +750,84 @@ func (exec *PublicationTaskExecutor) replay(ctx context.Context) (err error) {
 		}
 		return true
 	})
-	exec.ccprLogWm = types.TimestampToTS(txn.SnapshotTS())
+	if err != nil {
+		return
+	}
+	watermark = types.TimestampToTS(txn.SnapshotTS())
 	return
+}
+
+// replay merges a snapshot into a live generation. It is used for stale-read
+// recovery while that generation can still have in-flight work.
+func (exec *PublicationTaskExecutor) replay(ctx context.Context) error {
+	watermark, err := exec.loadReplay(ctx, exec.mergeReplayedTask)
+	if err != nil {
+		return err
+	}
+	exec.ccprLogWm = watermark
+	return nil
+}
+
+func (exec *PublicationTaskExecutor) mergeReplayedTask(
+	taskID string,
+	lsn uint64,
+	state int8,
+	subscriptionState int8,
+	dropAt *time.Time,
+) error {
+	current, ok := exec.getTask(taskID)
+	if ok &&
+		(current.State == IterationStatePending || current.State == IterationStateRunning) &&
+		lsn <= current.LSN {
+		// A replay snapshot can lag an admitted iteration. Preserve its local
+		// ownership until normal logtail apply observes a newer durable LSN.
+		// Subscription/drop metadata remains authoritative independently.
+		current.SubscriptionState = subscriptionState
+		current.DropAt = dropAt
+		exec.setTask(current)
+		return nil
+	}
+	return exec.addOrUpdateTask(taskID, lsn, state, subscriptionState, dropAt)
+}
+
+func (exec *PublicationTaskExecutor) addOrUpdateRecoveredTask(
+	taskID string,
+	lsn uint64,
+	state int8,
+	subscriptionState int8,
+	dropAt *time.Time,
+) error {
+	// Read-after-repair can use a snapshot from before the repair commit becomes
+	// visible through logtail. Mirror the idempotent storage repair in memory.
+	if dropAt == nil {
+		switch state {
+		case IterationStatePending, IterationStateRunning, IterationStateCanceled:
+			state = IterationStateCompleted
+		}
+	}
+	return exec.addOrUpdateTask(taskID, lsn, state, subscriptionState, dropAt)
+}
+
+// rebuildState replaces, rather than merges, the stopped generation's memory.
+// No worker from that generation remains to make its optimistic state durable.
+func (exec *PublicationTaskExecutor) rebuildState(ctx context.Context) error {
+	snapshot := &PublicationTaskExecutor{tasks: newPublicationTaskTree()}
+	watermark, err := exec.loadReplay(ctx, snapshot.addOrUpdateRecoveredTask)
+	if err != nil {
+		return err
+	}
+	exec.publishRebuiltState(snapshot, watermark)
+	return nil
+}
+
+func (exec *PublicationTaskExecutor) publishRebuiltState(
+	snapshot *PublicationTaskExecutor,
+	watermark types.TS,
+) {
+	exec.taskMu.Lock()
+	exec.tasks = snapshot.tasks
+	exec.ccprLogWm = watermark
+	exec.taskMu.Unlock()
 }
 
 func (exec *PublicationTaskExecutor) addOrUpdateTask(
@@ -758,9 +860,9 @@ func (exec *PublicationTaskExecutor) addOrUpdateTask(
 	return nil
 }
 
-func (exec *PublicationTaskExecutor) updateNonErrorTasksToComplete(ctx context.Context) error {
-	// Update tasks in database using SQL
-	// Update all rows where iteration_state != error and drop_at is NULL
+func (exec *PublicationTaskExecutor) repairAbandonedTasks(ctx context.Context) (err error) {
+	// Repair only nonterminal iterations. Avoid rewriting every already-complete
+	// row on each Pause/Resume cycle.
 	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
 	txn, err := getTxn(ctx, exec.txnEngine, exec.cnTxnClient, "publication update non-error tasks")
 	if err != nil {
@@ -769,15 +871,22 @@ func (exec *PublicationTaskExecutor) updateNonErrorTasksToComplete(ctx context.C
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
-	defer txn.Commit(ctx)
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, txn.Rollback(ctx))
+			return
+		}
+		err = txn.Commit(ctx)
+	}()
 
-	// Use SQL to update all rows where state != error and drop_at IS NULL
 	updateSQL := fmt.Sprintf(
 		`UPDATE mo_catalog.mo_ccpr_log `+
 			`SET iteration_state = %d `+
-			`WHERE iteration_state != %d AND drop_at IS NULL`,
+			`WHERE iteration_state IN (%d, %d, %d) AND drop_at IS NULL`,
 		IterationStateCompleted,
-		IterationStateError,
+		IterationStatePending,
+		IterationStateRunning,
+		IterationStateCanceled,
 	)
 
 	result, err := ExecWithResult(ctx, updateSQL, exec.cnUUID, txn)
@@ -786,7 +895,7 @@ func (exec *PublicationTaskExecutor) updateNonErrorTasksToComplete(ctx context.C
 	}
 	defer result.Close()
 
-	logutil.Info("Publication-Task updated non-error tasks with empty drop_at to complete")
+	logutil.Info("Publication-Task repaired abandoned iterations")
 	return nil
 }
 
@@ -1321,7 +1430,7 @@ var getTxn = func(
 	}
 	err = cnEngine.New(ctx, op)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, op.Rollback(ctx))
 	}
 	return op, nil
 }

--- a/pkg/publication/executor.go
+++ b/pkg/publication/executor.go
@@ -121,19 +121,22 @@ func PublicationTaskExecutorFactory(
 		if err != nil {
 			return
 		}
-		attachToTask(ctx, task.GetID(), exec)
+		if err = attachToTask(ctx, task.GetID(), exec); err != nil {
+			return
+		}
 
 		exec.runningMu.Lock()
 		if exec.running {
 			exec.runningMu.Unlock()
 			return
 		}
-		err = exec.initStateLocked()
+		err = exec.initStateLocked(ctx)
 		exec.runningMu.Unlock()
 		if err != nil {
 			return
 		}
-		exec.run(ctx)
+		exec.run(exec.ctx, exec.worker)
+		exec.Stop()
 		return
 	}
 }
@@ -272,19 +275,19 @@ func (exec *PublicationTaskExecutor) Start() error {
 	if exec.running {
 		return nil
 	}
-	err := exec.initStateLocked()
+	err := exec.initStateLocked(context.Background())
 	if err != nil {
 		return err
 	}
-	go exec.run(exec.ctx)
+	go exec.run(exec.ctx, exec.worker)
 	return nil
 }
 
-func (exec *PublicationTaskExecutor) initStateLocked() error {
+func (exec *PublicationTaskExecutor) initStateLocked(parent context.Context) error {
 	logutil.Info(
 		"Publication-Task Start",
 	)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(parent)
 	worker := NewWorker(exec.cnUUID, exec.txnEngine, exec.cnTxnClient, exec.mp, exec.upstreamSQLHelperFactory)
 	err := retryPublication(
 		ctx,
@@ -325,8 +328,8 @@ func (exec *PublicationTaskExecutor) Stop() {
 	logutil.Info(
 		"Publication-Task Stop",
 	)
-	exec.worker.Stop()
 	exec.cancel()
+	exec.worker.Stop()
 	exec.wg.Wait()
 	exec.ctx, exec.cancel = nil, nil
 	exec.worker = nil
@@ -338,7 +341,7 @@ func (exec *PublicationTaskExecutor) IsRunning() bool {
 	return exec.running
 }
 
-func (exec *PublicationTaskExecutor) run(ctx context.Context) {
+func (exec *PublicationTaskExecutor) run(ctx context.Context, worker Worker) {
 	logutil.Info(
 		"Publication-Task Run",
 	)
@@ -360,12 +363,12 @@ func (exec *PublicationTaskExecutor) run(ctx context.Context) {
 			// apply mo_ccpr_log
 			from := exec.ccprLogWm.Next()
 			to := types.TimestampToTS(exec.txnEngine.LatestLogtailAppliedTime())
-			err := exec.applyCcprLog(exec.ctx, from, to)
+			err := exec.applyCcprLog(ctx, from, to)
 			if err == nil {
 				exec.ccprLogWm = to
 			}
 			if err != nil && moerr.IsMoErrCode(err, moerr.ErrStaleRead) {
-				err = exec.replay(exec.ctx)
+				err = exec.replay(ctx)
 			}
 			if err != nil {
 				logutil.Error(
@@ -382,7 +385,7 @@ func (exec *PublicationTaskExecutor) run(ctx context.Context) {
 				continue
 			}
 			// check lease before submitting tasks
-			ok, err := CheckLeaseWithRetry(exec.ctx, exec.cnUUID, exec.txnEngine, exec.cnTxnClient)
+			ok, err := CheckLeaseWithRetry(ctx, exec.cnUUID, exec.txnEngine, exec.cnTxnClient)
 			if err != nil {
 				logutil.Error(
 					"Publication-Task check lease failed",
@@ -392,16 +395,9 @@ func (exec *PublicationTaskExecutor) run(ctx context.Context) {
 			}
 			if !ok {
 				logutil.Error("Publication-Task lease check failed, stopping executor")
-				exec.cancel()
+				go exec.Stop()
 				return
 			}
-			exec.runningMu.Lock()
-			if !exec.running || exec.worker == nil {
-				exec.runningMu.Unlock()
-				return
-			}
-			worker := exec.worker
-			exec.runningMu.Unlock()
 			for _, task := range candidateTasks {
 				task.State = IterationStatePending
 				exec.setTask(task)
@@ -419,7 +415,7 @@ func (exec *PublicationTaskExecutor) run(ctx context.Context) {
 				}
 			}
 		case <-gcTrigger.C:
-			err := GC(exec.ctx, exec.txnEngine, exec.cnTxnClient, exec.cnUUID, exec.upstreamSQLHelperFactory, exec.option.GCTTL)
+			err := GC(ctx, exec.txnEngine, exec.cnTxnClient, exec.cnUUID, exec.upstreamSQLHelperFactory, exec.option.GCTTL)
 			if err != nil {
 				logutil.Error(
 					"Publication-Task gc failed",

--- a/pkg/publication/executor.go
+++ b/pkg/publication/executor.go
@@ -125,17 +125,10 @@ func PublicationTaskExecutorFactory(
 			return
 		}
 
-		exec.runningMu.Lock()
-		if exec.running {
-			exec.runningMu.Unlock()
+		if err = exec.Start(); err != nil {
 			return
 		}
-		err = exec.initStateLocked(ctx)
-		exec.runningMu.Unlock()
-		if err != nil {
-			return
-		}
-		exec.run(exec.ctx, exec.worker)
+		exec.waitForTermination(ctx)
 		exec.Stop()
 		return
 	}
@@ -191,6 +184,8 @@ func NewPublicationTaskExecutor(
 	}()
 	option = fillDefaultOption(option)
 	exec = &PublicationTaskExecutor{
+		ownerCtx:                 ctx,
+		terminated:               make(chan struct{}),
 		ctx:                      ctx,
 		tasks:                    btree.NewBTreeGOptions(taskEntryLess, btree.Options{NoLocks: true}),
 		cnUUID:                   cdUUID,
@@ -232,8 +227,11 @@ type PublicationTaskExecutor struct {
 
 	option *PublicationExecutorOption
 
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx           context.Context
+	cancel        context.CancelFunc
+	ownerCtx      context.Context
+	terminated    chan struct{}
+	terminateOnce sync.Once
 
 	worker Worker
 	wg     sync.WaitGroup
@@ -256,7 +254,10 @@ func (exec *PublicationTaskExecutor) Pause() error {
 }
 
 func (exec *PublicationTaskExecutor) Cancel() error {
-	exec.Stop()
+	exec.runningMu.Lock()
+	defer exec.runningMu.Unlock()
+	exec.terminate()
+	exec.stopLocked()
 	return nil
 }
 
@@ -272,15 +273,47 @@ func (exec *PublicationTaskExecutor) Restart() error {
 func (exec *PublicationTaskExecutor) Start() error {
 	exec.runningMu.Lock()
 	defer exec.runningMu.Unlock()
+	if exec.isTerminated() {
+		return moerr.NewInternalErrorNoCtx("Publication-Task Executor is canceled")
+	}
 	if exec.running {
 		return nil
 	}
-	err := exec.initStateLocked(context.Background())
+	parent := exec.ownerCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	err := exec.initStateLocked(parent)
 	if err != nil {
 		return err
 	}
 	go exec.run(exec.ctx, exec.worker)
 	return nil
+}
+
+func (exec *PublicationTaskExecutor) waitForTermination(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-exec.terminated:
+	}
+}
+
+func (exec *PublicationTaskExecutor) terminate() {
+	if exec.terminated != nil {
+		exec.terminateOnce.Do(func() { close(exec.terminated) })
+	}
+}
+
+func (exec *PublicationTaskExecutor) isTerminated() bool {
+	if exec.terminated == nil {
+		return false
+	}
+	select {
+	case <-exec.terminated:
+		return true
+	default:
+		return false
+	}
 }
 
 func (exec *PublicationTaskExecutor) initStateLocked(parent context.Context) error {
@@ -321,6 +354,10 @@ func (exec *PublicationTaskExecutor) initStateLocked(parent context.Context) err
 func (exec *PublicationTaskExecutor) Stop() {
 	exec.runningMu.Lock()
 	defer exec.runningMu.Unlock()
+	exec.stopLocked()
+}
+
+func (exec *PublicationTaskExecutor) stopLocked() {
 	if !exec.running {
 		return
 	}
@@ -395,7 +432,7 @@ func (exec *PublicationTaskExecutor) run(ctx context.Context, worker Worker) {
 			}
 			if !ok {
 				logutil.Error("Publication-Task lease check failed, stopping executor")
-				go exec.Stop()
+				go exec.Cancel()
 				return
 			}
 			for _, task := range candidateTasks {

--- a/pkg/publication/executor.go
+++ b/pkg/publication/executor.go
@@ -121,6 +121,7 @@ func PublicationTaskExecutorFactory(
 		if err != nil {
 			return
 		}
+		defer exec.terminateLifetime()
 		if err = attachToTask(ctx, task.GetID(), exec); err != nil {
 			return
 		}
@@ -187,10 +188,11 @@ func NewPublicationTaskExecutor(
 		)
 	}()
 	option = fillDefaultOption(option)
+	ownerCtx, terminate := context.WithCancel(ctx)
 	exec = &PublicationTaskExecutor{
-		ownerCtx:                 ctx,
-		terminated:               make(chan struct{}),
-		ctx:                      ctx,
+		ownerCtx:                 ownerCtx,
+		terminate:                terminate,
+		ctx:                      ownerCtx,
 		tasks:                    newPublicationTaskTree(),
 		cnUUID:                   cdUUID,
 		txnEngine:                txnEngine,
@@ -231,11 +233,10 @@ type PublicationTaskExecutor struct {
 
 	option *PublicationExecutorOption
 
-	ctx           context.Context
-	cancel        context.CancelFunc
-	ownerCtx      context.Context
-	terminated    chan struct{}
-	terminateOnce sync.Once
+	ctx       context.Context
+	cancel    context.CancelFunc
+	ownerCtx  context.Context
+	terminate context.CancelFunc
 
 	worker Worker
 	wg     sync.WaitGroup
@@ -258,9 +259,12 @@ func (exec *PublicationTaskExecutor) Pause() error {
 }
 
 func (exec *PublicationTaskExecutor) Cancel() error {
+	// Start can hold runningMu while recovery is blocked in storage. Signal the
+	// lifetime context first so that work is interruptible before cleanup joins
+	// the generation under the state lock.
+	exec.terminateLifetime()
 	exec.runningMu.Lock()
 	defer exec.runningMu.Unlock()
-	exec.terminate()
 	exec.stopLocked()
 	return nil
 }
@@ -296,28 +300,24 @@ func (exec *PublicationTaskExecutor) Start() error {
 }
 
 func (exec *PublicationTaskExecutor) waitForTermination(ctx context.Context) {
+	var ownerDone <-chan struct{}
+	if exec.ownerCtx != nil {
+		ownerDone = exec.ownerCtx.Done()
+	}
 	select {
 	case <-ctx.Done():
-	case <-exec.terminated:
+	case <-ownerDone:
 	}
 }
 
-func (exec *PublicationTaskExecutor) terminate() {
-	if exec.terminated != nil {
-		exec.terminateOnce.Do(func() { close(exec.terminated) })
+func (exec *PublicationTaskExecutor) terminateLifetime() {
+	if exec.terminate != nil {
+		exec.terminate()
 	}
 }
 
 func (exec *PublicationTaskExecutor) isTerminated() bool {
-	if exec.terminated == nil {
-		return false
-	}
-	select {
-	case <-exec.terminated:
-		return true
-	default:
-		return false
-	}
+	return exec.ownerCtx != nil && exec.ownerCtx.Err() != nil
 }
 
 func (exec *PublicationTaskExecutor) initStateLocked(parent context.Context) error {

--- a/pkg/publication/executor.go
+++ b/pkg/publication/executor.go
@@ -778,9 +778,13 @@ func (exec *PublicationTaskExecutor) mergeReplayedTask(
 	current, ok := exec.getTask(taskID)
 	if ok &&
 		(current.State == IterationStatePending || current.State == IterationStateRunning) &&
-		lsn <= current.LSN {
+		(lsn < current.LSN ||
+			(lsn == current.LSN &&
+				(state == IterationStatePending || state == IterationStateRunning))) {
 		// A replay snapshot can lag an admitted iteration. Preserve its local
-		// ownership until normal logtail apply observes a newer durable LSN.
+		// ownership only for an older LSN or the same in-flight iteration. A
+		// terminal state at the same LSN is the durable completion of that exact
+		// iteration and must win before the replay watermark advances.
 		// Subscription/drop metadata remains authoritative independently.
 		current.SubscriptionState = subscriptionState
 		current.DropAt = dropAt

--- a/pkg/publication/executor_factory_test.go
+++ b/pkg/publication/executor_factory_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
@@ -43,5 +44,49 @@ func TestExecutorFactoryReturnsAttachErrorAndReleasesAdmission(t *testing.T) {
 
 	for range 2 {
 		require.ErrorIs(t, factory(context.Background(), &task.DaemonTask{}), attachErr)
+	}
+}
+
+func TestExecutorLifetimeSurvivesPauseAndEndsOnCancel(t *testing.T) {
+	exec := &PublicationTaskExecutor{terminated: make(chan struct{})}
+	returned := make(chan struct{})
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		exec.waitForTermination(context.Background())
+		close(returned)
+	}()
+	<-started
+
+	require.NoError(t, exec.Pause())
+	select {
+	case <-returned:
+		t.Fatal("pause terminated the daemon executor lifetime")
+	default:
+	}
+
+	require.NoError(t, exec.Cancel())
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not terminate the daemon executor lifetime")
+	}
+	require.Error(t, exec.Start())
+}
+
+func TestExecutorLifetimeEndsWithOwnerContext(t *testing.T) {
+	exec := &PublicationTaskExecutor{terminated: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	returned := make(chan struct{})
+	go func() {
+		exec.waitForTermination(ctx)
+		close(returned)
+	}()
+	cancel()
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("owner cancellation did not terminate the daemon executor lifetime")
 	}
 }

--- a/pkg/publication/executor_factory_test.go
+++ b/pkg/publication/executor_factory_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publication
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/task"
+	"github.com/matrixorigin/matrixone/pkg/taskservice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorFactoryReturnsAttachErrorAndReleasesAdmission(t *testing.T) {
+	running.Store(false)
+	t.Cleanup(func() { running.Store(false) })
+
+	attachErr := errors.New("attach failed")
+	factory := PublicationTaskExecutorFactory(
+		nil,
+		nil,
+		func(context.Context, uint64, taskservice.ActiveRoutine) error {
+			return attachErr
+		},
+		"",
+		nil,
+		nil,
+		nil,
+	)
+
+	for range 2 {
+		require.ErrorIs(t, factory(context.Background(), &task.DaemonTask{}), attachErr)
+	}
+}

--- a/pkg/publication/executor_factory_test.go
+++ b/pkg/publication/executor_factory_test.go
@@ -48,7 +48,8 @@ func TestExecutorFactoryReturnsAttachErrorAndReleasesAdmission(t *testing.T) {
 }
 
 func TestExecutorLifetimeSurvivesPauseAndEndsOnCancel(t *testing.T) {
-	exec := &PublicationTaskExecutor{terminated: make(chan struct{})}
+	ownerCtx, terminate := context.WithCancel(context.Background())
+	exec := &PublicationTaskExecutor{ownerCtx: ownerCtx, terminate: terminate}
 	returned := make(chan struct{})
 	started := make(chan struct{})
 	go func() {
@@ -75,8 +76,8 @@ func TestExecutorLifetimeSurvivesPauseAndEndsOnCancel(t *testing.T) {
 }
 
 func TestExecutorLifetimeEndsWithOwnerContext(t *testing.T) {
-	exec := &PublicationTaskExecutor{terminated: make(chan struct{})}
 	ctx, cancel := context.WithCancel(context.Background())
+	exec := &PublicationTaskExecutor{ownerCtx: ctx}
 	returned := make(chan struct{})
 	go func() {
 		exec.waitForTermination(ctx)
@@ -88,5 +89,36 @@ func TestExecutorLifetimeEndsWithOwnerContext(t *testing.T) {
 	case <-returned:
 	case <-time.After(time.Second):
 		t.Fatal("owner cancellation did not terminate the daemon executor lifetime")
+	}
+}
+
+func TestCancelSignalsLifetimeBeforeWaitingForStateLock(t *testing.T) {
+	ownerCtx, terminate := context.WithCancel(context.Background())
+	exec := &PublicationTaskExecutor{ownerCtx: ownerCtx, terminate: terminate}
+	exec.runningMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			exec.runningMu.Unlock()
+		}
+	}()
+
+	returned := make(chan struct{})
+	go func() {
+		_ = exec.Cancel()
+		close(returned)
+	}()
+
+	select {
+	case <-ownerCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("cancel waited for the state lock before signaling termination")
+	}
+	exec.runningMu.Unlock()
+	locked = false
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not finish after the state lock was released")
 	}
 }

--- a/pkg/publication/filter_object.go
+++ b/pkg/publication/filter_object.go
@@ -392,7 +392,9 @@ func filterNonAppendableObject(
 	// For data objects (or tombstone without aobjectMap), write directly to fileservice
 	writeJob := NewWriteObjectJob(ctx, localFS, upstreamObjectName, objectContent, ccprCache, txnID)
 	if writeObjectWorker != nil {
-		writeObjectWorker.SubmitWriteObject(writeJob)
+		if err := writeObjectWorker.SubmitWriteObject(writeJob); err != nil {
+			return objectio.ObjectStats{}, err
+		}
 	} else {
 		writeJob.Execute()
 	}
@@ -438,7 +440,9 @@ var GetObjectFromUpstreamWithWorker = func(
 		chunkJob := NewGetChunkJob(ctx, upstreamExecutor, objectName, i, subscriptionAccountName, pubName)
 		chunkJobs[i-1] = chunkJob
 		if getChunkWorker != nil {
-			getChunkWorker.SubmitGetChunk(chunkJob)
+			if err := getChunkWorker.SubmitGetChunk(chunkJob); err != nil {
+				return nil, err
+			}
 		} else {
 			chunkJob.Execute()
 		}
@@ -493,7 +497,9 @@ func getMetaWithRetry(
 
 		metaJob := NewGetMetaJob(ctx, upstreamExecutor, objectName, subscriptionAccountName, pubName)
 		if getChunkWorker != nil {
-			getChunkWorker.SubmitGetChunk(metaJob)
+			if err := getChunkWorker.SubmitGetChunk(metaJob); err != nil {
+				return nil, err
+			}
 		} else {
 			metaJob.Execute()
 		}
@@ -533,7 +539,9 @@ func getChunkWithRetry(
 
 		chunkJob := NewGetChunkJob(ctx, upstreamExecutor, objectName, chunkIndex, subscriptionAccountName, pubName)
 		if getChunkWorker != nil {
-			getChunkWorker.SubmitGetChunk(chunkJob)
+			if err := getChunkWorker.SubmitGetChunk(chunkJob); err != nil {
+				return nil, err
+			}
 		} else {
 			chunkJob.Execute()
 		}

--- a/pkg/publication/filter_object.go
+++ b/pkg/publication/filter_object.go
@@ -429,16 +429,22 @@ var GetObjectFromUpstreamWithWorker = func(
 	}
 
 	totalChunks := metaResult.TotalChunks
+	chunkCtx, cancelChunks := context.WithCancel(ctx)
+	var acceptedChunks acceptedJobBatch[*GetChunkJob]
+	defer func() {
+		// Cancel first so an error or partial admission cannot leave an accepted
+		// sibling blocked in I/O, then join before the shared executor can close.
+		cancelChunks()
+		acceptedChunks.join()
+	}()
 
 	// Fetch data chunks starting from chunk 1
 	// chunk 0 is metadata, chunks 1 to totalChunks are data chunks
 	allChunks := make([][]byte, totalChunks)
 
 	// Submit all chunk jobs to worker pool
-	chunkJobs := make([]*GetChunkJob, totalChunks)
 	for i := int64(1); i <= totalChunks; i++ {
-		chunkJob := NewGetChunkJob(ctx, upstreamExecutor, objectName, i, subscriptionAccountName, pubName)
-		chunkJobs[i-1] = chunkJob
+		chunkJob := NewGetChunkJob(chunkCtx, upstreamExecutor, objectName, i, subscriptionAccountName, pubName)
 		if getChunkWorker != nil {
 			if err := getChunkWorker.SubmitGetChunk(chunkJob); err != nil {
 				return nil, err
@@ -446,11 +452,12 @@ var GetObjectFromUpstreamWithWorker = func(
 		} else {
 			chunkJob.Execute()
 		}
+		acceptedChunks.add(chunkJob)
 	}
 
 	// Wait for all chunk jobs to complete, retry failed chunks
 	for i := int64(0); i < totalChunks; i++ {
-		chunkResult := chunkJobs[i].WaitDone().(*GetChunkJobResult)
+		chunkResult := acceptedChunks.waitNext().(*GetChunkJobResult)
 		if chunkResult.Err != nil {
 			// Retry failed chunk
 			chunkData, err := getChunkWithRetry(ctx, upstreamExecutor, objectName, i+1, getChunkWorker, subscriptionAccountName, pubName)

--- a/pkg/publication/filter_object_job.go
+++ b/pkg/publication/filter_object_job.go
@@ -60,9 +60,42 @@ type Job interface {
 	Execute()
 	WaitDone() any
 	GetType() int8
+}
+
+// TerminalJob is a Job that can publish an exactly-once failure when a worker
+// rejects or drains it. Worker pools require this additive contract at
+// admission so legacy Job implementations still compile and receive an
+// explicit error instead of hanging during shutdown.
+type TerminalJob interface {
+	Job
 	// Fail completes a job that cannot be executed. It is safe to race with
 	// Execute; exactly one terminal result is published.
 	Fail(error)
+}
+
+// acceptedJobBatch owns every job after successful admission. A caller must
+// join the batch before releasing resources shared by those jobs. Results are
+// consumed in admission order so each job's single terminal result is received
+// exactly once.
+type acceptedJobBatch[T Job] struct {
+	jobs   []T
+	joined int
+}
+
+func (b *acceptedJobBatch[T]) add(job T) {
+	b.jobs = append(b.jobs, job)
+}
+
+func (b *acceptedJobBatch[T]) waitNext() any {
+	result := b.jobs[b.joined].WaitDone()
+	b.joined++
+	return result
+}
+
+func (b *acceptedJobBatch[T]) join() {
+	for b.joined < len(b.jobs) {
+		b.waitNext()
+	}
 }
 
 // GetMetaJobResult holds the result of GetMetaJob

--- a/pkg/publication/filter_object_job.go
+++ b/pkg/publication/filter_object_job.go
@@ -17,6 +17,7 @@ package publication
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -59,6 +60,9 @@ type Job interface {
 	Execute()
 	WaitDone() any
 	GetType() int8
+	// Fail completes a job that cannot be executed. It is safe to race with
+	// Execute; exactly one terminal result is published.
+	Fail(error)
 }
 
 // GetMetaJobResult holds the result of GetMetaJob
@@ -79,6 +83,7 @@ type GetMetaJob struct {
 	subscriptionAccountName string
 	pubName                 string
 	result                  chan *GetMetaJobResult
+	completed               atomic.Bool
 }
 
 // NewGetMetaJob creates a new GetMetaJob
@@ -104,7 +109,7 @@ func (j *GetMetaJob) Execute() {
 		select {
 		case <-j.ctx.Done():
 			res.Err = j.ctx.Err()
-			j.result <- res
+			j.complete(res)
 			return
 		default:
 		}
@@ -114,7 +119,7 @@ func (j *GetMetaJob) Execute() {
 			lastErr = err
 			if !(DefaultClassifier{}).IsRetryable(err) {
 				res.Err = moerr.NewInternalErrorf(j.ctx, "failed to execute GETOBJECT query for offset 0: %v", err)
-				j.result <- res
+				j.complete(res)
 				return
 			}
 			continue
@@ -127,7 +132,7 @@ func (j *GetMetaJob) Execute() {
 				lastErr = err
 				if !(DefaultClassifier{}).IsRetryable(err) {
 					res.Err = moerr.NewInternalErrorf(j.ctx, "failed to read metadata for %s: %v", j.objectName, err)
-					j.result <- res
+					j.complete(res)
 					return
 				}
 				continue
@@ -135,7 +140,7 @@ func (j *GetMetaJob) Execute() {
 			result.Close()
 			cancel()
 			res.Err = moerr.NewInternalErrorf(j.ctx, "no object content returned for %s", j.objectName)
-			j.result <- res
+			j.complete(res)
 			return
 		}
 
@@ -145,7 +150,7 @@ func (j *GetMetaJob) Execute() {
 			lastErr = err
 			if !(DefaultClassifier{}).IsRetryable(err) {
 				res.Err = moerr.NewInternalErrorf(j.ctx, "failed to scan offset 0: %v", err)
-				j.result <- res
+				j.complete(res)
 				return
 			}
 			continue
@@ -155,23 +160,33 @@ func (j *GetMetaJob) Execute() {
 
 		if res.TotalChunks <= 0 {
 			res.Err = moerr.NewInternalErrorf(j.ctx, "invalid total_chunks: %d", res.TotalChunks)
-			j.result <- res
+			j.complete(res)
 			return
 		}
 
 		// Success
-		j.result <- res
+		j.complete(res)
 		return
 	}
 
 	// All retries failed
 	res.Err = moerr.NewInternalErrorf(j.ctx, "failed to get metadata for %s after %d retries: %v", j.objectName, maxRetries, lastErr)
-	j.result <- res
+	j.complete(res)
 }
 
 // WaitDone waits for the job to complete and returns the result
 func (j *GetMetaJob) WaitDone() any {
 	return <-j.result
+}
+
+func (j *GetMetaJob) complete(result *GetMetaJobResult) {
+	if j.completed.CompareAndSwap(false, true) {
+		j.result <- result
+	}
+}
+
+func (j *GetMetaJob) Fail(err error) {
+	j.complete(&GetMetaJobResult{Err: err})
 }
 
 // GetType returns the job type
@@ -195,6 +210,7 @@ type GetChunkJob struct {
 	subscriptionAccountName string
 	pubName                 string
 	result                  chan *GetChunkJobResult
+	completed               atomic.Bool
 }
 
 // NewGetChunkJob creates a new GetChunkJob
@@ -222,7 +238,7 @@ func (j *GetChunkJob) Execute() {
 		// acquired
 	case <-j.ctx.Done():
 		res.Err = j.ctx.Err()
-		j.result <- res
+		j.complete(res)
 		return
 	}
 	defer func() { <-sem }()
@@ -234,7 +250,7 @@ func (j *GetChunkJob) Execute() {
 		select {
 		case <-j.ctx.Done():
 			res.Err = j.ctx.Err()
-			j.result <- res
+			j.complete(res)
 			return
 		default:
 		}
@@ -244,7 +260,7 @@ func (j *GetChunkJob) Execute() {
 			lastErr = err
 			if !(DefaultClassifier{}).IsRetryable(err) {
 				res.Err = moerr.NewInternalErrorf(j.ctx, "failed to execute GETOBJECT query for offset %d: %v, sql: %v", j.chunkIndex, err, getChunkSQL)
-				j.result <- res
+				j.complete(res)
 				return
 			}
 			continue
@@ -262,7 +278,7 @@ func (j *GetChunkJob) Execute() {
 				lastErr = err
 				if !(DefaultClassifier{}).IsRetryable(err) {
 					res.Err = moerr.NewInternalErrorf(j.ctx, "failed to scan offset %d: %v", j.chunkIndex, err)
-					j.result <- res
+					j.complete(res)
 					return
 				}
 				continue
@@ -271,7 +287,7 @@ func (j *GetChunkJob) Execute() {
 			result.Close()
 			cancel()
 			// Success
-			j.result <- res
+			j.complete(res)
 			return
 		} else {
 			if err := result.Err(); err != nil {
@@ -280,7 +296,7 @@ func (j *GetChunkJob) Execute() {
 				lastErr = err
 				if !(DefaultClassifier{}).IsRetryable(err) {
 					res.Err = moerr.NewInternalErrorf(j.ctx, "failed to read chunk %d of %s: %v", j.chunkIndex, j.objectName, err)
-					j.result <- res
+					j.complete(res)
 					return
 				}
 				continue
@@ -289,19 +305,29 @@ func (j *GetChunkJob) Execute() {
 			cancel()
 			// No data returned and no error - this is a real "no content" error, don't retry
 			res.Err = moerr.NewInternalErrorf(j.ctx, "no chunk content returned for chunk %d of %s", j.chunkIndex, j.objectName)
-			j.result <- res
+			j.complete(res)
 			return
 		}
 	}
 
 	// All retries failed
 	res.Err = moerr.NewInternalErrorf(j.ctx, "failed to get chunk %d of %s after %d retries: %v", j.chunkIndex, j.objectName, maxRetries, lastErr)
-	j.result <- res
+	j.complete(res)
 }
 
 // WaitDone waits for the job to complete and returns the result
 func (j *GetChunkJob) WaitDone() any {
 	return <-j.result
+}
+
+func (j *GetChunkJob) complete(result *GetChunkJobResult) {
+	if j.completed.CompareAndSwap(false, true) {
+		j.result <- result
+	}
+}
+
+func (j *GetChunkJob) Fail(err error) {
+	j.complete(&GetChunkJobResult{ChunkIndex: j.chunkIndex, Err: err})
 }
 
 // GetType returns the job type
@@ -333,6 +359,7 @@ type WriteObjectJob struct {
 	ccprCache     CCPRTxnCacheWriter
 	txnID         []byte
 	result        chan *WriteObjectJobResult
+	completed     atomic.Bool
 }
 
 // NewWriteObjectJob creates a new WriteObjectJob
@@ -367,7 +394,7 @@ func (j *WriteObjectJob) Execute() {
 		isNewFile, err := j.ccprCache.WriteObject(j.ctx, j.objectName, j.txnID)
 		if err != nil {
 			res.Err = err
-			j.result <- res
+			j.complete(res)
 			return
 		}
 		isNewDuration := time.Since(t1)
@@ -386,7 +413,7 @@ func (j *WriteObjectJob) Execute() {
 			})
 			if err != nil {
 				res.Err = moerr.NewInternalErrorf(j.ctx, "failed to write object to fileservice: %v", err)
-				j.result <- res
+				j.complete(res)
 				return
 			}
 			// Notify cache that file has been written
@@ -415,18 +442,28 @@ func (j *WriteObjectJob) Execute() {
 				// File already exists, this is ok
 			} else {
 				res.Err = moerr.NewInternalErrorf(j.ctx, "failed to write object to fileservice: %v", err)
-				j.result <- res
+				j.complete(res)
 				return
 			}
 		}
 	}
 
-	j.result <- res
+	j.complete(res)
 }
 
 // WaitDone waits for the job to complete and returns the result
 func (j *WriteObjectJob) WaitDone() any {
 	return <-j.result
+}
+
+func (j *WriteObjectJob) complete(result *WriteObjectJobResult) {
+	if j.completed.CompareAndSwap(false, true) {
+		j.result <- result
+	}
+}
+
+func (j *WriteObjectJob) Fail(err error) {
+	j.complete(&WriteObjectJobResult{Err: err})
 }
 
 // GetType returns the job type
@@ -480,6 +517,7 @@ type FilterObjectJob struct {
 	aobjectMap              *AObjectMap // Used for tombstone rowid rewriting
 	ttlChecker              TTLChecker  // TTL expiration checker
 	result                  chan *FilterObjectJobResult
+	completed               atomic.Bool
 }
 
 // NewFilterObjectJob creates a new FilterObjectJob
@@ -527,7 +565,7 @@ func (j *FilterObjectJob) Execute() {
 	// Check TTL before starting
 	if j.ttlChecker != nil && !j.ttlChecker() {
 		res.Err = ErrSyncProtectionTTLExpired
-		j.result <- res
+		j.complete(res)
 		return
 	}
 
@@ -557,12 +595,22 @@ func (j *FilterObjectJob) Execute() {
 		res.DownstreamStats = filterResult.DownstreamStats
 		res.RowOffsetMap = filterResult.RowOffsetMap
 	}
-	j.result <- res
+	j.complete(res)
 }
 
 // WaitDone waits for the job to complete and returns the result
 func (j *FilterObjectJob) WaitDone() any {
 	return <-j.result
+}
+
+func (j *FilterObjectJob) complete(result *FilterObjectJobResult) {
+	if j.completed.CompareAndSwap(false, true) {
+		j.result <- result
+	}
+}
+
+func (j *FilterObjectJob) Fail(err error) {
+	j.complete(&FilterObjectJobResult{Err: err})
 }
 
 // GetType returns the job type

--- a/pkg/publication/filter_object_submit.go
+++ b/pkg/publication/filter_object_submit.go
@@ -423,6 +423,14 @@ func ApplyObjects(
 	var collectedTombstoneInsertStats []*ObjectWithTableInfo
 	var collectedDataDeleteStats []*ObjectWithTableInfo
 	var collectedDataInsertStats []*ObjectWithTableInfo
+	filterCtx, cancelFilters := context.WithCancel(ctx)
+	var acceptedFilters acceptedJobBatch[*FilterObjectJob]
+	defer func() {
+		// ApplyObjects owns the executors, transaction, and leaf workers used by
+		// filter jobs. Do not let any accepted child outlive this ownership scope.
+		cancelFilters()
+		acceptedFilters.join()
+	}()
 
 	// Get txnID from txn operator for CCPR cache
 	var txnID []byte
@@ -453,7 +461,7 @@ func ApplyObjects(
 		if !info.Delete {
 			statsBytes := info.Stats.Marshal()
 			// Data objects don't need aobjectMap for rewriting, pass nil
-			filterJob := NewFilterObjectJob(ctx, statsBytes, currentTS, upstreamExecutor, false, fs, mp, getChunkWorker, writeObjectWorker, subscriptionAccountName, pubName, ccprCache, txnID, nil, ttlChecker)
+			filterJob := NewFilterObjectJob(filterCtx, statsBytes, currentTS, upstreamExecutor, false, fs, mp, getChunkWorker, writeObjectWorker, subscriptionAccountName, pubName, ccprCache, txnID, nil, ttlChecker)
 			if filterObjectWorker != nil {
 				if err = filterObjectWorker.SubmitFilterObject(filterJob); err != nil {
 					return
@@ -461,6 +469,7 @@ func ApplyObjects(
 			} else {
 				filterJob.Execute()
 			}
+			acceptedFilters.add(filterJob)
 			info.FilterJob = filterJob
 		}
 	}
@@ -488,7 +497,7 @@ func ApplyObjects(
 					}
 				}
 			} else {
-				filterResult := info.FilterJob.WaitDone().(*FilterObjectJobResult)
+				filterResult := acceptedFilters.waitNext().(*FilterObjectJobResult)
 				if filterResult.Err != nil {
 					err = moerr.NewInternalErrorf(ctx, "failed to filter data object: %v", filterResult.Err)
 					return
@@ -535,7 +544,7 @@ func ApplyObjects(
 					Delete:      true,
 				})
 			} else {
-				filterResult := info.FilterJob.WaitDone().(*FilterObjectJobResult)
+				filterResult := acceptedFilters.waitNext().(*FilterObjectJobResult)
 				if filterResult.Err != nil {
 					err = moerr.NewInternalErrorf(ctx, "failed to filter data object: %v", filterResult.Err)
 					return
@@ -559,7 +568,7 @@ func ApplyObjects(
 		if !info.Delete {
 			statsBytes := info.Stats.Marshal()
 			// Tombstone objects need aobjectMap for rowid rewriting
-			filterJob := NewFilterObjectJob(ctx, statsBytes, currentTS, upstreamExecutor, true, fs, mp, getChunkWorker, writeObjectWorker, subscriptionAccountName, pubName, ccprCache, txnID, aobjectMap, ttlChecker)
+			filterJob := NewFilterObjectJob(filterCtx, statsBytes, currentTS, upstreamExecutor, true, fs, mp, getChunkWorker, writeObjectWorker, subscriptionAccountName, pubName, ccprCache, txnID, aobjectMap, ttlChecker)
 			if filterObjectWorker != nil {
 				if err = filterObjectWorker.SubmitFilterObject(filterJob); err != nil {
 					return
@@ -567,6 +576,7 @@ func ApplyObjects(
 			} else {
 				filterJob.Execute()
 			}
+			acceptedFilters.add(filterJob)
 			info.FilterJob = filterJob
 		}
 	}
@@ -577,7 +587,7 @@ func ApplyObjects(
 		if info.Delete {
 			continue
 		}
-		filterResult := info.FilterJob.WaitDone().(*FilterObjectJobResult)
+		filterResult := acceptedFilters.waitNext().(*FilterObjectJobResult)
 		if filterResult.Err != nil {
 			err = moerr.NewInternalErrorf(ctx, "failed to filter tombstone object: %v", filterResult.Err)
 			return

--- a/pkg/publication/filter_object_submit.go
+++ b/pkg/publication/filter_object_submit.go
@@ -455,7 +455,9 @@ func ApplyObjects(
 			// Data objects don't need aobjectMap for rewriting, pass nil
 			filterJob := NewFilterObjectJob(ctx, statsBytes, currentTS, upstreamExecutor, false, fs, mp, getChunkWorker, writeObjectWorker, subscriptionAccountName, pubName, ccprCache, txnID, nil, ttlChecker)
 			if filterObjectWorker != nil {
-				filterObjectWorker.SubmitFilterObject(filterJob)
+				if err = filterObjectWorker.SubmitFilterObject(filterJob); err != nil {
+					return
+				}
 			} else {
 				filterJob.Execute()
 			}
@@ -559,7 +561,9 @@ func ApplyObjects(
 			// Tombstone objects need aobjectMap for rowid rewriting
 			filterJob := NewFilterObjectJob(ctx, statsBytes, currentTS, upstreamExecutor, true, fs, mp, getChunkWorker, writeObjectWorker, subscriptionAccountName, pubName, ccprCache, txnID, aobjectMap, ttlChecker)
 			if filterObjectWorker != nil {
-				filterObjectWorker.SubmitFilterObject(filterJob)
+				if err = filterObjectWorker.SubmitFilterObject(filterJob); err != nil {
+					return
+				}
 			} else {
 				filterJob.Execute()
 			}

--- a/pkg/publication/memory_controller.go
+++ b/pkg/publication/memory_controller.go
@@ -338,6 +338,7 @@ func ReleaseGetChunkJob(job *GetChunkJob) {
 	case <-job.result:
 	default:
 	}
+	job.completed.Store(false)
 	getChunkJobPool.Put(job)
 }
 
@@ -379,6 +380,7 @@ func ReleaseWriteObjectJob(job *WriteObjectJob) {
 	case <-job.result:
 	default:
 	}
+	job.completed.Store(false)
 	writeObjectJobPool.Put(job)
 }
 
@@ -415,6 +417,7 @@ func ReleaseGetMetaJob(job *GetMetaJob) {
 	case <-job.result:
 	default:
 	}
+	job.completed.Store(false)
 	getMetaJobPool.Put(job)
 }
 
@@ -468,6 +471,7 @@ func ReleaseFilterObjectJob(job *FilterObjectJob) {
 	case <-job.result:
 	default:
 	}
+	job.completed.Store(false)
 	filterObjectJobPool.Put(job)
 }
 

--- a/pkg/publication/task_executor_test.go
+++ b/pkg/publication/task_executor_test.go
@@ -17,6 +17,7 @@ package publication
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -149,11 +150,45 @@ func TestPublicationLiveReplayPreservesAdmittedIteration(t *testing.T) {
 	require.Equal(t, IterationStatePending, task.State)
 
 	require.NoError(t, exec.mergeReplayedTask(
+		"task", 6, IterationStateRunning, SubscriptionStateRunning, nil,
+	))
+	task, _ = exec.getTask("task")
+	require.Equal(t, uint64(6), task.LSN)
+	require.Equal(t, IterationStatePending, task.State)
+
+	require.NoError(t, exec.mergeReplayedTask(
 		"task", 7, IterationStateCompleted, SubscriptionStateRunning, nil,
 	))
 	task, _ = exec.getTask("task")
 	require.Equal(t, uint64(7), task.LSN)
 	require.Equal(t, IterationStateCompleted, task.State)
+}
+
+func TestPublicationLiveReplayAppliesEqualLSNTerminalState(t *testing.T) {
+	for _, localState := range []int8{IterationStatePending, IterationStateRunning} {
+		for _, durableState := range []int8{
+			IterationStateCompleted,
+			IterationStateError,
+			IterationStateCanceled,
+		} {
+			t.Run(fmt.Sprintf("local-%d/durable-%d", localState, durableState), func(t *testing.T) {
+				exec := &PublicationTaskExecutor{tasks: newPublicationTaskTree()}
+				exec.setTask(TaskEntry{
+					TaskID:            "task",
+					LSN:               6,
+					State:             localState,
+					SubscriptionState: SubscriptionStateRunning,
+				})
+
+				require.NoError(t, exec.mergeReplayedTask(
+					"task", 6, durableState, SubscriptionStateRunning, nil,
+				))
+				task, _ := exec.getTask("task")
+				require.Equal(t, uint64(6), task.LSN)
+				require.Equal(t, durableState, task.State)
+			})
+		}
+	}
 }
 
 // ==== iteration.go: IterationContext ====

--- a/pkg/publication/task_executor_test.go
+++ b/pkg/publication/task_executor_test.go
@@ -77,6 +77,85 @@ func TestPublicationTaskExecutor_GetCandidateTasks_Mixed(t *testing.T) {
 	assert.Equal(t, 2, len(candidates))
 }
 
+func TestPublicationPublishRebuiltStateReplacesAbandonedGeneration(t *testing.T) {
+	exec := &PublicationTaskExecutor{tasks: newPublicationTaskTree()}
+	exec.setTask(TaskEntry{
+		TaskID:            "retained",
+		LSN:               6,
+		State:             IterationStatePending,
+		SubscriptionState: SubscriptionStateRunning,
+	})
+	exec.setTask(TaskEntry{TaskID: "stale-only"})
+
+	snapshot := &PublicationTaskExecutor{tasks: newPublicationTaskTree()}
+	snapshot.setTask(TaskEntry{
+		TaskID:            "retained",
+		LSN:               5,
+		State:             IterationStateCompleted,
+		SubscriptionState: SubscriptionStateRunning,
+	})
+	watermark := types.BuildTS(30, 0)
+	exec.publishRebuiltState(snapshot, watermark)
+
+	task, ok := exec.getTask("retained")
+	require.True(t, ok)
+	require.Equal(t, uint64(5), task.LSN)
+	require.Equal(t, IterationStateCompleted, task.State)
+	_, ok = exec.getTask("stale-only")
+	require.False(t, ok)
+	require.True(t, exec.ccprLogWm.EQ(&watermark))
+}
+
+func TestPublicationRecoveryNormalizesPreRepairSnapshot(t *testing.T) {
+	exec := &PublicationTaskExecutor{tasks: newPublicationTaskTree()}
+	require.NoError(t, exec.addOrUpdateRecoveredTask(
+		"running", 5, IterationStateRunning, SubscriptionStateRunning, nil,
+	))
+	require.NoError(t, exec.addOrUpdateRecoveredTask(
+		"error", 6, IterationStateError, SubscriptionStateError, nil,
+	))
+	require.NoError(t, exec.addOrUpdateRecoveredTask(
+		"canceled", 7, IterationStateCanceled, SubscriptionStateRunning, nil,
+	))
+	now := time.Now()
+	require.NoError(t, exec.addOrUpdateRecoveredTask(
+		"dropped", 8, IterationStateCanceled, SubscriptionStateDropped, &now,
+	))
+
+	running, _ := exec.getTask("running")
+	require.Equal(t, IterationStateCompleted, running.State)
+	errorTask, _ := exec.getTask("error")
+	require.Equal(t, IterationStateError, errorTask.State)
+	canceled, _ := exec.getTask("canceled")
+	require.Equal(t, IterationStateCompleted, canceled.State)
+	dropped, _ := exec.getTask("dropped")
+	require.Equal(t, IterationStateCanceled, dropped.State)
+}
+
+func TestPublicationLiveReplayPreservesAdmittedIteration(t *testing.T) {
+	exec := &PublicationTaskExecutor{tasks: newPublicationTaskTree()}
+	exec.setTask(TaskEntry{
+		TaskID:            "task",
+		LSN:               6,
+		State:             IterationStatePending,
+		SubscriptionState: SubscriptionStateRunning,
+	})
+
+	require.NoError(t, exec.mergeReplayedTask(
+		"task", 5, IterationStateCompleted, SubscriptionStateRunning, nil,
+	))
+	task, _ := exec.getTask("task")
+	require.Equal(t, uint64(6), task.LSN)
+	require.Equal(t, IterationStatePending, task.State)
+
+	require.NoError(t, exec.mergeReplayedTask(
+		"task", 7, IterationStateCompleted, SubscriptionStateRunning, nil,
+	))
+	task, _ = exec.getTask("task")
+	require.Equal(t, uint64(7), task.LSN)
+	require.Equal(t, IterationStateCompleted, task.State)
+}
+
 // ==== iteration.go: IterationContext ====
 
 func TestIterationContext_StringOutput(t *testing.T) {

--- a/pkg/publication/worker.go
+++ b/pkg/publication/worker.go
@@ -250,6 +250,7 @@ func (s *JobStats) ResetTopWriteObjectDurations() {
 
 type Worker interface {
 	Submit(taskID string, lsn uint64, state int8) error
+	// Stop cancels running work and discards work that has not started.
 	Stop()
 	// RegisterSyncProtection registers a sync protection job for keepalive
 	RegisterSyncProtection(jobID string, ttlExpireTS int64)
@@ -262,18 +263,21 @@ type Worker interface {
 // FilterObjectWorker is the interface for filter object worker pool
 type FilterObjectWorker interface {
 	SubmitFilterObject(job Job) error
+	// Stop is cancel-and-drain, not graceful completion of queued jobs.
 	Stop()
 }
 
 // GetChunkWorker is the interface for get upstream chunk worker pool
 type GetChunkWorker interface {
 	SubmitGetChunk(job Job) error
+	// Stop is cancel-and-drain, not graceful completion of queued jobs.
 	Stop()
 }
 
 // WriteObjectWorker is the interface for write object worker pool
 type WriteObjectWorker interface {
 	SubmitWriteObject(job Job) error
+	// Stop is cancel-and-drain, not graceful completion of queued jobs.
 	Stop()
 }
 
@@ -306,6 +310,8 @@ type worker struct {
 	cancel                   context.CancelFunc
 	ctx                      context.Context
 	closed                   atomic.Bool
+	stopOnce                 sync.Once
+	admissions               workerAdmissionGate
 	filterObjectWorker       FilterObjectWorker
 	getChunkWorker           GetChunkWorker
 	writeObjectWorker        WriteObjectWorker
@@ -318,6 +324,37 @@ type worker struct {
 type TaskContext struct {
 	TaskID string
 	LSN    uint64
+}
+
+type workerAdmissionGate struct {
+	mu sync.RWMutex
+	wg sync.WaitGroup
+}
+
+// enter registers a sender before it can block. seal excludes new senders,
+// cancels blocked ones, and waits until no sender can arrive after draining.
+func (g *workerAdmissionGate) enter(closed *atomic.Bool) bool {
+	if closed.Load() {
+		return false
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if closed.Load() {
+		return false
+	}
+	g.wg.Add(1)
+	return true
+}
+
+func (g *workerAdmissionGate) leave() {
+	g.wg.Done()
+}
+
+func (g *workerAdmissionGate) seal(cancel context.CancelFunc) {
+	g.mu.Lock()
+	cancel()
+	g.mu.Unlock()
+	g.wg.Wait()
 }
 
 func doneChan(ctx context.Context) <-chan struct{} {
@@ -448,9 +485,10 @@ func (w *worker) RunStatsPrinter() {
 }
 
 func (w *worker) Submit(taskID string, lsn uint64, state int8) error {
-	if w.closed.Load() {
+	if !w.admissions.enter(&w.closed) {
 		return moerr.NewInternalErrorNoCtx("Publication-Worker is closed")
 	}
+	defer w.admissions.leave()
 	task := &TaskContext{
 		TaskID: taskID,
 		LSN:    lsn,
@@ -522,19 +560,33 @@ func (w *worker) onItem(taskCtx *TaskContext) {
 }
 
 func (w *worker) Stop() {
-	if !w.closed.CompareAndSwap(false, true) {
-		return
-	}
-	w.cancel()
-	w.wg.Wait()
-	if w.filterObjectWorker != nil {
-		w.filterObjectWorker.Stop()
-	}
-	if w.getChunkWorker != nil {
-		w.getChunkWorker.Stop()
-	}
-	if w.writeObjectWorker != nil {
-		w.writeObjectWorker.Stop()
+	w.stopOnce.Do(func() {
+		w.closed.Store(true)
+		w.admissions.seal(w.cancel)
+		w.wg.Wait()
+		w.drainPending()
+		w.syncProtectionMu.Lock()
+		clear(w.syncProtectionJobs)
+		w.syncProtectionMu.Unlock()
+		if w.filterObjectWorker != nil {
+			w.filterObjectWorker.Stop()
+		}
+		if w.getChunkWorker != nil {
+			w.getChunkWorker.Stop()
+		}
+		if w.writeObjectWorker != nil {
+			w.writeObjectWorker.Stop()
+		}
+	})
+}
+
+func (w *worker) drainPending() {
+	for {
+		select {
+		case <-w.taskChan:
+		default:
+			return
+		}
 	}
 }
 
@@ -546,6 +598,9 @@ func (w *worker) Stop() {
 func (w *worker) RegisterSyncProtection(jobID string, ttlExpireTS int64) {
 	w.syncProtectionMu.Lock()
 	defer w.syncProtectionMu.Unlock()
+	if w.closed.Load() {
+		return
+	}
 
 	entry := &syncProtectionEntry{
 		jobID: jobID,
@@ -707,11 +762,13 @@ func (w *worker) updateIterationState(ctx context.Context, taskID string, iterat
 // ============================================================================
 
 type filterObjectWorker struct {
-	jobChan chan Job
-	wg      sync.WaitGroup
-	cancel  context.CancelFunc
-	ctx     context.Context
-	closed  atomic.Bool
+	jobChan    chan Job
+	wg         sync.WaitGroup
+	cancel     context.CancelFunc
+	ctx        context.Context
+	closed     atomic.Bool
+	stopOnce   sync.Once
+	admissions workerAdmissionGate
 }
 
 // NewFilterObjectWorker creates a new filter object worker pool
@@ -737,6 +794,7 @@ func (w *filterObjectWorker) start() {
 				case job := <-w.jobChan:
 					select {
 					case <-w.ctx.Done():
+						w.cancelPending()
 						return
 					default:
 					}
@@ -756,10 +814,16 @@ func (w *filterObjectWorker) start() {
 	}
 }
 
+func (w *filterObjectWorker) cancelPending() {
+	globalJobStats.FilterObjectPending.Add(-1)
+	v2.CCPRFilterObjectQueueSizeGauge.Dec()
+}
+
 func (w *filterObjectWorker) SubmitFilterObject(job Job) error {
-	if w.closed.Load() {
+	if !w.admissions.enter(&w.closed) {
 		return moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed")
 	}
+	defer w.admissions.leave()
 	if job == nil {
 		return moerr.NewInternalErrorNoCtx("cannot submit a nil filter object job")
 	}
@@ -769,18 +833,25 @@ func (w *filterObjectWorker) SubmitFilterObject(job Job) error {
 	case w.jobChan <- job:
 		return nil
 	case <-doneChan(w.ctx):
-		globalJobStats.FilterObjectPending.Add(-1)
-		v2.CCPRFilterObjectQueueSizeGauge.Dec()
+		w.cancelPending()
 		return moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed")
 	}
 }
 
 func (w *filterObjectWorker) Stop() {
-	if !w.closed.CompareAndSwap(false, true) {
-		return
-	}
-	w.cancel()
-	w.wg.Wait()
+	w.stopOnce.Do(func() {
+		w.closed.Store(true)
+		w.admissions.seal(w.cancel)
+		w.wg.Wait()
+		for {
+			select {
+			case <-w.jobChan:
+				w.cancelPending()
+			default:
+				return
+			}
+		}
+	})
 }
 
 // ============================================================================
@@ -788,11 +859,13 @@ func (w *filterObjectWorker) Stop() {
 // ============================================================================
 
 type getChunkWorker struct {
-	jobChan chan Job
-	wg      sync.WaitGroup
-	cancel  context.CancelFunc
-	ctx     context.Context
-	closed  atomic.Bool
+	jobChan    chan Job
+	wg         sync.WaitGroup
+	cancel     context.CancelFunc
+	ctx        context.Context
+	closed     atomic.Bool
+	stopOnce   sync.Once
+	admissions workerAdmissionGate
 }
 
 // NewGetChunkWorker creates a new get chunk worker pool
@@ -816,12 +889,13 @@ func (w *getChunkWorker) start() {
 				case <-w.ctx.Done():
 					return
 				case job := <-w.jobChan:
+					jobType := job.GetType()
 					select {
 					case <-w.ctx.Done():
+						w.cancelPending(jobType)
 						return
 					default:
 					}
-					jobType := job.GetType()
 					switch jobType {
 					case JobTypeGetMeta:
 						globalJobStats.IncrementGetMetaRunning()
@@ -850,10 +924,20 @@ func (w *getChunkWorker) start() {
 	}
 }
 
+func (w *getChunkWorker) cancelPending(jobType int8) {
+	switch jobType {
+	case JobTypeGetMeta:
+		globalJobStats.GetMetaPending.Add(-1)
+	default:
+		globalJobStats.GetChunkPending.Add(-1)
+	}
+}
+
 func (w *getChunkWorker) SubmitGetChunk(job Job) error {
-	if w.closed.Load() {
+	if !w.admissions.enter(&w.closed) {
 		return moerr.NewInternalErrorNoCtx("GetChunkWorker is closed")
 	}
+	defer w.admissions.leave()
 	if job == nil {
 		return moerr.NewInternalErrorNoCtx("cannot submit a nil get chunk job")
 	}
@@ -868,22 +952,25 @@ func (w *getChunkWorker) SubmitGetChunk(job Job) error {
 	case w.jobChan <- job:
 		return nil
 	case <-doneChan(w.ctx):
-		switch jobType {
-		case JobTypeGetMeta:
-			globalJobStats.GetMetaPending.Add(-1)
-		default:
-			globalJobStats.GetChunkPending.Add(-1)
-		}
+		w.cancelPending(jobType)
 		return moerr.NewInternalErrorNoCtx("GetChunkWorker is closed")
 	}
 }
 
 func (w *getChunkWorker) Stop() {
-	if !w.closed.CompareAndSwap(false, true) {
-		return
-	}
-	w.cancel()
-	w.wg.Wait()
+	w.stopOnce.Do(func() {
+		w.closed.Store(true)
+		w.admissions.seal(w.cancel)
+		w.wg.Wait()
+		for {
+			select {
+			case job := <-w.jobChan:
+				w.cancelPending(job.GetType())
+			default:
+				return
+			}
+		}
+	})
 }
 
 // ============================================================================
@@ -897,6 +984,8 @@ type simpleJobWorker struct {
 	cancel            context.CancelFunc
 	ctx               context.Context
 	closed            atomic.Bool
+	stopOnce          sync.Once
+	admissions        workerAdmissionGate
 	onPending         func()
 	onPendingCanceled func()
 	onRunningStart    func()
@@ -940,6 +1029,7 @@ func (w *simpleJobWorker) start(threadCount int) {
 				case job := <-w.jobChan:
 					select {
 					case <-w.ctx.Done():
+						w.cancelPending()
 						return
 					default:
 					}
@@ -957,10 +1047,17 @@ func (w *simpleJobWorker) start(threadCount int) {
 	}
 }
 
+func (w *simpleJobWorker) cancelPending() {
+	if w.onPendingCanceled != nil {
+		w.onPendingCanceled()
+	}
+}
+
 func (w *simpleJobWorker) submit(job Job) error {
-	if w.closed.Load() {
+	if !w.admissions.enter(&w.closed) {
 		return moerr.NewInternalErrorf(context.Background(), "%s is closed", w.name)
 	}
+	defer w.admissions.leave()
 	if job == nil {
 		return moerr.NewInternalErrorf(context.Background(), "cannot submit a nil job to %s", w.name)
 	}
@@ -969,19 +1066,25 @@ func (w *simpleJobWorker) submit(job Job) error {
 	case w.jobChan <- job:
 		return nil
 	case <-doneChan(w.ctx):
-		if w.onPendingCanceled != nil {
-			w.onPendingCanceled()
-		}
+		w.cancelPending()
 		return moerr.NewInternalErrorf(context.Background(), "%s is closed", w.name)
 	}
 }
 
 func (w *simpleJobWorker) stop() {
-	if !w.closed.CompareAndSwap(false, true) {
-		return
-	}
-	w.cancel()
-	w.wg.Wait()
+	w.stopOnce.Do(func() {
+		w.closed.Store(true)
+		w.admissions.seal(w.cancel)
+		w.wg.Wait()
+		for {
+			select {
+			case <-w.jobChan:
+				w.cancelPending()
+			default:
+				return
+			}
+		}
+	})
 }
 
 // ============================================================================

--- a/pkg/publication/worker.go
+++ b/pkg/publication/worker.go
@@ -364,6 +364,14 @@ func doneChan(ctx context.Context) <-chan struct{} {
 	return ctx.Done()
 }
 
+func rejectJob(job Job, workerName string) error {
+	err := moerr.NewInternalErrorNoCtxf("%s is closed", workerName)
+	if job != nil {
+		job.Fail(err)
+	}
+	return err
+}
+
 func NewWorker(
 	cnUUID string,
 	cnEngine engine.Engine,
@@ -563,20 +571,22 @@ func (w *worker) Stop() {
 	w.stopOnce.Do(func() {
 		w.closed.Store(true)
 		w.admissions.seal(w.cancel)
-		w.wg.Wait()
-		w.drainPending()
-		w.syncProtectionMu.Lock()
-		clear(w.syncProtectionJobs)
-		w.syncProtectionMu.Unlock()
-		if w.filterObjectWorker != nil {
-			w.filterObjectWorker.Stop()
-		}
+		// Stop leaf pools before their callers. A running filter job can wait on
+		// get-chunk/write jobs, and a top-level iteration can wait on a filter job.
 		if w.getChunkWorker != nil {
 			w.getChunkWorker.Stop()
 		}
 		if w.writeObjectWorker != nil {
 			w.writeObjectWorker.Stop()
 		}
+		if w.filterObjectWorker != nil {
+			w.filterObjectWorker.Stop()
+		}
+		w.wg.Wait()
+		w.drainPending()
+		w.syncProtectionMu.Lock()
+		clear(w.syncProtectionJobs)
+		w.syncProtectionMu.Unlock()
 	})
 }
 
@@ -795,6 +805,7 @@ func (w *filterObjectWorker) start() {
 					select {
 					case <-w.ctx.Done():
 						w.cancelPending()
+						job.Fail(moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed"))
 						return
 					default:
 					}
@@ -821,7 +832,7 @@ func (w *filterObjectWorker) cancelPending() {
 
 func (w *filterObjectWorker) SubmitFilterObject(job Job) error {
 	if !w.admissions.enter(&w.closed) {
-		return moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed")
+		return rejectJob(job, "FilterObjectWorker")
 	}
 	defer w.admissions.leave()
 	if job == nil {
@@ -834,7 +845,7 @@ func (w *filterObjectWorker) SubmitFilterObject(job Job) error {
 		return nil
 	case <-doneChan(w.ctx):
 		w.cancelPending()
-		return moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed")
+		return rejectJob(job, "FilterObjectWorker")
 	}
 }
 
@@ -845,8 +856,9 @@ func (w *filterObjectWorker) Stop() {
 		w.wg.Wait()
 		for {
 			select {
-			case <-w.jobChan:
+			case job := <-w.jobChan:
 				w.cancelPending()
+				job.Fail(moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed"))
 			default:
 				return
 			}
@@ -893,6 +905,7 @@ func (w *getChunkWorker) start() {
 					select {
 					case <-w.ctx.Done():
 						w.cancelPending(jobType)
+						job.Fail(moerr.NewInternalErrorNoCtx("GetChunkWorker is closed"))
 						return
 					default:
 					}
@@ -935,7 +948,7 @@ func (w *getChunkWorker) cancelPending(jobType int8) {
 
 func (w *getChunkWorker) SubmitGetChunk(job Job) error {
 	if !w.admissions.enter(&w.closed) {
-		return moerr.NewInternalErrorNoCtx("GetChunkWorker is closed")
+		return rejectJob(job, "GetChunkWorker")
 	}
 	defer w.admissions.leave()
 	if job == nil {
@@ -953,7 +966,7 @@ func (w *getChunkWorker) SubmitGetChunk(job Job) error {
 		return nil
 	case <-doneChan(w.ctx):
 		w.cancelPending(jobType)
-		return moerr.NewInternalErrorNoCtx("GetChunkWorker is closed")
+		return rejectJob(job, "GetChunkWorker")
 	}
 }
 
@@ -966,6 +979,7 @@ func (w *getChunkWorker) Stop() {
 			select {
 			case job := <-w.jobChan:
 				w.cancelPending(job.GetType())
+				job.Fail(moerr.NewInternalErrorNoCtx("GetChunkWorker is closed"))
 			default:
 				return
 			}
@@ -1030,6 +1044,7 @@ func (w *simpleJobWorker) start(threadCount int) {
 					select {
 					case <-w.ctx.Done():
 						w.cancelPending()
+						job.Fail(moerr.NewInternalErrorNoCtxf("%s is closed", w.name))
 						return
 					default:
 					}
@@ -1055,7 +1070,7 @@ func (w *simpleJobWorker) cancelPending() {
 
 func (w *simpleJobWorker) submit(job Job) error {
 	if !w.admissions.enter(&w.closed) {
-		return moerr.NewInternalErrorf(context.Background(), "%s is closed", w.name)
+		return rejectJob(job, w.name)
 	}
 	defer w.admissions.leave()
 	if job == nil {
@@ -1067,7 +1082,7 @@ func (w *simpleJobWorker) submit(job Job) error {
 		return nil
 	case <-doneChan(w.ctx):
 		w.cancelPending()
-		return moerr.NewInternalErrorf(context.Background(), "%s is closed", w.name)
+		return rejectJob(job, w.name)
 	}
 }
 
@@ -1078,8 +1093,9 @@ func (w *simpleJobWorker) stop() {
 		w.wg.Wait()
 		for {
 			select {
-			case <-w.jobChan:
+			case job := <-w.jobChan:
 				w.cancelPending()
+				job.Fail(moerr.NewInternalErrorNoCtxf("%s is closed", w.name))
 			default:
 				return
 			}

--- a/pkg/publication/worker.go
+++ b/pkg/publication/worker.go
@@ -366,10 +366,24 @@ func doneChan(ctx context.Context) <-chan struct{} {
 
 func rejectJob(job Job, workerName string) error {
 	err := moerr.NewInternalErrorNoCtxf("%s is closed", workerName)
-	if job != nil {
+	if job, ok := job.(TerminalJob); ok {
 		job.Fail(err)
 	}
 	return err
+}
+
+func validateTerminalJob(job Job, workerName string) error {
+	if _, ok := job.(TerminalJob); !ok {
+		return moerr.NewInternalErrorNoCtxf(
+			"%s requires a job with terminal failure completion", workerName,
+		)
+	}
+	return nil
+}
+
+func failAcceptedJob(job Job, err error) {
+	// Submit validates this contract before the job can enter a queue.
+	job.(TerminalJob).Fail(err)
 }
 
 func NewWorker(
@@ -805,7 +819,7 @@ func (w *filterObjectWorker) start() {
 					select {
 					case <-w.ctx.Done():
 						w.cancelPending()
-						job.Fail(moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed"))
+						failAcceptedJob(job, moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed"))
 						return
 					default:
 					}
@@ -838,6 +852,9 @@ func (w *filterObjectWorker) SubmitFilterObject(job Job) error {
 	if job == nil {
 		return moerr.NewInternalErrorNoCtx("cannot submit a nil filter object job")
 	}
+	if err := validateTerminalJob(job, "FilterObjectWorker"); err != nil {
+		return err
+	}
 	globalJobStats.IncrementFilterObjectPending()
 	v2.CCPRFilterObjectQueueSizeGauge.Inc()
 	select {
@@ -858,7 +875,7 @@ func (w *filterObjectWorker) Stop() {
 			select {
 			case job := <-w.jobChan:
 				w.cancelPending()
-				job.Fail(moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed"))
+				failAcceptedJob(job, moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed"))
 			default:
 				return
 			}
@@ -905,7 +922,7 @@ func (w *getChunkWorker) start() {
 					select {
 					case <-w.ctx.Done():
 						w.cancelPending(jobType)
-						job.Fail(moerr.NewInternalErrorNoCtx("GetChunkWorker is closed"))
+						failAcceptedJob(job, moerr.NewInternalErrorNoCtx("GetChunkWorker is closed"))
 						return
 					default:
 					}
@@ -954,6 +971,9 @@ func (w *getChunkWorker) SubmitGetChunk(job Job) error {
 	if job == nil {
 		return moerr.NewInternalErrorNoCtx("cannot submit a nil get chunk job")
 	}
+	if err := validateTerminalJob(job, "GetChunkWorker"); err != nil {
+		return err
+	}
 	jobType := job.GetType()
 	switch jobType {
 	case JobTypeGetMeta:
@@ -979,7 +999,7 @@ func (w *getChunkWorker) Stop() {
 			select {
 			case job := <-w.jobChan:
 				w.cancelPending(job.GetType())
-				job.Fail(moerr.NewInternalErrorNoCtx("GetChunkWorker is closed"))
+				failAcceptedJob(job, moerr.NewInternalErrorNoCtx("GetChunkWorker is closed"))
 			default:
 				return
 			}
@@ -1044,7 +1064,7 @@ func (w *simpleJobWorker) start(threadCount int) {
 					select {
 					case <-w.ctx.Done():
 						w.cancelPending()
-						job.Fail(moerr.NewInternalErrorNoCtxf("%s is closed", w.name))
+						failAcceptedJob(job, moerr.NewInternalErrorNoCtxf("%s is closed", w.name))
 						return
 					default:
 					}
@@ -1076,6 +1096,9 @@ func (w *simpleJobWorker) submit(job Job) error {
 	if job == nil {
 		return moerr.NewInternalErrorf(context.Background(), "cannot submit a nil job to %s", w.name)
 	}
+	if err := validateTerminalJob(job, w.name); err != nil {
+		return err
+	}
 	w.onPending()
 	select {
 	case w.jobChan <- job:
@@ -1095,7 +1118,7 @@ func (w *simpleJobWorker) stop() {
 			select {
 			case job := <-w.jobChan:
 				w.cancelPending()
-				job.Fail(moerr.NewInternalErrorNoCtxf("%s is closed", w.name))
+				failAcceptedJob(job, moerr.NewInternalErrorNoCtxf("%s is closed", w.name))
 			default:
 				return
 			}

--- a/pkg/publication/worker.go
+++ b/pkg/publication/worker.go
@@ -311,14 +311,20 @@ type worker struct {
 	writeObjectWorker        WriteObjectWorker
 
 	// Sync protection keepalive management
-	syncProtectionMu     sync.RWMutex
-	syncProtectionJobs   map[string]*syncProtectionEntry
-	syncProtectionTicker *time.Ticker
+	syncProtectionMu   sync.RWMutex
+	syncProtectionJobs map[string]*syncProtectionEntry
 }
 
 type TaskContext struct {
 	TaskID string
 	LSN    uint64
+}
+
+func doneChan(ctx context.Context) <-chan struct{} {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Done()
 }
 
 func NewWorker(
@@ -341,10 +347,42 @@ func NewWorker(
 		syncProtectionJobs:       make(map[string]*syncProtectionEntry),
 	}
 	worker.ctx, worker.cancel = context.WithCancel(context.Background())
-	go worker.Run()
-	go worker.RunStatsPrinter()
-	go worker.RunSyncProtectionKeepAlive()
+	worker.start()
 	return worker
+}
+
+// start seals this worker generation before NewWorker publishes it. Every
+// goroutine that Stop owns is registered before any of them can outlive Stop.
+func (w *worker) start() {
+	workerThreads := GetPublicationWorkerThread()
+	w.wg.Add(workerThreads + 2)
+	for i := 0; i < workerThreads; i++ {
+		go func() {
+			defer w.wg.Done()
+			for {
+				select {
+				case <-w.ctx.Done():
+					return
+				case task := <-w.taskChan:
+					// Do not admit queued work after this generation is canceled.
+					select {
+					case <-w.ctx.Done():
+						return
+					default:
+					}
+					w.onItem(task)
+				}
+			}
+		}()
+	}
+	go func() {
+		defer w.wg.Done()
+		w.RunStatsPrinter()
+	}()
+	go func() {
+		defer w.wg.Done()
+		w.RunSyncProtectionKeepAlive()
+	}()
 }
 
 // RunStatsPrinter prints job stats every 10 seconds
@@ -409,32 +447,20 @@ func (w *worker) RunStatsPrinter() {
 	}
 }
 
-func (w *worker) Run() {
-	for i := 0; i < GetPublicationWorkerThread(); i++ {
-		w.wg.Add(1)
-		go func() {
-			defer w.wg.Done()
-			for {
-				select {
-				case <-w.ctx.Done():
-					return
-				case task := <-w.taskChan:
-					w.onItem(task)
-				}
-			}
-		}()
-	}
-}
-
 func (w *worker) Submit(taskID string, lsn uint64, state int8) error {
 	if w.closed.Load() {
-		return moerr.NewInternalError(context.Background(), "Publication-Worker is closed")
+		return moerr.NewInternalErrorNoCtx("Publication-Worker is closed")
 	}
-	w.taskChan <- &TaskContext{
+	task := &TaskContext{
 		TaskID: taskID,
 		LSN:    lsn,
 	}
-	return nil
+	select {
+	case w.taskChan <- task:
+		return nil
+	case <-doneChan(w.ctx):
+		return moerr.NewInternalErrorNoCtx("Publication-Worker is closed")
+	}
 }
 
 func (w *worker) onItem(taskCtx *TaskContext) {
@@ -496,10 +522,11 @@ func (w *worker) onItem(taskCtx *TaskContext) {
 }
 
 func (w *worker) Stop() {
-	w.closed.Store(true)
+	if !w.closed.CompareAndSwap(false, true) {
+		return
+	}
 	w.cancel()
 	w.wg.Wait()
-	close(w.taskChan)
 	if w.filterObjectWorker != nil {
 		w.filterObjectWorker.Stop()
 	}
@@ -508,10 +535,6 @@ func (w *worker) Stop() {
 	}
 	if w.writeObjectWorker != nil {
 		w.writeObjectWorker.Stop()
-	}
-	// Stop sync protection ticker
-	if w.syncProtectionTicker != nil {
-		w.syncProtectionTicker.Stop()
 	}
 }
 
@@ -563,14 +586,14 @@ func (w *worker) GetSyncProtectionTTL(jobID string) int64 {
 // all registered sync protection jobs to prevent TTL expiration
 func (w *worker) RunSyncProtectionKeepAlive() {
 	renewInterval := GetSyncProtectionRenewInterval()
-	w.syncProtectionTicker = time.NewTicker(renewInterval)
-	defer w.syncProtectionTicker.Stop()
+	ticker := time.NewTicker(renewInterval)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-w.ctx.Done():
 			return
-		case <-w.syncProtectionTicker.C:
+		case <-ticker.C:
 			w.renewAllSyncProtections()
 		}
 	}
@@ -697,13 +720,14 @@ func NewFilterObjectWorker() FilterObjectWorker {
 		jobChan: make(chan Job, 10000),
 	}
 	w.ctx, w.cancel = context.WithCancel(context.Background())
-	go w.Run()
+	w.start()
 	return w
 }
 
-func (w *filterObjectWorker) Run() {
-	for i := 0; i < GetFilterObjectWorkerThread(); i++ {
-		w.wg.Add(1)
+func (w *filterObjectWorker) start() {
+	workerThreads := GetFilterObjectWorkerThread()
+	w.wg.Add(workerThreads)
+	for i := 0; i < workerThreads; i++ {
 		go func() {
 			defer w.wg.Done()
 			for {
@@ -711,6 +735,11 @@ func (w *filterObjectWorker) Run() {
 				case <-w.ctx.Done():
 					return
 				case job := <-w.jobChan:
+					select {
+					case <-w.ctx.Done():
+						return
+					default:
+					}
 					globalJobStats.IncrementFilterObjectRunning()
 					v2.CCPRFilterObjectQueueSizeGauge.Dec()
 					v2.CCPRRunningFilterObjectJobsGauge.Inc()
@@ -729,19 +758,29 @@ func (w *filterObjectWorker) Run() {
 
 func (w *filterObjectWorker) SubmitFilterObject(job Job) error {
 	if w.closed.Load() {
-		return moerr.NewInternalError(context.Background(), "FilterObjectWorker is closed")
+		return moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed")
+	}
+	if job == nil {
+		return moerr.NewInternalErrorNoCtx("cannot submit a nil filter object job")
 	}
 	globalJobStats.IncrementFilterObjectPending()
 	v2.CCPRFilterObjectQueueSizeGauge.Inc()
-	w.jobChan <- job
-	return nil
+	select {
+	case w.jobChan <- job:
+		return nil
+	case <-doneChan(w.ctx):
+		globalJobStats.FilterObjectPending.Add(-1)
+		v2.CCPRFilterObjectQueueSizeGauge.Dec()
+		return moerr.NewInternalErrorNoCtx("FilterObjectWorker is closed")
+	}
 }
 
 func (w *filterObjectWorker) Stop() {
-	w.closed.Store(true)
+	if !w.closed.CompareAndSwap(false, true) {
+		return
+	}
 	w.cancel()
 	w.wg.Wait()
-	close(w.jobChan)
 }
 
 // ============================================================================
@@ -762,14 +801,14 @@ func NewGetChunkWorker() GetChunkWorker {
 		jobChan: make(chan Job, 10000),
 	}
 	w.ctx, w.cancel = context.WithCancel(context.Background())
-	go w.Run()
+	w.start()
 	return w
 }
 
-func (w *getChunkWorker) Run() {
+func (w *getChunkWorker) start() {
 	workerThreadCount := GetGetChunkWorkerThread()
+	w.wg.Add(workerThreadCount)
 	for i := 0; i < workerThreadCount; i++ {
-		w.wg.Add(1)
 		go func() {
 			defer w.wg.Done()
 			for {
@@ -777,6 +816,11 @@ func (w *getChunkWorker) Run() {
 				case <-w.ctx.Done():
 					return
 				case job := <-w.jobChan:
+					select {
+					case <-w.ctx.Done():
+						return
+					default:
+					}
 					jobType := job.GetType()
 					switch jobType {
 					case JobTypeGetMeta:
@@ -808,7 +852,10 @@ func (w *getChunkWorker) Run() {
 
 func (w *getChunkWorker) SubmitGetChunk(job Job) error {
 	if w.closed.Load() {
-		return moerr.NewInternalError(context.Background(), "GetChunkWorker is closed")
+		return moerr.NewInternalErrorNoCtx("GetChunkWorker is closed")
+	}
+	if job == nil {
+		return moerr.NewInternalErrorNoCtx("cannot submit a nil get chunk job")
 	}
 	jobType := job.GetType()
 	switch jobType {
@@ -817,15 +864,26 @@ func (w *getChunkWorker) SubmitGetChunk(job Job) error {
 	default:
 		globalJobStats.IncrementGetChunkPending()
 	}
-	w.jobChan <- job
-	return nil
+	select {
+	case w.jobChan <- job:
+		return nil
+	case <-doneChan(w.ctx):
+		switch jobType {
+		case JobTypeGetMeta:
+			globalJobStats.GetMetaPending.Add(-1)
+		default:
+			globalJobStats.GetChunkPending.Add(-1)
+		}
+		return moerr.NewInternalErrorNoCtx("GetChunkWorker is closed")
+	}
 }
 
 func (w *getChunkWorker) Stop() {
-	w.closed.Store(true)
+	if !w.closed.CompareAndSwap(false, true) {
+		return
+	}
 	w.cancel()
 	w.wg.Wait()
-	close(w.jobChan)
 }
 
 // ============================================================================
@@ -833,16 +891,17 @@ func (w *getChunkWorker) Stop() {
 // ============================================================================
 
 type simpleJobWorker struct {
-	name             string
-	jobChan          chan Job
-	wg               sync.WaitGroup
-	cancel           context.CancelFunc
-	ctx              context.Context
-	closed           atomic.Bool
-	onPending        func()
-	onRunningStart   func()
-	onRunningFinish  func()
-	onRecordDuration func(job Job, duration time.Duration)
+	name              string
+	jobChan           chan Job
+	wg                sync.WaitGroup
+	cancel            context.CancelFunc
+	ctx               context.Context
+	closed            atomic.Bool
+	onPending         func()
+	onPendingCanceled func()
+	onRunningStart    func()
+	onRunningFinish   func()
+	onRecordDuration  func(job Job, duration time.Duration)
 }
 
 // newSimpleJobWorker creates a new simple job worker pool
@@ -850,26 +909,28 @@ func newSimpleJobWorker(
 	name string,
 	threadCount int,
 	onPending func(),
+	onPendingCanceled func(),
 	onRunningStart func(),
 	onRunningFinish func(),
 	onRecordDuration func(job Job, duration time.Duration),
 ) *simpleJobWorker {
 	w := &simpleJobWorker{
-		name:             name,
-		jobChan:          make(chan Job, 10000),
-		onPending:        onPending,
-		onRunningStart:   onRunningStart,
-		onRunningFinish:  onRunningFinish,
-		onRecordDuration: onRecordDuration,
+		name:              name,
+		jobChan:           make(chan Job, 10000),
+		onPending:         onPending,
+		onPendingCanceled: onPendingCanceled,
+		onRunningStart:    onRunningStart,
+		onRunningFinish:   onRunningFinish,
+		onRecordDuration:  onRecordDuration,
 	}
 	w.ctx, w.cancel = context.WithCancel(context.Background())
-	go w.run(threadCount)
+	w.start(threadCount)
 	return w
 }
 
-func (w *simpleJobWorker) run(threadCount int) {
+func (w *simpleJobWorker) start(threadCount int) {
+	w.wg.Add(threadCount)
 	for i := 0; i < threadCount; i++ {
-		w.wg.Add(1)
 		go func() {
 			defer w.wg.Done()
 			for {
@@ -877,6 +938,11 @@ func (w *simpleJobWorker) run(threadCount int) {
 				case <-w.ctx.Done():
 					return
 				case job := <-w.jobChan:
+					select {
+					case <-w.ctx.Done():
+						return
+					default:
+					}
 					w.onRunningStart()
 					startTime := time.Now()
 					job.Execute()
@@ -895,16 +961,27 @@ func (w *simpleJobWorker) submit(job Job) error {
 	if w.closed.Load() {
 		return moerr.NewInternalErrorf(context.Background(), "%s is closed", w.name)
 	}
+	if job == nil {
+		return moerr.NewInternalErrorf(context.Background(), "cannot submit a nil job to %s", w.name)
+	}
 	w.onPending()
-	w.jobChan <- job
-	return nil
+	select {
+	case w.jobChan <- job:
+		return nil
+	case <-doneChan(w.ctx):
+		if w.onPendingCanceled != nil {
+			w.onPendingCanceled()
+		}
+		return moerr.NewInternalErrorf(context.Background(), "%s is closed", w.name)
+	}
 }
 
 func (w *simpleJobWorker) stop() {
-	w.closed.Store(true)
+	if !w.closed.CompareAndSwap(false, true) {
+		return
+	}
 	w.cancel()
 	w.wg.Wait()
-	close(w.jobChan)
 }
 
 // ============================================================================
@@ -924,6 +1001,10 @@ func NewWriteObjectWorker() WriteObjectWorker {
 			func() {
 				globalJobStats.IncrementWriteObjectPending()
 				v2.CCPRWriteObjectQueueSizeGauge.Inc()
+			},
+			func() {
+				globalJobStats.WriteObjectPending.Add(-1)
+				v2.CCPRWriteObjectQueueSizeGauge.Dec()
 			},
 			func() {
 				globalJobStats.IncrementWriteObjectRunning()

--- a/pkg/publication/worker_submit_test.go
+++ b/pkg/publication/worker_submit_test.go
@@ -81,6 +81,7 @@ type mockJob struct{}
 func (m *mockJob) Execute()      {}
 func (m *mockJob) WaitDone() any { return nil }
 func (m *mockJob) GetType() int8 { return 0 }
+func (m *mockJob) Fail(error)    {}
 
 // ---- Worker pool submit success tests ----
 

--- a/pkg/publication/worker_submit_test.go
+++ b/pkg/publication/worker_submit_test.go
@@ -83,6 +83,37 @@ func (m *mockJob) WaitDone() any { return nil }
 func (m *mockJob) GetType() int8 { return 0 }
 func (m *mockJob) Fail(error)    {}
 
+type legacyJob struct{}
+
+func (m *legacyJob) Execute()      {}
+func (m *legacyJob) WaitDone() any { return nil }
+func (m *legacyJob) GetType() int8 { return 0 }
+
+var _ Job = (*legacyJob)(nil)
+
+func TestWorkerAdmissionRequiresAdditiveTerminalContract(t *testing.T) {
+	filterWorker := NewFilterObjectWorker()
+	defer filterWorker.Stop()
+	require.ErrorContains(t,
+		filterWorker.SubmitFilterObject(&legacyJob{}),
+		"terminal failure completion",
+	)
+
+	chunkWorker := NewGetChunkWorker()
+	defer chunkWorker.Stop()
+	require.ErrorContains(t,
+		chunkWorker.SubmitGetChunk(&legacyJob{}),
+		"terminal failure completion",
+	)
+
+	writeWorker := NewWriteObjectWorker()
+	defer writeWorker.Stop()
+	require.ErrorContains(t,
+		writeWorker.SubmitWriteObject(&legacyJob{}),
+		"terminal failure completion",
+	)
+}
+
 // ---- Worker pool submit success tests ----
 
 func TestFilterObjectWorker_SubmitSuccess(t *testing.T) {

--- a/pkg/publication/worker_test.go
+++ b/pkg/publication/worker_test.go
@@ -16,12 +16,14 @@ package publication
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +35,157 @@ func TestWorkerStopImmediatelyAfterConstruction(t *testing.T) {
 	w := NewWorker("", nil, nil, nil, nil)
 	w.Stop()
 	runtime.Gosched()
+}
+
+func TestStoppedWorkersCompleteRejectedJobs(t *testing.T) {
+	tests := []struct {
+		name   string
+		job    Job
+		submit func(Job) error
+	}{
+		{
+			name: "filter object",
+			job:  NewFilterObjectJob(context.Background(), nil, types.TS{}, nil, false, nil, nil, nil, nil, "", "", nil, nil, nil, nil),
+			submit: func(job Job) error {
+				worker := NewFilterObjectWorker()
+				worker.Stop()
+				return worker.SubmitFilterObject(job)
+			},
+		},
+		{
+			name: "get chunk",
+			job:  NewGetChunkJob(context.Background(), nil, "object", 1, "", ""),
+			submit: func(job Job) error {
+				worker := NewGetChunkWorker()
+				worker.Stop()
+				return worker.SubmitGetChunk(job)
+			},
+		},
+		{
+			name: "write object",
+			job:  NewWriteObjectJob(context.Background(), nil, "object", nil, nil, nil),
+			submit: func(job Job) error {
+				worker := NewWriteObjectWorker()
+				worker.Stop()
+				return worker.SubmitWriteObject(job)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Error(t, test.submit(test.job))
+			assertJobFailedPromptly(t, test.job)
+		})
+	}
+}
+
+func TestWorkerStopCompletesQueuedJobs(t *testing.T) {
+	previousStats := globalJobStats
+	globalJobStats = &JobStats{}
+	defer func() { globalJobStats = previousStats }()
+
+	filterCtx, filterCancel := context.WithCancel(context.Background())
+	filterWorker := &filterObjectWorker{
+		jobChan: make(chan Job, 1),
+		ctx:     filterCtx,
+		cancel:  filterCancel,
+	}
+	chunkCtx, chunkCancel := context.WithCancel(context.Background())
+	chunkWorker := &getChunkWorker{
+		jobChan: make(chan Job, 1),
+		ctx:     chunkCtx,
+		cancel:  chunkCancel,
+	}
+	writeCtx, writeCancel := context.WithCancel(context.Background())
+	writeWorker := &simpleJobWorker{
+		name:              "WriteObjectWorker",
+		jobChan:           make(chan Job, 1),
+		ctx:               writeCtx,
+		cancel:            writeCancel,
+		onPending:         func() {},
+		onPendingCanceled: func() {},
+	}
+
+	tests := []struct {
+		name   string
+		job    Job
+		submit func(Job) error
+		stop   func()
+	}{
+		{
+			name:   "filter object",
+			job:    NewFilterObjectJob(context.Background(), nil, types.TS{}, nil, false, nil, nil, nil, nil, "", "", nil, nil, nil, nil),
+			submit: filterWorker.SubmitFilterObject,
+			stop:   filterWorker.Stop,
+		},
+		{
+			name:   "get chunk",
+			job:    NewGetChunkJob(context.Background(), nil, "object", 1, "", ""),
+			submit: chunkWorker.SubmitGetChunk,
+			stop:   chunkWorker.Stop,
+		},
+		{
+			name:   "write object",
+			job:    NewWriteObjectJob(context.Background(), nil, "object", nil, nil, nil),
+			submit: writeWorker.submit,
+			stop:   writeWorker.stop,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, test.submit(test.job))
+			test.stop()
+			assertJobFailedPromptly(t, test.job)
+		})
+	}
+
+	require.Zero(t, globalJobStats.FilterObjectPending.Load())
+	require.Zero(t, globalJobStats.GetChunkPending.Load())
+}
+
+func TestJobCompletionIsExactlyOnce(t *testing.T) {
+	firstErr := errors.New("first")
+	job := NewWriteObjectJob(context.Background(), nil, "object", nil, nil, nil)
+	job.Fail(firstErr)
+	job.Fail(errors.New("second"))
+
+	result := job.WaitDone().(*WriteObjectJobResult)
+	require.ErrorIs(t, result.Err, firstErr)
+	select {
+	case <-job.result:
+		t.Fatal("job published more than one terminal result")
+	default:
+	}
+}
+
+func TestGetMetaReturnsWorkerRejection(t *testing.T) {
+	worker := NewGetChunkWorker()
+	worker.Stop()
+
+	_, err := getMetaWithRetry(context.Background(), nil, "object", worker, "", "")
+	require.Error(t, err)
+}
+
+func assertJobFailedPromptly(t *testing.T, job Job) {
+	t.Helper()
+	result := make(chan any, 1)
+	go func() { result <- job.WaitDone() }()
+	select {
+	case value := <-result:
+		switch value := value.(type) {
+		case *FilterObjectJobResult:
+			require.Error(t, value.Err)
+		case *GetChunkJobResult:
+			require.Error(t, value.Err)
+		case *WriteObjectJobResult:
+			require.Error(t, value.Err)
+		default:
+			t.Fatalf("unexpected job result type %T", value)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("job did not reach a terminal result")
+	}
 }
 
 func TestWorkerStopIsConcurrentAndIdempotent(t *testing.T) {

--- a/pkg/publication/worker_test.go
+++ b/pkg/publication/worker_test.go
@@ -61,6 +61,29 @@ func TestWorkerPoolsStopIdempotently(t *testing.T) {
 	}
 }
 
+func TestWorkerPoolsDrainPendingJobsOnStop(t *testing.T) {
+	previousProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previousProcs)
+	previousStats := globalJobStats
+	globalJobStats = &JobStats{}
+	defer func() { globalJobStats = previousStats }()
+
+	filterWorker := NewFilterObjectWorker()
+	require.NoError(t, filterWorker.SubmitFilterObject(&mockJob{}))
+	filterWorker.Stop()
+	require.Zero(t, globalJobStats.FilterObjectPending.Load())
+
+	getChunkWorker := NewGetChunkWorker()
+	require.NoError(t, getChunkWorker.SubmitGetChunk(&mockJob{}))
+	getChunkWorker.Stop()
+	require.Zero(t, globalJobStats.GetChunkPending.Load())
+
+	writeObjectWorker := NewWriteObjectWorker()
+	require.NoError(t, writeObjectWorker.SubmitWriteObject(&mockJob{}))
+	writeObjectWorker.Stop()
+	require.Zero(t, globalJobStats.WriteObjectPending.Load())
+}
+
 func TestSimpleWorkerCancellationUnblocksSubmitAndRollsBackPending(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	jobs := make(chan Job, 1)
@@ -78,6 +101,20 @@ func TestSimpleWorkerCancellationUnblocksSubmitAndRollsBackPending(t *testing.T)
 	cancel()
 	require.Error(t, w.submit(&mockJob{}))
 	require.Zero(t, pending.Load())
+}
+
+func TestWorkerStopClearsAndSealsSyncProtection(t *testing.T) {
+	w := &worker{
+		syncProtectionJobs: make(map[string]*syncProtectionEntry),
+	}
+	w.ctx, w.cancel = context.WithCancel(context.Background())
+	w.RegisterSyncProtection("before-stop", 1)
+
+	w.Stop()
+	require.Zero(t, w.GetSyncProtectionTTL("before-stop"))
+
+	w.RegisterSyncProtection("after-stop", 2)
+	require.Zero(t, w.GetSyncProtectionTTL("after-stop"))
 }
 
 func TestGetJobStats(t *testing.T) {

--- a/pkg/publication/worker_test.go
+++ b/pkg/publication/worker_test.go
@@ -15,12 +15,70 @@
 package publication
 
 import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWorkerStopImmediatelyAfterConstruction(t *testing.T) {
+	previous := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previous)
+
+	w := NewWorker("", nil, nil, nil, nil)
+	w.Stop()
+	runtime.Gosched()
+}
+
+func TestWorkerStopIsConcurrentAndIdempotent(t *testing.T) {
+	w := NewWorker("", nil, nil, nil, nil)
+	var stops sync.WaitGroup
+	for range 8 {
+		stops.Add(1)
+		go func() {
+			defer stops.Done()
+			w.Stop()
+		}()
+	}
+	stops.Wait()
+	require.Error(t, w.Submit("task-after-stop", 1, 0))
+}
+
+func TestWorkerPoolsStopIdempotently(t *testing.T) {
+	workers := []interface{ Stop() }{
+		NewFilterObjectWorker(),
+		NewGetChunkWorker(),
+		NewWriteObjectWorker(),
+	}
+	for _, w := range workers {
+		w.Stop()
+		w.Stop()
+	}
+}
+
+func TestSimpleWorkerCancellationUnblocksSubmitAndRollsBackPending(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	jobs := make(chan Job, 1)
+	jobs <- &mockJob{}
+	var pending atomic.Int64
+	w := &simpleJobWorker{
+		name:              "test worker",
+		jobChan:           jobs,
+		ctx:               ctx,
+		cancel:            cancel,
+		onPending:         func() { pending.Add(1) },
+		onPendingCanceled: func() { pending.Add(-1) },
+	}
+
+	cancel()
+	require.Error(t, w.submit(&mockJob{}))
+	require.Zero(t, pending.Load())
+}
 
 func TestGetJobStats(t *testing.T) {
 	stats := GetJobStats()

--- a/pkg/taskservice/daemon_task_test.go
+++ b/pkg/taskservice/daemon_task_test.go
@@ -588,17 +588,26 @@ func waitStarted(started *atomic.Bool, timeout time.Duration) {
 }
 
 func TestPauseResumeDaemonTask(t *testing.T) {
-	runTaskRunnerTest(t, func(r *taskRunner, s TaskService, store TaskStorage) {
-		dt := newDaemonTaskForTest(1, task.TaskStatus_Created, r.runnerID)
-		mustAddTestDaemonTask(t, store, 1, dt)
-		var started atomic.Bool
-		r.testRegisterExecutor(t, task.TaskCode_ConnectorKafkaSink, &started)
-		waitStarted(&started, time.Second*5)
+	for _, code := range []task.TaskCode{
+		task.TaskCode_ConnectorKafkaSink,
+		task.TaskCode_ISCPExecutor,
+		task.TaskCode_PublicationExecutor,
+	} {
+		t.Run(code.String(), func(t *testing.T) {
+			runTaskRunnerTest(t, func(r *taskRunner, s TaskService, store TaskStorage) {
+				dt := newDaemonTaskForTest(1, task.TaskStatus_Created, r.runnerID)
+				dt.Metadata.Executor = code
+				mustAddTestDaemonTask(t, store, 1, dt)
+				var started atomic.Bool
+				r.testRegisterExecutor(t, code, &started)
+				waitStarted(&started, time.Second*5)
 
-		expectTaskStatus(t, store, dt, task.TaskStatus_PauseRequested, task.TaskStatus_Paused)
-		expectTaskStatus(t, store, dt, task.TaskStatus_ResumeRequested, task.TaskStatus_Running)
-	}, WithRunnerParallelism(1),
-		WithRunnerFetchInterval(time.Millisecond))
+				expectTaskStatus(t, store, dt, task.TaskStatus_PauseRequested, task.TaskStatus_Paused)
+				expectTaskStatus(t, store, dt, task.TaskStatus_ResumeRequested, task.TaskStatus_Running)
+			}, WithRunnerParallelism(1),
+				WithRunnerFetchInterval(time.Millisecond))
+		})
+	}
 }
 
 func TestPauseTaskHandleIdempotent(t *testing.T) {

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -4768,9 +4768,11 @@ func TestISCPExecutorStartError(t *testing.T) {
 	assert.NoError(t, err)
 	err = cdcExecutor.Resume()
 	require.Error(t, err)
+	require.False(t, cdcExecutor.IsRunning())
 	rmFn()
 	err = cdcExecutor.Resume()
 	require.NoError(t, err)
+	require.True(t, cdcExecutor.IsRunning())
 }
 
 func TestStaleRead(t *testing.T) {

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -4431,19 +4431,13 @@ func TestApplyISCPLog(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestISCPReplay(t *testing.T) {
-
+func TestISCPResumeRecoversAcceptedIteration(t *testing.T) {
 	catalog.SetupDefines("")
-
-	// idAllocator := common.NewIdAllocator(1000)
-
-	var (
-		accountId = catalog.System_Account
-	)
+	accountID := catalog.System_Account
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountID)
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
 
@@ -4460,25 +4454,32 @@ func TestISCPReplay(t *testing.T) {
 	require.NoError(t, err)
 	err = mock_mo_intra_system_change_propagation_log(disttaeEngine, ctxWithTimeout)
 	require.NoError(t, err)
-	t.Log(taeHandler.GetDB().Catalog.SimplePPString(3))
-	// create database and table
 
 	bat := CreateDBAndTableForCNConsumerAndGetAppendData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", 10)
 	bats := bat.Split(10)
 	defer bat.Close()
 
-	// append 1 row
 	_, rel, txn, err := disttaeEngine.GetTable(ctxWithTimeout, "srcdb", "src_table")
-	require.Nil(t, err)
+	require.NoError(t, err)
+	tableID := rel.GetTableID(ctxWithTimeout)
+	require.NoError(t, rel.Write(ctxWithTimeout, containers.ToCNBatch(bats[0])))
+	require.NoError(t, txn.Commit(ctxWithTimeout))
+	minimumRecoveredWatermark := taeHandler.GetDB().TxnMgr.Now()
 
-	// tableID := rel.GetTableID(ctxWithTimeout)
+	// Fail after admission but before FlushJobStatusOnIterationState persists
+	// Running. This creates the original divergence deterministically: memory is
+	// Pending at LSN 1 while storage is still Completed at LSN 0.
+	fault.Enable()
+	defer fault.Disable()
+	rmFault, err := objectio.InjectCDCExecutor("iteration:src_table")
+	require.NoError(t, err)
+	faultRemoved := false
+	defer func() {
+		if !faultRemoved {
+			_, _ = rmFault()
+		}
+	}()
 
-	err = rel.Write(ctxWithTimeout, containers.ToCNBatch(bats[0]))
-	require.Nil(t, err)
-
-	txn.Commit(ctxWithTimeout)
-
-	// init cdc executor
 	checkLeaseStub := gostub.Stub(
 		&iscp.CheckLeaseWithRetry,
 		func(
@@ -4508,36 +4509,79 @@ func TestISCPReplay(t *testing.T) {
 	require.NoError(t, err)
 	cdcExecutor.SetRpcHandleFn(taeHandler.GetRPCHandle().HandleGetChangedTableList)
 
-	cdcExecutor.Start()
+	require.NoError(t, cdcExecutor.Start())
 	defer cdcExecutor.Stop()
 
-	registerFn := func(indexName string) {
-		txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
-		require.NoError(t, err)
-		ok, err := iscp.RegisterJob(
-			ctx, "", txn,
-			&iscp.JobSpec{
-				ConsumerInfo: iscp.ConsumerInfo{
-					ConsumerType: int8(iscp.ConsumerType_CNConsumer),
-				},
-			},
-			&iscp.JobID{
-				JobName:   indexName,
-				DBName:    "srcdb",
-				TableName: "src_table",
-			},
-			true,
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
+	require.NoError(t, err)
+	ok, err := iscp.RegisterJob(
+		ctx,
+		"",
+		txn,
+		&iscp.JobSpec{ConsumerInfo: iscp.ConsumerInfo{ConsumerType: int8(iscp.ConsumerType_CNConsumer)}},
+		&iscp.JobID{JobName: "replay_job", DBName: "srcdb", TableName: "src_table"},
+		false,
+	)
+	require.True(t, ok)
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
+
+	require.Eventually(t, func() bool {
+		lsn, state, found := cdcExecutor.GetJobState(accountID, tableID, "replay_job")
+		return found && lsn == 1 && state == iscp.ISCPJobState_Pending
+	}, 4*time.Second, 10*time.Millisecond)
+
+	readPersistedState := func() (int8, uint64) {
+		readTxn, readErr := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
+		require.NoError(t, readErr)
+		result, readErr := iscp.ExecWithResult(
+			ctxWithTimeout,
+			fmt.Sprintf(
+				"SELECT job_state, job_status FROM `mo_catalog`.`mo_iscp_log` WHERE account_id = %d AND table_id = %d AND job_name = 'replay_job'",
+				accountID,
+				tableID,
+			),
+			"",
+			readTxn,
 		)
-		assert.True(t, ok)
-		assert.NoError(t, err)
-		assert.NoError(t, txn.Commit(ctxWithTimeout))
+		require.NoError(t, readErr)
+		defer result.Close()
+
+		var state int8
+		var lsn uint64
+		result.ReadRows(func(rows int, cols []*vector.Vector) bool {
+			require.Equal(t, 1, rows)
+			state = vector.MustFixedColWithTypeCheck[int8](cols[0])[0]
+			status, statusErr := iscp.UnmarshalJobStatus(cols[1].GetBytesAt(0))
+			require.NoError(t, statusErr)
+			lsn = status.LSN
+			return true
+		})
+		require.NoError(t, readTxn.Commit(ctxWithTimeout))
+		return state, lsn
 	}
 
-	for i := 0; i < 10; i++ {
-		registerFn(fmt.Sprintf("hnsw_idx_%d", i))
-	}
+	persistedState, persistedLSN := readPersistedState()
+	require.Equal(t, iscp.ISCPJobState_Completed, persistedState)
+	require.Zero(t, persistedLSN)
+
 	cdcExecutor.Stop()
-	cdcExecutor.Start()
+	_, err = rmFault()
+	require.NoError(t, err)
+	faultRemoved = true
+	require.NoError(t, cdcExecutor.Resume())
+
+	require.Eventually(t, func() bool {
+		lsn, state, found := cdcExecutor.GetJobState(accountID, tableID, "replay_job")
+		watermark, watermarkFound := cdcExecutor.GetWatermark(accountID, tableID, "replay_job")
+		return found && watermarkFound &&
+			lsn == 1 && state == iscp.ISCPJobState_Completed &&
+			watermark.GE(&minimumRecoveredWatermark)
+	}, 10*time.Second, 10*time.Millisecond)
+
+	persistedState, persistedLSN = readPersistedState()
+	require.Equal(t, iscp.ISCPJobState_Completed, persistedState)
+	require.Equal(t, uint64(1), persistedLSN)
 }
 
 func TestRenameSrcTable(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25731

## What this PR does / why we need it:

The CI failure in TestISCPExecutorStartError is a pre-existing worker lifecycle race, not a regression from PR #25725. NewWorker returned before Run registered its goroutines in the WaitGroup. An immediate Stop could therefore wait for zero goroutines, close the task channel, and return; the delayed Run then received a nil value from that closed channel and dereferenced it.

This PR fixes the lifecycle protocol instead of guarding the observed nil dereference:

- registers every owned worker goroutine before publishing the worker;
- uses context cancellation instead of closing work queues that have racing senders;
- seals sender admission before cancellation, waits for admitted senders, and drains queued references only after no late sender can arrive;
- makes concurrent Stop calls wait for one shared, exactly-once cleanup;
- defines shutdown as cancel-and-drain: calls admitted before the close linearization point may enqueue successfully, while calls admitted afterward return a closed error; queued work need not execute;
- rejects nil work and rolls back pending counters/gauges for cancellation and drained jobs;
- clears and seals sync-protection state during shutdown;
- publishes an ISCP executor generation only after replay and state initialization succeed;
- binds each run loop to immutable context/worker generation snapshots;
- propagates daemon-task parent cancellation, releases singleton admission, and returns attachment failures;
- applies the same invariants to the publication worker and its subordinate pools, where a deterministic clean-main reproduction found the same panic;
- stops all executor and keepalive tickers through their owning goroutines.

The original failing engine test now verifies that a failed Resume leaves the executor stopped and that the next Resume creates a healthy generation.

Performance validation on Apple M4:

- buffered send: about 14 ns/op;
- cancellation-aware send: about 22 ns/op;
- full admission-gated send: about 28 ns/op;
- all variants: 0 allocations;
- publication worker construction: about 0.10-0.13 ms.

The additional nanoseconds are negligible relative to the SQL/RPC/fileservice work dispatched by these queues.

Test matrix after the final edit and latest-main merge:

- go test ./pkg/iscp ./pkg/publication
- go test -race ./pkg/iscp ./pkg/publication
- go test ./pkg/vm/engine/test -run '^TestISCPExecutorStartError$' -count=20
- go test -race ./pkg/vm/engine/test -run '^TestISCPExecutorStartError$' -count=1
- go test ./pkg/vm/engine/test
- go vet ./pkg/iscp ./pkg/publication
- go build ./pkg/iscp ./pkg/publication

All commands passed with branch head fa20b0d37c based on main 0c21589ddd.
