### PR TITLE
[4.2-dev] fix(txn): preserve snapshot state on cancellation

### DIFF
--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -989,13 +989,20 @@ func (tc *txnOperator) updateSnapshot(
 		time.Time{},
 		UpdateSnapshotEvent,
 		func() error {
-			var err error
+			var (
+				next timestamp.Timestamp
+				err  error
+			)
 			if waiter, ok := tc.timestampWaiter.(closeAwareTimestampWaiter); ok {
-				tc.mu.txn.SnapshotTS, err = waiter.GetTimestampWithClose(ctx, ts, closeC)
+				next, err = waiter.GetTimestampWithClose(ctx, ts, closeC)
 			} else {
-				tc.mu.txn.SnapshotTS, err = tc.timestampWaiter.GetTimestamp(ctx, ts)
+				next, err = tc.timestampWaiter.GetTimestamp(ctx, ts)
 			}
-			return err
+			if err != nil {
+				return err
+			}
+			tc.mu.txn.SnapshotTS = next
+			return nil
 		},
 		true)
 	return err
@@ -1636,7 +1643,7 @@ func (tc *txnOperator) addPartitionLocked(tn metadata.TNShard) {
 
 func (tc *txnOperator) validate(ctx context.Context, locked bool) error {
 	if _, ok := ctx.Deadline(); !ok {
-		tc.logger.Fatal("context deadline not set")
+		return moerr.NewInvalidInput(ctx, "txn operation context deadline not set")
 	}
 
 	return tc.checkStatus(locked)

--- a/pkg/txn/client/operator_test.go
+++ b/pkg/txn/client/operator_test.go
@@ -824,17 +824,14 @@ func TestCheckLockTableBindsCleanSecondCallIsThrottled(t *testing.T) {
 	})
 }
 
-func TestContextWithoutDeadlineWillPanic(t *testing.T) {
-	runOperatorTests(t, func(_ context.Context, tc *txnOperator, _ *testTxnSender) {
-		defer func() {
-			if err := recover(); err != nil {
-				return
-			}
-			assert.Fail(t, "must panic")
-		}()
-
+func TestContextWithoutDeadlineReturnsError(t *testing.T) {
+	runOperatorTests(t, func(_ context.Context, tc *txnOperator, sender *testTxnSender) {
 		_, err := tc.Write(context.Background(), nil)
-		assert.NoError(t, err)
+		require.ErrorContains(t, err, "txn operation context deadline not set")
+
+		sender.Lock()
+		defer sender.Unlock()
+		require.Empty(t, sender.lastRequests)
 	})
 }
 
@@ -1084,6 +1081,30 @@ func TestUpdateSnapshotTSWithWaiter(t *testing.T) {
 				require.Equal(t, newTestTimestamp(ts).Next(), tc.Txn().SnapshotTS)
 			})
 	})
+}
+
+func TestUpdateSnapshotPreservesSnapshotOnWaitError(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		waiter TimestampWaiter
+	}{
+		{name: "close-aware waiter", waiter: &blockingTimestampWaiter{entered: make(chan struct{}, 1)}},
+		{name: "legacy waiter", waiter: &legacyBlockingTimestampWaiter{entered: make(chan struct{}, 1)}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runOperatorTests(t, func(_ context.Context, tc *txnOperator, _ *testTxnSender) {
+				initial := newTestTimestamp(10)
+				tc.timestampWaiter = test.waiter
+				tc.mu.txn.SnapshotTS = initial
+
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				err := tc.UpdateSnapshot(ctx, newTestTimestamp(20))
+				require.ErrorIs(t, err, context.Canceled)
+				require.Equal(t, initial, tc.SnapshotTS())
+			})
+		})
+	}
 }
 
 func TestRollbackMultiTimes(t *testing.T) {

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -267,11 +267,16 @@ func (txn *Transaction) WriteBatch(
 	tableName string,
 	bat *batch.Batch,
 	tnStore DNStore) (genRowidVec *vector.Vector, err error) {
-	return txn.writeBatchWithAutoIncrEpochKnown(typ, note, accountId, databaseId, tableId,
+	ctx := context.Background()
+	if txn.proc != nil && txn.proc.Ctx != nil {
+		ctx = txn.proc.Ctx
+	}
+	return txn.writeBatchWithAutoIncrEpochKnown(ctx, typ, note, accountId, databaseId, tableId,
 		databaseName, tableName, bat, tnStore, 0, false)
 }
 
 func (txn *Transaction) writeBatchWithAutoIncrEpoch(
+	ctx context.Context,
 	typ int, note string,
 	accountId uint32,
 	databaseId uint64,
@@ -282,11 +287,12 @@ func (txn *Transaction) writeBatchWithAutoIncrEpoch(
 	tnStore DNStore,
 	autoIncrEpoch uint32,
 ) (genRowidVec *vector.Vector, err error) {
-	return txn.writeBatchWithAutoIncrEpochKnown(typ, note, accountId, databaseId, tableId,
+	return txn.writeBatchWithAutoIncrEpochKnown(ctx, typ, note, accountId, databaseId, tableId,
 		databaseName, tableName, bat, tnStore, autoIncrEpoch, true)
 }
 
 func (txn *Transaction) writeBatchWithAutoIncrEpochKnown(
+	ctx context.Context,
 	typ int, note string,
 	accountId uint32,
 	databaseId uint64,
@@ -298,6 +304,12 @@ func (txn *Transaction) writeBatchWithAutoIncrEpochKnown(
 	autoIncrEpoch uint32,
 	autoIncrEpochKnown bool,
 ) (genRowidVec *vector.Vector, err error) {
+	if ctx == nil {
+		return nil, moerr.NewInvalidInputNoCtx("disttae workspace write context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if err := txn.requireAutoIncrEpochFenceCommit(autoIncrEpoch, autoIncrEpochKnown); err != nil {
 		return nil, err
 	}
@@ -329,6 +341,7 @@ func (txn *Transaction) writeBatchWithAutoIncrEpochKnown(
 		// internal SQL on the current txn and reenter txn.Lock via
 		// UpdateSnapshotWriteOffset. Resolve the PK position before taking txn.Lock.
 		pkCheckPos, pkCheckReady, err = txn.resolvePKCheckPosForWrite(
+			ctx,
 			typ,
 			accountId,
 			databaseName,
@@ -646,7 +659,7 @@ func checkPKDup(
 }
 
 // checkDup check whether the txn.writes has duplicate pk entry
-func (txn *Transaction) checkDup() error {
+func (txn *Transaction) checkDup(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
 		v2.TxnCheckPKDupDurationHistogram.Observe(time.Since(start).Seconds())
@@ -664,7 +677,7 @@ func (txn *Transaction) checkDup() error {
 			return idx, nil
 		}
 		if _, ok := tablesDef[e.tableId]; !ok {
-			tbl, err := txn.getTable(e.accountId, e.databaseName, e.tableName)
+			tbl, err := txn.getTable(ctx, e.accountId, e.databaseName, e.tableName)
 			if err != nil {
 				return -1, err
 			}
@@ -1050,7 +1063,7 @@ func (txn *Transaction) dumpInsertBatchLocked(
 	// Resolve every table that will be flushed BEFORE mutating txn.writes:
 	// getTable must never run while this goroutine holds the lock. See
 	// resolveDumpTablesLocked for the window contract.
-	tables, ok, err := txn.resolveDumpTablesLocked(offset, skipTable, INSERT)
+	tables, ok, err := txn.resolveDumpTablesLocked(ctx, offset, skipTable, INSERT)
 	if err != nil {
 		return err
 	}
@@ -1194,7 +1207,7 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 
 	// See the comment in dumpInsertBatchLocked: tables must be resolved
 	// while txn.writes is still consistent, with the lock released.
-	tables, ok, err := txn.resolveDumpTablesLocked(offset, nil, DELETE)
+	tables, ok, err := txn.resolveDumpTablesLocked(ctx, offset, nil, DELETE)
 	if err != nil {
 		return err
 	}
@@ -1345,6 +1358,7 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 // offset during the window, so there is nothing left this dump round may
 // safely touch.
 func (txn *Transaction) resolveDumpTablesLocked(
+	ctx context.Context,
 	offset int,
 	skipTable map[uint64]bool,
 	typ int,
@@ -1384,7 +1398,7 @@ func (txn *Transaction) resolveDumpTablesLocked(
 
 	txn.Unlock()
 	for _, k := range keys {
-		tbl, terr := txn.getTable(k.accountId, k.dbName, k.name)
+		tbl, terr := txn.getTable(ctx, k.accountId, k.dbName, k.name)
 		if terr != nil {
 			txn.Lock()
 			return nil, false, terr
@@ -1405,12 +1419,19 @@ func (txn *Transaction) resolveDumpTablesLocked(
 }
 
 func (txn *Transaction) getTable(
+	ctx context.Context,
 	id uint32,
 	dbName string,
 	tbName string,
 ) (engine.Relation, error) {
 	if txn.engine == nil {
 		return nil, moerr.NewInternalErrorNoCtx("disttae txn engine is nil")
+	}
+	if ctx == nil {
+		return nil, moerr.NewInvalidInputNoCtx("disttae table lookup context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	if injected, rogueUpdate, errorOut := objectio.CNReenterSnapshotOffsetOnGetTableInjected(); injected {
@@ -1443,11 +1464,7 @@ func (txn *Transaction) getTable(
 		return nil, moerr.NewInternalErrorNoCtx("disttae txn operator is nil")
 	}
 
-	ctx := context.WithValue(
-		context.Background(),
-		defines.TenantIDKey{},
-		id,
-	)
+	ctx = defines.AttachAccountId(ctx, id)
 
 	database, err := txn.engine.Database(ctx, dbName, txnOp)
 	if err != nil {
@@ -1461,6 +1478,7 @@ func (txn *Transaction) getTable(
 }
 
 func (txn *Transaction) resolvePKCheckPosForWrite(
+	ctx context.Context,
 	typ int,
 	accountId uint32,
 	databaseName, tableName string,
@@ -1484,15 +1502,11 @@ func (txn *Transaction) resolvePKCheckPosForWrite(
 		return -1, false, nil
 	}
 
-	tbl, err := txn.getTable(accountId, databaseName, tableName)
+	tbl, err := txn.getTable(ctx, accountId, databaseName, tableName)
 	if err != nil {
 		return -1, false, err
 	}
-	tableDefCtx := context.Background()
-	if txn.proc != nil && txn.proc.Ctx != nil {
-		tableDefCtx = txn.proc.Ctx
-	}
-	tableDef := tbl.GetTableDef(tableDefCtx)
+	tableDef := tbl.GetTableDef(defines.AttachAccountId(ctx, accountId))
 	if tableDef == nil || tableDef.Pkey == nil {
 		return -1, true, nil
 	}
@@ -2207,7 +2221,7 @@ func (txn *Transaction) mergeTxnWorkspaceLocked(ctx context.Context) error {
 // resolveDumpTablesLocked). Because other goroutines may add deletions while
 // the lock is released, the scan-resolve cycle repeats until every table
 // referenced by txn.deletedBlocks is resolved.
-func (txn *Transaction) resolveCompactTablesLocked() (map[tableKey]engine.Relation, error) {
+func (txn *Transaction) resolveCompactTablesLocked(ctx context.Context) (map[tableKey]engine.Relation, error) {
 	tables := make(map[tableKey]engine.Relation)
 	for {
 		var missing []tableKey
@@ -2232,7 +2246,7 @@ func (txn *Transaction) resolveCompactTablesLocked() (map[tableKey]engine.Relati
 
 		txn.Unlock()
 		for _, k := range missing {
-			tbl, err := txn.getTable(k.accountId, k.dbName, k.name)
+			tbl, err := txn.getTable(ctx, k.accountId, k.dbName, k.name)
 			if err != nil {
 				txn.Lock()
 				return nil, err
@@ -2253,7 +2267,7 @@ func (txn *Transaction) compactDeletionOnObjsLocked(ctx context.Context) error {
 	// resolve every affected table BEFORE building the compaction state and
 	// spawning workers; workers must not call getTable (see
 	// resolveCompactTablesLocked)
-	tables, err := txn.resolveCompactTablesLocked()
+	tables, err := txn.resolveCompactTablesLocked(ctx)
 	if err != nil {
 		return err
 	}
@@ -2715,7 +2729,7 @@ func (txn *Transaction) Commit(ctx context.Context) (reqs []txn.TxnRequest, err 
 
 	if !txn.hasS3Op.Load() &&
 		txn.op.TxnOptions().CheckDupEnabled() {
-		if err := txn.checkDup(); err != nil {
+		if err := txn.checkDup(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1912,6 +1912,7 @@ func (tbl *txnTable) Write(ctx context.Context, bat *batch.Batch) error {
 		return err
 	}
 	if _, err := tbl.getTxn().writeBatchWithAutoIncrEpoch(
+		ctx,
 		INSERT,
 		"",
 		tbl.accountId,
@@ -2044,6 +2045,12 @@ func (tbl *txnTable) Delete(
 	if tbl.db.op.IsSnapOp() {
 		return moerr.NewInternalErrorNoCtx("delete operation is not allowed in snapshot transaction")
 	}
+	if ctx == nil {
+		return moerr.NewInvalidInputNoCtx("disttae table delete context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	var (
 		deletionTyp = bat.Attrs[0]
@@ -2148,12 +2155,12 @@ func (tbl *txnTable) SoftDeleteObject(ctx context.Context, objID *objectio.Objec
 	return nil
 }
 
-func (tbl *txnTable) writeTnPartition(_ context.Context, bat *batch.Batch) error {
+func (tbl *txnTable) writeTnPartition(ctx context.Context, bat *batch.Batch) error {
 	ibat, err := util.CopyBatch(bat, tbl.getTxn().proc)
 	if err != nil {
 		return err
 	}
-	if _, err := tbl.getTxn().writeBatchWithAutoIncrEpoch(DELETE, "", tbl.accountId, tbl.db.databaseId, tbl.tableId,
+	if _, err := tbl.getTxn().writeBatchWithAutoIncrEpoch(ctx, DELETE, "", tbl.accountId, tbl.db.databaseId, tbl.tableId,
 		tbl.db.databaseName, tbl.tableName, ibat, tbl.getTxn().tnStores[0], tbl.extraInfo.AutoIncrEpoch); err != nil {
 		ibat.Clean(tbl.getTxn().proc.Mp())
 		return err

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -163,6 +163,7 @@ func TestAutoIncrEpochWritePathsRejectBeforeWorkspaceMutation(t *testing.T) {
 	t.Run("row", func(t *testing.T) {
 		txn := newTxn(t)
 		_, err := txn.writeBatchWithAutoIncrEpochKnown(
+			context.Background(),
 			INSERT, "", 1, 2, 3, "db", "tbl", nil, DNStore{}, 1, true,
 		)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNotSupported), err)
@@ -374,7 +375,7 @@ func TestWriteBatchRecordsPKCheckState(t *testing.T) {
 		txn := newTransactionWithActivePKTableForTest(t, "pk")
 		bat := newInt64BatchForTest(t, txn.proc, []string{"pk"}, []int64{1})
 
-		_, err := txn.writeBatchWithAutoIncrEpoch(INSERT, "", 1, 7, 42, "db", "tbl", bat, DNStore{}, 7)
+		_, err := txn.writeBatchWithAutoIncrEpoch(context.Background(), INSERT, "", 1, 7, 42, "db", "tbl", bat, DNStore{}, 7)
 		require.NoError(t, err)
 		require.Len(t, txn.writes, 1)
 		require.Equal(t, uint32(7), txn.writes[0].autoIncrEpoch)
@@ -417,7 +418,7 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 			},
 		}
 
-		err := txn.checkDup()
+		err := txn.checkDup(context.Background())
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 	})
@@ -442,7 +443,7 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 			},
 		}
 
-		err := txn.checkDup()
+		err := txn.checkDup(context.Background())
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 	})
@@ -477,7 +478,7 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, txn.checkDup())
+		require.NoError(t, txn.checkDup(context.Background()))
 	})
 
 	t.Run("out of range falls back to legacy", func(t *testing.T) {
@@ -496,7 +497,7 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 			},
 		}
 
-		err := txn.checkDup()
+		err := txn.checkDup(context.Background())
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 	})
@@ -516,7 +517,7 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 			},
 		}
 
-		err := txn.checkDup()
+		err := txn.checkDup(context.Background())
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 	})
@@ -536,7 +537,7 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 			},
 		}
 
-		err := txn.checkDup()
+		err := txn.checkDup(context.Background())
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 	})
@@ -556,7 +557,7 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, txn.checkDup())
+		require.NoError(t, txn.checkDup(context.Background()))
 	})
 }
 
@@ -611,20 +612,57 @@ func TestAdjustUpdateOrderLockedUsesAdjustedWriteOffset(t *testing.T) {
 func TestTransactionGetTableNilGuards(t *testing.T) {
 	txn := &Transaction{}
 
-	_, err := txn.getTable(0, "db", "tbl")
+	_, err := txn.getTable(context.Background(), 0, "db", "tbl")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "disttae txn engine is nil")
 
 	txn.engine = &Engine{}
-	_, err = txn.getTable(0, "db", "tbl")
+	_, err = txn.getTable(nil, 0, "db", "tbl")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "disttae table lookup context is nil")
+
+	_, err = txn.getTable(context.Background(), 0, "db", "tbl")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "disttae txn operator is nil")
+}
+
+func TestTxnTableWriteTnPartitionHonorsCanceledContext(t *testing.T) {
+	txn := newTransactionWithActivePKTableForTest(t, "pk")
+	txn.tnStores = []DNStore{{}}
+	tbl := txn.tableOps.existAndActive(genTableKey(1, "tbl", 7, "db"))
+	require.NotNil(t, tbl)
+	tbl.extraInfo = &api.SchemaExtra{}
+	bat := newDeleteBatchForTest(t, txn.proc, []int64{1})
+	defer bat.Clean(txn.proc.Mp())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := tbl.writeTnPartition(ctx, bat)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, txn.writes)
+}
+
+func TestTxnTableDeleteHonorsCanceledContext(t *testing.T) {
+	txn := newTransactionWithActivePKTableForTest(t, "pk")
+	txn.op.(*mock_frontend.MockTxnOperator).EXPECT().IsSnapOp().Return(false)
+	txn.tnStores = []DNStore{{}}
+	tbl := txn.tableOps.existAndActive(genTableKey(1, "tbl", 7, "db"))
+	require.NotNil(t, tbl)
+	tbl.extraInfo = &api.SchemaExtra{}
+	bat := newDeleteBatchForTest(t, txn.proc, []int64{1})
+	defer bat.Clean(txn.proc.Mp())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := tbl.Delete(ctx, bat, "")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, txn.writes)
 }
 
 func TestResolvePKCheckPosForWriteEarlyExit(t *testing.T) {
 	txn := &Transaction{}
 
-	pos, ready, err := txn.resolvePKCheckPosForWrite(INSERT, 0, "db", "tbl", 1, nil)
+	pos, ready, err := txn.resolvePKCheckPosForWrite(context.Background(), INSERT, 0, "db", "tbl", 1, nil)
 	require.NoError(t, err)
 	require.True(t, ready)
 	require.Equal(t, -1, pos)
@@ -632,17 +670,17 @@ func TestResolvePKCheckPosForWriteEarlyExit(t *testing.T) {
 	proc := testutil.NewProc(t)
 	bat := newInt64BatchForTest(t, proc, []string{"pk"}, []int64{1})
 
-	pos, ready, err = txn.resolvePKCheckPosForWrite(ALTER, 0, "db", "tbl", 1, bat)
+	pos, ready, err = txn.resolvePKCheckPosForWrite(context.Background(), ALTER, 0, "db", "tbl", 1, bat)
 	require.NoError(t, err)
 	require.True(t, ready)
 	require.Equal(t, -1, pos)
 
-	pos, ready, err = txn.resolvePKCheckPosForWrite(INSERT, 0, "db", "tbl", catalog.MO_TABLES_ID, bat)
+	pos, ready, err = txn.resolvePKCheckPosForWrite(context.Background(), INSERT, 0, "db", "tbl", catalog.MO_TABLES_ID, bat)
 	require.NoError(t, err)
 	require.True(t, ready)
 	require.Equal(t, -1, pos)
 
-	pos, ready, err = txn.resolvePKCheckPosForWrite(INSERT, 0, "db", "tbl", 42, bat)
+	pos, ready, err = txn.resolvePKCheckPosForWrite(context.Background(), INSERT, 0, "db", "tbl", 42, bat)
 	require.NoError(t, err)
 	require.False(t, ready)
 	require.Equal(t, -1, pos)
@@ -940,6 +978,7 @@ func TestResolvePKCheckPosForWriteWithActiveTxnTable(t *testing.T) {
 	txn := newTransactionWithActivePKTableForTest(t, "pk")
 
 	pos, ready, err := txn.resolvePKCheckPosForWrite(
+		context.Background(),
 		INSERT,
 		1,
 		"db",
@@ -952,6 +991,7 @@ func TestResolvePKCheckPosForWriteWithActiveTxnTable(t *testing.T) {
 	require.Equal(t, 0, pos)
 
 	pos, ready, err = txn.resolvePKCheckPosForWrite(
+		context.Background(),
 		INSERT,
 		1,
 		"db",
@@ -964,6 +1004,7 @@ func TestResolvePKCheckPosForWriteWithActiveTxnTable(t *testing.T) {
 	require.Equal(t, 0, pos)
 
 	pos, ready, err = txn.resolvePKCheckPosForWrite(
+		context.Background(),
 		DELETE,
 		1,
 		"db",
@@ -976,6 +1017,7 @@ func TestResolvePKCheckPosForWriteWithActiveTxnTable(t *testing.T) {
 	require.Equal(t, 1, pos)
 
 	pos, ready, err = txn.resolvePKCheckPosForWrite(
+		context.Background(),
 		INSERT,
 		1,
 		"db",


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26767

## What this PR does / why we need it:

Backport #26774 to `4.2-dev`.

- Publish a new transaction snapshot only after the timestamp waiter succeeds, so cancellation and waiter errors cannot replace a valid snapshot with `0-0`.
- Propagate the statement context through disttae workspace writes, table lookup, dump, compaction, and duplicate checking instead of detaching catalog lookup with a background context.
- Return an ordinary invalid-input error when a transaction operation has no context deadline instead of terminating the CN process.
- Reject canceled delete operations before workspace mutation and cover the cancellation paths with regression tests.

The existing statement rollback contract remains responsible for undoing workspace changes when cancellation arrives after a statement has already started mutating its workspace.

This is a clean cherry-pick of commit `d68c9083e9411e55264bc54bc3b88fe1d079396a` from #26774 onto `4.2-dev` at `60283acdd464788cc0a1f91ad3e035dddc9454c4`.

Validation:

- `go list`, `go build`, and `go vet` for `pkg/txn/client`, `pkg/vm/engine/disttae`, `pkg/sql/colexec/deletion`, and `pkg/sql/compile`.
- Full tests for those four packages.
- Full race tests for `pkg/txn/client` and `pkg/vm/engine/disttae`.
- Four focused cancellation/snapshot regressions under the race detector, each repeated 100 times.
- `git diff --check` and pre-push concurrency/unhappy-path self-review.