### PR TITLE
fix: stabilize async regression contracts and ISCP errors

### DIFF
--- a/pkg/iscp/iteration.go
+++ b/pkg/iscp/iteration.go
@@ -1039,7 +1039,7 @@ func ProcessInitSQL(
 	txnOp, err := cnTxnClient.New(ctx, nowTs, createByOpt)
 	if txnOp != nil {
 		defer func() {
-			err = finishInitSQLTxn(ctx, txnOp, err)
+			err = finishISCPTransaction(ctx, txnOp, err)
 		}()
 	}
 	// injection is for ut
@@ -1098,14 +1098,14 @@ func ProcessInitSQL(
 	return
 }
 
-func finishInitSQLTxn(ctx context.Context, txnOp client.TxnOperator, err error) error {
+func finishISCPTransaction(ctx context.Context, txnOp client.TxnOperator, err error) error {
 	if txnOp == nil {
 		return err
 	}
 	cleanupCtx, cancel := context.WithTimeoutCause(
 		context.WithoutCancel(ctx),
 		time.Minute*5,
-		moerr.NewInternalErrorNoCtx("iscp init sql txn finish timeout"),
+		moerr.NewInternalErrorNoCtx("iscp transaction finish timeout"),
 	)
 	defer cancel()
 	if err != nil {

--- a/pkg/iscp/iteration_consumer_context_test.go
+++ b/pkg/iscp/iteration_consumer_context_test.go
@@ -209,7 +209,7 @@ func TestRunInitSQLWithRuntimeSkipsFencedInitSQL(t *testing.T) {
 	require.False(t, called)
 }
 
-type initSQLTxnForTest struct {
+type iscpTxnForTest struct {
 	client.TxnOperator
 	commitErr         error
 	rollbackErr       error
@@ -220,36 +220,36 @@ type initSQLTxnForTest struct {
 	rollbackErrAtCall error
 }
 
-func (t *initSQLTxnForTest) Commit(ctx context.Context) error {
+func (t *iscpTxnForTest) Commit(ctx context.Context) error {
 	t.committed = true
 	t.commitCtx = ctx
 	return t.commitErr
 }
 
-func (t *initSQLTxnForTest) Rollback(ctx context.Context) error {
+func (t *iscpTxnForTest) Rollback(ctx context.Context) error {
 	t.rolledBack = true
 	t.rollbackCtx = ctx
 	t.rollbackErrAtCall = ctx.Err()
 	return t.rollbackErr
 }
 
-func TestFinishInitSQLTxnReturnsCommitError(t *testing.T) {
+func TestFinishISCPTransactionReturnsCommitError(t *testing.T) {
 	commitErr := errors.New("commit failed")
-	txn := &initSQLTxnForTest{commitErr: commitErr}
+	txn := &iscpTxnForTest{commitErr: commitErr}
 
-	err := finishInitSQLTxn(context.Background(), txn, nil)
+	err := finishISCPTransaction(context.Background(), txn, nil)
 
 	require.ErrorIs(t, err, commitErr)
 	require.True(t, txn.committed)
 	require.False(t, txn.rolledBack)
 }
 
-func TestFinishInitSQLTxnRollsBackWithIndependentContext(t *testing.T) {
+func TestFinishISCPTransactionRollsBackWithIndependentContext(t *testing.T) {
 	parent, cancel := context.WithCancel(context.Background())
 	cancel()
-	txn := &initSQLTxnForTest{}
+	txn := &iscpTxnForTest{}
 
-	err := finishInitSQLTxn(parent, txn, context.Canceled)
+	err := finishISCPTransaction(parent, txn, context.Canceled)
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.True(t, txn.rolledBack)

--- a/pkg/iscp/mock_consumer.go
+++ b/pkg/iscp/mock_consumer.go
@@ -206,17 +206,17 @@ func (s *interalSqlConsumer) createTargetTable(ctx context.Context) error {
 	return err
 }
 
-func (s *interalSqlConsumer) Consume(ctx context.Context, data DataRetriever) error {
+func (s *interalSqlConsumer) Consume(ctx context.Context, data DataRetriever) (err error) {
 	s.dataRetriever = data
 	data.GetAccountID()
 	data.GetTableID()
 
 	if !s.inited {
-
-		err := s.createTargetTable(context.Background())
+		err = s.createTargetTable(ctx)
 		if err != nil {
 			return err
 		}
+		s.inited = true
 	}
 
 	if msg, injected := objectio.ISCPExecutorInjected(); injected && msg == "consume" {
@@ -246,24 +246,17 @@ func (s *interalSqlConsumer) Consume(ctx context.Context, data DataRetriever) er
 			}
 		}
 	case ISCPDataType_Tail:
-		ctx := context.WithValue(context.Background(), defines.TenantIDKey{}, catalog.System_Account)
+		ctx := context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
 		ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 		defer cancel()
-		txn, err := getTxn(ctx, s.cnEngine, s.cnTxnClient, "internalSqlConsumer")
+		var txn client.TxnOperator
+		txn, err = getTxn(ctx, s.cnEngine, s.cnTxnClient, "internalSqlConsumer")
 		if err != nil {
 			return err
 		}
 
 		defer func() {
-			if err != nil {
-				err = txn.Rollback(ctx)
-			} else {
-				err = txn.Commit(ctx)
-			}
-
-			if err != nil {
-				logutil.Error("InteralSqlConsumer Consume Tail failed")
-			}
+			err = finishISCPTransaction(ctx, txn, err)
 		}()
 
 		for {
@@ -334,17 +327,17 @@ func (s *interalSqlConsumer) sinkSnapshot(ctx context.Context, bat *AtomicBatch)
 			}
 			// step1: get row from the batch
 			if err = extractRowFromEveryVector(ctx, bat, i, s.insertRow); err != nil {
-				panic(err)
+				return err
 			}
 
 			// step2: transform rows into sql parts
 			if err = s.getInsertRowBuf(ctx); err != nil {
-				panic(err)
+				return err
 			}
 
 			// step3: append to sqlBuf, send sql if sqlBuf is full
 			if sqlBuffer, err = s.appendSqlBuf(ctx, UpsertRow, sqlBuffer, nil); err != nil {
-				panic(err)
+				return err
 			}
 		}
 	}
@@ -378,7 +371,7 @@ func (s *interalSqlConsumer) sinkTail(ctx context.Context, insertBatch, deleteBa
 			s.preRowType = DeleteRow
 		}
 		if sqlBuffer, err = s.sinkDelete(ctx, deleteIter, sqlBuffer, txn); err != nil {
-			panic(err)
+			return err
 		}
 		// get next item
 		deleteIterHasNext = deleteIter.Next()
@@ -395,7 +388,7 @@ func (s *interalSqlConsumer) sinkTail(ctx context.Context, insertBatch, deleteBa
 			s.preRowType = InsertRow
 		}
 		if sqlBuffer, err = s.sinkInsert(ctx, insertIter, sqlBuffer, txn); err != nil {
-			panic(err)
+			return err
 		}
 		// get next item
 		insertIterHasNext = insertIter.Next()
@@ -468,7 +461,6 @@ func (s *interalSqlConsumer) tryFlushSqlBuf(ctx context.Context, txn client.TxnO
 		result.Close()
 		if err != nil {
 			logutil.Errorf("iscp interalSqlConsumer(%v) send sql failed, err: %v, sql: %s", s.tableInfo.Name, err, sqlBuffer[:])
-			panic(err)
 		}
 		return
 	}
@@ -478,8 +470,6 @@ func (s *interalSqlConsumer) tryFlushSqlBuf(ctx context.Context, txn client.TxnO
 	result.Close()
 	if err != nil {
 		logutil.Errorf("iscp interalSqlConsumer(%v) send sql failed, err: %v, sql: %s", s.tableInfo.Name, err, sqlBuffer[:])
-		// record error
-		panic(err)
 	}
 	return
 }
@@ -520,7 +510,9 @@ func (s *interalSqlConsumer) appendSqlBuf(ctx context.Context, rowType RowType, 
 		if s.isNonEmptyDeleteStmt(sqlBuffer) {
 			sqlBuffer = appendBytes(sqlBuffer, s.deleteSuffix)
 		}
-		s.tryFlushSqlBuf(ctx, txn, sqlBuffer)
+		if err = s.tryFlushSqlBuf(ctx, txn, sqlBuffer); err != nil {
+			return nil, err
+		}
 		sqlBuffer = make([]byte, 0)
 
 		// reset s.sqlBuf

--- a/pkg/iscp/mock_consumer_test.go
+++ b/pkg/iscp/mock_consumer_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iscp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/stretchr/testify/require"
+)
+
+type flushErrorSQLExecutor struct {
+	err error
+}
+
+func (e flushErrorSQLExecutor) Exec(context.Context, string, executor.Options) (executor.Result, error) {
+	return executor.Result{}, e.err
+}
+
+func (e flushErrorSQLExecutor) ExecTxn(
+	context.Context,
+	func(executor.TxnExecutor) error,
+	executor.Options,
+) error {
+	return e.err
+}
+
+func TestInternalSQLConsumerFlushReturnsError(t *testing.T) {
+	expected := errors.New("flush failed")
+	consumer := &interalSqlConsumer{
+		internalSqlExecutor: flushErrorSQLExecutor{err: expected},
+		dataRetriever:       &DataRetrieverImpl{accountID: 7},
+		tableInfo:           &plan.TableDef{Name: "source"},
+	}
+
+	require.ErrorIs(t, consumer.tryFlushSqlBuf(context.Background(), nil, []byte("insert")), expected)
+}

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -5709,8 +5709,28 @@ func TestLockWaitTimeoutExpiresDuringLockTableBindRPC(t *testing.T) {
 		[]string{"s1"},
 		func(alloc *lockTableAllocator, services []*service) {
 			s := services[0]
+			const (
+				warmupTableID = uint64(24915)
+				targetTableID = uint64(24916)
+			)
+			// Establish allocator reachability and the normal-client backend before
+			// starting the lock-wait budget. The behavior under test is expiry while
+			// GetBind is in flight, not cold transport creation or service startup.
+			warmupCtx, cancelWarmup := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancelWarmup()
+			warmupTxnID := []byte("bind-rpc-warmup")
+			_, err := s.Lock(
+				warmupCtx,
+				warmupTableID,
+				[][]byte{{1}},
+				warmupTxnID,
+				newTestRowExclusiveOptions())
+			require.NoError(t, err)
+			require.NoError(t, s.Unlock(context.Background(), warmupTxnID, timestamp.Timestamp{}))
+
 			entered := make(chan struct{})
 			release := make(chan struct{})
+			var enteredOnce sync.Once
 			var releaseOnce sync.Once
 			releaseHandler := func() {
 				releaseOnce.Do(func() { close(release) })
@@ -5719,26 +5739,29 @@ func TestLockWaitTimeoutExpiresDuringLockTableBindRPC(t *testing.T) {
 			alloc.server.RegisterMethodHandler(
 				pb.Method_GetBind,
 				func(
-					context.Context,
-					context.CancelFunc,
-					*pb.Request,
-					*pb.Response,
-					morpc.ClientSession,
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *pb.Request,
+					resp *pb.Response,
+					cs morpc.ClientSession,
 				) {
-					close(entered)
+					if req.GetBind.Table != targetTableID {
+						alloc.handleGetBind(ctx, cancel, req, resp, cs)
+						return
+					}
+					enteredOnce.Do(func() { close(entered) })
 					<-release
 				})
 
 			options := newTestRowExclusiveOptions()
 			options.LockWaitTimeout = 60
-			options.LockWaitDeadline = time.Now().Add(100 * time.Millisecond).UnixNano()
+			options.LockWaitDeadline = time.Now().Add(time.Second).UnixNano()
 			txnID := []byte("bind-rpc-waiter")
 			resultC := make(chan error, 1)
-			start := time.Now()
 			go func() {
 				_, err := s.Lock(
 					context.Background(),
-					24916,
+					targetTableID,
 					[][]byte{{1}},
 					txnID,
 					options)
@@ -5747,16 +5770,21 @@ func TestLockWaitTimeoutExpiresDuringLockTableBindRPC(t *testing.T) {
 
 			select {
 			case <-entered:
-			case <-time.After(time.Second):
-				require.Fail(t, "lock request did not reach the allocator")
+			case err := <-resultC:
+				require.FailNowf(
+					t,
+					"lock request returned before entering allocator RPC",
+					"error=%v",
+					err)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "lock request did not reach the allocator")
 			}
 			select {
 			case err := <-resultC:
 				require.ErrorIs(t, err, ErrLockTimeout)
-				require.Less(t, time.Since(start), time.Second)
-			case <-time.After(2 * time.Second):
+			case <-time.After(5 * time.Second):
 				releaseHandler()
-				require.Fail(t, "lock budget did not cancel the allocator RPC")
+				require.FailNow(t, "lock budget did not cancel the allocator RPC")
 			}
 			releaseHandler()
 			require.NoError(t, s.Unlock(context.Background(), txnID, timestamp.Timestamp{}))

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -9960,17 +9960,8 @@ func TestDedupSnapshot1(t *testing.T) {
 
 	targetLSN := tae.Wal.GetLSNWatermark()
 	require.NotZero(t, targetLSN)
-	require.Eventually(
-		t,
-		func() bool {
-			return tae.AllCheckpointsFinished() &&
-				tae.Wal.GetCheckpointed() >= targetLSN
-		},
-		30*time.Second,
-		25*time.Millisecond,
-		"background checkpoint did not cover LSN %d",
-		targetLSN,
-	)
+	tae.WaitAllCheckpointsFinished()
+	require.GreaterOrEqual(t, tae.Wal.GetCheckpointed(), targetLSN)
 
 	txn, rel := tae.GetRelation()
 	startTS := txn.GetStartTS()

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -3329,7 +3329,7 @@ func TestUpdateJobSpec(t *testing.T) {
 
 	tableID := rel.GetTableID(ctxWithTimeout)
 
-	txn.Commit(ctxWithTimeout)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
 	// init cdc executor
 	checkLeaseStub := gostub.Stub(
@@ -3362,7 +3362,7 @@ func TestUpdateJobSpec(t *testing.T) {
 	require.NoError(t, err)
 	cdcExecutor.SetRpcHandleFn(taeHandler.GetRPCHandle().HandleGetChangedTableList)
 
-	cdcExecutor.Start()
+	require.NoError(t, cdcExecutor.Start())
 	defer cdcExecutor.Stop()
 	jobName := "job1"
 	dbName := "srcdb"
@@ -3384,46 +3384,58 @@ func TestUpdateJobSpec(t *testing.T) {
 		},
 		false,
 	)
-	assert.True(t, ok)
-	assert.NoError(t, err)
-	assert.NoError(t, txn.Commit(ctxWithTimeout))
+	require.True(t, ok)
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
-	appendFn := func(idx int) {
+	appendFn := func(idx int) types.TS {
 		_, rel, txn, err := disttaeEngine.GetTable(ctxWithTimeout, dbName, tableName)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		err = rel.Write(ctxWithTimeout, containers.ToCNBatch(bats[idx]))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
-		txn.Commit(ctxWithTimeout)
+		require.NoError(t, txn.Commit(ctxWithTimeout))
+		return types.TimestampToTS(txn.Txn().CommitTS)
 	}
 
-	checkWaterMarkFn := func(waitTime int) {
-		now := taeHandler.GetDB().TxnMgr.Now()
-		testutils.WaitExpect(
-			waitTime,
-			func() bool {
-				ts, _ := cdcExecutor.GetWatermark(accountId, tableID, jobName)
-				return ts.GE(&now)
+	waitForWatermark := func(target types.TS) {
+		waitForISCPWatermark(
+			t,
+			func() (types.TS, bool) {
+				return cdcExecutor.GetWatermark(accountId, tableID, jobName)
 			},
+			target,
+			10*time.Second,
+			10*time.Millisecond,
+			accountId,
+			tableID,
+			jobName,
 		)
-		ts, _ := cdcExecutor.GetWatermark(accountId, tableID, jobName)
-		assert.True(t, ts.GE(&now), jobName)
 	}
 
-	checkJobTypeFn := func(waitTime int, expectJobType uint16) {
-		testutils.WaitExpect(
-			waitTime,
-			func() bool {
-				jobType, _ := cdcExecutor.GetJobType(accountId, tableID, jobName)
-				return jobType == expectJobType
-			},
+	waitForJobType := func(expected uint16) {
+		reached := assert.Eventually(t, func() bool {
+			jobType, found := cdcExecutor.GetJobType(accountId, tableID, jobName)
+			return found && jobType == expected
+		}, 10*time.Second, 10*time.Millisecond)
+		if reached {
+			return
+		}
+		jobType, found := cdcExecutor.GetJobType(accountId, tableID, jobName)
+		require.FailNowf(
+			t,
+			"ISCP job type did not reach target",
+			"account=%d table=%d job=%s found=%t current=%d target=%d",
+			accountId,
+			tableID,
+			jobName,
+			found,
+			jobType,
+			expected,
 		)
-		jobType, _ := cdcExecutor.GetJobType(accountId, tableID, jobName)
-		assert.True(t, jobType == expectJobType, jobName)
 	}
-	appendFn(0)
-	checkWaterMarkFn(4000)
+	waitForWatermark(appendFn(0))
 
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
 	require.NoError(t, err)
@@ -3443,13 +3455,11 @@ func TestUpdateJobSpec(t *testing.T) {
 			},
 		},
 	)
-	assert.True(t, ok)
-	assert.NoError(t, err)
-	assert.NoError(t, txn.Commit(ctxWithTimeout))
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
-	checkJobTypeFn(4000, iscp.TriggerType_AlwaysUpdate)
-	appendFn(1)
-	checkWaterMarkFn(4000)
+	waitForJobType(iscp.TriggerType_AlwaysUpdate)
+	waitForWatermark(appendFn(1))
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
 	require.NoError(t, err)
 	err = iscp.UpdateJobSpec(
@@ -3471,15 +3481,13 @@ func TestUpdateJobSpec(t *testing.T) {
 			},
 		},
 	)
-	assert.True(t, ok)
-	assert.NoError(t, err)
-	assert.NoError(t, txn.Commit(ctxWithTimeout))
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
-	checkJobTypeFn(4000, iscp.TriggerType_Timed)
-	appendFn(2)
-	checkWaterMarkFn(4000)
+	waitForJobType(iscp.TriggerType_Timed)
+	waitForWatermark(appendFn(2))
 
-	CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, "job1")
+	CheckTableData(t, disttaeEngine, ctxWithTimeout, dbName, tableName, tableID, jobName)
 }
 
 func TestFlushWatermark(t *testing.T) {
@@ -5764,6 +5772,7 @@ func TestISCPTableIDChange(t *testing.T) {
 	var (
 		accountId = catalog.System_Account
 	)
+	const jobName = "test_idx"
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -5791,14 +5800,15 @@ func TestISCPTableIDChange(t *testing.T) {
 
 	// append 1 row
 	_, rel, txn, err := disttaeEngine.GetTable(ctxWithTimeout, "srcdb", "src_table")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	tableID := rel.GetTableID(ctxWithTimeout)
 
 	err = rel.Write(ctxWithTimeout, containers.ToCNBatch(bats[0]))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	txn.Commit(ctxWithTimeout)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
+	initialTarget := types.TimestampToTS(txn.Txn().CommitTS)
 
 	// init cdc executor
 	checkLeaseStub := gostub.Stub(
@@ -5845,45 +5855,60 @@ func TestISCPTableIDChange(t *testing.T) {
 			},
 		},
 		&iscp.JobID{
-			JobName:   "test_idx",
+			JobName:   jobName,
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
 		false,
 	)
-	assert.True(t, ok)
-	assert.NoError(t, err)
-	assert.NoError(t, txn.Commit(ctxWithTimeout))
+	require.True(t, ok)
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
 
-	// wait for synchronization to initialize prevISCPTableID
+	// Establish the initial replay and snapshot before simulating a table ID
+	// change. Otherwise the fault can race the state it is meant to invalidate.
+	waitForISCPWatermark(
+		t,
+		func() (types.TS, bool) {
+			return cdcExecutor.GetWatermark(accountId, tableID, jobName)
+		},
+		initialTarget,
+		10*time.Second,
+		10*time.Millisecond,
+		accountId,
+		tableID,
+		jobName,
+	)
 
 	// enable injection to trigger table id change check
 	fault.Enable()
 	defer fault.Disable()
 	rmFn, err := objectio.InjectCDCExecutor("tableIDChange")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer rmFn()
 
 	// append more data to trigger synchronization
 	_, rel, txn, err = disttaeEngine.GetTable(ctxWithTimeout, "srcdb", "src_table")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = rel.Write(ctxWithTimeout, containers.ToCNBatch(bats[1]))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	txn.Commit(ctxWithTimeout)
-
-	now := taeHandler.GetDB().TxnMgr.Now()
-	testutils.WaitExpect(
-		4000,
-		func() bool {
-			ts, ok := cdcExecutor.GetWatermark(accountId, tableID, "test_idx")
-			return ok && ts.GE(&now)
+	require.NoError(t, txn.Commit(ctxWithTimeout))
+	target := types.TimestampToTS(txn.Txn().CommitTS)
+	waitForISCPWatermark(
+		t,
+		func() (types.TS, bool) {
+			return cdcExecutor.GetWatermark(accountId, tableID, jobName)
 		},
+		target,
+		10*time.Second,
+		10*time.Millisecond,
+		accountId,
+		tableID,
+		jobName,
 	)
-	ts, ok := cdcExecutor.GetWatermark(accountId, tableID, "test_idx")
-	assert.True(t, ok)
-	assert.True(t, ts.GE(&now))
+	CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, jobName)
 }
 
 func TestIterationError(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26506
Fixes #26524
Fixes #26525

Also fixes the `TestISCPTableIDChange` failure and teardown panic observed in [PR #26520 CI](https://github.com/matrixorigin/matrixone/actions/runs/30639293057/job/91185157725?pr=26520).

## What this PR does / why we need it:

These failures share an async-test contract problem, but not one product root cause:

- `TestLockWaitTimeoutExpiresDuringLockTableBindRPC` started a 100 ms absolute budget before a cold GetBind transport was ready, then assumed the request had entered the allocator. Warm the real client path first and use an explicit handler-entry barrier. The stub only intercepts the target table and every failure path releases it.
- `TestUpdateJobSpec` sampled an unrelated `TxnMgr.Now()` after an append and used non-fatal assertions. Use each append transaction commit TS as the exact watermark target, require job registration/update preconditions, and validate the resulting data.
- `TestDedupSnapshot1` duplicated a 30 second checkpoint wait even though a healthy CI ICKP can run longer. Reuse the bounded common checkpoint barrier and verify that it covers the append LSN. This still exercises the real background checkpoint without force or retry.
- `TestISCPTableIDChange` enabled the stale-table fault before proving the initial replay/snapshot state existed. Establish the first committed watermark, inject the table-ID change, append a second committed row, wait for recovery, and compare source/target data in both directions.

The CI teardown also exposed a real unhappy path: the internal SQL consumer panicked on SQL/context errors even though `Consume` already returns an error. Propagate extraction, buffer flush, and SQL failures through the existing consumer error path; use the existing bounded cancellation-independent transaction finalizer for commit/rollback. Invariant panics remain unchanged.

This is deliberately not fixed with retry, fixed sleep, CI-specific branches, or larger data sets.

## Test plan

All tests use their existing 1-10 row inputs.

- Focused tests for all four reported scenarios: pass.
- Repetition: lock 5/5, TAE 5/5, two ISCP scenarios 10/10.
- Race: targeted lock, TAE, ISCP executor, and ISCP consumer tests pass.
- `go test ./pkg/iscp`: pass.
- `go test ./pkg/lockservice`: pass.
- `golangci-lint --new-from-rev=origin/main` on changed packages: 0 issues.
- License header check: 0 invalid.

## Correctness and performance

Normal lock, checkpoint, and watermark production paths are unchanged. Internal SQL consumer success-path work remains the same apart from one transaction-level bounded cleanup context; error checks occur only at existing error/flush boundaries. Setting the existing initialized state also avoids repeated target-table DDL if a consumer instance is reused. No per-row retry, sleep, or new unbounded state is introduced.