### PR TITLE
fix: respect scheduler CPU limits for RPC workers

### DIFF
--- a/pkg/cnservice/server_query_test.go
+++ b/pkg/cnservice/server_query_test.go
@@ -283,7 +283,7 @@ func Test_service_handleGoMaxProcs(t *testing.T) {
 				resp: &query.Response{},
 			},
 			wantErr: nil,
-			want:    &query.Response{GoMaxProcsResponse: query.GoMaxProcsResponse{MaxProcs: int32(goruntime.NumCPU())}},
+			want:    &query.Response{GoMaxProcsResponse: query.GoMaxProcsResponse{MaxProcs: int32(goruntime.GOMAXPROCS(0))}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/common/morpc/cfg.go
+++ b/pkg/common/morpc/cfg.go
@@ -15,7 +15,6 @@
 package morpc
 
 import (
-	"math"
 	"runtime"
 	"time"
 
@@ -24,6 +23,11 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"go.uber.org/zap"
+)
+
+const (
+	defaultMinServerWorkers    = 100
+	defaultServerWorkersPerCPU = 8
 )
 
 var (
@@ -110,7 +114,9 @@ func (c *Config) Adjust() {
 		c.SendQueueSize = 100000
 	}
 	if c.ServerWorkers == 0 {
-		c.ServerWorkers = int(math.Max(100, float64(8*runtime.NumCPU())))
+		// GOMAXPROCS reflects container CPU quotas and explicit scheduler limits,
+		// while NumCPU can expose all CPUs on the host.
+		c.ServerWorkers = defaultServerWorkers(runtime.GOMAXPROCS(0))
 	}
 	if c.ServerBufferQueueSize == 0 {
 		c.ServerBufferQueueSize = 100000
@@ -124,6 +130,14 @@ func (c *Config) Adjust() {
 	if c.GCChannelBufferSize == 0 {
 		c.GCChannelBufferSize = DefaultGCChannelBufferSize
 	}
+}
+
+func defaultServerWorkers(maxProcs int) int {
+	workers := defaultServerWorkersPerCPU * maxProcs
+	if workers < defaultMinServerWorkers {
+		return defaultMinServerWorkers
+	}
+	return workers
 }
 
 // NewClient create client from config

--- a/pkg/common/morpc/cfg_test.go
+++ b/pkg/common/morpc/cfg_test.go
@@ -15,6 +15,7 @@
 package morpc
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
@@ -22,6 +23,11 @@ import (
 )
 
 func TestAdjustConfig(t *testing.T) {
+	previousMaxProcs := runtime.GOMAXPROCS(1)
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(previousMaxProcs)
+	})
+
 	c := Config{}
 	c.Adjust()
 	assert.Equal(t, defaultMaxConnections, c.MaxConnections)
@@ -30,4 +36,44 @@ func TestAdjustConfig(t *testing.T) {
 	assert.Equal(t, toml.ByteSize(defaultBufferSize), c.WriteBufferSize)
 	assert.Equal(t, toml.ByteSize(defaultBufferSize), c.ReadBufferSize)
 	assert.Equal(t, toml.ByteSize(defaultMaxMessageSize), c.MaxMessageSize)
+	assert.Equal(t, defaultMinServerWorkers, c.ServerWorkers)
+
+	c = Config{ServerWorkers: 7}
+	c.Adjust()
+	assert.Equal(t, 7, c.ServerWorkers)
+}
+
+func TestDefaultServerWorkers(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxProcs int
+		expected int
+	}{
+		{
+			name:     "minimum",
+			maxProcs: 1,
+			expected: defaultMinServerWorkers,
+		},
+		{
+			name:     "minimum boundary",
+			maxProcs: 12,
+			expected: defaultMinServerWorkers,
+		},
+		{
+			name:     "scales above minimum",
+			maxProcs: 13,
+			expected: 104,
+		},
+		{
+			name:     "large scheduler",
+			maxProcs: 112,
+			expected: 896,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, defaultServerWorkers(test.maxProcs))
+		})
+	}
 }

--- a/pkg/common/system/system.go
+++ b/pkg/common/system/system.go
@@ -238,6 +238,21 @@ func GoMaxProcs() int {
 	return int(goMaxProcs.Load())
 }
 
+// effectiveGoMaxProcs never raises a scheduler limit already established by
+// the Go runtime or GOMAXPROCS, while preserving the detected CPU upper bound.
+func effectiveGoMaxProcs(availableCPUs, currentMaxProcs int) int {
+	if availableCPUs < 1 {
+		return currentMaxProcs
+	}
+	if currentMaxProcs < 1 {
+		return availableCPUs
+	}
+	if currentMaxProcs < availableCPUs {
+		return currentMaxProcs
+	}
+	return availableCPUs
+}
+
 // SetGoMaxProcs
 // co-operate with pkg/cnservice/service.handleGoMaxProcs
 func SetGoMaxProcs(n int) (ret int) {
@@ -403,5 +418,8 @@ func refreshQuotaConfig() {
 func init() {
 	pid = os.Getpid()
 	refreshQuotaConfig()
-	SetGoMaxProcs(int(cpuNum.Load()))
+	SetGoMaxProcs(effectiveGoMaxProcs(
+		int(cpuNum.Load()),
+		runtime.GOMAXPROCS(0),
+	))
 }

--- a/pkg/common/system/system_test.go
+++ b/pkg/common/system/system_test.go
@@ -107,6 +107,55 @@ func Benchmark_GoRutinues(b *testing.B) {
 	})
 }
 
+func TestEffectiveGoMaxProcs(t *testing.T) {
+	tests := []struct {
+		name            string
+		availableCPUs   int
+		currentMaxProcs int
+		expected        int
+	}{
+		{
+			name:            "available CPUs unavailable",
+			availableCPUs:   0,
+			currentMaxProcs: 8,
+			expected:        8,
+		},
+		{
+			name:            "scheduler limit unavailable",
+			availableCPUs:   24,
+			currentMaxProcs: 0,
+			expected:        24,
+		},
+		{
+			name:            "scheduler limit below available CPUs",
+			availableCPUs:   24,
+			currentMaxProcs: 8,
+			expected:        8,
+		},
+		{
+			name:            "scheduler limit matches available CPUs",
+			availableCPUs:   24,
+			currentMaxProcs: 24,
+			expected:        24,
+		},
+		{
+			name:            "scheduler limit above available CPUs",
+			availableCPUs:   24,
+			currentMaxProcs: 32,
+			expected:        24,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, effectiveGoMaxProcs(
+				test.availableCPUs,
+				test.currentMaxProcs,
+			))
+		})
+	}
+}
+
 // TestSetGoMaxProcs
 // ut for https://github.com/matrixorigin/MO-Cloud/issues/4486
 func TestSetGoMaxProcs(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26299 and #26316.

## What this PR does / why we need it:

The Ubuntu/x86 race job for #26316 failed while `pkg/tests/shard` was starting
its embedded cluster. The first test timed out in `waitAnyShardReadyLocked`; a
later nil dereference was secondary because the shared fixture's `sync.Once`
had already completed without publishing a cluster.

The runner had an 8-CPU scheduling limit but exposed 112 host CPUs through
`runtime.NumCPU()`. Each embedded TN therefore created 896 transaction RPC
workers (`8 * 112`). With the existing heavy-package parallelism of 3, several
race-instrumented clusters created thousands of unnecessary workers and
starved HAKeeper startup.

This fixes the resource model rather than changing test scheduling:

- system initialization never raises a scheduler limit already established by
  the Go runtime or `GOMAXPROCS`;
- the default MORPC server-worker count uses `runtime.GOMAXPROCS(0)`, which is
  the capacity available to Go scheduling, instead of host CPU visibility;
- the existing minimum of 100 workers and multiplier of 8 remain unchanged;
- explicit `server-workers` configuration remains authoritative.

There is no package serialization, test-package allowlist, retry, timeout
extension, assertion weakening, or reduction of `HEAVY_RACE_PARALLEL`.
Bare-metal defaults remain unchanged when `GOMAXPROCS == runtime.NumCPU()`.

## Validation

- `go build ./pkg/common/morpc ./pkg/common/system`
- `go vet ./pkg/common/morpc ./pkg/common/system`
- focused race stress, each separately with a 30-second budget:
  - `TestAdjustConfig`: terminal duration below timer resolution, `count=100`
  - `TestDefaultServerWorkers`: terminal duration below timer resolution,
    `count=100`
  - `TestEffectiveGoMaxProcs`: terminal duration below timer resolution,
    `count=100`
- complete owning packages:
  - `mo-cgo-test -race -count=1 ./pkg/common/morpc`
  - `mo-cgo-test -race -count=1 ./pkg/common/system`
- controlled startup with `GOMAXPROCS=8` preserved 8 rather than raising it to
  the 24 CPUs visible on the local host
- concurrently, with `GOMAXPROCS=8` and `-race`:
  - `TestPartitionBasedShardCanBeCreated` in `pkg/tests/shard`
  - `Test_TxnExecutorExec` in `pkg/tests/txnexecutor`
- `mo-cgo-test -race -count=1 ./pkg/txn/rpc`
- `git diff --check origin/main...HEAD`
