### PR TITLE
fix(hashbuild): avoid false spill budget rejection for reused tail batches

### DIFF
--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -263,18 +263,34 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		// same upstream batch a second time when it is spilled directly.
 		ctr.hashmapBuilder.InputBatchRowCount += result.Batch.RowCount()
 		if hashBuild.IsShuffle {
-			if err := ctr.ensureSpillScratchReservation(result.Batch, analyzer); err != nil {
-				// A larger ingress batch may require growing the emergency lease.
-				// If retained copies are consuming the missing headroom, drain them
-				// under the already-admitted lease, then retry for the current batch.
+			// First prove that the current upstream batch can always be spilled
+			// directly. This uses its actual materialization semantics and never
+			// projects a hypothetical retained batch.
+			if err := ctr.ensureDirectSpillScratchReservation(result.Batch, analyzer); err != nil {
+				// Existing retained batches were admitted with a future-drain
+				// proof. Drain them under that lease, then retry the direct proof
+				// after their source reservations have been released.
 				if spillMode || !errors.Is(err, process.ErrHashBuildBudgetAdmission) || len(ctr.hashmapBuilder.Batches.Buf) == 0 {
 					return err
 				}
 				if err := startSpill(); err != nil {
 					return err
 				}
-				if err := ctr.ensureSpillScratchReservation(result.Batch, analyzer); err != nil {
+				if err := ctr.ensureDirectSpillScratchReservation(result.Batch, analyzer); err != nil {
 					return err
+				}
+			}
+			if !spillMode {
+				// A batch may become retained only after its future spill scratch
+				// is admitted. If that proof does not fit, do not copy it: switch
+				// to the already-proven direct-spill path.
+				if err := ctr.ensureRetainedSpillScratchReservation(result.Batch, analyzer); err != nil {
+					if !errors.Is(err, process.ErrHashBuildBudgetAdmission) {
+						return err
+					}
+					if err := startSpill(); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/merge"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
@@ -665,6 +666,68 @@ func TestHashBuildIsShuffle(t *testing.T) {
 	tc.proc.Free()
 }
 
+func TestShuffleHashBuildFallsBackToDirectSpillWhenRetainedProofRejects(t *testing.T) {
+	tc := newTestCase(t, []bool{false}, []types.Type{types.T_varchar.ToType()}, []*plan.Expr{newExpr(0, types.T_varchar.ToType())})
+	tc.arg.IsShuffle = true
+	tc.arg.ShuffleIdx = 0
+	tc.arg.SpillThreshold = 1 << 30
+	tc.arg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 3500}
+	tc.arg.SetChildren([]vm.Operator{tc.marg})
+	require.NoError(t, tc.marg.Prepare(tc.proc))
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	const capBytes = uint64(8 << 20)
+	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	tc.arg.ctr.hashmapBuilder.setBudget(generation)
+
+	payload := make([]byte, 1<<20)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	build := batch.NewWithSize(1)
+	build.Vecs[0], err = vector.NewConstBytes(types.T_varchar.ToType(), payload, 1, tc.proc.Mp())
+	require.NoError(t, err)
+	build.SetRowCount(1)
+
+	directNeed, err := spillBudgetBytes(build)
+	require.NoError(t, err)
+	require.Less(t, directNeed, capBytes)
+	retainedNeed, err := spillRetainedBudgetBytes(build)
+	require.NoError(t, err)
+	require.Greater(t, retainedNeed, capBytes)
+
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(build, nil, tc.proc.Mp())
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, tc.proc.Mp())
+	_, err = vm.Exec(tc.arg, tc.proc)
+	require.NoError(t, err)
+
+	result, err := message.ReceiveJoinMapResult(tc.arg.JoinMapTag, true, tc.arg.ShuffleIdx, tc.proc.GetMessageBoard(), tc.proc.Ctx)
+	require.NoError(t, err)
+	require.True(t, result.IsSuccess())
+	jm := result.JoinMap()
+	require.NotNil(t, jm)
+	require.True(t, jm.IsSpilled(), "failed future-retained proof must choose direct spill")
+	require.Equal(t, int64(1), jm.GetRowCount())
+	for _, file := range jm.TakeSpillBuildFiles() {
+		if file != nil {
+			require.NoError(t, file.Close())
+		}
+	}
+	require.Empty(t, tc.arg.ctr.hashmapBuilder.Batches.Buf)
+	require.Zero(t, generation.Used())
+	require.Zero(t, generation.SpillDiskUsed())
+	require.Zero(t, generation.SpillFDUsed())
+
+	tc.arg.Reset(tc.proc, false, nil)
+	tc.arg.Free(tc.proc, false, nil)
+	tc.marg.Reset(tc.proc, false, nil)
+	generation.Close()
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
+}
+
 func TestShuffleHashBuildSpillsExpressionKey(t *testing.T) {
 	bindProc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	col := newExpr(0, types.T_int32.ToType())
@@ -857,7 +920,10 @@ func TestShuffleHashBuildDrainsRetainedBatchBeforeGrowingScratch(t *testing.T) {
 	forcedGrowReject := false
 	aggregate.SetAggregateCapProvider(func() (uint64, error) {
 		providerCalls++
-		if providerCalls == 3 {
+		// First ingress reserves direct scratch, grows it for future retained
+		// drain, then reserves its copy. Reject the fourth admission: growing
+		// direct scratch for the larger second ingress while that copy is live.
+		if providerCalls == 4 {
 			forcedGrowReject = true
 			return generation.Used(), nil
 		}
@@ -865,7 +931,7 @@ func TestShuffleHashBuildDrainsRetainedBatchBeforeGrowingScratch(t *testing.T) {
 	})
 
 	first := newBatch(tc.types, tc.proc, 8192)
-	second := newBatch(tc.types, tc.proc, 16384)
+	second := newBatch(tc.types, tc.proc, 65536)
 	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(first, nil, tc.proc.Mp())
 	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(second, nil, tc.proc.Mp())
 	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, tc.proc.Mp())
@@ -879,7 +945,7 @@ func TestShuffleHashBuildDrainsRetainedBatchBeforeGrowingScratch(t *testing.T) {
 	require.True(t, result.IsSuccess())
 	jm := result.JoinMap()
 	require.True(t, jm.IsSpilled())
-	require.Equal(t, int64(24576), jm.GetRowCount())
+	require.Equal(t, int64(73728), jm.GetRowCount())
 	for _, file := range jm.TakeSpillBuildFiles() {
 		if file != nil {
 			require.NoError(t, file.Close())

--- a/pkg/sql/colexec/hashbuild/hashmap_test.go
+++ b/pkg/sql/colexec/hashbuild/hashmap_test.go
@@ -204,7 +204,7 @@ func TestCleanCopiedBatchReleasesCoalescedIngressReservations(t *testing.T) {
 	for range 2 {
 		input := testutil.NewBatch([]types.Type{types.T_int32.ToType()}, true, colexec.DefaultBatchSize/2, proc.Mp())
 		if emergencyNeed == 0 {
-			emergencyNeed, err = spillEmergencyBudgetBytes(input)
+			emergencyNeed, err = spillRetainedBudgetBytes(input)
 			require.NoError(t, err)
 		}
 		require.NoError(t, hb.copyBuildBatch(input, proc))
@@ -213,7 +213,7 @@ func TestCleanCopiedBatchReleasesCoalescedIngressReservations(t *testing.T) {
 	require.Len(t, hb.Batches.Buf, 1, "small ingress batches should coalesce")
 	require.Len(t, hb.batchReservations, 2, "reservations follow ingress, not physical batches")
 	require.Greater(t, generation.Used(), uint64(0))
-	physicalNeed, err := spillBudgetBytes(hb.Batches.Buf[0])
+	physicalNeed, err := spillScratchBudgetBytes(hb.Batches.Buf[0], true)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, emergencyNeed, physicalNeed)
 

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -63,8 +63,8 @@ func spillBudgetBytes(bat *batch.Batch) (uint64, error) {
 // its original Length when Batch.Shuffle reduces the batch RowCount. Using
 // Size and then scaling by RowCount therefore counts the original cardinality
 // twice. Allocated covers the physical vector/area capacity; const vectors add
-// one non-const descriptor per output row because UnionInt32 materializes those
-// descriptors in the selected spill batch.
+// one non-const descriptor and any out-of-line payload per output row because
+// UnionInt32 materializes both in the selected spill batch.
 func spillSourceBytes(bat *batch.Batch) (uint64, error) {
 	if bat == nil || bat.RowCount() <= 0 {
 		return 0, nil
@@ -91,6 +91,20 @@ func spillSourceBytes(bat *batch.Batch) (uint64, error) {
 			return 0, process.ErrHashBuildBudgetInvalid
 		}
 		source += materialized
+		if vec.GetType().IsVarlen() && !vec.IsConstNull() {
+			value := vec.GetBytesAt(0)
+			if len(value) > types.VarlenaInlineSize {
+				payloadWidth := uint64(len(value))
+				if rows > math.MaxUint64/payloadWidth {
+					return 0, process.ErrHashBuildBudgetInvalid
+				}
+				materializedPayload := rows * payloadWidth
+				if source > math.MaxUint64-materializedPayload {
+					return 0, process.ErrHashBuildBudgetInvalid
+				}
+				source += materializedPayload
+			}
+		}
 	}
 	return source, nil
 }
@@ -142,6 +156,80 @@ func spillBudgetFor(rows, source uint64) (uint64, error) {
 	return total, nil
 }
 
+// spillProjectedSourceBytes estimates a compact targetRows-row materialization
+// from the live values in bat. It deliberately does not use vector capacity:
+// producers commonly reuse a full-size allocation for a tiny tail batch, and
+// treating that retained capacity as a per-row cost amplifies it by
+// DefaultBatchSize / RowCount.
+func spillProjectedSourceBytes(bat *batch.Batch, targetRows uint64) (uint64, error) {
+	if bat == nil || bat.RowCount() <= 0 || targetRows == 0 {
+		return 0, nil
+	}
+	rows := uint64(bat.RowCount())
+	var source uint64
+	for _, vec := range bat.Vecs {
+		if vec == nil {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		typeSize := vec.GetType().TypeSize()
+		if typeSize < 0 {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		width := uint64(typeSize)
+		if width > 0 && targetRows > math.MaxUint64/width {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		materialized := targetRows * width
+		if source > math.MaxUint64-materialized {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		source += materialized
+
+		if !vec.GetType().IsVarlen() {
+			continue
+		}
+		if vec.IsConstNull() {
+			continue
+		}
+		values, _ := vector.MustVarlenaRawData(vec)
+		valueRows := rows
+		if vec.IsConst() {
+			valueRows = 1
+		}
+		if valueRows == 0 || valueRows > uint64(len(values)) {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		var externalPayload uint64
+		for i := uint64(0); i < valueRows; i++ {
+			if values[i].IsSmall() {
+				continue
+			}
+			_, length := values[i].OffsetLen()
+			if externalPayload > math.MaxUint64-uint64(length) {
+				return 0, process.ErrHashBuildBudgetInvalid
+			}
+			externalPayload += uint64(length)
+		}
+		if externalPayload > math.MaxUint64/targetRows {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		projectedPayload := externalPayload * targetRows
+		if projectedPayload > math.MaxUint64-(valueRows-1) {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		projectedPayload = (projectedPayload + valueRows - 1) / valueRows
+		if source > math.MaxUint64-projectedPayload {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		source += projectedPayload
+	}
+	// spillBudgetFor separately covers the selected materialization and marshal
+	// growth. Return only the compact source here; multiplying it again would
+	// reserve those copies twice and starve expression scratch under small
+	// query budgets.
+	return source, nil
+}
+
 // spillEmergencyBudgetBytes covers both the upstream ingress batch and the
 // largest physical batch CopyIntoBatches can form by coalescing small inputs.
 func spillEmergencyBudgetBytes(bat *batch.Batch) (uint64, error) {
@@ -150,24 +238,20 @@ func spillEmergencyBudgetBytes(bat *batch.Batch) (uint64, error) {
 		return need, err
 	}
 	rows := uint64(bat.RowCount())
-	source, err := spillSourceBytes(bat)
+	source, err := spillProjectedSourceBytes(bat, uint64(colexec.DefaultBatchSize))
 	if err != nil {
 		return 0, err
 	}
-	if source > math.MaxUint64/uint64(colexec.DefaultBatchSize) {
-		return 0, process.ErrHashBuildBudgetInvalid
-	}
-	scaled := (source*uint64(colexec.DefaultBatchSize) + rows - 1) / rows
 	metadata, ok := retainedMetadataAllowance(bat)
 	if !ok || metadata > math.MaxUint64/uint64(colexec.DefaultBatchSize) {
 		return 0, process.ErrHashBuildBudgetInvalid
 	}
 	scaledMetadata := (metadata*uint64(colexec.DefaultBatchSize) + rows - 1) / rows
-	if scaled > math.MaxUint64-scaledMetadata {
+	if source > math.MaxUint64-scaledMetadata {
 		return 0, process.ErrHashBuildBudgetInvalid
 	}
-	scaled += scaledMetadata
-	physicalNeed, err := spillBudgetFor(uint64(colexec.DefaultBatchSize), scaled)
+	source += scaledMetadata
+	physicalNeed, err := spillBudgetFor(uint64(colexec.DefaultBatchSize), source)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -42,71 +42,156 @@ const (
 	spillWriteCoalesceSize = 64 << 10
 )
 
-// spillBudgetBytes is intentionally conservative.  The input batch remains
-// owned by the upstream operator while HashBuild evaluates and partitions it,
-// so its footprint is included in the temporary peak alongside hash values,
-// row selections, the selected bucket, and marshal scratch.
-func spillBudgetBytes(bat *batch.Batch) (uint64, error) {
-	if bat == nil || bat.RowCount() <= 0 {
-		return 0, nil
+type spillMaterializationMode uint8
+
+const (
+	// spillDirectMaterialization models UnionInt32 on the current upstream
+	// batch. A const varlen source copies its out-of-line payload once and
+	// broadcasts the resulting descriptor.
+	spillDirectMaterialization spillMaterializationMode = iota
+	// spillRetainedMaterialization models the compact non-const batch produced
+	// by CopyIntoBatches. A later UnionInt32 treats every retained row as an
+	// independent value, even when the ingress vector was const.
+	spillRetainedMaterialization
+)
+
+func spillCheckedAdd(total, value uint64) (uint64, error) {
+	if total > math.MaxUint64-value {
+		return 0, process.ErrHashBuildBudgetInvalid
 	}
-	rows := uint64(bat.RowCount())
-	source, err := spillSourceBytes(bat)
-	if err != nil {
-		return 0, err
-	}
-	return spillBudgetFor(rows, source)
+	return total + value, nil
 }
 
-// spillSourceBytes returns a physical upper bound for materializing bat during
-// spill. Batch.Size is a logical estimate: in particular, a const vector keeps
-// its original Length when Batch.Shuffle reduces the batch RowCount. Using
-// Size and then scaling by RowCount therefore counts the original cardinality
-// twice. Allocated covers the physical vector/area capacity; const vectors add
-// one non-const descriptor and any out-of-line payload per output row because
-// UnionInt32 materializes both in the selected spill batch.
-func spillSourceBytes(bat *batch.Batch) (uint64, error) {
-	if bat == nil || bat.RowCount() <= 0 {
+func spillCheckedMul(left, right uint64) (uint64, error) {
+	if left != 0 && right > math.MaxUint64/left {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	return left * right, nil
+}
+
+// spillMaterializedBytes models the batch that spillBatchBounded creates with
+// UnionInt32. It follows vector materialization semantics instead of retained
+// capacity or stale logical length: fixed-width descriptors are per output
+// row, null payload is skipped, and direct const varlen payload is copied once.
+func spillMaterializedBytes(
+	bat *batch.Batch,
+	targetRows uint64,
+	mode spillMaterializationMode,
+) (uint64, error) {
+	if bat == nil || bat.RowCount() <= 0 || targetRows == 0 {
 		return 0, nil
 	}
-	source := uint64(bat.Allocated())
-	rows := uint64(bat.RowCount())
+	liveRows := uint64(bat.RowCount())
+	var materialized uint64
 	for _, vec := range bat.Vecs {
 		if vec == nil {
 			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		if !vec.IsConst() {
-			continue
 		}
 		typeSize := vec.GetType().TypeSize()
 		if typeSize < 0 {
 			return 0, process.ErrHashBuildBudgetInvalid
 		}
-		width := uint64(typeSize)
-		if width > 0 && rows > math.MaxUint64/width {
+		descriptors, err := spillCheckedMul(targetRows, uint64(typeSize))
+		if err != nil {
+			return 0, err
+		}
+		if materialized, err = spillCheckedAdd(materialized, descriptors); err != nil {
+			return 0, err
+		}
+		if !vec.GetType().IsVarlen() || vec.IsConstNull() {
+			continue
+		}
+
+		values, _ := vector.MustVarlenaRawData(vec)
+		valueRows := liveRows
+		if vec.IsConst() {
+			valueRows = 1
+		}
+		if valueRows == 0 || valueRows > uint64(len(values)) {
 			return 0, process.ErrHashBuildBudgetInvalid
 		}
-		materialized := rows * width
-		if source > math.MaxUint64-materialized {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		source += materialized
-		if vec.GetType().IsVarlen() && !vec.IsConstNull() {
-			value := vec.GetBytesAt(0)
-			if len(value) > types.VarlenaInlineSize {
-				payloadWidth := uint64(len(value))
-				if rows > math.MaxUint64/payloadWidth {
-					return 0, process.ErrHashBuildBudgetInvalid
-				}
-				materializedPayload := rows * payloadWidth
-				if source > math.MaxUint64-materializedPayload {
-					return 0, process.ErrHashBuildBudgetInvalid
-				}
-				source += materializedPayload
+		var livePayload uint64
+		hasNull := !vec.GetNulls().EmptyByFlag()
+		for row := uint64(0); row < valueRows; row++ {
+			if hasNull && vec.GetNulls().Contains(row) {
+				continue
+			}
+			if values[row].IsSmall() {
+				continue
+			}
+			_, length := values[row].OffsetLen()
+			if livePayload, err = spillCheckedAdd(livePayload, uint64(length)); err != nil {
+				return 0, err
 			}
 		}
+
+		projectedPayload := livePayload
+		if !(mode == spillDirectMaterialization && vec.IsConst()) {
+			// A retained CopyIntoBatches destination is non-const. Repeating
+			// the complete live sample is a conservative bound for any compact
+			// target batch assembled from ingress batches whose individual
+			// high-water estimates were admitted before copying.
+			roundedRows, err := spillCheckedAdd(targetRows, valueRows-1)
+			if err != nil {
+				return 0, err
+			}
+			repeats := roundedRows / valueRows
+			if projectedPayload, err = spillCheckedMul(livePayload, repeats); err != nil {
+				return 0, err
+			}
+		}
+		if materialized, err = spillCheckedAdd(materialized, projectedPayload); err != nil {
+			return 0, err
+		}
 	}
-	return source, nil
+	return materialized, nil
+}
+
+// spillPeakBudgetFor accounts each simultaneously live component explicitly.
+// inputBytes is zero for a retained batch whose source reservation is already
+// owned by HashBuild.
+func spillPeakBudgetFor(rows, inputBytes, selectedBytes uint64) (uint64, error) {
+	rowScratch, err := spillCheckedMul(rows, 12) // hashes + one row-id array
+	if err != nil {
+		return 0, err
+	}
+	total, err := spillCheckedAdd(rowScratch, inputBytes)
+	if err != nil {
+		return 0, err
+	}
+	if total, err = spillCheckedAdd(total, selectedBytes); err != nil {
+		return 0, err
+	}
+	// MarshalBinary writes selected data and varlen area into a bytes.Buffer.
+	// Twice the selected footprint plus fixed headers covers buffer growth.
+	marshalBytes, err := spillCheckedMul(selectedBytes, 2)
+	if err != nil {
+		return 0, err
+	}
+	if marshalBytes, err = spillCheckedAdd(marshalBytes, 64*1024); err != nil {
+		return 0, err
+	}
+	if total, err = spillCheckedAdd(total, marshalBytes); err != nil {
+		return 0, err
+	}
+	if total > uint64(^uint(0)>>1) {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	return total, nil
+}
+
+// spillBudgetBytes admits only the actual direct-spill path for the current
+// input. It never projects a hypothetical retained batch.
+func spillBudgetBytes(bat *batch.Batch) (uint64, error) {
+	if bat == nil || bat.RowCount() <= 0 {
+		return 0, nil
+	}
+	rows := uint64(bat.RowCount())
+	selected, err := spillMaterializedBytes(bat, rows, spillDirectMaterialization)
+	if err != nil {
+		return 0, err
+	}
+	return spillPeakBudgetFor(rows, uint64(bat.Allocated()), selected)
 }
 
 // spillScratchBudgetBytes returns the incremental spill charge. A copied
@@ -127,156 +212,53 @@ func spillScratchBudgetBytes(bat *batch.Batch, sourceAlreadyCharged bool) (uint6
 	return need - source, nil
 }
 
-func spillBudgetFor(rows, source uint64) (uint64, error) {
-	if rows > math.MaxUint64/12 {
-		return 0, process.ErrHashBuildBudgetInvalid
-	}
-	// hash values + one reusable selection array.  The selected batch and its
-	// varlen area may overlap the source capacity, hence a full additional
-	// source allocation is charged rather than just logical Size().
-	total := rows * 12
-	if source > math.MaxUint64-total {
-		return 0, process.ErrHashBuildBudgetInvalid
-	}
-	total += source
-	// A selected bucket can contain every input row.  MarshalBinary emits
-	// vector metadata and varlen area; 2x payload plus fixed headers is a safe
-	// upper bound before bytes.Buffer grows.
-	if source > (math.MaxUint64-64*1024)/2 {
-		return 0, process.ErrHashBuildBudgetInvalid
-	}
-	marshal := source*2 + 64*1024
-	if total > math.MaxUint64-marshal {
-		return 0, process.ErrHashBuildBudgetInvalid
-	}
-	total += marshal
-	if total > uint64(^uint(0)>>1) {
-		return 0, process.ErrHashBuildBudgetInvalid
-	}
-	return total, nil
-}
-
-// spillProjectedSourceBytes estimates a compact targetRows-row materialization
-// from the live values in bat. It deliberately does not use vector capacity:
-// producers commonly reuse a full-size allocation for a tiny tail batch, and
-// treating that retained capacity as a per-row cost amplifies it by
-// DefaultBatchSize / RowCount.
-func spillProjectedSourceBytes(bat *batch.Batch, targetRows uint64) (uint64, error) {
-	if bat == nil || bat.RowCount() <= 0 || targetRows == 0 {
+// spillRetainedBudgetBytes is the future-drain proof required before
+// CopyIntoBatches may retain a small input. The destination loses constness,
+// so its selected payload follows retained rather than direct semantics.
+func spillRetainedBudgetBytes(bat *batch.Batch) (uint64, error) {
+	if bat == nil || bat.RowCount() <= 0 {
 		return 0, nil
 	}
 	rows := uint64(bat.RowCount())
-	var source uint64
-	for _, vec := range bat.Vecs {
-		if vec == nil {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		typeSize := vec.GetType().TypeSize()
-		if typeSize < 0 {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		width := uint64(typeSize)
-		if width > 0 && targetRows > math.MaxUint64/width {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		materialized := targetRows * width
-		if source > math.MaxUint64-materialized {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		source += materialized
-
-		if !vec.GetType().IsVarlen() {
-			continue
-		}
-		if vec.IsConstNull() {
-			continue
-		}
-		values, _ := vector.MustVarlenaRawData(vec)
-		valueRows := rows
-		if vec.IsConst() {
-			valueRows = 1
-		}
-		if valueRows == 0 || valueRows > uint64(len(values)) {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		var externalPayload uint64
-		hasNull := !vec.GetNulls().EmptyByFlag()
-		for i := uint64(0); i < valueRows; i++ {
-			// UnionInt32 does not copy null values. Reused varlen vectors can
-			// retain a stale non-inline header in a null slot, so charging that
-			// dead payload would recreate the same false extrapolation this
-			// compact estimate is intended to avoid.
-			if hasNull && vec.GetNulls().Contains(i) {
-				continue
-			}
-			if values[i].IsSmall() {
-				continue
-			}
-			_, length := values[i].OffsetLen()
-			if externalPayload > math.MaxUint64-uint64(length) {
-				return 0, process.ErrHashBuildBudgetInvalid
-			}
-			externalPayload += uint64(length)
-		}
-		if externalPayload > math.MaxUint64/targetRows {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		projectedPayload := externalPayload * targetRows
-		if projectedPayload > math.MaxUint64-(valueRows-1) {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		projectedPayload = (projectedPayload + valueRows - 1) / valueRows
-		if source > math.MaxUint64-projectedPayload {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		source += projectedPayload
+	targetRows := rows
+	if rows < uint64(colexec.DefaultBatchSize) {
+		targetRows = uint64(colexec.DefaultBatchSize)
 	}
-	// spillBudgetFor separately covers the selected materialization and marshal
-	// growth. Return only the compact source here; multiplying it again would
-	// reserve those copies twice and starve expression scratch under small
-	// query budgets.
-	return source, nil
-}
-
-// spillEmergencyBudgetBytes covers both the upstream ingress batch and the
-// largest physical batch CopyIntoBatches can form by coalescing small inputs.
-func spillEmergencyBudgetBytes(bat *batch.Batch) (uint64, error) {
-	need, err := spillBudgetBytes(bat)
-	if err != nil || bat == nil || bat.RowCount() <= 0 || bat.RowCount() >= colexec.DefaultBatchSize {
-		return need, err
-	}
-	rows := uint64(bat.RowCount())
-	source, err := spillProjectedSourceBytes(bat, uint64(colexec.DefaultBatchSize))
+	selected, err := spillMaterializedBytes(bat, targetRows, spillRetainedMaterialization)
 	if err != nil {
 		return 0, err
 	}
 	metadata, ok := retainedMetadataAllowance(bat)
-	if !ok || metadata > math.MaxUint64/uint64(colexec.DefaultBatchSize) {
+	if !ok || metadata > math.MaxUint64/targetRows {
 		return 0, process.ErrHashBuildBudgetInvalid
 	}
-	scaledMetadata := (metadata*uint64(colexec.DefaultBatchSize) + rows - 1) / rows
-	if source > math.MaxUint64-scaledMetadata {
-		return 0, process.ErrHashBuildBudgetInvalid
+	projectedMetadata := metadata
+	if targetRows > rows {
+		projectedMetadata, err = spillCheckedMul(metadata, targetRows)
+		if err != nil {
+			return 0, err
+		}
+		projectedMetadata, err = spillCheckedAdd(projectedMetadata, rows-1)
+		if err != nil {
+			return 0, err
+		}
+		projectedMetadata /= rows
 	}
-	source += scaledMetadata
-	physicalNeed, err := spillBudgetFor(uint64(colexec.DefaultBatchSize), source)
-	if err != nil {
+	if selected, err = spillCheckedAdd(selected, projectedMetadata); err != nil {
 		return 0, err
 	}
-	if physicalNeed > need {
-		need = physicalNeed
-	}
-	return need, nil
+	// The retained source itself is covered by batchReservations.
+	return spillPeakBudgetFor(targetRows, 0, selected)
 }
 
-func (ctr *container) ensureSpillScratchReservation(bat *batch.Batch, analyzer process.Analyzer) error {
+func (ctr *container) ensureSpillScratchReservationBytes(need uint64, analyzer process.Analyzer) error {
 	if ctr.hashmapBuilder.budget == nil {
 		return nil
 	}
-	need, err := spillEmergencyBudgetBytes(bat)
-	if err != nil || need == 0 {
-		return err
+	if need == 0 {
+		return nil
 	}
+	var err error
 	if ctr.spillScratchReservation == nil {
 		ctr.spillScratchReservation, err = ctr.hashmapBuilder.budget.Reserve(need)
 		if err == nil {
@@ -300,6 +282,22 @@ func (ctr *container) ensureSpillScratchReservation(bat *batch.Batch, analyzer p
 	ctr.spillScratchBase = need
 	ctr.spillScratchEmergency = true
 	return nil
+}
+
+func (ctr *container) ensureDirectSpillScratchReservation(bat *batch.Batch, analyzer process.Analyzer) error {
+	need, err := spillBudgetBytes(bat)
+	if err != nil {
+		return err
+	}
+	return ctr.ensureSpillScratchReservationBytes(need, analyzer)
+}
+
+func (ctr *container) ensureRetainedSpillScratchReservation(bat *batch.Batch, analyzer process.Analyzer) error {
+	need, err := spillRetainedBudgetBytes(bat)
+	if err != nil {
+		return err
+	}
+	return ctr.ensureSpillScratchReservationBytes(need, analyzer)
 }
 
 func (ctr *container) releaseSpillScratchReservation() {

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -51,11 +51,48 @@ func spillBudgetBytes(bat *batch.Batch) (uint64, error) {
 		return 0, nil
 	}
 	rows := uint64(bat.RowCount())
-	source := uint64(bat.Allocated())
-	if size := uint64(bat.Size()); size > source {
-		source = size
+	source, err := spillSourceBytes(bat)
+	if err != nil {
+		return 0, err
 	}
 	return spillBudgetFor(rows, source)
+}
+
+// spillSourceBytes returns a physical upper bound for materializing bat during
+// spill. Batch.Size is a logical estimate: in particular, a const vector keeps
+// its original Length when Batch.Shuffle reduces the batch RowCount. Using
+// Size and then scaling by RowCount therefore counts the original cardinality
+// twice. Allocated covers the physical vector/area capacity; const vectors add
+// one non-const descriptor per output row because UnionInt32 materializes those
+// descriptors in the selected spill batch.
+func spillSourceBytes(bat *batch.Batch) (uint64, error) {
+	if bat == nil || bat.RowCount() <= 0 {
+		return 0, nil
+	}
+	source := uint64(bat.Allocated())
+	rows := uint64(bat.RowCount())
+	for _, vec := range bat.Vecs {
+		if vec == nil {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		if !vec.IsConst() {
+			continue
+		}
+		typeSize := vec.GetType().TypeSize()
+		if typeSize < 0 {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		width := uint64(typeSize)
+		if width > 0 && rows > math.MaxUint64/width {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		materialized := rows * width
+		if source > math.MaxUint64-materialized {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		source += materialized
+	}
+	return source, nil
 }
 
 // spillScratchBudgetBytes returns the incremental spill charge. A copied
@@ -113,9 +150,9 @@ func spillEmergencyBudgetBytes(bat *batch.Batch) (uint64, error) {
 		return need, err
 	}
 	rows := uint64(bat.RowCount())
-	source := uint64(bat.Allocated())
-	if size := uint64(bat.Size()); size > source {
-		source = size
+	source, err := spillSourceBytes(bat)
+	if err != nil {
+		return 0, err
 	}
 	if source > math.MaxUint64/uint64(colexec.DefaultBatchSize) {
 		return 0, process.ErrHashBuildBudgetInvalid

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -200,7 +200,15 @@ func spillProjectedSourceBytes(bat *batch.Batch, targetRows uint64) (uint64, err
 			return 0, process.ErrHashBuildBudgetInvalid
 		}
 		var externalPayload uint64
+		hasNull := !vec.GetNulls().EmptyByFlag()
 		for i := uint64(0); i < valueRows; i++ {
+			// UnionInt32 does not copy null values. Reused varlen vectors can
+			// retain a stale non-inline header in a null slot, so charging that
+			// dead payload would recreate the same false extrapolation this
+			// compact estimate is intended to avoid.
+			if hasNull && vec.GetNulls().Contains(i) {
+				continue
+			}
 			if values[i].IsSmall() {
 				continue
 			}

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -873,6 +873,72 @@ func TestRetainedSpillGrowsEmergencyLeaseWithoutDoubleChargingSource(t *testing.
 	require.NoError(t, ctr.flushSpillBuffers(files, analyzer))
 }
 
+func TestSpillEmergencyBudgetDoesNotDoubleScaleShuffledConstVector(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	const sourceRows = 32 * 1024
+	bat := batch.NewWithSize(2)
+	values := make([]int32, sourceRows)
+	for i := range values {
+		values[i] = int32(i)
+	}
+	bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	var err error
+	bat.Vecs[1], err = vector.NewConstBytes(
+		types.T_varchar.ToType(),
+		[]byte("test create big fulltext index"),
+		sourceRows,
+		proc.Mp(),
+	)
+	require.NoError(t, err)
+	bat.SetRowCount(sourceRows)
+	defer bat.Clean(proc.Mp())
+
+	// Batch.Shuffle intentionally leaves a const vector untouched while it
+	// changes the batch cardinality. This is the shape produced by the failed
+	// generate_series + const-varchar BVT query.
+	require.NoError(t, bat.Shuffle([]int64{0}, proc.Mp()))
+	require.Equal(t, 1, bat.RowCount())
+	require.Equal(t, sourceRows, bat.Vecs[1].Length())
+
+	legacySource := uint64(bat.Allocated())
+	if size := uint64(bat.Size()); size > legacySource {
+		legacySource = size
+	}
+	legacyScaled := legacySource * uint64(colexec.DefaultBatchSize)
+	legacyMetadata, ok := retainedMetadataAllowance(bat)
+	require.True(t, ok)
+	legacyScaled += legacyMetadata * uint64(colexec.DefaultBatchSize)
+	legacyNeed, err := spillBudgetFor(uint64(colexec.DefaultBatchSize), legacyScaled)
+	require.NoError(t, err)
+	require.Greater(t, legacyNeed, uint64(10<<30),
+		"the old logical-size extrapolation must reproduce the false 10 GiB rejection")
+
+	need, err := spillEmergencyBudgetBytes(bat)
+	require.NoError(t, err)
+	require.Less(t, need, uint64(16<<20),
+		"physical admission must not scale a const vector's stale logical length")
+
+	// The corrected estimate must still cover the physical 8192-row batch that
+	// CopyIntoBatches can form from repeated one-row ingress batches.
+	full := batch.NewWithSize(2)
+	fullValues := make([]int32, colexec.DefaultBatchSize)
+	fullStrings := make([]string, colexec.DefaultBatchSize)
+	for i := range fullValues {
+		fullValues[i] = int32(i)
+		fullStrings[i] = "test create big fulltext index"
+	}
+	full.Vecs[0] = testutil.MakeInt32Vector(fullValues, nil, proc.Mp())
+	full.Vecs[1] = testutil.MakeVarcharVector(fullStrings, nil, proc.Mp())
+	full.SetRowCount(colexec.DefaultBatchSize)
+	defer full.Clean(proc.Mp())
+
+	fullNeed, err := spillBudgetBytes(full)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, need, fullNeed)
+}
+
 func TestEnsureSpillFile(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -1204,6 +1204,75 @@ func TestSpillRetainedEstimateCoversCopyIntoBatchesConstMaterialization(t *testi
 	require.GreaterOrEqual(t, estimated, uint64(selected.Allocated()))
 }
 
+func TestSpillRetainedEstimateFollowsFullBatchCloneToSemantics(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	makeConstBatch := func(payloadBytes int) *batch.Batch {
+		payload := make([]byte, payloadBytes)
+		for i := range payload {
+			payload[i] = 'x'
+		}
+		source := batch.NewWithSize(1)
+		var err error
+		source.Vecs[0], err = vector.NewConstBytes(
+			types.T_varchar.ToType(),
+			payload,
+			colexec.DefaultBatchSize,
+			proc.Mp(),
+		)
+		require.NoError(t, err)
+		source.SetRowCount(colexec.DefaultBatchSize)
+		return source
+	}
+
+	large := makeConstBatch(1 << 20)
+	defer large.Clean(proc.Mp())
+	directNeed, err := spillBudgetBytes(large)
+	require.NoError(t, err)
+	require.Less(t, directNeed, uint64(16<<20))
+	retainedNeed, err := spillRetainedBudgetBytes(large)
+	require.NoError(t, err)
+	require.Greater(t, retainedNeed, uint64(10<<30),
+		"a future non-const selection can materialize the MiB value once per row")
+
+	var retainedLarge colexec.Batches
+	defer retainedLarge.Clean(proc.Mp())
+	require.NoError(t, retainedLarge.CopyIntoBatches(large, proc))
+	require.Len(t, retainedLarge.Buf, 1)
+	require.False(t, retainedLarge.Buf[0].Vecs[0].IsConst(),
+		"Batch.Dup delegates to Batch.CloneTo/UnionBatch and does not call Vector.Dup")
+	require.Equal(t, 1<<20, len(retainedLarge.Buf[0].Vecs[0].GetArea()))
+
+	// Materialize a smaller exact-full-batch payload end-to-end to prove the
+	// future spill closure without allocating the MiB case's 8 GiB area.
+	small := makeConstBatch(4 << 10)
+	defer small.Clean(proc.Mp())
+	var retainedSmall colexec.Batches
+	defer retainedSmall.Clean(proc.Mp())
+	require.NoError(t, retainedSmall.CopyIntoBatches(small, proc))
+	require.False(t, retainedSmall.Buf[0].Vecs[0].IsConst())
+
+	estimated, err := spillMaterializedBytes(
+		small,
+		colexec.DefaultBatchSize,
+		spillRetainedMaterialization,
+	)
+	require.NoError(t, err)
+	selected := batch.NewWithSize(1)
+	selected.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	defer selected.Clean(proc.Mp())
+	sels := make([]int32, colexec.DefaultBatchSize)
+	for i := range sels {
+		sels[i] = int32(i)
+	}
+	require.NoError(t, selected.Vecs[0].PreExtend(colexec.DefaultBatchSize, proc.Mp()))
+	require.NoError(t, selected.Vecs[0].UnionInt32(retainedSmall.Buf[0].Vecs[0], sels, proc.Mp()))
+	selected.SetRowCount(colexec.DefaultBatchSize)
+	require.Equal(t, colexec.DefaultBatchSize*(4<<10), len(selected.Vecs[0].GetArea()))
+	require.GreaterOrEqual(t, estimated, uint64(selected.Allocated()))
+}
+
 func TestEnsureDirectSpillReservationFailsClosed(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -939,6 +939,65 @@ func TestSpillEmergencyBudgetDoesNotDoubleScaleShuffledConstVector(t *testing.T)
 	require.GreaterOrEqual(t, need, fullNeed)
 }
 
+func TestSpillEmergencyBudgetDoesNotScaleRetainedVectorCapacity(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	const sourceRows = 32 * 1024
+	bat := batch.NewWithSize(2)
+	values := make([]int32, sourceRows)
+	strings := make([]string, sourceRows)
+	for i := range values {
+		values[i] = int32(i)
+		strings[i] = "test create big fulltext index"
+	}
+	bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	bat.Vecs[1] = testutil.MakeVarcharVector(strings, nil, proc.Mp())
+	bat.SetRowCount(sourceRows)
+	defer bat.Clean(proc.Mp())
+
+	// Reused shuffle and table-function batches keep their allocation while
+	// publishing a tiny final batch. Only the first row is live, but Allocated
+	// still describes the original 32K-row capacity.
+	bat.Vecs[0].SetLength(1)
+	bat.Vecs[1].SetLength(1)
+	bat.SetRowCount(1)
+	require.Greater(t, bat.Allocated(), 1<<20)
+
+	need, err := spillEmergencyBudgetBytes(bat)
+	require.NoError(t, err)
+	require.Less(t, need, uint64(16<<20),
+		"retained source capacity must be charged once, not extrapolated per live row")
+
+	budget := process.MustNewHashBuildBudget(10<<30, 10<<30)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	defer generation.Close()
+	ctr := &container{}
+	ctr.hashmapBuilder.setBudget(generation)
+	defer ctr.releaseSpillScratchReservation()
+	analyzer := process.NewAnalyzer(0, false, false, "test")
+	require.NoError(t, ctr.ensureSpillScratchReservation(bat, analyzer))
+	require.Equal(t, need, ctr.spillScratchBase)
+	require.Zero(t, generation.Snapshot().RejectCount)
+
+	full := batch.NewWithSize(2)
+	fullValues := make([]int32, colexec.DefaultBatchSize)
+	fullStrings := make([]string, colexec.DefaultBatchSize)
+	for i := range fullValues {
+		fullValues[i] = int32(i)
+		fullStrings[i] = strings[0]
+	}
+	full.Vecs[0] = testutil.MakeInt32Vector(fullValues, nil, proc.Mp())
+	full.Vecs[1] = testutil.MakeVarcharVector(fullStrings, nil, proc.Mp())
+	full.SetRowCount(colexec.DefaultBatchSize)
+	defer full.Clean(proc.Mp())
+
+	fullNeed, err := spillBudgetBytes(full)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, need, fullNeed)
+}
+
 func TestEnsureSpillFile(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -998,6 +998,61 @@ func TestSpillEmergencyBudgetDoesNotScaleRetainedVectorCapacity(t *testing.T) {
 	require.GreaterOrEqual(t, need, fullNeed)
 }
 
+func TestSpillProjectedSourceSkipsStaleNullVarlenaPayload(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeVarcharVector([]string{"x"}, []uint64{0}, proc.Mp())
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	// A null append does not overwrite a reused varlen slot. Plant the stale
+	// non-inline header that such a slot can retain; UnionInt32 skips the null
+	// value, so this dead payload must not be projected into the spill batch.
+	values, _ := vector.MustVarlenaRawData(bat.Vecs[0])
+	const staleLen = uint32(1 << 20)
+	values[0].SetOffsetLen(0, staleLen)
+
+	targetRows := uint64(colexec.DefaultBatchSize)
+	legacySource := targetRows * (uint64(bat.Vecs[0].GetType().TypeSize()) + uint64(staleLen))
+	legacyNeed, err := spillBudgetFor(targetRows, legacySource)
+	require.NoError(t, err)
+	require.Greater(t, legacyNeed, uint64(10<<30),
+		"stale null payload would falsely exceed the query budget")
+
+	source, err := spillProjectedSourceBytes(bat, targetRows)
+	require.NoError(t, err)
+	require.Equal(t, targetRows*uint64(bat.Vecs[0].GetType().TypeSize()), source)
+
+	need, err := spillEmergencyBudgetBytes(bat)
+	require.NoError(t, err)
+	require.Less(t, need, uint64(16<<20))
+}
+
+func TestSpillProjectedSourceBoundaryInputs(t *testing.T) {
+	source, err := spillProjectedSourceBytes(nil, colexec.DefaultBatchSize)
+	require.NoError(t, err)
+	require.Zero(t, source)
+
+	invalid := batch.NewWithSize(1)
+	invalid.SetRowCount(1)
+	_, err = spillProjectedSourceBytes(invalid, colexec.DefaultBatchSize)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	constNull := batch.NewWithSize(1)
+	constNull.Vecs[0] = vector.NewConstNull(types.T_varchar.ToType(), 1, proc.Mp())
+	constNull.SetRowCount(1)
+	defer constNull.Clean(proc.Mp())
+
+	targetRows := uint64(colexec.DefaultBatchSize)
+	source, err = spillProjectedSourceBytes(constNull, targetRows)
+	require.NoError(t, err)
+	require.Equal(t, targetRows*uint64(types.T_varchar.ToType().TypeSize()), source)
+}
+
 func TestEnsureSpillFile(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"math"
 	"os"
 	"testing"
 
@@ -910,15 +911,19 @@ func TestSpillEmergencyBudgetDoesNotDoubleScaleShuffledConstVector(t *testing.T)
 	legacyMetadata, ok := retainedMetadataAllowance(bat)
 	require.True(t, ok)
 	legacyScaled += legacyMetadata * uint64(colexec.DefaultBatchSize)
-	legacyNeed, err := spillBudgetFor(uint64(colexec.DefaultBatchSize), legacyScaled)
+	legacyNeed, err := spillPeakBudgetFor(uint64(colexec.DefaultBatchSize), 0, legacyScaled)
 	require.NoError(t, err)
 	require.Greater(t, legacyNeed, uint64(10<<30),
 		"the old logical-size extrapolation must reproduce the false 10 GiB rejection")
 
-	need, err := spillEmergencyBudgetBytes(bat)
+	directNeed, err := spillBudgetBytes(bat)
 	require.NoError(t, err)
-	require.Less(t, need, uint64(16<<20),
-		"physical admission must not scale a const vector's stale logical length")
+	require.Less(t, directNeed, uint64(16<<20),
+		"direct admission must use the live const materialization")
+	retainedNeed, err := spillRetainedBudgetBytes(bat)
+	require.NoError(t, err)
+	require.Less(t, retainedNeed, uint64(16<<20),
+		"retained admission must not scale a const vector's stale logical length")
 
 	// The corrected estimate must still cover the physical 8192-row batch that
 	// CopyIntoBatches can form from repeated one-row ingress batches.
@@ -934,9 +939,9 @@ func TestSpillEmergencyBudgetDoesNotDoubleScaleShuffledConstVector(t *testing.T)
 	full.SetRowCount(colexec.DefaultBatchSize)
 	defer full.Clean(proc.Mp())
 
-	fullNeed, err := spillBudgetBytes(full)
+	fullNeed, err := spillScratchBudgetBytes(full, true)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, need, fullNeed)
+	require.GreaterOrEqual(t, retainedNeed, fullNeed)
 }
 
 func TestSpillEmergencyBudgetDoesNotScaleRetainedVectorCapacity(t *testing.T) {
@@ -964,10 +969,13 @@ func TestSpillEmergencyBudgetDoesNotScaleRetainedVectorCapacity(t *testing.T) {
 	bat.SetRowCount(1)
 	require.Greater(t, bat.Allocated(), 1<<20)
 
-	need, err := spillEmergencyBudgetBytes(bat)
+	directNeed, err := spillBudgetBytes(bat)
 	require.NoError(t, err)
-	require.Less(t, need, uint64(16<<20),
+	require.Less(t, directNeed, uint64(16<<20),
 		"retained source capacity must be charged once, not extrapolated per live row")
+	retainedNeed, err := spillRetainedBudgetBytes(bat)
+	require.NoError(t, err)
+	require.Less(t, retainedNeed, uint64(16<<20))
 
 	budget := process.MustNewHashBuildBudget(10<<30, 10<<30)
 	generation, err := budget.OpenGeneration(1)
@@ -977,8 +985,9 @@ func TestSpillEmergencyBudgetDoesNotScaleRetainedVectorCapacity(t *testing.T) {
 	ctr.hashmapBuilder.setBudget(generation)
 	defer ctr.releaseSpillScratchReservation()
 	analyzer := process.NewAnalyzer(0, false, false, "test")
-	require.NoError(t, ctr.ensureSpillScratchReservation(bat, analyzer))
-	require.Equal(t, need, ctr.spillScratchBase)
+	require.NoError(t, ctr.ensureDirectSpillScratchReservation(bat, analyzer))
+	require.NoError(t, ctr.ensureRetainedSpillScratchReservation(bat, analyzer))
+	require.Equal(t, max(directNeed, retainedNeed), ctr.spillScratchBase)
 	require.Zero(t, generation.Snapshot().RejectCount)
 
 	full := batch.NewWithSize(2)
@@ -993,9 +1002,9 @@ func TestSpillEmergencyBudgetDoesNotScaleRetainedVectorCapacity(t *testing.T) {
 	full.SetRowCount(colexec.DefaultBatchSize)
 	defer full.Clean(proc.Mp())
 
-	fullNeed, err := spillBudgetBytes(full)
+	fullNeed, err := spillScratchBudgetBytes(full, true)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, need, fullNeed)
+	require.GreaterOrEqual(t, retainedNeed, fullNeed)
 }
 
 func TestSpillProjectedSourceSkipsStaleNullVarlenaPayload(t *testing.T) {
@@ -1016,41 +1025,211 @@ func TestSpillProjectedSourceSkipsStaleNullVarlenaPayload(t *testing.T) {
 
 	targetRows := uint64(colexec.DefaultBatchSize)
 	legacySource := targetRows * (uint64(bat.Vecs[0].GetType().TypeSize()) + uint64(staleLen))
-	legacyNeed, err := spillBudgetFor(targetRows, legacySource)
+	legacyNeed, err := spillPeakBudgetFor(targetRows, 0, legacySource)
 	require.NoError(t, err)
 	require.Greater(t, legacyNeed, uint64(10<<30),
 		"stale null payload would falsely exceed the query budget")
 
-	source, err := spillProjectedSourceBytes(bat, targetRows)
+	source, err := spillMaterializedBytes(bat, targetRows, spillRetainedMaterialization)
 	require.NoError(t, err)
 	require.Equal(t, targetRows*uint64(bat.Vecs[0].GetType().TypeSize()), source)
 
-	need, err := spillEmergencyBudgetBytes(bat)
+	need, err := spillRetainedBudgetBytes(bat)
 	require.NoError(t, err)
 	require.Less(t, need, uint64(16<<20))
 }
 
-func TestSpillProjectedSourceBoundaryInputs(t *testing.T) {
-	source, err := spillProjectedSourceBytes(nil, colexec.DefaultBatchSize)
+func TestSpillMaterializedBytesBoundaryInputs(t *testing.T) {
+	source, err := spillMaterializedBytes(nil, colexec.DefaultBatchSize, spillRetainedMaterialization)
 	require.NoError(t, err)
 	require.Zero(t, source)
 
 	invalid := batch.NewWithSize(1)
 	invalid.SetRowCount(1)
-	_, err = spillProjectedSourceBytes(invalid, colexec.DefaultBatchSize)
+	_, err = spillMaterializedBytes(invalid, colexec.DefaultBatchSize, spillRetainedMaterialization)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	_, err = spillBudgetBytes(invalid)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	_, err = spillRetainedBudgetBytes(invalid)
 	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
 
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
+	short := batch.NewWithSize(1)
+	short.Vecs[0] = testutil.MakeVarcharVector([]string{"x"}, nil, proc.Mp())
+	short.SetRowCount(2)
+	defer short.Clean(proc.Mp())
+	_, err = spillMaterializedBytes(short, 2, spillDirectMaterialization)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+
 	constNull := batch.NewWithSize(1)
 	constNull.Vecs[0] = vector.NewConstNull(types.T_varchar.ToType(), 1, proc.Mp())
 	constNull.SetRowCount(1)
 	defer constNull.Clean(proc.Mp())
 
 	targetRows := uint64(colexec.DefaultBatchSize)
-	source, err = spillProjectedSourceBytes(constNull, targetRows)
+	source, err = spillMaterializedBytes(constNull, targetRows, spillRetainedMaterialization)
 	require.NoError(t, err)
 	require.Equal(t, targetRows*uint64(types.T_varchar.ToType().TypeSize()), source)
+}
+
+func TestSpillBudgetArithmeticFailsClosed(t *testing.T) {
+	value, err := spillCheckedAdd(math.MaxUint64-1, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(math.MaxUint64), value)
+	_, err = spillCheckedAdd(math.MaxUint64, 1)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+
+	value, err = spillCheckedMul(math.MaxUint64, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(math.MaxUint64), value)
+	_, err = spillCheckedMul(math.MaxUint64, 2)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+
+	_, err = spillPeakBudgetFor(math.MaxUint64, 0, 0)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	_, err = spillPeakBudgetFor(0, math.MaxUint64, 1)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	_, err = spillPeakBudgetFor(0, 0, math.MaxUint64)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+}
+
+func TestSpillReservationBoundaryInputs(t *testing.T) {
+	analyzer := process.NewAnalyzer(0, false, false, "spill reservation boundary")
+	ctr := &container{}
+	require.NoError(t, ctr.ensureSpillScratchReservationBytes(1, analyzer),
+		"an operator without a query budget does not need a token")
+
+	budget := process.MustNewHashBuildBudget(1, 1)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	defer generation.Close()
+	ctr.hashmapBuilder.setBudget(generation)
+	require.NoError(t, ctr.ensureSpillScratchReservationBytes(0, analyzer))
+	require.Nil(t, ctr.spillScratchReservation)
+
+	invalid := batch.NewWithSize(1)
+	invalid.SetRowCount(1)
+	err = ctr.ensureDirectSpillScratchReservation(invalid, analyzer)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	err = ctr.ensureRetainedSpillScratchReservation(invalid, analyzer)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	require.Zero(t, generation.Used())
+}
+
+func TestSpillMaterializedBytesFollowsConstUnionSemantics(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	payload := make([]byte, 1<<20)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	const rows = 64
+	source := batch.NewWithSize(1)
+	var err error
+	source.Vecs[0], err = vector.NewConstBytes(types.T_varchar.ToType(), payload, rows, proc.Mp())
+	require.NoError(t, err)
+	source.SetRowCount(rows)
+	defer source.Clean(proc.Mp())
+
+	directBytes, err := spillMaterializedBytes(source, rows, spillDirectMaterialization)
+	require.NoError(t, err)
+	require.Equal(t,
+		uint64(rows*types.T_varchar.ToType().TypeSize()+len(payload)),
+		directBytes,
+		"direct UnionInt32 copies one payload and broadcasts its descriptor")
+
+	selected := batch.NewWithSize(1)
+	selected.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	defer selected.Clean(proc.Mp())
+	sels := make([]int32, rows)
+	for i := range sels {
+		sels[i] = int32(i)
+	}
+	require.NoError(t, selected.Vecs[0].PreExtend(rows, proc.Mp()))
+	require.NoError(t, selected.Vecs[0].UnionInt32(source.Vecs[0], sels, proc.Mp()))
+	selected.SetRowCount(rows)
+	require.GreaterOrEqual(t, directBytes, uint64(selected.Allocated()))
+
+	retainedBytes, err := spillMaterializedBytes(source, rows, spillRetainedMaterialization)
+	require.NoError(t, err)
+	require.Equal(t,
+		uint64(rows)*(uint64(types.T_varchar.ToType().TypeSize())+uint64(len(payload))),
+		retainedBytes,
+		"CopyIntoBatches removes constness, so future selection copies each retained value")
+	require.Greater(t, retainedBytes, directBytes*32)
+}
+
+func TestSpillRetainedEstimateCoversCopyIntoBatchesConstMaterialization(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	payload := make([]byte, 1<<10)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	const (
+		inputRows = 4
+		totalRows = inputRows * 2
+	)
+	source := batch.NewWithSize(1)
+	var err error
+	source.Vecs[0], err = vector.NewConstBytes(types.T_varchar.ToType(), payload, inputRows, proc.Mp())
+	require.NoError(t, err)
+	source.SetRowCount(inputRows)
+	defer source.Clean(proc.Mp())
+
+	var retained colexec.Batches
+	defer retained.Clean(proc.Mp())
+	require.NoError(t, retained.CopyIntoBatches(source, proc))
+	require.NoError(t, retained.CopyIntoBatches(source, proc))
+	require.Len(t, retained.Buf, 1)
+	require.Equal(t, totalRows, retained.Buf[0].RowCount())
+	require.False(t, retained.Buf[0].Vecs[0].IsConst(),
+		"CopyIntoBatches materializes const ingress as retained row values")
+
+	estimated, err := spillMaterializedBytes(source, totalRows, spillRetainedMaterialization)
+	require.NoError(t, err)
+	selected := batch.NewWithSize(1)
+	selected.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	defer selected.Clean(proc.Mp())
+	sels := make([]int32, totalRows)
+	for i := range sels {
+		sels[i] = int32(i)
+	}
+	require.NoError(t, selected.Vecs[0].PreExtend(totalRows, proc.Mp()))
+	require.NoError(t, selected.Vecs[0].UnionInt32(retained.Buf[0].Vecs[0], sels, proc.Mp()))
+	selected.SetRowCount(totalRows)
+	require.GreaterOrEqual(t, estimated, uint64(selected.Allocated()))
+}
+
+func TestEnsureDirectSpillReservationFailsClosed(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3, 4}, nil, proc.Mp())
+	bat.SetRowCount(4)
+	defer bat.Clean(proc.Mp())
+
+	need, err := spillBudgetBytes(bat)
+	require.NoError(t, err)
+	require.Positive(t, need)
+	budget := process.MustNewHashBuildBudget(need-1, need-1)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	defer generation.Close()
+
+	ctr := &container{}
+	ctr.hashmapBuilder.setBudget(generation)
+	err = ctr.ensureDirectSpillScratchReservation(
+		bat,
+		process.NewAnalyzer(0, false, false, "direct spill reject"),
+	)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+	require.Nil(t, ctr.spillScratchReservation)
+	require.Zero(t, generation.Used())
 }
 
 func TestEnsureSpillFile(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -88,9 +88,10 @@ type container struct {
 	// consuming the scratch required to recover from hard-budget rejection.
 	spillScratchReservation *process.HashBuildReservation
 	// spillScratchEmergency marks a lease pre-admitted by
-	// ensureSpillScratchReservation. An uncharged upstream batch may not grow
-	// beyond this lease. A retained batch may grow it because its source memory
-	// remains charged separately while the batch is drained.
+	// ensureDirectSpillScratchReservation or
+	// ensureRetainedSpillScratchReservation. An uncharged upstream batch may
+	// not grow beyond this lease. A retained batch may grow it because its
+	// source memory remains charged separately while the batch is drained.
 	spillScratchEmergency bool
 	// spillScratchBase is the transient emergency floor. Coalesce-buffer
 	// growth is charged on top and must never be mistaken for this floor.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

fixes #25782

## What this PR does / why we need it:

HashBuild previously used one estimate for two materially different spill sources: the current upstream batch and a future batch retained by `CopyIntoBatches`. That conflated physical input capacity, selected-batch materialization, and marshal peak. Reused tail batches and const vectors could therefore be extrapolated into false multi-gigabyte requests and return `hash build budget admission rejected` before spill made progress.

For the failing `generate_series(3840001)` plus constant-varchar BVT shape, the old path requested 18.72 GB against a 10 GB query cap while only about 1.29 GB was in use.

This change replaces the estimator patch chain with a two-stage admission invariant:

1. Before handling an upstream shuffle batch, prove the actual direct-spill path. Direct const-varlen materialization follows `UnionInt32`: one live out-of-line payload plus per-row descriptors.
2. Before `CopyIntoBatches` may retain that batch, separately prove the largest future retained batch can be drained. The retained destination is non-const, so a later selection can copy payload per retained row and is budgeted accordingly.
3. If the retained proof is rejected, do not copy. Switch to the already-proven direct-spill path.
4. Every retained batch therefore carries a prior future-drain proof; existing retained batches can be drained to release headroom before retrying a larger direct input.

The accounting explicitly separates upstream physical input, selected materialization, row scratch, and marshal growth, uses checked arithmetic, and skips stale varlen headers in NULL rows.

Regression coverage includes:

- reused one-row tails retaining a 32K-row allocation;
- stale const logical length after shuffle;
- stale non-inline headers in NULL rows;
- MiB-scale const varlen direct materialization (one payload copy);
- the real `CopyIntoBatches` const-to-nonconst transition and future selection;
- retained-proof rejection falling back to successful direct spill;
- direct-proof rejection while retained memory is live, followed by drain and retry;
- arithmetic overflow and fail-closed admission boundaries;
- reservation, mpool, spill-disk, and spill-FD cleanup.

Validation on final rebased head:

- `go test -count=1 -timeout=180s ./pkg/sql/colexec/hashbuild`
- `go test -count=1 -timeout=180s ./pkg/sql/colexec/hashjoin`
- focused `go test -race` over the new materialization and state-transition tests
- `go build ./pkg/sql/colexec/hashbuild`
- `go vet ./pkg/sql/colexec/hashbuild`
- local CI-equivalent diff coverage: 82.02% (requested floor: 80%)
- prior TKE BVT run https://github.com/matrixorigin/ci-test/actions/runs/30166184404: the three previously failing inserts succeeded in 1.355s, 1.431s, and 1.425s, with zero hash-build budget admission rejections. A fresh CI/TKE validation is required for this final refactored head.