### PR TITLE
fix(plan): use hash anti join for filtered NOT EXISTS

### DIFF
--- a/pkg/sql/compile/in_mark_join_test.go
+++ b/pkg/sql/compile/in_mark_join_test.go
@@ -272,6 +272,57 @@ func TestCompileBroadcastCompositeMarkExpressionsUseHashJoin(t *testing.T) {
 	}
 }
 
+func TestCompileNullableNotExistsAntiJoinUsesHashJoin(t *testing.T) {
+	compilerCtx := plan2.NewMockCompilerContext(true)
+	statements, err := mysql.Parse(
+		compilerCtx.GetContext(),
+		`select n.n_nationkey
+		from tpch.nation n
+		where not exists (
+			select 1 from tpch.region r where r.r_comment = n.n_comment
+		)`,
+		1,
+	)
+	require.NoError(t, err)
+	require.Len(t, statements, 1)
+
+	logicPlan, err := plan2.BuildPlan(compilerCtx, statements[0], false)
+	require.NoError(t, err)
+	query := logicPlan.GetQuery()
+	require.NotNil(t, query)
+
+	var anti *plan.Node
+	for _, node := range query.Nodes {
+		if node.NodeType == plan.Node_JOIN && node.JoinType == plan.Node_ANTI {
+			anti = node
+			break
+		}
+	}
+	require.NotNil(t, anti)
+	require.Len(t, anti.Children, 2)
+	require.NotNil(t, anti.Stats)
+	anti.Stats.HashmapStats.Shuffle = false
+	anti.SendMsgList = []plan.MsgHeader{{
+		MsgType: int32(message.MsgJoinMap),
+		MsgTag:  1,
+	}}
+
+	left := query.Nodes[anti.Children[0]]
+	right := query.Nodes[anti.Children[1]]
+	c := newCompileForShuffleJoinTest(t, engine.Nodes{{Addr: "cn1:6001", Mcpu: 1}})
+	probe := newShuffleJoinTestScope(t, c.cnList[0], 1)
+	build := newShuffleJoinTestScope(t, c.cnList[0], 1)
+
+	result := c.compileJoin(anti, left, right, []*Scope{probe}, []*Scope{build})
+
+	require.Len(t, result, 1)
+	op, ok := result[0].RootOp.(*hashjoin.HashJoin)
+	require.True(t, ok, "compiled %T, want HashJoin", result[0].RootOp)
+	require.Equal(t, plan.Node_ANTI, op.JoinType)
+	require.Len(t, op.EqConds[0], 1)
+	require.Len(t, op.EqConds[1], 1)
+}
+
 func TestCompileBroadcastMarkJoinSelectsPhysicalOperator(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/sql/plan/flatten_subquery_test.go
+++ b/pkg/sql/plan/flatten_subquery_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/stretchr/testify/require"
 )
 
@@ -763,6 +764,54 @@ func TestInSubqueryJoinShapePreservesThreeValuedSemantics(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNullableNotExistsJoinPredicateNormalization(t *testing.T) {
+	const correlatedNotExists = `not exists (
+		select 1 from tpch.region r where r.r_comment = n.n_comment
+	)`
+
+	t.Run("filtering anti join exposes equality", func(t *testing.T) {
+		logicPlan, err := runOneStmt(NewMockOptimizer(true), t,
+			"select n.n_nationkey from tpch.nation n where "+correlatedNotExists)
+		require.NoError(t, err)
+
+		var anti *plan.Node
+		for _, node := range logicPlan.GetQuery().Nodes {
+			if node.NodeType == plan.Node_JOIN && node.JoinType == plan.Node_ANTI {
+				anti = node
+				break
+			}
+		}
+		require.NotNil(t, anti)
+		require.Len(t, anti.OnList, 1)
+		condition := anti.OnList[0].GetF()
+		require.NotNil(t, condition)
+		require.True(t, IsEqualFunc(condition.Func.GetObj()),
+			"ANTI join must expose its equality as a hash key")
+	})
+
+	t.Run("projected mark join preserves is true", func(t *testing.T) {
+		logicPlan, err := runOneStmt(NewMockOptimizer(true), t,
+			"select "+correlatedNotExists+" from tpch.nation n")
+		require.NoError(t, err)
+
+		var mark *plan.Node
+		for _, node := range logicPlan.GetQuery().Nodes {
+			if node.NodeType == plan.Node_JOIN && node.JoinType == plan.Node_MARK {
+				mark = node
+				break
+			}
+		}
+		require.NotNil(t, mark)
+		require.Len(t, mark.OnList, 1)
+		isTrue := mark.OnList[0].GetF()
+		require.NotNil(t, isTrue)
+		funcID, _ := function.DecodeOverloadID(isTrue.Func.GetObj())
+		require.Equal(t, int32(function.ISTRUE), funcID)
+		require.Len(t, isTrue.Args, 1)
+		require.True(t, IsEqualFunc(isTrue.Args[0].GetF().Func.GetObj()))
+	})
 }
 
 func TestDirectCorrelatedScalarProjectionUsesMatchMarker(t *testing.T) {

--- a/pkg/sql/plan/pushdown.go
+++ b/pkg/sql/plan/pushdown.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/vectorindex/metric"
 )
 
@@ -368,6 +369,7 @@ func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr,
 				if tryMark := filter.GetCol(); tryMark != nil {
 					if tryMark.RelPos == node.BindingTags[0] {
 						node.JoinType = plan.Node_SEMI
+						node.OnList = unwrapIsTrueFromMarkJoinEqualities(node.OnList, leftTags, rightTags, markTag)
 						node.BindingTags = nil
 						break
 					}
@@ -376,6 +378,7 @@ func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr,
 					if tryMark := arg.GetCol(); tryMark != nil {
 						if tryMark.RelPos == node.BindingTags[0] {
 							node.JoinType = plan.Node_ANTI
+							node.OnList = unwrapIsTrueFromMarkJoinEqualities(node.OnList, leftTags, rightTags, markTag)
 							node.BindingTags = nil
 							break
 						}
@@ -608,6 +611,38 @@ func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr,
 			fmt.Sprintf("pushdownFilters:after (nodeID: %d, no change, cantPushdown: %d)", nodeID, len(cantPushdown)))
 	}
 	return nodeID, cantPushdown
+}
+
+func unwrapIsTrueFromMarkJoinEqualities(
+	conditions []*plan.Expr,
+	leftTags, rightTags map[int32]bool,
+	markTag int32,
+) []*plan.Expr {
+	for i, condition := range conditions {
+		isTrue := condition.GetF()
+		if isTrue == nil || isTrue.Func == nil || len(isTrue.Args) != 1 {
+			continue
+		}
+		funcID, _ := function.DecodeOverloadID(isTrue.Func.GetObj())
+		if funcID != function.ISTRUE {
+			continue
+		}
+
+		equality := isTrue.Args[0]
+		equalFunc := equality.GetF()
+		if equalFunc == nil || equalFunc.Func == nil || len(equalFunc.Args) != 2 || !IsEqualFunc(equalFunc.Func.GetObj()) {
+			continue
+		}
+
+		leftSide := getJoinSideWithOuterScope(equalFunc.Args[0], leftTags, rightTags, markTag)
+		rightSide := getJoinSideWithOuterScope(equalFunc.Args[1], leftTags, rightTags, markTag)
+		if leftSide == JoinSideLeft && rightSide == JoinSideRight ||
+			leftSide == JoinSideRight && rightSide == JoinSideLeft {
+			conditions[i] = equality
+		}
+	}
+
+	return conditions
 }
 
 // referencesSyntheticGroupKey reports whether expr cannot be rewritten below

--- a/test/distributed/cases/subquery/mysql_compat_null_subquery.result
+++ b/test/distributed/cases/subquery/mysql_compat_null_subquery.result
@@ -47,6 +47,21 @@ id    k_label    exists_eq    not_exists_eq    exists_null_safe    not_exists_nu
 3    3    0    1    0    1
 4    NULL    0    1    1    0
 5    4    1    0    1    0
+select id, if(k is null, 'NULL', cast(k as char)) as k_label
+from t_outer
+where exists (select 1 from t_inner i where i.val = t_outer.k)
+order by id;
+id    k_label
+1    1
+2    2
+5    4
+select id, if(k is null, 'NULL', cast(k as char)) as k_label
+from t_outer
+where not exists (select 1 from t_inner i where i.val = t_outer.k)
+order by id;
+id    k_label
+3    3
+4    NULL
 select id, if(k is null, 'NULL', cast(k as char)) as k_label,
 k = (select max(val) from t_inner where grp = 3) as eq_scalar_nonnull,
 k = (select max(val) from t_inner where grp = 2) as eq_scalar_all_null,

--- a/test/distributed/cases/subquery/mysql_compat_null_subquery.sql
+++ b/test/distributed/cases/subquery/mysql_compat_null_subquery.sql
@@ -48,6 +48,18 @@ select id, if(k is null, 'NULL', cast(k as char)) as k_label,
 from t_outer
 order by id;
 
+-- issue #26797: filtering a nullable correlated equality lowers the MARK join
+-- to SEMI/ANTI without changing EXISTS/NOT EXISTS NULL semantics.
+select id, if(k is null, 'NULL', cast(k as char)) as k_label
+from t_outer
+where exists (select 1 from t_inner i where i.val = t_outer.k)
+order by id;
+
+select id, if(k is null, 'NULL', cast(k as char)) as k_label
+from t_outer
+where not exists (select 1 from t_inner i where i.val = t_outer.k)
+order by id;
+
 select id, if(k is null, 'NULL', cast(k as char)) as k_label,
        k = (select max(val) from t_inner where grp = 3) as eq_scalar_nonnull,
        k = (select max(val) from t_inner where grp = 2) as eq_scalar_all_null,


### PR DESCRIPTION
## Summary

- unwrap only strict cross-input `ISTRUE(equal)` predicates when a MARK join is lowered to SEMI/ANTI
- preserve projected MARK join three-valued semantics
- add planner and compiler regression tests
- fixes #26797

## Validation

- `.agents/skills/mo-dev/scripts/mo-cgo-test ./pkg/sql/plan ./pkg/sql/compile`
- `make build`
- fixed single-node service with 6GB memory cache: full `NOT EXISTS` returned 199500 in 599ms and used RIGHT ANTI hashOnPK; the old plan was LoopJoin and exceeded 180s
- complex correctness: 26/26
- indexed-table DML checks: 0 failures
- index combinations: 0 failures; predicate-order/index-order/function equivalences preserved
- concurrent harness: 630 queries, 0 errors/timeouts
- partition scenarios intentionally excluded
