### PR TITLE
fix(fulltext2): gate candidate LIMIT on exact pure-MUST filters

### DIFF
--- a/pkg/fulltext2/boolean.go
+++ b/pkg/fulltext2/boolean.go
@@ -599,11 +599,11 @@ func ParseBoolean(query []byte, tok tokenizer.Tokenizer) (BoolQuery, error) {
 // clauses. Planner optimizations use the same parser/tokenizer boundary as the
 // executor instead of reinterpreting Boolean syntax.
 func IsConjunctiveTermQuery(query []byte, parser string) (bool, error) {
-	tok, err := DocTokenizer(parser)
-	if err != nil {
+	parser = normalizeParser(parser)
+	if _, err := DocTokenizer(parser); err != nil {
 		return false, err
 	}
-	q, err := ParseBoolean(query, tok)
+	q, err := buildBooleanQuery(string(query), parser)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/fulltext2/boolean.go
+++ b/pkg/fulltext2/boolean.go
@@ -594,6 +594,30 @@ func ParseBoolean(query []byte, tok tokenizer.Tokenizer) (BoolQuery, error) {
 	return q, nil
 }
 
+// IsConjunctiveTermQuery reports whether query is a pure Boolean conjunction:
+// one or more MUST clauses, each of which is a single term, with no other
+// clauses. Planner optimizations use the same parser/tokenizer boundary as the
+// executor instead of reinterpreting Boolean syntax.
+func IsConjunctiveTermQuery(query []byte, parser string) (bool, error) {
+	tok, err := DocTokenizer(parser)
+	if err != nil {
+		return false, err
+	}
+	q, err := ParseBoolean(query, tok)
+	if err != nil {
+		return false, err
+	}
+	if len(q.must) == 0 || len(q.mustNot) != 0 || len(q.should) != 0 || len(q.adjust) != 0 {
+		return false, nil
+	}
+	for _, c := range q.must {
+		if c.kind != clauseTerm {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // rawToClause builds a clause (with its impact weight) from a raw scanned clause,
 // recursing into groups. ok=false when it tokenizes to nothing.
 func rawToClause(rc rawClause, tok tokenizer.Tokenizer) (clause, bool, error) {

--- a/pkg/fulltext2/boolean_test.go
+++ b/pkg/fulltext2/boolean_test.go
@@ -167,8 +167,9 @@ func TestScanBooleanGroups(t *testing.T) {
 
 func TestIsConjunctiveTermQuery(t *testing.T) {
 	tests := []struct {
-		query string
-		want  bool
+		query  string
+		parser string
+		want   bool
 	}{
 		{query: "+alpha", want: true},
 		{query: "+alpha +beta", want: true},
@@ -180,10 +181,20 @@ func TestIsConjunctiveTermQuery(t *testing.T) {
 		{query: "+alpha -beta"},
 		{query: "+alpha beta"},
 		{query: "+alpha ~beta"},
+		{query: "+中", parser: ParserDefault},
+		{query: "+中", parser: ParserNgram},
+		{query: "+中", parser: ParserJSON},
+		{query: "+中文", parser: ParserNgram},
+		{query: "+中文学习", parser: ParserNgram},
+		{query: "+json.value", parser: ParserJSONValue, want: true},
 	}
 	for _, tc := range tests {
-		t.Run(tc.query, func(t *testing.T) {
-			got, err := IsConjunctiveTermQuery([]byte(tc.query), ParserDefault)
+		t.Run(tc.parser+"/"+tc.query, func(t *testing.T) {
+			parser := tc.parser
+			if parser == "" {
+				parser = ParserDefault
+			}
+			got, err := IsConjunctiveTermQuery([]byte(tc.query), parser)
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
 		})

--- a/pkg/fulltext2/boolean_test.go
+++ b/pkg/fulltext2/boolean_test.go
@@ -164,3 +164,31 @@ func TestScanBooleanGroups(t *testing.T) {
 	require.Equal(t, byte('~'), got[2].prefix)
 	require.Equal(t, "jumps", got[2].text)
 }
+
+func TestIsConjunctiveTermQuery(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{query: "+alpha", want: true},
+		{query: "+alpha +beta", want: true},
+		{query: "+alpha +alpha +beta", want: true},
+		{query: "alpha"},
+		{query: "+\"alpha beta\""},
+		{query: "+alpha*"},
+		{query: "+(alpha beta)"},
+		{query: "+alpha -beta"},
+		{query: "+alpha beta"},
+		{query: "+alpha ~beta"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.query, func(t *testing.T) {
+			got, err := IsConjunctiveTermQuery([]byte(tc.query), ParserDefault)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	_, err := IsConjunctiveTermQuery([]byte("+alpha"), "unsupported")
+	require.Error(t, err)
+}

--- a/pkg/sql/colexec/table_function/fulltext.go
+++ b/pkg/sql/colexec/table_function/fulltext.go
@@ -1026,9 +1026,18 @@ func fulltextIndexMatch(
 	return
 }
 
+type fulltextMembershipFilterStatus uint8
+
+const (
+	fulltextMembershipFilterReady fulltextMembershipFilterStatus = iota
+	fulltextMembershipFilterPass
+	fulltextMembershipFilterDrop
+)
+
 // fulltextMembershipFilterResult holds the result from waiting for a unique-join-keys runtime filter.
 type fulltextMembershipFilterResult struct {
 	membershipFilterBytes []byte // serialized membership-filter payload for reader-level filtering
+	status                fulltextMembershipFilterStatus
 }
 
 // waitFulltextMembershipFilter waits for a unique-join-keys runtime filter message,
@@ -1050,8 +1059,66 @@ func waitFulltextMembershipFilter(proc *process.Process, specs []*plan.RuntimeFi
 		return nil, err
 	}
 
+	payload, err := buildFulltextMembershipFilter(proc, vecbytes)
+	if err != nil {
+		return nil, err
+	}
+	return &fulltextMembershipFilterResult{
+		membershipFilterBytes: payload,
+		status:                fulltextMembershipFilterReady,
+	}, nil
+}
+
+// waitFulltext2MembershipFilter preserves PASS and DROP terminal states. A
+// FULLTEXT2 candidate LIMIT is only safe while an exact membership filter is
+// available; PASS must therefore fall back to an unbounded search, while DROP
+// can terminate the search with an empty result.
+func waitFulltext2MembershipFilter(proc *process.Process, specs []*plan.RuntimeFilterSpec) (*fulltextMembershipFilterResult, error) {
+	if !hasFulltextMembershipFilterSpec(specs) {
+		return nil, nil
+	}
+
+	sqlProc := sqlexec.NewSqlProcess(proc)
+	sqlProc.RuntimeFilterSpecs = specs
+	vecbytes, status, err := sqlexec.WaitUniqueJoinKeysWithStatus(sqlProc)
+	if err != nil {
+		return nil, err
+	}
+	switch status {
+	case sqlexec.UniqueJoinKeysPass, sqlexec.UniqueJoinKeysNone:
+		return &fulltextMembershipFilterResult{status: fulltextMembershipFilterPass}, nil
+	case sqlexec.UniqueJoinKeysDrop:
+		return &fulltextMembershipFilterResult{status: fulltextMembershipFilterDrop}, nil
+	case sqlexec.UniqueJoinKeysAvailable:
+		if len(vecbytes) == 0 {
+			return &fulltextMembershipFilterResult{status: fulltextMembershipFilterPass}, nil
+		}
+		payload, err := buildFulltextMembershipFilter(proc, vecbytes)
+		if err != nil {
+			return nil, err
+		}
+		if len(payload) == 0 {
+			return &fulltextMembershipFilterResult{status: fulltextMembershipFilterPass}, nil
+		}
+		return &fulltextMembershipFilterResult{
+			membershipFilterBytes: payload,
+			status:                fulltextMembershipFilterReady,
+		}, nil
+	default:
+		return &fulltextMembershipFilterResult{status: fulltextMembershipFilterPass}, nil
+	}
+}
+
+func hasFulltextMembershipFilterSpec(specs []*plan.RuntimeFilterSpec) bool {
+	return len(specs) > 0 && specs[0].UseMembershipFilter
+}
+
+func buildFulltextMembershipFilter(proc *process.Process, vecbytes []byte) ([]byte, error) {
+	if len(vecbytes) == 0 {
+		return nil, nil
+	}
 	keyvec := new(vector.Vector)
-	if err = keyvec.UnmarshalBinary(vecbytes); err != nil {
+	if err := keyvec.UnmarshalBinary(vecbytes); err != nil {
 		return nil, err
 	}
 	// No keyvec.Free here on purpose: UnmarshalBinary aliases vecbytes (it sets
@@ -1070,7 +1137,7 @@ func waitFulltextMembershipFilter(proc *process.Process, specs []*plan.RuntimeFi
 	if err != nil {
 		return nil, err
 	}
-	return &fulltextMembershipFilterResult{membershipFilterBytes: payload}, nil
+	return payload, nil
 }
 
 // checkFulltextZeroRelevanceGuard evaluates the optional zero-relevance guard argument

--- a/pkg/sql/colexec/table_function/fulltext2_search.go
+++ b/pkg/sql/colexec/table_function/fulltext2_search.go
@@ -44,12 +44,14 @@ import (
 // positional query, and emits (doc_id, score) rows; the top-k is bounded by the
 // pushed LIMIT, and a pushed-down WHERE prefilter is applied inside the walk.
 type fulltext2SearchState struct {
-	inited      bool
-	tblcfg      fulltext2.TableConfig
-	limit       uint64
-	offset      int
-	filterBytes []byte // serialized docfilter membership (WHERE-clause prefilter), if any
-	batch       *batch.Batch
+	inited       bool
+	tblcfg       fulltext2.TableConfig
+	limit        uint64
+	plannedLimit uint64
+	offset       int
+	filterBytes  []byte // serialized docfilter membership (WHERE-clause prefilter), if any
+	dropFilter   bool   // runtime filter DROP: the build side is empty
+	batch        *batch.Batch
 
 	// LIMIT (non-streaming) path: SearchInto fills this caller-owned, box-free result — pk
 	// (out.Keys), scores (out.Dists), covered INCLUDE cols (out.Include). Held on the state
@@ -100,6 +102,26 @@ type ft2IncludeOut struct {
 
 func (u *fulltext2SearchState) end(tf *TableFunction, proc *process.Process) error { return nil }
 
+func (u *fulltext2SearchState) applyMembershipFilterResult(res *fulltextMembershipFilterResult) {
+	if res == nil {
+		// A configured prefilter without a terminal payload is fail-open. The
+		// filter-dependent candidate bound must not survive that fallback.
+		u.limit = 0
+		return
+	}
+	switch res.status {
+	case fulltextMembershipFilterReady:
+		u.filterBytes = res.membershipFilterBytes
+	case fulltextMembershipFilterDrop:
+		u.dropFilter = true
+	case fulltextMembershipFilterPass:
+		// The candidate bound is only sound when the exact membership filter
+		// reaches the search. PASS means the producer failed open, so stream
+		// all matches and let the final join apply the residual predicate.
+		u.limit = 0
+	}
+}
+
 func (u *fulltext2SearchState) reset(tf *TableFunction, proc *process.Process) {
 	u.stopStream()
 	if u.batch != nil {
@@ -107,6 +129,8 @@ func (u *fulltext2SearchState) reset(tf *TableFunction, proc *process.Process) {
 	}
 	u.offset = 0
 	u.filterBytes = nil
+	u.limit = u.plannedLimit
+	u.dropFilter = false
 	u.streaming = false
 	u.errCh = nil
 	u.done = false
@@ -262,6 +286,7 @@ func fulltext2SearchPrepare(proc *process.Process, arg *TableFunction) (tvfState
 	if st.limit, err = evalLimitExpression(proc, arg.Limit, 0); err != nil {
 		return nil, err
 	}
+	st.plannedLimit = st.limit
 	return st, nil
 }
 
@@ -318,6 +343,8 @@ func (u *fulltext2SearchState) start(tf *TableFunction, proc *process.Process, n
 
 	u.stopStream()
 	u.offset = 0
+	u.limit = u.plannedLimit
+	u.dropFilter = false
 	u.streaming = false
 	u.done = false
 	// u.out is kept and REUSED across queries (SearchInto Resets it per query), but EMPTY it
@@ -357,14 +384,15 @@ func (u *fulltext2SearchState) start(tf *TableFunction, proc *process.Process, n
 	// runtime filter, wait for it and build the docfilter membership bytes — the same
 	// mechanism bm25_search / fulltext_index_scan use. Applied INSIDE the WAND walk so
 	// the returned top-K is already filtered (no over-fetch).
-	if u.filterBytes == nil && len(tf.RuntimeFilterSpecs) > 0 {
-		res, ferr := waitFulltextMembershipFilter(proc, tf.RuntimeFilterSpecs)
+	if u.filterBytes == nil && hasFulltextMembershipFilterSpec(tf.RuntimeFilterSpecs) {
+		res, ferr := waitFulltext2MembershipFilter(proc, tf.RuntimeFilterSpecs)
 		if ferr != nil {
 			return ferr
 		}
-		if res != nil {
-			u.filterBytes = res.membershipFilterBytes
-		}
+		u.applyMembershipFilterResult(res)
+	}
+	if u.dropFilter {
+		return nil
 	}
 
 	// Run the query through the shared VectorIndexCache: the index (base + CDC tail)

--- a/pkg/sql/colexec/table_function/fulltext2_search_test.go
+++ b/pkg/sql/colexec/table_function/fulltext2_search_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vectorindex"
 	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/message"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,6 +71,59 @@ func TestFulltext2SearchPrepareLimit(t *testing.T) {
 	// prepared `LIMIT ?` parameter (a non-literal expr resolved at EXECUTE via evalLimitExpression)
 	// is covered end-to-end by the fulltext2_prepare BVT.
 	require.Equal(t, uint64(12), mk(&plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 12}}}}).limit)
+}
+
+func TestFulltext2SearchRuntimeFilterStatus(t *testing.T) {
+	st := &fulltext2SearchState{limit: 3, plannedLimit: 3}
+
+	st.applyMembershipFilterResult(&fulltextMembershipFilterResult{
+		status: fulltextMembershipFilterPass,
+	})
+	require.Zero(t, st.limit)
+	// PASS is a per-query downgrade. Reset must restore the planned candidate
+	// bound for the next query that receives an exact membership payload.
+	st.reset(nil, nil)
+	require.Equal(t, uint64(3), st.limit)
+
+	st.applyMembershipFilterResult(&fulltextMembershipFilterResult{
+		membershipFilterBytes: []byte{1, 2, 3},
+		status:                fulltextMembershipFilterReady,
+	})
+	require.Equal(t, []byte{1, 2, 3}, st.filterBytes)
+	require.Equal(t, uint64(3), st.limit)
+
+	st.reset(nil, nil)
+	st.applyMembershipFilterResult(&fulltextMembershipFilterResult{
+		status: fulltextMembershipFilterDrop,
+	})
+	require.True(t, st.dropFilter)
+}
+
+func TestWaitFulltext2MembershipFilterPreservesTerminalState(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		typ    int32
+		status fulltextMembershipFilterStatus
+	}{
+		{name: "pass", typ: message.RuntimeFilter_PASS, status: fulltextMembershipFilterPass},
+		{name: "drop", typ: message.RuntimeFilter_DROP, status: fulltextMembershipFilterDrop},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProc(t)
+			mb := message.NewMessageBoard()
+			proc.SetMessageBoard(mb)
+			tag := int32(901)
+			message.SendMessage(message.RuntimeFilterMessage{Tag: tag, Typ: tc.typ}, mb)
+
+			res, err := waitFulltext2MembershipFilter(proc, []*plan.RuntimeFilterSpec{{
+				Tag: tag, UseMembershipFilter: true,
+			}})
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Equal(t, tc.status, res.status)
+			require.Empty(t, res.membershipFilterBytes)
+		})
+	}
 }
 
 func TestFulltext2ScoreAlgo(t *testing.T) {

--- a/pkg/sql/colexec/table_function/fulltext2_search_test.go
+++ b/pkg/sql/colexec/table_function/fulltext2_search_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vectorindex"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,6 +75,12 @@ func TestFulltext2SearchPrepareLimit(t *testing.T) {
 }
 
 func TestFulltext2SearchRuntimeFilterStatus(t *testing.T) {
+	require.False(t, hasFulltextMembershipFilterSpec(nil))
+	require.False(t, hasFulltextMembershipFilterSpec([]*plan.RuntimeFilterSpec{{}}))
+	require.True(t, hasFulltextMembershipFilterSpec([]*plan.RuntimeFilterSpec{{
+		UseMembershipFilter: true,
+	}}))
+
 	st := &fulltext2SearchState{limit: 3, plannedLimit: 3}
 
 	st.applyMembershipFilterResult(&fulltextMembershipFilterResult{
@@ -97,6 +104,65 @@ func TestFulltext2SearchRuntimeFilterStatus(t *testing.T) {
 		status: fulltextMembershipFilterDrop,
 	})
 	require.True(t, st.dropFilter)
+
+	// A missing terminal payload on a configured membership-filter path is the
+	// same fail-open state as PASS. It must not retain the filter-dependent cap.
+	st.reset(nil, nil)
+	st.applyMembershipFilterResult(nil)
+	require.Zero(t, st.limit)
+	require.False(t, st.dropFilter)
+
+	// A fresh state with no configured membership-filter path never calls the
+	// downgrade helper, so the ordinary no-residual candidate bound is retained.
+	noPrefilter := &fulltext2SearchState{limit: 3, plannedLimit: 3}
+	require.Equal(t, uint64(3), noPrefilter.limit)
+}
+
+func TestFulltext2SearchPassPreventsCandidateUnderfill(t *testing.T) {
+	type candidate struct {
+		id      int64
+		allowed bool
+	}
+	// Relevance order: the two highest-scoring rows fail the residual WHERE,
+	// while the next two rows are the correct LIMIT 2 result.
+	candidates := []candidate{
+		{id: 1},
+		{id: 2},
+		{id: 3, allowed: true},
+		{id: 4, allowed: true},
+	}
+	filterAfterSearch := func(limit uint64) []int64 {
+		end := len(candidates)
+		if limit > 0 && int(limit) < end {
+			end = int(limit)
+		}
+		result := make([]int64, 0, 2)
+		for _, item := range candidates[:end] {
+			if item.allowed {
+				result = append(result, item.id)
+			}
+		}
+		return result
+	}
+
+	st := &fulltext2SearchState{limit: 2, plannedLimit: 2}
+	require.Empty(t, filterAfterSearch(st.limit),
+		"retaining the bound after a filter fallback would under-fill")
+
+	proc := testutil.NewProc(t)
+	mb := message.NewMessageBoard()
+	proc.SetMessageBoard(mb)
+	tag := int32(902)
+	message.SendMessage(message.RuntimeFilterMessage{
+		Tag: tag, Typ: message.RuntimeFilter_PASS,
+	}, mb)
+	res, err := waitFulltext2MembershipFilter(proc, []*plan.RuntimeFilterSpec{{
+		Tag: tag, UseMembershipFilter: true,
+	}})
+	require.NoError(t, err)
+	require.Equal(t, fulltextMembershipFilterPass, res.status)
+	st.applyMembershipFilterResult(res)
+	require.Equal(t, []int64{3, 4}, filterAfterSearch(st.limit))
 }
 
 func TestWaitFulltext2MembershipFilterPreservesTerminalState(t *testing.T) {
@@ -124,6 +190,78 @@ func TestWaitFulltext2MembershipFilterPreservesTerminalState(t *testing.T) {
 			require.Empty(t, res.membershipFilterBytes)
 		})
 	}
+}
+
+func TestFulltextMembershipFilterPaths(t *testing.T) {
+	spec := func(tag int32, enabled bool) []*plan.RuntimeFilterSpec {
+		return []*plan.RuntimeFilterSpec{{Tag: tag, UseMembershipFilter: enabled}}
+	}
+
+	// Both waiters must keep the existing no-filter behavior for an absent or
+	// disabled runtime-filter specification.
+	proc := testutil.NewProc(t)
+	res, err := waitFulltextMembershipFilter(proc, nil)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	res, err = waitFulltext2MembershipFilter(proc, spec(910, false))
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	// Build one production-shaped serialized key vector and feed it through the
+	// message board. This exercises the UNIQUEJOINKEYS -> docfilter path for
+	// both the legacy FULLTEXT waiter and FULLTEXT2's status-preserving waiter.
+	makePayload := func(t *testing.T) (*process.Process, []*plan.RuntimeFilterSpec, []byte) {
+		proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+		mb := message.NewMessageBoard()
+		proc.SetMessageBoard(mb)
+		vec := vector.NewVec(types.T_int64.ToType())
+		require.NoError(t, vector.AppendFixed(vec, int64(11), false, proc.Mp()))
+		require.NoError(t, vector.AppendFixed(vec, int64(22), false, proc.Mp()))
+		data, err := vec.MarshalBinary()
+		require.NoError(t, err)
+		message.SendMessage(message.RuntimeFilterMessage{
+			Tag:  910,
+			Typ:  message.RuntimeFilter_UNIQUEJOINKEYS,
+			Data: data,
+		}, mb)
+		return proc, spec(910, true), data
+	}
+
+	proc, specs, _ := makePayload(t)
+	res, err = waitFulltextMembershipFilter(proc, specs)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, fulltextMembershipFilterReady, res.status)
+	require.NotEmpty(t, res.membershipFilterBytes)
+
+	proc, specs, _ = makePayload(t)
+	res, err = waitFulltext2MembershipFilter(proc, specs)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, fulltextMembershipFilterReady, res.status)
+	require.NotEmpty(t, res.membershipFilterBytes)
+
+	// An available terminal with no payload is a safe fail-open result. A
+	// malformed payload remains an error rather than silently becoming a filter.
+	proc = testutil.NewProc(t)
+	mb := message.NewMessageBoard()
+	proc.SetMessageBoard(mb)
+	message.SendMessage(message.RuntimeFilterMessage{Tag: 911, Typ: message.RuntimeFilter_UNIQUEJOINKEYS}, mb)
+	res, err = waitFulltext2MembershipFilter(proc, spec(911, true))
+	require.NoError(t, err)
+	require.Equal(t, fulltextMembershipFilterPass, res.status)
+
+	proc = testutil.NewProc(t)
+	mb = message.NewMessageBoard()
+	proc.SetMessageBoard(mb)
+	message.SendMessage(message.RuntimeFilterMessage{Tag: 912, Typ: message.RuntimeFilter_UNIQUEJOINKEYS, Data: []byte{1, 2, 3}}, mb)
+	_, err = waitFulltext2MembershipFilter(proc, spec(912, true))
+	require.Error(t, err)
+
+	_, err = buildFulltextMembershipFilter(proc, nil)
+	require.NoError(t, err)
+	_, err = buildFulltextMembershipFilter(proc, []byte{1, 2, 3})
+	require.Error(t, err)
 }
 
 func TestFulltext2ScoreAlgo(t *testing.T) {

--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/docfilter"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -410,20 +411,29 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 		}
 	}
 
-	// A single fulltext stream can safely keep LIMIT+OFFSET candidates. With
-	// multiple streams, limiting each input before their intersection can drop
-	// documents that belong to the final top page, so leave those inputs
-	// unbounded until a joint top-k implementation exists.
-	//
-	// A lifted wrapped-MATCH predicate counts here exactly like a filter left on the scan, and
-	// this must be tested AFTER the lift emptied scanNode.FilterList -- otherwise removing the
-	// predicate from the scan is what makes the cap look safe. The predicate now runs in the
-	// FILTER node ABOVE the join, so capping the stream below it hands that filter only the
-	// top-relevance candidates: `where sc < 0.05 limit 1` would cap the stream to its single
-	// highest-scoring document and then reject it, returning nothing while qualifying rows sit
-	// just below the cap.
+	// Resolve the residual-WHERE prefilter before deciding whether the internal
+	// fulltext stream may keep only LIMIT+OFFSET candidates. The early LIMIT is
+	// correctness-safe only when that prefilter is exact.
+	pushdownEnabled := len(scanNode.FilterList) > 0
+	if pushdownEnabled && types.T(pkType.Id).IsInteger() &&
+		!localProtocolEnablesSortedMembershipFilter(builder.compCtx.GetProcess().GetService()) {
+		pushdownEnabled = false
+	}
+	if pushdownEnabled {
+		if val, err := builder.compCtx.ResolveVariable("fulltext_bloom_filter_pushdown", true, false); err == nil {
+			if v, ok := val.(int8); ok && v == 0 {
+				pushdownEnabled = false
+			}
+		}
+	}
+
+	exactPrefilter := docfilter.SupportsBitset(types.T(pkType.Id).ToType())
+
+	// A lifted wrapped-MATCH predicate counts here exactly like a filter left on the scan. It
+	// runs above the join, so limiting the stream below it can under-fill the final result.
 	limitExpr := builder.buildFullTextCandidateLimit(
-		scanNode, wrappedMatchFilters, ft_filters, paginationLimit, paginationOffset)
+		scanNode, wrappedMatchFilters, ft_filters, pushdownEnabled, exactPrefilter,
+		paginationLimit, paginationOffset)
 
 	// buildFullTextIndexScan
 	var last_node_id int32
@@ -630,20 +640,6 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	// Determine join structure based on whether scanNode still has non-fulltext filters.
 	// When filters remain, use pre-filter pushdown (nested JOIN + runtime filter)
 	// to reduce the number of doc_ids that fulltext_index_scan must process.
-	pushdownEnabled := len(scanNode.FilterList) > 0
-	if pushdownEnabled && types.T(pkType.Id).IsInteger() &&
-		!localProtocolEnablesSortedMembershipFilter(
-			builder.compCtx.GetProcess().GetService()) {
-		pushdownEnabled = false
-	}
-	if pushdownEnabled {
-		if val, err := builder.compCtx.ResolveVariable("fulltext_bloom_filter_pushdown", true, false); err == nil {
-			if v, ok := val.(int8); ok && v == 0 {
-				pushdownEnabled = false
-			}
-		}
-	}
-
 	var joinnodeID int32
 
 	if pushdownEnabled {
@@ -936,11 +932,18 @@ func (builder *QueryBuilder) buildFullTextCandidateLimit(
 	scanNode *plan.Node,
 	wrappedMatchFilters []*plan.Expr,
 	fullTextFilters []*plan.Expr,
+	prefilterPushdown bool,
+	exactPrefilter bool,
 	paginationLimit *plan.Expr,
 	paginationOffset *plan.Expr,
 ) *plan.Expr {
-	if builder.sqlCalcFoundRows || scanNode == nil || len(scanNode.FilterList) != 0 ||
+	if builder.sqlCalcFoundRows || scanNode == nil ||
 		len(wrappedMatchFilters) != 0 || len(fullTextFilters) != 1 {
+		return nil
+	}
+	if !shouldPushFulltextCandidateLimit(
+		len(fullTextFilters), len(scanNode.FilterList), prefilterPushdown, exactPrefilter,
+	) {
 		return nil
 	}
 	limit, _ := buildCandidateLimit(paginationLimit, paginationOffset)

--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -432,7 +432,7 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	// A lifted wrapped-MATCH predicate counts here exactly like a filter left on the scan. It
 	// runs above the join, so limiting the stream below it can under-fill the final result.
 	limitExpr := builder.buildFullTextCandidateLimit(
-		scanNode, wrappedMatchFilters, ft_filters, pushdownEnabled, exactPrefilter,
+		scanNode, wrappedMatchFilters, ft_filters, indexDefs, pushdownEnabled, exactPrefilter,
 		paginationLimit, paginationOffset)
 
 	// buildFullTextIndexScan
@@ -932,6 +932,7 @@ func (builder *QueryBuilder) buildFullTextCandidateLimit(
 	scanNode *plan.Node,
 	wrappedMatchFilters []*plan.Expr,
 	fullTextFilters []*plan.Expr,
+	indexDefs []*plan.IndexDef,
 	prefilterPushdown bool,
 	exactPrefilter bool,
 	paginationLimit *plan.Expr,
@@ -941,9 +942,20 @@ func (builder *QueryBuilder) buildFullTextCandidateLimit(
 		len(wrappedMatchFilters) != 0 || len(fullTextFilters) != 1 {
 		return nil
 	}
+	if len(scanNode.FilterList) == 0 {
+		limit, _ := buildCandidateLimit(paginationLimit, paginationOffset)
+		return limit
+	}
 	if !shouldPushFulltextCandidateLimit(
 		len(fullTextFilters), len(scanNode.FilterList), prefilterPushdown, exactPrefilter,
-	) {
+	) || len(indexDefs) != 1 ||
+		!fulltext2ConjunctiveCandidateLimitEligible(fullTextFilters[0], indexDefs[0]) {
+		return nil
+	}
+	// The residual-filter path is admitted at plan time, so prepared or dynamic
+	// LIMIT values remain unbounded. The no-residual path above preserves main's
+	// existing dynamic-LIMIT behavior.
+	if _, literal := getLiteralUint64(paginationLimit); !literal {
 		return nil
 	}
 	limit, _ := buildCandidateLimit(paginationLimit, paginationOffset)

--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -426,6 +426,18 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 			}
 		}
 	}
+	if pushdownEnabled {
+		for _, filter := range scanNode.FilterList {
+			if containsVolatileFunction(filter) {
+				// The prefilter topology evaluates residual filters in both the
+				// candidate scan and the final scan. A volatile predicate can
+				// produce different results in those evaluations, so it cannot
+				// safely participate in candidate-limit pushdown.
+				pushdownEnabled = false
+				break
+			}
+		}
+	}
 
 	exactPrefilter := docfilter.SupportsBitset(types.T(pkType.Id).ToType())
 

--- a/pkg/sql/plan/apply_indices_fulltext2.go
+++ b/pkg/sql/plan/apply_indices_fulltext2.go
@@ -28,9 +28,30 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	fulltext2engine "github.com/matrixorigin/matrixone/pkg/fulltext2"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
+
+func fulltext2ConjunctiveCandidateLimitEligible(match *plan.Expr, idxdef *plan.IndexDef) bool {
+	if match == nil || idxdef == nil || !catalog.IsFullText2IndexAlgo(idxdef.IndexAlgo) {
+		return false
+	}
+	fn := match.GetF()
+	if fn == nil || len(fn.Args) < 2 {
+		return false
+	}
+	pattern, mode := fn.Args[0].GetLit(), fn.Args[1].GetLit()
+	if pattern == nil || pattern.Isnull || mode == nil || mode.Isnull ||
+		mode.GetI64Val() != int64(tree.FULLTEXT_BOOLEAN) {
+		return false
+	}
+	eligible, err := fulltext2engine.IsConjunctiveTermQuery(
+		[]byte(pattern.GetSval()),
+		fulltext2ParserFromParams(idxdef.IndexAlgoParams),
+	)
+	return err == nil && eligible
+}
 
 // fulltext2PeelablePkColName returns the pk column name ONLY when the pk's type is one the
 // fulltext2 in-index predicate evaluator can actually compare — the integer family (incl.

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/fulltext2"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	statspb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
@@ -5246,6 +5247,25 @@ func TestFullTextCandidateLimitIncludesOffset(t *testing.T) {
 	require.Nil(t, scan.Offset)
 }
 
+func TestFullTextCandidateLimitWithoutResidualFilterKeepsDynamicLimit(t *testing.T) {
+	builder, joinID, leftScanID, _ := buildFullTextJoinRewriteTestPlan(t, true, false, false)
+	scan := builder.qry.Nodes[leftScanID]
+	scan.Limit = &planpb.Expr{Expr: &planpb.Expr_P{P: &planpb.ParamRef{Pos: 0}}}
+
+	newID, changed, err := builder.applyFullTextFiltersForScanInJoin(
+		joinID,
+		scan,
+		map[[2]int32]int{},
+		map[[2]int32]*planpb.Expr{},
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	functions := collectFullTextFunctionScans(builder, newID)
+	require.Len(t, functions, 1)
+	require.NotNil(t, functions[0].Limit.GetP())
+	require.Equal(t, int32(0), functions[0].Limit.GetP().Pos)
+}
+
 func TestFullTextCandidateLimitSQLCalcFoundRowsKeepsCompleteStream(t *testing.T) {
 	builder, joinID, leftScanID, _ := buildFullTextJoinRewriteTestPlan(t, true, false, false)
 	builder.sqlCalcFoundRows = true
@@ -5274,23 +5294,41 @@ func TestFullTextCandidateLimitSQLCalcFoundRowsKeepsCompleteStream(t *testing.T)
 func TestFullTextCandidateLimitWithResidualFilterRequiresExactPrefilter(t *testing.T) {
 	tests := []struct {
 		name            string
-		integerPK       bool
+		pkType          types.T
 		pushdown        int8
 		dynamicLimit    bool
 		preparedPattern bool
-		naturalMode     bool
+		mode            tree.FullTextSearchType
 		classicIndex    bool
+		parser          string
 		pattern         string
 		wantCandidateK  bool
 	}{
-		{name: "exact integer prefilter", integerPK: true, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
-		{name: "approximate varchar prefilter", pushdown: 1, pattern: "+hello +world"},
-		{name: "pushdown disabled", integerPK: true, pattern: "+hello +world"},
-		{name: "prepared limit", integerPK: true, pushdown: 1, dynamicLimit: true, pattern: "+hello +world"},
-		{name: "prepared pattern", integerPK: true, pushdown: 1, preparedPattern: true},
-		{name: "natural mode", integerPK: true, pushdown: 1, naturalMode: true, pattern: "hello world"},
-		{name: "complex boolean", integerPK: true, pushdown: 1, pattern: "+hello world"},
-		{name: "classic index", integerPK: true, pushdown: 1, classicIndex: true, pattern: "+hello +world"},
+		{name: "exact int8 prefilter", pkType: types.T_int8, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "exact int16 prefilter", pkType: types.T_int16, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "exact int32 prefilter", pkType: types.T_int32, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "exact int64 prefilter", pkType: types.T_int64, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "exact uint8 prefilter", pkType: types.T_uint8, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "exact uint16 prefilter", pkType: types.T_uint16, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "exact uint32 prefilter", pkType: types.T_uint32, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "exact uint64 prefilter", pkType: types.T_uint64, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "bit is not an exact membership type", pkType: types.T_bit, pushdown: 1, pattern: "+hello +world"},
+		{name: "approximate varchar prefilter", pkType: types.T_varchar, pushdown: 1, pattern: "+hello +world"},
+		{name: "uuid prefilter", pkType: types.T_uuid, pushdown: 1, pattern: "+hello +world"},
+		{name: "pushdown disabled", pkType: types.T_int64, pattern: "+hello +world"},
+		{name: "prepared limit", pkType: types.T_int64, pushdown: 1, dynamicLimit: true, pattern: "+hello +world"},
+		{name: "prepared pattern", pkType: types.T_int64, pushdown: 1, preparedPattern: true},
+		{name: "natural mode", pkType: types.T_int64, pushdown: 1, mode: tree.FULLTEXT_NL, pattern: "hello world"},
+		{name: "should clause", pkType: types.T_int64, pushdown: 1, pattern: "+hello world"},
+		{name: "explicit phrase", pkType: types.T_int64, pushdown: 1, pattern: `+"hello world"`},
+		{name: "prefix", pkType: types.T_int64, pushdown: 1, pattern: "+hello*"},
+		{name: "group", pkType: types.T_int64, pushdown: 1, pattern: "+(hello world)"},
+		{name: "must not", pkType: types.T_int64, pushdown: 1, pattern: "+hello -world"},
+		{name: "adjust", pkType: types.T_int64, pushdown: 1, pattern: "+hello ~world"},
+		{name: "default cjk becomes phrase", pkType: types.T_int64, pushdown: 1, pattern: "+中"},
+		{name: "ngram cjk becomes phrase", pkType: types.T_int64, pushdown: 1, parser: fulltext2.ParserNgram, pattern: "+中文"},
+		{name: "json value atomic term", pkType: types.T_int64, pushdown: 1, parser: fulltext2.ParserJSONValue, pattern: "+json.value", wantCandidateK: true},
+		{name: "classic index", pkType: types.T_int64, pushdown: 1, classicIndex: true, pattern: "+hello +world"},
 	}
 
 	for _, tc := range tests {
@@ -5301,6 +5339,9 @@ func TestFullTextCandidateLimitWithResidualFilterRequiresExactPrefilter(t *testi
 			scan := builder.qry.Nodes[leftScanID]
 			if !tc.classicIndex {
 				convertFullTextJoinTestToFulltext2(builder, scan)
+				if tc.parser != "" {
+					scan.TableDef.Indexes[0].IndexAlgoParams = fmt.Sprintf(`{"parser":%q}`, tc.parser)
+				}
 			}
 			matchFn := scan.FilterList[0].GetF()
 			if tc.preparedPattern {
@@ -5308,17 +5349,15 @@ func TestFullTextCandidateLimitWithResidualFilterRequiresExactPrefilter(t *testi
 			} else {
 				matchFn.Args[0] = makePlan2StringConstExprWithType(tc.pattern, false)
 			}
-			mode := tree.FULLTEXT_BOOLEAN
-			if tc.naturalMode {
-				mode = tree.FULLTEXT_NL
+			mode := tc.mode
+			if mode == 0 {
+				mode = tree.FULLTEXT_BOOLEAN
 			}
 			matchFn.Args[1] = makePlan2Int64ConstExprWithType(int64(mode))
-			if tc.integerPK {
-				int64Type := planpb.Type{Id: int32(types.T_int64)}
-				scan.TableDef.Cols[0].Typ = int64Type
-				indexTable := mockCtx.tables[strings.ToLower(scan.TableDef.Indexes[0].IndexTableName)]
-				indexTable.Cols[1].Typ = int64Type
-			}
+			pkType := planpb.Type{Id: int32(tc.pkType)}
+			scan.TableDef.Cols[0].Typ = pkType
+			indexTable := mockCtx.tables[strings.ToLower(scan.TableDef.Indexes[0].IndexTableName)]
+			indexTable.Cols[1].Typ = pkType
 			if tc.dynamicLimit {
 				scan.Limit = &planpb.Expr{Expr: &planpb.Expr_P{P: &planpb.ParamRef{Pos: 0}}}
 			} else {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -5384,6 +5384,62 @@ func TestFullTextCandidateLimitWithResidualFilterRequiresExactPrefilter(t *testi
 	}
 }
 
+func TestFullTextCandidateLimitRejectsVolatileResidualFilter(t *testing.T) {
+	builder, joinID, leftScanID, _ := buildFullTextJoinRewriteTestPlan(t, true, false, true)
+	mockCtx := builder.compCtx.(*fullTextJoinMockCompilerContext)
+	mockCtx.fulltextBloomFilterPushdown = 1
+	scan := builder.qry.Nodes[leftScanID]
+	convertFullTextJoinTestToFulltext2(builder, scan)
+
+	pkType := planpb.Type{Id: int32(types.T_int64)}
+	scan.TableDef.Cols[0].Typ = pkType
+	indexTable := mockCtx.tables[strings.ToLower(scan.TableDef.Indexes[0].IndexTableName)]
+	indexTable.Cols[1].Typ = pkType
+	matchFn := scan.FilterList[0].GetF()
+	matchFn.Args[0] = makePlan2StringConstExprWithType("+needle +world", false)
+	matchFn.Args[1] = makePlan2Int64ConstExprWithType(int64(tree.FULLTEXT_BOOLEAN))
+	scan.FilterList = append(scan.FilterList,
+		makeVolatileJoinFilter(t, mockCtx.MockCompilerContext, nil))
+	scan.Limit = makePlan2Uint64ConstExprWithType(2)
+	scan.Offset = makePlan2Uint64ConstExprWithType(1)
+
+	newID, changed, err := builder.applyFullTextFiltersForScanInJoin(
+		joinID,
+		scan,
+		map[[2]int32]int{},
+		map[[2]int32]*planpb.Expr{},
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	functions := collectFullTextFunctionScans(builder, newID)
+	require.Len(t, functions, 1)
+	require.Nil(t, functions[0].Limit,
+		"a volatile residual must not receive a filter-dependent candidate bound")
+
+	var volatileScanNodes int
+	var visit func(int32)
+	visit = func(nodeID int32) {
+		node := builder.qry.Nodes[nodeID]
+		if node == nil {
+			return
+		}
+		if node.NodeType == planpb.Node_TABLE_SCAN {
+			for _, filter := range node.FilterList {
+				if containsVolatileFunction(filter) {
+					volatileScanNodes++
+					break
+				}
+			}
+		}
+		for _, childID := range node.Children {
+			visit(childID)
+		}
+	}
+	visit(newID)
+	require.Equal(t, 1, volatileScanNodes,
+		"the volatile residual must be evaluated only by the final scan")
+}
+
 func convertFullTextJoinTestToFulltext2(builder *QueryBuilder, scan *planpb.Node) {
 	logical := scan.TableDef.Indexes[0]
 	store := *logical

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -5271,6 +5271,94 @@ func TestFullTextCandidateLimitSQLCalcFoundRowsKeepsCompleteStream(t *testing.T)
 	require.Nil(t, scan.Offset)
 }
 
+func TestFullTextCandidateLimitWithResidualFilterRequiresExactPrefilter(t *testing.T) {
+	tests := []struct {
+		name            string
+		integerPK       bool
+		pushdown        int8
+		dynamicLimit    bool
+		preparedPattern bool
+		naturalMode     bool
+		classicIndex    bool
+		pattern         string
+		wantCandidateK  bool
+	}{
+		{name: "exact integer prefilter", integerPK: true, pushdown: 1, pattern: "+hello +world", wantCandidateK: true},
+		{name: "approximate varchar prefilter", pushdown: 1, pattern: "+hello +world"},
+		{name: "pushdown disabled", integerPK: true, pattern: "+hello +world"},
+		{name: "prepared limit", integerPK: true, pushdown: 1, dynamicLimit: true, pattern: "+hello +world"},
+		{name: "prepared pattern", integerPK: true, pushdown: 1, preparedPattern: true},
+		{name: "natural mode", integerPK: true, pushdown: 1, naturalMode: true, pattern: "hello world"},
+		{name: "complex boolean", integerPK: true, pushdown: 1, pattern: "+hello world"},
+		{name: "classic index", integerPK: true, pushdown: 1, classicIndex: true, pattern: "+hello +world"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, joinID, leftScanID, _ := buildFullTextJoinRewriteTestPlan(t, true, false, true)
+			mockCtx := builder.compCtx.(*fullTextJoinMockCompilerContext)
+			mockCtx.fulltextBloomFilterPushdown = tc.pushdown
+			scan := builder.qry.Nodes[leftScanID]
+			if !tc.classicIndex {
+				convertFullTextJoinTestToFulltext2(builder, scan)
+			}
+			matchFn := scan.FilterList[0].GetF()
+			if tc.preparedPattern {
+				matchFn.Args[0] = &planpb.Expr{Expr: &planpb.Expr_P{P: &planpb.ParamRef{Pos: 0}}}
+			} else {
+				matchFn.Args[0] = makePlan2StringConstExprWithType(tc.pattern, false)
+			}
+			mode := tree.FULLTEXT_BOOLEAN
+			if tc.naturalMode {
+				mode = tree.FULLTEXT_NL
+			}
+			matchFn.Args[1] = makePlan2Int64ConstExprWithType(int64(mode))
+			if tc.integerPK {
+				int64Type := planpb.Type{Id: int32(types.T_int64)}
+				scan.TableDef.Cols[0].Typ = int64Type
+				indexTable := mockCtx.tables[strings.ToLower(scan.TableDef.Indexes[0].IndexTableName)]
+				indexTable.Cols[1].Typ = int64Type
+			}
+			if tc.dynamicLimit {
+				scan.Limit = &planpb.Expr{Expr: &planpb.Expr_P{P: &planpb.ParamRef{Pos: 0}}}
+			} else {
+				scan.Limit = makePlan2Uint64ConstExprWithType(10)
+			}
+			scan.Offset = makePlan2Uint64ConstExprWithType(5)
+
+			newID, changed, err := builder.applyFullTextFiltersForScanInJoin(
+				joinID,
+				scan,
+				map[[2]int32]int{},
+				map[[2]int32]*planpb.Expr{},
+			)
+			require.NoError(t, err)
+			require.True(t, changed)
+			functions := collectFullTextFunctionScans(builder, newID)
+			require.Len(t, functions, 1)
+			if tc.wantCandidateK {
+				require.Equal(t, uint64(15), functions[0].Limit.GetLit().GetU64Val())
+			} else {
+				require.Nil(t, functions[0].Limit)
+			}
+		})
+	}
+}
+
+func convertFullTextJoinTestToFulltext2(builder *QueryBuilder, scan *planpb.Node) {
+	logical := scan.TableDef.Indexes[0]
+	store := *logical
+	store.IndexAlgo = tree.INDEX_TYPE_FULLTEXT2.ToString()
+	store.IndexAlgoParams = `{"parser":"default"}`
+	store.IndexAlgoTableType = catalog.FullText2Index_TblType_Storage
+	store.IndexTableName = logical.IndexTableName + "_store"
+	meta := store
+	meta.IndexAlgoTableType = catalog.FullText2Index_TblType_Metadata
+	meta.IndexTableName = logical.IndexTableName + "_meta"
+	scan.TableDef.Indexes = []*planpb.IndexDef{&store, &meta}
+	registerFullTextJoinRegularIndexTable(builder, store.IndexTableName)
+}
+
 func TestFullTextDoesNotLimitIndependentIntersectionInputs(t *testing.T) {
 	builder, joinID, leftScanID, _ := buildFullTextJoinRewriteTestPlan(t, true, false, false)
 	scan := builder.qry.Nodes[leftScanID]
@@ -5526,6 +5614,7 @@ func buildFullTextJoinRewriteTestPlan(t *testing.T, leftFullText, rightFullText,
 
 type fullTextJoinMockCompilerContext struct {
 	*MockCompilerContext
+	fulltextBloomFilterPushdown int8
 }
 
 func newFullTextJoinMockCompilerContext() *fullTextJoinMockCompilerContext {
@@ -5535,6 +5624,9 @@ func newFullTextJoinMockCompilerContext() *fullTextJoinMockCompilerContext {
 func (m *fullTextJoinMockCompilerContext) ResolveVariable(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
 	if varName == "ft_relevancy_algorithm" {
 		return "", nil
+	}
+	if varName == "fulltext_bloom_filter_pushdown" {
+		return m.fulltextBloomFilterPushdown, nil
 	}
 	return m.MockCompilerContext.ResolveVariable(varName, isSystemVar, isGlobalVar)
 }
@@ -5676,10 +5768,11 @@ func collectFullTextFunctionScans(builder *QueryBuilder, nodeID int32) []*planpb
 
 	var nodes []*planpb.Node
 	if node.NodeType == planpb.Node_FUNCTION_SCAN &&
-		node.TableDef != nil &&
-		node.TableDef.TblFunc != nil &&
-		node.TableDef.TblFunc.Name == fulltext_index_scan_func_name {
-		nodes = append(nodes, node)
+		node.TableDef != nil && node.TableDef.TblFunc != nil {
+		name := node.TableDef.TblFunc.Name
+		if name == fulltext_index_scan_func_name || name == fulltext2_search_func_name {
+			nodes = append(nodes, node)
+		}
 	}
 	for _, childID := range node.Children {
 		nodes = append(nodes, collectFullTextFunctionScans(builder, childID)...)

--- a/pkg/sql/plan/limit_utils.go
+++ b/pkg/sql/plan/limit_utils.go
@@ -20,6 +20,15 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 )
 
+// shouldPushFulltextCandidateLimit reports whether one fulltext stream sees the
+// complete candidate domain for LIMIT+OFFSET. A residual source predicate is
+// safe only when prefilter pushdown applies an exact membership filter inside
+// search. A Bloom false positive can otherwise displace a true top-k row before
+// the final join removes it.
+func shouldPushFulltextCandidateLimit(fulltextStreams, residualFilters int, prefilterPushdown, exactPrefilter bool) bool {
+	return fulltextStreams == 1 && (residualFilters == 0 || prefilterPushdown && exactPrefilter)
+}
+
 // getLiteralUint64 returns a LIMIT/OFFSET value only when it is already a
 // uint64 literal. Optimizer rules must not treat a non-literal expression as
 // zero: prepared parameters and variables are evaluated at execution time.

--- a/pkg/sql/plan/limit_utils_test.go
+++ b/pkg/sql/plan/limit_utils_test.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"math"
+	"sort"
 	"testing"
 
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -30,6 +31,7 @@ func TestBuildCandidateLimit(t *testing.T) {
 		want       uint64
 		wantUsable bool
 	}{
+		{name: "no limit"},
 		{name: "limit only", limit: makePlan2Uint64ConstExprWithType(10), want: 10, wantUsable: true},
 		{name: "limit plus offset", limit: makePlan2Uint64ConstExprWithType(10), offset: makePlan2Uint64ConstExprWithType(5), want: 15, wantUsable: true},
 		{name: "zero offset", limit: makePlan2Uint64ConstExprWithType(10), offset: makePlan2Uint64ConstExprWithType(0), want: 10, wantUsable: true},
@@ -79,4 +81,37 @@ func TestShouldPushFulltextCandidateLimit(t *testing.T) {
 			require.Equal(t, tc.want, shouldPushFulltextCandidateLimit(tc.fulltextStreams, tc.residualFilters, tc.prefilterPushdown, tc.exactPrefilter))
 		})
 	}
+}
+
+func TestApproximatePrefilterCannotBoundCandidateTopK(t *testing.T) {
+	type candidate struct {
+		id      string
+		score   float32
+		allowed bool
+	}
+	candidates := []candidate{
+		{id: "bloom-false-positive", score: 2, allowed: false},
+		{id: "true-result", score: 1, allowed: true},
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].score > candidates[j].score
+	})
+
+	filterAllowed := func(in []candidate) []candidate {
+		out := make([]candidate, 0, len(in))
+		for _, item := range in {
+			if item.allowed {
+				out = append(out, item)
+			}
+		}
+		return out
+	}
+
+	// Bounding an approximate membership stream first lets a higher-scoring
+	// false positive occupy the only candidate slot. The final exact join then
+	// removes it and under-fills LIMIT 1.
+	require.Empty(t, filterAllowed(candidates[:1]))
+	require.Equal(t, "true-result", filterAllowed(candidates)[0].id)
+	require.False(t, shouldPushFulltextCandidateLimit(1, 1, true, false))
+	require.True(t, shouldPushFulltextCandidateLimit(1, 1, true, true))
 }

--- a/pkg/sql/plan/limit_utils_test.go
+++ b/pkg/sql/plan/limit_utils_test.go
@@ -56,3 +56,27 @@ func TestBuildCandidateLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldPushFulltextCandidateLimit(t *testing.T) {
+	tests := []struct {
+		name              string
+		fulltextStreams   int
+		residualFilters   int
+		prefilterPushdown bool
+		exactPrefilter    bool
+		want              bool
+	}{
+		{name: "single stream without residual filter", fulltextStreams: 1, want: true},
+		{name: "single stream with exact pushed residual filter", fulltextStreams: 1, residualFilters: 1, prefilterPushdown: true, exactPrefilter: true, want: true},
+		{name: "single stream with approximate pushed residual filter", fulltextStreams: 1, residualFilters: 1, prefilterPushdown: true, want: false},
+		{name: "single stream with unpushed residual filter", fulltextStreams: 1, residualFilters: 1, want: false},
+		{name: "multiple streams without residual filter", fulltextStreams: 2, want: false},
+		{name: "multiple streams with exact pushed residual filter", fulltextStreams: 2, residualFilters: 1, prefilterPushdown: true, exactPrefilter: true, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldPushFulltextCandidateLimit(tc.fulltextStreams, tc.residualFilters, tc.prefilterPushdown, tc.exactPrefilter))
+		})
+	}
+}

--- a/pkg/vectorindex/sqlexec/bloomfilter.go
+++ b/pkg/vectorindex/sqlexec/bloomfilter.go
@@ -29,6 +29,19 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
 )
 
+// UniqueJoinKeysStatus describes the terminal state of a unique-join-keys
+// runtime filter. PASS means that the producer could not safely construct an
+// exact filter and the consumer must fall back to an unfiltered plan. DROP
+// means that the build side is empty and the consumer can return no rows.
+type UniqueJoinKeysStatus uint8
+
+const (
+	UniqueJoinKeysNone UniqueJoinKeysStatus = iota
+	UniqueJoinKeysAvailable
+	UniqueJoinKeysPass
+	UniqueJoinKeysDrop
+)
+
 // WaitUniqueJoinKeys blocks until it receives a RuntimeFilter_UNIQUEJOINKEYS message
 // that matches sqlproc.RuntimeFilterSpecs (if any). It returns the raw serialized
 // unique join key bytes from the build side.
@@ -36,16 +49,32 @@ import (
 // The caller is responsible for deserializing the bytes and deciding how to use
 // them (e.g. exact pk IN filter vs a membership filter based on its own threshold).
 func WaitUniqueJoinKeys(sqlproc *SqlProcess) ([]byte, error) {
+	data, status, err := waitUniqueJoinKeys(sqlproc, false)
+	if status != UniqueJoinKeysAvailable {
+		return nil, err
+	}
+	return data, err
+}
+
+// WaitUniqueJoinKeysWithStatus is the status-preserving form used by consumers
+// whose correctness depends on knowing whether the producer sent PASS or DROP.
+// The legacy WaitUniqueJoinKeys API intentionally retains its old fail-open
+// behavior for callers that only use an optional membership filter.
+func WaitUniqueJoinKeysWithStatus(sqlproc *SqlProcess) ([]byte, UniqueJoinKeysStatus, error) {
+	return waitUniqueJoinKeys(sqlproc, true)
+}
+
+func waitUniqueJoinKeys(sqlproc *SqlProcess, preserveStatus bool) ([]byte, UniqueJoinKeysStatus, error) {
 	if sqlproc.Proc == nil {
-		return nil, nil
+		return nil, UniqueJoinKeysNone, nil
 	}
 
 	if len(sqlproc.RuntimeFilterSpecs) == 0 {
-		return nil, nil
+		return nil, UniqueJoinKeysNone, nil
 	}
 	spec := sqlproc.RuntimeFilterSpecs[0]
 	if !spec.UseMembershipFilter {
-		return nil, nil
+		return nil, UniqueJoinKeysNone, nil
 	}
 
 	msgReceiver := message.NewMessageReceiver(
@@ -55,7 +84,7 @@ func WaitUniqueJoinKeys(sqlproc *SqlProcess) ([]byte, error) {
 	)
 	msgs, ctxDone, err := msgReceiver.ReceiveMessage(true, sqlproc.GetContext())
 	if err != nil || ctxDone {
-		return nil, err
+		return nil, UniqueJoinKeysNone, err
 	}
 
 	for i := range msgs {
@@ -63,13 +92,23 @@ func WaitUniqueJoinKeys(sqlproc *SqlProcess) ([]byte, error) {
 		if !ok {
 			continue
 		}
-		if m.Typ != message.RuntimeFilter_UNIQUEJOINKEYS {
-			continue
+		switch m.Typ {
+		case message.RuntimeFilter_UNIQUEJOINKEYS:
+			return m.Data, UniqueJoinKeysAvailable, nil
+		case message.RuntimeFilter_PASS:
+			if !preserveStatus {
+				continue
+			}
+			return nil, UniqueJoinKeysPass, nil
+		case message.RuntimeFilter_DROP:
+			if !preserveStatus {
+				continue
+			}
+			return nil, UniqueJoinKeysDrop, nil
 		}
-		return m.Data, nil
 	}
 
-	return nil, nil
+	return nil, UniqueJoinKeysNone, nil
 }
 
 // BuildExactPkFilter converts a vector of primary key values into a comma-separated

--- a/pkg/vectorindex/sqlexec/bloomfilter_test.go
+++ b/pkg/vectorindex/sqlexec/bloomfilter_test.go
@@ -265,6 +265,34 @@ func TestWaitUniqueJoinKeysForTableFunction(t *testing.T) {
 	})
 }
 
+func TestWaitUniqueJoinKeysWithStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		typ    int32
+		status UniqueJoinKeysStatus
+	}{
+		{name: "pass", typ: message.RuntimeFilter_PASS, status: UniqueJoinKeysPass},
+		{name: "drop", typ: message.RuntimeFilter_DROP, status: UniqueJoinKeysDrop},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			mb := message.NewMessageBoard()
+			proc.SetMessageBoard(mb)
+			sqlproc := NewSqlProcess(proc)
+			tag := int32(900)
+			message.SendMessage(message.RuntimeFilterMessage{Tag: tag, Typ: tc.typ}, mb)
+			sqlproc.RuntimeFilterSpecs = []*plan.RuntimeFilterSpec{{
+				Tag: tag, UseMembershipFilter: true,
+			}}
+
+			data, status, err := WaitUniqueJoinKeysWithStatus(sqlproc)
+			require.NoError(t, err)
+			require.Nil(t, data)
+			require.Equal(t, tc.status, status)
+		})
+	}
+}
+
 func TestBuildExactPkFilter(t *testing.T) {
 	mp := mpool.MustNewZero()
 	proc := testutil.NewProcessWithMPool(t, "", mp)

--- a/pkg/vectorindex/sqlexec/bloomfilter_test.go
+++ b/pkg/vectorindex/sqlexec/bloomfilter_test.go
@@ -266,6 +266,35 @@ func TestWaitUniqueJoinKeysForTableFunction(t *testing.T) {
 }
 
 func TestWaitUniqueJoinKeysWithStatus(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+		sqlproc := NewSqlProcess(proc)
+		data, status, err := WaitUniqueJoinKeysWithStatus(sqlproc)
+		require.NoError(t, err)
+		require.Nil(t, data)
+		require.Equal(t, UniqueJoinKeysNone, status)
+	})
+
+	t.Run("available", func(t *testing.T) {
+		proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+		mb := message.NewMessageBoard()
+		proc.SetMessageBoard(mb)
+		sqlproc := NewSqlProcess(proc)
+		tag := int32(899)
+		payload := []byte{1, 2, 3}
+		message.SendMessage(message.RuntimeFilterMessage{
+			Tag: tag, Typ: message.RuntimeFilter_UNIQUEJOINKEYS, Data: payload,
+		}, mb)
+		sqlproc.RuntimeFilterSpecs = []*plan.RuntimeFilterSpec{{
+			Tag: tag, UseMembershipFilter: true,
+		}}
+
+		data, status, err := WaitUniqueJoinKeysWithStatus(sqlproc)
+		require.NoError(t, err)
+		require.Equal(t, payload, data)
+		require.Equal(t, UniqueJoinKeysAvailable, status)
+	})
+
 	for _, tc := range []struct {
 		name   string
 		typ    int32

--- a/test/distributed/cases/fulltext2/fulltext2_candidate_limit.result
+++ b/test/distributed/cases/fulltext2/fulltext2_candidate_limit.result
@@ -1,0 +1,201 @@
+set experimental_fulltext2_index = 1;
+drop database if exists fulltext2_candidate_limit;
+create database fulltext2_candidate_limit;
+use fulltext2_candidate_limit;
+create table ft_exact (
+id bigint primary key,
+body text not null,
+category varchar(20) not null
+);
+insert into ft_exact values
+(1, 'needle needle needle needle needle', 'drop'),
+(2, 'needle needle needle', 'drop'),
+(3, 'needle', 'keep'),
+(4, 'needle', 'keep'),
+(5, 'needle', 'keep');
+create fulltext2 index ft_exact_idx on ft_exact(body) with parser gojieba;
+set fulltext_bloom_filter_pushdown = 0;
+select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+➤ id[-5,64,0]  𝄀
+5  𝄀
+3
+set fulltext_bloom_filter_pushdown = 1;
+select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+➤ id[-5,64,0]  𝄀
+5  𝄀
+3
+select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2;
+➤ id[-5,64,0]  𝄀
+4  𝄀
+3
+explain select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_exact.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                          Limit: 3  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                          Filter Cond: (ft_exact.category = 'keep')
+create table ft_varchar (
+id varchar(20) primary key,
+body text not null,
+category varchar(20) not null
+);
+insert into ft_varchar values
+('doc-1', 'needle needle needle needle needle', 'drop'),
+('doc-2', 'needle needle needle', 'drop'),
+('doc-3', 'needle', 'keep'),
+('doc-4', 'needle', 'keep'),
+('doc-5', 'needle', 'keep');
+create fulltext2 index ft_varchar_idx on ft_varchar(body) with parser gojieba;
+set fulltext_bloom_filter_pushdown = 1;
+select id from ft_varchar
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+➤ id[12,20,0]  𝄀
+doc-5  𝄀
+doc-3
+explain select id from ft_varchar
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_varchar.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_varchar  𝄀
+                    Filter Cond: (ft_varchar.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_varchar.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_varchar.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_varchar  𝄀
+                          Filter Cond: (ft_varchar.category = 'keep')
+explain select id from ft_exact
+where match(body) against('+needle other' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_exact.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                          Filter Cond: (ft_exact.category = 'keep')
+explain select id from ft_exact
+where match(body) against('"needle other"' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_exact.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                          Filter Cond: (ft_exact.category = 'keep')
+explain select id from ft_exact
+where match(body) against('need*' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_exact.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                          Filter Cond: (ft_exact.category = 'keep')
+explain select id from ft_exact
+where match(body) against('+needle -other' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_exact.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                          Filter Cond: (ft_exact.category = 'keep')
+drop database fulltext2_candidate_limit;

--- a/test/distributed/cases/fulltext2/fulltext2_candidate_limit.result
+++ b/test/distributed/cases/fulltext2/fulltext2_candidate_limit.result
@@ -247,6 +247,24 @@ Project  𝄀
                     ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
                           Filter Cond: (ft_exact.category = 'keep')
 explain select id from ft_exact
+where match(body) against('+needle +world' in boolean mode) and category = 'keep' and rand() < 0.5
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep'), (rand() < 0.5)  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Table Function on fulltext2_search  𝄀
+                    Runtime Filter Probe: #[7,0]
+explain select id from ft_exact
 where match(body) against('needle' in natural language mode)
 limit 2 offset 1;
 -- @regex("Limit: 3", true)

--- a/test/distributed/cases/fulltext2/fulltext2_candidate_limit.result
+++ b/test/distributed/cases/fulltext2/fulltext2_candidate_limit.result
@@ -198,4 +198,132 @@ Project  𝄀
                           Runtime Filter Probe: #[7,0]  𝄀
                     ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
                           Filter Cond: (ft_exact.category = 'keep')
+explain select id from ft_exact
+where match(body) against('+(needle other)' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_exact.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                          Filter Cond: (ft_exact.category = 'keep')
+explain select id from ft_exact
+where match(body) against('+needle ~other' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Filter Cond: (ft_exact.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_exact.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                          Filter Cond: (ft_exact.category = 'keep')
+explain select id from ft_exact
+where match(body) against('needle' in natural language mode)
+limit 2 offset 1;
+-- @regex("Limit: 3", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_exact.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_exact  𝄀
+                    Runtime Filter Probe: ft_exact.id  𝄀
+              ->  Table Function on fulltext2_search  𝄀
+                    Limit: 3
+create table ft_ngram (
+id bigint primary key,
+body text not null,
+category varchar(20) not null
+);
+insert into ft_ngram values
+(1, '中文 中文', 'drop'),
+(2, '中文', 'keep'),
+(3, '中文', 'keep');
+create fulltext2 index ft_ngram_idx on ft_ngram(body) with parser ngram;
+explain select id from ft_ngram
+where match(body) against('+中文' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3", false)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_ngram.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_ngram  𝄀
+                    Filter Cond: (ft_ngram.category = 'keep')  𝄀
+                    Runtime Filter Probe: ft_ngram.id  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (mo_fulltext_alias_0.__mo_ft_doc_id = ft_ngram.id)  𝄀
+                    Runtime Filter Build: #[9,0]  𝄀
+                    ->  Table Function on fulltext2_search  𝄀
+                          Runtime Filter Probe: #[7,0]  𝄀
+                    ->  Table Scan on fulltext2_candidate_limit.ft_ngram  𝄀
+                          Filter Cond: (ft_ngram.category = 'keep')
+create table ft_include (
+id bigint primary key,
+body text not null,
+category bigint not null,
+payload varchar(20) not null
+);
+insert into ft_include values
+(1, 'needle needle needle', 0, 'a'),
+(2, 'needle', 1, 'b'),
+(3, 'needle', 1, 'c'),
+(4, 'needle', 1, 'd');
+create fulltext2 index ft_include_idx on ft_include(body) include(category) with parser gojieba;
+explain select id, payload from ft_include
+where match(body) against('needle' in natural language mode) and category = 1
+limit 2 offset 1;
+-- @regex("Limit: 3", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+        Limit: 2, Offset: 1  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (ft_include.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on fulltext2_candidate_limit.ft_include  𝄀
+                    Runtime Filter Probe: ft_include.id  𝄀
+              ->  Table Function on fulltext2_search  𝄀
+                    Limit: 3
 drop database fulltext2_candidate_limit;

--- a/test/distributed/cases/fulltext2/fulltext2_candidate_limit.sql
+++ b/test/distributed/cases/fulltext2/fulltext2_candidate_limit.sql
@@ -1,0 +1,91 @@
+-- FULLTEXT2 safe candidate LIMIT coverage.
+-- The exact BIGINT membership path may bound the TVF to LIMIT+OFFSET because
+-- membership is exact and the Boolean query is pure MUST. Approximate Bloom
+-- membership and every richer Boolean shape remain unbounded at the TVF.
+
+set experimental_fulltext2_index = 1;
+drop database if exists fulltext2_candidate_limit;
+create database fulltext2_candidate_limit;
+use fulltext2_candidate_limit;
+
+create table ft_exact (
+    id bigint primary key,
+    body text not null,
+    category varchar(20) not null
+);
+insert into ft_exact values
+(1, 'needle needle needle needle needle', 'drop'),
+(2, 'needle needle needle', 'drop'),
+(3, 'needle', 'keep'),
+(4, 'needle', 'keep'),
+(5, 'needle', 'keep');
+create fulltext2 index ft_exact_idx on ft_exact(body) with parser gojieba;
+
+-- Exact BIGINT membership: the high-scoring rows are filtered out. LIMIT+OFFSET
+-- must be applied after the exact membership, so the page is not under-filled.
+set fulltext_bloom_filter_pushdown = 0;
+-- @sortkey:0
+select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+set fulltext_bloom_filter_pushdown = 1;
+-- @sortkey:0
+select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @sortkey:0
+select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2;
+
+-- The inner table function receives LIMIT+OFFSET=3 on this exact pure-MUST path.
+-- Keep the regex assertion focused on the semantic candidate bound rather than
+-- the full explain formatting.
+-- @regex("Limit: 3",true)
+explain select id from ft_exact
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+
+-- VARCHAR membership is approximate, so the planner must not push a candidate
+-- LIMIT before the final exact join. The result remains identical to pushdown OFF.
+create table ft_varchar (
+    id varchar(20) primary key,
+    body text not null,
+    category varchar(20) not null
+);
+insert into ft_varchar values
+('doc-1', 'needle needle needle needle needle', 'drop'),
+('doc-2', 'needle needle needle', 'drop'),
+('doc-3', 'needle', 'keep'),
+('doc-4', 'needle', 'keep'),
+('doc-5', 'needle', 'keep');
+create fulltext2 index ft_varchar_idx on ft_varchar(body) with parser gojieba;
+set fulltext_bloom_filter_pushdown = 1;
+-- @sortkey:0
+select id from ft_varchar
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3",false)
+explain select id from ft_varchar
+where match(body) against('+needle' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+
+-- Non-pure Boolean forms must not receive the exact pure-MUST candidate bound.
+-- @regex("Limit: 3",false)
+explain select id from ft_exact
+where match(body) against('+needle other' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3",false)
+explain select id from ft_exact
+where match(body) against('"needle other"' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3",false)
+explain select id from ft_exact
+where match(body) against('need*' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3",false)
+explain select id from ft_exact
+where match(body) against('+needle -other' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+
+drop database fulltext2_candidate_limit;

--- a/test/distributed/cases/fulltext2/fulltext2_candidate_limit.sql
+++ b/test/distributed/cases/fulltext2/fulltext2_candidate_limit.sql
@@ -96,6 +96,14 @@ explain select id from ft_exact
 where match(body) against('+needle ~other' in boolean mode) and category = 'keep'
 limit 2 offset 1;
 
+-- A volatile residual is evaluated independently per row. It must not be
+-- duplicated into the copied prefilter scan or receive a filter-dependent
+-- candidate bound.
+-- @regex("Limit: 3",false)
+explain select id from ft_exact
+where match(body) against('+needle +world' in boolean mode) and category = 'keep' and rand() < 0.5
+limit 2 offset 1;
+
 -- The existing no-residual path remains broader than the residual-WHERE fast
 -- path and continues to push LIMIT+OFFSET without a membership dependency.
 -- @regex("Limit: 3",true)

--- a/test/distributed/cases/fulltext2/fulltext2_candidate_limit.sql
+++ b/test/distributed/cases/fulltext2/fulltext2_candidate_limit.sql
@@ -87,5 +87,57 @@ limit 2 offset 1;
 explain select id from ft_exact
 where match(body) against('+needle -other' in boolean mode) and category = 'keep'
 limit 2 offset 1;
+-- @regex("Limit: 3",false)
+explain select id from ft_exact
+where match(body) against('+(needle other)' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+-- @regex("Limit: 3",false)
+explain select id from ft_exact
+where match(body) against('+needle ~other' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+
+-- The existing no-residual path remains broader than the residual-WHERE fast
+-- path and continues to push LIMIT+OFFSET without a membership dependency.
+-- @regex("Limit: 3",true)
+explain select id from ft_exact
+where match(body) against('needle' in natural language mode)
+limit 2 offset 1;
+
+-- A CJK MUST operand under ngram is executed as a positional phrase, not a
+-- single term, so it must not enter the pure-MUST residual-WHERE route.
+create table ft_ngram (
+    id bigint primary key,
+    body text not null,
+    category varchar(20) not null
+);
+insert into ft_ngram values
+(1, '中文 中文', 'drop'),
+(2, '中文', 'keep'),
+(3, '中文', 'keep');
+create fulltext2 index ft_ngram_idx on ft_ngram(body) with parser ngram;
+-- @regex("Limit: 3",false)
+explain select id from ft_ngram
+where match(body) against('+中文' in boolean mode) and category = 'keep'
+limit 2 offset 1;
+
+-- Predicates peeled into a FULLTEXT2 INCLUDE filter are evaluated inside the
+-- search rather than by an external membership filter. Preserve main's normal
+-- candidate limit for this no-residual/in-index path.
+create table ft_include (
+    id bigint primary key,
+    body text not null,
+    category bigint not null,
+    payload varchar(20) not null
+);
+insert into ft_include values
+(1, 'needle needle needle', 0, 'a'),
+(2, 'needle', 1, 'b'),
+(3, 'needle', 1, 'c'),
+(4, 'needle', 1, 'd');
+create fulltext2 index ft_include_idx on ft_include(body) include(category) with parser gojieba;
+-- @regex("Limit: 3",true)
+explain select id, payload from ft_include
+where match(body) against('needle' in natural language mode) and category = 1
+limit 2 offset 1;
 
 drop database fulltext2_candidate_limit;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement

## Which issue(s) this PR fixes:

Issue #27251

## What this PR does / why we need it:

This change makes FULLTEXT2 candidate LIMIT pushdown safe for the narrow exact-filter path:

- a single FULLTEXT2 MATCH stream;
- literal `IN BOOLEAN MODE` pure-MUST single-term clauses;
- an exact integer primary-key membership prefilter;
- a literal LIMIT/OFFSET, with the candidate bound set to `LIMIT + OFFSET`.

It preserves current `main` behavior when there is no residual WHERE predicate, including dynamic LIMIT and INCLUDE in-index filtering.

Approximate Bloom membership, BIT/VARCHAR/UUID primary keys, complex Boolean shapes, implicit or explicit phrases/prefixes, multiple MATCH streams, prepared residual-path limits, and pushdown-disabled plans keep the unbounded candidate path.

This update also closes the two semantic review findings:

- Runtime-filter terminal status is preserved as `UNIQUEJOINKEYS`, `PASS`, or `DROP`. `PASS` (or a missing exact payload) disables the filter-dependent candidate bound so the final residual join cannot under-fill; `DROP` returns no FULLTEXT2 rows; an exact payload retains the bound. `Reset` restores the planned limit and clears query-local filter state.
- Planner eligibility uses the executor's parser-aware `buildBooleanQuery` AST. Default/ngram CJK phrase/prefix shapes are rejected, while supported JSON-value atomic terms and genuine single gojieba terms remain eligible.

The implementation remains five focused commits:

1. `fix(fulltext2): push candidate limit only with exact prefilters`
2. `fix(fulltext2): gate candidate limit on exact pure-must filters`
3. `test(fulltext2): cover safe candidate limit pushdown`
4. `fix(fulltext2): preserve runtime filter terminal states`
5. `test(fulltext2): cover runtime membership filter branches`

## Validation

Latest rebased base/head:

- Base: `3a52dd0ecf7ad7ee04fcf14700682caaf5b3466a`
- Head: `c405c7dd0f63dddcf031b74d69ca3b667cf8bc66`

Passed on the latest rebased head:

- owning package tests for `pkg/fulltext2`, `pkg/sql/plan`, `pkg/sql/colexec/table_function`, and `pkg/vectorindex/sqlexec`;
- focused race tests for the changed planner, parser, runtime-filter waiter, and FULLTEXT2 table-function paths;
- `git diff --check`;
- exact-head semantic preflight.

The broader controlled Linux/CGo validation below was run on the same semantic patch before this history-only rebase; the complete base-to-head patch is byte-identical:

- focused FULLTEXT2 parser eligibility tests;
- status-preserving unique-key waiter tests;
- deterministic hashbuild PASS producer tests (optional allocation rejection, marshal-budget rejection, one-byte-short admission, and spill);
- focused Planner candidate-limit route and boundary tests;
- focused FULLTEXT2 table-function PASS/DROP/Available/None, Reset, malformed-payload, and under-fill tests;
- owning package tests for `pkg/fulltext2`, `pkg/common/docfilter`, `pkg/vectorindex/sqlexec`, and `pkg/sql/colexec/table_function`;
- focused race tests plus the full `pkg/fulltext2` race suite;
- `go build ./cmd/mo-service`;
- owning-package `go vet`;
- `git diff --check`.

BVT on the same semantic patch before this history-only rebase:

- `fulltext2_candidate_limit`: 35/35 passed;
- classic FULLTEXT `fulltext_plugin_smoke` control: 12/12 passed.

The BVT covers exact BIGINT `LIMIT 2 OFFSET 1` (candidate bound 3), under-fill protection, pushdown ON/OFF equivalence, VARCHAR/UUID rejection, complex Boolean/phrase/prefix/CJK rejection, and preservation of no-residual and INCLUDE candidate limits.

Semantic preflight: PASS at exact head `c405c7dd0f63dddcf031b74d69ca3b667cf8bc66`, diff SHA256 `fb1449645db40815223701c21f6401b6b21006f18b15828e774d075be9213582`.

The historical host-busy directional run observed about 1.11x QPS and downstream candidates falling from 15,064 to 100. This PR does not claim a 20% search-kernel improvement; FULLTEXT2 search time was essentially unchanged.

## Compatibility and follow-up

No SQL syntax, DDL, index format, FST, CDC, runtime-filter wire protocol, protobuf, or public configuration is changed. Natural phrase, BM25 OR, complex Boolean, and no-LIMIT paths remain on their existing routes.

Filtered scan reuse is intentionally out of scope. Existing cost evidence does not satisfy the agreed scan-reuse gate in enough representative scenarios.

QA required: yes.

Production entrypoint: FULLTEXT2 Planner candidate-limit routing and the `fulltext2_search` table function.

Automated terminal: `test/distributed/cases/fulltext2/fulltext2_candidate_limit.sql` plus focused Go tests.

Remaining validation: fresh exact-head CI and renewed semantic review. The PR is Ready for review while these gates are pending.
