### PR TITLE
fix: generate valid CLONE SQL in async Python SDK

### DIFF
--- a/clients/python/matrixone/async_client.py
+++ b/clients/python/matrixone/async_client.py
@@ -45,6 +45,7 @@ from .connection_hooks import ConnectionAction, ConnectionHook, create_connectio
 from .load_data import AsyncLoadDataManager
 from .stage import AsyncStageManager
 from .cdc import AsyncCDCManager
+from .clone import BaseCloneManager
 from .exceptions import (
     ConnectionError,
     MoCtlError,
@@ -219,11 +220,8 @@ class AsyncSnapshotManager:
             return False
 
 
-class AsyncCloneManager:
+class AsyncCloneManager(BaseCloneManager):
     """Async clone manager"""
-
-    def __init__(self, client):
-        self.client = client
 
     async def clone_database(
         self,
@@ -233,12 +231,7 @@ class AsyncCloneManager:
         if_not_exists: bool = False,
     ) -> None:
         """Clone database asynchronously"""
-        if_not_exists_clause = "IF NOT EXISTS" if if_not_exists else ""
-
-        if snapshot_name:
-            sql = f"CREATE DATABASE {target_db} {if_not_exists_clause} CLONE {source_db} FOR SNAPSHOT '{snapshot_name}'"
-        else:
-            sql = f"CREATE DATABASE {target_db} {if_not_exists_clause} CLONE {source_db}"
+        sql = self._build_clone_database_sql(target_db, source_db, snapshot_name, if_not_exists)
 
         await self.client.execute(sql)
 
@@ -250,14 +243,7 @@ class AsyncCloneManager:
         if_not_exists: bool = False,
     ) -> None:
         """Clone table asynchronously"""
-        if_not_exists_clause = "IF NOT EXISTS" if if_not_exists else ""
-
-        if snapshot_name:
-            sql = (
-                f"CREATE TABLE {target_table} {if_not_exists_clause} " f"CLONE {source_table} FOR SNAPSHOT '{snapshot_name}'"
-            )
-        else:
-            sql = f"CREATE TABLE {target_table} {if_not_exists_clause} CLONE {source_table}"
+        sql = self._build_clone_table_sql(target_table, source_table, snapshot_name, if_not_exists)
 
         await self.client.execute(sql)
 

--- a/clients/python/matrixone/clone.py
+++ b/clients/python/matrixone/clone.py
@@ -49,6 +49,19 @@ class BaseCloneManager:
         """Get the executor for SQL execution (session or client)"""
         return self.executor if self.executor else self.client
 
+    def _build_clone_sql(
+        self,
+        object_type: str,
+        target_name: str,
+        source_name: str,
+        snapshot_name: Optional[str] = None,
+        if_not_exists: bool = False,
+    ) -> str:
+        """Build a CREATE ... CLONE SQL statement."""
+        if_not_exists_clause = "IF NOT EXISTS " if if_not_exists else ""
+        snapshot_clause = f' {{snapshot = "{snapshot_name}"}}' if snapshot_name else ""
+        return f"CREATE {object_type} {if_not_exists_clause}{target_name} CLONE {source_name}{snapshot_clause}"
+
     def _build_clone_database_sql(
         self,
         target_db: str,
@@ -57,14 +70,7 @@ class BaseCloneManager:
         if_not_exists: bool = False,
     ) -> str:
         """Build CLONE DATABASE SQL statement"""
-        if_not_exists_clause = "IF NOT EXISTS " if if_not_exists else ""
-
-        if snapshot_name:
-            return (
-                f"CREATE DATABASE {if_not_exists_clause}{target_db} " f"CLONE {source_db} {{snapshot = \"{snapshot_name}\"}}"
-            )
-        else:
-            return f"CREATE DATABASE {if_not_exists_clause}{target_db} CLONE {source_db}"
+        return self._build_clone_sql("DATABASE", target_db, source_db, snapshot_name, if_not_exists)
 
     def _build_clone_table_sql(
         self,
@@ -74,15 +80,7 @@ class BaseCloneManager:
         if_not_exists: bool = False,
     ) -> str:
         """Build CLONE TABLE SQL statement"""
-        if_not_exists_clause = "IF NOT EXISTS " if if_not_exists else ""
-
-        if snapshot_name:
-            return (
-                f"CREATE TABLE {if_not_exists_clause}{target_table} "
-                f"CLONE {source_table} {{snapshot = \"{snapshot_name}\"}}"
-            )
-        else:
-            return f"CREATE TABLE {if_not_exists_clause}{target_table} CLONE {source_table}"
+        return self._build_clone_sql("TABLE", target_table, source_table, snapshot_name, if_not_exists)
 
 
 class CloneManager(BaseCloneManager):

--- a/clients/python/tests/offline/test_async_client_query_comprehensive.py
+++ b/clients/python/tests/offline/test_async_client_query_comprehensive.py
@@ -636,7 +636,7 @@ class TestAsyncCloneManager(unittest.IsolatedAsyncioTestCase):
 
         await self.clone_manager.clone_database("target_db", "source_db")
 
-        self.mock_client.execute.assert_called_once_with("CREATE DATABASE target_db  CLONE source_db")
+        self.mock_client.execute.assert_called_once_with("CREATE DATABASE target_db CLONE source_db")
 
     async def test_clone_database_with_snapshot(self):
         """Test cloning database with snapshot"""
@@ -645,7 +645,7 @@ class TestAsyncCloneManager(unittest.IsolatedAsyncioTestCase):
         await self.clone_manager.clone_database_with_snapshot("target_db", "source_db", "test_snapshot")
 
         self.mock_client.execute.assert_called_once_with(
-            "CREATE DATABASE target_db  CLONE source_db FOR SNAPSHOT 'test_snapshot'"
+            'CREATE DATABASE target_db CLONE source_db {snapshot = "test_snapshot"}'
         )
 
     async def test_clone_database_if_not_exists(self):
@@ -654,7 +654,19 @@ class TestAsyncCloneManager(unittest.IsolatedAsyncioTestCase):
 
         await self.clone_manager.clone_database("target_db", "source_db", if_not_exists=True)
 
-        self.mock_client.execute.assert_called_once_with("CREATE DATABASE target_db IF NOT EXISTS CLONE source_db")
+        self.mock_client.execute.assert_called_once_with("CREATE DATABASE IF NOT EXISTS target_db CLONE source_db")
+
+    async def test_clone_database_with_snapshot_and_if_not_exists(self):
+        """Test cloning database with both grammar options"""
+        self.mock_client.execute.return_value = AsyncResultSet([], [])
+
+        await self.clone_manager.clone_database(
+            "target_db", "source_db", snapshot_name="test_snapshot", if_not_exists=True
+        )
+
+        self.mock_client.execute.assert_called_once_with(
+            'CREATE DATABASE IF NOT EXISTS target_db CLONE source_db {snapshot = "test_snapshot"}'
+        )
 
     async def test_clone_table(self):
         """Test cloning table"""
@@ -662,7 +674,7 @@ class TestAsyncCloneManager(unittest.IsolatedAsyncioTestCase):
 
         await self.clone_manager.clone_table("target_table", "source_table")
 
-        self.mock_client.execute.assert_called_once_with("CREATE TABLE target_table  CLONE source_table")
+        self.mock_client.execute.assert_called_once_with("CREATE TABLE target_table CLONE source_table")
 
     async def test_clone_table_with_snapshot(self):
         """Test cloning table with snapshot"""
@@ -671,7 +683,27 @@ class TestAsyncCloneManager(unittest.IsolatedAsyncioTestCase):
         await self.clone_manager.clone_table_with_snapshot("target_table", "source_table", "test_snapshot")
 
         self.mock_client.execute.assert_called_once_with(
-            "CREATE TABLE target_table  CLONE source_table FOR SNAPSHOT 'test_snapshot'"
+            'CREATE TABLE target_table CLONE source_table {snapshot = "test_snapshot"}'
+        )
+
+    async def test_clone_table_if_not_exists(self):
+        """Test cloning table with if not exists"""
+        self.mock_client.execute.return_value = AsyncResultSet([], [])
+
+        await self.clone_manager.clone_table("target_table", "source_table", if_not_exists=True)
+
+        self.mock_client.execute.assert_called_once_with("CREATE TABLE IF NOT EXISTS target_table CLONE source_table")
+
+    async def test_clone_table_with_snapshot_and_if_not_exists(self):
+        """Test cloning table with both grammar options"""
+        self.mock_client.execute.return_value = AsyncResultSet([], [])
+
+        await self.clone_manager.clone_table(
+            "target_table", "source_table", snapshot_name="test_snapshot", if_not_exists=True
+        )
+
+        self.mock_client.execute.assert_called_once_with(
+            'CREATE TABLE IF NOT EXISTS target_table CLONE source_table {snapshot = "test_snapshot"}'
         )
 
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27087

## What this PR does / why we need it:

### Root cause

The public `AsyncCloneManager` in `clients/python/matrixone/async_client.py` had its own SQL construction. It placed `IF NOT EXISTS` after the destination name and emitted snapshots as `FOR SNAPSHOT 'name'`, while MatrixOne's CLONE grammar requires `IF NOT EXISTS` before the destination and brace-form snapshot options.

### Changes

- Centralize database/table CLONE SQL construction in `BaseCloneManager`.
- Make the legacy async manager reuse that shared builder instead of duplicating SQL assembly.
- Generate grammar-compatible SQL for both database and table clone operations, including snapshot-only, `IF NOT EXISTS`-only, and combined options.
- Preserve the existing brace-form double-quoted snapshot representation already used by the shared clone builder.

### Issue-to-test proof

`TestAsyncCloneManager` now asserts the exact SQL sent to the executor for both database and table cloning across:

- current-state clone;
- snapshot clone;
- `IF NOT EXISTS` clone; and
- snapshot plus `IF NOT EXISTS` (the issue reproduction combination).

A parser-level check also accepted the resulting table/database forms and rejected the legacy `FOR SNAPSHOT` form.

### Tests

- `cd clients/python && python -m pytest tests/offline/ -v --tb=short`
- `cd clients/python && python -m pytest tests/offline/test_async_client_query_comprehensive.py -q -k 'TestAsyncCloneManager'`
- `cd clients/python && python -m pytest tests/offline/test_clone_builder.py -q`
- `cd clients/python && python -m pytest tests/offline/test_sqlalchemy_integration.py -q`
- `cd clients/python && python -m pytest tests/offline/test_unified_transaction.py -q`
- `PYTHONPATH=clients/python python -m compileall -q clients/python/matrixone/clone.py clients/python/matrixone/async_client.py`

The online suite was not run because it requires a live MatrixOne service; this change is covered by deterministic SDK unit tests and the server parser grammar check.

### Residual risks

No execution, transaction, or identifier-handling behavior was changed. Snapshot-name escaping remains governed by the SDK's existing interpolation behavior and is outside this issue's scope.
