### PR TITLE
fix(stage): detect cyclic stage references during resolution (#26890)

### DIFF
--- a/pkg/stage/stageutil/stageutil.go
+++ b/pkg/stage/stageutil/stageutil.go
@@ -33,12 +33,33 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
+// ExpandSubStage resolves a stage:// URL down to its concrete backing URL, following each
+// stage-to-stage reference in turn.
+//
+// A cyclic definition (a -> a, or a -> b -> a) has no concrete URL to reach, so the walk is
+// terminated by the visited set below and reported as a bounded error. Nothing rejects such a
+// definition at CREATE/ALTER STAGE time, and the cycle can be closed by altering any node in the
+// chain, so resolution is where it must be caught: without the check the walk never ends, and
+// because StageLoadCatalog serves repeat lookups from proc's stage cache it spins with no SQL and
+// no I/O — the CN request hangs rather than failing (#26890).
 func ExpandSubStage(s stage.StageDef, proc *process.Process) (stage.StageDef, error) {
-	if s.Url.Scheme == stage.STAGE_PROTOCOL {
+	// Stage names already expanded on this chain, in order, for both the cycle test and the error
+	// message. The walk is bounded by the number of distinct stages: every hop consumes one name.
+	visited := make(map[string]struct{})
+	var chain []string
+
+	for s.Url.Scheme == stage.STAGE_PROTOCOL {
 		stagename, prefix, query, err := stage.ParseStageUrl(s.Url)
 		if err != nil {
 			return stage.StageDef{}, err
 		}
+
+		if _, seen := visited[stagename]; seen {
+			return stage.StageDef{}, moerr.NewBadConfigf(context.TODO(),
+				"cyclic stage reference: %s -> %s", strings.Join(chain, " -> "), stagename)
+		}
+		visited[stagename] = struct{}{}
+		chain = append(chain, stagename)
 
 		res, err := StageLoadCatalog(proc, stagename)
 		if err != nil {
@@ -47,7 +68,7 @@ func ExpandSubStage(s stage.StageDef, proc *process.Process) (stage.StageDef, er
 
 		res.Url = res.Url.JoinPath(prefix)
 		res.Url.RawQuery = query
-		return ExpandSubStage(res, proc)
+		s = res
 	}
 
 	return s, nil

--- a/pkg/stage/stageutil/stageutil_test.go
+++ b/pkg/stage/stageutil/stageutil_test.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/stage"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
 func TestStageCache(t *testing.T) {
@@ -84,6 +86,78 @@ func TestStageFail(t *testing.T) {
 
 	_, err = UrlToStageDef("not a url", proc)
 	require.NotNil(t, err)
+}
+
+// setStage seeds the process stage cache so resolution runs entirely off the cache — the same
+// state a repeated lookup reaches in production, and the state in which a cycle spins without
+// issuing any SQL.
+func setStage(t *testing.T, proc *process.Process, name, rawurl string) {
+	u, err := url.Parse(rawurl)
+	require.NoError(t, err)
+	proc.GetStageCache().Set(name, stage.StageDef{Id: 1, Name: name, Url: u})
+}
+
+// TestStageCyclicReference: a stage:// cycle has no concrete URL to resolve to, so resolution must
+// fail with a bounded error instead of walking the cycle forever (#26890). Self-cycle, two-node and
+// three-node cycles are all reached through the normal UrlToStageDef entry point.
+func TestStageCyclicReference(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stages map[string]string
+		furl   string
+	}{
+		{
+			name:   "self",
+			stages: map[string]string{"selfa": "stage://selfa/loop"},
+			furl:   "stage://selfa/a.csv",
+		},
+		{
+			name:   "two-node",
+			stages: map[string]string{"twoa": "stage://twob/x", "twob": "stage://twoa/y"},
+			furl:   "stage://twoa/a.csv",
+		},
+		{
+			name: "three-node",
+			stages: map[string]string{
+				"tria": "stage://trib/x", "trib": "stage://tric/y", "tric": "stage://tria/z",
+			},
+			furl: "stage://tria/a.csv",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			for name, u := range tc.stages {
+				setStage(t, proc, name, u)
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := UrlToStageDef(tc.furl, proc)
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "cyclic stage reference")
+			case <-time.After(30 * time.Second):
+				t.Fatal("UrlToStageDef hung on a cyclic stage reference")
+			}
+		})
+	}
+}
+
+// TestStageChainNoFalseCycle: a legal multi-hop chain that revisits no stage must still resolve —
+// the cycle check must not reject repeated path segments or a long acyclic chain.
+func TestStageChainNoFalseCycle(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	setStage(t, proc, "chaina", "stage://chainb/one")
+	setStage(t, proc, "chainb", "stage://chainc/one")
+	setStage(t, proc, "chainc", "file:///tmp")
+
+	s, err := UrlToStageDef("stage://chaina/a.csv", proc)
+	require.NoError(t, err)
+	require.Equal(t, "file:///tmp/one/one/a.csv", s.Url.String())
 }
 
 func Test_runSql(t *testing.T) {


### PR DESCRIPTION
ExpandSubStage followed each stage:// reference recursively with no termination condition other than reaching a concrete scheme, so a cyclic definition (a -> a, or a -> b -> a) recursed forever. StageLoadCatalog serves repeat lookups from the process stage cache, so after the first pass around the cycle the loop issues no SQL and no I/O — it spins and the CN request hangs instead of failing.

Walk the chain iteratively with a visited set of stage names and return a bounded error naming the cycle. Termination is structural: every hop consumes one distinct name. Resolution is the right choke point — nothing rejects a cycle at CREATE/ALTER STAGE time and the cycle can be closed by altering any node in the chain, and both entry points (UrlToStageDef, UrlToStageDefForExport) funnel through ExpandSubStage.

Tests cover self-, two-node and three-node cycles through UrlToStageDef, each with a watchdog so a regression fails as "hung" rather than hanging CI, plus a control that a legal three-hop acyclic chain still resolves.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26890

## What this PR does / why we need it:

  A cyclic `stage://` definition hung the CN request instead of returning an error.

  ### Root cause

  `ExpandSubStage` (`pkg/stage/stageutil/stageutil.go`) followed each stage-to-stage
  reference recursively, with no termination condition other than reaching a concrete
  scheme:

  ```go
  res, err := StageLoadCatalog(proc, stagename)
  ...
  return ExpandSubStage(res, proc)   // no visited set
  ```

  A cycle (`a -> a`, or `a -> b -> c -> a`) has no concrete URL to reach, so the walk
  never ends. `StageLoadCatalog` serves repeat lookups from the process stage cache, so
  after the first pass around the cycle the loop issues no SQL and no I/O — it becomes a
  tight spin (growing the URL via `JoinPath` on every hop) rather than something a query
  timeout or context cancellation can break. The request hangs; other CN work is
  unaffected, which matches the localized symptom in the issue.

  ### Fix

  Walk the chain iteratively, tracking the stage names already expanded, and fail with a
  bounded error naming the cycle:

  ```
  cyclic stage reference: twoa -> twob -> twoa
  ```

  Termination is structural rather than a tuned limit: every hop consumes one distinct
  stage name, so the walk cannot exceed the number of stages. No depth cap is added — the
  visited set already bounds it, and an arbitrary limit would only risk rejecting a legal
  deep chain.

  ### Why resolution time, not DDL time

  `doCreateStage` (`pkg/frontend/authenticate.go`) validates only the URL protocol prefix;
  it never resolves the referenced stage. A cycle can also be closed by `ALTER STAGE` on
  *any* node in an existing chain, so a DDL-side check would have to cover every mutation
  path and would still race with concurrent DDL. Resolution is the choke point: both entry
  points, `UrlToStageDef` and `UrlToStageDefForExport`, funnel through `ExpandSubStage`,
  and it is the only recursion on `STAGE_PROTOCOL` in the tree. Existing stages that are
  already cyclic are handled too — no migration needed.

  The change is contained: the exported signature is unchanged, no behavior changes for
  acyclic chains, and the error is a normal `moerr` returned on the existing error path.

  ## Tests

  `pkg/stage/stageutil/stageutil_test.go`:

  - `TestStageCyclicReference` — self-cycle, two-node and three-node cycles, each driven
    through the normal `UrlToStageDef` entry point and run under a watchdog, so a
    regression fails as `"UrlToStageDef hung on a cyclic stage reference"` instead of
    hanging CI.
  - `TestStageChainNoFalseCycle` — control: a legal three-hop acyclic chain
    (`chaina -> chainb -> chainc -> file:///tmp`) still resolves, with path segments
    joined in order.

  Verification:

  - Pre-fix proof: with the fix reverted, `TestStageCyclicReference/self` fails at exactly
    30.00s with the hang message — the reported defect, reproduced.
  - Post-fix: `./pkg/stage/...` passes; the four stage-resolution tests complete in 0.073s.
  - Dependent packages that consume stage resolution pass: `pkg/datalink/...`,
    `pkg/sql/colexec/externalwrite`, `pkg/sql/colexec/table_function`.
