### PR TITLE
test(logservice): isolate WAL recovery service roles

### DIFF
--- a/pkg/logservice/service_bootstrap_test.go
+++ b/pkg/logservice/service_bootstrap_test.go
@@ -82,15 +82,30 @@ func TestServiceBootstrapRestoresHAKeeperAndWAL(t *testing.T) {
 	cfg.BootstrapConfig.Restore.Enabled = true
 	cfg.HAKeeperClientConfig.ServiceAddresses = []string{cfg.LogServiceServiceAddr()}
 	fileServices := newFS()
-	s, err := NewService(
-		cfg,
-		fileServices,
-		nil,
-		WithBackendFilter(func(morpc.Message, string) bool { return true }),
-	)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, s.Close()) }()
+	var s *Service
+	closeService := func() {
+		if s == nil {
+			return
+		}
+		service := s
+		s = nil
+		require.NoError(t, service.Close())
+	}
+	restartService := func(serviceCfg Config) {
+		closeService()
+		var serviceErr error
+		s, serviceErr = NewService(
+			serviceCfg,
+			fileServices,
+			nil,
+			WithBackendFilter(func(morpc.Message, string) bool { return true }),
+		)
+		require.NoError(t, serviceErr)
+	}
+	restartService(cfg)
+	defer closeService()
 	require.True(t, s.walRecovery.configured)
+	require.True(t, s.walRecovery.coordinator)
 	require.True(t, s.walRecovery.pending.Load())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -150,8 +165,10 @@ func TestServiceBootstrapRestoresHAKeeperAndWAL(t *testing.T) {
 	// artifact and must not wait for the coordinator to restart with it.
 	nonCoordinatorCfg := cfg
 	nonCoordinatorCfg.BootstrapConfig.Restore.WALDataPath = ""
-	s.walRecovery.coordinator = false
-	s.setWALRecoveryInProgress(true)
+	restartService(nonCoordinatorCfg)
+	require.True(t, s.walRecovery.configured)
+	require.False(t, s.walRecovery.coordinator)
+	require.True(t, s.walRecovery.pending.Load())
 	require.NoError(t, s.BootstrapHAKeeper(ctx, nonCoordinatorCfg))
 	require.False(t, s.walRecovery.pending.Load())
 
@@ -162,8 +179,10 @@ func TestServiceBootstrapRestoresHAKeeperAndWAL(t *testing.T) {
 
 	// A restart normally retains the restore configuration. It must verify the
 	// replicated destination marker, preserve the current lease and skip replay.
-	s.walRecovery.coordinator = true
-	s.setWALRecoveryInProgress(true)
+	restartService(cfg)
+	require.True(t, s.walRecovery.configured)
+	require.True(t, s.walRecovery.coordinator)
+	require.True(t, s.walRecovery.pending.Load())
 	require.NoError(t, s.BootstrapHAKeeper(ctx, cfg))
 	require.False(t, s.walRecovery.pending.Load())
 	restartedState, err := s.store.getCheckerState()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26652

## What this PR does / why we need it:

### Root cause

`NewService` derives `walRecovery.coordinator` from the restore configuration before it starts the heartbeat worker, and that role is immutable for the service generation. `TestServiceBootstrapRestoresHAKeeperAndWAL` instead reused one live service for coordinator and non-coordinator restart scenarios by assigning that plain boolean after workers had started. The live heartbeat could read the field concurrently in `addWALRecoveryStatus`, producing the reported race.

### Changes

- Add local lifecycle helpers that fully close the active test service before constructing the next generation.
- Construct coordinator and non-coordinator generations from their real restore configurations, so each generation derives its role before its heartbeat worker starts.
- Assert `configured`, `coordinator`, and initial `pending` state for every generation before bootstrap.
- Preserve the existing recovery-marker, ID-watermark, lease, replay-skip, and cancellation assertions.
- Keep production synchronization and runtime behavior unchanged; the immutable-after-start role contract remains explicit.

### Issue-to-test proof

- The initial generation proves coordinator recovery and clears its pending status after bootstrap.
- A separately constructed non-coordinator generation proves restart without a WAL artifact, including role derivation and pending-status completion.
- A third coordinator generation proves the normal configured restart path while retaining the replicated marker, ID watermarks, and post-recovery lease.
- The issue's focused race command passes 10 consecutive runs after the change, so no test write can overlap the heartbeat read.
- BVT is not applicable because this is an internal LogService test/service-generation ownership defect with no SQL-visible behavior.

### Validation

Passed on `origin/main` at `00aaf78e24`:

- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -run '^TestServiceBootstrapRestoresHAKeeperAndWAL$' -count=10 -timeout=600s ./pkg/logservice` (`320.899s`)
- Related WAL recovery/restore race suite covering status publication, coordinator waiting, recovery state, input validation, and replay (`53.661s`)
- `GOWORK=off go list -mod=readonly ./pkg/logservice`
- `GOWORK=off go build -mod=readonly ./pkg/logservice` with the repository CGo include/library environment
- `GOWORK=off go vet -mod=readonly ./pkg/logservice` with the repository CGo include/library environment
- `git diff --check`

Broader package verification was attempted but is not reported as passing:

- Full `./pkg/logservice` race testing is blocked by `TestZombieRepro_WithFix` failing to transfer leadership within 10 seconds; the identical focused failure reproduces on an isolated pristine `origin/main` worktree. Its failed cleanup then causes the fixed-port `TestZombieRepro_WithoutFix` to fail.
- Full non-race testing also encountered unrelated HAKeeper cluster-test timeouts; serial execution excluding `TestZombieRepro_*` still failed only `TestHAKeeperCanBootstrapAndRepairShards` and `TestRestoreIDWatermarksFromNonLeader`. The changed target test passed, and the directly related race suite above passed.
- The reported workflow was already on attempt 2 and was not rerun.

### Residual risks

No production code, API, configuration, or runtime behavior changes. Each replacement service is created only after `Close` stops the previous generation's workers and releases its resources; the helper clears ownership before closing so an error path cannot close the same generation twice. The local full-package gaps above are outside this one-test change and are recorded explicitly.
