### PR TITLE
fix: avoid nil rightMatchedIter panic in hashjoin finalize on early teardown

### DIFF
--- a/pkg/sql/colexec/hashjoin/join.go
+++ b/pkg/sql/colexec/hashjoin/join.go
@@ -225,7 +225,12 @@ func (hashJoin *HashJoin) Call(proc *process.Process) (vm.CallResult, error) {
 				return result, err
 			}
 
-			if ctr.rightRowsMatched == nil || (hashJoin.NumCPU > 1 && !hashJoin.IsMerger) {
+			// Only enter Finalize when syncBitmap ran to completion and set
+			// the iterator. It stays nil for non-merger workers, when there
+			// is no bitmap at all, or when the merger observed teardown (a
+			// worker sent a nil bitmap on Reset, or the context was
+			// canceled) — in all these cases there is nothing to finalize.
+			if ctr.rightMatchedIter == nil {
 				ctr.state = End
 			} else {
 				ctr.state = Finalize

--- a/pkg/sql/colexec/hashjoin/join.go
+++ b/pkg/sql/colexec/hashjoin/join.go
@@ -689,12 +689,20 @@ func (ctr *container) syncBitmap(hashJoin *HashJoin, proc *process.Process) erro
 
 			for cnt := 1; cnt < int(hashJoin.NumCPU); cnt++ {
 				v := colexec.ReceiveBitmapFromChannel(proc.Ctx, hashJoin.Channel)
-				if v != nil {
-					matchedCnt += v.Count()
-					ctr.rightRowsMatched.Or(v)
-				} else {
+				if v == nil {
+					// A worker was torn down before syncing (its Reset sends
+					// nil) or the context was canceled. The merge is aborted,
+					// but keep draining this generation's remaining messages
+					// so no stale bitmap is left behind in the shared
+					// channel, then bail out without initializing the
+					// iterator — Call routes to End and nothing is finalized.
+					for cnt++; cnt < int(hashJoin.NumCPU); cnt++ {
+						colexec.ReceiveBitmapFromChannel(proc.Ctx, hashJoin.Channel)
+					}
 					return nil
 				}
+				matchedCnt += v.Count()
+				ctr.rightRowsMatched.Or(v)
 			}
 
 			if ctr.probeSingle && matchedCnt > ctr.rightRowsMatched.Count() {

--- a/pkg/sql/colexec/hashjoin/join_test.go
+++ b/pkg/sql/colexec/hashjoin/join_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
@@ -391,6 +392,80 @@ func TestHashJoinSingleRejectsDuplicateMatchesAcrossWorkers(t *testing.T) {
 	err := ctr.syncBitmap(hashJoin, proc)
 	require.Error(t, err)
 	require.True(t, moerr.IsMoErrCode(err, moerr.ErrSubqueryNo1Row))
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+// A merger whose syncBitmap is aborted by a nil bitmap from the channel (a
+// worker torn down before syncing, e.g. when an outer LIMIT stops the query
+// early, sends nil from Reset) must go to End instead of entering Finalize
+// with a nil rightMatchedIter.
+func TestHashJoinMergerSyncBitmapAborted(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	matched := new(bitmap.Bitmap)
+	matched.InitWithSize(4)
+	matched.Add(0)
+
+	hashJoin := &HashJoin{
+		JoinType:    plan.Node_RIGHT,
+		IsRightJoin: true,
+		NumCPU:      2,
+		IsMerger:    true,
+		Channel:     make(chan *bitmap.Bitmap, 2),
+	}
+	hashJoin.Channel <- nil
+	hashJoin.ctr.state = SyncBitmap
+	hashJoin.ctr.rightRowsMatched = matched
+
+	result, err := hashJoin.Call(proc)
+	require.NoError(t, err)
+	require.Nil(t, result.Batch)
+	require.Equal(t, vm.ExecStop, result.Status)
+
+	hashJoin.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestHashJoinMergerFinalizeEmitsUnmatchedBuildRows(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rightBat := makeInt32Batch(proc, []int32{10, 20, 30, 40})
+
+	matched := new(bitmap.Bitmap)
+	matched.InitWithSize(4)
+	matched.Add(0)
+	remoteMatches := new(bitmap.Bitmap)
+	remoteMatches.InitWithSize(4)
+	remoteMatches.Add(1)
+
+	hashJoin := &HashJoin{
+		JoinType:    plan.Node_RIGHT,
+		IsRightJoin: true,
+		NumCPU:      2,
+		IsMerger:    true,
+		Channel:     make(chan *bitmap.Bitmap, 2),
+		ResultCols:  []colexec.ResultPos{colexec.NewResultPos(1, 0)},
+		RightTypes:  []types.Type{types.T_int32.ToType()},
+	}
+	hashJoin.Channel <- remoteMatches
+	hashJoin.ctr.state = SyncBitmap
+	hashJoin.ctr.rightRowsMatched = matched
+	hashJoin.ctr.rightBats = []*batch.Batch{rightBat}
+
+	result, err := hashJoin.Call(proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	require.Equal(t, 2, result.Batch.RowCount())
+	vals := vector.MustFixedColWithTypeCheck[int32](result.Batch.Vecs[0])
+	require.Equal(t, []int32{30, 40}, vals[:2])
+
+	result, err = hashJoin.Call(proc)
+	require.NoError(t, err)
+	require.Nil(t, result.Batch)
+	require.Equal(t, vm.ExecStop, result.Status)
+
+	rightBat.Clean(proc.Mp())
+	hashJoin.Free(proc, false, nil)
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }

--- a/pkg/sql/colexec/hashjoin/join_test.go
+++ b/pkg/sql/colexec/hashjoin/join_test.go
@@ -399,29 +399,80 @@ func TestHashJoinSingleRejectsDuplicateMatchesAcrossWorkers(t *testing.T) {
 // A merger whose syncBitmap is aborted by a nil bitmap from the channel (a
 // worker torn down before syncing, e.g. when an outer LIMIT stops the query
 // early, sends nil from Reset) must go to End instead of entering Finalize
-// with a nil rightMatchedIter.
+// with a nil rightMatchedIter. The aborted generation must also drain the
+// remaining worker messages so a later run over the same channel does not
+// observe stale bitmaps.
 func TestHashJoinMergerSyncBitmapAborted(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rightBat := makeInt32Batch(proc, []int32{10, 20, 30, 40})
+
 	matched := new(bitmap.Bitmap)
 	matched.InitWithSize(4)
 	matched.Add(0)
+	staleMatches := new(bitmap.Bitmap)
+	staleMatches.InitWithSize(4)
+	staleMatches.Add(1)
 
 	hashJoin := &HashJoin{
 		JoinType:    plan.Node_RIGHT,
 		IsRightJoin: true,
-		NumCPU:      2,
+		NumCPU:      3,
 		IsMerger:    true,
-		Channel:     make(chan *bitmap.Bitmap, 2),
+		Channel:     make(chan *bitmap.Bitmap, 3),
+		ResultCols:  []colexec.ResultPos{colexec.NewResultPos(1, 0)},
+		RightTypes:  []types.Type{types.T_int32.ToType()},
 	}
+	// Worker A was torn down before syncing (its Reset sends nil); worker B
+	// synced normally and its bitmap lands after the abort marker.
 	hashJoin.Channel <- nil
+	hashJoin.Channel <- staleMatches
 	hashJoin.ctr.state = SyncBitmap
 	hashJoin.ctr.rightRowsMatched = matched
+	hashJoin.ctr.rightBats = []*batch.Batch{rightBat}
 
 	result, err := hashJoin.Call(proc)
 	require.NoError(t, err)
 	require.Nil(t, result.Batch)
 	require.Equal(t, vm.ExecStop, result.Status)
+	// Worker B's bitmap must not be left behind in the shared channel.
+	require.Empty(t, hashJoin.Channel)
 
+	// The merger already synced this generation, so Reset must not push the
+	// nil abort marker either.
+	hashJoin.Reset(proc, false, nil)
+	require.Empty(t, hashJoin.Channel)
+
+	// Next generation over the same operator and channel: a clean sync must
+	// only observe this generation's bitmaps.
+	matched2 := new(bitmap.Bitmap)
+	matched2.InitWithSize(4)
+	matched2.Add(0)
+	workerMatches1 := new(bitmap.Bitmap)
+	workerMatches1.InitWithSize(4)
+	workerMatches1.Add(1)
+	workerMatches2 := new(bitmap.Bitmap)
+	workerMatches2.InitWithSize(4)
+	workerMatches2.Add(2)
+
+	hashJoin.Channel <- workerMatches1
+	hashJoin.Channel <- workerMatches2
+	hashJoin.ctr.state = SyncBitmap
+	hashJoin.ctr.rightRowsMatched = matched2
+	hashJoin.ctr.rightBats = []*batch.Batch{rightBat}
+
+	result, err = hashJoin.Call(proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	require.Equal(t, 1, result.Batch.RowCount())
+	vals := vector.MustFixedColWithTypeCheck[int32](result.Batch.Vecs[0])
+	require.Equal(t, []int32{40}, vals[:1])
+
+	result, err = hashJoin.Call(proc)
+	require.NoError(t, err)
+	require.Nil(t, result.Batch)
+	require.Equal(t, vm.ExecStop, result.Status)
+
+	rightBat.Clean(proc.Mp())
 	hashJoin.Free(proc, false, nil)
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25802

## What this PR does / why we need it:

Fixes a nil pointer panic in `hashjoin.(*container).finalize` (join.go:716) hit by multi-CTE LEFT JOIN queries with an outer LIMIT.

**Root cause.** In a parallel (NumCPU > 1) right-flavored hash join (`EmitUnmatchedBuild() == true`), the merger's `syncBitmap` can receive a nil bitmap from the shared channel and returns early **without initializing `rightMatchedIter`**. The nil arrives when:

1. a non-merger worker is Reset before syncing its bitmap — its `Reset` intentionally sends nil so the merger doesn't block forever. This happens whenever the query is torn down early, e.g. the outer `LIMIT 300`/`LIMIT 100` in the failing q0503/q0751 is satisfied mid-probe; or
2. `proc.Ctx` is canceled while the merger waits in `ReceiveBitmapFromChannel`.

The `Call` state machine then advanced from `SyncBitmap` to `Finalize` because it only checked `rightRowsMatched != nil` (the merger's own bitmap always exists), and `finalize` dereferenced the nil iterator. This explains why only the two LIMIT variants of the 35-query template panicked: it is a race between early LIMIT termination and bitmap synchronization.

**Fix.** Gate the `SyncBitmap -> Finalize` transition on `ctr.rightMatchedIter != nil` — exactly the invariant `finalize` depends on, and only true when `syncBitmap` ran to completion. All early-exit paths (non-merger worker, no bitmap, merge aborted by teardown/cancellation) now go to `End`. When the merge is aborted the query is being torn down anyway, so no unmatched-build rows need to be emitted.

**Tests.** Two new unit tests:
- `TestHashJoinMergerSyncBitmapAborted` reproduces the exact panic stack from the issue without the fix (merger receives nil from a torn-down worker) and asserts a clean `ExecStop` with the fix;
- `TestHashJoinMergerFinalizeEmitsUnmatchedBuildRows` guards the healthy path: the merger merges a real worker bitmap and still emits the unmatched build rows.

No BVT case is added: the bug is a teardown race between parallel pipelines that cannot be triggered deterministically from SQL.

**Note (out of scope).** While investigating, we noticed the parallel + spill + right-join combination has deeper pre-existing issues (exclusive `TakeSpillBuildFds` on a shared JoinMap; workers reach `End` after the first bucket). Those are unrelated to this panic and left for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
