### PR TITLE
fix(plan): select eligible shuffle key across join predicates

### DIFF
--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -849,11 +849,18 @@ func TestCompileLocalShuffleJoinOnlySkipsProvenProbeShuffle(t *testing.T) {
 	tests := []struct {
 		name             string
 		method           plan.ShuffleMethod
+		shuffleType      plan.ShuffleType
 		wantProbeShuffle bool
 	}{
 		{
 			name:             "normal strategy repartitions probe",
 			method:           plan.ShuffleMethod_Normal,
+			wantProbeShuffle: true,
+		},
+		{
+			name:             "normal range strategy repartitions probe",
+			method:           plan.ShuffleMethod_Normal,
+			shuffleType:      plan.ShuffleType_Range,
 			wantProbeShuffle: true,
 		},
 		{
@@ -868,6 +875,7 @@ func TestCompileLocalShuffleJoinOnlySkipsProvenProbeShuffle(t *testing.T) {
 			c := newCompileForShuffleJoinTest(t, engine.Nodes{cn})
 			node := newShuffleJoinTestNode(dop)
 			node.Stats.HashmapStats.ShuffleMethod = tt.method
+			node.Stats.HashmapStats.ShuffleType = tt.shuffleType
 			left := &plan.Node{Stats: &plan.Stats{Dop: dop}}
 			right := &plan.Node{Stats: &plan.Stats{Dop: dop}}
 			probe := newShuffleJoinTestScope(t, cn, int(dop))
@@ -882,6 +890,8 @@ func TestCompileLocalShuffleJoinOnlySkipsProvenProbeShuffle(t *testing.T) {
 			probeInput := result[0].RootOp.GetOperatorBase().GetChildren(0)
 			if tt.wantProbeShuffle {
 				require.IsType(t, &shuffle.Shuffle{}, probeInput)
+				probeShuffle := probeInput.(*shuffle.Shuffle)
+				require.Equal(t, int32(tt.shuffleType), probeShuffle.ShuffleType)
 				require.Same(t, originalProbeRoot, probeInput.GetOperatorBase().GetChildren(0))
 			} else {
 				require.Same(t, originalProbeRoot, probeInput)

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -844,6 +844,52 @@ func TestCompileShuffleJoinKeepsReusableLocalShuffle(t *testing.T) {
 		"reusing an existing probe partition must keep the single local fast path")
 }
 
+func TestCompileLocalShuffleJoinOnlySkipsProvenProbeShuffle(t *testing.T) {
+	const dop = int32(4)
+	tests := []struct {
+		name             string
+		method           plan.ShuffleMethod
+		wantProbeShuffle bool
+	}{
+		{
+			name:             "normal strategy repartitions probe",
+			method:           plan.ShuffleMethod_Normal,
+			wantProbeShuffle: true,
+		},
+		{
+			name:   "proved reuse keeps probe partition",
+			method: plan.ShuffleMethod_Reuse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cn := engine.Node{Addr: "cn1:6001", Mcpu: int(dop)}
+			c := newCompileForShuffleJoinTest(t, engine.Nodes{cn})
+			node := newShuffleJoinTestNode(dop)
+			node.Stats.HashmapStats.ShuffleMethod = tt.method
+			left := &plan.Node{Stats: &plan.Stats{Dop: dop}}
+			right := &plan.Node{Stats: &plan.Stats{Dop: dop}}
+			probe := newShuffleJoinTestScope(t, cn, int(dop))
+			build := newShuffleJoinTestScope(t, cn, int(dop))
+			originalProbeRoot := probe.RootOp
+
+			result := c.compileLocalShuffleJoin(
+				node, left, right, []*Scope{probe}, []*Scope{build},
+			)
+
+			require.Len(t, result, 1)
+			probeInput := result[0].RootOp.GetOperatorBase().GetChildren(0)
+			if tt.wantProbeShuffle {
+				require.IsType(t, &shuffle.Shuffle{}, probeInput)
+				require.Same(t, originalProbeRoot, probeInput.GetOperatorBase().GetChildren(0))
+			} else {
+				require.Same(t, originalProbeRoot, probeInput)
+			}
+		})
+	}
+}
+
 func TestCompileShuffleJoinDistributesSinkScanHashbuild(t *testing.T) {
 	const dop = int32(2)
 	tests := []struct {

--- a/pkg/sql/plan/join_order.go
+++ b/pkg/sql/plan/join_order.go
@@ -171,7 +171,16 @@ func isEquiCond2(expr *plan.Expr) bool {
 		return false
 	}
 	lpos, rpos := HasColExpr(e.F.Args[0], -1), HasColExpr(e.F.Args[1], -1)
-	return lpos != -1 && rpos != -1 && lpos != rpos
+	if lpos == 0 && rpos == 1 {
+		return true
+	}
+	if lpos == 1 && rpos == 0 {
+		// Keep the executor contract identical before and after remapping: the
+		// probe/left expression is always argument 0.
+		e.F.Args[0], e.F.Args[1] = e.F.Args[1], e.F.Args[0]
+		return true
+	}
+	return false
 }
 
 func IsEqualFunc(id int64) bool {

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -459,6 +459,28 @@ func reuseShuffleStrategy(hashmapStats *plan.HashMapStats, child *plan.Node) {
 	hashmapStats.Nullcnt = childStats.Nullcnt
 }
 
+// restoreRangeStrategyAfterRemap carries only range boundaries derived for the
+// same join condition before remapping. remapAllColRefs mutates OnList
+// expressions in place and never reorders them, so ShuffleColIdx remains the
+// stable condition identity across tempOptimizeForDML. Physical Reuse and the
+// multi-CN Hybrid decision are deliberately excluded: both depend on the
+// current child topology and must be proved again.
+func restoreRangeStrategyAfterRemap(
+	hashmapStats, previous *plan.HashMapStats,
+	candidateIdx int32,
+) bool {
+	if previous == nil || previous.ShuffleColIdx != candidateIdx ||
+		previous.ShuffleType != plan.ShuffleType_Range {
+		return false
+	}
+	hashmapStats.ShuffleType = plan.ShuffleType_Range
+	hashmapStats.ShuffleColMin = previous.ShuffleColMin
+	hashmapStats.ShuffleColMax = previous.ShuffleColMax
+	hashmapStats.Ranges = previous.Ranges
+	hashmapStats.Nullcnt = previous.Nullcnt
+	return true
+}
+
 func maybeSorted(node *plan.Node, builder *QueryBuilder, tag int32) bool {
 	// for scan node, primary key and cluster by may be sorted
 	if node.NodeType == plan.Node_TABLE_SCAN {
@@ -609,6 +631,8 @@ func planShuffleJoinCandidate(
 	condition *plan.Expr,
 	leftHashCol, rightHashCol *plan.ColRef,
 	afterRemap bool,
+	candidateIdx int32,
+	previousHashmapStats *plan.HashMapStats,
 ) (plan.HashMapStats, bool) {
 	candidateNode := *node
 	candidateStats := *node.Stats
@@ -640,7 +664,11 @@ func planShuffleJoinCandidate(
 			if condition.Ndv >= 0 && condition.Ndv < ShuffleThreshHoldOfNDV {
 				return candidateHashmapStats, false
 			}
-			determineNonReusableShuffleType(leftHashCol, &candidateNode, builder, afterRemap)
+			if !afterRemap || !restoreRangeStrategyAfterRemap(
+				&candidateHashmapStats, previousHashmapStats, candidateIdx,
+			) {
+				determineNonReusableShuffleType(leftHashCol, &candidateNode, builder, afterRemap)
+			}
 		}
 	}
 	return candidateHashmapStats, shuffleJoinCandidateSurvivesRecheck(&candidateNode, condition.Ndv)
@@ -657,6 +685,7 @@ func selectShuffleJoinCondition(
 	onList []*plan.Expr,
 	leftTags, rightTags map[int32]bool,
 	afterRemap bool,
+	previousHashmapStats *plan.HashMapStats,
 ) (int, plan.HashMapStats) {
 	firstSupportedIdx := -1
 	var firstSupportedStats plan.HashMapStats
@@ -685,6 +714,7 @@ func selectShuffleJoinCondition(
 
 		candidateStats, eligible := planShuffleJoinCandidate(
 			node, builder, condition, leftHashCol, rightHashCol, afterRemap,
+			int32(i), previousHashmapStats,
 		)
 		if firstSupportedIdx == -1 {
 			firstSupportedIdx = i
@@ -704,6 +734,11 @@ func selectShuffleJoinCondition(
 // createQuery has remapped column references to local RelPos 0/1, so they must
 // use the positional form instead.
 func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilder, afterRemap bool) {
+	var previousHashmapStats *plan.HashMapStats
+	if afterRemap {
+		previous := *node.Stats.HashmapStats
+		previousHashmapStats = &previous
+	}
 	// do not shuffle by default
 	node.Stats.HashmapStats.Shuffle = false
 	node.Stats.HashmapStats.ShuffleColIdx = -1
@@ -764,6 +799,7 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 	}
 	idx, candidateHashmapStats := selectShuffleJoinCondition(
 		node, builder, node.OnList, leftTags, rightTags, afterRemap,
+		previousHashmapStats,
 	)
 	if idx == -1 {
 		return

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -394,9 +394,10 @@ func reusableShuffleChild(
 	col *plan.ColRef,
 	node *plan.Node,
 	builder *QueryBuilder,
+	afterRemap bool,
 ) (*plan.Node, bool) {
 	if col == nil || node == nil || builder == nil || builder.qry == nil ||
-		len(node.Children) == 0 || builder.tag2Table[col.RelPos] != nil {
+		len(node.Children) == 0 {
 		return nil, false
 	}
 	childID := node.Children[0]
@@ -406,15 +407,56 @@ func reusableShuffleChild(
 	child := builder.qry.Nodes[childID]
 	if child == nil || child.NodeType != plan.Node_AGG || child.Stats == nil ||
 		child.Stats.HashmapStats == nil || !child.Stats.HashmapStats.Shuffle ||
-		len(child.BindingTags) == 0 || col.RelPos != child.BindingTags[0] ||
-		col.ColPos < 0 || int(col.ColPos) >= len(child.GroupBy) {
+		child.Stats.HashmapStats.ShuffleColIdx < 0 ||
+		int(child.Stats.HashmapStats.ShuffleColIdx) >= len(child.GroupBy) {
 		return nil, false
 	}
-	groupCol := child.GroupBy[col.ColPos].GetCol()
+
+	shuffleColIdx := child.Stats.HashmapStats.ShuffleColIdx
+	if afterRemap {
+		// Aggregate group keys are exposed as RelPos -1. ColPos retains the
+		// original group-by index even when ProjectList is compacted, while the
+		// join column position refers to the compacted output slot.
+		if col.RelPos != 0 || col.ColPos < 0 || int(col.ColPos) >= len(child.ProjectList) {
+			return nil, false
+		}
+		projectCol := child.ProjectList[col.ColPos].GetCol()
+		if projectCol == nil || projectCol.RelPos != -1 || projectCol.ColPos != shuffleColIdx {
+			return nil, false
+		}
+		return child, true
+	}
+
+	if builder.tag2Table[col.RelPos] != nil || len(child.BindingTags) == 0 ||
+		col.RelPos != child.BindingTags[0] || col.ColPos != shuffleColIdx {
+		return nil, false
+	}
+	groupCol := child.GroupBy[shuffleColIdx].GetCol()
 	if groupCol == nil || builder.tag2Table[groupCol.RelPos] == nil {
 		return nil, false
 	}
 	return child, true
+}
+
+func resetShuffleStrategy(hashmapStats *plan.HashMapStats) {
+	hashmapStats.ShuffleType = plan.ShuffleType_Hash
+	hashmapStats.ShuffleTypeForMultiCN = plan.ShuffleTypeForMultiCN_Simple
+	hashmapStats.ShuffleColMin = 0
+	hashmapStats.ShuffleColMax = 0
+	hashmapStats.ShuffleMethod = plan.ShuffleMethod_Normal
+	hashmapStats.Nullcnt = 0
+	hashmapStats.Ranges = nil
+}
+
+func reuseShuffleStrategy(hashmapStats *plan.HashMapStats, child *plan.Node) {
+	childStats := child.Stats.HashmapStats
+	hashmapStats.ShuffleMethod = plan.ShuffleMethod_Reuse
+	hashmapStats.ShuffleType = childStats.ShuffleType
+	hashmapStats.ShuffleTypeForMultiCN = childStats.ShuffleTypeForMultiCN
+	hashmapStats.ShuffleColMin = childStats.ShuffleColMin
+	hashmapStats.ShuffleColMax = childStats.ShuffleColMax
+	hashmapStats.Ranges = childStats.Ranges
+	hashmapStats.Nullcnt = childStats.Nullcnt
 }
 
 func maybeSorted(node *plan.Node, builder *QueryBuilder, tag int32) bool {
@@ -431,26 +473,48 @@ func maybeSorted(node *plan.Node, builder *QueryBuilder, tag int32) bool {
 }
 
 func determineShuffleType(col *plan.ColRef, node *plan.Node, builder *QueryBuilder) {
-	// hash by default
-	node.Stats.HashmapStats.ShuffleType = plan.ShuffleType_Hash
+	determineShuffleTypeWithColRefMode(col, node, builder, false)
+}
 
-	if builder == nil {
+func determineShuffleTypeWithColRefMode(
+	col *plan.ColRef,
+	node *plan.Node,
+	builder *QueryBuilder,
+	afterRemap bool,
+) {
+	// Every planning pass starts from a normal hash strategy. Candidate-specific
+	// range/reuse state must be proved again for the current column.
+	resetShuffleStrategy(node.Stats.HashmapStats)
+
+	if col == nil || builder == nil {
 		return
 	}
-	tableDef, ok := builder.tag2Table[col.RelPos]
 
+	if child, reusable := reusableShuffleChild(col, node, builder, afterRemap); reusable {
+		reuseShuffleStrategy(node.Stats.HashmapStats, child)
+		return
+	}
+	determineNonReusableShuffleType(col, node, builder, afterRemap)
+}
+
+func determineNonReusableShuffleType(
+	col *plan.ColRef,
+	node *plan.Node,
+	builder *QueryBuilder,
+	afterRemap bool,
+) {
+	if col == nil || builder == nil {
+		return
+	}
+	// Global binding tags and table statistics are no longer addressable after
+	// remapping. If reuse was not structurally re-proved above, hash shuffle is
+	// the only strategy that can be derived from the late plan safely.
+	if afterRemap {
+		return
+	}
+
+	tableDef, ok := builder.tag2Table[col.RelPos]
 	if !ok {
-		child, reusable := reusableShuffleChild(col, node, builder)
-		if !reusable {
-			return
-		}
-		node.Stats.HashmapStats.ShuffleMethod = plan.ShuffleMethod_Reuse
-		node.Stats.HashmapStats.ShuffleType = plan.ShuffleType_Range
-		node.Stats.HashmapStats.HashmapSize = child.Stats.HashmapStats.HashmapSize
-		node.Stats.HashmapStats.ShuffleColMin = child.Stats.HashmapStats.ShuffleColMin
-		node.Stats.HashmapStats.ShuffleColMax = child.Stats.HashmapStats.ShuffleColMax
-		node.Stats.HashmapStats.Ranges = child.Stats.HashmapStats.Ranges
-		node.Stats.HashmapStats.Nullcnt = child.Stats.HashmapStats.Nullcnt
 		return
 	}
 
@@ -544,18 +608,40 @@ func planShuffleJoinCandidate(
 	builder *QueryBuilder,
 	condition *plan.Expr,
 	leftHashCol, rightHashCol *plan.ColRef,
+	afterRemap bool,
 ) (plan.HashMapStats, bool) {
 	candidateNode := *node
 	candidateStats := *node.Stats
-	candidateHashmapStats := *node.Stats.HashmapStats
+	// HashmapSize and HashOnPK describe the join itself. All shuffle-strategy
+	// fields are candidate-local and must not leak from a previous key or pass.
+	candidateHashmapStats := plan.HashMapStats{
+		HashmapSize:   node.Stats.HashmapStats.HashmapSize,
+		HashOnPK:      node.Stats.HashmapStats.HashOnPK,
+		ShuffleColIdx: -1,
+	}
 	candidateNode.Stats = &candidateStats
 	candidateStats.HashmapStats = &candidateHashmapStats
+	resetShuffleStrategy(&candidateHashmapStats)
 
 	isExprBasedShuffle := leftHashCol == nil || rightHashCol == nil
 	if isExprBasedShuffle {
-		candidateHashmapStats.ShuffleType = plan.ShuffleType_Hash
+		// Expressions cannot reuse an aggregate column partition. Shortcut the
+		// same known-low NDV guard used by the final check.
+		if condition.Ndv >= 0 && condition.Ndv < ShuffleThreshHoldOfNDV {
+			return candidateHashmapStats, false
+		}
 	} else {
-		determineShuffleType(leftHashCol, &candidateNode, builder)
+		child, reusable := reusableShuffleChild(leftHashCol, &candidateNode, builder, afterRemap)
+		if reusable {
+			reuseShuffleStrategy(&candidateHashmapStats, child)
+		} else {
+			// Reuse is the only exception to the low-NDV guard. Check it once,
+			// before looking up range statistics for a candidate that cannot win.
+			if condition.Ndv >= 0 && condition.Ndv < ShuffleThreshHoldOfNDV {
+				return candidateHashmapStats, false
+			}
+			determineNonReusableShuffleType(leftHashCol, &candidateNode, builder, afterRemap)
+		}
 	}
 	return candidateHashmapStats, shuffleJoinCandidateSurvivesRecheck(&candidateNode, condition.Ndv)
 }
@@ -571,8 +657,9 @@ func selectShuffleJoinCondition(
 	onList []*plan.Expr,
 	leftTags, rightTags map[int32]bool,
 	afterRemap bool,
-) (int, plan.HashMapStats, bool) {
+) (int, plan.HashMapStats) {
 	firstSupportedIdx := -1
+	var firstSupportedStats plan.HashMapStats
 
 	for i, condition := range onList {
 		fn := condition.GetF()
@@ -596,22 +683,19 @@ func selectShuffleJoinCondition(
 			continue
 		}
 
+		candidateStats, eligible := planShuffleJoinCandidate(
+			node, builder, condition, leftHashCol, rightHashCol, afterRemap,
+		)
 		if firstSupportedIdx == -1 {
 			firstSupportedIdx = i
+			firstSupportedStats = candidateStats
 		}
-		_, reusable := reusableShuffleChild(leftHashCol, node, builder)
-		if !reusable && condition.Ndv >= 0 && condition.Ndv < ShuffleThreshHoldOfNDV {
-			continue
-		}
-		candidateStats, eligible := planShuffleJoinCandidate(
-			node, builder, condition, leftHashCol, rightHashCol,
-		)
 		if eligible {
-			return i, candidateStats, true
+			return i, candidateStats
 		}
 	}
 
-	return firstSupportedIdx, plan.HashMapStats{}, false
+	return firstSupportedIdx, firstSupportedStats
 }
 
 // determineShuffleForJoinWithColRefMode plans join shuffle either before or
@@ -623,6 +707,7 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 	// do not shuffle by default
 	node.Stats.HashmapStats.Shuffle = false
 	node.Stats.HashmapStats.ShuffleColIdx = -1
+	resetShuffleStrategy(node.Stats.HashmapStats)
 	if node.NodeType != plan.Node_JOIN {
 		return
 	}
@@ -677,7 +762,7 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 	if node.JoinType == plan.Node_MARK && !markJoinSupportsShuffle(node, builder, leftTags, rightTags, afterRemap) {
 		return
 	}
-	idx, candidateHashmapStats, candidatePlanned := selectShuffleJoinCondition(
+	idx, candidateHashmapStats := selectShuffleJoinCondition(
 		node, builder, node.OnList, leftTags, rightTags, afterRemap,
 	)
 	if idx == -1 {
@@ -717,17 +802,9 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 	// Only integer and string keys are supported by the shuffle executor.
 	isExprBasedShuffle := leftHashCol == nil || rightHashCol == nil
 	if isSupportedShuffleJoinKeyType(typ) {
-		if candidatePlanned {
-			candidateHashmapStats.ShuffleColIdx = int32(idx)
-			candidateHashmapStats.Shuffle = true
-			*node.Stats.HashmapStats = candidateHashmapStats
-		} else {
-			node.Stats.HashmapStats.ShuffleColIdx = int32(idx)
-			node.Stats.HashmapStats.Shuffle = true
-		}
-		if !candidatePlanned && leftHashCol != nil && !isExprBasedShuffle {
-			determineShuffleType(leftHashCol, node, builder)
-		}
+		candidateHashmapStats.ShuffleColIdx = int32(idx)
+		candidateHashmapStats.Shuffle = true
+		*node.Stats.HashmapStats = candidateHashmapStats
 		// For expression-based shuffle (serial_full/serial in join condition):
 		// Force hash shuffle because range shuffle depends on column stats (min/max/ranges)
 		// which don't apply to expression results. Hash shuffle works universally.

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -390,6 +390,33 @@ func GetHashColumn(expr *plan.Expr) (*plan.ColRef, int32) {
 	return nil, -1
 }
 
+func reusableShuffleChild(
+	col *plan.ColRef,
+	node *plan.Node,
+	builder *QueryBuilder,
+) (*plan.Node, bool) {
+	if col == nil || node == nil || builder == nil || builder.qry == nil ||
+		len(node.Children) == 0 || builder.tag2Table[col.RelPos] != nil {
+		return nil, false
+	}
+	childID := node.Children[0]
+	if childID < 0 || int(childID) >= len(builder.qry.Nodes) {
+		return nil, false
+	}
+	child := builder.qry.Nodes[childID]
+	if child == nil || child.NodeType != plan.Node_AGG || child.Stats == nil ||
+		child.Stats.HashmapStats == nil || !child.Stats.HashmapStats.Shuffle ||
+		len(child.BindingTags) == 0 || col.RelPos != child.BindingTags[0] ||
+		col.ColPos < 0 || int(col.ColPos) >= len(child.GroupBy) {
+		return nil, false
+	}
+	groupCol := child.GroupBy[col.ColPos].GetCol()
+	if groupCol == nil || builder.tag2Table[groupCol.RelPos] == nil {
+		return nil, false
+	}
+	return child, true
+}
+
 func maybeSorted(node *plan.Node, builder *QueryBuilder, tag int32) bool {
 	// for scan node, primary key and cluster by may be sorted
 	if node.NodeType == plan.Node_TABLE_SCAN {
@@ -413,24 +440,17 @@ func determineShuffleType(col *plan.ColRef, node *plan.Node, builder *QueryBuild
 	tableDef, ok := builder.tag2Table[col.RelPos]
 
 	if !ok {
-		child := builder.qry.Nodes[node.Children[0]]
-		if child.NodeType == plan.Node_AGG && child.Stats.HashmapStats.Shuffle && col.RelPos == child.BindingTags[0] {
-			col = child.GroupBy[col.ColPos].GetCol()
-			if col == nil {
-				return
-			}
-			_, ok = builder.tag2Table[col.RelPos]
-			if !ok {
-				return
-			}
-			node.Stats.HashmapStats.ShuffleMethod = plan.ShuffleMethod_Reuse
-			node.Stats.HashmapStats.ShuffleType = plan.ShuffleType_Range
-			node.Stats.HashmapStats.HashmapSize = child.Stats.HashmapStats.HashmapSize
-			node.Stats.HashmapStats.ShuffleColMin = child.Stats.HashmapStats.ShuffleColMin
-			node.Stats.HashmapStats.ShuffleColMax = child.Stats.HashmapStats.ShuffleColMax
-			node.Stats.HashmapStats.Ranges = child.Stats.HashmapStats.Ranges
-			node.Stats.HashmapStats.Nullcnt = child.Stats.HashmapStats.Nullcnt
+		child, reusable := reusableShuffleChild(col, node, builder)
+		if !reusable {
+			return
 		}
+		node.Stats.HashmapStats.ShuffleMethod = plan.ShuffleMethod_Reuse
+		node.Stats.HashmapStats.ShuffleType = plan.ShuffleType_Range
+		node.Stats.HashmapStats.HashmapSize = child.Stats.HashmapStats.HashmapSize
+		node.Stats.HashmapStats.ShuffleColMin = child.Stats.HashmapStats.ShuffleColMin
+		node.Stats.HashmapStats.ShuffleColMax = child.Stats.HashmapStats.ShuffleColMax
+		node.Stats.HashmapStats.Ranges = child.Stats.HashmapStats.Ranges
+		node.Stats.HashmapStats.Nullcnt = child.Stats.HashmapStats.Nullcnt
 		return
 	}
 
@@ -480,6 +500,67 @@ func determineShuffleType(col *plan.ColRef, node *plan.Node, builder *QueryBuild
 // to determine if join need to go shuffle
 func determineShuffleForJoin(node *plan.Node, builder *QueryBuilder) {
 	determineShuffleForJoinWithColRefMode(node, builder, false)
+}
+
+func isSupportedShuffleJoinKeyType(typ int32) bool {
+	switch types.T(typ) {
+	case types.T_int64, types.T_int32, types.T_int16,
+		types.T_uint64, types.T_uint32, types.T_uint16,
+		types.T_varchar, types.T_char, types.T_text:
+		return true
+	default:
+		return false
+	}
+}
+
+// selectShuffleJoinCondition keeps the first condition that the current plan
+// can already shuffle on, including reuse and unknown-NDV plans. It only scans
+// later conditions when an earlier condition is unsupported or known to be
+// below the NDV threshold. This removes predicate-order-dependent eligibility
+// without changing established valid plans.
+func selectShuffleJoinCondition(
+	node *plan.Node,
+	builder *QueryBuilder,
+	onList []*plan.Expr,
+	leftTags, rightTags map[int32]bool,
+	afterRemap bool,
+) int {
+	firstSupportedIdx := -1
+
+	for i, condition := range onList {
+		fn := condition.GetF()
+		if fn == nil || len(fn.Args) != 2 {
+			continue
+		}
+
+		isEqui := isEquiCond(condition, leftTags, rightTags)
+		if afterRemap {
+			isEqui = isEquiCond2(condition)
+		}
+		if !isEqui {
+			continue
+		}
+
+		leftHashCol, leftType := GetHashColumn(fn.Args[0])
+		rightHashCol, rightType := GetHashColumn(fn.Args[1])
+		if (leftHashCol == nil && leftType == -1) ||
+			(rightHashCol == nil && rightType == -1) ||
+			!isSupportedShuffleJoinKeyType(leftType) {
+			continue
+		}
+
+		if firstSupportedIdx == -1 {
+			firstSupportedIdx = i
+		}
+		if _, reusable := reusableShuffleChild(leftHashCol, node, builder); reusable {
+			return i
+		}
+		if condition.Ndv < 0 || condition.Ndv >= ShuffleThreshHoldOfNDV {
+			return i
+		}
+	}
+
+	return firstSupportedIdx
 }
 
 // determineShuffleForJoinWithColRefMode plans join shuffle either before or
@@ -534,16 +615,6 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 		return
 	}
 
-	idx := 0
-	isEquiJoin := false
-	if afterRemap {
-		isEquiJoin = IsEquiJoin2(node.OnList)
-	} else {
-		isEquiJoin = builder.IsEquiJoin(node)
-	}
-	if !isEquiJoin {
-		return
-	}
 	leftTags := make(map[int32]bool)
 	for _, tag := range builder.enumerateTags(node.Children[0]) {
 		leftTags[tag] = true
@@ -555,16 +626,9 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 	if node.JoinType == plan.Node_MARK && !markJoinSupportsShuffle(node, builder, leftTags, rightTags, afterRemap) {
 		return
 	}
-	// for now ,only support the first join condition
-	for i := range node.OnList {
-		isEqui := isEquiCond(node.OnList[i], leftTags, rightTags)
-		if afterRemap {
-			isEqui = isEquiCond2(node.OnList[i])
-		}
-		if isEqui {
-			idx = i
-			break
-		}
+	idx := selectShuffleJoinCondition(node, builder, node.OnList, leftTags, rightTags, afterRemap)
+	if idx == -1 {
+		return
 	}
 	if node.IsRightJoin {
 		if node.Stats.HashmapStats.HashmapSize < threshHoldForRightJoinShuffle {
@@ -597,10 +661,9 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 		return
 	}
 
-	//for now ,only support integer and string type
+	// Only integer and string keys are supported by the shuffle executor.
 	isExprBasedShuffle := leftHashCol == nil || rightHashCol == nil
-	switch types.T(typ) {
-	case types.T_int64, types.T_int32, types.T_int16, types.T_uint64, types.T_uint32, types.T_uint16, types.T_varchar, types.T_char, types.T_text:
+	if isSupportedShuffleJoinKeyType(typ) {
 		node.Stats.HashmapStats.ShuffleColIdx = int32(idx)
 		node.Stats.HashmapStats.Shuffle = true
 		if leftHashCol != nil && !isExprBasedShuffle {

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -513,18 +513,65 @@ func isSupportedShuffleJoinKeyType(typ int32) bool {
 	}
 }
 
+func shuffleJoinCandidateSurvivesRecheck(node *plan.Node, ndv float64) bool {
+	hashmapStats := node.Stats.HashmapStats
+	if hashmapStats.ShuffleType == plan.ShuffleType_Hash && hashmapStats.HashmapSize < threshHoldForHashShuffle {
+		return false
+	}
+	if hashmapStats.ShuffleType == plan.ShuffleType_Range && hashmapStats.Ranges == nil &&
+		hashmapStats.ShuffleColMax-hashmapStats.ShuffleColMin < 100000 {
+		return false
+	}
+	if hashmapStats.ShuffleMethod != plan.ShuffleMethod_Reuse &&
+		ndv >= 0 && ndv < ShuffleThreshHoldOfNDV {
+		return false
+	}
+	if hashmapStats.ShuffleType == plan.ShuffleType_Hash &&
+		node.JoinType == plan.Node_DEDUP && node.IsRightJoin {
+		return false
+	}
+	return true
+}
+
+// planShuffleJoinCandidate applies the existing candidate-specific shuffle
+// rules to a copy of the join statistics. Candidate selection must use the
+// same range/hash recheck as the final plan; otherwise an apparently valid
+// condition can be rejected later and hide a usable condition after it. The
+// returned statistics are reused by the caller so the selected candidate is
+// not planned twice.
+func planShuffleJoinCandidate(
+	node *plan.Node,
+	builder *QueryBuilder,
+	condition *plan.Expr,
+	leftHashCol, rightHashCol *plan.ColRef,
+) (plan.HashMapStats, bool) {
+	candidateNode := *node
+	candidateStats := *node.Stats
+	candidateHashmapStats := *node.Stats.HashmapStats
+	candidateNode.Stats = &candidateStats
+	candidateStats.HashmapStats = &candidateHashmapStats
+
+	isExprBasedShuffle := leftHashCol == nil || rightHashCol == nil
+	if isExprBasedShuffle {
+		candidateHashmapStats.ShuffleType = plan.ShuffleType_Hash
+	} else {
+		determineShuffleType(leftHashCol, &candidateNode, builder)
+	}
+	return candidateHashmapStats, shuffleJoinCandidateSurvivesRecheck(&candidateNode, condition.Ndv)
+}
+
 // selectShuffleJoinCondition keeps the first condition that the current plan
-// can already shuffle on, including reuse and unknown-NDV plans. It only scans
-// later conditions when an earlier condition is unsupported or known to be
-// below the NDV threshold. This removes predicate-order-dependent eligibility
-// without changing established valid plans.
+// can actually shuffle on after the existing range/hash recheck. It only scans
+// later conditions when an earlier condition is unsupported or rejected by
+// those rules. This removes predicate-order-dependent eligibility without
+// changing established valid plans.
 func selectShuffleJoinCondition(
 	node *plan.Node,
 	builder *QueryBuilder,
 	onList []*plan.Expr,
 	leftTags, rightTags map[int32]bool,
 	afterRemap bool,
-) int {
+) (int, plan.HashMapStats, bool) {
 	firstSupportedIdx := -1
 
 	for i, condition := range onList {
@@ -552,15 +599,19 @@ func selectShuffleJoinCondition(
 		if firstSupportedIdx == -1 {
 			firstSupportedIdx = i
 		}
-		if _, reusable := reusableShuffleChild(leftHashCol, node, builder); reusable {
-			return i
+		_, reusable := reusableShuffleChild(leftHashCol, node, builder)
+		if !reusable && condition.Ndv >= 0 && condition.Ndv < ShuffleThreshHoldOfNDV {
+			continue
 		}
-		if condition.Ndv < 0 || condition.Ndv >= ShuffleThreshHoldOfNDV {
-			return i
+		candidateStats, eligible := planShuffleJoinCandidate(
+			node, builder, condition, leftHashCol, rightHashCol,
+		)
+		if eligible {
+			return i, candidateStats, true
 		}
 	}
 
-	return firstSupportedIdx
+	return firstSupportedIdx, plan.HashMapStats{}, false
 }
 
 // determineShuffleForJoinWithColRefMode plans join shuffle either before or
@@ -626,7 +677,9 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 	if node.JoinType == plan.Node_MARK && !markJoinSupportsShuffle(node, builder, leftTags, rightTags, afterRemap) {
 		return
 	}
-	idx := selectShuffleJoinCondition(node, builder, node.OnList, leftTags, rightTags, afterRemap)
+	idx, candidateHashmapStats, candidatePlanned := selectShuffleJoinCondition(
+		node, builder, node.OnList, leftTags, rightTags, afterRemap,
+	)
 	if idx == -1 {
 		return
 	}
@@ -664,9 +717,15 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 	// Only integer and string keys are supported by the shuffle executor.
 	isExprBasedShuffle := leftHashCol == nil || rightHashCol == nil
 	if isSupportedShuffleJoinKeyType(typ) {
-		node.Stats.HashmapStats.ShuffleColIdx = int32(idx)
-		node.Stats.HashmapStats.Shuffle = true
-		if leftHashCol != nil && !isExprBasedShuffle {
+		if candidatePlanned {
+			candidateHashmapStats.ShuffleColIdx = int32(idx)
+			candidateHashmapStats.Shuffle = true
+			*node.Stats.HashmapStats = candidateHashmapStats
+		} else {
+			node.Stats.HashmapStats.ShuffleColIdx = int32(idx)
+			node.Stats.HashmapStats.Shuffle = true
+		}
+		if !candidatePlanned && leftHashCol != nil && !isExprBasedShuffle {
 			determineShuffleType(leftHashCol, node, builder)
 		}
 		// For expression-based shuffle (serial_full/serial in join condition):
@@ -682,25 +741,7 @@ func determineShuffleForJoinWithColRefMode(node *plan.Node, builder *QueryBuilde
 
 	//recheck shuffle plan
 	if node.Stats.HashmapStats.Shuffle {
-		if node.Stats.HashmapStats.ShuffleType == plan.ShuffleType_Hash && node.Stats.HashmapStats.HashmapSize < threshHoldForHashShuffle {
-			node.Stats.HashmapStats.Shuffle = false
-		}
-
-		if node.Stats.HashmapStats.ShuffleType == plan.ShuffleType_Range && node.Stats.HashmapStats.Ranges == nil && node.Stats.HashmapStats.ShuffleColMax-node.Stats.HashmapStats.ShuffleColMin < 100000 {
-			node.Stats.HashmapStats.Shuffle = false
-		}
-		if node.Stats.HashmapStats.ShuffleMethod != plan.ShuffleMethod_Reuse {
-			highestNDV := node.OnList[idx].Ndv
-			// A negative NDV means that statistics are unavailable.  Do not treat
-			// unknown cardinality as low cardinality: for a large build side that
-			// would turn a valid shuffle plan back into a broadcast hash build and
-			// can concentrate the entire hash table on one CN.
-			if highestNDV >= 0 && highestNDV < ShuffleThreshHoldOfNDV {
-				node.Stats.HashmapStats.Shuffle = false
-			}
-		}
-
-		if node.Stats.HashmapStats.ShuffleType == plan.ShuffleType_Hash && node.JoinType == plan.Node_DEDUP && node.IsRightJoin {
+		if !shuffleJoinCandidateSurvivesRecheck(node, node.OnList[idx].Ndv) {
 			node.Stats.HashmapStats.Shuffle = false
 		}
 

--- a/pkg/sql/plan/shuffle_strategy_remap_test.go
+++ b/pkg/sql/plan/shuffle_strategy_remap_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+)
+
+func TestDetermineShuffleForJoinPreservesOnlySameConditionRangeAfterRemap(t *testing.T) {
+	t.Run("same condition keeps range through real remap", func(t *testing.T) {
+		builder, join, aggregate := makeShuffleJoinRealRemapFixture(t)
+		aggregate.Stats.HashmapStats.ShuffleColIdx = 1
+		join.Stats.HashmapStats = &plan.HashMapStats{
+			HashmapSize: threshHoldForHashShuffle - 1,
+			Shuffle:     true, ShuffleColIdx: 1,
+			ShuffleType:           plan.ShuffleType_Range,
+			ShuffleTypeForMultiCN: plan.ShuffleTypeForMultiCN_Hybrid,
+			ShuffleMethod:         plan.ShuffleMethod_Reuse,
+			ShuffleColMin:         10, ShuffleColMax: 1_000_000,
+			Ranges: []float64{100, 1_000}, Nullcnt: 7,
+		}
+
+		_, err := builder.remapAllColRefs(
+			join.NodeId,
+			0,
+			make(map[[2]int32]int),
+			make(map[[2]int32]bool),
+			make(map[[2]int32]int),
+		)
+		require.NoError(t, err)
+		// tempOptimizeForDML resets join cardinality flags after createQuery's
+		// remap, while the earlier condition identity and range derivation remain.
+		resetHashMapStats(join.Stats)
+		join.Stats.HashmapStats.HashmapSize = threshHoldForHashShuffle - 1
+		// Neither join key can reuse the aggregate's current third-key partition.
+		aggregate.Stats.HashmapStats.ShuffleColIdx = 2
+
+		determineShuffleForJoinWithColRefMode(join, builder, true)
+
+		require.True(t, join.Stats.HashmapStats.Shuffle)
+		require.Equal(t, int32(1), join.Stats.HashmapStats.ShuffleColIdx)
+		require.Equal(t, plan.ShuffleType_Range, join.Stats.HashmapStats.ShuffleType)
+		require.Equal(t, plan.ShuffleTypeForMultiCN_Simple, join.Stats.HashmapStats.ShuffleTypeForMultiCN)
+		require.Equal(t, plan.ShuffleMethod_Normal, join.Stats.HashmapStats.ShuffleMethod)
+		require.Equal(t, int64(10), join.Stats.HashmapStats.ShuffleColMin)
+		require.Equal(t, int64(1_000_000), join.Stats.HashmapStats.ShuffleColMax)
+		require.Equal(t, []float64{100, 1_000}, join.Stats.HashmapStats.Ranges)
+		require.Equal(t, int64(7), join.Stats.HashmapStats.Nullcnt)
+	})
+
+	t.Run("later column cannot inherit earlier strategy", func(t *testing.T) {
+		join := &plan.Node{
+			NodeType: plan.Node_JOIN,
+			JoinType: plan.Node_INNER,
+			Children: []int32{0, 1},
+			OnList: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_int64, 64, 0, 1, 0),
+				makeShuffleJoinEquality(t, types.T_int64, 100_000, 0, 1, 1),
+			},
+			Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+				HashmapSize: 3_000_000,
+				Shuffle:     true, ShuffleColIdx: 0,
+				ShuffleType:           plan.ShuffleType_Range,
+				ShuffleTypeForMultiCN: plan.ShuffleTypeForMultiCN_Hybrid,
+				ShuffleMethod:         plan.ShuffleMethod_Reuse,
+				ShuffleColMin:         10, ShuffleColMax: 1_000_000,
+				Ranges: []float64{100, 1_000}, Nullcnt: 7,
+			}},
+		}
+		builder := &QueryBuilder{qry: &plan.Query{Nodes: []*plan.Node{
+			makeShuffleJoinTestChild(10, 10_000_000),
+			makeShuffleJoinTestChild(20, 3_000_000),
+		}}}
+
+		determineShuffleForJoinWithColRefMode(join, builder, true)
+
+		require.True(t, join.Stats.HashmapStats.Shuffle)
+		require.Equal(t, int32(1), join.Stats.HashmapStats.ShuffleColIdx)
+		require.Equal(t, plan.ShuffleType_Hash, join.Stats.HashmapStats.ShuffleType)
+		require.Equal(t, plan.ShuffleTypeForMultiCN_Simple, join.Stats.HashmapStats.ShuffleTypeForMultiCN)
+		require.Equal(t, plan.ShuffleMethod_Normal, join.Stats.HashmapStats.ShuffleMethod)
+		require.Zero(t, join.Stats.HashmapStats.ShuffleColMin)
+		require.Zero(t, join.Stats.HashmapStats.ShuffleColMax)
+		require.Nil(t, join.Stats.HashmapStats.Ranges)
+		require.Zero(t, join.Stats.HashmapStats.Nullcnt)
+	})
+
+	t.Run("expression cannot inherit column range strategy", func(t *testing.T) {
+		join := &plan.Node{
+			NodeType: plan.Node_JOIN,
+			JoinType: plan.Node_INNER,
+			Children: []int32{0, 1},
+			OnList: []*plan.Expr{
+				makeShuffleJoinSerialEquality(t, 100_000, 0, 1, 0),
+			},
+			Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+				HashmapSize: threshHoldForHashShuffle - 1,
+				Shuffle:     true, ShuffleColIdx: 0,
+				ShuffleType:   plan.ShuffleType_Range,
+				ShuffleMethod: plan.ShuffleMethod_Reuse,
+				ShuffleColMin: 10, ShuffleColMax: 1_000_000,
+				Ranges: []float64{100, 1_000}, Nullcnt: 7,
+			}},
+		}
+		builder := &QueryBuilder{qry: &plan.Query{Nodes: []*plan.Node{
+			makeShuffleJoinTestChild(10, 10_000_000),
+			makeShuffleJoinTestChild(20, 3_000_000),
+		}}}
+
+		determineShuffleForJoinWithColRefMode(join, builder, true)
+
+		require.False(t, join.Stats.HashmapStats.Shuffle)
+		require.Equal(t, plan.ShuffleType_Hash, join.Stats.HashmapStats.ShuffleType)
+		require.Equal(t, plan.ShuffleMethod_Normal, join.Stats.HashmapStats.ShuffleMethod)
+		require.Nil(t, join.Stats.HashmapStats.Ranges)
+	})
+}

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -524,6 +524,275 @@ func TestDetermineShuffleForJoinNDVGuard(t *testing.T) {
 	require.False(t, lowNDVJoin.Stats.HashmapStats.Shuffle)
 }
 
+func TestDetermineShuffleForJoinFindsEligibleConditionAcrossPredicateOrder(t *testing.T) {
+	joinTypes := []plan.Node_JoinType{
+		plan.Node_INNER,
+		plan.Node_ANTI,
+		plan.Node_SEMI,
+		plan.Node_LEFT,
+		plan.Node_RIGHT,
+		plan.Node_OUTER,
+		plan.Node_MARK,
+	}
+
+	for _, joinType := range joinTypes {
+		for _, afterRemap := range []bool{false, true} {
+			for _, highFirst := range []bool{false, true} {
+				name := fmt.Sprintf("%s/after-remap=%t/high-first=%t", joinType, afterRemap, highFirst)
+				t.Run(name, func(t *testing.T) {
+					leftRel, rightRel := int32(10), int32(20)
+					if afterRemap {
+						leftRel, rightRel = 0, 1
+					}
+					low := makeShuffleJoinEquality(t, types.T_int64, 64, leftRel, rightRel, 0)
+					high := makeShuffleJoinEquality(t, types.T_int64, 100_000, leftRel, rightRel, 1)
+					conditions := []*plan.Expr{low, high}
+					wantIdx := int32(1)
+					if highFirst {
+						conditions = []*plan.Expr{high, low}
+						wantIdx = 0
+					}
+
+					left := makeShuffleJoinTestChild(10, 10_000_000)
+					right := makeShuffleJoinTestChild(20, 3_000_000)
+					node := &plan.Node{
+						NodeType: plan.Node_JOIN,
+						JoinType: joinType,
+						Children: []int32{0, 1},
+						OnList:   conditions,
+						Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+							HashmapSize: 3_000_000,
+						}},
+					}
+
+					determineShuffleForJoinWithColRefMode(
+						node,
+						&QueryBuilder{qry: &plan.Query{Nodes: []*plan.Node{left, right}}},
+						afterRemap,
+					)
+
+					require.True(t, node.Stats.HashmapStats.Shuffle)
+					require.Equal(t, wantIdx, node.Stats.HashmapStats.ShuffleColIdx)
+					require.Equal(t, float64(100_000), node.OnList[wantIdx].Ndv)
+				})
+			}
+		}
+	}
+}
+
+func TestDetermineShuffleForJoinCandidateFallbacks(t *testing.T) {
+	sameSide := makeShuffleJoinEquality(t, types.T_int64, 200_000, 10, 20, 0)
+	sameSide.GetF().Args[1].GetCol().RelPos = 10
+
+	tests := []struct {
+		name        string
+		candidates  []*plan.Expr
+		wantShuffle bool
+		wantNDV     float64
+	}{
+		{
+			name: "unsupported first does not hide supported key",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_float32, 200_000, 10, 20, 0),
+				makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 1),
+			},
+			wantShuffle: true,
+			wantNDV:     100_000,
+		},
+		{
+			name: "same-side equality does not hide join key",
+			candidates: []*plan.Expr{
+				sameSide,
+				makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 1),
+			},
+			wantShuffle: true,
+			wantNDV:     100_000,
+		},
+		{
+			name: "supported expression key remains eligible",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_int64, 64, 10, 20, 0),
+				makeShuffleJoinSerialEquality(t, 100_000, 10, 20, 1),
+			},
+			wantShuffle: true,
+			wantNDV:     100_000,
+		},
+		{
+			name: "unknown first preserves existing eligible choice",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_int64, -1, 10, 20, 0),
+				makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 1),
+			},
+			wantShuffle: true,
+			wantNDV:     -1,
+		},
+		{
+			name: "unknown remains eligible when known candidates are low",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_int64, 64, 10, 20, 0),
+				makeShuffleJoinEquality(t, types.T_int64, -1, 10, 20, 1),
+			},
+			wantShuffle: true,
+			wantNDV:     -1,
+		},
+		{
+			name: "all known candidates are low cardinality",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_int64, 64, 10, 20, 0),
+				makeShuffleJoinEquality(t, types.T_int64, 1_000, 10, 20, 1),
+			},
+			wantNDV: 64,
+		},
+		{
+			name: "all candidates use unsupported types",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_float32, 100_000, 10, 20, 0),
+				makeShuffleJoinEquality(t, types.T_float64, 200_000, 10, 20, 1),
+			},
+			wantNDV: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &plan.Node{
+				NodeType: plan.Node_JOIN,
+				JoinType: plan.Node_INNER,
+				Children: []int32{0, 1},
+				OnList:   tt.candidates,
+				Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+					HashmapSize: 3_000_000,
+				}},
+			}
+			builder := &QueryBuilder{qry: &plan.Query{Nodes: []*plan.Node{
+				makeShuffleJoinTestChild(10, 10_000_000),
+				makeShuffleJoinTestChild(20, 3_000_000),
+			}}}
+
+			determineShuffleForJoin(node, builder)
+
+			require.Equal(t, tt.wantShuffle, node.Stats.HashmapStats.Shuffle)
+			if tt.wantNDV < 0 && !tt.wantShuffle {
+				require.Equal(t, int32(-1), node.Stats.HashmapStats.ShuffleColIdx)
+				return
+			}
+			require.NotEqual(t, int32(-1), node.Stats.HashmapStats.ShuffleColIdx)
+			require.Equal(t, tt.wantNDV, node.OnList[node.Stats.HashmapStats.ShuffleColIdx].Ndv)
+		})
+	}
+}
+
+func TestDetermineShuffleForJoinPreservesReusableFirstCondition(t *testing.T) {
+	left := makeShuffleJoinTestChild(10, 10_000_000)
+	left.NodeType = plan.Node_AGG
+	left.GroupBy = []*plan.Expr{
+		{
+			Typ:  plan.Type{Id: int32(types.T_int64), NotNullable: true},
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 0}},
+		},
+		{},
+	}
+	left.Stats.HashmapStats = &plan.HashMapStats{
+		Shuffle:       true,
+		ShuffleType:   plan.ShuffleType_Range,
+		HashmapSize:   3_000_000,
+		ShuffleColMin: 0,
+		ShuffleColMax: 1_000_000,
+	}
+	right := makeShuffleJoinTestChild(20, 3_000_000)
+	node := &plan.Node{
+		NodeType: plan.Node_JOIN,
+		JoinType: plan.Node_INNER,
+		Children: []int32{0, 1},
+		OnList: []*plan.Expr{
+			makeShuffleJoinEquality(t, types.T_int64, 64, 10, 20, 0),
+			makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 1),
+		},
+		Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+			HashmapSize: 3_000_000,
+		}},
+	}
+	builder := &QueryBuilder{
+		qry:       &plan.Query{Nodes: []*plan.Node{left, right}},
+		tag2Table: map[int32]*plan.TableDef{100: {}},
+	}
+
+	determineShuffleForJoin(node, builder)
+
+	require.True(t, node.Stats.HashmapStats.Shuffle)
+	require.Equal(t, int32(0), node.Stats.HashmapStats.ShuffleColIdx)
+	require.Equal(t, plan.ShuffleMethod_Reuse, node.Stats.HashmapStats.ShuffleMethod)
+}
+
+func makeShuffleJoinEquality(
+	t *testing.T,
+	keyType types.T,
+	ndv float64,
+	leftRel, rightRel, colPos int32,
+) *plan.Expr {
+	t.Helper()
+
+	typ := keyType.ToType()
+	equal, err := function.GetFunctionByName(context.Background(), "=", []types.Type{typ, typ})
+	require.NoError(t, err)
+
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool), NotNullable: true},
+		Ndv: ndv,
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{Obj: equal.GetEncodedOverloadID(), ObjName: "="},
+			Args: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(keyType), NotNullable: true},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: leftRel,
+						ColPos: colPos,
+					}},
+				},
+				{
+					Typ: plan.Type{Id: int32(keyType), NotNullable: true},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: rightRel,
+						ColPos: colPos,
+					}},
+				},
+			},
+		}},
+	}
+}
+
+func makeShuffleJoinSerialEquality(
+	t *testing.T,
+	ndv float64,
+	leftRel, rightRel, colPos int32,
+) *plan.Expr {
+	t.Helper()
+
+	condition := makeShuffleJoinEquality(t, types.T_varchar, ndv, leftRel, rightRel, colPos)
+	for i, arg := range condition.GetF().Args {
+		condition.GetF().Args[i] = &plan.Expr{
+			Typ: arg.Typ,
+			Expr: &plan.Expr_F{F: &plan.Function{
+				Func: &plan.ObjectRef{ObjName: "serial"},
+				Args: []*plan.Expr{arg},
+			}},
+		}
+	}
+	return condition
+}
+
+func makeShuffleJoinTestChild(bindingTag int32, outcnt float64) *plan.Node {
+	return &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		BindingTags: []int32{bindingTag},
+		ProjectList: []*plan.Expr{
+			makeMarkShuffleColumn(true, bindingTag, 0),
+			makeMarkShuffleColumn(true, bindingTag, 1),
+		},
+		Stats: &plan.Stats{Outcnt: outcnt, HashmapStats: &plan.HashMapStats{}},
+	}
+}
+
 func TestDetermineShuffleForLatePlanStep(t *testing.T) {
 	// IVF maintenance also contains internal scans without binding tags. The
 	// post-createQuery shuffle pass must recognize its local RelPos 0/1 join

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -636,6 +636,23 @@ func TestDetermineShuffleForJoinCandidateFallbacks(t *testing.T) {
 			wantNDV:     -1,
 		},
 		{
+			name: "NDV threshold is inclusive",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_int64, ShuffleThreshHoldOfNDV, 10, 20, 0),
+			},
+			wantShuffle: true,
+			wantNDV:     ShuffleThreshHoldOfNDV,
+		},
+		{
+			name: "candidate immediately below NDV threshold does not hide eligible key",
+			candidates: []*plan.Expr{
+				makeShuffleJoinEquality(t, types.T_int64, ShuffleThreshHoldOfNDV-1, 10, 20, 0),
+				makeShuffleJoinEquality(t, types.T_int64, ShuffleThreshHoldOfNDV, 10, 20, 1),
+			},
+			wantShuffle: true,
+			wantNDV:     ShuffleThreshHoldOfNDV,
+		},
+		{
 			name: "all known candidates are low cardinality",
 			candidates: []*plan.Expr{
 				makeShuffleJoinEquality(t, types.T_int64, 64, 10, 20, 0),
@@ -722,6 +739,161 @@ func TestDetermineShuffleForJoinPreservesReusableFirstCondition(t *testing.T) {
 	require.True(t, node.Stats.HashmapStats.Shuffle)
 	require.Equal(t, int32(0), node.Stats.HashmapStats.ShuffleColIdx)
 	require.Equal(t, plan.ShuffleMethod_Reuse, node.Stats.HashmapStats.ShuffleMethod)
+}
+
+func TestDetermineShuffleForJoinSkipsCandidateRejectedByFinalRecheck(t *testing.T) {
+	tests := []struct {
+		name            string
+		expressionFirst bool
+		hashmapSize     float64
+		wantIdx         int32
+		wantType        plan.ShuffleType
+		wantMethod      plan.ShuffleMethod
+	}{
+		{
+			name:        "reusable range key remains first choice",
+			hashmapSize: threshHoldForHashShuffle - 1,
+			wantIdx:     0,
+			wantType:    plan.ShuffleType_Range,
+			wantMethod:  plan.ShuffleMethod_Reuse,
+		},
+		{
+			name:            "rejected hash key does not hide reusable range key",
+			expressionFirst: true,
+			hashmapSize:     threshHoldForHashShuffle - 1,
+			wantIdx:         1,
+			wantType:        plan.ShuffleType_Range,
+			wantMethod:      plan.ShuffleMethod_Reuse,
+		},
+		{
+			name:            "hash threshold is inclusive",
+			expressionFirst: true,
+			hashmapSize:     threshHoldForHashShuffle,
+			wantIdx:         0,
+			wantType:        plan.ShuffleType_Hash,
+			wantMethod:      plan.ShuffleMethod_Normal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expressionKey := makeShuffleJoinSerialEquality(t, 100_000, 10, 20, 0)
+			reusableKey := makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 1)
+			conditions := []*plan.Expr{reusableKey, expressionKey}
+			if tt.expressionFirst {
+				conditions = []*plan.Expr{expressionKey, reusableKey}
+			}
+
+			left := makeShuffleJoinTestChild(10, 10_000_000)
+			left.NodeType = plan.Node_AGG
+			left.GroupBy = []*plan.Expr{
+				{
+					Typ:  plan.Type{Id: int32(types.T_int64), NotNullable: true},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 0}},
+				},
+				{
+					Typ:  plan.Type{Id: int32(types.T_int64), NotNullable: true},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 1}},
+				},
+			}
+			left.Stats.HashmapStats = &plan.HashMapStats{
+				Shuffle:       true,
+				ShuffleType:   plan.ShuffleType_Range,
+				HashmapSize:   3_000_000,
+				ShuffleColMin: 0,
+				ShuffleColMax: 1_000_000,
+			}
+			right := makeShuffleJoinTestChild(20, 3_000_000)
+			node := &plan.Node{
+				NodeType: plan.Node_JOIN,
+				JoinType: plan.Node_INNER,
+				Children: []int32{0, 1},
+				OnList:   conditions,
+				Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+					// The expression key is forced to hash shuffle and therefore
+					// rejected below the 2 MiB hash threshold. The reusable range
+					// key after it must still be considered.
+					HashmapSize: tt.hashmapSize,
+				}},
+			}
+			builder := &QueryBuilder{
+				qry:       &plan.Query{Nodes: []*plan.Node{left, right}},
+				tag2Table: map[int32]*plan.TableDef{100: {}},
+			}
+
+			determineShuffleForJoin(node, builder)
+
+			require.True(t, node.Stats.HashmapStats.Shuffle)
+			require.Equal(t, tt.wantIdx, node.Stats.HashmapStats.ShuffleColIdx)
+			require.Equal(t, tt.wantType, node.Stats.HashmapStats.ShuffleType)
+			require.Equal(t, tt.wantMethod, node.Stats.HashmapStats.ShuffleMethod)
+		})
+	}
+}
+
+func TestSelectShuffleJoinConditionAdversarialPermutations(t *testing.T) {
+	unsupported := makeShuffleJoinEquality(t, types.T_float64, 100_000, 10, 20, 0)
+	knownLow := makeShuffleJoinEquality(t, types.T_int64, ShuffleThreshHoldOfNDV-1, 10, 20, 1)
+	rejectedExpression := makeShuffleJoinSerialEquality(t, 100_000, 10, 20, 2)
+	reusable := makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 3)
+
+	left := makeShuffleJoinTestChild(10, 10_000_000)
+	left.NodeType = plan.Node_AGG
+	left.GroupBy = []*plan.Expr{
+		{},
+		{},
+		{},
+		{
+			Typ:  plan.Type{Id: int32(types.T_int64), NotNullable: true},
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 3}},
+		},
+	}
+	left.Stats.HashmapStats = &plan.HashMapStats{
+		Shuffle:       true,
+		ShuffleType:   plan.ShuffleType_Range,
+		HashmapSize:   3_000_000,
+		ShuffleColMin: 0,
+		ShuffleColMax: 1_000_000,
+	}
+	right := makeShuffleJoinTestChild(20, 3_000_000)
+	builder := &QueryBuilder{
+		qry:       &plan.Query{Nodes: []*plan.Node{left, right}},
+		tag2Table: map[int32]*plan.TableDef{100: {}},
+	}
+	leftTags := map[int32]bool{10: true}
+	rightTags := map[int32]bool{20: true}
+
+	permutationCount := 0
+	var checkPermutations func([]*plan.Expr, int)
+	checkPermutations = func(conditions []*plan.Expr, next int) {
+		if next == len(conditions) {
+			permutationCount++
+			node := &plan.Node{
+				NodeType: plan.Node_JOIN,
+				JoinType: plan.Node_INNER,
+				Children: []int32{0, 1},
+				Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+					HashmapSize: threshHoldForHashShuffle - 1,
+				}},
+			}
+
+			idx, _, planned := selectShuffleJoinCondition(node, builder, conditions, leftTags, rightTags, false)
+
+			require.NotEqual(t, -1, idx)
+			require.True(t, planned)
+			require.Same(t, reusable, conditions[idx])
+			return
+		}
+
+		for i := next; i < len(conditions); i++ {
+			permutation := append([]*plan.Expr(nil), conditions...)
+			permutation[next], permutation[i] = permutation[i], permutation[next]
+			checkPermutations(permutation, next+1)
+		}
+	}
+
+	checkPermutations([]*plan.Expr{unsupported, knownLow, rejectedExpression, reusable}, 0)
+	require.Equal(t, 24, permutationCount)
 }
 
 func makeShuffleJoinEquality(

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -711,6 +711,7 @@ func TestDetermineShuffleForJoinPreservesReusableFirstCondition(t *testing.T) {
 	}
 	left.Stats.HashmapStats = &plan.HashMapStats{
 		Shuffle:       true,
+		ShuffleColIdx: 0,
 		ShuffleType:   plan.ShuffleType_Range,
 		HashmapSize:   3_000_000,
 		ShuffleColMin: 0,
@@ -739,6 +740,160 @@ func TestDetermineShuffleForJoinPreservesReusableFirstCondition(t *testing.T) {
 	require.True(t, node.Stats.HashmapStats.Shuffle)
 	require.Equal(t, int32(0), node.Stats.HashmapStats.ShuffleColIdx)
 	require.Equal(t, plan.ShuffleMethod_Reuse, node.Stats.HashmapStats.ShuffleMethod)
+}
+
+func TestDetermineShuffleForJoinReuseMatchesChildPartition(t *testing.T) {
+	tests := []struct {
+		name      string
+		childIdx  int32
+		childType plan.ShuffleType
+		wantIdx   int32
+	}{
+		{
+			name:      "reuse preserves hash partitioning",
+			childIdx:  0,
+			childType: plan.ShuffleType_Hash,
+			wantIdx:   0,
+		},
+		{
+			name:      "only the actual child shuffle key is reusable",
+			childIdx:  1,
+			childType: plan.ShuffleType_Range,
+			wantIdx:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			left := makeShuffleJoinTestChild(10, 10_000_000)
+			left.NodeType = plan.Node_AGG
+			left.GroupBy = []*plan.Expr{
+				{
+					Typ:  plan.Type{Id: int32(types.T_int64), NotNullable: true},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 0}},
+				},
+				{
+					Typ:  plan.Type{Id: int32(types.T_int64), NotNullable: true},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 1}},
+				},
+			}
+			left.Stats.HashmapStats = &plan.HashMapStats{
+				Shuffle:               true,
+				ShuffleColIdx:         tt.childIdx,
+				ShuffleType:           tt.childType,
+				ShuffleTypeForMultiCN: plan.ShuffleTypeForMultiCN_Hybrid,
+				HashmapSize:           9_000_000,
+				ShuffleColMin:         10,
+				ShuffleColMax:         1_000_000,
+				Ranges:                []float64{100, 1_000},
+				Nullcnt:               7,
+			}
+			node := &plan.Node{
+				NodeType: plan.Node_JOIN,
+				JoinType: plan.Node_INNER,
+				Children: []int32{0, 1},
+				OnList: []*plan.Expr{
+					makeShuffleJoinEquality(t, types.T_int64, 64, 10, 20, 0),
+					makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 1),
+				},
+				Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+					HashmapSize: 3_000_000,
+				}},
+			}
+			builder := &QueryBuilder{
+				qry: &plan.Query{Nodes: []*plan.Node{
+					left,
+					makeShuffleJoinTestChild(20, 3_000_000),
+				}},
+				tag2Table: map[int32]*plan.TableDef{100: {}},
+			}
+
+			determineShuffleForJoin(node, builder)
+
+			require.True(t, node.Stats.HashmapStats.Shuffle)
+			require.Equal(t, tt.wantIdx, node.Stats.HashmapStats.ShuffleColIdx)
+			require.Equal(t, plan.ShuffleMethod_Reuse, node.Stats.HashmapStats.ShuffleMethod)
+			require.Equal(t, tt.childType, node.Stats.HashmapStats.ShuffleType)
+			require.Equal(t, plan.ShuffleTypeForMultiCN_Hybrid, node.Stats.HashmapStats.ShuffleTypeForMultiCN)
+			require.Equal(t, float64(3_000_000), node.Stats.HashmapStats.HashmapSize,
+				"reuse must not replace the join build cardinality with the aggregate cardinality")
+		})
+	}
+}
+
+func TestDetermineShuffleForJoinReprovesReuseAcrossRealRemap(t *testing.T) {
+	builder, join, agg := makeShuffleJoinRealRemapFixture(t)
+
+	// The normal optimizer pass proves that the low-NDV first condition reuses
+	// the aggregate's existing partitioning.
+	determineShuffleForJoin(join, builder)
+	require.True(t, join.Stats.HashmapStats.Shuffle)
+	require.Equal(t, int32(0), join.Stats.HashmapStats.ShuffleColIdx)
+	require.Equal(t, plan.ShuffleMethod_Reuse, join.Stats.HashmapStats.ShuffleMethod)
+
+	// Exercise the same remapping routine used by createQuery. In particular,
+	// aggregate BindingTags disappear and join inputs become local RelPos 0/1.
+	_, err := builder.remapAllColRefs(
+		join.NodeId,
+		0,
+		make(map[[2]int32]int),
+		make(map[[2]int32]bool),
+		make(map[[2]int32]int),
+	)
+	require.NoError(t, err)
+	require.Empty(t, agg.BindingTags)
+	require.Len(t, agg.ProjectList, 2)
+	require.Equal(t, int32(-1), agg.ProjectList[0].GetCol().RelPos)
+	require.Equal(t, int32(0), agg.ProjectList[0].GetCol().ColPos)
+	require.Equal(t, int32(0), join.OnList[0].GetF().Args[0].GetCol().RelPos)
+	require.Equal(t, int32(1), join.OnList[0].GetF().Args[1].GetCol().RelPos)
+
+	// The late DML pass must re-prove reuse through the remapped aggregate
+	// output, not inherit the previous generation's method blindly.
+	determineShuffleForJoinWithColRefMode(join, builder, true)
+	require.True(t, join.Stats.HashmapStats.Shuffle)
+	require.Equal(t, int32(0), join.Stats.HashmapStats.ShuffleColIdx)
+	require.Equal(t, plan.ShuffleMethod_Reuse, join.Stats.HashmapStats.ShuffleMethod)
+	require.Equal(t, plan.ShuffleType_Range, join.Stats.HashmapStats.ShuffleType)
+
+	// Simulate a later planner generation changing the aggregate partition key
+	// to a third group key. The first join key is now low and non-reusable, so the
+	// second key wins. Its strategy must be clean Normal/Hash state; carrying the
+	// old key's Reuse would make compile skip the probe shuffle incorrectly.
+	agg.Stats.HashmapStats.ShuffleColIdx = 2
+	determineShuffleForJoinWithColRefMode(join, builder, true)
+	require.True(t, join.Stats.HashmapStats.Shuffle)
+	require.Equal(t, int32(1), join.Stats.HashmapStats.ShuffleColIdx)
+	require.Equal(t, plan.ShuffleMethod_Normal, join.Stats.HashmapStats.ShuffleMethod)
+	require.Equal(t, plan.ShuffleType_Hash, join.Stats.HashmapStats.ShuffleType)
+	require.Equal(t, plan.ShuffleTypeForMultiCN_Simple, join.Stats.HashmapStats.ShuffleTypeForMultiCN)
+	require.Zero(t, join.Stats.HashmapStats.ShuffleColMin)
+	require.Zero(t, join.Stats.HashmapStats.ShuffleColMax)
+	require.Zero(t, join.Stats.HashmapStats.Nullcnt)
+	require.Nil(t, join.Stats.HashmapStats.Ranges)
+}
+
+func TestDetermineShuffleForJoinNormalizesReversedConditionAfterRemap(t *testing.T) {
+	condition := makeShuffleJoinEquality(t, types.T_int64, 100_000, 1, 0, 0)
+	node := &plan.Node{
+		NodeType: plan.Node_JOIN,
+		JoinType: plan.Node_INNER,
+		Children: []int32{0, 1},
+		OnList:   []*plan.Expr{condition},
+		Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+			HashmapSize: 3_000_000,
+		}},
+	}
+	builder := &QueryBuilder{qry: &plan.Query{Nodes: []*plan.Node{
+		makeShuffleJoinTestChild(10, 10_000_000),
+		makeShuffleJoinTestChild(20, 3_000_000),
+	}}}
+
+	determineShuffleForJoinWithColRefMode(node, builder, true)
+
+	require.True(t, node.Stats.HashmapStats.Shuffle)
+	require.Equal(t, int32(0), condition.GetF().Args[0].GetCol().RelPos)
+	require.Equal(t, int32(1), condition.GetF().Args[1].GetCol().RelPos)
 }
 
 func TestDetermineShuffleForJoinSkipsCandidateRejectedByFinalRecheck(t *testing.T) {
@@ -798,6 +953,7 @@ func TestDetermineShuffleForJoinSkipsCandidateRejectedByFinalRecheck(t *testing.
 			}
 			left.Stats.HashmapStats = &plan.HashMapStats{
 				Shuffle:       true,
+				ShuffleColIdx: 1,
 				ShuffleType:   plan.ShuffleType_Range,
 				HashmapSize:   3_000_000,
 				ShuffleColMin: 0,
@@ -850,6 +1006,7 @@ func TestSelectShuffleJoinConditionAdversarialPermutations(t *testing.T) {
 	}
 	left.Stats.HashmapStats = &plan.HashMapStats{
 		Shuffle:       true,
+		ShuffleColIdx: 3,
 		ShuffleType:   plan.ShuffleType_Range,
 		HashmapSize:   3_000_000,
 		ShuffleColMin: 0,
@@ -877,10 +1034,9 @@ func TestSelectShuffleJoinConditionAdversarialPermutations(t *testing.T) {
 				}},
 			}
 
-			idx, _, planned := selectShuffleJoinCondition(node, builder, conditions, leftTags, rightTags, false)
+			idx, _ := selectShuffleJoinCondition(node, builder, conditions, leftTags, rightTags, false)
 
 			require.NotEqual(t, -1, idx)
-			require.True(t, planned)
 			require.Same(t, reusable, conditions[idx])
 			return
 		}
@@ -963,6 +1119,95 @@ func makeShuffleJoinTestChild(bindingTag int32, outcnt float64) *plan.Node {
 		},
 		Stats: &plan.Stats{Outcnt: outcnt, HashmapStats: &plan.HashMapStats{}},
 	}
+}
+
+func makeShuffleJoinRealRemapFixture(t *testing.T) (*QueryBuilder, *plan.Node, *plan.Node) {
+	t.Helper()
+
+	intType := plan.Type{Id: int32(types.T_int64), NotNullable: true}
+	makeTableDef := func(id uint64, prefix string) *plan.TableDef {
+		return &plan.TableDef{
+			TblId: id,
+			Cols: []*plan.ColDef{
+				{Name: prefix + "_a", Typ: intType},
+				{Name: prefix + "_b", Typ: intType},
+				{Name: prefix + "_c", Typ: intType},
+			},
+		}
+	}
+
+	leftTable := makeTableDef(1, "left")
+	leftScan := &plan.Node{
+		NodeId:      0,
+		NodeType:    plan.Node_TABLE_SCAN,
+		BindingTags: []int32{100},
+		TableDef:    leftTable,
+		Stats: &plan.Stats{
+			Outcnt:       10_000_000,
+			HashmapStats: &plan.HashMapStats{},
+		},
+	}
+	agg := &plan.Node{
+		NodeId:      1,
+		NodeType:    plan.Node_AGG,
+		Children:    []int32{0},
+		BindingTags: []int32{10, 11},
+		GroupBy: []*plan.Expr{
+			{Typ: intType, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 0}}},
+			{Typ: intType, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 1}}},
+			{Typ: intType, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 100, ColPos: 2}}},
+		},
+		Stats: &plan.Stats{
+			Outcnt: 10_000_000,
+			HashmapStats: &plan.HashMapStats{
+				Shuffle:               true,
+				ShuffleColIdx:         0,
+				ShuffleType:           plan.ShuffleType_Range,
+				ShuffleTypeForMultiCN: plan.ShuffleTypeForMultiCN_Hybrid,
+				HashmapSize:           9_000_000,
+				ShuffleColMin:         10,
+				ShuffleColMax:         1_000_000,
+				Ranges:                []float64{100, 1_000},
+				Nullcnt:               7,
+			},
+		},
+	}
+
+	rightTable := makeTableDef(2, "right")
+	rightScan := &plan.Node{
+		NodeId:      2,
+		NodeType:    plan.Node_TABLE_SCAN,
+		BindingTags: []int32{20},
+		TableDef:    rightTable,
+		Stats: &plan.Stats{
+			Outcnt:       3_000_000,
+			HashmapStats: &plan.HashMapStats{},
+		},
+	}
+	join := &plan.Node{
+		NodeId:   3,
+		NodeType: plan.Node_JOIN,
+		JoinType: plan.Node_INNER,
+		Children: []int32{1, 2},
+		OnList: []*plan.Expr{
+			makeShuffleJoinEquality(t, types.T_int64, 64, 10, 20, 0),
+			makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 1),
+		},
+		Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+			HashmapSize: 3_000_000,
+		}},
+	}
+	builder := &QueryBuilder{
+		qry: &plan.Query{
+			Nodes: []*plan.Node{leftScan, agg, rightScan, join},
+			Steps: []int32{join.NodeId},
+		},
+		tag2Table: map[int32]*plan.TableDef{
+			100: leftTable,
+			20:  rightTable,
+		},
+	}
+	return builder, join, agg
 }
 
 func TestDetermineShuffleForLatePlanStep(t *testing.T) {

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -1034,7 +1034,7 @@ func TestSelectShuffleJoinConditionAdversarialPermutations(t *testing.T) {
 				}},
 			}
 
-			idx, _ := selectShuffleJoinCondition(node, builder, conditions, leftTags, rightTags, false)
+			idx, _ := selectShuffleJoinCondition(node, builder, conditions, leftTags, rightTags, false, nil)
 
 			require.NotEqual(t, -1, idx)
 			require.Same(t, reusable, conditions[idx])


### PR DESCRIPTION
## What changed

- Inspect all equi-join predicates instead of letting the first equality unconditionally choose the shuffle key.
- Keep the first candidate that can **actually survive the existing complete shuffle recheck**: supported shape/type, current child-AGG reuse, NDV policy, hash/range gates, and DEDUP restrictions.
- Evaluate each candidate on generation-clean `HashMapStats`; rejected keys and earlier planning passes cannot leak `Reuse`, Range, or Hybrid state into the selected key.
- Re-prove `ShuffleMethod_Reuse` against the current child partition after DML column remapping, and make compile skip probe repartitioning only for proven reuse.
- Preserve pre-remap Range boundaries only when the same `OnList` condition remains selected after remapping. `remapAllColRefs` mutates conditions in place without reordering them, so the condition index is stable. Reuse and multi-CN Hybrid are deliberately not restored because both depend on current physical topology.

## Why

For a multi-key join such as:

```sql
ON l.bucket = r.bucket AND l.id = r.id
```

the planner previously stopped at low-NDV `bucket`, disabled shuffle, and never considered high-NDV `id`. Reversing equivalent predicates changed the plan and bounded spill.

Adversarial testing found the same underlying defect when a high-NDV `serial(id)` first candidate passed the initial choice but was later rejected: expression shuffle is hash-only and the estimated HashMap was below the existing hash threshold, yet the later range-capable `id` was never tried.

A second planning-generation issue appeared in the DML path. `createQuery` first derives Range/reuse state, then remaps columns; `tempOptimizeForDML` recalculates cardinality before the late shuffle pass. The late pass must preserve stable same-key Range information to avoid degrading a valid Range plan to Hash, but it must never carry physical Reuse/Hybrid state unless the current topology proves it again.

The root cause is not a particular SQL, threshold, or join type: candidate choice, derived key strategy, and physical reuse have different dependencies and lifetimes. This PR aligns those lifetimes without adding a ranking framework or executor policy.

## First-principles / unhappy-path audit

| Property | Result |
|---|---|
| Correctness | The selected key is an existing equality predicate and passes the same final checks as the emitted plan. Equal values use identical Range boundaries on probe/build. |
| Generation safety | Hash/Range choice is candidate-local. Same-condition Range data may cross remap; Reuse and Hybrid must be re-proved from the current graph. Changed keys and expression keys start from Hash/Normal/Simple. |
| Ownership | Planner-only value copies and read-only Range slice reuse; no resource creation, transfer, goroutine, wait, or cleanup path. |
| Termination/boundedness | One bounded synchronous scan, `O(number of join predicates)`, constant candidate state, no cache/list growth. |
| Compatibility | The first candidate already valid under current rules remains selected. Unknown NDV and valid AGG reuse remain supported; all-low/unsupported cases remain broadcast. |
| Performance | Each candidate is planned once and the selected stats are reused. The normal pre-remap path does not snapshot prior strategy. No executor hot-path work was added. |

## Coverage

White-box coverage includes:

- low/high-NDV permutations across INNER, ANTI, SEMI, LEFT, RIGHT, FULL, and MARK;
- pre-remap and post-remap/DML column-reference modes;
- unsupported type, same-side equality, supported expression, unknown NDV, all-low, and all-unsupported fallbacks;
- exact NDV and hash threshold boundaries;
- a candidate rejected by final hash recheck followed by a valid range/reuse candidate;
- all 24 permutations of unsupported, known-low, final-recheck-rejected, and reusable candidates;
- real `remapAllColRefs` plus the `tempOptimizeForDML` HashMap reset transition;
- same-key Range preservation while stale Reuse/Hybrid is cleared;
- changed-key and expression-key non-inheritance;
- compile verification that both Hash+Normal and Range+Normal repartition the probe, while proven Reuse does not.

Black-box validation on a fresh single-node instance built from this branch:

```text
#26556 SQL, low-NDV first:             3/3 range(id), SpillRows=260000, SpillSize=9.09 MiB
#26556 SQL, high-NDV first:            3/3 range(id), SpillRows=260000, SpillSize=9.09 MiB
both result orders:                    (130000, 130000, 16900130000)
serial(id) first / id first:           both range(id), SpillRows=260000, SpillSize=2.07 MiB
CAST/arithmetic/low-NDV/mixed keys:    later id selected and spilled
INNER/LEFT/RIGHT/FULL/SEMI/ANTI/MARK:  later eligible key selected and spilled
client cancel during physical spill:  canceled; zero spill files; CN healthy
service stop during physical spill:   canceled; zero spill files; restart healthy
```

Latest repository validation on macOS/arm64 with the deterministic CGo wrapper:

```text
10 affected planner/compiler tests, each -race -count=100  PASS
pkg/sql/plan full package, normal and race                 PASS
pkg/sql/compile full package, normal and race              PASS
go vet ./pkg/sql/plan ./pkg/sql/compile                    PASS
selector: 1 key 45.8 ns; 128 low + eligible 4.73-4.79 us  0 alloc
post-remap same-key Range selection ~50.1 ns               0 alloc
```

## Non-goals / decision log

- Broadcast/shared JoinMap spill remains #25782; all-low or unsupported-key joins intentionally retain the current broadcast decision.
- No new threshold, ranking model, executor protocol, log, or metric.
- Hybrid is not restored from the earlier pass: current topology is required to justify it.
- No per-query planner logging: the chosen key is visible in `EXPLAIN`, and spill rows/bytes already exist; extra logs here would add volume without better decision evidence.

Closes #26556

Roadmap: #26563
