### PR TITLE
[4.2] fix(lockservice): exclude uncertain locks from deadlock graph

### DIFF
--- a/pkg/lockservice/lock_table_remote.go
+++ b/pkg/lockservice/lock_table_remote.go
@@ -193,7 +193,7 @@ func (l *remoteLockTable) lock(
 	// The request may have reached the remote owner and acquired locks even if
 	// the response was lost or the client-side context timed out. Keep local
 	// bookkeeping so normal transaction close can send the remote unlock.
-	_ = txn.lockAdded(l.bind.Group, l.bind, rows, l.logger)
+	_ = txn.lockAddedForCleanup(l.bind.Group, l.bind, rows, l.logger)
 	logRemoteLockFailed(l.logger, txn, rows, opts, l.bind, err)
 	if moerr.IsMoErrCode(err, moerr.ErrRemoteLockWaitTimeout) {
 		cb(pb.Result{}, err)

--- a/pkg/lockservice/lock_table_remote_test.go
+++ b/pkg/lockservice/lock_table_remote_test.go
@@ -650,6 +650,7 @@ func TestLockRemoteWithContextTimeoutTracksLockForUnlock(t *testing.T) {
 			holder := txn.getHoldLocksLocked(l.bind.Group)
 			require.Contains(t, holder.tableKeys, l.bind.Table)
 			require.Contains(t, holder.tableBinds, l.bind.Table)
+			require.Contains(t, holder.uncertainLockKeys[l.bind.Table], string([]byte{1}))
 
 			require.NoError(t, txn.close(txnID, timestamp.Timestamp{}, func(uint32, uint64) (lockTable, error) {
 				return l, nil

--- a/pkg/lockservice/service_observability_test.go
+++ b/pkg/lockservice/service_observability_test.go
@@ -91,6 +91,95 @@ func TestGetWaitingList(t *testing.T) {
 	)
 }
 
+func TestRemoteWaitingListRequiresConfirmedHolder(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1", "s2"},
+		func(_ *lockTableAllocator, services []*service) {
+			owner := services[0]
+			source := services[1]
+			tableID := uint64(1)
+			row := []byte{1}
+			holderTxnID := []byte("holder")
+			waiterTxnID := []byte("waiter")
+			options := newTestRowExclusiveOptions()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			_, err := owner.Lock(ctx, tableID, [][]byte{row}, holderTxnID, options)
+			require.NoError(t, err)
+
+			waiterDone := make(chan error, 1)
+			go func() {
+				_, err := source.Lock(ctx, tableID, [][]byte{row}, waiterTxnID, options)
+				waiterDone <- err
+			}()
+			waitWaiters(t, owner, tableID, row, 1)
+
+			released := false
+			defer func() {
+				if released {
+					return
+				}
+				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Second)
+				defer cleanupCancel()
+				_ = owner.Unlock(cleanupCtx, holderTxnID, timestamp.Timestamp{})
+				select {
+				case <-waiterDone:
+				case <-cleanupCtx.Done():
+				}
+			}()
+
+			remoteTable, err := source.getLockTable(ctx, 0, tableID)
+			require.NoError(t, err)
+			require.IsType(t, &remoteLockTable{}, remoteTable)
+
+			// A failed remote response records the requested row locally so
+			// transaction cleanup can conservatively unlock it. That record is
+			// uncertain: the owner still has this transaction in its waiter queue.
+			waiterTxn := source.activeTxnHolder.getActiveTxn(waiterTxnID, false, "")
+			require.NotNil(t, waiterTxn)
+			waiterTxn.Lock()
+			err = waiterTxn.lockAddedForCleanup(
+				remoteTable.getBind().Group,
+				remoteTable.getBind(),
+				[][]byte{row},
+				source.logger,
+			)
+			waiterTxn.Unlock()
+			require.NoError(t, err)
+
+			ok, waiting, err := source.GetWaitingList(ctx, waiterTxnID)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Empty(t, waiting,
+				"an uncertain local lock record must not make a waiter depend on itself")
+
+			var confirmedHolderWaiters []pb.WaitTxn
+			err = remoteTable.getLock(
+				ctx,
+				row,
+				pb.WaitTxn{TxnID: holderTxnID},
+				func(lock Lock) {
+					lock.waiters.iter(func(w *waiter) bool {
+						confirmedHolderWaiters = append(confirmedHolderWaiters, w.txn)
+						return true
+					})
+				},
+			)
+			require.NoError(t, err)
+			require.Len(t, confirmedHolderWaiters, 1)
+			require.Equal(t, waiterTxnID, confirmedHolderWaiters[0].TxnID)
+
+			require.NoError(t, owner.Unlock(ctx, holderTxnID, timestamp.Timestamp{}))
+			released = true
+			require.NoError(t, <-waiterDone)
+			require.NoError(t, source.Unlock(ctx, waiterTxnID, timestamp.Timestamp{}))
+		},
+	)
+}
+
 func TestGetLockHolder(t *testing.T) {
 	runLockServiceTests(
 		t,

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -36,6 +36,10 @@ var (
 type tableLockHolder struct {
 	tableKeys  map[uint64]*cowSlice
 	tableBinds map[uint64]pb.LockTable
+	// uncertainLockKeys contains rows recorded only because a remote Lock
+	// response failed. They remain in tableKeys for conservative cleanup, but
+	// do not prove that this transaction holds the row for deadlock detection.
+	uncertainLockKeys map[uint64]map[string]struct{}
 	// tableBindIntents records bind versions touched before a lock attempt
 	// finishes, so bind-change fencing also covers failed in-flight attempts.
 	tableBindIntents map[uint64]pb.LockTable
@@ -106,6 +110,17 @@ func (txn *activeTxn) lockRemoved(
 	})
 	v.close()
 	h.tableKeys[table] = newV
+	if uncertain := h.uncertainLockKeys[table]; len(uncertain) > 0 {
+		for key := range removedLocks {
+			delete(uncertain, key)
+		}
+		if len(uncertain) == 0 {
+			delete(h.uncertainLockKeys, table)
+			if len(h.uncertainLockKeys) == 0 {
+				h.uncertainLockKeys = nil
+			}
+		}
+	}
 }
 
 func (txn *activeTxn) lockAdded(
@@ -113,6 +128,28 @@ func (txn *activeTxn) lockAdded(
 	bind pb.LockTable,
 	locks [][]byte,
 	logger *log.MOLogger,
+) error {
+	return txn.addLocks(group, bind, locks, logger, true)
+}
+
+// lockAddedForCleanup records locks that a failed remote request may have
+// acquired. The rows must be unlocked when the transaction closes, but cannot
+// be used as confirmed holder edges by deadlock detection.
+func (txn *activeTxn) lockAddedForCleanup(
+	group uint32,
+	bind pb.LockTable,
+	locks [][]byte,
+	logger *log.MOLogger,
+) error {
+	return txn.addLocks(group, bind, locks, logger, false)
+}
+
+func (txn *activeTxn) addLocks(
+	group uint32,
+	bind pb.LockTable,
+	locks [][]byte,
+	logger *log.MOLogger,
+	confirmed bool,
 ) error {
 
 	if txn.beforeLockAdded != nil {
@@ -140,17 +177,80 @@ func (txn *activeTxn) lockAdded(
 	defer logTxnLockAdded(logger, txn, locks)
 	h := txn.getHoldLocksLocked(group)
 	v, ok := h.tableKeys[bind.Table]
-	var err error
+	var existing map[string]struct{}
+	if !confirmed && ok {
+		requested := make(map[string]struct{}, len(locks))
+		for _, key := range locks {
+			requested[string(key)] = struct{}{}
+		}
+		existing = make(map[string]struct{}, len(requested))
+		s := v.slice()
+		s.iter(func(key []byte) bool {
+			value := util.UnsafeBytesToString(key)
+			if _, ok := requested[value]; ok {
+				existing[string(key)] = struct{}{}
+			}
+			return true
+		})
+		s.unref()
+	}
+
 	if ok {
-		return v.append(locks)
+		if err := v.append(locks); err != nil {
+			return err
+		}
+	} else {
+		cs, err := newCowSlice(txn.fsp, locks)
+		if err != nil {
+			return err
+		}
+		h.tableKeys[bind.Table] = cs
+		h.tableBinds[bind.Table] = bind
 	}
-	cs, err := newCowSlice(txn.fsp, locks)
-	if err != nil {
-		return err
+
+	if confirmed {
+		h.markLocksConfirmed(bind.Table, locks)
+	} else {
+		h.markNewLocksUncertain(bind.Table, locks, existing)
 	}
-	h.tableKeys[bind.Table] = cs
-	h.tableBinds[bind.Table] = bind
 	return nil
+}
+
+func (h *tableLockHolder) markLocksConfirmed(table uint64, locks [][]byte) {
+	uncertain := h.uncertainLockKeys[table]
+	if len(uncertain) == 0 {
+		return
+	}
+	for _, key := range locks {
+		delete(uncertain, util.UnsafeBytesToString(key))
+	}
+	if len(uncertain) == 0 {
+		delete(h.uncertainLockKeys, table)
+		if len(h.uncertainLockKeys) == 0 {
+			h.uncertainLockKeys = nil
+		}
+	}
+}
+
+func (h *tableLockHolder) markNewLocksUncertain(
+	table uint64,
+	locks [][]byte,
+	existing map[string]struct{},
+) {
+	for _, key := range locks {
+		if _, ok := existing[util.UnsafeBytesToString(key)]; ok {
+			continue
+		}
+		if h.uncertainLockKeys == nil {
+			h.uncertainLockKeys = make(map[uint64]map[string]struct{})
+		}
+		uncertain := h.uncertainLockKeys[table]
+		if uncertain == nil {
+			uncertain = make(map[string]struct{})
+			h.uncertainLockKeys[table] = uncertain
+		}
+		uncertain[string(key)] = struct{}{}
+	}
 }
 
 func (txn *activeTxn) lockTableBindTouched(bind pb.LockTable) bool {
@@ -364,6 +464,10 @@ func (txn *activeTxn) removeClosedLockTable(
 	}
 	delete(h.tableKeys, table)
 	delete(h.tableBinds, table)
+	delete(h.uncertainLockKeys, table)
+	if len(h.uncertainLockKeys) == 0 {
+		h.uncertainLockKeys = nil
+	}
 	// Keep the intent until the whole transaction closes. It owns the service
 	// drain reference even after this table was successfully released during a
 	// retryable, multi-table cleanup.
@@ -533,11 +637,20 @@ func (txn *activeTxn) fetchWhoWaitingMe(
 	groups := make([]uint32, 0, len(txn.lockHolders))
 	tables := make([]uint64, 0, len(txn.lockHolders))
 	lockKeys := make([]*fixedSlice, 0, len(txn.lockHolders))
+	uncertainLockKeys := make([]map[string]struct{}, 0, len(txn.lockHolders))
 	for g, m := range txn.lockHolders {
 		for table, cs := range m.tableKeys {
 			tables = append(tables, table)
 			lockKeys = append(lockKeys, cs.slice())
 			groups = append(groups, g)
+			var uncertainCopy map[string]struct{}
+			if uncertain := m.uncertainLockKeys[table]; len(uncertain) > 0 {
+				uncertainCopy = make(map[string]struct{}, len(uncertain))
+				for key := range uncertain {
+					uncertainCopy[key] = struct{}{}
+				}
+			}
+			uncertainLockKeys = append(uncertainLockKeys, uncertainCopy)
 		}
 	}
 
@@ -575,6 +688,9 @@ func (txn *activeTxn) fetchWhoWaitingMe(
 			if err := ctx.Err(); err != nil {
 				fetchErr = err
 				return false
+			}
+			if _, ok := uncertainLockKeys[idx][util.UnsafeBytesToString(lockKey)]; ok {
+				return true
 			}
 			if err := l.getLock(
 				ctx,

--- a/pkg/lockservice/txn_test.go
+++ b/pkg/lockservice/txn_test.go
@@ -110,6 +110,42 @@ func TestLockAdded(t *testing.T) {
 	})
 }
 
+func TestCleanupOnlyLockStateTransitions(t *testing.T) {
+	reuse.RunReuseTests(func() {
+		id := []byte("t1")
+		bind := pb.LockTable{Group: 0, Table: 1}
+		logger := getLogger("")
+		txn := newActiveTxn(id, string(id), newFixedSlicePool(8), "")
+		defer reuse.Free(txn, nil)
+
+		key1 := []byte("k1")
+		key2 := []byte("k2")
+		require.NoError(t, txn.lockAddedForCleanup(
+			bind.Group, bind, [][]byte{key1}, logger))
+
+		holder := txn.getHoldLocksLocked(bind.Group)
+		require.Contains(t, holder.tableKeys, bind.Table,
+			"cleanup-only locks must remain available to transaction close")
+		require.Contains(t, holder.uncertainLockKeys[bind.Table], string(key1))
+
+		// A successful retry promotes the row to a confirmed holder.
+		require.NoError(t, txn.lockAdded(
+			bind.Group, bind, [][]byte{key1}, logger))
+		require.Nil(t, holder.uncertainLockKeys)
+
+		// A later failed retry must not downgrade a row already confirmed held.
+		require.NoError(t, txn.lockAddedForCleanup(
+			bind.Group, bind, [][]byte{key1, key2}, logger))
+		require.NotContains(t, holder.uncertainLockKeys[bind.Table], string(key1))
+		require.Contains(t, holder.uncertainLockKeys[bind.Table], string(key2))
+
+		txn.lockRemoved(bind.Group, bind.Table, map[string]struct{}{
+			string(key2): {},
+		})
+		require.Nil(t, holder.uncertainLockKeys)
+	})
+}
+
 func TestLockAddedThatShouldFail(t *testing.T) {
 	reuse.RunReuseTests(func() {
 		id := []byte("t1")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27124.

Backport of #26925, which fixes #26922.

## What this PR does / why we need it:

### Root cause

When a remote Lock response is lost, canceled, or times out, the source CN must retain the requested rows so transaction close can conservatively send Unlock. In 4.2-dev those cleanup records are stored in `activeTxn.tableKeys`, and distributed deadlock detection also treats every entry in that collection as proof that the transaction holds the row.

If the request is still waiting on the owner, the owner returns that same transaction as a waiter and the polluted wait-for graph produces a false `T <= T` self-cycle. This exact sequence is present in #27124: a failed remote lock with `context canceled` is followed by a self-cycle and user-visible `20701`.

### Fix

- Keep uncertain rows in `tableKeys` so conservative remote cleanup remains unchanged.
- Track cleanup-only rows in a sparse per-table set and exclude them from `fetchWhoWaitingMe`.
- Promote an uncertain row after a successful Lock result.
- Never downgrade an already confirmed row after a later uncertain retry.
- Remove sparse state on lock removal, table cleanup, transaction close, and object reuse.

This does not suppress genuine multi-transaction deadlocks. It removes only deadlock edges that are not backed by a confirmed lock. Normal successful Lock calls do not allocate the sparse state.

### Validation

- `TestRemoteWaitingListRequiresConfirmedHolder`: passed; race `-count=100` passed.
- `TestCleanupOnlyLockStateTransitions`: passed; race `-count=100` passed.
- `TestLockRemoteWithContextTimeoutTracksLockForUnlock`: passed; race `-count=100` passed.
- `go build ./pkg/lockservice`: passed.
- `go vet ./pkg/lockservice`: passed.
- `go test ./pkg/lockservice`: passed.
- `go test -race ./pkg/lockservice`: passed.

Cherry-picked from `e88f5e4a706f28590f6dd69076cd38981eceaaa9`.