### PR TITLE
fix: handle bare boolean filters in block selectivity

### DIFF
--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -2485,9 +2485,11 @@ func getOverlap(s *pb.StatsInfo, colname string) float64 {
 
 func calcBlockSelectivityUsingShuffleRange(s *pb.StatsInfo, colname string, expr *plan.Expr) float64 {
 	sel := expr.Selectivity
-	switch expr.GetF().Func.ObjName {
-	case "isnull", "is_null", "prefix_eq", "prefix_in", "prefix_between", "prefix_in_range": //special handle
-		return sel
+	if fn := expr.GetF(); fn != nil {
+		switch fn.Func.ObjName {
+		case "isnull", "is_null", "prefix_eq", "prefix_in", "prefix_between", "prefix_in_range": //special handle
+			return sel
+		}
 	}
 	overlap := getOverlap(s, colname)
 	if overlap < overlapThreshold/3 {

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -29,6 +29,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCalcBlockSelectivityUsingShuffleRangeBareColumn(t *testing.T) {
+	t.Run("bare column uses the generic overlap estimate", func(t *testing.T) {
+		expr := &planpb.Expr{
+			Selectivity: 0.5,
+			Expr: &planpb.Expr_Col{
+				Col: &planpb.ColRef{Name: "enabled"},
+			},
+		}
+
+		require.Equal(t, 1.0, calcBlockSelectivityUsingShuffleRange(nil, "enabled", expr))
+	})
+
+	t.Run("special function keeps its direct estimate", func(t *testing.T) {
+		expr := &planpb.Expr{
+			Selectivity: 0.25,
+			Expr: &planpb.Expr_F{
+				F: &planpb.Function{Func: &planpb.ObjectRef{ObjName: "prefix_eq"}},
+			},
+		}
+
+		require.Equal(t, 0.25, calcBlockSelectivityUsingShuffleRange(nil, "enabled", expr))
+	})
+}
+
 func TestSafeStatsRatiosAvoidNonFiniteSelectivity(t *testing.T) {
 	t.Run("limit never increases cardinality", func(t *testing.T) {
 		builder := NewQueryBuilder(planpb.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)

--- a/pkg/tests/issues/issue_26216_test.go
+++ b/pkg/tests/issues/issue_26216_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestIssue26216CopiedViewSupportsBareBooleanPredicate(t *testing.T) {
-	require.NoError(t, runIssue26087AuthenticatedClusterTest(func(c embed.Cluster) {
+	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
 		defer cancel()
 
@@ -58,7 +58,7 @@ func TestIssue26216CopiedViewSupportsBareBooleanPredicate(t *testing.T) {
 
 		execSQLRequire(t, ctx, db, "data branch create database `"+targetDB+"` from `"+sourceDB+"`")
 		assertIssue26216ViewRows(t, ctx, db, targetDB)
-	}))
+	})
 }
 
 func assertIssue26216ViewRows(t *testing.T, ctx context.Context, db *sql.DB, databaseName string) {

--- a/pkg/tests/issues/issue_26216_test.go
+++ b/pkg/tests/issues/issue_26216_test.go
@@ -63,10 +63,21 @@ func TestIssue26216CopiedViewSupportsBareBooleanPredicate(t *testing.T) {
 
 func assertIssue26216ViewRows(t *testing.T, ctx context.Context, db *sql.DB, databaseName string) {
 	t.Helper()
-	var id int
-	var amount string
-	require.NoError(t, db.QueryRowContext(ctx,
-		"select id, cast(amount as char) from `"+databaseName+"`.`v` order by id").Scan(&id, &amount))
-	require.Equal(t, 1, id)
-	require.Equal(t, "10.00", amount)
+	rows, err := db.QueryContext(ctx,
+		"select id, cast(amount as char) from `"+databaseName+"`.`v` order by id")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var ids []int
+	var amounts []string
+	for rows.Next() {
+		var id int
+		var amount string
+		require.NoError(t, rows.Scan(&id, &amount))
+		ids = append(ids, id)
+		amounts = append(amounts, amount)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, []int{1}, ids)
+	require.Equal(t, []string{"10.00"}, amounts)
 }

--- a/pkg/tests/issues/issue_26216_test.go
+++ b/pkg/tests/issues/issue_26216_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue26216CopiedViewSupportsBareBooleanPredicate(t *testing.T) {
+	require.NoError(t, runIssue26087AuthenticatedClusterTest(func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		db, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
+		require.NoError(t, err)
+		defer db.Close()
+		execSQLRequire(t, ctx, db, "set role moadmin")
+		execSQLRequire(t, ctx, db, "select mo_feature_registry_upsert('branch', 'Branch feature', '{\"allowed_scope\":[]}', true)")
+
+		const (
+			sourceDB = "issue_26216_src"
+			targetDB = "issue_26216_dst"
+		)
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+targetDB+"`")
+			execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+sourceDB+"`")
+		}()
+
+		execSQLRequire(t, ctx, db, "create database `"+sourceDB+"`")
+		execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`t` (id int primary key, amount decimal(10,2), enabled bool not null)")
+		execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`.`t` values (1, 10.00, true), (2, 20.00, false)")
+		execSQLRequire(t, ctx, db, "create view `"+sourceDB+"`.`v` as select id, amount from `"+sourceDB+"`.`t` where enabled")
+		assertIssue26216ViewRows(t, ctx, db, sourceDB)
+
+		execSQLRequire(t, ctx, db, "data branch create database `"+targetDB+"` from `"+sourceDB+"`")
+		assertIssue26216ViewRows(t, ctx, db, targetDB)
+	}))
+}
+
+func assertIssue26216ViewRows(t *testing.T, ctx context.Context, db *sql.DB, databaseName string) {
+	t.Helper()
+	var id int
+	var amount string
+	require.NoError(t, db.QueryRowContext(ctx,
+		"select id, cast(amount as char) from `"+databaseName+"`.`v` order by id").Scan(&id, &amount))
+	require.Equal(t, 1, id)
+	require.Equal(t, "10.00", amount)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26216

## What this PR does / why we need it:

Copied views can expose a bare boolean column as a zonemappable filter. The
block-selectivity estimator treated every such filter as a function expression
and dereferenced a missing function, causing an internal error when querying
the copied view.

This change only applies function-specific selectivity handling when the
expression is actually a function. Bare columns continue through the existing
generic overlap estimate. Regression coverage includes both the estimator's
expression-shape boundary and a real embedded Data Branch database copy whose
source and copied views are queried through SQL.

Validation:

- `go build ./pkg/sql/plan`
- `go vet ./pkg/sql/plan ./pkg/tests/issues`
- full `pkg/sql/plan` tests, normal and `-race`
- focused estimator test, `-race -count=100`
- embedded copied-view regression

QA handoff required: yes. Please verify the reported Data Branch copied-view
scenario with a bare boolean predicate in a deployed test environment before
closing the issue.
