### PR TITLE
[4.2] fix(plan): lock base rows before irregular update fanout

### DIFF
--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -1194,10 +1194,26 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 	// base-table MULTI_UPDATE. Their stale entries are deleted by the immutable
 	// old PK and rebuilt after createQuery from this materialized step. Async
 	// indexes are deliberately absent and remain CDC-only.
+	hasInlineIrregularMaintenance := false
 	for i, indexes := range inlineIrregularIndexes {
 		if len(indexes) == 0 {
 			continue
 		}
+		// Gate every synchronous maintenance branch on the existing base/regular-
+		// index lock before the final row image is fanned out. Preserve the complete
+		// image because the shared sink and RETURNING consume it positionally.
+		lastNodeID = builder.appendNode(&plan.Node{
+			NodeType:    plan.Node_LOCK_OP,
+			Children:    []int32{lastNodeID},
+			TableDef:    dmlCtx.tableDefs[0],
+			BindingTags: []int32{finalProjTag},
+			LockTargets: lockTargets,
+		}, bindCtx)
+		if builder.preserveLockProjection == nil {
+			builder.preserveLockProjection = make(map[int32]struct{})
+		}
+		builder.preserveLockProjection[lastNodeID] = struct{}{}
+
 		alias := dmlCtx.aliases[i]
 		pkPos := finalColName2Idx[alias+"."+dmlCtx.tableDefs[i].Pkey.PkeyColName]
 		lastNodeID = builder.appendOnDupIrregularMaintSource(
@@ -1210,6 +1226,7 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 			dmlCtx.tableDefs[i],
 			dmlCtx.objRefs[i],
 		)
+		hasInlineIrregularMaintenance = true
 		// Multi-target UPDATE is routed to the legacy planner before this point,
 		// so at most one target can require inline irregular maintenance here.
 		break
@@ -1221,13 +1238,15 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		UpdateCtxList: updateCtxList,
 	}
 
-	lastNodeID = builder.appendNode(&plan.Node{
-		NodeType:    plan.Node_LOCK_OP,
-		Children:    []int32{lastNodeID},
-		TableDef:    dmlCtx.tableDefs[0],
-		BindingTags: []int32{builder.genNewBindTag()},
-		LockTargets: lockTargets,
-	}, bindCtx)
+	if !hasInlineIrregularMaintenance {
+		lastNodeID = builder.appendNode(&plan.Node{
+			NodeType:    plan.Node_LOCK_OP,
+			Children:    []int32{lastNodeID},
+			TableDef:    dmlCtx.tableDefs[0],
+			BindingTags: []int32{builder.genNewBindTag()},
+			LockTargets: lockTargets,
+		}, bindCtx)
+	}
 	reCheckifNeedLockWholeTable(builder)
 
 	dmlNode.Children = append(dmlNode.Children, lastNodeID)

--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -121,8 +121,14 @@ func (builder *QueryBuilder) removeSimpleProjections(nodeID int32, parentType pl
 		}
 
 	case plan.Node_LOCK_OP:
+		childParentType := node.NodeType
+		if _, preserve := builder.preserveLockProjection[nodeID]; preserve {
+			// Keep the immediate PROJECT as the stable positional row-image boundary
+			// consumed by the shared irregular-maintenance sink.
+			childParentType = plan.Node_UNKNOWN
+		}
 		for i, childID := range node.Children {
-			newChildID, childProjMap := builder.removeSimpleProjections(childID, node.NodeType, true, colRefCnt)
+			newChildID, childProjMap := builder.removeSimpleProjections(childID, childParentType, true, colRefCnt)
 			node.Children[i] = newChildID
 			for ref, expr := range childProjMap {
 				projMap[ref] = expr

--- a/pkg/sql/plan/update_planner_route_test.go
+++ b/pkg/sql/plan/update_planner_route_test.go
@@ -231,6 +231,132 @@ func TestBindUpdateProducesTypedPlannerRoutes(t *testing.T) {
 	}
 }
 
+func TestUpdateIrregularIndexLocksBeforeMaintenanceFanout(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		algo      string
+		tableType string
+	}{
+		{name: "ivfflat", algo: catalog.MoIndexIvfFlatAlgo.ToString(), tableType: catalog.SystemSI_IVFFLAT_TblType_Entries},
+		{name: "fulltext", algo: catalog.MOIndexFullTextAlgo.ToString(), tableType: catalog.FullTextIndex_TblType},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			baseTable := mock.ctxt.tables["nation"]
+			baseTable.Indexes = []*planpb.IndexDef{{
+				IndexName:          "idx_irregular",
+				IndexTableName:     "idx_irregular_entries",
+				IndexAlgo:          test.algo,
+				IndexAlgoTableType: test.tableType,
+				Parts:              []string{"n_comment"},
+				TableExist:         true,
+			}}
+
+			stmt, err := parsers.ParseOne(
+				mock.CurrentContext().GetContext(),
+				dialect.MYSQL,
+				"UPDATE nation SET n_comment = 'updated' WHERE n_nationkey = 1",
+				1,
+			)
+			require.NoError(t, err)
+			defer stmt.Free()
+
+			builder := NewQueryBuilder(planpb.Query_UPDATE, mock.CurrentContext(), false, true)
+			rootID, err := builder.bindUpdate(stmt.(*tree.Update), NewBindContext(builder, nil))
+			require.NoError(t, err)
+
+			query := builder.qry
+			maintenanceSinkID := query.Steps[builder.irregularMaintSourceStep]
+			require.Equal(t, planpb.Node_SINK, query.Nodes[maintenanceSinkID].NodeType)
+
+			visited := make(map[int32]struct{})
+			var findBaseTableLock func(int32) int32
+			findBaseTableLock = func(nodeID int32) int32 {
+				if _, ok := visited[nodeID]; ok {
+					return -1
+				}
+				visited[nodeID] = struct{}{}
+				node := query.Nodes[nodeID]
+				if node.NodeType == planpb.Node_LOCK_OP {
+					for _, target := range node.LockTargets {
+						if target.TableId == baseTable.TblId {
+							return nodeID
+						}
+					}
+				}
+				for _, childID := range node.Children {
+					if lockID := findBaseTableLock(childID); lockID >= 0 {
+						return lockID
+					}
+				}
+				for _, sourceStep := range node.SourceStep {
+					if lockID := findBaseTableLock(query.Steps[sourceStep]); lockID >= 0 {
+						return lockID
+					}
+				}
+				return -1
+			}
+
+			lockID := findBaseTableLock(maintenanceSinkID)
+			require.NotEqual(t, int32(-1), lockID,
+				"all irregular-index maintenance branches must wait for the base-table lock")
+			require.Len(t, query.Nodes[lockID].Children, 1)
+			expectedImageCols := len(query.Nodes[query.Nodes[lockID].Children[0]].ProjectList)
+			require.Greater(t, expectedImageCols, 1)
+
+			baseLockCount := 0
+			for _, node := range query.Nodes {
+				for _, target := range node.LockTargets {
+					if target.TableId == baseTable.TblId {
+						baseLockCount++
+					}
+				}
+			}
+			require.Equal(t, 1, baseLockCount, "the existing base lock must be moved, not duplicated")
+
+			builder.qry.Steps = append(builder.qry.Steps, rootID)
+			query, err = builder.createQuery()
+			require.NoError(t, err)
+			lockNode := query.Nodes[lockID]
+			require.GreaterOrEqual(t, len(lockNode.ProjectList), expectedImageCols)
+			require.Len(t, query.Nodes[maintenanceSinkID].ProjectList, expectedImageCols)
+			for i, expr := range query.Nodes[maintenanceSinkID].ProjectList {
+				col := expr.GetCol()
+				require.NotNil(t, col)
+				require.Less(t, col.ColPos, int32(len(lockNode.ProjectList)))
+				require.Equal(t, int32(i), col.ColPos,
+					"the shared sink must preserve the final-row-image column order")
+				require.Equal(t, lockNode.ProjectList[i].Typ.Id, expr.Typ.Id)
+			}
+		})
+	}
+}
+
+func TestUpdateWithoutIrregularIndexKeepsLockAtDMLInput(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	baseTable := mock.ctxt.tables["nation"]
+	stmt, err := parsers.ParseOne(
+		mock.CurrentContext().GetContext(),
+		dialect.MYSQL,
+		"UPDATE nation SET n_name = 'updated' WHERE n_nationkey = 1",
+		1,
+	)
+	require.NoError(t, err)
+	defer stmt.Free()
+
+	builder := NewQueryBuilder(planpb.Query_UPDATE, mock.CurrentContext(), false, true)
+	rootID, err := builder.bindUpdate(stmt.(*tree.Update), NewBindContext(builder, nil))
+	require.NoError(t, err)
+
+	root := builder.qry.Nodes[rootID]
+	require.Equal(t, planpb.Node_MULTI_UPDATE, root.NodeType)
+	require.Len(t, root.Children, 1)
+	lockNode := builder.qry.Nodes[root.Children[0]]
+	require.Equal(t, planpb.Node_LOCK_OP, lockNode.NodeType)
+	require.NotEmpty(t, lockNode.LockTargets)
+	require.Equal(t, baseTable.TblId, lockNode.LockTargets[0].TableId)
+}
+
 func TestBindUpdateForeignKeyRoutingByAffectedColumns(t *testing.T) {
 	prepareEmpDept := func(mock *MockOptimizer) {
 		emp := mock.ctxt.tables["emp"]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27124

Backport of #27144. Related to #27142, #26925, and #26518.

## What this PR does / why we need it:

### Root cause

#26518 moved synchronous IVF/full-text UPDATE maintenance to separate top-level steps that consume a shared materialized final-row image. The existing base/regular-index `LOCK_OP` remained downstream of that materialization in only the main `MULTI_UPDATE` consumer.

The base consumer and hidden-index consumers could therefore acquire locks in opposite order:

```text
T1: base row -> waits for IVF/full-text hidden row
T2: IVF/full-text hidden row -> waits for base row
```

#26925 removes false self-cycles from deadlock detection, but it cannot remove these real two-transaction cycles.

### Fix

For UPDATEs with synchronous irregular-index maintenance, move the existing base/regular-index `LOCK_OP` before the shared row-image `SINK`:

```text
final row image
  -> existing LOCK_OP
  -> shared SINK
     -> base MULTI_UPDATE
     -> irregular delete maintenance
     -> irregular insert maintenance
```

Preserve the complete positional row image through the moved lock gate so all sink consumers continue to resolve the same columns.

This is a semantic backport because the original main commit conflicts with the current 4.2 planner implementation. It retains #27144's lock-order invariant while adapting to the 4.2 UPDATE fanout helper. 4.2 does not support master-index UPDATE, so the regression covers its reachable IVF and full-text paths.

### Risk assessment

- No new lock, lock mode, release rule, RPC, or lockservice behavior is introduced.
- Normal UPDATEs keep `MULTI_UPDATE -> LOCK_OP`.
- Synchronous IVF/full-text UPDATEs execute the same lock operation once, earlier in the same transaction.
- Async indexes remain CDC-only.

### Tests

- Verified the new planner regression fails on clean 4.2-dev `aaac5956fd` for both IVF and full-text because the maintenance fanout has no upstream base lock.
- `pkg/sql/plan` full package test.
- Focused planner regressions with `-count=10`.
- `go vet ./pkg/sql/plan`.
- `TestIssue26341CancelAndRetryFulltextUpdate` embedded three-CN regression, covering lock blocking, cancellation, rollback, retry, and hidden-index consistency.
