### PR TITLE
fix ut2

### DIFF
--- a/pkg/embed/cluster.go
+++ b/pkg/embed/cluster.go
@@ -340,14 +340,7 @@ func (c *cluster) createServiceOperators(from int) error {
 		}
 		if c.options.heartbeatTimeout > 0 {
 			s.Adjust(func(cfg *ServiceConfig) {
-				switch s.serviceType {
-				case metadata.ServiceType_CN:
-					cfg.CN.HAKeeper.HeatbeatTimeout.Duration = c.options.heartbeatTimeout
-				case metadata.ServiceType_TN:
-					if cfg.TN_please_use_getTNServiceConfig != nil {
-						cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration = c.options.heartbeatTimeout
-					}
-				}
+				applyHAKeeperHeartbeatTimeout(cfg, s.serviceType, c.options.heartbeatTimeout)
 			})
 		}
 
@@ -357,6 +350,28 @@ func (c *cluster) createServiceOperators(from int) error {
 		c.services = append(c.services, s)
 	}
 	return nil
+}
+
+func applyHAKeeperHeartbeatTimeout(
+	cfg *ServiceConfig,
+	serviceType metadata.ServiceType,
+	timeout time.Duration,
+) {
+	switch serviceType {
+	case metadata.ServiceType_CN:
+		cfg.CN.HAKeeper.HeatbeatTimeout.Duration = timeout
+	case metadata.ServiceType_TN:
+		// Keep the legacy [dn] alias effective for callers that still use it.
+		if cfg.TN_please_use_getTNServiceConfig == nil {
+			cfg.TN_please_use_getTNServiceConfig = cfg.TNCompatible
+		}
+		if cfg.TN_please_use_getTNServiceConfig != nil {
+			cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration = timeout
+		}
+		if cfg.TNCompatible != nil && cfg.TNCompatible != cfg.TN_please_use_getTNServiceConfig {
+			cfg.TNCompatible.HAKeeper.HeatbeatTimeout.Duration = timeout
+		}
+	}
 }
 
 func (c *cluster) initConfigs() error {

--- a/pkg/embed/cluster.go
+++ b/pkg/embed/cluster.go
@@ -60,11 +60,12 @@ type cluster struct {
 	pendingCleanup []*operator
 
 	options struct {
-		dataPath  string
-		cn        int
-		withProxy bool
-		preStart  func(ServiceOperator)
-		testing   bool
+		dataPath         string
+		cn               int
+		withProxy        bool
+		preStart         func(ServiceOperator)
+		testing          bool
+		heartbeatTimeout time.Duration
 	}
 
 	ports struct {
@@ -336,6 +337,18 @@ func (c *cluster) createServiceOperators(from int) error {
 		)
 		if err != nil {
 			return err
+		}
+		if c.options.heartbeatTimeout > 0 {
+			s.Adjust(func(cfg *ServiceConfig) {
+				switch s.serviceType {
+				case metadata.ServiceType_CN:
+					cfg.CN.HAKeeper.HeatbeatTimeout.Duration = c.options.heartbeatTimeout
+				case metadata.ServiceType_TN:
+					if cfg.TN_please_use_getTNServiceConfig != nil {
+						cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration = c.options.heartbeatTimeout
+					}
+				}
+			})
 		}
 
 		if c.options.preStart != nil {

--- a/pkg/embed/cluster_test.go
+++ b/pkg/embed/cluster_test.go
@@ -104,6 +104,30 @@ func TestBasicCluster(t *testing.T) {
 	require.Equal(t, cn, v)
 }
 
+func TestWithHAKeeperHeartbeatTimeout(t *testing.T) {
+	timeout := 15 * time.Second
+	clusterValue, err := NewCluster(
+		WithCNCount(2),
+		WithHAKeeperHeartbeatTimeout(timeout),
+	)
+	require.NoError(t, err)
+	c := clusterValue.(*cluster)
+	defer func() {
+		require.NoError(t, c.Close())
+	}()
+
+	for _, svc := range c.services {
+		cfg := svc.GetServiceConfig()
+		switch svc.ServiceType() {
+		case metadata.ServiceType_CN:
+			require.Equal(t, timeout, cfg.CN.HAKeeper.HeatbeatTimeout.Duration)
+		case metadata.ServiceType_TN:
+			require.NotNil(t, cfg.TN_please_use_getTNServiceConfig)
+			require.Equal(t, timeout, cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration)
+		}
+	}
+}
+
 func TestSingleCNCluster(t *testing.T) {
 	c, err := NewCluster()
 	require.NoError(t, err)

--- a/pkg/embed/cluster_test.go
+++ b/pkg/embed/cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -30,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/tnservice"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,6 +116,7 @@ func TestWithHAKeeperHeartbeatTimeout(t *testing.T) {
 	c := clusterValue.(*cluster)
 	defer func() {
 		require.NoError(t, c.Close())
+		require.NoError(t, os.RemoveAll(c.options.dataPath))
 	}()
 
 	for _, svc := range c.services {
@@ -126,6 +129,16 @@ func TestWithHAKeeperHeartbeatTimeout(t *testing.T) {
 			require.Equal(t, timeout, cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration)
 		}
 	}
+}
+
+func TestHAKeeperHeartbeatTimeoutHonorsLegacyTNConfig(t *testing.T) {
+	timeout := 15 * time.Second
+	cfg := &ServiceConfig{TNCompatible: &tnservice.Config{}}
+
+	applyHAKeeperHeartbeatTimeout(cfg, metadata.ServiceType_TN, timeout)
+
+	require.Same(t, cfg.TNCompatible, cfg.TN_please_use_getTNServiceConfig)
+	require.Equal(t, timeout, cfg.getTNServiceConfig().HAKeeper.HeatbeatTimeout.Duration)
 }
 
 func TestSingleCNCluster(t *testing.T) {

--- a/pkg/embed/options.go
+++ b/pkg/embed/options.go
@@ -14,6 +14,8 @@
 
 package embed
 
+import "time"
+
 func WithConfigs(
 	configs []string,
 ) Option {
@@ -41,5 +43,14 @@ func WithCNCount(
 func WithTesting() Option {
 	return func(c *cluster) {
 		c.options.testing = true
+	}
+}
+
+// WithHAKeeperHeartbeatTimeout overrides the CN and TN HAKeeper heartbeat RPC
+// deadline for this embedded cluster. It is intended for integration tests that
+// run several services in one process under constrained CI resources.
+func WithHAKeeperHeartbeatTimeout(timeout time.Duration) Option {
+	return func(c *cluster) {
+		c.options.heartbeatTimeout = timeout
 	}
 }

--- a/pkg/tests/partition/partition_test.go
+++ b/pkg/tests/partition/partition_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/embed"
@@ -173,6 +174,10 @@ func runPartitionClusterTestWithReuse(
 			[]embed.Option{
 				embed.WithCNCount(3),
 				embed.WithTesting(),
+				// The shared test cluster runs one TN and three CNs on the same
+				// CI worker. Keep the test-only RPC deadline above transient
+				// scheduling stalls without changing production defaults.
+				embed.WithHAKeeperHeartbeatTimeout(15 * time.Second),
 			},
 			options...,
 		)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26463

## What this PR does / why we need it:

  - 新增 embed.WithHAKeeperHeartbeatTimeout。
  - partition 集成测试的 1 TN + 3 CN embedded 集群设置为 15s，缓解 CI 负载下原 3 秒 heartbeat deadline 超时。
  - timeout 在 CN/TN 服务启动前注入，新增 CN 服务也会生效。
  - 同时兼容 TN 新 [tn] 与旧 [dn] 配置别名。
  - 补充 CN/TN timeout 注入及 legacy TN 配置路径的单测。
  - 不改变生产环境 heartbeat 默认值。
