### PR TITLE
fix(join): restore accounted spill read buffering

### DIFF
--- a/pkg/sql/colexec/spillutil/accounted_file_reader.go
+++ b/pkg/sql/colexec/spillutil/accounted_file_reader.go
@@ -1,0 +1,241 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spillutil
+
+import (
+	"io"
+	"os"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+)
+
+// accountedFileReader restores buffered sequential spill reads without
+// reintroducing the untracked Go-heap buffer removed by allocation-owned
+// admission. The buffer is optional: under allocation pressure the reader
+// releases it and continues directly from the file.
+type accountedFileReader struct {
+	fd         *os.File
+	mp         *mpool.MPool
+	allocation *SpillAllocationAccount
+	buffer     *mpool.AccountedBuffer
+
+	offset     int64
+	fdOffset   int64
+	bufferPos  int
+	pendingErr error
+	disabled   bool
+}
+
+func newAccountedFileReader(
+	mp *mpool.MPool,
+	allocation *SpillAllocationAccount,
+	fd *os.File,
+) (*accountedFileReader, error) {
+	if mp == nil || allocation == nil {
+		return nil, mpool.ErrAllocationAccountInvalid
+	}
+	reader := &accountedFileReader{
+		mp:         mp,
+		allocation: allocation,
+	}
+	if err := reader.Reset(fd); err != nil {
+		return nil, err
+	}
+	return reader, nil
+}
+
+func (r *accountedFileReader) Read(value []byte) (int, error) {
+	if len(value) == 0 {
+		return 0, nil
+	}
+	if r == nil || r.fd == nil {
+		return 0, io.EOF
+	}
+	if available := r.buffered(); available > 0 {
+		if available > len(value) {
+			available = len(value)
+		}
+		copy(value, r.buffer.Bytes()[r.bufferPos:r.bufferPos+available])
+		r.bufferPos += available
+		r.offset += int64(available)
+		return available, nil
+	}
+	if r.pendingErr != nil {
+		err := r.pendingErr
+		r.pendingErr = nil
+		return 0, err
+	}
+	if err := r.ensureBuffer(); err != nil {
+		return 0, err
+	}
+	if r.disabled || len(value) >= spillReadBufferSize {
+		return r.readDirect(value)
+	}
+	if err := r.fill(); err != nil {
+		return 0, err
+	}
+	return r.Read(value)
+}
+
+func (r *accountedFileReader) Offset() int64 {
+	if r == nil {
+		return 0
+	}
+	return r.offset
+}
+
+func (r *accountedFileReader) Reset(fd *os.File) error {
+	if r == nil {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	r.fd = fd
+	r.offset = 0
+	r.fdOffset = 0
+	r.bufferPos = 0
+	r.pendingErr = nil
+	r.disabled = false
+	if r.buffer != nil {
+		r.buffer.Reset()
+	}
+	if fd == nil {
+		return nil
+	}
+	offset, err := fd.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	r.offset = offset
+	r.fdOffset = offset
+	return nil
+}
+
+// DisableBufferAt releases optional read-ahead capacity and restores the
+// physical descriptor to the unpublished record offset before a decode retry.
+func (r *accountedFileReader) DisableBufferAt(offset int64) error {
+	if r == nil || r.fd == nil || offset < 0 {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	_, seekErr := r.fd.Seek(offset, io.SeekStart)
+	if r.buffer != nil {
+		r.buffer.Free()
+		r.buffer = nil
+	}
+	r.offset = offset
+	r.fdOffset = offset
+	r.bufferPos = 0
+	r.pendingErr = nil
+	r.disabled = true
+	return seekErr
+}
+
+func (r *accountedFileReader) Free() {
+	if r == nil {
+		return
+	}
+	if r.buffer != nil {
+		r.buffer.Free()
+		r.buffer = nil
+	}
+	r.fd = nil
+	r.mp = nil
+	r.allocation = nil
+	r.offset = 0
+	r.fdOffset = 0
+	r.bufferPos = 0
+	r.pendingErr = nil
+	r.disabled = true
+}
+
+func (r *accountedFileReader) buffered() int {
+	if r == nil || r.buffer == nil {
+		return 0
+	}
+	return r.buffer.Len() - r.bufferPos
+}
+
+func (r *accountedFileReader) ensureBuffer() error {
+	if r.disabled {
+		return nil
+	}
+	if r.buffer == nil {
+		buffer, err := r.allocation.newBuffer(
+			r.mp,
+			SpillAllocationSiteReadBuffer,
+		)
+		if err != nil {
+			return err
+		}
+		r.buffer = buffer
+	}
+	if r.buffer.Cap() >= spillReadBufferSize {
+		return nil
+	}
+	if err := r.buffer.EnsureCapacity(spillReadBufferSize); err != nil {
+		if !mpool.IsRetryableAllocationCapacity(err) {
+			return err
+		}
+		r.buffer.Free()
+		r.buffer = nil
+		r.disabled = true
+	}
+	return nil
+}
+
+func (r *accountedFileReader) fill() error {
+	if r.buffer == nil {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	if err := r.syncFileOffset(); err != nil {
+		return err
+	}
+	if err := r.buffer.Resize(spillReadBufferSize); err != nil {
+		return err
+	}
+	n, err := r.fd.Read(r.buffer.Bytes())
+	r.fdOffset += int64(n)
+	r.bufferPos = 0
+	if resizeErr := r.buffer.Resize(n); resizeErr != nil {
+		return resizeErr
+	}
+	if n == 0 {
+		if err == nil {
+			return io.EOF
+		}
+		return err
+	}
+	r.pendingErr = err
+	return nil
+}
+
+func (r *accountedFileReader) readDirect(value []byte) (int, error) {
+	if err := r.syncFileOffset(); err != nil {
+		return 0, err
+	}
+	n, err := r.fd.Read(value)
+	r.offset += int64(n)
+	r.fdOffset += int64(n)
+	return n, err
+}
+
+func (r *accountedFileReader) syncFileOffset() error {
+	if r.fdOffset == r.offset {
+		return nil
+	}
+	if _, err := r.fd.Seek(r.offset, io.SeekStart); err != nil {
+		return err
+	}
+	r.fdOffset = r.offset
+	return nil
+}

--- a/pkg/sql/colexec/spillutil/allocation_account.go
+++ b/pkg/sql/colexec/spillutil/allocation_account.go
@@ -37,6 +37,7 @@ const (
 	SpillAllocationSiteDecodedGrouping
 	SpillAllocationSiteSelectedNulls
 	SpillAllocationSiteSelectedGrouping
+	SpillAllocationSiteReadBuffer
 )
 
 // SpillAllocationAccount is the allocation provenance for one spill

--- a/pkg/sql/colexec/spillutil/allocation_account_test.go
+++ b/pkg/sql/colexec/spillutil/allocation_account_test.go
@@ -217,6 +217,76 @@ func TestSpillAllocationAccountDecodedBatchLifecycle(t *testing.T) {
 	finalizeTestSpillAllocationAccount(t, state)
 }
 
+func TestSpillReadBufferFallsBackUnderAllocationPressure(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(
+		t,
+		"",
+		mpool.MustNew("spill-read-buffer-fallback"),
+	)
+	defer proc.Free()
+	values := make([]int64, 128)
+	for i := range values {
+		values[i] = int64(i)
+	}
+	source := testutil.NewBatchWithVectors([]*vector.Vector{
+		testutil.NewVector(
+			len(values),
+			types.T_int64.ToType(),
+			proc.Mp(),
+			false,
+			values,
+		),
+	}, nil)
+	defer source.Clean(proc.Mp())
+
+	state := newTestSpillAllocationAccount(t, 32<<10, 64)
+	reader := BucketReader{
+		fd:         writeSpillAllocationTestFile(t, source, 0),
+		allocation: state.allocation,
+	}
+	reuse := batch.NewOffHeapWithSize(0)
+	decoded, err := reader.ReadBatch(proc, reuse)
+	require.NoError(t, err)
+	require.Equal(t, source.RowCount(), decoded.RowCount())
+	require.NotNil(t, reader.reader)
+	require.True(t, reader.reader.disabled)
+	require.Less(t, state.account.Snapshot().Used, uint64(spillReadBufferSize))
+
+	reader.Close()
+	reuse.Clean(proc.Mp())
+	finalizeTestSpillAllocationAccount(t, state)
+}
+
+func TestSpillReadBufferReleasesWhenRewindFails(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(
+		t,
+		"",
+		mpool.MustNew("spill-read-buffer-rewind-failure"),
+	)
+	defer proc.Free()
+	state := newTestSpillAllocationAccount(t, 1<<20, 16)
+
+	path := filepath.Join(t.TempDir(), "closed-spill.bin")
+	require.NoError(t, os.WriteFile(path, []byte("spill"), 0o600))
+	file, err := os.Open(path)
+	require.NoError(t, err)
+	reader, err := newAccountedFileReader(proc.Mp(), state.allocation, file)
+	require.NoError(t, err)
+	require.NoError(t, reader.ensureBuffer())
+	require.NotNil(t, reader.buffer)
+	require.Positive(t, state.account.Snapshot().Used)
+
+	require.NoError(t, file.Close())
+	require.Error(t, reader.DisableBufferAt(0))
+	require.Nil(t, reader.buffer)
+	require.True(t, reader.disabled)
+	require.Zero(t, state.account.Snapshot().Used)
+
+	reader.Free()
+	reader.Free()
+	finalizeTestSpillAllocationAccount(t, state)
+}
+
 func TestSpillAllocationAccountDecodedReuseRetriesFromCleanRecord(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(
 		t,

--- a/pkg/sql/colexec/spillutil/issue_26661_benchmark_test.go
+++ b/pkg/sql/colexec/spillutil/issue_26661_benchmark_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spillutil
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+)
+
+// BenchmarkSpillReadMergedSmallRecords models the many small per-bucket records
+// produced by a low-threshold shuffled join. One logical output batch requires
+// decoding and merging 64 physical records.
+func BenchmarkSpillReadMergedSmallRecords(b *testing.B) {
+	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
+	defer proc.Free()
+
+	values := make([]int64, 128)
+	for i := range values {
+		values[i] = int64(i)
+	}
+	source := testutil.NewBatchWithVectors([]*vector.Vector{
+		testutil.NewVector(
+			len(values),
+			types.T_int64.ToType(),
+			proc.Mp(),
+			false,
+			values,
+		),
+	}, nil)
+	defer source.Clean(proc.Mp())
+
+	record := marshalTestSpillRecord(source)
+	payload := make([]byte, 0, 64*len(record))
+	for range 64 {
+		payload = append(payload, record...)
+	}
+	path := filepath.Join(b.TempDir(), "small-records.bin")
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		b.Fatal(err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	state := newTestSpillAllocationAccount(b, 64<<20, 4_096)
+	reader := BucketReader{
+		fd:           file,
+		mergeRecords: true,
+		allocation:   state.allocation,
+	}
+	reuse := batch.NewOffHeapWithSize(0)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for range b.N {
+		if _, err = file.Seek(0, io.SeekStart); err != nil {
+			b.Fatal(err)
+		}
+		if reader.reader != nil {
+			if err = reader.reader.Reset(file); err != nil {
+				b.Fatal(err)
+			}
+		}
+		reader.headerPending = false
+		decoded, err := reader.ReadBatch(proc, reuse)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if decoded.RowCount() != 64*len(values) {
+			b.Fatalf("decoded rows = %d", decoded.RowCount())
+		}
+	}
+	b.StopTimer()
+	reuse.Clean(proc.Mp())
+	reader.Close()
+	finalizeTestSpillAllocationAccount(b, state)
+}

--- a/pkg/sql/colexec/spillutil/join_spill.go
+++ b/pkg/sql/colexec/spillutil/join_spill.go
@@ -48,6 +48,9 @@ const (
 	// Coalesce serialized records across source batches without retaining
 	// selected vectors. Retained buffer capacity is charged once.
 	spillWriteCoalesceSize = 64 << 10
+	// Match the write coalescing boundary so one physical read usually consumes
+	// a complete write while keeping per-reader admission bounded.
+	spillReadBufferSize = spillWriteCoalesceSize
 	// Keep enough decoded-batch headroom to reuse the reservation for ordinary
 	// spill records without retaining the pre-admission unmarshal estimate
 	// for a large record until the reader closes. The additive bound makes the
@@ -80,6 +83,7 @@ func checkSpillCanceled(proc *process.Process) error {
 // instead of an untracked Go-heap buffer.
 type BucketReader struct {
 	fd            *os.File
+	reader        *accountedFileReader
 	header        [16]byte
 	headerPending bool
 	spillFile     *message.SpillFile
@@ -92,7 +96,12 @@ type BucketReader struct {
 func (r *BucketReader) ReadBatch(
 	proc *process.Process,
 	reuseBat *batch.Batch,
-) (*batch.Batch, error) {
+) (_ *batch.Batch, retErr error) {
+	defer func() {
+		if retErr != nil && !errors.Is(retErr, io.EOF) && r.reader != nil {
+			_ = r.reader.DisableBufferAt(r.reader.Offset())
+		}
+	}()
 	if err := checkSpillCanceled(proc); err != nil {
 		return nil, err
 	}
@@ -107,6 +116,17 @@ func (r *BucketReader) ReadBatch(
 	}
 	if r.allocation == nil {
 		return nil, mpool.ErrAllocationAccountInvalid
+	}
+	if r.reader == nil {
+		var err error
+		r.reader, err = newAccountedFileReader(
+			proc.Mp(),
+			r.allocation,
+			r.fd,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := reuseBat.SetAllocationAccount(r.allocation.decoded); err != nil {
 		return nil, err
@@ -201,7 +221,7 @@ func (r *BucketReader) peekRecordRows(proc *process.Process) (int64, error) {
 		return 0, err
 	}
 	if !r.headerPending {
-		if _, err := io.ReadFull(r.fd, r.header[:]); err != nil {
+		if _, err := io.ReadFull(r.reader, r.header[:]); err != nil {
 			return 0, err
 		}
 		r.headerPending = true
@@ -225,7 +245,7 @@ func (r *BucketReader) readBatchRecord(
 		return nil, err
 	}
 	if !r.headerPending {
-		if _, err := io.ReadFull(r.fd, r.header[:]); err != nil {
+		if _, err := io.ReadFull(r.reader, r.header[:]); err != nil {
 			return nil, err
 		}
 	}
@@ -238,16 +258,13 @@ func (r *BucketReader) readBatchRecord(
 			"negative spill batch header",
 		)
 	}
-	payloadOffset, err := r.fd.Seek(0, io.SeekCurrent)
-	if err != nil {
-		return nil, err
-	}
+	payloadOffset := r.reader.Offset()
 	decode := func() (io.LimitedReader, error) {
 		reuseBat.CleanOnlyData()
 		if err := checkSpillCanceled(proc); err != nil {
 			return io.LimitedReader{}, err
 		}
-		limited := io.LimitedReader{R: r.fd, N: batchSize}
+		limited := io.LimitedReader{R: r.reader, N: batchSize}
 		return limited, reuseBat.UnmarshalFromReaderWithGrouping(&limited, proc.Mp())
 	}
 	limited, decodeErr := decode()
@@ -258,7 +275,7 @@ func (r *BucketReader) readBatchRecord(
 		if err := reuseBat.SetAllocationAccount(r.allocation.decoded); err != nil {
 			return nil, err
 		}
-		if _, err := r.fd.Seek(payloadOffset, io.SeekStart); err != nil {
+		if err := r.reader.DisableBufferAt(payloadOffset); err != nil {
 			return nil, err
 		}
 		r.cleanRetries++
@@ -274,7 +291,7 @@ func (r *BucketReader) readBatchRecord(
 			limited.N,
 		)
 	}
-	if _, err := io.ReadFull(r.fd, r.header[:8]); err != nil {
+	if _, err := io.ReadFull(r.reader, r.header[:8]); err != nil {
 		return nil, err
 	}
 	if types.DecodeUint64(r.header[:8]) != SpillMagic {
@@ -312,6 +329,14 @@ func (r *BucketReader) ResetForSpillFile(file *message.SpillFile) error {
 	}
 	r.spillFile = file
 	r.fd = file.File()
+	if r.reader != nil {
+		if err := r.reader.Reset(r.fd); err != nil {
+			_ = file.Close()
+			r.spillFile = nil
+			r.fd = nil
+			return err
+		}
+	}
 	r.headerPending = false
 	r.schema = nil
 	return nil
@@ -328,12 +353,19 @@ func (r *BucketReader) closeCurrentFile() {
 		_ = r.fd.Close()
 		r.fd = nil
 	}
+	if r.reader != nil {
+		_ = r.reader.Reset(nil)
+	}
 	r.headerPending = false
 	r.schema = nil
 }
 
 func (r *BucketReader) Close() {
 	r.closeCurrentFile()
+	if r.reader != nil {
+		r.reader.Free()
+		r.reader = nil
+	}
 }
 
 // BucketWriter writes serialized batch records to an fd.


### PR DESCRIPTION
Use a bounded allocation-accounted read buffer for sequential spill records, and fall back to direct reads under allocation pressure. Release the optional buffer on retry, error, and terminal cleanup paths.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26661

## What this PR does / why we need it:

fix(join): restore accounted spill read buffering