### PR TITLE
fix(morpc): terminate pending work during backend and stream close

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -198,7 +198,6 @@ type remoteBackend struct {
 	}
 
 	pool struct {
-		streams *sync.Pool
 		futures *sync.Pool
 	}
 }
@@ -229,17 +228,6 @@ func NewRemoteBackend(
 	rb.pool.futures = &sync.Pool{
 		New: func() interface{} {
 			return newFuture(rb.releaseFuture)
-		},
-	}
-	rb.pool.streams = &sync.Pool{
-		New: func() any {
-			return newStream(
-				rb,
-				make(chan Message, rb.options.streamBufferSize),
-				rb.newFuture,
-				rb.doSend,
-				rb.removeActiveStream,
-				rb.active)
 		},
 	}
 	rb.waitWriteC = make(chan struct{}, 1)
@@ -425,6 +413,8 @@ func (rb *remoteBackend) Close() {
 
 	rb.stopper.Stop()
 	rb.doClose()
+	rb.makeAllWaitingFutureFailed(backendClosed)
+	rb.clean()
 	rb.inactive()
 }
 
@@ -656,7 +646,6 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			normalExit = true
-			rb.clean()
 			return
 		default:
 			msg, err := rb.conn.Read(goetty.ReadOptions{Timeout: rb.options.readTimeout})
@@ -846,7 +835,13 @@ func (rb *remoteBackend) clean() {
 }
 
 func (rb *remoteBackend) acquireStream() *stream {
-	return rb.pool.streams.Get().(*stream)
+	return newStream(
+		rb,
+		make(chan Message, rb.options.streamBufferSize),
+		rb.newFuture,
+		rb.doSend,
+		rb.removeActiveStream,
+		rb.active)
 }
 
 func (rb *remoteBackend) cancelActiveStreams() {
@@ -860,25 +855,16 @@ func (rb *remoteBackend) cancelActiveStreams() {
 
 func (rb *remoteBackend) removeActiveStream(s *stream) {
 	rb.mu.Lock()
-	defer rb.mu.Unlock()
-
 	delete(rb.mu.activeStreams, s.id)
 	delete(rb.mu.futures, s.id)
-	if s.unlockAfterClose {
-		rb.Unlock()
-	}
-	if len(s.c) > 0 {
+	channelNotEmpty := len(s.c) > 0
+	rb.mu.Unlock()
+	if channelNotEmpty {
 		panic("BUG: stream channel is not empty")
 	}
-	// When backend is already stopped (e.g. stream closed with closeConn=true), do not Put
-	// the stream back into the pool. Otherwise backend->pool->stream->backend forms a cycle
-	// and the backend (and its goetty session / newCounters) can never be GC'd after removal
-	// from the client, so heap inuse for newCounters stays high.
-	rb.stateMu.RLock()
-	stopped := rb.stateMu.state == stateStopped
-	rb.stateMu.RUnlock()
-	if !stopped {
-		rb.pool.streams.Put(s)
+
+	if s.unlockAfterClose {
+		rb.Unlock()
 	}
 }
 
@@ -1263,7 +1249,9 @@ func (s *stream) setFinalizer() {
 
 func (s *stream) destroy() {
 	close(s.c)
-	s.cancel()
+	if s.cancel != nil {
+		s.cancel()
+	}
 }
 
 func (s *stream) Send(ctx context.Context, request Message) error {
@@ -1327,19 +1315,20 @@ func (s *stream) Receive() (chan Message, error) {
 }
 
 func (s *stream) Close(closeConn bool) error {
+	s.cancel()
 	if closeConn {
 		s.rb.logger.Info("stream call closed on client", append(s.rb.logFields(), zap.Uint64("stream-id", s.id))...)
 		s.rb.Close()
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.mu.closed {
+		s.mu.Unlock()
 		return nil
 	}
 
 	s.cleanCLocked()
 	s.mu.closed = true
+	s.mu.Unlock()
 	s.unregisterFunc(s)
 	return nil
 }
@@ -1381,6 +1370,7 @@ func (s *stream) done(
 		select {
 		case s.c <- response:
 		case <-ctx.Done():
+		case <-s.ctx.Done():
 		}
 	})
 }

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -392,6 +392,53 @@ func TestFutureGetCannotBlockIfCloseBackend(t *testing.T) {
 	)
 }
 
+func TestCloseBackendNotifiesWaitingFuture(t *testing.T) {
+	received := make(chan struct{})
+	var once sync.Once
+	testBackendSend(t,
+		func(conn goetty.IOSession, msg interface{}, _ uint64) error {
+			once.Do(func() { close(received) })
+			return nil
+		},
+		func(b *remoteBackend) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			f, err := b.Send(ctx, newTestMessage(1))
+			require.NoError(t, err)
+			defer f.Close()
+			select {
+			case <-received:
+			case <-time.After(time.Second):
+				t.Fatal("request was not written before backend close")
+			}
+
+			resultC := make(chan error, 1)
+			go func() {
+				_, err := f.Get()
+				resultC <- err
+			}()
+
+			closeC := make(chan struct{})
+			go func() {
+				b.Close()
+				close(closeC)
+			}()
+			select {
+			case <-closeC:
+			case <-time.After(time.Second):
+				t.Fatal("backend close did not return")
+			}
+			select {
+			case err := <-resultC:
+				require.ErrorIs(t, err, backendClosed)
+			case <-time.After(time.Second):
+				t.Fatal("waiting future was not notified when backend closed")
+			}
+		},
+	)
+}
+
 func TestStream(t *testing.T) {
 	testBackendSend(t,
 		func(conn goetty.IOSession, msg interface{}, seq uint64) error {
@@ -600,6 +647,127 @@ func TestDoneWithClosedStreamCannotPanic(t *testing.T) {
 	assert.NoError(t, s.Send(ctx, &testMessage{id: s.ID()}))
 	assert.NoError(t, s.Close(false))
 	s.done(context.TODO(), RPCMessage{}, false)
+}
+
+func TestCloseStreamUnblocksFullReceiveChannel(t *testing.T) {
+	c := make(chan Message, 1)
+	unregistered := 0
+	s := newStream(
+		nil,
+		c,
+		func() *Future { return newFuture(nil) },
+		func(m *Future) error { return nil },
+		func(s *stream) { unregistered++ },
+		func() {})
+	s.init(1, false)
+	c <- newTestMessage(1)
+
+	doneC := make(chan struct{})
+	go func() {
+		defer close(doneC)
+		s.done(context.Background(), RPCMessage{
+			Message:        newTestMessage(1),
+			stream:         true,
+			streamSequence: 1,
+		}, false)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for s.mu.TryLock() {
+		s.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("stream response did not block on the full receive channel")
+		}
+		runtime.Gosched()
+	}
+
+	closeC := make(chan error, 1)
+	go func() { closeC <- s.Close(false) }()
+	select {
+	case err := <-closeC:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("stream close blocked behind a full receive channel")
+	}
+	select {
+	case <-doneC:
+	case <-time.After(time.Second):
+		t.Fatal("stream response delivery did not observe stream close")
+	}
+	require.Equal(t, 1, unregistered)
+	require.Empty(t, c)
+}
+
+func TestClosedStreamHandleAndChannelAreNotReused(t *testing.T) {
+	testBackendSend(t,
+		func(conn goetty.IOSession, msg interface{}, _ uint64) error { return nil },
+		func(b *remoteBackend) {
+			first, err := b.NewStream(false)
+			require.NoError(t, err)
+			firstC, err := first.Receive()
+			require.NoError(t, err)
+			require.NoError(t, first.Close(false))
+
+			second, err := b.NewStream(false)
+			require.NoError(t, err)
+			secondC, err := second.Receive()
+			require.NoError(t, err)
+			defer func() { require.NoError(t, second.Close(false)) }()
+
+			require.NotSame(t, first, second)
+			require.NotEqual(t, firstC, secondC)
+		},
+	)
+}
+
+func TestRemoveActiveStreamDoesNotHoldBackendMutexWhileUnlocking(t *testing.T) {
+	rb := &remoteBackend{}
+	rb.stateMu.state = stateStopped
+	rb.stateMu.locked = true
+	rb.mu.futures = make(map[uint64]*Future)
+	rb.mu.activeStreams = make(map[uint64]*stream)
+	s := &stream{
+		rb:               rb,
+		c:                make(chan Message, 1),
+		id:               1,
+		unlockAfterClose: true,
+	}
+	rb.mu.activeStreams[s.id] = s
+
+	// Reproduce NewStream's stateMu -> rb.mu order while stream removal
+	// needs to release the backend lock via stateMu.
+	rb.mu.Lock()
+	rb.stateMu.RLock()
+	doneC := make(chan struct{})
+	go func() {
+		defer close(doneC)
+		rb.removeActiveStream(s)
+	}()
+	rb.mu.Unlock()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		if rb.mu.TryLock() {
+			_, exists := rb.mu.activeStreams[s.id]
+			rb.mu.Unlock()
+			if !exists {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			rb.stateMu.RUnlock()
+			t.Fatal("stream removal held rb.mu while waiting for stateMu")
+		}
+		runtime.Gosched()
+	}
+
+	rb.stateMu.RUnlock()
+	select {
+	case <-doneC:
+	case <-time.After(time.Second):
+		t.Fatal("stream removal did not finish after stateMu was released")
+	}
+	require.False(t, rb.Locked())
 }
 
 func TestGCStream(t *testing.T) {

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -101,10 +101,13 @@ func TestHandleServerWriteWithClosedSession(t *testing.T) {
 		defer cancel()
 
 		c := newTestClient(t)
+		handlerDone := make(chan error, 1)
 		rs.RegisterRequestHandler(func(_ context.Context, request RPCMessage, _ uint64, cs ClientSession) error {
 			assert.NoError(t, c.Close())
+			// The peer may still accept a write briefly after the client closes;
+			// transport buffering does not guarantee an immediate write error.
 			err := cs.Write(ctx, request.Message)
-			assert.Error(t, err)
+			handlerDone <- err
 			return err
 		})
 
@@ -114,8 +117,13 @@ func TestHandleServerWriteWithClosedSession(t *testing.T) {
 
 		defer f.Close()
 		resp, err := f.Get()
-		assert.Error(t, ctx.Err(), err)
+		assert.ErrorIs(t, err, backendClosed)
 		assert.Nil(t, resp)
+		select {
+		case <-handlerDone:
+		case <-ctx.Done():
+			t.Fatal("server handler did not finish after client close")
+		}
 	})
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25943
Fixes #25945

## What this PR does / why we need it:

- cancels a stream before waiting for its lock, so a full receive channel cannot block Stream.Close(false)
- gives each stream an independent handle, receive channel, and cancellation context instead of reusing externally visible stream objects
- stops backend I/O and closes the transport before failing all response-waiting Futures with backendClosed
- releases the backend map mutex before taking backend state locks during stream removal
- adds deterministic close, lock-order, generation-isolation, and race regressions

## Testing

- make thirdparties
- mo-cgo-test -race -count=20 focused MORPC close regressions
- mo-cgo-test ./pkg/common/morpc
- mo-cgo-test -race ./pkg/common/morpc
- go build ./pkg/common/morpc
- go vet ./pkg/common/morpc
- mo-cgo-test ./pkg/cnservice/cnclient