### PR TITLE
fix(tae): align late aobject visibility with parent txn

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -3816,6 +3816,211 @@ func TestDelete3(t *testing.T) {
 	t.Log(tae.Catalog.SimplePPString(common.PPL1))
 }
 
+type flushPrepareBarrier struct {
+	reached chan struct{}
+	release chan struct{}
+}
+
+func (entry *flushPrepareBarrier) PrepareCommit() error {
+	close(entry.reached)
+	<-entry.release
+	return nil
+}
+
+func (*flushPrepareBarrier) PrepareRollback() error { return nil }
+func (*flushPrepareBarrier) ApplyCommit(string) error {
+	return nil
+}
+func (*flushPrepareBarrier) ApplyRollback() error { return nil }
+func (*flushPrepareBarrier) MakeCommand(uint32) (txnif.TxnCmd, error) {
+	return txnbase.NewTxnStateCmd(
+		"flush-prepare-barrier",
+		txnif.TxnStateCommitted,
+		types.TS{},
+	), nil
+}
+
+type txnEntryLogger interface {
+	LogTxnEntry(txnif.TxnEntry, []*common.ID, []*common.ID) error
+}
+
+func newFlushTransferScenario(
+	t *testing.T, ctx context.Context, beforeFlush txnif.TxnEntry,
+) (*testutil.TestEngine, txnif.AsyncTxn, map[types.Objectid]struct{}) {
+	opts := config.WithLongScanAndCKPOpts(nil)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	t.Cleanup(func() { require.NoError(t, tae.Close()) })
+
+	schema := catalog.MockSchemaAll(3, 2)
+	schema.Extra.BlockMaxRows = 10
+	schema.Extra.ObjectMaxBlocks = 2
+	tae.BindSchema(schema)
+	bat := catalog.MockBatch(schema, 31)
+	tae.CreateRelAndAppend(bat, true)
+	bat.Close()
+
+	flushTxn, flushRel := tae.GetRelation()
+	var metas []*catalog.ObjectEntry
+	it := flushRel.MakeObjectIt(false)
+	for it.Next() {
+		obj := it.GetObject()
+		metas = append(metas, obj.GetMeta().(*catalog.ObjectEntry))
+		require.NoError(t, obj.Close())
+	}
+	require.NoError(t, it.Close())
+	if beforeFlush != nil {
+		logger, ok := flushRel.(txnEntryLogger)
+		require.True(t, ok)
+		require.NoError(t, logger.LogTxnEntry(beforeFlush, nil, nil))
+	}
+	task, err := jobs.NewFlushTableTailTask(nil, flushTxn, metas, nil, tae.Runtime)
+	require.NoError(t, err)
+	require.NoError(t, task.OnExec(ctx))
+
+	require.NoError(t, tae.DeleteAll(true))
+	beforeTxn, relBeforeTransfer := tae.GetRelation()
+	oldTombstoneIDs := make(map[types.Objectid]struct{})
+	tombstoneIt := relBeforeTransfer.MakeObjectIt(true)
+	for tombstoneIt.Next() {
+		obj := tombstoneIt.GetObject()
+		meta := obj.GetMeta().(*catalog.ObjectEntry)
+		oldTombstoneIDs[*meta.ID()] = struct{}{}
+		require.NoError(t, obj.Close())
+	}
+	require.NoError(t, tombstoneIt.Close())
+	require.NoError(t, beforeTxn.Commit(ctx))
+	return tae, flushTxn, oldTombstoneIDs
+}
+
+func collectNewTombstones(
+	t *testing.T,
+	ctx context.Context,
+	tae *testutil.TestEngine,
+	oldTombstoneIDs map[types.Objectid]struct{},
+) []*catalog.ObjectEntry {
+	afterTxn, relAfterTransfer := tae.GetRelation()
+	var newTombstones []*catalog.ObjectEntry
+	tombstoneIt := relAfterTransfer.MakeObjectIt(true)
+	for tombstoneIt.Next() {
+		obj := tombstoneIt.GetObject()
+		meta := obj.GetMeta().(*catalog.ObjectEntry)
+		if _, existed := oldTombstoneIDs[*meta.ID()]; !existed {
+			newTombstones = append(newTombstones, meta)
+		}
+		require.NoError(t, obj.Close())
+	}
+	require.NoError(t, tombstoneIt.Close())
+	require.NoError(t, afterTxn.Commit(ctx))
+	sort.Slice(newTombstones, func(i, j int) bool {
+		left, right := newTombstones[i].GetCreatedAt(), newTombstones[j].GetCreatedAt()
+		return left.LT(&right)
+	})
+	return newTombstones
+}
+
+func checkRowsAtSnapshot(
+	t *testing.T,
+	ctx context.Context,
+	tae *testutil.TestEngine,
+	snapshotTS types.TS,
+	rows int,
+) {
+	snapshotTxn, err := tae.StartTxnWithStartTSAndSnapshotTS(nil, snapshotTS)
+	require.NoError(t, err)
+	snapshotTxn.BindAccessInfo(0, 0, 0)
+	snapshotRel := tae.GetRelationWithTxn(snapshotTxn)
+	testutil.CheckAllColRowsByScan(t, snapshotRel, rows, true)
+	require.NoError(t, snapshotTxn.Commit(ctx))
+}
+
+func TestFlushTransferTombstonesVisibleAtParentCommit(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	ctx := context.Background()
+	tae, flushTxn, oldTombstoneIDs := newFlushTransferScenario(t, ctx, nil)
+
+	require.NoError(t, flushTxn.Commit(ctx))
+	newTombstones := collectNewTombstones(t, ctx, tae, oldTombstoneIDs)
+	require.GreaterOrEqual(t, len(newTombstones), 2)
+
+	// The rewritten data and every transferred delete form one visibility
+	// unit. Check every timestamp where that result could change, rather than
+	// relying only on the latest snapshot.
+	flushCommitTS := flushTxn.GetCommitTS()
+	snapshotTSs := []types.TS{flushCommitTS.Prev(), flushCommitTS}
+	for _, tombstone := range newTombstones {
+		createdAt := tombstone.GetCreatedAt()
+		require.False(t, flushCommitTS.LT(&createdAt))
+		snapshotTSs = append(snapshotTSs, createdAt)
+	}
+	lastCreatedAt := newTombstones[len(newTombstones)-1].GetCreatedAt()
+	snapshotTSs = append(snapshotTSs, lastCreatedAt.Next())
+	checked := make(map[types.TS]struct{}, len(snapshotTSs))
+	for _, snapshotTS := range snapshotTSs {
+		if _, ok := checked[snapshotTS]; ok {
+			continue
+		}
+		checked[snapshotTS] = struct{}{}
+		checkRowsAtSnapshot(t, ctx, tae, snapshotTS, 0)
+	}
+
+	tae.Restart(ctx)
+	tae.CheckRowsByScan(0, true)
+}
+
+func TestFlushTransferTombstonesVisibleToSnapshotStartedWhilePreparing(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	ctx := context.Background()
+	barrier := &flushPrepareBarrier{
+		reached: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	tae, flushTxn, _ := newFlushTransferScenario(t, ctx, barrier)
+
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- flushTxn.Commit(ctx)
+	}()
+	select {
+	case <-barrier.reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("flush transaction did not reach PrepareCommit")
+	}
+
+	// Fix the reader snapshot after the parent timestamp has been assigned but
+	// before the late transfer creates any new appendable objects.
+	snapshotTxn, err := tae.StartTxn(nil)
+	require.NoError(t, err)
+	snapshotTxn.BindAccessInfo(0, 0, 0)
+	snapshotRel := tae.GetRelationWithTxn(snapshotTxn)
+	close(barrier.release)
+	require.NoError(t, <-commitDone)
+	testutil.CheckAllColRowsByScan(t, snapshotRel, 0, true)
+	require.NoError(t, snapshotTxn.Commit(ctx))
+}
+
+func TestFlushTransferTombstonesRollback(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	ctx := context.Background()
+	tae, flushTxn, oldTombstoneIDs := newFlushTransferScenario(t, ctx, nil)
+
+	injectedErr := errors.New("rollback after late tombstone transfer")
+	flushTxn.SetPrepareCommitFn(func(txn txnif.AsyncTxn) error {
+		if err := txn.GetStore().PrepareCommit(); err != nil {
+			return err
+		}
+		return injectedErr
+	})
+	require.ErrorIs(t, flushTxn.Commit(ctx), injectedErr)
+
+	// The catalog may retain empty committed aobj shells, but transferred rows
+	// owned by the rolled-back parent must never become visible.
+	newTombstones := collectNewTombstones(t, ctx, tae, oldTombstoneIDs)
+	require.NotEmpty(t, newTombstones)
+	tae.CheckRowsByScan(0, true)
+	tae.Restart(ctx)
+	tae.CheckRowsByScan(0, true)
+}
+
 func TestDropCreated1(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	ctx := context.Background()

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -3978,21 +3978,42 @@ func TestFlushTransferTombstonesVisibleToSnapshotStartedWhilePreparing(t *testin
 
 	commitDone := make(chan error, 1)
 	go func() {
+		defer close(commitDone)
 		commitDone <- flushTxn.Commit(ctx)
 	}()
+	releaseParent := sync.OnceFunc(func() {
+		close(barrier.release)
+	})
+	t.Cleanup(func() {
+		releaseParent()
+		select {
+		case <-commitDone:
+		case <-time.After(5 * time.Second):
+			t.Error("flush transaction did not exit after releasing PrepareCommit")
+		}
+	})
 	select {
 	case <-barrier.reached:
 	case <-time.After(5 * time.Second):
 		t.Fatal("flush transaction did not reach PrepareCommit")
 	}
 
-	// Fix the reader snapshot after the parent timestamp has been assigned but
-	// before the late transfer creates any new appendable objects.
-	snapshotTxn, err := tae.StartTxn(nil)
+	parentPrepareTS := flushTxn.GetPrepareTS()
+	readerSnapshotTS := tae.TxnMgr.Now()
+	require.Truef(
+		t,
+		parentPrepareTS.LT(&readerSnapshotTS),
+		"reader snapshot %s must cross parent prepare timestamp %s",
+		readerSnapshotTS.ToString(),
+		parentPrepareTS.ToString(),
+	)
+	// Fix a reader snapshot beyond the parent visibility boundary while the
+	// barrier still guarantees that no late transfer object has been created.
+	snapshotTxn, err := tae.StartTxnWithStartTSAndSnapshotTS(nil, readerSnapshotTS)
 	require.NoError(t, err)
 	snapshotTxn.BindAccessInfo(0, 0, 0)
 	snapshotRel := tae.GetRelationWithTxn(snapshotTxn)
-	close(barrier.release)
+	releaseParent()
 	require.NoError(t, <-commitDone)
 	testutil.CheckAllColRowsByScan(t, snapshotRel, 0, true)
 	require.NoError(t, snapshotTxn.Commit(ctx))

--- a/pkg/vm/engine/tae/txn/txnimpl/table.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table.go
@@ -826,14 +826,18 @@ func (tbl *txnTable) createCommittedAppendableObject(opts *objectio.CreateObjOpt
 	}
 	var meta *catalog.ObjectEntry
 	if txn.GetTxnState(false) == txnif.TxnStatePreparing {
-		// Flush and merge may transfer deletes after the parent transaction has
-		// entered PrepareCommit.  The append rows are still owned by that
-		// transaction, but allocating a fresh create timestamp for each
-		// appendable object would make the rewritten data visible before all of
-		// its tombstones.  Keep the catalog entry outside the transaction while
-		// aligning its visibility with the parent transaction. The append MVCC
-		// node still makes readers crossing this timestamp wait for the parent,
-		// and WAL replay reconstructs the object from that append at the same TS.
+		// This is a deliberate exception to the normal atomic timestamp
+		// allocation and catalog publication below. Flush and merge may transfer
+		// deletes after the parent has entered PrepareCommit, and each new
+		// appendable object is only a carrier for rows still owned by that parent
+		// transaction. A fresh object timestamp would split rewritten data from
+		// its tombstones. Use the parent's visibility boundary instead.
+		// Correctness scan paths that cross it wait on the parent's rewritten
+		// data/append MVCC before snapshotting the transfer tombstones, and WAL
+		// replay reconstructs the carrier from its append at the same timestamp.
+		//
+		// Do not use this branch for independently committed object state: such
+		// state must retain AllocateAndPublishCommitTS ordering.
 		meta, err = tbl.entry.CreateCommittedObject(txn.GetPrepareTS(), opts, factory)
 		if err != nil {
 			return

--- a/pkg/vm/engine/tae/txn/txnimpl/table.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table.go
@@ -815,6 +815,7 @@ func (tbl *txnTable) createCommittedAppendableObject(opts *objectio.CreateObjOpt
 	if !opts.Stats.GetAppendable() {
 		return nil, moerr.NewInternalErrorNoCtx("CreateObject outside txn only supports appendable object")
 	}
+	txn := tbl.store.txn
 	baseTxn, ok := tbl.store.txn.GetBase().(*txnbase.Txn)
 	if !ok || baseTxn.Mgr == nil {
 		return nil, moerr.NewInternalErrorNoCtx("missing txn manager for appendable object create")
@@ -824,6 +825,22 @@ func (tbl *txnTable) createCommittedAppendableObject(opts *objectio.CreateObjOpt
 		factory = tbl.store.catalog.DataFactory.MakeObjectFactory()
 	}
 	var meta *catalog.ObjectEntry
+	if txn.GetTxnState(false) == txnif.TxnStatePreparing {
+		// Flush and merge may transfer deletes after the parent transaction has
+		// entered PrepareCommit.  The append rows are still owned by that
+		// transaction, but allocating a fresh create timestamp for each
+		// appendable object would make the rewritten data visible before all of
+		// its tombstones.  Keep the catalog entry outside the transaction while
+		// aligning its visibility with the parent transaction. The append MVCC
+		// node still makes readers crossing this timestamp wait for the parent,
+		// and WAL replay reconstructs the object from that append at the same TS.
+		meta, err = tbl.entry.CreateCommittedObject(txn.GetPrepareTS(), opts, factory)
+		if err != nil {
+			return
+		}
+		obj = newObject(tbl, meta)
+		return
+	}
 	_, err = baseTxn.Mgr.AllocateAndPublishCommitTS(func(createTS types.TS) error {
 		meta, err = tbl.entry.CreateCommittedObject(createTS, opts, factory)
 		return err


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

N/A. This regression was isolated from the `TestDelete3` failure after #25534. It is unrelated to #26175.

## What this PR does / why we need it

### Root cause

A flush/merge transaction can collect deletes again from `flushTableTailEntry.PrepareCommit`, after its prepare/commit timestamp has already been assigned. If that late transfer rolls over the current tombstone appender, `prepareApplyANode` creates one or more appendable tombstone objects.

Since #25534, appendable objects are committed catalog entries outside the transaction. The active append path is correct because the object create timestamp precedes the append transaction commit. In the late-transfer path, however, each object received a fresh timestamp later than the parent flush timestamp. A snapshot could therefore see the rewritten data while seeing none or only a prefix of its transferred tombstones.

The deterministic reproducer on unmodified main returned visible rows after the delete. The strengthened concurrent-snapshot mutation test returns 22 rows without this fix and 0 with it.

### Fix

This PR keeps appendable objects outside transactions. It does not add object-create transaction entries or object-create WAL records.

When an appendable object is created while its append transaction is already `Preparing`, its committed catalog entry uses the parent prepare timestamp. The object remains only a carrier: its appended rows are still owned by the parent append MVCC node. Correctness scan paths that cross that timestamp wait on the parent's rewritten data/append MVCC before snapshotting transfer tombstones. WAL replay reconstructs a missing appendable object from the append command at the same timestamp.

The normal `Active` path remains on `AllocateAndPublishCommitTS`, preserving #25534's atomic timestamp allocation/catalog publication contract. The `Preparing` branch is a deliberate, narrow exception for parent-owned late-transfer rows; independently committed object state must continue to use the normal publication path.

### Design and performance

- aobjects remain outside transactions and may survive creator rollback as empty catalog shells;
- an empty shell without append/delete state remains intentionally non-durable, as in #25534;
- rollback removes the parent-owned append MVCC rows, so transferred deletes cannot become visible after parent abort;
- replay reconstructs committed carriers from append WAL without a format or upgrade change;
- multiple carriers may share the parent timestamp; object name remains the catalog ordering tie-breaker;
- the active path adds one transaction-state read per aobject creation, not per row or per commit;
- the rare preparing path avoids the per-object global timestamp allocation;
- no new I/O, WAL record, storage scan, allocation, or global publication fence is introduced;
- tombstone-only incremental dedup remains a best-effort fallback rather than gaining a strict global catalog fence.

## Coverage

The tests force multiple tombstone-object rollovers and cover:

- snapshots immediately before, at, and after every relevant visibility boundary;
- a reader snapshot explicitly greater than the parent prepare timestamp, fixed while the parent is `Preparing` and before any late transfer object exists;
- cleanup that always releases the deterministic prepare barrier and waits for the commit goroutine, including assertion failures;
- rollback after late transfer object creation;
- restart/replay after both commit and rollback;
- the existing outside-transaction aobject lifecycle through the full txnimpl suite.

Validation on the final diff:

- enhanced concurrent-snapshot test: fails on unmodified main with 22 visible rows, passes with this fix;
- focused regression set: `-count=10`;
- `TestDelete3` plus the new tests: `-race -count=20`;
- full `pkg/vm/engine/tae/db/test` suite;
- full `pkg/vm/engine/tae/...` suite with `-p=1`;
- `go vet` for both modified packages;
- `go build` for `pkg/vm/engine/tae/txn/txnimpl`;
- `git diff --check`.
