### PR TITLE
perf(disttae): reduce logtail replay allocations (cherry-pick #26234)

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -687,27 +687,18 @@ func (p *PartitionState) HandleRowsDelete(
 	ctx context.Context,
 	input *api.Batch,
 	packer *types.Packer,
-	pool *mpool.MPool,
+	_ *mpool.MPool,
 ) {
 	ctx, task := trace.NewTask(ctx, "PartitionState.HandleRowsDelete")
 	defer task.End()
-
-	vec := mustVectorFromProto(input.Vecs[0])
-	defer vec.Free(pool)
-	rowIDVector := vector.MustFixedColWithTypeCheck[types.Rowid](vec)
-
-	vec = mustVectorFromProto(input.Vecs[1])
-	defer vec.Free(pool)
-	timeVector := vector.MustFixedColWithTypeCheck[types.TS](vec)
-
-	vec = mustVectorFromProto(input.Vecs[3])
-	defer vec.Free(pool)
-	tbRowIdVector := vector.MustFixedColWithTypeCheck[types.Rowid](vec)
 
 	batch, err := batch.ProtoBatchToBatch(input)
 	if err != nil {
 		panic(err)
 	}
+	rowIDVector := vector.MustFixedColWithTypeCheck[types.Rowid](batch.Vecs[0])
+	timeVector := vector.MustFixedColWithTypeCheck[types.TS](batch.Vecs[1])
+	tbRowIdVector := vector.MustFixedColWithTypeCheck[types.Rowid](batch.Vecs[3])
 
 	var primaryKeys [][]byte
 	if len(input.Vecs) > 2 {
@@ -781,25 +772,19 @@ func (p *PartitionState) HandleRowsInsert(
 	input *api.Batch,
 	primarySeqnum int,
 	packer *types.Packer,
-	pool *mpool.MPool,
+	_ *mpool.MPool,
 ) (
 	primaryKeys [][]byte,
 ) {
 	ctx, task := trace.NewTask(ctx, "PartitionState.HandleRowsInsert")
 	defer task.End()
 
-	vec := mustVectorFromProto(input.Vecs[0])
-	defer vec.Free(pool)
-	rowIDVector := vector.MustFixedColWithTypeCheck[types.Rowid](vec)
-
-	vec = mustVectorFromProto(input.Vecs[1])
-	defer vec.Free(pool)
-	timeVector := vector.MustFixedColWithTypeCheck[types.TS](vec)
-
 	batch, err := batch.ProtoBatchToBatch(input)
 	if err != nil {
 		panic(err)
 	}
+	rowIDVector := vector.MustFixedColWithTypeCheck[types.Rowid](batch.Vecs[0])
+	timeVector := vector.MustFixedColWithTypeCheck[types.TS](batch.Vecs[1])
 	primaryKeys = readutil.EncodePrimaryKeyVector(
 		batch.Vecs[2+primarySeqnum],
 		packer,

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state_benchmark_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state_benchmark_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtailreplay
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/pb/api"
+)
+
+func BenchmarkPartitionStateHandleRowsInsert(b *testing.B) {
+	pool := mpool.MustNewZero()
+	input, clean := newReplayInsertBatch(b, pool)
+	b.Cleanup(clean)
+
+	state := NewPartitionState("", false, 42, false)
+	packer := types.NewPacker()
+	b.Cleanup(packer.Close)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		state.HandleRowsInsert(ctx, input, 0, packer, pool)
+	}
+}
+
+func BenchmarkPartitionStateHandleRowsDelete(b *testing.B) {
+	pool := mpool.MustNewZero()
+	input, clean := newReplayDeleteBatch(b, pool)
+	b.Cleanup(clean)
+
+	state := NewPartitionState("", false, 42, false)
+	packer := types.NewPacker()
+	b.Cleanup(packer.Close)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		state.HandleRowsDelete(ctx, input, packer, pool)
+	}
+}
+
+func newReplayInsertBatch(b *testing.B, pool *mpool.MPool) (*api.Batch, func()) {
+	b.Helper()
+
+	rowIDVec := vector.NewVec(types.T_Rowid.ToType())
+	tsVec := vector.NewVec(types.T_TS.ToType())
+	pkVec := vector.NewVec(types.T_int64.ToType())
+
+	segmentID := objectio.NewSegmentid()
+	blockID := objectio.NewBlockid(segmentID, 0, 0)
+	vector.AppendFixed(rowIDVec, objectio.NewRowid(blockID, 0), false, pool)
+	vector.AppendFixed(tsVec, types.BuildTS(1, 0), false, pool)
+	vector.AppendFixed(pkVec, int64(1), false, pool)
+
+	input := &api.Batch{
+		Attrs: []string{"rowid", "time", "pk"},
+		Vecs: []api.Vector{
+			mustVectorToProto(rowIDVec),
+			mustVectorToProto(tsVec),
+			mustVectorToProto(pkVec),
+		},
+	}
+	return input, func() {
+		rowIDVec.Free(pool)
+		tsVec.Free(pool)
+		pkVec.Free(pool)
+	}
+}
+
+func newReplayDeleteBatch(b *testing.B, pool *mpool.MPool) (*api.Batch, func()) {
+	b.Helper()
+
+	rowIDVec := vector.NewVec(types.T_Rowid.ToType())
+	tsVec := vector.NewVec(types.T_TS.ToType())
+	pkVec := vector.NewVec(types.T_int64.ToType())
+	tombstoneRowIDVec := vector.NewVec(types.T_Rowid.ToType())
+
+	segmentID := objectio.NewSegmentid()
+	blockID := objectio.NewBlockid(segmentID, 0, 0)
+	vector.AppendFixed(rowIDVec, objectio.NewRowid(blockID, 0), false, pool)
+	vector.AppendFixed(tsVec, types.BuildTS(2, 0), false, pool)
+	vector.AppendFixed(pkVec, int64(1), false, pool)
+	vector.AppendFixed(tombstoneRowIDVec, types.RandomRowid(), false, pool)
+
+	input := &api.Batch{
+		Attrs: []string{"rowid", "time", "pk", "tombstone_rowid"},
+		Vecs: []api.Vector{
+			mustVectorToProto(rowIDVec),
+			mustVectorToProto(tsVec),
+			mustVectorToProto(pkVec),
+			mustVectorToProto(tombstoneRowIDVec),
+		},
+	}
+	return input, func() {
+		rowIDVec.Free(pool)
+		tsVec.Free(pool)
+		pkVec.Free(pool)
+		tombstoneRowIDVec.Free(pool)
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26182

## What this PR does / why we need it:

Cherry-picks #26234 to `4.2-dev`.

`HandleRowsInsert` and `HandleRowsDelete` converted the same protobuf vectors
individually before converting the complete batch, creating redundant vector
wrappers on every replayed batch. This change reuses the vectors from the
single `ProtoBatchToBatch` conversion and adds allocation benchmarks for both
paths.
