### PR TITLE
fix(window): evaluate cumulative sum frames linearly

### DIFF
--- a/pkg/sql/colexec/aggexec/sum_decimal_fast.go
+++ b/pkg/sql/colexec/aggexec/sum_decimal_fast.go
@@ -34,6 +34,8 @@ type sumDecimal64FastExec struct {
 	isSum bool
 }
 
+func (*sumDecimal64FastExec) sourcePreservingMerge() {}
+
 func newSumDecimal64FastExec(mp *mpool.MPool, isSum bool, aggID int64, isDistinct bool, param types.Type) AggFuncExec {
 	var exec sumDecimal64FastExec
 	exec.mp = mp
@@ -357,6 +359,8 @@ type sumDecimal128FastExec struct {
 	isSum         bool
 	overflowCheck bool // true when input precision > 28 (SUM can overflow)
 }
+
+func (*sumDecimal128FastExec) sourcePreservingMerge() {}
 
 func newSumDecimal128FastExec(mp *mpool.MPool, isSum bool, aggID int64, isDistinct bool, param types.Type) AggFuncExec {
 	var exec sumDecimal128FastExec

--- a/pkg/sql/colexec/aggexec/sumavg2.go
+++ b/pkg/sql/colexec/aggexec/sumavg2.go
@@ -117,6 +117,8 @@ type sumAvgExec[T float64 | int64 | uint64, A types.Ints | types.UInts | types.F
 	ofCheck func(T, T, T) error
 }
 
+func (*sumAvgExec[T, A]) sourcePreservingMerge() {}
+
 func (exec *sumAvgExec[T, A]) Fill(groupIndex int, row int, vectors []*vector.Vector) error {
 	return exec.BatchFill(row, []uint64{uint64(groupIndex + 1)}, vectors)
 }
@@ -684,6 +686,8 @@ type sumAvgDecExec[A sumAvgDecimalArg, S sumAvgDecimalState] struct {
 	isSum        bool
 	localAddSafe bool // true when state type is wider than arg type (overflow impossible in local buffer)
 }
+
+func (*sumAvgDecExec[A, S]) sourcePreservingMerge() {}
 
 func (exec *sumAvgDecExec[A, S]) Fill(groupIndex int, row int, vectors []*vector.Vector) error {
 	return exec.BatchFill(row, []uint64{uint64(groupIndex + 1)}, vectors)

--- a/pkg/sql/colexec/aggexec/types.go
+++ b/pkg/sql/colexec/aggexec/types.go
@@ -194,6 +194,22 @@ type AggFuncExec interface {
 	Free()
 }
 
+// sourcePreservingMerger is implemented only by aggregate executors whose
+// Merge method leaves the source group unchanged. Merge normally permits
+// ownership transfer because distributed aggregation consumes partial states;
+// window execution needs the stronger contract when it snapshots a running
+// aggregate into multiple result groups.
+type sourcePreservingMerger interface {
+	sourcePreservingMerge()
+}
+
+// MergePreservesSource reports whether repeated merges can safely snapshot
+// exec without consuming or otherwise mutating its source group.
+func MergePreservesSource(exec AggFuncExec) bool {
+	_, ok := exec.(sourcePreservingMerger)
+	return ok
+}
+
 // PrepareParamKindStateAccessor is an optional capability implemented by the
 // aggregate state backed executors.  It exposes the provenance of the value
 // vector without widening AggFuncExec (value-window and other non-serializable

--- a/pkg/sql/colexec/window/types.go
+++ b/pkg/sql/colexec/window/types.go
@@ -41,6 +41,13 @@ type container struct {
 	bat     *batch.Batch
 	batAggs []aggexec.AggFuncExec
 
+	// runningAgg retains the one-group aggregate for a cumulative ROWS frame
+	// between bounded output chunks. runningNextRow is both the continuation
+	// cursor and a guard against accidentally reusing the state out of order.
+	runningAgg       aggexec.AggFuncExec
+	runningNextRow   int
+	runningPartition int
+
 	desc      []bool
 	nullsLast []bool
 	orderVecs []colexec.ExprEvalVector
@@ -112,6 +119,7 @@ func (window *Window) Reset(proc *process.Process, pipelineFailed bool, err erro
 	// otherwise keep their accumulated state (e.g. json payloads, distinct
 	// hashes) in the mpool until the next reuse.
 	ctr.freeAggFun()
+	ctr.freeRunningAgg()
 	if ctr.bat != nil {
 		ctr.bat.CleanOnlyData()
 	}
@@ -125,6 +133,7 @@ func (window *Window) Free(proc *process.Process, pipelineFailed bool, err error
 	// Free aggregators before the batch so an error exit from Call (which skips
 	// the normal freeAggFun()) does not leak their mpool-held state.
 	ctr.freeAggFun()
+	ctr.freeRunningAgg()
 	ctr.freeBatch(proc.Mp())
 	ctr.freeExes()
 	ctr.freeVector(proc.Mp())
@@ -182,6 +191,15 @@ func (ctr *container) freeAggFun() {
 		}
 	}
 	ctr.batAggs = nil
+}
+
+func (ctr *container) freeRunningAgg() {
+	if ctr.runningAgg != nil {
+		ctr.runningAgg.Free()
+		ctr.runningAgg = nil
+	}
+	ctr.runningNextRow = 0
+	ctr.runningPartition = 0
 }
 
 func (ctr *container) freeExes() {

--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -251,6 +251,10 @@ func (window *Window) Call(proc *process.Process) (vm.CallResult, error) {
 			}
 		case eval:
 			result := vm.NewCallResult()
+			// A new materialized input batch starts a new aggregate generation.
+			// Normally the previous generation is released after its last chunk;
+			// this also closes reuse after an interrupted or failed generation.
+			ctr.freeRunningAgg()
 			if err = ctr.evalAggVector(ctr.bat, proc); err != nil {
 				return result, err
 			}
@@ -394,6 +398,21 @@ func (ctr *container) makeAggregateExecutor(
 ) error {
 	ctr.freeAggFun()
 	ctr.batAggs = make([]aggexec.AggFuncExec, len(ap.Aggs))
+	exec, err := ctr.newAggregateExecutor(idx, ap, proc, groupCount)
+	if err != nil {
+		ctr.batAggs = nil
+		return err
+	}
+	ctr.batAggs[idx] = exec
+	return nil
+}
+
+func (ctr *container) newAggregateExecutor(
+	idx int,
+	ap *Window,
+	proc *process.Process,
+	groupCount int,
+) (aggexec.AggFuncExec, error) {
 	ag := ap.Aggs[idx]
 	// Derive one argument type per aggregate argument so multi-argument
 	// window aggregates (for example json_objectagg) match Group's contract.
@@ -405,23 +424,26 @@ func (ctr *container) makeAggregateExecutor(
 		)
 	}
 
-	var err error
-	ctr.batAggs[idx], err = aggexec.MakeAgg(proc.Mp(), ag.GetAggID(), ag.IsDistinct(), argTypes...)
+	exec, err := aggexec.MakeAgg(proc.Mp(), ag.GetAggID(), ag.IsDistinct(), argTypes...)
 	if err != nil {
-		ctr.freeAggFun()
-		return err
+		return nil, err
 	}
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			exec.Free()
+		}
+	}()
 	if config := ag.GetExtraInformation(); config != nil {
-		if err = ctr.batAggs[idx].SetExtraInformation(config, 0); err != nil {
-			ctr.freeAggFun()
-			return err
+		if err = exec.SetExtraInformation(config, 0); err != nil {
+			return nil, err
 		}
 	}
-	if err = ctr.batAggs[idx].GroupGrow(groupCount); err != nil {
-		ctr.freeAggFun()
-		return err
+	if err = exec.GroupGrow(groupCount); err != nil {
+		return nil, err
 	}
-	return nil
+	succeeded = true
+	return exec, nil
 }
 
 func (ctr *container) processAggregateFuncRange(
@@ -436,8 +458,14 @@ func (ctr *container) processAggregateFuncRange(
 	}
 	defer ctr.freeAggFun()
 
-	n := ctr.bat.RowCount()
 	w := ap.WinSpecList[idx].Expr.(*plan.Expr_W).W
+	frame := ctr.frameAt(idx, w.Frame)
+	if cumulativeRowsFrame(frame, ctr.ps, ctr.bat.RowCount()) &&
+		aggexec.MergePreservesSource(ctr.batAggs[idx]) {
+		return ctr.processCumulativeAggregateFuncRange(idx, ap, proc, outputStart, outputEnd)
+	}
+
+	n := ctr.bat.RowCount()
 	for j := outputStart; j < outputEnd; j++ {
 		if err := checkCanceled(proc, j-outputStart); err != nil {
 			return nil, err
@@ -449,7 +477,7 @@ func (ctr *container) processAggregateFuncRange(
 		}
 
 		left, right, err := ctr.buildInterval(
-			j, partitionStart, partitionEnd, ctr.frameAt(idx, w.Frame))
+			j, partitionStart, partitionEnd, frame)
 		if err != nil {
 			return nil, err
 		}
@@ -484,6 +512,137 @@ func (ctr *container) processAggregateFuncRange(
 	// Aggregate state initializes its physical capacity as NULL. Keep only
 	// logical-row nulls so downstream HasNull checks do not see an unused tail.
 	nulls.RemoveRange(vec.GetNulls(), uint64(vec.Length()), math.MaxUint64)
+	return vec, nil
+}
+
+// cumulativeRowsFrame reports whether every frame in the materialized batch
+// starts at its partition boundary and ends at the current row. A finite
+// PRECEDING bound is equivalent to UNBOUNDED PRECEDING when it covers the
+// largest runtime partition.
+func cumulativeRowsFrame(frame *plan.FrameClause, partitions []int64, rowCount int) bool {
+	if frame == nil || frame.Type != plan.FrameClause_ROWS ||
+		frame.Start == nil || frame.End == nil ||
+		frame.Start.Type != plan.FrameBound_PRECEDING ||
+		frame.End.Type != plan.FrameBound_CURRENT_ROW || frame.End.UnBounded {
+		return false
+	}
+	if frame.Start.UnBounded {
+		return true
+	}
+	if frame.Start.Val == nil || frame.Start.Val.GetLit() == nil {
+		return false
+	}
+	bound, ok := frame.Start.Val.GetLit().Value.(*plan.Literal_U64Val)
+	if !ok {
+		return false
+	}
+
+	maxPartitionRows, ok := largestPartitionSize(partitions, rowCount)
+	if !ok {
+		return false
+	}
+	if maxPartitionRows <= 1 {
+		return true
+	}
+	return bound.U64Val >= uint64(maxPartitionRows-1)
+}
+
+func largestPartitionSize(partitions []int64, rowCount int) (int, bool) {
+	if rowCount < 0 {
+		return 0, false
+	}
+	if len(partitions) == 0 {
+		return rowCount, true
+	}
+	if partitions[0] != 0 {
+		return 0, false
+	}
+
+	maxRows := 0
+	for i, start := range partitions {
+		end := int64(rowCount)
+		if i+1 < len(partitions) {
+			end = partitions[i+1]
+		}
+		if start < 0 || end <= start || end > int64(rowCount) {
+			return 0, false
+		}
+		maxRows = max(maxRows, int(end-start))
+	}
+	return maxRows, true
+}
+
+func partitionEnd(partitions []int64, partition int, rowCount int) int {
+	if len(partitions) == 0 || partition+1 >= len(partitions) {
+		return rowCount
+	}
+	return int(partitions[partition+1])
+}
+
+// processCumulativeAggregateFuncRange advances one aggregate state per input
+// row and snapshots it into the corresponding output group. This changes
+// fixed-size cumulative aggregates such as SUM from O(partitionRows^2) Fill
+// calls to O(partitionRows), while retaining state across output chunks.
+func (ctr *container) processCumulativeAggregateFuncRange(
+	idx int,
+	ap *Window,
+	proc *process.Process,
+	outputStart int,
+	outputEnd int,
+) (_ *vector.Vector, retErr error) {
+	if outputStart != ctr.runningNextRow {
+		ctr.freeRunningAgg()
+		return nil, moerr.NewInternalErrorNoCtx("cumulative window output is not sequential")
+	}
+	defer func() {
+		if retErr != nil {
+			ctr.freeRunningAgg()
+		}
+	}()
+
+	if ctr.runningAgg == nil {
+		ctr.runningAgg, retErr = ctr.newAggregateExecutor(idx, ap, proc, 1)
+		if retErr != nil {
+			return nil, retErr
+		}
+	}
+
+	n := ctr.bat.RowCount()
+	currentPartitionEnd := partitionEnd(ctr.ps, ctr.runningPartition, n)
+	for j := outputStart; j < outputEnd; j++ {
+		if err := checkCanceled(proc, j-outputStart); err != nil {
+			return nil, err
+		}
+		if j == currentPartitionEnd {
+			ctr.runningAgg.Free()
+			ctr.runningAgg, retErr = ctr.newAggregateExecutor(idx, ap, proc, 1)
+			if retErr != nil {
+				return nil, retErr
+			}
+			ctr.runningPartition++
+			currentPartitionEnd = partitionEnd(ctr.ps, ctr.runningPartition, n)
+		}
+		if err := ctr.runningAgg.Fill(0, j, ctr.aggVecs[idx].Vec); err != nil {
+			return nil, err
+		}
+		if err := ctr.batAggs[idx].Merge(ctr.runningAgg, j-outputStart, 0); err != nil {
+			return nil, err
+		}
+		ctr.runningNextRow = j + 1
+	}
+
+	vecs, err := ctr.batAggs[idx].Flush()
+	if err != nil {
+		return nil, err
+	}
+	vec, err := aggexec.MergeSplitResult(vecs, proc.Mp())
+	if err != nil {
+		return nil, err
+	}
+	nulls.RemoveRange(vec.GetNulls(), uint64(vec.Length()), math.MaxUint64)
+	if outputEnd == n {
+		ctr.freeRunningAgg()
+	}
 	return vec, nil
 }
 

--- a/pkg/sql/colexec/window/window_benchmark_test.go
+++ b/pkg/sql/colexec/window/window_benchmark_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm"
 )
 
-// BenchmarkWindowFirstBatch models a LIMIT consumer: it asks Window for only
-// the first output batch and then resets the pipeline. The input is large
-// enough to cross eight aggregate-result chunks.
+// BenchmarkWindowFirstBatch models the #23107 LIMIT consumer: it asks Window
+// for only the first output batch of a large cumulative frame and then resets
+// the pipeline.
 func BenchmarkWindowFirstBatch(b *testing.B) {
 	const rows = colexec.DefaultBatchSize * 8
 
@@ -44,7 +44,7 @@ func BenchmarkWindowFirstBatch(b *testing.B) {
 		input.SetRowCount(rows)
 
 		spec := makeWindowSpec()
-		spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+		spec.Expr.(*plan.Expr_W).W.Frame = makeFiniteCumulativeFrame(2147483647)
 		arg := &Window{
 			WinSpecList: []*plan.Expr{spec},
 			Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},

--- a/pkg/sql/colexec/window/window_test.go
+++ b/pkg/sql/colexec/window/window_test.go
@@ -187,6 +187,34 @@ func TestWindowFrameEvaluationHonorsCancellation(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
+func TestCumulativeWindowCancellationReleasesState(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	const rows = cancellationCheckInterval * 2
+	values := make([]int32, rows)
+	bat := makeInt32Batch(proc.Mp(), values)
+	spec := makeWindowSpec()
+	spec.GetW().Frame = makeCumulativeFrame()
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
+	}
+	require.NoError(t, arg.Prepare(proc))
+	arg.ctr.bat = bat
+	require.NoError(t, arg.ctr.evalAggVector(bat, proc))
+
+	// Cancel at the second polling interval, after the running aggregate has
+	// accumulated state, to exercise the mid-chunk cleanup path.
+	proc.Ctx = newCancelAfterDoneChecksContext(proc.Ctx, 2)
+	err := arg.ctr.processFunc(0, arg, proc, arg.OpAnalyzer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, arg.ctr.batAggs)
+	require.Nil(t, arg.ctr.runningAgg)
+
+	arg.Free(proc, true, err)
+	proc.Free()
+	require.Zero(t, proc.Mp().CurrNB())
+}
+
 func TestWindowCallHonorsPreCancellation(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	ctx, cancel := context.WithCancel(proc.Ctx)
@@ -228,6 +256,30 @@ func makeCurrentRowFrame() *plan.FrameClause {
 		Type:  plan.FrameClause_ROWS,
 		Start: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
 		End:   &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+	}
+}
+
+func makeCumulativeFrame() *plan.FrameClause {
+	return &plan.FrameClause{
+		Type: plan.FrameClause_ROWS,
+		Start: &plan.FrameBound{
+			Type:      plan.FrameBound_PRECEDING,
+			UnBounded: true,
+		},
+		End: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+	}
+}
+
+func makeFiniteCumulativeFrame(preceding uint64) *plan.FrameClause {
+	return &plan.FrameClause{
+		Type: plan.FrameClause_ROWS,
+		Start: &plan.FrameBound{
+			Type: plan.FrameBound_PRECEDING,
+			Val: &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+				Value: &plan.Literal_U64Val{U64Val: preceding},
+			}}},
+		},
+		End: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
 	}
 }
 
@@ -491,6 +543,38 @@ func TestWindowPrepareFrameBoundsFeedAggregateConsumer(t *testing.T) {
 	require.Zero(t, proc.Mp().CurrNB())
 }
 
+func TestWindowPreparedCumulativeBoundUsesRuntimeValue(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	planned := &plan.FrameClause{
+		Type: plan.FrameClause_ROWS,
+		Start: &plan.FrameBound{
+			Type: plan.FrameBound_PRECEDING,
+			Val:  makePreparedRowsBoundExpr(t, 0),
+		},
+		End: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+	}
+	arg := makeWindowWithFrame(planned)
+	bat := makeInt32Batch(proc.Mp(), []int32{10, 20, 30, 40})
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+	params := setWindowPrepareParams(t, proc, stringPtr("2147483647"))
+
+	require.NoError(t, arg.Prepare(proc))
+	require.True(t, cumulativeRowsFrame(arg.ctr.runtimeFrames[0], nil, bat.RowCount()))
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.Equal(t, []int64{10, 30, 60, 100},
+		vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1]))
+	requirePreparedRowsBoundUnchanged(t, planned.Start.Val, 0)
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.SetPrepareParams(nil)
+	params.Free(proc.Mp())
+	proc.Free()
+	require.Zero(t, proc.Mp().CurrNB())
+}
+
 func TestWindowPrepareFrameBoundsFeedValueConsumers(t *testing.T) {
 	tests := []struct {
 		name string
@@ -588,6 +672,38 @@ func TestBuildRowsIntervalSaturatesLargeOffsets(t *testing.T) {
 			start, end := ctr.buildRowsInterval(12, 10, 15, testCase.frame)
 			require.Equal(t, testCase.wantStart, start)
 			require.Equal(t, testCase.wantEnd, end)
+		})
+	}
+}
+
+func TestCumulativeRowsFrameEligibility(t *testing.T) {
+	tests := []struct {
+		name       string
+		frame      *plan.FrameClause
+		partitions []int64
+		rows       int
+		want       bool
+	}{
+		{name: "unbounded", frame: makeCumulativeFrame(), rows: 4, want: true},
+		{name: "finite covers partition", frame: makeFiniteCumulativeFrame(3), rows: 4, want: true},
+		{name: "finite shorter than partition", frame: makeFiniteCumulativeFrame(2), rows: 4},
+		{name: "finite covers largest partition", frame: makeFiniteCumulativeFrame(2), partitions: []int64{0, 3, 5}, rows: 7, want: true},
+		{name: "finite shorter than one partition", frame: makeFiniteCumulativeFrame(1), partitions: []int64{0, 3, 5}, rows: 7},
+		{name: "current row start", frame: makeCurrentRowFrame(), rows: 4},
+		{name: "following end", frame: makeFullFrame(), rows: 4},
+		{name: "range frame", frame: &plan.FrameClause{
+			Type:  plan.FrameClause_RANGE,
+			Start: &plan.FrameBound{Type: plan.FrameBound_PRECEDING, UnBounded: true},
+			End:   &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+		}, rows: 4},
+		{name: "invalid partitions", frame: makeFiniteCumulativeFrame(10), partitions: []int64{1}, rows: 4},
+		{name: "empty partition", frame: makeFiniteCumulativeFrame(10), partitions: []int64{0, 0}, rows: 4},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want,
+				cumulativeRowsFrame(test.frame, test.partitions, test.rows))
 		})
 	}
 }
@@ -698,8 +814,10 @@ func TestWindowJsonObjectAggOutput(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	bat := makeKeyValBatch(proc.Mp(), []string{"k1", "k2", "k3"}, nil, []int32{10, 20, 30})
 
+	spec := makeAggWindowSpec("json_objectagg")
+	spec.GetW().Frame = makeCumulativeFrame()
 	arg := &Window{
-		WinSpecList: []*plan.Expr{makeAggWindowSpec("json_objectagg")},
+		WinSpecList: []*plan.Expr{spec},
 		Aggs:        []aggexec.AggFuncExecExpression{jsonObjectAggColExpr(t, 0, 1)},
 		OperatorBase: vm.OperatorBase{
 			OperatorInfo: vm.OperatorInfo{Idx: 0},
@@ -715,11 +833,17 @@ func TestWindowJsonObjectAggOutput(t *testing.T) {
 
 	resVec := result.Batch.Vecs[len(result.Batch.Vecs)-1]
 	require.Equal(t, 3, resVec.Length())
-	// Full frame over a single partition: every row aggregates the whole partition.
-	want := `{"k1": 10, "k2": 20, "k3": 30}`
-	for i := 0; i < resVec.Length(); i++ {
-		require.Equal(t, want, types.DecodeJson(resVec.GetBytesAt(i)).String(), "row %d", i)
+	// JSON aggregate Merge may consume its source state, so it must retain the
+	// ordinary frame evaluator instead of entering the SUM/AVG cumulative path.
+	want := []string{
+		`{"k1": 10}`,
+		`{"k1": 10, "k2": 20}`,
+		`{"k1": 10, "k2": 20, "k3": 30}`,
 	}
+	for i := 0; i < resVec.Length(); i++ {
+		require.Equal(t, want[i], types.DecodeJson(resVec.GetBytesAt(i)).String(), "row %d", i)
+	}
+	require.Nil(t, arg.ctr.runningAgg)
 
 	arg.Free(proc, false, nil)
 	op.Free(proc, false, nil)
@@ -779,9 +903,8 @@ func collectFixedWindowColumn[T types.FixedSizeT](
 	}
 }
 
-// TestWindowAggResultAcrossChunks verifies that Window exposes one logical
-// result as bounded output batches. CURRENT ROW keeps the test O(n) while the
-// input crosses AggBatchSize.
+// TestWindowAggResultAcrossChunks verifies that a cumulative aggregate retains
+// its running state across bounded output batches.
 func TestWindowAggResultAcrossChunks(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	rows := aggexec.AggBatchSize + 17
@@ -798,7 +921,7 @@ func TestWindowAggResultAcrossChunks(t *testing.T) {
 	second.SetRowCount(rows - split)
 
 	spec := makeWindowSpec()
-	spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+	spec.Expr.(*plan.Expr_W).W.Frame = makeCumulativeFrame()
 	arg := &Window{
 		WinSpecList: []*plan.Expr{spec},
 		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
@@ -813,8 +936,10 @@ func TestWindowAggResultAcrossChunks(t *testing.T) {
 	resultValues := collectFixedWindowColumn[int64](t, arg, proc, 1)
 	require.Len(t, resultValues, rows)
 	for _, idx := range []int{0, aggexec.AggBatchSize - 1, aggexec.AggBatchSize, rows - 1} {
-		require.Equal(t, int64(values[idx]), resultValues[idx], "row %d", idx)
+		want := int64(idx+1) * int64(idx+2) / 2
+		require.Equal(t, want, resultValues[idx], "row %d", idx)
 	}
+	require.Nil(t, arg.ctr.runningAgg)
 
 	arg.Free(proc, false, nil)
 	op.Free(proc, false, nil)
@@ -1203,7 +1328,7 @@ func TestWindowResetBeforeAllChunksReleasesState(t *testing.T) {
 	bat.SetRowCount(rows)
 
 	spec := makeWindowSpec()
-	spec.Expr.(*plan.Expr_W).W.Frame = makeCurrentRowFrame()
+	spec.Expr.(*plan.Expr_W).W.Frame = makeCumulativeFrame()
 	arg := &Window{
 		WinSpecList: []*plan.Expr{spec},
 		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
@@ -1221,13 +1346,70 @@ func TestWindowResetBeforeAllChunksReleasesState(t *testing.T) {
 	require.Equal(t, colexec.DefaultBatchSize, arg.ctr.emitOffset)
 	require.Equal(t, emit, arg.ctr.status)
 	require.Nil(t, arg.ctr.batAggs)
+	require.NotNil(t, arg.ctr.runningAgg)
 
 	// Model LIMIT stopping the pipeline after the first output chunk.
 	arg.Reset(proc, false, nil)
+	require.Nil(t, arg.ctr.runningAgg)
 	arg.Free(proc, false, nil)
 	op.Free(proc, false, nil)
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestCumulativeAggregateResetsAtPartitionBoundary(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	bat := makeInt32Batch(proc.Mp(), []int32{1, 2, 10, 20})
+	spec := makeWindowSpec()
+	spec.GetW().Frame = makeFiniteCumulativeFrame(1)
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
+	}
+	ctr := &container{
+		bat:     bat,
+		ps:      []int64{0, 2},
+		aggVecs: []colexec.ExprEvalVector{{Vec: []*vector.Vector{bat.Vecs[0]}}},
+	}
+
+	result, err := ctr.processAggregateFuncRange(0, arg, proc, 0, bat.RowCount())
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 3, 10, 30},
+		vector.MustFixedColWithTypeCheck[int64](result))
+	require.Nil(t, ctr.runningAgg)
+
+	result.Free(proc.Mp())
+	bat.Clean(proc.Mp())
+	proc.Free()
+	require.Zero(t, proc.Mp().CurrNB())
+}
+
+func TestCumulativeAggregatePreservesNullSemantics(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 0, 3}, []uint64{1}, proc.Mp())
+	bat.SetRowCount(3)
+	spec := makeWindowSpec()
+	spec.GetW().Frame = makeCumulativeFrame()
+	arg := &Window{
+		WinSpecList: []*plan.Expr{spec},
+		Aggs:        []aggexec.AggFuncExecExpression{newAggExpr()},
+	}
+	ctr := &container{
+		bat:     bat,
+		aggVecs: []colexec.ExprEvalVector{{Vec: []*vector.Vector{bat.Vecs[0]}}},
+	}
+
+	result, err := ctr.processAggregateFuncRange(0, arg, proc, 0, bat.RowCount())
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 1, 4},
+		vector.MustFixedColWithTypeCheck[int64](result))
+	require.False(t, result.HasNull())
+
+	result.Free(proc.Mp())
+	bat.Clean(proc.Mp())
+	proc.Free()
+	require.Zero(t, proc.Mp().CurrNB())
 }
 
 func TestWindowOrdersPartitionedInput(t *testing.T) {

--- a/test/distributed/cases/window/window.result
+++ b/test/distributed/cases/window/window.result
@@ -4832,6 +4832,24 @@ id    k_label    v    cnt_rng
 4    1    11    4
 5    NULL    20    6
 6    NULL    30    6
+create table t_window_23107(id int);
+insert into t_window_23107 values (1), (2), (3), (4), (5), (6),
+(7), (8), (9), (10), (11), (12);
+select id,
+sum(id) over (order by id rows between 2147483647 preceding and current row) as running_sum
+from t_window_23107 limit 10;
+id    running_sum
+1    1
+2    3
+3    6
+4    10
+5    15
+6    21
+7    28
+8    36
+9    45
+10    55
+drop table t_window_23107;
 drop table t_desc;
 drop database test_range_desc;
 drop database test;

--- a/test/distributed/cases/window/window.sql
+++ b/test/distributed/cases/window/window.sql
@@ -1731,6 +1731,16 @@ select id, ifnull(cast(k as char), 'NULL') as k_label, v,
        count(*) over (order by k desc range between unbounded preceding and current row) as cnt_rng
 from t_desc order by k desc, id;
 
+-- Regression for issue #23107: a very large finite PRECEDING bound covers the
+-- partition and must use the cumulative window path.
+create table t_window_23107(id int);
+insert into t_window_23107 values (1), (2), (3), (4), (5), (6),
+  (7), (8), (9), (10), (11), (12);
+select id,
+       sum(id) over (order by id rows between 2147483647 preceding and current row) as running_sum
+from t_window_23107 limit 10;
+drop table t_window_23107;
+
 drop table t_desc;
 drop database test_range_desc;
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23107

## What this PR does / why we need it:

Recognizes ROWS frames ending at CURRENT ROW whose PRECEDING bound covers the runtime partition and evaluates SUM/AVG with one source-preserving running aggregate state. This avoids replaying every prefix for every output row while retaining state across bounded output chunks and resetting it at partition boundaries.

Aggregate executors must explicitly opt into the source-preserving Merge contract; aggregates whose Merge may consume the source retain the existing evaluator.

Adds prepared-bound, partition, NULL, cancellation, early Reset, multi-chunk, SQL regression, and benchmark coverage. The first-batch benchmark for the issue shape improves from about 3.0 s to about 1.25 ms locally.

Tests:
- .agents/skills/mo-dev/scripts/mo-cgo-test ./pkg/sql/colexec/aggexec ./pkg/sql/colexec/window -count=1
- .agents/skills/mo-dev/scripts/mo-cgo-test ./pkg/sql/colexec/window -run '^$' -bench '^BenchmarkWindowFirstBatch$' -benchtime=5x -count=1