### PR TITLE
[4.2] fix: preserve block filters for remote table scans

### DIFF
--- a/pkg/sql/compile/remote_expr.go
+++ b/pkg/sql/compile/remote_expr.go
@@ -119,6 +119,51 @@ func foldVarExprsInRemoteRunScope(s *Scope, proc *process.Process) (*Scope, bool
 	return copied, folded, err
 }
 
+func copyBlockFiltersForRemoteRun(s *Scope) *Scope {
+	if s == nil {
+		return nil
+	}
+	var copied *Scope
+	preScopesCopied := false
+	var blockFilters []*plan.Expr
+	if s.DataSource != nil {
+		// DataSource.BlockFilterList contains coordinator-owned Fold IDs after
+		// InitAllDataSource. Send the original expressions from the plan node so
+		// the remote Compile can create and evaluate its own Fold executors. This
+		// also preserves empty scalar literals across protobuf serialization.
+		if s.DataSource.node != nil && len(s.DataSource.node.BlockFilterList) > 0 {
+			blockFilters = s.DataSource.node.BlockFilterList
+		} else {
+			blockFilters = s.DataSource.BlockFilterList
+		}
+	}
+	if len(blockFilters) > 0 {
+		value := *s
+		dataSource := *s.DataSource
+		dataSource.BlockFilterList = plan2.DeepCopyExprList(blockFilters)
+		value.DataSource = &dataSource
+		copied = &value
+	}
+	for i := range s.PreScopes {
+		pre := copyBlockFiltersForRemoteRun(s.PreScopes[i])
+		if pre != s.PreScopes[i] {
+			if copied == nil {
+				value := *s
+				copied = &value
+			}
+			if !preScopesCopied {
+				copied.PreScopes = append([]*Scope(nil), s.PreScopes...)
+				preScopesCopied = true
+			}
+			copied.PreScopes[i] = pre
+		}
+	}
+	if copied == nil {
+		return s
+	}
+	return copied
+}
+
 func copyScopeForVarExprFold(s *Scope) *Scope {
 	if s == nil {
 		return nil

--- a/pkg/sql/compile/remoterun.go
+++ b/pkg/sql/compile/remoterun.go
@@ -212,6 +212,20 @@ func fillPipeline(s *Scope) (*pipeline.Pipeline, error) {
 	return p, nil
 }
 
+func sourceNodeForRemoteRun(source *Source) *plan.Node {
+	if source == nil || source.node == nil {
+		return nil
+	}
+	// pipeline.Source does not have wire fields for the execution-time filter
+	// lists. Carry them in a per-message node copy so the reusable plan node is
+	// not mutated and the remote ranges phase sees the same predicates.
+	node := *source.node
+	if source.BlockFilterList != nil {
+		node.BlockFilterList = source.BlockFilterList
+	}
+	return &node
+}
+
 // generatePipeline generate a base pipeline.Pipeline structure without instructions
 // according to source scope.
 func generatePipeline(s *Scope, ctx *scopeContext, ctxId int32) (*pipeline.Pipeline, int32, error) {
@@ -265,7 +279,7 @@ func generatePipeline(s *Scope, ctx *scopeContext, ctxId int32) (*pipeline.Pipel
 			PushdownAddr:           s.DataSource.PushdownAddr,
 			Expr:                   s.DataSource.FilterExpr,
 			TableDef:               s.DataSource.TableDef,
-			Node:                   s.DataSource.node,
+			Node:                   sourceNodeForRemoteRun(s.DataSource),
 			Timestamp:              &s.DataSource.Timestamp,
 			RuntimeFilterProbeList: s.DataSource.RuntimeFilterSpecs,
 			IsConst:                s.DataSource.isConst,
@@ -404,8 +418,10 @@ func generateScope(proc *process.Process, p *pipeline.Pipeline, ctx *scopeContex
 			RecvMsgList:           dsc.RecvMsgList,
 			MembershipFilterBytes: dsc.MembershipFilter,
 		}
-		// Extract IndexReaderParam from node for remote CN execution
 		if dsc.Node != nil {
+			if isRemote {
+				s.DataSource.BlockFilterList = plan2.DeepCopyExprList(dsc.Node.BlockFilterList)
+			}
 			s.DataSource.IndexReaderParam = dsc.Node.IndexReaderParam
 		}
 	}

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -225,6 +225,7 @@ func prepareRemoteRunSendingData(
 	remoteExecutionID uuid.UUID,
 ) (scopeData []byte, withoutOutput bool, processData []byte, folded bool, err error) {
 	encodedScope, withoutOutput := getScopeForRemoteRunEncoding(s)
+	encodedScope = copyBlockFiltersForRemoteRun(encodedScope)
 	encodedScope, folded, err = foldVarExprsInRemoteRunScope(encodedScope, proc)
 	if err != nil {
 		return nil, false, nil, false, err

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -89,6 +89,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
@@ -2821,6 +2822,295 @@ func Test_prepareRemoteRunSendingData(t *testing.T) {
 	_, withoutOut, _, _, err = prepareRemoteRunSendingData("", s3, proc, nil, uuid.Nil)
 	require.NoError(t, err)
 	require.True(t, withoutOut)
+}
+
+func TestPrepareRemoteRunSendingDataPreservesBlockFilters(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	proc.Ctx = context.WithValue(proc.Ctx, defines.TenantIDKey{}, uint32(0))
+	proc.Base.TxnOperator = fakeTxnOperator{}
+	proc.Base.SessionInfo.TimeZone = time.UTC
+
+	int64Type := types.T_int64.ToType()
+	greaterEqual, err := planfunction.GetFunctionByName(
+		context.Background(), ">=", []types.Type{int64Type, int64Type})
+	require.NoError(t, err)
+	originalFilter := &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool), NotNullable: true},
+		Expr: &planpb.Expr_F{F: &planpb.Function{
+			Func: &planpb.ObjectRef{Obj: greaterEqual.GetEncodedOverloadID(), ObjName: ">="},
+			Args: []*planpb.Expr{
+				{
+					Typ:  planpb.Type{Id: int32(types.T_int64), NotNullable: true},
+					Expr: &planpb.Expr_Col{Col: &planpb.ColRef{Name: "a", ColPos: 0}},
+				},
+				plan.MakePlan2Int64ConstExprWithType(42),
+			},
+		}},
+	}
+	compiledFilter := plan.DeepCopyExpr(originalFilter)
+	var executors []colexec.ExpressionExecutor
+	t.Cleanup(func() {
+		for _, executor := range executors {
+			executor.Free()
+		}
+	})
+	_, err = plan.ReplaceFoldExpr(proc, compiledFilter, &executors)
+	require.NoError(t, err)
+	require.True(t, plan.HasFoldExprForList([]*planpb.Expr{compiledFilter}))
+	require.Nil(t, compiledFilter.GetF().Args[1].GetFold().Data)
+
+	s := &Scope{
+		Magic:  Remote,
+		Proc:   proc,
+		RootOp: value_scan.NewArgument(),
+		DataSource: &Source{
+			node: &planpb.Node{
+				BlockFilterList: []*planpb.Expr{originalFilter},
+			},
+			BlockFilterList: []*planpb.Expr{compiledFilter},
+		},
+	}
+
+	scopeData, _, _, _, err := prepareRemoteRunSendingData("", s, proc, nil, uuid.Nil)
+	require.NoError(t, err)
+	require.True(t, plan.HasFoldExprForList(s.DataSource.BlockFilterList))
+	require.Nil(t, compiledFilter.GetF().Args[1].GetFold().Data)
+	require.False(t, plan.HasFoldExprForList(s.DataSource.node.BlockFilterList))
+	restored, err := decodeScope(scopeData, proc, true, nil)
+	require.NoError(t, err)
+
+	require.Len(t, restored.DataSource.BlockFilterList, 1)
+	require.False(t, plan.HasFoldExprForList(restored.DataSource.BlockFilterList))
+	remoteCompile := &Compile{proc: restored.Proc}
+	t.Cleanup(func() {
+		for _, executor := range remoteCompile.filterExprExes {
+			executor.Free()
+		}
+	})
+	filters, err := restored.handleRuntimeFilters(remoteCompile, nil)
+	require.NoError(t, err)
+	require.Len(t, filters, 1)
+	require.True(t, plan.HasFoldExprForList(filters))
+	require.NotEmpty(t, filters[0].GetF().Args[1].GetFold().Data)
+	require.False(t, plan.HasFoldExprForList(restored.DataSource.BlockFilterList))
+	_, _, _, _, _, canCompile, _ := readutil.CompileFilterExprs(filters, &planpb.TableDef{
+		Cols: []*planpb.ColDef{{
+			Name:   "a",
+			Typ:    planpb.Type{Id: int32(types.T_int64)},
+			Seqnum: 0,
+		}},
+		Name2ColIndex: map[string]int32{"a": 0},
+	}, nil)
+	require.True(t, canCompile)
+
+	invalidRemote := &Scope{
+		IsRemote:   true,
+		Proc:       proc,
+		DataSource: &Source{BlockFilterList: []*planpb.Expr{compiledFilter}},
+	}
+	_, err = invalidRemote.handleRuntimeFilters(&Compile{proc: proc}, nil)
+	require.ErrorContains(t, err, "sender-owned Fold value")
+
+	legacyScope := &Scope{
+		Proc:   proc,
+		RootOp: value_scan.NewArgument(),
+		DataSource: &Source{
+			node: &planpb.Node{
+				BlockFilterList: []*planpb.Expr{plan.DeepCopyExpr(originalFilter)},
+			},
+		},
+	}
+	legacyScopeData, err := encodeScope(legacyScope)
+	require.NoError(t, err)
+	legacyRestored, err := decodeScope(legacyScopeData, proc, true, nil)
+	require.NoError(t, err)
+	require.Len(t, legacyRestored.DataSource.BlockFilterList, 1)
+	require.False(t, plan.HasFoldExprForList(legacyRestored.DataSource.BlockFilterList))
+	legacyCompile := &Compile{proc: legacyRestored.Proc}
+	t.Cleanup(func() {
+		for _, executor := range legacyCompile.filterExprExes {
+			executor.Free()
+		}
+	})
+	legacyFilters, err := legacyRestored.handleRuntimeFilters(legacyCompile, nil)
+	require.NoError(t, err)
+	require.Len(t, legacyFilters, 1)
+	require.True(t, plan.HasFoldExprForList(legacyFilters))
+
+	nestedFilter := plan.DeepCopyExpr(originalFilter)
+	_, err = plan.ReplaceFoldExpr(proc, nestedFilter, &executors)
+	require.NoError(t, err)
+	nested := &Scope{
+		Magic:  Remote,
+		Proc:   proc,
+		RootOp: value_scan.NewArgument(),
+		PreScopes: []*Scope{{
+			Proc:   proc,
+			RootOp: value_scan.NewArgument(),
+			DataSource: &Source{
+				node:            &planpb.Node{BlockFilterList: []*planpb.Expr{originalFilter}},
+				BlockFilterList: []*planpb.Expr{nestedFilter},
+			},
+		}},
+	}
+	nestedData, _, _, _, err := prepareRemoteRunSendingData("", nested, proc, nil, uuid.Nil)
+	require.NoError(t, err)
+	nestedRestored, err := decodeScope(nestedData, proc, true, nil)
+	require.NoError(t, err)
+	require.Len(t, nestedRestored.PreScopes, 1)
+	require.False(t, plan.HasFoldExprForList(nestedRestored.PreScopes[0].DataSource.BlockFilterList))
+	require.True(t, plan.HasFoldExprForList(nested.PreScopes[0].DataSource.BlockFilterList))
+}
+
+func TestPrepareRemoteRunSendingDataPreservesEmptyScalarBlockFilter(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	proc.Ctx = context.WithValue(proc.Ctx, defines.TenantIDKey{}, uint32(0))
+	proc.Base.TxnOperator = fakeTxnOperator{}
+	proc.Base.SessionInfo.TimeZone = time.UTC
+
+	varcharType := types.T_varchar.ToType()
+	equal, err := planfunction.GetFunctionByName(
+		context.Background(), "=", []types.Type{varcharType, varcharType})
+	require.NoError(t, err)
+	originalFilter := &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool), NotNullable: true},
+		Expr: &planpb.Expr_F{F: &planpb.Function{
+			Func: &planpb.ObjectRef{Obj: equal.GetEncodedOverloadID(), ObjName: "="},
+			Args: []*planpb.Expr{
+				{
+					Typ:  planpb.Type{Id: int32(types.T_varchar), NotNullable: true},
+					Expr: &planpb.Expr_Col{Col: &planpb.ColRef{Name: "a", ColPos: 0}},
+				},
+				plan.MakePlan2StringConstExprWithType(""),
+			},
+		}},
+	}
+	filter := plan.DeepCopyExpr(originalFilter)
+	var executors []colexec.ExpressionExecutor
+	t.Cleanup(func() {
+		for _, executor := range executors {
+			executor.Free()
+		}
+	})
+	_, err = plan.ReplaceFoldExpr(proc, filter, &executors)
+	require.NoError(t, err)
+	s := &Scope{
+		Magic:  Remote,
+		Proc:   proc,
+		RootOp: value_scan.NewArgument(),
+		DataSource: &Source{
+			node:            &planpb.Node{BlockFilterList: []*planpb.Expr{originalFilter}},
+			BlockFilterList: []*planpb.Expr{filter},
+		},
+	}
+	fold := filter.GetF().Args[1].GetFold()
+	require.False(t, fold.IsConst)
+	require.Nil(t, fold.Data)
+
+	scopeData, _, _, _, err := prepareRemoteRunSendingData("", s, proc, nil, uuid.Nil)
+	require.NoError(t, err)
+	restored, err := decodeScope(scopeData, proc, true, nil)
+	require.NoError(t, err)
+	require.False(t, plan.HasFoldExprForList(restored.DataSource.BlockFilterList))
+	restoredCompile := &Compile{proc: restored.Proc}
+	t.Cleanup(func() {
+		for _, executor := range restoredCompile.filterExprExes {
+			executor.Free()
+		}
+	})
+	filters, err := restored.handleRuntimeFilters(restoredCompile, nil)
+	require.NoError(t, err)
+	require.Len(t, filters, 1)
+	restoredFold := filters[0].GetF().Args[1].GetFold()
+	require.True(t, restoredFold.IsConst)
+	require.NotNil(t, restoredFold.Data)
+	require.Empty(t, restoredFold.Data)
+	_, _, _, _, _, canCompile, _ := readutil.CompileFilterExprs(filters, &planpb.TableDef{
+		Cols: []*planpb.ColDef{{
+			Name:   "a",
+			Typ:    planpb.Type{Id: int32(types.T_varchar)},
+			Seqnum: 0,
+		}},
+		Name2ColIndex: map[string]int32{"a": 0},
+	}, nil)
+	require.True(t, canCompile)
+}
+
+func TestPrepareRemoteRunSendingDataFoldsBlockFilterVariables(t *testing.T) {
+	proc := newResolveVariableProcess(t, "ANSI")
+	proc.Ctx = context.WithValue(proc.Ctx, defines.TenantIDKey{}, uint32(0))
+	proc.Base.TxnOperator = fakeTxnOperator{}
+	proc.Base.SessionInfo.TimeZone = time.UTC
+
+	textType := types.T_text.ToType()
+	equal, err := planfunction.GetFunctionByName(
+		context.Background(), "=", []types.Type{textType, textType})
+	require.NoError(t, err)
+	originalFilter := &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool), NotNullable: true},
+		Expr: &planpb.Expr_F{F: &planpb.Function{
+			Func: &planpb.ObjectRef{Obj: equal.GetEncodedOverloadID(), ObjName: "="},
+			Args: []*planpb.Expr{
+				{
+					Typ:  planpb.Type{Id: int32(types.T_text), NotNullable: true},
+					Expr: &planpb.Expr_Col{Col: &planpb.ColRef{Name: "a", ColPos: 0}},
+				},
+				makeTestVarExpr("sql_mode"),
+			},
+		}},
+	}
+	compiledFilter := plan.DeepCopyExpr(originalFilter)
+	var executors []colexec.ExpressionExecutor
+	t.Cleanup(func() {
+		for _, executor := range executors {
+			executor.Free()
+		}
+	})
+	_, err = plan.ReplaceFoldExpr(proc, compiledFilter, &executors)
+	require.NoError(t, err)
+
+	s := &Scope{
+		Magic:  Remote,
+		Proc:   proc,
+		RootOp: value_scan.NewArgument(),
+		DataSource: &Source{
+			node:            &planpb.Node{BlockFilterList: []*planpb.Expr{originalFilter}},
+			BlockFilterList: []*planpb.Expr{compiledFilter},
+		},
+	}
+	scopeData, _, _, folded, err := prepareRemoteRunSendingData("", s, proc, nil, uuid.Nil)
+	require.NoError(t, err)
+	require.True(t, folded)
+	require.True(t, containsVarExpr(originalFilter))
+
+	restored, err := decodeScope(scopeData, proc, true, nil)
+	require.NoError(t, err)
+	require.Len(t, restored.DataSource.BlockFilterList, 1)
+	require.False(t, containsVarExpr(restored.DataSource.BlockFilterList[0]))
+	require.Equal(t, "ANSI", restored.DataSource.BlockFilterList[0].GetF().Args[1].GetLit().GetSval())
+
+	// Remote processes do not carry the coordinator's variable resolver. The
+	// serialized block filter must therefore be self-contained before it builds
+	// receiver-owned Fold executors.
+	restored.Proc.SetResolveVariableFunc(nil)
+	remoteCompile := &Compile{proc: restored.Proc}
+	t.Cleanup(func() {
+		for _, executor := range remoteCompile.filterExprExes {
+			executor.Free()
+		}
+	})
+	filters, err := restored.handleRuntimeFilters(remoteCompile, nil)
+	require.NoError(t, err)
+	require.Len(t, filters, 1)
+	_, _, _, _, _, canCompile, _ := readutil.CompileFilterExprs(filters, &planpb.TableDef{
+		Cols: []*planpb.ColDef{{
+			Name:   "a",
+			Typ:    planpb.Type{Id: int32(types.T_text)},
+			Seqnum: 0,
+		}},
+		Name2ColIndex: map[string]int32{"a": 0},
+	}, nil)
+	require.True(t, canCompile)
 }
 
 func TestPrepareRemoteRunSendingDataKeepsConnectorChildTableFunctionParams(t *testing.T) {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -987,17 +987,34 @@ func (s *Scope) handleRuntimeFilters(c *Compile, runtimeFilters []receivedRuntim
 		s.DataSource.FilterExpr = colexec.RewriteFilterExprList(pkFilters)
 	}
 
-	for _, e := range s.DataSource.BlockFilterList {
+	blockFilterList := s.DataSource.BlockFilterList
+	if s.IsRemote {
+		// Keep the decoded scope as a reusable raw-expression template. Fold IDs
+		// belong to this Compile generation and must not be stored back in it.
+		blockFilterList = plan2.DeepCopyExprList(blockFilterList)
+	}
+	for _, e := range blockFilterList {
+		// RemoteRun carries the original block-filter expressions so this Compile
+		// owns the Fold executors used to expand ranges. A Fold already present on
+		// the wire contains a sender-owned executor ID and is therefore invalid.
+		if s.IsRemote {
+			if plan2.HasFoldValExpr(e) {
+				return nil, moerr.NewInternalErrorNoCtx("remote block filter contains a sender-owned Fold value")
+			}
+			if _, err := plan2.ReplaceFoldExpr(s.Proc, e, &c.filterExprExes); err != nil {
+				return nil, err
+			}
+		}
 		err := plan2.EvalFoldExpr(s.Proc, e, &c.filterExprExes)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(runtimeInExprList) == 0 && len(s.DataSource.BlockFilterList) == 0 {
+	if len(runtimeInExprList) == 0 && len(blockFilterList) == 0 {
 		return nil, nil
 	}
-	return append(runtimeInExprList, s.DataSource.BlockFilterList...), nil
+	return append(runtimeInExprList, blockFilterList...), nil
 }
 
 func (s *Scope) isTableScan() bool {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26960

## What this PR does / why we need it:

Backport of #27043 to 4.2-dev.

Remote table-scan pipelines serialized the plan node, but the receiving CN never restored Node.BlockFilterList into its execution Source. Remote range expansion therefore received no block predicates and scanned the full committed persisted partition.

This change:

- carries raw block-filter expressions in a per-message node copy without mutating the reusable coordinator scope;
- folds session variables before serialization, then creates and evaluates receiver-owned Fold executors on the remote CN;
- restores block filters for old-sender/new-receiver rolling upgrades;
- keeps decoded scopes as raw reusable templates and preserves empty scalar literals across protobuf serialization.

Validation:

- GOWORK=off go build -mod=readonly ./pkg/sql/compile
- GOWORK=off go vet -mod=readonly ./pkg/sql/compile
- focused remote block-filter regression tests
- focused race stress for all three new tests with count=100
- full pkg/sql/compile tests, with and without the race detector
