### PR TITLE
fix(test): wait for failed ICKP cleanup

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -9304,7 +9304,23 @@ func Test_CheckpointChaos1(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	err = tae.DB.ForceCheckpoint(ctx, now)
-	assert.Error(t, err)
+	require.Error(t, err)
+	// The caller deadline does not cancel an already admitted runner-owned ICKP.
+	// Wait for both queued intent retirement and execution cleanup before
+	// asserting the file-service snapshot.
+	waitCtx, waitCancel := context.WithTimeout(
+		context.Background(), testutil.TestCheckpointTimeout,
+	)
+	defer waitCancel()
+	if intent := tae.BGCheckpointRunner.GetICKPIntentOnlyForTest(); intent != nil {
+		select {
+		case <-waitCtx.Done():
+			require.NoError(t, context.Cause(waitCtx))
+		case <-intent.Wait():
+		}
+	}
+	require.NoError(t,
+		tae.BGCheckpointRunner.WaitRunningCKPDoneForTest(waitCtx, false))
 	require.Equal(t, filesBeforeFailure, snapshotFileService(t, tae.Runtime.Fs),
 		"failed ICKP publication must roll back its data and table-ID objects")
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26583

## What this PR does / why we need it:

### Root cause

The object reported by `Test_CheckpointChaos1` was observed before the failed ICKP reached its terminal cleanup boundary; it was not a post-cleanup leak.

`ForceCheckpoint` stops waiting when its caller context expires, but an already admitted ICKP runs under the checkpoint executor context. In the failing CI timeline, `ForceCheckpoint` returned on the one-second deadline while the runner-owned ICKP was still deleting its unpublished data and table-ID objects. The test immediately took a file-service snapshot and could therefore observe one transient 760-byte object.

### Change

After the expected caller timeout, the test now waits for both sides of the asynchronous boundary:

- the queued/running ICKP intent reaches retirement;
- the runner-owned checkpoint execution finishes cleanup.

Only then does it assert that the file-service snapshot is unchanged. The strict rollback assertion remains; production checkpoint cancellation and cleanup semantics are unchanged.

The intent wait closes the enqueue-before-running window, while the existing runner job barrier closes the interval between intent retirement and completion of unpublished-object deletion.

### Validation

Based on current main `c726a6199094`:

- focused `Test_CheckpointChaos1` under `-race`: measured 1.02s;
- adaptive race stress with a 30s budget: `-race -count=29` passed in 30.722s;
- full `pkg/vm/engine/tae/db/test` under `-race`: passed in 77.015s;
- full package in normal mode: passed in 54.172s;
- owning-package `go vet`: passed;
- `gofmt` and `git diff --check`: passed.