### PR TITLE
fix: harden regular prefix index correctness

### DIFF
--- a/pkg/catalog/secondary_index_utils.go
+++ b/pkg/catalog/secondary_index_utils.go
@@ -127,7 +127,13 @@ const (
 	IndexAlgoParamMaxIndexCapacity    = "max_index_capacity"
 	IndexAlgoParamQuantizerTrainLimit = "quantizer_train_limit"
 
+	// IndexAlgoParamPrefixLengths is the legacy, delimiter-separated encoding.
+	// It remains readable for metadata written by older versions.
 	IndexAlgoParamPrefixLengths = "prefix_lengths"
+	// IndexAlgoParamPrefixLengthsV2 stores a JSON object in a string value.
+	// Unlike the legacy colon/comma-separated value, it can represent every
+	// legal quoted column name without ambiguity.
+	IndexAlgoParamPrefixLengthsV2 = "prefix_lengths_v2"
 )
 
 func ParseIncludeColumnsValue(raw string) ([]string, error) {
@@ -298,8 +304,8 @@ func IndexParamsMapToJsonString(res map[string]string) (string, error) {
 }
 
 func AddIndexPrefixLengthsToParams(indexParams string, keyParts []*tree.KeyPart) (string, error) {
-	prefixLengths := IndexPrefixLengthsToString(keyParts)
-	if prefixLengths == "" {
+	prefixLengths := indexPrefixLengthsFromKeyParts(keyParts)
+	if len(prefixLengths) == 0 {
 		return indexParams, nil
 	}
 
@@ -311,15 +317,17 @@ func AddIndexPrefixLengthsToParams(indexParams string, keyParts []*tree.KeyPart)
 		}
 		params = existing
 	}
-	params[IndexAlgoParamPrefixLengths] = prefixLengths
+	if err := SetIndexPrefixLengthsInParamMap(params, prefixLengths); err != nil {
+		return "", err
+	}
 	return IndexParamsMapToJsonString(params)
 }
 
+// IndexPrefixLengthsToString returns the legacy delimiter-separated encoding.
+// New catalog metadata must be written through AddIndexPrefixLengthsToParams
+// or SetIndexPrefixLengthsInParamMap so delimiter-bearing identifiers select
+// the lossless v2 representation.
 func IndexPrefixLengthsToString(keyParts []*tree.KeyPart) string {
-	if len(keyParts) == 0 {
-		return ""
-	}
-
 	prefixLengths := make(map[string]int, len(keyParts))
 	for _, keyPart := range keyParts {
 		if keyPart == nil || keyPart.ColName == nil || keyPart.Length <= 0 {
@@ -327,6 +335,21 @@ func IndexPrefixLengthsToString(keyParts []*tree.KeyPart) string {
 		}
 		prefixLengths[keyPart.ColName.ColName()] = keyPart.Length
 	}
+	return indexPrefixLengthsMapToLegacyString(prefixLengths)
+}
+
+func indexPrefixLengthsFromKeyParts(keyParts []*tree.KeyPart) map[string]int {
+	prefixLengths := make(map[string]int, len(keyParts))
+	for _, keyPart := range keyParts {
+		if keyPart == nil || keyPart.ColName == nil || keyPart.Length <= 0 {
+			continue
+		}
+		prefixLengths[keyPart.ColName.ColName()] = keyPart.Length
+	}
+	return prefixLengths
+}
+
+func indexPrefixLengthsMapToLegacyString(prefixLengths map[string]int) string {
 	if len(prefixLengths) == 0 {
 		return ""
 	}
@@ -342,6 +365,34 @@ func IndexPrefixLengthsToString(keyParts []*tree.KeyPart) string {
 		encoded = append(encoded, fmt.Sprintf("%s:%d", part, prefixLengths[part]))
 	}
 	return strings.Join(encoded, ",")
+}
+
+// SetIndexPrefixLengthsInParamMap writes prefix-length metadata to params.
+// Ordinary names keep the legacy representation for stable catalog output;
+// names containing a legacy delimiter use the lossless v2 representation.
+func SetIndexPrefixLengthsInParamMap(params map[string]string, prefixLengths map[string]int) error {
+	if params == nil {
+		return moerr.NewInvalidInputNoCtx("nil index params map")
+	}
+	delete(params, IndexAlgoParamPrefixLengths)
+	delete(params, IndexAlgoParamPrefixLengthsV2)
+	if len(prefixLengths) == 0 {
+		return nil
+	}
+
+	for part := range prefixLengths {
+		if strings.ContainsAny(part, ":,") {
+			encoded, err := json.Marshal(prefixLengths)
+			if err != nil {
+				return err
+			}
+			params[IndexAlgoParamPrefixLengthsV2] = string(encoded)
+			return nil
+		}
+	}
+
+	params[IndexAlgoParamPrefixLengths] = indexPrefixLengthsMapToLegacyString(prefixLengths)
+	return nil
 }
 
 func IndexPrefixLengthsFromParams(indexParams string) map[string]int {
@@ -361,11 +412,26 @@ func IndexPrefixLengthsFromParamsWithError(indexParams string) (map[string]int, 
 		return nil, err
 	}
 
+	if encoded, ok := params[IndexAlgoParamPrefixLengthsV2]; ok {
+		if encoded == "" {
+			return nil, nil
+		}
+		prefixLengths := make(map[string]int)
+		if err := json.Unmarshal([]byte(encoded), &prefixLengths); err != nil {
+			return nil, moerr.NewInvalidInputNoCtxf("invalid v2 index prefix lengths %q", encoded)
+		}
+		for part, length := range prefixLengths {
+			if part == "" || length <= 0 {
+				return nil, moerr.NewInvalidInputNoCtxf("invalid v2 index prefix length %q", encoded)
+			}
+		}
+		return prefixLengths, nil
+	}
+
 	encoded := params[IndexAlgoParamPrefixLengths]
 	if encoded == "" {
 		return nil, nil
 	}
-
 	prefixLengths := make(map[string]int)
 	for _, item := range strings.Split(encoded, ",") {
 		part, lengthText, ok := strings.Cut(item, ":")

--- a/pkg/catalog/secondary_index_utils_test.go
+++ b/pkg/catalog/secondary_index_utils_test.go
@@ -109,6 +109,14 @@ func TestIndexPrefixLengthsFromParamsWithError(t *testing.T) {
 			},
 		},
 		{
+			name:   "valid delimiter-bearing v2 prefix lengths",
+			params: `{"prefix_lengths_v2":"{\"a:b\":2,\"c,d\":3}"}`,
+			want: map[string]int{
+				"a:b": 2,
+				"c,d": 3,
+			},
+		},
+		{
 			name:      "invalid json",
 			params:    "{bad json",
 			wantError: true,
@@ -126,6 +134,11 @@ func TestIndexPrefixLengthsFromParamsWithError(t *testing.T) {
 		{
 			name:      "non positive length",
 			params:    `{"prefix_lengths":"t:0"}`,
+			wantError: true,
+		},
+		{
+			name:      "invalid v2 payload",
+			params:    `{"prefix_lengths_v2":"not-json"}`,
 			wantError: true,
 		},
 	}
@@ -241,6 +254,25 @@ func TestAddIndexPrefixLengthsToParams(t *testing.T) {
 		got, err := AddIndexPrefixLengthsToParams("", keyParts)
 		require.NoError(t, err)
 		require.Equal(t, map[string]int{"a": 10, "b": 20}, IndexPrefixLengthsFromParams(got))
+	})
+
+	t.Run("delimiter-bearing names use v2 metadata", func(t *testing.T) {
+		got, err := AddIndexPrefixLengthsToParams("", []*tree.KeyPart{
+			newPrefixKeyPart("a:b", 2),
+			newPrefixKeyPart("c,d", 3),
+		})
+		require.NoError(t, err)
+
+		params, err := IndexParamsStringToMap(got)
+		require.NoError(t, err)
+		require.NotContains(t, params, IndexAlgoParamPrefixLengths)
+		require.JSONEq(t, `{"a:b":2,"c,d":3}`, params[IndexAlgoParamPrefixLengthsV2])
+		require.Equal(t, map[string]int{"a:b": 2, "c,d": 3}, IndexPrefixLengthsFromParams(got))
+	})
+
+	t.Run("nil params map is rejected", func(t *testing.T) {
+		err := SetIndexPrefixLengthsInParamMap(nil, map[string]int{"a": 1})
+		require.Error(t, err)
 	})
 }
 

--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -48,7 +48,8 @@ const (
 	MORPCVersion10     int64 = 10 // persisted appendable-object abort metadata
 	MORPCVersion11     int64 = 11 // bounded Sorted64 membership-filter wire format
 	MORPCVersion12     int64 = 12 // prepared-parameter provenance in remote process metadata and aggregate trailers
-	MORPCLatestVersion       = MORPCVersion12
+	MORPCVersion13     int64 = 13 // lossless v2 prefix-index metadata
+	MORPCLatestVersion       = MORPCVersion13
 )
 
 // DefaultLockWaitTimeoutSeconds is shared by the frontend default and by

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1650,6 +1650,13 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 }
 
 func (builder *QueryBuilder) applyExtraFiltersOnIndex(idxDef *IndexDef, node *plan.Node, idxTableNode *plan.Node, filterIdx []int32) {
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	if err != nil {
+		// Invalid metadata must not make an optional filter pushdown affect query
+		// correctness. The original filters remain on the base-table scan.
+		return
+	}
+
 	for i := range node.FilterList {
 		// if already in filterIdx, continue
 		applied := false
@@ -1676,14 +1683,24 @@ func (builder *QueryBuilder) applyExtraFiltersOnIndex(idxDef *IndexDef, node *pl
 			continue
 		}
 		for k := range idxDef.Parts {
-			colIdx := node.TableDef.Name2ColIndex[catalog.ResolveAlias(idxDef.Parts[k])]
+			partName := catalog.ResolveAlias(idxDef.Parts[k])
+			colIdx := node.TableDef.Name2ColIndex[partName]
 			if colIdx != col.ColPos {
 				continue
 			}
+			if prefixLengths[partName] > 0 {
+				// A prefix index only stores a lossy substring. Applying a
+				// full-value predicate to it can reject valid candidates, so
+				// leave the predicate as a base-table residual.
+				continue
+			}
 			idxColExpr := GetColExpr(idxTableNode.TableDef.Cols[0].Typ, idxTableNode.BindingTags[0], 0)
-			deserialExpr, _ := MakeSerialExtractExpr(builder.GetContext(), idxColExpr, fn.Args[colArgIdx].Typ, int64(k))
+			idxPartExpr := idxColExpr
+			if indexTableStoresSerializedKey(idxDef) {
+				idxPartExpr, _ = MakeSerialExtractExpr(builder.GetContext(), idxColExpr, fn.Args[colArgIdx].Typ, int64(k))
+			}
 			newFilter := DeepCopyExpr(node.FilterList[i])
-			newFilter.GetF().Args[colArgIdx] = deserialExpr
+			newFilter.GetF().Args[colArgIdx] = idxPartExpr
 			idxTableNode.FilterList = append(idxTableNode.FilterList, newFilter)
 			applied = true
 		}

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1823,6 +1823,20 @@ func findLeadingFilter(idxDef *IndexDef, node *plan.Node) ([]int32, bool) {
 	return nil, false
 }
 
+func (builder *QueryBuilder) makeIndexLookupPartExpr(idxDef *IndexDef, partPos int, inputExpr *plan.Expr) *plan.Expr {
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	if err != nil || partPos < 0 || partPos >= len(idxDef.Parts) {
+		return DeepCopyExpr(inputExpr)
+	}
+
+	partName := catalog.ResolveAlias(idxDef.Parts[partPos])
+	lookupExpr, err := builder.makeIndexPartExprFromInputExpr(inputExpr, partName, prefixLengths)
+	if err != nil {
+		return DeepCopyExpr(inputExpr)
+	}
+	return lookupExpr
+}
+
 func (builder *QueryBuilder) replaceEqualCondition(idxDef *IndexDef, filterList []*plan.Expr, filterPos []int32, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
 	numParts := len(idxDef.Parts)
 	if numParts == 1 { //directly equal
@@ -1830,6 +1844,7 @@ func (builder *QueryBuilder) replaceEqualCondition(idxDef *IndexDef, filterList 
 		args := expr.GetF().Args
 		args[0].GetCol().RelPos = idxTag
 		args[0].GetCol().ColPos = 0
+		args[1] = builder.makeIndexLookupPartExpr(idxDef, 0, args[1])
 		return expr
 	}
 
@@ -1838,7 +1853,7 @@ func (builder *QueryBuilder) replaceEqualCondition(idxDef *IndexDef, filterList 
 	serialArgs := make([]*plan.Expr, len(filterPos))
 	for i := range filterPos {
 		filter := filterList[filterPos[i]]
-		serialArgs[i] = DeepCopyExpr(filter.GetF().Args[1])
+		serialArgs[i] = builder.makeIndexLookupPartExpr(idxDef, i, filter.GetF().Args[1])
 		compositeFilterSel = compositeFilterSel * filter.Selectivity
 	}
 	rightArg, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), indexTableLookupSerialFunc(idxDef), serialArgs)
@@ -2095,6 +2110,14 @@ func runtimeConstMayBeNull(expr *plan.Expr) bool {
 }
 
 func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node, colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr, scanSnapshot *Snapshot) int32 {
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	if err != nil || len(prefixLengths) > 0 {
+		// Prefix indexes store only a substring of each configured part. They are
+		// safe for locating candidates followed by a base-table lookup, but cannot
+		// reconstruct the full column value required by an index-only scan.
+		return -1
+	}
+
 	// check if this index contains all columns needed
 	for i := range node.TableDef.Cols {
 		if colRefCnt[[2]int32{node.BindingTags[0], int32(i)}] > 0 {

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -757,7 +757,12 @@ func (builder *QueryBuilder) buildRegularIndexTopSortContext(projNode *plan.Node
 }
 
 func usableRegularHintIndex(idxDef *plan.IndexDef) bool {
-	return idxDef != nil && idxDef.TableExist && catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) && !isSpatialIndexDef(idxDef)
+	return idxDef != nil &&
+		idxDef.TableExist &&
+		catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) &&
+		!isSpatialIndexDef(idxDef) &&
+		regularIndexPrefixMetadataUsable(idxDef) &&
+		!regularIndexHasDeclaredPrefix(idxDef)
 }
 
 func indexLeadingColumnsMatch(idxDef *plan.IndexDef, tableDef *plan.TableDef, colPositions []int32) bool {
@@ -1548,6 +1553,71 @@ func getVectorIndexIncludedColumns(multiTableIndex *MultiTableIndex) ([]string, 
 	return nil, nil
 }
 
+// regularIndexPrefixMetadataUsable validates the relationship between persisted
+// prefix metadata and the logical index parts. Optional index access must fail
+// closed when older DDL left a stale column-name key behind, or when the
+// metadata is malformed; probing with the complete value can otherwise miss a
+// physically truncated key.
+func regularIndexPrefixMetadataUsable(idxDef *IndexDef) bool {
+	if idxDef == nil || len(idxDef.Parts) == 0 {
+		return false
+	}
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	if err != nil {
+		return false
+	}
+	for prefixPart := range prefixLengths {
+		matched := false
+		for _, part := range idxDef.Parts {
+			if prefixPart == catalog.ResolveAlias(part) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func validateRegularIndexPrefixMetadata(idxDef *IndexDef) error {
+	if regularIndexPrefixMetadataUsable(idxDef) {
+		return nil
+	}
+	indexName := ""
+	if idxDef != nil {
+		indexName = idxDef.IndexName
+	}
+	return moerr.NewInvalidInputNoCtxf(
+		"invalid prefix metadata for index %q; rebuild the index before writing to the table",
+		indexName,
+	)
+}
+
+func validateTableRegularIndexPrefixMetadata(tableDef *TableDef) error {
+	if tableDef == nil {
+		return nil
+	}
+	for _, idxDef := range tableDef.Indexes {
+		if idxDef == nil || !idxDef.TableExist || !catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) {
+			continue
+		}
+		if err := validateRegularIndexPrefixMetadata(idxDef); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func regularIndexHasDeclaredPrefix(idxDef *IndexDef) bool {
+	if idxDef == nil {
+		return true
+	}
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	return err != nil || len(prefixLengths) > 0
+}
+
 func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, node *plan.Node, colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr) int32 {
 	if len(node.FilterList) == 0 || len(node.TableDef.Indexes) == 0 {
 		return nodeID
@@ -1577,6 +1647,9 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 		}
 		if isSpatialIndexDef(node.TableDef.Indexes[i]) {
 			spatialIndexes = append(spatialIndexes, node.TableDef.Indexes[i])
+			continue
+		}
+		if !regularIndexPrefixMetadataUsable(node.TableDef.Indexes[i]) {
 			continue
 		}
 		indexes = append(indexes, node.TableDef.Indexes[i])
@@ -1624,8 +1697,10 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 	idxToChoose, filterIdx := builder.getMostSelectiveIndexForPointSelect(indexes, node, ignoreStats)
 	if idxToChoose != -1 {
 		retID, idxTableNodeID := builder.applyIndexJoin(indexes[idxToChoose], node, EqualIndexCondition, filterIdx, scanSnapshot)
-		builder.applyExtraFiltersOnIndex(indexes[idxToChoose], node, builder.qry.Nodes[idxTableNodeID], filterIdx)
-		return retID
+		if idxTableNodeID != -1 {
+			builder.applyExtraFiltersOnIndex(indexes[idxToChoose], node, builder.qry.Nodes[idxTableNodeID], filterIdx)
+			return retID
+		}
 	}
 
 	idxToChoose, filterIdx = builder.getIndexForNonEquiCond(indexes, node)
@@ -1840,29 +1915,32 @@ func findLeadingFilter(idxDef *IndexDef, node *plan.Node) ([]int32, bool) {
 	return nil, false
 }
 
-func (builder *QueryBuilder) makeIndexLookupPartExpr(idxDef *IndexDef, partPos int, inputExpr *plan.Expr) *plan.Expr {
+func (builder *QueryBuilder) makeIndexLookupPartExpr(idxDef *IndexDef, partPos int, inputExpr *plan.Expr) (*plan.Expr, error) {
 	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
-	if err != nil || partPos < 0 || partPos >= len(idxDef.Parts) {
-		return DeepCopyExpr(inputExpr)
+	if err != nil {
+		return nil, err
+	}
+	if partPos < 0 || partPos >= len(idxDef.Parts) {
+		return nil, moerr.NewInvalidInputNoCtxf("invalid index part position %d", partPos)
 	}
 
 	partName := catalog.ResolveAlias(idxDef.Parts[partPos])
-	lookupExpr, err := builder.makeIndexPartExprFromInputExpr(inputExpr, partName, prefixLengths)
-	if err != nil {
-		return DeepCopyExpr(inputExpr)
-	}
-	return lookupExpr
+	return builder.makeIndexPartExprFromInputExpr(inputExpr, partName, prefixLengths)
 }
 
-func (builder *QueryBuilder) replaceEqualCondition(idxDef *IndexDef, filterList []*plan.Expr, filterPos []int32, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
+func (builder *QueryBuilder) replaceEqualCondition(idxDef *IndexDef, filterList []*plan.Expr, filterPos []int32, idxTag int32, idxTableDef *plan.TableDef) (*plan.Expr, error) {
 	numParts := len(idxDef.Parts)
 	if numParts == 1 { //directly equal
 		expr := DeepCopyExpr(filterList[filterPos[0]])
 		args := expr.GetF().Args
 		args[0].GetCol().RelPos = idxTag
 		args[0].GetCol().ColPos = 0
-		args[1] = builder.makeIndexLookupPartExpr(idxDef, 0, args[1])
-		return expr
+		var err error
+		args[1], err = builder.makeIndexLookupPartExpr(idxDef, 0, args[1])
+		if err != nil {
+			return nil, err
+		}
+		return expr, nil
 	}
 
 	// a=1 and b=2, change to prefix_eq
@@ -1870,19 +1948,29 @@ func (builder *QueryBuilder) replaceEqualCondition(idxDef *IndexDef, filterList 
 	serialArgs := make([]*plan.Expr, len(filterPos))
 	for i := range filterPos {
 		filter := filterList[filterPos[i]]
-		serialArgs[i] = builder.makeIndexLookupPartExpr(idxDef, i, filter.GetF().Args[1])
+		var err error
+		serialArgs[i], err = builder.makeIndexLookupPartExpr(idxDef, i, filter.GetF().Args[1])
+		if err != nil {
+			return nil, err
+		}
 		compositeFilterSel = compositeFilterSel * filter.Selectivity
 	}
-	rightArg, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), indexTableLookupSerialFunc(idxDef), serialArgs)
+	rightArg, err := BindFuncExprImplByPlanExpr(builder.GetContext(), indexTableLookupSerialFunc(idxDef), serialArgs)
+	if err != nil {
+		return nil, err
+	}
 
 	funcName := "="
 	if len(filterPos) < numParts {
 		funcName = "prefix_eq"
 	}
 	leadingColExpr := GetColExpr(idxTableDef.Cols[0].Typ, idxTag, 0)
-	expr, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), funcName, []*plan.Expr{leadingColExpr, rightArg})
+	expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), funcName, []*plan.Expr{leadingColExpr, rightArg})
+	if err != nil {
+		return nil, err
+	}
 	expr.Selectivity = compositeFilterSel
-	return expr
+	return expr, nil
 }
 
 func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *plan.Expr, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
@@ -1948,9 +2036,9 @@ func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *
 	return expr
 }
 
-func (builder *QueryBuilder) replaceLeadingFilter(idxDef *IndexDef, filterList []*plan.Expr, leadingPos []int32, leadingEqualCond bool, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
+func (builder *QueryBuilder) replaceLeadingFilter(idxDef *IndexDef, filterList []*plan.Expr, leadingPos []int32, leadingEqualCond bool, idxTag int32, idxTableDef *plan.TableDef) (*plan.Expr, error) {
 	if !leadingEqualCond { // a IN (1, 2, 3), a BETWEEN 1 AND 2
-		return builder.replaceNonEqualCondition(idxDef, filterList[leadingPos[0]], idxTag, idxTableDef)
+		return builder.replaceNonEqualCondition(idxDef, filterList[leadingPos[0]], idxTag, idxTableDef), nil
 	}
 	return builder.replaceEqualCondition(idxDef, filterList, leadingPos, idxTag, idxTableDef)
 }
@@ -2215,8 +2303,12 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 	if e != nil {
 		panic(e)
 	}
-	builder.addNameByColRef(idxTag, idxTableDef)
 	leadingColExpr := GetColExpr(idxTableDef.Cols[0].Typ, idxTag, 0)
+	newLeadingFilter, err := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
+	if err != nil {
+		return -1
+	}
+	builder.addNameByColRef(idxTag, idxTableDef)
 
 	if numParts == 1 {
 		colIdx := node.TableDef.Name2ColIndex[idxDef.Parts[0]]
@@ -2235,7 +2327,6 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 		}
 	}
 
-	newLeadingFilter := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
 	residualLeadingPos := indexOnlyResidualLeadingFilterPositions(idxDef, node.TableDef, node.FilterList, leadingPos, newLeadingFilter)
 	filterCapacity := 1 + len(missFilterIdx) + len(residualLeadingPos)
 	newFilterList := make([]*plan.Expr, 0, filterCapacity)
@@ -2397,14 +2488,27 @@ func classifyRangeBound(fn *plan.Function) (col *plan.ColRef, isLower bool) {
 func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *plan.Node) (int, []int32) {
 	colPos2Idx := make(map[int32]int)
 	for i, idxDef := range indexes {
+		// Prefix keys are lossy. IN and range operators can use block-level
+		// pruning implementations that compare the untruncated probe with the
+		// persisted prefix and under-fetch after flush. Keep prefix indexes for
+		// equality candidate lookup only, where the probe is explicitly truncated.
+		if regularIndexHasDeclaredPrefix(idxDef) {
+			continue
+		}
 		numParts := len(idxDef.Parts)
 		if !idxDef.Unique {
 			numParts--
 		}
 		if idxDef.Unique && numParts == 1 {
-			colPos2Idx[node.TableDef.Name2ColIndex[idxDef.Parts[0]]] = i
+			colPos, ok := node.TableDef.Name2ColIndex[catalog.ResolveAlias(idxDef.Parts[0])]
+			if ok {
+				colPos2Idx[colPos] = i
+			}
 		} else if !idxDef.Unique && numParts >= 1 {
-			colPos2Idx[node.TableDef.Name2ColIndex[idxDef.Parts[0]]] = i
+			colPos, ok := node.TableDef.Name2ColIndex[catalog.ResolveAlias(idxDef.Parts[0])]
+			if ok {
+				colPos2Idx[colPos] = i
+			}
 		}
 	}
 
@@ -2602,11 +2706,13 @@ func (builder *QueryBuilder) applyIndexJoin(idxDef *IndexDef, node *plan.Node, f
 	if err != nil {
 		panic(err)
 	}
-	builder.addNameByColRef(idxTag, idxTableDef)
 
 	var idxFilter *plan.Expr
 	if filterType == EqualIndexCondition {
-		idxFilter = builder.replaceEqualCondition(idxDef, node.FilterList, filterIdx, idxTag, idxTableDef)
+		idxFilter, err = builder.replaceEqualCondition(idxDef, node.FilterList, filterIdx, idxTag, idxTableDef)
+		if err != nil {
+			return node.NodeId, -1
+		}
 	} else if filterType == SpatialIndexCondition {
 		spatialColMap := buildSpatialIndexColMap(idxDef, node, idxTag, idxTableDef)
 		idxFilter = replaceColumnsForExpr(DeepCopyExpr(node.FilterList[filterIdx[0]]), spatialColMap)
@@ -2615,6 +2721,7 @@ func (builder *QueryBuilder) applyIndexJoin(idxDef *IndexDef, node *plan.Node, f
 	} else {
 		idxFilter = builder.replaceNonEqualCondition(idxDef, node.FilterList[filterIdx[0]], idxTag, idxTableDef)
 	}
+	builder.addNameByColRef(idxTag, idxTableDef)
 
 	// recod index table scan info
 	idxScanInfo := plan.IndexScanInfo{
@@ -2843,7 +2950,11 @@ func (builder *QueryBuilder) applyIndicesForJoins(nodeID int32, node *plan.Node,
 	indexes := builder.filterRegularIndexesByJoinHints(leftChild, leftChild.TableDef.Indexes)
 	condIdx := make([]indexJoinCondition, 0, len(col2Cond))
 	for _, idxDef := range indexes {
-		if !idxDef.TableExist || !catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) || isSpatialIndexDef(idxDef) {
+		if !idxDef.TableExist ||
+			!catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) ||
+			isSpatialIndexDef(idxDef) ||
+			!regularIndexPrefixMetadataUsable(idxDef) ||
+			regularIndexHasDeclaredPrefix(idxDef) {
 			continue
 		}
 

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -4133,6 +4133,89 @@ func TestReplaceEqualConditionTruncatesSinglePartPrefixIndexLookup(t *testing.T)
 	require.True(t, exprContainsFuncName(expr.GetF().Args[1], "substring"))
 }
 
+func TestApplyExtraFiltersOnIndexUsesPhysicalKeyShape(t *testing.T) {
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "status:4",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		idxDef            *planpb.IndexDef
+		wantPushed        bool
+		wantSerialExtract bool
+	}{
+		{
+			name: "direct single-column unique key",
+			idxDef: &planpb.IndexDef{
+				Parts:  []string{"status"},
+				Unique: true,
+			},
+			wantPushed: true,
+		},
+		{
+			name: "serialized composite key",
+			idxDef: &planpb.IndexDef{
+				Parts:  []string{"status", "id"},
+				Unique: true,
+			},
+			wantPushed:        true,
+			wantSerialExtract: true,
+		},
+		{
+			name: "lossy prefix key",
+			idxDef: &planpb.IndexDef{
+				Parts:           []string{"status"},
+				Unique:          true,
+				IndexAlgoParams: prefixParams,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+			baseTag := builder.genNewBindTag()
+			indexTag := builder.genNewBindTag()
+			node := &planpb.Node{
+				BindingTags: []int32{baseTag},
+				TableDef: &planpb.TableDef{
+					Cols: []*planpb.ColDef{
+						{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+						{Name: "status", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 32}},
+					},
+					Name2ColIndex: map[string]int32{"id": 0, "status": 1},
+					Pkey:          &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+				},
+				FilterList: []*planpb.Expr{
+					makeStringEqFilterExpr(baseTag, 1, "active"),
+					makeStringEqFilterExpr(baseTag, 1, "active"),
+				},
+			}
+			idxTableNode := &planpb.Node{
+				TableDef:    makeTestIndexTableDef(),
+				BindingTags: []int32{indexTag},
+			}
+
+			builder.applyExtraFiltersOnIndex(tt.idxDef, node, idxTableNode, []int32{0})
+
+			if !tt.wantPushed {
+				require.Empty(t, idxTableNode.FilterList)
+				return
+			}
+			require.Len(t, idxTableNode.FilterList, 1)
+			pushed := idxTableNode.FilterList[0]
+			require.Equal(t, tt.wantSerialExtract, exprContainsFuncName(pushed, "serial_extract"))
+			if !tt.wantSerialExtract {
+				idxCol := pushed.GetF().Args[0].GetCol()
+				require.NotNil(t, idxCol)
+				require.Equal(t, indexTag, idxCol.RelPos)
+				require.Equal(t, int32(0), idxCol.ColPos)
+			}
+		})
+	}
+}
+
 func TestReplaceNonEqualConditionUsesSerialFullForNonUniqueCompositeIndexIn(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	idxDef := &planpb.IndexDef{

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -4443,7 +4443,8 @@ func TestIndexOnlyResidualLeadingFilterPositionsAreMinimal(t *testing.T) {
 	lastLiteral := makeStringEqFilterExpr(0, 2, "\x00")
 	setIndexFilterArgumentType(lastLiteral, tableDef.Cols[2].Typ)
 	filters := []*planpb.Expr{firstLiteral, lastLiteral}
-	lookup := builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	lookup, err := builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	require.NoError(t, err)
 
 	require.Equal(t, []int32{1}, indexOnlyResidualLeadingFilterPositions(
 		idxDef, tableDef, filters, []int32{0, 1}, lookup,
@@ -4451,7 +4452,8 @@ func TestIndexOnlyResidualLeadingFilterPositionsAreMinimal(t *testing.T) {
 
 	firstPrepared := makeParamEqFilterExpr(0, 1, 0)
 	filters[0] = firstPrepared
-	lookup = builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	lookup, err = builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	require.NoError(t, err)
 	require.Equal(t, []int32{0, 1}, indexOnlyResidualLeadingFilterPositions(
 		idxDef, tableDef, filters, []int32{0, 1}, lookup,
 	))
@@ -4463,7 +4465,8 @@ func TestIndexOnlyResidualLeadingFilterPositionsAreMinimal(t *testing.T) {
 	lastFixedWidth := makeEqFilterExpr(2)
 	lastFixedWidth.GetF().Args[0].GetCol().RelPos = 0
 	filters = []*planpb.Expr{firstByteString, lastFixedWidth}
-	lookup = builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	lookup, err = builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, makeTestIndexTableDef())
+	require.NoError(t, err)
 	require.Empty(t, indexOnlyResidualLeadingFilterPositions(
 		idxDef, tableDef, filters, []int32{0, 1}, lookup,
 	))

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -740,6 +740,19 @@ func TestIndexHintJoinScopeFiltersCandidates(t *testing.T) {
 	}
 }
 
+func TestIndexJoinSkipsLossyPrefixIndex(t *testing.T) {
+	builder, joinID, leftScanID, leftDef := makeIndexHintJoinBuilder(t)
+	leftDef.Indexes[0].IndexAlgoParams = `{"prefix_lengths":"a:1"}`
+	join := builder.qry.Nodes[joinID]
+
+	newID, err := builder.applyIndicesForJoins(
+		joinID, join, map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+	require.NoError(t, err)
+	require.Equal(t, joinID, newID)
+	require.Equal(t, leftScanID, join.Children[0])
+	require.Empty(t, join.RuntimeFilterBuildList)
+}
+
 func TestIndexJoinBuildsVersionedSerializedRuntimeFilter(t *testing.T) {
 	builder, joinID, leftScanID, _ := makeIndexHintJoinBuilder(t)
 	join := builder.qry.Nodes[joinID]
@@ -4043,6 +4056,107 @@ func TestIndexTableLookupSerialFunc(t *testing.T) {
 	}))
 }
 
+func TestRegularIndexPrefixMetadataUsable(t *testing.T) {
+	tests := []struct {
+		name   string
+		parts  []string
+		params string
+		want   bool
+	}{
+		{name: "no prefix metadata", parts: []string{"name"}, want: true},
+		{name: "matching legacy metadata", parts: []string{"name"}, params: `{"prefix_lengths":"name:4"}`, want: true},
+		{name: "matching v2 metadata", parts: []string{"head:line"}, params: `{"prefix_lengths_v2":"{\"head:line\":4}"}`, want: true},
+		{name: "non-canonical case fails closed", parts: []string{"name"}, params: `{"prefix_lengths":"Name:4"}`, want: false},
+		{name: "stale renamed part", parts: []string{"renamed"}, params: `{"prefix_lengths":"name:4"}`, want: false},
+		{name: "malformed metadata", parts: []string{"name"}, params: `{"prefix_lengths":"name:0"}`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, regularIndexPrefixMetadataUsable(&planpb.IndexDef{
+				Parts:           tt.parts,
+				IndexAlgoParams: tt.params,
+			}))
+		})
+	}
+
+	fullIndex := &planpb.IndexDef{TableExist: true, Parts: []string{"name"}}
+	prefixIndex := &planpb.IndexDef{TableExist: true, Parts: []string{"name"}, IndexAlgoParams: `{"prefix_lengths":"name:4"}`}
+	staleIndex := &planpb.IndexDef{TableExist: true, Parts: []string{"renamed"}, IndexAlgoParams: `{"prefix_lengths":"name:4"}`}
+	require.True(t, usableRegularHintIndex(fullIndex))
+	require.False(t, usableRegularHintIndex(prefixIndex))
+	require.False(t, usableRegularHintIndex(staleIndex))
+	require.NoError(t, validateRegularIndexPrefixMetadata(prefixIndex))
+	require.ErrorContains(t, validateRegularIndexPrefixMetadata(staleIndex), "rebuild the index")
+	require.ErrorContains(t, validateTableRegularIndexPrefixMetadata(&planpb.TableDef{
+		Indexes: []*planpb.IndexDef{staleIndex},
+	}), "rebuild the index")
+}
+
+func TestGetIndexForNonEquiCondSkipsDeclaredPrefixIndexes(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	node := &planpb.Node{
+		BindingTags: []int32{bindTag},
+		TableDef: &planpb.TableDef{
+			Name2ColIndex: map[string]int32{"id": 0, "name": 1},
+			Cols: []*planpb.ColDef{
+				{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+				{Name: "name", Typ: planpb.Type{Id: int32(types.T_varchar)}},
+			},
+			Pkey: &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+		},
+	}
+	prefixNonUnique := &planpb.IndexDef{
+		IndexName:       "idx_name_prefix",
+		Parts:           []string{"name", catalog.CreateAlias("id")},
+		IndexAlgoParams: `{"prefix_lengths":"name:4"}`,
+	}
+	prefixUnique := &planpb.IndexDef{
+		IndexName:       "uq_name_prefix",
+		Parts:           []string{"name"},
+		Unique:          true,
+		IndexAlgoParams: `{"prefix_lengths":"name:4"}`,
+	}
+
+	filters := []struct {
+		name string
+		expr *planpb.Expr
+	}{
+		{name: "in", expr: makeStringInFilterExpr(bindTag, 1, "abcdx", "abcex")},
+		{name: "between", expr: makeStringBetweenFilterExpr(bindTag, 1, "abcdx", "abcex")},
+		{name: "range", expr: makeRangeFilterExpr(bindTag, 1, ">=", 99)},
+	}
+	for _, idxDef := range []*planpb.IndexDef{prefixNonUnique, prefixUnique} {
+		for _, filter := range filters {
+			t.Run(idxDef.IndexName+"/"+filter.name, func(t *testing.T) {
+				node.FilterList = []*planpb.Expr{filter.expr}
+				idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{idxDef}, node)
+				require.Equal(t, -1, idxPos)
+				require.Nil(t, filterIdx)
+			})
+		}
+	}
+
+	complete := &planpb.IndexDef{IndexName: "idx_name_full", Parts: []string{"name", catalog.CreateAlias("id")}}
+	node.FilterList = []*planpb.Expr{makeStringInFilterExpr(bindTag, 1, "abcdx", "abcex")}
+	idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{prefixNonUnique, complete}, node)
+	require.Equal(t, 1, idxPos)
+	require.Equal(t, []int32{0}, filterIdx)
+}
+
+func TestMakeIndexLookupPartExprDoesNotFailOpen(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:           []string{"name"},
+		IndexAlgoParams: `{"prefix_lengths":"name:0"}`,
+	}
+
+	expr, err := builder.makeIndexLookupPartExpr(idxDef, 0, makePlan2StringConstExprWithType("abcdx"))
+	require.Error(t, err)
+	require.Nil(t, expr)
+}
+
 func TestReplaceEqualConditionUsesSerialFullForNonUniqueCompositeIndex(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	idxDef := &planpb.IndexDef{
@@ -4052,7 +4166,8 @@ func TestReplaceEqualConditionUsesSerialFullForNonUniqueCompositeIndex(t *testin
 	idxTableDef := makeTestIndexTableDef()
 	filters := []*planpb.Expr{makeStringEqFilterExpr(0, 3, "active")}
 
-	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, idxTableDef)
+	expr, err := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, idxTableDef)
+	require.NoError(t, err)
 
 	require.NotNil(t, expr.GetF())
 	require.Equal(t, "prefix_eq", expr.GetF().Func.ObjName)
@@ -4071,7 +4186,8 @@ func TestReplaceEqualConditionKeepsSerialForUniqueCompositeIndex(t *testing.T) {
 		makeStringEqFilterExpr(0, 4, "2026-07-02 00:00:00"),
 	}
 
-	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
+	expr, err := builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
+	require.NoError(t, err)
 
 	require.NotNil(t, expr.GetF())
 	require.Equal(t, "=", expr.GetF().Func.ObjName)
@@ -4092,7 +4208,8 @@ func TestReplaceEqualConditionTruncatesPrefixIndexLookupPart(t *testing.T) {
 	idxTableDef := makeTestIndexTableDef()
 	filters := []*planpb.Expr{makeStringEqFilterExpr(0, 1, "active")}
 
-	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, idxTableDef)
+	expr, err := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, idxTableDef)
+	require.NoError(t, err)
 
 	require.NotNil(t, expr.GetF())
 	require.Equal(t, "prefix_eq", expr.GetF().Func.ObjName)
@@ -4126,7 +4243,8 @@ func TestReplaceEqualConditionTruncatesSinglePartPrefixIndexLookup(t *testing.T)
 	}
 	filters := []*planpb.Expr{makeStringEqFilterExpr(0, 1, "active")}
 
-	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, makeTestIndexTableDef())
+	expr, err := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, makeTestIndexTableDef())
+	require.NoError(t, err)
 
 	require.NotNil(t, expr.GetF())
 	require.Equal(t, "=", expr.GetF().Func.ObjName)

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -4078,6 +4078,61 @@ func TestReplaceEqualConditionKeepsSerialForUniqueCompositeIndex(t *testing.T) {
 	assert.Equal(t, "serial", wrappedSerialFuncName(t, expr.GetF().Args[1]))
 }
 
+func TestReplaceEqualConditionTruncatesPrefixIndexLookupPart(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "status:4",
+	})
+	require.NoError(t, err)
+	idxDef := &planpb.IndexDef{
+		Parts:           []string{"status", "id"},
+		Unique:          false,
+		IndexAlgoParams: prefixParams,
+	}
+	idxTableDef := makeTestIndexTableDef()
+	filters := []*planpb.Expr{makeStringEqFilterExpr(0, 1, "active")}
+
+	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, idxTableDef)
+
+	require.NotNil(t, expr.GetF())
+	require.Equal(t, "prefix_eq", expr.GetF().Func.ObjName)
+	require.True(t, exprContainsFuncName(expr, "substring"))
+	serialFn := expr.GetF().Args[1].GetF()
+	require.NotNil(t, serialFn)
+	require.Len(t, serialFn.Args, 1)
+	prefixArg := serialFn.Args[0].GetF()
+	require.NotNil(t, prefixArg)
+	if prefixArg.Func.ObjName == "cast" {
+		require.Len(t, prefixArg.Args, 1)
+		prefixArg = prefixArg.Args[0].GetF()
+		require.NotNil(t, prefixArg)
+	}
+	require.Equal(t, "substring", prefixArg.Func.ObjName)
+	require.Len(t, prefixArg.Args, 3)
+	require.Equal(t, int64(1), prefixArg.Args[1].GetLit().GetI64Val())
+	require.Equal(t, int64(4), prefixArg.Args[2].GetLit().GetI64Val())
+}
+
+func TestReplaceEqualConditionTruncatesSinglePartPrefixIndexLookup(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "status:4",
+	})
+	require.NoError(t, err)
+	idxDef := &planpb.IndexDef{
+		Parts:           []string{"status"},
+		Unique:          true,
+		IndexAlgoParams: prefixParams,
+	}
+	filters := []*planpb.Expr{makeStringEqFilterExpr(0, 1, "active")}
+
+	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, makeTestIndexTableDef())
+
+	require.NotNil(t, expr.GetF())
+	require.Equal(t, "=", expr.GetF().Func.ObjName)
+	require.True(t, exprContainsFuncName(expr.GetF().Args[1], "substring"))
+}
+
 func TestReplaceNonEqualConditionUsesSerialFullForNonUniqueCompositeIndexIn(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	idxDef := &planpb.IndexDef{
@@ -4211,6 +4266,117 @@ func TestIndexOnlyResidualLeadingFilterPositionsAreMinimal(t *testing.T) {
 	require.Empty(t, indexOnlyResidualLeadingFilterPositions(
 		idxDef, tableDef, filters, []int32{0, 1}, lookup,
 	))
+}
+
+func TestTryIndexOnlyScanRejectsLossyPrefixIndex(t *testing.T) {
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "status:4",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		indexAlgoParams string
+		wantIndexOnly   bool
+	}{
+		{name: "full value index", wantIndexOnly: true},
+		{name: "prefix index", indexAlgoParams: prefixParams, wantIndexOnly: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+			ctx := NewBindContext(builder, nil)
+			bindTag := builder.genNewBindTag()
+			idxDef := &planpb.IndexDef{
+				IndexName:       "idx_status_id",
+				IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+				IndexAlgoParams: tt.indexAlgoParams,
+				IndexTableName:  "__mo_idx_status_id",
+				Parts:           []string{"status", "id"},
+				Unique:          false,
+				TableExist:      true,
+			}
+			registerMockIndexTable(t, builder, idxDef.IndexTableName)
+			node := &planpb.Node{
+				NodeType:    planpb.Node_TABLE_SCAN,
+				ObjRef:      &planpb.ObjectRef{SchemaName: "test", ObjName: "t"},
+				BindingTags: []int32{bindTag},
+				TableDef: &planpb.TableDef{
+					Name: "t",
+					Cols: []*planpb.ColDef{
+						{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+						{Name: "status", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 32}},
+					},
+					Name2ColIndex: map[string]int32{"id": 0, "status": 1},
+					Pkey:          &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+				},
+				Stats:      &planpb.Stats{TableCnt: 100, Outcnt: 1, Selectivity: 0.01, Cost: 100},
+				FilterList: []*planpb.Expr{makeStringEqFilterExpr(bindTag, 1, "active")},
+			}
+			scanID := builder.appendNode(node, ctx)
+
+			idxNodeID := builder.tryIndexOnlyScan(idxDef, builder.qry.Nodes[scanID], map[[2]int32]int{{bindTag, 1}: 1}, map[[2]int32]*planpb.Expr{}, &Snapshot{})
+			if tt.wantIndexOnly {
+				require.NotEqual(t, int32(-1), idxNodeID)
+			} else {
+				require.Equal(t, int32(-1), idxNodeID)
+			}
+		})
+	}
+}
+
+func TestApplyIndicesForFiltersUsesIndexJoinForPrefixIndex(t *testing.T) {
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "status:4",
+	})
+	require.NoError(t, err)
+
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	ctx := NewBindContext(builder, nil)
+	bindTag := builder.genNewBindTag()
+	idxDef := &planpb.IndexDef{
+		IndexName:       "idx_status_id",
+		IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+		IndexAlgoParams: prefixParams,
+		IndexTableName:  "__mo_idx_status_id",
+		Parts:           []string{"status", "id"},
+		Unique:          false,
+		TableExist:      true,
+	}
+	registerMockIndexTable(t, builder, idxDef.IndexTableName)
+	node := &planpb.Node{
+		NodeType:    planpb.Node_TABLE_SCAN,
+		ObjRef:      &planpb.ObjectRef{SchemaName: "test", ObjName: "t"},
+		BindingTags: []int32{bindTag},
+		TableDef: &planpb.TableDef{
+			Name: "t",
+			Cols: []*planpb.ColDef{
+				{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+				{Name: "status", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 32}},
+			},
+			Name2ColIndex: map[string]int32{"id": 0, "status": 1},
+			Pkey:          &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+			Indexes:       []*planpb.IndexDef{idxDef},
+		},
+		Stats:      &planpb.Stats{TableCnt: 100, Outcnt: 1, Selectivity: 0.01, Cost: 100},
+		FilterList: []*planpb.Expr{makeStringEqFilterExpr(bindTag, 1, "active")},
+	}
+	scanID := builder.appendNode(node, ctx)
+
+	resultID := builder.applyIndicesForFiltersRegularIndex(scanID, builder.qry.Nodes[scanID], map[[2]int32]int{{bindTag, 1}: 1}, map[[2]int32]*planpb.Expr{})
+	require.NotEqual(t, scanID, resultID)
+
+	indexJoin := builder.qry.Nodes[resultID]
+	require.Equal(t, planpb.Node_JOIN, indexJoin.NodeType)
+	require.Equal(t, planpb.Node_INDEX, indexJoin.JoinType)
+	require.Equal(t, scanID, indexJoin.Children[0])
+	require.Len(t, builder.qry.Nodes[scanID].FilterList, 1)
+	require.Equal(t, "=", builder.qry.Nodes[scanID].FilterList[0].GetF().Func.ObjName)
+
+	indexScan := builder.qry.Nodes[indexJoin.Children[1]]
+	require.True(t, indexScan.IndexScanInfo.IsIndexScan)
+	require.Equal(t, idxDef.IndexName, indexScan.IndexScanInfo.IndexName)
 }
 
 func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testing.T) {

--- a/pkg/sql/plan/bind_delete.go
+++ b/pkg/sql/plan/bind_delete.go
@@ -96,6 +96,11 @@ func (builder *QueryBuilder) bindDelete(ctx CompilerContext, stmt *tree.Delete, 
 			return 0, moerr.NewUnsupportedDML(builder.GetContext(), "rewrite to truncate table")
 		}
 	}
+	for _, tableDef := range dmlCtx.tableDefs {
+		if err := validateTableRegularIndexPrefixMetadata(tableDef); err != nil {
+			return 0, err
+		}
+	}
 
 	var selectList []tree.SelectExpr
 	colName2Idx := make([]map[string]int32, len(stmt.Tables))

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -76,6 +76,9 @@ func (builder *QueryBuilder) bindInsert(stmt *tree.Insert, bindCtx *BindContext)
 	// createQuery from the materialized new-row image. HNSW/CAGRA/IVF-PQ are cron-
 	// maintained and ride the modern path with no inline sub-plan.
 	tableDef := dmlCtx.tableDefs[0]
+	if err := validateTableRegularIndexPrefixMetadata(tableDef); err != nil {
+		return 0, err
+	}
 	if stmt.HasReturning() {
 		if err := validateReturningTarget(builder, tableDef, dmlCtx.objRefs[0]); err != nil {
 			return 0, err

--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -46,6 +46,9 @@ func (builder *QueryBuilder) bindReplace(stmt *tree.Replace, bindCtx *BindContex
 	// MASTER now has full synchronous modern maintenance (delete-by-pk + insert),
 	// same as IVF/fulltext. HNSW/CAGRA/IVF-PQ are cron-maintained.
 	tableDef := dmlCtx.tableDefs[0]
+	if err := validateTableRegularIndexPrefixMetadata(tableDef); err != nil {
+		return 0, err
+	}
 
 	irregularIndexes := getIrregularIndexes(tableDef)
 

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -123,6 +123,9 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		}
 
 		tableDef := dmlCtx.tableDefs[i]
+		if err := validateTableRegularIndexPrefixMetadata(tableDef); err != nil {
+			return 0, err
+		}
 		colOffsets[i] = int32(len(selectList))
 		useColInPartExpr := make(map[string]bool)
 

--- a/pkg/sql/plan/build_alter_change_column.go
+++ b/pkg/sql/plan/build_alter_change_column.go
@@ -345,7 +345,7 @@ func checkIndexedColumnTypeChange(ctx context.Context, tableDef *plan.TableDef, 
 
 // Check if the column name is valid and conflicts with internal hidden columns
 func checkColumnNameValid(ctx context.Context, colName string) error {
-	if _, ok := catalog.InternalColumns[colName]; ok {
+	if _, ok := catalog.InternalColumns[colName]; ok || catalog.IsAlias(colName) {
 		return moerr.NewErrWrongColumnName(ctx, colName)
 	}
 	return nil

--- a/pkg/sql/plan/build_alter_change_column.go
+++ b/pkg/sql/plan/build_alter_change_column.go
@@ -271,6 +271,9 @@ func buildColumnAndConstraint(
 			for j, partCol := range indexInfo.Parts {
 				partCol = catalog.ResolveAlias(partCol)
 				if partCol == oldCol.Name {
+					if _, err := renameIndexPrefixLengthMetadata(indexInfo, oldCol.Name, newColName); err != nil {
+						return nil, err
+					}
 					indexInfo.Parts[j] = newColName
 				}
 			}

--- a/pkg/sql/plan/build_alter_change_column.go
+++ b/pkg/sql/plan/build_alter_change_column.go
@@ -267,6 +267,11 @@ func buildColumnAndConstraint(
 	// If the column name of the table changes, it is necessary to check if it is associated
 	// with the index key. If it is an index key column, column name replacement is required.
 	if newColName != oldCol.Name {
+		if err := requirePrefixIndexesRenameProtocol(
+			ctx, targetTableDef.Indexes, oldCol.Name, newColName,
+		); err != nil {
+			return nil, err
+		}
 		for _, indexInfo := range targetTableDef.Indexes {
 			for j, partCol := range indexInfo.Parts {
 				partCol = catalog.ResolveAlias(partCol)

--- a/pkg/sql/plan/build_alter_rename_column.go
+++ b/pkg/sql/plan/build_alter_rename_column.go
@@ -17,6 +17,7 @@ package plan
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -109,8 +110,22 @@ func updateRenameColumnInTableDef(
 		for j, partCol := range indexInfo.Parts {
 			partCol = catalog.ResolveAlias(partCol)
 			if partCol == oldColName {
+				prefixMetadataAffected, err := renameIndexPrefixLengthMetadata(
+					indexInfo, oldColName, newColName,
+				)
+				if err != nil {
+					return nil, err
+				}
 				indexInfo.Parts[j] = newColName
 				indexAffected = true
+				if prefixMetadataAffected {
+					sqls = append(sqls, fmt.Sprintf(
+						"update `mo_catalog`.`mo_indexes` set algo_params = '%s' where table_id = %d and name = '%s' ; ",
+						sqlquote.EscapeString(indexInfo.IndexAlgoParams),
+						tableDef.TblId,
+						sqlquote.EscapeString(indexInfo.IndexName),
+					))
+				}
 				break
 			}
 		}
@@ -172,6 +187,63 @@ func updateRenameColumnInTableDef(
 	}
 
 	return
+}
+
+// renameIndexPrefixLengthMetadata rewrites the column-name keys in regular
+// index prefix metadata. Prefix lengths describe the physical hidden-index key,
+// so leaving an old logical column name behind causes later DML and reads to
+// disagree about whether the key is truncated.
+func renameIndexPrefixLengthMetadata(indexInfo *plan.IndexDef, oldColName, newColName string) (bool, error) {
+	if !catalog.IsRegularIndexAlgo(indexInfo.IndexAlgo) || indexInfo.IndexAlgoParams == "" {
+		return false, nil
+	}
+
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(indexInfo.IndexAlgoParams)
+	if err != nil {
+		return false, err
+	}
+
+	oldPrefixName := oldColName
+	length, ok := prefixLengths[oldPrefixName]
+	if !ok {
+		for partName, partLength := range prefixLengths {
+			if strings.EqualFold(partName, oldColName) {
+				oldPrefixName = partName
+				length = partLength
+				ok = true
+				break
+			}
+		}
+	}
+	if !ok {
+		return false, nil
+	}
+
+	params, err := catalog.IndexParamsStringToMap(indexInfo.IndexAlgoParams)
+	if err != nil {
+		return false, err
+	}
+	sessionVars, err := catalog.IndexParamsSessionVars(indexInfo.IndexAlgoParams)
+	if err != nil {
+		return false, err
+	}
+	delete(prefixLengths, oldPrefixName)
+	prefixLengths[newColName] = length
+	parts := make([]string, 0, len(prefixLengths))
+	for partName := range prefixLengths {
+		parts = append(parts, partName)
+	}
+	sort.Strings(parts)
+	encoded := make([]string, 0, len(parts))
+	for _, partName := range parts {
+		encoded = append(encoded, fmt.Sprintf("%s:%d", partName, prefixLengths[partName]))
+	}
+	params[catalog.IndexAlgoParamPrefixLengths] = strings.Join(encoded, ",")
+	indexInfo.IndexAlgoParams, err = catalog.IndexParamsMapToJsonStringWithSessionVars(params, sessionVars)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func addRenameContextToAlterCtx(

--- a/pkg/sql/plan/build_alter_rename_column.go
+++ b/pkg/sql/plan/build_alter_rename_column.go
@@ -102,6 +102,11 @@ func updateRenameColumnInTableDef(
 		!strings.EqualFold(newColName, oldColName) {
 		return nil, moerr.NewErrDupFieldName(ctx.GetContext(), newColNameOrigin)
 	}
+	if err := requirePrefixIndexesRenameProtocol(
+		ctx, tableDef.Indexes, oldColName, newColName,
+	); err != nil {
+		return nil, err
+	}
 
 	// update index key
 	indexAffected := false
@@ -186,6 +191,40 @@ func updateRenameColumnInTableDef(
 	}
 
 	return
+}
+
+func requirePrefixIndexesRenameProtocol(ctx CompilerContext, indexes []*plan.IndexDef, oldColName, newColName string) error {
+	for _, indexInfo := range indexes {
+		if indexInfo == nil {
+			continue
+		}
+		for _, partCol := range indexInfo.Parts {
+			if catalog.ResolveAlias(partCol) != oldColName {
+				continue
+			}
+			if err := requirePrefixIndexRenameProtocol(ctx, indexInfo, oldColName, newColName); err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func requirePrefixIndexRenameProtocol(ctx CompilerContext, indexInfo *plan.IndexDef, oldColName, newColName string) error {
+	if !catalog.IsRegularIndexAlgo(indexInfo.IndexAlgo) || indexInfo.IndexAlgoParams == "" {
+		return nil
+	}
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(indexInfo.IndexAlgoParams)
+	if err != nil {
+		return err
+	}
+	for prefixPart := range prefixLengths {
+		if strings.EqualFold(prefixPart, oldColName) {
+			return requirePrefixIndexV2Protocol(ctx.GetContext(), ctx.GetProcess(), newColName)
+		}
+	}
+	return nil
 }
 
 // renameIndexPrefixLengthMetadata rewrites the column-name keys in regular

--- a/pkg/sql/plan/build_alter_rename_column.go
+++ b/pkg/sql/plan/build_alter_rename_column.go
@@ -17,7 +17,6 @@ package plan
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -229,16 +228,9 @@ func renameIndexPrefixLengthMetadata(indexInfo *plan.IndexDef, oldColName, newCo
 	}
 	delete(prefixLengths, oldPrefixName)
 	prefixLengths[newColName] = length
-	parts := make([]string, 0, len(prefixLengths))
-	for partName := range prefixLengths {
-		parts = append(parts, partName)
+	if err := catalog.SetIndexPrefixLengthsInParamMap(params, prefixLengths); err != nil {
+		return false, err
 	}
-	sort.Strings(parts)
-	encoded := make([]string, 0, len(parts))
-	for _, partName := range parts {
-		encoded = append(encoded, fmt.Sprintf("%s:%d", partName, prefixLengths[partName]))
-	}
-	params[catalog.IndexAlgoParamPrefixLengths] = strings.Join(encoded, ",")
 	indexInfo.IndexAlgoParams, err = catalog.IndexParamsMapToJsonStringWithSessionVars(params, sessionVars)
 	if err != nil {
 		return false, err

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -200,10 +200,10 @@ func requirePrefixIndexV2Protocol(ctx context.Context, proc *process.Process, co
 	value, ok := moruntime.ServiceRuntime(proc.GetService()).
 		GetGlobalVariables(moruntime.MOProtocolVersion)
 	version, valid := value.(int64)
-	if !ok || !valid || version < defines.MORPCVersion12 {
+	if !ok || !valid || version < defines.MORPCVersion13 {
 		return moerr.NewNotSupported(
 			ctx,
-			"prefix indexes on column names containing ':' or ',' require all CNs to support protocol version 12",
+			"prefix indexes on column names containing ':' or ',' require all CNs to support protocol version 13",
 		)
 	}
 	return nil

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -17,6 +17,7 @@ package plan
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -184,6 +185,25 @@ func requireCheckConstraintProtocol(ctx context.Context, proc *process.Process) 
 		return moerr.NewNotSupported(
 			ctx,
 			"CHECK constraints require all CNs to support protocol version 7",
+		)
+	}
+	return nil
+}
+
+// requirePrefixIndexV2Protocol uses the deployment-managed common protocol
+// version. The orchestrator raises it only after every participating CN can
+// decode the lossless prefix_lengths_v2 catalog representation.
+func requirePrefixIndexV2Protocol(ctx context.Context, proc *process.Process, columnName string) error {
+	if !strings.ContainsAny(columnName, ":,") || proc == nil {
+		return nil
+	}
+	value, ok := moruntime.ServiceRuntime(proc.GetService()).
+		GetGlobalVariables(moruntime.MOProtocolVersion)
+	version, valid := value.(int64)
+	if !ok || !valid || version < defines.MORPCVersion12 {
+		return moerr.NewNotSupported(
+			ctx,
+			"prefix indexes on column names containing ':' or ',' require all CNs to support protocol version 12",
 		)
 	}
 	return nil

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -2550,7 +2550,7 @@ func buildUniqueIndexTable(createTable *plan.CreateTable, indexInfos []*tree.Uni
 		} else {
 			indexDef.Comment = ""
 		}
-		indexDef.IndexAlgoParams, err = catalog.AddIndexPrefixLengthsToParams(indexDef.IndexAlgoParams, indexInfo.KeyParts)
+		indexDef.IndexAlgoParams, err = addIndexPrefixLengthsToParams(ctx, indexDef.IndexAlgoParams, indexInfo.KeyParts)
 		if err != nil {
 			return err
 		}
@@ -2576,6 +2576,20 @@ func buildIndexAlgoParams(indexInfo *tree.Index) (string, error) {
 		return catalog.IndexParamsMapToJsonString(res)
 	}
 	return catalog.IndexParamsToJsonString(indexInfo)
+}
+
+func addIndexPrefixLengthsToParams(ctx CompilerContext, indexParams string, keyParts []*tree.KeyPart) (string, error) {
+	for _, keyPart := range keyParts {
+		if keyPart == nil || keyPart.ColName == nil || keyPart.Length <= 0 {
+			continue
+		}
+		if err := requirePrefixIndexV2Protocol(
+			ctx.GetContext(), ctx.GetProcess(), keyPart.ColName.ColName(),
+		); err != nil {
+			return "", err
+		}
+	}
+	return catalog.AddIndexPrefixLengthsToParams(indexParams, keyParts)
 }
 
 func buildSecondaryIndexDef(createTable *plan.CreateTable, indexInfos []*tree.Index, colMap map[string]*ColDef, existedIndexes []*plan.IndexDef, pkeyName string, ctx CompilerContext) (err error) {
@@ -2762,7 +2776,7 @@ func buildMasterSecondaryIndexDef(ctx CompilerContext, indexInfo *tree.Index, co
 		indexDef.Comment = ""
 		indexDef.IndexAlgoParams = ""
 	}
-	indexDef.IndexAlgoParams, err = catalog.AddIndexPrefixLengthsToParams(indexDef.IndexAlgoParams, indexInfo.KeyParts)
+	indexDef.IndexAlgoParams, err = addIndexPrefixLengthsToParams(ctx, indexDef.IndexAlgoParams, indexInfo.KeyParts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2951,7 +2965,7 @@ func buildRegularSecondaryIndexDef(ctx CompilerContext, indexInfo *tree.Index, c
 		indexDef.Comment = ""
 		indexDef.IndexAlgoParams = ""
 	}
-	indexDef.IndexAlgoParams, err = catalog.AddIndexPrefixLengthsToParams(indexDef.IndexAlgoParams, indexInfo.KeyParts)
+	indexDef.IndexAlgoParams, err = addIndexPrefixLengthsToParams(ctx, indexDef.IndexAlgoParams, indexInfo.KeyParts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1761,6 +1761,17 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 	if stmt.IsAsSelect {
 		// add as select cols
 		for _, col := range asSelectCols {
+			if !checkTableColumnNameValid(col.Name) {
+				colName := col.OriginName
+				if colName == "" {
+					colName = col.Name
+				}
+				return moerr.NewInvalidInputf(
+					ctx.GetContext(),
+					"table column name '%s' is illegal and conflicts with internal keyword",
+					colName,
+				)
+			}
 			colMap[col.Name] = col
 			createTable.TableDef.Cols = append(createTable.TableDef.Cols, col)
 		}

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -2219,6 +2219,35 @@ func TestBuildRegularSecondaryIndexPersistsPrefixLengths(t *testing.T) {
 	}
 }
 
+func TestBuildPrefixIndexV2ProtocolGate(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	proc := mock.CurrentContext().GetProcess()
+	rt := moruntime.ServiceRuntime(proc.GetService())
+	original, hadOriginal := rt.GetGlobalVariables(moruntime.MOProtocolVersion)
+	defer func() {
+		if hadOriginal {
+			rt.SetGlobalVariables(moruntime.MOProtocolVersion, original)
+		} else {
+			rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
+		}
+	}()
+
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion11)
+	_, err := runOneStmt(mock, t,
+		"CREATE TABLE prefix_v1_ok (id INT PRIMARY KEY, name VARCHAR(32), INDEX idx_name(name(4)))")
+	require.NoError(t, err)
+	_, err = runOneStmt(mock, t,
+		"CREATE TABLE prefix_v2_blocked (id INT PRIMARY KEY, `head:line` VARCHAR(32), INDEX idx_name(`head:line`(4)))")
+	require.ErrorContains(t, err, "protocol version 12")
+
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion12)
+	logicPlan, err := runOneStmt(mock, t,
+		"CREATE TABLE prefix_v2_ok (id INT PRIMARY KEY, `head:line` VARCHAR(32), INDEX idx_name(`head:line`(4)))")
+	require.NoError(t, err)
+	indexDef := logicPlan.GetDdl().GetCreateTable().GetTableDef().GetIndexes()[0]
+	require.Equal(t, map[string]int{"head:line": 4}, catalog.IndexPrefixLengthsFromParams(indexDef.IndexAlgoParams))
+}
+
 func TestBuildVectorIndexAllowsIvfFlatOnly(t *testing.T) {
 	mock := NewMockOptimizer(false)
 	sqls := []string{

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -2232,15 +2232,15 @@ func TestBuildPrefixIndexV2ProtocolGate(t *testing.T) {
 		}
 	}()
 
-	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion11)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion12)
 	_, err := runOneStmt(mock, t,
 		"CREATE TABLE prefix_v1_ok (id INT PRIMARY KEY, name VARCHAR(32), INDEX idx_name(name(4)))")
 	require.NoError(t, err)
 	_, err = runOneStmt(mock, t,
 		"CREATE TABLE prefix_v2_blocked (id INT PRIMARY KEY, `head:line` VARCHAR(32), INDEX idx_name(`head:line`(4)))")
-	require.ErrorContains(t, err, "protocol version 12")
+	require.ErrorContains(t, err, "protocol version 13")
 
-	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion12)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion13)
 	logicPlan, err := runOneStmt(mock, t,
 		"CREATE TABLE prefix_v2_ok (id INT PRIMARY KEY, `head:line` VARCHAR(32), INDEX idx_name(`head:line`(4)))")
 	require.NoError(t, err)

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3360,6 +3360,11 @@ func appendPreInsertPlan(
 
 	var useColumns []int32
 	idxDef := tableDef.Indexes[indexIdx]
+	if catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) {
+		if err := validateRegularIndexPrefixMetadata(idxDef); err != nil {
+			return 0, err
+		}
+	}
 	colsMap := make(map[string]int)
 	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
 	if err != nil {

--- a/pkg/sql/plan/build_util.go
+++ b/pkg/sql/plan/build_util.go
@@ -966,7 +966,8 @@ func getTablePriKeyName(priKeyDef *plan.PrimaryKeyDef) string {
 func checkTableColumnNameValid(name string) bool {
 	if name == catalog.Row_ID || name == catalog.CPrimaryKeyColName ||
 		name == catalog.TableTailAttrDeleteRowID || name == catalog.TableTailAttrAborted ||
-		name == catalog.TableTailAttrPKVal || name == catalog.TableTailAttrCommitTs {
+		name == catalog.TableTailAttrPKVal || name == catalog.TableTailAttrCommitTs ||
+		catalog.IsAlias(name) {
 		return false
 	}
 	return true

--- a/pkg/sql/plan/coverage_regression_test.go
+++ b/pkg/sql/plan/coverage_regression_test.go
@@ -175,6 +175,43 @@ func TestChangeColumnRenamesClusterByAndTracksIvfIncludeMetadata(t *testing.T) {
 	require.NotContains(t, copyTable.Indexes[0].IndexAlgoParams, "include_columns")
 }
 
+func TestChangeColumnRenamesPrefixLengthMetadata(t *testing.T) {
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "title:4",
+	})
+	require.NoError(t, err)
+
+	mock := NewMockOptimizer(false)
+	origin := makeAlterCoverageTableDef()
+	origin.Indexes = append(origin.Indexes, &planpb.IndexDef{
+		IndexName:       "uq_title",
+		IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+		IndexAlgoParams: prefixParams,
+		Parts:           []string{"title"},
+		Unique:          true,
+	})
+	copyTable := DeepCopyTableDef(origin, true)
+	alterCtx := initAlterTableContext(origin, copyTable, origin.DbName)
+	alterPlan := &planpb.AlterTable{
+		Database:     origin.DbName,
+		TableDef:     origin,
+		CopyTableDef: copyTable,
+	}
+	spec := mustParseAlterTableChangeColumnClause(
+		t,
+		mock.CurrentContext(),
+		"alter table t1 change column title headline varchar(64)",
+	)
+
+	_, err = ChangeColumn(mock.CurrentContext(), alterPlan, spec, alterCtx)
+	require.NoError(t, err)
+	idxDef := copyTable.Indexes[len(copyTable.Indexes)-1]
+	require.Equal(t, []string{"headline"}, idxDef.Parts)
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	require.NoError(t, err)
+	require.Equal(t, map[string]int{"headline": 4}, prefixLengths)
+}
+
 func TestAppendAffectedAlterColumnNamesKeepsOldNameForChangeColumn(t *testing.T) {
 	affectedCols := appendAffectedAlterColumnNames(nil, "title", "headline")
 	require.Equal(t, []string{"title", "headline"}, affectedCols)

--- a/pkg/sql/plan/coverage_regression_test.go
+++ b/pkg/sql/plan/coverage_regression_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
@@ -513,6 +515,74 @@ func TestRenameIndexPrefixLengthMetadataBoundaryCases(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, []string{"title"}, tableDef.Indexes[0].Parts)
 	})
+}
+
+func TestRenamePrefixIndexV2ProtocolGate(t *testing.T) {
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "title:4",
+	})
+	require.NoError(t, err)
+	tableDef := &planpb.TableDef{
+		TblId: 1,
+		Cols: []*ColDef{
+			{Name: "id", OriginName: "id"},
+			{Name: "title", OriginName: "title"},
+		},
+		Pkey: &PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+		Indexes: []*planpb.IndexDef{
+			{
+				IndexName: "idx_title_full",
+				IndexAlgo: catalog.MoIndexDefaultAlgo.ToString(),
+				Parts:     []string{"title", catalog.CreateAlias("id")},
+			},
+			{
+				IndexName:       "idx_title",
+				IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+				IndexAlgoParams: prefixParams,
+				Parts:           []string{"title", catalog.CreateAlias("id")},
+			},
+		},
+	}
+	mock := NewMockOptimizer(false)
+	proc := mock.CurrentContext().GetProcess()
+	rt := moruntime.ServiceRuntime(proc.GetService())
+	original, hadOriginal := rt.GetGlobalVariables(moruntime.MOProtocolVersion)
+	defer func() {
+		if hadOriginal {
+			rt.SetGlobalVariables(moruntime.MOProtocolVersion, original)
+		} else {
+			rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
+		}
+	}()
+
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion11)
+	_, err = updateRenameColumnInTableDef(
+		mock.CurrentContext(),
+		tableDef.Cols[1],
+		tableDef,
+		&tree.AlterTableRenameColumnClause{
+			OldColumnName: tree.NewUnresolvedColName("title"),
+			NewColumnName: tree.NewUnresolvedColName("head:line"),
+		},
+	)
+	require.ErrorContains(t, err, "protocol version 12")
+	require.Equal(t, []string{"title", catalog.CreateAlias("id")}, tableDef.Indexes[0].Parts)
+	require.Equal(t, []string{"title", catalog.CreateAlias("id")}, tableDef.Indexes[1].Parts)
+	require.Equal(t, prefixParams, tableDef.Indexes[1].IndexAlgoParams)
+
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion12)
+	_, err = updateRenameColumnInTableDef(
+		mock.CurrentContext(),
+		tableDef.Cols[1],
+		tableDef,
+		&tree.AlterTableRenameColumnClause{
+			OldColumnName: tree.NewUnresolvedColName("title"),
+			NewColumnName: tree.NewUnresolvedColName("head:line"),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "head:line", tableDef.Indexes[0].Parts[0])
+	require.Equal(t, "head:line", tableDef.Indexes[1].Parts[0])
 }
 
 func TestUpdateRenameColumnInTableDefRejectsDuplicateTargetName(t *testing.T) {

--- a/pkg/sql/plan/coverage_regression_test.go
+++ b/pkg/sql/plan/coverage_regression_test.go
@@ -212,6 +212,46 @@ func TestChangeColumnRenamesPrefixLengthMetadata(t *testing.T) {
 	require.Equal(t, map[string]int{"headline": 4}, prefixLengths)
 }
 
+func TestChangeColumnEncodesDelimiterBearingPrefixLengthMetadata(t *testing.T) {
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "title:4",
+	})
+	require.NoError(t, err)
+
+	mock := NewMockOptimizer(false)
+	origin := makeAlterCoverageTableDef()
+	origin.Indexes = append(origin.Indexes, &planpb.IndexDef{
+		IndexName:       "uq_title",
+		IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+		IndexAlgoParams: prefixParams,
+		Parts:           []string{"title"},
+		Unique:          true,
+	})
+	copyTable := DeepCopyTableDef(origin, true)
+	alterCtx := initAlterTableContext(origin, copyTable, origin.DbName)
+	alterPlan := &planpb.AlterTable{
+		Database:     origin.DbName,
+		TableDef:     origin,
+		CopyTableDef: copyTable,
+	}
+	spec := mustParseAlterTableChangeColumnClause(
+		t,
+		mock.CurrentContext(),
+		"alter table t1 change column title `head:line` varchar(64)",
+	)
+
+	_, err = ChangeColumn(mock.CurrentContext(), alterPlan, spec, alterCtx)
+	require.NoError(t, err)
+	idxDef := copyTable.Indexes[len(copyTable.Indexes)-1]
+	require.Equal(t, []string{"head:line"}, idxDef.Parts)
+	require.Equal(t, map[string]int{"head:line": 4}, catalog.IndexPrefixLengthsFromParams(idxDef.IndexAlgoParams))
+
+	params, err := catalog.IndexParamsStringToMap(idxDef.IndexAlgoParams)
+	require.NoError(t, err)
+	require.NotContains(t, params, catalog.IndexAlgoParamPrefixLengths)
+	require.JSONEq(t, `{"head:line":4}`, params[catalog.IndexAlgoParamPrefixLengthsV2])
+}
+
 func TestAppendAffectedAlterColumnNamesKeepsOldNameForChangeColumn(t *testing.T) {
 	affectedCols := appendAffectedAlterColumnNames(nil, "title", "headline")
 	require.Equal(t, []string{"title", "headline"}, affectedCols)
@@ -357,6 +397,47 @@ func TestUpdateRenameColumnInTableDefRenamesPrefixLengthMetadata(t *testing.T) {
 	require.Contains(t, allSQL, "set algo_params = '{\"prefix_lengths\":\"headline:4\"}' where table_id = 42 and name = 'uq_title'")
 	require.Contains(t, allSQL, "set algo_params = '{\"comment\":\"keep\",\"prefix_lengths\":\"headline:4,note:2\"}' where table_id = 42 and name = 'idx_title_note'")
 	require.NotContains(t, allSQL, "name = 'idx_note'")
+}
+
+func TestUpdateRenameColumnInTableDefEncodesDelimiterBearingPrefixName(t *testing.T) {
+	prefixParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "title:4",
+	})
+	require.NoError(t, err)
+
+	mock := NewMockOptimizer(false)
+	tableDef := &planpb.TableDef{
+		TblId: 7,
+		Cols: []*ColDef{
+			{Name: "id", OriginName: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "title", OriginName: "title", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 32}},
+		},
+		Pkey: &PrimaryKeyDef{Names: []string{"id"}, PkeyColName: "id"},
+		Indexes: []*planpb.IndexDef{{
+			IndexName:       "idx_title",
+			IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+			IndexAlgoParams: prefixParams,
+			Parts:           []string{"title"},
+		}},
+	}
+
+	_, err = updateRenameColumnInTableDef(
+		mock.CurrentContext(),
+		tableDef.Cols[1],
+		tableDef,
+		&tree.AlterTableRenameColumnClause{
+			OldColumnName: tree.NewUnresolvedColName("title"),
+			NewColumnName: tree.NewUnresolvedColName("head:line"),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"head:line"}, tableDef.Indexes[0].Parts)
+	require.Equal(t, map[string]int{"head:line": 4}, catalog.IndexPrefixLengthsFromParams(tableDef.Indexes[0].IndexAlgoParams))
+
+	params, err := catalog.IndexParamsStringToMap(tableDef.Indexes[0].IndexAlgoParams)
+	require.NoError(t, err)
+	require.NotContains(t, params, catalog.IndexAlgoParamPrefixLengths)
+	require.JSONEq(t, `{"head:line":4}`, params[catalog.IndexAlgoParamPrefixLengthsV2])
 }
 
 func TestUpdateRenameColumnInTableDefRejectsDuplicateTargetName(t *testing.T) {

--- a/pkg/sql/plan/coverage_regression_test.go
+++ b/pkg/sql/plan/coverage_regression_test.go
@@ -252,6 +252,16 @@ func TestChangeColumnEncodesDelimiterBearingPrefixLengthMetadata(t *testing.T) {
 	require.JSONEq(t, `{"head:line":4}`, params[catalog.IndexAlgoParamPrefixLengthsV2])
 }
 
+func TestInternalAliasPrefixIsRejectedForUserColumns(t *testing.T) {
+	aliasName := catalog.CreateAlias("payload")
+	require.False(t, checkTableColumnNameValid(aliasName))
+	require.True(t, checkTableColumnNameValid("payload"))
+
+	mock := NewMockOptimizer(false)
+	require.Error(t, checkColumnNameValid(mock.CurrentContext().GetContext(), aliasName))
+	require.NoError(t, checkColumnNameValid(mock.CurrentContext().GetContext(), "payload"))
+}
+
 func TestAppendAffectedAlterColumnNamesKeepsOldNameForChangeColumn(t *testing.T) {
 	affectedCols := appendAffectedAlterColumnNames(nil, "title", "headline")
 	require.Equal(t, []string{"title", "headline"}, affectedCols)

--- a/pkg/sql/plan/coverage_regression_test.go
+++ b/pkg/sql/plan/coverage_regression_test.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -448,6 +449,70 @@ func TestUpdateRenameColumnInTableDefEncodesDelimiterBearingPrefixName(t *testin
 	require.NoError(t, err)
 	require.NotContains(t, params, catalog.IndexAlgoParamPrefixLengths)
 	require.JSONEq(t, `{"head:line":4}`, params[catalog.IndexAlgoParamPrefixLengthsV2])
+}
+
+func TestRenameIndexPrefixLengthMetadataBoundaryCases(t *testing.T) {
+	t.Run("case-insensitive legacy key keeps nested session vars", func(t *testing.T) {
+		params, err := catalog.IndexParamsMapToJsonStringWithSessionVars(
+			map[string]string{catalog.IndexAlgoParamPrefixLengths: "Title:4"},
+			json.RawMessage(`{"cfg":{}}`),
+		)
+		require.NoError(t, err)
+		indexDef := &planpb.IndexDef{
+			IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+			IndexAlgoParams: params,
+		}
+
+		affected, err := renameIndexPrefixLengthMetadata(indexDef, "title", "headline")
+		require.NoError(t, err)
+		require.True(t, affected)
+		require.Equal(t, map[string]int{"headline": 4}, catalog.IndexPrefixLengthsFromParams(indexDef.IndexAlgoParams))
+		sessionVars, err := catalog.IndexParamsSessionVars(indexDef.IndexAlgoParams)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"cfg":{}}`, string(sessionVars))
+	})
+
+	t.Run("unprefixed renamed part does not rewrite params", func(t *testing.T) {
+		params, err := catalog.IndexParamsMapToJsonString(map[string]string{
+			catalog.IndexAlgoParamPrefixLengths: "note:2",
+		})
+		require.NoError(t, err)
+		indexDef := &planpb.IndexDef{
+			IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+			IndexAlgoParams: params,
+		}
+
+		affected, err := renameIndexPrefixLengthMetadata(indexDef, "title", "headline")
+		require.NoError(t, err)
+		require.False(t, affected)
+		require.Equal(t, params, indexDef.IndexAlgoParams)
+	})
+
+	t.Run("invalid persisted metadata aborts rename before mutation", func(t *testing.T) {
+		tableDef := &planpb.TableDef{
+			Cols: []*ColDef{{Name: "title", OriginName: "title"}},
+			Pkey: &PrimaryKeyDef{},
+			Indexes: []*planpb.IndexDef{{
+				IndexName:       "idx_title",
+				IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+				IndexAlgoParams: `{"prefix_lengths":"title:0"}`,
+				Parts:           []string{"title"},
+			}},
+		}
+		mock := NewMockOptimizer(false)
+
+		_, err := updateRenameColumnInTableDef(
+			mock.CurrentContext(),
+			tableDef.Cols[0],
+			tableDef,
+			&tree.AlterTableRenameColumnClause{
+				OldColumnName: tree.NewUnresolvedColName("title"),
+				NewColumnName: tree.NewUnresolvedColName("headline"),
+			},
+		)
+		require.Error(t, err)
+		require.Equal(t, []string{"title"}, tableDef.Indexes[0].Parts)
+	})
 }
 
 func TestUpdateRenameColumnInTableDefRejectsDuplicateTargetName(t *testing.T) {

--- a/pkg/sql/plan/coverage_regression_test.go
+++ b/pkg/sql/plan/coverage_regression_test.go
@@ -555,7 +555,7 @@ func TestRenamePrefixIndexV2ProtocolGate(t *testing.T) {
 		}
 	}()
 
-	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion11)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion12)
 	_, err = updateRenameColumnInTableDef(
 		mock.CurrentContext(),
 		tableDef.Cols[1],
@@ -565,12 +565,12 @@ func TestRenamePrefixIndexV2ProtocolGate(t *testing.T) {
 			NewColumnName: tree.NewUnresolvedColName("head:line"),
 		},
 	)
-	require.ErrorContains(t, err, "protocol version 12")
+	require.ErrorContains(t, err, "protocol version 13")
 	require.Equal(t, []string{"title", catalog.CreateAlias("id")}, tableDef.Indexes[0].Parts)
 	require.Equal(t, []string{"title", catalog.CreateAlias("id")}, tableDef.Indexes[1].Parts)
 	require.Equal(t, prefixParams, tableDef.Indexes[1].IndexAlgoParams)
 
-	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion12)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion13)
 	_, err = updateRenameColumnInTableDef(
 		mock.CurrentContext(),
 		tableDef.Cols[1],

--- a/pkg/sql/plan/coverage_regression_test.go
+++ b/pkg/sql/plan/coverage_regression_test.go
@@ -247,6 +247,81 @@ func TestUpdateRenameColumnInTableDefEscapesMoIndexesColumnNameUpdate(t *testing
 	require.Contains(t, sqls[0], "column_name = 'ti''tle'")
 }
 
+func TestUpdateRenameColumnInTableDefRenamesPrefixLengthMetadata(t *testing.T) {
+	singleParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		catalog.IndexAlgoParamPrefixLengths: "title:4",
+	})
+	require.NoError(t, err)
+	compositeParams, err := catalog.IndexParamsMapToJsonString(map[string]string{
+		"comment":                           "keep",
+		catalog.IndexAlgoParamPrefixLengths: "note:2,title:4",
+	})
+	require.NoError(t, err)
+
+	mock := NewMockOptimizer(false)
+	tableDef := &planpb.TableDef{
+		TblId: 42,
+		Cols: []*ColDef{
+			{Name: "id", OriginName: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "title", OriginName: "title", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 32}},
+			{Name: "note", OriginName: "note", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 32}},
+		},
+		Pkey: &PrimaryKeyDef{Names: []string{"id"}, PkeyColName: "id"},
+		Indexes: []*planpb.IndexDef{
+			{
+				IndexName:       "uq_title",
+				IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+				IndexAlgoParams: singleParams,
+				Parts:           []string{"title"},
+				Unique:          true,
+			},
+			{
+				IndexName:       "idx_title_note",
+				IndexAlgo:       catalog.MoIndexDefaultAlgo.ToString(),
+				IndexAlgoParams: compositeParams,
+				Parts:           []string{"title", "note", "id"},
+			},
+			{
+				IndexName: "idx_note",
+				IndexAlgo: catalog.MoIndexDefaultAlgo.ToString(),
+				Parts:     []string{"note", "id"},
+			},
+		},
+	}
+
+	sqls, err := updateRenameColumnInTableDef(
+		mock.CurrentContext(),
+		tableDef.Cols[1],
+		tableDef,
+		&tree.AlterTableRenameColumnClause{
+			OldColumnName: tree.NewUnresolvedColName("title"),
+			NewColumnName: tree.NewUnresolvedColName("headline"),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "headline", tableDef.Cols[1].Name)
+	require.Equal(t, []string{"headline"}, tableDef.Indexes[0].Parts)
+	require.Equal(t, []string{"headline", "note", "id"}, tableDef.Indexes[1].Parts)
+
+	singlePrefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(tableDef.Indexes[0].IndexAlgoParams)
+	require.NoError(t, err)
+	require.Equal(t, map[string]int{"headline": 4}, singlePrefixLengths)
+	compositePrefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(tableDef.Indexes[1].IndexAlgoParams)
+	require.NoError(t, err)
+	require.Equal(t, map[string]int{"headline": 4, "note": 2}, compositePrefixLengths)
+	compositeMetadata, err := catalog.IndexParamsStringToMap(tableDef.Indexes[1].IndexAlgoParams)
+	require.NoError(t, err)
+	require.Equal(t, "keep", compositeMetadata["comment"])
+	require.Equal(t, "headline:4,note:2", compositeMetadata[catalog.IndexAlgoParamPrefixLengths])
+
+	allSQL := strings.Join(sqls, "\n")
+	require.Len(t, sqls, 3)
+	require.Contains(t, allSQL, "set column_name = 'headline'")
+	require.Contains(t, allSQL, "set algo_params = '{\"prefix_lengths\":\"headline:4\"}' where table_id = 42 and name = 'uq_title'")
+	require.Contains(t, allSQL, "set algo_params = '{\"comment\":\"keep\",\"prefix_lengths\":\"headline:4,note:2\"}' where table_id = 42 and name = 'idx_title_note'")
+	require.NotContains(t, allSQL, "name = 'idx_note'")
+}
+
 func TestUpdateRenameColumnInTableDefRejectsDuplicateTargetName(t *testing.T) {
 	mock := NewMockOptimizer(false)
 	tableDef := makeAlterCoverageTableDef()

--- a/pkg/sql/plan/index_table_dml_test.go
+++ b/pkg/sql/plan/index_table_dml_test.go
@@ -59,6 +59,37 @@ func TestSingleSQLQuery(t *testing.T) {
 	outPutPlan(logicPlan, false, t)
 }
 
+func TestRegularIndexDMLRejectsStalePrefixMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "insert", sql: "insert into constraint_test.dept values (1, 'SALES', 'NY')"},
+		{name: "update", sql: "update constraint_test.dept set dname = 'SALES' where deptno = 1"},
+		{name: "delete", sql: "delete from constraint_test.dept where deptno = 1"},
+		{name: "replace", sql: "replace into constraint_test.dept values (1, 'SALES', 'NY')"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+"/valid", func(t *testing.T) {
+			_, err := runOneStmt(NewMockOptimizer(true), t, test.sql)
+			require.NoError(t, err)
+		})
+
+		t.Run(test.name+"/stale", func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			tableDef := mock.ctxt.tables["dept"]
+			require.NotNil(t, tableDef)
+			require.NotEmpty(t, tableDef.Indexes)
+			tableDef.Indexes[0].IndexName = "idx_dname"
+			tableDef.Indexes[0].IndexAlgoParams = `{"prefix_lengths":"old_dname:4"}`
+
+			_, err := runOneStmt(mock, t, test.sql)
+			require.ErrorContains(t, err, "invalid prefix metadata for index \"idx_dname\"")
+		})
+	}
+}
+
 // Single column unique index
 func TestSingleTableDeleteSQL(t *testing.T) {
 	mock := NewMockOptimizer(true)

--- a/test/distributed/cases/ddl/internal_alias_column.result
+++ b/test/distributed/cases/ddl/internal_alias_column.result
@@ -1,0 +1,38 @@
+drop database if exists internal_alias_column;
+create database internal_alias_column;
+use internal_alias_column;
+create table create_reject (
+id int primary key,
+`__mo_alias_payload` varchar(32),
+key idx_alias(`__mo_alias_payload`(2))
+);
+invalid input: table column name '__mo_alias_payload' is illegal and conflicts with internal keyword
+create table ctas_reject as
+select 1 as id, 'alpha-one' as `__mo_alias_payload`;
+invalid input: table column name '__mo_alias_payload' is illegal and conflicts with internal keyword
+create table ctas_ok as
+select 1 as id, 'alpha-one' as payload;
+show create table ctas_ok;
+➤ Table[12,7,0]  ¦  Create Table[12,82,0]  𝄀
+ctas_ok  ¦  CREATE TABLE `ctas_ok` (
+  `id` bigint NOT NULL,
+  `payload` varchar(9) NOT NULL
+)
+create table alter_reject (
+id int primary key,
+payload varchar(32)
+);
+alter table alter_reject rename column payload to `__mo_alias_payload`;
+Incorrect column name '__mo_alias_payload'
+alter table alter_reject change column payload `__mo_alias_payload` varchar(32);
+Incorrect column name '__mo_alias_payload'
+alter table alter_reject add column `__mo_alias_payload` varchar(32);
+Incorrect column name '__mo_alias_payload'
+show create table alter_reject;
+➤ Table[12,12,0]  ¦  Create Table[12,111,0]  𝄀
+alter_reject  ¦  CREATE TABLE `alter_reject` (
+  `id` int NOT NULL,
+  `payload` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+)
+drop database internal_alias_column;

--- a/test/distributed/cases/ddl/internal_alias_column.sql
+++ b/test/distributed/cases/ddl/internal_alias_column.sql
@@ -1,0 +1,35 @@
+drop database if exists internal_alias_column;
+create database internal_alias_column;
+use internal_alias_column;
+
+-- __mo_alias_ is the internal suffix namespace used for regular-index primary
+-- key storage. User columns must not be allowed to collide with it.
+-- @pattern
+create table create_reject (
+    id int primary key,
+    `__mo_alias_payload` varchar(32),
+    key idx_alias(`__mo_alias_payload`(2))
+);
+
+-- CTAS has a separate column-construction path.
+-- @pattern
+create table ctas_reject as
+select 1 as id, 'alpha-one' as `__mo_alias_payload`;
+
+create table ctas_ok as
+select 1 as id, 'alpha-one' as payload;
+show create table ctas_ok;
+
+create table alter_reject (
+    id int primary key,
+    payload varchar(32)
+);
+-- @pattern
+alter table alter_reject rename column payload to `__mo_alias_payload`;
+-- @pattern
+alter table alter_reject change column payload `__mo_alias_payload` varchar(32);
+-- @pattern
+alter table alter_reject add column `__mo_alias_payload` varchar(32);
+show create table alter_reject;
+
+drop database internal_alias_column;

--- a/test/distributed/cases/ddl/prefix_index_dml.result
+++ b/test/distributed/cases/ddl/prefix_index_dml.result
@@ -23,6 +23,9 @@ select id, a, b from prefix_idx_dml_uk order by id;
 ➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
 2  ¦  abcdef-new  ¦  20  𝄀
 3  ¦  uvwxyz-new  ¦  30
+select a from prefix_idx_dml_uk force index(uq_a) where a = 'abcdef-new';
+➤ a[12,32,0]  𝄀
+abcdef-new
 drop table prefix_idx_dml_uk;
 drop table if exists prefix_idx_dml_create_backfill;
 create table prefix_idx_dml_create_backfill(id int primary key, a varchar(32), b int);
@@ -50,3 +53,63 @@ select count(*) from prefix_idx_dml_alter_add where a = 'lmnopq-long';
 ➤ count(*)[-5,64,0]  𝄀
 0
 drop table prefix_idx_dml_alter_add;
+drop table if exists prefix_idx_covering_scan;
+create table prefix_idx_covering_scan(id int primary key, a varchar(32), b int, index idx_a(a(4)));
+insert into prefix_idx_covering_scan values
+(1, 'abc', 10),
+(2, 'abcd', 20),
+(3, 'abcdx', 30),
+(4, 'abcdy', 40),
+(5, '中中中中甲', 50),
+(6, '中中中中乙', 60);
+select count(*) from prefix_idx_covering_scan force index(idx_a) where a = 'abc';
+➤ count(*)[-5,64,0]  𝄀
+1
+select count(*) from prefix_idx_covering_scan ignore index(idx_a) where a = 'abc';
+➤ count(*)[-5,64,0]  𝄀
+1
+select count(*) from prefix_idx_covering_scan force index(idx_a) where a = 'abcd';
+➤ count(*)[-5,64,0]  𝄀
+1
+select count(*) from prefix_idx_covering_scan ignore index(idx_a) where a = 'abcd';
+➤ count(*)[-5,64,0]  𝄀
+1
+select count(*) from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+➤ count(*)[-5,64,0]  𝄀
+1
+select count(*) from prefix_idx_covering_scan ignore index(idx_a) where a = 'abcdx';
+➤ count(*)[-5,64,0]  𝄀
+1
+select a from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+➤ a[12,32,0]  𝄀
+abcdx
+select a from prefix_idx_covering_scan ignore index(idx_a) where a = 'abcdx';
+➤ a[12,32,0]  𝄀
+abcdx
+select a from prefix_idx_covering_scan force index(idx_a) where a = '中中中中甲';
+➤ a[12,32,0]  𝄀
+中中中中甲
+select a from prefix_idx_covering_scan ignore index(idx_a) where a = '中中中中甲';
+➤ a[12,32,0]  𝄀
+中中中中甲
+select id, a, b from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  b[4,32,0]  𝄀
+3  ¦  abcdx  ¦  30
+select mo_ctl('dn', 'flush', 'prefix_index_dml.prefix_idx_covering_scan');
+➤ mo_ctl(dn, flush, prefix_index_dml.prefix_idx_covering_scan)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select a from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+➤ a[12,32,0]  𝄀
+abcdx
+select a from prefix_idx_covering_scan force index(idx_a) where a = '中中中中甲';
+➤ a[12,32,0]  𝄀
+中中中中甲
+drop table prefix_idx_covering_scan;

--- a/test/distributed/cases/ddl/prefix_index_dml.result
+++ b/test/distributed/cases/ddl/prefix_index_dml.result
@@ -3,7 +3,7 @@ create table prefix_idx_dml_sk(id int primary key, a varchar(32), b int, index i
 insert into prefix_idx_dml_sk values (1, 'abcdef-long', 10);
 update prefix_idx_dml_sk set a = 'uvwxyz-long' where id = 1;
 select id, a, b from prefix_idx_dml_sk where a = 'uvwxyz-long';
-➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  b[4,32,0]  𝄀
 1  ¦  uvwxyz-long  ¦  10
 delete from prefix_idx_dml_sk where id = 1;
 select count(*) from prefix_idx_dml_sk where a = 'uvwxyz-long';
@@ -20,7 +20,7 @@ insert into prefix_idx_dml_uk values (2, 'abcdef-new', 20);
 delete from prefix_idx_dml_uk where id = 1;
 insert into prefix_idx_dml_uk values (3, 'uvwxyz-new', 30);
 select id, a, b from prefix_idx_dml_uk order by id;
-➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  b[4,32,0]  𝄀
 2  ¦  abcdef-new  ¦  20  𝄀
 3  ¦  uvwxyz-new  ¦  30
 select a from prefix_idx_dml_uk force index(uq_a) where a = 'abcdef-new';
@@ -33,7 +33,7 @@ insert into prefix_idx_dml_create_backfill values (1, 'abcdef-long', 10), (2, 'l
 create index idx_a on prefix_idx_dml_create_backfill(a(4));
 update prefix_idx_dml_create_backfill set a = 'uvwxyz-long' where id = 1;
 select id, a, b from prefix_idx_dml_create_backfill where a = 'uvwxyz-long';
-➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  b[4,32,0]  𝄀
 1  ¦  uvwxyz-long  ¦  10
 delete from prefix_idx_dml_create_backfill where id = 2;
 select count(*) from prefix_idx_dml_create_backfill where a = 'lmnopq-long';
@@ -46,7 +46,7 @@ insert into prefix_idx_dml_alter_add values (1, 'abcdef-long', 10), (2, 'lmnopq-
 alter table prefix_idx_dml_alter_add add index idx_a(a(4));
 update prefix_idx_dml_alter_add set a = 'uvwxyz-long' where id = 1;
 select id, a, b from prefix_idx_dml_alter_add where a = 'uvwxyz-long';
-➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  b[4,32,0]  𝄀
 1  ¦  uvwxyz-long  ¦  10
 delete from prefix_idx_dml_alter_add where id = 2;
 select count(*) from prefix_idx_dml_alter_add where a = 'lmnopq-long';

--- a/test/distributed/cases/ddl/prefix_index_dml.sql
+++ b/test/distributed/cases/ddl/prefix_index_dml.sql
@@ -17,6 +17,7 @@ insert into prefix_idx_dml_uk values (2, 'abcdef-new', 20);
 delete from prefix_idx_dml_uk where id = 1;
 insert into prefix_idx_dml_uk values (3, 'uvwxyz-new', 30);
 select id, a, b from prefix_idx_dml_uk order by id;
+select a from prefix_idx_dml_uk force index(uq_a) where a = 'abcdef-new';
 drop table prefix_idx_dml_uk;
 
 drop table if exists prefix_idx_dml_create_backfill;
@@ -38,3 +39,30 @@ select id, a, b from prefix_idx_dml_alter_add where a = 'uvwxyz-long';
 delete from prefix_idx_dml_alter_add where id = 2;
 select count(*) from prefix_idx_dml_alter_add where a = 'lmnopq-long';
 drop table prefix_idx_dml_alter_add;
+
+-- Regression for #26813: a prefix index cannot reconstruct a full value for
+-- an index-only scan. Exercise the prefix boundary and keep a lookup control.
+drop table if exists prefix_idx_covering_scan;
+create table prefix_idx_covering_scan(id int primary key, a varchar(32), b int, index idx_a(a(4)));
+insert into prefix_idx_covering_scan values
+    (1, 'abc', 10),
+    (2, 'abcd', 20),
+    (3, 'abcdx', 30),
+    (4, 'abcdy', 40),
+    (5, '中中中中甲', 50),
+    (6, '中中中中乙', 60);
+select count(*) from prefix_idx_covering_scan force index(idx_a) where a = 'abc';
+select count(*) from prefix_idx_covering_scan ignore index(idx_a) where a = 'abc';
+select count(*) from prefix_idx_covering_scan force index(idx_a) where a = 'abcd';
+select count(*) from prefix_idx_covering_scan ignore index(idx_a) where a = 'abcd';
+select count(*) from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+select count(*) from prefix_idx_covering_scan ignore index(idx_a) where a = 'abcdx';
+select a from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+select a from prefix_idx_covering_scan ignore index(idx_a) where a = 'abcdx';
+select a from prefix_idx_covering_scan force index(idx_a) where a = '中中中中甲';
+select a from prefix_idx_covering_scan ignore index(idx_a) where a = '中中中中甲';
+select id, a, b from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+select mo_ctl('dn', 'flush', 'prefix_index_dml.prefix_idx_covering_scan');
+select a from prefix_idx_covering_scan force index(idx_a) where a = 'abcdx';
+select a from prefix_idx_covering_scan force index(idx_a) where a = '中中中中甲';
+drop table prefix_idx_covering_scan;

--- a/test/distributed/cases/ddl/prefix_index_quoted_identifier.result
+++ b/test/distributed/cases/ddl/prefix_index_quoted_identifier.result
@@ -1,0 +1,133 @@
+drop database if exists prefix_index_quoted_identifier;
+create database prefix_index_quoted_identifier;
+use prefix_index_quoted_identifier;
+create table create_t (
+id int primary key,
+`a:b` varchar(32),
+`c,d` varchar(32),
+payload varchar(32),
+key idx_pair(`a:b`(3), `c,d`(2))
+);
+insert into create_t values
+(1, 'alpha-one', 'xy-one', 'p1'),
+(2, 'bravo-two', 'yz-two', 'p2');
+show create table create_t;
+➤ Table[12,8,0]  ¦  Create Table[12,213,0]  𝄀
+create_t  ¦  CREATE TABLE `create_t` (
+  `id` int NOT NULL,
+  `a:b` varchar(32) DEFAULT NULL,
+  `c,d` varchar(32) DEFAULT NULL,
+  `payload` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_pair` (`a:b`(3),`c,d`(2))
+)
+select algo_params
+from mo_catalog.mo_indexes
+where table_id = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'prefix_index_quoted_identifier' and relname = 'create_t'
+) and name = 'idx_pair' and column_name = 'a:b';
+➤ algo_params[12,2048,0]  𝄀
+{"prefix_lengths_v2":"{\"a:b\":3,\"c,d\":2}"}
+select mo_ctl('dn', 'flush', 'prefix_index_quoted_identifier.create_t');
+➤ mo_ctl(dn, flush, prefix_index_quoted_identifier.create_t)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id, `a:b`, `c,d`, payload
+from create_t force index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+➤ id[4,32,0]  ¦  a:b[12,32,0]  ¦  c,d[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  alpha-one  ¦  xy-one  ¦  p1
+select id, `a:b`, `c,d`, payload
+from create_t ignore index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+➤ id[4,32,0]  ¦  a:b[12,32,0]  ¦  c,d[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  alpha-one  ¦  xy-one  ¦  p1
+create table create_index_t (
+id int primary key,
+`a:b` varchar(32),
+`c,d` varchar(32)
+);
+create index idx_pair on create_index_t(`a:b`(3), `c,d`(2));
+insert into create_index_t values (1, 'alpha-one', 'xy-one');
+show create table create_index_t;
+➤ Table[12,14,0]  ¦  Create Table[12,181,0]  𝄀
+create_index_t  ¦  CREATE TABLE `create_index_t` (
+  `id` int NOT NULL,
+  `a:b` varchar(32) DEFAULT NULL,
+  `c,d` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_pair` (`a:b`(3),`c,d`(2))
+)
+select id, `a:b`, `c,d`
+from create_index_t force index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+➤ id[4,32,0]  ¦  a:b[12,32,0]  ¦  c,d[12,32,0]  𝄀
+1  ¦  alpha-one  ¦  xy-one
+create table alter_add_t (
+id int primary key,
+`a:b` varchar(32),
+`c,d` varchar(32)
+);
+alter table alter_add_t add index idx_pair(`a:b`(3), `c,d`(2));
+insert into alter_add_t values (1, 'alpha-one', 'xy-one');
+show create table alter_add_t;
+➤ Table[12,11,0]  ¦  Create Table[12,178,0]  𝄀
+alter_add_t  ¦  CREATE TABLE `alter_add_t` (
+  `id` int NOT NULL,
+  `a:b` varchar(32) DEFAULT NULL,
+  `c,d` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_pair` (`a:b`(3),`c,d`(2))
+)
+select id, `a:b`, `c,d`
+from alter_add_t force index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+➤ id[4,32,0]  ¦  a:b[12,32,0]  ¦  c,d[12,32,0]  𝄀
+1  ¦  alpha-one  ¦  xy-one
+create table rename_t (
+id int primary key,
+plain varchar(32),
+key idx_plain(plain(3))
+);
+insert into rename_t values (1, 'alpha-one');
+alter table rename_t rename column plain to `a:b`;
+show create table rename_t;
+➤ Table[12,8,0]  ¦  Create Table[12,133,0]  𝄀
+rename_t  ¦  CREATE TABLE `rename_t` (
+  `id` int NOT NULL,
+  `a:b` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_plain` (`a:b`(3))
+)
+select algo_params
+from mo_catalog.mo_indexes
+where table_id = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'prefix_index_quoted_identifier' and relname = 'rename_t'
+) and name = 'idx_plain' and column_name = 'a:b';
+➤ algo_params[12,2048,0]  𝄀
+{"prefix_lengths_v2":"{\"a:b\":3}"}
+select mo_ctl('dn', 'flush', 'prefix_index_quoted_identifier.rename_t');
+➤ mo_ctl(dn, flush, prefix_index_quoted_identifier.rename_t)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id, `a:b`
+from rename_t force index(idx_plain) where `a:b` = 'alpha-one';
+➤ id[4,32,0]  ¦  a:b[12,32,0]  𝄀
+1  ¦  alpha-one
+drop database prefix_index_quoted_identifier;

--- a/test/distributed/cases/ddl/prefix_index_quoted_identifier.sql
+++ b/test/distributed/cases/ddl/prefix_index_quoted_identifier.sql
@@ -1,0 +1,78 @@
+drop database if exists prefix_index_quoted_identifier;
+create database prefix_index_quoted_identifier;
+use prefix_index_quoted_identifier;
+
+-- Prefix metadata must support quoted column names that contain the legacy
+-- metadata delimiters (':' and ',').
+create table create_t (
+    id int primary key,
+    `a:b` varchar(32),
+    `c,d` varchar(32),
+    payload varchar(32),
+    key idx_pair(`a:b`(3), `c,d`(2))
+);
+insert into create_t values
+    (1, 'alpha-one', 'xy-one', 'p1'),
+    (2, 'bravo-two', 'yz-two', 'p2');
+show create table create_t;
+select algo_params
+from mo_catalog.mo_indexes
+where table_id = (
+    select rel_id from mo_catalog.mo_tables
+    where reldatabase = 'prefix_index_quoted_identifier' and relname = 'create_t'
+) and name = 'idx_pair' and column_name = 'a:b';
+select mo_ctl('dn', 'flush', 'prefix_index_quoted_identifier.create_t');
+select id, `a:b`, `c,d`, payload
+from create_t force index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+select id, `a:b`, `c,d`, payload
+from create_t ignore index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+
+-- Exercise the CREATE INDEX path as well.
+create table create_index_t (
+    id int primary key,
+    `a:b` varchar(32),
+    `c,d` varchar(32)
+);
+create index idx_pair on create_index_t(`a:b`(3), `c,d`(2));
+insert into create_index_t values (1, 'alpha-one', 'xy-one');
+show create table create_index_t;
+select id, `a:b`, `c,d`
+from create_index_t force index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+
+-- ALTER TABLE ADD INDEX has a third builder path.
+create table alter_add_t (
+    id int primary key,
+    `a:b` varchar(32),
+    `c,d` varchar(32)
+);
+alter table alter_add_t add index idx_pair(`a:b`(3), `c,d`(2));
+insert into alter_add_t values (1, 'alpha-one', 'xy-one');
+show create table alter_add_t;
+select id, `a:b`, `c,d`
+from alter_add_t force index(idx_pair)
+where `a:b` = 'alpha-one' and `c,d` = 'xy-one';
+
+-- Renaming an existing prefix-indexed column into a delimiter-bearing quoted
+-- name must migrate its legacy metadata to v2.
+create table rename_t (
+    id int primary key,
+    plain varchar(32),
+    key idx_plain(plain(3))
+);
+insert into rename_t values (1, 'alpha-one');
+alter table rename_t rename column plain to `a:b`;
+show create table rename_t;
+select algo_params
+from mo_catalog.mo_indexes
+where table_id = (
+    select rel_id from mo_catalog.mo_tables
+    where reldatabase = 'prefix_index_quoted_identifier' and relname = 'rename_t'
+) and name = 'idx_plain' and column_name = 'a:b';
+select mo_ctl('dn', 'flush', 'prefix_index_quoted_identifier.rename_t');
+select id, `a:b`
+from rename_t force index(idx_plain) where `a:b` = 'alpha-one';
+
+drop database prefix_index_quoted_identifier;

--- a/test/distributed/cases/ddl/rename_prefix_index.result
+++ b/test/distributed/cases/ddl/rename_prefix_index.result
@@ -1,0 +1,71 @@
+drop database if exists rename_prefix_index;
+create database rename_prefix_index;
+use rename_prefix_index;
+create table t (
+id int primary key,
+a varchar(32),
+b varchar(32),
+payload varchar(32),
+unique key uq_a(a(4)),
+key idx_ab(a(3), b(2))
+);
+insert into t values
+(1, 'abcd-one', 'xy-one', 'p1');
+alter table t rename column a to headline;
+show create table t;
+➤ Table[12,1,0]  ¦  Create Table[12,247,0]  𝄀
+t  ¦  CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `headline` varchar(32) DEFAULT NULL,
+  `b` varchar(32) DEFAULT NULL,
+  `payload` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_a` (`headline`(4)),
+  KEY `idx_ab` (`headline`(3),`b`(2))
+)
+select distinct name, column_name, algo_params
+from mo_catalog.mo_indexes
+where database_id = (
+select dat_id from mo_catalog.mo_database where datname = 'rename_prefix_index'
+) and name in ('uq_a', 'idx_ab')
+order by name, column_name;
+➤ name[12,64,0]  ¦  column_name[12,256,0]  ¦  algo_params[12,2048,0]  𝄀
+idx_ab  ¦  __mo_alias_id  ¦  {"prefix_lengths":"b:2,headline:3"}  𝄀
+idx_ab  ¦  b  ¦  {"prefix_lengths":"b:2,headline:3"}  𝄀
+idx_ab  ¦  headline  ¦  {"prefix_lengths":"b:2,headline:3"}  𝄀
+uq_a  ¦  headline  ¦  {"prefix_lengths":"headline:4"}
+insert into t values (2, 'abcd-two', 'xy-two', 'dup');
+Duplicate entry 'abcd' for key 'headline'
+insert into t values (3, 'abce-two', 'xz-two', 'p3');
+select id, headline, b, payload from t order by id;
+➤ id[4,32,0]  ¦  headline[12,32,0]  ¦  b[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcd-one  ¦  xy-one  ¦  p1  𝄀
+3  ¦  abce-two  ¦  xz-two  ¦  p3
+select mo_ctl('dn', 'flush', 'rename_prefix_index.t');
+➤ mo_ctl(dn, flush, rename_prefix_index.t)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id, headline, b, payload
+from t force index(uq_a) where headline = 'abcd-one';
+➤ id[4,32,0]  ¦  headline[12,32,0]  ¦  b[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcd-one  ¦  xy-one  ¦  p1
+select id, headline, b, payload
+from t ignore index(uq_a) where headline = 'abcd-one';
+➤ id[4,32,0]  ¦  headline[12,32,0]  ¦  b[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcd-one  ¦  xy-one  ¦  p1
+select id, headline, b, payload
+from t force index(idx_ab) where headline = 'abce-two' and b = 'xz-two';
+➤ id[4,32,0]  ¦  headline[12,32,0]  ¦  b[12,32,0]  ¦  payload[12,32,0]  𝄀
+3  ¦  abce-two  ¦  xz-two  ¦  p3
+select id, headline, b, payload
+from t ignore index(idx_ab) where headline = 'abce-two' and b = 'xz-two';
+➤ id[4,32,0]  ¦  headline[12,32,0]  ¦  b[12,32,0]  ¦  payload[12,32,0]  𝄀
+3  ¦  abce-two  ¦  xz-two  ¦  p3
+drop database rename_prefix_index;

--- a/test/distributed/cases/ddl/rename_prefix_index.result
+++ b/test/distributed/cases/ddl/rename_prefix_index.result
@@ -68,4 +68,52 @@ select id, headline, b, payload
 from t ignore index(idx_ab) where headline = 'abce-two' and b = 'xz-two';
 ➤ id[4,32,0]  ¦  headline[12,32,0]  ¦  b[12,32,0]  ¦  payload[12,32,0]  𝄀
 3  ¦  abce-two  ¦  xz-two  ¦  p3
+create table change_t (
+id int primary key,
+a varchar(32),
+unique key uq_a(a(4))
+);
+insert into change_t values (1, 'wxyz-one');
+alter table change_t change column a headline varchar(32);
+show create table change_t;
+➤ Table[12,8,0]  ¦  Create Table[12,145,0]  𝄀
+change_t  ¦  CREATE TABLE `change_t` (
+  `id` int NOT NULL,
+  `headline` varchar(32) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_a` (`headline`(4))
+)
+select name, column_name, algo_params
+from mo_catalog.mo_indexes
+where table_id = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'rename_prefix_index' and relname = 'change_t'
+) and name = 'uq_a' and column_name = 'headline'
+order by name, column_name;
+➤ name[12,64,0]  ¦  column_name[12,256,0]  ¦  algo_params[12,2048,0]  𝄀
+uq_a  ¦  headline  ¦  {"prefix_lengths":"headline:4"}
+insert into change_t values (2, 'wxyz-two');
+Duplicate entry 'wxyz' for key 'headline'
+insert into change_t values (3, 'wxya-three');
+select id, headline from change_t order by id;
+➤ id[4,32,0]  ¦  headline[12,32,0]  𝄀
+1  ¦  wxyz-one  𝄀
+3  ¦  wxya-three
+select mo_ctl('dn', 'flush', 'rename_prefix_index.change_t');
+➤ mo_ctl(dn, flush, rename_prefix_index.change_t)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id, headline from change_t force index(uq_a) where headline = 'wxyz-one';
+➤ id[4,32,0]  ¦  headline[12,32,0]  𝄀
+1  ¦  wxyz-one
+select id, headline from change_t ignore index(uq_a) where headline = 'wxyz-one';
+➤ id[4,32,0]  ¦  headline[12,32,0]  𝄀
+1  ¦  wxyz-one
 drop database rename_prefix_index;

--- a/test/distributed/cases/ddl/rename_prefix_index.sql
+++ b/test/distributed/cases/ddl/rename_prefix_index.sql
@@ -1,0 +1,43 @@
+drop database if exists rename_prefix_index;
+create database rename_prefix_index;
+use rename_prefix_index;
+
+create table t (
+    id int primary key,
+    a varchar(32),
+    b varchar(32),
+    payload varchar(32),
+    unique key uq_a(a(4)),
+    key idx_ab(a(3), b(2))
+);
+insert into t values
+    (1, 'abcd-one', 'xy-one', 'p1');
+
+alter table t rename column a to headline;
+show create table t;
+
+-- Both ordinary indexes must carry the renamed prefix key in catalog metadata.
+select distinct name, column_name, algo_params
+from mo_catalog.mo_indexes
+where database_id = (
+    select dat_id from mo_catalog.mo_database where datname = 'rename_prefix_index'
+) and name in ('uq_a', 'idx_ab')
+order by name, column_name;
+
+-- The renamed unique prefix still rejects an equal prefix, while a different
+-- prefix remains valid and must be materialized with the same metadata.
+insert into t values (2, 'abcd-two', 'xy-two', 'dup');
+insert into t values (3, 'abce-two', 'xz-two', 'p3');
+
+select id, headline, b, payload from t order by id;
+select mo_ctl('dn', 'flush', 'rename_prefix_index.t');
+select id, headline, b, payload
+from t force index(uq_a) where headline = 'abcd-one';
+select id, headline, b, payload
+from t ignore index(uq_a) where headline = 'abcd-one';
+select id, headline, b, payload
+from t force index(idx_ab) where headline = 'abce-two' and b = 'xz-two';
+select id, headline, b, payload
+from t ignore index(idx_ab) where headline = 'abce-two' and b = 'xz-two';
+
+drop database rename_prefix_index;

--- a/test/distributed/cases/ddl/rename_prefix_index.sql
+++ b/test/distributed/cases/ddl/rename_prefix_index.sql
@@ -40,4 +40,27 @@ from t force index(idx_ab) where headline = 'abce-two' and b = 'xz-two';
 select id, headline, b, payload
 from t ignore index(idx_ab) where headline = 'abce-two' and b = 'xz-two';
 
+-- CHANGE COLUMN has a separate planner path but the same metadata contract.
+create table change_t (
+    id int primary key,
+    a varchar(32),
+    unique key uq_a(a(4))
+);
+insert into change_t values (1, 'wxyz-one');
+alter table change_t change column a headline varchar(32);
+show create table change_t;
+select name, column_name, algo_params
+from mo_catalog.mo_indexes
+where table_id = (
+    select rel_id from mo_catalog.mo_tables
+    where reldatabase = 'rename_prefix_index' and relname = 'change_t'
+) and name = 'uq_a' and column_name = 'headline'
+order by name, column_name;
+insert into change_t values (2, 'wxyz-two');
+insert into change_t values (3, 'wxya-three');
+select id, headline from change_t order by id;
+select mo_ctl('dn', 'flush', 'rename_prefix_index.change_t');
+select id, headline from change_t force index(uq_a) where headline = 'wxyz-one';
+select id, headline from change_t ignore index(uq_a) where headline = 'wxyz-one';
+
 drop database rename_prefix_index;

--- a/test/distributed/cases/optimizer/prefix_index_non_equality.result
+++ b/test/distributed/cases/optimizer/prefix_index_non_equality.result
@@ -1,0 +1,217 @@
+drop database if exists prefix_index_non_equality;
+create database prefix_index_non_equality;
+use prefix_index_non_equality;
+create table n (
+id int primary key,
+a varchar(64),
+key idx_a(a(4))
+);
+insert into n values
+(1, 'abbz'),
+(2, 'abcd'),
+(3, 'abcdx'),
+(4, 'abcdy'),
+(5, 'abce'),
+(6, 'abcex'),
+(7, 'abcf'),
+(8, '中中中中甲'),
+(9, '中中中中乙');
+select id from n where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select id from n force index(idx_a) where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select id from n ignore index(idx_a) where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select id from n where a between 'abcdx' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n force index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n ignore index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n where a >= 'abcdx' and a < 'abcf' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n force index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n ignore index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+prepare prefix_in_stmt from 'select id from n force index(idx_a) where a in (?, ?) order by id';
+set @left_value = 'abcdx', @right_value = 'abcex';
+execute prefix_in_stmt using @left_value, @right_value;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select mo_ctl('dn', 'flush', 'prefix_index_non_equality.n');
+➤ mo_ctl(dn, flush, prefix_index_non_equality.n)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id from n force index(idx_a) where a in ('abcdx') order by id;
+➤ id[4,32,0]  𝄀
+3
+select id from n ignore index(idx_a) where a in ('abcdx') order by id;
+➤ id[4,32,0]  𝄀
+3
+select id from n force index(idx_a) where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select id from n ignore index(idx_a) where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select id from n where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select id from n force index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n ignore index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n where a between 'abcdx' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n force index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n ignore index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+select id from n where a >= 'abcdx' and a < 'abcf' order by id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+5  𝄀
+6
+execute prefix_in_stmt using @left_value, @right_value;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+deallocate prepare prefix_in_stmt;
+select id from n force index(idx_a) where a in ('中中中中甲') order by id;
+➤ id[4,32,0]  𝄀
+8
+select id from n ignore index(idx_a) where a in ('中中中中甲') order by id;
+➤ id[4,32,0]  𝄀
+8
+select id from n where a in ('中中中中甲') order by id;
+➤ id[4,32,0]  𝄀
+8
+create table rhs (a varchar(64));
+insert into rhs values ('abcdx'), ('abcex');
+select n.id from n force index for join(idx_a) join rhs on n.a = rhs.a order by n.id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+select n.id from n ignore index for join(idx_a) join rhs on n.a = rhs.a order by n.id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+6
+create table ordered_prefix (
+id int primary key,
+a varchar(64),
+key idx_a(a(4))
+);
+insert into ordered_prefix values (1, 'abcdz'), (2, 'abcda'), (3, 'abcdy');
+select id, a from ordered_prefix force index for order by(idx_a) order by a limit 2;
+➤ id[4,32,0]  ¦  a[12,64,0]  𝄀
+2  ¦  abcda  𝄀
+3  ¦  abcdy
+select id, a from ordered_prefix ignore index for order by(idx_a) order by a limit 2;
+➤ id[4,32,0]  ¦  a[12,64,0]  𝄀
+2  ¦  abcda  𝄀
+3  ¦  abcdy
+create table u (
+id int primary key,
+a varchar(64),
+unique key uq_a(a(4))
+);
+insert into u values (1, 'abbz'), (2, 'abcdx'), (3, 'abcex'), (4, 'abcf');
+select mo_ctl('dn', 'flush', 'prefix_index_non_equality.u');
+➤ mo_ctl(dn, flush, prefix_index_non_equality.u)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id from u where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+2  𝄀
+3
+select id from u force index(uq_a) where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+2  𝄀
+3
+select id from u ignore index(uq_a) where a in ('abcdx', 'abcex') order by id;
+➤ id[4,32,0]  𝄀
+2  𝄀
+3
+select id from u where a between 'abcdw' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+2  𝄀
+3
+select id from u force index(uq_a) where a between 'abcdw' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+2  𝄀
+3
+select id from u ignore index(uq_a) where a between 'abcdw' and 'abcex' order by id;
+➤ id[4,32,0]  𝄀
+2  𝄀
+3
+drop database prefix_index_non_equality;

--- a/test/distributed/cases/optimizer/prefix_index_non_equality.sql
+++ b/test/distributed/cases/optimizer/prefix_index_non_equality.sql
@@ -1,0 +1,83 @@
+drop database if exists prefix_index_non_equality;
+create database prefix_index_non_equality;
+use prefix_index_non_equality;
+
+-- Prefix IN and range probes used to under-fetch persisted hidden-index blocks.
+-- FORCE/IGNORE pairs are correctness oracles; FORCE may safely fall back to the
+-- base table when a lossy prefix index is not eligible for the predicate.
+create table n (
+    id int primary key,
+    a varchar(64),
+    key idx_a(a(4))
+);
+insert into n values
+    (1, 'abbz'),
+    (2, 'abcd'),
+    (3, 'abcdx'),
+    (4, 'abcdy'),
+    (5, 'abce'),
+    (6, 'abcex'),
+    (7, 'abcf'),
+    (8, '中中中中甲'),
+    (9, '中中中中乙');
+
+select id from n where a in ('abcdx', 'abcex') order by id;
+select id from n force index(idx_a) where a in ('abcdx', 'abcex') order by id;
+select id from n ignore index(idx_a) where a in ('abcdx', 'abcex') order by id;
+select id from n where a between 'abcdx' and 'abcex' order by id;
+select id from n force index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+select id from n ignore index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+select id from n where a >= 'abcdx' and a < 'abcf' order by id;
+select id from n force index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+select id from n ignore index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+prepare prefix_in_stmt from 'select id from n force index(idx_a) where a in (?, ?) order by id';
+set @left_value = 'abcdx', @right_value = 'abcex';
+execute prefix_in_stmt using @left_value, @right_value;
+
+select mo_ctl('dn', 'flush', 'prefix_index_non_equality.n');
+select id from n force index(idx_a) where a in ('abcdx') order by id;
+select id from n ignore index(idx_a) where a in ('abcdx') order by id;
+select id from n force index(idx_a) where a in ('abcdx', 'abcex') order by id;
+select id from n ignore index(idx_a) where a in ('abcdx', 'abcex') order by id;
+select id from n where a in ('abcdx', 'abcex') order by id;
+select id from n force index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+select id from n ignore index(idx_a) where a between 'abcdx' and 'abcex' order by id;
+select id from n where a between 'abcdx' and 'abcex' order by id;
+select id from n force index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+select id from n ignore index(idx_a) where a >= 'abcdx' and a < 'abcf' order by id;
+select id from n where a >= 'abcdx' and a < 'abcf' order by id;
+execute prefix_in_stmt using @left_value, @right_value;
+deallocate prepare prefix_in_stmt;
+select id from n force index(idx_a) where a in ('中中中中甲') order by id;
+select id from n ignore index(idx_a) where a in ('中中中中甲') order by id;
+select id from n where a in ('中中中中甲') order by id;
+
+create table rhs (a varchar(64));
+insert into rhs values ('abcdx'), ('abcex');
+select n.id from n force index for join(idx_a) join rhs on n.a = rhs.a order by n.id;
+select n.id from n ignore index for join(idx_a) join rhs on n.a = rhs.a order by n.id;
+
+create table ordered_prefix (
+    id int primary key,
+    a varchar(64),
+    key idx_a(a(4))
+);
+insert into ordered_prefix values (1, 'abcdz'), (2, 'abcda'), (3, 'abcdy');
+select id, a from ordered_prefix force index for order by(idx_a) order by a limit 2;
+select id, a from ordered_prefix ignore index for order by(idx_a) order by a limit 2;
+
+create table u (
+    id int primary key,
+    a varchar(64),
+    unique key uq_a(a(4))
+);
+insert into u values (1, 'abbz'), (2, 'abcdx'), (3, 'abcex'), (4, 'abcf');
+select mo_ctl('dn', 'flush', 'prefix_index_non_equality.u');
+select id from u where a in ('abcdx', 'abcex') order by id;
+select id from u force index(uq_a) where a in ('abcdx', 'abcex') order by id;
+select id from u ignore index(uq_a) where a in ('abcdx', 'abcex') order by id;
+select id from u where a between 'abcdw' and 'abcex' order by id;
+select id from u force index(uq_a) where a between 'abcdw' and 'abcex' order by id;
+select id from u ignore index(uq_a) where a between 'abcdw' and 'abcex' order by id;
+
+drop database prefix_index_non_equality;

--- a/test/distributed/cases/optimizer/unique_index_extra_filter.result
+++ b/test/distributed/cases/optimizer/unique_index_extra_filter.result
@@ -1,0 +1,96 @@
+drop database if exists unique_index_extra_filter;
+create database unique_index_extra_filter;
+use unique_index_extra_filter;
+create table t (
+id int primary key,
+a varchar(32),
+payload varchar(32),
+unique index uq_a(a)
+);
+insert into t values
+(1, 'abcdx', 'p1'),
+(2, 'abce0', 'p2');
+select id, a, payload from t where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select id, a, payload from t ignore index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and a > 'abcdw';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select id, a, payload from t force index(uq_a) where 'abcdw' < a and a = 'abcdx';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and payload = 'p1';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select mo_ctl('dn', 'flush', 'unique_index_extra_filter.t');
+➤ mo_ctl(dn, flush, unique_index_extra_filter.t)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id, a, payload from t where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select id, a, payload from t ignore index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+create table composite_control (
+id int primary key,
+a varchar(32),
+b int,
+payload varchar(32),
+unique index uq_ab(a, b)
+);
+insert into composite_control values
+(1, 'abcdx', 10, 'p1'),
+(2, 'abce0', 20, 'p2');
+select id, a, b, payload
+from composite_control force index(uq_ab)
+where a = 'abcdx' and b = 10 and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  b[4,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  10  ¦  p1
+create table prefix_control (
+id int primary key,
+a varchar(32),
+payload varchar(32),
+unique index uq_a(a(4))
+);
+insert into prefix_control values
+(1, 'abcdx', 'p1'),
+(2, 'abce0', 'p2');
+select id, a, payload
+from prefix_control force index(uq_a)
+where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+select mo_ctl('dn', 'flush', 'unique_index_extra_filter.prefix_control');
+➤ mo_ctl(dn, flush, unique_index_extra_filter.prefix_control)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select id, a, payload
+from prefix_control force index(uq_a)
+where a = 'abcdx' and a like 'abcdx%';
+➤ id[4,32,0]  ¦  a[12,32,0]  ¦  payload[12,32,0]  𝄀
+1  ¦  abcdx  ¦  p1
+drop database unique_index_extra_filter;

--- a/test/distributed/cases/optimizer/unique_index_extra_filter.sql
+++ b/test/distributed/cases/optimizer/unique_index_extra_filter.sql
@@ -1,0 +1,67 @@
+drop database if exists unique_index_extra_filter;
+create database unique_index_extra_filter;
+use unique_index_extra_filter;
+
+create table t (
+    id int primary key,
+    a varchar(32),
+    payload varchar(32),
+    unique index uq_a(a)
+);
+insert into t values
+    (1, 'abcdx', 'p1'),
+    (2, 'abce0', 'p2');
+
+-- A one-part unique index stores its key directly, so an extra predicate on
+-- that part must not try to decode the raw key with serial_extract.
+select id, a, payload from t where a = 'abcdx' and a like 'abcdx%';
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+select id, a, payload from t ignore index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and a > 'abcdw';
+select id, a, payload from t force index(uq_a) where 'abcdw' < a and a = 'abcdx';
+
+-- Predicates on columns not represented by the hidden index stay on the base
+-- table and remain a control for the backfill path.
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and payload = 'p1';
+
+select mo_ctl('dn', 'flush', 'unique_index_extra_filter.t');
+select id, a, payload from t where a = 'abcdx' and a like 'abcdx%';
+select id, a, payload from t force index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+select id, a, payload from t ignore index(uq_a) where a = 'abcdx' and a like 'abcdx%';
+
+-- Serialized composite keys must continue to extract individual parts before
+-- pushing additional predicates.
+create table composite_control (
+    id int primary key,
+    a varchar(32),
+    b int,
+    payload varchar(32),
+    unique index uq_ab(a, b)
+);
+insert into composite_control values
+    (1, 'abcdx', 10, 'p1'),
+    (2, 'abce0', 20, 'p2');
+select id, a, b, payload
+from composite_control force index(uq_ab)
+where a = 'abcdx' and b = 10 and a like 'abcdx%';
+
+-- A lossy prefix part cannot evaluate a full-value extra predicate on the
+-- hidden index. It remains a base-table residual after candidate lookup.
+create table prefix_control (
+    id int primary key,
+    a varchar(32),
+    payload varchar(32),
+    unique index uq_a(a(4))
+);
+insert into prefix_control values
+    (1, 'abcdx', 'p1'),
+    (2, 'abce0', 'p2');
+select id, a, payload
+from prefix_control force index(uq_a)
+where a = 'abcdx' and a like 'abcdx%';
+select mo_ctl('dn', 'flush', 'unique_index_extra_filter.prefix_control');
+select id, a, payload
+from prefix_control force index(uq_a)
+where a = 'abcdx' and a like 'abcdx%';
+
+drop database unique_index_extra_filter;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26813
Fixes #26818
Fixes #26822
Fixes #26823
Fixes #26824

## What this PR does / why we need it:

Regular prefix indexes had correctness gaps across planning, metadata maintenance, DDL validation, and rolling upgrades:

- Use the stored prefix only for equality candidate lookup, retain the full base-table residual, and reject lossy index-only reconstruction.
- Disable prefix indexes for IN, BETWEEN, scalar/paired ranges, ORDER/GROUP reconstruction, and relational index joins until those paths have prefix-aware candidate semantics.
- Fail closed when prefix metadata is malformed or no longer matches the logical index parts. Optional reads skip the index; INSERT, UPDATE, DELETE, and REPLACE reject the stale index with a rebuild instruction.
- Preserve prefix lengths through RENAME COLUMN and CHANGE COLUMN, including an all-index preflight so protocol or metadata failures occur before the first TableDef mutation.
- Keep ordinary identifiers on the legacy metadata representation, and gate lossless `prefix_lengths_v2` emission for delimiter-bearing identifiers on deployment protocol version 13.
- Reserve the internal `__mo_alias_` namespace across explicit CREATE TABLE, CTAS, ADD COLUMN, CHANGE COLUMN, and RENAME COLUMN paths.

## Review follow-up: actual versus theoretical

The P1 findings are real:

- On the pre-fix PR binary after flushing hidden-index blocks, `FORCE INDEX` prefix IN returned no rows while `IGNORE INDEX` returned ids 3 and 6. Prefix BETWEEN and range also disagreed with the base-table oracle.
- `FORCE INDEX FOR ORDER BY` returned truncated values (`abcd`) and chose the wrong LIMIT 2 rows; `IGNORE INDEX` returned the full values in the correct order.
- A table created and renamed by the base binary persisted `column_name=b` with `{"prefix_lengths":"a:4"}`. The pre-fix PR still selected the index and missed the row. The updated binary returns the row through a base-table scan.
- The base-version metadata reader was run against an actual v2 payload and returned no prefix lengths, confirming the rolling-upgrade incompatibility rather than assuming it.
- On that same stale catalog, the updated binary rejects INSERT, UPDATE, DELETE, and REPLACE before execution and leaves the rows unchanged. Before the fix, non-unique DELETE returned success without deleting the row, while REPLACE admitted two unique-index values with the same stored prefix.

A forced relational equality JOIN did select the prefix index on the pre-fix binary, but the tested result remained correct. This PR still disables that unproven path as requested; it is not presented as a reproduced wrong-result case.

## Validation

- Rebased cleanly onto current `main` at `415724ff30cfb1dd96fa2eb75110402fbc4e7239`.
- Protocol boundary regressions prove v12 rejects and v13 accepts lossless prefix metadata on both CREATE and RENAME.\n- `make build`.
- Controlled CGo tests: full `./pkg/sql/plan`; `./pkg/catalog`, `./pkg/common/runtime`, `./pkg/sql/plan/function/ctl`.
- Protocol-adjacent tests: `./pkg/frontend`, `./pkg/sql/compile`, `./pkg/txn/rpc`, and `./pkg/vm/engine/tae/db/dbutils`.
- `go vet`: `./pkg/catalog`, `./pkg/common/runtime`, `./pkg/sql/plan`, and `./pkg/sql/plan/function/ctl`.
- Focused BVT on the final binary: 200/200 statements across six scripts.
- The new 52-statement matrix covers default/FORCE/IGNORE, unique and non-unique prefixes, IN/BETWEEN/paired ranges, same-prefix neighbors, prepared values, Unicode, JOIN/ORDER hints, and reads before and after flush.
- `git diff --check`.
