### PR TITLE
fix: enforce named snapshot object scope

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -1860,6 +1860,11 @@ func getRelations(
 		)
 		return
 	}
+	if err = validateDataBranchNamedSnapshotScope(
+		ctx, tarName.AtTsExpr, tarSnap, tarDBName, tarTblName, tarRel,
+	); err != nil {
+		return
+	}
 
 	if baseDB, err = eng.Database(ctx, baseDBName, txnOpB); err != nil {
 		logutil.Error(
@@ -1883,6 +1888,11 @@ func getRelations(
 		)
 		return
 	}
+	if err = validateDataBranchNamedSnapshotScope(
+		ctx, baseName.AtTsExpr, baseSnap, baseDBName, baseTblName, baseRel,
+	); err != nil {
+		return
+	}
 
 	logutil.Info(
 		"DataBranch-GetRelations-Done",
@@ -1893,6 +1903,23 @@ func getRelations(
 	)
 
 	return
+}
+
+func validateDataBranchNamedSnapshotScope(
+	ctx context.Context,
+	atTsExpr *tree.AtTimeStamp,
+	snapshot *plan2.Snapshot,
+	databaseName string,
+	tableName string,
+	relation engine.Relation,
+) error {
+	if atTsExpr == nil || atTsExpr.Type != tree.ATTIMESTAMPSNAPSHOT {
+		return nil
+	}
+	tableDef := relation.GetTableDef(ctx)
+	return plan2.ValidateSnapshotScope(
+		snapshot, databaseName, tableName, tableDef.DbId, plan2.SnapshotTableID(tableDef),
+	)
 }
 
 func constructChangeHandle(

--- a/pkg/frontend/data_branch_helpers_test.go
+++ b/pkg/frontend/data_branch_helpers_test.go
@@ -28,6 +28,9 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,6 +67,54 @@ func TestDataBranchSQLKeyEqual(t *testing.T) {
 		require.Equal(t, "serial(left_key) = serial(right_key)",
 			dataBranchSQLKeyEqual("left_key", "right_key", typ),
 		)
+	}
+}
+
+func TestValidateDataBranchNamedSnapshotScope(t *testing.T) {
+	ctx := context.Background()
+	snapshot := &plan2.Snapshot{ExtraInfo: &planpb.SnapshotExtraInfo{
+		Name:  "snapshot",
+		Level: tree.SNAPSHOTLEVELTABLE.String(),
+		ObjId: 7,
+	}}
+	namedSnapshot := &tree.AtTimeStamp{Type: tree.ATTIMESTAMPSNAPSHOT}
+
+	t.Run("unnamed source does not require a relation", func(t *testing.T) {
+		require.NoError(t, validateDataBranchNamedSnapshotScope(
+			ctx, nil, snapshot, "db", "table", nil,
+		))
+	})
+
+	tests := []struct {
+		name     string
+		tableDef *planpb.TableDef
+		err      string
+	}{
+		{
+			name:     "matches logical table identity",
+			tableDef: &planpb.TableDef{DbId: 1, TblId: 8, LogicalId: 7},
+		},
+		{
+			name:     "rejects another table",
+			tableDef: &planpb.TableDef{DbId: 1, TblId: 8, LogicalId: 9},
+			err:      "internal error: table-level snapshot(snapshot) does not belong to the table(db-table)",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			relation := mock_frontend.NewMockRelation(ctrl)
+			relation.EXPECT().GetTableDef(ctx).Return(test.tableDef)
+
+			err := validateDataBranchNamedSnapshotScope(
+				ctx, namedSnapshot, snapshot, "db", "table", relation,
+			)
+			if test.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, test.err)
+		})
 	}
 }
 

--- a/pkg/frontend/data_branch_privilege.go
+++ b/pkg/frontend/data_branch_privilege.go
@@ -483,6 +483,16 @@ func requireBranchReadOnTableName(
 	if err != nil {
 		return stats, err
 	}
+	if normalized.AtTsExpr != nil && normalized.AtTsExpr.Type == tree.ATTIMESTAMPSNAPSHOT {
+		snapshot, err := resolveSnapshot(ses, normalized.AtTsExpr)
+		if err != nil {
+			return stats, err
+		}
+		// Keep the historical relation used by the existing privilege probe, but
+		// avoid applying query scope validation to this synthetic statement. The
+		// DATA BRANCH endpoint validates the named snapshot against its relation.
+		normalized.AtTsExpr = newMoTimestampHint(snapshot.TS.PhysicalTime)
+	}
 	stmt := branchSelectForTableName(normalized)
 	p, err := buildPlan(ctx, ses, ses.GetTxnCompileCtx(), stmt)
 	if err != nil {

--- a/pkg/frontend/show_recovery_window.go
+++ b/pkg/frontend/show_recovery_window.go
@@ -419,8 +419,8 @@ func searchTables(
 		}
 
 		searchSQL = fmt.Sprintf(
-			"select reldatabase, relname from `%s`.`%s` {SNAPSHOT = '%s'} where %s",
-			catalog.MO_CATALOG, catalog.MO_TABLES, snap.snapshotName,
+			"select reldatabase, relname from `%s`.`%s` {MO_TS = %d} where %s",
+			catalog.MO_CATALOG, catalog.MO_TABLES, snap.ts,
 			searchCondA+searchCondB+searchCondC,
 		)
 

--- a/pkg/frontend/show_recovery_window_test.go
+++ b/pkg/frontend/show_recovery_window_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/stretchr/testify/require"
+)
+
+type recoveryWindowExecRecorder struct {
+	backgroundExecTest
+}
+
+func (recorder *recoveryWindowExecRecorder) Exec(ctx context.Context, sql string) error {
+	recorder.sql2result[sql] = newMrsForShowTables(nil)
+	return recorder.backgroundExecTest.Exec(ctx, sql)
+}
+
+func TestSearchTablesReadsCatalogAtSnapshotTimestamp(t *testing.T) {
+	ses := newValidateSession(t)
+	ses.SetTenantInfo(&TenantInfo{Tenant: "tenant"})
+
+	bh := &recoveryWindowExecRecorder{}
+	bh.init()
+	tableToSnaps, tableToPitrs, err := searchTables(
+		context.Background(), ses, bh, tree.RECOVERYWINDOWLEVELDATABASE,
+		"tenant", "db", "", nil,
+		[]tableRecoveryWindowForSnapshot{{
+			snapshotName: "snapshot",
+			level:        tree.SNAPSHOTLEVELDATABASE.String(),
+			ts:           42,
+			databaseName: "db",
+		}},
+		1,
+	)
+	require.NoError(t, err)
+	require.Empty(t, tableToSnaps)
+	require.Empty(t, tableToPitrs)
+	require.Len(t, bh.executedSQLs, 1)
+	require.Contains(t, bh.executedSQLs[0], "`mo_catalog`.`mo_tables` {MO_TS = 42}")
+	require.NotContains(t, bh.executedSQLs[0], "SNAPSHOT =")
+}

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -908,6 +908,9 @@ func checkRestorePriv(ctx context.Context, ses *Session, snapshot *snapshotRecor
 		if string(stmt.AccountName) != ses.GetTenantInfo().GetTenant() {
 			return moerr.NewInternalError(ctx, "can't restore table from other account's snapshot")
 		}
+		if snapshot.level == tree.RESTORELEVELDATABASE.String() && snapshot.databaseName != string(stmt.DatabaseName) {
+			return moerr.NewInternalErrorf(ctx, "databaseName(%v) does not match snapshot.databaseName(%v)", string(stmt.DatabaseName), snapshot.databaseName)
+		}
 		if snapshot.level == tree.RESTORELEVELTABLE.String() {
 			if snapshot.databaseName != string(stmt.DatabaseName) || snapshot.tableName != string(stmt.TableName) {
 				return moerr.NewInternalErrorf(ctx, "tableName(%v) does not match snapshot.tableName(%v)", string(stmt.TableName), snapshot.tableName)
@@ -1188,7 +1191,7 @@ func restoreToDatabaseOrTable(
 
 	var createDbSql string
 	var isSubDb bool
-	createDbSql, err = getCreateDatabaseSql(ctx, sid, bh, snapshotName, dbName, restoreAccount)
+	createDbSql, err = getCreateDatabaseSql(ctx, sid, bh, snapshotName, snapshotTs, dbName, restoreAccount)
 	if err != nil {
 		return
 	}
@@ -2225,12 +2228,13 @@ func getCreateDatabaseSql(ctx context.Context,
 	sid string,
 	bh BackgroundExec,
 	snapshotName string,
+	snapshotTs int64,
 	dbName string,
 	accountId uint32) (string, error) {
 
 	sql := "select datname, dat_createsql from mo_catalog.mo_database"
-	if len(snapshotName) > 0 {
-		sql += fmt.Sprintf(" {snapshot = '%s'}", snapshotName)
+	if snapshotTs > 0 {
+		sql += fmt.Sprintf(" {MO_TS = %d}", snapshotTs)
 	}
 	sql += fmt.Sprintf(" where datname = '%s' and account_id = %d", dbName, accountId)
 	getLogger(sid).Debug(fmt.Sprintf("[%s] get create database `%s` sql: %s", snapshotName, dbName, sql))

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -213,6 +213,30 @@ func TestHistoricalRestoreTopoSortUsesSchemaWhenCatalogRowsAreMissing(t *testing
 	})
 }
 
+func TestCheckRestorePrivEnforcesDatabaseSnapshotScope(t *testing.T) {
+	ctx := context.Background()
+	ses := &Session{feSessionImpl: feSessionImpl{
+		tenant: &TenantInfo{Tenant: "tenant"},
+	}}
+	snapshot := &snapshotRecord{
+		level:        tree.SNAPSHOTLEVELDATABASE.String(),
+		accountName:  "tenant",
+		databaseName: "source_db",
+	}
+	stmt := &tree.RestoreSnapShot{
+		Level:        tree.RESTORELEVELTABLE,
+		AccountName:  "tenant",
+		DatabaseName: "source_db",
+		TableName:    "table",
+	}
+
+	require.NoError(t, checkRestorePriv(ctx, ses, snapshot, stmt))
+
+	stmt.DatabaseName = "other_db"
+	err := checkRestorePriv(ctx, ses, snapshot, stmt)
+	require.EqualError(t, err, "internal error: databaseName(other_db) does not match snapshot.databaseName(source_db)")
+}
+
 func TestCollectRestoreSourceTableInfos(t *testing.T) {
 	t.Run("database restore reads only the selected table", func(t *testing.T) {
 		var listed bool

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -311,7 +311,7 @@ func TestRestoreExternalTableSnapshotAndFromTS(t *testing.T) {
 			snapshotTs   = int64(100)
 		)
 
-		bh.sql2result[fmt.Sprintf("select datname, dat_createsql from mo_catalog.mo_database {snapshot = '%s'} where datname = '%s' and account_id = 0", snapshotName, dbName)] =
+		bh.sql2result[fmt.Sprintf("select datname, dat_createsql from mo_catalog.mo_database {MO_TS = %d} where datname = '%s' and account_id = 0", snapshotTs, dbName)] =
 			newMrsForRestoreStringRows([]string{"datname", "dat_createsql"}, [][]interface{}{{dbName, "create database db1"}})
 		bh.sql2result[fmt.Sprintf(checkDatabaseIsMasterFormat, quoteSQLStringLiteral(dbName), quoteSQLStringLiteral(dbName))] = newMrsForRestoreStringRows([]string{"db_name"}, nil)
 		bh.sql2result[fmt.Sprintf(getPubInfoSql, uint32(sysAccountID))+" and database_name = 'db1'"] = newMrsForRestoreStringRows([]string{"account_id"}, nil)
@@ -343,7 +343,7 @@ func TestRestoreExternalTableSnapshotAndFromTS(t *testing.T) {
 			snapshotTs   = int64(100)
 		)
 
-		bh.sql2result[fmt.Sprintf("select datname, dat_createsql from mo_catalog.mo_database {snapshot = '%s'} where datname = '%s' and account_id = 0", snapshotName, dbName)] =
+		bh.sql2result[fmt.Sprintf("select datname, dat_createsql from mo_catalog.mo_database {MO_TS = %d} where datname = '%s' and account_id = 0", snapshotTs, dbName)] =
 			newMrsForRestoreStringRows([]string{"datname", "dat_createsql"}, [][]interface{}{{dbName, "create database db1"}})
 		bh.sql2result[buildTableInfoListSQL(dbName, tblName, snapshotTs, uint32(sysAccountID))] =
 			newMrsForRestoreStringRows([]string{"relname", "table_type", "relkind", "viewdef"}, [][]interface{}{{tblName, "BASE TABLE", catalog.SystemExternalRel}})

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -49,17 +49,21 @@ func buildShowCreateDatabase(stmt *tree.ShowCreateDatabase,
 		if snapshot, err = getTimeStampByTsHint(ctx, stmt.AtTsExpr); err != nil {
 			return nil, err
 		}
-
-		if stmt.AtTsExpr.Type == tree.ATTIMESTAMPSNAPSHOT {
-			snapshotSpec = fmt.Sprintf("{snapshot = '%s'}", stmt.AtTsExpr.SnapshotName)
-		} else {
-			snapshotSpec = fmt.Sprintf("{MO_TS = %d}", snapshot.TS.PhysicalTime)
-		}
+		snapshotSpec = showSnapshotSpec(stmt.AtTsExpr, snapshot)
 	}
 
 	name, err := databaseIsValid(getSuitableDBName("", stmt.Name), ctx, snapshot)
 	if err != nil {
 		return nil, err
+	}
+	if snapshot != nil && snapshot.ExtraInfo != nil {
+		databaseID, err := ctx.GetDatabaseId(name, snapshot)
+		if err != nil {
+			return nil, err
+		}
+		if err = ValidateSnapshotDatabaseScope(snapshot, name, databaseID); err != nil {
+			return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
+		}
 	}
 
 	if sub, err := ctx.GetSubscriptionMeta(name, snapshot); err != nil {
@@ -119,6 +123,9 @@ func buildShowCreateTable(stmt *tree.ShowCreateTable, ctx CompilerContext) (*Pla
 	}
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), dbName, tblName)
+	}
+	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, tableDef.TblId); err != nil {
+		return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
 	}
 	if tableDef.TableType == catalog.SystemViewRel {
 		var newStmt *tree.ShowCreateView
@@ -188,6 +195,9 @@ func buildShowCreateView(stmt *tree.ShowCreateView, ctx CompilerContext) (*Plan,
 	if tableDef == nil || tableDef.TableType != catalog.SystemViewRel {
 		return nil, moerr.NewInvalidInputf(ctx.GetContext(), "show view '%s' is not a valid view", tblName)
 	}
+	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, tableDef.TblId); err != nil {
+		return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
+	}
 	sqlStr := "select \"%s\" as `View`, \"%s\" as `Create View`, 'utf8mb4' as `character_set_client`, 'utf8mb4_general_ci' as `collation_connection`"
 	var viewStr string
 	if tableDef.TableType == catalog.SystemViewRel {
@@ -228,19 +238,28 @@ func buildShowDatabases(stmt *tree.ShowDatabases, ctx CompilerContext) (*Plan, e
 		if snapshot, err = getTimeStampByTsHint(ctx, stmt.AtTsExpr); err != nil {
 			return nil, err
 		}
-
 		if stmt.AtTsExpr.Type == tree.ATTIMESTAMPSNAPSHOT {
 			accountId = snapshot.Tenant.TenantID
-			snapshotSpec = fmt.Sprintf("{snapshot = '%s'}", stmt.AtTsExpr.SnapshotName)
-		} else {
-			snapshotSpec = fmt.Sprintf("{MO_TS = %d}", snapshot.TS.PhysicalTime)
+		}
+		snapshotSpec = showSnapshotSpec(stmt.AtTsExpr, snapshot)
+		if snapshot.ExtraInfo != nil {
+			switch snapshot.ExtraInfo.Level {
+			case tree.SNAPSHOTLEVELDATABASE.String():
+				snapshotSpec = fmt.Sprintf("{MO_TS = %d}", snapshot.TS.PhysicalTime)
+			case tree.SNAPSHOTLEVELTABLE.String():
+				return nil, moerr.NewInternalErrorf(ctx.GetContext(), "table-level snapshot(%s) cannot list databases", snapshot.ExtraInfo.Name)
+			}
 		}
 
 	}
 
 	// Any account should show database MO_CATALOG_DB_NAME
 	accountClause := fmt.Sprintf("account_id = %v or (account_id = 0 and datname = '%s')", accountId, MO_CATALOG_DB_NAME)
-	sql = fmt.Sprintf("SELECT datname `Database` FROM %s.mo_database %s WHERE (%s) ORDER BY %s", MO_CATALOG_DB_NAME, snapshotSpec, accountClause, catalog.SystemDBAttr_Name)
+	sql = fmt.Sprintf("SELECT datname `Database` FROM %s.mo_database %s WHERE (%s)", MO_CATALOG_DB_NAME, snapshotSpec, accountClause)
+	if snapshot != nil && snapshot.ExtraInfo != nil && snapshot.ExtraInfo.Level == tree.SNAPSHOTLEVELDATABASE.String() {
+		sql += fmt.Sprintf(" and dat_id = %d", snapshot.ExtraInfo.ObjId)
+	}
+	sql += fmt.Sprintf(" ORDER BY %s", catalog.SystemDBAttr_Name)
 
 	if stmt.Where != nil {
 		return returnByWhereAndBaseSQL(ctx, sql, stmt.Where, ddlType)
@@ -295,19 +314,25 @@ func buildShowTables(stmt *tree.ShowTables, ctx CompilerContext) (*Plan, error) 
 		if snapshot, err = getTimeStampByTsHint(ctx, stmt.AtTsExpr); err != nil {
 			return nil, err
 		}
-
 		if stmt.AtTsExpr.Type == tree.ATTIMESTAMPSNAPSHOT {
 			accountId = snapshot.Tenant.TenantID
-			snapshotSpec = fmt.Sprintf("{snapshot = '%s'}", stmt.AtTsExpr.SnapshotName)
-		} else {
-			snapshotSpec = fmt.Sprintf("{MO_TS = %d}", snapshot.TS.PhysicalTime)
 		}
+		snapshotSpec = showSnapshotSpec(stmt.AtTsExpr, snapshot)
 
 	}
 
 	dbName, err := databaseIsValid(stmt.DBName, ctx, snapshot)
 	if err != nil {
 		return nil, err
+	}
+	if snapshot != nil && snapshot.ExtraInfo != nil {
+		databaseID, err := ctx.GetDatabaseId(dbName, snapshot)
+		if err != nil {
+			return nil, err
+		}
+		if err = ValidateSnapshotDatabaseScope(snapshot, dbName, databaseID); err != nil {
+			return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
+		}
 	}
 
 	var tableType string
@@ -1122,6 +1147,14 @@ func returnByRewriteSQL(ctx CompilerContext, sql string,
 	}
 	defer newStmt.Free()
 	return getReturnDdlBySelectStmt(ctx, newStmt, ddlType)
+}
+
+func showSnapshotSpec(atTsExpr *tree.AtTimeStamp, snapshot *Snapshot) string {
+	if atTsExpr.Type == tree.ATTIMESTAMPSNAPSHOT &&
+		(snapshot.ExtraInfo == nil || snapshot.ExtraInfo.Level != tree.SNAPSHOTLEVELDATABASE.String()) {
+		return fmt.Sprintf("{snapshot = '%s'}", atTsExpr.SnapshotName)
+	}
+	return fmt.Sprintf("{MO_TS = %d}", snapshot.TS.PhysicalTime)
 }
 
 func returnByWhereAndBaseSQL(ctx CompilerContext, baseSQL string,

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -124,7 +124,7 @@ func buildShowCreateTable(stmt *tree.ShowCreateTable, ctx CompilerContext) (*Pla
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), dbName, tblName)
 	}
-	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, tableDef.TblId); err != nil {
+	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, SnapshotTableID(tableDef)); err != nil {
 		return nil, err
 	}
 	if tableDef.TableType == catalog.SystemViewRel {
@@ -195,7 +195,7 @@ func buildShowCreateView(stmt *tree.ShowCreateView, ctx CompilerContext) (*Plan,
 	if tableDef == nil || tableDef.TableType != catalog.SystemViewRel {
 		return nil, moerr.NewInvalidInputf(ctx.GetContext(), "show view '%s' is not a valid view", tblName)
 	}
-	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, tableDef.TblId); err != nil {
+	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, SnapshotTableID(tableDef)); err != nil {
 		return nil, err
 	}
 	sqlStr := "select \"%s\" as `View`, \"%s\" as `Create View`, 'utf8mb4' as `character_set_client`, 'utf8mb4_general_ci' as `collation_connection`"

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -62,7 +62,7 @@ func buildShowCreateDatabase(stmt *tree.ShowCreateDatabase,
 			return nil, err
 		}
 		if err = ValidateSnapshotDatabaseScope(snapshot, name, databaseID); err != nil {
-			return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
+			return nil, err
 		}
 	}
 
@@ -125,7 +125,7 @@ func buildShowCreateTable(stmt *tree.ShowCreateTable, ctx CompilerContext) (*Pla
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), dbName, tblName)
 	}
 	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, tableDef.TblId); err != nil {
-		return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
+		return nil, err
 	}
 	if tableDef.TableType == catalog.SystemViewRel {
 		var newStmt *tree.ShowCreateView
@@ -196,7 +196,7 @@ func buildShowCreateView(stmt *tree.ShowCreateView, ctx CompilerContext) (*Plan,
 		return nil, moerr.NewInvalidInputf(ctx.GetContext(), "show view '%s' is not a valid view", tblName)
 	}
 	if err = ValidateSnapshotScope(snapshot, dbName, tblName, tableDef.DbId, tableDef.TblId); err != nil {
-		return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
+		return nil, err
 	}
 	sqlStr := "select \"%s\" as `View`, \"%s\" as `Create View`, 'utf8mb4' as `character_set_client`, 'utf8mb4_general_ci' as `collation_connection`"
 	var viewStr string
@@ -331,7 +331,7 @@ func buildShowTables(stmt *tree.ShowTables, ctx CompilerContext) (*Plan, error) 
 			return nil, err
 		}
 		if err = ValidateSnapshotDatabaseScope(snapshot, dbName, databaseID); err != nil {
-			return nil, moerr.NewInternalError(ctx.GetContext(), err.Error())
+			return nil, err
 		}
 	}
 

--- a/pkg/sql/plan/build_table_clone.go
+++ b/pkg/sql/plan/build_table_clone.go
@@ -201,7 +201,7 @@ func checkPrivilege(
 				srcTblDef.DbName,
 				srcTblDef.Name,
 				srcTblDef.DbId,
-				srcTblDef.TblId,
+				SnapshotTableID(srcTblDef),
 			); err != nil {
 				snapshotErr = err
 			}
@@ -214,7 +214,7 @@ func checkPrivilege(
 				srcTblDef.DbName,
 				srcTblDef.Name,
 				srcTblDef.DbId,
-				srcTblDef.TblId,
+				SnapshotTableID(srcTblDef),
 			); err != nil {
 				snapshotErr = err
 			}

--- a/pkg/sql/plan/build_table_clone.go
+++ b/pkg/sql/plan/build_table_clone.go
@@ -181,7 +181,6 @@ func checkPrivilege(
 	scanSnapshot *Snapshot,
 	cloneType tree.CloneStmtType,
 ) (err error) {
-
 	var (
 		misMsg string
 
@@ -203,23 +202,29 @@ func checkPrivilege(
 			if cloneType == tree.CloneCluster || cloneType == tree.CloneAccount {
 				snapshotMisMatch = true
 				misMsg = "cannot use a database-level snapshot to clone cluster/account"
-			} else if scanSnapshot.ExtraInfo.ObjId != uint64(srcTblDef.DbId) {
+			} else if err := ValidateSnapshotScope(
+				scanSnapshot,
+				srcTblDef.DbName,
+				srcTblDef.Name,
+				srcTblDef.DbId,
+				srcTblDef.TblId,
+			); err != nil {
 				snapshotMisMatch = true
-				misMsg = fmt.Sprintf(
-					"database-level snapshot(%s) does not belong to the database(%s)",
-					scanSnapshot.ExtraInfo.Name, srcTblDef.DbName,
-				)
+				misMsg = err.Error()
 			}
 		case tree.SNAPSHOTLEVELTABLE.String():
 			if cloneType == tree.CloneCluster || cloneType == tree.CloneAccount ||
 				cloneType == tree.WithinAccCloneDB || cloneType == tree.BetweenAccCloneDB {
 				snapshotMisMatch = true
 				misMsg = "cannot use a table-level snapshot to clone cluster/account/database"
-			} else if scanSnapshot.ExtraInfo.ObjId != uint64(srcTblDef.TblId) {
-				misMsg = fmt.Sprintf(
-					"table-level snapshot(%s) does not belong to the table(%s-%s)",
-					scanSnapshot.ExtraInfo.Name, srcTblDef.DbName, srcTblDef.Name,
-				)
+			} else if err := ValidateSnapshotScope(
+				scanSnapshot,
+				srcTblDef.DbName,
+				srcTblDef.Name,
+				srcTblDef.DbId,
+				srcTblDef.TblId,
+			); err != nil {
+				misMsg = err.Error()
 				snapshotMisMatch = true
 			}
 		}

--- a/pkg/sql/plan/build_table_clone.go
+++ b/pkg/sql/plan/build_table_clone.go
@@ -181,27 +181,21 @@ func checkPrivilege(
 	scanSnapshot *Snapshot,
 	cloneType tree.CloneStmtType,
 ) (err error) {
-	var (
-		misMsg string
-
-		snapshotMisMatch = false
-	)
+	var snapshotErr error
 
 	if scanSnapshot != nil && scanSnapshot.ExtraInfo != nil {
 		switch scanSnapshot.ExtraInfo.Level {
 		case tree.SNAPSHOTLEVELCLUSTER.String():
 		case tree.SNAPSHOTLEVELACCOUNT.String():
 			if scanSnapshot.ExtraInfo.ObjId != uint64(srcAccount) {
-				misMsg = fmt.Sprintf(
+				snapshotErr = moerr.NewInternalErrorNoCtxf(
 					"account-level snapshot(%s) does not belong to the account(%d)",
 					scanSnapshot.ExtraInfo.Name, srcAccount,
 				)
-				snapshotMisMatch = true
 			}
 		case tree.SNAPSHOTLEVELDATABASE.String():
 			if cloneType == tree.CloneCluster || cloneType == tree.CloneAccount {
-				snapshotMisMatch = true
-				misMsg = "cannot use a database-level snapshot to clone cluster/account"
+				snapshotErr = moerr.NewInternalErrorNoCtx("cannot use a database-level snapshot to clone cluster/account")
 			} else if err := ValidateSnapshotScope(
 				scanSnapshot,
 				srcTblDef.DbName,
@@ -209,14 +203,12 @@ func checkPrivilege(
 				srcTblDef.DbId,
 				srcTblDef.TblId,
 			); err != nil {
-				snapshotMisMatch = true
-				misMsg = err.Error()
+				snapshotErr = err
 			}
 		case tree.SNAPSHOTLEVELTABLE.String():
 			if cloneType == tree.CloneCluster || cloneType == tree.CloneAccount ||
 				cloneType == tree.WithinAccCloneDB || cloneType == tree.BetweenAccCloneDB {
-				snapshotMisMatch = true
-				misMsg = "cannot use a table-level snapshot to clone cluster/account/database"
+				snapshotErr = moerr.NewInternalErrorNoCtx("cannot use a table-level snapshot to clone cluster/account/database")
 			} else if err := ValidateSnapshotScope(
 				scanSnapshot,
 				srcTblDef.DbName,
@@ -224,13 +216,12 @@ func checkPrivilege(
 				srcTblDef.DbId,
 				srcTblDef.TblId,
 			); err != nil {
-				misMsg = err.Error()
-				snapshotMisMatch = true
+				snapshotErr = err
 			}
 		}
 	}
 
-	if snapshotMisMatch {
+	if snapshotErr != nil {
 		logutil.Error(
 			"SNAPSHOT-MISMATCH",
 			zap.String("snapshot",
@@ -246,7 +237,7 @@ func checkPrivilege(
 					srcTblDef.TblId)),
 		)
 
-		return moerr.NewInternalErrorNoCtx(misMsg)
+		return snapshotErr
 	}
 
 	// 1. only sys can clone from system databases

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -10090,6 +10090,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, t
 			}
 		}
 
+		explicitNamedSnapshot := false
 		if tbl.AtTsExpr != nil {
 			if tbl.IcebergRef != nil {
 				return 0, moerr.NewInvalidInput(builder.GetContext(), "cannot combine MO snapshot hint with FOR ICEBERG time travel")
@@ -10103,6 +10104,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, t
 			if err != nil {
 				return 0, err
 			}
+			explicitNamedSnapshot = tbl.AtTsExpr.Type == tree.ATTIMESTAMPSNAPSHOT
 		}
 
 		var snapshot *Snapshot
@@ -10144,6 +10146,12 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, t
 		}
 		if tableDef == nil {
 			return 0, moerr.NewNoSuchTablef(builder.GetContext(), "SQL parser error: table %q does not exist", table)
+		}
+		if explicitNamedSnapshot {
+			err = ValidateSnapshotScope(snapshot, schema, table, tableDef.DbId, tableDef.TblId)
+		}
+		if err != nil {
+			return 0, moerr.NewInternalError(builder.GetContext(), err.Error())
 		}
 
 		tableDef.Name2ColIndex = map[string]int32{}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -10148,7 +10148,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, t
 			return 0, moerr.NewNoSuchTablef(builder.GetContext(), "SQL parser error: table %q does not exist", table)
 		}
 		if explicitNamedSnapshot {
-			err = ValidateSnapshotScope(snapshot, schema, table, tableDef.DbId, tableDef.TblId)
+			err = ValidateSnapshotScope(snapshot, schema, table, tableDef.DbId, SnapshotTableID(tableDef))
 		}
 		if err != nil {
 			return 0, err

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -10151,7 +10151,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext, t
 			err = ValidateSnapshotScope(snapshot, schema, table, tableDef.DbId, tableDef.TblId)
 		}
 		if err != nil {
-			return 0, moerr.NewInternalError(builder.GetContext(), err.Error())
+			return 0, err
 		}
 
 		tableDef.Name2ColIndex = map[string]int32{}

--- a/pkg/sql/plan/query_builder_test.go
+++ b/pkg/sql/plan/query_builder_test.go
@@ -419,6 +419,39 @@ func TestBuildTable_AlterView(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBuildTableRejectsOutOfScopeSnapshot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := NewMockCompilerContext2(ctrl)
+	snapshot := &Snapshot{ExtraInfo: &plan.SnapshotExtraInfo{
+		Name: "snapshot", Level: tree.SNAPSHOTLEVELTABLE.String(), ObjId: 1,
+	}}
+	ctx.EXPECT().ResolveVariable(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+	ctx.EXPECT().GetLowerCaseTableNames().Return(int64(1))
+	ctx.EXPECT().GetSnapshot().Return(nil)
+	ctx.EXPECT().ResolveSnapshotWithSnapshotName("snapshot").Return(snapshot, nil)
+	ctx.EXPECT().DatabaseExists("db", snapshot).Return(true)
+	ctx.EXPECT().GetSubscriptionMeta("db", snapshot).Return(nil, nil)
+	ctx.EXPECT().Resolve("db", "other_table", snapshot).Return(
+		&plan.ObjectRef{SchemaName: "db", ObjName: "other_table"},
+		&plan.TableDef{DbId: 1, TblId: 2},
+		nil,
+	)
+	ctx.EXPECT().GetContext().Return(context.Background()).AnyTimes()
+
+	builder := NewQueryBuilder(plan.Query_SELECT, ctx, false, false)
+	bindCtx := NewBindContext(builder, nil)
+	bindCtx.snapshot = snapshot
+	table := &tree.TableName{}
+	table.SchemaName = "db"
+	table.ObjectName = "other_table"
+	table.AtTsExpr = &tree.AtTimeStamp{
+		Type: tree.ATTIMESTAMPSNAPSHOT,
+		Expr: tree.NewNumVal("snapshot", "snapshot", false, tree.P_char),
+	}
+	_, err := builder.buildTable(table, bindCtx, nil)
+	require.EqualError(t, err, "internal error: table-level snapshot(snapshot) does not belong to the table(db-other_table)")
+}
+
 func TestBindViewUsesStoredSQLModeForPipesAsConcat(t *testing.T) {
 	sqlMode := "PIPES_AS_CONCAT"
 	builder, nodeID := buildViewForSQLModeTest(t, "v_pipe", ViewData{

--- a/pkg/sql/plan/snapshot_scope_test.go
+++ b/pkg/sql/plan/snapshot_scope_test.go
@@ -18,11 +18,38 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
+
+type namedSnapshotCompilerContext struct {
+	*MockCompilerContext
+	snapshot *Snapshot
+}
+
+func (c *namedSnapshotCompilerContext) ResolveSnapshotWithSnapshotName(string) (*Snapshot, error) {
+	return c.snapshot, nil
+}
+
+func snapshotScopeExprContainsObjectID(expr *planpb.Expr, objectID uint64) bool {
+	literal := expr.GetLit()
+	if literal != nil && (literal.GetI64Val() == int64(objectID) || literal.GetU64Val() == objectID) {
+		return true
+	}
+	if function := expr.GetF(); function != nil {
+		for _, argument := range function.Args {
+			if snapshotScopeExprContainsObjectID(argument, objectID) {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 func TestValidateSnapshotScope(t *testing.T) {
 	newSnapshot := func(level string, objectID uint64) *Snapshot {
@@ -101,6 +128,62 @@ func TestSnapshotTableID(t *testing.T) {
 	require.Zero(t, SnapshotTableID(nil))
 	require.Equal(t, uint64(2), SnapshotTableID(&planpb.TableDef{TblId: 2}))
 	require.Equal(t, uint64(3), SnapshotTableID(&planpb.TableDef{TblId: 2, LogicalId: 3}))
+}
+
+func TestBuildShowDatabasesRejectsTableSnapshot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := NewMockCompilerContext2(ctrl)
+	snapshot := &Snapshot{
+		TS:     &timestamp.Timestamp{PhysicalTime: 42},
+		Tenant: &planpb.SnapshotTenant{},
+		ExtraInfo: &planpb.SnapshotExtraInfo{
+			Name:  "snapshot",
+			Level: tree.SNAPSHOTLEVELTABLE.String(),
+			ObjId: 7,
+		},
+	}
+	ctx.EXPECT().GetAccountId().Return(uint32(0), nil)
+	ctx.EXPECT().GetSnapshot().Return(nil)
+	ctx.EXPECT().ResolveSnapshotWithSnapshotName("snapshot").Return(snapshot, nil)
+	ctx.EXPECT().GetContext().Return(context.Background()).AnyTimes()
+	ctx.EXPECT().ResolveVariable(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
+	_, err := buildShowDatabases(&tree.ShowDatabases{AtTsExpr: &tree.AtTimeStamp{
+		Type:         tree.ATTIMESTAMPSNAPSHOT,
+		SnapshotName: "snapshot",
+		Expr:         tree.NewNumVal("snapshot", "snapshot", false, tree.P_char),
+	}}, ctx)
+	require.EqualError(t, err, "internal error: table-level snapshot(snapshot) cannot list databases")
+}
+
+func TestBuildShowDatabasesRestrictsDatabaseSnapshot(t *testing.T) {
+	ctx := &namedSnapshotCompilerContext{
+		MockCompilerContext: NewMockCompilerContext(true),
+		snapshot: &Snapshot{
+			TS:     &timestamp.Timestamp{PhysicalTime: 42},
+			Tenant: &planpb.SnapshotTenant{},
+			ExtraInfo: &planpb.SnapshotExtraInfo{
+				Name:  "snapshot",
+				Level: tree.SNAPSHOTLEVELDATABASE.String(),
+				ObjId: 7,
+			},
+		},
+	}
+	ctx.tables["mo_database"].Cols = append(ctx.tables["mo_database"].Cols, &planpb.ColDef{
+		Name: "dat_id",
+		Typ:  planpb.Type{Id: int32(types.T_uint64)},
+	})
+
+	plan, err := buildShowDatabases(&tree.ShowDatabases{AtTsExpr: &tree.AtTimeStamp{
+		Type:         tree.ATTIMESTAMPSNAPSHOT,
+		SnapshotName: "snapshot",
+		Expr:         tree.NewNumVal("snapshot", "snapshot", false, tree.P_char),
+	}}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.True(t, queryContainsExpr(plan.GetQuery(), func(expr *planpb.Expr) bool {
+		return snapshotScopeExprContainsObjectID(expr, 7)
+	}))
 }
 
 func TestCheckPrivilegeUsesSnapshotLogicalTableID(t *testing.T) {

--- a/pkg/sql/plan/snapshot_scope_test.go
+++ b/pkg/sql/plan/snapshot_scope_test.go
@@ -95,3 +95,9 @@ func TestValidateSnapshotDatabaseScope(t *testing.T) {
 		})
 	}
 }
+
+func TestSnapshotTableID(t *testing.T) {
+	require.Zero(t, SnapshotTableID(nil))
+	require.Equal(t, uint64(2), SnapshotTableID(&planpb.TableDef{TblId: 2}))
+	require.Equal(t, uint64(3), SnapshotTableID(&planpb.TableDef{TblId: 2, LogicalId: 3}))
+}

--- a/pkg/sql/plan/snapshot_scope_test.go
+++ b/pkg/sql/plan/snapshot_scope_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+)
+
+func TestValidateSnapshotScope(t *testing.T) {
+	newSnapshot := func(level string, objectID uint64) *Snapshot {
+		return &Snapshot{ExtraInfo: &planpb.SnapshotExtraInfo{
+			Name:  "snapshot",
+			Level: level,
+			ObjId: objectID,
+		}}
+	}
+
+	tests := []struct {
+		name       string
+		snapshot   *Snapshot
+		databaseID uint64
+		tableID    uint64
+		err        string
+	}{
+		{name: "timestamp snapshot", databaseID: 1, tableID: 2},
+		{name: "cluster snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELCLUSTER.String(), 0), databaseID: 1, tableID: 2},
+		{name: "account snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELACCOUNT.String(), 1), databaseID: 1, tableID: 2},
+		{name: "database snapshot same database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 1), databaseID: 1, tableID: 3},
+		{name: "database snapshot other database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 1), databaseID: 2, tableID: 3, err: "database-level snapshot(snapshot) does not belong to the database(db)"},
+		{name: "table snapshot same table", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), databaseID: 1, tableID: 2},
+		{name: "table snapshot other table", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), databaseID: 1, tableID: 3, err: "table-level snapshot(snapshot) does not belong to the table(db-table)"},
+		{name: "unknown snapshot level", snapshot: newSnapshot("unknown", 1), databaseID: 1, tableID: 2, err: "unsupported snapshot level \"unknown\""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateSnapshotScope(test.snapshot, "db", "table", test.databaseID, test.tableID)
+			if test.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, test.err)
+		})
+	}
+}
+
+func TestValidateSnapshotDatabaseScope(t *testing.T) {
+	newSnapshot := func(level string, objectID uint64) *Snapshot {
+		return &Snapshot{ExtraInfo: &planpb.SnapshotExtraInfo{
+			Name:  "snapshot",
+			Level: level,
+			ObjId: objectID,
+		}}
+	}
+
+	tests := []struct {
+		name     string
+		snapshot *Snapshot
+		err      string
+	}{
+		{name: "timestamp snapshot"},
+		{name: "cluster snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELCLUSTER.String(), 0)},
+		{name: "account snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELACCOUNT.String(), 1)},
+		{name: "database snapshot same database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 1)},
+		{name: "database snapshot other database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 2), err: "database-level snapshot(snapshot) does not belong to the database(db)"},
+		{name: "table snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), err: "table-level snapshot(snapshot) cannot read database-wide metadata for database(db)"},
+		{name: "unknown snapshot level", snapshot: newSnapshot("unknown", 1), err: "unsupported snapshot level \"unknown\""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateSnapshotDatabaseScope(test.snapshot, "db", 1)
+			if test.err == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, test.err)
+		})
+	}
+}

--- a/pkg/sql/plan/snapshot_scope_test.go
+++ b/pkg/sql/plan/snapshot_scope_test.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -100,4 +101,32 @@ func TestSnapshotTableID(t *testing.T) {
 	require.Zero(t, SnapshotTableID(nil))
 	require.Equal(t, uint64(2), SnapshotTableID(&planpb.TableDef{TblId: 2}))
 	require.Equal(t, uint64(3), SnapshotTableID(&planpb.TableDef{TblId: 2, LogicalId: 3}))
+}
+
+func TestCheckPrivilegeUsesSnapshotLogicalTableID(t *testing.T) {
+	ctx := context.WithValue(
+		context.Background(), tree.CloneLevelCtxKey{}, tree.RestoreCloneLevelTable,
+	)
+	tableDef := &planpb.TableDef{
+		DbName:    "db",
+		Name:      "table",
+		DbId:      1,
+		TblId:     8,
+		LogicalId: 7,
+	}
+
+	newSnapshot := func(objectID uint64) *Snapshot {
+		return &Snapshot{ExtraInfo: &planpb.SnapshotExtraInfo{
+			Name:  "snapshot",
+			Level: tree.SNAPSHOTLEVELTABLE.String(),
+			ObjId: objectID,
+		}}
+	}
+
+	require.NoError(t, checkPrivilege(
+		ctx, 1, 1, nil, tableDef, "db", newSnapshot(7), tree.WithinDBCloneTable,
+	))
+	require.EqualError(t, checkPrivilege(
+		ctx, 1, 1, nil, tableDef, "db", newSnapshot(8), tree.WithinDBCloneTable,
+	), "internal error: table-level snapshot(snapshot) does not belong to the table(db-table)")
 }

--- a/pkg/sql/plan/snapshot_scope_test.go
+++ b/pkg/sql/plan/snapshot_scope_test.go
@@ -43,10 +43,10 @@ func TestValidateSnapshotScope(t *testing.T) {
 		{name: "cluster snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELCLUSTER.String(), 0), databaseID: 1, tableID: 2},
 		{name: "account snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELACCOUNT.String(), 1), databaseID: 1, tableID: 2},
 		{name: "database snapshot same database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 1), databaseID: 1, tableID: 3},
-		{name: "database snapshot other database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 1), databaseID: 2, tableID: 3, err: "database-level snapshot(snapshot) does not belong to the database(db)"},
+		{name: "database snapshot other database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 1), databaseID: 2, tableID: 3, err: "internal error: database-level snapshot(snapshot) does not belong to the database(db)"},
 		{name: "table snapshot same table", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), databaseID: 1, tableID: 2},
-		{name: "table snapshot other table", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), databaseID: 1, tableID: 3, err: "table-level snapshot(snapshot) does not belong to the table(db-table)"},
-		{name: "unknown snapshot level", snapshot: newSnapshot("unknown", 1), databaseID: 1, tableID: 2, err: "unsupported snapshot level \"unknown\""},
+		{name: "table snapshot other table", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), databaseID: 1, tableID: 3, err: "internal error: table-level snapshot(snapshot) does not belong to the table(db-table)"},
+		{name: "unknown snapshot level", snapshot: newSnapshot("unknown", 1), databaseID: 1, tableID: 2, err: "internal error: unsupported snapshot level \"unknown\""},
 	}
 
 	for _, test := range tests {
@@ -79,9 +79,9 @@ func TestValidateSnapshotDatabaseScope(t *testing.T) {
 		{name: "cluster snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELCLUSTER.String(), 0)},
 		{name: "account snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELACCOUNT.String(), 1)},
 		{name: "database snapshot same database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 1)},
-		{name: "database snapshot other database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 2), err: "database-level snapshot(snapshot) does not belong to the database(db)"},
-		{name: "table snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), err: "table-level snapshot(snapshot) cannot read database-wide metadata for database(db)"},
-		{name: "unknown snapshot level", snapshot: newSnapshot("unknown", 1), err: "unsupported snapshot level \"unknown\""},
+		{name: "database snapshot other database", snapshot: newSnapshot(tree.SNAPSHOTLEVELDATABASE.String(), 2), err: "internal error: database-level snapshot(snapshot) does not belong to the database(db)"},
+		{name: "table snapshot", snapshot: newSnapshot(tree.SNAPSHOTLEVELTABLE.String(), 2), err: "internal error: table-level snapshot(snapshot) cannot read database-wide metadata for database(db)"},
+		{name: "unknown snapshot level", snapshot: newSnapshot("unknown", 1), err: "internal error: unsupported snapshot level \"unknown\""},
 	}
 
 	for _, test := range tests {

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -161,7 +161,7 @@ func ValidateSnapshotScope(
 		return nil
 	case tree.SNAPSHOTLEVELDATABASE.String():
 		if snapshot.ExtraInfo.ObjId != databaseID {
-			return fmt.Errorf(
+			return moerr.NewInternalErrorNoCtxf(
 				"database-level snapshot(%s) does not belong to the database(%s)",
 				snapshot.ExtraInfo.Name,
 				databaseName,
@@ -169,7 +169,7 @@ func ValidateSnapshotScope(
 		}
 	case tree.SNAPSHOTLEVELTABLE.String():
 		if snapshot.ExtraInfo.ObjId != tableID {
-			return fmt.Errorf(
+			return moerr.NewInternalErrorNoCtxf(
 				"table-level snapshot(%s) does not belong to the table(%s-%s)",
 				snapshot.ExtraInfo.Name,
 				databaseName,
@@ -177,7 +177,7 @@ func ValidateSnapshotScope(
 			)
 		}
 	default:
-		return fmt.Errorf("unsupported snapshot level %q", snapshot.ExtraInfo.Level)
+		return moerr.NewInternalErrorNoCtxf("unsupported snapshot level %q", snapshot.ExtraInfo.Level)
 	}
 
 	return nil
@@ -200,20 +200,20 @@ func ValidateSnapshotDatabaseScope(
 		return nil
 	case tree.SNAPSHOTLEVELDATABASE.String():
 		if snapshot.ExtraInfo.ObjId != databaseID {
-			return fmt.Errorf(
+			return moerr.NewInternalErrorNoCtxf(
 				"database-level snapshot(%s) does not belong to the database(%s)",
 				snapshot.ExtraInfo.Name,
 				databaseName,
 			)
 		}
 	case tree.SNAPSHOTLEVELTABLE.String():
-		return fmt.Errorf(
+		return moerr.NewInternalErrorNoCtxf(
 			"table-level snapshot(%s) cannot read database-wide metadata for database(%s)",
 			snapshot.ExtraInfo.Name,
 			databaseName,
 		)
 	default:
-		return fmt.Errorf("unsupported snapshot level %q", snapshot.ExtraInfo.Level)
+		return moerr.NewInternalErrorNoCtxf("unsupported snapshot level %q", snapshot.ExtraInfo.Level)
 	}
 
 	return nil

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -143,6 +143,82 @@ func ParseViewDependencyKey(viewKey string) (string, string, *Snapshot, error) {
 	return string(databaseName), string(viewName), snapshot, nil
 }
 
+// ValidateSnapshotScope verifies that a relation belongs to the object covered
+// by a named snapshot. Timestamp-only snapshots have no object restriction.
+func ValidateSnapshotScope(
+	snapshot *Snapshot,
+	databaseName string,
+	tableName string,
+	databaseID uint64,
+	tableID uint64,
+) error {
+	if snapshot == nil || snapshot.ExtraInfo == nil {
+		return nil
+	}
+
+	switch snapshot.ExtraInfo.Level {
+	case tree.SNAPSHOTLEVELCLUSTER.String(), tree.SNAPSHOTLEVELACCOUNT.String():
+		return nil
+	case tree.SNAPSHOTLEVELDATABASE.String():
+		if snapshot.ExtraInfo.ObjId != databaseID {
+			return fmt.Errorf(
+				"database-level snapshot(%s) does not belong to the database(%s)",
+				snapshot.ExtraInfo.Name,
+				databaseName,
+			)
+		}
+	case tree.SNAPSHOTLEVELTABLE.String():
+		if snapshot.ExtraInfo.ObjId != tableID {
+			return fmt.Errorf(
+				"table-level snapshot(%s) does not belong to the table(%s-%s)",
+				snapshot.ExtraInfo.Name,
+				databaseName,
+				tableName,
+			)
+		}
+	default:
+		return fmt.Errorf("unsupported snapshot level %q", snapshot.ExtraInfo.Level)
+	}
+
+	return nil
+}
+
+// ValidateSnapshotDatabaseScope verifies that an operation scoped to a
+// database is compatible with a named snapshot. A table snapshot cannot read
+// database-wide metadata because it represents a single relation.
+func ValidateSnapshotDatabaseScope(
+	snapshot *Snapshot,
+	databaseName string,
+	databaseID uint64,
+) error {
+	if snapshot == nil || snapshot.ExtraInfo == nil {
+		return nil
+	}
+
+	switch snapshot.ExtraInfo.Level {
+	case tree.SNAPSHOTLEVELCLUSTER.String(), tree.SNAPSHOTLEVELACCOUNT.String():
+		return nil
+	case tree.SNAPSHOTLEVELDATABASE.String():
+		if snapshot.ExtraInfo.ObjId != databaseID {
+			return fmt.Errorf(
+				"database-level snapshot(%s) does not belong to the database(%s)",
+				snapshot.ExtraInfo.Name,
+				databaseName,
+			)
+		}
+	case tree.SNAPSHOTLEVELTABLE.String():
+		return fmt.Errorf(
+			"table-level snapshot(%s) cannot read database-wide metadata for database(%s)",
+			snapshot.ExtraInfo.Name,
+			databaseName,
+		)
+	default:
+		return fmt.Errorf("unsupported snapshot level %q", snapshot.ExtraInfo.Level)
+	}
+
+	return nil
+}
+
 type CompilerContext interface {
 	// Default database/schema in context
 	DefaultDatabase() string

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -183,6 +183,18 @@ func ValidateSnapshotScope(
 	return nil
 }
 
+// SnapshotTableID returns the stable identity used by table snapshots. A
+// copy-table ALTER replaces the physical table while preserving LogicalId.
+func SnapshotTableID(tableDef *TableDef) uint64 {
+	if tableDef == nil {
+		return 0
+	}
+	if tableDef.LogicalId != 0 {
+		return tableDef.LogicalId
+	}
+	return tableDef.TblId
+}
+
 // ValidateSnapshotDatabaseScope verifies that an operation scoped to a
 // database is compatible with a named snapshot. A table snapshot cannot read
 // database-wide metadata because it represents a single relation.

--- a/pkg/tests/issues/issue_26120_test.go
+++ b/pkg/tests/issues/issue_26120_test.go
@@ -89,10 +89,14 @@ func TestIssue26120SnapshotBranchKeepsHistoricalParentIdentity(t *testing.T) {
 
 func relationIDAtSnapshot(t *testing.T, ctx context.Context, db *sql.DB, databaseName, tableName, snapshotName string) uint64 {
 	t.Helper()
+	var snapshotTS int64
+	require.NoError(t, db.QueryRowContext(ctx,
+		"select ts from mo_catalog.mo_snapshots where sname = ?", snapshotName).Scan(&snapshotTS))
+
 	var id uint64
 	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
-		"select rel_id from mo_catalog.mo_tables {snapshot='%s'} where account_id = 0 and reldatabase = '%s' and relname = '%s'",
-		snapshotName, databaseName, tableName)).Scan(&id))
+		"select rel_id from mo_catalog.mo_tables {MO_TS = %d} where account_id = 0 and reldatabase = '%s' and relname = '%s'",
+		snapshotTS, databaseName, tableName)).Scan(&id))
 	return id
 }
 

--- a/test/distributed/cases/snapshot/snapshot_scope.result
+++ b/test/distributed/cases/snapshot/snapshot_scope.result
@@ -1,0 +1,85 @@
+drop snapshot if exists snapshot_scope_table;
+drop snapshot if exists snapshot_scope_database;
+drop database if exists snapshot_scope_a;
+drop database if exists snapshot_scope_b;
+create database snapshot_scope_a;
+create database snapshot_scope_b;
+create table snapshot_scope_a.t (id int primary key, v varchar(16));
+create table snapshot_scope_a.other (id int primary key, v varchar(16));
+create table snapshot_scope_b.t (id int primary key, v varchar(16));
+insert into snapshot_scope_a.t values (1, 'a_before');
+insert into snapshot_scope_a.other values (1, 'other_before');
+insert into snapshot_scope_b.t values (1, 'b_before');
+create snapshot snapshot_scope_table for table snapshot_scope_a t;
+create snapshot snapshot_scope_database for database snapshot_scope_a;
+update snapshot_scope_a.t set v = 'a_after';
+update snapshot_scope_a.other set v = 'other_after';
+update snapshot_scope_b.t set v = 'b_after';
+select 'table_snapshot_control' as case_name, v from snapshot_scope_a.t{snapshot = 'snapshot_scope_table'};
+➤ case_name[12,16,0]  ¦  v[12,12,0]  𝄀
+table_snapshot_control  ¦  a_before
+select 'table_snapshot_same_database_other_table' as case_name, v from snapshot_scope_a.other{snapshot = 'snapshot_scope_table'};
+internal error: table-level snapshot(snapshot_scope_table) does not belong to the table(snapshot_scope_a-other)
+select 'table_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_table'};
+internal error: table-level snapshot(snapshot_scope_table) does not belong to the table(snapshot_scope_b-t)
+select 'database_snapshot_table_control' as case_name, v from snapshot_scope_a.t{snapshot = 'snapshot_scope_database'};
+➤ case_name[12,23,0]  ¦  v[12,12,0]  𝄀
+database_snapshot_table_control  ¦  a_before
+select 'database_snapshot_other_table_control' as case_name, v from snapshot_scope_a.other{snapshot = 'snapshot_scope_database'};
+➤ case_name[12,27,0]  ¦  v[12,12,0]  𝄀
+database_snapshot_other_table_control  ¦  other_before
+select 'database_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_database'};
+internal error: database-level snapshot(snapshot_scope_database) does not belong to the database(snapshot_scope_b)
+show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_table'};
+➤ Table[12,0,0]  ¦  Create Table[12,70,0]  𝄀
+t  ¦  CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `v` varchar(16) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+)
+show create table snapshot_scope_a.other {snapshot = 'snapshot_scope_table'};
+internal error: table-level snapshot(snapshot_scope_table) does not belong to the table(snapshot_scope_a-other)
+show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_database'};
+➤ Table[12,0,0]  ¦  Create Table[12,70,0]  𝄀
+t  ¦  CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `v` varchar(16) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+)
+show create table snapshot_scope_b.t {snapshot = 'snapshot_scope_database'};
+internal error: database-level snapshot(snapshot_scope_database) does not belong to the database(snapshot_scope_b)
+show tables from snapshot_scope_a {snapshot = 'snapshot_scope_database'};
+➤ Tables_in_snapshot_scope_a[12,3750,0]  𝄀
+other  𝄀
+t
+show tables from snapshot_scope_a {snapshot = 'snapshot_scope_table'};
+internal error: table-level snapshot(snapshot_scope_table) cannot read database-wide metadata for database(snapshot_scope_a)
+show databases {snapshot = 'snapshot_scope_database'};
+➤ Database[12,3750,0]  𝄀
+snapshot_scope_a
+show databases {snapshot = 'snapshot_scope_table'};
+internal error: table-level snapshot(snapshot_scope_table) cannot list databases
+show create database snapshot_scope_a {snapshot = 'snapshot_scope_database'};
+➤ Database[12,12,0]  ¦  Create Database[12,25,0]  𝄀
+snapshot_scope_a  ¦  CREATE DATABASE `snapshot_scope_a`
+show create database snapshot_scope_b {snapshot = 'snapshot_scope_database'};
+internal error: database-level snapshot(snapshot_scope_database) does not belong to the database(snapshot_scope_b)
+show create database snapshot_scope_a {snapshot = 'snapshot_scope_table'};
+internal error: table-level snapshot(snapshot_scope_table) cannot read database-wide metadata for database(snapshot_scope_a)
+restore table snapshot_scope_a.t{snapshot = 'snapshot_scope_database'};
+select 'database_snapshot_restore_same_database' as case_name, v from snapshot_scope_a.t;
+➤ case_name[12,29,0]  ¦  v[12,12,0]  𝄀
+database_snapshot_restore_same_database  ¦  a_before
+restore table snapshot_scope_b.t{snapshot = 'snapshot_scope_database'};
+internal error: databaseName(snapshot_scope_b) does not match snapshot.databaseName(snapshot_scope_a)
+select 'database_snapshot_cross_database_restore_unchanged' as case_name, v from snapshot_scope_b.t;
+➤ case_name[12,37,0]  ¦  v[12,12,0]  𝄀
+database_snapshot_cross_database_restore_unchanged  ¦  b_after
+restore table snapshot_scope_a.t{snapshot = 'snapshot_scope_table'};
+select 'table_snapshot_restore_control' as case_name, v from snapshot_scope_a.t;
+➤ case_name[12,22,0]  ¦  v[12,12,0]  𝄀
+table_snapshot_restore_control  ¦  a_before
+drop snapshot snapshot_scope_table;
+drop snapshot snapshot_scope_database;
+drop database snapshot_scope_a;
+drop database snapshot_scope_b;

--- a/test/distributed/cases/snapshot/snapshot_scope.result
+++ b/test/distributed/cases/snapshot/snapshot_scope.result
@@ -1,4 +1,5 @@
 drop snapshot if exists snapshot_scope_table;
+drop snapshot if exists snapshot_scope_table_altered;
 drop snapshot if exists snapshot_scope_database;
 drop database if exists snapshot_scope_a;
 drop database if exists snapshot_scope_b;
@@ -6,18 +7,26 @@ create database snapshot_scope_a;
 create database snapshot_scope_b;
 create table snapshot_scope_a.t (id int primary key, v varchar(16));
 create table snapshot_scope_a.other (id int primary key, v varchar(16));
+create table snapshot_scope_a.altered (id int primary key, v varchar(16));
 create table snapshot_scope_b.t (id int primary key, v varchar(16));
 insert into snapshot_scope_a.t values (1, 'a_before');
 insert into snapshot_scope_a.other values (1, 'other_before');
+insert into snapshot_scope_a.altered values (1, 'alter_before');
 insert into snapshot_scope_b.t values (1, 'b_before');
 create snapshot snapshot_scope_table for table snapshot_scope_a t;
+create snapshot snapshot_scope_table_altered for table snapshot_scope_a altered;
 create snapshot snapshot_scope_database for database snapshot_scope_a;
+alter table snapshot_scope_a.altered add column version int default 0;
 update snapshot_scope_a.t set v = 'a_after';
 update snapshot_scope_a.other set v = 'other_after';
+update snapshot_scope_a.altered set v = 'alter_after';
 update snapshot_scope_b.t set v = 'b_after';
 select 'table_snapshot_control' as case_name, v from snapshot_scope_a.t{snapshot = 'snapshot_scope_table'};
 ➤ case_name[12,16,0]  ¦  v[12,12,0]  𝄀
 table_snapshot_control  ¦  a_before
+select 'table_snapshot_copy_alter_control' as case_name, v from snapshot_scope_a.altered{snapshot = 'snapshot_scope_table_altered'};
+➤ case_name[12,24,0]  ¦  v[12,12,0]  𝄀
+table_snapshot_copy_alter_control  ¦  alter_before
 select 'table_snapshot_same_database_other_table' as case_name, v from snapshot_scope_a.other{snapshot = 'snapshot_scope_table'};
 internal error: table-level snapshot(snapshot_scope_table) does not belong to the table(snapshot_scope_a-other)
 select 'table_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_table'};
@@ -30,6 +39,8 @@ select 'database_snapshot_other_table_control' as case_name, v from snapshot_sco
 database_snapshot_other_table_control  ¦  other_before
 select 'database_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_database'};
 internal error: database-level snapshot(snapshot_scope_database) does not belong to the database(snapshot_scope_b)
+data branch diff snapshot_scope_a.other{snapshot = 'snapshot_scope_table'} against snapshot_scope_a.t;
+internal error: table-level snapshot(snapshot_scope_table) does not belong to the table(snapshot_scope_a-other)
 show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_table'};
 ➤ Table[12,0,0]  ¦  Create Table[12,70,0]  𝄀
 t  ¦  CREATE TABLE `t` (
@@ -50,6 +61,7 @@ show create table snapshot_scope_b.t {snapshot = 'snapshot_scope_database'};
 internal error: database-level snapshot(snapshot_scope_database) does not belong to the database(snapshot_scope_b)
 show tables from snapshot_scope_a {snapshot = 'snapshot_scope_database'};
 ➤ Tables_in_snapshot_scope_a[12,3750,0]  𝄀
+altered  𝄀
 other  𝄀
 t
 show tables from snapshot_scope_a {snapshot = 'snapshot_scope_table'};
@@ -80,6 +92,7 @@ select 'table_snapshot_restore_control' as case_name, v from snapshot_scope_a.t;
 ➤ case_name[12,22,0]  ¦  v[12,12,0]  𝄀
 table_snapshot_restore_control  ¦  a_before
 drop snapshot snapshot_scope_table;
+drop snapshot snapshot_scope_table_altered;
 drop snapshot snapshot_scope_database;
 drop database snapshot_scope_a;
 drop database snapshot_scope_b;

--- a/test/distributed/cases/snapshot/snapshot_scope.result
+++ b/test/distributed/cases/snapshot/snapshot_scope.result
@@ -41,6 +41,8 @@ select 'database_snapshot_other_database' as case_name, v from snapshot_scope_b.
 internal error: database-level snapshot(snapshot_scope_database) does not belong to the database(snapshot_scope_b)
 data branch diff snapshot_scope_a.other{snapshot = 'snapshot_scope_table'} against snapshot_scope_a.t;
 internal error: table-level snapshot(snapshot_scope_table) does not belong to the table(snapshot_scope_a-other)
+data branch diff snapshot_scope_a.t against snapshot_scope_a.other{snapshot = 'snapshot_scope_table'};
+internal error: table-level snapshot(snapshot_scope_table) does not belong to the table(snapshot_scope_a-other)
 show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_table'};
 ➤ Table[12,0,0]  ¦  Create Table[12,70,0]  𝄀
 t  ¦  CREATE TABLE `t` (

--- a/test/distributed/cases/snapshot/snapshot_scope.sql
+++ b/test/distributed/cases/snapshot/snapshot_scope.sql
@@ -34,6 +34,7 @@ select 'database_snapshot_other_table_control' as case_name, v from snapshot_sco
 select 'database_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_database'};
 
 data branch diff snapshot_scope_a.other{snapshot = 'snapshot_scope_table'} against snapshot_scope_a.t;
+data branch diff snapshot_scope_a.t against snapshot_scope_a.other{snapshot = 'snapshot_scope_table'};
 
 show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_table'};
 show create table snapshot_scope_a.other {snapshot = 'snapshot_scope_table'};

--- a/test/distributed/cases/snapshot/snapshot_scope.sql
+++ b/test/distributed/cases/snapshot/snapshot_scope.sql
@@ -1,4 +1,5 @@
 drop snapshot if exists snapshot_scope_table;
+drop snapshot if exists snapshot_scope_table_altered;
 drop snapshot if exists snapshot_scope_database;
 drop database if exists snapshot_scope_a;
 drop database if exists snapshot_scope_b;
@@ -7,24 +8,32 @@ create database snapshot_scope_a;
 create database snapshot_scope_b;
 create table snapshot_scope_a.t (id int primary key, v varchar(16));
 create table snapshot_scope_a.other (id int primary key, v varchar(16));
+create table snapshot_scope_a.altered (id int primary key, v varchar(16));
 create table snapshot_scope_b.t (id int primary key, v varchar(16));
 insert into snapshot_scope_a.t values (1, 'a_before');
 insert into snapshot_scope_a.other values (1, 'other_before');
+insert into snapshot_scope_a.altered values (1, 'alter_before');
 insert into snapshot_scope_b.t values (1, 'b_before');
 
 create snapshot snapshot_scope_table for table snapshot_scope_a t;
+create snapshot snapshot_scope_table_altered for table snapshot_scope_a altered;
 create snapshot snapshot_scope_database for database snapshot_scope_a;
+alter table snapshot_scope_a.altered add column version int default 0;
 update snapshot_scope_a.t set v = 'a_after';
 update snapshot_scope_a.other set v = 'other_after';
+update snapshot_scope_a.altered set v = 'alter_after';
 update snapshot_scope_b.t set v = 'b_after';
 
 select 'table_snapshot_control' as case_name, v from snapshot_scope_a.t{snapshot = 'snapshot_scope_table'};
+select 'table_snapshot_copy_alter_control' as case_name, v from snapshot_scope_a.altered{snapshot = 'snapshot_scope_table_altered'};
 select 'table_snapshot_same_database_other_table' as case_name, v from snapshot_scope_a.other{snapshot = 'snapshot_scope_table'};
 select 'table_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_table'};
 
 select 'database_snapshot_table_control' as case_name, v from snapshot_scope_a.t{snapshot = 'snapshot_scope_database'};
 select 'database_snapshot_other_table_control' as case_name, v from snapshot_scope_a.other{snapshot = 'snapshot_scope_database'};
 select 'database_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_database'};
+
+data branch diff snapshot_scope_a.other{snapshot = 'snapshot_scope_table'} against snapshot_scope_a.t;
 
 show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_table'};
 show create table snapshot_scope_a.other {snapshot = 'snapshot_scope_table'};
@@ -46,6 +55,7 @@ restore table snapshot_scope_a.t{snapshot = 'snapshot_scope_table'};
 select 'table_snapshot_restore_control' as case_name, v from snapshot_scope_a.t;
 
 drop snapshot snapshot_scope_table;
+drop snapshot snapshot_scope_table_altered;
 drop snapshot snapshot_scope_database;
 drop database snapshot_scope_a;
 drop database snapshot_scope_b;

--- a/test/distributed/cases/snapshot/snapshot_scope.sql
+++ b/test/distributed/cases/snapshot/snapshot_scope.sql
@@ -1,0 +1,51 @@
+drop snapshot if exists snapshot_scope_table;
+drop snapshot if exists snapshot_scope_database;
+drop database if exists snapshot_scope_a;
+drop database if exists snapshot_scope_b;
+
+create database snapshot_scope_a;
+create database snapshot_scope_b;
+create table snapshot_scope_a.t (id int primary key, v varchar(16));
+create table snapshot_scope_a.other (id int primary key, v varchar(16));
+create table snapshot_scope_b.t (id int primary key, v varchar(16));
+insert into snapshot_scope_a.t values (1, 'a_before');
+insert into snapshot_scope_a.other values (1, 'other_before');
+insert into snapshot_scope_b.t values (1, 'b_before');
+
+create snapshot snapshot_scope_table for table snapshot_scope_a t;
+create snapshot snapshot_scope_database for database snapshot_scope_a;
+update snapshot_scope_a.t set v = 'a_after';
+update snapshot_scope_a.other set v = 'other_after';
+update snapshot_scope_b.t set v = 'b_after';
+
+select 'table_snapshot_control' as case_name, v from snapshot_scope_a.t{snapshot = 'snapshot_scope_table'};
+select 'table_snapshot_same_database_other_table' as case_name, v from snapshot_scope_a.other{snapshot = 'snapshot_scope_table'};
+select 'table_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_table'};
+
+select 'database_snapshot_table_control' as case_name, v from snapshot_scope_a.t{snapshot = 'snapshot_scope_database'};
+select 'database_snapshot_other_table_control' as case_name, v from snapshot_scope_a.other{snapshot = 'snapshot_scope_database'};
+select 'database_snapshot_other_database' as case_name, v from snapshot_scope_b.t{snapshot = 'snapshot_scope_database'};
+
+show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_table'};
+show create table snapshot_scope_a.other {snapshot = 'snapshot_scope_table'};
+show create table snapshot_scope_a.t {snapshot = 'snapshot_scope_database'};
+show create table snapshot_scope_b.t {snapshot = 'snapshot_scope_database'};
+show tables from snapshot_scope_a {snapshot = 'snapshot_scope_database'};
+show tables from snapshot_scope_a {snapshot = 'snapshot_scope_table'};
+show databases {snapshot = 'snapshot_scope_database'};
+show databases {snapshot = 'snapshot_scope_table'};
+show create database snapshot_scope_a {snapshot = 'snapshot_scope_database'};
+show create database snapshot_scope_b {snapshot = 'snapshot_scope_database'};
+show create database snapshot_scope_a {snapshot = 'snapshot_scope_table'};
+
+restore table snapshot_scope_a.t{snapshot = 'snapshot_scope_database'};
+select 'database_snapshot_restore_same_database' as case_name, v from snapshot_scope_a.t;
+restore table snapshot_scope_b.t{snapshot = 'snapshot_scope_database'};
+select 'database_snapshot_cross_database_restore_unchanged' as case_name, v from snapshot_scope_b.t;
+restore table snapshot_scope_a.t{snapshot = 'snapshot_scope_table'};
+select 'table_snapshot_restore_control' as case_name, v from snapshot_scope_a.t;
+
+drop snapshot snapshot_scope_table;
+drop snapshot snapshot_scope_database;
+drop database snapshot_scope_a;
+drop database snapshot_scope_b;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27116

## What this PR does / why we need it:

### Root cause

Named snapshots retain their declared level and object ID in `Snapshot.ExtraInfo`, but relation planning and selected SHOW paths applied only their timestamp. A table snapshot could therefore read a different table, including through SHOW CREATE. `RESTORE TABLE` also omitted the target-database check when its snapshot was database-level.

The initial scope enforcement also exposed two internal metadata readers that must retain historical time travel without presenting themselves as a user-selected named snapshot: DATA BRANCH's synthetic privilege query and SHOW RECOVERY WINDOW's `mo_catalog.mo_tables` scan. Finally, a copy-table ALTER replaces a physical relation while retaining its logical table ID, which is the identity captured by a table snapshot.

### Changes

- Add shared named-snapshot table/database scope validators and a single logical-table-ID helper.
- Enforce scope for normal table scans, SHOW forms, clone, RESTORE TABLE, and both DATA BRANCH endpoints.
- Keep internal catalog and privilege reads on the already-resolved `MO_TS`; validate the actual user-selected relation separately.
- Reject cross-database database-snapshot restores before restore work begins.
- Add regression coverage for the reverse DATA BRANCH endpoint and for table/database snapshot `SHOW DATABASES` boundaries.

### Issue-to-test proof

- `test/distributed/cases/snapshot/snapshot_scope.sql` covers #27116's cross-table SELECT and cross-database RESTORE repros, same-object controls, restore failure atomicity, table/database SHOW boundaries, copy-table ALTER logical identity, and DATA BRANCH rejection with the named snapshot on either endpoint.
- `pkg/sql/plan/query_builder_test.go:TestBuildTableRejectsOutOfScopeSnapshot` proves an unrelated relation is rejected during named-snapshot planning.
- `pkg/sql/plan/snapshot_scope_test.go` covers named-snapshot scope levels, logical-ID selection, table snapshots rejected by `SHOW DATABASES`, and database-snapshot catalog plans constrained by `dat_id`.
- `pkg/frontend/data_branch_helpers_test.go:TestValidateDataBranchNamedSnapshotScope` proves DATA BRANCH validates the resolved endpoint's logical table identity.
- `pkg/frontend/snapshot_test.go:TestCheckRestorePrivEnforcesDatabaseSnapshotScope` proves the database-snapshot restore target check permits its source database and rejects another database.
- `pkg/frontend/show_recovery_window_test.go:TestSearchTablesReadsCatalogAtSnapshotTimestamp` proves the internal recovery-window catalog scan uses `MO_TS`.
- Existing CI regressions retain coverage for valid DATA BRANCH snapshots across copy-table ALTER and SHOW RECOVERY WINDOW catalog reads.

### Tests run

- Pre-fix isolated reproduction against the reported baseline: table snapshots read another table and database snapshots restored another database's table.
- `make build` — PASS.
- `make err-check` — PASS.
- `mo-cgo-test -count=1 -timeout=180s ./pkg/sql/plan` — PASS.
- `mo-cgo-test -count=1 -timeout=120s -run '^TestBuildShowDatabases(RejectsTableSnapshot|RestrictsDatabaseSnapshot)$' ./pkg/sql/plan` — PASS.
- `mo-cgo-test -list '^TestBuildShowDatabases(RejectsTableSnapshot|RestrictsDatabaseSnapshot)$' ./pkg/sql/plan` — both tests enumerated.
- Focused frontend tests for DATA BRANCH, restore scope, and recovery-window catalog reads — PASS.
- Local standalone MatrixOne BVT, result files manually inspected: `snapshot_scope` — 54/54; `diff_schema_evolve` — 278/278; `show_recovery_window` — 109/109.

### CI follow-up

The prior Proxy BVT failure was PR-caused and fixed in the earlier integration commits; the later Proxy and pessimistic BVT jobs passed. The earlier arm64 SCA failure is green after compliant error construction.

The earlier Coverage failure was PR-caused, not the external download outage: workflow `31755103070` attempt 2 completed its coverage-UT producer successfully, then its final Coverage job reported 61/83 changed statements (73.49%), below the 75% threshold. This commit added direct semantic tests for the previously uncovered table-snapshot rejection and database-`dat_id` filtering branches. The follow-up workflow `31762472675` passed its Coverage job and all required enabled checks.

### Residual risks

No catalog migration, fallback path, concurrency behavior, or resource ownership change is introduced. Database snapshots now expose only their declared database through `SHOW DATABASES`; table snapshots reject database-wide SHOW operations by design.
