### PR TITLE
fix time timestamp

### DIFF
--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -4685,8 +4685,12 @@ func DatetimeToTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper,
 
 func TimestampToTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	scale := ivecs[0].GetType().Scale
+	loc := time.Local
+	if proc != nil && proc.GetSessionInfo() != nil && proc.GetSessionInfo().TimeZone != nil {
+		loc = proc.GetSessionInfo().TimeZone
+	}
 	return opUnaryFixedToFixed[types.Timestamp, types.Time](ivecs, result, proc, length, func(v types.Timestamp) types.Time {
-		return v.ToDatetime(time.Local).ToTime(scale)
+		return v.ToDatetime(loc).ToTime(scale)
 	}, selectList)
 }
 

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -4678,6 +4678,7 @@ func DateToTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pro
 
 func DatetimeToTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	scale := ivecs[0].GetType().Scale
+	result.GetResultVector().SetTypeScale(scale)
 	return opUnaryFixedToFixed[types.Datetime, types.Time](ivecs, result, proc, length, func(v types.Datetime) types.Time {
 		return v.ToTime(scale)
 	}, selectList)
@@ -4685,6 +4686,7 @@ func DatetimeToTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper,
 
 func TimestampToTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	scale := ivecs[0].GetType().Scale
+	result.GetResultVector().SetTypeScale(scale)
 	loc := time.Local
 	if proc != nil && proc.GetSessionInfo() != nil && proc.GetSessionInfo().TimeZone != nil {
 		loc = proc.GetSessionInfo().TimeZone

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -4111,6 +4111,42 @@ func TestTimestampToTimeUsesSessionTimeZone(t *testing.T) {
 	}
 }
 
+func TestTimeTemporalOverloadsPreserveInputScale(t *testing.T) {
+	var timeFn *FuncNew
+	for i := range supportedDateAndTimeBuiltIns {
+		if supportedDateAndTimeBuiltIns[i].functionId == TIME {
+			timeFn = &supportedDateAndTimeBuiltIns[i]
+			break
+		}
+	}
+	require.NotNil(t, timeFn)
+
+	testCases := []struct {
+		argType types.T
+		scale   int32
+	}{
+		{argType: types.T_datetime, scale: 6},
+		{argType: types.T_timestamp, scale: 6},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.argType.String(), func(t *testing.T) {
+			var matched *overload
+			for i := range timeFn.Overloads {
+				overload := &timeFn.Overloads[i]
+				if len(overload.args) == 1 && overload.args[0] == tc.argType {
+					matched = overload
+					break
+				}
+			}
+			require.NotNil(t, matched)
+
+			got := matched.retType([]types.Type{tc.argType.ToTypeWithScale(tc.scale)})
+			require.Equal(t, types.T_time, got.Oid)
+			require.Equal(t, tc.scale, got.Scale)
+		})
+	}
+}
+
 func initToTimestampCase() []tcTemp {
 	d1, _ := types.ParseDatetime("2022-01-01", 6)
 	d2, _ := types.ParseDatetime("2022-01-01 00:00:00", 6)

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -4062,6 +4062,55 @@ func TestToTime(t *testing.T) {
 	}
 }
 
+func TestTimestampToTimeUsesSessionTimeZone(t *testing.T) {
+	storedUTC, err := types.ParseTimestamp(time.UTC, "2024-01-02 04:30:45.654321", 6)
+	require.NoError(t, err)
+
+	timestampType := types.T_timestamp.ToTypeWithScale(6)
+	timeType := types.T_time.ToTypeWithScale(6)
+	testCases := []struct {
+		name string
+		loc  *time.Location
+		want types.Time
+	}{
+		{
+			name: "utc",
+			loc:  time.UTC,
+			want: types.TimeFromClock(false, 4, 30, 45, 654321),
+		},
+		{
+			name: "utc_plus_8",
+			loc:  time.FixedZone("UTC+8", 8*60*60),
+			want: types.TimeFromClock(false, 12, 30, 45, 654321),
+		},
+		{
+			name: "utc_minus_5",
+			loc:  time.FixedZone("UTC-5", -5*60*60),
+			want: types.TimeFromClock(false, 23, 30, 45, 654321),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			proc.GetSessionInfo().TimeZone = tc.loc
+			fcTC := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(timestampType,
+						[]types.Timestamp{storedUTC},
+						[]bool{false}),
+				},
+				NewFunctionTestResult(timeType, false,
+					[]types.Time{tc.want},
+					[]bool{false}),
+				TimestampToTime)
+			s, info := fcTC.Run()
+			require.True(t, s, info)
+			require.Equal(t, int32(6), fcTC.GetResultVectorDirectly().GetType().Scale)
+		})
+	}
+}
+
 func initToTimestampCase() []tcTemp {
 	d1, _ := types.ParseDatetime("2022-01-01", 6)
 	d2, _ := types.ParseDatetime("2022-01-01 00:00:00", 6)

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -10362,7 +10362,7 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 				overloadId: 2,
 				args:       []types.T{types.T_datetime},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_time.ToType()
+					return types.T_time.ToTypeWithScale(parameters[0].Scale)
 				},
 				newOp: func() executeLogicOfOverload {
 					return DatetimeToTime
@@ -10432,7 +10432,7 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 				overloadId: 9,
 				args:       []types.T{types.T_timestamp},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_time.ToType()
+					return types.T_time.ToTypeWithScale(parameters[0].Scale)
 				},
 				newOp: func() executeLogicOfOverload {
 					return TimestampToTime

--- a/test/distributed/cases/function/func_datetime_subtime.result
+++ b/test/distributed/cases/function/func_datetime_subtime.result
@@ -1,5 +1,5 @@
 SELECT CAST(SUBTIME('2007-12-31 23:59:59.999999', '1 1:1:1.000002') AS CHAR) AS result1;
-➤ result1[12,-1,0]  𝄀
+➤ result1[12,65535,0]  𝄀
 2007-12-30 22:58:58.999997
 SELECT TIME(SUBTIME('15:30:45', '01:15:30')) AS time_sub_time;
 ➤ time_sub_time[92,64,0]  𝄀
@@ -11,7 +11,7 @@ SELECT TIME(SUBTIME('00:00:00', '00:00:01')) AS zero_sub_second;
 ➤ zero_sub_second[92,64,0]  𝄀
 23:59:59
 SELECT CAST(SUBTIME('2007-12-31 23:59:59.999999', '1 1:1:1.000002') AS CHAR) AS datetime_sub_time;
-➤ datetime_sub_time[12,-1,0]  𝄀
+➤ datetime_sub_time[12,65535,0]  𝄀
 2007-12-30 22:58:58.999997
 SELECT SUBTIME('2007-12-31 10:30:45', '02:15:30') AS datetime_sub_hours;
 ➤ datetime_sub_hours[93,64,0]  𝄀
@@ -35,11 +35,11 @@ SELECT SUBTIME('2007-12-31 00:00:00', '1 0:0:0') AS negative_datetime;
 ➤ negative_datetime[93,64,0]  𝄀
 2007-12-30 00:00:00
 SELECT CAST(SUBTIME('2007-12-31 23:59:59.999999', '0 0:0:0.000001') AS CHAR) AS with_microseconds;
-➤ with_microseconds[12,-1,0]  𝄀
+➤ with_microseconds[12,65535,0]  𝄀
 2007-12-31 23:59:59.999998
 SELECT TIME(SUBTIME('15:30:45.500000', '00:00:00.200000')) AS time_with_microseconds;
 ➤ time_with_microseconds[92,64,0]  𝄀
-15:30:45
+15:30:45.300000000
 SELECT SUBTIME(NULL, '01:00:00') AS null_expr1;
 ➤ null_expr1[92,64,0]  𝄀
 null
@@ -63,7 +63,7 @@ SELECT * FROM t1 WHERE SUBTIME(dt, t) < '2007-12-31 00:00:00';
 2007-12-31 23:59:59  ¦  25:01:01
 DROP TABLE t1;
 SELECT CAST(SUBTIME('2007-12-31 23:59:59.999999', '0 0:0:0.000000') AS CHAR) AS no_change;
-➤ no_change[12,-1,0]  𝄀
+➤ no_change[12,65535,0]  𝄀
 2007-12-31 23:59:59.999999
 SELECT SUBTIME('2007-12-31 00:00:00', '0 0:0:1') AS one_second_before;
 ➤ one_second_before[93,64,0]  𝄀

--- a/test/distributed/cases/function/func_datetime_timezone.result
+++ b/test/distributed/cases/function/func_datetime_timezone.result
@@ -200,3 +200,34 @@ select now(6) as value_now, current_timestamp(6) as value_current_timestamp
 value_now    value_current_timestamp    dot_pos_now    dot_pos_current_timestamp    decimal_digits_now    decimal_digits_current_timestamp    last_3_digits_now    last_3_digits_current_timestamp
 2025-11-22 18:07:17.321246000    2025-11-22 18:07:17.321246000    20    20    6    6        
 set time_zone = '+00:00';
+drop table if exists t_time_timestamp_timezone;
+create table t_time_timestamp_timezone (
+id int,
+ts timestamp(6),
+dt datetime(6)
+);
+set time_zone = '+00:00';
+insert into t_time_timestamp_timezone values
+(1, '2024-01-02 04:30:45.654321', '2024-01-02 04:30:45.654321');
+set time_zone = '+08:00';
+select time(ts) as ts_time_plus8,
+time(dt) as dt_time_plus8,
+hour(ts) as ts_hour_plus8,
+minute(ts) as ts_minute_plus8,
+second(ts) as ts_second_plus8,
+microsecond(time(ts)) as ts_micro_plus8
+from t_time_timestamp_timezone;
+ts_time_plus8    dt_time_plus8    ts_hour_plus8    ts_minute_plus8    ts_second_plus8    ts_micro_plus8
+12:30:45.654321000    04:30:45.654321000    12    30    45    654321
+set time_zone = '-05:00';
+select time(ts) as ts_time_minus5,
+time(dt) as dt_time_minus5,
+hour(ts) as ts_hour_minus5,
+minute(ts) as ts_minute_minus5,
+second(ts) as ts_second_minus5,
+microsecond(time(ts)) as ts_micro_minus5
+from t_time_timestamp_timezone;
+ts_time_minus5    dt_time_minus5    ts_hour_minus5    ts_minute_minus5    ts_second_minus5    ts_micro_minus5
+23:30:45.654321000    04:30:45.654321000    23    30    45    654321
+set time_zone = '+00:00';
+drop table if exists t_time_timestamp_timezone;

--- a/test/distributed/cases/function/func_datetime_timezone.test
+++ b/test/distributed/cases/function/func_datetime_timezone.test
@@ -235,3 +235,36 @@ from (
 ) as t;
 
 set time_zone = '+00:00';
+
+-- @case
+-- @desc:TIME(timestamp) follows session time_zone and keeps fractional seconds
+drop table if exists t_time_timestamp_timezone;
+create table t_time_timestamp_timezone (
+    id int,
+    ts timestamp(6),
+    dt datetime(6)
+);
+set time_zone = '+00:00';
+insert into t_time_timestamp_timezone values
+    (1, '2024-01-02 04:30:45.654321', '2024-01-02 04:30:45.654321');
+
+set time_zone = '+08:00';
+select time(ts) as ts_time_plus8,
+       time(dt) as dt_time_plus8,
+       hour(ts) as ts_hour_plus8,
+       minute(ts) as ts_minute_plus8,
+       second(ts) as ts_second_plus8,
+       microsecond(time(ts)) as ts_micro_plus8
+from t_time_timestamp_timezone;
+
+set time_zone = '-05:00';
+select time(ts) as ts_time_minus5,
+       time(dt) as dt_time_minus5,
+       hour(ts) as ts_hour_minus5,
+       minute(ts) as ts_minute_minus5,
+       second(ts) as ts_second_minus5,
+       microsecond(time(ts)) as ts_micro_minus5
+from t_time_timestamp_timezone;
+
+set time_zone = '+00:00';
+drop table if exists t_time_timestamp_timezone;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26978

## What this PR does / why we need it:

• 此分支主要修复 TIME(timestamp_col) 忽略 session time zone 的问题。

  修改内容：

  - TIME(TIMESTAMP) 不再使用服务器本地 time.Local，改为使用 proc.GetSessionInfo().TimeZone。
  - TIME(DATETIME(n)) / TIME(TIMESTAMP(n)) 的返回类型保留入参 scale，避免 timestamp(6) 变成 TIME(0) 丢失小数秒。
  - 新增 UT 覆盖 TIME(timestamp) 在 UTC、+08:00、-05:00 下的转换结果。
  - 新增 BVT 覆盖：
      - TIME(ts) 随 session time_zone 改变；
      - TIME(dt) 不随 time_zone 改变；
      - TIME(ts) 与 HOUR/MINUTE/SECOND(ts) 一致；
      - MICROSECOND(TIME(ts)) 保留精度。
