### PR TITLE
test: stabilize embedded and ISCP race tests under CI load

### DIFF
--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -243,10 +243,9 @@ function run_tests(){
             return 0
         fi
 
-        # Keep Dragonboat/logstore packages on one race-test process at a time.
-        # Dynamic ports avoid address collisions, but do not remove their CPU
-        # scheduling sensitivity under race instrumentation. The issues package
-        # also runs multiple embedded services and needs the same runner isolation.
+        # These packages need exclusive runner access. NewTestService callers
+        # bind fixed ports, while the issues package runs multiple embedded
+        # services whose race builds can starve under package-level concurrency.
         if ! serial_test_scope=$(go list ${GO_MODULE_MODE} \
             ./pkg/logservice \
             ./pkg/vm/engine/tae/logstore \

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -243,9 +243,10 @@ function run_tests(){
             return 0
         fi
 
-        # These packages need exclusive runner access. NewTestService callers
-        # bind fixed ports, while the issues package runs multiple embedded
-        # services whose race builds can starve under package-level concurrency.
+        # Keep Dragonboat/logstore packages on one race-test process at a time.
+        # Dynamic ports avoid address collisions, but do not remove their CPU
+        # scheduling sensitivity under race instrumentation. The issues package
+        # also runs multiple embedded services and needs the same runner isolation.
         if ! serial_test_scope=$(go list ${GO_MODULE_MODE} \
             ./pkg/logservice \
             ./pkg/vm/engine/tae/logstore \

--- a/pkg/embed/iceberg_sql_harness_test.go
+++ b/pkg/embed/iceberg_sql_harness_test.go
@@ -54,7 +54,9 @@ const (
 	embeddedIcebergSnapshotCurrent      int64 = 202
 	embeddedIcebergTimestampCutoff            = int64(1767312000000) // 2026-01-02T00:00:00Z in ms.
 	embeddedIcebergAccountRetryInterval       = 100 * time.Millisecond
-	embeddedIcebergAccountCreateTimeout       = 10 * time.Second
+	// CREATE ACCOUNT initializes all tenant system tables, so it can legitimately
+	// take longer than a regular SQL statement on a loaded integration runner.
+	embeddedIcebergAccountCreateTimeout = 30 * time.Second
 )
 
 type embeddedIcebergSQLExecer interface {

--- a/pkg/embed/iceberg_sql_harness_test.go
+++ b/pkg/embed/iceberg_sql_harness_test.go
@@ -72,6 +72,18 @@ func (f embeddedIcebergSQLExecerFunc) ExecContext(ctx context.Context, stmt stri
 	return f(ctx, stmt, args...)
 }
 
+type embeddedIcebergAccountRetryPolicy struct {
+	attemptTimeout time.Duration
+	retryInterval  time.Duration
+}
+
+func defaultEmbeddedIcebergAccountRetryPolicy() embeddedIcebergAccountRetryPolicy {
+	return embeddedIcebergAccountRetryPolicy{
+		attemptTimeout: embeddedIcebergAccountAttemptTimeout,
+		retryInterval:  embeddedIcebergAccountRetryInterval,
+	}
+}
+
 func TestCreateEmbeddedIcebergTenantAccountRetriesConnectionErrors(t *testing.T) {
 	var calls int
 	var statement string
@@ -86,51 +98,102 @@ func TestCreateEmbeddedIcebergTenantAccountRetriesConnectionErrors(t *testing.T)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	require.NoError(t, createEmbeddedIcebergTenantAccount(ctx, execer, "iceacc_retry"))
+	require.NoError(t, createEmbeddedIcebergTenantAccountWithRetryPolicy(
+		ctx,
+		execer,
+		"iceacc_retry",
+		embeddedIcebergAccountRetryPolicy{
+			attemptTimeout: time.Second,
+		},
+	))
 	require.Equal(t, 2, calls)
 	require.Equal(t, "create account if not exists iceacc_retry admin_name 'admin' identified by '111'", statement)
 }
 
 func TestCreateEmbeddedIcebergTenantAccountRetriesExpiredAttempt(t *testing.T) {
 	var calls int
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	outerDeadline, ok := ctx.Deadline()
+	require.True(t, ok)
+
 	execer := embeddedIcebergSQLExecerFunc(func(ctx context.Context, _ string, _ ...any) (sql.Result, error) {
 		calls++
 		if calls == 1 {
-			<-ctx.Done()
-			return nil, ctx.Err()
+			attemptDeadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.True(t, attemptDeadline.Before(outerDeadline))
+			return nil, context.DeadlineExceeded
 		}
 		return nil, nil
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	require.NoError(t, createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+	require.NoError(t, createEmbeddedIcebergTenantAccountWithRetryPolicy(
 		ctx,
 		execer,
 		"iceacc_slow_attempt",
-		10*time.Millisecond,
+		embeddedIcebergAccountRetryPolicy{
+			attemptTimeout: time.Minute,
+		},
 	))
 	require.Equal(t, 2, calls)
 }
 
-func TestCreateEmbeddedIcebergTenantAccountStopsAtOuterDeadline(t *testing.T) {
+func TestCreateEmbeddedIcebergTenantAccountStopsAtExpiredOuterDeadline(t *testing.T) {
 	var calls int
-	execer := embeddedIcebergSQLExecerFunc(func(ctx context.Context, _ string, _ ...any) (sql.Result, error) {
+	execer := embeddedIcebergSQLExecerFunc(func(context.Context, string, ...any) (sql.Result, error) {
 		calls++
-		<-ctx.Done()
-		return nil, ctx.Err()
+		return nil, nil
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 1))
 	defer cancel()
-	err := createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+	<-ctx.Done()
+	err := createEmbeddedIcebergTenantAccountWithRetryPolicy(
 		ctx,
 		execer,
 		"iceacc_outer_deadline",
-		time.Second,
+		embeddedIcebergAccountRetryPolicy{
+			attemptTimeout: time.Second,
+		},
 	)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.Equal(t, 1, calls)
+	require.Zero(t, calls)
+}
+
+func TestCreateEmbeddedIcebergTenantAccountRejectsInvalidRetryPolicy(t *testing.T) {
+	var calls int
+	execer := embeddedIcebergSQLExecerFunc(func(context.Context, string, ...any) (sql.Result, error) {
+		calls++
+		return nil, nil
+	})
+
+	tests := []struct {
+		name   string
+		policy embeddedIcebergAccountRetryPolicy
+	}{
+		{
+			name: "non-positive attempt timeout",
+		},
+		{
+			name: "negative retry interval",
+			policy: embeddedIcebergAccountRetryPolicy{
+				attemptTimeout: time.Second,
+				retryInterval:  -time.Nanosecond,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Error(t, createEmbeddedIcebergTenantAccountWithRetryPolicy(
+				context.Background(),
+				execer,
+				"iceacc_invalid_policy",
+				test.policy,
+			))
+		})
+	}
+	require.Zero(t, calls)
 }
 
 func TestCreateEmbeddedIcebergTenantAccountRejectsNonConnectionErrors(t *testing.T) {
@@ -749,22 +812,25 @@ func openIcebergTenantTestSQL(t *testing.T, c Cluster, rootDB *sql.DB) *embedded
 }
 
 func createEmbeddedIcebergTenantAccount(ctx context.Context, db embeddedIcebergSQLExecer, accountName string) error {
-	return createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+	return createEmbeddedIcebergTenantAccountWithRetryPolicy(
 		ctx,
 		db,
 		accountName,
-		embeddedIcebergAccountAttemptTimeout,
+		defaultEmbeddedIcebergAccountRetryPolicy(),
 	)
 }
 
-func createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+func createEmbeddedIcebergTenantAccountWithRetryPolicy(
 	ctx context.Context,
 	db embeddedIcebergSQLExecer,
 	accountName string,
-	attemptTimeout time.Duration,
+	policy embeddedIcebergAccountRetryPolicy,
 ) error {
-	if attemptTimeout <= 0 {
+	if policy.attemptTimeout <= 0 {
 		return fmt.Errorf("create embedded Iceberg tenant account: attempt timeout must be positive")
+	}
+	if policy.retryInterval < 0 {
+		return fmt.Errorf("create embedded Iceberg tenant account: retry interval must not be negative")
 	}
 
 	stmt := fmt.Sprintf("create account if not exists %s admin_name 'admin' identified by '111'", accountName)
@@ -772,7 +838,7 @@ func createEmbeddedIcebergTenantAccountWithAttemptTimeout(
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return fmt.Errorf("create embedded Iceberg tenant account: %w", ctxErr)
 		}
-		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		attemptCtx, cancel := context.WithTimeout(ctx, policy.attemptTimeout)
 		_, err := db.ExecContext(attemptCtx, stmt)
 		cancel()
 		if err == nil {
@@ -785,7 +851,7 @@ func createEmbeddedIcebergTenantAccountWithAttemptTimeout(
 			return err
 		}
 
-		timer := time.NewTimer(embeddedIcebergAccountRetryInterval)
+		timer := time.NewTimer(policy.retryInterval)
 		select {
 		case <-ctx.Done():
 			timer.Stop()

--- a/pkg/embed/iceberg_sql_harness_test.go
+++ b/pkg/embed/iceberg_sql_harness_test.go
@@ -56,7 +56,10 @@ const (
 	embeddedIcebergAccountRetryInterval       = 100 * time.Millisecond
 	// CREATE ACCOUNT initializes all tenant system tables, so it can legitimately
 	// take longer than a regular SQL statement on a loaded integration runner.
-	embeddedIcebergAccountCreateTimeout = 30 * time.Second
+	// Keep an outer setup budget separate from each attempt so a slow or lost
+	// response cannot consume the retry budget it is supposed to trigger.
+	embeddedIcebergAccountAttemptTimeout = 10 * time.Second
+	embeddedIcebergAccountCreateTimeout  = 30 * time.Second
 )
 
 type embeddedIcebergSQLExecer interface {
@@ -86,6 +89,28 @@ func TestCreateEmbeddedIcebergTenantAccountRetriesConnectionErrors(t *testing.T)
 	require.NoError(t, createEmbeddedIcebergTenantAccount(ctx, execer, "iceacc_retry"))
 	require.Equal(t, 2, calls)
 	require.Equal(t, "create account if not exists iceacc_retry admin_name 'admin' identified by '111'", statement)
+}
+
+func TestCreateEmbeddedIcebergTenantAccountRetriesExpiredAttempt(t *testing.T) {
+	var calls int
+	execer := embeddedIcebergSQLExecerFunc(func(ctx context.Context, _ string, _ ...any) (sql.Result, error) {
+		calls++
+		if calls == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return nil, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+		ctx,
+		execer,
+		"iceacc_slow_attempt",
+		10*time.Millisecond,
+	))
+	require.Equal(t, 2, calls)
 }
 
 func TestCreateEmbeddedIcebergTenantAccountRejectsNonConnectionErrors(t *testing.T) {
@@ -704,11 +729,34 @@ func openIcebergTenantTestSQL(t *testing.T, c Cluster, rootDB *sql.DB) *embedded
 }
 
 func createEmbeddedIcebergTenantAccount(ctx context.Context, db embeddedIcebergSQLExecer, accountName string) error {
+	return createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+		ctx,
+		db,
+		accountName,
+		embeddedIcebergAccountAttemptTimeout,
+	)
+}
+
+func createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+	ctx context.Context,
+	db embeddedIcebergSQLExecer,
+	accountName string,
+	attemptTimeout time.Duration,
+) error {
+	if attemptTimeout <= 0 {
+		return fmt.Errorf("create embedded Iceberg tenant account: attempt timeout must be positive")
+	}
+
 	stmt := fmt.Sprintf("create account if not exists %s admin_name 'admin' identified by '111'", accountName)
 	for {
-		_, err := db.ExecContext(ctx, stmt)
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		_, err := db.ExecContext(attemptCtx, stmt)
+		cancel()
 		if err == nil {
 			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("create embedded Iceberg tenant account: %w (last connection error: %v)", ctxErr, err)
 		}
 		if !morpc.IsConnectionError(err) {
 			return err

--- a/pkg/embed/iceberg_sql_harness_test.go
+++ b/pkg/embed/iceberg_sql_harness_test.go
@@ -113,6 +113,26 @@ func TestCreateEmbeddedIcebergTenantAccountRetriesExpiredAttempt(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+func TestCreateEmbeddedIcebergTenantAccountStopsAtOuterDeadline(t *testing.T) {
+	var calls int
+	execer := embeddedIcebergSQLExecerFunc(func(ctx context.Context, _ string, _ ...any) (sql.Result, error) {
+		calls++
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err := createEmbeddedIcebergTenantAccountWithAttemptTimeout(
+		ctx,
+		execer,
+		"iceacc_outer_deadline",
+		time.Second,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, calls)
+}
+
 func TestCreateEmbeddedIcebergTenantAccountRejectsNonConnectionErrors(t *testing.T) {
 	var calls int
 	execer := embeddedIcebergSQLExecerFunc(func(_ context.Context, _ string, _ ...any) (sql.Result, error) {
@@ -749,6 +769,9 @@ func createEmbeddedIcebergTenantAccountWithAttemptTimeout(
 
 	stmt := fmt.Sprintf("create account if not exists %s admin_name 'admin' identified by '111'", accountName)
 	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("create embedded Iceberg tenant account: %w", ctxErr)
+		}
 		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
 		_, err := db.ExecContext(attemptCtx, stmt)
 		cancel()

--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -138,6 +138,12 @@ func getSqlForAccountInfo(like *tree.ComparisonExpr, accId int64, needObjectCoun
 	return fmt.Sprintf(getAccountInfoFormatV2, dbCountFilter, tblCountFilter, objectCountExpr, clause)
 }
 
+func needShowAccountsObjectCount(account *TenantInfo, sa *tree.ShowAccounts, database string) bool {
+	return account.IsSysTenant() &&
+		sa.Like == nil &&
+		database == mometric.MetricDBConst
+}
+
 func buildAccountInfoClause(like *tree.ComparisonExpr, accId int64) string {
 	predicates := make([]string, 0, 2)
 	if like != nil {
@@ -542,14 +548,13 @@ func doShowAccounts(ctx context.Context, ses *Session, sa *tree.ShowAccounts) (e
 		return err
 	}
 
-	var needUpdateObjectCountMetric bool
-	if account.IsSysTenant() &&
-		sa.Like == nil &&
-		ses.GetTxnCompileCtx().GetDatabase() == mometric.MetricDBConst {
-		// storage usage cron task try to get storage usage for all accounts,
-		// adding an extra col to return object count val for all accounts.
-		needUpdateObjectCountMetric = true
-	}
+	// The storage-usage cron task queries all accounts from the metrics
+	// database and needs an extra object-count column in that result.
+	needUpdateObjectCountMetric := needShowAccountsObjectCount(
+		account,
+		sa,
+		ses.GetTxnCompileCtx().GetDatabase(),
+	)
 
 	if account.IsSysTenant() {
 		sql = getSqlForAccountInfo(sa.Like, -1, needUpdateObjectCountMetric)

--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -138,10 +138,25 @@ func getSqlForAccountInfo(like *tree.ComparisonExpr, accId int64, needObjectCoun
 	return fmt.Sprintf(getAccountInfoFormatV2, dbCountFilter, tblCountFilter, objectCountExpr, clause)
 }
 
-func needShowAccountsObjectCount(account *TenantInfo, sa *tree.ShowAccounts, database string) bool {
-	return account.IsSysTenant() &&
+func buildShowAccountsSQL(
+	account *TenantInfo,
+	sa *tree.ShowAccounts,
+	database string,
+) (sql string, needObjectCount bool) {
+	isSysTenant := account.IsSysTenant()
+	accountID := int64(account.GetTenantID())
+	like := sa.Like
+	if isSysTenant {
+		accountID = -1
+	} else {
+		// Non-system tenants can only inspect their own account. Preserve the
+		// existing behavior of ignoring a SHOW ACCOUNTS LIKE clause here.
+		like = nil
+	}
+	needObjectCount = isSysTenant &&
 		sa.Like == nil &&
 		database == mometric.MetricDBConst
+	return getSqlForAccountInfo(like, accountID, needObjectCount), needObjectCount
 }
 
 func buildAccountInfoClause(like *tree.ComparisonExpr, accId int64) string {
@@ -548,16 +563,13 @@ func doShowAccounts(ctx context.Context, ses *Session, sa *tree.ShowAccounts) (e
 		return err
 	}
 
-	// The storage-usage cron task queries all accounts from the metrics
-	// database and needs an extra object-count column in that result.
-	needUpdateObjectCountMetric := needShowAccountsObjectCount(
-		account,
-		sa,
-		ses.GetTxnCompileCtx().GetDatabase(),
-	)
-
+	var needUpdateObjectCountMetric bool
 	if account.IsSysTenant() {
-		sql = getSqlForAccountInfo(sa.Like, -1, needUpdateObjectCountMetric)
+		sql, needUpdateObjectCountMetric = buildShowAccountsSQL(
+			account,
+			sa,
+			ses.GetTxnCompileCtx().GetDatabase(),
+		)
 		accInfosBatches, accIds, err = getAccountInfo(ctx, bh, sql, mp)
 		if err != nil {
 			return err
@@ -570,7 +582,11 @@ func doShowAccounts(ctx context.Context, ses *Session, sa *tree.ShowAccounts) (e
 		}
 		// switch to the sys account to get account info
 		newCtx := defines.AttachAccountId(ctx, uint32(sysAccountID))
-		sql = getSqlForAccountInfo(nil, int64(account.GetTenantID()), needUpdateObjectCountMetric)
+		sql, needUpdateObjectCountMetric = buildShowAccountsSQL(
+			account,
+			sa,
+			ses.GetTxnCompileCtx().GetDatabase(),
+		)
 		accInfosBatches, accIds, err = getAccountInfo(newCtx, bh, sql, mp)
 		if err != nil {
 			return err

--- a/pkg/frontend/show_account_test.go
+++ b/pkg/frontend/show_account_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/util/metric/mometric"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/cmd_util"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 	"github.com/stretchr/testify/assert"
@@ -148,6 +149,59 @@ func Test_getSqlForAccountInfo(t *testing.T) {
 			}
 			_, err = parsers.ParseOne(context.Background(), dialect.MYSQL, got, 1)
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNeedShowAccountsObjectCount(t *testing.T) {
+	sysAccount := &TenantInfo{Tenant: GetDefaultTenant()}
+	tenantAccount := &TenantInfo{Tenant: "tenant"}
+	allAccounts := &tree.ShowAccounts{}
+	filteredAccounts := &tree.ShowAccounts{
+		Like: &tree.ComparisonExpr{},
+	}
+
+	tests := []struct {
+		name      string
+		account   *TenantInfo
+		statement *tree.ShowAccounts
+		database  string
+		want      bool
+	}{
+		{
+			name:      "metrics cron query",
+			account:   sysAccount,
+			statement: allAccounts,
+			database:  mometric.MetricDBConst,
+			want:      true,
+		},
+		{
+			name:      "non metrics database",
+			account:   sysAccount,
+			statement: allAccounts,
+			database:  "mo_catalog",
+		},
+		{
+			name:      "filtered sys query",
+			account:   sysAccount,
+			statement: filteredAccounts,
+			database:  mometric.MetricDBConst,
+		},
+		{
+			name:      "tenant query",
+			account:   tenantAccount,
+			statement: allAccounts,
+			database:  mometric.MetricDBConst,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, needShowAccountsObjectCount(
+				test.account,
+				test.statement,
+				test.database,
+			))
 		})
 	}
 }

--- a/pkg/frontend/show_account_test.go
+++ b/pkg/frontend/show_account_test.go
@@ -153,55 +153,87 @@ func Test_getSqlForAccountInfo(t *testing.T) {
 	}
 }
 
-func TestNeedShowAccountsObjectCount(t *testing.T) {
+func TestBuildShowAccountsSQL(t *testing.T) {
 	sysAccount := &TenantInfo{Tenant: GetDefaultTenant()}
-	tenantAccount := &TenantInfo{Tenant: "tenant"}
+	tenantAccount := &TenantInfo{Tenant: "tenant", TenantID: 42}
 	allAccounts := &tree.ShowAccounts{}
-	filteredAccounts := &tree.ShowAccounts{
-		Like: &tree.ComparisonExpr{},
-	}
+	filtered, err := parsers.ParseOne(context.Background(), dialect.MYSQL, "show accounts like 'tenant%'", 1)
+	require.NoError(t, err)
+	filteredAccounts := filtered.(*tree.ShowAccounts)
 
 	tests := []struct {
-		name      string
-		account   *TenantInfo
-		statement *tree.ShowAccounts
-		database  string
-		want      bool
+		name            string
+		account         *TenantInfo
+		statement       *tree.ShowAccounts
+		database        string
+		wantObjectCount bool
+		wantContains    []string
+		wantNotContains []string
 	}{
 		{
-			name:      "metrics cron query",
-			account:   sysAccount,
-			statement: allAccounts,
-			database:  mometric.MetricDBConst,
-			want:      true,
+			name:            "metrics cron query",
+			account:         sysAccount,
+			statement:       allAccounts,
+			database:        mometric.MetricDBConst,
+			wantObjectCount: true,
+			wantContains: []string{
+				"CAST(0 AS BIGINT) AS object_count",
+			},
+			wantNotContains: []string{
+				"where ma.account_id =",
+			},
 		},
 		{
 			name:      "non metrics database",
 			account:   sysAccount,
 			statement: allAccounts,
 			database:  "mo_catalog",
+			wantNotContains: []string{
+				"AS object_count",
+			},
 		},
 		{
 			name:      "filtered sys query",
 			account:   sysAccount,
 			statement: filteredAccounts,
 			database:  mometric.MetricDBConst,
+			wantContains: []string{
+				"where ma.account_name like 'tenant%'",
+			},
+			wantNotContains: []string{
+				"AS object_count",
+			},
 		},
 		{
 			name:      "tenant query",
 			account:   tenantAccount,
-			statement: allAccounts,
+			statement: filteredAccounts,
 			database:  mometric.MetricDBConst,
+			wantContains: []string{
+				"WHERE md.account_id = 42",
+				"AND mt.account_id = 42",
+				"where ma.account_id = 42",
+			},
+			wantNotContains: []string{
+				"AS object_count",
+				"account_name like",
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.want, needShowAccountsObjectCount(
-				test.account,
-				test.statement,
-				test.database,
-			))
+			rawSQL, needObjectCount := buildShowAccountsSQL(test.account, test.statement, test.database)
+			sql := normalizeSQL(rawSQL)
+			require.Equal(t, test.wantObjectCount, needObjectCount)
+			for _, fragment := range test.wantContains {
+				require.Contains(t, sql, normalizeSQL(fragment))
+			}
+			for _, fragment := range test.wantNotContains {
+				require.NotContains(t, sql, normalizeSQL(fragment))
+			}
+			_, err := parsers.ParseOne(context.Background(), dialect.MYSQL, sql, 1)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/iscp/iteration.go
+++ b/pkg/iscp/iteration.go
@@ -246,6 +246,7 @@ func ExecuteIterationWithRuntime(
 	// injection is for ut
 	if msg, injected := objectio.ISCPExecutorInjected(); injected && msg == "collectChanges" {
 		err = moerr.NewInternalErrorNoCtx(msg)
+		objectio.WaitForISCPExecutorFault(ctx, msg)
 	}
 	// injection is for ut
 	if msg, injected := objectio.ISCPExecutorInjected(); injected && strings.HasPrefix(msg, "iteration:") {
@@ -421,6 +422,7 @@ func runISCPTaskIterationConsumers(
 			// injection is for ut
 			if msg, injected := objectio.ISCPExecutorInjected(); injected && msg == "changesNext" {
 				err = moerr.NewInternalErrorNoCtx(msg)
+				objectio.WaitForISCPExecutorFault(ctxWithCancel, msg)
 			}
 			if err != nil {
 				jobNames := ""

--- a/pkg/iscp/mock_consumer.go
+++ b/pkg/iscp/mock_consumer.go
@@ -220,12 +220,14 @@ func (s *interalSqlConsumer) Consume(ctx context.Context, data DataRetriever) er
 	}
 
 	if msg, injected := objectio.ISCPExecutorInjected(); injected && msg == "consume" {
+		objectio.WaitForISCPExecutorFault(ctx, msg)
 		return moerr.NewInternalErrorNoCtx(msg)
 	}
 	if msg, injected := objectio.ISCPExecutorInjected(); injected && strings.HasPrefix(msg, "consumeWithJobName") {
 		strs := strings.Split(msg, ":")
 		for i := 1; i < len(strs); i++ {
 			if s.jobName == strs[i] {
+				objectio.WaitForISCPExecutorFault(ctx, msg)
 				return moerr.NewInternalErrorNoCtx(strs[0])
 			}
 		}

--- a/pkg/objectio/injects.go
+++ b/pkg/objectio/injects.go
@@ -466,6 +466,18 @@ func ISCPExecutorInjected() (string, bool) {
 	return sarg, injected
 }
 
+// ISCPExecutorFaultWaitKey identifies the optional phase barrier for one
+// executor fault. Tests install the barrier before enabling the matching fault,
+// then observe its waiter to prove that the asynchronous worker reached the
+// intended failure point.
+func ISCPExecutorFaultWaitKey(msg string) string {
+	return FJ_CDCExecutor + ":" + msg
+}
+
+func WaitForISCPExecutorFault(ctx context.Context, msg string) {
+	WaitInjectedCtx(ctx, ISCPExecutorFaultWaitKey(msg))
+}
+
 func CDCScanTableInjected() (string, bool) {
 	_, sarg, injected := fault.TriggerFault(FJ_CDCScanTable)
 	return sarg, injected

--- a/pkg/util/test/cron_task_test.go
+++ b/pkg/util/test/cron_task_test.go
@@ -26,8 +26,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/config"
-	"github.com/matrixorigin/matrixone/pkg/defines"
-	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/frontend"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -120,55 +118,4 @@ func TestGetTenantInfo(t *testing.T) {
 	require.Equal(t, "sys", tenant.GetTenant())
 	require.Equal(t, "internal", tenant.GetUser())
 	require.Equal(t, "moadmin", tenant.GetDefaultRole())
-}
-
-func TestCalculateObjectCount(t *testing.T) {
-	c, err := embed.NewCluster(embed.WithCNCount(1))
-	require.NoError(t, err)
-	require.NoError(t, c.Start())
-
-	svc, err := c.GetCNService(0)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(0))
-
-	// query with metrics db
-	{
-		queryOpts := ie.NewOptsBuilder().Database(mometric.MetricDBConst).Internal(true).Finish()
-
-		result := frontend.NewInternalExecutor(svc.ServiceID()).Query(ctx, mometric.ShowAllAccountSQL, queryOpts)
-		require.NoError(t, result.Error())
-
-		name2idx := make(map[string]uint64)
-		for colIdx := uint64(0); colIdx < result.ColumnCount(); colIdx++ {
-			colName, _, _, err := result.Column(ctx, colIdx)
-			require.NoError(t, err)
-			name2idx[colName] = colIdx
-		}
-
-		_, ok := name2idx[mometric.ColumnObjectCount]
-		require.True(t, ok)
-	}
-
-	{
-		queryOpts := ie.NewOptsBuilder().Internal(true).Finish()
-
-		result := frontend.NewInternalExecutor(svc.ServiceID()).Query(ctx, mometric.ShowAllAccountSQL, queryOpts)
-		require.NoError(t, result.Error())
-
-		name2idx := make(map[string]uint64)
-		for colIdx := uint64(0); colIdx < result.ColumnCount(); colIdx++ {
-			colName, _, _, err := result.Column(ctx, colIdx)
-			require.NoError(t, err)
-			name2idx[colName] = colIdx
-		}
-
-		_, ok := name2idx[mometric.ColumnObjectCount]
-		require.False(t, ok)
-	}
-
-	svc.Close()
 }

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -2454,15 +2454,12 @@ func TestISCPExecutor4(t *testing.T) {
 	require.NoError(t, cdcExecutor.Start())
 	defer cdcExecutor.Stop()
 
-	fault.Enable()
+	require.True(t, fault.Enable(), "fault injection was already enabled before TestISCPExecutor4")
 	t.Cleanup(func() {
 		fault.Disable()
 	})
 
-	injectCDCExecutorFault := func(name string) func() {
-		remove, err := objectio.InjectCDCExecutor(name)
-		require.NoError(t, err)
-
+	registerFaultCleanup := func(remove func() (bool, error)) func() {
 		var (
 			once      sync.Once
 			removeOK  bool
@@ -2477,6 +2474,51 @@ func TestISCPExecutor4(t *testing.T) {
 		}
 		t.Cleanup(cleanup)
 		return cleanup
+	}
+
+	addFaultPoint := func(name, action, arg string) func() {
+		require.NoError(t, fault.AddFaultPoint(
+			ctx,
+			name,
+			":::",
+			action,
+			0,
+			arg,
+			false,
+		))
+		return registerFaultCleanup(func() (bool, error) {
+			return fault.RemoveFaultPoint(context.Background(), name)
+		})
+	}
+
+	injectCDCExecutorFault := func(name string) (waitUntilHit func(time.Time), remove func()) {
+		waitKey := objectio.ISCPExecutorFaultWaitKey(name)
+		waitersKey := waitKey + ":waiters"
+		removeWait := addFaultPoint(waitKey, "wait", "")
+		removeWaitersProbe := addFaultPoint(waitersKey, "getwaiters", waitKey)
+
+		removeInjection, err := objectio.InjectCDCExecutor(name)
+		require.NoError(t, err)
+		removeInjectedFault := registerFaultCleanup(removeInjection)
+
+		waitUntilHit = func(deadline time.Time) {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				require.FailNowf(t, "ISCP fault phase budget exhausted", "fault=%s", name)
+			}
+			require.Eventually(t, func() bool {
+				waiters, _, ok := fault.TriggerFault(waitersKey)
+				return ok && waiters > 0
+			}, remaining, 10*time.Millisecond, "ISCP worker did not reach injected fault %s", name)
+		}
+		remove = func() {
+			// Stop new failures before releasing the worker already parked at
+			// the exact injected failure point.
+			removeInjectedFault()
+			removeWait()
+			removeWaitersProbe()
+		}
+		return waitUntilHit, remove
 	}
 
 	registerFn := func(jobName string) {
@@ -2512,66 +2554,78 @@ func TestISCPExecutor4(t *testing.T) {
 		return types.TimestampToTS(txn.Txn().CommitTS)
 	}
 
-	const indexCount = 3
-	checkWatermarkFn := func(indexName string, target types.TS, expectResult bool, waitFor time.Duration) {
-		reached := func() bool {
-			ts, ok := cdcExecutor.GetWatermark(accountId, tableID, indexName)
-			return ok && ts.GE(&target)
-		}
-		if expectResult {
-			// Recovery is asynchronous and shares the race runner with the TAE
-			// engine. The budget is only a hang guard: successful checks return
-			// immediately, while a failure includes the last observed watermark.
-			waitForISCPWatermark(
+	const (
+		indexCount = 3
+		// Observable state transitions, rather than this duration, are the
+		// correctness oracle. This only bounds a broken asynchronous phase;
+		// successful phases return as soon as every watermark is durable.
+		iscpPhaseHangGuard = 30 * time.Second
+	)
+	waitForAllWatermarks := func(target types.TS, deadline time.Time) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			require.FailNowf(
 				t,
-				func() (types.TS, bool) {
-					return cdcExecutor.GetWatermark(accountId, tableID, indexName)
-				},
-				target,
-				waitFor,
-				10*time.Millisecond,
+				"ISCP phase budget exhausted before watermark wait",
+				"account=%d table=%d target=%s",
 				accountId,
 				tableID,
-				indexName,
-			)
-		} else {
-			require.Never(
-				t,
-				reached,
-				100*time.Millisecond,
-				10*time.Millisecond,
-				"job %s unexpectedly reached target %s",
-				indexName,
 				target.ToString(),
 			)
 		}
-	}
 
-	waitForAllWatermarks := func(target types.TS) {
-		deadline := time.Now().Add(30 * time.Second)
+		reached := assert.Eventually(t, func() bool {
+			for i := 0; i < indexCount; i++ {
+				current, found := cdcExecutor.GetWatermark(
+					accountId,
+					tableID,
+					fmt.Sprintf("hnsw_idx_%d", i),
+				)
+				if !found || current.LT(&target) {
+					return false
+				}
+			}
+			return true
+		}, remaining, 10*time.Millisecond)
+		if reached {
+			return
+		}
+
 		for i := 0; i < indexCount; i++ {
 			indexName := fmt.Sprintf("hnsw_idx_%d", i)
 			current, found := cdcExecutor.GetWatermark(accountId, tableID, indexName)
-			if found && current.GE(&target) {
-				continue
-			}
-
-			remaining := time.Until(deadline)
-			if remaining <= 0 {
-				require.FailNowf(
-					t,
-					"ISCP watermark recovery budget exhausted",
-					"account=%d table=%d job=%s found=%t current=%s target=%s",
-					accountId,
-					tableID,
-					indexName,
-					found,
-					current.ToString(),
-					target.ToString(),
-				)
-			}
-			checkWatermarkFn(indexName, target, true, remaining)
+			t.Logf(
+				"ISCP watermark timeout: account=%d table=%d job=%s found=%t current=%s target=%s",
+				accountId,
+				tableID,
+				indexName,
+				found,
+				current.ToString(),
+				target.ToString(),
+			)
 		}
+		require.FailNow(t, "not all ISCP watermarks reached the target")
+	}
+
+	exerciseFaultRecovery := func(name string, batchIndex int) {
+		deadline := time.Now().Add(iscpPhaseHangGuard)
+		waitUntilHit, removeFault := injectCDCExecutorFault(name)
+		target := appendFn(batchIndex)
+		waitUntilHit(deadline)
+
+		current, found := cdcExecutor.GetWatermark(accountId, tableID, "hnsw_idx_0")
+		require.True(t, found)
+		require.Truef(
+			t,
+			current.LT(&target),
+			"fault %s did not stop hnsw_idx_0 before target: current=%s target=%s",
+			name,
+			current.ToString(),
+			target.ToString(),
+		)
+
+		removeFault()
+		waitForAllWatermarks(target, deadline)
 	}
 
 	for i := 0; i < indexCount; i++ {
@@ -2582,38 +2636,21 @@ func TestISCPExecutor4(t *testing.T) {
 	appendFn(1)
 
 	// insertAsyncIndexIterations failed
+	deadline := time.Now().Add(iscpPhaseHangGuard)
 	target := appendFn(2)
-	waitForAllWatermarks(target)
+	waitForAllWatermarks(target, deadline)
 
 	// collectChanges failed
-	rmFn := injectCDCExecutorFault("collectChanges")
-	target = appendFn(3)
-	checkWatermarkFn("hnsw_idx_0", target, false, 0)
-	rmFn()
-	waitForAllWatermarks(target)
+	exerciseFaultRecovery("collectChanges", 3)
 
 	// changesNext failed
-	rmFn = injectCDCExecutorFault("changesNext")
-	target = appendFn(6)
-	checkWatermarkFn("hnsw_idx_0", target, false, 0)
-	rmFn()
-	waitForAllWatermarks(target)
+	exerciseFaultRecovery("changesNext", 6)
 
 	// consume failed
-	rmFn = injectCDCExecutorFault("consume")
-	target = appendFn(7)
-	checkWatermarkFn("hnsw_idx_0", target, false, 0)
-	rmFn()
-	waitForAllWatermarks(target)
+	exerciseFaultRecovery("consume", 7)
+
 	// consume, firstTxn failed
-	rmFn = injectCDCExecutorFault("consumeWithJobName:hnsw_idx_0")
-	target = appendFn(8)
-	checkWatermarkFn("hnsw_idx_0", target, false, 0)
-	// for i := 1; i < indexCount; i++ {
-	// 	CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, fmt.Sprintf("hnsw_idx_%d", i))
-	// }
-	rmFn()
-	waitForAllWatermarks(target)
+	exerciseFaultRecovery("consumeWithJobName:hnsw_idx_0", 8)
 
 	for i := 0; i < indexCount; i++ {
 		CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, fmt.Sprintf("hnsw_idx_%d", i))

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -2419,7 +2419,7 @@ func TestISCPExecutor4(t *testing.T) {
 
 	tableID := rel.GetTableID(ctxWithTimeout)
 
-	txn.Commit(ctxWithTimeout)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
 	// init cdc executor
 	checkLeaseStub := gostub.Stub(
@@ -2451,11 +2451,33 @@ func TestISCPExecutor4(t *testing.T) {
 	require.NoError(t, err)
 	cdcExecutor.SetRpcHandleFn(taeHandler.GetRPCHandle().HandleGetChangedTableList)
 
-	cdcExecutor.Start()
+	require.NoError(t, cdcExecutor.Start())
 	defer cdcExecutor.Stop()
 
 	fault.Enable()
-	defer fault.Disable()
+	t.Cleanup(func() {
+		fault.Disable()
+	})
+
+	injectCDCExecutorFault := func(name string) func() {
+		remove, err := objectio.InjectCDCExecutor(name)
+		require.NoError(t, err)
+
+		var (
+			once      sync.Once
+			removeOK  bool
+			removeErr error
+		)
+		cleanup := func() {
+			once.Do(func() {
+				removeOK, removeErr = remove()
+			})
+			require.NoError(t, removeErr)
+			require.True(t, removeOK)
+		}
+		t.Cleanup(cleanup)
+		return cleanup
+	}
 
 	registerFn := func(jobName string) {
 		txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
@@ -2474,9 +2496,9 @@ func TestISCPExecutor4(t *testing.T) {
 			},
 			false,
 		)
-		assert.True(t, ok)
-		assert.NoError(t, err)
-		assert.NoError(t, txn.Commit(ctxWithTimeout))
+		require.True(t, ok)
+		require.NoError(t, err)
+		require.NoError(t, txn.Commit(ctxWithTimeout))
 	}
 
 	appendFn := func(idx int) types.TS {
@@ -2490,19 +2512,68 @@ func TestISCPExecutor4(t *testing.T) {
 		return types.TimestampToTS(txn.Txn().CommitTS)
 	}
 
-	checkWaterMarkFn := func(indexName string, target types.TS, expectResult bool) {
+	const indexCount = 3
+	checkWatermarkFn := func(indexName string, target types.TS, expectResult bool, waitFor time.Duration) {
 		reached := func() bool {
 			ts, ok := cdcExecutor.GetWatermark(accountId, tableID, indexName)
 			return ok && ts.GE(&target)
 		}
 		if expectResult {
-			require.Eventually(t, reached, 10*time.Second, 10*time.Millisecond, indexName)
+			// Recovery is asynchronous and shares the race runner with the TAE
+			// engine. The budget is only a hang guard: successful checks return
+			// immediately, while a failure includes the last observed watermark.
+			waitForISCPWatermark(
+				t,
+				func() (types.TS, bool) {
+					return cdcExecutor.GetWatermark(accountId, tableID, indexName)
+				},
+				target,
+				waitFor,
+				10*time.Millisecond,
+				accountId,
+				tableID,
+				indexName,
+			)
 		} else {
-			require.Never(t, reached, 100*time.Millisecond, 10*time.Millisecond, indexName)
+			require.Never(
+				t,
+				reached,
+				100*time.Millisecond,
+				10*time.Millisecond,
+				"job %s unexpectedly reached target %s",
+				indexName,
+				target.ToString(),
+			)
 		}
 	}
 
-	indexCount := 3
+	waitForAllWatermarks := func(target types.TS) {
+		deadline := time.Now().Add(30 * time.Second)
+		for i := 0; i < indexCount; i++ {
+			indexName := fmt.Sprintf("hnsw_idx_%d", i)
+			current, found := cdcExecutor.GetWatermark(accountId, tableID, indexName)
+			if found && current.GE(&target) {
+				continue
+			}
+
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				require.FailNowf(
+					t,
+					"ISCP watermark recovery budget exhausted",
+					"account=%d table=%d job=%s found=%t current=%s target=%s",
+					accountId,
+					tableID,
+					indexName,
+					found,
+					current.ToString(),
+					target.ToString(),
+				)
+			}
+			checkWatermarkFn(indexName, target, true, remaining)
+		}
+	}
+
 	for i := 0; i < indexCount; i++ {
 		registerFn(fmt.Sprintf("hnsw_idx_%d", i))
 	}
@@ -2512,51 +2583,37 @@ func TestISCPExecutor4(t *testing.T) {
 
 	// insertAsyncIndexIterations failed
 	target := appendFn(2)
-	for i := 0; i < indexCount; i++ {
-		checkWaterMarkFn(fmt.Sprintf("hnsw_idx_%d", i), target, true)
-	}
+	waitForAllWatermarks(target)
 
 	// collectChanges failed
-	rmFn, err := objectio.InjectCDCExecutor("collectChanges")
-	assert.NoError(t, err)
+	rmFn := injectCDCExecutorFault("collectChanges")
 	target = appendFn(3)
-	checkWaterMarkFn("hnsw_idx_0", target, false)
+	checkWatermarkFn("hnsw_idx_0", target, false, 0)
 	rmFn()
-	for i := 0; i < indexCount; i++ {
-		checkWaterMarkFn(fmt.Sprintf("hnsw_idx_%d", i), target, true)
-	}
+	waitForAllWatermarks(target)
 
 	// changesNext failed
-	rmFn, err = objectio.InjectCDCExecutor("changesNext")
-	assert.NoError(t, err)
+	rmFn = injectCDCExecutorFault("changesNext")
 	target = appendFn(6)
-	checkWaterMarkFn("hnsw_idx_0", target, false)
+	checkWatermarkFn("hnsw_idx_0", target, false, 0)
 	rmFn()
-	for i := 0; i < indexCount; i++ {
-		checkWaterMarkFn(fmt.Sprintf("hnsw_idx_%d", i), target, true)
-	}
+	waitForAllWatermarks(target)
 
 	// consume failed
-	rmFn, err = objectio.InjectCDCExecutor("consume")
-	assert.NoError(t, err)
+	rmFn = injectCDCExecutorFault("consume")
 	target = appendFn(7)
-	checkWaterMarkFn("hnsw_idx_0", target, false)
+	checkWatermarkFn("hnsw_idx_0", target, false, 0)
 	rmFn()
-	for i := 0; i < indexCount; i++ {
-		checkWaterMarkFn(fmt.Sprintf("hnsw_idx_%d", i), target, true)
-	}
+	waitForAllWatermarks(target)
 	// consume, firstTxn failed
-	rmFn, err = objectio.InjectCDCExecutor("consumeWithJobName:hnsw_idx_0")
-	assert.NoError(t, err)
+	rmFn = injectCDCExecutorFault("consumeWithJobName:hnsw_idx_0")
 	target = appendFn(8)
-	checkWaterMarkFn("hnsw_idx_0", target, false)
+	checkWatermarkFn("hnsw_idx_0", target, false, 0)
 	// for i := 1; i < indexCount; i++ {
 	// 	CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, fmt.Sprintf("hnsw_idx_%d", i))
 	// }
 	rmFn()
-	for i := 0; i < indexCount; i++ {
-		checkWaterMarkFn(fmt.Sprintf("hnsw_idx_%d", i), target, true)
-	}
+	waitForAllWatermarks(target)
 
 	for i := 0; i < indexCount; i++ {
 		CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, fmt.Sprintf("hnsw_idx_%d", i))


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Test and CI

## Which issue(s) this PR fixes

Fixes #26107

## What this PR does / why we need it

This PR fixes three timing-sensitive race-UT failures by closing their timeout and asynchronous-state contracts. Successful paths do not sleep, and correctness is asserted from observable state transitions.

### Embedded Iceberg tenant setup

`CREATE ACCOUNT IF NOT EXISTS` initializes tenant catalog/system tables and is safe to retry. The old helper used one 10s context for both the active SQL request and the whole retry loop. Once an attempt consumed that deadline, the retry path had no remaining budget.

- bound each SQL attempt independently;
- give the complete create operation a separate 30s budget;
- stop immediately when the outer context expires;
- retry only connection/transient errors;
- validate retry policy and cover attempt expiry, outer expiry, cancellation, connection errors, and definitive SQL errors without short timing assertions.

### Object-count schema coverage

`TestCalculateObjectCount` started a complete Log/TN/CN cluster only to verify whether the frontend-generated `SHOW ACCOUNTS` SQL includes `object_count`. Under race load, that exposed unrelated Dragonboat/HAKeeper bootstrap timing.

The production decision and the SQL it controls now come from one helper. Focused tests validate and parse the actual generated SQL for:

- sys tenant + metrics database + no `LIKE` (include `object_count`);
- non-metrics database;
- filtered sys queries;
- non-system tenants, including preservation of the existing account-only filtering behavior.

The full embedded-cluster test is removed; existing frontend tests continue to cover the projection itself.

### ISCP recovery test

The old test used `Never(100ms)` to infer that an asynchronous failure happened, then removed the fault and waited up to 10s per watermark. It never proved that the worker had reached the intended fault, so scheduler load could make the injection disappear before it was exercised. In the reported run, recovery also crossed the fixed assertion deadline shortly after the transaction committed.

Each injected phase now has an optional context-aware fault barrier:

1. install the barrier and the executor fault;
2. append the target transaction;
3. wait until a worker is observably parked at that exact fault;
4. assert the target watermark has not advanced;
5. remove the main fault before releasing all parked workers;
6. wait for all three watermarks under one 30s phase hang guard.

All fault points have exactly-once cleanup, including `FailNow` paths. Normal production execution is unchanged because the barrier exists only when a test installs its keyed fault point.

Failure evidence: https://github.com/matrixorigin/matrixone/actions/runs/30469746913/job/90636646900?pr=26161

## Scope

The earlier comment-only `optools/run_ut.sh` change was removed. This PR does not change package scheduling or globally serialize unrelated tests.

## Validation

- CGo-configured `go build` for changed non-test packages
- CGo-configured `go vet` for all owning packages
- `make err-check`
- `bash -n optools/run_ut.sh`
- `git diff --check`
- adaptive exact race tests:
  - `TestISCPExecutor4`: measured 5.32s, `-race -count=5`
  - six embedded account retry/deadline tests: each `-race -count=100`
  - `TestBuildShowAccountsSQL`: `-race -count=100`
- complete owning-package race tests (`-race -count=1`), run serially:
  - `pkg/frontend`: 26.2s
  - `pkg/embed`: 116.7s
  - `pkg/util/test`: 1.1s
  - `pkg/iscp`: 1.2s
  - `pkg/objectio`: 2.1s
  - `pkg/vm/engine/test`: 171.9s
