### PR TITLE
fix: preserve expression defaults in SHOW CREATE TABLE and CLONE

### DIFF
--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -184,7 +184,7 @@ func constructCreateTableSQL(
 					buf.WriteString(" DEFAULT NULL")
 				}
 			} else if len(col.Default.OriginString) > 0 {
-				buf.WriteString(" DEFAULT " + formatDefaultExpr(col.Default.OriginString))
+				buf.WriteString(" DEFAULT " + formatDefaultExpr(col.Default.OriginString, col.Default.Expr))
 			}
 
 			if col.OnUpdate != nil && col.OnUpdate.Expr != nil {
@@ -1471,10 +1471,16 @@ func formatStr(str string) string {
 	return strings.Replace(tmp, "'", "''", -1)
 }
 
-func formatDefaultExpr(expr string) string {
+// formatDefaultExpr escapes literal defaults for the generated CREATE TABLE
+// statement. Non-literal defaults already contain SQL syntax in OriginString,
+// so escaping their quotes as string contents would corrupt the expression.
+func formatDefaultExpr(expr string, defaultExpr *plan.Expr) string {
 	trimmed := strings.TrimSpace(expr)
 	if strings.HasPrefix(trimmed, "(") && strings.HasSuffix(trimmed, ")") {
 		return trimmed
+	}
+	if defaultExpr != nil && defaultExpr.GetLit() == nil {
+		return expr
 	}
 	return formatStr(expr)
 }

--- a/pkg/sql/plan/build_show_util_test.go
+++ b/pkg/sql/plan/build_show_util_test.go
@@ -160,6 +160,16 @@ func Test_buildTestShowCreateTable(t *testing.T) {
 			sql:  `CREATE TABLE t_expr_default (id INT, c VARCHAR(10) DEFAULT (concat('x','y')), s VARCHAR(10) DEFAULT 'plain')`,
 			want: "CREATE TABLE `t_expr_default` (\n  `id` int DEFAULT NULL,\n  `c` varchar(10) DEFAULT (concat('x', 'y')),\n  `s` varchar(10) DEFAULT 'plain'\n)",
 		},
+		{
+			name: "expression default preserves quoted function arguments",
+			sql:  `CREATE TABLE t_sequence_default (id BIGINT DEFAULT nextval('seq'), v VARCHAR(20))`,
+			want: "CREATE TABLE `t_sequence_default` (\n  `id` bigint DEFAULT nextval('seq'),\n  `v` varchar(20) DEFAULT NULL\n)",
+		},
+		{
+			name: "literal default remains formatted",
+			sql:  `CREATE TABLE t_literal_default (id BIGINT DEFAULT 42)`,
+			want: "CREATE TABLE `t_literal_default` (\n  `id` bigint DEFAULT 42\n)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/distributed/cases/git4data/clone/clone_default_expression.result
+++ b/test/distributed/cases/git4data/clone/clone_default_expression.result
@@ -1,0 +1,52 @@
+drop database if exists clone_default_src;
+drop database if exists clone_default_table_dst;
+drop database if exists clone_default_db_dst;
+create database clone_default_src;
+use clone_default_src;
+create sequence seq increment 5 start 10;
+create table t_seq (
+id bigint primary key default nextval('seq'),
+v varchar(20)
+);
+create table t_literal (id bigint default 42);
+insert into t_seq(v) values ('source');
+insert into t_literal values ();
+show create table t_seq;
+➤ Table[12,3,0]  ¦  Create Table[12,93,0]  𝄀
+t_seq  ¦  CREATE TABLE `t_seq` (
+  `id` bigint NOT NULL DEFAULT nextval('seq'),
+  `v` varchar(20) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+)
+show create table t_literal;
+➤ Table[12,6,0]  ¦  Create Table[12,39,0]  𝄀
+t_literal  ¦  CREATE TABLE `t_literal` (
+  `id` bigint DEFAULT 42
+)
+create database clone_default_table_dst;
+create table clone_default_table_dst.t_seq clone clone_default_src.t_seq;
+create table clone_default_table_dst.t_literal clone clone_default_src.t_literal;
+show tables from clone_default_table_dst;
+➤ Tables_in_clone_default_table_dst[12,3750,0]  𝄀
+t_literal  𝄀
+t_seq
+select * from clone_default_table_dst.t_seq;
+➤ id[-5,64,0]  ¦  v[12,15,0]  𝄀
+10  ¦  source
+select * from clone_default_table_dst.t_literal;
+➤ id[-5,64,0]  𝄀
+42
+create database clone_default_db_dst clone clone_default_src;
+show tables from clone_default_db_dst;
+➤ Tables_in_clone_default_db_dst[12,3750,0]  𝄀
+t_literal  𝄀
+t_seq
+select * from clone_default_db_dst.t_seq;
+➤ id[-5,64,0]  ¦  v[12,15,0]  𝄀
+10  ¦  source
+select * from clone_default_db_dst.t_literal;
+➤ id[-5,64,0]  𝄀
+42
+drop database if exists clone_default_src;
+drop database if exists clone_default_table_dst;
+drop database if exists clone_default_db_dst;

--- a/test/distributed/cases/git4data/clone/clone_default_expression.sql
+++ b/test/distributed/cases/git4data/clone/clone_default_expression.sql
@@ -1,0 +1,36 @@
+-- issue#27101: DDL reconstruction must preserve quoted arguments in default expressions.
+drop database if exists clone_default_src;
+drop database if exists clone_default_table_dst;
+drop database if exists clone_default_db_dst;
+
+create database clone_default_src;
+use clone_default_src;
+
+create sequence seq increment 5 start 10;
+create table t_seq (
+    id bigint primary key default nextval('seq'),
+    v varchar(20)
+);
+create table t_literal (id bigint default 42);
+
+insert into t_seq(v) values ('source');
+insert into t_literal values ();
+
+show create table t_seq;
+show create table t_literal;
+
+create database clone_default_table_dst;
+create table clone_default_table_dst.t_seq clone clone_default_src.t_seq;
+create table clone_default_table_dst.t_literal clone clone_default_src.t_literal;
+show tables from clone_default_table_dst;
+select * from clone_default_table_dst.t_seq;
+select * from clone_default_table_dst.t_literal;
+
+create database clone_default_db_dst clone clone_default_src;
+show tables from clone_default_db_dst;
+select * from clone_default_db_dst.t_seq;
+select * from clone_default_db_dst.t_literal;
+
+drop database if exists clone_default_src;
+drop database if exists clone_default_table_dst;
+drop database if exists clone_default_db_dst;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27101

## What this PR does / why we need it:

### Root cause

`ConstructCreateTableSQL` formats every non-NULL default through `formatStr`. That helper is correct for a literal default, but `Default.OriginString` is also used for already-formatted SQL expressions. As a result, the quote in `nextval('seq')` was escaped as string content and reconstructed DDL contained the invalid `nextval(''seq'')`. SHOW CREATE TABLE and both CLONE paths reuse this reconstruction.

### Changes

- Pass the planned default expression into the shared default formatter.
- Preserve `OriginString` verbatim for non-literal default expressions, while retaining the existing literal escaping and parenthesized-expression behavior.
- Add a planner regression case that reconstructs and asserts `DEFAULT nextval('seq')`, plus a `DEFAULT 42` literal control.
- Add a distributed regression covering SHOW CREATE TABLE, table-level CLONE, database-level CLONE, row preservation, target table existence, and the literal-default control at both clone scopes.

### Issue-to-test proof

- SHOW CREATE TABLE: the planner unit test asserts the generated DDL contains `DEFAULT nextval('seq')`; the BVT also records the exact SHOW output and then exercises the same reconstructed DDL through both clone paths, which would fail on the previous `nextval(''seq'')` output.
- Table-level CLONE: the BVT creates cloned sequence-default and literal-default tables, verifies both target tables exist, and verifies the source row/default value is preserved.
- Database-level CLONE: the BVT clones the source database, verifies both tables exist, and verifies the sequence-default row and literal default are preserved.

### Tests run

- `make build`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^Test_buildTestShowCreateTable$' ./pkg/sql/plan` (focused regression)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=600s ./pkg/sql/plan` (full package; passed)
- mo-tester generated and independently reran `test/distributed/cases/git4data/clone/clone_default_expression.sql` against this build; 25/25 SQL statements passed.

### Residual risks and scope

This PR fixes DDL reconstruction of default expressions. It does not change sequence-object cloning or sequence-to-table semantics tracked by the related issues #27049 and #27050. Legacy catalog entries with no planned default expression retain the previous formatter behavior.
