### PR TITLE
fix(pSpool): clear ownership before recycling slots

### DIFF
--- a/pkg/container/pSpool/sender.go
+++ b/pkg/container/pSpool/sender.go
@@ -334,8 +334,16 @@ func (ps *PipelineSpool) releaseCurrentLocked(idx int) {
 			if ps.cleanupDone {
 				ps.cleanSlotLocked(last)
 			} else {
-				ps.cache.CacheBatch(
-					ps.shardPool[last].useCache, ps.shardPool[last].cacheID, ps.shardPool[last].dataContent)
+				// The slot and batch pools have independent reuse orders, so a
+				// returned batch may be assigned to a different slot immediately.
+				// Detach the batch before either object is republished; otherwise
+				// this slot can retain an alias that later cleanup frees prematurely.
+				msg := &ps.shardPool[last]
+				data := msg.dataContent
+				useCache := msg.useCache
+				cacheID := msg.cacheID
+				ps.clearSlotLocked(last)
+				ps.cache.CacheBatch(useCache, cacheID, data)
 				ps.freeShardPool <- last
 			}
 		}
@@ -382,8 +390,10 @@ func (ps *PipelineSpool) cleanSlotLocked(idx uint32) {
 	if msg.useCache && msg.dataContent != nil {
 		msg.dataContent.Clean(ps.cache.mp)
 	}
-	msg.dataContent = nil
-	msg.errContent = nil
-	msg.useCache = false
-	msg.cacheID = 0
+	ps.clearSlotLocked(idx)
+}
+
+func (ps *PipelineSpool) clearSlotLocked(idx uint32) {
+	ps.shardPool[idx] = pipelineSpoolMessage{}
+	ps.doRefCheck[idx] = false
 }

--- a/pkg/container/pSpool/sender_test.go
+++ b/pkg/container/pSpool/sender_test.go
@@ -293,6 +293,184 @@ func TestPipelineSpoolAbortDefersCurrentBatchRelease(t *testing.T) {
 	require.Equal(t, int64(0), mp.CurrNB())
 }
 
+func TestPipelineSpoolReleasedSlotDoesNotRetainOwnership(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 1)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 1)
+	batchErr := moerr.NewInternalErrorNoCtx("batch error")
+	queryDone, err := sp.SendBatch(context.Background(), 0, src, batchErr)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+
+	got, info := sp.ReceiveBatch(0)
+	require.NotNil(t, got)
+	require.Same(t, batchErr, info)
+	slot, ok := sp.rs[0].getLastPop()
+	require.True(t, ok)
+
+	sp.ReleaseCurrent(0)
+
+	msg := sp.shardPool[slot]
+	require.Nil(t, msg.dataContent)
+	require.Nil(t, msg.errContent)
+	require.False(t, msg.useCache)
+	require.Zero(t, msg.cacheID)
+	require.False(t, sp.doRefCheck[slot])
+
+	sp.ForceCleanupAfterTerminalSignal()
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolAbortDoesNotCleanReusedCurrentBatch(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 1024)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 1)
+	queryDone, err := sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	first, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	require.NotNil(t, first)
+	sp.ReleaseCurrent(0)
+
+	queryDone, err = sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	current, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	require.Same(t, first, current, "the test must exercise batch reuse across different slots")
+
+	sp.Abort(nil)
+	require.Equal(t, 1024, current.RowCount())
+	values := vector.MustFixedColWithTypeCheck[int64](current.Vecs[0])
+	require.Equal(t, int64(1), values[0])
+	require.Equal(t, int64(1024), values[len(values)-1])
+
+	sp.ReleaseCurrent(0)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolAbortDoesNotCleanReusedCurrentBroadcastBatch(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 1024)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 2)
+	queryDone, err := sp.SendBatch(context.Background(), SendToAllLocal, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	first0, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	first1, info := sp.ReceiveBatch(1)
+	require.NoError(t, info)
+	require.Same(t, first0, first1)
+	sp.ReleaseCurrent(0)
+	sp.ReleaseCurrent(1)
+
+	queryDone, err = sp.SendBatch(context.Background(), SendToAllLocal, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	current0, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	current1, info := sp.ReceiveBatch(1)
+	require.NoError(t, info)
+	require.Same(t, first0, current0, "the test must exercise batch reuse across different slots")
+	require.Same(t, current0, current1)
+
+	sp.Abort(nil)
+	require.Equal(t, 1024, current0.RowCount())
+	require.Equal(t, int64(1), vector.MustFixedColWithTypeCheck[int64](current1.Vecs[0])[0])
+
+	sp.ReleaseCurrent(0)
+	require.Greater(t, mp.CurrNB(), int64(0))
+	require.Equal(t, 1024, current1.RowCount())
+	sp.ReleaseCurrent(1)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolConcurrentAbortAndBroadcastRelease(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := newSpoolTestBatch(t, srcMP, 16)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	for iteration := 0; iteration < 256; iteration++ {
+		sp := InitMyPipelineSpool(mp, 2)
+		queryDone, err := sp.SendBatch(context.Background(), SendToAllLocal, src, nil)
+		require.NoError(t, err)
+		require.False(t, queryDone)
+		got0, info := sp.ReceiveBatch(0)
+		require.NoError(t, info)
+		got1, info := sp.ReceiveBatch(1)
+		require.NoError(t, info)
+		require.Same(t, got0, got1)
+
+		start := make(chan struct{})
+		done := make(chan struct{}, 3)
+		run := func(fn func()) {
+			go func() {
+				<-start
+				fn()
+				done <- struct{}{}
+			}()
+		}
+		run(func() { sp.Abort(nil) })
+		run(func() { sp.ReleaseCurrent(0) })
+		run(func() { sp.ReleaseCurrent(1) })
+		close(start)
+
+		timer := time.NewTimer(5 * time.Second)
+		for range 3 {
+			select {
+			case <-done:
+			case <-timer.C:
+				t.Fatalf("Abort and ReleaseCurrent did not finish at iteration %d", iteration)
+			}
+		}
+		timer.Stop()
+		require.Equal(t, int64(0), mp.CurrNB(), "iteration %d", iteration)
+	}
+}
+
 func TestPipelineSpoolAbortUnblocksSendBatchWaitingForFreeSlot(t *testing.T) {
 	mp := mpool.MustNewZeroNoFixed()
 	t.Cleanup(func() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25854

## What this PR does / why we need it:

Fixes #25854.

pSpool manages message slots and cached batches in two independent pools. The normal release path returned both objects but retained the old batch, error, and cache metadata in the released slot. When the cached batch was reused by another slot, Abort could clean the stale free slot and thereby clear a batch still owned by a receiver.

This PR restores the ownership boundary:

- Detach all message metadata before returning the batch to the cache or publishing the slot to the free pool.
- Reuse the same clear operation for direct cleanup so normal, aborted, and late-release paths have one invariant.
- Cover the free-slot invariant and the stale-alias sequence for both a single receiver and a two-receiver broadcast.
- Cover concurrent Abort and final broadcast releases over all lock orderings.
- Verify current data remains readable until the final ReleaseCurrent and all MPool memory is reclaimed afterward.

The release path adds no locks, goroutines, allocations, scans, atomic operations, or extra helper calls. It only clears a fixed-size slot at the existing final-reference release point.

Testing:

- pSpool full package, count 100
- pSpool focused race matrix, count 100, including 256 Abort/release interleavings per run
- connector, dispatch, and process full package tests
- connector, dispatch, and process terminal/abort race tests, count 10
- pSpool plus PR #25850 combined race suite, count 20
- go build on pSpool and all direct consumers
- go vet on pSpool
- git diff check