### PR TITLE
test(fileservice): isolate external object storage integration

### DIFF
--- a/.github/workflows/object-storage-integration.yml
+++ b/.github/workflows/object-storage-integration.yml
@@ -1,6 +1,13 @@
 name: Object Storage Integration
 
 on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    branches: [main, 4.2-dev, '[0-9]+.[0-9]+*']
+    paths:
+      - "pkg/fileservice/**"
+      - "go.mod"
+      - "go.sum"
   workflow_dispatch:
   schedule:
     - cron: "30 18 * * *"
@@ -10,5 +17,17 @@ permissions:
 
 jobs:
   object-storage-integration:
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.draft == false &&
+        (
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||
+          contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+        )
+      )
     uses: matrixorigin/CI/.github/workflows/object-storage-integration.yaml@main
+    with:
+      checkout_repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      checkout_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/object-storage-integration.yml
+++ b/.github/workflows/object-storage-integration.yml
@@ -1,0 +1,14 @@
+name: Object Storage Integration
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 18 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  object-storage-integration:
+    uses: matrixorigin/CI/.github/workflows/object-storage-integration.yaml@main
+    secrets: inherit

--- a/pkg/fileservice/object_storage_arguments_test.go
+++ b/pkg/fileservice/object_storage_arguments_test.go
@@ -25,11 +25,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+const runExternalObjectStorageTestsEnv = "MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS"
 
 func TestObjectStorageArguments(t *testing.T) {
 
@@ -64,14 +65,29 @@ func TestObjectStorageArguments(t *testing.T) {
 	})
 }
 
-func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []ObjectStorageArguments) {
-
-	// disk
-	ret = append(ret, ObjectStorageArguments{
+func localObjectStorageArgumentsForTest(defaultName string, t *testing.T) []ObjectStorageArguments {
+	return []ObjectStorageArguments{{
 		Name:     defaultName,
 		Endpoint: "disk",
 		Bucket:   t.TempDir(),
-	})
+	}}
+}
+
+func shouldRunExternalObjectStorageTests(short bool, enabled string) bool {
+	return !short && enabled == "1"
+}
+
+func requireExternalObjectStorageTests(t *testing.T) {
+	t.Helper()
+	if shouldRunExternalObjectStorageTests(testing.Short(), os.Getenv(runExternalObjectStorageTestsEnv)) {
+		return
+	}
+	t.Skipf("external object storage tests require -short=false and %s=1", runExternalObjectStorageTestsEnv)
+}
+
+func externalObjectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []ObjectStorageArguments) {
+	t.Helper()
+	requireExternalObjectStorageTests(t)
 
 	// s3.json
 	content, err := os.ReadFile("s3.json")
@@ -86,19 +102,22 @@ func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []Obje
 				RoleARN   string `json:"role-arn"`
 			}
 
-			if err := json.Unmarshal(content, &config); err == nil {
-				ret = append(ret, ObjectStorageArguments{
-					Name:      "s3.json " + defaultName,
-					Endpoint:  config.Endpoint,
-					Region:    config.Region,
-					KeyID:     config.APIKey,
-					KeySecret: config.APISecret,
-					Bucket:    config.Bucket,
-					RoleARN:   config.RoleARN,
-					KeyPrefix: fmt.Sprintf("%v", rand.Int64()),
-				})
+			if err := json.Unmarshal(content, &config); err != nil {
+				t.Fatalf("parse s3.json: %v", err)
 			}
+			ret = append(ret, ObjectStorageArguments{
+				Name:      "s3.json " + defaultName,
+				Endpoint:  config.Endpoint,
+				Region:    config.Region,
+				KeyID:     config.APIKey,
+				KeySecret: config.APISecret,
+				Bucket:    config.Bucket,
+				RoleARN:   config.RoleARN,
+				KeyPrefix: fmt.Sprintf("%v", rand.Int64()),
+			})
 		}
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("read s3.json: %v", err)
 	}
 
 	// s3_fs_test_new.xml
@@ -108,15 +127,18 @@ func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []Obje
 			XMLName xml.Name               `xml:"Spec"`
 			Cases   []S3CredentialTestCase `xml:"Case"`
 		}
-		if err := xml.Unmarshal(content, &spec); err == nil {
-			for _, kase := range spec.Cases {
-				if kase.Skip {
-					continue
-				}
-				kase.KeyPrefix = fmt.Sprintf("%v", rand.Int64())
-				ret = append(ret, kase.ObjectStorageArguments)
-			}
+		if err := xml.Unmarshal(content, &spec); err != nil {
+			t.Fatalf("parse s3_fs_test_new.xml: %v", err)
 		}
+		for _, kase := range spec.Cases {
+			if kase.Skip {
+				continue
+			}
+			kase.KeyPrefix = fmt.Sprintf("%v", rand.Int64())
+			ret = append(ret, kase.ObjectStorageArguments)
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("read s3_fs_test_new.xml: %v", err)
 	}
 
 	// envs
@@ -137,20 +159,40 @@ func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []Obje
 		reader := csv.NewReader(strings.NewReader(value))
 		argStrs, err := reader.Read()
 		if err != nil {
-			logutil.Warn("bad S3FS test spec", zap.Any("spec", value))
-			continue
+			t.Fatalf("parse %s: %v", name, err)
 		}
 		var args ObjectStorageArguments
 		if err := args.SetFromString(argStrs); err != nil {
-			logutil.Warn("bad S3FS test spec", zap.Any("spec", value))
-			continue
+			t.Fatalf("parse %s: %v", name, err)
 		}
 		args.KeyPrefix = fmt.Sprintf("%v", rand.Int64())
 
 		ret = append(ret, args)
 	}
+	if len(ret) == 0 {
+		t.Fatalf("%s=1 but no external object storage test configuration was found", runExternalObjectStorageTestsEnv)
+	}
 
 	return ret
+}
+
+func TestShouldRunExternalObjectStorageTests(t *testing.T) {
+	testCases := []struct {
+		name    string
+		short   bool
+		enabled string
+		want    bool
+	}{
+		{name: "explicitly enabled", enabled: "1", want: true},
+		{name: "disabled by default"},
+		{name: "short mode wins", short: true, enabled: "1"},
+		{name: "invalid value", enabled: "true"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, shouldRunExternalObjectStorageTests(testCase.short, testCase.enabled))
+		})
+	}
 }
 
 func TestQCloudRegion(t *testing.T) {

--- a/pkg/fileservice/object_storage_test.go
+++ b/pkg/fileservice/object_storage_test.go
@@ -224,7 +224,16 @@ func testObjectStorageWithParentContext[T ObjectStorage](
 }
 
 func TestObjectStorages(t *testing.T) {
-	for _, args := range objectStorageArgumentsForTest("test", t) {
+	testObjectStorages(t, localObjectStorageArgumentsForTest("test", t))
+}
+
+func TestObjectStoragesExternal(t *testing.T) {
+	testObjectStorages(t, externalObjectStorageArgumentsForTest("test", t))
+}
+
+func testObjectStorages(t *testing.T, testArguments []ObjectStorageArguments) {
+	t.Helper()
+	for _, args := range testArguments {
 
 		t.Run(args.Name, func(t *testing.T) {
 			specCtx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)

--- a/pkg/fileservice/qcloud_sdk_test.go
+++ b/pkg/fileservice/qcloud_sdk_test.go
@@ -35,9 +35,10 @@ import (
 )
 
 func TestQCloudSDK(t *testing.T) {
+	testArguments := externalObjectStorageArgumentsForTest("test", t)
 
 	t.Run("object storage", func(t *testing.T) {
-		for _, args := range objectStorageArgumentsForTest("test", t) {
+		for _, args := range testArguments {
 			if !strings.Contains(args.Endpoint, "myqcloud") {
 				continue
 			}
@@ -62,7 +63,7 @@ func TestQCloudSDK(t *testing.T) {
 	})
 
 	t.Run("file service", func(t *testing.T) {
-		for _, args := range objectStorageArgumentsForTest("test", t) {
+		for _, args := range testArguments {
 			if !strings.Contains(args.Endpoint, "myqcloud") {
 				continue
 			}

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -1508,13 +1508,14 @@ type S3CredentialTestCase struct {
 	ObjectStorageArguments
 }
 
-var s3CredentialTestCases = func() []S3CredentialTestCase {
+func s3CredentialTestCasesForTest(t *testing.T) []S3CredentialTestCase {
+	t.Helper()
 	content, err := os.ReadFile("s3_fs_test_new.xml")
 	if os.IsNotExist(err) {
 		return nil
 	}
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	var spec struct {
 		XMLName xml.Name               `xml:"Spec"`
@@ -1522,12 +1523,14 @@ var s3CredentialTestCases = func() []S3CredentialTestCase {
 	}
 	err = xml.Unmarshal(content, &spec)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	return spec.Cases
-}()
+}
 
 func TestNewS3FSFromSpec(t *testing.T) {
+	requireExternalObjectStorageTests(t)
+	s3CredentialTestCases := s3CredentialTestCasesForTest(t)
 	if len(s3CredentialTestCases) == 0 {
 		t.Skip("no case")
 	}
@@ -1748,8 +1751,16 @@ func BenchmarkS3FSAllocateCacheData(b *testing.B) {
 }
 
 func TestS3FSFromSpecs(t *testing.T) {
+	testS3FSFromSpecs(t, localObjectStorageArgumentsForTest("test", t))
+}
 
-	for _, args := range objectStorageArgumentsForTest("test", t) {
+func TestS3FSFromExternalSpecs(t *testing.T) {
+	testS3FSFromSpecs(t, externalObjectStorageArgumentsForTest("test", t))
+}
+
+func testS3FSFromSpecs(t *testing.T, testArguments []ObjectStorageArguments) {
+	t.Helper()
+	for _, args := range testArguments {
 
 		t.Run(args.Name, func(t *testing.T) {
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26541

## What this PR does / why we need it:

### Root cause

`objectStorageArgumentsForTest` mixed two test tiers. It always added a local disk backend, but it also discovered `s3.json`, `s3_fs_test_new.xml`, and every ambient `TEST_S3FS_*` variable. Coverage CI exported real Aliyun and QCloud credentials while running `go test -short`, so ordinary UT coverage executed cross-cloud integration tests.

The reported failure was a TCP connect timeout from a Tencent Guangzhou TKE runner to Aliyun OSS. DNS resolved and no HTTP response was received. The same commit passed on rerun with a different ephemeral runner. Credentials, request semantics, SDK implementation, memory, and disk are therefore not the direct cause; the defect is allowing an external network dependency into the required short-test path.

### Changes

- split local and external object-storage argument sources
- keep the existing object-storage and S3FS contract assertions shared between both tiers
- require both non-short mode and `MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS=1` before reading external configuration or contacting a provider
- fail closed when explicitly enabled integration configuration is missing or malformed
- move XML integration configuration loading out of package initialization
- run real Aliyun/QCloud integration tests before merge when a PR changes `pkg/fileservice`, `go.mod`, or `go.sum`
- retain a daily/manual integration run to detect provider, credential, or network drift independently of code changes

The PR trigger checks out the exact head commit only for repository members/collaborators or PRs explicitly labeled `safe-to-test`, preserving the security boundary required by `pull_request_target` and cloud secrets. Unrelated PRs do not allocate an object-storage integration runner.

### Compatibility and rollout

Merge matrixorigin/CI#416 first, then this PR. Developers who intentionally run real object-storage tests must now use non-short mode and set `MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS=1`; relying on ambient `TEST_S3FS_*` variables alone is intentionally no longer supported.

There is no production-code, API, wire-format, storage-format, or runtime behavior change.

### Validation

- full `go test -short ./pkg/fileservice -count=1` with Aliyun and QCloud test variables deliberately pointed at `127.0.0.1:1`: passed in 28.275s without external connection attempts
- full `go test ./pkg/fileservice -count=1` with external integration disabled: passed in 27.919s
- focused local/external tier tests in short and normal modes: passed; external tests reported explicit skips unless both opt-in conditions were met
- `go vet ./pkg/fileservice`
- `actionlint` v1.7.7 on the MatrixOne caller and both paired CI workflows; known custom-runner and existing `job.workflow_*` false positives excluded
- `git diff --check`
