### PR TITLE
test: cover MergeCTE buffered batches after reset

### DIFF
--- a/pkg/sql/colexec/mergecte/mergecte_test.go
+++ b/pkg/sql/colexec/mergecte/mergecte_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -154,6 +155,65 @@ func TestAuditMergeCTERecursiveErrorThenRetryDoesNotEmitStaleBatch(t *testing.T)
 	require.Nil(t, arg.ctr.freeBats)
 	require.Nil(t, arg.ctr.bats)
 	require.Nil(t, arg.ctr.buf)
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestMergeCTEResetDropsBufferedRecursiveBatches(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	arg := &MergeCTE{NodeCnt: 1}
+	cleaned := false
+	t.Cleanup(func() {
+		if cleaned {
+			return
+		}
+		freeMergeCTEChildren(arg, proc, true)
+		arg.Free(proc, true, nil)
+		proc.Free()
+	})
+
+	makeBatch := func(value int64) *batch.Batch {
+		bat := batch.NewWithSize(1)
+		bat.SetVector(0, testutil.MakeInt64Vector([]int64{value}, nil, proc.Mp()))
+		bat.SetRowCount(1)
+		return bat
+	}
+	firstRecursive := makeBatch(10)
+	lastRecursive := makeBatch(20)
+	lastRecursive.SetLast()
+	arg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{makeBatch(1)}))
+	arg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{firstRecursive, lastRecursive}))
+	require.NoError(t, arg.Prepare(proc))
+
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1}, vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[0]))
+
+	result, err = vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.True(t, result.Batch.Last())
+
+	result, err = vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.Equal(t, []int64{10}, vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[0]))
+	require.Len(t, arg.ctr.bats, 1)
+	require.Equal(t, []int64{20}, vector.MustFixedColWithTypeCheck[int64](arg.ctr.bats[0].Vecs[0]))
+
+	arg.Reset(proc, false, nil)
+	require.Nil(t, arg.ctr.bats)
+	require.Nil(t, arg.ctr.buf)
+	freeMergeCTEChildren(arg, proc, false)
+	arg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{makeBatch(99)}))
+	arg.AppendChild(colexec.NewMockOperator())
+	require.NoError(t, arg.Prepare(proc))
+
+	result, err = vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.Equal(t, []int64{99}, vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[0]))
+
+	freeMergeCTEChildren(arg, proc, false)
+	arg.Free(proc, false, nil)
+	proc.Free()
+	cleaned = true
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26285

## What this PR does / why we need it:

PR #26406 already made `MergeCTE.Reset` discard buffered output aliases from the previous execution. This PR adds the exact regression coverage requested by #26285:

- run an initial execution with values `1`, `10`, and `20`;
- stop after returning `10`, while `20` remains buffered;
- reset and reuse the operator with a new initial value of `99`;
- verify that the next execution returns `99` instead of the stale buffered `20`;
- verify that all owned batches are released.

Validation:

- focused regression test, `count=10`;
- focused race test, `count=100`;
- full `pkg/sql/colexec/mergecte` tests with and without the race detector;
- `pkg/sql/colexec/mergerecursive` tests;
- `go build` and `go vet` for both packages;
- `mergecte` package coverage: 80.7%.
