### PR TITLE
fix(frontend): preserve binary charset in data branch diff

### DIFF
--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -665,6 +665,43 @@ func TestDataBranchOutputBuildOutputSchema(t *testing.T) {
 		require.Equal(t, uint32(types.MaxVarcharLen), col.Length())
 	})
 
+	t.Run("default output preserves binary charset metadata", func(t *testing.T) {
+		binaryTblStuff := tblStuff
+		binaryTblStuff.def.colNames = []string{"b", "bn", "vb", "s"}
+		binaryTblStuff.def.colTypes = []types.Type{
+			types.New(types.T_bit, 10, 0),
+			types.New(types.T_binary, 8, 0),
+			types.New(types.T_varbinary, 32, 0),
+			types.New(types.T_varchar, 32, 0),
+		}
+		binaryTblStuff.def.visibleIdxes = []int{0, 1, 2, 3}
+
+		ses.SetMysqlResultSet(&MysqlResultSet{})
+		stmt := &tree.DataBranchDiff{
+			TargetTable: *target,
+			BaseTable:   *base,
+			OutputOpt:   nil,
+		}
+		require.NoError(t, buildOutputSchema(ctx, ses, stmt, binaryTblStuff))
+
+		mrs := ses.GetMysqlResultSet()
+		for idx, expectedType := range []defines.MysqlType{
+			defines.MYSQL_TYPE_BIT,
+			defines.MYSQL_TYPE_VARCHAR,
+			defines.MYSQL_TYPE_VARCHAR,
+			defines.MYSQL_TYPE_VAR_STRING,
+		} {
+			col, err := mrs.GetColumn(ctx, uint64(idx+2))
+			require.NoError(t, err)
+			require.Equal(t, expectedType, col.ColumnType())
+			expectedCharset := uint16(charsetBinary)
+			if idx == 3 {
+				expectedCharset = charsetVarchar
+			}
+			require.Equal(t, expectedCharset, col.(*MysqlColumn).Charset())
+		}
+	})
+
 	t.Run("summary output", func(t *testing.T) {
 		ses.SetMysqlResultSet(&MysqlResultSet{})
 		stmt := &tree.DataBranchDiff{

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -1599,6 +1599,10 @@ func setMysqlColumnTypeInfo(ctx context.Context, typ types.Type, col *MysqlColum
 		return err
 	}
 	setMysqlColumnTypeMetadata(col, typ)
+	setCharacter(col)
+	if typ.Oid == types.T_binary || typ.Oid == types.T_varbinary {
+		col.SetCharset(charsetBinary)
+	}
 	return nil
 }
 
@@ -2056,12 +2060,6 @@ func colDef2MysqlColumn(ctx context.Context, col *plan.ColDef) (*MysqlColumn, er
 		return nil, err
 	}
 	setColFlag(c)
-	setCharacter(c)
-
-	// For binary/varbinary with mysql_type_varchar.Change the charset.
-	if types.T(col.Typ.Id) == types.T_binary || types.T(col.Typ.Id) == types.T_varbinary {
-		c.SetCharset(0x3f)
-	}
 
 	c.SetDecimal(col.Typ.Scale)
 

--- a/test/distributed/cases/git4data/branch/merge/merge_3.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_3.result
@@ -45,12 +45,12 @@ insert into payout_ops values
 (50, 'south', 2, null, null, 'kai', null, x'CCCC33', 'new workflow');
 data branch diff payout_stage against payout_ops;
 diff payout_stage against payout_ops    flag    batch_id    region    total_count    payout_amount    approved_at    reviewer    comments    review_hash    escalation_reason
-payout_stage    UPDATE    10    east    5    null    2024-02-28 08:30:00    null    baseline review    ��    manual hold
+payout_stage    UPDATE    10    east    5    null    2024-02-28 08:30:00    null    baseline review    ªª    manual hold
 payout_ops    UPDATE    10    east    5    1250.75    2024-02-28 08:30:00    amy    auto adjusted    null    null
 payout_stage    UPDATE    20    west    3    null    2024-03-01 12:00:00    nina    null    null    missing invoices
-payout_ops    UPDATE    30    null    null    null    2024-02-28 10:00:00    leo    null    ��"    null
+payout_ops    UPDATE    30    null    null    null    2024-02-28 10:00:00    leo    null    »»"    null
 payout_stage    INSERT    40    north    null    2500.00    null    null    ad-hoc bonus    null    null
-payout_ops    INSERT    50    south    2    null    null    kai    null    ��3    new workflow
+payout_ops    INSERT    50    south    2    null    null    kai    null    ÌÌ3    new workflow
 data branch merge payout_stage into payout_ops;
 internal error: conflict: payout_stage DELETE and payout_ops DELETE on pk(10) with different values
 data branch merge payout_stage into payout_ops when conflict skip;
@@ -109,11 +109,11 @@ insert into audit_right values
 data branch diff audit_right against audit_left;
 diff audit_right against audit_left    flag    job_id    shard    seq    checksum    status    payload    metric    event_time
 audit_right    INSERT    101    a01    2    null    null    inventory gap    0.750    2024-03-03 11:00:00
-audit_left    INSERT    101    a01    1    �    open    inventory gap    null    2024-03-02 09:00:00
+audit_left    INSERT    101    a01    1    ª    open    inventory gap    null    2024-03-02 09:00:00
 audit_left    INSERT    102    b02    null    null    pending    null    1.250    2024-03-02 10:30:00
-audit_right    INSERT    103    c03    5    �"    closed    retry    1.500    2024-03-02 08:30:00
-audit_left    INSERT    103    c03    5    �"    closed    retry    null    null
-audit_right    INSERT    104    d04    1    �3    open    null    null    null
+audit_right    INSERT    103    c03    5    »"    closed    retry    1.500    2024-03-02 08:30:00
+audit_left    INSERT    103    c03    5    »"    closed    retry    null    null
+audit_right    INSERT    104    d04    1    Ì3    open    null    null    null
 data branch merge audit_right into audit_left when conflict skip;
 select job_id, shard, seq, status, payload, metric
 from audit_left


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26399

## What this PR does / why we need it:

`DATA BRANCH DIFF` builds its default result columns outside the normal planned-query column path. It reused the engine-to-MySQL type and length conversion, but did not apply the normal character-set metadata. As a result, `BIT`, `BINARY`, and `VARBINARY` columns kept charset `0` instead of MySQL binary charset `63`; clients such as PyMySQL consequently attempted UTF-8 decoding for non-UTF-8 bytes.

This change moves the existing character-set derivation, including the `BINARY`/`VARBINARY` override required by their VARCHAR wire type, into the shared `setMysqlColumnTypeInfo` helper. Both normal query results and Data Branch DIFF results now use the same metadata rule, and the duplicate normal-query logic is removed.

The unit regression covers `BIT(10)`, `BINARY(8)`, and `VARBINARY(32)` as binary charset columns and keeps `VARCHAR` as a text-charset boundary case. Before the fix, it failed with expected charset `0x3f`, actual `0x0`.

The first full CI run exposed two stale expectations in the existing `git4data/branch/merge/merge_3.sql` BVT. Those expectations contained UTF-8 replacement characters produced by the buggy text metadata. They now reflect the preserved `AA`, `BB`, and `CC` byte values emitted through the binary result path. Each updated value was checked against its SQL hex literal and the exact CI result; no generated result was accepted without semantic inspection.

Validation:

- deterministic CGo `go build -mod=readonly ./pkg/frontend`
- deterministic CGo `go vet -mod=readonly ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -run '^TestDataBranchOutputBuildOutputSchema$' ./pkg/frontend` (measured test duration 0.01s)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=240s -run '^TestDataBranchOutputBuildOutputSchema$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=900s ./pkg/frontend`
- exact-head CI passed frontend UT, SCA, UT coverage, coverage merge, proxy BVT, standalone pessimistic BVT, and connector E2E checks

The BVT compares values rather than ColumnDefinition41 metadata, so the unit test remains the direct protocol-metadata oracle. The BVT additionally protects the client-visible binary-value behavior affected by that metadata.

Residual risk is limited to result metadata and compatible client rendering: stored values and row encoding are unchanged. The shared helper preserves the pre-existing metadata behavior of normal query results while extending it to DIFF.
