### PR TITLE
ci: skip coverage merge for cancelled workflows

### DIFF
--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -109,7 +109,7 @@ jobs:
   matrixone-coverage-merge:
     name: Matrixone Utils CI
     needs: [check-pr-valid, bvt-group-plan, matrixone-ut-coverage, matrixone-compose-ci, matrixone-standalone-ci]
-    if: ${{ always() && needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
+    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/coverage-merge.yaml@main
     with:
       prerequisites_ready: ${{ needs.bvt-group-plan.result == 'success' && needs.matrixone-ut-coverage.result == 'success' && needs.matrixone-ut-coverage.outputs.coverage_ready == 'true' && needs.matrixone-compose-ci.result == 'success' && needs.matrixone-standalone-ci.result == 'success' }}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26569

Fixes #26569

## What this PR does / why we need it:

### Root cause

The coverage merge job used `always()` so it was still eligible while GitHub cancelled a superseded workflow. Its required producers then concluded `cancelled`, the caller reduced those results to `prerequisites_ready: false`, and the reusable coverage workflow deliberately failed its prerequisite gate. This turned cancellation of stale work into a failed PR check.

### Change

Replace the merge job's `always()` status check with GitHub's cancellation-aware `!cancelled()` status check. A superseded workflow now skips or cancels its merge job, while a non-cancelled run with a genuine producer failure still invokes the merge workflow with `prerequisites_ready: false` and retains the existing failure signal.

### Validation

- Reproduced the pre-change behavior in workflow run 30707381514 attempt 1: the UT and BVT coverage producers concluded `cancelled`, then `Matrixone Utils CI / Coverage` ran with `prerequisites_ready: false` and failed its prerequisite verification.
- `actionlint v1.7.12 -verbose .github/workflows/entrypoint.yaml`
- `git diff --check origin/main...HEAD`
- Reviewed the complete state matrix for successful producers, genuine producer failure, workflow cancellation, invalid PR metadata, and the 3.0 branch path.

BVT and Go unit tests are not applicable because this change only affects GitHub Actions' server-side job scheduling. The linked issue records the hosted regression scenarios and their expected conclusions.

### Residual risk

Local tooling validates the workflow syntax and expression shape but cannot emulate GitHub's server-side cancellation reevaluation. Hosted Actions must confirm the cancellation, failure, and success cases documented on the issue.
