### PR TITLE
[4.2] fix: harden tenant view upgrades

### DIFF
--- a/pkg/bootstrap/service_upgrade_tenant.go
+++ b/pkg/bootstrap/service_upgrade_tenant.go
@@ -338,13 +338,23 @@ func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
 				return
 			}
 
-			for {
-				if hasUpgradeTenants, err := fn(); err != nil || hasUpgradeTenants {
-					continue
-				}
-				break
-			}
+			drainUpgradeTenants(ctx, fn)
 			timer.Reset(s.upgrade.checkUpgradeTenantDuration)
+		}
+	}
+}
+
+func drainUpgradeTenants(ctx context.Context, fn func() (bool, error)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		hasUpgradeTenants, err := fn()
+		if err != nil || !hasUpgradeTenants {
+			return
 		}
 	}
 }

--- a/pkg/bootstrap/service_upgrade_tenant_test.go
+++ b/pkg/bootstrap/service_upgrade_tenant_test.go
@@ -81,6 +81,82 @@ func Test_asyncUpgradeTenantTask(t *testing.T) {
 	)
 }
 
+func TestDrainUpgradeTenants(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []struct {
+			hasTenants bool
+			err        error
+		}
+		wantCalls int
+	}{
+		{
+			name: "drains healthy work",
+			results: []struct {
+				hasTenants bool
+				err        error
+			}{
+				{hasTenants: true},
+				{hasTenants: true},
+				{},
+			},
+			wantCalls: 3,
+		},
+		{
+			name: "stops when no work remains",
+			results: []struct {
+				hasTenants bool
+				err        error
+			}{{}},
+			wantCalls: 1,
+		},
+		{
+			name: "stops on error",
+			results: []struct {
+				hasTenants bool
+				err        error
+			}{{err: moerr.NewInternalErrorNoCtx("upgrade failed")}},
+			wantCalls: 1,
+		},
+		{
+			name: "error wins over stale work flag",
+			results: []struct {
+				hasTenants bool
+				err        error
+			}{{hasTenants: true, err: moerr.NewInternalErrorNoCtx("upgrade failed")}},
+			wantCalls: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			drainUpgradeTenants(t.Context(), func() (bool, error) {
+				if calls >= len(test.results) {
+					t.Fatalf("unexpected call %d", calls+1)
+				}
+				result := test.results[calls]
+				calls++
+				return result.hasTenants, result.err
+			})
+			require.Equal(t, test.wantCalls, calls)
+		})
+	}
+}
+
+func TestDrainUpgradeTenantsStopsAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+
+	drainUpgradeTenants(ctx, func() (bool, error) {
+		calls++
+		cancel()
+		return true, nil
+	})
+
+	require.Equal(t, 1, calls)
+}
+
 func Test_asyncUpgradeTenantTask_SkipsTenantAtTargetVersion(t *testing.T) {
 	sid := ""
 	runtime.RunTest(

--- a/pkg/bootstrap/versions/v4_0_5/tenant_upgrade_list.go
+++ b/pkg/bootstrap/versions/v4_0_5/tenant_upgrade_list.go
@@ -32,7 +32,7 @@ var tenantUpgEntries = []versions.UpgradeEntry{
 	upgradeInformationSchemaView("TABLES", sysview.InformationSchemaTablesDDL),
 	upgradeInformationSchemaView("COLUMNS", sysview.InformationSchemaColumnsDDL),
 	upgradeInformationSchemaView("STATISTICS", sysview.InformationSchemaStatisticsDDL),
-	upgradeInformationSchemaView("TABLE_CONSTRAINTS", sysview.InformationSchemaTableConstraintsDDL),
+	upgradeInformationSchemaViewFromLegacyTable("TABLE_CONSTRAINTS", sysview.InformationSchemaTableConstraintsDDL),
 }
 
 func upgradeInformationSchemaView(viewName, viewDDL string) versions.UpgradeEntry {
@@ -49,6 +49,28 @@ func upgradeInformationSchemaView(viewName, viewDDL string) versions.UpgradeEntr
 			return exists && viewDef == viewDDL, nil
 		},
 		PreSql: fmt.Sprintf("DROP VIEW IF EXISTS %s.%s;", sysview.InformationDBConst, viewName),
+	}
+}
+
+// upgradeInformationSchemaViewFromLegacyTable converges an information_schema
+// object that historical tenant upgrades may have left as a base table. Keep
+// all SQL fully qualified because tenant upgrade transactions use mo_catalog as
+// their default database.
+func upgradeInformationSchemaViewFromLegacyTable(viewName, viewDDL string) versions.UpgradeEntry {
+	return versions.UpgradeEntry{
+		Schema:    sysview.InformationDBConst,
+		TableName: viewName,
+		UpgType:   versions.MODIFY_VIEW,
+		UpgSql:    fmt.Sprintf("DROP VIEW IF EXISTS %s.%s;", sysview.InformationDBConst, viewName),
+		CheckFunc: func(txn executor.TxnExecutor, accountId uint32) (bool, error) {
+			exists, viewDef, err := versions.CheckViewDefinition(txn, accountId, sysview.InformationDBConst, viewName)
+			if err != nil {
+				return false, err
+			}
+			return exists && viewDef == viewDDL, nil
+		},
+		PreSql:  fmt.Sprintf("DROP TABLE IF EXISTS %s.%s;", sysview.InformationDBConst, viewName),
+		PostSql: viewDDL,
 	}
 }
 

--- a/pkg/bootstrap/versions/v4_0_5/upgrade_test.go
+++ b/pkg/bootstrap/versions/v4_0_5/upgrade_test.go
@@ -19,9 +19,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/prashantv/gostub"
 
 	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/util/sysview"
 )
@@ -61,13 +64,14 @@ func TestIcebergOrphanCleanupTenantUpgradeEntries(t *testing.T) {
 
 func TestInformationSchemaTenantUpgradeEntries(t *testing.T) {
 	views := []struct {
-		name string
-		ddl  string
+		name            string
+		ddl             string
+		legacyBaseTable bool
 	}{
 		{name: "TABLES", ddl: sysview.InformationSchemaTablesDDL},
 		{name: "COLUMNS", ddl: sysview.InformationSchemaColumnsDDL},
 		{name: "STATISTICS", ddl: sysview.InformationSchemaStatisticsDDL},
-		{name: "TABLE_CONSTRAINTS", ddl: sysview.InformationSchemaTableConstraintsDDL},
+		{name: "TABLE_CONSTRAINTS", ddl: sysview.InformationSchemaTableConstraintsDDL, legacyBaseTable: true},
 	}
 
 	for i, view := range views {
@@ -75,8 +79,12 @@ func TestInformationSchemaTenantUpgradeEntries(t *testing.T) {
 		if entry.Schema != sysview.InformationDBConst || entry.TableName != view.name || entry.UpgType != versions.MODIFY_VIEW {
 			t.Fatalf("unexpected information_schema.%s upgrade: %+v", view.name, entry)
 		}
-		if entry.UpgSql != view.ddl {
-			t.Fatalf("%s upgrade does not use the current view definition: %s", view.name, entry.UpgSql)
+		definitionSQL := entry.UpgSql
+		if view.legacyBaseTable {
+			definitionSQL = entry.PostSql
+		}
+		if definitionSQL != view.ddl {
+			t.Fatalf("%s upgrade does not use the current view definition: %s", view.name, definitionSQL)
 		}
 		for _, want := range []string{
 			"relkind = 'temporary_table'",
@@ -84,15 +92,80 @@ func TestInformationSchemaTenantUpgradeEntries(t *testing.T) {
 			"mo_is_legacy_temporary_table",
 			"[0-9a-f]{32}",
 		} {
-			if !strings.Contains(entry.UpgSql, want) {
-				t.Fatalf("%s upgrade is missing legacy temporary-table compatibility %q: %s", view.name, want, entry.UpgSql)
+			if !strings.Contains(definitionSQL, want) {
+				t.Fatalf("%s upgrade is missing legacy temporary-table compatibility %q: %s", view.name, want, definitionSQL)
 			}
 		}
-		wantPreSQL := "drop view if exists information_schema." + strings.ToLower(view.name)
-		if !strings.Contains(strings.ToLower(entry.PreSql), wantPreSQL) {
-			t.Fatalf("%s upgrade is missing its drop-view precondition: %s", view.name, entry.PreSql)
+		if view.legacyBaseTable {
+			requireSQLContains(t, entry.PreSql, "drop table if exists information_schema."+strings.ToLower(view.name))
+			requireSQLContains(t, entry.UpgSql, "drop view if exists information_schema."+strings.ToLower(view.name))
+			continue
+		}
+		requireSQLContains(t, entry.PreSql, "drop view if exists information_schema."+strings.ToLower(view.name))
+		if entry.PostSql != "" {
+			t.Fatalf("%s regular view upgrade should not use post-sql: %s", view.name, entry.PostSql)
 		}
 	}
+}
+
+func requireSQLContains(t *testing.T, sql, want string) {
+	t.Helper()
+	if !strings.Contains(strings.ToLower(sql), want) {
+		t.Fatalf("SQL %q does not contain %q", sql, want)
+	}
+}
+
+func TestInformationSchemaLegacyTableUpgradeIsOrderedAndIdempotent(t *testing.T) {
+	entry := upgradeInformationSchemaViewFromLegacyTable("TABLE_CONSTRAINTS", sysview.InformationSchemaTableConstraintsDDL)
+	upgraded := false
+	stub := gostub.Stub(&versions.CheckViewDefinition, func(_ executor.TxnExecutor, accountID uint32, schema, viewName string) (bool, string, error) {
+		if accountID != 42 || schema != sysview.InformationDBConst || viewName != "TABLE_CONSTRAINTS" {
+			t.Fatalf("unexpected view check arguments: account=%d schema=%s view=%s", accountID, schema, viewName)
+		}
+		if upgraded {
+			return true, sysview.InformationSchemaTableConstraintsDDL, nil
+		}
+		return false, "", nil
+	})
+	defer stub.Reset()
+
+	var executed []string
+	txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+	txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{}).AnyTimes()
+	txnExecutor := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+		executed = append(executed, sql)
+		if sql == entry.PostSql {
+			upgraded = true
+		}
+		return executor.Result{}, nil
+	}, txnOperator)
+
+	if err := entry.Upgrade(txnExecutor, 42); err != nil {
+		t.Fatalf("first upgrade: %v", err)
+	}
+	if want := []string{entry.PreSql, entry.UpgSql, entry.PostSql}; !equalStrings(executed, want) {
+		t.Fatalf("unexpected execution order: got %q, want %q", executed, want)
+	}
+
+	executed = nil
+	if err := entry.Upgrade(txnExecutor, 42); err != nil {
+		t.Fatalf("second upgrade: %v", err)
+	}
+	if len(executed) != 0 {
+		t.Fatalf("matching view should skip DDL, executed %q", executed)
+	}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestInformationSchemaTenantUpgradeCheckFunc(t *testing.T) {

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -3338,9 +3338,14 @@ func buildDropView(stmt *tree.DropView, ctx CompilerContext) (*Plan, error) {
 		}
 	} else {
 		if tableDef.ViewSql == nil {
-			return nil, moerr.NewBadView(ctx.GetContext(), dropTable.Database, dropTable.Table)
+			if !dropTable.IfExists {
+				return nil, moerr.NewBadView(ctx.GetContext(), dropTable.Database, dropTable.Table)
+			}
+			// DROP VIEW IF EXISTS must not target a same-named base table.
+			// An empty table name is the established DropTable executor no-op.
+			dropTable.Table = ""
 		}
-		if obj.PubInfo != nil {
+		if tableDef.ViewSql != nil && obj.PubInfo != nil {
 			return nil, moerr.NewInternalError(ctx.GetContext(), "cannot drop view in subscription database")
 		}
 	}

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -103,6 +103,27 @@ func TestBuildDropTemporaryTableIfExistsDoesNotTargetPermanentTable(t *testing.T
 	require.Nil(t, p.GetDdl().GetDropTable().GetTableDef())
 }
 
+func TestBuildDropViewIfExistsDoesNotTargetBaseTable(t *testing.T) {
+	stmt, err := parsers.ParseOne(t.Context(), dialect.MYSQL, "drop view if exists nation", 1)
+	require.NoError(t, err)
+	defer stmt.Free()
+
+	p, err := BuildPlan(NewMockCompilerContext(false), stmt, false)
+	require.NoError(t, err)
+	drop := p.GetDdl().GetDropTable()
+	require.Empty(t, drop.GetTable())
+	require.True(t, drop.GetIsView())
+}
+
+func TestBuildDropViewRejectsBaseTableWithoutIfExists(t *testing.T) {
+	stmt, err := parsers.ParseOne(t.Context(), dialect.MYSQL, "drop view nation", 1)
+	require.NoError(t, err)
+	defer stmt.Free()
+
+	_, err = BuildPlan(NewMockCompilerContext(false), stmt, false)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrBadView), err)
+}
+
 func (c *rootSQLCompilerContext) GetRootSql() string {
 	c.calls++
 	return c.rootSQL

--- a/test/distributed/cases/ddl/drop_if_exists.result
+++ b/test/distributed/cases/ddl/drop_if_exists.result
@@ -48,6 +48,22 @@ show tables;
 Tables_in_db1
 drop database db1;
 drop account acc101;
+drop database if exists drop_view_if_exists_test;
+create database drop_view_if_exists_test;
+use drop_view_if_exists_test;
+create table base_table(a int);
+insert into base_table values (1);
+drop view if exists base_table;
+select * from base_table;
+a
+1
+create view stale_view as select a from base_table;
+drop table if exists stale_view;
+select * from stale_view;
+a
+1
+drop view stale_view;
+drop database drop_view_if_exists_test;
 drop database if exists test;
 create database test;
 begin;

--- a/test/distributed/cases/ddl/drop_if_exists.sql
+++ b/test/distributed/cases/ddl/drop_if_exists.sql
@@ -50,7 +50,6 @@ drop database db1;
 -- @session
 drop account acc101;
 
--- @bvt:issue#27289
 drop database if exists drop_view_if_exists_test;
 create database drop_view_if_exists_test;
 use drop_view_if_exists_test;
@@ -63,7 +62,6 @@ drop table if exists stale_view;
 select * from stale_view;
 drop view stale_view;
 drop database drop_view_if_exists_test;
--- @bvt:issue
 
 
 drop database if exists test;
@@ -79,5 +77,4 @@ select disable_fault_injection();
 commit;
 
 drop database test;
-
 

--- a/test/distributed/cases/ddl/drop_if_exists.sql
+++ b/test/distributed/cases/ddl/drop_if_exists.sql
@@ -50,6 +50,21 @@ drop database db1;
 -- @session
 drop account acc101;
 
+-- @bvt:issue#27289
+drop database if exists drop_view_if_exists_test;
+create database drop_view_if_exists_test;
+use drop_view_if_exists_test;
+create table base_table(a int);
+insert into base_table values (1);
+drop view if exists base_table;
+select * from base_table;
+create view stale_view as select a from base_table;
+drop table if exists stale_view;
+select * from stale_view;
+drop view stale_view;
+drop database drop_view_if_exists_test;
+-- @bvt:issue
+
 
 drop database if exists test;
 create database test;
@@ -64,6 +79,5 @@ select disable_fault_injection();
 commit;
 
 drop database test;
-
 
 

--- a/test/distributed/cases/mo_cloud/mo_cloud.result
+++ b/test/distributed/cases/mo_cloud/mo_cloud.result
@@ -964,9 +964,11 @@ alter account `2ef38bf3_b821_4cab_879e_3b788f1e922f` admin_name 'admin' identifi
 internal error: do not have privilege to execute the statement
 delete from mo_mo.operation where created_at <= '2023-07-21 13:42:02';
 no such table mo_mo.operation
+set mo_table_stats.force_update = yes;
 select distinct IF(relkind = 'v', 0, mo_table_rows('information_schema','character_sets')) as `rows` from mo_catalog.mo_tables where reldatabase='information_schema' and relname='character_sets';
 ➤ rows[-5,64,0]  𝄀
-0
+3
+set mo_table_stats.force_update = no;
 select distinct IF(relkind = 'v', 0, mo_table_rows('mo_sample_data_tpch_sf1','customer')) as `rows` from mo_catalog.mo_tables where reldatabase='mo_sample_data_tpch_sf1' and relname='customer';
 ➤ rows[-5,64,0]
 select distinct IF(relkind = 'v', 0, mo_table_rows('mo_sample_data_tpch_sf1','lineitem')) as `rows` from mo_catalog.mo_tables where reldatabase='mo_sample_data_tpch_sf1' and relname='lineitem';

--- a/test/distributed/cases/mo_cloud/mo_cloud.sql
+++ b/test/distributed/cases/mo_cloud/mo_cloud.sql
@@ -187,7 +187,9 @@ UPDATE `mo_mo`.`wb` SET `updated_at`='2023-07-28 06:02:41.452' WHERE id = '9579c
 
 alter account `2ef38bf3_b821_4cab_879e_3b788f1e922f` admin_name 'admin' identified by 'abcd';
 delete from mo_mo.operation where created_at <= '2023-07-21 13:42:02';
+set mo_table_stats.force_update = yes;
 select distinct IF(relkind = 'v', 0, mo_table_rows('information_schema','character_sets')) as `rows` from mo_catalog.mo_tables where reldatabase='information_schema' and relname='character_sets';
+set mo_table_stats.force_update = no;
 select distinct IF(relkind = 'v', 0, mo_table_rows('mo_sample_data_tpch_sf1','customer')) as `rows` from mo_catalog.mo_tables where reldatabase='mo_sample_data_tpch_sf1' and relname='customer';
 select distinct IF(relkind = 'v', 0, mo_table_rows('mo_sample_data_tpch_sf1','lineitem')) as `rows` from mo_catalog.mo_tables where reldatabase='mo_sample_data_tpch_sf1' and relname='lineitem';
 select distinct IF(relkind = 'v', 0, mo_table_rows('mo_sample_data_tpch_sf1','nation')) as `rows` from mo_catalog.mo_tables where reldatabase='mo_sample_data_tpch_sf1' and relname='nation';

--- a/test/distributed/cases/view/alter_view.result
+++ b/test/distributed/cases/view/alter_view.result
@@ -177,6 +177,5 @@ INSERT INTO t1 VALUES ('a');
 CREATE VIEW t2 AS SELECT * FROM t1;
 table t2 already exists
 DROP VIEW IF EXISTS t2;
-invalid view 'alter_view.t2'
 DROP TABLE t1;
 DROP TABLE t2;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Refs #27287, #27288, #27289.

Backport of #27299 to `4.2-dev`.

## What this PR does / why we need it:

- Makes the `information_schema.TABLE_CONSTRAINTS` tenant upgrade converge when an older tenant contains a same-named base table.
- Stops the tenant-upgrade drain loop on errors or cancellation instead of spinning indefinitely.
- Makes `DROP VIEW IF EXISTS` a no-op when the resolved object is a base table, while preserving the error for `DROP VIEW` without `IF EXISTS`.
- Enables and updates the related BVT regressions.

This backport intentionally does not include the `v4_0_6` changes from #27299 because those upgrade entries are not present on `4.2-dev`.

Validation:

- `make thirdparties`
- `GOWORK=off go list/build/vet/test` for `./pkg/bootstrap`, `./pkg/bootstrap/versions/v4_0_5`, and `./pkg/sql/plan`
- Focused race tests, 100 repetitions each, plus full `./pkg/bootstrap` race test
- `make build`
- `drop_if_exists.sql`: 47/47 passed, 0 ignored
- `alter_view.sql`: 100/100 passed, 0 ignored
