### PR TITLE
fix(frontend): skip saving cloud non-user query results

### DIFF
--- a/pkg/frontend/query_result.go
+++ b/pkg/frontend/query_result.go
@@ -58,10 +58,11 @@ func canSaveQueryResult(ctx context.Context, ses *Session) bool {
 	}
 
 	stmtProfile := ses.GetStmtProfile()
-	if stmtProfile.GetSqlSourceType() == constant.InternalSql {
+	sqlSourceType := stmtProfile.GetSqlSourceType()
+	if sqlSourceType == constant.InternalSql || sqlSourceType == constant.CloudNoUserSql {
 		return false
 	}
-	if stmtProfile.GetStmtType() == "Select" && stmtProfile.GetSqlSourceType() != constant.CloudUserSql {
+	if stmtProfile.GetStmtType() == "Select" && sqlSourceType != constant.CloudUserSql {
 		return false
 	}
 

--- a/pkg/frontend/query_result_test.go
+++ b/pkg/frontend/query_result_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/frontend/constant"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
@@ -116,6 +117,39 @@ func newBatch(ts []types.Type, rows int, proc *process.Process) *batch.Batch {
 		}
 	}
 	return bat
+}
+
+func TestCanSaveQueryResultBySQLSource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ses := newTestSession(t, ctrl)
+	defer ses.Close()
+
+	ctx := context.Background()
+	assert.NoError(t, ses.SetSessionSysVar(ctx, "save_query_result", int8(1)))
+	ses.ast = &tree.ShowColumns{}
+
+	tests := []struct {
+		name       string
+		stmtType   string
+		sourceType string
+		want       bool
+	}{
+		{name: "cloud user show", stmtType: "Show Columns", sourceType: constant.CloudUserSql, want: true},
+		{name: "cloud user select", stmtType: "Select", sourceType: constant.CloudUserSql, want: true},
+		{name: "cloud non-user show", stmtType: "Show Columns", sourceType: constant.CloudNoUserSql, want: false},
+		{name: "cloud non-user select", stmtType: "Select", sourceType: constant.CloudNoUserSql, want: false},
+		{name: "internal show", stmtType: "Show Columns", sourceType: constant.InternalSql, want: false},
+		{name: "external show", stmtType: "Show Columns", sourceType: constant.ExternSql, want: true},
+		{name: "external select", stmtType: "Select", sourceType: constant.ExternSql, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ses.SetStmtType(test.stmtType)
+			ses.SetSqlSourceType(test.sourceType)
+			assert.Equal(t, test.want, canSaveQueryResult(ctx, ses))
+		})
+	}
 }
 
 func Test_saveQueryResultMeta(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/26960

## What this PR does / why we need it:

Cloud services enable `save_query_result` so SQL editor queries can be read later through `result_scan` and `meta_scan`. The result-saving gate previously allowed non-SELECT `cloud_nonuser_sql` statements, so background metadata queries such as `SHOW COLUMNS` unnecessarily wrote query-result data and metadata objects.

This change rejects all `cloud_nonuser_sql` statements at the centralized query-result saving gate. User-facing `cloud_user_sql` and `/* save_result */` queries keep their existing behavior.

Tests cover cloud user, cloud non-user, internal, and external SQL across SELECT and SHOW statement types.

Validation:

- `GOWORK=off go build -mod=readonly ./pkg/frontend`
- `GOWORK=off go vet -mod=readonly ./pkg/frontend`
- `GOWORK=off go test -mod=readonly -count=1 -timeout 120s ./pkg/frontend`
