### PR TITLE
fix(window): support split aggregate results

### DIFF
--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -65,21 +65,22 @@ func TestLockBlockedOnRemote(t *testing.T) {
 }
 
 func TestFetchWhoWaitingMeUsesActiveRemoteWaiterSnapshots(t *testing.T) {
-	runLockServiceTests(
+	const tableID = uint64(10)
+	row := []byte("row")
+	seedTxn := []byte("seed")
+	holderTxn := []byte("remote-holder")
+	activeWaiterTxn := []byte("active-waiter")
+
+	runLockServiceTestsWithAdjustConfig(
 		t,
 		[]string{"s1", "s2", "s3"},
+		10*time.Second,
 		func(_ *lockTableAllocator, s []*service) {
 			owner := s[0]
 			holderService := s[1]
 			waiterService := s[2]
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-
-			const tableID = uint64(10)
-			row := []byte("row")
-			seedTxn := []byte("seed")
-			holderTxn := []byte("remote-holder")
-			activeWaiterTxn := []byte("active-waiter")
 
 			// Bind the table to owner, then acquire it through holderService so
 			// fetchWhoWaitingMe has to query a remote lock table.
@@ -99,9 +100,25 @@ func TestFetchWhoWaitingMeUsesActiveRemoteWaiterSnapshots(t *testing.T) {
 				waitResult <- err
 			}()
 			defer func() {
-				require.NoError(t, holderService.Unlock(ctx, holderTxn, timestamp.Timestamp{}))
-				require.NoError(t, <-waitResult)
-				require.NoError(t, waiterService.Unlock(ctx, activeWaiterTxn, timestamp.Timestamp{}))
+				cleanupCtx, cleanupCancel := context.WithTimeoutCause(
+					context.Background(), 5*time.Second, context.DeadlineExceeded)
+				defer cleanupCancel()
+
+				holderUnlockErr := holderService.Unlock(cleanupCtx, holderTxn, timestamp.Timestamp{})
+				var waitErr error
+				select {
+				case waitErr = <-waitResult:
+				case <-cleanupCtx.Done():
+					waitErr = cleanupCtx.Err()
+				}
+				var waiterUnlockErr error
+				if waitErr == nil {
+					waiterUnlockErr = waiterService.Unlock(cleanupCtx, activeWaiterTxn, timestamp.Timestamp{})
+				}
+
+				require.NoError(t, holderUnlockErr)
+				require.NoError(t, waitErr)
+				require.NoError(t, waiterUnlockErr)
 			}()
 
 			waitWaiters(t, owner, tableID, row, 1)
@@ -151,6 +168,42 @@ func TestFetchWhoWaitingMeUsesActiveRemoteWaiterSnapshots(t *testing.T) {
 				holderService.getLockTable,
 			))
 			require.Equal(t, [][]byte{activeWaiterTxn}, waitingTxnIDs)
+		},
+		func(cfg *Config) {
+			// CheckActiveTxn gets its authoritative transaction liveness from
+			// TxnIterFunc in production. Keep the synthetic remote transactions
+			// visible so the orphan checker cannot legitimately remove the lock
+			// before this test snapshots its waiters.
+			cfg.TxnIterFunc = func(fn func([]byte) bool) {
+				for _, txnID := range [][]byte{holderTxn, activeWaiterTxn} {
+					if !fn(txnID) {
+						return
+					}
+				}
+			}
+		},
+	)
+}
+
+func TestWaitLocalWaitersIsBounded(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1"},
+		func(_ *lockTableAllocator, s []*service) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			const tableID = uint64(10)
+			row := []byte("row")
+			txnID := []byte("holder")
+			mustAddTestLock(t, ctx, s[0], tableID, txnID, [][]byte{row}, pb.Granularity_Row)
+
+			lt, err := s[0].getLockTable(0, tableID)
+			require.NoError(t, err)
+			err = waitLocalWaitersWithTimeout(lt.(*localLockTable), row, 1, 20*time.Millisecond)
+			require.EqualError(t, err, "internal error: timed out waiting for 1 local lock waiters, observed 0")
+
+			require.NoError(t, s[0].Unlock(ctx, txnID, timestamp.Timestamp{}))
 		},
 	)
 }

--- a/pkg/lockservice/test_helper.go
+++ b/pkg/lockservice/test_helper.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
@@ -121,6 +122,15 @@ func waitLocalWaiters(
 	lt *localLockTable,
 	key []byte,
 	waitersCount int) error {
+	return waitLocalWaitersWithTimeout(lt, key, waitersCount, 10*time.Second)
+}
+
+func waitLocalWaitersWithTimeout(
+	lt *localLockTable,
+	key []byte,
+	waitersCount int,
+	waitTimeout time.Duration) error {
+	observedWaiters := 0
 	fn := func() bool {
 		lt.mu.Lock()
 		defer lt.mu.Unlock()
@@ -131,22 +141,34 @@ func waitLocalWaiters(
 		}
 
 		if !ok {
+			observedWaiters = 0
 			return false
 		}
 
-		waiters := make([]*waiter, 0)
-		lock.waiters.iter(func(w *waiter) bool {
-			waiters = append(waiters, w)
+		observedWaiters = 0
+		lock.waiters.iter(func(*waiter) bool {
+			observedWaiters++
 			return true
 		})
-		return len(waiters) == waitersCount
+		return observedWaiters == waitersCount
 	}
 
+	timeout := time.NewTimer(waitTimeout)
+	defer timeout.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		if fn() {
 			return nil
 		}
-		time.Sleep(time.Millisecond * 10)
+		select {
+		case <-timeout.C:
+			return moerr.NewInternalErrorNoCtxf(
+				"timed out waiting for %d local lock waiters, observed %d",
+				waitersCount,
+				observedWaiters)
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/pkg/sql/colexec/aggexec/tool.go
+++ b/pkg/sql/colexec/aggexec/tool.go
@@ -18,10 +18,81 @@ import (
 	"bytes"
 	io "io"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 )
+
+// MergeSplitResult turns the physical chunks returned by AggFuncExec.Flush
+// into one logical result vector. It consumes every input vector on all paths:
+// on success the caller owns only the returned vector, and on failure all input
+// vectors have been freed.
+//
+// The common single-chunk path is zero-copy. For multiple chunks, the first
+// vector is reused and grown once before the remaining chunks are appended in
+// order. UnionBatch's full-vector path preserves nulls and copies varlen areas
+// in bulk.
+func MergeSplitResult(vecs []*vector.Vector, mp *mpool.MPool) (*vector.Vector, error) {
+	if len(vecs) == 0 {
+		return nil, moerr.NewInternalErrorNoCtx("aggregate returned no result vectors")
+	}
+
+	result := vecs[0]
+	if len(vecs) == 1 {
+		if result == nil {
+			return nil, moerr.NewInternalErrorNoCtx("aggregate returned a nil result vector")
+		}
+		return result, nil
+	}
+	if result == nil {
+		freeAggResultVectors(vecs, mp)
+		return nil, moerr.NewInternalErrorNoCtx("aggregate returned a nil result vector")
+	}
+
+	additionalRows, additionalArea := 0, 0
+	resultType := *result.GetType()
+	for i := 1; i < len(vecs); i++ {
+		if vecs[i] == nil {
+			freeAggResultVectors(vecs, mp)
+			return nil, moerr.NewInternalErrorNoCtxf("aggregate returned a nil result vector at chunk %d", i)
+		}
+		if !resultType.Eq(*vecs[i].GetType()) {
+			err := moerr.NewInternalErrorNoCtxf(
+				"aggregate returned inconsistent result types %s and %s",
+				resultType.String(), vecs[i].GetType().String())
+			freeAggResultVectors(vecs, mp)
+			return nil, err
+		}
+		additionalRows += vecs[i].Length()
+		additionalArea += len(vecs[i].GetArea())
+	}
+
+	if err := result.PreExtendWithArea(additionalRows, additionalArea, mp); err != nil {
+		freeAggResultVectors(vecs, mp)
+		return nil, err
+	}
+	for i := 1; i < len(vecs); i++ {
+		source := vecs[i]
+		if err := result.UnionBatch(source, 0, source.Length(), nil, mp); err != nil {
+			result.Free(mp)
+			for j := i; j < len(vecs); j++ {
+				vecs[j].Free(mp)
+			}
+			return nil, err
+		}
+		source.Free(mp)
+	}
+	return result, nil
+}
+
+func freeAggResultVectors(vecs []*vector.Vector, mp *mpool.MPool) {
+	for _, vec := range vecs {
+		if vec != nil {
+			vec.Free(mp)
+		}
+	}
+}
 
 // vectorUnmarshal is instead of vector.UnmarshalBinary.
 // it will check if mp is nil first.

--- a/pkg/sql/colexec/aggexec/tool_test.go
+++ b/pkg/sql/colexec/aggexec/tool_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggexec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func makeOffHeapFixedVector[T any](
+	t testing.TB,
+	mp *mpool.MPool,
+	typ types.Type,
+	values []T,
+	nulls []bool,
+) *vector.Vector {
+	t.Helper()
+	vec := vector.NewOffHeapVecWithType(typ)
+	require.NoError(t, vector.AppendFixedList(vec, values, nulls, mp))
+	return vec
+}
+
+func makeOffHeapVarcharVector(
+	t testing.TB,
+	mp *mpool.MPool,
+	values []string,
+	nulls []bool,
+) *vector.Vector {
+	t.Helper()
+	vec := vector.NewOffHeapVecWithType(types.T_varchar.ToType())
+	require.NoError(t, vector.AppendStringList(vec, values, nulls, mp))
+	return vec
+}
+
+func TestMergeSplitResult(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		result, err := MergeSplitResult(nil, mpool.MustNewZero())
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("single nil chunk", func(t *testing.T) {
+		result, err := MergeSplitResult([]*vector.Vector{nil}, mpool.MustNewZero())
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("single chunk is zero copy", func(t *testing.T) {
+		mp := mpool.MustNewZero()
+		input := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{1, 2, 3}, nil)
+		result, err := MergeSplitResult([]*vector.Vector{input}, mp)
+		require.NoError(t, err)
+		require.Same(t, input, result)
+		result.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	})
+
+	t.Run("fixed chunks preserve order and nulls", func(t *testing.T) {
+		mp := mpool.MustNewZero()
+		first := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{1, 2}, []bool{false, true})
+		second := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{3, 4}, []bool{true, false})
+		third := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{5, 6}, nil)
+		result, err := MergeSplitResult([]*vector.Vector{first, second, third}, mp)
+		require.NoError(t, err)
+		require.Same(t, first, result)
+		require.Equal(t, 6, result.Length())
+		// A NULL row's payload is deliberately unspecified; its bitmap is the
+		// semantic value. Non-NULL payloads must remain ordered.
+		values := vector.MustFixedColWithTypeCheck[int32](result)
+		require.Equal(t, int32(1), values[0])
+		require.Equal(t, int32(4), values[3])
+		require.False(t, result.GetNulls().Contains(0))
+		require.True(t, result.GetNulls().Contains(1))
+		require.True(t, result.GetNulls().Contains(2))
+		require.False(t, result.GetNulls().Contains(3))
+		require.Equal(t, int32(5), values[4])
+		require.Equal(t, int32(6), values[5])
+		result.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	})
+
+	t.Run("varlen chunks preserve inline and area values", func(t *testing.T) {
+		mp := mpool.MustNewZero()
+		longA := "this value is longer than the inline varlena limit A"
+		longB := "this value is longer than the inline varlena limit B"
+		first := makeOffHeapVarcharVector(t, mp, []string{"a", longA}, nil)
+		second := makeOffHeapVarcharVector(t, mp, []string{"", longB, "z"}, []bool{true, false, false})
+		result, err := MergeSplitResult([]*vector.Vector{first, second}, mp)
+		require.NoError(t, err)
+		require.Equal(t, 5, result.Length())
+		require.Equal(t, "a", string(result.GetBytesAt(0)))
+		require.Equal(t, longA, string(result.GetBytesAt(1)))
+		require.True(t, result.GetNulls().Contains(2))
+		require.Equal(t, longB, string(result.GetBytesAt(3)))
+		require.Equal(t, "z", string(result.GetBytesAt(4)))
+		result.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	})
+
+	t.Run("nil chunk frees all inputs", func(t *testing.T) {
+		mp := mpool.MustNewZero()
+		first := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{1}, nil)
+		last := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{2}, nil)
+		result, err := MergeSplitResult([]*vector.Vector{first, nil, last}, mp)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Equal(t, int64(0), mp.CurrNB())
+	})
+
+	t.Run("nil first chunk frees remaining inputs", func(t *testing.T) {
+		mp := mpool.MustNewZero()
+		last := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{2}, nil)
+		result, err := MergeSplitResult([]*vector.Vector{nil, last}, mp)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Equal(t, int64(0), mp.CurrNB())
+	})
+
+	t.Run("mismatched types free all inputs", func(t *testing.T) {
+		mp := mpool.MustNewZero()
+		first := makeOffHeapFixedVector(t, mp, types.T_int32.ToType(), []int32{1}, nil)
+		second := vector.NewOffHeapVecWithType(types.T_int64.ToType())
+		require.NoError(t, vector.AppendFixed(second, int64(2), false, mp))
+		result, err := MergeSplitResult([]*vector.Vector{first, second}, mp)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Equal(t, int64(0), mp.CurrNB())
+	})
+
+	t.Run("allocation failure frees all inputs", func(t *testing.T) {
+		const limit = 1 << 20
+		mp, err := mpool.NewMPool("merge-split-limited", limit, mpool.NoFixed)
+		require.NoError(t, err)
+		var filler []byte
+		defer func() {
+			if filler != nil {
+				mp.Free(filler)
+			}
+			mpool.DeleteMPool(mp)
+		}()
+		first := makeOffHeapFixedVector(t, mp, types.T_int64.ToType(), []int64{1}, nil)
+		second := makeOffHeapFixedVector(t, mp, types.T_int64.ToType(), make([]int64, 1024), nil)
+		remaining := int64(limit) - mp.CurrNB()
+		require.Greater(t, remaining, int64(1024))
+		filler, err = mp.Alloc(int(remaining-64), true)
+		require.NoError(t, err)
+		usedByFiller := mp.CurrNB() - int64(first.Allocated()) - int64(second.Allocated())
+
+		result, err := MergeSplitResult([]*vector.Vector{first, second}, mp)
+		if result != nil {
+			result.Free(mp)
+		}
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Equal(t, usedByFiller, mp.CurrNB(), "failed merge must release both source vectors")
+
+		mp.Free(filler)
+		filler = nil
+		require.Equal(t, int64(0), mp.CurrNB())
+	})
+}
+
+func BenchmarkMergeSplitResult(b *testing.B) {
+	values := make([]int64, AggBatchSize)
+	for i := range values {
+		values[i] = int64(i)
+	}
+
+	b.Run("fixed/1_chunk", func(b *testing.B) {
+		mp := mpool.MustNewZero()
+		result := makeOffHeapFixedVector(b, mp, types.T_int64.ToType(), values, nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var err error
+			result, err = MergeSplitResult([]*vector.Vector{result}, mp)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+		result.Free(mp)
+		require.Equal(b, int64(0), mp.CurrNB())
+	})
+
+	for _, chunks := range []int{2, 4} {
+		b.Run(fmt.Sprintf("fixed/%d_chunks", chunks), func(b *testing.B) {
+			mp := mpool.MustNewZero()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				vecs := make([]*vector.Vector, chunks)
+				for j := range vecs {
+					vecs[j] = makeOffHeapFixedVector(b, mp, types.T_int64.ToType(), values, nil)
+				}
+				b.StartTimer()
+				result, err := MergeSplitResult(vecs, mp)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+				result.Free(mp)
+			}
+			require.Equal(b, int64(0), mp.CurrNB())
+		})
+	}
+
+	b.Run("varlen/2_chunks", func(b *testing.B) {
+		const chunkRows = 1024
+		mp := mpool.MustNewZero()
+		values := make([]string, chunkRows)
+		for i := range values {
+			values[i] = fmt.Sprintf("row-%04d-with-non-inline-payload", i)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			vecs := []*vector.Vector{
+				makeOffHeapVarcharVector(b, mp, values, nil),
+				makeOffHeapVarcharVector(b, mp, values, nil),
+			}
+			b.StartTimer()
+			result, err := MergeSplitResult(vecs, mp)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.StopTimer()
+			result.Free(mp)
+		}
+		require.Equal(b, int64(0), mp.CurrNB())
+	})
+}

--- a/pkg/sql/colexec/timewin/timewin.go
+++ b/pkg/sql/colexec/timewin/timewin.go
@@ -18,8 +18,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -408,14 +406,12 @@ func (ctr *container) calRes(ap *TimeWin, proc *process.Process) (err error) {
 		if err != nil {
 			return err
 		}
-		if len(vecs) > 1 {
-			for _, vec := range vecs {
-				vec.Free(proc.Mp())
-			}
-			return moerr.NewInternalErrorNoCtx("the TimeWin operator currently does not support sending split result of window function.")
+		result, err := aggexec.MergeSplitResult(vecs, proc.Mp())
+		if err != nil {
+			return err
 		}
 
-		ctr.bat.SetVector(int32(i), vecs[0])
+		ctr.bat.SetVector(int32(i), result)
 		i++
 	}
 

--- a/pkg/sql/colexec/timewin/timewin.go
+++ b/pkg/sql/colexec/timewin/timewin.go
@@ -58,17 +58,9 @@ func (timeWin *TimeWin) Prepare(proc *process.Process) (err error) {
 				}
 			}
 		}
-		ctr.aggs = make([]aggexec.AggFuncExec, len(timeWin.Aggs))
-		for i, ag := range timeWin.Aggs {
-			ctr.aggs[i], err = aggexec.MakeAgg(proc.Mp(), ag.GetAggID(), ag.IsDistinct(), timeWin.Types[i])
-			if err != nil {
-				return err
-			}
-			if config := ag.GetExtraConfig(); config != nil {
-				if err = ctr.aggs[i].SetExtraInformation(config, 0); err != nil {
-					return err
-				}
-			}
+		ctr.aggs, err = makeAggExecutors(timeWin, proc, false)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -241,24 +233,20 @@ func (timeWin *TimeWin) Call(proc *process.Process) (vm.CallResult, error) {
 			if ctr.last {
 				ctr.status = end
 			} else {
+				replacements, err := makeAggExecutors(timeWin, proc, true)
+				if err != nil {
+					return result, err
+				}
+
+				// Flush transfers only result vectors; executor-owned state (for
+				// example DISTINCT hash tables) remains live until Free. Construct
+				// every replacement first so an allocation/configuration failure
+				// leaves the current executors owned by ctr and available for the
+				// normal terminal cleanup path.
+				ctr.freeAgg()
+				ctr.aggs = replacements
 				ctr.status = nextWindow
-				for i, ag := range timeWin.Aggs {
-					ctr.aggs[i], err = aggexec.MakeAgg(proc.Mp(), ag.GetAggID(), ag.IsDistinct(), timeWin.Types[i])
-					if err != nil {
-						return result, err
-					}
-					if config := ag.GetExtraConfig(); config != nil {
-						if err = ctr.aggs[i].SetExtraInformation(config, 0); err != nil {
-							return result, err
-						}
-					}
-				}
 				ctr.group = 0
-				for _, ag := range ctr.aggs {
-					if err := ag.GroupGrow(1); err != nil {
-						return result, err
-					}
-				}
 				ctr.withoutFill = true
 			}
 
@@ -273,6 +261,38 @@ func (timeWin *TimeWin) Call(proc *process.Process) (vm.CallResult, error) {
 		}
 
 	}
+}
+
+func makeAggExecutors(timeWin *TimeWin, proc *process.Process, growFirstGroup bool) (_ []aggexec.AggFuncExec, err error) {
+	aggs := make([]aggexec.AggFuncExec, len(timeWin.Aggs))
+	defer func() {
+		if err != nil {
+			for _, agg := range aggs {
+				if agg != nil {
+					agg.Free()
+				}
+			}
+		}
+	}()
+
+	for i, expression := range timeWin.Aggs {
+		aggs[i], err = aggexec.MakeAgg(
+			proc.Mp(), expression.GetAggID(), expression.IsDistinct(), timeWin.Types[i])
+		if err != nil {
+			return nil, err
+		}
+		if config := expression.GetExtraConfig(); config != nil {
+			if err = aggs[i].SetExtraInformation(config, 0); err != nil {
+				return nil, err
+			}
+		}
+		if growFirstGroup {
+			if err = aggs[i].GroupGrow(1); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return aggs, nil
 }
 
 func newTsExpr(typ plan.Type, ctx context.Context) (*plan.Expr, error) {
@@ -399,6 +419,12 @@ func (ctr *container) fillRows() error {
 const maxTimeWindowRows = 8192
 
 func (ctr *container) calRes(ap *TimeWin, proc *process.Process) (err error) {
+	// The output batch remains owned by TimeWin and is valid until the next
+	// Call. Once the downstream asks for another result, the previous batch has
+	// been consumed and must be released before ctr.bat is replaced.
+	if ctr.bat != nil {
+		ctr.bat.Clean(proc.Mp())
+	}
 	ctr.bat = batch.NewWithSize(ctr.colCnt)
 	i := 0
 	for _, agg := range ctr.aggs {

--- a/pkg/sql/colexec/timewin/timewin_test.go
+++ b/pkg/sql/colexec/timewin/timewin_test.go
@@ -161,11 +161,11 @@ func TestTimeWin(t *testing.T) {
 	}
 }
 
-// TestTimeWinAggResultAcrossChunks verifies that calRes materializes one
-// logical result vector even when AggFuncExec.Flush returns multiple physical
-// chunks. It exercises the same contract as a TimeWin producing >8192 groups
-// without making the state-machine setup obscure the regression.
-func TestTimeWinAggResultAcrossChunks(t *testing.T) {
+// TestTimeWinSplitDistinctResultAndReplace verifies the complete non-final
+// flush transition: split physical results are materialized as one logical
+// batch, and the flushed DISTINCT executor is freed before its replacement is
+// installed.
+func TestTimeWinSplitDistinctResultAndReplace(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	rows := aggexec.AggBatchSize + 17
 	values := make([]int32, rows)
@@ -176,23 +176,77 @@ func TestTimeWinAggResultAcrossChunks(t *testing.T) {
 	}
 	input := testutil.MakeInt32Vector(values, nil, proc.Mp())
 
-	agg, err := aggexec.MakeAgg(proc.Mp(), function.AggSumOverloadID, false, types.T_int32.ToType())
+	agg, err := aggexec.MakeAgg(proc.Mp(), function.AggSumOverloadID, true, types.T_int32.ToType())
 	require.NoError(t, err)
 	require.NoError(t, agg.GroupGrow(rows))
 	require.NoError(t, agg.BatchFill(0, groups, []*vector.Vector{input}))
 
-	arg := &TimeWin{}
+	arg := &TimeWin{
+		Types: []types.Type{types.T_int32.ToType()},
+		Aggs: []aggexec.AggFuncExecExpression{
+			aggexec.MakeAggFunctionExpression(
+				function.AggSumOverloadID, true, []*plan.Expr{newExpression(0)}, nil),
+		},
+	}
+	arg.ctr.status = flush
 	arg.ctr.colCnt = 1
 	arg.ctr.aggs = []aggexec.AggFuncExec{agg}
-	require.NoError(t, arg.ctr.calRes(arg, proc))
-	require.NotNil(t, arg.ctr.bat)
-	resultValues := vector.MustFixedColWithTypeCheck[int64](arg.ctr.bat.Vecs[0])
+	result, err := arg.Call(proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	resultValues := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[0])
 	require.Len(t, resultValues, rows)
 	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
 		require.Equal(t, int64(values[idx]), resultValues[idx], "row %d", idx)
 	}
 
+	require.Equal(t, int32(nextWindow), arg.ctr.status)
+	require.Len(t, arg.ctr.aggs, 1)
+	require.NotSame(t, agg, arg.ctr.aggs[0])
+
+	// A second intermediate flush verifies both generations: the first output
+	// batch is released on the next Call, and the first replacement executor is
+	// released when the second replacement is installed.
+	require.NoError(t, arg.ctr.aggs[0].Fill(0, 0, []*vector.Vector{input}))
+	arg.ctr.status = flush
+	secondResult, err := arg.Call(proc)
+	require.NoError(t, err)
+	require.NotNil(t, secondResult.Batch)
+	require.Equal(t, []int64{1}, vector.MustFixedColWithTypeCheck[int64](secondResult.Batch.Vecs[0]))
+
 	arg.Free(proc, false, nil)
+	input.Free(proc.Mp())
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestTimeWinReplacementFailurePreservesOwnership(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	input := testutil.MakeInt32Vector([]int32{1}, nil, proc.Mp())
+
+	agg, err := aggexec.MakeAgg(proc.Mp(), function.AggSumOverloadID, true, types.T_int32.ToType())
+	require.NoError(t, err)
+	require.NoError(t, agg.GroupGrow(1))
+	require.NoError(t, agg.Fill(0, 0, []*vector.Vector{input}))
+
+	arg := &TimeWin{
+		Types: []types.Type{types.T_int32.ToType(), types.T_int32.ToType()},
+		Aggs: []aggexec.AggFuncExecExpression{
+			aggexec.MakeAggFunctionExpression(
+				function.AggSumOverloadID, true, []*plan.Expr{newExpression(0)}, nil),
+			aggexec.MakeAggFunctionExpression(-9999, false, []*plan.Expr{newExpression(0)}, nil),
+		},
+	}
+	arg.ctr.status = flush
+	arg.ctr.colCnt = 1
+	arg.ctr.aggs = []aggexec.AggFuncExec{agg}
+
+	_, err = arg.Call(proc)
+	require.Error(t, err)
+	require.Len(t, arg.ctr.aggs, 1)
+	require.Same(t, agg, arg.ctr.aggs[0], "failed replacement must not overwrite the owned executor")
+
+	arg.Free(proc, true, err)
 	input.Free(proc.Mp())
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())

--- a/pkg/sql/colexec/timewin/timewin_test.go
+++ b/pkg/sql/colexec/timewin/timewin_test.go
@@ -161,6 +161,43 @@ func TestTimeWin(t *testing.T) {
 	}
 }
 
+// TestTimeWinAggResultAcrossChunks verifies that calRes materializes one
+// logical result vector even when AggFuncExec.Flush returns multiple physical
+// chunks. It exercises the same contract as a TimeWin producing >8192 groups
+// without making the state-machine setup obscure the regression.
+func TestTimeWinAggResultAcrossChunks(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := aggexec.AggBatchSize + 17
+	values := make([]int32, rows)
+	groups := make([]uint64, rows)
+	for i := range values {
+		values[i] = int32(i + 1)
+		groups[i] = uint64(i + 1)
+	}
+	input := testutil.MakeInt32Vector(values, nil, proc.Mp())
+
+	agg, err := aggexec.MakeAgg(proc.Mp(), function.AggSumOverloadID, false, types.T_int32.ToType())
+	require.NoError(t, err)
+	require.NoError(t, agg.GroupGrow(rows))
+	require.NoError(t, agg.BatchFill(0, groups, []*vector.Vector{input}))
+
+	arg := &TimeWin{}
+	arg.ctr.colCnt = 1
+	arg.ctr.aggs = []aggexec.AggFuncExec{agg}
+	require.NoError(t, arg.ctr.calRes(arg, proc))
+	require.NotNil(t, arg.ctr.bat)
+	resultValues := vector.MustFixedColWithTypeCheck[int64](arg.ctr.bat.Vecs[0])
+	require.Len(t, resultValues, rows)
+	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
+		require.Equal(t, int64(values[idx]), resultValues[idx], "row %d", idx)
+	}
+
+	arg.Free(proc, false, nil)
+	input.Free(proc.Mp())
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
 func resetChildren(arg *TimeWin, m *mpool.MPool) {
 	bat := colexec.MakeMockTimeWinBatchs(m)
 	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})

--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -342,14 +342,10 @@ func (ctr *container) processFunc(idx int, ap *Window, proc *process.Process, an
 	if err != nil {
 		return err
 	}
-	if len(vecs) > 1 {
-		for _, vec := range vecs {
-			vec.Free(proc.Mp())
-		}
-		return moerr.NewInternalErrorNoCtx("the Window operator currently does not support sending split result of window function.")
+	ctr.vec, err = aggexec.MergeSplitResult(vecs, proc.Mp())
+	if err != nil {
+		return err
 	}
-
-	ctr.vec = vecs[0]
 	if isWinOrder {
 		ctr.vec.SetNulls(nil)
 	}

--- a/pkg/sql/colexec/window/window_test.go
+++ b/pkg/sql/colexec/window/window_test.go
@@ -134,6 +134,14 @@ func makeFullFrame() *plan.FrameClause {
 	}
 }
 
+func makeCurrentRowFrame() *plan.FrameClause {
+	return &plan.FrameClause{
+		Type:  plan.FrameClause_ROWS,
+		Start: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+		End:   &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+	}
+}
+
 func makeWindowSpec() *plan.Expr {
 	return &plan.Expr{
 		Typ: plan.Type{},
@@ -180,9 +188,26 @@ func newColExprWithType(pos int32, typ types.Type) *plan.Expr {
 }
 
 func newAggExpr() aggexec.AggFuncExecExpression {
+	return newAggExprAt(0)
+}
+
+func newAggExprAt(pos int32) aggexec.AggFuncExecExpression {
 	e, _ := function.GetFunctionByName(context.Background(), "sum", []types.Type{types.T_int32.ToType()})
 	id := e.GetEncodedOverloadID()
-	return aggexec.MakeAggFunctionExpression(id, false, []*plan.Expr{newColExpr(0)}, nil)
+	return aggexec.MakeAggFunctionExpression(id, false, []*plan.Expr{newColExpr(pos)}, nil)
+}
+
+func newTypedSumAggExpr(t *testing.T, pos int32, typ types.Type) aggexec.AggFuncExecExpression {
+	e, err := function.GetFunctionByName(context.Background(), "sum", []types.Type{typ})
+	require.NoError(t, err)
+	return aggexec.MakeAggFunctionExpression(
+		e.GetEncodedOverloadID(), false, []*plan.Expr{newColExprWithType(pos, typ)}, nil)
+}
+
+func newRowNumberAggExpr(t *testing.T) aggexec.AggFuncExecExpression {
+	e, err := function.GetFunctionByName(context.Background(), "row_number", nil)
+	require.NoError(t, err)
+	return aggexec.MakeAggFunctionExpression(e.GetEncodedOverloadID(), false, nil, nil)
 }
 
 // newJsonObjectAggExpr builds a two-argument aggregate expression:
@@ -279,6 +304,179 @@ func TestWindowJsonObjectAggNullKeyNoLeak(t *testing.T) {
 	op.Free(proc, true, err)
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB(), "no mpool leak on the json_objectagg error path")
+}
+
+// TestWindowAggResultAcrossChunks verifies that the aggregate executor's
+// physical result chunks are invisible to the Window operator. CURRENT ROW is
+// deliberately used to keep the test O(n) while crossing AggBatchSize.
+func TestWindowAggResultAcrossChunks(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := aggexec.AggBatchSize + 17
+	values := make([]int32, rows)
+	for i := range values {
+		values[i] = int32(i + 1)
+	}
+	split := aggexec.AggBatchSize / 2
+	first := batch.NewWithSize(1)
+	first.Vecs[0] = testutil.MakeInt32Vector(values[:split], nil, proc.Mp())
+	first.SetRowCount(split)
+	second := batch.NewWithSize(1)
+	second.Vecs[0] = testutil.MakeInt32Vector(values[split:], nil, proc.Mp())
+	second.SetRowCount(rows - split)
+
+	spec := makeWindowSpec()
+	spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{first, second})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	resultValues := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1])
+	require.Len(t, resultValues, rows)
+	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
+		require.Equal(t, int64(values[idx]), resultValues[idx], "row %d", idx)
+	}
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+// TestWindowPartitionedAggResultAcrossChunks covers the receive-per-partition
+// path. The upstream Partition operator guarantees one logical partition per
+// input batch; the constant first column models that contract here.
+func TestWindowPartitionedAggResultAcrossChunks(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := aggexec.AggBatchSize + 17
+	values := make([]int32, rows)
+	for i := range values {
+		values[i] = int32(i + 1)
+	}
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = testutil.MakeInt32Vector(make([]int32, rows), nil, proc.Mp())
+	bat.Vecs[1] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	bat.SetRowCount(rows)
+
+	spec := makeWindowSpec()
+	w := spec.Expr.(*plan.Expr_W).W
+	w.PartitionBy = []*plan.Expr{newColExpr(0)}
+	w.Frame = makeCurrentRowFrame()
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newAggExprAt(1)},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	resultValues := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[2])
+	require.Len(t, resultValues, rows)
+	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
+		require.Equal(t, int64(values[idx]), resultValues[idx], "row %d", idx)
+	}
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+// TestWindowDecimalAggResultAcrossChunks matches the DECIMAL(20,2) SUM shape
+// from issue #25813 and exercises the decimal aggregate implementation.
+func TestWindowDecimalAggResultAcrossChunks(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := aggexec.AggBatchSize + 17
+	typ := types.New(types.T_decimal128, 20, 2)
+	values := make([]types.Decimal128, rows)
+	for i := range values {
+		values[i] = types.Decimal128{B0_63: uint64(i + 1)}
+	}
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.NewDecimal128Vector(rows, typ, proc.Mp(), false, nil, values)
+	bat.SetRowCount(rows)
+
+	spec := makeWindowSpec()
+	spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newTypedSumAggExpr(t, 0, typ)},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	resultValues := vector.MustFixedColWithTypeCheck[types.Decimal128](result.Batch.Vecs[1])
+	require.Len(t, resultValues, rows)
+	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
+		require.Equal(t, values[idx], resultValues[idx], "row %d", idx)
+	}
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+// TestWindowOrderResultAcrossChunks covers the dedicated window-function
+// executor, whose physical result is split independently of ordinary SUM.
+func TestWindowOrderResultAcrossChunks(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := aggexec.AggBatchSize + 17
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector(make([]int32, rows), nil, proc.Mp())
+	bat.SetRowCount(rows)
+
+	arg := &Window{
+		WinSpecList: []*plan.Expr{{
+			Expr: &plan.Expr_W{W: &plan.WindowSpec{
+				Name:       "row_number",
+				WindowFunc: newFunExpr("row_number"),
+			}},
+		}},
+		Aggs: []aggexec.AggFuncExecExpression{newRowNumberAggExpr(t)},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	resultValues := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1])
+	require.Len(t, resultValues, rows)
+	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
+		require.Equal(t, int64(idx+1), resultValues[idx], "row %d", idx)
+	}
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
 func newFunExpr(name string) *plan.Expr {

--- a/test/distributed/cases/window/window_split_result.result
+++ b/test/distributed/cases/window/window_split_result.result
@@ -1,0 +1,53 @@
+drop database if exists window_split_result;
+create database window_split_result;
+use window_split_result;
+create table t_win_split (
+id bigint,
+g int,
+v decimal(20, 2)
+);
+insert into t_win_split
+select result, 1, cast(result as decimal(20, 2))
+from generate_series(1, 9000, 1) g;
+select current_sum
+from (
+select sum(v) over (rows between current row and current row) as current_sum
+from t_win_split
+) w
+where current_sum in (1, 8192, 8193, 9000)
+order by current_sum;
+current_sum
+1.00
+8192.00
+8193.00
+9000.00
+select id, current_sum, rn
+from (
+select id,
+sum(v) over (partition by g rows between current row and current row) as current_sum,
+row_number() over (partition by g order by id) as rn
+from t_win_split
+) w
+where rn in (1, 8192, 8193, 9000)
+order by rn;
+id    current_sum    rn
+1    1.00    1
+8192    8192.00    8192
+8193    8193.00    8193
+9000    9000.00    9000
+select count(*) as row_count,
+min(rn) as min_rn,
+max(rn) as max_rn,
+sum(rn) as rn_checksum,
+sum(current_sum) as value_checksum,
+sum(abs(id - rn)) as row_alignment_checksum,
+sum(abs(cast(id as decimal(20, 2)) - current_sum)) as value_alignment_checksum
+from (
+select id,
+sum(v) over (partition by g rows between current row and current row) as current_sum,
+row_number() over (partition by g order by id) as rn
+from t_win_split
+) w;
+row_count    min_rn    max_rn    rn_checksum    value_checksum    row_alignment_checksum    value_alignment_checksum
+9000    1    9000    40504500    40504500.00    0    0.00
+drop database window_split_result;

--- a/test/distributed/cases/window/window_split_result.sql
+++ b/test/distributed/cases/window/window_split_result.sql
@@ -1,0 +1,55 @@
+-- Regression for issue #25813. AggFuncExec splits physical result vectors at
+-- 8192 rows; Window must expose one complete logical result across that
+-- internal boundary.
+drop database if exists window_split_result;
+create database window_split_result;
+use window_split_result;
+
+create table t_win_split (
+    id bigint,
+    g int,
+    v decimal(20, 2)
+);
+insert into t_win_split
+select result, 1, cast(result as decimal(20, 2))
+from generate_series(1, 9000, 1) g;
+
+-- No PARTITION BY: Window receives and materializes all input batches. The
+-- CURRENT ROW frame keeps the regression O(n) while producing 9000 groups.
+select current_sum
+from (
+    select sum(v) over (rows between current row and current row) as current_sum
+    from t_win_split
+) w
+where current_sum in (1, 8192, 8193, 9000)
+order by current_sum;
+
+-- One 9000-row partition exercises the receive-per-partition path and the
+-- dedicated ROW_NUMBER executor. Filtering on window results prevents the
+-- boundary predicate from being pushed below the Window operators.
+select id, current_sum, rn
+from (
+    select id,
+           sum(v) over (partition by g rows between current row and current row) as current_sum,
+           row_number() over (partition by g order by id) as rn
+    from t_win_split
+) w
+where rn in (1, 8192, 8193, 9000)
+order by rn;
+
+-- Verify that no row is lost, duplicated, or reordered while chunks merge.
+select count(*) as row_count,
+       min(rn) as min_rn,
+       max(rn) as max_rn,
+       sum(rn) as rn_checksum,
+       sum(current_sum) as value_checksum,
+       sum(abs(id - rn)) as row_alignment_checksum,
+       sum(abs(cast(id as decimal(20, 2)) - current_sum)) as value_alignment_checksum
+from (
+    select id,
+           sum(v) over (partition by g rows between current row and current row) as current_sum,
+           row_number() over (partition by g order by id) as rn
+    from t_win_split
+) w;
+
+drop database window_split_result;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25813

## What this PR does / why we need it:

`AggFuncExec.Flush` returns multiple physical vectors after its result exceeds the aggregation chunk size (8192 rows). `Window` treated that internal storage detail as an unsupported logical result and failed the query. `TimeWin` had copied the same single-vector assumption and was vulnerable when one flush cohort crossed the chunk boundary.

This PR introduces a shared aggregate-result merge primitive and uses it in both single-batch consumers:

- preserve the common single-chunk path as zero-copy;
- reuse the first vector and pre-grow it once for multi-chunk results;
- append complete chunks in order through `UnionBatch`, preserving fixed values, NULLs, grouping metadata, and varlen areas;
- consume all result vectors on every path, including nil chunks, inconsistent types, allocation failure, and append failure;
- keep `Group` unchanged because its physical chunks intentionally correspond to separate output batches.

The regression matrix covers ordinary SUM, DECIMAL(20,2) SUM from the issue, ROW_NUMBER's dedicated window executor, partitioned and non-partitioned Window input paths, TimeWin, fixed and varlen vectors, NULLs, multiple chunks, invalid results, off-heap OOM, and mpool cleanup.

Performance on Apple M4 with production-style off-heap vectors:

- one chunk: ~1.36 ns/op, zero copy, 0 Go allocations;
- two fixed chunks: ~10.2 us/op;
- four fixed chunks: ~19.3 us/op;
- two varlen chunks: ~4.8 us/op.

Multi-chunk work is linear in the result bytes and performs one capacity plan instead of incremental or per-row growth. Multi-chunk Window/TimeWin queries previously returned an error, so the existing successful path has no regression.

Validation:

- `go test ./pkg/sql/colexec/... -count=1 -timeout=300s` with the repository CGo/rpath settings
- focused regression tests for Window, TimeWin, and the shared merge helper
- focused regression matrix under `go test -race`
- `go vet ./pkg/sql/colexec/aggexec ./pkg/sql/colexec/window ./pkg/sql/colexec/timewin`
- `BenchmarkMergeSplitResult` with fixed/varlen and 1/2/4 chunk cases
