### PR TITLE
perf(hashmap): allocate int iterator buffers lazily

### DIFF
--- a/pkg/common/hashmap/inthashmap.go
+++ b/pkg/common/hashmap/inthashmap.go
@@ -44,12 +44,7 @@ func NewIntHashMap(hasNull bool, memPool *mpool.MPool) (*IntHashMap, error) {
 
 func (m *IntHashMap) NewIterator() *intHashMapIterator {
 	return &intHashMapIterator{
-		mp:      m,
-		keys:    make([]uint64, UnitLimit),
-		keyOffs: make([]uint32, UnitLimit),
-		values:  make([]uint64, UnitLimit),
-		zValues: make([]int64, UnitLimit),
-		hashes:  make([]uint64, UnitLimit),
+		mp: m,
 	}
 }
 

--- a/pkg/common/hashmap/inthashmap_lazy_test.go
+++ b/pkg/common/hashmap/inthashmap_lazy_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashmap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntHashMapIteratorLazyBuffers(t *testing.T) {
+	for _, hasNull := range []bool{false, true} {
+		t.Run(fmt.Sprintf("has-null-%t", hasNull), func(t *testing.T) {
+			for _, typ := range []types.Type{types.T_int32.ToType(), types.T_int64.ToType()} {
+				t.Run(typ.String(), func(t *testing.T) {
+					for _, count := range []int{0, 1, 255, 256} {
+						t.Run(fmt.Sprintf("rows-%d", count), func(t *testing.T) {
+							m := mpool.MustNewZero()
+							mp, err := NewIntHashMap(hasNull, m)
+							require.NoError(t, err)
+							defer mp.Free()
+
+							vecs := newVectorsWithNull([]types.Type{typ}, false, max(count, 1), m)
+							defer func() {
+								for _, vec := range vecs {
+									vec.Free(m)
+								}
+							}()
+
+							itr := mp.NewIterator()
+							assertIntIteratorCapacity(t, itr, 0, hasNull)
+							vs, zvs, err := itr.Insert(0, count, vecs)
+							require.NoError(t, err)
+							require.Len(t, vs, count)
+							require.Len(t, zvs, count)
+
+							insertedVs := append([]uint64(nil), vs...)
+							insertedZvs := append([]int64(nil), zvs...)
+							foundVs, foundZvs := itr.Find(0, count, vecs)
+							if count > 0 {
+								require.Equal(t, insertedVs, foundVs)
+								require.Equal(t, insertedZvs, foundZvs)
+							}
+							assertIntIteratorCapacity(t, itr, count, hasNull)
+						})
+					}
+				})
+			}
+		})
+	}
+
+	t.Run("grow-and-shrink", func(t *testing.T) {
+		itr := &intHashMapIterator{}
+		for _, tc := range []struct {
+			count   int
+			wantCap int
+		}{
+			{count: 0, wantCap: 0},
+			{count: 1, wantCap: 1},
+			{count: 255, wantCap: 255},
+			{count: 1, wantCap: 255},
+			{count: 256, wantCap: 256},
+			{count: 0, wantCap: 256},
+		} {
+			itr.ensureCapacity(tc.count)
+			require.Len(t, itr.keys, tc.count)
+			require.Len(t, itr.keyOffs, tc.count)
+			require.Len(t, itr.values, tc.count)
+			require.Len(t, itr.zValues, tc.count)
+			require.Len(t, itr.hashes, tc.count)
+			assertIntIteratorCapacity(t, itr, tc.wantCap, false)
+		}
+		require.Panics(t, func() {
+			itr.ensureCapacity(UnitLimit + 1)
+		})
+	})
+
+	t.Run("owner-change-adds-null-guard", func(t *testing.T) {
+		m := mpool.MustNewZero()
+		nonNullable, err := NewIntHashMap(false, m)
+		require.NoError(t, err)
+		defer nonNullable.Free()
+		nullable, err := NewIntHashMap(true, m)
+		require.NoError(t, err)
+		defer nullable.Free()
+
+		nonNullVecs := newVectors([]types.Type{types.T_int64.ToType()}, false, UnitLimit, m)
+		nullVecs := newVectorsWithNull([]types.Type{types.T_int64.ToType()}, false, UnitLimit, m)
+		defer func() {
+			for _, vec := range append(nonNullVecs, nullVecs...) {
+				vec.Free(m)
+			}
+		}()
+
+		itr := nonNullable.NewIterator()
+		_, _, err = itr.Insert(0, UnitLimit, nonNullVecs)
+		require.NoError(t, err)
+		require.Equal(t, UnitLimit, cap(itr.keys))
+
+		IteratorChangeOwner(itr, nullable)
+		_, _, err = itr.Insert(0, UnitLimit, nullVecs)
+		require.NoError(t, err)
+		assertIntIteratorCapacity(t, itr, UnitLimit, true)
+	})
+}
+
+func assertIntIteratorCapacity(t *testing.T, itr *intHashMapIterator, want int, hasNull bool) {
+	t.Helper()
+	if want == 0 {
+		require.Zero(t, cap(itr.keys))
+	} else {
+		wantKeyCap := want
+		if hasNull {
+			wantKeyCap++
+		}
+		require.Equal(t, wantKeyCap, cap(itr.keys))
+	}
+	require.Equal(t, want, cap(itr.keyOffs))
+	require.Equal(t, want, cap(itr.values))
+	require.Equal(t, want, cap(itr.zValues))
+	require.Equal(t, want, cap(itr.hashes))
+}
+
+var (
+	benchmarkIntIterator *intHashMapIterator
+	benchmarkIntValues   []uint64
+)
+
+func BenchmarkIntHashMapIteratorFirstInsert(b *testing.B) {
+	for _, count := range []int{1, 255, 256} {
+		b.Run(fmt.Sprintf("rows-%d", count), func(b *testing.B) {
+			m := mpool.MustNewZero()
+			mp, err := NewIntHashMap(false, m)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer mp.Free()
+
+			vec := newVector(count, types.T_int64.ToType(), m, false, nil)
+			defer vec.Free(m)
+			vecs := []*vector.Vector{vec}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				itr := mp.NewIterator()
+				vs, _, err := itr.Insert(0, count, vecs)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkIntIterator = itr
+				benchmarkIntValues = vs
+			}
+		})
+	}
+}

--- a/pkg/common/hashmap/iterator.go
+++ b/pkg/common/hashmap/iterator.go
@@ -108,6 +108,10 @@ func (itr *strHashmapIterator) Insert(start, count int, vecs []*vector.Vector) (
 }
 
 func (itr *intHashMapIterator) Find(start, count int, vecs []*vector.Vector) ([]uint64, []int64) {
+	itr.ensureCapacity(count)
+	if count == 0 {
+		return itr.values, itr.zValues
+	}
 	for i := 0; i < count; i++ {
 		itr.keys[i] = 0
 	}
@@ -126,6 +130,10 @@ func (itr *intHashMapIterator) DetectDup(vecs []*vector.Vector, row int) (bool, 
 
 func (itr *intHashMapIterator) Insert(start, count int, vecs []*vector.Vector) ([]uint64, []int64, error) {
 	var err error
+	itr.ensureCapacity(count)
+	if count == 0 {
+		return itr.values, itr.zValues, nil
+	}
 
 	defer func() {
 		for i := 0; i < count; i++ {
@@ -145,6 +153,33 @@ func (itr *intHashMapIterator) Insert(start, count int, vecs []*vector.Vector) (
 	vs, zvs := itr.values[:count], itr.zValues[:count]
 	updateHashTableRows(itr.mp, vs, zvs)
 	return vs, zvs, err
+}
+
+func (itr *intHashMapIterator) ensureCapacity(count int) {
+	if count > UnitLimit {
+		panic("int hashmap iterator count exceeds UnitLimit")
+	}
+	keyCount := count
+	if count > 0 && itr.mp != nil && itr.mp.hasNull {
+		// A nullable 8-byte key stores a null marker followed by the value. The
+		// last key can therefore use one byte in a guard slot past the logical
+		// key slice, including when count is UnitLimit.
+		keyCount++
+	}
+	if count <= cap(itr.keyOffs) && keyCount <= cap(itr.keys) {
+		itr.keys = itr.keys[:count]
+		itr.keyOffs = itr.keyOffs[:count]
+		itr.values = itr.values[:count]
+		itr.zValues = itr.zValues[:count]
+		itr.hashes = itr.hashes[:count]
+		return
+	}
+
+	itr.keys = make([]uint64, keyCount)[:count]
+	itr.keyOffs = make([]uint32, count)
+	itr.values = make([]uint64, count)
+	itr.zValues = make([]int64, count)
+	itr.hashes = make([]uint64, count)
 }
 
 func updateHashTableRows(hashMap HashMap, vs []uint64, zvs []int64) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25472

## What this PR does / why we need it:

`IntHashMap.NewIterator` eagerly allocated five `UnitLimit`-sized buffers for every iterator, even when a call processed only a few rows. In the clean 1000-VU insert profile this was the largest flat allocation site: 19,271.57 MB, or 4.56% of total allocation space.

This change:

- allocates iterator buffers lazily on the first non-empty `Find` or `Insert`, sized to the requested row count;
- reuses existing capacity when the iterator processes a smaller or equal batch later;
- preserves the nullable 8-byte-key guard slot at `count == UnitLimit` while keeping all logical slice lengths equal to `count`;
- keeps the existing `UnitLimit` contract and returns empty slices without allocating for `count == 0`.

There is no public API change. Tests cover real NULL values, `int32`/`int64`, counts `0/1/255/256`, grow/shrink/reuse, and changing an iterator owner from a non-nullable map to a nullable map at `UnitLimit`.

### Validation

```text
go test -race -count=1 ./pkg/common/hashmap
go test -count=1 ./pkg/sql/colexec/hashbuild ./pkg/sql/colexec/dedupjoin ./pkg/sql/colexec/rightdedupjoin ./pkg/sql/colexec/group
go test -run '^$' -bench '^BenchmarkIntHashMapIteratorFirstInsert$' -benchmem -count=5 ./pkg/common/hashmap
```

All passed. Allocation results were stable across five benchmark runs:

| Rows | B/op | allocs/op |
|---:|---:|---:|
| 1 | 168 | 6 |
| 255 | 9,344 | 6 |
| 256 | 9,344 | 6 |

### Fresh-data insert A/B/A

Environment: mo-129, 1000 VUs, 120 seconds, `max-active=640`, `disable-trace=true` in log/TN/CN, 8 GB SHARED memory cache and 50 GB SHARED disk cache. Every arm used an independent fresh data, cache, config, and result directory; prepare/warmup/run contamination logs were all empty.

| Arm | TPS | Avg | P95 | CPU ms/query | alloc kB/query | malloc/query | GC count |
|---|---:|---:|---:|---:|---:|---:|---:|
| Baseline A | 20,188.98 | 49.45 ms | 71.83 ms | 2.162 | 198.698 | 1,902.307 | 192 |
| Patched | 21,585.35 | 46.26 ms | 69.29 ms | 2.061 | 188.904 | 1,901.542 | 187 |
| Baseline A2 | 20,227.90 | 49.34 ms | 71.83 ms | 2.154 | 198.629 | 1,901.761 | 187 |

Compared with the mean of both baseline arms:

- TPS: +6.814%
- average latency: -6.347%
- P95: -3.536%
- CPU/query: -4.505%
- alloc/query: -4.913%
- malloc/query: -0.026% (neutral, as expected; this change reduces buffer sizes rather than allocation count)

Baseline binary SHA256: `b3c6c0d834110db64402bddceb2dd534ca532c412ac4e84d8cc5310342aa423c`  
Patched binary SHA256: `9c9cdbad7b3f8bd27a8f85dc55f6cbacc9b743d6cda82507cbf7aedaa7e4a83a`

### Exact change-commit allocation profile

The change commit was rebuilt and profiled separately with the same workload and configuration using an independent fresh dataset:

- profiled change commit: `b9876a9548c14ee59f02d056204811da7e393a88`
- current PR head: `d53b8bbe2cdef0d3c3eb2161bcc446b267ef0224` (Mergify's automatic merge of current `main`; the hashmap diff is unchanged)
- binary SHA256: `8b81bbf605a0e6a8c9031c28e9ead6c685090aec45a9e38404c60973c304c498`
- result: 2,430,963 transactions, 20,228.51 TPS, 49.36 ms average, 110.66 ms P95
- normalized runtime: 2.120 ms CPU/query, 191.071 kB allocated/query, 1,930.619 mallocs/query, 183 GCs
- prepare/warmup/run contamination logs: empty

This is a single-arm run for exact change-commit hotspot validation; cross-base throughput and latency are not used as an A/B claim.

The original clean baseline profile attributed 19,271.57 MB / 4.56% of 423,012.13 MB to `IntHashMap.NewIterator`. In the final 30-second delta profile:

- `IntHashMap.NewIterator`: 73.51 MB / 0.065%
- `intHashMapIterator.ensureCapacity`: 27.00 MB / 0.024%
- combined: 100.51 MB / 0.089%

After normalizing by total allocation space, the iterator allocation share fell by 98.04% (51.0x). The removed fixed-buffer allocation did not migrate to `ensureCapacity` or another new hotspot.
