### PR TITLE
[4.2-dev] fix(clone): preserve foreign key metadata across alter copy

### DIFF
--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -78,7 +78,7 @@ func collectCloneDatabaseSource(
 	if err != nil {
 		return source, err
 	}
-	sortedFkTbls, err := fkTablesTopoSort(ctx, bh, snapshot, srcDBName, "")
+	sortedFkTbls, err := fkTablesTopoSort(ctx, bh, snapshot, srcDBName, "", srcTblInfos)
 	if err != nil {
 		return source, err
 	}

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -1094,8 +1094,22 @@ func doRestorePitr(ctx context.Context, ses *Session, stmt *tree.RestorePitr) (s
 		return
 	}
 
+	sourceTableInfos, err := collectRestoreSourceTableInfos(
+		dbName,
+		tblName,
+		func() ([]string, error) {
+			return showDatabasesWithPitr(ctx, ses.GetService(), bh, pitrName, ts)
+		},
+		func(sourceDBName string, sourceTblName string) ([]*tableInfo, error) {
+			return getTableInfoWithPitr(ctx, ses.GetService(), bh, pitrName, ts, sourceDBName, sourceTblName)
+		},
+	)
+	if err != nil {
+		return
+	}
+
 	// get topo sorted tables with foreign key
-	sortedFkTbls, err = fkTablesTopoSortInPitrRestore(ctx, bh, ts, dbName, tblName)
+	sortedFkTbls, err = fkTablesTopoSortInPitrRestore(ctx, bh, ts, dbName, tblName, sourceTableInfos)
 	if err != nil {
 		return
 	}
@@ -1635,7 +1649,7 @@ func deleteCurFkTableInPitrRestore(ctx context.Context,
 	)
 
 	// get topo sorted tables with foreign key
-	sortedFkTbls, err = fkTablesTopoSortInPitrRestore(ctx, bh, 0, dbName, tblName)
+	sortedFkTbls, err = fkTablesTopoSortInPitrRestore(ctx, bh, 0, dbName, tblName, nil)
 	if err != nil {
 		return
 	}
@@ -1671,25 +1685,14 @@ func fkTablesTopoSortInPitrRestore(
 	bh BackgroundExec,
 	ts int64,
 	dbName string,
-	tblName string) (sortedTbls []string, err error) {
-	// get foreign key deps from mo_catalog.mo_foreign_keys
+	tblName string,
+	tableInfos []*tableInfo,
+) (sortedTbls []string, err error) {
 	fkDeps, err := getFkDepsInPitrRestore(ctx, bh, ts, dbName, tblName)
 	if err != nil {
 		return
 	}
-
-	g := toposort{next: make(map[string][]string)}
-	for key, deps := range fkDeps {
-		g.addVertex(key)
-		for _, depTbl := range deps {
-			// exclude self dep
-			if key != depTbl {
-				g.addEdge(depTbl, key)
-			}
-		}
-	}
-	sortedTbls, err = g.sort()
-	return
+	return topoSortRestoreFkDeps(ctx, fkDeps, tableInfos)
 }
 
 func restoreTablesWithFkByPitr(

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -661,8 +661,22 @@ func doRestoreSnapshot(ctx context.Context, ses *Session, stmt *tree.RestoreSnap
 		Tenant: &plan.SnapshotTenant{TenantID: restoreAccount},
 	}
 
+	sourceTableInfos, err := collectRestoreSourceTableInfos(
+		dbName,
+		tblName,
+		func() ([]string, error) {
+			return showDatabasesAtTS(ctx, ses.GetService(), bh, snapshot.ts, restoreAccount)
+		},
+		func(sourceDBName string, sourceTblName string) ([]*tableInfo, error) {
+			return getTableInfos(ctx, ses.GetService(), bh, tempSnap, sourceDBName, sourceTblName)
+		},
+	)
+	if err != nil {
+		return stats, err
+	}
+
 	// get topo sorted tables with foreign key
-	sortedFkTbls, err := fkTablesTopoSort(ctx, bh, tempSnap, dbName, tblName)
+	sortedFkTbls, err := fkTablesTopoSort(ctx, bh, tempSnap, dbName, tblName, sourceTableInfos)
 	if err != nil {
 		return
 	}
@@ -903,7 +917,7 @@ func deleteCurFkTables(
 	ctx = defines.AttachAccountId(ctx, toAccountId)
 
 	// get topo sorted tables with foreign key
-	sortedFkTbls, err := fkTablesTopoSort(ctx, bh, nil, dbName, tblName)
+	sortedFkTbls, err := fkTablesTopoSort(ctx, bh, nil, dbName, tblName, nil)
 	if err != nil {
 		return
 	}
@@ -1873,6 +1887,27 @@ func showDatabases(ctx context.Context, sid string, bh BackgroundExec, snapshotN
 	return dbNames, nil
 }
 
+func showDatabasesAtTS(
+	ctx context.Context,
+	sid string,
+	bh BackgroundExec,
+	ts int64,
+	accountID uint32,
+) ([]string, error) {
+	getLogger(sid).Debug(fmt.Sprintf("[%d:%d] start to get all database", accountID, ts))
+	sql := fmt.Sprintf("show databases {MO_TS = %d}", ts)
+	colsList, err := getStringColsList(defines.AttachAccountId(ctx, accountID), bh, sql, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	dbNames := make([]string, len(colsList))
+	for i, cols := range colsList {
+		dbNames[i] = cols[0]
+	}
+	return dbNames, nil
+}
+
 func showFullTables(
 	ctx context.Context,
 	sid string,
@@ -2339,14 +2374,62 @@ func fkTablesTopoSort(
 	snapshot *plan.Snapshot,
 	dbName string,
 	tblName string,
+	tableInfos []*tableInfo,
 ) (sortedTbls []string, err error) {
 
-	// get foreign key deps from mo_catalog.mo_foreign_keys
+	// mo_foreign_keys is required for unresolved forward references, while the
+	// table schema is the durable source for resolved constraints. Older COPY
+	// ALTER versions could lose catalog rows without losing the table
+	// constraint, so restore and clone reconcile both representations.
 	fkDeps, err := getFkDeps(ctx, bh, snapshot, dbName, tblName)
 	if err != nil {
 		return
 	}
+	return topoSortRestoreFkDeps(ctx, fkDeps, tableInfos)
+}
 
+func topoSortRestoreFkDeps(
+	ctx context.Context,
+	catalogFkDeps map[string][]string,
+	tableInfos []*tableInfo,
+) ([]string, error) {
+	schemaFkDeps, err := getFkDepsFromTableInfos(ctx, tableInfos)
+	if err != nil {
+		return nil, err
+	}
+	mergeFkDeps(catalogFkDeps, schemaFkDeps)
+	return topoSortFkDeps(catalogFkDeps)
+}
+
+func collectRestoreSourceTableInfos(
+	dbName string,
+	tblName string,
+	listDatabases func() ([]string, error),
+	getTableInfosForDatabase func(string, string) ([]*tableInfo, error),
+) ([]*tableInfo, error) {
+	if dbName != "" {
+		return getTableInfosForDatabase(dbName, tblName)
+	}
+
+	dbNames, err := listDatabases()
+	if err != nil {
+		return nil, err
+	}
+	var tableInfos []*tableInfo
+	for _, sourceDBName := range dbNames {
+		if needSkipDb(sourceDBName) {
+			continue
+		}
+		dbTableInfos, err := getTableInfosForDatabase(sourceDBName, "")
+		if err != nil {
+			return nil, err
+		}
+		tableInfos = append(tableInfos, dbTableInfos...)
+	}
+	return tableInfos, nil
+}
+
+func topoSortFkDeps(fkDeps map[string][]string) ([]string, error) {
 	g := toposort{next: make(map[string][]string)}
 	for key, deps := range fkDeps {
 		g.addVertex(key)
@@ -2357,8 +2440,71 @@ func fkTablesTopoSort(
 			}
 		}
 	}
-	sortedTbls, err = g.sort()
-	return
+	return g.sort()
+}
+
+func getFkDepsFromTableInfos(
+	ctx context.Context,
+	tableInfos []*tableInfo,
+) (map[string][]string, error) {
+	deps := make(map[string][]string)
+	for _, info := range tableInfos {
+		if info == nil || info.typ == view || info.createSql == "" {
+			continue
+		}
+		statements, err := parsers.Parse(ctx, dialect.MYSQL, info.createSql, 0)
+		if err != nil {
+			return nil, err
+		}
+		if len(statements) != 1 {
+			return nil, moerr.NewInternalErrorf(
+				ctx,
+				"expected one CREATE TABLE statement for %s.%s, got %d",
+				info.dbName,
+				info.tblName,
+				len(statements),
+			)
+		}
+		createTable, ok := statements[0].(*tree.CreateTable)
+		if !ok {
+			return nil, moerr.NewInternalErrorf(
+				ctx,
+				"expected CREATE TABLE statement for %s.%s",
+				info.dbName,
+				info.tblName,
+			)
+		}
+		childKey := genKey(info.dbName, info.tblName)
+		for _, tableDef := range createTable.Defs {
+			foreignKey, ok := tableDef.(*tree.ForeignKey)
+			if !ok || foreignKey.Refer == nil {
+				continue
+			}
+			parentDB := string(foreignKey.Refer.TableName.SchemaName)
+			if parentDB == "" {
+				parentDB = info.dbName
+			}
+			parentTable := string(foreignKey.Refer.TableName.ObjectName)
+			deps[childKey] = append(deps[childKey], genKey(parentDB, parentTable))
+		}
+	}
+	return deps, nil
+}
+
+func mergeFkDeps(dst, src map[string][]string) {
+	for child, parents := range src {
+		seen := make(map[string]struct{}, len(dst[child])+len(parents))
+		for _, parent := range dst[child] {
+			seen[parent] = struct{}{}
+		}
+		for _, parent := range parents {
+			if _, exists := seen[parent]; exists {
+				continue
+			}
+			seen[parent] = struct{}{}
+			dst[child] = append(dst[child], parent)
+		}
+	}
 }
 
 func restoreToCluster(ctx context.Context,
@@ -2638,7 +2784,38 @@ func restoreAccountUsingClusterSnapshotToNew(ctx context.Context,
 	// get topo sorted tables with foreign key
 	var sortedFkTbls []string
 	var fkTableMap map[string]*tableInfo
-	sortedFkTbls, err = fkTablesTopoSortWithTS(ctx, bh, "", "", snapshotTs, uint32(fromAccount), uint32(toAccountId))
+	sourceTableInfos, err := collectRestoreSourceTableInfos(
+		"",
+		"",
+		func() ([]string, error) {
+			return showDatabasesFromTS(ctx, ses.GetService(), bh, snapshotTs, uint32(fromAccount), uint32(toAccountId))
+		},
+		func(sourceDBName string, sourceTblName string) ([]*tableInfo, error) {
+			return getTableInfosFromTS(
+				ctx,
+				ses.GetService(),
+				bh,
+				sourceDBName,
+				sourceTblName,
+				snapshotTs,
+				uint32(fromAccount),
+				uint32(toAccountId),
+			)
+		},
+	)
+	if err != nil {
+		return err
+	}
+	sortedFkTbls, err = fkTablesTopoSortWithTS(
+		ctx,
+		bh,
+		"",
+		"",
+		snapshotTs,
+		uint32(fromAccount),
+		uint32(toAccountId),
+		sourceTableInfos,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/snapshot_restore_with_ts.go
+++ b/pkg/frontend/snapshot_restore_with_ts.go
@@ -26,27 +26,23 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 )
 
-func fkTablesTopoSortWithTS(ctx context.Context, bh BackgroundExec, dbName string, tblName string, ts int64, from, to uint32) (sortedTbls []string, err error) {
+func fkTablesTopoSortWithTS(
+	ctx context.Context,
+	bh BackgroundExec,
+	dbName string,
+	tblName string,
+	ts int64,
+	from,
+	to uint32,
+	tableInfos []*tableInfo,
+) (sortedTbls []string, err error) {
 	newCtx := defines.AttachAccountId(ctx, from)
 	getLogger("").Info(fmt.Sprintf("[%d:%d] start to get fk tables topo sort from account %d", from, ts, from))
-	// get foreign key deps from mo_catalog.mo_foreign_keys
 	fkDeps, err := getFkDepsWithTS(newCtx, bh, dbName, tblName, ts, from, to)
 	if err != nil {
 		return
 	}
-
-	g := toposort{next: make(map[string][]string)}
-	for key, deps := range fkDeps {
-		g.addVertex(key)
-		for _, depTbl := range deps {
-			// exclude self dep
-			if key != depTbl {
-				g.addEdge(depTbl, key)
-			}
-		}
-	}
-	sortedTbls, err = g.sort()
-	return
+	return topoSortRestoreFkDeps(ctx, fkDeps, tableInfos)
 }
 
 func getFkDepsWithTS(ctx context.Context, bh BackgroundExec, db string, tbl string, ts int64, from, to uint32) (ans map[string][]string, err error) {

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -42,6 +42,230 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
+func TestGetFkDepsFromTableInfos(t *testing.T) {
+	tableInfos := []*tableInfo{
+		{
+			dbName:    "d",
+			tblName:   "parent",
+			typ:       "BASE TABLE",
+			createSql: "create table `d`.`parent` (`id` int primary key)",
+		},
+		{
+			dbName:  "d",
+			tblName: "child",
+			typ:     "BASE TABLE",
+			createSql: "create table `d`.`child` (" +
+				"`id` int primary key, `parent_id` int, " +
+				"constraint `fk_child` foreign key (`parent_id`) " +
+				"references `d`.`parent` (`id`))",
+		},
+		{
+			dbName:  "d",
+			tblName: "self_ref",
+			typ:     "BASE TABLE",
+			createSql: "create table `d`.`self_ref` (" +
+				"`id` int primary key, `parent_id` int, " +
+				"constraint `fk_self` foreign key (`parent_id`) " +
+				"references `self_ref` (`id`))",
+		},
+		{
+			dbName:    "d",
+			tblName:   "v",
+			typ:       view,
+			createSql: "create view `d`.`v` as select 1",
+		},
+	}
+
+	deps, err := getFkDepsFromTableInfos(context.Background(), tableInfos)
+	require.NoError(t, err)
+	require.Equal(t, []string{genKey("d", "parent")}, deps[genKey("d", "child")])
+	require.Equal(t, []string{genKey("d", "self_ref")}, deps[genKey("d", "self_ref")])
+	require.NotContains(t, deps, genKey("d", "v"))
+}
+
+func TestMergeFkDepsDeduplicatesSources(t *testing.T) {
+	child := genKey("d", "child")
+	parent := genKey("d", "parent")
+	otherParent := genKey("d", "other_parent")
+	dst := map[string][]string{child: {parent}}
+	src := map[string][]string{child: {parent, otherParent}}
+
+	mergeFkDeps(dst, src)
+
+	require.Equal(t, []string{parent, otherParent}, dst[child])
+}
+
+func TestFkTablesTopoSortUsesSchemaWhenCatalogRowsAreMissing(t *testing.T) {
+	const dbName = "legacy"
+	bh := &backgroundExecTest{}
+	bh.init()
+	bh.sql2result["select db_name, table_name, refer_db_name, refer_table_name "+
+		"from mo_catalog.mo_foreign_keys where db_name = 'legacy'"] = newMrsForPitrRecord(nil)
+
+	tableInfos := []*tableInfo{
+		{
+			dbName:    dbName,
+			tblName:   "parent",
+			typ:       "BASE TABLE",
+			createSql: "create table `legacy`.`parent` (`id` int primary key)",
+		},
+		{
+			dbName:  dbName,
+			tblName: "child",
+			typ:     "BASE TABLE",
+			createSql: "create table `legacy`.`child` (" +
+				"`id` int primary key, `parent_id` int, " +
+				"constraint `fk_legacy` foreign key (`parent_id`) " +
+				"references `legacy`.`parent` (`id`))",
+		},
+	}
+
+	sorted, err := fkTablesTopoSort(
+		context.Background(),
+		bh,
+		nil,
+		dbName,
+		"",
+		tableInfos,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{genKey(dbName, "parent"), genKey(dbName, "child")},
+		sorted,
+	)
+}
+
+func TestHistoricalRestoreTopoSortUsesSchemaWhenCatalogRowsAreMissing(t *testing.T) {
+	const (
+		dbName = "legacy"
+		ts     = int64(100)
+	)
+	tableInfos := []*tableInfo{
+		{
+			dbName:    dbName,
+			tblName:   "parent",
+			typ:       "BASE TABLE",
+			createSql: "create table `legacy`.`parent` (`id` int primary key)",
+		},
+		{
+			dbName:  dbName,
+			tblName: "child",
+			typ:     "BASE TABLE",
+			createSql: "create table `legacy`.`child` (" +
+				"`id` int primary key, `parent_id` int, " +
+				"constraint `fk_legacy` foreign key (`parent_id`) " +
+				"references `legacy`.`parent` (`id`))",
+		},
+	}
+	want := []string{genKey(dbName, "parent"), genKey(dbName, "child")}
+	catalogSQL := fmt.Sprintf(
+		"select db_name, table_name, refer_db_name, refer_table_name "+
+			"from mo_catalog.mo_foreign_keys {MO_TS = %d} where db_name = '%s'",
+		ts,
+		dbName,
+	)
+
+	t.Run("pitr", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[catalogSQL] = newMrsForPitrRecord(nil)
+
+		sorted, err := fkTablesTopoSortInPitrRestore(
+			context.Background(),
+			bh,
+			ts,
+			dbName,
+			"",
+			tableInfos,
+		)
+		require.NoError(t, err)
+		require.Equal(t, want, sorted)
+	})
+
+	t.Run("dropped account timestamp restore", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[catalogSQL] = newMrsForPitrRecord(nil)
+
+		sorted, err := fkTablesTopoSortWithTS(
+			context.Background(),
+			bh,
+			dbName,
+			"",
+			ts,
+			0,
+			0,
+			tableInfos,
+		)
+		require.NoError(t, err)
+		require.Equal(t, want, sorted)
+	})
+}
+
+func TestCollectRestoreSourceTableInfos(t *testing.T) {
+	t.Run("database restore reads only the selected table", func(t *testing.T) {
+		var listed bool
+		var requestedDB, requestedTable string
+		tableInfos, err := collectRestoreSourceTableInfos(
+			"db1",
+			"child",
+			func() ([]string, error) {
+				listed = true
+				return nil, nil
+			},
+			func(dbName string, tblName string) ([]*tableInfo, error) {
+				requestedDB, requestedTable = dbName, tblName
+				return []*tableInfo{{dbName: dbName, tblName: tblName}}, nil
+			},
+		)
+		require.NoError(t, err)
+		require.False(t, listed)
+		require.Equal(t, "db1", requestedDB)
+		require.Equal(t, "child", requestedTable)
+		require.Len(t, tableInfos, 1)
+	})
+
+	t.Run("account restore reads every user database", func(t *testing.T) {
+		var requested []string
+		tableInfos, err := collectRestoreSourceTableInfos(
+			"",
+			"",
+			func() ([]string, error) {
+				return []string{moCatalog, "db1", "db2"}, nil
+			},
+			func(dbName string, tblName string) ([]*tableInfo, error) {
+				require.Empty(t, tblName)
+				requested = append(requested, dbName)
+				return []*tableInfo{{dbName: dbName, tblName: "t"}}, nil
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{"db1", "db2"}, requested)
+		require.Len(t, tableInfos, 2)
+	})
+}
+
+func TestShowDatabasesAtTSDoesNotResolveSnapshotMetadata(t *testing.T) {
+	const (
+		snapshotTS = int64(100)
+		accountID  = uint32(42)
+	)
+	sql := fmt.Sprintf("show databases {MO_TS = %d}", snapshotTS)
+	bh := &backgroundExecTest{}
+	bh.init()
+	bh.sql2result[sql] = newMrsForSqlForShowDatabases([][]interface{}{
+		{"db1"},
+		{"db2"},
+	})
+
+	dbNames, err := showDatabasesAtTS(context.Background(), "", bh, snapshotTS, accountID)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"db1", "db2"}, dbNames)
+	require.Equal(t, []string{sql}, bh.executedSQLs)
+}
+
 func TestRestoreExternalTableSnapshotAndFromTS(t *testing.T) {
 	convey.Convey("snapshot bulk restore skips external table", t, func() {
 		ctx := context.WithValue(context.TODO(), defines.TenantIDKey{}, uint32(sysAccountID))
@@ -426,20 +650,20 @@ func Test_fkTablesTopoSortWithTS(t *testing.T) {
 
 		ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(sysAccountID))
 
-		_, err := fkTablesTopoSortWithTS(ctx, bh, "", "", 0, 0, 0)
+		_, err := fkTablesTopoSortWithTS(ctx, bh, "", "", 0, 0, 0, nil)
 		convey.So(err, convey.ShouldNotBeNil)
 
 		sql := "select db_name, table_name, refer_db_name, refer_table_name from mo_catalog.mo_foreign_keys"
 		mrs := newMrsForPitrRecord([][]interface{}{})
 		bh.sql2result[sql] = mrs
 
-		_, err = fkTablesTopoSortWithTS(ctx, bh, "", "", 0, 0, 0)
+		_, err = fkTablesTopoSortWithTS(ctx, bh, "", "", 0, 0, 0, nil)
 		convey.So(err, convey.ShouldBeNil)
 
 		sql = "select db_name, table_name, refer_db_name, refer_table_name from mo_catalog.mo_foreign_keys"
 		mrs = newMrsForPitrRecord([][]interface{}{{"db1", "table1", "db2", "table2"}})
 		bh.sql2result[sql] = mrs
-		_, err = fkTablesTopoSortWithTS(ctx, bh, "", "", 0, 0, 0)
+		_, err = fkTablesTopoSortWithTS(ctx, bh, "", "", 0, 0, 0, nil)
 		convey.So(err, convey.ShouldBeNil)
 	})
 }

--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -455,6 +455,27 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 		return err
 	}
 
+	if !plan2.IsFkBannedDatabase(qry.Database) {
+		// Apply ALTER actions to the source rows first, then make those rows
+		// follow the replacement relation. This preserves catalog-only forward
+		// references and avoids exposing a half-renamed self reference.
+		for _, sql := range qry.UpdateFkSqls {
+			if err = c.runSql(sql); err != nil {
+				return err
+			}
+		}
+		prepareFkSqls, _ := plan2.GetSqlForTransferAlterCopyFk(
+			qry.Database,
+			qry.TableDef.Name,
+			qry.CopyTableDef.Name,
+		)
+		for _, sql := range prepareFkSqls {
+			if err = c.runSql(sql); err != nil {
+				return err
+			}
+		}
+	}
+
 	// 7. drop original table.
 	// ISCP: That will also drop ISCP related jobs and pitr of the original table.
 	dropSql := fmt.Sprintf("drop table `%s`.`%s`", dbName, tblName)
@@ -494,6 +515,19 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 			zap.String("copy table name", qry.CopyTableDef.Name),
 			zap.Error(err))
 		return err
+	}
+
+	if !plan2.IsFkBannedDatabase(qry.Database) {
+		_, finalizeFkSqls := plan2.GetSqlForTransferAlterCopyFk(
+			qry.Database,
+			qry.TableDef.Name,
+			qry.CopyTableDef.Name,
+		)
+		for _, sql := range finalizeFkSqls {
+			if err = c.runSql(sql); err != nil {
+				return err
+			}
+		}
 	}
 
 	newTableDef := newRel.CopyTableDef(c.proc.Ctx)
@@ -677,6 +711,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 				c,
 				fkey,
 				originRel.GetTableID(c.proc.Ctx),
+				newRel.GetTableID(c.proc.Ctx),
 			)
 			if err != nil {
 				c.proc.Error(c.proc.Ctx, "notify parent table foreign key TableId Change for alter table",
@@ -868,7 +903,9 @@ func (s *Scope) doAlterTable(c *Compile) error {
 
 	var err error
 	if qry.AlgorithmType == plan.AlterTable_COPY {
-		err = s.AlterTableCopy(c)
+		// COPY ALTER transfers mo_foreign_keys around the source-table drop,
+		// so its catalog statements are executed inside AlterTableCopy.
+		return s.AlterTableCopy(c)
 	} else {
 		err = s.AlterTableInplace(c)
 	}
@@ -982,15 +1019,32 @@ func restoreNewTableRefChildTbls(c *Compile, copyRel engine.Relation, refChildTb
 	if err != nil {
 		return err
 	}
-	oldCt.Cts = append(oldCt.Cts, &engine.RefChildTableDef{
-		Tables: refChildTbls,
-	})
+	addRefChildTableIDs(oldCt, refChildTbls)
 	return copyRel.UpdateConstraint(c.proc.Ctx, oldCt)
 }
 
 // notifyParentTableFkTableIdChange Notify the parent table of changes in the tableid of the foreign key table
-func notifyParentTableFkTableIdChange(c *Compile, fkey *plan.ForeignKeyDef, oldTableId uint64) error {
+func reconcileParentRefChildTableID(
+	constraintDef *engine.ConstraintDef,
+	oldTableID uint64,
+	newTableID uint64,
+) {
+	reconcileRefChildTableID(constraintDef, oldTableID, newTableID)
+}
+
+func notifyParentTableFkTableIdChange(
+	c *Compile,
+	fkey *plan.ForeignKeyDef,
+	oldTableID uint64,
+	newTableID uint64,
+) error {
 	foreignTblId := fkey.ForeignTbl
+	if foreignTblId == 0 {
+		// Self-referencing foreign keys use 0 as the parent-table sentinel.
+		// The ALTER copy is already carrying that constraint on newRel, and
+		// there is no separate parent relation to update.
+		return nil
+	}
 	_, _, fatherRelation, err := c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), foreignTblId)
 	if err != nil {
 		return err
@@ -999,13 +1053,7 @@ func notifyParentTableFkTableIdChange(c *Compile, fkey *plan.ForeignKeyDef, oldT
 	if err != nil {
 		return err
 	}
-	for _, ct := range oldCt.Cts {
-		if def, ok1 := ct.(*engine.RefChildTableDef); ok1 {
-			def.Tables = plan2.RemoveIf(def.Tables, func(id uint64) bool {
-				return id == oldTableId
-			})
-		}
-	}
+	reconcileParentRefChildTableID(oldCt, oldTableID, newTableID)
 	return fatherRelation.UpdateConstraint(c.proc.Ctx, oldCt)
 }
 

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -55,6 +55,126 @@ func TestShouldEnableAlterCopyPipelineFlush(t *testing.T) {
 	assert.True(t, shouldEnableAlterCopyPipelineFlush(&plan2.AlterCopyOpt{SkipPkDedup: true}))
 }
 
+func TestReplaceRefChildTableID(t *testing.T) {
+	t.Run("replace altered child and preserve siblings", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{10, 20, 30}},
+		}}
+		replaceRefChildTableID(constraintDef, 20, 21)
+		require.Equal(t, []uint64{10, 21, 30}, canonicalRefChildTableIDs(constraintDef))
+	})
+
+	t.Run("do not invent a missing child reference", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{10, 30}},
+		}}
+		replaceRefChildTableID(constraintDef, 20, 21)
+		require.Equal(t, []uint64{10, 30}, canonicalRefChildTableIDs(constraintDef))
+	})
+
+	t.Run("canonicalize duplicate definitions and table ids", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{10, 20, 21}},
+			&engine.RefChildTableDef{Tables: []uint64{20, 30, 0}},
+			&engine.RefChildTableDef{Tables: []uint64{0}},
+		}}
+		replaceRefChildTableID(constraintDef, 20, 21)
+
+		require.Len(t, constraintDef.Cts, 1)
+		require.Equal(
+			t,
+			[]uint64{10, 21, 30, 0},
+			constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
+		)
+	})
+
+	t.Run("keep an empty reference list empty", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{}
+		replaceRefChildTableID(constraintDef, 20, 21)
+		require.Len(t, constraintDef.Cts, 1)
+		require.Empty(t, canonicalRefChildTableIDs(constraintDef))
+	})
+}
+
+func TestTruncateRefChildTableIDReplacementCanonicalizesLegacyState(t *testing.T) {
+	constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+		&engine.RefChildTableDef{Tables: []uint64{0, 10, 20}},
+		&engine.RefChildTableDef{Tables: []uint64{10, 20, 30}},
+		&engine.RefChildTableDef{Tables: []uint64{0}},
+	}}
+
+	replaceRefChildTableID(constraintDef, 20, 21)
+
+	require.Len(t, constraintDef.Cts, 1)
+	require.Equal(
+		t,
+		[]uint64{0, 10, 21, 30},
+		constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
+	)
+}
+
+func TestCanonicalRefChildTableIDMutations(t *testing.T) {
+	t.Run("add merges definitions and deduplicates sentinel", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{0, 10}},
+			&engine.RefChildTableDef{Tables: []uint64{10, 20}},
+		}}
+
+		addRefChildTableIDs(constraintDef, []uint64{0, 20, 30})
+
+		require.Len(t, constraintDef.Cts, 1)
+		require.Equal(
+			t,
+			[]uint64{0, 10, 20, 30},
+			constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
+		)
+	})
+
+	t.Run("remove deletes every duplicate and keeps other ids", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{0, 10, 20}},
+			&engine.RefChildTableDef{Tables: []uint64{10, 30}},
+		}}
+
+		removeRefChildTableID(constraintDef, 10)
+
+		require.Len(t, constraintDef.Cts, 1)
+		require.Equal(
+			t,
+			[]uint64{0, 20, 30},
+			constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
+		)
+	})
+}
+
+func TestReconcileParentRefChildTableID(t *testing.T) {
+	t.Run("replace child in existing reverse reference", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{10, 20, 30}},
+		}}
+		reconcileParentRefChildTableID(constraintDef, 20, 21)
+
+		require.Len(t, constraintDef.Cts, 1)
+		require.Equal(
+			t,
+			[]uint64{10, 21, 30},
+			constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
+		)
+	})
+
+	t.Run("restore reverse reference removed while dropping old child", func(t *testing.T) {
+		constraintDef := &engine.ConstraintDef{}
+		reconcileParentRefChildTableID(constraintDef, 20, 21)
+
+		require.Len(t, constraintDef.Cts, 1)
+		require.Equal(
+			t,
+			[]uint64{21},
+			constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
+		)
+	})
+}
+
 type alterCopyInsertSpyExecutor struct {
 	insertSQL    string
 	insertErr    error

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -2752,21 +2752,101 @@ func AddChildTblIdToParentTable(ctx context.Context, fkRelation engine.Relation,
 	if err != nil {
 		return err
 	}
-	var oldRefChildDef *engine.RefChildTableDef
-	for _, ct := range oldCt.Cts {
-		if old, ok := ct.(*engine.RefChildTableDef); ok {
-			oldRefChildDef = old
+	addRefChildTableIDs(oldCt, []uint64{tblId})
+	return fkRelation.UpdateConstraint(ctx, oldCt)
+}
+
+func canonicalRefChildTableIDs(constraintDef *engine.ConstraintDef) []uint64 {
+	var tableIDs []uint64
+	seen := make(map[uint64]struct{})
+	for _, constraint := range constraintDef.Cts {
+		refChildDef, ok := constraint.(*engine.RefChildTableDef)
+		if !ok {
+			continue
+		}
+		for _, tableID := range refChildDef.Tables {
+			if _, exists := seen[tableID]; exists {
+				continue
+			}
+			seen[tableID] = struct{}{}
+			tableIDs = append(tableIDs, tableID)
 		}
 	}
-	if oldRefChildDef == nil {
-		oldRefChildDef = &engine.RefChildTableDef{}
+	return tableIDs
+}
+
+func setRefChildTableIDs(constraintDef *engine.ConstraintDef, tableIDs []uint64) {
+	canonical := make([]uint64, 0, len(tableIDs))
+	seen := make(map[uint64]struct{}, len(tableIDs))
+	for _, tableID := range tableIDs {
+		if _, exists := seen[tableID]; exists {
+			continue
+		}
+		seen[tableID] = struct{}{}
+		canonical = append(canonical, tableID)
 	}
-	oldRefChildDef.Tables = append(oldRefChildDef.Tables, tblId)
-	newCt, err := MakeNewCreateConstraint(oldCt, oldRefChildDef)
-	if err != nil {
-		return err
+	constraintDef.Cts = plan2.RemoveIf(
+		constraintDef.Cts,
+		func(constraint engine.Constraint) bool {
+			_, ok := constraint.(*engine.RefChildTableDef)
+			return ok
+		},
+	)
+	constraintDef.Cts = append(
+		constraintDef.Cts,
+		&engine.RefChildTableDef{Tables: canonical},
+	)
+}
+
+func addRefChildTableIDs(constraintDef *engine.ConstraintDef, added []uint64) {
+	tableIDs := canonicalRefChildTableIDs(constraintDef)
+	seen := make(map[uint64]struct{}, len(tableIDs)+len(added))
+	for _, tableID := range tableIDs {
+		seen[tableID] = struct{}{}
 	}
-	return fkRelation.UpdateConstraint(ctx, newCt)
+	for _, tableID := range added {
+		if _, exists := seen[tableID]; exists {
+			continue
+		}
+		seen[tableID] = struct{}{}
+		tableIDs = append(tableIDs, tableID)
+	}
+	setRefChildTableIDs(constraintDef, tableIDs)
+}
+
+func removeRefChildTableID(constraintDef *engine.ConstraintDef, removed uint64) {
+	tableIDs := canonicalRefChildTableIDs(constraintDef)
+	tableIDs = plan2.RemoveIf(tableIDs, func(tableID uint64) bool {
+		return tableID == removed
+	})
+	setRefChildTableIDs(constraintDef, tableIDs)
+}
+
+func replaceRefChildTableID(
+	constraintDef *engine.ConstraintDef,
+	oldTableID uint64,
+	newTableID uint64,
+) bool {
+	tableIDs := canonicalRefChildTableIDs(constraintDef)
+	replaced := false
+	for i, tableID := range tableIDs {
+		if tableID == oldTableID {
+			tableIDs[i] = newTableID
+			replaced = true
+		}
+	}
+	setRefChildTableIDs(constraintDef, tableIDs)
+	return replaced
+}
+
+func reconcileRefChildTableID(
+	constraintDef *engine.ConstraintDef,
+	oldTableID uint64,
+	newTableID uint64,
+) {
+	if !replaceRefChildTableID(constraintDef, oldTableID, newTableID) {
+		addRefChildTableIDs(constraintDef, []uint64{newTableID})
+	}
 }
 
 func AddFkeyToRelation(ctx context.Context, fkRelation engine.Relation, fkey *plan.ForeignKeyDef) error {
@@ -2799,14 +2879,7 @@ func (s *Scope) removeChildTblIdFromParentTable(c *Compile, fkRelation engine.Re
 	if err != nil {
 		return err
 	}
-	for _, ct := range oldCt.Cts {
-		if def, ok := ct.(*engine.RefChildTableDef); ok {
-			def.Tables = plan2.RemoveIf[uint64](def.Tables, func(id uint64) bool {
-				return id == tblId
-			})
-			break
-		}
-	}
+	removeRefChildTableID(oldCt, tblId)
 	return fkRelation.UpdateConstraint(c.proc.Ctx, oldCt)
 }
 
@@ -2991,11 +3064,10 @@ func (s *Scope) TruncateTable(c *Compile) error {
 		if err != nil {
 			return err
 		}
-		if updateRefChildTableConstraintIDs(oldCt, oldID, newID) {
-			err = fkRelation.UpdateConstraint(c.proc.Ctx, oldCt)
-			if err != nil {
-				return err
-			}
+		replaceRefChildTableID(oldCt, oldID, newID)
+		err = fkRelation.UpdateConstraint(c.proc.Ctx, oldCt)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -3024,23 +3096,6 @@ func cloneCreateIndexForPartition(
 		def.IndexTableName = fmt.Sprintf("%s_%s", def.IndexTableName, partitionName)
 	}
 	return cloned
-}
-
-func updateRefChildTableConstraintIDs(ct *engine.ConstraintDef, oldID, newID uint64) bool {
-	updated := false
-	for _, c := range ct.Cts {
-		def, ok := c.(*engine.RefChildTableDef)
-		if !ok {
-			continue
-		}
-		for idx, refTable := range def.Tables {
-			if refTable == oldID {
-				def.Tables[idx] = newID
-				updated = true
-			}
-		}
-	}
-	return updated
 }
 
 func (s *Scope) DropSequence(c *Compile) error {

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -265,8 +265,6 @@ func buildAlterTableCopy(stmt *tree.AlterTable, cctx CompilerContext) (*Plan, er
 
 	alterTablePlan.ChangeTblColIdMap = alterTableCtx.changColDefMap
 	alterTablePlan.UpdateFkSqls = append(alterTablePlan.UpdateFkSqls, alterTableCtx.UpdateSqls...)
-	//delete copy table records from mo_catalog.mo_foreign_keys
-	alterTablePlan.UpdateFkSqls = append(alterTablePlan.UpdateFkSqls, getSqlForDeleteTable(schemaName, alterTableCtx.copyTableName))
 	return &Plan{
 		Plan: &plan.Plan_Ddl{
 			Ddl: &plan.DataDefinition{

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3575,6 +3575,53 @@ func getSqlForRenameTable(db, oldName, newName string) (ret []string) {
 	return
 }
 
+// GetSqlForTransferAlterCopyFk returns the catalog statements that transfer
+// child-side foreign-key metadata from the source relation to its COPY
+// replacement. The source rows are authoritative because UpdateFkSqls has
+// already applied the ALTER actions to them; rows created while creating the
+// temporary relation are discarded before the transfer.
+//
+// Parent-side names intentionally remain unchanged. The replacement ultimately
+// takes the source name, so changing refer_table_name would expose an
+// intermediate reference to a non-existent temporary parent.
+func GetSqlForTransferAlterCopyFk(db, sourceTable, copyTable string) (
+	prepare []string,
+	finalize []string,
+) {
+	prepare = append(prepare, getSqlForDeleteFkChildTable(db, copyTable))
+	prepare = append(prepare, getSqlForRenameFkChildTable(db, sourceTable, copyTable))
+	finalize = append(finalize, getSqlForRenameFkChildTable(db, copyTable, sourceTable))
+	return
+}
+
+// quoteSQLStringLiteral escapes and wraps a value for use as a SQL string literal.
+func quoteSQLStringLiteral(s string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`'`, `''`,
+	)
+	return "'" + replacer.Replace(s) + "'"
+}
+
+func getSqlForDeleteFkChildTable(db, table string) string {
+	return fmt.Sprintf(
+		"delete from `mo_catalog`.`mo_foreign_keys` "+
+			"where db_name = %s and table_name = %s",
+		quoteSQLStringLiteral(db),
+		quoteSQLStringLiteral(table),
+	)
+}
+
+func getSqlForRenameFkChildTable(db, oldName, newName string) string {
+	return fmt.Sprintf(
+		"update `mo_catalog`.`mo_foreign_keys` set table_name = %s "+
+			"where db_name = %s and table_name = %s",
+		quoteSQLStringLiteral(newName),
+		quoteSQLStringLiteral(db),
+		quoteSQLStringLiteral(oldName),
+	)
+}
+
 // getSqlForRenameColumn returns the sqls that rename the column of all fk relationships in mo_foreign_keys
 func getSqlForRenameColumn(db, table, oldName, newName string) (ret []string) {
 	sb := strings.Builder{}

--- a/pkg/sql/plan/build_dml_util_test.go
+++ b/pkg/sql/plan/build_dml_util_test.go
@@ -57,6 +57,22 @@ func Test_runSql(t *testing.T) {
 	require.Error(t, err, "internal error: no account id in context")
 }
 
+func TestGetSqlForTransferAlterCopyFk(t *testing.T) {
+	prepare, finalize := GetSqlForTransferAlterCopyFk(
+		"db'1",
+		"source'child",
+		"copy'child",
+	)
+
+	require.Equal(t, []string{
+		"delete from `mo_catalog`.`mo_foreign_keys` where db_name = 'db''1' and table_name = 'copy''child'",
+		"update `mo_catalog`.`mo_foreign_keys` set table_name = 'copy''child' where db_name = 'db''1' and table_name = 'source''child'",
+	}, prepare)
+	require.Equal(t, []string{
+		"update `mo_catalog`.`mo_foreign_keys` set table_name = 'source''child' where db_name = 'db''1' and table_name = 'copy''child'",
+	}, finalize)
+}
+
 func Test_buildPreDeleteFullTextIndexAsync(t *testing.T) {
 	{
 		//invalid json

--- a/test/distributed/cases/git4data/clone/clone_fk_after_alter.result
+++ b/test/distributed/cases/git4data/clone/clone_fk_after_alter.result
@@ -1,0 +1,440 @@
+drop database if exists fk_clone_alter_child_src;
+drop database if exists fk_clone_alter_child_dst;
+create database fk_clone_alter_child_src;
+use fk_clone_alter_child_src;
+create table fk_clone_alter_child_src.parent (
+id int primary key,
+name varchar(32) not null
+);
+create table fk_clone_alter_child_src.child (
+id int primary key,
+parent_id int,
+payload varchar(32),
+constraint fk_child_parent foreign key (parent_id)
+references fk_clone_alter_child_src.parent(id)
+);
+insert into fk_clone_alter_child_src.parent values (1, 'p1'), (2, 'p2');
+insert into fk_clone_alter_child_src.child values (10, 1, 'c1'), (20, 2, 'c2');
+alter table fk_clone_alter_child_src.child add column note varchar(32) default 'n';
+alter table fk_clone_alter_child_src.child modify column payload varchar(64);
+alter table fk_clone_alter_child_src.child rename column note to remark;
+alter table fk_clone_alter_child_src.child add index idx_payload(payload);
+alter table fk_clone_alter_child_src.child drop index idx_payload;
+alter table fk_clone_alter_child_src.child drop column remark;
+select table_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_alter_child_src'
+order by constraint_name;
+table_name    refer_table_name
+child    parent
+delete from fk_clone_alter_child_src.parent where id = 1;
+internal error: Cannot delete or update a parent row: a foreign key constraint fails
+create database fk_clone_alter_child_dst clone fk_clone_alter_child_src;
+select * from fk_clone_alter_child_dst.child order by id;
+id    parent_id    payload
+10    1    c1
+20    2    c2
+show create table fk_clone_alter_child_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `payload` varchar(64) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_child_parent` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+delete from fk_clone_alter_child_dst.parent where id = 1;
+internal error: Cannot delete or update a parent row: a foreign key constraint fails
+insert into fk_clone_alter_child_dst.child values (30, 999, 'invalid');
+internal error: Cannot add or update a child row: a foreign key constraint fails
+insert into fk_clone_alter_child_dst.child values (30, 1, 'valid');
+select count(*) from fk_clone_alter_child_dst.child;
+count(*)
+3
+drop database fk_clone_alter_child_dst;
+drop database fk_clone_alter_child_src;
+drop database if exists fk_clone_alter_both_src;
+drop database if exists fk_clone_alter_both_dst;
+create database fk_clone_alter_both_src;
+use fk_clone_alter_both_src;
+create table fk_clone_alter_both_src.parent (
+id int primary key,
+code varchar(16) unique
+);
+create table fk_clone_alter_both_src.child (
+id int primary key,
+parent_id int,
+constraint fk_both foreign key (parent_id)
+references fk_clone_alter_both_src.parent(id)
+);
+insert into fk_clone_alter_both_src.parent values (1, 'a');
+insert into fk_clone_alter_both_src.child values (1, 1);
+alter table fk_clone_alter_both_src.parent add column description varchar(64);
+alter table fk_clone_alter_both_src.parent modify column description varchar(128);
+alter table fk_clone_alter_both_src.child add column created_at datetime;
+create database fk_clone_alter_both_dst clone fk_clone_alter_both_src;
+show create table fk_clone_alter_both_dst.parent;
+Table    Create Table
+parent    CREATE TABLE `parent` (\n  `id` int NOT NULL,\n  `code` varchar(16) DEFAULT NULL,\n  `description` varchar(128) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `code` (`code`)\n)
+show create table fk_clone_alter_both_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `created_at` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_both` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_alter_both_dst.child(id, parent_id) values (2, 404);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+select count(*) from fk_clone_alter_both_dst.child;
+count(*)
+1
+drop database fk_clone_alter_both_dst;
+drop database fk_clone_alter_both_src;
+drop database if exists fk_clone_siblings_src;
+drop database if exists fk_clone_siblings_dst;
+create database fk_clone_siblings_src;
+use fk_clone_siblings_src;
+create table fk_clone_siblings_src.parent (id int primary key);
+create table fk_clone_siblings_src.child_a (
+id int primary key,
+parent_id int,
+constraint fk_sibling_a foreign key (parent_id)
+references fk_clone_siblings_src.parent(id)
+);
+create table fk_clone_siblings_src.child_b (
+id int primary key,
+parent_id int,
+constraint fk_sibling_b foreign key (parent_id)
+references fk_clone_siblings_src.parent(id)
+);
+alter table fk_clone_siblings_src.child_a add column a1 int default 1;
+alter table fk_clone_siblings_src.child_b add column b1 int default 2;
+alter table fk_clone_siblings_src.child_a add column a2 int default 3;
+create database fk_clone_siblings_dst clone fk_clone_siblings_src;
+show create table fk_clone_siblings_dst.child_a;
+Table    Create Table
+child_a    CREATE TABLE `child_a` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `a1` int DEFAULT 1,\n  `a2` int DEFAULT 3,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_sibling_a` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+show create table fk_clone_siblings_dst.child_b;
+Table    Create Table
+child_b    CREATE TABLE `child_b` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `b1` int DEFAULT 2,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_sibling_b` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_siblings_dst.child_a values (1, 100, 1, 3);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+insert into fk_clone_siblings_dst.child_b values (1, 100, 2);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_siblings_dst;
+drop database fk_clone_siblings_src;
+drop database if exists fk_clone_chain_src;
+drop database if exists fk_clone_chain_dst;
+create database fk_clone_chain_src;
+use fk_clone_chain_src;
+create table fk_clone_chain_src.root (id int primary key);
+create table fk_clone_chain_src.middle (
+id int primary key,
+root_id int,
+constraint fk_middle_root foreign key (root_id)
+references fk_clone_chain_src.root(id)
+);
+create table fk_clone_chain_src.leaf (
+id int primary key,
+middle_id int,
+constraint fk_leaf_middle foreign key (middle_id)
+references fk_clone_chain_src.middle(id)
+);
+insert into fk_clone_chain_src.root values (1);
+insert into fk_clone_chain_src.middle values (1, 1);
+insert into fk_clone_chain_src.leaf values (1, 1);
+alter table fk_clone_chain_src.root add column root_value varchar(20);
+alter table fk_clone_chain_src.middle add column middle_value varchar(20);
+alter table fk_clone_chain_src.leaf add column leaf_value varchar(20);
+create database fk_clone_chain_dst clone fk_clone_chain_src;
+select leaf.id, middle.id, root.id
+from fk_clone_chain_dst.leaf leaf
+join fk_clone_chain_dst.middle middle on leaf.middle_id = middle.id
+join fk_clone_chain_dst.root root on middle.root_id = root.id;
+id    id    id
+1    1    1
+insert into fk_clone_chain_dst.leaf(id, middle_id) values (2, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_chain_dst;
+drop database fk_clone_chain_src;
+drop database if exists fk_clone_composite_src;
+drop database if exists fk_clone_composite_dst;
+create database fk_clone_composite_src;
+use fk_clone_composite_src;
+create table fk_clone_composite_src.parent (
+tenant_id int,
+object_id int,
+primary key (tenant_id, object_id)
+);
+create table fk_clone_composite_src.child (
+id int primary key,
+tenant_id int,
+object_id int,
+constraint fk_composite foreign key (tenant_id, object_id)
+references fk_clone_composite_src.parent(tenant_id, object_id)
+);
+insert into fk_clone_composite_src.parent values (1, 1);
+insert into fk_clone_composite_src.child values (1, 1, 1);
+alter table fk_clone_composite_src.child add column payload varchar(32);
+alter table fk_clone_composite_src.child modify column payload varchar(64);
+create database fk_clone_composite_dst clone fk_clone_composite_src;
+show create table fk_clone_composite_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `tenant_id` int DEFAULT NULL,\n  `object_id` int DEFAULT NULL,\n  `payload` varchar(64) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_composite` FOREIGN KEY (`tenant_id`,`object_id`) REFERENCES `parent` (`tenant_id`,`object_id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_composite_dst.child(id, tenant_id, object_id) values (2, 1, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_composite_dst;
+drop database fk_clone_composite_src;
+drop database if exists fk_clone_multi_parent_src;
+drop database if exists fk_clone_multi_parent_dst;
+create database fk_clone_multi_parent_src;
+use fk_clone_multi_parent_src;
+create table fk_clone_multi_parent_src.parent_a (id int primary key);
+create table fk_clone_multi_parent_src.parent_b (id int primary key);
+create table fk_clone_multi_parent_src.child (
+id int primary key,
+parent_a_id int,
+parent_b_id int,
+constraint fk_multi_a foreign key (parent_a_id)
+references fk_clone_multi_parent_src.parent_a(id),
+constraint fk_multi_b foreign key (parent_b_id)
+references fk_clone_multi_parent_src.parent_b(id)
+);
+alter table fk_clone_multi_parent_src.child add column payload int default 0;
+alter table fk_clone_multi_parent_src.child add column note varchar(32);
+create database fk_clone_multi_parent_dst clone fk_clone_multi_parent_src;
+show create table fk_clone_multi_parent_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_a_id` int DEFAULT NULL,\n  `parent_b_id` int DEFAULT NULL,\n  `payload` int DEFAULT 0,\n  `note` varchar(32) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_multi_a` FOREIGN KEY (`parent_a_id`) REFERENCES `parent_a` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,\n  CONSTRAINT `fk_multi_b` FOREIGN KEY (`parent_b_id`) REFERENCES `parent_b` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_multi_parent_dst.child(id, parent_a_id, parent_b_id) values (1, 1, 1);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_multi_parent_dst;
+drop database fk_clone_multi_parent_src;
+drop database if exists fk_clone_self_src;
+drop database if exists fk_clone_self_dst;
+create database fk_clone_self_src;
+use fk_clone_self_src;
+create table fk_clone_self_src.node (
+id int primary key,
+parent_id int,
+constraint fk_node_parent foreign key (parent_id)
+references fk_clone_self_src.node(id)
+);
+insert into fk_clone_self_src.node values (1, null), (2, 1);
+alter table fk_clone_self_src.node add column label varchar(32);
+alter table fk_clone_self_src.node add index idx_label(label);
+create database fk_clone_self_dst clone fk_clone_self_src;
+select id, parent_id from fk_clone_self_dst.node order by id;
+id    parent_id
+1    null
+2    1
+show create table fk_clone_self_dst.node;
+Table    Create Table
+node    CREATE TABLE `node` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `label` varchar(32) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_label` (`label`),\n  CONSTRAINT `fk_node_parent` FOREIGN KEY (`parent_id`) REFERENCES `node` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_self_dst.node(id, parent_id) values (3, 999);
+Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_self_dst;
+drop database fk_clone_self_src;
+drop database if exists fk_clone_recreate_fk_src;
+drop database if exists fk_clone_recreate_fk_dst;
+create database fk_clone_recreate_fk_src;
+use fk_clone_recreate_fk_src;
+create table fk_clone_recreate_fk_src.parent (id int primary key);
+create table fk_clone_recreate_fk_src.child (
+id int primary key,
+parent_id int,
+constraint fk_recreated foreign key (parent_id)
+references fk_clone_recreate_fk_src.parent(id)
+);
+alter table fk_clone_recreate_fk_src.child drop foreign key fk_recreated;
+alter table fk_clone_recreate_fk_src.child add column payload varchar(32);
+alter table fk_clone_recreate_fk_src.child
+add constraint fk_recreated foreign key (parent_id)
+references fk_clone_recreate_fk_src.parent(id);
+alter table fk_clone_recreate_fk_src.child add column note varchar(32);
+create database fk_clone_recreate_fk_dst clone fk_clone_recreate_fk_src;
+show create table fk_clone_recreate_fk_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `payload` varchar(32) DEFAULT NULL,\n  `note` varchar(32) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_recreated` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_recreate_fk_dst.child(id, parent_id) values (1, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_recreate_fk_dst;
+drop database fk_clone_recreate_fk_src;
+drop database if exists fk_clone_forward_src;
+create database fk_clone_forward_src;
+use fk_clone_forward_src;
+set foreign_key_checks = 0;
+create table fk_clone_forward_src.child (
+id int primary key,
+parent_id int,
+constraint fk_forward foreign key (parent_id)
+references fk_clone_forward_src.parent(id)
+);
+alter table fk_clone_forward_src.child add column payload int;
+select table_name, constraint_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_forward_src'
+order by constraint_name;
+table_name    constraint_name    refer_table_name
+child    fk_forward    parent
+create table fk_clone_forward_src.parent (id int primary key);
+set foreign_key_checks = 1;
+show create table fk_clone_forward_src.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `payload` int DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_forward` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_forward_src.child values (1, 404, 0);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_forward_src;
+drop database if exists fk_clone_forward_drop_src;
+create database fk_clone_forward_drop_src;
+use fk_clone_forward_drop_src;
+create table fk_clone_forward_drop_src.parent (id int primary key);
+create table fk_clone_forward_drop_src.child (
+id int primary key,
+parent_id int,
+constraint fk_forward_drop foreign key (parent_id)
+references fk_clone_forward_drop_src.parent(id)
+);
+set foreign_key_checks = 0;
+drop table fk_clone_forward_drop_src.parent;
+alter table fk_clone_forward_drop_src.child add column payload int;
+select table_name, constraint_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_forward_drop_src'
+order by constraint_name;
+table_name    constraint_name    refer_table_name
+child    fk_forward_drop    parent
+create table fk_clone_forward_drop_src.parent (id int primary key);
+set foreign_key_checks = 1;
+show create table fk_clone_forward_drop_src.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `payload` int DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_forward_drop` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_forward_drop_src.child values (1, 404, 0);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_forward_drop_src;
+drop database if exists fk_clone_self_external_src;
+create database fk_clone_self_external_src;
+use fk_clone_self_external_src;
+create table fk_clone_self_external_src.parent (
+id int primary key,
+parent_id int,
+constraint fk_self_external_self foreign key (parent_id)
+references fk_clone_self_external_src.parent(id)
+);
+create table fk_clone_self_external_src.child (
+id int primary key,
+parent_id int,
+constraint fk_self_external_child foreign key (parent_id)
+references fk_clone_self_external_src.parent(id)
+);
+alter table fk_clone_self_external_src.parent add column payload int;
+select table_name, constraint_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_self_external_src'
+order by table_name, constraint_name;
+table_name    constraint_name    refer_table_name
+child    fk_self_external_child    parent
+parent    fk_self_external_self    parent
+drop table fk_clone_self_external_src.child;
+drop table fk_clone_self_external_src.parent;
+drop database fk_clone_self_external_src;
+drop database if exists fk_clone_rename_columns_src;
+drop database if exists fk_clone_rename_columns_dst;
+create database fk_clone_rename_columns_src;
+use fk_clone_rename_columns_src;
+create table fk_clone_rename_columns_src.parent (old_id int primary key);
+create table fk_clone_rename_columns_src.child (
+id int primary key,
+old_parent_id int,
+constraint fk_rename_columns foreign key (old_parent_id)
+references fk_clone_rename_columns_src.parent(old_id)
+);
+alter table fk_clone_rename_columns_src.child
+rename column old_parent_id to parent_id;
+alter table fk_clone_rename_columns_src.parent
+rename column old_id to id;
+select table_name, column_name, refer_table_name, refer_column_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_rename_columns_src'
+order by constraint_name;
+table_name    column_name    refer_table_name    refer_column_name
+child    parent_id    parent    id
+create database fk_clone_rename_columns_dst clone fk_clone_rename_columns_src;
+show create table fk_clone_rename_columns_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_rename_columns` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_rename_columns_dst.child values (1, 404);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_rename_columns_dst;
+drop database fk_clone_rename_columns_src;
+drop snapshot if exists fk_clone_alter_snapshot;
+drop database if exists fk_clone_snapshot_src;
+drop database if exists fk_clone_snapshot_dst;
+create database fk_clone_snapshot_src;
+use fk_clone_snapshot_src;
+create table fk_clone_snapshot_src.parent (id int primary key);
+create table fk_clone_snapshot_src.child (
+id int primary key,
+parent_id int,
+constraint fk_snapshot foreign key (parent_id)
+references fk_clone_snapshot_src.parent(id)
+);
+insert into fk_clone_snapshot_src.parent values (1);
+insert into fk_clone_snapshot_src.child values (1, 1);
+alter table fk_clone_snapshot_src.child add column before_snapshot varchar(32);
+create snapshot fk_clone_alter_snapshot for database fk_clone_snapshot_src;
+alter table fk_clone_snapshot_src.child add column after_snapshot varchar(32);
+insert into fk_clone_snapshot_src.parent values (2);
+insert into fk_clone_snapshot_src.child(id, parent_id) values (2, 2);
+create database fk_clone_snapshot_dst clone fk_clone_snapshot_src
+{snapshot = 'fk_clone_alter_snapshot'};
+show create table fk_clone_snapshot_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `before_snapshot` varchar(32) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_snapshot` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+select id, parent_id from fk_clone_snapshot_dst.child order by id;
+id    parent_id
+1    1
+insert into fk_clone_snapshot_dst.child(id, parent_id) values (3, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_snapshot_dst;
+drop database fk_clone_snapshot_src;
+drop snapshot fk_clone_alter_snapshot;
+drop database if exists fk_clone_chain_clone_src;
+drop database if exists fk_clone_chain_clone_mid;
+drop database if exists fk_clone_chain_clone_dst;
+create database fk_clone_chain_clone_src;
+use fk_clone_chain_clone_src;
+create table fk_clone_chain_clone_src.parent (id int primary key);
+create table fk_clone_chain_clone_src.child (
+id int primary key,
+parent_id int,
+constraint fk_clone_chain foreign key (parent_id)
+references fk_clone_chain_clone_src.parent(id)
+);
+alter table fk_clone_chain_clone_src.child add column source_value int;
+create database fk_clone_chain_clone_mid clone fk_clone_chain_clone_src;
+use fk_clone_chain_clone_mid;
+alter table fk_clone_chain_clone_mid.child add column middle_value int;
+create database fk_clone_chain_clone_dst clone fk_clone_chain_clone_mid;
+show create table fk_clone_chain_clone_dst.child;
+Table    Create Table
+child    CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `parent_id` int DEFAULT NULL,\n  `source_value` int DEFAULT NULL,\n  `middle_value` int DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_clone_chain` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_chain_clone_dst.child(id, parent_id) values (1, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_chain_clone_dst;
+drop database fk_clone_chain_clone_mid;
+drop database fk_clone_chain_clone_src;
+drop database if exists fk_clone_rename_src;
+drop database if exists fk_clone_rename_dst;
+create database fk_clone_rename_src;
+use fk_clone_rename_src;
+create table fk_clone_rename_src.parent (id int primary key);
+create table fk_clone_rename_src.child (
+id int primary key,
+parent_id int,
+constraint fk_rename foreign key (parent_id)
+references fk_clone_rename_src.parent(id)
+);
+alter table fk_clone_rename_src.parent rename column id to parent_key;
+alter table fk_clone_rename_src.child rename column parent_id to parent_key;
+rename table fk_clone_rename_src.parent to fk_clone_rename_src.renamed_parent;
+rename table fk_clone_rename_src.child to fk_clone_rename_src.renamed_child;
+alter table fk_clone_rename_src.renamed_child add column payload varchar(32);
+create database fk_clone_rename_dst clone fk_clone_rename_src;
+show create table fk_clone_rename_dst.renamed_child;
+Table    Create Table
+renamed_child    CREATE TABLE `renamed_child` (\n  `id` int NOT NULL,\n  `parent_key` int DEFAULT NULL,\n  `payload` varchar(32) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT `fk_rename` FOREIGN KEY (`parent_key`) REFERENCES `renamed_parent` (`parent_key`) ON DELETE RESTRICT ON UPDATE RESTRICT\n)
+insert into fk_clone_rename_dst.renamed_child(id, parent_key) values (1, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+drop database fk_clone_rename_dst;
+drop database fk_clone_rename_src;

--- a/test/distributed/cases/git4data/clone/clone_fk_after_alter.sql
+++ b/test/distributed/cases/git4data/clone/clone_fk_after_alter.sql
@@ -1,0 +1,407 @@
+-- @suite
+-- @case
+-- @desc: clone databases after COPY and metadata-only ALTER operations on foreign-key tables
+-- @label:bvt
+
+-- 1. Repeated unrelated ALTER operations on one FK child.
+drop database if exists fk_clone_alter_child_src;
+drop database if exists fk_clone_alter_child_dst;
+create database fk_clone_alter_child_src;
+use fk_clone_alter_child_src;
+create table fk_clone_alter_child_src.parent (
+    id int primary key,
+    name varchar(32) not null
+);
+create table fk_clone_alter_child_src.child (
+    id int primary key,
+    parent_id int,
+    payload varchar(32),
+    constraint fk_child_parent foreign key (parent_id)
+        references fk_clone_alter_child_src.parent(id)
+);
+insert into fk_clone_alter_child_src.parent values (1, 'p1'), (2, 'p2');
+insert into fk_clone_alter_child_src.child values (10, 1, 'c1'), (20, 2, 'c2');
+alter table fk_clone_alter_child_src.child add column note varchar(32) default 'n';
+alter table fk_clone_alter_child_src.child modify column payload varchar(64);
+alter table fk_clone_alter_child_src.child rename column note to remark;
+alter table fk_clone_alter_child_src.child add index idx_payload(payload);
+alter table fk_clone_alter_child_src.child drop index idx_payload;
+alter table fk_clone_alter_child_src.child drop column remark;
+select table_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_alter_child_src'
+order by constraint_name;
+delete from fk_clone_alter_child_src.parent where id = 1;
+create database fk_clone_alter_child_dst clone fk_clone_alter_child_src;
+select * from fk_clone_alter_child_dst.child order by id;
+show create table fk_clone_alter_child_dst.child;
+delete from fk_clone_alter_child_dst.parent where id = 1;
+insert into fk_clone_alter_child_dst.child values (30, 999, 'invalid');
+insert into fk_clone_alter_child_dst.child values (30, 1, 'valid');
+select count(*) from fk_clone_alter_child_dst.child;
+drop database fk_clone_alter_child_dst;
+drop database fk_clone_alter_child_src;
+
+-- 2. ALTER the parent, then the child. Child FK metadata and parent reverse
+-- references must both follow the new physical table IDs.
+drop database if exists fk_clone_alter_both_src;
+drop database if exists fk_clone_alter_both_dst;
+create database fk_clone_alter_both_src;
+use fk_clone_alter_both_src;
+create table fk_clone_alter_both_src.parent (
+    id int primary key,
+    code varchar(16) unique
+);
+create table fk_clone_alter_both_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_both foreign key (parent_id)
+        references fk_clone_alter_both_src.parent(id)
+);
+insert into fk_clone_alter_both_src.parent values (1, 'a');
+insert into fk_clone_alter_both_src.child values (1, 1);
+alter table fk_clone_alter_both_src.parent add column description varchar(64);
+alter table fk_clone_alter_both_src.parent modify column description varchar(128);
+alter table fk_clone_alter_both_src.child add column created_at datetime;
+create database fk_clone_alter_both_dst clone fk_clone_alter_both_src;
+show create table fk_clone_alter_both_dst.parent;
+show create table fk_clone_alter_both_dst.child;
+insert into fk_clone_alter_both_dst.child(id, parent_id) values (2, 404);
+select count(*) from fk_clone_alter_both_dst.child;
+drop database fk_clone_alter_both_dst;
+drop database fk_clone_alter_both_src;
+
+-- 3. Multiple altered children referencing the same parent.
+drop database if exists fk_clone_siblings_src;
+drop database if exists fk_clone_siblings_dst;
+create database fk_clone_siblings_src;
+use fk_clone_siblings_src;
+create table fk_clone_siblings_src.parent (id int primary key);
+create table fk_clone_siblings_src.child_a (
+    id int primary key,
+    parent_id int,
+    constraint fk_sibling_a foreign key (parent_id)
+        references fk_clone_siblings_src.parent(id)
+);
+create table fk_clone_siblings_src.child_b (
+    id int primary key,
+    parent_id int,
+    constraint fk_sibling_b foreign key (parent_id)
+        references fk_clone_siblings_src.parent(id)
+);
+alter table fk_clone_siblings_src.child_a add column a1 int default 1;
+alter table fk_clone_siblings_src.child_b add column b1 int default 2;
+alter table fk_clone_siblings_src.child_a add column a2 int default 3;
+create database fk_clone_siblings_dst clone fk_clone_siblings_src;
+show create table fk_clone_siblings_dst.child_a;
+show create table fk_clone_siblings_dst.child_b;
+insert into fk_clone_siblings_dst.child_a values (1, 100, 1, 3);
+insert into fk_clone_siblings_dst.child_b values (1, 100, 2);
+drop database fk_clone_siblings_dst;
+drop database fk_clone_siblings_src;
+
+-- 4. Multi-level FK chain with ALTER at every level.
+drop database if exists fk_clone_chain_src;
+drop database if exists fk_clone_chain_dst;
+create database fk_clone_chain_src;
+use fk_clone_chain_src;
+create table fk_clone_chain_src.root (id int primary key);
+create table fk_clone_chain_src.middle (
+    id int primary key,
+    root_id int,
+    constraint fk_middle_root foreign key (root_id)
+        references fk_clone_chain_src.root(id)
+);
+create table fk_clone_chain_src.leaf (
+    id int primary key,
+    middle_id int,
+    constraint fk_leaf_middle foreign key (middle_id)
+        references fk_clone_chain_src.middle(id)
+);
+insert into fk_clone_chain_src.root values (1);
+insert into fk_clone_chain_src.middle values (1, 1);
+insert into fk_clone_chain_src.leaf values (1, 1);
+alter table fk_clone_chain_src.root add column root_value varchar(20);
+alter table fk_clone_chain_src.middle add column middle_value varchar(20);
+alter table fk_clone_chain_src.leaf add column leaf_value varchar(20);
+create database fk_clone_chain_dst clone fk_clone_chain_src;
+select leaf.id, middle.id, root.id
+from fk_clone_chain_dst.leaf leaf
+join fk_clone_chain_dst.middle middle on leaf.middle_id = middle.id
+join fk_clone_chain_dst.root root on middle.root_id = root.id;
+insert into fk_clone_chain_dst.leaf(id, middle_id) values (2, 999);
+drop database fk_clone_chain_dst;
+drop database fk_clone_chain_src;
+
+-- 5. Composite foreign key after repeated child ALTER.
+drop database if exists fk_clone_composite_src;
+drop database if exists fk_clone_composite_dst;
+create database fk_clone_composite_src;
+use fk_clone_composite_src;
+create table fk_clone_composite_src.parent (
+    tenant_id int,
+    object_id int,
+    primary key (tenant_id, object_id)
+);
+create table fk_clone_composite_src.child (
+    id int primary key,
+    tenant_id int,
+    object_id int,
+    constraint fk_composite foreign key (tenant_id, object_id)
+        references fk_clone_composite_src.parent(tenant_id, object_id)
+);
+insert into fk_clone_composite_src.parent values (1, 1);
+insert into fk_clone_composite_src.child values (1, 1, 1);
+alter table fk_clone_composite_src.child add column payload varchar(32);
+alter table fk_clone_composite_src.child modify column payload varchar(64);
+create database fk_clone_composite_dst clone fk_clone_composite_src;
+show create table fk_clone_composite_dst.child;
+insert into fk_clone_composite_dst.child(id, tenant_id, object_id) values (2, 1, 999);
+drop database fk_clone_composite_dst;
+drop database fk_clone_composite_src;
+
+-- 6. One altered child referencing two different parents.
+drop database if exists fk_clone_multi_parent_src;
+drop database if exists fk_clone_multi_parent_dst;
+create database fk_clone_multi_parent_src;
+use fk_clone_multi_parent_src;
+create table fk_clone_multi_parent_src.parent_a (id int primary key);
+create table fk_clone_multi_parent_src.parent_b (id int primary key);
+create table fk_clone_multi_parent_src.child (
+    id int primary key,
+    parent_a_id int,
+    parent_b_id int,
+    constraint fk_multi_a foreign key (parent_a_id)
+        references fk_clone_multi_parent_src.parent_a(id),
+    constraint fk_multi_b foreign key (parent_b_id)
+        references fk_clone_multi_parent_src.parent_b(id)
+);
+alter table fk_clone_multi_parent_src.child add column payload int default 0;
+alter table fk_clone_multi_parent_src.child add column note varchar(32);
+create database fk_clone_multi_parent_dst clone fk_clone_multi_parent_src;
+show create table fk_clone_multi_parent_dst.child;
+insert into fk_clone_multi_parent_dst.child(id, parent_a_id, parent_b_id) values (1, 1, 1);
+drop database fk_clone_multi_parent_dst;
+drop database fk_clone_multi_parent_src;
+
+-- 7. Self-referencing FK remains valid after ALTER and clone.
+drop database if exists fk_clone_self_src;
+drop database if exists fk_clone_self_dst;
+create database fk_clone_self_src;
+use fk_clone_self_src;
+create table fk_clone_self_src.node (
+    id int primary key,
+    parent_id int,
+    constraint fk_node_parent foreign key (parent_id)
+        references fk_clone_self_src.node(id)
+);
+insert into fk_clone_self_src.node values (1, null), (2, 1);
+alter table fk_clone_self_src.node add column label varchar(32);
+alter table fk_clone_self_src.node add index idx_label(label);
+create database fk_clone_self_dst clone fk_clone_self_src;
+select id, parent_id from fk_clone_self_dst.node order by id;
+show create table fk_clone_self_dst.node;
+insert into fk_clone_self_dst.node(id, parent_id) values (3, 999);
+drop database fk_clone_self_dst;
+drop database fk_clone_self_src;
+
+-- 8. Drop and recreate an FK around other ALTER operations.
+drop database if exists fk_clone_recreate_fk_src;
+drop database if exists fk_clone_recreate_fk_dst;
+create database fk_clone_recreate_fk_src;
+use fk_clone_recreate_fk_src;
+create table fk_clone_recreate_fk_src.parent (id int primary key);
+create table fk_clone_recreate_fk_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_recreated foreign key (parent_id)
+        references fk_clone_recreate_fk_src.parent(id)
+);
+alter table fk_clone_recreate_fk_src.child drop foreign key fk_recreated;
+alter table fk_clone_recreate_fk_src.child add column payload varchar(32);
+alter table fk_clone_recreate_fk_src.child
+    add constraint fk_recreated foreign key (parent_id)
+        references fk_clone_recreate_fk_src.parent(id);
+alter table fk_clone_recreate_fk_src.child add column note varchar(32);
+create database fk_clone_recreate_fk_dst clone fk_clone_recreate_fk_src;
+show create table fk_clone_recreate_fk_dst.child;
+insert into fk_clone_recreate_fk_dst.child(id, parent_id) values (1, 999);
+drop database fk_clone_recreate_fk_dst;
+drop database fk_clone_recreate_fk_src;
+
+-- 9. A catalog-only forward reference must survive COPY ALTER until its
+-- parent is created.
+drop database if exists fk_clone_forward_src;
+create database fk_clone_forward_src;
+use fk_clone_forward_src;
+set foreign_key_checks = 0;
+create table fk_clone_forward_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_forward foreign key (parent_id)
+        references fk_clone_forward_src.parent(id)
+);
+alter table fk_clone_forward_src.child add column payload int;
+select table_name, constraint_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_forward_src'
+order by constraint_name;
+create table fk_clone_forward_src.parent (id int primary key);
+set foreign_key_checks = 1;
+show create table fk_clone_forward_src.child;
+insert into fk_clone_forward_src.child values (1, 404, 0);
+drop database fk_clone_forward_src;
+
+-- 10. Dropping and recreating a parent under FOREIGN_KEY_CHECKS=0 is another
+-- catalog-only forward-reference path.
+drop database if exists fk_clone_forward_drop_src;
+create database fk_clone_forward_drop_src;
+use fk_clone_forward_drop_src;
+create table fk_clone_forward_drop_src.parent (id int primary key);
+create table fk_clone_forward_drop_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_forward_drop foreign key (parent_id)
+        references fk_clone_forward_drop_src.parent(id)
+);
+set foreign_key_checks = 0;
+drop table fk_clone_forward_drop_src.parent;
+alter table fk_clone_forward_drop_src.child add column payload int;
+select table_name, constraint_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_forward_drop_src'
+order by constraint_name;
+create table fk_clone_forward_drop_src.parent (id int primary key);
+set foreign_key_checks = 1;
+show create table fk_clone_forward_drop_src.child;
+insert into fk_clone_forward_drop_src.child values (1, 404, 0);
+drop database fk_clone_forward_drop_src;
+
+-- 11. A self-referencing parent with another child must have one canonical
+-- reverse-reference definition after COPY ALTER.
+drop database if exists fk_clone_self_external_src;
+create database fk_clone_self_external_src;
+use fk_clone_self_external_src;
+create table fk_clone_self_external_src.parent (
+    id int primary key,
+    parent_id int,
+    constraint fk_self_external_self foreign key (parent_id)
+        references fk_clone_self_external_src.parent(id)
+);
+create table fk_clone_self_external_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_self_external_child foreign key (parent_id)
+        references fk_clone_self_external_src.parent(id)
+);
+alter table fk_clone_self_external_src.parent add column payload int;
+select table_name, constraint_name, refer_table_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_self_external_src'
+order by table_name, constraint_name;
+drop table fk_clone_self_external_src.child;
+drop table fk_clone_self_external_src.parent;
+drop database fk_clone_self_external_src;
+
+-- 12. FK catalog column names must follow COPY ALTER column renames on both
+-- the child and parent sides.
+drop database if exists fk_clone_rename_columns_src;
+drop database if exists fk_clone_rename_columns_dst;
+create database fk_clone_rename_columns_src;
+use fk_clone_rename_columns_src;
+create table fk_clone_rename_columns_src.parent (old_id int primary key);
+create table fk_clone_rename_columns_src.child (
+    id int primary key,
+    old_parent_id int,
+    constraint fk_rename_columns foreign key (old_parent_id)
+        references fk_clone_rename_columns_src.parent(old_id)
+);
+alter table fk_clone_rename_columns_src.child
+    rename column old_parent_id to parent_id;
+alter table fk_clone_rename_columns_src.parent
+    rename column old_id to id;
+select table_name, column_name, refer_table_name, refer_column_name
+from mo_catalog.mo_foreign_keys
+where db_name = 'fk_clone_rename_columns_src'
+order by constraint_name;
+create database fk_clone_rename_columns_dst clone fk_clone_rename_columns_src;
+show create table fk_clone_rename_columns_dst.child;
+insert into fk_clone_rename_columns_dst.child values (1, 404);
+drop database fk_clone_rename_columns_dst;
+drop database fk_clone_rename_columns_src;
+
+-- 13. Clone an explicit database snapshot taken after ALTER.
+drop snapshot if exists fk_clone_alter_snapshot;
+drop database if exists fk_clone_snapshot_src;
+drop database if exists fk_clone_snapshot_dst;
+create database fk_clone_snapshot_src;
+use fk_clone_snapshot_src;
+create table fk_clone_snapshot_src.parent (id int primary key);
+create table fk_clone_snapshot_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_snapshot foreign key (parent_id)
+        references fk_clone_snapshot_src.parent(id)
+);
+insert into fk_clone_snapshot_src.parent values (1);
+insert into fk_clone_snapshot_src.child values (1, 1);
+alter table fk_clone_snapshot_src.child add column before_snapshot varchar(32);
+create snapshot fk_clone_alter_snapshot for database fk_clone_snapshot_src;
+alter table fk_clone_snapshot_src.child add column after_snapshot varchar(32);
+insert into fk_clone_snapshot_src.parent values (2);
+insert into fk_clone_snapshot_src.child(id, parent_id) values (2, 2);
+create database fk_clone_snapshot_dst clone fk_clone_snapshot_src
+    {snapshot = 'fk_clone_alter_snapshot'};
+show create table fk_clone_snapshot_dst.child;
+select id, parent_id from fk_clone_snapshot_dst.child order by id;
+insert into fk_clone_snapshot_dst.child(id, parent_id) values (3, 999);
+drop database fk_clone_snapshot_dst;
+drop database fk_clone_snapshot_src;
+drop snapshot fk_clone_alter_snapshot;
+
+-- 10. Clone, ALTER the cloned child, then clone again.
+drop database if exists fk_clone_chain_clone_src;
+drop database if exists fk_clone_chain_clone_mid;
+drop database if exists fk_clone_chain_clone_dst;
+create database fk_clone_chain_clone_src;
+use fk_clone_chain_clone_src;
+create table fk_clone_chain_clone_src.parent (id int primary key);
+create table fk_clone_chain_clone_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_clone_chain foreign key (parent_id)
+        references fk_clone_chain_clone_src.parent(id)
+);
+alter table fk_clone_chain_clone_src.child add column source_value int;
+create database fk_clone_chain_clone_mid clone fk_clone_chain_clone_src;
+use fk_clone_chain_clone_mid;
+alter table fk_clone_chain_clone_mid.child add column middle_value int;
+create database fk_clone_chain_clone_dst clone fk_clone_chain_clone_mid;
+show create table fk_clone_chain_clone_dst.child;
+insert into fk_clone_chain_clone_dst.child(id, parent_id) values (1, 999);
+drop database fk_clone_chain_clone_dst;
+drop database fk_clone_chain_clone_mid;
+drop database fk_clone_chain_clone_src;
+
+-- 11. Rename FK columns and tables before cloning.
+drop database if exists fk_clone_rename_src;
+drop database if exists fk_clone_rename_dst;
+create database fk_clone_rename_src;
+use fk_clone_rename_src;
+create table fk_clone_rename_src.parent (id int primary key);
+create table fk_clone_rename_src.child (
+    id int primary key,
+    parent_id int,
+    constraint fk_rename foreign key (parent_id)
+        references fk_clone_rename_src.parent(id)
+);
+alter table fk_clone_rename_src.parent rename column id to parent_key;
+alter table fk_clone_rename_src.child rename column parent_id to parent_key;
+rename table fk_clone_rename_src.parent to fk_clone_rename_src.renamed_parent;
+rename table fk_clone_rename_src.child to fk_clone_rename_src.renamed_child;
+alter table fk_clone_rename_src.renamed_child add column payload varchar(32);
+create database fk_clone_rename_dst clone fk_clone_rename_src;
+show create table fk_clone_rename_dst.renamed_child;
+insert into fk_clone_rename_dst.renamed_child(id, parent_key) values (1, 999);
+drop database fk_clone_rename_dst;
+drop database fk_clone_rename_src;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Backport of #26330 to `4.2-dev`.

Relates to #26328.

## What this PR does / why we need it:

COPY-mode `ALTER TABLE` replaces a relation with a new physical table. Before #26330, this could lose or split foreign-key metadata, and clone/snapshot/PITR restore could miss dependency edges after an affected ALTER.

This backport:

- transfers child-side `mo_foreign_keys` rows across the COPY replacement and restores the logical source table name;
- keeps parent-side names stable so self references do not point at the temporary relation;
- canonicalizes parent reverse-reference mutations and preserves self-reference sentinel `0`;
- derives clone and restore dependency edges from historical table DDL in addition to catalog rows;
- enumerates ordinary snapshot source databases at the source timestamp;
- includes the unit and BVT regression coverage from #26330.

Backport notes:

- cherry-picked squash commit `eeaa44641d8984a248e6447b93e4e80d9f6a2f71`;
- resolved test conflicts by retaining only tests introduced by #26330, excluding unrelated newer main-branch tests;
- included the `pkg/sql/plan` SQL string literal quoting helper required by #26330. The helper originated in #26218, but the rest of that unrelated change is not included.

## Validation

- `go test ./pkg/sql/plan ./pkg/sql/compile ./pkg/frontend`
- `git diff --check origin/4.2-dev...HEAD`

Issue #26328 was validated with a fresh single-node deployment using the exact reported schema and `ALTER TABLE` sequence:

| Check | `4.2-dev` base (`84e8ed9d2`) | This PR (`e933c4e90`) |
| --- | --- | --- |
| FK catalog rows before ALTER | 1 | 1 |
| FK catalog rows after ALTER | 0 | 1 |
| `CREATE DATABASE ... CLONE ...` | Fails with `can't find fkTable` | Succeeds |
| Cloned FK catalog rows | N/A | 1 |
| Valid child insert | N/A | Succeeds |
| Missing-parent child insert | N/A | Rejected by FK |
| Clone the cloned database | N/A | Succeeds; FK catalog rows remain 1 |

This confirms both the original failure and the repair of the underlying catalog metadata, cloned schema, and FK enforcement.

The BVT SQL and audited result from #26330 are included unchanged; the complete BVT suite was not rerun locally for this backport.