### PR TITLE
fix: propagate data branch CSV copy errors

### DIFF
--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -1205,6 +1205,52 @@ func shouldDiffAsCSV(sqlRet executor.Result) (bool, error) {
 	return vector.GetFixedAtWithTypeCheck[uint64](sqlRet.Batches[0].Vecs[0], 0) == 0, nil
 }
 
+func submitCSVBatchForConversion(
+	ctx context.Context,
+	ses *Session,
+	tblStuff tableStuff,
+	bat *batch.Batch,
+	ep *ExportConfig,
+	workerWg *sync.WaitGroup,
+) error {
+	copied, err := bat.Dup(ses.proc.Mp())
+	if err != nil {
+		return err
+	}
+
+	idx := ep.Index.Add(1)
+	workerWg.Add(1)
+	if err = tblStuff.worker.Submit(func() {
+		defer workerWg.Done()
+		constructByte(ctx, ses, copied, idx, ep.ByteChan, ep)
+	}); err != nil {
+		workerWg.Done()
+		copied.Clean(ses.proc.Mp())
+		ep.Index.Add(-1)
+		return err
+	}
+	return nil
+}
+
+func flushRemainingCSVBatchBytes(ctx context.Context, ep *ExportConfig) error {
+	if ctx.Err() != nil || ep.WriteIndex.Load() == ep.Index.Load() {
+		return nil
+	}
+	return exportAllDataFromBatches(ep)
+}
+
+func waitForCSVConversionWorkers(inputCtx context.Context, workerWg *sync.WaitGroup) error {
+	workerWg.Wait()
+	return inputCtx.Err()
+}
+
+func joinCSVInputError(err, inputErr error) error {
+	if inputErr == nil || errors.Is(err, inputErr) {
+		return err
+	}
+	return errors.Join(err, inputErr)
+}
+
 func writeCSV(
 	inputCtx context.Context,
 	ses *Session,
@@ -1325,12 +1371,10 @@ func writeCSV(
 				ep.BatchMap[ep.WriteIndex.Load()] = nil
 			}
 		}
-		if ep.WriteIndex.Load() != ep.Index.Load() {
-			if err2 := exportAllDataFromBatches(ep); err2 != nil {
-				select {
-				case writerErr <- err2:
-				default:
-				}
+		if err2 := flushRemainingCSVBatchBytes(ctx, ep); err2 != nil {
+			select {
+			case writerErr <- err2:
+			default:
 			}
 		}
 	}); err != nil {
@@ -1406,14 +1450,9 @@ func writeCSV(
 				continue
 			}
 			for _, bat := range sqlRet.Batches {
-				copied, _ := bat.Dup(ses.proc.Mp())
-				idx := ep.Index.Add(1)
-				workerWg.Add(1)
-				if submitErr := tblStuff.worker.Submit(func() {
-					defer workerWg.Done()
-					constructByte(ctx, ses, copied, idx, ep.ByteChan, ep)
-				}); submitErr != nil {
-					workerWg.Done()
+				if submitErr := submitCSVBatchForConversion(
+					ctx, ses, tblStuff, bat, ep, &workerWg,
+				); submitErr != nil {
 					err = errors.Join(err, submitErr)
 					stop = true
 					cancelCtx()
@@ -1425,11 +1464,15 @@ func writeCSV(
 	}
 
 	wg.Wait()
-	workerWg.Wait()
+	inputErr := waitForCSVConversionWorkers(inputCtx, &workerWg)
 	closeByte.Do(func() {
 		close(ep.ByteChan)
 	})
 	writerWg.Wait()
+	if inputErr == nil {
+		inputErr = inputCtx.Err()
+	}
+	err = joinCSVInputError(err, inputErr)
 
 	select {
 	case e := <-writerErr:

--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/golang/mock/gomock"
@@ -37,6 +38,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pbtimestamp "github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/panjf2000/ants/v2"
 	"github.com/stretchr/testify/require"
@@ -867,6 +869,126 @@ func TestDataBranchOutputShouldDiffAsCSV(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ok)
 	})
+}
+
+func TestSubmitCSVBatchForConversionReturnsCopyErrorBeforeSubmit(t *testing.T) {
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+
+	dstMP, err := mpool.NewMPool("data-branch-csv-copy-failure", 1<<20, mpool.NoFixed)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		mpool.DeleteMPool(dstMP)
+	})
+
+	bat := batch.NewOffHeapWithSize(1)
+	bat.Vecs[0] = vector.NewVec(types.T_text.ToType())
+	require.NoError(t, vector.AppendBytes(bat.Vecs[0], make([]byte, 2<<20), false, srcMP))
+	bat.SetRowCount(1)
+	t.Cleanup(func() {
+		bat.Clean(srcMP)
+	})
+
+	ses := &Session{proc: testutil.NewProcessWithMPool(t, "", dstMP)}
+	ep := &ExportConfig{}
+	var workerWg sync.WaitGroup
+
+	_, wantErr := bat.Dup(dstMP)
+	require.Error(t, wantErr)
+	require.Zero(t, dstMP.CurrNB())
+
+	err = submitCSVBatchForConversion(
+		context.Background(), ses, tableStuff{}, bat, ep, &workerWg,
+	)
+	require.EqualError(t, err, wantErr.Error())
+	require.Zero(t, ep.Index.Load())
+	require.Zero(t, dstMP.CurrNB())
+	workerWg.Wait()
+}
+
+func TestSubmitCSVBatchForConversionCleansCopyOnSubmitError(t *testing.T) {
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	dstMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(dstMP)
+	})
+
+	bat := batch.NewOffHeapWithSize(1)
+	bat.Vecs[0] = vector.NewVec(types.T_text.ToType())
+	require.NoError(t, vector.AppendBytes(bat.Vecs[0], []byte("value"), false, srcMP))
+	bat.SetRowCount(1)
+	t.Cleanup(func() {
+		bat.Clean(srcMP)
+	})
+
+	worker, err := ants.NewPool(1)
+	require.NoError(t, err)
+	worker.Release()
+
+	ses := &Session{proc: testutil.NewProcessWithMPool(t, "", dstMP)}
+	ep := &ExportConfig{}
+	var workerWg sync.WaitGroup
+
+	err = submitCSVBatchForConversion(
+		context.Background(), ses, tableStuff{worker: worker}, bat, ep, &workerWg,
+	)
+	require.Error(t, err)
+	require.Zero(t, ep.Index.Load())
+	require.Zero(t, dstMP.CurrNB())
+	workerWg.Wait()
+}
+
+func TestFlushRemainingCSVBatchBytesSkipsCanceledIndexGap(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ep := &ExportConfig{}
+	ep.Index.Store(1)
+	ep.ByteChan = make(chan *BatchByte)
+	close(ep.ByteChan)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- flushRemainingCSVBatchBytes(ctx, ep)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("canceled CSV writer waited for a batch index that cannot be produced")
+	}
+}
+
+func TestWaitForCSVConversionWorkersReturnsLateCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var workerWg sync.WaitGroup
+	workerWg.Add(1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- waitForCSVConversionWorkers(ctx, &workerWg)
+	}()
+
+	cancel()
+	workerWg.Done()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("waiting for CSV conversion workers did not terminate")
+	}
+}
+
+func TestJoinCSVInputErrorDoesNotDuplicateObservedCancellation(t *testing.T) {
+	require.EqualError(t, joinCSVInputError(context.Canceled, context.Canceled), context.Canceled.Error())
+	require.ErrorIs(t, joinCSVInputError(nil, context.Canceled), context.Canceled)
 }
 
 func TestDataBranchOutputWriteRowValues(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26128

## What this PR does / why we need it:

`DATA BRANCH DIFF ... OUTPUT FILE` previously discarded `Batch.Dup` errors and could submit a nil batch to the CSV conversion worker.

Changes:
- return the original batch-copy error before mutating worker or index accounting;
- clean an untransferred copied batch and roll back accounting when worker submission fails;
- cover copy failure and submission failure with real mpool and worker-pool barriers.

Validation:
- `go test ./pkg/frontend -run '^TestSubmitCSVBatchForConversion' -count=3`
- `go test ./pkg/frontend -count=1`
- `go test -race ./pkg/frontend -run '^TestSubmitCSVBatchForConversion' -count=1`
- `git diff --check`

Non-goals:
- no change to successful CSV formatting, ordering, or file naming;
- no change to the ordinary export path.
