### PR TITLE
fix(morpc): linearize message cache retirement

### DIFF
--- a/pkg/common/morpc/cache.go
+++ b/pkg/common/morpc/cache.go
@@ -68,8 +68,6 @@ func (c *cache) Pop() (Message, bool, error) {
 func (c *cache) Close() {
 	c.Lock()
 	defer c.Unlock()
-	for idx := range c.queue {
-		c.queue[idx] = nil
-	}
+	c.queue = nil
 	c.closed = true
 }

--- a/pkg/common/morpc/cache_test.go
+++ b/pkg/common/morpc/cache_test.go
@@ -32,6 +32,7 @@ func TestCacheAdd(t *testing.T) {
 	v, err = c.Len()
 	assert.Error(t, err)
 	assert.Equal(t, v, 0)
+	assert.Nil(t, c.(*cache).queue)
 }
 
 func TestCachePop(t *testing.T) {

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -713,6 +713,7 @@ func (cs *clientSession) Close() error {
 	clear(cs.receivedStreamSequences)
 	caches := make([]cacheWithContext, 0, len(cs.mu.caches))
 	for _, c := range cs.mu.caches {
+		c.closeCache()
 		caches = append(caches, c)
 	}
 	cs.mu.caches = nil
@@ -720,7 +721,7 @@ func (cs *clientSession) Close() error {
 	cs.streamStateMu.Unlock()
 
 	for _, c := range caches {
-		c.close()
+		c.cancelContexts()
 	}
 	cs.cancelWrite()
 	return cs.conn.Close()
@@ -863,16 +864,13 @@ func (cs *clientSession) checkCacheTimeout() {
 				cs.mu.Lock()
 				for k, c := range cs.mu.caches {
 					if c.closeIfTimeout() {
-						delete(cs.mu.caches, k)
-						expired = append(expired, c)
-						if cs.metrics != nil {
-							cs.metrics.messageCacheStateGauge.Dec()
-						}
+						retired, _ := cs.retireCacheLocked(k)
+						expired = append(expired, retired)
 					}
 				}
 				cs.mu.Unlock()
 				for _, c := range expired {
-					c.close()
+					c.cancelContexts()
 				}
 				if cs.messageCacheScanHook != nil {
 					cs.messageCacheScanHook()
@@ -997,17 +995,30 @@ func (cs *clientSession) DeleteCache(cacheID uint64) {
 		cs.mu.Unlock()
 		return
 	}
-	c, ok := cs.mu.caches[cacheID]
-	if ok {
-		delete(cs.mu.caches, cacheID)
-		if cs.metrics != nil {
-			cs.metrics.messageCacheStateGauge.Dec()
-		}
-	}
+	c, ok := cs.retireCacheLocked(cacheID)
 	cs.mu.Unlock()
 	if ok {
-		c.close()
+		c.cancelContexts()
 	}
+}
+
+// retireCacheLocked closes a cache before publishing its removal. This keeps
+// the registry and every cache handle in one lifecycle state: once callers can
+// no longer discover the cache, previously returned handles are already closed.
+// The caller must hold cs.mu for writing. Transferred context cancellation is
+// deliberately deferred until after the lock is released because it may re-enter
+// the session.
+func (cs *clientSession) retireCacheLocked(cacheID uint64) (cacheWithContext, bool) {
+	c, ok := cs.mu.caches[cacheID]
+	if !ok {
+		return cacheWithContext{}, false
+	}
+	c.closeCache()
+	delete(cs.mu.caches, cacheID)
+	if cs.metrics != nil {
+		cs.metrics.messageCacheStateGauge.Dec()
+	}
+	return c, true
 }
 
 func (cs *clientSession) GetCache(cacheID uint64) (MessageCache, error) {
@@ -1030,8 +1041,11 @@ type cacheWithContext struct {
 	cancels []context.CancelFunc
 }
 
-func (c cacheWithContext) close() {
+func (c cacheWithContext) closeCache() {
 	c.cache.Close()
+}
+
+func (c cacheWithContext) cancelContexts() {
 	for _, cancel := range c.cancels {
 		cancel()
 	}

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -737,6 +737,11 @@ func TestFinishStreamRacesWithSessionClose(t *testing.T) {
 }
 
 func TestServerTimeoutCacheWillRemoved(t *testing.T) {
+	type cacheObservation struct {
+		cache   MessageCache
+		session ClientSession
+	}
+
 	scanDone := make(chan struct{}, 1)
 	testRPCServer(t, func(rs *server) {
 		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
@@ -747,34 +752,46 @@ func TestServerTimeoutCacheWillRemoved(t *testing.T) {
 			assert.NoError(t, c.Close())
 		}()
 
-		cc := make(chan MessageCache, 1)
+		cacheCreated := make(chan cacheObservation, 1)
 		rs.RegisterRequestHandler(func(ctx context.Context, msg RPCMessage, seq uint64, cs ClientSession) error {
 			request := msg.Message
 			cache, err := cs.CreateCache(ctx, request.GetID())
 			if err != nil {
 				return err
 			}
-			cc <- cache
-			return cache.Add(request)
+			if err := cache.Add(request); err != nil {
+				return err
+			}
+			select {
+			case cacheCreated <- cacheObservation{
+				cache:   cache,
+				session: cs,
+			}:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		})
 
 		st, err := c.NewStream(context.Background(), testAddr, false)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, st.Close(false))
 		}()
 
 		// Stream.Send requires request.GetID() == stream.ID(); stream id is assigned by backend at NewStream().
-		assert.NoError(t, st.Send(ctx, newTestMessage(st.ID())))
-		cache := <-cc
-		v, ok := rs.sessions.Load(uint64(1))
-		require.True(t, ok)
-		cs := v.(*clientSession)
+		require.NoError(t, st.Send(ctx, newTestMessage(st.ID())))
+		var observation cacheObservation
+		select {
+		case observation = <-cacheCreated:
+		case <-ctx.Done():
+			t.Fatal("server handler did not create the message cache")
+		}
 	waitForRetirement:
 		for {
 			select {
 			case <-scanDone:
-				cached, err := cs.GetCache(st.ID())
+				cached, err := observation.session.GetCache(st.ID())
 				require.NoError(t, err)
 				if cached == nil {
 					break waitForRetirement
@@ -783,7 +800,7 @@ func TestServerTimeoutCacheWillRemoved(t *testing.T) {
 				t.Fatal("message cache was not retired by timeout scans")
 			}
 		}
-		_, err = cache.Len()
+		_, err = observation.cache.Len()
 		require.Error(t, err, "expired cache must be closed before removal")
 	}, WithServerMessageCacheScanHookForTesting(func() {
 		select {

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -737,6 +737,7 @@ func TestFinishStreamRacesWithSessionClose(t *testing.T) {
 }
 
 func TestServerTimeoutCacheWillRemoved(t *testing.T) {
+	scanDone := make(chan struct{}, 1)
 	testRPCServer(t, func(rs *server) {
 		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
 		defer cancel()
@@ -767,19 +768,102 @@ func TestServerTimeoutCacheWillRemoved(t *testing.T) {
 		assert.NoError(t, st.Send(ctx, newTestMessage(st.ID())))
 		cache := <-cc
 		v, ok := rs.sessions.Load(uint64(1))
-		if ok {
-			cs := v.(*clientSession)
-			for {
-				cs.mu.RLock()
-				if len(cs.mu.caches) == 0 {
-					cs.mu.RUnlock()
-					_, err := cache.Len()
-					require.Error(t, err, "expired cache must be closed before removal")
-					return
+		require.True(t, ok)
+		cs := v.(*clientSession)
+	waitForRetirement:
+		for {
+			select {
+			case <-scanDone:
+				cached, err := cs.GetCache(st.ID())
+				require.NoError(t, err)
+				if cached == nil {
+					break waitForRetirement
 				}
-				cs.mu.RUnlock()
+			case <-ctx.Done():
+				t.Fatal("message cache was not retired by timeout scans")
 			}
 		}
+		_, err = cache.Len()
+		require.Error(t, err, "expired cache must be closed before removal")
+	}, WithServerMessageCacheScanHookForTesting(func() {
+		select {
+		case scanDone <- struct{}{}:
+		default:
+		}
+	}))
+}
+
+type cacheRetirementObserver struct {
+	session           *clientSession
+	cacheID           uint64
+	registeredAtClose chan bool
+}
+
+func (c *cacheRetirementObserver) Add(Message) error           { return nil }
+func (c *cacheRetirementObserver) Len() (int, error)           { return 0, nil }
+func (c *cacheRetirementObserver) Pop() (Message, bool, error) { return nil, false, nil }
+
+func (c *cacheRetirementObserver) Close() {
+	_, registered := c.session.mu.caches[c.cacheID]
+	c.registeredAtClose <- registered
+}
+
+func TestMessageCacheRetirementLinearizesBeforeRemoval(t *testing.T) {
+	newSessionWithCache := func(t *testing.T, ctx context.Context) (*clientSession, *cacheRetirementObserver) {
+		t.Helper()
+		cs := newClientSession(nil, newTestIOSession(nil, nil), nil, nil, nil)
+		t.Cleanup(func() { require.NoError(t, cs.Close()) })
+		cache := &cacheRetirementObserver{
+			session:           cs,
+			cacheID:           1,
+			registeredAtClose: make(chan bool, 1),
+		}
+		cs.mu.caches[1] = cacheWithContext{ctx: ctx, cache: cache}
+		return cs, cache
+	}
+	assertLinearized := func(t *testing.T, cache *cacheRetirementObserver) {
+		t.Helper()
+		select {
+		case registered := <-cache.registeredAtClose:
+			require.True(t, registered, "cache was removed before MessageCache.Close ran")
+		case <-time.After(time.Second):
+			t.Fatal("cache retirement did not close the cache")
+		}
+	}
+
+	t.Run("explicit delete", func(t *testing.T) {
+		cs, cache := newSessionWithCache(t, context.Background())
+		cs.DeleteCache(1)
+		assertLinearized(t, cache)
+		cached, err := cs.GetCache(1)
+		require.NoError(t, err)
+		require.Nil(t, cached)
+		require.NoError(t, cs.Close())
+	})
+
+	t.Run("session close", func(t *testing.T) {
+		cs, cache := newSessionWithCache(t, context.Background())
+		require.NoError(t, cs.Close())
+		assertLinearized(t, cache)
+	})
+
+	t.Run("request timeout", func(t *testing.T) {
+		ctx, expire := context.WithCancel(context.Background())
+		cs, cache := newSessionWithCache(t, ctx)
+		scanDone := make(chan struct{}, 1)
+		cs.messageCacheScanHook = func() { scanDone <- struct{}{} }
+		cs.startCheckCacheTimeout()
+		expire()
+		select {
+		case <-scanDone:
+		case <-time.After(2500 * time.Millisecond):
+			t.Fatal("message cache timeout scan did not complete")
+		}
+		assertLinearized(t, cache)
+		cached, err := cs.GetCache(1)
+		require.NoError(t, err)
+		require.Nil(t, cached)
+		require.NoError(t, cs.Close())
 	})
 }
 
@@ -796,6 +880,8 @@ func TestCancelableMessageCacheLifecycle(t *testing.T) {
 		require.NoError(t, cache.Add(newTestMessage(1)))
 		cs.DeleteCache(1)
 		require.Equal(t, int32(1), canceled.Load())
+		_, err = cache.Len()
+		require.Error(t, err)
 		require.NoError(t, cs.Close())
 		require.Equal(t, int32(1), canceled.Load())
 	})
@@ -803,7 +889,7 @@ func TestCancelableMessageCacheLifecycle(t *testing.T) {
 	t.Run("session close", func(t *testing.T) {
 		cs := newClientSession(nil, newTestIOSession(nil, nil), nil, nil, nil)
 		var canceled atomic.Int32
-		_, err := cs.CreateCacheWithCancel(
+		cache, err := cs.CreateCacheWithCancel(
 			context.Background(),
 			1,
 			func() { canceled.Add(1) },
@@ -811,6 +897,8 @@ func TestCancelableMessageCacheLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, cs.Close())
 		require.Equal(t, int32(1), canceled.Load())
+		_, err = cache.Len()
+		require.Error(t, err)
 	})
 
 	t.Run("all fragments", func(t *testing.T) {
@@ -832,6 +920,8 @@ func TestCancelableMessageCacheLifecycle(t *testing.T) {
 	t.Run("request timeout", func(t *testing.T) {
 		cs := newClientSession(nil, newTestIOSession(nil, nil), nil, nil, nil)
 		ctx, expire := context.WithCancel(context.Background())
+		scanDone := make(chan struct{}, 1)
+		cs.messageCacheScanHook = func() { scanDone <- struct{}{} }
 		var canceled atomic.Int32
 		cache, err := cs.CreateCacheWithCancel(
 			ctx,
@@ -840,9 +930,12 @@ func TestCancelableMessageCacheLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err)
 		expire()
-		require.Eventually(t, func() bool {
-			return canceled.Load() == 1
-		}, 2500*time.Millisecond, 10*time.Millisecond)
+		select {
+		case <-scanDone:
+		case <-time.After(2500 * time.Millisecond):
+			t.Fatal("message cache timeout scan did not complete")
+		}
+		require.Equal(t, int32(1), canceled.Load())
 		_, err = cache.Len()
 		require.Error(t, err)
 		require.NoError(t, cs.Close())
@@ -858,10 +951,14 @@ func TestCancelableMessageCacheCallbacksCanReenterSession(t *testing.T) {
 	) {
 		t.Helper()
 		callbackDone := make(chan struct{})
-		_, err := cs.CreateCacheWithCancel(
+		cacheClosed := make(chan error, 1)
+		var cache MessageCache
+		cache, err := cs.CreateCacheWithCancel(
 			context.Background(),
 			1,
 			func() {
+				_, err := cache.Len()
+				cacheClosed <- err
 				_, _ = cs.GetCache(1)
 				close(callbackDone)
 			},
@@ -877,6 +974,7 @@ func TestCancelableMessageCacheCallbacksCanReenterSession(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("cache cancel callback deadlocked while re-entering the session")
 		}
+		require.Error(t, <-cacheClosed, "cache must be closed before cancellation callbacks run")
 		select {
 		case <-triggerDone:
 		case <-time.After(time.Second):
@@ -900,7 +998,11 @@ func TestCancelableMessageCacheCallbacksCanReenterSession(t *testing.T) {
 		cs := newClientSession(nil, newTestIOSession(nil, nil), nil, nil, nil)
 		ctx, expire := context.WithCancel(context.Background())
 		callbackDone := make(chan struct{})
-		_, err := cs.CreateCacheWithCancel(ctx, 1, func() {
+		cacheClosed := make(chan error, 1)
+		var cache MessageCache
+		cache, err := cs.CreateCacheWithCancel(ctx, 1, func() {
+			_, err := cache.Len()
+			cacheClosed <- err
 			_, _ = cs.GetCache(1)
 			close(callbackDone)
 		})
@@ -911,6 +1013,7 @@ func TestCancelableMessageCacheCallbacksCanReenterSession(t *testing.T) {
 		case <-time.After(2500 * time.Millisecond):
 			t.Fatal("timeout cancel callback deadlocked while re-entering the session")
 		}
+		require.Error(t, <-cacheClosed, "cache must be closed before cancellation callbacks run")
 		require.NoError(t, cs.Close())
 	})
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Feature
- [ ] Documentation
- [ ] Examples
- [ ] Enhancement
- [ ] Tool
- [ ] Other

## Which issue(s) this PR fixes:

fixes #26590

## What this PR does / why we need it:

MORPC message-cache retirement previously removed a cache from the session registry before closing it. A concurrent holder could therefore observe the cache as undiscoverable while its old handle still accepted `Len`, `Add`, or `Pop`. The timeout scanner exposed this race in `TestServerTimeoutCacheWillRemoved`.

The root cause was coupling two different cleanup phases: internal cache closure and externally re-entrant transferred-context cancellation. Cancellation callbacks must run after releasing the session lock, but cache closure must be linearized with registry removal.

This change:

- closes each cache while holding the session registry lock, before removing it;
- runs transferred cancellation callbacks after unlocking, preserving callback re-entry safety;
- applies the same retirement invariant to timeout cleanup, explicit `DeleteCache`, and session `Close`;
- releases the closed cache's queue backing storage;
- adds event-driven white-box and real RPC regressions without sleeps or retries.

The normal request/happy path is unchanged. The additional synchronization is limited to cache retirement paths.

Validation:

- `TestServerTimeoutCacheWillRemoved`: race, 29 repetitions
- retirement linearization/lifecycle/re-entry tests: race, 30 repetitions each
- `TestCacheAdd|TestCachePop`: race, 100 repetitions
- full `./pkg/common/morpc`: race and normal
- `go build ./pkg/common/morpc` and `go vet ./pkg/common/morpc`
- `TestFragmentedPipelineCacheSurvivesHandlerRelease` in `./pkg/cnservice`: race
