### PR TITLE
fix dup buckets

### DIFF
--- a/pkg/sql/colexec/timewin/types.go
+++ b/pkg/sql/colexec/timewin/types.go
@@ -210,6 +210,9 @@ func (timeWin *TimeWin) MakeIntervalAndSliding(interval, sliding *plan.Expr) err
 		return err
 	}
 	val1 := interval.Expr.(*plan.Expr_List).List.List[0].Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I64Val).I64Val
+	if val1 <= 0 {
+		return moerr.NewInvalidInputNoCtx("time window interval must be greater than zero")
+	}
 	timeWin.Interval, err = calcDatetime(val1, typ)
 	if err != nil {
 		return err
@@ -222,6 +225,9 @@ func (timeWin *TimeWin) MakeIntervalAndSliding(interval, sliding *plan.Expr) err
 			return err
 		}
 		val2 := sliding.Expr.(*plan.Expr_List).List.List[0].Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I64Val).I64Val
+		if val2 <= 0 {
+			return moerr.NewInvalidInputNoCtx("time window sliding value must be greater than zero")
+		}
 		timeWin.Sliding, err = calcDatetime(val2, typ)
 		if err != nil {
 			return err

--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -1737,6 +1737,9 @@ func Truncate(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc 
 
 func getIntervalNum(diff, unit int64, proc *process.Process) (int64, error) {
 	var num int64
+	if diff <= 0 {
+		return num, moerr.NewInvalidInput(proc.Ctx, "time window interval must be greater than zero")
+	}
 	iTyp := types.IntervalType(unit)
 	err := types.JudgeIntervalNumOverflow(diff, iTyp)
 	if err != nil {
@@ -1781,12 +1784,18 @@ func getSecondNum(diff, unit int64, proc *process.Process) (int64, error) {
 
 func Divisor(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) (err error) {
 	diff1, _ := vector.GenerateFunctionFixedTypeParameter[int64](ivecs[0]).GetValue(0)
+	if diff1 <= 0 {
+		return moerr.NewInvalidInput(proc.Ctx, "time window interval must be greater than zero")
+	}
 	unit1, _ := vector.GenerateFunctionFixedTypeParameter[int64](ivecs[1]).GetValue(0)
 	num1, err := getSecondNum(diff1, unit1, proc)
 	if err != nil {
 		return err
 	}
 	diff2, _ := vector.GenerateFunctionFixedTypeParameter[int64](ivecs[2]).GetValue(0)
+	if diff2 <= 0 {
+		return moerr.NewInvalidInput(proc.Ctx, "time window sliding value must be greater than zero")
+	}
 	unit2, _ := vector.GenerateFunctionFixedTypeParameter[int64](ivecs[3]).GetValue(0)
 	num2, err := getSecondNum(diff2, unit2, proc)
 	if err != nil {

--- a/pkg/sql/plan/function/func_binary_test.go
+++ b/pkg/sql/plan/function/func_binary_test.go
@@ -13107,6 +13107,69 @@ func TestMoWinTruncateKeepsZeroDatetimeDistinctFromEpoch(t *testing.T) {
 	require.Equal(t, types.DatetimeEpoch, got[1])
 }
 
+func TestMoWinTruncateRejectsNonPositiveInterval(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	values := vector.NewVec(types.T_datetime.ToType())
+	require.NoError(t, vector.AppendFixed(values, types.DatetimeEpoch, false, proc.Mp()))
+	defer values.Free(proc.Mp())
+
+	diff, err := vector.NewConstFixed(types.T_int64.ToType(), int64(0), 1, proc.Mp())
+	require.NoError(t, err)
+	defer diff.Free(proc.Mp())
+	unit, err := vector.NewConstFixed(types.T_int64.ToType(), int64(types.Minute), 1, proc.Mp())
+	require.NoError(t, err)
+	defer unit.Free(proc.Mp())
+
+	result := vector.NewFunctionResultWrapper(types.T_datetime.ToType(), proc.Mp())
+	defer result.Free()
+	require.NoError(t, result.PreExtendAndReset(1))
+	require.ErrorContains(t, Truncate([]*vector.Vector{values, diff, unit}, result, proc, 1, nil), "time window interval must be greater than zero")
+}
+
+func TestMoWinDivisorRejectsNonPositiveIntervalAndSliding(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	newConst := func(v int64) *vector.Vector {
+		vec, err := vector.NewConstFixed(types.T_int64.ToType(), v, 1, proc.Mp())
+		require.NoError(t, err)
+		return vec
+	}
+	minute := newConst(int64(types.Minute))
+	defer minute.Free(proc.Mp())
+
+	for _, tc := range []struct {
+		name     string
+		interval int64
+		sliding  int64
+		wantErr  string
+	}{
+		{
+			name:     "zero interval",
+			interval: 0,
+			sliding:  1,
+			wantErr:  "time window interval must be greater than zero",
+		},
+		{
+			name:     "zero sliding",
+			interval: 5,
+			sliding:  0,
+			wantErr:  "time window sliding value must be greater than zero",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			interval := newConst(tc.interval)
+			defer interval.Free(proc.Mp())
+			sliding := newConst(tc.sliding)
+			defer sliding.Free(proc.Mp())
+
+			result := vector.NewFunctionResultWrapper(types.T_int64.ToType(), proc.Mp())
+			defer result.Free()
+			require.NoError(t, result.PreExtendAndReset(1))
+			require.ErrorContains(t, Divisor([]*vector.Vector{interval, minute, sliding, minute}, result, proc, 1, nil), tc.wantErr)
+		})
+	}
+}
+
 func TestDateTruncCheckRejectsInvalidArguments(t *testing.T) {
 	overloads := allSupportedFunctions[DATE_TRUNC].Overloads
 

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -8902,7 +8902,11 @@ func makeHelpFuncForTimeWindow(astTimeWindow *tree.TimeWindow) (*helpFunc, error
 	return h, nil
 }
 
-const unsupportedTimeWindowIntervalUnit = "Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit"
+const (
+	unsupportedTimeWindowIntervalUnit = "Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit"
+	timeWindowIntervalMustBePositive  = "time window interval must be greater than zero"
+	timeWindowSlidingMustBePositive   = "time window sliding value must be greater than zero"
+)
 
 func validateTimeWindowIntervalUnits(ctx context.Context, astTimeWindow *tree.TimeWindow) error {
 	if astTimeWindow == nil {
@@ -8911,10 +8915,31 @@ func validateTimeWindowIntervalUnits(ctx context.Context, astTimeWindow *tree.Ti
 	if err := validateTimeWindowIntervalUnit(ctx, astTimeWindow.Interval.Unit); err != nil {
 		return err
 	}
+	if err := validateTimeWindowIntervalValue(ctx, astTimeWindow.Interval.Val, timeWindowIntervalMustBePositive); err != nil {
+		return err
+	}
 	if astTimeWindow.Sliding != nil {
 		if err := validateTimeWindowIntervalUnit(ctx, astTimeWindow.Sliding.Unit); err != nil {
 			return err
 		}
+		if err := validateTimeWindowIntervalValue(ctx, astTimeWindow.Sliding.Val, timeWindowSlidingMustBePositive); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTimeWindowIntervalValue(ctx context.Context, expr tree.Expr, message string) error {
+	val, ok := expr.(*tree.NumVal)
+	if !ok {
+		return nil
+	}
+	n, ok := val.Int64()
+	if !ok {
+		return nil
+	}
+	if n <= 0 {
+		return moerr.NewInvalidInput(ctx, message)
 	}
 	return nil
 }

--- a/pkg/sql/plan/query_builder_test.go
+++ b/pkg/sql/plan/query_builder_test.go
@@ -2602,9 +2602,85 @@ func TestQueryBuilder_bindTimeWindowRejectsUnsupportedUnitsBeforeCompile(t *test
 	}
 }
 
+func TestQueryBuilder_bindTimeWindowRejectsNonPositiveValuesBeforeCompile(t *testing.T) {
+	tests := []struct {
+		name          string
+		intervalValue int64
+		slidingValue  *int64
+		errorContains string
+	}{
+		{
+			name:          "zero interval",
+			intervalValue: 0,
+			errorContains: timeWindowIntervalMustBePositive,
+		},
+		{
+			name:          "negative interval",
+			intervalValue: -1,
+			errorContains: timeWindowIntervalMustBePositive,
+		},
+		{
+			name:          "zero sliding",
+			intervalValue: 5,
+			slidingValue:  ptrTo[int64](0),
+			errorContains: timeWindowSlidingMustBePositive,
+		},
+		{
+			name:          "negative sliding",
+			intervalValue: 5,
+			slidingValue:  ptrTo[int64](-1),
+			errorContains: timeWindowSlidingMustBePositive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, bindCtx := genBuilderAndCtxWithColumnType(types.T_timestamp, "ts")
+			havingBinder := NewHavingBinder(builder, bindCtx)
+			projectionBinder := NewProjectionBinder(builder, bindCtx, havingBinder)
+
+			astTimeWindow := &tree.TimeWindow{
+				Interval: &tree.Interval{
+					Col:  tree.NewUnresolvedName(tree.NewCStr("ts", 0)),
+					Val:  tree.NewNumVal(tt.intervalValue, fmt.Sprintf("%d", tt.intervalValue), false, tree.P_int64),
+					Unit: "minute",
+				},
+			}
+			if tt.slidingValue != nil {
+				astTimeWindow.Sliding = &tree.Sliding{
+					Val:  tree.NewNumVal(*tt.slidingValue, fmt.Sprintf("%d", *tt.slidingValue), false, tree.P_int64),
+					Unit: "minute",
+				}
+			}
+
+			helpFunc, err := makeHelpFuncForTimeWindow(astTimeWindow)
+			require.NoError(t, err)
+			timeWindowGroup := &plan.Expr{
+				Typ: plan.Type{Id: int32(types.T_datetime)},
+				Expr: &plan.Expr_Col{
+					Col: &plan.ColRef{RelPos: 1, ColPos: 0},
+				},
+			}
+
+			_, _, _, _, _, _, _, _, err = builder.bindTimeWindow(
+				bindCtx,
+				projectionBinder,
+				astTimeWindow,
+				timeWindowGroup,
+				helpFunc,
+			)
+			require.ErrorContains(t, err, tt.errorContains)
+		})
+	}
+}
+
 func TestValidateTimeWindowIntervalUnitRejectsInvalidUnit(t *testing.T) {
 	err := validateTimeWindowIntervalUnit(context.Background(), "century")
 	require.ErrorContains(t, err, "invalid interval type 'century'")
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
 }
 
 func TestQueryBuilder_bindTimeWindow(t *testing.T) {

--- a/test/distributed/cases/window/time_window.result
+++ b/test/distributed/cases/window/time_window.result
@@ -855,6 +855,10 @@ select max(a) as enable, min(a) as collation from tt1 interval(ts, 1, minute);
 ➤ enable[4,32,0]  ¦  collation[4,32,0]
 drop table if exists tw_interval_bad_unit;
 create table tw_interval_bad_unit(ts timestamp(6), v int);
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 0, minute);
+invalid input: time window interval must be greater than zero
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 5, minute) sliding(0, minute);
+invalid input: time window sliding value must be greater than zero
 select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, month);
 not supported: Time Window aggregate only support SECOND, MINUTE, HOUR, DAY as the time unit
 select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, week);

--- a/test/distributed/cases/window/time_window.sql
+++ b/test/distributed/cases/window/time_window.sql
@@ -285,6 +285,11 @@ select max(a) as enable, min(a) as collation from tt1 interval(ts, 1, minute);
 -- unsupported calendar units should return a normal SQL error, not enter the compile panic path
 drop table if exists tw_interval_bad_unit;
 create table tw_interval_bad_unit(ts timestamp(6), v int);
+-- zero interval/sliding should return a normal SQL error before pipeline execution
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 0, minute);
+-- @bvt:issue
+select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 5, minute) sliding(0, minute);
 -- @bvt:issue
 select _wstart, _wend, count(*) from tw_interval_bad_unit interval(ts, 1, month);
 -- @bvt:issue


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26987

## What this PR does / why we need it:

• 此分支主要修复 Time Window 对非正窗口参数缺少校验的问题。

  修改内容：

  - 在 planner/binder 阶段增加校验：
      - INTERVAL(ts, 0, unit) / 负数 interval 直接报错；
      - SLIDING(0, unit) / 负数 sliding 直接报错；
      - 避免进入 pipeline 后出现除零 panic 或重复窗口结果。

  - 在执行侧增加兜底保护：
      - timewin.MakeIntervalAndSliding 校验 interval/sliding 必须大于 0；
      - mo_win_truncate 拒绝非正 interval；
      - mo_win_divisor 拒绝非正 interval/sliding。

  - 新增测试：
      - Go UT 覆盖 binder 阶段的 0/负数 interval、0/负数 sliding；
      - Go UT 覆盖 mo_win_truncate / mo_win_divisor 内部防线；
      - BVT 覆盖：
          - interval(ts, 0, minute)
          - interval(ts, 5, minute) sliding(0, minute)
