### PR TITLE
fix(pipeline): abort batch flow on stop sending

### DIFF
--- a/pkg/sql/colexec/types2.go
+++ b/pkg/sql/colexec/types2.go
@@ -133,6 +133,20 @@ func (srv *Server) CancelPipelineSending(
 	srv.ensureSessionCleanupLocked(session)
 }
 
+// HasPendingPipelineCancellation reports whether StopSending arrived before
+// the pipeline record was published. The tombstone remains owned by the
+// colexec registry so RecordBuiltPipeline and RecordDispatchPipeline preserve
+// their existing, distinct cancellation semantics.
+func (srv *Server) HasPendingPipelineCancellation(
+	session morpc.ClientSession, streamID uint64,
+) bool {
+	key := generateRecordKey(session, streamID)
+	srv.receivedRunningPipeline.Lock()
+	defer srv.receivedRunningPipeline.Unlock()
+	info, ok := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key]
+	return ok && info.alreadyDone && info.receiver == nil && info.queryCancel == nil
+}
+
 func (srv *Server) RemoveRelatedPipeline(session morpc.ClientSession, streamID uint64) {
 	key := generateRecordKey(session, streamID)
 	srv.receivedRunningPipeline.Lock()

--- a/pkg/sql/colexec/types2_test.go
+++ b/pkg/sql/colexec/types2_test.go
@@ -353,6 +353,9 @@ func TestCancelPipelineSending(t *testing.T) {
 	require.True(t, record3.alreadyDone, "Tombstone should mark the pipeline already done")
 	require.Nil(t, record3.receiver, "Tombstone should not carry a dispatch receiver")
 	require.Nil(t, record3.queryCancel, "Tombstone should not carry a cancel func yet")
+	require.True(t, srv.HasPendingPipelineCancellation(session, streamID3))
+	require.False(t, srv.HasPendingPipelineCancellation(session, streamID2),
+		"a registered dispatch pipeline is not a pre-registration cancellation")
 }
 
 // TestRemoveRelatedPipeline tests RemoveRelatedPipeline function

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -515,6 +515,11 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) (err error) {
 
 	case pipeline.Method_StopSending:
 		receiver.colexecServer.CancelPipelineSending(receiver.clientSession, receiver.messageId)
+		abortPipelineBatchFlow(
+			receiver.clientSession,
+			receiver.messageId,
+			moerr.NewQueryInterrupted(receiver.messageCtx),
+		)
 
 	default:
 		panic(fmt.Sprintf("unknown pipeline message type %d.", receiver.messageTyp))

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -143,6 +143,7 @@ func CnServerMessageHandler(
 			return err
 		}
 		receiver.streamLifecycle = lifecycle
+		receiver.abortBatchFlowForPendingStop()
 		receiver.acceptedTeardownMode = pipeline.StreamTeardownMode_FinishAck
 	}
 
@@ -211,6 +212,23 @@ func (receiver *messageReceiverOnServer) waitUntilDisconnectedOrCancelled() {
 	select {
 	case <-receiver.connectionCtx.Done():
 	case <-receiver.messageCtx.Done():
+	}
+}
+
+// abortBatchFlowForPendingStop closes the registration race with StopSending.
+// StopSending first publishes a colexec cancellation tombstone and then looks
+// up the lifecycle; registration publishes the lifecycle and then checks that
+// tombstone. Whichever message wins, one side observes the other side's state.
+func (receiver *messageReceiverOnServer) abortBatchFlowForPendingStop() {
+	if receiver.streamLifecycle == nil || receiver.colexecServer == nil {
+		return
+	}
+	if receiver.colexecServer.HasPendingPipelineCancellation(
+		receiver.clientSession, receiver.messageId,
+	) {
+		receiver.streamLifecycle.batchFlow.abort(
+			moerr.NewQueryInterrupted(receiver.messageCtx),
+		)
 	}
 }
 

--- a/pkg/sql/compile/remoterunServer_test.go
+++ b/pkg/sql/compile/remoterunServer_test.go
@@ -593,6 +593,63 @@ func TestHandlePipelineStopSendingAbortsOutstandingBatchFlow(t *testing.T) {
 	require.Zero(t, session.closeCalls)
 }
 
+func TestPipelineStopBeforeLifecycleRegistrationIsReconciled(t *testing.T) {
+	server := colexec.NewServer("")
+	sessionCtx, closeSession := context.WithCancel(context.Background())
+	session := &lifecycleTestSession{ctx: sessionCtx}
+	const streamID = 405
+	t.Cleanup(func() {
+		server.RemoveRelatedPipeline(session, streamID)
+		closeSession()
+	})
+
+	stopReceiver := &messageReceiverOnServer{
+		messageCtx:    context.Background(),
+		messageId:     streamID,
+		messageTyp:    pipeline.Method_StopSending,
+		clientSession: session,
+		colexecServer: server,
+	}
+	require.NoError(t, handlePipelineMessage(stopReceiver))
+	require.True(t, server.HasPendingPipelineCancellation(session, streamID))
+
+	flow := newPipelineBatchFlow(1, 1024)
+	lifecycle, err := registerPipelineStreamLifecycle(session, streamID, flow)
+	require.NoError(t, err)
+	t.Cleanup(lifecycle.remove)
+
+	// Model the failure mode directly: the lifecycle is now published, and an
+	// outstanding batch appears before the pre-registration Stop is reconciled.
+	seq, err := flow.reserve(context.Background(), context.Background(), 10)
+	require.NoError(t, err)
+	pipelineReceiver := &messageReceiverOnServer{
+		messageCtx:      context.Background(),
+		messageId:       streamID,
+		clientSession:   session,
+		streamLifecycle: lifecycle,
+		colexecServer:   server,
+	}
+	pipelineReceiver.abortBatchFlowForPendingStop()
+
+	err = flow.waitUntilDrained(context.Background(), context.Background(), nil)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted), err)
+	_, err = flow.reserve(context.Background(), context.Background(), 1)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted), err)
+	require.NoError(t, flow.acknowledge(seq), "a late ACK must be harmless after reconciliation")
+
+	dispatchReceiver := &process.WrapCs{
+		MsgId: streamID,
+		Uid:   uuid.Must(uuid.NewV7()),
+		Cs:    session,
+		Err:   make(chan error, 1),
+	}
+	server.RecordDispatchPipeline(session, streamID, dispatchReceiver)
+	require.False(t, dispatchReceiver.ReceiverDone,
+		"lifecycle cancellation must not change dispatch ReceiverDone semantics")
+	require.False(t, server.HasPendingPipelineCancellation(session, streamID),
+		"dispatch registration must retain its existing stale-tombstone cleanup")
+}
+
 func TestMessageReceiverSendBatchUsesNegotiatedCredits(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	session := mock_morpc.NewMockClientSession(ctrl)

--- a/pkg/sql/compile/remoterunServer_test.go
+++ b/pkg/sql/compile/remoterunServer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	mock_morpc "github.com/matrixorigin/matrixone/pkg/common/morpc/mock_morpc"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
@@ -548,6 +549,48 @@ func TestCnServerMessageHandlerWaitObservesConnectionClose(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("wait did not observe connection close")
 	}
+}
+
+func TestHandlePipelineStopSendingAbortsOutstandingBatchFlow(t *testing.T) {
+	server := colexec.NewServer("")
+	session := &lifecycleTestSession{ctx: context.Background()}
+	flow := newPipelineBatchFlow(1, 1024)
+	lifecycle, err := registerPipelineStreamLifecycle(session, 400, flow)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		lifecycle.remove()
+		server.RemoveRelatedPipeline(session, 400)
+	})
+
+	seq, err := flow.reserve(context.Background(), context.Background(), 10)
+	require.NoError(t, err)
+	drainStarted := make(chan struct{})
+	drainDone := make(chan error, 1)
+	go func() {
+		close(drainStarted)
+		drainDone <- flow.waitUntilDrained(context.Background(), context.Background(), nil)
+	}()
+	<-drainStarted
+
+	receiver := &messageReceiverOnServer{
+		messageCtx:    context.Background(),
+		messageId:     400,
+		messageTyp:    pipeline.Method_StopSending,
+		clientSession: session,
+		colexecServer: server,
+	}
+	require.NoError(t, handlePipelineMessage(receiver))
+
+	select {
+	case err = <-drainDone:
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted), err)
+	case <-time.After(time.Second):
+		t.Fatal("StopSending did not release the terminal-response drain barrier")
+	}
+	require.NoError(t, handlePipelineBatchAck(
+		&pipeline.Message{Id: 400, BatchAckSequence: seq}, session),
+		"a concurrently flushed ACK must remain harmless after StopSending")
+	require.Zero(t, session.closeCalls)
 }
 
 func TestMessageReceiverSendBatchUsesNegotiatedCredits(t *testing.T) {

--- a/pkg/sql/compile/remoterun_batch_flow.go
+++ b/pkg/sql/compile/remoterun_batch_flow.go
@@ -40,6 +40,7 @@ type pipelineBatchFlow struct {
 	bytes    uint64
 	pending  map[uint64]uint64
 	changed  chan struct{}
+	abortErr error
 }
 
 func newPipelineBatchFlow(requestedCount uint32, requestedBytes uint64) *pipelineBatchFlow {
@@ -76,6 +77,11 @@ func (f *pipelineBatchFlow) reserve(
 	}
 	for {
 		f.mu.Lock()
+		if f.abortErr != nil {
+			err := f.abortErr
+			f.mu.Unlock()
+			return 0, err
+		}
 		countAvailable := uint32(len(f.pending)) < f.maxCount
 		bytesAvailable := f.bytes+size <= f.maxBytes || len(f.pending) == 0
 		if countAvailable && bytesAvailable {
@@ -99,6 +105,27 @@ func (f *pipelineBatchFlow) reserve(
 	}
 }
 
+// abort makes the flow terminal without pretending that outstanding batches
+// were acknowledged. It releases retained batch accounting and wakes both
+// credit waiters and the terminal-response drain barrier. The first abort cause
+// owns the terminal state; later StopSending messages and late ACKs are benign.
+func (f *pipelineBatchFlow) abort(cause error) {
+	if f == nil {
+		return
+	}
+	if cause == nil {
+		cause = context.Canceled
+	}
+	f.mu.Lock()
+	if f.abortErr == nil {
+		f.abortErr = cause
+		clear(f.pending)
+		f.bytes = 0
+		f.notifyLocked()
+	}
+	f.mu.Unlock()
+}
+
 func (f *pipelineBatchFlow) rollback(seq uint64) {
 	if f == nil || seq == 0 {
 		return
@@ -118,6 +145,9 @@ func (f *pipelineBatchFlow) acknowledge(seq uint64) error {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.abortErr != nil {
+		return nil
+	}
 	if seq <= f.ackedSeq {
 		return nil
 	}
@@ -149,6 +179,11 @@ func (f *pipelineBatchFlow) waitUntilDrained(
 	delayC := timer.C
 	for {
 		f.mu.Lock()
+		if f.abortErr != nil {
+			err := f.abortErr
+			f.mu.Unlock()
+			return err
+		}
 		if len(f.pending) == 0 {
 			f.mu.Unlock()
 			return nil
@@ -170,6 +205,15 @@ func (f *pipelineBatchFlow) waitUntilDrained(
 			}
 		}
 	}
+}
+
+func abortPipelineBatchFlow(cs morpc.ClientSession, id uint64, cause error) {
+	key := pipelineStreamLifecycleKey{session: cs, id: id}
+	value, ok := pipelineStreamLifecycles.Load(key)
+	if !ok {
+		return
+	}
+	value.(*pipelineStreamLifecycle).batchFlow.abort(cause)
 }
 
 func handlePipelineBatchAck(message *pipeline.Message, cs morpc.ClientSession) error {

--- a/pkg/sql/compile/remoterun_batch_flow_test.go
+++ b/pkg/sql/compile/remoterun_batch_flow_test.go
@@ -16,7 +16,9 @@ package compile
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
 	"github.com/stretchr/testify/require"
@@ -112,6 +114,51 @@ func TestPipelineBatchFlowWaitsForCreditAndObservesConnectionClose(t *testing.T)
 	flow.rollback(0)
 	require.NoError(t, flow.acknowledge(0))
 	require.NoError(t, flow.acknowledge(seq))
+}
+
+func TestPipelineBatchFlowAbortWakesWaitersAndReleasesAccounting(t *testing.T) {
+	flow := newPipelineBatchFlow(1, 1024)
+	seq, err := flow.reserve(context.Background(), context.Background(), 10)
+	require.NoError(t, err)
+
+	reserveStarted := make(chan struct{})
+	reserveDone := make(chan error, 1)
+	go func() {
+		close(reserveStarted)
+		_, err := flow.reserve(context.Background(), context.Background(), 1)
+		reserveDone <- err
+	}()
+	waitStarted := make(chan struct{})
+	waitDone := make(chan error, 1)
+	go func() {
+		close(waitStarted)
+		waitDone <- flow.waitUntilDrained(context.Background(), context.Background(), nil)
+	}()
+	<-reserveStarted
+	<-waitStarted
+
+	firstCause := errors.New("stop sending")
+	flow.abort(firstCause)
+	flow.abort(errors.New("later abort"))
+
+	select {
+	case err := <-reserveDone:
+		require.ErrorIs(t, err, firstCause)
+	case <-time.After(time.Second):
+		t.Fatal("abort did not wake a blocked credit reservation")
+	}
+	select {
+	case err := <-waitDone:
+		require.ErrorIs(t, err, firstCause)
+	case <-time.After(time.Second):
+		t.Fatal("abort did not wake the terminal-response drain barrier")
+	}
+
+	flow.mu.Lock()
+	require.Empty(t, flow.pending)
+	require.Zero(t, flow.bytes)
+	flow.mu.Unlock()
+	require.NoError(t, flow.acknowledge(seq), "an ACK already in flight must be harmless after abort")
 }
 
 func TestHandlePipelineBatchAck(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26746

## What this PR does / why we need it:

The client sends a batch ACK before StopSending, but the server can process those messages concurrently and observe StopSending first. StopSending canceled query execution without terminating the negotiated batch-flow state, so the original handler could remain blocked in waitUntilDrained until the 30-second connection timeout.

This change adds an idempotent aborted state to pipelineBatchFlow. StopSending now aborts the matching flow after canceling execution, releases outstanding batch accounting, wakes credit and drain waiters, rejects new reservations, and treats an already-flushed late ACK as harmless.

It also closes the pre-registration race called out in review. StopSending first publishes the existing session-cleaned colexec cancellation tombstone and then checks the lifecycle; lifecycle registration publishes the lifecycle and then checks that tombstone. This publish-then-check handshake guarantees that either side observes the other without changing dispatch ReceiverDone semantics from #23153.

Regression coverage verifies blocked waiter release, first-cause/idempotent abort behavior, accounting cleanup, the lifecycle-before-StopSending case, and the exact StopSending -> lifecycle registration -> outstanding batch/drain ordering with dispatch tombstone cleanup.