### PR TITLE
perf(fulltext): order strict AND terms by metadata cost

### DIFF
--- a/pkg/fulltext/fulltext.go
+++ b/pkg/fulltext/fulltext.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -104,6 +105,72 @@ func findValuePattern(ps []*Pattern) []*Pattern {
 
 func (s *SearchAccum) PatternAnyPlus() bool {
 	return s.AnyPlus
+}
+
+// StrictBooleanAndTerms returns the unique exact tokens of a pure
+// "+term +term ..." Boolean query. Runtime validation is required even when
+// the planner marked a candidate because parser-specific tokenization can turn
+// a syntactic term into a phrase or another unsupported expression.
+func (s *SearchAccum) StrictBooleanAndTerms(parser string) ([]string, bool, error) {
+	if s.Mode != int64(tree.FULLTEXT_BOOLEAN) || len(s.Pattern) != 1 {
+		return nil, false, nil
+	}
+	root := s.Pattern[0]
+	if root.Operator != JOIN || len(root.Children) < 2 {
+		return nil, false, nil
+	}
+	terms := make([]string, 0, len(root.Children))
+	seen := make(map[string]struct{}, len(root.Children))
+	for _, required := range root.Children {
+		if required.Operator != PLUS || len(required.Children) != 1 || required.Children[0].Operator != TEXT {
+			return nil, false, nil
+		}
+		tokens, err := ParsePatternInNLMode(required.Children[0].Text, parser)
+		if err != nil {
+			return nil, false, err
+		}
+		if len(tokens) != 1 || tokens[0].Operator != TEXT {
+			return nil, false, nil
+		}
+		term := tokens[0].Text
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		terms = append(terms, term)
+	}
+	return terms, len(terms) >= 2, nil
+}
+
+// OrderStrictBooleanAnd rewrites only the commutative JOIN child order. Pattern
+// indexes and leaves are preserved, so the legacy SQL and scoring semantics do
+// not change.
+func (s *SearchAccum) OrderStrictBooleanAnd(ordered []string, parser string) error {
+	if len(s.Pattern) != 1 || len(ordered) == 0 {
+		return nil
+	}
+	rank := make(map[string]int, len(ordered))
+	for i, term := range ordered {
+		rank[term] = i
+	}
+	root := s.Pattern[0]
+	type rankedChild struct {
+		child *Pattern
+		rank  int
+	}
+	children := make([]rankedChild, 0, len(root.Children))
+	for _, child := range root.Children {
+		tokens, err := ParsePatternInNLMode(child.Children[0].Text, parser)
+		if err != nil {
+			return err
+		}
+		children = append(children, rankedChild{child: child, rank: rank[tokens[0].Text]})
+	}
+	sort.SliceStable(children, func(i, j int) bool { return children[i].rank < children[j].rank })
+	for i := range children {
+		root.Children[i] = children[i].child
+	}
+	return nil
 }
 
 func hasPatternAnyPlus(ps []*Pattern) bool {

--- a/pkg/fulltext/fulltext_test.go
+++ b/pkg/fulltext/fulltext_test.go
@@ -123,6 +123,26 @@ func TestPatternBoolean(t *testing.T) {
 	}
 }
 
+func TestStrictBooleanAndTermsAndOrdering(t *testing.T) {
+	s, err := NewSearchAccum("src", "idx", "+common +rare +common", int64(tree.FULLTEXT_BOOLEAN), "", ALGO_TFIDF)
+	require.NoError(t, err)
+	terms, ok, err := s.StrictBooleanAndTerms("")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"common", "rare"}, terms)
+	require.NoError(t, s.OrderStrictBooleanAnd([]string{"rare", "common"}, ""))
+	require.Equal(t, "rare", s.Pattern[0].Children[0].Children[0].Text)
+	require.Equal(t, "common", s.Pattern[0].Children[1].Children[0].Text)
+
+	for _, pattern := range []string{"+one", "+one -two", "+one +two*", `+"one two" +three`} {
+		candidate, candidateErr := NewSearchAccum("src", "idx", pattern, int64(tree.FULLTEXT_BOOLEAN), "", ALGO_TFIDF)
+		require.NoError(t, candidateErr)
+		_, eligible, eligibleErr := candidate.StrictBooleanAndTerms("")
+		require.NoError(t, eligibleErr)
+		require.False(t, eligible, pattern)
+	}
+}
+
 func TestPatternNL(t *testing.T) {
 
 	tests := []TestCase{

--- a/pkg/fulltext/jieba_test.go
+++ b/pkg/fulltext/jieba_test.go
@@ -107,6 +107,16 @@ func TestPatternToSqlGojiebaBoolean(t *testing.T) {
 		"sql should not contain ngram bigram 清华大: %s", sql)
 }
 
+func TestStrictBooleanAndTermsGojieba(t *testing.T) {
+	s, err := NewSearchAccum("src", "idx", "+清华大学 +北京 +北京",
+		int64(tree.FULLTEXT_BOOLEAN), `{"parser":"gojieba"}`, ALGO_TFIDF)
+	require.NoError(t, err)
+	terms, ok, err := s.StrictBooleanAndTerms("gojieba")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"清华大学", "北京"}, terms)
+}
+
 // TestParsePhraseJieba verifies that BOOLEAN-MODE phrase queries are
 // segmented through gojieba and not just split on whitespace. With the old
 // behavior, "我来到北京" (no spaces) collapsed to a single TEXT pattern

--- a/pkg/fulltext/types.go
+++ b/pkg/fulltext/types.go
@@ -101,8 +101,9 @@ Run Eval() to get final answer and score
 
 // Parser parameters
 type FullTextParserParam struct {
-	Parser string `json:"parser"`
-	Async  string `json:"async"`
+	Parser        string `json:"parser"`
+	Async         string `json:"async"`
+	FilterOnlyAnd bool   `json:"filter_only_and,omitempty"`
 }
 
 // Search accumulator is to parse the search string into list of pattern and each pattern will associate with WordAccum by pattern.Text

--- a/pkg/sql/colexec/table_function/fulltext.go
+++ b/pkg/sql/colexec/table_function/fulltext.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/matrixorigin/matrixone/pkg/common/docfilter"
@@ -882,6 +883,28 @@ func fulltextIndexMatch(
 		s, err := fulltext.NewSearchAccum(srctbl, tblname, pattern, mode, string(tableFunction.Params), scoreAlgo)
 		if err != nil {
 			return err
+		}
+
+		terms, strictAnd, err := s.StrictBooleanAndTerms(u.param.Parser)
+		if err != nil {
+			return err
+		}
+		filterOnlyAnd := u.param.FilterOnlyAnd && strictAnd && scoreAlgo == fulltext.ALGO_TFIDF &&
+			u.limit > 0 && u.limit <= maxFulltextAndTopK
+		if filterOnlyAnd {
+			started := time.Now()
+			ordered, driverRows, fallback, estimateErr := ftEstimateAndOrderFulltextTerms(proc, tableFunction.OpAnalyzer, tblname, terms)
+			stats := opStats
+			stats.AddExtraStat("FulltextTermsCount", int64(len(terms)))
+			stats.AddExtraStat("FulltextEstimatorTimeNanos", time.Since(started).Nanoseconds())
+			stats.AddExtraStat("FulltextEstimatorFallbackCount", fallback)
+			if estimateErr != nil {
+				return estimateErr
+			}
+			stats.AddExtraStat("FulltextEstimatedDriverRows", int64(driverRows))
+			if err = s.OrderStrictBooleanAnd(ordered, u.param.Parser); err != nil {
+				return err
+			}
 		}
 
 		u.mpool = fulltext.NewFixedBytePool(proc, uint64(s.Nkeywords), 0, 0)

--- a/pkg/sql/colexec/table_function/fulltext_estimator.go
+++ b/pkg/sql/colexec/table_function/fulltext_estimator.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table_function
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/perfcounter"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+const maxFulltextAndTopK = uint64(4096)
+
+type fulltextTermEstimate struct {
+	term  string
+	rows  uint64
+	known bool
+}
+
+var ftEstimateAndOrderFulltextTerms = estimateAndOrderFulltextTerms
+
+func splitFulltextTableName(name string) (string, string, error) {
+	name = strings.TrimSpace(name)
+	var parts []string
+	if strings.HasPrefix(name, "`") && strings.HasSuffix(name, "`") {
+		parts = strings.SplitN(name[1:len(name)-1], "`.`", 2)
+	} else {
+		parts = strings.SplitN(name, ".", 2)
+	}
+	if len(parts) != 2 {
+		return "", "", moerr.NewInvalidInputNoCtx("fulltext index table must be schema-qualified")
+	}
+	trim := func(s string) string { return strings.Trim(strings.TrimSpace(s), "`") }
+	db, table := trim(parts[0]), trim(parts[1])
+	if db == "" || table == "" {
+		return "", "", moerr.NewInvalidInputNoCtx("invalid fulltext index table name")
+	}
+	return db, table, nil
+}
+
+// orderFulltextTerms uses an object-level upper bound. Since the hidden table
+// is clustered by word, only objects whose word zone map can contain a term
+// contribute rows. An uninitialized zone map makes all estimates incomplete;
+// ordering then falls back to deterministic token properties.
+func orderFulltextTerms(terms []string, infos []*plan.MetadataScanInfo) (ordered []string, driverRows uint64, fallback int64) {
+	estimates := make([]fulltextTermEstimate, len(terms))
+	metadataComplete := len(infos) > 0
+	for _, info := range infos {
+		if info == nil || len(info.ZoneMap) == 0 || !index.ZM(info.ZoneMap).IsInited() || !index.ZM(info.ZoneMap).IsString() {
+			metadataComplete = false
+			break
+		}
+	}
+	for i, term := range terms {
+		estimates[i] = fulltextTermEstimate{term: term, known: metadataComplete}
+		if metadataComplete {
+			for _, info := range infos {
+				if index.ZM(info.ZoneMap).Contains([]byte(term)) && info.RowCnt > 0 {
+					estimates[i].rows += uint64(info.RowCnt)
+				}
+			}
+		} else {
+			fallback++
+		}
+	}
+	sort.SliceStable(estimates, func(i, j int) bool {
+		if estimates[i].known != estimates[j].known {
+			return estimates[i].known
+		}
+		if estimates[i].known && estimates[i].rows != estimates[j].rows {
+			return estimates[i].rows < estimates[j].rows
+		}
+		if len(estimates[i].term) != len(estimates[j].term) {
+			return len(estimates[i].term) > len(estimates[j].term)
+		}
+		return bytes.Compare([]byte(estimates[i].term), []byte(estimates[j].term)) < 0
+	})
+	ordered = make([]string, len(estimates))
+	for i := range estimates {
+		ordered[i] = estimates[i].term
+	}
+	if len(estimates) > 0 && estimates[0].known {
+		driverRows = estimates[0].rows
+	}
+	return ordered, driverRows, fallback
+}
+
+func estimateAndOrderFulltextTerms(proc *process.Process, analyzer process.Analyzer, indexTable string, terms []string) ([]string, uint64, int64, error) {
+	dbName, tableName, err := splitFulltextTableName(indexTable)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	e, ok := proc.Ctx.Value(defines.EngineKey{}).(engine.Engine)
+	if !ok || e == nil {
+		return nil, 0, 0, moerr.NewInternalError(proc.Ctx, "missing engine for fulltext term estimator")
+	}
+	db, err := e.Database(proc.Ctx, dbName, proc.GetTxnOperator())
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	rel, err := db.Relation(proc.Ctx, tableName, nil)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	ctx := perfcounter.AttachS3RequestKey(proc.Ctx, analyzer.GetOpCounterSet())
+	infos, err := process.MeasureFilesystemWait(analyzer, func() ([]*plan.MetadataScanInfo, error) {
+		return rel.GetColumMetadataScanInfo(ctx, "word", false)
+	})
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	ordered, rows, fallback := orderFulltextTerms(terms, infos)
+	return ordered, rows, fallback, nil
+}

--- a/pkg/sql/colexec/table_function/fulltext_estimator_test.go
+++ b/pkg/sql/colexec/table_function/fulltext_estimator_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table_function
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderFulltextTermsByMetadataUpperBound(t *testing.T) {
+	infos := []*plan.MetadataScanInfo{
+		{RowCnt: 500, ZoneMap: index.BuildZM(types.T_varchar, []byte("common"))},
+		{RowCnt: 10, ZoneMap: index.BuildZM(types.T_varchar, []byte("rare"))},
+	}
+	ordered, rows, fallback := orderFulltextTerms([]string{"common", "rare"}, infos)
+	require.Equal(t, []string{"rare", "common"}, ordered)
+	require.Equal(t, uint64(10), rows)
+	require.Zero(t, fallback)
+}
+
+func TestOrderFulltextTermsMetadataFallbackIsDeterministic(t *testing.T) {
+	ordered, rows, fallback := orderFulltextTerms([]string{"aa", "bbbb", "ab"}, nil)
+	require.Equal(t, []string{"bbbb", "aa", "ab"}, ordered)
+	require.Zero(t, rows)
+	require.Equal(t, int64(3), fallback)
+}
+
+func TestSplitFulltextTableName(t *testing.T) {
+	db, table, err := splitFulltextTableName("`db`.`idx`")
+	require.NoError(t, err)
+	require.Equal(t, "db", db)
+	require.Equal(t, "idx", table)
+	_, _, err = splitFulltextTableName("idx")
+	require.Error(t, err)
+}

--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -77,7 +77,7 @@ func (builder *QueryBuilder) applyIndicesForProjectionUsingFullTextIndex(nodeID 
 	}
 
 	idxID, filter_node_ids, proj_node_ids, err := builder.applyJoinFullTextIndices(nodeID, projNode, scanNode,
-		internalLimit, internalOffset, filterids, filterIndexDefs, projids, projIndexDef, eqmap, colRefCnt, idxColMap)
+		internalLimit, internalOffset, sortNode == nil, filterids, filterIndexDefs, projids, projIndexDef, eqmap, colRefCnt, idxColMap)
 	if err != nil {
 		return -1, err
 	}
@@ -188,7 +188,7 @@ func (builder *QueryBuilder) applyIndicesForAggUsingFullTextIndex(nodeID int32, 
 	eqmap := make(map[int32]int32)
 
 	idxID, _, _, err := builder.applyJoinFullTextIndices(nodeID, projNode, scanNode,
-		scanNode.Limit, scanNode.Offset, filterids, filterIndexDefs, projids, projIndexDefs, eqmap, colRefCnt, idxColMap)
+		scanNode.Limit, scanNode.Offset, false, filterids, filterIndexDefs, projids, projIndexDefs, eqmap, colRefCnt, idxColMap)
 	if err != nil {
 		return -1, err
 	}
@@ -205,6 +205,7 @@ func (builder *QueryBuilder) applyIndicesForAggUsingFullTextIndex(nodeID int32, 
 
 func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *plan.Node, scanNode *plan.Node,
 	paginationLimit, paginationOffset *plan.Expr,
+	allowFilterOnlyAnd bool,
 	filterids []int32, filter_indexDefs []*plan.IndexDef,
 	projids []int32, proj_indexDefs []*plan.IndexDef, eqmap map[int32]int32,
 	colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr) (int32, []int32, []int32, error) {
@@ -260,6 +261,9 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	if len(scanNode.FilterList) == 0 && len(ft_filters) == 1 {
 		limitExpr, _ = buildCandidateLimit(paginationLimit, paginationOffset)
 	}
+	filterOnlyAnd := allowFilterOnlyAnd && limitExpr != nil && len(filterids) == 1 &&
+		len(ft_filters) == 1 && len(scanNode.FilterList) == 0 &&
+		isSingleIntegerPrimaryKey(scanNode.TableDef) && projectsOnlyPrimaryKey(projNode, scanNode)
 
 	// buildFullTextIndexScan
 	var last_node_id int32
@@ -272,6 +276,13 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 		srctblname := fmt.Sprintf("`%s`.`%s`", scanNode.ObjRef.SchemaName, scanNode.TableDef.Name)
 		fn := ftidxscan.GetF()
 		params := idxdef.IndexAlgoParams
+		if filterOnlyAnd && i == 0 {
+			var err error
+			params, err = markFullTextFilterOnlyAnd(params)
+			if err != nil {
+				return -1, nil, nil, err
+			}
+		}
 		aliasName := fmt.Sprintf("mo_fulltext_alias_%d", i)
 
 		modeLit := fn.Args[1].GetLit()
@@ -666,6 +677,7 @@ func (builder *QueryBuilder) applyFullTextFiltersForScanInJoin(nodeID int32, sca
 		scanNode,
 		scanNode.Limit,
 		scanNode.Offset,
+		false,
 		filterids,
 		filterIndexDefs,
 		nil,
@@ -684,6 +696,37 @@ func (builder *QueryBuilder) applyFullTextFiltersForScanInJoin(nodeID int32, sca
 	scanNode.Offset = nil
 
 	return newNodeID, true, nil
+}
+
+func isSingleIntegerPrimaryKey(tableDef *plan.TableDef) bool {
+	if tableDef == nil || tableDef.Pkey == nil || len(tableDef.Pkey.Names) != 1 {
+		return false
+	}
+	pos, ok := tableDef.Name2ColIndex[tableDef.Pkey.PkeyColName]
+	if !ok || pos < 0 || int(pos) >= len(tableDef.Cols) {
+		return false
+	}
+	colType := tableDef.Cols[pos].Typ
+	switch types.T(colType.Id) {
+	case types.T_int8, types.T_int16, types.T_int32, types.T_int64,
+		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64:
+		return true
+	default:
+		return false
+	}
+}
+
+func projectsOnlyPrimaryKey(projNode, scanNode *plan.Node) bool {
+	if projNode == nil || scanNode == nil || scanNode.TableDef == nil ||
+		len(projNode.ProjectList) != 1 || len(scanNode.BindingTags) != 1 {
+		return false
+	}
+	pkPos, ok := scanNode.TableDef.Name2ColIndex[scanNode.TableDef.Pkey.PkeyColName]
+	if !ok {
+		return false
+	}
+	col := projNode.ProjectList[0].GetCol()
+	return col != nil && col.RelPos == scanNode.BindingTags[0] && col.ColPos == pkPos
 }
 
 func (builder *QueryBuilder) fullTextRewriteContextNodeID(preferredNodeID int32, scanNode *plan.Node) int32 {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"reflect"
 	"slices"
@@ -25,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/fulltext"
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
@@ -1405,6 +1407,36 @@ func TestFullTextCandidateLimitIncludesOffset(t *testing.T) {
 	require.Equal(t, uint64(5), builder.qry.Nodes[newID].Offset.GetLit().GetU64Val())
 	require.Nil(t, scan.Limit)
 	require.Nil(t, scan.Offset)
+}
+
+func TestFullTextProjectionMarksBoundedFilterOnlyAndScan(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, newFullTextJoinMockCompilerContext(), false, true)
+	ctx := NewBindContext(builder, nil)
+	tableDef := makeFullTextJoinTestTableDef("docs", true)
+	tableDef.Cols[0].Typ = planpb.Type{Id: int32(types.T_int64)}
+	tag := builder.genNewBindTag()
+	match := makeFullTextMatchExpr("+Matrix +Origin", int64(tree.FULLTEXT_BOOLEAN), tableDef, tag, []int32{2, 3})
+	scanID := builder.appendNode(makeFullTextJoinTestScan(tableDef, tag, []*planpb.Expr{match}), ctx)
+	projectID := builder.appendNode(&planpb.Node{
+		NodeType:    planpb.Node_PROJECT,
+		Children:    []int32{scanID},
+		ProjectList: []*planpb.Expr{ftjColExpr(tableDef, tag, 0)},
+		Limit:       makePlan2Uint64ConstExprWithType(100),
+	}, ctx)
+	project := builder.qry.Nodes[projectID]
+	scan := builder.qry.Nodes[scanID]
+	filterIDs, indexDefs := builder.getFullTextMatchFiltersFromScanNode(scan)
+	_, err := builder.applyIndicesForProjectionUsingFullTextIndex(
+		projectID, project, nil, scan, filterIDs, indexDefs, nil, nil,
+		map[[2]int32]int{}, map[[2]int32]*planpb.Expr{},
+	)
+	require.NoError(t, err)
+
+	functions := collectFullTextFunctionScans(builder, projectID)
+	require.Len(t, functions, 1)
+	var params fulltext.FullTextParserParam
+	require.NoError(t, json.Unmarshal(functions[0].TableDef.TblFunc.Param, &params))
+	require.True(t, params.FilterOnlyAnd)
 }
 
 func TestFullTextDoesNotLimitIndependentIntersectionInputs(t *testing.T) {

--- a/pkg/sql/plan/fulltext.go
+++ b/pkg/sql/plan/fulltext.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -23,6 +24,18 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
+
+func markFullTextFilterOnlyAnd(params string) (string, error) {
+	param := make(map[string]json.RawMessage)
+	if strings.TrimSpace(params) != "" {
+		if err := json.Unmarshal([]byte(params), &param); err != nil {
+			return "", err
+		}
+	}
+	param["filter_only_and"] = json.RawMessage("true")
+	encoded, err := json.Marshal(param)
+	return string(encoded), err
+}
 
 // coldef shall copy index type
 var (

--- a/pkg/sql/plan/fulltext_test.go
+++ b/pkg/sql/plan/fulltext_test.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -51,6 +52,19 @@ func TestBuildFullTextIndexScanBuildsSqlForLiteralPattern(t *testing.T) {
 	require.NotEmpty(t, node.Stats.Sql)
 	require.True(t, strings.Contains(node.Stats.Sql, "`test`.`__mo_fts_idx`"))
 	require.True(t, strings.Contains(node.Stats.Sql, "matrix"))
+}
+
+func TestMarkFullTextFilterOnlyAndPreservesIndexParams(t *testing.T) {
+	params, err := markFullTextFilterOnlyAnd(`{"parser":"gojieba","async":"true","future":{"enabled":true}}`)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(params), &got))
+	require.Equal(t, "gojieba", got["parser"])
+	require.Equal(t, "true", got["async"])
+	require.Equal(t, true, got["filter_only_and"])
+	require.Equal(t, map[string]any{"enabled": true}, got["future"])
+	_, err = markFullTextFilterOnlyAnd("{")
+	require.Error(t, err)
 }
 
 func TestGetFullTextSqlSkipsPreparedPattern(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26307

## What this PR does / why we need it:

Adds the capability stage for the bounded filter-only Boolean strict-AND fulltext path:

- marks only a single FULLTEXT filter with an integer PK-only projection, no ordinary filter/sort, and a finite LIMIT/OFFSET;
- revalidates TF-IDF Boolean pure `+term` queries at runtime and limits `LIMIT+OFFSET` to 4096;
- estimates per-term posting upper bounds from hidden-index `word` metadata in the current transaction snapshot;
- deterministically orders strict-AND terms rarest first and exposes estimator diagnostics;
- keeps every unsupported or ambiguous query on the legacy path.

This is P0-1 only. It intentionally retains the existing Group/HashJoin execution. P0-2 posting intersection is kept on a separate branch until this capability change is accepted. No SQL, DDL, catalog, or persisted index-format change is introduced.

Validation on exact commit `ce84963c8`:

- `mo-cgo-test ./pkg/fulltext ./pkg/sql/colexec/table_function ./pkg/sql/plan -count=1`
- the stacked exact head also passed the same three packages under `-race`, plus focused parser/planner tests for 100 iterations
- `go build` and `go vet` passed for the three owning packages on the stacked head

Performance validation remains pending because the shared mo-129 host currently has an unrelated Actions Runner, MO process, and long-running memory monitor. No contaminated benchmark was started.
