### PR TITLE
fix(frontend): scope diagnostics to latest statement

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1106,7 +1106,7 @@ func doShowErrors(ses *Session, execCtx *ExecCtx) error {
 	mrs.AddColumn(CodeCol)
 	mrs.AddColumn(MsgCol)
 
-	info := ses.GetErrInfo()
+	info := ses.diagnosticsSnapshot()
 
 	for i := info.length() - 1; i >= 0; i-- {
 		row := make([]interface{}, 3)
@@ -1124,6 +1124,26 @@ func handleShowErrors(ses FeSession, execCtx *ExecCtx) error {
 		return err
 	}
 	return err
+}
+
+func isDiagnosticsStatement(stmt tree.Statement) bool {
+	switch stmt.(type) {
+	case *tree.ShowErrors, *tree.ShowWarnings:
+		return true
+	default:
+		return false
+	}
+}
+
+func isTopLevelClientStatement(ses *Session, execCtx *ExecCtx, input *UserInput) bool {
+	return ses != nil && execCtx != nil && input != nil &&
+		!input.isInternal() && !execCtx.inMigration && !ses.IsDerivedStmt()
+}
+
+func resetDiagnosticsForStatement(ses *Session, execCtx *ExecCtx, input *UserInput, stmt tree.Statement) {
+	if isTopLevelClientStatement(ses, execCtx, input) && !isDiagnosticsStatement(stmt) {
+		ses.resetDiagnostics()
+	}
 }
 
 func doShowVariables(ses *Session, execCtx *ExecCtx, sv *tree.ShowVariables) error {
@@ -4492,6 +4512,9 @@ func doComQuery(ses *Session, execCtx *ExecCtx, input *UserInput) (retErr error)
 
 	ParseDuration := time.Since(beginInstant)
 	recordParseError := func(errorInput *UserInput, parseErr error) error {
+		if isTopLevelClientStatement(ses, execCtx, errorInput) {
+			ses.resetDiagnostics()
+		}
 		statsInfo.ParseStage.ParseDuration = time.Since(beginInstant)
 		var recordErr error
 		execCtx.reqCtx, recordErr = RecordParseErrorStatement(
@@ -4519,6 +4542,9 @@ func doComQuery(ses *Session, execCtx *ExecCtx, input *UserInput) (retErr error)
 
 	singleStatement := len(cws) == 1 && !stagedSQLMode
 	if ses.GetCmd() == COM_STMT_PREPARE && !singleStatement {
+		if len(cws) > 0 {
+			resetDiagnosticsForStatement(ses, execCtx, input, cws[0].GetAst())
+		}
 		return moerr.NewNotSupported(execCtx.reqCtx, "prepare multi statements")
 	}
 
@@ -4557,6 +4583,7 @@ func doComQuery(ses *Session, execCtx *ExecCtx, input *UserInput) (retErr error)
 
 	for i := 0; i < len(cws); i++ {
 		cw := cws[i]
+		stmt := cw.GetAst()
 		currentInput := input
 		currentSQLRecord := ""
 		sqlType := input.getSqlSourceType(i)
@@ -4572,10 +4599,10 @@ func doComQuery(ses *Session, execCtx *ExecCtx, input *UserInput) (retErr error)
 		// Install the policy that belongs to this wrapper before authorization and
 		// planning. In particular, DefaultDatabase uses it for unqualified names.
 		installStatementRemap(execCtx, cw)
-		if cw.GetAst().GetQueryType() == tree.QueryTypeDDL || cw.GetAst().GetQueryType() == tree.QueryTypeDCL ||
-			cw.GetAst().GetQueryType() == tree.QueryTypeOth ||
-			cw.GetAst().GetQueryType() == tree.QueryTypeTCL {
-			if _, ok := cw.GetAst().(*tree.SetVar); !ok {
+		if stmt.GetQueryType() == tree.QueryTypeDDL || stmt.GetQueryType() == tree.QueryTypeDCL ||
+			stmt.GetQueryType() == tree.QueryTypeOth ||
+			stmt.GetQueryType() == tree.QueryTypeTCL {
+			if _, ok := stmt.(*tree.SetVar); !ok {
 				ses.cleanCache()
 			}
 			canCache = false
@@ -4588,7 +4615,7 @@ func doComQuery(ses *Session, execCtx *ExecCtx, input *UserInput) (retErr error)
 		// clear the previous statement's run result so a statement that does not
 		// set it (e.g. a status statement) does not inherit a stale AffectRows.
 		execCtx.runResult = nil
-		stmt := cw.GetAst()
+		resetDiagnosticsForStatement(ses, execCtx, currentInput, stmt)
 		removePrepareStmtForReplacement(ses, stmt)
 		var err2 error
 		execCtx.reqCtx, err2 = RecordStatement(execCtx.reqCtx, ses, proc, cw, beginInstant, currentSQLRecord, sqlType, singleStatement)
@@ -4859,12 +4886,14 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 			ses.addSqlCount(1)
 			err = handleSidecarOffload(ses, execCtx, query, useGPU)
 			if err == nil {
+				ses.resetDiagnostics()
 				setRowCount(ses, ses.GetProc(), -1)
 				mer := NewMysqlExecutionResult(0, 0, 0, 0, ses.GetMysqlResultSet())
 				resp = ses.SetNewResponse(ResultResponse, 0, int(COM_QUERY), mer, true)
 				return resp, nil
 			}
 			if err != errSidecarNotConfigured {
+				ses.resetDiagnostics()
 				markRowCountFailed(ses, ses.GetProc())
 				resp = NewGeneralErrorResponse(COM_QUERY, ses.GetTxnHandler().GetServerStatus(), err)
 				return resp, nil
@@ -4878,6 +4907,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		// SQL mode current for each staged statement.
 		rewritePolicy, rewriteErr := captureRewritePolicy(execCtx.reqCtx, ses)
 		if rewriteErr != nil {
+			ses.resetDiagnostics()
 			markRowCountFailed(ses, ses.GetProc())
 			resp = NewGeneralErrorResponse(COM_QUERY, ses.GetTxnHandler().GetServerStatus(), rewriteErr)
 			return resp, nil
@@ -4929,6 +4959,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 			var rewriteErr error
 			sql, rewriteErr = rewriteSQL(execCtx.reqCtx, ses, sql)
 			if rewriteErr != nil {
+				ses.resetDiagnostics()
 				markRowCountFailed(ses, ses.GetProc())
 				resp = NewGeneralErrorResponse(COM_STMT_PREPARE, ses.GetTxnHandler().GetServerStatus(), rewriteErr)
 				return resp, nil
@@ -4957,6 +4988,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		var prepareStmt *PrepareStmt
 		sql, prepareStmt, err = parseStmtExecute(execCtx.reqCtx, ses, req.GetData().([]byte))
 		if err != nil {
+			ses.resetDiagnostics()
 			if prepareStmt != nil {
 				prepareStmt.clearBinaryParamState(ses.GetProc())
 			}

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -85,6 +85,88 @@ func mockRecordStatement(ctx context.Context) (context.Context, *gostub.Stubs) {
 	return ctx, stubs
 }
 
+func TestDoComQueryParseErrorReplacesPreviousDiagnostics(t *testing.T) {
+	ctx := defines.AttachAccountId(context.Background(), catalog.System_Account)
+	ctrl := gomock.NewController(t)
+	ses := newTestSession(t, ctrl)
+	defer ses.Close()
+
+	ses.appendErrorDiagnostic(1000, "stale diagnostic marker")
+	execCtx := newTestExecCtx(ctx, ctrl)
+	execCtx.ses = ses
+
+	err := doComQuery(ses, execCtx, &UserInput{sql: "select from"})
+	require.Error(t, err)
+	// sendErrPacket records the final client-facing error after doComQuery
+	// returns. Mirror that protocol step here so this test exercises the same
+	// diagnostics lifecycle without opening a network connection.
+	ses.appendErrorDiagnostic(1064, err.Error())
+
+	info := ses.diagnosticsSnapshot()
+	require.Equal(t, 1, info.length())
+	require.Equal(t, []uint16{1064}, info.codes)
+	require.NotContains(t, info.msgs, "stale diagnostic marker")
+}
+
+func TestDoComQueryPrepareMultiReplacesPreviousDiagnostics(t *testing.T) {
+	ctx := defines.AttachAccountId(context.Background(), catalog.System_Account)
+	ctrl := gomock.NewController(t)
+	ses := newTestSession(t, ctrl)
+	defer ses.Close()
+
+	ses.SetCmd(COM_STMT_PREPARE)
+	ses.appendErrorDiagnostic(1000, "stale diagnostic marker")
+	execCtx := newTestExecCtx(ctx, ctrl)
+	execCtx.ses = ses
+
+	err := doComQuery(ses, execCtx, &UserInput{sql: "prepare __mo_stmt_1 from select 1; select 2"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "prepare multi statements")
+	ses.appendErrorDiagnostic(1235, err.Error())
+
+	info := ses.diagnosticsSnapshot()
+	require.Equal(t, 1, info.length())
+	require.Equal(t, []uint16{1235}, info.codes)
+	require.NotContains(t, info.msgs, "stale diagnostic marker")
+}
+
+func TestResetDiagnosticsForStatementLifecycle(t *testing.T) {
+	ses := &Session{errInfo: &errInfo{maxCnt: MoDefaultErrorCount}}
+	execCtx := &ExecCtx{}
+	input := &UserInput{}
+
+	ses.appendErrorDiagnostic(1000, "previous error")
+	resetDiagnosticsForStatement(ses, execCtx, input, &tree.ShowWarnings{})
+	require.Equal(t, 1, ses.diagnosticsSnapshot().length())
+	resetDiagnosticsForStatement(ses, execCtx, input, &tree.ShowErrors{})
+	require.Equal(t, 1, ses.diagnosticsSnapshot().length())
+
+	resetDiagnosticsForStatement(ses, execCtx, input, &tree.Select{})
+	require.Zero(t, ses.diagnosticsSnapshot().length())
+
+	ses.appendErrorDiagnostic(1001, "internal error")
+	input.isInternalInput = true
+	resetDiagnosticsForStatement(ses, execCtx, input, &tree.ShowWarnings{})
+	require.Equal(t, 1, ses.diagnosticsSnapshot().length())
+	resetDiagnosticsForStatement(ses, execCtx, input, &tree.Select{})
+	require.Equal(t, 1, ses.diagnosticsSnapshot().length())
+	input.isInternalInput = false
+
+	execCtx.inMigration = true
+	resetDiagnosticsForStatement(ses, execCtx, input, &tree.Select{})
+	require.Equal(t, 1, ses.diagnosticsSnapshot().length())
+	execCtx.inMigration = false
+
+	ses.ReplaceDerivedStmt(true)
+	resetDiagnosticsForStatement(ses, execCtx, input, &tree.Select{})
+	require.Equal(t, 1, ses.diagnosticsSnapshot().length())
+	ses.ReplaceDerivedStmt(false)
+
+	snapshot := ses.diagnosticsSnapshot()
+	snapshot.codes[0] = 2000
+	require.Equal(t, uint16(1001), ses.diagnosticsSnapshot().codes[0])
+}
+
 func TestRecordStatementResetsDivByZeroErrorMode(t *testing.T) {
 	ctx := context.Background()
 	setPu("", config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil))
@@ -2515,6 +2597,7 @@ func Test_ExecRequestStmtExecuteErrorClearsPreparedBinaryState(t *testing.T) {
 
 	ses := newTestSession(t, ctrl)
 	ec := newTestExecCtx(ctx, ctrl)
+	ses.appendErrorDiagnostic(1000, "stale diagnostic marker")
 	stmtID := uint32(321)
 	stmtName := getPrepareStmtName(stmtID)
 	st := tree.NewPrepareString(tree.Identifier(stmtName), "select ?, ?")
@@ -2556,6 +2639,7 @@ func Test_ExecRequestStmtExecuteErrorClearsPreparedBinaryState(t *testing.T) {
 	require.Equal(t, ErrorResponse, resp.category)
 	require.Nil(t, prepareStmt.params)
 	require.Empty(t, prepareStmt.getFromSendLongData)
+	require.Zero(t, ses.diagnosticsSnapshot().length())
 }
 
 func Test_CMD_FIELD_LIST(t *testing.T) {
@@ -5554,6 +5638,7 @@ func Test_ExecRequest_SidecarSuccess(t *testing.T) {
 	require.NoError(t, err)
 	ses.SetDatabaseName("testdb")
 	setRowCount(ses, ses.GetProc(), 7)
+	ses.appendErrorDiagnostic(1000, "stale diagnostic marker")
 
 	ec := newTestExecCtx(ctx, ctrl)
 	req := &Request{
@@ -5567,6 +5652,7 @@ func Test_ExecRequest_SidecarSuccess(t *testing.T) {
 	assert.Equal(t, ResultResponse, resp.category)
 	assert.Equal(t, int64(-1), ses.GetLastAffectedRows())
 	assert.Equal(t, int64(-1), ses.GetProc().GetAffectedRows())
+	assert.Zero(t, ses.diagnosticsSnapshot().length())
 }
 
 func Test_ExecRequest_SidecarError(t *testing.T) {
@@ -5591,6 +5677,7 @@ func Test_ExecRequest_SidecarError(t *testing.T) {
 	require.NoError(t, err)
 	ses.SetDatabaseName("testdb")
 	setRowCount(ses, ses.GetProc(), 7)
+	ses.appendErrorDiagnostic(1000, "stale diagnostic marker")
 
 	ec := newTestExecCtx(ctx, ctrl)
 	req := &Request{
@@ -5605,6 +5692,9 @@ func Test_ExecRequest_SidecarError(t *testing.T) {
 	assert.Equal(t, ErrorResponse, resp.category)
 	assert.Equal(t, int64(-1), ses.GetLastAffectedRows())
 	assert.Equal(t, int64(-1), ses.GetProc().GetAffectedRows())
+	// Sending the response records the current sidecar error later; ExecRequest
+	// must first discard diagnostics from the preceding statement.
+	assert.Zero(t, ses.diagnosticsSnapshot().length())
 }
 
 func TestExecRequestRewriteFailureMarksRowCountFailed(t *testing.T) {
@@ -5619,6 +5709,7 @@ func TestExecRequestRewriteFailureMarksRowCountFailed(t *testing.T) {
 			ses.rewriteEnabled.Store(true)
 			ses.ruleCache = map[string]string{}
 			setRowCount(ses, ses.GetProc(), 7)
+			ses.appendErrorDiagnostic(1000, "stale diagnostic marker")
 
 			ec := newTestExecCtx(ctx, ctrl)
 			req := &Request{
@@ -5631,6 +5722,7 @@ func TestExecRequestRewriteFailureMarksRowCountFailed(t *testing.T) {
 			assert.Equal(t, ErrorResponse, resp.category)
 			assert.Equal(t, int64(-1), ses.GetLastAffectedRows())
 			assert.Equal(t, int64(-1), ses.GetProc().GetAffectedRows())
+			assert.Zero(t, ses.diagnosticsSnapshot().length())
 		})
 	}
 }

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -2087,7 +2087,7 @@ Error information includes several elements: an error code, SQLSTATE value, and 
 */
 func (mp *MysqlProtocolImpl) sendErrPacket(errorCode uint16, sqlState, errorMessage string) error {
 	if mp.ses != nil {
-		mp.ses.GetErrInfo().push(errorCode, errorMessage)
+		mp.ses.appendErrorDiagnostic(errorCode, errorMessage)
 	}
 	errPkt := mp.makeErrPayload(errorCode, sqlState, errorMessage)
 	return mp.writePackets(errPkt)

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -727,7 +727,20 @@ func (e *errInfo) push(code uint16, msg string) {
 	e.msgs = append(e.msgs, msg)
 }
 
-func (e *errInfo) length() int {
+func (e *errInfo) reset() {
+	e.codes = e.codes[:0]
+	e.msgs = e.msgs[:0]
+}
+
+func (e *errInfo) snapshot() errInfo {
+	return errInfo{
+		codes:  append([]uint16(nil), e.codes...),
+		msgs:   append([]string(nil), e.msgs...),
+		maxCnt: e.maxCnt,
+	}
+}
+
+func (e errInfo) length() int {
 	return len(e.codes)
 }
 
@@ -1207,10 +1220,29 @@ func (ses *Session) GetOutputCallback(execCtx *ExecCtx) func(*batch.Batch, *perf
 	}
 }
 
-func (ses *Session) GetErrInfo() *errInfo {
+func (ses *Session) resetDiagnostics() {
 	ses.mu.Lock()
 	defer ses.mu.Unlock()
-	return ses.errInfo
+	if ses.errInfo != nil {
+		ses.errInfo.reset()
+	}
+}
+
+func (ses *Session) appendErrorDiagnostic(code uint16, msg string) {
+	ses.mu.Lock()
+	defer ses.mu.Unlock()
+	if ses.errInfo != nil {
+		ses.errInfo.push(code, msg)
+	}
+}
+
+func (ses *Session) diagnosticsSnapshot() errInfo {
+	ses.mu.Lock()
+	defer ses.mu.Unlock()
+	if ses.errInfo == nil {
+		return errInfo{}
+	}
+	return ses.errInfo.snapshot()
 }
 
 func (ses *Session) GenNewStmtId() uint32 {

--- a/test/distributed/cases/system/system.result
+++ b/test/distributed/cases/system/system.result
@@ -158,7 +158,7 @@ use issue_26372;
 create table t(id int primary key, uk int unique);
 insert into t values (1, 10), (2, 20);
 select * from stale_diagnostic_marker_26372;
-no such table issue_26372.stale_diagnostic_marker_26372
+SQL parser error: table "stale_diagnostic_marker_26372" does not exist
 update t set uk = 20 where id = 1;
 Duplicate entry '20' for key 'uk'
 show warnings;

--- a/test/distributed/cases/system/system.result
+++ b/test/distributed/cases/system/system.result
@@ -152,3 +152,24 @@ select * from table02 {snapshot = 'snapshot01'} limit 1;
 SQL parser error: table "table02" does not exist
 drop snapshot if exists snapshot01;
 drop database db01;
+drop database if exists issue_26372;
+create database issue_26372;
+use issue_26372;
+create table t(id int primary key, uk int unique);
+insert into t values (1, 10), (2, 20);
+select * from stale_diagnostic_marker_26372;
+no such table issue_26372.stale_diagnostic_marker_26372
+update t set uk = 20 where id = 1;
+Duplicate entry '20' for key 'uk'
+show warnings;
+Level    Code    Message
+Error    1062    Duplicate entry '20' for key 'uk'
+show warnings;
+Level    Code    Message
+Error    1062    Duplicate entry '20' for key 'uk'
+select 1;
+1
+1
+show warnings;
+Level    Code    Message
+drop database issue_26372;

--- a/test/distributed/cases/system/system.sql
+++ b/test/distributed/cases/system/system.sql
@@ -124,3 +124,16 @@ select * from table02 {snapshot = 'snapshot01'} limit 0;
 select * from table02 {snapshot = 'snapshot01'} limit 1;
 drop snapshot if exists snapshot01;
 drop database db01;
+
+drop database if exists issue_26372;
+create database issue_26372;
+use issue_26372;
+create table t(id int primary key, uk int unique);
+insert into t values (1, 10), (2, 20);
+select * from stale_diagnostic_marker_26372;
+update t set uk = 20 where id = 1;
+show warnings;
+show warnings;
+select 1;
+show warnings;
+drop database issue_26372;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26372

## What this PR does / why we need it:

- resets the session diagnostics area at each top-level non-diagnostic statement boundary, including parse and protocol paths that return before normal execution
- preserves diagnostics across `SHOW WARNINGS` / `SHOW ERRORS` and internal, migration, or derived statements
- returns a locked deep snapshot to diagnostics consumers instead of exposing mutable session slices
- adds focused unit coverage and an unskipped BVT for missing-table error -> unique-key `UPDATE` error -> repeated `SHOW WARNINGS` -> successful-statement clearing

Validation:

- `go test -count=1 ./pkg/frontend`
- seven affected tests independently passed `-race -count=100`
- `go test -race -count=1 ./pkg/frontend`
- `go build ./pkg/frontend/...`
- `go vet ./pkg/frontend/...`
- exact-head single-node MySQL protocol scenario passed
- preflight: `PASS review=PASS validation=PENDING`

QA is required after merge because this changes user-visible MySQL diagnostics behavior.
