### PR TITLE
chore(thirdparties): track onnxruntime binaries with git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+thirdparties/onnxruntime/*.so filter=lfs diff=lfs merge=lfs -text
+thirdparties/onnxruntime/*.dylib filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 *.o
 *.a
 *.so
+!thirdparties/onnxruntime/*.so
+!thirdparties/onnxruntime/*.dylib
 *.exe
 *.lib
 *.swp

--- a/thirdparties/onnxruntime/onnxruntime.so
+++ b/thirdparties/onnxruntime/onnxruntime.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13ab8084954fa4a47c777880180b90810d6020f021441395712b48a75b74c68b
+size 22326072

--- a/thirdparties/onnxruntime/onnxruntime_arm64.dylib
+++ b/thirdparties/onnxruntime/onnxruntime_arm64.dylib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d306d2bc768540766c7ed8a1e0ff05d2870c77a934ebeee4a7bafa1b732ef299
+size 35138784

--- a/thirdparties/onnxruntime/onnxruntime_arm64.so
+++ b/thirdparties/onnxruntime/onnxruntime_arm64.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:648ffa64fbe027ae27139109410900cf776a030dec2dbbac51053318cc44c286
+size 18693384


### PR DESCRIPTION
## What

Add the onnxruntime shared libraries under `thirdparties/onnxruntime/` and track them with git-lfs:

- `onnxruntime.so` (linux x86_64, 22M)
- `onnxruntime_arm64.so` (linux arm64, 18M)
- `onnxruntime_arm64.dylib` (macOS arm64, 34M)

## How

- `.gitattributes`: LFS tracking scoped to `thirdparties/onnxruntime/*.so` and `*.dylib` so other `.so` files in the repo are unaffected.
- `.gitignore`: the global `*.so` rule was blocking the linux binaries; added negation exceptions for this directory.

Binaries are stored via git-lfs (pointers in git, blobs in LFS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)