### PR TITLE
fix(morpc): avoid stream sequence gaps for skipped responses

### DIFF
--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -415,6 +415,11 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 						continue
 					}
 
+					if !cs.assignStreamSequence(&f.send) {
+						cs.releaseMessage(f.send)
+						f.messageSent(backendClosed)
+						continue
+					}
 					timeout += v
 					// Record the information of some responses in advance, because after flush,
 					// these responses will be released, thus avoiding causing data race.
@@ -718,14 +723,6 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 		return nil, moerr.NewClientClosedNoCtx()
 	}
 
-	id := response.GetID()
-	if v, ok := cs.sentStreamSequences.Load(id); ok {
-		seq := v.(uint32) + 1
-		cs.sentStreamSequences.Store(id, seq)
-		msg.stream = true
-		msg.streamSequence = seq
-	}
-
 	f := cs.newFutureFunc()
 	f.init(msg)
 	if !f.oneWay {
@@ -743,6 +740,27 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 	}
 	cs.metrics.sendingQueueSizeGauge.Set(float64(len(cs.c)))
 	return f, nil
+}
+
+// assignStreamSequence runs in the single server write loop after a response
+// has passed the filter and context checks. Assigning the sequence at enqueue
+// time leaves a permanent gap when the queued response expires before it is
+// written, causing the client to tear down an otherwise healthy stream.
+func (cs *clientSession) assignStreamSequence(msg *RPCMessage) bool {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	if cs.mu.closed {
+		return false
+	}
+
+	id := msg.Message.GetID()
+	if v, ok := cs.sentStreamSequences.Load(id); ok {
+		seq := v.(uint32) + 1
+		cs.sentStreamSequences.Store(id, seq)
+		msg.stream = true
+		msg.streamSequence = seq
+	}
+	return true
 }
 
 func (cs *clientSession) releaseMessage(msg RPCMessage) {

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -561,6 +561,71 @@ func (s *server) getSessionCount() int {
 	return n
 }
 
+// sentStreamState owns the complete lifecycle of server-side stream response
+// sequences. Its lock is never held across queue operations, network I/O, or
+// future waits.
+type sentStreamState struct {
+	mu        sync.Mutex
+	closed    bool
+	sequences map[uint64]uint32
+}
+
+func (s *sentStreamState) start(id uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return false
+	}
+	if s.sequences == nil {
+		s.sequences = make(map[uint64]uint32)
+	}
+	if _, ok := s.sequences[id]; ok {
+		return false
+	}
+	s.sequences[id] = 0
+	return true
+}
+
+func (s *sentStreamState) next(id uint64) (uint32, bool, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, false, false
+	}
+	seq, ok := s.sequences[id]
+	if !ok {
+		return 0, false, true
+	}
+	seq++
+	s.sequences[id] = seq
+	return seq, true, true
+}
+
+func (s *sentStreamState) finish(id uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sequences, id)
+}
+
+func (s *sentStreamState) close() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0
+	}
+	s.closed = true
+	count := len(s.sequences)
+	clear(s.sequences)
+	return count
+}
+
+func (s *sentStreamState) contains(id uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.sequences[id]
+	return ok
+}
+
 type clientSession struct {
 	metrics       *serverMetrics
 	codec         Codec
@@ -572,16 +637,14 @@ type clientSession struct {
 	// boundary for validation and terminal retirement.
 	streamStateMu           sync.Mutex
 	receivedStreamSequences map[uint64]uint32
-	// streaming id -> last sent sequence, multi-stream access in multi-goroutines if
-	// the tcp connection is shared. But no concurrent in one stream.
-	sentStreamSequences   sync.Map
-	cancel                context.CancelFunc
-	ctx                   context.Context
-	releaseMessageFunc    func(Message)
-	checkTimeoutCacheOnce sync.Once
-	closedC               chan struct{}
-	disconnectedC         chan struct{}
-	mu                    struct {
+	sentStreams             sentStreamState
+	cancel                  context.CancelFunc
+	ctx                     context.Context
+	releaseMessageFunc      func(Message)
+	checkTimeoutCacheOnce   sync.Once
+	closedC                 chan struct{}
+	disconnectedC           chan struct{}
+	mu                      struct {
 		sync.RWMutex
 		closed bool
 		caches map[uint64]cacheWithContext
@@ -628,15 +691,13 @@ func (cs *clientSession) Close() error {
 	cs.cleanSend()
 	close(cs.c)
 	cs.mu.closed = true
+	sentCount := cs.sentStreams.close()
 	if cs.metrics != nil {
 		cs.metrics.receivedStreamStateGauge.Sub(float64(len(cs.receivedStreamSequences)))
-		sentCount := 0
-		cs.sentStreamSequences.Range(func(_, _ any) bool { sentCount++; return true })
 		cs.metrics.sentStreamStateGauge.Sub(float64(sentCount))
 		cs.metrics.messageCacheStateGauge.Sub(float64(len(cs.mu.caches)))
 	}
 	clear(cs.receivedStreamSequences)
-	cs.sentStreamSequences.Clear()
 	for _, c := range cs.mu.caches {
 		c.cache.Close()
 	}
@@ -747,16 +808,11 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 // time leaves a permanent gap when the queued response expires before it is
 // written, causing the client to tear down an otherwise healthy stream.
 func (cs *clientSession) assignStreamSequence(msg *RPCMessage) bool {
-	cs.mu.RLock()
-	defer cs.mu.RUnlock()
-	if cs.mu.closed {
+	seq, stream, open := cs.sentStreams.next(msg.Message.GetID())
+	if !open {
 		return false
 	}
-
-	id := msg.Message.GetID()
-	if v, ok := cs.sentStreamSequences.Load(id); ok {
-		seq := v.(uint32) + 1
-		cs.sentStreamSequences.Store(id, seq)
+	if stream {
 		msg.stream = true
 		msg.streamSequence = seq
 	}
@@ -813,14 +869,16 @@ func (cs *clientSession) validateStreamRequest(
 	if sequence != expectSequence {
 		return false
 	}
-	cs.receivedStreamSequences[id] = sequence
 	if sequence == 1 {
-		cs.sentStreamSequences.Store(id, uint32(0))
+		if !cs.sentStreams.start(id) {
+			return false
+		}
 		if cs.metrics != nil {
 			cs.metrics.receivedStreamStateGauge.Inc()
 			cs.metrics.sentStreamStateGauge.Inc()
 		}
 	}
+	cs.receivedStreamSequences[id] = sequence
 	return true
 }
 
@@ -861,7 +919,7 @@ func (cs *clientSession) FinishStream(
 	err = cs.Write(ctx, response)
 	if err == nil {
 		delete(cs.receivedStreamSequences, token.streamID)
-		cs.sentStreamSequences.Delete(token.streamID)
+		cs.sentStreams.finish(token.streamID)
 		if cs.metrics != nil {
 			cs.metrics.receivedStreamStateGauge.Dec()
 			cs.metrics.sentStreamStateGauge.Dec()

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -501,6 +501,62 @@ func TestFinishStreamFlushesAckAndRetiresSequenceState(t *testing.T) {
 	})
 }
 
+func TestCanceledStreamResponseDoesNotCreateSequenceGap(t *testing.T) {
+	testRPCServer(t, func(rs *server) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		canceledWriteResult := make(chan error, 1)
+
+		rs.RegisterRequestHandler(func(_ context.Context, msg RPCMessage, _ uint64, session ClientSession) error {
+			canceledCtx, cancelWrite := context.WithTimeout(context.Background(), time.Second)
+			cancelWrite()
+			canceledWriteResult <- session.Write(canceledCtx, newTestMessage(msg.Message.GetID()))
+			return session.Write(ctx, newTestMessage(msg.Message.GetID()))
+		})
+
+		client := newTestClient(t)
+		defer func() { require.NoError(t, client.Close()) }()
+		stream, err := client.NewStream(ctx, testAddr, false)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, stream.Close(false)) }()
+		responses, err := stream.Receive()
+		require.NoError(t, err)
+
+		require.NoError(t, stream.Send(ctx, newTestMessage(stream.ID())))
+		select {
+		case response := <-responses:
+			require.NotNil(t, response)
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
+		require.Error(t, <-canceledWriteResult)
+	})
+}
+
+func TestAssignStreamSequenceRejectsClosedSession(t *testing.T) {
+	cs := newClientSession(nil, newTestIOSession(nil, nil), nil, func() *Future { return &Future{} }, nil)
+	defer cs.cancel()
+	cs.sentStreamSequences.Store(uint64(11), uint32(0))
+	msg := RPCMessage{Message: newTestMessage(11)}
+
+	cs.mu.Lock()
+	started := make(chan struct{})
+	assigned := make(chan bool, 1)
+	go func() {
+		close(started)
+		assigned <- cs.assignStreamSequence(&msg)
+	}()
+	<-started
+	cs.mu.closed = true
+	cs.sentStreamSequences.Clear()
+	cs.mu.Unlock()
+
+	require.False(t, <-assigned)
+	require.False(t, msg.stream)
+	_, exists := cs.sentStreamSequences.Load(uint64(11))
+	require.False(t, exists)
+}
+
 func TestFinishStreamPoisonsSessionWithPendingCache(t *testing.T) {
 	cs := newClientSession(nil, newTestIOSession(nil, nil), nil, func() *Future { return &Future{} }, nil)
 	cs.receivedStreamSequences[11] = 2

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -492,7 +492,7 @@ func TestFinishStreamFlushesAckAndRetiresSequenceState(t *testing.T) {
 			cs.streamStateMu.Lock()
 			_, receivedExists := cs.receivedStreamSequences[stream.ID()]
 			cs.streamStateMu.Unlock()
-			_, sentExists := cs.sentStreamSequences.Load(stream.ID())
+			sentExists := cs.sentStreams.contains(stream.ID())
 			require.False(t, receivedExists)
 			require.False(t, sentExists)
 		case <-ctx.Done():
@@ -533,34 +533,97 @@ func TestCanceledStreamResponseDoesNotCreateSequenceGap(t *testing.T) {
 	})
 }
 
-func TestAssignStreamSequenceRejectsClosedSession(t *testing.T) {
-	cs := newClientSession(nil, newTestIOSession(nil, nil), nil, func() *Future { return &Future{} }, nil)
-	defer cs.cancel()
-	cs.sentStreamSequences.Store(uint64(11), uint32(0))
-	msg := RPCMessage{Message: newTestMessage(11)}
+func TestAssignStreamSequenceProgressesWhileCloseWaitsOnFullQueue(t *testing.T) {
+	cs := newClientSession(
+		newServerMetrics("test"),
+		newTestIOSession(nil, nil),
+		newTestCodec(),
+		func() *Future { return newFuture(nil) },
+		nil,
+	)
+	cs.c = make(chan *Future, 1)
+	require.True(t, cs.sentStreams.start(11))
 
-	cs.mu.Lock()
-	started := make(chan struct{})
+	queued := newFuture(nil)
+	queued.init(RPCMessage{
+		Ctx:     context.Background(),
+		Message: newTestMessage(10),
+		oneWay:  true,
+	})
+	cs.c <- queued
+
+	senderDone := make(chan error, 1)
+	go func() {
+		senderDone <- cs.AsyncWrite(newTestMessage(12))
+	}()
+	senderBlocked := assert.Eventually(t, func() bool {
+		if cs.mu.TryLock() {
+			cs.mu.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond)
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- cs.Close()
+	}()
+	closeWaiting := assert.Eventually(t, func() bool {
+		if cs.mu.TryRLock() {
+			cs.mu.RUnlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond)
+
+	msg := RPCMessage{Message: newTestMessage(11)}
 	assigned := make(chan bool, 1)
 	go func() {
-		close(started)
 		assigned <- cs.assignStreamSequence(&msg)
 	}()
-	<-started
-	cs.mu.closed = true
-	cs.sentStreamSequences.Clear()
-	cs.mu.Unlock()
+	var assignProgressed bool
+	select {
+	case assignProgressed = <-assigned:
+	case <-time.After(time.Second):
+	}
 
-	require.False(t, <-assigned)
-	require.False(t, msg.stream)
-	_, exists := cs.sentStreamSequences.Load(uint64(11))
-	require.False(t, exists)
+	if f, ok := <-cs.c; ok && f != nil {
+		f.Close()
+	}
+
+	var senderErr, closeErr error
+	select {
+	case senderErr = <-senderDone:
+	case <-time.After(time.Second):
+		t.Fatal("blocked sender did not finish")
+	}
+	select {
+	case closeErr = <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("session close did not finish")
+	}
+
+	require.True(t, senderBlocked)
+	require.True(t, closeWaiting)
+	require.True(t, assignProgressed)
+	require.True(t, msg.stream)
+	require.Equal(t, uint32(1), msg.streamSequence)
+	require.NoError(t, senderErr)
+	require.NoError(t, closeErr)
+
+	late := RPCMessage{Message: newTestMessage(11)}
+	require.False(t, cs.assignStreamSequence(&late))
+	require.False(t, late.stream)
+	require.False(t, cs.sentStreams.contains(11))
 }
 
 func TestFinishStreamPoisonsSessionWithPendingCache(t *testing.T) {
 	cs := newClientSession(nil, newTestIOSession(nil, nil), nil, func() *Future { return &Future{} }, nil)
 	cs.receivedStreamSequences[11] = 2
-	cs.sentStreamSequences.Store(uint64(11), uint32(1))
+	require.True(t, cs.sentStreams.start(11))
+	_, stream, open := cs.sentStreams.next(11)
+	require.True(t, open)
+	require.True(t, stream)
 	_, err := cs.CreateCache(context.Background(), 11)
 	require.NoError(t, err)
 	token := StreamTerminalToken{owner: cs, streamID: 11, sequence: 2}

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -772,8 +772,10 @@ func generateProcessHelper(data []byte, cli client.TxnClient) (processHelper, er
 // indefinitely when a remote CN fails.
 const waitRegistrationTimeout = 30 * time.Second
 
-func newRemoteDispatchNotRegisteredYetError(ctx context.Context, uid uuid.UUID) error {
-	return moerr.NewRemoteDispatchNotRegistered(ctx, uid.String())
+func newRemoteDispatchNotRegisteredYetError(_ context.Context, uid uuid.UUID) error {
+	// Registration lag is an expected, retryable protocol state. Keep the
+	// typed wire error without reporting every receiver attempt as an ERROR.
+	return moerr.NewRemoteDispatchNotRegistered(moerr.NoReportContext(), uid.String())
 }
 
 func isRemoteDispatchNotRegisteredYetError(err error) bool {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25803

## What this PR does / why we need it:

MORPC previously assigned stream response sequence numbers when responses entered the server send queue. If a queued response expired or was canceled before the write loop processed it, that response was skipped after already consuming its sequence number. The next valid response then reached the client with a gap, causing `sequence out of order` followed by `rpc stream closed`.

This PR:

- assigns stream sequence numbers in the single server write loop after filter, context, and timeout checks;
- synchronizes write-time assignment with session close so retired sequence state cannot be missed or resurrected;
- adds regression coverage for canceled responses and the close/assignment boundary;
- suppresses automatic ERROR reporting for the expected, typed `RemoteDispatchNotRegistered` retry response while preserving its wire code and terminal timeout behavior.

Validation:

- `go test -race -count=100 -run "TestCanceledStreamResponseDoesNotCreateSequenceGap|TestAssignStreamSequenceRejectsClosedSession" ./pkg/common/morpc`
- `go test -race -count=1 ./pkg/common/morpc`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 ./pkg/sql/compile`
- focused compile race tests
- `go build ./pkg/common/morpc ./pkg/sql/compile`
- `go vet ./pkg/common/morpc ./pkg/sql/compile`