### PR TITLE
[4.2-dev] fix(morpc): preserve slow responses after probe timeout

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -122,9 +122,10 @@ func WithBackendReadTimeout(value time.Duration) BackendOption {
 	}
 }
 
-// WithBackendLivenessProbe verifies peer liveness over a transport independent
-// from this backend. A successful probe turns a read inactivity timeout into a
-// request-level wait instead of resetting the shared data connection.
+// WithBackendLivenessProbe observes peer liveness over a transport independent
+// from this backend. When unary data traffic stalls, the current data generation
+// is drained without discarding pending requests; probe failures remain
+// inconclusive because the data connection can still make progress.
 func WithBackendLivenessProbe(value func(context.Context, string) error) BackendOption {
 	return func(rb *remoteBackend) {
 		rb.options.livenessProbe = value
@@ -234,9 +235,8 @@ type remoteBackend struct {
 		id             uint64
 		lastActiveTime atomic.Value //time.Time
 		unavailable    atomic.Bool
-		// draining seals new pool admission after data transport inactivity was
-		// confirmed against a healthy independent control connection. Existing
-		// Futures remain owned by this backend and may still complete.
+		// draining seals new pool admission after data transport inactivity.
+		// Existing Futures remain owned by this backend and may still complete.
 		draining atomic.Bool
 	}
 
@@ -1329,16 +1329,6 @@ func (rb *remoteBackend) keepDataConnectionAfterProbe(
 		return true
 	}
 
-	timeout := rb.options.readTimeout / 5
-	if timeout <= 0 || timeout > internalTimeout {
-		timeout = internalTimeout
-	}
-	probeCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	if err := rb.options.livenessProbe(probeCtx, rb.remote); err != nil {
-		rb.metrics.observeBackendError(rb.remote, "liveness-probe", err)
-		return false
-	}
 	rb.stateMu.Lock()
 	if rb.stateMu.state != stateRunning {
 		rb.stateMu.Unlock()
@@ -1348,16 +1338,31 @@ func (rb *remoteBackend) keepDataConnectionAfterProbe(
 		rb.atomic.draining.CompareAndSwap(false, true)
 	rb.stateMu.Unlock()
 	if startedDraining {
-		// A pong proves that the peer is alive, not that this data TCP can make
-		// progress. Seal it from new pool admission, preserve existing requests,
-		// and let the client publish a fresh data generation on next demand.
+		// Response inactivity is enough to stop admitting new work to this data
+		// generation, but not enough to fail requests that can still complete.
+		// Preserve them while the client publishes a fresh generation on demand.
 		rb.logger.Debug(
-			"data backend draining after independent liveness probe",
+			"data backend draining after response inactivity",
 			rb.logFields()...,
 		)
 		rb.mu.Lock()
 		rb.finishDrainingLocked()
 		rb.mu.Unlock()
+	}
+
+	timeout := rb.options.readTimeout / 5
+	if timeout <= 0 || timeout > internalTimeout {
+		timeout = internalTimeout
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := rb.options.livenessProbe(probeCtx, rb.remote); err != nil {
+		rb.metrics.observeBackendError(rb.remote, "liveness-probe", err)
+		// The control transport is independent from this data connection. Its
+		// failure is therefore inconclusive: the peer may still return a valid
+		// slow response on the data connection. Leave reset and Future failure to
+		// a terminal data error or the client's bounded generation lifecycle.
+		return true
 	}
 	return true
 }

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -550,11 +550,29 @@ func TestDataProgressPendingSetIsBounded(t *testing.T) {
 	require.False(t, rb.livenessMu.overflow)
 }
 
-func TestFailedLivenessProbeResetsDataConnection(t *testing.T) {
-	probed := make(chan struct{}, 1)
+func TestTimedOutLivenessProbePreservesSlowDataResponse(t *testing.T) {
+	requestReceived := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	probeStarted := make(chan struct{})
+	var requestOnce sync.Once
+	var probeOnce sync.Once
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseResponse) }) }
+	t.Cleanup(release)
+
 	testBackendSend(t,
-		func(goetty.IOSession, interface{}, uint64) error {
-			return nil
+		func(conn goetty.IOSession, msg interface{}, _ uint64) error {
+			request := msg.(RPCMessage)
+			requestOnce.Do(func() { close(requestReceived) })
+			select {
+			case <-releaseResponse:
+			case <-time.After(time.Second):
+				return context.DeadlineExceeded
+			}
+			return conn.Write(RPCMessage{
+				Ctx:     request.Ctx,
+				Message: newTestMessage(request.Message.GetID()),
+			}, goetty.WriteOptions{Flush: true})
 		},
 		func(b *remoteBackend) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -562,19 +580,33 @@ func TestFailedLivenessProbeResetsDataConnection(t *testing.T) {
 			f, err := b.Send(ctx, newTestMessage(1))
 			require.NoError(t, err)
 			defer f.Close()
-			_, err = f.Get()
-			require.Error(t, err)
-			require.NotErrorIs(t, err, context.DeadlineExceeded)
+
 			select {
-			case <-probed:
-			default:
+			case <-requestReceived:
+			case <-ctx.Done():
+				t.Fatal("request did not reach server")
+			}
+			select {
+			case <-probeStarted:
+			case <-ctx.Done():
 				t.Fatal("failed liveness probe did not run")
 			}
+
+			require.False(t, b.admissionAvailable(),
+				"an inconclusive probe must still seal the inactive data generation")
+			_, err = b.Send(ctx, newTestMessage(2))
+			require.ErrorIs(t, err, backendDraining)
+
+			release()
+			_, err = f.Get()
+			require.NoError(t, err,
+				"a timed-out control transport must not discard a valid slow data response")
 		},
 		WithBackendReadTimeout(20*time.Millisecond),
-		WithBackendLivenessProbe(func(context.Context, string) error {
-			probed <- struct{}{}
-			return errors.New("control transport unavailable")
+		WithBackendLivenessProbe(func(ctx context.Context, _ string) error {
+			probeOnce.Do(func() { close(probeStarted) })
+			<-ctx.Done()
+			return ctx.Err()
 		}),
 	)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26888.

Backport of #26903 to `4.2-dev`.

## What this PR does / why we need it:

Backports the MORPC fix that prevents an inconclusive control-probe timeout from resetting a data backend that can still return valid slow Lock responses.

The #26888 incident occurred on `4.2-dev`: one failed probe closed the shared backend and failed all pending Lock Futures together as ErrorCode 20505. The lock owner returned those responses shortly after the caller had already closed the connection.

This change affects only the response-inactivity path:

- seal the inactive data generation from new admission before probing;
- preserve its pending Futures when the independent control probe times out;
- direct new requests to the bounded replacement generation;
- retain immediate reset behavior for terminal data errors such as EOF, connection reset, and broken pipe.

The normal MORPC request/response path does not add locks, allocations, or RPCs.

### Backport verification

- Cherry-picked with `-x` from `aa11c18f2a3d6a2609eaa425ae50b51ce72c321f`.
- Backport and main commits have the same stable patch ID.
- No conflicts or manual semantic changes.
- Focused MORPC liveness/generation tests: `-count=30` passed.
- `TestTimedOutLivenessProbePreservesSlowDataResponse`: race `-count=100` passed.
- `go test ./pkg/common/morpc/...` passed.
- `go test -race ./pkg/common/morpc` passed.
- `go test ./pkg/lockservice/...` passed.
- MORPC and lockservice build and vet checks passed.
