### PR TITLE
[4.2] fix(disttae): handle empty TN response in table stats

### DIFF
--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -250,7 +250,8 @@ func requestStorageUsage(ctx context.Context, ses *Session, accIds [][]int64) (r
 		return nil, tried, err
 	}
 
-	return result.Data.([]any)[0], tried, nil
+	response, err := ctl.GetFirstTNResponse(ctx, result)
+	return response, tried, err
 }
 
 func handleStorageUsageResponse_V2(

--- a/pkg/frontend/show_account_test.go
+++ b/pkg/frontend/show_account_test.go
@@ -22,6 +22,9 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/clusterservice"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -264,6 +267,30 @@ func Test_updateCount(t *testing.T) {
 	vector.AppendFixed[int64](bat.Vecs[0], ori, false, proc.GetMPool())
 	updateCount(bat.Vecs[0], add, 0)
 	require.Equal(t, ori+add, vector.GetFixedAtWithTypeCheck[int64](bat.Vecs[0], 0))
+}
+
+func TestRequestStorageUsageWithNoTN(t *testing.T) {
+	rt := moruntime.ServiceRuntime("")
+	oldCluster, hadOldCluster := rt.GetGlobalVariables(moruntime.ClusterService)
+	emptyCluster := clusterservice.NewMOCluster("", nil, 0, clusterservice.WithDisableRefresh())
+	rt.SetGlobalVariables(moruntime.ClusterService, emptyCluster)
+	t.Cleanup(func() {
+		if hadOldCluster {
+			rt.SetGlobalVariables(moruntime.ClusterService, oldCluster)
+		} else {
+			rt.CompareAndDeleteGlobalVariables(moruntime.ClusterService, emptyCluster)
+		}
+		emptyCluster.Close()
+	})
+
+	ctrl := gomock.NewController(t)
+	ses := newTestSession(t, ctrl)
+	t.Cleanup(ses.Close)
+
+	response, tried, err := requestStorageUsage(context.Background(), ses, nil)
+	require.Nil(t, response)
+	require.False(t, tried)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend), err)
 }
 
 func Test_updateStorageUsageCache_V2(t *testing.T) {

--- a/pkg/sql/plan/function/ctl/ctl.go
+++ b/pkg/sql/plan/function/ctl/ctl.go
@@ -106,7 +106,11 @@ func MoCtl(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *pr
 		return err
 	}
 	if command == InspectMethod {
-		obj := res.Data.([]any)[0].(*cmd_util.InspectResp)
+		response, err := GetFirstTNResponse(proc.Ctx, res)
+		if err != nil {
+			return err
+		}
+		obj := response.(*cmd_util.InspectResp)
 		err = rs.AppendBytes([]byte(obj.ConsoleString()), false)
 		return err
 	}

--- a/pkg/sql/plan/function/ctl/types.go
+++ b/pkg/sql/plan/function/ctl/types.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -120,4 +121,17 @@ type handleFunc func(proc *process.Process,
 type Result struct {
 	Method string `json:"method"`
 	Data   any    `json:"result"`
+}
+
+// GetFirstTNResponse returns the first response for callers that require a TN target.
+// Commands for which an empty target set is valid should use Result.Data directly.
+func GetFirstTNResponse(ctx context.Context, result Result) (any, error) {
+	responses, ok := result.Data.([]any)
+	if !ok {
+		return nil, moerr.NewInternalErrorf(ctx, "invalid TN response data %T", result.Data)
+	}
+	if len(responses) == 0 {
+		return nil, moerr.NewNoAvailableBackend(ctx)
+	}
+	return responses[0], nil
 }

--- a/pkg/sql/plan/function/ctl/types_test.go
+++ b/pkg/sql/plan/function/ctl/types_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFirstTNResponse(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("first response", func(t *testing.T) {
+		response, err := GetFirstTNResponse(ctx, Result{Data: []any{"first", "second"}})
+		require.NoError(t, err)
+		require.Equal(t, "first", response)
+	})
+
+	t.Run("no TN response", func(t *testing.T) {
+		response, err := GetFirstTNResponse(ctx, Result{Data: []any{}})
+		require.Nil(t, response)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend), err)
+	})
+
+	t.Run("invalid response data", func(t *testing.T) {
+		response, err := GetFirstTNResponse(ctx, Result{Data: "invalid"})
+		require.Nil(t, response)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrInternal), err)
+	})
+}

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -2940,7 +2940,11 @@ func getChangedTableList(
 		if err != nil {
 			return err
 		}
-		resp = ret.Data.([]any)[0].(*cmd_util.GetChangedTableListResp)
+		response, err := ctl.GetFirstTNResponse(ctx, ret)
+		if err != nil {
+			return err
+		}
+		resp = response.(*cmd_util.GetChangedTableListResp)
 	}
 
 	//if resp.Newest == nil {

--- a/pkg/vm/engine/disttae/mo_table_stats_test.go
+++ b/pkg/vm/engine/disttae/mo_table_stats_test.go
@@ -17,13 +17,64 @@ package disttae
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/cmd_util"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGetChangedTableListWithNoTN(t *testing.T) {
+	ctx := context.Background()
+
+	client.RunTxnTests(func(cli client.TxnClient, _ rpc.TxnSender) {
+		rt := runtime.ServiceRuntime("")
+		oldCluster, hadOldCluster := rt.GetGlobalVariables(runtime.ClusterService)
+		emptyCluster := mockCluster{}
+		rt.SetGlobalVariables(runtime.ClusterService, emptyCluster)
+		t.Cleanup(func() {
+			if hadOldCluster {
+				rt.SetGlobalVariables(runtime.ClusterService, oldCluster)
+			} else {
+				rt.CompareAndDeleteGlobalVariables(runtime.ClusterService, emptyCluster)
+			}
+		})
+
+		eng := &Engine{cli: cli}
+		var (
+			pairs        []tablePair
+			to, oldest   types.TS
+			from, latest timestamp.Timestamp
+		)
+
+		err := getChangedTableList(
+			ctx,
+			"",
+			eng,
+			nil,
+			nil,
+			nil,
+			[]timestamp.Timestamp{from, latest},
+			&pairs,
+			&to,
+			&oldest,
+			cmd_util.CollectChanged,
+			nil,
+		)
+
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend), err)
+	})
+}
 
 func Test_intsJoin(t *testing.T) {
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26779

## What this PR does / why we need it:

Backports #26782 (`c72224bea6`) to `4.2-dev`.

Adds a shared `ctl.GetFirstTNResponse` boundary for callers that require a TN response. When no TN is available, table statistics, `SHOW ACCOUNTS` storage usage, and `mo_ctl(..., INSPECT, ...)` now return `ErrNoAvailableBackend` instead of indexing an empty result and panicking the CN. Commands where an empty target set is valid continue to consume `Result.Data` directly.

The original regression tests are included unchanged.

## Testing

- `go test -mod=readonly -count=1 -timeout 180s ./pkg/sql/plan/function/ctl ./pkg/frontend ./pkg/vm/engine/disttae`