### PR TITLE
ci: temporarily disable local Iceberg E2E

### DIFF
--- a/.github/workflows/iceberg-connector.yml
+++ b/.github/workflows/iceberg-connector.yml
@@ -34,6 +34,8 @@ permissions:
 jobs:
   iceberg-e2e-local:
     name: Iceberg E2E Local
+    # Temporarily disabled while the local Iceberg E2E suite is stabilized.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     continue-on-error: true


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27094

## What this PR does / why we need it:

Temporarily disable the `Iceberg E2E Local` job in the `Iceberg Connector E2E` workflow.

The job in [this CI run](https://github.com/matrixorigin/matrixone/actions/runs/31690611570/job/94416813546?pr=27112) ran for about 45 minutes and was cancelled. The job is already advisory, but it still consumes a runner and repeatedly leaves an uninformative cancelled result while the local Iceberg E2E suite is being stabilized.

The workflow and test command are kept intact; removing the job-level `if: ${{ false }}` condition will re-enable it.

Validation:

- YAML parsed successfully.
- `git diff --check` passed.
