### PR TITLE
fix(data branch): support binary primary keys

### DIFF
--- a/pkg/objectio/mergeutil/types.go
+++ b/pkg/objectio/mergeutil/types.go
@@ -110,7 +110,8 @@ func MergeSortBatches(
 	case types.T_uuid:
 		ds := &fixedDataSlice[types.Uuid]{getFixedCols[types.Uuid](batches, sortKeyIdx)}
 		merge = newMerge(sort.UuidLess, ds, nulls)
-	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_datalink:
+	case types.T_char, types.T_varchar, types.T_blob, types.T_text,
+		types.T_binary, types.T_varbinary, types.T_datalink:
 		ds := &varlenaDataSlice{getVarlenaCols(batches, sortKeyIdx)}
 		merge = newMerge(sort.GenericLess[string], ds, nulls)
 	case types.T_Rowid:

--- a/pkg/objectio/mergeutil/types_test.go
+++ b/pkg/objectio/mergeutil/types_test.go
@@ -144,6 +144,52 @@ func TestMergeSortBatchesYear(t *testing.T) {
 	require.Equal(t, []int32{10, 20, 30, 40, 50}, gotPayloads)
 }
 
+func TestMergeSortBatchesBinaryTypes(t *testing.T) {
+	testCases := []struct {
+		name string
+		typ  types.Type
+	}{
+		{name: "binary", typ: types.New(types.T_binary, 4, 0)},
+		{name: "varbinary", typ: types.New(types.T_varbinary, 8, 0)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := mpool.MustNewZero()
+			batches := []*batch.Batch{
+				newVarlenaMergeBatch(t, mp, tc.typ,
+					[][]byte{{0x00}, {'b'}, {0xff}}, []int32{10, 30, 50}),
+				newVarlenaMergeBatch(t, mp, tc.typ,
+					[][]byte{{0x00, 0x01}, {'a'}, {'b', 0x00}}, []int32{20, 40, 60}),
+			}
+			for _, bat := range batches {
+				defer bat.Clean(mp)
+			}
+
+			newBuffer := func() *batch.Batch {
+				return batch.NewWithSchema(false, []string{"id", "payload"}, []types.Type{tc.typ, types.T_int32.ToType()})
+			}
+			buffer := newBuffer()
+
+			var gotKeys [][]byte
+			var gotPayloads []int32
+			buffer, err := MergeSortBatches(batches, 0, buffer, func(out *batch.Batch) (*batch.Batch, error) {
+				payloads := vector.MustFixedColNoTypeCheck[int32](out.Vecs[1])
+				for i := 0; i < out.RowCount(); i++ {
+					gotKeys = append(gotKeys, append([]byte(nil), out.Vecs[0].GetBytesAt(i)...))
+					gotPayloads = append(gotPayloads, payloads[i])
+				}
+				out.Clean(mp)
+				return newBuffer(), nil
+			}, mp, nil)
+			require.NoError(t, err)
+			defer buffer.Clean(mp)
+			require.Equal(t, [][]byte{{0x00}, {0x00, 0x01}, {'a'}, {'b'}, {'b', 0x00}, {0xff}}, gotKeys)
+			require.Equal(t, []int32{10, 20, 40, 30, 60, 50}, gotPayloads)
+		})
+	}
+}
+
 func newDecimal256MergeBatch(
 	t *testing.T,
 	mp *mpool.MPool,
@@ -177,6 +223,25 @@ func newYearMergeBatch(
 	bat := batch.NewWithSchema(false, []string{"id", "payload"}, []types.Type{types.T_year.ToType(), types.T_int32.ToType()})
 	for i, key := range keys {
 		require.NoError(t, vector.AppendFixed(bat.Vecs[0], key, false, mp))
+		require.NoError(t, vector.AppendFixed(bat.Vecs[1], payloads[i], false, mp))
+	}
+	bat.SetRowCount(len(keys))
+	return bat
+}
+
+func newVarlenaMergeBatch(
+	t *testing.T,
+	mp *mpool.MPool,
+	typ types.Type,
+	keys [][]byte,
+	payloads []int32,
+) *batch.Batch {
+	t.Helper()
+	require.Len(t, payloads, len(keys))
+
+	bat := batch.NewWithSchema(false, []string{"id", "payload"}, []types.Type{typ, types.T_int32.ToType()})
+	for i, key := range keys {
+		require.NoError(t, vector.AppendBytes(bat.Vecs[0], key, false, mp))
 		require.NoError(t, vector.AppendFixed(bat.Vecs[1], payloads[i], false, mp))
 	}
 	bat.SetRowCount(len(keys))

--- a/test/distributed/cases/git4data/branch/edge/branch_binary_pk.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_binary_pk.result
@@ -1,0 +1,44 @@
+drop database if exists branch_binary_pk;
+create database branch_binary_pk;
+use branch_binary_pk;
+create table binary_base(k binary(4) primary key, v int);
+insert into binary_base values
+(x'00', 10),
+(x'0061', 20),
+(x'61', 30),
+(x'ff', 40);
+data branch create table binary_branch from binary_base;
+select hex(k) as k, v from binary_branch order by k;
+➤ k[12,-1,0]  ¦  v[4,32,0]  𝄀
+00000000  ¦  10  𝄀
+00610000  ¦  20  𝄀
+61000000  ¦  30  𝄀
+FF000000  ¦  40
+update binary_branch set v = 31 where hex(k) = '61000000';
+select v as binary_base_v from binary_base where hex(k) = '61000000';
+➤ binary_base_v[4,32,0]  𝄀
+30
+select v as binary_branch_v from binary_branch where hex(k) = '61000000';
+➤ binary_branch_v[4,32,0]  𝄀
+31
+create table varbinary_base(k varbinary(8) primary key, v int);
+insert into varbinary_base values
+(x'00', 10),
+(x'0001', 20),
+(x'61', 30),
+(x'ff', 40);
+data branch create table varbinary_branch from varbinary_base;
+select hex(k) as k, v from varbinary_branch order by k;
+➤ k[12,-1,0]  ¦  v[4,32,0]  𝄀
+00  ¦  10  𝄀
+0001  ¦  20  𝄀
+61  ¦  30  𝄀
+FF  ¦  40
+update varbinary_branch set v = 31 where k = x'61';
+select v as varbinary_base_v from varbinary_base where k = x'61';
+➤ varbinary_base_v[4,32,0]  𝄀
+30
+select v as varbinary_branch_v from varbinary_branch where k = x'61';
+➤ varbinary_branch_v[4,32,0]  𝄀
+31
+drop database branch_binary_pk;

--- a/test/distributed/cases/git4data/branch/edge/branch_binary_pk.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_binary_pk.sql
@@ -1,0 +1,30 @@
+-- DATA BRANCH must preserve and sort fixed- and variable-length binary primary keys.
+drop database if exists branch_binary_pk;
+create database branch_binary_pk;
+use branch_binary_pk;
+
+create table binary_base(k binary(4) primary key, v int);
+insert into binary_base values
+  (x'00', 10),
+  (x'0061', 20),
+  (x'61', 30),
+  (x'ff', 40);
+data branch create table binary_branch from binary_base;
+select hex(k) as k, v from binary_branch order by k;
+update binary_branch set v = 31 where hex(k) = '61000000';
+select v as binary_base_v from binary_base where hex(k) = '61000000';
+select v as binary_branch_v from binary_branch where hex(k) = '61000000';
+
+create table varbinary_base(k varbinary(8) primary key, v int);
+insert into varbinary_base values
+  (x'00', 10),
+  (x'0001', 20),
+  (x'61', 30),
+  (x'ff', 40);
+data branch create table varbinary_branch from varbinary_base;
+select hex(k) as k, v from varbinary_branch order by k;
+update varbinary_branch set v = 31 where k = x'61';
+select v as varbinary_base_v from varbinary_base where k = x'61';
+select v as varbinary_branch_v from varbinary_branch where k = x'61';
+
+drop database branch_binary_pk;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26075

## What this PR does / why we need it:

### Root cause

`DATA BRANCH CREATE TABLE` copies rows through the sinker spill-sort path. The ordinary batch sorter already supports `BINARY` and `VARBINARY`, but `mergeutil.MergeSortBatches` omitted both OIDs from its varlena dispatch. When either type was the primary-key sort key, multi-batch merge initialization reached the default branch and panicked with `invalid type: BINARY` or `invalid type: VARBINARY`.

### Changes

- Route `BINARY` and `VARBINARY` sort keys through the existing varlena merge implementation, preserving the same raw-byte lexicographic ordering used by the ordinary sorter.
- Add a focused merge-sort unit test for both types, including interleaved batches, byte prefixes, NUL bytes, high bytes, and payload/key association.
- Add a self-contained Data Branch BVT covering fixed-binary padding, variable-binary byte preservation, ordering, successful table branch creation, and branch isolation.

### Tests

- Pre-fix regression proof: `TestMergeSortBatchesBinaryTypes/binary` panicked at `pkg/objectio/mergeutil/types.go:120` with `invalid type: BINARY`.
- `go build ./pkg/objectio/mergeutil` with the repository CGo environment.
- `go vet ./pkg/objectio/mergeutil` with the repository CGo environment.
- After rebasing onto `ffad68fdb`, `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s ./pkg/objectio/mergeutil`.
- After rebasing, `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=300s -run '^TestMergeSortBatchesBinaryTypes$' ./pkg/objectio/mergeutil`.
- After rebasing, `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=300s ./pkg/objectio/mergeutil`.
- After rebasing, `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=300s ./pkg/objectio/ioutil`.
- `mo-tester` BVT `branch_binary_pk.sql`: 3/3 runs passed, each 18/18 statements at 100%.
- CI follow-up: run 30699038757 attempt 1 reproduced an unrelated `morpc` options-slice race tracked in #26562; the failed Ubuntu/x86 UT job passed on attempt 2, and the completed SCA, coverage, and BVT checks are green.

### Residual risks

No known residual correctness risk. The change only admits two already-supported varlena types into the merge-sort dispatch; it does not alter storage formats, comparison rules, or behavior for unsupported types.
