### PR TITLE
fix(join): canonicalize DOUBLE signed zero across spill modes

### DIFF
--- a/pkg/common/hashmap/inthashmap.go
+++ b/pkg/common/hashmap/inthashmap.go
@@ -17,8 +17,10 @@ package hashmap
 import (
 	"bytes"
 	"io"
+	"math"
 	"unsafe"
 
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/hashtable"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -99,6 +101,9 @@ func (itr *intHashMapIterator) encodeHashKeys(vecs []*vector.Vector, start, coun
 			fillKeys[uint32](itr, vec, 4, start, count)
 		case 8:
 			fillKeys[uint64](itr, vec, 8, start, count)
+			if vec.GetType().Oid == types.T_float64 {
+				normalizeFloat64HashKeys(itr, vec, start, count)
+			}
 		default:
 			if !vec.IsConst() && vec.GetArea() == nil {
 				fillVarlenaKey(itr, vec, start, count)
@@ -106,6 +111,21 @@ func (itr *intHashMapIterator) encodeHashKeys(vecs []*vector.Vector, start, coun
 				fillStrKey(itr, vec, start, count)
 			}
 		}
+	}
+}
+
+func normalizeFloat64HashKeys(itr *intHashMapIterator, vec *vector.Vector, start, n int) {
+	if vec.IsConstNull() {
+		return
+	}
+	nsp := vec.GetNulls()
+	for i := 0; i < n; i++ {
+		if nsp.Contains(uint64(i + start)) {
+			continue
+		}
+		valueOffset := itr.keyOffs[i] - uint32(types.T_float64.TypeLen())
+		ptr := (*uint64)(unsafe.Add(unsafe.Pointer(&itr.keys[i]), valueOffset))
+		*ptr = keycodec.CanonicalFloat64Bits(math.Float64frombits(*ptr))
 	}
 }
 

--- a/pkg/common/hashmap/inthashmap.go
+++ b/pkg/common/hashmap/inthashmap.go
@@ -17,7 +17,6 @@ package hashmap
 import (
 	"bytes"
 	"io"
-	"math"
 	"unsafe"
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
@@ -100,9 +99,10 @@ func (itr *intHashMapIterator) encodeHashKeys(vecs []*vector.Vector, start, coun
 		case 4:
 			fillKeys[uint32](itr, vec, 4, start, count)
 		case 8:
-			fillKeys[uint64](itr, vec, 8, start, count)
 			if vec.GetType().Oid == types.T_float64 {
-				normalizeFloat64HashKeys(itr, vec, start, count)
+				fillFloat64Keys(itr, vec, start, count)
+			} else {
+				fillKeys[uint64](itr, vec, 8, start, count)
 			}
 		default:
 			if !vec.IsConst() && vec.GetArea() == nil {
@@ -114,18 +114,82 @@ func (itr *intHashMapIterator) encodeHashKeys(vecs []*vector.Vector, start, coun
 	}
 }
 
-func normalizeFloat64HashKeys(itr *intHashMapIterator, vec *vector.Vector, start, n int) {
+func fillFloat64Keys(itr *intHashMapIterator, vec *vector.Vector, start, n int) {
+	keys := itr.keys
+	keyOffs := itr.keyOffs
 	if vec.IsConstNull() {
+		if itr.mp.hasNull {
+			for i := 0; i < n; i++ {
+				*(*int8)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) = 1
+				keyOffs[i]++
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				itr.zValues[i] = 0
+			}
+		}
 		return
 	}
-	nsp := vec.GetNulls()
-	for i := 0; i < n; i++ {
-		if nsp.Contains(uint64(i + start)) {
-			continue
+
+	values := vector.MustFixedColNoTypeCheck[float64](vec)
+	if vec.IsConst() {
+		bits := keycodec.CanonicalFloat64Bits(values[0])
+		if itr.mp.hasNull {
+			for i := 0; i < n; i++ {
+				*(*int8)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) = 0
+				*(*uint64)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i]+1)) = bits
+			}
+			uint32AddScalar(1+uint32(types.T_float64.TypeLen()), keyOffs[:n], keyOffs[:n])
+		} else {
+			for i := 0; i < n; i++ {
+				*(*uint64)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) = bits
+			}
+			uint32AddScalar(uint32(types.T_float64.TypeLen()), keyOffs[:n], keyOffs[:n])
 		}
-		valueOffset := itr.keyOffs[i] - uint32(types.T_float64.TypeLen())
-		ptr := (*uint64)(unsafe.Add(unsafe.Pointer(&itr.keys[i]), valueOffset))
-		*ptr = keycodec.CanonicalFloat64Bits(math.Float64frombits(*ptr))
+		return
+	}
+
+	if !vec.GetNulls().Any() {
+		if itr.mp.hasNull {
+			for i := 0; i < n; i++ {
+				*(*int8)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) = 0
+				*(*uint64)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i]+1)) =
+					keycodec.CanonicalFloat64Bits(values[i+start])
+			}
+			uint32AddScalar(1+uint32(types.T_float64.TypeLen()), keyOffs[:n], keyOffs[:n])
+		} else {
+			for i := 0; i < n; i++ {
+				*(*uint64)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) =
+					keycodec.CanonicalFloat64Bits(values[i+start])
+			}
+			uint32AddScalar(uint32(types.T_float64.TypeLen()), keyOffs[:n], keyOffs[:n])
+		}
+		return
+	}
+
+	nsp := vec.GetNulls()
+	if itr.mp.hasNull {
+		for i := 0; i < n; i++ {
+			if nsp.Contains(uint64(i + start)) {
+				*(*int8)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) = 1
+				keyOffs[i]++
+			} else {
+				*(*int8)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) = 0
+				*(*uint64)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i]+1)) =
+					keycodec.CanonicalFloat64Bits(values[i+start])
+				keyOffs[i] += 1 + uint32(types.T_float64.TypeLen())
+			}
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			if nsp.Contains(uint64(i + start)) {
+				itr.zValues[i] = 0
+				continue
+			}
+			*(*uint64)(unsafe.Add(unsafe.Pointer(&keys[i]), keyOffs[i])) =
+				keycodec.CanonicalFloat64Bits(values[i+start])
+			keyOffs[i] += uint32(types.T_float64.TypeLen())
+		}
 	}
 }
 

--- a/pkg/common/hashmap/keycodec/keycodec.go
+++ b/pkg/common/hashmap/keycodec/keycodec.go
@@ -18,26 +18,122 @@ package keycodec
 
 import (
 	"math"
+	"unsafe"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 )
 
-var positiveFloat64Zero [8]byte
-
 // CanonicalFloat64Bits makes SQL-equal signed zero values use one hash key.
 func CanonicalFloat64Bits(value float64) uint64 {
-	if value == 0 {
+	bits := math.Float64bits(value)
+	if bits<<1 == 0 {
 		return 0
 	}
-	return math.Float64bits(value)
+	return bits
 }
 
-// BytesAt returns the canonical hash-key bytes for one vector row.
-func BytesAt(vec *vector.Vector, row int) []byte {
-	if vec.GetType().Oid == types.T_float64 &&
-		vector.GetFixedAtNoTypeCheck[float64](vec, row) == 0 {
-		return positiveFloat64Zero[:]
+// CanonicalFloat64Bytes returns the native-endian bytes used by the resident
+// hashmaps and spill partitioning. Returning the bytes by value avoids exposing
+// mutable package-global storage to callers.
+func CanonicalFloat64Bytes(value float64) [8]byte {
+	bits := CanonicalFloat64Bits(value)
+	return *(*[8]byte)(unsafe.Pointer(&bits))
+}
+
+// HashCombine merges one column hash into the hash state for a composite key.
+func HashCombine(hash, columnHash uint64) uint64 {
+	return hash ^ (columnHash + 0x9e3779b97f4a7c15 + (hash << 6) + (hash >> 2))
+}
+
+// ComputeXXHash computes the canonical partition hash for a set of typed key
+// vectors. Type dispatch happens once per vector; row loops remain specialized
+// so common raw-byte keys do not pay a per-row codec dispatch cost.
+func ComputeXXHash(keyVecs []*vector.Vector, hashValues []uint64, seed uint64) {
+	if len(hashValues) == 0 {
+		return
 	}
-	return vec.GetRawBytesAt(row)
+
+	rowCount := len(hashValues)
+	for i := 0; i < rowCount; i++ {
+		hashValues[i] = seed
+	}
+	if len(keyVecs) == 0 {
+		return
+	}
+
+	for _, vec := range keyVecs {
+		if vec.GetType().Oid == types.T_float64 {
+			computeFloat64XXHash(vec, hashValues)
+			continue
+		}
+		if vec.IsConst() {
+			columnHash := uint64(0)
+			if !vec.IsConstNull() {
+				columnHash = xxhash.Sum64(vec.GetRawBytesAt(0))
+			}
+			for i := 0; i < rowCount; i++ {
+				hashValues[i] = HashCombine(hashValues[i], columnHash)
+			}
+			continue
+		}
+
+		n := rowCount
+		if vec.Length() < n {
+			n = vec.Length()
+		}
+		if vec.GetNulls().Any() {
+			nulls := vec.GetNulls()
+			for i := 0; i < n; i++ {
+				if nulls.Contains(uint64(i)) {
+					hashValues[i] = HashCombine(hashValues[i], 0)
+				} else {
+					hashValues[i] = HashCombine(hashValues[i], xxhash.Sum64(vec.GetRawBytesAt(i)))
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				hashValues[i] = HashCombine(hashValues[i], xxhash.Sum64(vec.GetRawBytesAt(i)))
+			}
+		}
+	}
+}
+
+func computeFloat64XXHash(vec *vector.Vector, hashValues []uint64) {
+	rowCount := len(hashValues)
+	if vec.IsConst() {
+		columnHash := uint64(0)
+		if !vec.IsConstNull() {
+			values := vector.MustFixedColNoTypeCheck[float64](vec)
+			value := CanonicalFloat64Bytes(values[0])
+			columnHash = xxhash.Sum64(value[:])
+		}
+		for i := 0; i < rowCount; i++ {
+			hashValues[i] = HashCombine(hashValues[i], columnHash)
+		}
+		return
+	}
+
+	n := rowCount
+	if vec.Length() < n {
+		n = vec.Length()
+	}
+	values := vector.MustFixedColNoTypeCheck[float64](vec)
+	if vec.GetNulls().Any() {
+		nulls := vec.GetNulls()
+		for i := 0; i < n; i++ {
+			if nulls.Contains(uint64(i)) {
+				hashValues[i] = HashCombine(hashValues[i], 0)
+			} else {
+				value := CanonicalFloat64Bytes(values[i])
+				hashValues[i] = HashCombine(hashValues[i], xxhash.Sum64(value[:]))
+			}
+		}
+		return
+	}
+	for i := 0; i < n; i++ {
+		value := CanonicalFloat64Bytes(values[i])
+		hashValues[i] = HashCombine(hashValues[i], xxhash.Sum64(value[:]))
+	}
 }

--- a/pkg/common/hashmap/keycodec/keycodec.go
+++ b/pkg/common/hashmap/keycodec/keycodec.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package keycodec defines the canonical byte contract shared by resident
+// hashmaps and spill partitioning.
+package keycodec
+
+import (
+	"math"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+)
+
+var positiveFloat64Zero [8]byte
+
+// CanonicalFloat64Bits makes SQL-equal signed zero values use one hash key.
+func CanonicalFloat64Bits(value float64) uint64 {
+	if value == 0 {
+		return 0
+	}
+	return math.Float64bits(value)
+}
+
+// BytesAt returns the canonical hash-key bytes for one vector row.
+func BytesAt(vec *vector.Vector, row int) []byte {
+	if vec.GetType().Oid == types.T_float64 &&
+		vector.GetFixedAtNoTypeCheck[float64](vec, row) == 0 {
+		return positiveFloat64Zero[:]
+	}
+	return vec.GetRawBytesAt(row)
+}

--- a/pkg/common/hashmap/strhashmap.go
+++ b/pkg/common/hashmap/strhashmap.go
@@ -135,12 +135,30 @@ func fillFloat64GroupStr(itr *strHashmapIterator, vec *vector.Vector, n, start i
 		return
 	}
 	if vec.IsConst() {
-		value := keycodec.BytesAt(vec, 0)
+		values := vector.MustFixedColNoTypeCheck[float64](vec)
+		value := keycodec.CanonicalFloat64Bytes(values[0])
 		for i := 0; i < n; i++ {
 			if itr.mp.hasNull {
 				keys[i] = append(keys[i], byte(0))
 			}
-			keys[i] = append(keys[i], value...)
+			keys[i] = append(keys[i], value[:]...)
+		}
+		return
+	}
+
+	values := vector.MustFixedColNoTypeCheck[float64](vec)
+	if !vec.GetNulls().Any() {
+		if itr.mp.hasNull {
+			for i := 0; i < n; i++ {
+				keys[i] = append(keys[i], byte(0))
+				value := keycodec.CanonicalFloat64Bytes(values[i+start])
+				keys[i] = append(keys[i], value[:]...)
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				value := keycodec.CanonicalFloat64Bytes(values[i+start])
+				keys[i] = append(keys[i], value[:]...)
+			}
 		}
 		return
 	}
@@ -156,12 +174,14 @@ func fillFloat64GroupStr(itr *strHashmapIterator, vec *vector.Vector, n, start i
 				keys[i] = append(keys[i], byte(1))
 			} else {
 				keys[i] = append(keys[i], byte(0))
-				keys[i] = append(keys[i], keycodec.BytesAt(vec, row)...)
+				value := keycodec.CanonicalFloat64Bytes(values[row])
+				keys[i] = append(keys[i], value[:]...)
 			}
 		} else if nsp.Contains(uint64(row)) {
 			itr.zValues[i] = 0
 		} else {
-			keys[i] = append(keys[i], keycodec.BytesAt(vec, row)...)
+			value := keycodec.CanonicalFloat64Bytes(values[row])
+			keys[i] = append(keys[i], value[:]...)
 		}
 	}
 }

--- a/pkg/common/hashmap/strhashmap.go
+++ b/pkg/common/hashmap/strhashmap.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/hashtable"
@@ -96,7 +97,11 @@ func (m *StrHashMap) Size() int64 {
 func (itr *strHashmapIterator) encodeHashKeys(vecs []*vector.Vector, start, count int) {
 	for _, vec := range vecs {
 		if vec.GetType().IsFixedLen() {
-			fillGroupStr(itr, vec, count, vec.GetType().TypeSize(), start, 0, len(vecs))
+			if vec.GetType().Oid == types.T_float64 {
+				fillFloat64GroupStr(itr, vec, count, start)
+			} else {
+				fillGroupStr(itr, vec, count, vec.GetType().TypeSize(), start, 0, len(vecs))
+			}
 		} else {
 			fillStringGroupStr(itr, vec, count, start, len(vecs))
 		}
@@ -105,6 +110,58 @@ func (itr *strHashmapIterator) encodeHashKeys(vecs []*vector.Vector, start, coun
 	for i := 0; i < count; i++ {
 		if l := len(keys[i]); l < 16 {
 			keys[i] = append(keys[i], hashtable.StrKeyPadding[l:]...)
+		}
+	}
+}
+
+func fillFloat64GroupStr(itr *strHashmapIterator, vec *vector.Vector, n, start int) {
+	keys := itr.keys
+	if vec.IsGrouping() {
+		for i := 0; i < n; i++ {
+			keys[i] = append(keys[i], byte(2))
+		}
+		return
+	}
+	if vec.IsConstNull() {
+		if itr.mp.hasNull {
+			for i := 0; i < n; i++ {
+				keys[i] = append(keys[i], byte(1))
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				itr.zValues[i] = 0
+			}
+		}
+		return
+	}
+	if vec.IsConst() {
+		value := keycodec.BytesAt(vec, 0)
+		for i := 0; i < n; i++ {
+			if itr.mp.hasNull {
+				keys[i] = append(keys[i], byte(0))
+			}
+			keys[i] = append(keys[i], value...)
+		}
+		return
+	}
+
+	nsp := vec.GetNulls()
+	gsp := vec.GetGrouping()
+	for i := 0; i < n; i++ {
+		row := i + start
+		if itr.mp.hasNull {
+			if gsp.Contains(uint64(row)) {
+				keys[i] = append(keys[i], byte(2))
+			} else if nsp.Contains(uint64(row)) {
+				keys[i] = append(keys[i], byte(1))
+			} else {
+				keys[i] = append(keys[i], byte(0))
+				keys[i] = append(keys[i], keycodec.BytesAt(vec, row)...)
+			}
+		} else if nsp.Contains(uint64(row)) {
+			itr.zValues[i] = 0
+		} else {
+			keys[i] = append(keys[i], keycodec.BytesAt(vec, row)...)
 		}
 	}
 }

--- a/pkg/common/hashmap/strhashmap_test.go
+++ b/pkg/common/hashmap/strhashmap_test.go
@@ -16,6 +16,7 @@ package hashmap
 
 import (
 	"io"
+	"math"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -30,6 +31,44 @@ import (
 const (
 	Rows = 10
 )
+
+func TestStrHashMapFloat64SignedZero(t *testing.T) {
+	m := mpool.MustNewZero()
+	mp, err := NewStrHashMap(false, m)
+	require.NoError(t, err)
+	defer func() {
+		mp.Free()
+		require.Zero(t, m.Stats().NumCurrBytes.Load())
+	}()
+
+	floatType := types.T_float64.ToType()
+	intType := types.T_int8.ToType()
+	build := []*vector.Vector{
+		vector.NewVec(floatType),
+		vector.NewVec(intType),
+	}
+	probe := []*vector.Vector{
+		vector.NewVec(floatType),
+		vector.NewVec(intType),
+	}
+	defer func() {
+		for _, vec := range append(build, probe...) {
+			vec.Free(m)
+		}
+	}()
+	require.NoError(t, vector.AppendFixed(build[0], float64(0), false, m))
+	require.NoError(t, vector.AppendFixed(build[1], int8(7), false, m))
+	require.NoError(t, vector.AppendFixed(probe[0], math.Copysign(0, -1), false, m))
+	require.NoError(t, vector.AppendFixed(probe[1], int8(7), false, m))
+
+	itr := mp.NewIterator()
+	vals, _, err := itr.Insert(0, 1, build)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), vals[0])
+	vals, zvals := itr.Find(0, 1, probe)
+	require.Equal(t, uint64(1), vals[0])
+	require.Equal(t, int64(1), zvals[0])
+}
 
 func TestInsert(t *testing.T) {
 	m := mpool.MustNewZero()

--- a/pkg/common/hashmap/strhashmap_test.go
+++ b/pkg/common/hashmap/strhashmap_test.go
@@ -32,42 +32,226 @@ const (
 	Rows = 10
 )
 
-func TestStrHashMapFloat64SignedZero(t *testing.T) {
-	m := mpool.MustNewZero()
-	mp, err := NewStrHashMap(false, m)
-	require.NoError(t, err)
-	defer func() {
-		mp.Free()
-		require.Zero(t, m.Stats().NumCurrBytes.Load())
-	}()
+type float64HashMapShape struct {
+	name        string
+	vectorKind  string
+	hasNull     bool
+	start       int
+	count       int
+	wantValues  []uint64
+	wantZValues []int64
+	wantGroups  uint64
+}
 
-	floatType := types.T_float64.ToType()
-	intType := types.T_int8.ToType()
-	build := []*vector.Vector{
-		vector.NewVec(floatType),
-		vector.NewVec(intType),
+func TestHashMapsFloat64SignedZeroContract(t *testing.T) {
+	// Vector representation and NULL policy must not change the signed-zero
+	// equality contract. Exercise both the single-key IntHashMap and a
+	// composite-key StrHashMap through their public iterator API.
+	mapKinds := []struct {
+		name      string
+		composite bool
+	}{
+		{name: "int"},
+		{name: "composite-str", composite: true},
 	}
-	probe := []*vector.Vector{
-		vector.NewVec(floatType),
-		vector.NewVec(intType),
+	shapes := []float64HashMapShape{
+		{
+			name:        "flat",
+			vectorKind:  "flat",
+			start:       1,
+			count:       1,
+			wantValues:  []uint64{1},
+			wantZValues: []int64{1},
+			wantGroups:  1,
+		},
+		{
+			name:        "flat-nullable-map",
+			vectorKind:  "flat",
+			hasNull:     true,
+			start:       1,
+			count:       1,
+			wantValues:  []uint64{1},
+			wantZValues: []int64{1},
+			wantGroups:  1,
+		},
+		{
+			name:        "flat-null-filter",
+			vectorKind:  "flat-null",
+			count:       2,
+			wantValues:  []uint64{1, 0},
+			wantZValues: []int64{1, 0},
+			wantGroups:  1,
+		},
+		{
+			name:        "flat-null-key",
+			vectorKind:  "flat-null",
+			hasNull:     true,
+			count:       2,
+			wantValues:  []uint64{1, 2},
+			wantZValues: []int64{1, 1},
+			wantGroups:  2,
+		},
+		{
+			name:        "const",
+			vectorKind:  "const",
+			count:       2,
+			wantValues:  []uint64{1, 1},
+			wantZValues: []int64{1, 1},
+			wantGroups:  1,
+		},
+		{
+			name:        "const-nullable-map",
+			vectorKind:  "const",
+			hasNull:     true,
+			count:       2,
+			wantValues:  []uint64{1, 1},
+			wantZValues: []int64{1, 1},
+			wantGroups:  1,
+		},
+		{
+			name:        "const-null-filter",
+			vectorKind:  "const-null",
+			count:       2,
+			wantValues:  []uint64{0, 0},
+			wantZValues: []int64{0, 0},
+			wantGroups:  0,
+		},
+		{
+			name:        "const-null-key",
+			vectorKind:  "const-null",
+			hasNull:     true,
+			count:       2,
+			wantValues:  []uint64{1, 1},
+			wantZValues: []int64{1, 1},
+			wantGroups:  1,
+		},
+	}
+
+	for _, mapKind := range mapKinds {
+		for _, shape := range shapes {
+			t.Run(mapKind.name+"/"+shape.name, func(t *testing.T) {
+				runFloat64HashMapShape(t, mapKind.composite, shape)
+			})
+		}
+	}
+}
+
+func runFloat64HashMapShape(t *testing.T, composite bool, shape float64HashMapShape) {
+	m := mpool.MustNewZero()
+	var (
+		hashMap HashMap
+		itr     Iterator
+		build   []*vector.Vector
+		probe   []*vector.Vector
+	)
+	if composite {
+		mp, err := NewStrHashMap(shape.hasNull, m)
+		require.NoError(t, err)
+		hashMap = mp
+		itr = mp.NewIterator()
+	} else {
+		mp, err := NewIntHashMap(shape.hasNull, m)
+		require.NoError(t, err)
+		hashMap = mp
+		itr = mp.NewIterator()
 	}
 	defer func() {
-		for _, vec := range append(build, probe...) {
+		hashMap.Free()
+		for _, vec := range build {
 			vec.Free(m)
 		}
+		for _, vec := range probe {
+			vec.Free(m)
+		}
+		require.Zero(t, m.Stats().NumCurrBytes.Load())
 	}()
-	require.NoError(t, vector.AppendFixed(build[0], float64(0), false, m))
-	require.NoError(t, vector.AppendFixed(build[1], int8(7), false, m))
-	require.NoError(t, vector.AppendFixed(probe[0], math.Copysign(0, -1), false, m))
-	require.NoError(t, vector.AppendFixed(probe[1], int8(7), false, m))
+	buildFloat, probeFloat := makeFloat64HashMapShapeVectors(t, m, shape.vectorKind)
+	build = makeFloat64HashMapKeys(t, m, buildFloat, composite)
+	probe = makeFloat64HashMapKeys(t, m, probeFloat, composite)
 
-	itr := mp.NewIterator()
-	vals, _, err := itr.Insert(0, 1, build)
+	values, zValues, err := itr.Insert(shape.start, shape.count, build)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), vals[0])
-	vals, zvals := itr.Find(0, 1, probe)
-	require.Equal(t, uint64(1), vals[0])
-	require.Equal(t, int64(1), zvals[0])
+	require.Equal(t, shape.wantZValues, zValues)
+	require.Equal(t, shape.wantValues, liveHashMapValues(values, zValues))
+	require.Equal(t, shape.wantGroups, hashMap.GroupCount())
+
+	values, zValues = itr.Find(shape.start, shape.count, probe)
+	require.Equal(t, shape.wantZValues, zValues)
+	require.Equal(t, shape.wantValues, liveHashMapValues(values, zValues))
+	require.Equal(t, shape.wantGroups, hashMap.GroupCount())
+}
+
+func liveHashMapValues(values []uint64, zValues []int64) []uint64 {
+	live := append([]uint64(nil), values...)
+	for row := range live {
+		// Iterator values are unspecified when zValues marks the row filtered.
+		if zValues[row] == 0 {
+			live[row] = 0
+		}
+	}
+	return live
+}
+
+func makeFloat64HashMapShapeVectors(
+	t *testing.T,
+	m *mpool.MPool,
+	vectorKind string,
+) (*vector.Vector, *vector.Vector) {
+	floatType := types.T_float64.ToType()
+	switch vectorKind {
+	case "flat":
+		build := vector.NewVec(floatType)
+		probe := vector.NewVec(floatType)
+		require.NoError(t, vector.AppendFixed(build, float64(123), false, m))
+		require.NoError(t, vector.AppendFixed(build, float64(0), false, m))
+		require.NoError(t, vector.AppendFixed(probe, float64(456), false, m))
+		require.NoError(t, vector.AppendFixed(probe, math.Copysign(0, -1), false, m))
+		return build, probe
+	case "flat-null":
+		build := vector.NewVec(floatType)
+		probe := vector.NewVec(floatType)
+		require.NoError(t, vector.AppendFixed(build, float64(0), false, m))
+		require.NoError(t, vector.AppendFixed(build, float64(99), true, m))
+		require.NoError(t, vector.AppendFixed(probe, math.Copysign(0, -1), false, m))
+		require.NoError(t, vector.AppendFixed(probe, float64(77), true, m))
+		return build, probe
+	case "const":
+		build, err := vector.NewConstFixed(floatType, float64(0), 2, m)
+		require.NoError(t, err)
+		probe, err := vector.NewConstFixed(floatType, math.Copysign(0, -1), 2, m)
+		require.NoError(t, err)
+		return build, probe
+	case "const-null":
+		return vector.NewConstNull(floatType, 2, m), vector.NewConstNull(floatType, 2, m)
+	default:
+		t.Fatalf("unknown float64 hashmap vector kind %q", vectorKind)
+		return nil, nil
+	}
+}
+
+func makeFloat64HashMapKeys(
+	t *testing.T,
+	m *mpool.MPool,
+	floatVec *vector.Vector,
+	composite bool,
+) []*vector.Vector {
+	if !composite {
+		return []*vector.Vector{floatVec}
+	}
+
+	intType := types.T_int8.ToType()
+	var discriminator *vector.Vector
+	if floatVec.IsConst() {
+		var err error
+		discriminator, err = vector.NewConstFixed(intType, int8(7), floatVec.Length(), m)
+		require.NoError(t, err)
+	} else {
+		discriminator = vector.NewVec(intType)
+		for row := 0; row < floatVec.Length(); row++ {
+			require.NoError(t, vector.AppendFixed(discriminator, int8(7), false, m))
+		}
+	}
+	return []*vector.Vector{floatVec, discriminator}
 }
 
 func TestInsert(t *testing.T) {

--- a/pkg/sql/colexec/dedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/dedupjoin/key_contract_test.go
@@ -39,9 +39,8 @@ type dedupKeyContractMode struct {
 }
 
 func TestDedupJoinDoubleSignedZeroContract(t *testing.T) {
-	// Scalar DOUBLE equality treats +0 and -0 as equal. The false expectations
-	// characterize the current key-encoding gap for one representative
-	// DedupJoin operation across all three execution modes.
+	// Scalar DOUBLE equality treats +0 and -0 as equal, so every execution mode
+	// must capture the matching probe value.
 	modes := []dedupKeyContractMode{
 		{name: "resident"},
 		{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
@@ -49,7 +48,7 @@ func TestDedupJoinDoubleSignedZeroContract(t *testing.T) {
 	}
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
-			require.False(t, runDedupJoinDoubleSignedZeroContract(t, mode))
+			require.True(t, runDedupJoinDoubleSignedZeroContract(t, mode))
 		})
 	}
 }

--- a/pkg/sql/colexec/dedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/dedupjoin/key_contract_test.go
@@ -105,6 +105,7 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 		OnDuplicateAction:               plan.Node_FAIL,
 		OldColCapturePlaceholderIdxList: []int32{1},
 		OldColCaptureProbeIdxList:       []int32{1},
+		DelColIdx:                       -1,
 		IsShuffle:                       mode.shuffle,
 		ShuffleIdx:                      0,
 		SpillThreshold:                  mode.spillThreshold,
@@ -159,8 +160,11 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 		require.NoError(t, execErr)
 		if result.Batch != nil {
 			keys := vector.MustFixedColNoTypeCheck[float64](result.Batch.Vecs[0])
+			capturedValues := vector.MustFixedColNoTypeCheck[int32](result.Batch.Vecs[1])
 			for i, key := range keys {
-				if key == 0 && !result.Batch.Vecs[1].GetNulls().Contains(uint64(i)) {
+				if key == 0 &&
+					!result.Batch.Vecs[1].GetNulls().Contains(uint64(i)) &&
+					capturedValues[i] == 42 {
 					targetCaptured = true
 				}
 			}

--- a/pkg/sql/colexec/dedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/dedupjoin/key_contract_test.go
@@ -16,14 +16,17 @@ package dedupjoin
 
 import (
 	"math"
+	"sort"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/spillutil"
 	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -38,22 +41,44 @@ type dedupKeyContractMode struct {
 	wantReSpill      bool
 }
 
+type dedupKeyContractRow struct {
+	keyBits      uint64
+	captured     int32
+	capturedNull bool
+}
+
 func TestDedupJoinDoubleSignedZeroContract(t *testing.T) {
-	// Scalar DOUBLE equality treats +0 and -0 as equal, so every execution mode
-	// must capture the matching probe value.
+	// Scalar DOUBLE equality treats +0 and -0 as equal. Every execution mode
+	// must preserve the complete build row set and capture exactly that target.
 	modes := []dedupKeyContractMode{
 		{name: "resident"},
-		{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
+		{name: "initial-spill", shuffle: true, spillThreshold: hashmap.UnitLimit + 1, wantInitialSpill: true},
 		{name: "re-spill", shuffle: true, spillThreshold: 2, wantInitialSpill: true, wantReSpill: true},
 	}
+	want := expectedDedupJoinDoubleSignedZeroRows()
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
-			require.True(t, runDedupJoinDoubleSignedZeroContract(t, mode))
+			require.Equal(t, want, runDedupJoinDoubleSignedZeroContract(t, mode))
 		})
 	}
 }
 
-func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMode) bool {
+func expectedDedupJoinDoubleSignedZeroRows() []dedupKeyContractRow {
+	rows := make([]dedupKeyContractRow, hashmap.UnitLimit+1)
+	for key := 0; key <= hashmap.UnitLimit; key++ {
+		rows[key] = dedupKeyContractRow{
+			keyBits:      math.Float64bits(float64(key)),
+			capturedNull: key != 0,
+		}
+	}
+	rows[0].captured = 42
+	return rows
+}
+
+func runDedupJoinDoubleSignedZeroContract(
+	t *testing.T,
+	mode dedupKeyContractMode,
+) []dedupKeyContractRow {
 	proc, ctrl := newCaptureTestProc(t)
 	defer ctrl.Finish()
 	proc.Base.Lim.Size = 8 << 20
@@ -74,13 +99,20 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 		if probeBatch != nil {
 			probeBatch.Clean(proc.Mp())
 		}
-		budget, err := proc.GetHashBuildBudget()
-		require.NoError(t, err)
-		require.Zero(t, budget.Used())
-		require.Zero(t, budget.SpillDiskUsed())
-		require.Zero(t, budget.SpillFDUsed())
+		budget, budgetErr := proc.GetHashBuildBudget()
+		var used, diskUsed, fdUsed uint64
+		if budgetErr == nil {
+			used = budget.Used()
+			diskUsed = budget.SpillDiskUsed()
+			fdUsed = budget.SpillFDUsed()
+		}
 		proc.Free()
-		require.Zero(t, proc.Mp().CurrNB())
+		mpoolBytes := proc.Mp().CurrNB()
+		require.NoError(t, budgetErr)
+		require.Zero(t, used)
+		require.Zero(t, diskUsed)
+		require.Zero(t, fdUsed)
+		require.Zero(t, mpoolBytes)
 	}()
 
 	floatType := types.T_float64.ToType()
@@ -92,19 +124,23 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 	tag++
 	joinMapTag := tag
 
-	const buildRows = 256
+	const buildRows = hashmap.UnitLimit + 1
 	buildKeys := vector.NewVec(floatType)
 	buildPlaceholder := vector.NewVec(intType)
-	require.NoError(t, vector.AppendFixed(buildKeys, float64(0), false, proc.Mp()))
-	require.NoError(t, vector.AppendFixed(buildPlaceholder, int32(0), true, proc.Mp()))
-	for i := 1; i < buildRows; i++ {
-		require.NoError(t, vector.AppendFixed(buildKeys, float64(i), false, proc.Mp()))
+	for key := 1; key < buildRows; key++ {
+		require.NoError(t, vector.AppendFixed(buildKeys, float64(key), false, proc.Mp()))
 		require.NoError(t, vector.AppendFixed(buildPlaceholder, int32(0), true, proc.Mp()))
 	}
+	// Keep the equality target in the second hashmap chunk (start=UnitLimit).
+	require.NoError(t, vector.AppendFixed(buildKeys, float64(0), false, proc.Mp()))
+	require.NoError(t, vector.AppendFixed(buildPlaceholder, int32(0), true, proc.Mp()))
 	buildBatch = batch.NewWithSize(2)
 	buildBatch.Vecs[0] = buildKeys
 	buildBatch.Vecs[1] = buildPlaceholder
 	buildBatch.SetRowCount(buildRows)
+	if mode.wantReSpill {
+		requireDedupTargetBucketReSpills(t, buildKeys, buildRows-1, mode.spillThreshold)
+	}
 
 	probeBatch = batch.NewWithSize(2)
 	probeBatch.Vecs[0] = vector.NewVec(floatType)
@@ -167,19 +203,28 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 	require.NoError(t, err)
 	require.Nil(t, buildResult.Batch)
 
-	targetCaptured := false
+	resultRows := make([]dedupKeyContractRow, 0, buildRows)
 	for {
 		result, execErr := vm.Exec(dedupArg, proc)
 		require.NoError(t, execErr)
 		if result.Batch != nil {
+			require.Len(t, result.Batch.Vecs, 2)
+			require.True(t, result.Batch.Vecs[0].GetNulls().IsEmpty())
 			keys := vector.MustFixedColNoTypeCheck[float64](result.Batch.Vecs[0])
 			capturedValues := vector.MustFixedColNoTypeCheck[int32](result.Batch.Vecs[1])
+			require.Len(t, keys, result.Batch.RowCount())
+			require.Len(t, capturedValues, result.Batch.RowCount())
 			for i, key := range keys {
-				if key == 0 &&
-					!result.Batch.Vecs[1].GetNulls().Contains(uint64(i)) &&
-					capturedValues[i] == 42 {
-					targetCaptured = true
+				capturedNull := result.Batch.Vecs[1].GetNulls().Contains(uint64(i))
+				captured := int32(0)
+				if !capturedNull {
+					captured = capturedValues[i]
 				}
+				resultRows = append(resultRows, dedupKeyContractRow{
+					keyBits:      math.Float64bits(key),
+					captured:     captured,
+					capturedNull: capturedNull,
+				})
 			}
 		}
 		if result.Status == vm.ExecStop {
@@ -204,5 +249,27 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 		require.Equal(t, reSpillBefore, reSpillAfter)
 	}
 
-	return targetCaptured
+	sort.Slice(resultRows, func(i, j int) bool {
+		return resultRows[i].keyBits < resultRows[j].keyBits
+	})
+	return resultRows
+}
+
+func requireDedupTargetBucketReSpills(
+	t *testing.T,
+	keys *vector.Vector,
+	targetRow int,
+	spillThreshold int64,
+) {
+	hashes := make([]uint64, keys.Length())
+	spillutil.ComputeXXHash([]*vector.Vector{keys}, hashes, 0)
+	mask := uint64(spillutil.SpillNumBuckets - 1)
+	targetBucket := hashes[targetRow] & mask
+	var bucketRows int64
+	for _, hash := range hashes {
+		if hash&mask == targetBucket {
+			bucketRows++
+		}
+	}
+	require.GreaterOrEqual(t, bucketRows, spillThreshold)
 }

--- a/pkg/sql/colexec/dedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/dedupjoin/key_contract_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dedupjoin
+
+import (
+	"math"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
+	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type dedupKeyContractMode struct {
+	name             string
+	shuffle          bool
+	spillThreshold   int64
+	wantInitialSpill bool
+	wantReSpill      bool
+}
+
+func TestDedupJoinDoubleSignedZeroContract(t *testing.T) {
+	// Scalar DOUBLE equality treats +0 and -0 as equal. The false expectations
+	// characterize the current key-encoding gap for one representative
+	// DedupJoin operation across all three execution modes.
+	modes := []dedupKeyContractMode{
+		{name: "resident"},
+		{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
+		{name: "re-spill", shuffle: true, spillThreshold: 2, wantInitialSpill: true, wantReSpill: true},
+	}
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			require.False(t, runDedupJoinDoubleSignedZeroContract(t, mode))
+		})
+	}
+}
+
+func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMode) bool {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+	proc.Base.Lim.Size = 8 << 20
+	proc.Base.Lim.SpillSize = 64 << 20
+
+	floatType := types.T_float64.ToType()
+	intType := types.T_int32.ToType()
+	conditions := [][]*plan.Expr{
+		{newExpr(0, floatType)},
+		{newExpr(0, floatType)},
+	}
+	tag++
+	joinMapTag := tag
+
+	const buildRows = 256
+	buildKeys := vector.NewVec(floatType)
+	buildPlaceholder := vector.NewVec(intType)
+	require.NoError(t, vector.AppendFixed(buildKeys, float64(0), false, proc.Mp()))
+	require.NoError(t, vector.AppendFixed(buildPlaceholder, int32(0), true, proc.Mp()))
+	for i := 1; i < buildRows; i++ {
+		require.NoError(t, vector.AppendFixed(buildKeys, float64(i), false, proc.Mp()))
+		require.NoError(t, vector.AppendFixed(buildPlaceholder, int32(0), true, proc.Mp()))
+	}
+	buildBatch := batch.NewWithSize(2)
+	buildBatch.Vecs[0] = buildKeys
+	buildBatch.Vecs[1] = buildPlaceholder
+	buildBatch.SetRowCount(buildRows)
+
+	probeBatch := batch.NewWithSize(2)
+	probeBatch.Vecs[0] = vector.NewVec(floatType)
+	probeBatch.Vecs[1] = vector.NewVec(intType)
+	require.NoError(t, vector.AppendFixed(
+		probeBatch.Vecs[0],
+		math.Copysign(0, -1),
+		false,
+		proc.Mp(),
+	))
+	require.NoError(t, vector.AppendFixed(probeBatch.Vecs[1], int32(42), false, proc.Mp()))
+	probeBatch.SetRowCount(1)
+
+	dedupArg := &DedupJoin{
+		LeftTypes:  []types.Type{floatType, intType},
+		RightTypes: []types.Type{floatType, intType},
+		Conditions: conditions,
+		Result: []colexec.ResultPos{
+			colexec.NewResultPos(1, 0),
+			colexec.NewResultPos(1, 1),
+		},
+		OnDuplicateAction:               plan.Node_FAIL,
+		OldColCapturePlaceholderIdxList: []int32{1},
+		OldColCaptureProbeIdxList:       []int32{1},
+		IsShuffle:                       mode.shuffle,
+		ShuffleIdx:                      0,
+		SpillThreshold:                  mode.spillThreshold,
+		JoinMapTag:                      joinMapTag,
+	}
+	dedupArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{probeBatch}))
+
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:      true,
+		NeedBatches:      true,
+		Conditions:       conditions[1],
+		IsDedup:          true,
+		DelColIdx:        -1,
+		IsShuffle:        mode.shuffle,
+		ShuffleIdx:       0,
+		SpillThreshold:   mode.spillThreshold,
+		JoinMapTag:       joinMapTag,
+		JoinMapRefCnt:    1,
+		NeedAllocateSels: false,
+	}
+	if mode.shuffle {
+		buildArg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: joinMapTag + 8000}
+	}
+	buildArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{buildBatch}))
+	defer func() {
+		dedupArg.Free(proc, false, nil)
+		buildArg.Free(proc, false, nil)
+		budget, err := proc.GetHashBuildBudget()
+		require.NoError(t, err)
+		require.Zero(t, budget.Used())
+		require.Zero(t, budget.SpillDiskUsed())
+		require.Zero(t, budget.SpillFDUsed())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	}()
+
+	spillBefore := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),
+	)
+	reSpillBefore := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("respill", "2"),
+	)
+	require.NoError(t, buildArg.Prepare(proc))
+	require.NoError(t, dedupArg.Prepare(proc))
+	buildResult, err := vm.Exec(buildArg, proc)
+	require.NoError(t, err)
+	require.Nil(t, buildResult.Batch)
+
+	targetCaptured := false
+	for {
+		result, execErr := vm.Exec(dedupArg, proc)
+		require.NoError(t, execErr)
+		if result.Batch != nil {
+			keys := vector.MustFixedColNoTypeCheck[float64](result.Batch.Vecs[0])
+			for i, key := range keys {
+				if key == 0 && !result.Batch.Vecs[1].GetNulls().Contains(uint64(i)) {
+					targetCaptured = true
+				}
+			}
+		}
+		if result.Status == vm.ExecStop {
+			break
+		}
+	}
+
+	spillAfter := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),
+	)
+	reSpillAfter := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("respill", "2"),
+	)
+	if mode.wantInitialSpill {
+		require.Greater(t, spillAfter, spillBefore)
+	} else {
+		require.Equal(t, spillBefore, spillAfter)
+	}
+	if mode.wantReSpill {
+		require.Greater(t, reSpillAfter, reSpillBefore)
+	} else {
+		require.Equal(t, reSpillBefore, reSpillAfter)
+	}
+
+	return targetCaptured
+}

--- a/pkg/sql/colexec/dedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/dedupjoin/key_contract_test.go
@@ -58,6 +58,30 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 	defer ctrl.Finish()
 	proc.Base.Lim.Size = 8 << 20
 	proc.Base.Lim.SpillSize = 64 << 20
+	var buildBatch, probeBatch *batch.Batch
+	var dedupArg *DedupJoin
+	var buildArg *hashbuild.HashBuild
+	defer func() {
+		if dedupArg != nil {
+			dedupArg.Free(proc, false, nil)
+		}
+		if buildArg != nil {
+			buildArg.Free(proc, false, nil)
+		}
+		if buildBatch != nil {
+			buildBatch.Clean(proc.Mp())
+		}
+		if probeBatch != nil {
+			probeBatch.Clean(proc.Mp())
+		}
+		budget, err := proc.GetHashBuildBudget()
+		require.NoError(t, err)
+		require.Zero(t, budget.Used())
+		require.Zero(t, budget.SpillDiskUsed())
+		require.Zero(t, budget.SpillFDUsed())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	}()
 
 	floatType := types.T_float64.ToType()
 	intType := types.T_int32.ToType()
@@ -77,12 +101,12 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 		require.NoError(t, vector.AppendFixed(buildKeys, float64(i), false, proc.Mp()))
 		require.NoError(t, vector.AppendFixed(buildPlaceholder, int32(0), true, proc.Mp()))
 	}
-	buildBatch := batch.NewWithSize(2)
+	buildBatch = batch.NewWithSize(2)
 	buildBatch.Vecs[0] = buildKeys
 	buildBatch.Vecs[1] = buildPlaceholder
 	buildBatch.SetRowCount(buildRows)
 
-	probeBatch := batch.NewWithSize(2)
+	probeBatch = batch.NewWithSize(2)
 	probeBatch.Vecs[0] = vector.NewVec(floatType)
 	probeBatch.Vecs[1] = vector.NewVec(intType)
 	require.NoError(t, vector.AppendFixed(
@@ -94,7 +118,7 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 	require.NoError(t, vector.AppendFixed(probeBatch.Vecs[1], int32(42), false, proc.Mp()))
 	probeBatch.SetRowCount(1)
 
-	dedupArg := &DedupJoin{
+	dedupArg = &DedupJoin{
 		LeftTypes:  []types.Type{floatType, intType},
 		RightTypes: []types.Type{floatType, intType},
 		Conditions: conditions,
@@ -113,7 +137,7 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 	}
 	dedupArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{probeBatch}))
 
-	buildArg := &hashbuild.HashBuild{
+	buildArg = &hashbuild.HashBuild{
 		NeedHashMap:      true,
 		NeedBatches:      true,
 		Conditions:       conditions[1],
@@ -130,17 +154,6 @@ func runDedupJoinDoubleSignedZeroContract(t *testing.T, mode dedupKeyContractMod
 		buildArg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: joinMapTag + 8000}
 	}
 	buildArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{buildBatch}))
-	defer func() {
-		dedupArg.Free(proc, false, nil)
-		buildArg.Free(proc, false, nil)
-		budget, err := proc.GetHashBuildBudget()
-		require.NoError(t, err)
-		require.Zero(t, budget.Used())
-		require.Zero(t, budget.SpillDiskUsed())
-		require.Zero(t, budget.SpillFDUsed())
-		proc.Free()
-		require.Zero(t, proc.Mp().CurrNB())
-	}()
 
 	spillBefore := promtestutil.ToFloat64(
 		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -1035,7 +1036,7 @@ func computeXXHash(keyVecs []*vector.Vector, hashValues []uint64) {
 		if vec.IsConst() {
 			colHash := uint64(0)
 			if !vec.IsConstNull() {
-				colHash = xxhash.Sum64(vec.GetRawBytesAt(0))
+				colHash = xxhash.Sum64(keycodec.BytesAt(vec, 0))
 			}
 			for i := 0; i < rowCount; i++ {
 				hashValues[i] = hashCombine(hashValues[i], colHash)
@@ -1051,12 +1052,12 @@ func computeXXHash(keyVecs []*vector.Vector, hashValues []uint64) {
 					if nulls.Contains(uint64(i)) {
 						hashValues[i] = hashCombine(hashValues[i], 0)
 					} else {
-						hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(vec.GetRawBytesAt(i)))
+						hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
 					}
 				}
 			} else {
 				for i := 0; i < n; i++ {
-					hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(vec.GetRawBytesAt(i)))
+					hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
 				}
 			}
 		}

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"os"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
@@ -1013,11 +1012,6 @@ func (hashBuild *HashBuild) shouldSpillBatches() bool {
 	return colexec.ShouldSpill(ctr.memUsed(), int64(ctr.hashmapBuilder.InputBatchRowCount), ctr.spillThreshold)
 }
 
-// hashCombine merges a new hash value into a running hash state (Boost-style).
-func hashCombine(h, val uint64) uint64 {
-	return h ^ (val + 0x9e3779b97f4a7c15 + (h << 6) + (h >> 2))
-}
-
 // computeXXHash computes hash values for spill-partitioning using
 // column-at-a-time processing for better cache locality.
 // Each column is processed in a tight loop over all rows, avoiding
@@ -1026,41 +1020,5 @@ func computeXXHash(keyVecs []*vector.Vector, hashValues []uint64) {
 	if len(keyVecs) == 0 || len(hashValues) == 0 {
 		return
 	}
-
-	rowCount := len(hashValues)
-	for i := 0; i < rowCount; i++ {
-		hashValues[i] = 0
-	}
-
-	for _, vec := range keyVecs {
-		if vec.IsConst() {
-			colHash := uint64(0)
-			if !vec.IsConstNull() {
-				colHash = xxhash.Sum64(keycodec.BytesAt(vec, 0))
-			}
-			for i := 0; i < rowCount; i++ {
-				hashValues[i] = hashCombine(hashValues[i], colHash)
-			}
-		} else {
-			n := rowCount
-			if vec.Length() < n {
-				n = vec.Length()
-			}
-			if vec.GetNulls().Any() {
-				nulls := vec.GetNulls()
-				for i := 0; i < n; i++ {
-					if nulls.Contains(uint64(i)) {
-						hashValues[i] = hashCombine(hashValues[i], 0)
-					} else {
-						hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
-					}
-				}
-			} else {
-				for i := 0; i < n; i++ {
-					hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
-				}
-			}
-		}
-	}
-
+	keycodec.ComputeXXHash(keyVecs, hashValues, 0)
 }

--- a/pkg/sql/colexec/hashjoin/key_contract_test.go
+++ b/pkg/sql/colexec/hashjoin/key_contract_test.go
@@ -214,9 +214,16 @@ func runHashJoinKeyContract(t *testing.T, keyCase joinKeyContractCase, mode join
 	)
 	tc.proc.Base.Lim.Size = 8 << 20
 	tc.proc.Base.Lim.SpillSize = 64 << 20
+	var build, probe *batch.Batch
 	defer func() {
 		tc.arg.Free(tc.proc, false, nil)
 		tc.barg.Free(tc.proc, false, nil)
+		if build != nil {
+			build.Clean(tc.proc.Mp())
+		}
+		if probe != nil {
+			probe.Clean(tc.proc.Mp())
+		}
 		budget, err := tc.proc.GetHashBuildBudget()
 		require.NoError(t, err)
 		require.Zero(t, budget.Used())
@@ -232,10 +239,10 @@ func runHashJoinKeyContract(t *testing.T, keyCase joinKeyContractCase, mode join
 	for i := 1; i < buildRows; i++ {
 		buildValues[i] = keyCase.makeBuildFiller(i)
 	}
-	build := batch.NewWithSize(1)
+	build = batch.NewWithSize(1)
 	build.Vecs[0] = makeJoinKeyVector(t, tc.proc, keyCase.typ, buildValues)
 	build.SetRowCount(buildRows)
-	probe := batch.NewWithSize(1)
+	probe = batch.NewWithSize(1)
 	probe.Vecs[0] = makeJoinKeyVector(t, tc.proc, keyCase.typ, []joinKeyContractValue{keyCase.probe})
 	probe.SetRowCount(1)
 

--- a/pkg/sql/colexec/hashjoin/key_contract_test.go
+++ b/pkg/sql/colexec/hashjoin/key_contract_test.go
@@ -1,0 +1,365 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashjoin
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type joinKeyContractValue struct {
+	value any
+	null  bool
+}
+
+type joinKeyContractCase struct {
+	name              string
+	typ               types.Type
+	build             joinKeyContractValue
+	probe             joinKeyContractValue
+	sqlEquality       string
+	residentMatch     bool
+	initialSpillMatch bool
+	reSpillMatch      bool
+	makeBuildFiller   func(int) joinKeyContractValue
+}
+
+type joinKeyExecutionMode struct {
+	name             string
+	shuffle          bool
+	spillThreshold   int64
+	wantInitialSpill bool
+	wantReSpill      bool
+}
+
+var joinKeyExecutionModes = []joinKeyExecutionMode{
+	{name: "resident"},
+	{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
+	{name: "re-spill", shuffle: true, spillThreshold: 2, wantInitialSpill: true, wantReSpill: true},
+}
+
+func TestHashJoinKeyEqualityContract(t *testing.T) {
+	// This is a characterization table for issue #26432, not the final desired
+	// behavior. sqlEquality comes from the real scalar "=" evaluator; the three
+	// match columns deliberately record today's hash-key behavior so the codec
+	// fix can change the contract in one visible place.
+	cases := hashJoinKeyContractCases()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.sqlEquality, runScalarEqualityOracle(t, tc))
+			for _, mode := range joinKeyExecutionModes {
+				t.Run(mode.name, func(t *testing.T) {
+					wantMatch := tc.residentMatch
+					if mode.wantInitialSpill {
+						wantMatch = tc.initialSpillMatch
+					}
+					if mode.wantReSpill {
+						wantMatch = tc.reSpillMatch
+					}
+					require.Equal(t, wantMatch, runHashJoinKeyContract(t, tc, mode))
+				})
+			}
+		})
+	}
+}
+
+func hashJoinKeyContractCases() []joinKeyContractCase {
+	float32Type := types.T_float32.ToType()
+	float32Type.Scale = 2
+	vectorZero := make([]float32, 8)
+	vectorNegativeZero := make([]float32, 8)
+	vectorNegativeZero[3] = float32(math.Copysign(0, -1))
+
+	return []joinKeyContractCase{
+		{
+			name:              "double-signed-zero",
+			typ:               types.T_float64.ToType(),
+			build:             joinKeyContractValue{value: float64(0)},
+			probe:             joinKeyContractValue{value: math.Copysign(0, -1)},
+			sqlEquality:       "TRUE",
+			residentMatch:     false,
+			initialSpillMatch: false,
+			reSpillMatch:      false,
+			makeBuildFiller: func(i int) joinKeyContractValue {
+				return joinKeyContractValue{value: float64(i + 1)}
+			},
+		},
+		{
+			name:              "scaled-float32",
+			typ:               float32Type,
+			build:             joinKeyContractValue{value: float32(1.234)},
+			probe:             joinKeyContractValue{value: float32(1.23)},
+			sqlEquality:       "TRUE",
+			residentMatch:     false,
+			initialSpillMatch: false,
+			reSpillMatch:      false,
+			makeBuildFiller: func(i int) joinKeyContractValue {
+				return joinKeyContractValue{value: float32(i + 10)}
+			},
+		},
+		{
+			name:              "json-numeric-representation",
+			typ:               types.T_json.ToType(),
+			build:             joinKeyContractValue{value: "1"},
+			probe:             joinKeyContractValue{value: "1.0"},
+			sqlEquality:       "TRUE",
+			residentMatch:     false,
+			initialSpillMatch: false,
+			reSpillMatch:      false,
+			makeBuildFiller: func(i int) joinKeyContractValue {
+				return joinKeyContractValue{value: strconv.Itoa(i + 100)}
+			},
+		},
+		{
+			name:              "vecf32-signed-zero",
+			typ:               types.T_array_float32.ToType(),
+			build:             joinKeyContractValue{value: vectorZero},
+			probe:             joinKeyContractValue{value: vectorNegativeZero},
+			sqlEquality:       "TRUE",
+			residentMatch:     false,
+			initialSpillMatch: false,
+			reSpillMatch:      false,
+			makeBuildFiller: func(i int) joinKeyContractValue {
+				return joinKeyContractValue{value: []float32{float32(i + 1), 1, 2, 3, 4, 5, 6, 7}}
+			},
+		},
+		{
+			name:              "double-nan",
+			typ:               types.T_float64.ToType(),
+			build:             joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
+			probe:             joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
+			sqlEquality:       "FALSE",
+			residentMatch:     true,
+			initialSpillMatch: true,
+			reSpillMatch:      true,
+			makeBuildFiller: func(i int) joinKeyContractValue {
+				return joinKeyContractValue{value: float64(i + 1)}
+			},
+		},
+		{
+			name:              "double-null",
+			typ:               types.T_float64.ToType(),
+			build:             joinKeyContractValue{null: true},
+			probe:             joinKeyContractValue{null: true},
+			sqlEquality:       "NULL",
+			residentMatch:     false,
+			initialSpillMatch: false,
+			reSpillMatch:      false,
+			makeBuildFiller: func(i int) joinKeyContractValue {
+				return joinKeyContractValue{value: float64(i + 1)}
+			},
+		},
+	}
+}
+
+func runScalarEqualityOracle(t *testing.T, tc joinKeyContractCase) string {
+	proc := testutil.NewProcess(t)
+	var left, right, result *vector.Vector
+	defer func() {
+		if result != nil {
+			result.Free(proc.Mp())
+		}
+		if left != nil {
+			left.Free(proc.Mp())
+		}
+		if right != nil {
+			right.Free(proc.Mp())
+		}
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	}()
+	left = makeJoinKeyVector(t, proc, tc.typ, []joinKeyContractValue{tc.build})
+	right = makeJoinKeyVector(t, proc, tc.typ, []joinKeyContractValue{tc.probe})
+
+	fn, err := function.GetFunctionByName(context.Background(), "=", []types.Type{tc.typ, tc.typ})
+	require.NoError(t, err)
+	result, err = function.RunFunctionDirectly(
+		proc,
+		fn.GetEncodedOverloadID(),
+		[]*vector.Vector{left, right},
+		1,
+	)
+	require.NoError(t, err)
+
+	got := "NULL"
+	if !result.GetNulls().Contains(0) {
+		if vector.MustFixedColNoTypeCheck[bool](result)[0] {
+			got = "TRUE"
+		} else {
+			got = "FALSE"
+		}
+	}
+
+	return got
+}
+
+func runHashJoinKeyContract(t *testing.T, keyCase joinKeyContractCase, mode joinKeyExecutionMode) bool {
+	keyExprs := [][]*plan.Expr{
+		{newExpr(0, keyCase.typ)},
+		{newExpr(0, keyCase.typ)},
+	}
+	tc := newTestCase(
+		t,
+		[]bool{true},
+		[]types.Type{keyCase.typ},
+		[]colexec.ResultPos{colexec.NewResultPos(0, 0)},
+		keyExprs,
+	)
+	tc.proc.Base.Lim.Size = 8 << 20
+	tc.proc.Base.Lim.SpillSize = 64 << 20
+	defer func() {
+		tc.arg.Free(tc.proc, false, nil)
+		tc.barg.Free(tc.proc, false, nil)
+		budget, err := tc.proc.GetHashBuildBudget()
+		require.NoError(t, err)
+		require.Zero(t, budget.Used())
+		require.Zero(t, budget.SpillDiskUsed())
+		require.Zero(t, budget.SpillFDUsed())
+		tc.proc.Free()
+		require.Zero(t, tc.proc.Mp().CurrNB())
+	}()
+
+	const buildRows = 256
+	buildValues := make([]joinKeyContractValue, buildRows)
+	buildValues[0] = keyCase.build
+	for i := 1; i < buildRows; i++ {
+		buildValues[i] = keyCase.makeBuildFiller(i)
+	}
+	build := batch.NewWithSize(1)
+	build.Vecs[0] = makeJoinKeyVector(t, tc.proc, keyCase.typ, buildValues)
+	build.SetRowCount(buildRows)
+	probe := batch.NewWithSize(1)
+	probe.Vecs[0] = makeJoinKeyVector(t, tc.proc, keyCase.typ, []joinKeyContractValue{keyCase.probe})
+	probe.SetRowCount(1)
+
+	tc.arg.NonEqCond = nil
+	tc.arg.IsShuffle = mode.shuffle
+	tc.arg.ShuffleIdx = 0
+	tc.arg.SpillThreshold = mode.spillThreshold
+	tc.barg.IsShuffle = mode.shuffle
+	tc.barg.ShuffleIdx = 0
+	tc.barg.SpillThreshold = mode.spillThreshold
+	tc.barg.NeedBatches = false
+	if mode.shuffle {
+		tc.barg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 7000}
+	}
+	resetChildrenWithBatch(tc.arg, probe)
+	resetHashBuildChildrenWithBatch(tc.barg, build)
+
+	spillBefore := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),
+	)
+	reSpillBefore := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("respill", "2"),
+	)
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+	require.NoError(t, tc.barg.Prepare(tc.proc))
+	buildResult, err := vm.Exec(tc.barg, tc.proc)
+	require.NoError(t, err)
+	require.Nil(t, buildResult.Batch)
+
+	resultRows := 0
+	for {
+		result, execErr := vm.Exec(tc.arg, tc.proc)
+		require.NoError(t, execErr)
+		if result.Batch != nil {
+			resultRows += result.Batch.RowCount()
+		}
+		if result.Status == vm.ExecStop {
+			break
+		}
+	}
+
+	spillAfter := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),
+	)
+	reSpillAfter := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("respill", "2"),
+	)
+	if mode.wantInitialSpill {
+		require.Greater(t, spillAfter, spillBefore)
+	} else {
+		require.Equal(t, spillBefore, spillAfter)
+	}
+	if mode.wantReSpill {
+		require.Greater(t, reSpillAfter, reSpillBefore)
+	} else {
+		require.Equal(t, reSpillBefore, reSpillAfter)
+	}
+
+	return resultRows == 1
+}
+
+func makeJoinKeyVector(
+	t *testing.T,
+	proc *process.Process,
+	typ types.Type,
+	values []joinKeyContractValue,
+) *vector.Vector {
+	vec := vector.NewVec(typ)
+	for _, value := range values {
+		switch typ.Oid {
+		case types.T_float32:
+			v, _ := value.value.(float32)
+			require.NoError(t, vector.AppendFixed(vec, v, value.null, proc.Mp()))
+		case types.T_float64:
+			v, _ := value.value.(float64)
+			require.NoError(t, vector.AppendFixed(vec, v, value.null, proc.Mp()))
+		case types.T_json:
+			if value.null {
+				require.NoError(t, vector.AppendBytes(vec, nil, true, proc.Mp()))
+				continue
+			}
+			jsonText, ok := value.value.(string)
+			require.True(t, ok)
+			jsonValue, err := types.ParseStringToByteJson(jsonText)
+			require.NoError(t, err)
+			encoded, err := types.EncodeJson(jsonValue)
+			require.NoError(t, err)
+			require.NoError(t, vector.AppendBytes(vec, encoded, false, proc.Mp()))
+		case types.T_array_float32:
+			if value.null {
+				require.NoError(t, vector.AppendBytes(vec, nil, true, proc.Mp()))
+				continue
+			}
+			arrayValue, ok := value.value.([]float32)
+			require.True(t, ok)
+			require.NoError(t, vector.AppendBytes(
+				vec,
+				types.ArrayToBytes(arrayValue),
+				false,
+				proc.Mp(),
+			))
+		default:
+			t.Fatalf("unsupported join-key contract type %s", typ.String())
+		}
+	}
+	return vec
+}

--- a/pkg/sql/colexec/hashjoin/key_contract_test.go
+++ b/pkg/sql/colexec/hashjoin/key_contract_test.go
@@ -45,6 +45,7 @@ type joinKeyContractCase struct {
 	build           joinKeyContractValue
 	probe           joinKeyContractValue
 	sqlEquality     string
+	skipReason      string
 	makeBuildFiller func(int) joinKeyContractValue
 }
 
@@ -70,6 +71,9 @@ func TestHashJoinKeyEqualityContract(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.sqlEquality, runScalarEqualityOracle(t, tc))
+			if tc.skipReason != "" {
+				t.Skipf("#26432: %s", tc.skipReason)
+			}
 			wantMatch := tc.sqlEquality == "TRUE"
 			for _, mode := range joinKeyExecutionModes {
 				t.Run(mode.name, func(t *testing.T) {
@@ -104,6 +108,7 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			build:       joinKeyContractValue{value: float32(1.234)},
 			probe:       joinKeyContractValue{value: float32(1.23)},
 			sqlEquality: "TRUE",
+			skipReason:  "scaled FLOAT32 key encoding is pending",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float32(i + 10)}
 			},
@@ -114,6 +119,7 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			build:       joinKeyContractValue{value: "1"},
 			probe:       joinKeyContractValue{value: "1.0"},
 			sqlEquality: "TRUE",
+			skipReason:  "JSON numeric key encoding is pending",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: strconv.Itoa(i + 100)}
 			},
@@ -124,6 +130,7 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			build:       joinKeyContractValue{value: vectorZero},
 			probe:       joinKeyContractValue{value: vectorNegativeZero},
 			sqlEquality: "TRUE",
+			skipReason:  "VECF32 element key encoding is pending",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: []float32{float32(i + 1), 1, 2, 3, 4, 5, 6, 7}}
 			},
@@ -134,6 +141,7 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			build:       joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
 			probe:       joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
 			sqlEquality: "FALSE",
+			skipReason:  "NaN non-match key handling is pending",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float64(i + 1)}
 			},

--- a/pkg/sql/colexec/hashjoin/key_contract_test.go
+++ b/pkg/sql/colexec/hashjoin/key_contract_test.go
@@ -17,21 +17,30 @@ package hashjoin
 import (
 	"context"
 	"math"
+	"sort"
 	"strconv"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/message"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	joinKeyContractBuildRows      = hashmap.UnitLimit + 1
+	joinKeyContractEquivalentFrom = hashmap.UnitLimit / 2
 )
 
 type joinKeyContractValue struct {
@@ -47,6 +56,7 @@ type joinKeyContractCase struct {
 	sqlEquality     string
 	skipReason      string
 	makeBuildFiller func(int) joinKeyContractValue
+	makeEquivalent  func(int) joinKeyContractValue
 }
 
 type joinKeyExecutionMode struct {
@@ -59,7 +69,7 @@ type joinKeyExecutionMode struct {
 
 var joinKeyExecutionModes = []joinKeyExecutionMode{
 	{name: "resident"},
-	{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
+	{name: "initial-spill", shuffle: true, spillThreshold: joinKeyContractBuildRows, wantInitialSpill: true},
 	{name: "re-spill", shuffle: true, spillThreshold: 2, wantInitialSpill: true, wantReSpill: true},
 }
 
@@ -74,10 +84,10 @@ func TestHashJoinKeyEqualityContract(t *testing.T) {
 			if tc.skipReason != "" {
 				t.Skipf("#26432: %s", tc.skipReason)
 			}
-			wantMatch := tc.sqlEquality == "TRUE"
+			wantPayloads := expectedJoinKeyContractPayloads(tc)
 			for _, mode := range joinKeyExecutionModes {
 				t.Run(mode.name, func(t *testing.T) {
-					require.Equal(t, wantMatch, runHashJoinKeyContract(t, tc, mode))
+					require.Equal(t, wantPayloads, runHashJoinKeyContract(t, tc, mode))
 				})
 			}
 		})
@@ -101,6 +111,12 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float64(i + 1)}
 			},
+			makeEquivalent: func(i int) joinKeyContractValue {
+				if i%2 == 0 {
+					return joinKeyContractValue{value: float64(0)}
+				}
+				return joinKeyContractValue{value: math.Copysign(0, -1)}
+			},
 		},
 		{
 			name:        "scaled-float32",
@@ -111,6 +127,12 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			skipReason:  "scaled FLOAT32 key encoding is pending",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float32(i + 10)}
+			},
+			makeEquivalent: func(i int) joinKeyContractValue {
+				if i%2 == 0 {
+					return joinKeyContractValue{value: float32(1.234)}
+				}
+				return joinKeyContractValue{value: float32(1.23)}
 			},
 		},
 		{
@@ -123,6 +145,12 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: strconv.Itoa(i + 100)}
 			},
+			makeEquivalent: func(i int) joinKeyContractValue {
+				if i%2 == 0 {
+					return joinKeyContractValue{value: "1"}
+				}
+				return joinKeyContractValue{value: "1.0"}
+			},
 		},
 		{
 			name:        "vecf32-signed-zero",
@@ -133,6 +161,12 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			skipReason:  "VECF32 element key encoding is pending",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: []float32{float32(i + 1), 1, 2, 3, 4, 5, 6, 7}}
+			},
+			makeEquivalent: func(i int) joinKeyContractValue {
+				if i%2 == 0 {
+					return joinKeyContractValue{value: vectorZero}
+				}
+				return joinKeyContractValue{value: vectorNegativeZero}
 			},
 		},
 		{
@@ -145,6 +179,9 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float64(i + 1)}
 			},
+			makeEquivalent: func(int) joinKeyContractValue {
+				return joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)}
+			},
 		},
 		{
 			name:        "double-null",
@@ -155,8 +192,22 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float64(i + 1)}
 			},
+			makeEquivalent: func(int) joinKeyContractValue {
+				return joinKeyContractValue{null: true}
+			},
 		},
 	}
+}
+
+func expectedJoinKeyContractPayloads(tc joinKeyContractCase) []int32 {
+	if tc.sqlEquality != "TRUE" {
+		return nil
+	}
+	payloads := make([]int32, 0, joinKeyContractBuildRows-joinKeyContractEquivalentFrom)
+	for row := joinKeyContractEquivalentFrom; row < joinKeyContractBuildRows; row++ {
+		payloads = append(payloads, int32(row))
+	}
+	return payloads
 }
 
 func runScalarEqualityOracle(t *testing.T, tc joinKeyContractCase) string {
@@ -200,65 +251,96 @@ func runScalarEqualityOracle(t *testing.T, tc joinKeyContractCase) string {
 	return got
 }
 
-func runHashJoinKeyContract(t *testing.T, keyCase joinKeyContractCase, mode joinKeyExecutionMode) bool {
+func runHashJoinKeyContract(
+	t *testing.T,
+	keyCase joinKeyContractCase,
+	mode joinKeyExecutionMode,
+) []int32 {
 	keyExprs := [][]*plan.Expr{
 		{newExpr(0, keyCase.typ)},
 		{newExpr(0, keyCase.typ)},
 	}
-	tc := newTestCase(
-		t,
-		[]bool{true},
-		[]types.Type{keyCase.typ},
-		[]colexec.ResultPos{colexec.NewResultPos(0, 0)},
-		keyExprs,
-	)
-	tc.proc.Base.Lim.Size = 8 << 20
-	tc.proc.Base.Lim.SpillSize = 64 << 20
+	proc := testutil.NewProcess(t)
+	proc.SetMessageBoard(message.NewMessageBoard())
+	proc.Base.Lim.Size = 8 << 20
+	proc.Base.Lim.SpillSize = 64 << 20
+	tag++
+	joinMapTag := tag
+	payloadType := types.T_int32.ToType()
+	arg := &HashJoin{
+		LeftTypes:      []types.Type{keyCase.typ},
+		RightTypes:     []types.Type{keyCase.typ, payloadType},
+		ResultCols:     []colexec.ResultPos{colexec.NewResultPos(1, 1)},
+		EqConds:        keyExprs,
+		NumCPU:         1,
+		IsMerger:       true,
+		IsShuffle:      mode.shuffle,
+		ShuffleIdx:     0,
+		SpillThreshold: mode.spillThreshold,
+		JoinMapTag:     joinMapTag,
+	}
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:      true,
+		NeedBatches:      true,
+		NeedAllocateSels: true,
+		Conditions:       keyExprs[1],
+		IsShuffle:        mode.shuffle,
+		ShuffleIdx:       0,
+		SpillThreshold:   mode.spillThreshold,
+		JoinMapTag:       joinMapTag,
+		JoinMapRefCnt:    1,
+	}
+	if mode.shuffle {
+		buildArg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: joinMapTag + 7000}
+	}
 	var build, probe *batch.Batch
 	defer func() {
-		tc.arg.Free(tc.proc, false, nil)
-		tc.barg.Free(tc.proc, false, nil)
+		arg.Free(proc, false, nil)
+		buildArg.Free(proc, false, nil)
 		if build != nil {
-			build.Clean(tc.proc.Mp())
+			build.Clean(proc.Mp())
 		}
 		if probe != nil {
-			probe.Clean(tc.proc.Mp())
+			probe.Clean(proc.Mp())
 		}
-		budget, err := tc.proc.GetHashBuildBudget()
-		require.NoError(t, err)
-		require.Zero(t, budget.Used())
-		require.Zero(t, budget.SpillDiskUsed())
-		require.Zero(t, budget.SpillFDUsed())
-		tc.proc.Free()
-		require.Zero(t, tc.proc.Mp().CurrNB())
+		budget, budgetErr := proc.GetHashBuildBudget()
+		var used, diskUsed, fdUsed uint64
+		if budgetErr == nil {
+			used = budget.Used()
+			diskUsed = budget.SpillDiskUsed()
+			fdUsed = budget.SpillFDUsed()
+		}
+		proc.Free()
+		mpoolBytes := proc.Mp().CurrNB()
+		require.NoError(t, budgetErr)
+		require.Zero(t, used)
+		require.Zero(t, diskUsed)
+		require.Zero(t, fdUsed)
+		require.Zero(t, mpoolBytes)
 	}()
 
-	const buildRows = 256
-	buildValues := make([]joinKeyContractValue, buildRows)
-	buildValues[0] = keyCase.build
-	for i := 1; i < buildRows; i++ {
-		buildValues[i] = keyCase.makeBuildFiller(i)
+	buildValues := make([]joinKeyContractValue, joinKeyContractBuildRows)
+	buildPayloads := make([]int32, joinKeyContractBuildRows)
+	for row := 0; row < hashmap.UnitLimit; row++ {
+		if row < joinKeyContractEquivalentFrom {
+			buildValues[row] = keyCase.makeBuildFiller(row)
+		} else {
+			buildValues[row] = keyCase.makeEquivalent(row - joinKeyContractEquivalentFrom)
+		}
+		buildPayloads[row] = int32(row)
 	}
-	build = batch.NewWithSize(1)
-	build.Vecs[0] = makeJoinKeyVector(t, tc.proc, keyCase.typ, buildValues)
-	build.SetRowCount(buildRows)
+	buildValues[hashmap.UnitLimit] = keyCase.build
+	buildPayloads[hashmap.UnitLimit] = hashmap.UnitLimit
+	build = batch.NewWithSize(2)
+	build.Vecs[0] = makeJoinKeyVector(t, proc, keyCase.typ, buildValues)
+	build.Vecs[1] = testutil.MakeInt32Vector(buildPayloads, nil, proc.Mp())
+	build.SetRowCount(joinKeyContractBuildRows)
 	probe = batch.NewWithSize(1)
-	probe.Vecs[0] = makeJoinKeyVector(t, tc.proc, keyCase.typ, []joinKeyContractValue{keyCase.probe})
+	probe.Vecs[0] = makeJoinKeyVector(t, proc, keyCase.typ, []joinKeyContractValue{keyCase.probe})
 	probe.SetRowCount(1)
 
-	tc.arg.NonEqCond = nil
-	tc.arg.IsShuffle = mode.shuffle
-	tc.arg.ShuffleIdx = 0
-	tc.arg.SpillThreshold = mode.spillThreshold
-	tc.barg.IsShuffle = mode.shuffle
-	tc.barg.ShuffleIdx = 0
-	tc.barg.SpillThreshold = mode.spillThreshold
-	tc.barg.NeedBatches = false
-	if mode.shuffle {
-		tc.barg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 7000}
-	}
-	resetChildrenWithBatch(tc.arg, probe)
-	resetHashBuildChildrenWithBatch(tc.barg, build)
+	resetChildrenWithBatch(arg, probe)
+	resetHashBuildChildrenWithBatch(buildArg, build)
 
 	spillBefore := promtestutil.ToFloat64(
 		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),
@@ -266,18 +348,22 @@ func runHashJoinKeyContract(t *testing.T, keyCase joinKeyContractCase, mode join
 	reSpillBefore := promtestutil.ToFloat64(
 		metricv2.HashBuildSpillDepthCounter.WithLabelValues("respill", "2"),
 	)
-	require.NoError(t, tc.arg.Prepare(tc.proc))
-	require.NoError(t, tc.barg.Prepare(tc.proc))
-	buildResult, err := vm.Exec(tc.barg, tc.proc)
+	require.NoError(t, arg.Prepare(proc))
+	require.NoError(t, buildArg.Prepare(proc))
+	buildResult, err := vm.Exec(buildArg, proc)
 	require.NoError(t, err)
 	require.Nil(t, buildResult.Batch)
 
-	resultRows := 0
+	var resultPayloads []int32
 	for {
-		result, execErr := vm.Exec(tc.arg, tc.proc)
+		result, execErr := vm.Exec(arg, proc)
 		require.NoError(t, execErr)
 		if result.Batch != nil {
-			resultRows += result.Batch.RowCount()
+			require.Len(t, result.Batch.Vecs, 1)
+			require.True(t, result.Batch.Vecs[0].GetNulls().IsEmpty())
+			payloads := vector.MustFixedColNoTypeCheck[int32](result.Batch.Vecs[0])
+			require.Len(t, payloads, result.Batch.RowCount())
+			resultPayloads = append(resultPayloads, payloads...)
 		}
 		if result.Status == vm.ExecStop {
 			break
@@ -301,7 +387,10 @@ func runHashJoinKeyContract(t *testing.T, keyCase joinKeyContractCase, mode join
 		require.Equal(t, reSpillBefore, reSpillAfter)
 	}
 
-	return resultRows == 1
+	sort.Slice(resultPayloads, func(i, j int) bool {
+		return resultPayloads[i] < resultPayloads[j]
+	})
+	return resultPayloads
 }
 
 func makeJoinKeyVector(

--- a/pkg/sql/colexec/hashjoin/key_contract_test.go
+++ b/pkg/sql/colexec/hashjoin/key_contract_test.go
@@ -40,15 +40,12 @@ type joinKeyContractValue struct {
 }
 
 type joinKeyContractCase struct {
-	name              string
-	typ               types.Type
-	build             joinKeyContractValue
-	probe             joinKeyContractValue
-	sqlEquality       string
-	residentMatch     bool
-	initialSpillMatch bool
-	reSpillMatch      bool
-	makeBuildFiller   func(int) joinKeyContractValue
+	name            string
+	typ             types.Type
+	build           joinKeyContractValue
+	probe           joinKeyContractValue
+	sqlEquality     string
+	makeBuildFiller func(int) joinKeyContractValue
 }
 
 type joinKeyExecutionMode struct {
@@ -66,23 +63,16 @@ var joinKeyExecutionModes = []joinKeyExecutionMode{
 }
 
 func TestHashJoinKeyEqualityContract(t *testing.T) {
-	// This is a characterization table for issue #26432, not the final desired
-	// behavior. sqlEquality comes from the real scalar "=" evaluator; the three
-	// match columns deliberately record today's hash-key behavior so the codec
-	// fix can change the contract in one visible place.
+	// sqlEquality is verified against the real scalar "=" evaluator. Every hash
+	// execution mode must then implement that same SQL contract: only TRUE
+	// matches; FALSE and NULL do not.
 	cases := hashJoinKeyContractCases()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.sqlEquality, runScalarEqualityOracle(t, tc))
+			wantMatch := tc.sqlEquality == "TRUE"
 			for _, mode := range joinKeyExecutionModes {
 				t.Run(mode.name, func(t *testing.T) {
-					wantMatch := tc.residentMatch
-					if mode.wantInitialSpill {
-						wantMatch = tc.initialSpillMatch
-					}
-					if mode.wantReSpill {
-						wantMatch = tc.reSpillMatch
-					}
 					require.Equal(t, wantMatch, runHashJoinKeyContract(t, tc, mode))
 				})
 			}
@@ -99,79 +89,61 @@ func hashJoinKeyContractCases() []joinKeyContractCase {
 
 	return []joinKeyContractCase{
 		{
-			name:              "double-signed-zero",
-			typ:               types.T_float64.ToType(),
-			build:             joinKeyContractValue{value: float64(0)},
-			probe:             joinKeyContractValue{value: math.Copysign(0, -1)},
-			sqlEquality:       "TRUE",
-			residentMatch:     false,
-			initialSpillMatch: false,
-			reSpillMatch:      false,
+			name:        "double-signed-zero",
+			typ:         types.T_float64.ToType(),
+			build:       joinKeyContractValue{value: float64(0)},
+			probe:       joinKeyContractValue{value: math.Copysign(0, -1)},
+			sqlEquality: "TRUE",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float64(i + 1)}
 			},
 		},
 		{
-			name:              "scaled-float32",
-			typ:               float32Type,
-			build:             joinKeyContractValue{value: float32(1.234)},
-			probe:             joinKeyContractValue{value: float32(1.23)},
-			sqlEquality:       "TRUE",
-			residentMatch:     false,
-			initialSpillMatch: false,
-			reSpillMatch:      false,
+			name:        "scaled-float32",
+			typ:         float32Type,
+			build:       joinKeyContractValue{value: float32(1.234)},
+			probe:       joinKeyContractValue{value: float32(1.23)},
+			sqlEquality: "TRUE",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float32(i + 10)}
 			},
 		},
 		{
-			name:              "json-numeric-representation",
-			typ:               types.T_json.ToType(),
-			build:             joinKeyContractValue{value: "1"},
-			probe:             joinKeyContractValue{value: "1.0"},
-			sqlEquality:       "TRUE",
-			residentMatch:     false,
-			initialSpillMatch: false,
-			reSpillMatch:      false,
+			name:        "json-numeric-representation",
+			typ:         types.T_json.ToType(),
+			build:       joinKeyContractValue{value: "1"},
+			probe:       joinKeyContractValue{value: "1.0"},
+			sqlEquality: "TRUE",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: strconv.Itoa(i + 100)}
 			},
 		},
 		{
-			name:              "vecf32-signed-zero",
-			typ:               types.T_array_float32.ToType(),
-			build:             joinKeyContractValue{value: vectorZero},
-			probe:             joinKeyContractValue{value: vectorNegativeZero},
-			sqlEquality:       "TRUE",
-			residentMatch:     false,
-			initialSpillMatch: false,
-			reSpillMatch:      false,
+			name:        "vecf32-signed-zero",
+			typ:         types.T_array_float32.ToType(),
+			build:       joinKeyContractValue{value: vectorZero},
+			probe:       joinKeyContractValue{value: vectorNegativeZero},
+			sqlEquality: "TRUE",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: []float32{float32(i + 1), 1, 2, 3, 4, 5, 6, 7}}
 			},
 		},
 		{
-			name:              "double-nan",
-			typ:               types.T_float64.ToType(),
-			build:             joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
-			probe:             joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
-			sqlEquality:       "FALSE",
-			residentMatch:     true,
-			initialSpillMatch: true,
-			reSpillMatch:      true,
+			name:        "double-nan",
+			typ:         types.T_float64.ToType(),
+			build:       joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
+			probe:       joinKeyContractValue{value: math.Float64frombits(0x7ff8000000000001)},
+			sqlEquality: "FALSE",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float64(i + 1)}
 			},
 		},
 		{
-			name:              "double-null",
-			typ:               types.T_float64.ToType(),
-			build:             joinKeyContractValue{null: true},
-			probe:             joinKeyContractValue{null: true},
-			sqlEquality:       "NULL",
-			residentMatch:     false,
-			initialSpillMatch: false,
-			reSpillMatch:      false,
+			name:        "double-null",
+			typ:         types.T_float64.ToType(),
+			build:       joinKeyContractValue{null: true},
+			probe:       joinKeyContractValue{null: true},
+			sqlEquality: "NULL",
 			makeBuildFiller: func(i int) joinKeyContractValue {
 				return joinKeyContractValue{value: float64(i + 1)}
 			},

--- a/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rightdedupjoin
+
+import (
+	"math"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
+	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type rightDedupKeyContractMode struct {
+	name             string
+	shuffle          bool
+	spillThreshold   int64
+	wantInitialSpill bool
+	wantReSpill      bool
+}
+
+func TestRightDedupJoinDoubleSignedZeroContract(t *testing.T) {
+	// Pessimistic RightDedupJoin reports a duplicate when the probe key matches
+	// an existing build key. The false expectations characterize the current
+	// +0/-0 key-encoding gap across all three execution modes.
+	modes := []rightDedupKeyContractMode{
+		{name: "resident"},
+		{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
+		{name: "re-spill", shuffle: true, spillThreshold: 2, wantInitialSpill: true, wantReSpill: true},
+	}
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			require.False(t, runRightDedupJoinDoubleSignedZeroContract(t, mode))
+		})
+	}
+}
+
+func runRightDedupJoinDoubleSignedZeroContract(
+	t *testing.T,
+	mode rightDedupKeyContractMode,
+) bool {
+	proc, ctrl := newRightDedupTestProcess(t, true)
+	defer ctrl.Finish()
+	proc.Base.Lim.Size = 8 << 20
+	proc.Base.Lim.SpillSize = 64 << 20
+
+	floatType := types.T_float64.ToType()
+	conditions := [][]*plan.Expr{
+		{newExpr(0, floatType)},
+		{newExpr(0, floatType)},
+	}
+	tag++
+	joinMapTag := tag
+
+	const buildRows = 256
+	buildBatch := batch.NewWithSize(1)
+	buildBatch.Vecs[0] = vector.NewVec(floatType)
+	require.NoError(t, vector.AppendFixed(buildBatch.Vecs[0], float64(0), false, proc.Mp()))
+	for i := 1; i < buildRows; i++ {
+		require.NoError(t, vector.AppendFixed(buildBatch.Vecs[0], float64(i), false, proc.Mp()))
+	}
+	buildBatch.SetRowCount(buildRows)
+
+	probeBatch := batch.NewWithSize(1)
+	probeBatch.Vecs[0] = vector.NewVec(floatType)
+	require.NoError(t, vector.AppendFixed(
+		probeBatch.Vecs[0],
+		math.Copysign(0, -1),
+		false,
+		proc.Mp(),
+	))
+	probeBatch.SetRowCount(1)
+
+	rightDedupArg := &RightDedupJoin{
+		LeftTypes:         []types.Type{floatType},
+		RightTypes:        []types.Type{floatType},
+		Conditions:        conditions,
+		Result:            []colexec.ResultPos{colexec.NewResultPos(0, 0)},
+		OnDuplicateAction: plan.Node_FAIL,
+		DedupColName:      "contract_key",
+		DedupColTypes:     []plan.Type{{Id: int32(types.T_float64)}},
+		IsShuffle:         mode.shuffle,
+		ShuffleIdx:        0,
+		SpillThreshold:    mode.spillThreshold,
+		JoinMapTag:        joinMapTag,
+	}
+	rightDedupArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{probeBatch}))
+
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:    true,
+		NeedBatches:    false,
+		Conditions:     conditions[1],
+		IsShuffle:      mode.shuffle,
+		ShuffleIdx:     0,
+		SpillThreshold: mode.spillThreshold,
+		JoinMapTag:     joinMapTag,
+		JoinMapRefCnt:  1,
+	}
+	if mode.shuffle {
+		buildArg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: joinMapTag + 9000}
+	}
+	buildArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{buildBatch}))
+	defer func() {
+		rightDedupArg.Free(proc, false, nil)
+		buildArg.Free(proc, false, nil)
+		budget, err := proc.GetHashBuildBudget()
+		require.NoError(t, err)
+		require.Zero(t, budget.Used())
+		require.Zero(t, budget.SpillDiskUsed())
+		require.Zero(t, budget.SpillFDUsed())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	}()
+
+	spillBefore := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),
+	)
+	reSpillBefore := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("respill", "2"),
+	)
+	require.NoError(t, buildArg.Prepare(proc))
+	require.NoError(t, rightDedupArg.Prepare(proc))
+	buildResult, err := vm.Exec(buildArg, proc)
+	require.NoError(t, err)
+	require.Nil(t, buildResult.Batch)
+
+	matchedBuildKey := false
+	for {
+		result, execErr := vm.Exec(rightDedupArg, proc)
+		if execErr != nil {
+			require.Contains(t, execErr.Error(), "Duplicate entry")
+			matchedBuildKey = true
+			break
+		}
+		if result.Status == vm.ExecStop {
+			break
+		}
+	}
+
+	spillAfter := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),
+	)
+	reSpillAfter := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("respill", "2"),
+	)
+	if mode.wantInitialSpill {
+		require.Greater(t, spillAfter, spillBefore)
+	} else {
+		require.Equal(t, spillBefore, spillAfter)
+	}
+	if mode.wantReSpill {
+		require.Greater(t, reSpillAfter, reSpillBefore)
+	} else {
+		require.Equal(t, reSpillBefore, reSpillAfter)
+	}
+
+	return matchedBuildKey
+}

--- a/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
@@ -39,9 +39,8 @@ type rightDedupKeyContractMode struct {
 }
 
 func TestRightDedupJoinDoubleSignedZeroContract(t *testing.T) {
-	// Pessimistic RightDedupJoin reports a duplicate when the probe key matches
-	// an existing build key. The false expectations characterize the current
-	// +0/-0 key-encoding gap across all three execution modes.
+	// Pessimistic RightDedupJoin must report a duplicate when -0 probes an
+	// existing +0 build key, in every execution mode.
 	modes := []rightDedupKeyContractMode{
 		{name: "resident"},
 		{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
@@ -49,7 +48,7 @@ func TestRightDedupJoinDoubleSignedZeroContract(t *testing.T) {
 	}
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
-			require.False(t, runRightDedupJoinDoubleSignedZeroContract(t, mode))
+			require.True(t, runRightDedupJoinDoubleSignedZeroContract(t, mode))
 		})
 	}
 }

--- a/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
@@ -18,12 +18,15 @@ import (
 	"math"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/spillutil"
 	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -43,12 +46,12 @@ func TestRightDedupJoinDoubleSignedZeroContract(t *testing.T) {
 	// existing +0 build key, in every execution mode.
 	modes := []rightDedupKeyContractMode{
 		{name: "resident"},
-		{name: "initial-spill", shuffle: true, spillThreshold: 64, wantInitialSpill: true},
+		{name: "initial-spill", shuffle: true, spillThreshold: hashmap.UnitLimit + 1, wantInitialSpill: true},
 		{name: "re-spill", shuffle: true, spillThreshold: 2, wantInitialSpill: true, wantReSpill: true},
 	}
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
-			require.True(t, runRightDedupJoinDoubleSignedZeroContract(t, mode))
+			runRightDedupJoinDoubleSignedZeroContract(t, mode)
 		})
 	}
 }
@@ -56,7 +59,7 @@ func TestRightDedupJoinDoubleSignedZeroContract(t *testing.T) {
 func runRightDedupJoinDoubleSignedZeroContract(
 	t *testing.T,
 	mode rightDedupKeyContractMode,
-) bool {
+) {
 	proc, ctrl := newRightDedupTestProcess(t, true)
 	defer ctrl.Finish()
 	proc.Base.Lim.Size = 8 << 20
@@ -77,13 +80,20 @@ func runRightDedupJoinDoubleSignedZeroContract(
 		if probeBatch != nil {
 			probeBatch.Clean(proc.Mp())
 		}
-		budget, err := proc.GetHashBuildBudget()
-		require.NoError(t, err)
-		require.Zero(t, budget.Used())
-		require.Zero(t, budget.SpillDiskUsed())
-		require.Zero(t, budget.SpillFDUsed())
+		budget, budgetErr := proc.GetHashBuildBudget()
+		var used, diskUsed, fdUsed uint64
+		if budgetErr == nil {
+			used = budget.Used()
+			diskUsed = budget.SpillDiskUsed()
+			fdUsed = budget.SpillFDUsed()
+		}
 		proc.Free()
-		require.Zero(t, proc.Mp().CurrNB())
+		mpoolBytes := proc.Mp().CurrNB()
+		require.NoError(t, budgetErr)
+		require.Zero(t, used)
+		require.Zero(t, diskUsed)
+		require.Zero(t, fdUsed)
+		require.Zero(t, mpoolBytes)
 	}()
 
 	floatType := types.T_float64.ToType()
@@ -94,14 +104,23 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	tag++
 	joinMapTag := tag
 
-	const buildRows = 256
+	const buildRows = hashmap.UnitLimit + 1
 	buildBatch = batch.NewWithSize(1)
 	buildBatch.Vecs[0] = vector.NewVec(floatType)
-	require.NoError(t, vector.AppendFixed(buildBatch.Vecs[0], float64(0), false, proc.Mp()))
-	for i := 1; i < buildRows; i++ {
-		require.NoError(t, vector.AppendFixed(buildBatch.Vecs[0], float64(i), false, proc.Mp()))
+	for key := 1; key < buildRows; key++ {
+		require.NoError(t, vector.AppendFixed(buildBatch.Vecs[0], float64(key), false, proc.Mp()))
 	}
+	// Keep the equality target in the second hashmap chunk (start=UnitLimit).
+	require.NoError(t, vector.AppendFixed(buildBatch.Vecs[0], float64(0), false, proc.Mp()))
 	buildBatch.SetRowCount(buildRows)
+	if mode.wantReSpill {
+		requireRightDedupTargetBucketReSpills(
+			t,
+			buildBatch.Vecs[0],
+			buildRows-1,
+			mode.spillThreshold,
+		)
+	}
 
 	probeBatch = batch.NewWithSize(1)
 	probeBatch.Vecs[0] = vector.NewVec(floatType)
@@ -155,16 +174,20 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	require.NoError(t, err)
 	require.Nil(t, buildResult.Batch)
 
-	matchedBuildKey := false
+	outputRows := 0
 	for {
 		result, execErr := vm.Exec(rightDedupArg, proc)
+		if result.Batch != nil {
+			outputRows += result.Batch.RowCount()
+		}
 		if execErr != nil {
-			require.Contains(t, execErr.Error(), "Duplicate entry")
-			matchedBuildKey = true
+			require.True(t, moerr.IsMoErrCode(execErr, moerr.ErrDuplicateEntry))
+			require.Contains(t, execErr.Error(), "Duplicate entry '-0' for key 'contract_key'")
+			require.Zero(t, outputRows)
 			break
 		}
 		if result.Status == vm.ExecStop {
-			break
+			t.Fatal("expected signed-zero duplicate")
 		}
 	}
 
@@ -184,6 +207,23 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	} else {
 		require.Equal(t, reSpillBefore, reSpillAfter)
 	}
+}
 
-	return matchedBuildKey
+func requireRightDedupTargetBucketReSpills(
+	t *testing.T,
+	keys *vector.Vector,
+	targetRow int,
+	spillThreshold int64,
+) {
+	hashes := make([]uint64, keys.Length())
+	spillutil.ComputeXXHash([]*vector.Vector{keys}, hashes, 0)
+	mask := uint64(spillutil.SpillNumBuckets - 1)
+	targetBucket := hashes[targetRow] & mask
+	var bucketRows int64
+	for _, hash := range hashes {
+		if hash&mask == targetBucket {
+			bucketRows++
+		}
+	}
+	require.GreaterOrEqual(t, bucketRows, spillThreshold)
 }

--- a/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
+++ b/pkg/sql/colexec/rightdedupjoin/key_contract_test.go
@@ -61,6 +61,30 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	defer ctrl.Finish()
 	proc.Base.Lim.Size = 8 << 20
 	proc.Base.Lim.SpillSize = 64 << 20
+	var buildBatch, probeBatch *batch.Batch
+	var rightDedupArg *RightDedupJoin
+	var buildArg *hashbuild.HashBuild
+	defer func() {
+		if rightDedupArg != nil {
+			rightDedupArg.Free(proc, false, nil)
+		}
+		if buildArg != nil {
+			buildArg.Free(proc, false, nil)
+		}
+		if buildBatch != nil {
+			buildBatch.Clean(proc.Mp())
+		}
+		if probeBatch != nil {
+			probeBatch.Clean(proc.Mp())
+		}
+		budget, err := proc.GetHashBuildBudget()
+		require.NoError(t, err)
+		require.Zero(t, budget.Used())
+		require.Zero(t, budget.SpillDiskUsed())
+		require.Zero(t, budget.SpillFDUsed())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	}()
 
 	floatType := types.T_float64.ToType()
 	conditions := [][]*plan.Expr{
@@ -71,7 +95,7 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	joinMapTag := tag
 
 	const buildRows = 256
-	buildBatch := batch.NewWithSize(1)
+	buildBatch = batch.NewWithSize(1)
 	buildBatch.Vecs[0] = vector.NewVec(floatType)
 	require.NoError(t, vector.AppendFixed(buildBatch.Vecs[0], float64(0), false, proc.Mp()))
 	for i := 1; i < buildRows; i++ {
@@ -79,7 +103,7 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	}
 	buildBatch.SetRowCount(buildRows)
 
-	probeBatch := batch.NewWithSize(1)
+	probeBatch = batch.NewWithSize(1)
 	probeBatch.Vecs[0] = vector.NewVec(floatType)
 	require.NoError(t, vector.AppendFixed(
 		probeBatch.Vecs[0],
@@ -89,7 +113,7 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	))
 	probeBatch.SetRowCount(1)
 
-	rightDedupArg := &RightDedupJoin{
+	rightDedupArg = &RightDedupJoin{
 		LeftTypes:         []types.Type{floatType},
 		RightTypes:        []types.Type{floatType},
 		Conditions:        conditions,
@@ -104,7 +128,7 @@ func runRightDedupJoinDoubleSignedZeroContract(
 	}
 	rightDedupArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{probeBatch}))
 
-	buildArg := &hashbuild.HashBuild{
+	buildArg = &hashbuild.HashBuild{
 		NeedHashMap:    true,
 		NeedBatches:    false,
 		Conditions:     conditions[1],
@@ -118,17 +142,6 @@ func runRightDedupJoinDoubleSignedZeroContract(
 		buildArg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: joinMapTag + 9000}
 	}
 	buildArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{buildBatch}))
-	defer func() {
-		rightDedupArg.Free(proc, false, nil)
-		buildArg.Free(proc, false, nil)
-		budget, err := proc.GetHashBuildBudget()
-		require.NoError(t, err)
-		require.Zero(t, budget.Used())
-		require.Zero(t, budget.SpillDiskUsed())
-		require.Zero(t, budget.SpillFDUsed())
-		proc.Free()
-		require.Zero(t, proc.Mp().CurrNB())
-	}()
 
 	spillBefore := promtestutil.ToFloat64(
 		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"),

--- a/pkg/sql/colexec/spillutil/join_spill.go
+++ b/pkg/sql/colexec/spillutil/join_spill.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/google/uuid"
 
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
@@ -992,7 +993,7 @@ func ComputeXXHash(keyVecs []*vector.Vector, hashValues []uint64, seed uint64) {
 		if vec.IsConst() {
 			colHash := uint64(0)
 			if !vec.IsConstNull() {
-				colHash = xxhash.Sum64(vec.GetRawBytesAt(0))
+				colHash = xxhash.Sum64(keycodec.BytesAt(vec, 0))
 			}
 			for i := 0; i < rowCount; i++ {
 				hashValues[i] = hashCombine(hashValues[i], colHash)
@@ -1008,12 +1009,12 @@ func ComputeXXHash(keyVecs []*vector.Vector, hashValues []uint64, seed uint64) {
 					if nulls.Contains(uint64(i)) {
 						hashValues[i] = hashCombine(hashValues[i], 0)
 					} else {
-						hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(vec.GetRawBytesAt(i)))
+						hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
 					}
 				}
 			} else {
 				for i := 0; i < n; i++ {
-					hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(vec.GetRawBytesAt(i)))
+					hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
 				}
 			}
 		}

--- a/pkg/sql/colexec/spillutil/join_spill.go
+++ b/pkg/sql/colexec/spillutil/join_spill.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/google/uuid"
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
@@ -970,55 +969,14 @@ func writeBucketPayload(proc *process.Process, payload []byte, rows int64, w *Bu
 
 // hashCombine merges a new hash value into a running hash state (Boost-style).
 func hashCombine(h, val uint64) uint64 {
-	return h ^ (val + 0x9e3779b97f4a7c15 + (h << 6) + (h >> 2))
+	return keycodec.HashCombine(h, val)
 }
 
 // ComputeXXHash evaluates key vectors and computes XXHash64 values using
 // column-at-a-time processing for better cache locality. seed initialises every
 // hash slot so different spill depths produce different bucket distributions.
 func ComputeXXHash(keyVecs []*vector.Vector, hashValues []uint64, seed uint64) {
-	if len(hashValues) == 0 {
-		return
-	}
-
-	rowCount := len(hashValues)
-	for i := 0; i < rowCount; i++ {
-		hashValues[i] = seed
-	}
-	if len(keyVecs) == 0 {
-		return
-	}
-
-	for _, vec := range keyVecs {
-		if vec.IsConst() {
-			colHash := uint64(0)
-			if !vec.IsConstNull() {
-				colHash = xxhash.Sum64(keycodec.BytesAt(vec, 0))
-			}
-			for i := 0; i < rowCount; i++ {
-				hashValues[i] = hashCombine(hashValues[i], colHash)
-			}
-		} else {
-			n := rowCount
-			if vec.Length() < n {
-				n = vec.Length()
-			}
-			if vec.GetNulls().Any() {
-				nulls := vec.GetNulls()
-				for i := 0; i < n; i++ {
-					if nulls.Contains(uint64(i)) {
-						hashValues[i] = hashCombine(hashValues[i], 0)
-					} else {
-						hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
-					}
-				}
-			} else {
-				for i := 0; i < n; i++ {
-					hashValues[i] = hashCombine(hashValues[i], xxhash.Sum64(keycodec.BytesAt(vec, i)))
-				}
-			}
-		}
-	}
+	keycodec.ComputeXXHash(keyVecs, hashValues, seed)
 }
 
 // classifyRows computes bucket counts, prefix offsets, and one contiguous row


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26432. This is an incremental contract fix; it intentionally does **not** close the whole issue.

## What this PR does / why we need it

Spill is not a separate equality domain. A join key that is equal under SQL must remain equivalent in every physical phase: resident hashmap lookup, initial spill partitioning, probe partitioning, and recursive re-spill.

This PR fixes one concrete violation of that invariant: SQL `DOUBLE +0 = -0` was true in the scalar evaluator, while raw IEEE-754 bytes sent the two values to different hashmap keys or spill partitions.

The implementation defines signed-zero canonicalization once in `keycodec` and uses the same typed contract in all CN-local phases:

- resident `IntHashMap` keys;
- resident composite `StrHashMap` keys;
- initial build-side spill partitioning;
- probe-side partitioning and recursive re-spill.

Resident hashmaps dispatch once per vector and retain specialized row loops. Initial spill and re-spill call the same vector-level partition-hash implementation. Common non-`DOUBLE` loops are unchanged; there is no per-row interface dispatch or allocation.

Only the ephemeral hashmap/partition key is canonicalized. Input vectors, result values, and serialized spill batches retain their original values and format, so this introduces no spill-file or wire-format change.

## Contract status

Each pending case first executes the real scalar `=` evaluator as the SQL oracle, then skips before asserting the known-incomplete physical behavior. The PR does not bless a current mismatch as expected output.

| Type / values | Scalar SQL `=` | Resident | Initial spill | Re-spill | Status |
| --- | --- | --- | --- | --- | --- |
| `DOUBLE +0 / -0` | `TRUE` | match | match | match | **fixed and active** |
| scaled `FLOAT32(scale=2) 1.234 / 1.23` | `TRUE` | pending | pending | pending | skipped with #26432 reason |
| `JSON 1 / 1.0` | `TRUE` | pending | pending | pending | skipped with #26432 reason |
| `VECF32 +0 / -0` | `TRUE` | pending | pending | pending | skipped with #26432 reason |
| same-payload `DOUBLE NaN / NaN` | `FALSE` | pending | pending | pending | skipped with #26432 reason |
| `DOUBLE NULL / NULL` | `NULL` | no match | no match | no match | **active and correct** |

`FLOAT64` is not currently eligible for the planner's remote-shuffle key path. This PR establishes the local resident/spill/re-spill invariant; remote typed-key equivalence and the remaining types stay tracked by #26432.

## Regression design

These are deterministic operator-level tests, not large-data BVTs or embedded-cluster SQL. A low spill threshold selects the physical mode with 257 build rows plus one probe row, so runtime and memory remain small while the same batches traverse real join operators and spill files.

| Operator | Exact oracle checked in resident, initial-spill, and re-spill modes |
| --- | --- |
| HashJoin | One `-0` probe must return exactly the 129 distinct payloads belonging to the skewed `+0/-0` build equivalence class—no loss, duplicate, wrong build row, or NULL payload. |
| DedupJoin | The exact 257-row build multiset is preserved; only the signed-zero row receives probe capture `42`, with exact capture NULL states. |
| RightDedupJoin | The signed-zero pair returns `ErrDuplicateEntry` for `contract_key`, with zero output before and at the error. |

The fixtures also prove that:

- the signed-zero target starts in the second hashmap chunk (`start > 0`);
- resident mode does not spill;
- initial-spill mode increments depth 1 but not depth 2;
- re-spill mode increments both depths, and the target bucket itself meets the re-spill threshold;
- operator cleanup returns memory-budget usage, spill-disk usage, open spill FDs, and mpool bytes to zero.

A public hashmap-iterator contract matrix covers both `IntHashMap` and composite `StrHashMap`: flat vectors with a non-zero start, nullable vectors with and without actual NULLs, NULL filtering, NULL-as-key, constants, and constant NULLs. It asserts `zValues`, live group IDs, and `GroupCount` across insert and find operations.

## Scope and performance

Microbenchmark setup: latest `main` versus this branch, identical harness, `GOMAXPROCS=1`, five samples/median, 8192 spill rows and 256 resident hashmap rows.

| Path | latest `main` ns/row | this PR ns/row | delta |
| --- | ---: | ---: | ---: |
| spill `INT64` | 4.824 | 4.861 | +0.8% |
| spill `DOUBLE` | 4.788 | 2.660 | -44.4% |
| resident IntHashMap `INT64` | 2.879 | 2.882 | +0.1% |
| resident IntHashMap `DOUBLE` | 2.941 | 2.814 | -4.3% |
| resident StrHashMap composite `INT64` | 7.869 | 7.942 | +0.9% |
| resident StrHashMap composite `DOUBLE` | 7.887 | 6.903 | -12.5% |

The common integer paths show no material regression. The `DOUBLE` specializations are faster than the previous raw-byte path while implementing SQL-equivalent hashing.

## Test plan

All commands use the repository's deterministic CGo/libmo wrapper and were rerun after rebasing onto `origin/main` at `38ce3a774a`.

Focused race stress, all pass with `-race -count=100`:

- `TestHashJoinKeyEqualityContract`
- `TestDedupJoinDoubleSignedZeroContract`
- `TestRightDedupJoinDoubleSignedZeroContract`
- `TestHashMapsFloat64SignedZeroContract`

Complete non-race and `-race -count=1` suites both pass for all owning packages:

- `pkg/common/hashmap`
- `pkg/sql/colexec/hashbuild`
- `pkg/sql/colexec/spillutil`
- `pkg/sql/colexec/hashjoin`
- `pkg/sql/colexec/dedupjoin`
- `pkg/sql/colexec/rightdedupjoin`

`go vet` and `go build -mod=readonly` pass for the same six packages. The new hashmap state matrix directly exercises the `FLOAT64` const, nullable, NULL, non-zero-start, and composite-key branches that the prior CI coverage review identified.
