### PR TITLE
fix: stop MergeTop from replaying its final batch

### DIFF
--- a/pkg/sql/colexec/mergetop/top.go
+++ b/pkg/sql/colexec/mergetop/top.go
@@ -119,29 +119,41 @@ func (mergeTop *MergeTop) Call(proc *process.Process) (
 
 	result = vm.NewCallResult()
 	if mergeTop.ctr.limit == 0 {
-		result.Batch = nil
+		mergeTop.ctr.state = vm.End
 		result.Status = vm.ExecStop
 		return result, nil
 	}
 
-	if end, err := mergeTop.ctr.build(mergeTop, proc, analyzer); err != nil {
+	if mergeTop.ctr.state == vm.Build {
+		if end, err := mergeTop.ctr.build(mergeTop, proc, analyzer); err != nil {
+			return result, err
+		} else if end {
+			mergeTop.ctr.state = vm.End
+			result.Status = vm.ExecStop
+			return result, nil
+		}
+		mergeTop.ctr.state = vm.Eval
+	}
+
+	if mergeTop.ctr.state == vm.Eval {
+		if mergeTop.ctr.bat == nil || mergeTop.ctr.bat.IsEmpty() {
+			mergeTop.ctr.state = vm.End
+			result.Status = vm.ExecStop
+			return result, nil
+		}
+		err = mergeTop.ctr.eval(mergeTop.ctr.limit, proc, analyzer, &result)
+		if err == nil {
+			mergeTop.ctr.state = vm.End
+			result.Status = vm.ExecStop
+		}
 		return result, err
-	} else if end {
-		result.Status = vm.ExecStop
-		return result, nil
 	}
 
-	if mergeTop.ctr.bat == nil || mergeTop.ctr.bat.IsEmpty() {
-		result.Batch = nil
-		result.Status = vm.ExecStop
-		return result, nil
+	if mergeTop.ctr.state == vm.End {
+		return vm.CancelResult, nil
 	}
-	err = mergeTop.ctr.eval(mergeTop.ctr.limit, proc, analyzer, &result)
-	if err == nil {
-		result.Status = vm.ExecStop
-		return result, nil
-	}
-	return result, err
+
+	panic("bug")
 }
 
 func (ctr *container) build(ap *MergeTop, proc *process.Process, analyzer process.Analyzer) (bool, error) {

--- a/pkg/sql/colexec/mergetop/top_test.go
+++ b/pkg/sql/colexec/mergetop/top_test.go
@@ -148,6 +148,114 @@ func TestMergeTopMaxUint64LimitReturnsAllRows(t *testing.T) {
 	require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
 }
 
+func TestMergeTopEmitsFinalBatchOnce(t *testing.T) {
+	tc := newTestCase(t, []bool{false}, []types.Type{types.T_int64.ToType()}, 1,
+		[]*plan.OrderBySpec{{Expr: newExpression(0)}})
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+	resetChildren(tc.arg, []*batch.Batch{newBatch(tc.types, tc.proc, 3)})
+
+	t.Cleanup(func() {
+		tc.arg.Free(tc.proc, false, nil)
+		tc.arg.GetChildren(0).Free(tc.proc, false, nil)
+		tc.proc.Free()
+		require.Zero(t, tc.proc.Mp().CurrNB())
+	})
+
+	result, err := vm.Exec(tc.arg, tc.proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	require.Equal(t, 1, result.Batch.RowCount())
+	require.Equal(t, vm.ExecStop, result.Status)
+
+	for range 2 {
+		result, err = vm.Exec(tc.arg, tc.proc)
+		require.NoError(t, err)
+		require.Nil(t, result.Batch)
+		require.Equal(t, vm.ExecStop, result.Status)
+	}
+}
+
+func TestMergeTopEmptyResultRemainsTerminal(t *testing.T) {
+	testCases := []struct {
+		name  string
+		limit int64
+		rows  int64
+	}{
+		{name: "empty input", limit: 1},
+		{name: "zero limit", rows: 3},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tc := newTestCase(t, []bool{false}, []types.Type{types.T_int64.ToType()}, testCase.limit,
+				[]*plan.OrderBySpec{{Expr: newExpression(0)}})
+			require.NoError(t, tc.arg.Prepare(tc.proc))
+			var bats []*batch.Batch
+			if testCase.rows > 0 {
+				bats = []*batch.Batch{newBatch(tc.types, tc.proc, testCase.rows)}
+			}
+			resetChildren(tc.arg, bats)
+
+			t.Cleanup(func() {
+				tc.arg.Free(tc.proc, false, nil)
+				tc.arg.GetChildren(0).Free(tc.proc, false, nil)
+				tc.proc.Free()
+				require.Zero(t, tc.proc.Mp().CurrNB())
+			})
+
+			for range 2 {
+				result, err := vm.Exec(tc.arg, tc.proc)
+				require.NoError(t, err)
+				require.Nil(t, result.Batch)
+				require.Equal(t, vm.ExecStop, result.Status)
+			}
+		})
+	}
+}
+
+func TestMergeTopResetStartsNewGeneration(t *testing.T) {
+	tc := newTestCase(t, []bool{false}, []types.Type{types.T_int64.ToType()}, 1,
+		[]*plan.OrderBySpec{{Expr: newExpression(0)}})
+	var children []vm.Operator
+	t.Cleanup(func() {
+		tc.arg.Free(tc.proc, false, nil)
+		for _, child := range children {
+			child.Free(tc.proc, false, nil)
+		}
+		tc.proc.Free()
+		require.Zero(t, tc.proc.Mp().CurrNB())
+	})
+
+	newValuesBatch := func(values []int64) *batch.Batch {
+		bat := batch.NewWithSize(1)
+		bat.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+		require.NoError(t, vector.AppendFixedList(bat.Vecs[0], values, nil, tc.proc.Mp()))
+		bat.SetRowCount(len(values))
+		return bat
+	}
+	runGeneration := func(values []int64, expected int64) {
+		require.NoError(t, tc.arg.Prepare(tc.proc))
+		resetChildren(tc.arg, []*batch.Batch{newValuesBatch(values)})
+		children = append(children, tc.arg.GetChildren(0))
+
+		result, err := vm.Exec(tc.arg, tc.proc)
+		require.NoError(t, err)
+		require.NotNil(t, result.Batch)
+		require.Equal(t, []int64{expected},
+			vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[0]))
+		require.Equal(t, vm.ExecStop, result.Status)
+
+		result, err = vm.Exec(tc.arg, tc.proc)
+		require.NoError(t, err)
+		require.Nil(t, result.Batch)
+		require.Equal(t, vm.ExecStop, result.Status)
+	}
+
+	runGeneration([]int64{3, 1, 2}, 1)
+	tc.arg.Reset(tc.proc, false, nil)
+	runGeneration([]int64{9, 8}, 8)
+}
+
 func TestMergeTopFloatNaNLastAndPeerTieBreak(t *testing.T) {
 	tc := newTestCase(t, []bool{false, false}, []types.Type{types.T_float64.ToType(), types.T_int64.ToType()}, 5,
 		[]*plan.OrderBySpec{{Expr: newExpression(0)}, {Expr: newExpression(1)}})

--- a/pkg/sql/colexec/mergetop/types.go
+++ b/pkg/sql/colexec/mergetop/types.go
@@ -43,6 +43,7 @@ var _ interface {
 
 type container struct {
 	n     int // result vector number
+	state vm.CtrState
 	sels  []int64
 	poses []int32           // sorted list of attributes
 	cmps  []compare.Compare // compare structure used to do sort work
@@ -297,6 +298,7 @@ func mergeTopTerminalCapacityError(ctx context.Context, err error) error {
 
 func (ctr *container) reset(proc *process.Process) {
 	ctr.n = 0
+	ctr.state = vm.Build
 	if ctr.allocationAccount != nil && cap(ctr.sels) != 0 {
 		mpool.FreeSlice(proc.Mp(), ctr.sels)
 	}
@@ -329,6 +331,7 @@ func (ctr *container) reset(proc *process.Process) {
 }
 
 func (ctr *container) free(proc *process.Process) {
+	ctr.state = vm.Build
 	if ctr.allocationAccount != nil && cap(ctr.sels) != 0 {
 		mpool.FreeSlice(proc.Mp(), ctr.sels)
 	}

--- a/test/distributed/cases/dml/replace/replace_workspace.result
+++ b/test/distributed/cases/dml/replace/replace_workspace.result
@@ -13,7 +13,22 @@ create table t_replace_shuffle_capture(a int primary key, b int, marker int);
 begin;
 replace into t_replace_shuffle_capture select a, a, 24472 from t2;
 rollback;
+create table t_replace_mergetop_once(a int primary key, marker int);
+insert into t_replace_mergetop_once select a, 0 from t2;
+select a, marker from t_replace_mergetop_once order by a desc limit 1;
+a    marker
+819200    0
+replace into t_replace_mergetop_once
+select a, marker + 1 from t_replace_mergetop_once order by a desc limit 1;
+select count(*) as total, min(a) as min_a, max(a) as max_a, sum(marker) as marker_sum
+from t_replace_mergetop_once;
+total    min_a    max_a    marker_sum
+819200    1    819200    1
+select a, marker from t_replace_mergetop_once where marker <> 0;
+a    marker
+819200    1
 drop table if exists t1;
 drop table if exists t_replace_shuffle_capture;
+drop table if exists t_replace_mergetop_once;
 drop table if exists t2;
 drop database if exists test;

--- a/test/distributed/cases/dml/replace/replace_workspace.sql
+++ b/test/distributed/cases/dml/replace/replace_workspace.sql
@@ -19,7 +19,7 @@ begin;
 replace into t_replace_shuffle_capture select a, a, 24472 from t2;
 rollback;
 
--- issue #27212: an AP MergeTop nested below HashBuild must publish its final
+-- An AP MergeTop nested below HashBuild must publish its final
 -- LIMIT batch once instead of replaying it until the CN runs out of memory.
 create table t_replace_mergetop_once(a int primary key, marker int);
 insert into t_replace_mergetop_once select a, 0 from t2;

--- a/test/distributed/cases/dml/replace/replace_workspace.sql
+++ b/test/distributed/cases/dml/replace/replace_workspace.sql
@@ -19,7 +19,19 @@ begin;
 replace into t_replace_shuffle_capture select a, a, 24472 from t2;
 rollback;
 
+-- issue #27212: an AP MergeTop nested below HashBuild must publish its final
+-- LIMIT batch once instead of replaying it until the CN runs out of memory.
+create table t_replace_mergetop_once(a int primary key, marker int);
+insert into t_replace_mergetop_once select a, 0 from t2;
+select a, marker from t_replace_mergetop_once order by a desc limit 1;
+replace into t_replace_mergetop_once
+select a, marker + 1 from t_replace_mergetop_once order by a desc limit 1;
+select count(*) as total, min(a) as min_a, max(a) as max_a, sum(marker) as marker_sum
+from t_replace_mergetop_once;
+select a, marker from t_replace_mergetop_once where marker <> 0;
+
 drop table if exists t1;
 drop table if exists t_replace_shuffle_capture;
+drop table if exists t_replace_mergetop_once;
 drop table if exists t2;
 drop database if exists test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27212

## What this PR does / why we need it:

`MergeTop` kept its final result batch after returning it. A blocking parent such as `HashBuild` drains its child until it receives a nil batch, so `REPLACE INTO ... SELECT FROM` with `ORDER BY ... LIMIT` could consume the same batch repeatedly and eventually crash the CN due to memory exhaustion.

This change:

- adds an explicit `Build -> Eval -> End` execution state to `MergeTop`;
- emits the final batch exactly once and returns `ExecStop` with a nil batch afterward;
- resets the execution state for operator reuse;
- adds unit coverage for one-shot emission, empty/zero-limit termination, and reset generations;
- adds an AP-path BVT regression for same-table `REPLACE ... SELECT ... ORDER BY ... LIMIT`, including a marker row that proves the selected row is applied exactly once.

Validation:

- full `pkg/sql/colexec/mergetop` package tests through the repository CGo wrapper;
- focused race tests (100 iterations each) and the full package race test;
- `go build` and `go vet` for the package;
- `make build`;
- enhanced `replace_workspace` BVT: 26/26 passed;
- isolated 3-CN verification confirming the AP plan (`Top -> MergeTop -> HashBuild`) and successful LIMIT 1 / LIMIT 5000 execution with row-count and distinct-key preservation.
