### PR TITLE
fix: account group spill disk at physical writes

### DIFF
--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -242,7 +242,7 @@ func (w *countingShortWriter) Write(value []byte) (int, error) {
 func TestGroupSpillWriterDoesNotRetryFailedFlush(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	target := &countingShortWriter{}
-	w, err := newGroupSpillWriter(&container{mp: proc.Mp()}, target, context.Background())
+	w, err := newGroupSpillWriter(&container{mp: proc.Mp()}, target, context.Background(), nil)
 	require.NoError(t, err)
 	require.NoError(t, w.ensureBuffer())
 	require.NoError(t, w.buffer.Resize(1))
@@ -330,7 +330,7 @@ func TestGroupSpillSaveArgCodecObservesCancellationWithinOneGroup(t *testing.T) 
 
 	ctx, cancel := context.WithCancel(context.Background())
 	target := &cancelAfterWriteWriter{cancel: cancel}
-	writer, err := newGroupSpillWriter(&g.ctr, target, ctx)
+	writer, err := newGroupSpillWriter(&g.ctr, target, ctx, nil)
 	require.NoError(t, err)
 	err = codec.SaveSpillIntermediateResult(1, 0, []uint8{1}, writer)
 	require.ErrorIs(t, err, context.Canceled)

--- a/pkg/sql/colexec/group/helper.go
+++ b/pkg/sql/colexec/group/helper.go
@@ -91,18 +91,12 @@ func writeSpillBool(writer io.Writer, value bool) error {
 
 type spillRecordWriter struct {
 	target  io.Writer
-	disk    *process.ExecutionSpillDiskReservation
 	written int64
 }
 
 func (w *spillRecordWriter) Write(value []byte) (int, error) {
 	if w == nil || w.target == nil {
 		return 0, io.ErrClosedPipe
-	}
-	if w.disk != nil {
-		if err := w.disk.Grow(uint64(len(value))); err != nil {
-			return 0, err
-		}
 	}
 	n, err := w.target.Write(value)
 	w.written += int64(n)
@@ -511,7 +505,7 @@ func (ctr *container) openSpillBucket(
 		return err
 	}
 	bkt.file = file
-	bkt.writer, err = newGroupSpillWriter(ctr, file, proc.Ctx)
+	bkt.writer, err = newGroupSpillWriter(ctr, file, proc.Ctx, diskToken)
 	if err != nil {
 		_ = file.Close()
 		bkt.file = nil
@@ -566,7 +560,7 @@ func (ctr *container) writeSpillRecord(
 			return 0, 0, err
 		}
 	}
-	record := spillRecordWriter{target: bkt.writer, disk: bkt.diskToken}
+	record := spillRecordWriter{target: bkt.writer}
 	cnt := int64(len(rows))
 	if err := types.WriteInt64(&record, cnt); err != nil {
 		return 0, 0, err

--- a/pkg/sql/colexec/group/spill_reader.go
+++ b/pkg/sql/colexec/group/spill_reader.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/spillutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -209,7 +210,6 @@ type groupSpillWriter struct {
 	ctr      *container
 	target   io.Writer
 	ctx      context.Context
-	disk     *process.ExecutionSpillDiskReservation
 	buffer   reusableSpillBuffer
 	disabled bool
 	failed   error
@@ -224,7 +224,11 @@ func newGroupSpillWriter(
 	if ctr == nil || ctr.mp == nil || target == nil || ctx == nil {
 		return nil, mpool.ErrAllocationAccountInvalid
 	}
-	return &groupSpillWriter{ctr: ctr, target: target, ctx: ctx, disk: disk}, nil
+	return &groupSpillWriter{
+		ctr:    ctr,
+		target: spillutil.NewDiskReservationWriter(target, disk),
+		ctx:    ctx,
+	}, nil
 }
 
 func (w *groupSpillWriter) ensureBuffer() error {
@@ -327,7 +331,6 @@ func (w *groupSpillWriter) Free() {
 	w.ctr = nil
 	w.target = nil
 	w.ctx = nil
-	w.disk = nil
 	w.disabled = true
 	w.failed = nil
 }
@@ -336,11 +339,6 @@ func (w *groupSpillWriter) Free() {
 // Codec writes are coalesced above this boundary so accounting does not
 // serialize every small logical fragment on the shared execution budget.
 func (w *groupSpillWriter) writePhysical(value []byte) (int, error) {
-	if w.disk != nil {
-		if err := w.disk.Grow(uint64(len(value))); err != nil {
-			return 0, err
-		}
-	}
 	return writeGroupSpillBytes(w.target, value)
 }
 

--- a/pkg/sql/colexec/group/spill_reader.go
+++ b/pkg/sql/colexec/group/spill_reader.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
 // groupSpillReader keeps read-ahead physical storage under the Group owner.
@@ -208,6 +209,7 @@ type groupSpillWriter struct {
 	ctr      *container
 	target   io.Writer
 	ctx      context.Context
+	disk     *process.ExecutionSpillDiskReservation
 	buffer   reusableSpillBuffer
 	disabled bool
 	failed   error
@@ -217,11 +219,12 @@ func newGroupSpillWriter(
 	ctr *container,
 	target io.Writer,
 	ctx context.Context,
+	disk *process.ExecutionSpillDiskReservation,
 ) (*groupSpillWriter, error) {
 	if ctr == nil || ctr.mp == nil || target == nil || ctx == nil {
 		return nil, mpool.ErrAllocationAccountInvalid
 	}
-	return &groupSpillWriter{ctr: ctr, target: target, ctx: ctx}, nil
+	return &groupSpillWriter{ctr: ctr, target: target, ctx: ctx, disk: disk}, nil
 }
 
 func (w *groupSpillWriter) ensureBuffer() error {
@@ -264,7 +267,7 @@ func (w *groupSpillWriter) Write(value []byte) (int, error) {
 		return 0, err
 	}
 	if w.disabled {
-		return writeGroupSpillBytes(w.target, value)
+		return w.writePhysical(value)
 	}
 	written := 0
 	for len(value) != 0 {
@@ -305,7 +308,7 @@ func (w *groupSpillWriter) Flush() error {
 	if w.buffer == nil || w.buffer.Len() == 0 {
 		return nil
 	}
-	if _, err := writeGroupSpillBytes(w.target, w.buffer.Bytes()); err != nil {
+	if _, err := w.writePhysical(w.buffer.Bytes()); err != nil {
 		w.failed = err
 		return err
 	}
@@ -324,8 +327,21 @@ func (w *groupSpillWriter) Free() {
 	w.ctr = nil
 	w.target = nil
 	w.ctx = nil
+	w.disk = nil
 	w.disabled = true
 	w.failed = nil
+}
+
+// writePhysical admits disk capacity immediately before one physical write.
+// Codec writes are coalesced above this boundary so accounting does not
+// serialize every small logical fragment on the shared execution budget.
+func (w *groupSpillWriter) writePhysical(value []byte) (int, error) {
+	if w.disk != nil {
+		if err := w.disk.Grow(uint64(len(value))); err != nil {
+			return 0, err
+		}
+	}
+	return writeGroupSpillBytes(w.target, value)
 }
 
 func writeGroupSpillBytes(target io.Writer, value []byte) (int, error) {

--- a/pkg/sql/colexec/group/spill_writer_perf_test.go
+++ b/pkg/sql/colexec/group/spill_writer_perf_test.go
@@ -31,6 +31,20 @@ type groupSpillCountingWriter struct {
 	bytes  int
 }
 
+type groupSpillPartialWriter struct {
+	limit  int
+	err    error
+	writes int
+	bytes  int
+}
+
+func (w *groupSpillPartialWriter) Write(value []byte) (int, error) {
+	w.writes++
+	n := min(w.limit, len(value))
+	w.bytes += n
+	return n, w.err
+}
+
 func (w *groupSpillCountingWriter) Write(value []byte) (int, error) {
 	w.writes++
 	w.bytes += len(value)
@@ -136,6 +150,51 @@ func TestGroupSpillWriterDirectFallbackAccountsOneWrite(t *testing.T) {
 	generation.Close()
 	budget.Close()
 	require.Zero(t, pool.CurrNB())
+}
+
+func TestGroupSpillWriterReconcilesPartialPhysicalWrites(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		direct    bool
+		targetErr error
+		wantErr   error
+	}{
+		{name: "buffered short write", wantErr: io.ErrShortWrite},
+		{name: "buffered partial error", targetErr: io.ErrUnexpectedEOF, wantErr: io.ErrUnexpectedEOF},
+		{name: "direct short write", direct: true, wantErr: io.ErrShortWrite},
+		{name: "direct partial error", direct: true, targetErr: io.ErrUnexpectedEOF, wantErr: io.ErrUnexpectedEOF},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			budget, generation, disk := newGroupSpillPerfBudget(t)
+			target := &groupSpillPartialWriter{limit: 4, err: test.targetErr}
+			pool := mpool.MustNewZero()
+			writer, err := newGroupSpillWriter(
+				&container{mp: pool}, target, context.Background(), disk)
+			require.NoError(t, err)
+			writer.disabled = test.direct
+
+			payload := make([]byte, 8)
+			n, writeErr := writer.Write(payload)
+			if test.direct {
+				require.Equal(t, 4, n)
+				require.ErrorIs(t, writeErr, test.wantErr)
+			} else {
+				require.Equal(t, len(payload), n)
+				require.NoError(t, writeErr)
+				require.ErrorIs(t, writer.Flush(), test.wantErr)
+			}
+			require.Equal(t, 1, target.writes)
+			require.Equal(t, 4, target.bytes)
+			require.Equal(t, uint64(4), disk.Size())
+
+			writer.Free()
+			require.True(t, disk.Release())
+			require.Zero(t, generation.Snapshot().SpillDiskUsed)
+			generation.Close()
+			budget.Close()
+			require.Zero(t, pool.CurrNB())
+		})
+	}
 }
 
 func BenchmarkGroupSpillWriterDiskAccounting(b *testing.B) {

--- a/pkg/sql/colexec/group/spill_writer_perf_test.go
+++ b/pkg/sql/colexec/group/spill_writer_perf_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+type groupSpillCountingWriter struct {
+	writes int
+	bytes  int
+}
+
+func (w *groupSpillCountingWriter) Write(value []byte) (int, error) {
+	w.writes++
+	w.bytes += len(value)
+	return len(value), nil
+}
+
+func newGroupSpillPerfBudget(t testing.TB) (
+	*process.ExecutionResourceBudget,
+	*process.ExecutionResourceGeneration,
+	*process.ExecutionSpillDiskReservation,
+) {
+	t.Helper()
+	budget, err := process.NewExecutionResourceBudget(1<<40, 1<<39)
+	require.NoError(t, err)
+	generation, err := budget.OpenGeneration(1)
+	require.NoError(t, err)
+	disk, err := generation.ReserveSpillDisk(0)
+	require.NoError(t, err)
+	return budget, generation, disk
+}
+
+func TestGroupSpillWriterAccountsPhysicalWrites(t *testing.T) {
+	budget, generation, disk := newGroupSpillPerfBudget(t)
+	target := &groupSpillCountingWriter{}
+	pool := mpool.MustNewZero()
+	writer, err := newGroupSpillWriter(
+		&container{mp: pool}, target, context.Background(), disk)
+	require.NoError(t, err)
+	record := spillRecordWriter{target: writer}
+	before := generation.Snapshot().ReserveCount
+	payload := make([]byte, 32)
+	for range 1000 {
+		_, err = record.Write(payload)
+		require.NoError(t, err)
+	}
+	if got := disk.Size(); got != 0 {
+		t.Errorf("buffered bytes charged before physical write: got %d", got)
+	}
+	require.NoError(t, writer.Flush())
+	require.Equal(t, 1, target.writes)
+	require.Equal(t, len(payload)*1000, target.bytes)
+	require.Equal(t, uint64(len(payload)*1000), disk.Size())
+	require.Equal(t, uint64(1), generation.Snapshot().ReserveCount-before)
+
+	writer.Free()
+	require.True(t, disk.Release())
+	require.Zero(t, generation.Snapshot().SpillDiskUsed)
+	generation.Close()
+	budget.Close()
+	require.Zero(t, pool.CurrNB())
+}
+
+func TestGroupSpillWriterAdmitsDiskBeforePhysicalWrite(t *testing.T) {
+	budget, generation, disk := newGroupSpillPerfBudget(t)
+	remaining := uint64(31)
+	held, err := generation.ReserveSpillDisk(generation.SpillDiskCap() - remaining)
+	require.NoError(t, err)
+	target := &groupSpillCountingWriter{}
+	pool := mpool.MustNewZero()
+	writer, err := newGroupSpillWriter(
+		&container{mp: pool}, target, context.Background(), disk)
+	require.NoError(t, err)
+
+	_, err = writer.Write(make([]byte, remaining+1))
+	require.NoError(t, err)
+	err = writer.Flush()
+	require.Error(t, err)
+	require.Zero(t, target.writes)
+	require.Zero(t, target.bytes)
+	require.Zero(t, disk.Size())
+
+	writer.Free()
+	require.True(t, disk.Release())
+	require.True(t, held.Release())
+	require.Zero(t, generation.Snapshot().SpillDiskUsed)
+	generation.Close()
+	budget.Close()
+	require.Zero(t, pool.CurrNB())
+}
+
+func TestGroupSpillWriterDirectFallbackAccountsOneWrite(t *testing.T) {
+	budget, generation, disk := newGroupSpillPerfBudget(t)
+	target := &groupSpillCountingWriter{}
+	pool := mpool.MustNewZero()
+	writer, err := newGroupSpillWriter(
+		&container{mp: pool}, target, context.Background(), disk)
+	require.NoError(t, err)
+	writer.disabled = true
+	before := generation.Snapshot().ReserveCount
+
+	payload := make([]byte, 32)
+	n, err := writer.Write(payload)
+	require.NoError(t, err)
+	require.Equal(t, len(payload), n)
+	require.Equal(t, 1, target.writes)
+	require.Equal(t, len(payload), target.bytes)
+	require.Equal(t, uint64(len(payload)), disk.Size())
+	require.Equal(t, uint64(1), generation.Snapshot().ReserveCount-before)
+
+	writer.Free()
+	require.True(t, disk.Release())
+	require.Zero(t, generation.Snapshot().SpillDiskUsed)
+	generation.Close()
+	budget.Close()
+	require.Zero(t, pool.CurrNB())
+}
+
+func BenchmarkGroupSpillWriterDiskAccounting(b *testing.B) {
+	for _, test := range []struct {
+		name    string
+		workers int
+	}{
+		{name: "1-writer", workers: 1},
+		{name: "14-writers", workers: 14},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			oldProcs := runtime.GOMAXPROCS(test.workers)
+			defer runtime.GOMAXPROCS(oldProcs)
+			budget, err := process.NewExecutionResourceBudget(1<<40, 1<<39)
+			require.NoError(b, err)
+			generation, err := budget.OpenGeneration(1)
+			require.NoError(b, err)
+			pool := mpool.MustNewZero()
+			payload := make([]byte, 32)
+			b.SetBytes(int64(len(payload)))
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				disk, err := generation.ReserveSpillDisk(0)
+				require.NoError(b, err)
+				writer, err := newGroupSpillWriter(
+					&container{mp: pool}, io.Discard, context.Background(), disk)
+				require.NoError(b, err)
+				record := spillRecordWriter{target: writer}
+				for pb.Next() {
+					_, err = record.Write(payload)
+					require.NoError(b, err)
+				}
+				require.NoError(b, writer.Flush())
+				writer.Free()
+				require.True(b, disk.Release())
+			})
+			b.StopTimer()
+			generation.Close()
+			budget.Close()
+			require.Zero(b, pool.CurrNB())
+		})
+	}
+}

--- a/pkg/sql/colexec/group/wire_edge_test.go
+++ b/pkg/sql/colexec/group/wire_edge_test.go
@@ -233,9 +233,9 @@ func TestGroupSpillReaderWriterBoundaryMatrix(t *testing.T) {
 	require.False(t, disabled)
 
 	var output bytes.Buffer
-	_, err = newGroupSpillWriter(nil, &output, ctx)
+	_, err = newGroupSpillWriter(nil, &output, ctx, nil)
 	require.ErrorIs(t, err, mpool.ErrAllocationAccountInvalid)
-	writer, err := newGroupSpillWriter(ctr, &output, ctx)
+	writer, err := newGroupSpillWriter(ctr, &output, ctx, nil)
 	require.NoError(t, err)
 	n, err = writer.Write(payload)
 	require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestGroupSpillReaderWriterBoundaryMatrix(t *testing.T) {
 
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
-	cancelledWriter, err := newGroupSpillWriter(ctr, io.Discard, cancelled)
+	cancelledWriter, err := newGroupSpillWriter(ctr, io.Discard, cancelled, nil)
 	require.NoError(t, err)
 	_, err = cancelledWriter.Write([]byte{1})
 	require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25782

## What this PR does / why we need it:

Group spill disk accounting currently calls `ExecutionSpillDiskReservation.Grow` for every small codec write before those writes reach the existing 64 KiB coalescing buffer. TPCH 1T Q18 produces millions of spill records, so concurrent Group operators repeatedly contend on the shared execution-budget mutex and spend most of the query serializing budget updates rather than performing spill I/O.

This change moves disk admission to the physical-write boundary:

- buffered codec writes are accounted once when the coalesced buffer is flushed;
- direct-write fallback still admits disk capacity immediately before each physical write;
- disk-limit rejection still occurs before the underlying write;
- spill record byte counts and token ownership/cleanup remain unchanged.

Local regression evidence:

- before the fix, 1,000 logical 32-byte writes caused 1,000 disk reservations and the regression test failed because buffered bytes were charged before physical I/O;
- after the fix, the same workload produces one physical write and one disk reservation;
- local microbenchmark improved from about 207 ns/op to 128 ns/op with one writer, and from about 283 ns/op to 190 ns/op with 14 concurrent writers;
- the Group package, focused stress tests, full package race tests, build, and vet pass.
