### PR TITLE
fix(disttae): deduplicate workspace row selections

### DIFF
--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -1733,6 +1733,20 @@ func (txn *Transaction) deleteBatch(
 	return bat
 }
 
+func (txn *Transaction) addBatchSelectionsLocked(bat *batch.Batch, sels []int64) {
+	selections := append(txn.batchSelectList[bat], sels...)
+	slices.Sort(selections)
+	txn.batchSelectList[bat] = slices.Compact(selections)
+}
+
+func (txn *Transaction) selectAllBatchRowsLocked(bat *batch.Batch) {
+	selections := txn.batchSelectList[bat][:0]
+	for i := range bat.RowCount() {
+		selections = append(selections, int64(i))
+	}
+	txn.batchSelectList[bat] = selections
+}
+
 // Delete rows belongs to uncommitted raw data batch in txn's workspace.
 func (txn *Transaction) deleteTableWrites(
 	databaseId uint64,
@@ -1790,7 +1804,7 @@ func (txn *Transaction) deleteTableWrites(
 			}
 		}
 		if len(sels) > 0 {
-			txn.batchSelectList[entry.bat] = append(txn.batchSelectList[entry.bat], sels...)
+			txn.addBatchSelectionsLocked(entry.bat, sels)
 		}
 	}
 }
@@ -1856,8 +1870,10 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 	if len(txn.batchSelectList) > 0 {
 		for _, e := range txn.writes {
 			if sels, ok := txn.batchSelectList[e.bat]; ok {
-				txn.approximateInMemInsertCnt -= len(sels)
+				// Repeated internal deletes can select the same workspace row more than once.
 				slices.Sort(sels)
+				sels = slices.Compact(sels)
+				txn.approximateInMemInsertCnt -= len(sels)
 				shrinkBatchWithRowids(e.bat, sels)
 				delete(txn.batchSelectList, e.bat)
 			}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1841,9 +1841,7 @@ func (tbl *txnTable) AlterTable(ctx context.Context, c *engine.ConstraintDef, re
 				if err != nil {
 					return err
 				}
-				for j := 0; j < cur.bat.RowCount(); j++ {
-					txn.batchSelectList[cur.bat] = append(txn.batchSelectList[cur.bat], int64(j))
-				}
+				txn.selectAllBatchRowsLocked(cur.bat)
 
 			}
 		}

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -615,6 +615,35 @@ func TestMergeTxnWorkspaceKeepsCatalogBeforeDependentData(t *testing.T) {
 	require.Less(t, createIdx, dataIdx)
 }
 
+func TestMergeTxnWorkspaceDeduplicatesDeleteSelections(t *testing.T) {
+	proc := testutil.NewProc(t)
+	bat := newInsertBatchWithRowIDForTest(t, proc, []int64{10, 20, 30, 40})
+	txn := &Transaction{
+		proc:            proc,
+		deletedBlocks:   &deletedBlocks{offsets: make(map[types.Blockid][]int64)},
+		batchSelectList: make(map[*batch.Batch][]int64),
+		writes: []Entry{{
+			typ:        INSERT,
+			tableId:    42,
+			databaseId: 7,
+			bat:        bat,
+		}},
+		approximateInMemInsertCnt: bat.RowCount(),
+	}
+	defer bat.Clean(proc.Mp())
+
+	// Two internal delete passes select the same rows. Their raw event count
+	// equals the batch row count, but only half of the rows are deleted.
+	txn.addBatchSelectionsLocked(bat, []int64{1, 3})
+	txn.addBatchSelectionsLocked(bat, []int64{1, 3})
+	require.Equal(t, []int64{1, 3}, txn.batchSelectList[bat])
+
+	require.NoError(t, txn.mergeTxnWorkspaceLocked(context.Background()))
+	require.Equal(t, 2, bat.RowCount())
+	require.Equal(t, []int64{10, 30}, vector.MustFixedColWithTypeCheck[int64](bat.Vecs[1]))
+	require.Equal(t, 2, txn.approximateInMemInsertCnt)
+}
+
 func TestResolvePKCheckPosForWriteWithActiveTxnTable(t *testing.T) {
 	txn := newTransactionWithActivePKTableForTest(t, "pk")
 

--- a/test/distributed/cases/git4data/clone/clone_in_alter_table_2.result
+++ b/test/distributed/cases/git4data/clone/clone_in_alter_table_2.result
@@ -260,7 +260,7 @@ ft_tag_body  ¦  FULLTEXT  ¦  doc_body,tag  ¦  fulltext  ¦    ¦  -  𝄀
 ft_title_body  ¦  FULLTEXT  ¦  doc_body,title  ¦  fulltext  ¦    ¦  -  𝄀
 idx_account_status  ¦  MULTIPLE  ¦  account_id,status  ¦    ¦    ¦  -  𝄀
 idx_embedding  ¦  MULTIPLE  ¦  embedding  ¦  ivfflat  ¦  centroids,entries,metadata  ¦  {"lists":"3","op_type":"vector_cosine_ops"}  𝄀
-idx_tenant_shard  ¦  MULTIPLE  ¦  tenant  ¦    ¦    ¦  -  𝄀
+idx_tenant_shard  ¦  MULTIPLE  ¦  shard,tenant  ¦    ¦    ¦  -  𝄀
 uk_tenant_doc  ¦  UNIQUE  ¦  doc_code,tenant  ¦    ¦    ¦  -
 drop table t4;
 SET experimental_fulltext_index = 0;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26582

## What this PR does / why we need it:

### Root cause

`batchSelectList` records workspace rows removed by internal deletes. Repeated ALTER/index metadata operations can select the same row more than once. In the reproduced case, one 14-row `mo_indexes` batch accumulated `[10 11 12]` three times.

`mergeTxnWorkspaceLocked` sorted that list but did not deduplicate it. Both `Batch.Shrink(..., true)` and `approximateInMemInsertCnt` therefore treated nine selection events as nine distinct rows. The over-shrink removed the `shard` row of `idx_tenant_shard`. Before merge, readers also used `len(sels) == RowCount()` as the all-rows-deleted test, so duplicate events could hide a partially live batch when their raw count happened to equal the batch row count.

The SQL declares `idx_tenant_shard (tenant, shard)`, and its catalog query orders `group_concat` by column name. The complete result is therefore `shard,tenant`; the prior `tenant` expectation encoded the over-shrink.

### Changes

- Keep additive workspace selections sorted and unique at their ownership boundary.
- Represent ALTER's full-batch selection as the exact row range instead of appending it to an existing list.
- Defensively compact selections again before merge accounting and physical shrink.
- Add a unit regression where two delete passes produce four raw events for a four-row batch but only two distinct rows; verify the batch remains visible before merge, the correct rows survive merge, and the insert count stays consistent.
- Update the repeated ALTER/clone BVT expectation to the semantically complete `shard,tenant` metadata.

### Validation

- `make build`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s -run '^TestMergeTxnWorkspaceDeduplicatesDeleteSelections$' ./pkg/vm/engine/disttae`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=20m ./pkg/vm/engine/disttae`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=5m -run '^TestMergeTxnWorkspaceDeduplicatesDeleteSelections$' ./pkg/vm/engine/disttae`
- Fresh standalone pessimistic BVT: `clone_in_alter_table_2.sql` passed 87/87 with 0 failures and the complete `shard,tenant` result.
- Manually inspected the BVT expectation against the declared composite index and the query's explicit alphabetical ordering; no tester-generated result was accepted as authoritative.

### Compatibility and residual risk

There is no API, wire, catalog schema, or on-disk format change. Selection normalization is in-place after the existing append/sort flow, bounds retained selections by batch row count, and remains under the transaction lock. No resource ownership or wait dependency changes.

Open PR #26581 independently compacts selections inside a broader workspace-accounting refactor and exposed this stale BVT expectation. This PR isolates the selection-set correctness fix on `main`; if #26581 lands first, the overlapping merge helper line will need the same semantic resolution during rebase.
