### PR TITLE
[4.2] fix(cnservice): gate startup on self-visible cluster inventory

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -402,6 +402,9 @@ func (s *service) Start() (err error) {
 		s.lifecycle = serviceStarted
 	}()
 
+	if err = s.waitForClusterSelfReady(); err != nil {
+		return err
+	}
 	if err = s.bootstrap(); err != nil {
 		return err
 	}

--- a/pkg/cnservice/server_cluster.go
+++ b/pkg/cnservice/server_cluster.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cnservice
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/matrixorigin/matrixone/pkg/clusterservice"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/version"
+)
+
+const minClusterReadinessRetryInterval = 100 * time.Millisecond
+
+// waitForClusterSelfReady prevents ingress from opening before this CN's local
+// authoritative cluster snapshot contains the heartbeat generation it just
+// published. Proxy and CN maintain independent snapshots, so a replacement CN
+// can otherwise receive traffic while its own snapshot still predates itself.
+func (s *service) waitForClusterSelfReady() error {
+	// Some focused lifecycle tests build only the service dependencies relevant
+	// to their assertion. NewService always initializes moCluster.
+	if s.moCluster == nil {
+		return nil
+	}
+
+	timeout := s.cfg.HAKeeper.DiscoveryTimeout.Duration
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	retryInterval := s.cfg.HAKeeper.HeatbeatInterval.Duration
+	if retryInterval < minClusterReadinessRetryInterval {
+		retryInterval = minClusterReadinessRetryInterval
+	}
+	return s.waitForClusterSelfReadyWithContext(ctx, retryInterval)
+}
+
+func (s *service) waitForClusterSelfReadyWithContext(
+	ctx context.Context,
+	retryInterval time.Duration,
+) error {
+	select {
+	case <-ctx.Done():
+		return s.clusterSelfReadinessError(ctx, nil)
+	case <-s.hakeeperConnected:
+	}
+
+	refresher, ok := s.moCluster.(clusterservice.AuthoritativeRefresher)
+	if !ok {
+		return moerr.NewInternalErrorNoCtx(
+			"CN cluster service does not support authoritative refresh")
+	}
+
+	var lastRefreshErr error
+	for attempts := 1; ; attempts++ {
+		lastRefreshErr = refresher.Refresh(ctx)
+		if lastRefreshErr == nil {
+			ready, err := s.clusterSnapshotContainsSelf(ctx)
+			if err != nil {
+				lastRefreshErr = err
+			} else if ready {
+				s.logger.Info("CN is visible in local cluster inventory",
+					zap.String("uuid", s.cfg.UUID),
+					zap.Int("refresh-attempts", attempts))
+				return nil
+			}
+		}
+
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return s.clusterSelfReadinessError(ctx, lastRefreshErr)
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *service) clusterSnapshotContainsSelf(ctx context.Context) (bool, error) {
+	found := false
+	err := clusterservice.GetCNServiceWithoutWorkingStateWithContext(
+		ctx,
+		s.moCluster,
+		clusterservice.NewServiceIDSelector(s.cfg.UUID),
+		func(cn metadata.CNService) bool {
+			found = cn.PipelineServiceAddress == s.pipelineServiceServiceAddr() &&
+				cn.CommitID == version.CommitID
+			return false
+		})
+	return found, err
+}
+
+func (s *service) clusterSelfReadinessError(ctx context.Context, refreshErr error) error {
+	if refreshErr != nil {
+		return moerr.NewInternalErrorf(
+			context.Background(),
+			"CN %s was not published in its local cluster inventory before startup deadline: %v: %v",
+			s.cfg.UUID,
+			ctx.Err(),
+			refreshErr)
+	}
+	return moerr.NewInternalErrorf(
+		context.Background(),
+		"CN %s was not published in its local cluster inventory before startup deadline: %v",
+		s.cfg.UUID,
+		ctx.Err())
+}

--- a/pkg/cnservice/server_cluster_test.go
+++ b/pkg/cnservice/server_cluster_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cnservice
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/matrixorigin/matrixone/pkg/clusterservice"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/common/stopper"
+	"github.com/matrixorigin/matrixone/pkg/frontend/test/mock_lock"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/version"
+)
+
+type readinessCluster struct {
+	clusterservice.MOCluster
+
+	mu           sync.Mutex
+	snapshots    [][]metadata.CNService
+	current      []metadata.CNService
+	refreshCalls int
+	refreshHook  func(context.Context, int) error
+}
+
+type nonRefreshingCluster struct {
+	clusterservice.MOCluster
+}
+
+func (c *readinessCluster) Refresh(ctx context.Context) error {
+	c.mu.Lock()
+	c.refreshCalls++
+	call := c.refreshCalls
+	hook := c.refreshHook
+	c.mu.Unlock()
+
+	if hook != nil {
+		if err := hook(ctx, call); err != nil {
+			return err
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.snapshots) > 0 {
+		idx := call - 1
+		if idx >= len(c.snapshots) {
+			idx = len(c.snapshots) - 1
+		}
+		c.current = append([]metadata.CNService(nil), c.snapshots[idx]...)
+	}
+	return nil
+}
+
+func (c *readinessCluster) GetCNServiceWithoutWorkingState(
+	_ clusterservice.Selector,
+	apply func(metadata.CNService) bool,
+) {
+	c.mu.Lock()
+	services := append([]metadata.CNService(nil), c.current...)
+	c.mu.Unlock()
+	for _, cn := range services {
+		if !apply(cn) {
+			return
+		}
+	}
+}
+
+func (c *readinessCluster) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.refreshCalls
+}
+
+func TestClusterSelfReadinessRequiresCurrentHeartbeatGeneration(t *testing.T) {
+	const (
+		serviceID = "cn-1"
+		address   = "127.0.0.1:6002"
+	)
+	cluster := &readinessCluster{
+		snapshots: [][]metadata.CNService{
+			{{
+				ServiceID:              serviceID,
+				PipelineServiceAddress: "127.0.0.1:5002",
+				CommitID:               version.CommitID,
+			}},
+			{{
+				ServiceID:              serviceID,
+				PipelineServiceAddress: address,
+				CommitID:               version.CommitID + "-previous",
+			}},
+			{{
+				ServiceID:              serviceID,
+				PipelineServiceAddress: address,
+				CommitID:               version.CommitID,
+			}},
+		},
+	}
+	heartbeatReady := make(chan struct{})
+	close(heartbeatReady)
+	s := &service{
+		cfg: &Config{
+			UUID:           serviceID,
+			ServiceAddress: address,
+		},
+		logger:            zap.NewNop(),
+		moCluster:         cluster,
+		hakeeperConnected: heartbeatReady,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, s.waitForClusterSelfReadyWithContext(ctx, time.Millisecond))
+	require.Equal(t, 3, cluster.calls())
+}
+
+func TestClusterSelfReadinessHonorsCancellationBeforeHeartbeat(t *testing.T) {
+	cluster := &readinessCluster{}
+	s := &service{
+		cfg:               &Config{UUID: t.Name()},
+		logger:            zap.NewNop(),
+		moCluster:         cluster,
+		hakeeperConnected: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.waitForClusterSelfReadyWithContext(ctx, time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "before startup deadline")
+	require.Zero(t, cluster.calls())
+}
+
+func TestClusterSelfReadinessReportsAuthoritativeRefreshFailure(t *testing.T) {
+	refreshErr := errors.New("hakeeper snapshot unavailable")
+	ctx, cancel := context.WithCancel(context.Background())
+	cluster := &readinessCluster{
+		refreshHook: func(context.Context, int) error {
+			cancel()
+			return refreshErr
+		},
+	}
+	heartbeatReady := make(chan struct{})
+	close(heartbeatReady)
+	s := &service{
+		cfg:               &Config{UUID: t.Name()},
+		logger:            zap.NewNop(),
+		moCluster:         cluster,
+		hakeeperConnected: heartbeatReady,
+	}
+
+	err := s.waitForClusterSelfReadyWithContext(ctx, time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), refreshErr.Error())
+	require.Equal(t, 1, cluster.calls())
+}
+
+func TestClusterSelfReadinessRejectsNonAuthoritativeCluster(t *testing.T) {
+	heartbeatReady := make(chan struct{})
+	close(heartbeatReady)
+	s := &service{
+		cfg:               &Config{UUID: t.Name()},
+		logger:            zap.NewNop(),
+		moCluster:         &nonRefreshingCluster{},
+		hakeeperConnected: heartbeatReady,
+	}
+
+	err := s.waitForClusterSelfReadyWithContext(context.Background(), time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support authoritative refresh")
+}
+
+func TestServiceStartDoesNotBootstrapBeforeClusterSelfReady(t *testing.T) {
+	moruntime.RunTest(t.Name(), func(moruntime.Runtime) {
+		const address = "127.0.0.1:6002"
+		refreshEntered := make(chan struct{})
+		releaseRefresh := make(chan struct{})
+		var enterOnce sync.Once
+		var releaseOnce sync.Once
+		release := func() { releaseOnce.Do(func() { close(releaseRefresh) }) }
+		t.Cleanup(release)
+		cluster := &readinessCluster{
+			snapshots: [][]metadata.CNService{{{
+				ServiceID:              t.Name(),
+				PipelineServiceAddress: address,
+				CommitID:               version.CommitID,
+			}}},
+			refreshHook: func(ctx context.Context, _ int) error {
+				enterOnce.Do(func() { close(refreshEntered) })
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-releaseRefresh:
+					return nil
+				}
+			},
+		}
+
+		bootstrapErr := errors.New("stop after readiness gate")
+		boot := &testBootService{bootstrapErr: bootstrapErr}
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ls := mock_lock.NewMockLockService(ctrl)
+		ls.EXPECT().Close().Return(nil).Times(2)
+		cfg := &Config{
+			UUID:           t.Name(),
+			ServiceAddress: address,
+		}
+		cfg.HAKeeper.DiscoveryTimeout.Duration = time.Second
+		cfg.HAKeeper.HeatbeatInterval.Duration = time.Millisecond
+		cfg.Txn.Trace.BufferSize = 1
+		heartbeatReady := make(chan struct{})
+		close(heartbeatReady)
+		s := &service{
+			cfg:                cfg,
+			logger:             zap.NewNop(),
+			stopper:            stopper.NewStopper("test-cluster-readiness"),
+			bootstrapService:   boot,
+			mo:                 closeErrorMOServer{},
+			cancelMoServerFunc: func() {},
+			server:             closeOnlyRPCServer{},
+			lockService:        ls,
+			moCluster:          cluster,
+			hakeeperConnected:  heartbeatReady,
+		}
+		s.options.traceDataPath = t.TempDir()
+
+		startDone := make(chan error, 1)
+		go func() {
+			startDone <- s.Start()
+		}()
+		<-refreshEntered
+		require.Zero(t, boot.bootstrapCount.Load())
+
+		release()
+		require.ErrorIs(t, <-startDone, bootstrapErr)
+		require.Equal(t, int32(1), boot.bootstrapCount.Load())
+	})
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27152

## What this PR does / why we need it:

Backports #27166 (`f0d9a378ed`) to `4.2-dev`.

A replacement CN can publish a successful heartbeat and become visible to Proxy while its own local `MOCluster` still contains a pre-registration snapshot that does not include that CN. IVF entries scans require the current coordinator CN because only it can expose local appendable ranges, so this ordering gap can reject valid requests with `required-current-cn-outside-pool`.

This change gates CN startup before bootstrap and all query ingress until:

1. the first CN heartbeat succeeds;
2. an authoritative local cluster refresh succeeds; and
3. the refreshed snapshot contains this CN's service ID, pipeline address, and build commit.

The retry is bounded by the existing HAKeeper discovery timeout. Failure uses the existing CN startup rollback path. The change does not relax tenant/label pool isolation or IVF's `CurrentCNRequired` rule, and it adds no query or transaction hot-path work.

The original regression tests are included unchanged.

## Testing

- `go list -mod=readonly ./pkg/cnservice`
- `go build -mod=readonly ./pkg/cnservice`
- `go test -mod=readonly -count=1 -timeout=300s ./pkg/cnservice`
- each of the five new readiness/lifecycle tests under `-race -count=100`
- `go test -mod=readonly -race -count=1 -timeout=600s ./pkg/cnservice`
- `go vet -mod=readonly ./pkg/cnservice`
