### PR TITLE
fix(frontend): keep ordinary SET inside explicit transactions

### DIFF
--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -3793,8 +3793,22 @@ func Test_statement_type(t *testing.T) {
 		convey.So(IsAdministrativeStatement(&tree.CreateAccount{}), convey.ShouldBeTrue)
 		convey.So(IsParameterModificationStatement(&tree.SetVar{}), convey.ShouldBeTrue)
 		convey.So(IsParameterModificationStatement(&tree.SetTransaction{}), convey.ShouldBeFalse)
-		convey.So(NeedToBeCommittedInActiveTransaction(&tree.SetVar{}), convey.ShouldBeTrue)
+		convey.So(NeedToBeCommittedInActiveTransaction(&tree.SetVar{}), convey.ShouldBeFalse)
 		convey.So(NeedToBeCommittedInActiveTransaction(&tree.SetTransaction{}), convey.ShouldBeFalse)
+		convey.So(needToFinishTransactionAtStatementEnd(&ExecCtx{
+			stmt: &tree.SetVar{},
+			txnOpt: FeTxnOption{
+				activeTxnAtStartKnown: true,
+				activeTxnAtStart:      false,
+			},
+		}), convey.ShouldBeTrue)
+		convey.So(needToFinishTransactionAtStatementEnd(&ExecCtx{
+			stmt: &tree.SetVar{},
+			txnOpt: FeTxnOption{
+				activeTxnAtStartKnown: true,
+				activeTxnAtStart:      true,
+			},
+		}), convey.ShouldBeFalse)
 		convey.So(needToFinishTransactionAtStatementEnd(&ExecCtx{
 			stmt: &tree.SetTransaction{},
 			txnOpt: FeTxnOption{

--- a/pkg/frontend/stmt_kind.go
+++ b/pkg/frontend/stmt_kind.go
@@ -146,18 +146,16 @@ func IsCreateDropSequence(stmt tree.Statement) bool {
 }
 
 /*
-NeedToBeCommittedInActiveTransaction checks the statement that need to be committed
-in an active transaction.
-
-Currently, it includes the drop statement, the administration statement ,
-
-	the parameter modification statement.
+NeedToBeCommittedInActiveTransaction checks statements whose execution must commit
+an already active transaction. Ordinary SET statements are intentionally excluded;
+their session state changes must not commit a user's explicit transaction. The
+SET autocommit OFF -> ON transition commits through TxnHandler.SetAutocommit.
 */
 func NeedToBeCommittedInActiveTransaction(stmt tree.Statement) bool {
 	if stmt == nil {
 		return false
 	}
-	return IsCreateDropSequence(stmt) || IsAdministrativeStatement(stmt) || IsParameterModificationStatement(stmt) || isLockTableStatement(stmt)
+	return IsCreateDropSequence(stmt) || IsAdministrativeStatement(stmt) || isLockTableStatement(stmt)
 }
 
 func isLockTableStatement(stmt tree.Statement) bool {

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -896,6 +896,14 @@ func needToFinishTransactionAtStatementEnd(execCtx *ExecCtx) bool {
 	if statementContainsTransactionCharacteristic(execCtx.stmt) {
 		return execCtx.txnOpt.activeTxnAtStartKnown && !execCtx.txnOpt.activeTxnAtStart
 	}
+	// SET changes session state and must preserve an explicit transaction that
+	// was already active. The frontend still creates a temporary transaction
+	// for a standalone SET, so finish that transaction when there was no active
+	// user transaction at statement start. SET autocommit=1 is handled by
+	// TxnHandler.SetAutocommit, which commits the OFF -> ON transition directly.
+	if IsParameterModificationStatement(execCtx.stmt) {
+		return execCtx.txnOpt.activeTxnAtStartKnown && !execCtx.txnOpt.activeTxnAtStart
+	}
 	if NeedToBeCommittedInActiveTransaction(execCtx.stmt) {
 		return true
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Keep ordinary session and user-variable SET statements inside an already explicit transaction, while preserving the existing standalone SET cleanup and the dedicated autocommit OFF-to-ON commit behavior.

## Summary

- remove ordinary `SET` from the implicit-commit statement classification
- preserve an explicit transaction across session/user-variable assignments
- still finish the frontend-owned transaction for standalone SET statements
- retain the dedicated OFF -> ON `autocommit` commit path
- add transaction-state regression assertions

This prevents `SET @x`, `SET NAMES`, and unchanged session assignments from committing earlier DML.

Fixes #26872

## Testing

`go test ./pkg/frontend -count=1`