### PR TITLE
fix(frontend): use hidden fake pk type for data branch lca probe

### DIFF
--- a/pkg/frontend/data_branch_hashdiff.go
+++ b/pkg/frontend/data_branch_hashdiff.go
@@ -249,10 +249,17 @@ func handleDelsOnLCA(
 		lcaTblDef    = tblStuff.lcaRel.GetTableDef(ctx)
 		targetTblDef = tblStuff.tarRel.GetTableDef(ctx)
 
-		colTypes           = tblStuff.def.colTypes
-		expandedPKColIdxes = tblStuff.def.pkColIdxes
-		snapshotTS         = types.TimestampToTS(snapshot)
+		colTypes        = tblStuff.def.colTypes
+		probePKColIdxes = tblStuff.def.pkColIdxes
+		snapshotTS      = types.TimestampToTS(snapshot)
 	)
+	if tblStuff.def.pkKind == fakeKind {
+		// pkColIdxes contains the visible columns that define a fake PK for
+		// hash-diff matching. The SQL LCA probe joins on the generated hidden
+		// PK instead, so its cast and equality type must come from that hidden
+		// column rather than from the first visible column.
+		probePKColIdxes = []int{tblStuff.def.pkColIdx}
+	}
 	lcaLayout, err := lcaProbeColumnLayout(
 		lcaTblDef, targetTblDef, tblStuff.def.colNames, tblStuff.def.colTypes,
 		tblStuff.def.tarOnlyIdxes, tblStuff.def.lcaColNames,
@@ -288,7 +295,7 @@ func handleDelsOnLCA(
 			// The synthetic hash column is internal and cannot be renamed.
 			pkNames = []string{catalog.FakePrimaryKeyColName}
 		} else {
-			pkNames, err = lcaLayout.columnNamesForTargetIndexes(expandedPKColIdxes)
+			pkNames, err = lcaLayout.columnNamesForTargetIndexes(probePKColIdxes)
 			if err != nil {
 				return nil, err
 			}
@@ -314,7 +321,7 @@ func handleDelsOnLCA(
 				valsBuf.WriteString(fmt.Sprintf("row(%d,", i))
 				for j := range tuple {
 					if err = formatValIntoStringWithFloatCast(
-						ses, tuple[j], colTypes[expandedPKColIdxes[j]], valsBuf, true,
+						ses, tuple[j], colTypes[probePKColIdxes[j]], valsBuf, true,
 					); err != nil {
 						return nil, err
 					}
@@ -339,7 +346,7 @@ func handleDelsOnLCA(
 		} else {
 			// real pk
 			valsBuf.Reset()
-			pkType := colTypes[expandedPKColIdxes[0]]
+			pkType := colTypes[probePKColIdxes[0]]
 			for i := range tBat.Vecs[0].Length() {
 				valsBuf.WriteString(fmt.Sprintf("row(%d,", i))
 				b := tBat.Vecs[0].GetRawBytesAt(i)
@@ -383,11 +390,11 @@ func handleDelsOnLCA(
 		for i := range quotedPKNames {
 			left := fmt.Sprintf("lca.%s", quotedPKNames[i])
 			right := fmt.Sprintf("pks.%s", quotedPKValueAliases[i])
-			if castType, ok := lcaProbeJoinCastType(colTypes[expandedPKColIdxes[i]]); ok {
+			if castType, ok := lcaProbeJoinCastType(colTypes[probePKColIdxes[i]]); ok {
 				right = fmt.Sprintf("cast(%s as %s)", right, castType)
 			}
 			sqlBuf.WriteString(dataBranchSQLKeyEqual(
-				left, right, colTypes[expandedPKColIdxes[i]],
+				left, right, colTypes[probePKColIdxes[i]],
 			))
 			if i != len(quotedPKNames)-1 {
 				sqlBuf.WriteString(" AND ")

--- a/pkg/frontend/data_branch_hashdiff_test.go
+++ b/pkg/frontend/data_branch_hashdiff_test.go
@@ -1867,6 +1867,65 @@ func TestHandleDelsOnLCA_SQLPaths(t *testing.T) {
 		require.ErrorIs(t, err, wantErr)
 	})
 
+	t.Run("fake pk sql builder uses the hidden key type", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		tblStuff := newTestBranchTableStuff(ctrl)
+		tblStuff.lcaRel = mock_frontend.NewMockRelation(ctrl)
+		tblStuff.def.pkKind = fakeKind
+		tblStuff.def.colNames = []string{"f", "note", catalog.FakePrimaryKeyColName}
+		tblStuff.def.colTypes = []types.Type{
+			types.T_float64.ToType(),
+			types.T_varchar.ToType(),
+			types.T_uint64.ToType(),
+		}
+		tblStuff.def.visibleIdxes = []int{0, 1}
+		tblStuff.def.writableIdxes = []int{0, 1}
+		tblStuff.def.pkColIdx = 2
+		tblStuff.def.pkColIdxes = []int{0, 1}
+
+		targetDef := tblStuff.tarRel.GetTableDef(context.Background())
+		targetDef.Cols = []*plan.ColDef{
+			{Name: "f", ColId: 1, Typ: plan.Type{Id: int32(types.T_float64)}},
+			{Name: "note", ColId: 2, Typ: plan.Type{Id: int32(types.T_varchar)}},
+			{Name: catalog.FakePrimaryKeyColName, ColId: 3, Hidden: true, Typ: plan.Type{Id: int32(types.T_uint64)}},
+		}
+		targetDef.Pkey = &plan.PrimaryKeyDef{
+			Names:       []string{catalog.FakePrimaryKeyColName},
+			PkeyColName: catalog.FakePrimaryKeyColName,
+		}
+		lcaDef := &plan.TableDef{
+			DbName: "db1",
+			Name:   "lca_tbl",
+			Cols:   targetDef.Cols,
+			Pkey:   targetDef.Pkey,
+		}
+		tblStuff.lcaRel.(*mock_frontend.MockRelation).EXPECT().GetTableDef(gomock.Any()).Return(lcaDef).AnyTimes()
+		tblStuff.lcaRel.(*mock_frontend.MockRelation).EXPECT().GetTableID(gomock.Any()).Return(uint64(81)).AnyTimes()
+
+		wantErr := moerr.NewInternalErrorNoCtx("stop after sql capture")
+		bh := mock_frontend.NewMockBackgroundExec(ctrl)
+		bh.EXPECT().Exec(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, sql string) error {
+			require.Contains(t, sql,
+				"lca.`__mo_fake_pk_col` = cast(pks.`__mo_data_branch_pk_0` as BIGINT UNSIGNED)")
+			require.NotContains(t, sql, "serial(lca.`__mo_fake_pk_col`)")
+			return wantErr
+		}).Times(1)
+
+		tBat := batch.NewWithSize(1)
+		tBat.Vecs[0] = vector.NewVec(types.T_uint64.ToType())
+		require.NoError(t, vector.AppendFixed(tBat.Vecs[0], uint64(42), false, ses.proc.Mp()))
+		tBat.SetRowCount(1)
+		defer tBat.Clean(ses.proc.Mp())
+
+		_, err := handleDelsOnLCA(
+			context.Background(), ses, bh, tBat, tblStuff,
+			types.BuildTS(10, 0).ToTimestamp(),
+		)
+		require.ErrorIs(t, err, wantErr)
+	})
+
 	t.Run("composite pk sql builder propagates non recoverable error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/test/distributed/cases/git4data/branch/edge/branch_float_special_values.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_float_special_values.result
@@ -50,12 +50,14 @@ data branch create table no_pk_src from no_pk_base;
 data branch create table no_pk_dst from no_pk_base;
 delete from no_pk_src where note = 'remove';
 update no_pk_src set note = 'updated' where note = 'update';
+data branch diff no_pk_src against no_pk_dst;
+➤ diff no_pk_src against no_pk_dst[12,0,0]  ¦  flag[12,0,0]  ¦  f[8,53,31]  ¦  note[12,16,0]  𝄀
+no_pk_src  ¦  DELETE  ¦  NaN  ¦  remove  𝄀
+no_pk_src  ¦  UPDATE  ¦  Infinity  ¦  updated
 data branch merge no_pk_src into no_pk_dst;
 select f, note from no_pk_dst order by note;
 ➤ f[8,54,0]  ¦  note[12,-1,0]  𝄀
 -Infinity  ¦  keep  𝄀
-NaN  ¦  remove  𝄀
-Infinity  ¦  update  𝄀
 Infinity  ¦  updated
 create table portable_base(f32 float, f64 double, marker double, note varchar(16));
 insert into portable_base values

--- a/test/distributed/cases/git4data/branch/edge/branch_float_special_values.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_float_special_values.sql
@@ -47,6 +47,7 @@ data branch create table no_pk_dst from no_pk_base;
 delete from no_pk_src where note = 'remove';
 update no_pk_src set note = 'updated' where note = 'update';
 
+data branch diff no_pk_src against no_pk_dst;
 data branch merge no_pk_src into no_pk_dst;
 select f, note from no_pk_dst order by note;
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26072

## What this PR does / why we need it:

### Root cause

For tables without an explicit primary key, hash-diff matching uses the visible columns as the fake-PK identity, but the LCA SQL probe joins through the generated hidden `__mo_fake_pk_col`. The probe selected its cast/equality type from the first visible column instead of the hidden key column. When the first visible column was `DOUBLE`, the generated join became `serial(__mo_fake_pk_col) = serial(cast(... AS DOUBLE))`, so existing LCA rows were treated as misses. `DATA BRANCH DIFF` consequently omitted no-PK deletes and updates, and MERGE left stale rows beside updated rows.

### Changes

- Use the hidden fake-PK column's type for fake-PK LCA probe casts and equality predicates; real and composite primary-key paths are unchanged.
- Add a frontend unit regression that captures the generated probe SQL for a no-PK table whose first visible column is `DOUBLE` and requires the hidden `BIGINT UNSIGNED` key type.
- Extend the existing special-float BVT to assert no-PK DIFF emits the NaN DELETE and `+Inf` UPDATE, preserves the unchanged `-Inf` row, and that MERGE removes/replaces the corresponding destination rows. The same case continues to cover all three special values through primary-key `OUTPUT AS`, MERGE, PICK, and portable SQL behavior.

### Issue-to-test proof

- `pkg/frontend/data_branch_hashdiff_test.go`: directly proves the corrected LCA join SQL for the failing no-PK schema shape.
- `test/distributed/cases/git4data/branch/edge/branch_float_special_values.sql`: proves the no-PK NaN deletion, `+Inf` update, `-Inf` preservation, and final MERGE state, in addition to the original primary-key cases for all three special values.

### Tests run

- `make build`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^TestHandleDelsOnLCA_SQLPaths/fake_pk_sql_builder_uses_the_hidden_key_type$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s -run '^(TestHandleDelsOnLCA_SQLPaths|TestHashDiff_)' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=600s ./pkg/frontend`
- `GOWORK=off go vet -mod=readonly ./pkg/frontend` with the repository CGo include/library paths
- `branch_float_special_values.sql` through mo-tester: 257/257 passed with `-n -r 100`
- `merge_8.sql` through mo-tester: 172/172 passed with `-n -r 100`

The BVT runs use `-n` because current result metadata contains unrelated version-dependent width differences; all SQL result values and ordering were compared.

### Residual risks

No API or schema behavior changes are introduced. The fix adds no fallback path, query, or concurrency/resource-lifecycle change. The existing BVT metadata drift remains outside this focused fix and is explicitly isolated by `-n` during verification.
