### PR TITLE
[4.2-dev] fix(fileservice): prevent duplicate range fan-out

### DIFF
--- a/pkg/fileservice/io_merger.go
+++ b/pkg/fileservice/io_merger.go
@@ -15,6 +15,7 @@
 package fileservice
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -29,11 +30,16 @@ type IOMerger struct {
 }
 
 type IOMergeKey struct {
-	Path       string
-	Offset     int64
-	End        int64
+	Path   string
+	Offset int64
+	End    int64
+	Policy Policy
+	// FullObject describes the physical read range. CacheFill additionally
+	// distinguishes requests whose successful leader publishes a reusable
+	// full-object disk-cache entry. Followers must not long-wait a generation
+	// that cannot publish the artifact they intend to reuse.
 	FullObject bool
-	Policy     Policy
+	CacheFill  bool
 }
 
 func NewIOMerger() *IOMerger {
@@ -46,67 +52,107 @@ var maxIOWaitDuration = time.Minute
 
 var shortIOWaitDuration = time.Millisecond * 200
 
-func (i *IOMerger) makeWaitFunc(key IOMergeKey, ch chan struct{}, maxWaitDuration time.Duration) func() {
+func waitForIOGeneration(
+	ctx context.Context,
+	key IOMergeKey,
+	generation <-chan struct{},
+	maxWaitDuration time.Duration,
+) (completed bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	metric.IOMergerCounterWait.Add(1)
-	return func() {
-		t0 := time.Now()
-		defer func() {
-			metric.IOMergerDurationWait.Observe(time.Since(t0).Seconds())
-		}()
-		deadline := time.Now().Add(maxWaitDuration)
-		for {
-			waitDuration := slowIOWaitDuration
-			if maxWaitDuration > 0 {
-				remaining := time.Until(deadline)
-				if remaining <= 0 {
-					return
-				}
-				waitDuration = min(waitDuration, remaining)
+	t0 := time.Now()
+	defer func() {
+		metric.IOMergerDurationWait.Observe(time.Since(t0).Seconds())
+	}()
+
+	var deadline time.Time
+	if maxWaitDuration > 0 {
+		deadline = t0.Add(maxWaitDuration)
+	}
+	nextWaitDuration := func() (time.Duration, bool) {
+		if deadline.IsZero() {
+			return slowIOWaitDuration, false
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return 0, true
+		}
+		if slowIOWaitDuration <= 0 {
+			return remaining, false
+		}
+		return min(slowIOWaitDuration, remaining), false
+	}
+
+	waitDuration, expired := nextWaitDuration()
+	if expired {
+		return false, nil
+	}
+	if waitDuration <= 0 {
+		select {
+		case <-generation:
+			return true, nil
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+	timer := time.NewTimer(waitDuration)
+	defer timer.Stop()
+	for {
+		select {
+		case <-generation:
+			return true, nil
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-timer.C:
+			waitDuration, expired = nextWaitDuration()
+			if expired {
+				return false, nil
 			}
-			timer := time.NewTimer(waitDuration)
-			select {
-			case <-ch:
-				timer.Stop()
-				return
-			case <-timer.C:
-				if maxWaitDuration > 0 && !time.Now().Before(deadline) {
-					// don't wait too long
-					// number of I/O requests may increase, but we don't want to hurt latencies too much.
-					return
-				}
-				logutil.Warn("wait io for too long",
-					zap.Any("wait", time.Since(t0)),
-					zap.Any("key", key),
-				)
-			}
+			logutil.Warn("wait io for too long",
+				zap.Any("wait", time.Since(t0)),
+				zap.Any("key", key),
+			)
+			timer.Reset(waitDuration)
 		}
 	}
 }
 
-func (i *IOMerger) Merge(key IOMergeKey, maxWaitDuration time.Duration) (done func(), wait func()) {
+func (i *IOMerger) merge(key IOMergeKey) (func(), chan struct{}) {
 	if v, ok := i.flying.Load(key); ok {
-		// wait
-		return nil, i.makeWaitFunc(key, v.(chan struct{}), maxWaitDuration)
+		return nil, v.(chan struct{})
 	}
 
 	// try initiate
-	ch := make(chan struct{})
-	v, loaded := i.flying.LoadOrStore(key, ch)
+	generation := make(chan struct{})
+	v, loaded := i.flying.LoadOrStore(key, generation)
 	if loaded {
-		// not the first request, wait
-		return nil, i.makeWaitFunc(key, v.(chan struct{}), maxWaitDuration)
+		return nil, v.(chan struct{})
 	}
 
 	// initiated
 	metric.IOMergerCounterInitiate.Add(1)
 	t0 := time.Now()
 	return func() {
-		defer func() {
-			metric.IOMergerDurationInitiate.Observe(time.Since(t0).Seconds())
-		}()
 		i.flying.Delete(key)
-		close(ch)
+		close(generation)
+		metric.IOMergerDurationInitiate.Observe(time.Since(t0).Seconds())
 	}, nil
+}
+
+// Merge preserves the original callback API for callers that only need one
+// bounded wait. S3FS and LocalFS use merge directly so a follower can remain
+// bound to the exact generation it collided with across multiple wait phases.
+func (i *IOMerger) Merge(key IOMergeKey, maxWaitDuration time.Duration) (done func(), wait func()) {
+	done, waiter := i.merge(key)
+	if waiter == nil {
+		return done, nil
+	}
+	return nil, func() {
+		_, _ = waitForIOGeneration(context.Background(), key, waiter, maxWaitDuration)
+	}
 }
 
 func (i *IOMerger) IsMerging(key IOMergeKey) bool {

--- a/pkg/fileservice/io_merger.go
+++ b/pkg/fileservice/io_merger.go
@@ -36,8 +36,8 @@ type IOMergeKey struct {
 	Policy Policy
 	// FullObject describes the physical read range. CacheFill additionally
 	// distinguishes requests whose successful leader publishes a reusable
-	// full-object disk-cache entry. Followers must not long-wait a generation
-	// that cannot publish the artifact they intend to reuse.
+	// cache entry. Followers must not wait for a generation that cannot publish
+	// the artifact they intend to reuse.
 	FullObject bool
 	CacheFill  bool
 }

--- a/pkg/fileservice/io_merger_test.go
+++ b/pkg/fileservice/io_merger_test.go
@@ -15,10 +15,23 @@
 package fileservice
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 )
+
+type waitStartedContext struct {
+	context.Context
+	once    sync.Once
+	started chan struct{}
+}
+
+func (c *waitStartedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.started) })
+	return c.Context.Done()
+}
 
 func TestIOMerger(t *testing.T) {
 	merger := NewIOMerger()
@@ -149,5 +162,84 @@ func TestIOMergerIsMerging(t *testing.T) {
 	done()
 	if merger.IsMerging(key) {
 		t.Fatal("expected key to stop merging")
+	}
+}
+
+func TestIOMergerWaitContext(t *testing.T) {
+	merger := NewIOMerger()
+	key := IOMergeKey{Path: "foo"}
+	done, waiter := merger.merge(key)
+	if done == nil || waiter != nil {
+		t.Fatal("expected first merge to initiate")
+	}
+	defer func() {
+		if merger.IsMerging(key) {
+			done()
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, waiter = merger.merge(key)
+	if waiter == nil {
+		t.Fatal("expected second merge to wait")
+	}
+	completed, err := waitForIOGeneration(ctx, key, waiter, time.Second)
+	if completed || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled wait, got %v", err)
+	}
+	completed, err = waitForIOGeneration(context.Background(), key, waiter, time.Millisecond)
+	if completed || err != nil {
+		t.Fatalf("expected bounded wait to expire, got completed=%v, err=%v", completed, err)
+	}
+
+	waitCtx := &waitStartedContext{
+		Context: context.Background(),
+		started: make(chan struct{}),
+	}
+	type waitResult struct {
+		completed bool
+		err       error
+	}
+	waitDone := make(chan waitResult, 1)
+	go func() {
+		completed, err := waitForIOGeneration(waitCtx, key, waiter, time.Second)
+		waitDone <- waitResult{completed: completed, err: err}
+	}()
+	<-waitCtx.started
+	done()
+	result := <-waitDone
+	if !result.completed || result.err != nil {
+		t.Fatalf("merge completion wait failed: completed=%v, err=%v", result.completed, result.err)
+	}
+	completed, err = waitForIOGeneration(context.Background(), key, waiter, time.Second)
+	if !completed || err != nil {
+		t.Fatalf("completed merge wait failed: completed=%v, err=%v", completed, err)
+	}
+}
+
+func TestIOMergerWaiterRemainsBoundToGeneration(t *testing.T) {
+	merger := NewIOMerger()
+	key := IOMergeKey{Path: "foo"}
+
+	finishFirst, waiter := merger.merge(key)
+	if finishFirst == nil || waiter != nil {
+		t.Fatal("expected first merge to initiate")
+	}
+	_, firstWaiter := merger.merge(key)
+	if firstWaiter == nil {
+		t.Fatal("expected waiter for first generation")
+	}
+	finishFirst()
+
+	finishSecond, waiter := merger.merge(key)
+	if finishSecond == nil || waiter != nil {
+		t.Fatal("expected second generation to initiate")
+	}
+	defer finishSecond()
+
+	completed, err := waitForIOGeneration(context.Background(), key, firstWaiter, time.Second)
+	if !completed || err != nil {
+		t.Fatalf("first-generation waiter followed a later generation: completed=%v, err=%v", completed, err)
 	}
 }

--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -16,6 +16,11 @@ package fileservice
 
 import "math"
 
+const (
+	minExpensiveRangeReadSpan        = int64(8 << 20)
+	maxMinimalRangeReadAmplification = int64(8)
+)
+
 func (i *IOVector) allDone() bool {
 	for _, entry := range i.Entries {
 		if !entry.done {
@@ -89,6 +94,40 @@ func (i *IOVector) readMinimalRange() (min *int64, max *int64) {
 		}
 	}
 	return
+}
+
+// expensiveMinimalRangeRead reports whether collapsing the unfinished entries
+// into one range would fetch substantially more data than the caller requested.
+// Unknown or invalid ranges keep the existing fallback behavior.
+func (i *IOVector) expensiveMinimalRangeRead() (logicalBytes, spanBytes int64, expensive bool) {
+	minOffset := int64(math.MaxInt64)
+	maxEnd := int64(0)
+	n := 0
+	for _, entry := range i.Entries {
+		if entry.done {
+			continue
+		}
+		if entry.Offset < 0 || entry.Size <= 0 || entry.Offset > math.MaxInt64-entry.Size {
+			return 0, 0, false
+		}
+		if logicalBytes > math.MaxInt64-entry.Size {
+			return 0, 0, false
+		}
+		n++
+		logicalBytes += entry.Size
+		minOffset = min(minOffset, entry.Offset)
+		maxEnd = max(maxEnd, entry.Offset+entry.Size)
+	}
+	if n < 2 || minOffset == math.MaxInt64 || maxEnd < minOffset {
+		return logicalBytes, 0, false
+	}
+	spanBytes = maxEnd - minOffset
+	if spanBytes <= minExpensiveRangeReadSpan ||
+		logicalBytes > math.MaxInt64/maxMinimalRangeReadAmplification {
+		return logicalBytes, spanBytes, false
+	}
+	return logicalBytes, spanBytes,
+		spanBytes > logicalBytes*maxMinimalRangeReadAmplification
 }
 
 func (i *IOVector) size() *int64 {

--- a/pkg/fileservice/io_vector_test.go
+++ b/pkg/fileservice/io_vector_test.go
@@ -15,6 +15,7 @@
 package fileservice
 
 import (
+	"math"
 	"sync/atomic"
 	"testing"
 
@@ -125,4 +126,75 @@ func TestIOVectorIOMergeKeyDoesNotMutateReadToEndEntry(t *testing.T) {
 	require.Equal(t, int64(4), key.Offset)
 	require.Equal(t, int64(0), key.End)
 	require.Equal(t, int64(-1), vector.Entries[0].Size)
+}
+
+func TestIOVectorExpensiveMinimalRangeRead(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   []IOEntry
+		expensive bool
+	}{
+		{
+			name: "large sparse range",
+			entries: []IOEntry{
+				{Offset: 0, Size: 1 << 20},
+				{Offset: 32 << 20, Size: 1 << 20},
+			},
+			expensive: true,
+		},
+		{
+			name: "adjacent ranges",
+			entries: []IOEntry{
+				{Offset: 0, Size: 5 << 20},
+				{Offset: 5 << 20, Size: 5 << 20},
+			},
+		},
+		{
+			name: "small sparse range",
+			entries: []IOEntry{
+				{Offset: 0, Size: 1 << 10},
+				{Offset: 4 << 20, Size: 1 << 10},
+			},
+		},
+		{
+			name: "exact amplification boundary",
+			entries: []IOEntry{
+				{Offset: 0, Size: 1 << 20},
+				{Offset: 15 << 20, Size: 1 << 20},
+			},
+		},
+		{
+			name:    "single range",
+			entries: []IOEntry{{Offset: 32 << 20, Size: 1 << 10}},
+		},
+		{
+			name: "completed sparse range",
+			entries: []IOEntry{
+				{Offset: 0, Size: 1 << 20},
+				{Offset: 32 << 20, Size: 1 << 20, done: true},
+			},
+		},
+		{
+			name: "read to end",
+			entries: []IOEntry{
+				{Offset: 0, Size: 1 << 20},
+				{Offset: 32 << 20, Size: -1},
+			},
+		},
+		{
+			name: "overflowing range",
+			entries: []IOEntry{
+				{Offset: 0, Size: 1 << 20},
+				{Offset: math.MaxInt64, Size: 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			vector := IOVector{Entries: test.entries}
+			_, _, expensive := vector.expensiveMinimalRangeRead()
+			require.Equal(t, test.expensive, expensive)
+		})
+	}
 }

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -448,6 +448,15 @@ func (l *LocalFS) write(ctx context.Context, vector IOVector) (bytesWritten int,
 }
 
 func (l *LocalFS) Read(ctx context.Context, vector *IOVector) (err error) {
+	// Cache updates are deferred below. Keep the merge generation active until
+	// those updates finish so a completed follower can reuse the leader output.
+	var finishMerge func()
+	defer func() {
+		if finishMerge != nil {
+			finishMerge()
+		}
+	}()
+
 	// Record diskIO IO and netwokIO(un memory IO) time Consumption
 	stats := statistic.StatsInfoFromContext(ctx)
 	ioStart := time.Now()
@@ -574,18 +583,25 @@ read_disk_cache:
 	if mayReadMemoryCache || mayReadDiskCache {
 		// may read caches, merge
 		startLock := time.Now()
-		done, wait := l.ioMerger.Merge(vector.ioMergeKey(), maxIOWaitDuration)
+		mergeKey := vector.ioMergeKey()
+		done, generation := l.ioMerger.merge(mergeKey)
 		if done != nil {
-			defer done()
+			finishMerge = done
 			stats.AddLocalFSReadIOMergerTimeConsumption(time.Since(startLock))
 		} else {
-			wait()
+			completed, waitErr := waitForIOGeneration(ctx, mergeKey, generation, maxIOWaitDuration)
 			stats.AddLocalFSReadIOMergerTimeConsumption(time.Since(startLock))
-			if mayReadMemoryCache {
-				goto read_memory_cache
-			} else {
+			if waitErr != nil {
+				return waitErr
+			}
+			if completed {
+				if mayReadMemoryCache {
+					goto read_memory_cache
+				}
 				goto read_disk_cache
 			}
+			// A timed-out follower must not rejoin the same generation forever.
+			// Fall through to its own bounded local read.
 		}
 	}
 

--- a/pkg/fileservice/local_fs_test.go
+++ b/pkg/fileservice/local_fs_test.go
@@ -23,8 +23,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
@@ -32,6 +34,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type localBlockingDataCache struct {
+	fscache.DataCache
+	updateStarted chan struct{}
+	releaseUpdate chan struct{}
+	once          sync.Once
+}
+
+func (c *localBlockingDataCache) Set(ctx context.Context, key fscache.CacheKey, data fscache.Data) error {
+	c.once.Do(func() { close(c.updateStarted) })
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.releaseUpdate:
+	}
+	return c.DataCache.Set(ctx, key, data)
+}
 
 func TestLocalFSStatFileReturnsNonNotExistError(t *testing.T) {
 	ctx := context.Background()
@@ -42,6 +61,106 @@ func TestLocalFSStatFileReturnsNonNotExistError(t *testing.T) {
 
 	_, err = fs.StatFile(ctx, "file/child")
 	require.ErrorIs(t, err, syscall.ENOTDIR)
+}
+
+func TestLocalFSMergeWaitHasBoundedFallback(t *testing.T) {
+	ctx := context.Background()
+	originalMaxWait := maxIOWaitDuration
+	maxIOWaitDuration = 5 * time.Millisecond
+	t.Cleanup(func() { maxIOWaitDuration = originalMaxWait })
+
+	local, err := NewLocalFS(ctx, "local", t.TempDir(), DisabledCacheConfig, nil)
+	require.NoError(t, err)
+	require.NoError(t, local.Write(ctx, IOVector{
+		FilePath: "foo",
+		Entries:  []IOEntry{{Size: 3, Data: []byte("foo")}},
+		Policy:   SkipAllCache,
+	}))
+
+	vector := &IOVector{
+		FilePath: "foo",
+		Entries:  []IOEntry{{Offset: 0, Size: 3}},
+	}
+	t.Cleanup(vector.Release)
+	finishMerge, waitMerge := local.ioMerger.Merge(vector.ioMergeKey(), maxIOWaitDuration)
+	require.NotNil(t, finishMerge)
+	require.Nil(t, waitMerge)
+	releaseMerge := sync.OnceFunc(finishMerge)
+	t.Cleanup(releaseMerge)
+
+	readDone := make(chan error, 1)
+	go func() { readDone <- local.Read(context.Background(), vector) }()
+	select {
+	case err := <-readDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		releaseMerge()
+		select {
+		case <-readDone:
+		case <-time.After(time.Second):
+			t.Fatal("local follower did not terminate after merge release")
+		}
+		t.Fatal("local follower rejoined a timed-out merge generation")
+	}
+	require.Equal(t, []byte("foo"), vector.Entries[0].Data)
+}
+
+func TestLocalFSMergeCompletesAfterCacheUpdate(t *testing.T) {
+	ctx := context.Background()
+	local, err := NewLocalFS(ctx, "local", t.TempDir(), CacheConfig{
+		MemoryCapacity: ptrTo(toml.ByteSize(1 << 20)),
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, local.Write(ctx, IOVector{
+		FilePath: "foo",
+		Entries:  []IOEntry{{Size: 3, Data: []byte("foo")}},
+		Policy:   SkipAllCache,
+	}))
+
+	cache := &localBlockingDataCache{
+		DataCache:     local.memCache.cache,
+		updateStarted: make(chan struct{}),
+		releaseUpdate: make(chan struct{}),
+	}
+	local.memCache.cache = cache
+	releaseUpdate := sync.OnceFunc(func() { close(cache.releaseUpdate) })
+	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	var wg sync.WaitGroup
+	vector := &IOVector{
+		FilePath: "foo",
+		Policy:   SkipFullFilePreloads,
+		Entries: []IOEntry{{
+			Offset:      0,
+			Size:        3,
+			ToCacheData: CacheOriginalData,
+		}},
+	}
+	t.Cleanup(func() {
+		cancel()
+		releaseUpdate()
+		wg.Wait()
+		vector.Release()
+	})
+
+	readDone := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		readDone <- local.Read(readCtx, vector)
+	}()
+	select {
+	case <-cache.updateStarted:
+	case <-readCtx.Done():
+		t.Fatalf("cache update did not start: %v", readCtx.Err())
+	}
+	require.True(t, local.ioMerger.IsMerging(vector.ioMergeKey()))
+	releaseUpdate()
+	select {
+	case err := <-readDone:
+		require.NoError(t, err)
+	case <-readCtx.Done():
+		t.Fatalf("local read did not finish: %v", readCtx.Err())
+	}
 }
 
 func TestLocalFS(t *testing.T) {

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"io"
 	"iter"
+	"math"
 	pathpkg "path"
 	"runtime"
 	"slices"
@@ -755,7 +756,7 @@ read_disk_cache:
 		}
 	}
 
-	if forcePerEntryRangeRead {
+	if forcePerEntryRangeRead || forceMinimalRangeRead {
 		goto read_s3
 	}
 	if mayReadMemoryCache || mayReadDiskCache {
@@ -827,6 +828,36 @@ read_disk_cache:
 					goto read_s3
 				}
 				forceMinimalRangeRead = true
+				if rangeKey, ok := s.singleEntryRangeMergeKey(vector); ok {
+					LogEvent(ctx, str_ioMerger_Merge_begin)
+					rangeMergeStart := time.Now()
+					rangeDone, rangeGeneration := s.ioMerger.merge(rangeKey)
+					if rangeDone != nil {
+						finishMerge = rangeDone
+						stats.AddS3FSReadIOMergerTimeConsumption(time.Since(rangeMergeStart))
+						metric.FSReadDurationIOMerger.Observe(time.Since(rangeMergeStart).Seconds())
+						LogEvent(ctx, str_ioMerger_Merge_initiate)
+						LogEvent(ctx, str_ioMerger_Merge_end)
+					} else {
+						LogEvent(ctx, str_ioMerger_Merge_wait)
+						completed, waitErr = waitForIOGeneration(
+							ctx, rangeKey, rangeGeneration, maxIOWaitDuration,
+						)
+						rangeMergeTime := time.Since(rangeMergeStart)
+						stats.AddS3FSReadIOMergerTimeConsumption(rangeMergeTime)
+						metric.FSReadDurationIOMerger.Observe(rangeMergeTime.Seconds())
+						LogEvent(ctx, str_ioMerger_Merge_end)
+						if waitErr != nil {
+							return waitErr
+						}
+						if completed {
+							if mayReadMemoryCache {
+								goto read_memory_cache
+							}
+							goto read_disk_cache
+						}
+					}
+				}
 				goto read_s3
 			}
 			if completed {
@@ -1224,6 +1255,43 @@ func (s *S3FS) readMergeKey(vector *IOVector) IOMergeKey {
 		key.CacheFill = s.willCacheFullObject(vector)
 	}
 	return key
+}
+
+func (s *S3FS) singleEntryRangeMergeKey(vector *IOVector) (IOMergeKey, bool) {
+	var target *IOEntry
+	for i := range vector.Entries {
+		entry := &vector.Entries[i]
+		if entry.done {
+			continue
+		}
+		if target != nil || entry.Offset < 0 || entry.Size <= 0 ||
+			entry.Offset > math.MaxInt64-entry.Size ||
+			entry.WriterForRead != nil || entry.ReadCloserForRead != nil {
+			return IOMergeKey{}, false
+		}
+		target = entry
+	}
+	if target == nil {
+		return IOMergeKey{}, false
+	}
+
+	canPublish := target.ToCacheData != nil && s.memCache != nil &&
+		!vector.Policy.Any(SkipMemoryCacheReads, SkipMemoryCacheWrites)
+	if !canPublish {
+		canPublish = s.diskCache != nil && vector.Policy.CacheIOEntry() &&
+			!vector.Policy.Any(SkipDiskCacheReads, SkipDiskCacheWrites)
+	}
+	if !canPublish {
+		return IOMergeKey{}, false
+	}
+
+	return IOMergeKey{
+		Path:      vector.FilePath,
+		Offset:    target.Offset,
+		End:       target.Offset + target.Size,
+		Policy:    vector.Policy,
+		CacheFill: true,
+	}, true
 }
 
 func (s *S3FS) willCacheFullObject(vector *IOVector) bool {

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -417,6 +417,9 @@ func (s *S3FS) PrefetchFile(ctx context.Context, filePath string) error {
 	if err != nil {
 		return err
 	}
+	if s.diskCache == nil {
+		return nil
+	}
 
 	startLock := time.Now()
 	defer func() {
@@ -426,6 +429,7 @@ func (s *S3FS) PrefetchFile(ctx context.Context, filePath string) error {
 	done, _ := s.ioMerger.Merge(IOMergeKey{
 		Path:       filePath,
 		FullObject: true,
+		CacheFill:  true,
 	}, maxIOWaitDuration)
 	if done != nil {
 		defer done()
@@ -435,15 +439,13 @@ func (s *S3FS) PrefetchFile(ctx context.Context, filePath string) error {
 	}
 
 	// load to disk cache
-	if s.diskCache != nil {
-		if err := s.diskCache.SetFile(
-			ctx, path.File,
-			func(ctx context.Context) (io.ReadCloser, error) {
-				return s.newReadCloser(ctx, filePath)
-			},
-		); err != nil {
-			return err
-		}
+	if err := s.diskCache.SetFile(
+		ctx, path.File,
+		func(ctx context.Context) (io.ReadCloser, error) {
+			return s.newReadCloser(ctx, filePath)
+		},
+	); err != nil {
+		return err
 	}
 	return nil
 }
@@ -659,6 +661,10 @@ func (s *S3FS) Read(ctx context.Context, vector *IOVector) (err error) {
 		}()
 	}
 
+	mayReadMemoryCache := vector.Policy&SkipMemoryCacheReads == 0
+	mayReadDiskCache := vector.Policy&SkipDiskCacheReads == 0
+	forceMinimalRangeRead := false
+	forcePerEntryRangeRead := false
 read_memory_cache:
 	if s.memCache != nil {
 
@@ -749,19 +755,25 @@ read_disk_cache:
 		}
 	}
 
-	mayReadMemoryCache := vector.Policy&SkipMemoryCacheReads == 0
-	mayReadDiskCache := vector.Policy&SkipDiskCacheReads == 0
-	forceMinimalRangeRead := false
+	if forcePerEntryRangeRead {
+		goto read_s3
+	}
 	if mayReadMemoryCache || mayReadDiskCache {
 		// may read caches, merge
+		mergeKey := s.readMergeKey(vector)
+		if mergeKey.FullObject && !mergeKey.CacheFill {
+			// Stream-only reads cannot publish a reusable cache artifact, so
+			// serializing them behind an unrelated request only adds head-of-line
+			// blocking without eliminating any storage read.
+			goto read_s3
+		}
 		LogEvent(ctx, str_ioMerger_Merge_begin)
 		startLock := time.Now()
-		mergeKey := vector.ioMergeKey()
 		waitDuration := maxIOWaitDuration
 		if mergeKey.FullObject {
 			waitDuration = shortIOWaitDuration
 		}
-		done, wait := s.ioMerger.Merge(mergeKey, waitDuration)
+		done, generation := s.ioMerger.merge(mergeKey)
 		if done != nil {
 			finishMerge = done
 			stats.AddS3FSReadIOMergerTimeConsumption(time.Since(startLock))
@@ -770,19 +782,62 @@ read_disk_cache:
 			LogEvent(ctx, str_ioMerger_Merge_end)
 		} else {
 			LogEvent(ctx, str_ioMerger_Merge_wait)
-			wait()
+			completed, waitErr := waitForIOGeneration(ctx, mergeKey, generation, waitDuration)
 			stats.AddS3FSReadIOMergerTimeConsumption(time.Since(startLock))
 			metric.FSReadDurationIOMerger.Observe(time.Since(startLock).Seconds())
 			LogEvent(ctx, str_ioMerger_Merge_end)
-			if mergeKey.FullObject && s.ioMerger.IsMerging(mergeKey) {
+			if waitErr != nil {
+				return waitErr
+			}
+			if !completed && mergeKey.FullObject {
+				logicalBytes, spanBytes, expensive := vector.expensiveMinimalRangeRead()
+				if mergeKey.CacheFill && expensive {
+					LogEvent(ctx, str_ioMerger_Merge_wait_expensive_range,
+						logicalBytes, spanBytes)
+					waitStart := time.Now()
+					remainingWaitDuration := maxIOWaitDuration - waitDuration
+					if remainingWaitDuration > 0 {
+						completed, waitErr = waitForIOGeneration(
+							ctx,
+							mergeKey,
+							generation,
+							remainingWaitDuration,
+						)
+					}
+					waitTime := time.Since(waitStart)
+					stats.AddS3FSReadIOMergerTimeConsumption(waitTime)
+					metric.FSReadDurationIOMerger.Observe(waitTime.Seconds())
+					if waitErr != nil {
+						return waitErr
+					}
+					if !completed {
+						forcePerEntryRangeRead = true
+						if mayReadMemoryCache {
+							goto read_memory_cache
+						}
+						goto read_disk_cache
+					}
+					if mayReadMemoryCache {
+						goto read_memory_cache
+					}
+					goto read_disk_cache
+				}
+				if expensive {
+					forcePerEntryRangeRead = true
+					goto read_s3
+				}
 				forceMinimalRangeRead = true
 				goto read_s3
 			}
-			if mayReadMemoryCache {
-				goto read_memory_cache
-			} else {
+			if completed {
+				if mayReadMemoryCache {
+					goto read_memory_cache
+				}
 				goto read_disk_cache
 			}
+			// The local bound expired. Do not join the same generation again;
+			// make bounded follower progress through the normal range read.
+			goto read_s3
 		}
 	}
 
@@ -795,7 +850,12 @@ read_s3:
 		}
 	}
 	s3ReadStart := time.Now()
-	if err := s.read(ctx, vector, forceMinimalRangeRead); err != nil {
+	if forcePerEntryRangeRead {
+		err = s.readEntriesIndividually(ctx, vector)
+	} else {
+		err = s.read(ctx, vector, forceMinimalRangeRead)
+	}
+	if err != nil {
 		return err
 	}
 	metric.FSReadDurationS3Read.Observe(time.Since(s3ReadStart).Seconds())
@@ -806,6 +866,31 @@ read_s3:
 		})
 	}
 
+	return nil
+}
+
+func (s *S3FS) readEntriesIndividually(ctx context.Context, vector *IOVector) error {
+	// The full-object merge is still stalled after its bounded wait. Read exact
+	// entry ranges sequentially so this follower can progress without fetching
+	// the potentially much larger sparse envelope.
+	for i := range vector.Entries {
+		if vector.Entries[i].done {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		single := &IOVector{
+			FilePath: vector.FilePath,
+			Entries:  []IOEntry{vector.Entries[i]},
+			ExpireAt: vector.ExpireAt,
+			Policy:   vector.Policy,
+		}
+		if err := s.read(ctx, single, true); err != nil {
+			return err
+		}
+		vector.Entries[i] = single.Entries[0]
+	}
 	return nil
 }
 
@@ -1131,6 +1216,34 @@ func (s *S3FS) shouldStreamFullObjectToDiskCache(vector *IOVector) bool {
 		}
 	}
 	return true
+}
+
+func (s *S3FS) readMergeKey(vector *IOVector) IOMergeKey {
+	key := vector.ioMergeKey()
+	if key.FullObject {
+		key.CacheFill = s.willCacheFullObject(vector)
+	}
+	return key
+}
+
+func (s *S3FS) willCacheFullObject(vector *IOVector) bool {
+	if s.diskCache == nil || vector.Policy.Any(SkipDiskCacheWrites) {
+		return false
+	}
+	willReadFullObject := false
+	for i := range vector.Entries {
+		entry := &vector.Entries[i]
+		if entry.done {
+			continue
+		}
+		if entry.Size == 0 {
+			return false
+		}
+		if entry.WriterForRead == nil && entry.ReadCloserForRead == nil {
+			willReadFullObject = true
+		}
+	}
+	return willReadFullObject
 }
 
 func (s *S3FS) readFullObjectToDiskCacheStreaming(

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -240,6 +240,18 @@ type blockingReadObjectStorage struct {
 	readCount   atomic.Int64
 }
 
+type generatedRangeObjectStorage struct {
+	dummyObjectStorage
+	mu    sync.Mutex
+	reads []objectStorageReadRange
+}
+
+type heldWriter struct {
+	once    sync.Once
+	started chan struct{}
+	release chan struct{}
+}
+
 type blockingDataCache struct {
 	fscache.DataCache
 	updateStarted chan struct{}
@@ -269,6 +281,37 @@ func (b *blockingDataCache) Set(ctx context.Context, key fscache.CacheKey, data 
 		}
 	}
 	return b.DataCache.Set(ctx, key, data)
+}
+
+func (g *generatedRangeObjectStorage) Read(
+	_ context.Context,
+	key string,
+	min *int64,
+	max *int64,
+) (io.ReadCloser, error) {
+	g.mu.Lock()
+	g.reads = append(g.reads, objectStorageReadRange{
+		key: key,
+		min: cloneInt64Pointer(min),
+		max: cloneInt64Pointer(max),
+	})
+	g.mu.Unlock()
+	if min == nil || max == nil || *max < *min {
+		return nil, errors.New("expected a bounded range read")
+	}
+	return io.NopCloser(bytes.NewReader(make([]byte, *max-*min))), nil
+}
+
+func (g *generatedRangeObjectStorage) readRanges() []objectStorageReadRange {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]objectStorageReadRange(nil), g.reads...)
+}
+
+func (w *heldWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+	return len(p), nil
 }
 
 func (r *readRangeRecordingObjectStorage) Read(ctx context.Context, key string, min *int64, max *int64) (io.ReadCloser, error) {
@@ -1059,7 +1102,7 @@ func TestS3FSRangeReadSkipsFullObjectDiskCacheUpdate(t *testing.T) {
 			},
 		},
 	}
-	doneMerge, waitMerge := fs.ioMerger.Merge(fullObjectVec.ioMergeKey(), maxIOWaitDuration)
+	doneMerge, waitMerge := fs.ioMerger.Merge(fs.readMergeKey(fullObjectVec), maxIOWaitDuration)
 	assert.NotNil(t, doneMerge)
 	assert.Nil(t, waitMerge)
 	releasedMerge := false
@@ -1155,7 +1198,7 @@ func TestS3FSRangeReadSkipsFullObjectIOMergeBeforeDiskCacheUpdate(t *testing.T) 
 			},
 		},
 	}
-	doneMerge, waitMerge := fs.ioMerger.Merge(fullObjectVec.ioMergeKey(), maxIOWaitDuration)
+	doneMerge, waitMerge := fs.ioMerger.Merge(fs.readMergeKey(fullObjectVec), maxIOWaitDuration)
 	assert.NotNil(t, doneMerge)
 	assert.Nil(t, waitMerge)
 	releasedMerge := false
@@ -1195,7 +1238,7 @@ func TestS3FSRangeReadSkipsFullObjectIOMergeBeforeDiskCacheUpdate(t *testing.T) 
 	case result := <-readDone:
 		assert.Nil(t, result.err)
 		assert.Equal(t, data[123:130], result.data)
-		assert.True(t, fs.ioMerger.IsMerging(fullObjectVec.ioMergeKey()))
+		assert.True(t, fs.ioMerger.IsMerging(fs.readMergeKey(fullObjectVec)))
 		assert.False(t, fs.diskCache.isUpdating(fs.diskCache.pathForFile("foo/bar")))
 		read, ok := recorder.lastRead()
 		assert.True(t, ok)
@@ -1210,6 +1253,286 @@ func TestS3FSRangeReadSkipsFullObjectIOMergeBeforeDiskCacheUpdate(t *testing.T) 
 		result := <-readDone
 		t.Fatalf("range read waited for full-object io merge before disk cache update: %v", result.err)
 	}
+}
+
+func TestS3FSExpensiveRangeWaitsForFullObjectMergeUntilContextDeadline(t *testing.T) {
+	ctx := context.Background()
+	originalShortWait := shortIOWaitDuration
+	shortIOWaitDuration = time.Millisecond
+	t.Cleanup(func() {
+		shortIOWaitDuration = originalShortWait
+	})
+
+	fs, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Name:      "s3",
+			Endpoint:  "disk",
+			Bucket:    t.TempDir(),
+			KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+		},
+		CacheConfig{
+			DiskPath:     ptrTo(t.TempDir()),
+			DiskCapacity: ptrTo[toml.ByteSize](1 << 30),
+		},
+		nil,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+
+	storage := &blockingReadObjectStorage{
+		ObjectStorage: fs.storage,
+		readStarted:   make(chan struct{}),
+		releaseRead:   make(chan struct{}),
+	}
+	fs.storage = storage
+	vector := &IOVector{
+		FilePath: "foo/bar",
+		Entries: []IOEntry{
+			{Offset: 0, Size: 1 << 20},
+			{Offset: 32 << 20, Size: 1 << 20},
+		},
+	}
+	doneMerge, waitMerge := fs.ioMerger.Merge(fs.readMergeKey(vector), maxIOWaitDuration)
+	require.NotNil(t, doneMerge)
+	require.Nil(t, waitMerge)
+	releaseMerge := sync.OnceFunc(doneMerge)
+	releaseRead := sync.OnceFunc(func() { close(storage.releaseRead) })
+	readCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	t.Cleanup(func() {
+		cancel()
+		releaseRead()
+		releaseMerge()
+		vector.Release()
+		fs.Close(ctx)
+	})
+
+	err = fs.Read(readCtx, vector)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, int64(0), storage.readCount.Load())
+}
+
+func TestS3FSExpensiveRangeHasBoundedPerEntryFallback(t *testing.T) {
+	ctx := context.Background()
+	originalShortWait := shortIOWaitDuration
+	originalMaxWait := maxIOWaitDuration
+	shortIOWaitDuration = time.Millisecond
+	maxIOWaitDuration = 5 * time.Millisecond
+	t.Cleanup(func() {
+		shortIOWaitDuration = originalShortWait
+		maxIOWaitDuration = originalMaxWait
+	})
+
+	fs, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Name:      "s3",
+			Endpoint:  "disk",
+			Bucket:    t.TempDir(),
+			KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+		},
+		CacheConfig{
+			DiskPath:     ptrTo(t.TempDir()),
+			DiskCapacity: ptrTo[toml.ByteSize](1 << 30),
+		},
+		nil,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+
+	storage := &generatedRangeObjectStorage{}
+	fs.storage = storage
+	vector := &IOVector{
+		FilePath: "foo/bar",
+		Entries: []IOEntry{
+			{Offset: 0, Size: 1},
+			{Offset: 9 << 20, Size: 1},
+		},
+	}
+	doneMerge, waitMerge := fs.ioMerger.Merge(fs.readMergeKey(vector), maxIOWaitDuration)
+	require.NotNil(t, doneMerge)
+	require.Nil(t, waitMerge)
+	releaseMerge := sync.OnceFunc(doneMerge)
+	t.Cleanup(func() {
+		releaseMerge()
+		vector.Release()
+		fs.Close(ctx)
+	})
+
+	readDone := make(chan error, 1)
+	go func() {
+		readDone <- fs.Read(context.Background(), vector)
+	}()
+	select {
+	case err := <-readDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		releaseMerge()
+		select {
+		case <-readDone:
+		case <-time.After(time.Second):
+			t.Fatal("follower did not terminate after releasing the merge leader")
+		}
+		t.Fatal("follower with no caller deadline did not reach a bounded fallback")
+	}
+
+	reads := storage.readRanges()
+	require.Len(t, reads, 2)
+	require.Equal(t, int64(0), *reads[0].min)
+	require.Equal(t, int64(1), *reads[0].max)
+	require.Equal(t, int64(9<<20), *reads[1].min)
+	require.Equal(t, int64(9<<20)+1, *reads[1].max)
+}
+
+func TestS3FSCacheFillDoesNotWaitForNonProducingLeader(t *testing.T) {
+	ctx := context.Background()
+	fs, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Name:      "s3",
+			Endpoint:  "disk",
+			Bucket:    t.TempDir(),
+			KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+		},
+		CacheConfig{
+			DiskPath:     ptrTo(t.TempDir()),
+			DiskCapacity: ptrTo[toml.ByteSize](1 << 30),
+		},
+		nil,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { fs.Close(ctx) })
+
+	data := make([]byte, (9<<20)+1)
+	data[0] = 1
+	data[len(data)-1] = 2
+	require.NoError(t, fs.Write(ctx, IOVector{
+		FilePath: "foo/bar",
+		Entries:  []IOEntry{{Size: int64(len(data)), Data: data}},
+		Policy:   SkipAllCache,
+	}))
+
+	writer := &heldWriter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	releaseWriter := sync.OnceFunc(func() { close(writer.release) })
+	leaderVector := &IOVector{
+		FilePath: "foo/bar",
+		Entries: []IOEntry{{
+			Offset:        0,
+			Size:          1,
+			WriterForRead: writer,
+		}},
+	}
+	followerVector := &IOVector{
+		FilePath: "foo/bar",
+		Entries: []IOEntry{
+			{Offset: 0, Size: 1},
+			{Offset: 9 << 20, Size: 1},
+		},
+	}
+	t.Cleanup(followerVector.Release)
+	require.False(t, fs.readMergeKey(leaderVector).CacheFill)
+	require.True(t, fs.readMergeKey(followerVector).CacheFill)
+	require.NotEqual(t, fs.readMergeKey(leaderVector), fs.readMergeKey(followerVector))
+
+	leaderDone := make(chan error, 1)
+	go func() { leaderDone <- fs.Read(ctx, leaderVector) }()
+	t.Cleanup(func() {
+		releaseWriter()
+		select {
+		case err := <-leaderDone:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Error("non-cache-producing leader did not terminate")
+		}
+	})
+	select {
+	case <-writer.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("non-cache-producing leader did not reach its writer")
+	}
+	require.False(t, fs.ioMerger.IsMerging(fs.readMergeKey(leaderVector)))
+
+	followerDone := make(chan error, 1)
+	go func() { followerDone <- fs.Read(ctx, followerVector) }()
+	select {
+	case err := <-followerDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		releaseWriter()
+		select {
+		case <-followerDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("cache-producing follower did not terminate after leader release")
+		}
+		t.Fatal("cache-producing follower waited for a non-cache-producing leader")
+	}
+	require.Equal(t, []byte{1}, followerVector.Entries[0].Data)
+	require.Equal(t, []byte{2}, followerVector.Entries[1].Data)
+}
+
+func TestS3FSRangeMergeWaitHasBoundedFallback(t *testing.T) {
+	ctx := context.Background()
+	originalMaxWait := maxIOWaitDuration
+	maxIOWaitDuration = 5 * time.Millisecond
+	t.Cleanup(func() { maxIOWaitDuration = originalMaxWait })
+
+	fs, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Name:      "s3",
+			Endpoint:  "disk",
+			Bucket:    t.TempDir(),
+			KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+		},
+		CacheConfig{
+			DiskPath:     ptrTo(t.TempDir()),
+			DiskCapacity: ptrTo[toml.ByteSize](1 << 30),
+		},
+		nil,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { fs.Close(ctx) })
+	storage := &generatedRangeObjectStorage{}
+	fs.storage = storage
+	vector := &IOVector{
+		FilePath: "foo/bar",
+		Policy:   SkipFullFilePreloads,
+		Entries:  []IOEntry{{Offset: 0, Size: 1}},
+	}
+	t.Cleanup(vector.Release)
+	finishMerge, waitMerge := fs.ioMerger.Merge(fs.readMergeKey(vector), maxIOWaitDuration)
+	require.NotNil(t, finishMerge)
+	require.Nil(t, waitMerge)
+	releaseMerge := sync.OnceFunc(finishMerge)
+	t.Cleanup(releaseMerge)
+
+	readDone := make(chan error, 1)
+	go func() { readDone <- fs.Read(context.Background(), vector) }()
+	select {
+	case err := <-readDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		releaseMerge()
+		select {
+		case <-readDone:
+		case <-time.After(time.Second):
+			t.Fatal("range follower did not terminate after merge release")
+		}
+		t.Fatal("range follower rejoined a timed-out merge generation")
+	}
+	reads := storage.readRanges()
+	require.Len(t, reads, 1)
+	require.Equal(t, int64(0), *reads[0].min)
+	require.Equal(t, int64(1), *reads[0].max)
 }
 
 func TestS3FSRangeReadSkipsPrefetchFullObjectIOMerge(t *testing.T) {
@@ -1249,6 +1572,7 @@ func TestS3FSRangeReadSkipsPrefetchFullObjectIOMerge(t *testing.T) {
 	doneMerge, waitMerge := fs.ioMerger.Merge(IOMergeKey{
 		Path:       "foo/bar",
 		FullObject: true,
+		CacheFill:  true,
 	}, maxIOWaitDuration)
 	assert.NotNil(t, doneMerge)
 	assert.Nil(t, waitMerge)
@@ -1486,6 +1810,63 @@ func TestS3FSShouldStreamFullObjectToDiskCacheExclusions(t *testing.T) {
 	}))
 }
 
+func TestS3FSWillCacheFullObject(t *testing.T) {
+	ctx := context.Background()
+	cache, err := NewDiskCache(ctx, t.TempDir(), fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { cache.Close(ctx) })
+	fs := &S3FS{diskCache: cache}
+
+	writer := new(bytes.Buffer)
+	var reader io.ReadCloser
+	tests := []struct {
+		name   string
+		vector *IOVector
+		want   bool
+	}{
+		{
+			name:   "ordinary entry",
+			vector: &IOVector{Entries: []IOEntry{{Size: 1}}},
+			want:   true,
+		},
+		{
+			name:   "writer only",
+			vector: &IOVector{Entries: []IOEntry{{Size: 1, WriterForRead: writer}}},
+		},
+		{
+			name:   "read closer only",
+			vector: &IOVector{Entries: []IOEntry{{Size: 1, ReadCloserForRead: &reader}}},
+		},
+		{
+			name: "mixed ordinary and writer",
+			vector: &IOVector{Entries: []IOEntry{
+				{Size: 1, WriterForRead: writer},
+				{Offset: 1, Size: 1},
+			}},
+			want: true,
+		},
+		{
+			name: "zero-sized entry prevents publication",
+			vector: &IOVector{Entries: []IOEntry{
+				{Size: 1},
+				{Offset: 1, Size: 0},
+			}},
+		},
+		{
+			name: "disk cache writes disabled",
+			vector: &IOVector{
+				Policy:  SkipDiskCacheWrites,
+				Entries: []IOEntry{{Size: 1}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, fs.willCacheFullObject(test.vector))
+		})
+	}
+}
+
 type errorReadCloser struct {
 	reader *bytes.Reader
 	err    error
@@ -1695,7 +2076,7 @@ func TestS3FSIOMerger(t *testing.T) {
 	// at this point, otherwise a waiter can become a second merge leader before
 	// the first leader's cache contents are visible. This assertion is
 	// deterministically false with defer done() at the Merge call site.
-	require.True(t, fs.ioMerger.IsMerging(newReadVector().ioMergeKey()))
+	require.True(t, fs.ioMerger.IsMerging(fs.readMergeKey(newReadVector())))
 
 	waiterCtx := WithEventLogger(readCtx)
 	startRead(waiterCtx)

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -1535,6 +1535,200 @@ func TestS3FSRangeMergeWaitHasBoundedFallback(t *testing.T) {
 	require.Equal(t, int64(1), *reads[0].max)
 }
 
+func TestS3FSSingleEntryFallbackCoalescesExactRange(t *testing.T) {
+	ctx := context.Background()
+	originalShortWait := shortIOWaitDuration
+	shortIOWaitDuration = time.Millisecond
+	t.Cleanup(func() { shortIOWaitDuration = originalShortWait })
+
+	fs, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Name:      "s3",
+			Endpoint:  "disk",
+			Bucket:    t.TempDir(),
+			KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+		},
+		CacheConfig{
+			MemoryCapacity: ptrTo[toml.ByteSize](1 << 20),
+			DiskPath:       ptrTo(t.TempDir()),
+			DiskCapacity:   ptrTo[toml.ByteSize](1 << 30),
+		},
+		nil,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, fs.memCache)
+	t.Cleanup(func() { fs.Close(ctx) })
+
+	rangeStorage := &generatedRangeObjectStorage{}
+	storage := &blockingReadObjectStorage{
+		ObjectStorage: rangeStorage,
+		readStarted:   make(chan struct{}),
+		releaseRead:   make(chan struct{}),
+	}
+	fs.storage = storage
+
+	newVector := func() *IOVector {
+		return &IOVector{
+			FilePath: "foo/bar",
+			Entries: []IOEntry{{
+				Offset:      123,
+				Size:        7,
+				ToCacheData: CacheOriginalData,
+			}},
+		}
+	}
+	fullObjectVector := newVector()
+	fullObjectDone, fullObjectWait := fs.ioMerger.Merge(
+		fs.readMergeKey(fullObjectVector), maxIOWaitDuration,
+	)
+	require.NotNil(t, fullObjectDone)
+	require.Nil(t, fullObjectWait)
+	releaseFullObject := sync.OnceFunc(fullObjectDone)
+	releaseStorage := sync.OnceFunc(func() { close(storage.releaseRead) })
+	t.Cleanup(func() {
+		releaseStorage()
+		releaseFullObject()
+	})
+
+	leaderVector := newVector()
+	leaderDone := make(chan error, 1)
+	go func() { leaderDone <- fs.Read(ctx, leaderVector) }()
+	select {
+	case <-storage.readStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("single-range leader did not reach object storage")
+	}
+
+	const followers = 16
+	followerCtx, cancelFollowers := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancelFollowers()
+	followerDone := make(chan error, followers)
+	for range followers {
+		go func() {
+			vector := newVector()
+			defer vector.Release()
+			followerDone <- fs.Read(followerCtx, vector)
+		}()
+	}
+	for range followers {
+		select {
+		case err := <-followerDone:
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		case <-time.After(5 * time.Second):
+			t.Fatal("single-range follower did not honor caller cancellation")
+		}
+	}
+	require.Equal(t, int64(1), storage.readCount.Load())
+
+	releaseStorage()
+	select {
+	case err := <-leaderDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("single-range leader did not terminate")
+	}
+	require.Equal(t, []byte(make([]byte, 7)), leaderVector.Entries[0].Data)
+	leaderVector.Release()
+
+	cachedVector := newVector()
+	require.NoError(t, fs.Read(ctx, cachedVector))
+	require.NotNil(t, cachedVector.Entries[0].CachedData)
+	require.Equal(t, []byte(make([]byte, 7)), cachedVector.Entries[0].CachedData.Bytes())
+	cachedVector.Release()
+	require.Equal(t, int64(1), storage.readCount.Load())
+	require.Len(t, rangeStorage.readRanges(), 1)
+}
+
+func TestS3FSSingleEntryFallbackDoesNotMergeDifferentRanges(t *testing.T) {
+	ctx := context.Background()
+	originalShortWait := shortIOWaitDuration
+	shortIOWaitDuration = time.Millisecond
+	t.Cleanup(func() { shortIOWaitDuration = originalShortWait })
+
+	fs, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Name:      "s3",
+			Endpoint:  "disk",
+			Bucket:    t.TempDir(),
+			KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+		},
+		CacheConfig{
+			MemoryCapacity: ptrTo[toml.ByteSize](1 << 20),
+			DiskPath:       ptrTo(t.TempDir()),
+			DiskCapacity:   ptrTo[toml.ByteSize](1 << 30),
+		},
+		nil,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { fs.Close(ctx) })
+
+	rangeStorage := &generatedRangeObjectStorage{}
+	storage := &blockingReadObjectStorage{
+		ObjectStorage: rangeStorage,
+		readStarted:   make(chan struct{}),
+		releaseRead:   make(chan struct{}),
+	}
+	fs.storage = storage
+
+	newVector := func(offset int64) *IOVector {
+		return &IOVector{
+			FilePath: "foo/bar",
+			Entries: []IOEntry{{
+				Offset:      offset,
+				Size:        7,
+				ToCacheData: CacheOriginalData,
+			}},
+		}
+	}
+	fullObjectDone, fullObjectWait := fs.ioMerger.Merge(
+		fs.readMergeKey(newVector(123)), maxIOWaitDuration,
+	)
+	require.NotNil(t, fullObjectDone)
+	require.Nil(t, fullObjectWait)
+	releaseFullObject := sync.OnceFunc(fullObjectDone)
+	releaseStorage := sync.OnceFunc(func() { close(storage.releaseRead) })
+	t.Cleanup(func() {
+		releaseStorage()
+		releaseFullObject()
+	})
+
+	first := newVector(123)
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- fs.Read(ctx, first) }()
+	select {
+	case <-storage.readStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first exact range did not reach object storage")
+	}
+
+	second := newVector(456)
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- fs.Read(ctx, second) }()
+	select {
+	case err := <-secondDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("different exact range waited for an unrelated leader")
+	}
+	require.Equal(t, int64(2), storage.readCount.Load())
+
+	releaseStorage()
+	select {
+	case err := <-firstDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("first exact range did not terminate")
+	}
+	first.Release()
+	second.Release()
+}
+
 func TestS3FSRangeReadSkipsPrefetchFullObjectIOMerge(t *testing.T) {
 	ctx := context.Background()
 	fs, err := NewS3FS(

--- a/pkg/fileservice/string.go
+++ b/pkg/fileservice/string.go
@@ -21,6 +21,7 @@ var (
 	str_ioMerger_Merge_end                    = internString("ioMerger.Merge end")
 	str_ioMerger_Merge_initiate               = internString("ioMerger.Merge initiate")
 	str_ioMerger_Merge_wait                   = internString("ioMerger.Merge wait")
+	str_ioMerger_Merge_wait_expensive_range   = internString("ioMerger.Merge wait expensive range")
 	str_read_vector_Caches_begin              = internString("read vector.Caches begin")
 	str_read_vector_Caches_end                = internString("read vector.Caches end")
 	str_update_vector_Caches_begin            = internString("update vector.Caches begin")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25129
issue #26172

## What this PR does / why we need it:

Backport the complete FileService range fan-out fix to `4.2-dev`.

`4.2-dev` contains the range-bypass and 200 ms fallback introduced by #24759
and #24871, but does not contain #26758. Therefore backporting only the
single-entry follow-up from #26834 would leave the multi-entry sparse-range
fan-out unchanged. This PR applies both fixes in dependency order:

1. #26758: avoid wide sparse fallback reads and bind waiters to the exact
   cache-producing merge generation.
2. #26834: coalesce duplicate single-entry exact-range fallbacks after the
   full-object generation exceeds its short wait.

The normal cache-hit and uncontended read paths are unchanged. All waits remain
caller-cancelable and bounded. Merge generations have no background goroutine
or persistent queue and are deleted on leader completion. Followers recheck
cache publication before falling back to a bounded exact read.

Validation on the `4.2-dev` base (`4066fffaf7`):

- focused FileService regression set, `-count=3`
- six concurrency/lifecycle tests under `-race` (`20` or `100` repetitions)
- full `pkg/fileservice` test
- full `pkg/fileservice` race test
- `go build` and `go vet` for `pkg/fileservice`

Backported commits retain `-x` provenance for #26758 and #26834.
