### PR TITLE
fix: prune tombstones using merge snapshot

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -4094,6 +4094,93 @@ func TestFlushTransferTombstonesRollback(t *testing.T) {
 	tae.CheckRowsByScan(0, true)
 }
 
+func TestTombstoneMergeKeepsTargetDroppedAfterSnapshot(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	ctx := context.Background()
+	opts := config.WithLongScanAndCKPOpts(nil)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+
+	schema := catalog.MockSchemaAll(3, 2)
+	schema.Extra.BlockMaxRows = 10
+	schema.Extra.ObjectMaxBlocks = 2
+	tae.BindSchema(schema)
+	rows := catalog.MockBatch(schema, 10)
+	defer rows.Close()
+	tae.CreateRelAndAppend(rows, true)
+
+	deleteTxn, deleteRel := tae.GetRelation()
+	key := rows.Vecs[schema.GetSingleSortKeyIdx()].Get(0)
+	targetID, targetRow, err := deleteRel.GetByFilter(ctx, handle.NewEQFilter(key))
+	require.NoError(t, err)
+	require.NoError(t, deleteRel.RangeDelete(
+		targetID, targetRow, targetRow, handle.DT_Normal,
+	))
+	require.NoError(t, deleteTxn.Commit(ctx))
+
+	flushTxn, flushRel := tae.GetRelation()
+	tombstoneMetas := testutil.GetAllAppendableMetas(flushRel, true)
+	require.NotEmpty(t, tombstoneMetas)
+	flushTask, err := jobs.NewFlushTableTailTask(
+		nil, flushTxn, nil, tombstoneMetas, tae.Runtime,
+	)
+	require.NoError(t, err)
+	require.NoError(t, flushTask.OnExec(ctx))
+	require.NoError(t, flushTxn.Commit(ctx))
+
+	mergeTxn, mergeRel := tae.GetRelation()
+	var persistedTombstones []*catalog.ObjectEntry
+	it := mergeRel.MakeObjectIt(true)
+	for it.Next() {
+		meta := it.GetObject().GetMeta().(*catalog.ObjectEntry)
+		if !meta.IsAppendable() {
+			persistedTombstones = append(persistedTombstones, meta)
+		}
+	}
+	require.NoError(t, it.Close())
+	require.NotEmpty(t, persistedTombstones)
+
+	// The merge snapshot predates this object drop. Pruning against the latest
+	// catalog state would make the compaction erase a tombstone that belongs to
+	// the concurrent data-object generation.
+	dropTxn, dropRel := tae.GetRelation()
+	require.NoError(t, dropRel.SoftDeleteObject(targetID.ObjectID(), false))
+	require.NoError(t, dropTxn.Commit(ctx))
+	mergeStartTS, dropCommitTS := mergeTxn.GetStartTS(), dropTxn.GetCommitTS()
+	require.True(t, mergeStartTS.LT(&dropCommitTS))
+
+	mergeTask, err := jobs.NewMergeObjectsTask(
+		nil, mergeTxn, persistedTombstones, tae.Runtime, 0, true,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mergeTask.OnExec(ctx))
+	require.Len(t, mergeTask.GetCommitEntry().CreatedObjs, 1)
+	created := objectio.ObjectStats(mergeTask.GetCommitEntry().CreatedObjs[0])
+	require.Equal(t, uint32(1), created.Rows())
+	require.NoError(t, mergeTxn.Commit(ctx))
+
+	// The next merge starts after the target drop, so it must reclaim the now
+	// obsolete tombstone instead of retaining it indefinitely.
+	pruneTxn, pruneRel := tae.GetRelation()
+	persistedTombstones = persistedTombstones[:0]
+	it = pruneRel.MakeObjectIt(true)
+	for it.Next() {
+		meta := it.GetObject().GetMeta().(*catalog.ObjectEntry)
+		if !meta.IsAppendable() {
+			persistedTombstones = append(persistedTombstones, meta)
+		}
+	}
+	require.NoError(t, it.Close())
+	require.NotEmpty(t, persistedTombstones)
+	pruneTask, err := jobs.NewMergeObjectsTask(
+		nil, pruneTxn, persistedTombstones, tae.Runtime, 0, true,
+	)
+	require.NoError(t, err)
+	require.NoError(t, pruneTask.OnExec(ctx))
+	require.Empty(t, pruneTask.GetCommitEntry().CreatedObjs)
+	require.NoError(t, pruneTxn.Commit(ctx))
+}
+
 func TestTransferredTombstonesSyncFailureRollsBack(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -291,11 +291,12 @@ func (task *mergeObjectsTask) LoadNextBatch(
 	task.tnDataBats[objIdx] = data
 
 	if task.isTombstone {
+		mergeStartTS := task.txn.GetStartTS()
 		err = data.Vecs[0].Foreach(func(v any, isNull bool, row int) error {
 			rowID := v.(types.Rowid)
 			objectID := rowID.BorrowObjectID()
 			obj, err := task.tableEntry.GetObjectByID(objectID, false)
-			if err != nil || obj.HasDropCommitted() {
+			if err != nil || canPruneTombstoneTarget(obj, mergeStartTS) {
 				if data.Deletes == nil {
 					data.Deletes = &nulls.Nulls{}
 				}
@@ -339,6 +340,18 @@ func (task *mergeObjectsTask) LoadNextBatch(
 
 	retBatch.SetRowCount(data.Length())
 	return retBatch, data.Deletes, releaseF, nil
+}
+
+// canPruneTombstoneTarget reports whether a target data object was already
+// dropped at the tombstone merge's snapshot. A later drop belongs to a
+// concurrent data-object generation, so this merge must retain the tombstone;
+// a subsequent merge can prune it after the drop enters its snapshot.
+func canPruneTombstoneTarget(target *catalog.ObjectEntry, mergeStartTS types.TS) bool {
+	if !target.HasDropCommitted() {
+		return false
+	}
+	dropTS := target.GetDeleteAt()
+	return dropTS.LE(&mergeStartTS)
 }
 
 func (task *mergeObjectsTask) GetCommitEntry() *api.MergeCommitEntry {


### PR DESCRIPTION
## Summary

Fixes #26804.

Tombstone merge now prunes a target row only when the target object was committed as dropped at the merge transaction snapshot. A later object drop is retained for a subsequent merge, preventing concurrent data-object generations from losing tombstones.

Adds a deterministic regression covering both snapshot cases.

## Validation

- Focused test and full `pkg/vm/engine/tae/db/test` pass.
- Focused race stress (`-race -count=100`) passes.
- Full owning-package race test passes.
- Build and vet pass.
- On machine 55, the pre-fix baseline regression fails and the fixed version passes.
