### PR TITLE
fix(data branch): apply changes after column renames

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -1150,10 +1150,7 @@ func getTableStuff(
 	dstTable tree.TableName,
 ) (tblStuff tableStuff, err error) {
 
-	var (
-		tarTblDef  *plan.TableDef
-		baseTblDef *plan.TableDef
-	)
+	var tarTblDef *plan.TableDef
 
 	if tblStuff.tarRel, tblStuff.baseRel, tblStuff.tarSnap, tblStuff.baseSnap, err = getRelations(
 		ctx, ses, bh, srcTable, dstTable,
@@ -1162,10 +1159,6 @@ func getTableStuff(
 	}
 
 	tarTblDef = tblStuff.tarRel.GetTableDef(ctx)
-	baseTblDef = tblStuff.baseRel.GetTableDef(ctx)
-	if err = checkDataBranchPrimaryKeyCompatibility(tarTblDef, baseTblDef); err != nil {
-		return
-	}
 
 	for _, col := range tarTblDef.Cols {
 		if col.Name == catalog.Row_ID {
@@ -1185,12 +1178,12 @@ func getTableStuff(
 		}
 	}
 
-	if baseTblDef.Pkey.PkeyColName == catalog.FakePrimaryKeyColName {
+	if tarTblDef.Pkey.PkeyColName == catalog.FakePrimaryKeyColName {
 		tblStuff.def.pkKind = fakeKind
-	} else if baseTblDef.Pkey.CompPkeyCol != nil {
+	} else if tarTblDef.Pkey.CompPkeyCol != nil {
 		// case 2: composite pk, combined all pks columns as the PK
 		tblStuff.def.pkKind = compositeKind
-		pkNames := baseTblDef.Pkey.Names
+		pkNames := tarTblDef.Pkey.Names
 		for _, name := range pkNames {
 			idx := dataBranchColumnIndexByName(tblStuff.def.colNames, name)
 			if idx < 0 {
@@ -1202,7 +1195,7 @@ func getTableStuff(
 	} else {
 		// normal pk
 		tblStuff.def.pkKind = normalKind
-		pkName := baseTblDef.Pkey.PkeyColName
+		pkName := tarTblDef.Pkey.PkeyColName
 		idx := dataBranchColumnIndexByName(tblStuff.def.colNames, pkName)
 		if idx < 0 {
 			err = moerr.NewInternalErrorNoCtxf("primary key column %q is not present in target data columns", pkName)
@@ -1211,14 +1204,14 @@ func getTableStuff(
 		tblStuff.def.pkColIdxes = append(tblStuff.def.pkColIdxes, idx)
 	}
 
-	tblStuff.def.pkColIdx = dataBranchColumnIndexByName(tblStuff.def.colNames, baseTblDef.Pkey.PkeyColName)
+	tblStuff.def.pkColIdx = dataBranchColumnIndexByName(tblStuff.def.colNames, tarTblDef.Pkey.PkeyColName)
 	if tblStuff.def.pkColIdx < 0 {
-		err = moerr.NewInternalErrorNoCtxf("primary key column %q is not present in target data columns", baseTblDef.Pkey.PkeyColName)
+		err = moerr.NewInternalErrorNoCtxf("primary key column %q is not present in target data columns", tarTblDef.Pkey.PkeyColName)
 		return
 	}
-	tblStuff.def.pkSeqnum = int(baseTblDef.Cols[baseTblDef.Name2ColIndex[baseTblDef.Pkey.PkeyColName]].Seqnum)
+	tblStuff.def.pkSeqnum = int(tarTblDef.Cols[tarTblDef.Name2ColIndex[tarTblDef.Pkey.PkeyColName]].Seqnum)
 	if tblStuff.def.pkKind == fakeKind {
-		tblStuff.def.pkColIdxes = dataBranchFakePKColIdxes(baseTblDef)
+		tblStuff.def.pkColIdxes = dataBranchFakePKColIdxes(tarTblDef)
 	}
 
 	tblStuff.retPool = &retBatchList{}
@@ -1530,12 +1523,30 @@ func dataBranchPrimaryKeyColumns(tblDef *plan.TableDef) (kind int, names []strin
 }
 
 func checkDataBranchPrimaryKeyCompatibility(tarDef, baseDef *plan.TableDef) error {
+	return checkDataBranchPrimaryKeyCompatibilityWithResolver(
+		tarDef, baseDef,
+		func(tarCol *plan.ColDef) *plan.ColDef {
+			return dataBranchColumnDefByLogicalName(baseDef, tarCol)
+		},
+	)
+}
+
+func checkDataBranchPrimaryKeyCompatibilityWithResolver(
+	tarDef, baseDef *plan.TableDef,
+	resolveBaseColumn dataBranchEndpointColumnResolver,
+) error {
 	tarKind, tarNames := dataBranchPrimaryKeyColumns(tarDef)
 	baseKind, baseNames := dataBranchPrimaryKeyColumns(baseDef)
 	compatible := tarKind == baseKind && len(tarNames) == len(baseNames)
-	if compatible {
+	if compatible && tarKind != fakeKind {
 		for i := range tarNames {
-			if !strings.EqualFold(tarNames[i], baseNames[i]) {
+			tarCol := dataBranchColumnDefByName(tarDef, tarNames[i])
+			if tarCol == nil {
+				compatible = false
+				break
+			}
+			baseCol := resolveBaseColumn(tarCol)
+			if baseCol == nil || !strings.EqualFold(baseCol.Name, baseNames[i]) {
 				compatible = false
 				break
 			}
@@ -1573,7 +1584,9 @@ func checkSchemaCompatibilityWithResolver(
 	tarDef, baseDef *plan.TableDef,
 	resolveBaseColumn dataBranchEndpointColumnResolver,
 ) (commonIdxes, commonVisibleIdxes, tarOnlyIdxes []int, err error) {
-	if err = checkDataBranchPrimaryKeyCompatibility(tarDef, baseDef); err != nil {
+	if err = checkDataBranchPrimaryKeyCompatibilityWithResolver(
+		tarDef, baseDef, resolveBaseColumn,
+	); err != nil {
 		return
 	}
 
@@ -2333,7 +2346,7 @@ func dataBranchLineageEndpointColumns(
 				candidateReachesLCA, candidateLCACol, candidateRedefined :=
 					dataBranchColumnReachesLCA(baseDefs, baseLineageOnly, candidate)
 				if candidateRedefined || !candidateReachesLCA ||
-					dataBranchColumnDefByLogicalName(baseDefs[0], tarLCACol) != candidateLCACol {
+					dataBranchEndpointColumnDef(baseDefs[0], tarLCACol) != candidateLCACol {
 					continue
 				}
 				if baseCol != nil {
@@ -2353,7 +2366,7 @@ func dataBranchLineageEndpointColumns(
 		)
 		identityMismatch := tarRedefined || baseRedefined || tarReachesLCA != baseReachesLCA
 		if tarReachesLCA && baseReachesLCA {
-			identityMismatch = dataBranchColumnDefByLogicalName(baseDefs[0], tarLCACol) != baseLCACol
+			identityMismatch = dataBranchEndpointColumnDef(baseDefs[0], tarLCACol) != baseLCACol
 		}
 		if !tarReachesLCA && !baseReachesLCA {
 			// Independently added same-name columns are compatible when the

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -1522,15 +1522,6 @@ func dataBranchPrimaryKeyColumns(tblDef *plan.TableDef) (kind int, names []strin
 	return normalKind, []string{tblDef.Pkey.PkeyColName}
 }
 
-func checkDataBranchPrimaryKeyCompatibility(tarDef, baseDef *plan.TableDef) error {
-	return checkDataBranchPrimaryKeyCompatibilityWithResolver(
-		tarDef, baseDef,
-		func(tarCol *plan.ColDef) *plan.ColDef {
-			return dataBranchColumnDefByLogicalName(baseDef, tarCol)
-		},
-	)
-}
-
 func checkDataBranchPrimaryKeyCompatibilityWithResolver(
 	tarDef, baseDef *plan.TableDef,
 	resolveBaseColumn dataBranchEndpointColumnResolver,

--- a/pkg/frontend/data_branch_hashdiff.go
+++ b/pkg/frontend/data_branch_hashdiff.go
@@ -2841,8 +2841,8 @@ func dataBranchSourceColToTargetIdx(
 // isDataBranchDerivedCompositePKColumn reports whether the two columns are the
 // hidden serialization of the same logical composite primary key. COPY ALTER
 // rebuilds this derived column and may assign it a new Seqnum even though the
-// component-column identities, which checkDataBranchPrimaryKeyCompatibility
-// has already validated, remain unchanged.
+// component-column identities, which schema reconciliation has already
+// validated, remain unchanged.
 func isDataBranchDerivedCompositePKColumn(
 	sourceDef, targetDef *plan2.TableDef,
 	sourceCol, targetCol *plan2.ColDef,
@@ -2992,14 +2992,22 @@ func dataBranchHistoricalProbeStuff(
 ) tableStuff {
 	probeStuff := tblStuff
 	probeStuff.lcaRel = endpointRel
-	if endpointRel.GetTableID(ctx) == tblStuff.tarRel.GetTableID(ctx) {
+	endpointTableID := endpointRel.GetTableID(ctx)
+	if endpointTableID == tblStuff.tarRel.GetTableID(ctx) {
 		// Target-side hydration restores the current values of columns that
 		// were absent or incompatible in an older physical generation.
 		probeStuff.tarRel = endpointRel
 		probeStuff.def.tarOnlyIdxes = nil
 		probeStuff.def.lcaColNames = nil
-	} else {
+	} else if endpointTableID == tblStuff.baseRel.GetTableID(ctx) {
+		// Base-side hydration emits SQL against the base endpoint, so map the
+		// target batch layout to the base endpoint's visible column names.
 		probeStuff.def.lcaColNames = probeStuff.def.baseColNames
+	} else {
+		// A bounded target-side PICK can hydrate from an older physical target
+		// generation. Its relation definition already carries that generation's
+		// exact names; base endpoint names are neither valid nor needed here.
+		probeStuff.def.lcaColNames = nil
 	}
 	return probeStuff
 }

--- a/pkg/frontend/data_branch_hashdiff.go
+++ b/pkg/frontend/data_branch_hashdiff.go
@@ -51,6 +51,30 @@ type lcaProbeLayout struct {
 	enumValues  []string
 }
 
+func (layout lcaProbeLayout) columnNameForTargetIndex(targetIdx int) (string, bool) {
+	for i, candidateIdx := range layout.targetIdxes {
+		if candidateIdx == targetIdx {
+			return layout.attrs[i], true
+		}
+	}
+	return "", false
+}
+
+func (layout lcaProbeLayout) columnNamesForTargetIndexes(targetIdxes []int) ([]string, error) {
+	names := make([]string, len(targetIdxes))
+	for i, targetIdx := range targetIdxes {
+		name, ok := layout.columnNameForTargetIndex(targetIdx)
+		if !ok {
+			return nil, moerr.NewInternalErrorNoCtxf(
+				"data branch: target column index %d is absent from LCA probe layout",
+				targetIdx,
+			)
+		}
+		names[i] = name
+	}
+	return names, nil
+}
+
 func lcaProbeResultTargetIndexes(
 	layout lcaProbeLayout,
 	targetColumnCount int,
@@ -123,9 +147,26 @@ func lcaProbeColumnLayout(
 				"DATA BRANCH target column %q is unavailable", name,
 			)
 		}
-		var lcaCol *plan2.ColDef
+		var (
+			lcaCol      *plan2.ColDef
+			lcaAttrName string
+		)
 		if targetIdx < len(lcaColNames) && lcaColNames[targetIdx] != "" {
-			lcaCol = dataBranchColumnDefByName(lcaDef, lcaColNames[targetIdx])
+			lcaAttrName = lcaColNames[targetIdx]
+			lcaCol = dataBranchColumnDefByName(lcaDef, lcaAttrName)
+			if lcaCol == nil {
+				// The LCA relation may also be a current endpoint whose visible
+				// name changed after the LCA snapshot. Keep the validated
+				// historical name for time-travel SQL while taking compatible
+				// type metadata from the same stable endpoint identity.
+				lcaCol = dataBranchEndpointColumnDef(lcaDef, targetCol)
+			}
+			if lcaCol == nil {
+				return lcaProbeLayout{}, moerr.NewInternalErrorNoCtxf(
+					"LCA data branch column %q cannot be resolved at the current endpoint",
+					lcaAttrName,
+				)
+			}
 		}
 		if lcaCol == nil {
 			lcaCol = dataBranchColumnDefByLogicalName(lcaDef, targetCol)
@@ -141,6 +182,9 @@ func lcaProbeColumnLayout(
 		if lcaCol == nil {
 			continue
 		}
+		if lcaAttrName == "" {
+			lcaAttrName = lcaCol.Name
+		}
 		derivedCompositePK := isDataBranchDerivedCompositePKColumn(
 			lcaDef, targetDef, lcaCol, targetCol,
 		)
@@ -152,7 +196,7 @@ func lcaProbeColumnLayout(
 				targetCol.Name,
 			)
 		}
-		layout.attrs = append(layout.attrs, lcaCol.Name)
+		layout.attrs = append(layout.attrs, lcaAttrName)
 		layout.types = append(layout.types, types.New(types.T(lcaCol.Typ.Id), lcaCol.Typ.Width, lcaCol.Typ.Scale))
 		layout.targetIdxes = append(layout.targetIdxes, targetIdx)
 		layout.enumValues = append(layout.enumValues, lcaCol.Typ.Enumvalues)
@@ -179,7 +223,6 @@ func handleDelsOnLCA(
 		fullTargetLayout bool
 
 		lcaTblDef    = tblStuff.lcaRel.GetTableDef(ctx)
-		baseTblDef   = tblStuff.baseRel.GetTableDef(ctx)
 		targetTblDef = tblStuff.tarRel.GetTableDef(ctx)
 
 		colTypes           = tblStuff.def.colTypes
@@ -216,7 +259,16 @@ func handleDelsOnLCA(
 		// timestamp may fail with unknown db/table even though the caller already
 		// knows the stable table ID.
 		mots := fmt.Sprintf("{MO_TS=%d} ", snapshot.PhysicalTime)
-		pkNames := lcaTblDef.Pkey.Names
+		var pkNames []string
+		if tblStuff.def.pkKind == fakeKind {
+			// The synthetic hash column is internal and cannot be renamed.
+			pkNames = []string{catalog.FakePrimaryKeyColName}
+		} else {
+			pkNames, err = lcaLayout.columnNamesForTargetIndexes(expandedPKColIdxes)
+			if err != nil {
+				return nil, err
+			}
+		}
 		quotedPKNames := make([]string, len(pkNames))
 		quotedPKValueAliases := make([]string, len(pkNames))
 		for i, name := range pkNames {
@@ -226,7 +278,7 @@ func handleDelsOnLCA(
 		quotedOrdinalAlias := quoteIdentifierForSQL("__mo_data_branch_ordinal")
 
 		// composite pk
-		if baseTblDef.Pkey.CompPkeyCol != nil {
+		if tblStuff.def.pkKind == compositeKind {
 			var tuple types.Tuple
 			cols, area := vector.MustVarlenaRawData(tBat.Vecs[0])
 			for i := range cols {
@@ -251,7 +303,7 @@ func handleDelsOnLCA(
 					valsBuf.WriteString(", ")
 				}
 			}
-		} else if baseTblDef.Pkey.PkeyColName == catalog.FakePrimaryKeyColName {
+		} else if tblStuff.def.pkKind == fakeKind {
 			// fake pk
 			pks := vector.MustFixedColNoTypeCheck[uint64](tBat.Vecs[0])
 			for i := range pks {
@@ -630,15 +682,14 @@ func runLCAProbeWithReaderFallback(
 	if err != nil {
 		return executor.Result{}, err
 	}
-	lcaPKIdx := slices.IndexFunc(lcaLayout.attrs, func(name string) bool {
-		return strings.EqualFold(name, lcaTblDef.Pkey.PkeyColName)
-	})
-	if lcaPKIdx < 0 {
+	lcaPKName, ok := lcaLayout.columnNameForTargetIndex(tblStuff.def.pkColIdx)
+	if !ok {
 		return executor.Result{}, moerr.NewInternalErrorNoCtxf(
-			"data branch: LCA primary key column %q is absent from probe layout",
-			lcaTblDef.Pkey.PkeyColName,
+			"data branch: target primary key column index %d is absent from LCA probe layout",
+			tblStuff.def.pkColIdx,
 		)
 	}
+	lcaPKIdx := slices.Index(lcaLayout.attrs, lcaPKName)
 	// Build a sorted IN vector for reader-side PK filtering.
 	// The sorted-search path uses binary search over the IN value array and
 	// assumes the array is ordered; an unsorted IN vector can drop valid hits.
@@ -648,7 +699,7 @@ func runLCAProbeWithReaderFallback(
 		return executor.Result{}, err
 	}
 	filterVec.InplaceSort()
-	pkFilterExpr := readutil.ConstructInExpr(ctx, lcaTblDef.Pkey.PkeyColName, filterVec)
+	pkFilterExpr := readutil.ConstructInExpr(ctx, lcaPKName, filterVec)
 	prepareCost = time.Since(start)
 
 	tmp := batch.NewWithSize(len(lcaLayout.attrs))
@@ -2709,7 +2760,13 @@ func dataBranchSourceColToTargetIdx(
 	if sourceDef == nil || targetDef == nil {
 		return nil, moerr.NewInternalErrorNoCtx("missing schema for historical data branch projection")
 	}
-	if err := checkDataBranchPrimaryKeyCompatibility(targetDef, sourceDef); err != nil {
+	if err := checkDataBranchPrimaryKeyCompatibilityWithResolver(
+		targetDef,
+		sourceDef,
+		func(targetCol *plan2.ColDef) *plan2.ColDef {
+			return dataBranchEndpointColumnDef(sourceDef, targetCol)
+		},
+	); err != nil {
 		return nil, moerr.NewNotSupportedNoCtxf(
 			"historical data branch primary key is incompatible with the endpoint schema: %s",
 			err.Error(),
@@ -2750,7 +2807,7 @@ func dataBranchSourceColToTargetIdx(
 		if col.Name == catalog.Row_ID {
 			continue
 		}
-		targetCol := dataBranchColumnDefByLogicalName(targetDef, col)
+		targetCol := dataBranchEndpointColumnDef(targetDef, col)
 		targetIdx := -1
 		if targetCol != nil {
 			targetIdx = dataBranchColumnIndexByName(targetColNames, targetCol.Name)

--- a/pkg/frontend/data_branch_hashdiff_test.go
+++ b/pkg/frontend/data_branch_hashdiff_test.go
@@ -1191,12 +1191,14 @@ func TestLCAProbeColumnLayoutKeepsHistoricalNameAfterEndpointRename(t *testing.T
 	require.Equal(t, []string{"id"}, pkNames)
 }
 
-func TestDataBranchHistoricalProbeStuffUsesEndpointRenameMapping(t *testing.T) {
+func TestDataBranchHistoricalProbeStuffMapsOnlyBaseEndpointNames(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	targetRel := mock_frontend.NewMockRelation(ctrl)
 	baseRel := mock_frontend.NewMockRelation(ctrl)
+	historicalTargetRel := mock_frontend.NewMockRelation(ctrl)
 	targetRel.EXPECT().GetTableID(gomock.Any()).Return(uint64(2)).AnyTimes()
 	baseRel.EXPECT().GetTableID(gomock.Any()).Return(uint64(3)).AnyTimes()
+	historicalTargetRel.EXPECT().GetTableID(gomock.Any()).Return(uint64(4)).AnyTimes()
 	tblStuff := tableStuff{tarRel: targetRel, baseRel: baseRel}
 	tblStuff.def.baseColNames = []string{"a", "base_name"}
 	tblStuff.def.lcaColNames = []string{"a", "ancestor_name"}
@@ -1206,6 +1208,12 @@ func TestDataBranchHistoricalProbeStuffUsesEndpointRenameMapping(t *testing.T) {
 
 	baseProbe := dataBranchHistoricalProbeStuff(context.Background(), tblStuff, baseRel)
 	require.Equal(t, []string{"a", "base_name"}, baseProbe.def.lcaColNames)
+
+	historicalTargetProbe := dataBranchHistoricalProbeStuff(
+		context.Background(), tblStuff, historicalTargetRel,
+	)
+	require.Nil(t, historicalTargetProbe.def.lcaColNames)
+	require.Same(t, targetRel, historicalTargetProbe.tarRel)
 }
 
 func TestLCAProbeColumnLayoutExcludesIncompatibleTargetOnlyColumn(t *testing.T) {

--- a/pkg/frontend/data_branch_hashdiff_test.go
+++ b/pkg/frontend/data_branch_hashdiff_test.go
@@ -1166,6 +1166,31 @@ func TestLCAProbeColumnLayoutUsesLineageResolvedRename(t *testing.T) {
 	require.Equal(t, []int{0, 1}, layout.targetIdxes)
 }
 
+func TestLCAProbeColumnLayoutKeepsHistoricalNameAfterEndpointRename(t *testing.T) {
+	lcaDef := &plan.TableDef{Cols: []*plan.ColDef{
+		{Name: "id_new", ColId: 1, Seqnum: 0, Typ: plan.Type{Id: int32(types.T_int64)}},
+	}}
+	targetDef := &plan.TableDef{Cols: []*plan.ColDef{
+		{Name: "id", ColId: 1, Seqnum: 0, Typ: plan.Type{Id: int32(types.T_int64)}},
+	}}
+
+	layout, err := lcaProbeColumnLayout(
+		lcaDef,
+		targetDef,
+		[]string{"id"},
+		[]types.Type{types.T_int64.ToType()},
+		nil,
+		[]string{"id"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"id"}, layout.attrs)
+	require.Equal(t, []int{0}, layout.targetIdxes)
+	pkNames, err := layout.columnNamesForTargetIndexes([]int{0})
+	require.NoError(t, err)
+	require.Equal(t, []string{"id"}, pkNames)
+}
+
 func TestDataBranchHistoricalProbeStuffUsesEndpointRenameMapping(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	targetRel := mock_frontend.NewMockRelation(ctrl)
@@ -1394,6 +1419,45 @@ func decodeCapturedRows(t *testing.T, bat *batch.Batch, colTypes []types.Type) [
 
 func TestHandleDelsOnLCA_SQLPaths(t *testing.T) {
 	ses := newValidateSession(t)
+
+	t.Run("uses historical primary key name after LCA endpoint rename", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		tblStuff := newTestBranchTableStuff(ctrl)
+		tblStuff.lcaRel = mock_frontend.NewMockRelation(ctrl)
+		tblStuff.def.lcaColNames = []string{"id", "name", "hidden"}
+		lcaDef := newTestBranchTableDef("lca_tbl", "name")
+		lcaDef.Cols[0].Name = "id_new"
+		lcaDef.Pkey.Names = []string{"id_new"}
+		lcaDef.Pkey.PkeyColName = "id_new"
+		tblStuff.lcaRel.(*mock_frontend.MockRelation).EXPECT().
+			GetTableDef(gomock.Any()).Return(lcaDef).AnyTimes()
+		tblStuff.lcaRel.(*mock_frontend.MockRelation).EXPECT().
+			GetTableID(gomock.Any()).Return(uint64(75)).AnyTimes()
+
+		wantErr := moerr.NewInternalErrorNoCtx("stop after sql capture")
+		bh := mock_frontend.NewMockBackgroundExec(ctrl)
+		bh.EXPECT().Exec(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, sql string) error {
+				require.Contains(t, sql, "lca.`id`")
+				require.NotContains(t, sql, "lca.`id_new`")
+				return wantErr
+			}).
+			Times(1)
+
+		tBat := batch.NewWithSize(1)
+		tBat.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+		require.NoError(t, vector.AppendFixed(tBat.Vecs[0], int64(1), false, ses.proc.Mp()))
+		tBat.SetRowCount(1)
+		defer tBat.Clean(ses.proc.Mp())
+
+		_, err := handleDelsOnLCA(
+			context.Background(), ses, bh, tBat, tblStuff,
+			types.BuildTS(10, 0).ToTimestamp(),
+		)
+		require.ErrorIs(t, err, wantErr)
+	})
 
 	t.Run("quotes primary key identifiers in generated join", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -1711,6 +1775,7 @@ func TestHandleDelsOnLCA_SQLPaths(t *testing.T) {
 
 		tblStuff := newTestBranchTableStuff(ctrl)
 		tblStuff.lcaRel = mock_frontend.NewMockRelation(ctrl)
+		tblStuff.def.pkKind = fakeKind
 		lcaDef := newTestBranchTableDef("lca_tbl", "name")
 		lcaDef.Pkey = &plan.PrimaryKeyDef{
 			Names:       []string{"__mo_fake_pk_col"},
@@ -1756,6 +1821,7 @@ func TestHandleDelsOnLCA_SQLPaths(t *testing.T) {
 
 		tblStuff := newTestBranchTableStuff(ctrl)
 		tblStuff.lcaRel = mock_frontend.NewMockRelation(ctrl)
+		tblStuff.def.pkKind = compositeKind
 		lcaDef := newTestBranchTableDef("lca_tbl", "name")
 		lcaDef.Pkey = &plan.PrimaryKeyDef{
 			Names:       []string{"id", "name"},
@@ -2898,6 +2964,29 @@ func TestDataBranchSourceColToTargetIdxAllowsCopyAlterIdentityReassignment(t *te
 	}
 
 	mapping, err := dataBranchSourceColToTargetIdx(sourceDef, targetDef, []string{"a", "b"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, mapping)
+}
+
+func TestDataBranchSourceColToTargetIdxPreservesRenamedPrimaryKeyIdentity(t *testing.T) {
+	sourceDef := &plan.TableDef{
+		Cols: []*plan.ColDef{
+			{Name: "id", ColId: 1, Seqnum: 0, Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "payload", ColId: 2, Seqnum: 1, Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+	}
+	targetDef := &plan.TableDef{
+		Cols: []*plan.ColDef{
+			{Name: "id_new", ColId: 1, Seqnum: 0, Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "payload", ColId: 2, Seqnum: 1, Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: "id_new", Names: []string{"id_new"}},
+	}
+
+	mapping, err := dataBranchSourceColToTargetIdx(
+		sourceDef, targetDef, []string{"id_new", "payload"}, nil,
+	)
 	require.NoError(t, err)
 	require.Equal(t, []int{0, 1}, mapping)
 }

--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -220,7 +220,7 @@ func newApplyBatchInfo(
 	deleteKeyNames := make([]string, len(deleteKeyColIdxes))
 	deleteStageNames := make([]string, len(deleteKeyColIdxes))
 	for i, idx := range deleteKeyColIdxes {
-		deleteKeyNames[i] = tblStuff.def.colNames[idx]
+		deleteKeyNames[i] = tblStuff.def.baseColNames[idx]
 		deleteStageNames[i] = fmt.Sprintf("branch_apply_key_%d", i)
 	}
 
@@ -230,7 +230,7 @@ func newApplyBatchInfo(
 	}
 	writableNames := make([]string, len(writableIdxes))
 	for i, idx := range writableIdxes {
-		writableNames[i] = tblStuff.def.colNames[idx]
+		writableNames[i] = tblStuff.def.baseColNames[idx]
 	}
 
 	seq := atomic.AddUint64(&diffTempTableSeq, 1)
@@ -1738,7 +1738,7 @@ func writeDeleteRowSQLFull(
 		if i > 0 {
 			buf.WriteString(" and ")
 		}
-		colName := quoteIdentifierForSQL(tblStuff.def.colNames[idx])
+		colName := quoteIdentifierForSQL(tblStuff.def.baseColNames[idx])
 		if row[idx] == nil {
 			buf.WriteString(colName)
 			buf.WriteString(" is null")
@@ -2219,10 +2219,10 @@ func writeInsertRowValues(
 	return nil
 }
 
-func quotedColumnNamesByIdxes(tblStuff tableStuff, idxes []int) []string {
+func quotedBaseColumnNamesByIdxes(tblStuff tableStuff, idxes []int) []string {
 	names := make([]string, len(idxes))
 	for i, idx := range idxes {
-		names[i] = quoteIdentifierForSQL(tblStuff.def.colNames[idx])
+		names[i] = quoteIdentifierForSQL(tblStuff.def.baseColNames[idx])
 	}
 	return names
 }
@@ -2513,7 +2513,7 @@ func flushSqlValues(
 				tblStuff.baseRel.GetTableDef(ctx).DbName,
 				tblStuff.baseRel.GetTableDef(ctx).Name,
 			),
-			strings.Join(quotedColumnNamesByIdxes(tblStuff, insertIdxes), ","),
+			strings.Join(quotedBaseColumnNamesByIdxes(tblStuff, insertIdxes), ","),
 		))
 	}
 
@@ -2525,10 +2525,10 @@ func flushSqlValues(
 					tblStuff.baseRel.GetTableDef(ctx).DbName,
 					tblStuff.baseRel.GetTableDef(ctx).Name,
 				),
-				quoteIdentifierForSQL(tblStuff.def.colNames[tblStuff.def.pkColIdx]),
+				quoteIdentifierForSQL(tblStuff.def.baseColNames[tblStuff.def.pkColIdx]),
 			))
 		} else {
-			pkNames := quotedColumnNamesByIdxes(tblStuff, tblStuff.def.pkColIdxes)
+			pkNames := quotedBaseColumnNamesByIdxes(tblStuff, tblStuff.def.pkColIdxes)
 			sqlBuffer.WriteString(fmt.Sprintf(
 				"delete from %s where (%s) in (",
 				qualifiedTableName(

--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -1342,7 +1342,8 @@ func TestDataBranchOutputWriteDeleteRowSQLFull(t *testing.T) {
 	tblStuff := tableStuff{
 		baseRel: baseRel,
 	}
-	tblStuff.def.colNames = []string{"id", "name"}
+	tblStuff.def.colNames = []string{"id", "name_new"}
+	tblStuff.def.baseColNames = []string{"id", "name"}
 	tblStuff.def.colTypes = []types.Type{types.T_int64.ToType(), types.T_varchar.ToType()}
 	tblStuff.def.visibleIdxes = []int{0, 1}
 
@@ -1410,7 +1411,8 @@ func TestDataBranchOutputFlushSqlValuesWithWriteFile(t *testing.T) {
 	tblStuff := tableStuff{
 		baseRel: baseRel,
 	}
-	tblStuff.def.colNames = []string{"id", "name"}
+	tblStuff.def.colNames = []string{"id", "name_new"}
+	tblStuff.def.baseColNames = []string{"id", "name"}
 	tblStuff.def.visibleIdxes = []int{0, 1}
 	tblStuff.def.writableIdxes = []int{0, 1}
 	tblStuff.def.pkColIdx = 0
@@ -1608,6 +1610,7 @@ func TestDataBranchOutputBuildDataBranchApplyLayout(t *testing.T) {
 		baseRel: baseRel,
 	}
 	tblStuff.def.colNames = []string{"id", "name", "age"}
+	tblStuff.def.baseColNames = []string{"id", "name", "age"}
 	tblStuff.def.pkColIdxes = []int{0, 2}
 	tblStuff.def.visibleIdxes = []int{0, 1, 2}
 	tblStuff.def.writableIdxes = []int{0, 1, 2}
@@ -1654,6 +1657,45 @@ func TestDataBranchOutputBuildDataBranchApplyLayout(t *testing.T) {
 	require.True(t, deleteByFullRow)
 	require.Nil(t, deleteKeyColIdxes)
 	require.Nil(t, info)
+}
+
+func TestDataBranchApplyLayoutUsesDestinationColumnNames(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	baseRel := mock_frontend.NewMockRelation(ctrl)
+	baseRel.EXPECT().GetTableDef(gomock.Any()).Return(&plan.TableDef{
+		DbName: "db1",
+		Name:   "base",
+	}).AnyTimes()
+	baseRel.EXPECT().GetTableName().Return("base").AnyTimes()
+
+	for _, tc := range []struct {
+		name            string
+		sourceName      string
+		destinationName string
+	}{
+		{name: "source renamed", sourceName: "payload_new", destinationName: "payload"},
+		{name: "destination renamed", sourceName: "payload", destinationName: "payload_new"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tblStuff := tableStuff{baseRel: baseRel}
+			tblStuff.def.colNames = []string{"id", tc.sourceName}
+			tblStuff.def.baseColNames = []string{"id", tc.destinationName}
+			tblStuff.def.pkColIdxes = []int{0}
+			tblStuff.def.visibleIdxes = []int{0, 1}
+			tblStuff.def.writableIdxes = []int{0, 1}
+			tblStuff.def.pkKind = normalKind
+
+			_, _, info := buildDataBranchApplyLayout(
+				ctx, &Session{}, tblStuff, dataBranchApplyModeOnlineMerge,
+			)
+			require.NotNil(t, info)
+			require.Equal(t, []string{"id"}, info.deleteKeyNames)
+			require.Equal(t, []string{"id", tc.destinationName}, info.writableNames)
+		})
+	}
 }
 
 func TestDataBranchOutputAppenderAppendRowAndFlushAll(t *testing.T) {
@@ -1995,6 +2037,7 @@ func TestNewApplyBatchInfoUsesCommonVisibleColumnsForEvolvedSchema(t *testing.T)
 	tblStuff.def.commonVisibleIdxes = []int{0, 3}
 	tblStuff.def.commonWritableIdxes = []int{0, 3}
 	tblStuff.def.tarOnlyIdxes = []int{2}
+	tblStuff.def.baseColNames = []string{"a", "", "", "b"}
 
 	info := newApplyBatchInfo(ctx, ses, tblStuff, []int{0}, false)
 	require.NotNil(t, info)
@@ -2010,6 +2053,7 @@ func TestNewApplyBatchInfoExcludesGeneratedColumns(t *testing.T) {
 
 	tblStuff := newTestBranchTableStuff(ctrl)
 	tblStuff.def.colNames = []string{"id", "value", "generated_value"}
+	tblStuff.def.baseColNames = []string{"id", "value", "generated_value"}
 	tblStuff.def.visibleIdxes = []int{0, 1, 2}
 	tblStuff.def.writableIdxes = []int{0, 1}
 	tblStuff.def.commonVisibleIdxes = []int{0, 1, 2}
@@ -2142,6 +2186,9 @@ func TestDataBranchOutputNoPKDeleteModes(t *testing.T) {
 	defer ctrl.Finish()
 
 	tblStuff := newFakePKBranchTableStuff(ctrl)
+	// Exercise the direct no-PK SQL paths with a source-side rename. The row
+	// layout keeps the source name while destination SQL must use baseColNames.
+	tblStuff.def.colNames[1] = "name_new"
 
 	t.Run("online merge deletes by fake pk", func(t *testing.T) {
 		var out bytes.Buffer
@@ -2298,6 +2345,7 @@ func newFakePKBranchTableStuff(ctrl *gomock.Controller) tableStuff {
 	var tblStuff tableStuff
 	tblStuff.baseRel = baseRel
 	tblStuff.def.colNames = []string{"id", "name", "__mo_fake_pk_col"}
+	tblStuff.def.baseColNames = []string{"id", "name", "__mo_fake_pk_col"}
 	tblStuff.def.colTypes = []types.Type{
 		types.T_int64.ToType(),
 		types.T_varchar.ToType(),

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -1663,6 +1663,35 @@ func TestCheckSchemaCompatibility_RejectsChangedPrimaryKeyWithCommonColumns(t *t
 	require.ErrorContains(t, err, "primary key columns")
 }
 
+func TestCheckSchemaCompatibilityWithResolver_AcceptsRenamedPrimaryKey(t *testing.T) {
+	tarDef := &plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{Names: []string{"id_new"}, PkeyColName: "id_new"},
+		Cols: []*plan.ColDef{
+			{ColId: 1, Seqnum: 0, Name: "id_new", Primary: true, Typ: plan.Type{Id: int32(types.T_int64)}},
+			{ColId: 2, Seqnum: 1, Name: "payload", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+	}
+	baseDef := &plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{Names: []string{"id"}, PkeyColName: "id"},
+		Cols: []*plan.ColDef{
+			{ColId: 1, Seqnum: 0, Name: "id", Primary: true, Typ: plan.Type{Id: int32(types.T_int64)}},
+			{ColId: 2, Seqnum: 1, Name: "payload", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+	}
+
+	commonIdxes, commonVisibleIdxes, tarOnlyIdxes, err := checkSchemaCompatibilityWithResolver(
+		tarDef,
+		baseDef,
+		func(tarCol *plan.ColDef) *plan.ColDef {
+			return dataBranchEndpointColumnDef(baseDef, tarCol)
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, commonIdxes)
+	require.Equal(t, []int{0, 1}, commonVisibleIdxes)
+	require.Empty(t, tarOnlyIdxes)
+}
+
 func TestCheckSchemaCompatibility_TypeMismatch(t *testing.T) {
 	tarDef := &plan.TableDef{
 		Name: "target",
@@ -1805,6 +1834,33 @@ func TestValidateDataBranchColumnLineage(t *testing.T) {
 		require.NoError(t, validateDataBranchColumnLineage(
 			tarDefs, []bool{false, false}, baseDefs, []bool{false, false},
 		))
+	})
+
+	t.Run("rename on LCA endpoint after fork preserves identity", func(t *testing.T) {
+		lcaAtFork := tableDef(col("a", 1, 0), col("b", 2, 1))
+		tarEndpoint := tableDef(col("a", 1, 0), col("b", 2, 1))
+		baseEndpoint := tableDef(col("a", 1, 0), col("bb", 2, 1))
+
+		endpointColumns, err := dataBranchLineageEndpointColumns(
+			[]*plan.TableDef{lcaAtFork, tarEndpoint}, []bool{false, false},
+			[]*plan.TableDef{baseEndpoint}, []bool{false},
+		)
+		require.NoError(t, err)
+		require.Same(t, baseEndpoint.Cols[1], endpointColumns["b"])
+	})
+
+	t.Run("replacement on LCA endpoint after fork remains discontinuous", func(t *testing.T) {
+		lcaAtFork := tableDef(col("a", 1, 0), col("b", 2, 1))
+		tarEndpoint := tableDef(col("a", 1, 0), col("b", 2, 1))
+		baseWithoutColumn := tableDef(col("a", 10, 0))
+		baseReplacement := tableDef(col("a", 20, 0), col("bb", 2, 1))
+
+		endpointColumns, err := dataBranchLineageEndpointColumns(
+			[]*plan.TableDef{lcaAtFork, tarEndpoint}, []bool{false, false},
+			[]*plan.TableDef{lcaAtFork, baseWithoutColumn, baseReplacement}, []bool{false, true, true},
+		)
+		require.NoError(t, err)
+		require.NotContains(t, endpointColumns, "b")
 	})
 
 	t.Run("rename preserves stable identity across edge kinds", func(t *testing.T) {

--- a/test/distributed/cases/git4data/branch/edge/branch_rename_apply.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_rename_apply.result
@@ -1,0 +1,153 @@
+drop database if exists branch_rename_apply;
+create database branch_rename_apply;
+use branch_rename_apply;
+create table merge_source_base(id int primary key, payload int);
+insert into merge_source_base values (1, 10), (2, 20);
+data branch create table merge_source_branch from merge_source_base;
+alter table merge_source_branch rename column payload to payload_new;
+update merge_source_branch set payload_new = 11 where id = 1;
+insert into merge_source_branch values (3, 30);
+data branch merge merge_source_branch into merge_source_base when conflict accept;
+select * from merge_source_base order by id;
+➤ id[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table merge_destination_base(id int primary key, payload int);
+insert into merge_destination_base values (1, 10), (2, 20);
+data branch create table merge_destination_branch from merge_destination_base;
+alter table merge_destination_base rename column payload to payload_new;
+update merge_destination_branch set payload = 11 where id = 1;
+insert into merge_destination_branch values (3, 30);
+data branch merge merge_destination_branch into merge_destination_base when conflict accept;
+select * from merge_destination_base order by id;
+➤ id[4,32,0]  ¦  payload_new[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table pick_source_base(id int primary key, payload int);
+insert into pick_source_base values (1, 10), (2, 20);
+data branch create table pick_source_branch from pick_source_base;
+alter table pick_source_branch rename column payload to payload_new;
+update pick_source_branch set payload_new = 11 where id = 1;
+update pick_source_branch set payload_new = 22 where id = 2;
+insert into pick_source_branch values (3, 30);
+data branch pick pick_source_branch into pick_source_base keys(1, 3) when conflict accept;
+select * from pick_source_base order by id;
+➤ id[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table pick_destination_base(id int primary key, payload int);
+insert into pick_destination_base values (1, 10), (2, 20);
+data branch create table pick_destination_branch from pick_destination_base;
+alter table pick_destination_base rename column payload to payload_new;
+update pick_destination_branch set payload = 11 where id = 1;
+update pick_destination_branch set payload = 22 where id = 2;
+insert into pick_destination_branch values (3, 30);
+data branch pick pick_destination_branch into pick_destination_base keys(1, 3) when conflict accept;
+select * from pick_destination_base order by id;
+➤ id[4,32,0]  ¦  payload_new[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table merge_source_pk_base(id int primary key, payload int);
+insert into merge_source_pk_base values (1, 10), (2, 20);
+data branch create table merge_source_pk_branch from merge_source_pk_base;
+alter table merge_source_pk_branch rename column id to id_new;
+update merge_source_pk_branch set payload = 11 where id_new = 1;
+insert into merge_source_pk_branch values (3, 30);
+data branch merge merge_source_pk_branch into merge_source_pk_base when conflict accept;
+select * from merge_source_pk_base order by id;
+➤ id[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table merge_destination_pk_base(id int primary key, payload int);
+insert into merge_destination_pk_base values (1, 10), (2, 20);
+data branch create table merge_destination_pk_branch from merge_destination_pk_base;
+alter table merge_destination_pk_base rename column id to id_new;
+update merge_destination_pk_branch set payload = 11 where id = 1;
+insert into merge_destination_pk_branch values (3, 30);
+data branch merge merge_destination_pk_branch into merge_destination_pk_base when conflict accept;
+select * from merge_destination_pk_base order by id_new;
+➤ id_new[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table pick_source_pk_base(id int primary key, payload int);
+insert into pick_source_pk_base values (1, 10), (2, 20);
+data branch create table pick_source_pk_branch from pick_source_pk_base;
+alter table pick_source_pk_branch rename column id to id_new;
+update pick_source_pk_branch set payload = 11 where id_new = 1;
+update pick_source_pk_branch set payload = 22 where id_new = 2;
+insert into pick_source_pk_branch values (3, 30);
+data branch pick pick_source_pk_branch into pick_source_pk_base keys(1, 3) when conflict accept;
+select * from pick_source_pk_base order by id;
+➤ id[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table pick_destination_pk_base(id int primary key, payload int);
+insert into pick_destination_pk_base values (1, 10), (2, 20);
+data branch create table pick_destination_pk_branch from pick_destination_pk_base;
+alter table pick_destination_pk_base rename column id to id_new;
+update pick_destination_pk_branch set payload = 11 where id = 1;
+update pick_destination_pk_branch set payload = 22 where id = 2;
+insert into pick_destination_pk_branch values (3, 30);
+data branch pick pick_destination_pk_branch into pick_destination_pk_base keys(1, 3) when conflict accept;
+select * from pick_destination_pk_base order by id_new;
+➤ id_new[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table merge_source_cpk_base(tenant int, id int, payload int, primary key(tenant, id));
+insert into merge_source_cpk_base values (1, 1, 10), (1, 2, 20);
+data branch create table merge_source_cpk_branch from merge_source_cpk_base;
+alter table merge_source_cpk_branch rename column id to id_new;
+update merge_source_cpk_branch set payload = 11 where tenant = 1 and id_new = 1;
+insert into merge_source_cpk_branch values (1, 3, 30);
+data branch merge merge_source_cpk_branch into merge_source_cpk_base when conflict accept;
+select * from merge_source_cpk_base order by tenant, id;
+➤ tenant[4,32,0]  ¦  id[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  1  ¦  11  𝄀
+1  ¦  2  ¦  20  𝄀
+1  ¦  3  ¦  30
+create table merge_destination_cpk_base(tenant int, id int, payload int, primary key(tenant, id));
+insert into merge_destination_cpk_base values (1, 1, 10), (1, 2, 20);
+data branch create table merge_destination_cpk_branch from merge_destination_cpk_base;
+alter table merge_destination_cpk_base rename column id to id_new;
+update merge_destination_cpk_branch set payload = 11 where tenant = 1 and id = 1;
+insert into merge_destination_cpk_branch values (1, 3, 30);
+data branch merge merge_destination_cpk_branch into merge_destination_cpk_base when conflict accept;
+select * from merge_destination_cpk_base order by tenant, id_new;
+➤ tenant[4,32,0]  ¦  id_new[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  1  ¦  11  𝄀
+1  ¦  2  ¦  20  𝄀
+1  ¦  3  ¦  30
+create table merge_fake_pk_base(id int, payload int);
+insert into merge_fake_pk_base values (1, 10), (2, 20);
+data branch create table merge_fake_pk_branch from merge_fake_pk_base;
+alter table merge_fake_pk_branch rename column payload to payload_new;
+update merge_fake_pk_branch set payload_new = 11 where id = 1;
+insert into merge_fake_pk_branch values (3, 30);
+data branch merge merge_fake_pk_branch into merge_fake_pk_base when conflict accept;
+select * from merge_fake_pk_base order by id;
+➤ id[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+create table merge_evolved_base(id int primary key, payload int);
+insert into merge_evolved_base values (1, 10), (2, 20);
+data branch create table merge_evolved_branch from merge_evolved_base;
+alter table merge_evolved_branch rename column payload to payload_new;
+alter table merge_evolved_branch add column branch_only int default 0;
+update merge_evolved_branch set payload_new = 11, branch_only = 100 where id = 1;
+insert into merge_evolved_branch values (3, 30, 300);
+data branch merge merge_evolved_branch into merge_evolved_base when conflict accept;
+select * from merge_evolved_base order by id;
+➤ id[4,32,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+drop database branch_rename_apply;

--- a/test/distributed/cases/git4data/branch/edge/branch_rename_apply.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_rename_apply.sql
@@ -1,0 +1,132 @@
+-- DATA BRANCH MERGE and PICK must write lineage-equivalent columns by the
+-- destination endpoint name after a one-sided rename.
+drop database if exists branch_rename_apply;
+create database branch_rename_apply;
+use branch_rename_apply;
+
+-- MERGE: source endpoint renamed.
+create table merge_source_base(id int primary key, payload int);
+insert into merge_source_base values (1, 10), (2, 20);
+data branch create table merge_source_branch from merge_source_base;
+alter table merge_source_branch rename column payload to payload_new;
+update merge_source_branch set payload_new = 11 where id = 1;
+insert into merge_source_branch values (3, 30);
+data branch merge merge_source_branch into merge_source_base when conflict accept;
+select * from merge_source_base order by id;
+
+-- MERGE: destination endpoint renamed after the fork.
+create table merge_destination_base(id int primary key, payload int);
+insert into merge_destination_base values (1, 10), (2, 20);
+data branch create table merge_destination_branch from merge_destination_base;
+alter table merge_destination_base rename column payload to payload_new;
+update merge_destination_branch set payload = 11 where id = 1;
+insert into merge_destination_branch values (3, 30);
+data branch merge merge_destination_branch into merge_destination_base when conflict accept;
+select * from merge_destination_base order by id;
+
+-- PICK: source endpoint renamed. The unpicked row remains unchanged.
+create table pick_source_base(id int primary key, payload int);
+insert into pick_source_base values (1, 10), (2, 20);
+data branch create table pick_source_branch from pick_source_base;
+alter table pick_source_branch rename column payload to payload_new;
+update pick_source_branch set payload_new = 11 where id = 1;
+update pick_source_branch set payload_new = 22 where id = 2;
+insert into pick_source_branch values (3, 30);
+data branch pick pick_source_branch into pick_source_base keys(1, 3) when conflict accept;
+select * from pick_source_base order by id;
+
+-- PICK: destination endpoint renamed after the fork.
+create table pick_destination_base(id int primary key, payload int);
+insert into pick_destination_base values (1, 10), (2, 20);
+data branch create table pick_destination_branch from pick_destination_base;
+alter table pick_destination_base rename column payload to payload_new;
+update pick_destination_branch set payload = 11 where id = 1;
+update pick_destination_branch set payload = 22 where id = 2;
+insert into pick_destination_branch values (3, 30);
+data branch pick pick_destination_branch into pick_destination_base keys(1, 3) when conflict accept;
+select * from pick_destination_base order by id;
+
+-- MERGE: source primary key renamed.
+create table merge_source_pk_base(id int primary key, payload int);
+insert into merge_source_pk_base values (1, 10), (2, 20);
+data branch create table merge_source_pk_branch from merge_source_pk_base;
+alter table merge_source_pk_branch rename column id to id_new;
+update merge_source_pk_branch set payload = 11 where id_new = 1;
+insert into merge_source_pk_branch values (3, 30);
+data branch merge merge_source_pk_branch into merge_source_pk_base when conflict accept;
+select * from merge_source_pk_base order by id;
+
+-- MERGE: destination primary key renamed after the fork.
+create table merge_destination_pk_base(id int primary key, payload int);
+insert into merge_destination_pk_base values (1, 10), (2, 20);
+data branch create table merge_destination_pk_branch from merge_destination_pk_base;
+alter table merge_destination_pk_base rename column id to id_new;
+update merge_destination_pk_branch set payload = 11 where id = 1;
+insert into merge_destination_pk_branch values (3, 30);
+data branch merge merge_destination_pk_branch into merge_destination_pk_base when conflict accept;
+select * from merge_destination_pk_base order by id_new;
+
+-- PICK: source primary key renamed.
+create table pick_source_pk_base(id int primary key, payload int);
+insert into pick_source_pk_base values (1, 10), (2, 20);
+data branch create table pick_source_pk_branch from pick_source_pk_base;
+alter table pick_source_pk_branch rename column id to id_new;
+update pick_source_pk_branch set payload = 11 where id_new = 1;
+update pick_source_pk_branch set payload = 22 where id_new = 2;
+insert into pick_source_pk_branch values (3, 30);
+data branch pick pick_source_pk_branch into pick_source_pk_base keys(1, 3) when conflict accept;
+select * from pick_source_pk_base order by id;
+
+-- PICK: destination primary key renamed after the fork.
+create table pick_destination_pk_base(id int primary key, payload int);
+insert into pick_destination_pk_base values (1, 10), (2, 20);
+data branch create table pick_destination_pk_branch from pick_destination_pk_base;
+alter table pick_destination_pk_base rename column id to id_new;
+update pick_destination_pk_branch set payload = 11 where id = 1;
+update pick_destination_pk_branch set payload = 22 where id = 2;
+insert into pick_destination_pk_branch values (3, 30);
+data branch pick pick_destination_pk_branch into pick_destination_pk_base keys(1, 3) when conflict accept;
+select * from pick_destination_pk_base order by id_new;
+
+-- MERGE: one source-side composite primary key component renamed.
+create table merge_source_cpk_base(tenant int, id int, payload int, primary key(tenant, id));
+insert into merge_source_cpk_base values (1, 1, 10), (1, 2, 20);
+data branch create table merge_source_cpk_branch from merge_source_cpk_base;
+alter table merge_source_cpk_branch rename column id to id_new;
+update merge_source_cpk_branch set payload = 11 where tenant = 1 and id_new = 1;
+insert into merge_source_cpk_branch values (1, 3, 30);
+data branch merge merge_source_cpk_branch into merge_source_cpk_base when conflict accept;
+select * from merge_source_cpk_base order by tenant, id;
+
+-- MERGE: one destination-side composite primary key component renamed.
+create table merge_destination_cpk_base(tenant int, id int, payload int, primary key(tenant, id));
+insert into merge_destination_cpk_base values (1, 1, 10), (1, 2, 20);
+data branch create table merge_destination_cpk_branch from merge_destination_cpk_base;
+alter table merge_destination_cpk_base rename column id to id_new;
+update merge_destination_cpk_branch set payload = 11 where tenant = 1 and id = 1;
+insert into merge_destination_cpk_branch values (1, 3, 30);
+data branch merge merge_destination_cpk_branch into merge_destination_cpk_base when conflict accept;
+select * from merge_destination_cpk_base order by tenant, id_new;
+
+-- MERGE without an explicit primary key uses the direct insert path.
+create table merge_fake_pk_base(id int, payload int);
+insert into merge_fake_pk_base values (1, 10), (2, 20);
+data branch create table merge_fake_pk_branch from merge_fake_pk_base;
+alter table merge_fake_pk_branch rename column payload to payload_new;
+update merge_fake_pk_branch set payload_new = 11 where id = 1;
+insert into merge_fake_pk_branch values (3, 30);
+data branch merge merge_fake_pk_branch into merge_fake_pk_base when conflict accept;
+select * from merge_fake_pk_base order by id;
+
+-- A renamed common column remains writable when the source also adds a column.
+create table merge_evolved_base(id int primary key, payload int);
+insert into merge_evolved_base values (1, 10), (2, 20);
+data branch create table merge_evolved_branch from merge_evolved_base;
+alter table merge_evolved_branch rename column payload to payload_new;
+alter table merge_evolved_branch add column branch_only int default 0;
+update merge_evolved_branch set payload_new = 11, branch_only = 100 where id = 1;
+insert into merge_evolved_branch values (3, 30, 300);
+data branch merge merge_evolved_branch into merge_evolved_base when conflict accept;
+select * from merge_evolved_base order by id;
+
+drop database branch_rename_apply;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26062

## What this PR does / why we need it:

### Root cause

DATA BRANCH schema reconciliation already identifies equivalent columns by stable lineage, but the apply paths emitted destination SQL with source-side column names. A one-sided rename therefore passed DIFF and later failed during MERGE or PICK. The primary-key and LCA time-travel paths also used current logical names where stable endpoint or historical LCA names were required, so destination-side and primary-key renames could fail before or during apply.

Historical PICK hydration also needs to distinguish the base endpoint from an older physical generation of the target. Treating every non-current-target table ID as the base endpoint applies destination names to an old target schema; a bounded PICK across multiple ALTER generations then tries to resolve columns that did not exist at the upper bound.

### Changes

- carry the lineage-resolved destination column names through every MERGE/PICK write path, including batch/direct deletes, full-row predicates, composite primary keys, and tables without explicit primary keys;
- validate primary-key compatibility through the same stable column identity used for schema reconciliation, while continuing to reject primary-key membership or kind changes;
- resolve time-travel probes with the validated historical LCA column names and preserve renamed primary-key identity across historical generations;
- classify historical hydration relations by stable table ID, applying base endpoint names only to the actual base relation and retaining historical target-generation names for bounded PICK;
- add focused unit coverage and BVT coverage for source-side and destination-side renames across MERGE/PICK, normal/composite/fake primary keys, bounded multi-generation PICK, and schema evolution with source-only columns.

Generated columns remain visible for comparison but are still excluded from destination writes.

### Validation

- proved the original failure in both rename directions: source-side apply failed on the new name; destination-side apply failed schema compatibility on the renamed destination column; destination rows remained unchanged;
- `make build`;
- `go vet -mod=readonly ./pkg/frontend` with the repository CGo include/link settings;
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=15m ./pkg/frontend`;
- `golangci-lint v2.6.2` built with Go 1.26.4 against `./pkg/frontend/...`: 0 issues;
- focused DATA BRANCH unit tests for lineage mapping, apply SQL, historical LCA names, historical hydration endpoint classification, generated columns, and primary-key compatibility;
- `mo-tester` BVT: `branch_rename_apply` 105/105 assertions passed;
- existing bounded multi-generation PICK BVT `git4data/branch/pick/pick_9.sql`: 173/173 assertions passed with the same metadata-ignore mode used by CI;
- broader related BVT set (`branch_rename_apply`, `branch_rename_output`, `merge_generated_column`, `merge_schema_evolve`): 337/337 assertions passed, with no failed, ignored, or abnormal cases;
- manually inspected the generated BVT result against the intended row and destination-column semantics.

### CI follow-up

- the initial SCA failure was caused by an unused compatibility wrapper introduced by this PR; the wrapper was removed and the matching linter gate now passes locally;
- the initial PROXY BVT failure was caused by this PR misclassifying a historical target generation as the base endpoint; the stable-ID classification fix restores the existing `pick_9.sql` expectations;
- the Coverage failure was downstream of the failed PROXY coverage producer, not a separate root cause. There are no unrelated CI blockers to track or rerun.

### Residual risks

No known residual risk. The behavior change is limited to mappings whose stable lineage and logical schema are already validated; drop/add replacements, type changes, generated-column definition changes, and primary-key drift continue to fail closed. There are no API, catalog, storage-format, concurrency, or resource-lifecycle changes.
