### PR TITLE
fix: align rowids for nullable index updates

### DIFF
--- a/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex.go
+++ b/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex.go
@@ -128,7 +128,14 @@ func (preInsertSecIdx *PreInsertSecIdx) Call(proc *process.Process) (vm.CallResu
 
 	if isUpdate {
 		rowIdInBat := len(inputBat.Vecs) - 1
-		if err = preInsertSecIdx.ctr.buf.Vecs[rowIdColPos].UnionBatch(inputBat.Vecs[rowIdInBat], 0, inputBat.Vecs[rowIdInBat].Length(), nil, proc.Mp()); err != nil {
+		if bitMap.IsEmpty() {
+			err = preInsertSecIdx.ctr.buf.Vecs[rowIdColPos].UnionBatch(
+				inputBat.Vecs[rowIdInBat], 0, inputBat.Vecs[rowIdInBat].Length(), nil, proc.Mp())
+		} else {
+			err = util.CompactRowIdCol(
+				inputBat.Vecs[rowIdInBat], preInsertSecIdx.ctr.buf.Vecs[rowIdColPos], bitMap, proc)
+		}
+		if err != nil {
 			return result, err
 		}
 	}

--- a/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex_test.go
+++ b/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex_test.go
@@ -161,6 +161,94 @@ func TestPreInsertSecondarySingleVarcharUsesSizedUkType(t *testing.T) {
 	require.Equal(t, 1, arg.ctr.buf.Vecs[indexColPos].Length())
 }
 
+func TestPreInsertSecondaryUpdateKeepsRowsAligned(t *testing.T) {
+	testCases := []struct {
+		name         string
+		indexColumns [][]int64
+		nullRows     [][]bool
+		expectedRows []int
+	}{
+		{
+			name:         "single column filters nulls",
+			indexColumns: [][]int64{{100, 200, 300, 400}},
+			nullRows:     [][]bool{{true, false, true, false}},
+			expectedRows: []int{1, 3},
+		},
+		{
+			name: "composite key retains nulls",
+			indexColumns: [][]int64{
+				{100, 200, 300, 400},
+				{101, 201, 301, 401},
+			},
+			nullRows: [][]bool{
+				{true, false, false, false},
+				{false, false, true, false},
+			},
+			expectedRows: []int{0, 1, 2, 3},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProc(t)
+			pks := []int64{10, 20, 30, 40}
+			rowIDs := []types.Rowid{
+				types.BuildTestRowid(1, 1),
+				types.BuildTestRowid(1, 2),
+				types.BuildTestRowid(1, 3),
+				types.BuildTestRowid(1, 4),
+			}
+			input := batch.NewWithSize(len(tc.indexColumns) + 2)
+			input.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+			require.NoError(t, vector.AppendFixedList(input.Vecs[0], pks, nil, proc.Mp()))
+			for colIdx, values := range tc.indexColumns {
+				input.Vecs[colIdx+1] = vector.NewVec(types.T_int64.ToType())
+				for rowIdx, value := range values {
+					require.NoError(t, vector.AppendFixed(
+						input.Vecs[colIdx+1], value, tc.nullRows[colIdx][rowIdx], proc.Mp()))
+				}
+			}
+			input.Vecs[len(input.Vecs)-1] = vector.NewVec(types.T_Rowid.ToType())
+			require.NoError(t, vector.AppendFixedList(input.Vecs[len(input.Vecs)-1], rowIDs, nil, proc.Mp()))
+			input.SetRowCount(len(pks))
+			defer input.Clean(proc.Mp())
+
+			indexPositions := make([]int32, len(tc.indexColumns))
+			for i := range indexPositions {
+				indexPositions[i] = int32(i + 1)
+			}
+			arg := &PreInsertSecIdx{
+				PreInsertCtx: &plan.PreInsertUkCtx{
+					Columns:  indexPositions,
+					PkColumn: 0,
+					UkType:   plan.Type{Id: int32(types.T_int64)},
+				},
+			}
+			arg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{input}))
+			require.NoError(t, arg.Prepare(proc))
+			defer arg.Free(proc, false, nil)
+
+			result, err := arg.Call(proc)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expectedRows), result.Batch.RowCount())
+			for _, vec := range result.Batch.Vecs {
+				require.Equal(t, result.Batch.RowCount(), vec.Length())
+			}
+
+			var expectedPKs []int64
+			var expectedRowIDs []types.Rowid
+			for _, inputRow := range tc.expectedRows {
+				expectedPKs = append(expectedPKs, pks[inputRow])
+				expectedRowIDs = append(expectedRowIDs, rowIDs[inputRow])
+			}
+			require.Equal(t, expectedPKs,
+				vector.MustFixedColNoTypeCheck[int64](result.Batch.Vecs[pkColPos]))
+			require.Equal(t, expectedRowIDs,
+				vector.MustFixedColNoTypeCheck[types.Rowid](result.Batch.Vecs[rowIdColPos]))
+		})
+	}
+}
+
 func resetChildren(arg *PreInsertSecIdx, m *mpool.MPool) {
 	bat := colexec.MakeMockBatchs(m)
 	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})

--- a/pkg/sql/colexec/preinsertunique/preinsertunique.go
+++ b/pkg/sql/colexec/preinsertunique/preinsertunique.go
@@ -126,7 +126,14 @@ func (preInsertUnique *PreInsertUnique) Call(proc *process.Process) (vm.CallResu
 
 	if isUpdate {
 		rowIdInBat := len(inputBat.Vecs) - 1
-		if err = preInsertUnique.ctr.buf.Vecs[rowIdColPos].UnionBatch(inputBat.Vecs[rowIdInBat], 0, inputBat.Vecs[rowIdInBat].Length(), nil, proc.Mp()); err != nil {
+		if bitMap.IsEmpty() {
+			err = preInsertUnique.ctr.buf.Vecs[rowIdColPos].UnionBatch(
+				inputBat.Vecs[rowIdInBat], 0, inputBat.Vecs[rowIdInBat].Length(), nil, proc.Mp())
+		} else {
+			err = util.CompactRowIdCol(
+				inputBat.Vecs[rowIdInBat], preInsertUnique.ctr.buf.Vecs[rowIdColPos], bitMap, proc)
+		}
+		if err != nil {
 			return result, err
 		}
 	}

--- a/pkg/sql/colexec/preinsertunique/preinsertunique_test.go
+++ b/pkg/sql/colexec/preinsertunique/preinsertunique_test.go
@@ -161,6 +161,106 @@ func TestPreInsertUniqueSingleVarcharUsesSizedUkType(t *testing.T) {
 	require.Equal(t, 1, arg.ctr.buf.Vecs[indexColPos].Length())
 }
 
+func TestPreInsertUniqueUpdateKeepsCompactedRowsAligned(t *testing.T) {
+	testCases := []struct {
+		name         string
+		indexColumns [][]int64
+		nullRows     [][]bool
+		expectedRows []int
+	}{
+		{
+			name:         "single column mixed nulls",
+			indexColumns: [][]int64{{100, 200, 300, 400}},
+			nullRows:     [][]bool{{true, false, true, false}},
+			expectedRows: []int{1, 3},
+		},
+		{
+			name: "composite key excludes a row when any part is null",
+			indexColumns: [][]int64{
+				{100, 200, 300, 400},
+				{101, 201, 301, 401},
+			},
+			nullRows: [][]bool{
+				{true, false, false, false},
+				{false, false, true, false},
+			},
+			expectedRows: []int{1, 3},
+		},
+		{
+			name:         "all rows survive",
+			indexColumns: [][]int64{{100, 200, 300, 400}},
+			nullRows:     [][]bool{{false, false, false, false}},
+			expectedRows: []int{0, 1, 2, 3},
+		},
+		{
+			name:         "all rows filtered",
+			indexColumns: [][]int64{{100, 200, 300, 400}},
+			nullRows:     [][]bool{{true, true, true, true}},
+			expectedRows: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProc(t)
+			pks := []int64{10, 20, 30, 40}
+			rowIDs := []types.Rowid{
+				types.BuildTestRowid(1, 1),
+				types.BuildTestRowid(1, 2),
+				types.BuildTestRowid(1, 3),
+				types.BuildTestRowid(1, 4),
+			}
+			input := batch.NewWithSize(len(tc.indexColumns) + 2)
+			input.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+			require.NoError(t, vector.AppendFixedList(input.Vecs[0], pks, nil, proc.Mp()))
+			for colIdx, values := range tc.indexColumns {
+				input.Vecs[colIdx+1] = vector.NewVec(types.T_int64.ToType())
+				for rowIdx, value := range values {
+					require.NoError(t, vector.AppendFixed(
+						input.Vecs[colIdx+1], value, tc.nullRows[colIdx][rowIdx], proc.Mp()))
+				}
+			}
+			input.Vecs[len(input.Vecs)-1] = vector.NewVec(types.T_Rowid.ToType())
+			require.NoError(t, vector.AppendFixedList(input.Vecs[len(input.Vecs)-1], rowIDs, nil, proc.Mp()))
+			input.SetRowCount(len(pks))
+			defer input.Clean(proc.Mp())
+
+			indexPositions := make([]int32, len(tc.indexColumns))
+			for i := range indexPositions {
+				indexPositions[i] = int32(i + 1)
+			}
+			arg := &PreInsertUnique{
+				PreInsertCtx: &plan.PreInsertUkCtx{
+					Columns:  indexPositions,
+					PkColumn: 0,
+					UkType:   plan.Type{Id: int32(types.T_int64)},
+				},
+			}
+			arg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{input}))
+			require.NoError(t, arg.Prepare(proc))
+			defer arg.Free(proc, false, nil)
+
+			result, err := arg.Call(proc)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expectedRows), result.Batch.RowCount())
+			for _, vec := range result.Batch.Vecs {
+				require.Equal(t, result.Batch.RowCount(), vec.Length())
+			}
+
+			var expectedPKs []int64
+			var expectedRowIDs []types.Rowid
+			for _, inputRow := range tc.expectedRows {
+				expectedPKs = append(expectedPKs, pks[inputRow])
+				expectedRowIDs = append(expectedRowIDs, rowIDs[inputRow])
+			}
+			require.Equal(t, expectedPKs,
+				vector.MustFixedColNoTypeCheck[int64](result.Batch.Vecs[pkColPos]))
+			require.Equal(t, expectedRowIDs,
+				vector.MustFixedColNoTypeCheck[types.Rowid](result.Batch.Vecs[rowIdColPos]))
+		})
+	}
+}
+
 func resetChildren(arg *PreInsertUnique, m *mpool.MPool) {
 	bat := colexec.MakeMockBatchs(m)
 	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})

--- a/pkg/sql/util/index_util.go
+++ b/pkg/sql/util/index_util.go
@@ -1012,6 +1012,26 @@ func compactPrimaryCol(
 	return err
 }
 
+// CompactRowIdCol copies the Rowids whose input positions are not present in
+// bitMap. Callers keep the empty-bitmap path on UnionBatch so the common case
+// remains a bulk copy.
+func CompactRowIdCol(
+	v *vector.Vector,
+	vec *vector.Vector,
+	bitMap *nulls.Nulls,
+	proc *process.Process,
+) error {
+	sels := vector.GetSels()
+	for i := 0; i < v.Length(); i++ {
+		if !nulls.Contains(bitMap, uint64(i)) {
+			sels = append(sels, int64(i))
+		}
+	}
+	err := vec.Union(v, sels, proc.Mp())
+	vector.PutSels(sels)
+	return err
+}
+
 func XXHashVectors(vs []*vector.Vector,
 	proc *process.Process,
 	packers *PackerList,

--- a/test/distributed/cases/dml/update/update_index.result
+++ b/test/distributed/cases/dml/update/update_index.result
@@ -80,10 +80,10 @@ insert into t1 values(7, 7, 7);
 Duplicate entry ('\(\d\,\d\)'|'\d\w\d{5}\w\d{4}') for key '(.*)'
 insert into t2 values(7, 7, 7);
 Duplicate entry '7' for key '(.*)'
-update t1, t2 set t1.a = null, t2.a = null where t1.a = 7 and t1.a = t2.a;
-insert into t1 values(7, 7, 7);
+update t1, t2 set t1.a = case when t1.a = 2 then null else t1.a end, t2.a = case when t2.a = 2 then null else t2.a end where t1.a = t2.a;
+insert into t1 values(2, 2, 2);
 insert into t1 values(null, 8, 8);
-insert into t2 values(7, 7, 7);
+insert into t2 values(2, 2, 2);
 insert into t2 values(null, 8, 8);
 update t1, t2 set t1.a = 8, t1.b = null, t2.a = 8, t2.b = null where t1.b = 8 and t1.b = t2.b;
 insert into t1 values(8, 8, 8);
@@ -91,26 +91,26 @@ insert into t2 values(8, 8, 8);
 Duplicate entry '8' for key '(.*)'
 select * from t1;
 a    b    c
-2    2    2
+null    2    2
 3    3    3
 4    4    4
 5    5    5
 6    1    1
 1    1    1
-null    7    7
 7    7    7
+2    2    2
 8    null    8
 8    8    8
 select * from t2;
 a    b    c
-2    2    2
+null    2    2
 3    3    3
 4    4    4
 5    5    5
 6    1    1
 1    1    1
-null    7    7
 7    7    7
+2    2    2
 8    null    8
 drop table if exists t1;
 create table t1(a int, b int, c int, unique key(a), primary key(c));

--- a/test/distributed/cases/dml/update/update_index.test
+++ b/test/distributed/cases/dml/update/update_index.test
@@ -62,10 +62,10 @@ update t1, t2 set t1.a = 7, t2.a = 7 where t1.a is null and t2.a is null;
 insert into t1 values(7, 7, 7);
 -- @pattern
 insert into t2 values(7, 7, 7);
-update t1, t2 set t1.a = null, t2.a = null where t1.a = 7 and t1.a = t2.a;
-insert into t1 values(7, 7, 7);
+update t1, t2 set t1.a = case when t1.a = 2 then null else t1.a end, t2.a = case when t2.a = 2 then null else t2.a end where t1.a = t2.a;
+insert into t1 values(2, 2, 2);
 insert into t1 values(null, 8, 8);
-insert into t2 values(7, 7, 7);
+insert into t2 values(2, 2, 2);
 insert into t2 values(null, 8, 8);
 update t1, t2 set t1.a = 8, t1.b = null, t2.a = 8, t2.b = null where t1.b = 8 and t1.b = t2.b;
 insert into t1 values(8, 8, 8);


### PR DESCRIPTION
## What changed

- Compact update RowIDs with the same NULL bitmap already used for unique-index keys and primary keys.
- Apply the same alignment rule to single-column secondary-index preinsert; keep the composite secondary-index behavior unchanged.
- Preserve the existing `UnionBatch` fast path when no indexed value is NULL.
- Add white-box coverage for single/composite indexes and mixed/all/zero surviving rows.
- Reuse the existing multi-table `update_index` BVT data to reproduce the SQL-visible failure without adding redundant fixtures.

## Root cause

During an UPDATE of a nullable unique index, the index key and primary-key vectors discard rows whose indexed value becomes NULL, but the RowID vector was copied without the same compaction. The duplicate-check pipeline could therefore compare a surviving key with the RowID of a different row and reject a legal self-update as a duplicate.

## User impact

Fixes false `Duplicate entry` errors for batch updates where one indexed row becomes NULL while other indexed rows retain their existing keys.

## Performance and risk

- The common no-NULL path still uses the original bulk `UnionBatch`; the added branch only checks whether the bitmap is empty.
- Local 8K-RowID microbenchmark, 5 runs: original bulk path 2.296 µs/op vs guarded no-NULL path 2.300 µs/op, both 0 alloc/op (difference within measurement noise).
- A 25%-NULL batch takes about 20.6 µs per 8K rows, 35 B/op and 1 alloc/op; this work is required only when compaction is needed, and the selection buffer is pooled.
- No schema, wire, storage, public API, concurrency, or lifecycle changes.
- Pooled selections are returned on both success and error paths.

## Validation

- `go build` for the modified Go packages
- `go vet` for the modified Go packages
- deterministic CGo test wrapper over `preinsertunique`, `preinsertsecondaryindex`, and `sql/util`
- targeted race tests, 20 repetitions
- `make ARCHSIMD=0 build-with-prebuilt-native`
- real-server BVT: `update_index.test` passes 148/148
- regression oracle: clean latest `main` fails the reproducer with `Duplicate entry` (143/148 after cascading failures), while this change passes 148/148

Fixes #26334