### PR TITLE
refactor(frontend): make protocol buffers configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1095,19 +1095,19 @@ err-check:
 ifneq ("$(strip $(fmtErrs))$(strip $(errNews))", "")
  ifneq ("$(strip $(fmtErrs))", "")
 		$(warning 'fmt.Errorf()' is found.)
-		$(warning One of 'fmt.Errorf()' is called at: $(shell printf "%s\n" $(fmtErrs) | head -1))
+		$(warning One of 'fmt.Errorf()' is called at: $(firstword $(fmtErrs)))
  endif
  ifneq ("$(strip $(errNews))", "")
 		$(warning 'errors.New()' is found.)
-		$(warning One of 'errors.New()' is called at: $(shell printf "%s\n" $(errNews) | head -1))
+		$(warning One of 'errors.New()' is called at: $(firstword $(errNews)))
  endif
  ifneq ("$(strip $(withTimeout))", "")
 		$(warning 'context.WithTimeout' is found.)
-		$(warning One of 'context.WithTimeout' is called at: $(shell printf "%s\n" $(withTimeout) | head -1))
+		$(warning One of 'context.WithTimeout' is called at: $(firstword $(withTimeout)))
  endif
  ifneq ("$(strip $(withDeadline))", "")
 		$(warning 'context.WithDeadline' is found.)
-		$(warning One of 'context.WithDeadline' is called at: $(shell printf "%s\n" $(withDeadline) | head -1))
+		$(warning One of 'context.WithDeadline' is called at: $(firstword $(withDeadline)))
  endif
 	$(error Use moerr instead.)
 else

--- a/pkg/frontend/codec.go
+++ b/pkg/frontend/codec.go
@@ -16,24 +16,49 @@ package frontend
 
 import (
 	"context"
+	"io"
+
 	"github.com/fagongzi/goetty/v2/buf"
 	"github.com/fagongzi/goetty/v2/codec"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"io"
 )
 
 var (
 	errorInvalidLength0             = moerr.NewInvalidInput(context.Background(), "invalid length: 0")
 	errorLenOfWrittenNotEqLenOfData = moerr.NewInternalError(context.Background(), "len of written != len of the data")
+	// ErrPacketTooLarge identifies a MySQL packet rejected before its payload
+	// is decoded. Callers can use errors.Is to translate it to the protocol's
+	// ER_SERVER_NET_PACKET_TOO_LARGE response.
+	ErrPacketTooLarge = moerr.NewInvalidInputNoCtx("mysql packet too large")
 )
 
 const PacketHeaderLength = 4
 
-func NewSqlCodec() codec.Codec {
-	return &sqlCodec{}
+// SQLCodecOption customizes MySQL packet decoding. With no options the codec
+// retains its historical behavior.
+type SQLCodecOption func(*sqlCodec)
+
+// WithSQLCodecMaxPayloadSize rejects a packet from its four-byte header before
+// waiting for or retaining a payload larger than maxPayloadSize. A non-positive
+// value leaves the protocol's existing three-byte length limit unchanged.
+func WithSQLCodecMaxPayloadSize(maxPayloadSize int) SQLCodecOption {
+	return func(c *sqlCodec) {
+		c.maxPayloadSize = maxPayloadSize
+	}
+}
+
+func NewSqlCodec(options ...SQLCodecOption) codec.Codec {
+	c := &sqlCodec{}
+	for _, option := range options {
+		if option != nil {
+			option(c)
+		}
+	}
+	return c
 }
 
 type sqlCodec struct {
+	maxPayloadSize int
 }
 
 type Packet struct {
@@ -52,6 +77,9 @@ func (c *sqlCodec) Decode(in *buf.ByteBuf) (interface{}, bool, error) {
 	length := int32(uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16)
 	if length == 0 {
 		return nil, false, errorInvalidLength0
+	}
+	if c.maxPayloadSize > 0 && int(length) > c.maxPayloadSize {
+		return nil, false, ErrPacketTooLarge
 	}
 
 	sequenceID := int8(header[3])

--- a/pkg/frontend/codec_test.go
+++ b/pkg/frontend/codec_test.go
@@ -1,0 +1,71 @@
+// Copyright 2021 - 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"testing"
+
+	"github.com/fagongzi/goetty/v2/buf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLCodecMaxPayloadSize(t *testing.T) {
+	writeHeader := func(t *testing.T, payloadSize int) *buf.ByteBuf {
+		t.Helper()
+		data := buf.NewByteBuf(PacketHeaderLength)
+		require.NoError(t, data.WriteByte(byte(payloadSize)))
+		require.NoError(t, data.WriteByte(byte(payloadSize>>8)))
+		require.NoError(t, data.WriteByte(byte(payloadSize>>16)))
+		require.NoError(t, data.WriteByte(0))
+		return data
+	}
+
+	t.Run("reject from header before payload arrives", func(t *testing.T) {
+		data := writeHeader(t, 65)
+		defer data.Close()
+		codec := NewSqlCodec(WithSQLCodecMaxPayloadSize(64))
+
+		value, ok, err := codec.Decode(data)
+		require.ErrorIs(t, err, ErrPacketTooLarge)
+		require.False(t, ok)
+		require.Nil(t, value)
+		require.Equal(t, PacketHeaderLength, data.Readable())
+	})
+
+	t.Run("boundary packet remains compatible", func(t *testing.T) {
+		data := writeHeader(t, 4)
+		defer data.Close()
+		_, err := data.Write([]byte{1, 2, 3, 4})
+		require.NoError(t, err)
+		codec := NewSqlCodec(WithSQLCodecMaxPayloadSize(4))
+
+		value, ok, err := codec.Decode(data)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.NotNil(t, value)
+		require.Equal(t, []byte{1, 2, 3, 4}, value.(*Packet).Payload)
+	})
+
+	t.Run("default remains unbounded by option", func(t *testing.T) {
+		data := writeHeader(t, 65)
+		defer data.Close()
+		codec := NewSqlCodec()
+
+		value, ok, err := codec.Decode(data)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Nil(t, value)
+	})
+}

--- a/pkg/frontend/mysql_buffer.go
+++ b/pkg/frontend/mysql_buffer.go
@@ -56,6 +56,43 @@ type BufferAllocator struct {
 	allocator Allocator
 }
 
+// IOSessionOption customizes the memory retained by an IOSession. Options are
+// intentionally applied only by NewIOSessionWithOptions so existing frontend
+// callers keep the historical defaults.
+type IOSessionOption func(*ioSessionOptions)
+
+type ioSessionOptions struct {
+	bufferSize        int
+	allowedPacketSize int
+	allocator         Allocator
+}
+
+// WithIOSessionBufferSize sets the size of the buffer retained for the whole
+// session lifetime. Packets larger than this buffer continue to use the
+// existing dynamic read/write paths.
+func WithIOSessionBufferSize(size int) IOSessionOption {
+	return func(opts *ioSessionOptions) {
+		opts.bufferSize = size
+	}
+}
+
+// WithIOSessionAllowedPacketSize bounds a single logical MySQL packet. This is
+// useful for protocol endpoints, such as a Proxy login path, that never need
+// the frontend server's general-purpose packet maximum.
+func WithIOSessionAllowedPacketSize(size int) IOSessionOption {
+	return func(opts *ioSessionOptions) {
+		opts.allowedPacketSize = size
+	}
+}
+
+// WithIOSessionAllocator uses allocator for all buffers owned by the session.
+// The allocator must be safe for concurrent use when shared by sessions.
+func WithIOSessionAllocator(allocator Allocator) IOSessionOption {
+	return func(opts *ioSessionOptions) {
+		opts.allocator = allocator
+	}
+}
+
 func (ba *BufferAllocator) Alloc(size int) ([]byte, error) {
 	if size == 0 {
 		return nil, nil
@@ -102,7 +139,7 @@ func (block *MemBlock) ResetIndices() {
 
 // IsFull check read buf full or not
 func (block *MemBlock) IsFull() bool {
-	return block.writeIndex == fixBufferSize
+	return block.writeIndex >= len(block.data)
 }
 
 func (block *MemBlock) BufferLen() int {
@@ -168,6 +205,10 @@ type Conn struct {
 	header                [4]byte
 	// static buffer block for read & write in general cases
 	fixBuf MemBlock
+	// bufferSize is the allocation unit for the fixed and dynamic write
+	// buffers. It is configurable for lightweight protocol users such as the
+	// Proxy, while regular frontend sessions keep fixBufferSize.
+	bufferSize int
 	// dynamic write buffer block is organized by a list
 	dynamicWrBuf *list.List
 	// just for load local read
@@ -204,20 +245,58 @@ func (c *Conn) SetTimeout(d time.Duration) {
 
 // NewIOSession create a new io session
 func NewIOSession(conn net.Conn, pu *config.ParameterUnit, service string) (_ *Conn, err error) {
+	return NewIOSessionWithOptions(conn, pu, service)
+}
+
+// NewIOSessionWithOptions creates an IO session with optional buffer and
+// allocator overrides. The default behavior is identical to NewIOSession.
+func NewIOSessionWithOptions(
+	conn net.Conn,
+	pu *config.ParameterUnit,
+	service string,
+	options ...IOSessionOption,
+) (_ *Conn, err error) {
+	opts := ioSessionOptions{
+		bufferSize:        fixBufferSize,
+		allowedPacketSize: int(MaxPayloadSize),
+	}
+	for _, option := range options {
+		if option != nil {
+			option(&opts)
+		}
+	}
+	if opts.bufferSize < HeaderLengthOfTheProtocol {
+		return nil, moerr.NewInternalErrorNoCtxf(
+			"invalid IO session buffer size %d, must be at least %d",
+			opts.bufferSize,
+			HeaderLengthOfTheProtocol,
+		)
+	}
+	if opts.allowedPacketSize < 1 {
+		return nil, moerr.NewInternalErrorNoCtxf(
+			"invalid IO session allowed packet size %d, must be positive",
+			opts.allowedPacketSize,
+		)
+	}
+	if opts.allocator == nil {
+		opts.allocator = getSessionAlloc(service)
+	}
+
 	c := &Conn{
 		conn:                  conn,
 		localAddr:             conn.LocalAddr().String(),
 		remoteAddr:            conn.RemoteAddr().String(),
 		fixBuf:                MemBlock{},
+		bufferSize:            opts.bufferSize,
 		dynamicWrBuf:          list.New(),
-		allocator:             &BufferAllocator{allocator: getSessionAlloc(service)},
+		allocator:             &BufferAllocator{allocator: opts.allocator},
 		timeout:               pu.SV.SessionTimeout.Duration,
 		readTimeout:           pu.SV.NetReadTimeout.Duration,
 		writeTimeout:          pu.SV.NetWriteTimeout.Duration,
 		loadLocalReadTimeout:  pu.SV.LoadLocalReadTimeout.Duration,
 		loadLocalWriteTimeout: pu.SV.LoadLocalWriteTimeout.Duration,
 		maxBytesToFlush:       int(pu.SV.MaxBytesInOutbufToFlush * 1024),
-		allowedPacketSize:     int(MaxPayloadSize),
+		allowedPacketSize:     opts.allowedPacketSize,
 		service:               service,
 	}
 
@@ -227,7 +306,7 @@ func NewIOSession(conn net.Conn, pu *config.ParameterUnit, service string) (_ *C
 		}
 	}()
 
-	c.fixBuf.data, err = c.allocator.Alloc(fixBufferSize)
+	c.fixBuf.data, err = c.allocator.Alloc(c.bufferSize)
 	if err != nil {
 		return nil, err
 	}
@@ -334,6 +413,9 @@ func (c *Conn) ReadLoadLocalPacket() (_ []byte, err error) {
 	packetLength = int(uint32(c.header[0]) | uint32(c.header[1])<<8 | uint32(c.header[2])<<16)
 	sequenceId := c.header[3]
 	c.sequenceId = sequenceId + 1
+	if err = c.CheckAllowedPacketSize(packetLength); err != nil {
+		return
+	}
 
 	if c.loadLocalBuf.data == nil {
 		c.loadLocalBuf.data, err = c.allocator.Alloc(packetLength)
@@ -667,9 +749,9 @@ func (c *Conn) AppendPart(elems []byte) error {
 		}
 		curElemsRemainSpace := len(elems) - curBufRemainSpace
 
-		allocLength := Max(fixBufferSize, curElemsRemainSpace)
-		if allocLength%fixBufferSize != 0 {
-			allocLength += fixBufferSize - allocLength%fixBufferSize
+		allocLength := Max(c.bufferSize, curElemsRemainSpace)
+		if allocLength%c.bufferSize != 0 {
+			allocLength += c.bufferSize - allocLength%c.bufferSize
 		}
 
 		err = AllocNewBlock(c, allocLength)
@@ -728,7 +810,7 @@ var BeginPacket = func(c *Conn) error {
 // BeginPacket Reserve Header in the buffer
 func (c *Conn) BeginPacket() error {
 	if c.curBuf.AvailableSpaceLen() < HeaderLengthOfTheProtocol {
-		err := AllocNewBlock(c, fixBufferSize)
+		err := AllocNewBlock(c, c.bufferSize)
 		if err != nil {
 			return err
 		}

--- a/pkg/frontend/mysql_buffer_test.go
+++ b/pkg/frontend/mysql_buffer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prashantv/gostub"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/config"
@@ -911,6 +912,213 @@ func Test_NewIOSessionFailed(t *testing.T) {
 	conn2 := conn.RawConn()
 	conn.UseConn(conn2)
 	conn.RawConn()
+}
+
+func TestNewIOSessionWithOptions(t *testing.T) {
+	const bufferSize = 16
+
+	sv, err := getSystemVariables("test/system_vars_config.toml")
+	require.NoError(t, err)
+	pu := config.NewParameterUnit(sv, nil, nil, nil)
+
+	t.Run("invalid buffer size", func(t *testing.T) {
+		conn, err := NewIOSessionWithOptions(
+			&testConn{},
+			pu,
+			"",
+			WithIOSessionBufferSize(HeaderLengthOfTheProtocol-1),
+		)
+		assert.Error(t, err)
+		assert.Nil(t, conn)
+	})
+
+	t.Run("invalid allowed packet size", func(t *testing.T) {
+		conn, err := NewIOSessionWithOptions(
+			&testConn{},
+			pu,
+			"",
+			WithIOSessionAllowedPacketSize(0),
+		)
+		assert.Error(t, err)
+		assert.Nil(t, conn)
+	})
+
+	t.Run("default is backward compatible", func(t *testing.T) {
+		allocator := NewLeakCheckAllocator()
+		conn, err := NewIOSessionWithOptions(
+			&testConn{},
+			pu,
+			"",
+			WithIOSessionAllocator(allocator),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, fixBufferSize, conn.fixBuf.BufferLen())
+		assert.Equal(t, uint64(fixBufferSize), allocator.allocated)
+		assert.NoError(t, conn.Close())
+		assert.True(t, allocator.CheckBalance())
+	})
+
+	t.Run("small buffer reads exact and larger packets", func(t *testing.T) {
+		for _, payloadSize := range []int{bufferSize - HeaderLengthOfTheProtocol, 3 * bufferSize} {
+			t.Run(fmt.Sprintf("payload-%d", payloadSize), func(t *testing.T) {
+				allocator := NewLeakCheckAllocator()
+				payload := bytes.Repeat([]byte{byte(payloadSize)}, payloadSize)
+				rawConn := &testConn{data: makePacket(payload, 0)}
+				conn, err := NewIOSessionWithOptions(
+					rawConn,
+					pu,
+					"",
+					WithIOSessionBufferSize(bufferSize),
+					WithIOSessionAllocator(allocator),
+				)
+				require.NoError(t, err)
+				actual, err := conn.Read()
+				assert.NoError(t, err)
+				assert.Equal(t, payload, actual)
+				assert.Equal(t, bufferSize, conn.fixBuf.BufferLen())
+				assert.Equal(t, uint64(bufferSize), allocator.allocated)
+				assert.NoError(t, conn.Close())
+				assert.True(t, allocator.CheckBalance())
+			})
+		}
+	})
+
+	t.Run("dynamic write buffer is released on reset", func(t *testing.T) {
+		allocator := NewLeakCheckAllocator()
+		conn, err := NewIOSessionWithOptions(
+			&testConn{},
+			pu,
+			"",
+			WithIOSessionBufferSize(bufferSize),
+			WithIOSessionAllocator(allocator),
+		)
+		require.NoError(t, err)
+		assert.NoError(t, conn.BeginPacket())
+		assert.NoError(t, conn.Append(bytes.Repeat([]byte{1}, 3*bufferSize)...))
+		assert.Greater(t, allocator.allocated-allocator.freed, uint64(bufferSize))
+
+		conn.Reset()
+		assert.Equal(t, uint64(bufferSize), allocator.allocated-allocator.freed)
+		assert.NoError(t, conn.Close())
+		assert.True(t, allocator.CheckBalance())
+	})
+
+	t.Run("oversized packet is rejected without dynamic retention", func(t *testing.T) {
+		allocator := NewLeakCheckAllocator()
+		payload := bytes.Repeat([]byte{1}, bufferSize+1)
+		conn, err := NewIOSessionWithOptions(
+			&testConn{data: makePacket(payload, 0)},
+			pu,
+			"",
+			WithIOSessionBufferSize(bufferSize),
+			WithIOSessionAllowedPacketSize(bufferSize),
+			WithIOSessionAllocator(allocator),
+		)
+		require.NoError(t, err)
+		actual, err := conn.Read()
+		assert.Error(t, err)
+		assert.Nil(t, actual)
+		assert.Equal(t, uint64(bufferSize), allocator.allocated-allocator.freed)
+		assert.NoError(t, conn.Close())
+		assert.True(t, allocator.CheckBalance())
+	})
+
+	t.Run("load local packet limit is enforced before payload allocation", func(t *testing.T) {
+		for _, payloadSize := range []int{bufferSize, bufferSize + 1} {
+			t.Run(fmt.Sprintf("payload-%d", payloadSize), func(t *testing.T) {
+				allocator := NewLeakCheckAllocator()
+				payload := bytes.Repeat([]byte{1}, payloadSize)
+				rawConn := &testConn{data: makePacket(payload, 0)}
+				conn, err := NewIOSessionWithOptions(
+					rawConn,
+					pu,
+					"",
+					WithIOSessionBufferSize(bufferSize),
+					WithIOSessionAllowedPacketSize(bufferSize),
+					WithIOSessionAllocator(allocator),
+				)
+				require.NoError(t, err)
+
+				actual, err := conn.ReadLoadLocalPacket()
+				if payloadSize == bufferSize {
+					assert.NoError(t, err)
+					assert.Equal(t, payload, actual)
+					assert.Empty(t, rawConn.data)
+					assert.Equal(t, uint64(2*bufferSize), allocator.allocated-allocator.freed)
+				} else {
+					assert.Error(t, err)
+					assert.Nil(t, actual)
+					assert.Equal(t, payload, rawConn.data)
+					assert.Equal(t, uint64(bufferSize), allocator.allocated-allocator.freed)
+				}
+				assert.NoError(t, conn.Close())
+				assert.True(t, allocator.CheckBalance())
+			})
+		}
+	})
+
+	t.Run("oversized load local packet releases the reusable buffer", func(t *testing.T) {
+		allocator := NewLeakCheckAllocator()
+		allowedPayload := bytes.Repeat([]byte{1}, bufferSize)
+		oversizedPayload := bytes.Repeat([]byte{2}, bufferSize+1)
+		rawConn := &testConn{data: append(
+			makePacket(allowedPayload, 0),
+			makePacket(oversizedPayload, 1)...,
+		)}
+		conn, err := NewIOSessionWithOptions(
+			rawConn,
+			pu,
+			"",
+			WithIOSessionBufferSize(bufferSize),
+			WithIOSessionAllowedPacketSize(bufferSize),
+			WithIOSessionAllocator(allocator),
+		)
+		require.NoError(t, err)
+
+		actual, err := conn.ReadLoadLocalPacket()
+		require.NoError(t, err)
+		assert.Equal(t, allowedPayload, actual)
+		assert.Equal(t, uint64(2*bufferSize), allocator.allocated-allocator.freed)
+
+		actual, err = conn.ReadLoadLocalPacket()
+		assert.Error(t, err)
+		assert.Nil(t, actual)
+		assert.Nil(t, conn.loadLocalBuf.data)
+		assert.Equal(t, oversizedPayload, rawConn.data)
+		assert.Equal(t, uint64(bufferSize), allocator.allocated-allocator.freed)
+		assert.NoError(t, conn.Close())
+		assert.True(t, allocator.CheckBalance())
+	})
+
+	t.Run("shared allocator bounds aggregate session buffers", func(t *testing.T) {
+		allocator := NewSessionAllocator(&config.ParameterUnit{
+			SV: &config.FrontendParameters{GuestMmuLimitation: 2 * bufferSize},
+		})
+		newSession := func() (*Conn, error) {
+			return NewIOSessionWithOptions(
+				&testConn{},
+				pu,
+				"",
+				WithIOSessionBufferSize(bufferSize),
+				WithIOSessionAllocator(allocator),
+			)
+		}
+
+		first, err := newSession()
+		require.NoError(t, err)
+		second, err := newSession()
+		require.NoError(t, err)
+		third, err := newSession()
+		assert.Error(t, err)
+		assert.Nil(t, third)
+
+		require.NoError(t, first.Close())
+		third, err = newSession()
+		require.NoError(t, err)
+		require.NotNil(t, third)
+		require.NoError(t, second.Close())
+		require.NoError(t, third.Close())
+	})
 }
 
 func testDefer1(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [x] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

Part of #25856.

## What this PR does / why we need it:

This PR adds backward-compatible, opt-in controls for MySQL protocol memory:

- configure the retained `IOSession` buffer size without changing the existing 1 MiB default;
- inject a concurrency-safe shared allocator so multiple sessions can share one bounded memory budget;
- configure a logical packet limit for `IOSession` readers;
- reject oversized packets in `sqlCodec` from the 4-byte header, before waiting for or decoding the payload;
- make fixed/dynamic buffer growth use the actual configured allocation unit;
- make `err-check` diagnostics shell-safe by selecting the first match in Make instead of executing grep output as shell syntax.

Existing `NewIOSession` and `NewSqlCodec` callers retain their historical behavior. Tests cover exact-buffer boundaries, packets larger than the retained buffer, dynamic-buffer cleanup, aggregate allocator exhaustion/recovery, header-time rejection, boundary acceptance, and default compatibility.
