### PR TITLE
fix: read PITR length using catalog type

### DIFF
--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -532,7 +532,7 @@ func loadAlterDataBranchHistoricalSourcesWithQuery(
 	err = appendAlterDataBranchHistoricalSources(
 		res,
 		func(i int, cols []*vector.Vector) (int64, error) {
-			lengths := vector.MustFixedColNoTypeCheck[int64](cols[5])
+			lengths := vector.MustFixedColWithTypeCheck[uint8](cols[5])
 			units := executor.GetStringRows(cols[6])
 			return databranchutils.PitrRetentionLowerBound(now, int(lengths[i]), units[i])
 		},

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -1175,6 +1175,55 @@ func newAlterCopyFixedResult[T any](t *testing.T, mp *mpool.MPool, typ types.Typ
 	return memRes.GetResult()
 }
 
+func TestLoadAlterDataBranchHistoricalSourcesUsesPitrCatalogType(t *testing.T) {
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	ctrl := gomock.NewController(t)
+	c := newAlterCopyPrecheckCompile(t, ctrl, &alterCopyInsertSpyExecutor{})
+	mp := c.proc.Mp()
+	results := map[string]executor.Result{
+		alterDataBranchSnapshotSourceSQL(): newAlterLineageSnapshotSourceResult(
+			t, mp, nil, nil, nil, nil, nil, nil,
+		),
+		alterDataBranchPitrSourceSQL(): newAlterLineagePitrSourceResult(
+			t, mp,
+			[]string{"database", "table"},
+			[]string{"tenant", "tenant"},
+			[]string{"db_hour", "db_day"},
+			[]string{"", "tbl"},
+			[]uint64{101, 102},
+			[]uint8{1, 2},
+			[]string{"h", "d"},
+		),
+	}
+
+	sources, err := loadAlterDataBranchHistoricalSourcesWithQuery(
+		func(sql string) (executor.Result, error) {
+			res, ok := results[sql]
+			require.True(t, ok, "unexpected lineage source query: %s", sql)
+			return res, nil
+		},
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []databranchutils.HistoricalSource{
+		{
+			Level:        "database",
+			AccountName:  "tenant",
+			DatabaseName: "db_hour",
+			ObjectID:     101,
+			OldestTS:     now.Add(-time.Hour).UnixNano(),
+		},
+		{
+			Level:        "table",
+			AccountName:  "tenant",
+			DatabaseName: "db_day",
+			TableName:    "tbl",
+			ObjectID:     102,
+			OldestTS:     now.AddDate(0, 0, -2).UnixNano(),
+		},
+	}, sources)
+}
+
 func TestCompactExpiredAlterDataBranchLineage(t *testing.T) {
 	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
 	cloneTS := now.Add(-48 * time.Hour).UnixNano()
@@ -1187,7 +1236,7 @@ func TestCompactExpiredAlterDataBranchLineage(t *testing.T) {
 
 	for _, tc := range []struct {
 		name          string
-		pitrLength    int64
+		pitrLength    uint8
 		wantDeletes   bool
 		wantSQLSuffix []string
 	}{
@@ -1223,7 +1272,7 @@ func TestCompactExpiredAlterDataBranchLineage(t *testing.T) {
 			spyExec.results[snapshotSQL] = newAlterLineageSnapshotSourceResult(t, mp, nil, nil, nil, nil, nil, nil)
 			spyExec.results[pitrSQL] = newAlterLineagePitrSourceResult(
 				t, mp, []string{"table"}, []string{"tenant"}, []string{"db"}, []string{"tbl"},
-				[]uint64{1}, []int64{tc.pitrLength}, []string{"h"},
+				[]uint64{1}, []uint8{tc.pitrLength}, []string{"h"},
 			)
 
 			require.NoError(t, c.compactExpiredAlterDataBranchLineage(now))
@@ -1259,7 +1308,7 @@ func TestCompactExpiredAlterDataBranchLineageWithExecutor(t *testing.T) {
 		alterDataBranchSnapshotSourceSQL(): newAlterLineageSnapshotSourceResult(t, mp, nil, nil, nil, nil, nil, nil),
 		alterDataBranchPitrSourceSQL(): newAlterLineagePitrSourceResult(
 			t, mp, []string{"table"}, []string{"tenant"}, []string{"db"}, []string{"tbl"},
-			[]uint64{1}, []int64{24}, []string{"h"},
+			[]uint64{1}, []uint8{24}, []string{"h"},
 		),
 	}
 	var executed []string
@@ -1334,7 +1383,7 @@ func TestCompactExpiredAlterDataBranchLineageWithExecutorPropagatesDeleteError(t
 		alterDataBranchSnapshotSourceSQL(): newAlterLineageSnapshotSourceResult(t, mp, nil, nil, nil, nil, nil, nil),
 		alterDataBranchPitrSourceSQL(): newAlterLineagePitrSourceResult(
 			t, mp, []string{"table"}, []string{"tenant"}, []string{"db"}, []string{"tbl"},
-			[]uint64{1}, []int64{24}, []string{"h"},
+			[]uint64{1}, []uint8{24}, []string{"h"},
 		),
 	}
 	wantErr := errors.New("delete failed")
@@ -1423,12 +1472,12 @@ func newAlterLineagePitrSourceResult(
 	mp *mpool.MPool,
 	levels, accounts, databases, tables []string,
 	objectIDs []uint64,
-	lengths []int64,
+	lengths []uint8,
 	units []string,
 ) executor.Result {
 	memRes := executor.NewMemResult([]types.Type{
 		types.T_varchar.ToType(), types.T_varchar.ToType(), types.T_varchar.ToType(),
-		types.T_varchar.ToType(), types.T_uint64.ToType(), types.T_int64.ToType(),
+		types.T_varchar.ToType(), types.T_uint64.ToType(), types.T_uint8.ToType(),
 		types.T_varchar.ToType(),
 	}, mp)
 	memRes.NewBatchWithRowCount(len(levels))

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -1191,7 +1191,7 @@ func TestLoadAlterDataBranchHistoricalSourcesUsesPitrCatalogType(t *testing.T) {
 			[]string{"db_hour", "db_day"},
 			[]string{"", "tbl"},
 			[]uint64{101, 102},
-			[]uint8{1, 2},
+			[]uint8{1, 100},
 			[]string{"h", "d"},
 		),
 	}
@@ -1219,7 +1219,7 @@ func TestLoadAlterDataBranchHistoricalSourcesUsesPitrCatalogType(t *testing.T) {
 			DatabaseName: "db_day",
 			TableName:    "tbl",
 			ObjectID:     102,
-			OldestTS:     now.AddDate(0, 0, -2).UnixNano(),
+			OldestTS:     now.AddDate(0, 0, -100).UnixNano(),
 		},
 	}, sources)
 }

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -567,7 +567,7 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 			{"database_name", types.T_varchar, false, 50, 0},
 			{"table_name", types.T_varchar, false, 50, 0},
 			{"obj_id", types.T_uint64, false, 100, 0},
-			{"pitr_length", types.T_int64, false, 50, 0},
+			{"pitr_length", types.T_uint8, false, 50, 0},
 			{"pitr_unit", types.T_varchar, false, 50, 0},
 		},
 		pks: []int{0},

--- a/test/distributed/cases/git4data/branch/edge/branch_edge_cases.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_edge_cases.result
@@ -344,3 +344,18 @@ dst_tables_after_commit
 0
 drop database if exists br_txn_dst;
 drop database br_txn_src;
+drop pitr if exists issue26456_pitr;
+drop database if exists issue26456_pitr_db;
+create database issue26456_pitr_db;
+use issue26456_pitr_db;
+create table base(id int primary key, value int);
+insert into base values (1, 10), (2, 20);
+data branch create table child from base;
+create pitr issue26456_pitr for database issue26456_pitr_db range 1 'h';
+alter table base add column added int default 7;
+select id, value, added from base order by id;
+id    value    added
+1    10    7
+2    20    7
+drop pitr issue26456_pitr;
+drop database issue26456_pitr_db;

--- a/test/distributed/cases/git4data/branch/edge/branch_edge_cases.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_edge_cases.sql
@@ -310,3 +310,17 @@ select count(*) as dst_tables_after_commit
 
 drop database if exists br_txn_dst;
 drop database br_txn_src;
+
+-- @bvt:issue#26456
+drop pitr if exists issue26456_pitr;
+drop database if exists issue26456_pitr_db;
+create database issue26456_pitr_db;
+use issue26456_pitr_db;
+create table base(id int primary key, value int);
+insert into base values (1, 10), (2, 20);
+data branch create table child from base;
+create pitr issue26456_pitr for database issue26456_pitr_db range 1 'h';
+alter table base add column added int default 7;
+select id, value, added from base order by id;
+drop pitr issue26456_pitr;
+drop database issue26456_pitr_db;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26456

## What this PR does / why we need it:

`mo_catalog.mo_pitr.pitr_length` is persisted as `tinyint unsigned`, but the compile-layer DATA BRANCH lineage loader reinterpreted its result vector as `int64`. With multiple active PITR rows this requested more bytes than the `T_uint8` vector contained and panicked during lineage compaction.

This PR keeps the catalog DDL and the supported `1..100` range unchanged. It:

- reads `pitr_length` as checked `uint8` before the lossless conversion to `int`;
- aligns the planner catalog mock and compile test fixtures with the production `T_uint8` representation;
- covers direct loading, active/expired lineage retention, the background executor path, and delete-error propagation;
- adds a canonical DATA BRANCH + database PITR + COPY ALTER BVT case.

### Validation

- The new direct loader test reproduces the original panic before the production fix: `unsafe slice cast: from length 8 is not enough for length 16` at `pkg/sql/compile/alter.go:535`.
- After rebasing onto `upstream/main` at `11eaec8833e79b3b178ebeb9b6b2bb43fd6b679e`, `range-diff` showed all three PR patches are exactly equivalent.
- Focused compile tests passed with `-race -count=20`; full `./pkg/sql/compile` and `./pkg/sql/plan` tests passed with `-race -count=1` through the repository CGo wrapper.
- `git diff --check` passed.
- Superseded-head run `30538612665` passed SCA, Coverage, PROXY BVT, and PESSIMISTIC BVT. Ubuntu UT failed across unrelated cluster/lockservice tests because HAKeeper/TN startup timed out and a remote backend closed; the branch was rebased again instead of rerunning that superseded head.
- Exact-head preflight: `PASS review=PASS validation=PENDING` on `ea4e498bf086caed8a8feb1d984b5a1408df9540` (`diff_hash=67549bacba9eb7898120fa7d90b2b33a0d61acc11736ffb44d2bfed3f3b9a41a`).
- Local BVT execution is pending because `mo-tester` is unavailable on this machine; the SQL/result pair is included for exact-head CI.

### QA

QA required: yes

After merge, please validate PITR + DATA BRANCH + COPY ALTER in TKE or an equivalent environment and confirm that the original MOTR panic failure cluster no longer appears. Issue #26456 should remain open until that QA gate passes.
