### PR TITLE
fix: preserve clone auto-increment continuation

### DIFF
--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -2602,7 +2602,13 @@ func constructTableClone(
 			dstCreateTable = createTable
 			dstTblDef = createTable.TableDef
 			sameColumnIDSpace = false
-			metaCopy.Ctx.RequestedAutoIncrOffset = createTable.TableDef.AutoIncrOffset
+			// The source carries an explicit schema lower bound (for example,
+			// ALTER TABLE ... AUTO_INCREMENT), while the destination can carry
+			// a session-requested lower bound. A fresh clone must honor both.
+			metaCopy.Ctx.RequestedAutoIncrOffset = max(
+				clonePlan.SrcTableDef.AutoIncrOffset,
+				createTable.TableDef.AutoIncrOffset,
+			)
 		}
 	}
 	dstAutoIncrNames := mapCloneAutoIncrColumns(clonePlan.SrcTableDef, dstTblDef, sameColumnIDSpace)
@@ -2675,7 +2681,12 @@ func constructTableClone(
 				colIdxes := vector.MustFixedColWithTypeCheck[int32](cols[0])
 				offsets := vector.MustFixedColWithTypeCheck[uint64](cols[1])
 				for i := 0; i < rows; i++ {
-					if dstName, ok := dstAutoIncrNames[colIdxes[i]]; ok {
+					colIdx := colIdxes[i]
+					// A fresh clone has a new allocator. Its visible columns are
+					// reconstructed from copied rows and schema lower bounds instead
+					// of inheriting the source allocator's reserved batch upper bound.
+					if dstName, ok := dstAutoIncrNames[colIdx]; ok &&
+						(sameColumnIDSpace || clonePlan.SrcTableDef.Cols[colIdx].Hidden) {
 						autoIncrOffsets[dstName] = offsets[i]
 					}
 				}

--- a/pkg/sql/compile/operator_table_clone_test.go
+++ b/pkg/sql/compile/operator_table_clone_test.go
@@ -158,14 +158,14 @@ func TestConstructTableCloneUsesCopiedStateForFreshClone(t *testing.T) {
 		TblId:          7,
 		DbName:         "db-name",
 		Name:           "t`name",
-		AutoIncrOffset: 999,
+		AutoIncrOffset: 1999,
 		Cols: []*plan.ColDef{
 			{ColId: 1, Name: "payload", Typ: plan.Type{Id: int32(types.T_int64)}},
 			{ColId: 11, Name: "id`col", Typ: plan.Type{Id: int32(types.T_uint64), AutoIncr: true}},
 		},
 	}
 	dstDef := &plan.TableDef{
-		AutoIncrOffset: 1999,
+		AutoIncrOffset: 999,
 		Cols: []*plan.ColDef{
 			{ColId: 0, Name: "id`col", Typ: plan.Type{Id: int32(types.T_uint64), AutoIncr: true}},
 			{ColId: 10, Name: "payload", Typ: plan.Type{Id: int32(types.T_int64)}},

--- a/pkg/sql/compile/operator_table_clone_test.go
+++ b/pkg/sql/compile/operator_table_clone_test.go
@@ -143,7 +143,7 @@ func TestConstructTableCloneUsesPhysicalTemporaryDestination(t *testing.T) {
 	)
 }
 
-func TestConstructTableCloneReadsAllocatorAndMaximumFromSnapshot(t *testing.T) {
+func TestConstructTableCloneUsesCopiedStateForFreshClone(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	exec := &tableCloneRecordingExecutor{}
 	exec.run = func(sql string) (executor.Result, error) {
@@ -165,7 +165,7 @@ func TestConstructTableCloneReadsAllocatorAndMaximumFromSnapshot(t *testing.T) {
 		},
 	}
 	dstDef := &plan.TableDef{
-		AutoIncrOffset: 99,
+		AutoIncrOffset: 1999,
 		Cols: []*plan.ColDef{
 			{ColId: 0, Name: "id`col", Typ: plan.Type{Id: int32(types.T_uint64), AutoIncr: true}},
 			{ColId: 10, Name: "payload", Typ: plan.Type{Id: int32(types.T_int64)}},
@@ -183,9 +183,9 @@ func TestConstructTableCloneReadsAllocatorAndMaximumFromSnapshot(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(tc.Release)
-	require.Equal(t, uint64(99), tc.Ctx.RequestedAutoIncrOffset)
+	require.Equal(t, uint64(1999), tc.Ctx.RequestedAutoIncrOffset)
 	require.Equal(t, map[string]uint64{"id`col": 40}, tc.Ctx.SrcAutoIncrMaxValues)
-	require.Equal(t, map[string]uint64{"id`col": 50}, tc.Ctx.SrcAutoIncrOffsets)
+	require.Empty(t, tc.Ctx.SrcAutoIncrOffsets)
 	require.True(t, exec.opts.HasAccountID())
 	require.Equal(t, uint32(17), exec.opts.AccountID())
 
@@ -196,6 +196,36 @@ func TestConstructTableCloneReadsAllocatorAndMaximumFromSnapshot(t *testing.T) {
 			table+" {MO_TS = 123}",
 		exec.sql,
 	)
+}
+
+func TestConstructTableClonePreservesAllocatorForAlterCopy(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	exec := &tableCloneRecordingExecutor{}
+	exec.run = func(sql string) (executor.Result, error) {
+		if strings.Contains(sql, "mo_catalog.mo_increment_columns") {
+			return newTableCloneOffsetResult(t, proc.Mp(), 0, 50), nil
+		}
+		return newTableCloneResult(t, proc.Mp(), 40), nil
+	}
+	runtime.ServiceRuntime(proc.GetService()).SetGlobalVariables(runtime.InternalSQLExecutor, exec)
+
+	tc, err := constructTableClone(&Compile{proc: proc, pn: &plan.Plan{}}, &plan.CloneTable{
+		SrcTableDef: &plan.TableDef{
+			TblId:  7,
+			DbName: "db",
+			Name:   "src",
+			Cols: []*plan.ColDef{{
+				ColId: 11,
+				Name:  "id",
+				Typ:   plan.Type{Id: int32(types.T_uint64), AutoIncr: true},
+			}},
+		},
+		SrcObjDef: &plan.ObjectRef{},
+	})
+	require.NoError(t, err)
+	t.Cleanup(tc.Release)
+	require.Equal(t, map[string]uint64{"id": 40}, tc.Ctx.SrcAutoIncrMaxValues)
+	require.Equal(t, map[string]uint64{"id": 50}, tc.Ctx.SrcAutoIncrOffsets)
 }
 
 func TestMapCloneAutoIncrColumnsAcrossSchemaChanges(t *testing.T) {
@@ -276,6 +306,11 @@ func TestConstructTableCloneDoesNotReadHiddenMaximum(t *testing.T) {
 			}},
 		},
 		SrcObjDef: &plan.ObjectRef{},
+		CreateTable: cloneCreatePlan(&plan.TableDef{Cols: []*plan.ColDef{{
+			Name:   "__mo_fake_pk_col",
+			Hidden: true,
+			Typ:    plan.Type{Id: int32(types.T_uint64), AutoIncr: true},
+		}}}),
 	})
 	require.NoError(t, err)
 	t.Cleanup(tc.Release)

--- a/test/distributed/cases/git4data/clone/clone_auto_increment_state.result
+++ b/test/distributed/cases/git4data/clone/clone_auto_increment_state.result
@@ -1,0 +1,151 @@
+drop database if exists issue_27092;
+drop database if exists issue_27092_db_src;
+drop database if exists issue_27092_db_dst;
+drop database if exists issue_27092_branch_src;
+drop database if exists issue_27092_branch_dst;
+drop snapshot if exists issue_27092_snapshot;
+create database issue_27092;
+create table issue_27092.table_src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092.table_src(v) values (10), (20), (30);
+create table issue_27092.table_dst clone issue_27092.table_src;
+insert into issue_27092.table_dst(v) values (40);
+select
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'table_src') as source_next,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'table_dst') as clone_next,
+(select max(id) from issue_27092.table_dst) as clone_inserted_id;
+➤ source_next[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  𝄀
+4  ¦  5  ¦  4
+create table issue_27092.empty_src (
+id bigint auto_increment primary key,
+v int
+);
+create table issue_27092.empty_dst clone issue_27092.empty_src;
+insert into issue_27092.empty_dst(v) values (10);
+select
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'empty_src') as source_next,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'empty_dst') as clone_next,
+(select max(id) from issue_27092.empty_dst) as clone_inserted_id;
+➤ source_next[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  𝄀
+1  ¦  2  ¦  1
+create table issue_27092.deleted_src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092.deleted_src(v) values (10), (20), (30);
+delete from issue_27092.deleted_src where id = 3;
+create table issue_27092.deleted_dst clone issue_27092.deleted_src;
+insert into issue_27092.deleted_dst(v) values (40);
+select
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'deleted_src') as source_next,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'deleted_dst') as clone_next,
+(select max(id) from issue_27092.deleted_dst) as clone_inserted_id,
+(select count(*) from issue_27092.deleted_dst) as clone_rows;
+➤ source_next[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  ¦  clone_rows[-5,64,0]  𝄀
+4  ¦  4  ¦  3  ¦  3
+create table issue_27092.explicit_src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092.explicit_src(v) values (10), (20), (30);
+alter table issue_27092.explicit_src auto_increment = 100;
+create table issue_27092.explicit_dst clone issue_27092.explicit_src;
+insert into issue_27092.explicit_dst(v) values (40);
+select
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'explicit_src') as source_next,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'explicit_dst') as clone_next,
+(select max(id) from issue_27092.explicit_dst) as clone_inserted_id;
+➤ source_next[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  𝄀
+100  ¦  101  ¦  100
+begin;
+create table issue_27092.txn_src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092.txn_src(v) values (10), (20), (30);
+create table issue_27092.txn_dst clone issue_27092.txn_src;
+insert into issue_27092.txn_dst(v) values (40);
+select max(id) as clone_inserted_id from issue_27092.txn_dst;
+➤ clone_inserted_id[-5,64,0]  𝄀
+4
+commit;
+create database issue_27092_db_src;
+create table issue_27092_db_src.src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092_db_src.src(v) values (10), (20), (30);
+create database issue_27092_db_dst clone issue_27092_db_src;
+insert into issue_27092_db_dst.src(v) values (40);
+select
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092_db_src' and table_name = 'src') as source_next,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092_db_dst' and table_name = 'src') as clone_next,
+(select max(id) from issue_27092_db_dst.src) as clone_inserted_id;
+➤ source_next[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  𝄀
+4  ¦  5  ¦  4
+create table issue_27092.branch_table_src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092.branch_table_src(v) values (10), (20), (30);
+data branch create table issue_27092.branch_table_dst from issue_27092.branch_table_src;
+insert into issue_27092.branch_table_dst(v) values (40);
+select
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'branch_table_src') as source_next,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'branch_table_dst') as clone_next,
+(select max(id) from issue_27092.branch_table_dst) as clone_inserted_id;
+➤ source_next[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  𝄀
+4  ¦  5  ¦  4
+create database issue_27092_branch_src;
+create table issue_27092_branch_src.src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092_branch_src.src(v) values (10), (20), (30);
+data branch create database issue_27092_branch_dst from issue_27092_branch_src;
+insert into issue_27092_branch_dst.src(v) values (40);
+select
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092_branch_src' and table_name = 'src') as source_next,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092_branch_dst' and table_name = 'src') as clone_next,
+(select max(id) from issue_27092_branch_dst.src) as clone_inserted_id;
+➤ source_next[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  𝄀
+4  ¦  5  ¦  4
+create table issue_27092.snapshot_src (
+id bigint auto_increment primary key,
+v int
+);
+insert into issue_27092.snapshot_src(v) values (10), (20), (30);
+create snapshot issue_27092_snapshot for table issue_27092 snapshot_src;
+insert into issue_27092.snapshot_src(v) values (50);
+create table issue_27092.snapshot_dst clone issue_27092.snapshot_src {snapshot = 'issue_27092_snapshot'};
+insert into issue_27092.snapshot_dst(v) values (40);
+select
+(select count(*) from issue_27092.snapshot_dst where v in (10, 20, 30)) as snapshot_rows,
+(select count(*) from issue_27092.snapshot_dst where v = 50) as post_snapshot_rows,
+(select auto_increment from information_schema.tables
+where table_schema = 'issue_27092' and table_name = 'snapshot_dst') as clone_next,
+(select max(id) from issue_27092.snapshot_dst) as clone_inserted_id;
+➤ snapshot_rows[-5,64,0]  ¦  post_snapshot_rows[-5,64,0]  ¦  clone_next[-5,64,0]  ¦  clone_inserted_id[-5,64,0]  𝄀
+3  ¦  0  ¦  5  ¦  4
+drop snapshot issue_27092_snapshot;
+drop database issue_27092_branch_dst;
+drop database issue_27092_branch_src;
+drop database issue_27092_db_dst;
+drop database issue_27092_db_src;
+drop database issue_27092;

--- a/test/distributed/cases/git4data/clone/clone_auto_increment_state.sql
+++ b/test/distributed/cases/git4data/clone/clone_auto_increment_state.sql
@@ -1,0 +1,152 @@
+drop database if exists issue_27092;
+drop database if exists issue_27092_db_src;
+drop database if exists issue_27092_db_dst;
+drop database if exists issue_27092_branch_src;
+drop database if exists issue_27092_branch_dst;
+drop snapshot if exists issue_27092_snapshot;
+
+create database issue_27092;
+
+-- Table clone continues at the source's next visible value.
+create table issue_27092.table_src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092.table_src(v) values (10), (20), (30);
+create table issue_27092.table_dst clone issue_27092.table_src;
+insert into issue_27092.table_dst(v) values (40);
+select
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'table_src') as source_next,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'table_dst') as clone_next,
+  (select max(id) from issue_27092.table_dst) as clone_inserted_id;
+
+-- Empty sources start both allocators at one.
+create table issue_27092.empty_src (
+  id bigint auto_increment primary key,
+  v int
+);
+create table issue_27092.empty_dst clone issue_27092.empty_src;
+insert into issue_27092.empty_dst(v) values (10);
+select
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'empty_src') as source_next,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'empty_dst') as clone_next,
+  (select max(id) from issue_27092.empty_dst) as clone_inserted_id;
+
+-- A fresh clone owns an independent allocator seeded by the rows it copied.
+create table issue_27092.deleted_src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092.deleted_src(v) values (10), (20), (30);
+delete from issue_27092.deleted_src where id = 3;
+create table issue_27092.deleted_dst clone issue_27092.deleted_src;
+insert into issue_27092.deleted_dst(v) values (40);
+select
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'deleted_src') as source_next,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'deleted_dst') as clone_next,
+  (select max(id) from issue_27092.deleted_dst) as clone_inserted_id,
+  (select count(*) from issue_27092.deleted_dst) as clone_rows;
+
+-- An explicit AUTO_INCREMENT start remains part of the continuation state.
+create table issue_27092.explicit_src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092.explicit_src(v) values (10), (20), (30);
+alter table issue_27092.explicit_src auto_increment = 100;
+create table issue_27092.explicit_dst clone issue_27092.explicit_src;
+insert into issue_27092.explicit_dst(v) values (40);
+select
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'explicit_src') as source_next,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'explicit_dst') as clone_next,
+  (select max(id) from issue_27092.explicit_dst) as clone_inserted_id;
+
+-- A live clone inside an explicit transaction has the same continuation behavior.
+begin;
+create table issue_27092.txn_src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092.txn_src(v) values (10), (20), (30);
+create table issue_27092.txn_dst clone issue_27092.txn_src;
+insert into issue_27092.txn_dst(v) values (40);
+select max(id) as clone_inserted_id from issue_27092.txn_dst;
+commit;
+
+-- Database clone propagates live-source semantics to every nested table clone.
+create database issue_27092_db_src;
+create table issue_27092_db_src.src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092_db_src.src(v) values (10), (20), (30);
+create database issue_27092_db_dst clone issue_27092_db_src;
+insert into issue_27092_db_dst.src(v) values (40);
+select
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092_db_src' and table_name = 'src') as source_next,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092_db_dst' and table_name = 'src') as clone_next,
+  (select max(id) from issue_27092_db_dst.src) as clone_inserted_id;
+
+-- Both table and database Data Branch forms share live clone continuation.
+create table issue_27092.branch_table_src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092.branch_table_src(v) values (10), (20), (30);
+data branch create table issue_27092.branch_table_dst from issue_27092.branch_table_src;
+insert into issue_27092.branch_table_dst(v) values (40);
+select
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'branch_table_src') as source_next,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'branch_table_dst') as clone_next,
+  (select max(id) from issue_27092.branch_table_dst) as clone_inserted_id;
+
+create database issue_27092_branch_src;
+create table issue_27092_branch_src.src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092_branch_src.src(v) values (10), (20), (30);
+data branch create database issue_27092_branch_dst from issue_27092_branch_src;
+insert into issue_27092_branch_dst.src(v) values (40);
+select
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092_branch_src' and table_name = 'src') as source_next,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092_branch_dst' and table_name = 'src') as clone_next,
+  (select max(id) from issue_27092_branch_dst.src) as clone_inserted_id;
+
+-- Historical clone derives its independent allocator from snapshot-visible rows.
+create table issue_27092.snapshot_src (
+  id bigint auto_increment primary key,
+  v int
+);
+insert into issue_27092.snapshot_src(v) values (10), (20), (30);
+create snapshot issue_27092_snapshot for table issue_27092 snapshot_src;
+insert into issue_27092.snapshot_src(v) values (50);
+create table issue_27092.snapshot_dst clone issue_27092.snapshot_src {snapshot = 'issue_27092_snapshot'};
+insert into issue_27092.snapshot_dst(v) values (40);
+select
+  (select count(*) from issue_27092.snapshot_dst where v in (10, 20, 30)) as snapshot_rows,
+  (select count(*) from issue_27092.snapshot_dst where v = 50) as post_snapshot_rows,
+  (select auto_increment from information_schema.tables
+    where table_schema = 'issue_27092' and table_name = 'snapshot_dst') as clone_next,
+  (select max(id) from issue_27092.snapshot_dst) as clone_inserted_id;
+
+drop snapshot issue_27092_snapshot;
+drop database issue_27092_branch_dst;
+drop database issue_27092_branch_src;
+drop database issue_27092_db_dst;
+drop database issue_27092_db_src;
+drop database issue_27092;

--- a/test/distributed/cases/git4data/clone/table_clone.result
+++ b/test/distributed/cases/git4data/clone/table_clone.result
@@ -40,8 +40,8 @@ a    b
 22    20000
 23    20001
 40000    40000
-50001    3
-50002    4
+40001    3
+40002    4
 create table t3 clone t2;
 select * from t3 order by a asc;
 a    b
@@ -54,8 +54,8 @@ a    b
 22    20000
 23    20001
 40000    40000
-50001    3
-50002    4
+40001    3
+40002    4
 insert into t3(b) values(7),(8);
 insert into t3(a,b) values(5,9),(6,10);
 select * from t3 order by a asc;
@@ -71,10 +71,10 @@ a    b
 22    20000
 23    20001
 40000    40000
-50001    3
-50002    4
-60001    7
-60002    8
+40001    3
+40002    4
+40003    7
+40004    8
 delete from t3 where a mod 2 = 0 or a > 100;
 select * from t3 order by a asc;
 a    b
@@ -95,8 +95,8 @@ a    b
 6    6
 21    21
 23    20001
-60003    100
-60004    101
+40005    100
+40006    101
 create table t4 (a int, b int) cluster by(a,b);
 insert into t4 select *,* from generate_series(1, 5)g;
 create table t5 clone t4 to account sys;

--- a/test/distributed/cases/git4data/clone/temporary_table_clone.result
+++ b/test/distributed/cases/git4data/clone/temporary_table_clone.result
@@ -188,7 +188,7 @@ select * from auto_dst order by id;
 ➤ id[-5,64,0]  ¦  payload[12,15,0]  𝄀
 10  ¦  first  𝄀
 11  ¦  second  𝄀
-10010  ¦  third
+12  ¦  third
 drop temporary table auto_dst;
 create temporary table temp_src (id int primary key, v varchar(20));
 insert into temp_src values (9, 'temporary source');

--- a/test/distributed/cases/snapshot/sys_restore_system_table_to_sys_account.result
+++ b/test/distributed/cases/snapshot/sys_restore_system_table_to_sys_account.result
@@ -129,7 +129,7 @@ id    val
 1    a
 2    b
 3    c
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 proc_id    name    creator    args    lang    body    sql_mode    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
 1910000    test_if_hit_elseif_first_elseif    null    []    sql    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 1910001    test_if_hit_if    null    []    sql    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
@@ -138,7 +138,7 @@ create snapshot sp_sp05 for account;
 drop procedure test_if_hit_elseif_first_elseif;
 drop procedure test_if_hit_if;
 restore account sys{snapshot="sp_sp05"};
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 proc_id    name    creator    args    lang    body    sql_mode    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
 1910000    test_if_hit_elseif_first_elseif    null    []    sql    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 1910001    test_if_hit_if    null    []    sql    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
@@ -180,16 +180,16 @@ id    val
 1    1.5
 2    2.5
 3    3.5
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 proc_id    name    creator    args    lang    body    sql_mode    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1920000    test_if_hit_second_elseif    null    []    sql    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 order by id limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 1920001    test_if_hit_else    null    []    sql    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1920000    test_if_hit_second_elseif    null    []    sql    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 order by id limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp06;
 create snapshot sp_sp06 for account;
 drop table tbh1;
 drop table tbh2;
 drop procedure test_if_hit_second_elseif;
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 proc_id    name    creator    args    lang    body    sql_mode    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
 1920001    test_if_hit_else    null    []    sql    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account sys{snapshot="sp_sp06"};
@@ -201,10 +201,10 @@ id    val
 call test_if_hit_second_elseif();
 id    val
 1    a
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 proc_id    name    creator    args    lang    body    sql_mode    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1920000    test_if_hit_second_elseif    null    []    sql    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 order by id limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 1920001    test_if_hit_else    null    []    sql    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1920000    test_if_hit_second_elseif    null    []    sql    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 order by id limit 1; ELSE select * from tbh3; END IF; end    ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES    procedure_test    dump    2025-07-19 05:52:49    2025-07-19 05:52:49    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot sp_sp06;
 drop procedure test_if_hit_second_elseif;
 drop procedure test_if_hit_else;

--- a/test/distributed/cases/snapshot/sys_restore_system_table_to_sys_account.sql
+++ b/test/distributed/cases/snapshot/sys_restore_system_table_to_sys_account.sql
@@ -117,8 +117,9 @@ call test_if_hit_elseif_first_elseif();
 drop procedure if exists test_if_hit_if;
 create procedure test_if_hit_if() 'begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end';
 call test_if_hit_if();
+-- @sortkey:1
 -- @ignore:0,9,10
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 
 drop snapshot if exists sp_sp05;
 create snapshot sp_sp05 for account;
@@ -128,8 +129,9 @@ drop procedure test_if_hit_if;
 
 restore account sys{snapshot="sp_sp05"};
 
+-- @sortkey:1
 -- @ignore:0,9,10
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 call test_if_hit_elseif_first_elseif();
 call test_if_hit_if();
 drop snapshot sp_sp05;
@@ -163,8 +165,9 @@ call test_if_hit_second_elseif();
 drop procedure if exists test_if_hit_else;
 create procedure test_if_hit_else() 'begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end';
 call test_if_hit_else();
+-- @sortkey:1
 -- @ignore:0,9,10
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 
 drop snapshot if exists sp_sp06;
 create snapshot sp_sp06 for account;
@@ -172,15 +175,17 @@ create snapshot sp_sp06 for account;
 drop table tbh1;
 drop table tbh2;
 drop procedure test_if_hit_second_elseif;
+-- @sortkey:1
 -- @ignore:0,9,10
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 
 restore account sys{snapshot="sp_sp06"};
 
 call test_if_hit_else();
 call test_if_hit_second_elseif();
+-- @sortkey:1
 -- @ignore:0,9,10
-select * from mo_catalog.mo_stored_procedure;
+select * from mo_catalog.mo_stored_procedure order by name;
 
 drop snapshot sp_sp06;
 drop procedure test_if_hit_second_elseif;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27092

## What this PR does / why we need it:

### Root cause

Fresh table clones copied the source row from `mo_catalog.mo_increment_columns` into the destination allocator. That row offset is the upper bound of a reserved allocation batch (10,000 in the reproducer), not the next source-session value (4). Because a fresh clone has a new table ID and an independent allocator, transferring that reservation made its first generated ID 10,001.

The persisted table definition separately carries explicit schema lower bounds such as `ALTER TABLE ... AUTO_INCREMENT = 100`. Those are user-visible state and must still be preserved.

### Changes

- For a fresh clone, reconstruct visible auto-increment state from the copied row maximum and the larger source/destination schema lower bound. Do not copy the source allocator reserved-batch upper bound.
- Continue copying raw allocator state for ALTER COPY paths that retain the column-ID space, where existing CN caches make that state part of the ownership handoff.
- Continue copying allocator state for hidden internal auto-increment columns; hidden index-table allocator handling is unchanged.
- Add unit coverage for the fresh-clone and ALTER COPY ownership boundaries, including a source schema lower bound larger than the destination lower bound.
- Add BVT coverage for table clone, database clone, both Data Branch forms, empty sources, deleted maximum IDs, explicit `AUTO_INCREMENT`, explicit transactions, and historical snapshots.
- Stabilize the five existing snapshot stored-procedure checks with `ORDER BY name` and `@sortkey:1`, while retaining `@ignore:0,9,10`; this changes neither the expected `proc_id` entries nor any non-ignored field assertion.
- Update table-clone and temporary-table-clone BVT expectations to assert contiguous IDs from the highest copied row instead of discarded source reservation batches.

### Issue-to-test proof

- The exact issue reproduction reports source next `4`, clone next `5`, and first cloned-table insert `4` for table, database, and both Data Branch clone forms.
- Empty sources insert `1`; a source whose largest row was deleted seeds the independent clone from the copied maximum; explicit `AUTO_INCREMENT = 100` inserts `100`; snapshot clone asserts snapshot-visible rows plus exact `4 / 5` inserted/next values.
- A permanent source cloned into a temporary table preserves copied IDs `10` and `11`, then assigns `12` to the first destination insert.
- Unit tests prove that fresh visible columns discard the persisted reservation while preserving the larger source/destination schema floor; ALTER COPY and hidden internal columns retain allocator state required by their ownership model.
- The existing chained-clone BVT proves subsequent clone and delete/insert sequences continue at `40001` through `40006`, without introducing a new 10,000-value gap at each clone.
- The snapshot/restore procedure checks still validate every catalog field except the pre-existing ignored ID and timestamp columns. Their deterministic unique `name` ordering prevents ignored allocator IDs from pairing one procedure with another.

### Verification

Latest semantic rebase: patch-equivalent head `1c9ff2e42bc751bd0028bcfe0cd51b8704071bcb` was rebased conflict-free from `main` at `a15139da62b938b0918c19675c619b259cd86460` onto `main` at `07fe9a69c6a3d6ed5e2b4299fb143d10bef442c0`, producing exact head `23c7a20c072375324fee984c087de370ef5bd323`.

- `git range-diff a15139da62..1c9ff2e42b 07fe9a69c6..23c7a20c07`: all four clone patches are equivalent.
- Stable aggregate patch ID before and after the rebase: `ff530dfc6cb58fd343bc0663b95c917a95aa40fc`.
- The final diff is the intended six clone files plus two targeted snapshot BVT files; `git diff --check origin/main...HEAD` passed and the worktree is clean.
- On exact head `c3332623e5be8961a2c54bed286c888b75f82bee`, an isolated local MatrixOne service and mo-tester upstream/main `334d3e124bbfbdcd6b5cc63439278d172c72b706` passed `sys_restore_system_table_to_sys_account` twice with CI flags `-g -n -o`: 313/313 statements each time. Normal metadata mode also passed 313/313.
- A direct matcher negative-control proves the BVT assertion remains strict: ignored IDs `9/10` versus expected `1920000/1920001` fail under full-row sorting, while `ORDER BY name` plus `@sortkey:1` pairs rows correctly; mutations to each of the 14 non-ignored columns are rejected. `@sortkey:1` alone remains order-dependent, so it is deliberately paired with SQL ordering.
- Exact-head MatrixOne CGo validation selected and passed all eight focused clone allocator tests.
- Incoming main commit `07fe9a69c6 fix(embed): align HAKeeper transport timeout under race (#27849)` changes only embed/logservice configuration and its tests, with no PR-file overlap. All six directly affected tests passed: three embed timeout/config tests, two logservice client-config tests, and the authenticated two-CN fixture test.
- Because the incoming logservice change is a transitive dependency of the clone owners, the complete `pkg/sql/compile`, `pkg/frontend`, and `pkg/sql/colexec/table_clone` packages were rerun through the MatrixOne CGo wrapper and passed on exact head `23c7a20c07`.
- Workflow `33283224004` attempt 1 on exact head `23c7a20c07` passed shared build, normal Ubuntu UT, SCA, Coverage UT, and PROXY BVT. All three changed clone cases passed; PESSIMISTIC BVT reproduced only unrelated #27164, and aggregate Coverage was derivative.
- Attempt-2 PESSIMISTIC BVT job `99187224896` is in progress after the single permitted failed-job rerun.

### CI investigation

- #27164 remains the underlying mo-tester defect. Workflow `33283224004` attempt 1 reproduced its snapshot result-pairing mismatch in PESSIMISTIC BVT job `99182619116` on exact head `23c7a20c07`.
- PESSIMISTIC BVT completed 72,946 statements with 72,471 successful, exactly two failed, 473 ignored, and zero abnormal. `snapshot/sys_restore_system_table_to_sys_account.sql` completed 313 statements with 311 successful; at SQL rows 167 and 183, both `mo_stored_procedure` comparisons reported `row:0,column:1`, expected `test_if_hit_second_elseif`, and received `test_if_hit_else`. Expected ignored `proc_id` values were `1920000/1920001`; actual ignored values were `9/10`. The final error list contains no other SQL.
- All three changed clone cases passed in attempt 1: `clone_auto_increment_state.sql` 65/65, `table_clone.sql` 74/74, and `temporary_table_clone.sql` 163/163. This PR now adds only a case-level mitigation for all five `mo_stored_procedure` selectors in the same snapshot test; it does not modify mo-tester, expected `proc_id` values, or ignored columns. Fresh CI on `c3332623e5` is pending.
- Attempt-1 aggregate Coverage job `99186546271` was derivative: its direct log records `prerequisites_ready: false` for generation `33283224004-1` and exits before coverage processing.
- Workflow `33283224004` was rerun for failed jobs exactly once; its old-head results are superseded by fresh CI on `c3332623e5`. The rerun policy remains exhausted for that prior workflow.
- #27847 is resolved as a blocker for this PR. Current main includes #27848 test synchronization, and the directly affected quota test passed on the preceding exact head.
- #27833, #27127, #27771, #26519, and #27145 remain resolved as blockers for this PR.

### Residual risks

A fresh clone intentionally owns an independent allocator. If the highest generated source rows were deleted, the clone starts after the highest row it actually copied rather than inheriting an unused cached range from the source CN. Explicit schema lower bounds remain preserved. There are no catalog, wire-format, or API changes in this PR, and the fix does not read or mutate source CN allocator caches.


