### PR TITLE
fix: release merge transfer state before registration

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -12168,6 +12168,77 @@ func TestRollbackMergeAfterTransferredDeleteError(t *testing.T) {
 	require.Equal(t, 3, rel.GetMeta().(*catalog.TableEntry).ObjectCnt(false) /*Aobj(created + deleted), Nobj(rollbacked)*/)
 }
 
+func transferSlabCurrBytes(t *testing.T) int64 {
+	t.Helper()
+	var reports []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(mpool.ReportMemUsage("transfer-slab")), &reports))
+	for _, report := range reports {
+		raw, ok := report["transfer-slab"]
+		if !ok || string(raw) == `""` {
+			continue
+		}
+		var stats struct {
+			CurrBytes int64 `json:"currBytes"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &stats))
+		return stats.CurrBytes
+	}
+	return 0
+}
+
+func TestRollbackMergeBeforeRegistrationCleansTransferState(t *testing.T) {
+	ctx := context.Background()
+
+	opts := config.WithLongScanAndCKPOpts(nil)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+	schema := catalog.MockSchemaAll(1, 0)
+	schema.Extra.BlockMaxRows = 20
+	schema.Extra.ObjectMaxBlocks = 5
+	tae.BindSchema(schema)
+	bat := catalog.MockBatch(schema, 10)
+	defer bat.Close()
+	tae.CreateRelAndAppend(bat, true)
+	tae.CompactBlocks(true)
+
+	mergesort.DrainTransferSlabPool()
+	before := transferSlabCurrBytes(t)
+	t.Cleanup(mergesort.DrainTransferSlabPool)
+
+	txn, rel := tae.GetRelation()
+	defer func() {
+		assert.NoError(t, txn.Rollback(ctx))
+	}()
+	obj := testutil.GetOneBlockMeta(rel)
+	task, err := jobs.NewMergeObjectsTask(nil, txn, []*catalog.ObjectEntry{obj}, tae.Runtime, 0, false)
+	require.NoError(t, err)
+
+	// Commit the delete before the merge entry is built so phase-1 transfer
+	// writes TransferDelsMap during NewMergeObjectsEntry.
+	require.NoError(t, tae.DeleteAll(true))
+
+	const injectedErr = "mock pre-registration transfer error"
+	require.True(t, fault.Enable())
+	t.Cleanup(func() {
+		assert.True(t, fault.Disable())
+	})
+	require.NoError(t, fault.AddFaultPoint(ctx, objectio.FJ_TransferErrorAfterTransfer, ":::", "echo", 0, injectedErr, false))
+	t.Cleanup(func() {
+		removed, err := fault.RemoveFaultPoint(ctx, objectio.FJ_TransferErrorAfterTransfer)
+		assert.NoError(t, err)
+		assert.True(t, removed)
+	})
+
+	require.ErrorContains(t, task.OnExec(ctx), injectedErr)
+
+	created := objectio.ObjectStats(task.GetCommitEntry().CreatedObjs[0])
+	createdBlk := objectio.NewBlockidWithObjectID(created.ObjectName().ObjectId(), 0)
+	require.Nil(t, tae.Runtime.TransferDelsMap.GetDelsForBlk(createdBlk))
+
+	mergesort.DrainTransferSlabPool()
+	require.Equal(t, before, transferSlabCurrBytes(t))
+}
+
 func TestTransferInMerge(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -522,7 +522,14 @@ func HandleMergeEntryInTxn(
 	transferTable *mergesort.TransferTable,
 	rt *dbutils.Runtime,
 	isTombstone bool,
-) ([]*catalog.ObjectEntry, error) {
+) (createdObjs []*catalog.ObjectEntry, err error) {
+	transferTableOwned := true
+	defer func() {
+		if err != nil && transferTableOwned && transferTable != nil {
+			transferTable.Release()
+		}
+	}()
+
 	database, err := txn.GetDatabaseByID(entry.DbId)
 	if err != nil {
 		return nil, err
@@ -533,7 +540,7 @@ func HandleMergeEntryInTxn(
 	}
 
 	mergedObjs := make([]*catalog.ObjectEntry, 0, len(entry.MergedObjs))
-	createdObjs := make([]*catalog.ObjectEntry, 0, len(entry.CreatedObjs))
+	createdObjs = make([]*catalog.ObjectEntry, 0, len(entry.CreatedObjs))
 	ids := make([]*common.ID, 0, len(entry.MergedObjs)*2)
 
 	// drop merged blocks and objects
@@ -597,6 +604,9 @@ func HandleMergeEntryInTxn(
 		isTombstone,
 		rt,
 	)
+	// NewMergeObjectsEntry owns transferTable even when its preparation fails:
+	// its error path rolls the transfer state back before returning.
+	transferTableOwned = false
 	if err != nil {
 		return nil, err
 	}
@@ -605,12 +615,14 @@ func HandleMergeEntryInTxn(
 		if err = txn.LogTxnEntry(
 			entry.DbId, entry.TblId, txnEntry, nil, ids,
 		); err != nil {
+			txnEntry.RollbackTransferState()
 			return nil, err
 		}
 	} else {
 		if err = txn.LogTxnEntry(
 			entry.DbId, entry.TblId, txnEntry, ids, nil,
 		); err != nil {
+			txnEntry.RollbackTransferState()
 			return nil, err
 		}
 	}

--- a/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
@@ -71,7 +71,7 @@ func NewMergeObjectsEntry(
 	transferTable *mergesort.TransferTable,
 	isTombstone bool,
 	rt *dbutils.Runtime,
-) (*mergeObjectsEntry, error) {
+) (_ *mergeObjectsEntry, err error) {
 	totalCreatedBlkCnt := 0
 	for i, obj := range createdObjs {
 		createdObjs[i] = obj.GetLatestNode()
@@ -88,6 +88,11 @@ func NewMergeObjectsEntry(
 		isTombstone:   isTombstone,
 		taskName:      taskName,
 	}
+	defer func() {
+		if err != nil {
+			entry.RollbackTransferState()
+		}
+	}()
 
 	startTS := entry.txn.GetStartTS()
 	if entry.rt.BigDeleteHinter.HasBigDelAfter(entry.relation.ID(), &startTS) {
@@ -100,13 +105,12 @@ func NewMergeObjectsEntry(
 		if _, _, injected := fault.TriggerFault(objectio.FJ_TransferSlow); injected {
 			time.Sleep(time.Second)
 		}
-		var err error
 		// phase 1 transfer
 		entry.transCntBeforeCommit, _, err = entry.collectDelsAndTransfer(ctx, entry.txn.GetStartTS(), entry.collectTs)
 		if err != nil {
 			return nil, err
 		}
-		if err := entry.prepareTransferPage(ctx); err != nil {
+		if err = entry.prepareTransferPage(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -204,7 +208,10 @@ func (entry *mergeObjectsEntry) prepareTransferPage(ctx context.Context) error {
 	return nil
 }
 
-func (entry *mergeObjectsEntry) PrepareRollback() (err error) {
+// RollbackTransferState releases the state created while preparing delete
+// transfer. It deliberately does not remove output object files: before the
+// entry is registered, that remains the merge task's responsibility.
+func (entry *mergeObjectsEntry) RollbackTransferState() {
 	if entry.transferTable != nil {
 		entry.transferTable.Release()
 		entry.transferTable = nil
@@ -219,6 +226,11 @@ func (entry *mergeObjectsEntry) PrepareRollback() (err error) {
 		}
 	}
 	entry.pageIds = nil
+	entry.delTbls = nil
+}
+
+func (entry *mergeObjectsEntry) PrepareRollback() (err error) {
+	entry.RollbackTransferState()
 
 	fs := entry.rt.Fs
 	// for io task, dispatch by round robin, scope can be nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26445

## What this PR does / why we need it:

`DoMergeAndWrite` transfers ownership of its off-heap `TransferTable` slab to
the merge task before `HandleMergeEntryInTxn` constructs and registers the
transaction entry. A committed large delete can be recorded after the task's
initial big-delete check but before `NewMergeObjectsEntry`; that constructor
then rejects the merge. Since no transaction entry was registered, the normal
`PrepareRollback` path never released the slab. The same ownership gap also
left transfer pages and `TransferDelsMap` entries behind for later constructor
failures.

This change gives transfer state one explicit owner at every boundary:

- `HandleMergeEntryInTxn` releases a table when it fails before construction.
- `NewMergeObjectsEntry` rolls transfer state back on every construction
  error, including the production big-delete rejection.
- A failed `LogTxnEntry` rolls back the unregistered entry's transfer state.
- Registered entries retain the existing commit/rollback lifecycle; rollback
  now reuses the same idempotent transfer-state cleanup. Output-object file
  deletion remains owned by the existing merge-task error path, so it is not
  duplicated.

The regression executes a real merge with a committed delete, fails after
phase-1 transfer, and asserts both that `TransferDelsMap` is empty and that
the transfer-slab mpool allocation returns to its baseline.

Verified with:

- focused regression: `TestRollbackMergeBeforeRegistrationCleansTransferState`
- adjacent merge rollback/transfer tests:
  `TestRollbackMergeInQueue`, `TestRollbackMergeOnTransferError`,
  `TestRollbackMergeAfterTransferredDeleteError`,
  `TestRollbackMergeBeforeRegistrationCleansTransferState`,
  `TestTransferInMerge`, and `TestTransferInMerge2`
- full `./pkg/vm/engine/tae/db/test` package
- `go test -race -count=100` for the focused regression and race tests for
  `./pkg/vm/engine/tae/tables/txnentries` and
  `./pkg/vm/engine/tae/tables/jobs`
- `go build` and `go vet` for the changed implementation packages
