### PR TITLE
fix: complete shuffle writers during reset

### DIFF
--- a/pkg/sql/colexec/shuffle/shuffle.go
+++ b/pkg/sql/colexec/shuffle/shuffle.go
@@ -66,6 +66,7 @@ func (shuffle *Shuffle) Prepare(proc *process.Process) error {
 		return moerr.NewInternalError(proc.Ctx, "shuffle pool was aborted before prepare completed")
 	}
 	shuffle.ctr.held = true
+	shuffle.ctr.writingStopped = false
 	shuffle.ctr.ending = false
 	shuffle.ctr.runtimeFilterHandled = false
 	return nil
@@ -172,7 +173,7 @@ func (shuffle *Shuffle) Call(proc *process.Process) (vm.CallResult, error) {
 		bat := result.Batch
 		if bat == nil {
 			shuffle.ctr.ending = true
-			shuffle.ctr.shufflePool.stopWriting()
+			shuffle.stopWritingOnce()
 			result.Status = vm.ExecNext
 			result.Batch = batch.EmptyBatch
 			return result, nil

--- a/pkg/sql/colexec/shuffle/shufflepool_test.go
+++ b/pkg/sql/colexec/shuffle/shufflepool_test.go
@@ -341,6 +341,99 @@ func TestShufflePoolPeakIsReportedByExactlyOneHolder(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
+func TestShuffleSuccessfulResetCompletesWriter(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	sp := NewShufflePool(2, 2, false)
+	args := []*Shuffle{NewArgument(), NewArgument()}
+	defer func() {
+		for _, arg := range args {
+			if arg.GetShufflePool() != nil {
+				arg.Reset(proc, true, nil)
+			}
+			arg.Free(proc, false, nil)
+			arg.Release()
+		}
+	}()
+	for i, arg := range args {
+		arg.BucketNum = 2
+		arg.CurrentShuffleIdx = int32(i)
+		arg.SetShufflePool(sp)
+		require.NoError(t, arg.Prepare(proc))
+	}
+
+	args[0].stopWritingOnce()
+	require.False(t, sp.allStop())
+	woke := make(chan struct{})
+	waiting := make(chan struct{})
+	go func() {
+		close(waiting)
+		sp.waitBatchOrEnd(0, proc)
+		close(woke)
+	}()
+	<-waiting
+
+	args[1].Reset(proc, false, nil)
+	select {
+	case <-woke:
+	case <-time.After(time.Second):
+		t.Fatal("successful reset did not complete the writer")
+	}
+	args[0].Reset(proc, false, nil)
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestShuffleWriterStopsOnceAcrossEOFAndReset(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	sp := NewShufflePool(1, 1, false)
+	arg := NewArgument()
+	defer func() {
+		arg.Free(proc, false, nil)
+		arg.Release()
+	}()
+	arg.BucketNum = 1
+	arg.SetShufflePool(sp)
+	require.NoError(t, arg.Prepare(proc))
+
+	arg.stopWritingOnce()
+	arg.stopWritingOnce()
+	require.Equal(t, int32(1), sp.stoppers)
+	arg.Reset(proc, false, nil)
+	require.Equal(t, int32(1), sp.stoppers)
+}
+
+func TestShuffleFailedResetAbortsWithoutStoppingWriter(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	sp := NewShufflePool(1, 1, false)
+	arg := NewArgument()
+	defer func() {
+		arg.Free(proc, true, nil)
+		arg.Release()
+	}()
+	arg.BucketNum = 1
+	arg.SetShufflePool(sp)
+	require.NoError(t, arg.Prepare(proc))
+
+	woke := make(chan struct{})
+	waiting := make(chan struct{})
+	go func() {
+		close(waiting)
+		sp.waitBatchOrEnd(0, proc)
+		close(woke)
+	}()
+	<-waiting
+	arg.Reset(proc, true, nil)
+	select {
+	case <-woke:
+	case <-time.After(time.Second):
+		t.Fatal("failed reset did not abort the shuffle pool")
+	}
+	require.True(t, sp.aborted)
+	require.Zero(t, sp.stoppers)
+}
+
 func TestShufflePoolRetainsOwnershipWhenBatchSetWriteFails(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/pkg/sql/colexec/shuffle/types.go
+++ b/pkg/sql/colexec/shuffle/types.go
@@ -83,6 +83,14 @@ type container struct {
 	runtimeFilterHandled bool
 	exprExec             colexec.ExpressionExecutor
 	held                 bool
+	writingStopped       bool
+}
+
+func (shuffle *Shuffle) stopWritingOnce() {
+	if shuffle.ctr.held && !shuffle.ctr.writingStopped && shuffle.ctr.shufflePool != nil {
+		shuffle.ctr.shufflePool.stopWriting()
+		shuffle.ctr.writingStopped = true
+	}
 }
 
 func (shuffle *Shuffle) SetShufflePool(sp *ShufflePool) {
@@ -108,6 +116,7 @@ func (shuffle *Shuffle) Reset(proc *process.Process, pipelineFailed bool, err er
 				shuffle.ctr.shufflePool.abort(proc.Mp())
 			}
 		} else if shuffle.ctr.held {
+			shuffle.stopWritingOnce()
 			peak, ownsStats = shuffle.ctr.shufflePool.release(proc.Mp(), false)
 		}
 		if ownsStats && shuffle.OpAnalyzer != nil {
@@ -122,6 +131,7 @@ func (shuffle *Shuffle) Reset(proc *process.Process, pipelineFailed bool, err er
 	shuffle.ctr.pendingOffset = 0
 	shuffle.ctr.runtimeFilterHandled = false
 	shuffle.ctr.held = false
+	shuffle.ctr.writingStopped = false
 }
 
 func (shuffle *Shuffle) Free(proc *process.Process, pipelineFailed bool, err error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25922

## What this PR does / why we need it:

Each parallel shuffle holder must report that it will produce no more rows before releasing its pool ownership. Previously, `Shuffle.Call` reported writer completion only after observing child EOF. If a downstream operator stopped a pipeline earlier, successful `Reset` released the holder without incrementing the pool's stopper count. Other holders could then wait forever for a writer that had already exited.

This change makes writer completion exactly once across normal EOF and successful reset:

- normal EOF and successful cleanup share a guarded `stopWritingOnce` path;
- EOF followed by reset cannot double-count the writer;
- failed cleanup continues to abort the pool and wake waiters;
- the guard is cleared for operator reuse.

Regression tests cover successful early reset, EOF followed by reset, and failed reset.

Validation:

- focused lifecycle tests with `-race -count=20`
- full `pkg/sql/colexec/shuffle` tests with `-race`
- full `pkg/sql/colexec/group` tests
- compile-layer shuffle pool/generation tests
- `go build ./pkg/sql/colexec/shuffle`
- `go vet ./pkg/sql/colexec/shuffle`
- `git diff --check`
