### PR TITLE
fix(incrservice): keep lazy cleanup cancelable

### DIFF
--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -419,11 +419,15 @@ func (s *sqlStore) ForceSetOffset(
 }
 
 func (s *sqlStore) Delete(ctx context.Context, tableID uint64) error {
+	// This is lazy GC for a dropped table whose globally allocated ID is not
+	// reused. Commit durability is sufficient: no later operation depends on
+	// this CN observing the deletion immediately. In particular, do not wait
+	// for committed logtail visibility here, because service shutdown cancels
+	// and joins this worker and that wait does not observe the worker context.
 	opts := executor.Options{}.
 		WithDatabase(database).
 		WithEnableTrace().
 		WithDisableWaitPaused().
-		WithWaitCommittedLogApplied().
 		WithStatementOption(executor.StatementOption{}.WithDisableLog())
 
 	return s.exec.ExecTxn(ctx,

--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -449,8 +449,8 @@ func (s *sqlStore) Delete(ctx context.Context, tableID uint64) error {
 				rowCount += rows
 				return true
 			})
+			res.Close()
 			if rowCount == 0 {
-				res.Close()
 				return nil
 			}
 			res, err = s.exec.Exec(

--- a/pkg/incrservice/store_sql_test.go
+++ b/pkg/incrservice/store_sql_test.go
@@ -49,12 +49,16 @@ func TestDeleteWhenAccountNotExists(t *testing.T) {
 
 	mockSqlExecutor := mock_executor.NewMockSQLExecutor(ctrl)
 	mockSqlExecutor.EXPECT().ExecTxn(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, execFunc func(txn executor.TxnExecutor) error, opts executor.Options) error {
+		require.False(t, opts.WaitCommittedLogApplied(),
+			"lazy metadata deletion must remain cancelable during service shutdown")
 		return execFunc(nil)
 	}).AnyTimes()
 
 	// account not exists
 	var executedSQLs []string
 	mockSqlExecutor.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, sql string, opts executor.Options) (executor.Result, error) {
+		require.False(t, opts.WaitCommittedLogApplied(),
+			"lazy metadata deletion statements must remain cancelable during service shutdown")
 		executedSQLs = append(executedSQLs, sql)
 		res := executor.Result{}
 		return res, nil
@@ -78,10 +82,14 @@ func TestDeleteWhenAccountExists(t *testing.T) {
 
 	mockSqlExecutor := mock_executor.NewMockSQLExecutor(ctrl)
 	mockSqlExecutor.EXPECT().ExecTxn(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, execFunc func(txn executor.TxnExecutor) error, opts executor.Options) error {
+		require.False(t, opts.WaitCommittedLogApplied(),
+			"lazy metadata deletion must remain cancelable during service shutdown")
 		return execFunc(nil)
 	}).AnyTimes()
 	var executedSQLs []string
 	mockSqlExecutor.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, sql string, opts executor.Options) (executor.Result, error) {
+		require.False(t, opts.WaitCommittedLogApplied(),
+			"lazy metadata deletion statements must remain cancelable during service shutdown")
 		executedSQLs = append(executedSQLs, sql)
 		bat := &batch.Batch{}
 		bat.SetRowCount(1)

--- a/pkg/incrservice/store_sql_test.go
+++ b/pkg/incrservice/store_sql_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
-	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
@@ -86,17 +85,24 @@ func TestDeleteWhenAccountExists(t *testing.T) {
 			"lazy metadata deletion must remain cancelable during service shutdown")
 		return execFunc(nil)
 	}).AnyTimes()
+	mp := mpool.MustNewZero()
+	accountResult := executor.NewMemResult([]types.Type{types.T_varchar.ToType()}, mp)
+	accountResult.NewBatchWithRowCount(1)
+	require.NoError(t, executor.AppendStringRows(accountResult, 0, []string{"account"}))
+	accountLookupResult := accountResult.GetResult()
+	t.Cleanup(func() {
+		accountLookupResult.Close()
+		mpool.DeleteMPool(mp)
+	})
 	var executedSQLs []string
 	mockSqlExecutor.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, sql string, opts executor.Options) (executor.Result, error) {
 		require.False(t, opts.WaitCommittedLogApplied(),
 			"lazy metadata deletion statements must remain cancelable during service shutdown")
 		executedSQLs = append(executedSQLs, sql)
-		bat := &batch.Batch{}
-		bat.SetRowCount(1)
-		res := executor.Result{
-			Batches: []*batch.Batch{bat},
+		if strings.HasPrefix(sql, "select account_name") {
+			return accountLookupResult, nil
 		}
-		return res, nil
+		return executor.Result{}, nil
 	}).AnyTimes()
 
 	s := &sqlStore{
@@ -106,6 +112,7 @@ func TestDeleteWhenAccountExists(t *testing.T) {
 	err := s.Delete(ctx, 0)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(executedSQLs))
+	require.Zero(t, mp.CurrNB(), "account lookup result must be closed")
 }
 
 var _ lockservice.LockService = new(testLockService)


### PR DESCRIPTION
## Summary

- stop dropped-table auto-increment metadata GC from requesting a committed-logtail visibility wait
- keep the fail-closed wait unchanged for allocation and offset update paths
- release the account lookup result before executing the metadata delete
- assert transaction/nested SQL options and mpool release in regression tests

## Root cause

`TestHashBuildSharedBudgetRecoverySQL` completed its main workload, but CN shutdown joined the auto-increment cleanup worker while it was deleting metadata for a dropped table. The delete inherited `WithWaitCommittedLogApplied` into the nested SQL execution. After the transaction committed, `SyncLatestCommitTS` waited with its own five-minute background timeout and did not observe the cleanup worker context, so teardown ended in the five-minute fatal timeout seen in both PR #26850 and PR #26806.

A second deep-review pass found that the successful account lookup result was overwritten by the subsequent delete result when the tenant existed. Its batches therefore never reached `Result.Close`, retaining their mpool allocation for every cleaned table. The lookup result is now closed immediately after reading it, and the test uses a real allocated result to verify that `CurrNB` returns to zero.

## Safety

This delete is lazy GC for a globally allocated table ID that is not reused. Commit durability is sufficient; no later operation requires the same CN to observe the deletion immediately. Failed deletes remain in the destroyed-table set and are retried. Allocation and offset mutation paths retain their committed-logtail waits.

## Validation

- focused delete tests plus the background `TestDelete`
- `go test ./pkg/incrservice`
- `go test -race ./pkg/incrservice`
- each of the three delete tests with adaptive race stress: `T=0/0/0.06s`, `B=30s`, `N=100`
- `TestHashBuildSharedBudgetRecoverySQL` normally and under race; race `T=18.28s`, `B=30s`, `N=1`
- `go build ./pkg/incrservice`
- `go vet ./pkg/incrservice`
- `golangci-lint run ./pkg/incrservice/...` (0 issues)

Failure examples:
- https://github.com/matrixorigin/matrixone/actions/runs/31321448737/job/93265096191
- https://github.com/matrixorigin/matrixone/actions/runs/31321617474/job/93265404854