### PR TITLE
fix(parser): support Unicode select aliases

### DIFF
--- a/pkg/sql/parsers/dialect/mysql/mysql_lexer.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_lexer.go
@@ -166,6 +166,9 @@ func (l *Lexer) Lex(lval *yySymType) int {
 	if reservedKeywordsAfterAS[typ] && l.lastToken == AS {
 		typ = ID
 	}
+	if typ == unicodeID && l.lastToken == AS {
+		typ = ID
+	}
 
 	l.lastToken = typ
 	lval.str = str

--- a/pkg/sql/parsers/dialect/mysql/mysql_lexer.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_lexer.go
@@ -150,6 +150,7 @@ func (l *Lexer) GetParamIndex() int {
 }
 
 func (l *Lexer) Lex(lval *yySymType) int {
+	l.scanner.allowUnicodeIdentifier = l.lastToken == AS
 	typ, str := l.scanner.Scan()
 	l.scanner.LastToken = str
 
@@ -166,10 +167,6 @@ func (l *Lexer) Lex(lval *yySymType) int {
 	if reservedKeywordsAfterAS[typ] && l.lastToken == AS {
 		typ = ID
 	}
-	if typ == unicodeID && l.lastToken == AS {
-		typ = ID
-	}
-
 	l.lastToken = typ
 	lval.str = str
 	return typ

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -3774,6 +3774,40 @@ func TestValid(t *testing.T) {
 	}
 }
 
+func TestUnicodeIdentifierAliases(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT 1 AS qty",
+		"SELECT 1 AS الكمية",
+		"SELECT 1 AS 1数量",
+		"SELECT 1 AS `الكمية`",
+		"SELECT 1 AS `数量`",
+		"CREATE TABLE 数据表 (数量 INT)",
+		"SELECT 数量 FROM 数据表",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			_, err := ParseOne(context.Background(), sql, 1)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestInvalidUnicodeIdentifiers(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT 1 AS 😀",
+		"SELECT 1 AS `😀`",
+		"SELECT 1 AS 1😀",
+		"SELECT 1 AS 0x😀",
+		"SELECT 1 AS 0b😀",
+		"SELECT 1 AS `a\x00b`",
+		"SELECT 1 AS `\xff`",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			_, err := ParseOne(context.Background(), sql, 1)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestShowVariablesGlobalFlag(t *testing.T) {
 	ctx := context.TODO()
 	stmt, err := ParseOne(ctx, "show global variables like 'interactive_timeout'", 1)

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -3778,11 +3778,10 @@ func TestUnicodeIdentifierAliases(t *testing.T) {
 	for _, sql := range []string{
 		"SELECT 1 AS qty",
 		"SELECT 1 AS الكمية",
+		"SELECT 1 AS 数量",
 		"SELECT 1 AS 1数量",
 		"SELECT 1 AS `الكمية`",
 		"SELECT 1 AS `数量`",
-		"CREATE TABLE 数据表 (数量 INT)",
-		"SELECT 数量 FROM 数据表",
 	} {
 		t.Run(sql, func(t *testing.T) {
 			_, err := ParseOne(context.Background(), sql, 1)
@@ -3800,6 +3799,9 @@ func TestInvalidUnicodeIdentifiers(t *testing.T) {
 		"SELECT 1 AS 0b😀",
 		"SELECT 1 AS `a\x00b`",
 		"SELECT 1 AS `\xff`",
+		"CREATE TABLE 数据表 (数量 INT)",
+		"ALTER TABLE rename06 RENAME COLUMN col1 TO 数据库系统",
+		"CREATE ACCOUNT 非常 ADMIN_NAME 'admin' IDENTIFIED BY '123456'",
 	} {
 		t.Run(sql, func(t *testing.T) {
 			_, err := ParseOne(context.Background(), sql, 1)

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -3810,6 +3810,34 @@ func TestInvalidUnicodeIdentifiers(t *testing.T) {
 	}
 }
 
+func TestUnicodeIdentifierErrorPosition(t *testing.T) {
+	const prefix = "You have an error in your SQL syntax; check the manual that corresponds to your MatrixOne server version for the right syntax to use. syntax error"
+	tests := []struct {
+		sql  string
+		want string
+	}{
+		{
+			sql:  "ALTER TABLE rename06 RENAME COLUMN col1 TO 数据库系统;",
+			want: prefix + " at line 1 column 44 near \" 数据库系统;\";",
+		},
+		{
+			sql:  "CREATE ACCOUNT 非常 ADMIN_NAME 'admin' IDENTIFIED BY '123456';",
+			want: prefix + " at line 1 column 16 near \" 非常 ADMIN_NAME 'admin' IDENTIFIED BY '123456';\";",
+		},
+		{
+			sql:  "CREATE ACCOUNT 43349饪 ADMIN_NAME 'admin' IDENTIFIED BY '123456';",
+			want: prefix + " at line 1 column 20 near \" 43349饪 ADMIN_NAME 'admin' IDENTIFIED BY '123456';\";",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.sql, func(t *testing.T) {
+			_, err := ParseOne(context.Background(), test.sql, 1)
+			require.EqualError(t, err, test.want)
+		})
+	}
+}
+
 func TestShowVariablesGlobalFlag(t *testing.T) {
 	ctx := context.TODO()
 	stmt, err := ParseOne(ctx, "show global variables like 'interactive_timeout'", 1)

--- a/pkg/sql/parsers/dialect/mysql/scanner.go
+++ b/pkg/sql/parsers/dialect/mysql/scanner.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 )
@@ -140,7 +141,7 @@ func (s *Scanner) Scan() (int, string) {
 			return tID, ""
 		}
 		return tokenID, tBytes
-	case isLetter(ch):
+	case isIdentifierLetter(ch):
 		if ch == 'X' || ch == 'x' {
 			if s.peek(1) == '\'' {
 				s.incN(2)
@@ -551,7 +552,11 @@ func (s *Scanner) scanLiteralIdentifier() (int, string) {
 					return LEX_ERROR, ""
 				}
 				s.inc()
-				return QUOTE_ID, s.buf[start : s.Pos-1]
+				identifier := s.buf[start : s.Pos-1]
+				if !validIdentifier(identifier) {
+					return LEX_ERROR, identifier
+				}
+				return QUOTE_ID, identifier
 			}
 
 			var buf strings.Builder
@@ -597,7 +602,11 @@ func (s *Scanner) scanLiteralIdentifierSlow(buf *strings.Builder) (int, string) 
 		}
 		s.inc()
 	}
-	return QUOTE_ID, buf.String()
+	identifier := buf.String()
+	if !validIdentifier(identifier) {
+		return LEX_ERROR, identifier
+	}
+	return QUOTE_ID, identifier
 }
 
 // scanCommentTypeBlock scans a '/*' delimited comment;
@@ -730,7 +739,10 @@ func (s *Scanner) scanNumber() (int, string) {
 			p2 := s.Pos
 			if p1 == p2 || isDigit(s.cur()) {
 				token = ID
-				s.scanIdentifier(false)
+				typ, _ := s.scanIdentifier(false)
+				if typ == LEX_ERROR {
+					return LEX_ERROR, s.buf[start:s.Pos]
+				}
 				return token, strings.ToLower(s.buf[start:s.Pos])
 			}
 
@@ -743,7 +755,10 @@ func (s *Scanner) scanNumber() (int, string) {
 			p2 := s.Pos
 			if p1 == p2 || isDigit(s.cur()) {
 				token = ID
-				s.scanIdentifier(false)
+				typ, _ := s.scanIdentifier(false)
+				if typ == LEX_ERROR {
+					return LEX_ERROR, s.buf[start:s.Pos]
+				}
 				return token, strings.ToLower(s.buf[start:s.Pos])
 			}
 
@@ -774,10 +789,13 @@ exponent:
 	}
 
 exit:
-	if isLetter(s.cur()) {
+	if isIdentifierLetter(s.cur()) {
 		// TODO: optimize
+		typ, _ := s.scanIdentifier(false)
+		if typ == LEX_ERROR {
+			return LEX_ERROR, s.buf[start:s.Pos]
+		}
 		token = ID
-		s.scanIdentifier(false)
 	}
 
 	return token, strings.ToLower(s.buf[start:s.Pos])
@@ -796,7 +814,7 @@ func (s *Scanner) scanIdentifier(isVariable bool) (int, string) {
 		if ch == '$' && dollarFlag {
 			break
 		}
-		if !isLetter(ch) && !isDigit(ch) && ch != '@' && !(isVariable && isCarat(ch)) {
+		if !isIdentifierLetter(ch) && !isDigit(ch) && ch != '@' && !(isVariable && isCarat(ch)) {
 			break
 		}
 		if ch == '@' {
@@ -806,6 +824,9 @@ func (s *Scanner) scanIdentifier(isVariable bool) (int, string) {
 		s.inc()
 	}
 	keywordName := s.buf[start:s.Pos]
+	if !validIdentifier(keywordName) {
+		return LEX_ERROR, keywordName
+	}
 	lower := strings.ToLower(keywordName)
 	if keywordID, found := keywords[lower]; found {
 		// make transaction statements coexist with plsql
@@ -913,6 +934,21 @@ func (s *Scanner) peek(dist int) uint16 {
 		return eofChar
 	}
 	return uint16(s.buf[s.Pos+dist])
+}
+
+func validIdentifier(s string) bool {
+	for len(s) > 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == 0 || r > '\uFFFF' || r == utf8.RuneError && size == 1 {
+			return false
+		}
+		s = s[size:]
+	}
+	return true
+}
+
+func isIdentifierLetter(ch uint16) bool {
+	return isLetter(ch) || ch >= utf8.RuneSelf && ch != eofChar
 }
 
 func isLetter(ch uint16) bool {

--- a/pkg/sql/parsers/dialect/mysql/scanner.go
+++ b/pkg/sql/parsers/dialect/mysql/scanner.go
@@ -26,10 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 )
 
-const (
-	eofChar   = 0x100
-	unicodeID = 1 << 16
-)
+const eofChar = 0x100
 
 // maxPoolSQLSize is the size threshold beyond which a scanner will not be kept
 // in the pool and large fields will be cleared to release memory.
@@ -55,6 +52,10 @@ type Scanner struct {
 	PrePos      int
 	buf         string
 
+	// allowUnicodeIdentifier is enabled by the lexer only where the grammar
+	// accepts Unicode aliases. Other contexts retain the original tokenization.
+	allowUnicodeIdentifier bool
+
 	strBuilder bytes.Buffer
 }
 
@@ -65,6 +66,7 @@ func (s *Scanner) reset(clearLargeOnly bool, oversized bool) {
 	s.posVarIndex = 0
 	s.MysqlSpecialComment = nil
 	s.CommentFlag = false
+	s.allowUnicodeIdentifier = false
 	s.Pos = 0
 	s.Line = 0
 	s.Col = 0
@@ -144,7 +146,7 @@ func (s *Scanner) Scan() (int, string) {
 			return tID, ""
 		}
 		return tokenID, tBytes
-	case isIdentifierLetter(ch):
+	case s.isIdentifierLetter(ch):
 		if ch == 'X' || ch == 'x' {
 			if s.peek(1) == '\'' {
 				s.incN(2)
@@ -556,7 +558,7 @@ func (s *Scanner) scanLiteralIdentifier() (int, string) {
 				}
 				s.inc()
 				identifier := s.buf[start : s.Pos-1]
-				if identifierToken(identifier) == LEX_ERROR {
+				if !validIdentifier(identifier) {
 					return LEX_ERROR, identifier
 				}
 				return QUOTE_ID, identifier
@@ -606,7 +608,7 @@ func (s *Scanner) scanLiteralIdentifierSlow(buf *strings.Builder) (int, string) 
 		s.inc()
 	}
 	identifier := buf.String()
-	if identifierToken(identifier) == LEX_ERROR {
+	if !validIdentifier(identifier) {
 		return LEX_ERROR, identifier
 	}
 	return QUOTE_ID, identifier
@@ -746,9 +748,6 @@ func (s *Scanner) scanNumber() (int, string) {
 				if typ == LEX_ERROR {
 					return LEX_ERROR, s.buf[start:s.Pos]
 				}
-				if typ == unicodeID {
-					token = typ
-				}
 				return token, strings.ToLower(s.buf[start:s.Pos])
 			}
 
@@ -764,9 +763,6 @@ func (s *Scanner) scanNumber() (int, string) {
 				typ, _ := s.scanIdentifier(false)
 				if typ == LEX_ERROR {
 					return LEX_ERROR, s.buf[start:s.Pos]
-				}
-				if typ == unicodeID {
-					token = typ
 				}
 				return token, strings.ToLower(s.buf[start:s.Pos])
 			}
@@ -798,17 +794,13 @@ exponent:
 	}
 
 exit:
-	if isIdentifierLetter(s.cur()) {
+	if s.isIdentifierLetter(s.cur()) {
 		// TODO: optimize
 		typ, _ := s.scanIdentifier(false)
 		if typ == LEX_ERROR {
 			return LEX_ERROR, s.buf[start:s.Pos]
 		}
-		if typ == unicodeID {
-			token = typ
-		} else {
-			token = ID
-		}
+		token = ID
 	}
 
 	return token, strings.ToLower(s.buf[start:s.Pos])
@@ -827,7 +819,7 @@ func (s *Scanner) scanIdentifier(isVariable bool) (int, string) {
 		if ch == '$' && dollarFlag {
 			break
 		}
-		if !isIdentifierLetter(ch) && !isDigit(ch) && ch != '@' && !(isVariable && isCarat(ch)) {
+		if !s.isIdentifierLetter(ch) && !isDigit(ch) && ch != '@' && !(isVariable && isCarat(ch)) {
 			break
 		}
 		if ch == '@' {
@@ -837,12 +829,8 @@ func (s *Scanner) scanIdentifier(isVariable bool) (int, string) {
 		s.inc()
 	}
 	keywordName := s.buf[start:s.Pos]
-	token := identifierToken(keywordName)
-	if token == LEX_ERROR {
+	if s.allowUnicodeIdentifier && !validIdentifier(keywordName) {
 		return LEX_ERROR, keywordName
-	}
-	if token == unicodeID {
-		return token, keywordName
 	}
 	lower := strings.ToLower(keywordName)
 	if keywordID, found := keywords[lower]; found {
@@ -953,23 +941,19 @@ func (s *Scanner) peek(dist int) uint16 {
 	return uint16(s.buf[s.Pos+dist])
 }
 
-func identifierToken(s string) int {
-	token := ID
+func validIdentifier(s string) bool {
 	for len(s) > 0 {
 		r, size := utf8.DecodeRuneInString(s)
 		if r == 0 || r > '\uFFFF' || r == utf8.RuneError && size == 1 {
-			return LEX_ERROR
-		}
-		if r >= utf8.RuneSelf {
-			token = unicodeID
+			return false
 		}
 		s = s[size:]
 	}
-	return token
+	return true
 }
 
-func isIdentifierLetter(ch uint16) bool {
-	return isLetter(ch) || ch >= utf8.RuneSelf && ch != eofChar
+func (s *Scanner) isIdentifierLetter(ch uint16) bool {
+	return isLetter(ch) || s.allowUnicodeIdentifier && ch >= utf8.RuneSelf && ch != eofChar
 }
 
 func isLetter(ch uint16) bool {

--- a/pkg/sql/parsers/dialect/mysql/scanner.go
+++ b/pkg/sql/parsers/dialect/mysql/scanner.go
@@ -26,7 +26,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 )
 
-const eofChar = 0x100
+const (
+	eofChar   = 0x100
+	unicodeID = 1 << 16
+)
 
 // maxPoolSQLSize is the size threshold beyond which a scanner will not be kept
 // in the pool and large fields will be cleared to release memory.
@@ -553,7 +556,7 @@ func (s *Scanner) scanLiteralIdentifier() (int, string) {
 				}
 				s.inc()
 				identifier := s.buf[start : s.Pos-1]
-				if !validIdentifier(identifier) {
+				if identifierToken(identifier) == LEX_ERROR {
 					return LEX_ERROR, identifier
 				}
 				return QUOTE_ID, identifier
@@ -603,7 +606,7 @@ func (s *Scanner) scanLiteralIdentifierSlow(buf *strings.Builder) (int, string) 
 		s.inc()
 	}
 	identifier := buf.String()
-	if !validIdentifier(identifier) {
+	if identifierToken(identifier) == LEX_ERROR {
 		return LEX_ERROR, identifier
 	}
 	return QUOTE_ID, identifier
@@ -743,6 +746,9 @@ func (s *Scanner) scanNumber() (int, string) {
 				if typ == LEX_ERROR {
 					return LEX_ERROR, s.buf[start:s.Pos]
 				}
+				if typ == unicodeID {
+					token = typ
+				}
 				return token, strings.ToLower(s.buf[start:s.Pos])
 			}
 
@@ -758,6 +764,9 @@ func (s *Scanner) scanNumber() (int, string) {
 				typ, _ := s.scanIdentifier(false)
 				if typ == LEX_ERROR {
 					return LEX_ERROR, s.buf[start:s.Pos]
+				}
+				if typ == unicodeID {
+					token = typ
 				}
 				return token, strings.ToLower(s.buf[start:s.Pos])
 			}
@@ -795,7 +804,11 @@ exit:
 		if typ == LEX_ERROR {
 			return LEX_ERROR, s.buf[start:s.Pos]
 		}
-		token = ID
+		if typ == unicodeID {
+			token = typ
+		} else {
+			token = ID
+		}
 	}
 
 	return token, strings.ToLower(s.buf[start:s.Pos])
@@ -824,8 +837,12 @@ func (s *Scanner) scanIdentifier(isVariable bool) (int, string) {
 		s.inc()
 	}
 	keywordName := s.buf[start:s.Pos]
-	if !validIdentifier(keywordName) {
+	token := identifierToken(keywordName)
+	if token == LEX_ERROR {
 		return LEX_ERROR, keywordName
+	}
+	if token == unicodeID {
+		return token, keywordName
 	}
 	lower := strings.ToLower(keywordName)
 	if keywordID, found := keywords[lower]; found {
@@ -936,15 +953,19 @@ func (s *Scanner) peek(dist int) uint16 {
 	return uint16(s.buf[s.Pos+dist])
 }
 
-func validIdentifier(s string) bool {
+func identifierToken(s string) int {
+	token := ID
 	for len(s) > 0 {
 		r, size := utf8.DecodeRuneInString(s)
 		if r == 0 || r > '\uFFFF' || r == utf8.RuneError && size == 1 {
-			return false
+			return LEX_ERROR
+		}
+		if r >= utf8.RuneSelf {
+			token = unicodeID
 		}
 		s = s[size:]
 	}
-	return true
+	return token
 }
 
 func isIdentifierLetter(ch uint16) bool {

--- a/pkg/sql/parsers/dialect/mysql/scanner_test.go
+++ b/pkg/sql/parsers/dialect/mysql/scanner_test.go
@@ -80,9 +80,9 @@ func TestUnicodeIdentifier(t *testing.T) {
 		input string
 		want  int
 	}{
-		{name: "unquoted Arabic", input: "الكمية", want: ID},
-		{name: "unquoted Chinese", input: "数量", want: ID},
-		{name: "digit prefix Chinese", input: "1数量", want: ID},
+		{name: "unquoted Arabic", input: "الكمية", want: unicodeID},
+		{name: "unquoted Chinese", input: "数量", want: unicodeID},
+		{name: "digit prefix Chinese", input: "1数量", want: unicodeID},
 		{name: "quoted Arabic", input: "`الكمية`", want: QUOTE_ID},
 		{name: "quoted Chinese", input: "`数量`", want: QUOTE_ID},
 		{name: "invalid UTF-8", input: "`\xff`", want: LEX_ERROR},

--- a/pkg/sql/parsers/dialect/mysql/scanner_test.go
+++ b/pkg/sql/parsers/dialect/mysql/scanner_test.go
@@ -76,28 +76,31 @@ func TestLiteralID(t *testing.T) {
 
 func TestUnicodeIdentifier(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  int
+		name         string
+		input        string
+		allowUnicode bool
+		want         int
 	}{
-		{name: "unquoted Arabic", input: "الكمية", want: unicodeID},
-		{name: "unquoted Chinese", input: "数量", want: unicodeID},
-		{name: "digit prefix Chinese", input: "1数量", want: unicodeID},
+		{name: "unquoted Arabic", input: "الكمية", allowUnicode: true, want: ID},
+		{name: "unquoted Chinese", input: "数量", allowUnicode: true, want: ID},
+		{name: "digit prefix Chinese", input: "1数量", allowUnicode: true, want: ID},
 		{name: "quoted Arabic", input: "`الكمية`", want: QUOTE_ID},
 		{name: "quoted Chinese", input: "`数量`", want: QUOTE_ID},
 		{name: "invalid UTF-8", input: "`\xff`", want: LEX_ERROR},
-		{name: "digit prefix invalid UTF-8", input: "1\xff", want: LEX_ERROR},
+		{name: "digit prefix invalid UTF-8", input: "1\xff", allowUnicode: true, want: LEX_ERROR},
 		{name: "NUL", input: "`a\x00b`", want: LEX_ERROR},
 		{name: "supplementary character", input: "`😀`", want: LEX_ERROR},
-		{name: "digit prefix supplementary character", input: "1😀", want: LEX_ERROR},
-		{name: "hex prefix supplementary character", input: "0x😀", want: LEX_ERROR},
-		{name: "binary prefix supplementary character", input: "0b😀", want: LEX_ERROR},
+		{name: "digit prefix supplementary character", input: "1😀", allowUnicode: true, want: LEX_ERROR},
+		{name: "hex prefix supplementary character", input: "0x😀", allowUnicode: true, want: LEX_ERROR},
+		{name: "binary prefix supplementary character", input: "0b😀", allowUnicode: true, want: LEX_ERROR},
 		{name: "invalid UTF-8 bind variable", input: ":\xff", want: LEX_ERROR},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _ := NewScanner(dialect.MYSQL, test.input).Scan()
+			scanner := NewScanner(dialect.MYSQL, test.input)
+			scanner.allowUnicodeIdentifier = test.allowUnicode
+			got, _ := scanner.Scan()
 			if got != test.want {
 				t.Fatalf("Scan(%q) token = %s, want %s", test.input, tokenName(got), tokenName(test.want))
 			}

--- a/pkg/sql/parsers/dialect/mysql/scanner_test.go
+++ b/pkg/sql/parsers/dialect/mysql/scanner_test.go
@@ -74,6 +74,37 @@ func TestLiteralID(t *testing.T) {
 	}
 }
 
+func TestUnicodeIdentifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{name: "unquoted Arabic", input: "الكمية", want: ID},
+		{name: "unquoted Chinese", input: "数量", want: ID},
+		{name: "digit prefix Chinese", input: "1数量", want: ID},
+		{name: "quoted Arabic", input: "`الكمية`", want: QUOTE_ID},
+		{name: "quoted Chinese", input: "`数量`", want: QUOTE_ID},
+		{name: "invalid UTF-8", input: "`\xff`", want: LEX_ERROR},
+		{name: "digit prefix invalid UTF-8", input: "1\xff", want: LEX_ERROR},
+		{name: "NUL", input: "`a\x00b`", want: LEX_ERROR},
+		{name: "supplementary character", input: "`😀`", want: LEX_ERROR},
+		{name: "digit prefix supplementary character", input: "1😀", want: LEX_ERROR},
+		{name: "hex prefix supplementary character", input: "0x😀", want: LEX_ERROR},
+		{name: "binary prefix supplementary character", input: "0b😀", want: LEX_ERROR},
+		{name: "invalid UTF-8 bind variable", input: ":\xff", want: LEX_ERROR},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, _ := NewScanner(dialect.MYSQL, test.input).Scan()
+			if got != test.want {
+				t.Fatalf("Scan(%q) token = %s, want %s", test.input, tokenName(got), tokenName(test.want))
+			}
+		})
+	}
+}
+
 func tokenName(id int) string {
 	if id == STRING {
 		return "STRING"


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25014

## What this PR does / why we need it:

The MySQL scanner only treated ASCII letters as the start and continuation of unquoted identifiers, so select aliases containing Arabic, Chinese, or other BMP Unicode characters failed to parse.

This change enables valid BMP Unicode identifier scanning only when the lexer is reading the token after `AS`. Other grammar contexts retain their original tokenization and parser error positions. Invalid UTF-8, NUL, and supplementary characters remain rejected, including numeric, hexadecimal, and binary prefix paths.

Regression coverage includes Arabic and Chinese aliases, numeric prefixes, quoted aliases, invalid UTF-8, NUL, supplementary characters, bind variables, and exact legacy errors for non-alias DDL and account paths.

Validation:

- `make build`
- `go vet ./pkg/sql/parsers/...`
- `go test -count=1 ./pkg/sql/parsers/...`
- `go test -race -count=1 -run 'TestUnicodeIdentifier|TestInvalidUnicodeIdentifiers' ./pkg/sql/parsers/dialect/mysql`
- Verified through the MySQL protocol against a locally built MatrixOne service using an 8-row Chinese/Arabic dataset with grouping, NULL aggregation, and computed amounts; Unicode result-column headers were returned correctly.
- Verified the affected DDL and account cases still return parser error 1064 with the original error columns.
