### PR TITLE
fix: reserve hashbuild spill recovery budget

### DIFF
--- a/pkg/container/types/packer.go
+++ b/pkg/container/types/packer.go
@@ -30,6 +30,8 @@ type Packer struct {
 	bufferDeallocator malloc.Deallocator
 }
 
+const defaultPackerSize = uint64(4096)
+
 var packerAllocator = malloc.NewShardedAllocator(
 	runtime.GOMAXPROCS(0),
 	func() malloc.Allocator {
@@ -40,7 +42,7 @@ var packerAllocator = malloc.NewShardedAllocator(
 )
 
 func NewPacker() *Packer {
-	return NewPackerWithSize(4096)
+	return NewPackerWithSize(defaultPackerSize)
 }
 
 // PackerAllocationSize returns the backing size-class allocation made by
@@ -48,6 +50,45 @@ func NewPacker() *Packer {
 // allocation, including allocator rounding, before constructing a packer.
 func PackerAllocationSize(size uint64) (uint64, bool) {
 	return malloc.ClassAllocationSize(size)
+}
+
+// DefaultPackerCapacity returns the backing capacity retained by NewPacker.
+// Memory-governed callers use this value to admit construction before the
+// allocator is entered.
+func DefaultPackerCapacity() uint64 {
+	size, ok := PackerAllocationSize(defaultPackerSize)
+	if !ok {
+		panic("invalid default packer size")
+	}
+	return size
+}
+
+// PackerCapacityUpperBound bounds the backing capacity retained after any
+// sequence of Reset and append operations whose logical buffer length never
+// exceeds maxLength and whose individual append never exceeds maxAppend.
+//
+// ensureSizeSlow requests cap(buffer)+append from the class allocator. At a
+// growth point the old capacity is strictly less than maxLength, so the
+// request is at most maxLength+maxAppend-1. If the old capacity already covers
+// maxLength, no growth occurs. This mirrors the allocator contract without
+// replaying input-dependent append sequences in an admission hot path.
+func PackerCapacityUpperBound(maxLength, maxAppend uint64) (uint64, bool) {
+	initial := DefaultPackerCapacity()
+	if maxLength <= initial {
+		return initial, true
+	}
+	if maxAppend == 0 || maxLength > math.MaxUint64-maxAppend+1 {
+		return 0, false
+	}
+	request := maxLength + maxAppend - 1
+	capacity, ok := PackerAllocationSize(request)
+	if !ok {
+		return 0, false
+	}
+	if capacity < initial {
+		return initial, true
+	}
+	return capacity, true
 }
 
 func NewPackerWithSize(size uint64) *Packer {
@@ -62,7 +103,7 @@ func NewPackerWithSize(size uint64) *Packer {
 }
 
 func NewPackerArray(length int) []*Packer {
-	return NewPackerArrayWithSize(length, 4096)
+	return NewPackerArrayWithSize(length, defaultPackerSize)
 }
 
 func NewPackerArrayWithSize(length int, size uint64) []*Packer {
@@ -82,6 +123,14 @@ func (p *Packer) Close() {
 
 func (p *Packer) Reset() {
 	p.buffer = p.buffer[:0]
+}
+
+// Allocated returns the size-class capacity retained by the packer.
+func (p *Packer) Allocated() uint64 {
+	if p == nil {
+		return 0
+	}
+	return uint64(cap(p.buffer))
 }
 
 func (p *Packer) ensureSize(n int) {

--- a/pkg/container/types/packer_test.go
+++ b/pkg/container/types/packer_test.go
@@ -14,7 +14,12 @@
 
 package types
 
-import "testing"
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestPacker(t *testing.T) {
 	packer := NewPacker()
@@ -39,6 +44,42 @@ func TestClosedPackerIsOK(t *testing.T) {
 		t.Fatalf("got %v", len(bs))
 	}
 	packer.Close()
+}
+
+func TestPackerCapacityUpperBoundCoversGrowthAndReuse(t *testing.T) {
+	const (
+		columns = 4
+		width   = 65535
+	)
+	component := uint64(2*width + 3)
+	maxLength := uint64(columns) * component
+	bound, ok := PackerCapacityUpperBound(maxLength, component)
+	require.True(t, ok)
+	require.Equal(t, uint64(1<<20), bound)
+
+	packer := NewPacker()
+	require.Equal(t, DefaultPackerCapacity(), packer.Allocated())
+	value := make([]byte, width)
+	for range 2 {
+		packer.Reset()
+		for range columns {
+			packer.EncodeStringType(value)
+		}
+		require.Equal(t, int(maxLength), len(packer.GetBuf()))
+		require.LessOrEqual(t, packer.Allocated(), bound)
+	}
+	packer.Close()
+	require.Zero(t, packer.Allocated())
+
+	initial := DefaultPackerCapacity()
+	got, ok := PackerCapacityUpperBound(initial, initial)
+	require.True(t, ok)
+	require.Equal(t, initial, got)
+	got, ok = PackerCapacityUpperBound(initial+1, 1)
+	require.True(t, ok)
+	require.Equal(t, 2*initial, got)
+	_, ok = PackerCapacityUpperBound(math.MaxUint64, 2)
+	require.False(t, ok)
 }
 
 func BenchmarkPacker(b *testing.B) {

--- a/pkg/container/vector/pSpoolTools.go
+++ b/pkg/container/vector/pSpoolTools.go
@@ -16,17 +16,24 @@ package vector
 
 // SetVecData is dangerous and should be used with caution.
 func SetVecData(v *Vector, data []byte) {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	data = data[:cap(data)]
 	v.data = data
 }
 
 // SetVecArea is dangerous and should be used with caution.
 func SetVecArea(v *Vector, area []byte) {
+	v.areaDisjoint = false
 	v.area = area
 }
 
 // GetAndClearVecData is a dangerous function that may cause data leakage.
 func GetAndClearVecData(v *Vector) []byte {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	s := v.data
 	v.data = nil
 	return s
@@ -34,6 +41,7 @@ func GetAndClearVecData(v *Vector) []byte {
 
 // GetAndClearVecArea is a dangerous function that may cause data leakage.
 func GetAndClearVecArea(v *Vector) []byte {
+	v.areaDisjoint = false
 	s := v.area
 	v.area = nil
 	return s

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -67,6 +67,13 @@ type Vector struct {
 	isBin bool
 
 	offHeap bool
+
+	// areaDisjoint is true only when every non-inline varlena descriptor in the
+	// vector's logical range references a valid byte range disjoint from every
+	// other descriptor in that range. The invariant deliberately includes null
+	// rows, so changing a null bitmap cannot make this proof stale. Operations
+	// that reuse descriptors clear the proof; ordinary value appends retain it.
+	areaDisjoint bool
 }
 
 func toSliceOfLengthNoTypeCheck[T any](vec *Vector, length int) []T {
@@ -130,6 +137,7 @@ func (v *Vector) Reset(typ types.Type) {
 	v.nsp.Clear()
 	v.gsp.Clear()
 	v.sorted = false
+	v.areaDisjoint = true
 }
 
 func (v *Vector) ResetWithSameType() {
@@ -141,10 +149,12 @@ func (v *Vector) ResetWithSameType() {
 	v.nsp.Reset()
 	v.gsp.Reset()
 	v.sorted = false
+	v.areaDisjoint = true
 }
 
 func (v *Vector) ResetArea() {
 	v.area = v.area[:0]
+	v.areaDisjoint = v.length == 0
 }
 
 // TODO: It is semantically same as Reset, need to merge them later.
@@ -158,6 +168,7 @@ func (v *Vector) ResetWithNewType(t *types.Type) {
 	v.gsp.Clear()
 	v.length = 0
 	v.sorted = false
+	v.areaDisjoint = true
 }
 
 func (v *Vector) UnsafeGetRawData() []byte {
@@ -187,6 +198,9 @@ func (v *Vector) Allocated() int {
 }
 
 func (v *Vector) SetLength(n int) {
+	if v.typ.IsVarlen() && n != v.length {
+		v.areaDisjoint = false
+	}
 	v.length = n
 }
 
@@ -205,6 +219,11 @@ func (v *Vector) GetType() *types.Type {
 // but did not change the underlying data.   So the length
 // and capacity are all messed up.
 func (v *Vector) SetType(typ types.Type) {
+	if v.typ.IsVarlen() || typ.IsVarlen() {
+		// An empty logical range has no descriptors, even if reusable backing
+		// storage still contains stale bytes.
+		v.areaDisjoint = v.length == 0
+	}
 	v.typ = typ
 }
 
@@ -358,6 +377,7 @@ func (v *Vector) CleanOnlyData() {
 	v.nsp.Clear()
 	v.gsp.Clear()
 	v.sorted = false
+	v.areaDisjoint = v.length == 0
 }
 
 // no copy. it is unsafe if the user cannot determine the vector's life
@@ -472,6 +492,7 @@ func NewVec(typ types.Type) *Vector {
 	vec := NewVecFromReuse()
 	vec.typ = typ
 	vec.class = FLAT
+	vec.areaDisjoint = true
 	return vec
 }
 
@@ -486,12 +507,14 @@ func NewOffHeapVecWithTypeAndData(typ types.Type, data []byte, length, cap int) 
 	vec.offHeap = true
 	vec.data = data
 	vec.length = length
+	vec.areaDisjoint = !typ.IsVarlen() || length == 0
 	return vec
 }
 
 func NewOffHeapVec() *Vector {
 	vec := NewVecFromReuse()
 	vec.offHeap = true
+	vec.areaDisjoint = true
 	return vec
 }
 
@@ -505,6 +528,7 @@ func NewVecWithData(
 	vec.length = length
 	vec.data = data
 	vec.area = area
+	vec.areaDisjoint = !typ.IsVarlen() || length == 0
 	return vec
 }
 
@@ -518,6 +542,7 @@ func NewVecWithDataCopy(
 ) (*Vector, error) {
 	vec := NewVec(typ)
 	vec.length = length
+	vec.areaDisjoint = !typ.IsVarlen() || length == 0
 	var err error
 	if len(data) > 0 {
 		vec.data, err = mp.Alloc(len(data), false)
@@ -601,6 +626,9 @@ func (v *Vector) IsGrouping() bool {
 }
 
 func (v *Vector) SetClass(class int) {
+	if v.typ.IsVarlen() && class != v.class {
+		v.areaDisjoint = v.length == 0
+	}
 	v.class = class
 }
 
@@ -624,6 +652,10 @@ func (v *Vector) UnsetNull(i uint64) {
 
 // call this function if type already checked
 func SetFixedAtNoTypeCheck[T types.FixedSizeT](v *Vector, idx int, t T) error {
+	if v.typ.IsVarlen() {
+		// A caller-provided varlena descriptor can alias an existing area range.
+		v.areaDisjoint = false
+	}
 	vacol := MustFixedColNoTypeCheck[T](v)
 	if idx < 0 {
 		idx = len(vacol) + idx
@@ -638,6 +670,10 @@ func SetFixedAtNoTypeCheck[T types.FixedSizeT](v *Vector, idx int, t T) error {
 // Note:
 // it is 10x slower than SetFixedAtNoTypeCheck
 func SetFixedAtWithTypeCheck[T types.FixedSizeT](v *Vector, idx int, t T) error {
+	if v.typ.IsVarlen() {
+		// A caller-provided varlena descriptor can alias an existing area range.
+		v.areaDisjoint = false
+	}
 	// Let it panic if v is not a varlena vec
 	vacol := MustFixedColWithTypeCheck[T](v)
 
@@ -652,12 +688,21 @@ func SetFixedAtWithTypeCheck[T types.FixedSizeT](v *Vector, idx int, t T) error 
 }
 
 func SetBytesAt(v *Vector, idx int, bs []byte, mp *mpool.MPool) error {
+	disjoint := v.areaDisjoint
 	var va types.Varlena
 	err := BuildVarlenaFromByteSlice(v, &va, &bs, mp)
 	if err != nil {
 		return err
 	}
-	return SetFixedAtWithTypeCheck(v, idx, va)
+	if err = SetFixedAtWithTypeCheck(v, idx, va); err != nil {
+		return err
+	}
+	// SetBytesAt appends a fresh area range before replacing the descriptor;
+	// it cannot introduce an alias into a previously disjoint vector.
+	if disjoint {
+		v.areaDisjoint = true
+	}
+	return nil
 }
 
 func SetStringAt(v *Vector, idx int, bs string, mp *mpool.MPool) error {
@@ -690,6 +735,14 @@ func (v *Vector) IsConstNull() bool {
 
 func (v *Vector) GetArea() []byte {
 	return v.area
+}
+
+// VarlenaAreaIsDisjoint reports whether logical non-inline payload is bounded
+// by the vector's physical area without inspecting its descriptors. Const
+// vectors intentionally do not expose this proof because broadcasting one
+// descriptor changes logical materialization multiplicity.
+func (v *Vector) VarlenaAreaIsDisjoint() bool {
+	return v != nil && v.typ.IsVarlen() && !v.IsConst() && v.areaDisjoint
 }
 
 func (v *Vector) GetData() []byte {
@@ -727,6 +780,7 @@ func (v *Vector) Free(mp *mpool.MPool) {
 	v.gsp.Reset()
 	v.sorted = false
 	v.isBin = false
+	v.areaDisjoint = true
 
 	// if !v.OnUsed || v.OnPut {
 	// 	panic("free vector which unalloc or in put list")
@@ -820,6 +874,7 @@ func (v *Vector) UnmarshalBinaryTrusted(data []byte) error {
 }
 
 func (v *Vector) unmarshalBinary(data []byte, validateValues bool) error {
+	v.areaDisjoint = false
 	read := func(size int) ([]byte, error) {
 		if size < 0 || size > len(data) {
 			return nil, io.ErrUnexpectedEOF
@@ -1023,6 +1078,7 @@ func canonicalVectorTypeSize(typ types.Type) (int, error) {
 }
 
 func (v *Vector) UnmarshalBinaryWithCopy(data []byte, mp *mpool.MPool) error {
+	v.areaDisjoint = false
 	var err error
 
 	// read class
@@ -1080,6 +1136,7 @@ func (v *Vector) UnmarshalBinaryWithCopy(data []byte, mp *mpool.MPool) error {
 }
 
 func (v *Vector) UnmarshalWithReader(r io.Reader, mp *mpool.MPool) error {
+	v.areaDisjoint = false
 	var err error
 
 	if v.class, err = types.ReadByteAsInt(r); err != nil {
@@ -1134,6 +1191,10 @@ func (v *Vector) UnmarshalWithReader(r io.Reader, mp *mpool.MPool) error {
 }
 
 func (v *Vector) ToConst() {
+	if v.typ.IsVarlen() {
+		// A constant's single physical descriptor is logically broadcast.
+		v.areaDisjoint = false
+	}
 	v.class = CONSTANT
 }
 
@@ -1229,6 +1290,7 @@ func (v *Vector) dup(mp *mpool.MPool, offHeap, areaOffHeap bool) (*Vector, error
 		}
 		copy(w.area, v.area)
 	}
+	w.areaDisjoint = v.areaDisjoint
 	return w, nil
 }
 
@@ -1298,6 +1360,7 @@ func (v *Vector) CloneToFlatCompact(mp *mpool.MPool) (*Vector, error) {
 		dst[i].SetOffsetLen(uint32(offset), uint32(len(value)))
 		offset += len(value)
 	}
+	w.areaDisjoint = true
 	return w, nil
 }
 
@@ -1317,6 +1380,9 @@ func copyBitmapWithinLength(dst, src *nulls.Nulls, length int) {
 
 // Shrink use to shrink vectors, sels must be guaranteed to be ordered
 func (v *Vector) Shrink(sels []int64, negate bool) {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 
 	shrinkSortedCheckIfRaceDetectorEnabled(sels)
 
@@ -1392,6 +1458,9 @@ func (v *Vector) Shrink(sels []int64, negate bool) {
 }
 
 func (v *Vector) ShrinkByMask(sels *bitmap.Bitmap, negate bool, offset uint64) {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	if v.IsConst() {
 		if negate {
 			v.length -= sels.Count()
@@ -1465,6 +1534,9 @@ func (v *Vector) ShrinkByMask(sels *bitmap.Bitmap, negate bool, offset uint64) {
 
 // Shuffle use to shrink vectors, sels can be disordered
 func (v *Vector) Shuffle(sels []int64, mp *mpool.MPool) (err error) {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	if v.IsConst() {
 		return nil
 	}
@@ -1534,6 +1606,9 @@ func (v *Vector) Shuffle(sels []int64, mp *mpool.MPool) (err error) {
 // alloc/free churn when the permutation preserves the element count.
 // buf is grown as needed and retained across calls.
 func (v *Vector) ShuffleWithBuf(sels []int64, mp *mpool.MPool, buf *[]byte) (err error) {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	if v.IsConst() {
 		return nil
 	}
@@ -1606,6 +1681,7 @@ func (v *Vector) ShuffleWithBuf(sels []int64, mp *mpool.MPool, buf *[]byte) (err
 
 // Copy simply does v[vi] = w[wi]
 func (v *Vector) Copy(w *Vector, vi, wi int64, mp *mpool.MPool) error {
+	disjoint := v.areaDisjoint
 	if w.class == CONSTANT {
 		if w.IsConstNull() {
 			if !v.typ.IsFixedLen() {
@@ -1647,6 +1723,11 @@ func (v *Vector) Copy(w *Vector, vi, wi int64, mp *mpool.MPool) error {
 	}
 
 	v.GetNulls().Unset(uint64(vi))
+	// Copy either installs an inline value or appends a fresh area range. The
+	// overwritten descriptor becomes dead, so a valid disjoint proof survives.
+	if v.typ.IsVarlen() && disjoint {
+		v.areaDisjoint = true
+	}
 	return nil
 }
 
@@ -2408,6 +2489,7 @@ func GetUnionAllFunction(typ types.Type, mp *mpool.MPool) func(v, w *Vector) err
 						nulls.Add(&v.gsp, uint64(v.length))
 					}
 					if bm.Contains(uint64(i)) {
+						vs[v.length] = types.Varlena{}
 						nulls.Add(&v.nsp, uint64(v.length))
 					} else {
 						err = BuildVarlenaFromVarlena(v, &vs[v.length], &ws[i], &w.area, mp)
@@ -2810,6 +2892,9 @@ func (v *Vector) UnionNull(mp *mpool.MPool) error {
 
 // It is simply append. the purpose of retention is ease of use
 func (v *Vector) UnionOne(w *Vector, sel int64, mp *mpool.MPool) error {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	if err := extend(v, 1, mp); err != nil {
 		return err
 	}
@@ -2865,6 +2950,9 @@ func (v *Vector) UnionOne(w *Vector, sel int64, mp *mpool.MPool) error {
 
 // It is simply append. the purpose of retention is ease of use
 func (v *Vector) UnionMulti(w *Vector, sel int64, cnt int, mp *mpool.MPool) error {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	if cnt == 0 {
 		return nil
 	}
@@ -2918,6 +3006,9 @@ func (v *Vector) UnionInt32(w *Vector, sels []int32, mp *mpool.MPool) error {
 }
 
 func unionT[T int32 | int64](v, w *Vector, sels []T, mp *mpool.MPool) error {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	if len(sels) == 0 {
 		return nil
 	}
@@ -3051,6 +3142,9 @@ func unionT[T int32 | int64](v, w *Vector, sels []T, mp *mpool.MPool) error {
 }
 
 func (v *Vector) UnionBatch(w *Vector, offset int64, cnt int, flags []uint8, mp *mpool.MPool) error {
+	if v.typ.IsVarlen() {
+		v.areaDisjoint = false
+	}
 	addCnt := 0
 	if flags == nil {
 		addCnt = cnt
@@ -3666,6 +3760,9 @@ func (v *Vector) RowToString(idx int) string {
 }
 
 func SetConstNull(vec *Vector, length int, mp *mpool.MPool) error {
+	if vec.typ.IsVarlen() {
+		vec.areaDisjoint = false
+	}
 	if len(vec.data) > 0 {
 		vec.data = vec.data[:0]
 	}
@@ -3675,6 +3772,9 @@ func SetConstNull(vec *Vector, length int, mp *mpool.MPool) error {
 }
 
 func SetConstFixed[T any](vec *Vector, val T, length int, mp *mpool.MPool) error {
+	if vec.typ.IsVarlen() {
+		vec.areaDisjoint = false
+	}
 	if err := extend(vec, 1, mp); err != nil {
 		return err
 	}
@@ -3687,6 +3787,7 @@ func SetConstFixed[T any](vec *Vector, val T, length int, mp *mpool.MPool) error
 }
 
 func SetConstBytes(vec *Vector, val []byte, length int, mp *mpool.MPool) error {
+	vec.areaDisjoint = false
 	if err := extend(vec, 1, mp); err != nil {
 		return err
 	}
@@ -3700,6 +3801,7 @@ func SetConstBytes(vec *Vector, val []byte, length int, mp *mpool.MPool) error {
 }
 
 func SetConstByteJson(vec *Vector, bj bytejson.ByteJson, length int, mp *mpool.MPool) error {
+	vec.areaDisjoint = false
 	if err := extend(vec, 1, mp); err != nil {
 		return err
 	}
@@ -3718,6 +3820,7 @@ func SetConstByteJsonEncoded(
 	length int,
 	mp *mpool.MPool,
 ) error {
+	vec.areaDisjoint = false
 	oldAreaLen := len(vec.area)
 	var value types.Varlena
 	if err := BuildVarlenaFromByteJsonEncoded(vec, &value, enc, mp); err != nil {
@@ -3736,6 +3839,7 @@ func SetConstByteJsonEncoded(
 
 // SetConstArray set current vector as Constant_Array vector of given length.
 func SetConstArray[T types.ArrayElement](vec *Vector, val []T, length int, mp *mpool.MPool) error {
+	vec.areaDisjoint = false
 	var err error
 
 	if err := extend(vec, 1, mp); err != nil {
@@ -3978,6 +4082,10 @@ func AppendArrayList[T types.ArrayElement](vec *Vector, ws [][]T, isNulls []bool
 }
 
 func appendOneFixed[T any](vec *Vector, val T, isNull bool, mp *mpool.MPool) error {
+	if vec.typ.IsVarlen() && !isNull {
+		// Generic fixed appends can install an arbitrary varlena descriptor.
+		vec.areaDisjoint = false
+	}
 	if vec.IsConst() {
 		return moerr.NewInternalErrorNoCtx("append to const vector")
 	}
@@ -3988,6 +4096,12 @@ func appendOneFixed[T any](vec *Vector, val T, isNull bool, mp *mpool.MPool) err
 	length := vec.length
 	vec.length++
 	if isNull {
+		if vec.typ.IsVarlen() {
+			// Reused data capacity can contain a stale descriptor. Keep null rows
+			// inside the area-disjoint invariant by making the new slot inline.
+			toSliceOfLengthNoTypeCheck[types.Varlena](vec, vec.length)[length] =
+				types.Varlena{}
+		}
 		nulls.Add(&vec.nsp, uint64(length))
 	} else {
 		var col []T
@@ -4000,21 +4114,30 @@ func appendOneFixed[T any](vec *Vector, val T, isNull bool, mp *mpool.MPool) err
 func appendOneBytes(vec *Vector, val []byte, isNull bool, mp *mpool.MPool) error {
 	var err error
 	var va types.Varlena
+	if vec.IsConst() {
+		return moerr.NewInternalErrorNoCtx("append to const vector")
+	}
 
 	if isNull {
+		// AppendBytes is also the generic null append used by expression
+		// evaluation. Let appendOneFixed size the slot from vec.typ instead of
+		// treating every null as a varlena descriptor.
 		return appendOneFixed(vec, va, true, mp)
 	} else {
 		err = BuildVarlenaFromByteSlice(vec, &va, &val, mp)
 		if err != nil {
 			return err
 		}
-		return appendOneFixed(vec, va, false, mp)
+		return appendOneOwnedVarlena(vec, va, mp)
 	}
 }
 
 func appendOneByteJson(vec *Vector, bj bytejson.ByteJson, isNull bool, mp *mpool.MPool) error {
 	var err error
 	var va types.Varlena
+	if vec.IsConst() {
+		return moerr.NewInternalErrorNoCtx("append to const vector")
+	}
 
 	if isNull {
 		return appendOneFixed(vec, va, true, mp)
@@ -4023,7 +4146,7 @@ func appendOneByteJson(vec *Vector, bj bytejson.ByteJson, isNull bool, mp *mpool
 		if err != nil {
 			return err
 		}
-		return appendOneFixed(vec, va, false, mp)
+		return appendOneOwnedVarlena(vec, va, mp)
 	}
 }
 
@@ -4031,6 +4154,9 @@ func appendOneByteJson(vec *Vector, bj bytejson.ByteJson, isNull bool, mp *mpool
 func appendOneArray[T types.ArrayElement](vec *Vector, val []T, isNull bool, mp *mpool.MPool) error {
 	var err error
 	var va types.Varlena
+	if vec.IsConst() {
+		return moerr.NewInternalErrorNoCtx("append to const vector")
+	}
 
 	if isNull {
 		return appendOneFixed(vec, va, true, mp)
@@ -4039,17 +4165,42 @@ func appendOneArray[T types.ArrayElement](vec *Vector, val []T, isNull bool, mp 
 		if err != nil {
 			return err
 		}
-		return appendOneFixed(vec, va, false, mp)
+		return appendOneOwnedVarlena(vec, va, mp)
 	}
 }
 
+// appendOneOwnedVarlena installs a descriptor built against vec.area by one of
+// the helpers above. That construction either keeps the value inline or
+// appends a fresh range, so it preserves an existing disjoint-area proof
+// without the invalidate/restore stores required by generic descriptor writes.
+func appendOneOwnedVarlena(
+	vec *Vector,
+	value types.Varlena,
+	mp *mpool.MPool,
+) error {
+	if err := extend(vec, 1, mp); err != nil {
+		return err
+	}
+	index := vec.length
+	vec.length++
+	values := toSliceOfLengthNoTypeCheck[types.Varlena](vec, vec.length)
+	values[index] = value
+	return nil
+}
+
 func appendMultiFixed[T any](vec *Vector, val T, isNull bool, cnt int, mp *mpool.MPool) error {
+	if vec.typ.IsVarlen() && !isNull {
+		vec.areaDisjoint = false
+	}
 	if err := extend(vec, cnt, mp); err != nil {
 		return err
 	}
 	length := vec.length
 	vec.length += cnt
 	if isNull {
+		if vec.typ.IsVarlen() && cnt > 0 {
+			clear(toSliceOfLengthNoTypeCheck[types.Varlena](vec, vec.length)[length:])
+		}
 		nulls.AddRange(&vec.nsp, uint64(length), uint64(length+cnt))
 	} else if cnt > 0 {
 		// XXX check cnt > 0 to avoid issue #23295
@@ -4061,6 +4212,8 @@ func appendMultiFixed[T any](vec *Vector, val T, isNull bool, cnt int, mp *mpool
 }
 
 func appendMultiBytes(vec *Vector, val []byte, isNull bool, cnt int, mp *mpool.MPool) error {
+	// A non-inline value is materialized once and its descriptor is broadcast.
+	vec.areaDisjoint = false
 	var err error
 	var va types.Varlena
 	if err = extend(vec, cnt, mp); err != nil {
@@ -4085,6 +4238,10 @@ func appendMultiBytes(vec *Vector, val []byte, isNull bool, cnt int, mp *mpool.M
 }
 
 func appendList[T any](vec *Vector, vals []T, isNulls []bool, mp *mpool.MPool) error {
+	if vec.typ.IsVarlen() {
+		// Generic lists can contain repeated or externally-owned descriptors.
+		vec.areaDisjoint = false
+	}
 	if err := extend(vec, len(vals), mp); err != nil {
 		return err
 	}
@@ -4103,6 +4260,8 @@ func appendList[T any](vec *Vector, vals []T, isNulls []bool, mp *mpool.MPool) e
 
 func appendBytesList(vec *Vector, vals [][]byte, isNulls []bool, mp *mpool.MPool) error {
 	var err error
+	disjoint := vec.areaDisjoint
+	vec.areaDisjoint = false
 	if err = extend(vec, len(vals), mp); err != nil {
 		return err
 	}
@@ -4111,6 +4270,7 @@ func appendBytesList(vec *Vector, vals [][]byte, isNulls []bool, mp *mpool.MPool
 	col := MustFixedColNoTypeCheck[types.Varlena](vec)
 	for i, w := range vals {
 		if len(isNulls) > 0 && isNulls[i] {
+			col[length+i] = types.Varlena{}
 			nulls.Add(&vec.nsp, uint64(length+i))
 		} else {
 			err = BuildVarlenaFromByteSlice(vec, &col[length+i], &w, mp)
@@ -4119,11 +4279,16 @@ func appendBytesList(vec *Vector, vals [][]byte, isNulls []bool, mp *mpool.MPool
 			}
 		}
 	}
+	if disjoint {
+		vec.areaDisjoint = true
+	}
 	return nil
 }
 
 func appendStringList(vec *Vector, vals []string, isNulls []bool, mp *mpool.MPool) error {
 	var err error
+	disjoint := vec.areaDisjoint
+	vec.areaDisjoint = false
 
 	if err = extend(vec, len(vals), mp); err != nil {
 		return err
@@ -4133,6 +4298,7 @@ func appendStringList(vec *Vector, vals []string, isNulls []bool, mp *mpool.MPoo
 	col := MustFixedColNoTypeCheck[types.Varlena](vec)
 	for i, w := range vals {
 		if len(isNulls) > 0 && isNulls[i] {
+			col[length+i] = types.Varlena{}
 			nulls.Add(&vec.nsp, uint64(length+i))
 		} else {
 			bs := []byte(w)
@@ -4142,12 +4308,17 @@ func appendStringList(vec *Vector, vals []string, isNulls []bool, mp *mpool.MPoo
 			}
 		}
 	}
+	if disjoint {
+		vec.areaDisjoint = true
+	}
 	return nil
 }
 
 // appendArrayList mainly used for unit tests
 func appendArrayList[T types.ArrayElement](vec *Vector, vals [][]T, isNulls []bool, mp *mpool.MPool) error {
 	var err error
+	disjoint := vec.areaDisjoint
+	vec.areaDisjoint = false
 
 	if err = extend(vec, len(vals), mp); err != nil {
 		return err
@@ -4157,6 +4328,7 @@ func appendArrayList[T types.ArrayElement](vec *Vector, vals [][]T, isNulls []bo
 	col := MustFixedColNoTypeCheck[types.Varlena](vec)
 	for i, w := range vals {
 		if len(isNulls) > 0 && isNulls[i] {
+			col[length+i] = types.Varlena{}
 			nulls.Add(&vec.nsp, uint64(length+i))
 		} else {
 			bs := w
@@ -4165,6 +4337,9 @@ func appendArrayList[T types.ArrayElement](vec *Vector, vals [][]T, isNulls []bo
 				return err
 			}
 		}
+	}
+	if disjoint {
+		vec.areaDisjoint = true
 	}
 	return nil
 }
@@ -4316,6 +4491,9 @@ func (v *Vector) Window(start, end int) (*Vector, error) {
 	} else if v.IsConst() {
 		vec := NewVec(v.typ)
 		vec.class = v.class
+		if v.typ.IsVarlen() {
+			vec.areaDisjoint = false
+		}
 		vec.data = v.data
 		vec.area = v.area
 		vec.length = end - start
@@ -4333,6 +4511,7 @@ func (v *Vector) Window(start, end int) (*Vector, error) {
 	w.length = end - start
 	if v.typ.IsVarlen() {
 		w.area = v.area
+		w.areaDisjoint = v.areaDisjoint
 	}
 	w.cantFreeData = true
 	w.cantFreeArea = true
@@ -4377,14 +4556,15 @@ func (v *Vector) CloneWindowTo(w *Vector, start, end int, mp *mpool.MPool) error
 	}
 	if v.IsConstNull() {
 		w.class = CONSTANT
+		if v.typ.IsVarlen() {
+			w.areaDisjoint = false
+		}
 		w.length = end - start
 		w.data = nil
 		return nil
 	} else if v.IsConst() {
 		if v.typ.IsVarlen() {
-			w.class = CONSTANT
-			SetConstBytes(v, v.GetBytesAt(0), end-start, mp)
-			return nil
+			return SetConstBytes(w, v.GetBytesAt(0), end-start, mp)
 		} else {
 			w.class = v.class
 			w.data = make([]byte, len(v.data))
@@ -4405,6 +4585,7 @@ func (v *Vector) CloneWindowTo(w *Vector, start, end int, mp *mpool.MPool) error
 		if v.typ.IsVarlen() {
 			w.area = make([]byte, len(v.area))
 			copy(w.area, v.area)
+			w.areaDisjoint = v.areaDisjoint
 		}
 		w.cantFreeData = true
 		w.cantFreeArea = true
@@ -4415,18 +4596,25 @@ func (v *Vector) CloneWindowTo(w *Vector, start, end int, mp *mpool.MPool) error
 		}
 		w.length = end - start
 		if v.GetType().IsVarlen() {
+			// Expose the proof only after every destination descriptor has been
+			// independently materialized. An allocation failure can leave a
+			// partially initialized logical range.
+			w.areaDisjoint = false
 			var vCol, wCol []types.Varlena
 			ToSliceNoTypeCheck(v, &vCol)
 			ToSliceNoTypeCheck(w, &wCol)
 			for i := start; i < end; i++ {
-				if !nulls.Contains(&v.nsp, uint64(i)) {
-					bs := vCol[i].GetByteSlice(v.area)
-					err = BuildVarlenaFromByteSlice(w, &wCol[i-start], &bs, mp)
-					if err != nil {
-						return err
-					}
+				if nulls.Contains(&v.nsp, uint64(i)) {
+					wCol[i-start] = types.Varlena{}
+					continue
+				}
+				bs := vCol[i].GetByteSlice(v.area)
+				err = BuildVarlenaFromByteSlice(w, &wCol[i-start], &bs, mp)
+				if err != nil {
+					return err
 				}
 			}
+			w.areaDisjoint = true
 		} else {
 			tlen := v.typ.TypeSize()
 			copy(w.data[:length], v.data[start*tlen:end*tlen])

--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -394,6 +394,30 @@ func TestAppendBytes(t *testing.T) {
 	require.Equal(t, int64(0), mp.CurrNB())
 }
 
+func TestAppendBytesNullUsesVectorPhysicalType(t *testing.T) {
+	for _, typ := range []types.Type{
+		types.T_bool.ToType(),
+		types.T_decimal128.ToType(),
+		types.T_varchar.ToType(),
+	} {
+		t.Run(typ.String(), func(t *testing.T) {
+			mp := mpool.MustNewZero()
+			vec := NewVec(typ)
+
+			// AppendBytes is the generic null path used by expression
+			// evaluation, including for fixed-width result vectors.
+			for i := range 17 {
+				require.NoError(t, AppendBytes(vec, nil, true, mp))
+				require.True(t, vec.IsNull(uint64(i)))
+			}
+			require.Equal(t, 17, vec.Length())
+
+			vec.Free(mp)
+			require.Zero(t, mp.CurrNB())
+		})
+	}
+}
+
 func TestAppendArray(t *testing.T) {
 	{
 		// Array Float32
@@ -1607,6 +1631,20 @@ func TestCloneWindow(t *testing.T) {
 	require.Equal(t, 2, v4.Length())
 	require.Equal(t, int32(10), GetFixedAtWithTypeCheck[int32](v4, 0))
 	require.Equal(t, int32(10), GetFixedAtWithTypeCheck[int32](v4, 1))
+
+	payload := []byte(strings.Repeat("x", 128))
+	v5, err := NewConstBytes(types.T_varchar.ToType(), payload, 10, mp)
+	require.NoError(t, err)
+	defer v5.Free(mp)
+	v6 := NewOffHeapVecWithType(types.T_varchar.ToType())
+	defer v6.Free(mp)
+	require.NoError(t, v5.CloneWindowTo(v6, 3, 5, mp))
+	require.True(t, v6.IsConst())
+	require.Equal(t, 2, v6.Length())
+	require.Equal(t, payload, v6.GetBytesAt(0))
+	require.Equal(t, payload, v6.GetBytesAt(1))
+	require.Equal(t, 10, v5.Length(), "cloning must not mutate the source")
+	require.Equal(t, payload, v5.GetBytesAt(0))
 }
 
 func TestCloneWindowWithMpNil(t *testing.T) {
@@ -3710,4 +3748,84 @@ func TestInplaceSortAndCompactMarksUniqueVectorsSorted(t *testing.T) {
 	unsupported := NewVec(types.T_any.ToType())
 	unsupported.InplaceSortAndCompact()
 	require.False(t, unsupported.GetSorted())
+}
+
+func TestVarlenaAreaDisjointLifecycle(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+	typ := types.T_varchar.ToType()
+	payload := []byte(strings.Repeat("x", 128))
+
+	flat := NewVec(typ)
+	require.True(t, flat.VarlenaAreaIsDisjoint())
+	for range 2 {
+		require.NoError(t, AppendBytes(flat, payload, false, mp))
+	}
+	require.True(t, flat.VarlenaAreaIsDisjoint(),
+		"ordinary appends own disjoint area ranges")
+
+	values, _ := MustVarlenaRawData(flat)
+	require.True(t, flat.VarlenaAreaIsDisjoint(),
+		"read access must not mutate vector metadata")
+	require.NoError(t, SetFixedAtNoTypeCheck(flat, 1, values[0]))
+	require.False(t, flat.VarlenaAreaIsDisjoint(),
+		"installing an arbitrary descriptor must invalidate the proof")
+
+	flat.ResetWithSameType()
+	require.True(t, flat.VarlenaAreaIsDisjoint())
+	require.NoError(t, AppendBytes(flat, payload, false, mp))
+	flat.ResetWithSameType()
+	require.NoError(t, AppendBytes(flat, nil, true, mp))
+	values, _ = MustVarlenaRawData(flat)
+	require.True(t, values[0].IsSmall(),
+		"a null append must clear a stale descriptor from reused capacity")
+	flat.GetNulls().Del(0)
+	require.True(t, flat.VarlenaAreaIsDisjoint(),
+		"null-bitmap changes cannot invalidate a descriptor-level proof")
+
+	flat.ResetWithSameType()
+	for range 2 {
+		require.NoError(t, AppendBytes(flat, payload, false, mp))
+	}
+	flat.Shrink([]int64{0, 0}, false)
+	require.False(t, flat.VarlenaAreaIsDisjoint(),
+		"selection can duplicate a descriptor")
+	flat.Free(mp)
+
+	constant, err := NewConstBytes(typ, payload, 2, mp)
+	require.NoError(t, err)
+	shared := NewVec(typ)
+	require.NoError(t, shared.UnionBatch(constant, 0, 2, nil, mp))
+	require.False(t, shared.VarlenaAreaIsDisjoint(),
+		"const broadcast shares one non-inline descriptor")
+	compact, err := shared.CloneToFlatCompact(mp)
+	require.NoError(t, err)
+	require.True(t, compact.VarlenaAreaIsDisjoint(),
+		"compaction materializes independent payload ranges")
+
+	compact.Free(mp)
+	shared.Free(mp)
+	constant.Free(mp)
+	require.Zero(t, mp.CurrNB())
+}
+
+func TestVarlenaAreaDisjointAppendFailureFailsClosed(t *testing.T) {
+	mp, err := mpool.NewMPool("varlena-disjoint-failure", 1<<20, mpool.NoFixed)
+	require.NoError(t, err)
+	defer mpool.DeleteMPool(mp)
+
+	vec := NewVec(types.T_varchar.ToType())
+	vec.SetOffHeap(true)
+	err = AppendBytesList(
+		vec,
+		[][]byte{make([]byte, 128), make([]byte, 2<<20)},
+		nil,
+		mp,
+	)
+	require.Error(t, err)
+	require.False(t, vec.VarlenaAreaIsDisjoint(),
+		"a partially initialized logical range must never retain the fast proof")
+
+	vec.Free(mp)
+	require.Zero(t, mp.CurrNB())
 }

--- a/pkg/container/vector/versions.go
+++ b/pkg/container/vector/versions.go
@@ -70,6 +70,7 @@ func (v *Vector) MarshalBinaryWithBufferV1(buf *bytes.Buffer) error {
 }
 
 func (v *Vector) UnmarshalBinaryV1(data []byte) error {
+	v.areaDisjoint = false
 	// read class
 	v.class = int(data[0])
 	data = data[1:]

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -192,7 +192,7 @@ func NewExpressionExecutor(proc *process.Process, planExpr *plan.Expr) (Expressi
 			executor.overloadID = overloadID
 			executor.volatile, executor.timeDependent = overload.CannotFold(), overload.IsRealTimeRelated()
 			executor.fid, _ = function.DecodeOverloadID(overloadID)
-			executor.evalFn, executor.resetFn, executor.freeFn = overload.GetExecuteMethod()
+			executor.evalFn, executor.resetFn, executor.freeFn, executor.retainedBytesFn = overload.GetExecuteMethod()
 		}
 		typ := types.New(types.T(planExpr.Typ.Id), planExpr.Typ.Width, planExpr.Typ.Scale)
 
@@ -1800,7 +1800,7 @@ func GetExprZoneMap(
 						ivecs[i] = vecs[arg.AuxId]
 					}
 				}
-				fn, _, fnFree := overload.GetExecuteMethod()
+				fn, _, fnFree, _ := overload.GetExecuteMethod()
 				typ := types.New(types.T(expr.Typ.Id), expr.Typ.Width, expr.Typ.Scale)
 
 				result := vector.NewFunctionResultWrapper(typ, proc.Mp())

--- a/pkg/sql/colexec/evalExpressionMemory.go
+++ b/pkg/sql/colexec/evalExpressionMemory.go
@@ -20,9 +20,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 )
 
-// ExpressionExecutorRetainedBytes returns the mpool-backed vector capacity
-// owned by an executor tree. Borrowed evaluation results are deliberately not
-// counted: every owned vector is reached through exactly one executor field.
+// ExpressionExecutorRetainedBytes returns the backing capacity owned by an
+// executor tree. Borrowed evaluation results are deliberately not counted:
+// every owned vector is reached through exactly one executor field. Stateful
+// functions may additionally expose retained non-vector backing allocations.
 //
 // Go-managed executor metadata is not included here. HashBuild's expression
 // admission bound retains a separate per-vector allowance for that metadata.
@@ -62,6 +63,13 @@ func ExpressionExecutorRetainedBytes(executor ExpressionExecutor) (uint64, bool)
 		)
 		if !ok {
 			return 0, false
+		}
+		if expr.retainedBytesFn != nil {
+			retained := expr.retainedBytesFn()
+			if total > math.MaxUint64-retained {
+				return 0, false
+			}
+			total += retained
 		}
 		for _, parameter := range expr.selectedParameterVectors {
 			bytes, valid := expressionVectorRetainedBytes(parameter)

--- a/pkg/sql/colexec/evalExpressionReset.go
+++ b/pkg/sql/colexec/evalExpressionReset.go
@@ -60,6 +60,10 @@ type functionInformationForEval struct {
 		selectList *function.FunctionSelectList) error
 	resetFn func() error
 	freeFn  func() error
+
+	// retainedBytesFn reports stateful function backing allocations which are
+	// not represented by the executor's owned vectors.
+	retainedBytesFn func() uint64
 }
 
 func (fI *functionInformationForEval) reset() {
@@ -80,7 +84,7 @@ func (fI *functionInformationForEval) reset() {
 	if fI.evalFn != nil {
 		// we can set the context nil here since this function will never return an error.
 		overload, _ := function.GetFunctionById(context.TODO(), fI.overloadID)
-		fI.evalFn, fI.resetFn, fI.freeFn = overload.GetExecuteMethod()
+		fI.evalFn, fI.resetFn, fI.freeFn, fI.retainedBytesFn = overload.GetExecuteMethod()
 	}
 }
 

--- a/pkg/sql/colexec/hashbuild/budget.go
+++ b/pkg/sql/colexec/hashbuild/budget.go
@@ -999,12 +999,23 @@ func unionBatchAreaProjection(
 			uint64(physicalBytes), uint64(rows))
 		return physicalBytes, selectedPayload, err
 	}
+	if start == 0 && rows == src.Length() {
+		if src.VarlenaAreaIsDisjoint() {
+			// The retained full-vector copy preserves the complete physical area.
+			// Disjoint live descriptors prove their logical payload cannot exceed
+			// that area even when it contains dead bytes. This avoids an
+			// O(columns*rows) pre-spill scan for ordinary append-built vectors.
+			return len(src.GetArea()), uint64(len(src.GetArea())), nil
+		}
+		livePayload, err := logicalAppendAreaBytes(src, start, rows)
+		if err != nil {
+			return 0, 0, err
+		}
+		return len(src.GetArea()), livePayload, nil
+	}
 	livePayload, err := logicalAppendAreaBytes(src, start, rows)
 	if err != nil {
 		return 0, 0, err
-	}
-	if start == 0 && rows == src.Length() {
-		return len(src.GetArea()), livePayload, nil
 	}
 	if livePayload > uint64(math.MaxInt) {
 		return 0, 0, process.ErrHashBuildBudgetInvalid

--- a/pkg/sql/colexec/hashbuild/budget.go
+++ b/pkg/sql/colexec/hashbuild/budget.go
@@ -279,11 +279,26 @@ func (hb *HashmapBuilder) copyBuildBatch(src *batch.Batch, proc *process.Process
 	if hb.budget == nil {
 		return hb.Batches.CopyIntoBatches(src, proc)
 	}
-	projected, err := hb.projectedBatchCopyBytes(src)
+	projection, err := hb.projectedBatchCopy(src)
 	if err != nil {
 		return err
 	}
-	reservation, err := hb.budget.Reserve(projected)
+	return hb.copyBuildBatchProjected(src, proc, projection)
+}
+
+func (hb *HashmapBuilder) copyBuildBatchProjected(
+	src *batch.Batch,
+	proc *process.Process,
+	projection batchCopyProjection,
+) error {
+	if hb.budget == nil {
+		if err := hb.Batches.CopyIntoBatches(src, proc); err != nil {
+			return err
+		}
+		hb.retainedSpillTailSelected = projection.nextTailSelected
+		return nil
+	}
+	reservation, err := hb.budget.Reserve(projection.admissionBytes)
 	if err != nil {
 		return err
 	}
@@ -295,11 +310,13 @@ func (hb *HashmapBuilder) copyBuildBatch(src *batch.Batch, proc *process.Process
 	if err = hb.Batches.CopyIntoBatches(src, proc); err != nil {
 		reservation.Release()
 		hb.releaseBatchReservations()
+		hb.retainedSpillTailSelected = 0
 		return err
 	}
 	actual, err := batchCopyAllocatedDelta(hb.Batches.Buf, snapshot)
 	if err != nil {
 		hb.Batches.Clean(proc.Mp())
+		hb.retainedSpillTailSelected = 0
 		reservation.Release()
 		hb.releaseBatchReservations()
 		return err
@@ -307,26 +324,30 @@ func (hb *HashmapBuilder) copyBuildBatch(src *batch.Batch, proc *process.Process
 	metadata, ok := retainedMetadataAllowance(src)
 	if !ok || actual > math.MaxUint64-metadata {
 		hb.Batches.Clean(proc.Mp())
+		hb.retainedSpillTailSelected = 0
 		reservation.Release()
 		hb.releaseBatchReservations()
 		return process.ErrHashBuildBudgetInvalid
 	}
 	actual += metadata
-	if actual > projected {
+	if actual > projection.admissionBytes {
 		// This indicates an incomplete pre-allocation bound. Fail closed after
 		// cleaning; never legitimize the excess with post-allocation admission.
 		hb.Batches.Clean(proc.Mp())
+		hb.retainedSpillTailSelected = 0
 		reservation.Release()
 		hb.releaseBatchReservations()
 		return process.ErrHashBuildBudgetInvalid
 	}
 	if _, err = reservation.ReconcileDown(actual); err != nil {
 		hb.Batches.Clean(proc.Mp())
+		hb.retainedSpillTailSelected = 0
 		reservation.Release()
 		hb.releaseBatchReservations()
 		return err
 	}
 	hb.batchReservations = append(hb.batchReservations, reservation)
+	hb.retainedSpillTailSelected = projection.nextTailSelected
 	return nil
 }
 
@@ -351,32 +372,53 @@ func retainedMetadataAllowance(src *batch.Batch) (uint64, bool) {
 	return rows * perRow, true
 }
 
-// projectedPartialTailReplacementBytes follows UnionBatch's allocation order.
-// The existing tail reservation covers old capacities. At each grow, admission
-// needs the complete replacement capacity plus deltas retained by earlier grows.
-func projectedPartialTailReplacementBytes(
+func projectedSpillSelectedAppendBytes(
+	src *vector.Vector,
+	rows int,
+	payloadBytes uint64,
+) (uint64, error) {
+	if src == nil || rows < 0 {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	typeSize := src.GetType().TypeSize()
+	if typeSize < 0 {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	selected, err := spillCheckedMul(uint64(rows), uint64(typeSize))
+	if err != nil {
+		return 0, err
+	}
+	return spillCheckedAdd(selected, payloadBytes)
+}
+
+// projectedPartialTailReplacement follows UnionBatch's allocation order. The
+// existing tail reservation covers old capacities. At each grow, admission
+// needs the complete replacement capacity plus deltas retained by earlier
+// grows. appendedSelected is the logical spill materialization contributed by
+// this source range, computed from the same varlen scan used for allocation.
+func projectedPartialTailReplacement(
 	tail, src *batch.Batch,
 	appendRows int,
-) (peak, retained uint64, err error) {
+) (peak, retained, appendedSelected uint64, err error) {
 	if tail == nil || src == nil || appendRows < 0 || len(tail.Vecs) != len(src.Vecs) {
-		return 0, 0, process.ErrHashBuildBudgetInvalid
+		return 0, 0, 0, process.ErrHashBuildBudgetInvalid
 	}
 	for i, srcVec := range src.Vecs {
 		dstVec := tail.Vecs[i]
 		if dstVec == nil || srcVec == nil || dstVec.Length() > math.MaxInt-appendRows {
-			return 0, 0, process.ErrHashBuildBudgetInvalid
+			return 0, 0, 0, process.ErrHashBuildBudgetInvalid
 		}
 
 		typeSize := srcVec.GetType().TypeSize()
 		requiredRows := dstVec.Length() + appendRows
 		if typeSize < 0 || (typeSize > 0 && requiredRows > math.MaxInt/typeSize) {
-			return 0, 0, process.ErrHashBuildBudgetInvalid
+			return 0, 0, 0, process.ErrHashBuildBudgetInvalid
 		}
 		oldDataCap := cap(dstVec.GetData())
 		if requiredData := requiredRows * typeSize; requiredData > oldDataCap {
 			newCap, ok := mpool.GrowCapacity(int64(oldDataCap), int64(requiredData))
 			if !ok || retained > math.MaxUint64-uint64(newCap) {
-				return 0, 0, process.ErrHashBuildBudgetInvalid
+				return 0, 0, 0, process.ErrHashBuildBudgetInvalid
 			}
 			if candidate := retained + uint64(newCap); candidate > peak {
 				peak = candidate
@@ -384,17 +426,26 @@ func projectedPartialTailReplacementBytes(
 			retained += uint64(newCap) - uint64(oldDataCap)
 		}
 
-		areaBytes, areaErr :=
-			unionBatchAreaBytes(srcVec, 0, appendRows)
+		areaBytes, selectedPayload, areaErr :=
+			unionBatchAreaProjection(srcVec, 0, appendRows)
 		if areaErr != nil || areaBytes > math.MaxInt-len(dstVec.GetArea()) {
-			return 0, 0, process.ErrHashBuildBudgetInvalid
+			return 0, 0, 0, process.ErrHashBuildBudgetInvalid
+		}
+		selected, selectedErr := projectedSpillSelectedAppendBytes(
+			srcVec, appendRows, selectedPayload)
+		if selectedErr != nil {
+			return 0, 0, 0, selectedErr
+		}
+		appendedSelected, selectedErr = spillCheckedAdd(appendedSelected, selected)
+		if selectedErr != nil {
+			return 0, 0, 0, selectedErr
 		}
 		oldAreaCap := cap(dstVec.GetArea())
 		requiredArea := len(dstVec.GetArea()) + areaBytes
 		if requiredArea > oldAreaCap {
 			newCap, ok := mpool.GrowCapacity(int64(oldAreaCap), int64(requiredArea))
 			if !ok || retained > math.MaxUint64-uint64(newCap) {
-				return 0, 0, process.ErrHashBuildBudgetInvalid
+				return 0, 0, 0, process.ErrHashBuildBudgetInvalid
 			}
 			if candidate := retained + uint64(newCap); candidate > peak {
 				peak = candidate
@@ -402,23 +453,43 @@ func projectedPartialTailReplacementBytes(
 			retained += uint64(newCap) - uint64(oldAreaCap)
 		}
 	}
-	return peak, retained, nil
+	return peak, retained, appendedSelected, nil
 }
 
-// projectedNewDestinationBytes follows CopyIntoBatches for destinations that
-// start empty. Each destination vector is pre-extended to its final row count,
-// and each varlen area is then grown once by UnionBatch.
-func projectedNewDestinationBytes(src *batch.Batch, start, rows int) (uint64, error) {
+func projectedPartialTailReplacementBytes(
+	tail, src *batch.Batch,
+	appendRows int,
+) (peak, retained uint64, err error) {
+	peak, retained, _, err = projectedPartialTailReplacement(tail, src, appendRows)
+	return peak, retained, err
+}
+
+type batchCopyProjection struct {
+	admissionBytes      uint64
+	maxRetainedSelected uint64
+	maxRetainedRows     int
+	nextTailSelected    uint64
+	columns             int
+}
+
+// projectedNewDestinationAllocation follows CopyIntoBatches for destinations
+// that start empty. In addition to the total pre-allocation charge, it records
+// the largest individual destination. HashBuild reuses that already-required
+// projection to prove the future spill of every retained destination without
+// adding another varlen row scan to the non-spill path.
+func projectedNewDestinationAllocation(
+	src *batch.Batch,
+	start, rows int,
+) (total uint64, maxRows int, maxSelected, lastSelected uint64, err error) {
 	if src == nil || start < 0 || rows < 0 || start > src.RowCount() || rows > src.RowCount()-start {
-		return 0, process.ErrHashBuildBudgetInvalid
+		return 0, 0, 0, 0, process.ErrHashBuildBudgetInvalid
 	}
 	end := start + rows
-	var total uint64
-	add := func(value uint64) error {
-		if total > math.MaxUint64-value {
+	add := func(target *uint64, value uint64) error {
+		if *target > math.MaxUint64-value {
 			return process.ErrHashBuildBudgetInvalid
 		}
-		total += value
+		*target += value
 		return nil
 	}
 	for offset := start; offset < end; {
@@ -426,52 +497,79 @@ func projectedNewDestinationBytes(src *batch.Batch, start, rows int) (uint64, er
 		if segmentRows > colexec.DefaultBatchSize {
 			segmentRows = colexec.DefaultBatchSize
 		}
+		var segmentAllocated uint64
+		var segmentSelected uint64
 		for _, vec := range src.Vecs {
 			if vec == nil {
-				return 0, process.ErrHashBuildBudgetInvalid
+				return 0, 0, 0, 0, process.ErrHashBuildBudgetInvalid
 			}
 			typeSize := vec.GetType().TypeSize()
 			if typeSize < 0 || (typeSize > 0 && segmentRows > math.MaxInt/typeSize) {
-				return 0, process.ErrHashBuildBudgetInvalid
+				return 0, 0, 0, 0, process.ErrHashBuildBudgetInvalid
 			}
 			dataCap, ok := mpool.GrowCapacity(0, int64(segmentRows*typeSize))
 			if !ok || dataCap < 0 {
-				return 0, process.ErrHashBuildBudgetInvalid
+				return 0, 0, 0, 0, process.ErrHashBuildBudgetInvalid
 			}
-			if err := add(uint64(dataCap)); err != nil {
-				return 0, err
+			if err = add(&segmentAllocated, uint64(dataCap)); err != nil {
+				return 0, 0, 0, 0, err
 			}
-			if !vec.GetType().IsVarlen() {
-				continue
+			areaBytes := 0
+			var selectedPayload uint64
+			if vec.GetType().IsVarlen() {
+				var areaErr error
+				areaBytes, selectedPayload, areaErr =
+					unionBatchAreaProjection(vec, offset, segmentRows)
+				if areaErr != nil {
+					return 0, 0, 0, 0, process.ErrHashBuildBudgetInvalid
+				}
+				areaCap, ok := mpool.GrowCapacity(0, int64(areaBytes))
+				if !ok || areaCap < 0 {
+					return 0, 0, 0, 0, process.ErrHashBuildBudgetInvalid
+				}
+				if err = add(&segmentAllocated, uint64(areaCap)); err != nil {
+					return 0, 0, 0, 0, err
+				}
 			}
-
-			areaBytes, areaErr :=
-				unionBatchAreaBytes(vec, offset, segmentRows)
-			if areaErr != nil {
-				return 0, process.ErrHashBuildBudgetInvalid
+			selected, selectedErr := projectedSpillSelectedAppendBytes(
+				vec, segmentRows, selectedPayload)
+			if selectedErr != nil {
+				return 0, 0, 0, 0, selectedErr
 			}
-			areaCap, ok := mpool.GrowCapacity(0, int64(areaBytes))
-			if !ok || areaCap < 0 {
-				return 0, process.ErrHashBuildBudgetInvalid
+			if err = add(&segmentSelected, selected); err != nil {
+				return 0, 0, 0, 0, err
 			}
-			if err := add(uint64(areaCap)); err != nil {
-				return 0, err
-			}
+		}
+		if err = add(&total, segmentAllocated); err != nil {
+			return 0, 0, 0, 0, err
+		}
+		if segmentSelected > maxSelected {
+			maxSelected = segmentSelected
+		}
+		lastSelected = segmentSelected
+		if segmentRows > maxRows {
+			maxRows = segmentRows
 		}
 		offset += segmentRows
 	}
-	return total, nil
+	return total, maxRows, maxSelected, lastSelected, nil
 }
 
-func (hb *HashmapBuilder) projectedBatchCopyBytes(src *batch.Batch) (uint64, error) {
+func projectedNewDestinationBytes(src *batch.Batch, start, rows int) (uint64, error) {
+	total, _, _, _, err := projectedNewDestinationAllocation(src, start, rows)
+	return total, err
+}
+
+func (hb *HashmapBuilder) projectedBatchCopy(src *batch.Batch) (batchCopyProjection, error) {
 	if src == nil || src.RowCount() < 0 {
-		return 0, process.ErrHashBuildBudgetInvalid
+		return batchCopyProjection{}, process.ErrHashBuildBudgetInvalid
 	}
+	projection := batchCopyProjection{columns: len(src.Vecs)}
 	rows := uint64(src.RowCount())
 	last := len(hb.Batches.Buf) - 1
-	hasPartialTail := rows != uint64(colexec.DefaultBatchSize) &&
-		last >= 0 && hb.Batches.Buf[last] != nil &&
+	hadPartialTail := last >= 0 && hb.Batches.Buf[last] != nil &&
 		hb.Batches.Buf[last].RowCount() != colexec.DefaultBatchSize
+	hasPartialTail := rows != uint64(colexec.DefaultBatchSize) && hadPartialTail
 	appendRows := 0
 	if hasPartialTail {
 		// CopyIntoBatches appends into the partial tail. Derive each replacement
@@ -480,40 +578,80 @@ func (hb *HashmapBuilder) projectedBatchCopyBytes(src *batch.Batch) (uint64, err
 		// 1.25x steps before reaching the required size.
 		tail := hb.Batches.Buf[last]
 		if tail.RowCount() < 0 || tail.RowCount() >= colexec.DefaultBatchSize {
-			return 0, process.ErrHashBuildBudgetInvalid
+			return batchCopyProjection{}, process.ErrHashBuildBudgetInvalid
 		}
 		appendRows = colexec.DefaultBatchSize - tail.RowCount()
 		if appendRows > src.RowCount() {
 			appendRows = src.RowCount()
 		}
-		replacementPeak, retainedDelta, err := projectedPartialTailReplacementBytes(tail, src, appendRows)
+		replacementPeak, retainedDelta, appendedSelected, err :=
+			projectedPartialTailReplacement(tail, src, appendRows)
 		if err != nil {
-			return 0, err
+			return batchCopyProjection{}, err
 		}
 		projected := replacementPeak
+		combinedSelected, err := spillCheckedAdd(
+			hb.retainedSpillTailSelected, appendedSelected)
+		if err != nil {
+			return batchCopyProjection{}, err
+		}
+		projection.maxRetainedRows = tail.RowCount() + appendRows
+		projection.maxRetainedSelected = combinedSelected
+		if projection.maxRetainedRows < colexec.DefaultBatchSize {
+			projection.nextTailSelected = combinedSelected
+		}
 		if appendRows < src.RowCount() {
 			// After the tail grow finishes, its retained delta stays live while
 			// CopyIntoBatches materializes the remaining source rows.
-			remaining, err := projectedNewDestinationBytes(
+			remaining, maxRows, maxSelected, lastSelected, err := projectedNewDestinationAllocation(
 				src, appendRows, src.RowCount()-appendRows,
 			)
 			if err != nil {
-				return 0, err
+				return batchCopyProjection{}, err
 			}
 			if retainedDelta > math.MaxUint64-remaining {
-				return 0, process.ErrHashBuildBudgetInvalid
+				return batchCopyProjection{}, process.ErrHashBuildBudgetInvalid
 			}
 			if retained := retainedDelta + remaining; retained > projected {
 				projected = retained
 			}
+			if maxSelected > projection.maxRetainedSelected {
+				projection.maxRetainedSelected = maxSelected
+			}
+			if maxRows > projection.maxRetainedRows {
+				projection.maxRetainedRows = maxRows
+			}
+			remainingRows := src.RowCount() - appendRows
+			if remainingRows%colexec.DefaultBatchSize != 0 {
+				projection.nextTailSelected = lastSelected
+			} else {
+				projection.nextTailSelected = 0
+			}
 		}
-		return projectedBatchCopyWithMetadata(src, projected)
+		projection.admissionBytes, err = projectedBatchCopyWithMetadata(src, projected)
+		return projection, err
 	}
-	projected, err := projectedNewDestinationBytes(src, 0, src.RowCount())
+	projected, maxRows, maxSelected, lastSelected, err := projectedNewDestinationAllocation(
+		src, 0, src.RowCount())
 	if err != nil {
-		return 0, err
+		return batchCopyProjection{}, err
 	}
-	return projectedBatchCopyWithMetadata(src, projected)
+	projection.admissionBytes, err = projectedBatchCopyWithMetadata(src, projected)
+	projection.maxRetainedRows = maxRows
+	projection.maxRetainedSelected = maxSelected
+	if src.RowCount() == colexec.DefaultBatchSize && hadPartialTail {
+		// CopyIntoBatches swaps the new full batch before the old partial tail;
+		// the cached tail itself is unchanged.
+		projection.nextTailSelected = hb.retainedSpillTailSelected
+	} else if src.RowCount()%colexec.DefaultBatchSize != 0 {
+		projection.nextTailSelected = lastSelected
+	}
+	return projection, err
+}
+
+func (hb *HashmapBuilder) projectedBatchCopyBytes(src *batch.Batch) (uint64, error) {
+	projection, err := hb.projectedBatchCopy(src)
+	return projection.admissionBytes, err
 }
 
 func projectedBatchCopyWithMetadata(src *batch.Batch, projected uint64) (uint64, error) {
@@ -537,6 +675,7 @@ func projectedBatchCopyWithMetadata(src *batch.Batch, projected uint64) (uint64,
 
 func (hb *HashmapBuilder) cleanBatches(proc *process.Process) {
 	hb.Batches.Clean(proc.Mp())
+	hb.retainedSpillTailSelected = 0
 	hb.releaseBatchReservations()
 }
 
@@ -774,33 +913,107 @@ func uniqueAppendAreaBytes(src *vector.Vector, start, rows int, sels []int64) (i
 	return areaBytes, nil
 }
 
-// unionBatchAreaBytes mirrors Vector.UnionBatch's flags=nil varlen paths.
-// In particular, its whole-vector fast path copies the complete source area,
-// including bytes no longer referenced after SetLength/Shrink. Budget
-// admission must therefore use len(area), not only the live row references.
-func unionBatchAreaBytes(
+// logicalAppendAreaBytes sums the payload that UnionInt32 will materialize for
+// a contiguous non-const source range. It is intentionally separate from the
+// general selected-row helper above: retained-copy projection runs once per
+// ingress batch, so its common no-area and no-null paths avoid per-row class,
+// bitmap, and selection checks.
+func logicalAppendAreaBytes(src *vector.Vector, start, rows int) (uint64, error) {
+	if src == nil || !src.GetType().IsVarlen() || start < 0 || rows < 0 ||
+		start > src.Length() || rows > src.Length()-start || src.IsConst() {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	if rows == 0 || len(src.GetArea()) == 0 {
+		return 0, nil
+	}
+	values, _ := vector.MustVarlenaRawData(src)
+	end := start + rows
+	if end > len(values) {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	var payload uint64
+	if src.GetNulls().EmptyByFlag() {
+		for i := start; i < end; i++ {
+			if values[i].IsSmall() {
+				continue
+			}
+			_, length := values[i].OffsetLen()
+			if payload > math.MaxUint64-uint64(length) {
+				return 0, process.ErrHashBuildBudgetInvalid
+			}
+			payload += uint64(length)
+		}
+		return payload, nil
+	}
+	for i := start; i < end; i++ {
+		if src.GetNulls().Contains(uint64(i)) {
+			continue
+		}
+		if values[i].IsSmall() {
+			continue
+		}
+		_, length := values[i].OffsetLen()
+		if payload > math.MaxUint64-uint64(length) {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		payload += uint64(length)
+	}
+	return payload, nil
+}
+
+// unionBatchAreaProjection mirrors Vector.UnionBatch's flags=nil varlen paths
+// and keeps physical retention separate from logical spill materialization.
+// A whole-vector copy retains the complete source area, including stale bytes,
+// while shared varlena descriptors can make a later UnionInt32 copy the same
+// payload once per logical row. One live-descriptor scan therefore supplies the
+// exact selected payload without treating vector class as an ownership proxy.
+func unionBatchAreaProjection(
 	src *vector.Vector,
 	start, rows int,
-) (int, error) {
+) (physicalBytes int, selectedPayload uint64, err error) {
 	if src == nil || !src.GetType().IsVarlen() {
-		return 0, nil
+		return 0, 0, nil
 	}
 	if start < 0 || rows < 0 ||
 		start > src.Length() || rows > src.Length()-start {
-		return 0, process.ErrHashBuildBudgetInvalid
+		return 0, 0, process.ErrHashBuildBudgetInvalid
 	}
 	if rows == 0 {
-		return 0, nil
+		return 0, 0, nil
+	}
+	if len(src.GetArea()) == 0 {
+		return 0, 0, nil
 	}
 	if src.IsConst() {
 		// UnionBatch materializes the constant payload once and broadcasts its
-		// varlena header to the appended logical rows.
-		return uniqueAppendAreaBytes(src, 0, 1, nil)
+		// varlena header to the appended logical rows. UnionInt32 later copies
+		// that referenced payload once for every selected row.
+		physicalBytes, err = uniqueAppendAreaBytes(src, 0, 1, nil)
+		if err != nil {
+			return 0, 0, err
+		}
+		selectedPayload, err = spillCheckedMul(
+			uint64(physicalBytes), uint64(rows))
+		return physicalBytes, selectedPayload, err
+	}
+	livePayload, err := logicalAppendAreaBytes(src, start, rows)
+	if err != nil {
+		return 0, 0, err
 	}
 	if start == 0 && rows == src.Length() {
-		return len(src.GetArea()), nil
+		return len(src.GetArea()), livePayload, nil
 	}
-	return uniqueAppendAreaBytes(src, start, rows, nil)
+	if livePayload > uint64(math.MaxInt) {
+		return 0, 0, process.ErrHashBuildBudgetInvalid
+	}
+	return int(livePayload), livePayload, nil
+}
+
+// unionBatchAreaBytes is kept as the allocation-only projection used by
+// focused CopyIntoBatches admission tests.
+func unionBatchAreaBytes(src *vector.Vector, start, rows int) (int, error) {
+	physical, _, err := unionBatchAreaProjection(src, start, rows)
+	return physical, err
 }
 
 func (hb *HashmapBuilder) reserveUniqueAppendOverlap(dst *vector.Vector, rows, areaBytes int) (*process.HashBuildReservation, error) {

--- a/pkg/sql/colexec/hashbuild/budget.go
+++ b/pkg/sql/colexec/hashbuild/budget.go
@@ -293,6 +293,9 @@ func (hb *HashmapBuilder) copyBuildBatchProjected(
 ) error {
 	if hb.budget == nil {
 		if err := hb.Batches.CopyIntoBatches(src, proc); err != nil {
+			// CopyIntoBatches destroys every retained destination on failure.
+			// Keep the derived tail state transactional with that owner cleanup.
+			hb.retainedSpillTailSelected = 0
 			return err
 		}
 		hb.retainedSpillTailSelected = projection.nextTailSelected

--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -320,6 +320,11 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		ctr.hashmapBuilder.InputBatchRowCount += result.Batch.RowCount()
 		// If in spill mode, spill this batch directly to open files.
 		if spillMode {
+			if hashBuild.IsShuffle {
+				if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
+					return err
+				}
+			}
 			err := ctr.spillBatchBounded(proc, result.Batch, spillFiles, ctr.spillExprExecs, analyzer, false)
 			if err != nil {
 				return err
@@ -331,6 +336,23 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		// speculative spill sizing and reservation off the resident hot path while
 		// preserving enough budget headroom to drain the batches already retained.
 		if hashBuild.shouldSpillBeforeRetain(inputBatchSize) {
+			if hashBuild.IsShuffle {
+				// The current batch is still upstream-owned. If its direct recovery
+				// cannot grow while retained copies consume the shared generation,
+				// drain those copies under their existing lease and retry once.
+				if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
+					if !errors.Is(err, process.ErrHashBuildBudgetAdmission) ||
+						len(ctr.hashmapBuilder.Batches.Buf) == 0 {
+						return err
+					}
+					if err := startSpill(); err != nil {
+						return err
+					}
+					if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
+						return err
+					}
+				}
+			}
 			if err := startSpill(); err != nil {
 				return err
 			}
@@ -342,13 +364,33 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 
 		// Store original batch
 		retainedMemBefore := ctr.hashmapBuilder.Batches.MemSize
-		err = ctr.hashmapBuilder.copyBuildBatch(result.Batch, proc)
+		if hashBuild.IsShuffle {
+			// The retained destination may differ materially from ingress: const
+			// vectors become ordinary vectors and partial tails grow. Reuse the one
+			// unavoidable copy allocation projection to reserve the largest
+			// destination's future spill peak before any source row is retained.
+			var projection batchCopyProjection
+			projection, err = ctr.hashmapBuilder.projectedBatchCopy(result.Batch)
+			if err == nil {
+				err = ctr.ensureRetainedSpillRecovery(projection, analyzer)
+			}
+			if err == nil {
+				err = ctr.hashmapBuilder.copyBuildBatchProjected(result.Batch, proc, projection)
+			}
+		} else {
+			err = ctr.hashmapBuilder.copyBuildBatch(result.Batch, proc)
+		}
 		if err != nil {
 			if hashBuild.IsShuffle && errors.Is(err, process.ErrHashBuildBudgetAdmission) {
 				// The source batch is still owned by the upstream operator.  Do
 				// not retry CopyIntoBatches (or increment row count again); enter
-				// spill recovery and write this batch directly.
+				// spill recovery, then prove and write this batch directly. Any
+				// older retained copies are drained first under the recovery lease
+				// they already own, releasing their budget before this proof.
 				if err := startSpill(); err != nil {
+					return err
+				}
+				if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
 					return err
 				}
 				if err := ctr.spillBatchBounded(proc, result.Batch, spillFiles, ctr.spillExprExecs, analyzer, false); err != nil {
@@ -448,9 +490,9 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 				// publishing a semantically incomplete spill payload.
 				return err
 			}
-			// Preserve the copied batches and discard only partial map state.
-			// Scratch is admitted lazily while draining; failure remains a
-			// controlled resource error rather than an allocation past the cap.
+			// Preserve the copied batches and discard only partial map state. Every
+			// retained destination already owns a recovery high-water lease, so a
+			// hard map-budget rejection cannot strand the build in memory.
 			ctr.hashmapBuilder.FreeHashMapOnly(proc)
 			if err := startSpill(); err != nil {
 				return err

--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -219,6 +220,56 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 	var spillFiles []*os.File
 	bundleTransferred := false
 
+	ensureExpressionRecovery := func(rows int) error {
+		lease := ctr.hashmapBuilder.expressionLease
+		if lease == nil || lease.Len() != len(ctr.hashmapBuilder.executors) ||
+			len(ctr.hashmapBuilder.executors) != len(hashBuild.Conditions) {
+			return process.ErrHashBuildBudgetInvalid
+		}
+		return lease.EnsureRunRecovery(proc, rows)
+	}
+	ensureDirectRecovery := func(bat *batch.Batch) error {
+		if bat == nil {
+			return nil
+		}
+		if err := ensureExpressionRecovery(bat.RowCount()); err != nil {
+			return err
+		}
+		return ctr.ensureDirectSpillRecovery(bat, analyzer)
+	}
+	ensureRetainedRecovery := func(projection batchCopyProjection) error {
+		if err := ensureExpressionRecovery(projection.maxRetainedRows); err != nil {
+			return err
+		}
+		return ctr.ensureRetainedSpillRecovery(projection, analyzer)
+	}
+	ensureDirectRecoveryWithReclaim := func(bat *batch.Batch) error {
+		err := ensureDirectRecovery(bat)
+		if !spillMode || !errors.Is(err, process.ErrHashBuildBudgetAdmission) {
+			return err
+		}
+		reclaimed, reclaimErr := ctr.reclaimOptionalSpillCoalesce(
+			proc, spillFiles, analyzer)
+		if reclaimErr != nil {
+			return reclaimErr
+		}
+		if !reclaimed {
+			// The rejection came from mandatory owners or sibling pressure. A
+			// second identical admission cannot make progress.
+			return err
+		}
+		return ensureDirectRecovery(bat)
+	}
+	spillBatch := func(bat *batch.Batch, sourceAlreadyCharged bool) error {
+		return ctr.spillBatchBounded(
+			proc,
+			bat,
+			spillFiles,
+			analyzer,
+			sourceAlreadyCharged,
+		)
+	}
+
 	defer func() {
 		observeHashBuildBudget(analyzer, ctr.hashmapBuilder.budget)
 		for _, f := range spillFiles {
@@ -230,7 +281,6 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 			ctr.spillBundle.release()
 			ctr.spillBundle = nil
 		}
-		ctr.freeSpillExprExecs()
 		// Build-key executors are producer scratch. No consumer reads them after
 		// build() returns, so release their retained vectors and expression lease
 		// here instead of holding both until pipeline Reset.
@@ -258,9 +308,16 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 				hashBuild.JoinMapRefCnt,
 			)
 		}
-		execs, err := ctr.initSpillExprExecs(proc, hashBuild.Conditions)
-		if err != nil {
-			return err
+		for _, condition := range hashBuild.Conditions {
+			if condition == nil {
+				return process.ErrHashBuildBudgetInvalid
+			}
+		}
+		execs := ctr.hashmapBuilder.executors
+		expressionLease := ctr.hashmapBuilder.expressionLease
+		if expressionLease == nil || expressionLease.Len() != len(execs) ||
+			len(execs) != len(hashBuild.Conditions) {
+			return process.ErrHashBuildBudgetInvalid
 		}
 		if spillFiles == nil {
 			spillFiles = make([]*os.File, spillNumBuckets)
@@ -281,7 +338,7 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 				}
 				continue
 			}
-			if err := ctr.spillBatchBounded(proc, bat, spillFiles, execs, analyzer, true); err != nil {
+			if err := spillBatch(bat, true); err != nil {
 				return err
 			}
 			if err := ctr.hashmapBuilder.CleanCopiedBatchAt(0, proc); err != nil {
@@ -290,6 +347,17 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		}
 		v2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1").Inc()
 		return nil
+	}
+	spillDirect := func(bat *batch.Batch) error {
+		if err := startSpill(); err != nil {
+			return err
+		}
+		if hashBuild.IsShuffle {
+			if err := ensureDirectRecoveryWithReclaim(bat); err != nil {
+				return err
+			}
+		}
+		return spillBatch(bat, false)
 	}
 
 	for {
@@ -320,13 +388,7 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		ctr.hashmapBuilder.InputBatchRowCount += result.Batch.RowCount()
 		// If in spill mode, spill this batch directly to open files.
 		if spillMode {
-			if hashBuild.IsShuffle {
-				if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
-					return err
-				}
-			}
-			err := ctr.spillBatchBounded(proc, result.Batch, spillFiles, ctr.spillExprExecs, analyzer, false)
-			if err != nil {
+			if err := spillDirect(result.Batch); err != nil {
 				return err
 			}
 			continue
@@ -336,27 +398,7 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		// speculative spill sizing and reservation off the resident hot path while
 		// preserving enough budget headroom to drain the batches already retained.
 		if hashBuild.shouldSpillBeforeRetain(inputBatchSize) {
-			if hashBuild.IsShuffle {
-				// The current batch is still upstream-owned. If its direct recovery
-				// cannot grow while retained copies consume the shared generation,
-				// drain those copies under their existing lease and retry once.
-				if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
-					if !errors.Is(err, process.ErrHashBuildBudgetAdmission) ||
-						len(ctr.hashmapBuilder.Batches.Buf) == 0 {
-						return err
-					}
-					if err := startSpill(); err != nil {
-						return err
-					}
-					if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
-						return err
-					}
-				}
-			}
-			if err := startSpill(); err != nil {
-				return err
-			}
-			if err := ctr.spillBatchBounded(proc, result.Batch, spillFiles, ctr.spillExprExecs, analyzer, false); err != nil {
+			if err := spillDirect(result.Batch); err != nil {
 				return err
 			}
 			continue
@@ -372,7 +414,7 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 			var projection batchCopyProjection
 			projection, err = ctr.hashmapBuilder.projectedBatchCopy(result.Batch)
 			if err == nil {
-				err = ctr.ensureRetainedSpillRecovery(projection, analyzer)
+				err = ensureRetainedRecovery(projection)
 			}
 			if err == nil {
 				err = ctr.hashmapBuilder.copyBuildBatchProjected(result.Batch, proc, projection)
@@ -383,17 +425,11 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		if err != nil {
 			if hashBuild.IsShuffle && errors.Is(err, process.ErrHashBuildBudgetAdmission) {
 				// The source batch is still owned by the upstream operator.  Do
-				// not retry CopyIntoBatches (or increment row count again); enter
-				// spill recovery, then prove and write this batch directly. Any
-				// older retained copies are drained first under the recovery lease
-				// they already own, releasing their budget before this proof.
-				if err := startSpill(); err != nil {
-					return err
-				}
-				if err := ctr.ensureDirectSpillRecovery(result.Batch, analyzer); err != nil {
-					return err
-				}
-				if err := ctr.spillBatchBounded(proc, result.Batch, spillFiles, ctr.spillExprExecs, analyzer, false); err != nil {
+				// not retry CopyIntoBatches (or increment row count again). Every
+				// direct transition drains older retained copies under their existing
+				// guarantee, then gives mandatory recovery priority over optional
+				// write coalescing before writing this upstream-owned batch.
+				if err := spillDirect(result.Batch); err != nil {
 					return err
 				}
 				continue

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -48,6 +49,46 @@ const (
 	Rows          = 10     // default rows
 	BenchmarkRows = 100000 // default rows for benchmark
 )
+
+// gatedHashBuildInput exposes a deterministic boundary after HashBuild has
+// retained the first batch and before it can pull the second one. Tests use
+// that boundary to model other workers charging the same query generation
+// without scheduler sleeps or polling.
+type gatedHashBuildInput struct {
+	*colexec.MockOperator
+	batches            []*batch.Batch
+	current            int
+	firstBatchRetained chan struct{}
+	continueInput      chan struct{}
+}
+
+func newGatedHashBuildInput(batches ...*batch.Batch) *gatedHashBuildInput {
+	return &gatedHashBuildInput{
+		MockOperator:       colexec.NewMockOperator(),
+		batches:            batches,
+		firstBatchRetained: make(chan struct{}),
+		continueInput:      make(chan struct{}),
+	}
+}
+
+func (op *gatedHashBuildInput) Call(proc *process.Process) (vm.CallResult, error) {
+	result := vm.NewCallResult()
+	if op.current >= len(op.batches) {
+		result.Status = vm.ExecStop
+		return result, nil
+	}
+	if op.current == 1 {
+		close(op.firstBatchRetained)
+		select {
+		case <-op.continueInput:
+		case <-proc.Ctx.Done():
+			return result, context.Cause(proc.Ctx)
+		}
+	}
+	result.Batch = op.batches[op.current]
+	op.current++
+	return result, nil
+}
 
 func runtimeFilterPlanType(typ types.Type) *plan.Type {
 	return &plan.Type{
@@ -2518,7 +2559,7 @@ func TestHashBuildRejectsSharedSpillPayload(t *testing.T) {
 	tc.proc.Free()
 }
 
-func TestShuffleHashBuildDoesNotPreflightFutureSpill(t *testing.T) {
+func TestShuffleHashBuildRecoveryLeaseDoesNotForceSpill(t *testing.T) {
 	tc := newTestCase(t, []bool{false}, []types.Type{types.T_varchar.ToType()}, []*plan.Expr{newExpr(0, types.T_varchar.ToType())})
 	tc.arg.IsShuffle = true
 	tc.arg.ShuffleIdx = 0
@@ -2558,9 +2599,10 @@ func TestShuffleHashBuildDoesNotPreflightFutureSpill(t *testing.T) {
 	jm := result.JoinMap()
 	require.NotNil(t, jm)
 	require.False(t, jm.IsSpilled(),
-		"a resident build must not pay for or be redirected by hypothetical future spill scratch")
+		"a recovery lease changes admission ownership, not the local spill policy")
 	require.Equal(t, int64(1), jm.GetRowCount())
 	require.Zero(t, tc.arg.OpAnalyzer.GetOpStats().ExtraStats["HashBuildSpillStarts"])
+	require.Positive(t, tc.arg.OpAnalyzer.GetOpStats().ExtraStats["HashBuildSpillRecoveryReservedBytes"])
 	jm.Free()
 	require.Zero(t, generation.Used())
 	require.Zero(t, generation.SpillDiskUsed())
@@ -2599,41 +2641,23 @@ func TestShuffleHashBuildSpillsBeforeRetainingThresholdCrossingBatch(t *testing.
 	tc.arg.SpillThreshold = inputSize + 1
 	tc.arg.ctr.setSpillThreshold(tc.arg.SpillThreshold)
 
-	copyPeak, err := tc.arg.ctr.hashmapBuilder.projectedBatchCopyBytes(first)
+	projection, err := tc.arg.ctr.hashmapBuilder.projectedBatchCopy(first)
 	require.NoError(t, err)
-	retainedScratch, err := spillScratchBudgetBytes(first, true)
+	directRecovery, err := spillBudgetBytes(first)
 	require.NoError(t, err)
-	directScratch, err := spillBudgetBytes(second)
+	directRecovery, err = spillRecoveryReservationBytes(directRecovery)
+	require.NoError(t, err)
+	retainedRecovery, err := spillRetainedRecoveryBudgetBytes(projection)
+	require.NoError(t, err)
+	retainedRecovery, err = spillRecoveryReservationBytes(retainedRecovery)
 	require.NoError(t, err)
 
-	// Calibrate the retained reservation and the second copy's pre-allocation
-	// peak. The final cap deliberately admits both copies (the old path reaches
-	// its post-copy threshold) but rejects scratch while both sources are live;
-	// the pre-copy path needs only one retained source plus scratch, then the
-	// direct scratch after that source is released.
-	calibrationBudget := process.MustNewHashBuildBudget(1<<30, 1<<30)
-	calibration, err := calibrationBudget.OpenGeneration(1)
-	require.NoError(t, err)
-	var calibrationBuilder HashmapBuilder
-	calibrationBuilder.setBudget(calibration)
-	require.NoError(t, calibrationBuilder.copyBuildBatch(first, tc.proc))
-	actualFirst := calibration.Used()
-	secondCopyPeak, err := calibrationBuilder.projectedBatchCopyBytes(second)
-	require.NoError(t, err)
-	calibrationBuilder.cleanBatches(tc.proc)
-	require.Zero(t, calibration.Used())
-	calibration.Close()
-
+	// Admit the first recovery lease and its retained-copy allocation together.
+	// The second batch crosses the local threshold and must be spilled directly,
+	// without a second retained copy or any failed shared-budget admission.
 	coalesceSlack := uint64(spillNumBuckets * spillWriteCoalesceSize)
-	capBytes := max(
-		copyPeak,
-		actualFirst+secondCopyPeak,
-		actualFirst+retainedScratch,
-		directScratch,
-	) + coalesceSlack
-	oldPostCopyPeak := 2*actualFirst + retainedScratch
-	require.Less(t, capBytes, oldPostCopyPeak,
-		"fixture must reject lazy scratch only after retaining the crossing batch")
+	capBytes := max(directRecovery, retainedRecovery) +
+		projection.admissionBytes + coalesceSlack
 	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
 	generation, err := budget.OpenGeneration(1)
 	require.NoError(t, err)
@@ -2678,7 +2702,272 @@ func TestShuffleHashBuildSpillsBeforeRetainingThresholdCrossingBatch(t *testing.
 	require.Zero(t, tc.proc.Mp().CurrNB())
 }
 
-func TestShuffleHashBuildLazySpillAdmissionFailsClosed(t *testing.T) {
+func TestShuffleHashBuildPreservesRecoveryHeadroomAcrossSharedBudgetPressure(t *testing.T) {
+	typ := types.T_int32.ToType()
+	tc := newTestCase(t, []bool{false}, []types.Type{typ}, []*plan.Expr{newExpr(0, typ)})
+	tc.arg.IsShuffle = true
+	tc.arg.ShuffleIdx = 0
+	tc.arg.SpillThreshold = 2 * colexec.DefaultBatchSize
+	tc.arg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 3503}
+
+	makeBuildBatch := func(base int32) *batch.Batch {
+		values := make([]int32, colexec.DefaultBatchSize)
+		for i := range values {
+			values[i] = base + int32(i)
+		}
+		bat := batch.NewWithSize(1)
+		bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, tc.proc.Mp())
+		bat.SetRowCount(len(values))
+		return bat
+	}
+	first := makeBuildBatch(0)
+	second := makeBuildBatch(colexec.DefaultBatchSize)
+	input := newGatedHashBuildInput(first, second)
+	tc.arg.SetChildren([]vm.Operator{input})
+	require.NoError(t, input.Prepare(tc.proc))
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	directNeed, err := spillBudgetBytes(first)
+	require.NoError(t, err)
+	retainedNeed, err := spillScratchBudgetBytes(first, true)
+	require.NoError(t, err)
+	recoveryNeed := max(directNeed, retainedNeed)
+	require.Positive(t, recoveryNeed)
+
+	const capBytes = uint64(64 << 20)
+	require.Less(t, recoveryNeed, capBytes/2)
+	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	tc.arg.ctr.hashmapBuilder.setBudget(generation)
+
+	type execOutcome struct {
+		result vm.CallResult
+		err    error
+	}
+	execDone := make(chan execOutcome, 1)
+	go func() {
+		result, execErr := vm.Exec(tc.arg, tc.proc)
+		execDone <- execOutcome{result: result, err: execErr}
+	}()
+
+	select {
+	case <-input.firstBatchRetained:
+	case outcome := <-execDone:
+		t.Fatalf("HashBuild stopped before retaining the first batch: result=%+v err=%v", outcome.result, outcome.err)
+	}
+	continued := false
+	defer func() {
+		if !continued {
+			close(input.continueInput)
+		}
+	}()
+
+	usedAfterFirst := generation.Used()
+	require.Less(t, usedAfterFirst+recoveryNeed, capBytes)
+	// Model sibling HashBuild workers consuming every byte except one less than
+	// this worker needs to recover. A valid recovery lease is already charged
+	// and remains usable; a lazy design has no way to start spilling here.
+	blockerBytes := capBytes - usedAfterFirst - (retainedNeed - 1)
+	blocker, err := generation.Reserve(blockerBytes)
+	require.NoError(t, err)
+
+	close(input.continueInput)
+	continued = true
+	outcome := <-execDone
+	require.NoError(t, outcome.err)
+	require.Equal(t, vm.ExecStop, outcome.result.Status)
+
+	result, err := message.ReceiveJoinMapResult(
+		tc.arg.JoinMapTag, true, tc.arg.ShuffleIdx,
+		tc.proc.GetMessageBoard(), tc.proc.Ctx)
+	require.NoError(t, err)
+	require.True(t, result.IsSuccess())
+	jm := result.JoinMap()
+	require.NotNil(t, jm)
+	require.True(t, jm.IsSpilled())
+	require.Equal(t, int64(2*colexec.DefaultBatchSize), jm.GetRowCount())
+	payload, err := jm.TakeSpillBuildPayload()
+	require.NoError(t, err)
+	require.NoError(t, payload.Close())
+
+	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
+	require.Equal(t, int64(1), extra["HashBuildSpillStarts"])
+	require.Zero(t, extra["HashBuildSpillScratchReserveRejects"])
+	require.Zero(t, extra["HashBuildSpillScratchGrowRejects"])
+
+	require.True(t, blocker.Release())
+	require.Zero(t, generation.Used())
+	tc.arg.Reset(tc.proc, false, nil)
+	tc.arg.Free(tc.proc, false, nil)
+	input.Reset(tc.proc, false, nil)
+	input.Free(tc.proc, false, nil)
+	first.Clean(tc.proc.Mp())
+	second.Clean(tc.proc.Mp())
+	generation.Close()
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
+}
+
+func TestShuffleHashBuildRecoveryLeaseSharedGenerationFanout(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	values := make([]int32, colexec.DefaultBatchSize)
+	for i := range values {
+		values[i] = int32(i)
+	}
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	bat.SetRowCount(len(values))
+	defer bat.Clean(proc.Mp())
+
+	var projectionBuilder HashmapBuilder
+	projection, err := projectionBuilder.projectedBatchCopy(bat)
+	require.NoError(t, err)
+	directNeed, err := spillBudgetBytes(bat)
+	require.NoError(t, err)
+	directNeed, err = spillRecoveryReservationBytes(directNeed)
+	require.NoError(t, err)
+	retainedNeed, err := spillRetainedRecoveryBudgetBytes(projection)
+	require.NoError(t, err)
+	retainedNeed, err = spillRecoveryReservationBytes(retainedNeed)
+	require.NoError(t, err)
+	perWorker := max(directNeed, retainedNeed)
+
+	for _, workers := range []int{1, 8, 64} {
+		t.Run(fmt.Sprintf("workers-%d", workers), func(t *testing.T) {
+			capBytes, err := spillCheckedMul(perWorker, uint64(workers))
+			require.NoError(t, err)
+			budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+			generation, err := budget.OpenGeneration(1)
+			require.NoError(t, err)
+
+			containers := make([]container, workers)
+			analyzers := make([]process.Analyzer, workers)
+			start := make(chan struct{})
+			errs := make(chan error, workers)
+			var wg sync.WaitGroup
+			for i := range containers {
+				containers[i].hashmapBuilder.setBudget(generation)
+				analyzers[i] = process.NewAnalyzer(i, false, false, "recovery fanout")
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					<-start
+					if reserveErr := containers[i].ensureDirectSpillRecovery(bat, analyzers[i]); reserveErr != nil {
+						errs <- reserveErr
+						return
+					}
+					errs <- containers[i].ensureRetainedSpillRecovery(projection, analyzers[i])
+				}(i)
+			}
+			close(start)
+			wg.Wait()
+			close(errs)
+			for reserveErr := range errs {
+				require.NoError(t, reserveErr)
+			}
+			require.Equal(t, capBytes, generation.Used())
+			for i := range containers {
+				require.Equal(t, perWorker, containers[i].spillScratchBase)
+				require.NotNil(t, containers[i].spillScratchReservation)
+			}
+
+			wg = sync.WaitGroup{}
+			for i := range containers {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					containers[i].releaseSpillScratchReservation()
+					containers[i].releaseSpillScratchReservation()
+				}(i)
+			}
+			wg.Wait()
+			require.Zero(t, generation.Used())
+			generation.Close()
+		})
+	}
+}
+
+func TestShuffleHashBuildCancellationReleasesRecoveryLease(t *testing.T) {
+	typ := types.T_int32.ToType()
+	tc := newTestCase(t, []bool{false}, []types.Type{typ}, []*plan.Expr{newExpr(0, typ)})
+	tc.arg.IsShuffle = true
+	tc.arg.ShuffleIdx = 0
+	tc.arg.SpillThreshold = math.MaxInt64
+	tc.arg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 3504}
+
+	ctx, cancel := context.WithCancelCause(tc.proc.Ctx)
+	process.ReplacePipelineCtx(tc.proc, ctx, cancel)
+	makeBuildBatch := func(base int32) *batch.Batch {
+		values := make([]int32, colexec.DefaultBatchSize)
+		for i := range values {
+			values[i] = base + int32(i)
+		}
+		bat := batch.NewWithSize(1)
+		bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, tc.proc.Mp())
+		bat.SetRowCount(len(values))
+		return bat
+	}
+	first := makeBuildBatch(0)
+	second := makeBuildBatch(colexec.DefaultBatchSize)
+	input := newGatedHashBuildInput(first, second)
+	tc.arg.SetChildren([]vm.Operator{input})
+	require.NoError(t, input.Prepare(tc.proc))
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	const capBytes = uint64(64 << 20)
+	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	tc.arg.ctr.hashmapBuilder.setBudget(generation)
+
+	type execOutcome struct {
+		result vm.CallResult
+		err    error
+	}
+	execDone := make(chan execOutcome, 1)
+	go func() {
+		result, execErr := vm.Exec(tc.arg, tc.proc)
+		execDone <- execOutcome{result: result, err: execErr}
+	}()
+	select {
+	case <-input.firstBatchRetained:
+	case outcome := <-execDone:
+		t.Fatalf("HashBuild stopped before the cancellation boundary: result=%+v err=%v", outcome.result, outcome.err)
+	}
+	require.NotNil(t, tc.arg.ctr.spillScratchReservation)
+	require.Positive(t, generation.Used())
+
+	cancel(context.Canceled)
+	outcome := <-execDone
+	require.ErrorIs(t, outcome.err, context.Canceled)
+	require.Nil(t, tc.arg.ctr.spillScratchReservation,
+		"build terminal cleanup owns the recovery lease")
+	require.Positive(t, generation.Used(),
+		"the copied batch remains owned until pipeline Reset")
+
+	terminal, err := message.ReceiveJoinMapResult(
+		tc.arg.JoinMapTag, true, tc.arg.ShuffleIdx,
+		tc.proc.GetMessageBoard(), context.Background())
+	require.NoError(t, err)
+	require.True(t, terminal.IsBuildError())
+
+	tc.arg.Reset(tc.proc, true, outcome.err)
+	tc.arg.Reset(tc.proc, true, outcome.err)
+	input.Reset(tc.proc, true, outcome.err)
+	require.Zero(t, generation.Used())
+	tc.arg.Free(tc.proc, true, outcome.err)
+	tc.arg.Free(tc.proc, true, outcome.err)
+	input.Free(tc.proc, true, outcome.err)
+	first.Clean(tc.proc.Mp())
+	second.Clean(tc.proc.Mp())
+	generation.Close()
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
+}
+
+func TestShuffleHashBuildRecoveryAdmissionFailsBeforeRetain(t *testing.T) {
 	tc := newTestCase(t, []bool{false}, []types.Type{types.T_varchar.ToType()}, []*plan.Expr{newExpr(0, types.T_varchar.ToType())})
 	tc.arg.IsShuffle = true
 	tc.arg.ShuffleIdx = 0
@@ -2698,10 +2987,9 @@ func TestShuffleHashBuildLazySpillAdmissionFailsClosed(t *testing.T) {
 	require.NoError(t, err)
 	build.SetRowCount(1)
 
-	// Leave enough budget for the retained copy itself, but not for the
-	// additional scratch needed after the threshold requests spill. The lazy
-	// path must fail before scratch allocation instead of requiring every
-	// resident batch to pre-admit a hypothetical future spill.
+	// Leave enough budget for the retained copy in isolation, but not for the
+	// direct recovery path. Retention is forbidden: failing before the copy is
+	// the only state that neither exceeds the cap nor strands owned build rows.
 	copyPeak, err := tc.arg.ctr.hashmapBuilder.projectedBatchCopyBytes(build)
 	require.NoError(t, err)
 	budget := process.MustNewHashBuildBudget(copyPeak, copyPeak)
@@ -2717,8 +3005,9 @@ func TestShuffleHashBuildLazySpillAdmissionFailsClosed(t *testing.T) {
 		"terminal spill admission must use the resource-exhausted wire code")
 	require.Contains(t, buildErr.Error(), "hash build memory budget exceeded")
 	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
-	require.Equal(t, int64(1), extra["HashBuildSpillStarts"])
-	require.Equal(t, int64(1), extra["HashBuildSpillScratchReserveRejects"])
+	require.Zero(t, extra["HashBuildSpillStarts"])
+	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryReserveRejects"])
+	require.Zero(t, extra["HashBuildSpillScratchReserveRejects"])
 	require.Equal(t, int64(1), extra["QueryHashBudgetRejects"])
 
 	result, err := message.ReceiveJoinMapResult(

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -2809,6 +2809,118 @@ func TestShuffleHashBuildPreservesRecoveryHeadroomAcrossSharedBudgetPressure(t *
 	require.Zero(t, tc.proc.Mp().CurrNB())
 }
 
+func TestShuffleHashBuildExpressionRecoverySurvivesSharedBudgetPressure(t *testing.T) {
+	bindProc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	left := newExpr(0, types.T_int32.ToType())
+	right := newExpr(1, types.T_int32.ToType())
+	modulo, err := plan2.BindFuncExprImplByPlanExpr(
+		bindProc.Ctx,
+		"%",
+		[]*plan.Expr{left, right},
+	)
+	require.NoError(t, err)
+	bindProc.Free()
+
+	typ := types.T_int32.ToType()
+	tc := newTestCase(
+		t,
+		[]bool{false, false},
+		[]types.Type{typ, typ},
+		[]*plan.Expr{modulo},
+	)
+	tc.arg.IsShuffle = true
+	tc.arg.ShuffleIdx = 0
+	tc.arg.SpillThreshold = 2 * colexec.DefaultBatchSize
+	tc.arg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 3505}
+
+	makeBuildBatch := func(base int32) *batch.Batch {
+		leftValues := make([]int32, colexec.DefaultBatchSize)
+		rightValues := make([]int32, colexec.DefaultBatchSize)
+		for i := range leftValues {
+			leftValues[i] = base + int32(i)
+			rightValues[i] = int32(i%97 + 1)
+		}
+		bat := batch.NewWithSize(2)
+		bat.Vecs[0] = testutil.MakeInt32Vector(leftValues, nil, tc.proc.Mp())
+		bat.Vecs[1] = testutil.MakeInt32Vector(rightValues, nil, tc.proc.Mp())
+		bat.SetRowCount(len(leftValues))
+		return bat
+	}
+	first := makeBuildBatch(0)
+	second := makeBuildBatch(colexec.DefaultBatchSize)
+	input := newGatedHashBuildInput(first, second)
+	tc.arg.SetChildren([]vm.Operator{input})
+
+	// Initialize the Process-owned generation before Prepare so both the build
+	// expression lease and every later recovery owner charge the same ledger.
+	const capBytes = uint64(64 << 20)
+	tc.proc.Base.Lim.Size = int64(capBytes)
+	generation, err := tc.proc.GetHashBuildBudget()
+	require.NoError(t, err)
+	require.NoError(t, input.Prepare(tc.proc))
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	type execOutcome struct {
+		result vm.CallResult
+		err    error
+	}
+	execDone := make(chan execOutcome, 1)
+	go func() {
+		result, execErr := vm.Exec(tc.arg, tc.proc)
+		execDone <- execOutcome{result: result, err: execErr}
+	}()
+
+	select {
+	case <-input.firstBatchRetained:
+	case outcome := <-execDone:
+		t.Fatalf("HashBuild stopped before retaining the first batch: result=%+v err=%v", outcome.result, outcome.err)
+	}
+	continued := false
+	defer func() {
+		if !continued {
+			close(input.continueInput)
+		}
+	}()
+
+	usedAfterFirst := generation.Used()
+	require.Less(t, usedAfterFirst, capBytes)
+	blocker, err := generation.Reserve(capBytes - usedAfterFirst)
+	require.NoError(t, err)
+	require.Equal(t, capBytes, generation.Used())
+
+	close(input.continueInput)
+	continued = true
+	outcome := <-execDone
+	require.NoError(t, outcome.err)
+	require.Equal(t, vm.ExecStop, outcome.result.Status)
+
+	result, err := message.ReceiveJoinMapResult(
+		tc.arg.JoinMapTag, true, tc.arg.ShuffleIdx,
+		tc.proc.GetMessageBoard(), tc.proc.Ctx)
+	require.NoError(t, err)
+	require.True(t, result.IsSuccess())
+	jm := result.JoinMap()
+	require.NotNil(t, jm)
+	require.True(t, jm.IsSpilled())
+	require.Equal(t, int64(2*colexec.DefaultBatchSize), jm.GetRowCount())
+	payload, err := jm.TakeSpillBuildPayload()
+	require.NoError(t, err)
+	require.NoError(t, payload.Close())
+	require.Equal(t, int64(1),
+		tc.arg.OpAnalyzer.GetOpStats().ExtraStats["HashBuildSpillStarts"])
+
+	require.True(t, blocker.Release())
+	require.Zero(t, generation.Used())
+	tc.arg.Reset(tc.proc, false, nil)
+	tc.arg.Free(tc.proc, false, nil)
+	input.Reset(tc.proc, false, nil)
+	input.Free(tc.proc, false, nil)
+	first.Clean(tc.proc.Mp())
+	second.Clean(tc.proc.Mp())
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
+}
+
 func TestShuffleHashBuildRecoveryLeaseSharedGenerationFanout(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
@@ -3005,7 +3117,8 @@ func TestShuffleHashBuildRecoveryAdmissionFailsBeforeRetain(t *testing.T) {
 		"terminal spill admission must use the resource-exhausted wire code")
 	require.Contains(t, buildErr.Error(), "hash build memory budget exceeded")
 	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
-	require.Zero(t, extra["HashBuildSpillStarts"])
+	require.Equal(t, int64(1), extra["HashBuildSpillStarts"],
+		"the terminal direct-spill transition is counted even when admission rejects before I/O")
 	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryReserveRejects"])
 	require.Zero(t, extra["HashBuildSpillScratchReserveRejects"])
 	require.Equal(t, int64(1), extra["QueryHashBudgetRejects"])
@@ -3024,6 +3137,77 @@ func TestShuffleHashBuildRecoveryAdmissionFailsBeforeRetain(t *testing.T) {
 	tc.arg.Free(tc.proc, true, buildErr)
 	build.Clean(tc.proc.Mp())
 	require.Zero(t, generation.Used())
+	generation.Close()
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
+}
+
+func TestShuffleHashBuildSpillModeReclaimsOptionalCacheForRecoveryGrowth(t *testing.T) {
+	tc := newTestCase(t, []bool{false}, []types.Type{types.T_int32.ToType()}, []*plan.Expr{newExpr(0, types.T_int32.ToType())})
+	tc.arg.IsShuffle = true
+	tc.arg.ShuffleIdx = 0
+	tc.arg.SpillThreshold = 1
+	tc.arg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 3510}
+	tc.arg.SetChildren([]vm.Operator{tc.marg})
+	require.NoError(t, tc.marg.Prepare(tc.proc))
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	first := newBatch(tc.types, tc.proc, 1)
+	second := newBatch(tc.types, tc.proc, 2048)
+	firstNeed, err := spillBudgetBytes(first)
+	require.NoError(t, err)
+	firstNeed, err = spillRecoveryReservationBytes(firstNeed)
+	require.NoError(t, err)
+	secondNeed, err := spillBudgetBytes(second)
+	require.NoError(t, err)
+	secondNeed, err = spillRecoveryReservationBytes(secondNeed)
+	require.NoError(t, err)
+	require.Equal(t, firstNeed+uint64(spillWriteCoalesceSize), secondNeed,
+		"fixture needs one optional-cache quantum between recovery high waters")
+
+	budget := process.MustNewHashBuildBudget(secondNeed, secondNeed)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	tc.arg.ctr.hashmapBuilder.setBudget(generation)
+
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(first, nil, tc.proc.Mp())
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(second, nil, tc.proc.Mp())
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, tc.proc.Mp())
+	result, buildErr := vm.Exec(tc.arg, tc.proc)
+	require.NoError(t, buildErr)
+	require.Equal(t, vm.ExecStop, result.Status)
+
+	joinResult, err := message.ReceiveJoinMapResult(
+		tc.arg.JoinMapTag, true, tc.arg.ShuffleIdx,
+		tc.proc.GetMessageBoard(), tc.proc.Ctx)
+	require.NoError(t, err)
+	require.True(t, joinResult.IsSuccess())
+	jm := joinResult.JoinMap()
+	require.NotNil(t, jm)
+	require.True(t, jm.IsSpilled())
+	require.Equal(t, int64(2049), jm.GetRowCount())
+	payload, err := jm.TakeSpillBuildPayload()
+	require.NoError(t, err)
+	require.NoError(t, payload.Close())
+
+	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
+	require.Equal(t, int64(1), extra["HashBuildSpillStarts"])
+	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowRejects"])
+	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowCount"])
+	require.Equal(t, int64(secondNeed-firstNeed),
+		extra["HashBuildSpillRecoveryGrowBytes"])
+	require.Equal(t, int64(1), extra["HashBuildCoalesceGrowRejects"],
+		"one failed optional probe switches the rest of this batch to write-through")
+	require.Equal(t, int64(2), extra["QueryHashBudgetRejects"])
+	require.Zero(t, generation.Used())
+	require.Zero(t, generation.SpillDiskUsed())
+	require.Zero(t, generation.SpillFDUsed())
+
+	tc.arg.Reset(tc.proc, false, nil)
+	tc.marg.Reset(tc.proc, false, nil)
+	tc.arg.Free(tc.proc, false, nil)
+	first.Clean(tc.proc.Mp())
+	second.Clean(tc.proc.Mp())
 	generation.Close()
 	tc.proc.Free()
 	require.Zero(t, tc.proc.Mp().CurrNB())
@@ -3066,9 +3250,10 @@ func TestShuffleHashBuildSpillModeGrowthRejectReleasesRecoveryLease(t *testing.T
 
 	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
 	require.Equal(t, int64(1), extra["HashBuildSpillStarts"])
-	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowRejects"])
+	require.Equal(t, int64(2), extra["HashBuildSpillRecoveryGrowRejects"],
+		"reclaim retries once, then preserves a genuine over-cap failure")
 	require.Zero(t, extra["HashBuildCoalesceGrowRejects"])
-	require.Equal(t, int64(1), extra["QueryHashBudgetRejects"])
+	require.Equal(t, int64(2), extra["QueryHashBudgetRejects"])
 	require.Nil(t, tc.arg.ctr.spillScratchReservation)
 	require.Zero(t, tc.arg.ctr.spillScratchBase)
 	require.Zero(t, generation.Used())

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -3029,6 +3029,69 @@ func TestShuffleHashBuildRecoveryAdmissionFailsBeforeRetain(t *testing.T) {
 	require.Zero(t, tc.proc.Mp().CurrNB())
 }
 
+func TestShuffleHashBuildSpillModeGrowthRejectReleasesRecoveryLease(t *testing.T) {
+	tc := newTestCase(t, []bool{false}, []types.Type{types.T_int32.ToType()}, []*plan.Expr{newExpr(0, types.T_int32.ToType())})
+	tc.arg.IsShuffle = true
+	tc.arg.ShuffleIdx = 0
+	tc.arg.SpillThreshold = 1
+	tc.arg.RuntimeFilterSpec = &plan.RuntimeFilterSpec{Tag: tc.arg.JoinMapTag + 3503}
+	tc.arg.SetChildren([]vm.Operator{tc.marg})
+	require.NoError(t, tc.marg.Prepare(tc.proc))
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	first := newBatch(tc.types, tc.proc, 1)
+	second := newBatch(tc.types, tc.proc, 8*colexec.DefaultBatchSize)
+	firstNeed, err := spillBudgetBytes(first)
+	require.NoError(t, err)
+	firstNeed, err = spillRecoveryReservationBytes(firstNeed)
+	require.NoError(t, err)
+	secondNeed, err := spillBudgetBytes(second)
+	require.NoError(t, err)
+	secondNeed, err = spillRecoveryReservationBytes(secondNeed)
+	require.NoError(t, err)
+	capBytes := firstNeed + uint64(spillWriteCoalesceSize)
+	require.Greater(t, secondNeed, capBytes)
+
+	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	tc.arg.ctr.hashmapBuilder.setBudget(generation)
+
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(first, nil, tc.proc.Mp())
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(second, nil, tc.proc.Mp())
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, tc.proc.Mp())
+	_, buildErr := vm.Exec(tc.arg, tc.proc)
+	require.True(t, moerr.IsMoErrCode(buildErr, moerr.ErrOOM))
+	require.Contains(t, buildErr.Error(), "hash build memory budget exceeded")
+
+	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
+	require.Equal(t, int64(1), extra["HashBuildSpillStarts"])
+	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowRejects"])
+	require.Zero(t, extra["HashBuildCoalesceGrowRejects"])
+	require.Equal(t, int64(1), extra["QueryHashBudgetRejects"])
+	require.Nil(t, tc.arg.ctr.spillScratchReservation)
+	require.Zero(t, tc.arg.ctr.spillScratchBase)
+	require.Zero(t, generation.Used())
+
+	result, err := message.ReceiveJoinMapResult(
+		tc.arg.JoinMapTag, true, tc.arg.ShuffleIdx,
+		tc.proc.GetMessageBoard(), tc.proc.Ctx)
+	require.NoError(t, err)
+	require.True(t, result.IsBuildError())
+	require.Equal(t, buildErr.Error(), result.BuildError().Error())
+
+	tc.arg.Reset(tc.proc, true, buildErr)
+	tc.marg.Reset(tc.proc, true, buildErr)
+	tc.arg.Free(tc.proc, true, buildErr)
+	first.Clean(tc.proc.Mp())
+	second.Clean(tc.proc.Mp())
+	require.Zero(t, generation.SpillDiskUsed())
+	require.Zero(t, generation.SpillFDUsed())
+	generation.Close()
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
+}
+
 func TestShuffleHashBuildSpillsExpressionKey(t *testing.T) {
 	bindProc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	col := newExpr(0, types.T_int32.ToType())

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -2809,13 +2809,13 @@ func TestShuffleHashBuildPreservesRecoveryHeadroomAcrossSharedBudgetPressure(t *
 	require.Zero(t, tc.proc.Mp().CurrNB())
 }
 
-func TestShuffleHashBuildExpressionRecoverySurvivesSharedBudgetPressure(t *testing.T) {
+func TestShuffleHashBuildSerialFullRecoverySurvivesSharedBudgetPressure(t *testing.T) {
 	bindProc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	left := newExpr(0, types.T_int32.ToType())
 	right := newExpr(1, types.T_int32.ToType())
-	modulo, err := plan2.BindFuncExprImplByPlanExpr(
+	serialFull, err := plan2.BindFuncExprImplByPlanExpr(
 		bindProc.Ctx,
-		"%",
+		"serial_full",
 		[]*plan.Expr{left, right},
 	)
 	require.NoError(t, err)
@@ -2826,7 +2826,7 @@ func TestShuffleHashBuildExpressionRecoverySurvivesSharedBudgetPressure(t *testi
 		t,
 		[]bool{false, false},
 		[]types.Type{typ, typ},
-		[]*plan.Expr{modulo},
+		[]*plan.Expr{serialFull},
 	)
 	tc.arg.IsShuffle = true
 	tc.arg.ShuffleIdx = 0

--- a/pkg/sql/colexec/hashbuild/expression_memory.go
+++ b/pkg/sql/colexec/hashbuild/expression_memory.go
@@ -23,13 +23,18 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
 type expressionMemoryLeaseSlot struct {
-	tokens       []*process.HashBuildReservation
-	admittedPeak uint64
-	variableSize bool
+	tokens                   []*process.HashBuildReservation
+	admittedPeak             uint64
+	mayReplaceWithinBound    bool
+	recoveryPeak             uint64
+	recoveryMayReplace       bool
+	recoveryCandidate        uint64
+	recoveryCandidateReplace bool
 }
 
 // ExpressionMemoryLease couples one stable expression-executor set to the
@@ -46,12 +51,16 @@ type expressionMemoryLeaseSlot struct {
 // The owner must Free every executor and duplicate vector covered by the lease
 // before calling Release. A lease cannot cross statement budget generations.
 type ExpressionMemoryLease struct {
-	budget    *process.HashBuildBudgetGeneration
-	exprs     []*plan.Expr
-	executors []colexec.ExpressionExecutor
-	duplicate bool
-	slots     []expressionMemoryLeaseSlot
-	released  bool
+	budget              *process.HashBuildBudgetGeneration
+	exprs               []*plan.Expr
+	executors           []colexec.ExpressionExecutor
+	duplicate           bool
+	slots               []expressionMemoryLeaseSlot
+	recoveryReservation *process.HashBuildReservation
+	recoveryRows        int
+	recoveryReady       bool
+	recoveryReconcile   bool
+	released            bool
 }
 
 // NewBudgetedExpressionExecutors admits the mpool-backed capacity owned by
@@ -125,7 +134,7 @@ func NewBudgetedExpressionExecutors(
 			return nil, nil, process.ErrHashBuildBudgetInvalid
 		}
 		slot := &lease.slots[i]
-		slot.variableSize = expressionExecutorMayGrowWithinBound(expr)
+		slot.mayReplaceWithinBound = expressionExecutorMayGrowWithinBound(expr)
 		if len(slot.tokens) > 0 {
 			token := slot.tokens[0]
 			if retained == 0 {
@@ -168,7 +177,7 @@ func NewExpressionMemoryLease(
 			return nil, process.ErrHashBuildBudgetInvalid
 		}
 		lease.slots[i].admittedPeak = retained
-		lease.slots[i].variableSize = expressionExecutorMayGrowWithinBound(exprs[i])
+		lease.slots[i].mayReplaceWithinBound = expressionExecutorMayGrowWithinBound(exprs[i])
 		if retained == 0 {
 			continue
 		}
@@ -214,6 +223,18 @@ func expressionListInitialOwnedBytes(exprs []*plan.Expr) (uint64, error) {
 }
 
 func expressionExecutorMayGrowWithinBound(expr *plan.Expr) bool {
+	return expressionExecutorMayGrowWithinSelection(expr, false)
+}
+
+// expressionExecutorMayGrowWithinSelection reports whether an executor tree
+// can replace retained mpool capacity without increasing its input row bound.
+// Varlena values can change size at the same row count. A function evaluated
+// through a partial flow-control mask can likewise grow its cached compacted
+// parameters and selected result when only the mask distribution changes.
+func expressionExecutorMayGrowWithinSelection(
+	expr *plan.Expr,
+	mayReceivePartialSelection bool,
+) bool {
 	if expr == nil {
 		return true
 	}
@@ -221,11 +242,20 @@ func expressionExecutorMayGrowWithinBound(expr *plan.Expr) bool {
 	case *plan.Expr_Col, *plan.Expr_Lit, *plan.Expr_T, *plan.Expr_Vec:
 		return false
 	case *plan.Expr_F:
-		if types.T(expr.Typ.Id).FixedLength() < 0 {
+		if typed.F == nil || types.T(expr.Typ.Id).FixedLength() < 0 ||
+			mayReceivePartialSelection {
 			return true
 		}
-		for _, arg := range typed.F.GetArgs() {
-			if expressionExecutorMayGrowWithinBound(arg) {
+		fid := int32(-1)
+		if typed.F.Func != nil {
+			fid, _ = function.DecodeOverloadID(typed.F.Func.Obj)
+		}
+		for i, arg := range typed.F.GetArgs() {
+			if expressionExecutorMayGrowWithinSelection(
+				arg,
+				expressionChildMayReceivePartialSelection(
+					fid, i, mayReceivePartialSelection),
+			) {
 				return true
 			}
 		}
@@ -235,7 +265,8 @@ func expressionExecutorMayGrowWithinBound(expr *plan.Expr) bool {
 			return true
 		}
 		for _, item := range typed.List.GetList() {
-			if expressionExecutorMayGrowWithinBound(item) {
+			if expressionExecutorMayGrowWithinSelection(
+				item, mayReceivePartialSelection) {
 				return true
 			}
 		}
@@ -244,6 +275,21 @@ func expressionExecutorMayGrowWithinBound(expr *plan.Expr) bool {
 		return types.T(expr.Typ.Id).FixedLength() < 0
 	default:
 		return true
+	}
+}
+
+func expressionChildMayReceivePartialSelection(
+	fid int32,
+	argument int,
+	parentMayReceivePartialSelection bool,
+) bool {
+	switch fid {
+	case function.IFF, function.CASE, function.COALESCE:
+		// The first argument inherits the caller's mask. Every later argument
+		// can receive a mask narrowed by an earlier condition/value.
+		return parentMayReceivePartialSelection || argument > 0
+	default:
+		return parentMayReceivePartialSelection
 	}
 }
 
@@ -319,6 +365,160 @@ func initialAllocationCapacity(required uint64) (uint64, error) {
 	return uint64(capacity), nil
 }
 
+// EnsureRunRecovery admits the complete expression-executor peak needed to
+// evaluate batches up to rows without another budget reservation. HashBuild
+// calls it before retaining a spillable batch, so spill can always evaluate a
+// key and release the first retained batch even when sibling workers consume
+// all remaining query headroom.
+//
+// Root executors run sequentially but retain their result capacities. The
+// first-run bound therefore replaces each root's old admitted capacity with
+// its target peak in evaluation order. Executors whose capacity can still
+// vary inside the same row bound (varlena values or flow-control selected
+// scratch) may always overlap one old result with one replacement. A stable
+// fixed-width root needs the same protection only until it has successfully
+// reached this row high water. One aggregate standby token covers the largest
+// such overlap instead of pessimistically reserving two copies for every root.
+func (l *ExpressionMemoryLease) EnsureRunRecovery(
+	proc *process.Process,
+	rows int,
+) error {
+	if l == nil {
+		return process.ErrHashBuildBudgetInvalid
+	}
+	if l.released {
+		return process.ErrHashBuildReservationInactive
+	}
+	if rows < 0 || len(l.exprs) != len(l.executors) || len(l.slots) != len(l.executors) {
+		return process.ErrHashBuildBudgetInvalid
+	}
+	if l.budget == nil || (l.recoveryReady && rows <= l.recoveryRows) {
+		return nil
+	}
+
+	var running uint64
+	for i := range l.slots {
+		retained, ok := colexec.ExpressionExecutorRetainedBytes(l.executors[i])
+		if !ok || retained > l.slots[i].admittedPeak {
+			return process.ErrHashBuildBudgetInvalid
+		}
+		if running > math.MaxUint64-l.slots[i].admittedPeak {
+			return process.ErrHashBuildBudgetInvalid
+		}
+		running += l.slots[i].admittedPeak
+	}
+
+	target := running
+	var replacementOverlap uint64
+	for i, expr := range l.exprs {
+		peak, err := expressionVectorPeak(proc, expr, rows, l.duplicate)
+		if err != nil {
+			return err
+		}
+		slot := &l.slots[i]
+		slot.recoveryCandidate = peak
+		slot.recoveryCandidateReplace = slot.mayReplaceWithinBound
+
+		allocation := peak
+		nextRetained := peak
+		if slot.admittedPeak > nextRetained {
+			// Executors retain reusable high-water capacity; evaluating a
+			// smaller variable-width value does not prove that old capacity was
+			// returned to mpool.
+			nextRetained = slot.admittedPeak
+		}
+		if !slot.mayReplaceWithinBound && peak <= slot.admittedPeak {
+			// A fixed-width executor whose high water already covers this row
+			// bound reuses its vectors and retains the existing capacity.
+			allocation = 0
+			nextRetained = slot.admittedPeak
+		} else if !slot.mayReplaceWithinBound {
+			// Until this exact high water has executed successfully, a smaller
+			// fixed-width result can still overlap its later replacement.
+			slot.recoveryCandidateReplace = true
+		}
+		if running > math.MaxUint64-allocation {
+			return process.ErrHashBuildBudgetInvalid
+		}
+		if candidate := running + allocation; candidate > target {
+			target = candidate
+		}
+		if running < slot.admittedPeak ||
+			running-slot.admittedPeak > math.MaxUint64-nextRetained {
+			return process.ErrHashBuildBudgetInvalid
+		}
+		running = running - slot.admittedPeak + nextRetained
+		if slot.recoveryCandidateReplace && peak > replacementOverlap {
+			replacementOverlap = peak
+		}
+	}
+	if running > math.MaxUint64-replacementOverlap {
+		return process.ErrHashBuildBudgetInvalid
+	}
+	if repeated := running + replacementOverlap; repeated > target {
+		target = repeated
+	}
+
+	reserved := l.Reserved()
+	if target > reserved {
+		growth := target - reserved
+		if l.recoveryReservation == nil {
+			reservation, err := l.budget.Reserve(growth)
+			if err != nil {
+				return err
+			}
+			l.recoveryReservation = reservation
+		} else if err := l.recoveryReservation.Grow(growth); err != nil {
+			return err
+		}
+	}
+
+	for i := range l.slots {
+		l.slots[i].recoveryPeak = l.slots[i].recoveryCandidate
+		l.slots[i].recoveryMayReplace = l.slots[i].recoveryCandidateReplace
+	}
+	l.recoveryRows = rows
+	l.recoveryReady = true
+	return nil
+}
+
+func (l *ExpressionMemoryLease) reconcileRecoveryAfterRun() error {
+	if l == nil || l.recoveryReservation == nil {
+		return nil
+	}
+	var steady uint64
+	var replacementOverlap uint64
+	for i := range l.slots {
+		slot := &l.slots[i]
+		retained := slot.admittedPeak
+		if slot.recoveryPeak > retained {
+			retained = slot.recoveryPeak
+		}
+		if steady > math.MaxUint64-retained {
+			return process.ErrHashBuildBudgetInvalid
+		}
+		steady += retained
+		if slot.recoveryMayReplace && slot.recoveryPeak > replacementOverlap {
+			replacementOverlap = slot.recoveryPeak
+		}
+	}
+	if steady > math.MaxUint64-replacementOverlap {
+		return process.ErrHashBuildBudgetInvalid
+	}
+	steady += replacementOverlap
+	reserved := l.Reserved()
+	if reserved <= steady {
+		return nil
+	}
+	release := reserved - steady
+	recoverySize := l.recoveryReservation.Size()
+	if release > recoverySize {
+		release = recoverySize
+	}
+	_, err := l.recoveryReservation.ReconcileDown(recoverySize - release)
+	return err
+}
+
 // Run admits and evaluates each root in index order. Growth keeps the root's
 // old retained charge live, reserves only the uncovered allocate-copy-free
 // overlap, and reconciles that overlap into the new high-water charge.
@@ -339,6 +539,49 @@ func (l *ExpressionMemoryLease) Run(
 	if rows < 0 {
 		return process.ErrHashBuildBudgetInvalid
 	}
+	if l.budget != nil && l.recoveryReady && rows <= l.recoveryRows {
+		for i, expr := range l.exprs {
+			peak := l.slots[i].recoveryPeak
+			if rows < l.recoveryRows {
+				var peakErr error
+				peak, peakErr = expressionVectorPeak(proc, expr, rows, l.duplicate)
+				if peakErr != nil {
+					return peakErr
+				}
+			}
+			evalErr := fn(i)
+			if l.released {
+				return evalErr
+			}
+			if peak > l.slots[i].admittedPeak {
+				l.slots[i].admittedPeak = peak
+			}
+			if evalErr == nil && !l.slots[i].mayReplaceWithinBound && rows == l.recoveryRows &&
+				l.slots[i].recoveryMayReplace {
+				l.slots[i].recoveryMayReplace = false
+				l.recoveryReconcile = true
+			}
+			if evalErr != nil {
+				return evalErr
+			}
+		}
+		if l.recoveryReconcile {
+			// Return only replacement headroom whose fixed-width root has reached
+			// the prepared row high water. Keep every retained capacity, every root
+			// still growing toward that high water, and variable replacement owned.
+			if err := l.reconcileRecoveryAfterRun(); err != nil {
+				return err
+			}
+			l.recoveryReconcile = false
+		}
+		return nil
+	}
+	if l.recoveryReady && rows > l.recoveryRows {
+		// A larger unprepared evaluation can change the retained-capacity
+		// state. Keep the standby token owned, but require the next recovery
+		// preflight to recompute its guarantee from that new state.
+		l.recoveryReady = false
+	}
 
 	for i, expr := range l.exprs {
 		if l.budget == nil {
@@ -353,7 +596,7 @@ func (l *ExpressionMemoryLease) Run(
 			return peakErr
 		}
 		slot := &l.slots[i]
-		if peak <= slot.admittedPeak && !slot.variableSize {
+		if peak <= slot.admittedPeak && !slot.mayReplaceWithinBound {
 			if err := fn(i); err != nil {
 				return err
 			}
@@ -445,6 +688,13 @@ func (l *ExpressionMemoryLease) Reserved() uint64 {
 			total += size
 		}
 	}
+	if l.recoveryReservation != nil {
+		size := l.recoveryReservation.Size()
+		if total > math.MaxUint64-size {
+			return math.MaxUint64
+		}
+		total += size
+	}
 	return total
 }
 
@@ -479,7 +729,18 @@ func (l *ExpressionMemoryLease) Release() {
 		}
 		l.slots[i].tokens = nil
 		l.slots[i].admittedPeak = 0
+		l.slots[i].recoveryPeak = 0
+		l.slots[i].recoveryMayReplace = false
+		l.slots[i].recoveryCandidate = 0
+		l.slots[i].recoveryCandidateReplace = false
 	}
+	if l.recoveryReservation != nil {
+		l.recoveryReservation.Release()
+		l.recoveryReservation = nil
+	}
+	l.recoveryRows = 0
+	l.recoveryReady = false
+	l.recoveryReconcile = false
 	l.slots = nil
 	l.exprs = nil
 	l.executors = nil

--- a/pkg/sql/colexec/hashbuild/expression_memory.go
+++ b/pkg/sql/colexec/hashbuild/expression_memory.go
@@ -204,10 +204,29 @@ func expressionInitialOwnedBytes(expr *plan.Expr) (uint64, error) {
 	case *plan.Expr_List:
 		return expressionListInitialOwnedBytes(typed.List.GetList())
 	case *plan.Expr_F:
-		return expressionListInitialOwnedBytes(typed.F.GetArgs())
+		children, err := expressionListInitialOwnedBytes(typed.F.GetArgs())
+		if err != nil {
+			return 0, err
+		}
+		own := expressionFunctionInitialOwnedBytes(typed.F)
+		if children > math.MaxUint64-own {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		return children + own, nil
 	default:
 		return 0, nil
 	}
+}
+
+func expressionFunctionInitialOwnedBytes(fn *plan.Function) uint64 {
+	if fn == nil || fn.Func == nil {
+		return 0
+	}
+	fid, _ := function.DecodeOverloadID(fn.Func.Obj)
+	if fid == function.SERIAL || fid == function.SERIAL_FULL {
+		return types.DefaultPackerCapacity()
+	}
+	return 0
 }
 
 func expressionListInitialOwnedBytes(exprs []*plan.Expr) (uint64, error) {

--- a/pkg/sql/colexec/hashbuild/expression_memory_test.go
+++ b/pkg/sql/colexec/hashbuild/expression_memory_test.go
@@ -48,6 +48,47 @@ func makeExpressionLeaseTestExpr(t *testing.T, proc *process.Process) *plan.Expr
 	return expr
 }
 
+func makeSerialExpressionLeaseTestExpr(
+	t *testing.T,
+	proc *process.Process,
+	name string,
+	argTypes ...types.Type,
+) *plan.Expr {
+	t.Helper()
+	args := make([]*plan.Expr, len(argTypes))
+	for i, typ := range argTypes {
+		args[i] = &plan.Expr{
+			Typ: plan.Type{
+				Id:    int32(typ.Oid),
+				Width: typ.Width,
+				Scale: typ.Scale,
+			},
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: int32(i)}},
+		}
+	}
+	expr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, name, args)
+	require.NoError(t, err)
+	return expr
+}
+
+func makeSerialExpressionLeaseTestBatch(
+	t *testing.T,
+	proc *process.Process,
+	rows int,
+	value string,
+) *batch.Batch {
+	t.Helper()
+	values := make([]string, rows)
+	for i := range values {
+		values[i] = value
+	}
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = testutil.MakeVarcharVector(values, nil, proc.Mp())
+	bat.Vecs[1] = testutil.MakeVarcharVector(values, nil, proc.Mp())
+	bat.SetRowCount(rows)
+	return bat
+}
+
 func makeExpressionLeaseTestBatch(proc *process.Process, rows int) *batch.Batch {
 	values := make([]int32, rows)
 	for i := range values {
@@ -335,6 +376,166 @@ func TestExpressionMemoryLeasePreAdmitsVariableReplacement(t *testing.T) {
 	freeExpressionLeaseTestExecutors(executors)
 	lease.Release()
 	require.Zero(t, generation.Used())
+}
+
+func TestExpressionSerialResultPeakUsesEncodingContract(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	const rows = colexec.DefaultBatchSize
+
+	for _, name := range []string{"serial", "serial_full"} {
+		t.Run(name, func(t *testing.T) {
+			expr := makeSerialExpressionLeaseTestExpr(
+				t, proc, name, types.T_int32.ToType(), types.T_int32.ToType())
+			peak, err := expressionVectorPeak(proc, expr, rows, false)
+			require.NoError(t, err)
+			want, err := expressionWidthPeak(12, rows)
+			require.NoError(t, err)
+			require.Equal(t, want, peak)
+
+			generic, err := expressionTypePeak(expr.Typ, rows)
+			require.NoError(t, err)
+			require.Less(t, peak, generic)
+			withReplacement, err := expressionVectorPeak(proc, expr, rows, true)
+			require.NoError(t, err)
+			require.Equal(t, 2*peak, withReplacement)
+			require.Less(t, 2*peak, uint64(1<<30),
+				"a normal serial key must fit an otherwise empty 1 GiB budget")
+		})
+	}
+}
+
+func TestExpressionSerialRecoveryAdmissionAndReplacementMatrix(t *testing.T) {
+	const rows = colexec.DefaultBatchSize
+	for _, name := range []string{"serial", "serial_full"} {
+		t.Run(name, func(t *testing.T) {
+			for _, delta := range []int64{-1, 0, 1} {
+				t.Run(map[int64]string{-1: "N-1", 0: "N", 1: "N+1"}[delta], func(t *testing.T) {
+					proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+					expr := makeSerialExpressionLeaseTestExpr(
+						t,
+						proc,
+						name,
+						types.New(types.T_varchar, 32, 0),
+						types.New(types.T_varchar, 32, 0),
+					)
+					peak, err := expressionVectorPeak(proc, expr, rows, false)
+					require.NoError(t, err)
+					required := 2 * peak
+					capBytes := uint64(int64(required) + delta)
+					budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+					generation, err := budget.OpenGeneration(1)
+					require.NoError(t, err)
+					executors, lease, err := NewBudgetedExpressionExecutors(
+						proc, generation, []*plan.Expr{expr}, false)
+					require.NoError(t, err)
+
+					err = lease.EnsureRunRecovery(proc, rows)
+					if delta < 0 {
+						require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+						require.Zero(t, generation.Used())
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, required, lease.Reserved())
+						blocker, reserveErr := generation.Reserve(capBytes - generation.Used())
+						require.NoError(t, reserveErr)
+						reservesAtSaturation := generation.ReserveCount()
+
+						short := makeSerialExpressionLeaseTestBatch(t, proc, rows, "a")
+						wide := makeSerialExpressionLeaseTestBatch(
+							t, proc, rows, strings.Repeat("x", 32))
+						for _, input := range []*batch.Batch{short, wide, short} {
+							require.NoError(t, lease.Eval(
+								proc,
+								[]*batch.Batch{input},
+								rows,
+								func(_ int, _ *vector.Vector) error { return nil },
+							))
+						}
+						require.Equal(t, reservesAtSaturation, generation.ReserveCount(),
+							"first run, wider replacement, and reuse must consume only pre-admitted ownership")
+						retained, ok := lease.Retained()
+						require.True(t, ok)
+						require.LessOrEqual(t, retained, lease.Reserved())
+						short.Clean(proc.Mp())
+						wide.Clean(proc.Mp())
+						require.True(t, blocker.Release())
+					}
+
+					freeExpressionLeaseTestExecutors(executors)
+					lease.Release()
+					require.Zero(t, generation.Used())
+					generation.Close()
+					proc.Free()
+					require.Zero(t, proc.Mp().CurrNB())
+				})
+			}
+		})
+	}
+}
+
+func TestExpressionSerialRecoverySharedGenerationFanout(t *testing.T) {
+	const (
+		rows    = colexec.DefaultBatchSize
+		workers = 8
+	)
+	for _, name := range []string{"serial", "serial_full"} {
+		t.Run(name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			expr := makeSerialExpressionLeaseTestExpr(
+				t, proc, name, types.T_int32.ToType(), types.T_int32.ToType())
+			peak, err := expressionVectorPeak(proc, expr, rows, false)
+			require.NoError(t, err)
+			perWorker := 2 * peak
+			budgetCap, err := spillCheckedMul(perWorker, workers)
+			require.NoError(t, err)
+			budget := process.MustNewHashBuildBudget(budgetCap, budgetCap)
+			generation, err := budget.OpenGeneration(1)
+			require.NoError(t, err)
+
+			executorSets := make([][]colexec.ExpressionExecutor, workers)
+			leases := make([]*ExpressionMemoryLease, workers)
+			for i := range workers {
+				executorSets[i], leases[i], err = NewBudgetedExpressionExecutors(
+					proc, generation, []*plan.Expr{expr}, false)
+				require.NoError(t, err)
+				require.NoError(t, leases[i].EnsureRunRecovery(proc, rows))
+				require.Equal(t, perWorker, leases[i].Reserved())
+			}
+			require.Equal(t, budgetCap, generation.Used(),
+				"every worker must own its complete replacement peak")
+
+			values := make([]int32, rows)
+			for i := range values {
+				values[i] = int32(i)
+			}
+			input := batch.NewWithSize(2)
+			input.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+			input.Vecs[1] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+			input.SetRowCount(rows)
+			reservesAtSaturation := generation.ReserveCount()
+			for i := range workers {
+				require.NoError(t, leases[i].Eval(
+					proc,
+					[]*batch.Batch{input},
+					rows,
+					func(_ int, _ *vector.Vector) error { return nil },
+				))
+			}
+			require.Equal(t, reservesAtSaturation, generation.ReserveCount(),
+				"fanout evaluation must not perform a late shared-budget admission")
+
+			input.Clean(proc.Mp())
+			for i := range workers {
+				freeExpressionLeaseTestExecutors(executorSets[i])
+				leases[i].Release()
+			}
+			require.Zero(t, generation.Used())
+			generation.Close()
+			proc.Free()
+			require.Zero(t, proc.Mp().CurrNB())
+		})
+	}
 }
 
 func TestExpressionMemoryLeaseRecoveryUsesSequentialRootPeak(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/expression_memory_test.go
+++ b/pkg/sql/colexec/hashbuild/expression_memory_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,31 @@ func freeExpressionLeaseTestExecutors(executors []colexec.ExpressionExecutor) {
 	}
 }
 
+func TestExpressionChildMayReceivePartialSelection(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		fid      int32
+		argument int
+		parent   bool
+		want     bool
+	}{
+		{name: "ordinary root", fid: -1, argument: 1},
+		{name: "ordinary nested", fid: -1, argument: 0, parent: true, want: true},
+		{name: "iff condition", fid: function.IFF, argument: 0},
+		{name: "iff branch", fid: function.IFF, argument: 1, want: true},
+		{name: "case first condition", fid: function.CASE, argument: 0},
+		{name: "case later condition", fid: function.CASE, argument: 2, want: true},
+		{name: "coalesce first value", fid: function.COALESCE, argument: 0},
+		{name: "coalesce later value", fid: function.COALESCE, argument: 1, want: true},
+		{name: "nested first argument", fid: function.COALESCE, argument: 0, parent: true, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, expressionChildMayReceivePartialSelection(
+				test.fid, test.argument, test.parent))
+		})
+	}
+}
+
 func TestExpressionMemoryLeaseReusesRetainedHighWater(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
@@ -149,6 +175,242 @@ func TestExpressionMemoryLeaseReusesRetainedHighWater(t *testing.T) {
 		return evalExpressionLeaseTestExecutors(proc, executors, large)
 	}))
 	require.Equal(t, reservesAfterLarge, generation.ReserveCount())
+
+	freeExpressionLeaseTestExecutors(executors)
+	lease.Release()
+	require.Zero(t, generation.Used())
+}
+
+func TestExpressionMemoryLeasePreAdmitsRecoveryRun(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	expr := makeExpressionLeaseTestExpr(t, proc)
+	const budgetCap = uint64(8 << 20)
+	budget := process.MustNewHashBuildBudget(budgetCap, budgetCap)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	executors, lease, err := NewBudgetedExpressionExecutors(
+		proc, generation, []*plan.Expr{expr}, false)
+	require.NoError(t, err)
+
+	input := makeExpressionLeaseTestBatch(proc, colexec.DefaultBatchSize)
+	defer input.Clean(proc.Mp())
+	small := makeExpressionLeaseTestBatch(proc, 1)
+	defer small.Clean(proc.Mp())
+	require.NoError(t, lease.EnsureRunRecovery(proc, input.RowCount()))
+	require.Positive(t, lease.Reserved())
+	require.Equal(t, lease.Reserved(), generation.Used())
+	preparedReserved := lease.Reserved()
+
+	blocker, err := generation.Reserve(budgetCap - generation.Used())
+	require.NoError(t, err)
+	require.Equal(t, budgetCap, generation.Used())
+	reservesAtFullBudget := generation.ReserveCount()
+	require.NoError(t, lease.Eval(
+		proc,
+		[]*batch.Batch{small},
+		small.RowCount(),
+		func(_ int, _ *vector.Vector) error { return nil },
+	))
+	require.Equal(t, budgetCap, generation.Used(),
+		"a smaller first run must retain the future fixed-width growth overlap")
+	reconcilesBeforeHighWater := generation.ReconcileCount()
+	require.NoError(t, lease.Eval(
+		proc,
+		[]*batch.Batch{input},
+		input.RowCount(),
+		func(_ int, _ *vector.Vector) error { return nil },
+	))
+	require.Less(t, lease.Reserved(), preparedReserved,
+		"the fixed-width standby must be returned after reaching its high water")
+	require.Greater(t, generation.ReconcileCount(), reconcilesBeforeHighWater)
+	reconcilesAfterHighWater := generation.ReconcileCount()
+	for _, steady := range []*batch.Batch{input, small, input, small} {
+		require.NoError(t, lease.Eval(
+			proc,
+			[]*batch.Batch{steady},
+			steady.RowCount(),
+			func(_ int, _ *vector.Vector) error { return nil },
+		))
+	}
+	require.Equal(t, reservesAtFullBudget, generation.ReserveCount(),
+		"a prepared recovery run must not reserve after sibling pressure arrives")
+	require.Equal(t, reconcilesAfterHighWater, generation.ReconcileCount(),
+		"steady fixed-width evaluation must not reconcile per batch")
+
+	require.True(t, blocker.Release())
+	freeExpressionLeaseTestExecutors(executors)
+	lease.Release()
+	require.Zero(t, generation.Used())
+}
+
+func TestExpressionMemoryLeaseRecoveryGrowFailureKeepsPriorGuarantee(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	expr := makeExpressionLeaseTestExpr(t, proc)
+	const budgetCap = uint64(8 << 20)
+	budget := process.MustNewHashBuildBudget(budgetCap, budgetCap)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	executors, lease, err := NewBudgetedExpressionExecutors(
+		proc, generation, []*plan.Expr{expr}, false)
+	require.NoError(t, err)
+
+	small := makeExpressionLeaseTestBatch(proc, 1)
+	defer small.Clean(proc.Mp())
+	require.NoError(t, lease.EnsureRunRecovery(proc, small.RowCount()))
+	oldReserved := lease.Reserved()
+	blocker, err := generation.Reserve(budgetCap - generation.Used())
+	require.NoError(t, err)
+
+	err = lease.EnsureRunRecovery(proc, colexec.DefaultBatchSize)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+	require.Equal(t, oldReserved, lease.Reserved())
+	require.True(t, lease.recoveryReady)
+	require.Equal(t, small.RowCount(), lease.recoveryRows)
+	require.NoError(t, lease.Eval(
+		proc,
+		[]*batch.Batch{small},
+		small.RowCount(),
+		func(_ int, _ *vector.Vector) error { return nil },
+	), "the prior retained-batch bound must remain drainable")
+
+	require.True(t, blocker.Release())
+	freeExpressionLeaseTestExecutors(executors)
+	lease.Release()
+	require.Zero(t, generation.Used())
+}
+
+func TestExpressionMemoryLeasePreAdmitsVariableReplacement(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	col := &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
+	}
+	expr, err := plan2.BindFuncExprImplByPlanExpr(
+		proc.Ctx, "lower", []*plan.Expr{col})
+	require.NoError(t, err)
+	peak, err := expressionVectorPeak(proc, expr, 1, false)
+	require.NoError(t, err)
+	require.Less(t, peak, uint64(32<<20))
+
+	const budgetCap = uint64(64 << 20)
+	budget := process.MustNewHashBuildBudget(budgetCap, budgetCap)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	executors, lease, err := NewBudgetedExpressionExecutors(
+		proc, generation, []*plan.Expr{expr}, false)
+	require.NoError(t, err)
+	require.NoError(t, lease.EnsureRunRecovery(proc, 1))
+	require.Equal(t, 2*peak, lease.Reserved(),
+		"one variable root needs its retained result plus one replacement")
+
+	makeInput := func(value string) *batch.Batch {
+		bat := batch.NewWithSize(1)
+		bat.Vecs[0] = testutil.MakeVarcharVector([]string{value}, nil, proc.Mp())
+		bat.SetRowCount(1)
+		return bat
+	}
+	short := makeInput("a")
+	long := makeInput(strings.Repeat("b", 64<<10))
+	defer short.Clean(proc.Mp())
+	defer long.Clean(proc.Mp())
+
+	blocker, err := generation.Reserve(budgetCap - generation.Used())
+	require.NoError(t, err)
+	reservesAtFullBudget := generation.ReserveCount()
+	for _, input := range []*batch.Batch{short, long} {
+		require.NoError(t, lease.Eval(
+			proc,
+			[]*batch.Batch{input},
+			1,
+			func(_ int, _ *vector.Vector) error { return nil },
+		))
+	}
+	require.Equal(t, reservesAtFullBudget, generation.ReserveCount(),
+		"variable-size reuse must consume the pre-admitted replacement overlap")
+
+	require.True(t, blocker.Release())
+	freeExpressionLeaseTestExecutors(executors)
+	lease.Release()
+	require.Zero(t, generation.Used())
+}
+
+func TestExpressionMemoryLeaseRecoveryUsesSequentialRootPeak(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	col := &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
+	}
+	expr, err := plan2.BindFuncExprImplByPlanExpr(
+		proc.Ctx, "lower", []*plan.Expr{col})
+	require.NoError(t, err)
+	peak, err := expressionVectorPeak(proc, expr, 1, false)
+	require.NoError(t, err)
+
+	budget := process.MustNewHashBuildBudget(4*peak, 4*peak)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	exprs := []*plan.Expr{expr, expr}
+	executors, lease, err := NewBudgetedExpressionExecutors(
+		proc, generation, exprs, false)
+	require.NoError(t, err)
+	require.Zero(t, lease.Reserved())
+	require.NoError(t, lease.EnsureRunRecovery(proc, 1))
+	require.Equal(t, 3*peak, lease.Reserved(),
+		"sequential roots share one replacement standby instead of each reserving two copies")
+
+	freeExpressionLeaseTestExecutors(executors)
+	lease.Release()
+	require.Zero(t, generation.Used())
+}
+
+func TestExpressionMemoryLeaseRecoveryKeepsPriorRootHighWater(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	col := &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
+	}
+	expr, err := plan2.BindFuncExprImplByPlanExpr(
+		proc.Ctx, "lower", []*plan.Expr{col})
+	require.NoError(t, err)
+	smallPeak, err := expressionVectorPeak(proc, expr, 1, false)
+	require.NoError(t, err)
+	largePeak, err := expressionVectorPeak(proc, expr, 2, false)
+	require.NoError(t, err)
+	require.Greater(t, largePeak, smallPeak)
+
+	const budgetCap = uint64(128 << 20)
+	budget := process.MustNewHashBuildBudget(budgetCap, budgetCap)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	exprs := []*plan.Expr{expr, expr}
+	executors, lease, err := NewBudgetedExpressionExecutors(
+		proc, generation, exprs, false)
+	require.NoError(t, err)
+
+	large := batch.NewWithSize(1)
+	large.Vecs[0] = testutil.MakeVarcharVector([]string{"a", "b"}, nil, proc.Mp())
+	large.SetRowCount(2)
+	defer large.Clean(proc.Mp())
+	stopAfterFirstRoot := errors.New("stop after first root")
+	err = lease.Run(proc, large.RowCount(), func(index int) error {
+		_, evalErr := executors[index].Eval(
+			proc, []*batch.Batch{large}, nil)
+		if evalErr != nil {
+			return evalErr
+		}
+		return stopAfterFirstRoot
+	})
+	require.ErrorIs(t, err, stopAfterFirstRoot)
+	require.Equal(t, largePeak, lease.Reserved())
+
+	require.NoError(t, lease.EnsureRunRecovery(proc, 1))
+	require.Equal(t, largePeak+2*smallPeak, lease.Reserved(),
+		"a smaller re-preflight must retain the prior root plus the next root and its replacement")
 
 	freeExpressionLeaseTestExecutors(executors)
 	lease.Release()
@@ -525,6 +787,110 @@ func TestExpressionMemoryLeaseCoversFlowControlSelectedScratch(t *testing.T) {
 	require.True(t, ok)
 	require.LessOrEqual(t, retained, lease.Reserved())
 
+	freeExpressionLeaseTestExecutors(executors)
+	lease.Release()
+	require.Zero(t, generation.Used())
+}
+
+func TestExpressionMemoryLeaseKeepsFixedFlowControlReplacementStandby(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	condition := &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
+	}
+	makePlusZero := func(colPos int32) *plan.Expr {
+		col := &plan.Expr{
+			Typ:  plan.Type{Id: int32(types.T_int32)},
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: colPos}},
+		}
+		expr, err := plan2.BindFuncExprImplByPlanExpr(
+			proc.Ctx,
+			"+",
+			[]*plan.Expr{col, plan2.MakePlan2Int32ConstExprWithType(0)},
+		)
+		require.NoError(t, err)
+		return expr
+	}
+	expr, err := plan2.BindFuncExprImplByPlanExpr(
+		proc.Ctx,
+		"iff",
+		[]*plan.Expr{condition, makePlusZero(1), makePlusZero(2)},
+	)
+	require.NoError(t, err)
+
+	const rows = colexec.DefaultBatchSize
+	peak, err := expressionVectorPeak(proc, expr, rows, false)
+	require.NoError(t, err)
+	budgetCap := 4 * peak
+	budget := process.MustNewHashBuildBudget(budgetCap, budgetCap)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	executors, lease, err := NewBudgetedExpressionExecutors(
+		proc,
+		generation,
+		[]*plan.Expr{expr},
+		false,
+	)
+	require.NoError(t, err)
+	require.NoError(t, lease.EnsureRunRecovery(proc, rows))
+	prepared := lease.Reserved()
+	require.Greater(t, prepared, peak)
+	reconcilesAfterPrepare := generation.ReconcileCount()
+
+	makeInput := func(trueRows int) *batch.Batch {
+		mask := make([]bool, rows)
+		left := make([]int32, rows)
+		right := make([]int32, rows)
+		for row := range rows {
+			mask[row] = row < trueRows
+			left[row] = int32(row)
+			right[row] = int32(rows - row)
+		}
+		bat := batch.NewWithSize(3)
+		bat.Vecs[0] = testutil.MakeBoolVector(mask, nil, proc.Mp())
+		bat.Vecs[1] = testutil.MakeInt32Vector(left, nil, proc.Mp())
+		bat.Vecs[2] = testutil.MakeInt32Vector(right, nil, proc.Mp())
+		bat.SetRowCount(rows)
+		return bat
+	}
+	mostlyFalse := makeInput(1)
+	mostlyTrue := makeInput(rows - 1)
+	defer mostlyFalse.Clean(proc.Mp())
+	defer mostlyTrue.Clean(proc.Mp())
+
+	require.NoError(t, lease.Eval(
+		proc,
+		[]*batch.Batch{mostlyFalse},
+		rows,
+		func(_ int, _ *vector.Vector) error { return nil },
+	))
+	require.Equal(t, prepared, lease.Reserved(),
+		"one mask distribution cannot settle another distribution's scratch peak")
+	require.Equal(t, lease.Reserved(), generation.Used())
+	require.Equal(t, reconcilesAfterPrepare, generation.ReconcileCount(),
+		"a mask-dependent fixed tree must keep its replacement standby")
+	retainedBefore, ok := lease.Retained()
+	require.True(t, ok)
+
+	blocker, err := generation.Reserve(budgetCap - generation.Used())
+	require.NoError(t, err)
+	reservesAtFullBudget := generation.ReserveCount()
+	require.NoError(t, lease.Eval(
+		proc,
+		[]*batch.Batch{mostlyTrue},
+		rows,
+		func(_ int, _ *vector.Vector) error { return nil },
+	))
+	retainedAfter, ok := lease.Retained()
+	require.True(t, ok)
+	require.Greater(t, retainedAfter, retainedBefore,
+		"changing only the mask must exercise fixed-width selected-scratch growth")
+	require.Equal(t, reservesAtFullBudget, generation.ReserveCount())
+	require.Equal(t, reconcilesAfterPrepare, generation.ReconcileCount())
+	require.LessOrEqual(t, retainedAfter, lease.Reserved())
+
+	require.True(t, blocker.Release())
 	freeExpressionLeaseTestExecutors(executors)
 	lease.Release()
 	require.Zero(t, generation.Used())

--- a/pkg/sql/colexec/hashbuild/expression_memory_test.go
+++ b/pkg/sql/colexec/hashbuild/expression_memory_test.go
@@ -79,16 +79,27 @@ func makeSerialExpressionLeaseTestBatch(
 	typ types.Type,
 	value string,
 ) *batch.Batch {
+	return makeSerialExpressionLeaseTestBatchWithColumns(t, proc, rows, typ, value, 2)
+}
+
+func makeSerialExpressionLeaseTestBatchWithColumns(
+	t *testing.T,
+	proc *process.Process,
+	rows int,
+	typ types.Type,
+	value string,
+	columns int,
+) *batch.Batch {
 	t.Helper()
 	values := make([]string, rows)
 	for i := range values {
 		values[i] = value
 	}
-	bat := batch.NewWithSize(2)
-	bat.Vecs[0] = testutil.NewStringVector(rows, typ, proc.Mp(), false, nil, values)
-	bat.Vecs[1] = testutil.NewStringVector(rows, typ, proc.Mp(), false, nil, values)
-	require.NotNil(t, bat.Vecs[0])
-	require.NotNil(t, bat.Vecs[1])
+	bat := batch.NewWithSize(columns)
+	for i := range bat.Vecs {
+		bat.Vecs[i] = testutil.NewStringVector(rows, typ, proc.Mp(), false, nil, values)
+		require.NotNil(t, bat.Vecs[i])
+	}
 	bat.SetRowCount(rows)
 	return bat
 }
@@ -393,19 +404,106 @@ func TestExpressionSerialResultPeakUsesEncodingContract(t *testing.T) {
 				t, proc, name, types.T_int32.ToType(), types.T_int32.ToType())
 			peak, err := expressionVectorPeak(proc, expr, rows, false)
 			require.NoError(t, err)
-			want, err := expressionVarlenaWidthPeak(12, rows)
+			resultPeak, err := expressionVarlenaWidthPeak(12, rows)
 			require.NoError(t, err)
-			require.Equal(t, want, peak)
+			packerPeak, ok := types.PackerCapacityUpperBound(12, 6)
+			require.True(t, ok)
+			require.Equal(t, resultPeak+packerPeak, peak)
 
 			generic, err := expressionTypePeak(expr.Typ, rows)
 			require.NoError(t, err)
 			require.Less(t, peak, generic)
 			withReplacement, err := expressionVectorPeak(proc, expr, rows, true)
 			require.NoError(t, err)
-			require.Equal(t, 2*peak, withReplacement)
+			require.Equal(t, peak+resultPeak, withReplacement,
+				"duplicating the result must not duplicate the sole Packer owner")
 			require.Less(t, 2*peak, uint64(1<<30),
 				"a normal serial key must fit an otherwise empty 1 GiB budget")
 		})
+	}
+}
+
+func TestExpressionSerialPackerRecoveryBoundary(t *testing.T) {
+	const (
+		rows    = 1
+		columns = 4
+		width   = 65535
+	)
+	typ := types.New(types.T_varbinary, width, 0)
+	value := string(make([]byte, width))
+
+	for _, name := range []string{"serial", "serial_full"} {
+		for _, delta := range []int64{-1, 0, 1} {
+			t.Run(name+"/"+map[int64]string{-1: "N-1", 0: "N", 1: "N+1"}[delta], func(t *testing.T) {
+				proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+				argTypes := make([]types.Type, columns)
+				for i := range argTypes {
+					argTypes[i] = typ
+				}
+				expr := makeSerialExpressionLeaseTestExpr(t, proc, name, argTypes...)
+				component, supported := function.SerialEncodedTypeSizeBound(typ)
+				require.True(t, supported)
+				payload := uint64(columns) * component
+				resultPeak, err := expressionVarlenaWidthPeak(payload, rows)
+				require.NoError(t, err)
+				packerPeak, ok := types.PackerCapacityUpperBound(payload, component)
+				require.True(t, ok)
+				require.Equal(t, uint64(1<<20), packerPeak,
+					"the bound must follow the real class allocator and append contract")
+				peak, err := expressionVectorPeak(proc, expr, rows, false)
+				require.NoError(t, err)
+				require.Equal(t, resultPeak+packerPeak, peak)
+				required := 2 * peak
+				capBytes := uint64(int64(required) + delta)
+				budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+				generation, err := budget.OpenGeneration(1)
+				require.NoError(t, err)
+				executors, lease, err := NewBudgetedExpressionExecutors(
+					proc, generation, []*plan.Expr{expr}, false)
+				require.NoError(t, err)
+
+				err = lease.EnsureRunRecovery(proc, rows)
+				if delta < 0 {
+					require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+					freeExpressionLeaseTestExecutors(executors)
+					lease.Release()
+					require.Zero(t, generation.Used())
+					generation.Close()
+					proc.Free()
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, required, lease.Reserved())
+				blocker, err := generation.Reserve(capBytes - generation.Used())
+				require.NoError(t, err)
+				reservesAtSaturation := generation.ReserveCount()
+				input := makeSerialExpressionLeaseTestBatchWithColumns(
+					t, proc, rows, typ, value, columns)
+				for range 2 {
+					require.NoError(t, lease.Eval(
+						proc,
+						[]*batch.Batch{input},
+						rows,
+						func(_ int, _ *vector.Vector) error { return nil },
+					))
+				}
+				require.Equal(t, reservesAtSaturation, generation.ReserveCount())
+				retained, ok := lease.Retained()
+				require.True(t, ok)
+				require.Greater(t, retained, resultPeak,
+					"the physical oracle must include the real retained Packer")
+				require.LessOrEqual(t, retained, peak)
+
+				input.Clean(proc.Mp())
+				require.True(t, blocker.Release())
+				freeExpressionLeaseTestExecutors(executors)
+				lease.Release()
+				require.Zero(t, generation.Used())
+				generation.Close()
+				proc.Free()
+				require.Zero(t, proc.Mp().CurrNB())
+			})
+		}
 	}
 }
 
@@ -499,7 +597,8 @@ func TestExpressionSerialPhysicalCapacityRecoveryBoundary(t *testing.T) {
 					err = lease.EnsureRunRecovery(proc, rows)
 					if delta < 0 {
 						require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
-						require.Zero(t, generation.Used())
+						require.Equal(t, types.DefaultPackerCapacity(), generation.Used(),
+							"failed recovery growth must keep the live constructor allocation owned")
 						return
 					}
 					require.NoError(t, err)
@@ -559,7 +658,8 @@ func TestExpressionSerialRecoveryAdmissionAndReplacementMatrix(t *testing.T) {
 					err = lease.EnsureRunRecovery(proc, rows)
 					if delta < 0 {
 						require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
-						require.Zero(t, generation.Used())
+						require.Equal(t, types.DefaultPackerCapacity(), generation.Used(),
+							"failed recovery growth must keep the live constructor allocation owned")
 					} else {
 						require.NoError(t, err)
 						require.Equal(t, required, lease.Reserved())
@@ -1255,6 +1355,30 @@ func TestBudgetedExpressionConstructionAdmitsBeforeMpoolAllocation(t *testing.T)
 	require.Zero(t, peak, "budget rejection must happen before constructing the literal vector")
 	require.Zero(t, generation.Used())
 	require.Zero(t, mp.CurrNB())
+}
+
+func TestBudgetedSerialConstructionAdmitsPackerBeforeAllocation(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	expr := makeSerialExpressionLeaseTestExpr(
+		t, proc, "serial_full", types.T_int32.ToType(), types.T_int32.ToType())
+	initial, err := expressionInitialOwnedBytes(expr)
+	require.NoError(t, err)
+	require.Equal(t, types.DefaultPackerCapacity(), initial)
+
+	budget := process.MustNewHashBuildBudget(initial-1, initial-1)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	executors, lease, err := NewBudgetedExpressionExecutors(
+		proc,
+		generation,
+		[]*plan.Expr{expr},
+		false,
+	)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+	require.Nil(t, executors)
+	require.Nil(t, lease)
+	require.Zero(t, generation.Used())
 }
 
 func TestExpressionMemoryLeaseRetainsFailedEvaluationBound(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/expression_memory_test.go
+++ b/pkg/sql/colexec/hashbuild/expression_memory_test.go
@@ -17,6 +17,7 @@ package hashbuild
 import (
 	"context"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 
@@ -75,6 +76,7 @@ func makeSerialExpressionLeaseTestBatch(
 	t *testing.T,
 	proc *process.Process,
 	rows int,
+	typ types.Type,
 	value string,
 ) *batch.Batch {
 	t.Helper()
@@ -83,8 +85,10 @@ func makeSerialExpressionLeaseTestBatch(
 		values[i] = value
 	}
 	bat := batch.NewWithSize(2)
-	bat.Vecs[0] = testutil.MakeVarcharVector(values, nil, proc.Mp())
-	bat.Vecs[1] = testutil.MakeVarcharVector(values, nil, proc.Mp())
+	bat.Vecs[0] = testutil.NewStringVector(rows, typ, proc.Mp(), false, nil, values)
+	bat.Vecs[1] = testutil.NewStringVector(rows, typ, proc.Mp(), false, nil, values)
+	require.NotNil(t, bat.Vecs[0])
+	require.NotNil(t, bat.Vecs[1])
 	bat.SetRowCount(rows)
 	return bat
 }
@@ -389,7 +393,7 @@ func TestExpressionSerialResultPeakUsesEncodingContract(t *testing.T) {
 				t, proc, name, types.T_int32.ToType(), types.T_int32.ToType())
 			peak, err := expressionVectorPeak(proc, expr, rows, false)
 			require.NoError(t, err)
-			want, err := expressionWidthPeak(12, rows)
+			want, err := expressionVarlenaWidthPeak(12, rows)
 			require.NoError(t, err)
 			require.Equal(t, want, peak)
 
@@ -402,6 +406,128 @@ func TestExpressionSerialResultPeakUsesEncodingContract(t *testing.T) {
 			require.Less(t, 2*peak, uint64(1<<30),
 				"a normal serial key must fit an otherwise empty 1 GiB budget")
 		})
+	}
+}
+
+func TestExpressionSerialPhysicalCapacityBoundAndReuse(t *testing.T) {
+	const rows = colexec.DefaultBatchSize
+	for _, name := range []string{"serial", "serial_full"} {
+		for _, oid := range []types.T{types.T_binary, types.T_varbinary} {
+			t.Run(name+"/"+oid.String(), func(t *testing.T) {
+				proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+				typ := types.New(oid, 128, 0)
+				expr := makeSerialExpressionLeaseTestExpr(t, proc, name, typ, typ)
+				peak, err := expressionVectorPeak(proc, expr, rows, false)
+				require.NoError(t, err)
+				require.LessOrEqual(t, peak, uint64(math.MaxUint64/2))
+				budgetCap := 2 * peak
+				budget := process.MustNewHashBuildBudget(budgetCap, budgetCap)
+				generation, err := budget.OpenGeneration(1)
+				require.NoError(t, err)
+				executors, lease, err := NewBudgetedExpressionExecutors(
+					proc, generation, []*plan.Expr{expr}, false)
+				require.NoError(t, err)
+				defer func() {
+					freeExpressionLeaseTestExecutors(executors)
+					lease.Release()
+					require.Zero(t, generation.Used())
+					generation.Close()
+					proc.Free()
+					require.Zero(t, proc.Mp().CurrNB())
+				}()
+
+				input := makeSerialExpressionLeaseTestBatch(
+					t, proc, rows, typ, string(make([]byte, 128)))
+				defer input.Clean(proc.Mp())
+				eval := func() error {
+					return lease.Eval(
+						proc,
+						[]*batch.Batch{input},
+						rows,
+						func(_ int, _ *vector.Vector) error { return nil },
+					)
+				}
+
+				require.NoError(t, eval())
+				retained, ok := lease.Retained()
+				require.True(t, ok)
+				require.LessOrEqual(t, retained, peak,
+					"the pre-admitted peak must cover the executor's physical capacities")
+				require.NoError(t, eval(),
+					"a second batch within the same row/type bound must not fail the ownership audit")
+			})
+		}
+	}
+}
+
+func TestExpressionSerialPhysicalCapacityRecoveryBoundary(t *testing.T) {
+	const rows = colexec.DefaultBatchSize
+	for _, name := range []string{"serial", "serial_full"} {
+		for _, oid := range []types.T{types.T_binary, types.T_varbinary} {
+			for _, delta := range []int64{-1, 0, 1} {
+				t.Run(name+"/"+oid.String()+"/"+
+					map[int64]string{-1: "N-1", 0: "N", 1: "N+1"}[delta], func(t *testing.T) {
+					proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+					typ := types.New(oid, 128, 0)
+					expr := makeSerialExpressionLeaseTestExpr(t, proc, name, typ, typ)
+					peak, err := expressionVectorPeak(proc, expr, rows, false)
+					require.NoError(t, err)
+					require.LessOrEqual(t, peak, uint64(math.MaxUint64/2))
+					required := 2 * peak
+					require.Positive(t, required)
+					capBytes := required
+					if delta < 0 {
+						capBytes--
+					} else {
+						capBytes += uint64(delta)
+					}
+					budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+					generation, err := budget.OpenGeneration(1)
+					require.NoError(t, err)
+					executors, lease, err := NewBudgetedExpressionExecutors(
+						proc, generation, []*plan.Expr{expr}, false)
+					require.NoError(t, err)
+					defer func() {
+						freeExpressionLeaseTestExecutors(executors)
+						lease.Release()
+						require.Zero(t, generation.Used())
+						generation.Close()
+						proc.Free()
+						require.Zero(t, proc.Mp().CurrNB())
+					}()
+
+					err = lease.EnsureRunRecovery(proc, rows)
+					if delta < 0 {
+						require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+						require.Zero(t, generation.Used())
+						return
+					}
+					require.NoError(t, err)
+					require.Equal(t, required, lease.Reserved())
+					blocker, err := generation.Reserve(capBytes - generation.Used())
+					require.NoError(t, err)
+					defer blocker.Release()
+					reservesAtSaturation := generation.ReserveCount()
+
+					input := makeSerialExpressionLeaseTestBatch(
+						t, proc, rows, typ, string(make([]byte, 128)))
+					defer input.Clean(proc.Mp())
+					for range 2 {
+						require.NoError(t, lease.Eval(
+							proc,
+							[]*batch.Batch{input},
+							rows,
+							func(_ int, _ *vector.Vector) error { return nil },
+						))
+					}
+					require.Equal(t, reservesAtSaturation, generation.ReserveCount(),
+						"prepared first evaluation and reuse must not reserve under sibling pressure")
+					retained, ok := lease.Retained()
+					require.True(t, ok)
+					require.LessOrEqual(t, retained, peak)
+				})
+			}
+		}
 	}
 }
 
@@ -441,9 +567,10 @@ func TestExpressionSerialRecoveryAdmissionAndReplacementMatrix(t *testing.T) {
 						require.NoError(t, reserveErr)
 						reservesAtSaturation := generation.ReserveCount()
 
-						short := makeSerialExpressionLeaseTestBatch(t, proc, rows, "a")
+						short := makeSerialExpressionLeaseTestBatch(
+							t, proc, rows, types.New(types.T_varchar, 32, 0), "a")
 						wide := makeSerialExpressionLeaseTestBatch(
-							t, proc, rows, strings.Repeat("x", 32))
+							t, proc, rows, types.New(types.T_varchar, 32, 0), strings.Repeat("x", 32))
 						for _, input := range []*batch.Batch{short, wide, short} {
 							require.NoError(t, lease.Eval(
 								proc,
@@ -636,11 +763,10 @@ func TestExpressionTypePeakUsesArrayElementWidth(t *testing.T) {
 				Width: types.MaxArrayDimension,
 			}, 1)
 			require.NoError(t, err)
-			require.Equal(
-				t,
-				uint64(types.MaxArrayDimension)*tc.elementWidth+32+(64<<10),
-				peak,
-			)
+			want, err := expressionVarlenaWidthPeak(
+				uint64(types.MaxArrayDimension)*tc.elementWidth, 1)
+			require.NoError(t, err)
+			require.Equal(t, want, peak)
 		})
 	}
 }

--- a/pkg/sql/colexec/hashbuild/hashmap.go
+++ b/pkg/sql/colexec/hashbuild/hashmap.go
@@ -76,6 +76,12 @@ type HashmapBuilder struct {
 	budget                    *process.HashBuildBudgetGeneration
 	mapReservation            *hashMapReservationOwner
 	batchReservations         []*process.HashBuildReservation
+	// retainedSpillTailSelected is the logical materialized size of the one
+	// partial CopyIntoBatches tail. Varlena descriptors may share one physical
+	// payload while a later spill selection repeats it per logical row; tracking
+	// the logical sum incrementally avoids both an unsafe allocation proxy and
+	// repeatedly rescanning the growing tail.
+	retainedSpillTailSelected uint64
 	auxReservation            *process.HashBuildReservation
 	keyExprs                  []*plan.Expr
 	expressionLease           *ExpressionMemoryLease
@@ -126,6 +132,7 @@ func (hb *HashmapBuilder) GetJoinMap(mp *mpool.MPool) *message.JoinMap {
 	hb.StrHashMap = nil
 	hb.DelRows = nil
 	hb.Batches.Reset()
+	hb.retainedSpillTailSelected = 0
 	// Iterators are producer scratch and are not part of JoinMap ownership.
 	// Drop budgeted cached backing before transferring the encompassing aux
 	// reservation to a consumer that may free it immediately after publication.
@@ -227,6 +234,7 @@ func (hb *HashmapBuilder) Reset(proc *process.Process, hashTableHasNotSent bool)
 	hb.hashMapRowCountSet = false
 	hb.HasNullKey = false
 	hb.Batches.Reset()
+	hb.retainedSpillTailSelected = 0
 	hb.IntHashMap = nil
 	hb.StrHashMap = nil
 	hb.IgnoreRows = nil
@@ -253,6 +261,7 @@ func (hb *HashmapBuilder) Free(proc *process.Process) {
 	hb.needDupVec = false
 	hb.HasNullKey = false
 	hb.Batches.Reset()
+	hb.retainedSpillTailSelected = 0
 	hb.IntHashMap = nil
 	hb.StrHashMap = nil
 	hb.FreeExecutors()
@@ -298,6 +307,7 @@ func (hb *HashmapBuilder) FreeHashMapAndBatches(proc *process.Process) {
 	}
 	hb.Sels.Free(proc.Mp())
 	hb.Batches.Clean(proc.Mp())
+	hb.retainedSpillTailSelected = 0
 	hb.releaseReservations()
 }
 

--- a/pkg/sql/colexec/hashbuild/hashmap.go
+++ b/pkg/sql/colexec/hashbuild/hashmap.go
@@ -523,7 +523,7 @@ func expressionResultPeak(expr *plan.Expr, rows uint64) (uint64, error) {
 		}
 		payloadPerRow += component
 	}
-	return expressionWidthPeak(payloadPerRow, rows)
+	return expressionVarlenaWidthPeak(payloadPerRow, rows)
 }
 
 func nodeFunctionArgs(expr *plan.Expr) []*plan.Expr {
@@ -568,42 +568,128 @@ func expressionParamPeak(proc *process.Process, pos int32) (uint64, error) {
 func expressionTypePeak(typ plan.Type, rows uint64) (uint64, error) {
 	oid := types.T(typ.Id)
 	width := int64(oid.FixedLength())
-	if width < 0 {
-		width = int64(typ.Width)
-		hardMax := int64(types.MaxVarcharLen)
-		if oid.IsArrayRelate() {
-			elementWidth := int64(oid.ToType().GetArrayElementSize())
-			width *= elementWidth
-			hardMax = int64(types.MaxArrayDimension) * elementWidth
-		} else {
-			switch oid {
-			case types.T_blob, types.T_text, types.T_json, types.T_datalink,
-				types.T_geometry, types.T_geometry32:
-				hardMax = int64(types.MaxBlobLen)
-			}
+	if width >= 0 {
+		if width < 1 {
+			width = 1
 		}
-		if width > hardMax {
-			// Never clamp a declared bound downward. Array width is declared
-			// in elements, while every other varlena width is in bytes.
-			hardMax = width
-		}
-		width = hardMax
+		return expressionFixedWidthPeak(uint64(width), rows)
 	}
+
+	width = int64(typ.Width)
+	hardMax := int64(types.MaxVarcharLen)
+	if oid.IsArrayRelate() {
+		elementWidth := int64(oid.ToType().GetArrayElementSize())
+		width *= elementWidth
+		hardMax = int64(types.MaxArrayDimension) * elementWidth
+	} else {
+		switch oid {
+		case types.T_blob, types.T_text, types.T_json, types.T_datalink,
+			types.T_geometry, types.T_geometry32:
+			hardMax = int64(types.MaxBlobLen)
+		}
+	}
+	if width > hardMax {
+		// Never clamp a declared bound downward. Array width is declared
+		// in elements, while every other varlena width is in bytes.
+		hardMax = width
+	}
+	width = hardMax
 	if width < 1 {
 		width = 1
 	}
-	return expressionWidthPeak(uint64(width), rows)
+	return expressionVarlenaWidthPeak(uint64(width), rows)
 }
 
-func expressionWidthPeak(width, rows uint64) (uint64, error) {
-	if width > math.MaxUint64-32 {
+const (
+	expressionPerRowAllowance = uint64(32)
+	expressionAllocationSlack = uint64(64 << 10)
+)
+
+// expressionAllocationCapacityUpperBound bounds the capacity retained after
+// any sequence of GrowCapacity calls whose logical requirement never exceeds
+// required. The last growth either allocates required directly or starts from
+// a capacity below required. GrowCapacity's single-step growth is monotonic in
+// that starting capacity, so required-1 covers every incremental append
+// history without replaying an O(rows) growth sequence during HashBuild.
+func expressionAllocationCapacityUpperBound(required uint64) (uint64, error) {
+	if required == 0 {
+		return 0, nil
+	}
+	if mpool.CapLimit <= 0 {
 		return 0, process.ErrHashBuildBudgetInvalid
 	}
-	perRow := width + 32
-	if rows > (math.MaxUint64-(64<<10))/perRow {
+	limit := uint64(mpool.CapLimit)
+	if required >= limit {
+		// A successful mpool allocation cannot retain more than CapLimit.
+		// Values which exceed the allocator's own limit still fail in Eval.
+		return limit, nil
+	}
+	capacity, ok := mpool.GrowCapacity(int64(required-1), int64(required))
+	if !ok || capacity < 0 {
 		return 0, process.ErrHashBuildBudgetInvalid
 	}
-	return rows*perRow + (64 << 10), nil
+	return uint64(capacity), nil
+}
+
+func expressionFixedWidthPeak(width, rows uint64) (uint64, error) {
+	if width == 0 {
+		width = 1
+	}
+	if rows != 0 && width > math.MaxUint64/rows {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	dataCapacity, err := expressionAllocationCapacityUpperBound(width * rows)
+	if err != nil || rows > math.MaxUint64/expressionPerRowAllowance {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	allowance := rows * expressionPerRowAllowance
+	if dataCapacity > math.MaxUint64-allowance ||
+		dataCapacity+allowance > math.MaxUint64-expressionAllocationSlack {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	return dataCapacity + allowance + expressionAllocationSlack, nil
+}
+
+func expressionVarlenaWidthPeak(width, rows uint64) (uint64, error) {
+	if width == 0 {
+		width = 1
+	}
+	descriptorWidth := uint64(types.VarlenaSize)
+	if descriptorWidth > expressionPerRowAllowance ||
+		(rows != 0 && descriptorWidth > math.MaxUint64/rows) {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	dataCapacity, err := expressionAllocationCapacityUpperBound(
+		rows * descriptorWidth)
+	if err != nil {
+		return 0, err
+	}
+
+	var areaCapacity uint64
+	if width > uint64(types.VarlenaInlineSize) {
+		if rows != 0 && width > math.MaxUint64/rows {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		areaCapacity, err = expressionAllocationCapacityUpperBound(width * rows)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// The historical per-row allowance included the varlena descriptor. Its
+	// physical capacity is now charged above, leaving the non-mpool metadata
+	// allowance unchanged instead of double-counting the descriptor.
+	metadataPerRow := expressionPerRowAllowance - descriptorWidth
+	if rows != 0 && metadataPerRow > math.MaxUint64/rows {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	metadata := rows * metadataPerRow
+	if dataCapacity > math.MaxUint64-areaCapacity ||
+		dataCapacity+areaCapacity > math.MaxUint64-metadata ||
+		dataCapacity+areaCapacity+metadata > math.MaxUint64-expressionAllocationSlack {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	return dataCapacity + areaCapacity + metadata + expressionAllocationSlack, nil
 }
 
 func (hb *HashmapBuilder) releaseExpressionLease() {

--- a/pkg/sql/colexec/hashbuild/hashmap.go
+++ b/pkg/sql/colexec/hashbuild/hashmap.go
@@ -458,7 +458,7 @@ func expressionTreePeakWithSelection(
 		// expose a bounded vector-evaluator tree here.
 		return 0, 0, process.ErrHashBuildBudgetInvalid
 	}
-	output, err = expressionTypePeak(expr.Typ, rows)
+	output, err = expressionResultPeak(expr, rows)
 	if err != nil || total > math.MaxUint64-output {
 		return 0, 0, process.ErrHashBuildBudgetInvalid
 	}
@@ -485,6 +485,45 @@ func expressionTreePeakWithSelection(
 		}
 	}
 	return total, output, nil
+}
+
+// expressionResultPeak keeps the generic SQL-type bound for ordinary
+// functions, but lets functions with a stronger allocation contract provide a
+// tighter result bound. serial and serial_full are the first such functions:
+// their packer output is the sum of the component encodings, not an arbitrary
+// VARCHAR(max) value.
+func expressionResultPeak(expr *plan.Expr, rows uint64) (uint64, error) {
+	if expr == nil {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	fn, ok := expr.Expr.(*plan.Expr_F)
+	if !ok || fn.F == nil || fn.F.Func == nil {
+		return expressionTypePeak(expr.Typ, rows)
+	}
+	fid, _ := function.DecodeOverloadID(fn.F.Func.Obj)
+	if fid != function.SERIAL && fid != function.SERIAL_FULL {
+		return expressionTypePeak(expr.Typ, rows)
+	}
+
+	var payloadPerRow uint64
+	for _, arg := range fn.F.Args {
+		if arg == nil {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		component, supported := function.SerialEncodedTypeSizeBound(types.New(
+			types.T(arg.Typ.Id), arg.Typ.Width, arg.Typ.Scale,
+		))
+		if !supported {
+			// Keep the pre-existing representation-independent bound if the
+			// encoder contract does not recognize a planner type.
+			return expressionTypePeak(expr.Typ, rows)
+		}
+		if payloadPerRow > math.MaxUint64-component {
+			return 0, process.ErrHashBuildBudgetInvalid
+		}
+		payloadPerRow += component
+	}
+	return expressionWidthPeak(payloadPerRow, rows)
 }
 
 func nodeFunctionArgs(expr *plan.Expr) []*plan.Expr {
@@ -553,7 +592,14 @@ func expressionTypePeak(typ plan.Type, rows uint64) (uint64, error) {
 	if width < 1 {
 		width = 1
 	}
-	perRow := uint64(width) + 32
+	return expressionWidthPeak(uint64(width), rows)
+}
+
+func expressionWidthPeak(width, rows uint64) (uint64, error) {
+	if width > math.MaxUint64-32 {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	perRow := width + 32
 	if rows > (math.MaxUint64-(64<<10))/perRow {
 		return 0, process.ErrHashBuildBudgetInvalid
 	}

--- a/pkg/sql/colexec/hashbuild/hashmap.go
+++ b/pkg/sql/colexec/hashbuild/hashmap.go
@@ -463,6 +463,11 @@ func expressionTreePeakWithSelection(
 		return 0, 0, process.ErrHashBuildBudgetInvalid
 	}
 	total += output
+	private, privateErr := expressionFunctionPrivatePeak(expr)
+	if privateErr != nil || total > math.MaxUint64-private {
+		return 0, 0, process.ErrHashBuildBudgetInvalid
+	}
+	total += private
 
 	if _, isFunction := expr.Expr.(*plan.Expr_F); mayReceivePartialSelection && isFunction {
 		// A partially selected function retains both its ordinary full-row
@@ -489,9 +494,11 @@ func expressionTreePeakWithSelection(
 
 // expressionResultPeak keeps the generic SQL-type bound for ordinary
 // functions, but lets functions with a stronger allocation contract provide a
-// tighter result bound. serial and serial_full are the first such functions:
-// their packer output is the sum of the component encodings, not an arbitrary
-// VARCHAR(max) value.
+// tighter result-vector bound. serial and serial_full are the first such
+// functions: their encoded result is the sum of the component encodings, not
+// an arbitrary VARCHAR(max) value. Their retained Packer is charged separately
+// by expressionFunctionPrivatePeak so duplicate-result ownership does not
+// duplicate the sole function operator.
 func expressionResultPeak(expr *plan.Expr, rows uint64) (uint64, error) {
 	if expr == nil {
 		return 0, process.ErrHashBuildBudgetInvalid
@@ -505,25 +512,76 @@ func expressionResultPeak(expr *plan.Expr, rows uint64) (uint64, error) {
 		return expressionTypePeak(expr.Typ, rows)
 	}
 
-	var payloadPerRow uint64
-	for _, arg := range fn.F.Args {
-		if arg == nil {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		component, supported := function.SerialEncodedTypeSizeBound(types.New(
-			types.T(arg.Typ.Id), arg.Typ.Width, arg.Typ.Scale,
-		))
-		if !supported {
-			// Keep the pre-existing representation-independent bound if the
-			// encoder contract does not recognize a planner type.
-			return expressionTypePeak(expr.Typ, rows)
-		}
-		if payloadPerRow > math.MaxUint64-component {
-			return 0, process.ErrHashBuildBudgetInvalid
-		}
-		payloadPerRow += component
+	payloadPerRow, _, supported, err := serialExpressionPackerBounds(fn.F)
+	if err != nil {
+		return 0, err
+	}
+	if !supported {
+		// Keep the pre-existing representation-independent bound if the
+		// encoder contract does not recognize a planner type.
+		return expressionTypePeak(expr.Typ, rows)
 	}
 	return expressionVarlenaWidthPeak(payloadPerRow, rows)
+}
+
+func expressionFunctionPrivatePeak(expr *plan.Expr) (uint64, error) {
+	fn, ok := expr.Expr.(*plan.Expr_F)
+	if !ok || fn.F == nil || fn.F.Func == nil {
+		return 0, nil
+	}
+	fid, _ := function.DecodeOverloadID(fn.F.Func.Obj)
+	if fid != function.SERIAL && fid != function.SERIAL_FULL {
+		return 0, nil
+	}
+	payload, maxAppend, supported, err := serialExpressionPackerBounds(fn.F)
+	if err != nil {
+		return 0, err
+	}
+	if !supported {
+		// getPackFun resolves every component before encoding the first row.
+		// An unsupported component can therefore retain only the constructor's
+		// initial Packer allocation before Eval fails.
+		return types.DefaultPackerCapacity(), nil
+	}
+	capacity, ok := types.PackerCapacityUpperBound(payload, maxAppend)
+	if !ok {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	return capacity, nil
+}
+
+// serialExpressionPackerBounds returns both the maximum encoded row length and
+// the largest single append issued by its component encoders. A component
+// cannot append more in one call than its complete encoded-size bound, so the
+// maximum component bound is also a representation-independent append bound.
+func serialExpressionPackerBounds(fn *plan.Function) (
+	payload uint64,
+	maxAppend uint64,
+	supported bool,
+	err error,
+) {
+	if fn == nil {
+		return 0, 0, false, process.ErrHashBuildBudgetInvalid
+	}
+	for _, arg := range fn.Args {
+		if arg == nil {
+			return 0, 0, false, process.ErrHashBuildBudgetInvalid
+		}
+		component, ok := function.SerialEncodedTypeSizeBound(types.New(
+			types.T(arg.Typ.Id), arg.Typ.Width, arg.Typ.Scale,
+		))
+		if !ok {
+			return 0, 0, false, nil
+		}
+		if payload > math.MaxUint64-component {
+			return 0, 0, false, process.ErrHashBuildBudgetInvalid
+		}
+		payload += component
+		if component > maxAppend {
+			maxAppend = component
+		}
+	}
+	return payload, maxAppend, true, nil
 }
 
 func nodeFunctionArgs(expr *plan.Expr) []*plan.Expr {

--- a/pkg/sql/colexec/hashbuild/hashmap.go
+++ b/pkg/sql/colexec/hashbuild/hashmap.go
@@ -419,20 +419,12 @@ func expressionTreePeakWithSelection(
 			fid, _ = function.DecodeOverloadID(node.F.Func.Obj)
 		}
 		for i, arg := range node.F.Args {
-			childMayReceivePartialSelection := mayReceivePartialSelection
-			switch fid {
-			case function.IFF:
-				// IFF evaluates only its value branches through generated
-				// selection masks. Its condition inherits the caller mask.
-				childMayReceivePartialSelection = mayReceivePartialSelection || i > 0
-			case function.CASE, function.COALESCE:
-				childMayReceivePartialSelection = true
-			}
 			child, _, childErr := expressionTreePeakWithSelection(
 				proc,
 				arg,
 				rows,
-				childMayReceivePartialSelection,
+				expressionChildMayReceivePartialSelection(
+					fid, i, mayReceivePartialSelection),
 			)
 			if childErr != nil || total > math.MaxUint64-child {
 				return 0, 0, process.ErrHashBuildBudgetInvalid

--- a/pkg/sql/colexec/hashbuild/hashmap_test.go
+++ b/pkg/sql/colexec/hashbuild/hashmap_test.go
@@ -1067,6 +1067,47 @@ func TestUnionBatchAreaProjectionBoundaries(t *testing.T) {
 	require.Zero(t, selected)
 }
 
+func TestUnionBatchAreaProjectionWideFlatAndSharedRepresentations(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	typ := types.New(types.T_varchar, 128, 0)
+	const rows = 128
+	payload := make([]byte, 128)
+
+	flat := vector.NewVec(typ)
+	for range rows {
+		require.NoError(t, vector.AppendBytes(flat, payload, false, proc.Mp()))
+	}
+	defer flat.Free(proc.Mp())
+	require.True(t, flat.VarlenaAreaIsDisjoint())
+	physical, selected, err := unionBatchAreaProjection(flat, 0, rows)
+	require.NoError(t, err)
+	require.Equal(t, rows*len(payload), physical)
+	require.Equal(t, uint64(physical), selected)
+
+	constant, err := vector.NewConstBytes(typ, payload, rows, proc.Mp())
+	require.NoError(t, err)
+	defer constant.Free(proc.Mp())
+	shared := vector.NewVec(typ)
+	require.NoError(t, shared.UnionBatch(constant, 0, rows, nil, proc.Mp()))
+	defer shared.Free(proc.Mp())
+	require.False(t, shared.IsConst())
+	require.False(t, shared.VarlenaAreaIsDisjoint())
+	require.Equal(t, len(payload), len(shared.GetArea()))
+
+	physical, selected, err = unionBatchAreaProjection(shared, 0, rows)
+	require.NoError(t, err)
+	require.Equal(t, len(payload), physical)
+	require.Equal(t, uint64(rows*len(payload)), selected,
+		"a shared flat representation must retain the descriptor-scan fallback")
+
+	physical, selected, err = unionBatchAreaProjection(flat, 1, rows-1)
+	require.NoError(t, err)
+	require.Equal(t, (rows-1)*len(payload), physical)
+	require.Equal(t, uint64(physical), selected,
+		"a partial range must retain its exact-copy path")
+}
+
 func TestCleanCopiedBatchReleasesCoalescedIngressReservations(t *testing.T) {
 	const budgetCap = uint64(4 << 20)
 	budget, err := process.NewHashBuildBudget(budgetCap, budgetCap)

--- a/pkg/sql/colexec/hashbuild/hashmap_test.go
+++ b/pkg/sql/colexec/hashbuild/hashmap_test.go
@@ -1279,7 +1279,10 @@ func TestExpressionHashKeyAcceptsCastTargetType(t *testing.T) {
 
 	peak, err := expressionVectorPeak(proc, expr, 1024, false)
 	require.NoError(t, err)
-	require.Equal(t, uint64(204800), peak, "charge the target-type and cast result vectors")
+	outputPeak, err := expressionFixedWidthPeak(uint64(types.T_int32.TypeLen()), 1024)
+	require.NoError(t, err)
+	require.Equal(t, 2*outputPeak, peak,
+		"charge the target-type and cast result vectors")
 }
 
 func TestPreparedParamExpressionPeakUsesConstCardinality(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/hashmap_test.go
+++ b/pkg/sql/colexec/hashbuild/hashmap_test.go
@@ -518,6 +518,46 @@ func TestCopyBuildBatchProjectedWithoutBudgetTracksPartialTail(t *testing.T) {
 	require.Empty(t, hb.batchReservations)
 }
 
+func TestCopyBuildBatchProjectedWithoutBudgetFailureClearsTailProjection(t *testing.T) {
+	mp, err := mpool.NewMPool(t.Name(), 1<<20, mpool.NoFixed)
+	require.NoError(t, err)
+	proc := testutil.NewProcessWithMPool(t, "", mp)
+
+	first := testutil.NewBatch(
+		[]types.Type{types.T_int32.ToType()}, true, 1, proc.Mp())
+	second := testutil.NewBatch(
+		[]types.Type{types.T_int32.ToType()}, true,
+		colexec.DefaultBatchSize-1, proc.Mp())
+	var filler []byte
+	defer func() {
+		if filler != nil {
+			mp.Free(filler)
+		}
+		first.Clean(proc.Mp())
+		second.Clean(proc.Mp())
+		proc.Free()
+		require.Zero(t, mp.CurrNB())
+	}()
+
+	var hb HashmapBuilder
+	projection, err := hb.projectedBatchCopy(first)
+	require.NoError(t, err)
+	require.NoError(t, hb.copyBuildBatchProjected(first, proc, projection))
+	require.Positive(t, hb.retainedSpillTailSelected)
+
+	projection, err = hb.projectedBatchCopy(second)
+	require.NoError(t, err)
+	filler, err = mp.Alloc(int(mp.Cap()-mp.CurrNB()), true)
+	require.NoError(t, err)
+	require.Equal(t, mp.Cap(), mp.CurrNB())
+
+	err = hb.copyBuildBatchProjected(second, proc, projection)
+	require.Error(t, err)
+	require.Empty(t, hb.Batches.Buf)
+	require.Zero(t, hb.retainedSpillTailSelected)
+	require.Empty(t, hb.batchReservations)
+}
+
 func TestProjectedPartialTailReplacementMatchesUnionBatch(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
@@ -1149,12 +1189,12 @@ func TestSpillExpressionHashKeyUsesBoundedAdmission(t *testing.T) {
 	require.NoError(t, err)
 	ctr.hashmapBuilder.setBudget(generation)
 	expr := makeExpressionLeaseTestExpr(t, proc)
-	_, err = ctr.initSpillExprExecs(proc, []*plan.Expr{expr})
+	err = initSpillExprExecsForTest(&ctr, proc, []*plan.Expr{expr})
 	require.NoError(t, err)
-	require.NoError(t, ctr.spillExprLease.Run(proc, 8192, func(_ int) error { return nil }))
-	require.Positive(t, ctr.spillExprLease.Reserved())
-	require.Equal(t, ctr.spillExprLease.Reserved(), generation.Used())
-	ctr.freeSpillExprExecs()
+	require.NoError(t, ctr.hashmapBuilder.expressionLease.Run(proc, 8192, func(_ int) error { return nil }))
+	require.Positive(t, ctr.hashmapBuilder.expressionLease.Reserved())
+	require.Equal(t, ctr.hashmapBuilder.expressionLease.Reserved(), generation.Used())
+	ctr.hashmapBuilder.FreeExecutors()
 	require.Zero(t, generation.Used())
 }
 

--- a/pkg/sql/colexec/hashbuild/hashmap_test.go
+++ b/pkg/sql/colexec/hashbuild/hashmap_test.go
@@ -497,6 +497,27 @@ func TestCopyBuildBatchBudgetsWideVarcharPartialTailReplacement(t *testing.T) {
 	require.Equal(t, colexec.DefaultBatchSize, hb.Batches.Buf[0].RowCount())
 }
 
+func TestCopyBuildBatchProjectedWithoutBudgetTracksPartialTail(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	input := testutil.NewBatch(
+		[]types.Type{types.T_int32.ToType()}, true, 3, proc.Mp())
+	defer input.Clean(proc.Mp())
+
+	var hb HashmapBuilder
+	projection, err := hb.projectedBatchCopy(input)
+	require.NoError(t, err)
+	require.Positive(t, projection.nextTailSelected)
+	require.NoError(t, hb.copyBuildBatchProjected(input, proc, projection))
+	defer hb.cleanBatches(proc)
+
+	require.Len(t, hb.Batches.Buf, 1)
+	require.Equal(t, input.RowCount(), hb.Batches.Buf[0].RowCount())
+	require.Equal(t, projection.nextTailSelected, hb.retainedSpillTailSelected)
+	require.Empty(t, hb.batchReservations)
+}
+
 func TestProjectedPartialTailReplacementMatchesUnionBatch(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
@@ -978,6 +999,32 @@ func TestUniqueAppendBudgetIncludesDeadAreaCopiedByUnionBatch(t *testing.T) {
 	hb.releaseReservations()
 	require.Zero(t, generation.Used())
 	generation.Close()
+}
+
+func TestUnionBatchAreaProjectionBoundaries(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	inline := testutil.MakeVarcharVector([]string{"inline"}, nil, proc.Mp())
+	defer inline.Free(proc.Mp())
+	require.Empty(t, inline.GetArea())
+
+	physical, selected, err := unionBatchAreaProjection(inline, 0, 0)
+	require.NoError(t, err)
+	require.Zero(t, physical)
+	require.Zero(t, selected)
+
+	physical, selected, err = unionBatchAreaProjection(inline, 0, 1)
+	require.NoError(t, err)
+	require.Zero(t, physical)
+	require.Zero(t, selected)
+
+	_, _, err = unionBatchAreaProjection(inline, -1, 1)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+
+	selected, err = logicalAppendAreaBytes(inline, 0, 0)
+	require.NoError(t, err)
+	require.Zero(t, selected)
 }
 
 func TestCleanCopiedBatchReleasesCoalescedIngressReservations(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/nonspill_benchmark_test.go
+++ b/pkg/sql/colexec/hashbuild/nonspill_benchmark_test.go
@@ -59,6 +59,8 @@ func BenchmarkHashBuildNonSpillE2E(b *testing.B) {
 		typ                 types.Type
 		varcharPayloadBytes int
 		computed            bool
+		columns             int
+		batchCount          int
 	}{
 		{name: "INT64", typ: types.T_int64.ToType()},
 		{name: "INT64_PLUS_ZERO", typ: types.T_int64.ToType(), computed: true},
@@ -68,13 +70,68 @@ func BenchmarkHashBuildNonSpillE2E(b *testing.B) {
 			typ:                 types.T_varchar.ToType(),
 			varcharPayloadBytes: 128,
 		},
+		{
+			name:                "VARCHAR_32X128",
+			typ:                 types.T_varchar.ToType(),
+			varcharPayloadBytes: 128,
+			columns:             32,
+			batchCount:          1,
+		},
 	}
 	for _, benchmark := range benchmarks {
 		b.Run("Shuffle/"+benchmark.name, func(b *testing.B) {
 			benchmarkHashBuildNonSpillE2E(
-				b, benchmark.typ, benchmark.varcharPayloadBytes, benchmark.computed)
+				b,
+				benchmark.typ,
+				benchmark.varcharPayloadBytes,
+				benchmark.computed,
+				benchmark.columns,
+				benchmark.batchCount,
+			)
 		})
 	}
+}
+
+// BenchmarkUnionBatchAreaProjectionWideVarchar isolates the recovery
+// projection paid by an ordinary non-spill ingress batch. The common flat
+// representation should be O(columns), while shared or partial vectors retain
+// the descriptor-scan fallback covered by unit tests.
+func BenchmarkUnionBatchAreaProjectionWideVarchar(b *testing.B) {
+	mp := mpool.MustNewZero()
+	input := batch.NewWithSize(32)
+	payload := make([]byte, 128)
+	for column := range input.Vecs {
+		vec := vector.NewVec(types.T_varchar.ToType())
+		for range nonSpillBenchmarkBatchRows {
+			if err := vector.AppendBytes(vec, payload, false, mp); err != nil {
+				b.Fatal(err)
+			}
+		}
+		input.SetVector(int32(column), vec)
+	}
+	input.SetRowCount(nonSpillBenchmarkBatchRows)
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(len(input.Vecs)), "columns/op")
+	b.ResetTimer()
+	var projected uint64
+	for range b.N {
+		for _, vec := range input.Vecs {
+			_, selected, err := unionBatchAreaProjection(
+				vec, 0, nonSpillBenchmarkBatchRows)
+			if err != nil {
+				b.Fatal(err)
+			}
+			projected += selected
+		}
+	}
+	b.StopTimer()
+	if projected == 0 {
+		b.Fatal("projection was not evaluated")
+	}
+	input.Clean(mp)
+	require.Zero(b, mp.CurrNB())
+	mpool.DeleteMPool(mp)
 }
 
 func benchmarkHashBuildNonSpillE2E(
@@ -82,7 +139,15 @@ func benchmarkHashBuildNonSpillE2E(
 	keyType types.Type,
 	varcharPayloadBytes int,
 	computed bool,
+	columns int,
+	batchCount int,
 ) {
+	if columns == 0 {
+		columns = 1
+	}
+	if batchCount == 0 {
+		batchCount = nonSpillBenchmarkBatchCount
+	}
 	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
 	proc.SetMessageBoard(message.NewMessageBoard())
 	proc.Base.Lim.Size = 4 << 30
@@ -90,7 +155,7 @@ func benchmarkHashBuildNonSpillE2E(
 	proc.Base.Lim.BatchSize = 64 << 20
 
 	inputs := makeNonSpillBenchmarkBatches(
-		b, proc, keyType, varcharPayloadBytes)
+		b, proc, keyType, varcharPayloadBytes, columns, batchCount)
 	var inputBytes int64
 	for _, input := range inputs {
 		inputBytes += int64(input.Size())
@@ -111,7 +176,7 @@ func benchmarkHashBuildNonSpillE2E(
 	b.SetBytes(inputBytes)
 	b.ReportAllocs()
 	b.ReportMetric(
-		float64(nonSpillBenchmarkBatchCount*nonSpillBenchmarkBatchRows),
+		float64(batchCount*nonSpillBenchmarkBatchRows),
 		"rows/op",
 	)
 	b.ResetTimer()
@@ -135,12 +200,12 @@ func benchmarkHashBuildNonSpillE2E(
 		require.False(b, joinMap.IsSpilled())
 		require.Equal(
 			b,
-			int64(nonSpillBenchmarkBatchCount*nonSpillBenchmarkBatchRows),
+			int64(batchCount*nonSpillBenchmarkBatchRows),
 			joinMap.GetRowCount(),
 		)
 		require.Equal(
 			b,
-			uint64(nonSpillBenchmarkBatchCount*nonSpillBenchmarkBatchRows),
+			uint64(batchCount*nonSpillBenchmarkBatchRows),
 			joinMap.GetGroupCount(),
 			"benchmark keys must remain unique",
 		)
@@ -218,39 +283,43 @@ func makeNonSpillBenchmarkBatches(
 	proc *process.Process,
 	typ types.Type,
 	varcharPayloadBytes int,
+	columns int,
+	batchCount int,
 ) []*batch.Batch {
-	inputs := make([]*batch.Batch, nonSpillBenchmarkBatchCount)
+	inputs := make([]*batch.Batch, batchCount)
 	for batchIndex := range inputs {
-		input := batch.NewWithSize(1)
-		vec := vector.NewVec(typ)
-		rowBase := batchIndex * nonSpillBenchmarkBatchRows
-		for row := 0; row < nonSpillBenchmarkBatchRows; row++ {
-			value := rowBase + row
-			switch typ.Oid {
-			case types.T_int64:
-				require.NoError(
-					b,
-					vector.AppendFixed(vec, int64(value), false, proc.Mp()),
-				)
-			case types.T_varchar:
-				key := "key-" + strconv.Itoa(value)
-				if varcharPayloadBytes > len(key) {
-					key += strings.Repeat("x", varcharPayloadBytes-len(key))
+		input := batch.NewWithSize(columns)
+		for column := 0; column < columns; column++ {
+			vec := vector.NewVec(typ)
+			rowBase := batchIndex * nonSpillBenchmarkBatchRows
+			for row := 0; row < nonSpillBenchmarkBatchRows; row++ {
+				value := rowBase + row
+				switch typ.Oid {
+				case types.T_int64:
+					require.NoError(
+						b,
+						vector.AppendFixed(vec, int64(value), false, proc.Mp()),
+					)
+				case types.T_varchar:
+					key := "key-" + strconv.Itoa(value) + "-" + strconv.Itoa(column)
+					if varcharPayloadBytes > len(key) {
+						key += strings.Repeat("x", varcharPayloadBytes-len(key))
+					}
+					require.NoError(
+						b,
+						vector.AppendBytes(
+							vec,
+							[]byte(key),
+							false,
+							proc.Mp(),
+						),
+					)
+				default:
+					b.Fatalf("unsupported non-spill benchmark type %s", typ.Oid)
 				}
-				require.NoError(
-					b,
-					vector.AppendBytes(
-						vec,
-						[]byte(key),
-						false,
-						proc.Mp(),
-					),
-				)
-			default:
-				b.Fatalf("unsupported non-spill benchmark type %s", typ.Oid)
 			}
+			input.SetVector(int32(column), vec)
 		}
-		input.SetVector(0, vec)
 		input.SetRowCount(nonSpillBenchmarkBatchRows)
 		inputs[batchIndex] = input
 	}

--- a/pkg/sql/colexec/hashbuild/nonspill_benchmark_test.go
+++ b/pkg/sql/colexec/hashbuild/nonspill_benchmark_test.go
@@ -17,6 +17,7 @@ package hashbuild
 import (
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -53,27 +54,39 @@ const (
 //	  ./pkg/sql/colexec/hashbuild
 func BenchmarkHashBuildNonSpillE2E(b *testing.B) {
 	benchmarks := []struct {
-		name string
-		typ  types.Type
+		name                string
+		typ                 types.Type
+		varcharPayloadBytes int
 	}{
 		{name: "INT64", typ: types.T_int64.ToType()},
-		{name: "VARCHAR", typ: types.T_varchar.ToType()},
+		{name: "VARCHAR_INLINE", typ: types.T_varchar.ToType()},
+		{
+			name:                "VARCHAR_AREA_128",
+			typ:                 types.T_varchar.ToType(),
+			varcharPayloadBytes: 128,
+		},
 	}
 	for _, benchmark := range benchmarks {
 		b.Run("Shuffle/"+benchmark.name, func(b *testing.B) {
-			benchmarkHashBuildNonSpillE2E(b, benchmark.typ)
+			benchmarkHashBuildNonSpillE2E(
+				b, benchmark.typ, benchmark.varcharPayloadBytes)
 		})
 	}
 }
 
-func benchmarkHashBuildNonSpillE2E(b *testing.B, keyType types.Type) {
+func benchmarkHashBuildNonSpillE2E(
+	b *testing.B,
+	keyType types.Type,
+	varcharPayloadBytes int,
+) {
 	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
 	proc.SetMessageBoard(message.NewMessageBoard())
 	proc.Base.Lim.Size = 4 << 30
 	proc.Base.Lim.BatchRows = nonSpillBenchmarkBatchRows
 	proc.Base.Lim.BatchSize = 64 << 20
 
-	inputs := makeNonSpillBenchmarkBatches(b, proc, keyType)
+	inputs := makeNonSpillBenchmarkBatches(
+		b, proc, keyType, varcharPayloadBytes)
 	var inputBytes int64
 	for _, input := range inputs {
 		inputBytes += int64(input.Size())
@@ -186,6 +199,7 @@ func makeNonSpillBenchmarkBatches(
 	b testing.TB,
 	proc *process.Process,
 	typ types.Type,
+	varcharPayloadBytes int,
 ) []*batch.Batch {
 	inputs := make([]*batch.Batch, nonSpillBenchmarkBatchCount)
 	for batchIndex := range inputs {
@@ -201,11 +215,15 @@ func makeNonSpillBenchmarkBatches(
 					vector.AppendFixed(vec, int64(value), false, proc.Mp()),
 				)
 			case types.T_varchar:
+				key := "key-" + strconv.Itoa(value)
+				if varcharPayloadBytes > len(key) {
+					key += strings.Repeat("x", varcharPayloadBytes-len(key))
+				}
 				require.NoError(
 					b,
 					vector.AppendBytes(
 						vec,
-						[]byte("key-"+strconv.Itoa(value)),
+						[]byte(key),
 						false,
 						proc.Mp(),
 					),

--- a/pkg/sql/colexec/hashbuild/nonspill_benchmark_test.go
+++ b/pkg/sql/colexec/hashbuild/nonspill_benchmark_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
@@ -57,8 +58,10 @@ func BenchmarkHashBuildNonSpillE2E(b *testing.B) {
 		name                string
 		typ                 types.Type
 		varcharPayloadBytes int
+		computed            bool
 	}{
 		{name: "INT64", typ: types.T_int64.ToType()},
+		{name: "INT64_PLUS_ZERO", typ: types.T_int64.ToType(), computed: true},
 		{name: "VARCHAR_INLINE", typ: types.T_varchar.ToType()},
 		{
 			name:                "VARCHAR_AREA_128",
@@ -69,7 +72,7 @@ func BenchmarkHashBuildNonSpillE2E(b *testing.B) {
 	for _, benchmark := range benchmarks {
 		b.Run("Shuffle/"+benchmark.name, func(b *testing.B) {
 			benchmarkHashBuildNonSpillE2E(
-				b, benchmark.typ, benchmark.varcharPayloadBytes)
+				b, benchmark.typ, benchmark.varcharPayloadBytes, benchmark.computed)
 		})
 	}
 }
@@ -78,6 +81,7 @@ func benchmarkHashBuildNonSpillE2E(
 	b *testing.B,
 	keyType types.Type,
 	varcharPayloadBytes int,
+	computed bool,
 ) {
 	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
 	proc.SetMessageBoard(message.NewMessageBoard())
@@ -94,6 +98,15 @@ func benchmarkHashBuildNonSpillE2E(
 	budget, err := proc.GetHashBuildBudget()
 	require.NoError(b, err)
 	require.NotNil(b, budget)
+	keyExpr := nonSpillBenchmarkColumnExpr(0, keyType)
+	if computed {
+		keyExpr, err = plan2.BindFuncExprImplByPlanExpr(
+			proc.Ctx,
+			"+",
+			[]*plan.Expr{keyExpr, plan2.MakePlan2Int64ConstExprWithType(0)},
+		)
+		require.NoError(b, err)
+	}
 
 	b.SetBytes(inputBytes)
 	b.ReportAllocs()
@@ -106,7 +119,7 @@ func benchmarkHashBuildNonSpillE2E(
 
 	for i := 0; i < b.N; i++ {
 		child := colexec.NewMockOperator().WithBatchs(inputs)
-		arg := newNonSpillBenchmarkHashBuild(keyType, child)
+		arg := newNonSpillBenchmarkHashBuild(keyExpr, child)
 		require.NoError(b, child.Prepare(proc))
 		require.NoError(b, arg.Prepare(proc))
 		before := budget.Snapshot()
@@ -124,6 +137,12 @@ func benchmarkHashBuildNonSpillE2E(
 			b,
 			int64(nonSpillBenchmarkBatchCount*nonSpillBenchmarkBatchRows),
 			joinMap.GetRowCount(),
+		)
+		require.Equal(
+			b,
+			uint64(nonSpillBenchmarkBatchCount*nonSpillBenchmarkBatchRows),
+			joinMap.GetGroupCount(),
+			"benchmark keys must remain unique",
 		)
 		afterBuild := budget.Snapshot()
 		require.Greater(b, afterBuild.ReserveCount, before.ReserveCount)
@@ -156,10 +175,9 @@ func benchmarkHashBuildNonSpillE2E(
 }
 
 func newNonSpillBenchmarkHashBuild(
-	keyType types.Type,
+	keyExpr *plan.Expr,
 	child vm.Operator,
 ) *HashBuild {
-	keyExpr := nonSpillBenchmarkColumnExpr(0, keyType)
 	arg := &HashBuild{
 		NeedHashMap:    true,
 		NeedBatches:    true,

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -239,6 +239,198 @@ func spillScratchBudgetBytes(bat *batch.Batch, sourceAlreadyCharged bool) (uint6
 	return need - source, nil
 }
 
+const spillRecoveryReservationQuantum = uint64(64 << 10)
+
+// spillRecoveryReservationBytes rounds a recovery high-water mark to a small,
+// fixed allocation quantum. The lease is per HashBuild execution, not per
+// batch: rounding avoids rescanning near-identical varlen batches merely
+// because their payload differs by a few bytes, while keeping the bounded
+// over-reservation independent of row count, fanout, and query shape.
+func spillRecoveryReservationBytes(need uint64) (uint64, error) {
+	if need == 0 {
+		return 0, nil
+	}
+	if need > math.MaxUint64-(spillRecoveryReservationQuantum-1) {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	return (need + spillRecoveryReservationQuantum - 1) &^ (spillRecoveryReservationQuantum - 1), nil
+}
+
+// spillDirectRecoveryBudgetUpper is a row-scan-free upper bound used to decide
+// whether the current recovery lease can already spill an upstream batch.
+// Fixed-width and const batches are exact apart from bounded slack. A regular
+// varlen vector may have every descriptor reference the same physical area, so
+// rows*area is the smallest representation-independent bound available without
+// inspecting descriptors. Such batches are scanned exactly only when this
+// conservative bound crosses the retained high-water mark; this path is cold
+// for normal resident builds.
+func spillDirectRecoveryBudgetUpper(bat *batch.Batch) (uint64, bool, error) {
+	if bat == nil || bat.RowCount() <= 0 {
+		return 0, false, nil
+	}
+	rows := uint64(bat.RowCount())
+	var selected uint64
+	hasVarlen := false
+	for _, vec := range bat.Vecs {
+		if vec == nil {
+			return 0, false, process.ErrHashBuildBudgetInvalid
+		}
+		typeSize := vec.GetType().TypeSize()
+		if typeSize < 0 {
+			return 0, false, process.ErrHashBuildBudgetInvalid
+		}
+		descriptors, err := spillCheckedMul(rows, uint64(typeSize))
+		if err != nil {
+			return 0, false, err
+		}
+		selected, err = spillCheckedAdd(selected, descriptors)
+		if err != nil {
+			return 0, false, err
+		}
+		if vec.GetType().IsVarlen() && !vec.IsConstNull() {
+			hasVarlen = true
+			payloadUpper := uint64(len(vec.GetArea()))
+			if !vec.IsConst() {
+				payloadUpper, err = spillCheckedMul(payloadUpper, rows)
+				if err != nil {
+					return 0, false, err
+				}
+			}
+			selected, err = spillCheckedAdd(selected, payloadUpper)
+			if err != nil {
+				return 0, false, err
+			}
+		}
+	}
+	materializationSlack, err := spillMaterializationSlack(uint64(len(bat.Vecs)))
+	if err != nil {
+		return 0, false, err
+	}
+	selected, err = spillCheckedAdd(selected, materializationSlack)
+	if err != nil {
+		return 0, false, err
+	}
+	allocated := bat.Allocated()
+	if allocated < 0 {
+		return 0, false, process.ErrHashBuildBudgetInvalid
+	}
+	need, err := spillPeakBudgetFor(rows, uint64(allocated), selected, uint64(len(bat.Vecs)))
+	return need, hasVarlen, err
+}
+
+// spillRetainedRecoveryBudgetBytes turns the allocation projection already
+// required by CopyIntoBatches into a future-drain proof. The projection tracks
+// logical spill materialization rather than physical retained allocation:
+// ordinary non-const descriptors can also share one retained payload while a
+// later spill selection copies it once per row. Source memory itself is covered
+// separately by the retained-batch reservation.
+func spillRetainedRecoveryBudgetBytes(projection batchCopyProjection) (uint64, error) {
+	if projection.maxRetainedRows <= 0 || projection.columns < 0 {
+		return 0, process.ErrHashBuildBudgetInvalid
+	}
+	materializationSlack, err := spillMaterializationSlack(uint64(projection.columns))
+	if err != nil {
+		return 0, err
+	}
+	selected, err := spillCheckedAdd(
+		projection.maxRetainedSelected,
+		materializationSlack,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return spillPeakBudgetFor(
+		uint64(projection.maxRetainedRows),
+		0,
+		selected,
+		uint64(projection.columns),
+	)
+}
+
+func (ctr *container) ensureSpillRecoveryReservationBytes(
+	need uint64,
+	analyzer process.Analyzer,
+) error {
+	if ctr.hashmapBuilder.budget == nil || need == 0 || need <= ctr.spillScratchBase {
+		return nil
+	}
+	var err error
+	if ctr.spillScratchReservation == nil {
+		ctr.spillScratchReservation, err = ctr.hashmapBuilder.budget.Reserve(need)
+		if err != nil {
+			analyzer.GetOpStats().AddExtraStat("HashBuildSpillRecoveryReserveRejects", 1)
+			return err
+		}
+		ctr.spillScratchBase = need
+		analyzer.GetOpStats().SetMaxExtraStat(
+			"HashBuildSpillRecoveryReservedBytes", hashBuildStatInt64(need))
+		analyzer.GetOpStats().SetMaxExtraStat(
+			"HashBuildSpillScratchPeakBytes", hashBuildStatInt64(need))
+		return nil
+	}
+
+	grow := need - ctr.spillScratchBase
+	if err = ctr.spillScratchReservation.Grow(grow); err != nil {
+		analyzer.GetOpStats().AddExtraStat("HashBuildSpillRecoveryGrowRejects", 1)
+		return err
+	}
+	ctr.spillScratchBase = need
+	analyzer.GetOpStats().AddExtraStat("HashBuildSpillRecoveryGrowCount", 1)
+	analyzer.GetOpStats().AddExtraStat(
+		"HashBuildSpillRecoveryGrowBytes", hashBuildStatInt64(grow))
+	analyzer.GetOpStats().SetMaxExtraStat(
+		"HashBuildSpillRecoveryReservedBytes", hashBuildStatInt64(need))
+	analyzer.GetOpStats().SetMaxExtraStat(
+		"HashBuildSpillScratchPeakBytes", hashBuildStatInt64(need))
+	return nil
+}
+
+func (ctr *container) ensureDirectSpillRecovery(
+	bat *batch.Batch,
+	analyzer process.Analyzer,
+) error {
+	upper, hasVarlen, err := spillDirectRecoveryBudgetUpper(bat)
+	if err != nil {
+		return err
+	}
+	if upper <= ctr.spillScratchBase {
+		return nil
+	}
+	need := upper
+	if hasVarlen {
+		// The cheap upper includes dead/null varlena area. Pay the exact live-row
+		// scan only when a larger lease may be required, avoiding both false
+		// admission failure and a scan on steady-state batches.
+		need, err = spillBudgetBytes(bat)
+		if err != nil {
+			return err
+		}
+		if need <= ctr.spillScratchBase {
+			return nil
+		}
+	}
+	need, err = spillRecoveryReservationBytes(need)
+	if err != nil {
+		return err
+	}
+	return ctr.ensureSpillRecoveryReservationBytes(need, analyzer)
+}
+
+func (ctr *container) ensureRetainedSpillRecovery(
+	projection batchCopyProjection,
+	analyzer process.Analyzer,
+) error {
+	need, err := spillRetainedRecoveryBudgetBytes(projection)
+	if err != nil {
+		return err
+	}
+	need, err = spillRecoveryReservationBytes(need)
+	if err != nil {
+		return err
+	}
+	return ctr.ensureSpillRecoveryReservationBytes(need, analyzer)
+}
+
 func (ctr *container) growSpillScratchTransient(
 	required uint64,
 	analyzer process.Analyzer,

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -16,6 +16,7 @@ package hashbuild
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -27,7 +28,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
-	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -35,7 +35,6 @@ import (
 const (
 	spillNumBuckets = 32
 	spillMagic      = 0x12345678DEADBEEF
-	spillBufferSize = 8192 // Buffer 8192 rows before flushing
 	// Serialized records are accumulated per bucket across source batches.
 	// Allocation is admitted lazily against the lifecycle scratch lease and
 	// falls back to direct writes when the hard budget has no headroom.
@@ -450,6 +449,31 @@ func (ctr *container) growSpillScratchTransient(
 	return oldSize, true, nil
 }
 
+// growSpillScratchTransientWithReclaim gives a mandatory replacement overlap
+// one deterministic retry after returning optional coalesce ownership. Callers
+// invoke it before mutating the allocation being replaced; flushing previously
+// buffered records is therefore safe and the current allocation is never
+// replayed.
+func (ctr *container) growSpillScratchTransientWithReclaim(
+	proc *process.Process,
+	files []*os.File,
+	required uint64,
+	analyzer process.Analyzer,
+) (uint64, bool, error) {
+	oldSize, grew, err := ctr.growSpillScratchTransient(required, analyzer)
+	if !errors.Is(err, process.ErrHashBuildBudgetAdmission) {
+		return oldSize, grew, err
+	}
+	reclaimed, reclaimErr := ctr.reclaimOptionalSpillCoalesce(proc, files, analyzer)
+	if reclaimErr != nil {
+		return 0, false, reclaimErr
+	}
+	if !reclaimed {
+		return 0, false, err
+	}
+	return ctr.growSpillScratchTransient(required, analyzer)
+}
+
 func (ctr *container) restoreSpillScratchTransient(oldSize uint64, grew bool) error {
 	if !grew {
 		return nil
@@ -482,6 +506,42 @@ func (ctr *container) dropSpillScratchBuffers() {
 	ctr.spillSelection = nil
 	ctr.spillKeyVecs = nil
 	ctr.spillWriteBuf = bytes.Buffer{}
+}
+
+// reclaimOptionalSpillCoalesce gives mandatory recovery reservations priority
+// over the write-coalescing cache. It is called only at a quiescent mandatory
+// allocation boundary: between spill batches or before the current bucket's
+// replacement allocation. Transient scratch has been restored there, so every
+// byte above spillScratchBase is owned by optional per-bucket caches. Flush
+// their pending records, drop their backing, and return that charge to the
+// recovery floor before retrying mandatory admission once.
+func (ctr *container) reclaimOptionalSpillCoalesce(
+	proc *process.Process,
+	files []*os.File,
+	analyzer process.Analyzer,
+) (bool, error) {
+	if ctr.spillScratchReservation == nil {
+		if ctr.spillScratchBase != 0 {
+			return false, process.ErrHashBuildBudgetInvalid
+		}
+		return false, nil
+	}
+	current := ctr.spillScratchReservation.Size()
+	if current < ctr.spillScratchBase {
+		return false, process.ErrHashBuildBudgetInvalid
+	}
+	if current == ctr.spillScratchBase {
+		return false, nil
+	}
+	if err := ctr.flushSpillBuffers(proc, files, analyzer); err != nil {
+		return false, err
+	}
+	for bucket := range ctr.spillBucketWriteBufs {
+		ctr.spillBucketWriteBufs[bucket] = bytes.Buffer{}
+		ctr.spillBucketWriteRows[bucket] = 0
+	}
+	_, err := ctr.spillScratchReservation.ReconcileDown(ctr.spillScratchBase)
+	return err == nil, err
 }
 
 func spillMarshalGrowBytes(bat *batch.Batch) (uint64, error) {
@@ -591,20 +651,6 @@ func (ctr *container) writeSpillPayload(
 	return nil
 }
 
-func (ctr *container) flushBucketBuffer(proc *process.Process, bat *batch.Batch, file *os.File, analyzer process.Analyzer) (int64, error) {
-	if bat == nil || bat.RowCount() == 0 {
-		return 0, nil
-	}
-	cnt, err := marshalSpillRecord(bat, &ctr.spillWriteBuf)
-	if err != nil {
-		return 0, err
-	}
-	if err := ctr.writeSpillPayload(proc, file, ctr.spillWriteBuf.Bytes(), cnt, analyzer); err != nil {
-		return 0, err
-	}
-	return cnt, nil
-}
-
 func (ctr *container) getSpillFS(proc *process.Process) (fileservice.MutableFileService, error) {
 	if ctr.spillFS != nil {
 		return ctr.spillFS, nil
@@ -663,12 +709,27 @@ func (ctr *container) ensureSpillFile(proc *process.Process, files []*os.File, b
 // bucket. One selected batch is reused as each bucket is materialized and
 // marshaled before advancing; serialized records are coalesced until the
 // bounded buffers or final handoff flush.
-func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch, files []*os.File, executors []colexec.ExpressionExecutor, analyzer process.Analyzer, sourceAlreadyCharged bool) error {
+func (ctr *container) spillBatchBounded(
+	proc *process.Process,
+	bat *batch.Batch,
+	files []*os.File,
+	analyzer process.Analyzer,
+	sourceAlreadyCharged bool,
+) error {
 	if bat == nil || bat.RowCount() == 0 {
 		return nil
 	}
 	if err := checkHashBuildCanceled(proc); err != nil {
 		return err
+	}
+	expressionLease := ctr.hashmapBuilder.expressionLease
+	if expressionLease == nil {
+		return process.ErrHashBuildBudgetInvalid
+	}
+	rows := bat.RowCount()
+	keyCount := expressionLease.Len()
+	if keyCount == 0 {
+		return process.ErrHashBuildBudgetInvalid
 	}
 	need, err := spillScratchBudgetBytes(bat, sourceAlreadyCharged)
 	if err != nil {
@@ -706,10 +767,9 @@ func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch,
 		}
 	}
 
-	rows := bat.RowCount()
 	replacementOverlap, err := spillCapacityReplacementOverlap(
 		rows,
-		len(executors),
+		keyCount,
 		cap(ctr.spillHashValues),
 		cap(ctr.spillBucketRowIds),
 		cap(ctr.spillKeyVecs),
@@ -721,13 +781,14 @@ func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch,
 	if err != nil {
 		return err
 	}
-	oldScratchSize, grewScratch, err := ctr.growSpillScratchTransient(replacementPeak, analyzer)
+	oldScratchSize, grewScratch, err := ctr.growSpillScratchTransientWithReclaim(
+		proc, files, replacementPeak, analyzer)
 	if err != nil {
 		return err
 	}
 
-	if cap(ctr.spillKeyVecs) < len(executors) {
-		ctr.spillKeyVecs = make([]*vector.Vector, len(executors))
+	if cap(ctr.spillKeyVecs) < keyCount {
+		ctr.spillKeyVecs = make([]*vector.Vector, keyCount)
 	}
 	if cap(ctr.spillHashValues) < rows {
 		ctr.spillHashValues = make([]uint64, rows)
@@ -738,7 +799,7 @@ func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch,
 	if err := ctr.restoreSpillScratchTransient(oldScratchSize, grewScratch); err != nil {
 		return err
 	}
-	keyVecs := ctr.spillKeyVecs[:len(executors)]
+	keyVecs := ctr.spillKeyVecs[:keyCount]
 	var selected *batch.Batch
 	defer func() {
 		if selected != nil {
@@ -748,30 +809,19 @@ func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch,
 			ctr.spillKeyVecs[i] = nil
 		}
 	}()
-	evalOne := func(i int) error {
-		vec, evalErr := executors[i].Eval(proc, []*batch.Batch{bat}, nil)
-		if evalErr == nil {
+	err = expressionLease.Eval(
+		proc,
+		[]*batch.Batch{bat},
+		bat.RowCount(),
+		func(i int, vec *vector.Vector) error {
 			keyVecs[i] = vec
-		}
-		return evalErr
-	}
-	if ctr.spillExprLease != nil {
-		if ctr.spillExprLease.Len() != len(executors) {
-			return process.ErrHashBuildBudgetInvalid
-		}
-		err = ctr.spillExprLease.Run(proc, bat.RowCount(), evalOne)
-	} else {
-		for i := range executors {
-			if err = evalOne(i); err != nil {
-				break
-			}
-		}
-	}
+			return nil
+		},
+	)
 	if err != nil {
-		// Eval may leave newly allocated child/result vectors cached in the
-		// executor tree. Destroy that tree while both the previous and
-		// candidate reservations are still charged.
-		ctr.freeSpillExprExecs()
+		// Eval may leave child/result vectors cached. The caller that owns the
+		// executor set keeps its lease charged until it destroys the complete
+		// tree; this function must not guess or duplicate that ownership.
 		return err
 	}
 	if err := checkHashBuildCanceled(proc); err != nil {
@@ -812,6 +862,11 @@ func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch,
 		writePos[bucket] = pos + 1
 	}
 
+	// Coalescing is optional. Once one bucket cannot admit a new cache in this
+	// batch, later buckets without an already-owned cache write through instead
+	// of repeating the same fanout-sized budget rejection. The next ingress
+	// batch probes again, so released sibling headroom is still discoverable.
+	allowNewCoalesce := true
 	for bucket := 0; bucket < spillNumBuckets; bucket++ {
 		if err := checkHashBuildCanceled(proc); err != nil {
 			return err
@@ -851,7 +906,8 @@ func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch,
 			var file *os.File
 			file, spillErr = ctr.ensureSpillFile(proc, files, int(bucket))
 			if spillErr == nil {
-				spillErr = ctr.appendSpillRecord(proc, file, int(bucket), selected, need, analyzer)
+				spillErr = ctr.appendSpillRecord(
+					proc, files, file, int(bucket), selected, need, analyzer, &allowNewCoalesce)
 			}
 		}
 		selected.CleanOnlyData()
@@ -868,11 +924,13 @@ func (ctr *container) spillBatchBounded(proc *process.Process, bat *batch.Batch,
 // temporary copy can be retained.
 func (ctr *container) appendSpillRecord(
 	proc *process.Process,
+	files []*os.File,
 	file *os.File,
 	bucket int,
 	bat *batch.Batch,
 	scratchNeed uint64,
 	analyzer process.Analyzer,
+	allowNewCoalesce *bool,
 ) error {
 	if bucket < 0 || bucket >= spillNumBuckets {
 		return process.ErrHashBuildBudgetInvalid
@@ -888,7 +946,8 @@ func (ctr *container) appendSpillRecord(
 		if addErr != nil {
 			return addErr
 		}
-		oldScratchSize, grewScratch, err = ctr.growSpillScratchTransient(peak, analyzer)
+		oldScratchSize, grewScratch, err = ctr.growSpillScratchTransientWithReclaim(
+			proc, files, peak, analyzer)
 		if err != nil {
 			return err
 		}
@@ -911,7 +970,14 @@ func (ctr *container) appendSpillRecord(
 		return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
 	}
 	if buf.Len() == 0 {
+		if buf.Cap() < spillWriteCoalesceSize &&
+			allowNewCoalesce != nil && !*allowNewCoalesce {
+			return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
+		}
 		if !ctr.ensureSpillCoalesceCapacity(buf, analyzer) {
+			if allowNewCoalesce != nil {
+				*allowNewCoalesce = false
+			}
 			return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
 		}
 		if buf.Cap() < spillWriteCoalesceSize {
@@ -1006,65 +1072,6 @@ func (ctr *container) flushSpillBuffers(proc *process.Process, files []*os.File,
 		}
 	}
 	return firstErr
-}
-
-func (ctr *container) appendBuildBatchToSpillFiles(proc *process.Process, bat *batch.Batch, files []*os.File, buffers []*batch.Batch, executors []colexec.ExpressionExecutor, analyzer process.Analyzer) error {
-	// buffers is retained in the signature for source compatibility with older
-	// unit tests and callers.  The implementation intentionally ignores it:
-	// every non-empty bucket is selected and flushed before the next bucket is
-	// materialized, so no persistent fanout-sized vector set can grow.
-	_ = buffers
-	return ctr.spillBatchBounded(proc, bat, files, executors, analyzer, false)
-}
-
-// initSpillExprExecs initializes or validates spill expression executors.
-// Returns the executors slice ready for use. Called once when entering spill mode.
-func (ctr *container) initSpillExprExecs(proc *process.Process, conditions []*plan.Expr) ([]colexec.ExpressionExecutor, error) {
-	for _, condition := range conditions {
-		if condition == nil {
-			return nil, &process.HashBuildBudgetError{Kind: process.HashBuildBudgetErrorInvalid, Message: "nil shuffle spill key"}
-		}
-	}
-	if len(ctr.spillExprExecs) != len(conditions) {
-		execs, lease, err := NewBudgetedExpressionExecutors(
-			proc,
-			ctr.hashmapBuilder.budget,
-			conditions,
-			false,
-		)
-		if err != nil {
-			return nil, err
-		}
-		ctr.freeSpillExprExecs()
-		ctr.spillExprExecs = execs
-		ctr.spillExprLease = lease
-	} else if ctr.spillExprLease == nil {
-		lease, err := NewExpressionMemoryLease(
-			ctr.hashmapBuilder.budget,
-			conditions,
-			ctr.spillExprExecs,
-			false,
-		)
-		if err != nil {
-			return nil, err
-		}
-		ctr.spillExprLease = lease
-	}
-	return ctr.spillExprExecs, nil
-}
-
-// freeSpillExprExecs frees all cached spill expression executors.
-func (ctr *container) freeSpillExprExecs() {
-	for _, exec := range ctr.spillExprExecs {
-		if exec != nil {
-			exec.Free()
-		}
-	}
-	ctr.spillExprExecs = nil
-	if ctr.spillExprLease != nil {
-		ctr.spillExprLease.Release()
-		ctr.spillExprLease = nil
-	}
 }
 
 func (ctr *container) memUsed() int64 {

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -1562,6 +1562,20 @@ func TestRetainedSpillRecoveryProjectionMatrix(t *testing.T) {
 				{kind: "nullable", rows: 2*colexec.DefaultBatchSize + 17, payloadBytes: 64},
 			},
 		},
+		{
+			name: "partial-tail-with-exact-full-remainder",
+			ingresses: []ingressSpec{
+				{kind: "fixed", rows: colexec.DefaultBatchSize - 1},
+				{kind: "fixed", rows: colexec.DefaultBatchSize + 1},
+			},
+		},
+		{
+			name: "partial-tail-with-larger-varlen-remainder",
+			ingresses: []ingressSpec{
+				{kind: "const", rows: colexec.DefaultBatchSize - 1, payloadBytes: 1},
+				{kind: "const", rows: colexec.DefaultBatchSize + 2, payloadBytes: 64},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1648,6 +1662,18 @@ func TestRetainedSpillRecoveryProjectionMatrix(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, wantSelected, actualSelected)
 			}
+			if test.name == "partial-tail-with-exact-full-remainder" {
+				require.Zero(t, hb.retainedSpillTailSelected)
+				require.Equal(t, colexec.DefaultBatchSize,
+					hb.Batches.Buf[len(hb.Batches.Buf)-1].RowCount())
+			}
+			if test.name == "partial-tail-with-larger-varlen-remainder" {
+				tail := hb.Batches.Buf[len(hb.Batches.Buf)-1]
+				require.Equal(t, 1, tail.RowCount())
+				actualSelected, err := spillMaterializedBytes(tail)
+				require.NoError(t, err)
+				require.Equal(t, actualSelected, hb.retainedSpillTailSelected)
+			}
 
 			hb.cleanBatches(proc)
 			require.Zero(t, hb.retainedSpillTailSelected)
@@ -1675,6 +1701,129 @@ func TestSpillRecoveryReservationRoundingBoundaries(t *testing.T) {
 	}
 	_, err := spillRecoveryReservationBytes(math.MaxUint64)
 	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+}
+
+func TestSpillRecoveryReservationLifecycle(t *testing.T) {
+	t.Run("reserve-reuse-grow-release", func(t *testing.T) {
+		const capBytes = 2 * spillRecoveryReservationQuantum
+		budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+		generation, err := budget.OpenGeneration(1)
+		require.NoError(t, err)
+		defer generation.Close()
+
+		ctr := &container{}
+		ctr.hashmapBuilder.setBudget(generation)
+		analyzer := process.NewAnalyzer(0, false, false, "recovery lifecycle")
+
+		require.NoError(t, ctr.ensureSpillRecoveryReservationBytes(
+			spillRecoveryReservationQuantum, analyzer))
+		token := ctr.spillScratchReservation
+		require.NotNil(t, token)
+		require.Equal(t, spillRecoveryReservationQuantum, token.Size())
+		require.Equal(t, spillRecoveryReservationQuantum, generation.Used())
+
+		reserveCount := generation.ReserveCount()
+		require.NoError(t, ctr.ensureSpillRecoveryReservationBytes(1, analyzer))
+		require.Same(t, token, ctr.spillScratchReservation)
+		require.Equal(t, reserveCount, generation.ReserveCount())
+
+		require.NoError(t, ctr.ensureSpillRecoveryReservationBytes(capBytes, analyzer))
+		require.Same(t, token, ctr.spillScratchReservation)
+		require.Equal(t, capBytes, ctr.spillScratchBase)
+		require.Equal(t, capBytes, token.Size())
+		require.Equal(t, capBytes, generation.Used())
+		require.Equal(t, reserveCount+1, generation.ReserveCount())
+
+		extra := analyzer.GetOpStats().ExtraStats
+		require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowCount"])
+		require.Equal(t, int64(spillRecoveryReservationQuantum),
+			extra["HashBuildSpillRecoveryGrowBytes"])
+		require.Equal(t, int64(capBytes), extra["HashBuildSpillRecoveryReservedBytes"])
+
+		ctr.releaseSpillScratchReservation()
+		require.Nil(t, ctr.spillScratchReservation)
+		require.Zero(t, ctr.spillScratchBase)
+		require.Zero(t, generation.Used())
+	})
+
+	t.Run("grow-rejection-preserves-old-lease", func(t *testing.T) {
+		const capBytes = spillRecoveryReservationQuantum
+		budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+		generation, err := budget.OpenGeneration(1)
+		require.NoError(t, err)
+		defer generation.Close()
+
+		ctr := &container{}
+		ctr.hashmapBuilder.setBudget(generation)
+		analyzer := process.NewAnalyzer(0, false, false, "recovery grow rejection")
+		require.NoError(t, ctr.ensureSpillRecoveryReservationBytes(capBytes, analyzer))
+		token := ctr.spillScratchReservation
+
+		err = ctr.ensureSpillRecoveryReservationBytes(2*capBytes, analyzer)
+		require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+		require.Same(t, token, ctr.spillScratchReservation)
+		require.Equal(t, capBytes, ctr.spillScratchBase)
+		require.Equal(t, capBytes, token.Size())
+		require.Equal(t, capBytes, generation.Used())
+		require.Equal(t, uint64(1), generation.ReserveCount())
+		require.Equal(t, uint64(1), generation.RejectCount())
+
+		extra := analyzer.GetOpStats().ExtraStats
+		require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowRejects"])
+		require.Zero(t, extra["HashBuildSpillRecoveryGrowCount"])
+		require.NoError(t, ctr.ensureSpillRecoveryReservationBytes(capBytes, analyzer),
+			"a failed grow must leave the prior recovery lease reusable")
+
+		ctr.releaseSpillScratchReservation()
+		require.Zero(t, generation.Used())
+	})
+}
+
+func TestSpillRecoveryRejectsInvalidProofsWithoutChargingBudget(t *testing.T) {
+	const capBytes = spillRecoveryReservationQuantum
+	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	defer generation.Close()
+
+	ctr := &container{}
+	ctr.hashmapBuilder.setBudget(generation)
+	analyzer := process.NewAnalyzer(0, false, false, "invalid recovery proof")
+
+	upper, hasVarlen, err := spillDirectRecoveryBudgetUpper(nil)
+	require.NoError(t, err)
+	require.Zero(t, upper)
+	require.False(t, hasVarlen)
+	require.NoError(t, ctr.ensureDirectSpillRecovery(nil, analyzer))
+
+	malformed := batch.NewOffHeapWithSize(1)
+	malformed.SetRowCount(1)
+	err = ctr.ensureDirectSpillRecovery(malformed, analyzer)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	require.Nil(t, ctr.spillScratchReservation)
+	require.Zero(t, generation.Used())
+
+	for _, test := range []struct {
+		name       string
+		projection batchCopyProjection
+	}{
+		{name: "empty-destination", projection: batchCopyProjection{}},
+		{
+			name: "selected-size-overflow",
+			projection: batchCopyProjection{
+				maxRetainedRows:     1,
+				maxRetainedSelected: math.MaxUint64,
+				columns:             1,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := ctr.ensureRetainedSpillRecovery(test.projection, analyzer)
+			require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+			require.Nil(t, ctr.spillScratchReservation)
+			require.Zero(t, generation.Used())
+		})
+	}
 }
 
 func TestSpillDirectRecoveryUpperBoundsExactMatrix(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -35,6 +35,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func initSpillExprExecsForTest(
+	ctr *container,
+	proc *process.Process,
+	conditions []*plan.Expr,
+) error {
+	for _, condition := range conditions {
+		if condition == nil {
+			return process.ErrHashBuildBudgetInvalid
+		}
+	}
+	ctr.hashmapBuilder.FreeExecutors()
+	if err := ctr.hashmapBuilder.Prepare(
+		conditions, -1, -1, nil, proc,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
 func TestComputeXXHashBuild(t *testing.T) {
 	mp := mpool.MustNewZero()
 
@@ -67,38 +86,35 @@ func TestComputeXXHashBuild(t *testing.T) {
 	})
 }
 
-func TestFlushBucketBufferBuild(t *testing.T) {
+func TestMarshalSpillRecordBuild(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
-	spillfs, err := proc.GetSpillFileService()
-	require.NoError(t, err)
-
-	file, err := spillfs.CreateFile(context.Background(), "test_build_flush")
-	require.NoError(t, err)
-	defer func() {
-		file.Close()
-		spillfs.RemoveFile(context.Background(), "test_build_flush")
-	}()
-
-	analyzer := process.NewAnalyzer(0, false, false, "test")
-	ctr := &container{spillUUID: t.Name()}
-
-	t.Run("empty_buffer", func(t *testing.T) {
-		var buf *batch.Batch
-		cnt, err := ctr.flushBucketBuffer(proc, buf, file, analyzer)
+	t.Run("empty batch", func(t *testing.T) {
+		var buf bytes.Buffer
+		cnt, err := marshalSpillRecord(nil, &buf)
 		require.NoError(t, err)
-		require.Equal(t, int64(0), cnt)
+		require.Zero(t, cnt)
+		require.Zero(t, buf.Len())
 	})
 
-	t.Run("with_data", func(t *testing.T) {
+	t.Run("framed batch", func(t *testing.T) {
 		bat := batch.NewWithSize(1)
 		bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3}, nil, proc.Mp())
 		bat.SetRowCount(3)
+		defer bat.Clean(proc.Mp())
 
-		cnt, err := ctr.flushBucketBuffer(proc, bat, file, analyzer)
+		var buf bytes.Buffer
+		cnt, err := marshalSpillRecord(bat, &buf)
 		require.NoError(t, err)
 		require.Equal(t, int64(3), cnt)
+		require.GreaterOrEqual(t, buf.Len(), 24)
+		require.Equal(t, cnt, types.DecodeInt64(buf.Bytes()[:8]))
+		payloadBytes := types.DecodeInt64(buf.Bytes()[8:16])
+		require.Positive(t, payloadBytes)
+		require.Equal(t, int64(buf.Len()), 16+payloadBytes+8)
+		require.Equal(t, uint64(spillMagic),
+			types.DecodeUint64(buf.Bytes()[buf.Len()-8:]))
 	})
 }
 
@@ -236,38 +252,6 @@ func TestHashDistributionBuild(t *testing.T) {
 	require.Greater(t, nonEmptyBuckets, 1)
 }
 
-func TestLargeBufferFlushBuild(t *testing.T) {
-	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
-	defer proc.Free()
-
-	spillfs, err := proc.GetSpillFileService()
-	require.NoError(t, err)
-
-	analyzer := process.NewAnalyzer(0, false, false, "test")
-	file, err := spillfs.CreateFile(context.Background(), "test_large_build")
-	require.NoError(t, err)
-	defer func() {
-		file.Close()
-		spillfs.RemoveFile(context.Background(), "test_large_build")
-	}()
-
-	// Create large batch
-	size := spillBufferSize + 100
-	values := make([]int32, size)
-	for i := range values {
-		values[i] = int32(i)
-	}
-
-	bat := batch.NewWithSize(1)
-	bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
-	bat.SetRowCount(size)
-
-	ctr := &container{spillUUID: t.Name()}
-	cnt, err := ctr.flushBucketBuffer(proc, bat, file, analyzer)
-	require.NoError(t, err)
-	require.Equal(t, int64(size), cnt)
-}
-
 func TestMultipleDataTypesBuild(t *testing.T) {
 	mp := mpool.MustNewZero()
 
@@ -315,9 +299,13 @@ func TestFileWriteErrorBuild(t *testing.T) {
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1}, nil, proc.Mp())
 	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
 
 	ctr := &container{spillUUID: t.Name()}
-	_, err := ctr.flushBucketBuffer(proc, bat, file, analyzer)
+	var buf bytes.Buffer
+	cnt, err := marshalSpillRecord(bat, &buf)
+	require.NoError(t, err)
+	err = ctr.writeSpillPayload(proc, file, buf.Bytes(), cnt, analyzer)
 	require.Error(t, err)
 
 	spillfs.RemoveFile(context.Background(), "test_error_build")
@@ -350,7 +338,7 @@ func TestWriteSpillPayloadCancellationStopsBeforePhysicalWrite(t *testing.T) {
 	require.Zero(t, analyzer.GetOpStats().SpillRows)
 }
 
-func TestAppendBatchToSpillFilesPartitioning(t *testing.T) {
+func TestSpillBatchPartitioning(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
@@ -367,6 +355,7 @@ func TestAppendBatchToSpillFilesPartitioning(t *testing.T) {
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3, 4, 5, 6, 7, 8}, nil, proc.Mp())
 	bat.SetRowCount(8)
+	defer bat.Clean(proc.Mp())
 
 	conditions := []*plan.Expr{
 		{
@@ -377,27 +366,30 @@ func TestAppendBatchToSpillFilesPartitioning(t *testing.T) {
 		},
 	}
 
-	buffers := make([]*batch.Batch, spillNumBuckets)
-
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	ctr := &container{spillUUID: t.Name()}
-	_, err := ctr.initSpillExprExecs(proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat, files, buffers, ctr.spillExprExecs, analyzer)
+	defer ctr.hashmapBuilder.FreeExecutors()
+	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
+	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
 
-	// Flush remaining buffers (lazy file creation via ensureSpillFile)
-	for i, buf := range buffers {
-		if buf != nil && buf.RowCount() > 0 {
-			file, err := ctr.ensureSpillFile(proc, files, i)
-			require.NoError(t, err)
-			_, err = ctr.flushBucketBuffer(proc, buf, file, analyzer)
-			require.NoError(t, err)
-		}
+	hashes := make([]uint64, bat.RowCount())
+	computeXXHash(bat.Vecs, hashes)
+	expectedBuckets := make(map[int]struct{})
+	for _, hash := range hashes {
+		expectedBuckets[int(hash&(spillNumBuckets-1))] = struct{}{}
 	}
+	require.Greater(t, len(expectedBuckets), 1)
+	for bucket, file := range files {
+		_, expected := expectedBuckets[bucket]
+		require.Equalf(t, expected, file != nil, "bucket %d", bucket)
+	}
+	require.Equal(t, int64(bat.RowCount()), analyzer.GetOpStats().SpillRows)
 }
 
-func TestEmptyBatchSpill(t *testing.T) {
+func TestSpillBatchEmptyInput(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
@@ -413,6 +405,7 @@ func TestEmptyBatchSpill(t *testing.T) {
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{}, nil, proc.Mp())
 	bat.SetRowCount(0)
+	defer bat.Clean(proc.Mp())
 
 	conditions := []*plan.Expr{
 		{
@@ -423,17 +416,20 @@ func TestEmptyBatchSpill(t *testing.T) {
 		},
 	}
 
-	buffers := make([]*batch.Batch, spillNumBuckets)
-
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	ctr := &container{spillUUID: t.Name()}
-	_, err := ctr.initSpillExprExecs(proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat, files, buffers, ctr.spillExprExecs, analyzer)
+	defer ctr.hashmapBuilder.FreeExecutors()
+	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
+	for _, file := range files {
+		require.Nil(t, file)
+	}
+	require.Zero(t, analyzer.GetOpStats().SpillRows)
 }
 
-func TestAppendBuildBatchMultipleFlushes(t *testing.T) {
+func TestSpillBatchLargeInputPreservesRows(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
@@ -446,8 +442,7 @@ func TestAppendBuildBatchMultipleFlushes(t *testing.T) {
 		}
 	}()
 
-	// Create large batch to trigger buffer flushes
-	size := spillBufferSize * 2
+	size := 2 * colexec.DefaultBatchSize
 	values := make([]int32, size)
 	for i := range values {
 		values[i] = int32(i)
@@ -456,6 +451,7 @@ func TestAppendBuildBatchMultipleFlushes(t *testing.T) {
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
 	bat.SetRowCount(size)
+	defer bat.Clean(proc.Mp())
 
 	conditions := []*plan.Expr{
 		{
@@ -466,27 +462,19 @@ func TestAppendBuildBatchMultipleFlushes(t *testing.T) {
 		},
 	}
 
-	buffers := make([]*batch.Batch, spillNumBuckets)
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	ctr := &container{spillUUID: t.Name()}
 
-	_, err := ctr.initSpillExprExecs(proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat, files, buffers, ctr.spillExprExecs, analyzer)
+	defer ctr.hashmapBuilder.FreeExecutors()
+	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
-
-	// Flush remaining (lazy file creation via ensureSpillFile)
-	for i, buf := range buffers {
-		if buf != nil && buf.RowCount() > 0 {
-			file, err := ctr.ensureSpillFile(proc, files, i)
-			require.NoError(t, err)
-			_, err = ctr.flushBucketBuffer(proc, buf, file, analyzer)
-			require.NoError(t, err)
-		}
-	}
+	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
+	require.Equal(t, int64(bat.RowCount()), analyzer.GetOpStats().SpillRows)
 }
 
-func TestAppendBuildBatchWithNulls(t *testing.T) {
+func TestSpillBatchNullKeyPreservesRows(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
@@ -502,6 +490,7 @@ func TestAppendBuildBatchWithNulls(t *testing.T) {
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3, 4}, []uint64{1}, proc.Mp()) // null at index 1
 	bat.SetRowCount(4)
+	defer bat.Clean(proc.Mp())
 
 	conditions := []*plan.Expr{
 		{
@@ -512,27 +501,19 @@ func TestAppendBuildBatchWithNulls(t *testing.T) {
 		},
 	}
 
-	buffers := make([]*batch.Batch, spillNumBuckets)
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	ctr := &container{spillUUID: t.Name()}
 
-	_, err := ctr.initSpillExprExecs(proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat, files, buffers, ctr.spillExprExecs, analyzer)
+	defer ctr.hashmapBuilder.FreeExecutors()
+	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
-
-	// Flush remaining (lazy file creation via ensureSpillFile)
-	for i, buf := range buffers {
-		if buf != nil && buf.RowCount() > 0 {
-			file, err := ctr.ensureSpillFile(proc, files, i)
-			require.NoError(t, err)
-			_, err = ctr.flushBucketBuffer(proc, buf, file, analyzer)
-			require.NoError(t, err)
-		}
-	}
+	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
+	require.Equal(t, int64(bat.RowCount()), analyzer.GetOpStats().SpillRows)
 }
 
-func TestAppendBuildBatchMultiColumn(t *testing.T) {
+func TestSpillBatchMultiColumnPreservesRows(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
@@ -549,6 +530,7 @@ func TestAppendBuildBatchMultiColumn(t *testing.T) {
 	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3}, nil, proc.Mp())
 	bat.Vecs[1] = testutil.MakeVarcharVector([]string{"a", "b", "c"}, nil, proc.Mp())
 	bat.SetRowCount(3)
+	defer bat.Clean(proc.Mp())
 
 	conditions := []*plan.Expr{
 		{
@@ -565,24 +547,16 @@ func TestAppendBuildBatchMultiColumn(t *testing.T) {
 		},
 	}
 
-	buffers := make([]*batch.Batch, spillNumBuckets)
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	ctr := &container{spillUUID: t.Name()}
 
-	_, err := ctr.initSpillExprExecs(proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat, files, buffers, ctr.spillExprExecs, analyzer)
+	defer ctr.hashmapBuilder.FreeExecutors()
+	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
-
-	// Flush remaining (lazy file creation via ensureSpillFile)
-	for i, buf := range buffers {
-		if buf != nil && buf.RowCount() > 0 {
-			file, err := ctr.ensureSpillFile(proc, files, i)
-			require.NoError(t, err)
-			_, err = ctr.flushBucketBuffer(proc, buf, file, analyzer)
-			require.NoError(t, err)
-		}
-	}
+	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
+	require.Equal(t, int64(bat.RowCount()), analyzer.GetOpStats().SpillRows)
 }
 
 func TestShouldSpillBatchesRowThreshold(t *testing.T) {
@@ -664,7 +638,7 @@ func TestHashMultiColumnCombinations(t *testing.T) {
 	require.NotEqual(t, hashValues[0], hashValues[2])
 }
 
-func TestAppendBuildBatchSingleBucket(t *testing.T) {
+func TestSpillBatchSingleRowUsesOneBucket(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
@@ -681,6 +655,7 @@ func TestAppendBuildBatchSingleBucket(t *testing.T) {
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1}, nil, proc.Mp())
 	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
 
 	conditions := []*plan.Expr{
 		{
@@ -691,26 +666,27 @@ func TestAppendBuildBatchSingleBucket(t *testing.T) {
 		},
 	}
 
-	buffers := make([]*batch.Batch, spillNumBuckets)
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	ctr := &container{spillUUID: t.Name()}
 
-	_, err := ctr.initSpillExprExecs(proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat, files, buffers, ctr.spillExprExecs, analyzer)
+	defer ctr.hashmapBuilder.FreeExecutors()
+	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
 
-	// Most buffers should be nil
-	nilCount := 0
-	for _, buf := range buffers {
-		if buf == nil {
-			nilCount++
+	nonEmptyBuckets := 0
+	for _, file := range files {
+		if file != nil {
+			nonEmptyBuckets++
 		}
 	}
-	require.Greater(t, nilCount, spillNumBuckets-5)
+	require.Equal(t, 1, nonEmptyBuckets)
+	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
+	require.Equal(t, int64(1), analyzer.GetOpStats().SpillRows)
 }
 
-func TestBufferReuse(t *testing.T) {
+func TestSpillScratchSlicesReuseAcrossEqualBatches(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
@@ -732,28 +708,38 @@ func TestBufferReuse(t *testing.T) {
 		},
 	}
 
-	buffers := make([]*batch.Batch, spillNumBuckets)
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	ctr := &container{spillUUID: t.Name()}
 
-	_, err := ctr.initSpillExprExecs(proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
+	defer ctr.hashmapBuilder.FreeExecutors()
 
 	// First batch
 	bat1 := batch.NewWithSize(1)
 	bat1.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2}, nil, proc.Mp())
 	bat1.SetRowCount(2)
+	defer bat1.Clean(proc.Mp())
 
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat1, files, buffers, ctr.spillExprExecs, analyzer)
+	err = ctr.spillBatchBounded(proc, bat1, files, analyzer, false)
 	require.NoError(t, err)
+	require.Len(t, ctr.spillHashValues, bat1.RowCount())
+	require.Len(t, ctr.spillBucketRowIds, bat1.RowCount())
+	firstHashStorage := &ctr.spillHashValues[0]
+	firstRowIDStorage := &ctr.spillBucketRowIds[0]
 
 	// Second batch - buffers should be reused
 	bat2 := batch.NewWithSize(1)
 	bat2.Vecs[0] = testutil.MakeInt32Vector([]int32{3, 4}, nil, proc.Mp())
 	bat2.SetRowCount(2)
+	defer bat2.Clean(proc.Mp())
 
-	err = ctr.appendBuildBatchToSpillFiles(proc, bat2, files, buffers, ctr.spillExprExecs, analyzer)
+	err = ctr.spillBatchBounded(proc, bat2, files, analyzer, false)
 	require.NoError(t, err)
+	require.Same(t, firstHashStorage, &ctr.spillHashValues[0])
+	require.Same(t, firstRowIDStorage, &ctr.spillBucketRowIds[0])
+	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
+	require.Equal(t, int64(4), analyzer.GetOpStats().SpillRows)
 }
 
 func TestSpillExpressionLeaseRetainsLargeBatchHighWater(t *testing.T) {
@@ -775,28 +761,28 @@ func TestSpillExpressionLeaseRetainsLargeBatchHighWater(t *testing.T) {
 	expr := makeExpressionLeaseTestExpr(t, proc)
 	ctr := &container{spillUUID: t.Name()}
 	ctr.hashmapBuilder.setBudget(generation)
-	executors, err := ctr.initSpillExprExecs(proc, []*plan.Expr{expr})
+	err = initSpillExprExecsForTest(ctr, proc, []*plan.Expr{expr})
 	require.NoError(t, err)
-	require.NotNil(t, ctr.spillExprLease)
-	defer ctr.freeSpillExprExecs()
+	require.NotNil(t, ctr.hashmapBuilder.expressionLease)
+	defer ctr.hashmapBuilder.FreeExecutors()
 	defer ctr.dropSpillScratchBuffers()
 	defer ctr.releaseSpillScratchReservation()
 
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	large := makeExpressionLeaseTestBatch(proc, colexec.DefaultBatchSize)
 	defer large.Clean(proc.Mp())
-	require.NoError(t, ctr.spillBatchBounded(proc, large, files, executors, analyzer, false))
-	largeReserved := ctr.spillExprLease.Reserved()
+	require.NoError(t, ctr.spillBatchBounded(proc, large, files, analyzer, false))
+	largeReserved := ctr.hashmapBuilder.expressionLease.Reserved()
 	require.Positive(t, largeReserved)
 
 	small := makeExpressionLeaseTestBatch(proc, 1)
 	defer small.Clean(proc.Mp())
-	require.NoError(t, ctr.spillBatchBounded(proc, small, files, executors, analyzer, false))
-	require.Equal(t, largeReserved, ctr.spillExprLease.Reserved(),
+	require.NoError(t, ctr.spillBatchBounded(proc, small, files, analyzer, false))
+	require.Equal(t, largeReserved, ctr.hashmapBuilder.expressionLease.Reserved(),
 		"a small spill batch must not release retained executor headroom")
-	retained, ok := ctr.spillExprLease.Retained()
+	retained, ok := ctr.hashmapBuilder.expressionLease.Retained()
 	require.True(t, ok)
-	require.LessOrEqual(t, retained, ctr.spillExprLease.Reserved())
+	require.LessOrEqual(t, retained, ctr.hashmapBuilder.expressionLease.Reserved())
 }
 
 func TestSpillWriteCoalescesAcrossBatches(t *testing.T) {
@@ -807,20 +793,29 @@ func TestSpillWriteCoalescesAcrossBatches(t *testing.T) {
 	require.NoError(t, err)
 	defer generation.Close()
 	files := make([]*os.File, spillNumBuckets)
-	defer func() {
-		for _, file := range files {
-			if file != nil {
-				file.Close()
-			}
-		}
-	}()
 	conditions := []*plan.Expr{{
 		Typ:  plan.Type{Id: int32(types.T_int32)},
 		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
 	}}
 	ctr := &container{spillUUID: t.Name()}
 	ctr.hashmapBuilder.setBudget(generation)
-	_, err = ctr.initSpillExprExecs(proc, conditions)
+	cleanup := func() {
+		for i, file := range files {
+			if file != nil {
+				_ = file.Close()
+				files[i] = nil
+			}
+		}
+		if ctr.spillBundle != nil {
+			ctr.spillBundle.release()
+			ctr.spillBundle = nil
+		}
+		ctr.hashmapBuilder.FreeExecutors()
+		ctr.dropSpillScratchBuffers()
+		ctr.releaseSpillScratchReservation()
+	}
+	defer cleanup()
+	err = initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	bat := batch.NewWithSize(1)
@@ -828,7 +823,7 @@ func TestSpillWriteCoalescesAcrossBatches(t *testing.T) {
 	bat.SetRowCount(3)
 	defer bat.Clean(proc.Mp())
 	for i := 0; i < 2; i++ {
-		require.NoError(t, ctr.appendBuildBatchToSpillFiles(proc, bat, files, nil, ctr.spillExprExecs, analyzer))
+		require.NoError(t, ctr.spillBatchBounded(proc, bat, files, analyzer, false))
 	}
 	var pending int
 	for i := range ctr.spillBucketWriteBufs {
@@ -881,17 +876,73 @@ func TestSpillWriteCoalescesAcrossBatches(t *testing.T) {
 	require.GreaterOrEqual(t, scratchPeak, hashBuildStatInt64(ctr.spillScratchReservation.Size()))
 	require.Greater(t, scratchPeak, hashBuildStatInt64(ctr.spillScratchBase),
 		"scratch peak must include retained coalesce buffers above the base lease")
-	for _, f := range files {
-		if f != nil {
-			_ = f.Close()
+	cleanup()
+	require.Zero(t, generation.Used())
+}
+
+func TestReclaimOptionalSpillCoalesceReleasesRecoveryHeadroom(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	budget := process.MustNewHashBuildBudget(8<<20, 8<<20)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	defer generation.Close()
+
+	files := make([]*os.File, spillNumBuckets)
+	ctr := &container{spillUUID: t.Name()}
+	ctr.hashmapBuilder.setBudget(generation)
+	cleanup := func() {
+		for i, file := range files {
+			if file != nil {
+				_ = file.Close()
+				files[i] = nil
+			}
 		}
+		if ctr.spillBundle != nil {
+			ctr.spillBundle.release()
+			ctr.spillBundle = nil
+		}
+		ctr.hashmapBuilder.FreeExecutors()
+		ctr.dropSpillScratchBuffers()
+		ctr.releaseSpillScratchReservation()
 	}
-	if ctr.spillBundle != nil {
-		ctr.spillBundle.release()
-		ctr.spillBundle = nil
+	defer cleanup()
+	conditions := []*plan.Expr{{
+		Typ:  plan.Type{Id: int32(types.T_int32)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
+	}}
+	err = initSpillExprExecsForTest(ctr, proc, conditions)
+	require.NoError(t, err)
+	analyzer := process.NewAnalyzer(0, false, false, "recovery priority")
+
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 1, 1}, nil, proc.Mp())
+	bat.SetRowCount(3)
+	defer bat.Clean(proc.Mp())
+	require.NoError(t, ctr.spillBatchBounded(proc, bat, files, analyzer, false))
+	require.NotNil(t, ctr.spillScratchReservation)
+	base := ctr.spillScratchBase
+	beforeSize := ctr.spillScratchReservation.Size()
+	beforeUsed := generation.Used()
+	require.Greater(t, beforeSize, base)
+
+	reclaimed, err := ctr.reclaimOptionalSpillCoalesce(proc, files, analyzer)
+	require.NoError(t, err)
+	require.True(t, reclaimed)
+	require.Equal(t, base, ctr.spillScratchReservation.Size())
+	require.Equal(t, beforeUsed-(beforeSize-base), generation.Used())
+	for bucket := range ctr.spillBucketWriteBufs {
+		require.Zero(t, ctr.spillBucketWriteBufs[bucket].Len())
+		require.Zero(t, ctr.spillBucketWriteBufs[bucket].Cap())
+		require.Zero(t, ctr.spillBucketWriteRows[bucket])
 	}
-	ctr.dropSpillScratchBuffers()
-	ctr.releaseSpillScratchReservation()
+	// The transition is idempotent and must not shrink the mandatory floor.
+	reclaimed, err = ctr.reclaimOptionalSpillCoalesce(proc, files, analyzer)
+	require.NoError(t, err)
+	require.False(t, reclaimed)
+	require.Equal(t, base, ctr.spillScratchReservation.Size())
+
+	cleanup()
 	require.Zero(t, generation.Used())
 }
 
@@ -980,14 +1031,14 @@ func TestSpillScratchLazyGrowSucceeds(t *testing.T) {
 		spillScratchBase:        need - 1,
 	}
 	ctr.hashmapBuilder.setBudget(generation)
-	_, err = ctr.initSpillExprExecs(proc, conditions)
+	err = initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
-	defer ctr.freeSpillExprExecs()
+	defer ctr.hashmapBuilder.FreeExecutors()
 	defer ctr.dropSpillScratchBuffers()
 	defer ctr.releaseSpillScratchReservation()
 
 	analyzer := process.NewAnalyzer(0, false, false, "test")
-	require.NoError(t, ctr.spillBatchBounded(proc, bat, files, ctr.spillExprExecs, analyzer, true))
+	require.NoError(t, ctr.spillBatchBounded(proc, bat, files, analyzer, true))
 	require.Equal(t, need, ctr.spillScratchBase)
 	require.GreaterOrEqual(t, scratchToken.Size(), need)
 	require.Equal(t, int64(1), analyzer.GetOpStats().ExtraStats["HashBuildSpillScratchGrowCount"])
@@ -1026,8 +1077,13 @@ func TestSpillScratchLazyGrowRejectPreservesRetainedSource(t *testing.T) {
 		spillScratchBase:        need - 1,
 	}
 	ctr.hashmapBuilder.setBudget(generation)
+	err = initSpillExprExecsForTest(ctr, proc, []*plan.Expr{{
+		Typ:  plan.Type{Id: int32(types.T_int32)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
+	}})
+	require.NoError(t, err)
 	analyzer := process.NewAnalyzer(0, false, false, "lazy spill reject")
-	err = ctr.spillBatchBounded(proc, bat, files, nil, analyzer, true)
+	err = ctr.spillBatchBounded(proc, bat, files, analyzer, true)
 	require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
 	require.Equal(t, int64(1), analyzer.GetOpStats().ExtraStats["HashBuildSpillScratchGrowRejects"])
 	require.Equal(t, need-1, scratchToken.Size())
@@ -1040,6 +1096,7 @@ func TestSpillScratchLazyGrowRejectPreservesRetainedSource(t *testing.T) {
 		require.Nil(t, file)
 	}
 
+	ctr.hashmapBuilder.FreeExecutors()
 	ctr.releaseSpillScratchReservation()
 	sourceToken.Release()
 	require.Zero(t, generation.Used())
@@ -1291,6 +1348,60 @@ func TestSpillReplacementPeakReusesHighWaterLease(t *testing.T) {
 	require.Zero(t, generation.Used())
 }
 
+func TestSpillReplacementPeakReclaimsOptionalBeforeRetry(t *testing.T) {
+	const (
+		base     = uint64(spillWriteCoalesceSize)
+		capBytes = 2 * base
+	)
+	for _, test := range []struct {
+		name        string
+		required    uint64
+		wantRejects uint64
+		wantError   bool
+	}{
+		{name: "reclaimed overlap fits", required: capBytes, wantRejects: 1},
+		{name: "mandatory overlap exceeds cap", required: capBytes + 1, wantRejects: 2, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+			generation, err := budget.OpenGeneration(1)
+			require.NoError(t, err)
+			defer generation.Close()
+			token, err := generation.Reserve(capBytes)
+			require.NoError(t, err)
+
+			ctr := container{
+				hashmapBuilder:          HashmapBuilder{budget: generation},
+				spillScratchReservation: token,
+				spillScratchBase:        base,
+			}
+			ctr.spillBucketWriteBufs[0] = *bytes.NewBuffer(
+				make([]byte, 0, spillWriteCoalesceSize))
+			analyzer := process.NewAnalyzer(0, false, false, "replacement reclaim")
+
+			oldSize, grew, err := ctr.growSpillScratchTransientWithReclaim(
+				nil, nil, test.required, analyzer)
+			if test.wantError {
+				require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
+				require.False(t, grew)
+				require.Zero(t, oldSize)
+				require.Equal(t, base, token.Size())
+			} else {
+				require.NoError(t, err)
+				require.True(t, grew)
+				require.Equal(t, base, oldSize)
+				require.Equal(t, test.required, token.Size())
+				require.NoError(t, ctr.restoreSpillScratchTransient(oldSize, grew))
+				require.Equal(t, base, token.Size())
+			}
+			require.Equal(t, test.wantRejects, generation.RejectCount())
+			require.Zero(t, ctr.spillBucketWriteBufs[0].Cap())
+			token.Release()
+			require.Zero(t, generation.Used())
+		})
+	}
+}
+
 func TestSpillPeakChargesSerializedPayloadOnce(t *testing.T) {
 	const (
 		rows          = uint64(8192)
@@ -1344,7 +1455,7 @@ func TestSpillLazyReservationBoundaryInputs(t *testing.T) {
 	ctr.hashmapBuilder.setBudget(generation)
 	analyzer := process.NewAnalyzer(0, false, false, "spill reservation boundary")
 
-	require.NoError(t, ctr.spillBatchBounded(nil, nil, nil, nil, analyzer, false))
+	require.NoError(t, ctr.spillBatchBounded(nil, nil, nil, analyzer, false))
 	require.Nil(t, ctr.spillScratchReservation)
 
 	invalid := batch.NewWithSize(1)
@@ -1352,10 +1463,41 @@ func TestSpillLazyReservationBoundaryInputs(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 	err = ctr.spillBatchBounded(
-		proc, invalid, make([]*os.File, spillNumBuckets), nil, analyzer, false)
+		proc, invalid, make([]*os.File, spillNumBuckets), analyzer, false)
 	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
 	require.Nil(t, ctr.spillScratchReservation)
 	require.Zero(t, generation.Used())
+}
+
+func TestSpillBatchRejectsMissingExpressionOwnerBeforeScratchAdmission(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	defer proc.Free()
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1}, nil, proc.Mp())
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	need, err := spillBudgetBytes(bat)
+	require.NoError(t, err)
+	budget := process.MustNewHashBuildBudget(need, need)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	defer generation.Close()
+	ctr := &container{}
+	ctr.hashmapBuilder.setBudget(generation)
+
+	err = ctr.spillBatchBounded(
+		proc,
+		bat,
+		make([]*os.File, spillNumBuckets),
+		process.NewAnalyzer(0, false, false, "missing expression owner"),
+		false,
+	)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+	require.Nil(t, ctr.spillScratchReservation)
+	require.Zero(t, generation.Used())
+	require.Zero(t, generation.ReserveCount())
+	require.Zero(t, generation.RejectCount())
 }
 
 func TestSpillMaterializedBytesFollowsConstUnionSemantics(t *testing.T) {
@@ -1956,9 +2098,14 @@ func TestSpillBatchLazyReservationFailsClosed(t *testing.T) {
 
 	ctr := &container{}
 	ctr.hashmapBuilder.setBudget(generation)
+	err = initSpillExprExecsForTest(ctr, proc, []*plan.Expr{{
+		Typ:  plan.Type{Id: int32(types.T_int32)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
+	}})
+	require.NoError(t, err)
 	files := make([]*os.File, spillNumBuckets)
 	err = ctr.spillBatchBounded(
-		proc, bat, files, nil,
+		proc, bat, files,
 		process.NewAnalyzer(0, false, false, "direct spill reject"), false)
 	require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
 	require.Nil(t, ctr.spillScratchReservation)
@@ -1968,6 +2115,7 @@ func TestSpillBatchLazyReservationFailsClosed(t *testing.T) {
 	for _, file := range files {
 		require.Nil(t, file)
 	}
+	ctr.hashmapBuilder.FreeExecutors()
 	require.Zero(t, generation.Used())
 }
 

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -1514,6 +1515,277 @@ func TestSpillMaterializedEstimateFollowsFullBatchCloneToSemantics(t *testing.T)
 	selected.SetRowCount(colexec.DefaultBatchSize)
 	require.Equal(t, colexec.DefaultBatchSize*(4<<10), len(selected.Vecs[0].GetArea()))
 	require.GreaterOrEqual(t, estimated, uint64(selected.Allocated()))
+}
+
+func TestRetainedSpillRecoveryProjectionMatrix(t *testing.T) {
+	type ingressSpec struct {
+		kind         string
+		rows         int
+		payloadBytes int
+	}
+	tests := []struct {
+		name      string
+		ingresses []ingressSpec
+	}{
+		{
+			name: "fixed-boundaries-and-full-tail-swap",
+			ingresses: []ingressSpec{
+				{kind: "fixed", rows: colexec.DefaultBatchSize - 1},
+				{kind: "fixed", rows: 1},
+				{kind: "fixed", rows: colexec.DefaultBatchSize},
+				{kind: "fixed", rows: colexec.DefaultBatchSize + 1},
+			},
+		},
+		{
+			name: "const-varlen-incremental-tail",
+			ingresses: []ingressSpec{
+				{kind: "const", rows: 1, payloadBytes: 1024},
+				{kind: "const", rows: 31, payloadBytes: 2048},
+				{kind: "const", rows: colexec.DefaultBatchSize - 32, payloadBytes: 512},
+			},
+		},
+		{
+			name: "const-varlen-exact-full-batch",
+			ingresses: []ingressSpec{
+				{kind: "const", rows: colexec.DefaultBatchSize, payloadBytes: 4096},
+			},
+		},
+		{
+			name: "shared-varlen-exact-full-batch",
+			ingresses: []ingressSpec{
+				{kind: "shared", rows: colexec.DefaultBatchSize, payloadBytes: 1024},
+			},
+		},
+		{
+			name: "nullable-varlen-multiple-destinations",
+			ingresses: []ingressSpec{
+				{kind: "nullable", rows: 2*colexec.DefaultBatchSize + 17, payloadBytes: 64},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			defer proc.Free()
+			budget := process.MustNewHashBuildBudget(4<<30, 4<<30)
+			generation, err := budget.OpenGeneration(1)
+			require.NoError(t, err)
+			defer generation.Close()
+			var hb HashmapBuilder
+			hb.setBudget(generation)
+			defer hb.cleanBatches(proc)
+
+			var recoveryHighWater uint64
+			for ingressIndex, spec := range test.ingresses {
+				source := batch.NewWithSize(1)
+				switch spec.kind {
+				case "fixed":
+					values := make([]int32, spec.rows)
+					for i := range values {
+						values[i] = int32(ingressIndex*100_000 + i)
+					}
+					source.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+				case "const":
+					payload := bytes.Repeat([]byte{'x'}, spec.payloadBytes)
+					source.Vecs[0], err = vector.NewConstBytes(
+						types.T_varchar.ToType(), payload, spec.rows, proc.Mp())
+					require.NoError(t, err)
+				case "shared":
+					// UnionBatch deliberately flattens a constant while retaining one
+					// physical payload shared by every descriptor. This is a regular
+					// non-const vector, so recovery projection must follow logical row
+					// references rather than use class as a proxy for area ownership.
+					payload := bytes.Repeat([]byte{'x'}, spec.payloadBytes)
+					constant, constErr := vector.NewConstBytes(
+						types.T_varchar.ToType(), payload, spec.rows, proc.Mp())
+					require.NoError(t, constErr)
+					source.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+					require.NoError(t, source.Vecs[0].UnionBatch(
+						constant, 0, spec.rows, nil, proc.Mp()))
+					constant.Free(proc.Mp())
+					require.False(t, source.Vecs[0].IsConst())
+					require.Equal(t, spec.payloadBytes, len(source.Vecs[0].GetArea()))
+				case "nullable":
+					values := make([]string, spec.rows)
+					nulls := make([]uint64, 0, spec.rows/5+1)
+					for i := range values {
+						values[i] = strings.Repeat(string(rune('a'+i%17)), spec.payloadBytes)
+						if i%5 == 0 {
+							nulls = append(nulls, uint64(i))
+						}
+					}
+					source.Vecs[0] = testutil.MakeVarcharVector(values, nulls, proc.Mp())
+				default:
+					t.Fatalf("unknown ingress kind %q", spec.kind)
+				}
+				source.SetRowCount(spec.rows)
+
+				projection, projectionErr := hb.projectedBatchCopy(source)
+				require.NoError(t, projectionErr)
+				projectedNeed, projectionErr := spillRetainedRecoveryBudgetBytes(projection)
+				require.NoError(t, projectionErr)
+				projectedNeed, projectionErr = spillRecoveryReservationBytes(projectedNeed)
+				require.NoError(t, projectionErr)
+				recoveryHighWater = max(recoveryHighWater, projectedNeed)
+
+				require.NoError(t, hb.copyBuildBatchProjected(source, proc, projection))
+				require.Equal(t, projection.nextTailSelected, hb.retainedSpillTailSelected)
+				source.Clean(proc.Mp())
+
+				for retainedIndex, retained := range hb.Batches.Buf {
+					actualNeed, actualErr := spillScratchBudgetBytes(retained, true)
+					require.NoError(t, actualErr)
+					require.LessOrEqualf(t, actualNeed, recoveryHighWater,
+						"ingress=%d retained=%d rows=%d", ingressIndex, retainedIndex, retained.RowCount())
+				}
+			}
+
+			if test.name == "const-varlen-exact-full-batch" {
+				wantSelected := uint64(colexec.DefaultBatchSize) *
+					(uint64(types.T_varchar.ToType().TypeSize()) + 4096)
+				actualSelected, err := spillMaterializedBytes(hb.Batches.Buf[0])
+				require.NoError(t, err)
+				require.Equal(t, wantSelected, actualSelected)
+			}
+
+			hb.cleanBatches(proc)
+			require.Zero(t, hb.retainedSpillTailSelected)
+			require.Zero(t, generation.Used())
+			require.Zero(t, proc.Mp().CurrNB())
+		})
+	}
+}
+
+func TestSpillRecoveryReservationRoundingBoundaries(t *testing.T) {
+	tests := []struct {
+		need uint64
+		want uint64
+	}{
+		{need: 0, want: 0},
+		{need: 1, want: spillRecoveryReservationQuantum},
+		{need: spillRecoveryReservationQuantum - 1, want: spillRecoveryReservationQuantum},
+		{need: spillRecoveryReservationQuantum, want: spillRecoveryReservationQuantum},
+		{need: spillRecoveryReservationQuantum + 1, want: 2 * spillRecoveryReservationQuantum},
+	}
+	for _, test := range tests {
+		got, err := spillRecoveryReservationBytes(test.need)
+		require.NoError(t, err)
+		require.Equal(t, test.want, got)
+	}
+	_, err := spillRecoveryReservationBytes(math.MaxUint64)
+	require.ErrorIs(t, err, process.ErrHashBuildBudgetInvalid)
+}
+
+func TestSpillDirectRecoveryUpperBoundsExactMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		makeBatch  func(*testing.T, *process.Process) *batch.Batch
+		hasVarlen  bool
+		exactUpper bool
+	}{
+		{
+			name: "fixed",
+			makeBatch: func(_ *testing.T, proc *process.Process) *batch.Batch {
+				bat := batch.NewWithSize(1)
+				bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3, 4}, nil, proc.Mp())
+				bat.SetRowCount(4)
+				return bat
+			},
+			exactUpper: true,
+		},
+		{
+			name: "const-varlen",
+			makeBatch: func(t *testing.T, proc *process.Process) *batch.Batch {
+				bat := batch.NewWithSize(1)
+				var err error
+				bat.Vecs[0], err = vector.NewConstBytes(
+					types.T_varchar.ToType(), bytes.Repeat([]byte{'x'}, 4096),
+					colexec.DefaultBatchSize, proc.Mp())
+				require.NoError(t, err)
+				bat.SetRowCount(colexec.DefaultBatchSize)
+				return bat
+			},
+			hasVarlen:  true,
+			exactUpper: true,
+		},
+		{
+			name: "shared-varlen",
+			makeBatch: func(t *testing.T, proc *process.Process) *batch.Batch {
+				constant, err := vector.NewConstBytes(
+					types.T_varchar.ToType(), bytes.Repeat([]byte{'x'}, 4096),
+					colexec.DefaultBatchSize, proc.Mp())
+				require.NoError(t, err)
+				defer constant.Free(proc.Mp())
+				bat := batch.NewWithSize(1)
+				bat.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+				require.NoError(t, bat.Vecs[0].UnionBatch(
+					constant, 0, colexec.DefaultBatchSize, nil, proc.Mp()))
+				require.False(t, bat.Vecs[0].IsConst())
+				require.Equal(t, 4096, len(bat.Vecs[0].GetArea()))
+				bat.SetRowCount(colexec.DefaultBatchSize)
+				return bat
+			},
+			hasVarlen:  true,
+			exactUpper: true,
+		},
+		{
+			name: "nullable-varlen",
+			makeBatch: func(_ *testing.T, proc *process.Process) *batch.Batch {
+				const rows = 1024
+				values := make([]string, rows)
+				nulls := make([]uint64, 0, rows/2)
+				for i := range values {
+					values[i] = strings.Repeat("x", 128)
+					if i%2 == 0 {
+						nulls = append(nulls, uint64(i))
+					}
+				}
+				bat := batch.NewWithSize(1)
+				bat.Vecs[0] = testutil.MakeVarcharVector(values, nulls, proc.Mp())
+				bat.SetRowCount(rows)
+				return bat
+			},
+			hasVarlen: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			defer proc.Free()
+			bat := test.makeBatch(t, proc)
+			defer bat.Clean(proc.Mp())
+
+			upper, hasVarlen, err := spillDirectRecoveryBudgetUpper(bat)
+			require.NoError(t, err)
+			exact, err := spillBudgetBytes(bat)
+			require.NoError(t, err)
+			require.Equal(t, test.hasVarlen, hasVarlen)
+			require.GreaterOrEqual(t, upper, exact)
+			if test.exactUpper {
+				require.Equal(t, exact, upper)
+			}
+
+			capBytes, err := spillRecoveryReservationBytes(exact)
+			require.NoError(t, err)
+			budget := process.MustNewHashBuildBudget(capBytes, capBytes)
+			generation, err := budget.OpenGeneration(1)
+			require.NoError(t, err)
+			defer generation.Close()
+			ctr := &container{}
+			ctr.hashmapBuilder.setBudget(generation)
+			analyzer := process.NewAnalyzer(0, false, false, "direct recovery upper")
+			require.NoError(t, ctr.ensureDirectSpillRecovery(bat, analyzer))
+			reserved := ctr.spillScratchBase
+			reserveCount := generation.ReserveCount()
+			require.NoError(t, ctr.ensureDirectSpillRecovery(bat, analyzer))
+			require.Equal(t, reserved, ctr.spillScratchBase)
+			require.Equal(t, reserveCount, generation.ReserveCount())
+			ctr.releaseSpillScratchReservation()
+			require.Zero(t, generation.Used())
+		})
+	}
 }
 
 func TestSpillBatchLazyReservationFailsClosed(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -83,9 +83,11 @@ type container struct {
 	spillBucketWriteBufs [spillNumBuckets]bytes.Buffer
 	spillBucketWriteRows [spillNumBuckets]int64
 	spillKeyVecs         []*vector.Vector
-	// spillScratchReservation is a query/CN-charged lease retained while spill
-	// buffers are reusable. It is established lazily before the first scratch
-	// allocation and released with the execution generation.
+	// spillScratchReservation is the query/CN-charged recovery lease for this
+	// execution. Shuffle HashBuild establishes it before retaining spillable
+	// data; spill then reuses the same lease for its bounded scratch buffers.
+	// Direct spill callers may still establish it lazily. Reset, Free, and the
+	// build terminal cleanup all release it idempotently.
 	spillScratchReservation *process.HashBuildReservation
 	// spillScratchBase is the retained scratch floor. Coalesce-buffer growth is
 	// charged on top and must never be mistaken for this floor.
@@ -399,6 +401,9 @@ func hasHashBuildDiagnosticStats(extra map[string]int64) bool {
 		extra["HashBuildRuntimeFilterCollectionFallbacks"] != 0 ||
 		extra["HashBuildRuntimeFilterBudgetFallbacks"] != 0 ||
 		extra["HashBuildRuntimeFilterAllocationFallbacks"] != 0 ||
+		extra["HashBuildSpillRecoveryReserveRejects"] != 0 ||
+		extra["HashBuildSpillRecoveryGrowRejects"] != 0 ||
+		extra["HashBuildSpillRecoveryGrowCount"] != 0 ||
 		extra["HashBuildSpillScratchReserveRejects"] != 0 ||
 		extra["HashBuildSpillScratchGrowRejects"] != 0 ||
 		extra["HashBuildSpillScratchGrowCount"] != 0
@@ -471,6 +476,7 @@ func (hb *HashmapBuilder) CleanCopiedBatchAt(idx int, proc *process.Process) err
 	// reservation cannot be matched safely to Batches.Buf[idx]. Keep the
 	// conservative charges until the last physical batch has been dropped.
 	if len(hb.Batches.Buf) == 0 {
+		hb.retainedSpillTailSelected = 0
 		hb.releaseBatchReservations()
 	}
 	return nil
@@ -509,6 +515,7 @@ func (hb *HashmapBuilder) DrainCopiedBatches(
 	}
 	hb.Batches.Buf = nil
 	hb.Batches.MemSize = 0
+	hb.retainedSpillTailSelected = 0
 	hb.releaseBatchReservations()
 	return nil
 }

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -92,10 +92,6 @@ type container struct {
 	// spillScratchBase is the retained scratch floor. Coalesce-buffer growth is
 	// charged on top and must never be mistaken for this floor.
 	spillScratchBase uint64
-
-	// cached expression executors for spill (reused across batches)
-	spillExprExecs []colexec.ExpressionExecutor
-	spillExprLease *ExpressionMemoryLease
 }
 
 // spillFileBundle is deliberately owned by hashbuild.  Build converts each
@@ -367,7 +363,6 @@ func (hashBuild *HashBuild) Free(proc *process.Process, pipelineFailed bool, err
 	hashBuild.cleanupSpillFiles(proc)
 	hashBuild.ctr.spillFS = nil
 	hashBuild.ctr.hashmapBuilder.Free(proc)
-	hashBuild.ctr.freeSpillExprExecs()
 	hashBuild.ctr.dropSpillScratchBuffers()
 	hashBuild.ctr.releaseSpillScratchReservation()
 }

--- a/pkg/sql/plan/function/func_builtin_onnx_test.go
+++ b/pkg/sql/plan/function/func_builtin_onnx_test.go
@@ -295,10 +295,11 @@ func TestOnnxRunRegistration(t *testing.T) {
 		require.Equal(t, types.T_json,
 			ov.retType([]types.Type{types.T_varbinary.ToType()}).Oid)
 
-		evalFn, resetFn, freeFn := ov.GetExecuteMethod()
+		evalFn, resetFn, freeFn, retainedBytesFn := ov.GetExecuteMethod()
 		require.NotNil(t, evalFn)
 		require.NotNil(t, resetFn)
 		require.NotNil(t, freeFn)
+		require.Nil(t, retainedBytesFn)
 
 		// Drive one evaluation through the registered closure (the model is
 		// varbinary bytes; the datalink overload accepts them too via the

--- a/pkg/sql/plan/function/func_builtin_serial.go
+++ b/pkg/sql/plan/function/func_builtin_serial.go
@@ -39,3 +39,10 @@ func (op *opSerial) Reset() error {
 	op.packer.Reset()
 	return nil
 }
+
+func (op *opSerial) RetainedBytes() uint64 {
+	if op == nil {
+		return 0
+	}
+	return op.packer.Allocated()
+}

--- a/pkg/sql/plan/function/function.go
+++ b/pkg/sql/plan/function/function.go
@@ -245,7 +245,7 @@ func RunFunctionDirectly(proc *process.Process, overloadID int64, inputs []*vect
 		result.Free()
 		return nil, err
 	}
-	exec, _, execFree := f.GetExecuteMethod()
+	exec, _, execFree, _ := f.GetExecuteMethod()
 	if err = exec(inputs, result, proc, evaluateLength, nil); err != nil {
 		result.Free()
 		if execFree != nil {
@@ -459,6 +459,11 @@ type executeFreeOfOverload func() error
 // in case we need it in the future.
 type executeResetOfOverload func() error
 
+// executeRetainedBytesOfOverload reports non-vector backing allocations kept
+// alive by a stateful function operator. It is optional: ordinary functions
+// whose complete retained state is represented by executor vectors omit it.
+type executeRetainedBytesOfOverload func() uint64
+
 // an overload of a function.
 // stores all information about execution logic.
 type overload struct {
@@ -482,7 +487,12 @@ type overload struct {
 
 	// the execution logic and free logic.
 	// NOTE: use either newOp or newOpWithFree.
-	newOpWithFree func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload)
+	newOpWithFree func() (
+		executeLogicOfOverload,
+		executeResetOfOverload,
+		executeFreeOfOverload,
+		executeRetainedBytesOfOverload,
+	)
 
 	// in fact, the function framework does not directly run aggregate functions and window functions.
 	// we use two flags to mark whether function is one of them.
@@ -521,14 +531,18 @@ func (ov *overload) CannotExecuteInParallel() bool {
 	return ov.cannotParallel
 }
 
-func (ov *overload) GetExecuteMethod() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload) {
+func (ov *overload) GetExecuteMethod() (
+	executeLogicOfOverload,
+	executeResetOfOverload,
+	executeFreeOfOverload,
+	executeRetainedBytesOfOverload,
+) {
 	if ov.newOpWithFree != nil {
-		fn, fnReset, fnFree := ov.newOpWithFree()
-		return fn, fnReset, fnFree
+		return ov.newOpWithFree()
 	}
 
 	fn := ov.newOp()
-	return fn, nil, nil
+	return fn, nil, nil, nil
 }
 
 func (ov *overload) GetReturnTypeMethod() func(parameters []types.Type) types.Type {

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -1991,9 +1991,9 @@ var supportedStringBuiltIns = []FuncNew{
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_json.ToType()
 				},
-				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload) {
+				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload, executeRetainedBytesOfOverload) {
 					op := newOpOnnxRun()
-					return op.onnxRun, op.Reset, op.Close
+					return op.onnxRun, op.Reset, op.Close, nil
 				},
 			},
 			{
@@ -2004,9 +2004,9 @@ var supportedStringBuiltIns = []FuncNew{
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_json.ToType()
 				},
-				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload) {
+				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload, executeRetainedBytesOfOverload) {
 					op := newOpOnnxRun()
-					return op.onnxRun, op.Reset, op.Close
+					return op.onnxRun, op.Reset, op.Close, nil
 				},
 			},
 		},
@@ -2948,9 +2948,9 @@ var supportedStringBuiltIns = []FuncNew{
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_varchar.ToType()
 				},
-				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload) {
+				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload, executeRetainedBytesOfOverload) {
 					opSerial := newOpSerial()
-					return opSerial.BuiltInSerial, opSerial.Reset, opSerial.Close
+					return opSerial.BuiltInSerial, opSerial.Reset, opSerial.Close, opSerial.RetainedBytes
 				},
 			},
 		},
@@ -2974,9 +2974,9 @@ var supportedStringBuiltIns = []FuncNew{
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_varchar.ToType()
 				},
-				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload) {
+				newOpWithFree: func() (executeLogicOfOverload, executeResetOfOverload, executeFreeOfOverload, executeRetainedBytesOfOverload) {
 					opSerial := newOpSerial()
-					return opSerial.BuiltInSerialFull, opSerial.Reset, opSerial.Close
+					return opSerial.BuiltInSerialFull, opSerial.Reset, opSerial.Close, opSerial.RetainedBytes
 				},
 			},
 		},

--- a/pkg/sql/plan/function/serial_contract.go
+++ b/pkg/sql/plan/function/serial_contract.go
@@ -16,11 +16,106 @@ package function
 
 import (
 	"bytes"
+	"math"
+	"unicode/utf8"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 )
+
+// SerialEncodedTypeSizeBound returns the maximum number of bytes which the
+// production component encoder can append for one non-NULL value of typ.
+// Unlike a function's generic VARCHAR return width, this contract follows the
+// concrete tuple encoding and the input type's declared payload bound.
+//
+// The bool is false only when the production encoder does not support typ.
+// Callers must retain their representation-independent fallback in that case.
+func SerialEncodedTypeSizeBound(typ types.Type) (uint64, bool) {
+	if fixed, ok := serialFixedEncodedTypeSizeBound(typ.Oid); ok {
+		return fixed, true
+	}
+
+	payload, ok := serialTypePayloadSizeBound(typ)
+	if !ok || payload > (math.MaxUint64-3)/2 {
+		return 0, false
+	}
+	// string-type code + bytes code + terminator; every payload byte can be
+	// zero and therefore require one escape byte.
+	return 2*payload + 3, true
+}
+
+func serialFixedEncodedTypeSizeBound(oid types.T) (uint64, bool) {
+	// Integer-like values use one type byte, one ordered-length byte, and the
+	// maximum bytes of their concrete storage width. The remaining encodings
+	// are fixed-width in Packer.
+	switch oid {
+	case types.T_bool:
+		return 1, true
+	case types.T_int8, types.T_uint8:
+		return 3, true
+	case types.T_int16, types.T_uint16, types.T_year:
+		return 4, true
+	case types.T_int32, types.T_uint32, types.T_date:
+		return 6, true
+	case types.T_bit, types.T_int64, types.T_uint64,
+		types.T_time, types.T_datetime, types.T_timestamp:
+		return 10, true
+	case types.T_float32:
+		return 5, true
+	case types.T_float64:
+		return 9, true
+	case types.T_enum:
+		// Enum code followed by an encoded uint16 (type + length + data).
+		return 5, true
+	case types.T_decimal64:
+		return 9, true
+	case types.T_decimal128:
+		return 17, true
+	case types.T_uuid:
+		return 17, true
+	default:
+		return 0, false
+	}
+}
+
+func serialTypePayloadSizeBound(typ types.Type) (uint64, bool) {
+	declared := int64(typ.Width)
+	declaredOr := func(fallback int64) uint64 {
+		if declared <= 0 {
+			declared = fallback
+		}
+		return uint64(declared)
+	}
+	switch typ.Oid {
+	case types.T_char:
+		return declaredOr(types.MaxCharLen) * utf8.UTFMax, true
+	case types.T_varchar:
+		// CHAR/VARCHAR widths are characters, while the packer consumes stored
+		// UTF-8 bytes. One valid character can therefore occupy UTFMax bytes.
+		return declaredOr(types.MaxVarcharLen) * utf8.UTFMax, true
+	case types.T_binary:
+		return declaredOr(types.MaxBinaryLen), true
+	case types.T_varbinary:
+		return declaredOr(types.MaxVarBinaryLen), true
+	case types.T_array_float32, types.T_array_float64,
+		types.T_array_bf16, types.T_array_float16,
+		types.T_array_int8, types.T_array_uint8:
+		dimension := declared
+		if dimension <= 0 {
+			dimension = types.MaxArrayDimension
+		}
+		return uint64(dimension) * uint64(typ.GetArrayElementSize()), true
+	case types.T_json, types.T_blob, types.T_text, types.T_geometry, types.T_datalink:
+		bound := int64(types.MaxBlobLen)
+		if declared > bound {
+			bound = declared
+		}
+		return uint64(bound), true
+	default:
+		return 0, false
+	}
+}
 
 // SerialValueEncoder is the exact component encoder used by serial and
 // serial_full. Runtime-filter tuple materialization obtains these encoders once
@@ -77,30 +172,10 @@ func SerialEncodedValueSizeBound(
 		return 0, moerr.NewInternalErrorNoCtx(
 			"invalid serial runtime-filter component")
 	}
+	if fixed, ok := serialFixedEncodedTypeSizeBound(v.GetType().Oid); ok {
+		return fixed, nil
+	}
 	switch v.GetType().Oid {
-	case types.T_bool:
-		return 1, nil
-	case types.T_bit,
-		types.T_int8, types.T_int16, types.T_int32, types.T_int64,
-		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
-		types.T_date, types.T_time, types.T_datetime, types.T_timestamp,
-		types.T_year:
-		// One type byte, one integer-length byte, and at most eight data
-		// bytes. Narrow integers simply use less than this bound.
-		return 10, nil
-	case types.T_float32:
-		return 5, nil
-	case types.T_float64:
-		return 9, nil
-	case types.T_enum:
-		// Enum code + encoded uint16 type/value.
-		return 11, nil
-	case types.T_decimal64:
-		return 9, nil
-	case types.T_decimal128:
-		return 17, nil
-	case types.T_uuid:
-		return 17, nil
 	case types.T_json, types.T_char, types.T_varchar,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text,
 		types.T_geometry,

--- a/pkg/sql/plan/function/serial_contract_test.go
+++ b/pkg/sql/plan/function/serial_contract_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerialEncodedTypeSizeBound(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		typ       types.Type
+		want      uint64
+		supported bool
+	}{
+		{name: "bool", typ: types.T_bool.ToType(), want: 1, supported: true},
+		{name: "int8", typ: types.T_int8.ToType(), want: 3, supported: true},
+		{name: "uint8", typ: types.T_uint8.ToType(), want: 3, supported: true},
+		{name: "int16", typ: types.T_int16.ToType(), want: 4, supported: true},
+		{name: "uint16", typ: types.T_uint16.ToType(), want: 4, supported: true},
+		{name: "int32", typ: types.T_int32.ToType(), want: 6, supported: true},
+		{name: "uint32", typ: types.T_uint32.ToType(), want: 6, supported: true},
+		{name: "int64", typ: types.T_int64.ToType(), want: 10, supported: true},
+		{name: "uint64", typ: types.T_uint64.ToType(), want: 10, supported: true},
+		{name: "bit", typ: types.T_bit.ToType(), want: 10, supported: true},
+		{name: "float32", typ: types.T_float32.ToType(), want: 5, supported: true},
+		{name: "float64", typ: types.T_float64.ToType(), want: 9, supported: true},
+		{name: "date", typ: types.T_date.ToType(), want: 6, supported: true},
+		{name: "time", typ: types.T_time.ToType(), want: 10, supported: true},
+		{name: "datetime", typ: types.T_datetime.ToType(), want: 10, supported: true},
+		{name: "timestamp", typ: types.T_timestamp.ToType(), want: 10, supported: true},
+		{name: "year", typ: types.T_year.ToType(), want: 4, supported: true},
+		{name: "enum", typ: types.T_enum.ToType(), want: 5, supported: true},
+		{name: "decimal64", typ: types.T_decimal64.ToType(), want: 9, supported: true},
+		{name: "decimal128", typ: types.T_decimal128.ToType(), want: 17, supported: true},
+		{name: "uuid", typ: types.T_uuid.ToType(), want: 17, supported: true},
+		{
+			name:      "declared varchar",
+			typ:       types.New(types.T_varchar, 128, 0),
+			want:      2*(128*utf8.UTFMax) + 3,
+			supported: true,
+		},
+		{
+			name:      "unspecified varchar",
+			typ:       types.New(types.T_varchar, 0, 0),
+			want:      2*(types.MaxVarcharLen*utf8.UTFMax) + 3,
+			supported: true,
+		},
+		{
+			name:      "array bytes not descriptors",
+			typ:       types.New(types.T_array_float64, 16, 0),
+			want:      2*(16*8) + 3,
+			supported: true,
+		},
+		{
+			name:      "blob hard bound",
+			typ:       types.T_blob.ToType(),
+			want:      2*types.MaxBlobLen + 3,
+			supported: true,
+		},
+		{name: "unsupported", typ: types.T_decimal256.ToType()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := SerialEncodedTypeSizeBound(tc.typ)
+			require.Equal(t, tc.supported, ok)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSerialEncodedTypeSizeBoundCoversRuntimeValue(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	for _, tc := range []struct {
+		name string
+		vec  *vector.Vector
+	}{
+		{
+			name: "maximum int32 encoding",
+			vec: func() *vector.Vector {
+				vec := vector.NewVec(types.T_int32.ToType())
+				require.NoError(t, vector.AppendFixed(vec, int32(math.MinInt32), false, mp))
+				return vec
+			}(),
+		},
+		{
+			name: "all bytes escaped",
+			vec: func() *vector.Vector {
+				vec := vector.NewVec(types.New(types.T_varchar, 128, 0))
+				require.NoError(t, vector.AppendBytes(vec, make([]byte, 128), false, mp))
+				return vec
+			}(),
+		},
+		{
+			name: "declared width counts multibyte characters",
+			vec: func() *vector.Vector {
+				vec := vector.NewVec(types.New(types.T_varchar, 128, 0))
+				require.NoError(t, vector.AppendBytes(
+					vec, []byte(strings.Repeat("𐍈", 128)), false, mp))
+				return vec
+			}(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer tc.vec.Free(mp)
+			static, ok := SerialEncodedTypeSizeBound(*tc.vec.GetType())
+			require.True(t, ok)
+			runtimeBound, err := SerialEncodedValueSizeBound(tc.vec, 0)
+			require.NoError(t, err)
+
+			encoder, err := NewSerialValueEncoder(tc.vec)
+			require.NoError(t, err)
+			packer := types.NewPacker()
+			defer packer.Close()
+			encoder(tc.vec, 0, packer)
+			actual := uint64(len(packer.GetBuf()))
+
+			require.LessOrEqual(t, actual, runtimeBound,
+				"the runtime bound must cover the production encoder")
+			require.LessOrEqual(t, runtimeBound, static,
+				"the type contract must cover every admitted runtime value")
+		})
+	}
+}

--- a/pkg/tests/issues/hashbuild_recovery_test.go
+++ b/pkg/tests/issues/hashbuild_recovery_test.go
@@ -37,9 +37,10 @@ const (
 )
 
 // TestHashBuildSharedBudgetRecoverySQL is the SQL-protocol counterexample for
-// late spill admission. join_spill_mem remains disabled: a finite query budget
-// must force a parallel shuffle HashBuild to transition from retained data to
-// spill without losing rows or surfacing a terminal memory error.
+// late spill admission. join_spill_mem remains at its automatic threshold: a
+// lower finite query budget must force a parallel shuffle HashBuild to
+// transition from retained data to spill without losing rows or surfacing a
+// terminal memory error.
 //
 // The physical input is intentionally narrow and bounded. Patched statistics
 // select the same shuffle topology as a large analytical join, while the CN's
@@ -88,7 +89,8 @@ func TestHashBuildSharedBudgetRecoverySQL(t *testing.T) {
 	execJoinSpillSQL(t, ctx, conn, "use `"+dbName+"`")
 	execJoinSpillSQL(t, ctx, conn, "set @@max_dop = 8")
 	defer resetOptimizerHintsOnCN(t, port)
-	execJoinSpillSQL(t, ctx, conn, `set session optimizer_hints = "forceOneCN=1"`)
+	execJoinSpillSQL(t, ctx, conn,
+		`set session optimizer_hints = "forceOneCN=1,joinOrdering=1"`)
 	execJoinSpillSQL(t, ctx, conn, "set @@join_spill_mem = 0")
 
 	execJoinSpillSQL(t, ctx, conn,
@@ -104,9 +106,18 @@ func TestHashBuildSharedBudgetRecoverySQL(t *testing.T) {
 	patchJoinSpillStats(t, ctx, conn, dbName, "recovery_probe", 20_000_000)
 	patchJoinSpillStats(t, ctx, conn, dbName, "recovery_build", 10_000_000)
 	query := `select count(*)
-		from recovery_probe p join recovery_build b on p.k = b.k`
+		from recovery_probe p join recovery_build b
+			on serial_full(p.k, p.payload) = serial_full(b.k, b.payload)`
 	plan := queryJoinSpillText(t, ctx, conn, "explain "+query)
-	require.Contains(t, plan, "shuffle: range(")
+	require.Contains(t, plan, "shuffle: hash(")
+	require.Contains(t, plan, "serial_full(",
+		"the public regression must exercise the expression-key recovery path")
+	probeScan := strings.Index(plan, ".recovery_probe")
+	buildScan := strings.Index(plan, ".recovery_build")
+	require.NotEqualf(t, -1, probeScan, "probe scan missing from plan:\n%s", plan)
+	require.NotEqualf(t, -1, buildScan, "build scan missing from plan:\n%s", plan)
+	require.Lessf(t, probeScan, buildScan,
+		"the million-row table must remain the right/hash-build input:\n%s", plan)
 
 	spillBefore := promtestutil.ToFloat64(
 		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"))
@@ -115,7 +126,7 @@ func TestHashBuildSharedBudgetRecoverySQL(t *testing.T) {
 	require.Equal(t, int64(4096), count)
 	require.Greater(t, promtestutil.ToFloat64(
 		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1")), spillBefore,
-		"the zero-threshold query must spill because of the shared hard budget")
+		"the automatic-threshold query must spill because of the shared hard budget")
 
 	// A terminal recovery bug often leaves the service reachable but the query
 	// dependency graph poisoned. Verify both the result and a fresh statement.

--- a/pkg/tests/issues/hashbuild_recovery_test.go
+++ b/pkg/tests/issues/hashbuild_recovery_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
+	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	hashBuildRecoveryQueryCap = int64(28 << 20)
+	hashBuildRecoveryRows     = 1_000_000
+)
+
+// TestHashBuildSharedBudgetRecoverySQL is the SQL-protocol counterexample for
+// late spill admission. join_spill_mem remains disabled: a finite query budget
+// must force a parallel shuffle HashBuild to transition from retained data to
+// spill without losing rows or surfacing a terminal memory error.
+//
+// The physical input is intentionally narrow and bounded. Patched statistics
+// select the same shuffle topology as a large analytical join, while the CN's
+// query limit creates the relevant shared-budget pressure without TPCH-sized
+// fixture data.
+func TestHashBuildSharedBudgetRecoverySQL(t *testing.T) {
+	cluster, err := embed.StartTestCluster(
+		embed.WithCNCount(1),
+		embed.WithPreStart(func(service embed.ServiceOperator) {
+			if service.ServiceType() != metadata.ServiceType_CN {
+				return
+			}
+			service.Adjust(func(config *embed.ServiceConfig) {
+				config.CN.Frontend.ProcessLimitationSize = hashBuildRecoveryQueryCap
+				config.CN.Frontend.ProcessLimitationSpillSize = 1 << 30
+			})
+		}),
+	)
+	if cluster != nil {
+		t.Cleanup(func() { require.NoError(t, cluster.Close()) })
+	}
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	cn, err := cluster.GetCNService(0)
+	require.NoError(t, err)
+	port := cn.GetServiceConfig().CN.Frontend.Port
+	db, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
+	require.NoError(t, err)
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	dbName := strings.ToLower(testutils.GetDatabaseName(t))
+	execJoinSpillSQL(t, ctx, conn, "set role moadmin")
+	execJoinSpillSQL(t, ctx, conn, "drop database if exists `"+dbName+"`")
+	execJoinSpillSQL(t, ctx, conn, "create database `"+dbName+"`")
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_, _ = conn.ExecContext(cleanupCtx, "drop database if exists `"+dbName+"`")
+	}()
+	execJoinSpillSQL(t, ctx, conn, "use `"+dbName+"`")
+	execJoinSpillSQL(t, ctx, conn, "set @@max_dop = 8")
+	defer resetOptimizerHintsOnCN(t, port)
+	execJoinSpillSQL(t, ctx, conn, `set session optimizer_hints = "forceOneCN=1"`)
+	execJoinSpillSQL(t, ctx, conn, "set @@join_spill_mem = 0")
+
+	execJoinSpillSQL(t, ctx, conn,
+		"create table recovery_probe (k bigint not null, payload bigint not null) cluster by k")
+	execJoinSpillSQL(t, ctx, conn,
+		"create table recovery_build (k bigint not null, payload bigint not null, payload2 bigint not null) cluster by k")
+	execJoinSpillSQL(t, ctx, conn,
+		"insert into recovery_probe select result, result from generate_series(1, 4096) g")
+	execJoinSpillSQL(t, ctx, conn, fmt.Sprintf(
+		"insert into recovery_build select result, result, -result from generate_series(1, %d) g",
+		hashBuildRecoveryRows))
+
+	patchJoinSpillStats(t, ctx, conn, dbName, "recovery_probe", 20_000_000)
+	patchJoinSpillStats(t, ctx, conn, dbName, "recovery_build", 10_000_000)
+	query := `select count(*)
+		from recovery_probe p join recovery_build b on p.k = b.k`
+	plan := queryJoinSpillText(t, ctx, conn, "explain "+query)
+	require.Contains(t, plan, "shuffle: range(")
+
+	spillBefore := promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"))
+	var count int64
+	require.NoError(t, conn.QueryRowContext(ctx, query).Scan(&count))
+	require.Equal(t, int64(4096), count)
+	require.Greater(t, promtestutil.ToFloat64(
+		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1")), spillBefore,
+		"the zero-threshold query must spill because of the shared hard budget")
+
+	// A terminal recovery bug often leaves the service reachable but the query
+	// dependency graph poisoned. Verify both the result and a fresh statement.
+	var healthy int
+	require.NoError(t, conn.QueryRowContext(ctx, "select 1").Scan(&healthy))
+	require.Equal(t, 1, healthy)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26586.

Related architecture issue: #26459.

## What this PR does / why we need it:

### Root cause

Shuffle HashBuild workers share one finite query/CN budget. A worker could retain build batches until the shared budget was nearly exhausted, then discover that it did not own every resource needed to drain them:

- partition/materialization scratch and allocation-replacement overlap;
- shuffle-key expression executor evaluation, including varlen and flow-control replacement peaks;
- spill write buffers while optional coalescing cache was still charged.

A sibling worker could consume the missing headroom after retention. Recovery then failed before the first retained batch was released. This is a recovery-ownership defect, not a TPCH-Q9-specific threshold problem.

### Recovery invariant and fix

Before shuffle HashBuild retains a spillable destination, the same execution generation now owns a complete recovery proof:

1. The existing copy projection proves the largest retained destination and its logical later spill materialization.
2. The one stable build-key executor set owns an `ExpressionMemoryLease` that pre-admits the complete sequential expression recovery high-water. Spill reuses that executor/lease; the former second spill executor/lease owner is removed.
3. One rounded spill recovery lease covers mandatory partition/marshal scratch. Replacement allocation admits old+new overlap before mutation.
4. Mandatory recovery has priority over optional 64 KiB write coalescing. On admission failure, pending optional buffers are flushed/dropped and mandatory admission is retried exactly once. A genuine over-cap request still fails closed.

Retained batches are drained oldest-first and released immediately after each successful spill. Reset, Free, cancellation, expression failure, spill I/O failure, and publication handoff each preserve exactly one cleanup owner.

### Scope and performance

- No global coordinator, new framework, configuration, goroutine, channel, or probabilistic retry.
- Spill partitioning uses one row-id array and one reusable selected batch instead of fanout-sized vector sets.
- Resident HashBuild adds no per-row/per-batch synchronization or I/O. The recovery token cost is O(1) per execution.
- Merge-base to final `VARCHAR_AREA_128` A/B benchmark: 5.436 ms/op to 5.359 ms/op, p=0.684; no significant regression. Allocation delta is bounded at about 40 B and 2 allocations per execution.

### Validation on latest main

Rebased onto `4a747e4458`.

- `mo-cgo-test -count=1 ./pkg/sql/colexec/hashbuild`
- `mo-cgo-test -race -count=1 ./pkg/sql/colexec/hashbuild`
- Every current added/modified HashBuild behavioral test was measured and run separately under race; all 50 reached `-count=100`, including the deterministic expression-key/shared-pressure reproducer.
- Dependent packages passed: `hashjoin`, `dedupjoin`, `rightdedupjoin`, `spillutil`, and `pkg/sql/compile`.
- `go build` for HashBuild and `go vet` for HashBuild plus the issue regression passed.
- SQL black-box regression passed in 12.74s: one CN, max_dop=8, 28 MiB cap, forced shuffle, real spill, exact result 4096, and a fresh post-query statement.
- Post-rebase resident benchmark smoke: computed INT64 1.568 ms/op; area-backed VARCHAR 5.388 ms/op.

### Review-comment closure

The P1 expression-key counterexample at old head `9b5a8125` is accepted. `TestShuffleHashBuildExpressionRecoverySurvivesSharedBudgetPressure` uses a real computed `%` shuffle key, retains the first batch, fills the same generation exactly with sibling pressure, then proves retained drain plus direct spill succeeds and all budget ownership returns to zero.

### Non-goals

- Does not raise the query cap, special-case Q9, weaken assertions, or suppress a genuine memory error.
- Does not add broadcast HashBuild spill; the existing single-consumer ownership boundary remains fail-fast.
- Does not implement the wider allocation-accounted architecture tracked by #26459.