### PR TITLE
test(logservice): retry WAL recovery service startup

### DIFF
--- a/pkg/logservice/service_bootstrap_test.go
+++ b/pkg/logservice/service_bootstrap_test.go
@@ -206,16 +206,20 @@ func TestWALRecoveryRejectsDirtyDestinationAndKeepsFence(t *testing.T) {
 	walPath := filepath.Join(dir, "wal_data.bin")
 	require.NoError(t, writeTestWALDataFile(walPath, nil))
 
-	cfg := getServiceTestConfig()
-	defer vfs.ReportLeakedFD(cfg.FS, t)
-	cfg.DisableWorkers = false
-	// See TestServiceBootstrapRestoresHAKeeperAndWAL. This test needs the
-	// bootstrap heartbeat command batch to reach the local LogService.
-	cfg.RPC.MaxMessageSize = defaultMaxMessageSize
-	cfg.BootstrapConfig.InitHAKeeperMembers = []string{"131072:" + cfg.UUID}
-	cfg.HAKeeperClientConfig.ServiceAddresses = []string{cfg.LogServiceServiceAddr()}
-	s, err := NewService(
-		cfg,
+	var cfg Config
+	defer func() { vfs.ReportLeakedFD(cfg.FS, t) }()
+	genCfg := func() Config {
+		cfg = getServiceTestConfig()
+		cfg.DisableWorkers = false
+		// See TestServiceBootstrapRestoresHAKeeperAndWAL. This test needs the
+		// bootstrap heartbeat command batch to reach the local LogService.
+		cfg.RPC.MaxMessageSize = defaultMaxMessageSize
+		cfg.BootstrapConfig.InitHAKeeperMembers = []string{"131072:" + cfg.UUID}
+		cfg.HAKeeperClientConfig.ServiceAddresses = []string{cfg.LogServiceServiceAddr()}
+		return cfg
+	}
+	s, err := NewServiceWithRetry(
+		genCfg,
 		newFS(),
 		nil,
 		WithBackendFilter(func(morpc.Message, string) bool { return true }),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26673

## What this PR does / why we need it:

`TestWALRecoveryRejectsDirtyDestinationAndKeepsFence` selected RPC, Raft, and gossip ports before constructing its LogService, but the availability check did not reserve those ports. Another CI process could bind one in the gap before `NewService` started its listeners, causing the test to fail with `address already in use`.

This change builds the complete test configuration through a generator and uses the existing `NewServiceWithRetry` test helper. Every address collision now regenerates a consistent UUID, in-memory filesystem, RPC/Raft/gossip address set, bootstrap membership, and HAKeeper client address. The test keeps using the configuration from the successful service generation.

The existing dirty-destination, recovery-fence, lease-holder, and rejected-append assertions are unchanged. Production behavior, APIs, configuration, and storage formats are unaffected.

### Validation

- `TestWALRecoveryRejectsDirtyDestinationAndKeepsFence` passed 3 consecutive normal runs.
- The same test passed 3 consecutive race-detector runs.
- `TestServiceBootstrapRestoresHAKeeperAndWAL` and `TestWALRecoveryRejectsDirtyDestinationAndKeepsFence` passed together.
- `go build ./pkg/logservice` passed.
- `go vet ./pkg/logservice` passed.
- `git diff --check` passed.

A full local `pkg/logservice` run was attempted but is not reported as passing: another local `mo-service` was listening on the fixed HAKeeper address `127.0.0.1:32001`, which changed `TestNewServiceClosesStoreOnReplicaStartFailure` membership behavior. The focused WAL recovery tests above passed, and an isolated baseline full-package run passed.
