### PR TITLE
[4.2-dev] fix: preserve prepared numeric semantics for BIT casts

### DIFF
--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -67,6 +67,9 @@ type Vector struct {
 
 	// FIXME: Bad design! Will be deleted soon.
 	isBin bool
+	// isSignedIntegerParam records that a transient text vector came from a
+	// signed integer in the MySQL binary prepared-statement protocol.
+	isSignedIntegerParam bool
 
 	offHeap bool
 
@@ -357,6 +360,14 @@ func (v *Vector) GetIsBin() bool {
 
 func (v *Vector) SetIsBin(isBin bool) {
 	v.isBin = isBin
+}
+
+func (v *Vector) GetIsSignedIntegerParam() bool {
+	return v.isSignedIntegerParam
+}
+
+func (v *Vector) SetIsSignedIntegerParam(isSignedIntegerParam bool) {
+	v.isSignedIntegerParam = isSignedIntegerParam
 }
 
 func (v *Vector) NeedDup() bool {

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -67,9 +67,9 @@ type Vector struct {
 
 	// FIXME: Bad design! Will be deleted soon.
 	isBin bool
-	// isSignedIntegerParam records that a transient text vector came from a
-	// signed integer in the MySQL binary prepared-statement protocol.
-	isSignedIntegerParam bool
+	// isIntegerParam records that a transient text vector came from an integer
+	// in the MySQL binary prepared-statement protocol.
+	isIntegerParam bool
 
 	offHeap bool
 
@@ -362,12 +362,12 @@ func (v *Vector) SetIsBin(isBin bool) {
 	v.isBin = isBin
 }
 
-func (v *Vector) GetIsSignedIntegerParam() bool {
-	return v.isSignedIntegerParam
+func (v *Vector) GetIsIntegerParam() bool {
+	return v.isIntegerParam
 }
 
-func (v *Vector) SetIsSignedIntegerParam(isSignedIntegerParam bool) {
-	v.isSignedIntegerParam = isSignedIntegerParam
+func (v *Vector) SetIsIntegerParam(isIntegerParam bool) {
+	v.isIntegerParam = isIntegerParam
 }
 
 func (v *Vector) NeedDup() bool {
@@ -848,6 +848,7 @@ func (v *Vector) Free(mp *mpool.MPool) {
 	v.gsp.Reset()
 	v.sorted = false
 	v.isBin = false
+	v.isIntegerParam = false
 	v.allocationAccount = nil
 	v.areaDisjoint = true
 

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -42,6 +42,20 @@ const (
 	DIST            // dictionary vector
 )
 
+// PrepareParamKind preserves the source conversion category of a transient
+// text vector produced by MySQL prepared-statement execution.
+type PrepareParamKind uint8
+
+// Values are bit-packed into bool sections for remote Process transport. Keep
+// the numeric assignments stable and within three bits.
+const (
+	PrepareParamNone PrepareParamKind = iota
+	PrepareParamInteger
+	PrepareParamFloat
+	PrepareParamDecimal
+	PrepareParamBoolean
+)
+
 // Vector represent a column
 type Vector struct {
 	// vector's class
@@ -66,10 +80,8 @@ type Vector struct {
 	sorted bool // for some optimization
 
 	// FIXME: Bad design! Will be deleted soon.
-	isBin bool
-	// isIntegerParam records that a transient text vector came from an integer
-	// in the MySQL binary prepared-statement protocol.
-	isIntegerParam bool
+	isBin            bool
+	prepareParamKind PrepareParamKind
 
 	offHeap bool
 
@@ -362,12 +374,12 @@ func (v *Vector) SetIsBin(isBin bool) {
 	v.isBin = isBin
 }
 
-func (v *Vector) GetIsIntegerParam() bool {
-	return v.isIntegerParam
+func (v *Vector) GetPrepareParamKind() PrepareParamKind {
+	return v.prepareParamKind
 }
 
-func (v *Vector) SetIsIntegerParam(isIntegerParam bool) {
-	v.isIntegerParam = isIntegerParam
+func (v *Vector) SetPrepareParamKind(kind PrepareParamKind) {
+	v.prepareParamKind = kind
 }
 
 func (v *Vector) NeedDup() bool {
@@ -848,7 +860,7 @@ func (v *Vector) Free(mp *mpool.MPool) {
 	v.gsp.Reset()
 	v.sorted = false
 	v.isBin = false
-	v.isIntegerParam = false
+	v.prepareParamKind = PrepareParamNone
 	v.allocationAccount = nil
 	v.areaDisjoint = true
 

--- a/pkg/frontend/back_exec.go
+++ b/pkg/frontend/back_exec.go
@@ -413,6 +413,7 @@ func doComQueryInBack(
 	proc.SetStmtProfile(&backSes.stmtProfile)
 	proc.SetResolveVariableFunc(backSes.txnCompileCtx.ResolveVariable)
 	proc.SetResolveVariableIsBinFunc(backSes.txnCompileCtx.ResolveVariableIsBin)
+	proc.SetResolveVariablePrepareParamKindFunc(backSes.txnCompileCtx.ResolveVariablePrepareParamKind)
 	// backExec.Exec and ExecRestore reject multi-statement SQL before reaching
 	// this path, so one snapshot here covers the complete background statement.
 	refreshBackgroundStatementScopedSessionInfo(backSes, input, proc)

--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -32,6 +32,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/pubsub"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -828,6 +829,27 @@ func (tcc *TxnCompilerContext) ResolveVariableIsBin(varName string, isSystemVar,
 		return false, err
 	}
 	return udVar.IsBin, nil
+}
+
+func (tcc *TxnCompilerContext) ResolveVariablePrepareParamKind(
+	varName string,
+	isSystemVar, isGlobalVar bool,
+) (vector.PrepareParamKind, error) {
+	if value, ok := resolveStoredProcedureVariable(tcc.execCtx.reqCtx, varName); ok {
+		return prepareParamKindFromValue(value), nil
+	}
+	if isSystemVar {
+		value, err := tcc.ResolveVariable(varName, true, isGlobalVar)
+		if err != nil {
+			return vector.PrepareParamNone, err
+		}
+		return prepareParamKindFromValue(value), nil
+	}
+	udVar, err := tcc.GetSession().GetUserDefinedVar(varName)
+	if err != nil {
+		return vector.PrepareParamNone, err
+	}
+	return udVar.PrepareParamKind, nil
 }
 
 func resolveStoredProcedureVariable(ctx context.Context, varName string) (interface{}, bool) {

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -687,6 +687,16 @@ func initExecuteStmtParamWithResolver(
 	return initExecuteStmtParamWithResolverInSession(execCtx, ses, ses, cwft, execPlan, stmtName, resolve)
 }
 
+func isBinaryProtocolIntegerType(mysqlType defines.MysqlType) bool {
+	switch mysqlType {
+	case defines.MYSQL_TYPE_TINY, defines.MYSQL_TYPE_SHORT, defines.MYSQL_TYPE_INT24,
+		defines.MYSQL_TYPE_LONG, defines.MYSQL_TYPE_LONGLONG:
+		return true
+	default:
+		return false
+	}
+}
+
 func initExecuteStmtParamWithResolverInSession(
 	execCtx *ExecCtx,
 	owner *Session,
@@ -869,16 +879,21 @@ func initExecuteStmtParamWithResolverInSession(
 			return nil, nil, nil, originSQL, false, moerr.NewInvalidInput(reqCtx, "Incorrect arguments to EXECUTE")
 		}
 		paramCount := prepareStmt.params.Length()
-		isBin := make([]bool, paramCount)
-		isSignedInteger := make([]bool, paramCount)
+		var isInteger []bool
 		for i := 0; i < paramCount && i*2+1 < len(prepareStmt.ParamTypes); i++ {
 			mysqlType := defines.MysqlType(prepareStmt.ParamTypes[i*2])
-			unsigned := prepareStmt.ParamTypes[i*2+1]&0x80 != 0
-			isSignedInteger[i] = !unsigned && (mysqlType == defines.MYSQL_TYPE_TINY ||
-				mysqlType == defines.MYSQL_TYPE_SHORT || mysqlType == defines.MYSQL_TYPE_INT24 ||
-				mysqlType == defines.MYSQL_TYPE_LONG || mysqlType == defines.MYSQL_TYPE_LONGLONG)
+			if isBinaryProtocolIntegerType(mysqlType) {
+				if isInteger == nil {
+					isInteger = make([]bool, paramCount)
+				}
+				isInteger[i] = true
+			}
 		}
-		cwft.proc.SetPrepareParamsWithMeta(prepareStmt.params, isBin, isSignedInteger)
+		if isInteger == nil {
+			cwft.proc.SetPrepareParams(prepareStmt.params)
+		} else {
+			cwft.proc.SetPrepareParamsWithMeta(prepareStmt.params, nil, isInteger)
+		}
 		cwft.paramVals, err = preparedParamValues(cwft.proc)
 		if err != nil {
 			return nil, nil, nil, originSQL, false, err

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -868,7 +868,17 @@ func initExecuteStmtParamWithResolverInSession(
 		if prepareStmt.params.Length() != numParams {
 			return nil, nil, nil, originSQL, false, moerr.NewInvalidInput(reqCtx, "Incorrect arguments to EXECUTE")
 		}
-		cwft.proc.SetPrepareParams(prepareStmt.params)
+		paramCount := prepareStmt.params.Length()
+		isBin := make([]bool, paramCount)
+		isSignedInteger := make([]bool, paramCount)
+		for i := 0; i < paramCount && i*2+1 < len(prepareStmt.ParamTypes); i++ {
+			mysqlType := defines.MysqlType(prepareStmt.ParamTypes[i*2])
+			unsigned := prepareStmt.ParamTypes[i*2+1]&0x80 != 0
+			isSignedInteger[i] = !unsigned && (mysqlType == defines.MYSQL_TYPE_TINY ||
+				mysqlType == defines.MYSQL_TYPE_SHORT || mysqlType == defines.MYSQL_TYPE_INT24 ||
+				mysqlType == defines.MYSQL_TYPE_LONG || mysqlType == defines.MYSQL_TYPE_LONGLONG)
+		}
+		cwft.proc.SetPrepareParamsWithMeta(prepareStmt.params, isBin, isSignedInteger)
 		cwft.paramVals, err = preparedParamValues(cwft.proc)
 		if err != nil {
 			return nil, nil, nil, originSQL, false, err

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -690,7 +690,7 @@ func initExecuteStmtParamWithResolver(
 func isBinaryProtocolIntegerType(mysqlType defines.MysqlType) bool {
 	switch mysqlType {
 	case defines.MYSQL_TYPE_TINY, defines.MYSQL_TYPE_SHORT, defines.MYSQL_TYPE_INT24,
-		defines.MYSQL_TYPE_LONG, defines.MYSQL_TYPE_LONGLONG:
+		defines.MYSQL_TYPE_LONG, defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_YEAR:
 		return true
 	default:
 		return false

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -687,13 +687,17 @@ func initExecuteStmtParamWithResolver(
 	return initExecuteStmtParamWithResolverInSession(execCtx, ses, ses, cwft, execPlan, stmtName, resolve)
 }
 
-func isBinaryProtocolIntegerType(mysqlType defines.MysqlType) bool {
+func binaryProtocolPrepareParamKind(mysqlType defines.MysqlType) vector.PrepareParamKind {
 	switch mysqlType {
 	case defines.MYSQL_TYPE_TINY, defines.MYSQL_TYPE_SHORT, defines.MYSQL_TYPE_INT24,
 		defines.MYSQL_TYPE_LONG, defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_YEAR:
-		return true
+		return vector.PrepareParamInteger
+	case defines.MYSQL_TYPE_FLOAT, defines.MYSQL_TYPE_DOUBLE:
+		return vector.PrepareParamFloat
+	case defines.MYSQL_TYPE_DECIMAL, defines.MYSQL_TYPE_NEWDECIMAL:
+		return vector.PrepareParamDecimal
 	default:
-		return false
+		return vector.PrepareParamNone
 	}
 }
 
@@ -879,20 +883,21 @@ func initExecuteStmtParamWithResolverInSession(
 			return nil, nil, nil, originSQL, false, moerr.NewInvalidInput(reqCtx, "Incorrect arguments to EXECUTE")
 		}
 		paramCount := prepareStmt.params.Length()
-		var isInteger []bool
+		var kinds []vector.PrepareParamKind
 		for i := 0; i < paramCount && i*2+1 < len(prepareStmt.ParamTypes); i++ {
 			mysqlType := defines.MysqlType(prepareStmt.ParamTypes[i*2])
-			if isBinaryProtocolIntegerType(mysqlType) {
-				if isInteger == nil {
-					isInteger = make([]bool, paramCount)
+			kind := binaryProtocolPrepareParamKind(mysqlType)
+			if kind != vector.PrepareParamNone {
+				if kinds == nil {
+					kinds = make([]vector.PrepareParamKind, paramCount)
 				}
-				isInteger[i] = true
+				kinds[i] = kind
 			}
 		}
-		if isInteger == nil {
+		if kinds == nil {
 			cwft.proc.SetPrepareParams(prepareStmt.params)
 		} else {
-			cwft.proc.SetPrepareParamsWithMeta(prepareStmt.params, nil, isInteger)
+			cwft.proc.SetPrepareParamsWithMeta(prepareStmt.params, nil, kinds)
 		}
 		cwft.paramVals, err = preparedParamValues(cwft.proc)
 		if err != nil {
@@ -902,11 +907,11 @@ func initExecuteStmtParamWithResolverInSession(
 		if len(execPlan.Args) != numParams {
 			return nil, nil, nil, originSQL, false, moerr.NewInvalidInput(reqCtx, "Incorrect arguments to EXECUTE")
 		}
-		params, paramVals, paramIsBin, err := buildExecuteUserParams(cwft.proc, execPlan.Args)
+		params, paramVals, paramIsBin, paramKinds, err := buildExecuteUserParams(cwft.proc, execPlan.Args)
 		if err != nil {
 			return nil, nil, nil, originSQL, false, err
 		}
-		cwft.proc.SetOwnedPrepareParamsWithIsBin(params, paramIsBin)
+		cwft.proc.SetOwnedPrepareParamsWithMeta(params, paramIsBin, paramKinds)
 		cwft.paramVals = paramVals
 	} else {
 		if numParams > 0 {
@@ -1068,7 +1073,13 @@ func preparedParamValues(proc *process.Process) ([]any, error) {
 func buildExecuteUserParams(
 	proc *process.Process,
 	args []*plan.Expr,
-) (params *vector.Vector, paramVals []any, paramIsBin []bool, err error) {
+) (
+	params *vector.Vector,
+	paramVals []any,
+	paramIsBin []bool,
+	paramKinds []vector.PrepareParamKind,
+	err error,
+) {
 	params = vector.NewVec(types.T_text.ToType())
 	defer func() {
 		if err != nil {
@@ -1077,14 +1088,11 @@ func buildExecuteUserParams(
 	}()
 	paramVals = make([]any, len(args))
 	paramIsBin = make([]bool, len(args))
+	paramKinds = make([]vector.PrepareParamKind, len(args))
 	for i, arg := range args {
 		exprImpl := arg.Expr.(*plan.Expr_V)
 		var param any
 		param, err = proc.GetResolveVariableFunc()(exprImpl.V.Name, exprImpl.V.System, exprImpl.V.Global)
-		if err != nil {
-			return
-		}
-		err = util.AppendAnyToStringVector(proc, param, params)
 		if err != nil {
 			return
 		}
@@ -1094,6 +1102,19 @@ func buildExecuteUserParams(
 			if err != nil {
 				return
 			}
+		}
+		resolveKind := proc.GetResolveVariablePrepareParamKindFunc()
+		if resolveKind != nil {
+			paramKinds[i], err = resolveKind(exprImpl.V.Name, exprImpl.V.System, exprImpl.V.Global)
+			if err != nil {
+				return
+			}
+		} else {
+			paramKinds[i] = prepareParamKindFromValue(param)
+		}
+		err = util.AppendAnyToStringVector(proc, param, params)
+		if err != nil {
+			return
 		}
 		paramVals[i] = plan2.ParamValue{Value: param, IsBin: paramIsBin[i]}
 	}

--- a/pkg/frontend/computation_wrapper_test.go
+++ b/pkg/frontend/computation_wrapper_test.go
@@ -228,6 +228,57 @@ func TestInitExecuteStmtParamPreservesBinaryFlagPerUserVariable(t *testing.T) {
 	cw.proc.SetPrepareParams(nil)
 }
 
+func TestInitExecuteStmtParamPreservesIntegerProtocolProvenance(t *testing.T) {
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(t, 104, "select ?, ?, ?")
+	defer func() {
+		cw.proc.SetPrepareParams(nil)
+		prepareStmt.Close()
+	}()
+
+	prepareStmt.params = vector.NewVec(types.T_text.ToType())
+	for _, value := range []string{"5", "18446744073709551615", "5"} {
+		require.NoError(t, vector.AppendBytes(prepareStmt.params, []byte(value), false, cw.proc.Mp()))
+	}
+	prepareStmt.ParamTypes = []byte{
+		byte(defines.MYSQL_TYPE_LONGLONG), 0,
+		byte(defines.MYSQL_TYPE_LONGLONG), 0x80,
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
+	}
+
+	_, _, _, _, _, err := initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
+	require.NoError(t, err)
+	require.True(t, cw.proc.GetPrepareParamIsInteger(0))
+	require.True(t, cw.proc.GetPrepareParamIsInteger(1))
+	require.False(t, cw.proc.GetPrepareParamIsInteger(2))
+	require.False(t, cw.proc.GetPrepareParamIsInteger(3))
+	// An invalid parameter index must not bleed into the packed integer section.
+	require.False(t, cw.proc.GetPrepareParamIsBin(3))
+
+	prepareStmt.ParamTypes = []byte{
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
+	}
+	_, _, _, _, _, err = initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
+	require.NoError(t, err)
+	for i := 0; i < prepareStmt.params.Length(); i++ {
+		require.False(t, cw.proc.GetPrepareParamIsInteger(i), "parameter %d retained stale integer metadata", i)
+	}
+}
+
+func TestIsBinaryProtocolIntegerType(t *testing.T) {
+	for _, mysqlType := range []defines.MysqlType{
+		defines.MYSQL_TYPE_TINY,
+		defines.MYSQL_TYPE_SHORT,
+		defines.MYSQL_TYPE_INT24,
+		defines.MYSQL_TYPE_LONG,
+		defines.MYSQL_TYPE_LONGLONG,
+	} {
+		require.True(t, isBinaryProtocolIntegerType(mysqlType), "type %v", mysqlType)
+	}
+	require.False(t, isBinaryProtocolIntegerType(defines.MYSQL_TYPE_VAR_STRING))
+}
+
 func TestPreparedSetExpressionParamsAfterInit(t *testing.T) {
 	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
 		t, 108, "set @prepared_set_value = ? + 1")

--- a/pkg/frontend/computation_wrapper_test.go
+++ b/pkg/frontend/computation_wrapper_test.go
@@ -168,6 +168,7 @@ func newPreparedExecuteEnvForSQL(t testing.TB, stmtID uint32, sql string) (*Sess
 	ses.GetTxnCompileCtx().SetExecCtx(execCtx)
 	proc.SetResolveVariableFunc(ses.txnCompileCtx.ResolveVariable)
 	proc.SetResolveVariableIsBinFunc(ses.txnCompileCtx.ResolveVariableIsBin)
+	proc.SetResolveVariablePrepareParamKindFunc(ses.txnCompileCtx.ResolveVariablePrepareParamKind)
 	return ses, prepareStmt, cw, execCtx
 }
 
@@ -228,35 +229,53 @@ func TestInitExecuteStmtParamPreservesBinaryFlagPerUserVariable(t *testing.T) {
 	cw.proc.SetPrepareParams(nil)
 }
 
-func TestInitExecuteStmtParamPreservesIntegerProtocolProvenance(t *testing.T) {
-	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(t, 104, "select ?, ?, ?, ?")
+func TestInitExecuteStmtParamPreservesNumericProtocolProvenance(t *testing.T) {
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(t, 104, "select ?, ?, ?, ?, ?, ?, ?, ?")
 	defer func() {
 		cw.proc.SetPrepareParams(nil)
 		prepareStmt.Close()
 	}()
 
 	prepareStmt.params = vector.NewVec(types.T_text.ToType())
-	for _, value := range []string{"5", "18446744073709551615", "2024", "5"} {
+	for _, value := range []string{
+		"5", "18446744073709551615", "2024", "5.5", "5.5", "5.9", "5.9", "5",
+	} {
 		require.NoError(t, vector.AppendBytes(prepareStmt.params, []byte(value), false, cw.proc.Mp()))
 	}
 	prepareStmt.ParamTypes = []byte{
 		byte(defines.MYSQL_TYPE_LONGLONG), 0,
 		byte(defines.MYSQL_TYPE_LONGLONG), 0x80,
 		byte(defines.MYSQL_TYPE_YEAR), 0,
+		byte(defines.MYSQL_TYPE_FLOAT), 0,
+		byte(defines.MYSQL_TYPE_DOUBLE), 0,
+		byte(defines.MYSQL_TYPE_DECIMAL), 0,
+		byte(defines.MYSQL_TYPE_NEWDECIMAL), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 	}
 
 	_, _, _, _, _, err := initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
 	require.NoError(t, err)
-	require.True(t, cw.proc.GetPrepareParamIsInteger(0))
-	require.True(t, cw.proc.GetPrepareParamIsInteger(1))
-	require.True(t, cw.proc.GetPrepareParamIsInteger(2))
-	require.False(t, cw.proc.GetPrepareParamIsInteger(3))
-	require.False(t, cw.proc.GetPrepareParamIsInteger(4))
-	// An invalid parameter index must not bleed into the packed integer section.
-	require.False(t, cw.proc.GetPrepareParamIsBin(4))
+	for i, want := range []vector.PrepareParamKind{
+		vector.PrepareParamInteger,
+		vector.PrepareParamInteger,
+		vector.PrepareParamInteger,
+		vector.PrepareParamFloat,
+		vector.PrepareParamFloat,
+		vector.PrepareParamDecimal,
+		vector.PrepareParamDecimal,
+		vector.PrepareParamNone,
+	} {
+		require.Equal(t, want, cw.proc.GetPrepareParamKind(i), "parameter %d", i)
+	}
+	require.Equal(t, vector.PrepareParamNone, cw.proc.GetPrepareParamKind(8))
+	// An invalid parameter index must not bleed into another packed section.
+	require.False(t, cw.proc.GetPrepareParamIsBin(8))
 
 	prepareStmt.ParamTypes = []byte{
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
@@ -265,23 +284,53 @@ func TestInitExecuteStmtParamPreservesIntegerProtocolProvenance(t *testing.T) {
 	_, _, _, _, _, err = initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
 	require.NoError(t, err)
 	for i := 0; i < prepareStmt.params.Length(); i++ {
-		require.False(t, cw.proc.GetPrepareParamIsInteger(i), "parameter %d retained stale integer metadata", i)
+		require.Equal(t, vector.PrepareParamNone, cw.proc.GetPrepareParamKind(i),
+			"parameter %d retained stale numeric metadata", i)
 	}
 }
 
-func TestIsBinaryProtocolIntegerType(t *testing.T) {
-	for _, mysqlType := range []defines.MysqlType{
-		defines.MYSQL_TYPE_TINY,
-		defines.MYSQL_TYPE_SHORT,
-		defines.MYSQL_TYPE_INT24,
-		defines.MYSQL_TYPE_LONG,
-		defines.MYSQL_TYPE_LONGLONG,
-		defines.MYSQL_TYPE_YEAR,
+func TestBinaryProtocolPrepareParamKind(t *testing.T) {
+	for _, test := range []struct {
+		mysqlType defines.MysqlType
+		want      vector.PrepareParamKind
+	}{
+		{defines.MYSQL_TYPE_TINY, vector.PrepareParamInteger},
+		{defines.MYSQL_TYPE_SHORT, vector.PrepareParamInteger},
+		{defines.MYSQL_TYPE_INT24, vector.PrepareParamInteger},
+		{defines.MYSQL_TYPE_LONG, vector.PrepareParamInteger},
+		{defines.MYSQL_TYPE_LONGLONG, vector.PrepareParamInteger},
+		{defines.MYSQL_TYPE_YEAR, vector.PrepareParamInteger},
+		{defines.MYSQL_TYPE_FLOAT, vector.PrepareParamFloat},
+		{defines.MYSQL_TYPE_DOUBLE, vector.PrepareParamFloat},
+		{defines.MYSQL_TYPE_DECIMAL, vector.PrepareParamDecimal},
+		{defines.MYSQL_TYPE_NEWDECIMAL, vector.PrepareParamDecimal},
+		{defines.MYSQL_TYPE_BIT, vector.PrepareParamNone},
+		{defines.MYSQL_TYPE_VAR_STRING, vector.PrepareParamNone},
 	} {
-		require.True(t, isBinaryProtocolIntegerType(mysqlType), "type %v", mysqlType)
+		require.Equal(t, test.want, binaryProtocolPrepareParamKind(test.mysqlType), "type %v", test.mysqlType)
 	}
-	require.False(t, isBinaryProtocolIntegerType(defines.MYSQL_TYPE_BIT))
-	require.False(t, isBinaryProtocolIntegerType(defines.MYSQL_TYPE_VAR_STRING))
+}
+
+func TestSQLVariablePrepareParamKind(t *testing.T) {
+	for _, test := range []struct {
+		oid  types.T
+		want vector.PrepareParamKind
+	}{
+		{types.T_bool, vector.PrepareParamBoolean},
+		{types.T_bit, vector.PrepareParamInteger},
+		{types.T_int64, vector.PrepareParamInteger},
+		{types.T_uint64, vector.PrepareParamInteger},
+		{types.T_year, vector.PrepareParamInteger},
+		{types.T_float64, vector.PrepareParamFloat},
+		{types.T_decimal128, vector.PrepareParamDecimal},
+		{types.T_varchar, vector.PrepareParamNone},
+	} {
+		require.Equal(t, test.want, prepareParamKindFromType(test.oid), "type %v", test.oid)
+	}
+	require.Equal(t, vector.PrepareParamBoolean, prepareParamKindFromValue(true))
+	require.Equal(t, vector.PrepareParamInteger, prepareParamKindFromValue(uint64(5)))
+	require.Equal(t, vector.PrepareParamFloat, prepareParamKindFromValue(float64(5)))
+	require.Equal(t, vector.PrepareParamNone, prepareParamKindFromValue("5"))
 }
 
 func TestPreparedSetExpressionParamsAfterInit(t *testing.T) {
@@ -330,7 +379,7 @@ func TestInitExecuteStmtParamFreesParamsOnResolveError(t *testing.T) {
 			{Expr: &plan.Expr_V{V: &plan.VarRef{Name: "second"}}},
 		},
 	}
-	params, _, _, err := buildExecuteUserParams(cw.proc, execPlan.Args)
+	params, _, _, _, err := buildExecuteUserParams(cw.proc, execPlan.Args)
 	require.ErrorIs(t, err, assert.AnError)
 	require.Zero(t, params.Length())
 	require.Nil(t, params.GetData())
@@ -355,6 +404,9 @@ func TestResolveVariableIsBinHonorsStoredProcedureScope(t *testing.T) {
 	isBin, err := ses.txnCompileCtx.ResolveVariableIsBin("V1", false, false)
 	require.NoError(t, err)
 	require.False(t, isBin)
+	kind, err := ses.txnCompileCtx.ResolveVariablePrepareParamKind("V1", false, false)
+	require.NoError(t, err)
+	require.Equal(t, vector.PrepareParamInteger, kind)
 
 	value, err = ses.txnCompileCtx.ResolveVariable("session_only", false, false)
 	require.NoError(t, err)
@@ -362,6 +414,9 @@ func TestResolveVariableIsBinHonorsStoredProcedureScope(t *testing.T) {
 	isBin, err = ses.txnCompileCtx.ResolveVariableIsBin("session_only", false, false)
 	require.NoError(t, err)
 	require.True(t, isBin)
+	kind, err = ses.txnCompileCtx.ResolveVariablePrepareParamKind("session_only", false, false)
+	require.NoError(t, err)
+	require.Equal(t, vector.PrepareParamNone, kind)
 }
 
 func TestBuildExecuteUserParamsHonorsStoredProcedureScope(t *testing.T) {
@@ -380,11 +435,16 @@ func TestBuildExecuteUserParamsHonorsStoredProcedureScope(t *testing.T) {
 		{Expr: &plan.Expr_V{V: &plan.VarRef{Name: "local_shadow"}}},
 		{Expr: &plan.Expr_V{V: &plan.VarRef{Name: "session_only"}}},
 	}
-	params, paramVals, paramIsBin, err := buildExecuteUserParams(cw.proc, args)
+	params, paramVals, paramIsBin, paramKinds, err := buildExecuteUserParams(cw.proc, args)
 	require.NoError(t, err)
 	defer params.Free(cw.proc.Mp())
 
 	require.Equal(t, []bool{false, false, true}, paramIsBin)
+	require.Equal(t, []vector.PrepareParamKind{
+		vector.PrepareParamInteger,
+		vector.PrepareParamInteger,
+		vector.PrepareParamNone,
+	}, paramKinds)
 	require.Equal(t, []any{
 		plan2.ParamValue{Value: int64(10), IsBin: false},
 		plan2.ParamValue{Value: int64(20), IsBin: false},

--- a/pkg/frontend/computation_wrapper_test.go
+++ b/pkg/frontend/computation_wrapper_test.go
@@ -229,19 +229,20 @@ func TestInitExecuteStmtParamPreservesBinaryFlagPerUserVariable(t *testing.T) {
 }
 
 func TestInitExecuteStmtParamPreservesIntegerProtocolProvenance(t *testing.T) {
-	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(t, 104, "select ?, ?, ?")
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(t, 104, "select ?, ?, ?, ?")
 	defer func() {
 		cw.proc.SetPrepareParams(nil)
 		prepareStmt.Close()
 	}()
 
 	prepareStmt.params = vector.NewVec(types.T_text.ToType())
-	for _, value := range []string{"5", "18446744073709551615", "5"} {
+	for _, value := range []string{"5", "18446744073709551615", "2024", "5"} {
 		require.NoError(t, vector.AppendBytes(prepareStmt.params, []byte(value), false, cw.proc.Mp()))
 	}
 	prepareStmt.ParamTypes = []byte{
 		byte(defines.MYSQL_TYPE_LONGLONG), 0,
 		byte(defines.MYSQL_TYPE_LONGLONG), 0x80,
+		byte(defines.MYSQL_TYPE_YEAR), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 	}
 
@@ -249,12 +250,14 @@ func TestInitExecuteStmtParamPreservesIntegerProtocolProvenance(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, cw.proc.GetPrepareParamIsInteger(0))
 	require.True(t, cw.proc.GetPrepareParamIsInteger(1))
-	require.False(t, cw.proc.GetPrepareParamIsInteger(2))
+	require.True(t, cw.proc.GetPrepareParamIsInteger(2))
 	require.False(t, cw.proc.GetPrepareParamIsInteger(3))
+	require.False(t, cw.proc.GetPrepareParamIsInteger(4))
 	// An invalid parameter index must not bleed into the packed integer section.
-	require.False(t, cw.proc.GetPrepareParamIsBin(3))
+	require.False(t, cw.proc.GetPrepareParamIsBin(4))
 
 	prepareStmt.ParamTypes = []byte{
+		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
 		byte(defines.MYSQL_TYPE_VAR_STRING), 0,
@@ -273,9 +276,11 @@ func TestIsBinaryProtocolIntegerType(t *testing.T) {
 		defines.MYSQL_TYPE_INT24,
 		defines.MYSQL_TYPE_LONG,
 		defines.MYSQL_TYPE_LONGLONG,
+		defines.MYSQL_TYPE_YEAR,
 	} {
 		require.True(t, isBinaryProtocolIntegerType(mysqlType), "type %v", mysqlType)
 	}
+	require.False(t, isBinaryProtocolIntegerType(defines.MYSQL_TYPE_BIT))
 	require.False(t, isBinaryProtocolIntegerType(defines.MYSQL_TYPE_VAR_STRING))
 }
 

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -919,6 +919,7 @@ func doSetVar(
 	var err error = nil
 	var ok bool
 	var userVarIsBin bool
+	var userVarPrepareParamKind vector.PrepareParamKind
 	setVarFunc := func(system, global bool, name string, value interface{}, sql string) error {
 		var oldValueRaw interface{}
 		if system {
@@ -955,7 +956,8 @@ func doSetVar(
 				}
 			}
 		} else {
-			err = ses.setUserDefinedVar(name, value, sql, userVarIsBin)
+			err = ses.setUserDefinedVarWithKind(
+				name, value, sql, userVarIsBin, userVarPrepareParamKind)
 			if err != nil {
 				return err
 			}
@@ -967,9 +969,11 @@ func doSetVar(
 		name := assign.Name
 		var value interface{}
 		userVarIsBin = false
+		userVarPrepareParamKind = vector.PrepareParamNone
 
-		value, err = getExprValueWithPrepareMode(
-			assign.Value, ses, execCtx, preparedExpression, &userVarIsBin)
+		value, err = getExprValueWithPrepareMeta(
+			assign.Value, ses, execCtx, preparedExpression,
+			&userVarPrepareParamKind, &userVarIsBin)
 		if err != nil {
 			return err
 		}
@@ -4516,6 +4520,7 @@ func doComQuery(ses *Session, execCtx *ExecCtx, input *UserInput) (retErr error)
 	proc.SetAffectedRows(ses.GetLastAffectedRows())
 	proc.SetResolveVariableFunc(ses.txnCompileCtx.ResolveVariable)
 	proc.SetResolveVariableIsBinFunc(ses.txnCompileCtx.ResolveVariableIsBin)
+	proc.SetResolveVariablePrepareParamKindFunc(ses.txnCompileCtx.ResolveVariablePrepareParamKind)
 	refreshStatementScopedSessionInfo(ses, proc)
 	// Frontend client SQL — session-bound resolver. Procs constructed
 	// via pkg/sql/compile/sql_executor.go's NewTopProcess inherit

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2896,6 +2896,18 @@ func TestParseExecuteDataPreservesExactJsonOrderingParams(t *testing.T) {
 	}
 }
 
+func TestParseExecuteDataPreservesYearWireType(t *testing.T) {
+	data := make([]byte, 11)
+	copy(data, []byte{0, 0, 0, 0, 0, 0, 1, byte(defines.MYSQL_TYPE_YEAR), 0})
+	binary.LittleEndian.PutUint16(data[9:], 2024)
+
+	ctx := context.TODO()
+	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
+	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, data, 0))
+	require.Equal(t, "2024", prepareStmt.params.GetStringAt(0))
+	require.Equal(t, []byte{byte(defines.MYSQL_TYPE_YEAR), 0}, prepareStmt.ParamTypes)
+}
+
 func buildStringExecutePacket(proto *MysqlProtocolImpl, tp defines.MysqlType, payload string) []byte {
 	data := make([]byte, 8+2+9+len(payload))
 	copy(data, []byte{0, 0, 0, 0, 0, 0, 1, byte(tp), 0})

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -367,9 +368,24 @@ func (ses *Session) SetUserDefinedVar(name string, value interface{}, sql string
 }
 
 func (ses *Session) setUserDefinedVar(name string, value interface{}, sql string, isBin bool) error {
+	return ses.setUserDefinedVarWithKind(name, value, sql, isBin, prepareParamKindFromValue(value))
+}
+
+func (ses *Session) setUserDefinedVarWithKind(
+	name string,
+	value interface{},
+	sql string,
+	isBin bool,
+	kind vector.PrepareParamKind,
+) error {
 	ses.mu.Lock()
 	defer ses.mu.Unlock()
-	ses.userDefinedVars[strings.ToLower(name)] = &UserDefinedVar{Value: value, Sql: sql, IsBin: isBin}
+	ses.userDefinedVars[strings.ToLower(name)] = &UserDefinedVar{
+		Value:            value,
+		Sql:              sql,
+		IsBin:            isBin,
+		PrepareParamKind: kind,
+	}
 	return nil
 }
 

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -196,6 +196,17 @@ func getExprValueWithPrepareMode(
 	preparedExpression bool,
 	isBin ...*bool,
 ) (interface{}, error) {
+	return getExprValueWithPrepareMeta(e, ses, execCtx, preparedExpression, nil, isBin...)
+}
+
+func getExprValueWithPrepareMeta(
+	e tree.Expr,
+	ses *Session,
+	execCtx *ExecCtx,
+	preparedExpression bool,
+	prepareParamKind *vector.PrepareParamKind,
+	isBin ...*bool,
+) (interface{}, error) {
 	/*
 		CORNER CASE:
 			SET character_set_results = utf8; // e = tree.UnresolvedName{'utf8'}.
@@ -207,6 +218,9 @@ func getExprValueWithPrepareMode(
 		// set @a = on, type of a is bool.
 		if len(isBin) > 0 {
 			*isBin[0] = false
+		}
+		if prepareParamKind != nil {
+			*prepareParamKind = vector.PrepareParamNone
 		}
 		return v.ColName(), nil
 	}
@@ -296,6 +310,12 @@ func getExprValueWithPrepareMode(
 
 	if len(isBin) > 0 {
 		*isBin[0] = resultVec.GetIsBin()
+	}
+	if prepareParamKind != nil {
+		*prepareParamKind = resultVec.GetPrepareParamKind()
+		if *prepareParamKind == vector.PrepareParamNone {
+			*prepareParamKind = prepareParamKindFromType(resultVec.GetType().Oid)
+		}
 	}
 	return getValueFromVector(execCtx.reqCtx, resultVec, ses, planExpr)
 }

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fulltext"
 	"github.com/matrixorigin/matrixone/pkg/util/gpumode"
@@ -4265,9 +4266,42 @@ func valueIsBoolTrue(value interface{}) (bool, error) {
 }
 
 type UserDefinedVar struct {
-	Value interface{}
-	Sql   string
-	IsBin bool
+	Value            interface{}
+	Sql              string
+	IsBin            bool
+	PrepareParamKind vector.PrepareParamKind
+}
+
+func prepareParamKindFromType(oid types.T) vector.PrepareParamKind {
+	switch oid {
+	case types.T_bit, types.T_int8, types.T_int16, types.T_int32, types.T_int64,
+		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
+		types.T_year:
+		return vector.PrepareParamInteger
+	case types.T_float32, types.T_float64:
+		return vector.PrepareParamFloat
+	case types.T_decimal64, types.T_decimal128, types.T_decimal256:
+		return vector.PrepareParamDecimal
+	case types.T_bool:
+		return vector.PrepareParamBoolean
+	default:
+		return vector.PrepareParamNone
+	}
+}
+
+func prepareParamKindFromValue(value any) vector.PrepareParamKind {
+	switch value.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, types.MoYear:
+		return vector.PrepareParamInteger
+	case float32, float64:
+		return vector.PrepareParamFloat
+	case types.Decimal64, types.Decimal128, types.Decimal256:
+		return vector.PrepareParamDecimal
+	case bool:
+		return vector.PrepareParamBoolean
+	default:
+		return vector.PrepareParamNone
+	}
 }
 
 func autocommitValue(ses FeSession) (bool, error) {

--- a/pkg/shardservice/service_read.go
+++ b/pkg/shardservice/service_read.go
@@ -28,7 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/version"
 )
 
-func hasBinaryPrepareParam(param pb.ReadParam) bool {
+func hasVersionedPrepareParamMetadata(param pb.ReadParam) bool {
 	for _, isBin := range param.Process.PrepareParams.IsBin {
 		if isBin {
 			return true
@@ -42,7 +42,7 @@ func (s *service) validateRemoteReadCompatibility(
 	shard pb.TableShard,
 	param pb.ReadParam,
 ) error {
-	if !hasBinaryPrepareParam(param) {
+	if !hasVersionedPrepareParamMetadata(param) {
 		return nil
 	}
 
@@ -67,7 +67,7 @@ func (s *service) validateRemoteReadCompatibility(
 	}
 	return moerr.NewInternalErrorf(
 		ctx,
-		"cannot send binary prepared parameters to shard replica %s with an incompatible or unknown commit",
+		"cannot send prepared-parameter metadata to shard replica %s with an incompatible or unknown commit",
 		target,
 	)
 }

--- a/pkg/shardservice/service_read_test.go
+++ b/pkg/shardservice/service_read_test.go
@@ -74,7 +74,7 @@ func TestValidateRemoteReadCompatibility(t *testing.T) {
 	require.Error(t, s.validateRemoteReadCompatibility(t.Context(), unknown, binaryParam))
 }
 
-func TestNewReadRequestUsesVersionedMethodForBinaryParams(t *testing.T) {
+func TestNewReadRequestUsesVersionedMethodForPrepareParamMetadata(t *testing.T) {
 	s := &service{}
 	s.remote.pool = morpc.NewMessagePool(
 		func() *shard.Request { return &shard.Request{} },
@@ -96,6 +96,17 @@ func TestNewReadRequestUsesVersionedMethodForBinaryParams(t *testing.T) {
 	)
 	require.Equal(t, shard.Method_ShardReadV2, binaryReq.RPCMethod)
 	s.remote.pool.ReleaseRequest(binaryReq)
+
+	integerReq := s.newReadRequest(
+		target,
+		ReadRows,
+		shard.ReadParam{Process: pipeline.ProcessInfo{
+			PrepareParams: pipeline.PrepareParamInfo{Length: 1, IsBin: []bool{false, true}},
+		}},
+		timestamp.Timestamp{},
+	)
+	require.Equal(t, shard.Method_ShardReadV2, integerReq.RPCMethod)
+	s.remote.pool.ReleaseRequest(integerReq)
 }
 
 func TestOldReceiverRejectsVersionedShardReadBeforeHandler(t *testing.T) {

--- a/pkg/shardservice/service_read_test.go
+++ b/pkg/shardservice/service_read_test.go
@@ -97,16 +97,31 @@ func TestNewReadRequestUsesVersionedMethodForPrepareParamMetadata(t *testing.T) 
 	require.Equal(t, shard.Method_ShardReadV2, binaryReq.RPCMethod)
 	s.remote.pool.ReleaseRequest(binaryReq)
 
-	integerReq := s.newReadRequest(
+	numericReq := s.newReadRequest(
 		target,
 		ReadRows,
 		shard.ReadParam{Process: pipeline.ProcessInfo{
-			PrepareParams: pipeline.PrepareParamInfo{Length: 1, IsBin: []bool{false, true}},
+			// FLOAT has only the high kind bit set. It must still select the
+			// versioned method instead of looking only at the first kind section.
+			PrepareParams: pipeline.PrepareParamInfo{Length: 1, IsBin: []bool{false, false, true}},
 		}},
 		timestamp.Timestamp{},
 	)
-	require.Equal(t, shard.Method_ShardReadV2, integerReq.RPCMethod)
-	s.remote.pool.ReleaseRequest(integerReq)
+	require.Equal(t, shard.Method_ShardReadV2, numericReq.RPCMethod)
+	s.remote.pool.ReleaseRequest(numericReq)
+
+	booleanReq := s.newReadRequest(
+		target,
+		ReadRows,
+		shard.ReadParam{Process: pipeline.ProcessInfo{
+			// BOOLEAN uses the third kind bit and must also select the
+			// versioned method.
+			PrepareParams: pipeline.PrepareParamInfo{Length: 1, IsBin: []bool{false, false, false, true}},
+		}},
+		timestamp.Timestamp{},
+	)
+	require.Equal(t, shard.Method_ShardReadV2, booleanReq.RPCMethod)
+	s.remote.pool.ReleaseRequest(booleanReq)
 }
 
 func TestOldReceiverRejectsVersionedShardReadBeforeHandler(t *testing.T) {

--- a/pkg/shardservice/service_remote.go
+++ b/pkg/shardservice/service_remote.go
@@ -202,7 +202,7 @@ func (s *service) newReadRequest(
 ) *pb.Request {
 	req := s.remote.pool.AcquireRequest()
 	req.RPCMethod = pb.Method_ShardRead
-	if hasBinaryPrepareParam(param) {
+	if hasVersionedPrepareParamMetadata(param) {
 		req.RPCMethod = pb.Method_ShardReadV2
 	}
 	req.ShardRead.Shard = shard

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -433,7 +433,7 @@ func (expr *ParamExpressionExecutor) Eval(proc *process.Process, batches []*batc
 	}
 	if err == nil {
 		expr.vec.SetIsBin(proc.GetPrepareParamIsBin(expr.pos))
-		expr.vec.SetIsIntegerParam(proc.GetPrepareParamIsInteger(expr.pos))
+		expr.vec.SetPrepareParamKind(proc.GetPrepareParamKind(expr.pos))
 	}
 	return expr.vec, err
 }
@@ -516,6 +516,13 @@ func (expr *VarExpressionExecutor) Eval(proc *process.Process, batches []*batch.
 			return nil, err
 		}
 	}
+	prepareParamKind := vector.PrepareParamNone
+	if resolveKind := proc.GetResolveVariablePrepareParamKindFunc(); resolveKind != nil {
+		prepareParamKind, err = resolveKind(expr.name, expr.system, expr.global)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if val == nil {
 		if expr.null == nil {
@@ -525,6 +532,7 @@ func (expr *VarExpressionExecutor) Eval(proc *process.Process, batches []*batch.
 		}
 		if err == nil {
 			expr.null.SetIsBin(isBin)
+			expr.null.SetPrepareParamKind(prepareParamKind)
 		}
 		return expr.null, err
 	}
@@ -545,6 +553,7 @@ func (expr *VarExpressionExecutor) Eval(proc *process.Process, batches []*batch.
 	}
 	if err == nil {
 		expr.vec.SetIsBin(isBin)
+		expr.vec.SetPrepareParamKind(prepareParamKind)
 	}
 	return expr.vec, err
 }

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -433,7 +433,7 @@ func (expr *ParamExpressionExecutor) Eval(proc *process.Process, batches []*batc
 	}
 	if err == nil {
 		expr.vec.SetIsBin(proc.GetPrepareParamIsBin(expr.pos))
-		expr.vec.SetIsSignedIntegerParam(proc.GetPrepareParamIsSignedInteger(expr.pos))
+		expr.vec.SetIsIntegerParam(proc.GetPrepareParamIsInteger(expr.pos))
 	}
 	return expr.vec, err
 }

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -433,6 +433,7 @@ func (expr *ParamExpressionExecutor) Eval(proc *process.Process, batches []*batc
 	}
 	if err == nil {
 		expr.vec.SetIsBin(proc.GetPrepareParamIsBin(expr.pos))
+		expr.vec.SetIsSignedIntegerParam(proc.GetPrepareParamIsSignedInteger(expr.pos))
 	}
 	return expr.vec, err
 }

--- a/pkg/sql/colexec/evalExpression_test.go
+++ b/pkg/sql/colexec/evalExpression_test.go
@@ -300,33 +300,64 @@ func TestParamExpressionExecutorPreservesProtocolMetadataPerParameter(t *testing
 	params := vector.NewVec(types.T_text.ToType())
 	require.NoError(t, vector.AppendBytes(params, []byte("AB\x00\x00"), false, proc.Mp()))
 	require.NoError(t, vector.AppendBytes(params, []byte("5"), false, proc.Mp()))
+	require.NoError(t, vector.AppendBytes(params, []byte("5.5"), false, proc.Mp()))
+	require.NoError(t, vector.AppendBytes(params, []byte("5.9"), false, proc.Mp()))
+	require.NoError(t, vector.AppendBytes(params, []byte("true"), false, proc.Mp()))
 	require.NoError(t, vector.AppendBytes(params, []byte("text"), false, proc.Mp()))
-	proc.SetPrepareParamsWithMeta(params, []bool{true, false, false}, []bool{false, true, false})
+	proc.SetPrepareParamsWithMeta(params, []bool{true, false, false, false, false, false}, []vector.PrepareParamKind{
+		vector.PrepareParamNone,
+		vector.PrepareParamInteger,
+		vector.PrepareParamFloat,
+		vector.PrepareParamDecimal,
+		vector.PrepareParamBoolean,
+		vector.PrepareParamNone,
+	})
 	t.Cleanup(func() { params.Free(proc.Mp()) })
 
 	binaryExpr := NewParamExpressionExecutor(proc.Mp(), 0, types.T_text.ToType())
 	integerExpr := NewParamExpressionExecutor(proc.Mp(), 1, types.T_text.ToType())
-	textExpr := NewParamExpressionExecutor(proc.Mp(), 2, types.T_text.ToType())
+	floatExpr := NewParamExpressionExecutor(proc.Mp(), 2, types.T_text.ToType())
+	decimalExpr := NewParamExpressionExecutor(proc.Mp(), 3, types.T_text.ToType())
+	booleanExpr := NewParamExpressionExecutor(proc.Mp(), 4, types.T_text.ToType())
+	textExpr := NewParamExpressionExecutor(proc.Mp(), 5, types.T_text.ToType())
 	t.Cleanup(binaryExpr.Free)
 	t.Cleanup(integerExpr.Free)
+	t.Cleanup(floatExpr.Free)
+	t.Cleanup(decimalExpr.Free)
+	t.Cleanup(booleanExpr.Free)
 	t.Cleanup(textExpr.Free)
 
 	binaryVec, err := binaryExpr.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.True(t, binaryVec.GetIsBin())
-	require.False(t, binaryVec.GetIsIntegerParam())
+	require.Equal(t, vector.PrepareParamNone, binaryVec.GetPrepareParamKind())
 	require.Equal(t, "AB\x00\x00", binaryVec.GetStringAt(0))
 
 	integerVec, err := integerExpr.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.False(t, integerVec.GetIsBin())
-	require.True(t, integerVec.GetIsIntegerParam())
+	require.Equal(t, vector.PrepareParamInteger, integerVec.GetPrepareParamKind())
 	require.Equal(t, "5", integerVec.GetStringAt(0))
+
+	floatVec, err := floatExpr.Eval(proc, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, vector.PrepareParamFloat, floatVec.GetPrepareParamKind())
+	require.Equal(t, "5.5", floatVec.GetStringAt(0))
+
+	decimalVec, err := decimalExpr.Eval(proc, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, vector.PrepareParamDecimal, decimalVec.GetPrepareParamKind())
+	require.Equal(t, "5.9", decimalVec.GetStringAt(0))
+
+	booleanVec, err := booleanExpr.Eval(proc, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, vector.PrepareParamBoolean, booleanVec.GetPrepareParamKind())
+	require.Equal(t, "true", booleanVec.GetStringAt(0))
 
 	textVec, err := textExpr.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.False(t, textVec.GetIsBin())
-	require.False(t, textVec.GetIsIntegerParam())
+	require.Equal(t, vector.PrepareParamNone, textVec.GetPrepareParamKind())
 	require.Equal(t, "text", textVec.GetStringAt(0))
 }
 
@@ -479,15 +510,19 @@ func TestVarExpressionExecutor(t *testing.T) {
 	// require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
-func TestVarExpressionExecutorPreservesBinaryFlagOnReuse(t *testing.T) {
+func TestVarExpressionExecutorPreservesProtocolMetadataOnReuse(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	value := "AB\x00\x00"
 	isBin := true
+	prepareParamKind := vector.PrepareParamNone
 	proc.SetResolveVariableFunc(func(string, bool, bool) (interface{}, error) {
 		return value, nil
 	})
 	proc.SetResolveVariableIsBinFunc(func(string, bool, bool) (bool, error) {
 		return isBin, nil
+	})
+	proc.SetResolveVariablePrepareParamKindFunc(func(string, bool, bool) (vector.PrepareParamKind, error) {
+		return prepareParamKind, nil
 	})
 	expr := &plan.Expr{
 		Expr: &plan.Expr_V{V: &plan.VarRef{Name: "copied_var"}},
@@ -500,18 +535,28 @@ func TestVarExpressionExecutorPreservesBinaryFlagOnReuse(t *testing.T) {
 	vec, err := executor.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.True(t, vec.GetIsBin())
+	require.Equal(t, vector.PrepareParamNone, vec.GetPrepareParamKind())
 	require.Equal(t, "AB\x00\x00", vec.GetStringAt(0))
 
-	value, isBin = "text", false
+	value, isBin, prepareParamKind = "5.0", false, vector.PrepareParamFloat
 	vec, err = executor.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.False(t, vec.GetIsBin())
+	require.Equal(t, vector.PrepareParamFloat, vec.GetPrepareParamKind())
+	require.Equal(t, "5.0", vec.GetStringAt(0))
+
+	value, prepareParamKind = "text", vector.PrepareParamNone
+	vec, err = executor.Eval(proc, nil, nil)
+	require.NoError(t, err)
+	require.False(t, vec.GetIsBin())
+	require.Equal(t, vector.PrepareParamNone, vec.GetPrepareParamKind())
 	require.Equal(t, "text", vec.GetStringAt(0))
 
 	value, isBin = "CD\x00\x00", true
 	vec, err = executor.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.True(t, vec.GetIsBin())
+	require.Equal(t, vector.PrepareParamNone, vec.GetPrepareParamKind())
 	require.Equal(t, "CD\x00\x00", vec.GetStringAt(0))
 }
 

--- a/pkg/sql/colexec/evalExpression_test.go
+++ b/pkg/sql/colexec/evalExpression_test.go
@@ -295,27 +295,38 @@ func TestIffConstantFoldingSkipsUnselectedBranch(t *testing.T) {
 
 }
 
-func TestParamExpressionExecutorPreservesBinaryFlagPerParameter(t *testing.T) {
+func TestParamExpressionExecutorPreservesProtocolMetadataPerParameter(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	params := vector.NewVec(types.T_text.ToType())
 	require.NoError(t, vector.AppendBytes(params, []byte("AB\x00\x00"), false, proc.Mp()))
+	require.NoError(t, vector.AppendBytes(params, []byte("5"), false, proc.Mp()))
 	require.NoError(t, vector.AppendBytes(params, []byte("text"), false, proc.Mp()))
-	proc.SetPrepareParamsWithIsBin(params, []bool{true, false})
+	proc.SetPrepareParamsWithMeta(params, []bool{true, false, false}, []bool{false, true, false})
 	t.Cleanup(func() { params.Free(proc.Mp()) })
 
 	binaryExpr := NewParamExpressionExecutor(proc.Mp(), 0, types.T_text.ToType())
-	textExpr := NewParamExpressionExecutor(proc.Mp(), 1, types.T_text.ToType())
+	integerExpr := NewParamExpressionExecutor(proc.Mp(), 1, types.T_text.ToType())
+	textExpr := NewParamExpressionExecutor(proc.Mp(), 2, types.T_text.ToType())
 	t.Cleanup(binaryExpr.Free)
+	t.Cleanup(integerExpr.Free)
 	t.Cleanup(textExpr.Free)
 
 	binaryVec, err := binaryExpr.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.True(t, binaryVec.GetIsBin())
+	require.False(t, binaryVec.GetIsIntegerParam())
 	require.Equal(t, "AB\x00\x00", binaryVec.GetStringAt(0))
+
+	integerVec, err := integerExpr.Eval(proc, nil, nil)
+	require.NoError(t, err)
+	require.False(t, integerVec.GetIsBin())
+	require.True(t, integerVec.GetIsIntegerParam())
+	require.Equal(t, "5", integerVec.GetStringAt(0))
 
 	textVec, err := textExpr.Eval(proc, nil, nil)
 	require.NoError(t, err)
 	require.False(t, textVec.GetIsBin())
+	require.False(t, textVec.GetIsIntegerParam())
 	require.Equal(t, "text", textVec.GetStringAt(0))
 }
 

--- a/pkg/sql/compile/remoterunServer_test.go
+++ b/pkg/sql/compile/remoterunServer_test.go
@@ -247,7 +247,7 @@ func TestNewCompile_CreatesCorrectStructure(t *testing.T) {
 				Data:   append([]byte(nil), params.GetData()...),
 				Area:   append([]byte(nil), params.GetArea()...),
 				Nulls:  []bool{false, false},
-				IsBin:  []bool{true, false, false, true},
+				IsBin:  []bool{true, false, false, false, false, true, false, false},
 			},
 		},
 		messageAcquirer: func() morpc.Message {
@@ -265,8 +265,8 @@ func TestNewCompile_CreatesCorrectStructure(t *testing.T) {
 	require.Equal(t, "text", compile.proc.GetPrepareParams().GetStringAt(1))
 	require.True(t, compile.proc.GetPrepareParamIsBin(0))
 	require.False(t, compile.proc.GetPrepareParamIsBin(1))
-	require.False(t, compile.proc.GetPrepareParamIsInteger(0))
-	require.True(t, compile.proc.GetPrepareParamIsInteger(1))
+	require.Equal(t, vector.PrepareParamNone, compile.proc.GetPrepareParamKind(0))
+	require.Equal(t, vector.PrepareParamFloat, compile.proc.GetPrepareParamKind(1))
 	require.Equal(t, int64(42), compile.proc.GetAffectedRows())
 	require.True(t, compile.proc.GetStmtProfile().GetStatementIgnore())
 	require.NotNil(t, compile.fill, "fill callback should be set")

--- a/pkg/sql/compile/remoterunServer_test.go
+++ b/pkg/sql/compile/remoterunServer_test.go
@@ -247,7 +247,7 @@ func TestNewCompile_CreatesCorrectStructure(t *testing.T) {
 				Data:   append([]byte(nil), params.GetData()...),
 				Area:   append([]byte(nil), params.GetArea()...),
 				Nulls:  []bool{false, false},
-				IsBin:  []bool{true, false},
+				IsBin:  []bool{true, false, false, true},
 			},
 		},
 		messageAcquirer: func() morpc.Message {
@@ -265,6 +265,8 @@ func TestNewCompile_CreatesCorrectStructure(t *testing.T) {
 	require.Equal(t, "text", compile.proc.GetPrepareParams().GetStringAt(1))
 	require.True(t, compile.proc.GetPrepareParamIsBin(0))
 	require.False(t, compile.proc.GetPrepareParamIsBin(1))
+	require.False(t, compile.proc.GetPrepareParamIsInteger(0))
+	require.True(t, compile.proc.GetPrepareParamIsInteger(1))
 	require.Equal(t, int64(42), compile.proc.GetAffectedRows())
 	require.True(t, compile.proc.GetStmtProfile().GetStatementIgnore())
 	require.NotNil(t, compile.fill, "fill callback should be set")

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -3150,6 +3150,18 @@ func numericToBitWithIgnore[T constraints.Integer | constraints.Float](
 		} else {
 			floatValue := float64(v)
 			if floatValue < 0 {
+				// BIT(64) values are commonly transported through signed integer
+				// APIs (for example, JDBC setLong). Preserve the integer's bit
+				// pattern so values with the high bit set are not rejected.
+				if bitSize == 64 {
+					switch any(v).(type) {
+					case int, int8, int16, int32, int64:
+						if err := to.Append(uint64(v), false); err != nil {
+							return err
+						}
+						continue
+					}
+				}
 				if !statementIgnore(proc) {
 					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("int%d", bitSize), "value %v", v)
 				}

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -7565,20 +7565,25 @@ func strToBit(
 				return err
 			}
 		} else {
-			// Prepared parameters are transported internally in a text vector.
-			// Only preserve the two's-complement payload when protocol metadata
-			// proves that the value originated from a signed integer parameter.
-			// An SQL string literal containing the same characters remains a string.
-			if from.GetSourceVector().GetIsSignedIntegerParam() && len(v) > 1 && v[0] == '-' {
-				if signed, err := strconv.ParseInt(string(v), 10, 64); err == nil {
-					if bitSize != 64 {
-						return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
-					}
-					if err = to.Append(uint64(signed), false); err != nil {
-						return err
-					}
-					continue
+			// Prepared integer parameters are transported internally in a text
+			// vector. Protocol provenance selects numeric conversion for both signs;
+			// SQL string literals containing the same characters retain byte-string
+			// semantics.
+			if from.GetSourceVector().GetIsSignedIntegerParam() {
+				signed, err := strconv.ParseInt(string(v), 10, 64)
+				if err != nil {
+					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
 				}
+				if signed < 0 && bitSize != 64 {
+					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+				}
+				if signed >= 0 && uint64(signed) > maxBitValue(bitSize) {
+					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+				}
+				if err = to.Append(uint64(signed), false); err != nil {
+					return err
+				}
+				continue
 			}
 			if len(v) > 8 {
 				return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -7565,12 +7565,27 @@ func strToBit(
 				return err
 			}
 		} else {
-			// Prepared integer parameters are transported internally in canonical
-			// decimal text. Protocol provenance selects numeric conversion; SQL
-			// strings containing the same characters retain byte-string semantics.
-			if from.GetSourceVector().GetIsIntegerParam() {
+			// Prepared parameters are transported internally in canonical text.
+			// Provenance restores their source conversion category;
+			// SQL strings containing the same characters retain byte-string semantics.
+			kind := from.GetSourceVector().GetPrepareParamKind()
+			if kind != vector.PrepareParamNone {
 				input := string(v)
-				value, inRange, err := preparedIntegerToBit(input, bitSize)
+				var value uint64
+				var inRange bool
+				var err error
+				switch kind {
+				case vector.PrepareParamInteger:
+					value, inRange, err = preparedIntegerToBit(input, bitSize)
+				case vector.PrepareParamFloat:
+					value, inRange, err = preparedFloatToBit(input, bitSize)
+				case vector.PrepareParamDecimal:
+					value, inRange, err = preparedDecimalToBit(input, bitSize)
+				case vector.PrepareParamBoolean:
+					value, inRange, err = preparedBooleanToBit(input)
+				default:
+					return moerr.NewInternalErrorf(ctx, "unsupported prepared parameter kind %d", kind)
+				}
 				if err != nil || (!inRange && !statementIgnore(proc)) {
 					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", input)
 				}
@@ -7623,6 +7638,74 @@ func preparedIntegerToBit(input string, bitSize int) (value uint64, inRange bool
 		return maxValue, false, nil
 	}
 	return unsigned, true, nil
+}
+
+func preparedFloatToBit(input string, bitSize int) (value uint64, inRange bool, err error) {
+	floating, parseErr := strconv.ParseFloat(input, 64)
+	if parseErr != nil {
+		return 0, false, parseErr
+	}
+	if floating < 0 {
+		return 0, false, nil
+	}
+	rounded := math.Round(floating)
+	if math.IsNaN(rounded) || floatExceedsBitRange(rounded, bitSize) {
+		return maxBitValue(bitSize), false, nil
+	}
+	return uint64(rounded), true, nil
+}
+
+func preparedDecimalToBit(input string, bitSize int) (value uint64, inRange bool, err error) {
+	if input == "" {
+		return 0, false, &strconv.NumError{Func: "preparedDecimalToBit", Num: input, Err: strconv.ErrSyntax}
+	}
+	negative := input[0] == '-'
+	digits := input
+	if input[0] == '-' || input[0] == '+' {
+		digits = input[1:]
+	}
+	integerPart, fractionPart, foundDot := strings.Cut(digits, ".")
+	if integerPart == "" || (foundDot && fractionPart == "") || strings.Contains(fractionPart, ".") {
+		return 0, false, &strconv.NumError{Func: "preparedDecimalToBit", Num: input, Err: strconv.ErrSyntax}
+	}
+	nonZero := false
+	for _, part := range []string{integerPart, fractionPart} {
+		for i := 0; i < len(part); i++ {
+			if part[i] < '0' || part[i] > '9' {
+				return 0, false, &strconv.NumError{Func: "preparedDecimalToBit", Num: input, Err: strconv.ErrSyntax}
+			}
+			nonZero = nonZero || part[i] != '0'
+		}
+	}
+	// Decimal values are normalized before the direct typed cast, so a signed
+	// zero is zero while every other negative decimal remains out of range.
+	if negative && nonZero {
+		return 0, false, nil
+	}
+
+	unsigned, parseErr := strconv.ParseUint(integerPart, 10, 64)
+	if parseErr != nil {
+		if numErr, ok := parseErr.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
+			return maxBitValue(bitSize), false, nil
+		}
+		return 0, false, parseErr
+	}
+	maxValue := maxBitValue(bitSize)
+	if unsigned > maxValue {
+		return maxValue, false, nil
+	}
+	return unsigned, true, nil
+}
+
+func preparedBooleanToBit(input string) (value uint64, inRange bool, err error) {
+	boolean, parseErr := strconv.ParseBool(input)
+	if parseErr != nil {
+		return 0, false, parseErr
+	}
+	if boolean {
+		return 1, true, nil
+	}
+	return 0, true, nil
 }
 
 func strToArray[T types.ArrayElement](

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -2593,7 +2593,7 @@ func strTypeToOthers(proc *process.Process,
 	switch toType.Oid {
 	case types.T_bit:
 		rs := vector.MustFunctionResult[uint64](result)
-		return strToBit(ctx, source, rs, int(toType.Width), length, selectList)
+		return strToBit(ctx, proc, source, rs, int(toType.Width), length, selectList)
 	case types.T_int8:
 		rs := vector.MustFunctionResult[int8](result)
 		return strToSigned(ctx, source, rs, 8, length, selectList, explicit)
@@ -7555,7 +7555,7 @@ func strToStr(
 }
 
 func strToBit(
-	ctx context.Context,
+	ctx context.Context, proc *process.Process,
 	from vector.FunctionParameterWrapper[types.Varlena],
 	to *vector.FunctionResult[uint64], bitSize int, length int, selectList *FunctionSelectList) error {
 	for i := 0; i < length; i++ {
@@ -7575,10 +7575,22 @@ func strToBit(
 					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
 				}
 				if signed < 0 && bitSize != 64 {
-					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+					if !statementIgnore(proc) {
+						return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+					}
+					if err = to.Append(0, false); err != nil {
+						return err
+					}
+					continue
 				}
 				if signed >= 0 && uint64(signed) > maxBitValue(bitSize) {
-					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+					if !statementIgnore(proc) {
+						return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+					}
+					if err = to.Append(maxBitValue(bitSize), false); err != nil {
+						return err
+					}
+					continue
 				}
 				if err = to.Append(uint64(signed), false); err != nil {
 					return err

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -7553,6 +7553,21 @@ func strToBit(
 				return err
 			}
 		} else {
+			// Prepared parameters are transported internally in a text vector.
+			// Only preserve the two's-complement payload when protocol metadata
+			// proves that the value originated from a signed integer parameter.
+			// An SQL string literal containing the same characters remains a string.
+			if from.GetSourceVector().GetIsSignedIntegerParam() && len(v) > 1 && v[0] == '-' {
+				if signed, err := strconv.ParseInt(string(v), 10, 64); err == nil {
+					if bitSize != 64 {
+						return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+					}
+					if err = to.Append(uint64(signed), false); err != nil {
+						return err
+					}
+					continue
+				}
+			}
 			if len(v) > 8 {
 				return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
 			}

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -7565,34 +7565,16 @@ func strToBit(
 				return err
 			}
 		} else {
-			// Prepared integer parameters are transported internally in a text
-			// vector. Protocol provenance selects numeric conversion for both signs;
-			// SQL string literals containing the same characters retain byte-string
-			// semantics.
-			if from.GetSourceVector().GetIsSignedIntegerParam() {
-				signed, err := strconv.ParseInt(string(v), 10, 64)
-				if err != nil {
-					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
+			// Prepared integer parameters are transported internally in canonical
+			// decimal text. Protocol provenance selects numeric conversion; SQL
+			// strings containing the same characters retain byte-string semantics.
+			if from.GetSourceVector().GetIsIntegerParam() {
+				input := string(v)
+				value, inRange, err := preparedIntegerToBit(input, bitSize)
+				if err != nil || (!inRange && !statementIgnore(proc)) {
+					return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", input)
 				}
-				if signed < 0 && bitSize != 64 {
-					if !statementIgnore(proc) {
-						return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
-					}
-					if err = to.Append(0, false); err != nil {
-						return err
-					}
-					continue
-				}
-				if signed >= 0 && uint64(signed) > maxBitValue(bitSize) {
-					if !statementIgnore(proc) {
-						return moerr.NewOutOfRangef(ctx, fmt.Sprintf("bit(%d)", bitSize), "value %s", string(v))
-					}
-					if err = to.Append(maxBitValue(bitSize), false); err != nil {
-						return err
-					}
-					continue
-				}
-				if err = to.Append(uint64(signed), false); err != nil {
+				if err = to.Append(value, false); err != nil {
 					return err
 				}
 				continue
@@ -7615,6 +7597,32 @@ func strToBit(
 		}
 	}
 	return nil
+}
+
+// preparedIntegerToBit converts the canonical decimal representation emitted
+// by COM_STMT_EXECUTE. Negative values can only originate from signed protocol
+// integers; non-negative signed and unsigned values share the same BIT range.
+func preparedIntegerToBit(input string, bitSize int) (value uint64, inRange bool, err error) {
+	if strings.HasPrefix(input, "-") {
+		signed, parseErr := strconv.ParseInt(input, 10, 64)
+		if parseErr != nil {
+			return 0, false, parseErr
+		}
+		if signed < 0 && bitSize != 64 {
+			return 0, false, nil
+		}
+		return uint64(signed), true, nil
+	}
+
+	unsigned, parseErr := strconv.ParseUint(input, 10, 64)
+	if parseErr != nil {
+		return 0, false, parseErr
+	}
+	maxValue := maxBitValue(bitSize)
+	if unsigned > maxValue {
+		return maxValue, false, nil
+	}
+	return unsigned, true, nil
 }
 
 func strToArray[T types.ArrayElement](

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -169,13 +169,13 @@ func TestPreparedIntegerTextToBit(t *testing.T) {
 		[]FunctionTestInput{
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{
 				"-9223372036854775808", "-6109877384019645241", "-1",
-				"5", "9223372036854775807", "18446744073709551615",
+				"5", "2024", "9223372036854775807", "18446744073709551615",
 			}, nil),
 			NewFunctionTestInput(bit64, []uint64{}, nil),
 		},
 		NewFunctionTestResult(bit64, false, []uint64{
 			uint64(1) << 63, 12336866689689906375, math.MaxUint64,
-			5, math.MaxInt64, math.MaxUint64,
+			5, 2024, math.MaxInt64, math.MaxUint64,
 		}, nil),
 		NewCast)
 	tcc.parameters[0].SetIsIntegerParam(true)

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -136,6 +136,66 @@ func TestCastEnumToNumericTypes(t *testing.T) {
 	}
 }
 
+func TestSignedIntegerToBit64PreservesBitPattern(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+
+	for _, tc := range []struct {
+		name  string
+		input FunctionTestInput
+	}{
+		{"int8", NewFunctionTestInput(types.T_int8.ToType(), []int8{-1}, nil)},
+		{"int16", NewFunctionTestInput(types.T_int16.ToType(), []int16{-1}, nil)},
+		{"int32", NewFunctionTestInput(types.T_int32.ToType(), []int32{-1}, nil)},
+		{"int64", NewFunctionTestInput(types.T_int64.ToType(), []int64{-1}, nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tcc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{tc.input, NewFunctionTestInput(bit64, []uint64{}, nil)},
+				NewFunctionTestResult(bit64, false, []uint64{math.MaxUint64}, nil), NewCast)
+			succeed, info := tcc.Run()
+			require.True(t, succeed, info)
+		})
+	}
+}
+
+func TestPreparedSignedIntegerTextToBit(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+	bit63 := types.New(types.T_bit, 63, 0)
+
+	tcc := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-6109877384019645241", "-1"}, nil),
+			NewFunctionTestInput(bit64, []uint64{}, nil),
+		},
+		NewFunctionTestResult(bit64, false, []uint64{12336866689689906375, math.MaxUint64}, nil),
+		NewCast)
+	tcc.parameters[0].SetIsSignedIntegerParam(true)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, info)
+
+	stringCase := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-6109877384019645241"}, nil),
+			NewFunctionTestInput(bit64, []uint64{}, nil),
+		},
+		NewFunctionTestResult(bit64, true, []uint64{}, nil), NewCast)
+	succeed, info = stringCase.Run()
+	require.True(t, succeed, info)
+
+	tcc = NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-1"}, nil),
+			NewFunctionTestInput(bit63, []uint64{}, nil),
+		},
+		NewFunctionTestResult(bit63, true, []uint64{}, nil),
+		NewCast)
+	tcc.parameters[0].SetIsSignedIntegerParam(true)
+	succeed, info = tcc.Run()
+	require.True(t, succeed, info)
+}
+
 func TestInsertIgnoreCastsSpecialValues(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	proc.SetStmtProfile(&process.StmtProfile{})

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -159,7 +159,7 @@ func TestSignedIntegerToBit64PreservesBitPattern(t *testing.T) {
 	}
 }
 
-func TestPreparedSignedIntegerTextToBit(t *testing.T) {
+func TestPreparedIntegerTextToBit(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	bit64 := types.New(types.T_bit, 64, 0)
 	bit63 := types.New(types.T_bit, 63, 0)
@@ -167,12 +167,18 @@ func TestPreparedSignedIntegerTextToBit(t *testing.T) {
 
 	tcc := NewFunctionTestCase(proc,
 		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-6109877384019645241", "-1", "5"}, nil),
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{
+				"-9223372036854775808", "-6109877384019645241", "-1",
+				"5", "9223372036854775807", "18446744073709551615",
+			}, nil),
 			NewFunctionTestInput(bit64, []uint64{}, nil),
 		},
-		NewFunctionTestResult(bit64, false, []uint64{12336866689689906375, math.MaxUint64, 5}, nil),
+		NewFunctionTestResult(bit64, false, []uint64{
+			uint64(1) << 63, 12336866689689906375, math.MaxUint64,
+			5, math.MaxInt64, math.MaxUint64,
+		}, nil),
 		NewCast)
-	tcc.parameters[0].SetIsSignedIntegerParam(true)
+	tcc.parameters[0].SetIsIntegerParam(true)
 	succeed, info := tcc.Run()
 	require.True(t, succeed, info)
 
@@ -201,7 +207,7 @@ func TestPreparedSignedIntegerTextToBit(t *testing.T) {
 		},
 		NewFunctionTestResult(bit63, true, []uint64{}, nil),
 		NewCast)
-	tcc.parameters[0].SetIsSignedIntegerParam(true)
+	tcc.parameters[0].SetIsIntegerParam(true)
 	succeed, info = tcc.Run()
 	require.True(t, succeed, info)
 
@@ -212,7 +218,7 @@ func TestPreparedSignedIntegerTextToBit(t *testing.T) {
 		},
 		NewFunctionTestResult(bit3, true, []uint64{}, nil),
 		NewCast)
-	tcc.parameters[0].SetIsSignedIntegerParam(true)
+	tcc.parameters[0].SetIsIntegerParam(true)
 	succeed, info = tcc.Run()
 	require.True(t, succeed, info)
 }
@@ -250,21 +256,22 @@ func TestInsertIgnoreCastsSpecialValues(t *testing.T) {
 	runBitCast("decimal128 saturates", NewFunctionTestInput(types.New(types.T_decimal128, 20, 0), []types.Decimal128{{B0_63: 31}}, nil), bit4, 15)
 	runBitCast("decimal256 saturates", NewFunctionTestInput(types.New(types.T_decimal256, 40, 0), []types.Decimal256{{B0_63: 31}}, nil), bit4, 15)
 
-	runSignedPreparedBitCast := func(name, value string, want uint64) {
+	runPreparedIntegerBitCast := func(name, value string, want uint64) {
 		t.Helper()
 		t.Run(name, func(t *testing.T) {
 			input := NewFunctionTestInput(types.T_varchar.ToType(), []string{value}, nil)
 			tcc := NewFunctionTestCase(proc,
 				[]FunctionTestInput{input, NewFunctionTestInput(bit3, []uint64{}, nil)},
 				NewFunctionTestResult(bit3, false, []uint64{want}, nil), NewCast)
-			tcc.parameters[0].SetIsSignedIntegerParam(true)
+			tcc.parameters[0].SetIsIntegerParam(true)
 			succeed, info := tcc.Run()
 			require.True(t, succeed, info)
 		})
 	}
 
-	runSignedPreparedBitCast("signed prepared positive saturates", "8", 7)
-	runSignedPreparedBitCast("signed prepared negative becomes zero", "-1", 0)
+	runPreparedIntegerBitCast("prepared positive saturates", "8", 7)
+	runPreparedIntegerBitCast("prepared negative becomes zero", "-1", 0)
+	runPreparedIntegerBitCast("prepared unsigned maximum saturates", "18446744073709551615", 7)
 
 	runYearCast := func(name string, input FunctionTestInput) {
 		t.Helper()

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -163,13 +163,14 @@ func TestPreparedSignedIntegerTextToBit(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	bit64 := types.New(types.T_bit, 64, 0)
 	bit63 := types.New(types.T_bit, 63, 0)
+	bit3 := types.New(types.T_bit, 3, 0)
 
 	tcc := NewFunctionTestCase(proc,
 		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-6109877384019645241", "-1"}, nil),
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-6109877384019645241", "-1", "5"}, nil),
 			NewFunctionTestInput(bit64, []uint64{}, nil),
 		},
-		NewFunctionTestResult(bit64, false, []uint64{12336866689689906375, math.MaxUint64}, nil),
+		NewFunctionTestResult(bit64, false, []uint64{12336866689689906375, math.MaxUint64, 5}, nil),
 		NewCast)
 	tcc.parameters[0].SetIsSignedIntegerParam(true)
 	succeed, info := tcc.Run()
@@ -184,12 +185,32 @@ func TestPreparedSignedIntegerTextToBit(t *testing.T) {
 	succeed, info = stringCase.Run()
 	require.True(t, succeed, info)
 
+	stringCase = NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"5"}, nil),
+			NewFunctionTestInput(bit64, []uint64{}, nil),
+		},
+		NewFunctionTestResult(bit64, false, []uint64{53}, nil), NewCast)
+	succeed, info = stringCase.Run()
+	require.True(t, succeed, info)
+
 	tcc = NewFunctionTestCase(proc,
 		[]FunctionTestInput{
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-1"}, nil),
 			NewFunctionTestInput(bit63, []uint64{}, nil),
 		},
 		NewFunctionTestResult(bit63, true, []uint64{}, nil),
+		NewCast)
+	tcc.parameters[0].SetIsSignedIntegerParam(true)
+	succeed, info = tcc.Run()
+	require.True(t, succeed, info)
+
+	tcc = NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"8"}, nil),
+			NewFunctionTestInput(bit3, []uint64{}, nil),
+		},
+		NewFunctionTestResult(bit3, true, []uint64{}, nil),
 		NewCast)
 	tcc.parameters[0].SetIsSignedIntegerParam(true)
 	succeed, info = tcc.Run()

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -159,68 +159,57 @@ func TestSignedIntegerToBit64PreservesBitPattern(t *testing.T) {
 	}
 }
 
-func TestPreparedIntegerTextToBit(t *testing.T) {
+func TestPreparedTypedTextToBit(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	bit64 := types.New(types.T_bit, 64, 0)
 	bit63 := types.New(types.T_bit, 63, 0)
 	bit3 := types.New(types.T_bit, 3, 0)
 
-	tcc := NewFunctionTestCase(proc,
-		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{
-				"-9223372036854775808", "-6109877384019645241", "-1",
-				"5", "2024", "9223372036854775807", "18446744073709551615",
-			}, nil),
-			NewFunctionTestInput(bit64, []uint64{}, nil),
-		},
-		NewFunctionTestResult(bit64, false, []uint64{
-			uint64(1) << 63, 12336866689689906375, math.MaxUint64,
-			5, 2024, math.MaxInt64, math.MaxUint64,
-		}, nil),
-		NewCast)
-	tcc.parameters[0].SetIsIntegerParam(true)
-	succeed, info := tcc.Run()
-	require.True(t, succeed, info)
+	run := func(
+		name string,
+		kind vector.PrepareParamKind,
+		input []string,
+		bitType types.Type,
+		want []uint64,
+		wantError bool,
+	) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			tcc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), input, nil),
+					NewFunctionTestInput(bitType, []uint64{}, nil),
+				},
+				NewFunctionTestResult(bitType, wantError, want, nil), NewCast)
+			tcc.parameters[0].SetPrepareParamKind(kind)
+			succeed, info := tcc.Run()
+			require.True(t, succeed, info)
+		})
+	}
 
-	stringCase := NewFunctionTestCase(proc,
-		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-6109877384019645241"}, nil),
-			NewFunctionTestInput(bit64, []uint64{}, nil),
-		},
-		NewFunctionTestResult(bit64, true, []uint64{}, nil), NewCast)
-	succeed, info = stringCase.Run()
-	require.True(t, succeed, info)
-
-	stringCase = NewFunctionTestCase(proc,
-		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{"5"}, nil),
-			NewFunctionTestInput(bit64, []uint64{}, nil),
-		},
-		NewFunctionTestResult(bit64, false, []uint64{53}, nil), NewCast)
-	succeed, info = stringCase.Run()
-	require.True(t, succeed, info)
-
-	tcc = NewFunctionTestCase(proc,
-		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{"-1"}, nil),
-			NewFunctionTestInput(bit63, []uint64{}, nil),
-		},
-		NewFunctionTestResult(bit63, true, []uint64{}, nil),
-		NewCast)
-	tcc.parameters[0].SetIsIntegerParam(true)
-	succeed, info = tcc.Run()
-	require.True(t, succeed, info)
-
-	tcc = NewFunctionTestCase(proc,
-		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{"8"}, nil),
-			NewFunctionTestInput(bit3, []uint64{}, nil),
-		},
-		NewFunctionTestResult(bit3, true, []uint64{}, nil),
-		NewCast)
-	tcc.parameters[0].SetIsIntegerParam(true)
-	succeed, info = tcc.Run()
-	require.True(t, succeed, info)
+	run("integer bit64", vector.PrepareParamInteger, []string{
+		"-9223372036854775808", "-6109877384019645241", "-1",
+		"5", "2024", "9223372036854775807", "18446744073709551615",
+	}, bit64, []uint64{
+		uint64(1) << 63, 12336866689689906375, math.MaxUint64,
+		5, 2024, math.MaxInt64, math.MaxUint64,
+	}, false)
+	run("float rounds", vector.PrepareParamFloat, []string{"5", "5.6"}, bit64, []uint64{5, 6}, false)
+	run("decimal truncates", vector.PrepareParamDecimal,
+		[]string{"5.9", "18446744073709551615.9"}, bit64,
+		[]uint64{5, math.MaxUint64}, false)
+	run("decimal signed zero", vector.PrepareParamDecimal,
+		[]string{"-0.0", "+0.0"}, bit64, []uint64{0, 0}, false)
+	run("boolean", vector.PrepareParamBoolean,
+		[]string{"true", "false"}, bit64, []uint64{1, 0}, false)
+	run("string bytes", vector.PrepareParamNone, []string{"5"}, bit64, []uint64{53}, false)
+	run("negative string rejected", vector.PrepareParamNone,
+		[]string{"-6109877384019645241"}, bit64, nil, true)
+	run("narrow integer rejected", vector.PrepareParamInteger, []string{"-1"}, bit63, nil, true)
+	run("integer width checked", vector.PrepareParamInteger, []string{"8"}, bit3, nil, true)
+	run("negative float rejected", vector.PrepareParamFloat, []string{"-1"}, bit64, nil, true)
+	run("negative decimal rejected", vector.PrepareParamDecimal, []string{"-1.5"}, bit64, nil, true)
+	run("malformed decimal rejected", vector.PrepareParamDecimal, []string{"5.9junk"}, bit64, nil, true)
 }
 
 func TestInsertIgnoreCastsSpecialValues(t *testing.T) {
@@ -256,22 +245,30 @@ func TestInsertIgnoreCastsSpecialValues(t *testing.T) {
 	runBitCast("decimal128 saturates", NewFunctionTestInput(types.New(types.T_decimal128, 20, 0), []types.Decimal128{{B0_63: 31}}, nil), bit4, 15)
 	runBitCast("decimal256 saturates", NewFunctionTestInput(types.New(types.T_decimal256, 40, 0), []types.Decimal256{{B0_63: 31}}, nil), bit4, 15)
 
-	runPreparedIntegerBitCast := func(name, value string, want uint64) {
+	runPreparedNumericBitCast := func(
+		name string,
+		kind vector.PrepareParamKind,
+		value string,
+		want uint64,
+	) {
 		t.Helper()
 		t.Run(name, func(t *testing.T) {
 			input := NewFunctionTestInput(types.T_varchar.ToType(), []string{value}, nil)
 			tcc := NewFunctionTestCase(proc,
 				[]FunctionTestInput{input, NewFunctionTestInput(bit3, []uint64{}, nil)},
 				NewFunctionTestResult(bit3, false, []uint64{want}, nil), NewCast)
-			tcc.parameters[0].SetIsIntegerParam(true)
+			tcc.parameters[0].SetPrepareParamKind(kind)
 			succeed, info := tcc.Run()
 			require.True(t, succeed, info)
 		})
 	}
 
-	runPreparedIntegerBitCast("prepared positive saturates", "8", 7)
-	runPreparedIntegerBitCast("prepared negative becomes zero", "-1", 0)
-	runPreparedIntegerBitCast("prepared unsigned maximum saturates", "18446744073709551615", 7)
+	runPreparedNumericBitCast("prepared integer positive saturates", vector.PrepareParamInteger, "8", 7)
+	runPreparedNumericBitCast("prepared integer negative becomes zero", vector.PrepareParamInteger, "-1", 0)
+	runPreparedNumericBitCast("prepared unsigned maximum saturates", vector.PrepareParamInteger, "18446744073709551615", 7)
+	runPreparedNumericBitCast("prepared float rounds before saturation", vector.PrepareParamFloat, "7.6", 7)
+	runPreparedNumericBitCast("prepared float negative becomes zero", vector.PrepareParamFloat, "-1", 0)
+	runPreparedNumericBitCast("prepared decimal truncates before saturation", vector.PrepareParamDecimal, "8.9", 7)
 
 	runYearCast := func(name string, input FunctionTestInput) {
 		t.Helper()

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -221,6 +221,7 @@ func TestInsertIgnoreCastsSpecialValues(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	proc.SetStmtProfile(&process.StmtProfile{})
 	proc.GetStmtProfile().SetStatementRuntimeProfile("Insert", "DML", true)
+	bit3 := types.New(types.T_bit, 3, 0)
 	bit4 := types.New(types.T_bit, 4, 0)
 	bit64 := types.New(types.T_bit, 64, 0)
 
@@ -248,6 +249,22 @@ func TestInsertIgnoreCastsSpecialValues(t *testing.T) {
 	runBitCast("decimal64 saturates", NewFunctionTestInput(types.New(types.T_decimal64, 10, 0), []types.Decimal64{31}, nil), bit4, 15)
 	runBitCast("decimal128 saturates", NewFunctionTestInput(types.New(types.T_decimal128, 20, 0), []types.Decimal128{{B0_63: 31}}, nil), bit4, 15)
 	runBitCast("decimal256 saturates", NewFunctionTestInput(types.New(types.T_decimal256, 40, 0), []types.Decimal256{{B0_63: 31}}, nil), bit4, 15)
+
+	runSignedPreparedBitCast := func(name, value string, want uint64) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			input := NewFunctionTestInput(types.T_varchar.ToType(), []string{value}, nil)
+			tcc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{input, NewFunctionTestInput(bit3, []uint64{}, nil)},
+				NewFunctionTestResult(bit3, false, []uint64{want}, nil), NewCast)
+			tcc.parameters[0].SetIsSignedIntegerParam(true)
+			succeed, info := tcc.Run()
+			require.True(t, succeed, info)
+		})
+	}
+
+	runSignedPreparedBitCast("signed prepared positive saturates", "8", 7)
+	runSignedPreparedBitCast("signed prepared negative becomes zero", "-1", 0)
 
 	runYearCast := func(name string, input FunctionTestInput) {
 		t.Helper()

--- a/pkg/tests/issues/issue_26725_test.go
+++ b/pkg/tests/issues/issue_26725_test.go
@@ -98,5 +98,29 @@ func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
 		defer narrowStmt.Close()
 		_, err = narrowStmt.ExecContext(ctx, int64(1), int64(-1))
 		require.ErrorContains(t, err, "data out of range")
+
+		execSQLRequire(t, ctx, db,
+			"create table "+dbName+".t3(id bigint primary key, b bit(3))")
+		ignoreStmt, err := db.PrepareContext(ctx,
+			"insert ignore into "+dbName+".t3(id, b) values (?, ?), (?, ?)")
+		require.NoError(t, err)
+		defer ignoreStmt.Close()
+		_, err = ignoreStmt.ExecContext(ctx,
+			int64(1), int64(8),
+			int64(2), int64(-1))
+		require.NoError(t, err)
+
+		ignoreRows, err := db.QueryContext(ctx,
+			"select cast(b as unsigned) from "+dbName+".t3 order by id")
+		require.NoError(t, err)
+		defer ignoreRows.Close()
+		for _, expected := range []string{"7", "0"} {
+			require.True(t, ignoreRows.Next())
+			var actual string
+			require.NoError(t, ignoreRows.Scan(&actual))
+			require.Equal(t, expected, actual)
+		}
+		require.False(t, ignoreRows.Next())
+		require.NoError(t, ignoreRows.Err())
 	})
 }

--- a/pkg/tests/issues/issue_26725_test.go
+++ b/pkg/tests/issues/issue_26725_test.go
@@ -73,17 +73,17 @@ func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
 			require.NoError(t, rows.Scan(&actual))
 			require.Equal(t, expected, actual)
 		}
-	require.False(t, rows.Next())
-	require.NoError(t, rows.Err())
+		require.False(t, rows.Next())
+		require.NoError(t, rows.Err())
 
-	stringStmt, err := db.PrepareContext(ctx,
-		"insert into "+dbName+".t64(id, b) values (?, ?)")
-	require.NoError(t, err)
-	_, err = stringStmt.ExecContext(ctx, int64(3), "-6109877384019645241")
-	require.ErrorContains(t, err, "data out of range")
-	require.NoError(t, stringStmt.Close())
+		stringStmt, err := db.PrepareContext(ctx,
+			"insert into "+dbName+".t64(id, b) values (?, ?)")
+		require.NoError(t, err)
+		_, err = stringStmt.ExecContext(ctx, int64(3), "-6109877384019645241")
+		require.ErrorContains(t, err, "data out of range")
+		require.NoError(t, stringStmt.Close())
 
-	execSQLRequire(t, ctx, db,
+		execSQLRequire(t, ctx, db,
 			"create table "+dbName+".t63(id bigint primary key, b bit(63))")
 		narrowStmt, err := db.PrepareContext(ctx,
 			"insert into "+dbName+".t63(id, b) values (?, ?)")

--- a/pkg/tests/issues/issue_26725_test.go
+++ b/pkg/tests/issues/issue_26725_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/embed"
+)
+
+// TestIssue26725PreparedBit64SignedLong exercises the same binary prepared
+// statement path used by the legacy flink-cdc sink, which binds BIT(64)
+// payloads with PreparedStatement.setLong().
+func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
+	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		db, err := sql.Open("mysql", fmt.Sprintf(
+			"dump:111@tcp(127.0.0.1:%d)/?interpolateParams=false", port))
+		require.NoError(t, err)
+		defer db.Close()
+
+		const dbName = "issue_26725_prepared_bit64"
+		execSQLMaybe(t, ctx, db, "drop database if exists "+dbName)
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			execSQLMaybe(t, cleanupCtx, db, "drop database if exists "+dbName)
+		}()
+		execSQLRequire(t, ctx, db, "create database "+dbName)
+		execSQLRequire(t, ctx, db,
+			"create table "+dbName+".t64(id bigint primary key, b bit(64))")
+
+		stmt, err := db.PrepareContext(ctx,
+			"insert into "+dbName+".t64(id, b) values (?, ?), (?, ?)")
+		require.NoError(t, err)
+		_, err = stmt.ExecContext(ctx,
+			int64(1), int64(-6109877384019645241),
+			int64(2), int64(-1))
+		require.NoError(t, err)
+		require.NoError(t, stmt.Close())
+
+		rows, err := db.QueryContext(ctx,
+			"select cast(b as unsigned) from "+dbName+".t64 order by id")
+		require.NoError(t, err)
+		defer rows.Close()
+		for _, expected := range []string{"12336866689689906375", "18446744073709551615"} {
+			require.True(t, rows.Next())
+			var actual string
+			require.NoError(t, rows.Scan(&actual))
+			require.Equal(t, expected, actual)
+		}
+	require.False(t, rows.Next())
+	require.NoError(t, rows.Err())
+
+	stringStmt, err := db.PrepareContext(ctx,
+		"insert into "+dbName+".t64(id, b) values (?, ?)")
+	require.NoError(t, err)
+	_, err = stringStmt.ExecContext(ctx, int64(3), "-6109877384019645241")
+	require.ErrorContains(t, err, "data out of range")
+	require.NoError(t, stringStmt.Close())
+
+	execSQLRequire(t, ctx, db,
+			"create table "+dbName+".t63(id bigint primary key, b bit(63))")
+		narrowStmt, err := db.PrepareContext(ctx,
+			"insert into "+dbName+".t63(id, b) values (?, ?)")
+		require.NoError(t, err)
+		_, err = narrowStmt.ExecContext(ctx, int64(1), int64(-1))
+		require.ErrorContains(t, err, "data out of range")
+		require.NoError(t, narrowStmt.Close())
+	})
+}

--- a/pkg/tests/issues/issue_26725_test.go
+++ b/pkg/tests/issues/issue_26725_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/embed"
 )
 
-// TestIssue26725PreparedBit64Integer exercises the same binary prepared
-// statement path used by integer client bindings, including the legacy
+// TestIssue26725PreparedBit64Numeric exercises the same binary prepared
+// statement path used by numeric client bindings, including the legacy
 // flink-cdc sink's PreparedStatement.setLong() BIT(64) payloads.
-func TestIssue26725PreparedBit64Integer(t *testing.T) {
+func TestIssue26725PreparedBit64Numeric(t *testing.T) {
 	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
@@ -82,18 +82,90 @@ func TestIssue26725PreparedBit64Integer(t *testing.T) {
 		require.False(t, rows.Next())
 		require.NoError(t, rows.Err())
 
-		stringStmt, err := db.PrepareContext(ctx,
+		singleStmt, err := db.PrepareContext(ctx,
 			"insert into "+dbName+".t64(id, b) values (?, ?)")
 		require.NoError(t, err)
-		defer stringStmt.Close()
-		_, err = stringStmt.ExecContext(ctx, int64(6), "5")
+		defer singleStmt.Close()
+		_, err = singleStmt.ExecContext(ctx, int64(6), "5")
 		require.NoError(t, err)
 		var stringValue string
 		require.NoError(t, db.QueryRowContext(ctx,
 			"select cast(b as unsigned) from "+dbName+".t64 where id = 6").Scan(&stringValue))
 		require.Equal(t, "53", stringValue)
-		_, err = stringStmt.ExecContext(ctx, int64(7), "-6109877384019645241")
+		_, err = singleStmt.ExecContext(ctx, int64(7), "-6109877384019645241")
 		require.ErrorContains(t, err, "data out of range")
+
+		// Rebinding the same statement as DOUBLE must refresh string provenance
+		// and use numeric rather than ASCII byte semantics.
+		_, err = singleStmt.ExecContext(ctx, int64(8), float64(5))
+		require.NoError(t, err)
+		var floatValue string
+		require.NoError(t, db.QueryRowContext(ctx,
+			"select cast(b as unsigned) from "+dbName+".t64 where id = 8").Scan(&floatValue))
+		require.Equal(t, "5", floatValue)
+
+		// SQL PREPARE/EXECUTE must preserve the numeric type of user variables too.
+		execSQLRequire(t, ctx, db,
+			"prepare issue26725_sql from 'insert into "+dbName+".t64(id, b) values (?, ?)'")
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 9, @issue26725_bit = 5.0")
+		execSQLRequire(t, ctx, db,
+			"execute issue26725_sql using @issue26725_id, @issue26725_bit")
+		var sqlPrepareValue string
+		require.NoError(t, db.QueryRowContext(ctx,
+			"select cast(b as unsigned) from "+dbName+".t64 where id = 9").Scan(&sqlPrepareValue))
+		require.Equal(t, "5", sqlPrepareValue)
+
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 10, @issue26725_bit = 5")
+		execSQLRequire(t, ctx, db,
+			"execute issue26725_sql using @issue26725_id, @issue26725_bit")
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 11, @issue26725_bit = '5'")
+		execSQLRequire(t, ctx, db,
+			"execute issue26725_sql using @issue26725_id, @issue26725_bit")
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 12, @issue26725_bit = true")
+		execSQLRequire(t, ctx, db,
+			"execute issue26725_sql using @issue26725_id, @issue26725_bit")
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 13, @issue26725_bit = b'101'")
+		execSQLRequire(t, ctx, db,
+			"execute issue26725_sql using @issue26725_id, @issue26725_bit")
+		rows, err = db.QueryContext(ctx,
+			"select cast(b as unsigned) from "+dbName+".t64 where id between 10 and 13 order by id")
+		require.NoError(t, err)
+		defer rows.Close()
+		for _, expected := range []string{"5", "53", "1", "5"} {
+			require.True(t, rows.Next())
+			var actual string
+			require.NoError(t, rows.Scan(&actual))
+			require.Equal(t, expected, actual)
+		}
+		require.False(t, rows.Next())
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+		execSQLRequire(t, ctx, db, "deallocate prepare issue26725_sql")
+
+		// Direct user-variable expressions use a different executor from
+		// EXECUTE USING and must preserve the same source conversion semantics.
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 14, @issue26725_bit = 5.0")
+		execSQLRequire(t, ctx, db,
+			"insert into "+dbName+".t64(id, b) values (@issue26725_id, @issue26725_bit)")
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 15, @issue26725_bit = '5'")
+		execSQLRequire(t, ctx, db,
+			"insert into "+dbName+".t64(id, b) values (@issue26725_id, @issue26725_bit)")
+		execSQLRequire(t, ctx, db, "set @issue26725_id = 16, @issue26725_bit = true")
+		execSQLRequire(t, ctx, db,
+			"insert into "+dbName+".t64(id, b) values (@issue26725_id, @issue26725_bit)")
+		rows, err = db.QueryContext(ctx,
+			"select cast(b as unsigned) from "+dbName+".t64 where id between 14 and 16 order by id")
+		require.NoError(t, err)
+		defer rows.Close()
+		for _, expected := range []string{"5", "53", "1"} {
+			require.True(t, rows.Next())
+			var actual string
+			require.NoError(t, rows.Scan(&actual))
+			require.Equal(t, expected, actual)
+		}
+		require.False(t, rows.Next())
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
 
 		execSQLRequire(t, ctx, db,
 			"create table "+dbName+".t63(id bigint primary key, b bit(63))")
@@ -127,5 +199,6 @@ func TestIssue26725PreparedBit64Integer(t *testing.T) {
 		}
 		require.False(t, ignoreRows.Next())
 		require.NoError(t, ignoreRows.Err())
+		require.NoError(t, ignoreRows.Close())
 	})
 }

--- a/pkg/tests/issues/issue_26725_test.go
+++ b/pkg/tests/issues/issue_26725_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -27,10 +28,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/embed"
 )
 
-// TestIssue26725PreparedBit64SignedLong exercises the same binary prepared
-// statement path used by the legacy flink-cdc sink, which binds BIT(64)
-// payloads with PreparedStatement.setLong().
-func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
+// TestIssue26725PreparedBit64Integer exercises the same binary prepared
+// statement path used by integer client bindings, including the legacy
+// flink-cdc sink's PreparedStatement.setLong() BIT(64) payloads.
+func TestIssue26725PreparedBit64Integer(t *testing.T) {
 	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
@@ -55,20 +56,24 @@ func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
 			"create table "+dbName+".t64(id bigint primary key, b bit(64))")
 
 		stmt, err := db.PrepareContext(ctx,
-			"insert into "+dbName+".t64(id, b) values (?, ?), (?, ?), (?, ?)")
+			"insert into "+dbName+".t64(id, b) values (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)")
 		require.NoError(t, err)
 		defer stmt.Close()
 		_, err = stmt.ExecContext(ctx,
 			int64(1), int64(-6109877384019645241),
 			int64(2), int64(-1),
-			int64(3), int64(5))
+			int64(3), int64(5),
+			int64(4), uint64(5),
+			int64(5), uint64(math.MaxUint64))
 		require.NoError(t, err)
 
 		rows, err := db.QueryContext(ctx,
 			"select cast(b as unsigned) from "+dbName+".t64 order by id")
 		require.NoError(t, err)
 		defer rows.Close()
-		for _, expected := range []string{"12336866689689906375", "18446744073709551615", "5"} {
+		for _, expected := range []string{
+			"12336866689689906375", "18446744073709551615", "5", "5", "18446744073709551615",
+		} {
 			require.True(t, rows.Next())
 			var actual string
 			require.NoError(t, rows.Scan(&actual))
@@ -81,13 +86,13 @@ func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
 			"insert into "+dbName+".t64(id, b) values (?, ?)")
 		require.NoError(t, err)
 		defer stringStmt.Close()
-		_, err = stringStmt.ExecContext(ctx, int64(4), "5")
+		_, err = stringStmt.ExecContext(ctx, int64(6), "5")
 		require.NoError(t, err)
 		var stringValue string
 		require.NoError(t, db.QueryRowContext(ctx,
-			"select cast(b as unsigned) from "+dbName+".t64 where id = 4").Scan(&stringValue))
+			"select cast(b as unsigned) from "+dbName+".t64 where id = 6").Scan(&stringValue))
 		require.Equal(t, "53", stringValue)
-		_, err = stringStmt.ExecContext(ctx, int64(5), "-6109877384019645241")
+		_, err = stringStmt.ExecContext(ctx, int64(7), "-6109877384019645241")
 		require.ErrorContains(t, err, "data out of range")
 
 		execSQLRequire(t, ctx, db,

--- a/pkg/tests/issues/issue_26725_test.go
+++ b/pkg/tests/issues/issue_26725_test.go
@@ -55,19 +55,20 @@ func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
 			"create table "+dbName+".t64(id bigint primary key, b bit(64))")
 
 		stmt, err := db.PrepareContext(ctx,
-			"insert into "+dbName+".t64(id, b) values (?, ?), (?, ?)")
+			"insert into "+dbName+".t64(id, b) values (?, ?), (?, ?), (?, ?)")
 		require.NoError(t, err)
+		defer stmt.Close()
 		_, err = stmt.ExecContext(ctx,
 			int64(1), int64(-6109877384019645241),
-			int64(2), int64(-1))
+			int64(2), int64(-1),
+			int64(3), int64(5))
 		require.NoError(t, err)
-		require.NoError(t, stmt.Close())
 
 		rows, err := db.QueryContext(ctx,
 			"select cast(b as unsigned) from "+dbName+".t64 order by id")
 		require.NoError(t, err)
 		defer rows.Close()
-		for _, expected := range []string{"12336866689689906375", "18446744073709551615"} {
+		for _, expected := range []string{"12336866689689906375", "18446744073709551615", "5"} {
 			require.True(t, rows.Next())
 			var actual string
 			require.NoError(t, rows.Scan(&actual))
@@ -79,17 +80,23 @@ func TestIssue26725PreparedBit64SignedLong(t *testing.T) {
 		stringStmt, err := db.PrepareContext(ctx,
 			"insert into "+dbName+".t64(id, b) values (?, ?)")
 		require.NoError(t, err)
-		_, err = stringStmt.ExecContext(ctx, int64(3), "-6109877384019645241")
+		defer stringStmt.Close()
+		_, err = stringStmt.ExecContext(ctx, int64(4), "5")
+		require.NoError(t, err)
+		var stringValue string
+		require.NoError(t, db.QueryRowContext(ctx,
+			"select cast(b as unsigned) from "+dbName+".t64 where id = 4").Scan(&stringValue))
+		require.Equal(t, "53", stringValue)
+		_, err = stringStmt.ExecContext(ctx, int64(5), "-6109877384019645241")
 		require.ErrorContains(t, err, "data out of range")
-		require.NoError(t, stringStmt.Close())
 
 		execSQLRequire(t, ctx, db,
 			"create table "+dbName+".t63(id bigint primary key, b bit(63))")
 		narrowStmt, err := db.PrepareContext(ctx,
 			"insert into "+dbName+".t63(id, b) values (?, ?)")
 		require.NoError(t, err)
+		defer narrowStmt.Close()
 		_, err = narrowStmt.ExecContext(ctx, int64(1), int64(-1))
 		require.ErrorContains(t, err, "data out of range")
-		require.NoError(t, narrowStmt.Close())
 	})
 }

--- a/pkg/vm/process/process.go
+++ b/pkg/vm/process/process.go
@@ -162,12 +162,20 @@ func (proc *Process) SetPrepareParamsWithIsBin(prepareParams *vector.Vector, isB
 }
 
 // SetPrepareParamsWithMeta borrows prepareParams and carries per-parameter
-// string/binary and signed-integer protocol provenance. The two slices are
-// packed together so existing remote process serialization remains compatible.
-func (proc *Process) SetPrepareParamsWithMeta(prepareParams *vector.Vector, isBin, isSignedInteger []bool) {
-	metadata := make([]bool, 0, len(isBin)+len(isSignedInteger))
-	metadata = append(metadata, isBin...)
-	metadata = append(metadata, isSignedInteger...)
+// string/binary and integer-protocol provenance. The two fixed-width sections
+// are packed together so existing remote process serialization remains compatible.
+func (proc *Process) SetPrepareParamsWithMeta(prepareParams *vector.Vector, isBin, isInteger []bool) {
+	paramCount := 0
+	if prepareParams != nil {
+		paramCount = prepareParams.Length()
+	}
+	if paramCount == 0 || (len(isBin) == 0 && len(isInteger) == 0) {
+		proc.setPrepareParams(prepareParams, nil, false)
+		return
+	}
+	metadata := make([]bool, paramCount*2)
+	copy(metadata[:paramCount], isBin)
+	copy(metadata[paramCount:], isInteger)
 	proc.setPrepareParams(prepareParams, metadata, false)
 }
 

--- a/pkg/vm/process/process.go
+++ b/pkg/vm/process/process.go
@@ -162,26 +162,62 @@ func (proc *Process) SetPrepareParamsWithIsBin(prepareParams *vector.Vector, isB
 }
 
 // SetPrepareParamsWithMeta borrows prepareParams and carries per-parameter
-// string/binary and integer-protocol provenance. The two fixed-width sections
-// are packed together so existing remote process serialization remains compatible.
-func (proc *Process) SetPrepareParamsWithMeta(prepareParams *vector.Vector, isBin, isInteger []bool) {
-	paramCount := 0
-	if prepareParams != nil {
-		paramCount = prepareParams.Length()
-	}
-	if paramCount == 0 || (len(isBin) == 0 && len(isInteger) == 0) {
-		proc.setPrepareParams(prepareParams, nil, false)
-		return
-	}
-	metadata := make([]bool, paramCount*2)
-	copy(metadata[:paramCount], isBin)
-	copy(metadata[paramCount:], isInteger)
-	proc.setPrepareParams(prepareParams, metadata, false)
+// string/binary and source conversion-kind provenance. The bool slice retains the
+// legacy binary section followed by three kind-bit sections, so existing remote
+// process serialization remains compatible without a protobuf change.
+func (proc *Process) SetPrepareParamsWithMeta(
+	prepareParams *vector.Vector,
+	isBin []bool,
+	kinds []vector.PrepareParamKind,
+) {
+	proc.setPrepareParams(prepareParams, prepareParamMetadata(prepareParams, isBin, kinds), false)
 }
 
 // SetOwnedPrepareParamsWithIsBin transfers prepareParams to proc. Replacing or freeing proc releases it.
 func (proc *Process) SetOwnedPrepareParamsWithIsBin(prepareParams *vector.Vector, isBin []bool) {
 	proc.setPrepareParams(prepareParams, isBin, true)
+}
+
+// SetOwnedPrepareParamsWithMeta transfers prepareParams to proc and preserves
+// the same metadata contract as SetPrepareParamsWithMeta.
+func (proc *Process) SetOwnedPrepareParamsWithMeta(
+	prepareParams *vector.Vector,
+	isBin []bool,
+	kinds []vector.PrepareParamKind,
+) {
+	proc.setPrepareParams(prepareParams, prepareParamMetadata(prepareParams, isBin, kinds), true)
+}
+
+func prepareParamMetadata(
+	prepareParams *vector.Vector,
+	isBin []bool,
+	kinds []vector.PrepareParamKind,
+) []bool {
+	paramCount := 0
+	if prepareParams != nil {
+		paramCount = prepareParams.Length()
+	}
+	if paramCount == 0 || (len(isBin) == 0 && len(kinds) == 0) {
+		return nil
+	}
+	hasMetadata := false
+	for i := 0; i < paramCount; i++ {
+		if (i < len(isBin) && isBin[i]) || (i < len(kinds) && kinds[i] != vector.PrepareParamNone) {
+			hasMetadata = true
+			break
+		}
+	}
+	if !hasMetadata {
+		return nil
+	}
+	metadata := make([]bool, paramCount*4)
+	copy(metadata[:paramCount], isBin)
+	for i := 0; i < paramCount && i < len(kinds); i++ {
+		metadata[paramCount+i] = kinds[i]&1 != 0
+		metadata[paramCount*2+i] = kinds[i]&2 != 0
+		metadata[paramCount*3+i] = kinds[i]&4 != 0
+	}
+	return metadata
 }
 
 func (proc *Process) setPrepareParams(prepareParams *vector.Vector, isBin []bool, owned bool) {

--- a/pkg/vm/process/process.go
+++ b/pkg/vm/process/process.go
@@ -161,6 +161,16 @@ func (proc *Process) SetPrepareParamsWithIsBin(prepareParams *vector.Vector, isB
 	proc.setPrepareParams(prepareParams, isBin, false)
 }
 
+// SetPrepareParamsWithMeta borrows prepareParams and carries per-parameter
+// string/binary and signed-integer protocol provenance. The two slices are
+// packed together so existing remote process serialization remains compatible.
+func (proc *Process) SetPrepareParamsWithMeta(prepareParams *vector.Vector, isBin, isSignedInteger []bool) {
+	metadata := make([]bool, 0, len(isBin)+len(isSignedInteger))
+	metadata = append(metadata, isBin...)
+	metadata = append(metadata, isSignedInteger...)
+	proc.setPrepareParams(prepareParams, metadata, false)
+}
+
 // SetOwnedPrepareParamsWithIsBin transfers prepareParams to proc. Replacing or freeing proc releases it.
 func (proc *Process) SetOwnedPrepareParamsWithIsBin(prepareParams *vector.Vector, isBin []bool) {
 	proc.setPrepareParams(prepareParams, isBin, true)

--- a/pkg/vm/process/process2_test.go
+++ b/pkg/vm/process/process2_test.go
@@ -156,8 +156,23 @@ func TestOwnedPrepareParamsLifecycle(t *testing.T) {
 		return params
 	}
 
+	plain := newParams("plain")
+	proc.SetOwnedPrepareParamsWithMeta(
+		plain,
+		[]bool{false},
+		[]vector.PrepareParamKind{vector.PrepareParamNone},
+	)
+	require.Nil(t, proc.Base.prepareParamsIsBin, "default metadata must keep the zero-allocation path")
+
 	first := newParams("first")
-	proc.SetOwnedPrepareParamsWithIsBin(first, []bool{true})
+	proc.SetOwnedPrepareParamsWithMeta(
+		first,
+		[]bool{true},
+		[]vector.PrepareParamKind{vector.PrepareParamDecimal},
+	)
+	require.True(t, proc.GetPrepareParamIsBin(0))
+	require.Equal(t, vector.PrepareParamDecimal, proc.GetPrepareParamKind(0))
+	require.Zero(t, plain.Length(), "replacing owned default-metadata params must release them")
 	proc.SetPrepareParamsWithIsBin(first, []bool{false})
 	require.Equal(t, 1, first.Length(), "setting the same pointer must not release it")
 	require.True(t, proc.Base.prepareParamsOwned, "setting the same pointer must preserve ownership")

--- a/pkg/vm/process/process_codec_test.go
+++ b/pkg/vm/process/process_codec_test.go
@@ -324,7 +324,7 @@ func TestCodecServiceRoundTripsPreparedRowsFrameParams(t *testing.T) {
 	frameParams := vector.NewVec(types.T_text.ToType())
 	require.NoError(t, vector.AppendBytes(frameParams, []byte("1"), false, proc.Mp()))
 	require.NoError(t, vector.AppendBytes(frameParams, []byte("0"), false, proc.Mp()))
-	proc.SetPrepareParamsWithIsBin(frameParams, []bool{true, false})
+	proc.SetPrepareParamsWithMeta(frameParams, []bool{true, false}, []bool{false, true})
 
 	svc := NewCodecService(fakeCodecTxnClient{op: fakeCodecTxnOperator{}}, nil, nil, nil, nil, nil, nil, nil)
 	payload, err := svc.Encode(proc, "select sum(n) over (order by id rows between ? preceding and ? following)")
@@ -332,6 +332,7 @@ func TestCodecServiceRoundTripsPreparedRowsFrameParams(t *testing.T) {
 
 	info := pipeline.ProcessInfo{}
 	require.NoError(t, info.Unmarshal(payload))
+	require.Equal(t, []bool{true, false, false, true}, info.PrepareParams.IsBin)
 	decodedProc, err := svc.Decode(context.Background(), info)
 	require.NoError(t, err)
 	defer decodedProc.Free()
@@ -343,6 +344,8 @@ func TestCodecServiceRoundTripsPreparedRowsFrameParams(t *testing.T) {
 	require.False(t, decodedParams.GetNulls().Contains(1))
 	require.True(t, decodedProc.GetPrepareParamIsBin(0))
 	require.False(t, decodedProc.GetPrepareParamIsBin(1))
+	require.False(t, decodedProc.GetPrepareParamIsInteger(0))
+	require.True(t, decodedProc.GetPrepareParamIsInteger(1))
 	require.Equal(t, "1", decodedParams.GetStringAt(0))
 	require.Equal(t, "0", decodedParams.GetStringAt(1))
 }
@@ -369,6 +372,8 @@ func TestCodecServiceDecodesLegacyPrepareParamsWithoutBinaryFlags(t *testing.T) 
 	require.Equal(t, 2, decodedProc.GetPrepareParams().Length())
 	require.False(t, decodedProc.GetPrepareParamIsBin(0))
 	require.False(t, decodedProc.GetPrepareParamIsBin(1))
+	require.False(t, decodedProc.GetPrepareParamIsInteger(0))
+	require.False(t, decodedProc.GetPrepareParamIsInteger(1))
 	require.False(t, decodedProc.GetStmtProfile().GetStatementIgnore())
 	decodedProc.Free()
 }

--- a/pkg/vm/process/process_codec_test.go
+++ b/pkg/vm/process/process_codec_test.go
@@ -305,6 +305,8 @@ func TestCodecServiceEncodeDecodeAndLookup(t *testing.T) {
 	require.True(t, decodedProc.GetPrepareParams().GetNulls().Contains(1))
 	require.True(t, decodedProc.GetPrepareParamIsBin(0))
 	require.False(t, decodedProc.GetPrepareParamIsBin(1))
+	require.Equal(t, vector.PrepareParamNone, decodedProc.GetPrepareParamKind(0))
+	require.Equal(t, vector.PrepareParamNone, decodedProc.GetPrepareParamKind(1))
 	require.Equal(t, int64(42), decodedProc.GetAffectedRows())
 	require.True(t, decodedProc.GetStmtProfile().GetStatementIgnore())
 	decodedParams := decodedProc.GetPrepareParams()
@@ -324,7 +326,12 @@ func TestCodecServiceRoundTripsPreparedRowsFrameParams(t *testing.T) {
 	frameParams := vector.NewVec(types.T_text.ToType())
 	require.NoError(t, vector.AppendBytes(frameParams, []byte("1"), false, proc.Mp()))
 	require.NoError(t, vector.AppendBytes(frameParams, []byte("0"), false, proc.Mp()))
-	proc.SetPrepareParamsWithMeta(frameParams, []bool{true, false}, []bool{false, true})
+	require.NoError(t, vector.AppendBytes(frameParams, []byte("true"), false, proc.Mp()))
+	proc.SetPrepareParamsWithMeta(frameParams, []bool{true, false, false}, []vector.PrepareParamKind{
+		vector.PrepareParamNone,
+		vector.PrepareParamDecimal,
+		vector.PrepareParamBoolean,
+	})
 
 	svc := NewCodecService(fakeCodecTxnClient{op: fakeCodecTxnOperator{}}, nil, nil, nil, nil, nil, nil, nil)
 	payload, err := svc.Encode(proc, "select sum(n) over (order by id rows between ? preceding and ? following)")
@@ -332,22 +339,30 @@ func TestCodecServiceRoundTripsPreparedRowsFrameParams(t *testing.T) {
 
 	info := pipeline.ProcessInfo{}
 	require.NoError(t, info.Unmarshal(payload))
-	require.Equal(t, []bool{true, false, false, true}, info.PrepareParams.IsBin)
+	require.Equal(t, []bool{
+		true, false, false,
+		false, true, false,
+		false, true, false,
+		false, false, true,
+	}, info.PrepareParams.IsBin)
 	decodedProc, err := svc.Decode(context.Background(), info)
 	require.NoError(t, err)
 	defer decodedProc.Free()
 
 	decodedParams := decodedProc.GetPrepareParams()
 	require.NotNil(t, decodedParams)
-	require.Equal(t, 2, decodedParams.Length())
+	require.Equal(t, 3, decodedParams.Length())
 	require.False(t, decodedParams.GetNulls().Contains(0))
 	require.False(t, decodedParams.GetNulls().Contains(1))
+	require.False(t, decodedParams.GetNulls().Contains(2))
 	require.True(t, decodedProc.GetPrepareParamIsBin(0))
 	require.False(t, decodedProc.GetPrepareParamIsBin(1))
-	require.False(t, decodedProc.GetPrepareParamIsInteger(0))
-	require.True(t, decodedProc.GetPrepareParamIsInteger(1))
+	require.Equal(t, vector.PrepareParamNone, decodedProc.GetPrepareParamKind(0))
+	require.Equal(t, vector.PrepareParamDecimal, decodedProc.GetPrepareParamKind(1))
+	require.Equal(t, vector.PrepareParamBoolean, decodedProc.GetPrepareParamKind(2))
 	require.Equal(t, "1", decodedParams.GetStringAt(0))
 	require.Equal(t, "0", decodedParams.GetStringAt(1))
+	require.Equal(t, "true", decodedParams.GetStringAt(2))
 }
 
 func TestCodecServiceDecodesLegacyPrepareParamsWithoutBinaryFlags(t *testing.T) {
@@ -372,8 +387,8 @@ func TestCodecServiceDecodesLegacyPrepareParamsWithoutBinaryFlags(t *testing.T) 
 	require.Equal(t, 2, decodedProc.GetPrepareParams().Length())
 	require.False(t, decodedProc.GetPrepareParamIsBin(0))
 	require.False(t, decodedProc.GetPrepareParamIsBin(1))
-	require.False(t, decodedProc.GetPrepareParamIsInteger(0))
-	require.False(t, decodedProc.GetPrepareParamIsInteger(1))
+	require.Equal(t, vector.PrepareParamNone, decodedProc.GetPrepareParamKind(0))
+	require.Equal(t, vector.PrepareParamNone, decodedProc.GetPrepareParamKind(1))
 	require.False(t, decodedProc.GetStmtProfile().GetStatementIgnore())
 	decodedProc.Free()
 }

--- a/pkg/vm/process/types.go
+++ b/pkg/vm/process/types.go
@@ -362,26 +362,27 @@ type BaseProcess struct {
 	// statement in the same session, used by the ROW_COUNT() builtin.
 	// It follows MySQL semantics: -1 after a result-set statement (e.g. SELECT),
 	// 0 after DDL, and the affected row count after DML.
-	AffectedRows             *int64
-	LoadLocalReader          *io.PipeReader
-	Aicm                     *defines.AutoIncrCacheManager
-	resolveVariableFunc      func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error)
-	resolveVariableIsBinFunc func(varName string, isSystemVar, isGlobalVar bool) (bool, error)
-	prepareParams            *vector.Vector
-	prepareParamsIsBin       []bool
-	prepareParamsOwned       bool
-	QueryClient              qclient.QueryClient
-	Hakeeper                 logservice.CNHAKeeperClient
-	UdfService               udf.Service
-	WaitPolicy               lock.WaitPolicy
-	messageBoard             *message.MessageBoard
-	hashBuildBudgetMu        sync.Mutex
-	hashBuildBudget          *HashBuildBudgetGeneration
-	cteMemoryBudgetMu        sync.Mutex
-	cteMemoryBudget          *CTEMemoryBudget
-	logger                   *log.MOLogger
-	TxnOperator              client.TxnOperator
-	CloneTxnOperator         client.TxnOperator
+	AffectedRows                        *int64
+	LoadLocalReader                     *io.PipeReader
+	Aicm                                *defines.AutoIncrCacheManager
+	resolveVariableFunc                 func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error)
+	resolveVariableIsBinFunc            func(varName string, isSystemVar, isGlobalVar bool) (bool, error)
+	resolveVariablePrepareParamKindFunc func(varName string, isSystemVar, isGlobalVar bool) (vector.PrepareParamKind, error)
+	prepareParams                       *vector.Vector
+	prepareParamsIsBin                  []bool
+	prepareParamsOwned                  bool
+	QueryClient                         qclient.QueryClient
+	Hakeeper                            logservice.CNHAKeeperClient
+	UdfService                          udf.Service
+	WaitPolicy                          lock.WaitPolicy
+	messageBoard                        *message.MessageBoard
+	hashBuildBudgetMu                   sync.Mutex
+	hashBuildBudget                     *HashBuildBudgetGeneration
+	cteMemoryBudgetMu                   sync.Mutex
+	cteMemoryBudget                     *CTEMemoryBudget
+	logger                              *log.MOLogger
+	TxnOperator                         client.TxnOperator
+	CloneTxnOperator                    client.TxnOperator
 	// userLevelLockIdentity is session-scoped rather than statement-scoped.
 	// SessionInfo is rebuilt before every statement, so keeping this identity
 	// there would lose the synthetic transaction owner while locks are held.
@@ -533,8 +534,18 @@ func (proc *Process) GetPrepareParamIsBin(i int) bool {
 	return proc.getPrepareParamMeta(i, 0)
 }
 
-func (proc *Process) GetPrepareParamIsInteger(i int) bool {
-	return proc.getPrepareParamMeta(i, 1)
+func (proc *Process) GetPrepareParamKind(i int) vector.PrepareParamKind {
+	var kind vector.PrepareParamKind
+	if proc.getPrepareParamMeta(i, 1) {
+		kind |= 1
+	}
+	if proc.getPrepareParamMeta(i, 2) {
+		kind |= 2
+	}
+	if proc.getPrepareParamMeta(i, 3) {
+		kind |= 4
+	}
+	return kind
 }
 
 func (proc *Process) getPrepareParamMeta(i, section int) bool {
@@ -574,6 +585,19 @@ func (proc *Process) SetResolveVariableIsBinFunc(f func(varName string, isSystem
 
 func (proc *Process) GetResolveVariableIsBinFunc() func(varName string, isSystemVar, isGlobalVar bool) (bool, error) {
 	return proc.Base.resolveVariableIsBinFunc
+}
+
+func (proc *Process) SetResolveVariablePrepareParamKindFunc(
+	f func(varName string, isSystemVar, isGlobalVar bool) (vector.PrepareParamKind, error),
+) {
+	proc.Base.resolveVariablePrepareParamKindFunc = f
+}
+
+func (proc *Process) GetResolveVariablePrepareParamKindFunc() func(
+	varName string,
+	isSystemVar, isGlobalVar bool,
+) (vector.PrepareParamKind, error) {
+	return proc.Base.resolveVariablePrepareParamKindFunc
 }
 
 func (proc *Process) SetLastInsertID(num uint64) {

--- a/pkg/vm/process/types.go
+++ b/pkg/vm/process/types.go
@@ -530,16 +530,21 @@ func (proc *Process) GetPrepareParamsAt(i int) ([]byte, error) {
 }
 
 func (proc *Process) GetPrepareParamIsBin(i int) bool {
-	return i >= 0 && i < len(proc.Base.prepareParamsIsBin) && proc.Base.prepareParamsIsBin[i]
+	return proc.getPrepareParamMeta(i, 0)
 }
 
-func (proc *Process) GetPrepareParamIsSignedInteger(i int) bool {
+func (proc *Process) GetPrepareParamIsInteger(i int) bool {
+	return proc.getPrepareParamMeta(i, 1)
+}
+
+func (proc *Process) getPrepareParamMeta(i, section int) bool {
 	paramCount := 0
 	if proc.Base.prepareParams != nil {
 		paramCount = proc.Base.prepareParams.Length()
 	}
-	return i >= 0 && i < paramCount && paramCount+i < len(proc.Base.prepareParamsIsBin) &&
-		proc.Base.prepareParamsIsBin[paramCount+i]
+	offset := section*paramCount + i
+	return section >= 0 && i >= 0 && i < paramCount && offset < len(proc.Base.prepareParamsIsBin) &&
+		proc.Base.prepareParamsIsBin[offset]
 }
 
 // SetIncrStatementDisabled marks this process (and every child process

--- a/pkg/vm/process/types.go
+++ b/pkg/vm/process/types.go
@@ -533,6 +533,15 @@ func (proc *Process) GetPrepareParamIsBin(i int) bool {
 	return i >= 0 && i < len(proc.Base.prepareParamsIsBin) && proc.Base.prepareParamsIsBin[i]
 }
 
+func (proc *Process) GetPrepareParamIsSignedInteger(i int) bool {
+	paramCount := 0
+	if proc.Base.prepareParams != nil {
+		paramCount = proc.Base.prepareParams.Length()
+	}
+	return i >= 0 && i < paramCount && paramCount+i < len(proc.Base.prepareParamsIsBin) &&
+		proc.Base.prepareParamsIsBin[paramCount+i]
+}
+
 // SetIncrStatementDisabled marks this process (and every child process
 // sharing its BaseProcess) as running internal SQL that must not advance the
 // workspace snapshot write offset. See BaseProcess.incrStatementDisabled.

--- a/test/distributed/cases/prepare/prepare_all.result
+++ b/test/distributed/cases/prepare/prepare_all.result
@@ -680,7 +680,7 @@ select hex(b), cast(b as unsigned) from prepare_bit64_signed;
 AB355AE40850ECC7  ¦  12336866689689906375
 truncate table prepare_bit64_signed;
 insert into prepare_bit64_signed values ('-6109877384019645241');
--- @regex("data out of range", true)
+-- @regex("(data out of range|data too long)", true)
 Data truncation: data out of range: data type bit(64), value -6109877384019645241
 drop table if exists prepare_bit63_signed;
 create table prepare_bit63_signed (b bit(63));

--- a/test/distributed/cases/prepare/prepare_all.result
+++ b/test/distributed/cases/prepare/prepare_all.result
@@ -672,6 +672,31 @@ execute s using @maxint;
 18446744073709551615.5
 deallocate prepare s;
 drop table prepare_bit_numeric;
+drop table if exists prepare_bit64_signed;
+create table prepare_bit64_signed (b bit(64));
+prepare s from 'insert into prepare_bit64_signed values (?)';
+set @signed_high_bit = -9223372036854775808;
+execute s using @signed_high_bit;
+set @signed_all_bits = -1;
+execute s using @signed_all_bits;
+deallocate prepare s;
+select b from prepare_bit64_signed order by b;
+➔ b[-7,64,0]  𝄀
+9223372036854775808  𝄀
+18446744073709551615
+drop table if exists prepare_bit63_signed;
+create table prepare_bit63_signed (b bit(63));
+prepare s from 'insert into prepare_bit63_signed values (?)';
+set @signed_all_bits = -1;
+execute s using @signed_all_bits;
+-- @regex("data out of range", true)
+Data truncation: data out of range: data type int63, value -1
+deallocate prepare s;
+select count(*) from prepare_bit63_signed;
+➔ count(*)[-5,20,0]  𝄀
+0
+drop table prepare_bit64_signed;
+drop table prepare_bit63_signed;
 CREATE DATABASE mocloud_meta;
 PREPARE mo_stmt_id_1 FROM SELECT SCHEMA_NAME from Information_schema.SCHEMATA where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC,SCHEMA_NAME limit 1;
 SET @dbname1 = 'mocloud_meta%';

--- a/test/distributed/cases/prepare/prepare_all.result
+++ b/test/distributed/cases/prepare/prepare_all.result
@@ -674,15 +674,26 @@ deallocate prepare s;
 drop table prepare_bit_numeric;
 drop table if exists prepare_bit64_signed;
 create table prepare_bit64_signed (b bit(64));
+insert into prepare_bit64_signed values (-6109877384019645241);
+select hex(b), cast(b as unsigned) from prepare_bit64_signed;
+➤ hex(b)[12,-1,0]  ¦  cast(b as unsigned)[-5,64,0]  𝄀
+AB355AE40850ECC7  ¦  12336866689689906375
+truncate table prepare_bit64_signed;
+insert into prepare_bit64_signed values ('-6109877384019645241');
+-- @regex("data out of range", true)
+Data truncation: data out of range: data type bit(64), value -6109877384019645241
 prepare s from 'insert into prepare_bit64_signed values (?)';
 set @signed_high_bit = -9223372036854775808;
 execute s using @signed_high_bit;
+set @signed_workflow_value = -6109877384019645241;
+execute s using @signed_workflow_value;
 set @signed_all_bits = -1;
 execute s using @signed_all_bits;
 deallocate prepare s;
 select b from prepare_bit64_signed order by b;
 ➔ b[-7,64,0]  𝄀
 9223372036854775808  𝄀
+12336866689689906375  𝄀
 18446744073709551615
 drop table if exists prepare_bit63_signed;
 create table prepare_bit63_signed (b bit(63));

--- a/test/distributed/cases/prepare/prepare_all.result
+++ b/test/distributed/cases/prepare/prepare_all.result
@@ -682,29 +682,13 @@ truncate table prepare_bit64_signed;
 insert into prepare_bit64_signed values ('-6109877384019645241');
 -- @regex("data out of range", true)
 Data truncation: data out of range: data type bit(64), value -6109877384019645241
-prepare s from 'insert into prepare_bit64_signed values (?)';
-set @signed_high_bit = -9223372036854775808;
-execute s using @signed_high_bit;
-set @signed_workflow_value = -6109877384019645241;
-execute s using @signed_workflow_value;
-set @signed_all_bits = -1;
-execute s using @signed_all_bits;
-deallocate prepare s;
-select b from prepare_bit64_signed order by b;
-➔ b[-7,64,0]  𝄀
-9223372036854775808  𝄀
-12336866689689906375  𝄀
-18446744073709551615
 drop table if exists prepare_bit63_signed;
 create table prepare_bit63_signed (b bit(63));
-prepare s from 'insert into prepare_bit63_signed values (?)';
-set @signed_all_bits = -1;
-execute s using @signed_all_bits;
+insert into prepare_bit63_signed values (-1);
 -- @regex("data out of range", true)
 Data truncation: data out of range: data type int63, value -1
-deallocate prepare s;
 select count(*) from prepare_bit63_signed;
-➔ count(*)[-5,20,0]  𝄀
+➤ count(*)[-5,64,0]  𝄀
 0
 drop table prepare_bit64_signed;
 drop table prepare_bit63_signed;

--- a/test/distributed/cases/prepare/prepare_all.sql
+++ b/test/distributed/cases/prepare/prepare_all.sql
@@ -496,9 +496,19 @@ drop table prepare_bit_numeric;
 -- signed integer clients use the same 64-bit payload for BIT(64) values
 drop table if exists prepare_bit64_signed;
 create table prepare_bit64_signed (b bit(64));
+-- an unquoted integer expression preserves its signed 64-bit bit pattern
+insert into prepare_bit64_signed values (-6109877384019645241);
+select hex(b), cast(b as unsigned) from prepare_bit64_signed;
+truncate table prepare_bit64_signed;
+-- the same characters in an SQL string remain string-to-BIT input
+-- @regex("data out of range",true)
+insert into prepare_bit64_signed values ('-6109877384019645241');
+
 prepare s from 'insert into prepare_bit64_signed values (?)';
 set @signed_high_bit = -9223372036854775808;
 execute s using @signed_high_bit;
+set @signed_workflow_value = -6109877384019645241;
+execute s using @signed_workflow_value;
 set @signed_all_bits = -1;
 execute s using @signed_all_bits;
 deallocate prepare s;

--- a/test/distributed/cases/prepare/prepare_all.sql
+++ b/test/distributed/cases/prepare/prepare_all.sql
@@ -501,7 +501,7 @@ insert into prepare_bit64_signed values (-6109877384019645241);
 select hex(b), cast(b as unsigned) from prepare_bit64_signed;
 truncate table prepare_bit64_signed;
 -- the same characters in an SQL string remain string-to-BIT input
--- @regex("data out of range",true)
+-- @regex("(data out of range|data too long)",true)
 insert into prepare_bit64_signed values ('-6109877384019645241');
 
 -- the signed bit-pattern compatibility is limited to BIT(64)

--- a/test/distributed/cases/prepare/prepare_all.sql
+++ b/test/distributed/cases/prepare/prepare_all.sql
@@ -504,24 +504,11 @@ truncate table prepare_bit64_signed;
 -- @regex("data out of range",true)
 insert into prepare_bit64_signed values ('-6109877384019645241');
 
-prepare s from 'insert into prepare_bit64_signed values (?)';
-set @signed_high_bit = -9223372036854775808;
-execute s using @signed_high_bit;
-set @signed_workflow_value = -6109877384019645241;
-execute s using @signed_workflow_value;
-set @signed_all_bits = -1;
-execute s using @signed_all_bits;
-deallocate prepare s;
-select b from prepare_bit64_signed order by b;
-
 -- the signed bit-pattern compatibility is limited to BIT(64)
 drop table if exists prepare_bit63_signed;
 create table prepare_bit63_signed (b bit(63));
-prepare s from 'insert into prepare_bit63_signed values (?)';
-set @signed_all_bits = -1;
 -- @regex("data out of range",true)
-execute s using @signed_all_bits;
-deallocate prepare s;
+insert into prepare_bit63_signed values (-1);
 select count(*) from prepare_bit63_signed;
 
 drop table prepare_bit64_signed;

--- a/test/distributed/cases/prepare/prepare_all.sql
+++ b/test/distributed/cases/prepare/prepare_all.sql
@@ -493,6 +493,30 @@ deallocate prepare s;
 
 drop table prepare_bit_numeric;
 
+-- signed integer clients use the same 64-bit payload for BIT(64) values
+drop table if exists prepare_bit64_signed;
+create table prepare_bit64_signed (b bit(64));
+prepare s from 'insert into prepare_bit64_signed values (?)';
+set @signed_high_bit = -9223372036854775808;
+execute s using @signed_high_bit;
+set @signed_all_bits = -1;
+execute s using @signed_all_bits;
+deallocate prepare s;
+select b from prepare_bit64_signed order by b;
+
+-- the signed bit-pattern compatibility is limited to BIT(64)
+drop table if exists prepare_bit63_signed;
+create table prepare_bit63_signed (b bit(63));
+prepare s from 'insert into prepare_bit63_signed values (?)';
+set @signed_all_bits = -1;
+-- @regex("data out of range",true)
+execute s using @signed_all_bits;
+deallocate prepare s;
+select count(*) from prepare_bit63_signed;
+
+drop table prepare_bit64_signed;
+drop table prepare_bit63_signed;
+
 --test order by clause contains placeholder
 CREATE DATABASE mocloud_meta;
 PREPARE mo_stmt_id_1 FROM SELECT SCHEMA_NAME from Information_schema.SCHEMATA where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC,SCHEMA_NAME limit 1;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Test and CI

## Which issue(s) this PR fixes:

Fixes #26740.

Follow-up for #26728 and backport of #26748 to `4.2-dev`.

## What this PR does / why we need it:

MatrixOne transports prepared parameters internally through a transient text vector. That transport erased the source conversion semantics before assignment to `BIT(M)`, so the same value could be interpreted as ASCII bytes instead of a number.

This PR preserves the source conversion category across binary COM_STMT_EXECUTE, SQL EXECUTE USING, normal user-variable evaluation, process serialization, remote compile, and shard reads:

- signed and unsigned integers, including YEAR, use numeric BIT conversion;
- negative signed integers preserve their two-complement payload only for BIT(64);
- FLOAT/DOUBLE round with the existing numeric BIT rules;
- DECIMAL/NEWDECIMAL truncate the fractional part and keep exact uint64 range checks;
- Boolean values convert to 0/1;
- MYSQL_TYPE_BIT and string/blob parameters retain byte-string semantics;
- INSERT IGNORE retains the existing zero/max adjustment policy.

The metadata uses the existing process transport with backward decoding for legacy/no-metadata and the prior integer-only layout. Mixed-commit shard reads use the versioned method and are rejected before execution.

## Validation

- real database/sql binary prepared coverage for signed/unsigned integers, MaxUint64, DOUBLE rebinding, strings, BIT(63), and INSERT IGNORE;
- SQL PREPARE/EXECUTE USING and direct user-variable coverage for decimal, integer, string, Boolean, and BIT values;
- frontend protocol/type classification, parameter reuse/reset, Process ownership/codec, remote compile, shard version gating, and typed cast boundary tests;
- all affected package tests, focused embedded integration, go vet, golangci-lint, and git diff --check passed.