### PR TITLE
test(tae): remove tmp file GC timing race

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -13688,6 +13688,7 @@ func TestDumpTableFileNameDecode(t *testing.T) {
 }
 func Test_TmpFileService1(t *testing.T) {
 	ctx := context.Background()
+	var gcEnabled atomic.Bool
 
 	dir := testutils.InitTestEnv(ModuleName, t)
 	tmpFS, err := fileservice.NewTestTmpFileService("TMP", path.Join(dir, "tmp"), time.Millisecond*100)
@@ -13706,6 +13707,12 @@ func Test_TmpFileService1(t *testing.T) {
 	testFS, err := tmpFS.GetOrCreateApp(&fileservice.AppConfig{
 		Name: "test",
 		GCFn: func(filePath string, fs fileservice.FileService) (neesGC bool, err error) {
+			// Keep creation verification independent of scheduler timing. The
+			// periodic GC remains active throughout the test, but it cannot delete
+			// the file until the test has confirmed the write is visible.
+			if !gcEnabled.Load() {
+				return false, nil
+			}
 			createTime, err := decodeNameFn(filePath)
 			if err != nil {
 				return
@@ -13760,6 +13767,7 @@ func Test_TmpFileService1(t *testing.T) {
 
 	files := listFn()
 	assert.Equal(t, 1, len(files), "files are %v", files)
+	gcEnabled.Store(true)
 	testutils.WaitExpect(
 		4000,
 		func() bool {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26191

## What this PR does / why we need it:

`Test_TmpFileService1` used the same 100ms value for the temporary-file GC interval and the expiry threshold. On a delayed CI runner, the periodic GC could remove the file before the test made its initial visibility assertion.

The test now holds its test-local GC callback until after that initial assertion, then enables it and retains the existing polling assertion that periodic GC eventually deletes the expired file. This removes the scheduler race without changing production code, extending timeouts, or reducing coverage.

Validation:

- `Test_TmpFileService1`: 100 iterations
- `Test_TmpFileService1` with `-race`: 100 iterations
- `go build ./pkg/vm/engine/tae/db`
- `go vet ./pkg/vm/engine/tae/db/test`