### PR TITLE
fix(frontend): support numeric pick key literals

### DIFF
--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -1255,14 +1255,19 @@ func appendExprToVec(vec *vector.Vector, expr tree.Expr, pkType types.Type, tz *
 		if !ok {
 			return moerr.NewInvalidInputNoCtxf("unsupported unary expression type for PK filter: %T", e.Expr)
 		}
+		negative := false
 		s := num.String()
 		switch e.Op {
 		case tree.UNARY_MINUS:
+			negative = true
 			s = "-" + s
 		case tree.UNARY_PLUS:
 			s = "+" + s
 		default:
 			return moerr.NewInvalidInputNoCtxf("unsupported unary operator for PK filter: %v", e.Op)
+		}
+		if pkType.Oid.IsInteger() && (num.ValType == tree.P_hexnum || num.ValType == tree.P_float64) {
+			return appendIntegerNumValToVec(vec, num, negative, pkType, tz, mp)
 		}
 		return appendNumericStringToVec(vec, s, pkType, tz, mp)
 	case *tree.StrVal:
@@ -1276,7 +1281,51 @@ func appendExprToVec(vec *vector.Vector, expr tree.Expr, pkType types.Type, tz *
 // appendNumValToVec converts a numeric literal to the correct typed value
 // and appends it to the vector.
 func appendNumValToVec(vec *vector.Vector, val *tree.NumVal, pkType types.Type, tz *time.Location, mp *mpool.MPool) error {
+	if pkType.Oid.IsInteger() && (val.ValType == tree.P_hexnum || val.ValType == tree.P_float64) {
+		return appendIntegerNumValToVec(vec, val, false, pkType, tz, mp)
+	}
 	return appendNumericStringToVec(vec, val.String(), pkType, tz, mp)
+}
+
+func appendIntegerNumValToVec(
+	vec *vector.Vector,
+	val *tree.NumVal,
+	negative bool,
+	pkType types.Type,
+	tz *time.Location,
+	mp *mpool.MPool,
+) error {
+	var n *big.Int
+	switch val.ValType {
+	case tree.P_hexnum:
+		s := val.String()
+		if len(s) < 3 || (s[:2] != "0x" && s[:2] != "0X") {
+			return moerr.NewInvalidInputNoCtxf("invalid hexadecimal literal %q", s)
+		}
+		var ok bool
+		n, ok = new(big.Int).SetString(s[2:], 16)
+		if !ok {
+			return moerr.NewInvalidInputNoCtxf("invalid hexadecimal literal %q", s)
+		}
+	case tree.P_float64:
+		r, ok := new(big.Rat).SetString(val.String())
+		if !ok {
+			return moerr.NewInvalidInputNoCtxf("invalid numeric literal %q", val.String())
+		}
+		if !r.IsInt() {
+			return moerr.NewInvalidInputNoCtxf(
+				"numeric literal %q is not an integer for primary key type %s",
+				val.String(), pkType.String(),
+			)
+		}
+		n = new(big.Int).Set(r.Num())
+	default:
+		return moerr.NewInvalidInputNoCtxf("unsupported numeric literal %q", val.String())
+	}
+	if negative {
+		n.Neg(n)
+	}
+	return appendNumericStringToVec(vec, n.String(), pkType, tz, mp)
 }
 
 func appendNumericStringToVec(vec *vector.Vector, s string, pkType types.Type, tz *time.Location, mp *mpool.MPool) error {

--- a/pkg/frontend/data_branch_pick_test.go
+++ b/pkg/frontend/data_branch_pick_test.go
@@ -16,6 +16,7 @@ package frontend
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -585,6 +586,110 @@ func TestAppendExprToVec_BoolLiteral(t *testing.T) {
 	err = appendExprToVec(vec, expr, pkType, time.UTC, mp)
 	require.NoError(t, err)
 	require.True(t, vector.GetFixedAtNoTypeCheck[bool](vec, 0))
+}
+
+func TestAppendExprToVec_IntegerPKNumericLiteralForms(t *testing.T) {
+	stmtNode, err := parsers.ParseOne(
+		context.Background(),
+		dialect.MYSQL,
+		"data branch pick src into dst keys(0x2, 3e0, -4e0, +5e0, -0x6)",
+		1,
+	)
+	require.NoError(t, err)
+
+	stmt, ok := stmtNode.(*tree.DataBranchPick)
+	require.True(t, ok)
+	require.Len(t, stmt.Keys.KeyExprs, 5)
+
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+	defer mp.Free(nil)
+
+	vec := vector.NewVec(types.T_int32.ToType())
+	defer vec.Free(mp)
+	for _, expr := range stmt.Keys.KeyExprs {
+		require.NoError(t, appendExprToVec(vec, expr, *vec.GetType(), time.UTC, mp))
+	}
+	require.Equal(t, []int32{2, 3, -4, 5, -6}, vector.MustFixedColNoTypeCheck[int32](vec))
+}
+
+func TestAppendExprToVec_IntegerPKNumericLiteralBoundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		literal string
+		pkType  types.Type
+		want    any
+		wantErr string
+	}{
+		{name: "signed minimum", literal: "-1.28e2", pkType: types.T_int8.ToType(), want: int8(-128)},
+		{name: "signed maximum", literal: "+1.27e2", pkType: types.T_int8.ToType(), want: int8(127)},
+		{name: "unsigned negative zero", literal: "-0x0", pkType: types.T_uint8.ToType(), want: uint8(0)},
+		{name: "unsigned maximum", literal: "0xffffffffffffffff", pkType: types.T_uint64.ToType(), want: uint64(math.MaxUint64)},
+		{name: "fractional scientific", literal: "1.1e0", pkType: types.T_int32.ToType(), wantErr: "is not an integer"},
+		{name: "signed underflow", literal: "-1.29e2", pkType: types.T_int8.ToType(), wantErr: "out of range"},
+		{name: "signed overflow", literal: "1.28e2", pkType: types.T_int8.ToType(), wantErr: "out of range"},
+		{name: "unsigned negative", literal: "-1e0", pkType: types.T_uint8.ToType(), wantErr: "invalid syntax"},
+		{name: "unsigned overflow", literal: "0x100", pkType: types.T_uint8.ToType(), wantErr: "out of range"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmtNode, err := parsers.ParseOne(
+				context.Background(),
+				dialect.MYSQL,
+				"data branch pick src into dst keys("+tc.literal+")",
+				1,
+			)
+			require.NoError(t, err)
+			stmt := stmtNode.(*tree.DataBranchPick)
+
+			mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+			require.NoError(t, err)
+			defer mp.Free(nil)
+			vec := vector.NewVec(tc.pkType)
+			defer vec.Free(mp)
+
+			err = appendExprToVec(vec, stmt.Keys.KeyExprs[0], tc.pkType, time.UTC, mp)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				require.Zero(t, vec.Length())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, 1, vec.Length())
+			switch want := tc.want.(type) {
+			case int8:
+				require.Equal(t, want, vector.GetFixedAtNoTypeCheck[int8](vec, 0))
+			case uint8:
+				require.Equal(t, want, vector.GetFixedAtNoTypeCheck[uint8](vec, 0))
+			case uint64:
+				require.Equal(t, want, vector.GetFixedAtNoTypeCheck[uint64](vec, 0))
+			default:
+				t.Fatalf("unsupported expected type %T", want)
+			}
+		})
+	}
+}
+
+func TestAppendExprToVec_PreservesUnarySignForFloatPK(t *testing.T) {
+	stmtNode, err := parsers.ParseOne(
+		context.Background(),
+		dialect.MYSQL,
+		"data branch pick src into dst keys(-3e0)",
+		1,
+	)
+	require.NoError(t, err)
+	stmt := stmtNode.(*tree.DataBranchPick)
+
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+	defer mp.Free(nil)
+	pkType := types.T_float64.ToType()
+	vec := vector.NewVec(pkType)
+	defer vec.Free(mp)
+
+	require.NoError(t, appendExprToVec(vec, stmt.Keys.KeyExprs[0], pkType, time.UTC, mp))
+	require.Equal(t, float64(-3), vector.GetFixedAtNoTypeCheck[float64](vec, 0))
 }
 
 func TestAppendExprToVec_UnaryMinus(t *testing.T) {

--- a/test/distributed/cases/git4data/branch/pick/pick_14.result
+++ b/test/distributed/cases/git4data/branch/pick/pick_14.result
@@ -1,0 +1,95 @@
+drop database if exists data_branch_pick_numeric_literal_forms;
+create database data_branch_pick_numeric_literal_forms;
+use data_branch_pick_numeric_literal_forms;
+create table base_int(k int primary key, v int);
+insert into base_int values (-6, 60), (-4, 40), (2, 20), (3, 30), (5, 50);
+data branch create table src_int from base_int;
+data branch create table dst_hex from base_int;
+data branch create table dst_sci from base_int;
+data branch create table dst_negative_hex from base_int;
+update src_int set v = v + 100;
+select k from src_int where k in (0x2, 3e0, -4e0, +5e0, -0x6) order by k;
+➤ k[4,32,0]  𝄀
+-6  𝄀
+-4  𝄀
+2  𝄀
+3  𝄀
+5
+data branch pick src_int into dst_hex keys(0x2);
+select * from dst_hex order by k;
+➤ k[4,32,0]  ¦  v[4,32,0]  𝄀
+-6  ¦  60  𝄀
+-4  ¦  40  𝄀
+2  ¦  120  𝄀
+3  ¦  30  𝄀
+5  ¦  50
+data branch pick src_int into dst_sci keys(3e0, -4e0, +5e0);
+select * from dst_sci order by k;
+➤ k[4,32,0]  ¦  v[4,32,0]  𝄀
+-6  ¦  60  𝄀
+-4  ¦  140  𝄀
+2  ¦  20  𝄀
+3  ¦  130  𝄀
+5  ¦  150
+data branch pick src_int into dst_negative_hex keys(-0x6);
+select * from dst_negative_hex order by k;
+➤ k[4,32,0]  ¦  v[4,32,0]  𝄀
+-6  ¦  160  𝄀
+-4  ¦  40  𝄀
+2  ¦  20  𝄀
+3  ¦  30  𝄀
+5  ¦  50
+create table base_tinyint(k tinyint primary key, v int);
+insert into base_tinyint values (-128, 10), (1, 20), (127, 30);
+data branch create table src_tinyint from base_tinyint;
+data branch create table dst_tinyint from base_tinyint;
+update src_tinyint set v = v + 100;
+data branch pick src_tinyint into dst_tinyint keys(-1.28e2, +1.27e2);
+select * from dst_tinyint order by k;
+➤ k[-6,8,0]  ¦  v[4,32,0]  𝄀
+-128  ¦  110  𝄀
+1  ¦  20  𝄀
+127  ¦  130
+data branch pick src_tinyint into dst_tinyint keys(1.1e0);
+invalid input: numeric literal "1.1e0" is not an integer for primary key type TINYINT
+data branch pick src_tinyint into dst_tinyint keys(-1.29e2);
+strconv.ParseInt: parsing "-129": value out of range
+data branch pick src_tinyint into dst_tinyint keys(1.28e2);
+strconv.ParseInt: parsing "128": value out of range
+select * from dst_tinyint order by k;
+➤ k[-6,8,0]  ¦  v[4,32,0]  𝄀
+-128  ¦  110  𝄀
+1  ¦  20  𝄀
+127  ¦  130
+create table base_utinyint(k tinyint unsigned primary key, v int);
+insert into base_utinyint values (0, 10), (255, 20);
+data branch create table src_utinyint from base_utinyint;
+data branch create table dst_utinyint from base_utinyint;
+update src_utinyint set v = v + 100;
+data branch pick src_utinyint into dst_utinyint keys(-0x0, 0xff);
+select * from dst_utinyint order by k;
+➤ k[-6,8,0]  ¦  v[4,32,0]  𝄀
+0  ¦  110  𝄀
+255  ¦  120
+data branch pick src_utinyint into dst_utinyint keys(-1e0);
+strconv.ParseUint: parsing "-1": invalid syntax
+data branch pick src_utinyint into dst_utinyint keys(0x100);
+strconv.ParseUint: parsing "256": value out of range
+select * from dst_utinyint order by k;
+➤ k[-6,8,0]  ¦  v[4,32,0]  𝄀
+0  ¦  110  𝄀
+255  ¦  120
+create table base_uint(k bigint unsigned primary key, v int);
+insert into base_uint values (1, 10), (18446744073709551615, 20);
+data branch create table src_uint from base_uint;
+data branch create table dst_uint from base_uint;
+update src_uint set v = v + 100 where k = 18446744073709551615;
+select k from src_uint where k = 0xffffffffffffffff;
+➤ k[-5,64,0]  𝄀
+18446744073709551615
+data branch pick src_uint into dst_uint keys(0xffffffffffffffff);
+select * from dst_uint order by k;
+➤ k[-5,64,0]  ¦  v[4,32,0]  𝄀
+1  ¦  10  𝄀
+18446744073709551615  ¦  120
+drop database data_branch_pick_numeric_literal_forms;

--- a/test/distributed/cases/git4data/branch/pick/pick_14.sql
+++ b/test/distributed/cases/git4data/branch/pick/pick_14.sql
@@ -1,0 +1,61 @@
+drop database if exists data_branch_pick_numeric_literal_forms;
+create database data_branch_pick_numeric_literal_forms;
+use data_branch_pick_numeric_literal_forms;
+
+create table base_int(k int primary key, v int);
+insert into base_int values (-6, 60), (-4, 40), (2, 20), (3, 30), (5, 50);
+data branch create table src_int from base_int;
+data branch create table dst_hex from base_int;
+data branch create table dst_sci from base_int;
+data branch create table dst_negative_hex from base_int;
+update src_int set v = v + 100;
+
+select k from src_int where k in (0x2, 3e0, -4e0, +5e0, -0x6) order by k;
+
+data branch pick src_int into dst_hex keys(0x2);
+select * from dst_hex order by k;
+
+data branch pick src_int into dst_sci keys(3e0, -4e0, +5e0);
+select * from dst_sci order by k;
+
+data branch pick src_int into dst_negative_hex keys(-0x6);
+select * from dst_negative_hex order by k;
+
+create table base_tinyint(k tinyint primary key, v int);
+insert into base_tinyint values (-128, 10), (1, 20), (127, 30);
+data branch create table src_tinyint from base_tinyint;
+data branch create table dst_tinyint from base_tinyint;
+update src_tinyint set v = v + 100;
+
+data branch pick src_tinyint into dst_tinyint keys(-1.28e2, +1.27e2);
+select * from dst_tinyint order by k;
+
+data branch pick src_tinyint into dst_tinyint keys(1.1e0);
+data branch pick src_tinyint into dst_tinyint keys(-1.29e2);
+data branch pick src_tinyint into dst_tinyint keys(1.28e2);
+select * from dst_tinyint order by k;
+
+create table base_utinyint(k tinyint unsigned primary key, v int);
+insert into base_utinyint values (0, 10), (255, 20);
+data branch create table src_utinyint from base_utinyint;
+data branch create table dst_utinyint from base_utinyint;
+update src_utinyint set v = v + 100;
+
+data branch pick src_utinyint into dst_utinyint keys(-0x0, 0xff);
+select * from dst_utinyint order by k;
+
+data branch pick src_utinyint into dst_utinyint keys(-1e0);
+data branch pick src_utinyint into dst_utinyint keys(0x100);
+select * from dst_utinyint order by k;
+
+create table base_uint(k bigint unsigned primary key, v int);
+insert into base_uint values (1, 10), (18446744073709551615, 20);
+data branch create table src_uint from base_uint;
+data branch create table dst_uint from base_uint;
+update src_uint set v = v + 100 where k = 18446744073709551615;
+
+select k from src_uint where k = 0xffffffffffffffff;
+data branch pick src_uint into dst_uint keys(0xffffffffffffffff);
+select * from dst_uint order by k;
+
+drop database data_branch_pick_numeric_literal_forms;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26076

## What this PR does / why we need it:

`DATA BRANCH PICK ... KEYS(...)` passed the original spelling of numeric AST literals directly to base-10 integer parsers. As a result, hexadecimal literals such as `0x2` and scientific notation such as `3e0` failed before row materialization, even though ordinary SQL expressions resolve them to the corresponding integer keys.

This PR:

- converts hexadecimal and scientific numeric literals to an exact integer representation before using the existing PK-type parser and vector append path;
- preserves unary signs, including normalizing negative zero for unsigned keys;
- rejects fractional scientific literals and target-type overflow instead of truncating or wrapping to an unrelated key;
- adds parser-backed unit coverage for signed/unsigned limits, fractional values, overflow, negative values, and unary-sign behavior;
- adds BVT coverage for successful integer materialization and rejected boundary cases, including checks that rejected values leave destination rows unchanged.

Tests run:

- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s -run '^TestAppendExprToVec_' ./pkg/frontend`
- each of the three new exact tests under `-race -count=100` (`T=0s/0.01s/0s`, `B=30s`, `N=100`)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=180s ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=240s ./pkg/frontend`
- `go vet -mod=readonly ./pkg/frontend` with the repository CGo include/library environment
- `mo-tester ... -m genrs -i pick_14`, followed by manual inspection of every generated result
- `mo-tester ... -i pick_14` (47/47 statements passed)

Residual risk: none known. The change is limited to literal `KEYS` materialization for integer primary keys; other literal types and typed-subquery materialization are unchanged.
