### PR TITLE
fix(plan): return MySQL 1146 for missing tables

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -1198,6 +1198,14 @@ func NewNoSuchTable(ctx context.Context, db, tbl string) *Error {
 	return newError(noReportCtx, ErrNoSuchTable, db, tbl)
 }
 
+// NewNoSuchTablef preserves a caller-facing diagnostic while classifying the
+// error as ErrNoSuchTable for MySQL protocol compatibility.
+func NewNoSuchTablef(ctx context.Context, format string, args ...any) *Error {
+	err := NewNoSuchTable(ctx, "", "")
+	err.message = fmt.Sprintf(format, args...)
+	return err
+}
+
 func NewNoSuchSequence(ctx context.Context, db, tbl string) *Error {
 	noReportCtx := errutil.ContextWithNoReport(ctx, true)
 	return newError(noReportCtx, ErrNoSuchSequence, db, tbl)

--- a/pkg/common/moerr/error_test.go
+++ b/pkg/common/moerr/error_test.go
@@ -181,6 +181,13 @@ func TestResourceExhaustedWithDetailsEncoding(t *testing.T) {
 	require.Equal(t, err, decoded)
 }
 
+func TestNoSuchTableWithFormattedMessage(t *testing.T) {
+	err := NewNoSuchTablef(context.Background(), "SQL parser error: table %q does not exist", "missing")
+	require.Equal(t, ErrNoSuchTable, err.ErrorCode())
+	require.Equal(t, ER_NO_SUCH_TABLE, err.MySQLCode())
+	require.Equal(t, `SQL parser error: table "missing" does not exist`, err.Error())
+}
+
 func TestMPoolCapacityEncoding(t *testing.T) {
 	err := NewMPoolCapacityNoCtxf("alloc %d bytes, cap %d", 8, 4)
 	require.Equal(t, ErrMPoolCapacity, err.ErrorCode())

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -9258,7 +9258,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, t
 			return 0, err
 		}
 		if tableDef == nil {
-			return 0, moerr.NewParseErrorf(builder.GetContext(), "table %q does not exist", table)
+			return 0, moerr.NewNoSuchTablef(builder.GetContext(), "SQL parser error: table %q does not exist", table)
 		}
 
 		tableDef.Name2ColIndex = map[string]int32{}

--- a/pkg/sql/plan/query_builder_test.go
+++ b/pkg/sql/plan/query_builder_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/iceberg/model"
 	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
@@ -708,6 +709,20 @@ func TestWrongCases(t *testing.T) {
 		_, err := runOneStmt(mock, t, kase.sql)
 		require.Error(t, err, kase.comment, kase.sql)
 	}
+}
+
+func TestMissingBaseTableUsesNoSuchTableError(t *testing.T) {
+	testutil.NewProc(t)
+	mock := NewMockOptimizer(false)
+
+	_, err := runOneStmt(mock, t, "select * from mo_odbc_missing_state")
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable), err)
+
+	moErr, ok := err.(*moerr.Error)
+	require.True(t, ok)
+	require.Equal(t, moerr.ER_NO_SUCH_TABLE, moErr.MySQLCode())
+	require.Equal(t, `SQL parser error: table "mo_odbc_missing_state" does not exist`, moErr.Error())
 }
 
 func TestDefaultBigStats(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26684 

## What this PR does / why we need it:

fix(plan): return MySQL 1146 for missing tables