### PR TITLE
fix: avoid redundant foreign key rewrites during alter table

### DIFF
--- a/pkg/embed/issue26465_benchmark_test.go
+++ b/pkg/embed/issue26465_benchmark_test.go
@@ -1,0 +1,318 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embed
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	issue26465BenchmarkDepartmentIndexes = 768
+	issue26465BenchmarkUserIndexes       = 732
+	issue26465BenchmarkUserFKeys         = 349
+	issue26465BenchmarkCandidateFKeys    = 702
+)
+
+// BenchmarkIssue26465AlterCopyQAShape runs the same logical no-op COPY ALTER
+// that triggered the QA allocation profile, against the decoded QA cardinality.
+// Setup is intentionally excluded from timing. The fixture does not claim to
+// reproduce QA's unavailable full CREATE SQL. New DDL is canonicalized by
+// #26330, so it cannot recreate QA's 348 legacy RefChildTbl IDs; the legacy
+// serialization fan-out is covered by the engine microbenchmark.
+//
+// This is a manual benchmark. Start with one measured ALTER per scenario:
+// go test -run '^$' -bench '^BenchmarkIssue26465AlterCopyQAShape$' -benchmem -benchtime=1x ./pkg/embed
+func BenchmarkIssue26465AlterCopyQAShape(b *testing.B) {
+	restoreMemProfileRate := issue26465DisableSetupAllocationProfiling()
+	defer restoreMemProfileRate()
+
+	RunBaseClusterTests(b, func(cluster Cluster) {
+		cn, err := cluster.GetCNService(0)
+		if err != nil {
+			b.Fatal(err)
+		}
+		dsn := fmt.Sprintf(
+			"dump:111@tcp(127.0.0.1:%d)/",
+			cn.GetServiceConfig().CN.Frontend.Port,
+		)
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer db.Close()
+
+		benchmarkIssue26465DepartmentsCopy(b, db)
+		benchmarkIssue26465UsersCopy(b, db)
+		benchmarkIssue26465CandidatesCopy(b, db)
+	})
+}
+
+func TestIssue26465AlterCopyPreservesParentReference(t *testing.T) {
+	RunBaseClusterTests(t, func(cluster Cluster) {
+		cn, err := cluster.GetCNService(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dsn := fmt.Sprintf(
+			"dump:111@tcp(127.0.0.1:%d)/",
+			cn.GetServiceConfig().CN.Frontend.Port,
+		)
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		ctx := context.Background()
+		const database = "issue26465_parent_reference"
+		if _, err := db.ExecContext(ctx, "DROP DATABASE IF EXISTS "+database); err != nil {
+			t.Fatal(err)
+		}
+		defer db.ExecContext(ctx, "DROP DATABASE IF EXISTS "+database)
+		if _, err := db.ExecContext(ctx, "CREATE DATABASE "+database); err != nil {
+			t.Fatal(err)
+		}
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close()
+
+		for _, statement := range []string{
+			"USE " + database,
+			`CREATE TABLE parent (id INT PRIMARY KEY)`,
+			`CREATE TABLE child (
+				id INT PRIMARY KEY,
+				parent_id INT,
+				CONSTRAINT child_parent_fk_one FOREIGN KEY (parent_id) REFERENCES parent(id),
+				CONSTRAINT child_parent_fk_two FOREIGN KEY (parent_id) REFERENCES parent(id)
+			)`,
+			`ALTER TABLE child ADD COLUMN payload INT NULL`,
+		} {
+			if _, err := conn.ExecContext(ctx, statement); err != nil {
+				t.Fatalf("%s: %v", statement, err)
+			}
+		}
+
+		if _, err := conn.ExecContext(ctx, `DROP TABLE parent`); err == nil {
+			t.Fatal("parent table was dropped after ALTER COPY despite child foreign keys")
+		}
+	})
+}
+
+func benchmarkIssue26465DepartmentsCopy(b *testing.B, db *sql.DB) {
+	b.Run("departments_parent_copy_current_canonical_ref_child", func(b *testing.B) {
+		ctx, conn, cleanup := setupIssue26465DepartmentAndUsers(b, db, "issue26465_departments")
+		defer func() {
+			b.StopTimer()
+			cleanup()
+		}()
+
+		b.ResetTimer()
+		stopAllocationProfile := issue26465StartMeasuredAllocationProfiling()
+		b.StartTimer()
+		for range b.N {
+			issue26465Exec(b, ctx, conn, `ALTER TABLE departments CHANGE name name VARCHAR(100) NOT NULL COMMENT '部门名称'`)
+		}
+		b.StopTimer()
+		stopAllocationProfile()
+		b.ReportMetric(issue26465BenchmarkDepartmentIndexes, "department-indexes/op")
+		b.ReportMetric(issue26465BenchmarkUserIndexes, "user-indexes/op")
+		b.ReportMetric(issue26465BenchmarkUserFKeys, "user-fks/op")
+	})
+}
+
+func benchmarkIssue26465UsersCopy(b *testing.B, db *sql.DB) {
+	b.Run("users_child_copy_349_fks_to_one_parent", func(b *testing.B) {
+		ctx, conn, cleanup := setupIssue26465DepartmentAndUsers(b, db, "issue26465_users")
+		defer func() {
+			b.StopTimer()
+			cleanup()
+		}()
+
+		b.ResetTimer()
+		stopAllocationProfile := issue26465StartMeasuredAllocationProfiling()
+		b.StartTimer()
+		for range b.N {
+			issue26465Exec(b, ctx, conn, `ALTER TABLE users CHANGE department_id department_id INT NULL COMMENT '所属部门ID（关联 departments 表）'`)
+		}
+		b.StopTimer()
+		stopAllocationProfile()
+		b.ReportMetric(issue26465BenchmarkDepartmentIndexes, "department-indexes/op")
+		b.ReportMetric(issue26465BenchmarkUserIndexes, "user-indexes/op")
+		b.ReportMetric(issue26465BenchmarkUserFKeys, "user-fks/op")
+	})
+}
+
+func benchmarkIssue26465CandidatesCopy(b *testing.B, db *sql.DB) {
+	b.Run("candidates_child_copy_702_fks_to_three_parents", func(b *testing.B) {
+		ctx, conn, cleanup := setupIssue26465Candidates(b, db, "issue26465_candidates")
+		defer func() {
+			b.StopTimer()
+			cleanup()
+		}()
+
+		b.ResetTimer()
+		stopAllocationProfile := issue26465StartMeasuredAllocationProfiling()
+		b.StartTimer()
+		for range b.N {
+			issue26465Exec(b, ctx, conn, `ALTER TABLE candidates CHANGE payload payload INT NULL`)
+		}
+		b.StopTimer()
+		stopAllocationProfile()
+		b.ReportMetric(issue26465BenchmarkCandidateFKeys, "candidate-fks/op")
+		b.ReportMetric(3, "unique-parents/op")
+	})
+}
+
+func issue26465DisableSetupAllocationProfiling() func() {
+	if os.Getenv("MO_ISSUE_26465_PROFILE_ALLOCATIONS") != "1" {
+		return func() {}
+	}
+	previousRate := runtime.MemProfileRate
+	runtime.MemProfileRate = 0
+	return func() {
+		runtime.MemProfileRate = previousRate
+	}
+}
+
+func issue26465StartMeasuredAllocationProfiling() func() {
+	if os.Getenv("MO_ISSUE_26465_PROFILE_ALLOCATIONS") != "1" {
+		return func() {}
+	}
+	// This rate keeps the profile representative without distorting the DDL
+	// benchmark by recording every small allocation.
+	runtime.MemProfileRate = 64 * 1024
+	return func() {
+		runtime.MemProfileRate = 0
+	}
+}
+
+func setupIssue26465DepartmentAndUsers(
+	b *testing.B,
+	db *sql.DB,
+	database string,
+) (context.Context, *sql.Conn, func()) {
+	ctx, conn := issue26465SetupDatabase(b, db, database)
+	issue26465Exec(b, ctx, conn, issue26465DepartmentsDDL())
+	issue26465Exec(b, ctx, conn, issue26465UsersDDL())
+	return ctx, conn, func() {
+		conn.Close()
+		issue26465DropDatabase(b, db, database)
+	}
+}
+
+func setupIssue26465Candidates(
+	b *testing.B,
+	db *sql.DB,
+	database string,
+) (context.Context, *sql.Conn, func()) {
+	ctx, conn := issue26465SetupDatabase(b, db, database)
+	issue26465Exec(b, ctx, conn, `CREATE TABLE jobs (id INT PRIMARY KEY)`)
+	issue26465Exec(b, ctx, conn, `CREATE TABLE talent_pools (id INT PRIMARY KEY)`)
+	issue26465Exec(b, ctx, conn, `CREATE TABLE users (id INT PRIMARY KEY)`)
+	issue26465Exec(b, ctx, conn, issue26465CandidatesDDL())
+	return ctx, conn, func() {
+		conn.Close()
+		issue26465DropDatabase(b, db, database)
+	}
+}
+
+func issue26465SetupDatabase(b *testing.B, db *sql.DB, database string) (context.Context, *sql.Conn) {
+	b.StopTimer()
+	issue26465DropDatabase(b, db, database)
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	issue26465Exec(b, ctx, conn, "CREATE DATABASE "+database)
+	issue26465Exec(b, ctx, conn, "USE "+database)
+	return ctx, conn
+}
+
+func issue26465Exec(b *testing.B, ctx context.Context, conn *sql.Conn, statement string) {
+	b.Helper()
+	if _, err := conn.ExecContext(ctx, statement); err != nil {
+		b.Fatalf("%s: %v", statement, err)
+	}
+}
+
+func issue26465DropDatabase(b *testing.B, db *sql.DB, database string) {
+	b.Helper()
+	if _, err := db.Exec("DROP DATABASE IF EXISTS " + database); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func issue26465DepartmentsDDL() string {
+	defs := []string{
+		"id INT NOT NULL AUTO_INCREMENT",
+		"name VARCHAR(100) NOT NULL COMMENT '部门名称'",
+		"marker INT NULL",
+		"PRIMARY KEY (id)",
+	}
+	for i := range issue26465BenchmarkDepartmentIndexes {
+		defs = append(defs, fmt.Sprintf("KEY departments_idx_%04d (marker)", i))
+	}
+	return "CREATE TABLE departments (" + strings.Join(defs, ",") + ")"
+}
+
+func issue26465UsersDDL() string {
+	defs := []string{
+		"id INT NOT NULL AUTO_INCREMENT",
+		"department_id INT NULL COMMENT '所属部门ID（关联 departments 表）'",
+		"marker INT NULL",
+		"PRIMARY KEY (id)",
+	}
+	for i := range issue26465BenchmarkUserIndexes {
+		defs = append(defs, fmt.Sprintf("KEY users_idx_%04d (marker)", i))
+	}
+	for i := range issue26465BenchmarkUserFKeys {
+		defs = append(defs, fmt.Sprintf(
+			"CONSTRAINT users_department_fk_%04d FOREIGN KEY (department_id) REFERENCES departments(id) ON DELETE SET NULL ON UPDATE CASCADE",
+			i,
+		))
+	}
+	return "CREATE TABLE users (" + strings.Join(defs, ",") + ")"
+}
+
+func issue26465CandidatesDDL() string {
+	defs := []string{
+		"id INT NOT NULL AUTO_INCREMENT",
+		"job_id INT NULL",
+		"talent_pool_id INT NULL",
+		"created_by INT NULL",
+		"payload INT NULL",
+		"PRIMARY KEY (id)",
+		"KEY candidates_payload_idx_0 (payload)",
+		"KEY candidates_payload_idx_1 (payload)",
+		"KEY candidates_payload_idx_2 (payload)",
+	}
+	for i := range issue26465BenchmarkCandidateFKeys / 3 {
+		defs = append(defs,
+			fmt.Sprintf("CONSTRAINT candidates_jobs_fk_%04d FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE SET NULL ON UPDATE CASCADE", i),
+			fmt.Sprintf("CONSTRAINT candidates_talent_pools_fk_%04d FOREIGN KEY (talent_pool_id) REFERENCES talent_pools(id) ON DELETE SET NULL ON UPDATE CASCADE", i),
+			fmt.Sprintf("CONSTRAINT candidates_users_fk_%04d FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE", i),
+		)
+	}
+	return "CREATE TABLE candidates (" + strings.Join(defs, ",") + ")"
+}

--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -1222,7 +1222,10 @@ func (s *Scope) alterTableCopy(c *Compile, cleanup *alterAutoIncrementResetClean
 	// 3. create temporary replica table which doesn't have foreign key constraints
 	// Get logicalId from tableDef and pass it when creating the temporary table
 	oldLogicalId := qry.GetTableDef().GetLogicalId()
-	createTmpOpts := executor.StatementOption{}
+	// The temporary relation is not externally visible. Its parent backrefs are
+	// reconciled after the original relation is replaced, so avoid materializing
+	// an intermediate parent->temporary-table relationship here.
+	createTmpOpts := executor.StatementOption{}.WithIgnoreForeignKey()
 
 	if oldLogicalId != 0 {
 		createTmpOpts = createTmpOpts.WithKeepLogicalId(oldLogicalId)
@@ -1551,38 +1554,33 @@ func (s *Scope) alterTableCopy(c *Compile, cleanup *alterAutoIncrementResetClean
 			return err
 		}
 
-		// update foreign key child table references to the current table
-		for _, tblId := range qry.CopyTableDef.RefChildTbls {
-			err = updateTableForeignKeyColId(
-				c, qry.ChangeTblColIdMap, tblId,
-				originRel.GetTableID(c.proc.Ctx),
-				newRel.GetTableID(c.proc.Ctx),
-			)
-			if err != nil {
-				c.proc.Error(c.proc.Ctx, "update foreign key child table references to the current table for alter table",
-					zap.String("origin tableName", qry.GetTableDef().Name),
-					zap.String("copy table name", qry.CopyTableDef.Name),
-					zap.Error(err))
-				return err
-			}
+		if err = reconcileAlterCopyChildForeignKeyReferences(
+			c,
+			qry.ChangeTblColIdMap,
+			qry.CopyTableDef.RefChildTbls,
+			originRel.GetTableID(c.proc.Ctx),
+			newRel.GetTableID(c.proc.Ctx),
+		); err != nil {
+			c.proc.Error(c.proc.Ctx, "update foreign key child table references to the current table for alter table",
+				zap.String("origin tableName", qry.GetTableDef().Name),
+				zap.String("copy table name", qry.CopyTableDef.Name),
+				zap.Error(err))
+			return err
 		}
 	}
 
 	if len(qry.TableDef.Fkeys) > 0 {
-		for _, fkey := range qry.CopyTableDef.Fkeys {
-			err = notifyParentTableFkTableIdChange(
-				c,
-				fkey,
-				originRel.GetTableID(c.proc.Ctx),
-				newRel.GetTableID(c.proc.Ctx),
-			)
-			if err != nil {
-				c.proc.Error(c.proc.Ctx, "notify parent table foreign key TableId Change for alter table",
-					zap.String("origin tableName", qry.GetTableDef().Name),
-					zap.String("copy table name", qry.CopyTableDef.Name),
-					zap.Error(err))
-				return err
-			}
+		if err = reconcileAlterCopyParentForeignKeyReferences(
+			c,
+			qry.CopyTableDef.Fkeys,
+			originRel.GetTableID(c.proc.Ctx),
+			newRel.GetTableID(c.proc.Ctx),
+		); err != nil {
+			c.proc.Error(c.proc.Ctx, "notify parent table foreign key TableId Change for alter table",
+				zap.String("origin tableName", qry.GetTableDef().Name),
+				zap.String("copy table name", qry.CopyTableDef.Name),
+				zap.Error(err))
+			return err
 		}
 	}
 
@@ -2050,45 +2048,91 @@ func (s *Scope) RenameTable(c *Compile) (err error) {
 	return nil
 }
 
-// updateTableForeignKeyColId update foreign key colid of child table references
-func updateTableForeignKeyColId(
+func reconcileAlterCopyChildForeignKeyReferences(
 	c *Compile,
 	changeColDefMap map[uint64]*plan.ColDef,
-	childTblId uint64,
+	childTblIDs []uint64,
 	oldParentTblId uint64,
 	newParentTblId uint64,
 ) error {
-	var childRel engine.Relation
-	var err error
-	if childTblId == 0 {
-		//fk self refer does not update
-		return nil
-	} else {
-		_, _, childRel, err = c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), childTblId)
-		if err != nil {
+	for _, childTblID := range uniqueNonZeroTableIDs(childTblIDs) {
+		if err := updateTableForeignKeyColId(
+			c,
+			changeColDefMap,
+			childTblID,
+			oldParentTblId,
+			newParentTblId,
+		); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// updateTableForeignKeyColId updates one child relation only when it still
+// references the replaced parent relation.
+func updateTableForeignKeyColId(
+	c *Compile,
+	changeColDefMap map[uint64]*plan.ColDef,
+	childTblID uint64,
+	oldParentTblId uint64,
+	newParentTblId uint64,
+) error {
+	_, _, childRel, err := c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), childTblID)
+	if err != nil {
+		return err
 	}
 	oldCt, err := GetConstraintDef(c.proc.Ctx, childRel)
 	if err != nil {
 		return err
 	}
-	for _, ct := range oldCt.Cts {
+	changed, err := rewriteForeignKeyReferencesForAlterCopy(
+		c.proc.Ctx,
+		oldCt,
+		changeColDefMap,
+		oldParentTblId,
+		newParentTblId,
+	)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return childRel.UpdateConstraint(c.proc.Ctx, oldCt)
+}
+
+func rewriteForeignKeyReferencesForAlterCopy(
+	ctx context.Context,
+	constraintDef *engine.ConstraintDef,
+	changeColDefMap map[uint64]*plan.ColDef,
+	oldParentTblID uint64,
+	newParentTblID uint64,
+) (bool, error) {
+	changed := false
+	for _, ct := range constraintDef.Cts {
 		if def, ok1 := ct.(*engine.ForeignKeyDef); ok1 {
-			for i := 0; i < len(def.Fkeys); i++ {
-				fkey := def.Fkeys[i]
-				if fkey.ForeignTbl == oldParentTblId {
-					for j := 0; j < len(fkey.ForeignCols); j++ {
-						if newColDef, ok2 := changeColDefMap[fkey.ForeignCols[j]]; ok2 {
-							fkey.ForeignCols[j] = newColDef.ColId
-						}
+			for _, fkey := range def.Fkeys {
+				if fkey == nil {
+					return false, moerr.NewInternalError(ctx, "nil foreign key definition in ALTER COPY constraint")
+				}
+				if fkey.ForeignTbl != oldParentTblID {
+					continue
+				}
+				for j, foreignColID := range fkey.ForeignCols {
+					if newColDef, ok := changeColDefMap[foreignColID]; ok && foreignColID != newColDef.ColId {
+						fkey.ForeignCols[j] = newColDef.ColId
+						changed = true
 					}
-					fkey.ForeignTbl = newParentTblId
+				}
+				if fkey.ForeignTbl != newParentTblID {
+					fkey.ForeignTbl = newParentTblID
+					changed = true
 				}
 			}
 		}
 	}
-	return childRel.UpdateConstraint(c.proc.Ctx, oldCt)
+	return changed, nil
 }
 
 func updateNewTableColId(c *Compile, copyRel engine.Relation, changeColDefMap map[uint64]*plan.ColDef) error {
@@ -2119,29 +2163,37 @@ func restoreNewTableRefChildTbls(c *Compile, copyRel engine.Relation, refChildTb
 	return copyRel.UpdateConstraint(c.proc.Ctx, oldCt)
 }
 
-// notifyParentTableFkTableIdChange Notify the parent table of changes in the tableid of the foreign key table
-func reconcileParentRefChildTableID(
-	constraintDef *engine.ConstraintDef,
-	oldTableID uint64,
-	newTableID uint64,
-) {
-	reconcileRefChildTableID(constraintDef, oldTableID, newTableID)
-}
-
-func notifyParentTableFkTableIdChange(
+func reconcileAlterCopyParentForeignKeyReferences(
 	c *Compile,
-	fkey *plan.ForeignKeyDef,
+	fkeys []*plan.ForeignKeyDef,
 	oldTableID uint64,
 	newTableID uint64,
 ) error {
-	foreignTblId := fkey.ForeignTbl
-	if foreignTblId == 0 {
-		// Self-referencing foreign keys use 0 as the parent-table sentinel.
-		// The ALTER copy is already carrying that constraint on newRel, and
-		// there is no separate parent relation to update.
-		return nil
+	for _, fkey := range fkeys {
+		if fkey == nil {
+			return moerr.NewInternalError(c.proc.Ctx, "nil foreign key definition in ALTER COPY")
+		}
 	}
-	_, _, fatherRelation, err := c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), foreignTblId)
+	for _, parentTableID := range foreignKeyParentTableIDs(fkeys) {
+		if err := updateParentTableRefChildTableIDForAlterCopy(
+			c,
+			parentTableID,
+			oldTableID,
+			newTableID,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateParentTableRefChildTableIDForAlterCopy(
+	c *Compile,
+	parentTableID uint64,
+	oldTableID uint64,
+	newTableID uint64,
+) error {
+	_, _, fatherRelation, err := c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), parentTableID)
 	if err != nil {
 		return err
 	}
@@ -2149,8 +2201,32 @@ func notifyParentTableFkTableIdChange(
 	if err != nil {
 		return err
 	}
-	reconcileParentRefChildTableID(oldCt, oldTableID, newTableID)
+	reconcileRefChildTableID(oldCt, oldTableID, newTableID)
 	return fatherRelation.UpdateConstraint(c.proc.Ctx, oldCt)
+}
+
+func uniqueNonZeroTableIDs(tableIDs []uint64) []uint64 {
+	unique := make([]uint64, 0, len(tableIDs))
+	seen := make(map[uint64]struct{}, len(tableIDs))
+	for _, tableID := range tableIDs {
+		if tableID == 0 {
+			continue
+		}
+		if _, exists := seen[tableID]; exists {
+			continue
+		}
+		seen[tableID] = struct{}{}
+		unique = append(unique, tableID)
+	}
+	return unique
+}
+
+func foreignKeyParentTableIDs(fkeys []*plan.ForeignKeyDef) []uint64 {
+	parentTableIDs := make([]uint64, 0, len(fkeys))
+	for _, fkey := range fkeys {
+		parentTableIDs = append(parentTableIDs, fkey.ForeignTbl)
+	}
+	return uniqueNonZeroTableIDs(parentTableIDs)
 }
 
 func cloneUnaffectedIndexes(

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -507,32 +507,124 @@ func TestCanonicalRefChildTableIDMutations(t *testing.T) {
 	})
 }
 
-func TestReconcileParentRefChildTableID(t *testing.T) {
+func TestRewriteForeignKeyReferencesForAlterCopy(t *testing.T) {
+	constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
+		&engine.ForeignKeyDef{Fkeys: []*plan2.ForeignKeyDef{
+			{ForeignTbl: 10, ForeignCols: []uint64{1, 2}},
+			{ForeignTbl: 10, ForeignCols: []uint64{3}},
+			{ForeignTbl: 20, ForeignCols: []uint64{1}},
+		}},
+	}}
+
+	changed, err := rewriteForeignKeyReferencesForAlterCopy(
+		context.Background(),
+		constraintDef,
+		map[uint64]*plan2.ColDef{1: {ColId: 101}, 3: {ColId: 103}},
+		10,
+		11,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	fkeys := constraintDef.Cts[0].(*engine.ForeignKeyDef).Fkeys
+	require.Equal(t, uint64(11), fkeys[0].ForeignTbl)
+	require.Equal(t, []uint64{101, 2}, fkeys[0].ForeignCols)
+	require.Equal(t, uint64(11), fkeys[1].ForeignTbl)
+	require.Equal(t, []uint64{103}, fkeys[1].ForeignCols)
+	require.Equal(t, uint64(20), fkeys[2].ForeignTbl)
+	require.Equal(t, []uint64{1}, fkeys[2].ForeignCols)
+
+	changed, err = rewriteForeignKeyReferencesForAlterCopy(context.Background(), constraintDef, nil, 10, 11)
+	require.NoError(t, err)
+	require.False(t, changed)
+
+	_, err = rewriteForeignKeyReferencesForAlterCopy(context.Background(), &engine.ConstraintDef{Cts: []engine.Constraint{
+		&engine.ForeignKeyDef{Fkeys: []*plan2.ForeignKeyDef{nil}},
+	}}, nil, 10, 11)
+	require.ErrorContains(t, err, "nil foreign key definition")
+}
+
+func TestReconcileRefChildTableIDForAlterCopy(t *testing.T) {
 	t.Run("replace child in existing reverse reference", func(t *testing.T) {
 		constraintDef := &engine.ConstraintDef{Cts: []engine.Constraint{
 			&engine.RefChildTableDef{Tables: []uint64{10, 20, 30}},
 		}}
-		reconcileParentRefChildTableID(constraintDef, 20, 21)
+		reconcileRefChildTableID(constraintDef, 20, 21)
 
-		require.Len(t, constraintDef.Cts, 1)
-		require.Equal(
-			t,
-			[]uint64{10, 21, 30},
-			constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
-		)
+		require.Equal(t, []uint64{10, 21, 30}, canonicalRefChildTableIDs(constraintDef))
 	})
 
 	t.Run("restore reverse reference removed while dropping old child", func(t *testing.T) {
 		constraintDef := &engine.ConstraintDef{}
-		reconcileParentRefChildTableID(constraintDef, 20, 21)
+		reconcileRefChildTableID(constraintDef, 20, 21)
 
-		require.Len(t, constraintDef.Cts, 1)
-		require.Equal(
-			t,
-			[]uint64{21},
-			constraintDef.Cts[0].(*engine.RefChildTableDef).Tables,
-		)
+		require.Equal(t, []uint64{21}, canonicalRefChildTableIDs(constraintDef))
 	})
+}
+
+func TestReconcileAlterCopyForeignKeyReferencesOncePerRelation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	proc := testutil.NewProcess(t)
+
+	childUpdated := mock_frontend.NewMockRelation(ctrl)
+	childUnchanged := mock_frontend.NewMockRelation(ctrl)
+	parentOne := mock_frontend.NewMockRelation(ctrl)
+	parentTwo := mock_frontend.NewMockRelation(ctrl)
+
+	childUpdatedConstraint := &engine.ConstraintDef{Cts: []engine.Constraint{
+		&engine.ForeignKeyDef{Fkeys: []*plan2.ForeignKeyDef{{ForeignTbl: 1}}},
+	}}
+	childUnchangedConstraint := &engine.ConstraintDef{Cts: []engine.Constraint{
+		&engine.ForeignKeyDef{Fkeys: []*plan2.ForeignKeyDef{{ForeignTbl: 99}}},
+	}}
+	parentOneConstraint := &engine.ConstraintDef{Cts: []engine.Constraint{
+		&engine.RefChildTableDef{Tables: []uint64{1}},
+	}}
+	parentTwoConstraint := &engine.ConstraintDef{Cts: []engine.Constraint{
+		&engine.RefChildTableDef{Tables: []uint64{1}},
+	}}
+
+	childUpdated.EXPECT().UpdateConstraint(gomock.Any(), childUpdatedConstraint).Return(nil).Times(1)
+	parentOne.EXPECT().UpdateConstraint(gomock.Any(), parentOneConstraint).Return(nil).Times(1)
+	parentTwo.EXPECT().UpdateConstraint(gomock.Any(), parentTwoConstraint).Return(nil).Times(1)
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().GetRelationById(gomock.Any(), gomock.Any(), uint64(10)).Return("", "", childUpdated, nil).Times(1)
+	eng.EXPECT().GetRelationById(gomock.Any(), gomock.Any(), uint64(20)).Return("", "", childUnchanged, nil).Times(1)
+	eng.EXPECT().GetRelationById(gomock.Any(), gomock.Any(), uint64(30)).Return("", "", parentOne, nil).Times(1)
+	eng.EXPECT().GetRelationById(gomock.Any(), gomock.Any(), uint64(40)).Return("", "", parentTwo, nil).Times(1)
+
+	getConstraintDef := gostub.Stub(&GetConstraintDef, func(_ context.Context, rel engine.Relation) (*engine.ConstraintDef, error) {
+		switch rel {
+		case childUpdated:
+			return childUpdatedConstraint, nil
+		case childUnchanged:
+			return childUnchangedConstraint, nil
+		case parentOne:
+			return parentOneConstraint, nil
+		case parentTwo:
+			return parentTwoConstraint, nil
+		default:
+			t.Fatalf("unexpected relation passed to GetConstraintDef")
+			return nil, nil
+		}
+	})
+	defer getConstraintDef.Reset()
+
+	c := NewCompile("test", "test", "alter table child", "", "", eng, proc, nil, false, nil, time.Now())
+	require.NoError(t, reconcileAlterCopyChildForeignKeyReferences(c, nil, []uint64{10, 10, 0, 20}, 1, 2))
+	require.NoError(t, reconcileAlterCopyParentForeignKeyReferences(c, []*plan2.ForeignKeyDef{
+		{ForeignTbl: 30},
+		{ForeignTbl: 30},
+		{ForeignTbl: 0},
+		{ForeignTbl: 40},
+	}, 1, 2))
+
+	require.Equal(t, uint64(2), childUpdatedConstraint.Cts[0].(*engine.ForeignKeyDef).Fkeys[0].ForeignTbl)
+	require.Equal(t, uint64(99), childUnchangedConstraint.Cts[0].(*engine.ForeignKeyDef).Fkeys[0].ForeignTbl)
+	require.Equal(t, []uint64{2}, canonicalRefChildTableIDs(parentOneConstraint))
+	require.Equal(t, []uint64{2}, canonicalRefChildTableIDs(parentTwoConstraint))
+	require.ErrorContains(t, reconcileAlterCopyParentForeignKeyReferences(c, []*plan2.ForeignKeyDef{nil}, 1, 2), "nil foreign key definition")
 }
 
 func TestAlterCopyAutoIncrementCleanupDiscardsTrackedReset(t *testing.T) {

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -1621,7 +1621,13 @@ func (s *Scope) CreateTable(c *Compile) error {
 			return err
 		}
 
-		//2. need to append TableId to parent's TableDef.RefChildTbls
+		//2. append the child table ID to each distinct parent's RefChildTbls.
+		// A table can define several foreign keys to one parent. Updating that
+		// parent once per foreign key repeatedly rewrites its whole constraint
+		// definition, while one child-table ID is sufficient for the relation.
+		parentRelations := make([]engine.Relation, 0, len(fkTables))
+		hasSelfReference := false
+		ignoreForeignKey, _ := c.proc.Ctx.Value(defines.IgnoreForeignKey{}).(bool)
 		for i, fkTableName := range fkTables {
 			fkDbName := fkDbs[i]
 			if session != nil {
@@ -1631,17 +1637,11 @@ func (s *Scope) CreateTable(c *Compile) error {
 			}
 			fkey := qry.GetTableDef().Fkeys[i]
 			if fkey.ForeignTbl == 0 {
-				//fk self refer
-				//add current table to parent's children table
-				err = AddChildTblIdToParentTable(c.proc.Ctx, newRelation, 0)
-				if err != nil {
-					c.proc.Info(c.proc.Ctx, "createTable",
-						zap.String("databaseName", c.db),
-						zap.String("tableName", qry.GetTableDef().GetName()),
-						zap.Error(err),
-					)
-					return err
-				}
+				// A self-reference is represented by the sentinel table ID 0.
+				hasSelfReference = true
+				continue
+			}
+			if ignoreForeignKey {
 				continue
 			}
 			fkDbSource, err := c.e.Database(c.proc.Ctx, fkDbName, c.proc.GetTxnOperator())
@@ -1662,8 +1662,11 @@ func (s *Scope) CreateTable(c *Compile) error {
 				)
 				return err
 			}
-			//add current table to parent's children table
-			err = AddChildTblIdToParentTable(c.proc.Ctx, fkRelation, tblId)
+			parentRelations = append(parentRelations, fkRelation)
+		}
+
+		if hasSelfReference {
+			err = AddChildTblIdToParentTable(c.proc.Ctx, newRelation, 0)
 			if err != nil {
 				c.proc.Info(c.proc.Ctx, "createTable",
 					zap.String("databaseName", c.db),
@@ -1672,6 +1675,15 @@ func (s *Scope) CreateTable(c *Compile) error {
 				)
 				return err
 			}
+		}
+
+		if err = addChildTableIDToDistinctParents(c.proc.Ctx, parentRelations, tblId); err != nil {
+			c.proc.Info(c.proc.Ctx, "createTable",
+				zap.String("databaseName", c.db),
+				zap.String("tableName", qry.GetTableDef().GetName()),
+				zap.Error(err),
+			)
+			return err
 		}
 	}
 
@@ -3062,6 +3074,25 @@ func AddChildTblIdToParentTable(ctx context.Context, fkRelation engine.Relation,
 	}
 	addRefChildTableIDs(oldCt, []uint64{tblId})
 	return fkRelation.UpdateConstraint(ctx, oldCt)
+}
+
+func addChildTableIDToDistinctParents(
+	ctx context.Context,
+	parentRelations []engine.Relation,
+	childTableID uint64,
+) error {
+	updatedParents := make(map[uint64]struct{}, len(parentRelations))
+	for _, parentRelation := range parentRelations {
+		parentTableID := parentRelation.GetTableID(ctx)
+		if _, alreadyUpdated := updatedParents[parentTableID]; alreadyUpdated {
+			continue
+		}
+		if err := AddChildTblIdToParentTable(ctx, parentRelation, childTableID); err != nil {
+			return err
+		}
+		updatedParents[parentTableID] = struct{}{}
+	}
+	return nil
 }
 
 func canonicalRefChildTableIDs(constraintDef *engine.ConstraintDef) []uint64 {

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -1821,6 +1821,47 @@ func TestRemoveFkeysRelationshipsSkipsDeletedParentTableIds(t *testing.T) {
 	require.NoError(t, s.removeFkeysRelationships(c, "acc_test02"))
 }
 
+func TestAddChildTableIDToDistinctParents(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	parentOne := mock_frontend.NewMockRelation(ctrl)
+	duplicateParentOne := mock_frontend.NewMockRelation(ctrl)
+	parentTwo := mock_frontend.NewMockRelation(ctrl)
+	parentOne.EXPECT().GetTableID(gomock.Any()).Return(uint64(10)).Times(1)
+	duplicateParentOne.EXPECT().GetTableID(gomock.Any()).Return(uint64(10)).Times(1)
+	parentTwo.EXPECT().GetTableID(gomock.Any()).Return(uint64(20)).Times(1)
+
+	constraintFor := func() *engine.ConstraintDef {
+		return &engine.ConstraintDef{Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{1}},
+		}}
+	}
+	getConstraintDef := gostub.Stub(&GetConstraintDef, func(_ context.Context, relation engine.Relation) (*engine.ConstraintDef, error) {
+		switch relation {
+		case parentOne, parentTwo:
+			return constraintFor(), nil
+		default:
+			t.Fatalf("unexpected parent relation")
+			return nil, nil
+		}
+	})
+	defer getConstraintDef.Reset()
+
+	assertRefChild := func(_ context.Context, constraint *engine.ConstraintDef) error {
+		require.Equal(t, []uint64{1, 77}, canonicalRefChildTableIDs(constraint))
+		return nil
+	}
+	parentOne.EXPECT().UpdateConstraint(gomock.Any(), gomock.Any()).DoAndReturn(assertRefChild).Times(1)
+	parentTwo.EXPECT().UpdateConstraint(gomock.Any(), gomock.Any()).DoAndReturn(assertRefChild).Times(1)
+
+	require.NoError(t, addChildTableIDToDistinctParents(
+		context.Background(),
+		[]engine.Relation{parentOne, duplicateParentOne, parentTwo},
+		77,
+	))
+}
+
 func TestMissingTablePredicates(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -729,7 +729,10 @@ func isInplaceChangeColumn(
 	clause *tree.AlterTableChangeColumnClause,
 	tableDef *TableDef,
 ) (ok bool, err error) {
-	if clause.OldColumnName.ColName() != clause.NewColumn.Name.ColName() {
+	// CHANGE keeps the original spelling for catalog metadata. A case-only
+	// rename is therefore not equivalent to MODIFY when identifiers compare
+	// case-insensitively: it must use COPY to update foreign-key catalog rows.
+	if clause.OldColumnName.ColNameOrigin() != clause.NewColumn.Name.ColNameOrigin() {
 		return false, nil
 	}
 	return isInplaceColumnDefinition(ctx, clause.NewColumn, clause.Position, tableDef)

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -629,6 +629,14 @@ Loop:
 			}
 		case *tree.AlterTableChangeColumnClause:
 			algorithm = plan.AlterTable_COPY
+			var ok bool
+			ok, err = isInplaceChangeColumn(ctx, option, tableDef)
+			if err != nil {
+				return
+			}
+			if ok {
+				algorithm = plan.AlterTable_INPLACE
+			}
 		case *tree.AlterTableRenameColumnClause:
 			requiresRebuild, err := renameColumnRequiresPluginIndexRebuild(tableDef, option.OldColumnName.ColName())
 			if err != nil {
@@ -713,14 +721,34 @@ func isInplaceModifyColumn(
 	clause *tree.AlterTableModifyColumnClause,
 	tableDef *TableDef,
 ) (ok bool, err error) {
-	oCol := FindColumn(tableDef.Cols, clause.NewColumn.Name.ColName())
+	return isInplaceColumnDefinition(ctx, clause.NewColumn, clause.Position, tableDef)
+}
+
+func isInplaceChangeColumn(
+	ctx context.Context,
+	clause *tree.AlterTableChangeColumnClause,
+	tableDef *TableDef,
+) (ok bool, err error) {
+	if clause.OldColumnName.ColName() != clause.NewColumn.Name.ColName() {
+		return false, nil
+	}
+	return isInplaceColumnDefinition(ctx, clause.NewColumn, clause.Position, tableDef)
+}
+
+func isInplaceColumnDefinition(
+	ctx context.Context,
+	column *tree.ColumnTableDef,
+	position *tree.ColumnPosition,
+	tableDef *TableDef,
+) (ok bool, err error) {
+	oCol := FindColumn(tableDef.Cols, column.Name.ColName())
 	if oCol == nil {
 		err = moerr.NewBadFieldError(
-			ctx, clause.NewColumn.Name.ColNameOrigin(), tableDef.Name)
+			ctx, column.Name.ColNameOrigin(), tableDef.Name)
 		return
 	}
 
-	ok, err = positionMatched(ctx, clause.Position, tableDef, oCol)
+	ok, err = positionMatched(ctx, position, tableDef, oCol)
 	if err != nil {
 		return
 	}
@@ -728,7 +756,7 @@ func isInplaceModifyColumn(
 		return
 	}
 
-	ok, err = storageAgnosticType(ctx, clause.NewColumn, oCol)
+	ok, err = storageAgnosticType(ctx, column, oCol)
 	if err != nil {
 		return
 	}
@@ -736,7 +764,7 @@ func isInplaceModifyColumn(
 		return
 	}
 
-	ok, err = storageAgnosticAttrs(ctx, clause.NewColumn, oCol)
+	ok, err = storageAgnosticAttrs(ctx, column, oCol)
 	if err != nil {
 		return
 	}
@@ -785,30 +813,21 @@ func storageAgnosticType(
 
 	oTy := oCol.Typ
 
-	if oTy.Id != nTy.Id {
+	if oTy.Id != nTy.Id ||
+		oTy.Scale != nTy.Scale ||
+		oTy.Enumvalues != nTy.Enumvalues ||
+		oTy.AutoIncr != nTy.AutoIncr {
 		return
 	}
 
-	if nTy.Id != int32(types.T_varchar) && nTy.Id != int32(types.T_char) {
+	if nTy.Id == int32(types.T_varchar) || nTy.Id == int32(types.T_char) {
+		ok = oTy.Width <= nTy.Width
 		return
 	}
 
-	// leave autoInrement check to storage agnostic attrs because the autoInrement
-	// in nTy should be determined by nCol.Attributes
-
-	scaleMatch := oTy.Scale == nTy.Scale
-	enumMatch := oTy.Enumvalues == nTy.Enumvalues
-
-	if !scaleMatch || !enumMatch {
-		return
-	}
-
-	widthIncrease := oTy.Width <= nTy.Width
-	if !widthIncrease {
-		return
-	}
-
-	ok = true
+	// For every other type, only a byte-for-byte identical storage layout can
+	// avoid a COPY. Attribute changes are checked separately below.
+	ok = oTy.Width == nTy.Width
 	return
 }
 

--- a/pkg/sql/plan/build_alter_table_test.go
+++ b/pkg/sql/plan/build_alter_table_test.go
@@ -120,6 +120,84 @@ func TestAlterTable1(t *testing.T) {
 	outPutPlan(logicPlan, true, t)
 }
 
+func TestSameNameChangeColumnUsesInplaceAlter(t *testing.T) {
+	mock := newMetadataOnlyChangeColumnOptimizer()
+	const sql = `ALTER TABLE metadata_only CHANGE v v INT NULL COMMENT 'metadata only';`
+	logicPlan, err := buildSingleStmt(
+		mock,
+		t,
+		sql,
+	)
+	require.NoError(t, err)
+
+	alter := logicPlan.GetDdl().GetAlterTable()
+	require.Equal(t, plan.AlterTable_INPLACE, alter.AlgorithmType)
+	require.NotNil(t, alter.CopyTableDef)
+	require.Equal(t, "metadata only", FindColumn(alter.CopyTableDef.Cols, "v").Comment)
+	require.Empty(t, FindColumn(mock.ctxt.tables["metadata_only"].Cols, "v").Comment)
+	require.NotNil(t, alter.Actions[len(alter.Actions)-1].GetAlterReplaceDef())
+}
+
+func TestRenameChangeColumnStillUsesCopyAlter(t *testing.T) {
+	mock := newMetadataOnlyChangeColumnOptimizer()
+	logicPlan, err := buildSingleStmt(
+		mock,
+		t,
+		`ALTER TABLE metadata_only CHANGE v renamed_v INT;`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, plan.AlterTable_COPY, logicPlan.GetDdl().GetAlterTable().AlgorithmType)
+}
+
+func newMetadataOnlyChangeColumnOptimizer() *MockOptimizer {
+	mock := NewMockOptimizer(false)
+	mock.ctxt.objects["metadata_only"] = &ObjectRef{
+		SchemaName: "tpch",
+		ObjName:    "metadata_only",
+	}
+	mock.ctxt.tables["metadata_only"] = &TableDef{
+		DbName:    "tpch",
+		TblId:     987654,
+		Name:      "metadata_only",
+		TableType: catalog.SystemOrdinaryRel,
+		Cols: []*ColDef{
+			{
+				ColId:      1,
+				Name:       "id",
+				OriginName: "id",
+				Primary:    true,
+				Typ: plan.Type{
+					Id:          int32(types.T_int32),
+					NotNullable: true,
+					Width:       32,
+					Scale:       -1,
+				},
+				Default: &plan.Default{NullAbility: false},
+			},
+			{
+				ColId:      2,
+				Name:       "v",
+				OriginName: "v",
+				Typ:        plan.Type{Id: int32(types.T_int32), Width: 32, Scale: -1},
+				Default:    &plan.Default{NullAbility: true},
+			},
+		},
+		Name2ColIndex: map[string]int32{"id": 0, "v": 1},
+		Pkey: &plan.PrimaryKeyDef{
+			PkeyColName: "id",
+			Cols:        []uint64{1},
+			Names:       []string{"id"},
+		},
+		Indexes: []*plan.IndexDef{{
+			IndexName:      "idx_v",
+			Parts:          []string{"v"},
+			IndexTableName: "__mo_index_metadata_only_v",
+			TableExist:     true,
+		}},
+	}
+	return mock
+}
+
 func TestAlterTableAddColumns(t *testing.T) {
 	mock := NewMockOptimizer(false)
 	// CREATE TABLE t1 (a INTEGER, b CHAR(10));

--- a/pkg/sql/plan/build_alter_table_test.go
+++ b/pkg/sql/plan/build_alter_table_test.go
@@ -149,6 +149,24 @@ func TestRenameChangeColumnStillUsesCopyAlter(t *testing.T) {
 	require.Equal(t, plan.AlterTable_COPY, logicPlan.GetDdl().GetAlterTable().AlgorithmType)
 }
 
+func TestCaseOnlyChangeColumnUsesCopyAlterAndUpdatesForeignKeyCatalog(t *testing.T) {
+	mock := newMetadataOnlyChangeColumnOptimizer()
+	logicPlan, err := buildSingleStmt(
+		mock,
+		t,
+		`ALTER TABLE metadata_only CHANGE v V INT;`,
+	)
+	require.NoError(t, err)
+
+	alter := logicPlan.GetDdl().GetAlterTable()
+	require.Equal(t, plan.AlterTable_COPY, alter.AlgorithmType)
+	require.Equal(t, "V", FindColumn(alter.CopyTableDef.Cols, "v").OriginName)
+	// These update the child-side column_name and parent-side refer_column_name
+	// entries respectively, so either side of an FK relation retains the new
+	// spelling after the COPY replacement.
+	require.Equal(t, getSqlForRenameColumn("tpch", "metadata_only", "v", "V"), alter.UpdateFkSqls)
+}
+
 func newMetadataOnlyChangeColumnOptimizer() *MockOptimizer {
 	mock := NewMockOptimizer(false)
 	mock.ctxt.objects["metadata_only"] = &ObjectRef{

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -4512,6 +4512,32 @@ func buildAlterTableInplace(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, 
 			if err != nil {
 				return nil, err
 			}
+		case *tree.AlterTableChangeColumnClause:
+			// A same-name CHANGE with an unchanged storage layout has the same
+			// execution semantics as MODIFY, but historically took the COPY path.
+			ok, _ := isInplaceChangeColumn(ctx.GetContext(), opt, tableDef)
+			if !ok {
+				return nil, moerr.NewInvalidInputf(
+					ctx.GetContext(),
+					"failed inplace check: %s",
+					formatTreeNode(opt),
+				)
+			}
+
+			if alterTable.CopyTableDef == nil {
+				alterTable.CopyTableDef = DeepCopyTableDef(tableDef, true)
+			}
+
+			_, err := updateNewColumnInTableDef(
+				ctx,
+				alterTable.CopyTableDef,
+				FindColumn(alterTable.CopyTableDef.Cols, opt.OldColumnName.ColName()),
+				opt.NewColumn,
+				opt.Position,
+			)
+			if err != nil {
+				return nil, err
+			}
 		case *tree.AlterTableRenameColumnClause:
 			if err := checkTableType(ctx.GetContext(), tableDef, ""); err != nil {
 				return nil, err

--- a/pkg/vm/engine/issue26465_benchmark_test.go
+++ b/pkg/vm/engine/issue26465_benchmark_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+)
+
+const (
+	issue26465DepartmentIndexes   = 768
+	issue26465DepartmentRefChilds = 349
+	issue26465DepartmentBytes     = 133622
+
+	issue26465UserIndexes   = 732
+	issue26465UserFKeys     = 349
+	issue26465UserRefChilds = 480
+	issue26465UserBytes     = 180356
+
+	issue26465CandidateIndexes = 3
+	issue26465CandidateFKeys   = 702
+	issue26465CandidateBytes   = 146242
+
+	// A constraint update serializes the complete definition in
+	// UpdateConstraint, AlterTable, and txnDatabase.createWithID.
+	issue26465MarshalsPerConstraintUpdate = 3
+)
+
+var issue26465BenchmarkSink int
+
+type issue26465QAConstraintFixture struct {
+	departments *ConstraintDef
+	users       *ConstraintDef
+	candidates  *ConstraintDef
+}
+
+func TestIssue26465QAConstraintFixture(t *testing.T) {
+	fixture := newIssue26465QAConstraintFixture()
+
+	assertIssue26465ConstraintShape(
+		t,
+		fixture.departments,
+		issue26465DepartmentIndexes,
+		0,
+		issue26465DepartmentRefChilds,
+		issue26465DepartmentBytes,
+	)
+	assertIssue26465ConstraintShape(
+		t,
+		fixture.users,
+		issue26465UserIndexes,
+		issue26465UserFKeys,
+		issue26465UserRefChilds,
+		issue26465UserBytes,
+	)
+	assertIssue26465ConstraintShape(
+		t,
+		fixture.candidates,
+		issue26465CandidateIndexes,
+		issue26465CandidateFKeys,
+		0,
+		issue26465CandidateBytes,
+	)
+}
+
+// BenchmarkIssue26465QAConstraintRewrite models the allocation hot path from
+// QA's 2026-08-07 allocation profile. It deliberately uses the decoded QA
+// cardinalities and constraint-blob sizes, while keeping the fixture in-memory
+// and deterministic. The observed-loop cases describe QA's legacy fan-out;
+// the bounded cases are the acceptance target for the reconciliation fix.
+//
+// Run manually with:
+// go test -run '^$' -bench '^BenchmarkIssue26465QAConstraintRewrite$' -benchmem -benchtime=1x ./pkg/vm/engine
+func BenchmarkIssue26465QAConstraintRewrite(b *testing.B) {
+	fixture := newIssue26465QAConstraintFixture()
+
+	// A no-op COPY ALTER on departments visits 349 ref-child entries. QA had
+	// one current users table and 348 historical entries; users is used as the
+	// measured current constraint size for each rewrite.
+	benchmarkIssue26465ConstraintRewrite(
+		b,
+		"departments_copy/observed_349_users_rewrites",
+		fixture.users,
+		issue26465DepartmentRefChilds,
+	)
+	benchmarkIssue26465ConstraintRewrite(
+		b,
+		"departments_copy/bounded_one_users_rewrite",
+		fixture.users,
+		1,
+	)
+
+	// A COPY ALTER on users visits each of its 349 FKs even though every FK
+	// references the same departments relation.
+	benchmarkIssue26465ConstraintRewrite(
+		b,
+		"users_copy/observed_349_departments_rewrites",
+		fixture.departments,
+		issue26465UserFKeys,
+	)
+	benchmarkIssue26465ConstraintRewrite(
+		b,
+		"users_copy/bounded_one_departments_rewrite",
+		fixture.departments,
+		1,
+	)
+}
+
+func benchmarkIssue26465ConstraintRewrite(
+	b *testing.B,
+	name string,
+	constraint *ConstraintDef,
+	rewrites int,
+) {
+	b.Run(name, func(b *testing.B) {
+		encodedSize := issue26465ConstraintSize(constraint)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			for range rewrites {
+				for range issue26465MarshalsPerConstraintUpdate {
+					encoded, err := constraint.MarshalBinary()
+					if err != nil {
+						b.Fatal(err)
+					}
+					issue26465BenchmarkSink ^= len(encoded)
+				}
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(rewrites), "constraint-updates/op")
+		b.ReportMetric(
+			float64(rewrites*issue26465MarshalsPerConstraintUpdate*encodedSize),
+			"encoded-B/op",
+		)
+	})
+}
+
+func newIssue26465QAConstraintFixture() issue26465QAConstraintFixture {
+	departments := issue26465Constraint(
+		"departments",
+		issue26465DepartmentIndexes,
+		nil,
+		issue26465RefChildIDs(issue26465DepartmentRefChilds, 200),
+	)
+	issue26465PadConstraint(departments, issue26465DepartmentBytes)
+
+	users := issue26465Constraint(
+		"users",
+		issue26465UserIndexes,
+		issue26465ForeignKeys(issue26465UserFKeys, []uint64{100}),
+		issue26465RefChildIDs(issue26465UserRefChilds, 1000),
+	)
+	issue26465PadConstraint(users, issue26465UserBytes)
+
+	candidates := issue26465Constraint(
+		"candidates",
+		issue26465CandidateIndexes,
+		issue26465ForeignKeys(issue26465CandidateFKeys, []uint64{100, 101, 102}),
+		nil,
+	)
+	issue26465PadConstraint(candidates, issue26465CandidateBytes)
+
+	return issue26465QAConstraintFixture{
+		departments: departments,
+		users:       users,
+		candidates:  candidates,
+	}
+}
+
+func issue26465Constraint(
+	table string,
+	indexCount int,
+	fkeys []*plan.ForeignKeyDef,
+	refChildIDs []uint64,
+) *ConstraintDef {
+	indexes := make([]*plan.IndexDef, 0, indexCount)
+	for i := range indexCount {
+		indexes = append(indexes, &plan.IndexDef{
+			IdxId:          fmt.Sprintf("%s-index-id-%04d", table, i),
+			IndexName:      fmt.Sprintf("%s_index_%04d", table, i),
+			Parts:          []string{"id"},
+			IndexTableName: fmt.Sprintf("__mo_index_%s_%04d", table, i),
+			TableExist:     true,
+			Visible:        true,
+		})
+	}
+
+	constraints := []Constraint{
+		&IndexDef{Indexes: indexes},
+		&PrimaryKeyDef{Pkey: &plan.PrimaryKeyDef{
+			PkeyColId:   1,
+			PkeyColName: "id",
+			Names:       []string{"id"},
+		}},
+	}
+	if len(fkeys) > 0 {
+		constraints = append(constraints, &ForeignKeyDef{Fkeys: fkeys})
+	}
+	if len(refChildIDs) > 0 {
+		constraints = append(constraints, &RefChildTableDef{Tables: refChildIDs})
+	}
+	return &ConstraintDef{Cts: constraints}
+}
+
+func issue26465ForeignKeys(count int, parents []uint64) []*plan.ForeignKeyDef {
+	fkeys := make([]*plan.ForeignKeyDef, 0, count)
+	for i := range count {
+		fkeys = append(fkeys, &plan.ForeignKeyDef{
+			Name:        fmt.Sprintf("qa-fk-%04d", i),
+			Cols:        []uint64{2},
+			ForeignTbl:  parents[i%len(parents)],
+			ForeignCols: []uint64{1},
+			OnDelete:    plan.ForeignKeyDef_SET_NULL,
+			OnUpdate:    plan.ForeignKeyDef_CASCADE,
+		})
+	}
+	return fkeys
+}
+
+func issue26465RefChildIDs(count int, first uint64) []uint64 {
+	ids := make([]uint64, count)
+	for i := range ids {
+		ids[i] = first + uint64(i)
+	}
+	return ids
+}
+
+func issue26465PadConstraint(constraint *ConstraintDef, expectedSize int) {
+	indexDef := constraint.Cts[0].(*IndexDef)
+	if len(indexDef.Indexes) == 0 {
+		panic("QA fixture requires an index to hold deterministic padding")
+	}
+
+	padding := expectedSize - issue26465ConstraintSize(constraint)
+	for range 8 {
+		if padding < 0 {
+			panic("QA fixture is larger than the observed constraint blob")
+		}
+		indexDef.Indexes[0].Comment = strings.Repeat("x", padding)
+		actualSize := issue26465ConstraintSize(constraint)
+		if actualSize == expectedSize {
+			return
+		}
+		padding += expectedSize - actualSize
+	}
+	panic("cannot calibrate QA fixture constraint size")
+}
+
+func issue26465ConstraintSize(constraint *ConstraintDef) int {
+	encoded, err := constraint.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return len(encoded)
+}
+
+func assertIssue26465ConstraintShape(
+	t *testing.T,
+	constraint *ConstraintDef,
+	wantIndexes int,
+	wantFKeys int,
+	wantRefChilds int,
+	wantBytes int,
+) {
+	t.Helper()
+
+	var indexes, fkeys, refChildren int
+	for _, current := range constraint.Cts {
+		switch current := current.(type) {
+		case *IndexDef:
+			indexes += len(current.Indexes)
+		case *ForeignKeyDef:
+			fkeys += len(current.Fkeys)
+		case *RefChildTableDef:
+			refChildren += len(current.Tables)
+		}
+	}
+	if indexes != wantIndexes || fkeys != wantFKeys || refChildren != wantRefChilds {
+		t.Fatalf(
+			"unexpected QA fixture cardinality: indexes=%d fkeys=%d ref-children=%d",
+			indexes,
+			fkeys,
+			refChildren,
+		)
+	}
+	if actualBytes := issue26465ConstraintSize(constraint); actualBytes != wantBytes {
+		t.Fatalf("unexpected QA fixture size: got %d, want %d", actualBytes, wantBytes)
+	}
+}

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -531,90 +531,107 @@ const (
 )
 
 func (def *ConstraintDef) MarshalBinary() (data []byte, err error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
+	data = make([]byte, 0, def.marshalSize())
 	for _, ct := range def.Cts {
 		switch def := ct.(type) {
 		case *IndexDef:
-			if err := binary.Write(buf, binary.BigEndian, Index); err != nil {
-				return nil, err
-			}
-			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Indexes))); err != nil {
-				return nil, err
-			}
-
+			data = append(data, byte(Index))
+			data = appendConstraintUint64(data, uint64(len(def.Indexes)))
 			for _, indexdef := range def.Indexes {
-				bytes, err := indexdef.Marshal()
+				data, err = appendConstraintProto(data, indexdef)
 				if err != nil {
 					return nil, err
 				}
-				if err := binary.Write(buf, binary.BigEndian, uint64(len(bytes))); err != nil {
-					return nil, err
-				}
-				buf.Write(bytes)
 			}
 		case *RefChildTableDef:
-			if err := binary.Write(buf, binary.BigEndian, RefChildTable); err != nil {
-				return nil, err
-			}
-			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Tables))); err != nil {
-				return nil, err
-			}
+			data = append(data, byte(RefChildTable))
+			data = appendConstraintUint64(data, uint64(len(def.Tables)))
 			for _, tblId := range def.Tables {
-				if err := binary.Write(buf, binary.BigEndian, tblId); err != nil {
-					return nil, err
-				}
+				data = appendConstraintUint64(data, tblId)
 			}
 
 		case *ForeignKeyDef:
-			if err := binary.Write(buf, binary.BigEndian, ForeignKey); err != nil {
-				return nil, err
-			}
-			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Fkeys))); err != nil {
-				return nil, err
-			}
+			data = append(data, byte(ForeignKey))
+			data = appendConstraintUint64(data, uint64(len(def.Fkeys)))
 			for _, fk := range def.Fkeys {
-				bytes, err := fk.Marshal()
+				data, err = appendConstraintProto(data, fk)
 				if err != nil {
 					return nil, err
 				}
-
-				if err := binary.Write(buf, binary.BigEndian, uint64(len(bytes))); err != nil {
-					return nil, err
-				}
-				buf.Write(bytes)
 			}
 		case *PrimaryKeyDef:
-			if err := binary.Write(buf, binary.BigEndian, PrimaryKey); err != nil {
-				return nil, err
-			}
-			bytes, err := def.Pkey.Marshal()
+			data = append(data, byte(PrimaryKey))
+			data, err = appendConstraintProto(data, def.Pkey)
 			if err != nil {
 				return nil, err
 			}
-			if err := binary.Write(buf, binary.BigEndian, uint64((len(bytes)))); err != nil {
-				return nil, err
-			}
-			buf.Write(bytes)
 		case *StreamConfigsDef:
-			if err := binary.Write(buf, binary.BigEndian, StreamConfig); err != nil {
-				return nil, err
-			}
-			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Configs))); err != nil {
-				return nil, err
-			}
+			data = append(data, byte(StreamConfig))
+			data = appendConstraintUint64(data, uint64(len(def.Configs)))
 			for _, c := range def.Configs {
-				bytes, err := c.Marshal()
+				data, err = appendConstraintProto(data, c)
 				if err != nil {
 					return nil, err
 				}
-				if err := binary.Write(buf, binary.BigEndian, uint64(len(bytes))); err != nil {
-					return nil, err
-				}
-				buf.Write(bytes)
 			}
 		}
 	}
-	return buf.Bytes(), nil
+	return data, nil
+}
+
+type constraintProtoMarshaler interface {
+	ProtoSize() int
+	MarshalTo([]byte) (int, error)
+}
+
+func (def *ConstraintDef) marshalSize() int {
+	size := 0
+	for _, ct := range def.Cts {
+		switch def := ct.(type) {
+		case *IndexDef:
+			size += 1 + 8
+			for _, indexdef := range def.Indexes {
+				size += 8 + indexdef.ProtoSize()
+			}
+		case *RefChildTableDef:
+			size += 1 + 8 + 8*len(def.Tables)
+		case *ForeignKeyDef:
+			size += 1 + 8
+			for _, fk := range def.Fkeys {
+				size += 8 + fk.ProtoSize()
+			}
+		case *PrimaryKeyDef:
+			size += 1 + 8 + def.Pkey.ProtoSize()
+		case *StreamConfigsDef:
+			size += 1 + 8
+			for _, config := range def.Configs {
+				size += 8 + config.ProtoSize()
+			}
+		}
+	}
+	return size
+}
+
+func appendConstraintUint64(data []byte, value uint64) []byte {
+	start := len(data)
+	data = append(data, 0, 0, 0, 0, 0, 0, 0, 0)
+	binary.BigEndian.PutUint64(data[start:], value)
+	return data
+}
+
+func appendConstraintProto(data []byte, message constraintProtoMarshaler) ([]byte, error) {
+	size := message.ProtoSize()
+	data = appendConstraintUint64(data, uint64(size))
+	start := len(data)
+	data = data[:start+size]
+	written, err := message.MarshalTo(data[start:])
+	if err != nil {
+		return nil, err
+	}
+	if written != size {
+		return nil, moerr.NewInternalErrorNoCtx("constraint protobuf size mismatch")
+	}
+	return data, nil
 }
 
 func (def *ConstraintDef) UnmarshalBinary(data []byte) error {

--- a/pkg/vm/engine/types_test.go
+++ b/pkg/vm/engine/types_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstraintDefMarshalBinaryWireCompatibility(t *testing.T) {
+	constraint := &ConstraintDef{Cts: []Constraint{
+		&IndexDef{Indexes: []*plan.IndexDef{{
+			IdxId:          "idx-id",
+			IndexName:      "idx_name",
+			Parts:          []string{"id", "name"},
+			IndexTableName: "__mo_index_idx_name",
+			Unique:         true,
+			TableExist:     true,
+			Visible:        true,
+		}}},
+		&RefChildTableDef{Tables: []uint64{7, 11}},
+		&ForeignKeyDef{Fkeys: []*plan.ForeignKeyDef{{
+			Name:        "fk_parent",
+			Cols:        []uint64{2},
+			ForeignTbl:  42,
+			ForeignCols: []uint64{1},
+			OnDelete:    plan.ForeignKeyDef_SET_NULL,
+			OnUpdate:    plan.ForeignKeyDef_CASCADE,
+		}}},
+		&PrimaryKeyDef{Pkey: &plan.PrimaryKeyDef{
+			PkeyColId:   1,
+			PkeyColName: "id",
+			Names:       []string{"id"},
+		}},
+		&StreamConfigsDef{Configs: []*plan.Property{{Key: "k", Value: "v"}}},
+	}}
+
+	want, err := legacyConstraintDefMarshalBinary(constraint)
+	require.NoError(t, err)
+
+	got, err := constraint.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	decoded := new(ConstraintDef)
+	require.NoError(t, decoded.UnmarshalBinary(got))
+	require.Len(t, decoded.Cts, len(constraint.Cts))
+}
+
+// legacyConstraintDefMarshalBinary is kept only as a byte-for-byte oracle for
+// the allocation-reduced encoder above.
+func legacyConstraintDefMarshalBinary(def *ConstraintDef) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	for _, ct := range def.Cts {
+		switch def := ct.(type) {
+		case *IndexDef:
+			buf.WriteByte(byte(Index))
+			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Indexes))); err != nil {
+				return nil, err
+			}
+			for _, indexDef := range def.Indexes {
+				data, err := indexDef.Marshal()
+				if err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.BigEndian, uint64(len(data))); err != nil {
+					return nil, err
+				}
+				if _, err := buf.Write(data); err != nil {
+					return nil, err
+				}
+			}
+		case *RefChildTableDef:
+			buf.WriteByte(byte(RefChildTable))
+			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Tables))); err != nil {
+				return nil, err
+			}
+			for _, tableID := range def.Tables {
+				if err := binary.Write(buf, binary.BigEndian, tableID); err != nil {
+					return nil, err
+				}
+			}
+		case *ForeignKeyDef:
+			buf.WriteByte(byte(ForeignKey))
+			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Fkeys))); err != nil {
+				return nil, err
+			}
+			for _, foreignKey := range def.Fkeys {
+				data, err := foreignKey.Marshal()
+				if err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.BigEndian, uint64(len(data))); err != nil {
+					return nil, err
+				}
+				if _, err := buf.Write(data); err != nil {
+					return nil, err
+				}
+			}
+		case *PrimaryKeyDef:
+			buf.WriteByte(byte(PrimaryKey))
+			data, err := def.Pkey.Marshal()
+			if err != nil {
+				return nil, err
+			}
+			if err := binary.Write(buf, binary.BigEndian, uint64(len(data))); err != nil {
+				return nil, err
+			}
+			if _, err := buf.Write(data); err != nil {
+				return nil, err
+			}
+		case *StreamConfigsDef:
+			buf.WriteByte(byte(StreamConfig))
+			if err := binary.Write(buf, binary.BigEndian, uint64(len(def.Configs))); err != nil {
+				return nil, err
+			}
+			for _, config := range def.Configs {
+				data, err := config.Marshal()
+				if err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.BigEndian, uint64(len(data))); err != nil {
+					return nil, err
+				}
+				if _, err := buf.Write(data); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}

--- a/test/distributed/cases/foreign_key/issue_26465.result
+++ b/test/distributed/cases/foreign_key/issue_26465.result
@@ -1,0 +1,103 @@
+drop database if exists issue_26465;
+create database issue_26465;
+use issue_26465;
+create table departments (
+id int primary key,
+name varchar(100) not null,
+unique key uk_departments_name (name)
+);
+create table users (
+id int primary key,
+department_id_1 int,
+department_id_2 int,
+department_id_3 int,
+department_id_4 int,
+department_id_5 int,
+department_id_6 int,
+constraint fk_users_department_1 foreign key (department_id_1) references departments(id),
+constraint fk_users_department_2 foreign key (department_id_2) references departments(id),
+constraint fk_users_department_3 foreign key (department_id_3) references departments(id),
+constraint fk_users_department_4 foreign key (department_id_4) references departments(id),
+constraint fk_users_department_5 foreign key (department_id_5) references departments(id),
+constraint fk_users_department_6 foreign key (department_id_6) references departments(id),
+key idx_users_department_1 (department_id_1),
+key idx_users_department_2 (department_id_2),
+key idx_users_department_3 (department_id_3),
+key idx_users_department_4 (department_id_4),
+key idx_users_department_5 (department_id_5),
+key idx_users_department_6 (department_id_6)
+);
+insert into departments values (1, 'engineering');
+insert into users values (1, 1, 1, 1, 1, 1, 1);
+alter table users change department_id_1 department_id_1 int comment 'primary department';
+alter table users add column copied_child_marker int;
+drop table departments;
+internal error: can not drop table 'departments' referenced by some foreign key constraint
+insert into users (id, department_id_1) values (2, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+insert into users (id, department_id_1) values (2, 1);
+alter table departments change name name varchar(100) not null comment 'department name';
+alter table departments add column copied_parent_marker int;
+insert into users (id, department_id_1) values (3, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+insert into users (id, department_id_1) values (3, 1);
+create table jobs (id int primary key);
+create table talent_pools (id int primary key);
+create table owners (id int primary key);
+insert into jobs values (1);
+insert into talent_pools values (1);
+insert into owners values (1);
+create table candidates (
+id int primary key,
+job_id_1 int,
+job_id_2 int,
+talent_pool_id_1 int,
+talent_pool_id_2 int,
+owner_id_1 int,
+owner_id_2 int,
+constraint fk_candidates_job_1 foreign key (job_id_1) references jobs(id),
+constraint fk_candidates_job_2 foreign key (job_id_2) references jobs(id),
+constraint fk_candidates_talent_pool_1 foreign key (talent_pool_id_1) references talent_pools(id),
+constraint fk_candidates_talent_pool_2 foreign key (talent_pool_id_2) references talent_pools(id),
+constraint fk_candidates_owner_1 foreign key (owner_id_1) references owners(id),
+constraint fk_candidates_owner_2 foreign key (owner_id_2) references owners(id),
+key idx_candidates_job_1 (job_id_1),
+key idx_candidates_job_2 (job_id_2),
+key idx_candidates_talent_pool_1 (talent_pool_id_1),
+key idx_candidates_talent_pool_2 (talent_pool_id_2),
+key idx_candidates_owner_1 (owner_id_1),
+key idx_candidates_owner_2 (owner_id_2)
+);
+insert into candidates values (1, 1, 1, 1, 1, 1, 1);
+alter table candidates change job_id_1 job_id_1 int comment 'primary job';
+alter table candidates add column copied_child_marker int;
+drop table jobs;
+internal error: can not drop table 'jobs' referenced by some foreign key constraint
+insert into candidates (id, job_id_1) values (2, 999);
+internal error: Cannot add or update a child row: a foreign key constraint fails
+insert into candidates (id, job_id_1, talent_pool_id_1, owner_id_1) values (2, 1, 1, 1);
+select count(*) from users;
+➤ count(*)[-5,64,0]  𝄀
+3
+select count(*) from candidates;
+➤ count(*)[-5,64,0]  𝄀
+2
+select count(*) from information_schema.key_column_usage
+where constraint_schema = 'issue_26465'
+and table_name = 'users'
+and referenced_table_name = 'departments';
+➤ count(*)[-5,64,0]  𝄀
+6
+select count(*) from information_schema.key_column_usage
+where constraint_schema = 'issue_26465'
+and table_name = 'candidates'
+and referenced_table_name is not null;
+➤ count(*)[-5,64,0]  𝄀
+6
+drop table candidates;
+drop table users;
+drop table departments;
+drop table jobs;
+drop table talent_pools;
+drop table owners;
+drop database issue_26465;

--- a/test/distributed/cases/foreign_key/issue_26465.result
+++ b/test/distributed/cases/foreign_key/issue_26465.result
@@ -94,6 +94,31 @@ and table_name = 'candidates'
 and referenced_table_name is not null;
 ➤ count(*)[-5,64,0]  𝄀
 6
+create table case_parent (
+id int primary key,
+v int unique
+);
+create table case_child (
+id int primary key,
+v int,
+constraint fk_case_child foreign key (v) references case_parent(v)
+);
+alter table case_child change v V int;
+select column_name, referenced_column_name
+from information_schema.key_column_usage
+where constraint_schema = 'issue_26465'
+and constraint_name = 'fk_case_child';
+➤ column_name[12,64,0]  ¦  referenced_column_name[12,64,0]  𝄀
+V  ¦  v
+alter table case_parent change v V int;
+select column_name, referenced_column_name
+from information_schema.key_column_usage
+where constraint_schema = 'issue_26465'
+and constraint_name = 'fk_case_child';
+➤ column_name[12,64,0]  ¦  referenced_column_name[12,64,0]  𝄀
+V  ¦  V
+drop table case_child;
+drop table case_parent;
 drop table candidates;
 drop table users;
 drop table departments;

--- a/test/distributed/cases/foreign_key/issue_26465.sql
+++ b/test/distributed/cases/foreign_key/issue_26465.sql
@@ -107,6 +107,31 @@ select count(*) from information_schema.key_column_usage
       and table_name = 'candidates'
       and referenced_table_name is not null;
 
+-- A case-only CHANGE is a real rename for the FK catalog, even though the
+-- identifiers compare equal with lower_case_table_names enabled. Check both
+-- the child-side column_name and parent-side refer_column_name metadata.
+create table case_parent (
+    id int primary key,
+    v int unique
+);
+create table case_child (
+    id int primary key,
+    v int,
+    constraint fk_case_child foreign key (v) references case_parent(v)
+);
+alter table case_child change v V int;
+select column_name, referenced_column_name
+    from information_schema.key_column_usage
+    where constraint_schema = 'issue_26465'
+      and constraint_name = 'fk_case_child';
+alter table case_parent change v V int;
+select column_name, referenced_column_name
+    from information_schema.key_column_usage
+    where constraint_schema = 'issue_26465'
+      and constraint_name = 'fk_case_child';
+
+drop table case_child;
+drop table case_parent;
 drop table candidates;
 drop table users;
 drop table departments;

--- a/test/distributed/cases/foreign_key/issue_26465.sql
+++ b/test/distributed/cases/foreign_key/issue_26465.sql
@@ -1,0 +1,116 @@
+-- Issue #26465: ALTER COPY must retain all foreign-key relationships.
+--
+-- The production schema has hundreds of indexes and foreign keys.  Keep this
+-- BVT representative but compact; the exact production cardinalities belong
+-- in the Go benchmark because they would make every normal BVT expensive.
+
+drop database if exists issue_26465;
+create database issue_26465;
+use issue_26465;
+
+create table departments (
+    id int primary key,
+    name varchar(100) not null,
+    unique key uk_departments_name (name)
+);
+
+create table users (
+    id int primary key,
+    department_id_1 int,
+    department_id_2 int,
+    department_id_3 int,
+    department_id_4 int,
+    department_id_5 int,
+    department_id_6 int,
+    constraint fk_users_department_1 foreign key (department_id_1) references departments(id),
+    constraint fk_users_department_2 foreign key (department_id_2) references departments(id),
+    constraint fk_users_department_3 foreign key (department_id_3) references departments(id),
+    constraint fk_users_department_4 foreign key (department_id_4) references departments(id),
+    constraint fk_users_department_5 foreign key (department_id_5) references departments(id),
+    constraint fk_users_department_6 foreign key (department_id_6) references departments(id),
+    key idx_users_department_1 (department_id_1),
+    key idx_users_department_2 (department_id_2),
+    key idx_users_department_3 (department_id_3),
+    key idx_users_department_4 (department_id_4),
+    key idx_users_department_5 (department_id_5),
+    key idx_users_department_6 (department_id_6)
+);
+
+insert into departments values (1, 'engineering');
+insert into users values (1, 1, 1, 1, 1, 1, 1);
+
+-- Same-name CHANGE with only a comment update takes the INPLACE path.
+alter table users change department_id_1 department_id_1 int comment 'primary department';
+
+-- ADD COLUMN takes ALTER COPY.  The copied child must remain registered on its
+-- parent after the temporary table is removed.
+alter table users add column copied_child_marker int;
+--ERROR 3730 (HY000): Cannot drop table 'departments' referenced by a foreign key constraint 'fk_users_department_1' on table 'users'.
+drop table departments;
+--ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails
+insert into users (id, department_id_1) values (2, 999);
+insert into users (id, department_id_1) values (2, 1);
+
+-- The parent also has a large RefChildTbls set in the production schema.
+alter table departments change name name varchar(100) not null comment 'department name';
+alter table departments add column copied_parent_marker int;
+--ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails
+insert into users (id, department_id_1) values (3, 999);
+insert into users (id, department_id_1) values (3, 1);
+
+create table jobs (id int primary key);
+create table talent_pools (id int primary key);
+create table owners (id int primary key);
+insert into jobs values (1);
+insert into talent_pools values (1);
+insert into owners values (1);
+
+create table candidates (
+    id int primary key,
+    job_id_1 int,
+    job_id_2 int,
+    talent_pool_id_1 int,
+    talent_pool_id_2 int,
+    owner_id_1 int,
+    owner_id_2 int,
+    constraint fk_candidates_job_1 foreign key (job_id_1) references jobs(id),
+    constraint fk_candidates_job_2 foreign key (job_id_2) references jobs(id),
+    constraint fk_candidates_talent_pool_1 foreign key (talent_pool_id_1) references talent_pools(id),
+    constraint fk_candidates_talent_pool_2 foreign key (talent_pool_id_2) references talent_pools(id),
+    constraint fk_candidates_owner_1 foreign key (owner_id_1) references owners(id),
+    constraint fk_candidates_owner_2 foreign key (owner_id_2) references owners(id),
+    key idx_candidates_job_1 (job_id_1),
+    key idx_candidates_job_2 (job_id_2),
+    key idx_candidates_talent_pool_1 (talent_pool_id_1),
+    key idx_candidates_talent_pool_2 (talent_pool_id_2),
+    key idx_candidates_owner_1 (owner_id_1),
+    key idx_candidates_owner_2 (owner_id_2)
+);
+
+insert into candidates values (1, 1, 1, 1, 1, 1, 1);
+alter table candidates change job_id_1 job_id_1 int comment 'primary job';
+alter table candidates add column copied_child_marker int;
+--ERROR 3730 (HY000): Cannot drop table 'jobs' referenced by a foreign key constraint 'fk_candidates_job_1' on table 'candidates'.
+drop table jobs;
+--ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails
+insert into candidates (id, job_id_1) values (2, 999);
+insert into candidates (id, job_id_1, talent_pool_id_1, owner_id_1) values (2, 1, 1, 1);
+
+select count(*) from users;
+select count(*) from candidates;
+select count(*) from information_schema.key_column_usage
+    where constraint_schema = 'issue_26465'
+      and table_name = 'users'
+      and referenced_table_name = 'departments';
+select count(*) from information_schema.key_column_usage
+    where constraint_schema = 'issue_26465'
+      and table_name = 'candidates'
+      and referenced_table_name is not null;
+
+drop table candidates;
+drop table users;
+drop table departments;
+drop table jobs;
+drop table talent_pools;
+drop table owners;
+drop database issue_26465;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26465

## What this PR does / why we need it:

QA has tables with hundreds of index definitions and duplicated foreign-key metadata. A logically storage-agnostic same-name `ALTER TABLE ... CHANGE` previously selected ALTER COPY. COPY replaced the table ID, then rewrote full foreign-key/constraint metadata repeatedly: once per duplicate FK or historical ref-child table ID. The resulting allocation is temporary heap allocation, not the on-disk constraint blob itself, but it can be tens of GB for one ALTER.

This PR:

- routes exactly same-spelling, storage-agnostic `CHANGE COLUMN` operations through the existing in-place `ReplaceDef` path;
- keeps case-only `CHANGE COLUMN` renames on COPY, so both foreign-key catalog columns retain their original spelling;
- reconciles COPY foreign-key references once per unique parent/child relationship after the temporary table lifecycle, rather than once per duplicate metadata entry;
- avoids parent ref-child mutations during temporary COPY-table creation and performs one final, exact reconciliation;
- reduces `ConstraintDef.MarshalBinary` intermediate allocations while preserving the encoded wire format;
- adds focused plan/compiler/engine/embed tests, a representative FK BVT, and QA-shape benchmarks.

The BVT intentionally uses a compact multi-FK, multi-parent topology. It now also changes the case of a child FK column and then a parent referenced column, verifying `information_schema.KEY_COLUMN_USAGE` transitions from `V/v` to `V/V`. The production cardinalities are retained in Go benchmarks so regular BVT/CI is not made expensive.

## QA-shape benchmark

Local macOS/arm64 measurements, `-benchmem -benchtime=1x`; B/op is cumulative heap allocation for one ALTER, not retained metadata size.

| Scenario | Before | This PR |
| --- | ---: | ---: |
| `departments`: 768 indexes, 349 ref-child IDs | 5.27s / 1.67GB | 2.78s / 134MB |
| `users`: 732 indexes, 349 FKs to one parent | 20.99s / 84.53GB | 2.69s / 123MB |
| `candidates`: 702 FKs across three parents | 2.69s / 6.22GB | 20.7ms / 12.4MB |

Run with:

```bash
go test -run "^$" -bench "^BenchmarkIssue26465AlterCopyQAShape$" -benchmem -benchtime=1x ./pkg/embed
```

## Validation:

- `go test ./pkg/sql/plan -count=1`
- `go test ./pkg/sql/compile -run "^(TestAddChildTableIDToDistinctParents|TestReconcileAlterCopyForeignKeyReferencesOncePerRelation|TestRewriteForeignKeyReferencesForAlterCopy|TestReconcileRefChildTableIDForAlterCopy)$" -count=1`
- `go test ./pkg/vm/engine -run "^(TestConstraintDefMarshalBinaryWireCompatibility|TestIssue26465QAConstraintFixture)$" -count=1`
- `go test ./pkg/embed -run "^TestIssue26465AlterCopyPreservesParentReference$" -count=1`
- `mo-tester` run of `foreign_key/issue_26465`: 48/48 passed on the rebased head
- `git diff --check`
