### PR TITLE
fix ut

### DIFF
--- a/pkg/tests/issues/issue_26339_test.go
+++ b/pkg/tests/issues/issue_26339_test.go
@@ -26,6 +26,7 @@ import (
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	pbtxn "github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,6 +51,10 @@ func TestIssue26339ForeignKeyExecutionRegressions(t *testing.T) {
 		}()
 		execSQLRequire(t, ctx, db, "drop database if exists "+database)
 		execSQLRequire(t, ctx, db, "create database "+database)
+		// CREATE DATABASE commits before its catalog entry is necessarily visible to
+		// a later FK DDL transaction. Wait for the CN's catalog cache so FK setup
+		// cannot observe the transient ExpectedEOB state under CI load.
+		testutils.WaitDatabaseCreated(t, database, cn)
 
 		t.Run("optimistic parent update is rejected before concurrent child write", func(t *testing.T) {
 			execSQLRequire(t, ctx, db, "create table "+database+".optimistic_parent (id int primary key)")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26674

## What this PR does / why we need it:

      - TestIssue26339ForeignKeyExecutionRegressions 建库后等待 CN catalog cache 可见，再创建 FK 表，消除 CI 下 ExpectedEOB 的偶发失败。