### PR TITLE
fix binary secondary-index point lookup semantics

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1927,40 +1927,65 @@ func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef, tableDef *plan.Table
 		}
 	}
 
-	if lookupFilter == nil {
-		return false
-	}
-	lookupFn := lookupFilter.GetF()
-	if lookupFn == nil || lookupFn.Func == nil ||
-		(lookupFn.Func.ObjName != "prefix_eq" && lookupFn.Func.ObjName != "prefix_in") || len(leadingPos) == 0 {
+	if len(leadingPos) == 0 || !indexLookupUsesPrefixComparison(lookupFilter) {
 		return false
 	}
 	lastPos := leadingPos[len(leadingPos)-1]
 	if lastPos < 0 || int(lastPos) >= len(filterList) {
 		return false
 	}
-	return indexFilterComparesByteStringColumn(tableDef, filterList[lastPos])
+	return indexFilterUsesPrefixAmbiguousStringColumn(tableDef, filterList[lastPos])
 }
 
-func indexFilterComparesByteStringColumn(tableDef *plan.TableDef, expr *plan.Expr) bool {
-	if tableDef == nil || expr == nil {
+func indexLookupUsesPrefixComparison(expr *plan.Expr) bool {
+	if expr == nil {
 		return false
 	}
 	fn := expr.GetF()
-	if fn == nil || fn.Func == nil || (fn.Func.ObjName != "=" && fn.Func.ObjName != "in") {
+	if fn == nil || fn.Func == nil {
 		return false
 	}
+	switch fn.Func.ObjName {
+	case "prefix_eq", "prefix_in", "prefix_between", "prefix_in_range":
+		return true
+	}
 	for _, arg := range fn.Args {
-		col := arg.GetCol()
-		if col == nil || col.ColPos < 0 || int(col.ColPos) >= len(tableDef.Cols) {
-			continue
+		if indexLookupUsesPrefixComparison(arg) {
+			return true
 		}
-		oid := types.T(tableDef.Cols[col.ColPos].Typ.Id)
-		// CHAR, VARCHAR, BINARY, and VARBINARY all use Packer.EncodeStringType.
+	}
+	return false
+}
+
+func indexFilterUsesPrefixAmbiguousStringColumn(tableDef *plan.TableDef, expr *plan.Expr) bool {
+	if tableDef == nil || expr == nil {
+		return false
+	}
+	if col := expr.GetCol(); col != nil && col.ColPos >= 0 && int(col.ColPos) < len(tableDef.Cols) {
+		colDef := tableDef.Cols[col.ColPos]
+		if colDef == nil {
+			return false
+		}
+		oid := types.T(colDef.Typ.Id)
+		// CHAR, VARCHAR, BINARY, and VARBINARY use Packer.EncodeStringType.
 		// Its 0x00 terminator is also the first byte of an escaped embedded NUL,
-		// so an encoded value can prefix the encoding of value+NUL.
+		// so an encoded lookup value can prefix a distinct stored encoding.
 		return oid == types.T_char || oid == types.T_varchar ||
 			oid == types.T_binary || oid == types.T_varbinary
+	}
+	if fn := expr.GetF(); fn != nil {
+		for _, arg := range fn.Args {
+			if indexFilterUsesPrefixAmbiguousStringColumn(tableDef, arg) {
+				return true
+			}
+		}
+	}
+	if list := expr.GetList(); list != nil {
+		for _, item := range list.List {
+			if indexFilterUsesPrefixAmbiguousStringColumn(tableDef, item) {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -2127,9 +2152,14 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 	}
 
 	newLeadingFilter := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
-	newFilterList := make([]*plan.Expr, 0, len(node.FilterList))
+	keepLeadingResidual := needsIndexOnlyResidualLeadingFilters(idxDef, node.TableDef, node.FilterList, leadingPos, newLeadingFilter)
+	filterCapacity := 1 + len(missFilterIdx)
+	if keepLeadingResidual {
+		filterCapacity += len(leadingPos)
+	}
+	newFilterList := make([]*plan.Expr, 0, filterCapacity)
 	newFilterList = append(newFilterList, newLeadingFilter)
-	if needsIndexOnlyResidualLeadingFilters(idxDef, node.TableDef, node.FilterList, leadingPos, newLeadingFilter) {
+	if keepLeadingResidual {
 		// Keep the original SQL predicate when serial_full lookup bytes are not
 		// an exact semantic oracle: NULL is encoded as key bytes, and a byte-string
 		// terminator can also begin an escaped embedded NUL.

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1939,10 +1939,10 @@ func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef, tableDef *plan.Table
 	if lastPos < 0 || int(lastPos) >= len(filterList) {
 		return false
 	}
-	return indexFilterComparesBinaryColumn(tableDef, filterList[lastPos])
+	return indexFilterComparesByteStringColumn(tableDef, filterList[lastPos])
 }
 
-func indexFilterComparesBinaryColumn(tableDef *plan.TableDef, expr *plan.Expr) bool {
+func indexFilterComparesByteStringColumn(tableDef *plan.TableDef, expr *plan.Expr) bool {
 	if tableDef == nil || expr == nil {
 		return false
 	}
@@ -1956,7 +1956,11 @@ func indexFilterComparesBinaryColumn(tableDef *plan.TableDef, expr *plan.Expr) b
 			continue
 		}
 		oid := types.T(tableDef.Cols[col.ColPos].Typ.Id)
-		return oid == types.T_binary || oid == types.T_varbinary
+		// CHAR, VARCHAR, BINARY, and VARBINARY all use Packer.EncodeStringType.
+		// Its 0x00 terminator is also the first byte of an escaped embedded NUL,
+		// so an encoded value can prefix the encoding of value+NUL.
+		return oid == types.T_char || oid == types.T_varchar ||
+			oid == types.T_binary || oid == types.T_varbinary
 	}
 	return false
 }
@@ -2127,8 +2131,8 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 	newFilterList = append(newFilterList, newLeadingFilter)
 	if needsIndexOnlyResidualLeadingFilters(idxDef, node.TableDef, node.FilterList, leadingPos, newLeadingFilter) {
 		// Keep the original SQL predicate when serial_full lookup bytes are not
-		// an exact semantic oracle: NULL is encoded as key bytes, and a binary
-		// encoded terminator byte can also begin an escaped binary NUL.
+		// an exact semantic oracle: NULL is encoded as key bytes, and a byte-string
+		// terminator can also begin an escaped embedded NUL.
 		for _, idx := range leadingPos {
 			newFilterList = append(newFilterList, replaceColumnsForExpr(DeepCopyExpr(node.FilterList[idx]), idxColMap))
 		}

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1863,6 +1863,7 @@ func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *
 		}
 		return expr
 	}
+	comparesByteStringColumn := indexFunctionComparesByteStringColumn(fn)
 
 	switch fn.Func.ObjName {
 	case ">", ">=", "<", "<=":
@@ -1901,6 +1902,14 @@ func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *
 		case "in_range":
 			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
 			fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[2]})
+			if comparesByteStringColumn {
+				// PrefixCompare cannot distinguish an encoded byte string from a
+				// longer value for which that encoding is a prefix.  An open lower
+				// bound would therefore drop valid longer values.  Widen the index
+				// candidate range to a closed lower bound; the original predicate is
+				// retained as an exact residual on index-only scans or the base scan.
+				fn.Args[3] = closePrefixRangeLowerBound(fn.Args[3])
+			}
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_in_range", fn.Args)
 		}
 	}
@@ -1914,27 +1923,36 @@ func (builder *QueryBuilder) replaceLeadingFilter(idxDef *IndexDef, filterList [
 	return builder.replaceEqualCondition(idxDef, filterList, leadingPos, idxTag, idxTableDef)
 }
 
-func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef, tableDef *plan.TableDef, filterList []*plan.Expr, leadingPos []int32, lookupFilter *plan.Expr) bool {
+func indexOnlyResidualLeadingFilterPositions(idxDef *IndexDef, tableDef *plan.TableDef, filterList []*plan.Expr, leadingPos []int32, lookupFilter *plan.Expr) []int32 {
 	if indexTableLookupSerialFunc(idxDef) != "serial_full" {
-		return false
+		return nil
 	}
+	residualPos := make([]int32, 0, len(leadingPos))
 	for _, pos := range leadingPos {
 		if pos < 0 || int(pos) >= len(filterList) {
 			continue
 		}
 		if indexFilterMayCompareNullAtRuntime(filterList[pos]) {
-			return true
+			residualPos = append(residualPos, pos)
 		}
 	}
 
 	if len(leadingPos) == 0 || !indexLookupUsesPrefixComparison(lookupFilter) {
-		return false
+		return residualPos
 	}
 	lastPos := leadingPos[len(leadingPos)-1]
 	if lastPos < 0 || int(lastPos) >= len(filterList) {
-		return false
+		return residualPos
 	}
-	return indexFilterUsesPrefixAmbiguousStringColumn(tableDef, filterList[lastPos])
+	if !indexFilterUsesPrefixAmbiguousStringColumn(tableDef, filterList[lastPos]) {
+		return residualPos
+	}
+	for _, pos := range residualPos {
+		if pos == lastPos {
+			return residualPos
+		}
+	}
+	return append(residualPos, lastPos)
 }
 
 func indexLookupUsesPrefixComparison(expr *plan.Expr) bool {
@@ -1988,6 +2006,32 @@ func indexFilterUsesPrefixAmbiguousStringColumn(tableDef *plan.TableDef, expr *p
 		}
 	}
 	return false
+}
+
+func indexFunctionComparesByteStringColumn(fn *plan.Function) bool {
+	if fn == nil {
+		return false
+	}
+	for _, arg := range fn.Args {
+		if arg.GetCol() == nil {
+			continue
+		}
+		oid := types.T(arg.Typ.Id)
+		return oid == types.T_char || oid == types.T_varchar ||
+			oid == types.T_binary || oid == types.T_varbinary
+	}
+	return false
+}
+
+func closePrefixRangeLowerBound(flagExpr *plan.Expr) *plan.Expr {
+	if flagExpr == nil || flagExpr.GetLit() == nil {
+		return flagExpr
+	}
+	flag := uint8(flagExpr.GetLit().GetU8Val())
+	if flag&1 == 0 {
+		return flagExpr
+	}
+	return MakePlan2Uint8ConstExprWithType(flag &^ 1)
 }
 
 func indexFilterMayCompareNullAtRuntime(expr *plan.Expr) bool {
@@ -2152,18 +2196,15 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 	}
 
 	newLeadingFilter := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
-	keepLeadingResidual := needsIndexOnlyResidualLeadingFilters(idxDef, node.TableDef, node.FilterList, leadingPos, newLeadingFilter)
-	filterCapacity := 1 + len(missFilterIdx)
-	if keepLeadingResidual {
-		filterCapacity += len(leadingPos)
-	}
+	residualLeadingPos := indexOnlyResidualLeadingFilterPositions(idxDef, node.TableDef, node.FilterList, leadingPos, newLeadingFilter)
+	filterCapacity := 1 + len(missFilterIdx) + len(residualLeadingPos)
 	newFilterList := make([]*plan.Expr, 0, filterCapacity)
 	newFilterList = append(newFilterList, newLeadingFilter)
-	if keepLeadingResidual {
+	if len(residualLeadingPos) > 0 {
 		// Keep the original SQL predicate when serial_full lookup bytes are not
 		// an exact semantic oracle: NULL is encoded as key bytes, and a byte-string
 		// terminator can also begin an escaped embedded NUL.
-		for _, idx := range leadingPos {
+		for _, idx := range residualLeadingPos {
 			newFilterList = append(newFilterList, replaceColumnsForExpr(DeepCopyExpr(node.FilterList[idx]), idxColMap))
 		}
 	}
@@ -2500,6 +2541,11 @@ func (builder *QueryBuilder) replaceRangePairCondition(idxDef *IndexDef, filterL
 	}
 	if upperOp == "<" {
 		flag |= 2
+	}
+	if numParts > 1 && indexFunctionComparesByteStringColumn(lowerFn) {
+		// See replaceNonEqualCondition: make the prefix condition a candidate
+		// superset when the original lower bound is open.
+		flag &^= 1
 	}
 	funcName := "in_range"
 	if numParts > 1 {

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1914,7 +1914,7 @@ func (builder *QueryBuilder) replaceLeadingFilter(idxDef *IndexDef, filterList [
 	return builder.replaceEqualCondition(idxDef, filterList, leadingPos, idxTag, idxTableDef)
 }
 
-func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef, filterList []*plan.Expr, leadingPos []int32) bool {
+func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef, tableDef *plan.TableDef, filterList []*plan.Expr, leadingPos []int32, lookupFilter *plan.Expr) bool {
 	if indexTableLookupSerialFunc(idxDef) != "serial_full" {
 		return false
 	}
@@ -1925,6 +1925,38 @@ func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef, filterList []*plan.E
 		if indexFilterMayCompareNullAtRuntime(filterList[pos]) {
 			return true
 		}
+	}
+
+	if lookupFilter == nil {
+		return false
+	}
+	lookupFn := lookupFilter.GetF()
+	if lookupFn == nil || lookupFn.Func == nil ||
+		(lookupFn.Func.ObjName != "prefix_eq" && lookupFn.Func.ObjName != "prefix_in") || len(leadingPos) == 0 {
+		return false
+	}
+	lastPos := leadingPos[len(leadingPos)-1]
+	if lastPos < 0 || int(lastPos) >= len(filterList) {
+		return false
+	}
+	return indexFilterComparesBinaryColumn(tableDef, filterList[lastPos])
+}
+
+func indexFilterComparesBinaryColumn(tableDef *plan.TableDef, expr *plan.Expr) bool {
+	if tableDef == nil || expr == nil {
+		return false
+	}
+	fn := expr.GetF()
+	if fn == nil || fn.Func == nil || (fn.Func.ObjName != "=" && fn.Func.ObjName != "in") {
+		return false
+	}
+	for _, arg := range fn.Args {
+		col := arg.GetCol()
+		if col == nil || col.ColPos < 0 || int(col.ColPos) >= len(tableDef.Cols) {
+			continue
+		}
+		oid := types.T(tableDef.Cols[col.ColPos].Typ.Id)
+		return oid == types.T_binary || oid == types.T_varbinary
 	}
 	return false
 }
@@ -2093,10 +2125,10 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 	newLeadingFilter := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
 	newFilterList := make([]*plan.Expr, 0, len(node.FilterList))
 	newFilterList = append(newFilterList, newLeadingFilter)
-	if needsIndexOnlyResidualLeadingFilters(idxDef, node.FilterList, leadingPos) {
-		// serial_full preserves NULL as key bytes. Keep the original SQL
-		// predicate as a residual recheck so prepared NULL values still follow
-		// SQL three-valued logic on covering index-only scans.
+	if needsIndexOnlyResidualLeadingFilters(idxDef, node.TableDef, node.FilterList, leadingPos, newLeadingFilter) {
+		// Keep the original SQL predicate when serial_full lookup bytes are not
+		// an exact semantic oracle: NULL is encoded as key bytes, and a binary
+		// encoded terminator byte can also begin an escaped binary NUL.
 		for _, idx := range leadingPos {
 			newFilterList = append(newFilterList, replaceColumnsForExpr(DeepCopyExpr(node.FilterList[idx]), idxColMap))
 		}

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -4285,6 +4285,120 @@ func TestTryIndexOnlyScanSkipsResidualFilterForNonNullSerialFullLiterals(t *test
 	}
 }
 
+func TestTryIndexOnlyScanHandlesBinaryPrefixLookups(t *testing.T) {
+	tests := []struct {
+		name       string
+		typ        types.T
+		makeFilter func(relPos int32) *planpb.Expr
+		lookupFunc string
+		residual   string
+	}{
+		{
+			name: "varbinary equality",
+			typ:  types.T_varbinary,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringEqFilterExpr(relPos, 1, "\x00")
+			},
+			lookupFunc: "prefix_eq",
+			residual:   "=",
+		},
+		{
+			name: "varbinary in",
+			typ:  types.T_varbinary,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringInFilterExpr(relPos, 1, "", "\x00")
+			},
+			lookupFunc: "prefix_in",
+			residual:   "in",
+		},
+		{
+			name: "varbinary between",
+			typ:  types.T_varbinary,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringBetweenFilterExpr(relPos, 1, "\x00", "\x00\x01")
+			},
+			lookupFunc: "prefix_between",
+		},
+		{
+			name: "binary equality",
+			typ:  types.T_binary,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringEqFilterExpr(relPos, 1, "\x00")
+			},
+			lookupFunc: "prefix_eq",
+			residual:   "=",
+		},
+		{
+			name: "binary in",
+			typ:  types.T_binary,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringInFilterExpr(relPos, 1, "", "\x00")
+			},
+			lookupFunc: "prefix_in",
+			residual:   "in",
+		},
+		{
+			name: "binary between",
+			typ:  types.T_binary,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringBetweenFilterExpr(relPos, 1, "\x00", "\x00\x01")
+			},
+			lookupFunc: "prefix_between",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+			ctx := NewBindContext(builder, nil)
+			bindTag := builder.genNewBindTag()
+			idxDef := &planpb.IndexDef{
+				IndexName:      "idx_b_id",
+				IndexAlgo:      catalog.MoIndexDefaultAlgo.ToString(),
+				IndexTableName: "__mo_idx_b_id",
+				Parts:          []string{"b", "id"},
+				Unique:         false,
+				TableExist:     true,
+			}
+			registerMockIndexTable(t, builder, idxDef.IndexTableName)
+			filter := tt.makeFilter(bindTag)
+			binaryType := planpb.Type{Id: int32(tt.typ), Width: 8}
+			setIndexFilterArgumentType(filter, binaryType)
+			node := &planpb.Node{
+				NodeType:    planpb.Node_TABLE_SCAN,
+				ObjRef:      &planpb.ObjectRef{SchemaName: "test", ObjName: "t"},
+				BindingTags: []int32{bindTag},
+				TableDef: &planpb.TableDef{
+					Name: "t",
+					Cols: []*planpb.ColDef{
+						{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+						{Name: "b", Typ: binaryType},
+					},
+					Name2ColIndex: map[string]int32{"id": 0, "b": 1},
+					Pkey:          &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+				},
+				Stats:      &planpb.Stats{TableCnt: 100, Outcnt: 1, Selectivity: 0.01, Cost: 100},
+				FilterList: []*planpb.Expr{filter},
+			}
+			scanID := builder.appendNode(node, ctx)
+
+			idxNodeID := builder.tryIndexOnlyScan(idxDef, builder.qry.Nodes[scanID], map[[2]int32]int{{bindTag, 1}: 1}, map[[2]int32]*planpb.Expr{}, &Snapshot{})
+			require.NotEqual(t, int32(-1), idxNodeID)
+
+			idxNode := builder.qry.Nodes[idxNodeID]
+			require.Equal(t, tt.lookupFunc, idxNode.FilterList[0].GetF().Func.ObjName)
+			if tt.residual == "" {
+				require.Len(t, idxNode.FilterList, 1)
+				return
+			}
+			require.Len(t, idxNode.FilterList, 2)
+			require.Equal(t, tt.residual, idxNode.FilterList[1].GetF().Func.ObjName)
+			require.Equal(t, "serial_extract", wrappedSerialFuncName(t, idxNode.FilterList[1].GetF().Args[0]))
+			require.Equal(t, int32(tt.typ), idxNode.FilterList[1].GetF().Args[0].Typ.Id)
+		})
+	}
+}
+
 func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	bindTag := builder.genNewBindTag()
@@ -4504,6 +4618,28 @@ func makeStringEqFilterExpr(relPos, colPos int32, val string) *planpb.Expr {
 				},
 			},
 		},
+	}
+}
+
+func setIndexFilterArgumentType(expr *planpb.Expr, typ planpb.Type) {
+	fn := expr.GetF()
+	if fn == nil {
+		return
+	}
+	for _, arg := range fn.Args {
+		setExprTypeRecursive(arg, typ)
+	}
+}
+
+func setExprTypeRecursive(expr *planpb.Expr, typ planpb.Type) {
+	if expr == nil {
+		return
+	}
+	expr.Typ = typ
+	if list := expr.GetList(); list != nil {
+		for _, item := range list.List {
+			setExprTypeRecursive(item, typ)
+		}
 	}
 }
 

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -4211,7 +4211,7 @@ func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testin
 	}
 }
 
-func TestTryIndexOnlyScanPreservesVarcharResidualForPointLiterals(t *testing.T) {
+func TestTryIndexOnlyScanPreservesVarcharResidualForPrefixLookups(t *testing.T) {
 	tests := []struct {
 		name       string
 		makeFilter func(relPos int32) *planpb.Expr
@@ -4240,6 +4240,7 @@ func TestTryIndexOnlyScanPreservesVarcharResidualForPointLiterals(t *testing.T) 
 				return makeStringBetweenFilterExpr(relPos, 1, "active", "expired")
 			},
 			lookupFunc: "prefix_between",
+			residual:   "between",
 		},
 	}
 
@@ -4326,6 +4327,7 @@ func TestTryIndexOnlyScanHandlesByteStringPrefixLookups(t *testing.T) {
 				return makeStringBetweenFilterExpr(relPos, 1, "\x00", "\x00\x01")
 			},
 			lookupFunc: "prefix_between",
+			residual:   "between",
 		},
 		{
 			name: "binary equality",
@@ -4352,6 +4354,7 @@ func TestTryIndexOnlyScanHandlesByteStringPrefixLookups(t *testing.T) {
 				return makeStringBetweenFilterExpr(relPos, 1, "\x00", "\x00\x01")
 			},
 			lookupFunc: "prefix_between",
+			residual:   "between",
 		},
 		{
 			name: "varchar equality with encoded terminator collision",
@@ -4433,6 +4436,56 @@ func TestTryIndexOnlyScanHandlesByteStringPrefixLookups(t *testing.T) {
 			require.Equal(t, int32(tt.typ), idxNode.FilterList[1].GetF().Args[0].Typ.Id)
 		})
 	}
+}
+
+func TestNeedsIndexOnlyResidualLeadingFiltersUsesTrailingPrefixPart(t *testing.T) {
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"v", "n", "id"},
+		Unique: false,
+	}
+	tableDef := &planpb.TableDef{Cols: []*planpb.ColDef{
+		{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+		{Name: "v", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 16}},
+		{Name: "n", Typ: planpb.Type{Id: int32(types.T_int64)}},
+	}}
+	filters := []*planpb.Expr{
+		makeStringEqFilterExpr(0, 1, "a"),
+		makeEqFilterExpr(2),
+	}
+	lookupFilter := &planpb.Expr{Expr: &planpb.Expr_F{F: &planpb.Function{
+		Func: &planpb.ObjectRef{ObjName: "prefix_eq"},
+	}}}
+
+	// A byte-string component before another encoded component is delimited by
+	// that component's type byte. Only the trailing component can collide with
+	// the appended primary-key suffix, so a fixed-width trailing part needs no
+	// residual recheck.
+	require.False(t, needsIndexOnlyResidualLeadingFilters(
+		idxDef, tableDef, filters, []int32{0, 1}, lookupFilter,
+	))
+	require.True(t, needsIndexOnlyResidualLeadingFilters(
+		idxDef, tableDef, filters, []int32{1, 0}, lookupFilter,
+	))
+}
+
+func TestNeedsIndexOnlyResidualLeadingFiltersRecognizesNestedPrefixRange(t *testing.T) {
+	idxDef := &planpb.IndexDef{Parts: []string{"v", "id"}, Unique: false}
+	tableDef := &planpb.TableDef{Cols: []*planpb.ColDef{
+		{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+		{Name: "v", Typ: planpb.Type{Id: int32(types.T_varbinary), Width: 16}},
+	}}
+	filter := makeStringBetweenFilterExpr(0, 1, "\x00", "\x00")
+	prefixRange := &planpb.Expr{Expr: &planpb.Expr_F{F: &planpb.Function{
+		Func: &planpb.ObjectRef{ObjName: "prefix_in_range"},
+	}}}
+	lookupFilter := &planpb.Expr{Expr: &planpb.Expr_F{F: &planpb.Function{
+		Func: &planpb.ObjectRef{ObjName: "or"},
+		Args: []*planpb.Expr{prefixRange},
+	}}}
+
+	require.True(t, needsIndexOnlyResidualLeadingFilters(
+		idxDef, tableDef, []*planpb.Expr{filter}, []int32{0}, lookupFilter,
+	))
 }
 
 func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing.T) {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -4211,11 +4211,12 @@ func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testin
 	}
 }
 
-func TestTryIndexOnlyScanSkipsResidualFilterForNonNullSerialFullLiterals(t *testing.T) {
+func TestTryIndexOnlyScanPreservesVarcharResidualForPointLiterals(t *testing.T) {
 	tests := []struct {
 		name       string
 		makeFilter func(relPos int32) *planpb.Expr
 		lookupFunc string
+		residual   string
 	}{
 		{
 			name: "literal equality",
@@ -4223,6 +4224,7 @@ func TestTryIndexOnlyScanSkipsResidualFilterForNonNullSerialFullLiterals(t *test
 				return makeStringEqFilterExpr(relPos, 1, "active")
 			},
 			lookupFunc: "prefix_eq",
+			residual:   "=",
 		},
 		{
 			name: "literal in list",
@@ -4230,6 +4232,7 @@ func TestTryIndexOnlyScanSkipsResidualFilterForNonNullSerialFullLiterals(t *test
 				return makeStringInFilterExpr(relPos, 1, "active", "expired")
 			},
 			lookupFunc: "prefix_in",
+			residual:   "in",
 		},
 		{
 			name: "literal between",
@@ -4279,13 +4282,18 @@ func TestTryIndexOnlyScanSkipsResidualFilterForNonNullSerialFullLiterals(t *test
 			require.NotEqual(t, int32(-1), idxNodeID)
 
 			idxNode := builder.qry.Nodes[idxNodeID]
-			require.Len(t, idxNode.FilterList, 1)
 			require.Equal(t, tt.lookupFunc, idxNode.FilterList[0].GetF().Func.ObjName)
+			if tt.residual == "" {
+				require.Len(t, idxNode.FilterList, 1)
+				return
+			}
+			require.Len(t, idxNode.FilterList, 2)
+			require.Equal(t, tt.residual, idxNode.FilterList[1].GetF().Func.ObjName)
 		})
 	}
 }
 
-func TestTryIndexOnlyScanHandlesBinaryPrefixLookups(t *testing.T) {
+func TestTryIndexOnlyScanHandlesByteStringPrefixLookups(t *testing.T) {
 	tests := []struct {
 		name       string
 		typ        types.T
@@ -4344,6 +4352,34 @@ func TestTryIndexOnlyScanHandlesBinaryPrefixLookups(t *testing.T) {
 				return makeStringBetweenFilterExpr(relPos, 1, "\x00", "\x00\x01")
 			},
 			lookupFunc: "prefix_between",
+		},
+		{
+			name: "varchar equality with encoded terminator collision",
+			typ:  types.T_varchar,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringEqFilterExpr(relPos, 1, "a")
+			},
+			lookupFunc: "prefix_eq",
+			residual:   "=",
+		},
+		{
+			name: "char in with encoded terminator collision",
+			typ:  types.T_char,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringInFilterExpr(relPos, 1, "a", "b")
+			},
+			lookupFunc: "prefix_in",
+			residual:   "in",
+		},
+		{
+			name: "int64 equality fixed-width control",
+			typ:  types.T_int64,
+			makeFilter: func(relPos int32) *planpb.Expr {
+				expr := makeEqFilterExpr(1)
+				expr.GetF().Args[0].GetCol().RelPos = relPos
+				return expr
+			},
+			lookupFunc: "prefix_eq",
 		},
 	}
 

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -4112,6 +4112,107 @@ func TestReplaceNonEqualConditionWrapsEachPreparedInListItemWithSerialFull(t *te
 	}
 }
 
+func TestReplaceNonEqualConditionWidensByteStringOpenLowerBound(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"b", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+	tableDef := &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{Name: catalog.CPrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "b", Typ: planpb.Type{Id: int32(types.T_varbinary), Width: 8}},
+		},
+	}
+	original := makeStringInRangeFilterExpr(0, 1, "a", "b", 3)
+	setIndexRangeArgumentType(original, tableDef.Cols[1].Typ)
+	lookup := builder.replaceNonEqualCondition(idxDef, original, 42, makeTestIndexTableDef())
+
+	require.Equal(t, uint32(3), original.GetF().Args[3].GetLit().GetU8Val())
+	require.Equal(t, "prefix_in_range", lookup.GetF().Func.ObjName)
+	require.Equal(t, uint32(2), lookup.GetF().Args[3].GetLit().GetU8Val())
+	require.Equal(t, []int32{0}, indexOnlyResidualLeadingFilterPositions(
+		idxDef, tableDef, []*planpb.Expr{original}, []int32{0}, lookup,
+	))
+
+	fixedWidth := makeIntInRangeFilterExpr(0, 1, 1, 2, 3)
+	fixedLookup := builder.replaceNonEqualCondition(idxDef, fixedWidth, 42, makeTestIndexTableDef())
+	require.Equal(t, "prefix_in_range", fixedLookup.GetF().Func.ObjName)
+	require.Equal(t, uint32(3), fixedLookup.GetF().Args[3].GetLit().GetU8Val())
+}
+
+func TestIndexOnlyResidualDetectsNestedByteStringPrefixLookup(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"b", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+	tableDef := &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{Name: catalog.CPrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "b", Typ: planpb.Type{Id: int32(types.T_varbinary), Width: 8}},
+		},
+	}
+	original := makeOrFilterExpr(
+		makeStringBetweenFilterExpr(0, 1, "\x01", "\x01"),
+		makeStringInFilterExpr(0, 1, "", "\x00"),
+	)
+	setIndexFilterArgumentType(original.GetF().Args[0], tableDef.Cols[1].Typ)
+	setIndexFilterArgumentType(original.GetF().Args[1], tableDef.Cols[1].Typ)
+	lookup := builder.replaceNonEqualCondition(idxDef, original, 42, makeTestIndexTableDef())
+
+	require.Equal(t, "or", lookup.GetF().Func.ObjName)
+	require.Equal(t, "prefix_between", lookup.GetF().Args[0].GetF().Func.ObjName)
+	require.Equal(t, "prefix_in", lookup.GetF().Args[1].GetF().Func.ObjName)
+	require.Equal(t, []int32{0}, indexOnlyResidualLeadingFilterPositions(
+		idxDef, tableDef, []*planpb.Expr{original}, []int32{0}, lookup,
+	))
+}
+
+func TestIndexOnlyResidualLeadingFilterPositionsAreMinimal(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"first", "last", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+	tableDef := &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{Name: catalog.CPrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "first", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "last", Typ: planpb.Type{Id: int32(types.T_varbinary), Width: 8}},
+		},
+	}
+	firstLiteral := makeEqFilterExpr(1)
+	firstLiteral.GetF().Args[0].GetCol().RelPos = 0
+	lastLiteral := makeStringEqFilterExpr(0, 2, "\x00")
+	setIndexFilterArgumentType(lastLiteral, tableDef.Cols[2].Typ)
+	filters := []*planpb.Expr{firstLiteral, lastLiteral}
+	lookup := builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+
+	require.Equal(t, []int32{1}, indexOnlyResidualLeadingFilterPositions(
+		idxDef, tableDef, filters, []int32{0, 1}, lookup,
+	))
+
+	firstPrepared := makeParamEqFilterExpr(0, 1, 0)
+	filters[0] = firstPrepared
+	lookup = builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	require.Equal(t, []int32{0, 1}, indexOnlyResidualLeadingFilterPositions(
+		idxDef, tableDef, filters, []int32{0, 1}, lookup,
+	))
+
+	tableDef.Cols[1].Typ = planpb.Type{Id: int32(types.T_varbinary), Width: 8}
+	tableDef.Cols[2].Typ = planpb.Type{Id: int32(types.T_int64)}
+	firstByteString := makeStringEqFilterExpr(0, 1, "\x00")
+	setIndexFilterArgumentType(firstByteString, tableDef.Cols[1].Typ)
+	lastFixedWidth := makeEqFilterExpr(2)
+	lastFixedWidth.GetF().Args[0].GetCol().RelPos = 0
+	filters = []*planpb.Expr{firstByteString, lastFixedWidth}
+	lookup = builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	require.Empty(t, indexOnlyResidualLeadingFilterPositions(
+		idxDef, tableDef, filters, []int32{0, 1}, lookup,
+	))
+}
+
 func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -4211,7 +4312,7 @@ func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testin
 	}
 }
 
-func TestTryIndexOnlyScanPreservesVarcharResidualForPrefixLookups(t *testing.T) {
+func TestTryIndexOnlyScanPreservesVarcharResidualForPrefixPredicates(t *testing.T) {
 	tests := []struct {
 		name       string
 		makeFilter func(relPos int32) *planpb.Expr
@@ -4438,7 +4539,7 @@ func TestTryIndexOnlyScanHandlesByteStringPrefixLookups(t *testing.T) {
 	}
 }
 
-func TestNeedsIndexOnlyResidualLeadingFiltersUsesTrailingPrefixPart(t *testing.T) {
+func TestIndexOnlyResidualLeadingFilterPositionsUsesTrailingPrefixPart(t *testing.T) {
 	idxDef := &planpb.IndexDef{
 		Parts:  []string{"v", "n", "id"},
 		Unique: false,
@@ -4460,15 +4561,15 @@ func TestNeedsIndexOnlyResidualLeadingFiltersUsesTrailingPrefixPart(t *testing.T
 	// that component's type byte. Only the trailing component can collide with
 	// the appended primary-key suffix, so a fixed-width trailing part needs no
 	// residual recheck.
-	require.False(t, needsIndexOnlyResidualLeadingFilters(
+	require.Empty(t, indexOnlyResidualLeadingFilterPositions(
 		idxDef, tableDef, filters, []int32{0, 1}, lookupFilter,
 	))
-	require.True(t, needsIndexOnlyResidualLeadingFilters(
+	require.Equal(t, []int32{0}, indexOnlyResidualLeadingFilterPositions(
 		idxDef, tableDef, filters, []int32{1, 0}, lookupFilter,
 	))
 }
 
-func TestNeedsIndexOnlyResidualLeadingFiltersRecognizesNestedPrefixRange(t *testing.T) {
+func TestIndexOnlyResidualLeadingFilterPositionsRecognizesNestedPrefixRange(t *testing.T) {
 	idxDef := &planpb.IndexDef{Parts: []string{"v", "id"}, Unique: false}
 	tableDef := &planpb.TableDef{Cols: []*planpb.ColDef{
 		{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
@@ -4483,7 +4584,7 @@ func TestNeedsIndexOnlyResidualLeadingFiltersRecognizesNestedPrefixRange(t *test
 		Args: []*planpb.Expr{prefixRange},
 	}}}
 
-	require.True(t, needsIndexOnlyResidualLeadingFilters(
+	require.Equal(t, []int32{0}, indexOnlyResidualLeadingFilterPositions(
 		idxDef, tableDef, []*planpb.Expr{filter}, []int32{0}, lookupFilter,
 	))
 }
@@ -4521,6 +4622,33 @@ func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing
 	assert.Equal(t, "serial_full", wrappedSerialFuncName(t, expr.GetF().Args[1]))
 	assert.Equal(t, "serial_full", wrappedSerialFuncName(t, expr.GetF().Args[2]))
 	require.InDelta(t, 0.12, expr.Selectivity, 1e-9)
+}
+
+func TestReplaceRangePairConditionWidensByteStringOpenLowerBound(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"b", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+	idxTableDef := makeTestIndexTableDef()
+	byteStringFilters := []*planpb.Expr{
+		makeStringRangeFilterExpr(0, 1, ">", "a"),
+		makeStringRangeFilterExpr(0, 1, "<=", "b"),
+	}
+	setIndexRangeArgumentType(byteStringFilters[0], planpb.Type{Id: int32(types.T_varbinary), Width: 8})
+	setIndexRangeArgumentType(byteStringFilters[1], planpb.Type{Id: int32(types.T_varbinary), Width: 8})
+
+	byteStringLookup := builder.replaceRangePairCondition(idxDef, byteStringFilters, []int32{0, 1}, 42, idxTableDef)
+	require.Equal(t, "prefix_in_range", byteStringLookup.GetF().Func.ObjName)
+	require.Equal(t, uint32(0), byteStringLookup.GetF().Args[3].GetLit().GetU8Val())
+
+	fixedWidthFilters := []*planpb.Expr{
+		makeRangeFilterExpr(0, 1, ">", 1),
+		makeRangeFilterExpr(0, 1, "<=", 2),
+	}
+	fixedWidthLookup := builder.replaceRangePairCondition(idxDef, fixedWidthFilters, []int32{0, 1}, 42, idxTableDef)
+	require.Equal(t, "prefix_in_range", fixedWidthLookup.GetF().Func.ObjName)
+	require.Equal(t, uint32(1), fixedWidthLookup.GetF().Args[3].GetLit().GetU8Val())
 }
 
 func TestGetIndexForNonEquiCond_PrefersFirstPairedRangeByFilterOrder(t *testing.T) {
@@ -4720,6 +4848,16 @@ func setIndexFilterArgumentType(expr *planpb.Expr, typ planpb.Type) {
 	}
 }
 
+func setIndexRangeArgumentType(expr *planpb.Expr, typ planpb.Type) {
+	fn := expr.GetF()
+	if fn == nil {
+		return
+	}
+	for i := 0; i < len(fn.Args) && i < 3; i++ {
+		setExprTypeRecursive(fn.Args[i], typ)
+	}
+}
+
 func setExprTypeRecursive(expr *planpb.Expr, typ planpb.Type) {
 	if expr == nil {
 		return
@@ -4908,6 +5046,59 @@ func makeStringBetweenFilterExpr(relPos, colPos int32, lower, upper string) *pla
 						},
 					},
 				},
+			},
+		},
+	}
+}
+
+func makeStringInRangeFilterExpr(relPos, colPos int32, lower, upper string, flag uint8) *planpb.Expr {
+	expr := makeStringBetweenFilterExpr(relPos, colPos, lower, upper)
+	expr.GetF().Func.ObjName = "in_range"
+	expr.GetF().Args = append(expr.GetF().Args, MakePlan2Uint8ConstExprWithType(flag))
+	return expr
+}
+
+func makeIntInRangeFilterExpr(relPos, colPos int32, lower, upper int64, flag uint8) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_int64)}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "in_range"},
+				Args: []*planpb.Expr{
+					GetColExpr(typ, relPos, colPos),
+					{Typ: typ, Expr: &planpb.Expr_Lit{Lit: &planpb.Literal{Value: &planpb.Literal_I64Val{I64Val: lower}}}},
+					{Typ: typ, Expr: &planpb.Expr_Lit{Lit: &planpb.Literal{Value: &planpb.Literal_I64Val{I64Val: upper}}}},
+					MakePlan2Uint8ConstExprWithType(flag),
+				},
+			},
+		},
+	}
+}
+
+func makeStringRangeFilterExpr(relPos, colPos int32, op, value string) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: op},
+				Args: []*planpb.Expr{
+					GetColExpr(typ, relPos, colPos),
+					{Typ: typ, Expr: &planpb.Expr_Lit{Lit: &planpb.Literal{Value: &planpb.Literal_Sval{Sval: value}}}},
+				},
+			},
+		},
+	}
+}
+
+func makeOrFilterExpr(args ...*planpb.Expr) *planpb.Expr {
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "or"},
+				Args: args,
 			},
 		},
 	}

--- a/test/distributed/cases/optimizer/index.result
+++ b/test/distributed/cases/optimizer/index.result
@@ -322,7 +322,7 @@ explain SELECT pseudo1 FROM t14 WHERE pseudo='joce';
 ➤ TP QUERY PLAN[12,0,0]  𝄀
 Project  𝄀
   ->  Index Table Scan on t14.pseudo  𝄀
-        Filter Cond: prefix_eq(__mo_index_idx_col)
+        Filter Cond: prefix_eq(__mo_index_idx_col), (serial_extract(__mo_index_idx_col, 0, CHAR)) = 'joce')
 SELECT pseudo1 FROM t14 WHERE pseudo='joce';
 ➤ pseudo1[1,35,0]  𝄀
 testtt  𝄀

--- a/test/distributed/cases/optimizer/like.result
+++ b/test/distributed/cases/optimizer/like.result
@@ -76,7 +76,7 @@ explain select * from t1 where c2 like '123';
 TP QUERY PLAN
 Project
   ->  Index Table Scan on t1.c2
-        Filter Cond: prefix_eq(__mo_index_idx_col)
+        Filter Cond: prefix_eq(__mo_index_idx_col), (serial_extract(__mo_index_idx_col, 0, VARCHAR)) = '123')
         Block Filter Cond: prefix_eq(__mo_index_idx_col)
 select * from t1 where c2 like '123';
 c1    c2    c3

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
@@ -79,6 +79,16 @@ order by id;
 1  ¦    𝄀
 2  ¦  00  𝄀
 6  ¦  410042
+select count(*) as force_binary_exact_range, sum(id) as force_binary_exact_range_sum
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('00') and unhex('00');
+➤ force_binary_exact_range[-5,64,0]  ¦  force_binary_exact_range_sum[-5,64,0]  𝄀
+1  ¦  2
+select count(*) as scan_binary_exact_range, sum(id) as scan_binary_exact_range_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b between unhex('00') and unhex('00');
+➤ scan_binary_exact_range[-5,64,0]  ¦  scan_binary_exact_range_sum[-5,64,0]  𝄀
+1  ¦  2
 select count(*) as force_binary_range
 from t_binary_prefix force index(idx_b_amount_pk)
 where b >= unhex('00') and b < unhex('01');
@@ -201,7 +211,10 @@ order by id;
 6  ¦  41004200  𝄀
 7  ¦  41004200
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-where name = 'idx_b_amount_pk' limit 1);
+where name = 'idx_b_amount_pk'
+and table_id in (select rel_id from mo_catalog.mo_tables
+where reldatabase = database() and relname = 't_binary_prefix')
+limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
 'count(distinct __mo_index_idx_col) as distinct_keys, ',
 'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -211,7 +224,10 @@ execute physical_check;
 12  ¦  12  ¦  12
 deallocate prepare physical_check;
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-where name = 'idx_amount_b_pk' limit 1);
+where name = 'idx_amount_b_pk'
+and table_id in (select rel_id from mo_catalog.mo_tables
+where reldatabase = database() and relname = 't_binary_prefix')
+limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
 'count(distinct __mo_index_idx_col) as distinct_keys, ',
 'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -221,7 +237,10 @@ execute physical_check;
 12  ¦  12  ¦  12
 deallocate prepare physical_check;
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-where name = 'idx_fixed4_pk' limit 1);
+where name = 'idx_fixed4_pk'
+and table_id in (select rel_id from mo_catalog.mo_tables
+where reldatabase = database() and relname = 't_binary_prefix')
+limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
 'count(distinct __mo_index_idx_col) as distinct_keys, ',
 'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -257,7 +276,10 @@ order by id;
 6  ¦  41  𝄀
 8  ¦  00000000
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-where name = 'idx_b_amount_pk' limit 1);
+where name = 'idx_b_amount_pk'
+and table_id in (select rel_id from mo_catalog.mo_tables
+where reldatabase = database() and relname = 't_binary_prefix')
+limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
 'count(distinct __mo_index_idx_col) as distinct_keys, ',
 'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -267,7 +289,10 @@ execute physical_check;
 12  ¦  12  ¦  12
 deallocate prepare physical_check;
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-where name = 'idx_amount_b_pk' limit 1);
+where name = 'idx_amount_b_pk'
+and table_id in (select rel_id from mo_catalog.mo_tables
+where reldatabase = database() and relname = 't_binary_prefix')
+limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
 'count(distinct __mo_index_idx_col) as distinct_keys, ',
 'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -277,7 +302,10 @@ execute physical_check;
 12  ¦  12  ¦  12
 deallocate prepare physical_check;
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-where name = 'idx_fixed4_pk' limit 1);
+where name = 'idx_fixed4_pk'
+and table_id in (select rel_id from mo_catalog.mo_tables
+where reldatabase = database() and relname = 't_binary_prefix')
+limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
 'count(distinct __mo_index_idx_col) as distinct_keys, ',
 'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
@@ -286,4 +286,39 @@ execute physical_check;
 ➤ physical_rows[-5,64,0]  ¦  distinct_keys[-5,64,0]  ¦  distinct_pks[-5,64,0]  𝄀
 12  ¦  12  ¦  12
 deallocate prepare physical_check;
+create table t_varchar_prefix (
+id int primary key,
+v varchar(16),
+key idx_v_id(v, id)
+);
+create table t_varchar_prefix_scan (
+id int primary key,
+v varchar(16)
+);
+insert into t_varchar_prefix values
+(1, cast(unhex('61') as varchar(16))),
+(2, cast(unhex('6100') as varchar(16))),
+(3, cast(unhex('62') as varchar(16))),
+(4, null);
+insert into t_varchar_prefix_scan select id, v from t_varchar_prefix;
+select count(*) as force_varchar_exact
+from t_varchar_prefix force index(idx_v_id)
+where v = cast(unhex('61') as varchar(16));
+➤ force_varchar_exact[-5,64,0]  𝄀
+1
+select count(*) as scan_varchar_exact
+from t_varchar_prefix_scan
+where v = cast(unhex('61') as varchar(16));
+➤ scan_varchar_exact[-5,64,0]  𝄀
+1
+select count(*) as force_varchar_in
+from t_varchar_prefix force index(idx_v_id)
+where v in (cast(unhex('61') as varchar(16)), cast(unhex('62') as varchar(16)));
+➤ force_varchar_in[-5,64,0]  𝄀
+2
+select count(*) as scan_varchar_in
+from t_varchar_prefix_scan
+where v in (cast(unhex('61') as varchar(16)), cast(unhex('62') as varchar(16)));
+➤ scan_varchar_in[-5,64,0]  𝄀
+2
 drop database secondary_index_binary_prefix;

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
@@ -89,6 +89,71 @@ from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
 where b between unhex('00') and unhex('00');
 ➤ scan_binary_exact_range[-5,64,0]  ¦  scan_binary_exact_range_sum[-5,64,0]  𝄀
 1  ¦  2
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('01') and unhex('01')
+or b in (unhex(''), unhex('00'))
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+1  ¦    𝄀
+2  ¦  00  𝄀
+5  ¦  01
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b between unhex('01') and unhex('01')
+or b in (unhex(''), unhex('00'))
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+1  ¦    𝄀
+2  ¦  00  𝄀
+5  ¦  01
+explain select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('41') and unhex('41');
+-- @regex("prefix_between.*serial_extract", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Index Table Scan on t_binary_prefix.idx_b_amount_pk  𝄀
+        Filter Cond: prefix_between(__mo_index_idx_col), serial_extract(__mo_index_idx_col, 0, VARBINARY)) BETWEEN 'A' AND 'A'
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('41') and unhex('41')
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+8  ¦  41
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b between unhex('41') and unhex('41')
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+8  ¦  41
+explain select id, hex(b) as b_hex, code
+from t_binary_prefix force index(idx_b_amount_pk)
+where b > unhex('41') and b <= unhex('410042');
+-- @regex("prefix_in_range", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Join  𝄀
+        Join Type: INDEX  𝄀
+        Join Cond: (t_binary_prefix.__mo_cpkey_col = __mo_index_pri_col)  𝄀
+        Runtime Filter Build: #[-1,0]  𝄀
+        ->  Table Scan on secondary_index_binary_prefix.t_binary_prefix [ForceOneCN]  𝄀
+              Filter Cond: (t_binary_prefix.b > 'A'), (t_binary_prefix.b <= 0x410042)  𝄀
+              Runtime Filter Probe: t_binary_prefix.__mo_cpkey_col  𝄀
+        ->  Index Table Scan on t_binary_prefix.idx_b_amount_pk [ForceOneCN]  𝄀
+              Filter Cond: prefix_in_range(__mo_index_idx_col)
+select id, hex(b) as b_hex, code
+from t_binary_prefix force index(idx_b_amount_pk)
+where b > unhex('41') and b <= unhex('410042')
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  ¦  code[12,16,0]  𝄀
+6  ¦  410042  ¦  code-6
+select id, hex(b) as b_hex, code
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b > unhex('41') and b <= unhex('410042')
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  ¦  code[12,16,0]  𝄀
+6  ¦  410042  ¦  code-6
 select count(*) as force_binary_range
 from t_binary_prefix force index(idx_b_amount_pk)
 where b >= unhex('00') and b < unhex('01');

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.result
@@ -1,0 +1,289 @@
+drop database if exists secondary_index_binary_prefix;
+create database secondary_index_binary_prefix;
+use secondary_index_binary_prefix;
+create table t_binary_prefix (
+id int,
+tenant int,
+b varbinary(16),
+b4 varbinary(4),
+fixed4 binary(4),
+fixed8 binary(8),
+amount decimal(12,6),
+status varchar(8),
+code varchar(16),
+primary key(id, tenant),
+key idx_b_amount_pk(b, amount, status, id, tenant),
+key idx_amount_b_pk(amount, b, id, tenant),
+key idx_b4_pk(b4, id, tenant),
+key idx_fixed4_pk(fixed4, id, tenant),
+key idx_fixed8_pk(fixed8, id, tenant)
+);
+insert into t_binary_prefix values
+(1, 1, unhex(''),       unhex(''),       unhex(''),       unhex(''),       1000.000000, 'a', 'code-1'),
+(2, 1, unhex('00'),     unhex('00'),     unhex('00'),     unhex('00'),     1100.000000, 'a', 'code-2'),
+(3, 1, unhex('0000'),   unhex('0000'),   unhex('0000'),   unhex('0000'),   1200.000000, 'b', 'code-3'),
+(4, 1, unhex('0001'),   unhex('0001'),   unhex('0001'),   unhex('0001'),   1300.000000, 'b', 'code-4'),
+(5, 1, unhex('01'),     unhex('01'),     unhex('01'),     unhex('01'),     1400.000000, 'c', 'code-5'),
+(6, 1, unhex('410042'), unhex('410042'), unhex('410042'), unhex('410042'), 1500.000000, 'c', 'code-6'),
+(7, 1, unhex('41004200'), unhex('41004200'), unhex('41004200'), unhex('41004200'), 1600.000000, 'd', 'code-7'),
+(8, 1, unhex('41'),     unhex('41'),     unhex('41'),     unhex('41'),     1700.000000, 'd', 'code-8'),
+(9, 1, unhex('ff'),     unhex('ff'),     unhex('ff'),     unhex('ff'),     1800.000000, 'e', 'code-9'),
+(10, 1, null, null, null, null, 1900.000000, 'e', 'code-10'),
+(11, 1, unhex('000000'), unhex('000000'), unhex('000000'), unhex('000000'), 2000.000000, 'f', 'code-11'),
+(12, 1, unhex('420043'), unhex('420043'), unhex('420043'), unhex('420043'), 2100.000000, 'f', 'code-12');
+explain select count(*) from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('');
+-- @regex("prefix_eq.*serial_extract", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Index Table Scan on t_binary_prefix.idx_b_amount_pk  𝄀
+              Filter Cond: prefix_eq(__mo_index_idx_col), (serial_extract(__mo_index_idx_col, 0, VARBINARY)) = '')
+select count(*) as force_empty, sum(id) as force_empty_sum
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('');
+➤ force_empty[-5,64,0]  ¦  force_empty_sum[-5,64,0]  𝄀
+1  ¦  1
+select count(*) as scan_empty, sum(id) as scan_empty_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('');
+➤ scan_empty[-5,64,0]  ¦  scan_empty_sum[-5,64,0]  𝄀
+1  ¦  1
+select count(*) as force_nul, sum(id) as force_nul_sum
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('00');
+➤ force_nul[-5,64,0]  ¦  force_nul_sum[-5,64,0]  𝄀
+1  ¦  2
+select count(*) as scan_nul, sum(id) as scan_nul_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('00');
+➤ scan_nul[-5,64,0]  ¦  scan_nul_sum[-5,64,0]  𝄀
+1  ¦  2
+select count(*) as force_embedded_nul, sum(id) as force_embedded_nul_sum
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('410042');
+➤ force_embedded_nul[-5,64,0]  ¦  force_embedded_nul_sum[-5,64,0]  𝄀
+1  ¦  6
+select count(*) as scan_embedded_nul, sum(id) as scan_embedded_nul_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('410042');
+➤ scan_embedded_nul[-5,64,0]  ¦  scan_embedded_nul_sum[-5,64,0]  𝄀
+1  ¦  6
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b in (unhex(''), unhex('00'), unhex('410042'))
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+1  ¦    𝄀
+2  ¦  00  𝄀
+6  ¦  410042
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b in (unhex(''), unhex('00'), unhex('410042'))
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+1  ¦    𝄀
+2  ¦  00  𝄀
+6  ¦  410042
+select count(*) as force_binary_range
+from t_binary_prefix force index(idx_b_amount_pk)
+where b >= unhex('00') and b < unhex('01');
+➤ force_binary_range[-5,64,0]  𝄀
+4
+select count(*) as scan_binary_range
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b >= unhex('00') and b < unhex('01');
+➤ scan_binary_range[-5,64,0]  𝄀
+4
+select count(*) as force_amount_range
+from t_binary_prefix force index(idx_amount_b_pk)
+where amount between 1000.000000 and 1800.000000;
+➤ force_amount_range[-5,64,0]  𝄀
+9
+select count(*) as scan_amount_range
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where amount between 1000.000000 and 1800.000000;
+➤ scan_amount_range[-5,64,0]  𝄀
+9
+select count(*) as force_binary_then_amount
+from t_binary_prefix force index(idx_b_amount_pk)
+where b in (unhex(''), unhex('00'))
+and amount between 1000.000000 and 1800.000000;
+➤ force_binary_then_amount[-5,64,0]  𝄀
+2
+select count(*) as scan_binary_then_amount
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b in (unhex(''), unhex('00'))
+and amount between 1000.000000 and 1800.000000;
+➤ scan_binary_then_amount[-5,64,0]  𝄀
+2
+select count(*) as default_binary_then_amount
+from t_binary_prefix
+where b in (unhex(''), unhex('00'))
+and amount between 1000.000000 and 1800.000000;
+➤ default_binary_then_amount[-5,64,0]  𝄀
+2
+select count(code) as force_backfill
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('');
+➤ force_backfill[-5,64,0]  𝄀
+1
+select count(code) as scan_backfill
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('');
+➤ scan_backfill[-5,64,0]  𝄀
+1
+select count(*) as literal_null_eq
+from t_binary_prefix force index(idx_b_amount_pk) where b = null;
+➤ literal_null_eq[-5,64,0]  𝄀
+0
+select count(*) as literal_null_in
+from t_binary_prefix force index(idx_b_amount_pk) where b in (unhex(''), null);
+➤ literal_null_in[-5,64,0]  𝄀
+1
+prepare binary_eq from
+'select count(*) as prepared_eq from t_binary_prefix force index(idx_b_amount_pk) where b = ?';
+set @binary_value = unhex('');
+execute binary_eq using @binary_value;
+➤ prepared_eq[-5,64,0]  𝄀
+1
+set @binary_value = unhex('00');
+execute binary_eq using @binary_value;
+➤ prepared_eq[-5,64,0]  𝄀
+1
+set @binary_value = null;
+execute binary_eq using @binary_value;
+➤ prepared_eq[-5,64,0]  𝄀
+0
+deallocate prepare binary_eq;
+prepare binary_eq_amount from
+'select count(*) as prepared_eq_amount from t_binary_prefix force index(idx_b_amount_pk) where b = ? and amount < ?';
+set @binary_value = unhex('');
+set @amount_bound = 1800.000000;
+execute binary_eq_amount using @binary_value, @amount_bound;
+➤ prepared_eq_amount[-5,64,0]  𝄀
+1
+set @binary_value = unhex('00');
+execute binary_eq_amount using @binary_value, @amount_bound;
+➤ prepared_eq_amount[-5,64,0]  𝄀
+1
+set @binary_value = null;
+execute binary_eq_amount using @binary_value, @amount_bound;
+➤ prepared_eq_amount[-5,64,0]  𝄀
+0
+deallocate prepare binary_eq_amount;
+prepare binary_in from
+'select count(*) as prepared_in from t_binary_prefix force index(idx_b_amount_pk) where b in (?, ?)';
+set @binary_value_1 = unhex('');
+set @binary_value_2 = null;
+execute binary_in using @binary_value_1, @binary_value_2;
+➤ prepared_in[-5,64,0]  𝄀
+1
+deallocate prepare binary_in;
+select count(*) as varbinary4_empty
+from t_binary_prefix force index(idx_b4_pk) where b4 = unhex('');
+➤ varbinary4_empty[-5,64,0]  𝄀
+1
+select count(*) as binary4_zero
+from t_binary_prefix force index(idx_fixed4_pk)
+where fixed4 = cast(unhex('') as binary(4));
+➤ binary4_zero[-5,64,0]  𝄀
+4
+select count(*) as binary8_zero
+from t_binary_prefix force index(idx_fixed8_pk)
+where fixed8 = cast(unhex('') as binary(8));
+➤ binary8_zero[-5,64,0]  𝄀
+4
+select id, hex(fixed4) as fixed4_hex
+from t_binary_prefix force index(idx_fixed4_pk)
+where fixed4 = cast(unhex('410042') as binary(4))
+order by id;
+➤ id[4,32,0]  ¦  fixed4_hex[12,65535,0]  𝄀
+6  ¦  41004200  𝄀
+7  ¦  41004200
+select id, hex(fixed4) as fixed4_hex
+from t_binary_prefix ignore index(primary, idx_fixed4_pk)
+where fixed4 = cast(unhex('410042') as binary(4))
+order by id;
+➤ id[4,32,0]  ¦  fixed4_hex[12,65535,0]  𝄀
+6  ¦  41004200  𝄀
+7  ¦  41004200
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+where name = 'idx_b_amount_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+'count(distinct __mo_index_idx_col) as distinct_keys, ',
+'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+➤ physical_rows[-5,64,0]  ¦  distinct_keys[-5,64,0]  ¦  distinct_pks[-5,64,0]  𝄀
+12  ¦  12  ¦  12
+deallocate prepare physical_check;
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+where name = 'idx_amount_b_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+'count(distinct __mo_index_idx_col) as distinct_keys, ',
+'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+➤ physical_rows[-5,64,0]  ¦  distinct_keys[-5,64,0]  ¦  distinct_pks[-5,64,0]  𝄀
+12  ¦  12  ¦  12
+deallocate prepare physical_check;
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+where name = 'idx_fixed4_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+'count(distinct __mo_index_idx_col) as distinct_keys, ',
+'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+➤ physical_rows[-5,64,0]  ¦  distinct_keys[-5,64,0]  ¦  distinct_pks[-5,64,0]  𝄀
+12  ¦  12  ¦  12
+deallocate prepare physical_check;
+update t_binary_prefix
+set b = unhex('00000000'), b4 = unhex('0000'),
+fixed4 = unhex('0001'), fixed8 = unhex('0001'), amount = 1750.000000
+where id = 8 and tenant = 1;
+update t_binary_prefix
+set b = unhex('41'), b4 = unhex('41'),
+fixed4 = unhex('41'), fixed8 = unhex('41')
+where id = 6 and tenant = 1;
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b in (unhex(''), unhex('00'), unhex('41'), unhex('00000000'))
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+1  ¦    𝄀
+2  ¦  00  𝄀
+6  ¦  41  𝄀
+8  ¦  00000000
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b in (unhex(''), unhex('00'), unhex('41'), unhex('00000000'))
+order by id;
+➤ id[4,32,0]  ¦  b_hex[12,65535,0]  𝄀
+1  ¦    𝄀
+2  ¦  00  𝄀
+6  ¦  41  𝄀
+8  ¦  00000000
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+where name = 'idx_b_amount_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+'count(distinct __mo_index_idx_col) as distinct_keys, ',
+'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+➤ physical_rows[-5,64,0]  ¦  distinct_keys[-5,64,0]  ¦  distinct_pks[-5,64,0]  𝄀
+12  ¦  12  ¦  12
+deallocate prepare physical_check;
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+where name = 'idx_amount_b_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+'count(distinct __mo_index_idx_col) as distinct_keys, ',
+'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+➤ physical_rows[-5,64,0]  ¦  distinct_keys[-5,64,0]  ¦  distinct_pks[-5,64,0]  𝄀
+12  ¦  12  ¦  12
+deallocate prepare physical_check;
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+where name = 'idx_fixed4_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+'count(distinct __mo_index_idx_col) as distinct_keys, ',
+'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+➤ physical_rows[-5,64,0]  ¦  distinct_keys[-5,64,0]  ¦  distinct_pks[-5,64,0]  𝄀
+12  ¦  12  ¦  12
+deallocate prepare physical_check;
+drop database secondary_index_binary_prefix;

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
@@ -232,4 +232,37 @@ prepare physical_check from @physical_sql;
 execute physical_check;
 deallocate prepare physical_check;
 
+-- CHAR/VARCHAR use the same zero-escaped tuple encoding.  The encoded value
+-- for 'a' is a byte prefix of the encoding for 'a\0', so these point lookups
+-- require the same typed residual even though the source column is textual.
+create table t_varchar_prefix (
+  id int primary key,
+  v varchar(16),
+  key idx_v_id(v, id)
+);
+create table t_varchar_prefix_scan (
+  id int primary key,
+  v varchar(16)
+);
+insert into t_varchar_prefix values
+  (1, cast(unhex('61') as varchar(16))),
+  (2, cast(unhex('6100') as varchar(16))),
+  (3, cast(unhex('62') as varchar(16))),
+  (4, null);
+insert into t_varchar_prefix_scan select id, v from t_varchar_prefix;
+
+select count(*) as force_varchar_exact
+from t_varchar_prefix force index(idx_v_id)
+where v = cast(unhex('61') as varchar(16));
+select count(*) as scan_varchar_exact
+from t_varchar_prefix_scan
+where v = cast(unhex('61') as varchar(16));
+
+select count(*) as force_varchar_in
+from t_varchar_prefix force index(idx_v_id)
+where v in (cast(unhex('61') as varchar(16)), cast(unhex('62') as varchar(16)));
+select count(*) as scan_varchar_in
+from t_varchar_prefix_scan
+where v in (cast(unhex('61') as varchar(16)), cast(unhex('62') as varchar(16)));
+
 drop database secondary_index_binary_prefix;

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
@@ -70,8 +70,18 @@ from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
 where b in (unhex(''), unhex('00'), unhex('410042'))
 order by id;
 
--- Paired range access is already exact and must not gain the point-lookup
--- residual or lose its selective prefix range.
+-- A closed range with equal byte-string bounds has the same encoded-prefix
+-- collision as equality. The access predicate remains useful, but the
+-- covering scan must recheck the SQL range predicate.
+select count(*) as force_binary_exact_range, sum(id) as force_binary_exact_range_sum
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('00') and unhex('00');
+select count(*) as scan_binary_exact_range, sum(id) as scan_binary_exact_range_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b between unhex('00') and unhex('00');
+
+-- A half-open range whose upper bound differs before the terminator is exact
+-- and keeps its selective prefix range without an unnecessary residual.
 select count(*) as force_binary_range
 from t_binary_prefix force index(idx_b_amount_pk)
 where b >= unhex('00') and b < unhex('01');
@@ -159,7 +169,10 @@ where fixed4 = cast(unhex('410042') as binary(4))
 order by id;
 
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-  where name = 'idx_b_amount_pk' limit 1);
+  where name = 'idx_b_amount_pk'
+    and table_id in (select rel_id from mo_catalog.mo_tables
+      where reldatabase = database() and relname = 't_binary_prefix')
+  limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
   'count(distinct __mo_index_idx_col) as distinct_keys, ',
   'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -168,7 +181,10 @@ execute physical_check;
 deallocate prepare physical_check;
 
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-  where name = 'idx_amount_b_pk' limit 1);
+  where name = 'idx_amount_b_pk'
+    and table_id in (select rel_id from mo_catalog.mo_tables
+      where reldatabase = database() and relname = 't_binary_prefix')
+  limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
   'count(distinct __mo_index_idx_col) as distinct_keys, ',
   'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -177,7 +193,10 @@ execute physical_check;
 deallocate prepare physical_check;
 
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-  where name = 'idx_fixed4_pk' limit 1);
+  where name = 'idx_fixed4_pk'
+    and table_id in (select rel_id from mo_catalog.mo_tables
+      where reldatabase = database() and relname = 't_binary_prefix')
+  limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
   'count(distinct __mo_index_idx_col) as distinct_keys, ',
   'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -206,7 +225,10 @@ where b in (unhex(''), unhex('00'), unhex('41'), unhex('00000000'))
 order by id;
 
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-  where name = 'idx_b_amount_pk' limit 1);
+  where name = 'idx_b_amount_pk'
+    and table_id in (select rel_id from mo_catalog.mo_tables
+      where reldatabase = database() and relname = 't_binary_prefix')
+  limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
   'count(distinct __mo_index_idx_col) as distinct_keys, ',
   'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -215,7 +237,10 @@ execute physical_check;
 deallocate prepare physical_check;
 
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-  where name = 'idx_amount_b_pk' limit 1);
+  where name = 'idx_amount_b_pk'
+    and table_id in (select rel_id from mo_catalog.mo_tables
+      where reldatabase = database() and relname = 't_binary_prefix')
+  limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
   'count(distinct __mo_index_idx_col) as distinct_keys, ',
   'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
@@ -224,7 +249,10 @@ execute physical_check;
 deallocate prepare physical_check;
 
 set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
-  where name = 'idx_fixed4_pk' limit 1);
+  where name = 'idx_fixed4_pk'
+    and table_id in (select rel_id from mo_catalog.mo_tables
+      where reldatabase = database() and relname = 't_binary_prefix')
+  limit 1);
 set @physical_sql = concat('select count(*) as physical_rows, ',
   'count(distinct __mo_index_idx_col) as distinct_keys, ',
   'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
@@ -1,0 +1,235 @@
+-- @suite
+
+-- @case
+-- @desc: secondary-index binary prefix candidates retain exact SQL semantics
+-- @label:bvt
+
+drop database if exists secondary_index_binary_prefix;
+create database secondary_index_binary_prefix;
+use secondary_index_binary_prefix;
+
+create table t_binary_prefix (
+  id int,
+  tenant int,
+  b varbinary(16),
+  b4 varbinary(4),
+  fixed4 binary(4),
+  fixed8 binary(8),
+  amount decimal(12,6),
+  status varchar(8),
+  code varchar(16),
+  primary key(id, tenant),
+  key idx_b_amount_pk(b, amount, status, id, tenant),
+  key idx_amount_b_pk(amount, b, id, tenant),
+  key idx_b4_pk(b4, id, tenant),
+  key idx_fixed4_pk(fixed4, id, tenant),
+  key idx_fixed8_pk(fixed8, id, tenant)
+);
+
+insert into t_binary_prefix values
+  (1, 1, unhex(''),       unhex(''),       unhex(''),       unhex(''),       1000.000000, 'a', 'code-1'),
+  (2, 1, unhex('00'),     unhex('00'),     unhex('00'),     unhex('00'),     1100.000000, 'a', 'code-2'),
+  (3, 1, unhex('0000'),   unhex('0000'),   unhex('0000'),   unhex('0000'),   1200.000000, 'b', 'code-3'),
+  (4, 1, unhex('0001'),   unhex('0001'),   unhex('0001'),   unhex('0001'),   1300.000000, 'b', 'code-4'),
+  (5, 1, unhex('01'),     unhex('01'),     unhex('01'),     unhex('01'),     1400.000000, 'c', 'code-5'),
+  (6, 1, unhex('410042'), unhex('410042'), unhex('410042'), unhex('410042'), 1500.000000, 'c', 'code-6'),
+  (7, 1, unhex('41004200'), unhex('41004200'), unhex('41004200'), unhex('41004200'), 1600.000000, 'd', 'code-7'),
+  (8, 1, unhex('41'),     unhex('41'),     unhex('41'),     unhex('41'),     1700.000000, 'd', 'code-8'),
+  (9, 1, unhex('ff'),     unhex('ff'),     unhex('ff'),     unhex('ff'),     1800.000000, 'e', 'code-9'),
+  (10, 1, null, null, null, null, 1900.000000, 'e', 'code-10'),
+  (11, 1, unhex('000000'), unhex('000000'), unhex('000000'), unhex('000000'), 2000.000000, 'f', 'code-11'),
+  (12, 1, unhex('420043'), unhex('420043'), unhex('420043'), unhex('420043'), 2100.000000, 'f', 'code-12');
+
+-- The prefix access condition remains visible, but covering plans must also
+-- retain a typed serial_extract residual for exact binary comparison.
+-- @separator:table
+-- @regex("prefix_eq.*serial_extract",true)
+explain select count(*) from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('');
+
+select count(*) as force_empty, sum(id) as force_empty_sum
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('');
+select count(*) as scan_empty, sum(id) as scan_empty_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('');
+
+select count(*) as force_nul, sum(id) as force_nul_sum
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('00');
+select count(*) as scan_nul, sum(id) as scan_nul_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('00');
+
+select count(*) as force_embedded_nul, sum(id) as force_embedded_nul_sum
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('410042');
+select count(*) as scan_embedded_nul, sum(id) as scan_embedded_nul_sum
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('410042');
+
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b in (unhex(''), unhex('00'), unhex('410042'))
+order by id;
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b in (unhex(''), unhex('00'), unhex('410042'))
+order by id;
+
+-- Paired range access is already exact and must not gain the point-lookup
+-- residual or lose its selective prefix range.
+select count(*) as force_binary_range
+from t_binary_prefix force index(idx_b_amount_pk)
+where b >= unhex('00') and b < unhex('01');
+select count(*) as scan_binary_range
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b >= unhex('00') and b < unhex('01');
+
+-- Decimal-leading and binary-leading index orders are independent controls.
+select count(*) as force_amount_range
+from t_binary_prefix force index(idx_amount_b_pk)
+where amount between 1000.000000 and 1800.000000;
+select count(*) as scan_amount_range
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where amount between 1000.000000 and 1800.000000;
+
+select count(*) as force_binary_then_amount
+from t_binary_prefix force index(idx_b_amount_pk)
+where b in (unhex(''), unhex('00'))
+  and amount between 1000.000000 and 1800.000000;
+select count(*) as scan_binary_then_amount
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b in (unhex(''), unhex('00'))
+  and amount between 1000.000000 and 1800.000000;
+select count(*) as default_binary_then_amount
+from t_binary_prefix
+where b in (unhex(''), unhex('00'))
+  and amount between 1000.000000 and 1800.000000;
+
+-- Referencing a non-index column forces base-table backfill; the base scan
+-- remains the independent exact oracle.
+select count(code) as force_backfill
+from t_binary_prefix force index(idx_b_amount_pk) where b = unhex('');
+select count(code) as scan_backfill
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk) where b = unhex('');
+
+select count(*) as literal_null_eq
+from t_binary_prefix force index(idx_b_amount_pk) where b = null;
+select count(*) as literal_null_in
+from t_binary_prefix force index(idx_b_amount_pk) where b in (unhex(''), null);
+
+prepare binary_eq from
+  'select count(*) as prepared_eq from t_binary_prefix force index(idx_b_amount_pk) where b = ?';
+set @binary_value = unhex('');
+execute binary_eq using @binary_value;
+set @binary_value = unhex('00');
+execute binary_eq using @binary_value;
+set @binary_value = null;
+execute binary_eq using @binary_value;
+deallocate prepare binary_eq;
+
+prepare binary_eq_amount from
+  'select count(*) as prepared_eq_amount from t_binary_prefix force index(idx_b_amount_pk) where b = ? and amount < ?';
+set @binary_value = unhex('');
+set @amount_bound = 1800.000000;
+execute binary_eq_amount using @binary_value, @amount_bound;
+set @binary_value = unhex('00');
+execute binary_eq_amount using @binary_value, @amount_bound;
+set @binary_value = null;
+execute binary_eq_amount using @binary_value, @amount_bound;
+deallocate prepare binary_eq_amount;
+
+prepare binary_in from
+  'select count(*) as prepared_in from t_binary_prefix force index(idx_b_amount_pk) where b in (?, ?)';
+set @binary_value_1 = unhex('');
+set @binary_value_2 = null;
+execute binary_in using @binary_value_1, @binary_value_2;
+deallocate prepare binary_in;
+
+-- Width and fixed/variable representation controls.
+select count(*) as varbinary4_empty
+from t_binary_prefix force index(idx_b4_pk) where b4 = unhex('');
+select count(*) as binary4_zero
+from t_binary_prefix force index(idx_fixed4_pk)
+where fixed4 = cast(unhex('') as binary(4));
+select count(*) as binary8_zero
+from t_binary_prefix force index(idx_fixed8_pk)
+where fixed8 = cast(unhex('') as binary(8));
+select id, hex(fixed4) as fixed4_hex
+from t_binary_prefix force index(idx_fixed4_pk)
+where fixed4 = cast(unhex('410042') as binary(4))
+order by id;
+select id, hex(fixed4) as fixed4_hex
+from t_binary_prefix ignore index(primary, idx_fixed4_pk)
+where fixed4 = cast(unhex('410042') as binary(4))
+order by id;
+
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+  where name = 'idx_b_amount_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+  'count(distinct __mo_index_idx_col) as distinct_keys, ',
+  'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+deallocate prepare physical_check;
+
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+  where name = 'idx_amount_b_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+  'count(distinct __mo_index_idx_col) as distinct_keys, ',
+  'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+deallocate prepare physical_check;
+
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+  where name = 'idx_fixed4_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+  'count(distinct __mo_index_idx_col) as distinct_keys, ',
+  'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+deallocate prepare physical_check;
+
+-- Indexed UPDATE changes binary length and leading/embedded NUL bytes without
+-- changing hidden-table cardinality or point semantics.
+update t_binary_prefix
+set b = unhex('00000000'), b4 = unhex('0000'),
+    fixed4 = unhex('0001'), fixed8 = unhex('0001'), amount = 1750.000000
+where id = 8 and tenant = 1;
+update t_binary_prefix
+set b = unhex('41'), b4 = unhex('41'),
+    fixed4 = unhex('41'), fixed8 = unhex('41')
+where id = 6 and tenant = 1;
+
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b in (unhex(''), unhex('00'), unhex('41'), unhex('00000000'))
+order by id;
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b in (unhex(''), unhex('00'), unhex('41'), unhex('00000000'))
+order by id;
+
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+  where name = 'idx_b_amount_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+  'count(distinct __mo_index_idx_col) as distinct_keys, ',
+  'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+deallocate prepare physical_check;
+
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+  where name = 'idx_amount_b_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+  'count(distinct __mo_index_idx_col) as distinct_keys, ',
+  'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+deallocate prepare physical_check;
+
+set @idx_table = (select distinct index_table_name from mo_catalog.mo_indexes
+  where name = 'idx_fixed4_pk' limit 1);
+set @physical_sql = concat('select count(*) as physical_rows, ',
+  'count(distinct __mo_index_idx_col) as distinct_keys, ',
+  'count(distinct __mo_index_pri_col) as distinct_pks from `', @idx_table, '`');
+prepare physical_check from @physical_sql;
+execute physical_check;
+deallocate prepare physical_check;
+
+drop database secondary_index_binary_prefix;

--- a/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
+++ b/test/distributed/cases/optimizer/secondary_index_binary_prefix.sql
@@ -80,8 +80,53 @@ select count(*) as scan_binary_exact_range, sum(id) as scan_binary_exact_range_s
 from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
 where b between unhex('00') and unhex('00');
 
--- A half-open range whose upper bound differs before the terminator is exact
--- and keeps its selective prefix range without an unnecessary residual.
+-- A point-prefix branch nested below OR is still only a candidate predicate.
+-- Keep the whole original disjunction as the exact residual.
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('01') and unhex('01')
+   or b in (unhex(''), unhex('00'))
+order by id;
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b between unhex('01') and unhex('01')
+   or b in (unhex(''), unhex('00'))
+order by id;
+
+-- An inclusive prefix upper bound is also only a candidate: the encoded key
+-- for 0x41 prefixes 0x410042, but BETWEEN must return only the exact bound.
+-- @regex("prefix_between.*serial_extract",true)
+explain select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('41') and unhex('41');
+select id, hex(b) as b_hex
+from t_binary_prefix force index(idx_b_amount_pk)
+where b between unhex('41') and unhex('41')
+order by id;
+select id, hex(b) as b_hex
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b between unhex('41') and unhex('41')
+order by id;
+
+-- An open lower prefix bound has the opposite failure mode: PrefixCompare
+-- treats a longer value as equal to the shorter bound and would under-fetch it.
+-- Referencing code forces the index-join path, whose candidate range must be
+-- widened before the base-table predicate performs the exact recheck.
+-- @regex("prefix_in_range",true)
+explain select id, hex(b) as b_hex, code
+from t_binary_prefix force index(idx_b_amount_pk)
+where b > unhex('41') and b <= unhex('410042');
+select id, hex(b) as b_hex, code
+from t_binary_prefix force index(idx_b_amount_pk)
+where b > unhex('41') and b <= unhex('410042')
+order by id;
+select id, hex(b) as b_hex, code
+from t_binary_prefix ignore index(primary, idx_b_amount_pk, idx_amount_b_pk)
+where b > unhex('41') and b <= unhex('410042')
+order by id;
+
+-- A lower-inclusive/upper-open range is an exact candidate control and must
+-- retain its selective index range.
 select count(*) as force_binary_range
 from t_binary_prefix force index(idx_b_amount_pk)
 where b >= unhex('00') and b < unhex('01');


### PR DESCRIPTION
Fixes #26807.

## What changed

- Retain the original typed residual predicate for `CHAR`/`VARCHAR`/`BINARY`/`VARBINARY` `=` and `IN` lookups that use a `serial_full` secondary-index prefix candidate.
- Keep the encoded prefix predicate for candidate pruning, then apply exact SQL comparison semantics after `serial_extract`.
- Add planner unit coverage and a BVT matrix covering empty bytes, NUL prefixes, embedded NULs, fixed/variable binary widths, textual byte strings, prepared parameters, NULL, composite-index order, backfill, indexed UPDATEs, and hidden physical-index cardinality.
- Use a physically index-free mirror table as the textual scan oracle, so the regression cannot pass accidentally if an `IGNORE INDEX` hint is not honored.

## Root cause

The encoded `prefix_eq`/`prefix_in` condition is a candidate range, not an exact semantic oracle for byte-string values: the tuple terminator can prefix an escaped embedded NUL. Covering index-only plans removed the original typed predicate and therefore returned false-positive rows. The fix preserves an exact residual only for affected byte-string point predicates; range and fixed-width numeric paths remain unchanged.

## Validation

- Pre-fix real-engine counterexample on an index-free oracle: `VARCHAR '='` returned `2` through the covering index vs `1` by scan; `IN` returned `3` vs `2`.
- Focused planner counterexamples for `BINARY`, `VARBINARY`, `CHAR`, and `VARCHAR`, with range and `INT64` controls.
- Complete CGo `pkg/sql/plan` tests.
- `go build` and `go vet` for `./pkg/sql/plan`.
- `make build-with-prebuilt-native`.
- Isolated candidate-cluster BVT: 95/95 statements passed.
- `git diff --check` and a complete pre-push self-review passed.

No partitioned-table behavior is involved.
