### PR TITLE
fix(ci): retry UT analyzer installation

### DIFF
--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -32,6 +32,7 @@ fi
 
 shopt -s expand_aliases
 source ./utilities.sh
+source ./ut_tools.bash
 go version
 
 BUILD_WKSP=$(dirname "$PWD") && cd $BUILD_WKSP
@@ -316,7 +317,7 @@ function ut_summary(){
   # analyzer cannot parse a truncated/interleaved go test JSON stream.
   mkdir -p "${report_path}/failed/outputs"
 
-  if ! go install github.com/matrixorigin/go-ut-analysis@latest; then
+  if ! install_go_ut_analysis; then
     analysis_status=1
     logger "ERR" "failed to install go-ut-analysis"
   else

--- a/optools/ut_tools.bash
+++ b/optools/ut_tools.bash
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2026 Matrix Origin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GO_UT_ANALYSIS_VERSION="v0.0.0-20250711025253-f31acb12d3b1"
+
+function retry_command() {
+    if (( $# < 3 )); then
+        echo "Usage: retry_command MAX_ATTEMPTS DELAY_SECONDS COMMAND [ARG...]" >&2
+        return 2
+    fi
+
+    local max_attempts=$1
+    local delay_seconds=$2
+    shift 2
+
+    if ! [[ "${max_attempts}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "max_attempts must be a positive integer, got '${max_attempts}'" >&2
+        return 2
+    fi
+    if ! [[ "${delay_seconds}" =~ ^[0-9]+$ ]]; then
+        echo "delay_seconds must be a non-negative integer, got '${delay_seconds}'" >&2
+        return 2
+    fi
+
+    local attempt
+    local status
+    for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+        if "$@"; then
+            return 0
+        else
+            status=$?
+        fi
+
+        if (( attempt == max_attempts )); then
+            return "${status}"
+        fi
+        echo "command failed (attempt ${attempt}/${max_attempts}), retrying in ${delay_seconds}s..." >&2
+        sleep "${delay_seconds}"
+    done
+}
+
+function install_go_ut_analysis() {
+    local max_attempts=${1:-3}
+    local delay_seconds=${2:-5}
+
+    retry_command "${max_attempts}" "${delay_seconds}" \
+        go install "github.com/matrixorigin/go-ut-analysis@${GO_UT_ANALYSIS_VERSION}"
+}

--- a/optools/ut_tools_test.go
+++ b/optools/ut_tools_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optools
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const goUTAnalysisModule = "github.com/matrixorigin/go-ut-analysis@v0.0.0-20250711025253-f31acb12d3b1"
+
+func writeMockGo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "go")
+	script := `#!/bin/bash
+count=0
+if [[ -f "${MOCK_GO_COUNTER}" ]]; then count=$(<"${MOCK_GO_COUNTER}"); fi
+count=$((count + 1))
+echo "${count}" > "${MOCK_GO_COUNTER}"
+echo "$*" >> "${MOCK_GO_ARGS}"
+if (( count >= MOCK_GO_SUCCEED_AFTER )); then exit 0; fi
+exit "${MOCK_GO_FAILURE_STATUS}"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func runInstall(t *testing.T, attempts, succeedAfter, failureStatus int) ([]byte, int, string, string) {
+	t.Helper()
+
+	toolsPath, err := filepath.Abs("ut_tools.bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter := filepath.Join(t.TempDir(), "attempts")
+	arguments := filepath.Join(t.TempDir(), "arguments")
+	mockGoDir := writeMockGo(t)
+	cmd := exec.Command("bash", "-c", `source "$1"; install_go_ut_analysis "$2" 0`,
+		"bash", toolsPath, strconv.Itoa(attempts))
+	cmd.Env = append(os.Environ(),
+		"PATH="+mockGoDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"MOCK_GO_COUNTER="+counter,
+		"MOCK_GO_ARGS="+arguments,
+		"MOCK_GO_SUCCEED_AFTER="+strconv.Itoa(succeedAfter),
+		"MOCK_GO_FAILURE_STATUS="+strconv.Itoa(failureStatus),
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return output, 0, counter, arguments
+	}
+	if exitError, ok := err.(*exec.ExitError); ok {
+		return output, exitError.ExitCode(), counter, arguments
+	}
+	t.Fatalf("install go-ut-analysis: %v", err)
+	return nil, 0, "", ""
+}
+
+func assertAttempts(t *testing.T, counter, arguments string, expected int) {
+	t.Helper()
+
+	attempts, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(attempts)) != strconv.Itoa(expected) {
+		t.Fatalf("expected %d attempts, got %q", expected, attempts)
+	}
+	invocations, err := os.ReadFile(arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for lineNumber, invocation := range strings.Split(strings.TrimSpace(string(invocations)), "\n") {
+		if invocation != "install "+goUTAnalysisModule {
+			t.Fatalf("attempt %d used unexpected arguments %q", lineNumber+1, invocation)
+		}
+	}
+}
+
+func TestInstallGoUTAnalysisRetriesTransientFailures(t *testing.T) {
+	output, status, counter, arguments := runInstall(t, 3, 3, 42)
+	if status != 0 {
+		t.Fatalf("install failed with status %d: %s", status, output)
+	}
+	assertAttempts(t, counter, arguments, 3)
+}
+
+func TestInstallGoUTAnalysisDoesNotRetrySuccess(t *testing.T) {
+	output, status, counter, arguments := runInstall(t, 3, 1, 42)
+	if status != 0 {
+		t.Fatalf("install failed with status %d: %s", status, output)
+	}
+	assertAttempts(t, counter, arguments, 1)
+}
+
+func TestInstallGoUTAnalysisPreservesFinalFailure(t *testing.T) {
+	output, status, counter, arguments := runInstall(t, 3, 4, 42)
+	if status != 42 {
+		t.Fatalf("expected status 42, got %d: %s", status, output)
+	}
+	assertAttempts(t, counter, arguments, 3)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26573

## What this PR does / why we need it:

### Root cause

`optools/run_ut.sh` installed `github.com/matrixorigin/go-ut-analysis@latest` once, after the Go test phase had completed. In the reported Ubuntu job all Go tests passed, but the configured module proxy returned HTTP 502 while the Go command fetched a checksum-database tile. The one-shot install therefore failed, `ut_summary` set `analysis_status=1`, and the successful UT run was reported as failed.

The analyzer version was also resolved dynamically on every run, so the diagnostics dependency was not reproducible.

### Change

- Move UT analyzer installation into a focused `ut_tools.bash` module.
- Pin `go-ut-analysis` to `v0.0.0-20250711025253-f31acb12d3b1`, the version resolved in the failing job.
- Retry installation up to three times with a five-second interval. A successful attempt returns immediately; exhausting all attempts preserves failure, so persistent dependency failures remain visible.
- Keep analyzer execution and `UT_TEST_STATUS` / `analysis_status` aggregation unchanged, so actual unit-test failures and analyzer-result failures still fail the job.
- Add focused tests with a mocked `go` command for immediate success, recovery after transient failures, permanent failure, exact attempt counts, final status propagation, and the pinned install argument.

### Validation

- Reproduced the original failure from run 30708753033: `go-test=0`, then the one-shot analyzer install failed on a proxy-served sumdb HTTP 502 and produced `analysis=1`.
- Hosted MatrixOne ALL CI run 30714965858 passed: the Ubuntu/x86 job installed the pinned analyzer, reported `UNIT TESTING SUCCEEDED`, and all completed PR checks concluded success, skipped, or neutral.
- `bash -n optools/run_ut.sh optools/ut_tools.bash`
- `go vet ./optools`
- `make config`
- Actual installation of the pinned analyzer through `install_go_ut_analysis`, followed by an executable check.
- Adaptive focused race stress with a 30-second budget:
  - `TestInstallGoUTAnalysisRetriesTransientFailures`: `T=0.21s`, `N=100`
  - `TestInstallGoUTAnalysisDoesNotRetrySuccess`: `T=0.19s`, `N=100`
  - `TestInstallGoUTAnalysisPreservesFinalFailure`: `T=0.21s`, `N=100`
- `go test -race -count=1 -timeout=120s ./optools`
- `go test -count=1 ./optools`
- `git diff --check origin/main...HEAD`

BVT is not applicable because this change affects CI shell orchestration and does not change MatrixOne SQL or database behavior.

### Residual risk

- A persistent proxy outage still fails after three attempts by design; retries add at most 10 seconds of sleep.
- Each `go install` attempt retains its existing network timeout behavior. The Ubuntu `make ut` path remains bounded by its existing 60-minute outer timeout.
- Pinning removes `@latest` drift but requires an explicit version update when the analyzer is upgraded.
