### PR TITLE
fix(compile): prevent distributed delete dispatch hang

### DIFF
--- a/pkg/sql/compile/Remote_Run_DEV_GUIDE.md
+++ b/pkg/sql/compile/Remote_Run_DEV_GUIDE.md
@@ -49,7 +49,8 @@ func (s *Scope) RemoteRun(c *Compile) error {
     
     // Check if pipeline can be executed standalone at remote
     if !checkPipelineStandaloneExecutableAtRemote(s) {
-        return s.MergeRun(c)  // Fallback to local execution
+        return s.failRemoteRunBeforeStart(c,
+            moerr.NewInternalErrorNoCtx("remote pipeline is not standalone executable"))
     }
     
     // Create pipeline and send to remote node
@@ -76,7 +77,9 @@ func (s *Scope) RemoteRun(c *Compile) error {
 - Check if same address (execute locally via `MergeRun`)
 - Check if any operator cannot be executed remotely via `holdAnyCannotRemoteOperator()`
 - Check if pipeline can be executed standalone at remote via `checkPipelineStandaloneExecutableAtRemote`
-- If not standalone executable, fallback to local execution (`MergeRun`)
+- If not standalone executable, fail before start, cancel sibling pipelines, and clean up
+- Never silently execute a remote-selected tree on the coordinator: dispatch/connector
+  receiver locality is part of the compiled topology, and changing it can hang the query
 - Create pipeline and call `remoteRun` to send
 - Use `CleanRootOperator` for cleanup (not general cleanup)
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -5170,6 +5170,13 @@ func (c *Compile) newDeleteMergeScope(arg *deletion.Deletion, ss []*Scope, node 
 		arg.Nbucket = uint32(len(rs))
 		rs[i].setRootOperator(dupOperator(arg, 0, len(rs)))
 	}
+	// Every source dispatch targets all delete receivers on its CN through
+	// LocalRegs. Put those receivers in one RemoteRun tree so the encoded tree
+	// owns every local channel its dispatches reference.
+	stageNodes := shuffleBucketStageNodes(rs)
+	if len(rs) > len(stageNodes) {
+		rs = c.mergeScopesByStageNodes(rs, stageNodes)
+	}
 	return c.newMergeScope(rs)
 }
 
@@ -5423,10 +5430,8 @@ func (c *Compile) mergeShuffleScopesIfNeeded(ss []*Scope, force bool) []*Scope {
 // dispatch operator that sends to remote (cross-CN) receivers. A non-empty RemoteRegs is
 // the signature of a cross-CN shuffle dispatch (see constructDispatchLocalAndRemote).
 //
-// Precondition: it only inspects each scope's RootOp, assuming a shuffle dispatch is always
-// the root operator of its scope (constructDispatch results are attached via setRootOperator
-// with IsEnd=true, so nothing is appended on top of them). A dispatch nested as a child of
-// another operator would be missed -- which does not happen for shuffle dispatches today.
+// It inspects every operator in every scope because DML operators can wrap a shuffle dispatch
+// before this gate decides whether the receiver buckets need a per-CN transport envelope.
 //
 // Scope of the check (intentionally narrower than checkPipelineStandaloneExecutableAtRemote,
 // which rejects out-of-tree dispatch *and* out-of-tree connector targets): this gate only
@@ -5434,15 +5439,35 @@ func (c *Compile) mergeShuffleScopesIfNeeded(ss []*Scope, force bool) []*Scope {
 // dispatch together with its dop buckets. A scope tree that crosses CNs solely via a connector
 // is not the shuffle-bucket pattern grouping addresses and is intentionally left untouched.
 func scopeTreeHasCrossCNDispatch(s *Scope) bool {
-	if d, ok := s.RootOp.(*dispatch.Dispatch); ok && len(d.RemoteRegs) > 0 {
-		return true
-	}
-	for _, pre := range s.PreScopes {
-		if scopeTreeHasCrossCNDispatch(pre) {
+	visited := make(map[*Scope]struct{})
+	var containsCrossCNDispatch func(*Scope) bool
+	containsCrossCNDispatch = func(current *Scope) bool {
+		if current == nil {
+			return false
+		}
+		if _, ok := visited[current]; ok {
+			return false
+		}
+		visited[current] = struct{}{}
+
+		found := false
+		_ = vm.HandleAllOp(current.RootOp, func(_ vm.Operator, op vm.Operator) error {
+			if d, ok := op.(*dispatch.Dispatch); ok && len(d.RemoteRegs) > 0 {
+				found = true
+			}
+			return nil
+		})
+		if found {
 			return true
 		}
+		for _, pre := range current.PreScopes {
+			if containsCrossCNDispatch(pre) {
+				return true
+			}
+		}
+		return false
 	}
-	return false
+	return containsCrossCNDispatch(s)
 }
 
 // groupShuffleBucketsByCNIfNeeded groups the same-CN shuffle buckets (together with the
@@ -5453,8 +5478,8 @@ func scopeTreeHasCrossCNDispatch(s *Scope) bool {
 // separate RemoteRun trees while the shuffle dispatch only attaches to the first bucket.
 // When the consumer (here compileInsert) sends each bucket individually, RemoteRun ->
 // checkPipelineStandaloneExecutableAtRemote sees the dispatch.LocalRegs pointing to the
-// sibling out-of-tree buckets, converts the pipeline to local on the coordinator, and the
-// dispatch then runs on the coordinator instead of its compile-time CN -- mispaired with
+// sibling out-of-tree buckets. The legacy fallback ran the dispatch on the coordinator
+// instead of its compile-time CN, mispairing it with
 // the cross-CN receiver's FromAddr -> the remote receiver's GetProcByUuid spins / merge
 // WaitingEnd waits forever -> hang. Regrouping by CN keeps all of a CN's buckets in one
 // tree, so the whole group is really executed at the remote CN and the pairing is correct.

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -110,73 +110,61 @@ func (s *Scope) remoteRun(c *Compile) (sender *messageSenderOnClient, err error)
 	return sender, err
 }
 
-// checkPipelineStandaloneExecutableAtRemote is responsible for checking the standalone excitability of the pipeline
-// once it was sent to other remote node.
-//
-// it returns true if the pipeline has only the root operator capable of sending data to other outer pipeline.
+// checkPipelineStandaloneExecutableAtRemote verifies that every local channel used by the
+// encoded remote pipeline is owned by the encoded scope tree. A starting Connector or
+// Dispatch is retained on the caller and is intentionally excluded by remote encoding.
 func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
-	var regs = make(map[*process.WaitRegister]struct{})
-	var toScan []*Scope
-	// record which mergeReceivers this scope tree holds.
-	{
-		toScan = append(toScan, s)
-		for len(toScan) > 0 {
-			node := toScan[len(toScan)-1]
-			toScan = toScan[:len(toScan)-1]
+	if s == nil {
+		return false
+	}
 
-			if len(node.PreScopes) > 0 {
-				toScan = append(toScan, node.PreScopes...)
-			}
-
-			for i := range node.Proc.Reg.MergeReceivers {
-				regs[node.Proc.Reg.MergeReceivers[i]] = struct{}{}
-			}
+	encoded, _ := getScopeForRemoteRunEncoding(s)
+	regs := make(map[*process.WaitRegister]struct{})
+	visited := make(map[*Scope]struct{})
+	toScan := []*Scope{encoded}
+	encodedScopes := make([]*Scope, 0, len(s.PreScopes)+1)
+	for len(toScan) > 0 {
+		node := toScan[len(toScan)-1]
+		toScan = toScan[:len(toScan)-1]
+		if node == nil {
+			continue
+		}
+		if _, ok := visited[node]; ok {
+			continue
+		}
+		visited[node] = struct{}{}
+		encodedScopes = append(encodedScopes, node)
+		toScan = append(toScan, node.PreScopes...)
+		if node.Proc == nil {
+			continue
+		}
+		for _, reg := range node.Proc.Reg.MergeReceivers {
+			regs[reg] = struct{}{}
 		}
 	}
 
-	// check if there are target channels from other trees.
-	{
-		if len(s.PreScopes) > 0 {
-			toScan = append(toScan, s.PreScopes...)
-		}
-
-		for len(toScan) > 0 {
-			node := toScan[len(toScan)-1]
-			toScan = toScan[:len(toScan)-1]
-
-			if len(node.PreScopes) > 0 {
-				toScan = append(toScan, node.PreScopes...)
-			}
-
-			if node.RootOp.OpType() == vm.Dispatch {
-				t := node.RootOp.(*dispatch.Dispatch)
-				for i := range t.LocalRegs {
-					if _, ok := regs[t.LocalRegs[i]]; !ok {
-						s.Proc.Infof(
-							s.Proc.Ctx,
-							"txn id : %s, the pipeline %p convert to execute locally because it holds a dispatch operator will send data to other local pipeline tree.",
-							s.Proc.GetTxnOperator().Txn().ID, s)
-
-						return false
+	standalone := true
+	for _, node := range encodedScopes {
+		_ = vm.HandleAllOp(node.RootOp, func(_ vm.Operator, op vm.Operator) error {
+			switch typed := op.(type) {
+			case *dispatch.Dispatch:
+				for _, reg := range typed.LocalRegs {
+					if _, ok := regs[reg]; !ok {
+						standalone = false
+						break
 					}
 				}
-				continue
-			}
-			if node.RootOp.OpType() == vm.Connector {
-				t := node.RootOp.(*connector.Connector)
-				if _, ok := regs[t.Reg]; !ok {
-					s.Proc.Infof(
-						s.Proc.Ctx,
-						"txn id : %s, the pipeline %p convert to execute locally because it holds a connector operator will send data to other local pipeline tree.",
-						s.Proc.GetTxnOperator().Txn().ID, s)
-
-					return false
+			case *connector.Connector:
+				if _, ok := regs[typed.Reg]; !ok {
+					standalone = false
 				}
-				continue
 			}
+			return nil
+		})
+		if !standalone {
+			return false
 		}
 	}
-
 	return true
 }
 

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -352,7 +352,9 @@ func registerLocalDispatchReceivers(scopes []*Scope, localAddr string) (*remoteD
 			return skipDispatchReceivers
 		}
 		if !checkPipelineStandaloneExecutableAtRemote(s) {
-			return registerDispatchReceiverTree
+			// RemoteRun rejects this tree before it starts. Publishing its UUIDs
+			// on the caller would advertise an owner that never executes here.
+			return skipDispatchReceivers
 		}
 		if _, ok := s.RootOp.(*dispatch.Dispatch); ok {
 			return registerDispatchReceiverRoot

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -1532,6 +1532,37 @@ func TestRegisterLocalDispatchReceiversSkipsGuaranteedRemoteRunFailures(t *testi
 	}
 }
 
+func TestRegisterLocalDispatchReceiversSkipsNonStandaloneRemoteScope(t *testing.T) {
+	_ = colexec.NewServer("")
+
+	uid := uuid.Must(uuid.NewV7())
+	proc := testutil.NewProcess(t)
+	root := dispatch.NewArgument()
+	defer root.Release()
+	root.RemoteRegs = []colexec.ReceiveInfo{{Uuid: uid}}
+
+	invalidDispatch := dispatch.NewArgument()
+	defer invalidDispatch.Release()
+	invalidDispatch.LocalRegs = []*process.WaitRegister{{}}
+	pre := &Scope{Proc: proc.NewNoContextChildProc(0), RootOp: invalidDispatch}
+	s := &Scope{
+		Magic:     Remote,
+		Proc:      proc,
+		RootOp:    root,
+		NodeInfo:  engine.Node{Addr: "remote-cn:6002"},
+		PreScopes: []*Scope{pre},
+	}
+	require.False(t, checkPipelineStandaloneExecutableAtRemote(s))
+
+	registrations, err := registerLocalDispatchReceivers([]*Scope{s}, "local-cn:6002")
+	require.NoError(t, err)
+	defer registrations.cleanup()
+	registeredProc, notifyCh, ok := colexec.GetServer("").GetProcByUuid(uid, false)
+	require.False(t, ok)
+	require.Nil(t, registeredProc)
+	require.Nil(t, notifyCh)
+}
+
 func TestRegisterRemoteDispatchReceiversUsesOwningScopeProcess(t *testing.T) {
 	_ = colexec.NewServer("")
 
@@ -3082,6 +3113,35 @@ func Test_checkPipelineStandaloneExecutableAtRemote(t *testing.T) {
 
 		require.False(t, checkPipelineStandaloneExecutableAtRemote(s0))
 	}
+
+	// Operators below the root are part of the encoded remote pipeline and
+	// must not reference a receiver owned by another scope tree.
+	{
+		nestedDispatch := dispatch.NewArgument()
+		nestedDispatch.LocalRegs = []*process.WaitRegister{{}}
+		root := merge.NewArgument()
+		root.AppendChild(nestedDispatch)
+		s := &Scope{
+			Proc:   proc.NewContextChildProc(0),
+			RootOp: root,
+		}
+
+		require.False(t, checkPipelineStandaloneExecutableAtRemote(s))
+	}
+
+	// A starting Dispatch is retained on the caller by remote encoding. Its
+	// receiver ownership is therefore outside the encoded remote pipeline.
+	{
+		root := dispatch.NewArgument()
+		root.LocalRegs = []*process.WaitRegister{{}}
+		root.AppendChild(value_scan.NewArgument())
+		s := &Scope{
+			Proc:   proc.NewContextChildProc(0),
+			RootOp: root,
+		}
+
+		require.True(t, checkPipelineStandaloneExecutableAtRemote(s))
+	}
 }
 
 // TestDeletionCanTruncateSerializationRoundtrip verifies that CanTruncate is
@@ -3161,9 +3221,8 @@ func newDispatchSrcScopeForTest(proc *process.Process, addr string, localBuckets
 //
 //	before regrouping, the bucket that carries a cross-CN shuffle dispatch is wrongly
 //	judged non-standalone-executable (its dispatch LocalRegs point to a sibling bucket
-//	that lives in a separate send tree) -> RemoteRun converts it to local -> the dispatch
-//	lands on the coordinator, mispaired with the compile-time cross-CN receiver FromAddr
-//	-> hang.
+//	that lives in a separate send tree). The legacy RemoteRun fallback placed the dispatch
+//	on the coordinator, mispaired with the compile-time cross-CN receiver FromAddr -> hang.
 //
 //	after regrouping, the dop same-CN buckets (and the nested dispatch) become one per-CN
 //	send unit, so checkPipelineStandaloneExecutableAtRemote returns true and the whole
@@ -3239,6 +3298,176 @@ func TestGroupShuffleBucketsByCNIfNeeded_Gating(t *testing.T) {
 	// single CN -> returned unchanged even if a cross-CN dispatch is present.
 	c.cnList = engine.Nodes{engine.Node{Addr: "cn1:6001", Mcpu: 2}}
 	require.Equal(t, 4, len(c.groupShuffleBucketsByCNIfNeeded(ss)))
+
+	// A DML operator can wrap the cross-CN dispatch in the encoded operator
+	// tree; grouping must not depend on Dispatch being the root operator.
+	wrapped := make([]*Scope, 4)
+	for i, addr := range []string{"cn1:6001", "cn1:6001", "cn2:6001", "cn2:6001"} {
+		wrapped[i] = &Scope{
+			Magic:    Remote,
+			NodeInfo: engine.Node{Addr: addr, Mcpu: 1},
+			Proc:     proc.NewContextChildProc(0),
+		}
+		root := merge.NewArgument()
+		if i == 0 {
+			crossCN := dispatch.NewArgument()
+			crossCN.RemoteRegs = []colexec.ReceiveInfo{{Uuid: uuid.Must(uuid.NewV7()), NodeAddr: "cn2:6001"}}
+			root.AppendChild(crossCN)
+		}
+		wrapped[i].RootOp = root
+	}
+	require.Len(t, c.groupShuffleBucketsByCNIfNeeded(wrapped), 2)
+}
+
+func TestNewDeleteMergeScopeGroupsRemoteDeleteUnitsByCN(t *testing.T) {
+	const (
+		dop       = 16
+		stepCount = 2
+	)
+	addrs := []string{"cn-coordinator:6001", "cn-remote-1:6001", "cn-remote-2:6001"}
+	_ = colexec.NewServer("")
+	c := NewMockCompile(t)
+	c.addr = addrs[0]
+	c.execType = plan.ExecTypeAP_MULTICN
+	c.anal = &AnalyzeModule{qry: &plan.Query{}}
+	c.proc.Base.TxnOperator = fakeTxnOperator{}
+	c.cnList = make(engine.Nodes, len(addrs))
+	for i := range addrs {
+		c.cnList[i] = engine.Node{Addr: addrs[i], Mcpu: dop}
+	}
+
+	node := &planpb.Node{Stats: &planpb.Stats{HashmapStats: &planpb.HashMapStats{Shuffle: true}}}
+	type dispatchRoute struct {
+		from string
+		to   string
+	}
+	type receiverRoute struct {
+		from string
+		to   string
+	}
+	potentiallyMisplacedBySourceCN := make(map[string]int)
+	results := make([]*Scope, 0, stepCount)
+	t.Cleanup(func() { ReleaseScopes(results) })
+
+	for step := 0; step < stepCount; step++ {
+		sources := make([]*Scope, 0, len(addrs)*dop)
+		for _, addr := range addrs {
+			for range dop {
+				sourceScope := newScope(Remote)
+				sourceScope.NodeInfo = engine.Node{Addr: addr, Mcpu: 1}
+				sourceScope.Proc = c.proc.NewNoContextChildProc(0)
+				sourceScope.setRootOperator(value_scan.NewArgument())
+				sources = append(sources, sourceScope)
+			}
+		}
+
+		deleteArg := deletion.NewArgument()
+		deleteArg.DeleteCtx = &deletion.DeleteCtx{}
+		result := c.newDeleteMergeScope(deleteArg, sources, node)
+		deleteArg.Release()
+		results = append(results, result)
+
+		require.Len(t, result.PreScopes, len(addrs))
+		dispatches := make(map[uuid.UUID]dispatchRoute)
+		receivers := make(map[uuid.UUID]receiverRoute)
+		deleteBuckets := make(map[uint32]struct{})
+		dispatchCount := 0
+		visitedScopes := make(map[*Scope]struct{})
+
+		for _, unit := range result.PreScopes {
+			require.True(t, checkPipelineStandaloneExecutableAtRemote(unit))
+			unitAddr := unit.NodeInfo.Addr
+			var walk func(*Scope)
+			walk = func(scope *Scope) {
+				if scope == nil {
+					return
+				}
+				if _, ok := visitedScopes[scope]; ok {
+					return
+				}
+				visitedScopes[scope] = struct{}{}
+				for _, info := range scope.RemoteReceivRegInfos {
+					_, exists := receivers[info.Uuid]
+					require.False(t, exists)
+					receivers[info.Uuid] = receiverRoute{from: info.FromAddr, to: unitAddr}
+				}
+				_ = vm.HandleAllOp(scope.RootOp, func(_ vm.Operator, op vm.Operator) error {
+					switch typed := op.(type) {
+					case *dispatch.Dispatch:
+						dispatchCount++
+						require.Len(t, typed.LocalRegs, dop)
+						require.Len(t, typed.RemoteRegs, (len(addrs)-1)*dop)
+						if unitAddr != c.addr {
+							potentiallyMisplacedBySourceCN[unitAddr] += len(typed.RemoteRegs)
+						}
+						for _, remote := range typed.RemoteRegs {
+							_, exists := dispatches[remote.Uuid]
+							require.False(t, exists)
+							dispatches[remote.Uuid] = dispatchRoute{from: unitAddr, to: remote.NodeAddr}
+						}
+					case *deletion.Deletion:
+						require.True(t, typed.RemoteDelete)
+						require.Equal(t, uint32(len(addrs)*dop), typed.Nbucket)
+						_, exists := deleteBuckets[typed.IBucket]
+						require.False(t, exists)
+						deleteBuckets[typed.IBucket] = struct{}{}
+					}
+					return nil
+				})
+				for _, pre := range scope.PreScopes {
+					walk(pre)
+				}
+			}
+			walk(unit)
+		}
+
+		require.Equal(t, len(addrs)*dop, dispatchCount)
+		require.Len(t, deleteBuckets, len(addrs)*dop)
+		for bucket := range len(addrs) * dop {
+			_, ok := deleteBuckets[uint32(bucket)]
+			require.True(t, ok)
+		}
+		require.Len(t, dispatches, len(addrs)*dop*(len(addrs)-1)*dop)
+		require.Len(t, receivers, len(dispatches))
+		for uid, sender := range dispatches {
+			receiver, ok := receivers[uid]
+			require.True(t, ok)
+			require.Equal(t, sender.from, receiver.from)
+			require.Equal(t, sender.to, receiver.to)
+		}
+	}
+
+	require.Equal(t, 2048,
+		potentiallyMisplacedBySourceCN[addrs[1]]+potentiallyMisplacedBySourceCN[addrs[2]])
+	require.Equal(t, 1024, potentiallyMisplacedBySourceCN[addrs[1]])
+	require.Equal(t, 1024, potentiallyMisplacedBySourceCN[addrs[2]])
+}
+
+func TestNewDeleteMergeScopeGroupsDopOnSingleRemoteCN(t *testing.T) {
+	_ = colexec.NewServer("")
+	c := NewMockCompile(t)
+	c.addr = "cn-coordinator:6001"
+	c.anal = &AnalyzeModule{qry: &plan.Query{}}
+	c.proc.Base.TxnOperator = fakeTxnOperator{}
+
+	const dop = 2
+	sources := make([]*Scope, dop)
+	for i := range sources {
+		sources[i] = newScope(Remote)
+		sources[i].NodeInfo = engine.Node{Addr: "cn-remote:6001", Mcpu: 1}
+		sources[i].Proc = c.proc.NewNoContextChildProc(0)
+		sources[i].setRootOperator(value_scan.NewArgument())
+	}
+	deleteArg := deletion.NewArgument()
+	deleteArg.DeleteCtx = &deletion.DeleteCtx{}
+	result := c.newDeleteMergeScope(deleteArg, sources,
+		&planpb.Node{Stats: &planpb.Stats{HashmapStats: &planpb.HashMapStats{Shuffle: true}}})
+	deleteArg.Release()
+	t.Cleanup(result.release)
+
+	require.Len(t, result.PreScopes, 1)
+	require.Equal(t, "cn-remote:6001", result.PreScopes[0].NodeInfo.Addr)
+	require.True(t, checkPipelineStandaloneExecutableAtRemote(result.PreScopes[0]))
 }
 
 func TestCoordinatorLocalShuffleAttachesRemoteDispatchSource(t *testing.T) {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -435,18 +435,12 @@ func (s *Scope) RemoteRun(c *Compile) error {
 		return s.failRemoteRunBeforeStart(c, err)
 	}
 
-	// In fact, it's not a safe way to convert this pipeline to run at local.
-	//
-	// Just image this case,
-	// pipelineA holds an operator `dispatch d1`, d1 want to send data to pipelineB at node1.
-	// for this operator `d1`, it takes a remote-receiver (the pipelineB), and it will call a rpc for sending.
-	// but now, the pipelineB is not a remote-receiver but in local, the rpc will fail and the B cannot receive anything.
-	// This will cause a hung.
-	//
-	// we should avoid to generate this format pipeline, or do a suitable conversion for the dispatch operator,
-	// or refactor the dispatch operator for no need to know a receiver is local or remote.
+	// Local channel ownership and remote receiver addresses are fixed when the
+	// scope graph is compiled. Moving an incomplete remote tree to this CN would
+	// separate dispatches from their receivers, so reject it before any operator starts.
 	if !checkPipelineStandaloneExecutableAtRemote(s) {
-		return s.MergeRun(c)
+		return s.failRemoteRunBeforeStart(c, moerr.NewInternalErrorNoCtxf(
+			"remote pipeline for CN %q is not standalone executable", s.NodeInfo.Addr))
 	}
 	runtime.ServiceRuntime(s.Proc.GetService()).Logger().
 		Debug("remote run pipeline",
@@ -480,6 +474,9 @@ func (s *Scope) RemoteRun(c *Compile) error {
 }
 
 func (s *Scope) failRemoteRunBeforeStart(c *Compile, err error) error {
+	if c != nil && c.proc != nil && c.proc.Cancel != nil {
+		c.proc.Cancel(err)
+	}
 	cleanPipelineWitchStartFail(s, err, c.isPrepare)
 	return err
 }

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -1918,6 +1918,81 @@ func TestRemoteRunMalformedAddressTerminatesReceiver(t *testing.T) {
 	}
 }
 
+func TestRemoteRunNonStandalonePipelineFailsInsteadOfExecutingOnWrongCN(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := defines.AttachAccountId(context.Background(), catalog.System_Account)
+	proc.Ctx = ctx
+	proc.BuildPipelineContext(ctx)
+	proc.Base.TxnOperator = fakeTxnOperator{}
+	reg := process.NewPipelineEdge(1, 0)
+	rootProc := proc.NewContextChildProc(1)
+	preProc := proc.NewContextChildProc(0)
+	preDispatch := dispatch.NewArgument()
+	preDispatch.LocalRegs = []*process.WaitRegister{reg}
+	pre := &Scope{Magic: Remote, NodeInfo: engine.Node{Addr: "remote:6001"}, Proc: preProc, RootOp: preDispatch}
+	s := &Scope{
+		Magic:     Remote,
+		NodeInfo:  engine.Node{Addr: "remote:6001"},
+		Proc:      rootProc,
+		RootOp:    dispatch.NewArgument(),
+		PreScopes: []*Scope{pre},
+	}
+	c := &Compile{proc: proc, addr: "local:6001"}
+
+	done := make(chan error, 1)
+	go func() { done <- s.RemoteRun(c) }()
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "not standalone executable")
+		require.ErrorIs(t, context.Cause(proc.Ctx), err)
+	case <-time.After(time.Second):
+		proc.Cancel(moerr.NewInternalErrorNoCtx("test timeout"))
+		t.Fatal("non-standalone remote pipeline did not fail promptly")
+	}
+}
+
+func TestMergeRunReturnsWhenRemotePreScopeIsNotStandalone(t *testing.T) {
+	c := NewMockCompile(t)
+	c.execType = plan2.ExecTypeAP_MULTICN
+	c.hasMergeOp = true
+	c.proc.Base.TxnOperator = fakeTxnOperator{}
+
+	parent := &Scope{
+		Magic:  Merge,
+		Proc:   c.proc.NewContextChildProc(1),
+		RootOp: merge.NewArgument(),
+	}
+	outsideReg := process.NewPipelineEdge(1, 0)
+	invalidDispatch := dispatch.NewArgument()
+	invalidDispatch.LocalRegs = []*process.WaitRegister{outsideReg}
+	invalidPreScope := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: "remote:6001"},
+		Proc:     c.proc.NewContextChildProc(0),
+		RootOp:   invalidDispatch,
+	}
+	child := &Scope{
+		Magic:     Remote,
+		NodeInfo:  engine.Node{Addr: "remote:6001"},
+		Proc:      c.proc.NewContextChildProc(0),
+		RootOp:    connector.NewArgument().WithReg(parent.Proc.Reg.MergeReceivers[0]),
+		PreScopes: []*Scope{invalidPreScope},
+	}
+	parent.PreScopes = []*Scope{child}
+	require.False(t, checkPipelineStandaloneExecutableAtRemote(child))
+
+	done := make(chan error, 1)
+	go func() { done <- parent.MergeRun(c) }()
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "not standalone executable")
+		require.ErrorIs(t, context.Cause(parent.Proc.Ctx), err)
+	case <-time.After(2 * time.Second):
+		parent.Proc.Cancel(moerr.NewInternalErrorNoCtx("test timeout"))
+		t.Fatal("merge run hung after a non-standalone remote pre-scope failed")
+	}
+}
+
 func TestMergeRunReturnsWhenRemotePreScopeAddressIsMalformed(t *testing.T) {
 	c := NewMockCompile(t)
 	c.execType = plan2.ExecTypeAP_MULTICN


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26526

## What this PR does / why we need it:

### Root cause

`newDeleteMergeScope` created one receiver scope per delete bucket and attached only source `i` beneath receiver `i`. However, every source `Dispatch.LocalRegs` targeted all same-CN delete receivers. Each receiver tree therefore owned only one of the local channels used by its source dispatch and was not independently executable on its planned CN.

`RemoteRun` silently converted such a remote tree to local `MergeRun` on the coordinator. The dispatch UUID was then registered and executed on the coordinator while `RemoteReceivRegInfo.FromAddr` still named the planned worker CN. Receivers notified a CN that would never publish that UUID and waited indefinitely in `GetProcByUuid`.

The generated topology reproduces the incident exactly: two distributed-delete steps, three CNs with DOP 16, 64 misplaced remote source dispatches, 32 remote UUID routes per source, 2048 coordinator-side waits, and 1024 lookups on each remote CN.

### Incident correlation (sanitized)

The request-changes review correctly noted that the original issue discussion did not publish enough evidence to connect the nightly hang to this path. Rechecking the real CI Loki data and archived raw goroutine snapshots closes that gap:

- At `03:10:10.363181 UTC`, the target restore connection completed authentication and received the OK packet. At `03:10:10.567937`, the planner logged the sanitized query shape `LOAD DATA URL (...) ... PARALLEL=true`.
- At `03:10:10.590517`–`03:10:10.601298`, statement `019fb626-984b-7eda-bb4f-aac9e7d65773`, trace `c8489d33-8079-91e3-8f0b-56321c81ac0d` emitted 128 `remoterunClient.go:155` fallback messages: 64 unique pipeline pointers, each checked twice, explicitly converted to local execution because its dispatch referenced another local pipeline tree.
- In the `03:13:18` coordinator snapshot, the authenticated frontend goroutine is inside `executeStatusStmt -> Compile.Run -> runOnce`. The same compile execution contains 2 `MergeDelete.Call` stacks and 96 `Deletion.remoteDelete` stacks; every remote-delete stack passes through `Scope.RemoteRun -> Scope.MergeRun`. All 64 fallback pipeline pointers from Loki match those raw remote-delete stacks. The remaining 32 are the coordinator-local sources: `2 steps * 3 CNs * DOP 16 = 96`, of which `2 steps * 2 remote CNs * DOP 16 = 64` were misplaced.
- The wait-for graph is exact and stable from the `03:13` snapshots to the `14:50` snapshots: 2048 coordinator `sendNotifyMessageWithFactoryAndWait` waits and 1024 `GetProcByUuid` waits on each of the two remote CNs. The same stacks remained blocked for about 700 minutes.
- The earlier "zero Exec.Run" observation does not mean no statement executed. `status_stmt.go` calls `runner.Run(0)` first and emits `time of Exec.Run` only after it returns; the archived frontend stack shows that call still blocked. The cited salt timeout belongs to a different connection, was already occurring before restore started, and does not appear on the target restore session.

This directly ties the reported restore hang to the distributed `compileDelete -> newDeleteMergeScope -> RemoteRun -> MergeRun` fallback. A literal `DELETE` statement is not required: the physical `Deletion` and `MergeDelete` operators are present in the `LOAD DATA` execution stacks.

### Fix

- Group distributed-delete receiver buckets into one `RemoteRun` envelope per execution CN. Every envelope now owns all same-CN `LocalRegs` referenced by its source dispatches while preserving all delete buckets, UUIDs, and remote routes.
- Validate standalone execution against the complete operator tree that will actually be encoded, including dispatches or connectors wrapped by DML operators.
- Reject any remaining non-standalone remote tree before RPC or operator start, cancel the query context, and do not pre-register phantom dispatch owners on the coordinator.
- Update the `RemoteRun` guide to document the fail-fast contract.

The success path fixes the compiler topology. The runtime checks are a liveness backstop so a future invalid topology returns an error instead of changing placement and hanging.

### Validation

Based on latest `origin/4.2-dev` at `890270f4e6`.

- Focused topology and fail-fast regressions, `count=50`
- Focused race regressions, `count=3`
- Full `pkg/sql/compile` test package
- Full `pkg/sql/compile` test package with race detector
- `go build -mod=readonly ./pkg/sql/compile`
- `go vet -mod=readonly ./pkg/sql/compile`
- `git diff --check`

Regression coverage verifies per-CN standalone execution for multi-CN and single-remote-CN DOP, all `IBucket`/`Nbucket` values, UUID-to-receiver route bijection, the observed 2048/1024/1024 topology, pre-registration ownership, nested operators, direct fail-fast cancellation, and bounded `MergeRun` sibling shutdown.
