### PR TITLE
perf(disttae): eliminate per-tombstone scan allocations

### DIFF
--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -1395,27 +1395,16 @@ func (ls *LocalDisttaeDataSource) applyPStateTombstoneObjects(
 		return offsets, nil
 	}
 
-	var iter objectio.ObjectIter
-	getTombstone := func() (*objectio.ObjectStats, error) {
-		var err error
-		if iter == nil {
-			if iter, err = ls.pState.NewObjectsIter(
-				ls.snapshotTS, true, true,
-			); err != nil {
-				return nil, err
-			}
-		}
-		if iter.Next() {
-			entry := iter.Entry()
-			return &entry.ObjectStats, nil
-		}
-		return nil, nil
+	iter, err := ls.pState.NewObjectsIter(
+		ls.snapshotTS, true, true,
+	)
+	if err != nil {
+		return nil, err
 	}
-	defer func() {
-		if iter != nil {
-			iter.Close()
-		}
-	}()
+	defer iter.Close()
+
+	statsIter := reusableObjectStatsIter{iter: iter}
+	getTombstone := statsIter.next
 
 	// PXU TODO: handle len(offsets) < 10 or 20, 30?
 	if len(offsets) == 1 {
@@ -1460,6 +1449,20 @@ func (ls *LocalDisttaeDataSource) applyPStateTombstoneObjects(
 	})
 
 	return offsets, nil
+}
+
+type reusableObjectStatsIter struct {
+	iter    objectio.ObjectIter
+	current objectio.ObjectStats
+}
+
+// next returns stats that remain valid until the next call.
+func (i *reusableObjectStatsIter) next() (*objectio.ObjectStats, error) {
+	if !i.iter.Next() {
+		return nil, nil
+	}
+	i.current = i.iter.Entry().ObjectStats
+	return &i.current, nil
 }
 
 func (ls *LocalDisttaeDataSource) batchPrefetch(seqNums []uint16) {

--- a/pkg/vm/engine/disttae/local_disttae_datasource_test.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource_test.go
@@ -40,6 +40,53 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
 )
 
+type fixedObjectIter struct {
+	entries []objectio.ObjectEntry
+	pos     int
+}
+
+func (i *fixedObjectIter) Next() bool {
+	if i.pos >= len(i.entries) {
+		return false
+	}
+	i.pos++
+	return true
+}
+
+func (i *fixedObjectIter) Entry() objectio.ObjectEntry {
+	return i.entries[i.pos-1]
+}
+
+func (i *fixedObjectIter) Close() error {
+	return nil
+}
+
+func TestReusableObjectStatsIterAllocations(t *testing.T) {
+	const count = 10_000
+	entries := make([]objectio.ObjectEntry, count)
+
+	var visited int
+	allocs := testing.AllocsPerRun(10, func() {
+		visited = 0
+		iter := reusableObjectStatsIter{
+			iter: &fixedObjectIter{entries: entries},
+		}
+		for {
+			stats, err := iter.next()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stats == nil {
+				break
+			}
+			visited++
+		}
+	})
+
+	require.Equal(t, count, visited)
+	require.LessOrEqual(t, allocs, float64(2))
+}
+
 func TestRelationDataV2_MarshalAndUnMarshal(t *testing.T) {
 	location := objectio.NewRandomLocation(0, 0)
 	objID := location.ObjectId()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26465

## What this PR does / why we need it:

### Root cause

`applyPStateTombstoneObjects` adapted `objectio.ObjectIter` to a callback by doing:

```go
entry := iter.Entry()
return &entry.ObjectStats, nil
```

`ObjectIter.Entry()` returns an `ObjectEntry` by value. Taking the address of a field on that local copy makes the whole copied entry escape to the heap. The tombstone scan therefore allocated once for every physical tombstone object it visited.

This is especially expensive for MOI's metadata discovery workload: every 5 seconds it scans many workspaces and databases, repeatedly reaching this path. The allocation is not the only cause of the QA memory pressure reported in #26465, but it is a measured contributor.

### Change

- Create and close the p-state object iterator explicitly.
- Add `reusableObjectStatsIter`, which copies only `ObjectStats` into one reusable slot.
- Return a pointer to that slot. Its documented lifetime is until the next `next` call, which matches the existing callback consumer contract.
- Add an allocation regression test that scans 10,000 entries and rejects allocations proportional to entry count.

No API, storage format, or query result changes are introduced.

### Validation

#### Automated checks

- `mo-cgo-test -count=1 -timeout=10m ./pkg/vm/engine/disttae`: PASS
- `mo-cgo-test -count=100 -timeout=5m -run '^TestReusableObjectStatsIterAllocations$' ./pkg/vm/engine/disttae`: PASS
- CGo-aware `go vet ./pkg/vm/engine/disttae`: PASS
- `git diff --check origin/main...HEAD`: PASS
- `make static-check`: attempted, but the local repository `molint` binary was built with Go 1.20.5 and panics with `unsupported version: 2` while reading Go 1.26.4 export data. This is a local analyzer/toolchain compatibility failure, not a reported lint finding.

The regression test executes 10 runs of a 10,000-entry scan and permits at most 2 allocations per run, preventing restoration of per-entry allocation behavior.

#### Targeted allocation measurement

A temporary A/B benchmark of the old and new adapters over 10,000 entries measured:

| Adapter | Allocations/op | Bytes/op | Time/op |
| --- | ---: | ---: | ---: |
| Old field-address adapter | 10,001 | 1.92 MiB | ~342 µs |
| Reusable stats adapter | 1 | 32 B | ~128 µs |

The benchmark helper was diagnostic-only and is not included in this PR; the allocation invariant is retained by the committed regression test.

#### QA-scale local A/B

The local fixture was matched to the QA metadata and tombstone scale:

| Metric | Local | QA |
| --- | ---: | ---: |
| `mo_database` rows | 93 | 93 |
| `mo_tables` rows | 685 | 703 |
| `mo_columns` rows | 684 | 670 |
| MOI tenant catalog rows | 329 | 329 |
| Relevant physical tombstone objects | 1,791 | 1,795 |

The workload used the deployed MOI metadata-discovery SQL and transaction boundaries:

- 80 accounts/workspaces
- 333 databases (4.1625 average, 27 maximum per workspace)
- 8 workers
- fixed 5-second cadence
- 5 minutes per build
- 60 passes, 4,800 workspace units, and 19,980 database synchronizations per build
- zero workload failures in both runs

Both A/B servers were started with merge disabled in test-only binaries so the physical tombstone fixture remained stable. This was necessary because an earlier run was invalidated after automatic merge collapsed the tombstones between measurements. No merge-disabling instrumentation is part of this PR.

Results:

| Runtime metric over 5 minutes | Baseline | Patched | Difference |
| --- | ---: | ---: | ---: |
| `TotalAlloc` delta | 107,548,417,800 B | 103,235,140,736 B | -4,313,277,064 B (-4.01%) |
| `Mallocs` delta | 1,035,987,666 | 1,015,212,702 | -20,774,964 (-2.01%) |
| GC cycles | 52 | 51 | -1 |
| `HeapSys` delta | 1,751,482,368 B | 1,675,067,392 B | -76,414,976 B |
| Peak RSS | 5,162,270,720 B | 5,134,778,368 B | -27,492,352 B |
| Peak live heap sample | 3,133,560,144 B | 3,358,671,056 B | +225,110,912 B |

Allocation profiles close the specific defect:

- Baseline `applyPStateTombstoneObjects.func1`: 23,509,870 flat allocation objects and 4,304.79 MiB flat allocated space.
- Patched build: the allocation site is absent from both flat allocation profiles.

### Scope of the conclusion

This A/B proves that the patch removes the per-tombstone-object heap allocation under a workload and physical tombstone scale closely matching QA. It does **not** by itself prove that the complete QA CN OOM is resolved:

- the local baseline did not OOM with a 24 GiB limit;
- cumulative allocation fell materially, but peak RSS changed only slightly and the sampled peak live heap was noisy;
- #26465 also contains a high-frequency, broad metadata-discovery workload that should be evaluated independently.

Therefore this PR references #26465 but does not close it.
