### PR TITLE
fix(disttae): conserve workspace accounting after cleanup

### DIFF
--- a/pkg/vm/engine/disttae/table_meta_reader_test.go
+++ b/pkg/vm/engine/disttae/table_meta_reader_test.go
@@ -615,7 +615,7 @@ func TestCloneTxnTablesInVainGCDeletesUnreferencedTxnLocalSharedObject(t *testin
 	require.NoError(t, writeObjectToFS(ctx, fs, name))
 	txn.engine.cloneTxnCache.AddTxnLocalSharedFile(txn.op.Txn().ID, name)
 
-	txn.writes = append(txn.writes, Entry{
+	txn.appendWorkspaceEntryLocked(Entry{
 		typ:      INSERT,
 		tableId:  42,
 		fileName: name,
@@ -663,20 +663,18 @@ func TestCloneTxnTablesInVainGCKeepsLiveTxnLocalSharedObject(t *testing.T) {
 	txn.engine.cloneTxnCache.AddTxnLocalSharedFile(txn.op.Txn().ID, name)
 
 	liveBat := cloneObjectStatsBatchForTest(t, proc.Mp(), stats...)
-	txn.writes = append(txn.writes,
-		Entry{
-			typ:      INSERT,
-			tableId:  42,
-			fileName: name,
-			bat:      cloneObjectStatsBatchForTest(t, proc.Mp(), stats...),
-		},
-		Entry{
-			typ:      INSERT,
-			tableId:  43,
-			fileName: name,
-			bat:      liveBat,
-		},
-	)
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:      INSERT,
+		tableId:  42,
+		fileName: name,
+		bat:      cloneObjectStatsBatchForTest(t, proc.Mp(), stats...),
+	})
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:      INSERT,
+		tableId:  43,
+		fileName: name,
+		bat:      liveBat,
+	})
 
 	require.NoError(t, txn.mergeTxnWorkspaceLocked(ctx))
 	require.Nil(t, txn.writes[0].bat)
@@ -684,7 +682,7 @@ func TestCloneTxnTablesInVainGCKeepsLiveTxnLocalSharedObject(t *testing.T) {
 	require.True(t, txn.engine.cloneTxnCache.IsTxnLocalSharedFile(txn.op.Txn().ID, name))
 	require.True(t, objectExistsInFS(ctx, fs, name))
 
-	liveBat.Clean(proc.Mp())
+	txn.releaseWorkspaceEntryBatchLocked(1)
 }
 
 func TestCloneTxnUnknownCommitReleasesLocalStateWithoutObjectGC(t *testing.T) {
@@ -719,7 +717,7 @@ func TestCloneTxnUnknownCommitReleasesLocalStateWithoutObjectGC(t *testing.T) {
 	name := stats[0].ObjectName().String()
 	require.NoError(t, writeObjectToFS(ctx, fs, name))
 	txn.engine.cloneTxnCache.AddTxnLocalSharedFile(txn.op.Txn().ID, name)
-	txn.writes = append(txn.writes, Entry{
+	txn.appendWorkspaceEntryLocked(Entry{
 		typ:      INSERT,
 		tableId:  42,
 		fileName: name,

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -207,13 +207,13 @@ func (txn *Transaction) checkWorkspaceAccountingLocked() error {
 		entry := &txn.writes[i]
 		if entry.bat == nil {
 			if entry.accountedSize != 0 {
-				return fmt.Errorf("entry %d: nil batch accounts %d bytes", i, entry.accountedSize)
+				return moerr.NewInternalErrorNoCtxf("entry %d: nil batch accounts %d bytes", i, entry.accountedSize)
 			}
 			continue
 		}
 		size := uint64(entry.bat.Size())
 		if entry.accountedSize != size {
-			return fmt.Errorf("entry %d: accounted size %d, batch size %d", i, entry.accountedSize, size)
+			return moerr.NewInternalErrorNoCtxf("entry %d: accounted size %d, batch size %d", i, entry.accountedSize, size)
 		}
 		workspaceSize += size
 		if entry.fileName != "" || catalog.IsSystemTable(entry.tableId) {
@@ -232,7 +232,7 @@ func (txn *Transaction) checkWorkspaceAccountingLocked() error {
 		txn.approximateInMemInsertSize != insertSize ||
 		txn.approximateInMemInsertCnt != insertCnt ||
 		txn.approximateInMemDeleteCnt != deleteCnt {
-		return fmt.Errorf(
+		return moerr.NewInternalErrorNoCtxf(
 			"workspace accounting mismatch: workspace %d/%d, insert bytes %d/%d, insert rows %d/%d, delete rows %d/%d",
 			txn.workspaceSize, workspaceSize,
 			txn.approximateInMemInsertSize, insertSize,

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -79,6 +79,178 @@ func (txn *Transaction) ReadOnly() bool {
 	return txn.readOnly.Load()
 }
 
+func (txn *Transaction) accountWorkspaceEntryLocked(entry *Entry) {
+	if entry.accountedSize != 0 {
+		panic("BUG: workspace entry is already accounted")
+	}
+	if entry.bat == nil {
+		return
+	}
+
+	entry.accountedSize = uint64(entry.bat.Size())
+	txn.workspaceSize += entry.accountedSize
+	if entry.fileName != "" || catalog.IsSystemTable(entry.tableId) {
+		return
+	}
+
+	switch entry.typ {
+	case INSERT:
+		txn.approximateInMemInsertSize += entry.accountedSize
+		txn.approximateInMemInsertCnt += entry.bat.RowCount()
+	case DELETE:
+		txn.approximateInMemDeleteCnt += entry.bat.RowCount()
+	}
+}
+
+func (txn *Transaction) unaccountWorkspaceEntryLocked(entry *Entry) {
+	if entry.bat == nil {
+		if entry.accountedSize != 0 {
+			panic("BUG: nil workspace entry has accounted bytes")
+		}
+		return
+	}
+	if entry.accountedSize != uint64(entry.bat.Size()) {
+		panic("BUG: workspace entry changed outside accounting helpers")
+	}
+	if txn.workspaceSize < entry.accountedSize {
+		panic("BUG: workspace size accounting underflow")
+	}
+
+	txn.workspaceSize -= entry.accountedSize
+	if entry.fileName == "" && !catalog.IsSystemTable(entry.tableId) {
+		switch entry.typ {
+		case INSERT:
+			if txn.approximateInMemInsertSize < entry.accountedSize ||
+				txn.approximateInMemInsertCnt < entry.bat.RowCount() {
+				panic("BUG: in-memory insert accounting underflow")
+			}
+			txn.approximateInMemInsertSize -= entry.accountedSize
+			txn.approximateInMemInsertCnt -= entry.bat.RowCount()
+		case DELETE:
+			if txn.approximateInMemDeleteCnt < entry.bat.RowCount() {
+				panic("BUG: in-memory delete accounting underflow")
+			}
+			txn.approximateInMemDeleteCnt -= entry.bat.RowCount()
+		}
+	}
+	entry.accountedSize = 0
+}
+
+func (txn *Transaction) appendWorkspaceEntryLocked(entry Entry) {
+	txn.accountWorkspaceEntryLocked(&entry)
+	txn.writes = append(txn.writes, entry)
+}
+
+func (txn *Transaction) releaseWorkspaceEntryBatchLocked(idx int) {
+	entry := &txn.writes[idx]
+	if entry.bat == nil {
+		return
+	}
+
+	bat := entry.bat
+	txn.unaccountWorkspaceEntryLocked(entry)
+	delete(txn.batchSelectList, bat)
+	bat.Clean(txn.proc.GetMPool())
+	entry.bat = nil
+}
+
+func (txn *Transaction) shrinkWorkspaceEntryBatchLocked(idx int, sels []int64) {
+	entry := &txn.writes[idx]
+	if entry.bat == nil {
+		return
+	}
+	bat := entry.bat
+	if len(sels) == 0 {
+		delete(txn.batchSelectList, bat)
+		return
+	}
+
+	slices.Sort(sels)
+	sels = slices.Compact(sels)
+	txn.unaccountWorkspaceEntryLocked(entry)
+	shrinkBatchWithRowids(bat, sels)
+	txn.accountWorkspaceEntryLocked(entry)
+	delete(txn.batchSelectList, bat)
+}
+
+func (txn *Transaction) mergeWorkspaceEntryBatchesLocked(
+	ctx context.Context,
+	dstIdx int64,
+	srcIdx int64,
+) error {
+	dst := &txn.writes[dstIdx]
+	src := &txn.writes[srcIdx]
+	txn.unaccountWorkspaceEntryLocked(dst)
+	txn.unaccountWorkspaceEntryLocked(src)
+
+	if _, err := dst.bat.Append(ctx, txn.proc.Mp(), src.bat); err != nil {
+		// Append may have mutated some destination vectors before failing.
+		// Restore accounting from the two batches' actual states.
+		txn.accountWorkspaceEntryLocked(dst)
+		txn.accountWorkspaceEntryLocked(src)
+		return err
+	}
+
+	txn.accountWorkspaceEntryLocked(dst)
+	delete(txn.batchSelectList, src.bat)
+	src.bat.Clean(txn.proc.GetMPool())
+	src.bat = nil
+	return nil
+}
+
+func (txn *Transaction) checkWorkspaceAccountingLocked() error {
+	var workspaceSize uint64
+	var insertSize uint64
+	var insertCnt int
+	var deleteCnt int
+	for i := range txn.writes {
+		entry := &txn.writes[i]
+		if entry.bat == nil {
+			if entry.accountedSize != 0 {
+				return fmt.Errorf("entry %d: nil batch accounts %d bytes", i, entry.accountedSize)
+			}
+			continue
+		}
+		size := uint64(entry.bat.Size())
+		if entry.accountedSize != size {
+			return fmt.Errorf("entry %d: accounted size %d, batch size %d", i, entry.accountedSize, size)
+		}
+		workspaceSize += size
+		if entry.fileName != "" || catalog.IsSystemTable(entry.tableId) {
+			continue
+		}
+		switch entry.typ {
+		case INSERT:
+			insertSize += size
+			insertCnt += entry.bat.RowCount()
+		case DELETE:
+			deleteCnt += entry.bat.RowCount()
+		}
+	}
+
+	if txn.workspaceSize != workspaceSize ||
+		txn.approximateInMemInsertSize != insertSize ||
+		txn.approximateInMemInsertCnt != insertCnt ||
+		txn.approximateInMemDeleteCnt != deleteCnt {
+		return fmt.Errorf(
+			"workspace accounting mismatch: workspace %d/%d, insert bytes %d/%d, insert rows %d/%d, delete rows %d/%d",
+			txn.workspaceSize, workspaceSize,
+			txn.approximateInMemInsertSize, insertSize,
+			txn.approximateInMemInsertCnt, insertCnt,
+			txn.approximateInMemDeleteCnt, deleteCnt,
+		)
+	}
+	return nil
+}
+
+func (txn *Transaction) assertWorkspaceAccountingLocked() {
+	common.DoIfDebugEnabled(func() {
+		if err := txn.checkWorkspaceAccountingLocked(); err != nil {
+			panic(err)
+		}
+	})
+}
+
 // WriteBatch used to write data to the transaction buffer
 // insert/delete/update all use this api
 // truncate : it denotes the batch with typ DELETE on mo_tables is generated when Truncating
@@ -206,14 +378,6 @@ func (txn *Transaction) writeBatchWithAutoIncrEpochKnown(
 		}
 		bat.InsertVector(0, objectio.PhysicalAddr_Attr, genRowidVec)
 
-		if !catalog.IsSystemTable(tableId) {
-			txn.approximateInMemInsertSize += uint64(bat.Size())
-			txn.approximateInMemInsertCnt += bat.RowCount()
-		}
-	}
-
-	if typ == DELETE && !catalog.IsSystemTable(tableId) {
-		txn.approximateInMemDeleteCnt += bat.RowCount()
 	}
 
 	if injected, logLevel := objectio.LogWorkspaceInjected(
@@ -281,9 +445,8 @@ func (txn *Transaction) writeBatchWithAutoIncrEpochKnown(
 		pkCheckPos:         pkCheckPos,
 		pkCheckReady:       pkCheckReady,
 	}
-	txn.writes = append(txn.writes, e)
+	txn.appendWorkspaceEntryLocked(e)
 	txn.pkCount += bat.RowCount()
-	txn.workspaceSize += uint64(bat.Size())
 
 	trace.GetService(txn.proc.GetService()).TxnWrite(txn.op, tableId, typesNames[typ], bat)
 	return
@@ -773,7 +936,6 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 				return nil
 			}
 		}
-		size = 0
 	}
 	if offset < txn.adjustWriteOffset {
 		txn.adjustWriteOffset = offset
@@ -789,7 +951,7 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 		return err
 	}
 
-	if err := txn.dumpInsertBatchLocked(ctx, fs, offset, &size, &pkCount); err != nil {
+	if err := txn.dumpInsertBatchLocked(ctx, fs, offset, &pkCount); err != nil {
 		return err
 	}
 	// release the extra quota
@@ -807,7 +969,7 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 
 	if dumpAll {
 		if txn.approximateInMemDeleteCnt >= txn.engine.config.insertEntryMaxCount {
-			if err := txn.dumpDeleteBatchLocked(ctx, fs, offset, &size); err != nil {
+			if err := txn.dumpDeleteBatchLocked(ctx, fs, offset); err != nil {
 				return err
 			}
 			//After flushing inserts/deletes in memory into S3, the entries in txn.writes will be unordered,
@@ -816,8 +978,6 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 				return err
 			}
 		}
-		txn.approximateInMemDeleteCnt = 0
-		txn.approximateInMemInsertSize = 0
 		txn.pkCount -= pkCount
 		// modifies txn.writes.
 		writes := txn.writes[:0]
@@ -828,11 +988,9 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 		}
 		txn.writes = writes
 	} else {
-		txn.approximateInMemInsertSize -= size
 		txn.pkCount -= pkCount
 	}
-
-	txn.workspaceSize -= size
+	txn.assertWorkspaceAccountingLocked()
 	return nil
 }
 
@@ -840,7 +998,6 @@ func (txn *Transaction) dumpInsertBatchLocked(
 	ctx context.Context,
 	fs fileservice.FileService,
 	offset int,
-	size *uint64,
 	pkCount *int,
 ) error {
 
@@ -936,8 +1093,8 @@ func (txn *Transaction) dumpInsertBatchLocked(
 			// the lock held.
 			if _, ok := tables[tbKey.tableKey]; ok {
 				bat := txn.writes[i].bat
-				*size += uint64(bat.Size())
 				*pkCount += bat.RowCount()
+				txn.unaccountWorkspaceEntryLocked(&txn.writes[i])
 				// skip rowid
 				newBatch := batch.NewWithSize(len(bat.Vecs) - 1)
 				newBatch.SetAttributes(bat.Attrs[1:])
@@ -1030,7 +1187,6 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 	ctx context.Context,
 	fs fileservice.FileService,
 	offset int,
-	size *uint64,
 ) error {
 
 	// See the comment in dumpInsertBatchLocked: tables must be resolved
@@ -1078,7 +1234,7 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 			if _, ok := tables[tbKey.tableKey]; ok {
 				bat := txn.writes[i].bat
 				deleteCnt += bat.RowCount()
-				*size += uint64(bat.Size())
+				txn.unaccountWorkspaceEntryLocked(&txn.writes[i])
 
 				newBat := batch.NewWithSize(len(bat.Vecs))
 				newBat.SetAttributes(bat.Attrs)
@@ -1458,7 +1614,6 @@ func (txn *Transaction) writeFileLockedWithAutoIncrEpochKnown(
 	}
 
 	txn.readOnly.Store(false)
-	txn.workspaceSize += uint64(copied.Size())
 
 	if typ == DELETE {
 		col, area := vector.MustVarlenaRawData(copied.Vecs[0])
@@ -1484,7 +1639,7 @@ func (txn *Transaction) writeFileLockedWithAutoIncrEpochKnown(
 		autoIncrEpochKnown: autoIncrEpochKnown,
 	}
 
-	txn.writes = append(txn.writes, entry)
+	txn.appendWorkspaceEntryLocked(entry)
 
 	return nil
 }
@@ -1560,7 +1715,6 @@ func (txn *Transaction) writeFileLockedSkipTransferWithAutoIncrEpochKnown(
 	}
 
 	txn.readOnly.Store(false)
-	txn.workspaceSize += uint64(copied.Size())
 
 	if typ == DELETE {
 		col, area := vector.MustVarlenaRawData(copied.Vecs[0])
@@ -1585,7 +1739,7 @@ func (txn *Transaction) writeFileLockedSkipTransferWithAutoIncrEpochKnown(
 		autoIncrEpochKnown: autoIncrEpochKnown,
 	}
 
-	txn.writes = append(txn.writes, entry)
+	txn.appendWorkspaceEntryLocked(entry)
 
 	return nil
 }
@@ -1868,14 +2022,9 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 	txn.restoreTxnTableFunc = txn.restoreTxnTableFunc[:0]
 
 	if len(txn.batchSelectList) > 0 {
-		for _, e := range txn.writes {
-			if sels, ok := txn.batchSelectList[e.bat]; ok {
-				// Repeated internal deletes can select the same workspace row more than once.
-				slices.Sort(sels)
-				sels = slices.Compact(sels)
-				txn.approximateInMemInsertCnt -= len(sels)
-				shrinkBatchWithRowids(e.bat, sels)
-				delete(txn.batchSelectList, e.bat)
+		for i := range txn.writes {
+			if sels, ok := txn.batchSelectList[txn.writes[i].bat]; ok {
+				txn.shrinkWorkspaceEntryBatchLocked(i, sels)
 			}
 		}
 	}
@@ -1896,10 +2045,10 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 					)
 					_ = txn.GCObjsByIdxRange(i, i)
 				}
-				e.bat.Clean(txn.proc.GetMPool())
-				txn.writes[i].bat = nil
+				txn.releaseWorkspaceEntryBatchLocked(i)
 			}
 		}
+		txn.assertWorkspaceAccountingLocked()
 	}
 
 	if err := txn.compactDeletionOnObjsLocked(ctx); err != nil {
@@ -1949,12 +2098,9 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 				if b.bat != nil && a.tableId == b.tableId && a.databaseId == b.databaseId &&
 					a.bat.RowCount()+b.bat.RowCount() <= objectio.BlockMaxRows {
 					merged = true
-					if _, err = a.bat.Append(ctx, txn.proc.Mp(), b.bat); err != nil {
+					if err = txn.mergeWorkspaceEntryBatchesLocked(ctx, idxes[i], idxes[j]); err != nil {
 						return err
 					}
-
-					b.bat.Clean(txn.proc.GetMPool())
-					b.bat = nil
 				}
 
 				if a.bat.RowCount() == objectio.BlockMaxRows {
@@ -2028,6 +2174,7 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 		}
 	}
 
+	txn.assertWorkspaceAccountingLocked()
 	return nil
 }
 
@@ -2269,8 +2416,7 @@ func (txn *Transaction) compactDeletionOnObjsLocked(ctx context.Context) error {
 			offset += int(stats.BlkCnt())
 		}
 
-		txn.writes[i].bat.Clean(txn.proc.GetMPool())
-		txn.writes[i].bat = nil
+		txn.releaseWorkspaceEntryBatchLocked(i)
 	}
 
 	if txn.compactWorker == nil {
@@ -2695,8 +2841,10 @@ func (txn *Transaction) delTransaction() {
 		if txn.writes[i].bat == nil {
 			continue
 		}
+		txn.unaccountWorkspaceEntryLocked(&txn.writes[i])
 		txn.writes[i].bat.Clean(txn.proc.Mp())
 	}
+	txn.assertWorkspaceAccountingLocked()
 
 	txn.tableCache = nil
 	txn.tableOps = nil

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1822,30 +1822,31 @@ func (tbl *txnTable) AlterTable(ctx context.Context, c *engine.ConstraintDef, re
 	if createdInTxn {
 		// 3. adjust writes for the table
 		txn.Lock()
+		defer txn.Unlock()
 		for i, n := 0, len(txn.writes); i < n; i++ {
 			if cur := txn.writes[i]; cur.tableId == tbl.tableId && cur.bat != nil && cur.bat.RowCount() > 0 {
 				if sels, exist := txn.batchSelectList[cur.bat]; exist && len(sels) == cur.bat.RowCount() {
 					continue
 				}
-				txn.writes = append(txn.writes, txn.writes[i]) // copy by value
-				transfered := &txn.writes[len(txn.writes)-1]
-				transfered.tableName = tbl.tableName // in case renaming
-				transfered.bat, err = cur.bat.Dup(txn.proc.Mp())
-				if len(renameColMap) > 0 {
-					for i, attr := range transfered.bat.Attrs {
-						if newName, ok := renameColMap[attr]; ok {
-							transfered.bat.Attrs[i] = newName
-						}
-					}
-				}
+				transferred := cur
+				transferred.tableName = tbl.tableName // in case renaming
+				transferred.bat, err = cur.bat.Dup(txn.proc.Mp())
+				transferred.accountedSize = 0
 				if err != nil {
 					return err
 				}
+				if len(renameColMap) > 0 {
+					for i, attr := range transferred.bat.Attrs {
+						if newName, ok := renameColMap[attr]; ok {
+							transferred.bat.Attrs[i] = newName
+						}
+					}
+				}
+				txn.appendWorkspaceEntryLocked(transferred)
 				txn.selectAllBatchRowsLocked(cur.bat)
 
 			}
 		}
-		txn.Unlock()
 	}
 
 	return nil
@@ -2141,7 +2142,10 @@ func (tbl *txnTable) SoftDeleteObject(ctx context.Context, objID *objectio.Objec
 		autoIncrEpochKnown: true,
 	}
 
-	tbl.getTxn().writes = append(tbl.getTxn().writes, entry)
+	txn := tbl.getTxn()
+	txn.Lock()
+	defer txn.Unlock()
+	txn.appendWorkspaceEntryLocked(entry)
 	return nil
 }
 

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -558,7 +558,7 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 	defer func() {
 		for i := range txn.writes {
 			if txn.writes[i].bat != nil {
-				txn.writes[i].bat.Clean(proc.Mp())
+				txn.releaseWorkspaceEntryBatchLocked(i)
 			}
 		}
 	}()
@@ -571,7 +571,7 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 		if i == 1 {
 			tableID = 1000
 		}
-		txn.writes = append(txn.writes, Entry{
+		txn.appendWorkspaceEntryLocked(Entry{
 			typ:          INSERT,
 			tableId:      tableID,
 			databaseId:   dbID,
@@ -581,7 +581,7 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 		})
 	}
 
-	txn.writes = append(txn.writes, Entry{
+	txn.appendWorkspaceEntryLocked(Entry{
 		typ:          INSERT,
 		tableId:      catalog.MO_TABLES_ID,
 		databaseId:   catalog.MO_CATALOG_ID,
@@ -590,7 +590,7 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 		note:         noteForCreate(criticalTableID, "critical"),
 		bat:          newInt64BatchForTest(t, proc, []string{"pk"}, []int64{1}),
 	})
-	txn.writes = append(txn.writes, Entry{
+	txn.appendWorkspaceEntryLocked(Entry{
 		typ:          INSERT,
 		tableId:      criticalTableID,
 		databaseId:   dbID,
@@ -622,15 +622,14 @@ func TestMergeTxnWorkspaceDeduplicatesDeleteSelections(t *testing.T) {
 		proc:            proc,
 		deletedBlocks:   &deletedBlocks{offsets: make(map[types.Blockid][]int64)},
 		batchSelectList: make(map[*batch.Batch][]int64),
-		writes: []Entry{{
-			typ:        INSERT,
-			tableId:    42,
-			databaseId: 7,
-			bat:        bat,
-		}},
-		approximateInMemInsertCnt: bat.RowCount(),
 	}
-	defer bat.Clean(proc.Mp())
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:        INSERT,
+		tableId:    42,
+		databaseId: 7,
+		bat:        bat,
+	})
+	defer txn.releaseWorkspaceEntryBatchLocked(0)
 
 	// Two internal delete passes select the same rows. Their raw event count
 	// equals the batch row count, but only half of the rows are deleted.
@@ -642,6 +641,192 @@ func TestMergeTxnWorkspaceDeduplicatesDeleteSelections(t *testing.T) {
 	require.Equal(t, 2, bat.RowCount())
 	require.Equal(t, []int64{10, 30}, vector.MustFixedColWithTypeCheck[int64](bat.Vecs[1]))
 	require.Equal(t, 2, txn.approximateInMemInsertCnt)
+	require.NoError(t, txn.checkWorkspaceAccountingLocked())
+}
+
+func TestIssue25589RollbackLastStatementRestoresWorkspaceAccounting(t *testing.T) {
+	proc := testutil.NewProc(t)
+	op := newTxnOperatorForTest(t)
+	op.EXPECT().EnterRollbackStmt()
+	op.EXPECT().ExitRollbackStmt()
+	txn := &Transaction{
+		op:              op,
+		proc:            proc,
+		tableCache:      new(sync.Map),
+		tableOps:        newTableOps(),
+		databaseOps:     newDbOps(),
+		batchSelectList: make(map[*batch.Batch][]int64),
+		deletedBlocks:   &deletedBlocks{offsets: make(map[types.Blockid][]int64)},
+		isCCPRTxn:       true,
+	}
+
+	committed := newInsertBatchWithRowIDForTest(t, proc, []int64{1, 2})
+	rolledBack := newInsertBatchWithRowIDForTest(t, proc, []int64{3, 4, 5})
+	rolledBackDelete := newDeleteBatchForTest(t, proc, []int64{1, 2})
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: committed})
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: rolledBack})
+	txn.appendWorkspaceEntryLocked(Entry{typ: DELETE, databaseId: 7, tableId: 42, bat: rolledBackDelete})
+	txn.statementID = 1
+	txn.offsets = []int{1}
+
+	require.NoError(t, txn.RollbackLastStatement(context.Background()))
+	require.Len(t, txn.writes, 1)
+	require.Same(t, committed, txn.writes[0].bat)
+	require.Equal(t, uint64(committed.Size()), txn.workspaceSize)
+	require.Equal(t, uint64(committed.Size()), txn.approximateInMemInsertSize)
+	require.Equal(t, committed.RowCount(), txn.approximateInMemInsertCnt)
+	require.Zero(t, txn.approximateInMemDeleteCnt)
+	require.NoError(t, txn.checkWorkspaceAccountingLocked())
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+}
+
+func TestIssue25589MergeTxnWorkspaceRestoresAccountingForTablesInVain(t *testing.T) {
+	proc := testutil.NewProc(t)
+	bat := newInsertBatchWithRowIDForTest(t, proc, []int64{1, 2, 3})
+	txn := &Transaction{
+		proc:            proc,
+		tablesInVain:    map[uint64]int{42: 1},
+		batchSelectList: make(map[*batch.Batch][]int64),
+		deletedBlocks:   &deletedBlocks{offsets: make(map[types.Blockid][]int64)},
+	}
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: bat})
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Nil(t, txn.writes[0].bat)
+	require.Zero(t, txn.workspaceSize)
+	require.Zero(t, txn.approximateInMemInsertSize)
+	require.Zero(t, txn.approximateInMemInsertCnt)
+	require.NoError(t, txn.checkWorkspaceAccountingLocked())
+}
+
+func TestIssue25589MergeTxnWorkspaceRestoresAccountingAfterShrink(t *testing.T) {
+	proc := testutil.NewProc(t)
+	bat := newInsertBatchWithRowIDForTest(t, proc, []int64{1, 2, 3, 4})
+	txn := &Transaction{
+		proc:            proc,
+		tablesInVain:    make(map[uint64]int),
+		batchSelectList: map[*batch.Batch][]int64{bat: {1, 3}},
+		deletedBlocks:   &deletedBlocks{offsets: make(map[types.Blockid][]int64)},
+	}
+	txn.appendWorkspaceEntryLocked(Entry{typ: INSERT, databaseId: 7, tableId: 42, bat: bat})
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Equal(t, 2, bat.RowCount())
+	require.Equal(t, uint64(bat.Size()), txn.workspaceSize)
+	require.Equal(t, uint64(bat.Size()), txn.approximateInMemInsertSize)
+	require.Equal(t, bat.RowCount(), txn.approximateInMemInsertCnt)
+	require.NoError(t, txn.checkWorkspaceAccountingLocked())
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+}
+
+func TestIssue25589MergeTxnWorkspacePreservesAccountingWhenCombiningBatches(t *testing.T) {
+	proc := testutil.NewProc(t)
+	txn := &Transaction{
+		proc:            proc,
+		tablesInVain:    make(map[uint64]int),
+		batchSelectList: make(map[*batch.Batch][]int64),
+		deletedBlocks:   &deletedBlocks{offsets: make(map[types.Blockid][]int64)},
+	}
+	txn.currentRowId.SetSegment(colexec.TxnWorkspaceSegment)
+
+	for i := 0; i < 30; i++ {
+		txn.appendWorkspaceEntryLocked(Entry{
+			typ:        INSERT,
+			databaseId: 7,
+			tableId:    42,
+			bat:        newInsertBatchWithRowIDForTest(t, proc, []int64{int64(i)}),
+		})
+	}
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Len(t, txn.writes, 1)
+	require.Equal(t, 30, txn.writes[0].bat.RowCount())
+	require.Equal(t, uint64(txn.writes[0].bat.Size()), txn.workspaceSize)
+	require.Equal(t, uint64(txn.writes[0].bat.Size()), txn.approximateInMemInsertSize)
+	require.Equal(t, 30, txn.approximateInMemInsertCnt)
+	require.NoError(t, txn.checkWorkspaceAccountingLocked())
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
+}
+
+func TestIssue25589DumpInsertRestoresWorkspaceAccounting(t *testing.T) {
+	colexec.NewServer("")
+	txn := newTransactionWithActivePKTableForTest(t, "pk")
+	tbl := txn.tableOps.existAndActive(genTableKey(1, "tbl", 7, "db"))
+	require.NotNil(t, tbl)
+	tbl.tableDef.Cols[0].Typ = pbplan.Type{Id: int32(types.T_int64)}
+	txn.tnStores = []DNStore{{}}
+	txn.batchSelectList = make(map[*batch.Batch][]int64)
+	txn.tablesInVain = make(map[uint64]int)
+	txn.deletedBlocks = &deletedBlocks{offsets: make(map[types.Blockid][]int64)}
+	txn.cnObjsSummary = make(map[types.Objectid]Summary)
+	txn.currentRowId.SetSegment(colexec.TxnWorkspaceSegment)
+	txn.appendWorkspaceEntryLocked(Entry{
+		typ:          INSERT,
+		accountId:    1,
+		databaseId:   7,
+		tableId:      42,
+		databaseName: "db",
+		tableName:    "tbl",
+		bat:          newInsertBatchWithRowIDForTest(t, txn.proc, []int64{1, 2, 3}),
+	})
+
+	fs, err := colexec.GetSharedFSFromProc(txn.proc)
+	require.NoError(t, err)
+	var pkCount int
+	txn.Lock()
+	err = txn.dumpInsertBatchLocked(context.Background(), fs, 0, &pkCount)
+	txn.Unlock()
+	require.NoError(t, err)
+	require.Equal(t, 3, pkCount)
+	require.Zero(t, txn.approximateInMemInsertSize)
+	require.Zero(t, txn.approximateInMemInsertCnt)
+	require.NoError(t, txn.checkWorkspaceAccountingLocked())
+
+	for i := range txn.writes {
+		txn.releaseWorkspaceEntryBatchLocked(i)
+	}
+}
+
+func TestIssue25589SoftDeleteObjectUsesWorkspaceAccounting(t *testing.T) {
+	proc := testutil.NewProc(t)
+	txn := &Transaction{
+		proc:            proc,
+		tnStores:        []DNStore{{}},
+		batchSelectList: make(map[*batch.Batch][]int64),
+	}
+	op := newTxnOperatorForTestWithWorkspace(t, txn)
+	op.EXPECT().IsSnapOp().Return(false)
+	txn.op = op
+	tbl := &txnTable{
+		accountId: 1,
+		tableId:   42,
+		tableName: "tbl",
+		extraInfo: &api.SchemaExtra{},
+		db: &txnDatabase{
+			op:           op,
+			databaseId:   7,
+			databaseName: "db",
+		},
+	}
+	rowID := types.RandomRowid()
+
+	require.NoError(t, tbl.SoftDeleteObject(
+		context.Background(),
+		rowID.BorrowObjectID(),
+		false,
+	))
+	require.Len(t, txn.writes, 1)
+	require.Equal(t, SOFT_DELETE_OBJECT, txn.writes[0].typ)
+	require.Equal(t, uint64(txn.writes[0].bat.Size()), txn.workspaceSize)
+	require.Zero(t, txn.approximateInMemInsertSize)
+	require.Zero(t, txn.approximateInMemInsertCnt)
+	require.Zero(t, txn.approximateInMemDeleteCnt)
+	require.NoError(t, txn.checkWorkspaceAccountingLocked())
+
+	txn.releaseWorkspaceEntryBatchLocked(0)
 }
 
 func TestResolvePKCheckPosForWriteWithActiveTxnTable(t *testing.T) {
@@ -1687,10 +1872,9 @@ func TestIssue25557_LockedDumpInsertBatchReentrantGetTableDoesNotDeadlock(t *tes
 	go func() {
 		txn.Lock()
 		defer txn.Unlock()
-		var size uint64
 		var pkCount int
 		errCh <- txn.dumpInsertBatchLocked(
-			context.Background(), fs, 0, &size, &pkCount)
+			context.Background(), fs, 0, &pkCount)
 	}()
 
 	select {
@@ -1743,8 +1927,7 @@ func TestIssue25557_DumpDeleteBatchReentrantGetTableDoesNotDeadlock(t *testing.T
 	go func() {
 		txn.Lock()
 		defer txn.Unlock()
-		var size uint64
-		errCh <- txn.dumpDeleteBatchLocked(context.Background(), fs, 0, &size)
+		errCh <- txn.dumpDeleteBatchLocked(context.Background(), fs, 0)
 	}()
 
 	select {

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -1189,8 +1189,7 @@ func (txn *Transaction) RollbackLastStatement(ctx context.Context) error {
 			if txn.writes[i].bat == nil {
 				continue
 			}
-			txn.workspaceSize -= uint64(txn.writes[i].bat.Size())
-			txn.writes[i].bat.Clean(txn.proc.Mp())
+			txn.releaseWorkspaceEntryBatchLocked(i)
 		}
 		txn.writes = txn.writes[:end]
 		txn.offsets = txn.offsets[:txn.statementID]
@@ -1207,6 +1206,7 @@ func (txn *Transaction) RollbackLastStatement(ctx context.Context) error {
 			}
 		}
 	}
+	txn.assertWorkspaceAccountingLocked()
 	// rollback current statement's writes info
 	for b := range txn.batchSelectList {
 		delete(txn.batchSelectList, b)
@@ -1280,9 +1280,13 @@ type Entry struct {
 	// blockName for s3 file
 	fileName string
 	//tuples would be applied to the table which belongs to the tenant(accountId)
-	bat       *batch.Batch
-	tnStore   DNStore
-	pkChkByTN int8
+	bat *batch.Batch
+	// accountedSize is the batch size currently included in workspaceSize.
+	// Keeping it on the entry lets in-place mutations remove the old
+	// contribution before accounting for the batch's new state.
+	accountedSize uint64
+	tnStore       DNStore
+	pkChkByTN     int8
 	// autoIncrEpoch is the allocator epoch used to plan this user-table write.
 	// autoIncrEpochKnown distinguishes a valid initial zero epoch from an
 	// old CN that did not send the dependency.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #25589

## What this PR does / why we need it:

### Root cause

Workspace accounting was updated independently at mutation sites instead of being owned by each live `Entry`. `RollbackLastStatement` removed batches without decrementing the approximate insert counters, selection shrink only decremented row count, and `tablesInVain` cleanup released batches without decrementing any counters. Dump and batch-merge paths had the same structural risk because they transformed or removed entries while updating only part of the transaction totals.

The stale values feed workspace thresholds, quota acquisition, commit flushing, and `BIG-TXN` logging, so transactions could make resource decisions from data that no longer existed.

### Changes

- Add per-entry `accountedSize` state and transaction-owned helpers for workspace append, unaccount, release, shrink, and batch merge.
- Route every production workspace append and batch-removal path through those helpers, including raw writes, file-backed writes, ALTER transfer, soft-delete entries, dump, rollback, dropped-table invalidation, object compaction, and terminal cleanup.
- Recompute accounting from the actual post-shrink/post-merge batch state; reject underflow, double-accounting, and mutation outside the accounting helpers instead of masking drift.
- Preserve main's #26584 selection-set normalization at insertion/full-selection boundaries, then route the normalized selection through the centralized shrink-accounting helper.
- Add a debug invariant that compares all four counters with the surviving entries after merge, table invalidation, dump, rollback, and final cleanup.
- Construct invariant failures with `moerr.NewInternalErrorNoCtxf`, matching the repository error convention and the SCA `err-check` rule.
- Add deterministic unit regressions for statement rollback (including delete rows), `tablesInVain`, partial shrink, batch merge, S3 dump, and soft-delete append. Existing clone-GC tests now create affected entries through the same accounting path.

### Validation

- Pre-fix `TestIssue25589*`: reproduced all three reported mismatches (160 B retained after rollback, 96 B retained after table invalidation, and 128 B retained after shrink).
- Post-rebase focused run covering all 13 affected tests (the six issue regressions, selection deduplication, clone-GC/local-state cleanup, catalog ordering, and dump deadlock regressions): passed.
- Each of those 13 exact tests under `-race -count=100`: passed. Measured single-run race durations were 0-0.02 s; a 30 s adaptive budget therefore capped every repetition count at 100.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=20m ./pkg/vm/engine/disttae` (post-rebase): passed in 10.224 s.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=30m ./pkg/vm/engine/disttae` (post-rebase): passed in 13.053 s.
- `CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib" GOWORK=off go build -mod=readonly ./pkg/vm/engine/disttae`: passed.
- `CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib" GOWORK=off go vet -mod=readonly ./pkg/vm/engine/disttae`: passed.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=5m -run '^Test_BasicRollbackStatement$' ./pkg/vm/engine/test`: passed before the rebase; the rebase did not touch this package.
- `make err-check`: passed before the rebase; the rebase preserved the checked error construction.

### Test strategy and residual risk

No BVT is added because these counters are internal transaction state and have no deterministic SQL result oracle; the production symptom is threshold-dependent logging. Focused same-package unit tests assert the exact counters, and the engine rollback test covers the dependent transaction path. Main's #26584 BVT expectation correction is already in the base and is not part of this PR's diff; the semantic conflict resolution preserves its normalized selection behavior.

There is no wire, catalog, or on-disk format change. The invariant scan only runs when debug logging is enabled. This PR intentionally does not change workspace entry compaction or transaction semantics beyond conserving accounting for the entries that already survive each operation.
