### PR TITLE
fix(plan): infer prepared ntile parameters

### DIFF
--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2584,15 +2584,18 @@ func TestSendPrepareResponse(t *testing.T) {
 	})
 }
 
-func TestPreparedNumericAggregateBinaryProtocolMetadata(t *testing.T) {
+func TestPreparedNumericFunctionBinaryProtocolMetadata(t *testing.T) {
 	ctx := context.TODO()
 	tests := []struct {
-		name string
-		sql  string
+		name           string
+		sql            string
+		resultType     defines.MysqlType
+		resultDecimals uint8
 	}{
-		{name: "sum", sql: "select sum(?) as result"},
-		{name: "avg", sql: "select avg(?) as result"},
-		{name: "window sum", sql: "select sum(?) over () as result"},
+		{name: "sum", sql: "select sum(?) as result", resultType: defines.MYSQL_TYPE_DOUBLE, resultDecimals: mysqlDecimalNotSpecified},
+		{name: "avg", sql: "select avg(?) as result", resultType: defines.MYSQL_TYPE_DOUBLE, resultDecimals: mysqlDecimalNotSpecified},
+		{name: "window sum", sql: "select sum(?) over () as result", resultType: defines.MYSQL_TYPE_DOUBLE, resultDecimals: mysqlDecimalNotSpecified},
+		{name: "ntile", sql: "select ntile(?) over () as result", resultType: defines.MYSQL_TYPE_LONGLONG},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -2620,8 +2623,8 @@ func TestPreparedNumericAggregateBinaryProtocolMetadata(t *testing.T) {
 
 			result := parsePrepareColumnDefinition(t, packets[3])
 			require.Equal(t, "result", result.name)
-			require.Equal(t, defines.MYSQL_TYPE_DOUBLE, result.typ)
-			require.Equal(t, uint8(mysqlDecimalNotSpecified), result.decimals)
+			require.Equal(t, test.resultType, result.typ)
+			require.Equal(t, test.resultDecimals, result.decimals)
 			require.Equal(t, byte(defines.EOFHeader), packets[4][0])
 		})
 	}

--- a/pkg/sql/colexec/aggexec/window.go
+++ b/pkg/sql/colexec/aggexec/window.go
@@ -415,47 +415,49 @@ func (exec *ntileWindowExec) Fill(groupIndex int, row int, vectors []*vector.Vec
 		return moerr.NewInternalErrorNoCtx("ntile requires vectors")
 	}
 
-	// vectors[0] is the os (order sequence) vector
-	value := vector.MustFixedColWithTypeCheck[int64](vectors[0])[row]
-	exec.groups[groupIndex] = append(exec.groups[groupIndex], value)
-
 	// If vectors[1] exists, it's the bucket count parameter
 	if len(vectors) > 1 && exec.bucketCounts[groupIndex] == 0 {
 		bucketVec := vectors[1]
-		if !bucketVec.IsNull(uint64(row)) {
-			var bucketCount int64
-			switch bucketVec.GetType().Oid {
-			case types.T_int64:
-				bucketCount = vector.MustFixedColWithTypeCheck[int64](bucketVec)[row]
-			case types.T_int32:
-				bucketCount = int64(vector.MustFixedColWithTypeCheck[int32](bucketVec)[row])
-			case types.T_int16:
-				bucketCount = int64(vector.MustFixedColWithTypeCheck[int16](bucketVec)[row])
-			case types.T_int8:
-				bucketCount = int64(vector.MustFixedColWithTypeCheck[int8](bucketVec)[row])
-			case types.T_uint64:
-				bucketCount = int64(vector.MustFixedColWithTypeCheck[uint64](bucketVec)[row])
-			case types.T_uint32:
-				bucketCount = int64(vector.MustFixedColWithTypeCheck[uint32](bucketVec)[row])
-			case types.T_uint16:
-				bucketCount = int64(vector.MustFixedColWithTypeCheck[uint16](bucketVec)[row])
-			case types.T_uint8:
-				bucketCount = int64(vector.MustFixedColWithTypeCheck[uint8](bucketVec)[row])
-			default:
-				return moerr.NewInternalErrorNoCtx("ntile bucket count must be integer type")
-			}
-
-			if bucketCount <= 0 {
-				return moerr.NewInternalErrorNoCtx("ntile bucket count must be positive")
-			}
-			exec.bucketCounts[groupIndex] = bucketCount
+		if bucketVec.IsNull(uint64(row)) {
+			return moerr.NewInvalidInputNoCtx("ntile bucket count cannot be NULL")
 		}
+
+		var bucketCount int64
+		switch bucketVec.GetType().Oid {
+		case types.T_int64:
+			bucketCount = vector.MustFixedColWithTypeCheck[int64](bucketVec)[row]
+		case types.T_int32:
+			bucketCount = int64(vector.MustFixedColWithTypeCheck[int32](bucketVec)[row])
+		case types.T_int16:
+			bucketCount = int64(vector.MustFixedColWithTypeCheck[int16](bucketVec)[row])
+		case types.T_int8:
+			bucketCount = int64(vector.MustFixedColWithTypeCheck[int8](bucketVec)[row])
+		case types.T_uint64:
+			bucketCount = int64(vector.MustFixedColWithTypeCheck[uint64](bucketVec)[row])
+		case types.T_uint32:
+			bucketCount = int64(vector.MustFixedColWithTypeCheck[uint32](bucketVec)[row])
+		case types.T_uint16:
+			bucketCount = int64(vector.MustFixedColWithTypeCheck[uint16](bucketVec)[row])
+		case types.T_uint8:
+			bucketCount = int64(vector.MustFixedColWithTypeCheck[uint8](bucketVec)[row])
+		default:
+			return moerr.NewInternalErrorNoCtx("ntile bucket count must be integer type")
+		}
+
+		if bucketCount <= 0 {
+			return moerr.NewInternalErrorNoCtx("ntile bucket count must be positive")
+		}
+		exec.bucketCounts[groupIndex] = bucketCount
 	}
 
 	// Default to 1 bucket if not set
 	if exec.bucketCounts[groupIndex] == 0 {
 		exec.bucketCounts[groupIndex] = 1
 	}
+
+	// vectors[0] is the os (order sequence) vector
+	value := vector.MustFixedColWithTypeCheck[int64](vectors[0])[row]
+	exec.groups[groupIndex] = append(exec.groups[groupIndex], value)
 
 	return nil
 }

--- a/pkg/sql/colexec/aggexec/window_test.go
+++ b/pkg/sql/colexec/aggexec/window_test.go
@@ -1714,7 +1714,7 @@ func TestNtileExec_BoundaryConditions(t *testing.T) {
 		exec.Free()
 	})
 
-	t.Run("null_bucket_defaults_to_1", func(t *testing.T) {
+	t.Run("null_bucket_count", func(t *testing.T) {
 		exec, err := makeNtileExec(mp, WinIdOfNtile, false, []types.Type{types.T_int64.ToType()})
 		require.NoError(t, err)
 
@@ -1728,16 +1728,15 @@ func TestNtileExec_BoundaryConditions(t *testing.T) {
 		require.NoError(t, err)
 		defer bucketVec.Free(mp)
 
-		err = exec.GroupGrow(3)
+		err = exec.GroupGrow(1)
 		require.NoError(t, err)
 
-		for o := 0; o <= 3; o++ {
-			err = exec.Fill(0, o, []*vector.Vector{osVec, bucketVec})
-			require.NoError(t, err)
-		}
+		err = exec.Fill(0, 0, []*vector.Vector{osVec, bucketVec})
+		require.ErrorContains(t, err, "ntile bucket count cannot be NULL")
 
 		ntileExec := exec.(*ntileWindowExec)
-		require.Equal(t, int64(1), ntileExec.bucketCounts[0])
+		require.Empty(t, ntileExec.groups[0])
+		require.Zero(t, ntileExec.bucketCounts[0])
 
 		exec.Free()
 	})

--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -605,8 +605,11 @@ func (ctr *container) ntileBucketCount(idx int) (int64, error) {
 		return 1, nil
 	}
 	vec := ctr.aggVecs[idx].Vec[0]
-	if vec.Length() == 0 || vec.IsNull(0) {
+	if vec.Length() == 0 {
 		return 1, nil
+	}
+	if vec.IsNull(0) {
+		return 0, moerr.NewInvalidInputNoCtx("ntile bucket count cannot be NULL")
 	}
 	bucketCount, ok := getInt64FromVec(vec, 0)
 	if !ok {

--- a/pkg/sql/colexec/window/window_test.go
+++ b/pkg/sql/colexec/window/window_test.go
@@ -1191,6 +1191,18 @@ func TestWindowOrderFunctionsUsePeerBoundaries(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
+func TestNtileBucketCountRejectsNull(t *testing.T) {
+	mp := mpool.MustNewZero()
+	bucketVec := vector.NewConstNull(types.T_int64.ToType(), 1, mp)
+	defer bucketVec.Free(mp)
+
+	ctr := container{
+		aggVecs: []colexec.ExprEvalVector{{Vec: []*vector.Vector{bucketVec}}},
+	}
+	_, err := ctr.ntileBucketCount(0)
+	require.ErrorContains(t, err, "ntile bucket count cannot be NULL")
+}
+
 func TestWindowResetBeforeAllChunksReleasesState(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	rows := colexec.DefaultBatchSize * 2

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -2540,22 +2540,35 @@ func isPreparedNumericAggregate(name string, argCount int) bool {
 	return argCount == 1 && (strings.EqualFold(name, "sum") || strings.EqualFold(name, "avg"))
 }
 
-// bindPreparedNumericAggregateFuncExpr gives prepared SUM/AVG arguments the
-// same static numeric context as prepared arithmetic. ParamRef remains TEXT for
-// transport and an explicit cast materializes the inferred computation type.
+func preparedNumericFunctionTarget(name string, argCount int) (*Type, bool) {
+	if isPreparedNumericAggregate(name, argCount) {
+		return nil, true
+	}
+	if argCount == 1 && strings.EqualFold(name, "ntile") {
+		typ := types.T_int64.ToType()
+		target := makePlan2Type(&typ)
+		return &target, true
+	}
+	return nil, false
+}
+
+// bindPreparedNumericFuncExpr gives prepared numeric function arguments the
+// same static context as prepared arithmetic. SUM/AVG use the inferred numeric
+// domain, while NTILE requires an integer domain. ParamRef remains TEXT for
+// transport and an explicit cast materializes the computation type.
 // Non-parameter expressions stay on their original binding path, so ordinary
-// SUM/AVG over string columns continues to be rejected by aggregate overload
-// resolution.
-func (b *baseBinder) bindPreparedNumericAggregateFuncExpr(
+// string inputs continue to be rejected by function overload resolution.
+func (b *baseBinder) bindPreparedNumericFuncExpr(
 	name string,
 	astArgs []tree.Expr,
 	depth int32,
 ) (*plan.Expr, error) {
-	if b.builder == nil || !b.builder.isPrepareStatement || !isPreparedNumericAggregate(name, len(astArgs)) {
+	target, ok := preparedNumericFunctionTarget(name, len(astArgs))
+	if b.builder == nil || !b.builder.isPrepareStatement || !ok {
 		return b.bindFuncExprImplByAstExpr(name, astArgs, depth)
 	}
 
-	arg, err := b.bindNumericExprWithContext(astArgs[0], depth, nil)
+	arg, err := b.bindNumericExprWithContext(astArgs[0], depth, target)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/plan/function/list_window.go
+++ b/pkg/sql/plan/function/list_window.go
@@ -104,7 +104,7 @@ var supportedWindowInNewFramework = []FuncNew{
 		class:      plan.Function_WIN_ORDER,
 		layout:     STANDARD_FUNCTION,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
-			if len(inputs) == 1 {
+			if len(inputs) == 1 && inputs[0].Oid.IsInteger() {
 				return newCheckResultWithSuccess(0)
 			}
 			return newCheckResultWithFailure(failedFunctionParametersWrong)

--- a/pkg/sql/plan/function/list_window_test.go
+++ b/pkg/sql/plan/function/list_window_test.go
@@ -236,3 +236,38 @@ func TestCumeDistCheckFn(t *testing.T) {
 		require.Equal(t, failedFunctionParametersWrong, result.status)
 	})
 }
+
+func TestNtileCheckFn(t *testing.T) {
+	var ntileFunc *FuncNew
+	for i := range supportedWindowInNewFramework {
+		if supportedWindowInNewFramework[i].functionId == NTILE {
+			ntileFunc = &supportedWindowInNewFramework[i]
+			break
+		}
+	}
+	require.NotNil(t, ntileFunc)
+
+	for _, typ := range []types.Type{
+		types.T_int8.ToType(),
+		types.T_int64.ToType(),
+		types.T_uint64.ToType(),
+	} {
+		result := ntileFunc.checkFn(ntileFunc.Overloads, []types.Type{typ})
+		require.Equal(t, succeedMatched, result.status)
+	}
+
+	for _, typ := range []types.Type{
+		types.T_float64.ToType(),
+		types.T_decimal64.ToType(),
+		types.T_varchar.ToType(),
+	} {
+		result := ntileFunc.checkFn(ntileFunc.Overloads, []types.Type{typ})
+		require.Equal(t, failedFunctionParametersWrong, result.status)
+	}
+
+	require.Equal(t, failedFunctionParametersWrong,
+		ntileFunc.checkFn(ntileFunc.Overloads, nil).status)
+	require.Equal(t, failedFunctionParametersWrong,
+		ntileFunc.checkFn(ntileFunc.Overloads,
+			[]types.Type{types.T_int64.ToType(), types.T_int64.ToType()}).status)
+}

--- a/pkg/sql/plan/having_binder.go
+++ b/pkg/sql/plan/having_binder.go
@@ -221,7 +221,7 @@ func (b *HavingBinder) BindAggFunc(funcName string, astExpr *tree.FuncExpr, dept
 	if strings.EqualFold(funcName, NamePercentileCont) || strings.EqualFold(funcName, NamePercentileDisc) {
 		expr, err = b.bindOrderedSetPercentileAgg(funcName, astExpr, depth, isRoot)
 	} else {
-		expr, err = b.bindPreparedNumericAggregateFuncExpr(funcName, astExpr.Exprs, depth)
+		expr, err = b.bindPreparedNumericFuncExpr(funcName, astExpr.Exprs, depth)
 	}
 	if err != nil {
 		b.insideAgg = false

--- a/pkg/sql/plan/prepared_aggregate_params_test.go
+++ b/pkg/sql/plan/prepared_aggregate_params_test.go
@@ -308,6 +308,38 @@ func TestPreparedNumericAggregateParameterIdentity(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPreparedNtileParameter(t *testing.T) {
+	prepare := buildPreparedAggregatePlan(t,
+		"select n_nationkey, ntile(?) over (partition by n_regionkey order by n_nationkey) from nation")
+	require.Equal(t, []int32{int32(types.T_any)}, prepare.ParamTypes)
+	require.Equal(t, []int32{0}, preparedParamPositions(prepare))
+
+	originalTypes := preparedEffectiveParamTypes(t, prepare)
+	require.Equal(t, int32(types.T_int64), originalTypes[0].Id)
+
+	first, err := FillValuesOfParamsInPlan(context.Background(), prepare.Plan, []any{int64(2)})
+	require.NoError(t, err)
+	second, err := FillValuesOfParamsInPlan(context.Background(), prepare.Plan, []any{int64(5)})
+	require.NoError(t, err)
+	require.NotSame(t, first, second)
+	require.Equal(t, []int32{0}, preparedParamPositions(prepare))
+	require.Equal(t, originalTypes, preparedEffectiveParamTypes(t, prepare))
+}
+
+func TestNtileRequiresIntegerArgument(t *testing.T) {
+	for _, sql := range []string{
+		"select ntile(n_name) over (order by n_nationkey) from nation",
+		"select ntile(2.5) over (order by n_nationkey) from nation",
+		"select ntile(cast(? as char)) over (order by n_nationkey) from nation",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			mock := NewMockOptimizer(false)
+			_, err := runOneStmt(mock, t, fmt.Sprintf("prepare stmt1 from '%s'", sql))
+			require.ErrorContains(t, err, "invalid argument function ntile")
+		})
+	}
+}
+
 func TestPreparedNumericAggregateDoesNotCoerceStrings(t *testing.T) {
 	tests := []string{
 		"select sum(n_name) from nation",

--- a/pkg/sql/plan/window_binder.go
+++ b/pkg/sql/plan/window_binder.go
@@ -34,7 +34,7 @@ import (
 type windowFuncExprBinder interface {
 	BindExpr(tree.Expr, int32, bool) (*plan.Expr, error)
 	bindFuncExprImplByAstExpr(string, []tree.Expr, int32) (*plan.Expr, error)
-	bindPreparedNumericAggregateFuncExpr(string, []tree.Expr, int32) (*plan.Expr, error)
+	bindPreparedNumericFuncExpr(string, []tree.Expr, int32) (*plan.Expr, error)
 	bindPreparedRowsFrameBound(tree.Expr) (*plan.Expr, error)
 	makeFrameConstValue(tree.Expr, *plan.Type) (*plan.Expr, error)
 	GetContext() context.Context
@@ -254,7 +254,7 @@ func bindWindowFuncExpr(b windowFuncExprBinder, ctx *BindContext, funcName strin
 	}
 
 	// window function
-	windowFunc, err := b.bindPreparedNumericAggregateFuncExpr(funcName, astExpr.Exprs, depth)
+	windowFunc, err := b.bindPreparedNumericFuncExpr(funcName, astExpr.Exprs, depth)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/plan/window_binder_test.go
+++ b/pkg/sql/plan/window_binder_test.go
@@ -44,7 +44,7 @@ func (b *stubWindowBinder) bindFuncExprImplByAstExpr(name string, args []tree.Ex
 	return b.bindFuncExprFunc(name, args, depth)
 }
 
-func (b *stubWindowBinder) bindPreparedNumericAggregateFuncExpr(name string, args []tree.Expr, depth int32) (*planpb.Expr, error) {
+func (b *stubWindowBinder) bindPreparedNumericFuncExpr(name string, args []tree.Expr, depth int32) (*planpb.Expr, error) {
 	return b.bindFuncExprImplByAstExpr(name, args, depth)
 }
 

--- a/test/distributed/cases/prepare/prepared_numeric_aggregate.result
+++ b/test/distributed/cases/prepare/prepared_numeric_aggregate.result
@@ -40,11 +40,11 @@ INSERT INTO ntile_input VALUES (1, 1), (2, 1), (3, 1), (4, 2);
 PREPARE p_ntile FROM 'SELECT id, NTILE(?) OVER (PARTITION BY g ORDER BY id) AS bucket FROM ntile_input ORDER BY id';
 SET @value = 2;
 EXECUTE p_ntile USING @value;
-➤ id[-5,32,0]    bucket[-5,64,0]  𝄀
-1    1
-2    1
-3    2
-4    1
+➤ id[4,32,0]  ¦  bucket[-5,64,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  1  𝄀
+3  ¦  2  𝄀
+4  ¦  1
 DEALLOCATE PREPARE p_ntile;
 PREPARE p_recursive FROM 'WITH RECURSIVE r(n) AS (SELECT ? UNION ALL SELECT n + 1 FROM r WHERE n < 3) SELECT CAST(SUM(n) AS SIGNED) AS got FROM r';
 SET @value = 1;

--- a/test/distributed/cases/prepare/prepared_numeric_aggregate.result
+++ b/test/distributed/cases/prepare/prepared_numeric_aggregate.result
@@ -35,6 +35,17 @@ EXECUTE p_window USING @value;
 ➤ got[-5,64,0]  𝄀
 5
 DEALLOCATE PREPARE p_window;
+CREATE TABLE ntile_input(id INT PRIMARY KEY, g INT);
+INSERT INTO ntile_input VALUES (1, 1), (2, 1), (3, 1), (4, 2);
+PREPARE p_ntile FROM 'SELECT id, NTILE(?) OVER (PARTITION BY g ORDER BY id) AS bucket FROM ntile_input ORDER BY id';
+SET @value = 2;
+EXECUTE p_ntile USING @value;
+➤ id[-5,32,0]    bucket[-5,64,0]  𝄀
+1    1
+2    1
+3    2
+4    1
+DEALLOCATE PREPARE p_ntile;
 PREPARE p_recursive FROM 'WITH RECURSIVE r(n) AS (SELECT ? UNION ALL SELECT n + 1 FROM r WHERE n < 3) SELECT CAST(SUM(n) AS SIGNED) AS got FROM r';
 SET @value = 1;
 EXECUTE p_recursive USING @value;

--- a/test/distributed/cases/prepare/prepared_numeric_aggregate.result
+++ b/test/distributed/cases/prepare/prepared_numeric_aggregate.result
@@ -45,6 +45,9 @@ EXECUTE p_ntile USING @value;
 2  ¦  1  𝄀
 3  ¦  2  𝄀
 4  ¦  1
+SET @value = NULL;
+EXECUTE p_ntile USING @value;
+invalid input: ntile bucket count cannot be NULL
 DEALLOCATE PREPARE p_ntile;
 PREPARE p_recursive FROM 'WITH RECURSIVE r(n) AS (SELECT ? UNION ALL SELECT n + 1 FROM r WHERE n < 3) SELECT CAST(SUM(n) AS SIGNED) AS got FROM r';
 SET @value = 1;

--- a/test/distributed/cases/prepare/prepared_numeric_aggregate.sql
+++ b/test/distributed/cases/prepare/prepared_numeric_aggregate.sql
@@ -34,6 +34,8 @@ INSERT INTO ntile_input VALUES (1, 1), (2, 1), (3, 1), (4, 2);
 PREPARE p_ntile FROM 'SELECT id, NTILE(?) OVER (PARTITION BY g ORDER BY id) AS bucket FROM ntile_input ORDER BY id';
 SET @value = 2;
 EXECUTE p_ntile USING @value;
+SET @value = NULL;
+EXECUTE p_ntile USING @value;
 DEALLOCATE PREPARE p_ntile;
 
 PREPARE p_recursive FROM 'WITH RECURSIVE r(n) AS (SELECT ? UNION ALL SELECT n + 1 FROM r WHERE n < 3) SELECT CAST(SUM(n) AS SIGNED) AS got FROM r';

--- a/test/distributed/cases/prepare/prepared_numeric_aggregate.sql
+++ b/test/distributed/cases/prepare/prepared_numeric_aggregate.sql
@@ -1,5 +1,5 @@
 -- @case
--- @desc:Prepared SUM and AVG infer a stable numeric parameter domain
+-- @desc:Prepared numeric functions infer stable parameter domains
 -- @label:bvt
 
 DROP DATABASE IF EXISTS prepared_numeric_aggregate;
@@ -28,6 +28,13 @@ PREPARE p_window FROM 'SELECT CAST(SUM(?) OVER () AS SIGNED) AS got';
 SET @value = 5;
 EXECUTE p_window USING @value;
 DEALLOCATE PREPARE p_window;
+
+CREATE TABLE ntile_input(id INT PRIMARY KEY, g INT);
+INSERT INTO ntile_input VALUES (1, 1), (2, 1), (3, 1), (4, 2);
+PREPARE p_ntile FROM 'SELECT id, NTILE(?) OVER (PARTITION BY g ORDER BY id) AS bucket FROM ntile_input ORDER BY id';
+SET @value = 2;
+EXECUTE p_ntile USING @value;
+DEALLOCATE PREPARE p_ntile;
 
 PREPARE p_recursive FROM 'WITH RECURSIVE r(n) AS (SELECT ? UNION ALL SELECT n + 1 FROM r WHERE n < 3) SELECT CAST(SUM(n) AS SIGNED) AS got FROM r';
 SET @value = 1;


### PR DESCRIPTION
Cast prepared NTILE bucket markers to int64 while retaining dynamic parameter metadata, and reject non-integer bucket arguments during planning.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26867 

## What this PR does / why we need it:

fix(plan): infer prepared ntile parameters