### PR TITLE
fix(lockservice): backport owner-local remote lock deadlock fix to 4.1-dev

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -278,6 +278,8 @@ const (
 	ErrLockNeedUpgrade uint16 = 20707
 	// ErrCannotCommitOnInvalidCN cannot commit transaction on invalid CN
 	ErrCannotCommitOnInvalidCN uint16 = 20708
+	// ErrRemoteLockWaitTimeout remote lock owner-side wait timeout
+	ErrRemoteLockWaitTimeout uint16 = 20709
 
 	// Group 8: partition
 	ErrPartitionFunctionIsNotAllowed       uint16 = 20801
@@ -539,6 +541,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrLockConflict:            {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "lock options conflict, wait policy is fast fail"},
 	ErrLockNeedUpgrade:         {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "row level lock is too large that need upgrade to table level lock"},
 	ErrCannotCommitOnInvalidCN: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "cannot commit a orphan transaction on invalid cn"},
+	ErrRemoteLockWaitTimeout:   {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "remote lock wait timeout"},
 
 	// Group 8: partition
 	ErrPartitionFunctionIsNotAllowed:       {ER_PARTITION_FUNCTION_IS_NOT_ALLOWED, []string{MySQLDefaultSqlState}, "This partition function is not allowed"},
@@ -1482,6 +1485,10 @@ func NewLockTableNotFound(ctx context.Context) *Error {
 
 func NewLockConflict(ctx context.Context) *Error {
 	return newError(ctx, ErrLockConflict)
+}
+
+func NewRemoteLockWaitTimeout(ctx context.Context) *Error {
+	return newError(ctx, ErrRemoteLockWaitTimeout)
 }
 
 func NewPartitionFunctionIsNotAllowed(ctx context.Context) *Error {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -430,6 +430,10 @@ func NewLockConflictNoCtx() *Error {
 	return newError(Context(), ErrLockConflict)
 }
 
+func NewRemoteLockWaitTimeoutNoCtx() *Error {
+	return newError(Context(), ErrRemoteLockWaitTimeout)
+}
+
 func NewLockNeedUpgradeNoCtx() *Error {
 	return newError(Context(), ErrLockNeedUpgrade)
 }

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -1284,6 +1284,7 @@ var errCodeRollbackWholeTxn = map[uint16]bool{
 	moerr.ErrLockTableNotFound:        false,
 	moerr.ErrDeadlockCheckBusy:        false,
 	moerr.ErrLockConflict:             false,
+	moerr.ErrRemoteLockWaitTimeout:    false,
 	moerr.ErrTxnUnknown:               false,
 	moerr.ErrBackendClosed:            false,
 	moerr.ErrNoAvailableBackend:       false,
@@ -1325,6 +1326,8 @@ func getRandomErrorRollbackWholeTxn() error {
 		return moerr.NewDeadlockCheckBusyNoCtx()
 	case moerr.ErrLockConflict:
 		return moerr.NewLockConflictNoCtx()
+	case moerr.ErrRemoteLockWaitTimeout:
+		return moerr.NewRemoteLockWaitTimeoutNoCtx()
 	case moerr.ErrTxnUnknown:
 		return moerr.NewTxnUnknown(context.Background(), "test")
 	case moerr.ErrBackendClosed:

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -1063,6 +1063,7 @@ func Test_isErrorRollbackWholeTxn(t *testing.T) {
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewLockTableNotFoundNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewDeadlockCheckBusyNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewLockConflictNoCtx()))
+	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewRemoteLockWaitTimeoutNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewTxnUnknown(context.Background(), "test")))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewBackendClosedNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewNoAvailableBackendNoCtx()))

--- a/pkg/lockservice/cfg.go
+++ b/pkg/lockservice/cfg.go
@@ -28,6 +28,7 @@ var (
 	defaultKeepRemoteLockDuration = time.Second
 	defaultKeepBindTimeout        = time.Second * 10
 	defaultRemoteLockTimeout      = time.Minute * 10
+	defaultRemoteLockOwnerTimeout = time.Minute * 2
 	defaultRemoteTxnTimeout       = time.Second * 10
 )
 
@@ -60,6 +61,9 @@ type Config struct {
 	// RemoteLockTimeout how long does it take to receive a heartbeat that maintains the
 	// remote lock before releasing the lock
 	RemoteLockTimeout toml.Duration `toml:"remote-lock-timeout"`
+	// RemoteLockOwnerWaitTimeout is the owner-side wait cap for remote Lock RPC
+	// handling. A nil value uses the default. A non-nil zero duration disables it.
+	RemoteLockOwnerWaitTimeout *toml.Duration `toml:"remote-lock-owner-wait-timeout"`
 	// MaxLockRowCount each time a lock is added, some LockRow is stored in the lockservice, if
 	// too many LockRows are put in each time, it will cause too much memory overhead, this value
 	// limits the maximum count of LocRow put into the LockService each time, beyond this value it
@@ -102,6 +106,9 @@ func (c *Config) Validate() {
 	}
 	if c.RemoteLockTimeout.Duration == 0 {
 		c.RemoteLockTimeout.Duration = defaultRemoteLockTimeout
+	}
+	if c.RemoteLockOwnerWaitTimeout == nil {
+		c.RemoteLockOwnerWaitTimeout = &toml.Duration{Duration: defaultRemoteLockOwnerTimeout}
 	}
 	if c.KeepBindTimeout.Duration == 0 {
 		c.KeepBindTimeout.Duration = defaultKeepBindTimeout

--- a/pkg/lockservice/cfg_test.go
+++ b/pkg/lockservice/cfg_test.go
@@ -16,8 +16,11 @@ package lockservice
 
 import (
 	"testing"
+	"time"
 
+	tp "github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAdjustConfig(t *testing.T) {
@@ -27,5 +30,17 @@ func TestAdjustConfig(t *testing.T) {
 	assert.NotEmpty(t, c.ServiceAddress)
 	assert.NotEmpty(t, c.KeepBindDuration)
 	assert.NotEmpty(t, c.KeepRemoteLockDuration)
+	assert.NotNil(t, c.RemoteLockOwnerWaitTimeout)
+	assert.NotEmpty(t, c.RemoteLockOwnerWaitTimeout.Duration)
 	assert.NotEmpty(t, c.MaxFixedSliceSize)
+}
+
+func TestRemoteLockOwnerWaitTimeoutCanBeDisabled(t *testing.T) {
+	var c Config
+	_, err := tp.Decode(`remote-lock-owner-wait-timeout = "0s"`, &c)
+	require.NoError(t, err)
+	c.ServiceID = "s1"
+	c.Validate()
+	require.NotNil(t, c.RemoteLockOwnerWaitTimeout)
+	assert.Equal(t, time.Duration(0), c.RemoteLockOwnerWaitTimeout.Duration)
 }

--- a/pkg/lockservice/deadlock.go
+++ b/pkg/lockservice/deadlock.go
@@ -25,6 +25,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"go.uber.org/zap"
 )
 
 var (
@@ -94,6 +96,8 @@ func (d *detector) check(
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.mu.closed {
+		v2.TxnDeadlockDetectorEnqueueCounter.WithLabelValues("closed").Inc()
+		v2.TxnDeadlockDetectorQueueDepthGauge.Set(float64(len(d.c)))
 		return ErrDeadlockDetectorClosed
 	}
 
@@ -105,19 +109,30 @@ func (d *detector) check(
 
 	key := util.UnsafeBytesToString(txn.TxnID)
 	if _, ok := d.mu.activeCheckTxn[key]; ok {
+		v2.TxnDeadlockDetectorEnqueueCounter.WithLabelValues("dedup_skipped").Inc()
+		v2.TxnDeadlockDetectorQueueDepthGauge.Set(float64(len(d.c)))
 		return nil
 	}
-	d.mu.activeCheckTxn[key] = struct{}{}
 
 	select {
 	case d.c <- deadlockTxn{
 		holdTxnID: holdTxnID,
 		waitTxn:   txn,
 	}:
+		d.mu.activeCheckTxn[key] = struct{}{}
+		v2.TxnDeadlockDetectorEnqueueCounter.WithLabelValues("queued").Inc()
 	default:
 		// too many txns waiting for deadlock check, just return error
+		v2.TxnDeadlockDetectorEnqueueCounter.WithLabelValues("busy").Inc()
+		v2.TxnDeadlockDetectorQueueDepthGauge.Set(float64(len(d.c)))
+		d.logger.Warn("deadlock_detector_enqueue_busy",
+			zap.Int("queue-depth", len(d.c)),
+			zap.Int("queue-capacity", cap(d.c)),
+			zap.String("wait-txn", hex.EncodeToString(txn.TxnID)),
+			zap.String("hold-txn", hex.EncodeToString(holdTxnID)))
 		return ErrDeadlockCheckBusy
 	}
+	v2.TxnDeadlockDetectorQueueDepthGauge.Set(float64(len(d.c)))
 	return nil
 }
 
@@ -130,6 +145,7 @@ func (d *detector) doCheck(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case txn := <-d.c:
+			v2.TxnDeadlockDetectorQueueDepthGauge.Set(float64(len(d.c)))
 			w.reset(txn)
 			hasDeadlock, deadlockTxn, err := d.checkDeadlock(w)
 			if hasDeadlock {

--- a/pkg/lockservice/deadlock_owner_local.go
+++ b/pkg/lockservice/deadlock_owner_local.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lockservice
+
+import (
+	"encoding/hex"
+	"strings"
+
+	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"go.uber.org/zap"
+)
+
+type ownerLocalTxnKey struct {
+	txnID     string
+	createdOn string
+}
+
+type ownerLocalWaitEdge struct {
+	waiter  *waiter
+	waitFor []ownerLocalTxnKey
+}
+
+func newOwnerLocalTxnKey(txn pb.WaitTxn) ownerLocalTxnKey {
+	return ownerLocalTxnKey{
+		txnID:     string(txn.TxnID),
+		createdOn: txn.CreatedOn,
+	}
+}
+
+func (k ownerLocalTxnKey) equal(other ownerLocalTxnKey) bool {
+	return k.txnID == other.txnID && k.createdOn == other.createdOn
+}
+
+func (k ownerLocalTxnKey) debugString() string {
+	if k.createdOn == "" {
+		return hex.EncodeToString([]byte(k.txnID))
+	}
+	return hex.EncodeToString([]byte(k.txnID)) + "@" + k.createdOn
+}
+
+func (e ownerLocalWaitEdge) activeFor(txn ownerLocalTxnKey) bool {
+	return e.waiter != nil &&
+		e.waiter.getStatus() == blocking &&
+		newOwnerLocalTxnKey(e.waiter.txn).equal(txn)
+}
+
+// detectOwnerLocalDeadlockLocked checks cycles fully visible on this owner CN.
+// Caller must hold localLockTable.mu and the current txn mutex. The fast path
+// is intentionally scoped to remote-owner row/exclusive locks; all other cases
+// keep using the existing distributed detector.
+func (l *localLockTable) detectOwnerLocalDeadlockLocked(
+	c *lockContext,
+	conflictWith Lock,
+) bool {
+	if !c.opts.async ||
+		c.opts.Granularity != pb.Granularity_Row ||
+		c.opts.Mode != pb.LockMode_Exclusive ||
+		conflictWith.isShared() {
+		return false
+	}
+
+	current := newOwnerLocalTxnKey(c.waitTxn)
+	path, found := findOwnerLocalDeadlockPath(
+		l.mu.ownerLocalWaits,
+		current,
+		ownerLocalHolderKeys(conflictWith))
+	if !found {
+		return false
+	}
+
+	c.txn.deadlockFound = true
+	v2.TxnDeadlockOwnerLocalCounter.WithLabelValues("aborted").Inc()
+	l.logger.Warn("owner_local_deadlock_found",
+		zap.Uint64("table", l.bind.OriginTable),
+		zap.String("bind", l.bind.DebugString()),
+		zap.String("victim", hex.EncodeToString(c.txn.txnID)),
+		zap.Int("path-length", len(path)),
+		zap.String("path", formatOwnerLocalDeadlockPath(path)))
+	return true
+}
+
+func ownerLocalHolderKeys(lock Lock) []ownerLocalTxnKey {
+	holders := make([]ownerLocalTxnKey, 0, lock.holders.size())
+	for _, holder := range lock.holders.txns {
+		holders = append(holders, newOwnerLocalTxnKey(holder))
+	}
+	return holders
+}
+
+func (l *localLockTable) addOwnerLocalWaitEdgeLocked(
+	c *lockContext,
+	conflictWith Lock,
+) {
+	if c == nil ||
+		c.w == nil ||
+		!c.opts.async ||
+		c.opts.Granularity != pb.Granularity_Row ||
+		c.opts.Mode != pb.LockMode_Exclusive ||
+		conflictWith.isShared() ||
+		conflictWith.holders.size() == 0 {
+		return
+	}
+
+	waitFor := ownerLocalHolderKeys(conflictWith)
+	if len(waitFor) == 0 {
+		return
+	}
+	waiter := newOwnerLocalTxnKey(c.w.txn)
+	l.mu.ownerLocalWaits[waiter] = append(
+		l.mu.ownerLocalWaits[waiter],
+		ownerLocalWaitEdge{
+			waiter:  c.w,
+			waitFor: waitFor,
+		})
+}
+
+func (l *localLockTable) removeOwnerLocalWaitEdgeLocked(w *waiter) {
+	if w == nil {
+		return
+	}
+	l.removeOwnerLocalWaitEdgeByTxnLocked(newOwnerLocalTxnKey(w.txn), w)
+}
+
+func (l *localLockTable) removeOwnerLocalWaitEdgeByTxnLocked(
+	txn ownerLocalTxnKey,
+	w *waiter,
+) {
+	edges := l.mu.ownerLocalWaits[txn]
+	if len(edges) == 0 {
+		return
+	}
+	n := 0
+	for _, edge := range edges {
+		if edge.waiter == w {
+			continue
+		}
+		edges[n] = edge
+		n++
+	}
+	if n == 0 {
+		delete(l.mu.ownerLocalWaits, txn)
+		return
+	}
+	clear(edges[n:])
+	l.mu.ownerLocalWaits[txn] = edges[:n]
+}
+
+func (l *localLockTable) removeInactiveOwnerLocalWaitEdgesLocked(lock Lock) {
+	lock.waiters.iter(func(w *waiter) bool {
+		if w.getStatus() != blocking {
+			l.removeOwnerLocalWaitEdgeLocked(w)
+		}
+		return true
+	})
+}
+
+func findOwnerLocalDeadlockPath(
+	graph map[ownerLocalTxnKey][]ownerLocalWaitEdge,
+	start ownerLocalTxnKey,
+	startWaitFor []ownerLocalTxnKey,
+) ([]ownerLocalTxnKey, bool) {
+	visited := make(map[ownerLocalTxnKey]struct{}, len(graph))
+	path := []ownerLocalTxnKey{start}
+	visited[start] = struct{}{}
+
+	var dfs func(ownerLocalTxnKey, []ownerLocalTxnKey) bool
+	dfs = func(txn ownerLocalTxnKey, explicit []ownerLocalTxnKey) bool {
+		nexts := explicit
+		for _, edge := range graph[txn] {
+			if !edge.activeFor(txn) {
+				continue
+			}
+			nexts = append(nexts, edge.waitFor...)
+		}
+		for _, next := range nexts {
+			if next.equal(start) {
+				path = append(path, next)
+				return true
+			}
+			if _, ok := visited[next]; ok {
+				continue
+			}
+			visited[next] = struct{}{}
+			path = append(path, next)
+			if dfs(next, nil) {
+				return true
+			}
+			path = path[:len(path)-1]
+		}
+		return false
+	}
+
+	if dfs(start, startWaitFor) {
+		return path, true
+	}
+	return nil, false
+}
+
+func formatOwnerLocalDeadlockPath(path []ownerLocalTxnKey) string {
+	var b strings.Builder
+	for i, txn := range path {
+		if i > 0 {
+			b.WriteString(" <= ")
+		}
+		b.WriteString(txn.debugString())
+	}
+	return b.String()
+}

--- a/pkg/lockservice/deadlock_test.go
+++ b/pkg/lockservice/deadlock_test.go
@@ -125,6 +125,76 @@ func TestCheckWithDeadlockWith2Txn(t *testing.T) {
 	})
 }
 
+func TestCheckBusyDoesNotLeaveTxnMarkedActive(t *testing.T) {
+	reuse.RunReuseTests(func() {
+		holdTxn := []byte("holder")
+		waitTxn := pb.WaitTxn{TxnID: []byte("waiter")}
+
+		d := &detector{
+			logger: runtime.DefaultRuntime().Logger(),
+			c:      make(chan deadlockTxn, 1),
+		}
+		d.mu.activeCheckTxn = make(map[string]struct{}, 1)
+		d.c <- deadlockTxn{}
+
+		assert.ErrorIs(t, d.check(holdTxn, waitTxn), ErrDeadlockCheckBusy)
+		_, ok := d.mu.activeCheckTxn[string(waitTxn.TxnID)]
+		assert.False(t, ok)
+
+		<-d.c
+		assert.NoError(t, d.check(holdTxn, waitTxn))
+		_, ok = d.mu.activeCheckTxn[string(waitTxn.TxnID)]
+		assert.True(t, ok)
+		assert.Len(t, d.c, 1)
+	})
+}
+
+func TestOwnerLocalDeadlockPathUsesWaitEdges(t *testing.T) {
+	reuse.RunReuseTests(func() {
+		logger := runtime.DefaultRuntime().Logger()
+		txn1 := pb.WaitTxn{TxnID: []byte("txn1"), CreatedOn: "cn1"}
+		txn2 := pb.WaitTxn{TxnID: []byte("txn2"), CreatedOn: "cn1"}
+		txn3 := pb.WaitTxn{TxnID: []byte("txn3"), CreatedOn: "cn1"}
+
+		w1 := acquireWaiter(txn1, "owner-local-edge-test", logger)
+		defer w1.close("owner-local-edge-test", logger)
+		w1.setStatus(blocking)
+		w2 := acquireWaiter(txn2, "owner-local-edge-test", logger)
+		defer w2.close("owner-local-edge-test", logger)
+		w2.setStatus(blocking)
+
+		graph := map[ownerLocalTxnKey][]ownerLocalWaitEdge{
+			newOwnerLocalTxnKey(txn1): {{
+				waiter:  w1,
+				waitFor: []ownerLocalTxnKey{newOwnerLocalTxnKey(txn2)},
+			}},
+			newOwnerLocalTxnKey(txn2): {{
+				waiter:  w2,
+				waitFor: []ownerLocalTxnKey{newOwnerLocalTxnKey(txn3)},
+			}},
+		}
+
+		path, found := findOwnerLocalDeadlockPath(
+			graph,
+			newOwnerLocalTxnKey(txn3),
+			[]ownerLocalTxnKey{newOwnerLocalTxnKey(txn1)})
+		assert.True(t, found)
+		assert.Equal(t, []ownerLocalTxnKey{
+			newOwnerLocalTxnKey(txn3),
+			newOwnerLocalTxnKey(txn1),
+			newOwnerLocalTxnKey(txn2),
+			newOwnerLocalTxnKey(txn3),
+		}, path)
+
+		w2.setStatus(notified)
+		_, found = findOwnerLocalDeadlockPath(
+			graph,
+			newOwnerLocalTxnKey(txn3),
+			[]ownerLocalTxnKey{newOwnerLocalTxnKey(txn1)})
+		assert.False(t, found)
+	})
+}
+
 func TestPrintPathFromRoot(t *testing.T) {
 	// Test case 1: nil node
 	assert.Equal(t, "<nil>", printPathFromRoot(nil))

--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -50,6 +50,7 @@ type localLockTable struct {
 		closed           bool
 		store            LockStorage
 		tableCommittedAt timestamp.Timestamp
+		ownerLocalWaits  map[ownerLocalTxnKey][]ownerLocalWaitEdge
 	}
 
 	options struct {
@@ -76,6 +77,7 @@ func newLocalLockTable(
 		logger:    logger,
 	}
 	l.mu.store = newBtreeBasedStorage()
+	l.mu.ownerLocalWaits = make(map[ownerLocalTxnKey][]ownerLocalWaitEdge)
 	l.mu.tableCommittedAt, _ = clock.Now()
 	return l
 }
@@ -231,8 +233,13 @@ func (l *localLockTable) doLock(
 				// by other txn and readd into store. So c.w.conflictWith is
 				// invalid.
 				conflictWith, ok := l.mu.store.Get(ck)
-				if ok && conflictWith.closeWaiter(c.w, l.logger) {
-					l.mu.store.Delete(ck)
+				if ok {
+					l.removeOwnerLocalWaitEdgeLocked(c.w)
+					if conflictWith.closeWaiter(c.w, l.logger) {
+						l.mu.store.Delete(ck)
+					} else {
+						l.removeInactiveOwnerLocalWaitEdgesLocked(conflictWith)
+					}
 				}
 				l.mu.Unlock()
 			}
@@ -352,6 +359,7 @@ func (l *localLockTable) unlock(
 			lockCanRemoved := lock.closeTxn(
 				txn,
 				notifyValue{ts: commitTS})
+			l.removeInactiveOwnerLocalWaitEdgesLocked(lock)
 			logLockUnlocked(l.logger, txn, key, lock)
 
 			if lockCanRemoved {
@@ -424,6 +432,7 @@ func (l *localLockTable) close(reason closeReason) {
 		}
 		return true
 	})
+	clear(l.mu.ownerLocalWaits)
 	l.mu.store.Clear()
 	logLockTableClosed(l.logger, l.bind, false, reason)
 }
@@ -462,6 +471,7 @@ func (l *localLockTable) acquireRowLockLocked(c *lockContext) error {
 			hold, newHolder := lock.tryHold(l.logger, c)
 			if hold {
 				if c.w != nil {
+					l.removeOwnerLocalWaitEdgeLocked(c.w)
 					c.w = nil
 				}
 				// only new holder can added lock into txn.
@@ -567,7 +577,10 @@ func (l *localLockTable) handleLockConflictLocked(
 		return ErrLockConflict
 	}
 	if c.opts.async && !c.lockWaitDeadline.IsZero() && !time.Now().Before(c.lockWaitDeadline) {
-		return ErrLockTimeout
+		return c.getLockWaitTimeoutErr()
+	}
+	if l.detectOwnerLocalDeadlockLocked(c, conflictWith) {
+		return ErrDeadLockDetected
 	}
 
 	if c.opts.Granularity == pb.Granularity_Range {
@@ -594,6 +607,7 @@ func (l *localLockTable) handleLockConflictLocked(
 	// Set waiter to blocking before adding to events.mu.blockedWaiters so
 	// waiter_events.check() won't remove it (check removes only non-blocking).
 	c.txn.setBlocked(c.w, l.logger)
+	l.addOwnerLocalWaitEdgeLocked(c, conflictWith)
 	l.events.add(c)
 
 	// find conflict, and wait prev txn completed, and a new
@@ -613,6 +627,8 @@ func (l *localLockTable) closeRangeLastWaiterLocked(c *lockContext) {
 	if ok {
 		removed, empty := v.removeWaiter(c.w, l.logger)
 		if removed {
+			l.removeOwnerLocalWaitEdgeLocked(c.w)
+			l.removeInactiveOwnerLocalWaitEdgesLocked(v)
 			if empty {
 				l.mu.store.Delete(c.rangeLastWaitKey)
 			}
@@ -633,6 +649,10 @@ func (l *localLockTable) closeRangeLastWaiterLocked(c *lockContext) {
 	var deleteKeys [][]byte
 	l.mu.store.Iter(func(key []byte, lock Lock) bool {
 		removed, empty := lock.removeWaiter(c.w, l.logger)
+		if removed {
+			l.removeOwnerLocalWaitEdgeLocked(c.w)
+			l.removeInactiveOwnerLocalWaitEdgesLocked(lock)
+		}
 		if removed && empty {
 			deleteKeys = append(deleteKeys, append([]byte(nil), key...))
 		}

--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -176,6 +176,7 @@ func (l *localLockTable) doLock(
 		}
 		waitStart := time.Now()
 		v := c.w.wait(waitCtx, l.logger)
+		l.events.removeBlockedWaiter(c.w)
 		lockWaitTimeoutHit := leftTimeout > 0 &&
 			errors.Is(v.err, context.DeadlineExceeded) &&
 			context.Cause(waitCtx) == ErrLockTimeout

--- a/pkg/lockservice/lock_table_local_test.go
+++ b/pkg/lockservice/lock_table_local_test.go
@@ -128,6 +128,64 @@ func TestCloseLocalLockTableWithBlockedWaiter(t *testing.T) {
 		})
 }
 
+func TestSynchronousWaiterRemovedFromEventsBeforeAfterWait(t *testing.T) {
+	table := uint64(10)
+	getRunner(false)(
+		t,
+		table,
+		func(ctx context.Context, s *service, lt *localLockTable) {
+			rows := newTestRows(1, 2)
+			txn1 := newTestTxnID(1)
+			txn2 := newTestTxnID(2)
+
+			_, err := s.Lock(ctx, table, rows, txn1, newTestRangeExclusiveOptions())
+			require.NoError(t, err)
+
+			waiting := make(chan struct{})
+			removed := make(chan bool, 1)
+			lt.options.beforeWait = func(c *lockContext) func() {
+				if bytes.Equal(c.txn.txnID, txn2) {
+					return func() { close(waiting) }
+				}
+				return func() {}
+			}
+			lt.options.afterWait = func(c *lockContext) func() {
+				if !bytes.Equal(c.txn.txnID, txn2) {
+					return func() {}
+				}
+				return func() {
+					lt.events.mu.RLock()
+					defer lt.events.mu.RUnlock()
+					for _, w := range lt.events.mu.blockedWaiters {
+						if w == c.w {
+							removed <- false
+							return
+						}
+					}
+					removed <- true
+				}
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := s.Lock(ctx, table, rows, txn2, newTestRangeExclusiveOptions())
+				done <- err
+			}()
+
+			select {
+			case <-waiting:
+			case <-time.After(time.Second):
+				t.Fatal("txn2 did not begin waiting for the range lock")
+			}
+
+			require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+			require.True(t, <-removed)
+			require.NoError(t, <-done)
+			require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
+		},
+	)
+}
+
 func TestMergeRangeWithNoConflict(t *testing.T) {
 	cases := []struct {
 		txnID         string

--- a/pkg/lockservice/lock_table_remote.go
+++ b/pkg/lockservice/lock_table_remote.go
@@ -172,6 +172,10 @@ func (l *remoteLockTable) lock(
 		_ = txn.lockAdded(l.bind.Group, l.bind, rows, l.logger)
 	}
 	logRemoteLockFailed(l.logger, txn, rows, opts, l.bind, err)
+	if moerr.IsMoErrCode(err, moerr.ErrRemoteLockWaitTimeout) {
+		cb(pb.Result{}, err)
+		return
+	}
 	// encounter any error, we need try to check bind is valid.
 	// And use origin error to return, because once handlerError
 	// swallows the error, the transaction will not be abort.

--- a/pkg/lockservice/service_forward_test.go
+++ b/pkg/lockservice/service_forward_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,6 +57,47 @@ func TestForwardLock(t *testing.T) {
 			require.NotNil(t, txn)
 			require.Equal(t, l1.serviceID, txn.remoteService)
 			require.True(t, l2.activeTxnHolder.hasRemoteLockBind(l1.serviceID, l2.tableGroups.get(0, tableID).getBind(), time.Second))
+		},
+	)
+}
+
+func TestForwardLockOwnerWaitTimeoutFallbackReleasesPartialRemoteLock(t *testing.T) {
+	runLockServiceTestsWithAdjustConfig(
+		t,
+		[]string{"s1", "s2"},
+		time.Second*10,
+		func(alloc *lockTableAllocator, s []*service) {
+			tableID := uint64(10)
+			origin := s[0]
+			owner := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+
+			_, err := owner.getLockTableWithCreate(0, tableID, nil, pb.Sharding_None)
+			require.NoError(t, err)
+
+			row1 := []byte{1}
+			row2 := []byte{2}
+			holderTxn := []byte("holder")
+			originTxn := []byte("origin")
+			verifyTxn := []byte("verify")
+			mustAddTestLock(t, ctx, owner, tableID, holderTxn, [][]byte{row2}, pb.Granularity_Row)
+
+			opt := newTestRowExclusiveOptions()
+			opt.ForwardTo = owner.serviceID
+			_, err = origin.Lock(ctx, tableID, [][]byte{row1, row2}, originTxn, opt)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrDeadLockDetected), "got %v", err)
+
+			// An old origin treats the v1-compatible error as whole-transaction
+			// rollback, and its Unlock must release the partial grant on owner.
+			require.NoError(t, origin.Unlock(ctx, originTxn, timestamp.Timestamp{}))
+			_, err = owner.Lock(ctx, tableID, [][]byte{row1}, verifyTxn, newTestRowExclusiveOptions())
+			require.NoError(t, err)
+			require.NoError(t, owner.Unlock(ctx, verifyTxn, timestamp.Timestamp{}))
+			require.NoError(t, owner.Unlock(ctx, holderTxn, timestamp.Timestamp{}))
+		},
+		func(cfg *Config) {
+			cfg.RemoteLockOwnerWaitTimeout = &toml.Duration{Duration: 100 * time.Millisecond}
 		},
 	)
 }

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -264,8 +264,20 @@ func (s *service) handleRemoteLock(
 			}
 			lockErr = err
 			resp.Lock.Result = result
-			_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout, logFields)
+			_ = writeResponseWithDeadline(s.logger, cancel, resp, remoteLockWireError(err), cs, defaultRPCWriteTimeout, logFields)
 		})
+}
+
+// remoteLockWireError keeps Method_Lock v1 compatible during a rolling 4.1
+// upgrade. Old origins do not recognize ErrRemoteLockWaitTimeout as a
+// whole-transaction rollback error. Returning the established deadlock code
+// makes every supported origin roll back and issue remote unlock for any
+// partially granted rows.
+func remoteLockWireError(err error) error {
+	if moerr.IsMoErrCode(err, moerr.ErrRemoteLockWaitTimeout) {
+		return ErrDeadLockDetected
+	}
+	return err
 }
 
 func (s *service) handleForwardLock(

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -364,7 +364,7 @@ func (s *service) handleForwardLock(
 			}
 			lockErr = err
 			resp.Lock.Result = result
-			_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout, logFields)
+			_ = writeResponseWithDeadline(s.logger, cancel, resp, remoteLockWireError(err), cs, defaultRPCWriteTimeout, logFields)
 		})
 }
 

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -250,7 +250,11 @@ func (s *service) handleRemoteLock(
 		ctx,
 		txn,
 		req.Lock.Rows,
-		LockOptions{LockOptions: req.Lock.Options, async: true},
+		LockOptions{
+			LockOptions:                req.Lock.Options,
+			async:                      true,
+			remoteLockOwnerWaitTimeout: s.cfg.RemoteLockOwnerWaitTimeout.Duration,
+		},
 		func(result pb.Result, err error) {
 			if err == nil {
 				if e := s.checkBindChangedBeforeLockSuccess(txn, txnID, bind); e != nil {
@@ -334,7 +338,11 @@ func (s *service) handleForwardLock(
 		ctx,
 		txn,
 		req.Lock.Rows,
-		LockOptions{LockOptions: req.Lock.Options, async: true},
+		LockOptions{
+			LockOptions:                req.Lock.Options,
+			async:                      true,
+			remoteLockOwnerWaitTimeout: s.cfg.RemoteLockOwnerWaitTimeout.Duration,
+		},
 		func(result pb.Result, err error) {
 			if err == nil {
 				if e := s.checkBindChangedBeforeLockSuccess(txn, txnID, bind); e != nil {

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -830,6 +831,89 @@ func TestRemoteLockWaitTimeout_PrecisionIndependentOfLazyCheck(t *testing.T) {
 			// Must fire well before the 10s coarse tick.
 			require.Less(t, elapsed, 3*time.Second,
 				"precise timer should fire at ~1s, elapsed=%v", elapsed)
+		},
+	)
+}
+
+func TestRemoteOwnerLocalDeadlockFastPathBreaksPartialLockRing(t *testing.T) {
+	txn1 := []byte("txn1")
+	txn2 := []byte("txn2")
+	runLockServiceTestsWithAdjustConfig(
+		t,
+		[]string{"s1", "s2"},
+		time.Second*10,
+		func(alloc *lockTableAllocator, s []*service) {
+			tableID := uint64(10)
+			owner := s[0]
+			origin := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			// Pin the lock table to s1, then use s2 as the remote origin.
+			mustAddTestLock(t, ctx, owner, tableID, []byte("pin"), [][]byte{{0}}, pb.Granularity_Row)
+			require.NoError(t, owner.Unlock(ctx, []byte("pin"), timestamp.Timestamp{}))
+
+			row1 := []byte{1}
+			row2 := []byte{2}
+			opt := newTestRowExclusiveOptions()
+
+			mustAddTestLock(t, ctx, origin, tableID, txn1, [][]byte{row1}, pb.Granularity_Row)
+			mustAddTestLock(t, ctx, origin, tableID, txn2, [][]byte{row2}, pb.Granularity_Row)
+
+			errC := make(chan error, 1)
+			go func() {
+				_, err := origin.Lock(ctx, tableID, [][]byte{row2}, txn1, opt)
+				errC <- err
+			}()
+			require.NoError(t, WaitWaiters(owner, 0, tableID, row2, 1))
+
+			_, err := origin.Lock(ctx, tableID, [][]byte{row1}, txn2, opt)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrDeadLockDetected), "got %v", err)
+			require.NoError(t, origin.Unlock(ctx, txn2, timestamp.Timestamp{}))
+
+			require.NoError(t, <-errC)
+			require.NoError(t, origin.Unlock(ctx, txn1, timestamp.Timestamp{}))
+		},
+		func(cfg *Config) {
+			cfg.TxnIterFunc = func(fn func([]byte) bool) {
+				fn(txn1)
+				fn(txn2)
+			}
+		},
+	)
+}
+
+func TestRemoteLockOwnerWaitTimeoutReturnsDedicatedError(t *testing.T) {
+	runLockServiceTestsWithAdjustConfig(
+		t,
+		[]string{"s1", "s2"},
+		time.Second*10,
+		func(alloc *lockTableAllocator, s []*service) {
+			tableID := uint64(10)
+			owner := s[0]
+			origin := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+
+			txn1 := []byte("txn1")
+			txn2 := []byte("txn2")
+			row1 := []byte{1}
+			mustAddTestLock(t, ctx, owner, tableID, txn1, [][]byte{row1}, pb.Granularity_Row)
+
+			opt := newTestRowExclusiveOptions()
+			opt.LockWaitTimeout = 0
+			start := time.Now()
+			_, err := origin.Lock(ctx, tableID, [][]byte{row1}, txn2, opt)
+			elapsed := time.Since(start)
+
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrRemoteLockWaitTimeout), "got %v", err)
+			require.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
+			require.Less(t, elapsed, 2*time.Second)
+			require.NoError(t, origin.Unlock(ctx, txn2, timestamp.Timestamp{}))
+			require.NoError(t, owner.Unlock(ctx, txn1, timestamp.Timestamp{}))
+		},
+		func(cfg *Config) {
+			cfg.RemoteLockOwnerWaitTimeout = &toml.Duration{Duration: 100 * time.Millisecond}
 		},
 	)
 }

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -883,7 +883,7 @@ func TestRemoteOwnerLocalDeadlockFastPathBreaksPartialLockRing(t *testing.T) {
 	)
 }
 
-func TestRemoteLockOwnerWaitTimeoutReturnsDedicatedError(t *testing.T) {
+func TestRemoteLockOwnerWaitTimeoutUsesV1CompatibleRollbackError(t *testing.T) {
 	runLockServiceTestsWithAdjustConfig(
 		t,
 		[]string{"s1", "s2"},
@@ -906,7 +906,10 @@ func TestRemoteLockOwnerWaitTimeoutReturnsDedicatedError(t *testing.T) {
 			_, err := origin.Lock(ctx, tableID, [][]byte{row1}, txn2, opt)
 			elapsed := time.Since(start)
 
-			require.True(t, moerr.IsMoErrCode(err, moerr.ErrRemoteLockWaitTimeout), "got %v", err)
+			// Method_Lock is protocol v1. The owner keeps the dedicated timeout
+			// internally but must return an error an old 4.1 origin classifies as
+			// whole-transaction rollback, so partial remote locks are released.
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrDeadLockDetected), "got %v", err)
 			require.GreaterOrEqual(t, elapsed, 100*time.Millisecond)
 			require.Less(t, elapsed, 2*time.Second)
 			require.NoError(t, origin.Unlock(ctx, txn2, timestamp.Timestamp{}))
@@ -916,6 +919,55 @@ func TestRemoteLockOwnerWaitTimeoutReturnsDedicatedError(t *testing.T) {
 			cfg.RemoteLockOwnerWaitTimeout = &toml.Duration{Duration: 100 * time.Millisecond}
 		},
 	)
+}
+
+func TestRemoteLockOwnerWaitTimeoutFallbackReleasesPartialRemoteLock(t *testing.T) {
+	runLockServiceTestsWithAdjustConfig(
+		t,
+		[]string{"s1", "s2"},
+		time.Second*10,
+		func(alloc *lockTableAllocator, s []*service) {
+			tableID := uint64(10)
+			owner := s[0]
+			origin := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+
+			row1 := []byte{1}
+			row2 := []byte{2}
+			holderTxn := []byte("holder")
+			originTxn := []byte("origin")
+			verifyTxn := []byte("verify")
+			opt := newTestRowExclusiveOptions()
+			opt.LockWaitTimeout = 0
+
+			// Keep row2 busy. The remote request acquires row1 before waiting
+			// on row2, so it exercises the partial-grant cleanup path.
+			mustAddTestLock(t, ctx, owner, tableID, holderTxn, [][]byte{row2}, pb.Granularity_Row)
+			_, err := origin.Lock(ctx, tableID, [][]byte{row1, row2}, originTxn, opt)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrDeadLockDetected), "got %v", err)
+
+			// The legacy-compatible error must make the origin perform a whole
+			// transaction rollback, including remote unlock for row1.
+			require.NoError(t, origin.Unlock(ctx, originTxn, timestamp.Timestamp{}))
+			_, err = owner.Lock(ctx, tableID, [][]byte{row1}, verifyTxn, opt)
+			require.NoError(t, err)
+			require.NoError(t, owner.Unlock(ctx, verifyTxn, timestamp.Timestamp{}))
+			require.NoError(t, owner.Unlock(ctx, holderTxn, timestamp.Timestamp{}))
+		},
+		func(cfg *Config) {
+			cfg.RemoteLockOwnerWaitTimeout = &toml.Duration{Duration: 100 * time.Millisecond}
+		},
+	)
+}
+
+func TestRemoteLockWireErrorUsesCompatibleFallback(t *testing.T) {
+	require.True(t, moerr.IsMoErrCode(
+		remoteLockWireError(ErrRemoteLockWaitTimeout),
+		moerr.ErrDeadLockDetected))
+
+	err := moerr.NewLockTableBindChangedNoCtx()
+	require.Same(t, err, remoteLockWireError(err))
 }
 
 // TestRemoteLockWaitTimeout_ReturnsLockTimeout ensures that in a multi-CN

--- a/pkg/lockservice/types.go
+++ b/pkg/lockservice/types.go
@@ -44,6 +44,8 @@ var (
 	ErrLockConflict = moerr.NewLockConflictNoCtx()
 	// ErrLockTimeout lock table timeout
 	ErrLockTimeout = moerr.NewInvalidStateNoCtx("lock timeout")
+	// ErrRemoteLockWaitTimeout remote lock owner-side wait timeout
+	ErrRemoteLockWaitTimeout = moerr.NewRemoteLockWaitTimeoutNoCtx()
 )
 
 // Option lockservice option
@@ -250,7 +252,8 @@ type Server interface {
 // LockOptions options for lock
 type LockOptions struct {
 	pb.LockOptions
-	async bool
+	async                      bool
+	remoteLockOwnerWaitTimeout time.Duration
 }
 
 // Lock stores specific lock information. Since there are a large number of lock objects

--- a/pkg/lockservice/waiter.go
+++ b/pkg/lockservice/waiter.go
@@ -102,8 +102,11 @@ type waiter struct {
 	// case waiting relies on the context or other external cancellation.
 	// Set in waiterEvents.add() from the lockContext and checked in
 	// waiterEvents.check() to enforce timeouts on the async (remote) lock path.
-	lockWaitTimeout time.Duration
-	lockWaitTimer   atomic.Pointer[time.Timer]
+	lockWaitTimeout     time.Duration
+	lockWaitTimeoutErr  error
+	lockWaitGranularity pb.Granularity
+	lockWaitMode        pb.LockMode
+	lockWaitTimer       atomic.Pointer[time.Timer]
 
 	// just used for testing
 	beforeSwapStatusAdjustFunc func()
@@ -314,6 +317,9 @@ func (w *waiter) reset() {
 	w.lt.Store(nil)
 	w.setStatus(ready)
 	w.lockWaitTimeout = 0
+	w.lockWaitTimeoutErr = nil
+	w.lockWaitGranularity = pb.Granularity_Row
+	w.lockWaitMode = pb.LockMode_Exclusive
 	w.stopLockWaitTimer()
 }
 

--- a/pkg/lockservice/waiter_events.go
+++ b/pkg/lockservice/waiter_events.go
@@ -22,10 +22,12 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"go.uber.org/zap"
 )
 
@@ -39,22 +41,23 @@ func init() {
 }
 
 type lockContext struct {
-	ctx              context.Context
-	txn              *activeTxn
-	waitTxn          pb.WaitTxn
-	rows             [][]byte
-	opts             LockOptions
-	offset           int
-	idx              int
-	lockedTS         timestamp.Timestamp
-	result           pb.Result
-	cb               func(pb.Result, error)
-	lockFunc         func(*lockContext, bool)
-	w                *waiter
-	createAt         time.Time
-	closed           bool
-	rangeLastWaitKey []byte
-	lockWaitDeadline time.Time
+	ctx                context.Context
+	txn                *activeTxn
+	waitTxn            pb.WaitTxn
+	rows               [][]byte
+	opts               LockOptions
+	offset             int
+	idx                int
+	lockedTS           timestamp.Timestamp
+	result             pb.Result
+	cb                 func(pb.Result, error)
+	lockFunc           func(*lockContext, bool)
+	w                  *waiter
+	createAt           time.Time
+	closed             bool
+	rangeLastWaitKey   []byte
+	lockWaitDeadline   time.Time
+	lockWaitTimeoutErr error
 }
 
 func (l *localLockTable) newLockContext(
@@ -73,8 +76,8 @@ func (l *localLockTable) newLockContext(
 	c.cb = cb
 	c.result = pb.Result{LockedOn: bind}
 	c.createAt = time.Now()
-	if opts.async && opts.LockWaitTimeout > 0 {
-		c.lockWaitDeadline = c.createAt.Add(time.Duration(opts.LockWaitTimeout) * time.Second)
+	if opts.async {
+		c.lockWaitDeadline, c.lockWaitTimeoutErr = getAsyncLockWaitDeadline(c.createAt, opts)
 	}
 	return c
 }
@@ -104,6 +107,32 @@ func (c *lockContext) getLockWaitTimeout() time.Duration {
 		return time.Duration(c.opts.LockWaitTimeout) * time.Second
 	}
 	return time.Until(c.lockWaitDeadline)
+}
+
+func (c *lockContext) getLockWaitTimeoutErr() error {
+	if c.lockWaitTimeoutErr != nil {
+		return c.lockWaitTimeoutErr
+	}
+	return ErrLockTimeout
+}
+
+func getAsyncLockWaitDeadline(createAt time.Time, opts LockOptions) (time.Time, error) {
+	var (
+		deadline time.Time
+		err      error
+	)
+	if opts.LockWaitTimeout > 0 {
+		deadline = createAt.Add(time.Duration(opts.LockWaitTimeout) * time.Second)
+		err = ErrLockTimeout
+	}
+	if opts.remoteLockOwnerWaitTimeout > 0 {
+		remoteDeadline := createAt.Add(opts.remoteLockOwnerWaitTimeout)
+		if deadline.IsZero() || remoteDeadline.Before(deadline) {
+			deadline = remoteDeadline
+			err = ErrRemoteLockWaitTimeout
+		}
+	}
+	return deadline, err
 }
 
 type event struct {
@@ -194,9 +223,12 @@ func (mw *waiterEvents) add(c *lockContext) {
 	// doLock. waiterEvents owns timeout notifications only for async waits.
 	c.w.lockWaitTimeout = 0
 	if c.opts.async {
-		// Propagate the remaining session-level lock_wait_timeout to the waiter
-		// so the check loop enforces one budget across async re-queue cycles.
+		// Propagate the remaining async wait budget to the waiter so the check
+		// loop enforces one budget across re-queue cycles.
 		c.w.lockWaitTimeout = c.getLockWaitTimeout()
+		c.w.lockWaitTimeoutErr = c.getLockWaitTimeoutErr()
+		c.w.lockWaitGranularity = c.opts.Granularity
+		c.w.lockWaitMode = c.opts.Mode
 		if c.w.lockWaitTimeout <= 0 && !c.lockWaitDeadline.IsZero() {
 			c.w.lockWaitTimeout = time.Nanosecond
 		}
@@ -281,15 +313,32 @@ func (mw *waiterEvents) check(timeout time.Duration) {
 		wait := now.Sub(w.waitAt.Load().(time.Time))
 		mw.addToOrphanCheck(w, wait)
 
-		// enforce session-level lock_wait_timeout on the async (remote) path.
-		// The sync path enforces this via context.WithTimeoutCause in doLock;
-		// this gives the async path equivalent timeout enforcement.
+		// Enforce async lock wait timeout. The sync path enforces the
+		// session-level timeout via context.WithTimeoutCause in doLock.
 		if w.lockWaitTimeout > 0 && wait >= w.lockWaitTimeout {
-			mw.logger.Debug("lock wait timeout elapsed, notifying waiter",
-				zap.String("txn", w.String()),
-				zap.Duration("wait", wait),
-				zap.Duration("timeout", w.lockWaitTimeout))
-			w.notify(notifyValue{err: ErrLockTimeout}, mw.logger)
+			err := w.lockWaitTimeoutErr
+			if err == nil {
+				err = ErrLockTimeout
+			}
+			if moerr.IsMoErrCode(err, moerr.ErrRemoteLockWaitTimeout) {
+				v2.TxnRemoteLockOwnerTimeoutCounter.WithLabelValues(
+					w.lockWaitGranularity.String(),
+					w.lockWaitMode.String(),
+				).Inc()
+				mw.logger.Warn("remote_lock_owner_timeout",
+					zap.String("txn", hex.EncodeToString(w.txn.TxnID)),
+					zap.String("created-on", w.txn.CreatedOn),
+					zap.Duration("wait", wait),
+					zap.Duration("timeout", w.lockWaitTimeout),
+					zap.String("granularity", w.lockWaitGranularity.String()),
+					zap.String("mode", w.lockWaitMode.String()))
+			} else {
+				mw.logger.Debug("lock wait timeout elapsed, notifying waiter",
+					zap.String("txn", w.String()),
+					zap.Duration("wait", wait),
+					zap.Duration("timeout", w.lockWaitTimeout))
+			}
+			w.notify(notifyValue{err: err}, mw.logger)
 			w.close("waiterEvents check timeout", mw.logger)
 			mw.mu.blockedWaiters[i] = nil
 			continue

--- a/pkg/lockservice/waiter_events.go
+++ b/pkg/lockservice/waiter_events.go
@@ -209,6 +209,8 @@ func (mw *waiterEvents) close() {
 	for _, w := range mw.mu.blockedWaiters {
 		w.close("waiterEvents close", mw.logger)
 	}
+	clear(mw.mu.blockedWaiters)
+	mw.mu.blockedWaiters = nil
 	mw.mu.Unlock()
 }
 
@@ -250,6 +252,24 @@ func (mw *waiterEvents) addToLazyCheckDeadlockC(w *waiter) {
 	mw.mu.Lock()
 	defer mw.mu.Unlock()
 	mw.mu.blockedWaiters = append(mw.mu.blockedWaiters, w)
+}
+
+// removeBlockedWaiter stops the background checker from retaining a waiter
+// that the synchronous lock path is about to reuse.
+func (mw *waiterEvents) removeBlockedWaiter(w *waiter) {
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+
+	blocked := mw.mu.blockedWaiters[:0]
+	for _, current := range mw.mu.blockedWaiters {
+		if current == w {
+			current.close("waiterEvents remove blocked waiter", mw.logger)
+			continue
+		}
+		blocked = append(blocked, current)
+	}
+	clear(mw.mu.blockedWaiters[len(blocked):])
+	mw.mu.blockedWaiters = blocked
 }
 
 func (mw *waiterEvents) wakeCheck() {

--- a/pkg/lockservice/waiter_events_test.go
+++ b/pkg/lockservice/waiter_events_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lockservice
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaiterEventsRemoveBlockedWaiter(t *testing.T) {
+	w := newWaiter()
+	w.txn = pb.WaitTxn{TxnID: []byte("waiter")}
+	require.Equal(t, int32(1), w.ref("test", nil))
+
+	events := &waiterEvents{}
+	events.addToLazyCheckDeadlockC(w)
+	require.Equal(t, int32(2), w.refCount.Load())
+
+	events.removeBlockedWaiter(w)
+
+	events.mu.RLock()
+	require.Empty(t, events.mu.blockedWaiters)
+	events.mu.RUnlock()
+	require.Equal(t, int32(1), w.refCount.Load())
+}
+
+func TestWaiterEventsCloseDropsBlockedWaiters(t *testing.T) {
+	logger := getLogger("")
+	events := newWaiterEvents(0, nil, nil, time.Second, nil, logger)
+	w := newWaiter()
+	w.txn = pb.WaitTxn{TxnID: []byte("waiter")}
+	require.Equal(t, int32(1), w.ref("test", logger))
+
+	events.addToLazyCheckDeadlockC(w)
+	require.Equal(t, int32(2), w.refCount.Load())
+
+	events.close()
+
+	events.mu.RLock()
+	require.Empty(t, events.mu.blockedWaiters)
+	events.mu.RUnlock()
+	require.Equal(t, int32(1), w.refCount.Load())
+
+	events.removeBlockedWaiter(w)
+	require.Equal(t, int32(1), w.refCount.Load())
+}

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -143,10 +143,14 @@ func initTxnMetrics() {
 	registry.MustRegister(TxnUserRollbackCounter)
 	registry.MustRegister(TxnRollbackLastStatementCounter)
 	registry.MustRegister(txnLockCounter)
+	registry.MustRegister(TxnDeadlockDetectorEnqueueCounter)
+	registry.MustRegister(TxnDeadlockOwnerLocalCounter)
+	registry.MustRegister(TxnRemoteLockOwnerTimeoutCounter)
 	registry.MustRegister(txnPKChangeCheckCounter)
 	registry.MustRegister(txnPKMayBeChangedCounter)
 
 	registry.MustRegister(txnQueueSizeGauge)
+	registry.MustRegister(TxnDeadlockDetectorQueueDepthGauge)
 
 	registry.MustRegister(txnCommitDurationHistogram)
 	registry.MustRegister(TxnLifeCycleDurationHistogram)

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -92,6 +92,30 @@ var (
 	TxnLocalLockTotalCounter  = txnLockCounter.WithLabelValues("local")
 	TxnRemoteLockTotalCounter = txnLockCounter.WithLabelValues("remote")
 
+	TxnDeadlockDetectorEnqueueCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "lockservice",
+			Name:      "deadlock_detector_enqueue_total",
+			Help:      "Total number of lockservice deadlock detector enqueue attempts.",
+		}, []string{"result"})
+
+	TxnDeadlockOwnerLocalCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "lockservice",
+			Name:      "deadlock_owner_local_total",
+			Help:      "Total number of owner-local deadlock fast path results.",
+		}, []string{"result"})
+
+	TxnRemoteLockOwnerTimeoutCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "lockservice",
+			Name:      "remote_lock_owner_timeout_total",
+			Help:      "Total number of remote lock owner-side wait timeouts.",
+		}, []string{"granularity", "mode"})
+
 	txnPKChangeCheckCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "mo",
@@ -129,6 +153,14 @@ var (
 	TxnWaitActiveQueueSizeGauge = txnQueueSizeGauge.WithLabelValues("wait-active")
 	TxnActiveQueueSizeGauge     = txnQueueSizeGauge.WithLabelValues("active")
 	TxnLockRPCQueueSizeGauge    = txnQueueSizeGauge.WithLabelValues("lock-rpc")
+
+	TxnDeadlockDetectorQueueDepthGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "mo",
+			Subsystem: "lockservice",
+			Name:      "deadlock_detector_queue_depth",
+			Help:      "Current depth of the lockservice deadlock detector queue.",
+		})
 
 	txnCNCommittedLocationQuantityGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Backport of #25447 to 4.1-dev.

Fixes #25297
Fixes #25278
Related to #25279

## What this PR does / why we need it:

Backports the lockservice fix for owner-local remote lock deadlocks:

- detects owner-local wait cycles rooted at the actual conflicting holders;
- caps owner-side remote lock waits at two minutes by default;
- retains remote lock metadata so rollback can release partially granted locks;
- fixes deadlock detector enqueue bookkeeping and adds focused metrics;
- removes completed synchronous waiters from the deadlock-event set before a waiter can be reused, and drops retained waiter references during shutdown (the relevant lockservice portion of #25792).

Method_Lock is still protocol v1 and has no peer capability signal. The owner therefore keeps the dedicated ErrRemoteLockWaitTimeout internally but sends the existing ErrDeadLockDetected over v1. Every supported 4.1 origin recognizes that code as a whole-transaction rollback, so it issues remote unlock even for a partial multi-row grant during a rolling upgrade.

The cherry-pick applies cleanly to the current 4.1-dev / v4.1.2 baseline. Follow-up #25469 remains unnecessary on this branch: 4.1 already releases the forwarded transaction lock with defer txn.Unlock() before entering the asynchronous wait path.

## Validation

- go test -v ./pkg/lockservice -count=1 -timeout=20m — PASS (573.999s)
- go build ./pkg/lockservice — PASS
- go vet ./pkg/lockservice — PASS
- focused waiter and V1 compatibility regression tests under -race -count=10 — PASS
- go test ./pkg/frontend -run Test_isErrorRollbackWholeTxn -count=1 -timeout=5m (with repository CGO/rpath settings) — PASS

The V1 compatibility test makes a two-row remote request acquire row 1 then time out on row 2, checks the legacy deadlock code, performs the old-origin whole-transaction unlock, and verifies row 1 is immediately lockable.