### PR TITLE
test(lockservice): stabilize slow-peer isolation

### DIFF
--- a/pkg/lockservice/lock_table_keeper_test.go
+++ b/pkg/lockservice/lock_table_keeper_test.go
@@ -46,8 +46,10 @@ type peerIsolationClient struct {
 	Client
 	slowPeer    string
 	healthyPeer string
+	slowStarted chan struct{}
 	healthySent chan struct{}
-	once        sync.Once
+	slowOnce    sync.Once
+	healthyOnce sync.Once
 }
 
 type globalBoundClient struct {
@@ -180,11 +182,18 @@ func (c *peerIsolationClient) AsyncSend(
 	req *pb.Request,
 ) (*morpc.Future, error) {
 	if req.LockTable.ServiceID == c.healthyPeer {
-		c.once.Do(func() { close(c.healthySent) })
+		select {
+		case <-c.slowStarted:
+		case <-ctx.Done():
+			releaseRequest(req)
+			return nil, ctx.Err()
+		}
+		c.healthyOnce.Do(func() { close(c.healthySent) })
 		releaseRequest(req)
 		return nil, context.Canceled
 	}
 	if req.LockTable.ServiceID == c.slowPeer {
+		c.slowOnce.Do(func() { close(c.slowStarted) })
 		<-ctx.Done()
 		releaseRequest(req)
 		return nil, ctx.Err()
@@ -603,8 +612,12 @@ func TestKeepRemoteLockHasBoundedInflight(t *testing.T) {
 func TestKeepRemoteLockSlowPeerDoesNotBlockHealthyPeer(t *testing.T) {
 	logger := getLogger("")
 	client := &peerIsolationClient{
-		slowPeer:    "slow",
-		healthyPeer: "healthy",
+		// Keep the slow peer first in the deterministic ServiceID ordering.
+		// A scheduler that fills the entire window from one peer would then
+		// consume all slots before reaching the healthy peer.
+		slowPeer:    "a-slow",
+		healthyPeer: "z-healthy",
+		slowStarted: make(chan struct{}),
 		healthySent: make(chan struct{}),
 	}
 	tables := &lockTableHolders{
@@ -644,24 +657,38 @@ func TestKeepRemoteLockSlowPeerDoesNotBlockHealthyPeer(t *testing.T) {
 		groupTables: tables,
 		service:     &service{serviceID: "local", logger: logger},
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
 		keeper.doKeepRemoteLock(ctx, nil, nil)
 		close(done)
 	}()
+	const hangGuard = 5 * time.Second
+	t.Cleanup(func() {
+		cancel()
+		timer := time.NewTimer(hangGuard)
+		defer timer.Stop()
+		select {
+		case <-done:
+		case <-timer.C:
+			t.Errorf("keeper round did not stop during test cleanup")
+		}
+	})
+	waitForSignal := func(ch <-chan struct{}, failure string) {
+		t.Helper()
+		timer := time.NewTimer(hangGuard)
+		defer timer.Stop()
+		select {
+		case <-ch:
+		case <-timer.C:
+			t.Fatal(failure)
+		}
+	}
 
-	select {
-	case <-client.healthySent:
-	case <-ctx.Done():
-		t.Fatal("healthy peer keepalive was blocked by the slow peer")
-	}
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("keeper round exceeded its shared deadline")
-	}
+	waitForSignal(client.slowStarted, "slow peer keepalive did not start")
+	waitForSignal(client.healthySent, "healthy peer keepalive was blocked by the slow peer")
+	cancel()
+	waitForSignal(done, "keeper round did not stop after cancellation")
 }
 
 func TestKeepRemoteLockHasGlobalInflightBoundAcrossPeers(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes

Fixes #26405

## What this PR does / why we need it

`TestKeepRemoteLockSlowPeerDoesNotBlockHealthyPeer` used one 100 ms context as both the keeper round cancellation signal and the correctness deadline for observing healthy-peer scheduling. Under CI scheduler load, the deadline could expire before the launched healthy goroutine ran, producing a false failure. The test also named the peers `healthy` and `slow`; deterministic ServiceID sorting therefore put the healthy peer first, so the test did not prove isolation after a slow peer had actually blocked. A failure returned through `t.Fatal` without joining the keeper round.

The production keeper already gives each peer one slot before filling the remaining globally bounded 64-slot window, so no production timeout or scheduling change is needed.

This change:

- orders the slow peer before the healthy peer;
- uses a `slowStarted` barrier so the healthy observation is made only after a slow request is blocked;
- separates explicit cancellation from a generous 5 second hang guard;
- registers cleanup immediately and always cancels and joins the keeper round.

The 5 second duration is only a broken-test guard. Observable channel transitions remain the correctness oracle.

## Risk and performance

Test-only change. Production scheduling, RPC timeouts, allocation behavior, and concurrency limits are unchanged. Mock request ownership remains exactly once on success and cancellation paths, and every new wait terminates through a barrier, context cancellation, or the hang guard.

## Validation

- focused test selection verified with `go test -list`
- focused regression: `-race -count=100` PASS
- full `pkg/lockservice`: PASS, 104.963s
- full `pkg/lockservice` under race: PASS, 108.424s
- `go build ./pkg/lockservice` PASS
- `go vet ./pkg/lockservice` PASS
- `git diff --check` PASS