### PR TITLE
fix(vector): handle pruned IVFFLAT output columns

### DIFF
--- a/pkg/sql/colexec/table_function/ivf_search.go
+++ b/pkg/sql/colexec/table_function/ivf_search.go
@@ -51,6 +51,7 @@ type ivfSearchState struct {
 	keys           []any
 	distances      []float64
 	includeColumns []string
+	slots          vectorSearchSlots
 	// includeData stays keyed by column name for round-merge lookups and test
 	// assertions; output order still comes from includeColumns, not map iteration.
 	includeData          map[string][]any
@@ -159,16 +160,24 @@ func (u *ivfSearchState) call(tf *TableFunction, proc *process.Process) (vm.Call
 			}
 		}
 
-		vector.AppendAny(u.batch.Vecs[0], u.keys[u.offset], false, proc.Mp())
-		vector.AppendFixed(u.batch.Vecs[1], u.distances[u.offset], false, proc.Mp())
+		if u.slots.pk >= 0 {
+			vector.AppendAny(u.batch.Vecs[u.slots.pk], u.keys[u.offset], false, proc.Mp())
+		}
+		if u.slots.score >= 0 {
+			vector.AppendFixed(u.batch.Vecs[u.slots.score], u.distances[u.offset], false, proc.Mp())
+		}
 		for i, col := range u.includeColumns {
+			pos := u.slots.include[i]
+			if pos < 0 {
+				continue
+			}
 			isNull := false
 			if u.includeNulls != nil {
 				if nulls, ok := u.includeNulls[col]; ok && u.offset < len(nulls) {
 					isNull = nulls[u.offset]
 				}
 			}
-			vector.AppendAny(u.batch.Vecs[2+i], u.includeData[col][u.offset], isNull, proc.Mp())
+			vector.AppendAny(u.batch.Vecs[pos], u.includeData[col][u.offset], isNull, proc.Mp())
 		}
 		u.offset++
 		u.emittedCandidates++
@@ -427,6 +436,8 @@ func (u *ivfSearchState) start(tf *TableFunction, proc *process.Process, nthRow 
 
 		u.batch = tf.createResultBatch()
 		u.includeColumns = requestedIvfIncludeColumns(tf.Attrs)
+		u.slots = resolveVectorSearchSlots(
+			u.batch.Attrs, u.includeColumns, catalog.SystemSI_IVFFLAT_IncludeColPrefix)
 		if u.limit == 0 && (!u.multiRoundEnabled || len(u.includeColumns) == 0) {
 			u.limit = 1
 		}
@@ -470,15 +481,14 @@ func (u *ivfSearchState) start(tf *TableFunction, proc *process.Process, nthRow 
 }
 
 func requestedIvfIncludeColumns(attrs []string) []string {
-	if len(attrs) <= 2 {
-		return nil
-	}
-
-	cols := make([]string, 0, len(attrs)-2)
-	for _, attr := range attrs[2:] {
+	cols := make([]string, 0, len(attrs))
+	for _, attr := range attrs {
 		if strings.HasPrefix(attr, catalog.SystemSI_IVFFLAT_IncludeColPrefix) {
 			cols = append(cols, strings.TrimPrefix(attr, catalog.SystemSI_IVFFLAT_IncludeColPrefix))
 		}
+	}
+	if len(cols) == 0 {
+		return nil
 	}
 	return cols
 }

--- a/pkg/sql/colexec/table_function/ivf_search_test.go
+++ b/pkg/sql/colexec/table_function/ivf_search_test.go
@@ -231,6 +231,41 @@ func TestIvfSearch(t *testing.T) {
 	ut.arg.ctr.state.free(ut.arg, ut.proc, false, nil)
 }
 
+func TestIvfSearchScoreOnlyProjection(t *testing.T) {
+	oldNewIvfAlgo := newIvfAlgo
+	oldGetVersion := getVersion
+	newIvfAlgo = newMockIvfAlgoFn
+	getVersion = mockVersion
+	t.Cleanup(func() {
+		newIvfAlgo = oldNewIvfAlgo
+		getVersion = oldGetVersion
+	})
+
+	param := `{"op_type": "vector_l2_ops", "lists": "3"}`
+	ut := newIvfSearchTestCase(t, mpool.MustNewZero(), []string{"score"}, param)
+	ut.arg.Args = makeConstInputExprsIvfSearch()
+	inbat := makeBatchIvfSearch(ut.proc)
+
+	require.NoError(t, ut.arg.Prepare(ut.proc))
+	for i := range ut.arg.ctr.executorsForArgs {
+		var err error
+		ut.arg.ctr.argVecs[i], err = ut.arg.ctr.executorsForArgs[i].Eval(
+			ut.proc, []*batch.Batch{inbat}, nil)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, ut.arg.ctr.state.start(ut.arg, ut.proc, 0, nil))
+	t.Cleanup(func() {
+		ut.arg.ctr.state.free(ut.arg, ut.proc, false, nil)
+	})
+
+	result, err := ut.arg.ctr.state.call(ut.arg, ut.proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecNext, result.Status)
+	require.Equal(t, []string{"score"}, result.Batch.Attrs)
+	require.Equal(t, []float64{2}, vector.MustFixedColWithTypeCheck[float64](result.Batch.Vecs[0]))
+}
+
 var failedivfsearchparam []string = []string{"{",
 	"{\"op_type\": \"vector_xxx_ops\"}",
 	"{\"op_type\": \"vector_l2_ops\", \"lists\":\"\"}",

--- a/pkg/sql/colexec/table_function/vector_search_layout.go
+++ b/pkg/sql/colexec/table_function/vector_search_layout.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table_function
+
+func vectorSearchAttrPos(attrs []string, name string) int {
+	for i, attr := range attrs {
+		if attr == name {
+			return i
+		}
+	}
+	return -1
+}
+
+type vectorSearchSlots struct {
+	pk      int
+	score   int
+	include []int
+}
+
+func resolveVectorSearchSlots(attrs []string, includeColumns []string, includePrefix string) vectorSearchSlots {
+	slots := vectorSearchSlots{
+		pk:    vectorSearchAttrPos(attrs, "pkid"),
+		score: vectorSearchAttrPos(attrs, "score"),
+	}
+	if len(includeColumns) > 0 {
+		slots.include = make([]int, len(includeColumns))
+		for i, col := range includeColumns {
+			slots.include[i] = vectorSearchAttrPos(attrs, includePrefix+col)
+		}
+	}
+	return slots
+}

--- a/pkg/sql/colexec/table_function/vector_search_layout_test.go
+++ b/pkg/sql/colexec/table_function/vector_search_layout_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table_function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+)
+
+func TestVectorSearchAttrPos(t *testing.T) {
+	full := []string{"pkid", "score", catalog.SystemSI_IVFFLAT_IncludeColPrefix + "c"}
+	require.Equal(t, 0, vectorSearchAttrPos(full, "pkid"))
+	require.Equal(t, 1, vectorSearchAttrPos(full, "score"))
+	require.Equal(t, 2, vectorSearchAttrPos(full, catalog.SystemSI_IVFFLAT_IncludeColPrefix+"c"))
+
+	pruned := []string{"score"}
+	require.Equal(t, -1, vectorSearchAttrPos(pruned, "pkid"))
+	require.Equal(t, 0, vectorSearchAttrPos(pruned, "score"))
+
+	shifted := []string{"pkid", catalog.SystemSI_IVFFLAT_IncludeColPrefix + "c"}
+	require.Equal(t, -1, vectorSearchAttrPos(shifted, "score"))
+	require.Equal(t, 1, vectorSearchAttrPos(shifted, catalog.SystemSI_IVFFLAT_IncludeColPrefix+"c"))
+	require.Equal(t, -1, vectorSearchAttrPos(nil, "pkid"))
+}
+
+func TestRequestedIvfIncludeColumnsPositionIndependent(t *testing.T) {
+	prefix := catalog.SystemSI_IVFFLAT_IncludeColPrefix
+	require.Equal(t, []string{"a", "b"}, requestedIvfIncludeColumns(
+		[]string{"pkid", "score", prefix + "a", prefix + "b"}))
+	require.Equal(t, []string{"a"}, requestedIvfIncludeColumns([]string{"score", prefix + "a"}))
+	require.Equal(t, []string{"a"}, requestedIvfIncludeColumns([]string{prefix + "a"}))
+	require.Nil(t, requestedIvfIncludeColumns([]string{"pkid", "score"}))
+	require.Nil(t, requestedIvfIncludeColumns(nil))
+}
+
+func TestResolveVectorSearchSlots(t *testing.T) {
+	prefix := catalog.SystemSI_IVFFLAT_IncludeColPrefix
+
+	t.Run("full layout", func(t *testing.T) {
+		got := resolveVectorSearchSlots(
+			[]string{"pkid", "score", prefix + "a", prefix + "b"}, []string{"a", "b"}, prefix)
+		require.Equal(t, 0, got.pk)
+		require.Equal(t, 1, got.score)
+		require.Equal(t, []int{2, 3}, got.include)
+	})
+
+	t.Run("planner pruned pkid", func(t *testing.T) {
+		got := resolveVectorSearchSlots([]string{"score", prefix + "a"}, []string{"a"}, prefix)
+		require.Equal(t, -1, got.pk)
+		require.Equal(t, 0, got.score)
+		require.Equal(t, []int{1}, got.include)
+	})
+
+	t.Run("include column pruned", func(t *testing.T) {
+		got := resolveVectorSearchSlots([]string{"pkid", "score"}, []string{"a"}, prefix)
+		require.Equal(t, []int{-1}, got.include)
+	})
+
+	t.Run("no include columns", func(t *testing.T) {
+		got := resolveVectorSearchSlots([]string{"pkid", "score"}, nil, "")
+		require.Equal(t, 0, got.pk)
+		require.Equal(t, 1, got.score)
+		require.Nil(t, got.include)
+	})
+
+	t.Run("empty layout", func(t *testing.T) {
+		got := resolveVectorSearchSlots(nil, nil, "")
+		require.Equal(t, -1, got.pk)
+		require.Equal(t, -1, got.score)
+	})
+}

--- a/test/distributed/cases/vector/vector_ivf_projection.result
+++ b/test/distributed/cases/vector/vector_ivf_projection.result
@@ -1,0 +1,34 @@
+drop database if exists vector_ivf_projection;
+create database vector_ivf_projection;
+use vector_ivf_projection;
+create table t(id bigint, v vecf32(4));
+insert into t values
+(1, '[1,1,1,1]'),
+(2, '[2,2,2,2]'),
+(3, '[3,3,3,3]'),
+(4, '[10,10,10,10]');
+create index idx_v using ivfflat on t(v) lists=2 op_type 'vector_l2_ops';
+explain select l2_distance(v, '[1,1,1,1]') as distance
+from t order by distance limit 3;
+-- @regex("Table Function on ivf_search", true)
+➤ AP QUERY PLAN ON MULTICN(10 core)[12,0,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_ivf_alias_0.score INTERNAL  𝄀
+        Limit: 3  𝄀
+        ->  Table Function on ivf_search  𝄀
+              Index Reader Param:  Limit: 3  𝄀
+              Limit: 3
+select id, l2_distance(v, '[1,1,1,1]') as distance
+from t order by distance limit 3;
+➤ id[-5,64,0]  ¦  distance[8,9,0]  𝄀
+1  ¦  0.0  𝄀
+2  ¦  2.0  𝄀
+3  ¦  4.0
+select l2_distance(v, '[1,1,1,1]') as distance
+from t order by distance limit 3;
+➤ distance[8,9,0]  𝄀
+0.0  𝄀
+2.0  𝄀
+4.0
+drop database vector_ivf_projection;

--- a/test/distributed/cases/vector/vector_ivf_projection.sql
+++ b/test/distributed/cases/vector/vector_ivf_projection.sql
@@ -1,0 +1,24 @@
+drop database if exists vector_ivf_projection;
+create database vector_ivf_projection;
+use vector_ivf_projection;
+
+create table t(id bigint, v vecf32(4));
+insert into t values
+    (1, '[1,1,1,1]'),
+    (2, '[2,2,2,2]'),
+    (3, '[3,3,3,3]'),
+    (4, '[10,10,10,10]');
+create index idx_v using ivfflat on t(v) lists=2 op_type 'vector_l2_ops';
+
+-- @separator:table
+-- @regex("Table Function on ivf_search", true)
+explain select l2_distance(v, '[1,1,1,1]') as distance
+from t order by distance limit 3;
+
+select id, l2_distance(v, '[1,1,1,1]') as distance
+from t order by distance limit 3;
+
+select l2_distance(v, '[1,1,1,1]') as distance
+from t order by distance limit 3;
+
+drop database vector_ivf_projection;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring
- [ ] Epic
- [ ] CI/CD

## Which issue(s) this PR fixes:

Fixes #27283

## What this PR does / why we need it:

The planner may prune unused outputs from `ivf_search`. For a score-only projection, `pkid` is removed and `score` moves to slot 0. The executor previously wrote the primary key to fixed slot 0, causing an integer-to-float vector append panic.

This change resolves `pkid`, `score`, and INCLUDE output slots from the actual result attributes once per layout, skips pruned outputs, and discovers INCLUDE columns independently of their position. It adds unit and distributed SQL regressions for score-only projection.

## Validation

- `mo-cgo-test -v -count=1 -timeout=180s ./pkg/sql/colexec/table_function`
- `GOWORK=off go build ./pkg/sql/colexec/table_function`
- `GOWORK=off go vet ./pkg/sql/colexec/table_function`
- mo-tester distributed regression: 10/10 statements passed
- Text protocol and `COM_STMT_PREPARE` probes passed for score-only and full projections
