### PR TITLE
fix(hashbuild): preserve shared spill recovery ownership

### DIFF
--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -518,15 +518,12 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		}
 	}
 
-	// spillBatchBounded flushes each selected bucket immediately; no persistent
-	// 32-bucket vectors remain here. Flush any records retained by a legacy
-	// unbudgeted caller before rewinding every file and publishing the complete
-	// set, including a spill entered after hard map-budget rejection.
+	// spillBatchBounded writes each selected bucket immediately; no persistent
+	// 32-bucket vectors or pending records remain here. Rewind every file before
+	// publishing the complete set, including a spill entered after hard
+	// map-budget rejection.
 	if spillMode {
 		if err := checkHashBuildCanceled(proc); err != nil {
-			return err
-		}
-		if err := ctr.flushSpillBuffers(proc, spillFiles, analyzer); err != nil {
 			return err
 		}
 		for _, f := range spillFiles {

--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -243,23 +243,6 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 		}
 		return ctr.ensureRetainedSpillRecovery(projection, analyzer)
 	}
-	ensureDirectRecoveryWithReclaim := func(bat *batch.Batch) error {
-		err := ensureDirectRecovery(bat)
-		if !spillMode || !errors.Is(err, process.ErrHashBuildBudgetAdmission) {
-			return err
-		}
-		reclaimed, reclaimErr := ctr.reclaimOptionalSpillCoalesce(
-			proc, spillFiles, analyzer)
-		if reclaimErr != nil {
-			return reclaimErr
-		}
-		if !reclaimed {
-			// The rejection came from mandatory owners or sibling pressure. A
-			// second identical admission cannot make progress.
-			return err
-		}
-		return ensureDirectRecovery(bat)
-	}
 	spillBatch := func(bat *batch.Batch, sourceAlreadyCharged bool) error {
 		return ctr.spillBatchBounded(
 			proc,
@@ -353,7 +336,7 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 			return err
 		}
 		if hashBuild.IsShuffle {
-			if err := ensureDirectRecoveryWithReclaim(bat); err != nil {
+			if err := ensureDirectRecovery(bat); err != nil {
 				return err
 			}
 		}
@@ -427,8 +410,7 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 				// The source batch is still owned by the upstream operator.  Do
 				// not retry CopyIntoBatches (or increment row count again). Every
 				// direct transition drains older retained copies under their existing
-				// guarantee, then gives mandatory recovery priority over optional
-				// write coalescing before writing this upstream-owned batch.
+				// guarantee before writing this upstream-owned batch.
 				if err := spillDirect(result.Batch); err != nil {
 					return err
 				}
@@ -537,9 +519,9 @@ func (hashBuild *HashBuild) build(proc *process.Process, analyzer process.Analyz
 	}
 
 	// spillBatchBounded flushes each selected bucket immediately; no persistent
-	// 32-bucket vectors remain here. Flush serialized records accumulated across
-	// source batches before rewinding every file and publishing the
-	// complete set, including a spill entered after hard map-budget rejection.
+	// 32-bucket vectors remain here. Flush any records retained by a legacy
+	// unbudgeted caller before rewinding every file and publishing the complete
+	// set, including a spill entered after hard map-budget rejection.
 	if spillMode {
 		if err := checkHashBuildCanceled(proc); err != nil {
 			return err

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -2655,9 +2655,8 @@ func TestShuffleHashBuildSpillsBeforeRetainingThresholdCrossingBatch(t *testing.
 	// Admit the first recovery lease and its retained-copy allocation together.
 	// The second batch crosses the local threshold and must be spilled directly,
 	// without a second retained copy or any failed shared-budget admission.
-	coalesceSlack := uint64(spillNumBuckets * spillWriteCoalesceSize)
 	capBytes := max(directRecovery, retainedRecovery) +
-		projection.admissionBytes + coalesceSlack
+		projection.admissionBytes
 	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
 	generation, err := budget.OpenGeneration(1)
 	require.NoError(t, err)
@@ -3142,7 +3141,7 @@ func TestShuffleHashBuildRecoveryAdmissionFailsBeforeRetain(t *testing.T) {
 	require.Zero(t, tc.proc.Mp().CurrNB())
 }
 
-func TestShuffleHashBuildSpillModeReclaimsOptionalCacheForRecoveryGrowth(t *testing.T) {
+func TestShuffleHashBuildSpillModePreservesRecoveryGrowthHeadroom(t *testing.T) {
 	tc := newTestCase(t, []bool{false}, []types.Type{types.T_int32.ToType()}, []*plan.Expr{newExpr(0, types.T_int32.ToType())})
 	tc.arg.IsShuffle = true
 	tc.arg.ShuffleIdx = 0
@@ -3162,8 +3161,8 @@ func TestShuffleHashBuildSpillModeReclaimsOptionalCacheForRecoveryGrowth(t *test
 	require.NoError(t, err)
 	secondNeed, err = spillRecoveryReservationBytes(secondNeed)
 	require.NoError(t, err)
-	require.Equal(t, firstNeed+uint64(spillWriteCoalesceSize), secondNeed,
-		"fixture needs one optional-cache quantum between recovery high waters")
+	require.Equal(t, firstNeed+spillRecoveryReservationQuantum, secondNeed,
+		"fixture needs one mandatory recovery quantum between high waters")
 
 	budget := process.MustNewHashBuildBudget(secondNeed, secondNeed)
 	generation, err := budget.OpenGeneration(1)
@@ -3192,13 +3191,11 @@ func TestShuffleHashBuildSpillModeReclaimsOptionalCacheForRecoveryGrowth(t *test
 
 	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
 	require.Equal(t, int64(1), extra["HashBuildSpillStarts"])
-	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowRejects"])
+	require.Zero(t, extra["HashBuildSpillRecoveryGrowRejects"])
 	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowCount"])
 	require.Equal(t, int64(secondNeed-firstNeed),
 		extra["HashBuildSpillRecoveryGrowBytes"])
-	require.Equal(t, int64(1), extra["HashBuildCoalesceGrowRejects"],
-		"one failed optional probe switches the rest of this batch to write-through")
-	require.Equal(t, int64(2), extra["QueryHashBudgetRejects"])
+	require.Zero(t, extra["QueryHashBudgetRejects"])
 	require.Zero(t, generation.Used())
 	require.Zero(t, generation.SpillDiskUsed())
 	require.Zero(t, generation.SpillFDUsed())
@@ -3233,7 +3230,7 @@ func TestShuffleHashBuildSpillModeGrowthRejectReleasesRecoveryLease(t *testing.T
 	require.NoError(t, err)
 	secondNeed, err = spillRecoveryReservationBytes(secondNeed)
 	require.NoError(t, err)
-	capBytes := firstNeed + uint64(spillWriteCoalesceSize)
+	capBytes := firstNeed + spillRecoveryReservationQuantum
 	require.Greater(t, secondNeed, capBytes)
 
 	budget := process.MustNewHashBuildBudget(capBytes, capBytes)
@@ -3250,10 +3247,9 @@ func TestShuffleHashBuildSpillModeGrowthRejectReleasesRecoveryLease(t *testing.T
 
 	extra := tc.arg.OpAnalyzer.GetOpStats().ExtraStats
 	require.Equal(t, int64(1), extra["HashBuildSpillStarts"])
-	require.Equal(t, int64(2), extra["HashBuildSpillRecoveryGrowRejects"],
-		"reclaim retries once, then preserves a genuine over-cap failure")
-	require.Zero(t, extra["HashBuildCoalesceGrowRejects"])
-	require.Equal(t, int64(2), extra["QueryHashBudgetRejects"])
+	require.Equal(t, int64(1), extra["HashBuildSpillRecoveryGrowRejects"],
+		"a genuine over-cap recovery request fails once without a futile retry")
+	require.Equal(t, int64(1), extra["QueryHashBudgetRejects"])
 	require.Nil(t, tc.arg.ctr.spillScratchReservation)
 	require.Zero(t, tc.arg.ctr.spillScratchBase)
 	require.Zero(t, generation.Used())

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -34,9 +34,6 @@ import (
 const (
 	spillNumBuckets = 32
 	spillMagic      = 0x12345678DEADBEEF
-	// Legacy unbudgeted callers may accumulate serialized records per bucket
-	// across source batches. Hard-budgeted execution always writes through.
-	spillWriteCoalesceSize = 64 << 10
 )
 
 func spillCheckedAdd(total, value uint64) (uint64, error) {
@@ -464,10 +461,6 @@ func (ctr *container) releaseSpillScratchReservation() {
 }
 
 func (ctr *container) dropSpillScratchBuffers() {
-	for bucket := range ctr.spillBucketWriteBufs {
-		ctr.spillBucketWriteBufs[bucket] = bytes.Buffer{}
-		ctr.spillBucketWriteRows[bucket] = 0
-	}
 	ctr.spillHashValues = nil
 	ctr.spillBucketRowIds = nil
 	for i := range ctr.spillBucketCounts {
@@ -644,9 +637,7 @@ func (ctr *container) ensureSpillFile(proc *process.Process, files []*os.File, b
 // vectors. Hash values are classified with two linear passes (count, then
 // scatter after prefix offsets), and a single row-id array describes every
 // bucket. One selected batch is reused as each bucket is materialized and
-// marshaled before advancing. Hard-budgeted records are written through;
-// legacy unbudgeted callers may coalesce them until the bounded buffers or
-// final handoff flush.
+// marshaled and written before advancing.
 func (ctr *container) spillBatchBounded(
 	proc *process.Process,
 	bat *batch.Batch,
@@ -851,10 +842,9 @@ func (ctr *container) spillBatchBounded(
 	return nil
 }
 
-// appendSpillRecord writes one framed record immediately for hard-budgeted
-// execution. Legacy unbudgeted callers may append it to a bounded bucket
-// buffer; full buffers are written before accepting the next record and an
-// oversized record is always written directly.
+// appendSpillRecord writes one framed record immediately. HashBuild workers do
+// not retain optional file-bound data that could consume a sibling worker's
+// mandatory recovery headroom.
 func (ctr *container) appendSpillRecord(
 	proc *process.Process,
 	file *os.File,
@@ -891,96 +881,7 @@ func (ctr *container) appendSpillRecord(
 		return err
 	}
 	payload := ctr.spillWriteBuf.Bytes()
-	// A hard-budgeted HashBuild writes through. Pending coalesce data is an
-	// optional owner that cannot be reclaimed safely by a sibling worker: the
-	// sibling neither owns its file nor can wait for it without adding a
-	// shuffle wait-for edge. Keeping optional bytes out of budgeted executions
-	// therefore preserves every worker's already-admitted recovery ownership.
-	// Unbudgeted callers may retain the legacy bounded cache.
-	if ctr.hashmapBuilder.budget != nil {
-		return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
-	}
-	buf := &ctr.spillBucketWriteBufs[bucket]
-	if buf.Len() > 0 && buf.Len()+len(payload) > spillWriteCoalesceSize {
-		if err := ctr.flushPendingSpillBucket(proc, file, bucket, analyzer); err != nil {
-			return err
-		}
-	}
-	if len(payload) > spillWriteCoalesceSize {
-		return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
-	}
-	if buf.Len() == 0 {
-		if buf.Cap() < spillWriteCoalesceSize {
-			*buf = *bytes.NewBuffer(make([]byte, 0, spillWriteCoalesceSize))
-		}
-	}
-	_, _ = buf.Write(payload)
-	ctr.spillBucketWriteRows[bucket] += cnt
-	if buf.Len() >= spillWriteCoalesceSize {
-		return ctr.flushPendingSpillBucket(proc, file, bucket, analyzer)
-	}
-	return nil
-}
-
-func (ctr *container) flushPendingSpillBucket(
-	proc *process.Process,
-	file *os.File,
-	bucket int,
-	analyzer process.Analyzer,
-) error {
-	if bucket < 0 || bucket >= spillNumBuckets {
-		return process.ErrHashBuildBudgetInvalid
-	}
-	buf := &ctr.spillBucketWriteBufs[bucket]
-	if buf.Len() == 0 {
-		return nil
-	}
-	rows := ctr.spillBucketWriteRows[bucket]
-	payload := buf.Bytes()
-	err := ctr.writeSpillPayload(proc, file, payload, rows, analyzer)
-	// Clear even on a failed/partial write. A caller's enclosing failure path
-	// owns cleanup, and retrying the same bytes could duplicate records.
-	buf.Reset()
-	ctr.spillBucketWriteRows[bucket] = 0
-	return err
-}
-
-// flushSpillBuffers writes all pending bucket records before files are rewound
-// or handed to JoinMap. Cancellation is checked between physical writes. After
-// the first error, the remaining buffers are discarded rather than written, so
-// every buffer still reaches a terminal state without doing doomed I/O.
-func (ctr *container) flushSpillBuffers(proc *process.Process, files []*os.File, analyzer process.Analyzer) error {
-	var firstErr error
-	for bucket := 0; bucket < spillNumBuckets; bucket++ {
-		if ctr.spillBucketWriteBufs[bucket].Len() == 0 {
-			continue
-		}
-		if firstErr != nil {
-			ctr.spillBucketWriteBufs[bucket].Reset()
-			ctr.spillBucketWriteRows[bucket] = 0
-			continue
-		}
-		if err := checkHashBuildCanceled(proc); err != nil {
-			firstErr = err
-			ctr.spillBucketWriteBufs[bucket].Reset()
-			ctr.spillBucketWriteRows[bucket] = 0
-			continue
-		}
-		var file *os.File
-		if bucket < len(files) {
-			file = files[bucket]
-		}
-		if file == nil {
-			firstErr = process.ErrHashBuildBudgetInvalid
-			ctr.spillBucketWriteBufs[bucket].Reset()
-			ctr.spillBucketWriteRows[bucket] = 0
-			continue
-		}
-		if err := ctr.flushPendingSpillBucket(proc, file, bucket, analyzer); err != nil {
-			firstErr = err
-		}
-	}
-	return firstErr
+	return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
 }
 
 func (ctr *container) memUsed() int64 {

--- a/pkg/sql/colexec/hashbuild/spill.go
+++ b/pkg/sql/colexec/hashbuild/spill.go
@@ -16,7 +16,6 @@ package hashbuild
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -35,9 +34,8 @@ import (
 const (
 	spillNumBuckets = 32
 	spillMagic      = 0x12345678DEADBEEF
-	// Serialized records are accumulated per bucket across source batches.
-	// Allocation is admitted lazily against the lifecycle scratch lease and
-	// falls back to direct writes when the hard budget has no headroom.
+	// Legacy unbudgeted callers may accumulate serialized records per bucket
+	// across source batches. Hard-budgeted execution always writes through.
 	spillWriteCoalesceSize = 64 << 10
 )
 
@@ -449,31 +447,6 @@ func (ctr *container) growSpillScratchTransient(
 	return oldSize, true, nil
 }
 
-// growSpillScratchTransientWithReclaim gives a mandatory replacement overlap
-// one deterministic retry after returning optional coalesce ownership. Callers
-// invoke it before mutating the allocation being replaced; flushing previously
-// buffered records is therefore safe and the current allocation is never
-// replayed.
-func (ctr *container) growSpillScratchTransientWithReclaim(
-	proc *process.Process,
-	files []*os.File,
-	required uint64,
-	analyzer process.Analyzer,
-) (uint64, bool, error) {
-	oldSize, grew, err := ctr.growSpillScratchTransient(required, analyzer)
-	if !errors.Is(err, process.ErrHashBuildBudgetAdmission) {
-		return oldSize, grew, err
-	}
-	reclaimed, reclaimErr := ctr.reclaimOptionalSpillCoalesce(proc, files, analyzer)
-	if reclaimErr != nil {
-		return 0, false, reclaimErr
-	}
-	if !reclaimed {
-		return 0, false, err
-	}
-	return ctr.growSpillScratchTransient(required, analyzer)
-}
-
 func (ctr *container) restoreSpillScratchTransient(oldSize uint64, grew bool) error {
 	if !grew {
 		return nil
@@ -506,42 +479,6 @@ func (ctr *container) dropSpillScratchBuffers() {
 	ctr.spillSelection = nil
 	ctr.spillKeyVecs = nil
 	ctr.spillWriteBuf = bytes.Buffer{}
-}
-
-// reclaimOptionalSpillCoalesce gives mandatory recovery reservations priority
-// over the write-coalescing cache. It is called only at a quiescent mandatory
-// allocation boundary: between spill batches or before the current bucket's
-// replacement allocation. Transient scratch has been restored there, so every
-// byte above spillScratchBase is owned by optional per-bucket caches. Flush
-// their pending records, drop their backing, and return that charge to the
-// recovery floor before retrying mandatory admission once.
-func (ctr *container) reclaimOptionalSpillCoalesce(
-	proc *process.Process,
-	files []*os.File,
-	analyzer process.Analyzer,
-) (bool, error) {
-	if ctr.spillScratchReservation == nil {
-		if ctr.spillScratchBase != 0 {
-			return false, process.ErrHashBuildBudgetInvalid
-		}
-		return false, nil
-	}
-	current := ctr.spillScratchReservation.Size()
-	if current < ctr.spillScratchBase {
-		return false, process.ErrHashBuildBudgetInvalid
-	}
-	if current == ctr.spillScratchBase {
-		return false, nil
-	}
-	if err := ctr.flushSpillBuffers(proc, files, analyzer); err != nil {
-		return false, err
-	}
-	for bucket := range ctr.spillBucketWriteBufs {
-		ctr.spillBucketWriteBufs[bucket] = bytes.Buffer{}
-		ctr.spillBucketWriteRows[bucket] = 0
-	}
-	_, err := ctr.spillScratchReservation.ReconcileDown(ctr.spillScratchBase)
-	return err == nil, err
 }
 
 func spillMarshalGrowBytes(bat *batch.Batch) (uint64, error) {
@@ -707,8 +644,9 @@ func (ctr *container) ensureSpillFile(proc *process.Process, files []*os.File, b
 // vectors. Hash values are classified with two linear passes (count, then
 // scatter after prefix offsets), and a single row-id array describes every
 // bucket. One selected batch is reused as each bucket is materialized and
-// marshaled before advancing; serialized records are coalesced until the
-// bounded buffers or final handoff flush.
+// marshaled before advancing. Hard-budgeted records are written through;
+// legacy unbudgeted callers may coalesce them until the bounded buffers or
+// final handoff flush.
 func (ctr *container) spillBatchBounded(
 	proc *process.Process,
 	bat *batch.Batch,
@@ -781,8 +719,8 @@ func (ctr *container) spillBatchBounded(
 	if err != nil {
 		return err
 	}
-	oldScratchSize, grewScratch, err := ctr.growSpillScratchTransientWithReclaim(
-		proc, files, replacementPeak, analyzer)
+	oldScratchSize, grewScratch, err := ctr.growSpillScratchTransient(
+		replacementPeak, analyzer)
 	if err != nil {
 		return err
 	}
@@ -862,11 +800,6 @@ func (ctr *container) spillBatchBounded(
 		writePos[bucket] = pos + 1
 	}
 
-	// Coalescing is optional. Once one bucket cannot admit a new cache in this
-	// batch, later buckets without an already-owned cache write through instead
-	// of repeating the same fanout-sized budget rejection. The next ingress
-	// batch probes again, so released sibling headroom is still discoverable.
-	allowNewCoalesce := true
 	for bucket := 0; bucket < spillNumBuckets; bucket++ {
 		if err := checkHashBuildCanceled(proc); err != nil {
 			return err
@@ -907,7 +840,7 @@ func (ctr *container) spillBatchBounded(
 			file, spillErr = ctr.ensureSpillFile(proc, files, int(bucket))
 			if spillErr == nil {
 				spillErr = ctr.appendSpillRecord(
-					proc, files, file, int(bucket), selected, need, analyzer, &allowNewCoalesce)
+					proc, file, int(bucket), selected, need, analyzer)
 			}
 		}
 		selected.CleanOnlyData()
@@ -918,19 +851,17 @@ func (ctr *container) spillBatchBounded(
 	return nil
 }
 
-// appendSpillRecord appends one framed record to the bucket's bounded write
-// buffer. Full buffers are written before accepting the next record. A record
-// larger than the coalescing target is written directly, so no unbounded
-// temporary copy can be retained.
+// appendSpillRecord writes one framed record immediately for hard-budgeted
+// execution. Legacy unbudgeted callers may append it to a bounded bucket
+// buffer; full buffers are written before accepting the next record and an
+// oversized record is always written directly.
 func (ctr *container) appendSpillRecord(
 	proc *process.Process,
-	files []*os.File,
 	file *os.File,
 	bucket int,
 	bat *batch.Batch,
 	scratchNeed uint64,
 	analyzer process.Analyzer,
-	allowNewCoalesce *bool,
 ) error {
 	if bucket < 0 || bucket >= spillNumBuckets {
 		return process.ErrHashBuildBudgetInvalid
@@ -946,8 +877,8 @@ func (ctr *container) appendSpillRecord(
 		if addErr != nil {
 			return addErr
 		}
-		oldScratchSize, grewScratch, err = ctr.growSpillScratchTransientWithReclaim(
-			proc, files, peak, analyzer)
+		oldScratchSize, grewScratch, err = ctr.growSpillScratchTransient(
+			peak, analyzer)
 		if err != nil {
 			return err
 		}
@@ -960,6 +891,15 @@ func (ctr *container) appendSpillRecord(
 		return err
 	}
 	payload := ctr.spillWriteBuf.Bytes()
+	// A hard-budgeted HashBuild writes through. Pending coalesce data is an
+	// optional owner that cannot be reclaimed safely by a sibling worker: the
+	// sibling neither owns its file nor can wait for it without adding a
+	// shuffle wait-for edge. Keeping optional bytes out of budgeted executions
+	// therefore preserves every worker's already-admitted recovery ownership.
+	// Unbudgeted callers may retain the legacy bounded cache.
+	if ctr.hashmapBuilder.budget != nil {
+		return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
+	}
 	buf := &ctr.spillBucketWriteBufs[bucket]
 	if buf.Len() > 0 && buf.Len()+len(payload) > spillWriteCoalesceSize {
 		if err := ctr.flushPendingSpillBucket(proc, file, bucket, analyzer); err != nil {
@@ -970,16 +910,6 @@ func (ctr *container) appendSpillRecord(
 		return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
 	}
 	if buf.Len() == 0 {
-		if buf.Cap() < spillWriteCoalesceSize &&
-			allowNewCoalesce != nil && !*allowNewCoalesce {
-			return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
-		}
-		if !ctr.ensureSpillCoalesceCapacity(buf, analyzer) {
-			if allowNewCoalesce != nil {
-				*allowNewCoalesce = false
-			}
-			return ctr.writeSpillPayload(proc, file, payload, cnt, analyzer)
-		}
 		if buf.Cap() < spillWriteCoalesceSize {
 			*buf = *bytes.NewBuffer(make([]byte, 0, spillWriteCoalesceSize))
 		}
@@ -990,27 +920,6 @@ func (ctr *container) appendSpillRecord(
 		return ctr.flushPendingSpillBucket(proc, file, bucket, analyzer)
 	}
 	return nil
-}
-
-func (ctr *container) ensureSpillCoalesceCapacity(buf *bytes.Buffer, analyzer process.Analyzer) bool {
-	if buf == nil || buf.Cap() >= spillWriteCoalesceSize {
-		return true
-	}
-	if ctr.hashmapBuilder.budget == nil || ctr.spillScratchReservation == nil {
-		return ctr.hashmapBuilder.budget == nil
-	}
-	additional := uint64(spillWriteCoalesceSize - buf.Cap())
-	if err := ctr.spillScratchReservation.Grow(additional); err != nil {
-		analyzer.GetOpStats().AddExtraStat("HashBuildCoalesceGrowRejects", 1)
-		return false
-	}
-	analyzer.GetOpStats().AddExtraStat("HashBuildCoalesceGrowCount", 1)
-	analyzer.GetOpStats().AddExtraStat("HashBuildCoalesceGrowBytes", hashBuildStatInt64(additional))
-	analyzer.GetOpStats().SetMaxExtraStat(
-		"HashBuildSpillScratchPeakBytes",
-		hashBuildStatInt64(ctr.spillScratchReservation.Size()),
-	)
-	return true
 }
 
 func (ctr *container) flushPendingSpillBucket(

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -15,10 +15,8 @@
 package hashbuild
 
 import (
-	"bufio"
 	"bytes"
 	"context"
-	"io"
 	"math"
 	"os"
 	"strings"
@@ -373,8 +371,6 @@ func TestSpillBatchPartitioning(t *testing.T) {
 	defer ctr.hashmapBuilder.FreeExecutors()
 	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
-
 	hashes := make([]uint64, bat.RowCount())
 	computeXXHash(bat.Vecs, hashes)
 	expectedBuckets := make(map[int]struct{})
@@ -470,7 +466,6 @@ func TestSpillBatchLargeInputPreservesRows(t *testing.T) {
 	defer ctr.hashmapBuilder.FreeExecutors()
 	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
 	require.Equal(t, int64(bat.RowCount()), analyzer.GetOpStats().SpillRows)
 }
 
@@ -509,7 +504,6 @@ func TestSpillBatchNullKeyPreservesRows(t *testing.T) {
 	defer ctr.hashmapBuilder.FreeExecutors()
 	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
 	require.Equal(t, int64(bat.RowCount()), analyzer.GetOpStats().SpillRows)
 }
 
@@ -555,7 +549,6 @@ func TestSpillBatchMultiColumnPreservesRows(t *testing.T) {
 	defer ctr.hashmapBuilder.FreeExecutors()
 	err = ctr.spillBatchBounded(proc, bat, files, analyzer, false)
 	require.NoError(t, err)
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
 	require.Equal(t, int64(bat.RowCount()), analyzer.GetOpStats().SpillRows)
 }
 
@@ -682,7 +675,6 @@ func TestSpillBatchSingleRowUsesOneBucket(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, nonEmptyBuckets)
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
 	require.Equal(t, int64(1), analyzer.GetOpStats().SpillRows)
 }
 
@@ -738,7 +730,6 @@ func TestSpillScratchSlicesReuseAcrossEqualBatches(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, firstHashStorage, &ctr.spillHashValues[0])
 	require.Same(t, firstRowIDStorage, &ctr.spillBucketRowIds[0])
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
 	require.Equal(t, int64(4), analyzer.GetOpStats().SpillRows)
 }
 
@@ -785,96 +776,11 @@ func TestSpillExpressionLeaseRetainsLargeBatchHighWater(t *testing.T) {
 	require.LessOrEqual(t, retained, ctr.hashmapBuilder.expressionLease.Reserved())
 }
 
-func TestUnbudgetedSpillWriteCoalescesAcrossBatches(t *testing.T) {
-	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
-	defer proc.Free()
-	files := make([]*os.File, spillNumBuckets)
-	conditions := []*plan.Expr{{
-		Typ:  plan.Type{Id: int32(types.T_int32)},
-		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
-	}}
-	ctr := &container{spillUUID: t.Name()}
-	cleanup := func() {
-		for i, file := range files {
-			if file != nil {
-				_ = file.Close()
-				files[i] = nil
-			}
-		}
-		if ctr.spillBundle != nil {
-			ctr.spillBundle.release()
-			ctr.spillBundle = nil
-		}
-		ctr.hashmapBuilder.FreeExecutors()
-		ctr.dropSpillScratchBuffers()
-		ctr.releaseSpillScratchReservation()
-	}
-	defer cleanup()
-	err := initSpillExprExecsForTest(ctr, proc, conditions)
-	require.NoError(t, err)
-	analyzer := process.NewAnalyzer(0, false, false, "test")
-	bat := batch.NewWithSize(1)
-	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 1, 1}, nil, proc.Mp())
-	bat.SetRowCount(3)
-	defer bat.Clean(proc.Mp())
-	for i := 0; i < 2; i++ {
-		require.NoError(t, ctr.spillBatchBounded(proc, bat, files, analyzer, false))
-	}
-	var pending int
-	for i := range ctr.spillBucketWriteBufs {
-		pending += ctr.spillBucketWriteBufs[i].Len()
-	}
-	require.Positive(t, pending)
-	var file *os.File
-	for _, f := range files {
-		if f != nil {
-			file = f
-			break
-		}
-	}
-	require.NotNil(t, file)
-	stat, err := file.Stat()
-	require.NoError(t, err)
-	require.Zero(t, stat.Size(), "records stay pending until the handoff flush")
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
-	stat, err = file.Stat()
-	require.NoError(t, err)
-	require.Positive(t, stat.Size())
-	for i := range ctr.spillBucketWriteBufs {
-		require.Zero(t, ctr.spillBucketWriteBufs[i].Len())
-	}
-	_, err = file.Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	reader := bufio.NewReader(file)
-	var totalRows int64
-	for {
-		var header [16]byte
-		_, err = io.ReadFull(reader, header[:])
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-		cnt := types.DecodeInt64(header[:8])
-		payload := types.DecodeInt64(header[8:])
-		require.GreaterOrEqual(t, cnt, int64(0))
-		require.GreaterOrEqual(t, payload, int64(0))
-		_, err = io.CopyN(io.Discard, reader, payload)
-		require.NoError(t, err)
-		var magic [8]byte
-		_, err = io.ReadFull(reader, magic[:])
-		require.NoError(t, err)
-		require.Equal(t, uint64(spillMagic), types.DecodeUint64(magic[:]))
-		totalRows += cnt
-	}
-	require.Equal(t, int64(6), totalRows)
-	cleanup()
-}
-
 func TestBudgetedSpillWriteThroughPreservesSiblingRecoveryHeadroom(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
 
-	const floor = uint64(spillWriteCoalesceSize)
+	const floor = spillRecoveryReservationQuantum
 	budget := process.MustNewHashBuildBudget(3*floor, 3*floor)
 	generation, err := budget.OpenGeneration(1)
 	require.NoError(t, err)
@@ -922,8 +828,6 @@ func TestBudgetedSpillWriteThroughPreservesSiblingRecoveryHeadroom(t *testing.T)
 	require.Equal(t, floor, writer.spillScratchReservation.Size(),
 		"optional write caching must not enlarge a budgeted owner's mandatory lease")
 	require.Equal(t, 2*floor, generation.Used())
-	require.Zero(t, writer.spillBucketWriteBufs[0].Len())
-
 	require.NoError(t, recovery.ensureSpillRecoveryReservationBytes(2*floor, analyzer),
 		"one owner's optional I/O cache must not strand a sibling mandatory recovery grow")
 	require.Equal(t, 3*floor, generation.Used())
@@ -1029,7 +933,6 @@ func TestSpillScratchLazyGrowSucceeds(t *testing.T) {
 	require.GreaterOrEqual(t, scratchToken.Size(), need)
 	require.Equal(t, int64(1), analyzer.GetOpStats().ExtraStats["HashBuildSpillScratchGrowCount"])
 	require.Equal(t, int64(1), analyzer.GetOpStats().ExtraStats["HashBuildSpillScratchGrowBytes"])
-	require.NoError(t, ctr.flushSpillBuffers(proc, files, analyzer))
 }
 
 func TestSpillScratchLazyGrowRejectPreservesRetainedSource(t *testing.T) {
@@ -1086,28 +989,6 @@ func TestSpillScratchLazyGrowRejectPreservesRetainedSource(t *testing.T) {
 	ctr.releaseSpillScratchReservation()
 	sourceToken.Release()
 	require.Zero(t, generation.Used())
-}
-
-func TestFlushSpillBuffersCancellationDiscardsPendingWrites(t *testing.T) {
-	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
-	defer proc.Free()
-	ctx, cancel := context.WithCancelCause(proc.Ctx)
-	process.ReplacePipelineCtx(proc, ctx, cancel)
-
-	ctr := &container{}
-	for _, bucket := range []int{0, spillNumBuckets - 1} {
-		_, err := ctr.spillBucketWriteBufs[bucket].Write([]byte("pending"))
-		require.NoError(t, err)
-		ctr.spillBucketWriteRows[bucket] = 1
-	}
-	proc.Cancel(context.Canceled)
-
-	err := ctr.flushSpillBuffers(proc, nil, process.NewAnalyzer(0, false, false, "test"))
-	require.ErrorIs(t, err, context.Canceled)
-	for bucket := 0; bucket < spillNumBuckets; bucket++ {
-		require.Zero(t, ctr.spillBucketWriteBufs[bucket].Len())
-		require.Zero(t, ctr.spillBucketWriteRows[bucket])
-	}
 }
 
 func TestSpillMaterializedBytesDoesNotScaleShuffledConstVector(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -785,20 +785,15 @@ func TestSpillExpressionLeaseRetainsLargeBatchHighWater(t *testing.T) {
 	require.LessOrEqual(t, retained, ctr.hashmapBuilder.expressionLease.Reserved())
 }
 
-func TestSpillWriteCoalescesAcrossBatches(t *testing.T) {
+func TestUnbudgetedSpillWriteCoalescesAcrossBatches(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
-	budget := process.MustNewHashBuildBudget(8<<20, 8<<20)
-	generation, err := budget.OpenGeneration(8 << 20)
-	require.NoError(t, err)
-	defer generation.Close()
 	files := make([]*os.File, spillNumBuckets)
 	conditions := []*plan.Expr{{
 		Typ:  plan.Type{Id: int32(types.T_int32)},
 		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
 	}}
 	ctr := &container{spillUUID: t.Name()}
-	ctr.hashmapBuilder.setBudget(generation)
 	cleanup := func() {
 		for i, file := range files {
 			if file != nil {
@@ -815,7 +810,7 @@ func TestSpillWriteCoalescesAcrossBatches(t *testing.T) {
 		ctr.releaseSpillScratchReservation()
 	}
 	defer cleanup()
-	err = initSpillExprExecsForTest(ctr, proc, conditions)
+	err := initSpillExprExecsForTest(ctr, proc, conditions)
 	require.NoError(t, err)
 	analyzer := process.NewAnalyzer(0, false, false, "test")
 	bat := batch.NewWithSize(1)
@@ -872,78 +867,69 @@ func TestSpillWriteCoalescesAcrossBatches(t *testing.T) {
 		totalRows += cnt
 	}
 	require.Equal(t, int64(6), totalRows)
-	scratchPeak := analyzer.GetOpStats().ExtraStats["HashBuildSpillScratchPeakBytes"]
-	require.GreaterOrEqual(t, scratchPeak, hashBuildStatInt64(ctr.spillScratchReservation.Size()))
-	require.Greater(t, scratchPeak, hashBuildStatInt64(ctr.spillScratchBase),
-		"scratch peak must include retained coalesce buffers above the base lease")
 	cleanup()
-	require.Zero(t, generation.Used())
 }
 
-func TestReclaimOptionalSpillCoalesceReleasesRecoveryHeadroom(t *testing.T) {
+func TestBudgetedSpillWriteThroughPreservesSiblingRecoveryHeadroom(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	defer proc.Free()
-	budget := process.MustNewHashBuildBudget(8<<20, 8<<20)
+
+	const floor = uint64(spillWriteCoalesceSize)
+	budget := process.MustNewHashBuildBudget(3*floor, 3*floor)
 	generation, err := budget.OpenGeneration(1)
 	require.NoError(t, err)
 	defer generation.Close()
 
-	files := make([]*os.File, spillNumBuckets)
-	ctr := &container{spillUUID: t.Name()}
-	ctr.hashmapBuilder.setBudget(generation)
-	cleanup := func() {
-		for i, file := range files {
-			if file != nil {
-				_ = file.Close()
-				files[i] = nil
-			}
+	newOwner := func() *container {
+		reservation, reserveErr := generation.Reserve(floor)
+		require.NoError(t, reserveErr)
+		return &container{
+			spillUUID:               t.Name(),
+			hashmapBuilder:          HashmapBuilder{budget: generation},
+			spillScratchReservation: reservation,
+			spillScratchBase:        floor,
 		}
-		if ctr.spillBundle != nil {
-			ctr.spillBundle.release()
-			ctr.spillBundle = nil
-		}
-		ctr.hashmapBuilder.FreeExecutors()
-		ctr.dropSpillScratchBuffers()
-		ctr.releaseSpillScratchReservation()
 	}
-	defer cleanup()
-	conditions := []*plan.Expr{{
-		Typ:  plan.Type{Id: int32(types.T_int32)},
-		Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}},
-	}}
-	err = initSpillExprExecsForTest(ctr, proc, conditions)
+	writer := newOwner()
+	recovery := newOwner()
+	defer func() {
+		if writer.spillBundle != nil {
+			writer.spillBundle.release()
+			writer.spillBundle = nil
+		}
+		writer.dropSpillScratchBuffers()
+		writer.releaseSpillScratchReservation()
+		recovery.dropSpillScratchBuffers()
+		recovery.releaseSpillScratchReservation()
+		require.Zero(t, generation.Used())
+		require.Zero(t, generation.SpillDiskUsed())
+		require.Zero(t, generation.SpillFDUsed())
+	}()
+
+	files := make([]*os.File, spillNumBuckets)
+	file, err := writer.ensureSpillFile(proc, files, 0)
 	require.NoError(t, err)
-	analyzer := process.NewAnalyzer(0, false, false, "recovery priority")
+	defer file.Close()
 
 	bat := batch.NewWithSize(1)
-	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 1, 1}, nil, proc.Mp())
-	bat.SetRowCount(3)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{7}, nil, proc.Mp())
+	bat.SetRowCount(1)
 	defer bat.Clean(proc.Mp())
-	require.NoError(t, ctr.spillBatchBounded(proc, bat, files, analyzer, false))
-	require.NotNil(t, ctr.spillScratchReservation)
-	base := ctr.spillScratchBase
-	beforeSize := ctr.spillScratchReservation.Size()
-	beforeUsed := generation.Used()
-	require.Greater(t, beforeSize, base)
 
-	reclaimed, err := ctr.reclaimOptionalSpillCoalesce(proc, files, analyzer)
-	require.NoError(t, err)
-	require.True(t, reclaimed)
-	require.Equal(t, base, ctr.spillScratchReservation.Size())
-	require.Equal(t, beforeUsed-(beforeSize-base), generation.Used())
-	for bucket := range ctr.spillBucketWriteBufs {
-		require.Zero(t, ctr.spillBucketWriteBufs[bucket].Len())
-		require.Zero(t, ctr.spillBucketWriteBufs[bucket].Cap())
-		require.Zero(t, ctr.spillBucketWriteRows[bucket])
-	}
-	// The transition is idempotent and must not shrink the mandatory floor.
-	reclaimed, err = ctr.reclaimOptionalSpillCoalesce(proc, files, analyzer)
-	require.NoError(t, err)
-	require.False(t, reclaimed)
-	require.Equal(t, base, ctr.spillScratchReservation.Size())
+	analyzer := process.NewAnalyzer(0, false, false, "shared recovery ownership")
+	require.NoError(t, writer.appendSpillRecord(
+		proc, file, 0, bat, floor, analyzer))
+	require.Equal(t, floor, writer.spillScratchReservation.Size(),
+		"optional write caching must not enlarge a budgeted owner's mandatory lease")
+	require.Equal(t, 2*floor, generation.Used())
+	require.Zero(t, writer.spillBucketWriteBufs[0].Len())
 
-	cleanup()
-	require.Zero(t, generation.Used())
+	require.NoError(t, recovery.ensureSpillRecoveryReservationBytes(2*floor, analyzer),
+		"one owner's optional I/O cache must not strand a sibling mandatory recovery grow")
+	require.Equal(t, 3*floor, generation.Used())
+	stat, err := file.Stat()
+	require.NoError(t, err)
+	require.Positive(t, stat.Size(), "budgeted records are written through before the next owner admission")
 }
 
 func TestSpillScratchBudgetDoesNotDoubleChargeRetainedSource(t *testing.T) {
@@ -1346,60 +1332,6 @@ func TestSpillReplacementPeakReusesHighWaterLease(t *testing.T) {
 
 	token.Release()
 	require.Zero(t, generation.Used())
-}
-
-func TestSpillReplacementPeakReclaimsOptionalBeforeRetry(t *testing.T) {
-	const (
-		base     = uint64(spillWriteCoalesceSize)
-		capBytes = 2 * base
-	)
-	for _, test := range []struct {
-		name        string
-		required    uint64
-		wantRejects uint64
-		wantError   bool
-	}{
-		{name: "reclaimed overlap fits", required: capBytes, wantRejects: 1},
-		{name: "mandatory overlap exceeds cap", required: capBytes + 1, wantRejects: 2, wantError: true},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			budget := process.MustNewHashBuildBudget(capBytes, capBytes)
-			generation, err := budget.OpenGeneration(1)
-			require.NoError(t, err)
-			defer generation.Close()
-			token, err := generation.Reserve(capBytes)
-			require.NoError(t, err)
-
-			ctr := container{
-				hashmapBuilder:          HashmapBuilder{budget: generation},
-				spillScratchReservation: token,
-				spillScratchBase:        base,
-			}
-			ctr.spillBucketWriteBufs[0] = *bytes.NewBuffer(
-				make([]byte, 0, spillWriteCoalesceSize))
-			analyzer := process.NewAnalyzer(0, false, false, "replacement reclaim")
-
-			oldSize, grew, err := ctr.growSpillScratchTransientWithReclaim(
-				nil, nil, test.required, analyzer)
-			if test.wantError {
-				require.ErrorIs(t, err, process.ErrHashBuildBudgetAdmission)
-				require.False(t, grew)
-				require.Zero(t, oldSize)
-				require.Equal(t, base, token.Size())
-			} else {
-				require.NoError(t, err)
-				require.True(t, grew)
-				require.Equal(t, base, oldSize)
-				require.Equal(t, test.required, token.Size())
-				require.NoError(t, ctr.restoreSpillScratchTransient(oldSize, grew))
-				require.Equal(t, base, token.Size())
-			}
-			require.Equal(t, test.wantRejects, generation.RejectCount())
-			require.Zero(t, ctr.spillBucketWriteBufs[0].Cap())
-			token.Release()
-			require.Zero(t, generation.Used())
-		})
-	}
 }
 
 func TestSpillPeakChargesSerializedPayloadOnce(t *testing.T) {

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -77,9 +77,9 @@ type container struct {
 	spillBucketOffsets [spillNumBuckets + 1]int32
 	spillSelection     []int32
 	spillWriteBuf      bytes.Buffer
-	// spillBucketWriteBufs coalesce serialized records across source batches.
-	// Each buffer is bounded by spillWriteCoalesceSize (plus bytes.Buffer's
-	// bounded growth slack), so fanout does not imply fanout-sized vectors.
+	// spillBucketWriteBufs coalesce serialized records for legacy unbudgeted
+	// callers. Hard-budgeted executions write through so optional buffers cannot
+	// strand a sibling worker's mandatory recovery ownership.
 	spillBucketWriteBufs [spillNumBuckets]bytes.Buffer
 	spillBucketWriteRows [spillNumBuckets]int64
 	spillKeyVecs         []*vector.Vector
@@ -89,8 +89,7 @@ type container struct {
 	// Direct spill callers may still establish it lazily. Reset, Free, and the
 	// build terminal cleanup all release it idempotently.
 	spillScratchReservation *process.HashBuildReservation
-	// spillScratchBase is the retained scratch floor. Coalesce-buffer growth is
-	// charged on top and must never be mistaken for this floor.
+	// spillScratchBase is the retained mandatory scratch floor.
 	spillScratchBase uint64
 }
 

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -77,12 +77,7 @@ type container struct {
 	spillBucketOffsets [spillNumBuckets + 1]int32
 	spillSelection     []int32
 	spillWriteBuf      bytes.Buffer
-	// spillBucketWriteBufs coalesce serialized records for legacy unbudgeted
-	// callers. Hard-budgeted executions write through so optional buffers cannot
-	// strand a sibling worker's mandatory recovery ownership.
-	spillBucketWriteBufs [spillNumBuckets]bytes.Buffer
-	spillBucketWriteRows [spillNumBuckets]int64
-	spillKeyVecs         []*vector.Vector
+	spillKeyVecs       []*vector.Vector
 	// spillScratchReservation is the query/CN-charged recovery lease for this
 	// execution. Shuffle HashBuild establishes it before retaining spillable
 	// data; spill then reuses the same lease for its bounded scratch buffers.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26586.

Related architecture issue: #26459.

## What this PR does / why we need it:

### Root cause

PR #26585 correctly made each shuffle HashBuild own its mandatory spill-recovery high water before retaining build state, but the same reservation could later grow above that floor for optional 64 KiB per-bucket write-coalescing buffers.

That optional ownership was only reclaimable by the same HashBuild container. Under a shared query generation, sibling workers could retain up to 2 MiB each of pending coalesced records. A worker needing to grow its mandatory recovery lease then failed even though the competing bytes were optional and belonged to siblings.

The Ubuntu/x86 CI failure in PR #26638 exposed this exact interleaving: the 28 MiB generation was full, one shuffle worker needed one additional 64 KiB recovery quantum, and sibling workers retained optional coalesce capacity. The existing local reclaim path could not release another worker file-bound pending data, so it returned a controlled but avoidable budget error.

### Ownership invariant and fix

A HashBuild worker must not retain an optional I/O cache across another worker mandatory recovery admission boundary.

This PR enforces that invariant locally:

- spill records are written through immediately for every caller;
- their recovery reservations remain mandatory floors only;
- the per-bucket coalescing buffers and their flush/cancel state machine are removed;
- the local optional-reclaim and deterministic-retry paths are removed because they could never close sibling ownership;
- genuine over-cap mandatory growth still fails once and preserves the existing fail-closed cleanup contract.

The only non-test caller is HashBuild.build, and Prepare always installs a budget generation, so retaining a separate unbudgeted coalescing branch had no production compatibility value. The spill record format, reader, file ownership, disk/FD accounting, and JoinMap handoff are unchanged. A failed or canceled write still terminates through the existing build cleanup owner.

This deliberately does not add a cross-worker callback registry, coordinator, goroutine, lock, condition variable, or wait edge. A sibling cannot safely flush another worker file-bound pending data, and waiting for its owner can deadlock behind shuffle input/backpressure.

### Regression coverage

- A deterministic two-owner white-box counterexample fills an exact three-quantum shared generation. On the parent it fails because the writer optional cache enlarges its lease from 64 KiB to 128 KiB; on this branch it writes through and the sibling mandatory 64 KiB grow succeeds.
- A real two-batch shuffle HashBuild proves recovery high-water growth succeeds without an admission rejection.
- The genuine N+1 over-cap control still publishes one terminal error, performs no futile retry, and releases memory/disk/FD ownership.
- The existing 8-worker, 28 MiB SQL-protocol regression spills and returns the exact result.

### Performance boundary

The resident/non-spill path has no code change, synchronization, branch, or allocation.

The spill-only tradeoff is at most one write for each non-empty bucket record (32 buckets per ingress batch) instead of retaining per-worker optional buffers. The real 1M-row, 8-way, 28 MiB SQL regression was measured on the same machine and base commit:

- parent: 42.235 s for 3 runs
- this change: 41.350 s for 3 runs

No measurable regression was observed. The change also removes up to 2 MiB of optional memory ownership per spilling worker.

### Validation

- focused ownership/growth/over-cap tests
- focused ownership matrix under `-race -count=20`
- full `pkg/sql/colexec/hashbuild`: normal and race
- dependent `hashjoin` and `spillutil` packages
- `TestHashBuildSharedBudgetRecoverySQL`: 1 run plus 3-run A/B
- package-scoped `go list`, `go build`, `go vet`, and `golangci-lint` (0 issues)
- `git diff --check`