### PR TITLE
fix(pSpool): close pooled resource ownership on all exits

### DIFF
--- a/pkg/container/pSpool/copy.go
+++ b/pkg/container/pSpool/copy.go
@@ -105,7 +105,7 @@ func (cb *cachedBatch) GetCopiedBatch(
 
 		if vec.IsConst() {
 			if err = vector.GetConstSetFunction(typ, cb.mp)(dst.Vecs[i], vec, 0, vec.Length()); err != nil {
-				dst.Clean(cb.mp)
+				cb.CacheBatch(true, cacheID, dst)
 				return nil, false, 0, err
 			}
 
@@ -116,7 +116,7 @@ func (cb *cachedBatch) GetCopiedBatch(
 			if err = vector.GetUnionAllFunction(typ, cb.mp)(
 				dst.Vecs[i],
 				vec); err != nil {
-				dst.Clean(cb.mp)
+				cb.CacheBatch(true, cacheID, dst)
 				return nil, false, 0, err
 			}
 

--- a/pkg/container/pSpool/sender.go
+++ b/pkg/container/pSpool/sender.go
@@ -108,6 +108,7 @@ func (ps *PipelineSpool) SendBatch(
 
 	dst, useCache, cacheID, err := ps.cache.GetCopiedBatch(data)
 	if err != nil {
+		ps.freeShardPool <- messageIdx
 		return false, err
 	}
 	ps.updateSpoolMessage(messageIdx, dst, info, useCache, cacheID)

--- a/pkg/container/pSpool/sender.go
+++ b/pkg/container/pSpool/sender.go
@@ -335,8 +335,16 @@ func (ps *PipelineSpool) releaseCurrentLocked(idx int) {
 			if ps.cleanupDone {
 				ps.cleanSlotLocked(last)
 			} else {
-				ps.cache.CacheBatch(
-					ps.shardPool[last].useCache, ps.shardPool[last].cacheID, ps.shardPool[last].dataContent)
+				// The slot and batch pools have independent reuse orders, so a
+				// returned batch may be assigned to a different slot immediately.
+				// Detach the batch before either object is republished; otherwise
+				// this slot can retain an alias that later cleanup frees prematurely.
+				msg := &ps.shardPool[last]
+				data := msg.dataContent
+				useCache := msg.useCache
+				cacheID := msg.cacheID
+				ps.clearSlotLocked(last)
+				ps.cache.CacheBatch(useCache, cacheID, data)
 				ps.freeShardPool <- last
 			}
 		}
@@ -383,8 +391,10 @@ func (ps *PipelineSpool) cleanSlotLocked(idx uint32) {
 	if msg.useCache && msg.dataContent != nil {
 		msg.dataContent.Clean(ps.cache.mp)
 	}
-	msg.dataContent = nil
-	msg.errContent = nil
-	msg.useCache = false
-	msg.cacheID = 0
+	ps.clearSlotLocked(idx)
+}
+
+func (ps *PipelineSpool) clearSlotLocked(idx uint32) {
+	ps.shardPool[idx] = pipelineSpoolMessage{}
+	ps.doRefCheck[idx] = false
 }

--- a/pkg/container/pSpool/sender_test.go
+++ b/pkg/container/pSpool/sender_test.go
@@ -293,6 +293,184 @@ func TestPipelineSpoolAbortDefersCurrentBatchRelease(t *testing.T) {
 	require.Equal(t, int64(0), mp.CurrNB())
 }
 
+func TestPipelineSpoolReleasedSlotDoesNotRetainOwnership(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 1)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 1)
+	batchErr := moerr.NewInternalErrorNoCtx("batch error")
+	queryDone, err := sp.SendBatch(context.Background(), 0, src, batchErr)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+
+	got, info := sp.ReceiveBatch(0)
+	require.NotNil(t, got)
+	require.Same(t, batchErr, info)
+	slot, ok := sp.rs[0].getLastPop()
+	require.True(t, ok)
+
+	sp.ReleaseCurrent(0)
+
+	msg := sp.shardPool[slot]
+	require.Nil(t, msg.dataContent)
+	require.Nil(t, msg.errContent)
+	require.False(t, msg.useCache)
+	require.Zero(t, msg.cacheID)
+	require.False(t, sp.doRefCheck[slot])
+
+	sp.ForceCleanupAfterTerminalSignal()
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolAbortDoesNotCleanReusedCurrentBatch(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 1024)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 1)
+	queryDone, err := sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	first, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	require.NotNil(t, first)
+	sp.ReleaseCurrent(0)
+
+	queryDone, err = sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	current, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	require.Same(t, first, current, "the test must exercise batch reuse across different slots")
+
+	sp.Abort(nil)
+	require.Equal(t, 1024, current.RowCount())
+	values := vector.MustFixedColWithTypeCheck[int64](current.Vecs[0])
+	require.Equal(t, int64(1), values[0])
+	require.Equal(t, int64(1024), values[len(values)-1])
+
+	sp.ReleaseCurrent(0)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolAbortDoesNotCleanReusedCurrentBroadcastBatch(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 1024)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 2)
+	queryDone, err := sp.SendBatch(context.Background(), SendToAllLocal, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	first0, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	first1, info := sp.ReceiveBatch(1)
+	require.NoError(t, info)
+	require.Same(t, first0, first1)
+	sp.ReleaseCurrent(0)
+	sp.ReleaseCurrent(1)
+
+	queryDone, err = sp.SendBatch(context.Background(), SendToAllLocal, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	current0, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	current1, info := sp.ReceiveBatch(1)
+	require.NoError(t, info)
+	require.Same(t, first0, current0, "the test must exercise batch reuse across different slots")
+	require.Same(t, current0, current1)
+
+	sp.Abort(nil)
+	require.Equal(t, 1024, current0.RowCount())
+	require.Equal(t, int64(1), vector.MustFixedColWithTypeCheck[int64](current1.Vecs[0])[0])
+
+	sp.ReleaseCurrent(0)
+	require.Greater(t, mp.CurrNB(), int64(0))
+	require.Equal(t, 1024, current1.RowCount())
+	sp.ReleaseCurrent(1)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolConcurrentAbortAndBroadcastRelease(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 16)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	for iteration := 0; iteration < 256; iteration++ {
+		sp := InitMyPipelineSpool(mp, 2)
+		queryDone, err := sp.SendBatch(context.Background(), SendToAllLocal, src, nil)
+		require.NoError(t, err)
+		require.False(t, queryDone)
+		got0, info := sp.ReceiveBatch(0)
+		require.NoError(t, info)
+		got1, info := sp.ReceiveBatch(1)
+		require.NoError(t, info)
+		require.Same(t, got0, got1)
+
+		start := make(chan struct{})
+		done := make(chan struct{}, 3)
+		run := func(fn func()) {
+			go func() {
+				<-start
+				fn()
+				done <- struct{}{}
+			}()
+		}
+		run(func() { sp.Abort(nil) })
+		run(func() { sp.ReleaseCurrent(0) })
+		run(func() { sp.ReleaseCurrent(1) })
+		close(start)
+
+		timer := time.NewTimer(5 * time.Second)
+		for range 3 {
+			select {
+			case <-done:
+			case <-timer.C:
+				t.Fatalf("Abort and ReleaseCurrent did not finish at iteration %d", iteration)
+			}
+		}
+		timer.Stop()
+		require.Equal(t, int64(0), mp.CurrNB(), "iteration %d", iteration)
+	}
+}
+
 func TestPipelineSpoolAbortUnblocksSendBatchWaitingForFreeSlot(t *testing.T) {
 	mp := mpool.MustNewZeroNoFixed()
 	t.Cleanup(func() {

--- a/pkg/container/pSpool/sender_test.go
+++ b/pkg/container/pSpool/sender_test.go
@@ -375,6 +375,82 @@ func TestPipelineSpoolAbortWaitsForAllCurrentBroadcastReceivers(t *testing.T) {
 	require.Equal(t, int64(0), mp.CurrNB())
 }
 
+func TestPipelineSpoolSendBatchCopyFailureRestoresCapacity(t *testing.T) {
+	tests := []struct {
+		name      string
+		newVector func(*testing.T, *mpool.MPool) *vector.Vector
+	}{
+		{
+			name: "flat vector",
+			newVector: func(t *testing.T, mp *mpool.MPool) *vector.Vector {
+				vec := vector.NewVec(types.T_varchar.ToType())
+				require.NoError(t, vector.AppendBytes(vec, make([]byte, 2<<20), false, mp))
+				return vec
+			},
+		},
+		{
+			name: "const vector",
+			newVector: func(t *testing.T, mp *mpool.MPool) *vector.Vector {
+				vec, err := vector.NewConstBytes(types.T_varchar.ToType(), make([]byte, 2<<20), 1, mp)
+				require.NoError(t, err)
+				return vec
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dstMP, err := mpool.NewMPool("p-spool-copy-failure", 1<<20, mpool.NoFixed)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				mpool.DeleteMPool(dstMP)
+			})
+
+			srcMP := mpool.MustNewZeroNoFixed()
+			t.Cleanup(func() {
+				mpool.DeleteMPool(srcMP)
+			})
+			src := batch.NewWithSize(1)
+			src.Vecs[0] = test.newVector(t, srcMP)
+			src.SetRowCount(1)
+			t.Cleanup(func() {
+				src.Clean(srcMP)
+			})
+
+			sp := InitMyPipelineSpool(dstMP, 1)
+			t.Cleanup(func() {
+				sp.Abort(nil)
+			})
+
+			for range 3 {
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				done, err := sp.SendBatch(ctx, 0, src, nil)
+				cancel()
+				require.Error(t, err)
+				require.False(t, done)
+			}
+
+			require.Equal(t, cap(sp.freeShardPool), len(sp.freeShardPool))
+			require.Equal(t, cap(sp.freeShardPool), len(sp.cache.buffer.readyToUse))
+
+			small := newSpoolTestBatch(t, srcMP, 1)
+			t.Cleanup(func() {
+				small.Clean(srcMP)
+			})
+			done, err := sp.SendBatch(context.Background(), 0, small, nil)
+			require.NoError(t, err)
+			require.False(t, done)
+			got, info := sp.ReceiveBatch(0)
+			require.NoError(t, info)
+			require.Equal(t, 1, got.RowCount())
+			sp.ReleaseCurrent(0)
+
+			sp.Abort(nil)
+			require.Equal(t, int64(0), dstMP.CurrNB())
+		})
+	}
+}
+
 func newSpoolTestBatch(t *testing.T, mp *mpool.MPool, rows int) *batch.Batch {
 	t.Helper()
 	src := batch.NewWithSize(1)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25759
Fixes #25854

## What this PR does / why we need it:

This PR supersedes #25855 and closes two missing transitions in the same pSpool ownership state machine.

PipelineSpool independently pools message slots and cached batches. Every checkout must either be published to a receiver or rolled back, and every final release must detach the old owner before either pooled object becomes reusable.

This PR restores that lifecycle invariant on both paths:

- Failed admission: when batch copying fails, return the partially built batch and cache ID through the existing cache path, then return the unpublished message slot before propagating the original error.
- Successful final release: clear all slot data, error, cache, and reference metadata before returning the batch to the cache and publishing the slot to the free pool.
- Abort and late cleanup: reuse the same slot-clear operation so pending, current, broadcast, and cleanup-after-terminal paths cannot double-own or prematurely free a batch.

The successful release path adds no locks, goroutines, allocations, scans, atomic operations, or extra helper calls. It only performs the fixed-size slot clear required to transfer ownership. Copy-failure cleanup runs only on the error path.

Testing:

- pSpool full package, count 100
- pSpool full race suite, count 20
- focused race matrix, count 100, including 256 concurrent Abort and broadcast-release interleavings per run
- flat-vector and const-vector copy failures, repeated rollback, restored capacity, subsequent successful send, and final MPool cleanup
- connector, dispatch, and process full package tests
- connector, dispatch, and process terminal/abort race tests, count 10
- go build on pSpool and all direct consumers
- go vet on pSpool
- git diff check