### PR TITLE
fix(backup): preserve hidden commitTS in rewritten tombstones

### DIFF
--- a/pkg/objectio/ioutil/funcs.go
+++ b/pkg/objectio/ioutil/funcs.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
@@ -348,12 +349,16 @@ func IsRowDeletedByLocation(
 	if createdByCN {
 		deleted = (idx < len(rowids)) && (rowids[idx].EQ(row))
 	} else {
-		tss := vector.MustFixedColNoTypeCheck[types.TS](&data[1])
+		tss, err := ValidateTombstoneCommitTSColumn(len(rowids), &data[1])
+		if err != nil {
+			return false, err
+		}
 		for i := idx; i < len(rowids); i++ {
 			if !rowids[i].EQ(row) {
 				break
 			}
-			if tss[i].LE(snapshotTS) {
+			commitTS := tss.At(i)
+			if commitTS.LE(snapshotTS) {
 				deleted = true
 				break
 			}
@@ -397,7 +402,7 @@ func FillBlockDeleteMask(
 	if createdByCN {
 		deleteMask = EvalDeleteMaskFromCNCreatedTombstones(blockId, &persistedDeletes[0])
 	} else {
-		deleteMask = EvalDeleteMaskFromDNCreatedTombstones(
+		deleteMask, err = EvalDeleteMaskFromDNCreatedTombstones(
 			&persistedDeletes[0],
 			&persistedDeletes[1],
 			meta.GetBlockMeta(uint32(location.ID())),
@@ -417,7 +422,7 @@ func ReadDeletes(
 	isPersistedByCN bool,
 	cacheVectors containers.Vectors,
 	pkType *types.Type,
-) (objectio.ObjectDataMeta, func(), error) {
+) (meta objectio.ObjectDataMeta, release func(), err error) {
 
 	var cols []uint16
 	var typs []types.Type
@@ -435,9 +440,133 @@ func ReadDeletes(
 		typs = append(typs[:1], append([]types.Type{*pkType}, typs[1:]...)...)
 	}
 
-	return LoadTombstoneColumns(
+	meta, release, err = LoadTombstoneColumns(
 		ctx, cols, typs, fs, deltaLoc, cacheVectors, nil, fileservice.Policy(0),
 	)
+	if err != nil || isPersistedByCN {
+		return
+	}
+
+	commitIdx := len(cols) - 1
+	rowCount := cacheVectors[0].Length()
+	if _, err = ValidateTombstoneCommitTSColumn(rowCount, &cacheVectors[commitIdx]); err != nil {
+		if physicalCommitTS, ok := resolveLegacyBackupCommitTS(
+			meta.GetBlockMeta(uint32(deltaLoc.ID())),
+			&cacheVectors[commitIdx],
+		); ok {
+			release()
+			release = nil
+			cols[commitIdx] = physicalCommitTS
+			meta, release, err = LoadTombstoneColumns(
+				ctx, cols, typs, fs, deltaLoc, cacheVectors, nil, fileservice.Policy(0),
+			)
+			if err != nil {
+				return
+			}
+			rowCount = cacheVectors[0].Length()
+			_, err = ValidateTombstoneCommitTSColumn(rowCount, &cacheVectors[commitIdx])
+		}
+		if err != nil {
+			if release != nil {
+				release()
+			}
+			release = nil
+		}
+	}
+	return
+}
+
+// resolveLegacyBackupCommitTS recognizes the exact non-appendable tombstone
+// layout produced by the v4.1 and affected v4.2 Backup rewrite. That rewrite
+// used the generic object writer, so [rowid, primary-key, commitTS] was
+// persisted with dense seqnums [0, 1, 2] and MaxSeqnum 2 instead of declaring
+// commitTS as a special column. The v4.1 reader inferred the trailing column by
+// position, so a same-version restore still worked; the stricter 4.2 reader
+// needs this narrow mapping. Keep the rule local to the non-CN tombstone reader
+// so ordinary timestamp columns are never reinterpreted globally.
+func resolveLegacyBackupCommitTS(
+	block objectio.BlockObject,
+	resolvedCommitTS *vector.Vector,
+) (uint16, bool) {
+	const legacyCommitTSPosition uint16 = 2
+	if resolvedCommitTS == nil || !resolvedCommitTS.IsConstNull() ||
+		block.BlockHeader().Appendable() ||
+		block.GetColumnCount() != 3 ||
+		block.GetMetaColumnCount() != 3 ||
+		block.GetMaxSeqnum() != legacyCommitTSPosition ||
+		block.ColumnMeta(0).DataType() != uint8(types.T_Rowid) ||
+		block.ColumnMeta(1).DataType() == uint8(types.T_any) ||
+		block.ColumnMeta(legacyCommitTSPosition).DataType() != uint8(types.T_TS) {
+		return 0, false
+	}
+	return legacyCommitTSPosition, true
+}
+
+// TombstoneCommitTSColumn is a validated commit timestamp column. At preserves
+// Vector's constant-broadcast semantics without exposing its one-value backing
+// slice to callers that iterate over the full tombstone row count.
+type TombstoneCommitTSColumn struct {
+	vec *vector.Vector
+}
+
+func (c TombstoneCommitTSColumn) IsPresent() bool {
+	return c.vec != nil
+}
+
+func (c TombstoneCommitTSColumn) At(row int) types.TS {
+	return vector.GetFixedAtNoTypeCheck[types.TS](c.vec, row)
+}
+
+// ValidateTombstoneCommitTSColumn validates commitTS before a tombstone
+// consumer indexes it by the rowid count. A synthesized const-null vector has
+// the correct logical length but no fixed backing value, while a valid non-null
+// const vector has one value that must be broadcast to every logical row.
+func ValidateTombstoneCommitTSColumn(
+	expectedRows int,
+	commitTSVec *vector.Vector,
+) (TombstoneCommitTSColumn, error) {
+	if expectedRows < 0 {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtxf(
+			"negative tombstone row count %d", expectedRows,
+		)
+	}
+	if commitTSVec == nil {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtx("tombstone commit-ts column is missing")
+	}
+	if commitTSVec.GetType().Oid != types.T_TS {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtxf(
+			"tombstone commit-ts column has type %s, expected TS",
+			commitTSVec.GetType().String(),
+		)
+	}
+	if commitTSVec.IsConstNull() {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtx("tombstone commit-ts column is unavailable")
+	}
+	if commitTSVec.Length() != expectedRows {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtxf(
+			"tombstone commit-ts column has %d rows, expected %d",
+			commitTSVec.Length(), expectedRows,
+		)
+	}
+	if commitTSVec.GetNulls().Any() {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtx("tombstone commit-ts column contains null rows")
+	}
+	typeSize := int(commitTSVec.GetType().TypeSize())
+	backingRows := expectedRows
+	if commitTSVec.IsConst() && backingRows > 0 {
+		backingRows = 1
+	}
+	if typeSize <= 0 || backingRows > math.MaxInt/typeSize {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtx("tombstone commit-ts backing size overflows")
+	}
+	requiredBytes := backingRows * typeSize
+	if len(commitTSVec.GetData()) < requiredBytes {
+		return TombstoneCommitTSColumn{}, moerr.NewInvalidInputNoCtxf(
+			"tombstone commit-ts column has %d backing bytes, needs at least %d",
+			len(commitTSVec.GetData()), requiredBytes,
+		)
+	}
+	return TombstoneCommitTSColumn{vec: commitTSVec}, nil
 }
 
 func EvalDeleteMaskFromDNCreatedTombstones(
@@ -446,11 +575,15 @@ func EvalDeleteMaskFromDNCreatedTombstones(
 	meta objectio.BlockObject,
 	ts *types.TS,
 	blockid *types.Blockid,
-) (rows objectio.Bitmap) {
+) (rows objectio.Bitmap, err error) {
 	if deletedRows == nil {
 		return
 	}
 	rowids := vector.MustFixedColWithTypeCheck[types.Rowid](deletedRows)
+	tss, err := ValidateTombstoneCommitTSColumn(len(rowids), commitTSVec)
+	if err != nil {
+		return objectio.NullBitmap, err
+	}
 	start, end := FindStartEndOfBlockFromSortedRowids(rowids, blockid)
 	if start >= end {
 		return
@@ -470,9 +603,9 @@ func EvalDeleteMaskFromDNCreatedTombstones(
 			rows.Add(uint64(row))
 		}
 	} else {
-		tss := vector.MustFixedColWithTypeCheck[types.TS](commitTSVec)
 		for i := end - 1; i >= start; i-- {
-			if tss[i].GT(ts) {
+			commitTS := tss.At(i)
+			if commitTS.GT(ts) {
 				continue
 			}
 			row := rowids[i].GetRowOffset()

--- a/pkg/objectio/ioutil/funcs.go
+++ b/pkg/objectio/ioutil/funcs.go
@@ -455,7 +455,6 @@ func ReadDeletes(
 			&cacheVectors[commitIdx],
 		); ok {
 			release()
-			release = nil
 			cols[commitIdx] = physicalCommitTS
 			meta, release, err = LoadTombstoneColumns(
 				ctx, cols, typs, fs, deltaLoc, cacheVectors, nil, fileservice.Policy(0),

--- a/pkg/objectio/ioutil/funcs.go
+++ b/pkg/objectio/ioutil/funcs.go
@@ -450,20 +450,21 @@ func ReadDeletes(
 	commitIdx := len(cols) - 1
 	rowCount := cacheVectors[0].Length()
 	if _, err = ValidateTombstoneCommitTSColumn(rowCount, &cacheVectors[commitIdx]); err != nil {
-		if physicalCommitTS, ok := resolveLegacyBackupCommitTS(
-			meta.GetBlockMeta(uint32(deltaLoc.ID())),
-			&cacheVectors[commitIdx],
-		); ok {
-			release()
-			cols[commitIdx] = physicalCommitTS
-			meta, release, err = LoadTombstoneColumns(
-				ctx, cols, typs, fs, deltaLoc, cacheVectors, nil, fileservice.Policy(0),
-			)
-			if err != nil {
-				return
+		if cacheVectors[commitIdx].IsConstNull() {
+			if physicalCommitTS, ok := ResolveLegacyBackupTombstoneCommitTS(
+				meta.GetBlockMeta(uint32(deltaLoc.ID())),
+			); ok {
+				release()
+				cols[commitIdx] = physicalCommitTS
+				meta, release, err = LoadTombstoneColumns(
+					ctx, cols, typs, fs, deltaLoc, cacheVectors, nil, fileservice.Policy(0),
+				)
+				if err != nil {
+					return
+				}
+				rowCount = cacheVectors[0].Length()
+				_, err = ValidateTombstoneCommitTSColumn(rowCount, &cacheVectors[commitIdx])
 			}
-			rowCount = cacheVectors[0].Length()
-			_, err = ValidateTombstoneCommitTSColumn(rowCount, &cacheVectors[commitIdx])
 		}
 		if err != nil {
 			if release != nil {
@@ -475,21 +476,18 @@ func ReadDeletes(
 	return
 }
 
-// resolveLegacyBackupCommitTS recognizes the exact non-appendable tombstone
+// ResolveLegacyBackupTombstoneCommitTS recognizes the exact non-appendable tombstone
 // layout produced by the v4.1 and affected v4.2 Backup rewrite. That rewrite
 // used the generic object writer, so [rowid, primary-key, commitTS] was
 // persisted with dense seqnums [0, 1, 2] and MaxSeqnum 2 instead of declaring
 // commitTS as a special column. The v4.1 reader inferred the trailing column by
 // position, so a same-version restore still worked; the stricter 4.2 reader
-// needs this narrow mapping. Keep the rule local to the non-CN tombstone reader
-// so ordinary timestamp columns are never reinterpreted globally.
-func resolveLegacyBackupCommitTS(
-	block objectio.BlockObject,
-	resolvedCommitTS *vector.Vector,
-) (uint16, bool) {
+// needs this narrow mapping. Callers must additionally know that the object is
+// a non-CN tombstone; this metadata signature alone can also describe an
+// ordinary three-column object and must never be applied to generic reads.
+func ResolveLegacyBackupTombstoneCommitTS(block objectio.BlockObject) (uint16, bool) {
 	const legacyCommitTSPosition uint16 = 2
-	if resolvedCommitTS == nil || !resolvedCommitTS.IsConstNull() ||
-		block.BlockHeader().Appendable() ||
+	if block.BlockHeader().Appendable() ||
 		block.GetColumnCount() != 3 ||
 		block.GetMetaColumnCount() != 3 ||
 		block.GetMaxSeqnum() != legacyCommitTSPosition ||

--- a/pkg/objectio/ioutil/loadfuncs_test.go
+++ b/pkg/objectio/ioutil/loadfuncs_test.go
@@ -41,6 +41,25 @@ type releaseTrackingFS struct {
 	outstanding atomic.Int32
 }
 
+type failLegacyReloadFS struct {
+	*releaseTrackingFS
+	failed                   atomic.Bool
+	firstLeaseReleasedOnFail atomic.Bool
+}
+
+func (f *failLegacyReloadFS) Read(
+	ctx context.Context,
+	ioVector *fileservice.IOVector,
+) error {
+	// The first legacy read loads rowid while commitTS is synthesized. The
+	// compatibility reload then has two physical entries: rowid + commitTS.
+	if len(ioVector.Entries) == 2 && f.failed.CompareAndSwap(false, true) {
+		f.firstLeaseReleasedOnFail.Store(f.outstanding.Load() == 0)
+		return fmt.Errorf("injected legacy commit-ts reload failure")
+	}
+	return f.releaseTrackingFS.Read(ctx, ioVector)
+}
+
 func (f *releaseTrackingFS) Read(
 	ctx context.Context,
 	ioVector *fileservice.IOVector,
@@ -66,6 +85,288 @@ func (f *releaseTrackingFS) Read(
 type releaseTrackingData struct {
 	fscache.Data
 	outstanding *atomic.Int32
+}
+
+func TestValidateTombstoneCommitTSColumn(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	valid := vector.NewVec(types.T_TS.ToType())
+	for i := int64(1); i <= 3; i++ {
+		require.NoError(t, vector.AppendFixed(valid, types.BuildTS(i, 0), false, mp))
+	}
+	column, err := ValidateTombstoneCommitTSColumn(3, valid)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildTS(1, 0), column.At(0))
+	require.Equal(t, types.BuildTS(3, 0), column.At(2))
+	valid.Free(mp)
+
+	missing := vector.NewConstNull(types.T_TS.ToType(), 3, mp)
+	_, err = ValidateTombstoneCommitTSColumn(3, missing)
+	require.ErrorContains(t, err, "unavailable")
+	missing.Free(mp)
+
+	partial := vector.NewVec(types.T_TS.ToType())
+	require.NoError(t, vector.AppendFixed(partial, types.BuildTS(1, 0), false, mp))
+	_, err = ValidateTombstoneCommitTSColumn(3, partial)
+	require.ErrorContains(t, err, "1 rows, expected 3")
+	partial.Free(mp)
+
+	shortBacking := vector.NewVec(types.T_TS.ToType())
+	require.NoError(t, vector.AppendFixed(shortBacking, types.BuildTS(1, 0), false, mp))
+	shortBacking.SetLength(3)
+	_, err = ValidateTombstoneCommitTSColumn(3, shortBacking)
+	require.ErrorContains(t, err, "backing bytes")
+	shortBacking.Free(mp)
+
+	nullCommitTS := vector.NewVec(types.T_TS.ToType())
+	require.NoError(t, vector.AppendFixed(nullCommitTS, types.BuildTS(1, 0), true, mp))
+	_, err = ValidateTombstoneCommitTSColumn(1, nullCommitTS)
+	require.ErrorContains(t, err, "contains null rows")
+	nullCommitTS.Free(mp)
+
+	wrongType := vector.NewVec(types.T_int64.ToType())
+	_, err = ValidateTombstoneCommitTSColumn(0, wrongType)
+	require.ErrorContains(t, err, "expected TS")
+	wrongType.Free(mp)
+
+	constant, err := vector.NewConstFixed(types.T_TS.ToType(), types.BuildTS(1, 0), 3, mp)
+	require.NoError(t, err)
+	column, err = ValidateTombstoneCommitTSColumn(3, constant)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildTS(1, 0), column.At(0))
+	require.Equal(t, types.BuildTS(1, 0), column.At(2))
+	constant.Free(mp)
+}
+
+func TestLegacyBackupTombstoneUsesTrailingCommitTS(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	blockID := *objectio.NewBlockid(objectio.NewSegmentid(), 1, 0)
+	input := batch.NewWithSize(3)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_TS.ToType())
+	input.Vecs[2] = vector.NewVec(types.T_TS.ToType())
+	defer input.Clean(mp)
+
+	for _, row := range []struct {
+		offset   uint32
+		pk       types.TS
+		commitTS types.TS
+	}{
+		{offset: 1, pk: types.BuildTS(100, 0), commitTS: types.BuildTS(5, 0)},
+		{offset: 2, pk: types.BuildTS(100, 0), commitTS: types.BuildTS(20, 0)},
+	} {
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[0], types.NewRowid(&blockID, row.offset), false, mp,
+		))
+		require.NoError(t, vector.AppendFixed(input.Vecs[1], row.pk, false, mp))
+		require.NoError(t, vector.AppendFixed(input.Vecs[2], row.commitTS, false, mp))
+	}
+	input.SetRowCount(2)
+
+	// The old Backup path used the generic writer. It persisted commitTS as
+	// dense user seqnum 2 instead of hidden SEQNUM_COMMITTS.
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	writer, err := NewBlockWriter(fs, name.String())
+	require.NoError(t, err)
+	_, err = writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, _, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.False(t, blocks[0].BlockHeader().Appendable())
+	require.Equal(t, uint16(3), blocks[0].GetMetaColumnCount())
+	require.Equal(t, uint16(2), blocks[0].GetMaxSeqnum())
+	require.Equal(t, uint8(types.T_TS), blocks[0].ColumnMeta(2).DataType())
+
+	location := objectio.BuildLocation(
+		name,
+		blocks[0].GetExtent(),
+		uint32(input.RowCount()),
+		blocks[0].GetID(),
+	)
+	snapshot := types.BuildTS(10, 0)
+	trackingFS := &releaseTrackingFS{FileService: fs}
+
+	t.Run("timestamp primary key remains distinct", func(t *testing.T) {
+		cacheVectors := containers.NewVectors(3)
+		pkType := types.T_TS.ToType()
+		_, release, err := ReadDeletes(ctx, location, trackingFS, false, cacheVectors, &pkType)
+		require.NoError(t, err)
+		primaryKeys := vector.MustFixedColWithTypeCheck[types.TS](&cacheVectors[1])
+		commitTSs := vector.MustFixedColWithTypeCheck[types.TS](&cacheVectors[2])
+		require.Equal(t, []types.TS{types.BuildTS(100, 0), types.BuildTS(100, 0)}, primaryKeys)
+		require.Equal(t, []types.TS{types.BuildTS(5, 0), types.BuildTS(20, 0)}, commitTSs)
+		release()
+		require.Zero(t, trackingFS.outstanding.Load())
+	})
+
+	t.Run("point lookup", func(t *testing.T) {
+		row := types.NewRowid(&blockID, 1)
+		deleted, err := IsRowDeletedByLocation(ctx, &snapshot, &row, location, trackingFS, false)
+		require.NoError(t, err)
+		require.True(t, deleted)
+		require.Zero(t, trackingFS.outstanding.Load())
+	})
+
+	t.Run("block mask", func(t *testing.T) {
+		mask, err := FillBlockDeleteMask(ctx, &snapshot, &blockID, location, trackingFS, false)
+		require.NoError(t, err)
+		defer mask.Release()
+		require.True(t, mask.Contains(1))
+		require.False(t, mask.Contains(2))
+		require.Zero(t, trackingFS.outstanding.Load())
+	})
+
+	t.Run("reload failure releases first lease", func(t *testing.T) {
+		failingFS := &failLegacyReloadFS{
+			releaseTrackingFS: &releaseTrackingFS{FileService: fs},
+		}
+		cacheVectors := containers.NewVectors(2)
+		_, release, err := ReadDeletes(ctx, location, failingFS, false, cacheVectors, nil)
+		require.ErrorContains(t, err, "injected legacy commit-ts reload failure")
+		require.Nil(t, release)
+		require.True(t, failingFS.failed.Load())
+		require.True(t, failingFS.firstLeaseReleasedOnFail.Load())
+		require.Zero(t, failingFS.outstanding.Load())
+	})
+	require.Positive(t, trackingFS.tracked.Load())
+}
+
+func TestReadDeletesBroadcastsPersistedConstantCommitTS(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	blockID := *objectio.NewBlockid(objectio.NewSegmentid(), 1, 0)
+	input := batch.NewWithSize(3)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	for offset := uint32(1); offset <= 2; offset++ {
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[0], types.NewRowid(&blockID, offset), false, mp,
+		))
+		require.NoError(t, vector.AppendFixed(input.Vecs[1], int32(offset), false, mp))
+	}
+	commitTS := types.BuildTS(5, 0)
+	var err error
+	input.Vecs[2], err = vector.NewConstFixed(types.T_TS.ToType(), commitTS, 2, mp)
+	require.NoError(t, err)
+	input.SetRowCount(2)
+	defer input.Clean(mp)
+
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	writer, err := objectio.NewObjectWriter(
+		name, fs, 0, objectio.TombstoneSeqnums_DN_Created, nil,
+	)
+	require.NoError(t, err)
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	blocks, err := writer.WriteEnd(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	location := objectio.BuildLocation(
+		name, blocks[0].GetExtent(), uint32(input.RowCount()), blocks[0].GetID(),
+	)
+	cacheVectors := containers.NewVectors(2)
+	_, release, err := ReadDeletes(ctx, location, fs, false, cacheVectors, nil)
+	require.NoError(t, err)
+	require.True(t, cacheVectors[1].IsConst())
+	validated, err := ValidateTombstoneCommitTSColumn(2, &cacheVectors[1])
+	require.NoError(t, err)
+	require.Equal(t, commitTS, validated.At(0))
+	require.Equal(t, commitTS, validated.At(1))
+	release()
+
+	row := types.NewRowid(&blockID, 2)
+	deleted, err := IsRowDeletedByLocation(ctx, &commitTS, &row, location, fs, false)
+	require.NoError(t, err)
+	require.True(t, deleted)
+	mask, err := FillBlockDeleteMask(ctx, &commitTS, &blockID, location, fs, false)
+	require.NoError(t, err)
+	defer mask.Release()
+	require.True(t, mask.Contains(1))
+	require.True(t, mask.Contains(2))
+}
+
+func TestTimestampPrimaryKeyWithoutCommitTSIsRejected(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	blockID := *objectio.NewBlockid(objectio.NewSegmentid(), 1, 0)
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_TS.ToType())
+	defer input.Clean(mp)
+	require.NoError(t, vector.AppendFixed(
+		input.Vecs[0], types.NewRowid(&blockID, 1), false, mp,
+	))
+	require.NoError(t, vector.AppendFixed(input.Vecs[1], types.BuildTS(5, 0), false, mp))
+	input.SetRowCount(1)
+
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	writer, err := NewBlockWriter(fs, name.String())
+	require.NoError(t, err)
+	_, err = writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, _, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, uint16(2), blocks[0].GetMetaColumnCount())
+	require.Equal(t, uint16(1), blocks[0].GetMaxSeqnum())
+
+	location := objectio.BuildLocation(
+		name,
+		blocks[0].GetExtent(),
+		uint32(input.RowCount()),
+		blocks[0].GetID(),
+	)
+	snapshot := types.BuildTS(10, 0)
+	row := types.NewRowid(&blockID, 1)
+	trackingFS := &releaseTrackingFS{FileService: fs}
+
+	t.Run("non-CN point lookup", func(t *testing.T) {
+		_, err := IsRowDeletedByLocation(ctx, &snapshot, &row, location, trackingFS, false)
+		require.ErrorContains(t, err, "commit-ts column is unavailable")
+		require.Zero(t, trackingFS.outstanding.Load())
+	})
+
+	t.Run("non-CN block mask", func(t *testing.T) {
+		_, err := FillBlockDeleteMask(ctx, &snapshot, &blockID, location, trackingFS, false)
+		require.ErrorContains(t, err, "commit-ts column is unavailable")
+		require.Zero(t, trackingFS.outstanding.Load())
+	})
+
+	t.Run("CN-created path", func(t *testing.T) {
+		deleted, err := IsRowDeletedByLocation(ctx, &snapshot, &row, location, fs, true)
+		require.NoError(t, err)
+		require.True(t, deleted)
+	})
+}
+
+func TestEvalDeleteMaskRejectsMissingCommitTS(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+	var blockID types.Blockid
+	rowIDs := vector.NewVec(types.T_Rowid.ToType())
+	require.NoError(t, vector.AppendFixed(rowIDs, types.NewRowid(&blockID, 1), false, mp))
+	defer rowIDs.Free(mp)
+	missingCommitTS := vector.NewConstNull(types.T_TS.ToType(), 1, mp)
+	defer missingCommitTS.Free(mp)
+
+	rows, err := EvalDeleteMaskFromDNCreatedTombstones(
+		rowIDs, missingCommitTS, objectio.BlockObject{}, &types.TS{}, &blockID,
+	)
+	require.ErrorContains(t, err, "commit-ts column is unavailable")
+	require.False(t, rows.IsValid())
 }
 
 func (d *releaseTrackingData) Slice(length int) fscache.Data {

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -1630,11 +1630,15 @@ func (ls *LocalDisttaeDataSource) batchApplyTombstoneObjects(
 			}
 
 			var deletedRowIds []objectio.Rowid
-			var commit []types.TS
+			var commit ioutil.TombstoneCommitTSColumn
 
 			deletedRowIds = vector.MustFixedColWithTypeCheck[objectio.Rowid](&cacheVectors[0])
 			if !obj.GetCNCreated() {
-				commit = vector.MustFixedColWithTypeCheck[types.TS](&cacheVectors[1])
+				commit, err = ioutil.ValidateTombstoneCommitTSColumn(len(deletedRowIds), &cacheVectors[1])
+				if err != nil {
+					release()
+					return err
+				}
 			}
 
 			for i := 0; i < len(rowIds); i++ {
@@ -1642,8 +1646,13 @@ func (ls *LocalDisttaeDataSource) batchApplyTombstoneObjects(
 					deletedRowIds, rowIds[i].BorrowBlockID())
 
 				for j := s; j < e; j++ {
+					commitVisible := true
+					if commit.IsPresent() {
+						commitTS := commit.At(j)
+						commitVisible = commitTS.LE(&ls.snapshotTS)
+					}
 					if rowIds[i].EQ(&deletedRowIds[j]) &&
-						(commit == nil || commit[j].LE(&ls.snapshotTS)) {
+						commitVisible {
 						deletedMask.Add(uint64(i))
 						break
 					}

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -1601,11 +1601,13 @@ func (p *PartitionState) countTombstoneStatsLinear(
 
 			rowIds := vector.MustFixedColNoTypeCheck[types.Rowid](&persistedDeletes[0])
 
-			var commitTSs []types.TS
-			// When cnCreated=false (TN created), ReadDeletes reads [Rowid, CommitTS] at indices [0, 1]
-			// When cnCreated=true (CN created), ReadDeletes only reads [Rowid] at index [0], no CommitTS
-			if needCheckCommitTs && len(persistedDeletes) > 2 {
-				commitTSs = vector.MustFixedColNoTypeCheck[types.TS](&persistedDeletes[1])
+			var commitTSs ioutil.TombstoneCommitTSColumn
+			// ReadDeletes exposes commitTS only for TN-created tombstones.
+			if needCheckCommitTs && !cnCreated && len(persistedDeletes) > 1 {
+				commitTSs, readErr = ioutil.ValidateTombstoneCommitTSColumn(len(rowIds), &persistedDeletes[1])
+				if readErr != nil {
+					return false
+				}
 			}
 
 			var lastObjId types.Objectid
@@ -1618,7 +1620,12 @@ func (p *PartitionState) countTombstoneStatsLinear(
 					continue
 				}
 
-				if needCheckCommitTs && len(commitTSs) > 0 && commitTSs[j].GT(&snapshot) {
+				commitVisible := true
+				if commitTSs.IsPresent() {
+					commitTS := commitTSs.At(j)
+					commitVisible = !commitTS.GT(&snapshot)
+				}
+				if !commitVisible {
 					continue
 				}
 
@@ -1700,11 +1707,13 @@ func (p *PartitionState) countTombstoneStatsWithMap(
 
 				rowIds := vector.MustFixedColNoTypeCheck[types.Rowid](&persistedDeletes[0])
 
-				var commitTSs []types.TS
-				// When cnCreated=false (TN created), ReadDeletes reads [Rowid, CommitTS] at indices [0, 1]
-				// When cnCreated=true (CN created), ReadDeletes only reads [Rowid] at index [0], no CommitTS
-				if needCheckCommitTs && len(persistedDeletes) > 2 {
-					commitTSs = vector.MustFixedColNoTypeCheck[types.TS](&persistedDeletes[1])
+				var commitTSs ioutil.TombstoneCommitTSColumn
+				// ReadDeletes exposes commitTS only for TN-created tombstones.
+				if needCheckCommitTs && !cnCreated && len(persistedDeletes) > 1 {
+					commitTSs, readErr = ioutil.ValidateTombstoneCommitTSColumn(len(rowIds), &persistedDeletes[1])
+					if readErr != nil {
+						return false
+					}
 				}
 
 				var lastObjId types.Objectid
@@ -1716,7 +1725,12 @@ func (p *PartitionState) countTombstoneStatsWithMap(
 						continue
 					}
 
-					if needCheckCommitTs && len(commitTSs) > 0 && commitTSs[j].GT(&snapshot) {
+					commitVisible := true
+					if commitTSs.IsPresent() {
+						commitTS := commitTSs.At(j)
+						commitVisible = !commitTS.GT(&snapshot)
+					}
+					if !commitVisible {
 						continue
 					}
 
@@ -1794,7 +1808,7 @@ type tombstoneBlockIterator struct {
 	blocks       []objectio.BlockInfo
 	blockIdx     int
 	rowIds       []types.Rowid
-	commitTSs    []types.TS
+	commitTSs    ioutil.TombstoneCommitTSColumn
 	rowIdx       int
 	needCheckTS  bool
 	snapshot     types.TS
@@ -1832,10 +1846,13 @@ func (it *tombstoneBlockIterator) loadNextBlock() bool {
 
 	it.rowIds = vector.MustFixedColNoTypeCheck[types.Rowid](&it.persistedDel[0])
 
-	if it.needCheckTS && len(it.persistedDel) > 2 {
-		it.commitTSs = vector.MustFixedColNoTypeCheck[types.TS](&it.persistedDel[len(it.persistedDel)-1])
+	if it.needCheckTS && !cnCreated && len(it.persistedDel) > 1 {
+		it.commitTSs, it.err = ioutil.ValidateTombstoneCommitTSColumn(len(it.rowIds), &it.persistedDel[1])
+		if it.err != nil {
+			return false
+		}
 	} else {
-		it.commitTSs = nil
+		it.commitTSs = ioutil.TombstoneCommitTSColumn{}
 	}
 
 	it.rowIdx = 0
@@ -1867,7 +1884,12 @@ func (it *tombstoneBlockIterator) next() bool {
 	// Persisted tombstone iterator
 	for {
 		for it.rowIdx < len(it.rowIds) {
-			if it.needCheckTS && len(it.commitTSs) > 0 && it.commitTSs[it.rowIdx].GT(&it.snapshot) {
+			commitVisible := true
+			if it.commitTSs.IsPresent() {
+				commitTS := it.commitTSs.At(it.rowIdx)
+				commitVisible = !commitTS.GT(&it.snapshot)
+			}
+			if !commitVisible {
 				it.rowIdx++
 				continue
 			}
@@ -1934,6 +1956,17 @@ func (p *PartitionState) countTombstoneStatsWithMerge(
 	stats TombstoneStats,
 ) (TombstoneStats, error) {
 	iterators := make([]*tombstoneBlockIterator, 0, len(objects))
+	releaseIterator := func(it *tombstoneBlockIterator) {
+		if it.release != nil {
+			it.release()
+			it.release = nil
+		}
+	}
+	defer func() {
+		for _, it := range iterators {
+			releaseIterator(it)
+		}
+	}()
 
 	for _, obj := range objects {
 		cnCreated := obj.GetCNCreated()
@@ -1974,6 +2007,9 @@ func (p *PartitionState) countTombstoneStatsWithMerge(
 
 		if it.next() {
 			iterators = append(iterators, it)
+		} else if it.err != nil {
+			releaseIterator(it)
+			return stats, it.err
 		}
 	}
 
@@ -2016,9 +2052,6 @@ func (p *PartitionState) countTombstoneStatsWithMerge(
 	}
 
 	for _, it := range iterators {
-		if it.release != nil {
-			it.release()
-		}
 		if it.err != nil {
 			return stats, it.err
 		}

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
@@ -471,7 +471,7 @@ func TestCountTombstoneRows(t *testing.T) {
 	_, _, err = writer1.Sync(ctx)
 	require.NoError(t, err)
 
-	ss1 := writer1.GetObjectStats()
+	ss1 := writer1.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss1,
 		CreateTime:  types.BuildTS(1, 0),
@@ -502,7 +502,7 @@ func TestCountTombstoneRows(t *testing.T) {
 	_, _, err = writer2.Sync(ctx)
 	require.NoError(t, err)
 
-	ss2 := writer2.GetObjectStats()
+	ss2 := writer2.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss2,
 		CreateTime:  types.BuildTS(2, 0),
@@ -577,7 +577,7 @@ func TestCountTombstoneRows(t *testing.T) {
 	_, _, err = writer3.Sync(ctx)
 	require.NoError(t, err)
 
-	ss3 := writer3.GetObjectStats()
+	ss3 := writer3.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss3,
 		CreateTime:  types.BuildTS(4, 0),
@@ -987,7 +987,7 @@ func TestCountTombstoneRowsWithDuplicates(t *testing.T) {
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
 
-	ss := writer.GetObjectStats()
+	ss := writer.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss,
 		CreateTime:  types.BuildTS(2, 0),
@@ -1069,7 +1069,7 @@ func TestCountTombstoneRowsObjectVisibility(t *testing.T) {
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
 
-	ss := writer.GetObjectStats()
+	ss := writer.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss,
 		CreateTime:  types.BuildTS(3, 0),
@@ -1208,7 +1208,7 @@ func TestCountTombstoneRowsComprehensive(t *testing.T) {
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
 
-	ss := writer.GetObjectStats()
+	ss := writer.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss,
 		CreateTime:  types.BuildTS(3, 0),
@@ -1281,7 +1281,7 @@ func TestCollectTombstoneStats_CrossObjectDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = writer1.Sync(ctx)
 	require.NoError(t, err)
-	ss1 := writer1.GetObjectStats()
+	ss1 := writer1.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss1,
 		CreateTime:  types.BuildTS(2, 0),
@@ -1303,7 +1303,7 @@ func TestCollectTombstoneStats_CrossObjectDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = writer2.Sync(ctx)
 	require.NoError(t, err)
-	ss2 := writer2.GetObjectStats()
+	ss2 := writer2.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss2,
 		CreateTime:  types.BuildTS(3, 0),
@@ -1325,7 +1325,7 @@ func TestCollectTombstoneStats_CrossObjectDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = writer3.Sync(ctx)
 	require.NoError(t, err)
-	ss3 := writer3.GetObjectStats()
+	ss3 := writer3.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss3,
 		CreateTime:  types.BuildTS(4, 0),
@@ -1380,7 +1380,7 @@ func TestCollectTombstoneStats_CrossObjectAndInMemoryDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
-	ss := writer.GetObjectStats()
+	ss := writer.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss,
 		CreateTime:  types.BuildTS(2, 0),
@@ -1468,7 +1468,7 @@ func TestCountTombstoneRowsCNCreatedWithAppendable(t *testing.T) {
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
 
-	ss := writer.GetObjectStats()
+	ss := writer.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss,
 		CreateTime:  types.BuildTS(2, 0),
@@ -1567,7 +1567,7 @@ func TestCollectTombstoneStats_MergeVsMapConsistency(t *testing.T) {
 		_, _, err = writer.Sync(ctx)
 		require.NoError(t, err)
 
-		ss := writer.GetObjectStats()
+		ss := writer.GetObjectStats(objectio.WithCNCreated())
 		state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 			ObjectStats: *ss.Clone(),
 			CreateTime:  types.BuildTS(2, 0),
@@ -1590,6 +1590,48 @@ func TestCollectTombstoneStats_MergeVsMapConsistency(t *testing.T) {
 	// Both should produce same result
 	assert.Equal(t, statsMap.Rows, statsMerge.Rows, "Map and merge paths should produce identical row counts")
 	t.Logf("Map path: %d rows, Merge path: %d rows", statsMap.Rows, statsMerge.Rows)
+}
+
+func TestCountTombstoneStatsWithMergeReturnsInitialReaderError(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+	state := NewPartitionState("", false, 42, false)
+
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_TS.ToType())
+	defer input.Clean(mp)
+	var blockID types.Blockid
+	require.NoError(t, vector.AppendFixed(
+		input.Vecs[0], types.NewRowid(&blockID, 1), false, mp,
+	))
+	require.NoError(t, vector.AppendFixed(
+		input.Vecs[1], types.BuildTS(100, 0), false, mp,
+	))
+	input.SetRowCount(1)
+
+	// This is a non-CN tombstone with a timestamp PK but no commitTS. It is not
+	// the exact three-column legacy Backup signature and must fail explicitly.
+	writer := ioutil.ConstructTombstoneWriter(objectio.HiddenColumnSelection_None, fs)
+	_, err := writer.WriteBatch(input)
+	require.NoError(t, err)
+	_, _, err = writer.Sync(ctx)
+	require.NoError(t, err)
+	stats := writer.GetObjectStats()
+
+	_, err = state.countTombstoneStatsWithMerge(
+		ctx,
+		types.BuildTS(10, 0),
+		fs,
+		[]objectio.ObjectEntry{{
+			ObjectStats: stats,
+			CreateTime:  types.BuildTS(1, 0),
+		}},
+		TombstoneStats{},
+	)
+	require.ErrorContains(t, err, "commit-ts column is unavailable")
 }
 
 func TestCollectTombstoneStats_MultiObjectMultiBlock(t *testing.T) {
@@ -1650,7 +1692,7 @@ func TestCollectTombstoneStats_MultiObjectMultiBlock(t *testing.T) {
 		_, _, err := writer.Sync(ctx)
 		require.NoError(t, err)
 
-		ss := writer.GetObjectStats()
+		ss := writer.GetObjectStats(objectio.WithCNCreated())
 		state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 			ObjectStats: *ss.Clone(),
 			CreateTime:  types.BuildTS(2, 0),
@@ -1764,7 +1806,7 @@ func TestCollectTombstoneStats_ComprehensiveAllScenarios(t *testing.T) {
 	_, _, err = writer1.Sync(ctx)
 	require.NoError(t, err)
 
-	ss1 := writer1.GetObjectStats()
+	ss1 := writer1.GetObjectStats(objectio.WithCNCreated())
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: *ss1.Clone(),
 		CreateTime:  types.BuildTS(3, 0),
@@ -2009,7 +2051,7 @@ func TestCountTombstoneRowsEdgeCases(t *testing.T) {
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
 
-	ss := writer.GetObjectStats()
+	ss := writer.GetObjectStats(objectio.WithCNCreated())
 
 	// Test 1: Tombstone created after snapshot - should not be visible
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
@@ -2586,9 +2628,10 @@ func TestCollectTombstoneStats_AppendableTombstone(t *testing.T) {
 		DeleteTime:  types.TS{},
 	})
 
-	// Create appendable tombstone (CN created, appendable) at TS=10
+	// Create appendable TN tombstone at TS=10.
 	// Contains deletions from different commit times
 	writer := ioutil.ConstructTombstoneWriter(objectio.HiddenColumnSelection_CommitTS, fs)
+	writer.SetAppendable()
 	bat := batch.NewWithSize(3)
 	bat.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
 	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
@@ -2615,8 +2658,8 @@ func TestCollectTombstoneStats_AppendableTombstone(t *testing.T) {
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
 
-	ss := writer.GetObjectStats()
-	// Mark as appendable and CN created
+	ss := writer.GetObjectStats(objectio.WithAppendable())
+	// Mark as appendable and keep the default TN-created classification.
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss,
 		CreateTime:  types.BuildTS(10, 0),
@@ -2660,8 +2703,9 @@ func TestCollectTombstoneStats_AppendableDataWithAppendableTombstone(t *testing.
 		state.rows.Set(entry)
 	}
 
-	// Create appendable tombstone (flushed to S3) with deletions at different commit times
+	// Create an appendable TN tombstone with deletions at different commit times.
 	writer := ioutil.ConstructTombstoneWriter(objectio.HiddenColumnSelection_CommitTS, fs)
+	writer.SetAppendable()
 	bat := batch.NewWithSize(3)
 	bat.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
 	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
@@ -2688,8 +2732,8 @@ func TestCollectTombstoneStats_AppendableDataWithAppendableTombstone(t *testing.
 	_, _, err = writer.Sync(ctx)
 	require.NoError(t, err)
 
-	ss := writer.GetObjectStats()
-	// Appendable tombstone (CNCreated=true, Appendable=true)
+	ss := writer.GetObjectStats(objectio.WithAppendable())
+	// Appendable TN tombstone (CNCreated=false, Appendable=true).
 	state.tombstoneObjectsNameIndex.Set(objectio.ObjectEntry{
 		ObjectStats: ss,
 		CreateTime:  types.BuildTS(10, 0),

--- a/pkg/vm/engine/disttae/pk_check_guard_test.go
+++ b/pkg/vm/engine/disttae/pk_check_guard_test.go
@@ -178,4 +178,11 @@ func TestPKCommitTSMatchedInRange(t *testing.T) {
 	changed, ok = pkCommitTSMatchedInRange(constNull, []int64{0}, from, to)
 	require.False(t, ok)
 	require.False(t, changed)
+
+	constant, err := vector.NewConstFixed(types.T_TS.ToType(), types.BuildTS(15, 0), 4, mp)
+	require.NoError(t, err)
+	defer constant.Free(mp)
+	changed, ok = pkCommitTSMatchedInRange(constant, []int64{3}, from, to)
+	require.True(t, ok)
+	require.True(t, changed)
 }

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2628,20 +2628,19 @@ func pkCommitTSMatchedInRange(
 	sels []int64,
 	from, to types.TS,
 ) (bool, bool) {
-	if commitTSVec == nil ||
-		commitTSVec.GetType().Oid != types.T_TS ||
-		commitTSVec.IsConstNull() {
+	if commitTSVec == nil {
 		return false, false
 	}
-	timestamps := vector.MustFixedColWithTypeCheck[types.TS](commitTSVec)
+	rowCount := commitTSVec.Length()
+	timestamps, err := ioutil.ValidateTombstoneCommitTSColumn(rowCount, commitTSVec)
+	if err != nil {
+		return false, false
+	}
 	for _, sel := range sels {
-		if sel < 0 || int(sel) >= len(timestamps) {
+		if sel < 0 || int(sel) >= rowCount {
 			return false, false
 		}
-		if commitTSVec.IsNull(uint64(sel)) {
-			return false, false
-		}
-		ts := timestamps[sel]
+		ts := timestamps.At(int(sel))
 		if ts.GT(&from) && ts.LE(&to) {
 			return true, true
 		}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2999,6 +2999,29 @@ func tombstonePKExistsInRange(
 					mp,
 					fileservice.Policy(0),
 				)
+				if err == nil && !usable {
+					objectMeta, metaErr := objectio.FastLoadObjectMeta(ctx, &loc, false, fs)
+					if metaErr != nil {
+						err = metaErr
+					} else if legacyCommitTS, ok := ioutil.ResolveLegacyBackupTombstoneCommitTS(
+						objectMeta.MustDataMeta().GetBlockMeta(uint32(loc.ID())),
+					); ok {
+						changed, usable, _, err = ioutil.LoadColumnDataBySearchAndCheckTS(
+							ctx,
+							objectio.TombstoneAttr_PK_SeqNum,
+							pkType,
+							fs,
+							loc,
+							cachedSearch,
+							false,
+							legacyCommitTS,
+							from,
+							to,
+							mp,
+							fileservice.Policy(0),
+						)
+					}
+				}
 				if err != nil {
 					return true, "tombstone_read_error", nil
 				}

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -348,8 +348,73 @@ func TestTombstonePKExistsInRangeVarcharScopedSearch(t *testing.T) {
 	require.True(t, changed)
 	require.Equal(t, "tombstone_cn_hit", reason)
 
+	legacyBatch := batch.NewWithSize(3)
+	legacyBatch.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	legacyBatch.Vecs[1] = vector.NewVec(varcharType)
+	legacyBatch.Vecs[2] = vector.NewVec(types.T_TS.ToType())
+	require.NoError(t, vector.AppendFixed(legacyBatch.Vecs[0], makeRowid(4), false, mp))
+	require.NoError(t, vector.AppendBytes(legacyBatch.Vecs[1], []byte("legacy"), false, mp))
+	require.NoError(t, vector.AppendFixed(
+		legacyBatch.Vecs[2], types.BuildTS(10, 0), false, mp,
+	))
+	legacyBatch.SetRowCount(1)
+	legacyName := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	legacyWriter, err := ioutil.NewBlockWriter(fs, legacyName.String())
+	require.NoError(t, err)
+	_, err = legacyWriter.WriteBatch(legacyBatch)
+	require.NoError(t, err)
+	legacyBlocks, legacyExtent, err := legacyWriter.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, legacyBlocks, 1)
+	require.Equal(t, uint16(3), legacyBlocks[0].GetMetaColumnCount())
+	require.Equal(t, uint16(2), legacyBlocks[0].GetMaxSeqnum())
+	require.Equal(t, uint8(types.T_TS), legacyBlocks[0].ColumnMeta(2).DataType())
+	legacyStats := objectio.NewObjectStats()
+	require.NoError(t, objectio.SetObjectStatsObjectName(legacyStats, legacyName))
+	require.NoError(t, objectio.SetObjectStatsExtent(legacyStats, legacyExtent))
+	require.NoError(t, objectio.SetObjectStatsRowCnt(legacyStats, uint32(legacyBatch.RowCount())))
+	require.NoError(t, objectio.SetObjectStatsBlkCnt(legacyStats, uint32(len(legacyBlocks))))
+	require.NoError(t, objectio.SetObjectStatsSize(legacyStats, legacyExtent.End()))
+	legacyBatch.Clean(mp)
+
+	legacyState := logtailreplay.NewPartitionState("", true, 0, false)
+	require.NoError(t, legacyState.HandleObjectEntry(ctx, fs, objectio.ObjectEntry{
+		ObjectStats: *legacyStats,
+		CreateTime:  types.BuildTS(40, 0),
+	}, true))
+	legacyKey := vector.NewVec(varcharType)
+	require.NoError(t, vector.AppendBytes(legacyKey, []byte("legacy"), false, mp))
+	changed, reason, err = tombstonePKExistsInRange(
+		ctx,
+		legacyState,
+		types.BuildTS(20, 0),
+		types.BuildTS(30, 0),
+		legacyKey,
+		varcharType,
+		fs,
+		mp,
+	)
+	require.NoError(t, err)
+	require.False(t, changed, "the legacy physical commit timestamp is before the range")
+	require.Empty(t, reason)
+
+	changed, reason, err = tombstonePKExistsInRange(
+		ctx,
+		legacyState,
+		types.BuildTS(5, 0),
+		types.BuildTS(15, 0),
+		legacyKey,
+		varcharType,
+		fs,
+		mp,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "tombstone_commit_ts_hit", reason)
+
 	key.Free(mp)
 	missing.Free(mp)
+	legacyKey.Free(mp)
 }
 
 func TestBlockMetaMarshal(t *testing.T) {

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -57,6 +58,168 @@ type BackupDeltaLocDataSource struct {
 	ds         map[string]*objData
 	tombstones []objectio.ObjectStats
 	needShrink bool
+}
+
+const invalidBackupSpecialColumnPosition = math.MaxUint16
+
+// backupSpecialColumnLayout is the 4.2-local equivalent of the special-column
+// metadata resolver used by newer branches. Keeping it local avoids pulling the
+// later appendable-object format changes into this maintenance backport.
+type backupSpecialColumnLayout struct {
+	PhysicalAddr uint16
+	CommitTS     uint16
+	Abort        uint16
+}
+
+func (layout backupSpecialColumnLayout) resolve(seqnum uint16) (uint16, bool) {
+	switch seqnum {
+	case objectio.SEQNUM_COMMITTS:
+		return layout.CommitTS, layout.CommitTS != invalidBackupSpecialColumnPosition
+	case objectio.SEQNUM_ABORT:
+		return layout.Abort, layout.Abort != invalidBackupSpecialColumnPosition
+	default:
+		return invalidBackupSpecialColumnPosition, false
+	}
+}
+
+func resolveBackupSpecialColumnLayout(block objectio.BlockObject) backupSpecialColumnLayout {
+	layout := backupSpecialColumnLayout{
+		PhysicalAddr: invalidBackupSpecialColumnPosition,
+		CommitTS:     invalidBackupSpecialColumnPosition,
+		Abort:        invalidBackupSpecialColumnPosition,
+	}
+	metaColumnCount := block.GetMetaColumnCount()
+	if metaColumnCount == 0 {
+		return layout
+	}
+
+	pos := block.GetMaxSeqnum() + 1
+	if pos < metaColumnCount && block.ColumnMeta(pos).DataType() == uint8(types.T_Rowid) {
+		layout.PhysicalAddr = pos
+		pos++
+	}
+	if pos >= metaColumnCount || block.ColumnMeta(pos).DataType() != uint8(types.T_TS) {
+		return layout
+	}
+	layout.CommitTS = pos
+
+	pos++
+	if pos < metaColumnCount && block.ColumnMeta(pos).DataType() == uint8(types.T_Rowid) {
+		layout.PhysicalAddr = pos
+		pos++
+	}
+	if pos < metaColumnCount && block.ColumnMeta(pos).DataType() == uint8(types.T_bool) {
+		layout.Abort = pos
+	}
+	return layout
+}
+
+func loadSpecialColumnLayout(
+	ctx context.Context,
+	fs fileservice.FileService,
+	location objectio.Location,
+) (backupSpecialColumnLayout, error) {
+	objectMeta, err := objectio.FastLoadObjectMeta(ctx, &location, false, fs)
+	if err != nil {
+		return backupSpecialColumnLayout{}, err
+	}
+	blockMeta := objectMeta.MustDataMeta().GetBlockMeta(uint32(location.ID()))
+	return resolveBackupSpecialColumnLayout(blockMeta), nil
+}
+
+func visibleAppendableRows(
+	ctx context.Context,
+	bat *batch.Batch,
+	layout backupSpecialColumnLayout,
+	ts *types.TS,
+) ([]int64, error) {
+	commitPos, err := validateBackupTombstoneBatch(ctx, bat, layout)
+	if err != nil {
+		return nil, err
+	}
+	commitVec := bat.Vecs[commitPos]
+	commitTSs := vector.MustFixedColWithTypeCheck[types.TS](commitVec)
+	var abortVec *vector.Vector
+	if abortPos, ok := layout.resolve(objectio.SEQNUM_ABORT); ok && int(abortPos) < len(bat.Vecs) {
+		abortVec = bat.Vecs[abortPos]
+	}
+	rows := make([]int64, 0, len(commitTSs))
+	for row, commitTS := range commitTSs {
+		if commitVec.IsNull(uint64(row)) {
+			return nil, moerr.NewInternalErrorf(ctx, "appendable tombstone commit timestamp row %d is null", row)
+		}
+		if abortVec != nil {
+			if abortVec.IsNull(uint64(row)) {
+				return nil, moerr.NewInternalErrorf(ctx, "appendable tombstone abort row %d is null", row)
+			}
+			if vector.GetFixedAtNoTypeCheck[bool](abortVec, row) {
+				continue
+			}
+		}
+		if ts != nil && commitTS.GT(ts) {
+			continue
+		}
+		rows = append(rows, int64(row))
+	}
+	return rows, nil
+}
+
+func validateBackupTombstoneBatch(
+	ctx context.Context,
+	bat *batch.Batch,
+	layout backupSpecialColumnLayout,
+) (uint16, error) {
+	if bat == nil || len(bat.Vecs) < len(objectio.TombstoneSeqnums_DN_Created) {
+		return 0, moerr.NewInternalError(ctx, "appendable tombstone has too few columns")
+	}
+	if bat.Vecs[objectio.TombstoneAttr_Rowid_Idx] == nil ||
+		bat.Vecs[objectio.TombstoneAttr_Rowid_Idx].GetType().Oid != types.T_Rowid {
+		return 0, moerr.NewInternalError(ctx, "appendable tombstone has invalid rowid column")
+	}
+	if bat.Vecs[objectio.TombstoneAttr_PK_Idx] == nil {
+		return 0, moerr.NewInternalError(ctx, "appendable tombstone has no primary-key column")
+	}
+
+	rows := bat.Vecs[objectio.TombstoneAttr_Rowid_Idx].Length()
+	for pos, vec := range bat.Vecs {
+		if vec == nil {
+			return 0, moerr.NewInternalErrorf(ctx, "appendable tombstone column %d is nil", pos)
+		}
+		if vec.Length() != rows {
+			return 0, moerr.NewInternalErrorf(
+				ctx,
+				"appendable tombstone column %d has %d rows, expected %d",
+				pos,
+				vec.Length(),
+				rows,
+			)
+		}
+	}
+
+	commitPos, ok := layout.resolve(objectio.SEQNUM_COMMITTS)
+	if !ok || int(commitPos) >= len(bat.Vecs) || int(commitPos) < len(objectio.TombstoneSeqnums_CN_Created) {
+		return 0, moerr.NewInternalError(ctx, "appendable tombstone has no commit timestamp")
+	}
+	commitVec := bat.Vecs[commitPos]
+	if commitVec.GetType().Oid != types.T_TS || commitVec.IsConstNull() {
+		return 0, moerr.NewInternalError(ctx, "appendable tombstone has invalid commit timestamp column")
+	}
+
+	if physicalPos := layout.PhysicalAddr; physicalPos != invalidBackupSpecialColumnPosition {
+		if int(physicalPos) >= len(bat.Vecs) || bat.Vecs[physicalPos].GetType().Oid != types.T_Rowid {
+			return 0, moerr.NewInternalError(ctx, "appendable tombstone has invalid physical rowid column")
+		}
+	}
+	if abortPos, ok := layout.resolve(objectio.SEQNUM_ABORT); ok {
+		if int(abortPos) >= len(bat.Vecs) {
+			return 0, moerr.NewInternalError(ctx, "appendable tombstone has invalid abort column")
+		}
+		abortVec := bat.Vecs[abortPos]
+		if abortVec.GetType().Oid != types.T_bool || abortVec.IsConstNull() {
+			return 0, moerr.NewInternalError(ctx, "appendable tombstone has invalid abort column")
+		}
+	}
+	return commitPos, nil
 }
 
 func NewBackupDeltaLocDataSource(
@@ -226,25 +389,18 @@ func (d *BackupDeltaLocDataSource) GetTombstones(
 						return false, err
 					}
 					if !tombstone.GetCNCreated() {
-						deleteRow := make([]int64, 0)
-						for v := 0; v < bat.Vecs[0].Length(); v++ {
-							var commitTs types.TS
-							err = commitTs.Unmarshal(bat.Vecs[len(bat.Vecs)-1].GetRawBytesAt(v))
-							if err != nil {
-								return false, err
-							}
-							if commitTs.GT(&d.ts) {
-
-								logutil.Debug("[GetSnapshot]",
-									zap.Int("row", v),
-									zap.String("commitTs", commitTs.ToString()),
-									zap.String("location", location.String()))
-							} else {
-								deleteRow = append(deleteRow, int64(v))
-							}
+						layout, err := loadSpecialColumnLayout(ctx, d.fs, location)
+						if err != nil {
+							bat.Clean(common.DebugAllocator)
+							return false, err
 						}
-						if len(deleteRow) != bat.Vecs[0].Length() {
-							bat.Shrink(deleteRow, false)
+						visibleRows, err := visibleAppendableRows(ctx, bat, layout, &d.ts)
+						if err != nil {
+							bat.Clean(common.DebugAllocator)
+							return false, err
+						}
+						if len(visibleRows) != bat.Vecs[0].Length() {
+							bat.Shrink(visibleRows, false)
 						}
 					}
 					if id == 0 {
@@ -341,34 +497,68 @@ func trimTombstoneData(
 		var err error
 		var sortKey uint16
 		// As long as there is an aBlk to be deleted, isCkpChange must be set to true.
-		commitTs := types.TS{}
 		location.SetID(uint16(0))
 		bat, sortKey, err = ioutil.LoadOneBlock(ctx, fs, location, objectio.SchemaData)
 		if err != nil {
 			return err
 		}
-		deleteRow := make([]int64, 0)
-		for v := 0; v < bat.Vecs[0].Length(); v++ {
-			err = commitTs.Unmarshal(bat.Vecs[len(bat.Vecs)-1].GetRawBytesAt(v))
-			if err != nil {
-				return err
-			}
-			if commitTs.GT(&ts) {
-				logutil.Debugf("delete row %v, commitTs %v, location %v",
-					v, commitTs.ToString(), (*objectsData)[name].stats.ObjectLocation().String())
-			} else {
-				deleteRow = append(deleteRow, int64(v))
-			}
+		layout, err := loadSpecialColumnLayout(ctx, fs, location)
+		if err != nil {
+			bat.Clean(common.DebugAllocator)
+			return err
 		}
-		if len(deleteRow) != bat.Vecs[0].Length() {
-			bat.Shrink(deleteRow, false)
+		visibleRows, err := visibleAppendableRows(ctx, bat, layout, &ts)
+		if err != nil {
+			bat.Clean(common.DebugAllocator)
+			return err
 		}
-		bat = formatData(bat)
+		if len(visibleRows) != bat.Vecs[0].Length() {
+			bat.Shrink(visibleRows, false)
+		}
+		canonical, err := canonicalizeBackupTombstone(ctx, bat, layout)
+		if err != nil {
+			bat.Clean(common.DebugAllocator)
+			return err
+		}
+		bat = canonical
 		(*objectsData)[name].sortKey = sortKey
 		(*objectsData)[name].data = make([]*batch.Batch, 0)
 		(*objectsData)[name].data = append((*objectsData)[name].data, bat)
 	}
 	return nil
+}
+
+// canonicalizeBackupTombstone converts an appendable tombstone batch to the
+// non-appendable TN tombstone layout written into a backup. visibleAppendableRows
+// has already removed aborted rows and rows newer than the backup timestamp, so
+// physical row addresses and the abort column are no longer needed. The commit
+// timestamp must remain because restored TN tombstones use it for visibility.
+func canonicalizeBackupTombstone(
+	ctx context.Context,
+	data *batch.Batch,
+	layout backupSpecialColumnLayout,
+) (*batch.Batch, error) {
+	commitPos, err := validateBackupTombstoneBatch(ctx, data, layout)
+	if err != nil {
+		return nil, err
+	}
+	result := batch.NewWithSize(len(objectio.TombstoneSeqnums_DN_Created))
+	result.Vecs[objectio.TombstoneAttr_Rowid_Idx] = data.Vecs[objectio.TombstoneAttr_Rowid_Idx]
+	result.Vecs[objectio.TombstoneAttr_PK_Idx] = data.Vecs[objectio.TombstoneAttr_PK_Idx]
+	result.Vecs[objectio.TombstoneAttr_NA_CommitTs_Idx] = data.Vecs[commitPos]
+
+	for pos, vec := range data.Vecs {
+		if pos == objectio.TombstoneAttr_Rowid_Idx ||
+			pos == objectio.TombstoneAttr_PK_Idx ||
+			pos == int(commitPos) {
+			continue
+		}
+		vec.Free(common.DebugAllocator)
+	}
+	data.Vecs = nil
+	data.Attrs = nil
+	data.SetRowCount(0)
+	return formatData(result), nil
 }
 
 func appendValToBatch(
@@ -544,15 +734,27 @@ func ReWriteCheckpointAndBlockFromKey(
 	tombstonesData2 := make(map[string]*objData, 0)
 
 	defer func() {
-		for i := range objectsData {
-			if objectsData[i] != nil && objectsData[i].data != nil {
-				for z := range objectsData[i].data {
-					for y := range objectsData[i].data[z].Vecs {
-						objectsData[i].data[z].Vecs[y].Free(common.DebugAllocator)
+		released := make(map[*objData]struct{})
+		cleanup := func(data map[string]*objData) {
+			for _, objectData := range data {
+				if objectData == nil || objectData.data == nil {
+					continue
+				}
+				if _, ok := released[objectData]; ok {
+					continue
+				}
+				released[objectData] = struct{}{}
+				for _, bat := range objectData.data {
+					if bat != nil {
+						bat.Clean(common.DebugAllocator)
 					}
 				}
+				objectData.data = nil
 			}
 		}
+		cleanup(objectsData)
+		cleanup(tombstonesData)
+		cleanup(tombstonesData2)
 	}()
 	phaseNumber = 1
 	// Load checkpoint
@@ -679,7 +881,17 @@ func ReWriteCheckpointAndBlockFromKey(
 			segment := objectName.SegmentId()
 			name := objectio.BuildObjectName(&segment, fileNum)
 			var writer *ioutil.BlockWriter
-			writer, err = ioutil.NewBlockWriter(dstFs, name.String())
+			if objectData.dataType == objectio.SchemaTombstone {
+				writer, err = ioutil.NewBlockWriterNew(
+					dstFs,
+					name,
+					0,
+					objectio.TombstoneSeqnums_DN_Created,
+					true,
+				)
+			} else {
+				writer, err = ioutil.NewBlockWriter(dstFs, name.String())
+			}
 			if err != nil {
 				return err
 			}

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -138,13 +138,25 @@ func visibleAppendableRows(
 		return nil, err
 	}
 	commitVec := bat.Vecs[commitPos]
-	commitTSs := vector.MustFixedColWithTypeCheck[types.TS](commitVec)
+	commitTSs, err := ioutil.ValidateTombstoneCommitTSColumn(
+		bat.Vecs[objectio.TombstoneAttr_Rowid_Idx].Length(),
+		commitVec,
+	)
+	if err != nil {
+		return nil, moerr.NewInternalErrorf(
+			ctx,
+			"appendable tombstone has invalid commit timestamp column: %v",
+			err,
+		)
+	}
 	var abortVec *vector.Vector
 	if abortPos, ok := layout.resolve(objectio.SEQNUM_ABORT); ok && int(abortPos) < len(bat.Vecs) {
 		abortVec = bat.Vecs[abortPos]
 	}
-	rows := make([]int64, 0, len(commitTSs))
-	for row, commitTS := range commitTSs {
+	rowCount := bat.Vecs[objectio.TombstoneAttr_Rowid_Idx].Length()
+	rows := make([]int64, 0, rowCount)
+	for row := range rowCount {
+		commitTS := commitTSs.At(row)
 		if commitVec.IsNull(uint64(row)) {
 			return nil, moerr.NewInternalErrorf(ctx, "appendable tombstone commit timestamp row %d is null", row)
 		}

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -99,6 +99,9 @@ func resolveBackupSpecialColumnLayout(block objectio.BlockObject) backupSpecialC
 		pos++
 	}
 	if pos >= metaColumnCount || block.ColumnMeta(pos).DataType() != uint8(types.T_TS) {
+		if legacyCommitTS, ok := ioutil.ResolveLegacyBackupTombstoneCommitTS(block); ok {
+			layout.CommitTS = legacyCommitTS
+		}
 		return layout
 	}
 	layout.CommitTS = pos

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -557,6 +557,21 @@ func canonicalizeBackupTombstone(
 	if err != nil {
 		return nil, err
 	}
+	commitVec := data.Vecs[commitPos]
+	if commitVec.IsConst() {
+		// BlockWriter's metadata builder scans fixed-width backing bytes and
+		// cannot consume a logical N-row constant backed by one physical value.
+		// Materialize only this hidden column before transferring ownership.
+		materialized := vector.NewVec(*commitVec.GetType())
+		if err = materialized.UnionBatch(
+			commitVec, 0, commitVec.Length(), nil, common.DebugAllocator,
+		); err != nil {
+			materialized.Free(common.DebugAllocator)
+			return nil, err
+		}
+		commitVec.Free(common.DebugAllocator)
+		data.Vecs[commitPos] = materialized
+	}
 	result := batch.NewWithSize(len(objectio.TombstoneSeqnums_DN_Created))
 	result.Vecs[objectio.TombstoneAttr_Rowid_Idx] = data.Vecs[objectio.TombstoneAttr_Rowid_Idx]
 	result.Vecs[objectio.TombstoneAttr_PK_Idx] = data.Vecs[objectio.TombstoneAttr_PK_Idx]

--- a/pkg/vm/engine/tae/logtail/backup_test.go
+++ b/pkg/vm/engine/tae/logtail/backup_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/ckputil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,7 +116,9 @@ func TestCanonicalizeBackupTombstone(t *testing.T) {
 	}
 }
 
-func TestVisibleAppendableRowsBroadcastsConstantCommitTS(t *testing.T) {
+func TestBackupTombstoneWriterBroadcastsConstantCommitTS(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
 	input := newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_TS})
 	input.Vecs[2].Free(common.DebugAllocator)
 	commitTS := types.BuildTS(10, 0)
@@ -137,13 +140,48 @@ func TestVisibleAppendableRowsBroadcastsConstantCommitTS(t *testing.T) {
 	require.Equal(t, []int64{0, 1, 2}, visibleRows)
 
 	input.Shrink(visibleRows, false)
-	result, err := canonicalizeBackupTombstone(context.Background(), input, layout)
+	result, err := canonicalizeBackupTombstone(ctx, input, layout)
 	require.NoError(t, err)
 	defer result.Clean(common.DebugAllocator)
 	require.Equal(t, 3, result.RowCount())
+	require.False(t, result.Vecs[objectio.TombstoneAttr_NA_CommitTs_Idx].IsConst())
 	for row := range result.RowCount() {
 		require.Equal(t, commitTS, vector.GetFixedAtNoTypeCheck[types.TS](
 			result.Vecs[objectio.TombstoneAttr_NA_CommitTs_Idx], row))
+	}
+
+	objectID := objectio.NewObjectid()
+	name := objectio.BuildObjectNameWithObjectID(&objectID)
+	writer, err := ioutil.NewBlockWriterNew(
+		fs,
+		name,
+		0,
+		objectio.TombstoneSeqnums_DN_Created,
+		true,
+	)
+	require.NoError(t, err)
+	_, err = writer.WriteBatch(result)
+	require.NoError(t, err)
+	blocks, extent, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	location := objectio.BuildLocation(name, extent, blocks[0].GetRows(), blocks[0].GetID())
+	loaded := containers.NewVectors(len(objectio.TombstoneSeqnums_DN_Created))
+	_, release, err := ioutil.ReadDeletes(
+		ctx,
+		location,
+		fs,
+		false,
+		loaded,
+		ptrTo(types.T_int64.ToType()),
+	)
+	require.NoError(t, err)
+	defer release()
+	validated, err := ioutil.ValidateTombstoneCommitTSColumn(3, &loaded[2])
+	require.NoError(t, err)
+	for row := range 3 {
+		require.Equal(t, commitTS, validated.At(row))
 	}
 }
 

--- a/pkg/vm/engine/tae/logtail/backup_test.go
+++ b/pkg/vm/engine/tae/logtail/backup_test.go
@@ -1,0 +1,426 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtail
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/ckputil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeBackupTombstone(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		layout     backupSpecialColumnLayout
+		pkType     types.T
+		newBatch   func() *batch.Batch
+		resultRows int
+		cutoff     types.TS
+	}{
+		{
+			name:       "commit timestamp only",
+			layout:     newBackupTombstoneLayout(2, invalidBackupSpecialColumnPosition, invalidBackupSpecialColumnPosition),
+			pkType:     types.T_int64,
+			resultRows: 2,
+			cutoff:     types.BuildTS(15, 0),
+			newBatch: func() *batch.Batch {
+				return newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_TS})
+			},
+		},
+		{
+			name:       "commit timestamp and abort with timestamp pk",
+			layout:     newBackupTombstoneLayout(2, invalidBackupSpecialColumnPosition, 3),
+			pkType:     types.T_TS,
+			resultRows: 1,
+			cutoff:     types.BuildTS(15, 0),
+			newBatch: func() *batch.Batch {
+				return newBackupTombstoneTestBatch(t, types.T_TS, []types.T{types.T_TS, types.T_bool})
+			},
+		},
+		{
+			name:       "physical address before commit timestamp",
+			layout:     newBackupTombstoneLayout(3, 2, 4),
+			pkType:     types.T_int64,
+			resultRows: 1,
+			cutoff:     types.BuildTS(15, 0),
+			newBatch: func() *batch.Batch {
+				return newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_Rowid, types.T_TS, types.T_bool})
+			},
+		},
+		{
+			name:       "physical address after commit timestamp",
+			layout:     newBackupTombstoneLayout(2, 3, 4),
+			pkType:     types.T_int64,
+			resultRows: 1,
+			cutoff:     types.BuildTS(15, 0),
+			newBatch: func() *batch.Batch {
+				return newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_TS, types.T_Rowid, types.T_bool})
+			},
+		},
+		{
+			name:       "all rows filtered",
+			layout:     newBackupTombstoneLayout(2, invalidBackupSpecialColumnPosition, 3),
+			pkType:     types.T_int64,
+			resultRows: 0,
+			cutoff:     types.BuildTS(5, 0),
+			newBatch: func() *batch.Batch {
+				return newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_TS, types.T_bool})
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := test.newBatch()
+			defer input.Clean(common.DebugAllocator)
+			visibleRows, err := visibleAppendableRows(
+				context.Background(), input, test.layout, &test.cutoff)
+			require.NoError(t, err)
+			input.Shrink(visibleRows, false)
+			result, err := canonicalizeBackupTombstone(context.Background(), input, test.layout)
+			require.NoError(t, err)
+			defer result.Clean(common.DebugAllocator)
+
+			require.Len(t, result.Vecs, len(objectio.TombstoneSeqnums_DN_Created))
+			require.Equal(t, test.resultRows, result.RowCount())
+			require.Equal(t, types.T_Rowid, result.Vecs[objectio.TombstoneAttr_Rowid_Idx].GetType().Oid)
+			require.Equal(t, test.pkType, result.Vecs[objectio.TombstoneAttr_PK_Idx].GetType().Oid)
+			require.Equal(t, types.T_TS, result.Vecs[objectio.TombstoneAttr_NA_CommitTs_Idx].GetType().Oid)
+			if test.resultRows > 0 {
+				require.Equal(t, types.BuildTS(10, 0), vector.GetFixedAtWithTypeCheck[types.TS](
+					result.Vecs[objectio.TombstoneAttr_NA_CommitTs_Idx], 0))
+			}
+		})
+	}
+}
+
+func TestBackupTombstoneValidationRejectsMalformedColumns(t *testing.T) {
+	tests := []struct {
+		name   string
+		layout backupSpecialColumnLayout
+		mutate func(*batch.Batch)
+	}{
+		{
+			name:   "missing commit timestamp metadata",
+			layout: newBackupTombstoneLayout(invalidBackupSpecialColumnPosition, invalidBackupSpecialColumnPosition, invalidBackupSpecialColumnPosition),
+		},
+		{
+			name:   "short commit timestamp vector",
+			layout: newBackupTombstoneLayout(2, invalidBackupSpecialColumnPosition, 3),
+			mutate: func(bat *batch.Batch) {
+				bat.Vecs[2].SetLength(2)
+			},
+		},
+		{
+			name:   "wrong commit timestamp type",
+			layout: newBackupTombstoneLayout(3, invalidBackupSpecialColumnPosition, 2),
+		},
+		{
+			name:   "short abort vector",
+			layout: newBackupTombstoneLayout(2, invalidBackupSpecialColumnPosition, 3),
+			mutate: func(bat *batch.Batch) {
+				bat.Vecs[3].SetLength(2)
+			},
+		},
+		{
+			name:   "null commit timestamp",
+			layout: newBackupTombstoneLayout(2, invalidBackupSpecialColumnPosition, 3),
+			mutate: func(bat *batch.Batch) {
+				nulls.Add(bat.Vecs[2].GetNulls(), 1)
+			},
+		},
+		{
+			name:   "null abort flag",
+			layout: newBackupTombstoneLayout(2, invalidBackupSpecialColumnPosition, 3),
+			mutate: func(bat *batch.Batch) {
+				nulls.Add(bat.Vecs[3].GetNulls(), 1)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_TS, types.T_bool})
+			defer input.Clean(common.DebugAllocator)
+			if test.mutate != nil {
+				test.mutate(input)
+			}
+
+			_, err := visibleAppendableRows(context.Background(), input, test.layout, nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestBackupTombstoneWriterPreservesHiddenCommitTS(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+
+	input := newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_Rowid, types.T_TS, types.T_bool})
+	defer input.Clean(common.DebugAllocator)
+	layout := newBackupTombstoneLayout(3, 2, 4)
+	visibleRows, err := visibleAppendableRows(ctx, input, layout, ptrTo(types.BuildTS(15, 0)))
+	require.NoError(t, err)
+	require.Equal(t, []int64{0}, visibleRows)
+	input.Shrink(visibleRows, false)
+
+	output, err := canonicalizeBackupTombstone(ctx, input, layout)
+	require.NoError(t, err)
+	defer output.Clean(common.DebugAllocator)
+
+	objectID := objectio.NewObjectid()
+	name := objectio.BuildObjectNameWithObjectID(&objectID)
+	writer, err := ioutil.NewBlockWriterNew(
+		fs,
+		name,
+		0,
+		objectio.TombstoneSeqnums_DN_Created,
+		true,
+	)
+	require.NoError(t, err)
+	_, err = writer.WriteBatch(output)
+	require.NoError(t, err)
+	blocks, extent, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	location := objectio.BuildLocation(name, extent, blocks[0].GetRows(), blocks[0].GetID())
+	meta, err := objectio.FastLoadObjectMeta(ctx, &location, false, fs)
+	require.NoError(t, err)
+	blockMeta := meta.MustDataMeta().GetBlockMeta(uint32(location.ID()))
+	require.Equal(t, uint16(1), blockMeta.GetMaxSeqnum())
+	require.Equal(t, uint16(3), blockMeta.GetMetaColumnCount())
+	writtenLayout := resolveBackupSpecialColumnLayout(blockMeta)
+	require.Equal(t, uint16(2), writtenLayout.CommitTS)
+	require.Equal(t, uint16(invalidBackupSpecialColumnPosition), writtenLayout.Abort)
+	stats := writer.GetObjectStats()
+	require.False(t, stats.GetAppendable())
+	require.False(t, stats.GetCNCreated())
+
+	rowID := vector.GetFixedAtWithTypeCheck[types.Rowid](output.Vecs[0], 0)
+	deleted, err := ioutil.IsRowDeletedByLocation(
+		ctx,
+		ptrTo(types.BuildTS(15, 0)),
+		&rowID,
+		location,
+		fs,
+		false,
+	)
+	require.NoError(t, err)
+	require.True(t, deleted)
+}
+
+func TestRewriteCheckpointCanonicalizesBackupTombstone(t *testing.T) {
+	ctx := context.Background()
+	srcFS := testutil.NewSharedFS()
+	dstFS := testutil.NewSharedFS()
+
+	sourceBatch := newBackupTombstoneTestBatch(
+		t,
+		types.T_int64,
+		[]types.T{types.T_TS, types.T_Rowid},
+	)
+	defer sourceBatch.Clean(common.DebugAllocator)
+	objectID := objectio.NewObjectid()
+	sourceName := objectio.BuildObjectNameWithObjectID(&objectID)
+	sourceWriter, err := ioutil.NewBlockWriterNew(
+		srcFS,
+		sourceName,
+		0,
+		objectio.TombstoneSeqnums_DN_Created_PhyAddr,
+		true,
+	)
+	require.NoError(t, err)
+	sourceWriter.SetAppendable()
+	_, err = sourceWriter.WriteBatch(sourceBatch)
+	require.NoError(t, err)
+	_, _, err = sourceWriter.Sync(ctx)
+	require.NoError(t, err)
+	sourceStats := sourceWriter.GetObjectStats(objectio.WithAppendable())
+
+	cata := catalog.MockCatalog(nil)
+	defer cata.Close()
+	db, err := cata.CreateDBEntry("backup_test", "", "", nil)
+	require.NoError(t, err)
+	table, err := db.CreateTableEntry(catalog.MockSchema(2, 0), nil, nil)
+	require.NoError(t, err)
+	createTS := types.BuildTS(5, 0)
+	backupTS := types.BuildTS(15, 0)
+	dropTS := types.BuildTS(30, 0)
+	sourceEntry, err := table.CreateCommittedObject(
+		createTS,
+		&objectio.CreateObjOpt{Stats: &sourceStats, IsTombstone: true},
+		nil,
+	)
+	require.NoError(t, err)
+	catalog.MockDroppedObjectEntry2List(sourceEntry, dropTS)
+
+	collector := NewBaseCollector_V2(backupTS, dropTS, 0, srcFS)
+	defer collector.Close()
+	require.NoError(t, collector.Collect(cata))
+	checkpointData := collector.OrphanData()
+	defer checkpointData.Close()
+	checkpointLocation, _, err := checkpointData.Sync(ctx, srcFS)
+	require.NoError(t, err)
+
+	lastReader, err := GetCheckpointReader(
+		ctx,
+		"backup-test",
+		srcFS,
+		checkpointLocation,
+		CheckpointCurrentVersion,
+	)
+	require.NoError(t, err)
+	rewrittenLocation, _, _, err := ReWriteCheckpointAndBlockFromKey(
+		ctx,
+		"backup-test",
+		srcFS,
+		dstFS,
+		checkpointLocation,
+		lastReader,
+		CheckpointCurrentVersion,
+		backupTS,
+	)
+	require.NoError(t, err)
+
+	rewrittenReader, err := GetCheckpointReader(
+		ctx,
+		"backup-test",
+		dstFS,
+		rewrittenLocation,
+		CheckpointCurrentVersion,
+	)
+	require.NoError(t, err)
+	var rewrittenStats objectio.ObjectStats
+	err = rewrittenReader.ForEachRow(
+		ctx,
+		func(
+			_ uint32,
+			_, _ uint64,
+			objectType int8,
+			stats objectio.ObjectStats,
+			_ types.TS,
+			deleteTS types.TS,
+			_ types.Rowid,
+		) error {
+			if objectType == ckputil.ObjectType_Tombstone &&
+				deleteTS.IsEmpty() &&
+				stats.ObjectName().String() != sourceName.String() {
+				rewrittenStats = stats
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, rewrittenStats.IsZero())
+	require.False(t, rewrittenStats.GetAppendable())
+	require.False(t, rewrittenStats.GetCNCreated())
+	require.True(t, rewrittenStats.GetSorted())
+	require.Equal(t, uint32(2), rewrittenStats.Rows())
+
+	rewrittenObjectLocation := rewrittenStats.ObjectLocation()
+	rewrittenMeta, err := objectio.FastLoadObjectMeta(ctx, &rewrittenObjectLocation, false, dstFS)
+	require.NoError(t, err)
+	rewrittenBlockMeta := rewrittenMeta.MustDataMeta().GetBlockMeta(uint32(rewrittenObjectLocation.ID()))
+	require.Equal(t, uint16(1), rewrittenBlockMeta.GetMaxSeqnum())
+	require.Equal(t, uint16(3), rewrittenBlockMeta.GetMetaColumnCount())
+	rewrittenLayout := resolveBackupSpecialColumnLayout(rewrittenBlockMeta)
+	require.Equal(t, uint16(2), rewrittenLayout.CommitTS)
+	require.Equal(t, uint16(invalidBackupSpecialColumnPosition), rewrittenLayout.PhysicalAddr)
+	require.Equal(t, uint16(invalidBackupSpecialColumnPosition), rewrittenLayout.Abort)
+
+	var targetBlock types.Blockid
+	for row, expected := range []bool{true, true, false} {
+		rowID := types.NewRowid(&targetBlock, uint32(row))
+		deleted, err := ioutil.IsRowDeletedByLocation(
+			ctx,
+			&backupTS,
+			&rowID,
+			rewrittenObjectLocation,
+			dstFS,
+			false,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expected, deleted)
+	}
+}
+
+func newBackupTombstoneTestBatch(t *testing.T, pkType types.T, trailingTypes []types.T) *batch.Batch {
+	t.Helper()
+
+	bat := batch.NewWithSize(len(objectio.TombstoneSeqnums_CN_Created) + len(trailingTypes))
+	bat.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	bat.Vecs[1] = vector.NewVec(pkType.ToType())
+	for pos, typ := range trailingTypes {
+		bat.Vecs[len(objectio.TombstoneSeqnums_CN_Created)+pos] = vector.NewVec(typ.ToType())
+	}
+
+	var deletedBlock, physicalBlock types.Blockid
+	for row := range 3 {
+		require.NoError(t, vector.AppendFixed(
+			bat.Vecs[0], types.NewRowid(&deletedBlock, uint32(row)), false, common.DebugAllocator))
+		switch pkType {
+		case types.T_int64:
+			require.NoError(t, vector.AppendFixed(
+				bat.Vecs[1], int64(row+1), false, common.DebugAllocator))
+		case types.T_TS:
+			require.NoError(t, vector.AppendFixed(
+				bat.Vecs[1], types.BuildTS(int64(row+1), 0), false, common.DebugAllocator))
+		default:
+			t.Fatalf("unsupported test primary-key type %s", pkType.String())
+		}
+		for trailingPos, typ := range trailingTypes {
+			vec := bat.Vecs[len(objectio.TombstoneSeqnums_CN_Created)+trailingPos]
+			switch typ {
+			case types.T_Rowid:
+				require.NoError(t, vector.AppendFixed(
+					vec, types.NewRowid(&physicalBlock, uint32(row)), false, common.DebugAllocator))
+			case types.T_TS:
+				commitTS := types.BuildTS(10, 0)
+				if row == 2 {
+					commitTS = types.BuildTS(20, 0)
+				}
+				require.NoError(t, vector.AppendFixed(vec, commitTS, false, common.DebugAllocator))
+			case types.T_bool:
+				require.NoError(t, vector.AppendFixed(vec, row == 1, false, common.DebugAllocator))
+			default:
+				t.Fatalf("unsupported test column type %s", typ.String())
+			}
+		}
+	}
+	bat.SetRowCount(3)
+	return bat
+}
+
+func newBackupTombstoneLayout(commit, physical, abort uint16) backupSpecialColumnLayout {
+	return backupSpecialColumnLayout{
+		PhysicalAddr: physical,
+		CommitTS:     commit,
+		Abort:        abort,
+	}
+}
+
+func ptrTo[T any](value T) *T {
+	return &value
+}

--- a/pkg/vm/engine/tae/logtail/backup_test.go
+++ b/pkg/vm/engine/tae/logtail/backup_test.go
@@ -263,6 +263,74 @@ func TestBackupTombstoneWriterPreservesHiddenCommitTS(t *testing.T) {
 	require.True(t, deleted)
 }
 
+func TestBackupDeltaLocDataSourceReadsLegacyGenericWriterTombstone(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	input := batch.NewWithSize(3)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	input.Vecs[2] = vector.NewVec(types.T_TS.ToType())
+	defer input.Clean(common.DebugAllocator)
+
+	var deletedBlock types.Blockid
+	for row, commitTS := range []types.TS{types.BuildTS(5, 0), types.BuildTS(20, 0)} {
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[0],
+			types.NewRowid(&deletedBlock, uint32(row+1)),
+			false,
+			common.DebugAllocator,
+		))
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[1], int64(row+1), false, common.DebugAllocator,
+		))
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[2], commitTS, false, common.DebugAllocator,
+		))
+	}
+	input.SetRowCount(2)
+
+	// The affected Backup path wrote [rowid, pk, commitTS] with the generic
+	// writer, so commitTS was physical user seqnum 2 rather than SEQNUM_COMMITTS.
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	writer, err := ioutil.NewBlockWriter(fs, name.String())
+	require.NoError(t, err)
+	_, err = writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, extent, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, uint16(3), blocks[0].GetMetaColumnCount())
+	require.Equal(t, uint16(2), blocks[0].GetMaxSeqnum())
+	require.Equal(t, uint8(types.T_TS), blocks[0].ColumnMeta(2).DataType())
+
+	dataSource := NewBackupDeltaLocDataSource(
+		ctx,
+		fs,
+		types.BuildTS(10, 0),
+		make(map[string]*objData),
+	)
+	legacyStats := objectio.NewObjectStats()
+	require.NoError(t, objectio.SetObjectStatsObjectName(legacyStats, name))
+	require.NoError(t, objectio.SetObjectStatsExtent(legacyStats, extent))
+	require.NoError(t, objectio.SetObjectStatsRowCnt(legacyStats, uint32(input.RowCount())))
+	require.NoError(t, objectio.SetObjectStatsBlkCnt(legacyStats, uint32(len(blocks))))
+	require.NoError(t, objectio.SetObjectStatsSize(legacyStats, extent.End()))
+	dataSource.tombstones = []objectio.ObjectStats{*legacyStats}
+	t.Cleanup(func() {
+		for _, data := range dataSource.ds {
+			for _, bat := range data.data {
+				bat.Clean(common.DebugAllocator)
+			}
+		}
+	})
+
+	deletedRows, err := dataSource.GetTombstones(ctx, &deletedBlock)
+	require.NoError(t, err)
+	defer deletedRows.Release()
+	require.True(t, deletedRows.Contains(1))
+	require.False(t, deletedRows.Contains(2))
+}
+
 func TestRewriteCheckpointCanonicalizesBackupTombstone(t *testing.T) {
 	ctx := context.Background()
 	srcFS := testutil.NewSharedFS()

--- a/pkg/vm/engine/tae/logtail/backup_test.go
+++ b/pkg/vm/engine/tae/logtail/backup_test.go
@@ -115,6 +115,38 @@ func TestCanonicalizeBackupTombstone(t *testing.T) {
 	}
 }
 
+func TestVisibleAppendableRowsBroadcastsConstantCommitTS(t *testing.T) {
+	input := newBackupTombstoneTestBatch(t, types.T_int64, []types.T{types.T_TS})
+	input.Vecs[2].Free(common.DebugAllocator)
+	commitTS := types.BuildTS(10, 0)
+	var err error
+	input.Vecs[2], err = vector.NewConstFixed(
+		types.T_TS.ToType(), commitTS, input.RowCount(), common.DebugAllocator)
+	require.NoError(t, err)
+	defer input.Clean(common.DebugAllocator)
+
+	layout := newBackupTombstoneLayout(
+		2,
+		invalidBackupSpecialColumnPosition,
+		invalidBackupSpecialColumnPosition,
+	)
+	visibleRows, err := visibleAppendableRows(
+		context.Background(), input, layout, ptrTo(types.BuildTS(15, 0)),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int64{0, 1, 2}, visibleRows)
+
+	input.Shrink(visibleRows, false)
+	result, err := canonicalizeBackupTombstone(context.Background(), input, layout)
+	require.NoError(t, err)
+	defer result.Clean(common.DebugAllocator)
+	require.Equal(t, 3, result.RowCount())
+	for row := range result.RowCount() {
+		require.Equal(t, commitTS, vector.GetFixedAtNoTypeCheck[types.TS](
+			result.Vecs[objectio.TombstoneAttr_NA_CommitTs_Idx], row))
+	}
+}
+
 func TestBackupTombstoneValidationRejectsMalformedColumns(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/vm/engine/tae/tables/pnode.go
+++ b/pkg/vm/engine/tae/tables/pnode.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
@@ -116,7 +117,7 @@ func (node *persistedNode) Scan(
 	}
 	vecs, deletes, release, err := LoadPersistedColumnData(
 		ctx, readSchema, node.object.rt, id, colIdxes, location, mp, tsForAppendable,
-		!isScanNoCopy(ctx),
+		!isScanNoCopy(ctx), node.object.meta.Load().IsTombstone,
 	)
 	replaceCommitts := func(vecs []containers.Vector, i int) {
 		createTS := node.object.meta.Load().GetCreatedAt()
@@ -235,6 +236,8 @@ func (node *persistedNode) CollectObjectTombstoneInRange(
 	}
 	colIdxes := objectio.TombstoneColumns_TN_Created
 	readSchema := node.object.meta.Load().GetTable().GetLastestSchema(true)
+	pkIdx := readSchema.GetColIdx(objectio.TombstoneAttr_PK_Attr)
+	pkType := readSchema.ColDefs[pkIdx].GetType()
 	var startTS types.TS
 	if !node.object.meta.Load().IsAppendable() {
 		startTS = node.object.meta.Load().GetCreatedAt()
@@ -286,22 +289,28 @@ func (node *persistedNode) CollectObjectTombstoneInRange(
 		}
 		vecs, _, _, err := LoadPersistedColumnData(
 			ctx, readSchema, node.object.rt, id, colIdxes, location, mp, nil,
-			true,
+			true, true,
 		)
 		if err != nil {
 			return err
 		}
-		var commitTSs []types.TS
 		if !persistedByCN {
-			commitTSs = vector.MustFixedColWithTypeCheck[types.TS](vecs[2].GetDownstreamVector())
 			rowIDs := vector.MustFixedColWithTypeCheck[types.Rowid](vecs[0].GetDownstreamVector())
-			for i := 0; i < len(commitTSs); i++ {
-				commitTS := commitTSs[i]
+			commitTSs, err := ioutil.ValidateTombstoneCommitTSColumn(
+				len(rowIDs),
+				vecs[2].GetDownstreamVector(),
+			)
+			if err != nil {
+				for i := range vecs {
+					vecs[i].Close()
+				}
+				return err
+			}
+			for i := range rowIDs {
+				commitTS := commitTSs.At(i)
 				if commitTS.GE(&start) && commitTS.LE(&end) &&
 					types.PrefixCompare(rowIDs[i][:], objID[:]) == 0 { // TODO
 					if *bat == nil {
-						pkIdx := readSchema.GetColIdx(objectio.TombstoneAttr_PK_Attr)
-						pkType := readSchema.ColDefs[pkIdx].GetType()
 						*bat = catalog.NewTombstoneBatchByPKType(pkType, mp)
 					}
 					(*bat).GetVectorByName(objectio.TombstoneAttr_Rowid_Attr).Append(rowIDs[i], false)
@@ -311,11 +320,9 @@ func (node *persistedNode) CollectObjectTombstoneInRange(
 			}
 		} else {
 			rowIDs := vector.MustFixedColWithTypeCheck[types.Rowid](vecs[0].GetDownstreamVector())
-			for i := 0; i < len(rowIDs); i++ {
+			for i := range rowIDs {
 				if types.PrefixCompare(rowIDs[i][:], objID[:]) == 0 { // TODO
 					if *bat == nil {
-						pkIdx := readSchema.GetColIdx(objectio.TombstoneAttr_PK_Attr)
-						pkType := readSchema.ColDefs[pkIdx].GetType()
 						*bat = catalog.NewTombstoneBatchByPKType(pkType, mp)
 					}
 					(*bat).GetVectorByName(objectio.TombstoneAttr_Rowid_Attr).Append(rowIDs[i], false)
@@ -380,7 +387,7 @@ func (node *persistedNode) FillBlockTombstones(
 		}
 		vecs, _, _, err := LoadPersistedColumnData(
 			ctx, readSchema, node.object.rt, id, colIdxs, location, mp, nil,
-			true,
+			true, true,
 		)
 		if err != nil {
 			return err

--- a/pkg/vm/engine/tae/tables/pnode.go
+++ b/pkg/vm/engine/tae/tables/pnode.go
@@ -366,7 +366,16 @@ func (node *persistedNode) FillBlockTombstones(
 	); err != nil {
 		return err
 	}
+	isAppendable := node.object.meta.Load().IsAppendable()
 	colIdxs := []int{0}
+	if !isAppendable {
+		// A non-appendable tombstone can contain rows committed at different
+		// timestamps.  The object CreatedAt check above is only a coarse object
+		// visibility gate; use the hidden per-row commitTS for snapshot filtering.
+		// LoadPersistedColumnData also maps the affected Backup layout and leaves
+		// the exact two-column CN layout as const-null (CreatedAt semantics).
+		colIdxs = append(colIdxs, objectio.SEQNUM_COMMITTS)
+	}
 	for tombstoneBlkID := 0; tombstoneBlkID < node.object.meta.Load().BlockCnt(); tombstoneBlkID++ {
 		buf := bf.GetBloomFilter(uint32(tombstoneBlkID))
 		bfIndex := index.NewEmptyBloomFilterWithType(index.HBF)
@@ -392,9 +401,8 @@ func (node *persistedNode) FillBlockTombstones(
 		if err != nil {
 			return err
 		}
-		var commitTSs []types.TS
 		var commitTSVec containers.Vector
-		if node.object.meta.Load().IsAppendable() {
+		if isAppendable {
 			commitTSVec, err = node.object.LoadPersistedCommitTS(uint16(tombstoneBlkID))
 			if err != nil {
 				for i := range vecs {
@@ -402,13 +410,32 @@ func (node *persistedNode) FillBlockTombstones(
 				}
 				return err
 			}
-			commitTSs = vector.MustFixedColWithTypeCheck[types.TS](commitTSVec.GetDownstreamVector())
 		}
 		rowIDs := vector.MustFixedColWithTypeCheck[types.Rowid](vecs[0].GetDownstreamVector())
+		var commitTSs ioutil.TombstoneCommitTSColumn
+		if isAppendable {
+			commitTSs, err = ioutil.ValidateTombstoneCommitTSColumn(
+				len(rowIDs), commitTSVec.GetDownstreamVector(),
+			)
+		} else if !vecs[1].IsConstNull() {
+			commitTSs, err = ioutil.ValidateTombstoneCommitTSColumn(
+				len(rowIDs), vecs[1].GetDownstreamVector(),
+			)
+		}
+		if err != nil {
+			if commitTSVec != nil {
+				commitTSVec.Close()
+			}
+			for i := range vecs {
+				vecs[i].Close()
+			}
+			return err
+		}
 		// TODO: biselect, check visibility
 		for i := 0; i < len(rowIDs); i++ {
-			if node.object.meta.Load().IsAppendable() {
-				if commitTSs[i].GT(&startTS) {
+			if commitTSs.IsPresent() {
+				commitTS := commitTSs.At(i)
+				if commitTS.GT(&startTS) {
 					continue
 				}
 			}

--- a/pkg/vm/engine/tae/tables/pnode_test.go
+++ b/pkg/vm/engine/tae/tables/pnode_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tables
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistedNodeReadsLegacyBackupTombstone(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	smallPool := containers.NewVectorPool("legacy-tombstone-small", 4, containers.WithMPool(mp))
+	transientPool := containers.NewVectorPool("legacy-tombstone-transient", 4, containers.WithMPool(mp))
+	defer smallPool.Destory()
+	defer transientPool.Destory()
+	rt := dbutils.NewRuntime(
+		dbutils.WithRuntimeObjectFS(fs),
+		dbutils.WithRuntimeSmallPool(smallPool),
+		dbutils.WithRuntimeTransientPool(transientPool),
+	)
+
+	targetObject := objectio.NewObjectid()
+	input := batch.NewWithSize(3)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	input.Vecs[2] = vector.NewVec(types.T_TS.ToType())
+	for row, commitTS := range []types.TS{types.BuildTS(10, 0), types.BuildTS(20, 0)} {
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[0],
+			types.NewRowIDWithObjectIDBlkNumAndRowID(targetObject, 0, uint32(row+1)),
+			false,
+			mp,
+		))
+		require.NoError(t, vector.AppendFixed(input.Vecs[1], int32(row+1), false, mp))
+		require.NoError(t, vector.AppendFixed(input.Vecs[2], commitTS, false, mp))
+	}
+	input.SetRowCount(2)
+	defer input.Clean(mp)
+
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	writer, err := ioutil.NewBlockWriter(fs, name.String())
+	require.NoError(t, err)
+	writer.SetTombstone()
+	writer.SetPrimaryKeyWithType(
+		uint16(objectio.TombstonePrimaryKeyIdx),
+		index.HBF,
+		index.ObjectPrefixFn,
+		index.BlockPrefixFn,
+	)
+	_, err = writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, extent, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, uint16(3), blocks[0].GetMetaColumnCount())
+	require.Equal(t, uint16(2), blocks[0].GetMaxSeqnum())
+
+	stats := objectio.NewObjectStats()
+	require.NoError(t, objectio.SetObjectStatsObjectName(stats, name))
+	require.NoError(t, objectio.SetObjectStatsExtent(stats, extent))
+	require.NoError(t, objectio.SetObjectStatsRowCnt(stats, uint32(input.RowCount())))
+	require.NoError(t, objectio.SetObjectStatsBlkCnt(stats, uint32(len(blocks))))
+	require.NoError(t, objectio.SetObjectStatsSize(stats, extent.End()))
+
+	c := catalog.MockCatalog(nil)
+	defer c.Close()
+	db, err := c.CreateDBEntry("db", "", "", nil)
+	require.NoError(t, err)
+	table, err := db.CreateTableEntry(catalog.MockSchema(1, 0), nil, nil)
+	require.NoError(t, err)
+	entry, err := table.CreateCommittedObject(
+		types.BuildTS(10, 0),
+		&objectio.CreateObjOpt{Stats: stats, IsTombstone: true},
+		NewDataFactory(rt, "").MakeObjectFactory(),
+	)
+	require.NoError(t, err)
+
+	t.Run("scan preserves per-row commit timestamps", func(t *testing.T) {
+		var result *containers.Batch
+		err := entry.GetObjectData().Scan(
+			ctx,
+			&result,
+			nil,
+			table.GetLastestSchema(true),
+			0,
+			objectio.TombstoneColumns_TN_Created,
+			mp,
+		)
+		require.NoError(t, err)
+		if result != nil {
+			defer result.Close()
+		}
+		require.NotNil(t, result)
+		require.Equal(t, 2, result.Length())
+		require.Equal(t, types.BuildTS(10, 0), result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(0))
+		require.Equal(t, types.BuildTS(20, 0), result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(1))
+	})
+
+	t.Run("zero-copy scan transfers the compatibility reload lease", func(t *testing.T) {
+		var result *containers.Batch
+		err := entry.GetObjectData().Scan(
+			WithScanNoCopy(ctx),
+			&result,
+			nil,
+			table.GetLastestSchema(true),
+			0,
+			objectio.TombstoneColumns_TN_Created,
+			mp,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.DataRelease)
+		require.Equal(t, types.BuildTS(10, 0), result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(0))
+		require.Equal(t, types.BuildTS(20, 0), result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(1))
+		result.Close()
+		require.Nil(t, result.DataRelease)
+	})
+
+	t.Run("range collection uses physical commit timestamp", func(t *testing.T) {
+		var result *containers.Batch
+		err := entry.GetObjectData().CollectObjectTombstoneInRange(
+			ctx,
+			types.BuildTS(5, 0),
+			types.BuildTS(15, 0),
+			&targetObject,
+			&result,
+			mp,
+			transientPool,
+		)
+		require.NoError(t, err)
+		if result != nil {
+			defer result.Close()
+		}
+		require.NotNil(t, result)
+		require.Equal(t, 1, result.Length())
+		require.Equal(t, int32(1), result.GetVectorByName(objectio.TombstoneAttr_PK_Attr).Get(0))
+		require.Equal(t, types.BuildTS(10, 0), result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(0))
+	})
+}
+
+func TestPersistedNodeReadsCNCreatedTombstone(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	smallPool := containers.NewVectorPool("cn-tombstone-small", 4, containers.WithMPool(mp))
+	transientPool := containers.NewVectorPool("cn-tombstone-transient", 4, containers.WithMPool(mp))
+	defer smallPool.Destory()
+	defer transientPool.Destory()
+	rt := dbutils.NewRuntime(
+		dbutils.WithRuntimeObjectFS(fs),
+		dbutils.WithRuntimeSmallPool(smallPool),
+		dbutils.WithRuntimeTransientPool(transientPool),
+	)
+
+	targetObject := objectio.NewObjectid()
+	input := batch.NewWithSize(len(objectio.TombstoneSeqnums_CN_Created))
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	for row := range 2 {
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[0],
+			types.NewRowIDWithObjectIDBlkNumAndRowID(targetObject, 0, uint32(row+1)),
+			false,
+			mp,
+		))
+		require.NoError(t, vector.AppendFixed(input.Vecs[1], int32(row+1), false, mp))
+	}
+	input.SetRowCount(2)
+	defer input.Clean(mp)
+
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	writer, err := ioutil.NewBlockWriterNew(
+		fs,
+		name,
+		0,
+		objectio.TombstoneSeqnums_CN_Created,
+		true,
+	)
+	require.NoError(t, err)
+	writer.SetTombstone()
+	writer.SetPrimaryKeyWithType(
+		uint16(objectio.TombstonePrimaryKeyIdx),
+		index.HBF,
+		index.ObjectPrefixFn,
+		index.BlockPrefixFn,
+	)
+	_, err = writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, _, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, uint16(2), blocks[0].GetMetaColumnCount())
+
+	stats := writer.GetObjectStats(objectio.WithCNCreated())
+	require.True(t, stats.GetCNCreated())
+	createdAt := types.BuildTS(10, 0)
+	c := catalog.MockCatalog(nil)
+	defer c.Close()
+	db, err := c.CreateDBEntry("db", "", "", nil)
+	require.NoError(t, err)
+	table, err := db.CreateTableEntry(catalog.MockSchema(1, 0), nil, nil)
+	require.NoError(t, err)
+	entry, err := table.CreateCommittedObject(
+		createdAt,
+		&objectio.CreateObjOpt{Stats: &stats, IsTombstone: true},
+		NewDataFactory(rt, "").MakeObjectFactory(),
+	)
+	require.NoError(t, err)
+
+	t.Run("scan derives commit timestamp from object creation", func(t *testing.T) {
+		var result *containers.Batch
+		err := entry.GetObjectData().Scan(
+			ctx,
+			&result,
+			nil,
+			table.GetLastestSchema(true),
+			0,
+			objectio.TombstoneColumns_TN_Created,
+			mp,
+		)
+		require.NoError(t, err)
+		if result != nil {
+			defer result.Close()
+		}
+		require.NotNil(t, result)
+		require.Equal(t, 2, result.Length())
+		for row := range result.Length() {
+			require.Equal(t, createdAt, result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(row))
+		}
+	})
+
+	t.Run("range collection uses object creation timestamp", func(t *testing.T) {
+		var result *containers.Batch
+		err := entry.GetObjectData().CollectObjectTombstoneInRange(
+			ctx,
+			types.BuildTS(5, 0),
+			types.BuildTS(15, 0),
+			&targetObject,
+			&result,
+			mp,
+			transientPool,
+		)
+		require.NoError(t, err)
+		if result != nil {
+			defer result.Close()
+		}
+		require.NotNil(t, result)
+		require.Equal(t, 2, result.Length())
+		for row := range result.Length() {
+			require.Equal(t, createdAt, result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(row))
+		}
+	})
+}

--- a/pkg/vm/engine/tae/tables/pnode_test.go
+++ b/pkg/vm/engine/tae/tables/pnode_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
@@ -29,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 	"github.com/stretchr/testify/require"
 )
 
@@ -165,6 +167,136 @@ func TestPersistedNodeReadsLegacyBackupTombstone(t *testing.T) {
 		require.Equal(t, int32(1), result.GetVectorByName(objectio.TombstoneAttr_PK_Attr).Get(0))
 		require.Equal(t, types.BuildTS(10, 0), result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(0))
 	})
+
+	t.Run("block filtering uses per-row commit timestamp", func(t *testing.T) {
+		blockID := types.NewBlockidWithObjectID(&targetObject, 0)
+		for _, test := range []struct {
+			name        string
+			startTS     types.TS
+			wantOffsets []uint64
+		}{
+			{name: "before object creation", startTS: types.BuildTS(5, 0)},
+			{name: "between row commits", startTS: types.BuildTS(15, 0), wantOffsets: []uint64{101}},
+			{name: "after row commits", startTS: types.BuildTS(25, 0), wantOffsets: []uint64{101, 102}},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				var deletes *nulls.Nulls
+				err := entry.GetObjectData().FillBlockTombstones(
+					ctx,
+					txnbase.MockTxnReaderWithStartTS(test.startTS),
+					&blockID,
+					&deletes,
+					100,
+					mp,
+				)
+				require.NoError(t, err)
+				require.Equal(t, len(test.wantOffsets), deletes.Count())
+				for _, offset := range test.wantOffsets {
+					require.True(t, deletes.Contains(offset))
+				}
+			})
+		}
+	})
+}
+
+func TestPersistedNodeFiltersCanonicalTombstoneByCommitTS(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	smallPool := containers.NewVectorPool("canonical-tombstone-small", 4, containers.WithMPool(mp))
+	transientPool := containers.NewVectorPool("canonical-tombstone-transient", 4, containers.WithMPool(mp))
+	defer smallPool.Destory()
+	defer transientPool.Destory()
+	rt := dbutils.NewRuntime(
+		dbutils.WithRuntimeObjectFS(fs),
+		dbutils.WithRuntimeSmallPool(smallPool),
+		dbutils.WithRuntimeTransientPool(transientPool),
+	)
+
+	targetObject := objectio.NewObjectid()
+	input := batch.NewWithSize(len(objectio.TombstoneSeqnums_DN_Created))
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	input.Vecs[2] = vector.NewVec(types.T_TS.ToType())
+	for row, commitTS := range []types.TS{types.BuildTS(10, 0), types.BuildTS(20, 0)} {
+		require.NoError(t, vector.AppendFixed(
+			input.Vecs[0],
+			types.NewRowIDWithObjectIDBlkNumAndRowID(targetObject, 0, uint32(row+1)),
+			false,
+			mp,
+		))
+		require.NoError(t, vector.AppendFixed(input.Vecs[1], int32(row+1), false, mp))
+		require.NoError(t, vector.AppendFixed(input.Vecs[2], commitTS, false, mp))
+	}
+	input.SetRowCount(2)
+	defer input.Clean(mp)
+
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+	writer, err := ioutil.NewBlockWriterNew(
+		fs,
+		name,
+		0,
+		objectio.TombstoneSeqnums_DN_Created,
+		true,
+	)
+	require.NoError(t, err)
+	writer.SetPrimaryKeyWithType(
+		uint16(objectio.TombstonePrimaryKeyIdx),
+		index.HBF,
+		index.ObjectPrefixFn,
+		index.BlockPrefixFn,
+	)
+	_, err = writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, _, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, uint16(3), blocks[0].GetMetaColumnCount())
+
+	stats := writer.GetObjectStats()
+	require.False(t, stats.GetCNCreated())
+	c := catalog.MockCatalog(nil)
+	defer c.Close()
+	db, err := c.CreateDBEntry("db", "", "", nil)
+	require.NoError(t, err)
+	table, err := db.CreateTableEntry(catalog.MockSchema(1, 0), nil, nil)
+	require.NoError(t, err)
+	entry, err := table.CreateCommittedObject(
+		types.BuildTS(10, 0),
+		&objectio.CreateObjOpt{Stats: &stats, IsTombstone: true},
+		NewDataFactory(rt, "").MakeObjectFactory(),
+	)
+	require.NoError(t, err)
+
+	blockID := types.NewBlockidWithObjectID(&targetObject, 0)
+	for _, test := range []struct {
+		name        string
+		startTS     types.TS
+		wantOffsets []uint64
+	}{
+		{name: "before object creation", startTS: types.BuildTS(5, 0)},
+		{name: "between row commits", startTS: types.BuildTS(15, 0), wantOffsets: []uint64{101}},
+		{name: "after row commits", startTS: types.BuildTS(25, 0), wantOffsets: []uint64{101, 102}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var deletes *nulls.Nulls
+			fillErr := entry.GetObjectData().FillBlockTombstones(
+				ctx,
+				txnbase.MockTxnReaderWithStartTS(test.startTS),
+				&blockID,
+				&deletes,
+				100,
+				mp,
+			)
+			require.NoError(t, fillErr)
+			require.Equal(t, len(test.wantOffsets), deletes.Count())
+			for _, offset := range test.wantOffsets {
+				require.True(t, deletes.Contains(offset))
+			}
+		})
+	}
 }
 
 func TestPersistedNodeReadsCNCreatedTombstone(t *testing.T) {
@@ -279,6 +411,35 @@ func TestPersistedNodeReadsCNCreatedTombstone(t *testing.T) {
 		require.Equal(t, 2, result.Length())
 		for row := range result.Length() {
 			require.Equal(t, createdAt, result.GetVectorByName(objectio.TombstoneAttr_CommitTs_Attr).Get(row))
+		}
+	})
+
+	t.Run("block filtering keeps object creation timestamp semantics", func(t *testing.T) {
+		blockID := types.NewBlockidWithObjectID(&targetObject, 0)
+		for _, test := range []struct {
+			name        string
+			startTS     types.TS
+			wantOffsets []uint64
+		}{
+			{name: "before object creation", startTS: types.BuildTS(5, 0)},
+			{name: "after object creation", startTS: types.BuildTS(15, 0), wantOffsets: []uint64{101, 102}},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				var deletes *nulls.Nulls
+				err := entry.GetObjectData().FillBlockTombstones(
+					ctx,
+					txnbase.MockTxnReaderWithStartTS(test.startTS),
+					&blockID,
+					&deletes,
+					100,
+					mp,
+				)
+				require.NoError(t, err)
+				require.Equal(t, len(test.wantOffsets), deletes.Count())
+				for _, offset := range test.wantOffsets {
+					require.True(t, deletes.Contains(offset))
+				}
+			})
 		}
 	})
 }

--- a/pkg/vm/engine/tae/tables/utils.go
+++ b/pkg/vm/engine/tae/tables/utils.go
@@ -56,6 +56,7 @@ func LoadPersistedColumnData(
 	mp *mpool.MPool,
 	tsForAppendable *types.TS,
 	needCopy bool,
+	isTombstone bool,
 ) ([]containers.Vector, *nulls.Nulls, func(), error) {
 	cols := make([]uint16, 0, len(colIdxs))
 	typs := make([]types.Type, 0, len(colIdxs))
@@ -111,12 +112,92 @@ func LoadPersistedColumnData(
 		needCopy,
 		rt.VectorPool.Transient)
 	if err != nil {
+		if phyAddIdx >= 0 && vectors[phyAddIdx] != nil {
+			vectors[phyAddIdx].Close()
+		}
 		return nil, deletes, nil, err
 	}
+	cleanupLoaded := func(closePhysicalAddr bool) {
+		for _, vec := range vecs {
+			vec.Close()
+		}
+		if release != nil {
+			release()
+			release = nil
+		}
+		vecs = nil
+		if closePhysicalAddr && phyAddIdx >= 0 && vectors[phyAddIdx] != nil {
+			vectors[phyAddIdx].Close()
+			vectors[phyAddIdx] = nil
+		}
+	}
+	var validatedTombstoneCommitTS ioutil.TombstoneCommitTSColumn
+	if isTombstone && committsIdx >= 0 {
+		// The legacy physical-column mapping is intentionally gated by catalog
+		// tombstone identity: an ordinary three-column object can have the same
+		// physical metadata signature.
+		validatedTombstoneCommitTS, err = ioutil.ValidateTombstoneCommitTSColumn(
+			int(location.Rows()),
+			vecs[committsIdx].GetDownstreamVector(),
+		)
+		if err != nil && vecs[committsIdx].IsConstNull() {
+			objectMeta, metaErr := objectio.FastLoadObjectMeta(ctx, &location, false, rt.Fs)
+			if metaErr != nil {
+				cleanupLoaded(true)
+				return nil, deletes, nil, metaErr
+			}
+			blockMeta := objectMeta.MustDataMeta().GetBlockMeta(uint32(location.ID()))
+			if legacyCommitTS, ok := ioutil.ResolveLegacyBackupTombstoneCommitTS(blockMeta); ok {
+				cleanupLoaded(false)
+				cols[committsIdx] = legacyCommitTS
+				vecs, release, err = ioutil.LoadColumns2(
+					ctx, cols,
+					typs,
+					rt.Fs,
+					location,
+					fileservice.GetFileServicePolicy(ctx),
+					needCopy,
+					rt.VectorPool.Transient,
+				)
+				if err != nil {
+					if phyAddIdx >= 0 && vectors[phyAddIdx] != nil {
+						vectors[phyAddIdx].Close()
+					}
+					return nil, deletes, nil, err
+				}
+				validatedTombstoneCommitTS, err = ioutil.ValidateTombstoneCommitTSColumn(
+					int(location.Rows()),
+					vecs[committsIdx].GetDownstreamVector(),
+				)
+			} else if isCNCreatedTombstoneBlock(blockMeta) {
+				// CN-created tombstones persist only rowid and primary key. Their
+				// per-object CreatedAt is the logical commit timestamp, so keep
+				// the synthesized const-null vector for the caller to replace.
+				err = nil
+			}
+		}
+		if err != nil {
+			cleanupLoaded(true)
+			return nil, deletes, nil, err
+		}
+	}
 	if tsForAppendable != nil {
-		commits := vector.MustFixedColNoTypeCheck[types.TS](vecs[committsIdx].GetDownstreamVector())
-		for i := range commits {
-			if commits[i].GT(tsForAppendable) {
+		if validatedTombstoneCommitTS.IsPresent() {
+			for i := range int(location.Rows()) {
+				commitTS := validatedTombstoneCommitTS.At(i)
+				if commitTS.GT(tsForAppendable) {
+					if deletes == nil {
+						deletes = nulls.NewWithSize(int(location.Rows()))
+					}
+					deletes.Add(uint64(i))
+				}
+			}
+		} else {
+			commits := vector.MustFixedColNoTypeCheck[types.TS](vecs[committsIdx].GetDownstreamVector())
+			for i := range commits {
+				if !commits[i].GT(tsForAppendable) {
+					continue
+				}
 				if deletes == nil {
 					deletes = nulls.NewWithSize(int(location.Rows()))
 				}
@@ -136,6 +217,17 @@ func LoadPersistedColumnData(
 		vectors[idx] = vec
 	}
 	return vectors, deletes, release, nil
+}
+
+func isCNCreatedTombstoneBlock(block objectio.BlockObject) bool {
+	// Preserve the established two-column [rowid, pk] layout whose logical
+	// commit timestamp is the containing object's CreatedAt.
+	return !block.BlockHeader().Appendable() &&
+		block.GetColumnCount() == uint16(len(objectio.TombstoneSeqnums_CN_Created)) &&
+		block.GetMetaColumnCount() == uint16(len(objectio.TombstoneSeqnums_CN_Created)) &&
+		block.GetMaxSeqnum() == objectio.TombstoneAttr_PK_SeqNum &&
+		block.ColumnMeta(objectio.TombstoneAttr_Rowid_SeqNum).DataType() == uint8(types.T_Rowid) &&
+		block.ColumnMeta(objectio.TombstoneAttr_PK_SeqNum).DataType() != uint8(types.T_any)
 }
 
 func MakeImmuIndex(


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26991

## What this PR does / why we need it:

This is the `4.2-dev` backport of #26998, adapted to the 4.2 tombstone reader and on-disk layout.

Backup rewrites appendable TN tombstones after filtering rows by the backup timestamp. The old rewrite path used a generic block writer, which assigned dense seqnums to the physical `[rowid, pk, commitTS]` batch. As a result, commitTS was persisted as ordinary seqnum `2` instead of hidden `SEQNUM_COMMITTS`.

The v4.1 reader inferred that trailing column by position, so a v4.1.4 backup restored by v4.1.4 still works. The stricter 4.2 reader treats commitTS as absent, synthesizes a const-null vector with no fixed backing values, and could panic, reject recovery, silently omit tombstones, or conservatively report false PK conflicts depending on the consumer.

This PR closes both the producer and every identified reader boundary.

For newly generated backups, the trim path now produces one canonical non-appendable TN tombstone layout:

```text
physical columns: [rowid, pk, commitTS]
seqnums:          [0, 1, SEQNUM_COMMITTS]
meta columns:     3
max seqnum:       1
```

The producer implementation:

- resolves commitTS, abort, and physical-rowid positions from source object metadata;
- filters aborted rows and rows newer than the backup timestamp before rewriting;
- drops the stale physical row address and the already-consumed abort column;
- writes rewritten tombstones with explicit hidden-column seqnums;
- materializes a valid N-row constant commitTS before `BlockWriter`, whose fixed-width metadata scan otherwise indexes beyond the one-value backing;
- validates malformed source columns and releases rewritten batches on success and error paths without double-freeing shared `objData` references.

For existing malformed Backup artifacts, the reader implementation:

- recognizes only the exact non-CN, non-appendable three-column signature (`meta_columns=3`, `max_seq=2`, `[Rowid, PK, TS]`, and no strict hidden commitTS);
- reloads physical column `2` as commitTS while keeping a timestamp-valued user PK distinct;
- validates commitTS at shared reader boundaries and returns bounded errors for missing, null, wrong-type, length-mismatched, or short-backing vectors;
- preserves valid non-null constant-vector broadcast semantics in point lookup, block-mask evaluation, stats readers, local tombstone application, PK-change checks, and TAE persisted scans;
- routes `persistedNode.Scan` and `CollectObjectTombstoneInRange` through the compatibility mapping, while preserving the established two-column CN tombstone `CreatedAt` semantics;
- releases the first cache lease and temporary vector wrappers before compatibility reload, then transfers or releases the final copy/zero-copy ownership exactly once;
- propagates an initial merge-stats iterator read error instead of silently returning an undercount, while releasing previously admitted iterators.

`4.2-dev` predates the shared `objectio.SpecialColumnLayout` and still uses a reader layout without abort (`[rowid, commitTS]`, or `[rowid, pk, commitTS]` when PK is requested). This backport preserves that 4.2 protocol and keeps an equivalent special-column resolver local to Backup instead of pulling later appendable-object/abort reader changes into the maintenance branch.

The fix is fileservice-backend independent, so DISK, DISK-V2, and S3 Backup rewrites use the same corrected metadata and reader paths.

Validation:

- deterministic old generic-writer artifact consumed through point lookup, block mask, Backup datasource, varlen-PK search, TAE copy Scan, zero-copy Scan, and range collection;
- CN-created two-column control proving Scan and range collection still derive commitTS from object `CreatedAt`;
- timestamp-valued user-PK counterexample proving PK and trailing commitTS remain distinct;
- exact compatibility-reload failure injection and non-legacy error paths with cache-lease accounting;
- source layouts with commitTS only and physical rowid before/after commitTS;
- abort metadata compatibility at the Backup rewrite boundary;
- future, aborted, partially retained, and fully filtered row sets;
- malformed/missing/short/null commitTS returns a bounded error;
- persisted and producer-side N-row constant commitTS broadcast coverage, including `canonicalize -> WriteBatch -> Sync -> ReadDeletes`;
- merge-stats initial reader-error propagation;
- actual 4.2 checkpoint rewrite followed by metadata inspection and `IsRowDeletedByLocation` verification;
- full tests for `pkg/objectio/ioutil`, `pkg/vm/engine/tae/logtail`, `pkg/vm/engine/tae/tables`, `pkg/vm/engine/disttae`, and `pkg/vm/engine/disttae/logtailreplay`;
- affected-package `go list`, build, vet, and scoped `golangci-lint` (0 issues).
