### PR TITLE
fix(backup): respect checkpoint request deadlines

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -46,6 +46,58 @@ const (
 	ModuleName = "Backup"
 )
 
+func TestExecBackupRejectsIncompleteCheckpointResponse(t *testing.T) {
+	testCases := []struct {
+		name      string
+		locations []string
+		want      string
+	}{
+		{
+			name: "empty response",
+			want: "expected backup time and checkpoint location, got 0 field(s)",
+		},
+		{
+			name:      "checkpoint timeout response",
+			locations: []string{"2026-06-27 06:01:22"},
+			want:      "expected backup time and checkpoint location, got 1 field(s)",
+		},
+		{
+			name:      "empty backup time",
+			locations: []string{"", "checkpoint"},
+			want:      "backup time is empty",
+		},
+		{
+			name:      "empty checkpoint location",
+			locations: []string{"2026-06-27 06:01:22", ""},
+			want:      "checkpoint location is empty",
+		},
+		{
+			name:      "malformed checkpoint location",
+			locations: []string{"2026-06-27 06:01:22", "Failed"},
+			want:      "invalid checkpoint string",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := execBackup(
+				context.Background(),
+				"",
+				nil,
+				nil,
+				testCase.locations,
+				1,
+				types.TS{},
+				"full",
+				nil,
+				nil,
+				nil,
+			)
+			require.ErrorContains(t, err, testCase.want)
+		})
+	}
+}
+
 func TestBackupData(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)

--- a/pkg/backup/tae.go
+++ b/pkg/backup/tae.go
@@ -289,6 +289,20 @@ func execBackup(
 	protectionMgr *backupProtectionManager, // Optional: nil for tests, non-nil for production
 	globalIndex *GlobalFileIndex, // Optional: global file index for checking if file already backed up
 ) error {
+	if len(names) < 2 {
+		return moerr.NewInternalErrorf(
+			ctx,
+			"incomplete backup checkpoint response: expected backup time and checkpoint location, got %d field(s)",
+			len(names),
+		)
+	}
+	if names[0] == "" {
+		return moerr.NewInternalError(ctx, "incomplete backup checkpoint response: backup time is empty")
+	}
+	if names[1] == "" {
+		return moerr.NewInternalError(ctx, "incomplete backup checkpoint response: checkpoint location is empty")
+	}
+
 	backupTime := names[0]
 	trimString := names[1]
 	names = names[1:]
@@ -320,7 +334,7 @@ func execBackup(
 			continue
 		}
 		ckpStr := strings.Split(name, ":")
-		if len(ckpStr) != 2 && i > 0 {
+		if (i == 0 && len(ckpStr) != 5) || (i > 0 && len(ckpStr) != 2) {
 			return moerr.NewInternalError(ctx, fmt.Sprintf("invalid checkpoint string: %v", ckpStr))
 		}
 		metaLoc := ckpStr[0]

--- a/pkg/txn/storage/tae/storage_debug.go
+++ b/pkg/txn/storage/tae/storage_debug.go
@@ -93,9 +93,7 @@ func (s *taeStorage) Debug(ctx context.Context,
 	case uint32(api.OpCode_OpBackup):
 		resp, err := handleRead(ctx, txnMeta, data, s.taeHandler.HandleBackup)
 		if err != nil {
-			return types.Encode(&api.SyncLogTailResp{
-				CkpLocation: "Failed",
-			})
+			return nil, err
 		}
 		return resp.Read()
 	case uint32(api.OpCode_OpTraceSpan):

--- a/pkg/txn/storage/tae/storage_debug_test.go
+++ b/pkg/txn/storage/tae/storage_debug_test.go
@@ -33,6 +33,10 @@ type storageUsageErrorHandler struct {
 	rpchandle.Handler
 }
 
+type backupErrorHandler struct {
+	rpchandle.Handler
+}
+
 func (h *storageUsageErrorHandler) HandleStorageUsage(
 	context.Context,
 	txn.TxnMeta,
@@ -40,6 +44,27 @@ func (h *storageUsageErrorHandler) HandleStorageUsage(
 	*cmd_util.StorageUsageResp_V3,
 ) (func(), error) {
 	return nil, errStorageUsage
+}
+
+func (h *backupErrorHandler) HandleBackup(
+	context.Context,
+	txn.TxnMeta,
+	*cmd_util.Checkpoint,
+	*api.SyncLogTailResp,
+) (func(), error) {
+	return nil, context.DeadlineExceeded
+}
+
+func TestDebugBackupReturnsCheckpointError(t *testing.T) {
+	s := &taeStorage{taeHandler: &backupErrorHandler{}}
+	resp, err := s.Debug(
+		context.Background(),
+		txn.TxnMeta{},
+		uint32(api.OpCode_OpBackup),
+		nil,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, resp)
 }
 
 func TestDebugStorageUsageReturnsHandlerError(t *testing.T) {

--- a/pkg/vm/engine/tae/db/checkpoint/runner_test.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner_test.go
@@ -29,6 +29,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestContextForForceICKP(t *testing.T) {
+	t.Run("add the default timeout when the caller has none", func(t *testing.T) {
+		ctx, cancel := contextForForceICKP(context.Background())
+		defer cancel()
+
+		deadline, hasDeadline := ctx.Deadline()
+		assert.True(t, hasDeadline)
+		assert.WithinDuration(t, time.Now().Add(defaultForceICKPTimeout), deadline, time.Second)
+	})
+
+	t.Run("preserve a longer caller deadline", func(t *testing.T) {
+		callerDeadline := time.Now().Add(10 * time.Minute)
+		parent, cancelParent := context.WithDeadline(context.Background(), callerDeadline)
+		defer cancelParent()
+
+		ctx, cancel := contextForForceICKP(parent)
+		defer cancel()
+
+		deadline, hasDeadline := ctx.Deadline()
+		assert.True(t, hasDeadline)
+		assert.Equal(t, callerDeadline, deadline)
+	})
+}
+
 func TestCkpCheck(t *testing.T) {
 	ioutil.RunPipelineTest(
 		func() {

--- a/pkg/vm/engine/tae/db/checkpoint/testutils.go
+++ b/pkg/vm/engine/tae/db/checkpoint/testutils.go
@@ -26,6 +26,21 @@ import (
 	"go.uber.org/zap"
 )
 
+const defaultForceICKPTimeout = 2 * time.Minute
+
+func contextForForceICKP(
+	ctx context.Context,
+) (context.Context, context.CancelFunc) {
+	// A caller-provided deadline is part of the operation's contract. In
+	// particular, backup uses a longer request deadline because checkpoint
+	// duration scales with dirty data. Keep the historical timeout only as a
+	// safety net for callers that provide no deadline at all.
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, defaultForceICKPTimeout)
+}
+
 type TestRunner interface {
 	EnableCheckpoint(*CheckpointCfg)
 	DisableCheckpoint(ctx context.Context) (*CheckpointCfg, error)
@@ -208,7 +223,7 @@ func (r *runner) ForceICKP(ctx context.Context, ts *types.TS) (err error) {
 		)
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
+	ctx, cancel := contextForForceICKP(ctx)
 	defer cancel()
 
 	for {

--- a/pkg/vm/engine/tae/rpc/handle_debug.go
+++ b/pkg/vm/engine/tae/rpc/handle_debug.go
@@ -59,6 +59,20 @@ const (
 	DefaultTimeout = time.Minute * 3 / 2
 )
 
+func contextForBackupCheckpoint(
+	ctx context.Context,
+	timeout time.Duration,
+) (context.Context, context.CancelFunc) {
+	// The time needed to flush a backup checkpoint depends on the amount of
+	// dirty data. Do not impose the short timeout used by interactive debug
+	// commands when the caller did not request one. The request context still
+	// provides cancellation and the session-level deadline.
+	if timeout == 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
 ///
 ///
 /// impls TxnStorage:Debug
@@ -684,7 +698,6 @@ func (h *Handle) HandleBackup(
 	resp *api.SyncLogTailResp,
 ) (cb func(), err error) {
 	var (
-		timeout = req.FlushDuration
 		// Use the engine's HLC clock for the checkpoint TS, not wall-clock.
 		// HLC can be ahead of wall clock (e.g. after replaying logtail entries
 		// with future-dated timestamps); a wall-clock currTs could fall behind
@@ -699,10 +712,7 @@ func (h *Handle) HandleBackup(
 
 	locations += backupTime.Format(time.DateTime) + ";"
 
-	if timeout == 0 {
-		timeout = DefaultTimeout
-	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	ctx, cancel := contextForBackupCheckpoint(ctx, req.FlushDuration)
 	defer cancel()
 
 	if location, err = h.db.ForceCheckpointForBackup(ctx, currTs); err != nil {

--- a/pkg/vm/engine/tae/rpc/handle_debug_test.go
+++ b/pkg/vm/engine/tae/rpc/handle_debug_test.go
@@ -61,6 +61,29 @@ func TestHandleBackup(t *testing.T) {
 	}
 }
 
+func TestContextForBackupCheckpoint(t *testing.T) {
+	t.Run("inherit caller cancellation without an explicit timeout", func(t *testing.T) {
+		parent, cancelParent := context.WithCancel(context.Background())
+		ctx, cancel := contextForBackupCheckpoint(parent, 0)
+		defer cancel()
+
+		_, hasDeadline := ctx.Deadline()
+		require.False(t, hasDeadline)
+
+		cancelParent()
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+	})
+
+	t.Run("honor an explicit timeout", func(t *testing.T) {
+		ctx, cancel := contextForBackupCheckpoint(context.Background(), time.Minute)
+		defer cancel()
+
+		deadline, hasDeadline := ctx.Deadline()
+		require.True(t, hasDeadline)
+		require.WithinDuration(t, time.Now().Add(time.Minute), deadline, time.Second)
+	})
+}
+
 func TestHandleDiskCleaner_AddCheckerTTL(t *testing.T) {
 	h := mockTAEHandle(context.Background(), t, &options.Options{})
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25189

## What this PR does / why we need it:

A physical backup used the generic 90-second debug-command timeout for its forced checkpoint. Even after that outer timeout was removed, `ForceICKP` independently narrowed every caller to two minutes. Large dirty-data sets could therefore time out, and the TN debug layer then converted the checkpoint error into a successful `CkpLocation: "Failed"` response. The backup parser treated the incomplete response as checkpoint metadata and could panic on an out-of-range access.

This change:

- lets backup inherit the request/session deadline, while still honoring an explicitly supplied backup duration;
- makes `ForceICKP` preserve any caller-provided deadline and retain the historical two-minute fallback only for callers with no deadline;
- propagates backup checkpoint failures through the TN debug RPC instead of returning a sentinel success payload;
- validates backup checkpoint response cardinality and both special/regular checkpoint formats before indexing or copying files.

Successful backup response and on-disk formats are unchanged. Existing ordinary force-checkpoint calls still keep their 90-second deadline.

Validation:

- `go test -v -count=1 -timeout 300s ./pkg/backup ./pkg/txn/storage/tae ./pkg/vm/engine/tae/rpc ./pkg/vm/engine/tae/db/checkpoint`
- `go build ./pkg/backup ./pkg/txn/storage/tae ./pkg/vm/engine/tae/rpc ./pkg/vm/engine/tae/db/checkpoint`
- `go vet ./pkg/backup ./pkg/txn/storage/tae ./pkg/vm/engine/tae/rpc ./pkg/vm/engine/tae/db/checkpoint`
- `go test -v -count=1 ./pkg/txn/service -run '^TestDebug$'`
- targeted regression tests with `-race` for the four new tests
