### PR TITLE
fix(frontend): demote expected proxy extra-info timeout log

### DIFF
--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -3861,7 +3861,7 @@ func (mp *MysqlProtocolImpl) receiveExtraInfo(rs *Conn) {
 	if err := i.Decode(reader); err != nil {
 		// If the error is timeout, we treat it as normal case and do not update extra info.
 		if err, ok := err.(net.Error); ok && err.Timeout() {
-			mp.ses.Error(mp.ctx, "cannot get salt, maybe not use proxy",
+			mp.ses.Debug(mp.ctx, "cannot get salt, maybe not use proxy",
 				zap.Error(err))
 		} else {
 			mp.ses.Error(mp.ctx, "failed to get extra info",

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -37,7 +37,11 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
+	molog "github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/config"
@@ -48,6 +52,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	planPb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
@@ -61,6 +66,59 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+func newObservedProtocolSession() (*Session, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	ses := &Session{
+		logger:   molog.GetServiceLogger(zap.New(core), metadata.ServiceType_CN, "test"),
+		logLevel: zapcore.DebugLevel,
+	}
+	ses.loggerOnce.Do(func() {})
+	return ses, logs
+}
+
+func TestMysqlProtocolReceiveExtraInfoLogLevel(t *testing.T) {
+	t.Run("timeout is debug", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		defer clientConn.Close()
+		defer serverConn.Close()
+
+		ses, logs := newObservedProtocolSession()
+		proto := &MysqlProtocolImpl{
+			ctx: context.Background(),
+			ses: ses,
+		}
+		proto.receiveExtraInfo(&Conn{conn: serverConn})
+
+		entries := logs.FilterMessage("cannot get salt, maybe not use proxy").All()
+		require.Len(t, entries, 1)
+		require.Equal(t, zap.DebugLevel, entries[0].Level)
+	})
+
+	t.Run("malformed extra info is error", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		defer clientConn.Close()
+		defer serverConn.Close()
+
+		writeErr := make(chan error, 1)
+		go func() {
+			_, err := clientConn.Write([]byte{1, 0, 0xff})
+			writeErr <- err
+		}()
+
+		ses, logs := newObservedProtocolSession()
+		proto := &MysqlProtocolImpl{
+			ctx: context.Background(),
+			ses: ses,
+		}
+		proto.receiveExtraInfo(&Conn{conn: serverConn})
+		require.NoError(t, <-writeErr)
+
+		entries := logs.FilterMessage("failed to get extra info").All()
+		require.Len(t, entries, 1)
+		require.Equal(t, zap.ErrorLevel, entries[0].Level)
+	})
+}
 
 func registerConn(clientConn net.Conn) {
 	mysqlDriver.RegisterDialContext("custom", func(ctx context.Context, addr string) (net.Conn, error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26170

## What this PR does / why we need it:

When proxy support is enabled, `RoutineManager.Created` probes for MatrixOne
proxy extra-info before sending the MySQL handshake. A direct MySQL client does
not send that private header and instead waits for the server handshake, so the
probe's bounded 200 ms read timeout is the expected direct-connection fallback.

PR #21090 intended to reduce routine INFO logs, but this branch was accidentally
changed from `Info` to `Error` while the other routine logs were changed to
`Debug`. As a result, normal direct connections emit
`cannot get salt, maybe not use proxy` at Error level.

Log only the timeout branch at Debug. Keep malformed extra-info and unexpected
transport/decode failures at Error, and preserve all handshake, salt, label,
connection ID, and connection classification behavior. The regression test
uses real `net.Pipe` connections to cover both the direct-client timeout and
malformed extra-info paths.

Tested with:

`CGO_CFLAGS="-I$PWD/cgo -I$PWD/thirdparties/install/include" CGO_LDFLAGS="-L$PWD/thirdparties/install/lib" GOWORK=off GOFLAGS=-mod=readonly go build ./pkg/frontend`

`CGO_CFLAGS="-I$PWD/cgo -I$PWD/thirdparties/install/include" CGO_LDFLAGS="-L$PWD/thirdparties/install/lib" GOWORK=off GOFLAGS=-mod=readonly go vet ./pkg/frontend`

`.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=300s ./pkg/frontend`

`.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=240s -run '^TestMysqlProtocolReceiveExtraInfoLogLevel$' ./pkg/frontend`

`.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s -run '^TestMysqlClientProtocol_Handshake$' ./pkg/frontend`
