### PR TITLE
fix time window units

### DIFF
--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -4615,6 +4615,9 @@ func (builder *QueryBuilder) bindSelect(stmt *tree.Select, ctx *BindContext, isR
 	ctx.windowTag = builder.genNewBindTag()
 	ctx.sampleTag = builder.genNewBindTag()
 	if astTimeWindow != nil {
+		if err = validateTimeWindowIntervalUnits(builder.GetContext(), astTimeWindow); err != nil {
+			return
+		}
 		ctx.timeTag = builder.genNewBindTag() // ctx.timeTag > 0
 		// GAPFILL uses the same second-stage aggregate state machine as an
 		// explicit sliding window even when its external SQL is a tumbling
@@ -7559,6 +7562,10 @@ func (builder *QueryBuilder) bindTimeWindow(
 	boundTimeWindowOrderBy *plan.OrderBySpec,
 	err error,
 ) {
+	if err = validateTimeWindowIntervalUnits(builder.GetContext(), astTimeWindow); err != nil {
+		return
+	}
+
 	h := projectionBinder.havingBinder
 	col, err := ctx.qualifyColumnNames(astTimeWindow.Interval.Col, NoAlias)
 	if err != nil {
@@ -8893,6 +8900,36 @@ func makeHelpFuncForTimeWindow(astTimeWindow *tree.TimeWindow) (*helpFunc, error
 		}
 	}
 	return h, nil
+}
+
+const unsupportedTimeWindowIntervalUnit = "Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit"
+
+func validateTimeWindowIntervalUnits(ctx context.Context, astTimeWindow *tree.TimeWindow) error {
+	if astTimeWindow == nil {
+		return nil
+	}
+	if err := validateTimeWindowIntervalUnit(ctx, astTimeWindow.Interval.Unit); err != nil {
+		return err
+	}
+	if astTimeWindow.Sliding != nil {
+		if err := validateTimeWindowIntervalUnit(ctx, astTimeWindow.Sliding.Unit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTimeWindowIntervalUnit(ctx context.Context, unit string) error {
+	typ, err := types.IntervalTypeOf(unit)
+	if err != nil {
+		return err
+	}
+	switch typ {
+	case types.Second, types.Minute, types.Hour, types.Day:
+		return nil
+	default:
+		return moerr.NewNotSupported(ctx, unsupportedTimeWindowIntervalUnit)
+	}
 }
 
 func appendSelectList(

--- a/pkg/sql/plan/query_builder_test.go
+++ b/pkg/sql/plan/query_builder_test.go
@@ -2517,6 +2517,96 @@ func genBuilderAndCtxWithColumnType(typ types.T, colName string) (*QueryBuilder,
 	return builder, bindCtx
 }
 
+func TestQueryBuilder_bindTimeWindowRejectsUnsupportedUnitsBeforeCompile(t *testing.T) {
+	tests := []struct {
+		name         string
+		intervalUnit string
+		slidingUnit  string
+	}{
+		{
+			name:         "interval month",
+			intervalUnit: "month",
+		},
+		{
+			name:         "interval week",
+			intervalUnit: "week",
+		},
+		{
+			name:         "interval year",
+			intervalUnit: "year",
+		},
+		{
+			name:         "interval quarter",
+			intervalUnit: "quarter",
+		},
+		{
+			name:         "sliding month",
+			intervalUnit: "second",
+			slidingUnit:  "month",
+		},
+		{
+			name:         "sliding week",
+			intervalUnit: "day",
+			slidingUnit:  "week",
+		},
+		{
+			name:         "sliding year",
+			intervalUnit: "hour",
+			slidingUnit:  "year",
+		},
+		{
+			name:         "sliding quarter",
+			intervalUnit: "minute",
+			slidingUnit:  "quarter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, bindCtx := genBuilderAndCtxWithColumnType(types.T_timestamp, "ts")
+			havingBinder := NewHavingBinder(builder, bindCtx)
+			projectionBinder := NewProjectionBinder(builder, bindCtx, havingBinder)
+
+			astTimeWindow := &tree.TimeWindow{
+				Interval: &tree.Interval{
+					Col:  tree.NewUnresolvedName(tree.NewCStr("ts", 0)),
+					Val:  tree.NewNumVal(int64(1), "1", false, tree.P_int64),
+					Unit: tt.intervalUnit,
+				},
+			}
+			if tt.slidingUnit != "" {
+				astTimeWindow.Sliding = &tree.Sliding{
+					Val:  tree.NewNumVal(int64(1), "1", false, tree.P_int64),
+					Unit: tt.slidingUnit,
+				}
+			}
+
+			helpFunc, err := makeHelpFuncForTimeWindow(astTimeWindow)
+			require.NoError(t, err)
+			timeWindowGroup := &plan.Expr{
+				Typ: plan.Type{Id: int32(types.T_datetime)},
+				Expr: &plan.Expr_Col{
+					Col: &plan.ColRef{RelPos: 1, ColPos: 0},
+				},
+			}
+
+			_, _, _, _, _, _, _, _, err = builder.bindTimeWindow(
+				bindCtx,
+				projectionBinder,
+				astTimeWindow,
+				timeWindowGroup,
+				helpFunc,
+			)
+			require.ErrorContains(t, err, unsupportedTimeWindowIntervalUnit)
+		})
+	}
+}
+
+func TestValidateTimeWindowIntervalUnitRejectsInvalidUnit(t *testing.T) {
+	err := validateTimeWindowIntervalUnit(context.Background(), "century")
+	require.ErrorContains(t, err, "invalid interval type 'century'")
+}
+
 func TestQueryBuilder_bindTimeWindow(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/test/distributed/cases/window/time_window.result
+++ b/test/distributed/cases/window/time_window.result
@@ -853,4 +853,23 @@ drop table if exists tt1;
 create table tt1(ts timestamp primary key, a int);
 select max(a) as enable, min(a) as collation from tt1 interval(ts, 1, minute);
 ➤ enable[4,32,0]  ¦  collation[4,32,0]
+drop table if exists tw_interval_bad_unit;
+create table tw_interval_bad_unit(ts timestamp(6), v int);
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, month);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, week);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, year);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, quarter);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, month);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, week);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, year);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, quarter);
+not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
+drop table tw_interval_bad_unit;
 drop database time_window;

--- a/test/distributed/cases/window/time_window.sql
+++ b/test/distributed/cases/window/time_window.sql
@@ -282,4 +282,33 @@ drop table if exists tt1;
 create table tt1(ts timestamp primary key, a int);
 select max(a) as enable, min(a) as collation from tt1 interval(ts, 1, minute);
 
+-- unsupported calendar units should return a normal SQL error, not enter the compile panic path
+drop table if exists tw_interval_bad_unit;
+create table tw_interval_bad_unit(ts timestamp(6), v int);
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, month);
+-- @bvt:issue
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, week);
+-- @bvt:issue
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, year);
+-- @bvt:issue
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, quarter);
+-- @bvt:issue
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, month);
+-- @bvt:issue
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, week);
+-- @bvt:issue
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, year);
+-- @bvt:issue
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, day) sliding(1, quarter);
+-- @bvt:issue
+drop table tw_interval_bad_unit;
+
 drop database time_window;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26980

## What this PR does / why we need it:

• 此分支当前主要修改了 time-window 不支持时间单位的错误路径：

  - 在 planner/binder 阶段提前校验 INTERVAL/SLIDING 的单位，只允许 SECOND/MINUTE/HOUR/DAY。
  - 对 MONTH/WEEK/YEAR/QUARTER 返回普通 not supported SQL 错误，避免进入 compile 阶段触发 panic in compile 日志。
  - 保留执行器侧原有 unsupported 兜底逻辑，但正常 SQL 已不会走到 compile panic-path。
  - 补充单测覆盖：
      - interval(..., month/week/year/quarter)
      - sliding(..., month/week/year/quarter)
      - validator 对非法 unit 字符串的处理。

  - 补充 BVT 覆盖上述 SQL 错误路径，并移除了 parser 直接拒绝的 century case。

  验证已通过目标 Go 测试和 git diff --check。
