### PR TITLE
fix(plan): normalize decimal index range bounds

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1770,14 +1770,21 @@ func (builder *QueryBuilder) applyExtraFiltersOnIndex(idxDef *IndexDef, node *pl
 				continue
 			}
 			idxColExpr := GetColExpr(idxTableNode.TableDef.Cols[0].Typ, idxTableNode.BindingTags[0], 0)
-			idxPartExpr := idxColExpr
+			mappedExpr := idxColExpr
 			if indexTableStoresSerializedKey(idxDef) {
-				idxPartExpr, _ = MakeSerialExtractExpr(builder.GetContext(), idxColExpr, fn.Args[colArgIdx].Typ, int64(k))
+				var err error
+				mappedExpr, err = MakeSerialExtractExpr(builder.GetContext(), idxColExpr, fn.Args[colArgIdx].Typ, int64(k))
+				if err != nil {
+					// Extra-filter pushdown is optional. The original filter remains on
+					// the base table, so skip an unsupported serialized-key mapping.
+					continue
+				}
 			}
 			newFilter := DeepCopyExpr(node.FilterList[i])
-			newFilter.GetF().Args[colArgIdx] = idxPartExpr
+			newFilter.GetF().Args[colArgIdx] = mappedExpr
 			idxTableNode.FilterList = append(idxTableNode.FilterList, newFilter)
 			applied = true
+			break
 		}
 		if applied {
 			continue
@@ -1794,11 +1801,14 @@ func (builder *QueryBuilder) applyExtraFiltersOnIndex(idxDef *IndexDef, node *pl
 			for k := range node.TableDef.Pkey.Names {
 				if col.Name == node.TableDef.Pkey.Names[k] {
 					idxColExpr := GetColExpr(idxTableNode.TableDef.Cols[1].Typ, idxTableNode.BindingTags[0], 1)
-					deserialExpr, _ := MakeSerialExtractExpr(builder.GetContext(), idxColExpr, fn.Args[colArgIdx].Typ, int64(k))
+					deserialExpr, err := MakeSerialExtractExpr(builder.GetContext(), idxColExpr, fn.Args[colArgIdx].Typ, int64(k))
+					if err != nil {
+						break
+					}
 					newFilter := DeepCopyExpr(node.FilterList[i])
 					newFilter.GetF().Args[colArgIdx] = deserialExpr
 					idxTableNode.FilterList = append(idxTableNode.FilterList, newFilter)
-					continue
+					break
 				}
 			}
 		}

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -2003,6 +2003,7 @@ func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *
 		}
 	}
 
+	indexedPartType := fn.Args[0].Typ
 	fn.Args[0].GetCol().RelPos = idxTag
 	fn.Args[0].GetCol().ColPos = 0
 	fn.Args[0].Typ = idxTableDef.Cols[0].Typ
@@ -2010,6 +2011,8 @@ func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *
 		serialFunc := indexTableLookupSerialFunc(idxDef)
 		switch fn.Func.ObjName {
 		case "between":
+			fn.Args[1] = builder.normalizeDecimalIndexRangeBound(fn.Args[1], indexedPartType)
+			fn.Args[2] = builder.normalizeDecimalIndexRangeBound(fn.Args[2], indexedPartType)
 			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
 			fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[2]})
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_between", fn.Args)
@@ -2017,9 +2020,12 @@ func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *
 			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_in", fn.Args)
 		case ">", ">=", "<", "<=":
+			fn.Args[1] = builder.normalizeDecimalIndexRangeBound(fn.Args[1], indexedPartType)
 			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), fn.Func.ObjName, fn.Args)
 		case "in_range":
+			fn.Args[1] = builder.normalizeDecimalIndexRangeBound(fn.Args[1], indexedPartType)
+			fn.Args[2] = builder.normalizeDecimalIndexRangeBound(fn.Args[2], indexedPartType)
 			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
 			fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[2]})
 			if comparesByteStringColumn {
@@ -2291,12 +2297,16 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 		}
 	}
 
-	// For multi-part indexes, single <= or > with raw byte comparison is incorrect.
-	// <= under-fetches (misses rows at boundary), > over-fetches.
-	// Only allow these when paired (handled by getIndexForNonEquiCond).
-	// This check recurses into OR arms to catch `col <= 5 OR col > 9`.
-	if !leadingEqualCond && numParts > 1 && len(leadingPos) == 1 {
+	if !leadingEqualCond && numParts > 1 {
 		fn := node.FilterList[leadingPos[0]].GetF()
+		leadingColIdx := node.TableDef.Name2ColIndex[idxDef.Parts[0]]
+		if !canSerializeDecimalIndexRangeBounds(fn, node.TableDef.Cols[leadingColIdx].Typ) {
+			return -1
+		}
+		// For multi-part indexes, single <= or > with raw byte comparison is incorrect.
+		// <= under-fetches (misses rows at boundary), > over-fetches.
+		// Only allow these when paired (handled by getIndexForNonEquiCond).
+		// This check recurses into OR arms to catch `col <= 5 OR col > 9`.
 		if fn != nil && hasUnsafeRangeOp(fn) {
 			return -1
 		}
@@ -2540,6 +2550,9 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		if _, ok := colPos2Idx[col.ColPos]; !ok {
 			continue
 		}
+		if !canSerializeDecimalIndexRangeBounds(fn, node.TableDef.Cols[col.ColPos].Typ) {
+			continue
+		}
 		if isLower {
 			colLowerBounds[col.ColPos] = int32(i)
 		} else {
@@ -2554,6 +2567,9 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		if filterType == NonEqualIndexCondition {
 			idxPos, ok := colPos2Idx[col.ColPos]
 			if !ok {
+				continue
+			}
+			if !canSerializeDecimalIndexRangeBounds(fn, node.TableDef.Cols[col.ColPos].Typ) {
 				continue
 			}
 			if rangeCol, _ := classifyRangeBound(fn); rangeCol != nil {
@@ -2661,6 +2677,77 @@ func rangeFilterConstValue(fn *plan.Function) *plan.Expr {
 	return nil
 }
 
+func rangeFilterColumnType(fn *plan.Function) (plan.Type, bool) {
+	if len(fn.Args) < 2 {
+		return plan.Type{}, false
+	}
+	if fn.Args[0].GetCol() != nil && isRuntimeConstExpr(fn.Args[1]) {
+		return fn.Args[0].Typ, true
+	}
+	if isRuntimeConstExpr(fn.Args[0]) && fn.Args[1].GetCol() != nil {
+		return fn.Args[1].Typ, true
+	}
+	return plan.Type{}, false
+}
+
+func canSerializeDecimalIndexRangeBound(bound *plan.Expr, indexedPartType plan.Type) bool {
+	indexedType := makeTypeByPlan2Type(indexedPartType)
+	if !indexedType.Oid.IsDecimal() {
+		return true
+	}
+	if bound == nil {
+		return false
+	}
+	boundType := makeTypeByPlan2Expr(bound)
+	if !boundType.Oid.IsDecimal() {
+		return false
+	}
+	if boundType.Oid == indexedType.Oid && boundType.Scale == indexedType.Scale {
+		return true
+	}
+	return checkNoNeedCast(boundType, indexedType, bound)
+}
+
+func canSerializeDecimalIndexRangeBounds(fn *plan.Function, indexedPartType plan.Type) bool {
+	if fn == nil || fn.Func == nil {
+		return false
+	}
+	if fn.Func.ObjName == "or" {
+		for _, arg := range fn.Args {
+			if !canSerializeDecimalIndexRangeBounds(arg.GetF(), indexedPartType) {
+				return false
+			}
+		}
+		return true
+	}
+	if !types.T(indexedPartType.Id).IsDecimal() {
+		return true
+	}
+	switch fn.Func.ObjName {
+	case "between", "in_range":
+		return len(fn.Args) >= 3 &&
+			canSerializeDecimalIndexRangeBound(fn.Args[1], indexedPartType) &&
+			canSerializeDecimalIndexRangeBound(fn.Args[2], indexedPartType)
+	case ">", ">=", "<", "<=":
+		return canSerializeDecimalIndexRangeBound(rangeFilterConstValue(fn), indexedPartType)
+	default:
+		return true
+	}
+}
+
+func (builder *QueryBuilder) normalizeDecimalIndexRangeBound(bound *plan.Expr, indexedPartType plan.Type) *plan.Expr {
+	if bound == nil || !types.T(indexedPartType.Id).IsDecimal() ||
+		(bound.Typ.Id == indexedPartType.Id && bound.Typ.Scale == indexedPartType.Scale) ||
+		!canSerializeDecimalIndexRangeBound(bound, indexedPartType) {
+		return bound
+	}
+	normalized, err := forceCastExpr(builder.GetContext(), bound, indexedPartType)
+	if err != nil {
+		return bound
+	}
+	return normalized
+}
+
 func (builder *QueryBuilder) replaceRangePairCondition(idxDef *IndexDef, filterList []*plan.Expr, filterIdx []int32, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
 	numParts := len(idxDef.Parts)
 	lowerFn := filterList[filterIdx[0]].GetF()
@@ -2676,6 +2763,12 @@ func (builder *QueryBuilder) replaceRangePairCondition(idxDef *IndexDef, filterL
 	compositeFilterSel := filterList[filterIdx[0]].Selectivity * filterList[filterIdx[1]].Selectivity
 
 	if numParts > 1 {
+		if indexedPartType, ok := rangeFilterColumnType(lowerFn); ok {
+			lowerVal = builder.normalizeDecimalIndexRangeBound(lowerVal, indexedPartType)
+		}
+		if indexedPartType, ok := rangeFilterColumnType(upperFn); ok {
+			upperVal = builder.normalizeDecimalIndexRangeBound(upperVal, indexedPartType)
+		}
 		serialFunc := indexTableLookupSerialFunc(idxDef)
 		lowerVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{lowerVal})
 		upperVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{upperVal})

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -2297,7 +2297,7 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 		}
 	}
 
-	if !leadingEqualCond && numParts > 1 {
+	if !leadingEqualCond && indexTableStoresSerializedKey(idxDef) {
 		fn := node.FilterList[leadingPos[0]].GetF()
 		leadingColIdx := node.TableDef.Name2ColIndex[idxDef.Parts[0]]
 		if !canSerializeDecimalIndexRangeBounds(fn, node.TableDef.Cols[leadingColIdx].Typ) {
@@ -2508,7 +2508,12 @@ func classifyRangeBound(fn *plan.Function) (col *plan.ColRef, isLower bool) {
 }
 
 func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *plan.Node) (int, []int32) {
-	colPos2Idx := make(map[int32]int)
+	type indexCandidates struct {
+		preferred int
+		direct    int
+		hasDirect bool
+	}
+	colPos2Candidates := make(map[int32]indexCandidates)
 	for i, idxDef := range indexes {
 		// Prefix keys are lossy. IN and range operators can use block-level
 		// pruning implementations that compare the untruncated probe with the
@@ -2521,17 +2526,38 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		if !idxDef.Unique {
 			numParts--
 		}
-		if idxDef.Unique && numParts == 1 {
-			colPos, ok := node.TableDef.Name2ColIndex[catalog.ResolveAlias(idxDef.Parts[0])]
-			if ok {
-				colPos2Idx[colPos] = i
-			}
-		} else if !idxDef.Unique && numParts >= 1 {
-			colPos, ok := node.TableDef.Name2ColIndex[catalog.ResolveAlias(idxDef.Parts[0])]
-			if ok {
-				colPos2Idx[colPos] = i
-			}
+		if (idxDef.Unique && numParts != 1) || (!idxDef.Unique && numParts < 1) {
+			continue
 		}
+
+		colPos, ok := node.TableDef.Name2ColIndex[catalog.ResolveAlias(idxDef.Parts[0])]
+		if !ok {
+			continue
+		}
+		candidates := colPos2Candidates[colPos]
+		candidates.preferred = i
+		if !indexTableStoresSerializedKey(idxDef) {
+			candidates.direct = i
+			candidates.hasDirect = true
+		}
+		colPos2Candidates[colPos] = candidates
+	}
+	// Preserve the existing catalog-order preference for ordinary bounds. If a
+	// serialized candidate cannot represent the bound losslessly or safely as
+	// a single-ended range, use a direct unique key on the same column before
+	// giving up on the index lookup altogether. Unsafe operators are allowed
+	// while discovering, and after selecting, a paired range.
+	selectIndex := func(candidates indexCandidates, colPos int32, first, second *plan.Function, allowUnsafeRange bool) (int, bool) {
+		if !indexTableStoresSerializedKey(indexes[candidates.preferred]) ||
+			(canSerializeDecimalIndexRangeBounds(first, node.TableDef.Cols[colPos].Typ) &&
+				(second == nil || canSerializeDecimalIndexRangeBounds(second, node.TableDef.Cols[colPos].Typ)) &&
+				(allowUnsafeRange || !hasUnsafeRangeOp(first))) {
+			return candidates.preferred, true
+		}
+		if candidates.hasDirect {
+			return candidates.direct, true
+		}
+		return -1, false
 	}
 
 	// First pass: detect paired range conditions on index leading columns.
@@ -2547,10 +2573,11 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		if col == nil {
 			continue
 		}
-		if _, ok := colPos2Idx[col.ColPos]; !ok {
+		candidates, ok := colPos2Candidates[col.ColPos]
+		if !ok {
 			continue
 		}
-		if !canSerializeDecimalIndexRangeBounds(fn, node.TableDef.Cols[col.ColPos].Typ) {
+		if _, ok = selectIndex(candidates, col.ColPos, fn, nil, true); !ok {
 			continue
 		}
 		if isLower {
@@ -2565,31 +2592,36 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		fn := node.FilterList[i].GetF()
 		filterType, col := checkIndexFilter(fn)
 		if filterType == NonEqualIndexCondition {
-			idxPos, ok := colPos2Idx[col.ColPos]
+			candidates, ok := colPos2Candidates[col.ColPos]
 			if !ok {
-				continue
-			}
-			if !canSerializeDecimalIndexRangeBounds(fn, node.TableDef.Cols[col.ColPos].Typ) {
 				continue
 			}
 			if rangeCol, _ := classifyRangeBound(fn); rangeCol != nil {
 				lowerIdx, hasLower := colLowerBounds[rangeCol.ColPos]
 				upperIdx, hasUpper := colUpperBounds[rangeCol.ColPos]
 				if hasLower && hasUpper && int32(i) == min(lowerIdx, upperIdx) {
+					idxPos, usable := selectIndex(
+						candidates,
+						col.ColPos,
+						node.FilterList[lowerIdx].GetF(),
+						node.FilterList[upperIdx].GetF(),
+						true,
+					)
+					if !usable {
+						continue
+					}
 					if shouldSkipLargeRangeIndexByStats(node) {
 						continue
 					}
 					return idxPos, []int32{lowerIdx, upperIdx}
 				}
 			}
-			if fn != nil {
-				numParts := len(indexes[idxPos].Parts)
-				if numParts > 1 && hasUnsafeRangeOp(fn) {
-					continue
-				}
-				if isRangeOp(fn) && shouldSkipLargeRangeIndexByStats(node) {
-					continue
-				}
+			idxPos, usable := selectIndex(candidates, col.ColPos, fn, nil, false)
+			if !usable {
+				continue
+			}
+			if fn != nil && isRangeOp(fn) && shouldSkipLargeRangeIndexByStats(node) {
+				continue
 			}
 			return idxPos, []int32{int32(i)}
 		}

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -168,6 +168,112 @@ func TestDirectUniqueDecimalRangeResidualFilterUsesDirectKey(t *testing.T) {
 	require.Equal(t, decimalType, residualColExpr.Typ)
 }
 
+func TestApplyExtraFiltersOnIndexUsesPhysicalKeyEncoding(t *testing.T) {
+	intType := planpb.Type{Id: int32(types.T_int64)}
+	varcharType := planpb.Type{Id: int32(types.T_varchar)}
+	makeIndexNode := func(bindingTag int32, keyType, primaryType planpb.Type) *planpb.Node {
+		return &planpb.Node{
+			BindingTags: []int32{bindingTag},
+			TableDef: &planpb.TableDef{Cols: []*planpb.ColDef{
+				{Name: catalog.IndexTableIndexColName, Typ: keyType},
+				{Name: catalog.IndexTablePrimaryColName, Typ: primaryType},
+			}},
+		}
+	}
+
+	t.Run("serialized index part", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+		baseTag := builder.genNewBindTag()
+		indexTag := builder.genNewBindTag()
+		filter := makeTypedInt64RangeFilterExpr(baseTag, 1, ">=", 10, intType)
+		node := &planpb.Node{
+			TableDef: &planpb.TableDef{
+				Cols: []*planpb.ColDef{
+					{Name: "id", Typ: intType},
+					{Name: "a", Typ: intType},
+				},
+				Name2ColIndex: map[string]int32{"id": 0, "a": 1},
+				Pkey:          &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+			},
+			BindingTags: []int32{baseTag},
+			FilterList:  []*planpb.Expr{filter},
+		}
+		idxDef := &planpb.IndexDef{Parts: []string{"a", catalog.CreateAlias("id")}}
+		indexNode := makeIndexNode(indexTag, varcharType, intType)
+
+		builder.applyExtraFiltersOnIndex(idxDef, node, indexNode, nil)
+
+		require.Len(t, indexNode.FilterList, 1)
+		mapped := indexNode.FilterList[0].GetF().Args[0]
+		require.Equal(t, "serial_extract", wrappedSerialFuncName(t, mapped))
+		require.Equal(t, int32(0), mapped.GetF().Args[0].GetCol().ColPos)
+	})
+
+	t.Run("composite primary key part", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+		baseTag := builder.genNewBindTag()
+		indexTag := builder.genNewBindTag()
+		filter := makeTypedInt64RangeFilterExpr(baseTag, 0, ">=", 10, intType)
+		filter.GetF().Args[0].GetCol().Name = "tenant_id"
+		node := &planpb.Node{
+			TableDef: &planpb.TableDef{
+				Cols: []*planpb.ColDef{
+					{Name: "tenant_id", Typ: intType},
+					{Name: "id", Typ: intType},
+					{Name: "a", Typ: intType},
+					{Name: catalog.CPrimaryKeyColName, Typ: varcharType},
+				},
+				Name2ColIndex: map[string]int32{
+					"tenant_id":                0,
+					"id":                       1,
+					"a":                        2,
+					catalog.CPrimaryKeyColName: 3,
+				},
+				Pkey: &planpb.PrimaryKeyDef{
+					PkeyColName: catalog.CPrimaryKeyColName,
+					Names:       []string{"tenant_id", "id"},
+				},
+			},
+			BindingTags: []int32{baseTag},
+			FilterList:  []*planpb.Expr{filter},
+		}
+		idxDef := &planpb.IndexDef{Parts: []string{"a", catalog.CreateAlias(catalog.CPrimaryKeyColName)}}
+		indexNode := makeIndexNode(indexTag, varcharType, varcharType)
+
+		builder.applyExtraFiltersOnIndex(idxDef, node, indexNode, nil)
+
+		require.Len(t, indexNode.FilterList, 1)
+		mapped := indexNode.FilterList[0].GetF().Args[0]
+		require.Equal(t, "serial_extract", wrappedSerialFuncName(t, mapped))
+		require.Equal(t, int32(1), mapped.GetF().Args[0].GetCol().ColPos)
+
+		invalidPrimaryNode := makeIndexNode(builder.genNewBindTag(), varcharType, intType)
+		builder.applyExtraFiltersOnIndex(idxDef, node, invalidPrimaryNode, nil)
+		require.Empty(t, invalidPrimaryNode.FilterList)
+	})
+
+	t.Run("invalid serialized key metadata skips optional pushdown", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+		baseTag := builder.genNewBindTag()
+		indexTag := builder.genNewBindTag()
+		node := &planpb.Node{
+			TableDef: &planpb.TableDef{
+				Cols:          []*planpb.ColDef{{Name: "id", Typ: intType}, {Name: "a", Typ: intType}},
+				Name2ColIndex: map[string]int32{"id": 0, "a": 1},
+				Pkey:          &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+			},
+			BindingTags: []int32{baseTag},
+			FilterList:  []*planpb.Expr{makeTypedInt64RangeFilterExpr(baseTag, 1, ">=", 10, intType)},
+		}
+		idxDef := &planpb.IndexDef{Parts: []string{"a", catalog.CreateAlias("id")}}
+		indexNode := makeIndexNode(indexTag, intType, intType)
+
+		builder.applyExtraFiltersOnIndex(idxDef, node, indexNode, nil)
+
+		require.Empty(t, indexNode.FilterList)
+	})
+}
+
 func TestFilterRegularIndexesByScanHints(t *testing.T) {
 	idxA := &planpb.IndexDef{IndexName: "idx_a"}
 	idxB := &planpb.IndexDef{IndexName: "idx_b"}
@@ -5323,6 +5429,29 @@ func TestIndexRangeSerializationNormalizesDecimalBounds(t *testing.T) {
 			requireSerializedRangeBoundType(t, expr.GetF().Args[1], columnType, true)
 		})
 	}
+
+	t.Run("in range", func(t *testing.T) {
+		lower := makeDecimalRangeFilterExpr(t, bindTag, 1, ">", "10.250000", columnType, higherScaleType)
+		upper := makeDecimalRangeFilterExpr(t, bindTag, 1, "<", "15.750000", columnType, higherScaleType)
+		filter := &planpb.Expr{
+			Typ: planpb.Type{Id: int32(types.T_bool)},
+			Expr: &planpb.Expr_F{F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "in_range"},
+				Args: []*planpb.Expr{
+					DeepCopyExpr(lower.GetF().Args[0]),
+					DeepCopyExpr(lower.GetF().Args[1]),
+					DeepCopyExpr(upper.GetF().Args[1]),
+					MakePlan2Uint8ConstExprWithType(3),
+				},
+			}},
+		}
+
+		expr := builder.replaceNonEqualCondition(idxDef, filter, 42, idxTableDef)
+
+		require.Equal(t, "prefix_in_range", expr.GetF().Func.ObjName)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[1], columnType, true)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[2], columnType, true)
+	})
 
 	t.Run("equal scale decimal remains direct", func(t *testing.T) {
 		filters := []*planpb.Expr{

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -88,6 +88,33 @@ func TestIndexHintMissingIndexReturnsMysqlKeyDoesNotExist(t *testing.T) {
 	require.Contains(t, moErr.Error(), "Key 'idx_missing' doesn't exist in table 'single_idx_t'")
 }
 
+func TestSingleColumnUniqueDecimalRangeUsesIndex(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	addIndexHintChoiceTableForTest(mock)
+	decimalType := planpb.Type{Id: int32(types.T_decimal64), Width: 10, Scale: 2}
+	mainTable := mock.ctxt.tables["index_hint_t"]
+	mainTable.Cols[1].Typ = decimalType
+	mainTable.Indexes = []*planpb.IndexDef{
+		{
+			IndexName:      "uk_a",
+			Parts:          []string{"a"},
+			IndexTableName: "uk_hint_a",
+			TableExist:     true,
+			Unique:         true,
+		},
+	}
+	addIndexHintIndexTableForTest(mock, "uk_hint_a", 25365)
+	mock.ctxt.tables["uk_hint_a"].Cols[0].Typ = decimalType
+
+	queryPlan, err := runOneStmt(mock, t, `
+		select b
+		from index_hint_t force index(uk_a)
+		where a > 10.255000`)
+	require.NoError(t, err)
+	require.True(t, planHasIndexJoin(queryPlan))
+	require.Equal(t, "uk_a", findFirstIndexScanName(queryPlan))
+}
+
 func TestFilterRegularIndexesByScanHints(t *testing.T) {
 	idxA := &planpb.IndexDef{IndexName: "idx_a"}
 	idxB := &planpb.IndexDef{IndexName: "idx_b"}
@@ -5269,29 +5296,102 @@ func TestIndexRangeSerializationNormalizesDecimalBounds(t *testing.T) {
 		requireSerializedRangeBoundType(t, expr.GetF().Args[2], intType, false)
 	})
 
-	t.Run("non representable decimal falls back from index", func(t *testing.T) {
+	t.Run("non representable decimal follows index key encoding", func(t *testing.T) {
 		filters := []*planpb.Expr{
 			makeDecimalRangeFilterExpr(t, bindTag, 1, ">", "10.255000", columnType, higherScaleType),
 			makeDecimalRangeFilterExpr(t, bindTag, 1, "<=", "15.755000", columnType, higherScaleType),
 		}
-		node := &planpb.Node{
-			TableDef: &planpb.TableDef{
-				Name2ColIndex: map[string]int32{
-					catalog.FakePrimaryKeyColName: 0,
-					"price":                       1,
+		makeNode := func(filterList []*planpb.Expr) *planpb.Node {
+			return &planpb.Node{
+				TableDef: &planpb.TableDef{
+					Name2ColIndex: map[string]int32{
+						catalog.FakePrimaryKeyColName: 0,
+						"price":                       1,
+					},
+					Cols: []*planpb.ColDef{
+						{Name: catalog.FakePrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_uint64)}},
+						{Name: "price", Typ: columnType},
+					},
 				},
-				Cols: []*planpb.ColDef{
-					{Name: catalog.FakePrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_uint64)}},
-					{Name: "price", Typ: columnType},
-				},
-			},
-			FilterList: filters,
+				FilterList: filterList,
+			}
 		}
 
-		idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{idxDef}, node)
+		t.Run("serialized composite falls back", func(t *testing.T) {
+			idxPos, filterIdx := builder.getIndexForNonEquiCond(
+				[]*planpb.IndexDef{idxDef}, makeNode(filters))
 
-		require.Equal(t, -1, idxPos)
-		require.Nil(t, filterIdx)
+			require.Equal(t, -1, idxPos)
+			require.Nil(t, filterIdx)
+		})
+
+		directUniqueIdxDef := &planpb.IndexDef{
+			Parts:  []string{"price"},
+			Unique: true,
+		}
+
+		t.Run("direct unique single bound remains eligible", func(t *testing.T) {
+			idxPos, filterIdx := builder.getIndexForNonEquiCond(
+				[]*planpb.IndexDef{directUniqueIdxDef}, makeNode(filters[:1]))
+
+			require.Equal(t, 0, idxPos)
+			require.Equal(t, []int32{0}, filterIdx)
+		})
+
+		t.Run("direct unique paired bounds remain eligible", func(t *testing.T) {
+			idxPos, filterIdx := builder.getIndexForNonEquiCond(
+				[]*planpb.IndexDef{directUniqueIdxDef}, makeNode(filters))
+
+			require.Equal(t, 0, idxPos)
+			require.Equal(t, []int32{0, 1}, filterIdx)
+		})
+
+		for _, tc := range []struct {
+			name    string
+			indexes []*planpb.IndexDef
+			wantIdx int
+		}{
+			{
+				name:    "direct unique before serialized composite",
+				indexes: []*planpb.IndexDef{directUniqueIdxDef, idxDef},
+				wantIdx: 0,
+			},
+			{
+				name:    "direct unique after serialized composite",
+				indexes: []*planpb.IndexDef{idxDef, directUniqueIdxDef},
+				wantIdx: 1,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				idxPos, filterIdx := builder.getIndexForNonEquiCond(tc.indexes, makeNode(filters))
+
+				require.Equal(t, tc.wantIdx, idxPos)
+				require.Equal(t, []int32{0, 1}, filterIdx)
+			})
+		}
+
+		t.Run("direct unique paired fallback checks both bounds", func(t *testing.T) {
+			mixedBounds := []*planpb.Expr{
+				makeDecimalRangeFilterExpr(t, bindTag, 1, ">=", "10.250000", columnType, higherScaleType),
+				filters[1],
+			}
+
+			idxPos, filterIdx := builder.getIndexForNonEquiCond(
+				[]*planpb.IndexDef{directUniqueIdxDef, idxDef}, makeNode(mixedBounds))
+
+			require.Equal(t, 0, idxPos)
+			require.Equal(t, []int32{0, 1}, filterIdx)
+		})
+
+		t.Run("direct unique bypasses serialized operator restriction", func(t *testing.T) {
+			filter := makeDecimalRangeFilterExpr(t, bindTag, 1, ">", "10.25", columnType, columnType)
+
+			idxPos, filterIdx := builder.getIndexForNonEquiCond(
+				[]*planpb.IndexDef{directUniqueIdxDef, idxDef}, makeNode([]*planpb.Expr{filter}))
+
+			require.Equal(t, 0, idxPos)
+			require.Equal(t, []int32{0}, filterIdx)
+		})
 	})
 }
 

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -115,6 +115,59 @@ func TestSingleColumnUniqueDecimalRangeUsesIndex(t *testing.T) {
 	require.Equal(t, "uk_a", findFirstIndexScanName(queryPlan))
 }
 
+func TestDirectUniqueDecimalRangeResidualFilterUsesDirectKey(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	addIndexHintChoiceTableForTest(mock)
+	decimalType := planpb.Type{Id: int32(types.T_decimal64), Width: 10, Scale: 2}
+	mainTable := mock.ctxt.tables["index_hint_t"]
+	mainTable.Cols[1].Typ = decimalType
+	mainTable.Indexes = []*planpb.IndexDef{
+		{
+			IndexName:      "uk_a",
+			Parts:          []string{"a"},
+			IndexTableName: "uk_hint_a",
+			TableExist:     true,
+			Unique:         true,
+		},
+		{
+			IndexName:      "idx_a",
+			Parts:          []string{"a", catalog.CreateAlias("id")},
+			IndexTableName: "idx_hint_a",
+			TableExist:     true,
+		},
+	}
+	addIndexHintIndexTableForTest(mock, "uk_hint_a", 25365)
+	mock.ctxt.tables["uk_hint_a"].Cols[0].Typ = decimalType
+	addIndexHintIndexTableForTest(mock, "idx_hint_a", 25366)
+
+	queryPlan, err := runOneStmt(mock, t, `
+		select b
+		from index_hint_t force index(uk_a, idx_a)
+		where a >= 10.255000 and a >= 20.255000`)
+	require.NoError(t, err)
+	require.True(t, planHasIndexJoin(queryPlan))
+	indexScan := findFirstIndexScanNode(queryPlan)
+	require.NotNil(t, indexScan)
+	require.Equal(t, "uk_a", indexScan.IndexScanInfo.IndexName)
+	require.Len(t, indexScan.FilterList, 2)
+
+	residualFn := indexScan.FilterList[1].GetF()
+	require.NotNil(t, residualFn)
+	require.Len(t, residualFn.Args, 2)
+	for _, arg := range residualFn.Args {
+		require.NotNil(t, arg)
+	}
+	residualColExpr := residualFn.Args[0]
+	if residualColExpr.GetCol() == nil {
+		residualColExpr = residualFn.Args[1]
+	}
+	residualCol := residualColExpr.GetCol()
+	require.NotNil(t, residualCol)
+	require.Equal(t, int32(0), residualCol.ColPos)
+	require.Nil(t, residualColExpr.GetF())
+	require.Equal(t, decimalType, residualColExpr.Typ)
+}
+
 func TestFilterRegularIndexesByScanHints(t *testing.T) {
 	idxA := &planpb.IndexDef{IndexName: "idx_a"}
 	idxB := &planpb.IndexDef{IndexName: "idx_b"}

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -5190,6 +5190,111 @@ func TestReplaceRangePairConditionWidensByteStringOpenLowerBound(t *testing.T) {
 	require.Equal(t, uint32(1), fixedWidthLookup.GetF().Args[3].GetLit().GetU8Val())
 }
 
+func TestIndexRangeSerializationNormalizesDecimalBounds(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"price", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+	idxTableDef := makeTestIndexTableDef()
+	columnType := planpb.Type{Id: int32(types.T_decimal64), Width: 10, Scale: 2}
+	higherScaleType := planpb.Type{Id: int32(types.T_decimal64), Width: 10, Scale: 6}
+
+	t.Run("closed pair", func(t *testing.T) {
+		filters := []*planpb.Expr{
+			makeDecimalRangeFilterExpr(t, bindTag, 1, ">=", "10.250000", columnType, higherScaleType),
+			makeDecimalRangeFilterExpr(t, bindTag, 1, "<=", "15.750000", columnType, higherScaleType),
+		}
+
+		expr := builder.replaceRangePairCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
+
+		require.Equal(t, "prefix_between", expr.GetF().Func.ObjName)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[1], columnType, true)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[2], columnType, true)
+	})
+
+	t.Run("open pair", func(t *testing.T) {
+		filters := []*planpb.Expr{
+			makeDecimalRangeFilterExpr(t, bindTag, 1, ">", "10.250000", columnType, higherScaleType),
+			makeDecimalRangeFilterExpr(t, bindTag, 1, "<", "15.750000", columnType, higherScaleType),
+		}
+
+		expr := builder.replaceRangePairCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
+
+		require.Equal(t, "prefix_in_range", expr.GetF().Func.ObjName)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[1], columnType, true)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[2], columnType, true)
+	})
+
+	for _, tc := range []struct {
+		name string
+		op   string
+	}{
+		{name: "lower only", op: ">="},
+		{name: "upper only", op: "<"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := makeDecimalRangeFilterExpr(t, bindTag, 1, tc.op, "10.250000", columnType, higherScaleType)
+
+			expr := builder.replaceNonEqualCondition(idxDef, filter, 42, idxTableDef)
+
+			require.Equal(t, tc.op, expr.GetF().Func.ObjName)
+			requireSerializedRangeBoundType(t, expr.GetF().Args[1], columnType, true)
+		})
+	}
+
+	t.Run("equal scale decimal remains direct", func(t *testing.T) {
+		filters := []*planpb.Expr{
+			makeDecimalRangeFilterExpr(t, bindTag, 1, ">=", "10.25", columnType, columnType),
+			makeDecimalRangeFilterExpr(t, bindTag, 1, "<=", "15.75", columnType, columnType),
+		}
+
+		expr := builder.replaceRangePairCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
+
+		requireSerializedRangeBoundType(t, expr.GetF().Args[1], columnType, false)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[2], columnType, false)
+	})
+
+	t.Run("non decimal remains direct", func(t *testing.T) {
+		intType := planpb.Type{Id: int32(types.T_int64)}
+		filters := []*planpb.Expr{
+			makeTypedInt64RangeFilterExpr(bindTag, 1, ">=", 10, intType),
+			makeTypedInt64RangeFilterExpr(bindTag, 1, "<=", 15, intType),
+		}
+
+		expr := builder.replaceRangePairCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
+
+		requireSerializedRangeBoundType(t, expr.GetF().Args[1], intType, false)
+		requireSerializedRangeBoundType(t, expr.GetF().Args[2], intType, false)
+	})
+
+	t.Run("non representable decimal falls back from index", func(t *testing.T) {
+		filters := []*planpb.Expr{
+			makeDecimalRangeFilterExpr(t, bindTag, 1, ">", "10.255000", columnType, higherScaleType),
+			makeDecimalRangeFilterExpr(t, bindTag, 1, "<=", "15.755000", columnType, higherScaleType),
+		}
+		node := &planpb.Node{
+			TableDef: &planpb.TableDef{
+				Name2ColIndex: map[string]int32{
+					catalog.FakePrimaryKeyColName: 0,
+					"price":                       1,
+				},
+				Cols: []*planpb.ColDef{
+					{Name: catalog.FakePrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_uint64)}},
+					{Name: "price", Typ: columnType},
+				},
+			},
+			FilterList: filters,
+		}
+
+		idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{idxDef}, node)
+
+		require.Equal(t, -1, idxPos)
+		require.Nil(t, filterIdx)
+	})
+}
+
 func TestGetIndexForNonEquiCond_PrefersFirstPairedRangeByFilterOrder(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	bindTag := builder.genNewBindTag()
@@ -5785,6 +5890,69 @@ func makeRangeFilterExpr(relPos, colPos int32, op string, val int64) *planpb.Exp
 				},
 			},
 		},
+	}
+}
+
+func makeDecimalRangeFilterExpr(
+	t *testing.T,
+	relPos, colPos int32,
+	op, val string,
+	columnType, boundType planpb.Type,
+) *planpb.Expr {
+	t.Helper()
+	decimal, err := types.ParseDecimal64(val, boundType.Width, boundType.Scale)
+	require.NoError(t, err)
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: op},
+				Args: []*planpb.Expr{
+					{
+						Typ: columnType,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{RelPos: relPos, ColPos: colPos},
+						},
+					},
+					{
+						Typ: boundType,
+						Expr: &planpb.Expr_Lit{
+							Lit: &planpb.Literal{
+								Value: &planpb.Literal_Decimal64Val{
+									Decimal64Val: &planpb.Decimal64{A: int64(decimal)},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeTypedInt64RangeFilterExpr(relPos, colPos int32, op string, val int64, typ planpb.Type) *planpb.Expr {
+	expr := makeRangeFilterExpr(relPos, colPos, op, val)
+	expr.Typ = planpb.Type{Id: int32(types.T_bool)}
+	expr.GetF().Args[0].Typ = typ
+	expr.GetF().Args[1].Typ = typ
+	return expr
+}
+
+func requireSerializedRangeBoundType(t *testing.T, expr *planpb.Expr, want planpb.Type, wantCast bool) {
+	t.Helper()
+	serial := expr.GetF()
+	require.NotNil(t, serial)
+	require.Equal(t, "serial_full", serial.Func.ObjName)
+	require.Len(t, serial.Args, 1)
+	bound := serial.Args[0]
+	require.Equal(t, want.Id, bound.Typ.Id)
+	require.Equal(t, want.Width, bound.Typ.Width)
+	require.Equal(t, want.Scale, bound.Typ.Scale)
+	if wantCast {
+		require.NotNil(t, bound.GetF())
+		require.Equal(t, "cast", bound.GetF().Func.ObjName)
+	} else {
+		require.Nil(t, bound.GetF())
 	}
 }
 

--- a/test/distributed/cases/optimizer/secondary_index_range.result
+++ b/test/distributed/cases/optimizer/secondary_index_range.result
@@ -1056,4 +1056,79 @@ execute stmt_t11_idx;
 ➤ physical_rows[-5,64,0]  ¦  primary_mappings[-5,64,0]  𝄀
 6  ¦  6
 deallocate prepare stmt_t11_idx;
+drop table if exists t10;
+create table t10 (
+tenant_id int not null,
+id bigint not null,
+price decimal(10,2) not null,
+primary key (tenant_id, id),
+key idx_price_owner (price, tenant_id, id)
+);
+insert into t10
+select 1 + result % 8, result, cast(result / 100.0 as decimal(10,2))
+from generate_series(1, 10000) g;
+set @t10_idx = (select distinct index_table_name from mo_catalog.mo_indexes where name = 'idx_price_owner' limit 1);
+set @t10_idx_sql = concat(
+'select count(*) as physical_rows, count(distinct __mo_index_idx_col) as physical_keys, ',
+'count(distinct __mo_index_pri_col) as primary_mappings from d1.`', @t10_idx, '`'
+);
+prepare stmt_t10_idx from @t10_idx_sql;
+execute stmt_t10_idx;
+➤ physical_rows[-5,64,0]  ¦  physical_keys[-5,64,0]  ¦  primary_mappings[-5,64,0]  𝄀
+10000  ¦  10000  ¦  10000
+deallocate prepare stmt_t10_idx;
+select count(*) as closed_default from t10 where price between 10.250000 and 15.750000;
+➤ closed_default[-5,64,0]  𝄀
+551
+select count(*) as closed_force from t10 force index(idx_price_owner) where price between 10.250000 and 15.750000;
+➤ closed_force[-5,64,0]  𝄀
+551
+select count(*) as closed_ignore from t10 ignore index(idx_price_owner) where price between 10.250000 and 15.750000;
+➤ closed_ignore[-5,64,0]  𝄀
+551
+select count(*) as open_default from t10 where price > 10.250000 and price < 15.750000;
+➤ open_default[-5,64,0]  𝄀
+549
+select count(*) as open_force from t10 force index(idx_price_owner) where price > 10.250000 and price < 15.750000;
+➤ open_force[-5,64,0]  𝄀
+549
+select count(*) as open_ignore from t10 ignore index(idx_price_owner) where price > 10.250000 and price < 15.750000;
+➤ open_ignore[-5,64,0]  𝄀
+549
+select count(*) as lower_force from t10 force index(idx_price_owner) where price >= 10.250000;
+➤ lower_force[-5,64,0]  𝄀
+8976
+select count(*) as lower_ignore from t10 ignore index(idx_price_owner) where price >= 10.250000;
+➤ lower_ignore[-5,64,0]  𝄀
+8976
+select count(*) as upper_force from t10 force index(idx_price_owner) where price < 15.750000;
+➤ upper_force[-5,64,0]  𝄀
+1574
+select count(*) as upper_ignore from t10 ignore index(idx_price_owner) where price < 15.750000;
+➤ upper_ignore[-5,64,0]  𝄀
+1574
+select count(*) as equality_force from t10 force index(idx_price_owner) where price = 10.250000;
+➤ equality_force[-5,64,0]  𝄀
+1
+select count(*) as equality_ignore from t10 ignore index(idx_price_owner) where price = 10.250000;
+➤ equality_ignore[-5,64,0]  𝄀
+1
+select count(*) as equal_scale_force from t10 force index(idx_price_owner) where price between 10.25 and 15.75;
+➤ equal_scale_force[-5,64,0]  𝄀
+551
+select count(*) as equal_scale_ignore from t10 ignore index(idx_price_owner) where price between 10.25 and 15.75;
+➤ equal_scale_ignore[-5,64,0]  𝄀
+551
+select count(*) as rounding_force from t10 force index(idx_price_owner) where price > 10.255000 and price <= 15.755000;
+➤ rounding_force[-5,64,0]  𝄀
+550
+select count(*) as rounding_ignore from t10 ignore index(idx_price_owner) where price > 10.255000 and price <= 15.755000;
+➤ rounding_ignore[-5,64,0]  𝄀
+550
+select count(*) as rounding_between_force from t10 force index(idx_price_owner) where price between 10.255000 and 15.755000;
+➤ rounding_between_force[-5,64,0]  𝄀
+550
+select count(*) as rounding_between_ignore from t10 ignore index(idx_price_owner) where price between 10.255000 and 15.755000;
+➤ rounding_between_ignore[-5,64,0]  𝄀
+550
 drop database d1;

--- a/test/distributed/cases/optimizer/secondary_index_range.sql
+++ b/test/distributed/cases/optimizer/secondary_index_range.sql
@@ -411,6 +411,51 @@ set @t11_idx_sql = concat(
 prepare stmt_t11_idx from @t11_idx_sql;
 execute stmt_t11_idx;
 deallocate prepare stmt_t11_idx;
+ -- 30. Regression #26801: DECIMAL range bounds must be serialized at the
+-- indexed part's scale. The composite PK and direct hidden-table checks keep
+-- index maintenance independent from the range-result oracle.
+drop table if exists t10;
+create table t10 (
+    tenant_id int not null,
+    id bigint not null,
+    price decimal(10,2) not null,
+    primary key (tenant_id, id),
+    key idx_price_owner (price, tenant_id, id)
+);
+insert into t10
+select 1 + result % 8, result, cast(result / 100.0 as decimal(10,2))
+from generate_series(1, 10000) g;
+
+set @t10_idx = (select distinct index_table_name from mo_catalog.mo_indexes where name = 'idx_price_owner' limit 1);
+set @t10_idx_sql = concat(
+    'select count(*) as physical_rows, count(distinct __mo_index_idx_col) as physical_keys, ',
+    'count(distinct __mo_index_pri_col) as primary_mappings from d1.`', @t10_idx, '`'
+);
+prepare stmt_t10_idx from @t10_idx_sql;
+execute stmt_t10_idx;
+deallocate prepare stmt_t10_idx;
+
+select count(*) as closed_default from t10 where price between 10.250000 and 15.750000;
+select count(*) as closed_force from t10 force index(idx_price_owner) where price between 10.250000 and 15.750000;
+select count(*) as closed_ignore from t10 ignore index(idx_price_owner) where price between 10.250000 and 15.750000;
+
+select count(*) as open_default from t10 where price > 10.250000 and price < 15.750000;
+select count(*) as open_force from t10 force index(idx_price_owner) where price > 10.250000 and price < 15.750000;
+select count(*) as open_ignore from t10 ignore index(idx_price_owner) where price > 10.250000 and price < 15.750000;
+
+select count(*) as lower_force from t10 force index(idx_price_owner) where price >= 10.250000;
+select count(*) as lower_ignore from t10 ignore index(idx_price_owner) where price >= 10.250000;
+select count(*) as upper_force from t10 force index(idx_price_owner) where price < 15.750000;
+select count(*) as upper_ignore from t10 ignore index(idx_price_owner) where price < 15.750000;
+
+select count(*) as equality_force from t10 force index(idx_price_owner) where price = 10.250000;
+select count(*) as equality_ignore from t10 ignore index(idx_price_owner) where price = 10.250000;
+select count(*) as equal_scale_force from t10 force index(idx_price_owner) where price between 10.25 and 15.75;
+select count(*) as equal_scale_ignore from t10 ignore index(idx_price_owner) where price between 10.25 and 15.75;
+select count(*) as rounding_force from t10 force index(idx_price_owner) where price > 10.255000 and price <= 15.755000;
+select count(*) as rounding_ignore from t10 ignore index(idx_price_owner) where price > 10.255000 and price <= 15.755000;
+select count(*) as rounding_between_force from t10 force index(idx_price_owner) where price between 10.255000 and 15.755000;
+select count(*) as rounding_between_ignore from t10 ignore index(idx_price_owner) where price between 10.255000 and 15.755000;
 
 -- Cleanup
 drop database d1;


### PR DESCRIPTION
Fixes #26801.

Composite secondary-index range rewrites serialized DECIMAL constants using the literal scale instead of the indexed column scale. This produced wrong lower-bound bytes and could under-fetch or over-fetch rows.

The fix losslessly normalizes range constants to the indexed DECIMAL type before serialization. Bounds that require rounding conservatively bypass the index rewrite. Equal-scale and non-DECIMAL paths remain unchanged.

Validation:
- closed/open paired ranges
- lower-only and upper-only bounds
- equality and equal-scale controls
- rounding-sensitive fallback
- full pkg/sql/plan CGo suite
- isolated secondary_index_range BVT: 197/197
- git diff --check