### PR TITLE
docs: fix dead examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,35 +247,35 @@ Ready to dive deeper? Explore our comprehensive collection of hands-on tutorials
 
 | Tutorial | Language/Framework | Description |
 |----------|-------------------|-------------|
-| [Java CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/develop-java-crud-demo/) | Java | Java application development |
-| [SpringBoot and JPA CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/springboot-hibernate-crud-demo/) | Java | SpringBoot with Hibernate/JPA |
-| [PyMySQL CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/develop-python-crud-demo/) | Python | Basic database operations with Python |
-| [SQLAlchemy CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/sqlalchemy-python-crud-demo/) | Python | Python with SQLAlchemy ORM |
-| [Django CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/django-python-crud-demo/) | Python | Django web framework |
-| [Golang CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/develop-golang-crud-demo/) | Go | Go application development |
-| [Gorm CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/gorm-golang-crud-demo/) | Go | Go with Gorm ORM |
-| [C# CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/c-net-crud-demo/) | C# | .NET application development |
-| [TypeScript CRUD Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/typescript-crud-demo/) | TypeScript | TypeScript application development |
+| [Java CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-java-crud-demo.html) | Java | Java application development |
+| [SpringBoot and JPA CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/springboot-hibernate-crud-demo.html) | Java | SpringBoot with Hibernate/JPA |
+| [PyMySQL CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-python-crud-demo.html) | Python | Basic database operations with Python |
+| [SQLAlchemy CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/sqlalchemy-python-crud-demo.html) | Python | Python with SQLAlchemy ORM |
+| [Django CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/django-python-crud-demo.html) | Python | Django web framework |
+| [Golang CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-golang-crud-demo.html) | Go | Go application development |
+| [Gorm CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/gorm-golang-crud-demo.html) | Go | Go with Gorm ORM |
+| [C# CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/c-net-crud-demo.html) | C# | .NET application development |
+| [TypeScript CRUD Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/typescript-crud-demo.html) | TypeScript | TypeScript application development |
 
 ### 🚀 Advanced Features Tutorials
 
 | Tutorial | Use Case | Related MatrixOne Features |
 |----------|----------|---------------------------|
-| [Pinecone-Compatible Vector Search](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/pinecone-vector-demo/) | AI & Search | vector search, Pinecone-compatible API |
-| [IVF Index Health Monitoring](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/ivf-index-health-demo/) | AI & Search | vector search, IVF index |
-| [HNSW Vector Index](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/hnsw-vector-demo/) | AI & Search | vector search, HNSW index |
-| [Fulltext Natural Search](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/fulltext-natural-search-demo/) | AI & Search | fulltext search, natural language |
-| [Fulltext Boolean Search](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/fulltext-boolean-search-demo/) | AI & Search | fulltext search, boolean operators |
-| [Fulltext JSON Search](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/fulltext-json-search-demo/) | AI & Search | fulltext search, JSON data |
-| [Hybrid Search](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/hybrid-search-demo/) | AI & Search | hybrid search, vector + fulltext + SQL |
-| [RAG Application Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/rag-demo/) | AI & Search | RAG, vector search, fulltext search |
-| [Picture(Text)-to-Picture Search](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/search-picture-demo/) | AI & Search | multimodal search, image similarity |
-| [Dify Integration Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/dify-mo-demo/) | AI & Search | AI platform integration |
-| [HTAP Application Demo](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/htap-demo/) | Performance | HTAP, real-time analytics |
-| [Instant Clone for Multi-Team Development](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/efficient-clone-demo/) | Performance | instant clone, Git for Data |
-| [Safe Production Upgrade with Instant Rollback](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/snapshot-rollback-demo/) | Performance | snapshot, rollback, Git for Data |
+| [Pinecone-Compatible Vector Search](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/pinecone-vector-demo.html) | AI & Search | vector search, Pinecone-compatible API |
+| [IVF Index Health Monitoring](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/ivf-index-health-demo.html) | AI & Search | vector search, IVF index |
+| [HNSW Vector Index](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/hnsw-vector-demo.html) | AI & Search | vector search, HNSW index |
+| [Fulltext Natural Search](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/fulltext-natural-search-demo.html) | AI & Search | fulltext search, natural language |
+| [Fulltext Boolean Search](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/fulltext-boolean-search-demo.html) | AI & Search | fulltext search, boolean operators |
+| [Fulltext JSON Search](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/fulltext-json-search-demo.html) | AI & Search | fulltext search, JSON data |
+| [Hybrid Search](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/hybrid-search-demo.html) | AI & Search | hybrid search, vector + fulltext + SQL |
+| [RAG Application Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/rag-demo.html) | AI & Search | RAG, vector search, fulltext search |
+| [Picture(Text)-to-Picture Search](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/search-picture-demo.html) | AI & Search | multimodal search, image similarity |
+| [Dify Integration Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/dify-mo-demo.html) | AI & Search | AI platform integration |
+| [HTAP Application Demo](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/htap-demo.html) | Performance | HTAP, real-time analytics |
+| [Instant Clone for Multi-Team Development](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/efficient-clone-demo.html) | Performance | instant clone, Git for Data |
+| [Safe Production Upgrade with Instant Rollback](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/snapshot-rollback-demo.html) | Performance | snapshot, rollback, Git for Data |
 
-📖 **[View All Tutorials →](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/snapshot-rollback-demo/)**
+📖 **[View All Tutorials →](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-java-crud-demo.html)**
 
 ## 🛠️ <a id="installation--deployment">Installation & Deployment</a>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -241,35 +241,35 @@ for row in results.rows:
 
 | 教程 | 语言/框架 | 说明 |
 |----------|-------------------|-------------|
-| [Java CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/develop-java-crud-demo/) | Java | Java 应用开发 |
-| [SpringBoot 和 JPA CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/springboot-hibernate-crud-demo/) | Java | SpringBoot + Hibernate/JPA |
-| [PyMySQL CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/develop-python-crud-demo/) | Python | Python 基础数据库操作 |
-| [SQLAlchemy CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/sqlalchemy-python-crud-demo/) | Python | Python + SQLAlchemy ORM |
-| [Django CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/django-python-crud-demo/) | Python | Django Web 框架 |
-| [Golang CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/develop-golang-crud-demo/) | Go | Go 应用开发 |
-| [Gorm CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/gorm-golang-crud-demo/) | Go | Go + Gorm ORM |
-| [C# CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/c-net-crud-demo/) | C# | .NET 应用开发 |
-| [TypeScript CRUD 示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/typescript-crud-demo/) | TypeScript | TypeScript 应用开发 |
+| [Java CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-java-crud-demo.html) | Java | Java 应用开发 |
+| [SpringBoot 和 JPA CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/springboot-hibernate-crud-demo.html) | Java | SpringBoot + Hibernate/JPA |
+| [PyMySQL CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-python-crud-demo.html) | Python | Python 基础数据库操作 |
+| [SQLAlchemy CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/sqlalchemy-python-crud-demo.html) | Python | Python + SQLAlchemy ORM |
+| [Django CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/django-python-crud-demo.html) | Python | Django Web 框架 |
+| [Golang CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-golang-crud-demo.html) | Go | Go 应用开发 |
+| [Gorm CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/gorm-golang-crud-demo.html) | Go | Go + Gorm ORM |
+| [C# CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/c-net-crud-demo.html) | C# | .NET 应用开发 |
+| [TypeScript CRUD 示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/typescript-crud-demo.html) | TypeScript | TypeScript 应用开发 |
 
 ### 🚀 高级功能教程
 
 | 教程 | 使用场景 | 相关 MatrixOne 特性 |
 |----------|----------|---------------------------|
-| [Pinecone 兼容向量检索](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/pinecone-vector-demo/) | AI 与搜索 | 向量检索，Pinecone 兼容 API |
-| [IVF 索引健康监控](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/ivf-index-health-demo/) | AI 与搜索 | 向量检索，IVF 索引 |
-| [HNSW 向量索引](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/hnsw-vector-demo/) | AI 与搜索 | 向量检索，HNSW 索引 |
-| [全文自然语言搜索](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/fulltext-natural-search-demo/) | AI 与搜索 | 全文检索，自然语言 |
-| [全文布尔搜索](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/fulltext-boolean-search-demo/) | AI 与搜索 | 全文检索，布尔运算符 |
-| [全文 JSON 搜索](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/fulltext-json-search-demo/) | AI 与搜索 | 全文检索，JSON 数据 |
-| [混合搜索](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/hybrid-search-demo/) | AI 与搜索 | 混合搜索，向量+全文+SQL |
-| [RAG 应用示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/rag-demo/) | AI 与搜索 | RAG，向量检索，全文检索 |
-| [图文搜索应用](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/search-picture-demo/) | AI 与搜索 | 多模态搜索，图像相似度 |
-| [Dify 集成示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/dify-mo-demo/) | AI 与搜索 | AI 平台集成 |
-| [HTAP 应用示例](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/htap-demo/) | 性能 | HTAP，实时分析 |
-| [多团队开发即时克隆](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/efficient-clone-demo/) | 性能 | 即时克隆，Git for Data |
-| [生产环境安全升级与即时回滚](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/snapshot-rollback-demo/) | 性能 | 快照，回滚，Git for Data |
+| [Pinecone 兼容向量检索](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/pinecone-vector-demo.html) | AI 与搜索 | 向量检索，Pinecone 兼容 API |
+| [IVF 索引健康监控](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/ivf-index-health-demo.html) | AI 与搜索 | 向量检索，IVF 索引 |
+| [HNSW 向量索引](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/hnsw-vector-demo.html) | AI 与搜索 | 向量检索，HNSW 索引 |
+| [全文自然语言搜索](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/fulltext-natural-search-demo.html) | AI 与搜索 | 全文检索，自然语言 |
+| [全文布尔搜索](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/fulltext-boolean-search-demo.html) | AI 与搜索 | 全文检索，布尔运算符 |
+| [全文 JSON 搜索](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/fulltext-json-search-demo.html) | AI 与搜索 | 全文检索，JSON 数据 |
+| [混合搜索](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/hybrid-search-demo.html) | AI 与搜索 | 混合搜索，向量+全文+SQL |
+| [RAG 应用示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/rag-demo.html) | AI 与搜索 | RAG，向量检索，全文检索 |
+| [图文搜索应用](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/search-picture-demo.html) | AI 与搜索 | 多模态搜索，图像相似度 |
+| [Dify 集成示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/dify-mo-demo.html) | AI 与搜索 | AI 平台集成 |
+| [HTAP 应用示例](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/htap-demo.html) | 性能 | HTAP，实时分析 |
+| [多团队开发即时克隆](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/efficient-clone-demo.html) | 性能 | 即时克隆，Git for Data |
+| [生产环境安全升级与即时回滚](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/snapshot-rollback-demo.html) | 性能 | 快照，回滚，Git for Data |
 
-📖 **[查看所有教程 →](https://docs.matrixorigin.cn/en/v25.3.0.2/MatrixOne/Tutorial/snapshot-rollback-demo/)**
+📖 **[查看所有教程 →](https://docs.matrixorigin.cn/mo/en/latest/MatrixOne/Tutorial/develop-java-crud-demo.html)**
 
 ## 🛠️ <a id="installation--deployment">安装与部署</a>
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27280

## What this PR does / why we need it:

I checked the website and seems 25.3.0.2 had been dropped then I just followed the latest doc rules change 
all this kind of links to latest instead of versions.

fix the 404 links in README examples