### PR TITLE
[4.2] perf: defer wide scan columns until after filtering

### DIFF
--- a/pkg/sql/colexec/table_scan/late_materialization.go
+++ b/pkg/sql/colexec/table_scan/late_materialization.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table_scan
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/txn/trace"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+// Short varlen values are commonly cheaper to fetch with the predicate
+// columns in one I/O. At the standard 8192-row object block, a 256-byte
+// declared value can represent 2 MiB of logical payload, large enough to
+// justify a second selected-row read. Unbounded payload types are always
+// candidates.
+const lateMaterializationMinVarlenWidth = 256
+
+func isLateMaterializationCandidate(typ plan.Type) bool {
+	switch types.T(typ.Id) {
+	case types.T_text,
+		types.T_blob,
+		types.T_json,
+		types.T_datalink,
+		types.T_geometry,
+		types.T_geometry32,
+		types.T_array_float32,
+		types.T_array_float64,
+		types.T_array_bf16,
+		types.T_array_float16,
+		types.T_array_int8,
+		types.T_array_uint8:
+		return true
+	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary:
+		return typ.Width >= lateMaterializationMinVarlenWidth
+	default:
+		return false
+	}
+}
+
+func collectFilterColumnPositions(expr *plan.Expr, columns []bool) bool {
+	if expr == nil {
+		return true
+	}
+	switch item := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		if item.Col == nil {
+			return false
+		}
+		pos := int(item.Col.ColPos)
+		if pos < 0 || pos >= len(columns) {
+			return false
+		}
+		columns[pos] = true
+		return true
+	case *plan.Expr_F:
+		if item.F == nil {
+			return false
+		}
+		for _, arg := range item.F.Args {
+			if !collectFilterColumnPositions(arg, columns) {
+				return false
+			}
+		}
+		return true
+	case *plan.Expr_List:
+		if item.List == nil {
+			return false
+		}
+		for _, arg := range item.List.List {
+			if !collectFilterColumnPositions(arg, columns) {
+				return false
+			}
+		}
+		return true
+	case *plan.Expr_Lit:
+		if item.Lit == nil {
+			return false
+		}
+		return collectFilterColumnPositions(item.Lit.Src, columns)
+	case *plan.Expr_P:
+		return item.P != nil
+	case *plan.Expr_V:
+		return item.V != nil
+	case *plan.Expr_T:
+		return item.T != nil
+	case *plan.Expr_Max:
+		return item.Max != nil
+	case *plan.Expr_Vec:
+		return item.Vec != nil
+	case *plan.Expr_Fold:
+		return item.Fold != nil
+	case *plan.Expr_Raw, *plan.Expr_W, *plan.Expr_Sub, *plan.Expr_Corr:
+		// These forms either refer to a column outside the ordinary ColRef tree
+		// or require execution at a different logical boundary. Stay eager.
+		return false
+	default:
+		// Future expression forms stay eager until their column ownership is
+		// understood here.
+		return false
+	}
+}
+
+func (tableScan *TableScan) configureLateMaterialization() {
+	tableScan.ctr.earlyColumns = tableScan.ctr.earlyColumns[:0]
+	tableScan.ctr.lateColumns = tableScan.ctr.lateColumns[:0]
+
+	if len(tableScan.ctr.allFilterExecutors) == 0 ||
+		len(tableScan.Attrs) != len(tableScan.Types) ||
+		len(tableScan.Types) < 2 {
+		return
+	}
+
+	filterColumns := make([]bool, len(tableScan.Types))
+	for _, expr := range tableScan.RuntimeFilterExprs {
+		if !collectFilterColumnPositions(expr, filterColumns) {
+			return
+		}
+	}
+	for _, expr := range tableScan.FilterExprs {
+		if !collectFilterColumnPositions(expr, filterColumns) {
+			return
+		}
+	}
+	if !slices.Contains(filterColumns, true) {
+		return
+	}
+
+	for pos, typ := range tableScan.Types {
+		if !filterColumns[pos] && isLateMaterializationCandidate(typ) {
+			tableScan.ctr.lateColumns = append(tableScan.ctr.lateColumns, pos)
+		} else {
+			tableScan.ctr.earlyColumns = append(tableScan.ctr.earlyColumns, pos)
+		}
+	}
+	if len(tableScan.ctr.earlyColumns) == 0 || len(tableScan.ctr.lateColumns) == 0 {
+		tableScan.ctr.earlyColumns = tableScan.ctr.earlyColumns[:0]
+		tableScan.ctr.lateColumns = tableScan.ctr.lateColumns[:0]
+	}
+}
+
+func (tableScan *TableScan) batchColumnView(
+	bat *batch.Batch,
+	positions []int,
+	rowCount int,
+) *batch.Batch {
+	if positions == nil {
+		return bat
+	}
+	if tableScan.ctr.metricView == nil {
+		tableScan.ctr.metricView = batch.NewWithSize(len(tableScan.Types))
+	}
+	view := tableScan.ctr.metricView
+	view.Vecs = view.Vecs[:len(positions)]
+	for i, pos := range positions {
+		view.Vecs[i] = bat.Vecs[pos]
+	}
+	view.SetRowCount(rowCount)
+	return view
+}
+
+func (tableScan *TableScan) recordFilterInput(bat *batch.Batch, loadedColumns []int) {
+	view := tableScan.batchColumnView(bat, loadedColumns, bat.RowCount())
+	tableScan.OpAnalyzer.InputBlock()
+	tableScan.OpAnalyzer.Input(view)
+	tableScan.OpAnalyzer.ScanBytes(view)
+	tableScan.ctr.maxAllocSize = max(tableScan.ctr.maxAllocSize, bat.Size())
+	tableScan.ctr.filterReadMetrics = true
+}
+
+func (tableScan *TableScan) recordLateInput(bat *batch.Batch) {
+	// The rows were already counted when the early columns were filtered. A
+	// zero-row view adds only the bytes materialized for surviving rows.
+	view := tableScan.batchColumnView(bat, tableScan.ctr.lateColumns, 0)
+	tableScan.OpAnalyzer.Input(view)
+	tableScan.OpAnalyzer.ScanBytes(view)
+	tableScan.ctr.maxAllocSize = max(tableScan.ctr.maxAllocSize, bat.Size())
+}
+
+func (tableScan *TableScan) applyReaderFilter(
+	proc *process.Process,
+	bat *batch.Batch,
+	loadedColumns []int,
+) (engine.ReaderFilterResult, error) {
+	start := time.Now()
+	defer func() {
+		tableScan.ctr.filterActiveDuration += time.Since(start)
+	}()
+	if loadedColumns == nil {
+		// Eager fallbacks still have a complete pre-filter batch, so preserve the
+		// existing transaction data-trace boundary.
+		tableScan.traceRead(proc, bat)
+	}
+	tableScan.recordFilterInput(bat, loadedColumns)
+	tableScan.ctr.filterLateMaterialized = loadedColumns != nil
+	return tableScan.evalFilter(proc, bat, loadedColumns)
+}
+
+func (tableScan *TableScan) readBatch(
+	ctx context.Context,
+	proc *process.Process,
+) (bool, error) {
+	lateReader, ok := tableScan.Reader.(engine.LateMaterializationReader)
+	// Data tracing records complete pre-filter rows. Preserve that diagnostic
+	// contract by using the eager path while the feature is enabled. Reader
+	// summaries have the same pre-filter diagnostic contract.
+	traceDataEnabled := trace.GetService(proc.GetService()).Enabled(trace.FeatureTraceData)
+	readerSummaryEnabled := ctx.Value(defines.ReaderSummaryKey{}) != nil
+	if !ok || tableScan.ctr.readerFilter == nil || traceDataEnabled || readerSummaryEnabled {
+		return process.MeasureFilesystemWait(tableScan.OpAnalyzer, func() (bool, error) {
+			return tableScan.Reader.Read(
+				ctx,
+				tableScan.Attrs,
+				nil,
+				proc.Mp(),
+				tableScan.ctr.buf,
+			)
+		})
+	}
+
+	return process.MeasureFilesystemWaitExcluding(
+		tableScan.OpAnalyzer,
+		&tableScan.ctr.filterActiveDuration,
+		func() (bool, error) {
+			return lateReader.ReadWithFilter(
+				ctx,
+				tableScan.Attrs,
+				tableScan.ctr.earlyColumns,
+				tableScan.ctr.readerFilter,
+				proc.Mp(),
+				tableScan.ctr.buf,
+			)
+		},
+	)
+}

--- a/pkg/sql/colexec/table_scan/late_materialization_test.go
+++ b/pkg/sql/colexec/table_scan/late_materialization_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table_scan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/stretchr/testify/require"
+)
+
+type lateMaterializationTestReader struct {
+	reads     int
+	eagerRead bool
+	closed    bool
+}
+
+func (r *lateMaterializationTestReader) Read(
+	context.Context,
+	[]string,
+	*pbplan.Expr,
+	*mpool.MPool,
+	*batch.Batch,
+) (bool, error) {
+	r.eagerRead = true
+	return true, nil
+}
+
+func (r *lateMaterializationTestReader) ReadWithFilter(
+	_ context.Context,
+	_ []string,
+	earlyColumns []int,
+	filter engine.ReaderFilter,
+	mp *mpool.MPool,
+	bat *batch.Batch,
+) (bool, error) {
+	r.reads++
+	if r.reads > 1 {
+		return true, nil
+	}
+	for i := int32(0); i < 4; i++ {
+		if err := vector.AppendFixed(bat.Vecs[0], i, false, mp); err != nil {
+			return false, err
+		}
+	}
+	bat.SetRowCount(4)
+	_, err := filter(bat, earlyColumns)
+	return false, err
+}
+
+func (r *lateMaterializationTestReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+func (*lateMaterializationTestReader) SetFilterZM(objectio.ZoneMap)           {}
+func (*lateMaterializationTestReader) SetOrderBy([]*pbplan.OrderBySpec)       {}
+func (*lateMaterializationTestReader) SetIndexParam(*pbplan.IndexReaderParam) {}
+func (*lateMaterializationTestReader) GetOrderBy() []*pbplan.OrderBySpec      { return nil }
+
+func lateTestCol(pos int32, typ types.Type) *pbplan.Expr {
+	return &pbplan.Expr{
+		Typ: plan.MakePlan2Type(&typ),
+		Expr: &pbplan.Expr_Col{Col: &pbplan.ColRef{
+			RelPos: 0,
+			ColPos: pos,
+		}},
+	}
+}
+
+func lateTestCompare(t *testing.T, name string, pos int32, value int32) *pbplan.Expr {
+	t.Helper()
+	intType := types.T_int32.ToType()
+	boolType := types.T_bool.ToType()
+	fn, err := function.GetFunctionByName(context.Background(), name, []types.Type{intType, intType})
+	require.NoError(t, err)
+	return &pbplan.Expr{
+		Typ: plan.MakePlan2Type(&boolType),
+		Expr: &pbplan.Expr_F{F: &pbplan.Function{
+			Func: &pbplan.ObjectRef{ObjName: name, Obj: fn.GetEncodedOverloadID()},
+			Args: []*pbplan.Expr{
+				lateTestCol(pos, intType),
+				{
+					Typ:  plan.MakePlan2Type(&intType),
+					Expr: &pbplan.Expr_Lit{Lit: &pbplan.Literal{Value: &pbplan.Literal_I32Val{I32Val: value}}},
+				},
+			},
+		}},
+	}
+}
+
+func TestConfigureLateMaterialization(t *testing.T) {
+	intType := types.T_int32.ToType()
+	shortVarchar := types.New(types.T_varchar, 36, 0)
+	wideVarchar := types.New(types.T_varchar, 1024, 0)
+	textType := types.T_text.ToType()
+
+	newScan := func(filterPos int32) *TableScan {
+		return &TableScan{
+			Attrs: []string{"filter_col", "short_value", "text_value", "wide_value"},
+			Types: []pbplan.Type{
+				plan.MakePlan2Type(&intType),
+				plan.MakePlan2Type(&shortVarchar),
+				plan.MakePlan2Type(&textType),
+				plan.MakePlan2Type(&wideVarchar),
+			},
+			FilterExprs: []*pbplan.Expr{lateTestCol(filterPos, func() types.Type {
+				switch filterPos {
+				case 2:
+					return textType
+				default:
+					return intType
+				}
+			}())},
+			ctr: container{allFilterExecutors: []colexec.ExpressionExecutor{nil}},
+		}
+	}
+
+	t.Run("defers only wide output columns", func(t *testing.T) {
+		scan := newScan(0)
+		scan.configureLateMaterialization()
+		require.Equal(t, []int{0, 1}, scan.ctr.earlyColumns)
+		require.Equal(t, []int{2, 3}, scan.ctr.lateColumns)
+	})
+
+	t.Run("wide predicate column stays early", func(t *testing.T) {
+		scan := newScan(2)
+		scan.configureLateMaterialization()
+		require.Equal(t, []int{0, 1, 2}, scan.ctr.earlyColumns)
+		require.Equal(t, []int{3}, scan.ctr.lateColumns)
+	})
+
+	t.Run("unsupported reference stays eager", func(t *testing.T) {
+		scan := newScan(0)
+		scan.FilterExprs = []*pbplan.Expr{{Expr: &pbplan.Expr_Raw{Raw: &pbplan.RawColRef{}}}}
+		scan.configureLateMaterialization()
+		require.Empty(t, scan.ctr.earlyColumns)
+		require.Empty(t, scan.ctr.lateColumns)
+	})
+}
+
+func TestLateMaterializationFilterPreservesOriginalSelections(t *testing.T) {
+	proc := testutil.NewProc(t)
+	intType := types.T_int32.ToType()
+	textType := types.T_text.ToType()
+	scan := &TableScan{
+		Attrs: []string{"filter_col", "payload"},
+		Types: []pbplan.Type{plan.MakePlan2Type(&intType), plan.MakePlan2Type(&textType)},
+		FilterExprs: []*pbplan.Expr{
+			lateTestCompare(t, ">", 0, 1),
+			lateTestCompare(t, "<", 0, 4),
+		},
+	}
+	require.NoError(t, scan.Prepare(proc))
+	require.Equal(t, []int{0}, scan.ctr.earlyColumns)
+	require.Equal(t, []int{1}, scan.ctr.lateColumns)
+
+	bat := batch.NewOffHeapWithSize(2)
+	bat.Vecs[0] = vector.NewOffHeapVecWithType(intType)
+	bat.Vecs[1] = vector.NewOffHeapVecWithType(textType)
+	for i := int32(0); i < 5; i++ {
+		require.NoError(t, vector.AppendFixed(bat.Vecs[0], i, false, proc.Mp()))
+	}
+	bat.SetRowCount(5)
+
+	result, err := scan.applyReaderFilter(proc, bat, []int{0})
+	require.NoError(t, err)
+	require.False(t, result.All)
+	require.Equal(t, []int64{2, 3}, result.Sels)
+	require.Equal(t, 2, bat.RowCount())
+	require.Equal(t, []int32{2, 3}, vector.MustFixedColWithTypeCheck[int32](bat.Vecs[0]))
+	require.Zero(t, bat.Vecs[1].Length())
+
+	bat.Clean(proc.Mp())
+	scan.Free(proc, false, nil)
+	proc.Free()
+	require.Zero(t, proc.GetMPool().CurrNB())
+}
+
+func TestTableScanUsesLateMaterializationReader(t *testing.T) {
+	proc := testutil.NewProc(t)
+	intType := types.T_int32.ToType()
+	textType := types.T_text.ToType()
+	reader := &lateMaterializationTestReader{}
+	scan := &TableScan{
+		Reader: reader,
+		Attrs:  []string{"filter_col", "payload"},
+		Types:  []pbplan.Type{plan.MakePlan2Type(&intType), plan.MakePlan2Type(&textType)},
+		FilterExprs: []*pbplan.Expr{
+			lateTestCompare(t, ">", 0, 10),
+		},
+	}
+	require.NoError(t, scan.Prepare(proc))
+
+	result, err := vm.Exec(scan, proc)
+	require.NoError(t, err)
+	require.Nil(t, result.Batch)
+	require.Equal(t, 2, reader.reads)
+	require.False(t, reader.eagerRead)
+	require.Zero(t, scan.ctr.buf.Vecs[0].Length())
+	require.Zero(t, scan.ctr.buf.Vecs[1].Length())
+	require.Equal(t, int64(4), scan.OpAnalyzer.GetOpStats().InputRows)
+
+	scan.Reset(proc, false, nil)
+	require.True(t, reader.closed)
+	scan.Free(proc, false, nil)
+	proc.Free()
+	require.Zero(t, proc.GetMPool().CurrNB())
+}

--- a/pkg/sql/colexec/table_scan/table_scan.go
+++ b/pkg/sql/colexec/table_scan/table_scan.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/trace"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -78,6 +79,17 @@ func (tableScan *TableScan) Prepare(proc *process.Process) (err error) {
 	}
 	tableScan.ctr.allFilterExecutors = append(tableScan.ctr.allFilterExecutors, tableScan.ctr.runtimeFilterExecutors...)
 	tableScan.ctr.allFilterExecutors = append(tableScan.ctr.allFilterExecutors, tableScan.ctr.filterExecutors...)
+	tableScan.configureLateMaterialization()
+	if len(tableScan.ctr.earlyColumns) > 0 {
+		tableScan.ctr.readerFilter = func(
+			bat *batch.Batch,
+			loadedColumns []int,
+		) (engine.ReaderFilterResult, error) {
+			return tableScan.applyReaderFilter(proc, bat, loadedColumns)
+		}
+	} else {
+		tableScan.ctr.readerFilter = nil
+	}
 
 	err = tableScan.PrepareProjection(proc)
 	if tableScan.ctr.buf == nil {
@@ -141,12 +153,13 @@ func (tableScan *TableScan) Call(proc *process.Process) (vm.CallResult, error) {
 
 		// read data from storage engine
 		tableScan.ctr.buf.CleanOnlyData()
+		tableScan.ctr.filterReadMetrics = false
+		tableScan.ctr.filterLateMaterialized = false
+		tableScan.ctr.filterActiveDuration = 0
 
 		crs := analyzer.GetOpCounterSet()
 		newCtx := perfcounter.AttachS3RequestKey(proc.Ctx, crs)
-		isEnd, err := process.MeasureFilesystemWait(analyzer, func() (bool, error) {
-			return tableScan.Reader.Read(newCtx, tableScan.Attrs, nil, proc.Mp(), tableScan.ctr.buf)
-		})
+		isEnd, err := tableScan.readBatch(newCtx, proc)
 		if err != nil {
 			e = err
 			return vm.CancelResult, err
@@ -166,32 +179,38 @@ func (tableScan *TableScan) Call(proc *process.Process) (vm.CallResult, error) {
 			return vm.CancelResult, err
 		}
 
-		if tableScan.ctr.buf.IsEmpty() {
-			continue
-		}
-
-		trace.GetService(proc.GetService()).TxnRead(
-			proc.GetTxnOperator(),
-			proc.GetTxnOperator().Txn().SnapshotTS,
-			tableScan.TableID,
-			tableScan.Attrs,
-			tableScan.ctr.buf)
-
-		// record storage I/O metrics before filtering
-		analyzer.InputBlock()
-		analyzer.ScanBytes(tableScan.ctr.buf)
-		analyzer.Input(tableScan.ctr.buf) // record pre-filter rows for EXPLAIN ANALYZE inputRows
-		batSize := tableScan.ctr.buf.Size()
-		tableScan.ctr.maxAllocSize = max(tableScan.ctr.maxAllocSize, batSize)
-
-		// inline filter evaluation: filter rows before returning to caller
-		if len(tableScan.ctr.allFilterExecutors) > 0 {
-			if err = tableScan.evalFilter(proc); err != nil {
-				e = err
-				return vm.CancelResult, err
+		if tableScan.ctr.filterReadMetrics {
+			if tableScan.ctr.filterLateMaterialized && !tableScan.ctr.buf.IsEmpty() {
+				tableScan.recordLateInput(tableScan.ctr.buf)
 			}
 			if tableScan.ctr.buf.IsEmpty() {
-				continue // all rows filtered out, read next block
+				continue
+			}
+			if tableScan.ctr.filterLateMaterialized {
+				tableScan.traceRead(proc, tableScan.ctr.buf)
+			}
+		} else {
+			if tableScan.ctr.buf.IsEmpty() {
+				continue
+			}
+			tableScan.traceRead(proc, tableScan.ctr.buf)
+
+			// record storage I/O metrics before filtering
+			analyzer.InputBlock()
+			analyzer.ScanBytes(tableScan.ctr.buf)
+			analyzer.Input(tableScan.ctr.buf) // record pre-filter rows for EXPLAIN ANALYZE inputRows
+			batSize := tableScan.ctr.buf.Size()
+			tableScan.ctr.maxAllocSize = max(tableScan.ctr.maxAllocSize, batSize)
+
+			// inline filter evaluation: filter rows before returning to caller
+			if len(tableScan.ctr.allFilterExecutors) > 0 {
+				if _, err = tableScan.evalFilter(proc, tableScan.ctr.buf, nil); err != nil {
+					e = err
+					return vm.CancelResult, err
+				}
+				if tableScan.ctr.buf.IsEmpty() {
+					continue // all rows filtered out, read next block
+				}
 			}
 		}
 
@@ -203,13 +222,35 @@ func (tableScan *TableScan) Call(proc *process.Process) (vm.CallResult, error) {
 	return vm.CallResult{Batch: retBatch, Status: vm.ExecNext}, nil
 }
 
-// evalFilter evaluates inline filter expressions on ctr.buf in-place.
-// After evaluation, ctr.buf contains only the rows that pass all filters.
-// If all rows are filtered out, ctr.buf is set to EmptyBatch.
-func (tableScan *TableScan) evalFilter(proc *process.Process) error {
-	bat := tableScan.ctr.buf
+func (tableScan *TableScan) traceRead(proc *process.Process, bat *batch.Batch) {
+	trace.GetService(proc.GetService()).TxnRead(
+		proc.GetTxnOperator(),
+		proc.GetTxnOperator().Txn().SnapshotTS,
+		tableScan.TableID,
+		tableScan.Attrs,
+		bat,
+	)
+}
+
+// evalFilter evaluates inline filter expressions in-place. loadedColumns is
+// nil for an eager batch; otherwise it identifies the vectors currently
+// present in a late-materialized full-schema batch.
+func (tableScan *TableScan) evalFilter(
+	proc *process.Process,
+	bat *batch.Batch,
+	loadedColumns []int,
+) (engine.ReaderFilterResult, error) {
 	analyzer := tableScan.OpAnalyzer
 	var sels []int64
+	defer func() {
+		if sels != nil {
+			vector.PutSels(sels)
+		}
+	}()
+
+	tableScan.ctr.filterRows = tableScan.ctr.filterRows[:0]
+	hasSelection := false
+	trackOriginalRows := loadedColumns != nil
 
 	for i := range tableScan.ctr.allFilterExecutors {
 		if bat.IsEmpty() {
@@ -218,16 +259,16 @@ func (tableScan *TableScan) evalFilter(proc *process.Process) error {
 
 		vec, err := tableScan.ctr.allFilterExecutors[i].Eval(proc, []*batch.Batch{bat}, nil)
 		if err != nil {
-			return err
+			return engine.ReaderFilterResult{}, err
 		}
 
 		if proc.OperatorOutofMemory(int64(vec.Size())) {
-			return moerr.NewOOM(proc.Ctx)
+			return engine.ReaderFilterResult{}, moerr.NewOOM(proc.Ctx)
 		}
 		analyzer.Alloc(int64(vec.Size()))
 
 		if !vec.GetType().IsBoolean() {
-			return moerr.NewInvalidInput(proc.Ctx, "filter condition is not boolean")
+			return engine.ReaderFilterResult{}, moerr.NewInvalidInput(proc.Ctx, "filter condition is not boolean")
 		}
 
 		if tableScan.ctr.filterBs == nil {
@@ -243,7 +284,9 @@ func (tableScan *TableScan) evalFilter(proc *process.Process) error {
 		if vec.IsConst() {
 			v, null := bs.GetValue(0)
 			if null || !v {
-				bat.SetRowCount(0)
+				tableScan.clearLoadedFilterColumns(bat, loadedColumns)
+				tableScan.ctr.filterRows = tableScan.ctr.filterRows[:0]
+				hasSelection = true
 				break
 			}
 		} else {
@@ -270,19 +313,52 @@ func (tableScan *TableScan) evalFilter(proc *process.Process) error {
 			}
 
 			if len(sels) == 0 {
-				bat.SetRowCount(0)
+				tableScan.clearLoadedFilterColumns(bat, loadedColumns)
+				tableScan.ctr.filterRows = tableScan.ctr.filterRows[:0]
+				hasSelection = true
 				break
 			}
 
 			if len(sels) != bat.RowCount() {
-				bat.Shrink(sels, false)
+				if trackOriginalRows {
+					if !hasSelection {
+						tableScan.ctr.filterRows = append(tableScan.ctr.filterRows, sels...)
+						hasSelection = true
+					} else {
+						for j, row := range sels {
+							tableScan.ctr.filterRows[j] = tableScan.ctr.filterRows[row]
+						}
+						tableScan.ctr.filterRows = tableScan.ctr.filterRows[:len(sels)]
+					}
+				}
+
+				if loadedColumns == nil {
+					bat.Shrink(sels, false)
+				} else {
+					for _, pos := range loadedColumns {
+						bat.Vecs[pos].Shrink(sels, false)
+					}
+					bat.SetRowCount(len(sels))
+				}
 			}
 		}
 	}
 
-	if sels != nil {
-		vector.PutSels(sels)
+	if trackOriginalRows && hasSelection {
+		return engine.ReaderFilterResult{Sels: tableScan.ctr.filterRows}, nil
 	}
+	if !trackOriginalRows {
+		return engine.ReaderFilterResult{}, nil
+	}
+	return engine.ReaderFilterResult{All: true}, nil
+}
 
-	return nil
+func (tableScan *TableScan) clearLoadedFilterColumns(
+	bat *batch.Batch,
+	loadedColumns []int,
+) {
+	for _, pos := range loadedColumns {
+		bat.Vecs[pos].CleanOnlyData()
+	}
+	bat.SetRowCount(0)
 }

--- a/pkg/sql/colexec/table_scan/types.go
+++ b/pkg/sql/colexec/table_scan/types.go
@@ -15,6 +15,8 @@
 package table_scan
 
 import (
+	"time"
+
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -37,6 +39,14 @@ type container struct {
 	runtimeFilterExecutors []colexec.ExpressionExecutor
 	allFilterExecutors     []colexec.ExpressionExecutor // runtime + static; elements owned by above slices
 	filterBs               vector.FunctionParameterWrapper[bool]
+	earlyColumns           []int
+	lateColumns            []int
+	filterRows             []int64
+	filterReadMetrics      bool
+	filterLateMaterialized bool
+	filterActiveDuration   time.Duration
+	readerFilter           engine.ReaderFilter
+	metricView             *batch.Batch
 }
 
 type TableScan struct {
@@ -110,6 +120,13 @@ func (tableScan *TableScan) Reset(proc *process.Process, pipelineFailed bool, er
 	}
 	tableScan.ctr.runtimeFilterExecutors = nil
 	tableScan.ctr.allFilterExecutors = nil
+	tableScan.ctr.earlyColumns = tableScan.ctr.earlyColumns[:0]
+	tableScan.ctr.lateColumns = tableScan.ctr.lateColumns[:0]
+	tableScan.ctr.filterRows = tableScan.ctr.filterRows[:0]
+	tableScan.ctr.filterReadMetrics = false
+	tableScan.ctr.filterLateMaterialized = false
+	tableScan.ctr.filterActiveDuration = 0
+	tableScan.ctr.readerFilter = nil
 	tableScan.RuntimeFilterExprs = nil
 	tableScan.ctr.maxAllocSize = 0
 	if tableScan.OpAnalyzer != nil {
@@ -142,6 +159,17 @@ func (tableScan *TableScan) Free(proc *process.Process, pipelineFailed bool, err
 	}
 	tableScan.ctr.runtimeFilterExecutors = nil
 	tableScan.ctr.allFilterExecutors = nil
+	tableScan.ctr.earlyColumns = nil
+	tableScan.ctr.lateColumns = nil
+	tableScan.ctr.filterRows = nil
+	tableScan.ctr.filterReadMetrics = false
+	tableScan.ctr.filterLateMaterialized = false
+	tableScan.ctr.filterActiveDuration = 0
+	tableScan.ctr.readerFilter = nil
+	if tableScan.ctr.metricView != nil {
+		tableScan.ctr.metricView.Vecs = nil
+		tableScan.ctr.metricView = nil
+	}
 }
 
 func (tableScan *TableScan) closeReader() {

--- a/pkg/vm/engine/readutil/reader.go
+++ b/pkg/vm/engine/readutil/reader.go
@@ -17,6 +17,7 @@ package readutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -358,7 +359,15 @@ func (r *mergeReader) SetIndexParam(param *plan.IndexReaderParam) {
 }
 
 func (r *mergeReader) Close() error {
-	return nil
+	readers := r.rds
+	r.rds = nil
+	var firstErr error
+	for _, rd := range readers {
+		if err := rd.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (r *mergeReader) Read(
@@ -379,16 +388,70 @@ func (r *mergeReader) Read(
 	for len(r.rds) > 0 {
 		isEnd, err := r.rds[0].Read(ctx, cols, expr, mp, outBatch)
 		if err != nil {
-			for _, rd := range r.rds {
-				rd.Close()
-			}
-			return false, err
+			return false, errors.Join(err, r.Close())
 		}
 		if isEnd {
+			child := r.rds[0]
 			r.rds = r.rds[1:]
+			if closeErr := child.Close(); closeErr != nil {
+				return false, errors.Join(closeErr, r.Close())
+			}
 		} else {
 			if logutil.GetSkip1Logger().Core().Enabled(zap.DebugLevel) {
 				logutil.Debug("merge reader catch batch")
+			}
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (r *mergeReader) ReadWithFilter(
+	ctx context.Context,
+	cols []string,
+	earlyColumns []int,
+	filter engine.ReaderFilter,
+	mp *mpool.MPool,
+	outBatch *batch.Batch,
+) (bool, error) {
+	start := time.Now()
+	defer func() {
+		v2.TxnMergeReaderDurationHistogram.Observe(time.Since(start).Seconds())
+	}()
+	if filter == nil {
+		return false, moerr.NewInvalidInputNoCtx("nil reader filter")
+	}
+
+	if len(r.rds) == 0 {
+		return true, nil
+	}
+	for len(r.rds) > 0 {
+		var (
+			isEnd bool
+			err   error
+		)
+		if lateReader, ok := r.rds[0].(engine.LateMaterializationReader); ok {
+			isEnd, err = lateReader.ReadWithFilter(
+				ctx, cols, earlyColumns, filter, mp, outBatch,
+			)
+		} else {
+			isEnd, err = r.rds[0].Read(ctx, cols, nil, mp, outBatch)
+			if err == nil && !isEnd && !outBatch.IsEmpty() {
+				_, err = filter(outBatch, nil)
+			}
+		}
+		if err != nil {
+			return false, errors.Join(err, r.Close())
+		}
+		if isEnd {
+			child := r.rds[0]
+			r.rds = r.rds[1:]
+			if closeErr := child.Close(); closeErr != nil {
+				return false, errors.Join(closeErr, r.Close())
+			}
+		} else {
+			if logutil.GetSkip1Logger().Core().Enabled(zap.DebugLevel) {
+				logutil.Debug("merge reader catch filtered batch")
 			}
 			return false, nil
 		}
@@ -604,6 +667,34 @@ func (r *reader) Read(
 	mp *mpool.MPool,
 	outBatch *batch.Batch,
 ) (isEnd bool, err error) {
+	isEnd, _, err = r.read(ctx, cols, expr, mp, outBatch, nil, nil)
+	return isEnd, err
+}
+
+func (r *reader) ReadWithFilter(
+	ctx context.Context,
+	cols []string,
+	earlyColumns []int,
+	filter engine.ReaderFilter,
+	mp *mpool.MPool,
+	outBatch *batch.Batch,
+) (isEnd bool, err error) {
+	if filter == nil {
+		return false, moerr.NewInvalidInputNoCtx("nil reader filter")
+	}
+	isEnd, _, err = r.read(ctx, cols, nil, mp, outBatch, earlyColumns, filter)
+	return isEnd, err
+}
+
+func (r *reader) read(
+	ctx context.Context,
+	cols []string,
+	expr *plan.Expr,
+	mp *mpool.MPool,
+	outBatch *batch.Batch,
+	earlyColumns []int,
+	readerFilter engine.ReaderFilter,
+) (isEnd bool, lateMaterialized bool, err error) {
 	outBatch.CleanOnlyData()
 
 	var dataState engine.DataState
@@ -722,16 +813,16 @@ func (r *reader) Read(
 	dataState = state
 
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	if state == engine.End {
-		return true, nil
+		return true, false, nil
 	}
 	if state == engine.InMem {
 		if r.orderByLimit != nil && !r.orderByLimit.OrderedLimit {
 			sels, dists, err := blockio.HandleOrderByLimitOnIVFFlatIndex(ctx, nil, outBatch.Vecs[r.orderByLimit.ColPos], r.orderByLimit)
 			if err != nil {
-				return false, err
+				return false, false, err
 			}
 
 			// Keep batch cardinality consistent with pushed-down vector TopN result.
@@ -740,7 +831,7 @@ func (r *reader) Read(
 			if len(sels) == 0 {
 				outBatch.CleanOnlyData()
 			} else if err := outBatch.Shuffle(sels, mp); err != nil {
-				return false, err
+				return false, false, err
 			}
 
 			// Reuse the detached distVec when possible to avoid per-batch allocation.
@@ -750,12 +841,17 @@ func (r *reader) Read(
 			}
 			detachedDistVec = nil
 			if err := vector.AppendFixedList(distVec, dists, nil, mp); err != nil {
-				return false, err
+				return false, false, err
 			}
 			outBatch.Vecs = append(outBatch.Vecs, distVec)
 		}
 
-		return false, nil
+		if readerFilter != nil && !outBatch.IsEmpty() {
+			if _, err = readerFilter(outBatch, nil); err != nil {
+				return false, false, err
+			}
+		}
+		return false, false, nil
 	}
 	//read block
 	filter := r.withFilterMixin.filterState.filter
@@ -783,30 +879,60 @@ func (r *reader) Read(
 		detachedDistVec = nil
 	}
 
-	err = blockio.BlockDataRead(
-		statsCtx,
-		blkInfo,
-		r.source,
-		r.columns.seqnums,
-		r.columns.colTypes,
-		r.columns.phyAddrPos,
-		r.ts,
-		r.filterState.seqnums,
-		r.filterState.colTypes,
-		filter,
-		r.orderByLimit,
-		policy,
-		r.name,
-		outBatch,
-		r.cacheVectors,
-		mp,
-		r.fs,
-	)
+	if readerFilter != nil && r.orderByLimit == nil {
+		lateMaterialized = true
+		var preFilterRows int
+		preFilterRows, err = blockio.BlockDataReadWithFilter(
+			statsCtx,
+			blkInfo,
+			r.source,
+			r.columns.seqnums,
+			r.columns.colTypes,
+			r.columns.phyAddrPos,
+			r.ts,
+			r.filterState.seqnums,
+			r.filterState.colTypes,
+			filter,
+			policy,
+			r.name,
+			outBatch,
+			r.cacheVectors,
+			mp,
+			r.fs,
+			earlyColumns,
+			readerFilter,
+		)
+		if err == nil && preFilterRows == 1 {
+			// Preserve the exact-PK hit feedback that eager BlockDataRead records
+			// before TableScan applies its residual predicate.
+			r.withFilterMixin.filterState.memFilter.RecordExactHit()
+		}
+	} else {
+		err = blockio.BlockDataRead(
+			statsCtx,
+			blkInfo,
+			r.source,
+			r.columns.seqnums,
+			r.columns.colTypes,
+			r.columns.phyAddrPos,
+			r.ts,
+			r.filterState.seqnums,
+			r.filterState.colTypes,
+			filter,
+			r.orderByLimit,
+			policy,
+			r.name,
+			outBatch,
+			r.cacheVectors,
+			mp,
+			r.fs,
+		)
+	}
 	if err != nil {
-		return false, err
+		return false, lateMaterialized, err
 	}
 
-	if outBatch.RowCount() == 1 {
+	if !lateMaterialized && outBatch.RowCount() == 1 {
 		// found one row in this blk for the pk equal, record it
 		r.withFilterMixin.filterState.memFilter.RecordExactHit()
 	}
@@ -822,7 +948,13 @@ func (r *reader) Read(
 		outBatch.GetVector(int32(r.columns.indexOfFirstSortedColumn)).SetSorted(true)
 	}
 
-	return false, nil
+	if readerFilter != nil && !lateMaterialized && !outBatch.IsEmpty() {
+		if _, err = readerFilter(outBatch, nil); err != nil {
+			return false, false, err
+		}
+	}
+
+	return false, lateMaterialized, nil
 }
 
 func GetThresholdForReader(readerNum int) uint64 {

--- a/pkg/vm/engine/readutil/reader_test.go
+++ b/pkg/vm/engine/readutil/reader_test.go
@@ -15,14 +15,226 @@
 package readutil
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vectorindex/metric"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/stretchr/testify/require"
 )
+
+type singlePersistedBlockSource struct {
+	info       objectio.BlockInfo
+	emitted    bool
+	closeCount int32
+}
+
+func (s *singlePersistedBlockSource) Next(
+	context.Context,
+	[]string,
+	[]types.Type,
+	[]uint16,
+	int32,
+	any,
+	*mpool.MPool,
+	*batch.Batch,
+) (*objectio.BlockInfo, engine.DataState, error) {
+	if s.emitted {
+		return nil, engine.End, nil
+	}
+	s.emitted = true
+	return &s.info, engine.Persisted, nil
+}
+
+func (*singlePersistedBlockSource) ApplyTombstones(
+	context.Context,
+	*objectio.Blockid,
+	[]int64,
+	engine.TombstoneApplyPolicy,
+) ([]int64, error) {
+	return nil, nil
+}
+
+func (*singlePersistedBlockSource) GetTombstones(
+	context.Context,
+	*objectio.Blockid,
+) (objectio.Bitmap, error) {
+	return objectio.Bitmap{}, nil
+}
+
+func (*singlePersistedBlockSource) SetOrderBy([]*plan.OrderBySpec)  {}
+func (*singlePersistedBlockSource) GetOrderBy() []*plan.OrderBySpec { return nil }
+func (*singlePersistedBlockSource) SetFilterZM(objectio.ZoneMap)    {}
+func (s *singlePersistedBlockSource) Close() {
+	atomic.AddInt32(&s.closeCount, 1)
+}
+func (*singlePersistedBlockSource) String() string { return "singlePersistedBlockSource" }
+
+func TestReaderLateMaterializationSkipsPersistedPayload(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	writeMP := mpool.MustNewZero()
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_text.ToType())
+	for i := 0; i < 8; i++ {
+		require.NoError(t, vector.AppendFixed(input.Vecs[0], int32(i), false, writeMP))
+		require.NoError(t, vector.AppendBytes(input.Vecs[1], []byte("persisted-payload"), false, writeMP))
+	}
+	input.SetRowCount(8)
+	writer := ioutil.ConstructWriter(0, []uint16{0, 1}, -1, false, false, fs)
+	_, err := writer.WriteBatch(input)
+	require.NoError(t, err)
+	_, _, err = writer.Sync(ctx)
+	require.NoError(t, err)
+	stats := writer.GetObjectStats()
+	input.Clean(writeMP)
+	require.Zero(t, writeMP.CurrNB())
+	mpool.DeleteMPool(writeMP)
+
+	tableDef := &plan.TableDef{
+		Name:          "late_reader_test",
+		Name2ColIndex: map[string]int32{"id": 0, "payload": 1},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}, PkeyColName: "id"},
+		Cols: []*plan.ColDef{{
+			Name:    "id",
+			Seqnum:  0,
+			Primary: true,
+			Typ:     plan.Type{Id: int32(types.T_int32)},
+		}, {
+			Name:   "payload",
+			Seqnum: 1,
+			Typ:    plan.Type{Id: int32(types.T_text)},
+		}},
+	}
+	source := &singlePersistedBlockSource{info: stats.ConstructBlockInfo(0)}
+	queryMP := mpool.MustNewZero()
+	r, err := NewReader(
+		ctx,
+		queryMP,
+		nil,
+		fs,
+		tableDef,
+		timestamp.Timestamp{},
+		nil,
+		source,
+		0,
+		engine.FilterHint{},
+	)
+	require.NoError(t, err)
+	mr := NewMergeReader([]engine.Reader{r})
+
+	output := batch.NewWithSize(2)
+	output.Vecs[0] = vector.NewOffHeapVecWithType(types.T_int32.ToType())
+	output.Vecs[1] = vector.NewOffHeapVecWithType(types.T_text.ToType())
+	isEnd, err := mr.ReadWithFilter(
+		ctx,
+		[]string{"id", "payload"},
+		[]int{0},
+		func(bat *batch.Batch, loaded []int) (engine.ReaderFilterResult, error) {
+			require.Equal(t, []int{0}, loaded)
+			require.Equal(t, 8, bat.Vecs[0].Length())
+			require.Zero(t, bat.Vecs[1].Length())
+			bat.Vecs[0].CleanOnlyData()
+			bat.SetRowCount(0)
+			return engine.ReaderFilterResult{}, nil
+		},
+		queryMP,
+		output,
+	)
+	require.NoError(t, err)
+	require.False(t, isEnd)
+	require.Zero(t, output.RowCount())
+	require.Zero(t, output.Vecs[0].Length())
+	require.Zero(t, output.Vecs[1].Length())
+
+	require.NoError(t, mr.Close())
+	require.Equal(t, int32(1), atomic.LoadInt32(&source.closeCount))
+
+	output.Clean(queryMP)
+	require.Zero(t, queryMP.CurrNB())
+	mpool.DeleteMPool(queryMP)
+}
+
+func TestMergeReaderRejectsNilReaderFilter(t *testing.T) {
+	mr := NewMergeReader(nil)
+	_, err := mr.ReadWithFilter(context.Background(), nil, nil, nil, nil, nil)
+	require.ErrorContains(t, err, "nil reader filter")
+}
+
+type lateMaterializationReaderStub struct {
+	end        bool
+	err        error
+	closeCount int32
+}
+
+func (r *lateMaterializationReaderStub) Read(
+	context.Context, []string, *plan.Expr, *mpool.MPool, *batch.Batch,
+) (bool, error) {
+	return r.end, r.err
+}
+
+func (r *lateMaterializationReaderStub) ReadWithFilter(
+	context.Context, []string, []int, engine.ReaderFilter, *mpool.MPool, *batch.Batch,
+) (bool, error) {
+	return r.end, r.err
+}
+
+func (r *lateMaterializationReaderStub) Close() error {
+	atomic.AddInt32(&r.closeCount, 1)
+	return nil
+}
+
+func (*lateMaterializationReaderStub) SetOrderBy([]*plan.OrderBySpec)       {}
+func (*lateMaterializationReaderStub) GetOrderBy() []*plan.OrderBySpec      { return nil }
+func (*lateMaterializationReaderStub) SetIndexParam(*plan.IndexReaderParam) {}
+func (*lateMaterializationReaderStub) SetFilterZM(objectio.ZoneMap)         {}
+
+func TestMergeReaderReadWithFilterClosesChildren(t *testing.T) {
+	t.Run("on end", func(t *testing.T) {
+		child := &lateMaterializationReaderStub{end: true}
+		mr := NewMergeReader([]engine.Reader{child})
+		isEnd, err := mr.ReadWithFilter(
+			context.Background(), nil, nil,
+			func(*batch.Batch, []int) (engine.ReaderFilterResult, error) {
+				return engine.ReaderFilterResult{}, nil
+			}, nil, nil,
+		)
+		require.NoError(t, err)
+		require.True(t, isEnd)
+		require.Equal(t, int32(1), atomic.LoadInt32(&child.closeCount))
+		require.NoError(t, mr.Close())
+		require.Equal(t, int32(1), atomic.LoadInt32(&child.closeCount))
+	})
+
+	t.Run("on filter error", func(t *testing.T) {
+		filterErr := errors.New("filter failure")
+		child := &lateMaterializationReaderStub{err: filterErr}
+		mr := NewMergeReader([]engine.Reader{child})
+		_, err := mr.ReadWithFilter(
+			context.Background(), nil, nil,
+			func(*batch.Batch, []int) (engine.ReaderFilterResult, error) {
+				return engine.ReaderFilterResult{}, nil
+			}, nil, nil,
+		)
+		require.ErrorIs(t, err, filterErr)
+		require.Equal(t, int32(1), atomic.LoadInt32(&child.closeCount))
+		require.NoError(t, mr.Close())
+		require.Equal(t, int32(1), atomic.LoadInt32(&child.closeCount))
+	})
+}
 
 func TestReaderSetIndexParamDoesNotPreallocateDistHeap(t *testing.T) {
 	r := &reader{}

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -256,6 +256,109 @@ func BlockDataRead(
 	mp *mpool.MPool,
 	fs fileservice.FileService,
 ) error {
+	return blockDataRead(
+		ctx,
+		info,
+		ds,
+		columns,
+		colTypes,
+		phyAddrColumnPos,
+		ts,
+		filterSeqnums,
+		filterColTypes,
+		filter,
+		orderByLimit,
+		policy,
+		tableName,
+		bat,
+		cacheVectors,
+		mp,
+		fs,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+// BlockDataReadWithFilter applies a residual filter after materializing only
+// earlyColumns, then reads the other columns for the surviving rows. It is
+// intentionally limited to scans without storage TopN; callers must use the
+// eager BlockDataRead path when orderByLimit is active. preFilterRows is the
+// live row count after storage visibility and tombstones but before the
+// residual filter.
+func BlockDataReadWithFilter(
+	ctx context.Context,
+	info *objectio.BlockInfo,
+	ds engine.DataSource,
+	columns []uint16,
+	colTypes []types.Type,
+	phyAddrColumnPos int,
+	ts timestamp.Timestamp,
+	filterSeqnums []uint16,
+	filterColTypes []types.Type,
+	filter objectio.BlockReadFilter,
+	policy fileservice.Policy,
+	tableName string,
+	bat *batch.Batch,
+	cacheVectors containers.Vectors,
+	mp *mpool.MPool,
+	fs fileservice.FileService,
+	earlyColumns []int,
+	applyFilter engine.ReaderFilter,
+) (preFilterRows int, err error) {
+	if applyFilter == nil {
+		return 0, moerr.NewInvalidInputNoCtx("nil residual block filter")
+	}
+	if err := validateEarlyColumns(earlyColumns, len(columns)); err != nil {
+		return 0, err
+	}
+	err = blockDataRead(
+		ctx,
+		info,
+		ds,
+		columns,
+		colTypes,
+		phyAddrColumnPos,
+		ts,
+		filterSeqnums,
+		filterColTypes,
+		filter,
+		nil,
+		policy,
+		tableName,
+		bat,
+		cacheVectors,
+		mp,
+		fs,
+		earlyColumns,
+		applyFilter,
+		&preFilterRows,
+	)
+	return preFilterRows, err
+}
+
+func blockDataRead(
+	ctx context.Context,
+	info *objectio.BlockInfo,
+	ds engine.DataSource,
+	columns []uint16,
+	colTypes []types.Type,
+	phyAddrColumnPos int,
+	ts timestamp.Timestamp,
+	filterSeqnums []uint16,
+	filterColTypes []types.Type,
+	filter objectio.BlockReadFilter,
+	orderByLimit *objectio.IndexReaderTopOp,
+	policy fileservice.Policy,
+	tableName string,
+	bat *batch.Batch,
+	cacheVectors containers.Vectors,
+	mp *mpool.MPool,
+	fs fileservice.FileService,
+	earlyColumns []int,
+	applyFilter engine.ReaderFilter,
+	preFilterRows *int,
+) error {
 	if logutil.GetSkip1Logger().Core().Enabled(zap.DebugLevel) {
 		logutil.Debugf("read block %s, columns %v, types %v", info.BlockID.String(), columns, colTypes)
 	}
@@ -295,27 +398,50 @@ func BlockDataRead(
 		}
 	}
 
-	err = BlockDataReadInner(
-		ctx,
-		info,
-		ds,
-		columns,
-		colTypes,
-		phyAddrColumnPos,
-		snapshotTS,
-		sels,
-		orderByLimit,
-		policy,
-		bat,
-		cacheVectors,
-		mp,
-		fs,
-	)
+	if applyFilter == nil {
+		err = BlockDataReadInner(
+			ctx,
+			info,
+			ds,
+			columns,
+			colTypes,
+			phyAddrColumnPos,
+			snapshotTS,
+			sels,
+			orderByLimit,
+			policy,
+			bat,
+			cacheVectors,
+			mp,
+			fs,
+		)
+	} else {
+		err = blockDataReadWithFilter(
+			ctx,
+			info,
+			ds,
+			columns,
+			colTypes,
+			phyAddrColumnPos,
+			snapshotTS,
+			sels,
+			policy,
+			bat,
+			cacheVectors,
+			mp,
+			fs,
+			earlyColumns,
+			applyFilter,
+			preFilterRows,
+		)
+	}
 	if err != nil {
 		return err
 	}
 
-	bat.SetRowCount(bat.Vecs[0].Length())
+	if applyFilter == nil {
+		bat.SetRowCount(bat.Vecs[0].Length())
+	}
 	return nil
 }
 
@@ -676,6 +802,368 @@ func materializeBlockData(
 		}
 	}
 	return
+}
+
+func validateEarlyColumns(earlyColumns []int, columnCount int) error {
+	if len(earlyColumns) == 0 || len(earlyColumns) >= columnCount {
+		return moerr.NewInvalidInputNoCtxf(
+			"early column count %d must be in [1, %d)",
+			len(earlyColumns),
+			columnCount,
+		)
+	}
+	previous := -1
+	for _, pos := range earlyColumns {
+		if pos < 0 || pos >= columnCount {
+			return moerr.NewInvalidInputNoCtxf(
+				"early column position %d out of range [0, %d)",
+				pos,
+				columnCount,
+			)
+		}
+		if pos <= previous {
+			return moerr.NewInvalidInputNoCtx("early column positions must be sorted and unique")
+		}
+		previous = pos
+	}
+	return nil
+}
+
+func columnPositionsComplement(earlyColumns []int, columnCount int) []int {
+	lateColumns := make([]int, 0, columnCount-len(earlyColumns))
+	earlyIdx := 0
+	for pos := 0; pos < columnCount; pos++ {
+		if earlyIdx < len(earlyColumns) && earlyColumns[earlyIdx] == pos {
+			earlyIdx++
+			continue
+		}
+		lateColumns = append(lateColumns, pos)
+	}
+	return lateColumns
+}
+
+func validateLateMaterializationOutput(
+	columns []uint16,
+	colTypes []types.Type,
+	outputBat *batch.Batch,
+) error {
+	if len(columns) != len(colTypes) {
+		return moerr.NewInvalidInputNoCtxf(
+			"block column count %d does not match type count %d",
+			len(columns),
+			len(colTypes),
+		)
+	}
+	if outputBat == nil {
+		return moerr.NewInvalidInputNoCtx("nil output batch for late block read")
+	}
+	if len(outputBat.Vecs) < len(columns) {
+		return moerr.NewInvalidInputNoCtxf(
+			"block output vector count %d is smaller than column count %d",
+			len(outputBat.Vecs),
+			len(columns),
+		)
+	}
+	for pos := range columns {
+		if outputBat.Vecs[pos] == nil {
+			return moerr.NewInvalidInputNoCtxf("nil output vector for block column %d", columns[pos])
+		}
+	}
+	return nil
+}
+
+// materializeBlockColumnsAtPositions builds a non-owning batch view over the
+// caller's destination vectors. The view never releases those vectors.
+func materializeBlockColumnsAtPositions(
+	ctx context.Context,
+	info *objectio.BlockInfo,
+	columns []uint16,
+	colTypes []types.Type,
+	phyAddrColumnPos int,
+	positions []int,
+	selectRows []int64,
+	visibilityTS *types.TS,
+	policy fileservice.Policy,
+	outputBat *batch.Batch,
+	mp *mpool.MPool,
+	fs fileservice.FileService,
+) (objectio.Bitmap, error) {
+	if outputBat == nil {
+		return objectio.NullBitmap, moerr.NewInvalidInputNoCtx("nil output batch for block columns")
+	}
+	selectedColumns := make([]uint16, len(positions))
+	selectedTypes := make([]types.Type, len(positions))
+	selectedOutput := batch.NewWithSize(len(positions))
+	selectedPhyAddrPos := -1
+	for i, pos := range positions {
+		if pos < 0 || pos >= len(columns) || pos >= len(colTypes) || pos >= len(outputBat.Vecs) {
+			return objectio.NullBitmap, moerr.NewInvalidInputNoCtxf(
+				"block column position %d is out of range",
+				pos,
+			)
+		}
+		selectedColumns[i] = columns[pos]
+		selectedTypes[i] = colTypes[pos]
+		selectedOutput.Vecs[i] = outputBat.Vecs[pos]
+		if pos == phyAddrColumnPos {
+			selectedPhyAddrPos = i
+		}
+	}
+	return materializeBlockData(
+		ctx,
+		info,
+		selectedColumns,
+		selectedTypes,
+		selectedPhyAddrPos,
+		selectRows,
+		visibilityTS,
+		policy,
+		selectedOutput,
+		mp,
+		fs,
+	)
+}
+
+func validateReaderFilterResult(
+	result engine.ReaderFilterResult,
+	inputRows int,
+	outputRows int,
+) error {
+	if result.All {
+		if outputRows != inputRows {
+			return moerr.NewInvalidInputNoCtxf(
+				"residual filter marked all rows selected but changed row count from %d to %d",
+				inputRows,
+				outputRows,
+			)
+		}
+		return nil
+	}
+	if len(result.Sels) != outputRows {
+		return moerr.NewInvalidInputNoCtxf(
+			"residual filter returned %d selections for %d output rows",
+			len(result.Sels),
+			outputRows,
+		)
+	}
+	previous := int64(-1)
+	for _, row := range result.Sels {
+		if row < 0 || row >= int64(inputRows) {
+			return moerr.NewInvalidInputNoCtxf(
+				"residual filter row %d out of range [0, %d)",
+				row,
+				inputRows,
+			)
+		}
+		if row <= previous {
+			return moerr.NewInvalidInputNoCtx("residual filter rows must be sorted and unique")
+		}
+		previous = row
+	}
+	return nil
+}
+
+func blockDataReadWithFilter(
+	ctx context.Context,
+	info *objectio.BlockInfo,
+	ds engine.DataSource,
+	columns []uint16,
+	colTypes []types.Type,
+	phyAddrColumnPos int,
+	ts types.TS,
+	storageSelectRows []int64,
+	policy fileservice.Policy,
+	outputBat *batch.Batch,
+	cacheVectors containers.Vectors,
+	mp *mpool.MPool,
+	fs fileservice.FileService,
+	earlyColumns []int,
+	applyFilter engine.ReaderFilter,
+	preFilterRows *int,
+) (err error) {
+	if err = validateLateMaterializationOutput(columns, colTypes, outputBat); err != nil {
+		return err
+	}
+	cacheVectors.Free(mp)
+
+	var (
+		deleteMask       objectio.Bitmap
+		physicalRows     []int64
+		physicalRowCount int
+	)
+	if storageSelectRows != nil {
+		ignoredMask, readErr := materializeBlockColumnsAtPositions(
+			ctx,
+			info,
+			columns,
+			colTypes,
+			phyAddrColumnPos,
+			earlyColumns,
+			storageSelectRows,
+			nil,
+			policy,
+			outputBat,
+			mp,
+			fs,
+		)
+		ignoredMask.Release()
+		if readErr != nil {
+			return readErr
+		}
+		physicalRows = storageSelectRows
+	} else {
+		if ds == nil {
+			return moerr.NewInvalidInputNoCtx("nil data source for late block read")
+		}
+		tombstones, tombstoneErr := ds.GetTombstones(ctx, &info.BlockID)
+		if tombstoneErr != nil {
+			tombstones.Release()
+			return tombstoneErr
+		}
+		var visibilityTS *types.TS
+		if info.IsAppendable() {
+			visibilityTS = &ts
+		}
+		if deleteMask, err = materializeBlockColumnsAtPositions(
+			ctx,
+			info,
+			columns,
+			colTypes,
+			phyAddrColumnPos,
+			earlyColumns,
+			nil,
+			visibilityTS,
+			policy,
+			outputBat,
+			mp,
+			fs,
+		); err != nil {
+			tombstones.Release()
+			return err
+		}
+		if !deleteMask.IsValid() {
+			deleteMask = tombstones
+		} else {
+			deleteMask.Or(tombstones)
+			tombstones.Release()
+		}
+		defer deleteMask.Release()
+
+		physicalRowCount = outputBat.Vecs[earlyColumns[0]].Length()
+		if !deleteMask.IsEmpty() {
+			deleted := vector.GetSels()
+			defer func() { vector.PutSels(deleted) }()
+			deleted = deleteMask.ToI64Array(&deleted)
+			for _, pos := range earlyColumns {
+				outputBat.Vecs[pos].Shrink(deleted, true)
+			}
+		}
+	}
+
+	liveRows := outputBat.Vecs[earlyColumns[0]].Length()
+	outputBat.SetRowCount(liveRows)
+	for _, pos := range earlyColumns {
+		if outputBat.Vecs[pos].Length() != liveRows {
+			return moerr.NewInvalidInputNoCtxf(
+				"early column %d has %d rows before filtering, expected %d",
+				pos,
+				outputBat.Vecs[pos].Length(),
+				liveRows,
+			)
+		}
+	}
+	if preFilterRows != nil {
+		*preFilterRows = liveRows
+	}
+	if liveRows == 0 {
+		return nil
+	}
+
+	filterResult, err := applyFilter(outputBat, earlyColumns)
+	if err != nil {
+		return err
+	}
+	if err = validateReaderFilterResult(filterResult, liveRows, outputBat.RowCount()); err != nil {
+		return err
+	}
+	for _, pos := range earlyColumns {
+		if outputBat.Vecs[pos].Length() != outputBat.RowCount() {
+			return moerr.NewInvalidInputNoCtxf(
+				"residual filter left early column %d with %d rows for batch row count %d",
+				pos,
+				outputBat.Vecs[pos].Length(),
+				outputBat.RowCount(),
+			)
+		}
+	}
+	if outputBat.RowCount() == 0 {
+		return nil
+	}
+
+	selectedPhysicalRows := physicalRows
+	if physicalRows == nil && !deleteMask.IsEmpty() {
+		// Map only the surviving logical rows back to block offsets. In
+		// particular, a zero-result filter returns above without building an
+		// O(block rows) live-row slice.
+		selectedPhysicalRows = vector.GetSels()
+		defer func() { vector.PutSels(selectedPhysicalRows) }()
+		nextSelected := 0
+		liveRow := int64(0)
+		for physicalRow := 0; physicalRow < physicalRowCount; physicalRow++ {
+			if deleteMask.Contains(uint64(physicalRow)) {
+				continue
+			}
+			if filterResult.All ||
+				(nextSelected < len(filterResult.Sels) && filterResult.Sels[nextSelected] == liveRow) {
+				selectedPhysicalRows = append(selectedPhysicalRows, int64(physicalRow))
+				if !filterResult.All {
+					nextSelected++
+				}
+			}
+			liveRow++
+		}
+	} else if !filterResult.All {
+		if physicalRows == nil {
+			selectedPhysicalRows = filterResult.Sels
+		} else {
+			selectedPhysicalRows = vector.GetSels()
+			defer func() { vector.PutSels(selectedPhysicalRows) }()
+			for _, row := range filterResult.Sels {
+				selectedPhysicalRows = append(selectedPhysicalRows, physicalRows[row])
+			}
+		}
+	}
+
+	lateColumns := columnPositionsComplement(earlyColumns, len(columns))
+	ignoredMask, readErr := materializeBlockColumnsAtPositions(
+		ctx,
+		info,
+		columns,
+		colTypes,
+		phyAddrColumnPos,
+		lateColumns,
+		selectedPhysicalRows,
+		nil,
+		policy,
+		outputBat,
+		mp,
+		fs,
+	)
+	ignoredMask.Release()
+	if readErr != nil {
+		return readErr
+	}
+	for _, pos := range lateColumns {
+		if outputBat.Vecs[pos].Length() != outputBat.RowCount() {
+			return moerr.NewInvalidInputNoCtxf(
+				"late column %d has %d rows for batch row count %d",
+				pos,
+				outputBat.Vecs[pos].Length(),
+				outputBat.RowCount(),
+			)
+		}
+	}
+	return nil
 }
 
 // BlockDataReadInner only read data,don't apply deletes.

--- a/pkg/vm/engine/tae/blockio/read_test.go
+++ b/pkg/vm/engine/tae/blockio/read_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vectorindex/metric"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -268,6 +269,179 @@ func TestBlockDataReadInnerScopedMaterialization(t *testing.T) {
 	require.Zero(t, queryMP.CurrNB())
 }
 
+func TestBlockDataReadWithFilterDefersPayload(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	colTypes := []types.Type{types.T_int32.ToType(), types.T_text.ToType()}
+
+	writeMP := mpool.MustNewZero()
+	input := batch.NewWithSize(len(colTypes))
+	for i := range colTypes {
+		input.Vecs[i] = vector.NewVec(colTypes[i])
+	}
+	for i := 0; i < 8; i++ {
+		require.NoError(t, vector.AppendFixed(input.Vecs[0], int32(i), false, writeMP))
+		require.NoError(t, vector.AppendBytes(input.Vecs[1], []byte("payload-"+string(rune('0'+i))), false, writeMP))
+	}
+	input.SetRowCount(8)
+	writer := ioutil.ConstructWriter(0, []uint16{0, 1}, -1, false, false, fs)
+	_, err := writer.WriteBatch(input)
+	require.NoError(t, err)
+	_, _, err = writer.Sync(ctx)
+	require.NoError(t, err)
+	stats := writer.GetObjectStats()
+	info := stats.ConstructBlockInfo(0)
+	input.Clean(writeMP)
+	require.Zero(t, writeMP.CurrNB())
+	mpool.DeleteMPool(writeMP)
+
+	queryMP := mpool.MustNewZero()
+	defer mpool.DeleteMPool(queryMP)
+	output := batch.NewWithSize(len(colTypes))
+	for i := range colTypes {
+		output.Vecs[i] = vector.NewOffHeapVecWithType(colTypes[i])
+	}
+	cacheVectors := containers.NewVectors(len(colTypes) + 2)
+	ds := &blockReadTestDataSource{deleted: []uint64{3}}
+
+	read := func(filter engine.ReaderFilter) error {
+		_, err := BlockDataReadWithFilter(
+			ctx,
+			&info,
+			ds,
+			[]uint16{0, 1},
+			colTypes,
+			-1,
+			timestamp.Timestamp{},
+			nil,
+			nil,
+			objectio.BlockReadFilter{},
+			fileservice.Policy(0),
+			"late-read-test",
+			output,
+			cacheVectors,
+			queryMP,
+			fs,
+			[]int{0},
+			filter,
+		)
+		return err
+	}
+
+	t.Run("partial survivors map through tombstones", func(t *testing.T) {
+		require.NoError(t, read(func(bat *batch.Batch, loaded []int) (engine.ReaderFilterResult, error) {
+			require.Equal(t, []int{0}, loaded)
+			require.Zero(t, bat.Vecs[1].Length(), "payload must not be loaded before filtering")
+			values := vector.MustFixedColWithTypeCheck[int32](bat.Vecs[0])
+			sels := make([]int64, 0, len(values))
+			for i, value := range values {
+				if value >= 5 {
+					sels = append(sels, int64(i))
+				}
+			}
+			bat.Vecs[0].Shrink(sels, false)
+			bat.SetRowCount(len(sels))
+			return engine.ReaderFilterResult{Sels: sels}, nil
+		}))
+		require.Equal(t, 3, output.RowCount())
+		require.Equal(t, []int32{5, 6, 7}, vector.MustFixedColWithTypeCheck[int32](output.Vecs[0]))
+		require.Equal(t, "payload-5", output.Vecs[1].GetStringAt(0))
+		require.Equal(t, "payload-6", output.Vecs[1].GetStringAt(1))
+		require.Equal(t, "payload-7", output.Vecs[1].GetStringAt(2))
+	})
+
+	t.Run("all survivors preserve tombstone mapping", func(t *testing.T) {
+		output.CleanOnlyData()
+		require.NoError(t, read(func(bat *batch.Batch, _ []int) (engine.ReaderFilterResult, error) {
+			require.Zero(t, bat.Vecs[1].Length())
+			return engine.ReaderFilterResult{All: true}, nil
+		}))
+		require.Equal(t, []int32{0, 1, 2, 4, 5, 6, 7}, vector.MustFixedColWithTypeCheck[int32](output.Vecs[0]))
+		require.Equal(t, "payload-4", output.Vecs[1].GetStringAt(3))
+	})
+
+	t.Run("zero survivors never materialize payload", func(t *testing.T) {
+		output.CleanOnlyData()
+		require.NoError(t, read(func(bat *batch.Batch, _ []int) (engine.ReaderFilterResult, error) {
+			require.Zero(t, bat.Vecs[1].Length())
+			bat.Vecs[0].CleanOnlyData()
+			bat.SetRowCount(0)
+			return engine.ReaderFilterResult{}, nil
+		}))
+		require.Zero(t, output.RowCount())
+		require.Zero(t, output.Vecs[0].Length())
+		require.Zero(t, output.Vecs[1].Length())
+	})
+
+	t.Run("rejects inconsistent filtered vector lengths", func(t *testing.T) {
+		output.CleanOnlyData()
+		err := read(func(bat *batch.Batch, _ []int) (engine.ReaderFilterResult, error) {
+			bat.SetRowCount(0)
+			return engine.ReaderFilterResult{}, nil
+		})
+		require.ErrorContains(t, err, "left early column 0 with 7 rows")
+	})
+
+	t.Run("rejects mismatched column metadata", func(t *testing.T) {
+		output.CleanOnlyData()
+		_, err := BlockDataReadWithFilter(
+			ctx,
+			&info,
+			ds,
+			[]uint16{0, 1},
+			colTypes[:1],
+			-1,
+			timestamp.Timestamp{},
+			nil,
+			nil,
+			objectio.BlockReadFilter{},
+			fileservice.Policy(0),
+			"late-read-test",
+			output,
+			cacheVectors,
+			queryMP,
+			fs,
+			[]int{0},
+			func(*batch.Batch, []int) (engine.ReaderFilterResult, error) {
+				return engine.ReaderFilterResult{All: true}, nil
+			},
+		)
+		require.ErrorContains(t, err, "column count 2 does not match type count 1")
+	})
+
+	t.Run("storage selections compose with residual selections", func(t *testing.T) {
+		output.CleanOnlyData()
+		require.NoError(t, blockDataReadWithFilter(
+			ctx,
+			&info,
+			nil,
+			[]uint16{0, 1},
+			colTypes,
+			-1,
+			types.TS{},
+			[]int64{1, 4, 7},
+			fileservice.Policy(0),
+			output,
+			cacheVectors,
+			queryMP,
+			fs,
+			[]int{0},
+			func(bat *batch.Batch, _ []int) (engine.ReaderFilterResult, error) {
+				sels := []int64{1}
+				bat.Vecs[0].Shrink(sels, false)
+				bat.SetRowCount(1)
+				return engine.ReaderFilterResult{Sels: sels}, nil
+			},
+			nil,
+		))
+		require.Equal(t, []int32{4}, vector.MustFixedColWithTypeCheck[int32](output.Vecs[0]))
+		require.Equal(t, "payload-4", output.Vecs[1].GetStringAt(0))
+	})
+
+	output.Clean(queryMP)
+	require.Zero(t, queryMP.CurrNB())
+}
+
 func TestBlockDataReadInnerAppendableVisibility(t *testing.T) {
 	ctx := context.Background()
 	fs := testutil.NewSharedFS()
@@ -395,6 +569,46 @@ func TestBlockDataReadInnerAppendableVisibility(t *testing.T) {
 	require.Equal(t, uint32(0), rowids[0].GetRowOffset())
 	require.Equal(t, uint32(2), rowids[1].GetRowOffset())
 	output.Clean(queryMP)
+
+	lateOutput := batch.NewWithSize(2)
+	lateOutput.Vecs[0] = vector.NewOffHeapVecWithType(types.T_varchar.ToType())
+	lateOutput.Vecs[1] = vector.NewOffHeapVecWithType(objectio.RowidType)
+	_, err = BlockDataReadWithFilter(
+		ctx,
+		&info,
+		&blockReadTestDataSource{deleted: []uint64{1}},
+		[]uint16{0, objectio.SEQNUM_ROWID},
+		[]types.Type{types.T_varchar.ToType(), objectio.RowidType},
+		1,
+		timestamp.Timestamp{PhysicalTime: 7},
+		nil,
+		nil,
+		objectio.BlockReadFilter{},
+		fileservice.Policy(0),
+		"appendable-late-read-test",
+		lateOutput,
+		cacheVectors,
+		queryMP,
+		fs,
+		[]int{1},
+		func(bat *batch.Batch, _ []int) (engine.ReaderFilterResult, error) {
+			require.Zero(t, bat.Vecs[0].Length(), "payload must remain deferred")
+			visibleRowids := vector.MustFixedColWithTypeCheck[types.Rowid](bat.Vecs[1])
+			require.Equal(t, []uint32{0, 2}, []uint32{
+				visibleRowids[0].GetRowOffset(),
+				visibleRowids[1].GetRowOffset(),
+			})
+			sels := []int64{1}
+			bat.Vecs[1].Shrink(sels, false)
+			bat.SetRowCount(1)
+			return engine.ReaderFilterResult{Sels: sels}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "k2", lateOutput.Vecs[0].GetStringAt(0))
+	lateRowid := vector.GetFixedAtNoTypeCheck[types.Rowid](lateOutput.Vecs[1], 0)
+	require.Equal(t, uint32(2), lateRowid.GetRowOffset())
+	lateOutput.Clean(queryMP)
 
 	rowidOnly := batch.NewWithSize(1)
 	rowidOnly.Vecs[0] = vector.NewOffHeapVecWithType(objectio.RowidType)

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -1189,6 +1189,42 @@ type Reader interface {
 	//SetScanType()
 }
 
+// ReaderFilterResult describes which rows survived a ReaderFilter. Sels must
+// contain sorted, unique positions in the callback's input batch, and its
+// length must equal the filtered batch row count. Sels is borrowed from the
+// callback and is only valid until the next callback. When All is true, every
+// row survived, the callback must not change the row count, and Sels is ignored.
+type ReaderFilterResult struct {
+	Sels []int64
+	All  bool
+}
+
+// ReaderFilter evaluates a residual predicate over the columns listed in
+// loadedColumns. loadedColumns contains positions in the full output schema;
+// nil means every output column is already loaded and the row mapping is not
+// consumed. The callback must shrink the loaded vectors and update bat.RowCount
+// when only a subset survives. Readers invoke the callback synchronously and
+// must finish consuming its result before ReadWithFilter returns.
+type ReaderFilter func(
+	bat *batch.Batch,
+	loadedColumns []int,
+) (ReaderFilterResult, error)
+
+// LateMaterializationReader is an optional Reader capability. It reads the
+// early columns, applies filter, and materializes the remaining columns only
+// for surviving persisted rows. Readers must fall back to an eager read for
+// data sources that cannot be revisited, such as in-memory workspace data.
+type LateMaterializationReader interface {
+	ReadWithFilter(
+		ctx context.Context,
+		cols []string,
+		earlyColumns []int,
+		filter ReaderFilter,
+		mp *mpool.MPool,
+		outBatch *batch.Batch,
+	) (isEnd bool, err error)
+}
+
 type Database interface {
 	Relations(context.Context) ([]string, error)
 	Relation(context.Context, string, any) (Relation, error)

--- a/pkg/vm/process/operator_analyzer.go
+++ b/pkg/vm/process/operator_analyzer.go
@@ -116,6 +116,10 @@ type classifiedWaitAnalyzer interface {
 	WaitStopKind(time.Time, resource.WaitKind)
 }
 
+type durationWaitAnalyzer interface {
+	WaitDurationKind(time.Duration, resource.WaitKind)
+}
+
 // StopAnalyzerWait records a classified wait when the analyzer supports the
 // new resource extension, while preserving the original Analyzer contract.
 func StopAnalyzerWait(analyzer Analyzer, start time.Time, kind resource.WaitKind) {
@@ -130,10 +134,47 @@ func stopAnalyzerWait(analyzer Analyzer, start time.Time, kind resource.WaitKind
 	analyzer.WaitStop(start)
 }
 
+func stopAnalyzerWaitDuration(analyzer Analyzer, duration time.Duration, kind resource.WaitKind) {
+	if classified, ok := analyzer.(durationWaitAnalyzer); ok {
+		classified.WaitDurationKind(duration, kind)
+		return
+	}
+	stopAnalyzerWait(analyzer, time.Now().Add(-duration), kind)
+}
+
 // MeasureFilesystemWait records the complete duration of a storage boundary,
 // including error and panic exits.
 func MeasureFilesystemWait[T any](analyzer Analyzer, fn func() (T, error)) (T, error) {
 	return MeasureWait(analyzer, resource.WaitFilesystem, fn)
+}
+
+// MeasureFilesystemWaitExcluding records a storage boundary that invokes a
+// synchronous active-work callback. excluded is accumulated by that callback;
+// only the remaining duration is classified as filesystem wait.
+func MeasureFilesystemWaitExcluding[T any](
+	analyzer Analyzer,
+	excluded *time.Duration,
+	fn func() (T, error),
+) (ret T, err error) {
+	start := time.Now()
+	var excludedBefore time.Duration
+	if excluded != nil {
+		excludedBefore = *excluded
+	}
+	defer func() {
+		duration := time.Since(start)
+		if excluded != nil {
+			excludedDuration := *excluded - excludedBefore
+			if excludedDuration < 0 || excludedDuration > duration {
+				analyzer.GetOpStats().ResourceQuality |= resource.QualityInvariantFailure
+				duration = 0
+			} else {
+				duration -= excludedDuration
+			}
+		}
+		stopAnalyzerWaitDuration(analyzer, duration, resource.WaitFilesystem)
+	}()
+	return fn()
 }
 
 // MeasureFilesystemWaitErr is the error-only form of MeasureFilesystemWait.
@@ -412,7 +453,10 @@ func (opAlyzr *operatorAnalyzer) WaitStop(start time.Time) {
 }
 
 func (opAlyzr *operatorAnalyzer) WaitStopKind(start time.Time, kind resource.WaitKind) {
-	duration := time.Since(start)
+	opAlyzr.WaitDurationKind(time.Since(start), kind)
+}
+
+func (opAlyzr *operatorAnalyzer) WaitDurationKind(duration time.Duration, kind resource.WaitKind) {
 	if duration < 0 || kind >= resource.WaitKindCount {
 		opAlyzr.opStats.ResourceQuality |= resource.QualityInvariantFailure
 		return

--- a/pkg/vm/process/operator_analyzer_test.go
+++ b/pkg/vm/process/operator_analyzer_test.go
@@ -580,6 +580,28 @@ func TestMeasureWaitStopsAtBlockingBoundary(t *testing.T) {
 	assert.Zero(t, opAlyzr.opStats.ResourceQuality)
 }
 
+func TestMeasureFilesystemWaitExcludingActiveCallback(t *testing.T) {
+	opAlyzr := NewAnalyzer(0, false, false, "test").(*operatorAnalyzer)
+	opAlyzr.Start()
+
+	active := time.Hour
+	_, err := MeasureFilesystemWaitExcluding(opAlyzr, &active, func() (struct{}, error) {
+		time.Sleep(time.Millisecond)
+		start := time.Now()
+		time.Sleep(20 * time.Millisecond)
+		active += time.Since(start)
+		time.Sleep(time.Millisecond)
+		return struct{}{}, nil
+	})
+	assert.NoError(t, err)
+	wait := time.Duration(opAlyzr.opStats.ResourceWaitNS[resource.WaitFilesystem])
+	assert.Positive(t, wait)
+
+	opAlyzr.Stop()
+	assert.Positive(t, opAlyzr.opStats.TimeConsumed)
+	assert.Zero(t, opAlyzr.opStats.ResourceQuality)
+}
+
 func Test_operatorAnalyzer_AddParquetProfile(t *testing.T) {
 	opAlyzr := NewTempAnalyzer()
 	opAlyzr.AddParquetProfile(ParquetProfileStats{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26960

## What this PR does / why we need it:

Backport of #26969 to 4.2-dev.

Table scans currently materialize every projected column before evaluating residual filters. On the workload from #26960, the scan read 11.45 million rows / 7.32 GB and spent 62.78 seconds even though the query returned no rows. The captured CPU profile was dominated by copying and constructing varlen output rather than predicate evaluation.

This change adds block-local late materialization for output-only wide varlen columns:

- predicate columns and fixed/small output columns are loaded first;
- visibility and tombstones are applied before the residual filter;
- surviving logical row positions are mapped back to physical block offsets;
- deferred columns are loaded only for surviving rows.

The capability is optional on engine.Reader, so unsupported readers keep the eager path. In-memory data, storage TopN, sharding readers, transaction-data tracing, reader summaries, and unsupported expression forms also remain eager.

4.2-dev predates the merge-reader ownership fix present on main. This backport includes the required close-on-exhaustion/error behavior so the new ReadWithFilter path has the same exactly-once reader cleanup contract; focused tests cover both terminal paths.

Validation:

- GOWORK=off go build -mod=readonly ./pkg/vm/process ./pkg/sql/colexec/table_scan ./pkg/vm/engine/readutil ./pkg/vm/engine/tae/blockio ./pkg/vm/engine ./pkg/sql/compile ./pkg/vm/engine/disttae
- GOWORK=off go vet -mod=readonly over the same owning/dependent packages
- focused late-materialization, row-mapping, reader-ownership, and metric tests
- full owning/dependent package tests
- all eight focused tests with -race -count=100
- full process, table_scan, readutil, and blockio package tests with -race
