### PR TITLE
fix(parser): format data branch statements

### DIFF
--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -771,6 +771,90 @@ func TestDataBranchCreateTablePreservesQuotedApostropheIdentifier(t *testing.T) 
 	require.Equal(t, tree.Identifier("quote'src"), branchStmt.SrcTable.ObjectName)
 }
 
+func TestDataBranchStatementFormatRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "create table",
+			sql:  "data branch create table `dst``table` from `src``table` to account `acc``name`",
+			want: "data branch create table `dst``table` from `src``table` to account `acc``name`",
+		},
+		{
+			name: "delete table",
+			sql:  "data branch delete table `db``name`.`table``name`",
+			want: "data branch delete table `db``name`.`table``name`",
+		},
+		{
+			name: "create database",
+			sql:  "data branch create database `dst``db` from `src``db`{snapshot='snap''one'} to account `acc``name`",
+			want: "data branch create database `dst``db` from `src``db`{snapshot = 'snap''one'} to account `acc``name`",
+		},
+		{
+			name: "delete database",
+			sql:  "data branch delete database `db``name`",
+			want: "data branch delete database `db``name`",
+		},
+		{
+			name: "diff output as",
+			sql:  "data branch diff `db`.`target`{snapshot='target snap'} against `db`.`base`{snapshot='base snap'} columns (`id`, `select`) output as `out`.`result`",
+			want: "data branch diff `db`.`target`{snapshot = 'target snap'} against `db`.`base`{snapshot = 'base snap'} columns (`id`, `select`) output as `out`.`result`",
+		},
+		{
+			name: "diff output empty file",
+			sql:  "data branch diff target against base output file ''",
+			want: "data branch diff `target` against `base` output file ''",
+		},
+		{
+			name: "diff output file",
+			sql:  "data branch diff target against base output file '/tmp/branch''s/'",
+			want: "data branch diff `target` against `base` output file '/tmp/branch''s/'",
+		},
+		{
+			name: "diff output zero limit",
+			sql:  "data branch diff target against base output limit 0",
+			want: "data branch diff `target` against `base` output limit 0",
+		},
+		{
+			name: "diff output count",
+			sql:  "data branch diff target against base output count",
+			want: "data branch diff `target` against `base` output count",
+		},
+		{
+			name: "diff output summary",
+			sql:  "data branch diff target against base output summary",
+			want: "data branch diff `target` against `base` output summary",
+		},
+		{
+			name: "merge default conflict behavior",
+			sql:  "data branch merge src into dst",
+			want: "data branch merge `src` into `dst`",
+		},
+		{
+			name: "merge explicit conflict behavior",
+			sql:  "data branch merge src into dst when conflict skip",
+			want: "data branch merge `src` into `dst` when conflict skip",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stmt, err := ParseOne(context.Background(), test.sql, 1)
+			require.NoError(t, err)
+			defer stmt.Free()
+
+			formatted := tree.String(stmt, dialect.MYSQL)
+			require.Equal(t, test.want, formatted)
+
+			reparsed, err := ParseOne(context.Background(), formatted, 1)
+			require.NoError(t, err)
+			defer reparsed.Free()
+			require.IsType(t, stmt, reparsed)
+			require.Equal(t, formatted, tree.String(reparsed, dialect.MYSQL))
+		})
+	}
+}
+
 func TestDataBranchDiffOutputModes(t *testing.T) {
 	stmt, err := ParseOne(context.TODO(), `data branch diff t1{snapshot="sp1"} against t2{snapshot="sp2"} output summary`, 1)
 	require.NoError(t, err)

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -855,6 +855,73 @@ func TestDataBranchStatementFormatRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDataBranchPickFormatRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		sql          string
+		want         string
+		wantSrcDB    tree.Identifier
+		wantSrc      tree.Identifier
+		wantDst      tree.Identifier
+		wantFrom     string
+		wantTo       string
+		wantKeys     bool
+		wantConflict int
+	}{
+		{
+			name:         "quoted tables",
+			sql:          "data branch pick `select`.`src``table` into `dst``table` keys (1) when conflict skip",
+			want:         "data branch pick `select`.`src``table` into `dst``table` keys (1) when conflict skip",
+			wantSrcDB:    tree.Identifier("select"),
+			wantSrc:      tree.Identifier("src`table"),
+			wantDst:      tree.Identifier("dst`table"),
+			wantKeys:     true,
+			wantConflict: tree.CONFLICT_SKIP,
+		},
+		{
+			name:         "string snapshots",
+			sql:          "data branch pick src into dst between snapshot 'snap one' and 'snap''two' when conflict accept",
+			want:         "data branch pick `src` into `dst` between snapshot 'snap one' and 'snap''two' when conflict accept",
+			wantSrc:      tree.Identifier("src"),
+			wantDst:      tree.Identifier("dst"),
+			wantFrom:     "snap one",
+			wantTo:       "snap'two",
+			wantConflict: tree.CONFLICT_ACCEPT,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stmt, err := ParseOne(context.Background(), test.sql, 1)
+			require.NoError(t, err)
+			defer stmt.Free()
+
+			formatted := tree.String(stmt, dialect.MYSQL)
+			require.Equal(t, test.want, formatted)
+
+			reparsed, err := ParseOne(context.Background(), formatted, 1)
+			require.NoError(t, err)
+			defer reparsed.Free()
+
+			pick, ok := reparsed.(*tree.DataBranchPick)
+			require.True(t, ok)
+			require.Equal(t, test.wantSrcDB, pick.SrcTable.SchemaName)
+			require.Equal(t, test.wantSrc, pick.SrcTable.ObjectName)
+			require.Equal(t, test.wantDst, pick.DstTable.ObjectName)
+			require.Equal(t, test.wantFrom, pick.BetweenFrom)
+			require.Equal(t, test.wantTo, pick.BetweenTo)
+			if test.wantKeys {
+				require.NotNil(t, pick.Keys)
+				require.Equal(t, tree.PickKeysValues, pick.Keys.Type)
+				require.Len(t, pick.Keys.KeyExprs, 1)
+			} else {
+				require.Nil(t, pick.Keys)
+			}
+			require.NotNil(t, pick.ConflictOpt)
+			require.Equal(t, test.wantConflict, pick.ConflictOpt.Opt)
+			require.Equal(t, formatted, tree.String(reparsed, dialect.MYSQL))
+		})
+	}
+}
+
 func TestDataBranchDiffOutputModes(t *testing.T) {
 	stmt, err := ParseOne(context.TODO(), `data branch diff t1{snapshot="sp1"} against t2{snapshot="sp2"} output summary`, 1)
 	require.NoError(t, err)

--- a/pkg/sql/parsers/tree/data_branch.go
+++ b/pkg/sql/parsers/tree/data_branch.go
@@ -154,20 +154,16 @@ func (d *DataBranchCreateTable) StmtKind() StmtKind {
 }
 
 func (d *DataBranchCreateTable) Format(ctx *FmtCtx) {
-	ctx.WriteString("data branch create table ")
-	quoteIdentifier := ctx.quoteIdentifier
-	ctx.quoteIdentifier = true
-	d.CreateTable.Table.Format(ctx)
-	ctx.quoteIdentifier = quoteIdentifier
-	ctx.WriteString(" from ")
-	quoteIdentifier = ctx.quoteIdentifier
-	ctx.quoteIdentifier = true
-	d.SrcTable.Format(ctx)
-	ctx.quoteIdentifier = quoteIdentifier
-	if d.ToAccountOpt != nil {
-		ctx.WriteByte(' ')
-		d.ToAccountOpt.Format(ctx)
-	}
+	formatDataBranchStatement(ctx, func() {
+		ctx.WriteString("data branch create table ")
+		d.CreateTable.Table.Format(ctx)
+		ctx.WriteString(" from ")
+		d.SrcTable.Format(ctx)
+		if d.ToAccountOpt != nil {
+			ctx.WriteByte(' ')
+			d.ToAccountOpt.Format(ctx)
+		}
+	})
 }
 
 func (d *DataBranchCreateTable) String() string {
@@ -213,8 +209,10 @@ func (d *DataBranchDeleteTable) StmtKind() StmtKind {
 }
 
 func (d *DataBranchDeleteTable) Format(ctx *FmtCtx) {
-	//TODO implement me
-	panic("implement me")
+	formatDataBranchStatement(ctx, func() {
+		ctx.WriteString("data branch delete table ")
+		d.TableName.Format(ctx)
+	})
 }
 
 func (d *DataBranchDeleteTable) String() string {
@@ -230,8 +228,7 @@ func (d *DataBranchDeleteTable) GetQueryType() string {
 }
 
 func (d *DataBranchDeleteTable) TypeName() string {
-	//TODO implement me
-	panic("implement me")
+	return "data branch delete table"
 }
 
 func (d *DataBranchDeleteTable) Free() {
@@ -259,8 +256,19 @@ func (d *DataBranchCreateDatabase) StmtKind() StmtKind {
 }
 
 func (d *DataBranchCreateDatabase) Format(ctx *FmtCtx) {
-	//TODO implement me
-	panic("implement me")
+	formatDataBranchStatement(ctx, func() {
+		ctx.WriteString("data branch create database ")
+		ctx.WriteIdentifier(d.DstDatabase)
+		ctx.WriteString(" from ")
+		ctx.WriteIdentifier(d.SrcDatabase)
+		if d.AtTsExpr != nil {
+			d.AtTsExpr.Format(ctx)
+		}
+		if d.ToAccountOpt != nil {
+			ctx.WriteByte(' ')
+			d.ToAccountOpt.Format(ctx)
+		}
+	})
 }
 
 func (d *DataBranchCreateDatabase) String() string {
@@ -276,8 +284,7 @@ func (d *DataBranchCreateDatabase) GetQueryType() string {
 }
 
 func (d *DataBranchCreateDatabase) TypeName() string {
-	//TODO implement me
-	panic("implement me")
+	return "data branch create database"
 }
 
 func (d *DataBranchCreateDatabase) Free() {
@@ -306,8 +313,10 @@ func (d *DataBranchDeleteDatabase) StmtKind() StmtKind {
 }
 
 func (d *DataBranchDeleteDatabase) Format(ctx *FmtCtx) {
-	//TODO implement me
-	panic("implement me")
+	formatDataBranchStatement(ctx, func() {
+		ctx.WriteString("data branch delete database ")
+		ctx.WriteIdentifier(d.DatabaseName)
+	})
 }
 
 func (d *DataBranchDeleteDatabase) String() string {
@@ -323,8 +332,7 @@ func (d *DataBranchDeleteDatabase) GetQueryType() string {
 }
 
 func (d *DataBranchDeleteDatabase) TypeName() string {
-	//TODO implement me
-	panic("implement me")
+	return "data branch delete database"
 }
 
 func (d *DataBranchDeleteDatabase) Free() {
@@ -356,6 +364,24 @@ type DiffOutputOpt struct {
 	DirPath string
 }
 
+func (o *DiffOutputOpt) Format(ctx *FmtCtx) {
+	ctx.WriteString(" output ")
+	switch {
+	case o.As.ObjectName != "":
+		ctx.WriteString("as ")
+		o.As.Format(ctx)
+	case o.Limit != nil:
+		fmt.Fprintf(ctx, "limit %d", *o.Limit)
+	case o.Count:
+		ctx.WriteString("count")
+	case o.Summary:
+		ctx.WriteString("summary")
+	default:
+		ctx.WriteString("file ")
+		NewNumVal(o.DirPath, o.DirPath, false, P_char).Format(ctx)
+	}
+}
+
 type DataBranchDiff struct {
 	statementImpl
 
@@ -366,8 +392,7 @@ type DataBranchDiff struct {
 }
 
 func (s *DataBranchDiff) TypeName() string {
-	//TODO implement me
-	panic("implement me")
+	return "data branch diff"
 }
 
 func (s *DataBranchDiff) reset() {
@@ -383,8 +408,20 @@ func (s *DataBranchDiff) StmtKind() StmtKind {
 }
 
 func (s *DataBranchDiff) Format(ctx *FmtCtx) {
-	//TODO implement me
-	panic("implement me")
+	formatDataBranchStatement(ctx, func() {
+		ctx.WriteString("data branch diff ")
+		s.TargetTable.Format(ctx)
+		ctx.WriteString(" against ")
+		s.BaseTable.Format(ctx)
+		if len(s.Columns) > 0 {
+			ctx.WriteString(" columns (")
+			s.Columns.Format(ctx)
+			ctx.WriteByte(')')
+		}
+		if s.OutputOpt != nil {
+			s.OutputOpt.Format(ctx)
+		}
+	})
 }
 
 func (s *DataBranchDiff) String() string {
@@ -407,6 +444,18 @@ type ConflictOpt struct {
 	Opt int
 }
 
+func (o *ConflictOpt) Format(ctx *FmtCtx) {
+	ctx.WriteString(" when conflict ")
+	switch o.Opt {
+	case CONFLICT_FAIL:
+		ctx.WriteString("fail")
+	case CONFLICT_SKIP:
+		ctx.WriteString("skip")
+	case CONFLICT_ACCEPT:
+		ctx.WriteString("accept")
+	}
+}
+
 type DataBranchMerge struct {
 	statementImpl
 	SrcTable    TableName
@@ -415,8 +464,7 @@ type DataBranchMerge struct {
 }
 
 func (s *DataBranchMerge) TypeName() string {
-	//TODO implement me
-	panic("implement me")
+	return "data branch merge"
 }
 
 func (s *DataBranchMerge) reset() {
@@ -432,8 +480,15 @@ func (s *DataBranchMerge) StmtKind() StmtKind {
 }
 
 func (s *DataBranchMerge) Format(ctx *FmtCtx) {
-	//TODO implement me
-	panic("implement me")
+	formatDataBranchStatement(ctx, func() {
+		ctx.WriteString("data branch merge ")
+		s.SrcTable.Format(ctx)
+		ctx.WriteString(" into ")
+		s.DstTable.Format(ctx)
+		if s.ConflictOpt != nil {
+			s.ConflictOpt.Format(ctx)
+		}
+	})
 }
 
 func (s *DataBranchMerge) String() string {
@@ -711,16 +766,20 @@ func (s *DataBranchPick) Format(ctx *FmtCtx) {
 		ctx.WriteByte(')')
 	}
 	if s.ConflictOpt != nil {
-		ctx.WriteString(" when conflict ")
-		switch s.ConflictOpt.Opt {
-		case CONFLICT_FAIL:
-			ctx.WriteString("fail")
-		case CONFLICT_SKIP:
-			ctx.WriteString("skip")
-		case CONFLICT_ACCEPT:
-			ctx.WriteString("accept")
-		}
+		s.ConflictOpt.Format(ctx)
 	}
+}
+
+func formatDataBranchStatement(ctx *FmtCtx, format func()) {
+	quoteIdentifier := ctx.quoteIdentifier
+	singleQuoteString := ctx.singleQuoteString
+	ctx.quoteIdentifier = true
+	ctx.singleQuoteString = true
+	defer func() {
+		ctx.quoteIdentifier = quoteIdentifier
+		ctx.singleQuoteString = singleQuoteString
+	}()
+	format()
 }
 
 func (s *DataBranchPick) String() string {

--- a/pkg/sql/parsers/tree/data_branch.go
+++ b/pkg/sql/parsers/tree/data_branch.go
@@ -378,7 +378,7 @@ func (o *DiffOutputOpt) Format(ctx *FmtCtx) {
 		ctx.WriteString("summary")
 	default:
 		ctx.WriteString("file ")
-		NewNumVal(o.DirPath, o.DirPath, false, P_char).Format(ctx)
+		formatDataBranchString(ctx, o.DirPath)
 	}
 }
 
@@ -741,33 +741,39 @@ func (s *DataBranchPick) StmtKind() StmtKind {
 }
 
 func (s *DataBranchPick) Format(ctx *FmtCtx) {
-	ctx.WriteString("data branch pick ")
-	s.SrcTable.Format(ctx)
-	ctx.WriteString(" into ")
-	s.DstTable.Format(ctx)
-	if s.BetweenFrom != "" && s.BetweenTo != "" {
-		ctx.WriteString(" between snapshot ")
-		ctx.WriteString(s.BetweenFrom)
-		ctx.WriteString(" and ")
-		ctx.WriteString(s.BetweenTo)
-	}
-	if s.Keys != nil {
-		ctx.WriteString(" keys (")
-		if s.Keys.Type == PickKeysSubquery && s.Keys.Select != nil {
-			s.Keys.Select.Format(ctx)
-		} else {
-			for i, e := range s.Keys.KeyExprs {
-				if i > 0 {
-					ctx.WriteString(", ")
-				}
-				e.Format(ctx)
-			}
+	formatDataBranchStatement(ctx, func() {
+		ctx.WriteString("data branch pick ")
+		s.SrcTable.Format(ctx)
+		ctx.WriteString(" into ")
+		s.DstTable.Format(ctx)
+		if s.BetweenFrom != "" && s.BetweenTo != "" {
+			ctx.WriteString(" between snapshot ")
+			formatDataBranchString(ctx, s.BetweenFrom)
+			ctx.WriteString(" and ")
+			formatDataBranchString(ctx, s.BetweenTo)
 		}
-		ctx.WriteByte(')')
-	}
-	if s.ConflictOpt != nil {
-		s.ConflictOpt.Format(ctx)
-	}
+		if s.Keys != nil {
+			ctx.WriteString(" keys (")
+			if s.Keys.Type == PickKeysSubquery && s.Keys.Select != nil {
+				s.Keys.Select.Format(ctx)
+			} else {
+				for i, e := range s.Keys.KeyExprs {
+					if i > 0 {
+						ctx.WriteString(", ")
+					}
+					e.Format(ctx)
+				}
+			}
+			ctx.WriteByte(')')
+		}
+		if s.ConflictOpt != nil {
+			s.ConflictOpt.Format(ctx)
+		}
+	})
+}
+
+func formatDataBranchString(ctx *FmtCtx, value string) {
+	NewNumVal(value, value, false, P_char).Format(ctx)
 }
 
 func formatDataBranchStatement(ctx *FmtCtx, format func()) {

--- a/pkg/sql/parsers/tree/data_branch_test.go
+++ b/pkg/sql/parsers/tree/data_branch_test.go
@@ -57,16 +57,14 @@ func TestDataBranchDeleteTableLifecycle(t *testing.T) {
 	require.Equal(t, QueryTypeOth, stmt.GetQueryType())
 	require.Equal(t, DataBranch_DeleteTable, stmt.DataBranchType())
 
-	stmt.TableName.ObjectName = Identifier("table")
+	stmt.TableName = makeDataBranchTableName("db`name", "table`name", nil)
+	ctx := NewFmtCtx(dialect.MYSQL)
+	stmt.Format(ctx)
+	require.Equal(t, "data branch delete table `db``name`.`table``name`", ctx.String())
+	require.Equal(t, "data branch delete table", stmt.TypeName())
+
 	stmt.reset()
 	require.Equal(t, Identifier(""), stmt.TableName.ObjectName)
-
-	require.Panics(t, func() {
-		stmt.Format(nil)
-	})
-	require.Panics(t, func() {
-		stmt.TypeName()
-	})
 
 	stmt.Free()
 }
@@ -81,14 +79,21 @@ func TestDataBranchCreateDatabaseLifecycle(t *testing.T) {
 	require.Equal(t, QueryTypeOth, stmt.GetQueryType())
 	require.Equal(t, DataBranch_CreateDatabase, stmt.DataBranchType())
 
-	stmt.reset()
+	stmt.DstDatabase = Identifier("dst`db")
+	stmt.SrcDatabase = Identifier("src`db")
+	stmt.AtTsExpr = &AtTimeStamp{
+		Type: ATTIMESTAMPSNAPSHOT,
+		Expr: NewNumVal("snap'one", "snap'one", false, P_char),
+	}
+	stmt.ToAccountOpt = &ToAccountOpt{AccountName: Identifier("acc`name")}
+	ctx := NewFmtCtx(dialect.MYSQL)
+	stmt.Format(ctx)
+	require.Equal(t, "data branch create database `dst``db` from `src``db`{snapshot = 'snap''one'} to account `acc``name`", ctx.String())
+	require.Equal(t, "data branch create database", stmt.TypeName())
 
-	require.Panics(t, func() {
-		stmt.Format(nil)
-	})
-	require.Panics(t, func() {
-		stmt.TypeName()
-	})
+	stmt.reset()
+	require.Empty(t, stmt.DstDatabase)
+	require.Nil(t, stmt.AtTsExpr)
 
 	stmt.Free()
 }
@@ -103,16 +108,14 @@ func TestDataBranchDeleteDatabaseLifecycle(t *testing.T) {
 	require.Equal(t, QueryTypeOth, stmt.GetQueryType())
 	require.Equal(t, DataBranch_DeleteDatabase, stmt.DataBranchType())
 
-	stmt.DatabaseName = Identifier("db")
+	stmt.DatabaseName = Identifier("db`name")
+	ctx := NewFmtCtx(dialect.MYSQL)
+	stmt.Format(ctx)
+	require.Equal(t, "data branch delete database `db``name`", ctx.String())
+	require.Equal(t, "data branch delete database", stmt.TypeName())
+
 	stmt.reset()
 	require.Equal(t, Identifier(""), stmt.DatabaseName)
-
-	require.Panics(t, func() {
-		stmt.Format(nil)
-	})
-	require.Panics(t, func() {
-		stmt.TypeName()
-	})
 
 	stmt.Free()
 }
@@ -126,19 +129,19 @@ func TestDataBranchDiffLifecycle(t *testing.T) {
 	require.Equal(t, "branch diff", stmt.String())
 	require.Equal(t, QueryTypeOth, stmt.GetQueryType())
 
-	stmt.TargetTable.ObjectName = Identifier("target")
-	stmt.BaseTable.ObjectName = Identifier("base")
-	stmt.OutputOpt = &DiffOutputOpt{Count: true, Summary: true}
+	stmt.TargetTable = makeDataBranchTableName("db", "target", nil)
+	stmt.BaseTable = makeDataBranchTableName("db", "base", nil)
+	stmt.Columns = IdentifierList{Identifier("id"), Identifier("select")}
+	stmt.OutputOpt = &DiffOutputOpt{Count: true}
+	ctx := NewFmtCtx(dialect.MYSQL)
+	stmt.Format(ctx)
+	require.Equal(t, "data branch diff `db`.`target` against `db`.`base` columns (`id`, `select`) output count", ctx.String())
+	require.Equal(t, "data branch diff", stmt.TypeName())
+
 	stmt.reset()
 	require.Equal(t, Identifier(""), stmt.TargetTable.ObjectName)
+	require.Nil(t, stmt.Columns)
 	require.Nil(t, stmt.OutputOpt)
-
-	require.Panics(t, func() {
-		stmt.Format(nil)
-	})
-	require.Panics(t, func() {
-		stmt.TypeName()
-	})
 
 	stmt.Free()
 }
@@ -152,21 +155,78 @@ func TestDataBranchMergeLifecycle(t *testing.T) {
 	require.Equal(t, "branch merge", stmt.String())
 	require.Equal(t, QueryTypeOth, stmt.GetQueryType())
 
-	stmt.SrcTable.ObjectName = Identifier("src")
-	stmt.DstTable.ObjectName = Identifier("dst")
+	stmt.SrcTable = makeDataBranchTableName("db", "src", nil)
+	stmt.DstTable = makeDataBranchTableName("db", "dst", nil)
 	stmt.ConflictOpt = &ConflictOpt{Opt: CONFLICT_ACCEPT}
+	ctx := NewFmtCtx(dialect.MYSQL)
+	stmt.Format(ctx)
+	require.Equal(t, "data branch merge `db`.`src` into `db`.`dst` when conflict accept", ctx.String())
+	require.Equal(t, "data branch merge", stmt.TypeName())
+
 	stmt.reset()
 	require.Equal(t, Identifier(""), stmt.SrcTable.ObjectName)
 	require.Nil(t, stmt.ConflictOpt)
 
-	require.Panics(t, func() {
-		stmt.Format(nil)
-	})
-	require.Panics(t, func() {
-		stmt.TypeName()
-	})
-
 	stmt.Free()
+}
+
+func TestDataBranchDiffFormatOutputOptions(t *testing.T) {
+	limit := int64(0)
+	for _, test := range []struct {
+		name   string
+		option *DiffOutputOpt
+		want   string
+	}{
+		{name: "none", want: "data branch diff `target` against `base`"},
+		{name: "as", option: &DiffOutputOpt{As: makeDataBranchTableName("out", "result", nil)}, want: "data branch diff `target` against `base` output as `out`.`result`"},
+		{name: "empty file", option: &DiffOutputOpt{}, want: "data branch diff `target` against `base` output file ''"},
+		{name: "file", option: &DiffOutputOpt{DirPath: "/tmp/branch's/"}, want: "data branch diff `target` against `base` output file '/tmp/branch''s/'"},
+		{name: "zero limit", option: &DiffOutputOpt{Limit: &limit}, want: "data branch diff `target` against `base` output limit 0"},
+		{name: "count", option: &DiffOutputOpt{Count: true}, want: "data branch diff `target` against `base` output count"},
+		{name: "summary", option: &DiffOutputOpt{Summary: true}, want: "data branch diff `target` against `base` output summary"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stmt := &DataBranchDiff{
+				TargetTable: makeDataBranchTableName("", "target", nil),
+				BaseTable:   makeDataBranchTableName("", "base", nil),
+				OutputOpt:   test.option,
+			}
+			require.Equal(t, test.want, String(stmt, dialect.MYSQL))
+		})
+	}
+}
+
+func TestDataBranchMergeFormatConflictOptions(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		conflict *ConflictOpt
+		want     string
+	}{
+		{name: "default", want: "data branch merge `src` into `dst`"},
+		{name: "fail", conflict: &ConflictOpt{Opt: CONFLICT_FAIL}, want: "data branch merge `src` into `dst` when conflict fail"},
+		{name: "skip", conflict: &ConflictOpt{Opt: CONFLICT_SKIP}, want: "data branch merge `src` into `dst` when conflict skip"},
+		{name: "accept", conflict: &ConflictOpt{Opt: CONFLICT_ACCEPT}, want: "data branch merge `src` into `dst` when conflict accept"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stmt := &DataBranchMerge{
+				SrcTable:    makeDataBranchTableName("", "src", nil),
+				DstTable:    makeDataBranchTableName("", "dst", nil),
+				ConflictOpt: test.conflict,
+			}
+			require.Equal(t, test.want, String(stmt, dialect.MYSQL))
+		})
+	}
+}
+
+func makeDataBranchTableName(database, table string, atTsExpr *AtTimeStamp) TableName {
+	return *NewTableName(
+		Identifier(table),
+		ObjectNamePrefix{
+			SchemaName:     Identifier(database),
+			ExplicitSchema: database != "",
+		},
+		atTsExpr,
+	)
 }
 
 func TestObjectListLifecycle(t *testing.T) {

--- a/pkg/sql/parsers/tree/data_branch_test.go
+++ b/pkg/sql/parsers/tree/data_branch_test.go
@@ -451,11 +451,7 @@ func TestDataBranchPickFormat(t *testing.T) {
 	}
 	ctx := NewFmtCtx(0)
 	stmt.Format(ctx)
-	require.Contains(t, ctx.String(), "data branch pick")
-	require.Contains(t, ctx.String(), "src")
-	require.Contains(t, ctx.String(), "into")
-	require.Contains(t, ctx.String(), "dst")
-	require.Contains(t, ctx.String(), "keys (")
+	require.Equal(t, "data branch pick `src` into `dst` keys (1, 2)", ctx.String())
 
 	// With BETWEEN SNAPSHOT
 	stmt2 := &DataBranchPick{
@@ -466,10 +462,7 @@ func TestDataBranchPickFormat(t *testing.T) {
 	}
 	ctx = NewFmtCtx(0)
 	stmt2.Format(ctx)
-	result := ctx.String()
-	require.Contains(t, result, "between snapshot")
-	require.Contains(t, result, "snap_start")
-	require.Contains(t, result, "snap_end")
+	require.Equal(t, "data branch pick `src` into `dst` between snapshot 'snap_start' and 'snap_end'", ctx.String())
 
 	// With conflict options
 	for _, tt := range []struct {
@@ -491,6 +484,6 @@ func TestDataBranchPickFormat(t *testing.T) {
 		}
 		ctx = NewFmtCtx(0)
 		stmt3.Format(ctx)
-		require.Contains(t, ctx.String(), "when conflict "+tt.expect)
+		require.Equal(t, "data branch pick `src` into `dst` keys (1) when conflict "+tt.expect, ctx.String())
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Closes #26032

## What this PR does / why we need it:

### Root cause

The parser creates valid AST nodes for `DATA BRANCH DELETE TABLE`, `CREATE DATABASE`, `DELETE DATABASE`, `DIFF`, and `MERGE`, but their `Format` and `TypeName` methods still panic with `implement me`. Existing lifecycle tests explicitly expected those panics. `CREATE TABLE` had been implemented separately on current `main` after the issue was filed.

`DATA BRANCH PICK` did not panic, but it was the only formatter outside the shared data-branch formatting scope. Consequently reserved or escaped table identifiers were emitted without safe quoting. Its `BETWEEN SNAPSHOT` values were also written as raw SQL text, so parsed names containing whitespace or apostrophes produced SQL that `ParseOne` rejected.

### Changes

- Implement SQL formatting and type names for the five previously unimplemented data-branch statement nodes.
- Format the complete data-branch family, including `PICK`, through one shared identifier and string quoting scope.
- Restore `PICK` snapshot names as canonical SQL string literals and preserve escaped identifiers.
- Format every `DIFF` output form (`AS`, `FILE`, `LIMIT`, `COUNT`, and `SUMMARY`), including `LIMIT 0` and an empty file literal.
- Reuse shared string-literal and conflict-option formatters instead of duplicating restoration logic.
- Replace panic-expecting lifecycle assertions and add parser-format-parser round-trip coverage for all affected statements, `PICK` escaped identifiers and string snapshots, and option boundaries.
- Assert reparsed `PICK` table, snapshot, keys, and conflict-option semantics.

### Tests

- Pre-fix reproduction: `TestDataBranchPickFormatRoundTrip` failed both reported cases with malformed identifier and raw snapshot output.
- `go build ./pkg/sql/parsers/tree ./pkg/sql/parsers/dialect/mysql`
- `go vet ./pkg/sql/parsers/tree ./pkg/sql/parsers/dialect/mysql`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=240s ./pkg/sql/parsers/tree ./pkg/sql/parsers/dialect/mysql`
- Focused deterministic CGo race stress: `TestDataBranchPickFormatRoundTrip`, `TestDataBranchStatementFormatRoundTrip`, `TestDataBranchPickFormat`, and `TestDataBranchDiffFormatOutputOptions` each passed independently with `-race -count=100` (`T=0`, 30-second adaptive budget, `N=100`).
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=300s ./pkg/sql/parsers/tree ./pkg/sql/parsers/dialect/mysql`

All verification is against current `main` (`ffad68fdb`).

### BVT and residual risk

BVT is not applicable because executing a valid data-branch statement does not call the AST formatter; it cannot reproduce this failure. Focused AST and parser round-trip unit tests exercise the failing ownership boundary directly. No residual functional risk is known; the change is limited to SQL restoration and its tests.
