### PR TITLE
fix(logservice): isolate HAKeeper client from caller timeout

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -332,6 +332,7 @@ func (rb *remoteBackend) SendInternal(ctx context.Context, request Message) (*Fu
 func (rb *remoteBackend) send(ctx context.Context, request Message, internal bool) (*Future, error) {
 	f := rb.getFuture(ctx, request, internal)
 	if err := rb.doSend(f); err != nil {
+		f.messageSent(err)
 		f.Close()
 		return nil, err
 	}

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -68,6 +68,36 @@ func TestSend(t *testing.T) {
 	)
 }
 
+func TestSendContextErrorReleasesFuture(t *testing.T) {
+	rb := &remoteBackend{
+		codec:      newTestCodec(),
+		metrics:    newMetrics(""),
+		waitWriteC: make(chan struct{}, 1),
+		writeC:     make(chan *Future, 1),
+	}
+	rb.stateMu.state = stateRunning
+	rb.mu.futures = make(map[uint64]*Future)
+	rb.pool.futures = &sync.Pool{
+		New: func() any {
+			return newFuture(rb.releaseFuture)
+		},
+	}
+	// Keep the write queue full so Send exits through the caller-context path
+	// before the future is handed to the write loop.
+	rb.writeC <- nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	cancel()
+	future, err := rb.Send(ctx, newTestMessage(1))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, future)
+
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+	require.Empty(t, rb.mu.futures,
+		"a future that was never enqueued must be removed on Send failure")
+}
+
 func TestReadTimeoutWithNormalMessageMissed(t *testing.T) {
 	testBackendSend(t,
 		func(conn goetty.IOSession, msg interface{}, _ uint64) error {

--- a/pkg/logservice/client.go
+++ b/pkg/logservice/client.go
@@ -926,6 +926,7 @@ func getRPCClient(
 	backendOpts := []morpc.BackendOption{
 		morpc.WithBackendConnectTimeout(time.Second),
 		morpc.WithBackendHasPayloadResponse(),
+		morpc.WithBackendFreeOrphansResponse(releaseOrphanRPCResponse),
 		morpc.WithBackendLogger(logutil.GetGlobalLogger().Named("hakeeper-client-backend")),
 		morpc.WithBackendReadTimeout(readTimeout),
 	}
@@ -954,4 +955,8 @@ func getRPCClient(
 	codec := morpc.NewMessageCodec(sid, mf, codecOpts...)
 	bf := morpc.NewGoettyBasedBackendFactory(codec, backendOpts...)
 	return morpc.NewClient("logservice-client", bf, clientOpts...)
+}
+
+func releaseOrphanRPCResponse(message morpc.Message) {
+	message.(*RPCResponse).Release()
 }

--- a/pkg/logservice/client_test.go
+++ b/pkg/logservice/client_test.go
@@ -37,6 +37,17 @@ import (
 
 var testLogger = logutil.GetGlobalLogger().Named("logservice-test")
 
+func TestReleaseOrphanRPCResponse(t *testing.T) {
+	pool := &sync.Pool{}
+	response := &RPCResponse{
+		payload: []byte("payload"),
+		pool:    pool,
+	}
+
+	releaseOrphanRPCResponse(response)
+	require.Nil(t, response.payload)
+}
+
 func TestClientConfigIsValidated(t *testing.T) {
 	cfg := ClientConfig{}
 	cc, err := NewClient(context.TODO(), "", cfg)

--- a/pkg/logservice/hakeeper_client.go
+++ b/pkg/logservice/hakeeper_client.go
@@ -378,7 +378,7 @@ func (c *managedHAKeeperClient) GetClusterDetails(ctx context.Context) (pb.Clust
 			return pb.ClusterDetails{}, err
 		}
 		cd, err := c.getClient().getClusterDetails(ctx)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -406,7 +406,7 @@ func (c *managedHAKeeperClient) GetClusterState(ctx context.Context) (pb.Checker
 			return pb.CheckerState{}, err
 		}
 		s, err := c.getClient().getClusterState(ctx)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -451,7 +451,9 @@ func (c *managedHAKeeperClient) AllocateID(ctx context.Context) (uint64, error) 
 		firstID, err := sendCNAllocateIDFunc(c.mu.client, ctx, "", batchSize)
 
 		if err != nil {
-			c.resetClientLocked()
+			if shouldResetHAKeeperClient(err) {
+				c.resetClientLocked()
+			}
 			if c.isRetryableError(err) {
 				if err := c.waitRetryLocked(ctx); err != nil {
 					return 0, err
@@ -523,7 +525,9 @@ func (c *managedHAKeeperClient) AllocateIDByKeyWithBatch(
 		}
 		firstID, err := sendCNAllocateIDFunc(c.mu.client, ctx, key, batchSize)
 		if err != nil {
-			c.resetClientLocked()
+			if shouldResetHAKeeperClient(err) {
+				c.resetClientLocked()
+			}
 			if c.isRetryableError(err) {
 				if err := c.waitRetryLocked(ctx); err != nil {
 					return 0, err
@@ -555,7 +559,7 @@ func (c *managedHAKeeperClient) SendCNHeartbeat(ctx context.Context,
 			return pb.CommandBatch{}, err
 		}
 		result, err := c.getClient().sendCNHeartbeat(ctx, hb)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -584,7 +588,7 @@ func (c *managedHAKeeperClient) SendTNHeartbeat(ctx context.Context,
 			return pb.CommandBatch{}, err
 		}
 		cb, err := c.getClient().sendTNHeartbeat(ctx, hb)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -613,7 +617,7 @@ func (c *managedHAKeeperClient) SendLogHeartbeat(ctx context.Context,
 			return pb.CommandBatch{}, err
 		}
 		cb, err := c.getClient().sendLogHeartbeat(ctx, hb)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -642,7 +646,7 @@ func (c *managedHAKeeperClient) GetCNState(ctx context.Context) (pb.CNState, err
 			return pb.CNState{}, err
 		}
 		s, err := c.getClient().getCNState(ctx)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -673,7 +677,7 @@ func (c *managedHAKeeperClient) UpdateCNLabel(
 			return err
 		}
 		err := c.getClient().updateCNLabel(ctx, label)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -704,7 +708,7 @@ func (c *managedHAKeeperClient) UpdateCNWorkState(
 			return err
 		}
 		err := c.getClient().updateCNWorkState(ctx, state)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -735,7 +739,7 @@ func (c *managedHAKeeperClient) PatchCNStore(
 			return err
 		}
 		err := c.getClient().patchCNStore(ctx, stateLabel)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -766,7 +770,7 @@ func (c *managedHAKeeperClient) DeleteCNStore(
 			return err
 		}
 		err := c.getClient().deleteCNStore(ctx, cnStore)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -797,7 +801,7 @@ func (c *managedHAKeeperClient) SendProxyHeartbeat(
 			return pb.CommandBatch{}, err
 		}
 		cb, err := c.getClient().sendProxyHeartbeat(ctx, hb)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -826,7 +830,7 @@ func (c *managedHAKeeperClient) GetBackupData(ctx context.Context) ([]byte, erro
 			return nil, err
 		}
 		s, err := c.getClient().getBackupData(ctx)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -857,7 +861,7 @@ func (c *managedHAKeeperClient) UpdateNonVotingReplicaNum(
 			return err
 		}
 		err := c.getClient().updateNonVotingReplicaNum(ctx, num)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -888,7 +892,7 @@ func (c *managedHAKeeperClient) UpdateNonVotingLocality(
 			return err
 		}
 		err := c.getClient().updateNonVotingLocality(ctx, locality)
-		if err != nil {
+		if shouldResetHAKeeperClient(err) {
 			c.resetClient()
 		}
 		if c.isRetryableError(err) {
@@ -907,6 +911,15 @@ func (c *managedHAKeeperClient) isRetryableError(err error) bool {
 		logutil.IsExpectedConnectionCloseError(err) ||
 		moerr.IsMoErrCode(err, moerr.ErrNoHAKeeper) ||
 		moerr.IsMoErrCode(err, moerr.ErrUnexpectedEOF)
+}
+
+func shouldResetHAKeeperClient(err error) bool {
+	// A caller-scoped cancellation does not mean the shared transport is broken.
+	// MORPC discards the timed-out future, while its read loop independently
+	// detects and reconnects a failed transport.
+	return err != nil &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded)
 }
 
 func (c *managedHAKeeperClient) resetClient() {

--- a/pkg/logservice/hakeeper_client_test.go
+++ b/pkg/logservice/hakeeper_client_test.go
@@ -1102,6 +1102,60 @@ func TestAllocateBatchIDRetriesEOFSendError(t *testing.T) {
 	require.Equal(t, 2, sendCalls)
 }
 
+func TestAllocateBatchIDKeepsClientOnContextError(t *testing.T) {
+	originalSend := sendCNAllocateIDFunc
+	defer func() {
+		sendCNAllocateIDFunc = originalSend
+	}()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "canceled", err: context.Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &hakeeperClient{}
+			sendCalls := 0
+			sendCNAllocateIDFunc = func(
+				actualClient *hakeeperClient,
+				_ context.Context,
+				key string,
+				batch uint64,
+			) (uint64, error) {
+				sendCalls++
+				require.Same(t, client, actualClient)
+				require.Equal(t, "x", key)
+				require.Equal(t, uint64(2), batch)
+				if sendCalls == 1 {
+					return 0, tt.err
+				}
+				return 100, nil
+			}
+
+			c := &managedHAKeeperClient{
+				cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
+			}
+			c.mu.client = client
+			c.mu.allocIDByKey = make(map[string]*allocID)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			_, err := c.AllocateIDByKeyWithBatch(ctx, "x", 2)
+			require.ErrorIs(t, err, tt.err)
+			require.Same(t, client, c.mu.client,
+				"a caller-scoped context error must not close the shared client")
+
+			firstID, err := c.AllocateIDByKeyWithBatch(ctx, "x", 2)
+			require.NoError(t, err)
+			require.Equal(t, uint64(100), firstID)
+			require.Equal(t, 2, sendCalls)
+		})
+	}
+}
+
 func TestHAKeeperClientUpdateCNWorkState(t *testing.T) {
 	fn := func(t *testing.T, s *Service) {
 		cfg := HAKeeperClientConfig{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25868

## What this PR does / why we need it:

Managed HAKeeper operations share one MORPC client. Before this change, every request error reset and closed that shared client, including `context.Canceled` and `context.DeadlineExceeded` from one caller.

In TKE mergerun job 88168675381, a connection-ID allocation reached its frontend deadline and closed the established HAKeeper connection. Unrelated connection admission, CN heartbeat, task service, and cluster refresh requests were then forced through synchronous HAKeeper rediscovery. The SSB `q1.3` connection failed during that cascade even though HAKeeper recovered immediately and the next query succeeded.

A caller context error means only that request can no longer wait; it does not establish that the shared transport is broken. MORPC's backend read loop independently detects EOF, connection errors, and read timeouts and reconnects the transport.

This change:

- returns caller cancellation/deadline errors unchanged without closing the shared HAKeeper client;
- applies that rule consistently to all managed HAKeeper operations;
- preserves existing reset/reconnect/retry behavior for EOF, connection-close, `NoHAKeeper`, backend timeout, and every other non-context error;
- completes MORPC cleanup when `Send` fails before queue admission, so the Future is removed from the backend map instead of retaining its request indefinitely;
- recycles payload-bearing logservice responses that arrive after their Future has already been removed;
- does not change connection IDs, allocation batches, public APIs, configuration, timeouts, retry counts, or normal success paths.

The regression coverage proves:

- caller cancellation/deadline keeps the exact managed HAKeeper client reusable;
- EOF send errors still reset, rebuild, and retry the client;
- an admission-stage context error leaves no Future in MORPC's backend map (the test fails on unmodified code with one retained Future);
- the orphan-response callback releases the `RPCResponse` payload back through its existing pool lifecycle.

## Review follow-up and safety boundary

The requested review at `pullrequestreview-4730633356` identified two valid lifecycle gaps. Commit `ab3fdb94d4` addresses both with focused cleanup changes:

1. A Future is registered before `doSend`. If enqueue fails, no write-loop owner exists, so the synchronous send-error path now performs the single matching send-completion/unref before closing it.
2. A late payload response whose Future/Stream is already absent now uses `WithBackendFreeOrphansResponse` and the existing `RPCResponse.Release` implementation.

Normal queued sends are unchanged: only the write loop calls send completion. Normal responses are unchanged: the caller still owns `RPCResponse.Release`. The orphan callback runs only when MORPC finds neither a Future nor a Stream, so it does not overlap normal response ownership.

## Testing

Tested with MatrixOne macOS CGo header/link settings:

- `go test ./pkg/common/morpc -run '^TestSendContextErrorReleasesFuture$' -count=20`
- `go test -race ./pkg/common/morpc -run '^TestSendContextErrorReleasesFuture$' -count=20`
- focused HAKeeper/orphan-response tests: normal `count=10`, race `count=10`
- `go test ./pkg/common/morpc -count=1`
- `go test -race ./pkg/common/morpc -count=1`
- `go test ./pkg/logservice -count=1`
- `go test -race ./pkg/logservice -count=1`
- `go test ./pkg/frontend ./pkg/cnservice ./pkg/proxy -run '^$' -count=1`
- `go build ./pkg/common/morpc ./pkg/logservice ./pkg/frontend ./pkg/cnservice ./pkg/proxy`
- `go vet ./pkg/common/morpc ./pkg/logservice`
- `git diff --check`
