### PR TITLE
fix(lockservice): scope backend create timeout to recovery

### DIFF
--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -224,7 +224,10 @@ func WithClientDisableRetry() ClientOption {
 // WithClientLogger set client logger
 func WithClientLogger(logger *zap.Logger) ClientOption {
 	return func(c *client) {
+		// Keep the general client logger quiet for compatibility, but retain the
+		// caller's logger for explicitly rate-limited lifecycle diagnostics.
 		c.logger = logutil.GetPanicLoggerWithLevel(zap.FatalLevel)
+		c.diagnosticLogger = logger
 	}
 }
 
@@ -397,6 +400,12 @@ type client struct {
 		autoCreateQueueWaitTimeout    time.Duration
 		autoCreateQueueWaitTimeoutSet bool
 	}
+
+	// Keep failure-only diagnostics after the pre-existing hot client state so
+	// adding observability does not shift the mutex/pool fields used by every
+	// Send.
+	diagnosticLogger        *zap.Logger
+	autoCreateTimeoutLogger *logutil.RateLimitedLogger
 }
 
 // NewClient create rpc client with options
@@ -449,6 +458,14 @@ func NewClient(
 
 func (c *client) adjust() {
 	c.logger = logutil.Adjust(c.logger).Named(c.name)
+	c.diagnosticLogger = logutil.Adjust(c.diagnosticLogger)
+	// This logger has exactly one static event population. Retain only one keyed
+	// limiter state so a future accidental dynamic key cannot grow per-client
+	// diagnostic memory.
+	c.autoCreateTimeoutLogger = logutil.NewRateLimitedLoggerWithConfig(
+		c.diagnosticLogger,
+		logutil.RateLimitedLoggerConfig{MaxKeys: 1},
+	)
 	if c.createC == nil {
 		c.createC = make(chan string, 16)
 	}
@@ -1449,7 +1466,11 @@ type backendCreateState struct {
 	// ready together can therefore classify the result by event time rather
 	// than scheduler selection order.
 	completedAt atomic.Pointer[time.Time]
-	done        chan struct{}
+	// timeoutObserved deduplicates diagnostics and event metrics for callers
+	// coalesced on this exact create state. The request-impact counter remains
+	// per caller.
+	timeoutObserved atomic.Bool
+	done            chan struct{}
 	// factoryErr is set only when factory I/O completed with an error while
 	// this exact state still owned the remote generation. Closing done
 	// publishes it to waiters. Definitive connection errors are returned
@@ -1943,7 +1964,7 @@ func (c *client) handleAutoCreateWait(
 		!creationStart.IsZero() {
 		elapsed := time.Since(*creationStart)
 		if elapsed >= timeout {
-			return false, c.autoCreateTimeoutError(backend, elapsed, timeout)
+			return false, c.autoCreateTimeoutError(backend, elapsed, timeout, nil)
 		}
 	}
 
@@ -2157,6 +2178,7 @@ func (c *client) handleBackendCreateAdmissionDeadline(
 				backend,
 				time.Since(creationStart),
 				timeout,
+				state,
 			)
 		}
 	}
@@ -2172,6 +2194,7 @@ func (c *client) handleBackendCreateAdmissionDeadline(
 			backend,
 			time.Since(creationStart),
 			timeout,
+			state,
 		)
 	}
 	// The state was replaced without this waiter owning its completion. Treat
@@ -2216,6 +2239,7 @@ func (c *client) waitBackendFactoryCompletion(
 					backend,
 					completedAt.Sub(creationStart),
 					timeout,
+					state,
 				)
 			}
 			select {
@@ -2238,6 +2262,7 @@ func (c *client) waitBackendFactoryCompletion(
 				backend,
 				time.Since(creationStart),
 				timeout,
+				state,
 			)
 		}
 		timer := time.NewTimer(remaining)
@@ -2274,6 +2299,7 @@ func (c *client) classifyBackendFactoryCompletion(
 			backend,
 			completedAt.Sub(creationStart),
 			timeout,
+			state,
 		)
 	}
 	return definitiveBackendCreateError(state.factoryErr)
@@ -2297,7 +2323,7 @@ func (c *client) waitBackendRetryBackoff(
 	if timeout := c.options.autoCreateWaitTimeout; timeout > 0 {
 		remaining := timeout - time.Since(creationStart)
 		if remaining <= 0 {
-			return c.autoCreateTimeoutError(backend, time.Since(creationStart), timeout)
+			return c.autoCreateTimeoutError(backend, time.Since(creationStart), timeout, nil)
 		}
 		if remaining < wait {
 			wait = remaining
@@ -2316,7 +2342,7 @@ func (c *client) waitBackendRetryBackoff(
 	case <-timer.C:
 		if timedByCreateTimeout {
 			timeout := c.options.autoCreateWaitTimeout
-			return c.autoCreateTimeoutError(backend, time.Since(creationStart), timeout)
+			return c.autoCreateTimeoutError(backend, time.Since(creationStart), timeout, nil)
 		}
 		return nil
 	}
@@ -2326,12 +2352,29 @@ func (c *client) autoCreateTimeoutError(
 	backend string,
 	waited time.Duration,
 	timeout time.Duration,
+	state *backendCreateState,
 ) error {
-	c.logger.Warn("auto-create backend timed out",
+	c.metrics.autoCreateTimeoutCounter.Inc()
+	scope := "capacity-or-retry"
+	if state != nil {
+		scope = "create-state"
+		if !state.timeoutObserved.CompareAndSwap(false, true) {
+			return ErrBackendCreateTimeout
+		}
+		c.metrics.autoCreateTimeoutEventCounter.Inc()
+	}
+	c.autoCreateTimeoutLogger.WarnWithConfig(
+		"backend-auto-create-timeout",
+		"auto-create backend timed out",
+		logutil.RateLimitConfig{
+			Interval:   time.Minute,
+			BurstCount: 1,
+		},
+		zap.String("client", c.name),
 		zap.String("backend", backend),
+		zap.String("scope", scope),
 		zap.Duration("waited", waited),
 		zap.Duration("timeout", timeout))
-	c.metrics.autoCreateTimeoutCounter.Inc()
 	return ErrBackendCreateTimeout
 }
 

--- a/pkg/common/morpc/client_backend_deadline_regression_test.go
+++ b/pkg/common/morpc/client_backend_deadline_regression_test.go
@@ -1,0 +1,163 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type lateSuccessfulBackendFactory struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+	calls   atomic.Int32
+}
+
+func (f *lateSuccessfulBackendFactory) Create(
+	string,
+	...BackendOption,
+) (Backend, error) {
+	f.calls.Add(1)
+	f.once.Do(func() { close(f.entered) })
+	<-f.release
+	return &testBackend{activeTime: time.Now()}, nil
+}
+
+// TestAutoCreateDeadlineRejectsLateSuccessfulBackend reproduces the nightly
+// regression shape: many requests coalesce on one backend creation, the
+// factory succeeds after a 500ms wait budget, and every coalesced request
+// observes ErrBackendClosed (20502) even though the backend is published and
+// usable immediately afterwards.
+func TestAutoCreateDeadlineRejectsLateSuccessfulBackend(t *testing.T) {
+	const callers = 100
+	factory := &lateSuccessfulBackendFactory{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	core, observedLogs := observer.New(zap.WarnLevel)
+	rpcClient, err := NewClient(
+		t.Name(),
+		factory,
+		WithClientEnableAutoCreateBackend(),
+		WithClientAutoCreateWaitTimeout(500*time.Millisecond),
+		WithClientDisableCircuitBreaker(),
+		WithClientLogger(zap.New(core)),
+	)
+	require.NoError(t, err)
+	client := rpcClient.(*client)
+	timeoutsBefore := testutil.ToFloat64(client.metrics.autoCreateTimeoutCounter)
+	eventsBefore := testutil.ToFloat64(client.metrics.autoCreateTimeoutEventCounter)
+
+	var releaseOnce sync.Once
+	releaseFactory := func() {
+		releaseOnce.Do(func() { close(factory.release) })
+	}
+	t.Cleanup(func() {
+		releaseFactory()
+		require.NoError(t, rpcClient.Close())
+	})
+
+	type result struct {
+		future *Future
+		err    error
+	}
+	results := make(chan result, callers)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(callers)
+	for i := range callers {
+		go func(id int) {
+			ready.Done()
+			<-start
+			future, sendErr := rpcClient.Send(
+				context.Background(),
+				"remote-lock-service",
+				newTestMessage(uint64(id+1)),
+			)
+			results <- result{
+				future: future,
+				err:    sendErr,
+			}
+		}(i)
+	}
+	ready.Wait()
+	close(start)
+
+	select {
+	case <-factory.entered:
+	case <-time.After(time.Second):
+		t.Fatal("backend factory did not start")
+	}
+
+	for range callers {
+		select {
+		case got := <-results:
+			if got.future != nil {
+				got.future.Close()
+			}
+			require.ErrorIs(t, got.err, ErrBackendCreateTimeout)
+			require.True(t,
+				moerr.IsMoErrCode(got.err, moerr.ErrBackendClosed),
+				"late successful create surfaced as %v", got.err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("coalesced request did not hit the backend-create deadline")
+		}
+	}
+
+	require.EqualValues(t, 1, factory.calls.Load())
+	require.Equal(t, float64(callers),
+		testutil.ToFloat64(client.metrics.autoCreateTimeoutCounter)-timeoutsBefore)
+	require.Equal(t, float64(1),
+		testutil.ToFloat64(client.metrics.autoCreateTimeoutEventCounter)-eventsBefore)
+	require.Len(t, observedLogs.All(), 1,
+		"coalesced waiters must produce one rate-limited lifecycle warning")
+	require.Equal(t, 1, client.autoCreateTimeoutLogger.StateCount())
+	logFields := observedLogs.All()[0].ContextMap()
+	require.Equal(t, "backend-auto-create-timeout", logFields["event"])
+	require.Equal(t, t.Name(), logFields["client"])
+	require.Equal(t, "create-state", logFields["scope"])
+	releaseFactory()
+	require.Eventually(t, func() bool {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		return len(client.mu.backends["remote-lock-service"]) == 1
+	}, time.Second, time.Millisecond)
+
+	postCreateCtx, cancelPostCreate := context.WithTimeout(
+		context.Background(),
+		time.Second,
+	)
+	defer cancelPostCreate()
+	future, err := rpcClient.Send(
+		postCreateCtx,
+		"remote-lock-service",
+		newTestMessage(callers+1),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, future)
+	defer future.Close()
+	_, err = future.Get()
+	require.NoError(t, err)
+}

--- a/pkg/common/morpc/metrics.go
+++ b/pkg/common/morpc/metrics.go
@@ -47,6 +47,7 @@ type metrics struct {
 	connectDurationHistogram      prometheus.Observer
 	doneDurationHistogram         prometheus.Observer
 	autoCreateTimeoutCounter      prometheus.Counter // tracks auto-create wait timeouts
+	autoCreateTimeoutEventCounter prometheus.Counter // tracks distinct create states causing wait timeouts
 	backendUnavailableCounter     prometheus.Counter // tracks backend unavailable (pool has backends but all down)
 }
 
@@ -72,6 +73,7 @@ func newMetrics(name string) *metrics {
 		inputBytesCounter:             v2.NewRPCInputCounter(),
 		outputBytesCounter:            v2.NewRPCOutputCounter(),
 		autoCreateTimeoutCounter:      v2.NewRPCBackendAutoCreateTimeoutCounterByName(name),
+		autoCreateTimeoutEventCounter: v2.NewRPCBackendAutoCreateTimeoutEventCounterByName(name),
 		backendUnavailableCounter:     v2.NewRPCBackendUnavailableCounterByName(name),
 	}
 }
@@ -92,6 +94,9 @@ func rpcMetricErrorType(err error) string {
 	}
 	if moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect) {
 		return "backend_cannot_connect"
+	}
+	if errors.Is(err, ErrBackendCreateTimeout) {
+		return "backend_create_timeout"
 	}
 	if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) || errors.Is(err, backendClosed) {
 		return "backend_closed"

--- a/pkg/common/morpc/status_test.go
+++ b/pkg/common/morpc/status_test.go
@@ -16,6 +16,7 @@ package morpc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -139,6 +140,8 @@ func TestRPCMetricErrorType(t *testing.T) {
 		{"rpc timeout", moerr.NewRPCTimeoutNoCtx(), "rpc_timeout"},
 		{"backend cannot connect", moerr.NewBackendCannotConnectNoCtx(), "backend_cannot_connect"},
 		{"backend cannot connect wraps net error", moerr.NewBackendCannotConnectNoCtx(&mockNetError{}), "backend_cannot_connect"},
+		{"backend create timeout", ErrBackendCreateTimeout, "backend_create_timeout"},
+		{"wrapped backend create timeout", fmt.Errorf("wrapped: %w", ErrBackendCreateTimeout), "backend_create_timeout"},
 		{"backend closed", moerr.NewBackendClosedNoCtx(), "backend_closed"},
 		{"moerr unexpected eof", moerr.NewUnexpectedEOFNoCtx("test"), "unexpected_eof"},
 		{"unexpected eof", io.ErrUnexpectedEOF, "unexpected_eof"},

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -44,12 +44,12 @@ var (
 	defaultRPCEnqueueTimeout   = time.Second * 5
 	defaultHandleWorkers       = 12
 	defaultHandleGetTxnWorkers = 4
-	// Backend creation/recovery must fail fast when a remote lock service is
-	// gone. Factory execution and process-local queue admission are different
-	// failure domains: the former is peer health, while the latter is transient
-	// local congestion and must not trip the peer circuit breaker.
-	backendCreateWaitTimeout      = 500 * time.Millisecond
-	backendCreateQueueWaitTimeout = 5 * time.Second
+	// Recovery identity and validation probes must fail fast when a remote lock
+	// service is gone. Factory execution and process-local queue admission are
+	// different failure domains: the former is peer health, while the latter is
+	// transient local congestion and must not trip the peer circuit breaker.
+	recoveryBackendCreateWaitTimeout = 500 * time.Millisecond
+	backendCreateQueueWaitTimeout    = 5 * time.Second
 	// Recovery endpoints are hints: eviction safely falls back to service
 	// discovery and the negative-response confirmation path. Keep a hard bound
 	// so historical CN UUID churn cannot grow the client for its whole lifetime.
@@ -153,14 +153,11 @@ func NewClient(
 		morpc.WithBackendReadTimeout(defaultRPCTimeout),
 		morpc.WithBackendFreeOrphansResponse(releaseResponse))
 
-	// Bound backend creation for every lockservice transport. The short budget
-	// starts only when peer factory work is admitted; the longer, independent
-	// queue budget bounds local congestion without attributing it to the peer.
-	c.cfg.ClientOptions = append(
-		c.cfg.ClientOptions,
-		morpc.WithClientAutoCreateWaitTimeout(backendCreateWaitTimeout),
-		morpc.WithClientAutoCreateQueueWaitTimeout(backendCreateQueueWaitTimeout),
-	)
+	// Bound process-local create-queue congestion for every transport. Normal
+	// Lock/Unlock, keepalive, and control traffic must otherwise follow the
+	// caller's context: a healthy peer can legitimately take more than 500ms to
+	// establish a cold connection when a CN is CPU saturated.
+	*c.cfg = withBackendCreateQueueWaitTimeout(*c.cfg)
 	controlClient, err := c.cfg.NewControlClient(
 		service,
 		"lock-control-client",
@@ -176,6 +173,7 @@ func NewClient(
 			return controlClient.Ping(ctx, remote)
 		}),
 	)
+	recoveryConfig := withBackendCreateWaitTimeout(*c.cfg)
 
 	client, err := c.cfg.NewClient(
 		service,
@@ -186,7 +184,7 @@ func NewClient(
 	}
 	c.client = client
 	createdClients = append(createdClients, client)
-	activeTxnClient, err := c.cfg.NewClient(
+	activeTxnClient, err := recoveryConfig.NewClient(
 		service,
 		"lock-active-txn-client",
 		func() morpc.Message { return acquireResponse() })
@@ -195,7 +193,7 @@ func NewClient(
 	}
 	c.activeTxnClient = activeTxnClient
 	createdClients = append(createdClients, activeTxnClient)
-	validationClient, err := c.cfg.NewClient(
+	validationClient, err := recoveryConfig.NewClient(
 		service,
 		"lock-validation-client",
 		func() morpc.Message { return acquireResponse() })
@@ -221,6 +219,26 @@ func NewClient(
 	c.keeperClient = keeperClient
 	createdClients = append(createdClients, keeperClient)
 	return c, nil
+}
+
+func withBackendCreateWaitTimeout(cfg morpc.Config) morpc.Config {
+	cfg.ClientOptions = append(
+		append([]morpc.ClientOption(nil), cfg.ClientOptions...),
+		morpc.WithClientAutoCreateWaitTimeout(
+			recoveryBackendCreateWaitTimeout,
+		),
+	)
+	return cfg
+}
+
+func withBackendCreateQueueWaitTimeout(cfg morpc.Config) morpc.Config {
+	cfg.ClientOptions = append(
+		append([]morpc.ClientOption(nil), cfg.ClientOptions...),
+		morpc.WithClientAutoCreateQueueWaitTimeout(
+			backendCreateQueueWaitTimeout,
+		),
+	)
+	return cfg
 }
 
 func closeCreatedClients(clients []io.Closer) error {
@@ -442,6 +460,9 @@ func lockserviceRemoteRPCErrorType(err error) string {
 	}
 	if moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect) {
 		return "backend_cannot_connect"
+	}
+	if errors.Is(err, morpc.ErrBackendCreateTimeout) {
+		return "backend_create_timeout"
 	}
 	if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) {
 		return "backend_closed"

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -176,6 +177,57 @@ type closeResultRPCServer struct {
 	calls int
 }
 
+type blockingBackendFactory struct {
+	entered chan struct{}
+	release chan struct{}
+	started atomic.Bool
+}
+
+func (f *blockingBackendFactory) Create(
+	string,
+	...morpc.BackendOption,
+) (morpc.Backend, error) {
+	if f.started.CompareAndSwap(false, true) {
+		close(f.entered)
+	}
+	<-f.release
+	return timeoutPolicyTestBackend{}, nil
+}
+
+type timeoutPolicyTestBackend struct{}
+
+var errTimeoutPolicyBackendReached = errors.New("backend reached")
+
+func (timeoutPolicyTestBackend) Send(
+	context.Context,
+	morpc.Message,
+) (*morpc.Future, error) {
+	return nil, errTimeoutPolicyBackendReached
+}
+
+func (timeoutPolicyTestBackend) SendInternal(
+	context.Context,
+	morpc.Message,
+) (*morpc.Future, error) {
+	return nil, errTimeoutPolicyBackendReached
+}
+
+func (timeoutPolicyTestBackend) NewStream(bool) (morpc.Stream, error) {
+	return nil, errTimeoutPolicyBackendReached
+}
+
+func (timeoutPolicyTestBackend) Close() {}
+
+func (timeoutPolicyTestBackend) Busy() bool { return false }
+
+func (timeoutPolicyTestBackend) LastActiveTime() time.Time { return time.Now() }
+
+func (timeoutPolicyTestBackend) Lock() {}
+
+func (timeoutPolicyTestBackend) Unlock() {}
+
+func (timeoutPolicyTestBackend) Locked() bool { return false }
+
 func (s *closeResultRPCServer) Start() error {
 	return nil
 }
@@ -199,6 +251,8 @@ func TestLockserviceRemoteRPCErrorType(t *testing.T) {
 		{"nil", nil, ""},
 		{"rpc timeout", moerr.NewRPCTimeoutNoCtx(), "rpc_timeout"},
 		{"backend cannot connect", moerr.NewBackendCannotConnectNoCtx(), "backend_cannot_connect"},
+		{"backend create timeout", morpc.ErrBackendCreateTimeout, "backend_create_timeout"},
+		{"wrapped backend create timeout", fmt.Errorf("wrapped: %w", morpc.ErrBackendCreateTimeout), "backend_create_timeout"},
 		{"backend closed", moerr.NewBackendClosedNoCtx(), "backend_closed"},
 		{"unexpected eof", io.ErrUnexpectedEOF, "unexpected_eof"},
 		{"caller context deadline ignored", context.DeadlineExceeded, ""},
@@ -210,6 +264,136 @@ func TestLockserviceRemoteRPCErrorType(t *testing.T) {
 			assert.Equal(t, tt.want, lockserviceRemoteRPCErrorType(tt.err))
 		})
 	}
+}
+
+func TestLockserviceBackendCreateTimeoutPolicy(t *testing.T) {
+	normal := withBackendCreateQueueWaitTimeout(morpc.Config{
+		ClientOptions: []morpc.ClientOption{
+			morpc.WithClientEnableAutoCreateBackend(),
+			morpc.WithClientDisableCircuitBreaker(),
+		},
+	})
+	recovery := withBackendCreateWaitTimeout(normal)
+
+	require.Len(t, normal.ClientOptions, 3,
+		"normal lock traffic must not inherit the recovery factory deadline")
+	require.Len(t, recovery.ClientOptions, 4)
+
+	t.Run("normal traffic follows caller context", func(t *testing.T) {
+		factory := &blockingBackendFactory{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		client, err := morpc.NewClient(
+			t.Name(),
+			factory,
+			normal.ClientOptions...,
+		)
+		require.NoError(t, err)
+		var released atomic.Bool
+		release := func() {
+			if released.CompareAndSwap(false, true) {
+				close(factory.release)
+			}
+		}
+		t.Cleanup(func() {
+			release()
+			require.NoError(t, client.Close())
+		})
+
+		result := make(chan error, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		go func() {
+			result <- client.Ping(ctx, "normal-backend")
+		}()
+		select {
+		case <-factory.entered:
+		case <-time.After(time.Second):
+			t.Fatal("normal backend factory did not start")
+		}
+		select {
+		case err := <-result:
+			t.Fatalf("normal traffic stopped at the recovery deadline: %v", err)
+		case <-time.After(recoveryBackendCreateWaitTimeout + 100*time.Millisecond):
+		}
+		release()
+		select {
+		case err := <-result:
+			require.ErrorIs(t, err, errTimeoutPolicyBackendReached)
+		case <-time.After(time.Second):
+			t.Fatal("normal backend did not become usable after creation")
+		}
+	})
+
+	t.Run("recovery traffic keeps fast failure", func(t *testing.T) {
+		factory := &blockingBackendFactory{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		client, err := morpc.NewClient(
+			t.Name(),
+			factory,
+			recovery.ClientOptions...,
+		)
+		require.NoError(t, err)
+		defer func() {
+			close(factory.release)
+			require.NoError(t, client.Close())
+		}()
+
+		result := make(chan error, 1)
+		go func() {
+			result <- client.Ping(context.Background(), "recovery-backend")
+		}()
+		select {
+		case <-factory.entered:
+		case <-time.After(time.Second):
+			t.Fatal("recovery backend factory did not start")
+		}
+		select {
+		case err := <-result:
+			require.ErrorIs(t, err, morpc.ErrBackendCreateTimeout)
+		case <-time.After(2 * time.Second):
+			t.Fatal("recovery traffic did not honor the backend-create deadline")
+		}
+	})
+
+	t.Run("normal traffic remains caller cancellable", func(t *testing.T) {
+		factory := &blockingBackendFactory{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		client, err := morpc.NewClient(
+			t.Name(),
+			factory,
+			normal.ClientOptions...,
+		)
+		require.NoError(t, err)
+		defer func() {
+			close(factory.release)
+			require.NoError(t, client.Close())
+		}()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		result := make(chan error, 1)
+		go func() {
+			result <- client.Ping(ctx, "cancelled-normal-backend")
+		}()
+		select {
+		case <-factory.entered:
+		case <-time.After(time.Second):
+			t.Fatal("normal backend factory did not start")
+		}
+		cancel()
+		select {
+		case err := <-result:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(time.Second):
+			t.Fatal("normal traffic did not observe caller cancellation")
+		}
+	})
 }
 
 func TestCloseCreatedClientsClosesInReverseAndJoinsErrors(t *testing.T) {

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_rpc.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_rpc.go
@@ -207,11 +207,14 @@ func (c *DashboardCreator) initRPCConnectionMetricsRow() dashboard.Option {
 func (c *DashboardCreator) initRPCBackendHealthRow() dashboard.Option {
 	return dashboard.Row(
 		"Backend Health & Failures",
-		c.withGraph(
-			"Auto-Create Timeout Rate",
+		c.withMultiGraph(
+			"Auto-Create Timeout Impact vs Events",
 			4,
-			`sum(rate(`+c.getMetricWithFilter("mo_rpc_backend_auto_create_timeout_total", "")+`[$interval])) by (name)`,
-			"{{ name }}",
+			[]string{
+				`sum(rate(` + c.getMetricWithFilter("mo_rpc_backend_auto_create_timeout_total", "") + `[$interval])) by (name)`,
+				`sum(rate(` + c.getMetricWithFilter("mo_rpc_backend_auto_create_timeout_event_total", "") + `[$interval])) by (name)`,
+			},
+			[]string{"{{ name }} - requests", "{{ name }} - create events"},
 			axis.Unit("timeouts/s"),
 			axis.Min(0)),
 

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -219,6 +219,7 @@ func initRPCMetrics() {
 	registry.MustRegister(rpcGCInactiveProcessedCounter)
 	registry.MustRegister(rpcGCCreateProcessedCounter)
 	registry.MustRegister(rpcBackendAutoCreateTimeoutCounter)
+	registry.MustRegister(rpcBackendAutoCreateTimeoutEventCounter)
 	registry.MustRegister(rpcBackendUnavailableCounter)
 	registry.MustRegister(rpcCircuitBreakerStateGauge)
 	registry.MustRegister(rpcCircuitBreakerTripsCounter)

--- a/pkg/util/metric/v2/morpc.go
+++ b/pkg/util/metric/v2/morpc.go
@@ -107,6 +107,14 @@ var (
 			Help:      "Total number of auto-create backend wait timeouts.",
 		}, []string{"name"})
 
+	rpcBackendAutoCreateTimeoutEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "rpc",
+			Name:      "backend_auto_create_timeout_event_total",
+			Help:      "Total number of distinct backend-create states that caused one or more auto-create wait timeouts.",
+		}, []string{"name"})
+
 	rpcBackendUnavailableCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "mo",
@@ -374,6 +382,10 @@ func GetRPCGCInactiveProcessedCounter() prometheus.Counter {
 
 func NewRPCBackendAutoCreateTimeoutCounterByName(name string) prometheus.Counter {
 	return rpcBackendAutoCreateTimeoutCounter.WithLabelValues(name)
+}
+
+func NewRPCBackendAutoCreateTimeoutEventCounterByName(name string) prometheus.Counter {
+	return rpcBackendAutoCreateTimeoutEventCounter.WithLabelValues(name)
 }
 
 func NewRPCBackendUnavailableCounterByName(name string) prometheus.Counter {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26547

Related: #26475

Nightly regression: https://github.com/matrixorigin/mo-nightly-regression/actions/runs/30649446904/job/91275888648

## What this PR does / why we need it:

The failing 1000-thread sysbench run returned 100 lock RPC errors as backend-closed (20502). Incident metrics show the same 88/12 split across two clients in both MORPC auto-create timeouts and lockservice backend-closed errors, with no create-queue full/drop, circuit-breaker trip, pod restart, or OOM. The connection factory was delayed while the CNs were CPU saturated, so the lockservice-wide 500ms backend-create deadline expired for all callers coalesced on those two cold connections.

The direct mechanism is not unique to #26473: the 500ms lockservice setting came from #23435, and a genuinely blocked factory reproduces the 100/100 failure on both the pre-#26473 baseline and the incident MORPC code. #26473 makes completion-at-the-deadline classification deterministic, which can affect the boundary, but a real factory delay beyond 500ms does not require that change.

This PR:

- keeps the independent 5s local create-queue admission bound on every lockservice transport;
- limits the 500ms peer-health deadline to active-transaction recovery and service-validation transports, where fast failure is required;
- lets normal Lock/Unlock, keeper, and control traffic follow their already-bounded caller contexts and the backend's 5s connect timeout;
- preserves the independent liveness probe in recovery client configs;
- classifies backend-create timeout separately from generic backend-closed in MORPC and lockservice metrics;
- adds a low-cardinality distinct-create-event counter alongside the existing per-request impact counter;
- emits at most one warning per create state and rate-limits the static event to one log per client per minute;
- updates the RPC Grafana panel to compare affected requests with distinct create events.

Deep-review hardening:

- the timeout logger retains only one keyed limiter state, bounding future accidental dynamic-key growth;
- failure-only diagnostic fields are placed after the pre-existing hot client state, preserving mutex/pool field offsets used by every Send;
- normal traffic is tested for prompt caller cancellation while factory creation remains blocked;
- wrapped create-timeout errors retain their dedicated metric classification.

The regression tests construct a successful but delayed backend factory. They verify 100 coalesced callers all reproduce 20502 at 500ms, while producing 100 impact counts, one event count, one retained limiter key, and one warning. The lockservice policy test verifies normal traffic succeeds after waiting beyond 500ms, remains caller-cancellable, and recovery traffic still fails fast.

Verification after rebasing onto latest main:

- focused fan-out race: T=0.5s, B=30s, N=60
- focused lockservice role/cancellation race: T=1.11s, B=30s, N=27
- admission-boundary, nil-state timeout, and error-classification race: N=100 each
- full `./pkg/common/morpc` race: passed
- full `./pkg/lockservice` race: passed
- full non-race MORPC, lockservice, and metric-v2 tests: passed
- build and vet for all four modified packages: passed
- hot-path benchmark, clean main vs PR: both 144 B/op and 1 alloc/op; PR 207-212 ns/op vs main 210-211 ns/op
- dashboard compile-only test: passed; its live-Grafana tests require `127.0.0.1:80` and fail identically on clean HEAD when Grafana is absent
