### PR TITLE
fix: preserve zonemap pruning for DATETIME/TIMESTAMP comparisons

### DIFF
--- a/pkg/container/types/timestamp.go
+++ b/pkg/container/types/timestamp.go
@@ -250,6 +250,58 @@ func (ts Timestamp) ToDatetime(loc *time.Location) Datetime {
 	return Datetime(ts) + Datetime(offset)*MicroSecsPerSec
 }
 
+// DatetimeRangeToTimestampRange converts a DATETIME range to a TIMESTAMP range
+// only when the session time zone is order-preserving for every value in the
+// range.  A range that intersects a UTC-offset transition is rejected because
+// local times in a DST fold or gap are ambiguous or nonexistent.  Callers use
+// the boolean result as a proof boundary for min/max based pruning; ordinary
+// scalar casts should continue to use Datetime.ToTimestamp.
+func DatetimeRangeToTimestampRange(
+	minValue, maxValue Datetime,
+	loc *time.Location,
+) (minTimestamp, maxTimestamp Timestamp, ok bool) {
+	if loc == nil || minValue == ZeroDatetime || maxValue == ZeroDatetime || minValue > maxValue {
+		return 0, 0, false
+	}
+
+	minTimestamp = minValue.ToTimestamp(loc)
+	maxTimestamp = maxValue.ToTimestamp(loc)
+	if minTimestamp > maxTimestamp {
+		return 0, 0, false
+	}
+
+	// The UTC candidates produced from the endpoints are within one zone
+	// offset of the relevant transitions.  Include a generous margin so a
+	// fold or gap adjacent to either endpoint is also checked.
+	const transitionMargin = int64(2 * SecsPerDay)
+	loUnix := minTimestamp.Unix() - transitionMargin
+	hiUnix := maxTimestamp.Unix() + transitionMargin
+
+	// ZoneBounds includes transitions synthesized by a location's recurring
+	// extension rules, without depending on time.Location's private layout.
+	for probe := time.Unix(loUnix, 0).In(loc); ; {
+		_, next := probe.ZoneBounds()
+		if next.IsZero() || next.Unix() > hiUnix {
+			break
+		}
+		if !next.After(probe) {
+			return 0, 0, false
+		}
+		transition := next.Unix()
+		before := Timestamp(UnixToTimestamp(transition) - 1).ToDatetime(loc)
+		after := UnixToTimestamp(transition).ToDatetime(loc)
+		if before > after {
+			before, after = after, before
+		}
+		if minValue <= after && maxValue >= before {
+			return 0, 0, false
+		}
+		probe = next.In(loc)
+	}
+
+	return minTimestamp, maxTimestamp, true
+}
+
 // TruncateToScale truncates a timestamp to the given scale (0-6).
 // Scale represents fractional seconds precision:
 //   - 0: seconds (no fractional part)

--- a/pkg/container/types/timestamp_test.go
+++ b/pkg/container/types/timestamp_test.go
@@ -155,6 +155,56 @@ func TestLocation(t *testing.T) {
 	require.Greater(t, len(locPtr.zone), 1)
 }
 
+func TestDatetimeRangeToTimestampRange(t *testing.T) {
+	parse := func(t *testing.T, value string) Datetime {
+		t.Helper()
+		dt, err := ParseDatetime(value, 6)
+		require.NoError(t, err)
+		return dt
+	}
+
+	t.Run("fixed offset", func(t *testing.T) {
+		loc := time.FixedZone("UTC+08", 8*3600)
+		minValue := parse(t, "2026-08-10 10:00:00")
+		maxValue := parse(t, "2026-08-10 11:00:00")
+		minTimestamp, maxTimestamp, ok := DatetimeRangeToTimestampRange(minValue, maxValue, loc)
+		require.True(t, ok)
+		require.Equal(t, minValue.ToTimestamp(loc), minTimestamp)
+		require.Equal(t, maxValue.ToTimestamp(loc), maxTimestamp)
+	})
+
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	t.Run("ordinary named-zone range", func(t *testing.T) {
+		minValue := parse(t, "2024-01-10 10:00:00")
+		maxValue := parse(t, "2024-01-10 11:00:00")
+		_, _, ok := DatetimeRangeToTimestampRange(minValue, maxValue, newYork)
+		require.True(t, ok)
+	})
+
+	t.Run("recurring named-zone rules", func(t *testing.T) {
+		minValue := parse(t, "2050-01-10 10:00:00")
+		maxValue := parse(t, "2050-01-10 11:00:00")
+		_, _, ok := DatetimeRangeToTimestampRange(minValue, maxValue, newYork)
+		require.True(t, ok)
+	})
+
+	t.Run("DST spring gap", func(t *testing.T) {
+		minValue := parse(t, "2024-03-10 01:30:00")
+		maxValue := parse(t, "2024-03-10 03:30:00")
+		_, _, ok := DatetimeRangeToTimestampRange(minValue, maxValue, newYork)
+		require.False(t, ok)
+	})
+
+	t.Run("DST fall fold", func(t *testing.T) {
+		minValue := parse(t, "2024-11-03 01:00:00")
+		maxValue := parse(t, "2024-11-03 01:59:59")
+		_, _, ok := DatetimeRangeToTimestampRange(minValue, maxValue, newYork)
+		require.False(t, ok)
+	})
+}
+
 func TestTimestamp_TruncateToScale(t *testing.T) {
 	// Test timestamp with full microsecond precision: 1970-01-01 00:00:01.123456
 	ts := TimestampMinValue + 123456

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -2425,11 +2425,30 @@ func foldTemporalBetweenZoneMap(
 	}
 
 	zone := proc.GetSessionInfo().TimeZone
+	valueZM := zms[args[0].AuxId]
+	lowerZM := zms[args[1].AuxId]
+	upperZM := zms[args[2].AuxId]
+	if valueZM.GetType() == types.T_datetime &&
+		lowerZM.GetType() == types.T_timestamp &&
+		upperZM.GetType() == types.T_timestamp {
+		timestampScale := lowerZM.GetScale()
+		valueRange, valueOK := temporalZoneMapAsTimestampRange(valueZM, zone, timestampScale)
+		lowerRange, lowerOK := temporalZoneMapAsTimestampRange(lowerZM, zone, timestampScale)
+		upperRange, upperOK := temporalZoneMapAsTimestampRange(upperZM, zone, timestampScale)
+		if !valueOK || !lowerOK || !upperOK {
+			zms[auxID].Reset()
+		} else {
+			result := valueRange.max >= lowerRange.min && valueRange.min <= upperRange.max
+			zms[auxID] = index.SetBool(zms[auxID], result)
+		}
+		return true
+	}
+
 	lowerResult, lowerOK := temporalZoneMapComparison(
-		zms[args[0].AuxId], zms[args[1].AuxId], zone, ">=",
+		valueZM, lowerZM, zone, ">=",
 	)
 	upperResult, upperOK := temporalZoneMapComparison(
-		zms[args[0].AuxId], zms[args[2].AuxId], zone, "<=",
+		valueZM, upperZM, zone, "<=",
 	)
 	if lowerOK && !lowerResult || upperOK && !upperResult {
 		zms[auxID] = index.SetBool(zms[auxID], false)

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -1973,6 +1974,9 @@ func GetExprZoneMap(
 				if f() {
 					return zms[expr.AuxId]
 				}
+				if foldTemporalComparisonZoneMap(proc, args, zms, expr.AuxId, ">") {
+					return zms[expr.AuxId]
+				}
 				if res, ok = zms[args[0].AuxId].AnyGT(zms[args[1].AuxId]); !ok {
 					zms[expr.AuxId].Reset()
 				} else {
@@ -1985,6 +1989,9 @@ func GetExprZoneMap(
 					return zms[expr.AuxId]
 				}
 				if f() {
+					return zms[expr.AuxId]
+				}
+				if foldTemporalComparisonZoneMap(proc, args, zms, expr.AuxId, "<") {
 					return zms[expr.AuxId]
 				}
 				if res, ok = zms[args[0].AuxId].AnyLT(zms[args[1].AuxId]); !ok {
@@ -2001,6 +2008,9 @@ func GetExprZoneMap(
 				if f() {
 					return zms[expr.AuxId]
 				}
+				if foldTemporalComparisonZoneMap(proc, args, zms, expr.AuxId, ">=") {
+					return zms[expr.AuxId]
+				}
 				if res, ok = zms[args[0].AuxId].AnyGE(zms[args[1].AuxId]); !ok {
 					zms[expr.AuxId].Reset()
 				} else {
@@ -2013,6 +2023,9 @@ func GetExprZoneMap(
 					return zms[expr.AuxId]
 				}
 				if f() {
+					return zms[expr.AuxId]
+				}
+				if foldTemporalComparisonZoneMap(proc, args, zms, expr.AuxId, "<=") {
 					return zms[expr.AuxId]
 				}
 				if res, ok = zms[args[0].AuxId].AnyLE(zms[args[1].AuxId]); !ok {
@@ -2029,6 +2042,9 @@ func GetExprZoneMap(
 				if f() {
 					return zms[expr.AuxId]
 				}
+				if foldTemporalComparisonZoneMap(proc, args, zms, expr.AuxId, "=") {
+					return zms[expr.AuxId]
+				}
 				if res, ok = zms[args[0].AuxId].Intersect(zms[args[1].AuxId]); !ok {
 					zms[expr.AuxId].Reset()
 				} else {
@@ -2043,6 +2059,9 @@ func GetExprZoneMap(
 				if f() {
 					return zms[expr.AuxId]
 				}
+				if foldTemporalComparisonZoneMap(proc, args, zms, expr.AuxId, "!=") {
+					return zms[expr.AuxId]
+				}
 				if res, ok = anyNotEqualZoneMap(zms[args[0].AuxId], zms[args[1].AuxId]); !ok {
 					zms[expr.AuxId].Reset()
 				} else {
@@ -2055,6 +2074,9 @@ func GetExprZoneMap(
 					return zms[expr.AuxId]
 				}
 				if f() {
+					return zms[expr.AuxId]
+				}
+				if foldTemporalBetweenZoneMap(proc, args, zms, expr.AuxId) {
 					return zms[expr.AuxId]
 				}
 				if res, ok = zms[args[0].AuxId].AnyBetween(zms[args[1].AuxId], zms[args[2].AuxId]); !ok {
@@ -2284,6 +2306,159 @@ func anyNotEqualZoneMap(lhs, rhs objectio.ZoneMap) (bool, bool) {
 		return false, true
 	}
 	return true, true
+}
+
+// foldTemporalComparisonZoneMap evaluates a mixed DATETIME/TIMESTAMP
+// comparison against min/max metadata without changing the logical predicate.
+// DATETIME is interpreted in the session time zone, exactly like the execution
+// comparator.  If that conversion is not order-preserving over a zonemap range
+// (for example, the range intersects a DST fold or gap), the result is reset to
+// unknown so the block is conservatively retained for residual evaluation.
+func foldTemporalComparisonZoneMap(
+	proc *process.Process,
+	args []*plan.Expr,
+	zms []objectio.ZoneMap,
+	auxID int32,
+	op string,
+) bool {
+	lhs := zms[args[0].AuxId]
+	rhs := zms[args[1].AuxId]
+	if !lhs.IsInited() || !rhs.IsInited() ||
+		!isDatetimeTimestampZoneMapPair(lhs, rhs) {
+		return false
+	}
+
+	zone := proc.GetSessionInfo().TimeZone
+	timestampScale := lhs.GetScale()
+	if rhs.GetType() == types.T_timestamp {
+		timestampScale = rhs.GetScale()
+	}
+	lhsTimestamp, lhsOK := temporalZoneMapAsTimestampRange(lhs, zone, timestampScale)
+	rhsTimestamp, rhsOK := temporalZoneMapAsTimestampRange(rhs, zone, timestampScale)
+	if !lhsOK || !rhsOK {
+		zms[auxID].Reset()
+		return true
+	}
+
+	var result bool
+	switch op {
+	case ">":
+		result = lhsTimestamp.max > rhsTimestamp.min
+	case ">=":
+		result = lhsTimestamp.max >= rhsTimestamp.min
+	case "<":
+		result = lhsTimestamp.min < rhsTimestamp.max
+	case "<=":
+		result = lhsTimestamp.min <= rhsTimestamp.max
+	case "=":
+		result = lhsTimestamp.max >= rhsTimestamp.min && lhsTimestamp.min <= rhsTimestamp.max
+	case "!=":
+		result = lhsTimestamp.min != lhsTimestamp.max ||
+			rhsTimestamp.min != rhsTimestamp.max ||
+			lhsTimestamp.min != rhsTimestamp.min
+	default:
+		zms[auxID].Reset()
+		return true
+	}
+	zms[auxID] = index.SetBool(zms[auxID], result)
+	return true
+}
+
+func foldTemporalBetweenZoneMap(
+	proc *process.Process,
+	args []*plan.Expr,
+	zms []objectio.ZoneMap,
+	auxID int32,
+) bool {
+	if len(args) != 3 {
+		return false
+	}
+	hasDatetime, hasTimestamp := false, false
+	for _, arg := range args {
+		zm := zms[arg.AuxId]
+		if !zm.IsInited() {
+			return false
+		}
+		switch zm.GetType() {
+		case types.T_datetime:
+			hasDatetime = true
+		case types.T_timestamp:
+			hasTimestamp = true
+		default:
+			return false
+		}
+	}
+	if !hasDatetime || !hasTimestamp {
+		return false
+	}
+
+	zone := proc.GetSessionInfo().TimeZone
+	timestampScale := int32(6)
+	for _, arg := range args {
+		zm := zms[arg.AuxId]
+		if zm.GetType() == types.T_timestamp {
+			timestampScale = zm.GetScale()
+			break
+		}
+	}
+	var converted [3]temporalTimestampRange
+	for i, arg := range args {
+		var ok bool
+		converted[i], ok = temporalZoneMapAsTimestampRange(zms[arg.AuxId], zone, timestampScale)
+		if !ok {
+			zms[auxID].Reset()
+			return true
+		}
+	}
+	result := converted[0].max >= converted[1].min && converted[0].min <= converted[2].max
+	zms[auxID] = index.SetBool(zms[auxID], result)
+	return true
+}
+
+func isDatetimeTimestampZoneMapPair(lhs, rhs objectio.ZoneMap) bool {
+	return lhs.GetType() == types.T_datetime && rhs.GetType() == types.T_timestamp ||
+		lhs.GetType() == types.T_timestamp && rhs.GetType() == types.T_datetime
+}
+
+type temporalTimestampRange struct {
+	min types.Timestamp
+	max types.Timestamp
+}
+
+func temporalZoneMapAsTimestampRange(
+	zm objectio.ZoneMap,
+	zone *time.Location,
+	timestampScale int32,
+) (temporalTimestampRange, bool) {
+	if zm.GetType() == types.T_timestamp {
+		minValue, minOK := zm.GetMin().(types.Timestamp)
+		maxValue, maxOK := zm.GetMax().(types.Timestamp)
+		return temporalTimestampRange{min: minValue, max: maxValue}, minOK && maxOK
+	}
+	if zm.GetType() != types.T_datetime {
+		return temporalTimestampRange{}, false
+	}
+
+	minValue, minOK := zm.GetMin().(types.Datetime)
+	maxValue, maxOK := zm.GetMax().(types.Datetime)
+	if !minOK || !maxOK {
+		return temporalTimestampRange{}, false
+	}
+
+	var minTimestamp, maxTimestamp types.Timestamp
+	if isSingleValueZoneMap(zm) {
+		minTimestamp = minValue.ToTimestamp(zone).TruncateToScale(timestampScale)
+		maxTimestamp = minTimestamp
+	} else {
+		var ok bool
+		minTimestamp, maxTimestamp, ok = types.DatetimeRangeToTimestampRange(minValue, maxValue, zone)
+		if !ok {
+			return temporalTimestampRange{}, false
+		}
+		minTimestamp = minTimestamp.TruncateToScale(timestampScale)
+		maxTimestamp = maxTimestamp.TruncateToScale(timestampScale)
+	}
+	return temporalTimestampRange{min: minTimestamp, max: maxTimestamp}, true
 }
 
 func isSingleValueZoneMap(zm objectio.ZoneMap) bool {

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -2328,7 +2328,45 @@ func foldTemporalComparisonZoneMap(
 		return false
 	}
 
-	zone := proc.GetSessionInfo().TimeZone
+	result, ok := temporalZoneMapComparison(lhs, rhs, proc.GetSessionInfo().TimeZone, op)
+	if !ok {
+		zms[auxID].Reset()
+		return true
+	}
+	zms[auxID] = index.SetBool(zms[auxID], result)
+	return true
+}
+
+func temporalZoneMapComparison(
+	lhs, rhs objectio.ZoneMap,
+	zone *time.Location,
+	op string,
+) (bool, bool) {
+	if !lhs.IsInited() || !rhs.IsInited() {
+		return false, false
+	}
+	if lhs.GetType() == rhs.GetType() {
+		switch op {
+		case ">":
+			return lhs.AnyGT(rhs)
+		case ">=":
+			return lhs.AnyGE(rhs)
+		case "<":
+			return lhs.AnyLT(rhs)
+		case "<=":
+			return lhs.AnyLE(rhs)
+		case "=":
+			return lhs.Intersect(rhs)
+		case "!=":
+			return anyNotEqualZoneMap(lhs, rhs)
+		default:
+			return false, false
+		}
+	}
+	if !isDatetimeTimestampZoneMapPair(lhs, rhs) {
+		return false, false
+	}
+
 	timestampScale := lhs.GetScale()
 	if rhs.GetType() == types.T_timestamp {
 		timestampScale = rhs.GetScale()
@@ -2336,32 +2374,26 @@ func foldTemporalComparisonZoneMap(
 	lhsTimestamp, lhsOK := temporalZoneMapAsTimestampRange(lhs, zone, timestampScale)
 	rhsTimestamp, rhsOK := temporalZoneMapAsTimestampRange(rhs, zone, timestampScale)
 	if !lhsOK || !rhsOK {
-		zms[auxID].Reset()
-		return true
+		return false, false
 	}
-
-	var result bool
 	switch op {
 	case ">":
-		result = lhsTimestamp.max > rhsTimestamp.min
+		return lhsTimestamp.max > rhsTimestamp.min, true
 	case ">=":
-		result = lhsTimestamp.max >= rhsTimestamp.min
+		return lhsTimestamp.max >= rhsTimestamp.min, true
 	case "<":
-		result = lhsTimestamp.min < rhsTimestamp.max
+		return lhsTimestamp.min < rhsTimestamp.max, true
 	case "<=":
-		result = lhsTimestamp.min <= rhsTimestamp.max
+		return lhsTimestamp.min <= rhsTimestamp.max, true
 	case "=":
-		result = lhsTimestamp.max >= rhsTimestamp.min && lhsTimestamp.min <= rhsTimestamp.max
+		return lhsTimestamp.max >= rhsTimestamp.min && lhsTimestamp.min <= rhsTimestamp.max, true
 	case "!=":
-		result = lhsTimestamp.min != lhsTimestamp.max ||
+		return lhsTimestamp.min != lhsTimestamp.max ||
 			rhsTimestamp.min != rhsTimestamp.max ||
-			lhsTimestamp.min != rhsTimestamp.min
+			lhsTimestamp.min != rhsTimestamp.min, true
 	default:
-		zms[auxID].Reset()
-		return true
+		return false, false
 	}
-	zms[auxID] = index.SetBool(zms[auxID], result)
-	return true
 }
 
 func foldTemporalBetweenZoneMap(
@@ -2393,25 +2425,19 @@ func foldTemporalBetweenZoneMap(
 	}
 
 	zone := proc.GetSessionInfo().TimeZone
-	timestampScale := int32(6)
-	for _, arg := range args {
-		zm := zms[arg.AuxId]
-		if zm.GetType() == types.T_timestamp {
-			timestampScale = zm.GetScale()
-			break
-		}
+	lowerResult, lowerOK := temporalZoneMapComparison(
+		zms[args[0].AuxId], zms[args[1].AuxId], zone, ">=",
+	)
+	upperResult, upperOK := temporalZoneMapComparison(
+		zms[args[0].AuxId], zms[args[2].AuxId], zone, "<=",
+	)
+	if lowerOK && !lowerResult || upperOK && !upperResult {
+		zms[auxID] = index.SetBool(zms[auxID], false)
+	} else if lowerOK && upperOK {
+		zms[auxID] = index.SetBool(zms[auxID], true)
+	} else {
+		zms[auxID].Reset()
 	}
-	var converted [3]temporalTimestampRange
-	for i, arg := range args {
-		var ok bool
-		converted[i], ok = temporalZoneMapAsTimestampRange(zms[arg.AuxId], zone, timestampScale)
-		if !ok {
-			zms[auxID].Reset()
-			return true
-		}
-	}
-	result := converted[0].max >= converted[1].min && converted[0].min <= converted[2].max
-	zms[auxID] = index.SetBool(zms[auxID], result)
 	return true
 }
 

--- a/pkg/sql/colexec/evalExpression_zonemap_test.go
+++ b/pkg/sql/colexec/evalExpression_zonemap_test.go
@@ -17,6 +17,7 @@ package colexec_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -31,6 +32,124 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEvaluateFilterByZoneMapDatetimeTimestampComparison(t *testing.T) {
+	parseDatetime := func(t *testing.T, value string) types.Datetime {
+		t.Helper()
+		datetime, err := types.ParseDatetime(value, 6)
+		require.NoError(t, err)
+		return datetime
+	}
+	makeExpr := func(t *testing.T, timestamp types.Timestamp, scale int32) *plan.Expr {
+		t.Helper()
+		column := &plan.Expr{
+			Typ: plan.Type{Id: int32(types.T_datetime), Scale: 6},
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{RelPos: 0, ColPos: 0, Name: "request_at"},
+			},
+		}
+		constant := plan2.MakePlan2TimestampConstExprWithType(int64(timestamp))
+		constant.Typ.Scale = scale
+		expr, err := plan2.BindFuncExprImplByPlanExpr(context.Background(), ">", []*plan.Expr{column, constant})
+		require.NoError(t, err)
+		require.Equal(t, int32(types.T_datetime), expr.GetF().Args[0].Typ.Id)
+		require.Equal(t, int32(types.T_timestamp), expr.GetF().Args[1].Typ.Id)
+		return expr
+	}
+
+	t.Run("fixed offset prunes", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		defer proc.Free()
+		zone := time.FixedZone("UTC+08", 8*3600)
+		proc.GetSessionInfo().TimeZone = zone
+		threshold := parseDatetime(t, "2026-08-10 12:00:00").ToTimestamp(zone)
+		expr := makeExpr(t, threshold, 6)
+		meta := makeDatetimeBlockMeta(
+			parseDatetime(t, "2026-08-10 10:00:00"),
+			parseDatetime(t, "2026-08-10 11:00:00"),
+		)
+		zms, vecs := makeZoneMapEvalScratch(expr)
+
+		selected := colexec.EvaluateFilterByZoneMap(proc.Ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+	})
+
+	t.Run("ordinary named-zone range prunes", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		defer proc.Free()
+		zone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		proc.GetSessionInfo().TimeZone = zone
+		threshold := parseDatetime(t, "2024-01-10 12:00:00").ToTimestamp(zone)
+		expr := makeExpr(t, threshold, 6)
+		meta := makeDatetimeBlockMeta(
+			parseDatetime(t, "2024-01-10 10:00:00"),
+			parseDatetime(t, "2024-01-10 11:00:00"),
+		)
+		zms, vecs := makeZoneMapEvalScratch(expr)
+
+		selected := colexec.EvaluateFilterByZoneMap(proc.Ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+	})
+
+	t.Run("DST fold is conservative", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		defer proc.Free()
+		zone, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		proc.GetSessionInfo().TimeZone = zone
+		threshold, err := types.ParseTimestamp(time.UTC, "2024-11-03 06:15:00", 6)
+		require.NoError(t, err)
+		expr := makeExpr(t, threshold, 6)
+		meta := makeDatetimeBlockMeta(
+			parseDatetime(t, "2024-11-03 01:00:00"),
+			parseDatetime(t, "2024-11-03 01:59:59"),
+		)
+		zms, vecs := makeZoneMapEvalScratch(expr)
+
+		selected := colexec.EvaluateFilterByZoneMap(proc.Ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+		require.True(t, selected, "ambiguous local-time ranges must remain for residual evaluation")
+	})
+
+	t.Run("timestamp scale is applied before pruning", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		defer proc.Free()
+		proc.GetSessionInfo().TimeZone = time.UTC
+		value := parseDatetime(t, "2026-08-10 12:00:00.123456")
+		threshold := value.ToTimestamp(time.UTC).TruncateToScale(3)
+		expr := makeExpr(t, threshold, 3)
+		meta := makeDatetimeBlockMeta(value, value)
+		zms, vecs := makeZoneMapEvalScratch(expr)
+
+		selected := colexec.EvaluateFilterByZoneMap(proc.Ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+		require.False(t, selected, "comparison must retain the prior TIMESTAMP(3) cast precision")
+	})
+
+	t.Run("between prunes", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		defer proc.Free()
+		zone := time.FixedZone("UTC+08", 8*3600)
+		proc.GetSessionInfo().TimeZone = zone
+		column := &plan.Expr{
+			Typ: plan.Type{Id: int32(types.T_datetime), Scale: 6},
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{RelPos: 0, ColPos: 0, Name: "request_at"},
+			},
+		}
+		lower := plan2.MakePlan2TimestampConstExprWithType(int64(parseDatetime(t, "2026-08-10 12:00:00").ToTimestamp(zone)))
+		upper := plan2.MakePlan2TimestampConstExprWithType(int64(parseDatetime(t, "2026-08-10 13:00:00").ToTimestamp(zone)))
+		expr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, "between", []*plan.Expr{column, lower, upper})
+		require.NoError(t, err)
+		meta := makeDatetimeBlockMeta(
+			parseDatetime(t, "2026-08-10 10:00:00"),
+			parseDatetime(t, "2026-08-10 11:00:00"),
+		)
+		zms, vecs := makeZoneMapEvalScratch(expr)
+
+		selected := colexec.EvaluateFilterByZoneMap(proc.Ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+	})
+}
 
 func TestEvaluateFilterByZoneMapNullableInListIsConservative(t *testing.T) {
 	proc := testutil.NewProcess(t)
@@ -478,6 +597,19 @@ func makeVarcharBlockMeta(values ...string) objectio.BlockObject {
 	zm := index.NewZM(types.T_varchar, 0)
 	for _, value := range values {
 		index.UpdateZM(zm, []byte(value))
+	}
+	meta.MustGetColumn(0).SetZoneMap(zm)
+	return meta
+}
+
+func makeDatetimeBlockMeta(values ...types.Datetime) objectio.BlockObject {
+	dataMeta := objectio.BuildMetaData(1, 1)
+	meta := dataMeta.GetBlockMeta(0)
+
+	zm := index.NewZM(types.T_datetime, 6)
+	for _, value := range values {
+		encoded := int64(value)
+		index.UpdateZM(zm, types.EncodeInt64(&encoded))
 	}
 	meta.MustGetColumn(0).SetZoneMap(zm)
 	return meta

--- a/pkg/sql/colexec/evalExpression_zonemap_test.go
+++ b/pkg/sql/colexec/evalExpression_zonemap_test.go
@@ -149,6 +149,33 @@ func TestEvaluateFilterByZoneMapDatetimeTimestampComparison(t *testing.T) {
 		selected := colexec.EvaluateFilterByZoneMap(proc.Ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
 		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
 	})
+
+	t.Run("between applies each timestamp bound scale", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		defer proc.Free()
+		proc.GetSessionInfo().TimeZone = time.UTC
+		value := parseDatetime(t, "2026-08-10 12:00:00.123456")
+		column := &plan.Expr{
+			Typ: plan.Type{Id: int32(types.T_datetime), Scale: 6},
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{RelPos: 0, ColPos: 0, Name: "request_at"},
+			},
+		}
+		lower := plan2.MakePlan2TimestampConstExprWithType(int64(value.ToTimestamp(time.UTC).TruncateToScale(3)))
+		lower.Typ.Scale = 3
+		upperValue, err := types.ParseTimestamp(time.UTC, "2026-08-10 12:00:00.123100", 6)
+		require.NoError(t, err)
+		upper := plan2.MakePlan2TimestampConstExprWithType(int64(upperValue))
+		upper.Typ.Scale = 6
+		expr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, "between", []*plan.Expr{column, lower, upper})
+		require.NoError(t, err)
+		zms, vecs := makeZoneMapEvalScratch(expr)
+
+		selected := colexec.EvaluateFilterByZoneMap(
+			proc.Ctx, proc, expr, makeDatetimeBlockMeta(value), map[int]int{0: 0}, zms, vecs,
+		)
+		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+	})
 }
 
 func TestEvaluateFilterByZoneMapNullableInListIsConservative(t *testing.T) {

--- a/pkg/sql/colexec/evalExpression_zonemap_test.go
+++ b/pkg/sql/colexec/evalExpression_zonemap_test.go
@@ -150,7 +150,7 @@ func TestEvaluateFilterByZoneMapDatetimeTimestampComparison(t *testing.T) {
 		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
 	})
 
-	t.Run("between applies each timestamp bound scale", func(t *testing.T) {
+	t.Run("between preserves common value scale", func(t *testing.T) {
 		proc := testutil.NewProcess(t)
 		defer proc.Free()
 		proc.GetSessionInfo().TimeZone = time.UTC
@@ -174,7 +174,7 @@ func TestEvaluateFilterByZoneMapDatetimeTimestampComparison(t *testing.T) {
 		selected := colexec.EvaluateFilterByZoneMap(
 			proc.Ctx, proc, expr, makeDatetimeBlockMeta(value), map[int]int{0: 0}, zms, vecs,
 		)
-		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+		require.True(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
 	})
 }
 

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -3815,6 +3815,9 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 	for idx, expr := range args {
 		argsType[idx] = makeTypeByPlan2Expr(expr)
 	}
+	if err := normalizeNonConstantTemporalComparisonArgs(ctx, name, args, argsType); err != nil {
+		return nil, err
+	}
 
 	var funcID int64
 	var returnType types.Type
@@ -4194,6 +4197,45 @@ func bindConvertUsingCharset(ctx context.Context, args []*plan.Expr) error {
 	// selected charset on that argument so the overload's return-type callback
 	// can carry it into the bound result without inspecting expression values.
 	args[1].Typ.Charset = charset
+	return nil
+}
+
+// normalizeNonConstantTemporalComparisonArgs keeps both sides of equality and
+// ordering keys in one physical domain when neither side is a runtime
+// constant. Hash joins, shuffle keys, and runtime filters consume comparison
+// operands as keys instead of invoking the scalar comparison function, so raw
+// DATETIME and TIMESTAMP encodings cannot safely remain cross-typed there.
+// Column-versus-runtime-constant predicates stay cross-typed so storage can
+// see the raw column and apply the timezone-aware pruning path.
+func normalizeNonConstantTemporalComparisonArgs(
+	ctx context.Context,
+	name string,
+	args []*Expr,
+	argsType []types.Type,
+) error {
+	switch name {
+	case "=", "<", "<=", ">", ">=", "<>":
+	default:
+		return nil
+	}
+	if len(args) != 2 || len(argsType) != 2 ||
+		!((argsType[0].Oid == types.T_datetime && argsType[1].Oid == types.T_timestamp) ||
+			(argsType[0].Oid == types.T_timestamp && argsType[1].Oid == types.T_datetime)) ||
+		isRuntimeConstExpr(args[0]) || isRuntimeConstExpr(args[1]) {
+		return nil
+	}
+
+	datetimeIndex, timestampIndex := 0, 1
+	if argsType[0].Oid == types.T_timestamp {
+		datetimeIndex, timestampIndex = 1, 0
+	}
+	targetType := argsType[timestampIndex]
+	casted, err := appendCastBeforeExpr(ctx, args[datetimeIndex], makePlan2Type(&targetType))
+	if err != nil {
+		return err
+	}
+	args[datetimeIndex] = casted
+	argsType[datetimeIndex] = targetType
 	return nil
 }
 

--- a/pkg/sql/plan/base_binder_test.go
+++ b/pkg/sql/plan/base_binder_test.go
@@ -1173,6 +1173,35 @@ func TestBindFuncExprImplByPlanExpr_DatetimeTimestampComparisonRemainsCrossTyped
 	require.Equal(t, int32(types.T_timestamp), comparison.GetF().Args[1].Typ.Id)
 }
 
+func TestBindFuncExprImplByPlanExpr_NonConstantTemporalComparisonUsesCommonKeyType(t *testing.T) {
+	datetimeColumn := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_datetime), Scale: 6},
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{RelPos: 0, ColPos: 0, Name: "d"},
+		},
+	}
+	timestampColumn := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_timestamp), Scale: 3},
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{RelPos: 1, ColPos: 0, Name: "t"},
+		},
+	}
+
+	comparison, err := BindFuncExprImplByPlanExpr(context.Background(), "=", []*plan.Expr{
+		datetimeColumn,
+		timestampColumn,
+	})
+	require.NoError(t, err)
+	require.Len(t, comparison.GetF().Args, 2)
+	cast := comparison.GetF().Args[0].GetF()
+	require.NotNil(t, cast)
+	require.Equal(t, "cast", cast.Func.ObjName)
+	require.Equal(t, int32(types.T_timestamp), comparison.GetF().Args[0].Typ.Id)
+	require.Equal(t, int32(3), comparison.GetF().Args[0].Typ.Scale)
+	require.NotNil(t, comparison.GetF().Args[1].GetCol())
+	require.Equal(t, int32(types.T_timestamp), comparison.GetF().Args[1].Typ.Id)
+}
+
 func TestBuildPlan_DatetimeTimestampComparisonIsZonemappable(t *testing.T) {
 	compilerCtx := NewMockCompilerContext(true)
 	compilerCtx.dbs["system"] = true

--- a/pkg/sql/plan/base_binder_test.go
+++ b/pkg/sql/plan/base_binder_test.go
@@ -1151,6 +1151,67 @@ func TestBindFuncExprImplByPlanExpr_JsonValid(t *testing.T) {
 	})
 }
 
+func TestBindFuncExprImplByPlanExpr_DatetimeTimestampComparisonRemainsCrossTyped(t *testing.T) {
+	datetimeColumn := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_datetime), Scale: 6},
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{ColPos: 0, Name: "request_at"},
+		},
+	}
+	timestampValue, err := BindFuncExprImplByPlanExpr(context.Background(), "now", nil)
+	require.NoError(t, err)
+
+	comparison, err := BindFuncExprImplByPlanExpr(context.Background(), ">", []*plan.Expr{
+		datetimeColumn,
+		timestampValue,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(types.T_bool), comparison.Typ.Id)
+	require.Len(t, comparison.GetF().Args, 2)
+	require.NotNil(t, comparison.GetF().Args[0].GetCol())
+	require.Equal(t, int32(types.T_datetime), comparison.GetF().Args[0].Typ.Id)
+	require.Equal(t, int32(types.T_timestamp), comparison.GetF().Args[1].Typ.Id)
+}
+
+func TestBuildPlan_DatetimeTimestampComparisonIsZonemappable(t *testing.T) {
+	compilerCtx := NewMockCompilerContext(true)
+	compilerCtx.dbs["system"] = true
+	compilerCtx.objects["statement_info"] = &plan.ObjectRef{
+		SchemaName: "system",
+		ObjName:    "statement_info",
+	}
+	compilerCtx.tables["statement_info"] = &plan.TableDef{
+		Name: "statement_info",
+		Cols: []*plan.ColDef{{
+			Name: "request_at",
+			Typ:  plan.Type{Id: int32(types.T_datetime), Scale: 6},
+		}},
+	}
+
+	stmt, err := parsers.ParseOne(context.Background(), dialect.MYSQL,
+		"select request_at from system.statement_info where request_at > date_sub(now(), interval 1 hour)", 1)
+	require.NoError(t, err)
+	defer stmt.Free()
+	queryPlan, err := BuildPlan(compilerCtx, stmt, false)
+	require.NoError(t, err)
+
+	var scan *plan.Node
+	for _, node := range queryPlan.GetQuery().GetNodes() {
+		if node.GetNodeType() == plan.Node_TABLE_SCAN && node.GetTableDef().GetName() == "statement_info" {
+			scan = node
+			break
+		}
+	}
+	require.NotNil(t, scan)
+	require.Len(t, scan.FilterList, 1)
+	filterArgs := scan.FilterList[0].GetF().GetArgs()
+	require.Len(t, filterArgs, 2)
+	require.NotNil(t, filterArgs[0].GetCol())
+	require.Equal(t, int32(types.T_datetime), filterArgs[0].Typ.Id)
+	require.Equal(t, int32(types.T_timestamp), filterArgs[1].Typ.Id)
+	require.True(t, ExprIsZonemappable(compilerCtx.GetContext(), scan.FilterList[0]))
+}
+
 func TestBindFuncExprImplByPlanExpr_JsonOrderingWithDynamicParam(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/sql/plan/function/func_compare.go
+++ b/pkg/sql/plan/function/func_compare.go
@@ -27,6 +27,9 @@ import (
 )
 
 func otherCompareOperatorSupports(typ1, typ2 types.Type) bool {
+	if isDatetimeTimestampComparison(typ1, typ2) {
+		return true
+	}
 	if typ1.Oid != typ2.Oid {
 		return false
 	}
@@ -66,6 +69,9 @@ func jsonOrderingWithStringNotSupported(inputs []types.Type) bool {
 }
 
 func equalAndNotEqualOperatorSupports(typ1, typ2 types.Type) bool {
+	if isDatetimeTimestampComparison(typ1, typ2) {
+		return true
+	}
 	if typ1.Oid != typ2.Oid {
 		return false
 	}
@@ -92,6 +98,31 @@ func equalAndNotEqualOperatorSupports(typ1, typ2 types.Type) bool {
 		return false
 	}
 	return true
+}
+
+func compareDatetimeAndTimestamp(
+	parameters []*vector.Vector,
+	result *vector.FunctionResult[bool],
+	proc *process.Process,
+	length int,
+	cmp func(left, right types.Timestamp) bool,
+	selectList *FunctionSelectList,
+) error {
+	zone := proc.GetSessionInfo().TimeZone
+	if parameters[0].GetType().Oid == types.T_datetime {
+		timestampScale := parameters[1].GetType().Scale
+		return opBinaryFixedFixedToFixed[types.Datetime, types.Timestamp, bool](
+			parameters, result, proc, length,
+			func(left types.Datetime, right types.Timestamp) bool {
+				return cmp(left.ToTimestamp(zone).TruncateToScale(timestampScale), right)
+			}, selectList)
+	}
+	timestampScale := parameters[0].GetType().Scale
+	return opBinaryFixedFixedToFixed[types.Timestamp, types.Datetime, bool](
+		parameters, result, proc, length,
+		func(left types.Timestamp, right types.Datetime) bool {
+			return cmp(left, right.ToTimestamp(zone).TruncateToScale(timestampScale))
+		}, selectList)
 }
 
 func floatArrayEqual[T constraints.Float](left, right []T) bool {
@@ -361,6 +392,11 @@ func nullSafeEqualFn(parameters []*vector.Vector, result vector.FunctionResultWr
 func equalFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
 	rs := vector.MustFunctionResult[bool](result)
+	if isDatetimeTimestampComparison(*paramType, *parameters[1].GetType()) {
+		return compareDatetimeAndTimestamp(parameters, rs, proc, length, func(left, right types.Timestamp) bool {
+			return left == right
+		}, selectList)
+	}
 
 	switch paramType.Oid {
 	case types.T_bool:
@@ -769,6 +805,11 @@ func valueDec256Compare(
 func greatThanFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
 	rs := vector.MustFunctionResult[bool](result)
+	if isDatetimeTimestampComparison(*paramType, *parameters[1].GetType()) {
+		return compareDatetimeAndTimestamp(parameters, rs, proc, length, func(left, right types.Timestamp) bool {
+			return left > right
+		}, selectList)
+	}
 	switch paramType.Oid {
 	case types.T_bit:
 		return opBinaryFixedFixedToFixed[uint64, uint64, bool](parameters, rs, proc, length, func(a, b uint64) bool {
@@ -926,6 +967,11 @@ func greatThanFn(parameters []*vector.Vector, result vector.FunctionResultWrappe
 func greatEqualFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
 	rs := vector.MustFunctionResult[bool](result)
+	if isDatetimeTimestampComparison(*paramType, *parameters[1].GetType()) {
+		return compareDatetimeAndTimestamp(parameters, rs, proc, length, func(left, right types.Timestamp) bool {
+			return left >= right
+		}, selectList)
+	}
 	switch paramType.Oid {
 	case types.T_bool:
 		return opBinaryFixedFixedToFixed[bool, bool, bool](parameters, rs, proc, length, func(x, y bool) bool {
@@ -1083,6 +1129,11 @@ func greatEqualFn(parameters []*vector.Vector, result vector.FunctionResultWrapp
 func notEqualFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
 	rs := vector.MustFunctionResult[bool](result)
+	if isDatetimeTimestampComparison(*paramType, *parameters[1].GetType()) {
+		return compareDatetimeAndTimestamp(parameters, rs, proc, length, func(left, right types.Timestamp) bool {
+			return left != right
+		}, selectList)
+	}
 	switch paramType.Oid {
 	case types.T_bool:
 		return opBinaryFixedFixedToFixed[bool, bool, bool](parameters, rs, proc, length, func(a, b bool) bool {
@@ -1240,6 +1291,11 @@ func notEqualFn(parameters []*vector.Vector, result vector.FunctionResultWrapper
 func lessThanFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
 	rs := vector.MustFunctionResult[bool](result)
+	if isDatetimeTimestampComparison(*paramType, *parameters[1].GetType()) {
+		return compareDatetimeAndTimestamp(parameters, rs, proc, length, func(left, right types.Timestamp) bool {
+			return left < right
+		}, selectList)
+	}
 	switch paramType.Oid {
 	case types.T_bool:
 		return opBinaryFixedFixedToFixed[bool, bool, bool](parameters, rs, proc, length, func(x, y bool) bool {
@@ -1397,6 +1453,11 @@ func lessThanFn(parameters []*vector.Vector, result vector.FunctionResultWrapper
 func lessEqualFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
 	rs := vector.MustFunctionResult[bool](result)
+	if isDatetimeTimestampComparison(*paramType, *parameters[1].GetType()) {
+		return compareDatetimeAndTimestamp(parameters, rs, proc, length, func(left, right types.Timestamp) bool {
+			return left <= right
+		}, selectList)
+	}
 	switch paramType.Oid {
 	case types.T_bool:
 		return opBinaryFixedFixedToFixed[bool, bool, bool](parameters, rs, proc, length, func(x, y bool) bool {

--- a/pkg/sql/plan/function/func_compare_test.go
+++ b/pkg/sql/plan/function/func_compare_test.go
@@ -25,6 +25,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDatetimeTimestampComparisonPreservesInstantSemantics(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	zone, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	proc.GetSessionInfo().TimeZone = zone
+
+	datetime, err := types.ParseDatetime("2024-11-03 01:30:00", 6)
+	require.NoError(t, err)
+	secondFoldTimestamp, err := types.ParseTimestamp(time.UTC, "2024-11-03 06:15:00", 6)
+	require.NoError(t, err)
+	datetimeAsTimestamp := datetime.ToTimestamp(zone)
+
+	tests := []struct {
+		name string
+		fn   fEvalFn
+		want bool
+	}{
+		{name: "equal", fn: equalFn, want: datetimeAsTimestamp == secondFoldTimestamp},
+		{name: "not equal", fn: notEqualFn, want: datetimeAsTimestamp != secondFoldTimestamp},
+		{name: "greater", fn: greatThanFn, want: datetimeAsTimestamp > secondFoldTimestamp},
+		{name: "greater equal", fn: greatEqualFn, want: datetimeAsTimestamp >= secondFoldTimestamp},
+		{name: "less", fn: lessThanFn, want: datetimeAsTimestamp < secondFoldTimestamp},
+		{name: "less equal", fn: lessEqualFn, want: datetimeAsTimestamp <= secondFoldTimestamp},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_datetime.ToTypeWithScale(6), []types.Datetime{datetime, datetime}, []bool{false, true}),
+				NewFunctionTestInput(types.T_timestamp.ToTypeWithScale(6), []types.Timestamp{secondFoldTimestamp, secondFoldTimestamp}, nil),
+			}
+			expect := NewFunctionTestResult(types.T_bool.ToType(), false, []bool{test.want, false}, []bool{false, true})
+			testCase := NewFunctionTestCase(proc, inputs, expect, test.fn)
+			ok, info := testCase.Run()
+			require.True(t, ok, info)
+		})
+	}
+
+	t.Run("reversed operands", func(t *testing.T) {
+		inputs := []FunctionTestInput{
+			NewFunctionTestInput(types.T_timestamp.ToTypeWithScale(6), []types.Timestamp{secondFoldTimestamp}, []bool{false}),
+			NewFunctionTestInput(types.T_datetime.ToTypeWithScale(6), []types.Datetime{datetime}, []bool{false}),
+		}
+		expect := NewFunctionTestResult(types.T_bool.ToType(), false,
+			[]bool{secondFoldTimestamp > datetimeAsTimestamp}, []bool{false})
+		testCase := NewFunctionTestCase(proc, inputs, expect, greatThanFn)
+		ok, info := testCase.Run()
+		require.True(t, ok, info)
+	})
+
+	t.Run("timestamp scale remains the comparison precision", func(t *testing.T) {
+		preciseDatetime, err := types.ParseDatetime("2024-01-10 12:00:00.123456", 6)
+		require.NoError(t, err)
+		millisecondTimestamp := preciseDatetime.ToTimestamp(zone).TruncateToScale(3)
+		inputs := []FunctionTestInput{
+			NewFunctionTestInput(types.T_datetime.ToTypeWithScale(6), []types.Datetime{preciseDatetime}, nil),
+			NewFunctionTestInput(types.T_timestamp.ToTypeWithScale(3), []types.Timestamp{millisecondTimestamp}, nil),
+		}
+		expect := NewFunctionTestResult(types.T_bool.ToType(), false, []bool{true}, nil)
+		testCase := NewFunctionTestCase(proc, inputs, expect, equalFn)
+		ok, info := testCase.Run()
+		require.True(t, ok, info)
+	})
+}
+
 func TestJsonOrderingOperatorsUseExactComparison(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	defer proc.Free()

--- a/pkg/sql/plan/function/list_operator.go
+++ b/pkg/sql/plan/function/list_operator.go
@@ -20,6 +20,9 @@ import (
 )
 
 func comparisonTypeCastRule(left, right types.Type) (bool, types.Type, types.Type) {
+	if isDatetimeTimestampComparison(left, right) {
+		return false, left, right
+	}
 	hasCast, castLeft, castRight := fixedTypeCastRule1(left, right)
 	if !isCollatedTextType(castLeft.Oid) || !isCollatedTextType(castRight.Oid) {
 		return hasCast, castLeft, castRight
@@ -49,6 +52,11 @@ func comparisonTypeCastRule(left, right types.Type) (bool, types.Type, types.Typ
 	castLeft.Charset = charset
 	castRight.Charset = charset
 	return hasCast || left.Charset != charset || right.Charset != charset, castLeft, castRight
+}
+
+func isDatetimeTimestampComparison(left, right types.Type) bool {
+	return left.Oid == types.T_datetime && right.Oid == types.T_timestamp ||
+		left.Oid == types.T_timestamp && right.Oid == types.T_datetime
 }
 
 var supportedOperators = []FuncNew{
@@ -111,7 +119,7 @@ var supportedOperators = []FuncNew{
 		layout:     COMPARISON_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
 			if len(inputs) == 2 {
-				has, t1, t2 := comparisonTypeCastRule(inputs[0], inputs[1])
+				has, t1, t2 := fixedTypeCastRule1(inputs[0], inputs[1])
 				if has {
 					if equalAndNotEqualOperatorSupports(t1, t2) {
 						if t1.Oid == t2.Oid && t1.Oid.IsDecimal() {

--- a/pkg/sql/plan/function/operator_between.go
+++ b/pkg/sql/plan/function/operator_between.go
@@ -110,41 +110,62 @@ func opBetweenDatetimeTimestamp(
 	proc *process.Process,
 	length int,
 ) error {
-	timestampScale := int32(6)
-	for _, parameter := range parameters {
-		if parameter.GetType().Oid == types.T_timestamp {
-			timestampScale = parameter.GetType().Scale
-			break
-		}
-	}
-	toDatetimeTimestamp := func(value types.Datetime) types.Timestamp {
-		return value.ToTimestamp(proc.GetSessionInfo().TimeZone).TruncateToScale(timestampScale)
-	}
-	identityTimestamp := func(value types.Timestamp) types.Timestamp { return value }
+	zone := proc.GetSessionInfo().TimeZone
+	valueScale := parameters[0].GetType().Scale
+	lowerScale := parameters[1].GetType().Scale
+	upperScale := parameters[2].GetType().Scale
 
 	switch {
 	case parameters[0].GetType().Oid == types.T_datetime &&
 		parameters[1].GetType().Oid == types.T_datetime:
 		return opBetweenTemporal[types.Datetime, types.Datetime, types.Timestamp](
-			parameters, result, length, toDatetimeTimestamp, toDatetimeTimestamp, identityTimestamp)
+			parameters, result, length,
+			func(value, lower types.Datetime) bool { return value >= lower },
+			func(value types.Datetime, upper types.Timestamp) bool {
+				return value.ToTimestamp(zone).TruncateToScale(upperScale) <= upper
+			})
 	case parameters[0].GetType().Oid == types.T_datetime &&
 		parameters[2].GetType().Oid == types.T_datetime:
 		return opBetweenTemporal[types.Datetime, types.Timestamp, types.Datetime](
-			parameters, result, length, toDatetimeTimestamp, identityTimestamp, toDatetimeTimestamp)
+			parameters, result, length,
+			func(value types.Datetime, lower types.Timestamp) bool {
+				return value.ToTimestamp(zone).TruncateToScale(lowerScale) >= lower
+			},
+			func(value, upper types.Datetime) bool { return value <= upper })
 	case parameters[0].GetType().Oid == types.T_datetime:
 		return opBetweenTemporal[types.Datetime, types.Timestamp, types.Timestamp](
-			parameters, result, length, toDatetimeTimestamp, identityTimestamp, identityTimestamp)
+			parameters, result, length,
+			func(value types.Datetime, lower types.Timestamp) bool {
+				return value.ToTimestamp(zone).TruncateToScale(lowerScale) >= lower
+			},
+			func(value types.Datetime, upper types.Timestamp) bool {
+				return value.ToTimestamp(zone).TruncateToScale(upperScale) <= upper
+			})
 	case parameters[0].GetType().Oid == types.T_timestamp &&
 		parameters[1].GetType().Oid == types.T_timestamp:
 		return opBetweenTemporal[types.Timestamp, types.Timestamp, types.Datetime](
-			parameters, result, length, identityTimestamp, identityTimestamp, toDatetimeTimestamp)
+			parameters, result, length,
+			func(value, lower types.Timestamp) bool { return value >= lower },
+			func(value types.Timestamp, upper types.Datetime) bool {
+				return value <= upper.ToTimestamp(zone).TruncateToScale(valueScale)
+			})
 	case parameters[0].GetType().Oid == types.T_timestamp &&
 		parameters[2].GetType().Oid == types.T_timestamp:
 		return opBetweenTemporal[types.Timestamp, types.Datetime, types.Timestamp](
-			parameters, result, length, identityTimestamp, toDatetimeTimestamp, identityTimestamp)
+			parameters, result, length,
+			func(value types.Timestamp, lower types.Datetime) bool {
+				return value >= lower.ToTimestamp(zone).TruncateToScale(valueScale)
+			},
+			func(value, upper types.Timestamp) bool { return value <= upper })
 	default:
 		return opBetweenTemporal[types.Timestamp, types.Datetime, types.Datetime](
-			parameters, result, length, identityTimestamp, toDatetimeTimestamp, toDatetimeTimestamp)
+			parameters, result, length,
+			func(value types.Timestamp, lower types.Datetime) bool {
+				return value >= lower.ToTimestamp(zone).TruncateToScale(valueScale)
+			},
+			func(value types.Timestamp, upper types.Datetime) bool {
+				return value <= upper.ToTimestamp(zone).TruncateToScale(valueScale)
+			})
 	}
 }
 
@@ -156,9 +177,8 @@ func opBetweenTemporal[
 	parameters []*vector.Vector,
 	result *vector.FunctionResult[bool],
 	length int,
-	valueToTimestamp func(V) types.Timestamp,
-	lowerToTimestamp func(L) types.Timestamp,
-	upperToTimestamp func(U) types.Timestamp,
+	matchesLower func(V, L) bool,
+	matchesUpper func(V, U) bool,
 ) error {
 	valueParam := vector.GenerateFunctionFixedTypeParameter[V](parameters[0])
 	lowerParam := vector.GenerateFunctionFixedTypeParameter[L](parameters[1])
@@ -175,8 +195,7 @@ func opBetweenTemporal[
 			resultNulls.Add(i)
 			continue
 		}
-		instant := valueToTimestamp(value)
-		values[i] = instant >= lowerToTimestamp(lower) && instant <= upperToTimestamp(upper)
+		values[i] = matchesLower(value, lower) && matchesUpper(value, upper)
 	}
 	return nil
 }

--- a/pkg/sql/plan/function/operator_between.go
+++ b/pkg/sql/plan/function/operator_between.go
@@ -28,6 +28,9 @@ import (
 func betweenImpl(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
 	rs := vector.MustFunctionResult[bool](result)
+	if isMixedDatetimeTimestampTypes(parameters) {
+		return opBetweenDatetimeTimestamp(parameters, rs, proc, length)
+	}
 	switch paramType.Oid {
 	case types.T_bool:
 		return opBetweenBool(parameters, rs, proc, length)
@@ -81,6 +84,101 @@ func betweenImpl(parameters []*vector.Vector, result vector.FunctionResultWrappe
 	}
 
 	panic("unreached code")
+}
+
+func isMixedDatetimeTimestampTypes(parameters []*vector.Vector) bool {
+	if len(parameters) != 3 {
+		return false
+	}
+	hasDatetime, hasTimestamp := false, false
+	for _, parameter := range parameters {
+		switch parameter.GetType().Oid {
+		case types.T_datetime:
+			hasDatetime = true
+		case types.T_timestamp:
+			hasTimestamp = true
+		default:
+			return false
+		}
+	}
+	return hasDatetime && hasTimestamp
+}
+
+func opBetweenDatetimeTimestamp(
+	parameters []*vector.Vector,
+	result *vector.FunctionResult[bool],
+	proc *process.Process,
+	length int,
+) error {
+	timestampScale := int32(6)
+	for _, parameter := range parameters {
+		if parameter.GetType().Oid == types.T_timestamp {
+			timestampScale = parameter.GetType().Scale
+			break
+		}
+	}
+	toDatetimeTimestamp := func(value types.Datetime) types.Timestamp {
+		return value.ToTimestamp(proc.GetSessionInfo().TimeZone).TruncateToScale(timestampScale)
+	}
+	identityTimestamp := func(value types.Timestamp) types.Timestamp { return value }
+
+	switch {
+	case parameters[0].GetType().Oid == types.T_datetime &&
+		parameters[1].GetType().Oid == types.T_datetime:
+		return opBetweenTemporal[types.Datetime, types.Datetime, types.Timestamp](
+			parameters, result, length, toDatetimeTimestamp, toDatetimeTimestamp, identityTimestamp)
+	case parameters[0].GetType().Oid == types.T_datetime &&
+		parameters[2].GetType().Oid == types.T_datetime:
+		return opBetweenTemporal[types.Datetime, types.Timestamp, types.Datetime](
+			parameters, result, length, toDatetimeTimestamp, identityTimestamp, toDatetimeTimestamp)
+	case parameters[0].GetType().Oid == types.T_datetime:
+		return opBetweenTemporal[types.Datetime, types.Timestamp, types.Timestamp](
+			parameters, result, length, toDatetimeTimestamp, identityTimestamp, identityTimestamp)
+	case parameters[0].GetType().Oid == types.T_timestamp &&
+		parameters[1].GetType().Oid == types.T_timestamp:
+		return opBetweenTemporal[types.Timestamp, types.Timestamp, types.Datetime](
+			parameters, result, length, identityTimestamp, identityTimestamp, toDatetimeTimestamp)
+	case parameters[0].GetType().Oid == types.T_timestamp &&
+		parameters[2].GetType().Oid == types.T_timestamp:
+		return opBetweenTemporal[types.Timestamp, types.Datetime, types.Timestamp](
+			parameters, result, length, identityTimestamp, toDatetimeTimestamp, identityTimestamp)
+	default:
+		return opBetweenTemporal[types.Timestamp, types.Datetime, types.Datetime](
+			parameters, result, length, identityTimestamp, toDatetimeTimestamp, toDatetimeTimestamp)
+	}
+}
+
+func opBetweenTemporal[
+	V types.Datetime | types.Timestamp,
+	L types.Datetime | types.Timestamp,
+	U types.Datetime | types.Timestamp,
+](
+	parameters []*vector.Vector,
+	result *vector.FunctionResult[bool],
+	length int,
+	valueToTimestamp func(V) types.Timestamp,
+	lowerToTimestamp func(L) types.Timestamp,
+	upperToTimestamp func(U) types.Timestamp,
+) error {
+	valueParam := vector.GenerateFunctionFixedTypeParameter[V](parameters[0])
+	lowerParam := vector.GenerateFunctionFixedTypeParameter[L](parameters[1])
+	upperParam := vector.GenerateFunctionFixedTypeParameter[U](parameters[2])
+	resultVector := result.GetResultVector()
+	values := vector.MustFixedColNoTypeCheck[bool](resultVector)
+	resultNulls := resultVector.GetNulls()
+
+	for i := uint64(0); i < uint64(length); i++ {
+		value, valueNull := valueParam.GetValue(i)
+		lower, lowerNull := lowerParam.GetValue(i)
+		upper, upperNull := upperParam.GetValue(i)
+		if valueNull || lowerNull || upperNull {
+			resultNulls.Add(i)
+			continue
+		}
+		instant := valueToTimestamp(value)
+		values[i] = instant >= lowerToTimestamp(lower) && instant <= upperToTimestamp(upper)
+	}
+	return nil
 }
 
 func opBetweenBool(

--- a/pkg/sql/plan/function/operator_between.go
+++ b/pkg/sql/plan/function/operator_between.go
@@ -17,6 +17,7 @@ package function
 import (
 	"bytes"
 	"sort"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -133,14 +134,9 @@ func opBetweenDatetimeTimestamp(
 			},
 			func(value, upper types.Datetime) bool { return value <= upper })
 	case parameters[0].GetType().Oid == types.T_datetime:
-		return opBetweenTemporal[types.Datetime, types.Timestamp, types.Timestamp](
-			parameters, result, length,
-			func(value types.Datetime, lower types.Timestamp) bool {
-				return value.ToTimestamp(zone).TruncateToScale(lowerScale) >= lower
-			},
-			func(value types.Datetime, upper types.Timestamp) bool {
-				return value.ToTimestamp(zone).TruncateToScale(upperScale) <= upper
-			})
+		return opBetweenDatetimeAndTimestampBounds(
+			parameters, result, zone, lowerScale, length,
+		)
 	case parameters[0].GetType().Oid == types.T_timestamp &&
 		parameters[1].GetType().Oid == types.T_timestamp:
 		return opBetweenTemporal[types.Timestamp, types.Timestamp, types.Datetime](
@@ -167,6 +163,38 @@ func opBetweenDatetimeTimestamp(
 				return value <= upper.ToTimestamp(zone).TruncateToScale(valueScale)
 			})
 	}
+}
+
+// The pre-existing BETWEEN cast rule converted the value using the lower
+// comparison's target type, then reused that value for the upper comparison.
+// Preserve that observable precision contract while keeping the plan operands
+// cross-typed so storage can still see an unwrapped DATETIME column.
+func opBetweenDatetimeAndTimestampBounds(
+	parameters []*vector.Vector,
+	result *vector.FunctionResult[bool],
+	zone *time.Location,
+	timestampScale int32,
+	length int,
+) error {
+	valueParam := vector.GenerateFunctionFixedTypeParameter[types.Datetime](parameters[0])
+	lowerParam := vector.GenerateFunctionFixedTypeParameter[types.Timestamp](parameters[1])
+	upperParam := vector.GenerateFunctionFixedTypeParameter[types.Timestamp](parameters[2])
+	resultVector := result.GetResultVector()
+	values := vector.MustFixedColNoTypeCheck[bool](resultVector)
+	resultNulls := resultVector.GetNulls()
+
+	for i := uint64(0); i < uint64(length); i++ {
+		value, valueNull := valueParam.GetValue(i)
+		lower, lowerNull := lowerParam.GetValue(i)
+		upper, upperNull := upperParam.GetValue(i)
+		if valueNull || lowerNull || upperNull {
+			resultNulls.Add(i)
+			continue
+		}
+		instant := value.ToTimestamp(zone).TruncateToScale(timestampScale)
+		values[i] = instant >= lower && instant <= upper
+	}
+	return nil
 }
 
 func opBetweenTemporal[

--- a/pkg/sql/plan/function/operator_between_test.go
+++ b/pkg/sql/plan/function/operator_between_test.go
@@ -75,6 +75,93 @@ func TestBetweenDatetimeTimestampPreservesCommonValueScale(t *testing.T) {
 	require.True(t, ok, info)
 }
 
+func TestBetweenDatetimeTimestampTypeArrangements(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	proc.GetSessionInfo().TimeZone = time.UTC
+
+	valueDatetime, err := types.ParseDatetime("2026-08-10 12:00:00", 6)
+	require.NoError(t, err)
+	lowerDatetime, err := types.ParseDatetime("2026-08-10 11:00:00", 6)
+	require.NoError(t, err)
+	upperDatetime, err := types.ParseDatetime("2026-08-10 13:00:00", 6)
+	require.NoError(t, err)
+	valueTimestamp := valueDatetime.ToTimestamp(time.UTC)
+	lowerTimestamp := lowerDatetime.ToTimestamp(time.UTC)
+	upperTimestamp := upperDatetime.ToTimestamp(time.UTC)
+
+	datetimeType := types.T_datetime.ToTypeWithScale(6)
+	timestampType := types.T_timestamp.ToTypeWithScale(6)
+	datetimeInput := func(value types.Datetime, nulls []bool) FunctionTestInput {
+		return NewFunctionTestInput(datetimeType, []types.Datetime{value, value}, nulls)
+	}
+	timestampInput := func(value types.Timestamp, nulls []bool) FunctionTestInput {
+		return NewFunctionTestInput(timestampType, []types.Timestamp{value, value}, nulls)
+	}
+
+	tests := []struct {
+		name   string
+		inputs []FunctionTestInput
+	}{
+		{
+			name: "datetime value datetime lower timestamp upper",
+			inputs: []FunctionTestInput{
+				datetimeInput(valueDatetime, []bool{false, true}),
+				datetimeInput(lowerDatetime, nil),
+				timestampInput(upperTimestamp, nil),
+			},
+		},
+		{
+			name: "datetime value timestamp lower datetime upper",
+			inputs: []FunctionTestInput{
+				datetimeInput(valueDatetime, []bool{false, true}),
+				timestampInput(lowerTimestamp, nil),
+				datetimeInput(upperDatetime, nil),
+			},
+		},
+		{
+			name: "timestamp value timestamp lower datetime upper",
+			inputs: []FunctionTestInput{
+				timestampInput(valueTimestamp, []bool{false, true}),
+				timestampInput(lowerTimestamp, nil),
+				datetimeInput(upperDatetime, nil),
+			},
+		},
+		{
+			name: "timestamp value datetime lower timestamp upper",
+			inputs: []FunctionTestInput{
+				timestampInput(valueTimestamp, []bool{false, true}),
+				datetimeInput(lowerDatetime, nil),
+				timestampInput(upperTimestamp, nil),
+			},
+		},
+		{
+			name: "timestamp value datetime bounds",
+			inputs: []FunctionTestInput{
+				timestampInput(valueTimestamp, []bool{false, true}),
+				datetimeInput(lowerDatetime, nil),
+				datetimeInput(upperDatetime, nil),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testCase := NewFunctionTestCase(
+				proc,
+				test.inputs,
+				NewFunctionTestResult(
+					types.T_bool.ToType(), false,
+					[]bool{true, false}, []bool{false, true},
+				),
+				betweenImpl,
+			)
+			ok, info := testCase.Run()
+			require.True(t, ok, info)
+		})
+	}
+}
+
 func TestOpBetweenBool(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	boolType := types.T_bool.ToType()

--- a/pkg/sql/plan/function/operator_between_test.go
+++ b/pkg/sql/plan/function/operator_between_test.go
@@ -16,11 +16,40 @@ package function
 
 import (
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBetweenDatetimeTimestampPreservesInstantSemantics(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	zone, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	proc.GetSessionInfo().TimeZone = zone
+
+	datetime, err := types.ParseDatetime("2024-11-03 01:30:00", 6)
+	require.NoError(t, err)
+	lower, err := types.ParseTimestamp(time.UTC, "2024-11-03 05:00:00", 6)
+	require.NoError(t, err)
+	upper, err := types.ParseTimestamp(time.UTC, "2024-11-03 06:15:00", 6)
+	require.NoError(t, err)
+	want := datetime.ToTimestamp(zone) >= lower && datetime.ToTimestamp(zone) <= upper
+
+	testCase := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_datetime.ToTypeWithScale(6), []types.Datetime{datetime, datetime}, []bool{false, true}),
+			NewFunctionTestConstInput(types.T_timestamp.ToTypeWithScale(6), []types.Timestamp{lower}, nil),
+			NewFunctionTestConstInput(types.T_timestamp.ToTypeWithScale(6), []types.Timestamp{upper}, nil),
+		},
+		NewFunctionTestResult(types.T_bool.ToType(), false, []bool{want, false}, []bool{false, true}),
+		betweenImpl,
+	)
+	ok, info := testCase.Run()
+	require.True(t, ok, info)
+}
 
 func TestOpBetweenBool(t *testing.T) {
 	proc := testutil.NewProcess(t)

--- a/pkg/sql/plan/function/operator_between_test.go
+++ b/pkg/sql/plan/function/operator_between_test.go
@@ -51,6 +51,30 @@ func TestBetweenDatetimeTimestampPreservesInstantSemantics(t *testing.T) {
 	require.True(t, ok, info)
 }
 
+func TestBetweenDatetimeTimestampUsesEachBoundScale(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	proc.GetSessionInfo().TimeZone = time.UTC
+
+	value, err := types.ParseDatetime("2026-08-10 12:00:00.123456", 6)
+	require.NoError(t, err)
+	lower := value.ToTimestamp(time.UTC).TruncateToScale(3)
+	upper, err := types.ParseTimestamp(time.UTC, "2026-08-10 12:00:00.123100", 6)
+	require.NoError(t, err)
+
+	testCase := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_datetime.ToTypeWithScale(6), []types.Datetime{value}, nil),
+			NewFunctionTestConstInput(types.T_timestamp.ToTypeWithScale(3), []types.Timestamp{lower}, nil),
+			NewFunctionTestConstInput(types.T_timestamp.ToTypeWithScale(6), []types.Timestamp{upper}, nil),
+		},
+		NewFunctionTestResult(types.T_bool.ToType(), false, []bool{false}, nil),
+		betweenImpl,
+	)
+	ok, info := testCase.Run()
+	require.True(t, ok, info)
+}
+
 func TestOpBetweenBool(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	boolType := types.T_bool.ToType()

--- a/pkg/sql/plan/function/operator_between_test.go
+++ b/pkg/sql/plan/function/operator_between_test.go
@@ -51,7 +51,7 @@ func TestBetweenDatetimeTimestampPreservesInstantSemantics(t *testing.T) {
 	require.True(t, ok, info)
 }
 
-func TestBetweenDatetimeTimestampUsesEachBoundScale(t *testing.T) {
+func TestBetweenDatetimeTimestampPreservesCommonValueScale(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	defer proc.Free()
 	proc.GetSessionInfo().TimeZone = time.UTC
@@ -68,7 +68,7 @@ func TestBetweenDatetimeTimestampUsesEachBoundScale(t *testing.T) {
 			NewFunctionTestConstInput(types.T_timestamp.ToTypeWithScale(3), []types.Timestamp{lower}, nil),
 			NewFunctionTestConstInput(types.T_timestamp.ToTypeWithScale(6), []types.Timestamp{upper}, nil),
 		},
-		NewFunctionTestResult(types.T_bool.ToType(), false, []bool{false}, nil),
+		NewFunctionTestResult(types.T_bool.ToType(), false, []bool{true}, nil),
 		betweenImpl,
 	)
 	ok, info := testCase.Run()

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1165,7 +1165,7 @@ func (tbl *txnTable) rangesOnePart(
 ) (err error) {
 	var done bool
 
-	if done, err = readutil.TryFastFilterBlocks(
+	if done, err = readutil.TryFastFilterBlocksWithZone(
 		ctx,
 		tbl.db.op.SnapshotTS(),
 		tbl.tableDef,
@@ -1176,6 +1176,7 @@ func (tbl *txnTable) rangesOnePart(
 		outBlocks,
 		tbl.PrefetchAllMeta,
 		tbl.getTxn().engine.fs,
+		proc.GetSessionInfo().TimeZone,
 	); err != nil {
 		return err
 	} else if done {

--- a/pkg/vm/engine/readutil/exec_util.go
+++ b/pkg/vm/engine/readutil/exec_util.go
@@ -254,7 +254,28 @@ func TryFastFilterBlocks(
 	metaPrefetcher func(context.Context) bool,
 	fs fileservice.FileService,
 ) (ok bool, err error) {
-	fastFilterOp, loadOp, objectFilterOp, blockFilterOp, seekOp, ok, highSelectivityHint := CompileFilterExprs(rangesParam.BlockFilters, tableDef, fs)
+	return TryFastFilterBlocksWithZone(
+		ctx, snapshotTS, tableDef, rangesParam, objectList,
+		extraCommittedObjects, uncommittedObjects, outBlocks, metaPrefetcher, fs, nil,
+	)
+}
+
+func TryFastFilterBlocksWithZone(
+	ctx context.Context,
+	snapshotTS timestamp.Timestamp,
+	tableDef *plan.TableDef,
+	rangesParam engine.RangesParam,
+	objectList objectio.ObjectList,
+	extraCommittedObjects []objectio.ObjectStats,
+	uncommittedObjects []objectio.ObjectStats,
+	outBlocks *objectio.BlockInfoSlice,
+	metaPrefetcher func(context.Context) bool,
+	fs fileservice.FileService,
+	zone *time.Location,
+) (ok bool, err error) {
+	fastFilterOp, loadOp, objectFilterOp, blockFilterOp, seekOp, ok, highSelectivityHint := compileFilterExprs(
+		rangesParam.BlockFilters, tableDef, fs, zone,
+	)
 	if !ok {
 		return false, nil
 	}

--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -608,7 +608,6 @@ func compileTemporalFilterExpr(
 	if !isMixedTemporalFilterTypes(temporalTypes...) {
 		return
 	}
-	handled = true
 	if zone == nil {
 		return nil, nil, nil, nil, nil, false, false, true
 	}

--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -17,6 +17,7 @@ package readutil
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -394,10 +395,310 @@ func zoneMapMetadataComparable(
 	return bound == nil || (bound.IsInited() && bound.GetType() == columnType)
 }
 
+type temporalFilterRange struct {
+	min types.Timestamp
+	max types.Timestamp
+}
+
+func temporalFilterRangeFromZoneMap(
+	zm objectio.ZoneMap,
+	timestampScale int32,
+	zone *time.Location,
+) (temporalFilterRange, bool) {
+	switch zm.GetType() {
+	case types.T_timestamp:
+		minValue, minOK := zm.GetMin().(types.Timestamp)
+		maxValue, maxOK := zm.GetMax().(types.Timestamp)
+		return temporalFilterRange{min: minValue, max: maxValue}, minOK && maxOK
+	case types.T_datetime:
+		minValue, minOK := zm.GetMin().(types.Datetime)
+		maxValue, maxOK := zm.GetMax().(types.Datetime)
+		if !minOK || !maxOK {
+			return temporalFilterRange{}, false
+		}
+		if minValue == maxValue {
+			value := minValue.ToTimestamp(zone).TruncateToScale(timestampScale)
+			return temporalFilterRange{min: value, max: value}, true
+		}
+		minTimestamp, maxTimestamp, ok := types.DatetimeRangeToTimestampRange(minValue, maxValue, zone)
+		if !ok {
+			return temporalFilterRange{}, false
+		}
+		return temporalFilterRange{
+			min: minTimestamp.TruncateToScale(timestampScale),
+			max: maxTimestamp.TruncateToScale(timestampScale),
+		}, true
+	default:
+		return temporalFilterRange{}, false
+	}
+}
+
+func temporalFilterRangeFromValue(
+	value []byte,
+	valueType types.T,
+	timestampScale int32,
+	zone *time.Location,
+) (temporalFilterRange, bool) {
+	if len(value) != 8 {
+		return temporalFilterRange{}, false
+	}
+	var timestamp types.Timestamp
+	switch valueType {
+	case types.T_timestamp:
+		timestamp = types.DecodeTimestamp(value)
+	case types.T_datetime:
+		timestamp = types.DecodeDatetime(value).ToTimestamp(zone).TruncateToScale(timestampScale)
+	default:
+		return temporalFilterRange{}, false
+	}
+	return temporalFilterRange{min: timestamp, max: timestamp}, true
+}
+
+func temporalFilterMatch(op string, value, bound temporalFilterRange) zoneMapMatch {
+	var matches bool
+	switch op {
+	case "=":
+		matches = value.max >= bound.min && value.min <= bound.max
+	case "<":
+		matches = value.min < bound.max
+	case "<=":
+		matches = value.min <= bound.max
+	case ">":
+		matches = value.max > bound.min
+	case ">=":
+		matches = value.max >= bound.min
+	default:
+		return zoneMapMatch{}
+	}
+	return zoneMapMatch{matches: matches, comparable: true}
+}
+
+func makeTemporalFilterMatcher(
+	columnType types.T,
+	columnScale int32,
+	value []byte,
+	valueType types.T,
+	valueScale int32,
+	zone *time.Location,
+	op string,
+) (func(objectio.ZoneMap) zoneMapMatch, bool) {
+	if columnType == valueType {
+		return func(zm objectio.ZoneMap) zoneMapMatch {
+			switch op {
+			case "=":
+				return intersectsBound(zm, value, nil, columnType)
+			case "<":
+				return anyLTByBound(zm, value, nil, columnType)
+			case "<=":
+				return anyLEByBound(zm, value, nil, columnType)
+			case ">":
+				return anyGTByBound(zm, value, nil, columnType)
+			case ">=":
+				return anyGEByBound(zm, value, nil, columnType)
+			default:
+				return zoneMapMatch{}
+			}
+		}, true
+	}
+	if !isMixedTemporalFilterTypes(columnType, valueType) {
+		return nil, false
+	}
+
+	timestampScale := valueScale
+	if columnType == types.T_timestamp {
+		timestampScale = columnScale
+	}
+	bound, ok := temporalFilterRangeFromValue(value, valueType, timestampScale, zone)
+	if !ok {
+		return nil, false
+	}
+	return func(zm objectio.ZoneMap) zoneMapMatch {
+		valueRange, ok := temporalFilterRangeFromZoneMap(zm, timestampScale, zone)
+		if !ok {
+			return zoneMapMatch{}
+		}
+		return temporalFilterMatch(op, valueRange, bound)
+	}, true
+}
+
+func reverseTemporalFilterOperator(op string) string {
+	switch op {
+	case "<":
+		return ">"
+	case "<=":
+		return ">="
+	case ">":
+		return "<"
+	case ">=":
+		return "<="
+	default:
+		return op
+	}
+}
+
+func isMixedTemporalFilterTypes(typesToCheck ...types.T) bool {
+	hasDatetime, hasTimestamp := false, false
+	for _, typ := range typesToCheck {
+		switch typ {
+		case types.T_datetime:
+			hasDatetime = true
+		case types.T_timestamp:
+			hasTimestamp = true
+		default:
+			return false
+		}
+	}
+	return hasDatetime && hasTimestamp
+}
+
+func compileTemporalFilterExpr(
+	expr *plan.Expr,
+	exprImpl *plan.Expr_F,
+	tableDef *plan.TableDef,
+	fs fileservice.FileService,
+	zone *time.Location,
+) (
+	fastFilterOp FastFilterOp,
+	loadOp LoadOp,
+	objectFilterOp ObjectFilterOp,
+	blockFilterOp BlockFilterOp,
+	seekOp SeekFirstBlockOp,
+	canCompile bool,
+	highSelectivityHint bool,
+	handled bool,
+) {
+	op := exprImpl.F.Func.ObjName
+	if op != "=" && op != "<" && op != "<=" && op != ">" && op != ">=" && op != "between" {
+		return
+	}
+
+	args := exprImpl.F.Args
+	var colExpr *plan.Expr_Col
+	var columnPlanExpr *plan.Expr
+	var valueExprs []*plan.Expr
+	columnOnLeft := true
+	if op == "between" {
+		if len(args) != 3 {
+			return
+		}
+		var ok bool
+		if colExpr, ok = args[0].Expr.(*plan.Expr_Col); !ok {
+			return
+		}
+		columnPlanExpr = args[0]
+		valueExprs = args[1:]
+	} else {
+		if len(args) != 2 {
+			return
+		}
+		if col, ok := args[0].Expr.(*plan.Expr_Col); ok {
+			colExpr = col
+			columnPlanExpr = args[0]
+			valueExprs = args[1:]
+		} else if col, ok := args[1].Expr.(*plan.Expr_Col); ok {
+			colExpr = col
+			columnPlanExpr = args[1]
+			valueExprs = args[:1]
+			columnOnLeft = false
+		} else {
+			return
+		}
+	}
+
+	temporalTypes := make([]types.T, 0, len(valueExprs)+1)
+	temporalTypes = append(temporalTypes, types.T(columnPlanExpr.Typ.Id))
+	for _, valueExpr := range valueExprs {
+		temporalTypes = append(temporalTypes, types.T(valueExpr.Typ.Id))
+	}
+	if !isMixedTemporalFilterTypes(temporalTypes...) {
+		return
+	}
+	handled = true
+	if zone == nil {
+		return nil, nil, nil, nil, nil, false, false, true
+	}
+
+	values, ok := getConstBytesFromExpr(valueExprs)
+	if !ok {
+		return nil, nil, nil, nil, nil, false, false, true
+	}
+	colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+	if !columnOnLeft {
+		op = reverseTemporalFilterOperator(op)
+	}
+
+	matchers := make([]func(objectio.ZoneMap) zoneMapMatch, len(values))
+	for i := range values {
+		comparisonOp := op
+		if op == "between" {
+			if i == 0 {
+				comparisonOp = ">="
+			} else {
+				comparisonOp = "<="
+			}
+		}
+		matchers[i], ok = makeTemporalFilterMatcher(
+			types.T(colDef.Typ.Id), colDef.Typ.Scale,
+			values[i], types.T(valueExprs[i].Typ.Id), valueExprs[i].Typ.Scale,
+			zone, comparisonOp,
+		)
+		if !ok {
+			return nil, nil, nil, nil, nil, false, false, true
+		}
+	}
+	match := func(zm objectio.ZoneMap) zoneMapMatch {
+		if op == "between" {
+			return matchers[0](zm).and(matchers[1](zm))
+		}
+		return matchers[0](zm)
+	}
+
+	isPK, isSorted := isSortedKey(colDef)
+	if isSorted {
+		fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
+			if obj.ZMIsEmpty() {
+				return true, nil
+			}
+			return match(obj.SortKeyZoneMap()).mayMatch(), nil
+		}
+	}
+	loadOp = loadMetadataOnlyOpFactory(fs)
+	seqNum := colDef.Seqnum
+	objectFilterOp = func(meta objectio.ObjectMeta, _ objectio.BloomFilter) (bool, error) {
+		if isSorted {
+			return true, nil
+		}
+		return match(meta.MustDataMeta().MustGetColumn(uint16(seqNum)).ZoneMap()).mayMatch(), nil
+	}
+	blockFilterOp = func(
+		_ int, blkMeta objectio.BlockObject, _ objectio.BloomFilter,
+	) (bool, bool, error) {
+		return false, match(blkMeta.MustGetColumn(uint16(seqNum)).ZoneMap()).mayMatch(), nil
+	}
+	return fastFilterOp, loadOp, objectFilterOp, blockFilterOp, nil, true, isPK, true
+}
+
 func CompileFilterExprs(
 	exprs []*plan.Expr,
 	tableDef *plan.TableDef,
 	fs fileservice.FileService,
+) (
+	fastFilterOp FastFilterOp,
+	loadOp LoadOp,
+	objectFilterOp ObjectFilterOp,
+	blockFilterOp BlockFilterOp,
+	seekOp SeekFirstBlockOp,
+	canCompile bool,
+	highSelectivityHint bool,
+) {
+	return compileFilterExprs(exprs, tableDef, fs, nil)
+}
+
+func compileFilterExprs(
+	exprs []*plan.Expr,
+	tableDef *plan.TableDef,
+	fs fileservice.FileService,
+	zone *time.Location,
 ) (
 	fastFilterOp FastFilterOp,
 	loadOp LoadOp,
@@ -412,7 +713,7 @@ func CompileFilterExprs(
 		return
 	}
 	if len(exprs) == 1 {
-		return CompileFilterExpr(exprs[0], tableDef, fs)
+		return compileFilterExpr(exprs[0], tableDef, fs, zone)
 	}
 	ops1 := make([]FastFilterOp, 0, len(exprs))
 	ops2 := make([]LoadOp, 0, len(exprs))
@@ -422,7 +723,7 @@ func CompileFilterExprs(
 	compiled := 0
 
 	for _, expr := range exprs {
-		expr_op1, expr_op2, expr_op3, expr_op4, expr_op5, can, hsh := CompileFilterExpr(expr, tableDef, fs)
+		expr_op1, expr_op2, expr_op3, expr_op4, expr_op5, can, hsh := compileFilterExpr(expr, tableDef, fs, zone)
 		if !can {
 			continue
 		}
@@ -525,6 +826,23 @@ func CompileFilterExpr(
 	canCompile bool,
 	highSelectivityHint bool,
 ) {
+	return compileFilterExpr(expr, tableDef, fs, nil)
+}
+
+func compileFilterExpr(
+	expr *plan.Expr,
+	tableDef *plan.TableDef,
+	fs fileservice.FileService,
+	zone *time.Location,
+) (
+	fastFilterOp FastFilterOp,
+	loadOp LoadOp,
+	objectFilterOp ObjectFilterOp,
+	blockFilterOp BlockFilterOp,
+	seekOp SeekFirstBlockOp,
+	canCompile bool,
+	highSelectivityHint bool,
+) {
 	canCompile = true
 	if expr == nil {
 		return
@@ -533,6 +851,12 @@ func CompileFilterExpr(
 	// case *plan.Expr_Lit:
 	// case *plan.Expr_Col:
 	case *plan.Expr_F:
+		if op1, op2, op3, op4, op5, can, hsh, handled := compileTemporalFilterExpr(
+			expr, exprImpl, tableDef, fs, zone,
+		); handled {
+			return op1, op2, op3, op4, op5, can, hsh
+		}
+
 		switch exprImpl.F.Func.ObjName {
 		case "or":
 			highSelectivityHint = true
@@ -543,7 +867,7 @@ func CompileFilterExpr(
 			seekOps := make([]SeekFirstBlockOp, 0, len(exprImpl.F.Args))
 
 			for idx := range exprImpl.F.Args {
-				op1, op2, op3, op4, op5, can, hsh := CompileFilterExpr(exprImpl.F.Args[idx], tableDef, fs)
+				op1, op2, op3, op4, op5, can, hsh := compileFilterExpr(exprImpl.F.Args[idx], tableDef, fs, zone)
 				if !can {
 					return nil, nil, nil, nil, nil, false, false
 				}
@@ -637,7 +961,7 @@ func CompileFilterExpr(
 			compiled := 0
 
 			for idx := range exprImpl.F.Args {
-				op1, op2, op3, op4, op5, can, hsh := CompileFilterExpr(exprImpl.F.Args[idx], tableDef, fs)
+				op1, op2, op3, op4, op5, can, hsh := compileFilterExpr(exprImpl.F.Args[idx], tableDef, fs, zone)
 				if !can {
 					continue
 				}

--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -475,10 +475,9 @@ func temporalFilterMatch(op string, value, bound temporalFilterRange) zoneMapMat
 
 func makeTemporalFilterMatcher(
 	columnType types.T,
-	columnScale int32,
 	value []byte,
 	valueType types.T,
-	valueScale int32,
+	timestampScale int32,
 	zone *time.Location,
 	op string,
 ) (func(objectio.ZoneMap) zoneMapMatch, bool) {
@@ -504,10 +503,6 @@ func makeTemporalFilterMatcher(
 		return nil, false
 	}
 
-	timestampScale := valueScale
-	if columnType == types.T_timestamp {
-		timestampScale = columnScale
-	}
 	bound, ok := temporalFilterRangeFromValue(value, valueType, timestampScale, zone)
 	if !ok {
 		return nil, false
@@ -628,6 +623,13 @@ func compileTemporalFilterExpr(
 	}
 
 	matchers := make([]func(objectio.ZoneMap) zoneMapMatch, len(values))
+	columnType := types.T(colDef.Typ.Id)
+	commonBetweenScale := int32(-1)
+	if op == "between" && columnType == types.T_datetime &&
+		types.T(valueExprs[0].Typ.Id) == types.T_timestamp &&
+		types.T(valueExprs[1].Typ.Id) == types.T_timestamp {
+		commonBetweenScale = valueExprs[0].Typ.Scale
+	}
 	for i := range values {
 		comparisonOp := op
 		if op == "between" {
@@ -637,9 +639,15 @@ func compileTemporalFilterExpr(
 				comparisonOp = "<="
 			}
 		}
+		timestampScale := valueExprs[i].Typ.Scale
+		if columnType == types.T_timestamp {
+			timestampScale = colDef.Typ.Scale
+		} else if commonBetweenScale >= 0 {
+			timestampScale = commonBetweenScale
+		}
 		matchers[i], ok = makeTemporalFilterMatcher(
-			types.T(colDef.Typ.Id), colDef.Typ.Scale,
-			values[i], types.T(valueExprs[i].Typ.Id), valueExprs[i].Typ.Scale,
+			columnType,
+			values[i], types.T(valueExprs[i].Typ.Id), timestampScale,
 			zone, comparisonOp,
 		)
 		if !ok {

--- a/pkg/vm/engine/readutil/expr_util.go
+++ b/pkg/vm/engine/readutil/expr_util.go
@@ -102,9 +102,10 @@ func evalValue(
 ) {
 	var val []byte
 	var col *plan.Expr_Col
+	var valExprs []*plan.Expr
 
 	if !isVec {
-		col, vals, ok = mustColConstValueFromBinaryFuncExpr(exprImpl)
+		col, vals, valExprs, ok = mustColConstValueWithTypeFromBinaryFuncExpr(exprImpl)
 	} else {
 		col, val, ok = mustColVecValueFromBinaryFuncExpr(exprImpl)
 	}
@@ -154,7 +155,28 @@ func evalValue(
 	if isVec {
 		return true, types.T(tblDef.Cols[colPos].Typ.Id), [][]byte{val}
 	}
+	if mixedTemporalColumnAndValues(types.T(tblDef.Cols[colPos].Typ.Id), valExprs) {
+		return false, 0, nil
+	}
 	return true, types.T(tblDef.Cols[colPos].Typ.Id), vals
+}
+
+// A BasePKFilter compares persisted primary-key bytes directly. DATETIME and
+// TIMESTAMP use different physical domains, so a cross-typed scalar predicate
+// cannot be represented without the session time zone. Keep it on the residual
+// expression path instead of constructing a filter that can drop matching rows.
+func mixedTemporalColumnAndValues(
+	columnType types.T,
+	values []*plan.Expr,
+) bool {
+	for _, value := range values {
+		valueType := types.T(value.Typ.Id)
+		if columnType == types.T_datetime && valueType == types.T_timestamp ||
+			columnType == types.T_timestamp && valueType == types.T_datetime {
+			return true
+		}
+	}
+	return false
 }
 
 func mustColConstValueFromBinaryFuncExpr(

--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,7 +146,7 @@ func TestCompileTemporalFilterExprUsesSessionTimezone(t *testing.T) {
 		require.True(t, selected)
 	})
 
-	t.Run("between applies each timestamp bound scale", func(t *testing.T) {
+	t.Run("between preserves common value scale", func(t *testing.T) {
 		value := parseDatetime("2026-08-10 12:00:00.123456")
 		lower := makeTimestampExpr("2026-08-10 12:00:00.123456")
 		lower.Typ.Scale = 3
@@ -157,7 +158,7 @@ func TestCompileTemporalFilterExprUsesSessionTimezone(t *testing.T) {
 
 		_, selected, err := blockFilter(0, makeDatetimeMeta(value), nil)
 		require.NoError(t, err)
-		require.False(t, selected)
+		require.True(t, selected)
 	})
 
 	t.Run("timestamp column with datetime bound", func(t *testing.T) {
@@ -213,6 +214,94 @@ func TestCompileTemporalFilterExprUsesSessionTimezone(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, selected)
 	})
+}
+
+func TestConstructBasePKFilterRejectsMixedTemporalEncoding(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	proc.GetSessionInfo().TimeZone = time.FixedZone("UTC+08", 8*3600)
+	datetime, err := types.ParseDatetime("2026-08-10 10:00:00", 6)
+	require.NoError(t, err)
+	timestamp := datetime.ToTimestamp(proc.GetSessionInfo().TimeZone)
+
+	makeTable := func(oid types.T) *plan.TableDef {
+		return &plan.TableDef{
+			Name:          "temporal_pk",
+			Name2ColIndex: map[string]int32{"v": 0},
+			Cols: []*plan.ColDef{{
+				Name: "v", Typ: plan.Type{Id: int32(oid), Scale: 6}, Primary: true,
+			}},
+			Pkey: &plan.PrimaryKeyDef{Names: []string{"v"}, PkeyColName: "v"},
+		}
+	}
+	column := func(oid types.T) *plan.Expr {
+		expr := MakeColExprForTest(0, oid, "v")
+		expr.Typ.Scale = 6
+		return expr
+	}
+	datetimeValue := func() *plan.Expr {
+		return &plan.Expr{
+			Typ: plan.Type{Id: int32(types.T_datetime), Scale: 6},
+			Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+				Value: &plan.Literal_Datetimeval{Datetimeval: int64(datetime)},
+			}},
+		}
+	}
+	timestampValue := func() *plan.Expr {
+		expr := plan2.MakePlan2TimestampConstExprWithType(int64(timestamp))
+		expr.Typ.Scale = 6
+		return expr
+	}
+	assertInvalid := func(t *testing.T, tableDef *plan.TableDef, name string, args []*plan.Expr) {
+		t.Helper()
+		expr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, name, args)
+		require.NoError(t, err)
+		foldExpressionForTest(t, proc, expr)
+		filter, err := ConstructBasePKFilter(expr, tableDef, proc.Mp())
+		require.NoError(t, err)
+		require.False(t, filter.Valid)
+	}
+
+	datetimeTable := makeTable(types.T_datetime)
+	for _, op := range []string{"=", "<", "<=", ">", ">="} {
+		t.Run("datetime column "+op+" timestamp", func(t *testing.T) {
+			assertInvalid(t, datetimeTable, op, []*plan.Expr{column(types.T_datetime), timestampValue()})
+		})
+	}
+	t.Run("reversed operands", func(t *testing.T) {
+		assertInvalid(t, datetimeTable, "=", []*plan.Expr{timestampValue(), column(types.T_datetime)})
+	})
+	t.Run("between", func(t *testing.T) {
+		assertInvalid(t, datetimeTable, "between", []*plan.Expr{
+			column(types.T_datetime), timestampValue(), timestampValue(),
+		})
+	})
+	t.Run("timestamp column", func(t *testing.T) {
+		assertInvalid(t, makeTable(types.T_timestamp), "=", []*plan.Expr{
+			column(types.T_timestamp), datetimeValue(),
+		})
+	})
+	t.Run("same physical type remains valid", func(t *testing.T) {
+		expr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, "=", []*plan.Expr{
+			column(types.T_datetime), datetimeValue(),
+		})
+		require.NoError(t, err)
+		foldExpressionForTest(t, proc, expr)
+		filter, err := ConstructBasePKFilter(expr, datetimeTable, proc.Mp())
+		require.NoError(t, err)
+		require.True(t, filter.Valid)
+	})
+}
+
+func foldExpressionForTest(t *testing.T, proc *process.Process, expr *plan.Expr) {
+	t.Helper()
+	var executors []colexec.ExpressionExecutor
+	_, err := plan2.ReplaceFoldExpr(proc, expr, &executors)
+	require.NoError(t, err)
+	require.NoError(t, plan2.EvalFoldExpr(proc, expr, &executors))
+	for _, executor := range executors {
+		t.Cleanup(executor.Free)
+	}
 }
 
 func Test_ConstructBasePKFilter(t *testing.T) {

--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -40,8 +40,180 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCompileTemporalFilterExprUsesSessionTimezone(t *testing.T) {
+	zone := time.FixedZone("UTC+08", 8*3600)
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	proc.GetSessionInfo().TimeZone = zone
+	tableDef := &plan.TableDef{
+		Name:          "temporal_filter",
+		Name2ColIndex: map[string]int32{"v": 0},
+		Cols: []*plan.ColDef{{
+			Name:   "v",
+			Seqnum: 0,
+			Typ:    plan.Type{Id: int32(types.T_datetime), Scale: 6},
+		}},
+	}
+	parseDatetime := func(value string) types.Datetime {
+		datetime, err := types.ParseDatetime(value, 6)
+		require.NoError(t, err)
+		return datetime
+	}
+	makeTimestampExpr := func(value string) *plan.Expr {
+		timestamp := parseDatetime(value).ToTimestamp(zone)
+		expr := plan2.MakePlan2TimestampConstExprWithType(int64(timestamp))
+		expr.Typ.Scale = 6
+		return expr
+	}
+	makeDatetimeMeta := func(values ...types.Datetime) objectio.BlockObject {
+		dataMeta := objectio.BuildMetaData(1, 1)
+		meta := dataMeta.GetBlockMeta(0)
+		zm := index.NewZM(types.T_datetime, 6)
+		for _, value := range values {
+			encoded := int64(value)
+			index.UpdateZM(zm, types.EncodeInt64(&encoded))
+		}
+		meta.MustGetColumn(0).SetZoneMap(zm)
+		return meta
+	}
+	compile := func(t *testing.T, name string, args []*plan.Expr) BlockFilterOp {
+		t.Helper()
+		expr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, name, args)
+		require.NoError(t, err)
+		var executors []colexec.ExpressionExecutor
+		_, err = plan2.ReplaceFoldExpr(proc, expr, &executors)
+		require.NoError(t, err)
+		require.NoError(t, plan2.EvalFoldExpr(proc, expr, &executors))
+		for _, executor := range executors {
+			t.Cleanup(executor.Free)
+		}
+
+		_, _, _, _, _, canCompileWithoutZone, _ := CompileFilterExpr(expr, tableDef, nil)
+		require.False(t, canCompileWithoutZone, "mixed temporal filters must fail open without a session timezone")
+		_, _, _, blockFilter, _, canCompile, _ := compileFilterExpr(expr, tableDef, nil, zone)
+		require.True(t, canCompile)
+		require.NotNil(t, blockFilter)
+		return blockFilter
+	}
+	column := func() *plan.Expr {
+		expr := MakeColExprForTest(0, types.T_datetime, "v")
+		expr.Typ.Scale = 6
+		return expr
+	}
+
+	tests := []struct {
+		name        string
+		op          string
+		columnFirst bool
+		bound       string
+		value       string
+		want        bool
+	}{
+		{name: "less", op: "<", columnFirst: true, bound: "2026-08-10 12:00:00", value: "2026-08-10 10:30:00", want: true},
+		{name: "less equal", op: "<=", columnFirst: true, bound: "2026-08-10 10:30:00", value: "2026-08-10 10:30:00", want: true},
+		{name: "greater", op: ">", columnFirst: true, bound: "2026-08-10 12:00:00", value: "2026-08-10 10:30:00", want: false},
+		{name: "greater equal", op: ">=", columnFirst: true, bound: "2026-08-10 10:30:00", value: "2026-08-10 10:30:00", want: true},
+		{name: "equal", op: "=", columnFirst: true, bound: "2026-08-10 10:30:00", value: "2026-08-10 10:30:00", want: true},
+		{name: "reversed less", op: "<", columnFirst: false, bound: "2026-08-10 12:00:00", value: "2026-08-10 10:30:00", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bound := makeTimestampExpr(test.bound)
+			args := []*plan.Expr{column(), bound}
+			if !test.columnFirst {
+				args[0], args[1] = args[1], args[0]
+			}
+			blockFilter := compile(t, test.op, args)
+			_, selected, err := blockFilter(0, makeDatetimeMeta(parseDatetime(test.value)), nil)
+			require.NoError(t, err)
+			require.Equal(t, test.want, selected)
+		})
+	}
+
+	t.Run("between", func(t *testing.T) {
+		blockFilter := compile(t, "between", []*plan.Expr{
+			column(),
+			makeTimestampExpr("2026-08-10 10:00:00"),
+			makeTimestampExpr("2026-08-10 11:00:00"),
+		})
+		_, selected, err := blockFilter(0, makeDatetimeMeta(parseDatetime("2026-08-10 10:30:00")), nil)
+		require.NoError(t, err)
+		require.True(t, selected)
+	})
+
+	t.Run("between applies each timestamp bound scale", func(t *testing.T) {
+		value := parseDatetime("2026-08-10 12:00:00.123456")
+		lower := makeTimestampExpr("2026-08-10 12:00:00.123456")
+		lower.Typ.Scale = 3
+		lower.GetLit().Value = &plan.Literal_Timestampval{
+			Timestampval: int64(value.ToTimestamp(zone).TruncateToScale(3)),
+		}
+		upper := makeTimestampExpr("2026-08-10 12:00:00.123100")
+		blockFilter := compile(t, "between", []*plan.Expr{column(), lower, upper})
+
+		_, selected, err := blockFilter(0, makeDatetimeMeta(value), nil)
+		require.NoError(t, err)
+		require.False(t, selected)
+	})
+
+	t.Run("timestamp column with datetime bound", func(t *testing.T) {
+		tableDef.Cols[0].Typ = plan.Type{Id: int32(types.T_timestamp), Scale: 6}
+		t.Cleanup(func() {
+			tableDef.Cols[0].Typ = plan.Type{Id: int32(types.T_datetime), Scale: 6}
+		})
+		column := MakeColExprForTest(0, types.T_timestamp, "v")
+		column.Typ.Scale = 6
+		datetime := parseDatetime("2026-08-10 12:00:00")
+		bound := &plan.Expr{
+			Typ: plan.Type{Id: int32(types.T_datetime), Scale: 6},
+			Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+				Value: &plan.Literal_Datetimeval{Datetimeval: int64(datetime)},
+			}},
+		}
+		blockFilter := compile(t, "<", []*plan.Expr{column, bound})
+
+		dataMeta := objectio.BuildMetaData(1, 1)
+		meta := dataMeta.GetBlockMeta(0)
+		zm := index.NewZM(types.T_timestamp, 6)
+		value := int64(parseDatetime("2026-08-10 10:30:00").ToTimestamp(zone))
+		index.UpdateZM(zm, types.EncodeInt64(&value))
+		meta.MustGetColumn(0).SetZoneMap(zm)
+		_, selected, err := blockFilter(0, meta, nil)
+		require.NoError(t, err)
+		require.True(t, selected)
+	})
+
+	t.Run("DST fold remains conservative", func(t *testing.T) {
+		newYork, err := time.LoadLocation("America/New_York")
+		require.NoError(t, err)
+		proc.GetSessionInfo().TimeZone = newYork
+		threshold, err := types.ParseTimestamp(time.UTC, "2024-11-03 06:15:00", 6)
+		require.NoError(t, err)
+		bound := plan2.MakePlan2TimestampConstExprWithType(int64(threshold))
+		bound.Typ.Scale = 6
+		expr, err := plan2.BindFuncExprImplByPlanExpr(proc.Ctx, ">", []*plan.Expr{column(), bound})
+		require.NoError(t, err)
+		var executors []colexec.ExpressionExecutor
+		_, err = plan2.ReplaceFoldExpr(proc, expr, &executors)
+		require.NoError(t, err)
+		require.NoError(t, plan2.EvalFoldExpr(proc, expr, &executors))
+		for _, executor := range executors {
+			defer executor.Free()
+		}
+		_, _, _, blockFilter, _, canCompile, _ := compileFilterExpr(expr, tableDef, nil, newYork)
+		require.True(t, canCompile)
+		_, selected, err := blockFilter(0, makeDatetimeMeta(
+			parseDatetime("2024-11-03 01:00:00"),
+			parseDatetime("2024-11-03 01:59:59"),
+		), nil)
+		require.NoError(t, err)
+		require.True(t, selected)
+	})
+}
 
 func Test_ConstructBasePKFilter(t *testing.T) {
 	m := mpool.MustNew(t.Name())

--- a/test/distributed/cases/function/func_datetime_timezone.result
+++ b/test/distributed/cases/function/func_datetime_timezone.result
@@ -1,4 +1,30 @@
 set time_zone = '+00:00';
+drop database if exists temporal_cross_type_regression;
+create database temporal_cross_type_regression;
+set time_zone = '+08:00';
+set optimizer_hints = 'blockFilter=1';
+create table temporal_cross_type_regression.d(v datetime(6));
+create table temporal_cross_type_regression.t(v timestamp(6));
+insert into temporal_cross_type_regression.d values ('2026-08-10 10:00:00');
+insert into temporal_cross_type_regression.t values ('2026-08-10 10:00:00');
+select count(*) as join_count
+from temporal_cross_type_regression.d
+join temporal_cross_type_regression.t on d.v = t.v;
+join_count
+1
+create table temporal_cross_type_regression.f(v datetime(6));
+insert into temporal_cross_type_regression.f values ('2026-08-10 10:30:00');
+select mo_ctl('dn', 'flush', 'temporal_cross_type_regression.f');
+mo_ctl(dn, flush, temporal_cross_type_regression.f)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select count(*) as filter_count
+from temporal_cross_type_regression.f
+where v < cast('2026-08-10 12:00:00' as timestamp);
+filter_count
+1
+set optimizer_hints = '';
+set time_zone = '+00:00';
+drop database temporal_cross_type_regression;
 select now(), @@session.time_zone;
 now()    @@time_zone
 2025-11-22 10:07:17.141386000    +00:00

--- a/test/distributed/cases/function/func_datetime_timezone.result
+++ b/test/distributed/cases/function/func_datetime_timezone.result
@@ -22,6 +22,32 @@ from temporal_cross_type_regression.f
 where v < cast('2026-08-10 12:00:00' as timestamp);
 filter_count
 1
+create table temporal_cross_type_regression.p(v datetime(6) primary key);
+insert into temporal_cross_type_regression.p values ('2026-08-10 10:00:00');
+select count(*) as workspace_pk_count
+from temporal_cross_type_regression.p
+where v = cast('2026-08-10 10:00:00' as timestamp);
+workspace_pk_count
+1
+select mo_ctl('dn', 'flush', 'temporal_cross_type_regression.p');
+mo_ctl(dn, flush, temporal_cross_type_regression.p)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select count(*) as persisted_pk_count
+from temporal_cross_type_regression.p
+where v = cast('2026-08-10 10:00:00' as timestamp);
+persisted_pk_count
+1
+select count(*) as persisted_pk_between_count
+from temporal_cross_type_regression.p
+where v between cast('2026-08-10 09:00:00' as timestamp)
+and cast('2026-08-10 11:00:00' as timestamp);
+persisted_pk_between_count
+1
+select cast('2026-08-10 12:00:00.123456' as datetime(6))
+between cast('2026-08-10 12:00:00.123456' as timestamp(3))
+and cast('2026-08-10 12:00:00.123100' as timestamp(6)) as between_scale_result;
+between_scale_result
+1
 set optimizer_hints = '';
 set time_zone = '+00:00';
 drop database temporal_cross_type_regression;

--- a/test/distributed/cases/function/func_datetime_timezone.test
+++ b/test/distributed/cases/function/func_datetime_timezone.test
@@ -25,6 +25,25 @@ select count(*) as filter_count
 from temporal_cross_type_regression.f
 where v < cast('2026-08-10 12:00:00' as timestamp);
 
+create table temporal_cross_type_regression.p(v datetime(6) primary key);
+insert into temporal_cross_type_regression.p values ('2026-08-10 10:00:00');
+select count(*) as workspace_pk_count
+from temporal_cross_type_regression.p
+where v = cast('2026-08-10 10:00:00' as timestamp);
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'temporal_cross_type_regression.p');
+select count(*) as persisted_pk_count
+from temporal_cross_type_regression.p
+where v = cast('2026-08-10 10:00:00' as timestamp);
+select count(*) as persisted_pk_between_count
+from temporal_cross_type_regression.p
+where v between cast('2026-08-10 09:00:00' as timestamp)
+    and cast('2026-08-10 11:00:00' as timestamp);
+
+select cast('2026-08-10 12:00:00.123456' as datetime(6))
+    between cast('2026-08-10 12:00:00.123456' as timestamp(3))
+    and cast('2026-08-10 12:00:00.123100' as timestamp(6)) as between_scale_result;
+
 set optimizer_hints = '';
 set time_zone = '+00:00';
 drop database temporal_cross_type_regression;

--- a/test/distributed/cases/function/func_datetime_timezone.test
+++ b/test/distributed/cases/function/func_datetime_timezone.test
@@ -2,6 +2,32 @@
 -- @setup
 -- Test timezone setting and querying
 set time_zone = '+00:00';
+
+-- @case
+-- @desc:mixed DATETIME/TIMESTAMP comparison keeps join keys and block pruning semantically aligned
+drop database if exists temporal_cross_type_regression;
+create database temporal_cross_type_regression;
+set time_zone = '+08:00';
+set optimizer_hints = 'blockFilter=1';
+create table temporal_cross_type_regression.d(v datetime(6));
+create table temporal_cross_type_regression.t(v timestamp(6));
+insert into temporal_cross_type_regression.d values ('2026-08-10 10:00:00');
+insert into temporal_cross_type_regression.t values ('2026-08-10 10:00:00');
+select count(*) as join_count
+from temporal_cross_type_regression.d
+join temporal_cross_type_regression.t on d.v = t.v;
+
+create table temporal_cross_type_regression.f(v datetime(6));
+insert into temporal_cross_type_regression.f values ('2026-08-10 10:30:00');
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'temporal_cross_type_regression.f');
+select count(*) as filter_count
+from temporal_cross_type_regression.f
+where v < cast('2026-08-10 12:00:00' as timestamp);
+
+set optimizer_hints = '';
+set time_zone = '+00:00';
+drop database temporal_cross_type_regression;
 -- @ignore:0
 select now(), @@session.time_zone;
 
@@ -190,4 +216,3 @@ from (
 ) as t;
 
 set time_zone = '+00:00';
-


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26741

Related design discussion: #26775

## What this PR does / why we need it:

Mixed `DATETIME`/`TIMESTAMP` comparisons previously cast the `DATETIME` operand to `TIMESTAMP`. For predicates such as `system.statement_info.request_at > DATE_SUB(NOW(), INTERVAL 1 HOUR)`, that wrapped the column in a cast and prevented storage pruning from seeing the raw `DATETIME` column.

This PR keeps public result types unchanged and adds direct cross-type comparison support for comparison operators and `BETWEEN`. Column-to-runtime-constant predicates retain the raw column for pruning, while non-constant operands are normalized to one physical `TIMESTAMP` key domain so hash joins, shuffle keys, and runtime filters remain correct.

Both zonemap paths now use the session time zone and preserve the established `BETWEEN` precision contract. Conversion is used only when it is order-preserving; ranges that intersect a DST fold or gap fail open and remain for residual evaluation. The readutil fast path also avoids raw-byte comparisons and bloom lookups across the two physical temporal encodings.

The base primary-key byte filter has no session-time-zone context, so mixed `DATETIME`/`TIMESTAMP` predicates now fail open there and are evaluated by the residual expression instead of comparing incompatible physical encodings. This applies to both workspace and persisted primary-key reads.

Validation covers fixed-offset and named time zones, DST fold/gap counterexamples, differing `BETWEEN` bound scales, NULLs, binder/plan shape, join-key correctness, both zonemap paths, workspace and persisted primary-key reads, full owning-package tests, `go vet`, a full build, direct SQL reproductions, and the local `func_datetime_timezone` BVT (61/61).