### PR TITLE
fix(plan): preserve forced index access for ORDER BY

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -772,6 +772,63 @@ func indexLeadingColumnsMatch(idxDef *plan.IndexDef, tableDef *plan.TableDef, co
 	return true
 }
 
+func indexOrderColumnsMatch(idxDef *plan.IndexDef, scanNode *plan.Node, colPositions []int32) bool {
+	if idxDef == nil || scanNode == nil || scanNode.TableDef == nil || len(scanNode.BindingTags) == 0 || len(colPositions) == 0 {
+		return false
+	}
+
+	fixedPrefix := 0
+	for fixedPrefix < len(idxDef.Parts) && indexPartFixedByEquality(idxDef.Parts[fixedPrefix], scanNode) {
+		fixedPrefix++
+	}
+
+	nextPart := fixedPrefix
+	for _, colPos := range colPositions {
+		if colPos < 0 || int(colPos) >= len(scanNode.TableDef.Cols) {
+			return false
+		}
+		colName := scanNode.TableDef.Cols[colPos].Name
+		fixedOrderColumn := false
+		for i := 0; i < fixedPrefix; i++ {
+			if catalog.ResolveAlias(idxDef.Parts[i]) == colName {
+				fixedOrderColumn = true
+				break
+			}
+		}
+		if fixedOrderColumn {
+			continue
+		}
+		if nextPart >= len(idxDef.Parts) || catalog.ResolveAlias(idxDef.Parts[nextPart]) != colName {
+			return false
+		}
+		nextPart++
+	}
+	return true
+}
+
+func indexPartFixedByEquality(part string, scanNode *plan.Node) bool {
+	colPos, ok := scanNode.TableDef.Name2ColIndex[catalog.ResolveAlias(part)]
+	if !ok {
+		return false
+	}
+	tag := scanNode.BindingTags[0]
+	for _, filter := range scanNode.FilterList {
+		fn := filter.GetF()
+		if fn == nil || fn.Func == nil || fn.Func.ObjName != "=" || len(fn.Args) != 2 {
+			continue
+		}
+		leftCol := fn.Args[0].GetCol()
+		rightCol := fn.Args[1].GetCol()
+		if leftCol != nil && leftCol.RelPos == tag && leftCol.ColPos == colPos && isRuntimeConstExpr(fn.Args[1]) {
+			return true
+		}
+		if rightCol != nil && rightCol.RelPos == tag && rightCol.ColPos == colPos && isRuntimeConstExpr(fn.Args[0]) {
+			return true
+		}
+	}
+	return false
+}
+
 type forceIndexScope int
 
 const (
@@ -962,8 +1019,14 @@ func (builder *QueryBuilder) applyForceIndexHintToScan(scanNode *plan.Node, requ
 		indexes := filterIndexesByHintScope(scanNode.TableDef.Indexes, scope)
 		for _, idxDef := range indexes {
 			if !usableRegularHintIndex(idxDef) ||
-				(hintSet.join.forceSpecified && !indexAllowedByHintScope(idxDef.IndexName, hintSet.join)) ||
-				!indexLeadingColumnsMatch(idxDef, scanNode.TableDef, colPositions) {
+				(hintSet.join.forceSpecified && !indexAllowedByHintScope(idxDef.IndexName, hintSet.join)) {
+				continue
+			}
+			columnsMatch := indexLeadingColumnsMatch(idxDef, scanNode.TableDef, colPositions)
+			if requirement.scope == forceIndexForOrder {
+				columnsMatch = indexOrderColumnsMatch(idxDef, scanNode, colPositions)
+			}
+			if !columnsMatch {
 				continue
 			}
 			accessNodeID, idxNodeID, covering, err := builder.tryHintedIndexAccess(idxDef, scanNode, colRefCnt, idxColMap)
@@ -987,7 +1050,14 @@ func (builder *QueryBuilder) applyForceIndexHintToScan(scanNode *plan.Node, requ
 			return accessNodeID, nil
 		}
 		if hintSet.join.forceSpecified {
-			return builder.applyForcedJoinHintToScan(scanNode, hintSet.join, colRefCnt, idxColMap)
+			return builder.applyForcedHintAccessToScan(scanNode, hintSet.join, colRefCnt, idxColMap)
+		}
+		if requirement.scope == forceIndexForOrder && hintSet.scan.forceSpecified {
+			// An unscoped FORCE INDEX constrains access as well as ordering. If the
+			// named index cannot provide this ORDER BY, retain the forced access and
+			// let the Sort enforce ordering. An explicit FORCE INDEX FOR ORDER BY has
+			// no scan-scope fallback and therefore leaves base access unchanged.
+			return builder.applyForcedHintAccessToScan(scanNode, hintSet.scan, colRefCnt, idxColMap)
 		}
 		// A FORCE hint that cannot provide the requested ordering/grouping still
 		// excludes other secondary indexes from replacing the base scan.
@@ -997,11 +1067,11 @@ func (builder *QueryBuilder) applyForceIndexHintToScan(scanNode *plan.Node, requ
 	return scanNode.NodeId, nil
 }
 
-// applyForcedJoinHintToScan resolves incompatible ORDER/GROUP and JOIN force
-// scopes before a covering access publishes hidden-column replacements to its
-// ancestors. JOIN access has the same precedence that applyIndicesForJoins
-// historically enforced, but choosing it here keeps the replacement atomic.
-func (builder *QueryBuilder) applyForcedJoinHintToScan(scanNode *plan.Node, scope indexHintScopeSet,
+// applyForcedHintAccessToScan resolves a forced access scope before a covering
+// access publishes hidden-column replacements to its ancestors. JOIN access
+// has the same precedence that applyIndicesForJoins historically enforced, but
+// choosing it here keeps the replacement atomic.
+func (builder *QueryBuilder) applyForcedHintAccessToScan(scanNode *plan.Node, scope indexHintScopeSet,
 	colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr) (int32, error) {
 	if indexAllowedByHintScope(PrimaryKeyName, scope) {
 		builder.protectedScans[scanNode.NodeId]++

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -27,6 +27,7 @@ import (
 	indexplugin "github.com/matrixorigin/matrixone/pkg/indexplugin"
 	planplugin "github.com/matrixorigin/matrixone/pkg/indexplugin/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
 )
 
@@ -819,13 +820,54 @@ func indexPartFixedByEquality(part string, scanNode *plan.Node) bool {
 		}
 		leftCol := fn.Args[0].GetCol()
 		rightCol := fn.Args[1].GetCol()
-		if leftCol != nil && leftCol.RelPos == tag && leftCol.ColPos == colPos && isRuntimeConstExpr(fn.Args[1]) {
+		if leftCol != nil && leftCol.RelPos == tag && leftCol.ColPos == colPos && isScanInvariantRuntimeConstExpr(fn.Args[1]) {
 			return true
 		}
-		if rightCol != nil && rightCol.RelPos == tag && rightCol.ColPos == colPos && isRuntimeConstExpr(fn.Args[0]) {
+		if rightCol != nil && rightCol.RelPos == tag && rightCol.ColPos == colPos && isScanInvariantRuntimeConstExpr(fn.Args[0]) {
 			return true
 		}
 	}
+	return false
+}
+
+// isScanInvariantRuntimeConstExpr is stricter than isRuntimeConstExpr: an
+// expression can be independent of table columns while still producing a new
+// value for every row. Such volatile expressions cannot fix an index prefix to
+// one value for the duration of a scan.
+func isScanInvariantRuntimeConstExpr(expr *plan.Expr) bool {
+	return !containsVolatileFunction(expr) && isRuntimeConstExpr(expr)
+}
+
+func containsVolatileFunction(expr *plan.Expr) bool {
+	if expr == nil {
+		return true
+	}
+
+	switch exprImpl := expr.Expr.(type) {
+	case *plan.Expr_F:
+		if exprImpl.F == nil || exprImpl.F.Func == nil {
+			return true
+		}
+		overload, ok := function.GetFunctionByIdWithoutError(exprImpl.F.Func.Obj)
+		if !ok || overload.CannotFold() {
+			return true
+		}
+		for _, arg := range exprImpl.F.Args {
+			if containsVolatileFunction(arg) {
+				return true
+			}
+		}
+	case *plan.Expr_List:
+		if exprImpl.List == nil {
+			return true
+		}
+		for _, item := range exprImpl.List.List {
+			if containsVolatileFunction(item) {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -294,6 +294,182 @@ func TestIndexHintOrderScopePreservesCoveringIndexFilters(t *testing.T) {
 	require.Nil(t, indexScan.IndexReaderParam)
 }
 
+func TestForceIndexOrderAcceptsEqualityFixedLeadingPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		descending bool
+		backfill   bool
+	}{
+		{
+			name: "ascending covering without limit",
+			sql: `select id, a, b from index_hint_t force index for order by(idx_ab)
+				where a = 1 and b between 10 and 20 order by b, id`,
+		},
+		{
+			name: "descending noncovering with limit",
+			sql: `select payload from index_hint_t force index for order by(idx_ab)
+				where a = 1 and b between 10 and 20 order by b desc, id desc limit 10`,
+			descending: true,
+			backfill:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			addIndexHintChoiceTableForTest(mock)
+			addIndexHintPayloadColumnForTest(mock)
+
+			queryPlan, err := runOneStmt(mock, t, tt.sql)
+			require.NoError(t, err)
+			indexScan := findFirstIndexScanNode(queryPlan)
+			require.NotNil(t, indexScan)
+			require.Equal(t, "idx_ab", indexScan.IndexScanInfo.IndexName)
+			require.NotEmpty(t, indexScan.OrderBy)
+			require.Equal(t, tt.descending, indexScan.OrderBy[0].Flag&planpb.OrderBySpec_DESC != 0)
+			require.Equal(t, tt.backfill, planHasIndexJoin(queryPlan))
+			require.True(t, planHasSort(queryPlan))
+		})
+	}
+}
+
+func TestIndexOrderColumnsMatchEqualityFixedPrefix(t *testing.T) {
+	const scanTag int32 = 41
+	intType := planpb.Type{Id: int32(types.T_int32)}
+	tableDef := &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{Name: "id", Typ: intType},
+			{Name: "a", Typ: intType},
+			{Name: "b", Typ: intType},
+		},
+		Name2ColIndex: map[string]int32{"id": 0, "a": 1, "b": 2},
+	}
+
+	literalEquality := func(commuted bool, relPos int32) *planpb.Expr {
+		expr := makeEqFilterExpr(1)
+		expr.GetF().Args[0].GetCol().RelPos = relPos
+		if commuted {
+			expr.GetF().Args[0], expr.GetF().Args[1] = expr.GetF().Args[1], expr.GetF().Args[0]
+		}
+		return expr
+	}
+	columnEquality := makeEqFilterExpr(1)
+	columnEquality.GetF().Args[0].GetCol().RelPos = scanTag
+	columnEquality.GetF().Args[1] = GetColExpr(intType, scanTag, 2)
+	nonEquality := makeEqFilterExpr(1)
+	nonEquality.GetF().Func.ObjName = ">"
+	nonEquality.GetF().Args[0].GetCol().RelPos = scanTag
+
+	tests := []struct {
+		name       string
+		parts      []string
+		filters    []*planpb.Expr
+		orderCols  []int32
+		compatible bool
+	}{
+		{name: "literal fixes leading part", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{2, 0}, compatible: true},
+		{name: "commuted literal fixes leading part", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(true, scanTag)}, orderCols: []int32{2, 0}, compatible: true},
+		{name: "fixed part is order neutral", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{1, 2, 0}, compatible: true},
+		{name: "order by fixed part only", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{1}, compatible: true},
+		{name: "column equality does not fix a value", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{columnEquality}, orderCols: []int32{2, 0}},
+		{name: "foreign binding does not fix scan column", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag+1)}, orderCols: []int32{2, 0}},
+		{name: "non equality does not fix a value", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{nonEquality}, orderCols: []int32{2, 0}},
+		{name: "unconstrained suffix cannot be skipped", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{0}},
+		{name: "order cannot extend past index suffix", parts: []string{"a"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{2}},
+		{name: "missing index part metadata is not fixed", parts: []string{"missing", "b"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{2}},
+		{name: "invalid order column is rejected", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{3}},
+		{name: "empty order is rejected", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanNode := &planpb.Node{
+				BindingTags: []int32{scanTag},
+				TableDef:    tableDef,
+				FilterList:  tt.filters,
+			}
+			idxDef := &planpb.IndexDef{Parts: tt.parts}
+			require.Equal(t, tt.compatible, indexOrderColumnsMatch(idxDef, scanNode, tt.orderCols))
+		})
+	}
+}
+
+func TestPlainForceIndexRetainsAccessWhenOrderIsIncompatible(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		backfill bool
+	}{
+		{
+			name: "in predicate fixes multiple leading values",
+			sql:  "select id, a, b from index_hint_t force index(idx_ab) where a in (1, 2) order by b, id",
+		},
+		{
+			name: "range predicate leaves leading part varying with limit",
+			sql:  "select id, a, b from index_hint_t force index(idx_ab) where a between 1 and 2 order by b desc, id desc limit 10",
+		},
+		{
+			name:     "unconstrained middle part noncovering",
+			sql:      "select payload from index_hint_t force index(idx_ab) where a = 1 order by id",
+			backfill: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			addIndexHintChoiceTableForTest(mock)
+			addIndexHintPayloadColumnForTest(mock)
+
+			queryPlan, err := runOneStmt(mock, t, tt.sql)
+			require.NoError(t, err)
+			indexScan := findFirstIndexScanNode(queryPlan)
+			require.NotNil(t, indexScan)
+			require.Equal(t, "idx_ab", indexScan.IndexScanInfo.IndexName)
+			require.Empty(t, indexScan.OrderBy)
+			require.Equal(t, tt.backfill, planHasIndexJoin(queryPlan))
+			require.True(t, planHasSort(queryPlan))
+		})
+	}
+}
+
+func TestForceIndexOrderIncompatibleControls(t *testing.T) {
+	t.Run("order-scoped force does not become scan force", func(t *testing.T) {
+		mock := NewMockOptimizer(true)
+		addIndexHintChoiceTableForTest(mock)
+
+		queryPlan, err := runOneStmt(mock, t,
+			"select id from index_hint_t force index for order by(idx_ab) where a = 1 order by id")
+		require.NoError(t, err)
+		require.Empty(t, findFirstIndexScanName(queryPlan))
+		require.True(t, planHasSort(queryPlan))
+	})
+
+	t.Run("ordinary optimizer remains unforced", func(t *testing.T) {
+		mock := NewMockOptimizer(true)
+		addIndexHintChoiceTableForTest(mock)
+
+		queryPlan, err := runOneStmt(mock, t,
+			"select id from index_hint_t where b = 1 order by b, id")
+		require.NoError(t, err)
+		require.Empty(t, findFirstIndexScanName(queryPlan))
+		require.True(t, planHasSort(queryPlan))
+	})
+
+	t.Run("invalid plain force still errors", func(t *testing.T) {
+		mock := NewMockOptimizer(true)
+		addIndexHintChoiceTableForTest(mock)
+
+		_, err := runOneStmt(mock, t,
+			"select id from index_hint_t force index(idx_missing) where a = 1 order by b, id")
+		require.Error(t, err)
+		var moErr *moerr.Error
+		require.ErrorAs(t, err, &moErr)
+		require.Equal(t, moerr.ER_KEY_DOES_NOT_EXIST, moErr.MySQLCode())
+	})
+}
+
 func TestIgnoreIndexForOrderByBlocksCoveringIndexOrderedRead(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	addIndexHintChoiceTableForTest(mock)
@@ -1877,6 +2053,17 @@ func addGroupedJoinAlternativeIndexForTest(mock *MockOptimizer) {
 	mock.ctxt.pks[indexTable.Name] = []int{0}
 }
 
+func addIndexHintPayloadColumnForTest(mock *MockOptimizer) {
+	tableDef := mock.ctxt.tables["index_hint_t"]
+	payloadPos := int32(len(tableDef.Cols))
+	tableDef.Cols = append(tableDef.Cols, &planpb.ColDef{
+		ColId: 4, Name: "payload", OriginName: "payload",
+		Typ:     planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+		Default: &planpb.Default{NullAbility: true},
+	})
+	tableDef.Name2ColIndex["payload"] = payloadPos
+}
+
 func addIndexHintIndexTableForTest(mock *MockOptimizer, name string, tableID uint64) {
 	keyType := planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
 	pkType := planpb.Type{Id: int32(types.T_int32), NotNullable: true}
@@ -1932,6 +2119,18 @@ func planHasIndexJoin(p *Plan) bool {
 	}
 	for _, node := range p.GetQuery().Nodes {
 		if node.NodeType == planpb.Node_JOIN && node.JoinType == planpb.Node_INDEX {
+			return true
+		}
+	}
+	return false
+}
+
+func planHasSort(p *Plan) bool {
+	if p == nil || p.GetQuery() == nil {
+		return false
+	}
+	for _, node := range p.GetQuery().Nodes {
+		if node.NodeType == planpb.Node_SORT {
 			return true
 		}
 	}

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -354,6 +354,12 @@ func TestIndexOrderColumnsMatchEqualityFixedPrefix(t *testing.T) {
 		}
 		return expr
 	}
+	parameterEquality := makeEqFilterExpr(1)
+	parameterEquality.GetF().Args[0].GetCol().RelPos = scanTag
+	parameterEquality.GetF().Args[1] = &planpb.Expr{
+		Typ:  intType,
+		Expr: &planpb.Expr_P{P: &planpb.ParamRef{Pos: 0}},
+	}
 	columnEquality := makeEqFilterExpr(1)
 	columnEquality.GetF().Args[0].GetCol().RelPos = scanTag
 	columnEquality.GetF().Args[1] = GetColExpr(intType, scanTag, 2)
@@ -370,6 +376,7 @@ func TestIndexOrderColumnsMatchEqualityFixedPrefix(t *testing.T) {
 	}{
 		{name: "literal fixes leading part", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{2, 0}, compatible: true},
 		{name: "commuted literal fixes leading part", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(true, scanTag)}, orderCols: []int32{2, 0}, compatible: true},
+		{name: "parameter fixes leading part", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{parameterEquality}, orderCols: []int32{2, 0}, compatible: true},
 		{name: "fixed part is order neutral", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{1, 2, 0}, compatible: true},
 		{name: "order by fixed part only", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{literalEquality(false, scanTag)}, orderCols: []int32{1}, compatible: true},
 		{name: "column equality does not fix a value", parts: []string{"a", "b", "id"}, filters: []*planpb.Expr{columnEquality}, orderCols: []int32{2, 0}},
@@ -435,6 +442,26 @@ func TestPlainForceIndexRetainsAccessWhenOrderIsIncompatible(t *testing.T) {
 }
 
 func TestForceIndexOrderIncompatibleControls(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		predicate string
+	}{
+		{name: "volatile right operand", predicate: "a = floor(rand() * 2)"},
+		{name: "volatile left operand", predicate: "floor(rand() * 2) = a"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			addIndexHintChoiceTableForTest(mock)
+			mock.ctxt.tables["index_hint_t"].Cols[1].Typ = planpb.Type{Id: int32(types.T_float64)}
+
+			queryPlan, err := runOneStmt(mock, t,
+				"select id, a, b from index_hint_t force index for order by(idx_ab) where "+tt.predicate+" order by b, id")
+			require.NoError(t, err)
+			require.Empty(t, findFirstIndexScanName(queryPlan))
+			require.True(t, planHasSort(queryPlan))
+		})
+	}
+
 	t.Run("order-scoped force does not become scan force", func(t *testing.T) {
 		mock := NewMockOptimizer(true)
 		addIndexHintChoiceTableForTest(mock)

--- a/test/distributed/cases/optimizer/index_hint.result
+++ b/test/distributed/cases/optimizer/index_hint.result
@@ -100,6 +100,153 @@ limit 8;
 42  ¦  g02  ¦  5  ¦  29  𝄀
 192  ¦  g02  ¦  7  ¦  19  𝄀
 82  ¦  g02  ¦  8  ¦  44
+explain select id,a,b,c
+from t force index for order by(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b,c,id;
+-- @regex("Index Table Scan.*idx_a_b_c_id", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: serial_extract(__mo_index_idx_col, 1, INT)) INTERNAL, serial_extract(__mo_index_idx_col, 2, INT)) INTERNAL, __mo_index_pri_col INTERNAL  𝄀
+        ->  Index Table Scan on t.idx_a_b_c_id  𝄀
+              Sort Key: __mo_index_idx_col INTERNAL  𝄀
+              Filter Cond: (serial_extract(__mo_index_idx_col, 0, VARCHAR)) = 'g02'), serial_extract(__mo_index_idx_col, 1, INT)) BETWEEN 1 AND 8
+select id,a,b,c
+from t force index for order by(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b,c,id;
+➤ id[4,32,0]  ¦  a[12,8,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+112  ¦  g02  ¦  1  ¦  42  𝄀
+2  ¦  g02  ¦  2  ¦  14  𝄀
+152  ¦  g02  ¦  4  ¦  4  𝄀
+42  ¦  g02  ¦  5  ¦  29  𝄀
+192  ¦  g02  ¦  7  ¦  19  𝄀
+82  ¦  g02  ¦  8  ¦  44
+explain select id,status,b,c
+from t force index(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b desc,c desc,id desc
+limit 4;
+-- @regex("Index Table Scan.*idx_a_b_c_id", true)
+-- @regex("Join Type: INDEX", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: t.b DESC, t.c DESC, t.id DESC  𝄀
+        Limit: 4  𝄀
+        ->  Join  𝄀
+              Join Type: INDEX  𝄀
+              Join Cond: (t.id = __mo_index_pri_col)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on mysql_compat_index_hint.t [ForceOneCN]  𝄀
+                    Filter Cond: (t.a = 'g02'), t.b BETWEEN 1 AND 8  𝄀
+                    Runtime Filter Probe: t.id  𝄀
+              ->  Index Table Scan on t.idx_a_b_c_id [ForceOneCN]  𝄀
+                    Sort Key: __mo_index_idx_col DESC
+select id,status,b,c
+from t force index(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b desc,c desc,id desc
+limit 4;
+➤ id[4,32,0]  ¦  status[12,12,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+82  ¦  archived  ¦  8  ¦  44  𝄀
+192  ¦  active  ¦  7  ¦  19  𝄀
+42  ¦  archived  ¦  5  ¦  29  𝄀
+152  ¦  active  ¦  4  ¦  4
+explain select id,a,b
+from t force index(idx_a_b_c_id)
+where a in ('g01','g02')
+order by b,id;
+-- @regex("Index Table Scan.*idx_a_b_c_id", true)
+-- @regex("Sort", true)
+-- @regex("Index Reader Param", false)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: serial_extract(__mo_index_idx_col, 1, INT)) INTERNAL, __mo_index_pri_col INTERNAL  𝄀
+        ->  Index Table Scan on t.idx_a_b_c_id  𝄀
+              Filter Cond: serial_extract(__mo_index_idx_col, 0, VARCHAR)) in ([g01 g02])
+select id,a,b
+from t force index(idx_a_b_c_id)
+where a in ('g01','g02')
+order by b,id;
+➤ id[4,32,0]  ¦  a[12,8,0]  ¦  b[4,32,0]  𝄀
+222  ¦  g02  ¦  0  𝄀
+112  ¦  g02  ¦  1  𝄀
+2  ¦  g02  ¦  2  𝄀
+152  ¦  g02  ¦  4  𝄀
+42  ¦  g02  ¦  5  𝄀
+81  ¦  g01  ¦  7  𝄀
+192  ¦  g02  ¦  7  𝄀
+82  ¦  g02  ¦  8  𝄀
+232  ¦  g02  ¦  10
+explain select id,a,b
+from t force index(idx_a_b_c_id)
+where a between 'g01' and 'g02'
+order by b,id;
+-- @regex("Index Table Scan.*idx_a_b_c_id", true)
+-- @regex("Sort", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: serial_extract(__mo_index_idx_col, 1, INT)) INTERNAL, __mo_index_pri_col INTERNAL  𝄀
+        ->  Index Table Scan on t.idx_a_b_c_id  𝄀
+              Filter Cond: serial_extract(__mo_index_idx_col, 0, VARCHAR)) BETWEEN 'g01' AND 'g02'
+select count(*) as range_rows, count(distinct id) as range_ids
+from (
+select id
+from t force index(idx_a_b_c_id)
+where a between 'g01' and 'g02'
+order by b,id
+) forced_range;
+➤ range_rows[-5,64,0]  ¦  range_ids[-5,64,0]  𝄀
+9  ¦  9
+explain select id,a,c
+from t force index(idx_a_b_c_id)
+where a = 'g02'
+order by c,id;
+-- @regex("Index Table Scan.*idx_a_b_c_id", true)
+-- @regex("Sort", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: serial_extract(__mo_index_idx_col, 2, INT)) INTERNAL, __mo_index_pri_col INTERNAL  𝄀
+        ->  Index Table Scan on t.idx_a_b_c_id  𝄀
+              Filter Cond: (serial_extract(__mo_index_idx_col, 0, VARCHAR)) = 'g02')
+select id,a,c
+from t force index(idx_a_b_c_id)
+where a = 'g02'
+order by c,id;
+➤ id[4,32,0]  ¦  a[12,8,0]  ¦  c[4,32,0]  𝄀
+152  ¦  g02  ¦  4  𝄀
+2  ¦  g02  ¦  14  𝄀
+222  ¦  g02  ¦  17  𝄀
+192  ¦  g02  ¦  19  𝄀
+42  ¦  g02  ¦  29  𝄀
+232  ¦  g02  ¦  34  𝄀
+112  ¦  g02  ¦  42  𝄀
+82  ¦  g02  ¦  44
+explain select id,a,c
+from t force index for order by(idx_a_b_c_id)
+where a = 'g02'
+order by c,id;
+-- @regex("Index Table Scan.*idx_a_b_c_id", false)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: t.c INTERNAL, t.id INTERNAL  𝄀
+        ->  Table Scan on mysql_compat_index_hint.t  𝄀
+              Filter Cond: (t.a = 'g02')
+explain select id,a,c
+from t
+order by c,id;
+-- @regex("Index Table Scan", false)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: t.c INTERNAL, t.id INTERNAL  𝄀
+        ->  Table Scan on mysql_compat_index_hint.t
 explain select a,count(*)
 from t force index for group by(idx_a_b_c_id)
 group by a;

--- a/test/distributed/cases/optimizer/index_hint.sql
+++ b/test/distributed/cases/optimizer/index_hint.sql
@@ -61,6 +61,98 @@ from t force index for order by(idx_a_b_c_id)
 order by a,b,c,id
 limit 8;
 
+-- Regression #26814: equality-fixed leading index parts are order-neutral, so
+-- ORDER BY may consume the remaining suffix. Both scoped ORDER force and plain
+-- FORCE must keep the named access; the latter also owns scan selection when
+-- the index cannot provide order.
+-- @separator:table
+-- @regex("Index Table Scan.*idx_a_b_c_id",true)
+explain select id,a,b,c
+from t force index for order by(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b,c,id;
+
+select id,a,b,c
+from t force index for order by(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b,c,id;
+
+-- @separator:table
+-- @regex("Index Table Scan.*idx_a_b_c_id",true)
+-- @regex("Join Type: INDEX",true)
+explain select id,status,b,c
+from t force index(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b desc,c desc,id desc
+limit 4;
+
+select id,status,b,c
+from t force index(idx_a_b_c_id)
+where a = 'g02' and b between 1 and 8
+order by b desc,c desc,id desc
+limit 4;
+
+-- IN and range predicates leave multiple leading values, so the Sort remains;
+-- plain FORCE still constrains access to the named index.
+-- @separator:table
+-- @regex("Index Table Scan.*idx_a_b_c_id",true)
+-- @regex("Sort",true)
+-- @regex("Index Reader Param",false)
+explain select id,a,b
+from t force index(idx_a_b_c_id)
+where a in ('g01','g02')
+order by b,id;
+
+select id,a,b
+from t force index(idx_a_b_c_id)
+where a in ('g01','g02')
+order by b,id;
+
+-- @separator:table
+-- @regex("Index Table Scan.*idx_a_b_c_id",true)
+-- @regex("Sort",true)
+explain select id,a,b
+from t force index(idx_a_b_c_id)
+where a between 'g01' and 'g02'
+order by b,id;
+
+select count(*) as range_rows, count(distinct id) as range_ids
+from (
+  select id
+  from t force index(idx_a_b_c_id)
+  where a between 'g01' and 'g02'
+  order by b,id
+) forced_range;
+
+-- Omitting an unconstrained middle part is not order-compatible. Plain FORCE
+-- keeps idx_a_b_c_id plus Sort, while ORDER-scoped FORCE does not become a scan
+-- force and ordinary optimization remains unchanged.
+-- @separator:table
+-- @regex("Index Table Scan.*idx_a_b_c_id",true)
+-- @regex("Sort",true)
+explain select id,a,c
+from t force index(idx_a_b_c_id)
+where a = 'g02'
+order by c,id;
+
+select id,a,c
+from t force index(idx_a_b_c_id)
+where a = 'g02'
+order by c,id;
+
+-- @separator:table
+-- @regex("Index Table Scan.*idx_a_b_c_id",false)
+explain select id,a,c
+from t force index for order by(idx_a_b_c_id)
+where a = 'g02'
+order by c,id;
+
+-- @separator:table
+-- @regex("Index Table Scan",false)
+explain select id,a,c
+from t
+order by c,id;
+
 -- @separator:table
 -- @regex("Index Table Scan.*idx_a_b_c_id",true)
 explain select a,count(*)


### PR DESCRIPTION
## Summary

- let forced ORDER BY access skip a contiguous leading index prefix fixed by single-value equality
- preserve plain `FORCE INDEX` as an access-path constraint when the named index cannot provide ordering, leaving `Sort` to enforce order
- keep `FORCE INDEX FOR ORDER BY` order-scoped and leave ordinary optimization unchanged

## Root cause

The force-index ORDER BY prepass required ORDER columns to match the physical index from part zero. For an index such as `(status, amount, id)`, it therefore rejected a fixed status prefix followed by `ORDER BY amount, id` even though that prefix is order-neutral. When the order match failed, base-scan protection also caused an unscoped plain `FORCE INDEX` to be silently discarded.

The matcher now skips only a contiguous prefix fixed by `column = runtime_constant`. IN, range, and unconstrained or gapped parts remain order-incompatible. If an unscoped plain force cannot satisfy order, the planner still builds the named covering scan or index backfill join without marking it ordered, so the existing Sort remains authoritative.

## Validation

Fresh validation from isolated worktree `/home/xupeng/github/matrixone-issue-26814`, based on `origin/main` `0676200da47052659cf46ad9e22d67ab9654e393`:

- regression reproduced before the production change: equality-prefix and plain-force fallback cases failed to retain the index
- focused force/order planner tests: pass
- full `pkg/sql/plan` suite: pass
- package `go build` and `go vet` with repository-local CGo paths: pass
- whole `make build`: pass
- isolated candidate-binary BVT `optimizer/index_hint.sql`: 53/53 statements pass
- pairwise merge plus focused/full planner suites with draft #26848: pass
- pairwise merge plus focused/full planner suites with draft #26850 (for #26803): pass

The regression matrix covers ASC/DESC, LIMIT/no LIMIT, equality/IN/range/gapped leading parts, covering/backfill access, invalid hints, unhinted optimization, and exact/distinct row checks.

No row-path benchmark was added: the new work is planner-only and bounded by index parts times scan filters plus ORDER columns.

Fixes #26814
