### PR TITLE
fix(frontend): wait for active request before ResetSession

### DIFF
--- a/pkg/frontend/migrate.go
+++ b/pkg/frontend/migrate.go
@@ -32,6 +32,9 @@ type migrateController struct {
 	inProgress bool
 	// requestInProgress indicates if a SQL request owns the routine session.
 	requestInProgress bool
+	// resetWaiterPending reserves the single reset caller allowed to wait for
+	// the current request to finish.
+	resetWaiterPending bool
 	// operationCancel cancels the active lifecycle operation. It is published
 	// together with inProgress while holding the controller lock.
 	operationCancel context.CancelFunc
@@ -123,6 +126,18 @@ func (mc *migrateController) beginOperationAfterRequestWithContext(ctx context.C
 
 	mc.Lock()
 	defer mc.Unlock()
+	if mc.requestInProgress && !mc.inProgress {
+		if mc.resetWaiterPending {
+			return nil, false
+		}
+		mc.resetWaiterPending = true
+		defer func() {
+			if mc.resetWaiterPending {
+				mc.resetWaiterPending = false
+				mc.cond.Broadcast()
+			}
+		}()
+	}
 	waitNotified := false
 	for mc.requestInProgress && !mc.inProgress && !mc.closed && ctx.Err() == nil {
 		if !waitNotified && mc.requestWaitHook != nil {
@@ -131,7 +146,11 @@ func (mc *migrateController) beginOperationAfterRequestWithContext(ctx context.C
 		}
 		mc.cond.Wait()
 	}
-	return mc.startOperationLocked(ctx)
+	operationCtx, ok := mc.startOperationLocked(ctx)
+	if ok {
+		mc.resetWaiterPending = false
+	}
+	return operationCtx, ok
 }
 
 // tryBeginOperation starts a lifecycle operation only if it can proceed

--- a/pkg/frontend/migrate.go
+++ b/pkg/frontend/migrate.go
@@ -44,6 +44,9 @@ type migrateController struct {
 	// prove a reset reached the request-only admission wait before changing the
 	// request or its context.
 	requestWaitHook func()
+	// tryBeginOperationHook is test-only. Production leaves it nil; tests use
+	// it to pause a failed optimistic admission attempt.
+	tryBeginOperationHook func()
 	// the id of goroutine that executes the migration
 	goroutineID uint64
 }
@@ -165,8 +168,13 @@ func (mc *migrateController) tryBeginOperationWithContext(ctx context.Context) (
 		ctx = context.Background()
 	}
 	mc.Lock()
-	defer mc.Unlock()
-	return mc.startOperationLocked(ctx)
+	operationCtx, ok := mc.startOperationLocked(ctx)
+	hook := mc.tryBeginOperationHook
+	mc.Unlock()
+	if !ok && hook != nil {
+		hook()
+	}
+	return operationCtx, ok
 }
 
 func (mc *migrateController) startOperationLocked(ctx context.Context) (context.Context, bool) {

--- a/pkg/frontend/migrate.go
+++ b/pkg/frontend/migrate.go
@@ -37,6 +37,10 @@ type migrateController struct {
 	operationCancel context.CancelFunc
 	// cond coordinates lifecycle operations and routine cleanup.
 	cond *sync.Cond
+	// requestWaitHook is test-only. Production leaves it nil; tests use it to
+	// prove a reset reached the request-only admission wait before changing the
+	// request or its context.
+	requestWaitHook func()
 	// the id of goroutine that executes the migration
 	goroutineID uint64
 }
@@ -97,6 +101,34 @@ func (mc *migrateController) beginOperationWithContext(ctx context.Context) (con
 	mc.Lock()
 	defer mc.Unlock()
 	for (mc.inProgress || mc.requestInProgress) && !mc.closed && ctx.Err() == nil {
+		mc.cond.Wait()
+	}
+	return mc.startOperationLocked(ctx)
+}
+
+// beginOperationAfterRequestWithContext starts a lifecycle operation after an
+// already-running request finishes. Unlike beginOperationWithContext, it does
+// not queue behind another lifecycle operation: reset-session must preserve
+// the existing lifecycle-conflict fail-fast behavior.
+func (mc *migrateController) beginOperationAfterRequestWithContext(ctx context.Context) (context.Context, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	stopWakeup := context.AfterFunc(ctx, func() {
+		mc.Lock()
+		mc.cond.Broadcast()
+		mc.Unlock()
+	})
+	defer stopWakeup()
+
+	mc.Lock()
+	defer mc.Unlock()
+	waitNotified := false
+	for mc.requestInProgress && !mc.inProgress && !mc.closed && ctx.Err() == nil {
+		if !waitNotified && mc.requestWaitHook != nil {
+			waitNotified = true
+			mc.requestWaitHook()
+		}
 		mc.cond.Wait()
 	}
 	return mc.startOperationLocked(ctx)

--- a/pkg/frontend/routine.go
+++ b/pkg/frontend/routine.go
@@ -664,7 +664,9 @@ func (rt *Routine) migrateConnectionFromActionWithContext(
 }
 
 func (rt *Routine) resetSession(baseServiceID string, resp *query.ResetSessionResponse) error {
-	return rt.resetSessionWithContext(rt.getCancelRoutineCtx(), baseServiceID, resp)
+	return rt.resetSessionWithAdmission(
+		rt.getCancelRoutineCtx(), baseServiceID, resp, false,
+	)
 }
 
 func (rt *Routine) resetSessionWithContext(
@@ -672,7 +674,23 @@ func (rt *Routine) resetSessionWithContext(
 	baseServiceID string,
 	resp *query.ResetSessionResponse,
 ) error {
+	return rt.resetSessionWithAdmission(ctx, baseServiceID, resp, true)
+}
+
+func (rt *Routine) resetSessionWithAdmission(
+	ctx context.Context,
+	baseServiceID string,
+	resp *query.ResetSessionResponse,
+	waitForRequest bool,
+) error {
 	operationCtx, ok := rt.mc.tryBeginOperationWithContext(ctx)
+	if !ok && waitForRequest {
+		// ResetSession is sent after Proxy has sealed the client generation, so
+		// waiting here lets an already-running request finish before the old
+		// session is replaced. The QueryService caller supplies the bounded
+		// context; the no-context helper above intentionally remains fail-fast.
+		operationCtx, ok = rt.mc.beginOperationWithContext(ctx)
+	}
 	if !ok {
 		if ctx != nil {
 			if cause := context.Cause(ctx); cause != nil {

--- a/pkg/frontend/routine.go
+++ b/pkg/frontend/routine.go
@@ -689,7 +689,7 @@ func (rt *Routine) resetSessionWithAdmission(
 		// waiting here lets an already-running request finish before the old
 		// session is replaced. The QueryService caller supplies the bounded
 		// context; the no-context helper above intentionally remains fail-fast.
-		operationCtx, ok = rt.mc.beginOperationWithContext(ctx)
+		operationCtx, ok = rt.mc.beginOperationAfterRequestWithContext(ctx)
 	}
 	if !ok {
 		if ctx != nil {

--- a/pkg/frontend/routine.go
+++ b/pkg/frontend/routine.go
@@ -683,13 +683,16 @@ func (rt *Routine) resetSessionWithAdmission(
 	resp *query.ResetSessionResponse,
 	waitForRequest bool,
 ) error {
-	operationCtx, ok := rt.mc.tryBeginOperationWithContext(ctx)
-	if !ok && waitForRequest {
+	var operationCtx context.Context
+	var ok bool
+	if waitForRequest {
 		// ResetSession is sent after Proxy has sealed the client generation, so
 		// waiting here lets an already-running request finish before the old
 		// session is replaced. The QueryService caller supplies the bounded
 		// context; the no-context helper above intentionally remains fail-fast.
 		operationCtx, ok = rt.mc.beginOperationAfterRequestWithContext(ctx)
+	} else {
+		operationCtx, ok = rt.mc.tryBeginOperationWithContext(ctx)
 	}
 	if !ok {
 		if ctx != nil {

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -517,7 +517,11 @@ func (rm *RoutineManager) MigrateConnectionFromWithContext(
 }
 
 func (rm *RoutineManager) ResetSession(req *query.ResetSessionRequest, resp *query.ResetSessionResponse) error {
-	return rm.ResetSessionWithContext(rm.ctx, req, resp)
+	routine := rm.getRoutineByConnID(req.ConnID)
+	if routine == nil {
+		return moerr.NewInternalErrorf(rm.ctx, "cannot get routine to clear session %d", req.ConnID)
+	}
+	return routine.resetSession(rm.baseService.ID(), resp)
 }
 
 func (rm *RoutineManager) ResetSessionWithContext(

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -1008,6 +1008,8 @@ func TestRoutineManagerResetSessionWaitsForRequestAfterResponseWrite(t *testing.
 	case <-time.After(time.Second):
 		t.Fatal("request did not write its terminal response")
 	}
+	waitEntered := make(chan struct{})
+	routine.mc.requestWaitHook = func() { close(waitEntered) }
 
 	oldProc := oldSession.GetProc()
 	oldTxnHandler := oldSession.GetTxnHandler()
@@ -1024,7 +1026,9 @@ func TestRoutineManagerResetSessionWaitsForRequestAfterResponseWrite(t *testing.
 	select {
 	case err := <-resetResult:
 		t.Fatalf("reset returned before the request finished: %v", err)
-	case <-time.After(100 * time.Millisecond):
+	case <-waitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("reset did not enter the request-only admission wait")
 	}
 	require.Same(t, oldSession, routine.getSession())
 	require.Same(t, oldProc, oldSession.GetProc())

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -945,7 +945,7 @@ func receiveLegacyMigrationActionResult(t *testing.T, result <-chan error) error
 	}
 }
 
-func TestRoutineManagerResetSessionRejectsRequestAfterResponseWrite(t *testing.T) {
+func TestRoutineManagerResetSessionWaitsForRequestAfterResponseWrite(t *testing.T) {
 	const connID = uint32(1009)
 	ctrl := gomock.NewController(t)
 	oldSession := newTestSession(t, ctrl)
@@ -958,6 +958,7 @@ func TestRoutineManagerResetSessionRejectsRequestAfterResponseWrite(t *testing.T
 	rm, err := NewRoutineManager(context.Background(), "")
 	require.NoError(t, err)
 	rm.sessionManager = queryservice.NewSessionManager()
+	rm.setBaseService(&testMOServerBaseService{id: ""})
 
 	oldSession.respr = NewMysqlResp(protocol)
 	oldSession.setRoutineManager(rm)
@@ -1010,8 +1011,21 @@ func TestRoutineManagerResetSessionRejectsRequestAfterResponseWrite(t *testing.T
 
 	oldProc := oldSession.GetProc()
 	oldTxnHandler := oldSession.GetTxnHandler()
-	err = routine.resetSession("", &query.ResetSessionResponse{})
-	require.ErrorContains(t, err, "cannot reset session as routine is closed or busy")
+	resetCtx, cancelReset := context.WithTimeout(context.Background(), time.Second)
+	defer cancelReset()
+	resetResult := make(chan error, 1)
+	go func() {
+		resetResult <- rm.ResetSessionWithContext(
+			resetCtx,
+			&query.ResetSessionRequest{ConnID: connID},
+			&query.ResetSessionResponse{},
+		)
+	}()
+	select {
+	case err := <-resetResult:
+		t.Fatalf("reset returned before the request finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
 	require.Same(t, oldSession, routine.getSession())
 	require.Same(t, oldProc, oldSession.GetProc())
 	require.Same(t, oldTxnHandler, oldSession.GetTxnHandler())
@@ -1030,7 +1044,12 @@ func TestRoutineManagerResetSessionRejectsRequestAfterResponseWrite(t *testing.T
 		t.Fatal("request handler did not finish after response release")
 	}
 
-	require.NoError(t, routine.resetSession("", &query.ResetSessionResponse{}))
+	select {
+	case err := <-resetResult:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("reset did not finish after request release")
+	}
 	newSession := routine.getSession()
 	require.NotSame(t, oldSession, newSession)
 	require.Nil(t, oldSession.GetProc())
@@ -1038,6 +1057,19 @@ func TestRoutineManagerResetSessionRejectsRequestAfterResponseWrite(t *testing.T
 	registered = rm.sessionManager.GetAllSessions()
 	require.Len(t, registered, 1)
 	require.Same(t, newSession, registered[0])
+	require.NoError(t, rm.Handler(conn, []byte{byte(COM_PING)}))
+	secondResetCtx, cancelSecondReset := context.WithTimeout(context.Background(), time.Second)
+	defer cancelSecondReset()
+	require.NoError(t, rm.ResetSessionWithContext(
+		secondResetCtx,
+		&query.ResetSessionRequest{ConnID: connID},
+		&query.ResetSessionResponse{},
+	))
+	secondSession := routine.getSession()
+	require.NotSame(t, newSession, secondSession)
+	registered = rm.sessionManager.GetAllSessions()
+	require.Len(t, registered, 1)
+	require.Same(t, secondSession, registered[0])
 	require.NoError(t, rm.Handler(conn, []byte{byte(COM_PING)}))
 }
 

--- a/pkg/frontend/routine_test.go
+++ b/pkg/frontend/routine_test.go
@@ -386,6 +386,8 @@ func TestCanceledResetWaitingForRequestKeepsSession(t *testing.T) {
 	oldProc := oldSession.GetProc()
 	oldTxnHandler := oldSession.GetTxnHandler()
 	require.True(t, routine.mc.tryBeginRequest())
+	waitEntered := make(chan struct{})
+	routine.mc.requestWaitHook = func() { close(waitEntered) }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	resetResult := make(chan error, 1)
@@ -395,7 +397,9 @@ func TestCanceledResetWaitingForRequestKeepsSession(t *testing.T) {
 	select {
 	case err := <-resetResult:
 		t.Fatalf("reset returned before the request was canceled: %v", err)
-	case <-time.After(100 * time.Millisecond):
+	case <-waitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("reset did not enter the request-only admission wait")
 	}
 
 	cancel()
@@ -409,6 +413,49 @@ func TestCanceledResetWaitingForRequestKeepsSession(t *testing.T) {
 	require.Same(t, oldProc, oldSession.GetProc())
 	require.Same(t, oldTxnHandler, oldSession.GetTxnHandler())
 	routine.mc.endRequest()
+}
+
+func TestResetAdmissionRejectsConcurrentLifecycleOperation(t *testing.T) {
+	for _, owner := range []string{"reset", "migration"} {
+		t.Run(owner, func(t *testing.T) {
+			routine := NewRoutine(context.Background(), &testMysqlWriter{}, &config.FrontendParameters{})
+			t.Cleanup(routine.cancelRoutineFunc)
+			require.True(t, routine.mc.tryBeginOperation())
+			defer routine.mc.endOperation()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_, ok := routine.mc.beginOperationAfterRequestWithContext(ctx)
+			require.False(t, ok, "reset admission must not queue behind concurrent %s", owner)
+		})
+	}
+}
+
+func TestResetAdmissionStopsWhenRoutineClosesDuringRequestWait(t *testing.T) {
+	routine := NewRoutine(context.Background(), &testMysqlWriter{}, &config.FrontendParameters{})
+	t.Cleanup(routine.cancelRoutineFunc)
+	require.True(t, routine.mc.tryBeginRequest())
+	defer routine.mc.endRequest()
+
+	waitEntered := make(chan struct{})
+	routine.mc.requestWaitHook = func() { close(waitEntered) }
+	result := make(chan bool, 1)
+	go func() {
+		_, ok := routine.mc.beginOperationAfterRequestWithContext(context.Background())
+		result <- ok
+	}()
+	select {
+	case <-waitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("reset admission did not enter the request-only wait")
+	}
+	routine.mc.startClose()
+	select {
+	case ok := <-result:
+		require.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("reset admission did not stop after routine close")
+	}
 }
 
 func TestRoutineCloseCancelsResetRollback(t *testing.T) {

--- a/pkg/frontend/routine_test.go
+++ b/pkg/frontend/routine_test.go
@@ -406,6 +406,7 @@ func TestCanceledResetWaitingForRequestKeepsSession(t *testing.T) {
 	select {
 	case err := <-resetResult:
 		require.ErrorIs(t, err, context.Canceled)
+		require.False(t, routine.mc.resetWaiterPending)
 	case <-time.After(time.Second):
 		t.Fatal("reset did not honor cancellation while waiting for request")
 	}
@@ -453,8 +454,72 @@ func TestResetAdmissionStopsWhenRoutineClosesDuringRequestWait(t *testing.T) {
 	select {
 	case ok := <-result:
 		require.False(t, ok)
+		require.False(t, routine.mc.resetWaiterPending)
 	case <-time.After(time.Second):
 		t.Fatal("reset admission did not stop after routine close")
+	}
+}
+
+func TestResetAdmissionAllowsOnlyOnePendingRequestWaiter(t *testing.T) {
+	routine := NewRoutine(context.Background(), &testMysqlWriter{}, &config.FrontendParameters{})
+	t.Cleanup(routine.cancelRoutineFunc)
+	require.True(t, routine.mc.tryBeginRequest())
+
+	waitEntered := make(chan struct{})
+	var waitOnce sync.Once
+	routine.mc.requestWaitHook = func() {
+		waitOnce.Do(func() { close(waitEntered) })
+	}
+
+	firstCtx, cancelFirst := context.WithTimeout(context.Background(), time.Second)
+	defer cancelFirst()
+	firstResult := make(chan bool, 1)
+	go func() {
+		_, ok := routine.mc.beginOperationAfterRequestWithContext(firstCtx)
+		firstResult <- ok
+	}()
+	select {
+	case <-waitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first reset did not enter the request-only admission wait")
+	}
+
+	secondCtx, cancelSecond := context.WithTimeout(context.Background(), time.Second)
+	defer cancelSecond()
+	secondResult := make(chan bool, 1)
+	go func() {
+		_, ok := routine.mc.beginOperationAfterRequestWithContext(secondCtx)
+		secondResult <- ok
+	}()
+	select {
+	case ok := <-secondResult:
+		require.False(t, ok, "a second reset must not reserve another request waiter")
+	case <-time.After(100 * time.Millisecond):
+		routine.mc.endRequest()
+		select {
+		case ok := <-firstResult:
+			if ok {
+				routine.mc.endOperation()
+			}
+		case <-time.After(time.Second):
+			t.Fatal("first reset did not finish after request release")
+		}
+		select {
+		case ok := <-secondResult:
+			require.False(t, ok, "second reset waiter must not be admitted after the first completes")
+		case <-time.After(time.Second):
+			t.Fatal("second reset waiter did not finish after request release")
+		}
+		t.Fatal("second reset incorrectly waited behind the same request")
+	}
+
+	routine.mc.endRequest()
+	select {
+	case ok := <-firstResult:
+		require.True(t, ok)
+		routine.mc.endOperation()
+	case <-time.After(time.Second):
+		t.Fatal("first reset did not finish after request release")
 	}
 }
 

--- a/pkg/frontend/routine_test.go
+++ b/pkg/frontend/routine_test.go
@@ -432,6 +432,83 @@ func TestResetAdmissionRejectsConcurrentLifecycleOperation(t *testing.T) {
 	}
 }
 
+func TestResetAdmissionRejectsStaleLifecycleAttempt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	oldSession := newTestSession(t, ctrl)
+	rm, err := NewRoutineManager(context.Background(), "")
+	require.NoError(t, err)
+	rm.sessionManager = queryservice.NewSessionManager()
+	routine := NewRoutine(context.Background(), oldSession.GetResponser().MysqlRrWr(), &config.FrontendParameters{})
+	oldSession.setRoutineManager(rm)
+	oldSession.setRoutine(routine)
+	routine.setSession(oldSession)
+	rm.sessionManager.AddSession(oldSession)
+	t.Cleanup(func() {
+		if current := routine.getSession(); current != nil {
+			rm.sessionManager.RemoveSession(current)
+			current.Close()
+		}
+		routine.cancelRoutineFunc()
+		rm.cancelCtx()
+	})
+
+	// Model lifecycle A. The reset must reject this generation even if A ends
+	// before the reset caller's next scheduling point.
+	require.True(t, routine.mc.tryBeginOperation())
+	lifecycleHeld := true
+	defer func() {
+		if lifecycleHeld {
+			routine.mc.endOperation()
+		}
+	}()
+
+	attemptReached := make(chan struct{})
+	resumeAttempt := make(chan struct{})
+	routine.mc.tryBeginOperationHook = func() {
+		close(attemptReached)
+		<-resumeAttempt
+	}
+	waitEntered := make(chan struct{})
+	routine.mc.requestWaitHook = func() { close(waitEntered) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- routine.resetSessionWithContext(ctx, "", &query.ResetSessionResponse{})
+	}()
+
+	select {
+	case err := <-result:
+		// The fixed path makes one atomic admission decision while lifecycle A
+		// is still active and therefore never invokes the optimistic hook.
+		require.ErrorContains(t, err, "cannot reset session as routine is closed or busy")
+		require.Same(t, oldSession, routine.getSession())
+		require.False(t, routine.mc.resetWaiterPending)
+	case <-attemptReached:
+		// The pre-fix two-step path reaches this hook after its first failed
+		// attempt. Let A finish, start request N+1, and resume the stale reset.
+		routine.mc.endOperation()
+		lifecycleHeld = false
+		require.True(t, routine.mc.tryBeginRequest())
+		close(resumeAttempt)
+
+		select {
+		case err := <-result:
+			t.Fatalf("stale reset completed before request N+1 ended: %v", err)
+		case <-waitEntered:
+		}
+		routine.mc.endRequest()
+
+		select {
+		case err := <-result:
+			require.ErrorContains(t, err, "cannot reset session as routine is closed or busy")
+		case <-time.After(time.Second):
+			t.Fatal("stale reset did not finish after request N+1 ended")
+		}
+	}
+}
+
 func TestResetAdmissionStopsWhenRoutineClosesDuringRequestWait(t *testing.T) {
 	routine := NewRoutine(context.Background(), &testMysqlWriter{}, &config.FrontendParameters{})
 	t.Cleanup(routine.cancelRoutineFunc)

--- a/pkg/frontend/routine_test.go
+++ b/pkg/frontend/routine_test.go
@@ -362,6 +362,55 @@ func TestCanceledResetAdmissionDoesNotTouchSession(t *testing.T) {
 	routine.mc.endOperation()
 }
 
+func TestCanceledResetWaitingForRequestKeepsSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	oldSession := newTestSession(t, ctrl)
+	routine := NewRoutine(context.Background(), oldSession.GetResponser().MysqlRrWr(), &config.FrontendParameters{})
+	rm, err := NewRoutineManager(context.Background(), "")
+	require.NoError(t, err)
+	rm.sessionManager = queryservice.NewSessionManager()
+	rm.setBaseService(&testMOServerBaseService{id: ""})
+	oldSession.setRoutineManager(rm)
+	oldSession.setRoutine(routine)
+	routine.setSession(oldSession)
+	rm.sessionManager.AddSession(oldSession)
+	t.Cleanup(func() {
+		if current := routine.getSession(); current != nil {
+			rm.sessionManager.RemoveSession(current)
+			current.Close()
+		}
+		routine.cancelRoutineFunc()
+		rm.cancelCtx()
+	})
+
+	oldProc := oldSession.GetProc()
+	oldTxnHandler := oldSession.GetTxnHandler()
+	require.True(t, routine.mc.tryBeginRequest())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resetResult := make(chan error, 1)
+	go func() {
+		resetResult <- routine.resetSessionWithContext(ctx, "", &query.ResetSessionResponse{})
+	}()
+	select {
+	case err := <-resetResult:
+		t.Fatalf("reset returned before the request was canceled: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-resetResult:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("reset did not honor cancellation while waiting for request")
+	}
+	require.Same(t, oldSession, routine.getSession())
+	require.Same(t, oldProc, oldSession.GetProc())
+	require.Same(t, oldTxnHandler, oldSession.GetTxnHandler())
+	routine.mc.endRequest()
+}
+
 func TestRoutineCloseCancelsResetRollback(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	oldSession := newTestSession(t, ctrl)

--- a/pkg/proxy/conn_cache_test.go
+++ b/pkg/proxy/conn_cache_test.go
@@ -631,12 +631,13 @@ func TestPreparedShortConnectionQuitPublishesReusableBackend(t *testing.T) {
 		tun.mu.scp = &pipe{}
 		tun.mu.scp.mu.cond = sync.NewCond(&tun.mu.scp.mu)
 
-		// COM_STMT_CLOSE is a response-free prepared-statement command. Once it
-		// has crossed the tunnel, QUIT must see a clean boundary and may publish
-		// the backend after ResetSession completes.
-		stmtClose := makeSimplePacket("stmt close")
-		stmtClose[4] = byte(frontend.COM_STMT_CLOSE)
-		tun.trackClientRequest(stmtClose)
+		// A completed prepared-statement request has a response fence. QUIT must
+		// see that clean boundary and may publish the backend after ResetSession
+		// completes.
+		prepare := makeSimplePacket("select 1")
+		prepare[4] = byte(frontend.COM_STMT_PREPARE)
+		tun.trackClientRequest(prepare)
+		tun.trackServerResponse(makePrepareOKPacket(0, 0))
 		require.False(t, tun.hasInFlightClientRequest())
 
 		clientSide, backendSide := net.Pipe()

--- a/pkg/proxy/conn_cache_test.go
+++ b/pkg/proxy/conn_cache_test.go
@@ -25,9 +25,11 @@ import (
 	"time"
 
 	"github.com/lni/goutils/leaktest"
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/frontend"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	query "github.com/matrixorigin/matrixone/pkg/pb/query"
 	qclient "github.com/matrixorigin/matrixone/pkg/queryservice/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -606,5 +608,78 @@ func TestResetSession(t *testing.T) {
 			_, err := cc.(*connCache).resetSession(mockConn1)
 			assert.NoError(t, err)
 		})
+	})
+}
+
+func TestPreparedShortConnectionQuitPublishesReusableBackend(t *testing.T) {
+	cn := metadata.CNService{ServiceID: "s1", SQLAddress: "pipe"}
+	resetEntered := make(chan struct{})
+	runTestWithQueryServiceResetHandler(t, cn, func(ctx context.Context, req *query.Request, resp *query.Response, _ *morpc.Buffer) error {
+		if req.ResetSessionRequest == nil {
+			return fmt.Errorf("missing ResetSession request")
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			return fmt.Errorf("ResetSession request is missing its production deadline")
+		}
+		close(resetEntered)
+		resp.ResetSessionResponse = &query.ResetSessionResponse{Success: true, AuthString: []byte("auth")}
+		return nil
+	}, func(cc *clientConn, _ string) {
+		tun := &tunnel{}
+		tun.mu.csp = &pipe{}
+		tun.mu.csp.mu.cond = sync.NewCond(&tun.mu.csp.mu)
+		tun.mu.scp = &pipe{}
+		tun.mu.scp.mu.cond = sync.NewCond(&tun.mu.scp.mu)
+
+		// COM_STMT_CLOSE is a response-free prepared-statement command. Once it
+		// has crossed the tunnel, QUIT must see a clean boundary and may publish
+		// the backend after ResetSession completes.
+		stmtClose := makeSimplePacket("stmt close")
+		stmtClose[4] = byte(frontend.COM_STMT_CLOSE)
+		tun.trackClientRequest(stmtClose)
+		require.False(t, tun.hasInFlightClientRequest())
+
+		clientSide, backendSide := net.Pipe()
+		defer clientSide.Close()
+		defer backendSide.Close()
+		backend := newMockServerConn(backendSide)
+		backend.setCN(&CNServer{connID: 27, uuid: "cn1"})
+
+		cache := newConnCache(
+			context.Background(),
+			"",
+			runtime.DefaultRuntime().Logger(),
+			withQueryClient(cc.queryClient),
+			withAuthConstructor(nil),
+		)
+		cache.(*connCache).moCluster = cc.moCluster
+		defer cache.Close()
+
+		client := &clientConn{
+			log:        runtime.DefaultRuntime().Logger(),
+			tun:        tun,
+			sc:         backend,
+			connCache:  cache,
+			clientInfo: clientInfo{hash: "tenant-a"},
+		}
+		require.NoError(t, client.handleQuitCommand(context.Background()))
+		select {
+		case <-resetEntered:
+		case <-time.After(time.Second):
+			t.Fatal("connCache.Push did not reach QueryService ResetSession")
+		}
+		require.True(t, client.isConnCached())
+		require.Equal(t, 1, cache.Count())
+
+		// Pop is the next client's login/SET CONNECTION ID boundary. The same
+		// backend must remain usable for a prepared statement and a query.
+		reused := cache.Pop("tenant-a", 99, nil, nil, clientInfo{})
+		require.Same(t, backend, reused)
+		ok, err := reused.ExecStmt(internalStmt{cmdType: cmdQuery, s: "prepare p from 'select 1'"}, nil)
+		require.NoError(t, err)
+		require.True(t, ok)
+		ok, err = reused.ExecStmt(internalStmt{cmdType: cmdQuery, s: "select 1"}, nil)
+		require.NoError(t, err)
+		require.True(t, ok)
 	})
 }

--- a/pkg/proxy/conn_migration_test.go
+++ b/pkg/proxy/conn_migration_test.go
@@ -52,6 +52,25 @@ func runTestWithQueryServiceHandler(
 	migrateConnToHandler func(context.Context, *pb.Request, *pb.Response, *morpc.Buffer) error,
 	fn func(cc *clientConn, addr string),
 ) {
+	runTestWithQueryServiceHandlers(t, cn, migrateConnToHandler, nil, fn)
+}
+
+func runTestWithQueryServiceResetHandler(
+	t *testing.T,
+	cn metadata.CNService,
+	resetSessionHandler func(context.Context, *pb.Request, *pb.Response, *morpc.Buffer) error,
+	fn func(cc *clientConn, addr string),
+) {
+	runTestWithQueryServiceHandlers(t, cn, nil, resetSessionHandler, fn)
+}
+
+func runTestWithQueryServiceHandlers(
+	t *testing.T,
+	cn metadata.CNService,
+	migrateConnToHandler func(context.Context, *pb.Request, *pb.Response, *morpc.Buffer) error,
+	resetSessionHandler func(context.Context, *pb.Request, *pb.Response, *morpc.Buffer) error,
+	fn func(cc *clientConn, addr string),
+) {
 	sid := ""
 	runtime.RunTest(
 		sid,
@@ -111,7 +130,10 @@ func runTestWithQueryServiceHandler(
 				}
 			}
 			qs.AddHandleFunc(pb.CmdMethod_MigrateConnTo, migrateConnToHandler, false)
-			qs.AddHandleFunc(pb.CmdMethod_ResetSession, func(ctx context.Context, req *pb.Request, resp *pb.Response, _ *morpc.Buffer) error {
+			qs.AddHandleFunc(pb.CmdMethod_ResetSession, func(ctx context.Context, req *pb.Request, resp *pb.Response, buf *morpc.Buffer) error {
+				if resetSessionHandler != nil {
+					return resetSessionHandler(ctx, req, resp, buf)
+				}
 				if req.ResetSessionRequest == nil {
 					return moerr.NewInternalError(ctx, "bad request")
 				}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20022

## What this PR does / why we need it:

Changes:

- Fix the Frontend `ResetSession` admission race behind #20022: the production QueryService path waits for an already-running request to release its routine lease before replacing the session.
- Keep the no-context/direct helper fail-fast and reject a concurrent ResetSession or migration instead of queuing behind another lifecycle operation.
- Preserve the existing Proxy cache, protocol, SQL, and public API behavior; add a production-shaped prepared short-connection terminal regression.

Validation:

- Base: `upstream/main@0543eb93978de5551e0c07f871924e7db1cec893`
- Base behavior: **FAIL** — the pre-fix stale-generation and two-waiter schedules were reproduced during the review repair; this latest-main sync changed only the upstream base, not the PR source diff.
- PR head: `d30e156d787f42700eb26e5d4135f6cf67cb8379`
- PR-head behavior: **PASS** — request-only admission waits for the request lease, rejects concurrent reset/migration and stale lifecycle attempts, stops on close/cancellation, preserves the old Session/proc/txnHandler on failure, replaces exactly once, and supports a second reset.
- Frontend admission focused tests: normal PASS; each directly affected test under `-race -count=100` PASS; full `pkg/frontend` normal and race PASS.
- Proxy prepared terminal: normal PASS; `-race -count=100` PASS; full `pkg/proxy` normal and race PASS.
- `GOWORK=off go list` and `git diff --check` PASS.
- Controlled local build/vet are blocked by the pre-existing `pkg/common/docfilter` CGo symbol declarations; the same `mo_cbitmap_*` / `mo_croaring_*` errors reproduce on a clean `upstream/main` worktree.
- Semantic preflight: PASS at exact head `d30e156d787f42700eb26e5d4135f6cf67cb8379`, diff hash `2a955430273a007487595a0df337aeda90f6bd23bb0de1d9b97e994b2e586360`.
- The previous exact-head CI failure on `1ca82f36ea3c953a86c709e8eb17f351f318ad52` was classified as runner memory-cgroup OOM: `pkg/sql/plan/plan.test` was killed at the 14.68 GiB limit; the downstream Coverage merge failed because that producer failed. The branch was then synced to current `upstream/main` before fresh CI.

QA required: yes

- Reason: this is a lifecycle, session-generation, Proxy cache, and prepared-short-connection behavior change whose deployment terminal requires environment validation.
- Production entry point: QueryService `ResetSession` admission and Proxy connection-cache Push/Pop reuse.
- Automated terminal coverage: request release, lifecycle conflict, cancellation, close, single-waiter reservation, repeated reset, production QueryService deadline, cache reuse, prepared statement, and query execution.
- Remaining validation: current-main multi-CN/dual-Proxy prepared short-connection deployment validation with the topology and long-window load described below.

BVT: N/A — ordinary BVT cannot deterministically enable Proxy connection cache and prepared short connections.

Required QA: current main with #27207, 2+ CN and 2 Proxy, cache enabled, prepared short connections, independent Proxy/CN login probes, 100 concurrent for 10 minutes, then the 1000-vuser and 300-terminal long-window runs. Verify no backend/session growth, panic/restart, login failure, prepared-statement loss, or `wait active/createTxnOpUnsafe`.

This PR references `issue #20022` without auto-closing the Issue; the Issue remains open until QA provides complete version, topology, load, and terminal-login evidence.
