### PR TITLE
fix: snapshot async execution plans

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -5244,7 +5244,7 @@ func NewMarshalPlanHandler(ctx context.Context, stmt *motrace.StatementInfo, pla
 		h.marshalPlan = explain.BuildJsonPlan(ctx, h.uuid, &explain.MarshalPlanOptions, h.query)
 		h.marshalPlan.NewPlanStats.SetWaitActiveCost(h.waitActiveCost)
 		if phyPlan != nil {
-			h.marshalPlan.PhyPlan = *phyPlan
+			h.marshalPlan.PhyPlan = *phyPlan.CloneForExport()
 		}
 		if h.schedulingTrace != nil {
 			h.marshalPlan.Scheduling = h.schedulingTrace

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/matrixorigin/matrixone/pkg/sql/compile"
+	"github.com/matrixorigin/matrixone/pkg/sql/models"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
@@ -3458,6 +3459,154 @@ func TestMarshalPlanHandlerSanitizesNonFinitePlanStats(t *testing.T) {
 	require.NotContains(t, string(jsonBytes), "serialize plan to json error")
 }
 
+func TestJsonPlanHandlerSnapshotsPhyPlanBeforePreparedReset(t *testing.T) {
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	stmt := &motrace.StatementInfo{
+		StatementID: uid,
+		Statement:   []byte("select 1"),
+		RequestAt:   time.Now().Add(-motrace.GetLongQueryTime() - time.Second),
+	}
+	logicPlan := &plan0.Plan{Plan: &plan0.Plan_Query{Query: &plan0.Query{
+		Nodes: []*plan0.Node{{NodeId: 0, NodeType: plan0.Node_VALUE_SCAN}},
+		Steps: []int32{0},
+	}}}
+	stats := &process.OperatorStats{
+		CallNum:         7,
+		OperatorMetrics: map[process.MetricType]int64{process.OpScanTime: 11},
+	}
+	phyPlan := &models.PhyPlan{LocalScope: []models.PhyScope{{
+		RootOperator: &models.PhyOperator{OpName: "value scan", OpStats: stats},
+	}}}
+	handler := NewJsonPlanHandler(context.Background(), stmt, nil, logicPlan, phyPlan)
+	defer handler.Free()
+
+	stats.Reset()
+	stats.CallNum = 101
+	stats.OperatorMetrics = map[process.MetricType]int64{process.OpScanTime: 103}
+
+	var payload struct {
+		PhyPlan struct {
+			LocalScope []struct {
+				RootOperator struct {
+					OpStats struct {
+						CallNum         int              `json:"CallCount"`
+						OperatorMetrics map[string]int64 `json:"OperatorMetrics"`
+					} `json:"OpStats"`
+				} `json:"RootOperator"`
+			} `json:"scope"`
+		}
+	}
+	jsonBytes := handler.Marshal(context.Background())
+	require.NoError(t, json.Unmarshal(jsonBytes, &payload))
+	require.Len(t, payload.PhyPlan.LocalScope, 1)
+	require.Equal(t, 7, payload.PhyPlan.LocalScope[0].RootOperator.OpStats.CallNum)
+	require.Equal(t, int64(11), payload.PhyPlan.LocalScope[0].RootOperator.OpStats.OperatorMetrics["0"])
+}
+
+func TestMarshalPlanHandlerSanitizesSnapshotWithoutMutatingSource(t *testing.T) {
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	stmt := &motrace.StatementInfo{
+		StatementID: uid,
+		Statement:   []byte("select 1"),
+		RequestAt:   time.Now().Add(-motrace.GetLongQueryTime() - time.Second),
+	}
+	logicPlan := &plan0.Plan{Plan: &plan0.Plan_Query{Query: &plan0.Query{
+		Nodes: []*plan0.Node{{NodeId: 0, NodeType: plan0.Node_VALUE_SCAN}},
+		Steps: []int32{0},
+	}}}
+	backgroundQuery := &plan0.Query{Nodes: []*plan0.Node{{
+		NodeId:   0,
+		NodeType: plan0.Node_VALUE_SCAN,
+		Stats:    &plan0.Stats{Cost: math.Inf(1)},
+	}}, Steps: []int32{0}}
+	phyPlan := &models.PhyPlan{LocalScope: []models.PhyScope{{
+		RootOperator: &models.PhyOperator{OpName: "value scan", OpStats: &process.OperatorStats{
+			BackgroundQueries: []*plan0.Query{backgroundQuery},
+		}},
+	}}}
+	handler := NewJsonPlanHandler(context.Background(), stmt, nil, logicPlan, phyPlan)
+	defer handler.Free()
+
+	jsonBytes := handler.Marshal(context.Background())
+
+	require.NotContains(t, string(jsonBytes), "serialize plan to json error")
+	require.True(t, math.IsInf(backgroundQuery.Nodes[0].Stats.Cost, 1))
+}
+
+func TestJsonPlanHandlerSnapshotSurvivesSourceReuse(t *testing.T) {
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	stmt := &motrace.StatementInfo{
+		StatementID: uid,
+		Statement:   []byte("select 1"),
+		RequestAt:   time.Now().Add(-motrace.GetLongQueryTime() - time.Second),
+	}
+	logicPlan := &plan0.Plan{Plan: &plan0.Plan_Query{Query: &plan0.Query{
+		Nodes: []*plan0.Node{{NodeId: 0, NodeType: plan0.Node_VALUE_SCAN}},
+		Steps: []int32{0},
+	}}}
+	stats := &process.OperatorStats{
+		CallNum:         7,
+		OperatorMetrics: map[process.MetricType]int64{process.OpScanTime: 11},
+		ExtraStats:      map[string]int64{"SpillBytes": 13},
+	}
+	phyPlan := &models.PhyPlan{LocalScope: []models.PhyScope{{
+		RootOperator: &models.PhyOperator{OpName: "value scan", OpStats: stats},
+	}}}
+	handler := NewJsonPlanHandler(context.Background(), stmt, nil, logicPlan, phyPlan)
+	defer handler.Free()
+
+	startReuse := make(chan struct{})
+	stopReuse := make(chan struct{})
+	firstReuse := make(chan struct{})
+	reuseDone := make(chan struct{})
+	go func() {
+		defer close(reuseDone)
+		<-startReuse
+		stats.Reset()
+		stats.CallNum = 101
+		stats.OperatorMetrics = map[process.MetricType]int64{process.OpScanTime: 103}
+		stats.ExtraStats = map[string]int64{"SpillBytes": 107}
+		close(firstReuse)
+		for {
+			select {
+			case <-stopReuse:
+				return
+			default:
+				stats.Reset()
+				stats.CallNum = 101
+				stats.OperatorMetrics = map[process.MetricType]int64{process.OpScanTime: 103}
+				stats.ExtraStats = map[string]int64{"SpillBytes": 107}
+			}
+		}
+	}()
+	close(startReuse)
+	<-firstReuse
+	jsonBytes := handler.Marshal(context.Background())
+	close(stopReuse)
+	<-reuseDone
+
+	var payload struct {
+		PhyPlan struct {
+			LocalScope []struct {
+				RootOperator struct {
+					OpStats struct {
+						CallNum         int              `json:"CallCount"`
+						OperatorMetrics map[string]int64 `json:"OperatorMetrics"`
+						ExtraStats      map[string]int64 `json:"ExtraStats"`
+					} `json:"OpStats"`
+				} `json:"RootOperator"`
+			} `json:"scope"`
+		}
+	}
+	require.NoError(t, json.Unmarshal(jsonBytes, &payload))
+	require.Equal(t, 7, payload.PhyPlan.LocalScope[0].RootOperator.OpStats.CallNum)
+	require.Equal(t, int64(11), payload.PhyPlan.LocalScope[0].RootOperator.OpStats.OperatorMetrics["0"])
+	require.Equal(t, int64(13), payload.PhyPlan.LocalScope[0].RootOperator.OpStats.ExtraStats["SpillBytes"])
+}
+
 func TestJsonPlanHandlerRefreshesTerminalResourceSummary(t *testing.T) {
 	uid, err := uuid.NewV7()
 	require.NoError(t, err)
@@ -3507,6 +3656,7 @@ func TestJsonPlanHandlerRefreshesTerminalResourceSummary(t *testing.T) {
 	unmarshaled.Free()
 	require.Nil(t, unmarshaled.buffer)
 	require.Nil(t, unmarshaled.marshalHandler)
+	require.Nil(t, unmarshaled.Marshal(context.Background()))
 }
 
 func TestSchedulingTracePlanHandlerMarshalsLazilyOnce(t *testing.T) {
@@ -3541,6 +3691,7 @@ func TestJsonPlanHandlerKeepsStaticPlanPlaceholders(t *testing.T) {
 	shortHandler := NewJsonPlanHandler(
 		context.Background(), stmt, nil, shortPlan, nil, WithWaitActiveCost(time.Hour))
 	defer shortHandler.Free()
+	require.Nil(t, shortHandler.marshalHandler.marshalPlan)
 	require.Equal(t, sqlQueryIgnoreExecPlan, shortHandler.Marshal(context.Background()))
 	require.Nil(t, shortHandler.buffer)
 

--- a/pkg/lockservice/unknown_commit_test.go
+++ b/pkg/lockservice/unknown_commit_test.go
@@ -331,14 +331,17 @@ func TestUnknownCommitFenceOverflowReleasesSourceTxn(t *testing.T) {
 		defer cancel()
 
 		service := services[0]
-		now := time.Now()
+		// The setup performs one allocator RPC per fence. Keep every seed far
+		// enough in the future to create the overflow deadline after setup while
+		// retaining a shorter expiry than every seed.
+		seedDeadline := time.Now().Add(time.Hour)
 		for i := 0; i < maxPersistentFenceFrontierEntries; i++ {
 			// Increasing sequence and decreasing expiry intentionally build the
 			// largest exact non-dominated frontier.
 			_, _, ok := service.canUnlockUnknownCommits(
 				ctx,
 				[][]byte{[]byte(fmt.Sprintf("seed-%d", i))},
-				now.Add(time.Duration(maxPersistentFenceFrontierEntries-i+3)*time.Second),
+				seedDeadline.Add(time.Duration(maxPersistentFenceFrontierEntries-i+3)*time.Second),
 				uint64(i+1),
 			)
 			require.True(t, ok)
@@ -353,9 +356,12 @@ func TestUnknownCommitFenceOverflowReleasesSourceTxn(t *testing.T) {
 			newTestRowExclusiveOptions(),
 		)
 		require.NoError(t, err)
+		// Derive this after the RPC-heavy setup so its fence is still live when
+		// the resolver submits it.
+		overflowDeadline := time.Now().Add(time.Minute)
 		require.NoError(t, service.ResolveCommitUnknown(
 			overflowTxn,
-			now.Add(time.Second),
+			overflowDeadline,
 			maxPersistentFenceFrontierEntries+1,
 			nil,
 		))

--- a/pkg/sql/models/phy_plan.go
+++ b/pkg/sql/models/phy_plan.go
@@ -69,6 +69,165 @@ func NewPhyPlan() *PhyPlan {
 	}
 }
 
+// CloneForExport detaches the physical plan from the completed execution
+// generation before it is retained for asynchronous export. Callers must
+// invoke it before the source plan is reset or reused.
+func (p *PhyPlan) CloneForExport() *PhyPlan {
+	if p == nil {
+		return nil
+	}
+
+	nodeCount, childCount := countPhyPlanOperators(p)
+	cloner := phyPlanExportCloner{
+		operators: make(map[*PhyOperator]*PhyOperator, nodeCount),
+		stats:     make(map[*process.OperatorStats]*process.OperatorStats),
+		nodes:     make([]PhyOperator, nodeCount),
+		children:  make([]*PhyOperator, childCount),
+	}
+	clone := &PhyPlan{
+		Version:     p.Version,
+		RetryTime:   p.RetryTime,
+		LocalScope:  cloner.cloneScopes(p.LocalScope),
+		RemoteScope: cloner.cloneScopes(p.RemoteScope),
+	}
+	if p.Resource != nil {
+		resource := *p.Resource
+		clone.Resource = &resource
+	}
+	return clone
+}
+
+type phyPlanExportCloner struct {
+	operators map[*PhyOperator]*PhyOperator
+	stats     map[*process.OperatorStats]*process.OperatorStats
+	nodes     []PhyOperator
+	children  []*PhyOperator
+	nextNode  int
+	nextChild int
+}
+
+func countPhyPlanOperators(p *PhyPlan) (int, int) {
+	seen := make(map[*PhyOperator]struct{})
+	var countScopes func([]PhyScope) (int, int)
+	var countScope func(PhyScope) (int, int)
+	var countOperator func(*PhyOperator) (int, int)
+	countOperator = func(operator *PhyOperator) (int, int) {
+		if operator == nil {
+			return 0, 0
+		}
+		if _, ok := seen[operator]; ok {
+			return 0, 0
+		}
+		seen[operator] = struct{}{}
+		nodes, children := 1, len(operator.Children)
+		for _, child := range operator.Children {
+			childNodes, childChildren := countOperator(child)
+			nodes += childNodes
+			children += childChildren
+		}
+		return nodes, children
+	}
+	countScope = func(scope PhyScope) (int, int) {
+		nodes, children := countOperator(scope.RootOperator)
+		for _, preScope := range scope.PreScopes {
+			preNodes, preChildren := countScope(preScope)
+			nodes += preNodes
+			children += preChildren
+		}
+		return nodes, children
+	}
+	countScopes = func(scopes []PhyScope) (int, int) {
+		var nodes, children int
+		for _, scope := range scopes {
+			scopeNodes, scopeChildren := countScope(scope)
+			nodes += scopeNodes
+			children += scopeChildren
+		}
+		return nodes, children
+	}
+	localNodes, localChildren := countScopes(p.LocalScope)
+	remoteNodes, remoteChildren := countScopes(p.RemoteScope)
+	return localNodes + remoteNodes, localChildren + remoteChildren
+}
+
+func (c *phyPlanExportCloner) cloneScopes(scopes []PhyScope) []PhyScope {
+	if scopes == nil {
+		return nil
+	}
+	clones := make([]PhyScope, len(scopes))
+	for i, scope := range scopes {
+		clones[i] = c.cloneScope(scope)
+	}
+	return clones
+}
+
+func (c *phyPlanExportCloner) cloneScope(scope PhyScope) PhyScope {
+	clone := scope
+	clone.Receiver = clonePhyReceivers(scope.Receiver)
+	clone.DataSource = clonePhySource(scope.DataSource)
+	clone.PreScopes = c.cloneScopes(scope.PreScopes)
+	clone.RootOperator = c.cloneOperator(scope.RootOperator)
+	return clone
+}
+
+func clonePhyReceivers(receivers []PhyReceiver) []PhyReceiver {
+	if receivers == nil {
+		return nil
+	}
+	clone := make([]PhyReceiver, len(receivers))
+	copy(clone, receivers)
+	return clone
+}
+
+func clonePhySource(source *PhySource) *PhySource {
+	if source == nil {
+		return nil
+	}
+	clone := *source
+	if source.Attributes != nil {
+		clone.Attributes = make([]string, len(source.Attributes))
+		copy(clone.Attributes, source.Attributes)
+	}
+	return &clone
+}
+
+func (c *phyPlanExportCloner) cloneOperator(operator *PhyOperator) *PhyOperator {
+	if operator == nil {
+		return nil
+	}
+	if clone, ok := c.operators[operator]; ok {
+		return clone
+	}
+
+	clone := &c.nodes[c.nextNode]
+	c.nextNode++
+	*clone = *operator
+	c.operators[operator] = clone
+	clone.DestReceiver = clonePhyReceivers(operator.DestReceiver)
+	clone.OpStats = c.cloneOperatorStats(operator.OpStats)
+	if operator.Children != nil {
+		start := c.nextChild
+		c.nextChild += len(operator.Children)
+		clone.Children = c.children[start:c.nextChild]
+		for i, child := range operator.Children {
+			clone.Children[i] = c.cloneOperator(child)
+		}
+	}
+	return clone
+}
+
+func (c *phyPlanExportCloner) cloneOperatorStats(stats *process.OperatorStats) *process.OperatorStats {
+	if stats == nil {
+		return nil
+	}
+	if clone, ok := c.stats[stats]; ok {
+		return clone
+	}
+	clone := stats.CloneForExport()
+	c.stats[stats] = clone
+	return clone
+}
+
 func PhyPlanToJSON(p *PhyPlan) (string, error) {
 	jsonData, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {

--- a/pkg/sql/models/phy_plan.go
+++ b/pkg/sql/models/phy_plan.go
@@ -72,6 +72,10 @@ func NewPhyPlan() *PhyPlan {
 // CloneForExport detaches the physical plan from the completed execution
 // generation before it is retained for asynchronous export. Callers must
 // invoke it before the source plan is reset or reused.
+//
+// TestPhyPlanCloneForExportReferenceSchemaIsExplicit is the schema tripwire
+// for this semantic clone. Any new reference-bearing field must be classified
+// there and detached here before the test fixture can be updated.
 func (p *PhyPlan) CloneForExport() *PhyPlan {
 	if p == nil {
 		return nil
@@ -84,17 +88,14 @@ func (p *PhyPlan) CloneForExport() *PhyPlan {
 		nodes:     make([]PhyOperator, nodeCount),
 		children:  make([]*PhyOperator, childCount),
 	}
-	clone := &PhyPlan{
-		Version:     p.Version,
-		RetryTime:   p.RetryTime,
-		LocalScope:  cloner.cloneScopes(p.LocalScope),
-		RemoteScope: cloner.cloneScopes(p.RemoteScope),
-	}
+	clone := *p
+	clone.LocalScope = cloner.cloneScopes(p.LocalScope)
+	clone.RemoteScope = cloner.cloneScopes(p.RemoteScope)
 	if p.Resource != nil {
 		resource := *p.Resource
 		clone.Resource = &resource
 	}
-	return clone
+	return &clone
 }
 
 type phyPlanExportCloner struct {

--- a/pkg/sql/models/phy_plan_test.go
+++ b/pkg/sql/models/phy_plan_test.go
@@ -16,6 +16,8 @@ package models
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -78,12 +80,21 @@ func newBenchmarkPhyPlan(operatorCount int, withBackgroundQuery bool) *PhyPlan {
 	return &PhyPlan{LocalScope: []PhyScope{{RootOperator: root}}}
 }
 
-func TestPhyPlanCloneForExportDetachesExecutionGraph(t *testing.T) {
+func newPhyPlanExportCloneFixture() (*PhyPlan, *process.OperatorStats) {
 	stats := &process.OperatorStats{
 		OperatorName:    "shared",
 		CallNum:         7,
 		OperatorMetrics: map[process.MetricType]int64{process.OpScanTime: 11},
 		ExtraStats:      map[string]int64{"SpillBytes": 13},
+		BackgroundQueries: []*planpb.Query{{
+			Steps:      []int32{0},
+			Headings:   []string{"background"},
+			DetectSqls: []string{"select 1"},
+			BackgroundQueries: []*planpb.Query{{
+				Steps:    []int32{1},
+				Headings: []string{"nested"},
+			}},
+		}},
 	}
 	sharedChild := &PhyOperator{
 		OpName:  "child",
@@ -97,7 +108,7 @@ func TestPhyPlanCloneForExportDetachesExecutionGraph(t *testing.T) {
 		OpStats:      stats,
 		Children:     []*PhyOperator{sharedChild, sharedChild},
 	}
-	source := &PhyPlan{
+	return &PhyPlan{
 		Version:   "1.0",
 		RetryTime: 3,
 		Resource:  &resource.StatementResourceSummary{StatementWallNS: 17},
@@ -115,11 +126,70 @@ func TestPhyPlanCloneForExportDetachesExecutionGraph(t *testing.T) {
 			Magic:        "Remote",
 			RootOperator: sharedChild,
 		}},
+	}, stats
+}
+
+func TestPhyPlanCloneForExportReferenceSchemaIsExplicit(t *testing.T) {
+	source, stats := newPhyPlanExportCloneFixture()
+	testCases := []struct {
+		name                  string
+		value                 any
+		referenceBearingField []string
+	}{
+		{
+			name:                  "PhyPlan",
+			value:                 source,
+			referenceBearingField: []string{"LocalScope", "RemoteScope", "Resource"},
+		},
+		{
+			name:                  "PhyScope",
+			value:                 source.LocalScope[0],
+			referenceBearingField: []string{"Receiver", "DataSource", "PreScopes", "RootOperator"},
+		},
+		{
+			name:                  "PhyReceiver",
+			value:                 source.LocalScope[0].Receiver[0],
+			referenceBearingField: nil,
+		},
+		{
+			name:                  "PhySource",
+			value:                 source.LocalScope[0].DataSource,
+			referenceBearingField: []string{"Attributes"},
+		},
+		{
+			name:                  "PhyOperator",
+			value:                 source.LocalScope[0].RootOperator,
+			referenceBearingField: []string{"DestReceiver", "OpStats", "Children"},
+		},
+		{
+			name:                  "OperatorStats",
+			value:                 stats,
+			referenceBearingField: []string{"OperatorMetrics", "ExtraStats", "BackgroundQueries"},
+		},
+		{
+			name:                  "StatementResourceSummary",
+			value:                 source.Resource,
+			referenceBearingField: nil,
+		},
 	}
 
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			requireReferenceSchema(t, testCase.value, testCase.referenceBearingField)
+		})
+	}
+}
+
+func TestPhyPlanCloneForExportDetachesExecutionGraph(t *testing.T) {
+	source, stats := newPhyPlanExportCloneFixture()
+
 	got := source.CloneForExport()
+	shallow := *source
 
 	require.Equal(t, source, got)
+	require.NotEmpty(t, findMutableAliases(source, &shallow),
+		"positive control: a shallow plan copy must retain mutable aliases")
+	require.Empty(t, findMutableAliases(source, got))
 	require.NotSame(t, source, got)
 	require.NotSame(t, source.Resource, got.Resource)
 	require.NotSame(t, source.LocalScope[0].DataSource, got.LocalScope[0].DataSource)
@@ -149,6 +219,177 @@ func TestPhyPlanCloneForExportDetachesExecutionGraph(t *testing.T) {
 
 	var nilPlan *PhyPlan
 	require.Nil(t, nilPlan.CloneForExport())
+}
+
+func requireReferenceSchema(t *testing.T, fixture any, expected []string) {
+	t.Helper()
+	value := reflect.ValueOf(fixture)
+	require.True(t, value.IsValid())
+	if value.Kind() == reflect.Pointer {
+		require.False(t, value.IsNil())
+		value = value.Elem()
+	}
+	require.Equal(t, reflect.Struct, value.Kind())
+
+	typ := value.Type()
+	actual := make([]string, 0)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if containsMutableReference(field.Type) {
+			actual = append(actual, field.Name)
+		}
+	}
+	require.ElementsMatchf(t, expected, actual,
+		"%s reference schema changed; classify every new field, update CloneForExport, and populate this fixture",
+		typ)
+
+	for _, fieldName := range expected {
+		field := value.FieldByName(fieldName)
+		require.Truef(t, field.IsValid(), "%s.%s is not present", typ, fieldName)
+		require.Truef(t, hasPopulatedMutableReference(field),
+			"%s.%s must be populated so the alias-detachment test exercises it", typ, fieldName)
+	}
+}
+
+func containsMutableReference(typ reflect.Type) bool {
+	switch typ.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return true
+	case reflect.Array:
+		return containsMutableReference(typ.Elem())
+	case reflect.Struct:
+		for i := 0; i < typ.NumField(); i++ {
+			if containsMutableReference(typ.Field(i).Type) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasPopulatedMutableReference(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Map, reflect.Slice:
+		return !value.IsNil() && value.Len() > 0
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Pointer:
+		return !value.IsNil()
+	case reflect.UnsafePointer:
+		return !value.IsNil()
+	case reflect.Array:
+		for i := 0; i < value.Len(); i++ {
+			if hasPopulatedMutableReference(value.Index(i)) {
+				return true
+			}
+		}
+	case reflect.Struct:
+		for i := 0; i < value.NumField(); i++ {
+			if hasPopulatedMutableReference(value.Field(i)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type mutableReferenceIdentity struct {
+	kind    reflect.Kind
+	typ     reflect.Type
+	pointer uintptr
+}
+
+func findMutableAliases(source, clone any) []string {
+	sourceIdentities := make(map[mutableReferenceIdentity]string)
+	cloneIdentities := make(map[mutableReferenceIdentity]string)
+	collectMutableReferenceIdentities(
+		reflect.ValueOf(source), "source", sourceIdentities, make(map[mutableReferenceIdentity]struct{}))
+	collectMutableReferenceIdentities(
+		reflect.ValueOf(clone), "clone", cloneIdentities, make(map[mutableReferenceIdentity]struct{}))
+
+	aliases := make([]string, 0)
+	for identity, clonePath := range cloneIdentities {
+		if sourcePath, ok := sourceIdentities[identity]; ok {
+			aliases = append(aliases, fmt.Sprintf(
+				"%s and %s share %s at %#x",
+				sourcePath, clonePath, identity.typ, identity.pointer))
+		}
+	}
+	sort.Strings(aliases)
+	return aliases
+}
+
+func collectMutableReferenceIdentities(
+	value reflect.Value,
+	path string,
+	identities map[mutableReferenceIdentity]string,
+	visited map[mutableReferenceIdentity]struct{},
+) {
+	if !value.IsValid() {
+		return
+	}
+
+	switch value.Kind() {
+	case reflect.Interface:
+		if !value.IsNil() {
+			collectMutableReferenceIdentities(value.Elem(), path, identities, visited)
+		}
+	case reflect.Pointer:
+		if value.IsNil() {
+			return
+		}
+		identity := mutableReferenceIdentity{kind: value.Kind(), typ: value.Type(), pointer: value.Pointer()}
+		identities[identity] = path
+		if _, ok := visited[identity]; ok {
+			return
+		}
+		visited[identity] = struct{}{}
+		collectMutableReferenceIdentities(value.Elem(), path+"*", identities, visited)
+	case reflect.Map:
+		if value.IsNil() {
+			return
+		}
+		identity := mutableReferenceIdentity{
+			kind: value.Kind(), typ: value.Type(), pointer: uintptr(value.UnsafePointer()),
+		}
+		identities[identity] = path
+		if _, ok := visited[identity]; ok {
+			return
+		}
+		visited[identity] = struct{}{}
+		iter := value.MapRange()
+		for iter.Next() {
+			collectMutableReferenceIdentities(iter.Key(), path+"[key]", identities, visited)
+			collectMutableReferenceIdentities(iter.Value(), path+"[value]", identities, visited)
+		}
+	case reflect.Slice:
+		if value.IsNil() {
+			return
+		}
+		identity := mutableReferenceIdentity{kind: value.Kind(), typ: value.Type(), pointer: value.Pointer()}
+		identities[identity] = path
+		if _, ok := visited[identity]; ok {
+			return
+		}
+		visited[identity] = struct{}{}
+		for i := 0; i < value.Len(); i++ {
+			collectMutableReferenceIdentities(value.Index(i), fmt.Sprintf("%s[%d]", path, i), identities, visited)
+		}
+	case reflect.Array:
+		for i := 0; i < value.Len(); i++ {
+			collectMutableReferenceIdentities(value.Index(i), fmt.Sprintf("%s[%d]", path, i), identities, visited)
+		}
+	case reflect.Struct:
+		typ := value.Type()
+		for i := 0; i < value.NumField(); i++ {
+			collectMutableReferenceIdentities(
+				value.Field(i), path+"."+typ.Field(i).Name, identities, visited)
+		}
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		if !value.IsNil() {
+			identity := mutableReferenceIdentity{kind: value.Kind(), typ: value.Type(), pointer: value.Pointer()}
+			identities[identity] = path
+		}
+	}
 }
 
 func TestPhyPlanCloneForExportPreservesNilAndEmptyReferences(t *testing.T) {

--- a/pkg/sql/models/phy_plan_test.go
+++ b/pkg/sql/models/phy_plan_test.go
@@ -19,7 +19,10 @@ import (
 	"strings"
 	"testing"
 
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/util/resource"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -29,6 +32,145 @@ const (
 	isFirstFalse = 0 << 0 // 0000 : isFirst = false
 	isLastFalse  = 0 << 1 // 0000 : isLast = false
 )
+
+var benchmarkExportPhyPlan *PhyPlan
+
+func BenchmarkPhyPlanCloneForExport(b *testing.B) {
+	for _, operatorCount := range []int{10, 100, 1000} {
+		for _, withBackgroundQuery := range []bool{false, true} {
+			name := fmt.Sprintf("operators=%d/background=%t", operatorCount, withBackgroundQuery)
+			b.Run(name, func(b *testing.B) {
+				plan := newBenchmarkPhyPlan(operatorCount, withBackgroundQuery)
+				b.ReportAllocs()
+				for b.Loop() {
+					benchmarkExportPhyPlan = plan.CloneForExport()
+				}
+			})
+		}
+	}
+}
+
+func newBenchmarkPhyPlan(operatorCount int, withBackgroundQuery bool) *PhyPlan {
+	var root *PhyOperator
+	for i := 0; i < operatorCount; i++ {
+		stats := &process.OperatorStats{
+			CallNum:         i + 1,
+			OperatorMetrics: map[process.MetricType]int64{process.OpScanTime: int64(i)},
+			ExtraStats:      map[string]int64{"SpillBytes": int64(i)},
+		}
+		if withBackgroundQuery && i == 0 {
+			stats.BackgroundQueries = []*planpb.Query{{
+				Steps:      []int32{0},
+				Headings:   []string{"background"},
+				DetectSqls: []string{"select 1"},
+			}}
+		}
+		operator := &PhyOperator{
+			OpName:  "benchmark",
+			NodeIdx: i,
+			OpStats: stats,
+		}
+		if root != nil {
+			operator.Children = []*PhyOperator{root}
+		}
+		root = operator
+	}
+	return &PhyPlan{LocalScope: []PhyScope{{RootOperator: root}}}
+}
+
+func TestPhyPlanCloneForExportDetachesExecutionGraph(t *testing.T) {
+	stats := &process.OperatorStats{
+		OperatorName:    "shared",
+		CallNum:         7,
+		OperatorMetrics: map[process.MetricType]int64{process.OpScanTime: 11},
+		ExtraStats:      map[string]int64{"SpillBytes": 13},
+	}
+	sharedChild := &PhyOperator{
+		OpName:  "child",
+		NodeIdx: 1,
+		OpStats: stats,
+	}
+	root := &PhyOperator{
+		OpName:       "root",
+		NodeIdx:      0,
+		DestReceiver: []PhyReceiver{{Idx: 1, RemoteUuid: "receiver"}},
+		OpStats:      stats,
+		Children:     []*PhyOperator{sharedChild, sharedChild},
+	}
+	source := &PhyPlan{
+		Version:   "1.0",
+		RetryTime: 3,
+		Resource:  &resource.StatementResourceSummary{StatementWallNS: 17},
+		LocalScope: []PhyScope{{
+			Magic:      "Normal",
+			Receiver:   []PhyReceiver{{Idx: 2, RemoteUuid: "local"}},
+			DataSource: &PhySource{SchemaName: "db", RelationName: "tbl", Attributes: []string{"a", "b"}},
+			PreScopes: []PhyScope{{
+				Magic:        "Merge",
+				RootOperator: sharedChild,
+			}},
+			RootOperator: root,
+		}},
+		RemoteScope: []PhyScope{{
+			Magic:        "Remote",
+			RootOperator: sharedChild,
+		}},
+	}
+
+	got := source.CloneForExport()
+
+	require.Equal(t, source, got)
+	require.NotSame(t, source, got)
+	require.NotSame(t, source.Resource, got.Resource)
+	require.NotSame(t, source.LocalScope[0].DataSource, got.LocalScope[0].DataSource)
+	require.NotSame(t, source.LocalScope[0].RootOperator, got.LocalScope[0].RootOperator)
+	require.NotSame(t, source.LocalScope[0].RootOperator.OpStats, got.LocalScope[0].RootOperator.OpStats)
+	require.Same(t, got.LocalScope[0].RootOperator.Children[0], got.LocalScope[0].RootOperator.Children[1])
+	require.Same(t, got.LocalScope[0].RootOperator.Children[0], got.LocalScope[0].PreScopes[0].RootOperator)
+	require.Same(t, got.LocalScope[0].RootOperator.Children[0], got.RemoteScope[0].RootOperator)
+
+	source.Resource.StatementWallNS = 19
+	source.LocalScope[0].Receiver[0].Idx = 20
+	source.LocalScope[0].DataSource.Attributes[0] = "mutated"
+	source.LocalScope[0].RootOperator.DestReceiver[0].Idx = 21
+	source.LocalScope[0].RootOperator.Children = nil
+	stats.OperatorMetrics[process.OpScanTime] = 22
+	stats.ExtraStats["SpillBytes"] = 23
+	stats.Reset()
+
+	require.Equal(t, uint64(17), got.Resource.StatementWallNS)
+	require.Equal(t, 2, got.LocalScope[0].Receiver[0].Idx)
+	require.Equal(t, "a", got.LocalScope[0].DataSource.Attributes[0])
+	require.Equal(t, 1, got.LocalScope[0].RootOperator.DestReceiver[0].Idx)
+	require.Len(t, got.LocalScope[0].RootOperator.Children, 2)
+	require.Equal(t, 7, got.LocalScope[0].RootOperator.OpStats.CallNum)
+	require.Equal(t, int64(11), got.LocalScope[0].RootOperator.OpStats.OperatorMetrics[process.OpScanTime])
+	require.Equal(t, int64(13), got.LocalScope[0].RootOperator.OpStats.ExtraStats["SpillBytes"])
+
+	var nilPlan *PhyPlan
+	require.Nil(t, nilPlan.CloneForExport())
+}
+
+func TestPhyPlanCloneForExportPreservesNilAndEmptyReferences(t *testing.T) {
+	source := &PhyPlan{
+		LocalScope:  []PhyScope{{RootOperator: &PhyOperator{}}},
+		RemoteScope: []PhyScope{},
+	}
+
+	got := source.CloneForExport()
+
+	require.Nil(t, got.Resource)
+	require.Len(t, got.LocalScope, 1)
+	require.Nil(t, got.LocalScope[0].Receiver)
+	require.Nil(t, got.LocalScope[0].DataSource)
+	require.Nil(t, got.LocalScope[0].PreScopes)
+	require.NotNil(t, got.LocalScope[0].RootOperator)
+	require.Nil(t, got.LocalScope[0].RootOperator.DestReceiver)
+	require.Nil(t, got.LocalScope[0].RootOperator.OpStats)
+	require.Nil(t, got.LocalScope[0].RootOperator.Children)
+	require.NotNil(t, got.RemoteScope)
+	require.Empty(t, got.RemoteScope)
+}
 
 func TestPhyPlanJSON(t *testing.T) {
 	operatorStats := &process.OperatorStats{

--- a/pkg/vm/process/operator_analyzer.go
+++ b/pkg/vm/process/operator_analyzer.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
@@ -735,6 +736,38 @@ type OperatorStats struct {
 	ExtraStats map[string]int64 `json:"ExtraStats,omitempty"`
 
 	BackgroundQueries []*plan.Query `json:"BackgroundQueries,omitempty"`
+}
+
+// CloneForExport detaches the mutable references retained by an execution-plan
+// export. Callers must invoke it after the execution generation has completed
+// and before that generation is reset for reuse.
+func (ps *OperatorStats) CloneForExport() *OperatorStats {
+	if ps == nil {
+		return nil
+	}
+
+	clone := *ps
+	if ps.OperatorMetrics != nil {
+		clone.OperatorMetrics = make(map[MetricType]int64, len(ps.OperatorMetrics))
+		for key, value := range ps.OperatorMetrics {
+			clone.OperatorMetrics[key] = value
+		}
+	}
+	if ps.ExtraStats != nil {
+		clone.ExtraStats = make(map[string]int64, len(ps.ExtraStats))
+		for key, value := range ps.ExtraStats {
+			clone.ExtraStats[key] = value
+		}
+	}
+	if ps.BackgroundQueries != nil {
+		clone.BackgroundQueries = make([]*plan.Query, len(ps.BackgroundQueries))
+		for i, query := range ps.BackgroundQueries {
+			if query != nil {
+				clone.BackgroundQueries[i] = proto.Clone(query).(*plan.Query)
+			}
+		}
+	}
+	return &clone
 }
 
 // ResourceDelta returns the producer facts owned by this analyzer. Operator

--- a/pkg/vm/process/operator_analyzer_test.go
+++ b/pkg/vm/process/operator_analyzer_test.go
@@ -19,11 +19,59 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/matrixorigin/matrixone/pkg/util/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOperatorStatsCloneForExportDetachesMutableReferences(t *testing.T) {
+	query := &planpb.Query{
+		Steps:      []int32{1},
+		Headings:   []string{"source"},
+		DetectSqls: []string{"select 1"},
+		BackgroundQueries: []*planpb.Query{
+			{Steps: []int32{2}, Headings: []string{"nested"}},
+		},
+	}
+	source := &OperatorStats{
+		OperatorName:    "source",
+		CallNum:         7,
+		OperatorMetrics: map[MetricType]int64{OpScanTime: 11},
+		ExtraStats:      map[string]int64{"SpillBytes": 13},
+		BackgroundQueries: []*planpb.Query{
+			query,
+			nil,
+		},
+	}
+
+	got := source.CloneForExport()
+
+	require.Equal(t, source, got)
+	require.NotSame(t, source, got)
+	require.NotSame(t, source.BackgroundQueries[0], got.BackgroundQueries[0])
+	require.NotSame(t, source.BackgroundQueries[0].BackgroundQueries[0], got.BackgroundQueries[0].BackgroundQueries[0])
+	require.Nil(t, got.BackgroundQueries[1])
+
+	source.OperatorMetrics[OpScanTime] = 101
+	source.ExtraStats["SpillBytes"] = 103
+	source.BackgroundQueries[0].Steps[0] = 5
+	source.BackgroundQueries[0].Headings[0] = "mutated"
+	source.BackgroundQueries[0].BackgroundQueries[0].Headings[0] = "nested-mutated"
+	source.Reset()
+
+	require.Equal(t, "source", got.OperatorName)
+	require.Equal(t, 7, got.CallNum)
+	require.Equal(t, int64(11), got.OperatorMetrics[OpScanTime])
+	require.Equal(t, int64(13), got.ExtraStats["SpillBytes"])
+	require.Equal(t, int32(1), got.BackgroundQueries[0].Steps[0])
+	require.Equal(t, "source", got.BackgroundQueries[0].Headings[0])
+	require.Equal(t, "nested", got.BackgroundQueries[0].BackgroundQueries[0].Headings[0])
+
+	var nilStats *OperatorStats
+	require.Nil(t, nilStats.CloneForExport())
+}
 
 func TestOperatorStatsResourceDelta(t *testing.T) {
 	stats := OperatorStats{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26175

## What this PR does / why we need it:

The asynchronous JSON-plan exporter previously retained references into a completed execution generation. A prepared-plan reset/reuse could mutate those references before the asynchronous sanitizer or serializer consumed them, resulting in stale data, data races, or a panic.

This PR snapshots `PhyPlan` synchronously before reuse. The clone preserves intentional physical-plan DAG sharing while detaching all mutable execution-owned state: scopes, receivers, sources, operators, operator-stat maps, and background-query protobufs.

To prevent future fields from reopening the bug class, the tests now:

- assert the reference-bearing schema of every cloned type explicitly;
- populate every mutable fixture field;
- prove that a shallow copy is detected as aliased while `CloneForExport` has no mutable aliases;
- cover prepared reset/reuse and sanitizer isolation.

Verification:

- targeted `-race -count=10` tests for the snapshot/reset/sanitizer paths;
- complete UT for `pkg/sql/models`, `pkg/vm/process`, and `pkg/frontend`;
- `go vet` and `go build` for the affected packages;
- clone benchmark: a 1000-operator plan completes in about 0.34 ms locally.