### PR TITLE
fix(frontend): honor zero data branch diff limits

### DIFF
--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -806,6 +806,10 @@ func satisfyDiffOutputOpt(
 		var (
 			rows = make([][]any, 0, 100)
 		)
+		limitReached := func() bool {
+			return stmt.OutputOpt != nil && stmt.OutputOpt.Limit != nil &&
+				int64(len(rows)) >= *stmt.OutputOpt.Limit
+		}
 
 		// Resolve column projection (nil means show all visible columns).
 		displayIdxes, resolveErr := resolveProjectedIdxes(stmt.Columns, tblStuff)
@@ -834,6 +838,12 @@ func satisfyDiffOutputOpt(
 			}
 			// Sparse row: indexed by colIdx+2, so size must accommodate the largest index.
 			rowSize = slices.Max(extractIdxes) + 3
+		}
+
+		if limitReached() {
+			// The limit is already satisfied before consuming any rows (LIMIT 0).
+			hitLimit = true
+			stop()
 		}
 
 		for wrapped := range retCh {
@@ -869,8 +879,7 @@ func satisfyDiffOutputOpt(
 				}
 
 				rows = append(rows, row)
-				if stmt.OutputOpt != nil && stmt.OutputOpt.Limit != nil &&
-					int64(len(rows)) >= *stmt.OutputOpt.Limit {
+				if limitReached() {
 					// hit limit, cancel producers but keep draining the channel
 					hitLimit = true
 					stop()

--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -746,6 +746,61 @@ func TestDataBranchOutputBuildOutputSchema(t *testing.T) {
 	})
 }
 
+func TestDataBranchOutputLimitBoundaries(t *testing.T) {
+	tests := []struct {
+		name      string
+		limit     int64
+		wantRows  uint64
+		wantStops int
+	}{
+		{name: "zero", limit: 0, wantRows: 0, wantStops: 1},
+		{name: "one", limit: 1, wantRows: 1, wantStops: 1},
+		{name: "exact row count", limit: 2, wantRows: 2, wantStops: 1},
+		{name: "above row count", limit: 3, wantRows: 2, wantStops: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			ses := newValidateSession(t)
+			ses.SetMysqlResultSet(&MysqlResultSet{})
+
+			ctrl := gomock.NewController(t)
+			tblStuff := newTestBranchTableStuff(ctrl)
+			bat := tblStuff.retPool.acquireRetBatch(tblStuff, false)
+			t.Cleanup(func() {
+				tblStuff.retPool.freeAllRetBatches(ses.proc.Mp())
+			})
+			for i, name := range []string{"one", "two"} {
+				require.NoError(t, vector.AppendFixed(bat.Vecs[0], int64(i+1), false, ses.proc.Mp()))
+				require.NoError(t, vector.AppendBytes(bat.Vecs[1], []byte(name), false, ses.proc.Mp()))
+				require.NoError(t, vector.AppendBytes(bat.Vecs[2], []byte("hidden"), false, ses.proc.Mp()))
+			}
+			bat.SetRowCount(2)
+
+			retCh := make(chan batchWithKind, 1)
+			retCh <- batchWithKind{name: "child", kind: diffUpdate, batch: bat}
+			close(retCh)
+
+			stopCalls := 0
+			stmt := &tree.DataBranchDiff{OutputOpt: &tree.DiffOutputOpt{Limit: &tt.limit}}
+			require.NoError(t, satisfyDiffOutputOpt(
+				ctx,
+				cancel,
+				func() { stopCalls++ },
+				ses,
+				nil,
+				stmt,
+				branchMetaInfo{},
+				tblStuff,
+				retCh,
+			))
+			require.Equal(t, tt.wantRows, ses.GetMysqlResultSet().GetRowCount())
+			require.Equal(t, tt.wantStops, stopCalls)
+		})
+	}
+}
+
 func TestDataBranchOutputResolveProjectedIdxes(t *testing.T) {
 	tblStuff := tableStuff{}
 	tblStuff.def.colNames = []string{"id", "name", "age"}

--- a/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.result
@@ -1,0 +1,28 @@
+drop database if exists branch_output_limit_zero;
+create database branch_output_limit_zero;
+use branch_output_limit_zero;
+create table base(id int primary key, v int);
+insert into base values (1, 10), (2, 20), (3, 30);
+data branch create table child from base;
+update child set v = v + 1;
+insert into child values (4, 40);
+data branch diff child against base output limit 0;
+➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[4,32,0]
+data branch diff child against base columns (id) output limit 0;
+➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]
+data branch diff child against base output limit 1;
+➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[4,32,0]  𝄀
+child  ¦  UPDATE  ¦  1  ¦  11
+data branch diff child against base output limit 4;
+➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[4,32,0]  𝄀
+child  ¦  UPDATE  ¦  1  ¦  11  𝄀
+child  ¦  UPDATE  ¦  2  ¦  21  𝄀
+child  ¦  UPDATE  ¦  3  ¦  31  𝄀
+child  ¦  INSERT  ¦  4  ¦  40
+data branch diff child against base output limit 5;
+➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[4,32,0]  𝄀
+child  ¦  UPDATE  ¦  1  ¦  11  𝄀
+child  ¦  UPDATE  ¦  2  ¦  21  𝄀
+child  ¦  UPDATE  ¦  3  ¦  31  𝄀
+child  ¦  INSERT  ¦  4  ¦  40
+drop database branch_output_limit_zero;

--- a/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.result
@@ -4,8 +4,7 @@ use branch_output_limit_zero;
 create table base(id int primary key, v int);
 insert into base values (1, 10), (2, 20), (3, 30);
 data branch create table child from base;
-update child set v = v + 1;
-insert into child values (4, 40);
+update child set v = v + 1 where id = 1;
 data branch diff child against base output limit 0;
 ➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[4,32,0]
 data branch diff child against base columns (id) output limit 0;
@@ -13,6 +12,8 @@ data branch diff child against base columns (id) output limit 0;
 data branch diff child against base output limit 1;
 ➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[4,32,0]  𝄀
 child  ¦  UPDATE  ¦  1  ¦  11
+update child set v = v + 1 where id in (2, 3);
+insert into child values (4, 40);
 data branch diff child against base output limit 4;
 ➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[4,32,0]  𝄀
 child  ¦  UPDATE  ¦  1  ¦  11  𝄀

--- a/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.sql
@@ -1,0 +1,22 @@
+-- DATA BRANCH DIFF OUTPUT LIMIT must obey zero and adjacent boundaries.
+
+drop database if exists branch_output_limit_zero;
+create database branch_output_limit_zero;
+use branch_output_limit_zero;
+
+create table base(id int primary key, v int);
+insert into base values (1, 10), (2, 20), (3, 30);
+data branch create table child from base;
+update child set v = v + 1;
+insert into child values (4, 40);
+
+-- Zero rows, both with and without column projection.
+data branch diff child against base output limit 0;
+data branch diff child against base columns (id) output limit 0;
+
+-- Adjacent and upper boundaries retain their existing behavior.
+data branch diff child against base output limit 1;
+data branch diff child against base output limit 4;
+data branch diff child against base output limit 5;
+
+drop database branch_output_limit_zero;

--- a/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_output_limit_zero.sql
@@ -7,15 +7,18 @@ use branch_output_limit_zero;
 create table base(id int primary key, v int);
 insert into base values (1, 10), (2, 20), (3, 30);
 data branch create table child from base;
-update child set v = v + 1;
-insert into child values (4, 40);
+update child set v = v + 1 where id = 1;
 
 -- Zero rows, both with and without column projection.
 data branch diff child against base output limit 0;
 data branch diff child against base columns (id) output limit 0;
 
--- Adjacent and upper boundaries retain their existing behavior.
+-- The adjacent boundary is deterministic because only one row differs here.
 data branch diff child against base output limit 1;
+
+-- Upper boundaries retain their existing behavior for a larger diff set.
+update child set v = v + 1 where id in (2, 3);
+insert into child values (4, 40);
 data branch diff child against base output limit 4;
 data branch diff child against base output limit 5;
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26034

## What this PR does / why we need it:

`DATA BRANCH DIFF ... OUTPUT LIMIT 0` appended the first diff row before checking whether the output limit had already been reached. As a result, a valid zero limit returned one row.

This PR:

- centralizes the row-limit predicate and evaluates it before consuming rows, stopping producers immediately when the limit is zero while retaining the existing channel-drain and batch-recycle protocol;
- adds a focused unit test for limits 0, 1, the exact row count, and a limit above the row count, including producer-stop behavior;
- adds BVT coverage for zero limits with and without column projection, plus adjacent and upper boundaries;
- makes the `LIMIT 1` BVT setup deterministic by testing it while exactly one row differs. This avoids asserting which row an unordered multi-row diff produces first while preserving the row-count boundary coverage.

CI follow-up:

- The first PESSIMISTIC BVT run failed because the new `LIMIT 1` case expected row `id=1`, while the unordered diff validly returned `id=2`. The test setup now has exactly one differing row at that boundary.
- The Coverage job in that workflow was a dependent failure (`coverage merge skipped because at least one required producer was skipped or failed`), not an independent product failure.

Validation:

- `GOWORK=off go build -mod=readonly ./pkg/frontend`
- `GOWORK=off go vet -mod=readonly ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -json -count=1 -timeout=120s -run '^TestDataBranchOutputLimitBoundaries$' ./pkg/frontend`
- focused race stress: `T=0.01s`, `B=30s`, `N=100`; all 100 runs passed
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=300s ./pkg/frontend`
- BVT `branch_output_limit_zero`: 15/15 statements passed at 100% in each of 5 consecutive runs; generated output was manually checked for 0/1/4/5 row semantics

Residual risk: none known. Parsing and positive-limit semantics are unchanged; negative limits remain parser-rejected. Diff row order remains unspecified, and the regression test does not impose an ordering contract.
