### PR TITLE
fix: guard empty fixed-width vectors in CBloomFilter to avoid index-out-of-range panic

### DIFF
--- a/pkg/common/bloomfilter/cbloomfilter.go
+++ b/pkg/common/bloomfilter/cbloomfilter.go
@@ -266,6 +266,9 @@ func (bf *CBloomFilter) AddVector(v *vector.Vector) {
 }
 
 func (bf *CBloomFilter) testAndAddFixedVector(v *vector.Vector, callBack func(bool, bool, int)) {
+	if v.Length() == 0 {
+		return
+	}
 	fixedData := v.GetData()
 	typeSize := v.GetType().TypeSize()
 	length := v.Length()
@@ -323,6 +326,9 @@ func (bf *CBloomFilter) testAndAddVarlenaVector(v *vector.Vector, callBack func(
 }
 
 func (bf *CBloomFilter) testFixedVector(v *vector.Vector, callBack func(bool, bool, int)) []uint8 {
+	if v.Length() == 0 {
+		return []uint8{}
+	}
 	fixedData := v.GetData()
 	typeSize := v.GetType().TypeSize()
 	length := v.Length()
@@ -385,6 +391,9 @@ func (bf *CBloomFilter) testVarlenaVector(v *vector.Vector, callBack func(bool, 
 }
 
 func (bf *CBloomFilter) addFixedVector(v *vector.Vector) {
+	if v.Length() == 0 {
+		return
+	}
 	fixedData := v.GetData()
 	typeSize := v.GetType().TypeSize()
 	length := v.Length()

--- a/pkg/common/bloomfilter/cbloomfilter_fix_test.go
+++ b/pkg/common/bloomfilter/cbloomfilter_fix_test.go
@@ -120,6 +120,21 @@ func TestCBloomFilter_VarlenaVectorWithEmptySlices(t *testing.T) {
 	require.True(t, bf2.Test([]byte("world")))
 }
 
+func TestCBloomFilter_EmptyFixedVector(t *testing.T) {
+	mp := mpool.MustNewZero()
+	vec := vector.NewVec(types.T_int64.ToType())
+	defer vec.Free(mp)
+
+	bf := NewCBloomFilterWithProbability(1, 0.01)
+	defer bf.Free()
+
+	require.NotPanics(t, func() {
+		require.Empty(t, bf.TestVector(vec, nil))
+	})
+	require.NotPanics(t, func() { bf.AddVector(vec) })
+	require.NotPanics(t, func() { bf.TestAndAddVector(vec, nil) })
+}
+
 func TestCBloomFilter_IntegerCompatibility(t *testing.T) {
 	bf := NewCBloomFilterWithProbability(100, 0.0001)
 	defer bf.Free()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25618

## What this PR does / why we need it:

The three fixed-width `CBloomFilter` methods (`testAndAddFixedVector`, `testFixedVector`, `addFixedVector`) take `&fixedData[0]` and `&results[0]` unconditionally, which panics with `index out of range [0] with length 0` when the input vector is empty. Their varlena counterparts (`testAndAddVarlenaVector`, `testVarlenaVector`, `addVarlenaVector`) already return early on `v.Length() == 0`, so behavior on empty input was inconsistent by type.

This adds the same zero-length early return to the fixed-width path so `TestVector`/`AddVector`/`TestAndAddVector` are no-ops on an empty vector instead of panicking, matching the varlena behavior. A regression test covers all three fixed-width APIs.
