### PR TITLE
fix(hakeeper): preserve CN load across batch scheduling

### DIFF
--- a/pkg/hakeeper/task/cn_selector.go
+++ b/pkg/hakeeper/task/cn_selector.go
@@ -61,9 +61,11 @@ func (p *cnPool) selectCNs(rules ...rule) *cnPool {
 	newPool := newCNPool()
 	for _, cn := range p.sortedCN {
 		if matchAllRules(cn.info, rules...) {
-			heap.Push(newPool, cn)
+			newPool.freq[cn.uuid] = p.getFreq(cn.uuid)
+			newPool.sortedCN = append(newPool.sortedCN, cn)
 		}
 	}
+	heap.Init(newPool)
 	return newPool
 }
 

--- a/pkg/hakeeper/task/cn_selector_test.go
+++ b/pkg/hakeeper/task/cn_selector_test.go
@@ -192,3 +192,27 @@ func TestContains(t *testing.T) {
 	assert.True(t, contains([]string{"a"}, "a"))
 	assert.False(t, contains([]string{"a"}, "b"))
 }
+
+func TestSelectCNsPreservesFrequency(t *testing.T) {
+	matching := metadata.LabelList{Labels: []string{"etl"}}
+	pool := newCNPoolWithCNState(pb.CNState{Stores: map[string]pb.CNStoreInfo{
+		"a": {Labels: map[string]metadata.LabelList{"group": matching}},
+		"b": {Labels: map[string]metadata.LabelList{"group": matching}},
+		"c": {Labels: map[string]metadata.LabelList{
+			"group": {Labels: []string{"other"}},
+		}},
+	}})
+	storeA, ok := pool.getStore("a")
+	assert.True(t, ok)
+	storeB, ok := pool.getStore("b")
+	assert.True(t, ok)
+	pool.set(storeA, 3)
+	pool.set(storeB, 1)
+
+	selected := pool.selectCNs(containsLabel("group", "etl"))
+
+	assert.Equal(t, uint32(3), selected.getFreq("a"))
+	assert.Equal(t, uint32(1), selected.getFreq("b"))
+	assert.False(t, selected.contains("c"))
+	assert.Equal(t, "b", selected.min().uuid)
+}

--- a/pkg/hakeeper/task/task_scheduler.go
+++ b/pkg/hakeeper/task/task_scheduler.go
@@ -153,8 +153,8 @@ func allocateTask(
 	if t.Metadata.Options.Resource.GetMemory() > 0 {
 		rules = append(rules, withMemory(t.Metadata.Options.Resource.Memory))
 	}
-	cnPool = cnPool.selectCNs(rules...)
-	runner := cnPool.min()
+	candidateCNPool := cnPool.selectCNs(rules...)
+	runner := candidateCNPool.min()
 	if runner.uuid == "" {
 		runtime.ServiceRuntime(service).Logger().Error("failed to allocate task",
 			zap.Uint64("task-id", t.ID),

--- a/pkg/hakeeper/task/task_scheduler_test.go
+++ b/pkg/hakeeper/task/task_scheduler_test.go
@@ -16,6 +16,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -27,7 +28,23 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type recordingAllocateTaskService struct {
+	taskservice.TaskService
+	err     error
+	runners []string
+}
+
+func (s *recordingAllocateTaskService) Allocate(
+	_ context.Context,
+	_ task.AsyncTask,
+	taskRunner string,
+) error {
+	s.runners = append(s.runners, taskRunner)
+	return s.err
+}
 
 func TestMain(m *testing.M) {
 	logutil.SetupMOLogger(&logutil.LogConfig{
@@ -171,6 +188,92 @@ func TestScheduleCreatedTasks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, query)
 	assert.Equal(t, task.TaskStatus_Running, query[0].Status)
+}
+
+func TestScheduleCreatedTasksBalancesBatchAcrossCNs(t *testing.T) {
+	service := newTestTaskService(t)
+	scheduler := NewScheduler("", func() taskservice.TaskService { return service }, hakeeper.Config{})
+
+	require.NoError(t, service.CreateAsyncTask(context.Background(), task.TaskMetadata{ID: "existing"}))
+	scheduler.Schedule(pb.CNState{Stores: map[string]pb.CNStoreInfo{"a": {}}}, 0)
+
+	require.NoError(t, service.CreateBatch(context.Background(), []task.TaskMetadata{
+		{ID: "new-1"},
+		{ID: "new-2"},
+		{ID: "new-3"},
+	}))
+	scheduler.Schedule(pb.CNState{Stores: map[string]pb.CNStoreInfo{"a": {}, "b": {}}}, 0)
+
+	tasks, err := service.QueryAsyncTask(context.Background(),
+		taskservice.WithTaskStatusCond(task.TaskStatus_Running))
+	require.NoError(t, err)
+	counts := make(map[string]int)
+	for _, asyncTask := range tasks {
+		counts[asyncTask.TaskRunner]++
+	}
+	assert.Equal(t, 2, counts["a"])
+	assert.Equal(t, 2, counts["b"])
+}
+
+func TestScheduleCreatedTasksBalancesFilteredBatch(t *testing.T) {
+	service := newTestTaskService(t)
+	scheduler := NewScheduler("", func() taskservice.TaskService { return service }, hakeeper.Config{})
+	store := func(label string, cpu uint64) pb.CNStoreInfo {
+		return pb.CNStoreInfo{
+			Labels: map[string]metadata.LabelList{
+				"group": {Labels: []string{label}},
+			},
+			Resource: pb.Resource{CPUTotal: cpu, MemTotal: 200},
+		}
+	}
+
+	require.NoError(t, service.CreateAsyncTask(context.Background(), task.TaskMetadata{ID: "existing"}))
+	scheduler.Schedule(pb.CNState{Stores: map[string]pb.CNStoreInfo{"a": store("etl", 2)}}, 0)
+
+	options := task.TaskOptions{
+		Labels:   map[string]string{"group": "etl"},
+		Resource: &task.Resource{CPU: 2, Memory: 200},
+	}
+	require.NoError(t, service.CreateBatch(context.Background(), []task.TaskMetadata{
+		{ID: "new-1", Options: options},
+		{ID: "new-2", Options: options},
+		{ID: "new-3", Options: options},
+	}))
+	scheduler.Schedule(pb.CNState{Stores: map[string]pb.CNStoreInfo{
+		"a": store("etl", 2),
+		"b": store("etl", 2),
+		"c": store("etl", 1),
+		"d": store("other", 2),
+	}}, 0)
+
+	tasks, err := service.QueryAsyncTask(context.Background(),
+		taskservice.WithTaskStatusCond(task.TaskStatus_Running))
+	require.NoError(t, err)
+	counts := make(map[string]int)
+	for _, asyncTask := range tasks {
+		counts[asyncTask.TaskRunner]++
+	}
+	assert.Equal(t, 2, counts["a"])
+	assert.Equal(t, 2, counts["b"])
+	assert.Zero(t, counts["c"])
+	assert.Zero(t, counts["d"])
+}
+
+func TestAllocateTaskUpdatesLoadOnlyOnSuccess(t *testing.T) {
+	pool := newCNPoolWithCNState(pb.CNState{Stores: map[string]pb.CNStoreInfo{"a": {}, "b": {}}})
+	storeA, ok := pool.getStore("a")
+	require.True(t, ok)
+	pool.set(storeA, 1)
+
+	service := &recordingAllocateTaskService{err: errors.New("injected allocation failure")}
+	allocateTask("", service, task.AsyncTask{Metadata: task.TaskMetadata{ID: "failed"}}, pool)
+	assert.Equal(t, []string{"b"}, service.runners)
+	assert.Equal(t, uint32(0), pool.getFreq("b"))
+
+	service.err = nil
+	allocateTask("", service, task.AsyncTask{Metadata: task.TaskMetadata{ID: "succeeded"}}, pool)
+	assert.Equal(t, []string{"b", "b"}, service.runners)
+	assert.Equal(t, uint32(1), pool.getFreq("b"))
 }
 
 func TestReallocateExpiredTasks(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25833

## What this PR does / why we need it:

HAKeeper rebuilt a filtered CN pool for every Created task, but that pool reset the Running-task frequencies. A successful allocation then updated only the temporary pool, so the next task in the same scheduling round saw the same stale load snapshot and could select the same CN repeatedly.

This PR:

- preserves source frequencies when filtering a CN pool;
- selects from the per-task eligible view but records a successful allocation in the shared round pool;
- leaves failed allocations out of the load count;
- adds regressions for existing load, batch scheduling, label/resource filtering, and allocation failure.

The change does not alter label/resource eligibility, expired-CN handling, task persistence, timeout behavior, or tie-breaking.

Tested with:

`./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -run '<each focused regression>' ./pkg/hakeeper/task`

`./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 ./pkg/hakeeper/task`

`./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -run '^TestTaskSchedulerCan(ScheduleTasksToCNs|ReScheduleExpiredTasks)$' ./pkg/logservice`

`go build -mod=readonly ./pkg/hakeeper/task`

`go vet -mod=readonly ./pkg/hakeeper/task`
