### PR TITLE
perf(vector): compact varlen data in CopyBatch (cherry-pick #25824)

### DIFF
--- a/pkg/container/vector/clone_compact_test.go
+++ b/pkg/container/vector/clone_compact_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vector
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneToFlatCompactFreesPartialAllocation(t *testing.T) {
+	srcMP := mpool.MustNew("clone-compact-source")
+	src := NewVec(types.T_varchar.ToType())
+	require.NoError(t, AppendBytes(src, make([]byte, 2<<20), false, srcMP))
+
+	dstMP := mpool.MustNew("clone-compact-destination")
+	oldLimit := mpool.CapLimit
+	mpool.CapLimit = 1 << 20
+	t.Cleanup(func() { mpool.CapLimit = oldLimit })
+	got, err := src.CloneToFlatCompact(dstMP)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Equal(t, int64(0), dstMP.CurrNB())
+
+	src.Free(srcMP)
+	require.Equal(t, int64(0), srcMP.CurrNB())
+}
+
+func TestCloneToFlatCompactPreservesConstGrouping(t *testing.T) {
+	mp := mpool.MustNewZero()
+	tests := []struct {
+		name         string
+		newSource    func(t *testing.T) *Vector
+		wantGrouping []bool
+		wantNull     bool
+		checkValue   func(t *testing.T, vec *Vector)
+	}{
+		{
+			name: "fixed-value",
+			newSource: func(t *testing.T) *Vector {
+				vec, err := NewConstFixed(types.T_int8.ToType(), int8(7), 3, mp)
+				require.NoError(t, err)
+				vec.GetGrouping().Add(0, 2, 5)
+				return vec
+			},
+			wantGrouping: []bool{true, false, true},
+			checkValue: func(t *testing.T, vec *Vector) {
+				for row := range 3 {
+					require.Equal(t, int8(7), GetFixedAtNoTypeCheck[int8](vec, row))
+				}
+			},
+		},
+		{
+			name: "varlen-value",
+			newSource: func(t *testing.T) *Vector {
+				vec, err := NewConstBytes(types.T_varchar.ToType(), []byte("rollup"), 3, mp)
+				require.NoError(t, err)
+				vec.GetGrouping().Add(0, 2, 5)
+				return vec
+			},
+			wantGrouping: []bool{true, false, true},
+			checkValue: func(t *testing.T, vec *Vector) {
+				for row := range 3 {
+					require.Equal(t, "rollup", string(vec.GetBytesAt(row)))
+				}
+			},
+		},
+		{
+			name: "fixed-rollup-null",
+			newSource: func(t *testing.T) *Vector {
+				vec := NewRollupConst(types.T_int8.ToType(), 3, mp)
+				vec.GetGrouping().Add(5)
+				return vec
+			},
+			wantGrouping: []bool{true, true, true},
+			wantNull:     true,
+		},
+		{
+			name: "varlen-rollup-null",
+			newSource: func(t *testing.T) *Vector {
+				vec := NewRollupConst(types.T_varchar.ToType(), 3, mp)
+				vec.GetGrouping().Add(5)
+				return vec
+			},
+			wantGrouping: []bool{true, true, true},
+			wantNull:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := test.newSource(t)
+			dst, err := src.CloneToFlatCompact(mp)
+			require.NoError(t, err)
+			require.False(t, dst.IsConst())
+			require.Equal(t, 3, dst.Length())
+			for row, grouped := range test.wantGrouping {
+				require.Equal(t, grouped, dst.GetGrouping().Contains(uint64(row)))
+				require.Equal(t, test.wantNull, dst.GetNulls().Contains(uint64(row)))
+			}
+			require.False(t, dst.GetGrouping().Contains(5))
+			if test.checkValue != nil {
+				test.checkValue(t, dst)
+			}
+
+			src.Free(mp)
+			dst.Free(mp)
+			require.Equal(t, int64(0), mp.CurrNB())
+		})
+	}
+}

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -1010,6 +1010,89 @@ func (v *Vector) Dup(mp *mpool.MPool) (*Vector, error) {
 	return w, nil
 }
 
+// CloneToFlatCompact returns a deep, flat copy of v. Unlike Dup, the clone only
+// retains varlen payload referenced by the vector's logical rows, so stale or
+// unreferenced bytes in area are not propagated into batch memory accounting.
+func (v *Vector) CloneToFlatCompact(mp *mpool.MPool) (*Vector, error) {
+	w := NewVec(v.typ)
+	if v.class != FLAT || (!v.typ.IsFixedLen() && !v.typ.IsVarlen()) {
+		if err := GetUnionAllFunction(v.typ, mp)(w, v); err != nil {
+			w.Free(mp)
+			return nil, err
+		}
+		copyBitmapWithinLength(&w.gsp, &v.gsp, v.length)
+		return w, nil
+	}
+
+	if v.length == 0 {
+		return w, nil
+	}
+	if err := extend(w, v.length, mp); err != nil {
+		w.Free(mp)
+		return nil, err
+	}
+	w.length = v.length
+	copyBitmapWithinLength(&w.nsp, &v.nsp, v.length)
+	copyBitmapWithinLength(&w.gsp, &v.gsp, v.length)
+
+	if v.typ.IsFixedLen() {
+		dataLen := v.length * v.typ.TypeSize()
+		copy(w.data[:dataLen], v.data[:dataLen])
+		return w, nil
+	}
+
+	var src, dst []types.Varlena
+	ToSliceNoTypeCheck(v, &src)
+	ToSliceNoTypeCheck(w, &dst)
+	totalArea := 0
+	for i := range src {
+		if v.nsp.Contains(uint64(i)) || src[i].IsSmall() {
+			continue
+		}
+		_, n := src[i].OffsetLen()
+		totalArea += int(n)
+	}
+	if totalArea > 0 {
+		var err error
+		w.area, err = mp.Alloc(totalArea, w.offHeap)
+		if err != nil {
+			w.Free(mp)
+			return nil, err
+		}
+	}
+
+	offset := 0
+	for i := range src {
+		if v.nsp.Contains(uint64(i)) {
+			dst[i] = types.Varlena{}
+			continue
+		}
+		if src[i].IsSmall() {
+			dst[i] = src[i]
+			continue
+		}
+		value := src[i].GetByteSlice(v.area)
+		copy(w.area[offset:], value)
+		dst[i].SetOffsetLen(uint32(offset), uint32(len(value)))
+		offset += len(value)
+	}
+	return w, nil
+}
+
+func copyBitmapWithinLength(dst, src *nulls.Nulls, length int) {
+	if src.EmptyByFlag() {
+		return
+	}
+	limit := uint64(length)
+	src.Foreach(func(row uint64) bool {
+		if row >= limit {
+			return false
+		}
+		nulls.Add(dst, row)
+		return true
+	})
+}
+
 // Shrink use to shrink vectors, sels must be guaranteed to be ordered
 func (v *Vector) Shrink(sels []int64, negate bool) {
 

--- a/pkg/sql/util/copy_batch_test.go
+++ b/pkg/sql/util/copy_batch_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyBatchCompactsAndFlattens(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	mp := proc.Mp()
+	src := batch.NewWithSize(4)
+	src.Attrs = []string{"fixed", "varlen", "const", "const_null"}
+
+	fixed := vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixedList(fixed, []int64{11}, []bool{false}, mp))
+	fixed.GetNulls().Add(9)
+	fixed.GetGrouping().Add(0, 9)
+	fixed.SetSorted(true)
+
+	dead := []byte("dead-")
+	dead = append(dead, make([]byte, 4096)...)
+	live := []byte("live-")
+	live = append(live, make([]byte, 64)...)
+	varlen := vector.NewVec(types.T_varchar.ToType())
+	require.NoError(t, vector.AppendBytes(varlen, dead, false, mp))
+	require.NoError(t, vector.AppendBytes(varlen, live, false, mp))
+	varlen.Shrink([]int64{1}, false)
+	require.Greater(t, len(varlen.GetArea()), len(live))
+
+	constVec, err := vector.NewConstBytes(
+		types.T_varchar.ToType(),
+		[]byte("a repeated value long enough to use the area"),
+		1,
+		mp,
+	)
+	require.NoError(t, err)
+	constNull := vector.NewConstNull(types.T_int32.ToType(), 1, mp)
+
+	src.SetVector(0, fixed)
+	src.SetVector(1, varlen)
+	src.SetVector(2, constVec)
+	src.SetVector(3, constNull)
+	src.SetRowCount(1)
+
+	got, err := CopyBatch(src, proc)
+	require.NoError(t, err)
+	require.Equal(t, src.Attrs, got.Attrs)
+	require.Equal(t, src.RowCount(), got.RowCount())
+	for _, vec := range got.Vecs {
+		require.False(t, vec.IsConst())
+		require.Equal(t, 1, vec.Length())
+	}
+	require.False(t, got.Vecs[0].GetSorted())
+	require.Equal(t, int64(11), vector.GetFixedAtNoTypeCheck[int64](got.Vecs[0], 0))
+	require.True(t, got.Vecs[0].GetGrouping().Contains(0))
+	require.False(t, got.Vecs[0].GetNulls().Contains(9))
+	require.False(t, got.Vecs[0].GetGrouping().Contains(9))
+	require.Equal(t, live, got.Vecs[1].GetBytesAt(0))
+	require.Len(t, got.Vecs[1].GetArea(), len(live))
+	require.Equal(t, "a repeated value long enough to use the area", string(got.Vecs[2].GetBytesAt(0)))
+	require.True(t, got.Vecs[3].GetNulls().Contains(0))
+
+	require.NoError(t, vector.SetFixedAtNoTypeCheck(fixed, 0, int64(99)))
+	require.NoError(t, vector.SetBytesAt(varlen, 0, []byte("changed source value"), mp))
+	require.Equal(t, int64(11), vector.GetFixedAtNoTypeCheck[int64](got.Vecs[0], 0))
+	require.Equal(t, live, got.Vecs[1].GetBytesAt(0))
+
+	src.Clean(mp)
+	got.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func BenchmarkCopyBatchCompact(b *testing.B) {
+	proc := testutil.NewProcess(b)
+	mp := proc.Mp()
+	src := batch.NewWithSize(10)
+	for col := range src.Vecs {
+		vec := vector.NewVec(types.T_varchar.ToType())
+		for row := 0; row < 1024; row++ {
+			value := []byte(fmt.Sprintf("column-%d-row-%d-", col, row))
+			value = append(value, make([]byte, 64)...)
+			require.NoError(b, vector.AppendBytes(vec, value, false, mp))
+		}
+		sels := make([]int64, 0, 128)
+		for row := 0; row < 1024; row += 8 {
+			sels = append(sels, int64(row))
+		}
+		vec.Shrink(sels, false)
+		src.SetVector(int32(col), vec)
+	}
+	src.SetRowCount(128)
+	b.Cleanup(func() { src.Clean(mp) })
+
+	bench := func(b *testing.B, copyFn func() (*batch.Batch, error)) {
+		b.Helper()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			got, err := copyFn()
+			if err != nil {
+				b.Fatal(err)
+			}
+			got.Clean(mp)
+		}
+	}
+
+	b.Run("union-all", func(b *testing.B) {
+		bench(b, func() (*batch.Batch, error) {
+			return copyBatchWithUnionAll(src, mp)
+		})
+	})
+	b.Run("compact", func(b *testing.B) {
+		bench(b, func() (*batch.Batch, error) {
+			return CopyBatch(src, proc)
+		})
+	})
+}
+
+func BenchmarkCopyBatchAlreadyCompact(b *testing.B) {
+	proc := testutil.NewProcess(b)
+	mp := proc.Mp()
+	src := batch.NewWithSize(10)
+	for col := range src.Vecs {
+		vec := vector.NewVec(types.T_varchar.ToType())
+		for row := 0; row < 128; row++ {
+			value := []byte(fmt.Sprintf("column-%d-row-%d-", col, row))
+			value = append(value, make([]byte, 64)...)
+			require.NoError(b, vector.AppendBytes(vec, value, false, mp))
+		}
+		src.SetVector(int32(col), vec)
+	}
+	src.SetRowCount(128)
+	b.Cleanup(func() { src.Clean(mp) })
+
+	bench := func(b *testing.B, copyFn func() (*batch.Batch, error)) {
+		b.Helper()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			got, err := copyFn()
+			if err != nil {
+				b.Fatal(err)
+			}
+			got.Clean(mp)
+		}
+	}
+
+	b.Run("union-all", func(b *testing.B) {
+		bench(b, func() (*batch.Batch, error) {
+			return copyBatchWithUnionAll(src, mp)
+		})
+	})
+	b.Run("compact", func(b *testing.B) {
+		bench(b, func() (*batch.Batch, error) {
+			return CopyBatch(src, proc)
+		})
+	})
+}
+
+func copyBatchWithUnionAll(src *batch.Batch, mp *mpool.MPool) (*batch.Batch, error) {
+	dst := batch.NewWithSize(len(src.Vecs))
+	dst.Attrs = append(dst.Attrs, src.Attrs...)
+	for i, srcVec := range src.Vecs {
+		vec := vector.NewVec(*srcVec.GetType())
+		if err := vector.GetUnionAllFunction(*srcVec.GetType(), mp)(vec, srcVec); err != nil {
+			vec.Free(mp)
+			dst.Clean(mp)
+			return nil, err
+		}
+		dst.SetVector(int32(i), vec)
+	}
+	dst.SetRowCount(src.RowCount())
+	return dst, nil
+}

--- a/pkg/sql/util/util.go
+++ b/pkg/sql/util/util.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -45,8 +44,8 @@ func CopyBatch(bat *batch.Batch, proc *process.Process) (*batch.Batch, error) {
 	rbat := batch.NewWithSize(len(bat.Vecs))
 	rbat.Attrs = append(rbat.Attrs, bat.Attrs...)
 	for i, srcVec := range bat.Vecs {
-		vec := vector.NewVec(*srcVec.GetType())
-		if err := vector.GetUnionAllFunction(*srcVec.GetType(), proc.Mp())(vec, srcVec); err != nil {
+		vec, err := srcVec.CloneToFlatCompact(proc.Mp())
+		if err != nil {
 			rbat.Clean(proc.Mp())
 			return nil, err
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25472

## What this PR does / why we need it:

Cherry-pick #25824 to 4.1-dev.

- Adds `Vector.CloneToFlatCompact`, which returns a deep flat copy containing only varlen payload referenced by logical rows.
- Switches `sql/util.CopyBatch` to the compact clone while preserving ownership and caller cleanup.
- Preserves fixed/varlen values, NULL and grouping bitmaps, CONST/CONST NULL flattening, attributes, row count, and source/destination independence.