### PR TITLE
test(function): exclude JSON_OVERLAPS allocation check under race

### DIFF
--- a/pkg/sql/plan/function/func_builtin_json_overlap_alloc_test.go
+++ b/pkg/sql/plan/function/func_builtin_json_overlap_alloc_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !race
+
+package function
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Allocation counts are not stable under race instrumentation. Keep this
+// regression check in non-race builds while functional tests run in both.
+func TestJSONOverlapsAccessorAllocationsDoNotScaleWithRows(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	trueJSON := mustJsonBinaryString(t, `true`)
+	falseJSON := mustJsonBinaryString(t, `false`)
+
+	measure := func(rows int) float64 {
+		left := make([]string, rows)
+		right := make([]string, rows)
+		for i := range rows {
+			left[i] = trueJSON
+			right[i] = falseJSON
+		}
+		testCase := NewFunctionTestCase(
+			proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_json.ToType(), left, nil),
+				NewFunctionTestInput(types.T_json.ToType(), right, nil),
+			},
+			NewFunctionTestResult(types.T_int64.ToType(), false, nil, nil),
+			jsonOverlaps,
+		)
+		var runErr error
+		allocations := testing.AllocsPerRun(3, func() {
+			runErr = testCase.result.PreExtendAndReset(rows)
+			if runErr == nil {
+				runErr = testCase.fn(testCase.parameters, testCase.result, proc, rows, nil)
+			}
+		})
+		require.NoError(t, runErr)
+		return allocations
+	}
+
+	oneRow := measure(1)
+	manyRows := measure(8192)
+	require.LessOrEqual(t, manyRows, oneRow+10,
+		"accessor allocations must be batch-scoped: one=%f many=%f", oneRow, manyRows)
+}

--- a/pkg/sql/plan/function/func_builtin_json_overlap_test.go
+++ b/pkg/sql/plan/function/func_builtin_json_overlap_test.go
@@ -856,44 +856,6 @@ func TestJSONOverlapsPartialSelectListSkipsParsingAndPreservesNulls(t *testing.T
 	require.True(t, result.IsNull(3))
 }
 
-func TestJSONOverlapsAccessorAllocationsDoNotScaleWithRows(t *testing.T) {
-	proc := testutil.NewProcess(t)
-	trueJSON := mustJsonBinaryString(t, `true`)
-	falseJSON := mustJsonBinaryString(t, `false`)
-
-	measure := func(rows int) float64 {
-		left := make([]string, rows)
-		right := make([]string, rows)
-		for i := range rows {
-			left[i] = trueJSON
-			right[i] = falseJSON
-		}
-		testCase := NewFunctionTestCase(
-			proc,
-			[]FunctionTestInput{
-				NewFunctionTestInput(types.T_json.ToType(), left, nil),
-				NewFunctionTestInput(types.T_json.ToType(), right, nil),
-			},
-			NewFunctionTestResult(types.T_int64.ToType(), false, nil, nil),
-			jsonOverlaps,
-		)
-		var runErr error
-		allocations := testing.AllocsPerRun(3, func() {
-			runErr = testCase.result.PreExtendAndReset(rows)
-			if runErr == nil {
-				runErr = testCase.fn(testCase.parameters, testCase.result, proc, rows, nil)
-			}
-		})
-		require.NoError(t, runErr)
-		return allocations
-	}
-
-	oneRow := measure(1)
-	manyRows := measure(8192)
-	require.LessOrEqual(t, manyRows, oneRow+10,
-		"accessor allocations must be batch-scoped: one=%f many=%f", oneRow, manyRows)
-}
-
 func BenchmarkJSONOverlapIndexedArrays(b *testing.B) {
 	left, err := types.ParseSliceToByteJson([]byte(jsonOverlapIntegerArray(0, 8192)))
 	if err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26214

## What this PR does / why we need it:

`TestJSONOverlapsAccessorAllocationsDoNotScaleWithRows` uses
`testing.AllocsPerRun` around the complete 8192-row JSON_OVERLAPS execution.
Under race instrumentation, process-wide and instrumentation-dependent
allocation deltas can be attributed to that long execution and make the
allocation-only assertion fail unrelated pull requests. PR #26196 observed
`one=0, many=187`, while contemporaneous runs passed with unchanged function
code.

Move the allocation-statistics-only test unchanged into a dedicated
`//go:build !race` test file, following the established fix in #25915 for the
same failure mode.

This keeps:

- the 1-row versus 8192-row allocation regression assertion in non-race builds;
- all JSON_OVERLAPS functional tests in both race and non-race builds;
- production code and JSON_OVERLAPS behavior unchanged.

### Validation

- Non-race allocation test, 20 repetitions.
- Race-built test list confirms the allocation-only test is excluded.
- Focused JSON_OVERLAPS functional tests under `-race`.
- Full `pkg/sql/plan/function` package tests.
- Full `pkg/sql/plan/function` package tests under `-race`.
- `git diff --check`.
