### PR TITLE
ci: warm shared Go module cache for SCA

### DIFF
--- a/.github/workflows/sca-go-module-cache.yaml
+++ b/.github/workflows/sca-go-module-cache.yaml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   warm-go-module-cache:
     name: Warm Go module cache
+    if: github.ref == 'refs/heads/main'
     runs-on: ${{ vars.SCA_RUNNER_LABEL || 'arm64-mo-shanghai-4c8g' }}
     timeout-minutes: 90
     steps:

--- a/.github/workflows/sca-go-module-cache.yaml
+++ b/.github/workflows/sca-go-module-cache.yaml
@@ -41,13 +41,20 @@ jobs:
       - name: Resolve Go module cache metadata
         id: go-module-cache-metadata
         run: |
-          echo "path=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          cache_dir="$GITHUB_WORKSPACE/.sca-go-module-cache"
+          # Self-hosted runner workspaces can outlive a job. Start from only the
+          # trusted cache archive, not files left by a previous PR.
+          GOMODCACHE="$cache_dir" go clean -modcache
+          echo "GOMODCACHE=$cache_dir" >> "$GITHUB_ENV"
           echo "version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
       - name: Restore Go module cache
         id: go-module-cache
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          path: ${{ steps.go-module-cache-metadata.outputs.path }}
+          # A relative path keeps both the hidden cache version and tar entries
+          # identical to the reusable-workflow consumer across runner layouts.
+          path: .sca-go-module-cache
           key: matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
           restore-keys: |
             matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-
@@ -58,5 +65,5 @@ jobs:
         if: steps.go-module-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          path: ${{ steps.go-module-cache-metadata.outputs.path }}
+          path: .sca-go-module-cache
           key: ${{ steps.go-module-cache.outputs.cache-primary-key }}

--- a/.github/workflows/sca-go-module-cache.yaml
+++ b/.github/workflows/sca-go-module-cache.yaml
@@ -1,0 +1,61 @@
+name: Warm SCA Go module cache
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - go.mod
+      - go.sum
+      - .github/workflows/sca-go-module-cache.yaml
+  schedule:
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sca-go-module-cache
+  cancel-in-progress: false
+
+jobs:
+  warm-go-module-cache:
+    name: Warm Go module cache
+    runs-on: ${{ vars.SCA_RUNNER_LABEL || 'arm64-mo-shanghai-4c8g' }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Configure Shanghai Go proxy
+        if: ${{ !vars.SCA_RUNNER_LABEL || contains(vars.SCA_RUNNER_LABEL, 'shanghai') }}
+        run: |
+          echo "GOPROXY=http://goproxy.goproxy.svc.cluster.local|https://goproxy.cn|direct" >> "$GITHUB_ENV"
+      - name: Set up Go
+        uses: matrixorigin/CI/actions/setup-env@main
+        with:
+          cache: false
+          setup-java: false
+          setup-cmake: false
+          go-version-file: "${{ github.workspace }}/go.mod"
+      - name: Resolve Go module cache metadata
+        id: go-module-cache-metadata
+        run: |
+          echo "path=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          echo "version=$(go env GOVERSION)" >> "$GITHUB_OUTPUT"
+      - name: Restore Go module cache
+        id: go-module-cache
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ steps.go-module-cache-metadata.outputs.path }}
+          key: matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: |
+            matrixone-go-mod-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-module-cache-metadata.outputs.version }}-
+      - name: Download Go modules
+        if: steps.go-module-cache.outputs.cache-hit != 'true'
+        run: go mod download
+      - name: Save Go module cache
+        if: steps.go-module-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ steps.go-module-cache-metadata.outputs.path }}
+          key: ${{ steps.go-module-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27076

## What this PR does / why we need it:

Adds a trusted MatrixOne-side producer for the SCA Go module cache consumed by matrixorigin/CI#422.

- runs on trusted main pushes that change go.mod/go.sum, a daily schedule, and workflow_dispatch
- restores an existing compatible main cache before downloading deltas
- downloads all modules with the Shanghai proxy when running on a Shanghai SCA runner
- saves the exact cache key in the MatrixOne default-branch scope
- serializes warm-up runs and skips download/save on an exact hit
- uses the same relative staging path as the consumer so the hidden cache version and tar layout remain portable across runner nodes

The reusable PR workflow remains restore-only because MatrixOne CI is triggered by pull_request_target. Different PRs can therefore share this trusted main cache without being able to poison or overwrite it. The consumer moves the restored cache out of the source tree before license-eye scans source files.

Related: https://github.com/matrixorigin/CI/pull/422

Validation:

- YAML syntax parsed successfully
- actionlint passed
- producer/consumer path, key, and restore prefix match mechanically
- cache cleanup and relocation lifecycle simulated successfully
- git diff --check passed
