### PR TITLE
fix: avoid mutating shared batches in limit

### DIFF
--- a/pkg/sql/colexec/limit/limit.go
+++ b/pkg/sql/colexec/limit/limit.go
@@ -91,6 +91,10 @@ func (limit *Limit) Call(proc *process.Process) (vm.CallResult, error) {
 		if err != nil {
 			return vm.CancelResult, err
 		}
+		limit.ctr.buf.Attrs = append(limit.ctr.buf.Attrs[:0], bat.Attrs...)
+		limit.ctr.buf.Recursive = bat.Recursive
+		limit.ctr.buf.ShuffleIDX = bat.ShuffleIDX
+		limit.ctr.buf.SetRowCount(bat.RowCount())
 		batch.SetLength(limit.ctr.buf, int(limit.ctr.limit-limit.ctr.seen))
 		result.Batch = limit.ctr.buf
 		result.Status = vm.ExecStop

--- a/pkg/sql/colexec/limit/limit.go
+++ b/pkg/sql/colexec/limit/limit.go
@@ -84,9 +84,15 @@ func (limit *Limit) Call(proc *process.Process) (vm.CallResult, error) {
 	length := bat.RowCount()
 	newSeen := limit.ctr.seen + uint64(length)
 	if newSeen >= limit.ctr.limit { // limit - seen
-		// reset length is ok.
-		// we do not change the batch.Vecs & batch.Agg from pre Operator
-		batch.SetLength(bat, int(limit.ctr.limit-limit.ctr.seen))
+		if limit.ctr.buf != nil {
+			limit.ctr.buf.CleanOnlyData()
+		}
+		limit.ctr.buf, err = limit.ctr.buf.AppendWithCopy(proc.Ctx, proc.Mp(), bat)
+		if err != nil {
+			return vm.CancelResult, err
+		}
+		batch.SetLength(limit.ctr.buf, int(limit.ctr.limit-limit.ctr.seen))
+		result.Batch = limit.ctr.buf
 		result.Status = vm.ExecStop
 	}
 	limit.ctr.seen = newSeen

--- a/pkg/sql/colexec/limit/limit_test.go
+++ b/pkg/sql/colexec/limit/limit_test.go
@@ -138,6 +138,7 @@ func TestLimit(t *testing.T) {
 func TestLimitDoesNotMutateInputBatch(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	input := colexec.MakeMockBatchs(proc.Mp())
+	input.ShuffleIDX = 3
 	inputRows := input.RowCount()
 	inputLengths := make([]int, len(input.Vecs))
 	for i := range input.Vecs {
@@ -152,13 +153,32 @@ func TestLimitDoesNotMutateInputBatch(t *testing.T) {
 	result, err := arg.Call(proc)
 	require.NoError(t, err)
 	require.Equal(t, 1, result.Batch.RowCount())
+	require.Equal(t, int32(3), result.Batch.ShuffleIDX)
 	require.Equal(t, inputRows, input.RowCount())
 	for i := range input.Vecs {
 		require.Equal(t, inputLengths[i], input.Vecs[i].Length())
 	}
 
+	arg.Reset(proc, false, nil)
+	secondInput := colexec.MakeMockBatchs(proc.Mp())
+	secondInput.ShuffleIDX = 7
+	secondChild := colexec.NewMockOperator().WithBatchs([]*batch.Batch{secondInput})
+	arg.Children = nil
+	arg.AppendChild(secondChild)
+	require.NoError(t, arg.Prepare(proc))
+
+	result, err = arg.Call(proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Batch.RowCount())
+	require.Equal(t, int32(7), result.Batch.ShuffleIDX)
+	require.Equal(t, secondInput.RowCount(), inputRows)
+	for i := range secondInput.Vecs {
+		require.Equal(t, inputLengths[i], secondInput.Vecs[i].Length())
+	}
+
 	arg.Free(proc, false, nil)
 	child.Free(proc, false, nil)
+	secondChild.Free(proc, false, nil)
 	arg.Release()
 	proc.Free()
 	require.Zero(t, proc.Mp().CurrNB())

--- a/pkg/sql/colexec/limit/limit_test.go
+++ b/pkg/sql/colexec/limit/limit_test.go
@@ -135,6 +135,35 @@ func TestLimit(t *testing.T) {
 	}
 }
 
+func TestLimitDoesNotMutateInputBatch(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	input := colexec.MakeMockBatchs(proc.Mp())
+	inputRows := input.RowCount()
+	inputLengths := make([]int, len(input.Vecs))
+	for i := range input.Vecs {
+		inputLengths[i] = input.Vecs[i].Length()
+	}
+
+	arg := NewArgument().WithLimit(plan2.MakePlan2Uint64ConstExprWithType(1))
+	child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{input})
+	arg.AppendChild(child)
+	require.NoError(t, arg.Prepare(proc))
+
+	result, err := arg.Call(proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Batch.RowCount())
+	require.Equal(t, inputRows, input.RowCount())
+	for i := range input.Vecs {
+		require.Equal(t, inputLengths[i], input.Vecs[i].Length())
+	}
+
+	arg.Free(proc, false, nil)
+	child.Free(proc, false, nil)
+	arg.Release()
+	proc.Free()
+	require.Zero(t, proc.Mp().CurrNB())
+}
+
 func BenchmarkLimit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tcs := []limitTestCase{

--- a/pkg/sql/colexec/limit/types.go
+++ b/pkg/sql/colexec/limit/types.go
@@ -29,6 +29,7 @@ type container struct {
 	seen          uint64 // seen is the number of tuples seen so far
 	limit         uint64
 	limitExecutor colexec.ExpressionExecutor
+	buf           *batch.Batch
 }
 type Limit struct {
 	ctr       container
@@ -84,6 +85,10 @@ func (limit *Limit) Free(proc *process.Process, pipelineFailed bool, err error) 
 	if limit.ctr.limitExecutor != nil {
 		limit.ctr.limitExecutor.Free()
 		limit.ctr.limitExecutor = nil
+	}
+	if limit.ctr.buf != nil {
+		limit.ctr.buf.Clean(proc.Mp())
+		limit.ctr.buf = nil
 	}
 }
 

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -4850,7 +4850,7 @@ func TestRenameSrcTable(t *testing.T) {
 
 	tableID := rel.GetTableID(ctxWithTimeout)
 
-	txn.Commit(ctxWithTimeout)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
 	// init cdc executor
 	checkLeaseStub := gostub.Stub(
@@ -4884,7 +4884,7 @@ func TestRenameSrcTable(t *testing.T) {
 	require.NoError(t, err)
 	cdcExecutor.SetRpcHandleFn(taeHandler.GetRPCHandle().HandleGetChangedTableList)
 
-	cdcExecutor.Start()
+	require.NoError(t, cdcExecutor.Start())
 	defer cdcExecutor.Stop()
 	registerFn := func(indexName string) {
 		txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
@@ -4903,17 +4903,17 @@ func TestRenameSrcTable(t *testing.T) {
 			},
 			false,
 		)
-		assert.True(t, ok)
-		assert.NoError(t, err)
-		assert.NoError(t, txn.Commit(ctxWithTimeout))
+		require.True(t, ok)
+		require.NoError(t, err)
+		require.NoError(t, txn.Commit(ctxWithTimeout))
 	}
 	for i := 0; i < 10; i++ {
 		registerFn(fmt.Sprintf("hnsw_idx_%d", i))
 	}
 
 	now := taeHandler.GetDB().TxnMgr.Now()
-	testutils.WaitExpect(
-		4000,
+	require.Eventually(
+		t,
 		func() bool {
 			for i := 0; i < 10; i++ {
 				ts, ok := cdcExecutor.GetWatermark(accountId, tableID, fmt.Sprintf("hnsw_idx_%d", i))
@@ -4923,12 +4923,15 @@ func TestRenameSrcTable(t *testing.T) {
 			}
 			return true
 		},
+		30*time.Second,
+		10*time.Millisecond,
 	)
 	for i := 0; i < 10; i++ {
 		ts, ok := cdcExecutor.GetWatermark(accountId, tableID, fmt.Sprintf("hnsw_idx_%d", i))
-		assert.True(t, ok)
-		assert.True(t, ts.GE(&now))
+		require.True(t, ok)
+		require.True(t, ts.GE(&now))
 	}
+	cdcExecutor.Stop()
 
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
 	require.NoError(t, err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #23080

## What this PR does / why we need it:

`LIMIT` truncated its input batch in place. Recursive CTE pipelines can fan out the same batch to multiple consumers, so one consumer could shorten the vectors while another consumer still observed the original row count. This caused downstream expression evaluation to access rows beyond the shortened vector and panic.

This change:

- copies the final truncated batch into a buffer owned by the `Limit` operator;
- keeps the shared upstream batch immutable;
- releases the owned buffer in `Free`;
- adds a regression test that verifies limiting the output does not change the input batch row count or vector lengths.

Local validation:

- `gofmt`
- `git diff --check`
- focused `TestLimitDoesNotMutateInputBatch`
- focused race test with `-count=100`
- full `pkg/sql/colexec/limit` race suite
- `go vet ./pkg/sql/colexec/limit`
- BVT was not run locally.
