### PR TITLE
fix(plan): isolate table function input dependencies

### DIFF
--- a/pkg/sql/plan/fulltext.go
+++ b/pkg/sql/plan/fulltext.go
@@ -182,7 +182,13 @@ func (builder *QueryBuilder) getFullTextIndexScanSql(params string, idxtbl strin
 //
 // for composite key, use hex string X'abcd' as input of primary key and skip serial()
 // select unhex(hex(serial(cast(0 as smallint), cast(1 as int))));
-func (builder *QueryBuilder) buildFullTextIndexTokenize(tbl *tree.TableFunction, ctx *BindContext, exprs []*plan.Expr, children []int32) (int32, error) {
+func (builder *QueryBuilder) buildFullTextIndexTokenize(
+	tbl *tree.TableFunction,
+	ctx *BindContext,
+	exprs []*plan.Expr,
+	children []int32,
+	inputNodeID int32,
+) (int32, error) {
 
 	if len(exprs) < 3 {
 		return 0, moerr.NewInvalidInput(builder.GetContext(), "Invalid number of arguments (NARGS < 3).")
@@ -194,7 +200,10 @@ func (builder *QueryBuilder) buildFullTextIndexTokenize(tbl *tree.TableFunction,
 		return 0, err
 	}
 
-	scanNode := builder.qry.Nodes[children[0]]
+	if inputNodeID < 0 || int(inputNodeID) >= len(builder.qry.Nodes) {
+		return 0, moerr.NewInvalidInput(builder.GetContext(), "fulltext_index_tokenize requires a left input relation")
+	}
+	scanNode := builder.qry.Nodes[inputNodeID]
 	if scanNode.NodeType == plan.Node_TABLE_SCAN {
 		if len(exprs) < 3 {
 			return 0, moerr.NewInvalidInput(builder.GetContext(), "Invalid number of arguments (NARGS < 3).")

--- a/pkg/sql/plan/fulltext.go
+++ b/pkg/sql/plan/fulltext.go
@@ -203,6 +203,9 @@ func (builder *QueryBuilder) buildFullTextIndexTokenize(
 	if inputNodeID < 0 || int(inputNodeID) >= len(builder.qry.Nodes) {
 		return 0, moerr.NewInvalidInput(builder.GetContext(), "fulltext_index_tokenize requires a left input relation")
 	}
+	// inputNodeID supplies planning metadata such as the primary-key type. It
+	// does not by itself make the relation an execution child; buildTableFunction
+	// derives that dependency independently from the normalized arguments.
 	scanNode := builder.qry.Nodes[inputNodeID]
 	if scanNode.NodeType == plan.Node_TABLE_SCAN {
 		if len(exprs) < 3 {

--- a/pkg/sql/plan/generate_series_test.go
+++ b/pkg/sql/plan/generate_series_test.go
@@ -173,3 +173,110 @@ func TestBuildGenerateSeriesOwnsStableResultSchema(t *testing.T) {
 	require.Equal(t, types.T_varchar, types.T(first.TableDef.Cols[0].Typ.Id))
 	require.NotSame(t, first.TableDef.Cols[0], second.TableDef.Cols[0])
 }
+
+func TestTableFunctionInputDependency(t *testing.T) {
+	findFunctionScan := func(query *planpb.Query, name string) *planpb.Node {
+		for _, node := range query.Nodes {
+			if node.NodeType == planpb.Node_FUNCTION_SCAN &&
+				node.GetTableDef().GetTblFunc().GetName() == name {
+				return node
+			}
+		}
+		return nil
+	}
+
+	findNode := func(query *planpb.Query, nodeType planpb.Node_NodeType) *planpb.Node {
+		for _, node := range query.Nodes {
+			if node.NodeType == nodeType {
+				return node
+			}
+		}
+		return nil
+	}
+	countNodes := func(query *planpb.Query, nodeType planpb.Node_NodeType) int {
+		count := 0
+		for _, node := range query.Nodes {
+			if node.NodeType == nodeType {
+				count++
+			}
+		}
+		return count
+	}
+
+	tests := []struct {
+		name           string
+		sql            string
+		functionName   string
+		dependsOnInput bool
+		apply          bool
+		tableScans     int
+	}{
+		{
+			name:           "JOIN right function with literal arguments is a source",
+			sql:            "select * from nation n join generate_series(1, 5) g on n.n_nationkey = g.result",
+			functionName:   "generate_series",
+			dependsOnInput: false,
+			tableScans:     1,
+		},
+		{
+			name:           "JOIN right function with scalar-only arguments is a source",
+			sql:            "select * from nation n join generate_series(abs(1), 5) g on n.n_nationkey = g.result",
+			functionName:   "generate_series",
+			dependsOnInput: false,
+			tableScans:     1,
+		},
+		{
+			name:           "JOIN right function with left expression is row dependent",
+			sql:            "select * from nation n join generate_series(n.n_nationkey, n.n_nationkey + 1) g on n.n_nationkey = g.result",
+			functionName:   "generate_series",
+			dependsOnInput: true,
+			tableScans:     2,
+		},
+		{
+			name:           "generic table function shares the source rule",
+			sql:            "select * from nation n join generate_random_int64(5, 42) g on n.n_nationkey = g.nth",
+			functionName:   "generate_random_int64",
+			dependsOnInput: false,
+			tableScans:     1,
+		},
+		{
+			name:           "unnest with literal input is a source",
+			sql:            "select * from nation n join unnest('[1, 2, 3]') u on true",
+			functionName:   "unnest",
+			dependsOnInput: false,
+			tableScans:     1,
+		},
+		{
+			name:           "APPLY owns row dependency instead of FUNCTION_SCAN",
+			sql:            "select * from nation n cross apply generate_series(n.n_nationkey, n.n_nationkey + 1) g",
+			functionName:   "generate_series",
+			dependsOnInput: false,
+			apply:          true,
+			tableScans:     1,
+		},
+		{
+			name:           "APPLY keeps planning input separate from execution child",
+			sql:            "select * from nation n cross apply fulltext_index_tokenize('', n.n_nationkey, n.n_name) f",
+			functionName:   "fulltext_index_tokenize",
+			dependsOnInput: false,
+			apply:          true,
+			tableScans:     1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logicPlan, err := runOneStmt(NewMockOptimizer(false), t, test.sql)
+			require.NoError(t, err)
+
+			query := resolveQueryPlan(logicPlan).GetQuery()
+			functionScan := findFunctionScan(query, test.functionName)
+			require.NotNil(t, functionScan)
+			require.Equal(t, test.dependsOnInput, len(functionScan.Children) > 0)
+			require.Equal(t, test.tableScans, countNodes(query, planpb.Node_TABLE_SCAN))
+			if test.apply {
+				require.NotNil(t, findNode(query, planpb.Node_APPLY))
+			}
+		})
+	}
+}

--- a/pkg/sql/plan/generate_series_test.go
+++ b/pkg/sql/plan/generate_series_test.go
@@ -233,6 +233,14 @@ func TestTableFunctionInputDependency(t *testing.T) {
 			tableScans:     2,
 		},
 		{
+			name: "JOIN chain discovers dependencies in the complete left subtree",
+			sql: "select * from nation n join region r on n.n_regionkey = r.r_regionkey " +
+				"join generate_series(r.r_regionkey, r.r_regionkey) g on r.r_regionkey = g.result",
+			functionName:   "generate_series",
+			dependsOnInput: true,
+			tableScans:     4,
+		},
+		{
 			name:           "generic table function shares the source rule",
 			sql:            "select * from nation n join generate_random_int64(5, 42) g on n.n_nationkey = g.nth",
 			functionName:   "generate_random_int64",
@@ -243,6 +251,13 @@ func TestTableFunctionInputDependency(t *testing.T) {
 			name:           "unnest with literal input is a source",
 			sql:            "select * from nation n join unnest('[1, 2, 3]') u on true",
 			functionName:   "unnest",
+			dependsOnInput: false,
+			tableScans:     1,
+		},
+		{
+			name:           "fulltext JOIN uses input metadata without forcing execution dependency",
+			sql:            "select * from nation n join fulltext_index_tokenize('', 1, 'body') f on true",
+			functionName:   "fulltext_index_tokenize",
 			dependsOnInput: false,
 			tableScans:     1,
 		},
@@ -279,4 +294,13 @@ func TestTableFunctionInputDependency(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFullTextIndexTokenizeRequiresInputRelation(t *testing.T) {
+	_, err := runOneStmt(
+		NewMockOptimizer(false),
+		t,
+		"select * from fulltext_index_tokenize('', 1, 'body') f",
+	)
+	require.ErrorContains(t, err, "fulltext_index_tokenize requires a left input relation")
 }

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -8486,7 +8486,7 @@ func (builder *QueryBuilder) rewriteRightJoinToLeftJoin(nodeID int32) {
 
 func (builder *QueryBuilder) buildFrom(stmt tree.TableExprs, ctx *BindContext, isRoot bool) (int32, error) {
 	if len(stmt) == 1 {
-		return builder.buildTable(stmt[0], ctx, -1, nil)
+		return builder.buildTable(stmt[0], ctx, nil)
 	}
 	return 0, moerr.NewInternalError(ctx.binder.GetContext(), "stmt's length should be zero")
 	// for now, stmt'length always be zero. if someday that change in parser, you should uncomment these codes
@@ -8756,7 +8756,13 @@ func (builder *QueryBuilder) bindView(
 // legacy grammar where || meant concat.
 const legacyViewParserSQLMode = "PIPES_AS_CONCAT"
 
-func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, preNodeId int32, leftCtx *BindContext) (nodeID int32, err error) {
+type tableFunctionInput struct {
+	nodeID               int32
+	argCtx               *BindContext
+	attachExecutionChild bool
+}
+
+func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, tableInput *tableFunctionInput) (nodeID int32, err error) {
 	switch tbl := stmt.(type) {
 	case *tree.Select:
 		subCtx := NewBindContext(builder, ctx)
@@ -8873,7 +8879,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, p
 						Rewrites: map[string][]*tree.Rewrite{key: chain[:len(chain)-1]},
 					}
 				}
-				nodeID, err = builder.buildTable(top.Stmt, ctx, preNodeId, leftCtx)
+				nodeID, err = builder.buildTable(top.Stmt, ctx, tableInput)
 				if err != nil {
 					return
 				}
@@ -9050,7 +9056,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, p
 
 	case *tree.JoinTableExpr:
 		if tbl.Right == nil {
-			return builder.buildTable(tbl.Left, ctx, preNodeId, leftCtx)
+			return builder.buildTable(tbl.Left, ctx, tableInput)
 		}
 		return builder.buildJoinTable(tbl, ctx)
 
@@ -9071,10 +9077,10 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, p
 		if tbl.Id() == "result_scan" {
 			return builder.buildResultScan(tbl, ctx)
 		}
-		return builder.buildTableFunction(tbl, ctx, preNodeId, leftCtx)
+		return builder.buildTableFunction(tbl, ctx, tableInput)
 
 	case *tree.ParenTableExpr:
-		return builder.buildTable(tbl.Expr, ctx, preNodeId, leftCtx)
+		return builder.buildTable(tbl.Expr, ctx, tableInput)
 
 	case *tree.AliasedTableExpr: //allways AliasedTableExpr first
 		derivedSelect := numericProjectionTableSelect(tbl.Expr)
@@ -9096,7 +9102,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, p
 				ctx.hasSingleRow = true
 			}
 		} else {
-			nodeID, err = builder.buildTable(tbl.Expr, ctx, preNodeId, leftCtx)
+			nodeID, err = builder.buildTable(tbl.Expr, ctx, tableInput)
 		}
 		if err != nil {
 			return
@@ -9444,7 +9450,7 @@ func (builder *QueryBuilder) buildJoinTable(tbl *tree.JoinTableExpr, ctx *BindCo
 	leftCtx.numericTableProjectionAmbiguous = ctx.numericTableProjectionAmbiguous
 	rightCtx.numericTableProjectionAmbiguous = ctx.numericTableProjectionAmbiguous
 
-	leftChildID, err := builder.buildTable(tbl.Left, leftCtx, -1, leftCtx)
+	leftChildID, err := builder.buildTable(tbl.Left, leftCtx, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -9452,7 +9458,11 @@ func (builder *QueryBuilder) buildJoinTable(tbl *tree.JoinTableExpr, ctx *BindCo
 	if _, ok := tbl.Right.(*tree.TableFunction); ok {
 		return 0, moerr.NewSyntaxError(builder.GetContext(), "Every table function must have an alias")
 	}
-	rightChildID, err := builder.buildTable(tbl.Right, rightCtx, leftChildID, leftCtx)
+	rightChildID, err := builder.buildTable(tbl.Right, rightCtx, &tableFunctionInput{
+		nodeID:               leftChildID,
+		argCtx:               leftCtx,
+		attachExecutionChild: true,
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -9584,16 +9594,23 @@ func (builder *QueryBuilder) buildApplyTable(tbl *tree.ApplyTableExpr, ctx *Bind
 	leftCtx := NewBindContext(builder, ctx)
 	rightCtx := NewBindContext(builder, ctx)
 
-	leftChildID, err := builder.buildTable(tbl.Left, leftCtx, -1, leftCtx)
+	leftChildID, err := builder.buildTable(tbl.Left, leftCtx, nil)
 	if err != nil {
 		return 0, err
 	}
 
-	rightChildID, err := builder.buildTable(tbl.Right, rightCtx, leftChildID, leftCtx)
+	// APPLY owns the left input at execution time.  The right-hand builder still
+	// needs the input node for planning metadata and its bindings for argument
+	// resolution, but must not attach a copy to the FUNCTION_SCAN tree.  The
+	// apply operator evaluates the arguments and invokes the function once for
+	// each left row itself.
+	rightChildID, err := builder.buildTable(tbl.Right, rightCtx, &tableFunctionInput{
+		nodeID: leftChildID,
+		argCtx: leftCtx,
+	})
 	if err != nil {
 		return 0, err
 	}
-	builder.qry.Nodes[rightChildID].Children = nil //ignore the child of table_function in apply
 
 	err = ctx.mergeContexts(builder.GetContext(), leftCtx, rightCtx)
 	if err != nil {
@@ -9607,21 +9624,21 @@ func (builder *QueryBuilder) buildApplyTable(tbl *tree.ApplyTableExpr, ctx *Bind
 	return nodeID, nil
 }
 
-func (builder *QueryBuilder) buildTableFunction(tbl *tree.TableFunction, ctx *BindContext, preNodeId int32, leftCtx *BindContext) (int32, error) {
+func (builder *QueryBuilder) buildTableFunction(tbl *tree.TableFunction, ctx *BindContext, input *tableFunctionInput) (int32, error) {
 	var (
-		childId int32
-		err     error
-		nodeId  int32
+		err    error
+		nodeId int32
 	)
 
-	var children []int32
-	if preNodeId == -1 {
-		ctx.binder = NewTableBinder(builder, ctx)
-	} else {
-		ctx.binder = NewTableBinder(builder, leftCtx)
-		childId = builder.copyNode(ctx, preNodeId)
-		children = []int32{childId}
+	// Argument visibility, planning metadata, and execution input are distinct
+	// concepts.  JOIN and APPLY expose the same left bindings and node to their
+	// right table-function builder, but only JOIN may make that node an execution
+	// child.  APPLY supplies the left rows through its own operator.
+	argCtx := ctx
+	if input != nil && input.argCtx != nil {
+		argCtx = input.argCtx
 	}
+	ctx.binder = NewTableBinder(builder, argCtx)
 
 	exprs := make([]*plan.Expr, 0, len(tbl.Func.Exprs))
 	for _, v := range tbl.Func.Exprs {
@@ -9631,6 +9648,7 @@ func (builder *QueryBuilder) buildTableFunction(tbl *tree.TableFunction, ctx *Bi
 		}
 		exprs = append(exprs, curExpr)
 	}
+
 	id := tbl.Id()
 
 	// Plugin-registered table functions (hnsw_create / hnsw_search /
@@ -9641,54 +9659,91 @@ func (builder *QueryBuilder) buildTableFunction(tbl *tree.TableFunction, ctx *Bi
 	// time; this lookup routes the parser-side dispatch through that
 	// registry before the hardcoded switch below.
 	if b, ok := planplugin.TableFunc(id); ok {
-		return b(builder, tbl, ctx, exprs, children)
+		nodeId, err = b(builder, tbl, ctx, exprs, nil)
+	} else {
+		switch id {
+		case "unnest":
+			nodeId, err = builder.buildUnnest(tbl, ctx, exprs, nil)
+		case "generate_series":
+			nodeId, err = builder.buildGenerateSeries(tbl, ctx, exprs, nil)
+		case "generate_random_int64":
+			nodeId = builder.buildGenerateRandomInt64(tbl, ctx, exprs, nil)
+		case "generate_random_float64":
+			nodeId = builder.buildGenerateRandomFloat64(tbl, ctx, exprs, nil)
+		case "meta_scan":
+			nodeId, err = builder.buildMetaScan(tbl, ctx, exprs, nil)
+		case "current_account":
+			nodeId, err = builder.buildCurrentAccount(tbl, ctx, exprs, nil)
+		case "metadata_scan":
+			nodeId = builder.buildMetadataScan(tbl, ctx, exprs, nil)
+		case "processlist", "mo_sessions":
+			nodeId, err = builder.buildProcesslist(tbl, ctx, exprs, nil)
+		case "mo_configurations":
+			nodeId, err = builder.buildMoConfigurations(tbl, ctx, exprs, nil)
+		case "mo_locks":
+			nodeId, err = builder.buildMoLocks(tbl, ctx, exprs, nil)
+		case "mo_transactions":
+			nodeId, err = builder.buildMoTransactions(tbl, ctx, exprs, nil)
+		case "mo_cache":
+			nodeId, err = builder.buildMoCache(tbl, ctx, exprs, nil)
+		case "fulltext_index_scan":
+			nodeId, err = builder.buildFullTextIndexScan(tbl, ctx, exprs, nil)
+		case "fulltext_index_tokenize":
+			inputNodeID := int32(-1)
+			if input != nil {
+				inputNodeID = input.nodeID
+			}
+			nodeId, err = builder.buildFullTextIndexTokenize(tbl, ctx, exprs, nil, inputNodeID)
+		case "stage_list":
+			nodeId, err = builder.buildStageList(tbl, ctx, exprs, nil)
+		case "moplugin_table":
+			nodeId, err = builder.buildPluginExec(tbl, ctx, exprs, nil)
+		case "parse_jsonl_data":
+			nodeId, err = builder.buildParseJsonlData(tbl, ctx, exprs, nil)
+		case "parse_jsonl_file":
+			nodeId, err = builder.buildParseJsonlFile(tbl, ctx, exprs, nil)
+		case "table_stats":
+			nodeId = builder.buildTableStats(tbl, ctx, exprs, nil)
+		case "load_file_chunks":
+			nodeId = builder.buildLoadFileChunks(tbl, ctx, exprs, nil)
+		default:
+			err = moerr.NewNotSupportedf(builder.GetContext(), "table function '%s' not supported", id)
+		}
+	}
+	if err != nil {
+		return nodeId, err
 	}
 
-	switch id {
-	case "unnest":
-		nodeId, err = builder.buildUnnest(tbl, ctx, exprs, children)
-	case "generate_series":
-		nodeId, err = builder.buildGenerateSeries(tbl, ctx, exprs, children)
-	case "generate_random_int64":
-		nodeId = builder.buildGenerateRandomInt64(tbl, ctx, exprs, children)
-	case "generate_random_float64":
-		nodeId = builder.buildGenerateRandomFloat64(tbl, ctx, exprs, children)
-	case "meta_scan":
-		nodeId, err = builder.buildMetaScan(tbl, ctx, exprs, children)
-	case "current_account":
-		nodeId, err = builder.buildCurrentAccount(tbl, ctx, exprs, children)
-	case "metadata_scan":
-		nodeId = builder.buildMetadataScan(tbl, ctx, exprs, children)
-	case "processlist", "mo_sessions":
-		nodeId, err = builder.buildProcesslist(tbl, ctx, exprs, children)
-	case "mo_configurations":
-		nodeId, err = builder.buildMoConfigurations(tbl, ctx, exprs, children)
-	case "mo_locks":
-		nodeId, err = builder.buildMoLocks(tbl, ctx, exprs, children)
-	case "mo_transactions":
-		nodeId, err = builder.buildMoTransactions(tbl, ctx, exprs, children)
-	case "mo_cache":
-		nodeId, err = builder.buildMoCache(tbl, ctx, exprs, children)
-	case "fulltext_index_scan":
-		nodeId, err = builder.buildFullTextIndexScan(tbl, ctx, exprs, children)
-	case "fulltext_index_tokenize":
-		nodeId, err = builder.buildFullTextIndexTokenize(tbl, ctx, exprs, children)
-	case "stage_list":
-		nodeId, err = builder.buildStageList(tbl, ctx, exprs, children)
-	case "moplugin_table":
-		nodeId, err = builder.buildPluginExec(tbl, ctx, exprs, children)
-	case "parse_jsonl_data":
-		nodeId, err = builder.buildParseJsonlData(tbl, ctx, exprs, children)
-	case "parse_jsonl_file":
-		nodeId, err = builder.buildParseJsonlFile(tbl, ctx, exprs, children)
-	case "table_stats":
-		nodeId = builder.buildTableStats(tbl, ctx, exprs, children)
-	case "load_file_chunks":
-		nodeId = builder.buildLoadFileChunks(tbl, ctx, exprs, children)
-	default:
-		err = moerr.NewNotSupportedf(builder.GetContext(), "table function '%s' not supported", id)
+	// Builders may normalize or remove protocol-only arguments.  Inspect the
+	// expressions the executor will actually evaluate, not the pre-builder
+	// argument slice, before deciding whether the JOIN input is an execution
+	// dependency.
+	if input != nil && input.attachExecutionChild &&
+		builder.tableFunctionDependsOnInput(builder.qry.Nodes[nodeId].TblFuncExprList, input.nodeID) {
+		builder.qry.Nodes[nodeId].Children = []int32{builder.copyNode(ctx, input.nodeID)}
 	}
-	return nodeId, err
+	return nodeId, nil
+}
+
+// tableFunctionDependsOnInput reports whether any table-function argument
+// reads a binding produced by inputNodeID.  FUNCTION_SCAN.Children is an
+// execution dependency: the executor evaluates a function with a child once
+// per child row, while a childless function is evaluated once as a source.
+// Syntactic placement on a JOIN right side must not create that dependency.
+func (builder *QueryBuilder) tableFunctionDependsOnInput(exprs []*plan.Expr, inputNodeID int32) bool {
+	inputTags := make(map[int32]struct{})
+	for _, tag := range builder.enumerateTags(inputNodeID) {
+		inputTags[tag] = struct{}{}
+	}
+
+	for _, expr := range exprs {
+		for tag := range inputTags {
+			if containsTag(expr, tag) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (builder *QueryBuilder) GetContext() context.Context {

--- a/pkg/sql/plan/query_builder_test.go
+++ b/pkg/sql/plan/query_builder_test.go
@@ -370,7 +370,7 @@ func TestBuildTable_AlterView(t *testing.T) {
 	tb.SchemaName = "db"
 	tb.ObjectName = "v"
 	bc := NewBindContext(qb, nil)
-	_, err = qb.buildTable(tb, bc, -1, nil)
+	_, err = qb.buildTable(tb, bc, nil)
 	assert.Error(t, err)
 }
 
@@ -476,7 +476,7 @@ func buildViewForSQLModeTest(t *testing.T, viewName string, viewData ViewData) (
 	tableName := &tree.TableName{}
 	tableName.SchemaName = "db"
 	tableName.ObjectName = tree.Identifier(viewName)
-	nodeID, err := builder.buildTable(tableName, bindCtx, -1, nil)
+	nodeID, err := builder.buildTable(tableName, bindCtx, nil)
 	require.NoError(t, err)
 	require.Equal(t, plan.Node_PROJECT, builder.qry.Nodes[nodeID].NodeType)
 	require.Len(t, builder.qry.Nodes[nodeID].ProjectList, 1)
@@ -549,7 +549,7 @@ func TestTempTableAliasBindingUsesOriginName(t *testing.T) {
 	tb := &tree.TableName{}
 	tb.SchemaName = "db"
 	tb.ObjectName = "t1"
-	nodeID, err := qb.buildTable(&tree.AliasedTableExpr{Expr: tb}, bc, -1, nil)
+	nodeID, err := qb.buildTable(&tree.AliasedTableExpr{Expr: tb}, bc, nil)
 	require.NoError(t, err)
 
 	_, ok := bc.bindingByTable["t1"]

--- a/test/distributed/cases/function/table_func_generate_series.result
+++ b/test/distributed/cases/function/table_func_generate_series.result
@@ -282,3 +282,40 @@ nth    f64
 8    0.6296099782367262
 9    1.565520076524086
 10    -0.834259977430416
+drop table if exists issue_26431;
+create table issue_26431(i int primary key);
+insert into issue_26431 values (1), (2), (3);
+select count(*) as rhs_count
+from issue_26431 d
+join generate_series(1, 5) g on d.i = g.result;
+rhs_count
+3
+select count(*) as lhs_count
+from generate_series(1, 5) g
+join issue_26431 d on d.i = g.result;
+lhs_count
+3
+with gs as (
+    select result from generate_series(1, 5) g
+)
+select count(*) as cte_count
+from issue_26431 d
+join gs on d.i = gs.result;
+cte_count
+3
+select count(*) as random_count
+from issue_26431 d
+join generate_random_int64(5, 42) g on d.i = g.nth;
+random_count
+3
+select count(*) as unnest_count
+from issue_26431 d
+join unnest('[1, 2, 3]') u on true;
+unnest_count
+9
+select count(*) as apply_count
+from issue_26431 d
+cross apply generate_series(1, 5) g;
+apply_count
+15
+drop table issue_26431;

--- a/test/distributed/cases/function/table_func_generate_series.result
+++ b/test/distributed/cases/function/table_func_generate_series.result
@@ -290,23 +290,23 @@ from issue_26431 d
 join generate_series(1, 5) g on d.i = g.result;
 rhs_count
 3
+select count(*) as correlated_count
+from issue_26431 d
+join generate_series(d.i, d.i) g on d.i = g.result;
+correlated_count
+3
 select count(*) as lhs_count
 from generate_series(1, 5) g
 join issue_26431 d on d.i = g.result;
 lhs_count
 3
 with gs as (
-    select result from generate_series(1, 5) g
+select result from generate_series(1, 5) g
 )
 select count(*) as cte_count
 from issue_26431 d
 join gs on d.i = gs.result;
 cte_count
-3
-select count(*) as random_count
-from issue_26431 d
-join generate_random_int64(5, 42) g on d.i = g.nth;
-random_count
 3
 select count(*) as unnest_count
 from issue_26431 d

--- a/test/distributed/cases/function/table_func_generate_series.test
+++ b/test/distributed/cases/function/table_func_generate_series.test
@@ -82,6 +82,11 @@ insert into issue_26431 values (1), (2), (3);
 select count(*) as rhs_count
 from issue_26431 d
 join generate_series(1, 5) g on d.i = g.result;
+-- Use one generated row per left row so this case isolates the execution
+-- dependency without defining separate overlapping-range JOIN semantics.
+select count(*) as correlated_count
+from issue_26431 d
+join generate_series(d.i, d.i) g on d.i = g.result;
 select count(*) as lhs_count
 from generate_series(1, 5) g
 join issue_26431 d on d.i = g.result;
@@ -93,11 +98,7 @@ from issue_26431 d
 join gs on d.i = gs.result;
 
 -- The dependency rule is shared by all table functions, not special-cased
--- for generate_series.  generate_random_int64 has a stable ordinal column;
--- unnest has three literal-array rows.
-select count(*) as random_count
-from issue_26431 d
-join generate_random_int64(5, 42) g on d.i = g.nth;
+-- for generate_series.  unnest has three literal-array rows.
 select count(*) as unnest_count
 from issue_26431 d
 join unnest('[1, 2, 3]') u on true;

--- a/test/distributed/cases/function/table_func_generate_series.test
+++ b/test/distributed/cases/function/table_func_generate_series.test
@@ -74,3 +74,37 @@ select * from generate_random_float64(10, 42, '') t;
 select * from generate_random_float64(10, 42, 'exp') t;
 select * from generate_random_float64(10, 42, 'normal') t;
 
+-- Non-correlated table functions on the right side of JOIN are source
+-- relations.  They must not inherit a per-left-row execution dependency.
+drop table if exists issue_26431;
+create table issue_26431(i int primary key);
+insert into issue_26431 values (1), (2), (3);
+select count(*) as rhs_count
+from issue_26431 d
+join generate_series(1, 5) g on d.i = g.result;
+select count(*) as lhs_count
+from generate_series(1, 5) g
+join issue_26431 d on d.i = g.result;
+with gs as (
+    select result from generate_series(1, 5) g
+)
+select count(*) as cte_count
+from issue_26431 d
+join gs on d.i = gs.result;
+
+-- The dependency rule is shared by all table functions, not special-cased
+-- for generate_series.  generate_random_int64 has a stable ordinal column;
+-- unnest has three literal-array rows.
+select count(*) as random_count
+from issue_26431 d
+join generate_random_int64(5, 42) g on d.i = g.nth;
+select count(*) as unnest_count
+from issue_26431 d
+join unnest('[1, 2, 3]') u on true;
+
+-- APPLY remains explicitly row dependent even when its arguments are
+-- constants; its operator, rather than FUNCTION_SCAN.Children, owns that.
+select count(*) as apply_count
+from issue_26431 d
+cross apply generate_series(1, 5) g;
+drop table issue_26431;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26431

## What this PR does / why we need it:

A table function on the right side of a JOIN currently inherits a copied left input solely because of its syntactic position. For non-correlated arguments, that turns the table function into a per-left-row operator and silently duplicates results.

This change separates three independent planner concepts:

- argument binding visibility;
- the input node used for build-time metadata;
- the runtime FUNCTION_SCAN execution child.

JOIN now attaches an execution child only when the final runtime `TblFuncExprList` actually references a binding produced by the left input. The check runs after each built-in or plugin builder normalizes its protocol arguments. APPLY keeps access to the left node and bindings for planning, while its own operator remains the sole owner of per-row execution and no detached copied subtree is left behind.

The regression matrix covers:

- right-side versus left-side and CTE `generate_series` forms;
- scalar-only versus genuinely correlated arguments;
- generic random and `unnest` table functions;
- APPLY ownership and the `fulltext_index_tokenize` metadata path;
- typed plan structure and end-user SQL row counts.

Validation:

- `go build -mod=readonly ./pkg/sql/plan`
- `go vet -mod=readonly ./pkg/sql/plan`
- full `pkg/sql/plan` tests
- `TestTableFunctionInputDependency` with `-race -count=100` (`T=0.02s`, `B=30s`, `N=100`)
- full `pkg/sql/plan` with `-race -count=1`
- compile-side `TestDupOperatorTableFunctionPreservesProbeState`