### PR TITLE
test: stabilize TestInitSql watermark waits

### DIFF
--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -5209,7 +5209,7 @@ func TestInitSql(t *testing.T) {
 
 	tableID := rel.GetTableID(ctxWithTimeout)
 
-	txn.Commit(ctxWithAccount)
+	require.NoError(t, txn.Commit(ctxWithAccount))
 
 	// init cdc executor
 	opts := &iscp.ISCPExecutorOption{
@@ -5243,9 +5243,10 @@ func TestInitSql(t *testing.T) {
 	require.NoError(t, err)
 	cdcExecutor.SetRpcHandleFn(taeHandler.GetRPCHandle().HandleGetChangedTableList)
 
-	cdcExecutor.Start()
+	require.NoError(t, cdcExecutor.Start())
 	defer cdcExecutor.Stop()
 
+	const jobName = "idx"
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
 	require.NoError(t, err)
 	ok, err := iscp.RegisterJob(
@@ -5257,30 +5258,29 @@ func TestInitSql(t *testing.T) {
 			},
 		},
 		&iscp.JobID{
-			JobName:   "idx",
+			JobName:   jobName,
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
 		false,
 	)
-	assert.True(t, ok)
-	assert.NoError(t, err)
-	assert.NoError(t, txn.Commit(ctxWithTimeout))
+	require.True(t, ok)
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
-	now := taeHandler.GetDB().TxnMgr.Now()
-	testutils.WaitExpect(
-		4000,
-		func() bool {
-			ts, ok := cdcExecutor.GetWatermark(tableAccountID, tableID, "idx")
-			if !ok || !ts.GE(&now) {
-				return false
-			}
-			return true
+	target := types.TimestampToTS(txn.Txn().CommitTS)
+	waitForISCPWatermark(
+		t,
+		func() (types.TS, bool) {
+			return cdcExecutor.GetWatermark(tableAccountID, tableID, jobName)
 		},
+		target,
+		10*time.Second,
+		10*time.Millisecond,
+		tableAccountID,
+		tableID,
+		jobName,
 	)
-	ts, ok := cdcExecutor.GetWatermark(tableAccountID, tableID, "idx")
-	assert.True(t, ok)
-	assert.True(t, ts.GE(&now))
 
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
 	require.NoError(t, err)
@@ -5291,25 +5291,24 @@ func TestInitSql(t *testing.T) {
 	require.NoError(t, err)
 
 	txn2, rel2 := testutil2.GetRelation(t, tableAccountID, taeHandler.GetDB(), "srcdb", "src_table")
-	require.Nil(t, rel2.Append(ctx, bats))
-	require.Nil(t, txn2.Commit(ctx))
+	require.NoError(t, rel2.Append(ctx, bats))
+	require.NoError(t, txn2.Commit(ctx))
 
-	now = taeHandler.GetDB().TxnMgr.Now()
-	testutils.WaitExpect(
-		4000,
-		func() bool {
-			ts, ok := cdcExecutor.GetWatermark(tableAccountID, tableID, "idx")
-			if !ok || !ts.GE(&now) {
-				return false
-			}
-			return true
+	target = txn2.GetCommitTS()
+	waitForISCPWatermark(
+		t,
+		func() (types.TS, bool) {
+			return cdcExecutor.GetWatermark(tableAccountID, tableID, jobName)
 		},
+		target,
+		10*time.Second,
+		10*time.Millisecond,
+		tableAccountID,
+		tableID,
+		jobName,
 	)
-	ts, ok = cdcExecutor.GetWatermark(tableAccountID, tableID, "idx")
-	assert.True(t, ok)
-	assert.True(t, ts.GE(&now))
 
-	CheckTableData(t, disttaeEngine, ctxWithAccount, "srcdb", "src_table", tableID, "idx")
+	CheckTableData(t, disttaeEngine, ctxWithAccount, "srcdb", "src_table", tableID, jobName)
 	t.Log(taeHandler.GetDB().Catalog.SimplePPString(3))
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26486

## What this PR does / why we need it:

`TestInitSql` used a silent fixed 4-second poll and compared the ISCP watermark with `TxnMgr.Now()` sampled after commit. That timestamp can be ahead of the transaction the asynchronous pipeline must actually cover, and valid CI progress can arrive after the fixed window without any useful timeout diagnostics.

This test-only change uses the exact commit timestamp for both watermark transitions: the registration transaction's `CommitTS` and the append transaction's `GetCommitTS()`. It reuses the existing ISCP watermark helper, which returns as soon as the observable state reaches the target, retains a 10-second hang guard, and reports account, table, job, current watermark, and target on failure. Setup and commit errors are also made fatal so the test cannot continue with invalid state.

No production code or ISCP runtime behavior is changed.

Tested with:

`GOMAXPROCS=1 .agents/skills/mo-dev/scripts/mo-cgo-test -race -count=12 -cpu=1 -timeout=20m -run '^TestInitSql$' ./pkg/vm/engine/test`

`GOMAXPROCS=1 .agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -cpu=1 -timeout=30m ./pkg/vm/engine/test`

`go vet ./pkg/vm/engine/test`

`go build ./pkg/vm/engine/test`
