### PR TITLE
ci: identify stalled exclusive race package

### DIFF
--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -237,6 +237,8 @@ function run_tests(){
         local serial_test_scope
         local heavy_test_scope
         local light_test_scope
+        local package
+        local package_status=0
         local light_status=0
         local serial_status=0
         local heavy_status=0
@@ -295,8 +297,15 @@ function run_tests(){
         fi
 
         logger "INF" "Run exclusive race-test packages serially"
-        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} -short -v -json -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race $serial_test_scope >> $UT_REPORT
-        serial_status=$?
+        for package in ${serial_test_scope}; do
+            logger "INF" "Run exclusive race-test package ${package}"
+            LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} -short -v -json -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race "${package}" >> $UT_REPORT
+            package_status=$?
+            if (( package_status != 0 )); then
+                serial_status=1
+                logger "ERR" "Exclusive race-test package ${package} failed with status ${package_status}"
+            fi
+        done
 
         logger "INF" "Run heavy race-test packages with parallelism ${HEAVY_RACE_PARALLEL}"
         LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} -short -v -json -tags "${TAGS}" -p ${HEAVY_RACE_PARALLEL} -timeout "${UT_TIMEOUT}m" -race $heavy_test_scope >> $UT_REPORT


### PR DESCRIPTION
## What

Run exclusive race-test packages one at a time and log each package before invoking go test. Preserve serial execution, per-package timeout, continuation after failure, and aggregate failure status.

## Why

PR #26850 timed out in the exclusive race phase, but the raw Go JSON report was redirected to scratch storage and the outer 60-minute timeout killed the script before diagnostics were published. The job could only identify the phase, not the package that stalled.

With this change, the last visible package-start log identifies the active package even when the outer timeout terminates the script. Explicit failure logs also expose package exit status without waiting for report analysis.

Failure example: https://github.com/matrixorigin/matrixone/actions/runs/31325401600/job/93274844331

## Validation

- bash -n optools/run_ut.sh
- controlled behavior check using the exact modified loop: middle-package failure continues to the final package and retains aggregate failure; all-success scope retains success
- make -n ut UT_PARALLEL=6 UT_TIMEOUT=40
- git diff --check

## Performance

The exclusive scope remains serial and runs the same five package tests once each. This adds four bounded go command front-end invocations; build artifacts remain shared through the Go build cache.