### PR TITLE
[4.2-dev] fix(disttae): fence PK checks on table subscription readiness

### DIFF
--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -415,6 +415,18 @@ func (c *PushClient) canServeTableSnapshotNoWait(
 	ps *logtailreplay.PartitionState,
 	snapshot timestamp.Timestamp,
 ) (canServe bool, needWait bool) {
+	return canServeTableSnapshotWithPending(
+		ps,
+		snapshot,
+		c.subscribed.hasPendingUpdate(dbId, tblId),
+	)
+}
+
+func canServeTableSnapshotWithPending(
+	ps *logtailreplay.PartitionState,
+	snapshot timestamp.Timestamp,
+	pending bool,
+) (canServe bool, needWait bool) {
 	snapshotTS := types.TimestampToTS(snapshot)
 	if ps == nil || !ps.CanServe(snapshotTS) {
 		return false, false
@@ -434,7 +446,7 @@ func (c *PushClient) canServeTableSnapshotNoWait(
 	// waterline. Only block the latest-state fast path when this table has a
 	// known pending update and the current state has not applied up to the
 	// statement snapshot yet.
-	if c.subscribed.hasPendingUpdate(dbId, tblId) {
+	if pending {
 		return false, true
 	}
 	return true, false
@@ -1301,6 +1313,46 @@ func (c *PushClient) isSubscribed(
 	return ps, true, Subscribed
 }
 
+// getSubscribedSnapshotForPKCheck requires an open push-client admission gate
+// and captures the pending marker before the immutable partition snapshot while
+// holding the subscription generation.
+// If there is no pending update, the later snapshot includes every table
+// update known when the global logtail waterline reached the lock timestamp.
+func (c *PushClient) getSubscribedSnapshotForPKCheck(
+	ctx context.Context,
+	accId, dbId, tId uint64,
+) (*logtailreplay.PartitionState, bool, SubscribeState, bool) {
+	if !c.receivedLogTailTime.ready.Load() {
+		return nil, false, InvalidSubState, false
+	}
+
+	s := &c.subscribed
+	s.rw.RLock()
+	ent, exist := s.m[tId]
+	if !exist {
+		s.rw.RUnlock()
+		return nil, false, Unsubscribed, false
+	}
+	if ent.dbID != dbId || ent.state != Subscribed {
+		state := ent.state
+		s.rw.RUnlock()
+		return nil, false, state, false
+	}
+
+	now := time.Now().UnixNano()
+	if now-ent.lastTs.Load() > int64(time.Minute) {
+		ent.lastTs.Store(now)
+	}
+	pending := ent.pendingTo.Load() != nil
+	ps := c.eng.GetOrCreateLatestPart(ctx, accId, dbId, tId).Snapshot()
+	if !c.receivedLogTailTime.ready.Load() {
+		s.rw.RUnlock()
+		return nil, false, InvalidSubState, false
+	}
+	s.rw.RUnlock()
+	return ps, true, Subscribed, pending
+}
+
 func (c *PushClient) toSubIfUnsubscribed(ctx context.Context, dbId, tblId uint64) (SubscribeState, error) {
 	c.subscribed.rw.Lock()
 	defer c.subscribed.rw.Unlock()
@@ -1817,6 +1869,12 @@ func (s *logTailSubscriber) ready() bool {
 func (s *logTailSubscriber) waitReady(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	stop := context.AfterFunc(ctx, func() {
+		s.mu.Lock()
+		s.mu.cond.Broadcast()
+		s.mu.Unlock()
+	})
+	defer stop()
 	for !s.mu.ready {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -1161,6 +1161,159 @@ func TestWaitCanServeTableSnapshotWaitsForPendingUpdate(t *testing.T) {
 	assert.True(t, applied.EQ(&expectedApplied))
 }
 
+func TestPKCheckSnapshotRejectsResetSubscriptionGeneration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	e := &Engine{partitions: make(map[[2]uint64]*logtailreplay.Partition)}
+	e.pClient.eng = e
+	e.pClient.subscribed = subscribedTable{
+		eng: e,
+		m: map[uint64]*subEntry{
+			42: {dbID: 10, state: Subscribed},
+		},
+	}
+	e.pClient.receivedLogTailTime.ready.Store(true)
+
+	part := e.GetOrCreateLatestPart(ctx, 0, 10, 42)
+	state, done := part.MutateState()
+	state.UpdateDuration(types.TS{}, types.MaxTs())
+	done()
+	snapshot := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 1}
+	e.pClient.subscribed.setTablePendingUpdate(10, 42, snapshot.Prev())
+	stale := part.Snapshot()
+
+	// Reconnect resets the subscription generation before replacing partitions.
+	e.pClient.subscribed.rw.Lock()
+	e.pClient.subscribed.m = make(map[uint64]*subEntry)
+	e.pClient.subscribed.rw.Unlock()
+
+	ps, ok, subState, pending := e.pClient.getSubscribedSnapshotForPKCheck(ctx, 0, 10, 42)
+	require.Nil(t, ps)
+	require.False(t, ok, "a snapshot from a reset subscription generation is not ready")
+	require.Equal(t, Unsubscribed, subState)
+	require.False(t, pending)
+
+	// The stale snapshot itself still covers the timestamp. The generation
+	// check above is what prevents the PK path from treating it as current.
+	canServe, _ := canServeTableSnapshotWithPending(stale, snapshot, false)
+	require.True(t, canServe)
+}
+
+func TestPKCheckSnapshotRefreshesAfterPendingApply(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	e := &Engine{partitions: make(map[[2]uint64]*logtailreplay.Partition)}
+	e.pClient.eng = e
+	e.pClient.subscribed = subscribedTable{
+		eng: e,
+		m: map[uint64]*subEntry{
+			42: {dbID: 10, state: Subscribed},
+		},
+	}
+	e.pClient.receivedLogTailTime.ready.Store(true)
+
+	part := e.GetOrCreateLatestPart(ctx, 0, 10, 42)
+	state, done := part.MutateState()
+	state.UpdateDuration(types.TS{}, types.MaxTs())
+	done()
+	snapshot := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 1}
+	e.pClient.subscribed.setTablePendingUpdate(10, 42, snapshot.Prev())
+	stale := part.Snapshot()
+
+	state, done = part.MutateState()
+	state.UpdateAppliedTo(types.TimestampToTS(snapshot.Prev()))
+	done()
+	e.pClient.subscribed.clearTablePendingUpdate(10, 42, snapshot.Prev())
+
+	ps, ok, subState, pending := e.pClient.getSubscribedSnapshotForPKCheck(ctx, 0, 10, 42)
+	require.True(t, ok)
+	require.Equal(t, Subscribed, subState)
+	require.False(t, pending)
+	applied := ps.GetAppliedTo()
+	expected := types.TimestampToTS(snapshot.Prev())
+	require.True(t, applied.GE(&expected),
+		"the readiness proof must return the state that observed the applied update")
+	staleApplied := stale.GetAppliedTo()
+	require.False(t, staleApplied.GE(&expected), "the setup must retain the pre-apply snapshot")
+	require.Positive(t, e.pClient.subscribed.m[42].lastTs.Load(),
+		"PK checks must keep write-only subscriptions active for GC")
+}
+
+func TestPKCheckSnapshotRejectsClosedPushClientAdmission(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	e := &Engine{partitions: make(map[[2]uint64]*logtailreplay.Partition)}
+	e.pClient.eng = e
+	e.pClient.subscribed = subscribedTable{
+		eng: e,
+		m: map[uint64]*subEntry{
+			42: {dbID: 10, state: Subscribed},
+		},
+	}
+	part := e.GetOrCreateLatestPart(ctx, 0, 10, 42)
+	state, done := part.MutateState()
+	state.UpdateDuration(types.TS{}, types.MaxTs())
+	done()
+
+	ps, ok, subState, pending := e.pClient.getSubscribedSnapshotForPKCheck(ctx, 0, 10, 42)
+	require.Nil(t, ps)
+	require.False(t, ok)
+	require.Equal(t, InvalidSubState, subState)
+	require.False(t, pending)
+
+	e.pClient.receivedLogTailTime.ready.Store(true)
+	ps, ok, subState, pending = e.pClient.getSubscribedSnapshotForPKCheck(ctx, 0, 10, 42)
+	require.NotNil(t, ps)
+	require.True(t, ok)
+	require.Equal(t, Subscribed, subState)
+	require.False(t, pending)
+}
+
+type waitReadyObservedContext struct {
+	context.Context
+	checked chan struct{}
+	once    sync.Once
+}
+
+func (c *waitReadyObservedContext) Err() error {
+	err := c.Context.Err()
+	if err == nil {
+		c.once.Do(func() { close(c.checked) })
+	}
+	return err
+}
+
+func TestLogTailSubscriberWaitReadyReturnsOnContextCancel(t *testing.T) {
+	subscriber := newLogTailSubscriber()
+	base, cancel := context.WithCancel(context.Background())
+	ctx := &waitReadyObservedContext{
+		Context: base,
+		checked: make(chan struct{}),
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- subscriber.waitReady(ctx)
+	}()
+
+	select {
+	case <-ctx.checked:
+	case <-time.After(time.Second):
+		t.Fatal("waitReady did not reach its wait loop")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		// Release the waiter so a failed assertion does not leak the goroutine.
+		subscriber.setReady()
+		t.Fatal("waitReady did not observe context cancellation")
+	}
+}
+
 func newTestRoutineControllers(buffer int) []*routineController {
 	recRoutines := make([]*routineController, consumerNumber)
 	for i := range recRoutines {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2920,7 +2920,7 @@ func (tbl *txnTable) PrimaryKeysMayBeUpserted(
 	pkIndex int32,
 ) (bool, error) {
 	keysVector := batch.GetVector(pkIndex)
-	return tbl.primaryKeysMayBeChanged(ctx, from, to, keysVector, false)
+	return tbl.primaryKeysMayBeChanged(ctx, from, to, keysVector, false, false)
 }
 
 func (tbl *txnTable) PrimaryKeysMayBeModified(
@@ -2932,7 +2932,106 @@ func (tbl *txnTable) PrimaryKeysMayBeModified(
 	_ int32,
 ) (bool, error) {
 	keysVector := batch.GetVector(pkIndex)
-	return tbl.primaryKeysMayBeChanged(ctx, from, to, keysVector, true)
+	return tbl.primaryKeysMayBeChanged(ctx, from, to, keysVector, true, true)
+}
+
+func (tbl *txnTable) getPartitionStateForPKCheck(
+	ctx context.Context,
+	to types.TS,
+) (*logtailreplay.PartitionState, bool, error) {
+	eng := tbl.eng.(*Engine)
+	var checkedCreatedInTxn bool
+	var createdInTxn bool
+	var ticker *time.Ticker
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+	}()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+
+		ps, subscribed, state, pending := eng.PushClient().getSubscribedSnapshotForPKCheck(
+			ctx,
+			uint64(tbl.accountId),
+			tbl.db.databaseId,
+			tbl.tableId,
+		)
+		if subscribed {
+			canServe, needWait := canServeTableSnapshotWithPending(
+				ps,
+				to.ToTimestamp(),
+				pending,
+			)
+			if canServe || !needWait {
+				return ps, canServe, nil
+			}
+
+			if ticker == nil {
+				ticker = time.NewTicker(time.Millisecond)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, false, ctx.Err()
+			case <-ticker.C:
+			}
+			continue
+		}
+		if !checkedCreatedInTxn {
+			var err error
+			createdInTxn, err = tbl.isCreatedInTxn(ctx)
+			if err != nil {
+				return nil, false, err
+			}
+			checkedCreatedInTxn = true
+		}
+		if createdInTxn {
+			// A table created by this transaction has no committed remote history.
+			// Preserve the existing empty latest-state behavior without requiring a
+			// logtail subscription for a table that TN cannot expose yet.
+			part, err := eng.LazyLoadLatestCkp(
+				ctx,
+				uint64(tbl.accountId),
+				tbl.tableId,
+				tbl.tableName,
+				tbl.db.databaseId,
+				tbl.db.databaseName,
+			)
+			if err != nil {
+				return nil, false, err
+			}
+			return part.Snapshot(), true, nil
+		}
+		if state == InvalidSubState {
+			// Reconnect closes the push-client admission gate before clearing the
+			// old subscription map. Do not let getPartitionState reuse an entry
+			// from that old generation. The caller already holds the row lock, so
+			// waiting for an unbounded reconnect would retain locks and active-txn
+			// admission. This error is handled as a whole-txn rollback by frontend.
+			return nil, false, moerr.NewRetryForCNRollingRestart()
+		}
+
+		// Drive the existing subscription state machine to completion, then
+		// recapture both the pending marker and partition snapshot atomically with
+		// respect to reconnect/unsubscribe generation changes. Do not use the
+		// returned state directly: reconnect may replace its generation meanwhile.
+		loaded, err := tbl.getPartitionState(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		if loaded != nil {
+			_, end := loaded.GetDuration()
+			if end != types.MaxTs() {
+				// SubRspTableNotExist can still produce a finite historical
+				// partition for an old-table snapshot. It is a terminal fallback:
+				// use it only when it physically covers the PK-check upper bound.
+				return loaded, loaded.CanServe(to), nil
+			}
+		}
+	}
 }
 
 func (tbl *txnTable) primaryKeysMayBeChanged(
@@ -2941,6 +3040,7 @@ func (tbl *txnTable) primaryKeysMayBeChanged(
 	to types.TS,
 	keysVector *vector.Vector,
 	checkTombstone bool,
+	requireSubscribed bool,
 ) (bool, error) {
 	start := time.Now()
 	defer func() {
@@ -2966,20 +3066,36 @@ func (tbl *txnTable) primaryKeysMayBeChanged(
 		return false,
 			moerr.NewInternalErrorNoCtx("primary key modification is not allowed in snapshot transaction")
 	}
-	// Measure LazyLoadLatestCkp duration
-	lazyLoadStart := time.Now()
-	part, err := tbl.eng.(*Engine).LazyLoadLatestCkp(
-		ctx,
-		uint64(tbl.accountId),
-		tbl.tableId,
-		tbl.tableName,
-		tbl.db.databaseId,
-		tbl.db.databaseName)
-	v2.TxnLazyLoadCkpDurationHistogram.Observe(time.Since(lazyLoadStart).Seconds())
-	if err != nil {
-		return false, err
+
+	var snap *logtailreplay.PartitionState
+	if requireSubscribed {
+		var ready bool
+		snap, ready, err = tbl.getPartitionStateForPKCheck(ctx, to)
+		if err != nil {
+			return false, err
+		}
+		if !ready {
+			// A subscribed state that cannot cover the upper timestamp is unknown,
+			// not proof that the primary keys were unchanged. Returning true makes
+			// LockOp retry the statement on a fresh table snapshot.
+			return true, nil
+		}
+	} else {
+		// Measure LazyLoadLatestCkp duration
+		lazyLoadStart := time.Now()
+		part, err := tbl.eng.(*Engine).LazyLoadLatestCkp(
+			ctx,
+			uint64(tbl.accountId),
+			tbl.tableId,
+			tbl.tableName,
+			tbl.db.databaseId,
+			tbl.db.databaseName)
+		v2.TxnLazyLoadCkpDurationHistogram.Observe(time.Since(lazyLoadStart).Seconds())
+		if err != nil {
+			return false, err
+		}
+		snap = part.Snapshot()
 	}
-	snap := part.Snapshot()
 
 	var packer *types.Packer
 	put := tbl.eng.(*Engine).packerPool.Get(&packer)

--- a/pkg/vm/engine/disttae/txn_table_delegate.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate.go
@@ -767,9 +767,37 @@ func (tbl *txnTableDelegate) PrimaryKeysMayBeModified(
 		},
 	)
 	if err != nil {
-		return false, err
+		return false, normalizePKCheckError(err)
 	}
 	return modify, nil
+}
+
+func normalizePKCheckError(err error) error {
+	if cause := findPKCheckRollingRestart(err); cause != nil {
+		// shardservice aggregates replica errors with errors.Join, while frontend
+		// classifies whole-txn rollback errors by their concrete moerr type.
+		return cause
+	}
+	return err
+}
+
+func findPKCheckRollingRestart(err error) *moerr.Error {
+	if cause, ok := err.(*moerr.Error); ok &&
+		cause.ErrorCode() == moerr.ErrRetryForCNRollingRestart {
+		return cause
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range joined.Unwrap() {
+			if cause := findPKCheckRollingRestart(child); cause != nil {
+				return cause
+			}
+		}
+		return nil
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		return findPKCheckRollingRestart(wrapped.Unwrap())
+	}
+	return nil
 }
 
 func (tbl *txnTableDelegate) PrimaryKeysMayBeUpserted(

--- a/pkg/vm/engine/disttae/txn_table_delegate_test.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate_test.go
@@ -16,15 +16,39 @@ package disttae
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNormalizePKCheckErrorPreservesRollingRestart(t *testing.T) {
+	rollingRestart := moerr.NewRetryForCNRollingRestart()
+	joined := errors.Join(
+		moerr.NewReplicaNotFound("other replica"),
+		errors.New("replica read failed"),
+		rollingRestart,
+	)
+
+	err := normalizePKCheckError(joined)
+	require.Same(t, rollingRestart, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrRetryForCNRollingRestart))
+	require.Same(t, rollingRestart,
+		normalizePKCheckError(fmt.Errorf("wrapped: %w", rollingRestart)))
+
+	other := errors.New("other read failure")
+	require.Same(t, other, normalizePKCheckError(other))
+	joinedOther := errors.Join(other)
+	require.Same(t, joinedOther, normalizePKCheckError(joinedOther))
+}
 
 func TestTxnTableDelegate_CollectChanges(t *testing.T) {
 	table := &txnTableDelegate{}

--- a/pkg/vm/engine/disttae/txn_table_test.go
+++ b/pkg/vm/engine/disttae/txn_table_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -29,12 +30,15 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/cmd_util"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -310,6 +314,328 @@ func TestReusableRelationHandleRejectsNonDisttaeWorkspace(t *testing.T) {
 	op.EXPECT().Status().Return(txn.TxnStatus_Active)
 
 	require.ErrorContains(t, handle.Reset(op), "disttae transaction workspace")
+}
+
+func newPrimaryKeyCheckTableForTest(t *testing.T) (*txnTable, *Engine) {
+	t.Helper()
+
+	eng := &Engine{
+		partitions: make(map[[2]uint64]*logtailreplay.Partition),
+		packerPool: fileservice.NewPool(
+			8,
+			func() *types.Packer { return types.NewPacker() },
+			func(packer *types.Packer) { packer.Reset() },
+			func(packer *types.Packer) { packer.Close() },
+		),
+	}
+	eng.catalog.Store(cache.NewCatalog())
+	eng.pClient.eng = eng
+	eng.pClient.subscribed = subscribedTable{
+		eng: eng,
+		m:   make(map[uint64]*subEntry),
+	}
+	eng.pClient.receivedLogTailTime.ready.Store(true)
+
+	op, closeFn := client.NewTestTxnOperator(context.Background())
+	t.Cleanup(closeFn)
+	proc := testutil.NewProc(t)
+	t.Cleanup(proc.Free)
+
+	tbl := &txnTable{
+		accountId: 1,
+		tableId:   42,
+		tableName: "t",
+		db: &txnDatabase{
+			databaseId:   10,
+			databaseName: "db",
+			op:           op,
+		},
+		eng:  eng,
+		fake: true,
+	}
+	tbl.proc.Store(proc)
+
+	part := eng.GetOrCreateLatestPart(context.Background(), 1, 10, 42)
+	state, done := part.MutateState()
+	state.UpdateDuration(types.TS{}, types.MaxTs())
+	done()
+
+	return tbl, eng
+}
+
+func TestPrimaryKeysMayBeModifiedRequiresReadySubscription(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	mp := tbl.proc.Load().Mp()
+	bat := makeBatchForTest(mp, 7)
+	defer bat.Clean(mp)
+
+	from := types.BuildTS(10, 0)
+	to := types.BuildTS(20, 0)
+
+	eng.pClient.SetSubscribeState(10, 42, Subscribing)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		eng.pClient.SetSubscribeState(10, 42, Subscribed)
+	}()
+	changed, err := tbl.PrimaryKeysMayBeModified(context.Background(), from, to, bat, 0, -1)
+	require.NoError(t, err)
+	require.False(t, changed, "the PK check must use the completed subscription instead of retrying the statement")
+
+	eng.pClient.SetSubscribeState(10, 42, SubRspReceived)
+	changed, err = tbl.PrimaryKeysMayBeModified(context.Background(), from, to, bat, 0, -1)
+	require.NoError(t, err)
+	require.False(t, changed, "the PK check must finish loading the subscription response before checking")
+
+	eng.pClient.SetSubscribeState(10, 42, Subscribing)
+	changed, err = tbl.PrimaryKeysMayBeUpserted(context.Background(), from, to, bat, 0)
+	require.NoError(t, err)
+	require.False(t, changed, "the auto-increment recheck keeps its existing lazy-state semantics")
+
+	eng.pClient.SetSubscribeState(10, 42, Subscribed)
+	changed, err = tbl.PrimaryKeysMayBeModified(context.Background(), from, to, bat, 0, -1)
+	require.NoError(t, err)
+	require.False(t, changed, "a complete subscribed state with no matching key should keep the fast path")
+}
+
+func TestPrimaryKeysMayBeModifiedWaitsForSubscriptionData(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	mp := tbl.proc.Load().Mp()
+	bat := makeBatchForTest(mp, 7)
+	defer bat.Clean(mp)
+
+	rowIDVec := vector.NewVec(types.T_Rowid.ToType())
+	tsVec := vector.NewVec(types.T_TS.ToType())
+	pkVec := vector.NewVec(types.T_int64.ToType())
+	defer rowIDVec.Free(mp)
+	defer tsVec.Free(mp)
+	defer pkVec.Free(mp)
+	require.NoError(t, vector.AppendFixed(rowIDVec, types.RandomRowid(), false, mp))
+	require.NoError(t, vector.AppendFixed(tsVec, types.BuildTS(15, 0), false, mp))
+	require.NoError(t, vector.AppendFixed(pkVec, int64(7), false, mp))
+	insert := &api.Batch{
+		Attrs: []string{"rowid", "time", "pk"},
+		Vecs: []api.Vector{
+			mustVectorToProtoForMaterializedSnapshotTest(t, rowIDVec),
+			mustVectorToProtoForMaterializedSnapshotTest(t, tsVec),
+			mustVectorToProtoForMaterializedSnapshotTest(t, pkVec),
+		},
+	}
+
+	eng.pClient.SetSubscribeState(10, 42, Subscribing)
+	part := eng.GetOrCreateLatestPart(context.Background(), 1, 10, 42)
+	doneC := make(chan struct{})
+	defer func() { <-doneC }()
+	go func() {
+		defer close(doneC)
+		time.Sleep(10 * time.Millisecond)
+		packer := types.NewPacker()
+		defer packer.Close()
+		state, done := part.MutateState()
+		state.HandleRowsInsert(context.Background(), insert, 0, packer, mp)
+		done()
+		eng.pClient.SetSubscribeState(10, 42, Subscribed)
+	}()
+
+	changed, err := tbl.PrimaryKeysMayBeModified(
+		context.Background(),
+		types.BuildTS(10, 0),
+		types.BuildTS(20, 0),
+		bat,
+		0,
+		-1,
+	)
+	require.NoError(t, err)
+	require.True(t, changed, "the PK check must inspect versions loaded by the completed subscription")
+}
+
+func TestPrimaryKeysMayBeModifiedStopsWaitingWhenSubscriptionContextEnds(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	mp := tbl.proc.Load().Mp()
+	bat := makeBatchForTest(mp, 7)
+	defer bat.Clean(mp)
+
+	eng.pClient.SetSubscribeState(10, 42, Subscribing)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := tbl.PrimaryKeysMayBeModified(
+		ctx,
+		types.BuildTS(10, 0),
+		types.BuildTS(20, 0),
+		bat,
+		0,
+		-1,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestPrimaryKeysMayBeModifiedFailsFastWhenPushClientIsNotReady(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	mp := tbl.proc.Load().Mp()
+	bat := makeBatchForTest(mp, 7)
+	defer bat.Clean(mp)
+
+	eng.pClient.SetSubscribeState(10, 42, Subscribed)
+	eng.pClient.receivedLogTailTime.ready.Store(false)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := tbl.PrimaryKeysMayBeModified(
+		ctx,
+		types.BuildTS(10, 0),
+		types.BuildTS(20, 0),
+		bat,
+		0,
+		-1,
+	)
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrRetryForCNRollingRestart))
+}
+
+func TestPrimaryKeysMayBeModifiedSkipsReadinessForEmptyKeys(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	mp := tbl.proc.Load().Mp()
+	bat := makeBatchForTest(mp)
+	defer bat.Clean(mp)
+
+	eng.pClient.SetSubscribeState(10, 42, Subscribing)
+	changed, err := tbl.PrimaryKeysMayBeModified(
+		context.Background(),
+		types.BuildTS(10, 0),
+		types.BuildTS(20, 0),
+		bat,
+		0,
+		-1,
+	)
+	require.NoError(t, err)
+	require.False(t, changed, "an empty key set cannot conflict even while the table is rebuilding")
+}
+
+func TestPrimaryKeysMayBeModifiedHonorsPendingTableApply(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	mp := tbl.proc.Load().Mp()
+	bat := makeBatchForTest(mp, 7)
+	defer bat.Clean(mp)
+
+	from := types.BuildTS(10, 0)
+	to := types.BuildTS(20, 0)
+	eng.pClient.SetSubscribeState(10, 42, Subscribed)
+	eng.pClient.subscribed.setTablePendingUpdate(10, 42, to.ToTimestamp())
+
+	part := eng.GetOrCreateLatestPart(context.Background(), 1, 10, 42)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		state, done := part.MutateState()
+		state.UpdateAppliedTo(to.Prev())
+		done()
+	}()
+
+	changed, err := tbl.PrimaryKeysMayBeModified(context.Background(), from, to, bat, 0, -1)
+	require.NoError(t, err)
+	require.False(t, changed, "the PK check must wait for the pending table update before proving no change")
+}
+
+func TestPrimaryKeysMayBeModifiedForTableCreatedInTxn(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	tbl.fake = false
+	tbl.remoteWorkspace = true
+	tbl.createdInTxn = true
+	eng.pClient.receivedLogTailTime.ready.Store(false)
+
+	mp := tbl.proc.Load().Mp()
+	bat := makeBatchForTest(mp, 7)
+	defer bat.Clean(mp)
+
+	changed, err := tbl.PrimaryKeysMayBeModified(
+		context.Background(),
+		types.BuildTS(10, 0),
+		types.BuildTS(20, 0),
+		bat,
+		0,
+		-1,
+	)
+	require.NoError(t, err)
+	require.False(t, changed,
+		"a table created in this transaction has no committed remote history even during reconnect")
+}
+
+func TestPKCheckHistoricalSnapshotFallbackIsTerminal(t *testing.T) {
+	tbl, eng := newPrimaryKeyCheckTableForTest(t)
+	tbl.db.op.AddWorkspace(&Transaction{engine: eng})
+	snapshot := types.BuildTS(15, 0)
+	to := types.BuildTS(20, 0)
+	tbl.db.op.SetSnapshotTS(snapshot.ToTimestamp())
+
+	eng.snapshotMgr = NewSnapshotManager()
+	eng.snapshotMgr.Init()
+	historical := logtailreplay.NewPartition(
+		eng.service,
+		eng.GetLatestCatalogCache(),
+		uint64(tbl.accountId),
+		tbl.db.databaseId,
+		tbl.tableId,
+		nil,
+	)
+	state, done := historical.MutateState()
+	state.UpdateDuration(types.TS{}, to)
+	done()
+	expected := eng.snapshotMgr.Add(
+		tbl.db.databaseId,
+		tbl.tableId,
+		historical,
+		tbl.tableName,
+		snapshot,
+	)
+
+	oldSnapshotRead := RequestSnapshotRead
+	snapshotReads := 0
+	RequestSnapshotRead = func(
+		context.Context,
+		*txnTable,
+		*types.TS,
+	) (any, error) {
+		snapshotReads++
+		start := types.TS{}.ToTimestamp()
+		end := to.ToTimestamp()
+		return &cmd_util.SnapshotReadResp{
+			Succeed: true,
+			Entries: []*cmd_util.CheckpointEntryResp{
+				{
+					Start: &start,
+					End:   &end,
+				},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { RequestSnapshotRead = oldSnapshotRead })
+	subscribeAttempts := 0
+	eng.pClient.subscriber = newLogTailSubscriber()
+	eng.pClient.subscriber.sendSubscribe = func(context.Context, api.TableID) error {
+		subscribeAttempts++
+		return nil
+	}
+	eng.pClient.subscriber.setReady()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	eng.pClient.SetSubscribeState(10, 42, SubRspTableNotExist)
+	ps, ready, err := tbl.getPartitionStateForPKCheck(ctx, to)
+	require.NoError(t, err)
+	require.True(t, ready)
+	require.Same(t, expected, ps)
+	require.Equal(t, 1, snapshotReads,
+		"a successful historical fallback must not start another subscription cycle")
+	require.Zero(t, subscribeAttempts)
+
+	eng.pClient.SetSubscribeState(10, 42, SubRspTableNotExist)
+	ps, ready, err = tbl.getPartitionStateForPKCheck(ctx, to.Next())
+	require.NoError(t, err)
+	require.False(t, ready,
+		"a historical fallback outside its physical range must remain conservative")
+	require.Same(t, expected, ps)
+	require.Equal(t, 2, snapshotReads,
+		"an out-of-range fallback must also terminate after one snapshot read")
+	require.Zero(t, subscribeAttempts)
 }
 
 // func TestPrimaryKeyCheck(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Test and CI

## Which issue(s) this PR fixes:

Backport of #25888 for the subscription-readiness data-consistency path from #25704.

## What this PR does / why we need it:

Backports the remaining consistency fix that was absent from `4.2-dev`.

`PrimaryKeysMayBeModified` now requires a completed current-generation table subscription before it can prove that primary keys are unchanged. During logtail reconnect, first-table subscription, or a pending table update, it waits under the statement context or returns the existing whole-transaction retry error. This prevents an incomplete/stale partition snapshot from incorrectly proving "unchanged" after a row lock wait.

This backport preserves the upstream implementation and tests without adaptation.

The other requested consistency fixes are already in `4.2-dev`:
- #25722: merge commit `30df79c47b`
- #25847: merge commit `99e282671b`

## Test

- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=10m ./pkg/vm/engine/disttae`
- Focused regression tests for subscription generation, pending apply, cancellation, reconnect admission, historical fallback, and remote error normalization
- `go build ./pkg/vm/engine/disttae`
- `go vet ./pkg/vm/engine/disttae`
