### PR TITLE
fix(frontend): quote prepared statement names during migration

### DIFF
--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -2059,6 +2059,10 @@ type prepareStmtMigration struct {
 	commitFn   func(*Session, error) error
 }
 
+func quotePrepareStmtName(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
 func newPrepareStmtMigration(name string, sql string, paramTypes []byte) *prepareStmtMigration {
 	return &prepareStmtMigration{
 		name:       name,
@@ -2072,7 +2076,7 @@ func (p *prepareStmtMigration) Migrate(ctx context.Context, ses *Session) error 
 	ses.EnterFPrint(FPMigratePrepareStmt)
 	defer ses.ExitFPrint(FPMigratePrepareStmt)
 	if !strings.HasPrefix(strings.ToLower(p.sql), "prepare") {
-		p.sql = fmt.Sprintf("prepare %s from %s", p.name, p.sql)
+		p.sql = fmt.Sprintf("prepare %s from %s", quotePrepareStmtName(p.name), p.sql)
 	}
 
 	tempExecCtx := &ExecCtx{

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -698,11 +698,18 @@ func TestSession_Migrate(t *testing.T) {
 			PrepareStmts: []*query.PrepareStmt{
 				{Name: "p1", SQL: `select ?`},
 				{Name: "p2", SQL: `select ?`},
+				{Name: "a-b", SQL: `select ?`},
+				{Name: "select", SQL: `select ?`},
+				{Name: "a`b", SQL: `select ?`},
+				{Name: "from", SQL: `select ?`},
 			},
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, "d1", s.GetDatabaseName())
-		assert.Equal(t, 2, len(s.prepareStmts))
+		assert.Len(t, s.prepareStmts, 6)
+		for _, name := range []string{"a-b", "select", "a`b", "from"} {
+			assert.Contains(t, s.prepareStmts, name)
+		}
 		assert.Equal(t, int64(7), s.GetLastAffectedRows())
 		assert.Equal(t, int64(7), s.GetProc().GetAffectedRows())
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25903

## What this PR does / why we need it:

Prepared statement migration sends the normalized statement name and inner SQL
to the target CN. The target reconstructed textual PREPARE statements by
interpolating the normalized name without identifier quoting. A valid source
statement such as:

```sql
prepare `a-b` from select 1
```

was therefore replayed as invalid SQL:

```sql
prepare a-b from select 1
```

Quote the normalized name with the shared `sqlquote.Ident` helper before
replay. This also doubles embedded backticks, preserving the identifier and the
SQL statement boundary without changing the migration protobuf.

The regression test follows the real source parser and target migration path
for:

- ordinary names;
- names containing `-`;
- reserved words;
- names containing an embedded backtick.

Validation:

- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s -run '^TestSession_Migrate$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=240s ./pkg/frontend`
- `go test -count=1 ./pkg/common/sqlquote`
- `go build ./pkg/frontend` (with the repository CGo environment)
- `go vet ./pkg/frontend` (with the repository CGo environment)
