### PR TITLE
[4.2-dev] fix(hashmap): accept broadcast const iterator vectors

### DIFF
--- a/pkg/common/hashmap/iterator.go
+++ b/pkg/common/hashmap/iterator.go
@@ -30,7 +30,19 @@ func validateIteratorVectors(
 		return mpool.ErrAllocationAccountInvalid
 	}
 	for _, vec := range vecs {
-		if vec == nil || start > vec.Length() || count > vec.Length()-start {
+		if vec == nil {
+			return mpool.ErrAllocationAccountInvalid
+		}
+		// Const vectors physically store one value and broadcast it across the
+		// caller's logical row range. Hash encoders already handle that contract
+		// by reading row zero, so only require physical storage when rows are read.
+		if vec.IsConst() {
+			if count > 0 && vec.Length() == 0 {
+				return mpool.ErrAllocationAccountInvalid
+			}
+			continue
+		}
+		if start > vec.Length() || count > vec.Length()-start {
 			return mpool.ErrAllocationAccountInvalid
 		}
 	}

--- a/pkg/common/hashmap/strhashmap_test.go
+++ b/pkg/common/hashmap/strhashmap_test.go
@@ -537,20 +537,68 @@ func TestHashMapIteratorsRejectMalformedRowShapes(t *testing.T) {
 		},
 	} {
 		m, iterator := makeIterator()
-		short, err := vector.NewConstFixed(types.T_int32.ToType(), int32(1), 1, mp)
-		require.NoError(t, err)
+		short := vector.NewVec(types.T_int32.ToType())
+		require.NoError(t, vector.AppendFixed(short, int32(1), false, mp))
 		for _, vecs := range [][]*vector.Vector{
 			nil,
 			{nil},
 			{short},
 		} {
-			_, _, err = iterator.Insert(0, 2, vecs)
+			_, _, err := iterator.Insert(0, 2, vecs)
 			require.ErrorIs(t, err, mpool.ErrAllocationAccountInvalid)
 			_, _, err = iterator.Find(1, 1, vecs)
 			require.ErrorIs(t, err, mpool.ErrAllocationAccountInvalid)
 		}
 		require.Zero(t, m.GroupCount())
 		short.Free(mp)
+		m.Free()
+	}
+	require.Zero(t, mp.CurrNB())
+}
+
+func TestHashMapIteratorsBroadcastConstVectors(t *testing.T) {
+	mp := mpool.MustNewZero()
+	for _, makeIterator := range []func() (HashMap, Iterator){
+		func() (HashMap, Iterator) {
+			m, err := NewIntHashMap(true, mp)
+			require.NoError(t, err)
+			return m, m.NewIterator()
+		},
+		func() (HashMap, Iterator) {
+			m, err := NewStrHashMap(true, mp)
+			require.NoError(t, err)
+			return m, m.NewIterator()
+		},
+	} {
+		m, iterator := makeIterator()
+		constant, err := vector.NewConstFixed(types.T_int32.ToType(), int32(7), 1, mp)
+		require.NoError(t, err)
+
+		values, zValues, err := iterator.Insert(UnitLimit, 2, []*vector.Vector{constant})
+		require.NoError(t, err)
+		require.Equal(t, []uint64{1, 1}, values)
+		require.Equal(t, []int64{1, 1}, zValues)
+		require.Equal(t, uint64(1), m.GroupCount())
+
+		values, zValues, err = iterator.Find(UnitLimit*2, 2, []*vector.Vector{constant})
+		require.NoError(t, err)
+		require.Equal(t, []uint64{1, 1}, values)
+		require.Equal(t, []int64{1, 1}, zValues)
+
+		constantNull := vector.NewConstNull(types.T_int32.ToType(), 1, mp)
+		values, zValues, err = iterator.Insert(UnitLimit*3, 2, []*vector.Vector{constantNull})
+		require.NoError(t, err)
+		require.Equal(t, []uint64{2, 2}, values)
+		require.Equal(t, []int64{1, 1}, zValues)
+		require.Equal(t, uint64(2), m.GroupCount())
+
+		emptyConstant := vector.NewConstNull(types.T_int32.ToType(), 0, mp)
+		_, _, err = iterator.Insert(UnitLimit*4, 1, []*vector.Vector{emptyConstant})
+		require.ErrorIs(t, err, mpool.ErrAllocationAccountInvalid)
+
+		emptyConstant.Free(mp)
+		constantNull.Free(mp)
+		constant.Free(mp)
 		m.Free()
 	}
 	require.Zero(t, mp.CurrNB())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25992

## What this PR does / why we need it:

Backport #26836 to `4.2-dev`.

#26042 fixed the original prepared-parameter identity problem. Later, #26531
added strict HashMap iterator row-range validation and incorrectly treated a
physical length-1 const vector as a flat vector. Prepared `GROUP BY ?` therefore
fails whenever the input batch contains more than one logical row.

This change preserves strict bounds for flat vectors while accepting non-empty
const and const-null vectors as broadcast inputs, matching the existing IntHashMap
and StrHashMap encoders. Zero-length const vectors are still rejected whenever
rows are requested.

Validation on the `4.2-dev` base (`4066fffaf7`):

- malformed-flat and const-broadcast regression tests, `-count=10`
- full `pkg/common/hashmap` test and race test
- `go build` and `go vet` for `pkg/common/hashmap`
- `validateIteratorVectors` coverage: `100%`

The cherry-picked commit retains `-x` provenance for #26836.
