### PR TITLE
test(tae): scope TestCkpLeak checkpoint wait

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -8848,9 +8848,9 @@ func TestCkpLeak(t *testing.T) {
 	}
 	wg.Wait()
 	ckpCtx, cancel := context.WithTimeout(ctx, testutil.TestCheckpointTimeout)
-	defer cancel()
-	require.NoError(t, db.ForceCheckpoint(ckpCtx, db.TxnMgr.Now()))
-	testutil.WaitAllCheckpointsFinished(t, db)
+	err = db.ForceCheckpoint(ckpCtx, db.TxnMgr.Now())
+	cancel()
+	require.NoError(t, err)
 	t.Log(tae.Catalog.SimplePPString(common.PPL1))
 	checkLeak := func() bool {
 		ckpMetaFiles := db.BGCheckpointRunner.GetCheckpointMetaFiles()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance
- [ ] Refactoring
- [ ] Dependency Upgrade
- [x] Test and CI

## Which issue(s) this PR fixes:

issue #26242

## What this PR does / why we need it:

`TestCkpLeak` waited for global checkpoint quiescence after 200 concurrent appends. A new incremental checkpoint intent can stay pending after table-tail flush completes, so the 10-second helper can observe `target LSN: 201, checkpointed LSN: 1, current LSN: 203` even though the checkpoint worker is healthy. The production stalled-intent recovery threshold is two minutes, which does not fit this test contract.

Fence the completed workload at `db.TxnMgr.Now()` and use a bounded `ForceCheckpoint` to flush, schedule, and wait for a checkpoint covering that fixed timestamp. This follows the synchronization pattern already used by related TAE GC tests and changes test code only.

Validation:

- `mo-cgo-test -count=20 -run ^TestCkpLeak$ -timeout=180s ./pkg/vm/engine/tae/db/test`
- `mo-cgo-test -race -count=3 -run ^TestCkpLeak$ -timeout=240s ./pkg/vm/engine/tae/db/test`
- `mo-cgo-test -count=3 -run ^(TestCkpLeak|TestSnapshotGC|TestAppendAndGC2)$ -timeout=240s ./pkg/vm/engine/tae/db/test`
- `go vet -mod=readonly ./pkg/vm/engine/tae/db/test`
- `go build -mod=readonly ./pkg/vm/engine/tae/db/...`