### PR TITLE
fix(frontend): stop routine manager worker cleanly

### DIFF
--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -10081,7 +10081,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10136,7 +10136,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10191,7 +10191,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10242,7 +10242,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10294,7 +10294,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10342,7 +10342,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10397,7 +10397,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10442,7 +10442,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10491,7 +10491,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10540,7 +10540,7 @@ func Test_doAlterAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10615,7 +10615,7 @@ func Test_doDropAccount(t *testing.T) {
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 		ctx = defines.AttachAccountId(ctx, 0)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10680,7 +10680,7 @@ func Test_doDropAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10727,7 +10727,7 @@ func Test_doDropAccount(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		//no result set
@@ -10775,7 +10775,7 @@ func Test_doDropAccount_InTransaction(t *testing.T) {
 			ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 			ctx = defines.AttachAccountId(ctx, 0)
 
-			rm, _ := NewRoutineManager(ctx, "")
+			rm := newTestRoutineManager(t, ctx)
 			ses.rm = rm
 
 			// Setup SQL results
@@ -10845,7 +10845,7 @@ func Test_doDropAccount_InTransaction(t *testing.T) {
 			ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 			ctx = defines.AttachAccountId(ctx, 0)
 
-			rm, _ := NewRoutineManager(ctx, "")
+			rm := newTestRoutineManager(t, ctx)
 			ses.rm = rm
 
 			// Setup SQL results (no begin; needed)
@@ -14123,7 +14123,7 @@ func TestDoDropStage(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		tenant := &TenantInfo{
@@ -14178,7 +14178,7 @@ func TestDoDropStage(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		tenant := &TenantInfo{
@@ -14233,7 +14233,7 @@ func TestDoDropStage(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		tenant := &TenantInfo{
@@ -14286,7 +14286,7 @@ func TestDoDropStage(t *testing.T) {
 		pu.SV.KillRountinesInterval = 0
 		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
 
-		rm, _ := NewRoutineManager(ctx, "")
+		rm := newTestRoutineManager(t, ctx)
 		ses.rm = rm
 
 		tenant := &TenantInfo{

--- a/pkg/frontend/iceberg.go
+++ b/pkg/frontend/iceberg.go
@@ -478,11 +478,5 @@ func ensureIcebergFeatureEnabledForSession(ctx context.Context, ses interface {
 }
 
 func icebergParameterUnitForService(service string) *moconfig.ParameterUnit {
-	vars := getServerLevelVars(service)
-	if vars == nil {
-		return nil
-	}
-	value := vars.Pu.Load()
-	pu, _ := value.(*moconfig.ParameterUnit)
-	return pu
+	return getPuIfPresent(service)
 }

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -45,6 +45,7 @@ type RoutineManager struct {
 	clients                map[*Conn]*Routine
 	workerWG               sync.WaitGroup
 	cleanKillQueueInterval time.Duration
+	pu                     *config.ParameterUnit
 	// routinesByID keeps the routines by connection ID.
 	routinesByConnID map[uint32]*Routine
 	tlsConfig        *tls.Config
@@ -253,12 +254,12 @@ func (rm *RoutineManager) getTlsConfig() *tls.Config {
 
 func (rm *RoutineManager) getConnID() (uint32, error) {
 	// Only works in unit test.
-	if getPu(rm.service).HAKeeperClient == nil {
+	if rm.pu.HAKeeperClient == nil {
 		return nextConnectionID(), nil
 	}
 	ctx, cancel := context.WithTimeoutCause(rm.ctx, time.Second*2, moerr.CauseGetConnID)
 	defer cancel()
-	connID, err := getPu(rm.service).HAKeeperClient.AllocateIDByKey(ctx, ConnIDAllocKey)
+	connID, err := rm.pu.HAKeeperClient.AllocateIDByKey(ctx, ConnIDAllocKey)
 	if err != nil {
 		return 0, moerr.AttachCause(ctx, err)
 	}
@@ -290,12 +291,9 @@ func (rm *RoutineManager) Created(rs *Conn) error {
 		logutil.Errorf("failed to get connection ID from HAKeeper: %v", err)
 		return err
 	}
-	sid := ""
-	if rm.baseService != nil {
-		sid = rm.baseService.ID()
-	}
-	pro := NewMysqlClientProtocol(sid, connID, rs, int(getPu(rm.service).SV.MaxBytesInOutbufToFlush), getPu(rm.service).SV)
-	routine := NewRoutine(rm.getCtx(), pro, getPu(rm.service).SV)
+	sid := rm.service
+	pro := NewMysqlClientProtocol(sid, connID, rs, int(rm.pu.SV.MaxBytesInOutbufToFlush), rm.pu.SV)
+	routine := NewRoutine(rm.getCtx(), pro, rm.pu.SV)
 	v2.CreatedRoutineCounter.Inc()
 
 	cancelCtx := routine.getCancelRoutineCtx()
@@ -324,7 +322,7 @@ func (rm *RoutineManager) Created(rs *Conn) error {
 	ses.Debugf(cancelCtx, "have done some preparation for the connection %s", rs.RemoteAddress())
 
 	// With proxy module enabled, we try to update salt value and label info from proxy.
-	if getPu(rm.service).SV.ProxyEnabled {
+	if rm.pu.SV.ProxyEnabled {
 		pro.receiveExtraInfo(rs)
 	}
 	rm.setRoutine(rs, pro.connectionID, routine)
@@ -591,9 +589,22 @@ func (rm *RoutineManager) startKillRoutineWorker(interval time.Duration) {
 
 func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	pu, ok := ctx.Value(config.ParameterUnitKey).(*config.ParameterUnit)
-	if !ok || pu == nil {
-		pu = getPuIfPresent(service)
+	contextPU, _ := ctx.Value(config.ParameterUnitKey).(*config.ParameterUnit)
+	if contextPU != nil && contextPU.SV == nil {
+		cancel()
+		return nil, moerr.NewInternalError(ctx, "invalid parameter unit")
+	}
+	servicePU := getPuIfPresent(service)
+	pu := servicePU
+	publishPU := false
+	if contextPU != nil {
+		if servicePU == nil {
+			pu = contextPU
+			publishPU = true
+		} else if contextPU != servicePU {
+			cancel()
+			return nil, moerr.NewInternalErrorf(ctx, "parameter unit mismatch for service %q", service)
+		}
 	}
 	if pu == nil || pu.SV == nil {
 		cancel()
@@ -612,6 +623,7 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 		routinesByConnID: make(map[uint32]*Routine),
 		accountRoutine:   accountRoutine,
 		cancel:           cancel,
+		pu:               pu,
 		service:          service,
 	}
 	sv := pu.SV
@@ -622,6 +634,10 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 			cancel()
 			return nil, err
 		}
+	}
+	if publishPU && publishPuIfAbsent(service, pu) != pu {
+		cancel()
+		return nil, moerr.NewInternalErrorf(ctx, "parameter unit mismatch for service %q", service)
 	}
 
 	// add kill connect routine

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -590,11 +590,10 @@ func (rm *RoutineManager) startKillRoutineWorker(interval time.Duration) {
 }
 
 func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	pu, ok := ctx.Value(config.ParameterUnitKey).(*config.ParameterUnit)
 	if !ok || pu == nil {
-		pu = getPu(service)
+		pu = getPuIfPresent(service)
 	}
 	if pu == nil || pu.SV == nil {
 		cancel()

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -596,6 +596,10 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 	if !ok || pu == nil {
 		pu = getPu(service)
 	}
+	if pu == nil || pu.SV == nil {
+		cancel()
+		return nil, moerr.NewInternalError(ctx, "invalid parameter unit")
+	}
 	accountRoutine := &AccountRoutineManager{
 		killQueueMu:       sync.RWMutex{},
 		accountId2Routine: make(map[int64]map[*Routine]uint64),
@@ -613,7 +617,7 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 	}
 	sv := pu.SV
 	rm.cleanKillQueueInterval = time.Duration(sv.CleanKillQueueInterval) * time.Minute
-	if sv != nil && sv.EnableTls {
+	if sv.EnableTls {
 		err := initTlsConfig(rm, sv)
 		if err != nil {
 			cancel()

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -40,9 +40,11 @@ import (
 )
 
 type RoutineManager struct {
-	mu      sync.RWMutex
-	ctx     context.Context
-	clients map[*Conn]*Routine
+	mu                     sync.RWMutex
+	ctx                    context.Context
+	clients                map[*Conn]*Routine
+	workerWG               sync.WaitGroup
+	cleanKillQueueInterval time.Duration
 	// routinesByID keeps the routines by connection ID.
 	routinesByConnID map[uint32]*Routine
 	tlsConfig        *tls.Config
@@ -452,13 +454,12 @@ func (rm *RoutineManager) cleanKillQueue() {
 	ar := rm.accountRoutine
 	ar.killQueueMu.Lock()
 	defer ar.killQueueMu.Unlock()
-	pu := getPu(rm.service)
-	if pu != nil && pu.SV != nil {
-		tout := pu.SV.CleanKillQueueInterval
-		for toKillAccount, killRecord := range ar.killIdQueue {
-			if time.Since(killRecord.killTime) > time.Duration(tout)*time.Minute {
-				delete(ar.killIdQueue, toKillAccount)
-			}
+	if rm.cleanKillQueueInterval <= 0 {
+		return
+	}
+	for toKillAccount, killRecord := range ar.killIdQueue {
+		if time.Since(killRecord.killTime) > rm.cleanKillQueueInterval {
+			delete(ar.killIdQueue, toKillAccount)
 		}
 	}
 }
@@ -541,11 +542,10 @@ func (rm *RoutineManager) cancelCtx() {
 	if rm == nil {
 		return
 	}
-	rm.mu.Lock()
-	defer rm.mu.Unlock()
 	if rm.cancel != nil {
 		rm.cancel()
 	}
+	rm.workerWG.Wait()
 }
 
 func (rm *RoutineManager) killNetConns() {
@@ -564,6 +564,10 @@ func (rm *RoutineManager) killNetConns() {
 func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
+	pu, ok := ctx.Value(config.ParameterUnitKey).(*config.ParameterUnit)
+	if !ok || pu == nil {
+		pu = getPu(service)
+	}
 	accountRoutine := &AccountRoutineManager{
 		killQueueMu:       sync.RWMutex{},
 		accountId2Routine: make(map[int64]map[*Routine]uint64),
@@ -579,31 +583,39 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 		cancel:           cancel,
 		service:          service,
 	}
-	pu := getPu(rm.service)
 	sv := pu.SV
+	rm.cleanKillQueueInterval = time.Duration(sv.CleanKillQueueInterval) * time.Minute
 	if sv != nil && sv.EnableTls {
 		err := initTlsConfig(rm, sv)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 	}
 
 	// add kill connect routine
-	tout := pu.SV.KillRountinesInterval
-	if tout != 0 {
+	interval := time.Duration(sv.KillRountinesInterval) * time.Second
+	if interval > 0 {
+		rm.workerWG.Add(1)
 		go func() {
+			defer rm.workerWG.Done()
+			select {
+			case <-rm.ctx.Done():
+				return
+			default:
+			}
+			rm.KillRoutineConnections()
+
+			timer := time.NewTimer(interval)
+			defer timer.Stop()
 			for {
 				select {
 				case <-rm.ctx.Done():
 					return
-				default:
+				case <-timer.C:
 				}
 				rm.KillRoutineConnections()
-				if tout != 0 {
-					time.Sleep(time.Duration(tout) * time.Second)
-				} else {
-					break
-				}
+				timer.Reset(interval)
 			}
 		}()
 	}

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -561,6 +561,34 @@ func (rm *RoutineManager) killNetConns() {
 	}
 }
 
+func (rm *RoutineManager) startKillRoutineWorker(interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	rm.workerWG.Add(1)
+	go func() {
+		defer rm.workerWG.Done()
+		select {
+		case <-rm.ctx.Done():
+			return
+		default:
+		}
+		rm.KillRoutineConnections()
+
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
+		for {
+			select {
+			case <-rm.ctx.Done():
+				return
+			case <-timer.C:
+			}
+			rm.KillRoutineConnections()
+			timer.Reset(interval)
+		}
+	}()
+}
+
 func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
@@ -595,30 +623,7 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 
 	// add kill connect routine
 	interval := time.Duration(sv.KillRountinesInterval) * time.Second
-	if interval > 0 {
-		rm.workerWG.Add(1)
-		go func() {
-			defer rm.workerWG.Done()
-			select {
-			case <-rm.ctx.Done():
-				return
-			default:
-			}
-			rm.KillRoutineConnections()
-
-			timer := time.NewTimer(interval)
-			defer timer.Stop()
-			for {
-				select {
-				case <-rm.ctx.Done():
-					return
-				case <-timer.C:
-				}
-				rm.KillRoutineConnections()
-				timer.Reset(interval)
-			}
-		}()
-	}
+	rm.startKillRoutineWorker(interval)
 
 	return rm, nil
 }

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -374,12 +374,10 @@ func Test_rm(t *testing.T) {
 	pu := config.NewParameterUnit(sv, nil, nil, nil)
 	pu.SV.SkipCheckUser = true
 	pu.SV.KillRountinesInterval = 1
-	setPu("", pu)
-	rm, err := NewRoutineManager(context.Background(), "")
+	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, pu)
+	rm, err := NewRoutineManager(ctx, "")
 	assert.NoError(t, err)
 	rm.cleanKillQueue()
-	setPu("", nil)
-	time.Sleep(2 * time.Second)
 	rm.cancelCtx()
 }
 
@@ -453,9 +451,10 @@ func TestRoutineManagerKillAndCleanKillQueue(t *testing.T) {
 	ses := &Session{}
 	rt.setSession(ses)
 	rm := &RoutineManager{
-		ctx:              context.Background(),
-		clients:          make(map[*Conn]*Routine),
-		routinesByConnID: map[uint32]*Routine{1003: rt},
+		ctx:                    context.Background(),
+		clients:                make(map[*Conn]*Routine),
+		routinesByConnID:       map[uint32]*Routine{1003: rt},
+		cleanKillQueueInterval: time.Minute,
 		accountRoutine: &AccountRoutineManager{
 			killIdQueue:       make(map[int64]KillRecord),
 			accountId2Routine: make(map[int64]map[*Routine]uint64),
@@ -475,8 +474,6 @@ func TestRoutineManagerKillAndCleanKillQueue(t *testing.T) {
 	require.NoError(t, rm.kill(context.Background(), true, 1, 1003, ""))
 	require.True(t, rt.isCancelled())
 
-	pu := getPu("")
-	pu.SV.CleanKillQueueInterval = 1
 	rm.accountRoutine.killIdQueue[1] = NewKillRecord(time.Now().Add(-2*time.Minute), 1)
 	rm.accountRoutine.killIdQueue[2] = NewKillRecord(time.Now(), 1)
 	rm.cleanKillQueue()
@@ -495,13 +492,40 @@ func TestRoutineManagerKillRoutineConnections(t *testing.T) {
 		},
 	}
 	rm := &RoutineManager{
-		accountRoutine: ar,
-		service:        "",
+		accountRoutine:         ar,
+		service:                "",
+		cleanKillQueueInterval: time.Minute,
 	}
 
 	rm.KillRoutineConnections()
 	require.True(t, rt.isCancelled())
 	require.NotContains(t, ar.accountId2Routine, int64(20))
+}
+
+func TestRoutineManagerConfigSnapshotAndCancel(t *testing.T) {
+	pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+	pu.SV.SetDefaultValues()
+	pu.SV.KillRountinesInterval = 3600
+	pu.SV.CleanKillQueueInterval = 2
+	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, pu)
+
+	rm, err := NewRoutineManager(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Minute, rm.cleanKillQueueInterval)
+
+	pu.SV.CleanKillQueueInterval = 3
+	require.Equal(t, 2*time.Minute, rm.cleanKillQueueInterval)
+
+	done := make(chan struct{})
+	go func() {
+		rm.cancelCtx()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RoutineManager worker did not stop after cancellation")
+	}
 }
 
 func TestRoutineManagerMigrationAndResetErrorBranches(t *testing.T) {

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -552,6 +552,27 @@ func TestRoutineManagerRejectsMissingFrontendParameters(t *testing.T) {
 	require.ErrorContains(t, err, "invalid parameter unit")
 }
 
+func TestRoutineManagerRejectsMissingParameterUnit(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		initializeService bool
+	}{
+		{name: "uninitialized service"},
+		{name: "initialized service", initializeService: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			service := t.Name()
+			if tc.initializeService {
+				InitServerLevelVars(service)
+			}
+
+			rm, err := NewRoutineManager(context.Background(), service)
+			require.Nil(t, rm)
+			require.ErrorContains(t, err, "invalid parameter unit")
+		})
+	}
+}
+
 func TestRoutineManagerCancelWaitsForActiveWorker(t *testing.T) {
 	rt, proto := newUnitTestRoutine(t, 1007)
 	blockingConn := &blockingCloseConn{

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -111,6 +111,21 @@ type testConn struct {
 	rbuf   []byte
 }
 
+type blockingCloseConn struct {
+	testConn
+	closeStarted chan struct{}
+	closeRelease chan struct{}
+	startOnce    sync.Once
+}
+
+func (tc *blockingCloseConn) Close() error {
+	tc.startOnce.Do(func() {
+		close(tc.closeStarted)
+	})
+	<-tc.closeRelease
+	return nil
+}
+
 func (tc *testConn) Read(b []byte) (n int, err error) {
 	if tc.mod == testConnModReadReturnErr {
 		return 0, moerr.NewInternalErrorNoCtx("test conn read returns error")
@@ -525,6 +540,65 @@ func TestRoutineManagerConfigSnapshotAndCancel(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("RoutineManager worker did not stop after cancellation")
+	}
+}
+
+func TestRoutineManagerCancelWaitsForActiveWorker(t *testing.T) {
+	rt, proto := newUnitTestRoutine(t, 1007)
+	blockingConn := &blockingCloseConn{
+		closeStarted: make(chan struct{}),
+		closeRelease: make(chan struct{}),
+	}
+	proto.tcpConn.conn = blockingConn
+
+	const accountID = int64(21)
+	ctx, cancel := context.WithCancel(context.Background())
+	rm := &RoutineManager{
+		ctx:                    ctx,
+		cancel:                 cancel,
+		cleanKillQueueInterval: time.Hour,
+		accountRoutine: &AccountRoutineManager{
+			killIdQueue: map[int64]KillRecord{
+				accountID: NewKillRecord(time.Now(), 1),
+			},
+			accountId2Routine: map[int64]map[*Routine]uint64{
+				accountID: {rt: 1},
+			},
+		},
+	}
+	releaseWorker := sync.OnceFunc(func() {
+		close(blockingConn.closeRelease)
+	})
+	t.Cleanup(func() {
+		releaseWorker()
+		rm.cancelCtx()
+	})
+
+	rm.startKillRoutineWorker(time.Hour)
+	select {
+	case <-blockingConn.closeStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RoutineManager worker did not enter connection close")
+	}
+
+	cancelReturned := make(chan struct{})
+	go func() {
+		rm.cancelCtx()
+		close(cancelReturned)
+	}()
+	<-ctx.Done()
+
+	select {
+	case <-cancelReturned:
+		t.Fatal("RoutineManager cancellation returned before active worker exited")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseWorker()
+	select {
+	case <-cancelReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RoutineManager cancellation did not return after active worker exited")
 	}
 }
 

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -543,6 +543,15 @@ func TestRoutineManagerConfigSnapshotAndCancel(t *testing.T) {
 	}
 }
 
+func TestRoutineManagerRejectsMissingFrontendParameters(t *testing.T) {
+	pu := config.NewParameterUnit(nil, nil, nil, nil)
+	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, pu)
+
+	rm, err := NewRoutineManager(ctx, "")
+	require.Nil(t, rm)
+	require.ErrorContains(t, err, "invalid parameter unit")
+}
+
 func TestRoutineManagerCancelWaitsForActiveWorker(t *testing.T) {
 	rt, proto := newUnitTestRoutine(t, 1007)
 	blockingConn := &blockingCloseConn{

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -23,10 +23,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -40,6 +40,23 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+var nextRoutineManagerTestServiceID atomic.Uint64
+
+func newRoutineManagerTestService(t *testing.T) string {
+	t.Helper()
+	return t.Name() + "/routine-manager-" +
+		strconv.FormatUint(nextRoutineManagerTestServiceID.Add(1), 10)
+}
+
+func newTestRoutineManager(t *testing.T, ctx context.Context) *RoutineManager {
+	t.Helper()
+	service := newRoutineManagerTestService(t)
+	rm, err := NewRoutineManager(ctx, service)
+	require.NoError(t, err)
+	t.Cleanup(rm.cancelCtx)
+	return rm
+}
 
 func Test_Closed(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
@@ -390,10 +407,8 @@ func Test_rm(t *testing.T) {
 	pu.SV.SkipCheckUser = true
 	pu.SV.KillRountinesInterval = 1
 	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, pu)
-	rm, err := NewRoutineManager(ctx, "")
-	assert.NoError(t, err)
+	rm := newTestRoutineManager(t, ctx)
 	rm.cleanKillQueue()
-	rm.cancelCtx()
 }
 
 func TestRoutineManagerRoutineMaps(t *testing.T) {
@@ -524,8 +539,7 @@ func TestRoutineManagerConfigSnapshotAndCancel(t *testing.T) {
 	pu.SV.CleanKillQueueInterval = 2
 	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, pu)
 
-	rm, err := NewRoutineManager(ctx, "")
-	require.NoError(t, err)
+	rm := newTestRoutineManager(t, ctx)
 	require.Equal(t, 2*time.Minute, rm.cleanKillQueueInterval)
 
 	pu.SV.CleanKillQueueInterval = 3
@@ -547,7 +561,7 @@ func TestRoutineManagerRejectsMissingFrontendParameters(t *testing.T) {
 	pu := config.NewParameterUnit(nil, nil, nil, nil)
 	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, pu)
 
-	rm, err := NewRoutineManager(ctx, "")
+	rm, err := NewRoutineManager(ctx, t.Name())
 	require.Nil(t, rm)
 	require.ErrorContains(t, err, "invalid parameter unit")
 }
@@ -561,7 +575,7 @@ func TestRoutineManagerRejectsMissingParameterUnit(t *testing.T) {
 		{name: "initialized service", initializeService: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			service := t.Name()
+			service := newRoutineManagerTestService(t)
 			if tc.initializeService {
 				InitServerLevelVars(service)
 			}
@@ -571,6 +585,69 @@ func TestRoutineManagerRejectsMissingParameterUnit(t *testing.T) {
 			require.ErrorContains(t, err, "invalid parameter unit")
 		})
 	}
+}
+
+func TestRoutineManagerPublishesContextParameterUnit(t *testing.T) {
+	service := newRoutineManagerTestService(t)
+	pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+	pu.SV.SetDefaultValues()
+	pu.SV.KillRountinesInterval = 0
+	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, pu)
+
+	rm, err := NewRoutineManager(ctx, service)
+	require.NoError(t, err)
+	t.Cleanup(rm.cancelCtx)
+	require.Same(t, pu, getPuIfPresent(service))
+
+	conn := &Conn{
+		conn:       &testConn{},
+		remoteAddr: "remote",
+		service:    service,
+	}
+	require.NoError(t, rm.Created(conn))
+	require.NotNil(t, rm.getRoutine(conn))
+	rm.Closed(conn)
+	require.Nil(t, rm.getRoutine(conn))
+}
+
+func TestRoutineManagerRejectsParameterUnitMismatch(t *testing.T) {
+	service := newRoutineManagerTestService(t)
+	servicePU := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+	servicePU.SV.SetDefaultValues()
+	InitServerLevelVars(service)
+	setPu(service, servicePU)
+
+	contextPU := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+	contextPU.SV.SetDefaultValues()
+	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, contextPU)
+
+	rm, err := NewRoutineManager(ctx, service)
+	require.Nil(t, rm)
+	require.ErrorContains(t, err, "parameter unit mismatch")
+	require.Same(t, servicePU, getPuIfPresent(service))
+}
+
+func TestRoutineManagerFailedInitializationDoesNotPublishParameterUnit(t *testing.T) {
+	service := newRoutineManagerTestService(t)
+	invalidPU := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+	invalidPU.SV.SetDefaultValues()
+	invalidPU.SV.EnableTls = true
+	ctx := context.WithValue(context.Background(), config.ParameterUnitKey, invalidPU)
+
+	rm, err := NewRoutineManager(ctx, service)
+	require.Nil(t, rm)
+	require.ErrorContains(t, err, "cert file or key file is empty")
+	require.Nil(t, getPuIfPresent(service))
+
+	validPU := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+	validPU.SV.SetDefaultValues()
+	validPU.SV.KillRountinesInterval = 0
+	ctx = context.WithValue(context.Background(), config.ParameterUnitKey, validPU)
+
+	rm, err = NewRoutineManager(ctx, service)
+	require.NoError(t, err)
+	t.Cleanup(rm.cancelCtx)
+	require.Same(t, validPU, getPuIfPresent(service))
 }
 
 func TestRoutineManagerCancelWaitsForActiveWorker(t *testing.T) {

--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -580,6 +580,19 @@ func SetPUForExternalUT(service string, pu *config.ParameterUnit) {
 	setPu(service, pu)
 }
 
+func getPuIfPresent(service string) *config.ParameterUnit {
+	vars := getServerLevelVars(service)
+	if vars == nil {
+		return nil
+	}
+	value := vars.Pu.Load()
+	if value == nil {
+		return nil
+	}
+	pu, _ := value.(*config.ParameterUnit)
+	return pu
+}
+
 func getPu(service string) *config.ParameterUnit {
 	return getServerLevelVars(service).Pu.Load().(*config.ParameterUnit)
 }

--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -576,6 +576,15 @@ func setPu(service string, pu *config.ParameterUnit) {
 	getServerLevelVars(service).Pu.Store(pu)
 }
 
+func publishPuIfAbsent(service string, pu *config.ParameterUnit) *config.ParameterUnit {
+	InitServerLevelVars(service)
+	vars := getServerLevelVars(service)
+	if vars.Pu.CompareAndSwap(nil, pu) {
+		return pu
+	}
+	return vars.Pu.Load().(*config.ParameterUnit)
+}
+
 func SetPUForExternalUT(service string, pu *config.ParameterUnit) {
 	setPu(service, pu)
 }
@@ -594,7 +603,11 @@ func getPuIfPresent(service string) *config.ParameterUnit {
 }
 
 func getPu(service string) *config.ParameterUnit {
-	return getServerLevelVars(service).Pu.Load().(*config.ParameterUnit)
+	pu := getPuIfPresent(service)
+	if pu == nil {
+		panic("parameter unit is not initialized")
+	}
+	return pu
 }
 
 func setAicm(service string, aicm *defines.AutoIncrCacheManager) {

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -9463,7 +9463,9 @@ func TestSessionCloseRetainsCleanupWhenRetainedCapIsFull(t *testing.T) {
 	runUserLevelLockTest(t, func(services []lockservice.LockService) {
 		service := services[0].(*userLevelLockTestService)
 		service.blockUnlock.Store(true)
+		defer service.blockUnlock.Store(false)
 		holder := newUserLevelLockTestProcess(t, services[0], "acc")
+		contender := newUserLevelLockTestProcess(t, services[1], "acc")
 		name := "close_capacity_full"
 		v, err := getUserLevelLock(name, 0, holder)
 		require.NoError(t, err)
@@ -9493,6 +9495,10 @@ func TestSessionCloseRetainsCleanupWhenRetainedCapIsFull(t *testing.T) {
 		}
 		fillDetachedUserLevelLockCleanupAdmissionForTest(service, firstKey, chunks[0])
 		detachedUserLevelLockCleanups.Lock()
+		// Keep the synthetic backlog saturated. Starting its consumer here would
+		// make capacity availability depend on goroutine scheduling and allow the
+		// close cleanup to bypass the retained fallback this test exercises.
+		detachedUserLevelLockCleanups.backlogStarted = true
 		for i := 0; i < userLevelLockDetachedCleanupBacklog; i++ {
 			detachedUserLevelLockCleanups.backlog <- detachedUserLevelLockCleanupRequest{
 				ls:     service,
@@ -9508,6 +9514,43 @@ func TestSessionCloseRetainsCleanupWhenRetainedCapIsFull(t *testing.T) {
 		userLevelLocks.Unlock()
 		require.True(t, retained)
 		require.NotEmpty(t, UserLevelLocksForMigration(holder))
+
+		// Remove only the synthetic admission pressure, then verify the durable
+		// outcome. The retained worker may win the race with this explicit pass,
+		// so neither its transient map entry nor per-call progress is an oracle.
+		service.blockUnlock.Store(false)
+		detachedUserLevelLockCleanups.Lock()
+		detachedUserLevelLockCleanups.entries = make(map[detachedUserLevelLockCleanupKey]*detachedUserLevelLockCleanupEntry)
+		for {
+			select {
+			case <-detachedUserLevelLockCleanups.queue:
+			default:
+				goto closeCapacityQueueDrained
+			}
+		}
+	closeCapacityQueueDrained:
+		for {
+			select {
+			case <-detachedUserLevelLockCleanups.backlog:
+			default:
+				goto closeCapacityBacklogDrained
+			}
+		}
+	closeCapacityBacklogDrained:
+		detachedUserLevelLockCleanups.Unlock()
+		_, _ = runRetainedUserLevelLockCleanupPass()
+
+		row := string(userLevelLockRow(holder, name))
+		require.Eventually(t, func() bool {
+			service.state.Lock()
+			held := service.state.locks[row]
+			service.state.Unlock()
+			return held == "" && len(UserLevelLocksForMigration(holder)) == 0
+		}, 3*time.Second, 10*time.Millisecond)
+
+		v, err = getUserLevelLock(name, 0, contender)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
 	})
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26267

## What this PR does / why we need it:

A frontend race UT exposed two coupled problems: `RoutineManager` background workers read mutable shared configuration, and cancellation did not wait for a worker to exit. A test modifying the global `CleanKillQueueInterval` could therefore race with a worker leaked by an earlier test.

This change:

- captures the worker and kill-queue intervals from the constructor ParameterUnit;
- honors the ParameterUnit carried by the constructor context, with the service-level PU as fallback;
- makes the periodic wait cancellation-aware and joins the worker during cancellation;
- removes shared PU mutation and a 2-second sleep from the related tests;
- adds a deterministic, zero-sleep test for configuration snapshot and worker shutdown.

The immediate-first-run and delay-after-work scheduling semantics are preserved. No long-running stress test is added.

Validation:

- focused related tests: PASS
- focused `-race -count=3`: PASS
- full `pkg/frontend`: PASS (14.6s)
- full `pkg/frontend -race`: PASS (21.4s)
- `go build ./pkg/frontend`: PASS
- `go vet ./pkg/frontend`: PASS