### PR TITLE
fix: reject invalid DATE runtime assignments

### DIFF
--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -7048,7 +7048,10 @@ func strToDate(proc *process.Process,
 			s := convertByteSliceToString(v)
 			val, err := types.ParseDateCast(s)
 			if err != nil {
-				// Invalid date string returns NULL (MySQL behavior)
+				if assignmentCast {
+					return err
+				}
+				// Invalid date strings in expression casts return SQL NULL.
 				if err := to.Append(dft, true); err != nil {
 					return err
 				}

--- a/pkg/sql/plan/function/func_cast_zero_temporal_test.go
+++ b/pkg/sql/plan/function/func_cast_zero_temporal_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
@@ -264,6 +265,49 @@ func TestAssignmentCastZeroTemporalStringsPreserveSentinels(t *testing.T) {
 
 			assignment := runStringTemporalCast(t, proc, NewStrictCast, tc.input, tc.target, nil)
 			require.False(t, assignment.nulls[0], "assignment cast should preserve zero temporal sentinel")
+		})
+	}
+}
+
+func TestAssignmentDateCastRejectsInvalidStrings(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	proc.GetSessionInfo().TimeZone = time.UTC
+
+	for _, input := range []string{"2020-00-00", "2024-02-31"} {
+		t.Run(input, func(t *testing.T) {
+			// Invalid DATE values in an expression keep the existing CAST
+			// behavior and evaluate to SQL NULL.
+			expression := runStringTemporalCast(
+				t,
+				proc,
+				NewCast,
+				input,
+				types.T_date.ToType(),
+				nil,
+			)
+			require.True(t, expression.nulls[0])
+
+			// Runtime DML assignments, including prepared parameters, use
+			// cast_strict and must not silently persist the invalid value as
+			// NULL when the equivalent literal assignment is rejected.
+			inputVec := testutil.MakeVarcharVector([]string{input}, nil, proc.Mp())
+			defer inputVec.Free(proc.Mp())
+			targetType := vector.NewConstNull(types.T_date.ToType(), 1, proc.Mp())
+			defer targetType.Free(proc.Mp())
+			result := vector.NewFunctionResultWrapper(types.T_date.ToType(), proc.Mp())
+			defer result.Free()
+			require.NoError(t, result.PreExtendAndReset(1))
+
+			err := NewStrictCast(
+				[]*vector.Vector{inputVec, targetType},
+				result,
+				proc,
+				1,
+				nil,
+			)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidArg), err)
+			require.Contains(t, err.Error(), input)
 		})
 	}
 }

--- a/test/distributed/cases/dtype/mysql_compat_temporal_zero.result
+++ b/test/distributed/cases/dtype/mysql_compat_temporal_zero.result
@@ -355,6 +355,18 @@ select id, d, dt, ts from mysql_compat_temporal_zero_dml where id = 40;
 ➤ id[4,32,0]  ¦  d[91,64,0]  ¦  dt[93,64,0]  ¦  ts[93,64,0]  𝄀
 40  ¦  0000-00-00  ¦  0000-00-00 00:00:00  ¦  0000-00-00 00:00:00
 deallocate prepare temporal_zero_insert;
+truncate table mysql_compat_temporal_zero_dml;
+set sql_mode = '';
+prepare temporal_invalid_date_insert from
+'insert into mysql_compat_temporal_zero_dml(id, d) values (?, ?)';
+set @invalid_date_id = 50;
+set @invalid_date_value = '2020-00-00';
+execute temporal_invalid_date_insert using @invalid_date_id, @invalid_date_value;
+invalid argument parsedate, bad value 2020-00-00
+select count(*) as invalid_prepared_date_rows from mysql_compat_temporal_zero_dml;
+➤ invalid_prepared_date_rows[-5,64,0]  𝄀
+0
+deallocate prepare temporal_invalid_date_insert;
 set sql_mode = @old_sql_mode;
 set time_zone = @old_time_zone;
 drop table mysql_compat_temporal_zero;

--- a/test/distributed/cases/dtype/mysql_compat_temporal_zero.test
+++ b/test/distributed/cases/dtype/mysql_compat_temporal_zero.test
@@ -292,6 +292,18 @@ execute temporal_zero_insert;
 select id, d, dt, ts from mysql_compat_temporal_zero_dml where id = 40;
 deallocate prepare temporal_zero_insert;
 
+-- Runtime DATE assignments must not turn an invalid prepared parameter into
+-- SQL NULL. Literal and prepared assignments now reject the same input.
+truncate table mysql_compat_temporal_zero_dml;
+set sql_mode = '';
+prepare temporal_invalid_date_insert from
+    'insert into mysql_compat_temporal_zero_dml(id, d) values (?, ?)';
+set @invalid_date_id = 50;
+set @invalid_date_value = '2020-00-00';
+execute temporal_invalid_date_insert using @invalid_date_id, @invalid_date_value;
+select count(*) as invalid_prepared_date_rows from mysql_compat_temporal_zero_dml;
+deallocate prepare temporal_invalid_date_insert;
+
 set sql_mode = @old_sql_mode;
 set time_zone = @old_time_zone;
 drop table mysql_compat_temporal_zero;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25364

## What this PR does / why we need it:

Runtime string-to-DATE assignments use the internal `cast_strict` path. When
`ParseDateCast` rejected an invalid value, that path still appended SQL `NULL`
and returned success. As a result, a prepared INSERT could silently persist an
invalid DATE parameter as `NULL`, while the equivalent literal INSERT returned
an error.

Propagate the existing parse error only for assignment casts. Generic
expression casts keep their existing invalid-DATE-to-NULL behavior, and valid
full-zero DATE sentinels remain unchanged.

This is intentionally narrower than the full issue: it does not add storage
support for partial-zero dates or implement MySQL's permissive adjusted-value
semantics for INSERT/UPDATE IGNORE.

The regression coverage includes both function-level cast modes and the real
`PREPARE ... EXECUTE USING` DML path, including verification that the failed
statement inserts no row.

Tested with:

`go build -mod=readonly ./pkg/sql/plan/function`

`go vet -mod=readonly ./pkg/sql/plan/function`

`go test -mod=readonly -count=1 -timeout=240s ./pkg/sql/plan/function`

`go test -mod=readonly -race -count=100 -timeout=180s -run '^TestAssignmentDateCastRejectsInvalidStrings$' ./pkg/sql/plan/function`

`go test -mod=readonly -race -count=100 -timeout=180s -run '^TestAssignmentCastZeroTemporalStringsPreserveSentinels$' ./pkg/sql/plan/function`

`go test -mod=readonly -race -count=1 -timeout=300s ./pkg/sql/plan/function`

`go test -mod=readonly -count=1 -run '^(TestMakePlan2AssignmentCastExprUsesStrictForAssignmentTargets|TestForceAssignmentCastExprUsesAssignmentSemantics)$' ./pkg/sql/plan`

The CGo-transitive commands above were run with the repository's deterministic
MatrixOne CGo compile, link, and runtime-loader flags.
