### PR TITLE
fix(explain): handle shuffle runtime-filter markers safely

### DIFF
--- a/pkg/sql/plan/explain/explain_node.go
+++ b/pkg/sql/plan/explain/explain_node.go
@@ -809,15 +809,17 @@ func (ndesc *NodeDescribeImpl) GetBlockFilterConditionInfo(ctx context.Context, 
 }
 
 func (ndesc *NodeDescribeImpl) GetRuntimeFilteProbeInfo(ctx context.Context, options *ExplainOptions) (string, error) {
+	if !hasRuntimeFilterProbeExpr(ndesc.Node.RuntimeFilterProbeList) {
+		return "", nil
+	}
 	buf := bytes.NewBuffer(make([]byte, 0, 300))
 	buf.WriteString("Runtime Filter Probe: ")
 	if options.Format == EXPLAIN_FORMAT_TEXT {
 		first := true
 		for _, v := range ndesc.Node.RuntimeFilterProbeList {
 			if v == nil || v.Expr == nil {
-				// A shuffle runtime filter carries a PASS marker without an
-				// expression. It controls dataflow but is not an EXPLAINable
-				// predicate.
+				// Expression-less specs are control or transport markers, not
+				// predicates that EXPLAIN can render.
 				continue
 			}
 			if !first {
@@ -832,9 +834,6 @@ func (ndesc *NodeDescribeImpl) GetRuntimeFilteProbeInfo(ctx context.Context, opt
 				buf.WriteString(" Match Prefix")
 			}
 		}
-		if first {
-			return "", nil
-		}
 	} else if options.Format == EXPLAIN_FORMAT_JSON {
 		return "", moerr.NewNYI(ctx, "explain format json")
 	} else if options.Format == EXPLAIN_FORMAT_DOT {
@@ -844,18 +843,15 @@ func (ndesc *NodeDescribeImpl) GetRuntimeFilteProbeInfo(ctx context.Context, opt
 }
 
 func (ndesc *NodeDescribeImpl) GetRuntimeFilterBuildInfo(ctx context.Context, options *ExplainOptions) (string, error) {
+	if !hasRuntimeFilterBuildExpr(ndesc.Node.RuntimeFilterBuildList) {
+		return "", nil
+	}
 	buf := bytes.NewBuffer(make([]byte, 0, 300))
 	buf.WriteString("Runtime Filter Build: ")
 	if options.Format == EXPLAIN_FORMAT_TEXT {
 		first := true
 		for _, v := range ndesc.Node.RuntimeFilterBuildList {
-			if v == nil {
-				continue
-			}
-			expr := v.BuildExpr
-			if expr == nil {
-				expr = v.Expr
-			}
+			expr := runtimeFilterBuildExpr(v)
 			if expr == nil {
 				continue
 			}
@@ -868,15 +864,40 @@ func (ndesc *NodeDescribeImpl) GetRuntimeFilterBuildInfo(ctx context.Context, op
 				return "", err
 			}
 		}
-		if first {
-			return "", nil
-		}
 	} else if options.Format == EXPLAIN_FORMAT_JSON {
 		return "", moerr.NewNYI(ctx, "explain format json")
 	} else if options.Format == EXPLAIN_FORMAT_DOT {
 		return "", moerr.NewNYI(ctx, "explain format dot")
 	}
 	return buf.String(), nil
+}
+
+func hasRuntimeFilterProbeExpr(specs []*plan.RuntimeFilterSpec) bool {
+	for _, spec := range specs {
+		if spec != nil && spec.Expr != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRuntimeFilterBuildExpr(specs []*plan.RuntimeFilterSpec) bool {
+	for _, spec := range specs {
+		if runtimeFilterBuildExpr(spec) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func runtimeFilterBuildExpr(spec *plan.RuntimeFilterSpec) *plan.Expr {
+	if spec == nil {
+		return nil
+	}
+	if spec.BuildExpr != nil {
+		return spec.BuildExpr
+	}
+	return spec.Expr
 }
 
 func (ndesc *NodeDescribeImpl) GetSendMessageInfo(ctx context.Context, options *ExplainOptions) (string, error) {

--- a/pkg/sql/plan/explain/explain_node.go
+++ b/pkg/sql/plan/explain/explain_node.go
@@ -809,14 +809,17 @@ func (ndesc *NodeDescribeImpl) GetBlockFilterConditionInfo(ctx context.Context, 
 }
 
 func (ndesc *NodeDescribeImpl) GetRuntimeFilteProbeInfo(ctx context.Context, options *ExplainOptions) (string, error) {
-	if ndesc.Node.NodeType == plan.Node_JOIN && ndesc.Node.Stats.HashmapStats.Shuffle {
-		return "", nil
-	}
 	buf := bytes.NewBuffer(make([]byte, 0, 300))
 	buf.WriteString("Runtime Filter Probe: ")
 	if options.Format == EXPLAIN_FORMAT_TEXT {
 		first := true
 		for _, v := range ndesc.Node.RuntimeFilterProbeList {
+			if v == nil || v.Expr == nil {
+				// A shuffle runtime filter carries a PASS marker without an
+				// expression. It controls dataflow but is not an EXPLAINable
+				// predicate.
+				continue
+			}
 			if !first {
 				buf.WriteString(", ")
 			}
@@ -829,6 +832,9 @@ func (ndesc *NodeDescribeImpl) GetRuntimeFilteProbeInfo(ctx context.Context, opt
 				buf.WriteString(" Match Prefix")
 			}
 		}
+		if first {
+			return "", nil
+		}
 	} else if options.Format == EXPLAIN_FORMAT_JSON {
 		return "", moerr.NewNYI(ctx, "explain format json")
 	} else if options.Format == EXPLAIN_FORMAT_DOT {
@@ -838,9 +844,6 @@ func (ndesc *NodeDescribeImpl) GetRuntimeFilteProbeInfo(ctx context.Context, opt
 }
 
 func (ndesc *NodeDescribeImpl) GetRuntimeFilterBuildInfo(ctx context.Context, options *ExplainOptions) (string, error) {
-	if ndesc.Node.NodeType == plan.Node_JOIN && ndesc.Node.Stats.HashmapStats.Shuffle {
-		return "", nil
-	}
 	buf := bytes.NewBuffer(make([]byte, 0, 300))
 	buf.WriteString("Runtime Filter Build: ")
 	if options.Format == EXPLAIN_FORMAT_TEXT {
@@ -864,6 +867,9 @@ func (ndesc *NodeDescribeImpl) GetRuntimeFilterBuildInfo(ctx context.Context, op
 			if err != nil {
 				return "", err
 			}
+		}
+		if first {
+			return "", nil
 		}
 	} else if options.Format == EXPLAIN_FORMAT_JSON {
 		return "", moerr.NewNYI(ctx, "explain format json")

--- a/pkg/sql/plan/explain/explain_test.go
+++ b/pkg/sql/plan/explain/explain_test.go
@@ -70,36 +70,6 @@ func TestBasicSqlExplain(t *testing.T) {
 	runTestShouldPass(mockOptimizer, t, sqls)
 }
 
-func TestRuntimeFilterBuildExplainUsesGuardedExpression(t *testing.T) {
-	node := &plan2.Node{
-		NodeType: plan2.Node_JOIN,
-		Stats:    &plan2.Stats{HashmapStats: &plan2.HashMapStats{}},
-		RuntimeFilterBuildList: []*plan2.RuntimeFilterSpec{
-			nil,
-			{},
-			{
-				BuildExpr: &plan2.Expr{
-					Typ: plan2.Type{Id: int32(types.T_int64)},
-					Expr: &plan2.Expr_Col{Col: &plan2.ColRef{
-						Name: "build_key",
-					}},
-				},
-			},
-		},
-	}
-
-	got, err := NewNodeDescriptionImpl(node).GetRuntimeFilterBuildInfo(
-		context.Background(),
-		&ExplainOptions{Format: EXPLAIN_FORMAT_TEXT},
-	)
-	if err != nil {
-		t.Fatalf("GetRuntimeFilterBuildInfo() error = %v", err)
-	}
-	if !strings.Contains(got, "build_key") {
-		t.Fatalf("GetRuntimeFilterBuildInfo() = %q", got)
-	}
-}
-
 // Single table query
 func TestSingleTableQuery(t *testing.T) {
 	sqls := []string{

--- a/pkg/sql/plan/explain/shuffle_test.go
+++ b/pkg/sql/plan/explain/shuffle_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package explain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+// Shuffle joins publish expression-less runtime-filter specs as PASS markers.
+// They are transport control messages, not predicates. Stats are deliberately
+// varied here because optimizer hints may replace them after the markers have
+// already been generated.
+func TestRuntimeFilterProbeExplain(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats *plan.Stats
+		specs []*plan.RuntimeFilterSpec
+		want  string
+	}{
+		{
+			name:  "pass marker without stats",
+			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
+		},
+		{
+			name:  "nil and pass marker without hashmap stats",
+			stats: &plan.Stats{},
+			specs: []*plan.RuntimeFilterSpec{nil, {Tag: 1}},
+		},
+		{
+			name:  "mixed markers and predicates",
+			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{}},
+			specs: []*plan.RuntimeFilterSpec{
+				{Tag: 1},
+				{Tag: 2, Expr: runtimeFilterTestColumn("probe_id"), MatchPrefix: true},
+				{Tag: 3},
+				{Tag: 4, Expr: runtimeFilterTestColumn("probe_id_2")},
+			},
+			want: "Runtime Filter Probe: probe_id Match Prefix, probe_id_2",
+		},
+		{
+			name: "ordinary predicate without stats",
+			specs: []*plan.RuntimeFilterSpec{
+				{Tag: 1, Expr: runtimeFilterTestColumn("probe_id")},
+			},
+			want: "Runtime Filter Probe: probe_id",
+		},
+		{
+			name: "shuffle pass marker",
+			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+				Shuffle: true,
+			}},
+			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
+		},
+		{
+			name: "explicit predicate survives stale shuffle stats",
+			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+				Shuffle: true,
+			}},
+			specs: []*plan.RuntimeFilterSpec{
+				{Tag: 1, Expr: runtimeFilterTestColumn("probe_id")},
+			},
+			want: "Runtime Filter Probe: probe_id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node := &plan.Node{
+				NodeType:               plan.Node_JOIN,
+				Stats:                  test.stats,
+				RuntimeFilterProbeList: test.specs,
+			}
+			got, err := NewNodeDescriptionImpl(node).GetRuntimeFilteProbeInfo(
+				context.Background(),
+				NewExplainDefaultOptions(),
+			)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestRuntimeFilterBuildExplain(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats *plan.Stats
+		specs []*plan.RuntimeFilterSpec
+		want  string
+	}{
+		{
+			name:  "pass marker without stats",
+			specs: []*plan.RuntimeFilterSpec{nil, {Tag: 1}},
+		},
+		{
+			name:  "build expression and legacy fallback",
+			stats: &plan.Stats{},
+			specs: []*plan.RuntimeFilterSpec{
+				{Tag: 1},
+				{
+					Tag:       2,
+					Expr:      runtimeFilterTestColumn("ignored_probe_key"),
+					BuildExpr: runtimeFilterTestColumn("build_id"),
+				},
+				{Tag: 3, Expr: runtimeFilterTestColumn("legacy_build_id")},
+			},
+			want: "Runtime Filter Build: build_id, legacy_build_id",
+		},
+		{
+			name: "shuffle pass marker",
+			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+				Shuffle: true,
+			}},
+			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
+		},
+		{
+			name: "explicit predicate survives stale shuffle stats",
+			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+				Shuffle: true,
+			}},
+			specs: []*plan.RuntimeFilterSpec{
+				{Tag: 1, BuildExpr: runtimeFilterTestColumn("build_id")},
+			},
+			want: "Runtime Filter Build: build_id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node := &plan.Node{
+				NodeType:               plan.Node_JOIN,
+				Stats:                  test.stats,
+				RuntimeFilterBuildList: test.specs,
+			}
+			got, err := NewNodeDescriptionImpl(node).GetRuntimeFilterBuildInfo(
+				context.Background(),
+				NewExplainDefaultOptions(),
+			)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestRuntimeFilterPassMarkersDoNotCreateExtraInfoLabels(t *testing.T) {
+	node := &plan.Node{
+		NodeType:               plan.Node_JOIN,
+		Stats:                  &plan.Stats{},
+		RuntimeFilterProbeList: []*plan.RuntimeFilterSpec{{Tag: 1}},
+		RuntimeFilterBuildList: []*plan.RuntimeFilterSpec{{Tag: 1}},
+	}
+
+	got, err := NewNodeDescriptionImpl(node).GetExtraInfo(
+		context.Background(),
+		NewExplainDefaultOptions(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Join Type: INNER"}, got)
+}
+
+func runtimeFilterTestColumn(name string) *plan.Expr {
+	return &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_int64)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{Name: name}},
+	}
+}

--- a/pkg/sql/plan/explain/shuffle_test.go
+++ b/pkg/sql/plan/explain/shuffle_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 // Shuffle joins publish expression-less runtime-filter specs as PASS markers.
-// They are transport control messages, not predicates. Stats are deliberately
-// varied here because optimizer hints may replace them after the markers have
-// already been generated.
+// They are transport control messages, not predicates. The matrix varies the
+// marker shape independently from Shuffle because optimizer hints may replace
+// stats after the specs have already been generated.
 func TestRuntimeFilterProbeExplain(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -35,18 +35,28 @@ func TestRuntimeFilterProbeExplain(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "pass marker without stats",
+			name:  "pass marker after shuffle stats are replaced",
+			stats: runtimeFilterTestStats(false),
 			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
 		},
 		{
-			name:  "nil and pass marker without hashmap stats",
-			stats: &plan.Stats{},
-			specs: []*plan.RuntimeFilterSpec{nil, {Tag: 1}},
+			name:  "shuffle pass marker",
+			stats: runtimeFilterTestStats(true),
+			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
 		},
 		{
-			name:  "mixed markers and predicates",
-			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{}},
+			name:  "ordinary predicate after shuffle stats are replaced",
+			stats: runtimeFilterTestStats(false),
 			specs: []*plan.RuntimeFilterSpec{
+				{Tag: 1, Expr: runtimeFilterTestColumn("probe_id")},
+			},
+			want: "Runtime Filter Probe: probe_id",
+		},
+		{
+			name:  "mixed markers and predicates after stats replacement",
+			stats: runtimeFilterTestStats(false),
+			specs: []*plan.RuntimeFilterSpec{
+				nil,
 				{Tag: 1},
 				{Tag: 2, Expr: runtimeFilterTestColumn("probe_id"), MatchPrefix: true},
 				{Tag: 3},
@@ -55,24 +65,8 @@ func TestRuntimeFilterProbeExplain(t *testing.T) {
 			want: "Runtime Filter Probe: probe_id Match Prefix, probe_id_2",
 		},
 		{
-			name: "ordinary predicate without stats",
-			specs: []*plan.RuntimeFilterSpec{
-				{Tag: 1, Expr: runtimeFilterTestColumn("probe_id")},
-			},
-			want: "Runtime Filter Probe: probe_id",
-		},
-		{
-			name: "shuffle pass marker",
-			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
-				Shuffle: true,
-			}},
-			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
-		},
-		{
-			name: "explicit predicate survives stale shuffle stats",
-			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
-				Shuffle: true,
-			}},
+			name:  "explicit predicate survives stale shuffle stats",
+			stats: runtimeFilterTestStats(true),
 			specs: []*plan.RuntimeFilterSpec{
 				{Tag: 1, Expr: runtimeFilterTestColumn("probe_id")},
 			},
@@ -105,13 +99,20 @@ func TestRuntimeFilterBuildExplain(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "pass marker without stats",
-			specs: []*plan.RuntimeFilterSpec{nil, {Tag: 1}},
+			name:  "pass marker after shuffle stats are replaced",
+			stats: runtimeFilterTestStats(false),
+			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
+		},
+		{
+			name:  "shuffle pass marker",
+			stats: runtimeFilterTestStats(true),
+			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
 		},
 		{
 			name:  "build expression and legacy fallback",
-			stats: &plan.Stats{},
+			stats: runtimeFilterTestStats(false),
 			specs: []*plan.RuntimeFilterSpec{
+				nil,
 				{Tag: 1},
 				{
 					Tag:       2,
@@ -123,17 +124,8 @@ func TestRuntimeFilterBuildExplain(t *testing.T) {
 			want: "Runtime Filter Build: build_id, legacy_build_id",
 		},
 		{
-			name: "shuffle pass marker",
-			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
-				Shuffle: true,
-			}},
-			specs: []*plan.RuntimeFilterSpec{{Tag: 1}},
-		},
-		{
-			name: "explicit predicate survives stale shuffle stats",
-			stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
-				Shuffle: true,
-			}},
+			name:  "explicit predicate survives stale shuffle stats",
+			stats: runtimeFilterTestStats(true),
 			specs: []*plan.RuntimeFilterSpec{
 				{Tag: 1, BuildExpr: runtimeFilterTestColumn("build_id")},
 			},
@@ -161,17 +153,33 @@ func TestRuntimeFilterBuildExplain(t *testing.T) {
 func TestRuntimeFilterPassMarkersDoNotCreateExtraInfoLabels(t *testing.T) {
 	node := &plan.Node{
 		NodeType:               plan.Node_JOIN,
-		Stats:                  &plan.Stats{},
+		Stats:                  runtimeFilterTestStats(false),
 		RuntimeFilterProbeList: []*plan.RuntimeFilterSpec{{Tag: 1}},
 		RuntimeFilterBuildList: []*plan.RuntimeFilterSpec{{Tag: 1}},
 	}
 
-	got, err := NewNodeDescriptionImpl(node).GetExtraInfo(
-		context.Background(),
-		NewExplainDefaultOptions(),
-	)
-	require.NoError(t, err)
-	require.Equal(t, []string{"Join Type: INNER"}, got)
+	formats := []struct {
+		name   string
+		format ExplainFormat
+	}{
+		{name: "text", format: EXPLAIN_FORMAT_TEXT},
+		{name: "json", format: EXPLAIN_FORMAT_JSON},
+		{name: "dot", format: EXPLAIN_FORMAT_DOT},
+	}
+	for _, format := range formats {
+		t.Run(format.name, func(t *testing.T) {
+			got, err := NewNodeDescriptionImpl(node).GetExtraInfo(
+				context.Background(),
+				&ExplainOptions{Format: format.format},
+			)
+			require.NoError(t, err)
+			require.Equal(t, []string{"Join Type: INNER"}, got)
+		})
+	}
+}
+
+func runtimeFilterTestStats(shuffle bool) *plan.Stats {
+	return &plan.Stats{HashmapStats: &plan.HashMapStats{Shuffle: shuffle}}
 }
 
 func runtimeFilterTestColumn(name string) *plan.Expr {

--- a/pkg/tests/issues/issue_26408_join_spill_test.go
+++ b/pkg/tests/issues/issue_26408_join_spill_test.go
@@ -86,6 +86,7 @@ func TestIssue26408JoinSpillSQLRegression(t *testing.T) {
 		}()
 		execJoinSpillSQL(t, ctx, conn, "use `"+dbName+"`")
 		execJoinSpillSQL(t, ctx, conn, "set @@max_dop = 1")
+		defer resetOptimizerHintsOnCN(t, port)
 		execJoinSpillSQL(t, ctx, conn, `set session optimizer_hints = "forceOneCN=1"`)
 
 		execJoinSpillSQL(t, ctx, conn, "create table probe_keys (k bigint not null, payload bigint not null) cluster by k")

--- a/pkg/tests/issues/issue_26408_join_spill_test.go
+++ b/pkg/tests/issues/issue_26408_join_spill_test.go
@@ -197,18 +197,9 @@ func queryJoinSpillResult(
 
 func queryJoinSpillText(t *testing.T, ctx context.Context, conn *sql.Conn, query string) string {
 	t.Helper()
-	rows, err := conn.QueryContext(ctx, query)
+	text, err := testutils.QueryText(ctx, conn, query)
 	require.NoErrorf(t, err, "query failed: %s", query)
-	defer rows.Close()
-
-	var lines []string
-	for rows.Next() {
-		var line string
-		require.NoError(t, rows.Scan(&line))
-		lines = append(lines, line)
-	}
-	require.NoError(t, rows.Err())
-	return strings.Join(lines, "\n")
+	return text
 }
 
 func patchJoinSpillStats(

--- a/pkg/tests/issues/issue_26568_test.go
+++ b/pkg/tests/issues/issue_26568_test.go
@@ -132,6 +132,11 @@ func runIssue26568ExplainAttack(
 
 	issue26568Exec(t, ctx, conn, "set role moadmin")
 	issue26568Exec(t, ctx, conn, "use `"+dbName+"`")
+	// SET optimizer_hints also updates the CN service runtime, so closing this
+	// session is not enough to isolate the next test that reuses the cluster.
+	// Register cleanup before the mutation and use a fresh connection/context so
+	// restoration does not depend on the attack connection remaining healthy.
+	defer resetOptimizerHintsOnCN(t, port)
 	issue26568Exec(t, ctx, conn,
 		fmt.Sprintf(`set session optimizer_hints = "%s"`, attack.hint))
 	issue26568Exec(t, ctx, conn, "set session join_spill_mem = 1073741824")

--- a/pkg/tests/issues/issue_26568_test.go
+++ b/pkg/tests/issues/issue_26568_test.go
@@ -28,7 +28,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const issue26568Rows = 130_000
+const (
+	issue26568Rows                = 130_000
+	issue26568TPPlanTitle         = "TP QUERY PLAN"
+	issue26568MultiCNPlanTitle    = "AP QUERY PLAN ON MULTICN("
+	issue26568MultiCNPhyPlanTitle = "AP QUERY PHYPLAN ON MULTICN("
+)
 
 const issue26568JoinSQL = `
 	select count(*)
@@ -36,9 +41,10 @@ const issue26568JoinSQL = `
 	join po_r as r on l.id = r.id`
 
 type issue26568ExplainAttack struct {
-	name      string
-	hint      string
-	statement string
+	name                string
+	hint                string
+	statement           string
+	wantPlanTitlePrefix string
 }
 
 // TestIssue26568ExplainMultiCNHashJoin exercises the same SQL-protocol path as
@@ -61,32 +67,37 @@ func TestIssue26568ExplainMultiCNHashJoin(t *testing.T) {
 			t.Run(fmt.Sprintf("coordinator-cn-%d", index), func(t *testing.T) {
 				runIssue26568ExplainAttack(t, ctx, cn.GetServiceConfig().CN.Frontend.Port, dbName,
 					issue26568ExplainAttack{
-						name:      "reported logical plan",
-						hint:      "execType=2",
-						statement: "explain " + issue26568JoinSQL,
+						name:                "reported logical plan",
+						hint:                "execType=2",
+						statement:           "explain " + issue26568JoinSQL,
+						wantPlanTitlePrefix: issue26568MultiCNPlanTitle,
 					})
 			})
 		}
 
 		attacks := []issue26568ExplainAttack{
 			{
-				name:      "minimal stats replacement",
-				hint:      "execType=1",
-				statement: "explain " + issue26568JoinSQL,
+				name:                "minimal stats replacement",
+				hint:                "execType=1",
+				statement:           "explain " + issue26568JoinSQL,
+				wantPlanTitlePrefix: issue26568TPPlanTitle,
 			},
 			{
-				name:      "big stats verbose renderer",
-				hint:      "execType=2",
-				statement: "explain verbose " + issue26568JoinSQL,
+				name:                "big stats verbose renderer",
+				hint:                "execType=2",
+				statement:           "explain verbose " + issue26568JoinSQL,
+				wantPlanTitlePrefix: issue26568MultiCNPlanTitle,
 			},
 			{
-				name:      "huge stats replacement",
-				hint:      "execType=3",
-				statement: "explain " + issue26568JoinSQL,
+				name:                "huge stats replacement",
+				hint:                "execType=3",
+				statement:           "explain " + issue26568JoinSQL,
+				wantPlanTitlePrefix: issue26568MultiCNPlanTitle,
 			},
 			{
-				name: "multiple shuffle pass markers",
-				hint: "execType=2",
+				name:                "multiple shuffle pass markers",
+				hint:                "execType=2",
+				wantPlanTitlePrefix: issue26568MultiCNPlanTitle,
 				statement: `explain
 					select count(*)
 					from po_l as l
@@ -94,14 +105,10 @@ func TestIssue26568ExplainMultiCNHashJoin(t *testing.T) {
 					join po_l as l2 on l2.id = r.id`,
 			},
 			{
-				name:      "physical plan renderer",
-				hint:      "execType=2",
-				statement: "explain phyplan " + issue26568JoinSQL,
-			},
-			{
-				name:      "analyze renderer",
-				hint:      "execType=2",
-				statement: "explain analyze " + issue26568JoinSQL,
+				name:                "physical plan renderer",
+				hint:                "execType=2",
+				statement:           "explain phyplan " + issue26568JoinSQL,
+				wantPlanTitlePrefix: issue26568MultiCNPhyPlanTitle,
 			},
 		}
 		for _, attack := range attacks {
@@ -121,23 +128,22 @@ func runIssue26568ExplainAttack(
 ) {
 	t.Helper()
 	conn := openIssue26568Conn(t, ctx, port)
-	defer conn.Close()
+	defer func() { require.NoError(t, conn.Close()) }()
 
 	issue26568Exec(t, ctx, conn, "set role moadmin")
 	issue26568Exec(t, ctx, conn, "use `"+dbName+"`")
 	issue26568Exec(t, ctx, conn,
 		fmt.Sprintf(`set session optimizer_hints = "%s"`, attack.hint))
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		_, err := conn.ExecContext(cleanupCtx, `set session optimizer_hints = ""`)
-		require.NoError(t, err)
-	}()
 	issue26568Exec(t, ctx, conn, "set session join_spill_mem = 1073741824")
 
-	planText, err := testutils.QueryText(ctx, conn, attack.statement)
+	result, err := testutils.QueryTextResult(ctx, conn, attack.statement)
 	require.NoErrorf(t, err, "attack failed: %s", attack.name)
+	planText := result.Text
 	require.NotEmpty(t, planText)
+	require.Truef(t,
+		strings.HasPrefix(strings.ToUpper(result.ColumnName), attack.wantPlanTitlePrefix),
+		"attack %q did not reach plan class %q: got column %q",
+		attack.name, attack.wantPlanTitlePrefix, result.ColumnName)
 	require.Contains(t, strings.ToLower(planText), "join")
 	for _, line := range strings.Split(planText, "\n") {
 		line = strings.TrimSpace(line)
@@ -149,7 +155,7 @@ func runIssue26568ExplainAttack(
 func setupIssue26568Tables(t *testing.T, ctx context.Context, port int64, dbName string) {
 	t.Helper()
 	conn := openIssue26568Conn(t, ctx, port)
-	defer conn.Close()
+	defer func() { require.NoError(t, conn.Close()) }()
 
 	issue26568Exec(t, ctx, conn, "set role moadmin")
 	issue26568Exec(t, ctx, conn, "drop database if exists `"+dbName+"`")

--- a/pkg/tests/issues/issue_26568_test.go
+++ b/pkg/tests/issues/issue_26568_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+const issue26568Rows = 130_000
+
+const issue26568JoinSQL = `
+	select count(*)
+	from po_l as l
+	join po_r as r on l.id = r.id`
+
+type issue26568ExplainAttack struct {
+	name      string
+	hint      string
+	statement string
+}
+
+// TestIssue26568ExplainMultiCNHashJoin exercises the same SQL-protocol path as
+// the reported failure through two independent frontend coordinators, then
+// attacks the same plan contract through alternative stats and renderers.
+func TestIssue26568ExplainMultiCNHashJoin(t *testing.T) {
+	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cn0, err := c.GetCNService(0)
+		require.NoError(t, err)
+		dbName := strings.ToLower(testutils.GetDatabaseName(t))
+		cn0Port := cn0.GetServiceConfig().CN.Frontend.Port
+		setupIssue26568Tables(t, ctx, cn0Port, dbName)
+
+		for _, index := range []int{0, 1} {
+			cn, err := c.GetCNService(index)
+			require.NoError(t, err)
+			t.Run(fmt.Sprintf("coordinator-cn-%d", index), func(t *testing.T) {
+				runIssue26568ExplainAttack(t, ctx, cn.GetServiceConfig().CN.Frontend.Port, dbName,
+					issue26568ExplainAttack{
+						name:      "reported logical plan",
+						hint:      "execType=2",
+						statement: "explain " + issue26568JoinSQL,
+					})
+			})
+		}
+
+		attacks := []issue26568ExplainAttack{
+			{
+				name:      "minimal stats replacement",
+				hint:      "execType=1",
+				statement: "explain " + issue26568JoinSQL,
+			},
+			{
+				name:      "big stats verbose renderer",
+				hint:      "execType=2",
+				statement: "explain verbose " + issue26568JoinSQL,
+			},
+			{
+				name:      "huge stats replacement",
+				hint:      "execType=3",
+				statement: "explain " + issue26568JoinSQL,
+			},
+			{
+				name: "multiple shuffle pass markers",
+				hint: "execType=2",
+				statement: `explain
+					select count(*)
+					from po_l as l
+					join po_r as r on l.id = r.id
+					join po_l as l2 on l2.id = r.id`,
+			},
+			{
+				name:      "physical plan renderer",
+				hint:      "execType=2",
+				statement: "explain phyplan " + issue26568JoinSQL,
+			},
+			{
+				name:      "analyze renderer",
+				hint:      "execType=2",
+				statement: "explain analyze " + issue26568JoinSQL,
+			},
+		}
+		for _, attack := range attacks {
+			t.Run("attack/"+attack.name, func(t *testing.T) {
+				runIssue26568ExplainAttack(t, ctx, cn0Port, dbName, attack)
+			})
+		}
+	})
+}
+
+func runIssue26568ExplainAttack(
+	t *testing.T,
+	ctx context.Context,
+	port int64,
+	dbName string,
+	attack issue26568ExplainAttack,
+) {
+	t.Helper()
+	conn := openIssue26568Conn(t, ctx, port)
+	defer conn.Close()
+
+	issue26568Exec(t, ctx, conn, "set role moadmin")
+	issue26568Exec(t, ctx, conn, "use `"+dbName+"`")
+	issue26568Exec(t, ctx, conn,
+		fmt.Sprintf(`set session optimizer_hints = "%s"`, attack.hint))
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		_, err := conn.ExecContext(cleanupCtx, `set session optimizer_hints = ""`)
+		require.NoError(t, err)
+	}()
+	issue26568Exec(t, ctx, conn, "set session join_spill_mem = 1073741824")
+
+	planText, err := testutils.QueryText(ctx, conn, attack.statement)
+	require.NoErrorf(t, err, "attack failed: %s", attack.name)
+	require.NotEmpty(t, planText)
+	require.Contains(t, strings.ToLower(planText), "join")
+	for _, line := range strings.Split(planText, "\n") {
+		line = strings.TrimSpace(line)
+		require.NotEqual(t, "Runtime Filter Probe:", line)
+		require.NotEqual(t, "Runtime Filter Build:", line)
+	}
+}
+
+func setupIssue26568Tables(t *testing.T, ctx context.Context, port int64, dbName string) {
+	t.Helper()
+	conn := openIssue26568Conn(t, ctx, port)
+	defer conn.Close()
+
+	issue26568Exec(t, ctx, conn, "set role moadmin")
+	issue26568Exec(t, ctx, conn, "drop database if exists `"+dbName+"`")
+	t.Cleanup(func() {
+		cleanupIssue26568Database(t, port, dbName)
+	})
+	issue26568Exec(t, ctx, conn, "create database `"+dbName+"`")
+	issue26568Exec(t, ctx, conn, "use `"+dbName+"`")
+	issue26568Exec(t, ctx, conn, "create table po_l (id bigint primary key)")
+	issue26568Exec(t, ctx, conn, "create table po_r (id bigint primary key)")
+	issue26568Exec(t, ctx, conn, fmt.Sprintf(
+		"insert into po_l select result from generate_series(1, %d) g", issue26568Rows))
+	issue26568Exec(t, ctx, conn, fmt.Sprintf(
+		"insert into po_r select result from generate_series(1, %d) g", issue26568Rows))
+}
+
+func openIssue26568Conn(t *testing.T, ctx context.Context, port int64) *sql.Conn {
+	t.Helper()
+	db, err := sql.Open("mysql", issue26568DSN(port))
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	return conn
+}
+
+func cleanupIssue26568Database(t *testing.T, port int64, dbName string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("mysql", issue26568DSN(port))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+	issue26568Exec(t, ctx, db, "set role moadmin")
+	issue26568Exec(t, ctx, db, "drop database if exists `"+dbName+"`")
+}
+
+func issue26568DSN(port int64) string {
+	return fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port)
+}
+
+func issue26568Exec(t *testing.T, ctx context.Context, conn interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, statement string) {
+	t.Helper()
+	_, err := conn.ExecContext(ctx, statement)
+	require.NoErrorf(t, err, "exec failed: %s", statement)
+}

--- a/pkg/tests/issues/optimizer_hints_test.go
+++ b/pkg/tests/issues/optimizer_hints_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// resetOptimizerHintsOnCN restores the shared service-runtime value, not only
+// one session variable. Use a fresh connection and context so cleanup remains
+// independent of the connection and deadline exercised by the test.
+func resetOptimizerHintsOnCN(t *testing.T, port int64) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dsn := fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port)
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	for _, statement := range []string{
+		"set role moadmin",
+		`set session optimizer_hints = ""`,
+	} {
+		_, err = db.ExecContext(ctx, statement)
+		require.NoErrorf(t, err, "exec failed: %s", statement)
+	}
+}

--- a/pkg/tests/testutils/sql_text.go
+++ b/pkg/tests/testutils/sql_text.go
@@ -17,6 +17,7 @@ package testutils
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 )
 
@@ -26,26 +27,61 @@ type SQLTextQueryer interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }
 
-// QueryText executes a one-text-column query and joins its rows with newlines.
-// It is suitable for EXPLAIN and other SQL-protocol assertions whose result is
-// deliberately textual rather than a typed data set.
-func QueryText(ctx context.Context, queryer SQLTextQueryer, statement string) (string, error) {
+// TextQueryResult preserves both parts of a one-text-column SQL result: its
+// protocol column name and its text rows. EXPLAIN uses the column name to carry
+// the plan class, so both are part of that public SQL contract.
+type TextQueryResult struct {
+	ColumnName string
+	Text       string
+}
+
+// QueryTextResult executes a one-text-column query without discarding its SQL
+// protocol metadata.
+func QueryTextResult(
+	ctx context.Context,
+	queryer SQLTextQueryer,
+	statement string,
+) (TextQueryResult, error) {
 	rows, err := queryer.QueryContext(ctx, statement)
 	if err != nil {
-		return "", err
+		return TextQueryResult{}, err
 	}
 	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return TextQueryResult{}, err
+	}
+	if len(columns) != 1 {
+		return TextQueryResult{}, fmt.Errorf(
+			"expected one text column, got %d columns", len(columns))
+	}
 
 	var lines []string
 	for rows.Next() {
 		var line string
 		if err := rows.Scan(&line); err != nil {
-			return "", err
+			return TextQueryResult{}, err
 		}
 		lines = append(lines, line)
 	}
 	if err := rows.Err(); err != nil {
+		return TextQueryResult{}, err
+	}
+	return TextQueryResult{
+		ColumnName: columns[0],
+		Text:       strings.Join(lines, "\n"),
+	}, nil
+}
+
+// QueryText executes a one-text-column query and joins its rows with newlines.
+// It is suitable for EXPLAIN and other SQL-protocol assertions whose result is
+// deliberately textual rather than a typed data set. Use QueryTextResult when
+// the protocol column name is also part of the assertion.
+func QueryText(ctx context.Context, queryer SQLTextQueryer, statement string) (string, error) {
+	result, err := QueryTextResult(ctx, queryer, statement)
+	if err != nil {
 		return "", err
 	}
-	return strings.Join(lines, "\n"), nil
+	return result.Text, nil
 }

--- a/pkg/tests/testutils/sql_text.go
+++ b/pkg/tests/testutils/sql_text.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+)
+
+// SQLTextQueryer is the subset of database/sql used by text-returning SQL
+// assertions. Both *sql.DB and *sql.Conn implement it.
+type SQLTextQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+// QueryText executes a one-text-column query and joins its rows with newlines.
+// It is suitable for EXPLAIN and other SQL-protocol assertions whose result is
+// deliberately textual rather than a typed data set.
+func QueryText(ctx context.Context, queryer SQLTextQueryer, statement string) (string, error) {
+	rows, err := queryer.QueryContext(ctx, statement)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var lines []string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			return "", err
+		}
+		lines = append(lines, line)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return strings.Join(lines, "\n"), nil
+}

--- a/pkg/tests/testutils/sql_text.go
+++ b/pkg/tests/testutils/sql_text.go
@@ -17,8 +17,9 @@ package testutils
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 )
 
 // SQLTextQueryer is the subset of database/sql used by text-returning SQL
@@ -53,7 +54,7 @@ func QueryTextResult(
 		return TextQueryResult{}, err
 	}
 	if len(columns) != 1 {
-		return TextQueryResult{}, fmt.Errorf(
+		return TextQueryResult{}, moerr.NewInternalErrorf(ctx,
 			"expected one text column, got %d columns", len(columns))
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [ ] API-change
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Closes #26568

## What this PR does / why we need it:

Shuffle joins use expression-less runtime-filter specs as PASS transport markers. EXPLAIN previously decided whether to render those specs from mutable shuffle stats, so stats replacement could leave a marker on a non-shuffle-looking node and pass a nil expression to describeExpr.

This change makes rendering depend on the runtime-filter payload itself: marker-only specs are omitted, probe predicates render Expr, and build predicates prefer BuildExpr with the legacy Expr fallback. It also adds focused rendering matrices and a SQL-protocol multi-CN regression covering both coordinators, optimizer stats modes, multiple markers, and logical/verbose/physical renderers.

The shared SQL text helper preserves the one-column protocol metadata needed to assert the selected plan class.

## Test

- focused explain tests under race, count=100
- TestIssue26568ExplainMultiCNHashJoin under race
- TestIssue26408JoinSpillSQLRegression under race
- full pkg/sql/plan/explain package under race
- go build for pkg/sql/plan/explain and pkg/tests/testutils
- go vet for all modified packages