### PR TITLE
fix bootstrap retry after transient disconnect

### DIFF
--- a/pkg/bootstrap/service.go
+++ b/pkg/bootstrap/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/log"
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/frontend"
@@ -51,6 +52,8 @@ var (
 var (
 	bootstrapKey = "_mo_bootstrap"
 )
+
+const defaultBootstrapRetryInterval = time.Second
 
 var (
 	bootstrappedCheckerDB        = catalog.MOTaskDB
@@ -135,6 +138,8 @@ type service struct {
 	stopper *stopper.Stopper
 	handles []VersionHandle
 
+	bootstrapRetryInterval time.Duration
+
 	mu struct {
 		sync.RWMutex
 		tenants map[int32]bool
@@ -160,13 +165,14 @@ func NewService(
 	opts ...Option,
 ) Service {
 	s := &service{
-		sid:     sid,
-		clock:   clock,
-		exec:    exec,
-		lock:    lock,
-		client:  client,
-		logger:  getLogger(sid).Named("upgrade-framework"),
-		stopper: stopper.NewStopper("upgrade", stopper.WithLogger(getLogger(sid).RawLogger())),
+		sid:                    sid,
+		clock:                  clock,
+		exec:                   exec,
+		lock:                   lock,
+		client:                 client,
+		logger:                 getLogger(sid).Named("upgrade-framework"),
+		stopper:                stopper.NewStopper("upgrade", stopper.WithLogger(getLogger(sid).RawLogger())),
+		bootstrapRetryInterval: defaultBootstrapRetryInterval,
 	}
 	s.mu.tenants = make(map[int32]bool)
 	s.initUpgrade()
@@ -195,7 +201,7 @@ func (s *service) Bootstrap(ctx context.Context) error {
 	// current node get the bootstrap privilege
 	if ok {
 		// the auto-increment service has already been initialized at current time
-		return s.execBootstrap(ctx)
+		return s.execBootstrapWithRetry(ctx)
 	}
 
 	// otherwise, wait bootstrap completed
@@ -211,6 +217,65 @@ func (s *service) Bootstrap(ctx context.Context) error {
 				zap.Error(err))
 			return err
 		}
+	}
+}
+
+func (s *service) execBootstrapWithRetry(ctx context.Context) error {
+	for attempt := 1; ; attempt++ {
+		err := s.execBootstrap(ctx)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !morpc.IsConnectionError(err) {
+			return err
+		}
+
+		s.logger.Warn("bootstrap interrupted by connection error",
+			zap.Int("attempt", attempt),
+			zap.Error(err))
+
+		// A connection error can also hide a successful commit. Establish the
+		// durable bootstrap state before starting another all-or-nothing txn.
+		for {
+			if err := waitBootstrapRetry(ctx, s.bootstrapRetryInterval); err != nil {
+				return err
+			}
+
+			ok, checkErr := s.checkAlreadyBootstrapped(ctx)
+			if ok {
+				s.logger.Info("bootstrap completed despite lost connection",
+					zap.Int("attempt", attempt))
+				return nil
+			}
+			if checkErr == nil {
+				break
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if !morpc.IsConnectionError(checkErr) {
+				return checkErr
+			}
+
+			s.logger.Warn("bootstrap state check interrupted by connection error",
+				zap.Int("attempt", attempt),
+				zap.Error(checkErr))
+		}
+	}
+}
+
+func waitBootstrapRetry(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 

--- a/pkg/bootstrap/service_test.go
+++ b/pkg/bootstrap/service_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	mock_executor "github.com/matrixorigin/matrixone/pkg/util/executor/test"
 )
 
 var _ client.TxnOperator = new(testTxnOperator)
@@ -319,6 +320,95 @@ func TestBootstrapWithWait(t *testing.T) {
 			assert.True(t, n.Load() > 0)
 		},
 	)
+}
+
+func TestBootstrapRetriesConnectionError(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			ctrl := gomock.NewController(t)
+			exec := mock_executor.NewMockSQLExecutor(ctrl)
+			empty := executor.Result{}
+
+			exec.EXPECT().
+				Exec(gomock.Any(), "show databases", gomock.Any()).
+				Return(empty, nil).
+				Times(2)
+			exec.EXPECT().
+				ExecTxn(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(moerr.NewRPCTimeoutNoCtx())
+			exec.EXPECT().
+				ExecTxn(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil)
+
+			b := newBootstrapServiceForTest(sid, exec)
+			require.NoError(t, b.Bootstrap(context.Background()))
+		},
+	)
+}
+
+func TestBootstrapChecksStateBeforeRetry(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			ctrl := gomock.NewController(t)
+			exec := mock_executor.NewMockSQLExecutor(ctrl)
+
+			gomock.InOrder(
+				exec.EXPECT().
+					Exec(gomock.Any(), "show databases", gomock.Any()).
+					Return(executor.Result{}, nil),
+				exec.EXPECT().
+					ExecTxn(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(moerr.NewRPCTimeoutNoCtx()),
+				exec.EXPECT().
+					Exec(gomock.Any(), "show databases", gomock.Any()).
+					Return(newBootstrapStringResult(bootstrappedCheckerDB), nil),
+				exec.EXPECT().
+					Exec(gomock.Any(), fmt.Sprintf("show tables from %s", bootstrappedCheckerDB), gomock.Any()).
+					Return(newBootstrapStringResult(allBootstrappedCheckerTables()...), nil),
+			)
+
+			b := newBootstrapServiceForTest(sid, exec)
+			require.NoError(t, b.Bootstrap(context.Background()))
+		},
+	)
+}
+
+func TestBootstrapDoesNotRetryNonConnectionError(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			ctrl := gomock.NewController(t)
+			exec := mock_executor.NewMockSQLExecutor(ctrl)
+			expected := moerr.NewInternalErrorNoCtx("invalid bootstrap SQL")
+
+			exec.EXPECT().
+				Exec(gomock.Any(), "show databases", gomock.Any()).
+				Return(executor.Result{}, nil)
+			exec.EXPECT().
+				ExecTxn(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(expected)
+
+			b := newBootstrapServiceForTest(sid, exec)
+			require.ErrorIs(t, b.Bootstrap(context.Background()), expected)
+		},
+	)
+}
+
+func newBootstrapServiceForTest(sid string, exec executor.SQLExecutor) *service {
+	b := NewService(
+		sid,
+		&memLocker{},
+		clock.NewHLCClock(func() int64 { return 0 }, 0),
+		nil,
+		exec,
+	).(*service)
+	b.bootstrapRetryInterval = 0
+	return b
 }
 
 func TestBootstrapMissingSQLTaskTablesIsNotBootstrapped(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26091

## What this PR does / why we need it:

Embedded-cluster bootstrap runs all system initialization statements in one transaction. Under heavy CI load, a temporary HAKeeper/TN connection reset can abort that transaction. The bootstrap owner currently returns the connection error immediately, and CN startup converts it into a process-wide panic.

This PR makes the bootstrap owner recover only from errors classified by `morpc.IsConnectionError`:

- wait for the connection to recover within the existing five-minute bootstrap context;
- check durable bootstrap state before retrying, because a lost commit response can hide a successful commit;
- retry the complete all-or-nothing bootstrap transaction only when the state is definitively incomplete;
- continue returning non-connection errors immediately.

The bootstrap lock ownership and global timeout behavior are unchanged.

Validation:

- `go test ./pkg/bootstrap -count=1`
- `go test -race ./pkg/bootstrap -run 'TestBootstrap(RetriesConnectionError|ChecksStateBeforeRetry|DoesNotRetryNonConnectionError)' -count=1`
- `go test ./pkg/embed -run '^TestBasicCluster$' -count=1` in three independent processes
