### PR TITLE
chore: add backup owners for review coverage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,7 +21,7 @@
 /go.sum @XuPeng-SH
 
 # Top-level folders
-/cgo @aunjgr
+/cgo @aunjgr @XuPeng-SH
 /docs @fengttt @XuPeng-SH
 /etc @XuPeng-SH
 /optools @fengttt @XuPeng-SH
@@ -35,7 +35,7 @@
 /cmd/mo-service @XuPeng-SH
 
 /pkg/tools @XuPeng-SH
-/pkg/backup @LeftHandCold
+/pkg/backup @LeftHandCold @XuPeng-SH
 
 /pkg/datasync @volgariver6 @LeftHandCold
 
@@ -63,7 +63,7 @@
 /pkg/common/spool @aunjgr @aptend
 /pkg/common/async @XuPeng-SH
 /pkg/common/bitmap @aunjgr @XuPeng-SH
-/pkg/common/hashmap @aunjgr
+/pkg/common/hashmap @aunjgr @XuPeng-SH
 /pkg/common/moerr @XuPeng-SH
 /pkg/common/morpc @XuPeng-SH
 /pkg/common/moprobe @fengttt
@@ -73,10 +73,10 @@
 /pkg/common/reuse @XuPeng-SH
 
 # pkg/compare
-/pkg/compare @aunjgr
+/pkg/compare @aunjgr @XuPeng-SH
 
 # pkg/compress
-/pkg/compress @aunjgr
+/pkg/compress @aunjgr @XuPeng-SH
 
 # pkg/config
 /pkg/config @fengttt @XuPeng-SH
@@ -108,13 +108,13 @@
 /pkg/incrservice @XuPeng-SH @gouhongshen
 
 # pkg/lockservice
-/pkg/lockservice @iamlinjunhong
+/pkg/lockservice @iamlinjunhong @XuPeng-SH
 
 # pkg/shardservice
-/pkg/shardservice @iamlinjunhong
+/pkg/shardservice @iamlinjunhong @XuPeng-SH
 
 # pkg/partitionservice
-/pkg/partitionservice @iamlinjunhong
+/pkg/partitionservice @iamlinjunhong @XuPeng-SH
 
 # pkg/logservice
 /pkg/logservice @volgariver6 @LeftHandCold
@@ -137,49 +137,49 @@
 /pkg/pb/pipeline @XuPeng-SH @aunjgr
 /pkg/pb/plan @XuPeng-SH @aunjgr
 /pkg/pb/timestamp @XuPeng-SH
-/pkg/pb/txn @iamlinjunhong
+/pkg/pb/txn @iamlinjunhong @XuPeng-SH
 
 # pkg/perfcounter
 /pkg/perfcounter @XuPeng-SH
 
 # pkg/sort
-/pkg/sort @aunjgr
+/pkg/sort @aunjgr @XuPeng-SH
 
 # pkg/bootstrap
-/pkg/bootstrap @LeftHandCold
+/pkg/bootstrap @LeftHandCold @XuPeng-SH
 
 # pkg/sql
-/pkg/sql @aunjgr
+/pkg/sql @aunjgr @XuPeng-SH
 /pkg/sql/colexec @XuPeng-SH @aunjgr
 /pkg/sql/compile @XuPeng-SH @aunjgr
 /pkg/sql/models @aptend
-/pkg/sql/parsers @iamlinjunhong
+/pkg/sql/parsers @iamlinjunhong @XuPeng-SH
 /pkg/sql/plan @XuPeng-SH @aunjgr
 /pkg/sql/plan/function @XuPeng-SH @aunjgr
 /pkg/sql/plan/explain @XuPeng-SH @aunjgr
 /pkg/sql/plan/tools @gouhongshen
-/pkg/sql/colexec/indexjoin @aunjgr
-/pkg/sql/colexec/indexbuild @aunjgr
-/pkg/sql/colexec/intersect @aunjgr
-/pkg/sql/colexec/intersectall @aunjgr
-/pkg/sql/colexec/loopanti @aunjgr
-/pkg/sql/colexec/loopjoin @aunjgr
-/pkg/sql/colexec/loopleft @aunjgr
-/pkg/sql/colexec/loopmark @aunjgr
-/pkg/sql/colexec/loopsingle @aunjgr
-/pkg/sql/colexec/right @aunjgr
-/pkg/sql/colexec/rightanti @aunjgr
-/pkg/sql/colexec/rightsemi @aunjgr
-/pkg/sql/colexec/anti @aunjgr
-/pkg/sql/colexec/single @aunjgr
-/pkg/sql/colexec/mark @aunjgr
-/pkg/sql/colexec/semi @aunjgr
-/pkg/sql/colexec/join @aunjgr
-/pkg/sql/colexec/hashbuild @aunjgr
-/pkg/sql/colexec/left @aunjgr
-/pkg/sql/colexec/shuffle @aunjgr
-/pkg/sql/colexec/shuffleV2 @aunjgr
-/pkg/sql/colexec/shufflebuild @aunjgr
+/pkg/sql/colexec/indexjoin @aunjgr @XuPeng-SH
+/pkg/sql/colexec/indexbuild @aunjgr @XuPeng-SH
+/pkg/sql/colexec/intersect @aunjgr @XuPeng-SH
+/pkg/sql/colexec/intersectall @aunjgr @XuPeng-SH
+/pkg/sql/colexec/loopanti @aunjgr @XuPeng-SH
+/pkg/sql/colexec/loopjoin @aunjgr @XuPeng-SH
+/pkg/sql/colexec/loopleft @aunjgr @XuPeng-SH
+/pkg/sql/colexec/loopmark @aunjgr @XuPeng-SH
+/pkg/sql/colexec/loopsingle @aunjgr @XuPeng-SH
+/pkg/sql/colexec/right @aunjgr @XuPeng-SH
+/pkg/sql/colexec/rightanti @aunjgr @XuPeng-SH
+/pkg/sql/colexec/rightsemi @aunjgr @XuPeng-SH
+/pkg/sql/colexec/anti @aunjgr @XuPeng-SH
+/pkg/sql/colexec/single @aunjgr @XuPeng-SH
+/pkg/sql/colexec/mark @aunjgr @XuPeng-SH
+/pkg/sql/colexec/semi @aunjgr @XuPeng-SH
+/pkg/sql/colexec/join @aunjgr @XuPeng-SH
+/pkg/sql/colexec/hashbuild @aunjgr @XuPeng-SH
+/pkg/sql/colexec/left @aunjgr @XuPeng-SH
+/pkg/sql/colexec/shuffle @aunjgr @XuPeng-SH
+/pkg/sql/colexec/shuffleV2 @aunjgr @XuPeng-SH
+/pkg/sql/colexec/shufflebuild @aunjgr @XuPeng-SH
 /pkg/sql/colexec/multi_update @XuPeng
 
 # pkg/taskservice
@@ -194,7 +194,7 @@
 /pkg/testutil @XuPeng-SH
 
 # pkg/txn
-/pkg/txn @iamlinjunhong
+/pkg/txn @iamlinjunhong @XuPeng-SH
 /pkg/txn/storage/memorystorage @XuPeng-SH
 
 # pkg/util
@@ -208,14 +208,14 @@
 /pkg/util/fault @XuPeng-SH
 
 # pkg/vectorize
-/pkg/vectorize @aunjgr
+/pkg/vectorize @aunjgr @XuPeng-SH
 
 # engines and engine related stuff
 /pkg/vm @XuPeng-SH
 /pkg/vm/engine @XuPeng-SH
 /pkg/vm/pipeline @XuPeng-SH @aunjgr
 /pkg/vm/process @aunjgr @XuPeng-SH
-/pkg/vm/message @aunjgr
+/pkg/vm/message @aunjgr @XuPeng-SH
 /pkg/vm/engine/disttae @XuPeng-SH @gouhongshen
 /pkg/vm/engine/disttae/logtailreplay @XuPeng-SH @gouhongshen
 /pkg/vm/engine/tae @XuPeng-SH
@@ -241,9 +241,9 @@
 /proto/metadata.proto @XuPeng-SH
 /proto/metric.proto @aptend
 /proto/pipeline.proto @XuPeng-SH @aunjgr
-/proto/plan.proto @aunjgr
-/proto/timestamp.proto @iamlinjunhong
-/proto/txn.proto @iamlinjunhong
+/proto/plan.proto @aunjgr @XuPeng-SH
+/proto/timestamp.proto @iamlinjunhong @XuPeng-SH
+/proto/txn.proto @iamlinjunhong @XuPeng-SH
 /proto/api.proto @XuPeng-SH
 /proto/logtail.proto @XuPeng-SH
-/proto/shard.proto @iamlinjunhong
+/proto/shard.proto @iamlinjunhong @XuPeng-SH


### PR DESCRIPTION
## Summary

- add `@XuPeng-SH` as a backup CODEOWNER for modules that previously had a single owner
- preserve all existing ownership assignments
- improve review coverage for these modules

## Validation

- verified every updated rule now has a backup owner
- `git diff --check`