### PR TITLE
fix(logtail): propagate checkpoint iterator errors (#26233)

### DIFF
--- a/pkg/vm/engine/tae/logtail/ckp_reader.go
+++ b/pkg/vm/engine/tae/logtail/ckp_reader.go
@@ -754,7 +754,14 @@ func consumeCheckpointWithTableID(
 	if len(dataRanges) != 0 {
 		iter := ckputil.NewObjectIter(ctx, dataRanges, mp, fs)
 		defer iter.Close()
-		for ok, err := iter.Next(); ok && err == nil; ok, err = iter.Next() {
+		for {
+			ok, err := iter.Next()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				break
+			}
 			entry := iter.Entry()
 			if err := forEachObject(ctx, fs, entry, false); err != nil {
 				return err
@@ -764,7 +771,14 @@ func consumeCheckpointWithTableID(
 	if tombstoneRanges != nil {
 		iter := ckputil.NewObjectIter(ctx, tombstoneRanges, mp, fs)
 		defer iter.Close()
-		for ok, err := iter.Next(); ok && err == nil; ok, err = iter.Next() {
+		for {
+			ok, err := iter.Next()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				break
+			}
 			entry := iter.Entry()
 			if err := forEachObject(ctx, fs, entry, true); err != nil {
 				return err

--- a/pkg/vm/engine/tae/logtail/ckp_reader_test.go
+++ b/pkg/vm/engine/tae/logtail/ckp_reader_test.go
@@ -1,0 +1,225 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtail
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/ckputil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumeCheckpointWithTableID(t *testing.T) {
+	proc := testutil.NewProc(t)
+	fs, err := fileservice.Get[fileservice.FileService](
+		proc.GetFileService(),
+		defines.SharedFileServiceName,
+	)
+	require.NoError(t, err)
+
+	dataRanges, tombstoneRanges := makeCheckpointObjectRanges(t, proc.Mp(), fs)
+	var dataEntries, tombstoneEntries int
+	err = consumeCheckpointWithTableID(
+		context.Background(),
+		func(
+			_ context.Context,
+			_ fileservice.FileService,
+			_ objectio.ObjectEntry,
+			isTombstone bool,
+		) error {
+			if isTombstone {
+				tombstoneEntries++
+			} else {
+				dataEntries++
+			}
+			return nil
+		},
+		dataRanges,
+		tombstoneRanges,
+		1,
+		proc.Mp(),
+		fs,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, dataEntries)
+	require.Equal(t, 1, tombstoneEntries)
+}
+
+func TestConsumeCheckpointWithTableIDPropagatesIteratorError(t *testing.T) {
+	proc := testutil.NewProc(t)
+	fs, err := fileservice.Get[fileservice.FileService](
+		proc.GetFileService(),
+		defines.SharedFileServiceName,
+	)
+	require.NoError(t, err)
+
+	stats := objectio.NewObjectStats()
+	name := objectio.BuildObjectName(&types.Uuid{1}, 0)
+	location := objectio.BuildLocation(
+		name,
+		objectio.NewExtent(0, 0, 1, 1),
+		1,
+		0,
+	)
+	require.NoError(t, objectio.SetObjectStatsLocation(stats, location))
+
+	ranges := []ckputil.TableRange{{
+		TableID:     1,
+		ObjectType:  ckputil.ObjectType_Data,
+		ObjectStats: *stats,
+	}}
+
+	for _, test := range []struct {
+		name            string
+		dataRanges      []ckputil.TableRange
+		tombstoneRanges []ckputil.TableRange
+	}{
+		{
+			name:       "data",
+			dataRanges: ranges,
+		},
+		{
+			name:            "tombstone",
+			tombstoneRanges: ranges,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithDeadline(
+				context.Background(),
+				time.Now().Add(-time.Second),
+			)
+			defer cancel()
+
+			called := false
+			err := consumeCheckpointWithTableID(
+				ctx,
+				func(
+					context.Context,
+					fileservice.FileService,
+					objectio.ObjectEntry,
+					bool,
+				) error {
+					called = true
+					return nil
+				},
+				test.dataRanges,
+				test.tombstoneRanges,
+				1,
+				proc.Mp(),
+				fs,
+			)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.False(t, called)
+		})
+	}
+}
+
+func makeCheckpointObjectRanges(
+	t *testing.T,
+	mp *mpool.MPool,
+	fs fileservice.FileService,
+) ([]ckputil.TableRange, []ckputil.TableRange) {
+	t.Helper()
+
+	ctx := context.Background()
+	data := ckputil.NewObjectListBatch()
+	defer data.Clean(mp)
+
+	sinker := ckputil.NewDataSinker(
+		mp,
+		fs,
+		ioutil.WithMemorySizeThreshold(1),
+	)
+	defer sinker.Close()
+
+	packer := types.NewPacker()
+	defer packer.Close()
+
+	for i, vec := range data.Vecs {
+		switch i {
+		case ckputil.TableObjectsAttr_Accout_Idx:
+			require.NoError(t, vector.AppendMultiFixed(vec, uint32(0), false, 2, mp))
+		case ckputil.TableObjectsAttr_DB_Idx:
+			tableVec := data.Vecs[ckputil.TableObjectsAttr_Table_Idx]
+			objectTypeVec := data.Vecs[ckputil.TableObjectsAttr_ObjectType_Idx]
+			idVec := data.Vecs[ckputil.TableObjectsAttr_ID_Idx]
+			clusterVec := data.Vecs[ckputil.TableObjectsAttr_Cluster_Idx]
+			for _, objectType := range []int8{
+				ckputil.ObjectType_Data,
+				ckputil.ObjectType_Tombstone,
+			} {
+				var stats objectio.ObjectStats
+				name := objectio.MockObjectName()
+				require.NoError(t, objectio.SetObjectStatsObjectName(&stats, name))
+				require.NoError(t, objectio.SetObjectStatsSize(&stats, 1))
+
+				packer.Reset()
+				ckputil.EncodeCluser(
+					packer,
+					1,
+					objectType,
+					name.ObjectId(),
+					false,
+				)
+
+				require.NoError(t, vector.AppendFixed(objectTypeVec, objectType, false, mp))
+				require.NoError(t, vector.AppendFixed(vec, uint64(1), false, mp))
+				require.NoError(t, vector.AppendFixed(tableVec, uint64(1), false, mp))
+				require.NoError(t, vector.AppendBytes(idVec, stats[:], false, mp))
+				require.NoError(t, vector.AppendBytes(clusterVec, packer.Bytes(), false, mp))
+			}
+		case ckputil.TableObjectsAttr_CreateTS_Idx:
+			for range 2 {
+				require.NoError(t, vector.AppendFixed(vec, types.NextGlobalTsForTest(), false, mp))
+			}
+		case ckputil.TableObjectsAttr_DeleteTS_Idx:
+			for range 2 {
+				require.NoError(t, vector.AppendFixed(vec, types.NextGlobalTsForTest(), false, mp))
+			}
+		}
+	}
+	data.SetRowCount(2)
+
+	require.NoError(t, sinker.Write(ctx, data))
+	require.NoError(t, sinker.Sync(ctx))
+	files, inMemory := sinker.GetResult()
+	require.Empty(t, inMemory)
+	require.NotEmpty(t, files)
+
+	ranges := ckputil.MakeTableRangeBatch()
+	defer ranges.Clean(mp)
+	require.NoError(t, ckputil.CollectTableRanges(ctx, files, ranges, mp, fs))
+
+	return ckputil.ExportToTableRangesByFilter(
+			ranges,
+			1,
+			ckputil.ObjectType_Data,
+		),
+		ckputil.ExportToTableRangesByFilter(
+			ranges,
+			1,
+			ckputil.ObjectType_Tombstone,
+		)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26210

## What this PR does / why we need it:

After `task_kill_cn`, a replacement CN must rebuild table state by consuming the latest checkpoint before serving the subscription. `consumeCheckpointWithTableID` stopped its data and tombstone loops when `ObjectIter.Next()` returned an error, but discarded that error and returned nil. A context/FileService failure could therefore publish a partially reconstructed partition and finalize the table as `Subscribed`.

### Incident evidence for #26210

The production logs pin the reported storm to this failed-reconstruction shape rather than to ordinary TPCC contention:

1. At `17:25:22–17:25:44 UTC`, TN merge `MT-1299` compacted `bmsql_stock` and deleted its 18 source objects. The merge committed at `1785000344282453036-0`.
2. The ICKP covering `17:24:33–17:29:33 UTC` was completed at `17:31:58`, so it includes that merge deletion. A CN subscribing after this checkpoint must not serve rows from those source objects as live.
3. Replacement CN `mo-chaos-regression-dis-tp-cn-jndns` received the `bmsql_stock` subscription response at `17:32:15.660916` and logged `subscribe-ok` at `17:32:15.705894`. The triggering migrated `SELECT ... FROM bmsql_stock ... FOR UPDATE` prepare failed with `context deadline exceeded` at `17:32:15.707491`, immediately at the lazy checkpoint-consumption boundary.
4. The first reported `20618` at `17:32:55.368` is identified by TN as `TRANSFER-ERR`, `old-err=ExpectedEOB`, table `273124` (`bmsql_stock`). Its transaction ID maps back to CN `jndns`.
5. Full-window Loki counts match exactly: all **10,531** CN-side `r-w conflict` errors came from `jndns`, and TN logged exactly **10,531** `TRANSFER-ERR/ExpectedEOB` failures for table `273124`.
6. Those failures contain only 13 block-row IDs from seven objects. All seven are source objects deleted by the same `MT-1299` merge. Their TN transfer entries had already expired, which is why TN returned `ExpectedEOB`; a correctly rebuilt post-merge CN partition could not continue selecting those objects.
7. `task_kill_dn` started at `18:15:10`; the last conflict was at `18:15:13`. After logtail recovery, `jndns` subscribed `bmsql_stock` again with a new partition state at `18:16:23`, and the storm disappeared.

The affected binary cannot emit the iterator error itself: `S3FS.Read` may return `ctx.Err()` before installing its event logger, `ObjectIter.Next()` returns that error, and the old loop then discards it. The observable production signature is consequently false `subscribe-ok` followed by a partition that still serves objects whose checkpointed merge deletion was not applied. The deterministic regression supplies the missing direct function-level proof: with an expired context, `ObjectIter.Next()` returns `context.DeadlineExceeded` while the affected `consumeCheckpointWithTableID` returns nil.

### Failure path

1. `ObjectIter.Next()` returns a context/FileService error from `ioutil.LoadColumnsData`.
2. The old loop exits without returning that error.
3. `Partition.ConsumeCheckpoints` receives nil, publishes the partially populated copy, and sets `checkpointConsumed=true`.
4. `loadAndConsumeLatestCkp` receives nil and advances the table to `Subscribed`.
5. The CN serves stale checkpoint objects. Updates using their row IDs reach TN after the merge transfer entries have expired, and `txnimpl/table.go` converts `TransferTable.Pin(...)=ExpectedEOB` into `20618 r-w conflict`.

### Fix

This PR:

- checks every data and tombstone iterator result explicitly and returns the original error;
- prevents partial checkpoint state from being published or marked consumed;
- prevents a failed initial load from becoming `Subscribed`, allowing retry with a fresh context;
- preserves normal EOF, callback-error, and cleanup behavior;
- adds real checkpoint/FileService coverage for successful consumption and data/tombstone iterator failures.

There is no protocol, storage-format, RPC, locking, or normal-path I/O change. Legitimate r-w conflicts remain unchanged; this prevents the incomplete CN state that generated #26210’s pathological conflict storm.

## Testing

- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=5m ./pkg/vm/engine/tae/logtail`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=10 -timeout=10m -run
'TestConsumeCheckpointWithTableID($|PropagatesIteratorError)' ./pkg/vm/engine/tae/logtail`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=10m ./pkg/vm/engine/disttae`
- `go vet -mod=readonly ./pkg/vm/engine/tae/logtail`
- `go build -mod=readonly ./pkg/vm/engine/tae/logtail ./pkg/vm/engine/disttae`
- PR CI: UT, race-sensitive package tests, SCA, BVT, and coverage passed
