### PR TITLE
fix(window): stream split window results

### DIFF
--- a/pkg/sql/colexec/window/types.go
+++ b/pkg/sql/colexec/window/types.go
@@ -18,7 +18,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
@@ -31,6 +30,7 @@ var _ vm.Operator = new(Window)
 const (
 	receive = iota
 	eval
+	emit
 	done
 	receiveAll
 )
@@ -52,8 +52,8 @@ type container struct {
 
 	prepareParamKind aggexec.PrepareParamKindStates
 
-	vec  *vector.Vector
-	rBat *batch.Batch
+	emitOffset int
+	rBat       *batch.Batch
 
 	runtimeFrames []*plan.FrameClause
 }
@@ -103,6 +103,7 @@ func (window *Window) Release() {
 func (window *Window) Reset(proc *process.Process, pipelineFailed bool, err error) {
 	ctr := &window.ctr
 
+	ctr.cleanOutput(proc.Mp())
 	ctr.resetParam()
 	ctr.prepareParamKind.Reset(nil)
 	ctr.resetVectors()
@@ -114,16 +115,12 @@ func (window *Window) Reset(proc *process.Process, pipelineFailed bool, err erro
 	if ctr.bat != nil {
 		ctr.bat.CleanOnlyData()
 	}
-	// It needs to free, because the result of agg eval is not reuse the vector
-	if ctr.vec != nil {
-		ctr.vec.Free(proc.Mp())
-		ctr.vec = nil
-	}
 }
 
 func (window *Window) Free(proc *process.Process, pipelineFailed bool, err error) {
 	ctr := &window.ctr
 
+	ctr.cleanOutput(proc.Mp())
 	ctr.runtimeFrames = nil
 	// Free aggregators before the batch so an error exit from Call (which skips
 	// the normal freeAggFun()) does not leak their mpool-held state.
@@ -140,12 +137,24 @@ func (window *Window) ExecProjection(proc *process.Process, input *batch.Batch) 
 
 func (ctr *container) resetParam() {
 	ctr.status = receive
+	ctr.emitOffset = 0
 	ctr.desc = nil
 	ctr.nullsLast = nil
 	ctr.sels = nil
 	ctr.ps = nil
 	ctr.os = nil
 	ctr.runtimeFrames = nil
+}
+
+// cleanOutput releases the batch returned by the previous Call. Input-column
+// vectors in rBat are borrowed windows into ctr.bat; the appended window-result
+// vector is owned by rBat. The pipeline contract keeps a returned batch valid
+// until the next Call or Reset, so this is the earliest safe release point.
+func (ctr *container) cleanOutput(mp *mpool.MPool) {
+	if ctr.rBat != nil {
+		ctr.rBat.Clean(mp)
+		ctr.rBat = nil
+	}
 }
 
 func (ctr *container) resetVectors() {
@@ -202,7 +211,4 @@ func (ctr *container) freeVector(mp *mpool.MPool) {
 		}
 	}
 
-	if ctr.vec != nil {
-		ctr.vec.Free(mp)
-	}
 }

--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -198,6 +198,10 @@ func (window *Window) Call(proc *process.Process) (vm.CallResult, error) {
 
 	var err error
 	ctr := &window.ctr
+	// A returned batch is valid through the caller's processing of it. Once the
+	// next Call begins, release its borrowed input windows and owned result
+	// vector before reusing any operator state.
+	ctr.cleanOutput(proc.Mp())
 
 	for {
 		if err, canceled := vm.CancelCheck(proc); canceled {
@@ -218,6 +222,9 @@ func (window *Window) Call(proc *process.Process) (vm.CallResult, error) {
 					}
 					break
 				}
+				if result.Batch.IsEmpty() {
+					continue
+				}
 				ctr.bat, err = ctr.bat.AppendWithCopy(proc.Ctx, proc.Mp(), result.Batch)
 				if err != nil {
 					return result, err
@@ -230,6 +237,8 @@ func (window *Window) Call(proc *process.Process) (vm.CallResult, error) {
 			}
 			if result.Batch == nil {
 				ctr.status = done
+			} else if result.Batch.IsEmpty() {
+				continue
 			} else {
 				ctr.status = eval
 				if ctr.bat != nil {
@@ -254,78 +263,55 @@ func (window *Window) Call(proc *process.Process) (vm.CallResult, error) {
 				}
 			}
 
-			ctr.batAggs = make([]aggexec.AggFuncExec, len(window.Aggs))
-			for i, ag := range window.Aggs {
-				// Skip AggFuncExec creation for WIN_VALUE functions (lag/lead/first_value/last_value/nth_value)
-				// as they are handled directly in processValueFunc.
-				winName := window.WinSpecList[i].Expr.(*plan.Expr_W).W.Name
-				if function.GetFunctionIsWinValueFunByName(winName) {
-					continue
-				}
-				// Derive one argument type per aggregate argument so multi-argument
-				// window aggregates (e.g. json_objectagg) receive all their types,
-				// mirroring the group operator (colexec/group/helper.go).
-				argExprs := ag.GetArgExpressions()
-				argTypes := make([]types.Type, len(argExprs))
-				for j, arg := range argExprs {
-					argTypes[j] = types.NewWithCharset(
-						types.T(arg.Typ.Id), arg.Typ.Width, arg.Typ.Scale, uint8(arg.Typ.Charset),
-					)
-				}
-				ctr.batAggs[i], err = aggexec.MakeAgg(proc.Mp(), ag.GetAggID(), ag.IsDistinct(), argTypes...)
-				if err != nil {
-					return result, err
-				}
-				if config := ag.GetExtraInformation(); config != nil {
-					if err = ctr.batAggs[i].SetExtraInformation(config, 0); err != nil {
-						return result, err
-					}
-				}
-				if err = ctr.batAggs[i].GroupGrow(ctr.bat.RowCount()); err != nil {
-					return result, err
-				}
-			}
-			// calculate
-			for i, w := range window.WinSpecList {
-				if err = checkCanceled(proc, 0); err != nil {
-					return result, err
-				}
-				// sort and partitions
-				if window.Fs = makeOrderBy(w); window.Fs != nil {
-					if len(ctr.orderVecs) == 0 {
-						ctr.orderVecs = make([]colexec.ExprEvalVector, len(window.Fs))
-						for j := range ctr.orderVecs {
-							ctr.orderVecs[j], err = colexec.MakeEvalVector(proc, []*plan.Expr{window.Fs[j].Expr})
-							if err != nil {
-								return result, err
-							}
+			// Query planning creates one Window operator per window expression.
+			// Keep the materialized and sorted logical partition, then evaluate it
+			// lazily in bounded output chunks. A LIMIT consumer can stop after the
+			// first chunk without forcing the remaining frame calculations.
+			ctr.ps = nil
+			ctr.os = nil
+			ctr.sels = nil
+			w := window.WinSpecList[0]
+			if window.Fs = makeOrderBy(w); window.Fs != nil {
+				if len(ctr.orderVecs) == 0 {
+					ctr.orderVecs = make([]colexec.ExprEvalVector, len(window.Fs))
+					for j := range ctr.orderVecs {
+						ctr.orderVecs[j], err = colexec.MakeEvalVector(proc, []*plan.Expr{window.Fs[j].Expr})
+						if err != nil {
+							return result, err
 						}
 					}
-
-					_, err = ctr.processOrder(i, window, ctr.bat, proc)
-					if err != nil {
-						return result, err
-					}
 				}
-				// evaluate func
-				if err = ctr.processFunc(i, window, proc, analyzer); err != nil {
+
+				if _, err = ctr.processOrder(0, window, ctr.bat, proc); err != nil {
 					return result, err
 				}
 			}
-			// we can not reuse agg func
-			ctr.freeAggFun()
+			ctr.emitOffset = 0
+			ctr.status = emit
 
-			if len(window.WinSpecList[0].Expr.(*plan.Expr_W).W.PartitionBy) == 0 {
-				ctr.status = done
-			} else {
-				ctr.status = receive
+		case emit:
+			result := vm.NewCallResult()
+			start := ctr.emitOffset
+			end := min(start+colexec.DefaultBatchSize, ctr.bat.RowCount())
+			vec, err := ctr.processFuncRange(0, window, proc, analyzer, start, end)
+			if err != nil {
+				return result, err
+			}
+			result.Batch, err = ctr.makeResultBatch(start, end, vec)
+			if err != nil {
+				vec.Free(proc.Mp())
+				return result, err
 			}
 
-			if ctr.rBat != nil {
-				result.Batch = ctr.resetResultBatch(ctr.bat, ctr.vec)
-			} else {
-				result.Batch = ctr.makeResultBatch(ctr.bat, ctr.vec)
+			ctr.emitOffset = end
+			if end == ctr.bat.RowCount() {
+				if len(window.WinSpecList[0].Expr.(*plan.Expr_W).W.PartitionBy) == 0 {
+					ctr.status = done
+				} else {
+					ctr.status = receive
+				}
 			}
+
 			result.Status = vm.ExecNext
 			return result, nil
 		case done:
@@ -336,188 +322,329 @@ func (window *Window) Call(proc *process.Process) (vm.CallResult, error) {
 	}
 }
 
-func (ctr *container) makeResultBatch(bat *batch.Batch, vec *vector.Vector) *batch.Batch {
-	ctr.rBat = batch.NewWithSize(len(bat.Vecs) + 1)
-	i := 0
-	for i < len(bat.Vecs) {
-		ctr.rBat.Vecs[i] = bat.Vecs[i]
-		i++
+func (ctr *container) makeResultBatch(start, end int, vec *vector.Vector) (*batch.Batch, error) {
+	if vec == nil || vec.Length() != end-start {
+		return nil, moerr.NewInternalErrorNoCtx("window result length does not match output chunk")
 	}
-	ctr.rBat.Vecs[i] = vec
-	ctr.rBat.SetRowCount(vec.Length())
-	return ctr.rBat
+	rBat, err := ctr.bat.Window(start, end)
+	if err != nil {
+		return nil, err
+	}
+	rBat.Vecs = append(rBat.Vecs, vec)
+	rBat.SetRowCount(end - start)
+	ctr.rBat = rBat
+	return rBat, nil
 }
 
-func (ctr *container) resetResultBatch(bat *batch.Batch, vec *vector.Vector) *batch.Batch {
-	i := 0
-	for i < len(bat.Vecs) {
-		ctr.rBat.Vecs[i] = bat.Vecs[i]
-		i++
-	}
-	ctr.rBat.Vecs[i] = vec
-	ctr.rBat.SetRowCount(vec.Length())
-	return ctr.rBat
-}
-
+// processFunc retains the full-range helper used by focused cancellation
+// tests. Production Call uses processFuncRange with bounded output ranges.
 func (ctr *container) processFunc(idx int, ap *Window, proc *process.Process, analyzer process.Analyzer) error {
-	var err error
-	n := ctr.bat.Vecs[0].Length()
+	vec, err := ctr.processFuncRange(idx, ap, proc, analyzer, 0, ctr.bat.RowCount())
+	if vec != nil {
+		vec.Free(proc.Mp())
+	}
+	return err
+}
+
+func (ctr *container) processFuncRange(
+	idx int,
+	ap *Window,
+	proc *process.Process,
+	analyzer process.Analyzer,
+	outputStart int,
+	outputEnd int,
+) (*vector.Vector, error) {
+	if outputStart < 0 || outputEnd <= outputStart || outputEnd > ctr.bat.RowCount() {
+		return nil, moerr.NewInternalErrorNoCtx("invalid window output range")
+	}
+
 	w := ap.WinSpecList[idx].Expr.(*plan.Expr_W).W
 	funcName := w.Name
-	isWinOrder := function.GetFunctionIsWinOrderFunByName(funcName)
-	isWinValue := function.GetFunctionIsWinValueFunByName(funcName)
+	var (
+		vec *vector.Vector
+		err error
+	)
+	switch {
+	case function.GetFunctionIsWinValueFunByName(funcName):
+		// Value window functions use direct source-row lookup and therefore can
+		// materialize only the rows requested by this output chunk.
+		vec, err = ctr.processValueFuncRange(idx, ap, proc, outputStart, outputEnd)
+	case function.GetFunctionIsWinOrderFunByName(funcName):
+		// Rank-family functions are derived directly from the sorted peer
+		// boundaries. This avoids building one aggregate group per input row.
+		vec, err = ctr.processOrderFuncRange(idx, ap, proc, outputStart, outputEnd)
+	default:
+		vec, err = ctr.processAggregateFuncRange(idx, ap, proc, outputStart, outputEnd)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !vec.HasPrepareParamKind() {
+		vec.SetPrepareParamKind(ctr.prepareParamKind.Get(idx))
+	}
+	analyzer.Alloc(int64(vec.Size()))
+	return vec, nil
+}
 
-	if isWinValue {
-		// WIN_VALUE functions (lag/lead/first_value/last_value/nth_value):
-		// Direct index-based evaluation, bypassing AggFuncExec Fill/Flush entirely.
-		if ctr.vec != nil {
-			ctr.vec.Free(proc.Mp())
+func (ctr *container) makeAggregateExecutor(
+	idx int,
+	ap *Window,
+	proc *process.Process,
+	groupCount int,
+) error {
+	ctr.freeAggFun()
+	ctr.batAggs = make([]aggexec.AggFuncExec, len(ap.Aggs))
+	ag := ap.Aggs[idx]
+	// Derive one argument type per aggregate argument so multi-argument
+	// window aggregates (for example json_objectagg) match Group's contract.
+	argExprs := ag.GetArgExpressions()
+	argTypes := make([]types.Type, len(argExprs))
+	for j, arg := range argExprs {
+		argTypes[j] = types.NewWithCharset(
+			types.T(arg.Typ.Id), arg.Typ.Width, arg.Typ.Scale, uint8(arg.Typ.Charset),
+		)
+	}
+
+	var err error
+	ctr.batAggs[idx], err = aggexec.MakeAgg(proc.Mp(), ag.GetAggID(), ag.IsDistinct(), argTypes...)
+	if err != nil {
+		ctr.freeAggFun()
+		return err
+	}
+	if config := ag.GetExtraInformation(); config != nil {
+		if err = ctr.batAggs[idx].SetExtraInformation(config, 0); err != nil {
+			ctr.freeAggFun()
+			return err
 		}
-		ctr.vec, err = ctr.processValueFunc(idx, ap, proc)
+	}
+	if err = ctr.batAggs[idx].GroupGrow(groupCount); err != nil {
+		ctr.freeAggFun()
+		return err
+	}
+	return nil
+}
+
+func (ctr *container) processAggregateFuncRange(
+	idx int,
+	ap *Window,
+	proc *process.Process,
+	outputStart int,
+	outputEnd int,
+) (*vector.Vector, error) {
+	if err := ctr.makeAggregateExecutor(idx, ap, proc, outputEnd-outputStart); err != nil {
+		return nil, err
+	}
+	defer ctr.freeAggFun()
+
+	n := ctr.bat.RowCount()
+	w := ap.WinSpecList[idx].Expr.(*plan.Expr_W).W
+	for j := outputStart; j < outputEnd; j++ {
+		if err := checkCanceled(proc, j-outputStart); err != nil {
+			return nil, err
+		}
+
+		partitionStart, partitionEnd := 0, n
+		if ctr.ps != nil {
+			partitionStart, partitionEnd = buildPartitionInterval(ctr.ps, j, n)
+		}
+
+		left, right, err := ctr.buildInterval(
+			j, partitionStart, partitionEnd, ctr.frameAt(idx, w.Frame))
 		if err != nil {
-			return err
+			return nil, err
 		}
-		if ctr.vec != nil {
-			if !ctr.vec.HasPrepareParamKind() {
-				ctr.vec.SetPrepareParamKind(ctr.prepareParamKind.Get(idx))
-			}
-			analyzer.Alloc(int64(ctr.vec.Size()))
+		if right < partitionStart || left > partitionEnd || left >= right {
+			continue
 		}
-		ctr.os = nil
-		ctr.ps = nil
-		return nil
-	}
+		left = max(left, partitionStart)
+		right = min(right, partitionEnd)
 
-	if isWinOrder {
-		if ctr.ps == nil {
-			ctr.ps = append(ctr.ps, 0)
-		}
-		if ctr.os == nil {
-			ctr.os = append(ctr.os, 0)
-		}
-		ctr.ps = append(ctr.ps, int64(n))
-		ctr.os = append(ctr.os, int64(n))
-		if len(ctr.os) < len(ctr.ps) {
-			ctr.os = ctr.ps
-		}
-
-		// Special handling for NTILE: evaluate bucket count parameter
-		if funcName == "ntile" && len(ctr.aggVecs[idx].Vec) > 0 {
-			if err = ctr.evalAggVector(ctr.bat, proc); err != nil {
-				return err
+		group := j - outputStart
+		for k := left; k < right; k++ {
+			if err = checkCanceled(proc, k-left); err != nil {
+				return nil, err
 			}
-		}
-
-		vec := vector.NewVec(types.T_int64.ToType())
-		defer vec.Free(proc.Mp())
-		if err = vector.AppendFixedList(vec, ctr.os, nil, proc.Mp()); err != nil {
-			return err
-		}
-
-		o := 0
-		for p := 1; p < len(ctr.ps); p++ {
-			if err = checkCanceled(proc, p); err != nil {
-				return err
+			if err = ctr.batAggs[idx].Fill(group, k, ctr.aggVecs[idx].Vec); err != nil {
+				return nil, err
 			}
-			for ; o < len(ctr.os); o++ {
-				if err = checkCanceled(proc, o); err != nil {
-					return err
-				}
-
-				if ctr.os[o] <= ctr.ps[p] {
-					// For NTILE, pass both os vector and bucket count vector
-					var fillVecs []*vector.Vector
-					if funcName == "ntile" && len(ctr.aggVecs[idx].Vec) > 0 {
-						fillVecs = []*vector.Vector{vec, ctr.aggVecs[idx].Vec[0]}
-					} else {
-						fillVecs = []*vector.Vector{vec}
-					}
-
-					if err = ctr.batAggs[idx].Fill(p-1, o, fillVecs); err != nil {
-						return err
-					}
-
-				} else {
-					o--
-					break
-				}
-
-			}
-		}
-	} else {
-		// plan.Function_AGG
-		for j := 0; j < n; j++ {
-			if err = checkCanceled(proc, j); err != nil {
-				return err
-			}
-
-			start, end := 0, n
-
-			if ctr.ps != nil {
-				start, end = buildPartitionInterval(ctr.ps, j, n)
-			}
-
-			left, right, err := ctr.buildInterval(j, start, end, ctr.frameAt(idx, w.Frame))
-			if err != nil {
-				return err
-			}
-
-			if right < start || left > end || left >= right {
-				continue
-			}
-
-			if left < start {
-				left = start
-			}
-			if right > end {
-				right = end
-			}
-
-			for k := left; k < right; k++ {
-				if err = checkCanceled(proc, k-left); err != nil {
-					return err
-				}
-				if err = ctr.batAggs[idx].Fill(j, k, ctr.aggVecs[idx].Vec); err != nil {
-					return err
-				}
-			}
-
 		}
 	}
 
-	// result of agg eval is not reuse the vector
-	if ctr.vec != nil {
-		ctr.vec.Free(proc.Mp())
-	}
 	vecs, err := ctr.batAggs[idx].Flush()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	ctr.vec, err = aggexec.MergeSplitResult(vecs, proc.Mp())
+	// groupCount is bounded by DefaultBatchSize (the aggregate chunk size),
+	// so this is normally the zero-copy one-vector path. Keep the merge for
+	// defensive compatibility with aggregate implementations that split early.
+	vec, err := aggexec.MergeSplitResult(vecs, proc.Mp())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// Aggregate state initializes its physical capacity as NULL. Keep only
 	// logical-row nulls so downstream HasNull checks do not see an unused tail.
-	nulls.RemoveRange(ctr.vec.GetNulls(), uint64(ctr.vec.Length()), math.MaxUint64)
-	if !ctr.vec.HasPrepareParamKind() {
-		ctr.vec.SetPrepareParamKind(ctr.prepareParamKind.Get(idx))
+	nulls.RemoveRange(vec.GetNulls(), uint64(vec.Length()), math.MaxUint64)
+	return vec, nil
+}
+
+func (ctr *container) processOrderFuncRange(
+	idx int,
+	ap *Window,
+	proc *process.Process,
+	outputStart int,
+	outputEnd int,
+) (*vector.Vector, error) {
+	n := ctr.bat.RowCount()
+	funcName := ap.WinSpecList[idx].Expr.(*plan.Expr_W).W.Name
+
+	if funcName == "percent_rank" || funcName == "cume_dist" {
+		values := make([]float64, outputEnd-outputStart)
+		peerIndex, peerStart, peerEnd := peerInterval(ctr.os, outputStart, n)
+		for j := outputStart; j < outputEnd; j++ {
+			if err := checkCanceled(proc, j-outputStart); err != nil {
+				return nil, err
+			}
+			for j >= peerEnd {
+				peerIndex++
+				peerStart = peerEnd
+				peerEnd = n
+				if peerIndex+1 < len(ctr.os) {
+					peerEnd = int(ctr.os[peerIndex+1])
+				}
+			}
+			if funcName == "percent_rank" {
+				if n > 1 {
+					values[j-outputStart] = float64(peerStart) / float64(n-1)
+				}
+			} else {
+				values[j-outputStart] = float64(peerEnd) / float64(n)
+			}
+		}
+		vec := vector.NewVec(types.T_float64.ToType())
+		if err := vector.AppendFixedList(vec, values, nil, proc.Mp()); err != nil {
+			vec.Free(proc.Mp())
+			return nil, err
+		}
+		return vec, nil
 	}
-	if isWinOrder {
-		ctr.vec.SetNulls(nil)
+	values := make([]int64, outputEnd-outputStart)
+	switch funcName {
+	case "row_number":
+		for j := outputStart; j < outputEnd; j++ {
+			if err := checkCanceled(proc, j-outputStart); err != nil {
+				return nil, err
+			}
+			values[j-outputStart] = int64(j + 1)
+		}
+	case "ntile":
+		bucketCount, err := ctr.ntileBucketCount(idx)
+		if err != nil {
+			return nil, err
+		}
+		for j := outputStart; j < outputEnd; j++ {
+			if err := checkCanceled(proc, j-outputStart); err != nil {
+				return nil, err
+			}
+			values[j-outputStart] = ntileBucket(int64(j), int64(n), bucketCount)
+		}
+	case "rank", "dense_rank":
+		peerIndex, peerStart, peerEnd := peerInterval(ctr.os, outputStart, n)
+		for j := outputStart; j < outputEnd; j++ {
+			if err := checkCanceled(proc, j-outputStart); err != nil {
+				return nil, err
+			}
+			for j >= peerEnd {
+				peerIndex++
+				peerStart = peerEnd
+				peerEnd = n
+				if peerIndex+1 < len(ctr.os) {
+					peerEnd = int(ctr.os[peerIndex+1])
+				}
+			}
+			if funcName == "rank" {
+				values[j-outputStart] = int64(peerStart + 1)
+			} else {
+				values[j-outputStart] = int64(peerIndex + 1)
+			}
+		}
+	default:
+		return nil, moerr.NewInternalErrorNoCtxf("unsupported order window function: %s", funcName)
 	}
-	if ctr.vec != nil {
-		analyzer.Alloc(int64(ctr.vec.Size()))
+	vec := vector.NewVec(types.T_int64.ToType())
+	if err := vector.AppendFixedList(vec, values, nil, proc.Mp()); err != nil {
+		vec.Free(proc.Mp())
+		return nil, err
 	}
-	ctr.os = nil
-	ctr.ps = nil
-	return nil
+	return vec, nil
+}
+
+func peerInterval(boundaries []int64, row int, rowCount int) (index, start, end int) {
+	if len(boundaries) == 0 {
+		return 0, 0, rowCount
+	}
+	lo, hi := 0, len(boundaries)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if boundaries[mid] <= int64(row) {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	index = max(0, lo-1)
+	start = int(boundaries[index])
+	end = rowCount
+	if index+1 < len(boundaries) {
+		end = int(boundaries[index+1])
+	}
+	return index, start, end
+}
+
+func (ctr *container) ntileBucketCount(idx int) (int64, error) {
+	if idx >= len(ctr.aggVecs) || len(ctr.aggVecs[idx].Vec) == 0 {
+		return 1, nil
+	}
+	vec := ctr.aggVecs[idx].Vec[0]
+	if vec.Length() == 0 || vec.IsNull(0) {
+		return 1, nil
+	}
+	bucketCount, ok := getInt64FromVec(vec, 0)
+	if !ok {
+		return 0, moerr.NewInternalErrorNoCtx("ntile bucket count must be integer type")
+	}
+	if bucketCount <= 0 {
+		return 0, moerr.NewInternalErrorNoCtx("ntile bucket count must be positive")
+	}
+	return bucketCount, nil
+}
+
+func ntileBucket(row, rowCount, bucketCount int64) int64 {
+	regularSize := rowCount / bucketCount
+	largerBuckets := rowCount % bucketCount
+	largerSize := regularSize + 1
+	largerRows := largerBuckets * largerSize
+	if row < largerRows {
+		return row/largerSize + 1
+	}
+	// When there are more buckets than rows, every emitted row belongs to
+	// one of the larger buckets and the division below is unreachable.
+	return largerBuckets + (row-largerRows)/regularSize + 1
 }
 
 // processValueFunc handles WIN_VALUE functions (lag/lead/first_value/last_value/nth_value)
 // by directly computing results via index lookup, avoiding O(n²) frame materialization.
 func (ctr *container) processValueFunc(idx int, ap *Window, proc *process.Process) (result *vector.Vector, err error) {
-	n := ctr.bat.Vecs[0].Length()
+	return ctr.processValueFuncRange(idx, ap, proc, 0, ctr.bat.RowCount())
+}
+
+func (ctr *container) processValueFuncRange(
+	idx int,
+	ap *Window,
+	proc *process.Process,
+	outputStart int,
+	outputEnd int,
+) (result *vector.Vector, err error) {
+	n := ctr.bat.RowCount()
 	w := ap.WinSpecList[idx].Expr.(*plan.Expr_W).W
 	funcName := w.Name
 
@@ -549,8 +676,8 @@ func (ctr *container) processValueFunc(idx int, ap *Window, proc *process.Proces
 		if len(ctr.aggVecs[idx].Vec) >= 3 {
 			defaultVec = ctr.aggVecs[idx].Vec[2]
 		}
-		for j := 0; j < n; j++ {
-			if err = checkCanceled(proc, j); err != nil {
+		for j := outputStart; j < outputEnd; j++ {
+			if err = checkCanceled(proc, j-outputStart); err != nil {
 				return nil, err
 			}
 			offset, ok := constOffset, constOK
@@ -592,8 +719,8 @@ func (ctr *container) processValueFunc(idx int, ap *Window, proc *process.Proces
 		if len(ctr.aggVecs[idx].Vec) >= 3 {
 			defaultVec = ctr.aggVecs[idx].Vec[2]
 		}
-		for j := 0; j < n; j++ {
-			if err = checkCanceled(proc, j); err != nil {
+		for j := outputStart; j < outputEnd; j++ {
+			if err = checkCanceled(proc, j-outputStart); err != nil {
 				return nil, err
 			}
 			offset, ok := constOffset, constOK
@@ -623,8 +750,8 @@ func (ctr *container) processValueFunc(idx int, ap *Window, proc *process.Proces
 		}
 
 	case "first_value":
-		for j := 0; j < n; j++ {
-			if err = checkCanceled(proc, j); err != nil {
+		for j := outputStart; j < outputEnd; j++ {
+			if err = checkCanceled(proc, j-outputStart); err != nil {
 				return nil, err
 			}
 			start, end := 0, n
@@ -653,8 +780,8 @@ func (ctr *container) processValueFunc(idx int, ap *Window, proc *process.Proces
 		}
 
 	case "last_value":
-		for j := 0; j < n; j++ {
-			if err = checkCanceled(proc, j); err != nil {
+		for j := outputStart; j < outputEnd; j++ {
+			if err = checkCanceled(proc, j-outputStart); err != nil {
 				return nil, err
 			}
 			start, end := 0, n
@@ -692,8 +819,8 @@ func (ctr *container) processValueFunc(idx int, ap *Window, proc *process.Proces
 				constNth, constOK = getInt64FromVec(nthVec, 0)
 			}
 		}
-		for j := 0; j < n; j++ {
-			if err = checkCanceled(proc, j); err != nil {
+		for j := outputStart; j < outputEnd; j++ {
+			if err = checkCanceled(proc, j-outputStart); err != nil {
 				return nil, err
 			}
 			nthVal, ok := constNth, constOK

--- a/pkg/sql/colexec/window/window_benchmark_test.go
+++ b/pkg/sql/colexec/window/window_benchmark_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+)
+
+// BenchmarkWindowFirstBatch models a LIMIT consumer: it asks Window for only
+// the first output batch and then resets the pipeline. The input is large
+// enough to cross eight aggregate-result chunks.
+func BenchmarkWindowFirstBatch(b *testing.B) {
+	const rows = colexec.DefaultBatchSize * 8
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
+		values := make([]int32, rows)
+		for row := range values {
+			values[row] = int32(row + 1)
+		}
+		input := batch.NewWithSize(1)
+		input.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+		input.SetRowCount(rows)
+
+		spec := makeWindowSpec()
+		spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+		arg := &Window{
+			WinSpecList: []*plan.Expr{spec},
+			Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
+			OperatorBase: vm.OperatorBase{
+				OperatorInfo: vm.OperatorInfo{Idx: 0},
+			},
+		}
+		op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{input})
+		arg.AppendChild(op)
+
+		if err := arg.Prepare(proc); err != nil {
+			b.Fatal(err)
+		}
+		result, err := vm.Exec(arg, proc)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if result.Batch == nil || result.Batch.RowCount() == 0 {
+			b.Fatal("window returned no rows")
+		}
+
+		arg.Reset(proc, false, nil)
+		arg.Free(proc, false, nil)
+		op.Free(proc, false, nil)
+		proc.Free()
+		if got := proc.Mp().CurrNB(); got != 0 {
+			b.Fatalf("mpool leak: %d bytes", got)
+		}
+	}
+}

--- a/pkg/sql/colexec/window/window_test.go
+++ b/pkg/sql/colexec/window/window_test.go
@@ -655,7 +655,11 @@ func newTypedSumAggExpr(t *testing.T, pos int32, typ types.Type) aggexec.AggFunc
 }
 
 func newRowNumberAggExpr(t *testing.T) aggexec.AggFuncExecExpression {
-	e, err := function.GetFunctionByName(context.Background(), "row_number", nil)
+	return newOrderWindowAggExpr(t, "row_number")
+}
+
+func newOrderWindowAggExpr(t *testing.T, name string) aggexec.AggFuncExecExpression {
+	e, err := function.GetFunctionByName(context.Background(), name, nil)
 	require.NoError(t, err)
 	return aggexec.MakeAggFunctionExpression(e.GetEncodedOverloadID(), false, nil, nil)
 }
@@ -723,8 +727,8 @@ func TestWindowJsonObjectAggOutput(t *testing.T) {
 }
 
 // TestWindowJsonObjectAggNullKeyNoLeak reproduces the NULL-key error exit
-// (json_objectagg key cannot be NULL) mid-aggregation and asserts that Reset/Free
-// release the aggregators, guarding the error-path mpool leak fix.
+// (json_objectagg key cannot be NULL) mid-aggregation and asserts that the
+// chunk-local aggregator is released immediately.
 func TestWindowJsonObjectAggNullKeyNoLeak(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	// Row 1 has a NULL key: json_objectagg errors while filling the frame.
@@ -744,8 +748,8 @@ func TestWindowJsonObjectAggNullKeyNoLeak(t *testing.T) {
 	_, err := vm.Exec(arg, proc)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "key cannot be NULL")
-	// Aggregators were allocated during the failed eval and would leak without the fix.
-	require.NotNil(t, arg.ctr.batAggs)
+	// Chunk-local aggregators do not need to survive until pipeline Reset.
+	require.Nil(t, arg.ctr.batAggs)
 
 	arg.Reset(proc, true, err)
 	require.Nil(t, arg.ctr.batAggs, "Reset must release window aggregators after an error")
@@ -756,9 +760,28 @@ func TestWindowJsonObjectAggNullKeyNoLeak(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB(), "no mpool leak on the json_objectagg error path")
 }
 
-// TestWindowAggResultAcrossChunks verifies that the aggregate executor's
-// physical result chunks are invisible to the Window operator. CURRENT ROW is
-// deliberately used to keep the test O(n) while crossing AggBatchSize.
+func collectFixedWindowColumn[T types.FixedSizeT](
+	t *testing.T,
+	arg *Window,
+	proc *process.Process,
+	column int,
+) []T {
+	t.Helper()
+	var values []T
+	for {
+		result, err := vm.Exec(arg, proc)
+		require.NoError(t, err)
+		if result.Batch == nil {
+			return values
+		}
+		require.LessOrEqual(t, result.Batch.RowCount(), colexec.DefaultBatchSize)
+		values = append(values, vector.MustFixedColWithTypeCheck[T](result.Batch.Vecs[column])...)
+	}
+}
+
+// TestWindowAggResultAcrossChunks verifies that Window exposes one logical
+// result as bounded output batches. CURRENT ROW keeps the test O(n) while the
+// input crosses AggBatchSize.
 func TestWindowAggResultAcrossChunks(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	rows := aggexec.AggBatchSize + 17
@@ -787,10 +810,7 @@ func TestWindowAggResultAcrossChunks(t *testing.T) {
 	arg.AppendChild(op)
 
 	require.NoError(t, arg.Prepare(proc))
-	result, err := vm.Exec(arg, proc)
-	require.NoError(t, err)
-	require.NotNil(t, result.Batch)
-	resultValues := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1])
+	resultValues := collectFixedWindowColumn[int64](t, arg, proc, 1)
 	require.Len(t, resultValues, rows)
 	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
 		require.Equal(t, int64(values[idx]), resultValues[idx], "row %d", idx)
@@ -881,6 +901,33 @@ func TestWindowAggregateResultKeepsLogicalNulls(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
+func TestWindowSkipsEmptyInputBatch(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	empty := batch.NewWithSize(1)
+	empty.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	nonEmpty := makeInt32Batch(proc.Mp(), []int32{7})
+
+	spec := makeWindowSpec()
+	spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{empty, nonEmpty})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	require.Equal(t, []int64{7}, collectFixedWindowColumn[int64](t, arg, proc, 1))
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
 // TestWindowPartitionedAggResultAcrossChunks covers the receive-per-partition
 // path. The upstream Partition operator guarantees one logical partition per
 // input batch; the constant first column models that contract here.
@@ -911,10 +958,7 @@ func TestWindowPartitionedAggResultAcrossChunks(t *testing.T) {
 	arg.AppendChild(op)
 
 	require.NoError(t, arg.Prepare(proc))
-	result, err := vm.Exec(arg, proc)
-	require.NoError(t, err)
-	require.NotNil(t, result.Batch)
-	resultValues := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[2])
+	resultValues := collectFixedWindowColumn[int64](t, arg, proc, 2)
 	require.Len(t, resultValues, rows)
 	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
 		require.Equal(t, int64(values[idx]), resultValues[idx], "row %d", idx)
@@ -953,10 +997,7 @@ func TestWindowDecimalAggResultAcrossChunks(t *testing.T) {
 	arg.AppendChild(op)
 
 	require.NoError(t, arg.Prepare(proc))
-	result, err := vm.Exec(arg, proc)
-	require.NoError(t, err)
-	require.NotNil(t, result.Batch)
-	resultValues := vector.MustFixedColWithTypeCheck[types.Decimal128](result.Batch.Vecs[1])
+	resultValues := collectFixedWindowColumn[types.Decimal128](t, arg, proc, 1)
 	require.Len(t, resultValues, rows)
 	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
 		require.Equal(t, values[idx], resultValues[idx], "row %d", idx)
@@ -968,8 +1009,8 @@ func TestWindowDecimalAggResultAcrossChunks(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
-// TestWindowOrderResultAcrossChunks covers the dedicated window-function
-// executor, whose physical result is split independently of ordinary SUM.
+// TestWindowOrderResultAcrossChunks covers bounded rank-family output and the
+// row-number fast path across an output boundary.
 func TestWindowOrderResultAcrossChunks(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	rows := aggexec.AggBatchSize + 17
@@ -993,15 +1034,196 @@ func TestWindowOrderResultAcrossChunks(t *testing.T) {
 	arg.AppendChild(op)
 
 	require.NoError(t, arg.Prepare(proc))
-	result, err := vm.Exec(arg, proc)
-	require.NoError(t, err)
-	require.NotNil(t, result.Batch)
-	resultValues := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1])
+	resultValues := collectFixedWindowColumn[int64](t, arg, proc, 1)
 	require.Len(t, resultValues, rows)
 	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
 		require.Equal(t, int64(idx+1), resultValues[idx], "row %d", idx)
 	}
 
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestWindowRankPeerAcrossChunks(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := colexec.DefaultBatchSize + 17
+	values := make([]int32, rows)
+	for i := range values {
+		values[i] = int32(i / 3)
+	}
+	bat := makeInt32Batch(proc.Mp(), values)
+	arg := &Window{
+		WinSpecList: []*plan.Expr{{
+			Expr: &plan.Expr_W{W: &plan.WindowSpec{
+				Name:       "rank",
+				WindowFunc: newFunExpr("rank"),
+				OrderBy: []*plan.OrderBySpec{{
+					Expr: newColExpr(0),
+				}},
+			}},
+		}},
+		Aggs: []aggexec.AggFuncExecExpression{newOrderWindowAggExpr(t, "rank")},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	resultValues := collectFixedWindowColumn[int64](t, arg, proc, 1)
+	require.Len(t, resultValues, rows)
+	for _, row := range []int{0, 1, colexec.DefaultBatchSize - 2, colexec.DefaultBatchSize - 1, colexec.DefaultBatchSize, rows - 1} {
+		want := int64(row/3*3 + 1)
+		require.Equal(t, want, resultValues[row], "row %d", row)
+	}
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestWindowValueResultAcrossChunks(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := colexec.DefaultBatchSize + 17
+	values := make([]int32, rows)
+	for i := range values {
+		values[i] = int32(i + 1)
+	}
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	bat.SetRowCount(rows)
+
+	arg := &Window{
+		WinSpecList: []*plan.Expr{makeLagWindowSpec()},
+		Aggs:        []aggexec.AggFuncExecExpression{makeValueWindowAggExpr("lag")},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	var resultValues []int32
+	var resultNulls []bool
+	for {
+		result, err := vm.Exec(arg, proc)
+		require.NoError(t, err)
+		if result.Batch == nil {
+			break
+		}
+		require.LessOrEqual(t, result.Batch.RowCount(), colexec.DefaultBatchSize)
+		vec := result.Batch.Vecs[1]
+		resultValues = append(resultValues, vector.MustFixedColWithTypeCheck[int32](vec)...)
+		for row := range vec.Length() {
+			resultNulls = append(resultNulls, vec.IsNull(uint64(row)))
+		}
+	}
+	require.Len(t, resultValues, rows)
+	require.True(t, resultNulls[0])
+	for row := 1; row < rows; row++ {
+		require.False(t, resultNulls[row], "row %d", row)
+		require.Equal(t, values[row-1], resultValues[row], "row %d", row)
+	}
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestWindowOrderFunctionsUsePeerBoundaries(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{10, 10, 20, 30}, nil, proc.Mp())
+	bat.SetRowCount(4)
+
+	tests := []struct {
+		name        string
+		wantInt     []int64
+		wantFloat   []float64
+		bucketCount int64
+	}{
+		{name: "row_number", wantInt: []int64{2, 3, 4}},
+		{name: "rank", wantInt: []int64{1, 3, 4}},
+		{name: "dense_rank", wantInt: []int64{1, 2, 3}},
+		{name: "percent_rank", wantFloat: []float64{0, 2.0 / 3.0, 1}},
+		{name: "cume_dist", wantFloat: []float64{0.5, 0.75, 1}},
+		{name: "ntile", wantInt: []int64{1, 2, 3}, bucketCount: 3},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctr := container{
+				bat: bat,
+				// Sorted rows have peer groups [0,2), [2,3), [3,4).
+				os: []int64{0, 2, 3},
+			}
+			if test.name == "ntile" {
+				bucketVec, err := vector.NewConstFixed(
+					types.T_int64.ToType(), test.bucketCount, bat.RowCount(), proc.Mp())
+				require.NoError(t, err)
+				defer bucketVec.Free(proc.Mp())
+				ctr.aggVecs = []colexec.ExprEvalVector{{Vec: []*vector.Vector{bucketVec}}}
+			}
+			arg := &Window{WinSpecList: []*plan.Expr{{
+				Expr: &plan.Expr_W{W: &plan.WindowSpec{Name: test.name}},
+			}}}
+			// Start in the middle of a peer group to prove chunk boundaries do
+			// not reset rank state.
+			result, err := ctr.processOrderFuncRange(0, arg, proc, 1, 4)
+			require.NoError(t, err)
+			defer result.Free(proc.Mp())
+			if test.wantFloat != nil {
+				require.Equal(t, test.wantFloat, vector.MustFixedColWithTypeCheck[float64](result))
+			} else {
+				require.Equal(t, test.wantInt, vector.MustFixedColWithTypeCheck[int64](result))
+			}
+		})
+	}
+
+	bat.Clean(proc.Mp())
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestWindowResetBeforeAllChunksReleasesState(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	rows := colexec.DefaultBatchSize * 2
+	values := make([]int32, rows)
+	for i := range values {
+		values[i] = int32(i + 1)
+	}
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector(values, nil, proc.Mp())
+	bat.SetRowCount(rows)
+
+	spec := makeWindowSpec()
+	spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.Equal(t, colexec.DefaultBatchSize, result.Batch.RowCount())
+	require.Equal(t, colexec.DefaultBatchSize, arg.ctr.emitOffset)
+	require.Equal(t, emit, arg.ctr.status)
+	require.Nil(t, arg.ctr.batAggs)
+
+	// Model LIMIT stopping the pipeline after the first output chunk.
+	arg.Reset(proc, false, nil)
 	arg.Free(proc, false, nil)
 	op.Free(proc, false, nil)
 	proc.Free()

--- a/test/distributed/cases/window/window.result
+++ b/test/distributed/cases/window/window.result
@@ -3358,9 +3358,29 @@ count(*)
 select avg(d) over (order by d range between 2 preceding and 2 following) from td limit 10;
 [unknown result because it is related to issue#13008]
 select sum(d) over (order by d rows between 10 preceding and 10 following) from td limit 10;
-[unknown result because it is related to issue#23427]
+sum(d) over (order by d rows between 10 preceding and 10 following)
+66
+78
+91
+105
+120
+136
+153
+171
+190
+210
 select d,min(d) over (partition by d%7 order by d rows  between 2 preceding and 1 following) from td limit 10;
-[unknown result because it is related to issue#23427]
+d    min(d) over (partition by d % 7 order by d rows between 2 preceding and 1 following)
+7    7
+14    7
+21    7
+28    14
+35    21
+35    28
+42    35
+42    35
+49    42
+49    42
 drop table td;
 drop table if exists `c`;
 create table `c` (

--- a/test/distributed/cases/window/window.sql
+++ b/test/distributed/cases/window/window.sql
@@ -1138,12 +1138,8 @@ select count(*) from td;
 -- @bvt:issue#13008
 select avg(d) over (order by d range between 2 preceding and 2 following) from td limit 10;
 -- @bvt:issue
--- @bvt:issue#23427
 select sum(d) over (order by d rows between 10 preceding and 10 following) from td limit 10;
--- @bvt:issue
--- @bvt:issue#23427
 select d,min(d) over (partition by d%7 order by d rows  between 2 preceding and 1 following) from td limit 10;
--- @bvt:issue
 drop table td;
 
 drop table if exists `c`;


### PR DESCRIPTION
Emit bounded window result batches and evaluate frames lazily so LIMIT consumers can stop after the first chunk. Add rank/value fast paths and restore the large-window BVT coverage.

Fixes #23427

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23427 

## What this PR does / why we need it:

fix(window): stream split window results