### PR TITLE
fix(data branch): skip generated columns during apply

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -86,6 +86,125 @@ func dataBranchGeneratedColumnsEqual(left, right *plan.GeneratedCol) bool {
 	return left.OriginString != "" && left.OriginString == right.OriginString
 }
 
+func dataBranchGeneratedColumnsLogicallyEqual(
+	tarCol, baseCol *plan.ColDef,
+	tarDef, baseDef *plan.TableDef,
+	resolveBaseColumn dataBranchEndpointColumnResolver,
+) bool {
+	left, right := tarCol.GeneratedCol, baseCol.GeneratedCol
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left.IsStored != right.IsStored {
+		return false
+	}
+	if left.Expr == nil || right.Expr == nil {
+		return left.Expr == nil && right.Expr == nil &&
+			left.OriginString != "" && left.OriginString == right.OriginString
+	}
+
+	leftExpr := proto.Clone(left.Expr).(*plan.Expr)
+	rightExpr := proto.Clone(right.Expr).(*plan.Expr)
+	leftOK := canonicalizeDataBranchGeneratedExpr(leftExpr, func(pos int32) (string, bool) {
+		col := dataBranchGeneratedExprColumn(tarDef, pos)
+		if col == nil {
+			return "", false
+		}
+		resolved := resolveBaseColumn(col)
+		if resolved == nil {
+			return "", false
+		}
+		return strings.ToLower(resolved.Name), true
+	})
+	rightOK := canonicalizeDataBranchGeneratedExpr(rightExpr, func(pos int32) (string, bool) {
+		col := dataBranchGeneratedExprColumn(baseDef, pos)
+		if col == nil {
+			return "", false
+		}
+		return strings.ToLower(col.Name), true
+	})
+	return leftOK && rightOK && proto.Equal(leftExpr, rightExpr)
+}
+
+func dataBranchGeneratedExprColumn(tblDef *plan.TableDef, pos int32) *plan.ColDef {
+	if tblDef == nil || pos < 0 {
+		return nil
+	}
+	// GeneratedColBinder assigns ColPos over user DDL columns. Runtime table
+	// definitions may prefix rowid or contain other internal hidden columns.
+	var generatedExprPos int32
+	for _, col := range tblDef.Cols {
+		if !isDataBranchUserVisibleColumn(col) {
+			continue
+		}
+		if generatedExprPos == pos {
+			return col
+		}
+		generatedExprPos++
+	}
+	return nil
+}
+
+func canonicalizeDataBranchGeneratedExpr(
+	expr *plan.Expr,
+	resolveColumn func(int32) (string, bool),
+) bool {
+	if expr == nil {
+		return true
+	}
+	switch item := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		name, ok := resolveColumn(item.Col.ColPos)
+		if !ok {
+			return false
+		}
+		item.Col = &plan.ColRef{Name: name}
+	case *plan.Expr_Lit:
+		return canonicalizeDataBranchGeneratedExpr(item.Lit.Src, resolveColumn)
+	case *plan.Expr_F:
+		for _, arg := range item.F.Args {
+			if !canonicalizeDataBranchGeneratedExpr(arg, resolveColumn) {
+				return false
+			}
+		}
+	case *plan.Expr_List:
+		for _, listExpr := range item.List.List {
+			if !canonicalizeDataBranchGeneratedExpr(listExpr, resolveColumn) {
+				return false
+			}
+		}
+	case *plan.Expr_W:
+		if !canonicalizeDataBranchGeneratedExpr(item.W.WindowFunc, resolveColumn) {
+			return false
+		}
+		for _, partitionExpr := range item.W.PartitionBy {
+			if !canonicalizeDataBranchGeneratedExpr(partitionExpr, resolveColumn) {
+				return false
+			}
+		}
+		for _, order := range item.W.OrderBy {
+			if !canonicalizeDataBranchGeneratedExpr(order.Expr, resolveColumn) {
+				return false
+			}
+		}
+		if item.W.Frame != nil {
+			if item.W.Frame.Start != nil &&
+				!canonicalizeDataBranchGeneratedExpr(item.W.Frame.Start.Val, resolveColumn) {
+				return false
+			}
+			if item.W.Frame.End != nil &&
+				!canonicalizeDataBranchGeneratedExpr(item.W.Frame.End.Val, resolveColumn) {
+				return false
+			}
+		}
+	case *plan.Expr_Sub:
+		return canonicalizeDataBranchGeneratedExpr(item.Sub.Child, resolveColumn)
+	case *plan.Expr_Raw, *plan.Expr_Corr:
+		return false
+	}
+	return true
+}
+
 func dataBranchFakePKColIdxes(tblDef *plan.TableDef) []int {
 	idxes := make([]int, 0, len(tblDef.Cols))
 	dataIdx := 0
@@ -1505,7 +1624,9 @@ func checkSchemaCompatibilityWithResolver(
 		name := strings.ToLower(tarCol.Name)
 		baseCol := resolveBaseColumn(tarCol)
 		if baseCol != nil {
-			if !dataBranchGeneratedColumnsEqual(tarCol.GeneratedCol, baseCol.GeneratedCol) {
+			if !dataBranchGeneratedColumnsLogicallyEqual(
+				tarCol, baseCol, tarDef, baseDef, resolveBaseColumn,
+			) {
 				err = moerr.NewInternalErrorNoCtxf(
 					"schema compatibility check: column '%s' has different generated definitions",
 					tarCol.Name,

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -60,15 +61,29 @@ func isDataBranchUserVisibleColumn(col *plan.ColDef) bool {
 	if col.Hidden {
 		return false
 	}
-	if col.GeneratedCol != nil {
-		return false
-	}
 	switch col.Name {
 	case catalog.Row_ID, catalog.FakePrimaryKeyColName, catalog.CPrimaryKeyColName:
 		return false
 	default:
 		return true
 	}
+}
+
+func isDataBranchWritableColumn(col *plan.ColDef) bool {
+	return isDataBranchUserVisibleColumn(col) && col.GeneratedCol == nil
+}
+
+func dataBranchGeneratedColumnsEqual(left, right *plan.GeneratedCol) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left.IsStored != right.IsStored {
+		return false
+	}
+	if left.Expr != nil || right.Expr != nil {
+		return proto.Equal(left.Expr, right.Expr)
+	}
+	return left.OriginString != "" && left.OriginString == right.OriginString
 }
 
 func dataBranchFakePKColIdxes(tblDef *plan.TableDef) []int {
@@ -1067,6 +1082,9 @@ func getTableStuff(
 		if isDataBranchUserVisibleColumn(col) {
 			tblStuff.def.visibleIdxes = append(tblStuff.def.visibleIdxes, len(tblStuff.def.colNames)-1)
 		}
+		if isDataBranchWritableColumn(col) {
+			tblStuff.def.writableIdxes = append(tblStuff.def.writableIdxes, len(tblStuff.def.colNames)-1)
+		}
 	}
 
 	if baseTblDef.Pkey.PkeyColName == catalog.FakePrimaryKeyColName {
@@ -1192,6 +1210,15 @@ func reconcileDataBranchEndpointSchema(
 	}
 	tables.def.commonIdxes = commonIdxes
 	tables.def.commonVisibleIdxes = commonVisibleIdxes
+	commonVisibleSet := make(map[int]struct{}, len(commonVisibleIdxes))
+	for _, idx := range commonVisibleIdxes {
+		commonVisibleSet[idx] = struct{}{}
+	}
+	for _, idx := range tables.def.writableIdxes {
+		if _, ok := commonVisibleSet[idx]; ok {
+			tables.def.commonWritableIdxes = append(tables.def.commonWritableIdxes, idx)
+		}
+	}
 	tables.def.tarOnlyIdxes = tarOnlyIdxes
 
 	baseDataCols := make([]*plan.ColDef, 0, len(baseDef.Cols))
@@ -1381,7 +1408,10 @@ func isSchemaEquivalent(leftDef, rightDef *plan.TableDef) bool {
 			leftDef.Cols[i].ClusterBy != rightDef.Cols[i].ClusterBy ||
 			leftDef.Cols[i].Primary != rightDef.Cols[i].Primary ||
 			leftDef.Cols[i].Seqnum != rightDef.Cols[i].Seqnum ||
-			leftDef.Cols[i].NotNull != rightDef.Cols[i].NotNull {
+			leftDef.Cols[i].NotNull != rightDef.Cols[i].NotNull ||
+			!dataBranchGeneratedColumnsEqual(
+				leftDef.Cols[i].GeneratedCol, rightDef.Cols[i].GeneratedCol,
+			) {
 			return false
 		}
 	}
@@ -1474,11 +1504,14 @@ func checkSchemaCompatibilityWithResolver(
 
 		name := strings.ToLower(tarCol.Name)
 		baseCol := resolveBaseColumn(tarCol)
-		if baseCol != nil &&
-			isDataBranchUserVisibleColumn(tarCol) != isDataBranchUserVisibleColumn(baseCol) {
-			baseCol = nil
-		}
 		if baseCol != nil {
+			if !dataBranchGeneratedColumnsEqual(tarCol.GeneratedCol, baseCol.GeneratedCol) {
+				err = moerr.NewInternalErrorNoCtxf(
+					"schema compatibility check: column '%s' has different generated definitions",
+					tarCol.Name,
+				)
+				return
+			}
 			if baseCol.Typ.Id == tarCol.Typ.Id {
 				if !dataBranchColumnTypeAttributesEqual(baseCol.Typ, tarCol.Typ) {
 					err = moerr.NewInternalErrorNoCtxf(
@@ -1499,8 +1532,8 @@ func checkSchemaCompatibilityWithResolver(
 				commonColNameSet[strings.ToLower(baseCol.Name)] = true
 				if isDataBranchUserVisibleColumn(tarCol) {
 					commonVisibleIdxes = append(commonVisibleIdxes, dataIdx)
-					delete(baseVisibleColMap, strings.ToLower(baseCol.Name))
 				}
+				delete(baseVisibleColMap, strings.ToLower(baseCol.Name))
 			} else {
 				err = moerr.NewInternalErrorNoCtxf(
 					"schema compatibility check: column '%s' exists in both schemas but has different types (target: %d, base: %d)",

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -173,33 +173,12 @@ func canonicalizeDataBranchGeneratedExpr(
 				return false
 			}
 		}
-	case *plan.Expr_W:
-		if !canonicalizeDataBranchGeneratedExpr(item.W.WindowFunc, resolveColumn) {
-			return false
-		}
-		for _, partitionExpr := range item.W.PartitionBy {
-			if !canonicalizeDataBranchGeneratedExpr(partitionExpr, resolveColumn) {
-				return false
-			}
-		}
-		for _, order := range item.W.OrderBy {
-			if !canonicalizeDataBranchGeneratedExpr(order.Expr, resolveColumn) {
-				return false
-			}
-		}
-		if item.W.Frame != nil {
-			if item.W.Frame.Start != nil &&
-				!canonicalizeDataBranchGeneratedExpr(item.W.Frame.Start.Val, resolveColumn) {
-				return false
-			}
-			if item.W.Frame.End != nil &&
-				!canonicalizeDataBranchGeneratedExpr(item.W.Frame.End.Val, resolveColumn) {
-				return false
-			}
-		}
-	case *plan.Expr_Sub:
-		return canonicalizeDataBranchGeneratedExpr(item.Sub.Child, resolveColumn)
-	case *plan.Expr_Raw, *plan.Expr_Corr:
+	case *plan.Expr_T, *plan.Expr_Max, *plan.Expr_Vec, *plan.Expr_Fold:
+		// These leaf expressions contain no column references.
+	case *plan.Expr_Raw, *plan.Expr_Corr, *plan.Expr_W, *plan.Expr_Sub,
+		*plan.Expr_P, *plan.Expr_V:
+		// GeneratedColBinder rejects these endpoint-dependent expression kinds.
+		// Fail closed if malformed or legacy catalog metadata contains one.
 		return false
 	}
 	return true

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -60,6 +60,9 @@ func isDataBranchUserVisibleColumn(col *plan.ColDef) bool {
 	if col.Hidden {
 		return false
 	}
+	if col.GeneratedCol != nil {
+		return false
+	}
 	switch col.Name {
 	case catalog.Row_ID, catalog.FakePrimaryKeyColName, catalog.CPrimaryKeyColName:
 		return false
@@ -1471,6 +1474,10 @@ func checkSchemaCompatibilityWithResolver(
 
 		name := strings.ToLower(tarCol.Name)
 		baseCol := resolveBaseColumn(tarCol)
+		if baseCol != nil &&
+			isDataBranchUserVisibleColumn(tarCol) != isDataBranchUserVisibleColumn(baseCol) {
+			baseCol = nil
+		}
 		if baseCol != nil {
 			if baseCol.Typ.Id == tarCol.Typ.Id {
 				if !dataBranchColumnTypeAttributesEqual(baseCol.Typ, tarCol.Typ) {
@@ -1488,10 +1495,10 @@ func checkSchemaCompatibilityWithResolver(
 					return
 				}
 				commonIdxes = append(commonIdxes, dataIdx)
+				commonColNameSet[name] = true
+				commonColNameSet[strings.ToLower(baseCol.Name)] = true
 				if isDataBranchUserVisibleColumn(tarCol) {
 					commonVisibleIdxes = append(commonVisibleIdxes, dataIdx)
-					commonColNameSet[name] = true
-					commonColNameSet[strings.ToLower(baseCol.Name)] = true
 					delete(baseVisibleColMap, strings.ToLower(baseCol.Name))
 				}
 			} else {

--- a/pkg/frontend/data_branch_hashdiff_test.go
+++ b/pkg/frontend/data_branch_hashdiff_test.go
@@ -1075,6 +1075,9 @@ func newTestBranchTableStuff(ctrl *gomock.Controller) tableStuff {
 	}
 	tblStuff.def.pkKind = normalKind
 	tblStuff.def.visibleIdxes = []int{0, 1}
+	tblStuff.def.writableIdxes = []int{0, 1}
+	tblStuff.def.commonVisibleIdxes = []int{0, 1}
+	tblStuff.def.commonWritableIdxes = []int{0, 1}
 	tblStuff.def.pkColIdx = 0
 	tblStuff.def.pkColIdxes = []int{0}
 	tblStuff.retPool = &retBatchList{}

--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -144,7 +144,7 @@ type applyBatchInfo struct {
 	insertTable        string
 	deleteKeyNames     []string
 	deleteStageNames   []string
-	visibleNames       []string
+	writableNames      []string
 	disableInsertStage bool
 }
 
@@ -224,13 +224,13 @@ func newApplyBatchInfo(
 		deleteStageNames[i] = fmt.Sprintf("branch_apply_key_%d", i)
 	}
 
-	visibleIdxes := tblStuff.def.visibleIdxes
+	writableIdxes := tblStuff.def.writableIdxes
 	if len(tblStuff.def.tarOnlyIdxes) > 0 {
-		visibleIdxes = tblStuff.def.commonVisibleIdxes
+		writableIdxes = tblStuff.def.commonWritableIdxes
 	}
-	visibleNames := make([]string, len(visibleIdxes))
-	for i, idx := range visibleIdxes {
-		visibleNames[i] = tblStuff.def.colNames[idx]
+	writableNames := make([]string, len(writableIdxes))
+	for i, idx := range writableIdxes {
+		writableNames[i] = tblStuff.def.colNames[idx]
 	}
 
 	seq := atomic.AddUint64(&diffTempTableSeq, 1)
@@ -242,7 +242,7 @@ func newApplyBatchInfo(
 		insertTable:        fmt.Sprintf("__mo_diff_ins_%s_%d", sessionTag, seq),
 		deleteKeyNames:     deleteKeyNames,
 		deleteStageNames:   deleteStageNames,
-		visibleNames:       visibleNames,
+		writableNames:      writableNames,
 		disableInsertStage: disableInsertStage,
 	}
 }
@@ -1839,9 +1839,9 @@ func appendDataBranchApplyRowAsSQLValues(
 			}
 		}
 	} else {
-		insertIdxes := tblStuff.def.visibleIdxes
+		insertIdxes := tblStuff.def.writableIdxes
 		if len(tblStuff.def.tarOnlyIdxes) > 0 {
-			insertIdxes = tblStuff.def.commonVisibleIdxes
+			insertIdxes = tblStuff.def.commonWritableIdxes
 		}
 		if err = writeInsertRowValues(ses, tblStuff, row, tmpValsBuffer, insertIdxes); err != nil {
 			return err
@@ -2389,7 +2389,7 @@ func initApplyTables(
 		)
 	}
 	deleteCols := strings.Join(deleteSelectExprs, ",")
-	insertCols := joinQuotedColumnNames(batchInfo.visibleNames)
+	insertCols := joinQuotedColumnNames(batchInfo.writableNames)
 
 	stmts := []string{
 		fmt.Sprintf("drop table if exists %s", deleteTable),
@@ -2489,7 +2489,7 @@ func flushSqlValues(
 
 		if !batchInfo.disableInsertStage {
 			insertStmt := fmt.Sprintf("insert into %s values %s", insertTable, buf.String())
-			cols := joinQuotedColumnNames(batchInfo.visibleNames)
+			cols := joinQuotedColumnNames(batchInfo.writableNames)
 			applyStmt := fmt.Sprintf(
 				"insert into %s (%s) select %s from %s",
 				baseTable, cols, cols, insertTable,
@@ -2503,9 +2503,9 @@ func flushSqlValues(
 	defer releaseBuffer(tblStuff.bufPool, sqlBuffer)
 
 	initInsertIntoBuf := func() {
-		insertIdxes := tblStuff.def.visibleIdxes
+		insertIdxes := tblStuff.def.writableIdxes
 		if len(tblStuff.def.tarOnlyIdxes) > 0 {
-			insertIdxes = tblStuff.def.commonVisibleIdxes
+			insertIdxes = tblStuff.def.commonWritableIdxes
 		}
 		sqlBuffer.WriteString(fmt.Sprintf(
 			"insert into %s (%s) values ",

--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -1341,7 +1341,7 @@ func TestDataBranchOutputInitAndDropApplyTablesWithWriteFile(t *testing.T) {
 		insertTable:      "__mo_diff_ins_x",
 		deleteKeyNames:   []string{"id"},
 		deleteStageNames: []string{"branch_apply_key_0"},
-		visibleNames:     []string{"id", "name"},
+		writableNames:    []string{"id", "name"},
 	}
 
 	var out bytes.Buffer
@@ -1375,6 +1375,7 @@ func TestDataBranchOutputFlushSqlValuesWithWriteFile(t *testing.T) {
 	}
 	tblStuff.def.colNames = []string{"id", "name"}
 	tblStuff.def.visibleIdxes = []int{0, 1}
+	tblStuff.def.writableIdxes = []int{0, 1}
 	tblStuff.def.pkColIdx = 0
 	tblStuff.def.pkColIdxes = []int{0, 1}
 
@@ -1385,7 +1386,7 @@ func TestDataBranchOutputFlushSqlValuesWithWriteFile(t *testing.T) {
 		insertTable:      "__mo_diff_ins_x",
 		deleteKeyNames:   []string{"id", "name"},
 		deleteStageNames: []string{"branch_apply_key_0", "branch_apply_key_1"},
-		visibleNames:     []string{"id", "name"},
+		writableNames:    []string{"id", "name"},
 	}
 
 	var out bytes.Buffer
@@ -1444,7 +1445,7 @@ func TestDataBranchOutputTryFlushDeletesOrInserts(t *testing.T) {
 		deleteTable:    "__mo_diff_del_x",
 		insertTable:    "__mo_diff_ins_x",
 		deleteKeyNames: []string{"id"},
-		visibleNames:   []string{"id", "name"},
+		writableNames:  []string{"id", "name"},
 	}
 
 	t.Run("force flush both buffers", func(t *testing.T) {
@@ -1572,6 +1573,7 @@ func TestDataBranchOutputBuildDataBranchApplyLayout(t *testing.T) {
 	tblStuff.def.colNames = []string{"id", "name", "age"}
 	tblStuff.def.pkColIdxes = []int{0, 2}
 	tblStuff.def.visibleIdxes = []int{0, 1, 2}
+	tblStuff.def.writableIdxes = []int{0, 1, 2}
 	tblStuff.def.pkKind = normalKind
 
 	deleteByFullRow, deleteKeyColIdxes, info := buildDataBranchApplyLayout(
@@ -1584,7 +1586,7 @@ func TestDataBranchOutputBuildDataBranchApplyLayout(t *testing.T) {
 	require.Equal(t, "t1", info.baseTable)
 	require.Equal(t, []string{"id", "age"}, info.deleteKeyNames)
 	require.Equal(t, []string{"branch_apply_key_0", "branch_apply_key_1"}, info.deleteStageNames)
-	require.Equal(t, []string{"id", "name", "age"}, info.visibleNames)
+	require.Equal(t, []string{"id", "name", "age"}, info.writableNames)
 	require.False(t, info.disableInsertStage)
 	require.True(t, strings.HasPrefix(info.deleteTable, "__mo_diff_del_"))
 	require.True(t, strings.HasPrefix(info.insertTable, "__mo_diff_ins_"))
@@ -1598,7 +1600,7 @@ func TestDataBranchOutputBuildDataBranchApplyLayout(t *testing.T) {
 	require.NotNil(t, info)
 	require.Equal(t, []string{"__mo_fake_pk_col"}, info.deleteKeyNames)
 	require.Equal(t, []string{"branch_apply_key_0"}, info.deleteStageNames)
-	require.Equal(t, []string{"id", "name"}, info.visibleNames)
+	require.Equal(t, []string{"id", "name"}, info.writableNames)
 	require.True(t, info.disableInsertStage)
 
 	deleteByFullRow, deleteKeyColIdxes, info = buildDataBranchApplyLayout(
@@ -1624,7 +1626,7 @@ func TestDataBranchOutputAppenderAppendRowAndFlushAll(t *testing.T) {
 		deleteTable:    "__mo_diff_del_x",
 		insertTable:    "__mo_diff_ins_x",
 		deleteKeyNames: []string{"id"},
-		visibleNames:   []string{"id", "name"},
+		writableNames:  []string{"id", "name"},
 	}
 
 	t.Run("append delete in full-row mode", func(t *testing.T) {
@@ -1951,14 +1953,40 @@ func TestNewApplyBatchInfoUsesCommonVisibleColumnsForEvolvedSchema(t *testing.T)
 		types.T_int64.ToType(),
 	}
 	tblStuff.def.visibleIdxes = []int{0, 2, 3}
+	tblStuff.def.writableIdxes = []int{0, 2, 3}
 	tblStuff.def.commonIdxes = []int{0, 1, 3}
 	tblStuff.def.commonVisibleIdxes = []int{0, 3}
+	tblStuff.def.commonWritableIdxes = []int{0, 3}
 	tblStuff.def.tarOnlyIdxes = []int{2}
 
 	info := newApplyBatchInfo(ctx, ses, tblStuff, []int{0}, false)
 	require.NotNil(t, info)
 	require.Equal(t, []string{"a"}, info.deleteKeyNames)
-	require.Equal(t, []string{"a", "b"}, info.visibleNames)
+	require.Equal(t, []string{"a", "b"}, info.writableNames)
+}
+
+func TestNewApplyBatchInfoExcludesGeneratedColumns(t *testing.T) {
+	ctx := context.Background()
+	ses := newValidateSession(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tblStuff := newTestBranchTableStuff(ctrl)
+	tblStuff.def.colNames = []string{"id", "value", "generated_value"}
+	tblStuff.def.visibleIdxes = []int{0, 1, 2}
+	tblStuff.def.writableIdxes = []int{0, 1}
+	tblStuff.def.commonVisibleIdxes = []int{0, 1, 2}
+	tblStuff.def.commonWritableIdxes = []int{0, 1}
+
+	projected, err := resolveProjectedIdxes(
+		tree.IdentifierList{tree.Identifier("generated_value")}, tblStuff,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int{2}, projected)
+
+	info := newApplyBatchInfo(ctx, ses, tblStuff, []int{0}, false)
+	require.NotNil(t, info)
+	require.Equal(t, []string{"id", "value"}, info.writableNames)
 }
 
 func TestDataBranchOutputRemoveFileIgnoreError(t *testing.T) {
@@ -2239,6 +2267,7 @@ func newFakePKBranchTableStuff(ctrl *gomock.Controller) tableStuff {
 		types.T_uint64.ToType(),
 	}
 	tblStuff.def.visibleIdxes = []int{0, 1}
+	tblStuff.def.writableIdxes = []int{0, 1}
 	tblStuff.def.pkColIdx = 2
 	tblStuff.def.pkColIdxes = []int{0, 1}
 	tblStuff.def.pkKind = fakeKind

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -44,6 +44,12 @@ import (
 
 func TestDataBranchUserVisibleColumn(t *testing.T) {
 	require.True(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: "tenant"}))
+	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{
+		Name: "stored_total", GeneratedCol: &plan.GeneratedCol{IsStored: true},
+	}))
+	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{
+		Name: "virtual_total", GeneratedCol: &plan.GeneratedCol{IsStored: false},
+	}))
 	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.FakePrimaryKeyColName, Hidden: true}))
 	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.CPrimaryKeyColName, Hidden: true}))
 	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: "__mo_cbkey_006tenant003seq", Hidden: true}))
@@ -105,6 +111,7 @@ func TestDataBranchFakePKColIdxesUseOnlyVisibleColumns(t *testing.T) {
 			{Name: "tenant"},
 			{Name: "__mo_cbkey_006tenant003seq", Hidden: true},
 			{Name: "payload"},
+			{Name: "generated_payload", GeneratedCol: &plan.GeneratedCol{IsStored: true}},
 			{Name: catalog.FakePrimaryKeyColName, Hidden: true},
 		},
 	}
@@ -1263,6 +1270,96 @@ func TestCheckSchemaCompatibility_HiddenColumnsAreNotOutputColumns(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, []int{0, 1, 2}, commonIdxes)
 	require.Equal(t, []int{0, 2}, commonVisibleIdxes)
+	require.Empty(t, tarOnlyIdxes)
+}
+
+func TestCheckSchemaCompatibility_GeneratedColumnsAreNotOutputColumns(t *testing.T) {
+	newTableDef := func(stored bool) *plan.TableDef {
+		return &plan.TableDef{
+			Pkey: &plan.PrimaryKeyDef{PkeyColName: "id"},
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int64)}},
+				{Name: "value", Typ: plan.Type{Id: int32(types.T_int64)}},
+				{
+					Name:         "generated_value",
+					Typ:          plan.Type{Id: int32(types.T_int64)},
+					GeneratedCol: &plan.GeneratedCol{IsStored: stored},
+				},
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		stored bool
+	}{
+		{name: "stored", stored: true},
+		{name: "virtual", stored: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			commonIdxes, commonVisibleIdxes, tarOnlyIdxes, err :=
+				checkSchemaCompatibility(newTableDef(tc.stored), newTableDef(tc.stored))
+			require.NoError(t, err)
+			require.Equal(t, []int{0, 1, 2}, commonIdxes)
+			require.Equal(t, []int{0, 1}, commonVisibleIdxes)
+			require.Empty(t, tarOnlyIdxes)
+		})
+	}
+}
+
+func TestCheckSchemaCompatibility_DestinationGeneratedColumnIsNotWritable(t *testing.T) {
+	ordinaryDef := &plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: "id"},
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "value", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "derived", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+	}
+	generatedDef := &plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: "id"},
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "value", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{
+				Name:         "derived",
+				Typ:          plan.Type{Id: int32(types.T_int64)},
+				GeneratedCol: &plan.GeneratedCol{IsStored: true},
+			},
+		},
+	}
+
+	commonIdxes, commonVisibleIdxes, tarOnlyIdxes, err :=
+		checkSchemaCompatibility(ordinaryDef, generatedDef)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, commonIdxes)
+	require.Equal(t, []int{0, 1}, commonVisibleIdxes)
+	require.Equal(t, []int{2}, tarOnlyIdxes)
+
+	_, _, _, err = checkSchemaCompatibility(generatedDef, ordinaryDef)
+	require.ErrorContains(t, err, "base column 'derived' is not present in target schema")
+}
+
+func TestCheckSchemaCompatibility_StoredGeneratedPrimaryKey(t *testing.T) {
+	newTableDef := func() *plan.TableDef {
+		return &plan.TableDef{
+			Pkey: &plan.PrimaryKeyDef{Names: []string{"generated_id"}, PkeyColName: "generated_id"},
+			Cols: []*plan.ColDef{
+				{Name: "value", Typ: plan.Type{Id: int32(types.T_int64)}},
+				{
+					Name:         "generated_id",
+					Typ:          plan.Type{Id: int32(types.T_int64)},
+					GeneratedCol: &plan.GeneratedCol{IsStored: true},
+				},
+			},
+		}
+	}
+
+	commonIdxes, commonVisibleIdxes, tarOnlyIdxes, err :=
+		checkSchemaCompatibility(newTableDef(), newTableDef())
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, commonIdxes)
+	require.Equal(t, []int{0}, commonVisibleIdxes)
 	require.Empty(t, tarOnlyIdxes)
 }
 

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -1374,6 +1374,116 @@ func TestCheckSchemaCompatibility_RejectsDifferentGeneratedDefinitions(t *testin
 	}
 }
 
+func TestCheckSchemaCompatibility_GeneratedDefinitionsUseLogicalColumnIdentity(t *testing.T) {
+	intType := plan.Type{Id: int32(types.T_int64)}
+	generatedExpr := func(colPos int32) *plan.Expr {
+		return &plan.Expr{
+			Typ: intType,
+			Expr: &plan.Expr_F{F: &plan.Function{
+				Func: &plan.ObjectRef{Obj: 1, ObjName: "*"},
+				Args: []*plan.Expr{
+					{Typ: intType, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: colPos}}},
+					{Typ: intType, Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_I64Val{I64Val: 2}}}},
+				},
+			}},
+		}
+	}
+	newTableDef := func(reordered, generatedPK, referencesA bool) *plan.TableDef {
+		pkeyName := "id"
+		if generatedPK {
+			pkeyName = "g"
+		}
+		cols := []*plan.ColDef{
+			{Name: "id", Typ: intType},
+			{Name: "a", Typ: intType},
+			{Name: "b", Typ: intType},
+		}
+		if reordered {
+			cols[1], cols[2] = cols[2], cols[1]
+		}
+		refName := "b"
+		if referencesA {
+			refName = "a"
+		}
+		refPos := int32(0)
+		for i, col := range cols {
+			if col.Name == refName {
+				refPos = int32(i)
+				break
+			}
+		}
+		cols = append(cols, &plan.ColDef{
+			Name: "g", Typ: intType,
+			GeneratedCol: &plan.GeneratedCol{Expr: generatedExpr(refPos), OriginString: refName + " * 2", IsStored: true},
+		})
+		cols = append([]*plan.ColDef{{Name: catalog.Row_ID, Hidden: true}}, cols...)
+		return &plan.TableDef{
+			Pkey: &plan.PrimaryKeyDef{Names: []string{pkeyName}, PkeyColName: pkeyName},
+			Cols: cols,
+		}
+	}
+
+	for _, generatedPK := range []bool{false, true} {
+		t.Run(fmt.Sprintf("generated_pk_%t_matching_reordered", generatedPK), func(t *testing.T) {
+			_, _, _, err := checkSchemaCompatibility(
+				newTableDef(false, generatedPK, true),
+				newTableDef(true, generatedPK, true),
+			)
+			require.NoError(t, err)
+		})
+		t.Run(fmt.Sprintf("generated_pk_%t_mismatching_reordered", generatedPK), func(t *testing.T) {
+			_, _, _, err := checkSchemaCompatibility(
+				newTableDef(false, generatedPK, true),
+				newTableDef(true, generatedPK, false),
+			)
+			require.ErrorContains(t, err, "column 'g' has different generated definitions")
+		})
+	}
+
+	t.Run("lineage_resolver_canonicalizes_renamed_reference", func(t *testing.T) {
+		tarDef := &plan.TableDef{
+			Pkey: &plan.PrimaryKeyDef{Names: []string{"id"}, PkeyColName: "id"},
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: intType},
+				{Name: "new_a", Typ: intType},
+				{
+					Name: "g", Typ: intType,
+					GeneratedCol: &plan.GeneratedCol{Expr: generatedExpr(1), IsStored: true},
+				},
+			},
+		}
+		tarDef.Cols = append([]*plan.ColDef{{Name: catalog.Row_ID, Hidden: true}}, tarDef.Cols...)
+		baseDef := &plan.TableDef{
+			Pkey: &plan.PrimaryKeyDef{Names: []string{"id"}, PkeyColName: "id"},
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: intType},
+				{Name: "old_a", Typ: intType},
+				{
+					Name: "g", Typ: intType,
+					GeneratedCol: &plan.GeneratedCol{Expr: generatedExpr(1), IsStored: true},
+				},
+			},
+		}
+		baseDef.Cols = append([]*plan.ColDef{{Name: catalog.Row_ID, Hidden: true}}, baseDef.Cols...)
+		resolveBaseColumn := func(tarCol *plan.ColDef) *plan.ColDef {
+			switch tarCol.Name {
+			case "id":
+				return baseDef.Cols[1]
+			case "new_a":
+				return baseDef.Cols[2]
+			case "g":
+				return baseDef.Cols[3]
+			default:
+				return nil
+			}
+		}
+		_, _, _, err := checkSchemaCompatibilityWithResolver(
+			tarDef, baseDef, resolveBaseColumn,
+		)
+		require.NoError(t, err)
+	})
+}
+
 func TestCheckSchemaCompatibility_StoredGeneratedPrimaryKey(t *testing.T) {
 	newTableDef := func() *plan.TableDef {
 		return &plan.TableDef{

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -1484,6 +1484,94 @@ func TestCheckSchemaCompatibility_GeneratedDefinitionsUseLogicalColumnIdentity(t
 	})
 }
 
+func TestCanonicalizeDataBranchGeneratedExpr(t *testing.T) {
+	intType := plan.Type{Id: int32(types.T_int64)}
+	expr := &plan.Expr{Expr: &plan.Expr_List{List: &plan.ExprList{List: []*plan.Expr{
+		{Typ: intType, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 9, ColPos: 0}}},
+		{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Src: &plan.Expr{
+			Typ: intType, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 9, ColPos: 1}},
+		}}}},
+	}}}}
+	references := []string{"old_a", "old_b"}
+	require.True(t, canonicalizeDataBranchGeneratedExpr(expr, func(pos int32) (string, bool) {
+		if pos < 0 || int(pos) >= len(references) {
+			return "", false
+		}
+		return references[pos], true
+	}))
+	require.Equal(t, &plan.ColRef{Name: "old_a"}, expr.GetList().List[0].GetCol())
+	require.Equal(t, &plan.ColRef{Name: "old_b"}, expr.GetList().List[1].GetLit().Src.GetCol())
+
+	require.True(t, canonicalizeDataBranchGeneratedExpr(nil, nil))
+	require.True(t, canonicalizeDataBranchGeneratedExpr(
+		&plan.Expr{Expr: &plan.Expr_T{T: &plan.TargetType{}}}, nil,
+	))
+	require.False(t, canonicalizeDataBranchGeneratedExpr(
+		&plan.Expr{Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 2}}},
+		func(int32) (string, bool) { return "", false },
+	))
+	require.False(t, canonicalizeDataBranchGeneratedExpr(
+		&plan.Expr{Expr: &plan.Expr_Corr{Corr: &plan.CorrColRef{ColPos: 0}}}, nil,
+	))
+}
+
+func TestDataBranchGeneratedColumnsLogicallyEqualBoundaries(t *testing.T) {
+	intType := plan.Type{Id: int32(types.T_int64)}
+	colExpr := func(pos int32) *plan.Expr {
+		return &plan.Expr{Typ: intType, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: pos}}}
+	}
+	newTableDef := func(expr *plan.Expr, origin string, stored bool) (*plan.TableDef, *plan.ColDef) {
+		generated := &plan.ColDef{
+			Name: "g", Typ: intType,
+			GeneratedCol: &plan.GeneratedCol{Expr: expr, OriginString: origin, IsStored: stored},
+		}
+		return &plan.TableDef{Cols: []*plan.ColDef{
+			{Name: catalog.Row_ID, Hidden: true},
+			{Name: "a", Typ: intType},
+			generated,
+		}}, generated
+	}
+	resolveByName := func(def *plan.TableDef) dataBranchEndpointColumnResolver {
+		return func(col *plan.ColDef) *plan.ColDef {
+			return dataBranchColumnDefByLogicalName(def, col)
+		}
+	}
+
+	tarDef, tarCol := newTableDef(nil, "a * 2", true)
+	baseDef, baseCol := newTableDef(nil, "a * 2", true)
+	require.True(t, dataBranchGeneratedColumnsLogicallyEqual(
+		tarCol, baseCol, tarDef, baseDef, resolveByName(baseDef),
+	))
+	baseCol.GeneratedCol.OriginString = ""
+	require.False(t, dataBranchGeneratedColumnsLogicallyEqual(
+		tarCol, baseCol, tarDef, baseDef, resolveByName(baseDef),
+	))
+
+	baseCol.GeneratedCol = nil
+	require.False(t, dataBranchGeneratedColumnsLogicallyEqual(
+		tarCol, baseCol, tarDef, baseDef, resolveByName(baseDef),
+	))
+	baseDef, baseCol = newTableDef(colExpr(0), "a", true)
+	require.False(t, dataBranchGeneratedColumnsLogicallyEqual(
+		tarCol, baseCol, tarDef, baseDef, resolveByName(baseDef),
+	))
+	baseDef, baseCol = newTableDef(nil, "a * 2", false)
+	require.False(t, dataBranchGeneratedColumnsLogicallyEqual(
+		tarCol, baseCol, tarDef, baseDef, resolveByName(baseDef),
+	))
+
+	tarDef, tarCol = newTableDef(colExpr(9), "missing", true)
+	baseDef, baseCol = newTableDef(colExpr(0), "a", true)
+	require.False(t, dataBranchGeneratedColumnsLogicallyEqual(
+		tarCol, baseCol, tarDef, baseDef, resolveByName(baseDef),
+	))
+	tarDef, tarCol = newTableDef(colExpr(0), "a", true)
+	baseDef, baseCol = newTableDef(colExpr(9), "missing", true)
+	require.False(t, dataBranchGeneratedColumnsLogicallyEqual(
+		tarCol, baseCol, tarDef, baseDef, resolveByName(baseDef),
+	))
+}
+
 func TestCheckSchemaCompatibility_StoredGeneratedPrimaryKey(t *testing.T) {
 	newTableDef := func() *plan.TableDef {
 		return &plan.TableDef{

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -42,18 +42,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDataBranchUserVisibleColumn(t *testing.T) {
+func TestDataBranchColumnClassification(t *testing.T) {
 	require.True(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: "tenant"}))
-	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{
+	require.True(t, isDataBranchWritableColumn(&plan.ColDef{Name: "tenant"}))
+	require.True(t, isDataBranchUserVisibleColumn(&plan.ColDef{
 		Name: "stored_total", GeneratedCol: &plan.GeneratedCol{IsStored: true},
 	}))
-	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{
+	require.False(t, isDataBranchWritableColumn(&plan.ColDef{
+		Name: "stored_total", GeneratedCol: &plan.GeneratedCol{IsStored: true},
+	}))
+	require.True(t, isDataBranchUserVisibleColumn(&plan.ColDef{
+		Name: "virtual_total", GeneratedCol: &plan.GeneratedCol{IsStored: false},
+	}))
+	require.False(t, isDataBranchWritableColumn(&plan.ColDef{
 		Name: "virtual_total", GeneratedCol: &plan.GeneratedCol{IsStored: false},
 	}))
 	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.FakePrimaryKeyColName, Hidden: true}))
 	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.CPrimaryKeyColName, Hidden: true}))
 	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: "__mo_cbkey_006tenant003seq", Hidden: true}))
 	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.Row_ID, Hidden: true}))
+	require.False(t, dataBranchGeneratedColumnsEqual(&plan.GeneratedCol{}, &plan.GeneratedCol{}))
+	require.True(t, dataBranchGeneratedColumnsEqual(
+		&plan.GeneratedCol{OriginString: "tenant * 2", IsStored: true},
+		&plan.GeneratedCol{OriginString: "tenant * 2", IsStored: true},
+	))
 }
 
 func TestPrepareDataBranchWorkerValidatesBeforeAllocation(t *testing.T) {
@@ -115,7 +127,7 @@ func TestDataBranchFakePKColIdxesUseOnlyVisibleColumns(t *testing.T) {
 			{Name: catalog.FakePrimaryKeyColName, Hidden: true},
 		},
 	}
-	require.Equal(t, []int{0, 2}, dataBranchFakePKColIdxes(tblDef))
+	require.Equal(t, []int{0, 2, 3}, dataBranchFakePKColIdxes(tblDef))
 }
 
 func TestDataBranchSchemaEquivalentRequiresCompleteLogicalTypes(t *testing.T) {
@@ -1273,7 +1285,7 @@ func TestCheckSchemaCompatibility_HiddenColumnsAreNotOutputColumns(t *testing.T)
 	require.Empty(t, tarOnlyIdxes)
 }
 
-func TestCheckSchemaCompatibility_GeneratedColumnsAreNotOutputColumns(t *testing.T) {
+func TestCheckSchemaCompatibility_GeneratedColumnsRemainVisible(t *testing.T) {
 	newTableDef := func(stored bool) *plan.TableDef {
 		return &plan.TableDef{
 			Pkey: &plan.PrimaryKeyDef{PkeyColName: "id"},
@@ -1283,7 +1295,7 @@ func TestCheckSchemaCompatibility_GeneratedColumnsAreNotOutputColumns(t *testing
 				{
 					Name:         "generated_value",
 					Typ:          plan.Type{Id: int32(types.T_int64)},
-					GeneratedCol: &plan.GeneratedCol{IsStored: stored},
+					GeneratedCol: &plan.GeneratedCol{OriginString: "value * 2", IsStored: stored},
 				},
 			},
 		}
@@ -1301,13 +1313,13 @@ func TestCheckSchemaCompatibility_GeneratedColumnsAreNotOutputColumns(t *testing
 				checkSchemaCompatibility(newTableDef(tc.stored), newTableDef(tc.stored))
 			require.NoError(t, err)
 			require.Equal(t, []int{0, 1, 2}, commonIdxes)
-			require.Equal(t, []int{0, 1}, commonVisibleIdxes)
+			require.Equal(t, []int{0, 1, 2}, commonVisibleIdxes)
 			require.Empty(t, tarOnlyIdxes)
 		})
 	}
 }
 
-func TestCheckSchemaCompatibility_DestinationGeneratedColumnIsNotWritable(t *testing.T) {
+func TestCheckSchemaCompatibility_RejectsGeneratedAndOrdinaryMismatch(t *testing.T) {
 	ordinaryDef := &plan.TableDef{
 		Pkey: &plan.PrimaryKeyDef{PkeyColName: "id"},
 		Cols: []*plan.ColDef{
@@ -1324,20 +1336,42 @@ func TestCheckSchemaCompatibility_DestinationGeneratedColumnIsNotWritable(t *tes
 			{
 				Name:         "derived",
 				Typ:          plan.Type{Id: int32(types.T_int64)},
-				GeneratedCol: &plan.GeneratedCol{IsStored: true},
+				GeneratedCol: &plan.GeneratedCol{OriginString: "value * 2", IsStored: true},
 			},
 		},
 	}
 
-	commonIdxes, commonVisibleIdxes, tarOnlyIdxes, err :=
-		checkSchemaCompatibility(ordinaryDef, generatedDef)
-	require.NoError(t, err)
-	require.Equal(t, []int{0, 1}, commonIdxes)
-	require.Equal(t, []int{0, 1}, commonVisibleIdxes)
-	require.Equal(t, []int{2}, tarOnlyIdxes)
+	_, _, _, err := checkSchemaCompatibility(ordinaryDef, generatedDef)
+	require.ErrorContains(t, err, "column 'derived' has different generated definitions")
 
 	_, _, _, err = checkSchemaCompatibility(generatedDef, ordinaryDef)
-	require.ErrorContains(t, err, "base column 'derived' is not present in target schema")
+	require.ErrorContains(t, err, "column 'derived' has different generated definitions")
+}
+
+func TestCheckSchemaCompatibility_RejectsDifferentGeneratedDefinitions(t *testing.T) {
+	newTableDef := func(expr string, generatedPK bool) *plan.TableDef {
+		pkeyName := "id"
+		if generatedPK {
+			pkeyName = "generated_id"
+		}
+		return &plan.TableDef{
+			Pkey: &plan.PrimaryKeyDef{Names: []string{pkeyName}, PkeyColName: pkeyName},
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int64)}},
+				{
+					Name: "generated_id", Typ: plan.Type{Id: int32(types.T_int64)},
+					GeneratedCol: &plan.GeneratedCol{OriginString: expr, IsStored: true},
+				},
+			},
+		}
+	}
+
+	for _, generatedPK := range []bool{false, true} {
+		_, _, _, err := checkSchemaCompatibility(
+			newTableDef("id * 2", generatedPK), newTableDef("id * 3", generatedPK),
+		)
+		require.ErrorContains(t, err, "column 'generated_id' has different generated definitions")
+	}
 }
 
 func TestCheckSchemaCompatibility_StoredGeneratedPrimaryKey(t *testing.T) {
@@ -1349,7 +1383,7 @@ func TestCheckSchemaCompatibility_StoredGeneratedPrimaryKey(t *testing.T) {
 				{
 					Name:         "generated_id",
 					Typ:          plan.Type{Id: int32(types.T_int64)},
-					GeneratedCol: &plan.GeneratedCol{IsStored: true},
+					GeneratedCol: &plan.GeneratedCol{OriginString: "value * 2", IsStored: true},
 				},
 			},
 		}
@@ -1359,19 +1393,25 @@ func TestCheckSchemaCompatibility_StoredGeneratedPrimaryKey(t *testing.T) {
 		checkSchemaCompatibility(newTableDef(), newTableDef())
 	require.NoError(t, err)
 	require.Equal(t, []int{0, 1}, commonIdxes)
-	require.Equal(t, []int{0}, commonVisibleIdxes)
+	require.Equal(t, []int{0, 1}, commonVisibleIdxes)
 	require.Empty(t, tarOnlyIdxes)
 }
 
 func TestCheckSchemaCompatibility_RejectsBaseOnlyVisibleColumn(t *testing.T) {
-	tarDef := &plan.TableDef{Pkey: &plan.PrimaryKeyDef{PkeyColName: "a"}, Cols: []*plan.ColDef{{Name: "a", Typ: plan.Type{Id: int32(types.T_int64)}}}}
-	baseDef := &plan.TableDef{Pkey: &plan.PrimaryKeyDef{PkeyColName: "a"}, Cols: []*plan.ColDef{
-		{Name: "a", Typ: plan.Type{Id: int32(types.T_int64)}},
-		{Name: "removed", Typ: plan.Type{Id: int32(types.T_int64)}},
-	}}
+	for _, generated := range []bool{false, true} {
+		tarDef := &plan.TableDef{Pkey: &plan.PrimaryKeyDef{PkeyColName: "a"}, Cols: []*plan.ColDef{{Name: "a", Typ: plan.Type{Id: int32(types.T_int64)}}}}
+		baseOnly := &plan.ColDef{Name: "removed", Typ: plan.Type{Id: int32(types.T_int64)}}
+		if generated {
+			baseOnly.GeneratedCol = &plan.GeneratedCol{OriginString: "a * 2", IsStored: true}
+		}
+		baseDef := &plan.TableDef{Pkey: &plan.PrimaryKeyDef{PkeyColName: "a"}, Cols: []*plan.ColDef{
+			{Name: "a", Typ: plan.Type{Id: int32(types.T_int64)}},
+			baseOnly,
+		}}
 
-	_, _, _, err := checkSchemaCompatibility(tarDef, baseDef)
-	require.ErrorContains(t, err, "base column 'removed' is not present in target schema")
+		_, _, _, err := checkSchemaCompatibility(tarDef, baseDef)
+		require.ErrorContains(t, err, "base column 'removed' is not present in target schema")
+	}
 }
 
 func TestCheckSchemaCompatibility_PKChanged(t *testing.T) {

--- a/pkg/frontend/data_branch_types.go
+++ b/pkg/frontend/data_branch_types.go
@@ -221,20 +221,22 @@ type tableStuff struct {
 	lcaHasZeroHistory bool
 
 	def struct {
-		colNames     []string     // all columns
-		colTypes     []types.Type // all columns
-		visibleIdxes []int
-		pkColIdx     int
-		pkSeqnum     int   // physical column seqnum for PK (for ZoneMap lookup)
-		pkColIdxes   []int // expanded pk columns
-		pkKind       int
+		colNames      []string     // all columns
+		colTypes      []types.Type // all columns
+		visibleIdxes  []int
+		writableIdxes []int
+		pkColIdx      int
+		pkSeqnum      int   // physical column seqnum for PK (for ZoneMap lookup)
+		pkColIdxes    []int // expanded pk columns
+		pkKind        int
 
-		commonIdxes        []int    // indices of common columns (target data-batch ordering)
-		commonVisibleIdxes []int    // visible subset of commonIdxes for SQL/output/apply
-		tarOnlyIdxes       []int    // indices of target-only columns (target data-batch ordering)
-		baseColToTarIdx    []int    // for base batch Vec[i+1], the target column index, or -1
-		baseColNames       []string // target data column index to lineage-resolved base name
-		lcaColNames        []string // target data column index to lineage-resolved LCA name
+		commonIdxes         []int    // indices of common columns (target data-batch ordering)
+		commonVisibleIdxes  []int    // user-visible subset of commonIdxes for DIFF and row identity
+		commonWritableIdxes []int    // destination-writable subset of commonVisibleIdxes for apply
+		tarOnlyIdxes        []int    // indices of target-only columns (target data-batch ordering)
+		baseColToTarIdx     []int    // for base batch Vec[i+1], the target column index, or -1
+		baseColNames        []string // target data column index to lineage-resolved base name
+		lcaColNames         []string // target data column index to lineage-resolved LCA name
 	}
 
 	worker               *ants.Pool

--- a/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
@@ -1,0 +1,102 @@
+drop database if exists data_branch_generated_column;
+create database data_branch_generated_column;
+use data_branch_generated_column;
+create table stored_base (
+id int primary key,
+a int,
+b int,
+c int generated always as (a + b) stored
+);
+insert into stored_base(id, a, b) values (1, 10, 20), (2, 30, 40);
+data branch create table stored_branch from stored_base;
+update stored_branch set a = 11 where id = 1;
+insert into stored_branch(id, a, b) values (3, 50, 60);
+delete from stored_branch where id = 2;
+data branch diff stored_branch against stored_base output summary;
+➤ metric[12,0,0]  ¦  stored_branch[-5,0,0]  ¦  stored_base[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge stored_branch into stored_base when conflict accept;
+select id, a, b, c from stored_base order by id;
+➤ id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  11  ¦  20  ¦  31  𝄀
+3  ¦  50  ¦  60  ¦  110
+data branch diff stored_branch against stored_base output summary;
+➤ metric[12,0,0]  ¦  stored_branch[-5,0,0]  ¦  stored_base[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+create table virtual_base (
+id int primary key,
+a int,
+b int,
+c int generated always as (a + b) virtual
+);
+insert into virtual_base(id, a, b) values (1, 10, 20), (2, 30, 40);
+data branch create table virtual_branch from virtual_base;
+update virtual_branch set a = 11 where id = 1;
+insert into virtual_branch(id, a, b) values (3, 50, 60);
+delete from virtual_branch where id = 2;
+data branch diff virtual_branch against virtual_base output summary;
+➤ metric[12,0,0]  ¦  virtual_branch[-5,0,0]  ¦  virtual_base[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch pick virtual_branch into virtual_base keys(1, 2, 3) when conflict accept;
+select id, a, b, c from virtual_base order by id;
+➤ id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  11  ¦  20  ¦  31  𝄀
+3  ¦  50  ¦  60  ¦  110
+data branch diff virtual_branch against virtual_base output summary;
+➤ metric[12,0,0]  ¦  virtual_branch[-5,0,0]  ¦  virtual_base[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+create table ordinary_source (
+id int primary key,
+a int,
+b int,
+c int
+);
+insert into ordinary_source values (1, 11, 20, -1), (3, 50, 60, -1);
+create table generated_destination (
+id int primary key,
+a int,
+b int,
+c int generated always as (a + b) stored
+);
+insert into generated_destination(id, a, b) values (1, 10, 20), (2, 30, 40);
+data branch merge ordinary_source into generated_destination when conflict accept;
+select id, a, b, c from generated_destination order by id;
+➤ id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  11  ¦  20  ¦  31  𝄀
+2  ¦  30  ¦  40  ¦  70  𝄀
+3  ¦  50  ¦  60  ¦  110
+create table stored_generated_pk_base (
+a int,
+b int generated always as (a * 2) stored,
+payload int,
+primary key (b)
+);
+insert into stored_generated_pk_base(a, payload) values (1, 10), (2, 20);
+data branch create table stored_generated_pk_branch from stored_generated_pk_base;
+update stored_generated_pk_branch set payload = 11 where b = 2;
+insert into stored_generated_pk_branch(a, payload) values (3, 30);
+delete from stored_generated_pk_branch where b = 4;
+data branch diff stored_generated_pk_branch against stored_generated_pk_base output summary;
+➤ metric[12,0,0]  ¦  stored_generated_pk_branch[-5,0,0]  ¦  stored_generated_pk_base[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge stored_generated_pk_branch into stored_generated_pk_base when conflict accept;
+select a, b, payload from stored_generated_pk_base order by b;
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  2  ¦  11  𝄀
+3  ¦  6  ¦  30
+data branch diff stored_generated_pk_branch against stored_generated_pk_base output summary;
+➤ metric[12,0,0]  ¦  stored_generated_pk_branch[-5,0,0]  ¦  stored_generated_pk_base[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+drop database data_branch_generated_column;

--- a/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
@@ -17,6 +17,24 @@ data branch diff stored_branch against stored_base output summary;
 INSERTED  ¦  1  ¦  0  𝄀
 DELETED  ¦  1  ¦  0  𝄀
 UPDATED  ¦  1  ¦  0
+data branch diff stored_branch against stored_base;
+➤ diff stored_branch against stored_base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+stored_branch  ¦  UPDATE  ¦  1  ¦  11  ¦  20  ¦  31  𝄀
+stored_branch  ¦  DELETE  ¦  2  ¦  30  ¦  40  ¦  70  𝄀
+stored_branch  ¦  INSERT  ¦  3  ¦  50  ¦  60  ¦  110
+data branch diff stored_branch against stored_base columns(c, id);
+➤ diff stored_branch against stored_base[12,0,0]  ¦  flag[12,0,0]  ¦  c[4,32,0]  ¦  id[4,32,0]  𝄀
+stored_branch  ¦  UPDATE  ¦  31  ¦  1  𝄀
+stored_branch  ¦  DELETE  ¦  70  ¦  2  𝄀
+stored_branch  ¦  INSERT  ¦  110  ¦  3
+data branch diff stored_branch against stored_base columns(c, id) output as stored_generated_diff;
+➤ TABLE CREATED[12,0,0]  𝄀
+`data_branch_generated_column`.`stored_generated_diff`
+select __mo_diff_source, __mo_diff_flag, c, id from stored_generated_diff order by id, __mo_diff_source;
+➤ __mo_diff_source[12,-1,0]  ¦  __mo_diff_flag[12,-1,0]  ¦  c[4,32,0]  ¦  id[4,32,0]  𝄀
+stored_branch  ¦  UPDATE  ¦  31  ¦  1  𝄀
+stored_branch  ¦  DELETE  ¦  70  ¦  2  𝄀
+stored_branch  ¦  INSERT  ¦  110  ¦  3
 data branch merge stored_branch into stored_base when conflict accept;
 select id, a, b, c from stored_base order by id;
 ➤ id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
@@ -53,26 +71,27 @@ data branch diff virtual_branch against virtual_base output summary;
 INSERTED  ¦  0  ¦  0  𝄀
 DELETED  ¦  0  ¦  0  𝄀
 UPDATED  ¦  0  ¦  0
-create table ordinary_source (
+create table formula_source (
 id int primary key,
 a int,
-b int,
-c int
+g int generated always as (a * 2) stored
 );
-insert into ordinary_source values (1, 11, 20, -1), (3, 50, 60, -1);
-create table generated_destination (
+insert into formula_source(id, a) values (1, 11);
+create table formula_destination (
 id int primary key,
 a int,
-b int,
-c int generated always as (a + b) stored
+g int generated always as (a * 3) stored
 );
-insert into generated_destination(id, a, b) values (1, 10, 20), (2, 30, 40);
-data branch merge ordinary_source into generated_destination when conflict accept;
-select id, a, b, c from generated_destination order by id;
-➤ id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
-1  ¦  11  ¦  20  ¦  31  𝄀
-2  ¦  30  ¦  40  ¦  70  𝄀
-3  ¦  50  ¦  60  ¦  110
+insert into formula_destination(id, a) values (1, 10);
+data branch diff formula_source against formula_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+data branch merge formula_source into formula_destination when conflict accept;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+select id, a, g from formula_destination order by id;
+➤ id[4,32,0]  ¦  a[4,32,0]  ¦  g[4,32,0]  𝄀
+1  ¦  10  ¦  30
 create table stored_generated_pk_base (
 a int,
 b int generated always as (a * 2) stored,
@@ -99,4 +118,25 @@ data branch diff stored_generated_pk_branch against stored_generated_pk_base out
 INSERTED  ¦  0  ¦  0  𝄀
 DELETED  ¦  0  ¦  0  𝄀
 UPDATED  ¦  0  ¦  0
+create table generated_pk_source (
+a int,
+g int generated always as (a * 2) stored,
+primary key (g)
+);
+insert into generated_pk_source(a) values (1);
+create table generated_pk_destination (
+a int,
+g int generated always as (a * 3) stored,
+primary key (g)
+);
+insert into generated_pk_destination(a) values (1);
+data branch diff generated_pk_source against generated_pk_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+data branch merge generated_pk_source into generated_pk_destination when conflict accept;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+select a, g from generated_pk_destination order by g;
+➤ a[4,32,0]  ¦  g[4,32,0]  𝄀
+1  ¦  3
 drop database data_branch_generated_column;

--- a/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
@@ -139,4 +139,96 @@ internal error: schema compatibility check: column 'g' has different generated d
 select a, g from generated_pk_destination order by g;
 ➤ a[4,32,0]  ¦  g[4,32,0]  𝄀
 1  ¦  3
+create table reordered_matching_source (
+id int primary key,
+a int,
+b int,
+g int generated always as (a * 2) stored
+);
+insert into reordered_matching_source(id, a, b) values (1, 10, 7);
+create table reordered_matching_destination (
+id int primary key,
+b int,
+a int,
+g int generated always as (a * 2) stored
+);
+insert into reordered_matching_destination(id, b, a) values (1, 7, 9);
+data branch merge reordered_matching_source into reordered_matching_destination when conflict accept;
+select id, a, b, g from reordered_matching_destination order by id;
+➤ id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  g[4,32,0]  𝄀
+1  ¦  10  ¦  7  ¦  20
+data branch diff reordered_matching_source against reordered_matching_destination output summary;
+➤ metric[12,0,0]  ¦  reordered_matching_source[-5,0,0]  ¦  reordered_matching_destination[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+create table reordered_mismatch_source (
+id int primary key,
+a int,
+b int,
+g int generated always as (a * 2) stored
+);
+insert into reordered_mismatch_source(id, a, b) values (1, 10, 7);
+create table reordered_mismatch_destination (
+id int primary key,
+b int,
+a int,
+g int generated always as (b * 2) stored
+);
+insert into reordered_mismatch_destination(id, b, a) values (1, 7, 9);
+data branch diff reordered_mismatch_source against reordered_mismatch_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+data branch merge reordered_mismatch_source into reordered_mismatch_destination when conflict accept;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+select id, a, b, g from reordered_mismatch_destination order by id;
+➤ id[4,32,0]  ¦  a[4,32,0]  ¦  b[4,32,0]  ¦  g[4,32,0]  𝄀
+1  ¦  9  ¦  7  ¦  14
+create table reordered_generated_pk_source (
+a int,
+b int,
+g int generated always as (a * 2) stored,
+primary key (g)
+);
+insert into reordered_generated_pk_source(a, b) values (10, 7);
+create table reordered_generated_pk_destination (
+b int,
+a int,
+g int generated always as (a * 2) stored,
+primary key (g)
+);
+insert into reordered_generated_pk_destination(b, a) values (8, 10);
+data branch merge reordered_generated_pk_source into reordered_generated_pk_destination when conflict accept;
+select a, b, g from reordered_generated_pk_destination order by g;
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  g[4,32,0]  𝄀
+10  ¦  7  ¦  20
+data branch diff reordered_generated_pk_source against reordered_generated_pk_destination output summary;
+➤ metric[12,0,0]  ¦  reordered_generated_pk_source[-5,0,0]  ¦  reordered_generated_pk_destination[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+create table reordered_generated_pk_mismatch_source (
+a int,
+b int,
+g int generated always as (a * 2) stored,
+primary key (g)
+);
+insert into reordered_generated_pk_mismatch_source(a, b) values (10, 7);
+create table reordered_generated_pk_mismatch_destination (
+b int,
+a int,
+g int generated always as (b * 2) stored,
+primary key (g)
+);
+insert into reordered_generated_pk_mismatch_destination(b, a) values (7, 10);
+data branch diff reordered_generated_pk_mismatch_source against reordered_generated_pk_mismatch_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+data branch merge reordered_generated_pk_mismatch_source into reordered_generated_pk_mismatch_destination when conflict accept;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+internal error: schema compatibility check: column 'g' has different generated definitions
+select a, b, g from reordered_generated_pk_mismatch_destination order by g;
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  g[4,32,0]  𝄀
+10  ¦  7  ¦  14
 drop database data_branch_generated_column;

--- a/test/distributed/cases/git4data/branch/merge/merge_generated_column.sql
+++ b/test/distributed/cases/git4data/branch/merge/merge_generated_column.sql
@@ -96,4 +96,88 @@ data branch diff generated_pk_source against generated_pk_destination output sum
 data branch merge generated_pk_source into generated_pk_destination when conflict accept;
 select a, g from generated_pk_destination order by g;
 
+-- Generated expressions use logical column identity rather than endpoint-local
+-- ordinals when unrelated endpoint schemas order their columns differently.
+create table reordered_matching_source (
+    id int primary key,
+    a int,
+    b int,
+    g int generated always as (a * 2) stored
+);
+insert into reordered_matching_source(id, a, b) values (1, 10, 7);
+create table reordered_matching_destination (
+    id int primary key,
+    b int,
+    a int,
+    g int generated always as (a * 2) stored
+);
+insert into reordered_matching_destination(id, b, a) values (1, 7, 9);
+data branch merge reordered_matching_source into reordered_matching_destination when conflict accept;
+select id, a, b, g from reordered_matching_destination order by id;
+data branch diff reordered_matching_source against reordered_matching_destination output summary;
+
+-- These expressions have protobuf-equal local ordinals (ColPos 1) but refer to
+-- different logical columns: source.a versus destination.b.
+create table reordered_mismatch_source (
+    id int primary key,
+    a int,
+    b int,
+    g int generated always as (a * 2) stored
+);
+insert into reordered_mismatch_source(id, a, b) values (1, 10, 7);
+create table reordered_mismatch_destination (
+    id int primary key,
+    b int,
+    a int,
+    g int generated always as (b * 2) stored
+);
+insert into reordered_mismatch_destination(id, b, a) values (1, 7, 9);
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch diff reordered_mismatch_source against reordered_mismatch_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch merge reordered_mismatch_source into reordered_mismatch_destination when conflict accept;
+select id, a, b, g from reordered_mismatch_destination order by id;
+
+-- Matching generated primary-key expressions remain compatible across a
+-- reordered schema and retain consistent row identity.
+create table reordered_generated_pk_source (
+    a int,
+    b int,
+    g int generated always as (a * 2) stored,
+    primary key (g)
+);
+insert into reordered_generated_pk_source(a, b) values (10, 7);
+create table reordered_generated_pk_destination (
+    b int,
+    a int,
+    g int generated always as (a * 2) stored,
+    primary key (g)
+);
+insert into reordered_generated_pk_destination(b, a) values (8, 10);
+data branch merge reordered_generated_pk_source into reordered_generated_pk_destination when conflict accept;
+select a, b, g from reordered_generated_pk_destination order by g;
+data branch diff reordered_generated_pk_source against reordered_generated_pk_destination output summary;
+
+-- Generated primary-key expressions with colliding local ordinals but different
+-- logical references cannot share row identity.
+create table reordered_generated_pk_mismatch_source (
+    a int,
+    b int,
+    g int generated always as (a * 2) stored,
+    primary key (g)
+);
+insert into reordered_generated_pk_mismatch_source(a, b) values (10, 7);
+create table reordered_generated_pk_mismatch_destination (
+    b int,
+    a int,
+    g int generated always as (b * 2) stored,
+    primary key (g)
+);
+insert into reordered_generated_pk_mismatch_destination(b, a) values (7, 10);
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch diff reordered_generated_pk_mismatch_source against reordered_generated_pk_mismatch_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch merge reordered_generated_pk_mismatch_source into reordered_generated_pk_mismatch_destination when conflict accept;
+select a, b, g from reordered_generated_pk_mismatch_destination order by g;
+
 drop database data_branch_generated_column;

--- a/test/distributed/cases/git4data/branch/merge/merge_generated_column.sql
+++ b/test/distributed/cases/git4data/branch/merge/merge_generated_column.sql
@@ -15,6 +15,10 @@ update stored_branch set a = 11 where id = 1;
 insert into stored_branch(id, a, b) values (3, 50, 60);
 delete from stored_branch where id = 2;
 data branch diff stored_branch against stored_base output summary;
+data branch diff stored_branch against stored_base;
+data branch diff stored_branch against stored_base columns(c, id);
+data branch diff stored_branch against stored_base columns(c, id) output as stored_generated_diff;
+select __mo_diff_source, __mo_diff_flag, c, id from stored_generated_diff order by id, __mo_diff_source;
 data branch merge stored_branch into stored_base when conflict accept;
 select id, a, b, c from stored_base order by id;
 data branch diff stored_branch against stored_base output summary;
@@ -36,24 +40,24 @@ data branch pick virtual_branch into virtual_base keys(1, 2, 3) when conflict ac
 select id, a, b, c from virtual_base order by id;
 data branch diff virtual_branch against virtual_base output summary;
 
--- A destination generated column is non-writable even when an unrelated
--- source table has an ordinary column with the same name and type.
-create table ordinary_source (
+-- Generated columns are common only when their generation semantics match.
+create table formula_source (
     id int primary key,
     a int,
-    b int,
-    c int
+    g int generated always as (a * 2) stored
 );
-insert into ordinary_source values (1, 11, 20, -1), (3, 50, 60, -1);
-create table generated_destination (
+insert into formula_source(id, a) values (1, 11);
+create table formula_destination (
     id int primary key,
     a int,
-    b int,
-    c int generated always as (a + b) stored
+    g int generated always as (a * 3) stored
 );
-insert into generated_destination(id, a, b) values (1, 10, 20), (2, 30, 40);
-data branch merge ordinary_source into generated_destination when conflict accept;
-select id, a, b, c from generated_destination order by id;
+insert into formula_destination(id, a) values (1, 10);
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch diff formula_source against formula_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch merge formula_source into formula_destination when conflict accept;
+select id, a, g from formula_destination order by id;
 
 -- A STORED generated primary key participates in row identity but is still
 -- omitted from destination writes.
@@ -72,5 +76,24 @@ data branch diff stored_generated_pk_branch against stored_generated_pk_base out
 data branch merge stored_generated_pk_branch into stored_generated_pk_base when conflict accept;
 select a, b, payload from stored_generated_pk_base order by b;
 data branch diff stored_generated_pk_branch against stored_generated_pk_base output summary;
+
+-- Mismatched generated primary-key formulas cannot share row identity.
+create table generated_pk_source (
+    a int,
+    g int generated always as (a * 2) stored,
+    primary key (g)
+);
+insert into generated_pk_source(a) values (1);
+create table generated_pk_destination (
+    a int,
+    g int generated always as (a * 3) stored,
+    primary key (g)
+);
+insert into generated_pk_destination(a) values (1);
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch diff generated_pk_source against generated_pk_destination output summary;
+-- @regex("schema compatibility check: column 'g' has different generated definitions", true)
+data branch merge generated_pk_source into generated_pk_destination when conflict accept;
+select a, g from generated_pk_destination order by g;
 
 drop database data_branch_generated_column;

--- a/test/distributed/cases/git4data/branch/merge/merge_generated_column.sql
+++ b/test/distributed/cases/git4data/branch/merge/merge_generated_column.sql
@@ -1,0 +1,76 @@
+drop database if exists data_branch_generated_column;
+create database data_branch_generated_column;
+use data_branch_generated_column;
+
+-- MERGE must omit a STORED generated column from destination writes.
+create table stored_base (
+    id int primary key,
+    a int,
+    b int,
+    c int generated always as (a + b) stored
+);
+insert into stored_base(id, a, b) values (1, 10, 20), (2, 30, 40);
+data branch create table stored_branch from stored_base;
+update stored_branch set a = 11 where id = 1;
+insert into stored_branch(id, a, b) values (3, 50, 60);
+delete from stored_branch where id = 2;
+data branch diff stored_branch against stored_base output summary;
+data branch merge stored_branch into stored_base when conflict accept;
+select id, a, b, c from stored_base order by id;
+data branch diff stored_branch against stored_base output summary;
+
+-- PICK must omit a VIRTUAL generated column from destination writes.
+create table virtual_base (
+    id int primary key,
+    a int,
+    b int,
+    c int generated always as (a + b) virtual
+);
+insert into virtual_base(id, a, b) values (1, 10, 20), (2, 30, 40);
+data branch create table virtual_branch from virtual_base;
+update virtual_branch set a = 11 where id = 1;
+insert into virtual_branch(id, a, b) values (3, 50, 60);
+delete from virtual_branch where id = 2;
+data branch diff virtual_branch against virtual_base output summary;
+data branch pick virtual_branch into virtual_base keys(1, 2, 3) when conflict accept;
+select id, a, b, c from virtual_base order by id;
+data branch diff virtual_branch against virtual_base output summary;
+
+-- A destination generated column is non-writable even when an unrelated
+-- source table has an ordinary column with the same name and type.
+create table ordinary_source (
+    id int primary key,
+    a int,
+    b int,
+    c int
+);
+insert into ordinary_source values (1, 11, 20, -1), (3, 50, 60, -1);
+create table generated_destination (
+    id int primary key,
+    a int,
+    b int,
+    c int generated always as (a + b) stored
+);
+insert into generated_destination(id, a, b) values (1, 10, 20), (2, 30, 40);
+data branch merge ordinary_source into generated_destination when conflict accept;
+select id, a, b, c from generated_destination order by id;
+
+-- A STORED generated primary key participates in row identity but is still
+-- omitted from destination writes.
+create table stored_generated_pk_base (
+    a int,
+    b int generated always as (a * 2) stored,
+    payload int,
+    primary key (b)
+);
+insert into stored_generated_pk_base(a, payload) values (1, 10), (2, 20);
+data branch create table stored_generated_pk_branch from stored_generated_pk_base;
+update stored_generated_pk_branch set payload = 11 where b = 2;
+insert into stored_generated_pk_branch(a, payload) values (3, 30);
+delete from stored_generated_pk_branch where b = 4;
+data branch diff stored_generated_pk_branch against stored_generated_pk_base output summary;
+data branch merge stored_generated_pk_branch into stored_generated_pk_base when conflict accept;
+select a, b, payload from stored_generated_pk_base order by b;
+data branch diff stored_generated_pk_branch against stored_generated_pk_base output summary;
+
+drop database data_branch_generated_column;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26040

## What this PR does / why we need it:

### Root cause

DATA BRANCH used one column classification for both read-only output and destination writes. Generated columns are user-visible and participate in DIFF/row identity, but they are not writable. Including them in MERGE, PICK, and portable-SQL INSERT layouts caused error 20301; excluding them from the shared visible layout instead removed them from plain DIFF, `COLUMNS(...)`, and `OUTPUT AS`.

Schema compatibility also treated generated expressions as endpoint-local protobuf values. Generated column references store local column ordinals, so reordered unrelated schemas could make different logical references protobuf-equal, or make equivalent references unequal. That could let MERGE succeed while the destination recomputed a different value and could also corrupt generated-primary-key row identity.

### Changes

- Separate user-visible and destination-writable column classifications: generated columns remain visible for DIFF, projections, `OUTPUT AS`, and row identity, while STORED and VIRTUAL generated columns are omitted from all apply/portable-SQL writes.
- Build a common writable layout from the common visible layout for MERGE/PICK apply paths.
- Canonicalize every generated-expression column reference through its endpoint table definition and the existing lineage resolver before comparing expressions.
- Require matching generated-column kind, storage mode, and logical expression metadata before columns are considered schema-compatible, including generated primary keys.
- Fail closed when generated expression metadata, a referenced logical column, or a GeneratedColBinder-unsupported expression kind cannot be resolved safely.
- Preserve the existing rejection of base-only visible columns and ordinary/generated mismatches.
- Extend focused unit tests and BVT coverage for read-only visibility, writable layouts, lineage renames, reordered schemas, matching/mismatched formulas, generated primary keys, MERGE, PICK, portable SQL, projections, and `OUTPUT AS`.

### Tests

- `make build`
- CGo-configured `go vet -mod=readonly ./pkg/frontend`
- CGo wrapper: `go test -count=1 -timeout=600s -coverprofile=... ./pkg/frontend`
- CGo race wrapper: `go test -race -count=1 -timeout=600s ./pkg/frontend`
- CGo race wrapper: each of `TestCanonicalizeDataBranchGeneratedExpr`, `TestDataBranchGeneratedColumnsLogicallyEqualBoundaries`, and `TestCheckSchemaCompatibility_GeneratedDefinitionsUseLogicalColumnIdentity` passed independently with `-race -count=100` (`T` below timer resolution, `B=30s`, `N=100`).
- MatrixOne CI's exact `parse_coverage.py` against the complete PR diff and local frontend profile: 57/72 changed lines covered, 79.17% (required >75%).
- `mo-tester -i merge_generated_column -r 100`: 80/80 statements passed; the generated result was manually inspected against the SQL semantics.
- Pre-fix reproduction: MERGE failed with error 20301 and left the destination unchanged.
- Post-fix coverage verifies STORED MERGE and VIRTUAL PICK converge, portable SQL omits generated destinations, read-only outputs retain generated values, reordered matching formulas converge, and reordered mismatched ordinary/generated-PK formulas are rejected without changing the destination.

### Residual risks

No known residual risk. Generated-definition comparison is deliberately fail-closed when usable expression metadata or logical reference identity is absent. The change is confined to DATA BRANCH schema classification/validation and tests; it adds no concurrency, resource-lifecycle, or storage-lifecycle behavior.
