### PR TITLE
fix(colexec): honor cancellation at spill phase boundaries

### DIFF
--- a/pkg/sql/colexec/group/exec2.go
+++ b/pkg/sql/colexec/group/exec2.go
@@ -279,6 +279,14 @@ func (group *Group) Call(proc *process.Process) (vm.CallResult, error) {
 			}
 		}
 
+		if group.ctr.inputDone {
+			// EOF and cancellation can arrive in the same child call. Observe
+			// cancellation before flushing or reloading spill state.
+			if err, isCancel = vm.CancelCheck(proc); isCancel {
+				return vm.CancelResult, err
+			}
+		}
+
 		// spilling -- spill whatever left in memory, and load first spilled bucket.
 		if group.ctr.isSpilling() {
 			if bytes, rows, err := group.ctr.spillDataToDisk(proc, group.OpAnalyzer, nil); err != nil {

--- a/pkg/sql/colexec/group/exec2.go
+++ b/pkg/sql/colexec/group/exec2.go
@@ -547,6 +547,14 @@ func (ctr *container) appendGroupByBatch(
 }
 
 func (group *Group) outputOneBatch(proc *process.Process) (vm.CallResult, error) {
+	// Build can switch directly to Eval and publish in the same Call. The
+	// Call-entry check therefore does not cover cancellation that arrives while
+	// the child batch is being built. Observe it at the output work-unit boundary
+	// before advancing result ownership.
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return vm.CancelResult, err
+	}
+
 	if group.NeedEval {
 		return group.ctr.outputOneBatchFinal(proc, group.OpAnalyzer, group.Aggs)
 	} else {

--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -15,6 +15,7 @@
 package group
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
@@ -97,6 +98,19 @@ type cancelOnDoneCheckContext struct {
 	context.Context
 	remaining int
 	done      chan struct{}
+}
+
+type cancelAfterWriteWriter struct {
+	cancel context.CancelFunc
+	writes int
+}
+
+func (w *cancelAfterWriteWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == 1 {
+		w.cancel()
+	}
+	return len(p), nil
 }
 
 func newCancelOnDoneCheckContext(parent context.Context, checks int) *cancelOnDoneCheckContext {
@@ -362,7 +376,159 @@ func TestGroupSpillReloadHonorsCancellationAfterInput(t *testing.T) {
 	require.Zero(t, g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillReloadBuckets"])
 }
 
+func TestGroupSpillWriteHonorsCancellationAfterInputBatch(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	baseCtx := proc.Ctx
+	ctx, cancel := context.WithCancel(baseCtx)
+	proc.Ctx = ctx
+
+	input := batch.NewWithSize(1)
+	input.Vecs[0] = testutil.MakeInt32Vector([]int32{4, 1, 3, 2}, nil, proc.Mp())
+	input.SetRowCount(4)
+	child := colexec.NewMockOperator().
+		WithBatchs([]*batch.Batch{input}).
+		WithBatchCallback(func(int) { cancel() })
+	g := newGroupOp(proc, []*plan.Expr{colExpr(0, types.T_int32)}, []aggexec.AggFuncExecExpression{countStarAgg()})
+	g.SpillMem = 1
+	g.AppendChild(child)
+	require.NoError(t, g.Prepare(proc))
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		g.Free(proc, true, context.Canceled)
+		child.Free(proc, true, context.Canceled)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(g, proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Zero(t, g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillRecords"])
+	require.Nil(t, g.ctr.currentSpillBkt)
+}
+
+func TestGroupSpillWriteStopsAtBucketBoundary(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	baseCtx := proc.Ctx
+	g := newGroupOp(proc, []*plan.Expr{colExpr(0, types.T_int32)}, []aggexec.AggFuncExecExpression{countStarAgg()})
+	g.SpillMem = 1
+	require.NoError(t, g.Prepare(proc))
+
+	const rows = 1024
+	values := make([]int32, rows)
+	for i := range values {
+		values[i] = int32(i)
+	}
+	input := batch.NewWithSize(1)
+	input.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	input.SetRowCount(rows)
+	cleaned := false
+	t.Cleanup(func() {
+		if cleaned {
+			return
+		}
+		proc.Ctx = baseCtx
+		g.Free(proc, true, context.Canceled)
+		input.Clean(proc.Mp())
+		proc.Free()
+	})
+	needSpill, err := g.buildOneBatch(proc, input)
+	require.NoError(t, err)
+	require.True(t, needSpill)
+
+	hashCodes := make([]uint64, g.ctr.hr.Hash.GroupCount())
+	hashCodes = g.ctr.hr.Hash.FillGroupHashes(hashCodes)
+	g.ctr.computeBucketIndex(hashCodes, 1)
+	usedBuckets := make(map[int]struct{})
+	firstBucket := spillNumBuckets
+	for _, hashCode := range hashCodes {
+		bucketIndex := int(hashCode & (spillNumBuckets - 1))
+		usedBuckets[bucketIndex] = struct{}{}
+		firstBucket = min(firstBucket, bucketIndex)
+	}
+	require.Greater(t, len(usedBuckets), 1)
+
+	g.ctr.currentSpillBkt = make([]*spillBucket, spillNumBuckets)
+	for i := range g.ctr.currentSpillBkt {
+		g.ctr.currentSpillBkt[i] = &spillBucket{lv: 1, name: fmt.Sprintf("cancel-boundary-%d", i)}
+	}
+	file, err := os.CreateTemp(t.TempDir(), "group-cancel-boundary-*")
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(baseCtx)
+	writer := &cancelAfterWriteWriter{cancel: cancel}
+	g.ctr.currentSpillBkt[firstBucket].file = file
+	g.ctr.currentSpillBkt[firstBucket].writer = bufio.NewWriterSize(writer, 1)
+	proc.Ctx = ctx
+
+	_, _, err = g.ctr.spillDataToDisk(proc, g.OpAnalyzer, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, writer.writes)
+	require.Equal(t, int64(1), g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillRecords"])
+
+	proc.Ctx = baseCtx
+	g.Free(proc, true, context.Canceled)
+	input.Clean(proc.Mp())
+	proc.Free()
+	cleaned = true
+	require.Zero(t, proc.Mp().CurrNB())
+}
+
+func TestGroupSpillWriteStopsAfterLastBucket(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	baseCtx := proc.Ctx
+	g := newGroupOp(proc, []*plan.Expr{colExpr(0, types.T_int32)}, []aggexec.AggFuncExecExpression{countStarAgg()})
+	g.SpillMem = 1
+	require.NoError(t, g.Prepare(proc))
+
+	input := batch.NewWithSize(1)
+	input.Vecs[0] = testutil.MakeInt32Vector([]int32{1}, nil, proc.Mp())
+	input.SetRowCount(1)
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		if g.ctr.mp != nil {
+			g.Free(proc, true, context.Canceled)
+		}
+		input.Clean(proc.Mp())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	needSpill, err := g.buildOneBatch(proc, input)
+	require.NoError(t, err)
+	require.True(t, needSpill)
+	hashCodes := make([]uint64, g.ctr.hr.Hash.GroupCount())
+	hashCodes = g.ctr.hr.Hash.FillGroupHashes(hashCodes)
+	g.ctr.computeBucketIndex(hashCodes, 1)
+	require.Len(t, hashCodes, 1)
+	bucketIndex := int(hashCodes[0] & (spillNumBuckets - 1))
+
+	g.ctr.currentSpillBkt = make([]*spillBucket, spillNumBuckets)
+	for i := range g.ctr.currentSpillBkt {
+		g.ctr.currentSpillBkt[i] = &spillBucket{lv: 1, name: fmt.Sprintf("cancel-last-%d", i)}
+	}
+	file, err := os.CreateTemp(t.TempDir(), "group-cancel-last-*")
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(baseCtx)
+	writer := &cancelAfterWriteWriter{cancel: cancel}
+	g.ctr.currentSpillBkt[bucketIndex].file = file
+	g.ctr.currentSpillBkt[bucketIndex].writer = bufio.NewWriterSize(writer, 1)
+	proc.Ctx = ctx
+
+	_, _, err = g.ctr.spillDataToDisk(proc, g.OpAnalyzer, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, writer.writes)
+	require.Equal(t, int64(1), g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillRecords"])
+}
+
 func TestGroupSpillReloadCancellationCleansAndReuses(t *testing.T) {
+	const (
+		cancelAtLoadEntry = iota
+		cancelDuringBucketTransfer
+		cancelAfterBucketTransfer
+		cancelAfterFirstRecord
+	)
+
 	proc := testutil.NewProcess(t)
 	baseCtx := proc.Ctx
 
@@ -371,7 +537,8 @@ func TestGroupSpillReloadCancellationCleansAndReuses(t *testing.T) {
 	g.SpillMem = 4096
 	var spillFiles []*os.File
 	var child *colexec.MockOperator
-	installSpillInput := func() {
+	var nonEmptyBuckets int
+	installSpillInput := func(cancelPoint int) {
 		values := make([]int32, rows)
 		for i := range values {
 			values[i] = int32(i)
@@ -380,17 +547,34 @@ func TestGroupSpillReloadCancellationCleansAndReuses(t *testing.T) {
 		input.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
 		input.SetRowCount(rows)
 		spillFiles = nil
+		nonEmptyBuckets = 0
 		child = colexec.NewMockOperator().WithBatchs([]*batch.Batch{input}).WithEndOfDataCallback(func() {
 			for _, bkt := range g.ctr.currentSpillBkt {
 				if bkt.file != nil {
 					spillFiles = append(spillFiles, bkt.file)
 				}
+				if bkt.cnt > 0 {
+					nonEmptyBuckets++
+				}
 			}
+			checksAfterEOF := 3 // EOF boundary, final empty spill, load entry.
+			switch cancelPoint {
+			case cancelDuringBucketTransfer:
+				// Pass the first bucket-flush check and cancel before the second.
+				checksAfterEOF = 5
+			case cancelAfterBucketTransfer:
+				checksAfterEOF = nonEmptyBuckets + 4
+			case cancelAfterFirstRecord:
+				// Also pass every bucket flush, the post-transfer boundary, and
+				// the first record checkpoint; cancel before the second record.
+				checksAfterEOF = nonEmptyBuckets + 6
+			}
+			proc.Ctx = newCancelOnDoneCheckContext(baseCtx, checksAfterEOF)
 		})
 		g.Children = nil
 		g.AppendChild(child)
 	}
-	installSpillInput()
+	installSpillInput(cancelAtLoadEntry)
 	require.NoError(t, g.Prepare(proc))
 
 	t.Cleanup(func() {
@@ -403,7 +587,6 @@ func TestGroupSpillReloadCancellationCleansAndReuses(t *testing.T) {
 
 	// Cancel exactly at loadSpilledData entry. Current buckets have not
 	// transferred yet and Reset remains their sole cleanup owner.
-	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 5)
 	result, err := g.Call(proc)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, result.Batch)
@@ -420,12 +603,62 @@ func TestGroupSpillReloadCancellationCleansAndReuses(t *testing.T) {
 	child.Free(proc, true, context.Canceled)
 
 	proc.Ctx = baseCtx
-	installSpillInput()
+	installSpillInput(cancelDuringBucketTransfer)
 	require.NoError(t, g.Prepare(proc))
 
-	// Call entry, two child calls, the EOF phase boundary, load entry, first
-	// record, then cancel at the next per-record checkpoint.
-	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 7)
+	// One bucket has transferred to spillBkts; all remaining bucket files stay
+	// uniquely owned by currentSpillBkt.
+	result, err = g.Call(proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Equal(t, spillNumBuckets, nonEmptyBuckets)
+	require.NotNil(t, g.ctr.spillBkts)
+	require.Equal(t, 1, g.ctr.spillBkts.Len())
+	require.NotNil(t, g.ctr.currentSpillBkt)
+	transferredSlots := 0
+	for _, bkt := range g.ctr.currentSpillBkt {
+		if bkt == nil {
+			transferredSlots++
+		}
+	}
+	require.Equal(t, 1, transferredSlots)
+
+	transferFiles := append([]*os.File(nil), spillFiles...)
+	g.Reset(proc, true, context.Canceled)
+	for _, file := range transferFiles {
+		_, statErr := file.Stat()
+		require.Error(t, statErr)
+	}
+	child.Free(proc, true, context.Canceled)
+
+	proc.Ctx = baseCtx
+	installSpillInput(cancelAfterBucketTransfer)
+	require.NoError(t, g.Prepare(proc))
+
+	// All buckets have transferred to spillBkts, but cancellation is observed
+	// before a bucket is popped for reload.
+	result, err = g.Call(proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Nil(t, g.ctr.currentSpillBkt)
+	require.NotNil(t, g.ctr.spillBkts)
+	require.Equal(t, nonEmptyBuckets, g.ctr.spillBkts.Len())
+	require.Zero(t, g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillReloadBuckets"])
+
+	postTransferFiles := append([]*os.File(nil), spillFiles...)
+	g.Reset(proc, true, context.Canceled)
+	for _, file := range postTransferFiles {
+		_, statErr := file.Stat()
+		require.Error(t, statErr)
+	}
+	child.Free(proc, true, context.Canceled)
+
+	proc.Ctx = baseCtx
+	installSpillInput(cancelAfterFirstRecord)
+	require.NoError(t, g.Prepare(proc))
+
+	// After EOF: pass the phase boundaries and every bucket ownership transfer,
+	// then process one record and cancel at the next per-record checkpoint.
 	result, err = g.Call(proc)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, result.Batch)
@@ -634,6 +867,47 @@ func TestMergeGroupHonorsCancellationAfterInput(t *testing.T) {
 	outputs := collectBatches(t, merge, proc)
 	require.Len(t, outputs, 1)
 	require.Equal(t, 3, outputs[0].RowCount())
+}
+
+func TestMergeGroupSpillWriteHonorsCancellationAfterInputBatch(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	baseCtx := proc.Ctx
+	partial := batch.NewWithSize(1)
+	partial.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3}, nil, proc.Mp())
+	partial.SetRowCount(3)
+
+	var extra bytes.Buffer
+	mtyp := int32(H8)
+	nullable := false
+	nAggs := int32(0)
+	extra.Write(types.EncodeInt32(&mtyp))
+	extra.Write(types.EncodeBool(&nullable))
+	extra.Write(types.EncodeInt32(&nAggs))
+	partial.ExtraBuf = extra.Bytes()
+
+	ctx, cancel := context.WithCancel(baseCtx)
+	proc.Ctx = ctx
+	child := colexec.NewMockOperator().
+		WithBatchs([]*batch.Batch{partial}).
+		WithBatchCallback(func(int) { cancel() })
+	merge := newMergeGroupOp(nil)
+	merge.SpillMem = 1
+	merge.AppendChild(child)
+	require.NoError(t, merge.Prepare(proc))
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		merge.Free(proc, true, context.Canceled)
+		child.Free(proc, true, context.Canceled)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(merge, proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Zero(t, merge.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillRecords"])
+	require.Nil(t, merge.ctr.currentSpillBkt)
 }
 
 func TestMergeGroupFreesSpillAggListAfterBatchMerge(t *testing.T) {

--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -408,6 +408,63 @@ func TestGroupSpillWriteHonorsCancellationAfterInputBatch(t *testing.T) {
 	require.Nil(t, g.ctr.currentSpillBkt)
 }
 
+func TestGroupStreamingDoesNotPublishAfterInputCancellation(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	baseCtx := proc.Ctx
+	ctx, cancel := context.WithCancel(baseCtx)
+	proc.Ctx = ctx
+
+	input := batch.NewWithSize(1)
+	input.Vecs[0] = testutil.MakeInt32Vector([]int32{4, 1, 3, 2}, nil, proc.Mp())
+	input.SetRowCount(4)
+	child := colexec.NewMockOperator().
+		WithBatchs([]*batch.Batch{input}).
+		WithBatchCallback(func(int) { cancel() })
+	g := newGroupOp(proc, []*plan.Expr{colExpr(0, types.T_int32)}, []aggexec.AggFuncExecExpression{countStarAgg()})
+	g.NeedEval = false
+	g.SpillMem = 1
+	g.AppendChild(child)
+	require.NoError(t, g.Prepare(proc))
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		g.Free(proc, true, context.Canceled)
+		child.Free(proc, true, context.Canceled)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(g, proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Equal(t, vm.Eval, g.ctr.state)
+	require.Zero(t, g.ctr.currBatchIdx)
+	require.NotEmpty(t, g.ctr.groupByBatches)
+	require.Empty(t, g.ctr.groupByBatches[0].ExtraBuf)
+
+	g.Reset(proc, true, context.Canceled)
+	require.Nil(t, g.ctr.mp)
+	child.Free(proc, true, context.Canceled)
+
+	proc.Ctx = baseCtx
+	fresh := batch.NewWithSize(1)
+	fresh.Vecs[0] = testutil.MakeInt32Vector([]int32{8, 5, 7, 6}, nil, proc.Mp())
+	fresh.SetRowCount(4)
+	child = colexec.NewMockOperator().WithBatchs([]*batch.Batch{fresh})
+	g.Children = nil
+	g.AppendChild(child)
+	require.NoError(t, g.Prepare(proc))
+
+	freshResult, err := vm.Exec(g, proc)
+	require.NoError(t, err)
+	require.NotNil(t, freshResult.Batch)
+	require.Equal(t, 4, freshResult.Batch.RowCount())
+
+	end, err := vm.Exec(g, proc)
+	require.NoError(t, err)
+	require.Nil(t, end.Batch)
+}
+
 func TestGroupSpillWriteStopsAtBucketBoundary(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	baseCtx := proc.Ctx

--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -295,6 +295,39 @@ func TestGroupSpillReloadKeepsPreallocationBounded(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
+func TestGroupSpillReloadHonorsCancellationAfterInput(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	const rows = 65536
+	values := make([]int32, rows)
+	for i := range values {
+		values[i] = int32(i)
+	}
+	input := batch.NewWithSize(1)
+	input.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	input.SetRowCount(rows)
+
+	ctx, cancel := context.WithCancel(proc.Ctx)
+	proc.Ctx = ctx
+	child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{input}).WithEndOfDataCallback(cancel)
+	g := newGroupOp(proc, []*plan.Expr{colExpr(0, types.T_int32)}, []aggexec.AggFuncExecExpression{countStarAgg()})
+	g.SpillMem = 4096
+	g.AppendChild(child)
+	require.NoError(t, g.Prepare(proc))
+
+	t.Cleanup(func() {
+		g.Free(proc, true, context.Canceled)
+		child.Free(proc, true, context.Canceled)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(g, proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Zero(t, g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillReloadBuckets"])
+}
+
 func TestGroupedOrderedGroupConcatComposesWithGenericSpill(t *testing.T) {
 	for _, distinct := range []bool{false, true} {
 		t.Run(fmt.Sprintf("distinct=%t", distinct), func(t *testing.T) {
@@ -414,6 +447,40 @@ func TestMergeGroupPreservesLateNullableGroupKeys(t *testing.T) {
 	require.Equal(t, len(finalBatches)+1, merge.OpAnalyzer.GetOpStats().CallNum)
 	assertMergedTicketCounts(t, finalBatches, 2, 2)
 	merge.Free(proc, false, nil)
+}
+
+func TestMergeGroupHonorsCancellationAfterInput(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	partial := batch.NewWithSize(1)
+	partial.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3}, nil, proc.Mp())
+	partial.SetRowCount(3)
+
+	var extra bytes.Buffer
+	mtyp := int32(H8)
+	nullable := false
+	nAggs := int32(0)
+	extra.Write(types.EncodeInt32(&mtyp))
+	extra.Write(types.EncodeBool(&nullable))
+	extra.Write(types.EncodeInt32(&nAggs))
+	partial.ExtraBuf = extra.Bytes()
+
+	ctx, cancel := context.WithCancel(proc.Ctx)
+	proc.Ctx = ctx
+	child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{partial}).WithEndOfDataCallback(cancel)
+	merge := newMergeGroupOp(nil)
+	merge.AppendChild(child)
+	require.NoError(t, merge.Prepare(proc))
+
+	t.Cleanup(func() {
+		merge.Free(proc, true, context.Canceled)
+		child.Free(proc, true, context.Canceled)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(merge, proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
 }
 
 func TestMergeGroupFreesSpillAggListAfterBatchMerge(t *testing.T) {

--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -90,6 +91,39 @@ func newMergeGroupOp(aggs []aggexec.AggFuncExecExpression) *MergeGroup {
 		OperatorInfo: vm.OperatorInfo{Idx: 0, IsFirst: false, IsLast: false},
 	}
 	return mg
+}
+
+type cancelOnDoneCheckContext struct {
+	context.Context
+	remaining int
+	done      chan struct{}
+}
+
+func newCancelOnDoneCheckContext(parent context.Context, checks int) *cancelOnDoneCheckContext {
+	return &cancelOnDoneCheckContext{
+		Context:   parent,
+		remaining: checks,
+		done:      make(chan struct{}),
+	}
+}
+
+func (ctx *cancelOnDoneCheckContext) Done() <-chan struct{} {
+	if ctx.remaining > 0 {
+		ctx.remaining--
+		if ctx.remaining == 0 {
+			close(ctx.done)
+		}
+	}
+	return ctx.done
+}
+
+func (ctx *cancelOnDoneCheckContext) Err() error {
+	select {
+	case <-ctx.done:
+		return context.Canceled
+	default:
+		return nil
+	}
 }
 
 func resetChildren(g *Group, proc *process.Process) {
@@ -328,6 +362,105 @@ func TestGroupSpillReloadHonorsCancellationAfterInput(t *testing.T) {
 	require.Zero(t, g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillReloadBuckets"])
 }
 
+func TestGroupSpillReloadCancellationCleansAndReuses(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	baseCtx := proc.Ctx
+
+	const rows = 65536
+	g := newGroupOp(proc, []*plan.Expr{colExpr(0, types.T_int32)}, []aggexec.AggFuncExecExpression{countStarAgg()})
+	g.SpillMem = 4096
+	var spillFiles []*os.File
+	var child *colexec.MockOperator
+	installSpillInput := func() {
+		values := make([]int32, rows)
+		for i := range values {
+			values[i] = int32(i)
+		}
+		input := batch.NewWithSize(1)
+		input.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+		input.SetRowCount(rows)
+		spillFiles = nil
+		child = colexec.NewMockOperator().WithBatchs([]*batch.Batch{input}).WithEndOfDataCallback(func() {
+			for _, bkt := range g.ctr.currentSpillBkt {
+				if bkt.file != nil {
+					spillFiles = append(spillFiles, bkt.file)
+				}
+			}
+		})
+		g.Children = nil
+		g.AppendChild(child)
+	}
+	installSpillInput()
+	require.NoError(t, g.Prepare(proc))
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		g.Free(proc, false, nil)
+		child.Free(proc, false, nil)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	// Cancel exactly at loadSpilledData entry. Current buckets have not
+	// transferred yet and Reset remains their sole cleanup owner.
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 5)
+	result, err := g.Call(proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Zero(t, g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillReloadBuckets"])
+	require.NotEmpty(t, g.ctr.currentSpillBkt)
+	require.NotEmpty(t, spillFiles)
+	entryFiles := append([]*os.File(nil), spillFiles...)
+
+	g.Reset(proc, true, context.Canceled)
+	for _, file := range entryFiles {
+		_, statErr := file.Stat()
+		require.Error(t, statErr)
+	}
+	child.Free(proc, true, context.Canceled)
+
+	proc.Ctx = baseCtx
+	installSpillInput()
+	require.NoError(t, g.Prepare(proc))
+
+	// Call entry, two child calls, the EOF phase boundary, load entry, first
+	// record, then cancel at the next per-record checkpoint.
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 7)
+	result, err = g.Call(proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Positive(t, g.OpAnalyzer.GetOpStats().ExtraStats["GroupSpillReloadRecords"])
+	require.NotEmpty(t, spillFiles)
+	require.NotNil(t, g.ctr.spillBkts)
+	require.Positive(t, g.ctr.spillBkts.Len())
+
+	g.Reset(proc, true, context.Canceled)
+	require.Nil(t, g.ctr.mp)
+	require.Nil(t, g.ctr.aggList)
+	require.Nil(t, g.ctr.spillAggList)
+	require.Nil(t, g.ctr.currentSpillBkt)
+	for _, file := range spillFiles {
+		_, statErr := file.Stat()
+		require.Error(t, statErr)
+	}
+	child.Free(proc, true, context.Canceled)
+
+	proc.Ctx = baseCtx
+	fresh := batch.NewWithSize(1)
+	fresh.Vecs[0] = testutil.MakeInt32Vector([]int32{4, 1, 3, 2}, nil, proc.Mp())
+	fresh.SetRowCount(4)
+	child = colexec.NewMockOperator().WithBatchs([]*batch.Batch{fresh})
+	g.Children = nil
+	g.AppendChild(child)
+	require.NoError(t, g.Prepare(proc))
+
+	var outputRows int
+	for _, output := range collectBatches(t, g, proc) {
+		outputRows += output.RowCount()
+	}
+	require.Equal(t, 4, outputRows)
+}
+
 func TestGroupedOrderedGroupConcatComposesWithGenericSpill(t *testing.T) {
 	for _, distinct := range []bool{false, true} {
 		t.Run(fmt.Sprintf("distinct=%t", distinct), func(t *testing.T) {
@@ -451,6 +584,7 @@ func TestMergeGroupPreservesLateNullableGroupKeys(t *testing.T) {
 
 func TestMergeGroupHonorsCancellationAfterInput(t *testing.T) {
 	proc := testutil.NewProcess(t)
+	baseCtx := proc.Ctx
 	partial := batch.NewWithSize(1)
 	partial.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 2, 3}, nil, proc.Mp())
 	partial.SetRowCount(3)
@@ -472,8 +606,9 @@ func TestMergeGroupHonorsCancellationAfterInput(t *testing.T) {
 	require.NoError(t, merge.Prepare(proc))
 
 	t.Cleanup(func() {
-		merge.Free(proc, true, context.Canceled)
-		child.Free(proc, true, context.Canceled)
+		proc.Ctx = baseCtx
+		merge.Free(proc, false, nil)
+		child.Free(proc, false, nil)
 		proc.Free()
 		require.Zero(t, proc.Mp().CurrNB())
 	})
@@ -481,6 +616,24 @@ func TestMergeGroupHonorsCancellationAfterInput(t *testing.T) {
 	result, err := vm.Exec(merge, proc)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, result.Batch)
+
+	merge.Reset(proc, true, context.Canceled)
+	require.Nil(t, merge.ctr.mp)
+	child.Free(proc, true, context.Canceled)
+
+	proc.Ctx = baseCtx
+	freshPartial := batch.NewWithSize(1)
+	freshPartial.Vecs[0] = testutil.MakeInt32Vector([]int32{3, 1, 2}, nil, proc.Mp())
+	freshPartial.SetRowCount(3)
+	freshPartial.ExtraBuf = append(freshPartial.ExtraBuf[:0], extra.Bytes()...)
+	child = colexec.NewMockOperator().WithBatchs([]*batch.Batch{freshPartial})
+	merge.Children = nil
+	merge.AppendChild(child)
+	require.NoError(t, merge.Prepare(proc))
+
+	outputs := collectBatches(t, merge, proc)
+	require.Len(t, outputs, 1)
+	require.Equal(t, 3, outputs[0].RowCount())
 }
 
 func TestMergeGroupFreesSpillAggListAfterBatchMerge(t *testing.T) {

--- a/pkg/sql/colexec/group/helper.go
+++ b/pkg/sql/colexec/group/helper.go
@@ -234,6 +234,10 @@ func (ctr *container) computeBucketIndex(hashCodes []uint64, myLv uint64) {
 }
 
 func (ctr *container) spillDataToDisk(proc *process.Process, opAnalyzer process.Analyzer, parentBkt *spillBucket) (int64, int64, error) {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return 0, 0, err
+	}
+
 	var totalBytes, totalRows int64
 	var parentLv int
 	if parentBkt != nil {
@@ -338,6 +342,10 @@ func (ctr *container) spillDataToDisk(proc *process.Process, opAnalyzer process.
 
 	hcOffset := 0
 	for nthBatch, gb := range ctr.groupByBatches {
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			return 0, 0, err
+		}
+
 		rc := gb.RowCount()
 		if rc == 0 {
 			continue
@@ -369,6 +377,10 @@ func (ctr *container) spillDataToDisk(proc *process.Process, opAnalyzer process.
 		bktFlags := ctr.spillFlagFlat[:rc]
 
 		for _, i := range ctr.spillNonEmptyBuckets {
+			if err, canceled := vm.CancelCheck(proc); canceled {
+				return 0, 0, err
+			}
+
 			indices := bucketRowIds[i]
 			cnt := int64(len(indices))
 
@@ -443,6 +455,13 @@ func (ctr *container) spillDataToDisk(proc *process.Process, opAnalyzer process.
 				bktFlags[idx] = 0
 			}
 		}
+
+		// The last bucket has no following loop boundary. Check once more so
+		// cancellation during its serialization or write is still observed
+		// before starting another spill phase.
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			return 0, 0, err
+		}
 	}
 	opStats.AddExtraStat("GroupSpillSerializedBytes", totalBytes)
 	opStats.AddExtraStat("GroupSpillAggChunkHeadersOmitted", compactedAggChunks)
@@ -463,18 +482,28 @@ func (ctr *container) loadSpilledData(proc *process.Process, opAnalyzer process.
 		if ctr.spillBkts == nil {
 			ctr.spillBkts = list.New[*spillBucket]()
 		}
-		for _, bkt := range ctr.currentSpillBkt {
+		for i, bkt := range ctr.currentSpillBkt {
 			if bkt.cnt > 0 {
+				if err, canceled := vm.CancelCheck(proc); canceled {
+					return false, err
+				}
 				if err := bkt.flushWriter(); err != nil {
 					bkt.free()
+					ctr.currentSpillBkt[i] = nil
 					return false, err
 				}
 				ctr.spillBkts.PushBack(bkt)
 			} else {
 				bkt.free()
 			}
+			// Ownership has moved to spillBkts or ended at free(). Do not leave
+			// a second source reference behind if a later flush fails/cancels.
+			ctr.currentSpillBkt[i] = nil
 		}
 		ctr.currentSpillBkt = nil
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			return false, err
+		}
 	}
 
 	// then, if there is no spill bucket in the queue, done.

--- a/pkg/sql/colexec/group/helper.go
+++ b/pkg/sql/colexec/group/helper.go
@@ -454,6 +454,10 @@ func (ctr *container) spillDataToDisk(proc *process.Process, opAnalyzer process.
 
 // load spilled data from the spill bucket queue.
 func (ctr *container) loadSpilledData(proc *process.Process, opAnalyzer process.Analyzer, aggExprs []aggexec.AggFuncExecExpression) (_ bool, retErr error) {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return false, err
+	}
+
 	// first, if there is current spill bucket, transfer it to the spill bucket queue.
 	if ctr.currentSpillBkt != nil {
 		if ctr.spillBkts == nil {
@@ -531,6 +535,10 @@ func (ctr *container) loadSpilledData(proc *process.Process, opAnalyzer process.
 	bufferedFile := ctr.spillReader
 
 	for {
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			return false, err
+		}
+
 		// load next batch from the spill bucket.
 		readStart := time.Now()
 		cnt, err := types.ReadInt64(bufferedFile)

--- a/pkg/sql/colexec/group/mergeGroup.go
+++ b/pkg/sql/colexec/group/mergeGroup.go
@@ -95,6 +95,14 @@ func (mergeGroup *MergeGroup) Call(proc *process.Process) (vm.CallResult, error)
 			}
 		}
 
+		if mergeGroup.ctr.inputDone {
+			// EOF and cancellation can arrive in the same child call. Observe
+			// cancellation before final merge and spill materialization.
+			if err, isCancel := vm.CancelCheck(proc); isCancel {
+				return vm.CancelResult, err
+			}
+		}
+
 		// has partial results, merge them.
 		if mergeGroup.PartialResults != nil {
 			for i, ag := range mergeGroup.ctr.aggList {

--- a/pkg/sql/colexec/mergeorder/order.go
+++ b/pkg/sql/colexec/mergeorder/order.go
@@ -500,6 +500,11 @@ func (mergeOrder *MergeOrder) Call(proc *process.Process) (vm.CallResult, error)
 			}
 
 			if input.Batch == nil {
+				// The child may cancel the process while returning EOF, after this
+				// MergeOrder invocation has passed vm.Exec's entry cancellation check.
+				if err, canceled := vm.CancelCheck(proc); canceled {
+					return vm.CancelResult, err
+				}
 				if ctr.spilling {
 					if err = ctr.prepareSpillFinalMerge(proc, mergeOrder.OrderBySpecs, analyzer); err != nil {
 						return input, err

--- a/pkg/sql/colexec/mergeorder/order_test.go
+++ b/pkg/sql/colexec/mergeorder/order_test.go
@@ -184,6 +184,19 @@ func (ctx *cancelOnDoneCheckContext) Err() error {
 	}
 }
 
+type trackingMutableFileService struct {
+	fileservice.MutableFileService
+	files []*os.File
+}
+
+func (fs *trackingMutableFileService) CreateAndRemoveFile(ctx context.Context, filePath string) (*os.File, error) {
+	file, err := fs.MutableFileService.CreateAndRemoveFile(ctx, filePath)
+	if err == nil {
+		fs.files = append(fs.files, file)
+	}
+	return file, err
+}
+
 func makeTestCases(t *testing.T) []orderTestCase {
 	return []orderTestCase{
 		newTestCase(t, []types.Type{types.T_int8.ToType()}, []*plan.OrderBySpec{{Expr: newExpression(0, types.T_int8), Flag: 0}}),
@@ -302,6 +315,7 @@ func TestOrderSpillFinalMergeHonorsCancellationAfterInput(t *testing.T) {
 		SpillThreshold: 1,
 		OperatorBase:   vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
 	}
+	baseCtx := proc.Ctx
 	ctx, cancel := context.WithCancel(proc.Ctx)
 	proc.Ctx = ctx
 	child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{
@@ -313,8 +327,9 @@ func TestOrderSpillFinalMergeHonorsCancellationAfterInput(t *testing.T) {
 	require.NoError(t, arg.Prepare(proc))
 
 	t.Cleanup(func() {
-		arg.Free(proc, true, context.Canceled)
-		child.Free(proc, true, context.Canceled)
+		proc.Ctx = baseCtx
+		arg.Free(proc, false, nil)
+		child.Free(proc, false, nil)
 		proc.Free()
 		require.Zero(t, proc.Mp().CurrNB())
 	})
@@ -323,6 +338,22 @@ func TestOrderSpillFinalMergeHonorsCancellationAfterInput(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, result.Batch)
 	require.Empty(t, arg.ctr.spillReaders)
+
+	arg.Reset(proc, true, context.Canceled)
+	require.Empty(t, arg.ctr.spillRuns)
+	require.Empty(t, arg.ctr.spillReaders)
+	child.Free(proc, true, context.Canceled)
+
+	proc.Ctx = baseCtx
+	child = colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		newValuesBatch(proc, []int8{3}),
+		newValuesBatch(proc, []int8{1}),
+		newValuesBatch(proc, []int8{2}),
+	})
+	arg.Children = nil
+	arg.AppendChild(child)
+	require.NoError(t, arg.Prepare(proc))
+	require.Equal(t, []int8{1, 2, 3}, collectInt8Results(t, arg, proc, 0))
 }
 
 func TestSpillCancellationEntryCheckpoints(t *testing.T) {
@@ -415,6 +446,135 @@ func TestMergeRunsToSpillCancellationCheckpoints(t *testing.T) {
 			for _, run := range runs {
 				require.Nil(t, run.file)
 			}
+		})
+	}
+}
+
+func TestOpenSpillReadersCancellationPreservesOwnership(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	ctr := &container{
+		compares:        []compare.Compare{compare.New(types.T_int8.ToType(), false, false)},
+		executors:       make([]colexec.ExpressionExecutor, 1),
+		spillColPos:     []int32{-1},
+		spillKeyIndexes: []int{0},
+	}
+	analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-open-readers")
+	runs := []*spillRun{
+		newCancellationTestSpillRun(t, proc, ctr, analyzer, []int8{1}),
+		newCancellationTestSpillRun(t, proc, ctr, analyzer, []int8{2}),
+	}
+	firstFile, secondFile := runs[0].file, runs[1].file
+	baseCtx := proc.Ctx
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		ctr.cleanupSpill(proc)
+		closeSpillRuns(runs)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 2)
+	err := ctr.openSpillReaders(proc, runs)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Len(t, ctr.spillReaders, 1)
+	require.Nil(t, runs[0].file)
+	require.Same(t, secondFile, runs[1].file)
+	_, err = firstFile.Stat()
+	require.NoError(t, err)
+	_, err = secondFile.Stat()
+	require.NoError(t, err)
+
+	ctr.cleanupSpill(proc)
+	_, err = firstFile.Stat()
+	require.Error(t, err)
+	_, err = secondFile.Stat()
+	require.NoError(t, err)
+	closeSpillRuns(runs)
+	_, err = secondFile.Stat()
+	require.Error(t, err)
+}
+
+func TestReduceSpillRunsCleansCompletedRuns(t *testing.T) {
+	const inputRunCount = spillMergeFanIn + 2
+
+	tests := []struct {
+		name             string
+		cancelAfterFirst bool
+		corruptLaterRun  bool
+		wantError        error
+	}{
+		{
+			name:             "cancellation after completed fan-in group",
+			cancelAfterFirst: true,
+			wantError:        context.Canceled,
+		},
+		{
+			name:            "later merge read error",
+			corruptLaterRun: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			baseCtx := proc.Ctx
+			baseFS, err := proc.GetSpillFileService()
+			require.NoError(t, err)
+			trackingFS := &trackingMutableFileService{MutableFileService: baseFS}
+			ctr := &container{
+				compares:        []compare.Compare{compare.New(types.T_int8.ToType(), false, false)},
+				executors:       make([]colexec.ExpressionExecutor, 1),
+				spillColPos:     []int32{-1},
+				spillKeyIndexes: []int{0},
+				spillFS:         trackingFS,
+			}
+			analyzer := process.NewAnalyzer(0, false, false, "mergeorder-reduce-ownership")
+			runs := make([]*spillRun, 0, inputRunCount)
+			for i := range inputRunCount {
+				runs = append(runs, newCancellationTestSpillRun(t, proc, ctr, analyzer, []int8{int8(i)}))
+			}
+			ctr.spillRuns = runs
+			if test.cancelAfterFirst {
+				// Reduction check, merge entry, one check per source reader,
+				// chunk start, chunk completion, then the next group check.
+				proc.Ctx = newCancelOnDoneCheckContext(baseCtx, spillMergeFanIn+5)
+			}
+			if test.corruptLaterRun {
+				require.NoError(t, runs[spillMergeFanIn].file.Truncate(4))
+				_, err = runs[spillMergeFanIn].file.Seek(0, io.SeekStart)
+				require.NoError(t, err)
+			}
+
+			t.Cleanup(func() {
+				proc.Ctx = baseCtx
+				ctr.cleanupSpill(proc)
+				proc.Free()
+				require.Zero(t, proc.Mp().CurrNB())
+			})
+
+			err = ctr.reduceSpillRuns(proc, analyzer)
+			if test.wantError != nil {
+				require.ErrorIs(t, err, test.wantError)
+			} else {
+				require.Error(t, err)
+			}
+			require.Len(t, trackingFS.files, inputRunCount+1)
+			completedRunFile := trackingFS.files[inputRunCount]
+			_, statErr := completedRunFile.Stat()
+			require.Error(t, statErr)
+
+			for i := 0; i < spillMergeFanIn; i++ {
+				require.Nil(t, runs[i].file)
+			}
+			if test.wantError == nil {
+				// The failing run transferred to its reader before the read;
+				// only the not-yet-opened final run remains source-owned.
+				require.Nil(t, runs[spillMergeFanIn].file)
+			}
+			require.NotNil(t, runs[spillMergeFanIn+1].file)
+			_, statErr = runs[spillMergeFanIn+1].file.Stat()
+			require.NoError(t, statErr)
 		})
 	}
 }

--- a/pkg/sql/colexec/mergeorder/order_test.go
+++ b/pkg/sql/colexec/mergeorder/order_test.go
@@ -148,6 +148,42 @@ func (failWriter) Write(_ []byte) (int, error) {
 	return 0, io.ErrClosedPipe
 }
 
+// cancelOnDoneCheckContext deterministically cancels on the Nth observation of
+// Done. The spill paths are synchronous, so this lets tests select an exact
+// phase boundary without sleeps or scheduler races.
+type cancelOnDoneCheckContext struct {
+	context.Context
+	remaining int
+	done      chan struct{}
+}
+
+func newCancelOnDoneCheckContext(parent context.Context, checks int) *cancelOnDoneCheckContext {
+	return &cancelOnDoneCheckContext{
+		Context:   parent,
+		remaining: checks,
+		done:      make(chan struct{}),
+	}
+}
+
+func (ctx *cancelOnDoneCheckContext) Done() <-chan struct{} {
+	if ctx.remaining > 0 {
+		ctx.remaining--
+		if ctx.remaining == 0 {
+			close(ctx.done)
+		}
+	}
+	return ctx.done
+}
+
+func (ctx *cancelOnDoneCheckContext) Err() error {
+	select {
+	case <-ctx.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
 func makeTestCases(t *testing.T) []orderTestCase {
 	return []orderTestCase{
 		newTestCase(t, []types.Type{types.T_int8.ToType()}, []*plan.OrderBySpec{{Expr: newExpression(0, types.T_int8), Flag: 0}}),
@@ -287,6 +323,133 @@ func TestOrderSpillFinalMergeHonorsCancellationAfterInput(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, result.Batch)
 	require.Empty(t, arg.ctr.spillReaders)
+}
+
+func TestSpillCancellationEntryCheckpoints(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	baseCtx := proc.Ctx
+	analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-entry")
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	t.Run("open readers", func(t *testing.T) {
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		err := (&container{}).openSpillReaders(proc, []*spillRun{{}})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("merge runs", func(t *testing.T) {
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		merged, err := (&container{}).mergeRunsToSpill(proc, []*spillRun{{}, {}}, analyzer)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Nil(t, merged)
+	})
+
+	t.Run("reduce runs", func(t *testing.T) {
+		ctr := &container{spillRuns: make([]*spillRun, spillMergeFanIn+1)}
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		require.ErrorIs(t, ctr.reduceSpillRuns(proc, analyzer), context.Canceled)
+	})
+
+	t.Run("prepare final merge", func(t *testing.T) {
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		err := (&container{}).prepareSpillFinalMerge(proc, nil, analyzer)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("send result", func(t *testing.T) {
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		var result vm.CallResult
+		done, err := (&container{}).sendSpillResult(proc, &result)
+		require.ErrorIs(t, err, context.Canceled)
+		require.False(t, done)
+		require.Nil(t, result.Batch)
+	})
+}
+
+func TestMergeRunsToSpillCancellationCheckpoints(t *testing.T) {
+	const (
+		inputRunCount              = 2
+		beforeMaterializationCheck = 1 + inputRunCount + 1 // entry, each reader, chunk start
+		beforeSpillWriteCheck      = beforeMaterializationCheck + 1
+	)
+	tests := []struct {
+		name          string
+		cancelAtCheck int
+	}{
+		{name: "before materialization", cancelAtCheck: beforeMaterializationCheck},
+		{name: "before spill write", cancelAtCheck: beforeSpillWriteCheck},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			ctr := &container{
+				compares:        []compare.Compare{compare.New(types.T_int8.ToType(), false, false)},
+				executors:       make([]colexec.ExpressionExecutor, 1),
+				spillColPos:     []int32{-1},
+				spillKeyIndexes: []int{0},
+			}
+			analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-merge-runs")
+			runs := []*spillRun{
+				newCancellationTestSpillRun(t, proc, ctr, analyzer, []int8{1, 3}),
+				newCancellationTestSpillRun(t, proc, ctr, analyzer, []int8{2, 4}),
+			}
+			baseCtx := proc.Ctx
+
+			t.Cleanup(func() {
+				proc.Ctx = baseCtx
+				ctr.cleanupSpill(proc)
+				closeSpillRuns(runs)
+				proc.Free()
+				require.Zero(t, proc.Mp().CurrNB())
+			})
+
+			proc.Ctx = newCancelOnDoneCheckContext(baseCtx, test.cancelAtCheck)
+			merged, err := ctr.mergeRunsToSpill(proc, runs, analyzer)
+			require.ErrorIs(t, err, context.Canceled)
+			require.Nil(t, merged)
+			for _, run := range runs {
+				require.Nil(t, run.file)
+			}
+		})
+	}
+}
+
+func TestSendSpillResultHonorsCancellationBeforePublish(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	ctr := &container{
+		compares:        []compare.Compare{compare.New(types.T_int8.ToType(), false, false)},
+		executors:       make([]colexec.ExpressionExecutor, 1),
+		spillColPos:     []int32{-1},
+		spillKeyIndexes: []int{0},
+	}
+	analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-send")
+	run := newCancellationTestSpillRun(t, proc, ctr, analyzer, []int8{1, 2})
+	require.NoError(t, ctr.openSpillReaders(proc, []*spillRun{run}))
+	baseCtx := proc.Ctx
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		ctr.cleanupSpill(proc)
+		if ctr.buf != nil {
+			ctr.buf.Clean(proc.Mp())
+			ctr.buf = nil
+		}
+		closeSpillRuns([]*spillRun{run})
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 2)
+	var result vm.CallResult
+	done, err := ctr.sendSpillResult(proc, &result)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, done)
+	require.Nil(t, result.Batch)
 }
 
 func TestOrderSpillMultiPass(t *testing.T) {
@@ -1553,6 +1716,30 @@ func newValuesBatch(proc *process.Process, values []int8) *batch.Batch {
 		zs[i] = 1
 	}
 	return testutil.NewBatchWithVectors([]*vector.Vector{vec}, zs)
+}
+
+func newCancellationTestSpillRun(
+	t testing.TB,
+	proc *process.Process,
+	ctr *container,
+	analyzer process.Analyzer,
+	values []int8,
+) *spillRun {
+	t.Helper()
+	bat := newValuesBatch(proc, values)
+	defer bat.Clean(proc.Mp())
+
+	run, err := ctr.createSpillRun(proc)
+	require.NoError(t, err)
+	writer := bufio.NewWriterSize(run.file, spillIOBufferSize)
+	_, _, err = writeSpillBatch(proc, bat, []*vector.Vector{bat.Vecs[0]}, writer, &ctr.spillWriteBuf, analyzer)
+	require.NoError(t, err)
+	require.NoError(t, writer.Flush())
+	_, err = run.file.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	run.batchCount = 1
+	run.rowCount = int64(bat.RowCount())
+	return run
 }
 
 func newNullableValuesBatch(proc *process.Process, values []int8, nulls []uint64) *batch.Batch {

--- a/pkg/sql/colexec/mergeorder/order_test.go
+++ b/pkg/sql/colexec/mergeorder/order_test.go
@@ -174,6 +174,21 @@ func (r *callbackEOFReader) Read([]byte) (int, error) {
 	return 0, io.EOF
 }
 
+type cancelAfterReadReader struct {
+	reader io.Reader
+	cancel context.CancelFunc
+	reads  int
+}
+
+func (r *cancelAfterReadReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.reads++
+	if r.reads == 1 {
+		r.cancel()
+	}
+	return n, err
+}
+
 // cancelOnDoneCheckContext deterministically cancels on the Nth observation of
 // Done. The spill paths are synchronous, so this lets tests select an exact
 // phase boundary without sleeps or scheduler races.
@@ -579,9 +594,13 @@ func TestSpillCancellationEntryCheckpoints(t *testing.T) {
 
 func TestMergeRunsToSpillCancellationCheckpoints(t *testing.T) {
 	const (
-		inputRunCount              = 2
-		beforeMaterializationCheck = 1 + inputRunCount + 1 // entry, each reader, chunk start
-		beforeSpillWriteCheck      = beforeMaterializationCheck + 1
+		inputRunCount = 2
+		// Merge entry, then open-loop/read-entry/read-completion for each
+		// source reader, followed by the outer materialization check.
+		beforeMaterializationCheck = 1 + inputRunCount*3 + 1
+		// Each single-batch source then observes EOF at its next-read entry,
+		// followed by the completed-chunk check immediately before spill write.
+		beforeSpillWriteCheck = beforeMaterializationCheck + inputRunCount + 1
 	)
 	tests := []struct {
 		name          string
@@ -657,10 +676,11 @@ func TestMergeRunsToSpillStopsAtChunkBoundary(t *testing.T) {
 		require.Zero(t, proc.Mp().CurrNB())
 	})
 
-	// Entry, two reader-open checks, and the outer materialization check pass.
+	// Entry, both reader open/read/read-completion triplets, and the outer
+	// materialization check pass.
 	// Cancellation is observed after the first 64-row winner chunk, before
 	// the remaining rows are copied or an output batch is written.
-	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 5)
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 9)
 	merged, err := ctr.mergeRunsToSpill(proc, runs, analyzer)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, merged)
@@ -696,7 +716,9 @@ func TestOpenSpillReadersCancellationPreservesOwnership(t *testing.T) {
 		require.Zero(t, proc.Mp().CurrNB())
 	})
 
-	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 2)
+	// The first reader uses checks 1-3 for open, read entry, and successful
+	// read completion. Cancel at the second run's open-loop ownership boundary.
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 4)
 	err := ctr.openSpillReaders(proc, runs)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Len(t, ctr.spillReaders, 1)
@@ -715,6 +737,90 @@ func TestOpenSpillReadersCancellationPreservesOwnership(t *testing.T) {
 	closeSpillRuns(runs)
 	_, err = secondFile.Stat()
 	require.Error(t, err)
+}
+
+func TestSpillReaderRolloverCancellationBoundaries(t *testing.T) {
+	t.Run("before multi-batch refill", func(t *testing.T) {
+		proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+		baseCtx := proc.Ctx
+		ctr := &container{
+			compares:        []compare.Compare{compare.New(types.T_int8.ToType(), false, false)},
+			executors:       make([]colexec.ExpressionExecutor, 1),
+			spillColPos:     []int32{-1},
+			spillKeyIndexes: []int{0},
+		}
+		analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-rollover")
+		run := newCancellationTestSpillRunBatches(
+			t, proc, ctr, analyzer,
+			[]int8{1, 2},
+			[]int8{3, 4},
+		)
+		file := run.file
+		require.Equal(t, 2, run.batchCount)
+		require.NoError(t, ctr.openSpillReaders(proc, []*spillRun{run}))
+		require.Nil(t, run.file)
+		require.Len(t, ctr.spillReaders, 1)
+		reader := ctr.spillReaders[0]
+		require.Equal(t, []int8{1, 2}, vector.MustFixedColWithTypeCheck[int8](reader.batch.Vecs[0]))
+		bufferedBefore := reader.reader.Buffered()
+		require.Positive(t, bufferedBefore)
+
+		t.Cleanup(func() {
+			proc.Ctx = baseCtx
+			ctr.cleanupSpill(proc)
+			closeSpillRuns([]*spillRun{run})
+			proc.Free()
+			require.Zero(t, proc.Mp().CurrNB())
+		})
+
+		ctx, cancel := context.WithCancel(baseCtx)
+		proc.Ctx = ctx
+		cancel()
+		err := ctr.advanceSpillReaderByChunk(proc, 0, reader.batch.RowCount())
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, bufferedBefore, reader.reader.Buffered())
+		require.Equal(t, []int8{1, 2}, vector.MustFixedColWithTypeCheck[int8](reader.batch.Vecs[0]))
+		require.Equal(t, int64(2), reader.rowIdx)
+		require.Len(t, ctr.spillReaders, 1)
+
+		proc.Ctx = baseCtx
+		ctr.cleanupSpill(proc)
+		_, err = file.Stat()
+		require.Error(t, err)
+	})
+
+	t.Run("during refill IO", func(t *testing.T) {
+		proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+		baseCtx := proc.Ctx
+		ctr := &container{
+			executors:       make([]colexec.ExpressionExecutor, 1),
+			spillColPos:     []int32{-1},
+			spillKeyIndexes: []int{0},
+		}
+		analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-refill-io")
+		bat := newValuesBatch(proc, []int8{3, 4})
+		var payload bytes.Buffer
+		var writeBuf bytes.Buffer
+		_, _, err := writeSpillBatch(proc, bat, []*vector.Vector{bat.Vecs[0]}, &payload, &writeBuf, analyzer)
+		require.NoError(t, err)
+		bat.Clean(proc.Mp())
+
+		ctx, cancel := context.WithCancel(baseCtx)
+		proc.Ctx = ctx
+		source := &cancelAfterReadReader{reader: bytes.NewReader(payload.Bytes()), cancel: cancel}
+		reader := &spillRunReader{reader: bufio.NewReaderSize(source, spillIOBufferSize)}
+		t.Cleanup(func() {
+			proc.Ctx = baseCtx
+			reader.close(proc)
+			proc.Free()
+			require.Zero(t, proc.Mp().CurrNB())
+		})
+
+		ok, err := reader.readNextBatch(proc, ctr)
+		require.ErrorIs(t, err, context.Canceled)
+		require.False(t, ok)
+		require.Equal(t, 1, source.reads)
+	})
 }
 
 func TestReduceSpillRunsCleansCompletedRuns(t *testing.T) {
@@ -758,10 +864,11 @@ func TestReduceSpillRunsCleansCompletedRuns(t *testing.T) {
 			}
 			ctr.spillRuns = runs
 			if test.cancelAfterFirst {
-				// Reduction check, merge entry, one check per source reader,
-				// chunk start, chunk completion, three write boundaries, then
-				// the next group check.
-				proc.Ctx = newCancelOnDoneCheckContext(baseCtx, spillMergeFanIn+8)
+				// Reduction check, merge entry, three open/read checks per
+				// source reader, chunk start, one EOF read-entry check per
+				// single-batch reader, chunk completion, three write boundaries,
+				// then the next fan-in group check.
+				proc.Ctx = newCancelOnDoneCheckContext(baseCtx, spillMergeFanIn*4+8)
 			}
 			if test.corruptLaterRun {
 				require.NoError(t, runs[spillMergeFanIn].file.Truncate(4))
@@ -827,7 +934,8 @@ func TestSendSpillResultHonorsCancellationBeforePublish(t *testing.T) {
 		require.Zero(t, proc.Mp().CurrNB())
 	})
 
-	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 2)
+	// Send entry, the exhausted reader's next-read entry, then result publish.
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 3)
 	var result vm.CallResult
 	done, err := ctr.sendSpillResult(proc, &result)
 	require.ErrorIs(t, err, context.Canceled)
@@ -2162,20 +2270,31 @@ func newCancellationTestSpillRun(
 	analyzer process.Analyzer,
 	values []int8,
 ) *spillRun {
-	t.Helper()
-	bat := newValuesBatch(proc, values)
-	defer bat.Clean(proc.Mp())
+	return newCancellationTestSpillRunBatches(t, proc, ctr, analyzer, values)
+}
 
+func newCancellationTestSpillRunBatches(
+	t testing.TB,
+	proc *process.Process,
+	ctr *container,
+	analyzer process.Analyzer,
+	valueBatches ...[]int8,
+) *spillRun {
+	t.Helper()
 	run, err := ctr.createSpillRun(proc)
 	require.NoError(t, err)
 	writer := bufio.NewWriterSize(run.file, spillIOBufferSize)
-	_, _, err = writeSpillBatch(proc, bat, []*vector.Vector{bat.Vecs[0]}, writer, &ctr.spillWriteBuf, analyzer)
-	require.NoError(t, err)
+	for _, values := range valueBatches {
+		bat := newValuesBatch(proc, values)
+		rows, _, writeErr := writeSpillBatch(proc, bat, []*vector.Vector{bat.Vecs[0]}, writer, &ctr.spillWriteBuf, analyzer)
+		bat.Clean(proc.Mp())
+		require.NoError(t, writeErr)
+		run.batchCount++
+		run.rowCount += rows
+	}
 	require.NoError(t, writer.Flush())
 	_, err = run.file.Seek(0, io.SeekStart)
 	require.NoError(t, err)
-	run.batchCount = 1
-	run.rowCount = int64(bat.RowCount())
 	return run
 }
 

--- a/pkg/sql/colexec/mergeorder/order_test.go
+++ b/pkg/sql/colexec/mergeorder/order_test.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"container/heap"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -256,6 +257,36 @@ func TestOrderSpill(t *testing.T) {
 	arg.Free(proc, false, nil)
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestOrderSpillFinalMergeHonorsCancellationAfterInput(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	arg := &MergeOrder{
+		OrderBySpecs:   []*plan.OrderBySpec{{Expr: newExpression(0, types.T_int8), Flag: 0}},
+		SpillThreshold: 1,
+		OperatorBase:   vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	ctx, cancel := context.WithCancel(proc.Ctx)
+	proc.Ctx = ctx
+	child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		newValuesBatch(proc, []int8{1, 4, 7}),
+		newValuesBatch(proc, []int8{2, 5, 8}),
+		newValuesBatch(proc, []int8{3, 6, 9}),
+	}).WithEndOfDataCallback(cancel)
+	arg.AppendChild(child)
+	require.NoError(t, arg.Prepare(proc))
+
+	t.Cleanup(func() {
+		arg.Free(proc, true, context.Canceled)
+		child.Free(proc, true, context.Canceled)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(arg, proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Empty(t, arg.ctr.spillReaders)
 }
 
 func TestOrderSpillMultiPass(t *testing.T) {

--- a/pkg/sql/colexec/mergeorder/order_test.go
+++ b/pkg/sql/colexec/mergeorder/order_test.go
@@ -148,6 +148,32 @@ func (failWriter) Write(_ []byte) (int, error) {
 	return 0, io.ErrClosedPipe
 }
 
+type cancelAfterWriteWriter struct {
+	cancel context.CancelFunc
+	writes int
+}
+
+func (w *cancelAfterWriteWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == 1 {
+		w.cancel()
+	}
+	return len(p), nil
+}
+
+type callbackEOFReader struct {
+	callback func()
+	reads    int
+}
+
+func (r *callbackEOFReader) Read([]byte) (int, error) {
+	r.reads++
+	if r.callback != nil {
+		r.callback()
+	}
+	return 0, io.EOF
+}
+
 // cancelOnDoneCheckContext deterministically cancels on the Nth observation of
 // Done. The spill paths are synchronous, so this lets tests select an exact
 // phase boundary without sleeps or scheduler races.
@@ -356,6 +382,103 @@ func TestOrderSpillFinalMergeHonorsCancellationAfterInput(t *testing.T) {
 	require.Equal(t, []int8{1, 2, 3}, collectInt8Results(t, arg, proc, 0))
 }
 
+func TestOrderSpillWriteHonorsCancellationAfterInputBatch(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	arg := &MergeOrder{
+		OrderBySpecs:   []*plan.OrderBySpec{{Expr: newExpression(0, types.T_int8), Flag: 0}},
+		SpillThreshold: 1,
+		OperatorBase:   vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	baseCtx := proc.Ctx
+	ctx, cancel := context.WithCancel(baseCtx)
+	proc.Ctx = ctx
+	child := colexec.NewMockOperator().
+		WithBatchs([]*batch.Batch{newValuesBatch(proc, []int8{3, 1, 2})}).
+		WithBatchCallback(func(int) { cancel() })
+	arg.AppendChild(child)
+	require.NoError(t, arg.Prepare(proc))
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		arg.Free(proc, true, context.Canceled)
+		child.Free(proc, true, context.Canceled)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(arg, proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Empty(t, arg.ctr.spillRuns)
+	require.Nil(t, arg.ctr.spillActiveRun)
+}
+
+func TestWriteSpillBatchStopsAtBatchBoundary(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	baseCtx := proc.Ctx
+	ctx, cancel := context.WithCancel(baseCtx)
+	proc.Ctx = ctx
+	bat := newValuesBatch(proc, []int8{1, 2, 3})
+	writer := &cancelAfterWriteWriter{cancel: cancel}
+	analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-write")
+	var writeBuf bytes.Buffer
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		bat.Clean(proc.Mp())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	_, _, err := writeSpillBatch(proc, bat, []*vector.Vector{bat.Vecs[0]}, writer, &writeBuf, analyzer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, writer.writes)
+
+	_, _, err = writeSpillBatch(proc, bat, []*vector.Vector{bat.Vecs[0]}, writer, &writeBuf, analyzer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, writer.writes)
+
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 2)
+	var unwritten bytes.Buffer
+	_, _, err = writeSpillBatch(proc, bat, []*vector.Vector{bat.Vecs[0]}, &unwritten, &writeBuf, analyzer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, unwritten.Len())
+}
+
+func TestCleanupSpillDiscardsUncommittedActiveRun(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	file, err := os.CreateTemp(t.TempDir(), "mergeorder-uncommitted-*")
+	require.NoError(t, err)
+	cleaned := false
+	t.Cleanup(func() {
+		if cleaned {
+			return
+		}
+		_ = file.Close()
+		proc.Free()
+	})
+	written := &bytes.Buffer{}
+	activeWriter := bufio.NewWriterSize(written, 1024)
+	_, err = activeWriter.Write([]byte("uncommitted spill payload"))
+	require.NoError(t, err)
+	require.Zero(t, written.Len())
+
+	ctr := &container{
+		spillActiveRun:    &spillRun{file: file},
+		spillActiveWriter: activeWriter,
+	}
+	ctr.cleanupSpill(proc)
+	require.Zero(t, written.Len())
+	require.Nil(t, ctr.spillActiveRun)
+	require.Nil(t, ctr.spillActiveWriter)
+	_, err = file.Stat()
+	require.Error(t, err)
+
+	proc.Free()
+	cleaned = true
+	require.Zero(t, proc.Mp().CurrNB())
+}
+
 func TestSpillCancellationEntryCheckpoints(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	baseCtx := proc.Ctx
@@ -370,6 +493,59 @@ func TestSpillCancellationEntryCheckpoints(t *testing.T) {
 		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
 		err := (&container{}).openSpillReaders(proc, []*spillRun{{}})
 		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("spill cached runs", func(t *testing.T) {
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		require.ErrorIs(t, (&container{}).spillCachedRuns(proc, analyzer), context.Canceled)
+	})
+
+	t.Run("spill cached run boundary", func(t *testing.T) {
+		bat := newValuesBatch(proc, []int8{1})
+		ctr := &container{batchList: []*batch.Batch{bat}}
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 2)
+		require.ErrorIs(t, ctr.spillCachedRuns(proc, analyzer), context.Canceled)
+		require.Same(t, bat, ctr.batchList[0])
+		bat.Clean(proc.Mp())
+	})
+
+	t.Run("spill append", func(t *testing.T) {
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		err := (&container{}).spillBatchWithAppend(proc, nil, nil, nil, analyzer)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("finalize active run entry", func(t *testing.T) {
+		proc.Ctx = baseCtx
+		ctr := &container{}
+		require.NoError(t, ctr.ensureActiveSpillRun(proc))
+		proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 1)
+		require.ErrorIs(t, ctr.finalizeActiveSpillRun(proc, true), context.Canceled)
+		require.NotNil(t, ctr.spillActiveRun)
+		proc.Ctx = baseCtx
+		ctr.cleanupSpill(proc)
+	})
+
+	t.Run("finalize active run after flush", func(t *testing.T) {
+		file, err := os.CreateTemp(t.TempDir(), "mergeorder-finalize-cancel-*")
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(baseCtx)
+		writer := &cancelAfterWriteWriter{cancel: cancel}
+		buffered := bufio.NewWriterSize(writer, 1024)
+		_, err = buffered.Write([]byte("buffered spill payload"))
+		require.NoError(t, err)
+		require.Zero(t, writer.writes)
+		ctr := &container{
+			spillActiveRun:    &spillRun{file: file},
+			spillActiveWriter: buffered,
+		}
+		proc.Ctx = ctx
+		require.ErrorIs(t, ctr.finalizeActiveSpillRun(proc, true), context.Canceled)
+		require.Equal(t, 1, writer.writes)
+		require.Nil(t, ctr.spillActiveRun)
+		require.Empty(t, ctr.spillRuns)
+		_, err = file.Stat()
+		require.Error(t, err)
 	})
 
 	t.Run("merge runs", func(t *testing.T) {
@@ -447,6 +623,52 @@ func TestMergeRunsToSpillCancellationCheckpoints(t *testing.T) {
 				require.Nil(t, run.file)
 			}
 		})
+	}
+}
+
+func TestMergeRunsToSpillStopsAtChunkBoundary(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	baseCtx := proc.Ctx
+	baseFS, err := proc.GetSpillFileService()
+	require.NoError(t, err)
+	trackingFS := &trackingMutableFileService{MutableFileService: baseFS}
+	ctr := &container{
+		compares:        []compare.Compare{compare.New(types.T_int8.ToType(), false, false)},
+		executors:       make([]colexec.ExpressionExecutor, 1),
+		spillColPos:     []int32{-1},
+		spillKeyIndexes: []int{0},
+		spillFS:         trackingFS,
+	}
+	analyzer := process.NewAnalyzer(0, false, false, "mergeorder-cancel-merge-chunk")
+	firstValues := make([]int8, maxWinnerChunkRows*2)
+	for i := range firstValues {
+		firstValues[i] = 1
+	}
+	runs := []*spillRun{
+		newCancellationTestSpillRun(t, proc, ctr, analyzer, firstValues),
+		newCancellationTestSpillRun(t, proc, ctr, analyzer, []int8{2}),
+	}
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		ctr.cleanupSpill(proc)
+		closeSpillRuns(runs)
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	// Entry, two reader-open checks, and the outer materialization check pass.
+	// Cancellation is observed after the first 64-row winner chunk, before
+	// the remaining rows are copied or an output batch is written.
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 5)
+	merged, err := ctr.mergeRunsToSpill(proc, runs, analyzer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, merged)
+	require.Len(t, trackingFS.files, 3)
+	_, statErr := trackingFS.files[2].Stat()
+	require.Error(t, statErr)
+	for _, run := range runs {
+		require.Nil(t, run.file)
 	}
 }
 
@@ -537,8 +759,9 @@ func TestReduceSpillRunsCleansCompletedRuns(t *testing.T) {
 			ctr.spillRuns = runs
 			if test.cancelAfterFirst {
 				// Reduction check, merge entry, one check per source reader,
-				// chunk start, chunk completion, then the next group check.
-				proc.Ctx = newCancelOnDoneCheckContext(baseCtx, spillMergeFanIn+5)
+				// chunk start, chunk completion, three write boundaries, then
+				// the next group check.
+				proc.Ctx = newCancelOnDoneCheckContext(baseCtx, spillMergeFanIn+8)
 			}
 			if test.corruptLaterRun {
 				require.NoError(t, runs[spillMergeFanIn].file.Truncate(4))
@@ -610,6 +833,60 @@ func TestSendSpillResultHonorsCancellationBeforePublish(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, done)
 	require.Nil(t, result.Batch)
+}
+
+func TestSendSpillResultStopsAtChunkBoundary(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	baseCtx := proc.Ctx
+	ctx, cancel := context.WithCancel(baseCtx)
+	proc.Ctx = ctx
+
+	firstValues := make([]int8, batchSizeCheckInterval)
+	for i := range firstValues {
+		firstValues[i] = int8(i)
+	}
+	firstBatch := newValuesBatch(proc, firstValues)
+	secondBatch := newValuesBatch(proc, []int8{100})
+	firstEOF := &callbackEOFReader{callback: cancel}
+	secondEOF := &callbackEOFReader{}
+	firstReader := &spillRunReader{
+		reader:    bufio.NewReader(firstEOF),
+		batch:     firstBatch,
+		orderCols: []*vector.Vector{firstBatch.Vecs[0]},
+		heapIdx:   0,
+	}
+	secondReader := &spillRunReader{
+		reader:    bufio.NewReader(secondEOF),
+		batch:     secondBatch,
+		orderCols: []*vector.Vector{secondBatch.Vecs[0]},
+		heapIdx:   1,
+	}
+	firstReader.refreshDrainProfile()
+	secondReader.refreshDrainProfile()
+	ctr := &container{
+		compares:     []compare.Compare{compare.New(types.T_int8.ToType(), false, false)},
+		spillReaders: []*spillRunReader{firstReader, secondReader},
+	}
+	heap.Init(ctr)
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		ctr.cleanupSpill(proc)
+		if ctr.buf != nil {
+			ctr.buf.Clean(proc.Mp())
+			ctr.buf = nil
+		}
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	var result vm.CallResult
+	done, err := ctr.sendSpillResult(proc, &result)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, done)
+	require.Nil(t, result.Batch)
+	require.Equal(t, 1, firstEOF.reads)
+	require.Zero(t, secondEOF.reads)
 }
 
 func TestOrderSpillMultiPass(t *testing.T) {

--- a/pkg/sql/colexec/mergeorder/spill.go
+++ b/pkg/sql/colexec/mergeorder/spill.go
@@ -614,6 +614,9 @@ func (ctr *container) openSpillReaders(proc *process.Process, runs []*spillRun) 
 		}
 		reader := &spillRunReader{}
 		reader.reset(run.file)
+		// Ownership transfers to the reader before its first read. This keeps
+		// success, EOF, and read-error cleanup under the same owner.
+		run.file = nil
 		ok, err := reader.readNextBatch(proc, ctr)
 		if err != nil {
 			reader.close(proc)
@@ -624,7 +627,6 @@ func (ctr *container) openSpillReaders(proc *process.Process, runs []*spillRun) 
 		} else {
 			reader.close(proc)
 		}
-		run.file = nil
 	}
 	for i := range ctr.spillReaders {
 		ctr.spillReaders[i].heapIdx = i

--- a/pkg/sql/colexec/mergeorder/spill.go
+++ b/pkg/sql/colexec/mergeorder/spill.go
@@ -606,6 +606,9 @@ func (ctr *container) advanceSpillReaderByChunk(proc *process.Process, idx int, 
 func (ctr *container) openSpillReaders(proc *process.Process, runs []*spillRun) error {
 	ctr.spillReaders = make([]*spillRunReader, 0, len(runs))
 	for _, run := range runs {
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			return err
+		}
 		if _, err := run.file.Seek(0, io.SeekStart); err != nil {
 			return err
 		}
@@ -661,6 +664,9 @@ func (ctr *container) restoreSpillOrderColumns(proc *process.Process, dataBatch,
 }
 
 func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, analyzer process.Analyzer) (*spillRun, error) {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return nil, err
+	}
 	if len(runs) == 1 {
 		return runs[0], nil
 	}
@@ -679,12 +685,22 @@ func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, 
 		return nil, err
 	}
 	writer := bufio.NewWriterSize(run.file, spillIOBufferSize)
-	defer writer.Flush()
 
 	var out *batch.Batch
 	var outOrder *batch.Batch
 	keyCount := len(ctr.spillKeyIndexes)
 	for len(ctr.spillReaders) > 0 {
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			if out != nil {
+				out.Clean(proc.Mp())
+			}
+			if outOrder != nil {
+				outOrder.Clean(proc.Mp())
+			}
+			run.file.Close()
+			run.file = nil
+			return nil, err
+		}
 		if out == nil {
 			first := ctr.spillReaders[0].batch
 			out = batch.NewOffHeapWithSize(first.VectorCount())
@@ -907,6 +923,17 @@ func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, 
 				nextSizeCheck = rows + batchSizeCheckInterval
 			}
 		}
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			if out != nil {
+				out.Clean(proc.Mp())
+			}
+			if outOrder != nil {
+				outOrder.Clean(proc.Mp())
+			}
+			run.file.Close()
+			run.file = nil
+			return nil, err
+		}
 		out.SetRowCount(rows)
 		if outOrder != nil {
 			outOrder.SetRowCount(rows)
@@ -947,12 +974,17 @@ func (ctr *container) reduceSpillRuns(proc *process.Process, analyzer process.An
 	for len(ctr.spillRuns) > spillMergeFanIn {
 		nextRuns := make([]*spillRun, 0, (len(ctr.spillRuns)+spillMergeFanIn-1)/spillMergeFanIn)
 		for start := 0; start < len(ctr.spillRuns); start += spillMergeFanIn {
+			if err, canceled := vm.CancelCheck(proc); canceled {
+				closeSpillRuns(nextRuns)
+				return err
+			}
 			end := start + spillMergeFanIn
 			if end > len(ctr.spillRuns) {
 				end = len(ctr.spillRuns)
 			}
 			run, err := ctr.mergeRunsToSpill(proc, ctr.spillRuns[start:end], analyzer)
 			if err != nil {
+				closeSpillRuns(nextRuns)
 				return err
 			}
 			nextRuns = append(nextRuns, run)
@@ -963,6 +995,9 @@ func (ctr *container) reduceSpillRuns(proc *process.Process, analyzer process.An
 }
 
 func (ctr *container) prepareSpillFinalMerge(proc *process.Process, fs []*plan.OrderBySpec, analyzer process.Analyzer) error {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return err
+	}
 	if err := ctr.finalizeActiveSpillRun(proc, true); err != nil {
 		return err
 	}
@@ -977,6 +1012,9 @@ func (ctr *container) prepareSpillFinalMerge(proc *process.Process, fs []*plan.O
 }
 
 func (ctr *container) sendSpillResult(proc *process.Process, result *vm.CallResult) (bool, error) {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return false, err
+	}
 	if ctr.buf == nil {
 		if len(ctr.spillReaders) == 0 {
 			return true, nil
@@ -1109,6 +1147,9 @@ func (ctr *container) sendSpillResult(proc *process.Process, result *vm.CallResu
 
 	if rows == 0 {
 		return true, nil
+	}
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return false, err
 	}
 	ctr.buf.SetRowCount(rows)
 	result.Batch = ctr.buf

--- a/pkg/sql/colexec/mergeorder/spill.go
+++ b/pkg/sql/colexec/mergeorder/spill.go
@@ -112,6 +112,10 @@ func makeSpillOrderBatch(orderCols []*vector.Vector, rowCount int) batch.Batch {
 }
 
 func writeSpillBatch(proc *process.Process, bat *batch.Batch, keyCols []*vector.Vector, writer io.Writer, buf *bytes.Buffer, analyzer process.Analyzer) (int64, int64, error) {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return 0, 0, err
+	}
+
 	cnt := int64(bat.RowCount())
 	buf.Reset()
 	buf.Write(types.EncodeInt64(&cnt))
@@ -128,8 +132,14 @@ func writeSpillBatch(proc *process.Process, bat *batch.Batch, keyCols []*vector.
 	}
 	magic := uint64(spillMagic)
 	buf.Write(types.EncodeUint64(&magic))
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return 0, 0, err
+	}
 	written, err := writer.Write(buf.Bytes())
 	if err != nil {
+		return 0, 0, err
+	}
+	if err, canceled := vm.CancelCheck(proc); canceled {
 		return 0, 0, err
 	}
 	analyzer.Spill(int64(written))
@@ -348,6 +358,9 @@ func (ctr *container) finalizeActiveSpillRun(proc *process.Process, keepRun bool
 	if ctr.spillActiveRun == nil {
 		return nil
 	}
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return err
+	}
 	run := ctr.spillActiveRun
 	writer := ctr.spillActiveWriter
 	ctr.spillActiveRun = nil
@@ -361,6 +374,11 @@ func (ctr *container) finalizeActiveSpillRun(proc *process.Process, keepRun bool
 			run.file = nil
 			return err
 		}
+	}
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		run.file.Close()
+		run.file = nil
+		return err
 	}
 	if _, err := run.file.Seek(0, io.SeekStart); err != nil {
 		run.file.Close()
@@ -383,6 +401,10 @@ func (ctr *container) spillBatchWithAppend(
 	incomingOrderCols []*vector.Vector,
 	analyzer process.Analyzer,
 ) error {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return err
+	}
+
 	if ctr.spillActiveRun != nil && ((ctr.spillAppendTarget > 0 && ctr.spillActiveBytes >= ctr.spillAppendTarget) || !ctr.canAppendToActiveRun(incomingOrderCols)) {
 		if err := ctr.finalizeActiveSpillRun(proc, true); err != nil {
 			return err
@@ -402,9 +424,16 @@ func (ctr *container) spillBatchWithAppend(
 }
 
 func (ctr *container) spillCachedRuns(proc *process.Process, analyzer process.Analyzer) error {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return err
+	}
+
 	for i := range ctr.batchList {
 		if ctr.batchList[i] == nil {
 			continue
+		}
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			return err
 		}
 		bat := ctr.batchList[i]
 		keyCols, err := ctr.buildSpillKeyColumns(proc, bat)
@@ -742,6 +771,22 @@ func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, 
 			currentOutSize = -1
 		}
 		for len(ctr.spillReaders) > 0 {
+			if rows >= nextSizeCheck {
+				if err, canceled := vm.CancelCheck(proc); canceled {
+					out.Clean(proc.Mp())
+					if outOrder != nil {
+						outOrder.Clean(proc.Mp())
+					}
+					run.file.Close()
+					run.file = nil
+					return nil, err
+				}
+				if getOutSize() >= maxBatchSizeToSend {
+					break
+				}
+				nextSizeCheck = rows + batchSizeCheckInterval
+			}
+
 			if len(ctr.spillReaders) == 1 {
 				src := ctr.spillReaders[0]
 				chunk := computeDrainChunk(src, getOutSize())
@@ -776,9 +821,6 @@ func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, 
 				}
 				if getOutSize() >= maxBatchSizeToSend {
 					break
-				}
-				if rows >= nextSizeCheck {
-					nextSizeCheck = rows + batchSizeCheckInterval
 				}
 				continue
 			}
@@ -829,9 +871,6 @@ func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, 
 				if getOutSize() >= maxBatchSizeToSend {
 					break
 				}
-				if rows >= nextSizeCheck {
-					nextSizeCheck = rows + batchSizeCheckInterval
-				}
 				continue
 			}
 
@@ -880,9 +919,6 @@ func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, 
 						if getOutSize() >= maxBatchSizeToSend {
 							break
 						}
-						if rows >= nextSizeCheck {
-							nextSizeCheck = rows + batchSizeCheckInterval
-						}
 						continue
 					}
 				}
@@ -917,12 +953,6 @@ func (ctr *container) mergeRunsToSpill(proc *process.Process, runs []*spillRun, 
 				}
 				run.file.Close()
 				return nil, err
-			}
-			if rows >= nextSizeCheck {
-				if getOutSize() >= maxBatchSizeToSend {
-					break
-				}
-				nextSizeCheck = rows + batchSizeCheckInterval
 			}
 		}
 		if err, canceled := vm.CancelCheck(proc); canceled {
@@ -1050,6 +1080,16 @@ func (ctr *container) sendSpillResult(proc *process.Process, result *vm.CallResu
 		currentBufSize = -1
 	}
 	for len(ctr.spillReaders) > 0 {
+		if rows >= nextSizeCheck {
+			if err, canceled := vm.CancelCheck(proc); canceled {
+				return false, err
+			}
+			if getBufSize() >= maxBatchSizeToSend {
+				break
+			}
+			nextSizeCheck = rows + batchSizeCheckInterval
+		}
+
 		if len(ctr.spillReaders) == 1 {
 			src := ctr.spillReaders[0]
 			chunk := computeDrainChunk(src, getBufSize())
@@ -1066,9 +1106,6 @@ func (ctr *container) sendSpillResult(proc *process.Process, result *vm.CallResu
 			}
 			if getBufSize() >= maxBatchSizeToSend {
 				break
-			}
-			if rows >= nextSizeCheck {
-				nextSizeCheck = rows + batchSizeCheckInterval
 			}
 			continue
 		}
@@ -1095,9 +1132,6 @@ func (ctr *container) sendSpillResult(proc *process.Process, result *vm.CallResu
 			if getBufSize() >= maxBatchSizeToSend {
 				break
 			}
-			if rows >= nextSizeCheck {
-				nextSizeCheck = rows + batchSizeCheckInterval
-			}
 			continue
 		}
 
@@ -1122,9 +1156,6 @@ func (ctr *container) sendSpillResult(proc *process.Process, result *vm.CallResu
 					if getBufSize() >= maxBatchSizeToSend {
 						break
 					}
-					if rows >= nextSizeCheck {
-						nextSizeCheck = rows + batchSizeCheckInterval
-					}
 					continue
 				}
 			}
@@ -1138,12 +1169,6 @@ func (ctr *container) sendSpillResult(proc *process.Process, result *vm.CallResu
 		updateBufSize(reader, 1)
 		if err := ctr.advanceSpillReaderByChunk(proc, 0, 1); err != nil {
 			return false, err
-		}
-		if rows >= nextSizeCheck {
-			if getBufSize() >= maxBatchSizeToSend {
-				break
-			}
-			nextSizeCheck = rows + batchSizeCheckInterval
 		}
 	}
 

--- a/pkg/sql/colexec/mergeorder/types.go
+++ b/pkg/sql/colexec/mergeorder/types.go
@@ -388,6 +388,13 @@ func (r *spillRunReader) refreshDrainProfile() {
 }
 
 func (r *spillRunReader) readNextBatch(proc *process.Process, ctr *container) (bool, error) {
+	// A serialized spill batch is the reader's bounded I/O work unit. Check
+	// before releasing the current batch contents so a known cancellation does
+	// not consume or publish the next unit.
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return false, err
+	}
+
 	if r.batch != nil {
 		r.batch.CleanOnlyData()
 	}
@@ -416,5 +423,11 @@ func (r *spillRunReader) readNextBatch(proc *process.Process, ctr *container) (b
 	}
 	r.refreshDrainProfile()
 	r.rowIdx = 0
+	// The synchronous read/unmarshal cannot be interrupted. Observe cancellation
+	// once it completes, before the refilled batch becomes visible to heap/copy
+	// work in the caller.
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return false, err
+	}
 	return true, nil
 }

--- a/pkg/sql/colexec/mergeorder/types.go
+++ b/pkg/sql/colexec/mergeorder/types.go
@@ -247,16 +247,20 @@ func (ctr *container) cleanupSpill(proc *process.Process) {
 		ctr.spillReaders[i].close(proc)
 	}
 	ctr.spillReaders = nil
-	for i := range ctr.spillRuns {
-		if ctr.spillRuns[i] != nil && ctr.spillRuns[i].file != nil {
-			ctr.spillRuns[i].file.Close()
-			ctr.spillRuns[i].file = nil
-		}
-	}
+	closeSpillRuns(ctr.spillRuns)
 	ctr.spillRuns = nil
 	ctr.spilling = false
 	ctr.spillMemUsage = 0
 	ctr.spillWriteBuf.Reset()
+}
+
+func closeSpillRuns(runs []*spillRun) {
+	for i := range runs {
+		if runs[i] != nil && runs[i].file != nil {
+			runs[i].file.Close()
+			runs[i].file = nil
+		}
+	}
 }
 
 func (ctr *container) setSpillThreshold(threshold int64) {

--- a/pkg/sql/colexec/mergeorder/types.go
+++ b/pkg/sql/colexec/mergeorder/types.go
@@ -225,10 +225,9 @@ func (mergeOrder *MergeOrder) cleanBatchAndCol(proc *process.Process) {
 }
 
 func (ctr *container) cleanupSpill(proc *process.Process) {
-	if ctr.spillActiveWriter != nil {
-		_ = ctr.spillActiveWriter.Flush()
-		ctr.spillActiveWriter = nil
-	}
+	// An active run has not been committed to spillRuns yet. Cleanup discards
+	// it, so flushing would only perform useless I/O after cancellation/error.
+	ctr.spillActiveWriter = nil
 	if ctr.spillActiveRun != nil && ctr.spillActiveRun.file != nil {
 		ctr.spillActiveRun.file.Close()
 		ctr.spillActiveRun.file = nil

--- a/pkg/sql/colexec/mock_util.go
+++ b/pkg/sql/colexec/mock_util.go
@@ -33,8 +33,10 @@ var _ vm.Operator = new(MockOperator)
 type MockOperator struct {
 	vm.OperatorBase
 
-	batchs  []*batch.Batch
-	current int
+	batchs             []*batch.Batch
+	current            int
+	endCallback        func()
+	endCallbackInvoked bool
 }
 
 func (op *MockOperator) GetOperatorBase() *vm.OperatorBase {
@@ -56,6 +58,12 @@ func (op *MockOperator) WithBatchs(batchs []*batch.Batch) *MockOperator {
 	return op
 }
 
+func (op *MockOperator) WithEndOfDataCallback(callback func()) *MockOperator {
+	op.endCallback = callback
+	op.endCallbackInvoked = false
+	return op
+}
+
 func (op *MockOperator) GetBatchs() []*batch.Batch {
 	return op.batchs
 }
@@ -70,6 +78,7 @@ func (op *MockOperator) Reset(proc *process.Process, pipelineFailed bool, err er
 		}
 	}
 	op.current = 0
+	op.endCallbackInvoked = false
 }
 
 func (op *MockOperator) Free(proc *process.Process, pipelineFailed bool, err error) {
@@ -80,6 +89,8 @@ func (op *MockOperator) Free(proc *process.Process, pipelineFailed bool, err err
 	}
 	op.batchs = nil
 	op.current = 0
+	op.endCallback = nil
+	op.endCallbackInvoked = false
 }
 
 func (op *MockOperator) ExecProjection(proc *process.Process, input *batch.Batch) (*batch.Batch, error) {
@@ -102,6 +113,10 @@ func (op *MockOperator) Call(proc *process.Process) (vm.CallResult, error) {
 	result := vm.NewCallResult()
 	if op.current >= len(op.batchs) {
 		result.Status = vm.ExecStop
+		if op.endCallback != nil && !op.endCallbackInvoked {
+			op.endCallbackInvoked = true
+			op.endCallback()
+		}
 		return result, nil
 	}
 	result.Batch = op.batchs[op.current]

--- a/pkg/sql/colexec/mock_util.go
+++ b/pkg/sql/colexec/mock_util.go
@@ -35,6 +35,7 @@ type MockOperator struct {
 
 	batchs             []*batch.Batch
 	current            int
+	batchCallback      func(int)
 	endCallback        func()
 	endCallbackInvoked bool
 }
@@ -64,6 +65,11 @@ func (op *MockOperator) WithEndOfDataCallback(callback func()) *MockOperator {
 	return op
 }
 
+func (op *MockOperator) WithBatchCallback(callback func(int)) *MockOperator {
+	op.batchCallback = callback
+	return op
+}
+
 func (op *MockOperator) GetBatchs() []*batch.Batch {
 	return op.batchs
 }
@@ -89,6 +95,7 @@ func (op *MockOperator) Free(proc *process.Process, pipelineFailed bool, err err
 	}
 	op.batchs = nil
 	op.current = 0
+	op.batchCallback = nil
 	op.endCallback = nil
 	op.endCallbackInvoked = false
 }
@@ -119,8 +126,12 @@ func (op *MockOperator) Call(proc *process.Process) (vm.CallResult, error) {
 		}
 		return result, nil
 	}
-	result.Batch = op.batchs[op.current]
+	batchIndex := op.current
+	result.Batch = op.batchs[batchIndex]
 	op.current = op.current + 1
+	if op.batchCallback != nil {
+		op.batchCallback(batchIndex)
+	}
 	return result, nil
 }
 

--- a/pkg/sql/colexec/mock_util_test.go
+++ b/pkg/sql/colexec/mock_util_test.go
@@ -17,6 +17,7 @@ package colexec
 import (
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/stretchr/testify/require"
 )
@@ -45,4 +46,29 @@ func TestMockOperatorEndOfDataCallback(t *testing.T) {
 	_, err = op.Call(nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, callbackCalls)
+}
+
+func TestMockOperatorBatchCallback(t *testing.T) {
+	var batchIndexes []int
+	op := NewMockOperator().
+		WithBatchs([]*batch.Batch{batch.EmptyBatch, batch.EmptyBatch}).
+		WithBatchCallback(func(index int) {
+			batchIndexes = append(batchIndexes, index)
+		})
+
+	for range 3 {
+		_, err := op.Call(nil)
+		require.NoError(t, err)
+	}
+	require.Equal(t, []int{0, 1}, batchIndexes)
+
+	op.Reset(nil, false, nil)
+	_, err := op.Call(nil)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1, 0}, batchIndexes)
+
+	op.Free(nil, false, nil)
+	_, err = op.Call(nil)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1, 0}, batchIndexes)
 }

--- a/pkg/sql/colexec/mock_util_test.go
+++ b/pkg/sql/colexec/mock_util_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colexec
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockOperatorEndOfDataCallback(t *testing.T) {
+	callbackCalls := 0
+	op := NewMockOperator().WithEndOfDataCallback(func() {
+		callbackCalls++
+	})
+
+	result, err := op.Call(nil)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, result.Status)
+	require.Equal(t, 1, callbackCalls)
+
+	_, err = op.Call(nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, callbackCalls)
+
+	op.Reset(nil, false, nil)
+	_, err = op.Call(nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, callbackCalls)
+
+	op.Free(nil, false, nil)
+	_, err = op.Call(nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, callbackCalls)
+}

--- a/pkg/sql/colexec/top/top.go
+++ b/pkg/sql/colexec/top/top.go
@@ -122,6 +122,11 @@ func (top *Top) Call(proc *process.Process) (vm.CallResult, error) {
 			bat := result.Batch
 
 			if bat == nil {
+				// The child may cancel the process while returning EOF, after this
+				// Top invocation has passed vm.Exec's entry cancellation check.
+				if err, canceled := vm.CancelCheck(proc); canceled {
+					return vm.CancelResult, err
+				}
 				top.ctr.state = vm.Eval
 				break
 			}
@@ -466,6 +471,10 @@ func (ctr *container) evalInMemory(limit uint64, n int, proc *process.Process, r
 const evalSpillChunkSize = 8192
 
 func (ctr *container) evalSpill(limit uint64, n int, proc *process.Process, result *vm.CallResult) (bool, error) {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return false, err
+	}
+
 	// First call: pop heap into sorted order, free heap batch.
 	if ctr.orderedRefs == nil {
 		if uint64(len(ctr.sels)) < limit {
@@ -473,6 +482,11 @@ func (ctr *container) evalSpill(limit uint64, n int, proc *process.Process, resu
 		}
 		ctr.orderedRefs = make([]rowRef, len(ctr.sels))
 		for i, j := 0, len(ctr.sels); i < j; i++ {
+			if i%evalSpillChunkSize == 0 {
+				if err, canceled := vm.CancelCheck(proc); canceled {
+					return false, err
+				}
+			}
 			sel := heap.Pop(ctr).(int64)
 			ctr.orderedRefs[len(ctr.orderedRefs)-1-i] = ctr.rowRefs[sel]
 		}
@@ -511,11 +525,20 @@ func (ctr *container) evalSpill(limit uint64, n int, proc *process.Process, resu
 	}
 
 	outputBat := batch.NewOffHeapWithSize(n)
+	outputTransferred := false
+	defer func() {
+		if !outputTransferred {
+			outputBat.Clean(proc.Mp())
+		}
+	}()
 
 	reuseBat := batch.NewOffHeapWithSize(0)
 	defer reuseBat.Clean(proc.Mp())
 
 	for bIdx, rows := range batchRows {
+		if err, canceled := vm.CancelCheck(proc); canceled {
+			return false, err
+		}
 		info := ctr.spillIndex[bIdx]
 		data := make([]byte, info.size)
 		if _, err := ctr.spillFile.ReadAt(data, info.offset); err != nil {
@@ -550,9 +573,13 @@ func (ctr *container) evalSpill(limit uint64, n int, proc *process.Process, resu
 		}
 	}
 
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return false, err
+	}
 	outputBat.SetRowCount(chunkSize)
 	ctr.evalCursor = chunkEnd
 	ctr.spillOutBat = outputBat
+	outputTransferred = true
 	result.Batch = outputBat
 	return ctr.evalCursor >= len(ctr.orderedRefs), nil
 }

--- a/pkg/sql/colexec/top/top.go
+++ b/pkg/sql/colexec/top/top.go
@@ -152,6 +152,9 @@ func (top *Top) Call(proc *process.Process) (vm.CallResult, error) {
 
 			err = top.ctr.build(top, top.ctr.buildBat, proc, analyzer)
 			if err != nil {
+				if _, canceled := vm.CancelCheck(proc); canceled {
+					return vm.CancelResult, err
+				}
 				return result, err
 			}
 			if top.TopValueTag > 0 && top.updateTopValueZM() {
@@ -326,6 +329,10 @@ func (ctr *container) processBatch(limit uint64, bat *batch.Batch, proc *process
 }
 
 func (ctr *container) spillBatch(bat *batch.Batch, proc *process.Process, analyzer process.Analyzer) error {
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return err
+	}
+
 	if ctr.spillFile == nil {
 		f, err := os.CreateTemp("", "mo-top-spill-*")
 		if err != nil {
@@ -349,7 +356,13 @@ func (ctr *container) spillBatch(bat *batch.Batch, proc *process.Process, analyz
 	if err != nil {
 		return err
 	}
+	if err, canceled := vm.CancelCheck(proc); canceled {
+		return err
+	}
 	if _, err := ctr.spillFile.Write(data); err != nil {
+		return err
+	}
+	if err, canceled := vm.CancelCheck(proc); canceled {
 		return err
 	}
 

--- a/pkg/sql/colexec/top/top_test.go
+++ b/pkg/sql/colexec/top/top_test.go
@@ -292,6 +292,93 @@ func TestTopSpillEvalHonorsCancellationAfterInput(t *testing.T) {
 	require.Equal(t, 4, outputRows)
 }
 
+func TestTopSpillWriteHonorsCancellationAfterInputBatch(t *testing.T) {
+	limit := int64(topSpillThreshold + 1)
+	tc := newTestCase(t, mpool.MustNewZero(), []types.Type{types.T_int64.ToType()}, limit,
+		[]*plan.OrderBySpec{{Expr: newExpression(0), Flag: 0}})
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+	require.True(t, tc.arg.ctr.spilling)
+
+	baseCtx := tc.proc.Ctx
+	ctx, cancel := context.WithCancel(baseCtx)
+	tc.proc.Ctx = ctx
+	child := colexec.NewMockOperator().
+		WithBatchs([]*batch.Batch{newBatch(tc.types, tc.proc, 32)}).
+		WithBatchCallback(func(int) { cancel() })
+	tc.arg.AppendChild(child)
+
+	t.Cleanup(func() {
+		tc.proc.Ctx = baseCtx
+		tc.arg.Free(tc.proc, true, context.Canceled)
+		child.Free(tc.proc, true, context.Canceled)
+		tc.proc.Free()
+		require.Zero(t, tc.proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(tc.arg, tc.proc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
+	require.Nil(t, tc.arg.ctr.spillFile)
+	require.Empty(t, tc.arg.ctr.spillIndex)
+}
+
+func TestTopSpillBatchCancellationBeforeWrite(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	baseCtx := proc.Ctx
+	arg := &Top{}
+	arg.ctr.n = 1
+	src := newBatch([]types.Type{types.T_int64.ToType()}, proc, 32)
+	analyzer := process.NewAnalyzer(0, false, false, "top-cancel-write")
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		arg.Free(proc, true, context.Canceled)
+		src.Clean(proc.Mp())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	// The entry check passes. Cancellation is then observed after
+	// serialization but before the first file write.
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 2)
+	err := arg.ctr.spillBatch(src, proc, analyzer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, arg.ctr.spillFile)
+	info, statErr := arg.ctr.spillFile.Stat()
+	require.NoError(t, statErr)
+	require.Zero(t, info.Size())
+	require.Empty(t, arg.ctr.spillIndex)
+}
+
+func TestTopSpillBatchCancellationAfterWrite(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	baseCtx := proc.Ctx
+	arg := &Top{}
+	arg.ctr.n = 1
+	src := newBatch([]types.Type{types.T_int64.ToType()}, proc, 32)
+	analyzer := process.NewAnalyzer(0, false, false, "top-cancel-after-write")
+
+	t.Cleanup(func() {
+		proc.Ctx = baseCtx
+		arg.Free(proc, true, context.Canceled)
+		src.Clean(proc.Mp())
+		proc.Free()
+		require.Zero(t, proc.Mp().CurrNB())
+	})
+
+	// Entry and pre-write checks pass. The post-write boundary observes
+	// cancellation before the spill index or heap state is published.
+	proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 3)
+	err := arg.ctr.spillBatch(src, proc, analyzer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, arg.ctr.spillFile)
+	info, statErr := arg.ctr.spillFile.Stat()
+	require.NoError(t, statErr)
+	require.Positive(t, info.Size())
+	require.Empty(t, arg.ctr.spillIndex)
+	require.Zero(t, arg.ctr.spillBatIdx)
+}
+
 func TestTopSpillEvalCancellationCheckpoints(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/sql/colexec/top/top_test.go
+++ b/pkg/sql/colexec/top/top_test.go
@@ -244,6 +244,7 @@ func TestTopSpillEvalHonorsCancellationAfterInput(t *testing.T) {
 	require.NoError(t, tc.arg.Prepare(tc.proc))
 	require.True(t, tc.arg.ctr.spilling)
 
+	baseCtx := tc.proc.Ctx
 	ctx, cancel := context.WithCancel(tc.proc.Ctx)
 	tc.proc.Ctx = ctx
 	child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{
@@ -254,8 +255,9 @@ func TestTopSpillEvalHonorsCancellationAfterInput(t *testing.T) {
 	tc.arg.AppendChild(child)
 
 	t.Cleanup(func() {
-		tc.arg.Free(tc.proc, true, context.Canceled)
-		child.Free(tc.proc, true, context.Canceled)
+		tc.proc.Ctx = baseCtx
+		tc.arg.Free(tc.proc, false, nil)
+		child.Free(tc.proc, false, nil)
 		tc.proc.Free()
 		require.Zero(t, tc.proc.Mp().CurrNB())
 	})
@@ -264,6 +266,30 @@ func TestTopSpillEvalHonorsCancellationAfterInput(t *testing.T) {
 	require.NotNil(t, tc.arg.ctr.spillFile)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, result.Batch)
+
+	tc.arg.Reset(tc.proc, true, context.Canceled)
+	require.Nil(t, tc.arg.ctr.spillFile)
+	require.Nil(t, tc.arg.ctr.orderedRefs)
+	child.Free(tc.proc, true, context.Canceled)
+
+	tc.proc.Ctx = baseCtx
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+	child = colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		newBatch(tc.types, tc.proc, 4),
+	})
+	tc.arg.Children = nil
+	tc.arg.AppendChild(child)
+
+	var outputRows int
+	for {
+		result, execErr := vm.Exec(tc.arg, tc.proc)
+		require.NoError(t, execErr)
+		if result.Status == vm.ExecStop || result.Batch == nil {
+			break
+		}
+		outputRows += result.Batch.RowCount()
+	}
+	require.Equal(t, 4, outputRows)
 }
 
 func TestTopSpillEvalCancellationCheckpoints(t *testing.T) {
@@ -304,6 +330,44 @@ func TestTopSpillEvalCancellationCheckpoints(t *testing.T) {
 			require.Nil(t, arg.ctr.spillOutBat)
 		})
 	}
+}
+
+func TestTopSpillHeapCancellationCheckpoint(t *testing.T) {
+	limit := int64(topSpillThreshold + 1)
+	tc := newTestCase(t, mpool.MustNewZero(), []types.Type{types.T_int64.ToType()}, limit,
+		[]*plan.OrderBySpec{{Expr: newExpression(0), Flag: 0}})
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+	require.True(t, tc.arg.ctr.spilling)
+
+	src := newBatch(tc.types, tc.proc, limit)
+	tc.arg.ctr.n = len(src.Vecs)
+	require.NoError(t, tc.arg.ctr.build(tc.arg, src, tc.proc, tc.arg.OpAnalyzer))
+	src.Clean(tc.proc.Mp())
+	require.Greater(t, len(tc.arg.ctr.sels), evalSpillChunkSize)
+	originalRefs := len(tc.arg.ctr.sels)
+	baseCtx := tc.proc.Ctx
+
+	t.Cleanup(func() {
+		tc.proc.Ctx = baseCtx
+		tc.arg.Free(tc.proc, false, nil)
+		tc.proc.Free()
+		require.Zero(t, tc.proc.Mp().CurrNB())
+	})
+
+	// Entry and i=0 pass; cancellation is observed at i=8192 after a
+	// partially completed heap-to-order transfer.
+	tc.proc.Ctx = newCancelOnDoneCheckContext(baseCtx, 3)
+	var result vm.CallResult
+	done, err := tc.arg.ctr.evalSpill(uint64(limit), tc.arg.ctr.n, tc.proc, &result)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, done)
+	require.Nil(t, result.Batch)
+	require.Len(t, tc.arg.ctr.orderedRefs, originalRefs)
+	require.Len(t, tc.arg.ctr.sels, originalRefs-evalSpillChunkSize)
+
+	tc.arg.Reset(tc.proc, true, context.Canceled)
+	require.Nil(t, tc.arg.ctr.spillFile)
+	require.Nil(t, tc.arg.ctr.orderedRefs)
 }
 
 func TestTopSpillInsufficientRows(t *testing.T) {

--- a/pkg/sql/colexec/top/top_test.go
+++ b/pkg/sql/colexec/top/top_test.go
@@ -45,6 +45,39 @@ type testCase struct {
 	proc  *process.Process
 }
 
+type cancelOnDoneCheckContext struct {
+	context.Context
+	remaining int
+	done      chan struct{}
+}
+
+func newCancelOnDoneCheckContext(parent context.Context, checks int) *cancelOnDoneCheckContext {
+	return &cancelOnDoneCheckContext{
+		Context:   parent,
+		remaining: checks,
+		done:      make(chan struct{}),
+	}
+}
+
+func (ctx *cancelOnDoneCheckContext) Done() <-chan struct{} {
+	if ctx.remaining > 0 {
+		ctx.remaining--
+		if ctx.remaining == 0 {
+			close(ctx.done)
+		}
+	}
+	return ctx.done
+}
+
+func (ctx *cancelOnDoneCheckContext) Err() error {
+	select {
+	case <-ctx.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
 func genTestCases(t *testing.T) []testCase {
 	return []testCase{
 		newTestCase(t, mpool.MustNewZero(), []types.Type{types.T_int8.ToType()}, 3, []*plan.OrderBySpec{{Expr: newExpression(0), Flag: 0}}),
@@ -231,6 +264,46 @@ func TestTopSpillEvalHonorsCancellationAfterInput(t *testing.T) {
 	require.NotNil(t, tc.arg.ctr.spillFile)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, result.Batch)
+}
+
+func TestTopSpillEvalCancellationCheckpoints(t *testing.T) {
+	tests := []struct {
+		name          string
+		cancelAtCheck int
+	}{
+		{name: "before evaluation", cancelAtCheck: 1},
+		{name: "before spill read", cancelAtCheck: 2},
+		{name: "before result publish", cancelAtCheck: 3},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			arg := &Top{}
+			arg.ctr.n = 1
+			arg.ctr.orderedRefs = []rowRef{{batchIdx: 0, rowIdx: 0}}
+			analyzer := process.NewAnalyzer(0, false, false, "top-cancel-eval")
+			src := newBatch([]types.Type{types.T_int64.ToType()}, proc, 1)
+			require.NoError(t, arg.ctr.spillBatch(src, proc, analyzer))
+			src.Clean(proc.Mp())
+			baseCtx := proc.Ctx
+
+			t.Cleanup(func() {
+				proc.Ctx = baseCtx
+				arg.Free(proc, true, context.Canceled)
+				proc.Free()
+				require.Zero(t, proc.Mp().CurrNB())
+			})
+
+			proc.Ctx = newCancelOnDoneCheckContext(baseCtx, test.cancelAtCheck)
+			var result vm.CallResult
+			done, err := arg.ctr.evalSpill(1, 1, proc, &result)
+			require.ErrorIs(t, err, context.Canceled)
+			require.False(t, done)
+			require.Nil(t, result.Batch)
+			require.Nil(t, arg.ctr.spillOutBat)
+		})
+	}
 }
 
 func TestTopSpillInsufficientRows(t *testing.T) {

--- a/pkg/sql/colexec/top/top_test.go
+++ b/pkg/sql/colexec/top/top_test.go
@@ -16,6 +16,7 @@ package top
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -201,6 +202,35 @@ func TestTopSpill(t *testing.T) {
 		tc.proc.Free()
 		require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
 	}
+}
+
+func TestTopSpillEvalHonorsCancellationAfterInput(t *testing.T) {
+	limit := int64(topSpillThreshold + 1)
+	tc := newTestCase(t, mpool.MustNewZero(), []types.Type{types.T_int64.ToType()}, limit,
+		[]*plan.OrderBySpec{{Expr: newExpression(0), Flag: 0}})
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+	require.True(t, tc.arg.ctr.spilling)
+
+	ctx, cancel := context.WithCancel(tc.proc.Ctx)
+	tc.proc.Ctx = ctx
+	child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		newBatch(tc.types, tc.proc, 8192),
+		newBatch(tc.types, tc.proc, 8192),
+		newBatch(tc.types, tc.proc, 8192),
+	}).WithEndOfDataCallback(cancel)
+	tc.arg.AppendChild(child)
+
+	t.Cleanup(func() {
+		tc.arg.Free(tc.proc, true, context.Canceled)
+		child.Free(tc.proc, true, context.Canceled)
+		tc.proc.Free()
+		require.Zero(t, tc.proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(tc.arg, tc.proc)
+	require.NotNil(t, tc.arg.ctr.spillFile)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, result.Batch)
 }
 
 func TestTopSpillInsufficientRows(t *testing.T) {


### PR DESCRIPTION
## What changed

- observe cancellation before Group, MergeGroup, MergeOrder, and Top cross child EOF or a non-empty child batch into spill/evaluation work
- stop streaming Group output at the publish ownership boundary when cancellation arrives during the same Build -> Eval call
- check Group spill work at wave, group-batch, non-empty-bucket, bucket-flush, and reload-record boundaries
- check MergeOrder at cached/current batch serialization/write boundaries and bounded merge/materialization chunks
- guard MergeOrder spill-reader rollover before each serialized-batch refill and after synchronous read/unmarshal, before exposing the refilled batch
- check Top before serialization, before write, after write, heap-pop chunks, spill reads, and result publication
- keep partial file ownership singular: Group clears source slots as buckets transfer; MergeOrder transfers source runs before first read
- discard uncommitted MergeOrder active-run buffers during cleanup instead of flushing after cancellation
- preserve Reset as the generation boundary and verify cancellation -> Reset -> fresh context -> Prepare -> successful reuse

## First-principles contract

Once the process context is canceled, an operator must not begin another expensive spill work unit or publish another result batch. A single synchronous marshal/write or serialized-batch read/unmarshal cannot be interrupted safely, so each is guarded before and after. Subsequent work is bounded to one Group bucket, one MergeOrder chunk (at most 256 rows), one serialized spill batch, or one Top batch write. Result ownership advances only after the publish-boundary cancellation check. Every partial resource has exactly one cleanup owner, and Reset fully terminates generation N before generation N+1 is prepared.

## Validation

- unfixed baseline: the reported EOF spill regressions return a nil error after cancellation; the new multi-batch reader rollover test fails both before-refill and during-I/O subcases on `8a3a50d197` and passes on `4ce82117ee`
- review matrix covers Group streaming publication, 0/partial/all bucket transfer and partial reload; MergeOrder partial readers, non-empty `nextRuns`, multi-batch rollover, and chunk materialization; and Top pre/post write plus the 8,192-row heap-pop cancellation
- full tests pass for `./pkg/sql/colexec/...` and `./pkg/sql/compile`
- package coverage: colexec 63.2%, group 80.6%, mergeorder 78.2%, top 74.8%; MergeOrder `readNextBatch` is 100% covered and both new cancellation bodies execute
- `GOWORK=off` package selection, build, and vet pass for all four owning packages
- all 28 newly added tests pass under `-race -count=100`
- all four owning packages pass a complete race run
- explicitly rebased onto latest `origin/main@6091b418fd`

Fixes #26444
Fixes #26446
Fixes #26447

Related: #26563