### PR TITLE
fix(cn): react to cgroup memory pressure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/FastFilter/xorfilter v0.5.1
 	github.com/K-Phoen/grabana v0.21.19
 	github.com/K-Phoen/sdk v0.12.3
-	github.com/KimMachineGun/automemlimit v0.6.0
 	github.com/RoaringBitmap/roaring/v2 v2.16.0
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.34
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible
@@ -147,13 +146,11 @@ require (
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/cilium/ebpf v0.9.1 // indirect
 	github.com/clbanning/mxj v1.8.4 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble v0.0.0-20220407171941-2120d145e292 // indirect
 	github.com/cockroachdb/redact v1.1.3 // indirect
-	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
@@ -165,7 +162,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
@@ -215,9 +211,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/opencontainers/runtime-spec v1.0.2 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20201029093017-5a7df2af2ac7 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
@@ -231,7 +225,6 @@ require (
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartystreets/assertions v1.13.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/K-Phoen/grabana v0.21.19 h1:tJjRO8nN9JrFjLoQGtOB9P5ILoqENZZGAtt3nK+Ry
 github.com/K-Phoen/grabana v0.21.19/go.mod h1:B7gxVxacQUgHWmgqduf4WPZoKYHO1mvZnRVCoyQiwdw=
 github.com/K-Phoen/sdk v0.12.3 h1:ScutEQASc9VEKJCm3OjIMD82BIS9B2XtNg3gEf6Gs+M=
 github.com/K-Phoen/sdk v0.12.3/go.mod h1:qmM0wO23CtoDux528MXPpYvS4XkRWkWX6rvX9Za8EVU=
-github.com/KimMachineGun/automemlimit v0.6.0 h1:p/BXkH+K40Hax+PuWWPQ478hPjsp9h1CPDhLlA3Z37E=
-github.com/KimMachineGun/automemlimit v0.6.0/go.mod h1:T7xYht7B8r6AG/AqFcUdc7fzd2bIdBKmepfP2S1svPY=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
@@ -153,8 +151,6 @@ github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNE
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
-github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
-github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -201,8 +197,6 @@ github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3H
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
-github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpegeric/pdftotext-go v0.0.0-20241112123704-49cb86a3790e h1:tQSCiEjYPRU+AuuVR+zd+xYVOsEqX1clPhmIAM6FCHU=
 github.com/cpegeric/pdftotext-go v0.0.0-20241112123704-49cb86a3790e/go.mod h1:zt7uTOYu0EEeKatGaTi9JiP0I9ePHpDvjAwpfPXh/N0=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
@@ -276,8 +270,6 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
-github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsevents v0.1.1 h1:/125uxJvvoSDDBPen6yUZbil8J9ydKZnnl3TWWmvnkw=
 github.com/fsnotify/fsevents v0.1.1/go.mod h1:+d+hS27T6k5J8CRaPLKFgwKYcpS7GwW3Ule9+SC2ZRc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -319,8 +311,6 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
-github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -697,8 +687,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/opencontainers/runtime-spec v1.0.2 h1:UfAcuLBJB9Coz72x1hgl8O5RVzTdNiaglX6v2DM6FI0=
-github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
@@ -707,8 +695,6 @@ github.com/parquet-go/parquet-go v0.25.1 h1:l7jJwNM0xrk0cnIIptWMtnSnuxRkwq53S+Po
 github.com/parquet-go/parquet-go v0.25.1/go.mod h1:AXBuotO1XiBtcqJb/FKFyjBG4aqa3aQAAWF3ZPzCanY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
-github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -1115,7 +1101,6 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -83,6 +83,7 @@ const (
 	rssCacheAdmissionPressureTTL = 2 * time.Minute
 	rssCachePressureTargetOwner  = "cn-rss"
 	bootstrapRetryInterval       = 100 * time.Millisecond
+	memoryPressureSampleInterval = time.Second
 )
 
 var (
@@ -397,9 +398,32 @@ func (s *service) Start() error {
 		return err
 	}
 
+	if err := s.stopper.RunNamedTask("memory pressure monitor", func(ctx context.Context) {
+		runMemoryPressureMonitor(ctx, memoryPressureSampleInterval, s.CNMemoryThrottler.ForceRefresh)
+	}); err != nil {
+		return err
+	}
+
 	s.task.runnerReady.Store(true)
 	s.startTaskRunner()
 	return nil
+}
+
+func runMemoryPressureMonitor(
+	ctx context.Context,
+	interval time.Duration,
+	refresh func(),
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refresh()
+		}
+	}
 }
 
 func (s *service) Close() error {

--- a/pkg/cnservice/server_test.go
+++ b/pkg/cnservice/server_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -50,6 +51,20 @@ import (
 
 type closeErrorMOServer struct {
 	err error
+}
+
+func TestRunMemoryPressureMonitor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var calls atomic.Int32
+	runMemoryPressureMonitor(ctx, time.Millisecond, func() {
+		if calls.Add(1) == 3 {
+			cancel()
+		}
+	})
+
+	require.GreaterOrEqual(t, calls.Load(), int32(3))
 }
 
 func (s closeErrorMOServer) GetRoutineManager() *frontend.RoutineManager {

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -698,7 +698,7 @@ type service struct {
 		client  cnclient.PipelineClient
 	}
 
-	CNMemoryThrottler rscthrottler.RSCThrottler
+	CNMemoryThrottler rscthrottler.RefreshableRSCThrottler
 }
 
 func dumpCnConfig(cfg Config) (map[string]*logservicepb.ConfigItem, error) {

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -24,8 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/common/system"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
@@ -36,6 +36,7 @@ import (
 
 const (
 	refreshMaxInterval     = time.Second * 10
+	refreshLogInterval     = time.Minute
 	rssScavengeInterval    = time.Minute
 	rssCacheEvictTimeout   = time.Second * 10
 	rssScavengeVisibleRate = 0.70
@@ -78,6 +79,11 @@ type RSCThrottler interface {
 	Available() int64
 }
 
+type RefreshableRSCThrottler interface {
+	RSCThrottler
+	ForceRefresh()
+}
+
 type memThrottler struct {
 	limit atomic.Int64
 	rss   atomic.Int64
@@ -95,7 +101,11 @@ type memThrottler struct {
 	proc             *process.Process
 
 	cgroup atomic.Uint64
-	total  atomic.Uint64
+	// cgroupUsage is sampled from the same cgroup that imposes cgroup's
+	// effective limit. It includes kernel and page-cache charges that process
+	// RSS cannot observe.
+	cgroupUsage atomic.Uint64
+	total       atomic.Uint64
 
 	actualTotalMemory atomic.Uint64
 
@@ -103,6 +113,7 @@ type memThrottler struct {
 	limitRate float64
 
 	lastRefresh        atomic.Int64
+	lastRefreshLog     atomic.Int64
 	lastRSSScavenge    atomic.Int64
 	lastRSSCacheEvict  atomic.Int64
 	lastRSSCacheTarget atomic.Int64
@@ -132,13 +143,15 @@ type memThrottler struct {
 
 func (m *memThrottler) String() string {
 	return fmt.Sprintf(
-		"{%s: limit=%s, total=%s, available=%s, cgroup=%s, rss=%s, pinned=%s, pinnedRate=%f, limitRate=%f, isConstLimit=%v}",
+		"{%s: limit=%s, total=%s, available=%s, cgroup=%s, cgroup-usage=%s, rss=%s, physical-used=%s, pinned=%s, pinnedRate=%f, limitRate=%f, isConstLimit=%v}",
 		m.name,
 		common.HumanReadableBytes(int(m.limit.Load())),
 		common.HumanReadableBytes(int(m.total.Load())),
 		common.HumanReadableBytes(int(m.Available())),
 		common.HumanReadableBytes(int(m.cgroup.Load())),
+		common.HumanReadableBytes(int(m.cgroupUsage.Load())),
 		common.HumanReadableBytes(int(m.rss.Load())),
+		common.HumanReadableBytes(int(m.physicalMemoryUsed())),
 		common.HumanReadableBytes(int(m.reserved.Load())),
 		m.pinnedRate(),
 		m.limitRate,
@@ -180,6 +193,13 @@ func (m *memThrottler) refresh(force bool) {
 	)
 
 	defer func() {
+		lastLog := m.lastRefreshLog.Load()
+		if err == nil && time.Duration(now-lastLog) < refreshLogInterval {
+			return
+		}
+		if err == nil && !m.lastRefreshLog.CompareAndSwap(lastLog, now) {
+			return
+		}
 		logutil.Info(
 			fmt.Sprintf("%s-Refresh", MemoryThrottlerLogHeader),
 			zap.String("detail", m.String()),
@@ -188,7 +208,9 @@ func (m *memThrottler) refresh(force bool) {
 	}()
 
 	total = objectio.TotalMem()
-	cgroup, err = memlimit.FromCgroup()
+	cgroup, cgroupUsage := system.CgroupMemoryLimitAndUsage()
+	m.cgroup.Store(cgroup)
+	m.cgroupUsage.Store(cgroupUsage)
 
 	if cgroup != 0 && cgroup < total {
 		m.actualTotalMemory.Store(cgroup)
@@ -241,14 +263,21 @@ func (m *memThrottler) refresh(force bool) {
 		)
 		m.rssReservedBase.Store(base)
 		m.rssMpoolLiveBase.Store(liveBase)
-		m.tryScavengeRSS(now, rss)
+		m.tryScavengeRSS(now, m.physicalMemoryUsed())
 	}
 
-	m.cgroup.Store(cgroup)
 	m.total.Store(total)
 }
 
-func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
+func (m *memThrottler) physicalMemoryUsed() int64 {
+	cgroupUsage := m.cgroupUsage.Load()
+	if cgroupUsage > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return max(m.rss.Load(), int64(cgroupUsage))
+}
+
+func (m *memThrottler) tryScavengeRSS(now int64, physicalUsed int64) {
 	if !m.options.enableRSSScavenging {
 		return
 	}
@@ -260,7 +289,7 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	if visible < 0 {
 		visible = 0
 	}
-	rssRate := float64(rss) / float64(actualMaxMemory)
+	usedRate := float64(physicalUsed) / float64(actualMaxMemory)
 
 	var (
 		prevState              rssPressureState
@@ -276,7 +305,7 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 
 	m.rssScavengeMu.Lock()
 	prevState = rssPressureState(m.rssPressureState.Load())
-	nextState = nextRSSPressureState(prevState, rssRate)
+	nextState = nextRSSPressureState(prevState, usedRate)
 	cacheTargetPercent = rssPressureCacheTarget(nextState)
 
 	if nextState != prevState {
@@ -324,7 +353,7 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	m.rssScavengeMu.Unlock()
 
 	needFreeOSMemory := nextState != rssPressureNone &&
-		float64(visible) < float64(rss)*rssScavengeVisibleRate
+		float64(visible) < float64(physicalUsed)*rssScavengeVisibleRate
 	if needFreeOSMemory {
 		last := m.lastRSSScavenge.Load()
 		if time.Duration(now-last) > rssScavengeInterval &&
@@ -338,7 +367,9 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	metric.FSCachePressureTriggerCounter.Inc()
 	logutil.Info(
 		fmt.Sprintf("%s-RSSScavenge", MemoryThrottlerLogHeader),
-		zap.String("rss", common.HumanReadableBytes(int(rss))),
+		zap.String("rss", common.HumanReadableBytes(int(m.rss.Load()))),
+		zap.String("cgroup-usage", common.HumanReadableBytes(int(m.cgroupUsage.Load()))),
+		zap.String("physical-used", common.HumanReadableBytes(int(physicalUsed))),
 		zap.String("visible", common.HumanReadableBytes(int(visible))),
 		zap.String("actual-total-memory", common.HumanReadableBytes(int(actualMaxMemory))),
 		zap.Bool("free-os-memory", shouldFreeOSMemory),
@@ -426,7 +457,7 @@ func (m *memThrottler) Available() int64 {
 	var (
 		avail    int64
 		limit    = m.limit.Load()
-		rss      = m.rss.Load()
+		used     = m.physicalMemoryUsed()
 		reserved = m.reserved.Load()
 
 		actualMaxMemory = int64(m.actualTotalMemory.Load())
@@ -441,18 +472,18 @@ func (m *memThrottler) Available() int64 {
 			}
 
 			if info, err := m.proc.MemoryInfo(); err == nil {
-				rss = int64(info.RSS)
-				m.rss.Store(rss)
+				m.rss.Store(int64(info.RSS))
+				used = m.physicalMemoryUsed()
 			}
 		}
 
-		return max(0, limit-rss-reserved)
+		return max(0, limit-used-reserved)
 	}
 
-	if actualMaxMemory-rss >= limit {
+	if actualMaxMemory-used >= limit {
 		avail = limit - reserved
 	} else {
-		avail = actualMaxMemory - rss - reserved
+		avail = actualMaxMemory - used - reserved
 	}
 
 	return max(0, avail)
@@ -522,7 +553,7 @@ func NewMemThrottler(
 	name string,
 	limitRate float64,
 	opts ...MemThrottlerOption,
-) RSCThrottler {
+) RefreshableRSCThrottler {
 
 	throttler := &memThrottler{
 		limitRate: limitRate,
@@ -695,7 +726,7 @@ func cnFlushS3PhysicalAvailable(throttler *memThrottler, reserved int64) int64 {
 	liveBase := throttler.rssMpoolLiveBase.Load()
 	currentLive := mpool.GlobalStats().NumCurrBytes.Load()
 	covered := currentCNFlushS3RSSCovered(base, liveBase, reserved, currentLive)
-	used := throttler.rss.Load()
+	used := throttler.physicalMemoryUsed()
 	if delta := reserved - covered; delta > 0 {
 		used += delta
 	}
@@ -708,7 +739,7 @@ func cnFlushS3ProjectedPhysicalUsed(throttler *memThrottler, reserved int64) int
 	liveBase := throttler.rssMpoolLiveBase.Load()
 	currentLive := mpool.GlobalStats().NumCurrBytes.Load()
 	covered := currentCNFlushS3RSSCovered(base, liveBase, reserved, currentLive)
-	used := throttler.rss.Load()
+	used := throttler.physicalMemoryUsed()
 	if delta := reserved - covered; delta > 0 {
 		used += delta
 	}

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -391,6 +391,36 @@ func TestMemThrottlerRSSScavengingDisabled(t *testing.T) {
 	require.Equal(t, int32(0), calls.Load())
 }
 
+func TestMemThrottlerUsesCgroupMemoryPressure(t *testing.T) {
+	oldFreeOSMemory := freeOSMemory
+	defer func() { freeOSMemory = oldFreeOSMemory }()
+	freeOSMemory = func() {}
+
+	const gib = int64(mpool.GB)
+	throttler := &memThrottler{limitRate: 0.90}
+	throttler.options.enableRSSScavenging = true
+	throttler.actualTotalMemory.Store(uint64(36 * gib))
+	throttler.limit.Store(32 * gib)
+	throttler.rss.Store(3042 * gib / 100) // 84.5%: below the RSS soft threshold.
+	throttler.cgroupUsage.Store(uint64(3377 * gib / 100))
+
+	throttler.tryScavengeRSS(time.Now().UnixNano(), throttler.physicalMemoryUsed())
+
+	require.Equal(t, rssPressureHard, rssPressureState(throttler.rssPressureState.Load()))
+	require.Equal(t, 3377*gib/100, throttler.physicalMemoryUsed())
+	require.Equal(t, 36*gib-3377*gib/100, throttler.Available())
+}
+
+func TestCNFlushS3PhysicalMemoryUsesCgroupUsage(t *testing.T) {
+	throttler := &memThrottler{}
+	throttler.actualTotalMemory.Store(100)
+	throttler.rss.Store(80)
+	throttler.cgroupUsage.Store(94)
+
+	require.Equal(t, int64(6), cnFlushS3PhysicalAvailable(throttler, 0))
+	require.Equal(t, int64(94), cnFlushS3ProjectedPhysicalUsed(throttler, 0))
+}
+
 func TestAcquirePolicyForCNFlushS3(t *testing.T) {
 	t.Run("allow under high rss when pool has headroom", func(t *testing.T) {
 		throttler := &memThrottler{limitRate: 0.90}

--- a/pkg/common/system/system.go
+++ b/pkg/common/system/system.go
@@ -79,28 +79,42 @@ func MemoryTotal() uint64 {
 	return memoryTotal.Load()
 }
 
-// CgroupMemoryLimit returns the memory limit for the current process cgroup,
-// including when the process is not PID 1 (for example a systemd scope or a
-// nested container cgroup). Zero means unavailable.
-func CgroupMemoryLimit() uint64 {
-	if limit := hierarchicalCgroupMemoryLimit(pid); limit > 0 {
-		return limit
+// CgroupMemoryLimitAndUsage returns the memory limit and current usage from
+// the tightest limiting cgroup in the current process hierarchy. Returning a
+// matched pair matters for nested cgroups: a parent can impose the effective
+// limit and its usage includes memory charged outside the process' leaf
+// cgroup. Zero means unavailable.
+func CgroupMemoryLimitAndUsage() (limit uint64, usage uint64) {
+	if limit, usage = hierarchicalCgroupMemoryLimitAndUsage(pid); limit > 0 {
+		return
 	}
-	limit, err := cgroup.GetMemLimit(pid)
-	if err != nil || limit <= 0 {
-		return 0
+	rawLimit, limitErr := cgroup.GetMemLimit(pid)
+	rawUsage, usageErr := cgroup.GetMemUsage(pid)
+	if limitErr != nil || rawLimit <= 0 {
+		return 0, 0
 	}
-	return uint64(limit)
+	limit = uint64(rawLimit)
+	if usageErr == nil && rawUsage > 0 {
+		usage = uint64(rawUsage)
+	}
+	return
 }
 
-func hierarchicalCgroupMemoryLimit(pid int) uint64 {
+// CgroupMemoryLimit returns the effective memory limit for the current
+// process cgroup. Zero means unavailable.
+func CgroupMemoryLimit() uint64 {
+	limit, _ := CgroupMemoryLimitAndUsage()
+	return limit
+}
+
+func hierarchicalCgroupMemoryLimitAndUsage(pid int) (limit uint64, usage uint64) {
 	cgroupData, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
-		return 0
+		return 0, 0
 	}
 	mountData, err := os.ReadFile(fmt.Sprintf("/proc/%d/mountinfo", pid))
 	if err != nil {
-		return 0
+		return 0, 0
 	}
 
 	v2Path := ""
@@ -135,18 +149,22 @@ func hierarchicalCgroupMemoryLimit(pid int) uint64 {
 		case "cgroup2":
 			if v2Path != "" {
 				if dir, ok := cgroupDirectory(mountPoint, mountRoot, v2Path); ok {
-					return minHierarchicalLimit(dir, mountPoint, "memory.max")
+					return minHierarchicalLimitAndUsage(
+						dir, mountPoint, "memory.max", "memory.current",
+					)
 				}
 			}
 		case "cgroup":
 			if v1MemoryPath != "" && strings.Contains(","+right[2]+",", ",memory,") {
 				if dir, ok := cgroupDirectory(mountPoint, mountRoot, v1MemoryPath); ok {
-					return minHierarchicalLimit(dir, mountPoint, "memory.limit_in_bytes")
+					return minHierarchicalLimitAndUsage(
+						dir, mountPoint, "memory.limit_in_bytes", "memory.usage_in_bytes",
+					)
 				}
 			}
 		}
 	}
-	return 0
+	return 0, 0
 }
 
 func cgroupDirectory(mountPoint, mountRoot, processPath string) (string, bool) {
@@ -160,16 +178,24 @@ func cgroupDirectory(mountPoint, mountRoot, processPath string) (string, bool) {
 }
 
 func minHierarchicalLimit(dir, mountPoint, filename string) uint64 {
+	limit, _ := minHierarchicalLimitAndUsage(dir, mountPoint, filename, "")
+	return limit
+}
+
+func minHierarchicalLimitAndUsage(
+	dir, mountPoint, limitFilename, usageFilename string,
+) (minimum uint64, usage uint64) {
 	dir = filepath.Clean(dir)
 	mountPoint = filepath.Clean(mountPoint)
-	var minimum uint64
 	for {
-		data, err := os.ReadFile(filepath.Join(dir, filename))
+		data, err := os.ReadFile(filepath.Join(dir, limitFilename))
 		if err == nil {
 			value := strings.TrimSpace(string(data))
 			if value != "" && value != "max" {
-				if limit, parseErr := strconv.ParseUint(value, 10, 64); parseErr == nil && limit > 0 && (minimum == 0 || limit < minimum) {
+				if limit, parseErr := strconv.ParseUint(value, 10, 64); parseErr == nil &&
+					limit > 0 && (minimum == 0 || limit <= minimum) {
 					minimum = limit
+					usage = readCgroupUint(filepath.Join(dir, usageFilename))
 				}
 			}
 		}
@@ -182,7 +208,22 @@ func minHierarchicalLimit(dir, mountPoint, filename string) uint64 {
 		}
 		dir = parent
 	}
-	return minimum
+	return
+}
+
+func readCgroupUint(path string) uint64 {
+	if path == "" {
+		return 0
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return value
 }
 
 // MemoryAvailable returns the available size of memory of this node.

--- a/pkg/common/system/system_test.go
+++ b/pkg/common/system/system_test.go
@@ -71,6 +71,39 @@ func TestMinHierarchicalCgroupLimit(t *testing.T) {
 	require.Equal(t, filepath.Join(root, "tenant", "query"), dir)
 }
 
+func TestMinHierarchicalCgroupLimitAndUsage(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Join(root, "tenant")
+	child := filepath.Join(parent, "query")
+	require.NoError(t, os.MkdirAll(child, 0o700))
+
+	write := func(dir, name, value string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(value+"\n"), 0o600))
+	}
+	write(root, "memory.max", "max")
+	write(root, "memory.current", "100")
+	write(parent, "memory.max", "2147483648")
+	write(parent, "memory.current", "1500000000")
+	write(child, "memory.max", "3221225472")
+	write(child, "memory.current", "1200000000")
+
+	limit, usage := minHierarchicalLimitAndUsage(
+		child, root, "memory.max", "memory.current",
+	)
+	require.Equal(t, uint64(2<<30), limit)
+	require.Equal(t, uint64(1500000000), usage)
+
+	// If the leaf becomes the tighter cgroup, usage must be sampled from the
+	// leaf as well instead of being paired with its former parent limit.
+	write(child, "memory.max", "1073741824")
+	write(child, "memory.current", "900000000")
+	limit, usage = minHierarchicalLimitAndUsage(
+		child, root, "memory.max", "memory.current",
+	)
+	require.Equal(t, uint64(1<<30), limit)
+	require.Equal(t, uint64(900000000), usage)
+}
+
 // Benchmark_GoRutinues
 // goos: darwin
 // goarch: arm64


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement

## Which issue(s) this PR fixes:

Related to #26465

## What this PR does / why we need it:

CN memory pressure handling currently samples process RSS only when the
resource throttler is used. This misses two parts of the actual OOM boundary:

1. cgroup charges outside process RSS, including page cache and kernel slab;
2. read-only workloads that do not acquire resources through the throttler and
   can therefore leave pressure state stale for tens of seconds.

The QA workload from #26465 exposed both gaps. A 36 GiB CN reached about
35.1 GiB cgroup working set while process RSS was still about 32.1 GiB. The
hard-pressure state was entered only seconds before the container was
OOM-killed. One affected CN currently has 4.4 GiB of cgroup slab alone, mainly
associated with 11,107,273 disk-cache files, which RSS cannot observe.

This PR:

- reads the effective cgroup memory limit and usage as a matched pair from the
  tightest limiting cgroup ancestor (cgroup v1 and v2);
- uses `max(process RSS, cgroup usage)` for cache pressure, available-memory
  calculation, and the CN S3 physical-memory backstop;
- starts one stopper-managed, one-second CN pressure sampler so read-only
  workloads cannot leave the pressure state stale;
- rate-limits routine refresh logs while retaining immediate pressure
  transition logs;
- removes the now-unused `automemlimit` dependency.

Validation:

- `go test ./pkg/common/system ./pkg/common/rscthrottler ./pkg/cnservice -count=1`
- `go test -race ./pkg/common/system ./pkg/common/rscthrottler ./pkg/cnservice -count=1`
- `go vet ./pkg/common/system ./pkg/common/rscthrottler ./pkg/cnservice`
- cross-compiled `pkg/common/system` for Linux and ran it in an existing
  Alpine container with `--memory 256m`; the detector returned the exact
  268,435,456-byte limit and a non-zero usage below that limit.

The full MatrixOne container A/B is not included yet because the local builder
image cannot currently be fetched from Docker Hub (`auth.docker.io` TLS
failure). The component tests and real Linux cgroup test above pass; this PR is
kept as draft until full CI and workload validation complete.
