### PR TITLE
fix(gossip): disable unsupported push-pull route snapshots

### DIFF
--- a/pkg/gossip/delegate.go
+++ b/pkg/gossip/delegate.go
@@ -15,7 +15,6 @@
 package gossip
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/hashicorp/memberlist"
@@ -23,12 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/query"
 	"github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
-	"github.com/pierrec/lz4/v4"
 	"go.uber.org/zap"
-)
-
-var (
-	binaryEnc = binary.BigEndian
 )
 
 type Module interface {
@@ -167,101 +161,17 @@ func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
 	return data
 }
 
-func (d *delegate) dataCacheState() map[string]*query.CacheKeys {
-	d.dataCacheKey.mu.Lock()
-	defer d.dataCacheKey.mu.Unlock()
-	targetCacheKeys := make(map[string]*query.CacheKeys)
-	for key, target := range d.dataCacheKey.mu.keyTarget {
-		if _, ok := targetCacheKeys[target]; !ok {
-			targetCacheKeys[target] = &query.CacheKeys{}
-		}
-		targetCacheKeys[target].Keys = append(targetCacheKeys[target].Keys, key)
-	}
-	return targetCacheKeys
-}
-
-func (d *delegate) statsInfoState() map[string]*statsinfo.StatsInfoKeys {
-	d.statsInfoKey.mu.Lock()
-	defer d.statsInfoKey.mu.Unlock()
-	targetStatsInfo := make(map[string]*statsinfo.StatsInfoKeys)
-	for key, target := range d.statsInfoKey.mu.keyTarget {
-		if _, ok := targetStatsInfo[target]; !ok {
-			targetStatsInfo[target] = &statsinfo.StatsInfoKeys{}
-		}
-		targetStatsInfo[target].Keys = append(targetStatsInfo[target].Keys, key)
-	}
-	return targetStatsInfo
-}
-
 // LocalState implements the memberlist.Delegate interface.
-func (d *delegate) LocalState(join bool) []byte {
-	// If this a join action, there is no user data on this node.
-	if join {
-		return nil
-	}
-	targetState := gossip.TargetState{
-		Data: map[string]*gossip.LocalState{},
-	}
-
-	for addr, st := range d.dataCacheState() {
-		_, ok := targetState.Data[addr]
-		if !ok {
-			targetState.Data[addr] = &gossip.LocalState{}
-		}
-		targetState.Data[addr].CacheKeys = *st
-	}
-
-	for addr, st := range d.statsInfoState() {
-		_, ok := targetState.Data[addr]
-		if !ok {
-			targetState.Data[addr] = &gossip.LocalState{}
-		}
-		targetState.Data[addr].StatsInfoKeys = *st
-	}
-
-	data, err := targetState.Marshal()
-	if err != nil {
-		d.logger.Error("failed to marshal cache data", zap.Error(err))
-		return nil
-	}
-	dst := make([]byte, lz4.CompressBlockBound(len(data)+4))
-	l := lz4.Compressor{}
-	n, err := l.CompressBlock(data, dst[4:])
-	if err != nil {
-		d.logger.Error("failed to compress cache data", zap.Error(err))
-		return nil
-	}
-	binaryEnc.PutUint32(dst, uint32(len(data)))
-	return dst[:n+4]
+func (d *delegate) LocalState(bool) []byte {
+	// Routes are propagated incrementally by GetBroadcasts and NotifyMsg.
+	// Do not expose route snapshots through memberlist push/pull state.
+	return nil
 }
 
 // MergeRemoteState implements the memberlist.Delegate interface.
-func (d *delegate) MergeRemoteState(buf []byte, join bool) {
-	// We do NOT merge remote user data if this is a pull/push action.
-	// Means that, we only accept user data from a remote node when this
-	// is a new node and is trying to join to the gossip cluster.
-	if !join {
-		return
-	}
-	sz := binaryEnc.Uint32(buf)
-	dst := make([]byte, sz)
-	n, err := lz4.UncompressBlock(buf[4:], dst)
-	if err != nil {
-		d.logger.Error("failed to uncompress cache data from buf", zap.Error(err))
-		return
-	}
-	dst = dst[:n]
-	targetState := gossip.TargetState{}
-	if err := targetState.Unmarshal(dst); err != nil {
-		d.logger.Error("failed to unmarshal cache data", zap.Error(err))
-		return
-	}
-
-	for target, state := range targetState.Data {
-		d.dataCacheKey.update(target, state.CacheKeys.Keys)
-		d.statsInfoKey.update(target, state.StatsInfoKeys.Keys)
-	}
-}
+// Route snapshots are not part of MatrixOne's push/pull protocol, so ignore
+// remote user state without parsing or allocating from untrusted contents.
+func (d *delegate) MergeRemoteState([]byte, bool) {}
 
 // NotifyJoin implements the memberlist.EventDelegate interface.
 func (d *delegate) NotifyJoin(*memberlist.Node) {}

--- a/pkg/gossip/delegate_test.go
+++ b/pkg/gossip/delegate_test.go
@@ -17,7 +17,6 @@ package gossip
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/memberlist"
 	"github.com/matrixorigin/matrixone/pkg/pb/gossip"
@@ -221,114 +220,62 @@ func TestDelegateNotifyLeaveRemovesRoutesOwnedByDepartedNode(t *testing.T) {
 	assert.Equal(t, survivingAddr, receiver.getStatsInfoKey().Target(survivingStatsKey))
 }
 
-func TestDelegateStatsInfoStateDoesNotUseDataCacheMutex(t *testing.T) {
-	d := newDelegate(&zap.Logger{}, "127.0.0.1:8889")
-	d.dataCacheKey.mu.Lock()
-	d.statsInfoKey.mu.Lock()
+func TestDelegatePushPullStateDisabled(t *testing.T) {
+	const senderAddr = "127.0.0.1:8888"
+	sender := newDelegate(zap.NewNop(), senderAddr)
+	receiver := newDelegate(zap.NewNop(), "127.0.0.1:8889")
+	dataKey := query.CacheKey{Path: "data", Offset: 10, Sz: 20}
+	statsKey := statsinfo.StatsInfoKey{DatabaseID: 30, TableID: 40}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		d.statsInfoState()
-	}()
-
-	d.statsInfoKey.mu.Unlock()
-	timer := time.NewTimer(10 * time.Second)
-	defer timer.Stop()
-	select {
-	case <-done:
-		d.dataCacheKey.mu.Unlock()
-	case <-timer.C:
-		d.dataCacheKey.mu.Unlock()
-		<-done
-		t.Fatal("statsInfoState blocked on dataCacheKey")
-	}
-}
-
-func TestDelegate_DataCache_LocalStateAndMergeRemoteState(t *testing.T) {
-	l, err := zap.NewDevelopment()
-	assert.NoError(t, err)
-	d1 := newDelegate(l, "127.0.0.1:8888")
-	d2 := newDelegate(l, "127.0.0.1:8889")
-
-	for i := 0; i < 10; i++ {
-		ck := query.CacheKey{
-			Path:   fmt.Sprintf("p%d", i),
-			Offset: int64(10 * i),
-			Sz:     int64(10 * i),
-		}
-		d1.getDataCacheKey().AddItem(gossip.CommonItem{
-			Operation: gossip.Operation_Set,
-			Key: &gossip.CommonItem_CacheKey{
-				CacheKey: &ck,
-			},
-		})
-		assert.Equal(t, i+1, len(d1.dataCacheKey.queueMu.itemQueue))
+	sender.getDataCacheKey().AddItem(gossip.CommonItem{
+		Operation: gossip.Operation_Set,
+		Key: &gossip.CommonItem_CacheKey{
+			CacheKey: &dataKey,
+		},
+	})
+	sender.getStatsInfoKey().AddItem(gossip.CommonItem{
+		Operation: gossip.Operation_Set,
+		Key: &gossip.CommonItem_StatsInfoKey{
+			StatsInfoKey: &statsKey,
+		},
+	})
+	for _, data := range sender.GetBroadcasts(4, 32*1024) {
+		receiver.NotifyMsg(data)
 	}
 
-	data := d1.GetBroadcasts(4, 32*1024)
-	assert.NotNil(t, data)
-
-	for _, single := range data {
-		d2.NotifyMsg(single)
+	assertRoutesUnchanged := func(t *testing.T) {
+		t.Helper()
+		receiver.dataCacheKey.mu.Lock()
+		assert.Equal(t, map[query.CacheKey]string{dataKey: senderAddr}, receiver.dataCacheKey.mu.keyTarget)
+		receiver.dataCacheKey.mu.Unlock()
+		receiver.statsInfoKey.mu.Lock()
+		assert.Equal(t, map[statsinfo.StatsInfoKey]string{statsKey: senderAddr}, receiver.statsInfoKey.mu.keyTarget)
+		receiver.statsInfoKey.mu.Unlock()
 	}
-	assert.Equal(t, 10, len(d2.dataCacheKey.mu.keyTarget))
+	assertRoutesUnchanged(t)
+	assert.Nil(t, receiver.LocalState(false))
+	assert.Nil(t, receiver.LocalState(true))
 
-	buf := d2.LocalState(false)
-	d2.MergeRemoteState(buf, true)
-	for i := 0; i < 15; i++ {
-		target := d2.getDataCacheKey().Target(query.CacheKey{
-			Path:   fmt.Sprintf("p%d", i),
-			Offset: int64(10 * i),
-			Sz:     int64(10 * i),
-		})
-		if i < 10 {
-			assert.Equal(t, "127.0.0.1:8888", target)
-		} else {
-			assert.Equal(t, "", target)
-		}
+	testCases := []struct {
+		name string
+		buf  []byte
+	}{
+		{name: "empty", buf: nil},
+		{name: "one-byte", buf: []byte{0x01}},
+		{name: "two-bytes", buf: []byte{0x01, 0x02}},
+		{name: "three-bytes", buf: []byte{0x01, 0x02, 0x03}},
+		{name: "four-bytes", buf: []byte{0x00, 0x00, 0x00, 0x00}},
+		{name: "random-bytes", buf: []byte{0x7a, 0x31, 0xf4, 0x09, 0x88, 0x42, 0xce}},
+		{name: "maximum-size-header", buf: []byte{0xff, 0xff, 0xff, 0xff}},
 	}
-}
-
-func TestDelegate_StatsInfo_LocalStateAndMergeRemoteState(t *testing.T) {
-	l, err := zap.NewDevelopment()
-	assert.NoError(t, err)
-	d1 := newDelegate(l, "127.0.0.1:8888")
-	d2 := newDelegate(l, "127.0.0.1:8889")
-
-	for i := 0; i < 10; i++ {
-		si := statsinfo.StatsInfoKey{
-			DatabaseID: uint64(i),
-			TableID:    uint64(10 * i),
-		}
-		d1.getStatsInfoKey().AddItem(gossip.CommonItem{
-			Operation: gossip.Operation_Set,
-			Key: &gossip.CommonItem_StatsInfoKey{
-				StatsInfoKey: &si,
-			},
-		})
-		assert.Equal(t, i+1, len(d1.statsInfoKey.queueMu.itemQueue))
-	}
-
-	data := d1.GetBroadcasts(4, 32*1024)
-	assert.NotNil(t, data)
-
-	for _, single := range data {
-		d2.NotifyMsg(single)
-	}
-	assert.Equal(t, 10, len(d2.statsInfoKey.mu.keyTarget))
-
-	buf := d2.LocalState(false)
-	d2.MergeRemoteState(buf, true)
-	for i := 0; i < 15; i++ {
-		target := d2.getStatsInfoKey().Target(statsinfo.StatsInfoKey{
-			DatabaseID: uint64(i),
-			TableID:    uint64(10 * i),
-		})
-		if i < 10 {
-			assert.Equal(t, "127.0.0.1:8888", target)
-		} else {
-			assert.Equal(t, "", target)
+	for _, join := range []bool{false, true} {
+		for _, testCase := range testCases {
+			t.Run(fmt.Sprintf("join=%t/%s", join, testCase.name), func(t *testing.T) {
+				assert.NotPanics(t, func() {
+					receiver.MergeRemoteState(testCase.buf, join)
+				})
+				assertRoutesUnchanged(t)
+			})
 		}
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25942

## What this PR does / why we need it:

The gossip delegate had a route-snapshot codec that was not part of MatrixOne's effective memberlist protocol: join exchanges called `LocalState(true)`, which already returned nil, while periodic exchanges called `MergeRemoteState(..., false)`, which already ignored the snapshot. Honest nodes therefore never consumed this state, but malformed join state could still reach the decoder and trigger a short-buffer panic or an allocation controlled by its inner length header.

This PR makes that existing protocol decision explicit:

- `LocalState` returns nil for both push/pull modes;
- `MergeRemoteState` ignores remote user state without parsing or allocating;
- the dead binary/LZ4 snapshot codec and state builders are removed;
- the live incremental `GetBroadcasts` / `NotifyMsg` / `NotifyLeave` route path is unchanged.

The effective old/new rolling-upgrade behavior is unchanged. This PR is scoped to MatrixOne's delegate state and does not change the pinned memberlist transport/framing layer.

Tested with:

`./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -run '^TestDelegatePushPullStateDisabled$' ./pkg/gossip`

`./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=45 -run '^TestNodeGossip$' ./pkg/gossip`

`./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 ./pkg/gossip`

`./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -run '^$' ./pkg/cnservice`

`go build -mod=readonly ./pkg/gossip`

`go vet -mod=readonly ./pkg/gossip`
