### PR TITLE
fix: distribute sink scan shuffle hashbuild

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -5467,7 +5467,7 @@ func scopeTreeHasCrossCNDispatch(s *Scope) bool {
 // doSetRootOperator) appends a connector *on top of* that existing root using AppendChild
 // semantics, so the caller's operator is preserved as the connector's child, not replaced.
 func (c *Compile) groupShuffleBucketsByCNIfNeeded(ss []*Scope) []*Scope {
-	stageNodes := c.queryWorkerStageNodes()
+	stageNodes := shuffleBucketStageNodes(ss)
 	if len(stageNodes) <= 1 || len(ss) <= len(stageNodes) {
 		return ss
 	}
@@ -5482,6 +5482,26 @@ func (c *Compile) groupShuffleBucketsByCNIfNeeded(ss []*Scope) []*Scope {
 		return ss
 	}
 	return c.mergeScopesByStageNodes(ss, stageNodes)
+}
+
+// shuffleBucketStageNodes derives the grouping boundary from the receiver
+// scopes themselves. The receiver set may include a local SINK_SCAN owner that
+// is intentionally absent from the scheduled query-worker set.
+func shuffleBucketStageNodes(ss []*Scope) engine.Nodes {
+	stageNodes := make(engine.Nodes, 0, len(ss))
+	for _, scope := range ss {
+		found := false
+		for _, node := range stageNodes {
+			if sameExecutionNode(node, scope.NodeInfo) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			stageNodes = append(stageNodes, scope.NodeInfo)
+		}
+	}
+	return stageNodes
 }
 
 func (c *Compile) mergeScopesByStageNodes(ss []*Scope, stageNodes engine.Nodes) []*Scope {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -5249,11 +5249,12 @@ func (c *Compile) queryWorkerStageNodes() engine.Nodes {
 	return c.materializeScheduledWorkers(decision.Workers)
 }
 
-// shuffleJoinStageNodes keeps shuffle receivers on the coordinator when either
-// input depends on a SINK_SCAN. SINK_SCAN consumes an in-process PipelineEdge
-// created for another query step; that edge cannot be serialized and registered
-// on a remote CN. The scan/table side may still execute remotely and dispatch to
-// these local shuffle buckets, so hashbuild remains partitioned and spillable.
+// shuffleJoinStageNodes keeps the SINK_SCAN producer on its owning CN while
+// allowing the shuffle receivers to use every query worker. SINK_SCAN consumes
+// an in-process PipelineEdge created for another query step, so its scope cannot
+// be serialized to a remote CN. Including its owning CN in the receiver set lets
+// attachShuffleDispatchSource keep that scope local; the following dispatch can
+// still send buckets to hashbuild receivers on the other query workers.
 func (c *Compile) shuffleJoinStageNodes(probeScopes, buildScopes []*Scope) (engine.Nodes, bool) {
 	stageNode, hasSinkScan := sinkScanDependencyNode(probeScopes, buildScopes)
 	if !hasSinkScan {
@@ -5262,8 +5263,13 @@ func (c *Compile) shuffleJoinStageNodes(probeScopes, buildScopes []*Scope) (engi
 	if stageNode.Addr == "" {
 		stageNode = c.materializeScheduledWorker(c.currentCNWorker())
 	}
-	stageNode = scopeNodeWithMcpu(stageNode, 1)
-	return engine.Nodes{stageNode}, true
+	stageNodes := c.queryWorkerStageNodes()
+	for _, node := range stageNodes {
+		if sameExecutionNode(node, stageNode) {
+			return stageNodes, true
+		}
+	}
+	return append(stageNodes, scopeNodeWithMcpu(stageNode, 1)), true
 }
 
 func sinkScanDependencyNode(scopeLists ...[]*Scope) (engine.Node, bool) {

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/dispatch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/external"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/filter"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashjoin"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/limit"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/merge"
@@ -2408,7 +2409,7 @@ func TestRuntimeFilterResultKeepsItsOriginatingSpec(t *testing.T) {
 	}
 }
 
-func TestShuffleJoinStageNodesKeepsSinkScanReceiversLocal(t *testing.T) {
+func TestShuffleJoinStageNodesDistributesReceiversAndKeepsSinkScanWorker(t *testing.T) {
 	c := NewMockCompile(t)
 	c.addr = "cn-local:6001"
 	c.cnList = engine.Nodes{
@@ -2426,13 +2427,184 @@ func TestShuffleJoinStageNodesKeepsSinkScanReceiversLocal(t *testing.T) {
 
 	stageNodes, local := c.shuffleJoinStageNodes([]*Scope{sinkScope}, nil)
 	require.True(t, local)
-	require.Len(t, stageNodes, 1)
+	require.Len(t, stageNodes, 2)
 	require.Equal(t, "cn-local:6001", stageNodes[0].Addr)
+	require.Equal(t, "cn-remote:6001", stageNodes[1].Addr)
 
 	normalScope := &Scope{RootOp: merge.NewArgument()}
 	stageNodes, local = c.shuffleJoinStageNodes([]*Scope{normalScope}, nil)
 	require.False(t, local)
 	require.Len(t, stageNodes, 2)
+
+	c.cnList = engine.Nodes{
+		{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+	}
+	stageNodes, local = c.shuffleJoinStageNodes([]*Scope{sinkScope}, nil)
+	require.True(t, local)
+	require.Len(t, stageNodes, 2)
+	require.Equal(t, "cn-remote:6001", stageNodes[0].Addr)
+	require.Equal(t, "cn-local:6001", stageNodes[1].Addr)
+
+	c.cnList = nil
+	stageNodes, local = c.shuffleJoinStageNodes([]*Scope{sinkScope}, nil)
+	require.True(t, local)
+	require.Len(t, stageNodes, 1)
+	require.Equal(t, "cn-local:6001", stageNodes[0].Addr)
+}
+
+func TestCompileShuffleJoinDistributesSinkScanHashbuild(t *testing.T) {
+	const dop = int32(2)
+	tests := []struct {
+		name        string
+		joinType    plan.Node_JoinType
+		isRightJoin bool
+		sinkOnBuild bool
+	}{
+		{
+			name:     "probe-side sink inner join",
+			joinType: plan.Node_INNER,
+		},
+		{
+			name:        "build-side sink right dedup join",
+			joinType:    plan.Node_DEDUP,
+			isRightJoin: true,
+			sinkOnBuild: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nodes := engine.Nodes{
+				{Id: "cn-local", Addr: "cn-local:6001", Mcpu: int(dop)},
+				{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: int(dop)},
+			}
+			c := newCompileForSinkScanShuffleJoinTest(t, nodes)
+			node := newSinkScanShuffleJoinTestNode(dop)
+			node.JoinType = test.joinType
+			node.IsRightJoin = test.isRightJoin
+			if test.joinType == plan.Node_DEDUP {
+				node.DedupJoinCtx = &plan.DedupJoinCtx{}
+			}
+			left := &plan.Node{Stats: &plan.Stats{Dop: dop}}
+			right := &plan.Node{Stats: &plan.Stats{Dop: dop}}
+
+			sinkMerge := merge.NewArgument().WithSinkScan(true)
+			sinkRoot := projection.NewArgument()
+			sinkRoot.AppendChild(sinkMerge)
+			probe := newSinkScanShuffleJoinTestScope(t, nodes[1])
+			build := newSinkScanShuffleJoinTestScope(t, nodes[1])
+			var sinkScope *Scope
+			if test.sinkOnBuild {
+				build = newSinkScanShuffleJoinTestScope(t, nodes[0])
+				sinkScope = build
+			} else {
+				probe = newSinkScanShuffleJoinTestScope(t, nodes[0])
+				sinkScope = probe
+			}
+			sinkScope.RootOp = sinkRoot
+
+			result := c.compileShuffleJoin(node, left, right, []*Scope{probe}, []*Scope{build})
+
+			require.Len(t, result, len(nodes)*int(dop))
+			hashbuildByCN := make(map[string]int)
+			for _, scope := range result {
+				require.NotNil(t, scope)
+				require.NotEmpty(t, scope.PreScopes)
+				require.IsType(t, &hashbuild.HashBuild{}, scope.PreScopes[0].RootOp)
+				hashbuildByCN[scope.NodeInfo.Addr]++
+				if scope.NodeInfo.Addr == nodes[1].Addr {
+					_, hasSinkScan := sinkScanDependencyNode([]*Scope{scope})
+					require.False(t, hasSinkScan,
+						"the in-process SINK_SCAN dependency must never enter a remote scope tree")
+				}
+			}
+			require.Equal(t, int(dop), hashbuildByCN[nodes[0].Addr])
+			require.Equal(t, int(dop), hashbuildByCN[nodes[1].Addr])
+
+			sinkDispatch, ok := sinkScope.RootOp.(*dispatch.Dispatch)
+			require.True(t, ok)
+			require.Len(t, sinkDispatch.LocalRegs, int(dop))
+			require.Len(t, sinkDispatch.RemoteRegs, int(dop))
+
+			localSinkOwners := 0
+			for _, scope := range result {
+				_, hasSinkScan := sinkScanDependencyNode([]*Scope{scope})
+				if hasSinkScan {
+					localSinkOwners++
+					require.Equal(t, nodes[0].Addr, scope.NodeInfo.Addr)
+				}
+			}
+			require.Equal(t, 1, localSinkOwners,
+				"the local SINK_SCAN producer must be started by exactly one receiver tree")
+
+			grouped := c.groupShuffleBucketsByCNIfNeeded(result)
+			require.Len(t, grouped, len(nodes))
+			for _, scope := range grouped {
+				if scope.NodeInfo.Addr == nodes[1].Addr {
+					require.True(t, checkPipelineStandaloneExecutableAtRemote(scope),
+						"the remote CN bucket group must own every local receiver targeted by its dispatch")
+				}
+			}
+		})
+	}
+}
+
+func newCompileForSinkScanShuffleJoinTest(t *testing.T, nodes engine.Nodes) *Compile {
+	c := NewMockCompile(t)
+	c.addr = nodes[0].Addr
+	c.cnList = nodes
+	c.execType = plan2.ExecTypeAP_MULTICN
+	c.anal = &AnalyzeModule{}
+	return c
+}
+
+func newSinkScanShuffleJoinTestScope(t *testing.T, node engine.Node) *Scope {
+	scope := newScope(Remote)
+	scope.NodeInfo = scopeNodeWithMcpu(node, 1)
+	scope.Proc = testutil.NewProcess(t)
+	scope.setRootOperator(colexec.NewMockOperator())
+	return scope
+}
+
+func newSinkScanShuffleJoinTestNode(dop int32) *plan.Node {
+	leftCol := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_int64)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{
+			RelPos: 1,
+			ColPos: 0,
+		}},
+	}
+	rightCol := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_int64)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{
+			RelPos: 2,
+			ColPos: 0,
+		}},
+	}
+	return &plan.Node{
+		NodeType: plan.Node_JOIN,
+		JoinType: plan.Node_INNER,
+		Stats: &plan.Stats{
+			Dop:      dop,
+			TableCnt: 1000,
+			HashmapStats: &plan.HashMapStats{
+				Shuffle:       true,
+				ShuffleColIdx: 0,
+				ShuffleType:   plan.ShuffleType_Hash,
+				ShuffleMethod: plan.ShuffleMethod_Normal,
+			},
+		},
+		OnList: []*plan.Expr{{
+			Typ: plan.Type{Id: int32(types.T_bool)},
+			Expr: &plan.Expr_F{F: &plan.Function{
+				Args: []*plan.Expr{leftCol, rightCol},
+			}},
+		}},
+		SendMsgList: []plan.MsgHeader{{
+			MsgType: int32(message.MsgJoinMap),
+			MsgTag:  1,
+		}},
+	}
 }
 
 func TestAttachShuffleDispatchSourceFallsBackToFirstReceiver(t *testing.T) {

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -2549,6 +2549,64 @@ func TestCompileShuffleJoinDistributesSinkScanHashbuild(t *testing.T) {
 	}
 }
 
+func TestCompileJoinGroupsExternalSinkScanOwner(t *testing.T) {
+	const dop = int32(2)
+	for _, workerCount := range []int{1, 2} {
+		t.Run(fmt.Sprintf("%d scheduled workers", workerCount), func(t *testing.T) {
+			workers := make(engine.Nodes, workerCount)
+			for i := range workers {
+				workers[i] = engine.Node{
+					Id:   fmt.Sprintf("cn-remote-%d", i),
+					Addr: fmt.Sprintf("cn-remote-%d:6001", i),
+					Mcpu: int(dop),
+				}
+			}
+			owner := engine.Node{
+				Id:   "cn-sink-owner",
+				Addr: "cn-sink-owner:6001",
+				Mcpu: int(dop),
+			}
+			c := newCompileForSinkScanShuffleJoinTest(t, workers)
+			c.addr = owner.Addr
+
+			node := newSinkScanShuffleJoinTestNode(dop)
+			left := &plan.Node{Stats: &plan.Stats{Dop: dop}}
+			right := &plan.Node{Stats: &plan.Stats{Dop: dop}}
+			sinkMerge := merge.NewArgument().WithSinkScan(true)
+			sinkRoot := projection.NewArgument()
+			sinkRoot.AppendChild(sinkMerge)
+			probe := newSinkScanShuffleJoinTestScope(t, owner)
+			probe.RootOp = sinkRoot
+			build := newSinkScanShuffleJoinTestScope(t, workers[0])
+
+			buckets := c.compileJoin(node, left, right, []*Scope{probe}, []*Scope{build})
+			require.Len(t, buckets, (workerCount+1)*int(dop))
+
+			grouped := c.groupShuffleBucketsByCNIfNeeded(buckets)
+			require.Len(t, grouped, workerCount+1)
+
+			groupedByCN := make(map[string]*Scope, len(grouped))
+			sinkOwnerGroups := 0
+			for _, scope := range grouped {
+				groupedByCN[scope.NodeInfo.Addr] = scope
+				_, hasSinkScan := sinkScanDependencyNode([]*Scope{scope})
+				if hasSinkScan {
+					sinkOwnerGroups++
+					require.Equal(t, owner.Addr, scope.NodeInfo.Addr)
+				}
+			}
+			require.Equal(t, 1, sinkOwnerGroups)
+			require.Contains(t, groupedByCN, owner.Addr)
+			for _, worker := range workers {
+				remoteGroup, ok := groupedByCN[worker.Addr]
+				require.True(t, ok)
+				require.True(t, checkPipelineStandaloneExecutableAtRemote(remoteGroup),
+					"each remote CN group must own every receiver targeted by its local dispatches")
+			}
+		})
+	}
+}
+
 func newCompileForSinkScanShuffleJoinTest(t *testing.T, nodes engine.Nodes) *Compile {
 	c := NewMockCompile(t)
 	c.addr = nodes[0].Addr


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25114

## What this PR does / why we need it:

Keep the in-process SINK_SCAN producer on its owning CN.

Distribute shuffle hash-build receivers across all query worker CNs instead of
concentrating them on the coordinator.

Ensure the local SINK_SCAN scope is attached to exactly one local receiver tree
and is never serialized to a remote CN.

Preserve mixed local/remote shuffle dispatch and standalone remote execution.