### PR TITLE
fix(plan): enforce index metadata invariants safely

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -512,7 +512,7 @@ func (builder *QueryBuilder) applyIndicesForFilters(nodeID int32, node *plan.Nod
 	{
 		masterIndexes := make([]*plan.IndexDef, 0)
 		for _, indexDef := range node.TableDef.Indexes {
-			if indexDef.TableExist && !indexDef.Unique && catalog.IsMasterIndexAlgo(indexDef.IndexAlgo) {
+			if indexDef != nil && indexDef.TableExist && !indexDef.Unique && catalog.IsMasterIndexAlgo(indexDef.IndexAlgo) {
 				masterIndexes = append(masterIndexes, indexDef)
 			}
 		}
@@ -4190,7 +4190,7 @@ func (builder *QueryBuilder) applyIndicesForJoins(nodeID int32, node *plan.Node,
 	indexes := builder.filterRegularIndexesByJoinHints(leftChild, leftChild.TableDef.Indexes)
 	condIdx := make([]indexJoinCondition, 0, len(col2Cond))
 	for _, idxDef := range indexes {
-		if !idxDef.TableExist ||
+		if idxDef == nil || !idxDef.TableExist ||
 			!catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) ||
 			isSpatialIndexDef(idxDef) ||
 			!regularIndexPrefixMetadataUsable(idxDef) ||

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1299,13 +1299,17 @@ func TestIndexHintJoinScopeFiltersCandidates(t *testing.T) {
 }
 
 func TestApplyIndicesForJoinsSkipsNilIndexMetadata(t *testing.T) {
-	builder, joinID, _, leftDef := makeIndexHintJoinBuilder(t)
+	builder, joinID, leftScanID, leftDef := makeIndexHintJoinBuilder(t)
 	leftDef.Indexes = append([]*planpb.IndexDef{nil}, leftDef.Indexes...)
 
 	newID, err := builder.applyIndicesForJoins(
 		joinID, builder.qry.Nodes[joinID], map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
 	require.NoError(t, err)
 	require.Equal(t, joinID, newID)
+	join := builder.qry.Nodes[joinID]
+	require.NotEqual(t, leftScanID, join.Children[0])
+	require.Equal(t, planpb.Node_INDEX, builder.qry.Nodes[join.Children[0]].JoinType)
+	require.Len(t, join.RuntimeFilterBuildList, 1)
 }
 
 func TestIndexJoinSkipsLossyPrefixIndex(t *testing.T) {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1298,6 +1298,16 @@ func TestIndexHintJoinScopeFiltersCandidates(t *testing.T) {
 	}
 }
 
+func TestApplyIndicesForJoinsSkipsNilIndexMetadata(t *testing.T) {
+	builder, joinID, _, leftDef := makeIndexHintJoinBuilder(t)
+	leftDef.Indexes = append([]*planpb.IndexDef{nil}, leftDef.Indexes...)
+
+	newID, err := builder.applyIndicesForJoins(
+		joinID, builder.qry.Nodes[joinID], map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+	require.NoError(t, err)
+	require.Equal(t, joinID, newID)
+}
+
 func TestIndexJoinSkipsLossyPrefixIndex(t *testing.T) {
 	builder, joinID, leftScanID, leftDef := makeIndexHintJoinBuilder(t)
 	leftDef.Indexes[0].IndexAlgoParams = `{"prefix_lengths":"a:1"}`
@@ -7594,7 +7604,7 @@ func TestApplyIndicesForFiltersUsesIndexJoinForPrefixIndex(t *testing.T) {
 	}
 	scanID := builder.appendNode(node, ctx)
 
-	resultID := builder.applyIndicesForFiltersRegularIndex(scanID, builder.qry.Nodes[scanID], map[[2]int32]int{{bindTag, 1}: 1}, map[[2]int32]*planpb.Expr{})
+	resultID := builder.applyIndicesForFilters(scanID, builder.qry.Nodes[scanID], map[[2]int32]int{{bindTag, 1}: 1}, map[[2]int32]*planpb.Expr{})
 	require.NotEqual(t, scanID, resultID)
 
 	indexJoin := builder.qry.Nodes[resultID]

--- a/pkg/sql/plan/apply_indices_vector.go
+++ b/pkg/sql/plan/apply_indices_vector.go
@@ -460,7 +460,7 @@ func tableScanHasSingleRowFilter(node *plan.Node) bool {
 		}
 	}
 	for _, idx := range node.TableDef.Indexes {
-		if idx.Unique && filterListHasConstEqualityOnCols(node.FilterList, node.TableDef, tag, idx.Parts) {
+		if idx != nil && idx.Unique && filterListHasConstEqualityOnCols(node.FilterList, node.TableDef, tag, idx.Parts) {
 			return true
 		}
 	}

--- a/pkg/sql/plan/apply_indices_vector_join_test.go
+++ b/pkg/sql/plan/apply_indices_vector_join_test.go
@@ -673,7 +673,7 @@ func TestSingleRowVectorProviderProofBranches(t *testing.T) {
 
 	tableDef := newVectorJoinTableDef(false, false)
 	tableDef.Pkey = nil
-	tableDef.Indexes = []*plan.IndexDef{{Unique: true, Parts: []string{"id", "v"}}}
+	tableDef.Indexes = []*plan.IndexDef{nil, {Unique: true, Parts: []string{"id", "v"}}}
 	scanNode := &plan.Node{
 		NodeType:    plan.Node_TABLE_SCAN,
 		TableDef:    tableDef,

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -1179,6 +1179,9 @@ func (builder *QueryBuilder) appendModernChildFkMarkOks(
 			// name as the stable order shared by both sides.
 			targetKey := "0:"
 			if !partsEqual(pkeyNames, referencedNames) {
+				if err := validateTableIndexDefinitions(parentTableDef); err != nil {
+					return 0, nil, err
+				}
 				for _, idxDef := range parentTableDef.Indexes {
 					if idxDef.Unique && partsEqual(idxDef.Parts, referencedNames) {
 						targetKey = "1:" + idxDef.IndexTableName
@@ -1260,6 +1263,9 @@ func (builder *QueryBuilder) appendModernChildFkMarkOks(
 					}
 				}
 			} else {
+				if err := validateTableIndexDefinitions(parentTableDef); err != nil {
+					return 0, nil, err
+				}
 				var matchedIndex *plan.IndexDef
 				for _, idxDef := range parentTableDef.Indexes {
 					if idxDef.Unique && partsEqual(idxDef.Parts, referencedNames) {

--- a/pkg/sql/plan/bind_update_fk.go
+++ b/pkg/sql/plan/bind_update_fk.go
@@ -321,6 +321,9 @@ func (builder *QueryBuilder) appendUpdateParentForeignKeyChecks(
 				childTableID,
 			)
 		}
+		if err := validateTableIndexDefinitions(childTableDef); err != nil {
+			return 0, 0, err
+		}
 
 		for _, fk := range childTableDef.Fkeys {
 			referencesCurrentTable := fk.ForeignTbl == tableDef.TblId ||

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -534,6 +534,9 @@ func buildAlterTable(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, error) 
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), schemaName, tableName)
 	}
+	if err := validateTableIndexDefinitions(tableDef); err != nil {
+		return nil, err
+	}
 	isMongoDB, err := IsMongoDBTableDef(ctx.GetContext(), tableDef)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -533,6 +533,9 @@ func setTableExprToDmlTableInfo(ctx CompilerContext, tbl tree.TableExpr, tblInfo
 	if tableDef == nil {
 		return moerr.NewNoSuchTable(ctx.GetContext(), dbName, tblName)
 	}
+	if err := validateTableIndexDefinitions(tableDef); err != nil {
+		return err
+	}
 
 	if err := checkTableType(ctx.GetContext(), tableDef, tblInfo.typ); err != nil {
 		return err

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1043,6 +1043,9 @@ func buildCreateTable(
 		if tableDef == nil {
 			return nil, moerr.NewNoSuchTable(ctx.GetContext(), dbName, tblName)
 		}
+		if err := validateTableIndexDefinitions(tableDef); err != nil {
+			return nil, err
+		}
 		hadStructuredChecks := len(tableDef.Checks) > 0
 		if err := recoverLegacyChecks(ctx, tableDef); err != nil {
 			return nil, err
@@ -3251,6 +3254,9 @@ func buildTruncateTable(stmt *tree.TruncateTable, ctx CompilerContext) (*Plan, e
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), truncateTable.Database, truncateTable.Table)
 	} else {
+		if err := validateTableIndexDefinitions(tableDef); err != nil {
+			return nil, err
+		}
 		// Temporary tables shadow same-named permanent tables, but TRUNCATE is
 		// not supported for temporary tables. Reject the visible temporary table
 		// here so execution can never fall through to the hidden permanent table.
@@ -3427,6 +3433,9 @@ func buildDropTableSingle(ifExists bool, temporary bool, name *tree.TableName, c
 			return nil, moerr.NewNoSuchTable(ctx.GetContext(), dropTable.Database, dropTable.Table)
 		}
 		return dropTable, nil
+	}
+	if err := validateTableIndexDefinitions(tableDef); err != nil {
+		return nil, err
 	}
 
 	if obj.PubInfo != nil {
@@ -3667,6 +3676,9 @@ func buildCreateIndex(stmt *tree.CreateIndex, ctx CompilerContext) (*Plan, error
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), createIndex.Database, tableName)
 	}
+	if err := validateTableIndexDefinitions(tableDef); err != nil {
+		return nil, err
+	}
 	if err := checkCreateIndexTableType(ctx.GetContext(), tableDef); err != nil {
 		return nil, err
 	}
@@ -3901,6 +3913,9 @@ func buildDropIndex(stmt *tree.DropIndex, ctx CompilerContext) (*Plan, error) {
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), dropIndex.Database, dropIndex.Table)
 	}
+	if err := validateTableIndexDefinitions(tableDef); err != nil {
+		return nil, err
+	}
 
 	if obj.PubInfo != nil {
 		return nil, moerr.NewInternalError(ctx.GetContext(), "cannot drop index in subscription database")
@@ -4041,6 +4056,9 @@ func buildRenameTable(stmt *tree.RenameTable, ctx CompilerContext) (*Plan, error
 		}
 		if tableDef == nil {
 			return nil, moerr.NewNoSuchTable(ctx.GetContext(), schemaName, tableName)
+		}
+		if err := validateTableIndexDefinitions(tableDef); err != nil {
+			return nil, err
 		}
 
 		if tableDef.IsTemporary {
@@ -5064,6 +5082,9 @@ func getForeignKeyData(ctx CompilerContext, dbName string, tableDef *TableDef, d
 
 	_, parentTableDef, err := ctx.Resolve(parentDbName, parentTableName, nil)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateTableIndexDefinitions(parentTableDef); err != nil {
 		return nil, err
 	}
 	if parentTableDef == nil {

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -1099,6 +1099,9 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 					return err
 				}
 			}
+			if err := validateTableIndexDefinitions(childTableDef); err != nil {
+				return err
+			}
 			childPosMap := make(map[string]int32)
 			childTypMap := make(map[string]*plan.Type)
 			childId2name := make(map[uint64]string)

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -589,6 +589,9 @@ func buildShowColumns(stmt *tree.ShowColumns, ctx CompilerContext) (*Plan, error
 		}
 		if tableDef.Indexes != nil {
 			for _, indexDef := range tableDef.Indexes {
+				if indexDef == nil {
+					continue
+				}
 				name := colNameToOriginName[indexDef.Parts[0]]
 				if indexDef.Unique {
 					if isPrimaryKey(tableDef, indexDef.Parts) {

--- a/pkg/sql/plan/build_show_test.go
+++ b/pkg/sql/plan/build_show_test.go
@@ -266,6 +266,23 @@ func TestCoverage_buildShowColumns(t *testing.T) {
 	runTestShouldPass(mock, t, sqls, false, false)
 }
 
+func TestShowColumnsSkipsNilIndexMetadata(t *testing.T) {
+	control, err := runOneStmt(NewMockOptimizer(false), t, "show columns from single_idx_t")
+	require.NoError(t, err)
+
+	mock := NewMockOptimizer(false)
+	tableDef := mock.ctxt.tables["single_idx_t"]
+	require.NotNil(t, tableDef)
+	require.NotEmpty(t, tableDef.Indexes)
+	tableDef.Indexes = append([]*plan.IndexDef{nil}, tableDef.Indexes...)
+
+	got, err := runOneStmt(mock, t, "show columns from single_idx_t")
+	require.NoError(t, err)
+	require.Equal(t, control.GetQuery().GetHeadings(), got.GetQuery().GetHeadings())
+	require.True(t, queryContainsStringLiteral(control.GetQuery(), "MUL"))
+	require.True(t, queryContainsStringLiteral(got.GetQuery(), "MUL"))
+}
+
 func TestCoverage_buildShowTableStatus(t *testing.T) {
 	mock := NewMockOptimizer(false)
 

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -237,6 +237,9 @@ func constructCreateTableSQL(
 		indexNames := make(map[string]bool)
 
 		for _, indexdef := range tableDef.Indexes {
+			if indexdef == nil {
+				continue
+			}
 			// Index Name can be empty string when CREATE TABLE with index
 			// avoid duplicate only work when index name is not empty
 			if len(indexdef.IndexName) > 0 {

--- a/pkg/sql/plan/build_show_util_test.go
+++ b/pkg/sql/plan/build_show_util_test.go
@@ -184,7 +184,9 @@ func Test_buildShowCreateTableSpatialIndex(t *testing.T) {
 	)`)
 	require.NoError(t, err)
 
-	tableDef.Indexes = append(tableDef.Indexes, &plan.IndexDef{
+	// A sparse metadata slice must not prevent SHOW CREATE from rendering
+	// the valid index entries that follow it.
+	tableDef.Indexes = append(tableDef.Indexes, nil, &plan.IndexDef{
 		IndexName: "idx_g",
 		Parts:     []string{"g"},
 		IndexAlgo: catalog.MoIndexRTreeAlgo.ToString(),

--- a/pkg/sql/plan/dml_context.go
+++ b/pkg/sql/plan/dml_context.go
@@ -332,6 +332,9 @@ func (dmlCtx *DMLContext) resolveSingleTable(
 	if tableDef == nil {
 		return moerr.NewNoSuchTable(ctx.GetContext(), dbName, tblName)
 	}
+	if err := validateTableIndexDefinitions(tableDef); err != nil {
+		return err
+	}
 
 	// External tables are not handled by the modern DML binder. Writable ones
 	// (WRITE_FILE_PATTERN) defer to the legacy planner, whose buildInsert /

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -674,6 +674,9 @@ func indexesTableSize(ctx context.Context, db engine.Database, rel engine.Relati
 	var irel engine.Relation
 	var size uint64
 	for _, idef := range rel.GetTableDef(ctx).Indexes {
+		if idef == nil {
+			continue
+		}
 		if irel, err = db.Relation(ctx, idef.IndexTableName, nil); err != nil {
 			logutil.Info("indexesTableSize->Relation",
 				zap.String("originTable", rel.GetTableName()),

--- a/pkg/sql/plan/index_metadata.go
+++ b/pkg/sql/plan/index_metadata.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import "github.com/matrixorigin/matrixone/pkg/common/moerr"
+
+// validateTableIndexDefinitions enforces the dense IndexDef invariant before an
+// operation can omit maintenance, locking, or lifecycle work for an unknown
+// index. Healthy persisted metadata is dense; a nil entry means an in-memory
+// producer supplied incomplete metadata and must fail closed rather than be
+// treated as absent.
+func validateTableIndexDefinitions(tableDef *TableDef) error {
+	if tableDef == nil {
+		return nil
+	}
+	for pos, idxDef := range tableDef.Indexes {
+		if idxDef == nil {
+			return moerr.NewInternalErrorNoCtxf(
+				"nil index metadata for table %q at position %d", tableDef.Name, pos)
+		}
+	}
+	return nil
+}

--- a/pkg/sql/plan/indexdef_metadata_test.go
+++ b/pkg/sql/plan/indexdef_metadata_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/stretchr/testify/require"
 )
@@ -57,4 +58,106 @@ func TestIndexDefPreservesRemovedVisibilityMarkerAsUnknownWireData(t *testing.T)
 	roundTrip, err := decoded.Marshal()
 	require.NoError(t, err)
 	require.True(t, bytes.Contains(roundTrip, []byte{0x70, 0x01}))
+}
+
+func TestSparseIndexMetadataMutationPathsFailClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		dml      bool
+		nilFirst bool
+	}{
+		{name: "insert", sql: "insert into single_idx_t values (1, 100)", dml: true, nilFirst: true},
+		{name: "load", sql: "load data inline format='csv', data='1,100' into table single_idx_t fields terminated by ','", dml: true},
+		{name: "replace", sql: "replace into single_idx_t values (1, 100)", dml: true},
+		{name: "update", sql: "update single_idx_t set val = 100 where id = 1", dml: true, nilFirst: true},
+		{name: "delete", sql: "delete from single_idx_t where id = 1", dml: true},
+		{name: "select for update", sql: "select * from single_idx_t where val = 100 for update", dml: true, nilFirst: true},
+		{name: "alter table", sql: "alter table single_idx_t rename column val to val2", nilFirst: true},
+		{name: "rename table", sql: "rename table single_idx_t to single_idx_copy"},
+		{name: "truncate table", sql: "truncate table single_idx_t"},
+		{name: "drop table", sql: "drop table single_idx_t", nilFirst: true},
+		{name: "create index", sql: "create index idx_id on single_idx_t(id)"},
+		{name: "drop index", sql: "drop index idx_val on single_idx_t", nilFirst: true},
+		{name: "create table like", sql: "create table single_idx_copy like single_idx_t"},
+		{name: "clone table", sql: "create table single_idx_copy clone single_idx_t", nilFirst: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := NewMockOptimizer(test.dml)
+			tableDef := mock.ctxt.tables["single_idx_t"]
+			require.NotNil(t, tableDef)
+			require.NotEmpty(t, tableDef.Indexes)
+			if test.nilFirst {
+				tableDef.Indexes = append([]*planpb.IndexDef{nil}, tableDef.Indexes...)
+			} else {
+				tableDef.Indexes = append(tableDef.Indexes, nil)
+			}
+
+			_, err := runOneStmt(mock, t, test.sql)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrInternal), err)
+			require.ErrorContains(t, err, "nil index metadata")
+		})
+	}
+}
+
+func TestSparseIndexMetadataRelatedMutationTablesFailClosed(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*MockOptimizer)
+		sql   string
+	}{
+		{
+			name: "cascade target",
+			setup: func(mock *MockOptimizer) {
+				mock.ctxt.tables["replace_fk_sc"].Indexes = []*planpb.IndexDef{nil}
+			},
+			sql: "delete from replace_fk_sp where id = 1",
+		},
+		{
+			name: "foreign key unique parent",
+			setup: func(mock *MockOptimizer) {
+				parent := mock.ctxt.tables["replace_fk_p"]
+				child := mock.ctxt.tables["replace_fk_c"]
+				child.Cols[1].Typ = parent.Cols[1].Typ
+				child.Fkeys[0].ForeignCols = []uint64{parent.Cols[1].ColId}
+				parent.Indexes = []*planpb.IndexDef{nil, {
+					IndexName: "uk_v", IndexTableName: "__mo_index_fk_parent_v",
+					Parts: []string{"v"}, Unique: true, TableExist: true,
+				}}
+			},
+			sql: "insert into replace_fk_c values (10, 'x')",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			test.setup(mock)
+
+			_, err := runOneStmt(mock, t, test.sql)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrInternal), err)
+			require.ErrorContains(t, err, "nil index metadata")
+		})
+	}
+}
+
+func TestValidateTableIndexDefinitions(t *testing.T) {
+	require.NoError(t, validateTableIndexDefinitions(&planpb.TableDef{
+		Name:    "dense",
+		Indexes: []*planpb.IndexDef{{IndexName: "idx_a"}},
+	}))
+
+	for _, indexes := range [][]*planpb.IndexDef{
+		{nil, {IndexName: "idx_a"}},
+		{{IndexName: "idx_a"}, nil},
+	} {
+		err := validateTableIndexDefinitions(&planpb.TableDef{Name: "sparse", Indexes: indexes})
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrInternal), err)
+		require.ErrorContains(t, err, "nil index metadata")
+	}
 }

--- a/pkg/sql/plan/indexdef_metadata_test.go
+++ b/pkg/sql/plan/indexdef_metadata_test.go
@@ -145,6 +145,52 @@ func TestSparseIndexMetadataRelatedMutationTablesFailClosed(t *testing.T) {
 	}
 }
 
+func TestSparseIndexMetadataLegacyDMLTargetsFailClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		nilFirst bool
+	}{
+		{
+			name:     "joined update nil first",
+			sql:      "update emp left join dept on emp.deptno = dept.deptno set emp.sal = 5000",
+			nilFirst: true,
+		},
+		{
+			name: "joined update nil after valid",
+			sql:  "update emp left join dept on emp.deptno = dept.deptno set emp.sal = 5000",
+		},
+		{
+			name:     "multi-table delete nil first",
+			sql:      "delete emp, dept from emp, dept where emp.deptno = dept.deptno",
+			nilFirst: true,
+		},
+		{
+			name: "multi-table delete nil after valid",
+			sql:  "delete emp, dept from emp, dept where emp.deptno = dept.deptno",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			tableDef := mock.ctxt.tables["emp"]
+			require.NotNil(t, tableDef)
+			require.NotEmpty(t, tableDef.Indexes)
+			if test.nilFirst {
+				tableDef.Indexes = append([]*planpb.IndexDef{nil}, tableDef.Indexes...)
+			} else {
+				tableDef.Indexes = append(tableDef.Indexes, nil)
+			}
+
+			_, err := runOneStmt(mock, t, test.sql)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrInternal), err)
+			require.ErrorContains(t, err, "nil index metadata")
+		})
+	}
+}
+
 func TestValidateTableIndexDefinitions(t *testing.T) {
 	require.NoError(t, validateTableIndexDefinitions(&planpb.TableDef{
 		Name:    "dense",

--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -1280,6 +1280,11 @@ func (builder *QueryBuilder) lockTableIfLockNoRowsAtTheEndForDelAndUpdate() (err
 	}
 	tableDef := baseNode.TableDef
 	objRef := baseNode.ObjRef
+	if builder.isForUpdate && query.StmtType == plan.Query_SELECT {
+		if err = validateTableIndexDefinitions(tableDef); err != nil {
+			return
+		}
+	}
 	tableIDs := make(map[uint64]bool)
 	tableIDs[tableDef.TblId] = true
 	for _, idx := range tableDef.Indexes {

--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -105,7 +105,7 @@ func (rule *GetParamRule) MatchNode(node *Node) bool {
 		}
 		if node.NodeType == plan.Node_TABLE_SCAN && node.ObjRef != nil && node.TableDef != nil {
 			for _, indexDef := range node.TableDef.Indexes {
-				if indexplugin.IsPluginAlgo(indexDef.IndexAlgo) && indexDef.IndexTableName != "" {
+				if indexDef != nil && indexplugin.IsPluginAlgo(indexDef.IndexAlgo) && indexDef.IndexTableName != "" {
 					rule.indexDependencies = append(rule.indexDependencies, prepareIndexDependency{
 						baseRef:   node.ObjRef,
 						snapshot:  node.ScanSnapshot,
@@ -135,7 +135,7 @@ func (builder *QueryBuilder) recordPreparedPluginDependencies(scanNode *Node) er
 		prepareSchemaRefWithSnapshot(scanNode.ObjRef, scanNode.TableDef, scanNode.ScanSnapshot),
 	}
 	for _, indexDef := range scanNode.TableDef.Indexes {
-		if !indexplugin.IsPluginAlgo(indexDef.IndexAlgo) || indexDef.IndexTableName == "" {
+		if indexDef == nil || !indexplugin.IsPluginAlgo(indexDef.IndexAlgo) || indexDef.IndexTableName == "" {
 			continue
 		}
 		objRef, tableDef, err := builder.compCtx.ResolveIndexTableByRef(

--- a/pkg/sql/plan/visit_plan_rule_test.go
+++ b/pkg/sql/plan/visit_plan_rule_test.go
@@ -830,7 +830,7 @@ func TestResetPreparePlanCollectsHiddenIndexSchemas(t *testing.T) {
 					DbId:    1,
 					TblId:   2,
 					Version: 3,
-					Indexes: []*planpb.IndexDef{{
+					Indexes: []*planpb.IndexDef{nil, {
 						IndexAlgo:      catalog.MOIndexFullTextAlgo.ToString(),
 						IndexTableName: hiddenTable,
 					}},
@@ -874,7 +874,7 @@ func TestRecordPreparedPluginDependenciesSurvivesScanRemoval(t *testing.T) {
 		},
 		TableDef: &planpb.TableDef{
 			Name: "src", DbId: 1, TblId: 2, Version: 3,
-			Indexes: []*planpb.IndexDef{{
+			Indexes: []*planpb.IndexDef{nil, {
 				IndexAlgo:      catalog.MOIndexFullTextAlgo.ToString(),
 				IndexTableName: hiddenTable,
 			}},
@@ -927,6 +927,30 @@ func TestRecordPreparedPluginDependenciesSurvivesScanRemoval(t *testing.T) {
 	cloned := DeepCopyQuery(builder.qry)
 	require.Equal(t, builder.qry.CatalogDependencies, cloned.CatalogDependencies)
 	require.NotSame(t, builder.qry.CatalogDependencies[0], cloned.CatalogDependencies[0])
+}
+
+func TestPrepareSkipsNilIndexMetadata(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	tableDef := mock.ctxt.tables["single_idx_t"]
+	require.NotNil(t, tableDef)
+	require.NotEmpty(t, tableDef.Indexes)
+	tableDef.Indexes = append([]*planpb.IndexDef{nil}, tableDef.Indexes...)
+
+	logicPlan, err := runOneStmt(mock, t,
+		"prepare sparse_index_stmt from 'select val from single_idx_t where val = ?'")
+	require.NoError(t, err)
+	prepare := logicPlan.GetDcl().GetPrepare()
+	require.NotNil(t, prepare)
+	require.Len(t, prepare.ParamTypes, 1)
+	require.NotEmpty(t, prepare.Schemas)
+	foundBaseSchema := false
+	for _, schema := range prepare.Schemas {
+		if schema.GetObjName() == "single_idx_t" {
+			foundBaseSchema = true
+			break
+		}
+	}
+	require.True(t, foundBaseSchema)
 }
 
 func TestResetPreparedSetMergesTransientCatalogDependencies(t *testing.T) {


### PR DESCRIPTION
Follow-up to #26972. Removing the nil-tolerant optimizer visibility filter exposed unchecked nil IndexDef dereferences, but blindly skipping nil metadata on every path is not correct.

## Invariant and failure policy

Persisted engine metadata is dense: protobuf and constraint decoders allocate an IndexDef for every stored entry. A nil entry therefore represents incomplete in-memory metadata, not an optional physical index.

- read-only discovery and display paths skip nil entries and keep processing later valid indexes; the base table remains the authoritative correctness fallback
- mutation, locking, clone, and index-lifecycle paths fail closed before an unknown index can be omitted from maintenance, locking, copy, truncate, rename, or drop work
- no metadata is compacted, guessed, repaired in the background, or silently normalized

## What changed

Read-only closure:
- master, regular join, vector single-row, SHOW CREATE, SHOW COLUMNS, PREPARE dependency, and index-size traversals tolerate nil entries
- later valid indexes and plugin hidden-table dependencies remain eligible

Mutation closure:
- one dense-metadata validator is applied at the common DML target boundary
- ALTER, RENAME, TRUNCATE, DROP TABLE, CREATE/DROP INDEX, CREATE TABLE LIKE/CLONE, and foreign-key creation validate before lifecycle work
- SELECT FOR UPDATE/SHARE validates before hidden-index lock planning
- foreign-key unique-parent locking and cascaded child mutations validate related table metadata before building their mutation work

## Compatibility

The 4.1-dev and 4.2-dev visibility compatibility surface remains unchanged: protobuf field 8, mo_indexes.is_visible, accepted VISIBLE/INVISIBLE syntax, ALTER behavior, and SHOW behavior are preserved. Field 14 remains reserved as established by #26972. No wire, catalog, migration, or persisted metadata changes are introduced.

## Performance and unhappy paths

Read-only traversals add one constant-time nil branch per visited index. Mutation validation is a bounded O(number of indexes) planner-time scan per resolved table boundary, with no allocations on the healthy path. There is no row-level or batch-level work, catalog I/O, logging, retry loop, background task, cache, or new resource ownership.

Invalid metadata returns one deterministic internal error. It is not logged repeatedly and cannot proceed far enough to create index divergence or orphan hidden tables.

## Validation

- deterministic RED reproductions for SHOW COLUMNS, SELECT FOR UPDATE, DML/DDL mutation paths, foreign-key unique-parent locking, and cascade-child mutation
- regressions for nil-before-valid filter, join, vector, SHOW CREATE/COLUMNS, PREPARE, and plugin dependency paths
- INSERT, LOAD, REPLACE, UPDATE, DELETE, ALTER, RENAME, TRUNCATE, DROP, CREATE/DROP INDEX, CREATE LIKE, and CLONE fail-closed matrix
- full pkg/sql/plan tests
- go list, go build, and go vet for pkg/sql/plan
- git diff --check
- rebased onto current main at 3f2ed9b205
