### PR TITLE
fix(disttae): make GlobalStats.Get cancellation-aware

### DIFF
--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -460,6 +460,15 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 		}
 	}
 
+	if sync {
+		stopWake := context.AfterFunc(ctx, func() {
+			gs.mu.Lock()
+			gs.mu.cond.Broadcast()
+			gs.mu.Unlock()
+		})
+		defer stopWake()
+	}
+
 	gs.mu.Lock()
 	defer gs.mu.Unlock()
 
@@ -477,9 +486,8 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 			}
 
 			func() {
-				// We force to trigger the update, which will hang when the channel
-				// is full. Another goroutine will fetch items from the channel
-				// which hold the lock, so we need to unlock it first.
+				// A forced update can block while the channel is full. A worker
+				// draining it may need gs.mu, so unlock before enqueueing.
 				gs.mu.Unlock()
 				defer gs.mu.Lock()
 				// If the trigger condition is not satisfied, the stats will not be updated
@@ -491,6 +499,9 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 			info, ok = gs.mu.statsInfoMap[key]
 			if ok {
 				break
+			}
+			if ctx.Err() != nil {
+				return nil
 			}
 
 			// Wait until stats info of the key is updated.
@@ -547,10 +558,14 @@ func (gs *GlobalStats) enqueueStatsUpdate(key pb.StatsInfoKeyWithContext, force 
 		v2.StatsTriggerQueueSizeGauge.Set(float64(len(gs.updateC)))
 	}()
 	if force {
-		gs.updateC <- key
-		gs.queueWatcher.add(key.Key.TableID)
-		v2.StatsTriggerForcedCounter.Add(1)
-		return true
+		select {
+		case gs.updateC <- key:
+			gs.queueWatcher.add(key.Key.TableID)
+			v2.StatsTriggerForcedCounter.Add(1)
+			return true
+		case <-key.Ctx.Done():
+			return false
+		}
 	}
 
 	select {

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -1901,6 +1901,99 @@ func TestGlobalStatsGetDoesNotHoldMuWhileSubscribing(t *testing.T) {
 	})
 }
 
+func TestGlobalStatsGetReturnsWhenContextCanceledWhileWaiting(t *testing.T) {
+	runTest(t, func(ctx context.Context, e *Engine) {
+		const dbID uint64 = 100
+		const tblID uint64 = 10001
+		key := statsinfo.StatsInfoKey{
+			AccId:      0,
+			DatabaseID: dbID,
+			TableID:    tblID,
+			TableName:  "t",
+			DbName:     "d",
+		}
+
+		partition := e.GetOrCreateLatestPart(ctx, 0, dbID, tblID)
+		state, commit := partition.MutateState()
+		objectID := objectio.NewObjectid()
+		objectStats := objectio.NewObjectStatsWithObjectID(
+			&objectID, false, false, false)
+		require.NoError(t, objectio.SetObjectStatsSize(objectStats, 1))
+		require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+			ObjectStats: *objectStats,
+			CreateTime:  types.BuildTS(1, 0),
+		}, false))
+		commit()
+
+		e.pClient.eng = e
+		e.pClient.subscribed.eng = e
+		e.pClient.subscribed.rw.Lock()
+		if e.pClient.subscribed.m == nil {
+			e.pClient.subscribed.m = make(map[uint64]*subEntry)
+		}
+		e.pClient.subscribed.m[tblID] = &subEntry{
+			dbID:  dbID,
+			state: Subscribed,
+		}
+		e.pClient.subscribed.rw.Unlock()
+
+		// This isolated GlobalStats has no update worker. Receiving its forced
+		// request below proves Get reached the synchronous update path, after
+		// which no data-path goroutine can broadcast the condition variable.
+		gs := &GlobalStats{
+			ctx:          ctx,
+			engine:       e,
+			updateC:      make(chan statsinfo.StatsInfoKeyWithContext, 1),
+			queueWatcher: newQueueWatcher(),
+		}
+		gs.mu.statsInfoMap = make(map[statsinfo.StatsInfoKey]*statsinfo.StatsInfo)
+		gs.mu.cond = sync.NewCond(&gs.mu)
+
+		getCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		result := make(chan *statsinfo.StatsInfo, 1)
+		go func() {
+			result <- gs.Get(getCtx, key, true)
+		}()
+
+		select {
+		case <-gs.updateC:
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not enqueue the synchronous update")
+		}
+		cancel()
+
+		select {
+		case info := <-result:
+			require.Nil(t, info)
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not return after context cancellation")
+		}
+		gs.queueWatcher.del(tblID)
+	})
+}
+
+func TestEnqueueStatsUpdateForceReturnsWhenContextCanceled(t *testing.T) {
+	gs := &GlobalStats{
+		updateC:      make(chan statsinfo.StatsInfoKeyWithContext, 1),
+		queueWatcher: newQueueWatcher(),
+	}
+	queued := statsinfo.StatsInfoKeyWithContext{
+		Ctx: context.Background(),
+		Key: statsinfo.StatsInfoKey{TableID: 1},
+	}
+	gs.updateC <- queued
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	accepted := gs.enqueueStatsUpdate(statsinfo.StatsInfoKeyWithContext{
+		Ctx: ctx,
+		Key: statsinfo.StatsInfoKey{TableID: 2},
+	}, true)
+	require.False(t, accepted)
+	require.Equal(t, queued, <-gs.updateC)
+}
+
 func TestCacheRemoteInfoIfSubscribedBroadcastsWaiters(t *testing.T) {
 	runTest(t, func(ctx context.Context, e *Engine) {
 		gs := e.globalStats


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27139

## What this PR does / why we need it:

- Wake synchronous `GlobalStats.Get` waiters when their context is canceled, including cancellation while the forced-update path temporarily releases `gs.mu`.
- Make forced stats-update enqueue observe context cancellation when the queue is full.
- Add deterministic regressions for condition waiting and full-queue cancellation.

Validation:

- `pkg/vm/engine/disttae` full package tests and race tests
- focused cancellation tests with `-race -count=100`
- `pkg/embed.TestBasicCluster` with `matrixone_test` tags
- `go vet ./pkg/vm/engine/disttae`