### PR TITLE
fix: make internal SQL logtail waits cancelable

### DIFF
--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -188,18 +188,25 @@ func (s *sqlExecutor) ExecTxn(
 	if err = exec.commit(); err != nil {
 		return err
 	}
-	s.maybeWaitCommittedLogApplied(exec.opts)
-	return nil
+	return s.maybeWaitCommittedLogApplied(exec.ctx, exec.opts)
 }
 
-func (s *sqlExecutor) maybeWaitCommittedLogApplied(opts executor.Options) {
+func (s *sqlExecutor) maybeWaitCommittedLogApplied(
+	ctx context.Context,
+	opts executor.Options,
+) error {
 	if !opts.WaitCommittedLogApplied() {
-		return
+		return nil
 	}
 	ts := opts.Txn().Txn().CommitTS
 	if !ts.IsEmpty() {
-		s.txnClient.SyncLatestCommitTS(ts)
+		// The commit callback has already advanced the transaction client's
+		// latest commit timestamp. Keep the visibility barrier on the same
+		// caller-owned context as the transaction that requested it.
+		_, err := s.txnClient.WaitLogTailAppliedAt(ctx, ts)
+		return err
 	}
+	return nil
 }
 
 func (s *sqlExecutor) getCompileContext(

--- a/pkg/sql/compile/sql_executor_context_test.go
+++ b/pkg/sql/compile/sql_executor_context_test.go
@@ -16,20 +16,106 @@ package compile
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
 
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/util/resource"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
 )
+
+func TestInternalExecutorCommittedLogWaitHonorsCallerCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	txnClient := mock_frontend.NewMockTxnClient(ctrl)
+	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
+	commitTS := timestamp.Timestamp{PhysicalTime: 42}
+	txnOperator.EXPECT().Txn().Return(txn.TxnMeta{CommitTS: commitTS})
+
+	waitStarted := make(chan struct{})
+	txnClient.EXPECT().WaitLogTailAppliedAt(gomock.Any(), commitTS).DoAndReturn(
+		func(ctx context.Context, _ timestamp.Timestamp) (timestamp.Timestamp, error) {
+			close(waitStarted)
+			<-ctx.Done()
+			return timestamp.Timestamp{}, ctx.Err()
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	errC := make(chan error, 1)
+	go func() {
+		errC <- (&sqlExecutor{txnClient: txnClient}).maybeWaitCommittedLogApplied(
+			ctx,
+			executor.Options{}.
+				WithTxn(txnOperator).
+				WithWaitCommittedLogApplied(),
+		)
+	}()
+
+	select {
+	case <-waitStarted:
+	case <-time.After(time.Second):
+		t.Fatal("committed-log wait did not start")
+	}
+	cancel()
+	select {
+	case err := <-errC:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("caller cancellation did not release committed-log wait")
+	}
+}
+
+func TestInternalExecutorCommittedLogWaitContract(t *testing.T) {
+	waitErr := errors.New("logtail wait failed")
+	commitTS := timestamp.Timestamp{PhysicalTime: 42}
+
+	for _, tc := range []struct {
+		name      string
+		wait      bool
+		commitTS  timestamp.Timestamp
+		wantErr   error
+		wantCalls int
+	}{
+		{name: "disabled", commitTS: commitTS},
+		{name: "empty commit timestamp", wait: true},
+		{name: "success", wait: true, commitTS: commitTS, wantCalls: 1},
+		{name: "wait error", wait: true, commitTS: commitTS, wantErr: waitErr, wantCalls: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			txnClient := mock_frontend.NewMockTxnClient(ctrl)
+			txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
+			if tc.wait {
+				txnOperator.EXPECT().Txn().Return(txn.TxnMeta{CommitTS: tc.commitTS})
+			}
+			if tc.wantCalls == 1 {
+				txnClient.EXPECT().WaitLogTailAppliedAt(gomock.Any(), tc.commitTS).
+					Return(timestamp.Timestamp{}, tc.wantErr)
+			}
+			opts := executor.Options{}.WithTxn(txnOperator)
+			if tc.wait {
+				opts = opts.WithWaitCommittedLogApplied()
+			}
+
+			err := (&sqlExecutor{txnClient: txnClient}).maybeWaitCommittedLogApplied(
+				context.Background(), opts)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
 
 func TestNewInternalStatementContextPreservesRootAndClaimsStatsOnce(t *testing.T) {
 	root := resource.NewRoot(resource.ConnExternal)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27073

## What this PR does / why we need it:

### Root cause

`pkg/incrservice` asks the internal SQL executor to wait until a committed auto-increment update is visible in the local logtail. After committing with the caller-owned allocation context, `sqlExecutor.ExecTxn` discarded that context and called `TxnClient.SyncLatestCommitTS`. That API creates an independent five-minute background timeout and handles a failed wait with a fatal log. Consequently, allocator cancellation, its three-minute deadline, and CN shutdown could not release the post-commit wait. Under the race-UT load captured in #27073, `TestBasicCluster` remained in `sqlStore.Allocate -> SyncLatestCommitTS` until that independent timeout, and earlier runs outlived the whole UT job deadline.

The local transaction commit already advances the transaction client's latest commit timestamp through its `ClosedEvent` callback. The missing property was a cancelable visibility barrier, not another timestamp update.

### Changes

- Route the internal executor's post-commit visibility barrier through the existing `WaitLogTailAppliedAt` API with the transaction executor's caller-owned context.
- Return visibility-wait errors from `ExecTxn` after commit instead of entering the fatal background wait.
- Add deterministic unit coverage for caller cancellation, disabled waits, empty commit timestamps, successful waits, and wait-error propagation.

No retry, fallback, timeout tuning, public API, or unrelated embedded-cluster behavior is changed.

### Issue-to-test proof

- `TestInternalExecutorCommittedLogWaitHonorsCallerCancellation` deterministically enters the exact post-commit barrier, cancels its caller context, and proves the wait returns `context.Canceled` without relying on scheduler timing.
- `TestInternalExecutorCommittedLogWaitContract` covers the neighboring contract: disabled and empty-timestamp no-op paths, success, and error propagation.
- The issue's exact integration reproducer, `pkg/embed.TestBasicCluster`, passes under the race detector after the change.

BVT is not appropriate for this lifecycle defect because SQL cannot deterministically hold the internal timestamp waiter at the cancellation boundary; the focused unit test provides that synchronization with channel barriers, while `TestBasicCluster` covers the real embedded-cluster path.

### Validation

- Rebased cleanly onto `main` at `11981033c588d3fe7e6fcc50ead874dfcd88d8f8`; the upstream delta did not touch either changed file.
- `CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib" GOWORK=off go build -mod=readonly ./pkg/sql/compile`
- `CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib" GOWORK=off go vet -mod=readonly ./pkg/sql/compile`
- Focused new unit tests with `-race -count=100`: pass
- `TestBasicCluster` race measurement: `T=20.06s`; with `B=30s`, `N=1`
- `TestBasicCluster` again on the final rebased head with `-race -count=1`: pass in 25.421s
- Full `pkg/sql/compile` and dependent `pkg/incrservice`, normal and race: pass on the final rebased head
- `git diff --check origin/main...HEAD`: pass

### Residual risk

The CI resource-pressure condition that delayed logtail application is intermittent and was not forced locally. The invalid wait-for edge is independently proven by the preserved CI stack and deterministic cancellation regression; the exact embedded-cluster case also completes under race. The behavior after a visibility-wait failure changes from a process-fatal path to an error returned after commit, matching the existing `ExecTxn` error contract. Auto-increment callers may retry and skip committed values, which is already permitted for auto-increment allocation failures.
