### PR TITLE
perf(fulltext): bound filter-only boolean AND candidates

### DIFF
--- a/pkg/fulltext/fulltext.go
+++ b/pkg/fulltext/fulltext.go
@@ -106,6 +106,29 @@ func (s *SearchAccum) PatternAnyPlus() bool {
 	return s.AnyPlus
 }
 
+// IsPureBooleanAnd reports whether the parsed pattern is the strict Boolean
+// conjunction produced for "+term +term ...".  In the classic fulltext
+// implementation a JOIN pattern has one result slot for the whole
+// conjunction, so every matching document receives the same TF-IDF score.
+// Keep this deliberately narrow: prefix, phrase, group, negative and weighted
+// forms must retain the general scoring path.
+func (s *SearchAccum) IsPureBooleanAnd() bool {
+	if s.Mode != int64(tree.FULLTEXT_BOOLEAN) || len(s.Pattern) != 1 {
+		return false
+	}
+
+	root := s.Pattern[0]
+	if root.Operator != JOIN || len(root.Children) < 2 {
+		return false
+	}
+	for _, child := range root.Children {
+		if child.Operator != PLUS || len(child.Children) != 1 || child.Children[0].Operator != TEXT {
+			return false
+		}
+	}
+	return true
+}
+
 func hasPatternAnyPlus(ps []*Pattern) bool {
 	for _, p := range ps {
 		if p.Operator == PLUS || p.Operator == JOIN {

--- a/pkg/fulltext/fulltext_test.go
+++ b/pkg/fulltext/fulltext_test.go
@@ -659,6 +659,29 @@ func TestFullText2(t *testing.T) {
 
 }
 
+func TestSearchAccumIsPureBooleanAnd(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{name: "strict and", pattern: "+Matrix +Origin", want: true},
+		{name: "single required term", pattern: "+Matrix", want: false},
+		{name: "optional term", pattern: "+Matrix Origin", want: false},
+		{name: "negative term", pattern: "+Matrix -Origin", want: false},
+		{name: "prefix term", pattern: "+Matrix* +Origin", want: false},
+		{name: "required group", pattern: "+Matrix +(Origin One)", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := NewSearchAccum("src", "index", tc.pattern, int64(tree.FULLTEXT_BOOLEAN), "", ALGO_TFIDF)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, s.IsPureBooleanAnd())
+		})
+	}
+}
+
 func TestFullText3(t *testing.T) {
 
 	pattern := "+we -aRe -so -Happy"

--- a/pkg/fulltext/types.go
+++ b/pkg/fulltext/types.go
@@ -101,8 +101,9 @@ Run Eval() to get final answer and score
 
 // Parser parameters
 type FullTextParserParam struct {
-	Parser string `json:"parser"`
-	Async  string `json:"async"`
+	Parser     string `json:"parser"`
+	Async      string `json:"async"`
+	FilterOnly bool   `json:"filter_only,omitempty"`
 }
 
 // Search accumulator is to parse the search string into list of pattern and each pattern will associate with WordAccum by pattern.Text

--- a/pkg/sql/colexec/table_function/fulltext.go
+++ b/pkg/sql/colexec/table_function/fulltext.go
@@ -38,8 +38,9 @@ import (
 )
 
 const (
-	countstar_sql     = "SELECT COUNT(*) from %s where word = '%s'"
-	countstar_avg_sql = "SELECT COUNT(*), AVG(pos) from (SELECT doc_id, MAX(pos) AS pos from %s where word = '%s' GROUP BY doc_id) doc_len"
+	countstar_sql                     = "SELECT COUNT(*) from %s where word = '%s'"
+	countstar_avg_sql                 = "SELECT COUNT(*), AVG(pos) from (SELECT doc_id, MAX(pos) AS pos from %s where word = '%s' GROUP BY doc_id) doc_len"
+	maxFilterOnlyBooleanAndCandidates = uint64(1 << 20)
 )
 
 var ft_runSql = sqlexec.RunSql
@@ -64,6 +65,7 @@ type fulltextState struct {
 	minheap          vectorindex.SearchResultHeap
 	resbuf           []*vectorindex.SearchResultAnyKey
 	ranking          bool
+	filterOnlyAnd    bool
 
 	// Serialized membership-filter (docfilter) bytes for reader-level doc_id filtering
 	fulltextMembershipFilter []byte
@@ -103,6 +105,7 @@ func (u *fulltextState) resetRowState(proc *process.Process) {
 	u.docIDMap = make(map[any]any)
 	u.minheap = nil
 	u.resbuf = nil
+	u.filterOnlyAnd = false
 }
 
 func (u *fulltextState) free(tf *TableFunction, proc *process.Process, pipelineFailed bool, err error) {
@@ -383,6 +386,9 @@ func runWordStats(
 	); err != nil {
 		return
 	}
+	if u.filterOnlyAnd {
+		sql = fmt.Sprintf("%s LIMIT %d", sql, u.limit)
+	}
 
 	sqlProc := sqlexec.NewSqlProcess(proc)
 	// Attach the membership filter for reader-level doc_id filtering on the fulltext index table.
@@ -393,6 +399,45 @@ func runWordStats(
 	result, err = ft_runSql_streaming(ctx, sqlProc, sql, u.streamCh, u.errCh)
 
 	return
+}
+
+// collectFilterOnlyAnd consumes the already-deduplicated output of the strict
+// Boolean-AND SQL. The planner only enables this path when the score is not
+// user-visible. All candidates tie under the classic JOIN-pattern TF-IDF
+// semantics, so retaining at most LIMIT+OFFSET document IDs is sufficient and
+// avoids the general per-document aggregation maps.
+func collectFilterOnlyAnd(u *fulltextState, proc *process.Process) (streamClosed bool, err error) {
+	var res executor.Result
+	var ok bool
+
+	select {
+	case res, ok = <-u.streamCh:
+		if !ok {
+			return true, nil
+		}
+	case err = <-u.errCh:
+		return false, err
+	case <-proc.Ctx.Done():
+		return false, moerr.NewInternalError(proc.Ctx, "context cancelled")
+	}
+	defer res.Close()
+
+	for _, bat := range res.Batches {
+		if len(bat.Vecs) < 1 {
+			return false, moerr.NewInternalError(proc.Ctx, "output vector columns not match")
+		}
+		for i := 0; i < bat.RowCount(); i++ {
+			if uint64(len(u.resbuf)) >= u.limit {
+				return false, moerr.NewInternalError(proc.Ctx, "filter-only fulltext result exceeds pushed limit")
+			}
+			docID := vector.GetAny(bat.Vecs[0], i, false)
+			if bytes, isBytes := docID.([]byte); isBytes {
+				docID = append([]byte(nil), bytes...)
+			}
+			u.resbuf = append(u.resbuf, &vectorindex.SearchResultAnyKey{Id: docID, Distance: 0})
+		}
+	}
+	return false, nil
 }
 
 // evaluate the score for all document vectors in Agg hashtable.
@@ -699,6 +744,11 @@ func runCountStar(proc *process.Process, s *fulltext.SearchAccum) (executor.Resu
 	return res, nil
 }
 
+func canUseFilterOnlyBooleanAnd(param fulltext.FullTextParserParam, limit uint64, scoreAlgo fulltext.FullTextScoreAlgo, s *fulltext.SearchAccum) bool {
+	return param.FilterOnly && limit > 0 && limit <= maxFilterOnlyBooleanAndCandidates &&
+		scoreAlgo == fulltext.ALGO_TFIDF && s.IsPureBooleanAnd()
+}
+
 func fulltextIndexMatch(
 	u *fulltextState,
 	proc *process.Process,
@@ -729,19 +779,26 @@ func fulltextIndexMatch(
 			return err
 		}
 
-		u.mpool = fulltext.NewFixedBytePool(proc, uint64(s.Nkeywords), 0, 0)
-		u.agghtab = make(map[any]uint64, 1024)
-		u.aggcnt = make([]int64, s.Nkeywords)
+		u.filterOnlyAnd = canUseFilterOnlyBooleanAnd(u.param, u.limit, scoreAlgo, s)
 
-		// count(*) to get number of records in source table
-		res, err := runCountStar(proc, s)
-		if err != nil {
-			return err
+		var res executor.Result
+		if !u.filterOnlyAnd {
+			u.mpool = fulltext.NewFixedBytePool(proc, uint64(s.Nkeywords), 0, 0)
+			u.agghtab = make(map[any]uint64, 1024)
+			u.aggcnt = make([]int64, s.Nkeywords)
+
+			// count(*) to get number of records in source table
+			res, err = runCountStar(proc, s)
+			if err != nil {
+				return err
+			}
 		}
 
 		u.sacc = s
 
-		opStats.BackgroundQueries = append(opStats.BackgroundQueries, res.LogicalPlan)
+		if !u.filterOnlyAnd {
+			opStats.BackgroundQueries = append(opStats.BackgroundQueries, res.LogicalPlan)
+		}
 
 	}
 
@@ -776,7 +833,12 @@ func fulltextIndexMatch(
 	// get batch from SQL executor
 	sql_closed := false
 	for !sql_closed {
-		if sql_closed, err = groupby(u, proc, u.sacc); err != nil {
+		if u.filterOnlyAnd {
+			sql_closed, err = collectFilterOnlyAnd(u, proc)
+		} else {
+			sql_closed, err = groupby(u, proc, u.sacc)
+		}
+		if err != nil {
 			// notify the producer to stop the sql streaming
 			cancel(err)
 			break

--- a/pkg/sql/colexec/table_function/fulltext_test.go
+++ b/pkg/sql/colexec/table_function/fulltext_test.go
@@ -392,6 +392,80 @@ func TestRunCountStarUsesCountOnlyForTFIDF(t *testing.T) {
 	require.Zero(t, s.AvgDocLen)
 }
 
+func TestFilterOnlyBooleanAndBoundsCandidatesAndSkipsCount(t *testing.T) {
+	ut := newFTTestCase(t, mpool.MustNewZero(), ftdefaultAttrs, fulltext.ALGO_TFIDF, 2)
+	ut.arg.Params = []byte(`{"filter_only":true}`)
+	ut.arg.Args = makeConstInputExprsFTWithPattern("+Matrix +Origin", int64(tree.FULLTEXT_BOOLEAN))
+	inbat := makeBatchFT(ut.proc)
+
+	err := ut.arg.Prepare(ut.proc)
+	require.NoError(t, err)
+	for i := range ut.arg.ctr.executorsForArgs {
+		ut.arg.ctr.argVecs[i], err = ut.arg.ctr.executorsForArgs[i].Eval(ut.proc, []*batch.Batch{inbat}, nil)
+		require.NoError(t, err)
+	}
+
+	prevRunSQL := ft_runSql
+	prevRunStreaming := ft_runSql_streaming
+	defer func() {
+		ft_runSql = prevRunSQL
+		ft_runSql_streaming = prevRunStreaming
+	}()
+
+	ft_runSql = func(sqlproc *sqlexec.SqlProcess, sql string) (executor.Result, error) {
+		return executor.Result{}, moerr.NewInternalErrorf(sqlproc.Proc.Ctx, "count SQL must not run: %s", sql)
+	}
+	var streamingSQL string
+	ft_runSql_streaming = func(
+		ctx context.Context,
+		sqlproc *sqlexec.SqlProcess,
+		sql string,
+		ch chan executor.Result,
+		errChan chan error,
+	) (executor.Result, error) {
+		streamingSQL = sql
+		ch <- executor.Result{Mp: sqlproc.Proc.Mp(), Batches: []*batch.Batch{makeSmallTextBatchFT(sqlproc.Proc)}}
+		return executor.Result{}, nil
+	}
+
+	err = ut.arg.ctr.state.start(ut.arg, ut.proc, 0, nil)
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(streamingSQL, " LIMIT 2"), streamingSQL)
+
+	state := ut.arg.ctr.state.(*fulltextState)
+	require.True(t, state.filterOnlyAnd)
+	require.Nil(t, state.mpool)
+	require.Nil(t, state.agghtab)
+	require.Nil(t, state.aggcnt)
+	require.Len(t, state.resbuf, 2)
+
+	result, err := state.call(ut.arg, ut.proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecNext, result.Status)
+	require.Equal(t, 2, result.Batch.RowCount())
+	for i := 0; i < result.Batch.RowCount(); i++ {
+		require.Zero(t, vector.GetFixedAtWithTypeCheck[float32](result.Batch.Vecs[1], i))
+	}
+
+	result, err = state.call(ut.arg, ut.proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, result.Status)
+	requireStateFreeReturns(t, state, ut.arg, ut.proc)
+}
+
+func TestCanUseFilterOnlyBooleanAndBounds(t *testing.T) {
+	s, err := fulltext.NewSearchAccum("src", "index", "+Matrix +Origin", int64(tree.FULLTEXT_BOOLEAN), "", fulltext.ALGO_TFIDF)
+	require.NoError(t, err)
+	param := fulltext.FullTextParserParam{FilterOnly: true}
+
+	require.True(t, canUseFilterOnlyBooleanAnd(param, maxFilterOnlyBooleanAndCandidates, fulltext.ALGO_TFIDF, s))
+	require.False(t, canUseFilterOnlyBooleanAnd(param, maxFilterOnlyBooleanAndCandidates+1, fulltext.ALGO_TFIDF, s))
+	require.False(t, canUseFilterOnlyBooleanAnd(param, 0, fulltext.ALGO_TFIDF, s))
+	require.False(t, canUseFilterOnlyBooleanAnd(param, 100, fulltext.ALGO_BM25, s))
+	param.FilterOnly = false
+	require.False(t, canUseFilterOnlyBooleanAnd(param, 100, fulltext.ALGO_TFIDF, s))
+}
+
 func TestRunCountStarUsesDedupedDocLenForBM25(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	s := &fulltext.SearchAccum{TblName: "idx_table", ScoreAlgo: fulltext.ALGO_BM25}

--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -77,7 +77,7 @@ func (builder *QueryBuilder) applyIndicesForProjectionUsingFullTextIndex(nodeID 
 	}
 
 	idxID, filter_node_ids, proj_node_ids, err := builder.applyJoinFullTextIndices(nodeID, projNode, scanNode,
-		internalLimit, internalOffset, filterids, filterIndexDefs, projids, projIndexDef, eqmap, colRefCnt, idxColMap)
+		internalLimit, internalOffset, sortNode == nil, filterids, filterIndexDefs, projids, projIndexDef, eqmap, colRefCnt, idxColMap)
 	if err != nil {
 		return -1, err
 	}
@@ -188,7 +188,7 @@ func (builder *QueryBuilder) applyIndicesForAggUsingFullTextIndex(nodeID int32, 
 	eqmap := make(map[int32]int32)
 
 	idxID, _, _, err := builder.applyJoinFullTextIndices(nodeID, projNode, scanNode,
-		scanNode.Limit, scanNode.Offset, filterids, filterIndexDefs, projids, projIndexDefs, eqmap, colRefCnt, idxColMap)
+		scanNode.Limit, scanNode.Offset, false, filterids, filterIndexDefs, projids, projIndexDefs, eqmap, colRefCnt, idxColMap)
 	if err != nil {
 		return -1, err
 	}
@@ -205,6 +205,7 @@ func (builder *QueryBuilder) applyIndicesForAggUsingFullTextIndex(nodeID int32, 
 
 func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *plan.Node, scanNode *plan.Node,
 	paginationLimit, paginationOffset *plan.Expr,
+	allowFilterOnlyFastPath bool,
 	filterids []int32, filter_indexDefs []*plan.IndexDef,
 	projids []int32, proj_indexDefs []*plan.IndexDef, eqmap map[int32]int32,
 	colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr) (int32, []int32, []int32, error) {
@@ -260,6 +261,9 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	if len(scanNode.FilterList) == 0 && len(ft_filters) == 1 {
 		limitExpr, _ = buildCandidateLimit(paginationLimit, paginationOffset)
 	}
+	filterOnlyFastPath := allowFilterOnlyFastPath && limitExpr != nil && len(ft_filters) == 1 &&
+		len(filterids) == 1 && len(scanNode.FilterList) == 0 &&
+		scanNode.TableDef.Pkey != nil && len(scanNode.TableDef.Pkey.Names) == 1
 
 	// buildFullTextIndexScan
 	var last_node_id int32
@@ -272,6 +276,20 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 		srctblname := fmt.Sprintf("`%s`.`%s`", scanNode.ObjRef.SchemaName, scanNode.TableDef.Name)
 		fn := ftidxscan.GetF()
 		params := idxdef.IndexAlgoParams
+		if filterOnlyFastPath && i == 0 {
+			_, scoreProjected := ret_proj_node_ids_map[0]
+			async, asyncErr := catalog.IsIndexAsync(params)
+			if asyncErr != nil {
+				return -1, nil, nil, asyncErr
+			}
+			if !scoreProjected && !async {
+				markedParams, markErr := markFullTextFilterOnly(params)
+				if markErr != nil {
+					return -1, nil, nil, markErr
+				}
+				params = markedParams
+			}
+		}
 		aliasName := fmt.Sprintf("mo_fulltext_alias_%d", i)
 
 		modeLit := fn.Args[1].GetLit()
@@ -666,6 +684,7 @@ func (builder *QueryBuilder) applyFullTextFiltersForScanInJoin(nodeID int32, sca
 		scanNode,
 		scanNode.Limit,
 		scanNode.Offset,
+		false,
 		filterids,
 		filterIndexDefs,
 		nil,

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"reflect"
 	"slices"
@@ -25,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/fulltext"
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
@@ -1405,6 +1407,45 @@ func TestFullTextCandidateLimitIncludesOffset(t *testing.T) {
 	require.Equal(t, uint64(5), builder.qry.Nodes[newID].Offset.GetLit().GetU64Val())
 	require.Nil(t, scan.Limit)
 	require.Nil(t, scan.Offset)
+}
+
+func TestFullTextProjectionMarksBoundedFilterOnlyScan(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, newFullTextJoinMockCompilerContext(), false, true)
+	ctx := NewBindContext(builder, nil)
+	tableDef := makeFullTextJoinTestTableDef("docs", true)
+	tag := builder.genNewBindTag()
+	match := makeFullTextMatchExpr("+Matrix +Origin", int64(tree.FULLTEXT_BOOLEAN), tableDef, tag, []int32{2, 3})
+	scanID := builder.appendNode(makeFullTextJoinTestScan(tableDef, tag, []*planpb.Expr{match}), ctx)
+	projectID := builder.appendNode(&planpb.Node{
+		NodeType:    planpb.Node_PROJECT,
+		Children:    []int32{scanID},
+		ProjectList: []*planpb.Expr{ftjColExpr(tableDef, tag, 0)},
+		Limit:       makePlan2Uint64ConstExprWithType(100),
+	}, ctx)
+	project := builder.qry.Nodes[projectID]
+	scan := builder.qry.Nodes[scanID]
+
+	filterIDs, indexDefs := builder.getFullTextMatchFiltersFromScanNode(scan)
+	_, err := builder.applyIndicesForProjectionUsingFullTextIndex(
+		projectID,
+		project,
+		nil,
+		scan,
+		filterIDs,
+		indexDefs,
+		nil,
+		nil,
+		map[[2]int32]int{},
+		map[[2]int32]*planpb.Expr{},
+	)
+	require.NoError(t, err)
+
+	functions := collectFullTextFunctionScans(builder, projectID)
+	require.Len(t, functions, 1)
+	require.Equal(t, uint64(100), functions[0].Limit.GetLit().GetU64Val())
+	var params fulltext.FullTextParserParam
+	require.NoError(t, json.Unmarshal(functions[0].TableDef.TblFunc.Param, &params))
+	require.True(t, params.FilterOnly)
 }
 
 func TestFullTextDoesNotLimitIndependentIntersectionInputs(t *testing.T) {

--- a/pkg/sql/plan/fulltext.go
+++ b/pkg/sql/plan/fulltext.go
@@ -24,6 +24,21 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
 
+func markFullTextFilterOnly(params string) (string, error) {
+	param := make(map[string]json.RawMessage)
+	if len(params) > 0 {
+		if err := json.Unmarshal([]byte(params), &param); err != nil {
+			return "", err
+		}
+	}
+	param["filter_only"] = json.RawMessage("true")
+	encoded, err := json.Marshal(param)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
 // coldef shall copy index type
 var (
 	fulltext_index_scan_func_name     = "fulltext_index_scan"

--- a/pkg/sql/plan/fulltext_test.go
+++ b/pkg/sql/plan/fulltext_test.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -23,6 +24,21 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMarkFullTextFilterOnly(t *testing.T) {
+	params, err := markFullTextFilterOnly(`{"parser":"gojieba","async":"false","future":{"enabled":true}}`)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(params), &got))
+	require.Equal(t, "gojieba", got["parser"])
+	require.Equal(t, "false", got["async"])
+	require.Equal(t, true, got["filter_only"])
+	require.Equal(t, map[string]any{"enabled": true}, got["future"])
+
+	_, err = markFullTextFilterOnly("{")
+	require.Error(t, err)
+}
 
 func TestBuildFullTextIndexScanBuildsSqlForLiteralPattern(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, newFullTextJoinMockCompilerContext(), false, true)


### PR DESCRIPTION
## What type of PR is this?

- [x] Improvement

## Which issue(s) this PR fixes:

issue #26307

## What this PR does / why we need it:

This PR adds the first, deliberately narrow optimization for the classic FULLTEXT workload in #26307.

- The planner marks only a bounded, filter-only, single-index query through query-local table-function parameters.
- Runtime enables the fast path only for TF-IDF Boolean mode patterns parsed as strict `+term +term ...` AND queries.
- The table function pushes `LIMIT + OFFSET` into its internal SQL, skips `runCountStar`, and avoids the general per-document aggregation maps and fixed byte pool.
- The fast path emits tied scores for the existing Sort and retains at most the bounded candidate count.
- Visible scores, BM25, unbounded or very large limits, async indexes, explicit sort, residual filters, complex Boolean syntax, phrase/prefix/wildcard, and other unsupported shapes keep the existing path.

The current strict-AND JOIN pattern assigns the same TF-IDF score to every matching document. Therefore this optimization preserves the existing unordered Top-K semantics; it intentionally does not promise stable document IDs among ties.

The fast path is capped at 1,048,576 candidates. This PR addresses the bounded #26307 workload only and does not claim to solve the general high-cardinality memory boundary tracked by #25638.

### Validation at exact head `918c3fc01ecef36859aadb8add9a325814924d54`

- `mo-cgo-test -count=1 -timeout=300s ./pkg/fulltext ./pkg/sql/colexec/table_function ./pkg/sql/plan`
- `go vet ./pkg/fulltext ./pkg/sql/colexec/table_function ./pkg/sql/plan`
- Final stacked head additionally passed focused race tests (100 repetitions), full owning-package race tests, `go build`, `go vet`, and `make build`.
- Linux `GOAMD64=v3 GOEXPERIMENT=simd` binary built on host 129; SHA256: `34001480973d73d17c9d254e883b9f9f7668a674b2d5759ecae5f9b26c5ef9aa`.

### Performance gate

Pending; no performance result is claimed in this draft.

Two 230w/C10 baseline attempts were invalidated before warm-up because an unrelated self-hosted GitHub Runner took ownership of host 129 and executed `kill -9` against the benchmark MO. The conflicting workflow was `matrixorigin/mo-auto-test` run `30356127038`; another run started ten minutes later and repeated the same setup behavior. Per the benchmark protocol, these are contaminated host attempts rather than product failures.

The PR will remain draft until a reserved 129 window passes the five-minute idle gate and the per-PR threshold (QPS or CPU/query improvement at least 5%, errors zero, P99 regression no more than 5%).

### QA

QA is required because this changes fulltext execution behavior. Please cover the existing fulltext/gojieba/pushdown/membership suites and bounded strict-AND fallback boundaries.
