### PR TITLE
test(plan): benchmark low-cost row carrier pruning

### DIFF
--- a/pkg/sql/colexec/sample/sample_test.go
+++ b/pkg/sql/colexec/sample/sample_test.go
@@ -16,6 +16,8 @@ package sample
 
 import (
 	"bytes"
+	"runtime"
+	"runtime/debug"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -66,28 +68,30 @@ func makeSampleMemoryBatch(tb testing.TB, includeWide bool) (*batch.Batch, *mpoo
 	return bat, mp
 }
 
-func initializeOffHeapSampleResult(pool *sPool, input *batch.Batch) {
-	result := batch.NewWithSize(len(input.Vecs))
-	for i, vec := range input.Vecs {
-		result.Vecs[i] = vector.NewOffHeapVecWithType(*vec.GetType())
-	}
-
-	if len(input.Vecs) > 1 {
-		pool.growMulPool(1, len(input.Vecs))
-		pool.mPools[0].data.validBatch = result
-	} else {
-		pool.growSiPool(1)
-		pool.sPools[0].data.validBatch = result
-	}
-}
-
 func executeSampleMemoryCase(tb testing.TB, proc *process.Process, input *batch.Batch) sampleMemoryStats {
 	tb.Helper()
+
+	benchmark, isBenchmark := tb.(*testing.B)
+	if isBenchmark {
+		benchmark.StopTimer()
+	}
+	runtime.GC()
+	previousGCPercent := debug.SetGCPercent(-1)
+	gcRestored := false
+	defer func() {
+		if !gcRestored {
+			debug.SetGCPercent(previousGCPercent)
+		}
+	}()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	if isBenchmark {
+		benchmark.StartTimer()
+	}
 
 	mp := proc.Mp()
 	pool := newSamplePoolByRows(proc, input.RowCount(), len(input.Vecs), false)
 	defer pool.Free()
-	initializeOffHeapSampleResult(pool, input)
 	if err := pool.Sample(1, input.Vecs, nil, input); err != nil {
 		tb.Fatal(err)
 	}
@@ -98,14 +102,24 @@ func executeSampleMemoryCase(tb testing.TB, proc *process.Process, input *batch.
 	if result.RowCount() != input.RowCount() {
 		tb.Fatalf("expected %d sampled rows, got %d", input.RowCount(), result.RowCount())
 	}
+	if isBenchmark {
+		benchmark.StopTimer()
+	}
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
 
 	stats := sampleMemoryStats{
 		retainedBytes: int64(result.Allocated()),
-		peakBytes:     mp.Stats().HighWaterMark.Load(),
+		peakBytes:     int64(after.HeapAlloc - before.HeapAlloc),
 	}
 	result.Clean(mp)
 	if curr := mp.CurrNB(); curr != 0 {
 		tb.Fatalf("sample execution leaked %d mpool bytes", curr)
+	}
+	debug.SetGCPercent(previousGCPercent)
+	gcRestored = true
+	if isBenchmark {
+		benchmark.StartTimer()
 	}
 	return stats
 }
@@ -152,15 +166,16 @@ func BenchmarkSamplePrunedWideVarlenMemory(b *testing.B) {
 			proc := testutil.NewProcessWithMPool(b, "", outputMP)
 			defer proc.Free()
 
-			var retainedBytes int64
+			var peakBytes, retainedBytes int64
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
 				stats := executeSampleMemoryCase(b, proc, input)
+				peakBytes += stats.peakBytes
 				retainedBytes += stats.retainedBytes
 			}
+			b.ReportMetric(float64(peakBytes)/float64(b.N), "heap-peak-B/op")
 			b.ReportMetric(float64(retainedBytes)/float64(b.N), "vector-retained-B/op")
-			b.ReportMetric(float64(outputMP.Stats().HighWaterMark.Load()), "mpool-peak-B")
 		})
 	}
 }

--- a/pkg/sql/colexec/sample/sample_test.go
+++ b/pkg/sql/colexec/sample/sample_test.go
@@ -71,24 +71,6 @@ func makeSampleMemoryBatch(tb testing.TB, includeWide bool) (*batch.Batch, *mpoo
 func executeSampleMemoryCase(tb testing.TB, proc *process.Process, input *batch.Batch) sampleMemoryStats {
 	tb.Helper()
 
-	benchmark, isBenchmark := tb.(*testing.B)
-	if isBenchmark {
-		benchmark.StopTimer()
-	}
-	runtime.GC()
-	previousGCPercent := debug.SetGCPercent(-1)
-	gcRestored := false
-	defer func() {
-		if !gcRestored {
-			debug.SetGCPercent(previousGCPercent)
-		}
-	}()
-	var before runtime.MemStats
-	runtime.ReadMemStats(&before)
-	if isBenchmark {
-		benchmark.StartTimer()
-	}
-
 	mp := proc.Mp()
 	pool := newSamplePoolByRows(proc, input.RowCount(), len(input.Vecs), false)
 	defer pool.Free()
@@ -102,24 +84,13 @@ func executeSampleMemoryCase(tb testing.TB, proc *process.Process, input *batch.
 	if result.RowCount() != input.RowCount() {
 		tb.Fatalf("expected %d sampled rows, got %d", input.RowCount(), result.RowCount())
 	}
-	if isBenchmark {
-		benchmark.StopTimer()
-	}
-	var after runtime.MemStats
-	runtime.ReadMemStats(&after)
 
 	stats := sampleMemoryStats{
 		retainedBytes: int64(result.Allocated()),
-		peakBytes:     int64(after.HeapAlloc - before.HeapAlloc),
 	}
 	result.Clean(mp)
 	if curr := mp.CurrNB(); curr != 0 {
 		tb.Fatalf("sample execution leaked %d mpool bytes", curr)
-	}
-	debug.SetGCPercent(previousGCPercent)
-	gcRestored = true
-	if isBenchmark {
-		benchmark.StartTimer()
 	}
 	return stats
 }
@@ -135,7 +106,17 @@ func measureSampleMemoryCase(tb testing.TB, includeWide bool) sampleMemoryStats 
 	defer mpool.DeleteMPool(outputMP)
 	proc := testutil.NewProcessWithMPool(tb, "", outputMP)
 	defer proc.Free()
-	return executeSampleMemoryCase(tb, proc, input)
+
+	runtime.GC()
+	previousGCPercent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(previousGCPercent)
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	stats := executeSampleMemoryCase(tb, proc, input)
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	stats.peakBytes = int64(after.HeapAlloc - before.HeapAlloc)
+	return stats
 }
 
 func TestSamplePrunedWideVarlenMemory(t *testing.T) {
@@ -166,15 +147,13 @@ func BenchmarkSamplePrunedWideVarlenMemory(b *testing.B) {
 			proc := testutil.NewProcessWithMPool(b, "", outputMP)
 			defer proc.Free()
 
-			var peakBytes, retainedBytes int64
+			var retainedBytes int64
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
 				stats := executeSampleMemoryCase(b, proc, input)
-				peakBytes += stats.peakBytes
 				retainedBytes += stats.retainedBytes
 			}
-			b.ReportMetric(float64(peakBytes)/float64(b.N), "heap-peak-B/op")
 			b.ReportMetric(float64(retainedBytes)/float64(b.N), "vector-retained-B/op")
 		})
 	}

--- a/pkg/sql/colexec/sample/sample_test.go
+++ b/pkg/sql/colexec/sample/sample_test.go
@@ -15,8 +15,10 @@
 package sample
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -26,6 +28,121 @@ import (
 )
 
 const nullFlag = int64(-65535)
+
+const (
+	wideSampleRows  = 64
+	wideSampleBytes = 64 << 10
+)
+
+type sampleMemoryStats struct {
+	retainedBytes int64
+}
+
+func makeSampleMemoryBatch(tb testing.TB, includeWide bool) (*batch.Batch, *mpool.MPool) {
+	tb.Helper()
+
+	mp := mpool.MustNewZeroNoFixed()
+	columnCount := 1
+	if includeWide {
+		columnCount++
+	}
+	bat := batch.NewWithSize(columnCount)
+	column := 0
+	if includeWide {
+		bat.Vecs[column] = vector.NewVec(types.T_text.ToType())
+		payload := bytes.Repeat([]byte{'x'}, wideSampleBytes)
+		for range wideSampleRows {
+			require.NoError(tb, vector.AppendBytes(bat.Vecs[column], payload, false, mp))
+		}
+		column++
+	}
+
+	bat.Vecs[column] = vector.NewVec(types.T_int8.ToType())
+	for i := range wideSampleRows {
+		require.NoError(tb, vector.AppendFixed(bat.Vecs[column], int8(i), false, mp))
+	}
+	bat.SetRowCount(wideSampleRows)
+	return bat, mp
+}
+
+func executeSampleMemoryCase(tb testing.TB, proc *process.Process, input *batch.Batch) sampleMemoryStats {
+	tb.Helper()
+
+	mp := proc.Mp()
+	pool := newSamplePoolByRows(proc, input.RowCount(), len(input.Vecs), false)
+	if err := pool.Sample(1, input.Vecs, nil, input); err != nil {
+		tb.Fatal(err)
+	}
+	result, err := pool.Result(true)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if result.RowCount() != input.RowCount() {
+		tb.Fatalf("expected %d sampled rows, got %d", input.RowCount(), result.RowCount())
+	}
+
+	stats := sampleMemoryStats{
+		retainedBytes: int64(result.Allocated()),
+	}
+	result.Clean(mp)
+	pool.Free()
+	if curr := mp.CurrNB(); curr != 0 {
+		tb.Fatalf("sample execution leaked %d mpool bytes", curr)
+	}
+	return stats
+}
+
+func measureSampleMemoryCase(tb testing.TB, includeWide bool) sampleMemoryStats {
+	tb.Helper()
+
+	input, inputMP := makeSampleMemoryBatch(tb, includeWide)
+	defer mpool.DeleteMPool(inputMP)
+	defer input.Clean(inputMP)
+
+	outputMP := mpool.MustNewZeroNoFixed()
+	defer mpool.DeleteMPool(outputMP)
+	proc := testutil.NewProcessWithMPool(tb, "", outputMP)
+	defer proc.Free()
+	return executeSampleMemoryCase(tb, proc, input)
+}
+
+func TestSamplePrunedWideVarlenMemory(t *testing.T) {
+	unpruned := measureSampleMemoryCase(t, true)
+	pruned := measureSampleMemoryCase(t, false)
+
+	require.Positive(t, pruned.retainedBytes)
+	require.Greater(t, unpruned.retainedBytes, pruned.retainedBytes*100)
+}
+
+func BenchmarkSamplePrunedWideVarlenMemory(b *testing.B) {
+	for _, test := range []struct {
+		name        string
+		includeWide bool
+	}{
+		{name: "unpruned_wide", includeWide: true},
+		{name: "pruned_carrier", includeWide: false},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			input, inputMP := makeSampleMemoryBatch(b, test.includeWide)
+			defer mpool.DeleteMPool(inputMP)
+			defer input.Clean(inputMP)
+
+			outputMP := mpool.MustNewZeroNoFixed()
+			defer mpool.DeleteMPool(outputMP)
+			proc := testutil.NewProcessWithMPool(b, "", outputMP)
+			defer proc.Free()
+
+			var retainedBytes int64
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				stats := executeSampleMemoryCase(b, proc, input)
+				retainedBytes += stats.retainedBytes
+			}
+			b.ReportMetric(float64(retainedBytes)/float64(b.N), "vector-retained-B/op")
+		})
+	}
+}
 
 func TestSamplePool(t *testing.T) {
 	proc := testutil.NewProcess(t)

--- a/pkg/sql/colexec/sample/sample_test.go
+++ b/pkg/sql/colexec/sample/sample_test.go
@@ -36,6 +36,7 @@ const (
 
 type sampleMemoryStats struct {
 	retainedBytes int64
+	peakBytes     int64
 }
 
 func makeSampleMemoryBatch(tb testing.TB, includeWide bool) (*batch.Batch, *mpool.MPool) {
@@ -65,11 +66,28 @@ func makeSampleMemoryBatch(tb testing.TB, includeWide bool) (*batch.Batch, *mpoo
 	return bat, mp
 }
 
+func initializeOffHeapSampleResult(pool *sPool, input *batch.Batch) {
+	result := batch.NewWithSize(len(input.Vecs))
+	for i, vec := range input.Vecs {
+		result.Vecs[i] = vector.NewOffHeapVecWithType(*vec.GetType())
+	}
+
+	if len(input.Vecs) > 1 {
+		pool.growMulPool(1, len(input.Vecs))
+		pool.mPools[0].data.validBatch = result
+	} else {
+		pool.growSiPool(1)
+		pool.sPools[0].data.validBatch = result
+	}
+}
+
 func executeSampleMemoryCase(tb testing.TB, proc *process.Process, input *batch.Batch) sampleMemoryStats {
 	tb.Helper()
 
 	mp := proc.Mp()
 	pool := newSamplePoolByRows(proc, input.RowCount(), len(input.Vecs), false)
+	defer pool.Free()
+	initializeOffHeapSampleResult(pool, input)
 	if err := pool.Sample(1, input.Vecs, nil, input); err != nil {
 		tb.Fatal(err)
 	}
@@ -83,9 +101,9 @@ func executeSampleMemoryCase(tb testing.TB, proc *process.Process, input *batch.
 
 	stats := sampleMemoryStats{
 		retainedBytes: int64(result.Allocated()),
+		peakBytes:     mp.Stats().HighWaterMark.Load(),
 	}
 	result.Clean(mp)
-	pool.Free()
 	if curr := mp.CurrNB(); curr != 0 {
 		tb.Fatalf("sample execution leaked %d mpool bytes", curr)
 	}
@@ -111,7 +129,9 @@ func TestSamplePrunedWideVarlenMemory(t *testing.T) {
 	pruned := measureSampleMemoryCase(t, false)
 
 	require.Positive(t, pruned.retainedBytes)
+	require.Positive(t, pruned.peakBytes)
 	require.Greater(t, unpruned.retainedBytes, pruned.retainedBytes*100)
+	require.Greater(t, unpruned.peakBytes, pruned.peakBytes*100)
 }
 
 func BenchmarkSamplePrunedWideVarlenMemory(b *testing.B) {
@@ -140,6 +160,7 @@ func BenchmarkSamplePrunedWideVarlenMemory(b *testing.B) {
 				retainedBytes += stats.retainedBytes
 			}
 			b.ReportMetric(float64(retainedBytes)/float64(b.N), "vector-retained-B/op")
+			b.ReportMetric(float64(outputMP.Stats().HighWaterMark.Load()), "mpool-peak-B")
 		})
 	}
 }

--- a/pkg/sql/plan/explain/column_prune_test.go
+++ b/pkg/sql/plan/explain/column_prune_test.go
@@ -708,6 +708,26 @@ func TestColumnPruneSemanticBoundaries(t *testing.T) {
 }
 
 func TestColumnPruneOperatorShape(t *testing.T) {
+	t.Run("discarded wide scan output uses narrow carrier", func(t *testing.T) {
+		buildColumns := func(sql string) []Entry[string, []string] {
+			logicPlan, err := buildOneStmt(plan2.NewMockOptimizer(false), t, sql)
+			require.NoError(t, err)
+			columns, err := getPrunedTableColumns(logicPlan)
+			require.NoError(t, err)
+			return columns
+		}
+
+		consumed := buildColumns("select n_name, n_regionkey from nation")
+		discarded := buildColumns("select 1 from (select n_name, n_regionkey from nation) s")
+
+		require.Equal(t, []Entry[string, []string]{
+			{tableName: "nation", colNames: []string{"n_name", "n_regionkey"}},
+		}, consumed)
+		require.Equal(t, []Entry[string, []string]{
+			{tableName: "nation", colNames: []string{"n_nationkey"}},
+		}, discarded)
+	})
+
 	t.Run("scan chooses deterministic row carrier", func(t *testing.T) {
 		logicPlan, err := buildOneStmt(
 			plan2.NewMockOptimizer(false),

--- a/pkg/sql/plan/explain/column_prune_test.go
+++ b/pkg/sql/plan/explain/column_prune_test.go
@@ -708,26 +708,6 @@ func TestColumnPruneSemanticBoundaries(t *testing.T) {
 }
 
 func TestColumnPruneOperatorShape(t *testing.T) {
-	t.Run("discarded wide scan output uses narrow carrier", func(t *testing.T) {
-		buildColumns := func(sql string) []Entry[string, []string] {
-			logicPlan, err := buildOneStmt(plan2.NewMockOptimizer(false), t, sql)
-			require.NoError(t, err)
-			columns, err := getPrunedTableColumns(logicPlan)
-			require.NoError(t, err)
-			return columns
-		}
-
-		consumed := buildColumns("select n_name, n_regionkey from nation")
-		discarded := buildColumns("select 1 from (select n_name, n_regionkey from nation) s")
-
-		require.Equal(t, []Entry[string, []string]{
-			{tableName: "nation", colNames: []string{"n_name", "n_regionkey"}},
-		}, consumed)
-		require.Equal(t, []Entry[string, []string]{
-			{tableName: "nation", colNames: []string{"n_nationkey"}},
-		}, discarded)
-	})
-
 	t.Run("scan chooses deterministic row carrier", func(t *testing.T) {
 		logicPlan, err := buildOneStmt(
 			plan2.NewMockOptimizer(false),
@@ -918,6 +898,18 @@ func TestColumnPruneOperatorShape(t *testing.T) {
 	})
 
 	t.Run("sample chooses low-cost discarded carrier", func(t *testing.T) {
+		consumedPlan, err := buildOneStmt(
+			plan2.NewMockOptimizer(false),
+			t,
+			"select n_name, n_regionkey from (select sample(n_name, n_regionkey, 2 rows) from nation) s",
+		)
+		require.NoError(t, err)
+		consumedColumns, err := getPrunedTableColumns(consumedPlan)
+		require.NoError(t, err)
+		require.Equal(t, []Entry[string, []string]{
+			{tableName: "nation", colNames: []string{"n_name", "n_regionkey"}},
+		}, consumedColumns)
+
 		logicPlan, err := buildOneStmt(
 			plan2.NewMockOptimizer(false),
 			t,

--- a/pkg/sql/plan/query_builder_test.go
+++ b/pkg/sql/plan/query_builder_test.go
@@ -140,6 +140,42 @@ func TestChooseRowCarrier(t *testing.T) {
 	})
 }
 
+func TestChooseRowCarrierWideVarlenDoesNotAllocate(t *testing.T) {
+	const candidateCount = 1024
+	exprs := make([]*plan.Expr, candidateCount)
+	for i := range exprs {
+		exprs[i] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_text), Width: 1 << 20}}
+	}
+	exprs[candidateCount-1] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_int8)}}
+
+	require.Equal(t, candidateCount-1, chooseRowCarrier(exprs, false))
+	require.Zero(t, testing.AllocsPerRun(100, func() {
+		_ = chooseRowCarrier(exprs, false)
+	}))
+}
+
+var benchmarkRowCarrier int
+
+func BenchmarkChooseRowCarrierWideVarlen(b *testing.B) {
+	const (
+		candidateCount = 1024
+		wideBytes      = 1 << 20
+	)
+	exprs := make([]*plan.Expr, candidateCount)
+	for i := range exprs {
+		exprs[i] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_text), Width: wideBytes}}
+	}
+	exprs[candidateCount-1] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_int8)}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkRowCarrier = chooseRowCarrier(exprs, false)
+	}
+	b.ReportMetric(float64((candidateCount-1)*wideBytes)/(1<<20), "candidate-MiB")
+	b.ReportMetric(1, "retained-B")
+}
+
 func TestCanPruneSampleExprs(t *testing.T) {
 	makeCol := func(tag, pos int32, notNullable bool) *plan.Expr {
 		return &plan.Expr{

--- a/pkg/sql/plan/query_builder_test.go
+++ b/pkg/sql/plan/query_builder_test.go
@@ -140,42 +140,6 @@ func TestChooseRowCarrier(t *testing.T) {
 	})
 }
 
-func TestChooseRowCarrierWideVarlenDoesNotAllocate(t *testing.T) {
-	const candidateCount = 1024
-	exprs := make([]*plan.Expr, candidateCount)
-	for i := range exprs {
-		exprs[i] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_text), Width: 1 << 20}}
-	}
-	exprs[candidateCount-1] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_int8)}}
-
-	require.Equal(t, candidateCount-1, chooseRowCarrier(exprs, false))
-	require.Zero(t, testing.AllocsPerRun(100, func() {
-		_ = chooseRowCarrier(exprs, false)
-	}))
-}
-
-var benchmarkRowCarrier int
-
-func BenchmarkChooseRowCarrierWideVarlen(b *testing.B) {
-	const (
-		candidateCount = 1024
-		wideBytes      = 1 << 20
-	)
-	exprs := make([]*plan.Expr, candidateCount)
-	for i := range exprs {
-		exprs[i] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_text), Width: wideBytes}}
-	}
-	exprs[candidateCount-1] = &plan.Expr{Typ: plan.Type{Id: int32(types.T_int8)}}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		benchmarkRowCarrier = chooseRowCarrier(exprs, false)
-	}
-	b.ReportMetric(float64((candidateCount-1)*wideBytes)/(1<<20), "candidate-MiB")
-	b.ReportMetric(1, "retained-B")
-}
-
 func TestCanPruneSampleExprs(t *testing.T) {
 	makeCol := func(tag, pos int32, notNullable bool) *plan.Expr {
 		return &plan.Expr{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #25700

## What this PR does / why we need it:

- Adds a paired plan-shape regression test showing that consumed `SAMPLE` outputs retain both inputs while discarded outputs keep only the narrow row carrier.
- Adds a fixed-count execution memory test that runs the unchanged production sample-pool initialization path with wide `text` data and with the pruned `int8` carrier, verifies identical row counts, and checks that both retained vector memory and peak heap growth drop by more than 100x. Peak heap growth is measured once per case with controlled `runtime.MemStats` sampling outside any benchmark loop.
- Adds an execution benchmark whose loop runs only the normal `SAMPLE` production path, whose allocation metrics come from `benchmem`, and whose retained-memory metric comes from the actual result vectors.

Validation:

- `go build ./pkg/sql/plan/... ./pkg/sql/plan/explain`
- `go vet ./pkg/sql/plan/... ./pkg/sql/plan/explain`
- `mo-cgo-test -count=1 -timeout=240s ./pkg/sql/plan ./pkg/sql/plan/explain ./pkg/sql/colexec/sample`
- `mo-cgo-test -run '^$' -bench '^BenchmarkSamplePrunedWideVarlenMemory$' -benchmem -count=1 -timeout=120s ./pkg/sql/colexec/sample`
