### PR TITLE
fix(frontend): preserve plan cache LRU ownership

### DIFF
--- a/pkg/frontend/plan_cache.go
+++ b/pkg/frontend/plan_cache.go
@@ -62,6 +62,12 @@ func (pc *planCache) cache(sql string, stmts []tree.Statement, plans []*plan.Pla
 			return
 		}
 	}
+	if element, ok := pc.cachePool[sql]; ok {
+		freeStmts(element.Value.(*cachedPlan).stmts)
+		element.Value = &cachedPlan{sql: sql, stmts: stmts, plans: plans}
+		pc.lruList.MoveToFront(element)
+		return
+	}
 	element := pc.lruList.PushFront(&cachedPlan{sql: sql, stmts: stmts, plans: plans})
 	pc.cachePool[sql] = element
 	if pc.lruList.Len() > pc.capacity {

--- a/pkg/frontend/plan_cache_test.go
+++ b/pkg/frontend/plan_cache_test.go
@@ -69,6 +69,61 @@ func Test_LRU(t *testing.T) {
 	require.False(t, pc.isCached("3"))
 }
 
+func Test_DuplicateKeyReplacesCachedPlan(t *testing.T) {
+	pc := newPlanCache(2)
+	oldStmt := &trackedStatement{}
+	newStmt := &trackedStatement{}
+	oldPlan := &plan.Plan{}
+	newPlan := &plan.Plan{}
+
+	pc.cache("A", []tree.Statement{oldStmt}, []*plan.Plan{oldPlan})
+	pc.cache("A", []tree.Statement{newStmt}, []*plan.Plan{newPlan})
+	invalidStmt := &trackedStatement{}
+	pc.cache("A", []tree.Statement{invalidStmt}, []*plan.Plan{nil})
+	pc.cache("B", nil, nil)
+
+	require.True(t, pc.isCached("A"))
+	require.True(t, pc.isCached("B"))
+	require.Len(t, pc.cachePool, 2)
+	require.Equal(t, 2, pc.lruList.Len())
+	require.Equal(t, 1, oldStmt.freed)
+	require.Zero(t, newStmt.freed)
+	require.Equal(t, 1, invalidStmt.freed)
+	require.Same(t, newStmt, pc.get("A").stmts[0])
+	require.Same(t, newPlan, pc.get("A").plans[0])
+
+	pc.clean()
+	require.Equal(t, 1, oldStmt.freed)
+	require.Equal(t, 1, newStmt.freed)
+}
+
+func Test_DuplicateKeyRefreshesLRU(t *testing.T) {
+	pc := newPlanCache(2)
+	firstA := &trackedStatement{}
+	secondA := &trackedStatement{}
+	b := &trackedStatement{}
+	c := &trackedStatement{}
+
+	pc.cache("A", []tree.Statement{firstA}, []*plan.Plan{{}})
+	pc.cache("B", []tree.Statement{b}, []*plan.Plan{{}})
+	pc.cache("A", []tree.Statement{secondA}, []*plan.Plan{{}})
+	pc.cache("C", []tree.Statement{c}, []*plan.Plan{{}})
+
+	require.True(t, pc.isCached("A"))
+	require.False(t, pc.isCached("B"))
+	require.True(t, pc.isCached("C"))
+	require.Len(t, pc.cachePool, 2)
+	require.Equal(t, 2, pc.lruList.Len())
+	require.Equal(t, 1, firstA.freed)
+	require.Equal(t, 1, b.freed)
+	require.Zero(t, secondA.freed)
+	require.Zero(t, c.freed)
+
+	pc.clean()
+	require.Equal(t, 1, secondA.freed)
+	require.Equal(t, 1, c.freed)
+}
+
 func Test_CleanCache(t *testing.T) {
 	pc := newPlanCache(3)
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25745

## What this PR does / why we need it:

Reuses the existing LRU element when a SQL key is cached again instead of
creating a second list node and overwriting the map entry. This preserves the
one-to-one relationship between the cache map and LRU list, refreshes the key's
recency, and frees replaced statements exactly once.

The regression tests cover duplicate-key replacement, invalid replacement
plans, LRU refresh and eviction order, and statement cleanup ownership.

Validation:

- Focused duplicate-key tests with the race detector
- Full `pkg/frontend` unit test suite
- `go vet ./pkg/frontend`
- `go build ./pkg/frontend`
- 100% function coverage for `plan_cache.go`
