### PR TITLE
fix: release RemoteRun stream after peer close

### DIFF
--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -370,8 +370,10 @@ type messageSenderOnClient struct {
 	// or
 	// 2. we have never sent a message in succeed.
 	safeToClose bool
-	// alreadyClose should be true once we get a stream closed signal.
-	alreadyClose       bool
+	// receiveClosed records a terminal signal from the receive channel. It
+	// poisons backend reuse, but does not release the locally owned morpc Stream;
+	// close must still call Stream.Close.
+	receiveClosed      bool
 	reuseEligible      bool
 	terminalNegotiated bool
 	expectedEnd        pipeline.Method
@@ -384,8 +386,7 @@ type messageSenderOnClient struct {
 	// still poisons reuse.
 	allowCleanupCancellation bool
 
-	// gaugeDecOnce ensures PipelineMessageSenderGauge.Dec() is called at most once when close() runs
-	// (including when close() returns early because alreadyClose is true, so the gauge still decrements).
+	// gaugeDecOnce ensures PipelineMessageSenderGauge.Dec() is called at most once when close() runs.
 	gaugeDecOnce sync.Once
 }
 
@@ -435,7 +436,7 @@ func newMessageSenderOnClient(
 		ctxCancel:          streamCtxCancel,
 		useInternalTimeout: useInternalTimeout,
 		safeToClose:        true,
-		alreadyClose:       false,
+		receiveClosed:      false,
 		mp:                 mp,
 		anal:               analyzeModule,
 		streamSender:       streamSender,
@@ -527,18 +528,18 @@ func (sender *messageSenderOnClient) markStreamActive(method pipeline.Method) {
 	sender.stateMu.Lock()
 	defer sender.stateMu.Unlock()
 	sender.safeToClose = false
-	sender.alreadyClose = false
+	sender.receiveClosed = false
 	sender.reuseEligible = false
 	sender.terminalNegotiated = false
 	sender.allowCleanupCancellation = false
 	sender.expectedEnd = method
 }
 
-func (sender *messageSenderOnClient) markStreamClosed() {
+func (sender *messageSenderOnClient) markReceiveClosed() {
 	sender.stateMu.Lock()
 	defer sender.stateMu.Unlock()
 	sender.safeToClose = true
-	sender.alreadyClose = true
+	sender.receiveClosed = true
 	sender.reuseEligible = false
 	sender.terminalNegotiated = false
 }
@@ -569,7 +570,7 @@ func (sender *messageSenderOnClient) receiveMessage() (morpc.Message, error) {
 
 	case val, ok := <-sender.receiveCh:
 		if !ok || val == nil {
-			sender.markStreamClosed()
+			sender.markReceiveClosed()
 			return nil, moerr.NewStreamClosed(sender.ctx)
 		}
 		return val, nil
@@ -682,9 +683,9 @@ func forwardRemoteBatchWithContext(
 // no matter how we stop the remote-run, we should get the final remote cost here.
 func (sender *messageSenderOnClient) waitingTheStopResponse() {
 	sender.stateMu.Lock()
-	alreadyClose, safeToClose := sender.alreadyClose, sender.safeToClose
+	receiveClosed, safeToClose := sender.receiveClosed, sender.safeToClose
 	sender.stateMu.Unlock()
-	if alreadyClose || safeToClose {
+	if receiveClosed || safeToClose {
 		return
 	}
 
@@ -704,7 +705,7 @@ func (sender *messageSenderOnClient) waitingTheStopResponse() {
 		select {
 		case val, ok := <-sender.receiveCh:
 			if !ok || val == nil {
-				sender.markStreamClosed()
+				sender.markReceiveClosed()
 				return
 			}
 
@@ -759,7 +760,7 @@ func (sender *messageSenderOnClient) finishStreamForReuse() bool {
 	select {
 	case value, ok := <-sender.receiveCh:
 		if !ok || value == nil {
-			sender.markStreamClosed()
+			sender.markReceiveClosed()
 			return false
 		}
 		message, ok := value.(*pipeline.Message)
@@ -791,15 +792,14 @@ func (sender *messageSenderOnClient) dealRemoteAnalysis(p models.PhyPlan) {
 
 func (sender *messageSenderOnClient) close() {
 	sender.closeOnce.Do(func() {
-		// Ensure Gauge is decremented exactly once when this sender is torn down, including when
-		// alreadyClose is true (stream already closed by remote); otherwise we'd leak the gauge.
+		// Ensure Gauge is decremented exactly once when this sender is torn down.
 		defer sender.gaugeDecOnce.Do(func() { v2.PipelineMessageSenderGauge.Dec() })
 
 		sender.waitingTheStopResponse()
 		sender.stateMu.Lock()
-		alreadyClose, reuseEligible := sender.alreadyClose, sender.reuseEligible
+		receiveClosed, reuseEligible := sender.receiveClosed, sender.reuseEligible
 		sender.stateMu.Unlock()
-		if !alreadyClose && reuseEligible && sender.finishStreamForReuse() {
+		if !receiveClosed && reuseEligible && sender.finishStreamForReuse() {
 			v2.PipelineStreamTeardownCounter.WithLabelValues("client_reuse").Inc()
 			if sender.ctxCancel != nil {
 				sender.ctxCancel()
@@ -814,14 +814,9 @@ func (sender *messageSenderOnClient) close() {
 		} else {
 			v2.PipelineStreamTeardownCounter.WithLabelValues("client_legacy_or_poisoned_close").Inc()
 		}
-		sender.stateMu.Lock()
-		alreadyClose = sender.alreadyClose
-		sender.stateMu.Unlock()
 		if sender.ctxCancel != nil {
 			sender.ctxCancel()
 		}
-		if !alreadyClose {
-			_ = sender.streamSender.Close(true)
-		}
+		_ = sender.streamSender.Close(true)
 	})
 }

--- a/pkg/sql/compile/remoterunClient_test.go
+++ b/pkg/sql/compile/remoterunClient_test.go
@@ -250,6 +250,63 @@ func TestMessageSenderOnClientNegotiatedStreamTeardown(t *testing.T) {
 		sender.close()
 	})
 
+	for _, tt := range []struct {
+		name         string
+		closeChannel bool
+	}{
+		{name: "closed receive channel releases stream ownership", closeChannel: true},
+		{name: "nil receive message releases stream ownership"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			stream := mock_morpc.NewMockStream(ctrl)
+			responses := make(chan morpc.Message, 1)
+			if tt.closeChannel {
+				close(responses)
+			} else {
+				responses <- nil
+			}
+			stream.EXPECT().Close(true).Return(nil).Times(1)
+			sender := &messageSenderOnClient{
+				ctx:           context.Background(),
+				streamSender:  stream,
+				receiveCh:     responses,
+				reuseEligible: true,
+			}
+
+			message, err := sender.receiveMessage()
+			require.Nil(t, message)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrStreamClosed))
+			require.True(t, sender.receiveClosed)
+			require.False(t, sender.reuseEligible)
+
+			sender.close()
+			sender.close()
+		})
+	}
+
+	t.Run("peer close while waiting for FIN ACK poisons backend", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stream := mock_morpc.NewMockStream(ctrl)
+		responses := make(chan morpc.Message)
+		close(responses)
+		stream.EXPECT().ID().Return(uint64(13))
+		stream.EXPECT().Send(gomock.Any(), gomock.Any()).Return(nil)
+		stream.EXPECT().Close(true).Return(nil)
+		sender := &messageSenderOnClient{
+			ctx:           context.Background(),
+			streamSender:  stream,
+			receiveCh:     responses,
+			safeToClose:   true,
+			reuseEligible: true,
+		}
+
+		sender.close()
+		require.True(t, sender.receiveClosed)
+		require.False(t, sender.reuseEligible)
+	})
+
 	t.Run("malformed FIN ACK poisons backend", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		stream := mock_morpc.NewMockStream(ctrl)

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -438,7 +438,7 @@ func TestMessageSenderOnClientReceiveBatchReturnsStreamClosed(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, moerr.IsMoErrCode(err, moerr.ErrStreamClosed))
 	require.True(t, sender.safeToClose)
-	require.True(t, sender.alreadyClose)
+	require.True(t, sender.receiveClosed)
 }
 
 func TestNewParallelScope(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25760

## What this PR does / why we need it:

- Distinguish a closed receive path from completed local morpc Stream cleanup.
- Poison backend reuse after a closed receive channel or nil message, while still invoking Stream.Close(true) to release local ownership.
- Preserve the FIN/FIN_ACK Close(false) reuse path introduced by #25713.
- Keep teardown exactly once through the existing closeOnce guard.
- Cover closed channels, nil messages, repeated close calls, and peer close while waiting for FIN_ACK.

## Testing

- make thirdparties
- .agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -run ^(TestMessageSenderOnClientNegotiatedStreamTeardown|TestMessageSenderOnClientReceiveBatchReturnsStreamClosed)$ -timeout=120s ./pkg/sql/compile
- .agents/skills/mo-dev/scripts/mo-cgo-test -race -count=10 -run ^(TestMessageSenderOnClientNegotiatedStreamTeardown|TestMessageSenderOnClientReceiveBatchReturnsStreamClosed)$ -timeout=240s ./pkg/sql/compile
- .agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s ./pkg/sql/compile
- .agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=240s ./pkg/sql/compile
- go build ./pkg/sql/compile
- go vet ./pkg/sql/compile
- go test -count=1 -run ^(TestCloseStreamWithCloseConn|TestLockedStream)$ -timeout=120s ./pkg/common/morpc
- .agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -run ^TestTxnComputationWrapper_Run$ -timeout=120s ./pkg/frontend