### PR TITLE
ci: forward issue reopened events to WeWork Robot

### DIFF
--- a/.github/workflows/robot.yml
+++ b/.github/workflows/robot.yml
@@ -3,7 +3,7 @@ name: WeWork Robot
 # Controls when the workflow will run
 on:
   issues:
-    types: [closed, assigned, opened]
+    types: [closed, assigned, opened, reopened]
   schedule:
     - cron: '30 8 * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add `reopened` to WeWork Robot issue trigger types so the reusable CI `block-qa-reopen` job can run.

Depends on: matrixorigin/CI `add_reopen_bot` (block QA reopen policy).

## Test plan
- [ ] After CI side merges (or temporarily point `uses:` at the CI branch), reopen a closed issue as `heni02` / `Ariznawlll` and confirm robot workflow runs on `reopened`
- [ ] Confirm existing `closed` / `assigned` / `opened` / schedule paths still trigger


Made with [Cursor](https://cursor.com)