### PR TITLE
fix(tae): align stalled checkpoint flush recovery

### DIFF
--- a/pkg/vm/engine/tae/db/checkpoint/flusher.go
+++ b/pkg/vm/engine/tae/db/checkpoint/flusher.go
@@ -42,9 +42,7 @@ import (
 
 var ErrFlusherStopped = moerr.NewInternalErrorNoCtx("flusher stopped")
 
-const (
-	stalledCheckpointFlushAge = checkpointIntentOldAge
-)
+const maxStalledCheckpointFlushAge = checkpointIntentOldAge
 
 type FlushCfg struct {
 	ForceFlushTimeout       time.Duration
@@ -102,6 +100,17 @@ func (mode flushScheduleMode) bypassFlushReady() bool {
 
 func (mode flushScheduleMode) resetFlushDeadline() bool {
 	return mode != flushScheduleCheckpointBounded
+}
+
+func (mode flushScheduleMode) objectScanLowerBound(lastCkp types.TS) types.TS {
+	// A checkpoint-bounded or forced flush must consider the same object set
+	// as IsTableTailFlushed: every active appendable object at or before the
+	// request end. Such an object can receive writes after it was created, so
+	// its creation timestamp cannot be used to exclude it from recovery.
+	if mode.bypassFlushReady() {
+		return types.TS{}
+	}
+	return lastCkp
 }
 
 type FlushRequest struct {
@@ -332,6 +341,7 @@ type flushImpl struct {
 	objMemSizeList []tableAndSize
 
 	stalledCheckpointPickBounded bool
+	stalledCheckpointFlushAge    time.Duration
 
 	// Log throttling for collectTableMemUsage
 	logThrottleMu   sync.Mutex
@@ -396,6 +406,9 @@ func (flusher *flushImpl) fillDefaults() {
 	if flusher.flushInterval <= 0 {
 		flusher.flushInterval = time.Minute
 	}
+	if flusher.stalledCheckpointFlushAge <= 0 {
+		flusher.stalledCheckpointFlushAge = deriveStalledCheckpointFlushAge(flusher.flushInterval)
+	}
 	// TODO: what is flushLag? Here just refactoring the original code.
 	if flusher.flushLag <= 0 {
 		if flusher.flushInterval < time.Second {
@@ -408,6 +421,17 @@ func (flusher *flushImpl) fillDefaults() {
 	if flusher.flushQueueSize <= 0 {
 		flusher.flushQueueSize = 1000
 	}
+}
+
+func deriveStalledCheckpointFlushAge(flushInterval time.Duration) time.Duration {
+	// Give normal flushing two opportunities before using the bounded
+	// recovery path. Cap the delay at the historical production threshold,
+	// while allowing intentionally fast flush configurations to recover at
+	// the same cadence.
+	if flushInterval <= 0 || flushInterval >= maxStalledCheckpointFlushAge/2 {
+		return maxStalledCheckpointFlushAge
+	}
+	return 2 * flushInterval
 }
 
 func (flusher *flushImpl) triggerJob(ctx context.Context) {
@@ -434,7 +458,7 @@ func (flusher *flushImpl) triggerJob(ctx context.Context) {
 }
 
 func (flusher *flushImpl) pickStalledCheckpointFlushEntry(intent *CheckpointEntry) bool {
-	if !shouldScheduleStalledCheckpointFlush(intent, stalledCheckpointFlushAge) {
+	if !shouldScheduleStalledCheckpointFlush(intent, flusher.stalledCheckpointFlushAge) {
 		flusher.stalledCheckpointPickBounded = false
 		return false
 	}
@@ -517,6 +541,7 @@ func (flusher *flushImpl) scheduleFlush(
 			lastCkp = ckp.GetStart().Prev()
 		}
 	}
+	lastCkp = mode.objectScanLowerBound(lastCkp)
 	pressure := flusher.collectTableMemUsage(entry, lastCkp)
 	flusher.checkFlushConditionAndFire(entry, mode, pressure, lastCkp)
 }
@@ -526,7 +551,7 @@ func (flusher *flushImpl) makeStalledCheckpointFlushEntry() *logtail.DirtyTreeEn
 		return nil
 	}
 	intent := flusher.checkpointSchduler.PendingIncrementalCheckpoint()
-	return makeStalledCheckpointFlushEntry(flusher.sourcer, intent, stalledCheckpointFlushAge)
+	return makeStalledCheckpointFlushEntry(flusher.sourcer, intent, flusher.stalledCheckpointFlushAge)
 }
 
 func makeStalledCheckpointFlushEntry(
@@ -984,6 +1009,7 @@ func (flusher *flushImpl) Start() {
 			zap.Duration("cron-period", flusher.cronPeriod),
 			zap.Duration("flush-interval", flusher.flushInterval),
 			zap.Duration("flush-lag", flusher.flushLag),
+			zap.Duration("stalled-checkpoint-flush-age", flusher.stalledCheckpointFlushAge),
 			zap.Duration("force-flush-timeout", cfg.ForceFlushTimeout),
 			zap.Duration("force-flush-check-interval", cfg.ForceFlushCheckInterval),
 		)

--- a/pkg/vm/engine/tae/db/checkpoint/flusher_test.go
+++ b/pkg/vm/engine/tae/db/checkpoint/flusher_test.go
@@ -84,8 +84,10 @@ func TestShouldScheduleStalledCheckpointFlush(t *testing.T) {
 	assert.False(t, shouldScheduleStalledCheckpointFlush(intent, threshold))
 }
 
-func TestStalledCheckpointFlushAgeMatchesIntentOldAge(t *testing.T) {
-	assert.Equal(t, checkpointIntentOldAge, stalledCheckpointFlushAge)
+func TestStalledCheckpointFlushAgeFollowsFlushCadence(t *testing.T) {
+	assert.Equal(t, 20*time.Millisecond, deriveStalledCheckpointFlushAge(10*time.Millisecond))
+	assert.Equal(t, maxStalledCheckpointFlushAge, deriveStalledCheckpointFlushAge(time.Minute))
+	assert.Equal(t, maxStalledCheckpointFlushAge, deriveStalledCheckpointFlushAge(0))
 }
 
 func TestMakeStalledCheckpointFlushEntry(t *testing.T) {
@@ -119,9 +121,10 @@ func TestMakeStalledCheckpointFlushEntry(t *testing.T) {
 }
 
 func TestPickStalledCheckpointFlushEntryAlternatesWithNormal(t *testing.T) {
+	age := 10 * time.Millisecond
 	intent := NewCheckpointEntry("", types.BuildTS(2, 0), types.BuildTS(5, 0), ET_Incremental)
-	intent.bornTime = time.Now().Add(-stalledCheckpointFlushAge - time.Second)
-	flusher := &flushImpl{}
+	intent.bornTime = time.Now().Add(-age - time.Second)
+	flusher := &flushImpl{stalledCheckpointFlushAge: age}
 
 	assert.True(t, flusher.pickStalledCheckpointFlushEntry(intent))
 	assert.False(t, flusher.pickStalledCheckpointFlushEntry(intent))
@@ -187,6 +190,43 @@ func TestCheckpointBoundedScheduleDoesNotResetFlushDeadline(t *testing.T) {
 	assert.True(t, flushScheduleForce.resetFlushDeadline())
 }
 
+func TestCheckpointBoundedScanIncludesObjectsBeforeLastCheckpoint(t *testing.T) {
+	table := catalog.MockStaloneTableEntry(1, catalog.NewEmptySchema("test"))
+	beforeCheckpoint := catalog.NewStandaloneObject(table, types.BuildTS(1, 0), false)
+	afterCheckpoint := catalog.NewStandaloneObject(table, types.BuildTS(3, 0), false)
+	table.AddEntryLocked(beforeCheckpoint)
+	table.AddEntryLocked(afterCheckpoint)
+
+	lastCkp := types.BuildTS(2, 0)
+	end := types.BuildTS(4, 0)
+	var boundedObjects []*catalog.ObjectEntry
+	foreachAobjBefore(
+		context.Background(),
+		table,
+		end,
+		flushScheduleCheckpointBounded.objectScanLowerBound(lastCkp),
+		func(obj *catalog.ObjectEntry) {
+			boundedObjects = append(boundedObjects, obj)
+		},
+		func(*catalog.ObjectEntry) {},
+	)
+	assert.ElementsMatch(t, []*catalog.ObjectEntry{beforeCheckpoint, afterCheckpoint}, boundedObjects)
+	assert.Equal(t, types.TS{}, flushScheduleForce.objectScanLowerBound(lastCkp))
+
+	var cronObjects []*catalog.ObjectEntry
+	foreachAobjBefore(
+		context.Background(),
+		table,
+		end,
+		flushScheduleCron.objectScanLowerBound(lastCkp),
+		func(obj *catalog.ObjectEntry) {
+			cronObjects = append(cronObjects, obj)
+		},
+		func(*catalog.ObjectEntry) {},
+	)
+	assert.Equal(t, []*catalog.ObjectEntry{afterCheckpoint}, cronObjects)
+}
+
 func TestCheckpointBoundedFlushDoesNotResetTableDeadline(t *testing.T) {
 	flusher := &flushImpl{flushInterval: time.Hour}
 	table := catalog.MockStaloneTableEntry(1, catalog.NewEmptySchema("test"))
@@ -215,19 +255,21 @@ func TestCheckpointBoundedFlushDoesNotResetTableDeadline(t *testing.T) {
 }
 
 func TestTriggerJobFallsBackToNormalWhenBoundedEntryIsEmpty(t *testing.T) {
+	age := 10 * time.Millisecond
 	intentStart := types.BuildTS(2, 0)
 	intentEnd := types.BuildTS(5, 0)
 	intent := NewCheckpointEntry("", intentStart, intentEnd, ET_Incremental)
-	intent.bornTime = time.Now().Add(-stalledCheckpointFlushAge - time.Second)
+	intent.bornTime = time.Now().Add(-age - time.Second)
 
 	normal := newTestDirtyTreeEntry(types.BuildTS(1, 0), types.BuildTS(10, 0), 1)
 	sourcer := &triggerJobFallbackCollector{normal: normal}
 	scheduler := &triggerJobCheckpointScheduler{pending: intent}
 	queue := newFlushRequestQueue()
 	flusher := &flushImpl{
-		sourcer:            sourcer,
-		checkpointSchduler: scheduler,
-		flushRequestQ:      queue,
+		sourcer:                   sourcer,
+		checkpointSchduler:        scheduler,
+		flushRequestQ:             queue,
+		stalledCheckpointFlushAge: age,
 	}
 
 	flusher.triggerJob(context.Background())
@@ -246,18 +288,20 @@ func TestTriggerJobFallsBackToNormalWhenBoundedEntryIsEmpty(t *testing.T) {
 }
 
 func TestTriggerJobEnqueuesBoundedFlushWhenStalledCheckpointHasDirtyEntry(t *testing.T) {
+	age := 10 * time.Millisecond
 	intentStart := types.BuildTS(2, 0)
 	intentEnd := types.BuildTS(5, 0)
 	intent := NewCheckpointEntry("", intentStart, intentEnd, ET_Incremental)
-	intent.bornTime = time.Now().Add(-stalledCheckpointFlushAge - time.Second)
+	intent.bornTime = time.Now().Add(-age - time.Second)
 
 	sourcer := &triggerJobBoundedCollector{}
 	scheduler := &triggerJobCheckpointScheduler{pending: intent}
 	queue := newFlushRequestQueue()
 	flusher := &flushImpl{
-		sourcer:            sourcer,
-		checkpointSchduler: scheduler,
-		flushRequestQ:      queue,
+		sourcer:                   sourcer,
+		checkpointSchduler:        scheduler,
+		flushRequestQ:             queue,
+		stalledCheckpointFlushAge: age,
 	}
 
 	flusher.triggerJob(context.Background())


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [ ] Improvement
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes

Fixes #26260.

## What this PR does / why we need it

`TestAppend2` exposed a real checkpoint-progress gap rather than a slow-runner problem.

The checkpoint completion predicate waits for every active appendable object at or before the checkpoint end. The stalled-checkpoint flush path, however, selected objects using the previous checkpoint as a creation-time lower bound. Since appendable-object creation moved outside append transactions, an object can be created before the previous checkpoint and receive committed appends afterward. In that state the checkpoint correctly keeps waiting, but the recovery flush can never select the blocking object.

This change aligns the recovery side with the completion predicate:

- checkpoint-bounded and forced flushes scan all active appendable objects up to their request end;
- normal cron flushes retain the existing previous-checkpoint lower bound, preserving their steady-state scan cost;
- stalled-checkpoint recovery now follows the configured flush cadence (two flush intervals), capped at the historical two-minute production threshold. The default production configuration therefore remains unchanged, while intentionally fast test configurations recover promptly.

The existing `TestAppend2` timeout, concurrent append workload, full-row scan, checkpoint completion assertion, and duplicate-append failure assertion are unchanged.

## Validation

- focused checkpoint recovery tests: pass (`0.039s`)
- `go test -race ./pkg/vm/engine/tae/db/checkpoint`: pass (`1.152s`)
- `TestAppend2 -race -count=20`: pass; `4.352s` after vs `4.533s` clean-main baseline
- `go test ./pkg/vm/engine/tae/db/test`: pass (`53.004s`)
- `go test -race ./pkg/vm/engine/tae/db/test`: pass (`68.188s`)
- `go vet ./pkg/vm/engine/tae/db/checkpoint`: pass
- `git diff --check`: pass

No timeout was increased and no coverage assertion was removed or weakened.
