### PR TITLE
ci: run MongoDB and Iceberg E2E in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,8 +13,14 @@ logs/
 *.md
 !README.md
 
-# Ignore test files
+# Ignore test files except the connector runners and their contract tests. The
+# connector-ci image compiles both runners from the exact checked-out source.
 test/
+!test/
+!test/mongodb/
+!test/mongodb/**
+!test/iceberg/
+!test/iceberg/**
 report/
 
 # Ignore temporary files

--- a/.github/actions/build-connector-ci/action.yml
+++ b/.github/actions/build-connector-ci/action.yml
@@ -1,0 +1,58 @@
+name: Build connector CI image
+description: Build the revision-pinned MongoDB and Iceberg CI image with a shared GHA cache.
+
+inputs:
+  image:
+    description: Local Docker image tag to load.
+    required: true
+  revision:
+    description: Exact Git revision embedded in the image.
+    required: true
+  ignore-cache-export-error:
+    description: Whether a successful image build may continue when only GHA cache export fails.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Validate Iceberg golden vectors
+      shell: bash
+      run: python3 pkg/iceberg/metadata/testdata/generate_golden_vectors.py --check
+
+    - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Build connector CI image
+      id: build-primary
+      continue-on-error: true
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: .
+        file: optools/images/Dockerfile
+        target: connector-ci
+        load: true
+        tags: ${{ inputs.image }}
+        build-args: |
+          SOURCE_REVISION=${{ inputs.revision }}
+          GO_MOD_DOWNLOAD_TIMEOUT=10m
+        cache-from: |
+          type=gha,scope=connector-ci-${{ runner.arch }}
+          type=gha,scope=matrixone-native-${{ runner.arch == 'X64' && 'amd64' || 'arm64' }}
+        cache-to: type=gha,mode=max,scope=connector-ci-${{ runner.arch }},ignore-error=${{ inputs['ignore-cache-export-error'] }}
+
+    - name: Retry connector CI image build
+      if: steps.build-primary.outcome == 'failure'
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: .
+        file: optools/images/Dockerfile
+        target: connector-ci
+        load: true
+        tags: ${{ inputs.image }}
+        build-args: |
+          SOURCE_REVISION=${{ inputs.revision }}
+          GO_MOD_DOWNLOAD_TIMEOUT=10m
+        cache-from: |
+          type=gha,scope=connector-ci-${{ runner.arch }}
+          type=gha,scope=matrixone-native-${{ runner.arch == 'X64' && 'amd64' || 'arm64' }}
+        cache-to: type=gha,mode=max,scope=connector-ci-${{ runner.arch }},ignore-error=${{ inputs['ignore-cache-export-error'] }}

--- a/.github/workflows/connector-ci-cache.yml
+++ b/.github/workflows/connector-ci-cache.yml
@@ -1,0 +1,40 @@
+name: Connector CI Image Cache
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.dockerignore'
+      - '.github/actions/build-connector-ci/**'
+      - '.github/workflows/connector-ci-cache.yml'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - 'cgo/**'
+      - 'thirdparties/**'
+      - 'optools/images/Dockerfile'
+      - 'pkg/iceberg/**'
+      - 'test/iceberg/**'
+      - 'test/mongodb/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  warm-connector-image-cache:
+    name: Warm connector image cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      MO_CONNECTOR_CI_IMAGE: matrixone-connector-ci:${{ github.sha }}
+      MO_CONNECTOR_CI_REVISION: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/build-connector-ci
+        with:
+          image: ${{ env.MO_CONNECTOR_CI_IMAGE }}
+          revision: ${{ env.MO_CONNECTOR_CI_REVISION }}

--- a/.github/workflows/iceberg-connector.yml
+++ b/.github/workflows/iceberg-connector.yml
@@ -1,32 +1,9 @@
 name: Iceberg Connector E2E
 
+# Disabled for pull requests. Connector behavior is covered by regression;
+# keep this workflow available for explicit Docker E2E validation.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - '.github/workflows/entrypoint.yaml'
-      - '.github/workflows/iceberg-connector.yml'
-      - 'Makefile'
-      - 'optools/iceberg_ci.bash'
-      - 'optools/iceberg_external_runner.py'
-      - 'etc/launch-minio-local/**'
-      - 'test/iceberg/**'
-      - 'pkg/iceberg/**'
-      - 'pkg/sql/iceberg/**'
-      - 'pkg/sql/plan/**'
-      - 'pkg/sql/compile/**'
-      - 'pkg/frontend/**'
-      - 'pkg/sql/parsers/**'
-      - 'pkg/config/**'
-      - 'pkg/bootstrap/**'
-      - 'pkg/sql/colexec/external/**'
-      - 'pkg/sql/colexec/icebergdelete/**'
-      - 'pkg/sql/colexec/icebergwrite/**'
-      - 'pkg/embed/**'
-      - 'cmd/mo-service/**'
-      - 'pkg/cnservice/**'
-      - 'proto/pipeline.proto'
-      - 'pkg/pb/pipeline/**'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -34,20 +11,24 @@ permissions:
 jobs:
   iceberg-e2e-local:
     name: Iceberg E2E Local
-    # Temporarily disabled while the local Iceberg E2E suite is stabilized.
-    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     continue-on-error: true
     env:
       MO_ICEBERG_REPORT_DIR: test/iceberg/reports/iceberg-e2e-local-${{ github.run_id }}
+      MO_CONNECTOR_CI_IMAGE: matrixone-connector-ci:${{ github.sha }}
+      MO_CONNECTOR_CI_REVISION: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          go-version-file: go.mod
-          cache: true
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/build-connector-ci
+        with:
+          image: ${{ env.MO_CONNECTOR_CI_IMAGE }}
+          revision: ${{ env.MO_CONNECTOR_CI_REVISION }}
+          ignore-cache-export-error: 'true'
 
       - name: Run local Nessie/MinIO/MO Iceberg E2E
         run: make test-iceberg-e2e-local
@@ -59,7 +40,8 @@ jobs:
             echo "## Iceberg E2E local"
             echo ""
             echo "Mode: advisory / non-blocking"
-            echo "Artifact: \`iceberg-e2e-local-${{ github.sha }}-${{ github.run_id }}\`"
+            echo "Source revision: \`${MO_CONNECTOR_CI_REVISION}\`"
+            echo "Artifact: \`iceberg-e2e-local-${MO_CONNECTOR_CI_REVISION}-${{ github.run_id }}\`"
             echo ""
             if [ -f "${MO_ICEBERG_REPORT_DIR}/summary.md" ]; then
               cat "${MO_ICEBERG_REPORT_DIR}/summary.md"
@@ -71,6 +53,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: iceberg-e2e-local-${{ github.sha }}-${{ github.run_id }}
+          name: iceberg-e2e-local-${{ env.MO_CONNECTOR_CI_REVISION }}-${{ github.run_id }}
           path: |
             test/iceberg/reports/**

--- a/.github/workflows/mongodb-connector.yml
+++ b/.github/workflows/mongodb-connector.yml
@@ -15,13 +15,19 @@ jobs:
     timeout-minutes: 45
     env:
       MO_MONGODB_REPORT_DIR: test/mongodb/reports/e2e-${{ github.run_id }}
+      MO_CONNECTOR_CI_IMAGE: matrixone-connector-ci:${{ github.sha }}
+      MO_CONNECTOR_CI_REVISION: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          go-version-file: go.mod
-          cache: true
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/build-connector-ci
+        with:
+          image: ${{ env.MO_CONNECTOR_CI_IMAGE }}
+          revision: ${{ env.MO_CONNECTOR_CI_REVISION }}
+          ignore-cache-export-error: 'true'
 
       - name: Run MongoDB connector E2E
         run: make test-mongodb-e2e-local
@@ -32,7 +38,8 @@ jobs:
           {
             echo "## MongoDB connector E2E"
             echo ""
-            echo "Artifact: \`mongodb-e2e-local-${{ github.sha }}-${{ github.run_id }}\`"
+            echo "Source revision: \`${MO_CONNECTOR_CI_REVISION}\`"
+            echo "Artifact: \`mongodb-e2e-local-${MO_CONNECTOR_CI_REVISION}-${{ github.run_id }}\`"
             echo ""
             if [ -f "${MO_MONGODB_REPORT_DIR}/summary.md" ]; then
               cat "${MO_MONGODB_REPORT_DIR}/summary.md"
@@ -44,5 +51,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: mongodb-e2e-local-${{ github.sha }}-${{ github.run_id }}
+          name: mongodb-e2e-local-${{ env.MO_CONNECTOR_CI_REVISION }}-${{ github.run_id }}
           path: test/mongodb/reports/**

--- a/etc/launch-minio-local/docker-compose.yml
+++ b/etc/launch-minio-local/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - mo-minio-network
 
   nessie:
-    image: ghcr.io/projectnessie/nessie:latest
+    image: ghcr.io/projectnessie/nessie@sha256:c0f42874c810f28ac30fc991e979c1b8cf5a2cbfa94212086cdddeae49629517
     container_name: mo-nessie-local
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     ports:
@@ -37,7 +37,7 @@ services:
       NESSIE_CATALOG_DEFAULT_WAREHOUSE: warehouse
       NESSIE_CATALOG_WAREHOUSES_WAREHOUSE_LOCATION: s3://mo-iceberg/warehouse
       NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_ENDPOINT: http://minio:9000
-      NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_EXTERNAL_ENDPOINT: http://127.0.0.1:9000
+      NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_EXTERNAL_ENDPOINT: ${NESSIE_EXTERNAL_ENDPOINT:-http://127.0.0.1:9000}
       NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_REGION: us-east-1
       NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_AUTH_TYPE: STATIC
       NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_ACCESS_KEY: urn:nessie-secret:quarkus:s3default

--- a/optools/connector_ci_image.bash
+++ b/optools/connector_ci_image.bash
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright 2026 Matrix Origin
+# Licensed under the Apache License, Version 2.0.
+
+# Shared helpers for MongoDB and Iceberg connector E2E jobs. This file is
+# sourced by their profile scripts; it deliberately does not change shell
+# options or execute a command on its own.
+
+connector_ci_enabled() {
+  [[ -n "${MO_CONNECTOR_CI_IMAGE:-}" ]]
+}
+
+connector_ci_verify_image() {
+  local image="${MO_CONNECTOR_CI_IMAGE:-}"
+  local expected="${MO_CONNECTOR_CI_REVISION:-}"
+  [[ -n "$image" ]] || die "MO_CONNECTOR_CI_IMAGE is required for container mode"
+  [[ -n "$expected" ]] || die "MO_CONNECTOR_CI_REVISION is required for container mode"
+
+  local label embedded
+  label="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$image")" || \
+    die "connector CI image is unavailable: $image"
+  embedded="$(docker run --rm --entrypoint /bin/sh "$image" -c \
+    'test -x /connector-bin/mongodb-e2e && test -x /connector-bin/iceberg-e2e && cat /connector-source-revision')" || \
+    die "connector CI image smoke check failed: $image"
+  if [[ "$label" != "$expected" || "$embedded" != "$expected" ]]; then
+    die "connector CI image revision mismatch: expected $expected, label=$label, embedded=$embedded"
+  fi
+}
+
+connector_ci_wait_for_mo() {
+  local container="$1"
+  local expected_port="${2:-6001}"
+  local deadline=$((SECONDS + 120))
+  while (( SECONDS < deadline )); do
+    if [[ "$(docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null || true)" != "true" ]]; then
+      docker logs --tail 2000 "$container" >&2 || true
+      die "MatrixOne container exited before it became ready: $container"
+    fi
+    if docker logs --tail 2000 "$container" 2>&1 | grep -Eq "Server Listening on : .*:${expected_port}([^0-9]|$)"; then
+      return
+    fi
+    sleep 1
+  done
+  docker logs --tail 2000 "$container" >&2 || true
+  die "MatrixOne container did not publish port $expected_port: $container"
+}

--- a/optools/iceberg_ci.bash
+++ b/optools/iceberg_ci.bash
@@ -5,6 +5,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROFILE="${1:-core}"
 REPORT_DIR="${MO_ICEBERG_REPORT_DIR:-${ROOT_DIR}/test/iceberg/reports/ci_$(date -u +%Y%m%dT%H%M%SZ)}"
+if [[ "$REPORT_DIR" != /* ]]; then
+  REPORT_DIR="${ROOT_DIR}/${REPORT_DIR}"
+fi
 COVER_DIR="${MO_ICEBERG_COVER_DIR:-${ROOT_DIR}/test/iceberg/reports/coverage}"
 THIRDPARTIES_INSTALL_DIR="${ROOT_DIR}/thirdparties/install"
 
@@ -21,6 +24,9 @@ die() {
   printf '[iceberg-ci] ERROR: %s\n' "$*" >&2
   exit 1
 }
+
+# shellcheck source=optools/connector_ci_image.bash
+source "${ROOT_DIR}/optools/connector_ci_image.bash"
 
 run() {
   log "$*"
@@ -124,10 +130,14 @@ PY
 
 ICEBERG_E2E_TMP_DIR=""
 ICEBERG_E2E_MO_PID=""
+ICEBERG_E2E_MO_CONTAINER=""
 
 iceberg_e2e_collect_logs() {
   [[ -n "$ICEBERG_E2E_TMP_DIR" ]] || return
   mkdir -p "$REPORT_DIR"
+  if [[ -n "$ICEBERG_E2E_MO_CONTAINER" ]]; then
+    docker logs "$ICEBERG_E2E_MO_CONTAINER" >"${ICEBERG_E2E_TMP_DIR}/mo-service.log" 2>&1 || true
+  fi
   sanitize_artifact_file "${ICEBERG_E2E_TMP_DIR}/mo-service.log" "${REPORT_DIR}/mo-service.log"
   if command -v docker >/dev/null 2>&1; then
     (cd "${ROOT_DIR}/etc/launch-minio-local" && docker compose logs --no-color nessie >"${ICEBERG_E2E_TMP_DIR}/nessie.log" 2>&1) || true
@@ -139,39 +149,93 @@ iceberg_e2e_collect_logs() {
 
 iceberg_e2e_cleanup() {
   local status=$?
+  set +e
   if [[ -n "$ICEBERG_E2E_MO_PID" ]] && kill -0 "$ICEBERG_E2E_MO_PID" >/dev/null 2>&1; then
     kill "$ICEBERG_E2E_MO_PID" >/dev/null 2>&1 || true
     wait "$ICEBERG_E2E_MO_PID" >/dev/null 2>&1 || true
   fi
   iceberg_e2e_collect_logs
+  if [[ -n "$ICEBERG_E2E_MO_CONTAINER" ]]; then
+    docker rm -f "$ICEBERG_E2E_MO_CONTAINER" >/dev/null 2>&1 || true
+  fi
   (cd "$ROOT_DIR" && make dev-down-iceberg-tier-a >/dev/null 2>&1) || true
+  if [[ -d "$ICEBERG_E2E_TMP_DIR" && "$(basename "$ICEBERG_E2E_TMP_DIR")" == mo-iceberg-e2e-local.* ]]; then
+    rm -rf -- "$ICEBERG_E2E_TMP_DIR"
+  else
+    log "refusing to remove unexpected temporary path: $ICEBERG_E2E_TMP_DIR"
+  fi
   return "$status"
+}
+
+generate_iceberg_container_config() {
+  local generated_dir="${ICEBERG_E2E_TMP_DIR}/mo-config"
+  local source_dir="${ROOT_DIR}/etc/launch-minio-local"
+  mkdir -p "$generated_dir"
+  for name in log tn cn; do
+    sed -e "s#\\./etc/launch-minio-local/mo-data#${ICEBERG_E2E_TMP_DIR}/mo-data#g" \
+      -e "s#etc/launch-minio-local/mo-data#${ICEBERG_E2E_TMP_DIR}/mo-data#g" \
+      -e 's#http://127\.0\.0\.1:9000#http://minio:9000#g' \
+      "$source_dir/$name.toml" >"$generated_dir/$name.toml"
+  done
+  sed -e "s#\\./etc/launch-minio-local/log.toml#$generated_dir/log.toml#" \
+    -e "s#\\./etc/launch-minio-local/tn.toml#$generated_dir/tn.toml#" \
+    -e "s#\\./etc/launch-minio-local/cn.toml#$generated_dir/cn.toml#" \
+    "$source_dir/launch.toml" >"$generated_dir/launch.toml"
 }
 
 iceberg_e2e_local() {
   require_cmd docker
   require_cmd curl
   require_cmd python3
+  if connector_ci_enabled; then
+    connector_ci_verify_image
+  fi
 
   mkdir -p "$REPORT_DIR"
   ICEBERG_E2E_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mo-iceberg-e2e-local.XXXXXX")"
   trap iceberg_e2e_cleanup EXIT
+  export COMPOSE_PROJECT_NAME="mo-iceberg-$(basename "$ICEBERG_E2E_TMP_DIR" | tr '[:upper:].' '[:lower:]-')"
 
-  run make build
-  go_test_adapter
-  go_test_golden
+  if connector_ci_enabled; then
+    export NESSIE_EXTERNAL_ENDPOINT="http://minio:9000"
+    generate_iceberg_container_config
+  else
+    run make build
+    go_test_adapter
+    go_test_golden
+  fi
 
   run make dev-up-iceberg-tier-a
   log "starting mo-service for Iceberg E2E local"
-  MO_ICEBERG_ALLOW_PLAIN_HTTP=1 "${ROOT_DIR}/mo-service" -launch "${ROOT_DIR}/etc/launch-minio-local/launch.toml" \
-    >"${ICEBERG_E2E_TMP_DIR}/mo-service.log" 2>&1 &
-  ICEBERG_E2E_MO_PID="$!"
+  if connector_ci_enabled; then
+    local network="${COMPOSE_PROJECT_NAME}_mo-minio-network"
+    local container_user="$(id -u):$(id -g)"
+    ICEBERG_E2E_MO_CONTAINER="${COMPOSE_PROJECT_NAME}-mo"
+    docker run -d --name "$ICEBERG_E2E_MO_CONTAINER" --network "$network" --user "$container_user" \
+      --mount "type=bind,source=${ICEBERG_E2E_TMP_DIR},target=${ICEBERG_E2E_TMP_DIR}" \
+      -e MO_ICEBERG_ALLOW_PLAIN_HTTP=1 \
+      --entrypoint /mo-service "$MO_CONNECTOR_CI_IMAGE" \
+      -launch "${ICEBERG_E2E_TMP_DIR}/mo-config/launch.toml" >/dev/null
+    connector_ci_wait_for_mo "$ICEBERG_E2E_MO_CONTAINER" 6001
+    docker run --rm --network "$network" --user "$container_user" \
+      --mount "type=bind,source=${REPORT_DIR},target=${REPORT_DIR}" \
+      --entrypoint /connector-bin/iceberg-e2e "$MO_CONNECTOR_CI_IMAGE" \
+      --catalog-uri "${MO_ICEBERG_E2E_CATALOG_URI:-http://nessie:19120/iceberg}" \
+      --warehouse "${MO_ICEBERG_E2E_WAREHOUSE:-s3://mo-iceberg/warehouse}" \
+      --object-endpoint "${MO_ICEBERG_E2E_OBJECT_ENDPOINT:-minio}" \
+      --dsn "${MO_ICEBERG_E2E_DSN:-root:111@tcp(${ICEBERG_E2E_MO_CONTAINER}:6001)/?timeout=5s&readTimeout=30s&writeTimeout=30s&multiStatements=false}" \
+      --report-dir "$REPORT_DIR"
+  else
+    MO_ICEBERG_ALLOW_PLAIN_HTTP=1 "${ROOT_DIR}/mo-service" -launch "${ROOT_DIR}/etc/launch-minio-local/launch.toml" \
+      >"${ICEBERG_E2E_TMP_DIR}/mo-service.log" 2>&1 &
+    ICEBERG_E2E_MO_PID="$!"
 
-  run go run ./test/iceberg/iceberg_e2e_local.go \
-    --catalog-uri "${MO_ICEBERG_E2E_CATALOG_URI:-http://127.0.0.1:19120/iceberg}" \
-    --warehouse "${MO_ICEBERG_E2E_WAREHOUSE:-s3://mo-iceberg/warehouse}" \
-    --dsn "${MO_ICEBERG_E2E_DSN:-root:111@tcp(127.0.0.1:6001)/?timeout=5s&readTimeout=30s&writeTimeout=30s&multiStatements=false}" \
-    --report-dir "$REPORT_DIR"
+    run go run ./test/iceberg/iceberg_e2e_local.go \
+      --catalog-uri "${MO_ICEBERG_E2E_CATALOG_URI:-http://127.0.0.1:19120/iceberg}" \
+      --warehouse "${MO_ICEBERG_E2E_WAREHOUSE:-s3://mo-iceberg/warehouse}" \
+      --dsn "${MO_ICEBERG_E2E_DSN:-root:111@tcp(127.0.0.1:6001)/?timeout=5s&readTimeout=30s&writeTimeout=30s&multiStatements=false}" \
+      --report-dir "$REPORT_DIR"
+  fi
 
   iceberg_e2e_collect_logs
   verify_report_artifacts "$REPORT_DIR"
@@ -1008,57 +1072,61 @@ Profiles:
 USAGE
 }
 
-cd "$ROOT_DIR"
-require_cmd go
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  cd "$ROOT_DIR"
+  if [[ "$PROFILE" != "e2e-local" ]] || ! connector_ci_enabled; then
+    require_cmd go
+  fi
 
-case "$PROFILE" in
-  core) go_test_core ;;
-  embedded) go_test_embedded ;;
-  adapter) go_test_adapter ;;
-  golden) require_cmd python3; go_test_golden ;;
-  external-templates) require_cmd python3; validate_external_templates ;;
-  coverage) go_test_coverage ;;
-  preflight) preflight ;;
-  artifact) verify_report_artifacts "$REPORT_DIR" ;;
-  external-coverage) require_cmd python3; verify_external_coverage "$REPORT_DIR" ;;
-  dashboard) generate_cap_dashboard "$REPORT_DIR" ;;
-  readiness) generate_external_readiness "$REPORT_DIR" ;;
-  e2e-local) iceberg_e2e_local ;;
-  golden-real)
-    export MO_ICEBERG_CI_PROFILE="${MO_ICEBERG_CI_PROFILE:-golden-real}"
-    preflight
-    run_golden_real_if_enabled
-    verify_report_artifacts "$REPORT_DIR"
-    verify_external_coverage "$REPORT_DIR"
-    ;;
-  nightly)
-    preflight
-    run_tier_a_if_enabled
-    run_cross_engine_if_enabled
-    run_golden_real_if_enabled
-    run_remaining_external_if_enabled
-    go_test_golden
-    generate_cap_dashboard "$REPORT_DIR"
-    generate_external_readiness "$REPORT_DIR"
-    if [[ -d "$REPORT_DIR" ]] && find "$REPORT_DIR" -mindepth 1 -maxdepth 1 -type d | grep -q .; then
+  case "$PROFILE" in
+    core) go_test_core ;;
+    embedded) go_test_embedded ;;
+    adapter) go_test_adapter ;;
+    golden) require_cmd python3; go_test_golden ;;
+    external-templates) require_cmd python3; validate_external_templates ;;
+    coverage) go_test_coverage ;;
+    preflight) preflight ;;
+    artifact) verify_report_artifacts "$REPORT_DIR" ;;
+    external-coverage) require_cmd python3; verify_external_coverage "$REPORT_DIR" ;;
+    dashboard) generate_cap_dashboard "$REPORT_DIR" ;;
+    readiness) generate_external_readiness "$REPORT_DIR" ;;
+    e2e-local) iceberg_e2e_local ;;
+    golden-real)
+      export MO_ICEBERG_CI_PROFILE="${MO_ICEBERG_CI_PROFILE:-golden-real}"
+      preflight
+      run_golden_real_if_enabled
       verify_report_artifacts "$REPORT_DIR"
-      if external_coverage_profile_enabled; then
-        verify_external_coverage "$REPORT_DIR"
+      verify_external_coverage "$REPORT_DIR"
+      ;;
+    nightly)
+      preflight
+      run_tier_a_if_enabled
+      run_cross_engine_if_enabled
+      run_golden_real_if_enabled
+      run_remaining_external_if_enabled
+      go_test_golden
+      generate_cap_dashboard "$REPORT_DIR"
+      generate_external_readiness "$REPORT_DIR"
+      if [[ -d "$REPORT_DIR" ]] && find "$REPORT_DIR" -mindepth 1 -maxdepth 1 -type d | grep -q .; then
+        verify_report_artifacts "$REPORT_DIR"
+        if external_coverage_profile_enabled; then
+          verify_external_coverage "$REPORT_DIR"
+        fi
+      else
+        log "no external report cases found under $REPORT_DIR; artifact verification skipped"
       fi
-    else
-      log "no external report cases found under $REPORT_DIR; artifact verification skipped"
-    fi
-    ;;
-  local)
-    go_test_core
-    go_test_embedded
-    go_test_adapter
-    go_test_golden
-    validate_external_templates
-    go_test_coverage
-    generate_cap_dashboard "$REPORT_DIR"
-    generate_external_readiness "$REPORT_DIR"
-    ;;
-  -h|--help|help) usage ;;
-  *) usage; die "unknown profile: $PROFILE" ;;
-esac
+      ;;
+    local)
+      go_test_core
+      go_test_embedded
+      go_test_adapter
+      go_test_golden
+      validate_external_templates
+      go_test_coverage
+      generate_cap_dashboard "$REPORT_DIR"
+      generate_external_readiness "$REPORT_DIR"
+      ;;
+    -h|--help|help) usage ;;
+    *) usage; die "unknown profile: $PROFILE" ;;
+  esac
+fi

--- a/optools/images/Dockerfile
+++ b/optools/images/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM matrixorigin/golang:1.26.4-ubuntu22.04 AS build-base
 
 ENV GOWORK=off
@@ -15,11 +17,37 @@ RUN make -C thirdparties
 COPY cgo cgo
 RUN make -C cgo
 
+# The Iceberg adapter is a nested module and is invisible to the root module
+# download. Isolate its cache from the production builder: this stage is only
+# referenced by connector-builder, so ordinary runtime images never pay for
+# adapter dependencies.
+FROM build-base AS connector-modules
+
+ARG GOPROXY="https://proxy.golang.org,direct"
+ARG GO_MOD_DOWNLOAD_TIMEOUT=0
+RUN go env -w GOPROXY=${GOPROXY}
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY pkg/iceberg/adapter/iceberggo/go.mod pkg/iceberg/adapter/iceberggo/go.mod
+COPY pkg/iceberg/adapter/iceberggo/go.sum pkg/iceberg/adapter/iceberggo/go.sum
+RUN --mount=type=cache,id=matrixone-go-modules,target=/tmp/gomod-cache,sharing=locked \
+    nested_module_files="$(sha256sum pkg/iceberg/adapter/iceberggo/go.mod pkg/iceberg/adapter/iceberggo/go.sum)" && \
+    mkdir -p /go/pkg/mod /tmp/gomod-cache && \
+    cp -a /go/pkg/mod/. /tmp/gomod-cache/ && \
+    (cd pkg/iceberg/adapter/iceberggo && timeout "$GO_MOD_DOWNLOAD_TIMEOUT" env GOMODCACHE=/tmp/gomod-cache go mod download) && \
+    cp -a /tmp/gomod-cache/. /go/pkg/mod/ && \
+    if [ "$nested_module_files" != "$(sha256sum pkg/iceberg/adapter/iceberggo/go.mod pkg/iceberg/adapter/iceberggo/go.sum)" ]; then \
+        echo "nested go mod download changed go.mod/go.sum"; \
+        exit 1; \
+    fi
+
 FROM build-base AS builder
 
 # GOPROXY affects Go modules, not native dependencies. Keeping it out of the
 # native stage preserves that expensive cache when build environments differ.
 ARG GOPROXY="https://proxy.golang.org,direct"
+ARG GO_MOD_DOWNLOAD_TIMEOUT=0
 RUN go env -w GOPROXY=${GOPROXY}
 
 # Typecheck: enable type checking for ToSliceNoTypeCheck and ToSliceNoTypeCheck2
@@ -30,10 +58,16 @@ ARG GOBUILD_OPT=""
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN module_files="$(sha256sum go.mod go.sum)" && \
-    go mod download && \
+# Cache dependencies before copying source so ordinary source changes do not
+# invalidate them. The cache mount retains completed module downloads when a
+# transient failure aborts this layer; copying it back into /go/pkg/mod after
+# success makes the same cache exportable to a fresh GHA runner.
+RUN --mount=type=cache,id=matrixone-go-modules,target=/tmp/gomod-cache,sharing=locked \
+    module_files="$(sha256sum go.mod go.sum)" && \
+    mkdir -p /go/pkg/mod /tmp/gomod-cache && \
+    cp -a /go/pkg/mod/. /tmp/gomod-cache/ && \
+    timeout "$GO_MOD_DOWNLOAD_TIMEOUT" env GOMODCACHE=/tmp/gomod-cache go mod download && \
+    cp -a /tmp/gomod-cache/. /go/pkg/mod/ && \
     if [ "$module_files" != "$(sha256sum go.mod go.sum)" ]; then \
         echo "go mod download changed go.mod/go.sum; run make mod-tidy"; \
         exit 1; \
@@ -47,13 +81,34 @@ COPY --from=native /go/src/github.com/matrixorigin/matrixone/thirdparties/instal
 COPY --from=native /go/src/github.com/matrixorigin/matrixone/cgo/libmo.so cgo/libmo.so
 COPY --from=native /go/src/github.com/matrixorigin/matrixone/cgo/libmo.a cgo/libmo.a
 
-RUN if [ "$TYPECHECK" = "1" ]; then \
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    if [ "$TYPECHECK" = "1" ]; then \
 		make build-with-prebuilt-native TYPECHECK=1 GOBUILD_OPT="${GOBUILD_OPT}"; \
 	else \
 		make build-with-prebuilt-native GOBUILD_OPT="${GOBUILD_OPT}"; \
 	fi
 
-FROM matrixorigin/ubuntu:22.04
+# Keep connector validation out of the production image's default dependency
+# chain. CI explicitly targets connector-ci, while ordinary image builds still
+# end at the runtime stage below.
+FROM builder AS connector-builder
+
+ARG SOURCE_REVISION=unknown
+COPY --from=connector-modules /go/pkg/mod /go/pkg/mod
+ENV CGO_CFLAGS="-I/go/src/github.com/matrixorigin/matrixone/cgo -I/go/src/github.com/matrixorigin/matrixone/thirdparties/install/include"
+ENV CGO_LDFLAGS="-L/go/src/github.com/matrixorigin/matrixone/cgo -lmo -L/go/src/github.com/matrixorigin/matrixone/thirdparties/install/lib -Wl,-rpath,/go/src/github.com/matrixorigin/matrixone/cgo -Wl,-rpath,/go/src/github.com/matrixorigin/matrixone/thirdparties/install/lib -fopenmp"
+ENV LD_LIBRARY_PATH="/go/src/github.com/matrixorigin/matrixone/cgo:/go/src/github.com/matrixorigin/matrixone/thirdparties/install/lib"
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go test -count=1 ./test/mongodb ./test/iceberg && \
+    (cd pkg/iceberg/adapter/iceberggo && go test -tags iceberggo -count=1 ./...) && \
+    go test ./pkg/iceberg/metadata -run '^TestGoldenVectorProvenanceArtifacts$' -count=1 && \
+    mkdir -p /connector-bin && \
+    go build -o /connector-bin/mongodb-e2e ./test/mongodb && \
+    go build -o /connector-bin/iceberg-e2e ./test/iceberg && \
+    printf '%s\n' "$SOURCE_REVISION" >/connector-source-revision
+
+FROM matrixorigin/ubuntu:22.04 AS runtime-base
 
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/mo-service /mo-service
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/etc /etc
@@ -69,5 +124,22 @@ RUN mkdir -p /tmp/coverage && ldconfig && GOCOVERDIR=/tmp/coverage /mo-service -
 WORKDIR /
 
 EXPOSE 6001
+
+FROM runtime-base AS connector-ci
+
+ARG SOURCE_REVISION=unknown
+LABEL org.opencontainers.image.revision="${SOURCE_REVISION}"
+
+COPY --from=connector-builder /connector-bin /connector-bin
+COPY --from=connector-builder /connector-source-revision /connector-source-revision
+COPY --from=connector-builder /go/src/github.com/matrixorigin/matrixone/test/mongodb/fixture_manifest.json /test/mongodb/fixture_manifest.json
+
+RUN test -x /connector-bin/mongodb-e2e && \
+    test -x /connector-bin/iceberg-e2e && \
+    test "$(cat /connector-source-revision)" = "$SOURCE_REVISION"
+
+ENTRYPOINT [ "/mo-service", "-debug-http=:12345", "-launch", "/etc/quickstart/launch.toml"]
+
+FROM runtime-base AS runtime
 
 ENTRYPOINT [ "/mo-service", "-debug-http=:12345", "-launch", "/etc/quickstart/launch.toml"]

--- a/optools/mongodb_ci.bash
+++ b/optools/mongodb_ci.bash
@@ -7,12 +7,19 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROFILE="${1:-e2e-local}"
 REPORT_DIR="${MO_MONGODB_REPORT_DIR:-${ROOT_DIR}/test/mongodb/reports/ci_$(date -u +%Y%m%dT%H%M%SZ)}"
+if [[ "$REPORT_DIR" != /* ]]; then
+  REPORT_DIR="${ROOT_DIR}/${REPORT_DIR}"
+fi
 TMP_DIR=""
 MO_PID=""
+MO_CONTAINER=""
 
 log() { printf '[mongodb-ci] %s\n' "$*"; }
 die() { printf '[mongodb-ci] ERROR: %s\n' "$*" >&2; exit 1; }
 require() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+# shellcheck source=optools/connector_ci_image.bash
+source "${ROOT_DIR}/optools/connector_ci_image.bash"
 
 sanitize() {
   local source="$1" target="$2"
@@ -27,6 +34,9 @@ sanitize() {
 collect() {
   [[ -n "$TMP_DIR" ]] || return
   mkdir -p "$REPORT_DIR"
+  if [[ -n "$MO_CONTAINER" ]]; then
+    docker logs "$MO_CONTAINER" >"$TMP_DIR/mo-service.log" 2>&1 || true
+  fi
   sanitize "$TMP_DIR/mo-service.log" "$REPORT_DIR/mo-service.log"
   if command -v docker >/dev/null 2>&1; then
     MONGODB_PORT="${MONGODB_PORT:-27017}" MONGODB_ROOT_USER="${MONGODB_ROOT_USER:-x}" \
@@ -56,6 +66,9 @@ cleanup() {
     wait "$MO_PID" >/dev/null 2>&1 || true
   fi
   collect
+  if [[ -n "$MO_CONTAINER" ]]; then
+    docker rm -f "$MO_CONTAINER" >/dev/null 2>&1 || true
+  fi
   if [[ -n "$TMP_DIR" ]]; then
     MONGODB_PORT="${MONGODB_PORT:-27017}" MONGODB_ROOT_USER="${MONGODB_ROOT_USER:-x}" \
       MONGODB_ROOT_PASSWORD="${MONGODB_ROOT_PASSWORD:-x}" MONGODB_KEYFILE="${MONGODB_KEYFILE:-/dev/null}" \
@@ -139,7 +152,12 @@ generate_mo_config() {
 }
 
 run_e2e() {
-  require docker; require go; require python3; require openssl
+  require docker; require openssl
+  if connector_ci_enabled; then
+    connector_ci_verify_image
+  else
+    require go
+  fi
   mkdir -p "$REPORT_DIR"
   TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mo-mongodb-e2e.XXXXXX")"
   trap cleanup EXIT
@@ -147,7 +165,12 @@ run_e2e() {
   # Let Docker and MatrixOne bind port 0 themselves. The selected listeners
   # stay owned from allocation through use, eliminating the bind-close-rebind
   # window that let adjacent CI jobs steal either port.
-  export MONGODB_PORT="" MO_PORT="0"
+  export MONGODB_PORT=""
+  if connector_ci_enabled; then
+    export MO_PORT="6001"
+  else
+    export MO_PORT="0"
+  fi
   export MONGODB_ROOT_USER="root_$(openssl rand -hex 6)"
   export MONGODB_ROOT_PASSWORD="$(openssl rand -hex 24)"
   export MONGODB_READER_PASSWORD="$(openssl rand -hex 24)"
@@ -156,7 +179,9 @@ run_e2e() {
   openssl rand -base64 756 >"$MONGODB_KEYFILE"
   chmod 600 "$MONGODB_KEYFILE"
 
-  (cd "$ROOT_DIR" && make build)
+  if ! connector_ci_enabled; then
+    (cd "$ROOT_DIR" && make build)
+  fi
   generate_mo_config
   docker compose -p "$COMPOSE_PROJECT_NAME" -f "$ROOT_DIR/etc/launch-mongodb-local/compose.yaml" up -d
   MONGODB_PORT="$(docker compose -p "$COMPOSE_PROJECT_NAME" -f "$ROOT_DIR/etc/launch-mongodb-local/compose.yaml" port mongo 27017 | sed -nE 's/.*:([0-9]+)$/\1/p' | tail -1)"
@@ -173,19 +198,36 @@ run_e2e() {
     mongosh --quiet -u "$MONGODB_ROOT_USER" -p "$MONGODB_ROOT_PASSWORD" --authenticationDatabase admin \
     <"$ROOT_DIR/etc/launch-mongodb-local/init_and_seed.js" >/dev/null
   export MO_MONGODB_E2E_CREDENTIAL="{\"Username\":\"mo_reader\",\"Password\":\"$MONGODB_READER_PASSWORD\"}"
-	export MO_MONGODB_E2E_CREDENTIAL_NEXT="{\"Username\":\"mo_reader_next\",\"Password\":\"$MONGODB_READER_NEXT_PASSWORD\"}"
-	if [[ "$(uname -s)" == Darwin ]]; then
-		export DYLD_LIBRARY_PATH="$ROOT_DIR/cgo:$ROOT_DIR/thirdparties/install/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
-	else
-		export LD_LIBRARY_PATH="$ROOT_DIR/cgo:$ROOT_DIR/thirdparties/install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-	fi
-  "$ROOT_DIR/mo-service" -launch "$TMP_DIR/mo-config/launch.toml" >"$TMP_DIR/mo-service.log" 2>&1 &
-  MO_PID=$!
-  MO_PORT="$(wait_mo_port)"
-  export MO_PORT
-  (cd "$ROOT_DIR" && go run ./test/mongodb/mongodb_e2e_local.go \
-    --dsn "root:111@tcp(127.0.0.1:$MO_PORT)/?timeout=5s&readTimeout=30s&writeTimeout=30s" \
-    --mongo-host "127.0.0.1:$MONGODB_PORT" --report-dir "$REPORT_DIR")
+  export MO_MONGODB_E2E_CREDENTIAL_NEXT="{\"Username\":\"mo_reader_next\",\"Password\":\"$MONGODB_READER_NEXT_PASSWORD\"}"
+  if connector_ci_enabled; then
+    local network="${COMPOSE_PROJECT_NAME}_mongodb-e2e"
+    local container_user="$(id -u):$(id -g)"
+    MO_CONTAINER="${COMPOSE_PROJECT_NAME}-mo"
+    docker run -d --name "$MO_CONTAINER" --network "$network" --user "$container_user" \
+      --mount "type=bind,source=${TMP_DIR},target=${TMP_DIR}" \
+      -e MO_MONGODB_E2E_CREDENTIAL -e MO_MONGODB_E2E_CREDENTIAL_NEXT \
+      --entrypoint /mo-service "$MO_CONNECTOR_CI_IMAGE" \
+      -launch "$TMP_DIR/mo-config/launch.toml" >/dev/null
+    connector_ci_wait_for_mo "$MO_CONTAINER" "$MO_PORT"
+    docker run --rm --network "$network" --user "$container_user" \
+      --mount "type=bind,source=${REPORT_DIR},target=${REPORT_DIR}" \
+      --entrypoint /connector-bin/mongodb-e2e "$MO_CONNECTOR_CI_IMAGE" \
+      --dsn "root:111@tcp(${MO_CONTAINER}:${MO_PORT})/?timeout=5s&readTimeout=30s&writeTimeout=30s" \
+      --mongo-host "mongo:27017" --report-dir "$REPORT_DIR"
+  else
+    if [[ "$(uname -s)" == Darwin ]]; then
+      export DYLD_LIBRARY_PATH="$ROOT_DIR/cgo:$ROOT_DIR/thirdparties/install/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+    else
+      export LD_LIBRARY_PATH="$ROOT_DIR/cgo:$ROOT_DIR/thirdparties/install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    fi
+    "$ROOT_DIR/mo-service" -launch "$TMP_DIR/mo-config/launch.toml" >"$TMP_DIR/mo-service.log" 2>&1 &
+    MO_PID=$!
+    MO_PORT="$(wait_mo_port)"
+    export MO_PORT
+    (cd "$ROOT_DIR" && go run ./test/mongodb/mongodb_e2e_local.go \
+      --dsn "root:111@tcp(127.0.0.1:$MO_PORT)/?timeout=5s&readTimeout=30s&writeTimeout=30s" \
+      --mongo-host "127.0.0.1:$MONGODB_PORT" --report-dir "$REPORT_DIR")
+  fi
 }
 
 run_unit() {
@@ -196,12 +238,14 @@ run_unit() {
 		./pkg/sql/parsers/dialect/mysql ./pkg/sql/plan ./pkg/sql/compile ./pkg/frontend)
 }
 
-case "$PROFILE" in
-  unit) run_unit ;;
-  e2e-local) run_e2e ;;
-  nightly)
-	run_unit
-	run_e2e
-	;;
-  *) die "unknown profile: $PROFILE" ;;
-esac
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  case "$PROFILE" in
+    unit) run_unit ;;
+    e2e-local) run_e2e ;;
+    nightly)
+      run_unit
+      run_e2e
+      ;;
+    *) die "unknown profile: $PROFILE" ;;
+  esac
+fi

--- a/test/iceberg/iceberg_e2e_local.go
+++ b/test/iceberg/iceberg_e2e_local.go
@@ -41,13 +41,14 @@ import (
 )
 
 type localE2EConfig struct {
-	CatalogURI string
-	Warehouse  string
-	DSN        string
-	ReportDir  string
-	Namespace  string
-	Catalog    string
-	Database   string
+	CatalogURI     string
+	Warehouse      string
+	ObjectEndpoint string
+	DSN            string
+	ReportDir      string
+	Namespace      string
+	Catalog        string
+	Database       string
 }
 
 type caseResult struct {
@@ -75,6 +76,7 @@ func main() {
 	cfg := localE2EConfig{}
 	flag.StringVar(&cfg.CatalogURI, "catalog-uri", envOr("MO_ICEBERG_E2E_CATALOG_URI", "http://127.0.0.1:19120/iceberg"), "Iceberg REST catalog URI")
 	flag.StringVar(&cfg.Warehouse, "warehouse", envOr("MO_ICEBERG_E2E_WAREHOUSE", "s3://mo-iceberg/warehouse"), "Iceberg warehouse location")
+	flag.StringVar(&cfg.ObjectEndpoint, "object-endpoint", envOr("MO_ICEBERG_E2E_OBJECT_ENDPOINT", "localhost"), "object storage endpoint allowed by the Iceberg access policy")
 	flag.StringVar(&cfg.DSN, "dsn", envOr("MO_ICEBERG_E2E_DSN", "root:111@tcp(127.0.0.1:6001)/?timeout=5s&readTimeout=30s&writeTimeout=30s&multiStatements=false"), "MatrixOne MySQL DSN")
 	flag.StringVar(&cfg.ReportDir, "report-dir", envOr("MO_ICEBERG_REPORT_DIR", "test/iceberg/reports/e2e-local"), "report output directory")
 	flag.StringVar(&cfg.Namespace, "namespace", envOr("MO_ICEBERG_E2E_NAMESPACE", ""), "Iceberg namespace to create")
@@ -146,6 +148,7 @@ func main() {
 	cases := []func(context.Context) caseResult{
 		runner.catalogAndMappingCase,
 		runner.appendReadAndTimeTravelCase,
+		runner.aggregateAndEmptyScanCase,
 		runner.partitionFilterCase,
 		runner.mergeOnReadDeleteCase,
 	}
@@ -183,7 +186,7 @@ func (r *caseRunner) setup(ctx context.Context) error {
 			ident(r.cfg.Catalog), sqlString(r.cfg.CatalogURI), sqlString(r.cfg.Warehouse)),
 		fmt.Sprintf("CALL iceberg_register_access(%s, %s)",
 			sqlString(r.cfg.Catalog),
-			sqlString("scope=cluster,account_id=0,external_principal=ci-local,endpoint=localhost,region=us-east-1,bucket=mo-iceberg")),
+			sqlString(fmt.Sprintf("scope=cluster,account_id=0,external_principal=ci-local,endpoint=%s,region=us-east-1,bucket=mo-iceberg", r.cfg.ObjectEndpoint))),
 		fmt.Sprintf(`CREATE EXTERNAL TABLE %s.%s (
   order_id BIGINT,
   bucket INT,
@@ -377,6 +380,28 @@ func (r *caseRunner) partitionFilterCase(ctx context.Context) caseResult {
 		return failedCase("ICE-CI-E2E-030", "partition-filter", sqls, expected, actual, "partition filter result mismatch")
 	}
 	return passedCase("ICE-CI-E2E-030", "partition-filter", sqls, expected, actual, nil)
+}
+
+func (r *caseRunner) aggregateAndEmptyScanCase(ctx context.Context) caseResult {
+	table := fmt.Sprintf("%s.%s", ident(r.cfg.Database), ident("append_orders"))
+	sqls := []string{
+		fmt.Sprintf("SELECT region, COUNT(*), SUM(amount) FROM %s GROUP BY region ORDER BY region", table),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE order_id > 1000", table),
+	}
+	aggregates, err := queryLines(ctx, r.db, sqls[0])
+	if err != nil {
+		return failedCase("ICE-CI-E2E-025", "aggregate-and-empty-scan", sqls, nil, aggregates, err.Error())
+	}
+	empty, err := queryLines(ctx, r.db, sqls[1])
+	if err != nil {
+		return failedCase("ICE-CI-E2E-025", "aggregate-and-empty-scan", sqls, nil, empty, err.Error())
+	}
+	expected := []string{"ksa\t3\t90", "qat\t1\t40", "uae\t1\t20", "0"}
+	actual := append(append([]string{}, aggregates...), empty...)
+	if !sameLines(expected, actual) {
+		return failedCase("ICE-CI-E2E-025", "aggregate-and-empty-scan", sqls, expected, actual, "aggregate/empty scan result mismatch")
+	}
+	return passedCase("ICE-CI-E2E-025", "aggregate-and-empty-scan", sqls, expected, actual, nil)
 }
 
 func (r *caseRunner) mergeOnReadDeleteCase(ctx context.Context) caseResult {

--- a/test/iceberg/iceberg_e2e_local_test.go
+++ b/test/iceberg/iceberg_e2e_local_test.go
@@ -380,7 +380,7 @@ func TestLocalE2ESetupExecutesExpectedStatements(t *testing.T) {
 		"DROP ICEBERG CATALOG IF EXISTS",
 		"CREATE DATABASE",
 		"CREATE ICEBERG CATALOG",
-		"CALL iceberg_register_access",
+		"CALL iceberg_register_access.*endpoint=localhost",
 		"CREATE EXTERNAL TABLE",
 		"CREATE EXTERNAL TABLE",
 		"CREATE EXTERNAL TABLE",
@@ -389,6 +389,32 @@ func TestLocalE2ESetupExecutesExpectedStatements(t *testing.T) {
 	}
 	runner := &caseRunner{cfg: localE2ETestConfig(), db: db}
 	if err := runner.setup(context.Background()); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestLocalE2ESetupUsesConfiguredObjectEndpoint(t *testing.T) {
+	db, mock := newLocalE2ESQLMock(t)
+	defer db.Close()
+
+	for _, pattern := range []string{
+		"DROP DATABASE IF EXISTS",
+		"DROP ICEBERG CATALOG IF EXISTS",
+		"CREATE DATABASE",
+		"CREATE ICEBERG CATALOG",
+		"CALL iceberg_register_access.*endpoint=minio",
+		"CREATE EXTERNAL TABLE",
+		"CREATE EXTERNAL TABLE",
+		"CREATE EXTERNAL TABLE",
+	} {
+		mock.ExpectExec(pattern).WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+	cfg := localE2ETestConfig()
+	cfg.ObjectEndpoint = "minio"
+	if err := (&caseRunner{cfg: cfg, db: db}).setup(context.Background()); err != nil {
 		t.Fatalf("setup failed: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -1067,6 +1093,75 @@ func TestLocalE2EPartitionFilterCase(t *testing.T) {
 	}
 }
 
+func TestLocalE2EAggregateAndEmptyScanCase(t *testing.T) {
+	db, mock := newLocalE2ESQLMock(t)
+	defer db.Close()
+
+	mock.ExpectQuery("GROUP BY region").WillReturnRows(sqlmock.NewRows([]string{"region", "count", "sum"}).
+		AddRow("ksa", int64(3), int64(90)).
+		AddRow("qat", int64(1), int64(40)).
+		AddRow("uae", int64(1), int64(20)))
+	mock.ExpectQuery("order_id > 1000").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
+
+	result := (&caseRunner{cfg: localE2ETestConfig(), db: db}).aggregateAndEmptyScanCase(context.Background())
+	if result.Status != "passed" {
+		t.Fatalf("aggregate/empty scan case failed: %+v", result)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestLocalE2EAggregateAndEmptyScanCaseFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		mock   func(sqlmock.Sqlmock)
+		errSub string
+	}{
+		{
+			name: "aggregate query fails",
+			mock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("GROUP BY region").WillReturnError(errors.New("aggregate failed"))
+			},
+			errSub: "aggregate failed",
+		},
+		{
+			name: "empty query fails",
+			mock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("GROUP BY region").WillReturnRows(sqlmock.NewRows([]string{"region", "count", "sum"}).
+					AddRow("ksa", int64(3), int64(90)).
+					AddRow("qat", int64(1), int64(40)).
+					AddRow("uae", int64(1), int64(20)))
+				mock.ExpectQuery("order_id > 1000").WillReturnError(errors.New("empty scan failed"))
+			},
+			errSub: "empty scan failed",
+		},
+		{
+			name: "result mismatch",
+			mock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("GROUP BY region").WillReturnRows(sqlmock.NewRows([]string{"region", "count", "sum"}).
+					AddRow("ksa", int64(4), int64(100)))
+				mock.ExpectQuery("order_id > 1000").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+			},
+			errSub: "result mismatch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock := newLocalE2ESQLMock(t)
+			defer db.Close()
+			tt.mock(mock)
+			result := (&caseRunner{cfg: localE2ETestConfig(), db: db}).aggregateAndEmptyScanCase(context.Background())
+			if result.Status != "failed" || !strings.Contains(result.Error, tt.errSub) {
+				t.Fatalf("expected failure containing %q, got %+v", tt.errSub, result)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
 func TestLocalE2EMergeOnReadDeleteCase(t *testing.T) {
 	db, mock := newLocalE2ESQLMock(t)
 	defer db.Close()
@@ -1244,13 +1339,14 @@ func TestLocalE2ESeedRESTTables(t *testing.T) {
 
 func localE2ETestConfig() localE2EConfig {
 	return localE2EConfig{
-		CatalogURI: "http://127.0.0.1:19120/iceberg",
-		Warehouse:  "s3://mo-iceberg/warehouse",
-		DSN:        "root:111@tcp(127.0.0.1:6001)/",
-		ReportDir:  "test/iceberg/reports/e2e-local",
-		Namespace:  "ci_ns",
-		Catalog:    "ci_catalog",
-		Database:   "ci_db",
+		CatalogURI:     "http://127.0.0.1:19120/iceberg",
+		Warehouse:      "s3://mo-iceberg/warehouse",
+		ObjectEndpoint: "localhost",
+		DSN:            "root:111@tcp(127.0.0.1:6001)/",
+		ReportDir:      "test/iceberg/reports/e2e-local",
+		Namespace:      "ci_ns",
+		Catalog:        "ci_catalog",
+		Database:       "ci_db",
 	}
 }
 

--- a/test/mongodb/mongodb_e2e_local.go
+++ b/test/mongodb/mongodb_e2e_local.go
@@ -128,6 +128,20 @@ func runWithDSN(ctx context.Context, db *sql.DB, dsn, host string, r *report) er
 	}
 	r.Cases = append(r.Cases, "scan-projection-pushdown-null-conversion")
 
+	// Exercise a compound residual over a try_null numeric conversion, the
+	// ObjectID-to-CHAR mapping boundary, and the distinction between BSON null
+	// or missing values and present strings.
+	if err := expectScalar(ctx, db, "select count(*) from mongodb_ci.events where device_id = 'device-001' and site_id = 'site-east' and measurement >= 14 and measurement < 30", "2"); err != nil {
+		return err
+	}
+	if err := expectScalar(ctx, db, "select count(*) from mongodb_ci.events where mongo_id = '64b000000000000000000003'", "1"); err != nil {
+		return err
+	}
+	if err := expectScalar(ctx, db, "select count(*) from mongodb_ci.events where source_batch is not null", "2"); err != nil {
+		return err
+	}
+	r.Cases = append(r.Cases, "compound-predicate-objectid-null-boundaries")
+
 	// BSON DateTime preserves milliseconds, while DATETIME(0) truncates them.
 	// The source predicate must therefore remain residual-only: an exact MongoDB
 	// equality on 10:00:05.000 would incorrectly exclude this .100 source row.

--- a/test/mongodb/mongodb_e2e_local_test.go
+++ b/test/mongodb/mongodb_e2e_local_test.go
@@ -21,6 +21,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -49,6 +50,148 @@ func TestMongoDBLocalE2ERunnerDoesNotImportKernelPackages(t *testing.T) {
 	}
 }
 
+func TestConnectorE2EWorkflowsUseRevisionPinnedDockerImage(t *testing.T) {
+	repoRoot := mongoDBTestRepoRoot(t)
+	for _, name := range []string{"mongodb-connector.yml", "iceberg-connector.yml"} {
+		data, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", name))
+		require.NoError(t, err)
+		workflow := string(data)
+		require.NotContains(t, workflow, "actions/setup-go", "%s must not download Go modules on the host", name)
+		require.NotContains(t, workflow, "\n  pull_request:", "%s must not run for every PR", name)
+		require.NotContains(t, workflow, "if: ${{ false }}", "%s must remain manually runnable", name)
+		require.NotContains(t, workflow, "github.event.pull_request")
+		require.Contains(t, workflow, "workflow_dispatch:")
+		require.Contains(t, workflow, "MO_CONNECTOR_CI_REVISION: ${{ github.sha }}")
+		require.Contains(t, workflow, "uses: ./.github/actions/build-connector-ci")
+		require.Contains(t, workflow, "ignore-cache-export-error: 'true'")
+	}
+	buildAction, err := os.ReadFile(filepath.Join(repoRoot, ".github", "actions", "build-connector-ci", "action.yml"))
+	require.NoError(t, err)
+	sharedBuild := string(buildAction)
+	require.Contains(t, sharedBuild, "target: connector-ci")
+	require.Contains(t, sharedBuild, "cache-from: |")
+	require.Contains(t, sharedBuild, "type=gha,scope=connector-ci-")
+	require.Contains(t, sharedBuild, "scope=matrixone-native-")
+	require.Contains(t, sharedBuild, "cache-to: type=gha,mode=max,scope=connector-ci-")
+	require.Contains(t, sharedBuild, "ignore-error=${{ inputs['ignore-cache-export-error'] }}")
+	require.Contains(t, sharedBuild, "Retry connector CI image build")
+	require.Contains(t, sharedBuild, "GO_MOD_DOWNLOAD_TIMEOUT=10m")
+	require.Contains(t, sharedBuild, "python3 pkg/iceberg/metadata/testdata/generate_golden_vectors.py --check")
+
+	cacheWorkflow, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", "connector-ci-cache.yml"))
+	require.NoError(t, err)
+	cacheWarmup := string(cacheWorkflow)
+	require.Contains(t, cacheWarmup, "branches: [main]")
+	require.Contains(t, cacheWarmup, "uses: ./.github/actions/build-connector-ci")
+	require.NotContains(t, cacheWarmup, "ignore-cache-export-error: 'true'")
+
+	dockerfile, err := os.ReadFile(filepath.Join(repoRoot, "optools", "images", "Dockerfile"))
+	require.NoError(t, err)
+	imageContract := string(dockerfile)
+	require.NotContains(t, imageContract, "python3", "the pinned builder image does not contain Python")
+	for _, required := range []string{
+		"FROM builder AS connector-builder",
+		"FROM build-base AS connector-modules",
+		"COPY --from=connector-modules /go/pkg/mod /go/pkg/mod",
+		"FROM runtime-base AS connector-ci",
+		"org.opencontainers.image.revision",
+		"/connector-bin/mongodb-e2e",
+		"/connector-bin/iceberg-e2e",
+		"go test -tags iceberggo",
+		"ENV CGO_LDFLAGS=",
+		"id=matrixone-go-modules",
+		"sharing=locked",
+		"cp -a /tmp/gomod-cache/. /go/pkg/mod/",
+		"ARG GO_MOD_DOWNLOAD_TIMEOUT=0",
+		"timeout \"$GO_MOD_DOWNLOAD_TIMEOUT\" env GOMODCACHE=/tmp/gomod-cache go mod download",
+	} {
+		require.Contains(t, imageContract, required)
+	}
+
+	for _, tc := range []struct {
+		path     string
+		required []string
+	}{
+		{
+			path: "optools/mongodb_ci.bash",
+			required: []string{
+				"--user \"$container_user\"",
+				"--entrypoint /mo-service",
+				"--entrypoint /connector-bin/mongodb-e2e",
+				"--mongo-host \"mongo:27017\"",
+			},
+		},
+		{
+			path: "optools/iceberg_ci.bash",
+			required: []string{
+				"--user \"$container_user\"",
+				"--entrypoint /mo-service",
+				"--entrypoint /connector-bin/iceberg-e2e",
+				"http://nessie:19120/iceberg",
+				"http://minio:9000",
+				"--object-endpoint \"${MO_ICEBERG_E2E_OBJECT_ENDPOINT:-minio}\"",
+			},
+		},
+	} {
+		data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(tc.path)))
+		require.NoError(t, err)
+		for _, required := range tc.required {
+			require.Contains(t, string(data), required, "%s is missing its container contract", tc.path)
+		}
+		require.Equal(t, 2, strings.Count(string(data), `--user "$container_user"`),
+			"%s must run both MatrixOne and its E2E runner as the host user", tc.path)
+	}
+
+	compose, err := os.ReadFile(filepath.Join(repoRoot, "etc", "launch-minio-local", "docker-compose.yml"))
+	require.NoError(t, err)
+	require.NotContains(t, string(compose), "projectnessie/nessie:latest")
+	require.Contains(t, string(compose), "NESSIE_EXTERNAL_ENDPOINT:-http://127.0.0.1:9000")
+}
+
+func TestConnectorContainerConfigGenerators(t *testing.T) {
+	repoRoot := mongoDBTestRepoRoot(t)
+
+	t.Run("mongodb", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cmd := exec.Command("bash", "-c", `source "$1"; TMP_DIR="$2"; MO_PORT=6001; generate_mo_config`,
+			"connector-config-test", filepath.Join(repoRoot, "optools", "mongodb_ci.bash"), tmpDir)
+		output, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "generate MongoDB container config: %s", output)
+
+		for _, name := range []string{"log.toml", "tn.toml", "cn.toml"} {
+			data, err := os.ReadFile(filepath.Join(tmpDir, "mo-config", name))
+			require.NoError(t, err)
+			require.Contains(t, string(data), filepath.Join(tmpDir, "mo-data"))
+		}
+		cn, err := os.ReadFile(filepath.Join(tmpDir, "mo-config", "cn.toml"))
+		require.NoError(t, err)
+		require.Contains(t, string(cn), "[cn.frontend]\nport = 6001")
+		require.Contains(t, string(cn), "[cn.frontend.mongodb]\n")
+	})
+
+	t.Run("iceberg", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cmd := exec.Command("bash", "-c", `source "$1"; ICEBERG_E2E_TMP_DIR="$2"; generate_iceberg_container_config`,
+			"connector-config-test", filepath.Join(repoRoot, "optools", "iceberg_ci.bash"), tmpDir)
+		output, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "generate Iceberg container config: %s", output)
+
+		for _, name := range []string{"log.toml", "tn.toml", "cn.toml"} {
+			data, err := os.ReadFile(filepath.Join(tmpDir, "mo-config", name))
+			require.NoError(t, err)
+			config := string(data)
+			require.Contains(t, config, filepath.Join(tmpDir, "mo-data"))
+			require.NotContains(t, config, "http://127.0.0.1:9000")
+			require.Contains(t, config, "http://minio:9000")
+		}
+		launch, err := os.ReadFile(filepath.Join(tmpDir, "mo-config", "launch.toml"))
+		require.NoError(t, err)
+		for _, name := range []string{"log.toml", "tn.toml", "cn.toml"} {
+			require.Contains(t, string(launch), filepath.Join(tmpDir, "mo-config", name))
+		}
+	})
+}
+
 func TestMongoDBLocalE2ERunContract(t *testing.T) {
 	repoRoot := mongoDBTestRepoRoot(t)
 	previous, err := os.Getwd()
@@ -74,6 +217,9 @@ func TestMongoDBLocalE2ERunContract(t *testing.T) {
 	mock.ExpectQuery("select mongo_id").WillReturnRows(fixtureRows)
 	expectMongoDBE2EScalar(mock, "3")
 	expectMongoDBE2EScalar(mock, "3")
+	expectMongoDBE2EScalar(mock, "2")
+	expectMongoDBE2EScalar(mock, "1")
+	expectMongoDBE2EScalar(mock, "2")
 	expectMongoDBE2EScalar(mock, "1")
 	mock.ExpectQuery("select payload_1").WillReturnError(errors.New("MongoDB decoded batch byte limit exceeded"))
 	// A pre-canceled context is rejected by database/sql before it reaches the
@@ -114,6 +260,7 @@ func TestMongoDBLocalE2ERunContract(t *testing.T) {
 		"secret-backed-ddl",
 		"show-create-redaction-roundtrip",
 		"scan-projection-pushdown-null-conversion",
+		"compound-predicate-objectid-null-boundaries",
 		"low-precision-temporal-residual",
 		"decoded-vector-budget-enforced",
 		"multi-batch-cancel-recovery",


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27094

## What this PR does / why we need it:

- Builds the MongoDB and Iceberg connector E2E runtime and runners in a revision-pinned Docker image, avoiding cold host-side Go module downloads.
- Reuses bounded BuildKit/GHA caches and keeps exact source revision checks in the runtime image.
- Keeps MongoDB E2E manual-only as configured on main, while preserving the existing advisory Iceberg workflow.
- Adds MongoDB and Iceberg connector regression coverage and bounded cleanup/diagnostic paths.