### PR TITLE
fix ut

### DIFF
--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -4032,6 +4032,7 @@ func TestInvalidTimestamp(t *testing.T) {
 	var (
 		accountId = catalog.System_Account
 	)
+	const jobName = "hnsw_idx"
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -4102,7 +4103,7 @@ func TestInvalidTimestamp(t *testing.T) {
 	err = rel.Write(ctxWithTimeout, containers.ToCNBatch(bats[0]))
 	require.Nil(t, err)
 
-	txn.Commit(ctxWithTimeout)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
 	fault.Enable()
 	defer fault.Disable()
@@ -4120,40 +4121,43 @@ func TestInvalidTimestamp(t *testing.T) {
 			},
 		},
 		&iscp.JobID{
-			JobName:   "hnsw_idx",
+			JobName:   jobName,
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
 		false,
 	)
-	assert.True(t, ok)
-	assert.NoError(t, err)
-	assert.NoError(t, txn.Commit(ctxWithTimeout))
+	require.True(t, ok)
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
+
+	assert.Never(
+		t,
+		func() bool {
+			_, ok := cdcExecutor.GetWatermark(accountId, tableID, jobName)
+			return ok
+		},
+		4*time.Second,
+		10*time.Millisecond,
+	)
+
+	removed, err := rmFn()
+	require.NoError(t, err)
+	require.True(t, removed)
 
 	now := taeHandler.GetDB().TxnMgr.Now()
-	testutils.WaitExpect(
-		4000,
-		func() bool {
-			ts, ok := cdcExecutor.GetWatermark(accountId, tableID, "hnsw_idx")
-			return ok && ts.GE(&now)
+	waitForISCPWatermark(
+		t,
+		func() (types.TS, bool) {
+			return cdcExecutor.GetWatermark(accountId, tableID, jobName)
 		},
+		now,
+		10*time.Second,
+		10*time.Millisecond,
+		accountId,
+		tableID,
+		jobName,
 	)
-	_, ok = cdcExecutor.GetWatermark(accountId, tableID, "hnsw_idx")
-	assert.False(t, ok)
-
-	rmFn()
-
-	now = taeHandler.GetDB().TxnMgr.Now()
-	testutils.WaitExpect(
-		4000,
-		func() bool {
-			ts, ok := cdcExecutor.GetWatermark(accountId, tableID, "hnsw_idx")
-			return ok && ts.GE(&now)
-		},
-	)
-	ts, ok := cdcExecutor.GetWatermark(accountId, tableID, "hnsw_idx")
-	assert.True(t, ok)
-	assert.True(t, ts.GE(&now))
 }
 
 func TestCancelIteration1(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26491

## What this PR does / why we need it:

  - 提交、注册 job、移除 fault 等关键前置步骤改为 require，失败立即终止测试。
  - fault 生效期间改为 assert.Never，持续确认不会产生 watermark。
  - 移除 fault 后不再使用固定 4 秒轮询和裸断言，改复用 waitForISCPWatermark，最多等待 10 秒并输出当前/目标 watermark 诊断。
  - 提取 jobName 常量，减少重复字符串。

  目的：降低 CI 负载下 watermark 尚未完成就断言失败的概率，并提升失败信息可定位性。
