### PR TITLE
fix(morpc): isolate backend factory options

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -1480,7 +1480,9 @@ func NewGoettyBasedBackendFactory(codec Codec, options ...BackendOption) Backend
 func (bf *goettyBasedBackendFactory) Create(
 	remote string,
 	extraOptions ...BackendOption) (Backend, error) {
-	opts := append(bf.options, extraOptions...)
+	opts := make([]BackendOption, 0, len(bf.options)+len(extraOptions))
+	opts = append(opts, bf.options...)
+	opts = append(opts, extraOptions...)
 	return NewRemoteBackend(remote, bf.codec, opts...)
 }
 

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -1623,6 +1623,60 @@ func TestRemoteBackendUsesSharedLogger(t *testing.T) {
 	assert.Same(t, logger, b.logger, "backend should use shared logger, not a With() clone")
 }
 
+func TestGoettyBasedBackendFactoryConcurrentCreateOptions(t *testing.T) {
+	app := newTestApp(t, func(conn goetty.IOSession, msg interface{}, _ uint64) error {
+		return conn.Write(msg, goetty.WriteOptions{Flush: true})
+	})
+	require.NoError(t, app.Start())
+	defer func() { require.NoError(t, app.Stop()) }()
+
+	ready := make(chan struct{}, 2)
+	release := make(chan struct{})
+	options := make([]BackendOption, 1, 2)
+	options[0] = func(rb *remoteBackend) {
+		rb.metrics = newMetrics(t.Name())
+		ready <- struct{}{}
+		<-release
+	}
+	factory := NewGoettyBasedBackendFactory(newTestCodec(), options...)
+
+	type createResult struct {
+		backend Backend
+		err     error
+	}
+	create := func(bufferSize int) <-chan createResult {
+		resultC := make(chan createResult, 1)
+		go func() {
+			backend, err := factory.Create(testAddr, WithBackendBufferSize(bufferSize))
+			resultC <- createResult{backend: backend, err: err}
+		}()
+		return resultC
+	}
+
+	firstC := create(1)
+	secondC := create(2)
+	<-ready
+	<-ready
+	close(release)
+
+	first := <-firstC
+	second := <-secondC
+	defer func() {
+		if first.backend != nil {
+			first.backend.Close()
+		}
+		if second.backend != nil {
+			second.backend.Close()
+		}
+	}()
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	firstBackend := first.backend.(*remoteBackend)
+	secondBackend := second.backend.(*remoteBackend)
+	require.Equal(t, 1, firstBackend.options.bufferSize)
+	require.Equal(t, 2, secondBackend.options.bufferSize)
+}
+
 func TestRemoteBackendCloseDoesNotLogExpectedDoubleClose(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	core, logs := observer.New(zap.ErrorLevel)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26562

## What this PR does / why we need it:

### Root cause

`goettyBasedBackendFactory.Create` appended per-call backend options directly to the factory's `options` slice. When that slice had spare capacity, concurrent calls reused and wrote the same backing-array slots. Parallel backend-create workers made those writes concurrent, causing both a Go data race and cross-call option contamination.

### Changes

- Allocate one option slice owned by each `Create` call.
- Preserve the existing ordering of factory defaults followed by per-call options.
- Add a deterministic concurrency regression test that gives the factory option slice spare capacity, synchronizes two creates before either consumes its per-call option, and verifies that both backends retain their own buffer size.

### Tests

- `go build -mod=readonly ./pkg/common/morpc`
- `go vet -mod=readonly ./pkg/common/morpc`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=300s ./pkg/common/morpc`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=180s -run '^TestGoettyBasedBackendFactoryConcurrentCreateOptions$' ./pkg/common/morpc` (`T=0.03s`, `B=30s`, adaptive `N=100`)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=600s ./pkg/common/morpc`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=600s -run '^TestIssue26087ConcurrentDataBranchQuota$' ./pkg/tests/issues` (`T=31.27s`, `B=30s`, adaptive `N=1`)

### Residual risks

Each backend creation now deliberately allocates a short-lived option slice sized to the combined factory and per-call options. This keeps option ownership local without adding locks or serializing connection creation. No API, wire-format, or configuration behavior changes.

