### PR TITLE
test: cut resource-heavy UT wall time

### DIFF
--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -491,7 +491,7 @@ function run_tests(){
     echo "#  UT TIMEOUT:      $UT_TIMEOUT"
     echo "#  UT PARALLEL:     $UT_PARALLEL"
     echo "#  CLUSTER ADMISSION: process lifecycle"
-    echo "#  HEAVY RACE UT:   $HEAVY_RACE_PARALLEL package slots (+1 low-CPU engine shard)"
+    echo "#  HEAVY RACE UT:   $HEAVY_RACE_PARALLEL total package slots"
     horiz_rule
 
     logger "INF" "Clean go test cache"
@@ -660,15 +660,13 @@ function run_tests(){
             # engine/test is dominated by serial fixture lifecycles inside one
             # process. Build it once and split every discovered top-level test
             # across fresh race processes. The effective shard count and the
-            # remaining go-test parallelism use one extra process over the old
-            # package budget. Locally the two shards peak at 3.75 GB combined,
-            # only 1.1 GB above the old single process, while cutting runtime
-            # from 179s to 97s. Low custom budgets keep sequential waves.
+            # remaining go-test parallelism share HEAVY_RACE_PARALLEL as one
+            # strict process budget. Low custom budgets use sequential waves.
             engine_race_parallel=${ENGINE_RACE_SHARDS}
             if (( engine_race_parallel > HEAVY_RACE_PARALLEL )); then
                 engine_race_parallel=${HEAVY_RACE_PARALLEL}
             fi
-            resource_heavy_parallel=$(( HEAVY_RACE_PARALLEL - engine_race_parallel + 1 ))
+            resource_heavy_parallel=$(( HEAVY_RACE_PARALLEL - engine_race_parallel ))
             if (( HEAVY_RACE_PARALLEL <= engine_race_parallel )); then
                 resource_heavy_parallel=0
             fi

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -43,6 +43,9 @@ UT_TIMEOUT=${UT_TIMEOUT:-"15"}
 UT_PARALLEL=${UT_PARALLEL:-"1"}
 HEAVY_RACE_PARALLEL=${HEAVY_RACE_PARALLEL:-"3"}
 PLAN_RACE_SHARDS=${PLAN_RACE_SHARDS:-"8"}
+# Two shards cut the measured engine/test race runtime roughly in half while
+# keeping the default heavy-stage memory/process budget bounded.
+ENGINE_RACE_SHARDS=2
 SCA_REPORT="$G_WKSP/$G_TS-SCA-Report.out"
 UT_REPORT="$G_WKSP/$G_TS-UT-Report.out"
 UT_FILTER="$G_WKSP/$G_TS-UT-Filter.out"
@@ -52,6 +55,9 @@ RAW_COVERAGE="coverage.out"
 IS_BUILD_FAIL=""
 UT_TEST_STATUS=0
 PLAN_RACE_TEST_BINARY=""
+ENGINE_RACE_TEST_BINARY=""
+ENGINE_RACE_JOB_PID=""
+ENGINE_RACE_REPORT=""
 TAGS="matrixone_test"
 GO_MODULE_MODE="-mod=readonly"
 # Static analysis owns vet in the separate SCA job. Running it again for every
@@ -105,8 +111,56 @@ function report_active_ut_cases(){
         sed 's/^/[active_ut_cases] /'
 }
 
+function report_cgroup_memory_usage(){
+    local label=$1
+    local relative_path=""
+    local cgroup_path=""
+    local events=""
+
+    if [[ ! -r /proc/self/cgroup ]]; then
+        return 0
+    fi
+
+    relative_path=$(awk -F: '$1 == "0" { print $3; exit }' /proc/self/cgroup)
+    if [[ -n "${relative_path}" ]]; then
+        cgroup_path="/sys/fs/cgroup${relative_path}"
+        if [[ -r "${cgroup_path}/memory.peak" ]]; then
+            events=$(tr '\n' ' ' < "${cgroup_path}/memory.events")
+            logger "INF" "${label} cgroup memory: current=$(< "${cgroup_path}/memory.current") peak=$(< "${cgroup_path}/memory.peak") events=${events}"
+            return 0
+        fi
+    fi
+
+    relative_path=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' /proc/self/cgroup)
+    cgroup_path="/sys/fs/cgroup/memory${relative_path}"
+    if [[ -r "${cgroup_path}/memory.max_usage_in_bytes" ]]; then
+        logger "INF" "${label} cgroup memory: current=$(< "${cgroup_path}/memory.usage_in_bytes") peak=$(< "${cgroup_path}/memory.max_usage_in_bytes") failcnt=$(< "${cgroup_path}/memory.failcnt")"
+    fi
+}
+
 function handle_ut_termination(){
     trap - TERM
+    if [[ -n "${ENGINE_RACE_JOB_PID}" ]]; then
+        kill -TERM "${ENGINE_RACE_JOB_PID}" 2>/dev/null || true
+        wait "${ENGINE_RACE_JOB_PID}" 2>/dev/null || true
+        ENGINE_RACE_JOB_PID=""
+    fi
+    if [[ -n "${ENGINE_RACE_REPORT}" ]]; then
+        local partial_report
+        for partial_report in "${ENGINE_RACE_REPORT}".*; do
+            if [[ -f "${partial_report}" ]]; then
+                cat "${partial_report}" >> "${UT_REPORT}"
+            fi
+        done
+    fi
+    if [[ -n "${ENGINE_RACE_TEST_BINARY}" ]]; then
+        rm -f "${ENGINE_RACE_TEST_BINARY}"
+        ENGINE_RACE_TEST_BINARY=""
+    fi
+    if [[ -n "${ENGINE_RACE_REPORT}" ]]; then
+        rm -f "${ENGINE_RACE_REPORT}" "${ENGINE_RACE_REPORT}".*
+        ENGINE_RACE_REPORT=""
+    fi
     if [[ -n "${PLAN_RACE_TEST_BINARY}" ]]; then
         rm -f "${PLAN_RACE_TEST_BINARY}"
         PLAN_RACE_TEST_BINARY=""
@@ -114,6 +168,172 @@ function handle_ut_termination(){
     logger "ERR" "UT runner received SIGTERM; reporting work without terminal Go test events"
     report_active_ut_cases
     exit 143
+}
+
+function run_engine_race_shards(){
+    local engine_package=$1
+    local engine_race_shards=$2
+    local test_list="${G_WKSP}/${G_TS}-engine-race-tests.out"
+    local build_log="${G_WKSP}/${G_TS}-engine-race-build.out"
+    local metadata_file="${G_WKSP}/${G_TS}-engine-race-package.out"
+    local engine_package_dir=""
+    local engine_package_import=""
+    local build_status=0
+    local list_status=0
+    local shard_status=0
+    local wait_status=0
+    local test_name=""
+    local shard=0
+    local test_count=0
+    local pid=""
+    local metadata_status=0
+    local -a child_pids=(0)
+    local -a shard_patterns
+    local -a shard_counts
+    local -a shard_pids
+    local -a shard_reports
+
+    if ! [[ "${engine_race_shards}" =~ ^[1-9][0-9]*$ ]] ||
+        (( engine_race_shards > ENGINE_RACE_SHARDS )); then
+        logger "ERR" "engine race shard count must be 1 or ${ENGINE_RACE_SHARDS}, got '${engine_race_shards}'"
+        return 2
+    fi
+
+    trap 'for pid in "${child_pids[@]}"; do if (( pid > 0 )); then kill -TERM -- "-${pid}" 2>/dev/null || true; fi; done; wait; rm -f "${metadata_file}"; exit 143' TERM
+    set -m
+    go list ${GO_MODULE_MODE} \
+        -f '{{.Dir}}{{"\t"}}{{.ImportPath}}' "${engine_package}" \
+        > "${metadata_file}" 2>&1 &
+    child_pids=("$!")
+    set +m
+    wait "${child_pids[0]}"
+    metadata_status=$?
+    child_pids=(0)
+    if (( metadata_status != 0 )) ||
+        ! IFS=$'\t' read -r engine_package_dir engine_package_import < "${metadata_file}"; then
+        logger "ERR" "Failed to resolve package metadata for ${engine_package}"
+        tail -n 200 "${metadata_file}"
+        rm -f "${metadata_file}"
+        trap - TERM
+        set +m
+        return 2
+    fi
+    rm -f "${metadata_file}"
+
+    : > "${ENGINE_RACE_REPORT}"
+    set -m
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+        CGO_CFLAGS="${CGO_CFLAGS}" \
+        CGO_LDFLAGS="${CGO_LDFLAGS}" \
+        go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -race -tags "${TAGS}" \
+        -p 1 -c -o "${ENGINE_RACE_TEST_BINARY}" "${engine_package}" > "${build_log}" 2>&1 &
+    child_pids=("$!")
+    set +m
+    wait "${child_pids[0]}"
+    build_status=$?
+    child_pids=(0)
+    if (( build_status != 0 )); then
+        logger "ERR" "Failed to build race test binary for ${engine_package}"
+        tail -n 200 "${build_log}"
+        trap - TERM
+        set +m
+        return "${build_status}"
+    fi
+
+    set -m
+    (
+        cd "${engine_package_dir}" || exit 2
+        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+            "${ENGINE_RACE_TEST_BINARY}" -test.short=true \
+            -test.list='^(Test|Fuzz|Example)'
+    ) > "${test_list}" 2>&1 &
+    child_pids=("$!")
+    set +m
+    wait "${child_pids[0]}"
+    list_status=$?
+    child_pids=(0)
+    if (( list_status != 0 )); then
+        logger "ERR" "Failed to list tests for ${engine_package}"
+        tail -n 200 "${test_list}"
+        trap - TERM
+        set +m
+        return "${list_status}"
+    fi
+
+    for (( shard = 0; shard < engine_race_shards; shard++ )); do
+        shard_patterns[shard]='^('
+        shard_counts[shard]=0
+        shard_reports[shard]="${ENGINE_RACE_REPORT}.$(( shard + 1 ))"
+        : > "${shard_reports[shard]}"
+    done
+
+    # Alternate source-ordered top-level tests. This keeps adjacent tests from
+    # the same large fixture file in different processes, automatically covers
+    # newly added tests, and avoids a stale hand-maintained allowlist.
+    while IFS= read -r test_name; do
+        case "${test_name}" in
+            Test*|Fuzz*|Example*) ;;
+            *) continue ;;
+        esac
+        shard=$(( test_count % engine_race_shards ))
+        if (( shard_counts[shard] > 0 )); then
+            shard_patterns[shard]+='|'
+        fi
+        shard_patterns[shard]+="${test_name}"
+        shard_counts[shard]=$(( shard_counts[shard] + 1 ))
+        test_count=$(( test_count + 1 ))
+    done < "${test_list}"
+
+    if (( test_count == 0 )); then
+        logger "ERR" "No tests discovered for ${engine_package}"
+        trap - TERM
+        set +m
+        return 2
+    fi
+
+    logger "INF" "Run ${test_count} tests in ${engine_package} across ${engine_race_shards} concurrent fresh race-detector processes"
+    set -m
+    for (( shard = 0; shard < engine_race_shards; shard++ )); do
+        if (( shard_counts[shard] == 0 )); then
+            continue
+        fi
+        shard_patterns[shard]+=')$'
+        logger "INF" "Start ${engine_package} race shard $(( shard + 1 ))/${engine_race_shards} (${shard_counts[shard]} tests)"
+        (
+            cd "${engine_package_dir}" || exit 2
+            LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+                go tool test2json -t -p "${engine_package_import}" \
+                "${ENGINE_RACE_TEST_BINARY}" -test.short=true -test.v=test2json \
+                -test.paniconexit0=true -test.count=1 \
+                -test.timeout="${UT_TIMEOUT}m" \
+                -test.run="${shard_patterns[shard]}"
+        ) > "${shard_reports[shard]}" &
+        shard_pids[shard]=$!
+        child_pids[shard]=${shard_pids[shard]}
+    done
+    set +m
+
+    # Job control gives each shard (test2json and its test-binary child) a
+    # distinct process group, so cancellation cannot strand a race process.
+    for (( shard = 0; shard < engine_race_shards; shard++ )); do
+        if (( shard_counts[shard] == 0 )); then
+            continue
+        fi
+        pid=${shard_pids[shard]}
+        wait "${pid}"
+        wait_status=$?
+        child_pids[shard]=0
+        if (( wait_status != 0 )); then
+            shard_status=1
+            logger "ERR" "${engine_package} race shard $(( shard + 1 )) failed with status ${wait_status}"
+        fi
+        cat "${shard_reports[shard]}" >> "${ENGINE_RACE_REPORT}"
+    done
+    trap - TERM
+
+    rm -f "${ENGINE_RACE_TEST_BINARY}" "${ENGINE_RACE_REPORT}".*
+    ENGINE_RACE_TEST_BINARY=""
+    return "${shard_status}"
 }
 
 function run_vet(){
@@ -271,7 +491,7 @@ function run_tests(){
     echo "#  UT TIMEOUT:      $UT_TIMEOUT"
     echo "#  UT PARALLEL:     $UT_PARALLEL"
     echo "#  CLUSTER ADMISSION: process lifecycle"
-    echo "#  HEAVY RACE UT:   $HEAVY_RACE_PARALLEL"
+    echo "#  HEAVY RACE UT:   $HEAVY_RACE_PARALLEL package slots (+1 low-CPU engine shard)"
     horiz_rule
 
     logger "INF" "Clean go test cache"
@@ -305,6 +525,7 @@ function run_tests(){
     else
         logger "INF" "Run UT with race check"
         local plan_package
+        local engine_package
         local serial_test_scope
         local cluster_test_scope
         local resource_heavy_test_scope
@@ -316,7 +537,11 @@ function run_tests(){
         local serial_status=0
         local cluster_status=0
         local resource_heavy_status=0
+        local engine_status=0
         local plan_status=0
+        local resource_heavy_parallel=1
+        local engine_race_parallel=1
+        local shard_engine=1
 
         if ! [[ "${HEAVY_RACE_PARALLEL}" =~ ^[1-9][0-9]*$ ]] ||
             (( HEAVY_RACE_PARALLEL > 64 )); then
@@ -330,6 +555,11 @@ function run_tests(){
 
         if ! plan_package=$(go list ${GO_MODULE_MODE} ./pkg/sql/plan); then
             logger "ERR" "Failed to resolve ./pkg/sql/plan"
+            UT_TEST_STATUS=1
+            return 0
+        fi
+        if ! engine_package=$(go list ${GO_MODULE_MODE} ./pkg/vm/engine/test); then
+            logger "ERR" "Failed to resolve ./pkg/vm/engine/test"
             UT_TEST_STATUS=1
             return 0
         fi
@@ -365,11 +595,19 @@ function run_tests(){
             "${plan_package}" \
             ${serial_test_scope})
 
+        # Dependency-based group precedence remains authoritative. If this
+        # package ever starts owning an embedded cluster, keep it in that
+        # serialized lifecycle group instead of running it a second time here.
+        if printf '%s\n%s\n' "${serial_test_scope}" "${cluster_test_scope}" |
+            grep -Fxq "${engine_package}"; then
+            shard_engine=0
+            logger "INF" "Keep ${engine_package} in its higher-precedence race-test group"
+        fi
+
         if ! resource_heavy_test_scope=$(go list ${GO_MODULE_MODE} \
             ./pkg/backup \
             ./pkg/fileservice \
             ./pkg/sql/plan/function \
-            ./pkg/vm/engine/test \
             ./pkg/vm/engine/tae/db/test); then
             logger "ERR" "Failed to resolve resource-heavy race-test packages"
             UT_TEST_STATUS=1
@@ -378,12 +616,14 @@ function run_tests(){
         resource_heavy_test_scope=$(remove_packages_from_scope \
             "${resource_heavy_test_scope}" \
             "${plan_package}" \
+            "${engine_package}" \
             ${serial_test_scope} \
             ${cluster_test_scope})
 
         light_test_scope=$(remove_packages_from_scope \
             "${test_scope}" \
             "${plan_package}" \
+            "${engine_package}" \
             ${serial_test_scope} \
             ${cluster_test_scope} \
             ${resource_heavy_test_scope})
@@ -416,14 +656,67 @@ function run_tests(){
         LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p "${cluster_package_parallel}" -timeout "${UT_TIMEOUT}m" -race $cluster_test_scope >> $UT_REPORT
         cluster_status=$?
 
-        logger "INF" "Run resource-heavy race-test packages with parallelism ${HEAVY_RACE_PARALLEL}"
-        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p ${HEAVY_RACE_PARALLEL} -timeout "${UT_TIMEOUT}m" -race $resource_heavy_test_scope >> $UT_REPORT
+        if (( shard_engine == 1 )); then
+            # engine/test is dominated by serial fixture lifecycles inside one
+            # process. Build it once and split every discovered top-level test
+            # across fresh race processes. The effective shard count and the
+            # remaining go-test parallelism use one extra process over the old
+            # package budget. Locally the two shards peak at 3.75 GB combined,
+            # only 1.1 GB above the old single process, while cutting runtime
+            # from 179s to 97s. Low custom budgets keep sequential waves.
+            engine_race_parallel=${ENGINE_RACE_SHARDS}
+            if (( engine_race_parallel > HEAVY_RACE_PARALLEL )); then
+                engine_race_parallel=${HEAVY_RACE_PARALLEL}
+            fi
+            resource_heavy_parallel=$(( HEAVY_RACE_PARALLEL - engine_race_parallel + 1 ))
+            if (( HEAVY_RACE_PARALLEL <= engine_race_parallel )); then
+                resource_heavy_parallel=0
+            fi
+            ENGINE_RACE_TEST_BINARY="${G_WKSP}/${G_TS}-engine-race.test"
+            ENGINE_RACE_REPORT="${G_WKSP}/${G_TS}-engine-race-report.out"
+
+            if (( resource_heavy_parallel > 0 )); then
+                run_engine_race_shards "${engine_package}" "${engine_race_parallel}" &
+                ENGINE_RACE_JOB_PID=$!
+            else
+                resource_heavy_parallel=${HEAVY_RACE_PARALLEL}
+            fi
+        else
+            resource_heavy_parallel=${HEAVY_RACE_PARALLEL}
+        fi
+
+        logger "INF" "Run remaining resource-heavy race-test packages with parallelism ${resource_heavy_parallel}"
+        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p ${resource_heavy_parallel} -timeout "${UT_TIMEOUT}m" -race $resource_heavy_test_scope >> $UT_REPORT
         resource_heavy_status=$?
+
+        if (( shard_engine == 1 )); then
+            if [[ -n "${ENGINE_RACE_JOB_PID}" ]]; then
+                wait "${ENGINE_RACE_JOB_PID}"
+                engine_status=$?
+                ENGINE_RACE_JOB_PID=""
+            else
+                # Keep the helper's process-group TERM trap scoped to a
+                # subshell even when a low budget requires sequential waves.
+                run_engine_race_shards "${engine_package}" "${engine_race_parallel}" &
+                ENGINE_RACE_JOB_PID=$!
+                wait "${ENGINE_RACE_JOB_PID}"
+                engine_status=$?
+                ENGINE_RACE_JOB_PID=""
+            fi
+            if [[ -s "${ENGINE_RACE_REPORT}" ]]; then
+                cat "${ENGINE_RACE_REPORT}" >> "${UT_REPORT}"
+            fi
+            rm -f "${ENGINE_RACE_TEST_BINARY}" "${ENGINE_RACE_REPORT}" "${ENGINE_RACE_REPORT}".*
+            ENGINE_RACE_TEST_BINARY=""
+            ENGINE_RACE_REPORT=""
+        fi
+
+        report_cgroup_memory_usage "Resource-heavy UT"
 
         run_plan_race_shards "${plan_package}"
         plan_status=$?
 
-        if (( light_status != 0 || serial_status != 0 || cluster_status != 0 || resource_heavy_status != 0 || plan_status != 0 )); then
+        if (( light_status != 0 || serial_status != 0 || cluster_status != 0 || resource_heavy_status != 0 || engine_status != 0 || plan_status != 0 )); then
             UT_TEST_STATUS=1
         fi
     fi

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -1358,19 +1358,11 @@ func TestNewClientWithMOCluster(t *testing.T) {
 				},
 			}))
 	defer cluster.Close()
-	var newClientFailed bool
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				newClientFailed = true
-			}
-		}()
-		_, err := NewClient(sid, morpc.Config{})
-		if err != nil {
-			newClientFailed = true
-		}
-	}()
-	require.True(t, newClientFailed, "new LockService Client without a process-level cluster nor a custom cluster should fail")
+	// The custom cluster is the dependency under test. Assert the process-level
+	// fallback is absent directly instead of spending the legacy ten-second
+	// GetMOCluster startup timeout proving the same precondition indirectly.
+	_, ok := runtime.ServiceRuntime(sid).GetGlobalVariables(runtime.ClusterService)
+	require.False(t, ok)
 	c, err := NewClient(sid, morpc.Config{}, WithMOCluster(cluster))
 	require.NoError(t, err)
 	defer func() {

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -1925,7 +1925,7 @@ func TestIssue17655(t *testing.T) {
 				option)
 			require.True(t, moerr.IsMoErrCode(err, moerr.ErrNewTxnInCNRollingRestart))
 		},
-		nil,
+		accelerateLockKeeperForShortTest,
 	)
 }
 
@@ -1994,7 +1994,7 @@ func TestIssue3537(t *testing.T) {
 				}
 			}
 		},
-		nil,
+		accelerateLockKeeperForShortTest,
 	)
 }
 
@@ -2053,7 +2053,7 @@ func TestIssue3537_2(t *testing.T) {
 				}
 			}
 		},
-		nil,
+		accelerateLockKeeperForShortTest,
 	)
 }
 
@@ -2112,16 +2112,20 @@ func TestIssue3537_3(t *testing.T) {
 				}
 			}
 		},
-		nil,
+		accelerateLockKeeperForShortTest,
 	)
 }
 
 func TestIssue3288(t *testing.T) {
+	bindTimeout := time.Second
+	if testing.Short() {
+		bindTimeout = 200 * time.Millisecond
+	}
 	runLockServiceTestsWithLevel(
 		t,
 		zapcore.DebugLevel,
 		[]string{"s1", "s2"},
-		time.Second*1,
+		bindTimeout,
 		func(alloc *lockTableAllocator, s []*service) {
 			l1 := s[0]
 			l2 := s[1]
@@ -2180,7 +2184,7 @@ func TestIssue3288(t *testing.T) {
 			_ = result
 
 		},
-		nil,
+		accelerateLockKeeperForFastBindTimeout,
 	)
 }
 
@@ -2255,7 +2259,7 @@ func TestIssue3538(t *testing.T) {
 				}
 			}
 		},
-		nil,
+		accelerateLockKeeperForShortTest,
 	)
 }
 
@@ -2433,7 +2437,7 @@ func TestReLockSuccWithReStartCN(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, l1.Unlock(ctx, []byte("txn2"), timestamp.Timestamp{}))
 		},
-		nil,
+		accelerateLockKeeperForShortTest,
 	)
 }
 
@@ -2510,7 +2514,7 @@ func TestCheckTxnTimeout(t *testing.T) {
 				return l2.activeTxnHolder.empty()
 			}, time.Second*10, time.Millisecond*10)
 		},
-		nil,
+		accelerateLockKeeperForShortTest,
 	)
 }
 
@@ -5380,9 +5384,35 @@ func TestLeakWaiterForErr(t *testing.T) {
 			ll, err := l1.getLockTableWithCreate(context.Background(), 0, tableID, nil, pb.Sharding_None)
 			require.NoError(t, err)
 			lt := ll.(*localLockTable)
+			afterRangeWait := make(chan struct{})
+			resumeRangeLock := make(chan struct{})
+			waitForRangeRetry := func() {
+				select {
+				case <-afterRangeWait:
+				case <-ctx.Done():
+					require.FailNow(t, "range lock did not reach the retry barrier")
+				}
+			}
+			resumeRangeRetry := func() {
+				select {
+				case resumeRangeLock <- struct{}{}:
+				case <-ctx.Done():
+					require.FailNow(t, "range lock retry barrier was not waiting")
+				}
+			}
 			lt.options.afterWait = func(c *lockContext) func() {
 				if c.opts.Granularity == pb.Granularity_Range {
-					time.Sleep(time.Second)
+					return func() {
+						select {
+						case afterRangeWait <- struct{}{}:
+						case <-ctx.Done():
+							return
+						}
+						select {
+						case <-resumeRangeLock:
+						case <-ctx.Done():
+						}
+					}
 				}
 				return func() {}
 			}
@@ -5415,21 +5445,26 @@ func TestLeakWaiterForErr(t *testing.T) {
 			lt.mu.Unlock()
 
 			require.NoError(t, l1.Unlock(ctx, txn1, timestamp.Timestamp{}))
+			waitForRangeRetry()
 
 			_, err = l1.Lock(ctx, tableID, row5, txn2, newTestRowExclusiveOptions())
 			require.NoError(t, err)
+			resumeRangeRetry()
 			require.NoError(t, WaitWaiters(l1, 0, tableID, row5[0], 1))
 			require.NoError(t, l1.Unlock(ctx, txn2, timestamp.Timestamp{}))
+			waitForRangeRetry()
 
 			_, err = l1.Lock(ctx, tableID, row2, txn3, newTestRowExclusiveOptions())
 			require.NoError(t, err)
+			resumeRangeRetry()
 			require.NoError(t, WaitWaiters(l1, 0, tableID, row2[0], 1))
 			require.NoError(t, l1.Unlock(ctx, txn3, timestamp.Timestamp{}))
+			waitForRangeRetry()
+			resumeRangeRetry()
 
 			wg.Wait()
 			require.NoError(t, l1.Unlock(ctx, txn4, timestamp.Timestamp{}))
 
-			time.Sleep(500 * time.Millisecond)
 			require.NotEqual(t, int32(1), wt.refCount.Load())
 		},
 	)
@@ -6328,6 +6363,25 @@ func runLockServiceTestsWithLevel(
 			})
 		},
 	)
+}
+
+// accelerateLockKeeperForShortTest preserves the rolling-restart state
+// machine while avoiding production-scale heartbeat periods in the short CI
+// suite. The allocator timeout remains one second, so a healthy service still
+// refreshes its bind well inside the invalidation grace period.
+func accelerateLockKeeperForShortTest(cfg *Config) {
+	if testing.Short() {
+		cfg.KeepBindDuration.Duration = 200 * time.Millisecond
+	}
+}
+
+// TestIssue3288 uses a 200ms allocator timeout in the short suite. Keep live
+// service heartbeats comfortably inside that window so only the closed owner
+// becomes an invalid-bind candidate.
+func accelerateLockKeeperForFastBindTimeout(cfg *Config) {
+	if testing.Short() {
+		cfg.KeepBindDuration.Duration = 40 * time.Millisecond
+	}
 }
 
 func waitWaiters(

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -12341,7 +12341,9 @@ func TestPersistTransferTable(t *testing.T) {
 	}
 	page.SetPath(path)
 
-	time.Sleep(2 * time.Second)
+	// Expire only the in-memory representation. Advancing the page timestamp
+	// keeps this TTL boundary test deterministic under slow CI scheduling.
+	page.SetBornTS(time.Now().Add(-2 * time.Second))
 	tae.Runtime.TransferTable.RunTTL()
 	assert.True(t, page.IsPersist())
 	for i := 0; i < 10; i++ {
@@ -12414,7 +12416,8 @@ func TestClearPersistTransferTable(t *testing.T) {
 			}
 			page.SetPath(path)
 
-			time.Sleep(2 * time.Second)
+			// Expire the persisted representation without a wall-clock sleep.
+			page.SetBornTS(time.Now().Add(-3 * time.Second))
 			tae.Runtime.TransferTable.RunTTL()
 			_, err = tae.Runtime.TransferTable.Pin(*page.ID())
 			assert.True(t, errors.Is(err, moerr.GetOkExpectedEOB()))

--- a/pkg/vm/engine/tae/model/transfer_test.go
+++ b/pkg/vm/engine/tae/model/transfer_test.go
@@ -124,7 +124,9 @@ func TestTransferTable(t *testing.T) {
 
 	table.RunTTL()
 	assert.Equal(t, 1, table.Len())
-	time.Sleep(2 * time.Second)
+	// Advance the page's logical age instead of making the test depend on wall
+	// clock scheduling. The first RunTTL above still covers the unexpired path.
+	page1.SetBornTS(time.Now().Add(-page1.diskTTL - time.Second))
 	table.RunTTL()
 	assert.Equal(t, 0, table.Len())
 

--- a/pkg/vm/engine/test/txn_table_starcount_test.go
+++ b/pkg/vm/engine/test/txn_table_starcount_test.go
@@ -39,6 +39,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestStarCountBasic covers both the zero-row boundary and a fresh transaction
+// reading committed rows. A separate "readonly" test used the same ordinary
+// transaction path and duplicated this second assertion.
 func TestStarCountBasic(t *testing.T) {
 	catalog.SetupDefines("")
 
@@ -129,140 +132,33 @@ func TestStarCountBasic(t *testing.T) {
 
 	err = txn.Commit(ctx)
 	require.NoError(t, err)
-}
 
-func TestStarCountWithUncommittedInserts(t *testing.T) {
-	catalog.SetupDefines("")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
-
-	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
-	defer func() {
-		disttaeEngine.Close(ctx)
-		taeHandler.Close(true)
-		rpcAgent.Close()
-	}()
-
-	ctx, cancel = context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	// Setup: Create database and table with 100 rows
-	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
-	require.NoError(t, err)
-
-	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	schema := catalog2.MockSchemaAll(3, -1) // -1 means no primary key
-	schema.Name = "test_table"
-	defs, err := testutil.EngineTableDefBySchema(schema)
-	require.NoError(t, err)
-
-	err = db.Create(ctx, "test_table", defs)
-	require.NoError(t, err)
-
-	rel, err := db.Relation(ctx, "test_table", nil)
-	require.NoError(t, err)
-
-	bat := catalog2.MockBatch(schema, 100)
-	err = rel.Write(ctx, containers.ToCNBatch(bat))
-	require.NoError(t, err)
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	// Test: Add uncommitted inserts
+	// Reuse the engine and database fixture for the other zero boundary:
+	// uncommitted inserts on a table with no committed rows.
+	const emptyTable = "empty_with_uncommitted"
+	emptySchema := catalog2.MockSchemaAll(3, -1)
+	emptySchema.Name = emptyTable
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
 	require.NoError(t, err)
-
 	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
 	require.NoError(t, err)
-
-	rel, err = db.Relation(ctx, "test_table", nil)
+	defs, err = testutil.EngineTableDefBySchema(emptySchema)
 	require.NoError(t, err)
+	require.NoError(t, db.Create(ctx, emptyTable, defs))
+	require.NoError(t, txn.Commit(ctx))
 
-	// Insert 50 more rows (uncommitted) - no PK so no conflict
-	bat = catalog2.MockBatch(schema, 50)
-	err = rel.Write(ctx, containers.ToCNBatch(bat))
-	require.NoError(t, err)
-
-	// Count should include uncommitted inserts
-	count, err := rel.StarCount(ctx)
-	require.NoError(t, err)
-	t.Logf("StarCount returned: %d, expected: 150 (100 committed + 50 uncommitted)", count)
-	require.Equal(t, uint64(150), count, "Should count 100 committed + 50 uncommitted")
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
-}
-
-func TestStarCountReadonly(t *testing.T) {
-	catalog.SetupDefines("")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
-
-	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
-	defer func() {
-		disttaeEngine.Close(ctx)
-		taeHandler.Close(true)
-		rpcAgent.Close()
-	}()
-
-	ctx, cancel = context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	// Setup: Create database and table with 100 rows
-	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
-	require.NoError(t, err)
-
-	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	schema := catalog2.MockSchemaAll(3, 0)
-	schema.Name = "test_table"
-	defs, err := testutil.EngineTableDefBySchema(schema)
-	require.NoError(t, err)
-
-	err = db.Create(ctx, "test_table", defs)
-	require.NoError(t, err)
-
-	rel, err := db.Relation(ctx, "test_table", nil)
-	require.NoError(t, err)
-
-	bat := catalog2.MockBatch(schema, 100)
-	err = rel.Write(ctx, containers.ToCNBatch(bat))
-	require.NoError(t, err)
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	// Test: Readonly transaction (use snapshot)
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
 	require.NoError(t, err)
-
 	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
 	require.NoError(t, err)
-
-	rel, err = db.Relation(ctx, "test_table", nil)
+	rel, err = db.Relation(ctx, emptyTable, nil)
 	require.NoError(t, err)
-
-	// Readonly transaction should only see committed rows
-	count, err := rel.StarCount(ctx)
+	bat = catalog2.MockBatch(emptySchema, 50)
+	require.NoError(t, rel.Write(ctx, containers.ToCNBatch(bat)))
+	count, err = rel.StarCount(ctx)
 	require.NoError(t, err)
-	require.Equal(t, uint64(100), count, "Readonly should only count committed rows")
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
+	require.Equal(t, uint64(50), count, "empty table should count uncommitted inserts")
+	require.NoError(t, txn.Commit(ctx))
 }
 
 // TestStarCountWithPersistedInserts tests StarCount with persisted uncommitted inserts
@@ -456,137 +352,9 @@ func TestStarCountPersistedInsertsMultipleObjectStatsInOneBatch(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestStarCountReadonlyLarge tests readonly transaction with large dataset
-func TestStarCountReadonlyLarge(t *testing.T) {
-	catalog.SetupDefines("")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
-
-	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
-	defer func() {
-		disttaeEngine.Close(ctx)
-		taeHandler.Close(true)
-		rpcAgent.Close()
-	}()
-
-	ctx, cancel = context.WithTimeout(ctx, time.Minute*2)
-	defer cancel()
-
-	// Create database and table
-	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
-	require.NoError(t, err)
-
-	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	schema := catalog2.MockSchemaAll(3, -1)
-	schema.Name = "test_table"
-	defs, err := testutil.EngineTableDefBySchema(schema)
-	require.NoError(t, err)
-
-	err = db.Create(ctx, "test_table", defs)
-	require.NoError(t, err)
-
-	rel, err := db.Relation(ctx, "test_table", nil)
-	require.NoError(t, err)
-
-	// Insert 10k rows (reduced from 1M to keep test fast)
-	totalRows := 10000
-	batchSize := 1000
-	for i := 0; i < totalRows/batchSize; i++ {
-		bat := catalog2.MockBatch(schema, batchSize)
-		err = rel.Write(ctx, containers.ToCNBatch(bat))
-		require.NoError(t, err)
-	}
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	// Readonly transaction
-	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
-	require.NoError(t, err)
-
-	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	rel, err = db.Relation(ctx, "test_table", nil)
-	require.NoError(t, err)
-
-	count, err := rel.StarCount(ctx)
-	require.NoError(t, err)
-	require.Equal(t, uint64(totalRows), count)
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
-}
-
-// TestStarCountInMemoryEmpty tests in-memory inserts on empty table
-func TestStarCountInMemoryEmpty(t *testing.T) {
-	catalog.SetupDefines("")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
-
-	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
-	defer func() {
-		disttaeEngine.Close(ctx)
-		taeHandler.Close(true)
-		rpcAgent.Close()
-	}()
-
-	ctx, cancel = context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	// Create empty table
-	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
-	require.NoError(t, err)
-
-	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	schema := catalog2.MockSchemaAll(3, -1)
-	schema.Name = "test_table"
-	defs, err := testutil.EngineTableDefBySchema(schema)
-	require.NoError(t, err)
-
-	err = db.Create(ctx, "test_table", defs)
-	require.NoError(t, err)
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
-
-	// Insert 50 rows on empty table
-	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
-	require.NoError(t, err)
-
-	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
-	require.NoError(t, err)
-
-	rel, err := db.Relation(ctx, "test_table", nil)
-	require.NoError(t, err)
-
-	bat := catalog2.MockBatch(schema, 50)
-	err = rel.Write(ctx, containers.ToCNBatch(bat))
-	require.NoError(t, err)
-
-	count, err := rel.StarCount(ctx)
-	require.NoError(t, err)
-	require.Equal(t, uint64(50), count, "Empty table + 50 uncommitted = 50")
-
-	err = txn.Commit(ctx)
-	require.NoError(t, err)
-}
-
-// TestStarCountInMemoryLarge tests in-memory inserts with large dataset
+// TestStarCountInMemoryLarge checks the committed snapshot before adding
+// uncommitted rows, then checks the combined count. This retains both the
+// committed-only and committed-plus-workspace axes on one engine fixture.
 func TestStarCountInMemoryLarge(t *testing.T) {
 	catalog.SetupDefines("")
 
@@ -646,13 +414,16 @@ func TestStarCountInMemoryLarge(t *testing.T) {
 
 	rel, err = db.Relation(ctx, "test_table", nil)
 	require.NoError(t, err)
+	count, err := rel.StarCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(totalRows), count, "new transaction should see all committed rows")
 
 	uncommittedRows := 1000
 	bat := catalog2.MockBatch(schema, uncommittedRows)
 	err = rel.Write(ctx, containers.ToCNBatch(bat))
 	require.NoError(t, err)
 
-	count, err := rel.StarCount(ctx)
+	count, err = rel.StarCount(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(totalRows+uncommittedRows), count, "10k committed + 1k uncommitted = 11k")
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #26701

## What this PR does / why we need it:

The Ubuntu/x86 Unit Testing job still spends most of its wall time in serial, low-CPU test fixture lifecycles. In particular, `pkg/vm/engine/test` takes about three minutes locally under `-short -race` while averaging well below one core.

This change attacks that cost without dropping semantic coverage:

- builds the `pkg/vm/engine/test` race binary once, discovers every Test/Fuzz/Example dynamically, and distributes the complete set across two fresh concurrent processes;
- keeps each shard in the package source directory, writes independent JSON streams, propagates failures, and terminates complete test2json/test-binary process groups on cancellation;
- keeps dependency-derived group precedence authoritative, so the package falls back instead of running twice if it ever becomes an embedded-cluster owner;
- keeps engine shards and all remaining heavy packages inside the existing `HEAVY_RACE_PARALLEL` total process budget (default: engine two shards + remaining packages `-p 1`);
- reports cgroup current/peak/OOM counters for target-runner diagnostics;
- replaces production-scale sleeps in lock keeper and transfer-table TTL tests with bounded short-test timing or direct logical-age control;
- replaces polling sleeps in the lock waiter regression with cancellation-safe phase barriers;
- consolidates four redundant StarCount engine fixtures while preserving empty, committed, uncommitted, large, and tombstone axes.

### Measured strict-budget comparison

Same machine, same code, forced `-count=1`:

| Schedule | Wall time | Result |
|---|---:|---|
| current five packages, `-p 3` | 206.10s | PASS |
| engine two-shard path + remaining packages `-p 1` | 198.56s | PASS |

The complete local stage is 7.54 seconds / 3.7% faster while never exceeding three test-process slots. The engine package runtime itself falls from 179.2s to about 97s (46%); under the strict full-stage contention run its build/list/shards path completed in 125s. Conservative concurrent local RSS was about 6.6 GB.

The target Ubuntu/x86 run is authoritative for the net CI wall-time effect. The previous four-process revision is intentionally superseded; it reached the runner's 16-GiB cgroup lifetime peak and did not provide acceptable headroom.

### Validation

- all 163 discovered engine top-level tests reached terminal events: 160 pass, 3 existing skips;
- all remaining heavy packages passed under strict `-p 1`: backup, fileservice, plan/function, and TAE DB;
- combined shard/package JSON passed `go-ut-analysis` with zero failed outputs;
- engine full package `-short -race`: PASS;
- TAE DB and TAE model full packages `-short -race`: PASS;
- lockservice full package `-short -race`: PASS;
- lock timing tests passed repeated adaptive race runs; `TestLeakWaiterForErr -race -count=100` passed;
- real TERM during engine race build returned 143 with no surviving go-test, test binary, or test2json process;
- H=1 through H=64 scheduling arithmetic was reviewed: H>=3 uses exactly H total slots, H=1/H=2 use sequential waves;
- `bash -n optools/run_ut.sh`;
- `optools/testdata/active_ut_cases_test.bash`;
- `make err-check`;
- `git diff --check` and gofmt checks.

Target CI remains the merge authority: require the full UT job and JSON analysis to pass, with `memory.events` reporting `oom 0` and `oom_kill 0`. `memory.peak` is logged as a conservative cgroup-lifetime diagnostic, not represented as a stage-local measurement.