### PR TITLE
build: tolerate slow third-party downloads

### DIFF
--- a/thirdparties/download
+++ b/thirdparties/download
@@ -29,7 +29,11 @@ destination=$3
 
 attempts=${MO_DOWNLOAD_ATTEMPTS:-4}
 connect_timeout=${MO_DOWNLOAD_CONNECT_TIMEOUT_SECONDS:-15}
-max_time=${MO_DOWNLOAD_MAX_TIME_SECONDS:-120}
+# Large pinned artifacts can take more than ten minutes from some CI regions.
+# Keep a finite hard cap, while the low-speed guard below fails stalled transfers.
+max_time=${MO_DOWNLOAD_MAX_TIME_SECONDS:-1800}
+low_speed_limit=${MO_DOWNLOAD_LOW_SPEED_LIMIT_BYTES_PER_SECOND:-1024}
+low_speed_time=${MO_DOWNLOAD_LOW_SPEED_TIME_SECONDS:-120}
 max_bytes=${MO_DOWNLOAD_MAX_BYTES:-134217728}
 retry_delay=${MO_DOWNLOAD_RETRY_DELAY_SECONDS:-1}
 curl_bin=${MO_DOWNLOAD_CURL_BIN:-curl}
@@ -59,6 +63,8 @@ require_positive_integer() {
 require_positive_integer MO_DOWNLOAD_ATTEMPTS "$attempts"
 require_positive_integer MO_DOWNLOAD_CONNECT_TIMEOUT_SECONDS "$connect_timeout"
 require_positive_integer MO_DOWNLOAD_MAX_TIME_SECONDS "$max_time"
+require_positive_integer MO_DOWNLOAD_LOW_SPEED_LIMIT_BYTES_PER_SECOND "$low_speed_limit"
+require_positive_integer MO_DOWNLOAD_LOW_SPEED_TIME_SECONDS "$low_speed_time"
 require_positive_integer MO_DOWNLOAD_MAX_BYTES "$max_bytes"
 
 case "$retry_delay" in
@@ -166,6 +172,7 @@ run_curl() (
 	exec "$curl_bin" --disable --fail --location --show-error \
 		--proto '=https' --proto-redir '=https' \
 		--connect-timeout "$connect_timeout" --max-time "$max_time" \
+		--speed-limit "$low_speed_limit" --speed-time "$low_speed_time" \
 		--max-filesize "$max_bytes" \
 		"$@" \
 		--output "$tmp" "$url"

--- a/thirdparties/download_test
+++ b/thirdparties/download_test
@@ -30,6 +30,9 @@ mock_curl() {
 	retry_count=
 	retry_max_time=
 	retry_all_errors=0
+	max_time=
+	low_speed_limit=
+	low_speed_time=
 	while [ "$#" -gt 0 ]; do
 		case "$1" in
 			--output)
@@ -48,7 +51,19 @@ mock_curl() {
 				retry_all_errors=1
 				shift
 				;;
-			--connect-timeout | --max-time | --max-filesize | --proto | --proto-redir)
+			--max-time)
+				max_time=$2
+				shift 2
+				;;
+			--speed-limit)
+				low_speed_limit=$2
+				shift 2
+				;;
+			--speed-time)
+				low_speed_time=$2
+				shift 2
+				;;
+			--connect-timeout | --max-filesize | --proto | --proto-redir)
 				shift 2
 				;;
 			*)
@@ -65,6 +80,9 @@ mock_curl() {
 	printf '%s\n' "$retry_count" > "$MO_DOWNLOAD_MOCK_STATE/retry-count"
 	printf '%s\n' "$retry_max_time" > "$MO_DOWNLOAD_MOCK_STATE/retry-max-time"
 	printf '%s\n' "$retry_all_errors" > "$MO_DOWNLOAD_MOCK_STATE/retry-all-errors"
+	printf '%s\n' "$max_time" > "$MO_DOWNLOAD_MOCK_STATE/max-time"
+	printf '%s\n' "$low_speed_limit" > "$MO_DOWNLOAD_MOCK_STATE/low-speed-limit"
+	printf '%s\n' "$low_speed_time" > "$MO_DOWNLOAD_MOCK_STATE/low-speed-time"
 
 	count=0
 	if [ -f "$MO_DOWNLOAD_MOCK_STATE/count" ]; then
@@ -149,6 +167,15 @@ assert_retry_contract() {
 	[ "$retry_count" -eq $((MO_DOWNLOAD_ATTEMPTS - 1)) ] || fail "curl retry count is $retry_count"
 	[ "$retry_max_time" -eq $((MO_DOWNLOAD_MAX_TIME_SECONDS * MO_DOWNLOAD_ATTEMPTS)) ] || fail "curl retry time is $retry_max_time"
 	[ "$retry_all_errors" -eq 1 ] || fail "curl retry-all-errors is missing"
+}
+
+assert_slow_transfer_contract() {
+	IFS= read -r max_time < "$MO_DOWNLOAD_MOCK_STATE/max-time"
+	IFS= read -r low_speed_limit < "$MO_DOWNLOAD_MOCK_STATE/low-speed-limit"
+	IFS= read -r low_speed_time < "$MO_DOWNLOAD_MOCK_STATE/low-speed-time"
+	[ "$max_time" -eq 1800 ] || fail "default max time is $max_time seconds, expected 1800"
+	[ "$low_speed_limit" -eq 1024 ] || fail "default low-speed limit is $low_speed_limit bytes/s, expected 1024"
+	[ "$low_speed_time" -eq 120 ] || fail "default low-speed time is $low_speed_time seconds, expected 120"
 }
 
 assert_legacy_retry_contract() {
@@ -259,6 +286,18 @@ assert_retry_contract
 cmp "$fixture" "$MO_DOWNLOAD_MOCK_STATE/result" || fail "fresh download installed wrong content"
 assert_publicly_readable "$MO_DOWNLOAD_MOCK_STATE/result"
 assert_no_temp_files "$MO_DOWNLOAD_MOCK_STATE"
+
+new_case slow-transfer-defaults
+unset MO_DOWNLOAD_MAX_TIME_SECONDS
+MO_DOWNLOAD_MOCK_MODE=success
+export MO_DOWNLOAD_MOCK_MODE
+"$download_script" https://example.invalid/dependency "$expected_sha256" "$MO_DOWNLOAD_MOCK_STATE/result"
+assert_count 1
+assert_slow_transfer_contract
+cmp "$fixture" "$MO_DOWNLOAD_MOCK_STATE/result" || fail "slow-transfer defaults installed wrong content"
+assert_no_temp_files "$MO_DOWNLOAD_MOCK_STATE"
+MO_DOWNLOAD_MAX_TIME_SECONDS=1
+export MO_DOWNLOAD_MAX_TIME_SECONDS
 
 new_case checksum-failure
 MO_DOWNLOAD_MOCK_MODE=always-corrupt


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26664

## What this PR does / why we need it:

Cold Docker builds in the Guangzhou DinD runner repeatedly failed while downloading the pinned 21.9 MiB ONNX Runtime archive. The download made steady progress, but the downloader's 120-second per-attempt hard limit aborted it before completion. A successful control run on the same route needed about 14 minutes and 35 seconds.

This change:

- raises the default hard transfer limit from 120 seconds to 1800 seconds;
- aborts transfers that remain below 1 KiB/s for 120 seconds, so stalled connections still fail promptly;
- keeps both thresholds configurable through environment variables and validates them as positive integers;
- adds a regression test for the slow-transfer curl contract.

Existing HTTPS-only enforcement, connection timeout, bounded retries, download-size limit, SHA-256 verification, atomic publication, cache handling, legacy curl fallback, and concurrent-download behavior remain covered by the downloader test suite.

Validation:

- `sh -n thirdparties/download thirdparties/download_test`
- `git diff --check c58cd292d3e6e039a8882654d3b20ad345171e87..HEAD`
- `make -C thirdparties test-download`
