### PR TITLE
fix: restore protocol version after planner test

### DIFF
--- a/pkg/sql/plan/build_util_test.go
+++ b/pkg/sql/plan/build_util_test.go
@@ -603,7 +603,17 @@ func TestAssignmentCastPreservesNestedExplicitTemporalCast(t *testing.T) {
 // (cast_strict): an over-length value is rejected, not silently truncated.
 func TestBuildGeneratedExprUsesStrictForCharVarchar(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	moruntime.ServiceRuntime(proc.GetService()).SetGlobalVariables(
+	rt := moruntime.ServiceRuntime(proc.GetService())
+	original, hadOriginal := rt.GetGlobalVariables(moruntime.MOProtocolVersion)
+	t.Cleanup(func() {
+		if hadOriginal {
+			rt.SetGlobalVariables(moruntime.MOProtocolVersion, original)
+		} else {
+			rt.SetGlobalVariables(
+				moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
+		}
+	})
+	rt.SetGlobalVariables(
 		moruntime.MOProtocolVersion,
 		defines.MORPCVersion5,
 	)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26625

## What this PR does / why we need it:

`TestBuildGeneratedExprUsesStrictForCharVarchar` changes the shared empty-service runtime's `MOProtocolVersion` to v5 but did not restore it. Later planner tests in the same CI shard therefore observed a stale pre-rollout protocol and disabled fuzzy runtime filters.

Register cleanup before changing the shared value and restore the previous protocol version when the test completes. This change is test-only and does not alter planner or runtime-filter production behavior.

Tested with:

`go test -short -race -tags matrixone_test -count=1 -run '^(TestBuildGeneratedExprUsesStrictForCharVarchar|TestFinalizeFuzzyRuntimeFilterKeepsDecisionAtomic)$' ./pkg/sql/plan`

`go test -short -race -tags matrixone_test -count=100 -run '^TestBuildGeneratedExprUsesStrictForCharVarchar$' ./pkg/sql/plan`

`go test -short -race -tags matrixone_test -count=100 -run '^TestFinalizeFuzzyRuntimeFilterKeepsDecisionAtomic$' ./pkg/sql/plan`

`go test -short -race -tags matrixone_test -count=1 ./pkg/sql/plan`

`go build -tags matrixone_test ./pkg/sql/plan`

`go vet -tags matrixone_test ./pkg/sql/plan`
