### PR TITLE
fix(plan): preserve alter copy column sources

### DIFF
--- a/pkg/sql/plan/build_alter_change_column.go
+++ b/pkg/sql/plan/build_alter_change_column.go
@@ -109,11 +109,9 @@ func ChangeColumn(
 
 	updateClusterByInTableDef(ctx, tableDef, newColName, oldColName)
 
-	delete(alterCtx.alterColMap, oldColName)
-	alterCtx.alterColMap[newColName] = selectExpr{
-		sexprType: exprColumnName,
-		sexprStr:  oldColName,
-	}
+	// CHANGE may rename the target column, but it must preserve the original
+	// copy source (or the absence of one for a column added by this ALTER).
+	alterCtx.renameColumnSource(oldColName, newColName)
 
 	if tmpCol, ok := alterCtx.changColDefMap[oCol.ColId]; ok {
 		tmpCol.Name = newColName

--- a/pkg/sql/plan/build_alter_modify_column.go
+++ b/pkg/sql/plan/build_alter_modify_column.go
@@ -104,11 +104,6 @@ func ModifyColumn(
 		return false, err
 	}
 
-	alterCtx.alterColMap[nColName] = selectExpr{
-		sexprType: exprColumnName,
-		sexprStr:  oCol.Name,
-	}
-
 	return pkAffected, nil
 }
 

--- a/pkg/sql/plan/build_alter_rename_column.go
+++ b/pkg/sql/plan/build_alter_rename_column.go
@@ -399,12 +399,10 @@ func addRenameContextToAlterCtx(
 		return nil
 	}
 
-	// map the new column name to the old column as its data source
-	delete(alterCtx.alterColMap, oldColName)
-	alterCtx.alterColMap[newColName] = selectExpr{
-		sexprType: exprColumnName,
-		sexprStr:  oldColName,
-	}
+	// Rename the target column without changing where its copied data comes
+	// from. In particular, a column added earlier in the same ALTER has no
+	// source-table column to read from.
+	alterCtx.renameColumnSource(oldColName, newColName)
 
 	if tmpCol, ok := alterCtx.changColDefMap[oldCol.ColId]; ok {
 		tmpCol.Name = newColName

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -552,7 +552,7 @@ const UnKnownColId uint64 = math.MaxUint64
 
 type AlterTableContext struct {
 	// key   --> Copy table column name, letter case: lower
-	// value --> Original table column name
+	// value --> Expression used to populate it from the original table
 	alterColMap     map[string]selectExpr
 	schemaName      string
 	originTableName string
@@ -560,6 +560,14 @@ type AlterTableContext struct {
 	// key oldColId -> new ColDef
 	changColDefMap map[uint64]*ColDef
 	UpdateSqls     []string
+}
+
+func (ctx *AlterTableContext) renameColumnSource(oldName, newName string) {
+	source, hasSource := ctx.alterColMap[oldName]
+	delete(ctx.alterColMap, oldName)
+	if hasSource {
+		ctx.alterColMap[newName] = source
+	}
 }
 
 type exprType int

--- a/pkg/sql/plan/build_alter_table_test.go
+++ b/pkg/sql/plan/build_alter_table_test.go
@@ -438,9 +438,10 @@ func TestAlterTableCopyPreservesFinalColumnReplacementIdentity(t *testing.T) {
 
 func TestAlterTableCopySupportsActionsOnEarlierAddedColumn(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		sql       string
-		finalName string
+		name               string
+		sql                string
+		finalName          string
+		wantSelectFragment string
 	}{
 		{
 			name:      "rename",
@@ -457,6 +458,24 @@ func TestAlterTableCopySupportsActionsOnEarlierAddedColumn(t *testing.T) {
 			sql:       `ALTER TABLE t1 ADD COLUMN tmp INT, CHANGE COLUMN tmp added_col BIGINT;`,
 			finalName: "added_col",
 		},
+		{
+			name:               "rename implicit non-null default",
+			sql:                `ALTER TABLE t1 ADD COLUMN tmp INT NOT NULL, RENAME COLUMN tmp TO added_col;`,
+			finalName:          "added_col",
+			wantSelectFragment: "0",
+		},
+		{
+			name:               "modify implicit non-null default",
+			sql:                `ALTER TABLE t1 ADD COLUMN tmp INT NOT NULL, MODIFY COLUMN tmp BIGINT NOT NULL;`,
+			finalName:          "tmp",
+			wantSelectFragment: "0",
+		},
+		{
+			name:               "change implicit non-null default",
+			sql:                `ALTER TABLE t1 ADD COLUMN tmp INT NOT NULL, CHANGE COLUMN tmp added_col BIGINT NOT NULL;`,
+			finalName:          "added_col",
+			wantSelectFragment: "0",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			logicPlan, err := buildSingleStmt(NewMockOptimizer(false), t, tc.sql)
@@ -465,6 +484,16 @@ func TestAlterTableCopySupportsActionsOnEarlierAddedColumn(t *testing.T) {
 			alter := logicPlan.GetDdl().GetAlterTable()
 			require.Equal(t, plan.AlterTable_COPY, alter.AlgorithmType)
 			require.NotNil(t, FindColumn(alter.CopyTableDef.Cols, tc.finalName))
+
+			selectParts := strings.SplitN(alter.InsertTmpDataSql, " SELECT ", 2)
+			require.Len(t, selectParts, 2)
+			selectList := strings.SplitN(selectParts[1], " FROM ", 2)
+			require.Len(t, selectList, 2)
+			require.NotContains(t, selectList[0], "`tmp`",
+				"a column added by the same ALTER cannot be read from the source table")
+			if tc.wantSelectFragment != "" {
+				require.Contains(t, selectList[0], tc.wantSelectFragment)
+			}
 		})
 	}
 

--- a/test/distributed/cases/ddl/alter_table_integrity_regression.result
+++ b/test/distributed/cases/ddl/alter_table_integrity_regression.result
@@ -131,4 +131,31 @@ select count(*) from self_restrict;
 count(*)
 0
 insert into self_restrict values (3,null), (4,3);
+create table add_then_rename (id int primary key);
+insert into add_then_rename values (1), (2);
+alter table add_then_rename
+add column tmp int,
+rename column tmp to added_col;
+select id, added_col from add_then_rename order by id;
+id    added_col
+1    null
+2    null
+create table add_then_modify (id int primary key);
+insert into add_then_modify values (1), (2);
+alter table add_then_modify
+add column tmp int,
+modify column tmp bigint;
+select id, tmp from add_then_modify order by id;
+id    tmp
+1    null
+2    null
+create table add_then_change (id int primary key);
+insert into add_then_change values (1), (2);
+alter table add_then_change
+add column tmp int,
+change column tmp added_col bigint;
+select id, added_col from add_then_change order by id;
+id    added_col
+1    null
+2    null
 drop database alter_table_integrity_regression;

--- a/test/distributed/cases/ddl/alter_table_integrity_regression.sql
+++ b/test/distributed/cases/ddl/alter_table_integrity_regression.sql
@@ -1,6 +1,6 @@
 -- @suit
 -- @case
--- @desc: regressions for #26853, #26839, and #26838
+-- @desc: regressions for #26854, #26853, #26839, and #26838
 -- @label:bvt
 
 drop database if exists alter_table_integrity_regression;
@@ -120,5 +120,29 @@ insert into self_restrict values (1,null), (2,1);
 truncate table self_restrict;
 select count(*) from self_restrict;
 insert into self_restrict values (3,null), (4,3);
+
+-- #26854: a column added by the same ALTER does not exist in the source
+-- table. Later RENAME, MODIFY, and CHANGE actions must preserve that absence
+-- instead of generating an INSERT ... SELECT that reads the new column name.
+create table add_then_rename (id int primary key);
+insert into add_then_rename values (1), (2);
+alter table add_then_rename
+    add column tmp int,
+    rename column tmp to added_col;
+select id, added_col from add_then_rename order by id;
+
+create table add_then_modify (id int primary key);
+insert into add_then_modify values (1), (2);
+alter table add_then_modify
+    add column tmp int,
+    modify column tmp bigint;
+select id, tmp from add_then_modify order by id;
+
+create table add_then_change (id int primary key);
+insert into add_then_change values (1), (2);
+alter table add_then_change
+    add column tmp int,
+    change column tmp added_col bigint;
+select id, added_col from add_then_change order by id;
 
 drop database alter_table_integrity_regression;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26854

## What this PR does / why we need it:

Preserve COPY migration data-source lineage across compound ALTER TABLE actions.

- RENAME and CHANGE move the existing source expression instead of treating the intermediate column name as an original-table column
- MODIFY retains the source expression established by earlier actions
- keep the absence of a source expression for columns added earlier in the same ALTER, while preserving implicit NOT NULL values
- add planner assertions for generated INSERT ... SELECT SQL and execution BVT coverage for ADD followed by RENAME, MODIFY, and CHANGE

Validation:

- `GOWORK=off go build -mod=readonly ./pkg/sql/plan`
- `GOWORK=off go vet -mod=readonly ./pkg/sql/plan`
- `GOWORK=off go test -mod=readonly -v -count=1 -timeout 120s ./pkg/sql/plan`
- standalone MatrixOne build
- mo-tester `alter_table_integrity_regression.sql`: 68/68 passed