### PR TITLE
fix(logservice): prevent connection ID refill convoys

### DIFF
--- a/pkg/frontend/logservice_test.go
+++ b/pkg/frontend/logservice_test.go
@@ -34,6 +34,7 @@ type mockHAKeeperClient struct {
 	clusterState        pb.CheckerState
 	NonVotingReplicaNum uint64
 	NonVotingLocality   pb.Locality
+	allocateIDByKey     func(context.Context, string) (uint64, error)
 }
 
 func newMockHAKeeperClient() *mockHAKeeperClient {
@@ -53,6 +54,9 @@ func (c *mockHAKeeperClient) AllocateID(ctx context.Context) (uint64, error) {
 }
 
 func (c *mockHAKeeperClient) AllocateIDByKey(ctx context.Context, key string) (uint64, error) {
+	if c.allocateIDByKey != nil {
+		return c.allocateIDByKey(ctx, key)
+	}
 	return 0, nil
 }
 

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -256,7 +256,11 @@ func (rm *RoutineManager) getConnID() (uint32, error) {
 	if rm.pu.HAKeeperClient == nil {
 		return nextConnectionID(), nil
 	}
-	ctx, cancel := context.WithTimeoutCause(rm.ctx, time.Second*2, moerr.CauseGetConnID)
+	ctx, cancel := context.WithTimeoutCause(
+		rm.ctx,
+		rm.pu.SV.ConnectTimeout.Duration,
+		moerr.CauseGetConnID,
+	)
 	defer cancel()
 	connID, err := rm.pu.HAKeeperClient.AllocateIDByKey(ctx, ConnIDAllocKey)
 	if err != nil {

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -59,6 +59,33 @@ func newTestRoutineManager(t *testing.T, ctx context.Context) *RoutineManager {
 	return rm
 }
 
+func TestRoutineManagerGetConnIDUsesConnectTimeout(t *testing.T) {
+	const connectTimeout = 17 * time.Second
+	var observed time.Duration
+	client := newMockHAKeeperClient()
+	client.allocateIDByKey = func(ctx context.Context, key string) (uint64, error) {
+		require.Equal(t, ConnIDAllocKey, key)
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		observed = time.Until(deadline)
+		return 0, context.DeadlineExceeded
+	}
+	sv := &config.FrontendParameters{}
+	sv.SetDefaultValues()
+	sv.ConnectTimeout.Duration = connectTimeout
+	rm := &RoutineManager{
+		ctx: context.Background(),
+		pu: &config.ParameterUnit{
+			SV:             sv,
+			HAKeeperClient: client,
+		},
+	}
+
+	_, err := rm.getConnID()
+	require.Error(t, err)
+	require.InDelta(t, connectTimeout, observed, float64(time.Second))
+}
+
 func Test_Closed(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
 	defer serverConn.Close()

--- a/pkg/logservice/hakeeper_client.go
+++ b/pkg/logservice/hakeeper_client.go
@@ -387,7 +387,7 @@ func validateHAKeeperClientContext(ctx context.Context) error {
 	if _, ok := ctx.Deadline(); !ok {
 		return moerr.NewInvalidInput(ctx, "HAKeeper client context deadline not set")
 	}
-	return nil
+	return ctx.Err()
 }
 
 func newManagedHAKeeperClient(
@@ -407,14 +407,17 @@ func newManagedHAKeeperClient(
 		clientOptions:  GetClientOptions(ctx),
 	}
 	mc.mu.client = c
-	mc.mu.allocIDByKey = make(map[string]*allocID)
+	mc.allocMu.allocIDByKey = make(map[string]*allocID)
 	return mc, nil
 }
 
-// allocID contains nextID and lastID.
+// allocID owns one local ID batch and coordinates its refill. A waiter never
+// holds mu while waiting for HAKeeper, so its own context remains effective.
 type allocID struct {
+	sync.Mutex
 	nextID uint64
 	lastID uint64
+	refill chan struct{}
 }
 
 type managedHAKeeperClient struct {
@@ -426,13 +429,16 @@ type managedHAKeeperClient struct {
 	backendOptions []morpc.BackendOption
 	clientOptions  []morpc.ClientOption
 
+	// allocMu protects only the keyed-state map. Each allocID protects its own
+	// batch, so one key's refill cannot stop cached allocations for another key.
+	allocMu struct {
+		sync.RWMutex
+		allocIDByKey map[string]*allocID
+	}
+	sharedAllocID allocID
+
 	mu struct {
 		sync.RWMutex
-		// allocIDByKey is used to alloc IDs by different key.
-		allocIDByKey map[string]*allocID
-		// sharedAllocID is used to alloc global IDs.
-		sharedAllocID allocID
-
 		client *hakeeperClient
 	}
 }
@@ -554,57 +560,22 @@ func (c *managedHAKeeperClient) AllocateID(ctx context.Context) (uint64, error) 
 	if err := validateHAKeeperClientContext(ctx); err != nil {
 		return 0, err
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	batchSize := c.cfg.AllocateIDBatch
-	for {
-		if c.mu.sharedAllocID.nextID != 0 &&
-			c.mu.sharedAllocID.nextID <= c.mu.sharedAllocID.lastID {
-			v := c.mu.sharedAllocID.nextID
-			c.mu.sharedAllocID.nextID++
-			if v == 0 {
-				logutil.Error("id should not be 0",
-					zap.Uint64("nextID", c.mu.sharedAllocID.nextID),
-					zap.Uint64("lastID", c.mu.sharedAllocID.lastID))
-			}
-			return v, nil
-		}
-
-		if err := c.prepareClientLocked(ctx); err != nil {
-			if c.isRetryableError(err) {
-				if err := c.waitRetryLocked(ctx); err != nil {
-					return 0, err
-				}
-				continue
-			}
-			return 0, err
-		}
-		firstID, err := sendCNAllocateIDFunc(c.mu.client, ctx, "", batchSize)
-
-		if err != nil {
-			if shouldResetHAKeeperClient(err) {
-				c.resetClientLocked()
-			}
-			if c.isRetryableError(err) {
-				if err := c.waitRetryLocked(ctx); err != nil {
-					return 0, err
-				}
-				continue
-			}
-			logutil.Error("failed to allocate id",
-				zap.Error(err),
-				zap.Uint64("batch", c.cfg.AllocateIDBatch),
-				zap.Uint64("nextID", c.mu.sharedAllocID.nextID),
-				zap.Uint64("lastID", c.mu.sharedAllocID.lastID),
-			)
-			return 0, err
-		}
-
-		c.mu.sharedAllocID.nextID = firstID + 1
-		c.mu.sharedAllocID.lastID = firstID + batchSize - 1
-		return firstID, err
+	id, err := c.allocateID(ctx, "", batchSize, &c.sharedAllocID)
+	if err != nil {
+		c.sharedAllocID.Lock()
+		nextID := c.sharedAllocID.nextID
+		lastID := c.sharedAllocID.lastID
+		c.sharedAllocID.Unlock()
+		logutil.Error("failed to allocate id",
+			zap.Error(err),
+			zap.Uint64("batch", c.cfg.AllocateIDBatch),
+			zap.Uint64("nextID", nextID),
+			zap.Uint64("lastID", lastID),
+		)
+		return 0, err
 	}
+	return id, nil
 }
 
 // AllocateIDByKey implements the basicHAKeeperClient interface.
@@ -633,47 +604,111 @@ func (c *managedHAKeeperClient) AllocateIDByKeyWithBatch(
 		return 0, moerr.NewInvalidInput(ctx, "batch size must be greater than zero")
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	return c.allocateID(ctx, key, batchSize, c.getAllocID(key))
+}
 
+func (c *managedHAKeeperClient) getAllocID(key string) *allocID {
+	c.allocMu.RLock()
+	ids := c.allocMu.allocIDByKey[key]
+	c.allocMu.RUnlock()
+	if ids != nil {
+		return ids
+	}
+
+	c.allocMu.Lock()
+	defer c.allocMu.Unlock()
+	if c.allocMu.allocIDByKey == nil {
+		c.allocMu.allocIDByKey = make(map[string]*allocID)
+	}
+	ids = c.allocMu.allocIDByKey[key]
+	if ids == nil {
+		ids = &allocID{}
+		c.allocMu.allocIDByKey[key] = ids
+	}
+	return ids
+}
+
+func (c *managedHAKeeperClient) allocateID(
+	ctx context.Context,
+	key string,
+	batchSize uint64,
+	ids *allocID,
+) (uint64, error) {
 	for {
-		allocIDs, ok := c.mu.allocIDByKey[key]
-		if !ok {
-			allocIDs = &allocID{nextID: 0, lastID: 0}
-			c.mu.allocIDByKey[key] = allocIDs
-		}
-
-		if allocIDs.nextID != 0 && allocIDs.nextID <= allocIDs.lastID {
-			v := allocIDs.nextID
-			allocIDs.nextID++
-			return v, nil
-		}
-
-		if err := c.prepareClientLocked(ctx); err != nil {
-			if c.isRetryableError(err) {
-				if err := c.waitRetryLocked(ctx); err != nil {
-					return 0, err
-				}
-				continue
-			}
+		if err := ctx.Err(); err != nil {
 			return 0, err
 		}
-		firstID, err := sendCNAllocateIDFunc(c.mu.client, ctx, key, batchSize)
+
+		ids.Lock()
+		if ids.nextID != 0 && ids.nextID <= ids.lastID {
+			id := ids.nextID
+			ids.nextID++
+			ids.Unlock()
+			return id, nil
+		}
+		if ids.refill != nil {
+			refill := ids.refill
+			ids.Unlock()
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-refill:
+				continue
+			}
+		}
+
+		refill := make(chan struct{})
+		ids.refill = refill
+		ids.Unlock()
+
+		// The elected refiller owns this transition. It performs discovery and
+		// RPC without an allocation lock, then publishes the batch and wakes all
+		// waiters exactly once on either success or failure.
+		firstID, err := c.allocateIDBatch(ctx, key, batchSize)
+		ids.Lock()
+		if err == nil {
+			ids.nextID = firstID + 1
+			ids.lastID = firstID + batchSize - 1
+		}
+		ids.refill = nil
+		close(refill)
+		ids.Unlock()
+		return firstID, err
+	}
+}
+
+func (c *managedHAKeeperClient) allocateIDBatch(
+	ctx context.Context,
+	key string,
+	batchSize uint64,
+) (uint64, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		client, err := c.getPreparedClient(ctx)
 		if err != nil {
-			if shouldResetHAKeeperClient(err) {
-				c.resetClientLocked()
-			}
 			if c.isRetryableError(err) {
-				if err := c.waitRetryLocked(ctx); err != nil {
+				if err := c.waitRetry(ctx); err != nil {
 					return 0, err
 				}
 				continue
 			}
 			return 0, err
 		}
-
-		allocIDs.nextID = firstID + 1
-		allocIDs.lastID = firstID + batchSize - 1
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		firstID, err := sendCNAllocateIDFunc(client, ctx, key, batchSize)
+		if shouldResetHAKeeperClient(err) {
+			c.resetClientIfCurrent(client)
+		}
+		if c.isRetryableError(err) {
+			if err := c.waitRetry(ctx); err != nil {
+				return 0, err
+			}
+			continue
+		}
 		return firstID, err
 	}
 }
@@ -1178,6 +1213,12 @@ func (c *managedHAKeeperClient) resetClientIfCurrent(client *hakeeperClient) {
 func (c *managedHAKeeperClient) getPreparedClient(ctx context.Context) (*hakeeperClient, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// The context may have expired while this caller waited for another client
+	// preparation or reset. Do not pass a stale deadline into MORPC: besides
+	// being useless, that error can be mistaken for a broken shared transport.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if err := c.prepareClientLocked(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/logservice/hakeeper_client_test.go
+++ b/pkg/logservice/hakeeper_client_test.go
@@ -1664,7 +1664,7 @@ func TestAllocateBatchIDRetriesPrepareClientError(t *testing.T) {
 	c := &managedHAKeeperClient{
 		cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
 	}
-	c.mu.allocIDByKey = make(map[string]*allocID)
+	c.allocMu.allocIDByKey = make(map[string]*allocID)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	firstID, err := c.AllocateIDByKeyWithBatch(ctx, "x", 2)
@@ -1696,7 +1696,7 @@ func TestAllocateBatchIDRetriesPrepareClientErrorUntilContextDone(t *testing.T) 
 	c := &managedHAKeeperClient{
 		cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
 	}
-	c.mu.allocIDByKey = make(map[string]*allocID)
+	c.allocMu.allocIDByKey = make(map[string]*allocID)
 	ctx, cancel := context.WithTimeout(context.Background(), 55*time.Millisecond)
 	defer cancel()
 
@@ -1749,7 +1749,7 @@ func TestAllocateBatchIDRetriesEOFSendError(t *testing.T) {
 	c := &managedHAKeeperClient{
 		cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
 	}
-	c.mu.allocIDByKey = make(map[string]*allocID)
+	c.allocMu.allocIDByKey = make(map[string]*allocID)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	firstID, err := c.AllocateIDByKeyWithBatch(ctx, "x", 2)
@@ -1796,7 +1796,7 @@ func TestAllocateBatchIDKeepsClientOnContextError(t *testing.T) {
 				cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
 			}
 			c.mu.client = client
-			c.mu.allocIDByKey = make(map[string]*allocID)
+			c.allocMu.allocIDByKey = make(map[string]*allocID)
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 
@@ -1811,6 +1811,295 @@ func TestAllocateBatchIDKeepsClientOnContextError(t *testing.T) {
 			require.Equal(t, 2, sendCalls)
 		})
 	}
+}
+
+func TestAllocateIDByKeyRejectsExpiredContextBeforeRPC(t *testing.T) {
+	originalSend := sendCNAllocateIDFunc
+	defer func() {
+		sendCNAllocateIDFunc = originalSend
+	}()
+
+	var sendCalls atomic.Int64
+	sendCNAllocateIDFunc = func(
+		_ *hakeeperClient,
+		_ context.Context,
+		_ string,
+		_ uint64,
+	) (uint64, error) {
+		sendCalls.Add(1)
+		return 100, nil
+	}
+
+	client := &hakeeperClient{}
+	c := &managedHAKeeperClient{
+		cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
+	}
+	c.mu.client = client
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	cancel()
+
+	_, err := c.AllocateIDByKeyWithBatch(ctx, "connection", 2)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, sendCalls.Load())
+	require.Same(t, client, c.mu.client)
+}
+
+func TestAllocateIDByKeyWaiterHonorsContextDuringRefill(t *testing.T) {
+	originalSend := sendCNAllocateIDFunc
+	defer func() {
+		sendCNAllocateIDFunc = originalSend
+	}()
+
+	type refillRequest struct {
+		key   string
+		batch uint64
+	}
+	refillStarted := make(chan refillRequest, 1)
+	releaseRefill := make(chan struct{})
+	sendCNAllocateIDFunc = func(
+		_ *hakeeperClient,
+		_ context.Context,
+		key string,
+		batch uint64,
+	) (uint64, error) {
+		refillStarted <- refillRequest{key: key, batch: batch}
+		<-releaseRefill
+		return 100, nil
+	}
+
+	c := &managedHAKeeperClient{
+		cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
+	}
+	c.mu.client = &hakeeperClient{}
+	c.allocMu.allocIDByKey = make(map[string]*allocID)
+	leaderDone := make(chan error, 1)
+	leaderCtx, cancelLeader := context.WithTimeout(context.Background(), time.Second)
+	defer cancelLeader()
+	go func() {
+		_, err := c.AllocateIDByKeyWithBatch(leaderCtx, "connection", 2)
+		leaderDone <- err
+	}()
+	request := <-refillStarted
+	require.Equal(t, "connection", request.key)
+	require.Equal(t, uint64(2), request.batch)
+
+	waiterDone := make(chan error, 1)
+	waiterCtx, cancelWaiter := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelWaiter()
+	go func() {
+		_, err := c.AllocateIDByKeyWithBatch(waiterCtx, "connection", 2)
+		waiterDone <- err
+	}()
+
+	var waiterErr error
+	returnedBeforeRefill := false
+	select {
+	case waiterErr = <-waiterDone:
+		returnedBeforeRefill = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(releaseRefill)
+	require.NoError(t, <-leaderDone)
+	if !returnedBeforeRefill {
+		waiterErr = <-waiterDone
+		t.Fatalf("waiter remained blocked behind the refill after its context expired: %v", waiterErr)
+	}
+	require.ErrorIs(t, waiterErr, context.DeadlineExceeded)
+}
+
+func TestAllocateIDByKeySlowRefillDoesNotBlockCachedOtherKey(t *testing.T) {
+	originalSend := sendCNAllocateIDFunc
+	defer func() {
+		sendCNAllocateIDFunc = originalSend
+	}()
+
+	refillStarted := make(chan struct{})
+	releaseRefill := make(chan struct{})
+	sendCNAllocateIDFunc = func(
+		_ *hakeeperClient,
+		_ context.Context,
+		_ string,
+		_ uint64,
+	) (uint64, error) {
+		close(refillStarted)
+		<-releaseRefill
+		return 100, nil
+	}
+
+	c := &managedHAKeeperClient{
+		cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
+	}
+	c.mu.client = &hakeeperClient{}
+	cached := c.getAllocID("cached")
+	cached.nextID = 42
+	cached.lastID = 42
+	leaderDone := make(chan error, 1)
+	leaderCtx, cancelLeader := context.WithTimeout(context.Background(), time.Second)
+	defer cancelLeader()
+	go func() {
+		_, err := c.AllocateIDByKeyWithBatch(leaderCtx, "slow", 2)
+		leaderDone <- err
+	}()
+	<-refillStarted
+
+	cachedDone := make(chan struct {
+		id  uint64
+		err error
+	}, 1)
+	cachedCtx, cancelCached := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelCached()
+	go func() {
+		id, err := c.AllocateIDByKeyWithBatch(cachedCtx, "cached", 2)
+		cachedDone <- struct {
+			id  uint64
+			err error
+		}{id: id, err: err}
+	}()
+
+	var cachedResult struct {
+		id  uint64
+		err error
+	}
+	returnedBeforeRefill := false
+	select {
+	case cachedResult = <-cachedDone:
+		returnedBeforeRefill = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(releaseRefill)
+	require.NoError(t, <-leaderDone)
+	if !returnedBeforeRefill {
+		cachedResult = <-cachedDone
+		t.Fatalf("cached allocation for another key waited behind refill: %v", cachedResult.err)
+	}
+	require.NoError(t, cachedResult.err)
+	require.Equal(t, uint64(42), cachedResult.id)
+}
+
+func TestAllocateIDByKeyBurstSharesRefills(t *testing.T) {
+	originalSend := sendCNAllocateIDFunc
+	defer func() {
+		sendCNAllocateIDFunc = originalSend
+	}()
+
+	const (
+		connections = 1000
+		batchSize   = 100
+	)
+	refillStarted := make(chan struct{})
+	releaseRefill := make(chan struct{})
+	var firstRefill sync.Once
+	var sendCalls atomic.Int64
+	var nextID atomic.Uint64
+	nextID.Store(101)
+	sendCNAllocateIDFunc = func(
+		_ *hakeeperClient,
+		_ context.Context,
+		_ string,
+		batch uint64,
+	) (uint64, error) {
+		sendCalls.Add(1)
+		firstRefill.Do(func() {
+			close(refillStarted)
+			<-releaseRefill
+		})
+		return nextID.Add(batch) - batch, nil
+	}
+
+	c := &managedHAKeeperClient{
+		cfg: HAKeeperClientConfig{AllocateIDBatch: batchSize},
+	}
+	c.mu.client = &hakeeperClient{}
+	ids := c.getAllocID("connection")
+	// The incident entered the burst with 92 IDs left in the current batch.
+	ids.nextID = 9
+	ids.lastID = 100
+
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(connections)
+	results := make(chan struct {
+		id  uint64
+		err error
+	}, connections)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	for range connections {
+		go func() {
+			ready.Done()
+			<-start
+			id, err := c.AllocateIDByKeyWithBatch(ctx, "connection", batchSize)
+			results <- struct {
+				id  uint64
+				err error
+			}{id: id, err: err}
+		}()
+	}
+	ready.Wait()
+	close(start)
+	<-refillStarted
+	close(releaseRefill)
+
+	seen := make(map[uint64]struct{}, connections)
+	for range connections {
+		result := <-results
+		require.NoError(t, result.err)
+		_, exists := seen[result.id]
+		require.False(t, exists, "duplicate ID %d", result.id)
+		seen[result.id] = struct{}{}
+	}
+	require.Len(t, seen, connections)
+	for id := uint64(9); id <= 1008; id++ {
+		_, ok := seen[id]
+		require.True(t, ok, "missing ID %d", id)
+	}
+	require.Equal(t, int64(10), sendCalls.Load())
+}
+
+func TestAllocateIDByKeyWaiterRetriesAfterRefillFailure(t *testing.T) {
+	originalSend := sendCNAllocateIDFunc
+	defer func() {
+		sendCNAllocateIDFunc = originalSend
+	}()
+
+	firstRefillStarted := make(chan struct{})
+	var sendCalls atomic.Int64
+	sendCNAllocateIDFunc = func(
+		_ *hakeeperClient,
+		ctx context.Context,
+		_ string,
+		_ uint64,
+	) (uint64, error) {
+		if sendCalls.Add(1) == 1 {
+			close(firstRefillStarted)
+			<-ctx.Done()
+			return 0, ctx.Err()
+		}
+		return 200, nil
+	}
+
+	c := &managedHAKeeperClient{
+		cfg: HAKeeperClientConfig{AllocateIDBatch: 2},
+	}
+	client := &hakeeperClient{}
+	c.mu.client = client
+	leaderCtx, cancelLeader := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelLeader()
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := c.AllocateIDByKeyWithBatch(leaderCtx, "connection", 2)
+		leaderDone <- err
+	}()
+	<-firstRefillStarted
+
+	waiterCtx, cancelWaiter := context.WithTimeout(context.Background(), time.Second)
+	defer cancelWaiter()
+	waiterID, waiterErr := c.AllocateIDByKeyWithBatch(waiterCtx, "connection", 2)
+	require.NoError(t, waiterErr)
+	require.Equal(t, uint64(200), waiterID)
+	require.ErrorIs(t, <-leaderDone, context.DeadlineExceeded)
+	require.Equal(t, int64(2), sendCalls.Load())
+	require.Same(t, client, c.mu.client)
 }
 
 func TestAllocateIDConsumesEntireBatch(t *testing.T) {
@@ -1874,7 +2163,7 @@ func TestAllocateIDConsumesEntireBatch(t *testing.T) {
 				cfg: HAKeeperClientConfig{AllocateIDBatch: 3},
 			}
 			c.mu.client = &hakeeperClient{}
-			c.mu.allocIDByKey = make(map[string]*allocID)
+			c.allocMu.allocIDByKey = make(map[string]*allocID)
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 
@@ -1911,7 +2200,7 @@ func TestAllocateBatchOneIDsRemainUniqueAcrossClients(t *testing.T) {
 	newClient := func() *managedHAKeeperClient {
 		c := &managedHAKeeperClient{}
 		c.mu.client = &hakeeperClient{}
-		c.mu.allocIDByKey = make(map[string]*allocID)
+		c.allocMu.allocIDByKey = make(map[string]*allocID)
 		return c
 	}
 	clientA := newClient()
@@ -1949,7 +2238,7 @@ func TestAllocateIDByKeyRejectsZeroBatchBeforeRPC(t *testing.T) {
 
 	c := &managedHAKeeperClient{}
 	c.mu.client = &hakeeperClient{}
-	c.mu.allocIDByKey = make(map[string]*allocID)
+	c.allocMu.allocIDByKey = make(map[string]*allocID)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27114

## What this PR does / why we need it:

The failing debug job admitted exactly 92 of 1,000 Sysbench connections and
rejected the remaining 908. That matches the 92 IDs left in the local
100-ID connection batch. The rejected connections produced 908
`failed to get connection ID from HAKeeper` errors.

The apparent 5.28-second HAKeeper outage was mostly a client-side convoy:

1. `AllocateIDByKeyWithBatch` held the managed client's single mutex across
   cached allocation, HAKeeper discovery, and the refill RPC.
2. The first refill exhausted `getConnID`'s hard-coded two-second deadline.
3. Hundreds of callers had already passed context validation and then waited
   behind that mutex until their deadlines expired.
4. A stale waiter could consequently reach MORPC with an expired deadline.
   MORPC returned `invalid input: timeout has invalid deadline`; the managed
   client treated that local error as a broken shared transport and reset it.
5. The remaining stale waiters then serialized HAKeeper rediscovery under the
   same mutex. The job recorded 880 `isHAKeeper:false` results while that queue
   drained.

This change separates ID-batch state from managed-client state and gives each
allocation key its own refill coordination:

- one caller refills an empty batch while same-key waiters wait on a refill
  channel with their own contexts;
- cached IDs and other keys no longer wait behind a slow refill RPC;
- a failed refiller wakes waiters so a still-valid caller can take over;
- client snapshots are used outside the allocation lock and resets remain
  generation-safe;
- expired contexts are rejected before discovery/RPC; and
- connection-ID allocation uses the configured frontend `ConnectTimeout`
  (60 seconds by default) instead of an unrelated hard-coded two seconds.

The same refill primitive is used by unkeyed allocation so that path cannot
reintroduce cross-key blocking through the shared client mutex. No public API,
wire format, persistent state, or server-side ID allocation semantics change.

## Validation

The deterministic regressions failed on the unmodified implementation:

- a same-key waiter remained blocked after its 20 ms context expired and then
  incorrectly consumed an ID after the leader completed;
- `getConnID` exposed a roughly two-second deadline despite a configured
  17-second connection timeout.

The fixed implementation passes:

- 1,000 concurrent connection allocations starting with 92 cached IDs:
  1,000 unique contiguous IDs and exactly 10 refill RPCs;
- context cancellation while waiting for a refill;
- rejection of an already-expired context before RPC;
- cached allocation for another key during a blocked refill;
- waiter takeover after the refill owner fails;
- client reuse after caller-scoped context errors;
- complete batch-boundary consumption; and
- propagation of the configured frontend connection timeout.

Commands/results:

- focused regressions: pass;
- every focused regression with `-race -count=100`: pass;
- `pkg/logservice` owning-package tests: pass in 134.665s, excluding the
  independently reproduced baseline failure noted below;
- `pkg/frontend` owning-package tests: pass in 16.418s;
- `pkg/logservice` owning-package race tests: pass in 140.629s, with the same
  baseline exclusion;
- `pkg/frontend` owning-package race tests: pass in 25.105s;
- `go build -mod=readonly ./pkg/logservice ./pkg/frontend`: pass;
- `go vet -mod=readonly ./pkg/logservice ./pkg/frontend`: pass; and
- `git diff --check`: pass.

`TestNewServiceClosesStoreOnReplicaStartFailure` is currently a deterministic,
unrelated failure on this environment. On the clean `main` base
`bdbd613fdece966769eb68481a3e58bfbc36b30c`, the exact test failed 10/10 with
the same `service_test.go:171: Expected nil, but got *logservice.Service`
signature. This PR does not touch service construction or that test; it was the
only exclusion from the two package-level `pkg/logservice` runs above.

## Risk

The normal cached path adds only a per-key mutex; refill RPCs are still
single-flight per key. The change intentionally allows independent keys to
allocate concurrently, which HAKeeper already has to support across distinct
clients and CNs. Refill channels are per generation, owned and closed exactly
once by the elected refiller, and no background goroutine or new cleanup owner
is introduced.
