### PR TITLE
test(lockservice): retry indeterminate txn timeout checks

### DIFF
--- a/pkg/lockservice/orphan_txn_test.go
+++ b/pkg/lockservice/orphan_txn_test.go
@@ -1005,7 +1005,7 @@ func TestValidTxnCheckErrorThenConfirmedInactive(t *testing.T) {
 		},
 		func(pb.WaitTxn) (bool, error) {
 			if checks.Add(1) == 1 {
-				return false, moerr.NewBackendClosedNoCtx()
+				return false, morpc.ErrBackendCreateTimeout
 			}
 			return false, nil
 		},

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2497,8 +2497,14 @@ func TestCheckTxnTimeout(t *testing.T) {
 				}
 			}
 
-			l2.checkTxnTimeout(ctx)
-			require.True(t, l2.activeTxnHolder.empty())
+			// A recovery RPC timeout is deliberately indeterminate: the current
+			// scan must retain the transaction and a later scan retries it. Assert
+			// the scanner's eventual contract instead of requiring a cold recovery
+			// connection to be created within one 500ms attempt.
+			require.Eventually(t, func() bool {
+				l2.checkTxnTimeout(ctx)
+				return l2.activeTxnHolder.empty()
+			}, time.Second*10, time.Millisecond*10)
 		},
 		nil,
 	)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26575

## What this PR does / why we need it:

### Root cause

Lockservice active-transaction recovery intentionally uses a separate MORPC
client with a 500ms backend-create budget. The failing CI log shows that cold
connection timing out after 500.241548ms. Production correctly treats that
observation as indeterminate: it retains the transaction and retries during a
later timeout scan. `TestCheckTxnTimeout` instead required the transaction to be
removed by one scan, so scheduler delay in a valid recovery path failed the
test.

At the failing commit, that assertion also exited the topology callback before
the service and allocator cleanup statements. Their RPC goroutines remained
active and caused the later `TestIssue5176` and
`TestUnlockInRollingRestartCN` leak reports; the latter test's log contains the
previous test's service ID. Main has since merged #26555, which installs the
topology cleanup before the callback and closes it from a defer. This PR does
not duplicate that already-merged cleanup fix.

### Changes

- Make `TestCheckTxnTimeout` assert the production contract: an indeterminate
  scan may retain the transaction, but subsequent scans must eventually remove
  it after authoritative inactive and cannot-commit fence results.
- Exercise the exact observed `morpc.ErrBackendCreateTimeout` in the existing
  deterministic error-then-confirmed-inactive unit test.

The 500ms recovery policy remains unchanged. There are no production-code,
API, wire-format, or performance changes.

### Verification

Environment: Go 1.26.4, Darwin/arm64, controlled MatrixOne CGo test wrapper.

- Original three tests in order, non-race, `-count=10`: pass
- `TestValidTxnCheckErrorThenConfirmedInactive`, non-race, `-count=100`: pass
- Adaptive focused race stress (30s budget per test):
  - `TestCheckTxnTimeout`: T=1.16s, N=25
  - `TestValidTxnCheckErrorThenConfirmedInactive`: T=0s, N=100
  - `TestIssue5176`: T=0.09s, N=100
  - `TestUnlockInRollingRestartCN`: T=2.08s, N=14
- Full `./pkg/lockservice`, non-race: pass (113.574s)
- Full `./pkg/lockservice`, race: pass (121.847s)
- `go list`, `go build`, and `go vet` for `./pkg/lockservice`: pass

BVT is not applicable because the affected contract is an internal Go recovery
scanner and test-topology lifecycle, with no SQL-visible behavior.

### Residual risk

The test retains its existing 10s outer bound and still fails if recovery never
obtains an authoritative result. It only permits the transient first-scan
timeout that production explicitly handles by retrying.
