### PR TITLE
fix(frontend): match foreign key table names exactly

### DIFF
--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -2023,7 +2023,7 @@ func buildTableInfoListWhereClause(dbName string, tblName string, accountId uint
 		)
 	}
 	if len(tblName) > 0 {
-		whereClause += fmt.Sprintf(" and relname like %s", quoteSQLStringLiteral(tblName))
+		whereClause += fmt.Sprintf(" and relname = %s", quoteSQLStringLiteral(tblName))
 	}
 	whereClause += fmt.Sprintf(" and relkind != %s", quoteSQLStringLiteral(catalog.SystemSequenceRel))
 	return whereClause

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -441,12 +441,19 @@ func TestRestoreExternalTableDefensiveCloneGuards(t *testing.T) {
 }
 
 func TestBuildTableInfoListSQLEscapesLiterals(t *testing.T) {
-	sql := buildTableInfoListSQL("db'name", "tbl'name", 0, uint32(sysAccountID))
-	if !strings.Contains(sql, "reldatabase = 'db''name'") {
-		t.Fatalf("database name was not escaped in SQL: %s", sql)
-	}
-	if !strings.Contains(sql, "relname like 'tbl''name'") {
-		t.Fatalf("table name was not escaped in SQL: %s", sql)
+	for _, tableName := range []string{"tbl'name", "a_b", "a%b", `child\fk`} {
+		t.Run(tableName, func(t *testing.T) {
+			sql := buildTableInfoListSQL("db'name", tableName, 0, uint32(sysAccountID))
+			if !strings.Contains(sql, "reldatabase = 'db''name'") {
+				t.Fatalf("database name was not escaped in SQL: %s", sql)
+			}
+			if !strings.Contains(sql, "relname = "+quoteSQLStringLiteral(tableName)) {
+				t.Fatalf("table name was not matched exactly in SQL: %s", sql)
+			}
+			if strings.Contains(sql, "relname like "+quoteSQLStringLiteral(tableName)) {
+				t.Fatalf("table name was treated as a LIKE pattern in SQL: %s", sql)
+			}
+		})
 	}
 }
 

--- a/pkg/tests/issues/issue_26123_test.go
+++ b/pkg/tests/issues/issue_26123_test.go
@@ -88,13 +88,14 @@ func TestIssue26123DatabaseCopiesKeepLikeMetacharacterFKTables(t *testing.T) {
 					execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`parent_t` (id int primary key)")
 					if tc.collisionTable != "" {
 						execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`."+tc.collisionTable+" (id int primary key)")
+						execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`."+tc.collisionTable+" values (22)")
 					}
 					execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`."+tc.tableNameSQL+" (id int primary key, parent_id int, foreign key (parent_id) references `"+sourceDB+"`.`parent_t`(id))")
 					execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`.`parent_t` values (1)")
 					execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`."+tc.tableNameSQL+" values (11, 1)")
 
 					execSQLRequire(t, ctx, db, mode.copy(sourceDB, targetDB))
-					assertIssue26123CopiedFKTable(t, ctx, db, targetDB, tc.tableName, tc.tableNameSQL)
+					assertIssue26123CopiedFKTable(t, ctx, db, sourceDB, targetDB, tc.tableName, tc.tableNameSQL, tc.collisionTable)
 				})
 			}
 		}
@@ -105,9 +106,11 @@ func assertIssue26123CopiedFKTable(
 	t *testing.T,
 	ctx context.Context,
 	db *sql.DB,
+	sourceDatabaseName string,
 	databaseName string,
 	tableName string,
 	tableNameSQL string,
+	collisionTableSQL string,
 ) {
 	t.Helper()
 
@@ -116,6 +119,11 @@ func assertIssue26123CopiedFKTable(
 		"select id, parent_id from `"+databaseName+"`."+tableNameSQL).Scan(&id, &parentID))
 	require.Equal(t, 11, id)
 	require.Equal(t, 1, parentID)
+	if collisionTableSQL != "" {
+		require.NoError(t, db.QueryRowContext(ctx,
+			"select id from `"+databaseName+"`."+collisionTableSQL).Scan(&id))
+		require.Equal(t, 22, id)
+	}
 
 	var count int
 	require.NoError(t, db.QueryRowContext(ctx,
@@ -126,6 +134,14 @@ func assertIssue26123CopiedFKTable(
 		"select count(*) from mo_catalog.mo_foreign_keys where db_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
 		databaseName, databaseName).Scan(&count))
 	require.Equal(t, 1, count)
+	var sourceFKTableName, targetFKTableName string
+	require.NoError(t, db.QueryRowContext(ctx,
+		"select table_name from mo_catalog.mo_foreign_keys where db_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
+		sourceDatabaseName, sourceDatabaseName).Scan(&sourceFKTableName))
+	require.NoError(t, db.QueryRowContext(ctx,
+		"select table_name from mo_catalog.mo_foreign_keys where db_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
+		databaseName, databaseName).Scan(&targetFKTableName))
+	require.Equal(t, sourceFKTableName, targetFKTableName)
 
 	_, err := db.ExecContext(ctx,
 		"insert into `"+databaseName+"`."+tableNameSQL+" values (?, ?)", 111, 999)

--- a/pkg/tests/issues/issue_26123_test.go
+++ b/pkg/tests/issues/issue_26123_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue26123DatabaseCopiesKeepLikeMetacharacterFKTables(t *testing.T) {
+	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		db, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
+		require.NoError(t, err)
+		defer db.Close()
+		execSQLRequire(t, ctx, db, "set role moadmin")
+		execSQLRequire(t, ctx, db, "select mo_feature_registry_upsert('branch', 'Branch feature', '{\"allowed_scope\":[]}', true)")
+
+		copyModes := []struct {
+			name string
+			key  string
+			copy func(sourceDB, targetDB string) string
+		}{
+			{
+				name: "data branch",
+				key:  "branch",
+				copy: func(sourceDB, targetDB string) string {
+					return "data branch create database `" + targetDB + "` from `" + sourceDB + "`"
+				},
+			},
+			{
+				name: "clone",
+				key:  "clone",
+				copy: func(sourceDB, targetDB string) string {
+					return "create database `" + targetDB + "` clone `" + sourceDB + "`"
+				},
+			},
+		}
+		tableCases := []struct {
+			name           string
+			tableName      string
+			tableNameSQL   string
+			collisionTable string
+		}{
+			{name: "underscore", tableName: "a_b", tableNameSQL: "`a_b`", collisionTable: "`a0b`"},
+			{name: "percent", tableName: "a%b", tableNameSQL: "`a%b`", collisionTable: "`a0b`"},
+			{name: "backslash", tableName: `child\fk`, tableNameSQL: "`child\\fk`"},
+		}
+
+		for _, mode := range copyModes {
+			for _, tc := range tableCases {
+				t.Run(mode.name+"/"+tc.name, func(t *testing.T) {
+					sourceDB := "issue_26123_" + mode.key + "_" + tc.name + "_src"
+					targetDB := "issue_26123_" + mode.key + "_" + tc.name + "_dst"
+					defer func() {
+						cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+						defer cleanupCancel()
+						execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+targetDB+"`")
+						execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+sourceDB+"`")
+					}()
+
+					execSQLRequire(t, ctx, db, "drop database if exists `"+targetDB+"`")
+					execSQLRequire(t, ctx, db, "drop database if exists `"+sourceDB+"`")
+					execSQLRequire(t, ctx, db, "create database `"+sourceDB+"`")
+					execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`parent_t` (id int primary key)")
+					if tc.collisionTable != "" {
+						execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`."+tc.collisionTable+" (id int primary key)")
+					}
+					execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`."+tc.tableNameSQL+" (id int primary key, parent_id int, foreign key (parent_id) references `"+sourceDB+"`.`parent_t`(id))")
+					execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`.`parent_t` values (1)")
+					execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`."+tc.tableNameSQL+" values (11, 1)")
+
+					execSQLRequire(t, ctx, db, mode.copy(sourceDB, targetDB))
+					assertIssue26123CopiedFKTable(t, ctx, db, targetDB, tc.tableName, tc.tableNameSQL)
+				})
+			}
+		}
+	})
+}
+
+func assertIssue26123CopiedFKTable(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	databaseName string,
+	tableName string,
+	tableNameSQL string,
+) {
+	t.Helper()
+
+	var id, parentID int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"select id, parent_id from `"+databaseName+"`."+tableNameSQL).Scan(&id, &parentID))
+	require.Equal(t, 11, id)
+	require.Equal(t, 1, parentID)
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"select count(*) from mo_catalog.mo_tables where account_id = 0 and reldatabase = ? and relname = ?",
+		databaseName, tableName).Scan(&count))
+	require.Equal(t, 1, count)
+	require.NoError(t, db.QueryRowContext(ctx,
+		"select count(*) from mo_catalog.mo_foreign_keys where db_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
+		databaseName, databaseName).Scan(&count))
+	require.Equal(t, 1, count)
+
+	_, err := db.ExecContext(ctx,
+		"insert into `"+databaseName+"`."+tableNameSQL+" values (?, ?)", 111, 999)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26123

## What this PR does / why we need it:

Database CLONE and Data Branch pass an exact foreign-key table name into catalog lookup, but the query used LIKE. Underscore and percent could select a different sorted relation, while backslash could suppress the intended match.

This change uses equality for nonempty table-name lookups. Database-wide enumeration remains unchanged.

The embedded regression isolates all six combinations:

- Data Branch and CLONE
- underscore, percent, and backslash identifiers

Each case asserts the exact destination relation, copied row, target-local foreign-key catalog state, and invalid-write rejection. The newly merged cyclic-FK regression also passes with this change.

Exact-head validation:

- SQL builder test: race, 100 repetitions
- six production-authentic embedded cases: race
- cyclic-FK embedded regression: race
- complete pkg/frontend and pkg/tests/issues: race
- go vet
- git diff --check
- schema v4 preflight: review=PASS

## QA handoff

- QA required: yes
- Reason: this changes user-visible CLONE/Data Branch behavior and persisted foreign-key metadata.
- Required scenarios: run database CLONE and Data Branch with FK child names containing underscore, percent, and backslash; verify exact table names and rows, target-local mo_foreign_keys rows, and rejection of a child insert with a missing parent.
- The linked issue intentionally remains open for QA verification.