### PR TITLE
fix: preserve quoted aliases in CTAS (cherry-pick #25926)

### DIFF
--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -272,6 +272,11 @@ func TestQuoteSelectAlias(t *testing.T) {
 			sql:  "select `s``x`.`a``b` as `x``y` from `src``table` as `s``x`",
 			want: "select `s``x`.`a``b` as `x``y` from `src``table` as `s``x`",
 		},
+		{
+			name: "quoted index hints",
+			sql:  "select * from tbl force index (`select`, `a b`, `x``y`)",
+			want: "select * from `tbl` force index(`select`, `a b`, `x``y`)",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -277,6 +277,11 @@ func TestQuoteSelectAlias(t *testing.T) {
 			sql:  "select * from tbl force index (`select`, `a b`, `x``y`)",
 			want: "select * from `tbl` force index(`select`, `a b`, `x``y`)",
 		},
+		{
+			name: "quoted user variables",
+			sql:  "select @`a b`, @`select`, @`x``y`, @@autocommit",
+			want: "select @`a b`, @`select`, @`x``y`, @@autocommit",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -279,8 +279,8 @@ func TestQuoteSelectAlias(t *testing.T) {
 		},
 		{
 			name: "quoted user variables",
-			sql:  "select @`a b`, @`select`, @`x``y`, @@autocommit",
-			want: "select @`a b`, @`select`, @`x``y`, @@autocommit",
+			sql:  "select @`a b`, @`select`, @`x``y`, @@global.autocommit, @@session.autocommit, @@autocommit",
+			want: "select @`a b`, @`select`, @`x``y`, @@global.autocommit, @@autocommit, @@autocommit",
 		},
 	}
 
@@ -1130,10 +1130,10 @@ var (
 			output: "select @@tx_isolation",
 		}, {
 			input:  "select @@global.tx_isolation",
-			output: "select @@tx_isolation",
+			output: "select @@global.tx_isolation",
 		}, {
 			input:  "select @@GLOBAL.tx_isolation",
-			output: "select @@tx_isolation",
+			output: "select @@global.tx_isolation",
 		}, {
 			input:  "/* mysql-connector-java-8.0.27 (Revision: e920b979015ae7117d60d72bcc8f077a839cd791) */SHOW VARIABLES;",
 			output: "show variables",

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -247,13 +247,44 @@ func TestQuoteIdentifer(t *testing.T) {
 }
 
 func TestQuoteSelectAlias(t *testing.T) {
-	ast, err := ParseOne(context.TODO(), "select col as `中文别名` from tbl", 1)
-	require.NoError(t, err)
-	require.Equal(
-		t,
-		"select `col` as `中文别名` from `tbl`",
-		tree.StringWithOpts(ast, dialect.MYSQL, tree.WithQuoteIdentifier()),
-	)
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "reserved table alias",
+			sql:  "select `order`.col from tbl as `order`",
+			want: "select `order`.`col` from `tbl` as `order`",
+		},
+		{
+			name: "cte name and column aliases",
+			sql:  "with `select` (`from`, `中文 列`) as (select col1, col2 from tbl) select `from` from `select`",
+			want: "with `select`(`from`, `中文 列`) as (select `col1`, `col2` from `tbl`) select `from` from `select`",
+		},
+		{
+			name: "derived alias columns and join using",
+			sql:  "select `left`.`a b` from (select col as `a b` from tbl) as `left` (`a b`) join other as `right` using (`a b`)",
+			want: "select `left`.`a b` from (select `col` as `a b` from `tbl`) as `left`(`a b`) inner join `other` as `right` using (`a b`)",
+		},
+		{
+			name: "embedded backticks",
+			sql:  "select `s``x`.`a``b` as `x``y` from `src``table` as `s``x`",
+			want: "select `s``x`.`a``b` as `x``y` from `src``table` as `s``x`",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ast, err := ParseOne(context.TODO(), test.sql, 1)
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				test.want,
+				tree.StringWithOpts(ast, dialect.MYSQL, tree.WithQuoteIdentifier()),
+			)
+		})
+	}
 }
 
 var (

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -246,6 +246,16 @@ func TestQuoteIdentifer(t *testing.T) {
 	}
 }
 
+func TestQuoteSelectAlias(t *testing.T) {
+	ast, err := ParseOne(context.TODO(), "select col as `中文别名` from tbl", 1)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"select `col` as `中文别名` from `tbl`",
+		tree.StringWithOpts(ast, dialect.MYSQL, tree.WithQuoteIdentifier()),
+	)
+}
+
 var (
 	pitrSQLs = []struct {
 		input  string

--- a/pkg/sql/parsers/tree/expr.go
+++ b/pkg/sql/parsers/tree/expr.go
@@ -1679,6 +1679,9 @@ func (node *VarExpr) Format(ctx *FmtCtx) {
 		ctx.WriteByte('@')
 		if node.System {
 			ctx.WriteByte('@')
+			if node.Global {
+				ctx.WriteString("global.")
+			}
 			ctx.WriteString(node.Name)
 		} else {
 			ctx.WriteIdentifier(Identifier(node.Name))

--- a/pkg/sql/parsers/tree/expr.go
+++ b/pkg/sql/parsers/tree/expr.go
@@ -1679,8 +1679,10 @@ func (node *VarExpr) Format(ctx *FmtCtx) {
 		ctx.WriteByte('@')
 		if node.System {
 			ctx.WriteByte('@')
+			ctx.WriteString(node.Name)
+		} else {
+			ctx.WriteIdentifier(Identifier(node.Name))
 		}
-		ctx.WriteString(node.Name)
 	}
 }
 

--- a/pkg/sql/parsers/tree/identifier.go
+++ b/pkg/sql/parsers/tree/identifier.go
@@ -42,7 +42,7 @@ func (node *IdentifierList) Format(ctx *FmtCtx) {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.WriteString(string((*node)[i]))
+		ctx.WriteIdentifier((*node)[i])
 	}
 }
 
@@ -119,19 +119,10 @@ func (node *UnresolvedName) ColNameOrigin() string {
 }
 
 func (node *UnresolvedName) Format(ctx *FmtCtx) {
-	if ctx.quoteIdentifier {
-		for i := node.NumParts - 1; i >= 0; i-- {
-			ctx.WriteString("`" + node.CStrParts[i].Origin() + "`")
-			if i > 0 {
-				ctx.WriteByte('.')
-			}
-		}
-	} else {
-		for i := node.NumParts - 1; i >= 0; i-- {
-			ctx.WriteString(node.CStrParts[i].Origin())
-			if i > 0 {
-				ctx.WriteByte('.')
-			}
+	for i := node.NumParts - 1; i >= 0; i-- {
+		ctx.WriteIdentifier(Identifier(node.CStrParts[i].Origin()))
+		if i > 0 {
+			ctx.WriteByte('.')
 		}
 	}
 	if node.Star && node.NumParts > 0 {

--- a/pkg/sql/parsers/tree/select.go
+++ b/pkg/sql/parsers/tree/select.go
@@ -483,7 +483,7 @@ func (node *SelectExpr) Format(ctx *FmtCtx) {
 	node.Expr.Format(ctx)
 	if node.As != nil && !node.As.Empty() {
 		ctx.WriteString(" as ")
-		ctx.WriteString(node.As.Origin())
+		ctx.WriteIdentifier(Identifier(node.As.Origin()))
 	}
 }
 

--- a/pkg/sql/parsers/tree/select.go
+++ b/pkg/sql/parsers/tree/select.go
@@ -681,7 +681,7 @@ type AliasClause struct {
 
 func (node *AliasClause) Format(ctx *FmtCtx) {
 	if node.Alias != "" {
-		ctx.WriteString(string(node.Alias))
+		ctx.WriteIdentifier(node.Alias)
 	}
 	if node.Cols != nil {
 		ctx.WriteByte('(')

--- a/pkg/sql/parsers/tree/select.go
+++ b/pkg/sql/parsers/tree/select.go
@@ -816,7 +816,7 @@ func (node *IndexHint) Format(ctx *FmtCtx) {
 			if i > 0 {
 				ctx.WriteString(", ")
 			}
-			ctx.WriteString(value)
+			ctx.WriteIdentifier(Identifier(value))
 		}
 	}
 	ctx.WriteString(")")

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1447,7 +1447,13 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 
 		// insert into new_table select default_val1, default_val2, ..., * from (select clause);
 		var insertSqlBuilder strings.Builder
-		insertSqlBuilder.WriteString(fmt.Sprintf("insert into `%s`.`%s` select ", createTable.Database, createTable.TableDef.Name))
+		insertSqlBuilder.WriteString("insert into ")
+		targetFmtCtx := tree.NewFmtCtx(dialect.MYSQL, tree.WithQuoteIdentifier())
+		targetFmtCtx.WriteIdentifier(tree.Identifier(createTable.Database))
+		targetFmtCtx.WriteByte('.')
+		targetFmtCtx.WriteIdentifier(tree.Identifier(createTable.TableDef.Name))
+		insertSqlBuilder.WriteString(targetFmtCtx.String())
+		insertSqlBuilder.WriteString(" select ")
 
 		cols := createTable.TableDef.Cols
 		firstCol := true

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1468,7 +1468,11 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 		insertSqlBuilder.WriteString("*")
 
 		// from
-		fmtCtx := tree.NewFmtCtx(dialect.MYSQL, tree.WithQuoteString(true))
+		fmtCtx := tree.NewFmtCtx(
+			dialect.MYSQL,
+			tree.WithQuoteString(true),
+			tree.WithQuoteIdentifier(),
+		)
 		stmt.AsSource.Format(fmtCtx)
 		insertSqlBuilder.WriteString(fmt.Sprintf(" from (%s)", restoreIntervalSyntaxForCTAS(fmtCtx.String())))
 

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1734,13 +1734,19 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 func restoreIntervalSyntaxForCTAS(sql string) string {
 	var out strings.Builder
 	for i := 0; i < len(sql); {
+		if sql[i] == '\'' || sql[i] == '"' {
+			next := skipQuotedStringForCTAS(sql, i, sql[i])
+			out.WriteString(sql[i:next])
+			i = next
+			continue
+		}
 		if sql[i] == '`' {
 			next := skipBacktickIdentifierForCTAS(sql, i)
 			out.WriteString(sql[i:next])
 			i = next
 			continue
 		}
-		if !strings.HasPrefix(strings.ToLower(sql[i:]), "interval(") {
+		if !hasIntervalKeywordAt(sql, i) {
 			out.WriteByte(sql[i])
 			i++
 			continue
@@ -1767,46 +1773,70 @@ func parseIntervalCall(sql string, start int) (expr string, unit string, next in
 	pos := start + len(prefix)
 	depth := 1
 	comma := -1
-	inSingleQuote := false
-	inDoubleQuote := false
 
 	for pos < len(sql) {
 		ch := sql[pos]
-		if ch == '`' && !inSingleQuote && !inDoubleQuote {
+		if ch == '\'' || ch == '"' {
+			pos = skipQuotedStringForCTAS(sql, pos, ch)
+			continue
+		}
+		if ch == '`' {
 			pos = skipBacktickIdentifierForCTAS(sql, pos)
 			continue
 		}
 		switch ch {
-		case '\'':
-			if !inDoubleQuote {
-				inSingleQuote = !inSingleQuote
-			}
-		case '"':
-			if !inSingleQuote {
-				inDoubleQuote = !inDoubleQuote
-			}
 		case '(':
-			if !inSingleQuote && !inDoubleQuote {
-				depth++
-			}
+			depth++
 		case ')':
-			if !inSingleQuote && !inDoubleQuote {
-				depth--
-				if depth == 0 {
-					if comma == -1 {
-						return "", "", 0, false
-					}
-					return sql[start+len(prefix) : comma], sql[comma+1 : pos], pos + 1, true
+			depth--
+			if depth == 0 {
+				if comma == -1 {
+					return "", "", 0, false
 				}
+				return sql[start+len(prefix) : comma], sql[comma+1 : pos], pos + 1, true
 			}
 		case ',':
-			if !inSingleQuote && !inDoubleQuote && depth == 1 && comma == -1 {
+			if depth == 1 && comma == -1 {
 				comma = pos
 			}
 		}
 		pos++
 	}
 	return "", "", 0, false
+}
+
+func hasIntervalKeywordAt(sql string, start int) bool {
+	const keyword = "interval"
+	end := start + len(keyword)
+	if end >= len(sql) || sql[end] != '(' || !strings.EqualFold(sql[start:end], keyword) {
+		return false
+	}
+	return start == 0 || !isSQLIdentifierByte(sql[start-1])
+}
+
+func isSQLIdentifierByte(ch byte) bool {
+	return ch >= 0x80 || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' ||
+		ch >= '0' && ch <= '9' || ch == '_' || ch == '$'
+}
+
+func skipQuotedStringForCTAS(sql string, start int, quote byte) int {
+	for pos := start + 1; pos < len(sql); pos++ {
+		if sql[pos] == '\\' {
+			if pos+1 < len(sql) {
+				pos++
+			}
+			continue
+		}
+		if sql[pos] != quote {
+			continue
+		}
+		if pos+1 < len(sql) && sql[pos+1] == quote {
+			pos++
+			continue
+		}
+		return pos + 1
+	}
+	return len(sql)
 }
 
 func skipBacktickIdentifierForCTAS(sql string, start int) int {

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1734,6 +1734,12 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 func restoreIntervalSyntaxForCTAS(sql string) string {
 	var out strings.Builder
 	for i := 0; i < len(sql); {
+		if sql[i] == '`' {
+			next := skipBacktickIdentifierForCTAS(sql, i)
+			out.WriteString(sql[i:next])
+			i = next
+			continue
+		}
 		if !strings.HasPrefix(strings.ToLower(sql[i:]), "interval(") {
 			out.WriteByte(sql[i])
 			i++
@@ -1766,6 +1772,10 @@ func parseIntervalCall(sql string, start int) (expr string, unit string, next in
 
 	for pos < len(sql) {
 		ch := sql[pos]
+		if ch == '`' && !inSingleQuote && !inDoubleQuote {
+			pos = skipBacktickIdentifierForCTAS(sql, pos)
+			continue
+		}
 		switch ch {
 		case '\'':
 			if !inDoubleQuote {
@@ -1797,6 +1807,20 @@ func parseIntervalCall(sql string, start int) (expr string, unit string, next in
 		pos++
 	}
 	return "", "", 0, false
+}
+
+func skipBacktickIdentifierForCTAS(sql string, start int) int {
+	for pos := start + 1; pos < len(sql); pos++ {
+		if sql[pos] != '`' {
+			continue
+		}
+		if pos+1 < len(sql) && sql[pos+1] == '`' {
+			pos++
+			continue
+		}
+		return pos + 1
+	}
+	return len(sql)
 }
 
 func isIntervalUnitToken(unit string) bool {

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -667,13 +667,43 @@ func TestCreateTableAsSelectQuotesIdentifiers(t *testing.T) {
 }
 
 func TestCreateTableAsSelectPreservesIntervalSyntax(t *testing.T) {
-	got := restoreIntervalSyntaxForCTAS(
-		"select date_add(col2, interval(45, day)), date_sub(col2, interval(5, day)) from time01",
-	)
-	require.Contains(t, got, "interval 45 day")
-	require.Contains(t, got, "interval 5 day")
-	require.NotContains(t, got, "interval(45, day)")
-	require.NotContains(t, got, "interval(5, day)")
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "interval expressions",
+			sql:  "select date_add(col2, interval(45, day)), date_sub(col2, interval(5, day)) from time01",
+			want: "select date_add(col2, interval 45 day), date_sub(col2, interval 5 day) from time01",
+		},
+		{
+			name: "interval text in identifier",
+			sql:  "select `interval(x,day)` from src as `interval(y,month)`",
+			want: "select `interval(x,day)` from src as `interval(y,month)`",
+		},
+		{
+			name: "doubled backtick in identifier",
+			sql:  "select `a``interval(x,day)` from src",
+			want: "select `a``interval(x,day)` from src",
+		},
+		{
+			name: "unclosed backtick",
+			sql:  "select `interval(x,day)",
+			want: "select `interval(x,day)",
+		},
+		{
+			name: "quoted interval operand",
+			sql:  "select date_add(col2, interval(`a,b)`, day)) from src",
+			want: "select date_add(col2, interval `a,b)` day) from src",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, restoreIntervalSyntaxForCTAS(test.sql))
+		})
+	}
 }
 
 func TestParseDuration(t *testing.T) {

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -630,6 +630,24 @@ func TestCreateTableAsSelect(t *testing.T) {
 	runTestShouldPass(mock, t, sqls, false, false)
 }
 
+func TestCreateTableAsSelectQuotesIdentifiers(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	logicPlan, err := buildSingleStmt(
+		mock,
+		t,
+		"CREATE TABLE ctas_alias AS SELECT N_NAME AS `中文别名` FROM NATION",
+	)
+	require.NoError(t, err)
+
+	createTable := logicPlan.GetDdl().GetCreateTable()
+	require.NotNil(t, createTable)
+	require.Equal(
+		t,
+		"insert into `tpch`.`ctas_alias` select * from (select `nation`.`N_NAME` as `中文别名` from `nation`)",
+		createTable.GetCreateAsSelectSql(),
+	)
+}
+
 func TestCreateTableAsSelectPreservesIntervalSyntax(t *testing.T) {
 	got := restoreIntervalSyntaxForCTAS(
 		"select date_add(col2, interval(45, day)), date_sub(col2, interval(5, day)) from time01",

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -697,6 +697,36 @@ func TestCreateTableAsSelectPreservesIntervalSyntax(t *testing.T) {
 			sql:  "select date_add(col2, interval(`a,b)`, day)) from src",
 			want: "select date_add(col2, interval `a,b)` day) from src",
 		},
+		{
+			name: "single quoted string",
+			sql:  "select 'interval(1,day)' as c",
+			want: "select 'interval(1,day)' as c",
+		},
+		{
+			name: "double quoted string",
+			sql:  `select "interval(1,day)" as c`,
+			want: `select "interval(1,day)" as c`,
+		},
+		{
+			name: "doubled quote in string",
+			sql:  "select 'a''interval(1,day)' as c",
+			want: "select 'a''interval(1,day)' as c",
+		},
+		{
+			name: "backslash escaped quote in string",
+			sql:  `select 'a\'interval(1,day)' as c`,
+			want: `select 'a\'interval(1,day)' as c`,
+		},
+		{
+			name: "unclosed quoted string",
+			sql:  "select 'interval(1,day)",
+			want: "select 'interval(1,day)",
+		},
+		{
+			name: "identifier prefix",
+			sql:  "select myinterval(1, day), $interval(2, day), 中文interval(3, day)",
+			want: "select myinterval(1, day), $interval(2, day), 中文interval(3, day)",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -632,20 +632,38 @@ func TestCreateTableAsSelect(t *testing.T) {
 
 func TestCreateTableAsSelectQuotesIdentifiers(t *testing.T) {
 	mock := NewMockOptimizer(false)
-	logicPlan, err := buildSingleStmt(
-		mock,
-		t,
-		"CREATE TABLE ctas_alias AS SELECT N_NAME AS `中文别名` FROM NATION",
-	)
-	require.NoError(t, err)
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "non-ASCII select alias",
+			sql:  "CREATE TABLE ctas_alias AS SELECT N_NAME AS `中文别名` FROM NATION",
+			want: "insert into `tpch`.`ctas_alias` select * from (select `nation`.`N_NAME` as `中文别名` from `nation`)",
+		},
+		{
+			name: "reserved table alias",
+			sql:  "CREATE TABLE ctas_alias AS SELECT `order`.N_NAME AS `select` FROM NATION AS `order`",
+			want: "insert into `tpch`.`ctas_alias` select * from (select `order`.`N_NAME` as `select` from `nation` as `order`)",
+		},
+		{
+			name: "embedded backtick in target name",
+			sql:  "CREATE TABLE `ctas``alias` AS SELECT N_NAME FROM NATION",
+			want: "insert into `tpch`.`ctas``alias` select * from (select `nation`.`N_NAME` from `nation`)",
+		},
+	}
 
-	createTable := logicPlan.GetDdl().GetCreateTable()
-	require.NotNil(t, createTable)
-	require.Equal(
-		t,
-		"insert into `tpch`.`ctas_alias` select * from (select `nation`.`N_NAME` as `中文别名` from `nation`)",
-		createTable.GetCreateAsSelectSql(),
-	)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logicPlan, err := buildSingleStmt(mock, t, test.sql)
+			require.NoError(t, err)
+
+			createTable := logicPlan.GetDdl().GetCreateTable()
+			require.NotNil(t, createTable)
+			require.Equal(t, test.want, createTable.GetCreateAsSelectSql())
+		})
+	}
 }
 
 func TestCreateTableAsSelectPreservesIntervalSyntax(t *testing.T) {

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -1670,12 +1670,22 @@ create table ctas_interval_identifier_src (`interval(x,day)` int);
 insert into ctas_interval_identifier_src values (1), (2);
 create table ctas_interval_identifier_dst as
 select `interval(x,day)` from ctas_interval_identifier_src;
+desc ctas_interval_identifier_dst;
+➤ Field[1,0,0]  ¦  Type[1,0,0]  ¦  Null[1,0,0]  ¦  Key[1,0,0]  ¦  Default[1,0,0]  ¦  Extra[1,0,0]  ¦  Comment[1,0,0]  𝄀
+interval(x,day)  ¦  INT(32)  ¦  YES  ¦    ¦  null  ¦    ¦  
 select `interval(x,day)` from ctas_interval_identifier_dst order by `interval(x,day)`;
 ➤ interval(x,day)[4,32,0]  𝄀
 1  𝄀
 2
 drop table ctas_interval_identifier_dst;
 drop table ctas_interval_identifier_src;
+drop table if exists ctas_interval_string;
+create table ctas_interval_string as
+select 'interval(1,day)' as single_quoted, "interval(2,month)" as double_quoted;
+select * from ctas_interval_string;
+➤ single_quoted[12,-1,0]  ¦  double_quoted[12,-1,0]  𝄀
+interval(1,day)  ¦  interval(2,month)
+drop table ctas_interval_string;
 drop table alias01;
 drop database test;
 drop database if exists db1;

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -1686,6 +1686,16 @@ select * from ctas_interval_string;
 ➤ single_quoted[12,-1,0]  ¦  double_quoted[12,-1,0]  𝄀
 interval(1,day)  ¦  interval(2,month)
 drop table ctas_interval_string;
+set @`a b` = 1;
+set @`select` = 2;
+set @`x``y` = 3;
+drop table if exists ctas_user_variable;
+create table ctas_user_variable as
+select @`a b` as space_name, @`select` as reserved_name, @`x``y` as backtick_name;
+select * from ctas_user_variable;
+➤ space_name[12,0,0]  ¦  reserved_name[12,0,0]  ¦  backtick_name[12,0,0]  𝄀
+1  ¦  2  ¦  3
+drop table ctas_user_variable;
 drop table alias01;
 drop database test;
 drop database if exists db1;

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -1602,6 +1602,16 @@ select * from alias02;
 newcol    col1    col2
 null    1    2
 null    2    3
+drop table if exists ctas_non_ascii_alias;
+create table ctas_non_ascii_alias as select col1 as `中文别名` from alias01;
+desc ctas_non_ascii_alias;
+Field    Type    Null    Key    Default    Extra    Comment
+中文别名    INT(32)    YES        null        
+select `中文别名` from ctas_non_ascii_alias order by `中文别名`;
+中文别名
+1
+2
+drop table ctas_non_ascii_alias;
 drop table alias01;
 drop database test;
 drop database if exists db1;

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -1697,6 +1697,19 @@ select * from ctas_user_variable;
 1  ¦  2  ¦  3
 drop table ctas_user_variable;
 drop table alias01;
+set global autocommit = off;
+set session autocommit = on;
+select @@global.autocommit, @@session.autocommit;
+➤ @@global.autocommit[12,0,0]  ¦  @@autocommit[12,0,0]  𝄀
+0  ¦  1
+drop table if exists ctas_system_variable_scope;
+create table ctas_system_variable_scope as
+select @@global.autocommit as global_value, @@session.autocommit as session_value;
+select * from ctas_system_variable_scope;
+➤ global_value[12,0,0]  ¦  session_value[12,0,0]  𝄀
+0  ¦  1
+drop table ctas_system_variable_scope;
+set global autocommit = on;
 drop database test;
 drop database if exists db1;
 create database db1;

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -1612,6 +1612,41 @@ select `中文别名` from ctas_non_ascii_alias order by `中文别名`;
 1
 2
 drop table ctas_non_ascii_alias;
+drop table if exists ctas_reserved_alias;
+create table ctas_reserved_alias as select `order`.col1 as `select` from alias01 as `order`;
+select `select` from ctas_reserved_alias order by `select`;
+➤ select[4,32,0]  𝄀
+1  𝄀
+2
+drop table ctas_reserved_alias;
+drop table if exists ctas_cte_alias;
+create table ctas_cte_alias as with `select` (`from`) as (select col1 from alias01) select `from` from `select`;
+select `from` from ctas_cte_alias order by `from`;
+➤ from[4,32,0]  𝄀
+1  𝄀
+2
+drop table ctas_cte_alias;
+drop table if exists ctas_join_alias;
+create table ctas_join_alias as
+select `left`.`a b`
+from (select col1 as `a b` from alias01) as `left` (`a b`)
+join (select col1 as `a b` from alias01) as `right` (`a b`) using (`a b`);
+select `a b` from ctas_join_alias order by `a b`;
+➤ a b[4,32,0]  𝄀
+1  𝄀
+2
+drop table ctas_join_alias;
+drop table if exists `src``table`;
+drop table if exists `dst``table`;
+create table `src``table` (`a``b` int);
+insert into `src``table` values (1), (2);
+create table `dst``table` as select `s``x`.`a``b` as `x``y` from `src``table` as `s``x`;
+select `x``y` from `dst``table` order by `x``y`;
+➤ x`y[4,32,0]  𝄀
+1  𝄀
+2
+drop table `dst``table`;
+drop table `src``table`;
 drop table alias01;
 drop database test;
 drop database if exists db1;

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -1647,6 +1647,35 @@ select `x``y` from `dst``table` order by `x``y`;
 2
 drop table `dst``table`;
 drop table `src``table`;
+drop table if exists ctas_index_hint_src;
+drop table if exists ctas_index_hint_dst;
+create table ctas_index_hint_src (
+col1 int,
+index `select` (col1),
+index `a b` (col1),
+index `x``y` (col1)
+);
+insert into ctas_index_hint_src values (1), (2);
+create table ctas_index_hint_dst as
+select * from ctas_index_hint_src force index (`select`, `a b`, `x``y`);
+select * from ctas_index_hint_dst order by col1;
+➤ col1[4,32,0]  𝄀
+1  𝄀
+2
+drop table ctas_index_hint_dst;
+drop table ctas_index_hint_src;
+drop table if exists ctas_interval_identifier_src;
+drop table if exists ctas_interval_identifier_dst;
+create table ctas_interval_identifier_src (`interval(x,day)` int);
+insert into ctas_interval_identifier_src values (1), (2);
+create table ctas_interval_identifier_dst as
+select `interval(x,day)` from ctas_interval_identifier_src;
+select `interval(x,day)` from ctas_interval_identifier_dst order by `interval(x,day)`;
+➤ interval(x,day)[4,32,0]  𝄀
+1  𝄀
+2
+drop table ctas_interval_identifier_dst;
+drop table ctas_interval_identifier_src;
 drop table alias01;
 drop database test;
 drop database if exists db1;

--- a/test/distributed/cases/ddl/create_table_as_select.sql
+++ b/test/distributed/cases/ddl/create_table_as_select.sql
@@ -1139,6 +1139,29 @@ create table `dst``table` as select `s``x`.`a``b` as `x``y` from `src``table` as
 select `x``y` from `dst``table` order by `x``y`;
 drop table `dst``table`;
 drop table `src``table`;
+drop table if exists ctas_index_hint_src;
+drop table if exists ctas_index_hint_dst;
+create table ctas_index_hint_src (
+    col1 int,
+    index `select` (col1),
+    index `a b` (col1),
+    index `x``y` (col1)
+);
+insert into ctas_index_hint_src values (1), (2);
+create table ctas_index_hint_dst as
+select * from ctas_index_hint_src force index (`select`, `a b`, `x``y`);
+select * from ctas_index_hint_dst order by col1;
+drop table ctas_index_hint_dst;
+drop table ctas_index_hint_src;
+drop table if exists ctas_interval_identifier_src;
+drop table if exists ctas_interval_identifier_dst;
+create table ctas_interval_identifier_src (`interval(x,day)` int);
+insert into ctas_interval_identifier_src values (1), (2);
+create table ctas_interval_identifier_dst as
+select `interval(x,day)` from ctas_interval_identifier_src;
+select `interval(x,day)` from ctas_interval_identifier_dst order by `interval(x,day)`;
+drop table ctas_interval_identifier_dst;
+drop table ctas_interval_identifier_src;
 drop table alias01;
 -- @session
 drop database test;

--- a/test/distributed/cases/ddl/create_table_as_select.sql
+++ b/test/distributed/cases/ddl/create_table_as_select.sql
@@ -1111,6 +1111,11 @@ drop table if exists alias02;
 create table alias02 (NewCol int) as select * from alias01;
 show create table alias02;
 select * from alias02;
+drop table if exists ctas_non_ascii_alias;
+create table ctas_non_ascii_alias as select col1 as `中文别名` from alias01;
+desc ctas_non_ascii_alias;
+select `中文别名` from ctas_non_ascii_alias order by `中文别名`;
+drop table ctas_non_ascii_alias;
 drop table alias01;
 -- @session
 drop database test;

--- a/test/distributed/cases/ddl/create_table_as_select.sql
+++ b/test/distributed/cases/ddl/create_table_as_select.sql
@@ -1159,9 +1159,15 @@ create table ctas_interval_identifier_src (`interval(x,day)` int);
 insert into ctas_interval_identifier_src values (1), (2);
 create table ctas_interval_identifier_dst as
 select `interval(x,day)` from ctas_interval_identifier_src;
+desc ctas_interval_identifier_dst;
 select `interval(x,day)` from ctas_interval_identifier_dst order by `interval(x,day)`;
 drop table ctas_interval_identifier_dst;
 drop table ctas_interval_identifier_src;
+drop table if exists ctas_interval_string;
+create table ctas_interval_string as
+select 'interval(1,day)' as single_quoted, "interval(2,month)" as double_quoted;
+select * from ctas_interval_string;
+drop table ctas_interval_string;
 drop table alias01;
 -- @session
 drop database test;

--- a/test/distributed/cases/ddl/create_table_as_select.sql
+++ b/test/distributed/cases/ddl/create_table_as_select.sql
@@ -1178,6 +1178,15 @@ select * from ctas_user_variable;
 drop table ctas_user_variable;
 drop table alias01;
 -- @session
+set global autocommit = off;
+set session autocommit = on;
+select @@global.autocommit, @@session.autocommit;
+drop table if exists ctas_system_variable_scope;
+create table ctas_system_variable_scope as
+select @@global.autocommit as global_value, @@session.autocommit as session_value;
+select * from ctas_system_variable_scope;
+drop table ctas_system_variable_scope;
+set global autocommit = on;
 drop database test;
 
 -- privilege

--- a/test/distributed/cases/ddl/create_table_as_select.sql
+++ b/test/distributed/cases/ddl/create_table_as_select.sql
@@ -1116,6 +1116,29 @@ create table ctas_non_ascii_alias as select col1 as `中文别名` from alias01;
 desc ctas_non_ascii_alias;
 select `中文别名` from ctas_non_ascii_alias order by `中文别名`;
 drop table ctas_non_ascii_alias;
+drop table if exists ctas_reserved_alias;
+create table ctas_reserved_alias as select `order`.col1 as `select` from alias01 as `order`;
+select `select` from ctas_reserved_alias order by `select`;
+drop table ctas_reserved_alias;
+drop table if exists ctas_cte_alias;
+create table ctas_cte_alias as with `select` (`from`) as (select col1 from alias01) select `from` from `select`;
+select `from` from ctas_cte_alias order by `from`;
+drop table ctas_cte_alias;
+drop table if exists ctas_join_alias;
+create table ctas_join_alias as
+select `left`.`a b`
+from (select col1 as `a b` from alias01) as `left` (`a b`)
+join (select col1 as `a b` from alias01) as `right` (`a b`) using (`a b`);
+select `a b` from ctas_join_alias order by `a b`;
+drop table ctas_join_alias;
+drop table if exists `src``table`;
+drop table if exists `dst``table`;
+create table `src``table` (`a``b` int);
+insert into `src``table` values (1), (2);
+create table `dst``table` as select `s``x`.`a``b` as `x``y` from `src``table` as `s``x`;
+select `x``y` from `dst``table` order by `x``y`;
+drop table `dst``table`;
+drop table `src``table`;
 drop table alias01;
 -- @session
 drop database test;

--- a/test/distributed/cases/ddl/create_table_as_select.sql
+++ b/test/distributed/cases/ddl/create_table_as_select.sql
@@ -1168,6 +1168,14 @@ create table ctas_interval_string as
 select 'interval(1,day)' as single_quoted, "interval(2,month)" as double_quoted;
 select * from ctas_interval_string;
 drop table ctas_interval_string;
+set @`a b` = 1;
+set @`select` = 2;
+set @`x``y` = 3;
+drop table if exists ctas_user_variable;
+create table ctas_user_variable as
+select @`a b` as space_name, @`select` as reserved_name, @`x``y` as backtick_name;
+select * from ctas_user_variable;
+drop table ctas_user_variable;
 drop table alias01;
 -- @session
 drop database test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #25923

## What this PR does / why we need it:

This backports #25926 to `4.1-dev`.

CTAS serializes its source `SELECT` into an internal `INSERT ... SELECT` statement and parses that SQL again. The serialization did not consistently quote identifiers, so valid aliases using non-ASCII characters, reserved words, spaces, or embedded backticks could become invalid during the rewrite.

This PR makes CTAS identifier serialization complete across SELECT aliases, table and CTE aliases, alias column lists, `JOIN ... USING` columns, qualified names, and target table names. It includes parser, planner, and end-to-end CTAS regression coverage.

Validation on `4.1-dev`:

- parser and planner package builds passed;
- parser and planner `go vet` passed;
- complete parser and planner package tests passed;
- CTAS BVT: 953 passed, 0 failed, 30 ignored.
