### PR TITLE
[4.2-dev] fix(pipeline): wake receivers from terminal edge state

### DIFF
--- a/pkg/sql/colexec/connector/types_test.go
+++ b/pkg/sql/colexec/connector/types_test.go
@@ -179,6 +179,48 @@ func TestConnectorResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing
 	require.Same(t, process.ErrPipelineEndSignalDeliveryFailed, info)
 }
 
+func TestConnectorResetUndeliveredFallbackAbortWakesReceiver(t *testing.T) {
+	oldSignalSendTimeout := process.PipelineSignalSendTimeout
+	process.PipelineSignalSendTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		process.PipelineSignalSendTimeout = oldSignalSendTimeout
+	})
+
+	reg := process.NewPipelineEdge(1, 0)
+	reg.Ch2 <- process.NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
+
+	conn := &Connector{Reg: reg}
+	conn.Reset(nil, false, nil)
+
+	receiverCtx, cancelReceiver := context.WithCancel(context.Background())
+	defer cancelReceiver()
+	receiver := process.InitPipelineSignalReceiver(receiverCtx, []*process.WaitRegister{reg})
+
+	got, err := receiver.GetNextBatch(nil)
+	require.NoError(t, err)
+	require.Same(t, batch.EmptyBatch, got)
+
+	type result struct {
+		bat *batch.Batch
+		err error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		got, err := receiver.GetNextBatch(nil)
+		resultCh <- result{bat: got, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.Nil(t, result.bat)
+		require.ErrorIs(t, result.err, process.ErrPipelineEndSignalDeliveryFailed)
+	case <-time.After(time.Second):
+		cancelReceiver()
+		<-resultCh
+		t.Fatal("receiver remained blocked after the fallback Abort failed to enter the full channel")
+	}
+}
+
 func TestConnectorResetUsesSharedTerminalSendBudget(t *testing.T) {
 	oldSignalSendTimeout := process.PipelineSignalSendTimeout
 	process.PipelineSignalSendTimeout = 200 * time.Millisecond

--- a/pkg/vm/process/pipeline_edge.go
+++ b/pkg/vm/process/pipeline_edge.go
@@ -227,6 +227,21 @@ func (e *PipelineEdge) Err() error {
 	return e.terminalErr
 }
 
+// terminalSignalSnapshot returns the edge's terminal state after synchronizing
+// with any in-flight terminal sender. It is used by PipelineSignalReceiver when
+// Done has closed but the terminal signal itself could not enter a full Ch2.
+func (e *PipelineEdge) terminalSignalSnapshot() PipelineSignal {
+	if e == nil {
+		return NewEndSignal()
+	}
+	e.terminalMu.Lock()
+	defer e.terminalMu.Unlock()
+	if e.fatalTerminal {
+		return e.fatalSignal
+	}
+	return NewEndSignal()
+}
+
 // SendData sends a data batch via the edge. It returns true if the signal was
 // successfully sent, false if the context was cancelled.
 func (e *PipelineEdge) SendData(ctx context.Context, spool *pSpool.PipelineSpool, idx int) bool {
@@ -418,11 +433,15 @@ func (e *PipelineEdge) sendTerminalWithContext(ctx context.Context, signal Pipel
 	if e.fatalDelivered >= e.fatalRemaining {
 		return false
 	}
+	// Fatal state is durable and wakes PipelineSignalReceiver through Done.
+	// Never make this control path wait behind the data channel it terminates;
+	// enqueue as many fatal signals as fit and let the receiver synthesize any
+	// missing remainder from the recorded state.
 	for e.fatalDelivered < e.fatalRemaining {
 		select {
 		case e.Ch2 <- signal:
 			e.fatalDelivered++
-		case <-ctx.Done():
+		default:
 			return false
 		}
 	}

--- a/pkg/vm/process/pipeline_edge_test.go
+++ b/pkg/vm/process/pipeline_edge_test.go
@@ -666,9 +666,12 @@ func TestPipelineEdgeTimeoutFatalSendDoneClosesAfterTimeout(t *testing.T) {
 	reg := NewPipelineEdge(1, 0)
 	reg.Ch2 <- NewEndSignal() // fill it
 
-	// With a very short timeout, this must fail.
-	if SendPipelineSignalWithTimeout(reg, NewErrorSignal(moerr.NewInternalErrorNoCtx("fatal")), 10*time.Millisecond) {
+	start := time.Now()
+	if SendPipelineSignalWithTimeout(reg, NewErrorSignal(moerr.NewInternalErrorNoCtx("fatal")), time.Second) {
 		t.Fatal("SendPipelineSignalWithTimeout should fail on a full channel")
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("fatal send waited behind the full data channel: %s", elapsed)
 	}
 
 	select {

--- a/pkg/vm/process/process_spoolr.go
+++ b/pkg/vm/process/process_spoolr.go
@@ -281,12 +281,15 @@ func (signal PipelineSignal) Action() (data *batch.Batch, info error) {
 type PipelineSignalReceiver struct {
 	usrCtx context.Context
 	srcReg []*WaitRegister
+	doneCh []<-chan struct{}
 
 	alive int
 
-	// receive data channel, first reg is the monitor for runningCtx.
+	// reflect-select cases for receivers with more than eight inputs. The first
+	// case monitors usrCtx; each input then contributes a Ch2 case and a Done
+	// case.
 	regs []reflect.SelectCase
-	// how much nil batch should each reg wait. its length is 1 less than regs.
+	// how many terminal signals each srcReg still expects.
 	nbs []int
 
 	// currentSignal is the current signal this receiver was using.
@@ -303,6 +306,7 @@ type PipelineSignalReceiverState struct {
 func InitPipelineSignalReceiver(runningCtx context.Context, regs []*WaitRegister) *PipelineSignalReceiver {
 	nbs := make([]int, len(regs))
 	srcRegs := make([]*WaitRegister, len(regs))
+	doneCh := make([]<-chan struct{}, len(regs))
 
 	for i, reg := range regs {
 		// 0 is default number, it takes a same effect as 1.
@@ -312,22 +316,25 @@ func InitPipelineSignalReceiver(runningCtx context.Context, regs []*WaitRegister
 			nbs[i] = reg.NilBatchCnt
 		}
 		srcRegs[i] = reg
+		doneCh[i] = reg.Done()
 	}
 
 	// if regs were not much, we will use an optimized method to receive msg.
 	// and there is no need to init the `reflect.SelectCase`.
 	var scs []reflect.SelectCase = nil
 	if len(regs) > 8 {
-		scs = make([]reflect.SelectCase, 0, len(regs)+1)
+		scs = make([]reflect.SelectCase, 0, len(regs)*2+1)
 		scs = append(scs, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(runningCtx.Done())})
 		for i := range regs {
 			scs = append(scs, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(regs[i].Ch2)})
+			scs = append(scs, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(doneCh[i])})
 		}
 	}
 
 	return &PipelineSignalReceiver{
 		usrCtx:        runningCtx,
 		srcReg:        srcRegs,
+		doneCh:        doneCh,
 		alive:         len(regs),
 		regs:          scs,
 		nbs:           nbs,
@@ -428,10 +435,12 @@ func (receiver *PipelineSignalReceiver) removeIdxReceiver(chosen int) {
 	if receiver.nbs[idx] == 0 {
 		// remove the unused channel.
 		receiver.srcReg = append(receiver.srcReg[:idx], receiver.srcReg[idx+1:]...)
+		receiver.doneCh = append(receiver.doneCh[:idx], receiver.doneCh[idx+1:]...)
 		receiver.nbs = append(receiver.nbs[:idx], receiver.nbs[idx+1:]...)
 
 		if len(receiver.regs) > 0 {
-			receiver.regs = append(receiver.regs[:chosen], receiver.regs[chosen+1:]...)
+			caseIdx := idx*2 + 1
+			receiver.regs = append(receiver.regs[:caseIdx], receiver.regs[caseIdx+2:]...)
 		}
 		receiver.alive--
 	}
@@ -481,13 +490,52 @@ func (receiver *PipelineSignalReceiver) listenToAll() (int, PipelineSignal) {
 
 	// common case.
 	chosen, value, ok := reflect.Select(receiver.regs)
-	if !ok {
-		if chosen == 0 {
-			return 0, PipelineSignal{}
-		}
-		panic("unexpected sender close during GetNextBatch")
+	if chosen == 0 {
+		return 0, PipelineSignal{}
 	}
-	return chosen, value.Interface().(PipelineSignal)
+
+	idx := (chosen - 1) / 2
+	// Data cases occupy odd reflect indexes; Done cases occupy even indexes.
+	if chosen%2 == 1 {
+		if !ok {
+			panic("unexpected sender close during GetNextBatch")
+		}
+		return idx + 1, value.Interface().(PipelineSignal)
+	}
+	return receiver.receiveSignalOrTerminal(idx)
+}
+
+// receiveSignalOrTerminal handles an edge whose Done channel is ready. Ch2
+// remains the ordered source of truth: buffered data and successfully enqueued
+// terminal signals must be consumed before a terminal that failed to enqueue is
+// synthesized from the edge's durable terminal state.
+func (receiver *PipelineSignalReceiver) receiveSignalOrTerminal(idx int) (int, PipelineSignal) {
+	reg := receiver.srcReg[idx]
+	if signal, ok := tryReceivePipelineSignal(reg.Ch2); ok {
+		return idx + 1, signal
+	}
+
+	// Synchronize with an in-flight terminal sender. The sender closes Done
+	// before attempting a fatal enqueue, so it may enqueue after our first
+	// non-blocking receive. Recheck Ch2 after taking the snapshot to avoid
+	// synthesizing a duplicate terminal.
+	terminal := reg.terminalSignalSnapshot()
+	if signal, ok := tryReceivePipelineSignal(reg.Ch2); ok {
+		return idx + 1, signal
+	}
+	return idx + 1, terminal
+}
+
+func tryReceivePipelineSignal(ch <-chan PipelineSignal) (PipelineSignal, bool) {
+	select {
+	case signal, ok := <-ch:
+		if !ok {
+			panic("unexpected sender close during GetNextBatch")
+		}
+		return signal, true
+	default:
+		return PipelineSignal{}, false
+	}
 }
 
 func (receiver *PipelineSignalReceiver) WaitingEnd() {
@@ -529,6 +577,8 @@ func (receiver *PipelineSignalReceiver) listenToSingleEntry() (chosen int, v Pip
 		return 0, v
 	case v = <-receiver.srcReg[0].Ch2:
 		return 1, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
 	}
 }
 
@@ -540,6 +590,10 @@ func (receiver *PipelineSignalReceiver) listenToTwoEntry() (chosen int, v Pipeli
 		return 1, v
 	case v = <-receiver.srcReg[1].Ch2:
 		return 2, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
+	case <-receiver.doneCh[1]:
+		return receiver.receiveSignalOrTerminal(1)
 	}
 }
 
@@ -553,6 +607,12 @@ func (receiver *PipelineSignalReceiver) listenToThreeEntry() (chosen int, v Pipe
 		return 2, v
 	case v = <-receiver.srcReg[2].Ch2:
 		return 3, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
+	case <-receiver.doneCh[1]:
+		return receiver.receiveSignalOrTerminal(1)
+	case <-receiver.doneCh[2]:
+		return receiver.receiveSignalOrTerminal(2)
 	}
 }
 
@@ -568,6 +628,14 @@ func (receiver *PipelineSignalReceiver) listenToFourEntry() (chosen int, v Pipel
 		return 3, v
 	case v = <-receiver.srcReg[3].Ch2:
 		return 4, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
+	case <-receiver.doneCh[1]:
+		return receiver.receiveSignalOrTerminal(1)
+	case <-receiver.doneCh[2]:
+		return receiver.receiveSignalOrTerminal(2)
+	case <-receiver.doneCh[3]:
+		return receiver.receiveSignalOrTerminal(3)
 	}
 }
 
@@ -585,6 +653,16 @@ func (receiver *PipelineSignalReceiver) listenToFiveEntry() (chosen int, v Pipel
 		return 4, v
 	case v = <-receiver.srcReg[4].Ch2:
 		return 5, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
+	case <-receiver.doneCh[1]:
+		return receiver.receiveSignalOrTerminal(1)
+	case <-receiver.doneCh[2]:
+		return receiver.receiveSignalOrTerminal(2)
+	case <-receiver.doneCh[3]:
+		return receiver.receiveSignalOrTerminal(3)
+	case <-receiver.doneCh[4]:
+		return receiver.receiveSignalOrTerminal(4)
 	}
 }
 
@@ -604,6 +682,18 @@ func (receiver *PipelineSignalReceiver) listenToSixEntry() (chosen int, v Pipeli
 		return 5, v
 	case v = <-receiver.srcReg[5].Ch2:
 		return 6, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
+	case <-receiver.doneCh[1]:
+		return receiver.receiveSignalOrTerminal(1)
+	case <-receiver.doneCh[2]:
+		return receiver.receiveSignalOrTerminal(2)
+	case <-receiver.doneCh[3]:
+		return receiver.receiveSignalOrTerminal(3)
+	case <-receiver.doneCh[4]:
+		return receiver.receiveSignalOrTerminal(4)
+	case <-receiver.doneCh[5]:
+		return receiver.receiveSignalOrTerminal(5)
 	}
 }
 
@@ -625,6 +715,20 @@ func (receiver *PipelineSignalReceiver) listenToSevenEntry() (chosen int, v Pipe
 		return 6, v
 	case v = <-receiver.srcReg[6].Ch2:
 		return 7, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
+	case <-receiver.doneCh[1]:
+		return receiver.receiveSignalOrTerminal(1)
+	case <-receiver.doneCh[2]:
+		return receiver.receiveSignalOrTerminal(2)
+	case <-receiver.doneCh[3]:
+		return receiver.receiveSignalOrTerminal(3)
+	case <-receiver.doneCh[4]:
+		return receiver.receiveSignalOrTerminal(4)
+	case <-receiver.doneCh[5]:
+		return receiver.receiveSignalOrTerminal(5)
+	case <-receiver.doneCh[6]:
+		return receiver.receiveSignalOrTerminal(6)
 	}
 }
 
@@ -648,5 +752,21 @@ func (receiver *PipelineSignalReceiver) listenToEightEntry() (chosen int, v Pipe
 		return 7, v
 	case v = <-receiver.srcReg[7].Ch2:
 		return 8, v
+	case <-receiver.doneCh[0]:
+		return receiver.receiveSignalOrTerminal(0)
+	case <-receiver.doneCh[1]:
+		return receiver.receiveSignalOrTerminal(1)
+	case <-receiver.doneCh[2]:
+		return receiver.receiveSignalOrTerminal(2)
+	case <-receiver.doneCh[3]:
+		return receiver.receiveSignalOrTerminal(3)
+	case <-receiver.doneCh[4]:
+		return receiver.receiveSignalOrTerminal(4)
+	case <-receiver.doneCh[5]:
+		return receiver.receiveSignalOrTerminal(5)
+	case <-receiver.doneCh[6]:
+		return receiver.receiveSignalOrTerminal(6)
+	case <-receiver.doneCh[7]:
+		return receiver.receiveSignalOrTerminal(7)
 	}
 }

--- a/pkg/vm/process/process_spoolr_test.go
+++ b/pkg/vm/process/process_spoolr_test.go
@@ -93,6 +93,30 @@ func TestPipelineSignalReceiverSharedEdgeContinuesAfterFirstEndSignal(t *testing
 	}
 }
 
+func TestPipelineSignalReceiverDonePreservesBufferedDataOrder(t *testing.T) {
+	reg := NewPipelineEdge(2, 1)
+	if !reg.SendDataDirect(context.Background(), batch.EmptyBatch, nil) {
+		t.Fatal("failed to send buffered data")
+	}
+	if !reg.SendEnd() {
+		t.Fatal("failed to send End")
+	}
+
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{reg})
+	got, err := receiver.GetNextBatch(nil)
+	if err != nil {
+		t.Fatalf("GetNextBatch returned error before buffered data: %v", err)
+	}
+	if got != batch.EmptyBatch {
+		t.Fatal("Done notification bypassed buffered data")
+	}
+
+	got, err = receiver.GetNextBatch(nil)
+	if got != nil || err != nil {
+		t.Fatalf("unexpected result after buffered data and End: batch=%v err=%v", got, err)
+	}
+}
+
 func TestPipelineSignalReceiverSharedFatalCompletesRemainingCount(t *testing.T) {
 	reg := NewPipelineEdge(2, 2)
 	if !reg.SendError(moerr.NewInternalErrorNoCtx("shared fatal")) {
@@ -118,6 +142,116 @@ func TestPipelineSignalReceiverFailedCleanupWithoutCauseReturnsError(t *testing.
 	}
 	if err != ErrPipelineTerminalWithoutCause {
 		t.Fatal("failure terminal without cause did not return ErrPipelineTerminalWithoutCause")
+	}
+}
+
+func TestPipelineSignalReceiverWakesWhenFatalSignalCannotBeDelivered(t *testing.T) {
+	testCases := []struct {
+		name      string
+		regCount  int
+		targetIdx int
+	}{
+		{name: "optimized select", regCount: 1, targetIdx: 0},
+		{name: "reflect select first input", regCount: 9, targetIdx: 0},
+		{name: "reflect select middle input", regCount: 9, targetIdx: 4},
+		{name: "reflect select last input", regCount: 9, targetIdx: 8},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			regs := make([]*WaitRegister, testCase.regCount)
+			for i := range regs {
+				regs[i] = NewPipelineEdge(1, 1)
+			}
+			target := regs[testCase.targetIdx]
+			target.Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
+
+			fatalErr := moerr.NewInternalErrorNoCtx("fatal signal delivery failed")
+			sendCtx, cancelSend := context.WithCancel(context.Background())
+			cancelSend()
+			if SendPipelineSignalWithContext(sendCtx, target, NewErrorSignal(fatalErr)) {
+				t.Fatal("fatal signal unexpectedly entered the full channel")
+			}
+
+			receiverCtx, cancelReceiver := context.WithCancel(context.Background())
+			defer cancelReceiver()
+			receiver := InitPipelineSignalReceiver(receiverCtx, regs)
+
+			got, err := receiver.GetNextBatch(nil)
+			if err != nil {
+				t.Fatalf("GetNextBatch returned error before draining buffered data: %v", err)
+			}
+			if got != batch.EmptyBatch {
+				t.Fatal("receiver did not drain the buffered data before reporting the fatal terminal")
+			}
+
+			type result struct {
+				bat *batch.Batch
+				err error
+			}
+			resultCh := make(chan result, 1)
+			go func() {
+				got, err := receiver.GetNextBatch(nil)
+				resultCh <- result{bat: got, err: err}
+			}()
+
+			select {
+			case result := <-resultCh:
+				if result.bat != nil {
+					t.Fatal("fatal terminal returned a batch")
+				}
+				if result.err != fatalErr {
+					t.Fatalf("fatal terminal returned unexpected error: %v", result.err)
+				}
+			case <-time.After(100 * time.Millisecond):
+				cancelReceiver()
+				<-resultCh
+				t.Fatal("receiver remained blocked after the full channel drained")
+			}
+
+			// A 9-input receiver starts in reflect.Select mode. Removing any
+			// input drops it to the hand-written 8-way select; finish every
+			// remaining edge to verify both the reflect case reindexing and
+			// that mode transition.
+			for i, reg := range regs {
+				if i != testCase.targetIdx && !reg.SendEnd() {
+					t.Fatalf("failed to end remaining input %d", i)
+				}
+			}
+			got, err = receiver.GetNextBatch(nil)
+			if got != nil || err != nil {
+				t.Fatalf("receiver did not finish remaining inputs: batch=%v err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestPipelineSignalReceiverSynthesizesSharedUndeliveredFatalCount(t *testing.T) {
+	reg := NewPipelineEdge(1, 2)
+	reg.Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
+
+	fatalErr := moerr.NewInternalErrorNoCtx("shared fatal signal delivery failed")
+	sendCtx, cancelSend := context.WithCancel(context.Background())
+	cancelSend()
+	if SendPipelineSignalWithContext(sendCtx, reg, NewAbortSignal(fatalErr)) {
+		t.Fatal("fatal signal unexpectedly entered the full channel")
+	}
+
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{reg})
+	got, err := receiver.GetNextBatch(nil)
+	if err != nil || got != batch.EmptyBatch {
+		t.Fatalf("unexpected buffered data result: batch=%v err=%v", got, err)
+	}
+
+	for i := 0; i < 2; i++ {
+		got, err = receiver.GetNextBatch(nil)
+		if got != nil || err != fatalErr {
+			t.Fatalf("unexpected synthesized fatal %d: batch=%v err=%v", i, got, err)
+		}
+	}
+	got, err = receiver.GetNextBatch(nil)
+	if got != nil || err != nil {
+		t.Fatalf("receiver did not finish after the shared fatal count: batch=%v err=%v", got, err)
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26202 and #26125.

This PR targets `4.2-dev` for #26202. The same logical change needs to be forward-ported to `main` for the #26125 reproduction.

## What this PR does / why we need it:

A fatal `PipelineEdge` terminal is recorded and closes `Done()` before all required terminal signals are enqueued into `Ch2`. When `Ch2` is backpressured, the typed terminal signal can remain partially or completely undelivered. `PipelineSignalReceiver` previously waited only on its user context and `Ch2`, so it could remain blocked after the edge was already terminal. That leaves `Merge`, `RemoteRun`, and ultimately `Compile.runOnce` waiting indefinitely.

This change:

- listens to each edge `Done()` channel in both the optimized 1–8 input selects and the `reflect.Select` path;
- drains buffered `Ch2` signals before synthesizing a missing terminal from the durable edge state;
- synchronizes and rechecks `Ch2` to preserve ordering across the fatal-state/enqueue race;
- makes fatal terminal enqueue non-blocking while holding the terminal-state mutex, avoiding a control-path wait cycle behind the data channel;
- adds regressions for buffered ordering, undelivered fatal terminals, shared edges, connector fallback cleanup, and reflect-select removal/reindexing across the 9-to-8 input transition.

Normal `End` delivery and the legacy nil-batch compatibility path remain unchanged.

## Validation

- `go build ./pkg/vm/process ./pkg/sql/colexec/connector ./pkg/sql/colexec/merge ./pkg/sql/colexec/dispatch`
- `go vet ./pkg/vm/process ./pkg/sql/colexec/connector ./pkg/sql/colexec/merge ./pkg/sql/colexec/dispatch`
- focused new regressions with `-race -count=20`
- `go test -race -count=1 -timeout=600s ./pkg/vm/process ./pkg/sql/colexec/connector`
- `go test -count=1 -timeout=600s ./pkg/vm/process ./pkg/sql/colexec/connector`
- `go test -count=1 -timeout=600s ./pkg/sql/colexec/merge ./pkg/sql/colexec/dispatch`
- `git diff --check`