### PR TITLE
fix: guard REPEAT result length overflow

### DIFF
--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -1602,7 +1602,10 @@ func builtInRepeat(parameters []*vector.Vector, result vector.FunctionResultWrap
 		// I'm not sure if this is the right thing to do, MySql can repeat string with the result length at least 1,000,000.
 		// and there is no documentation about the limit of the result length.
 		sourceLen := int64(len(base))
-		if sourceLen*n > types.MaxVarcharLen {
+		if sourceLen == 0 {
+			return "", false
+		}
+		if n > types.MaxVarcharLen/sourceLen {
 			return "", true
 		}
 		return strings.Repeat(base, int(n)), false

--- a/pkg/sql/plan/function/func_builtin_test.go
+++ b/pkg/sql/plan/function/func_builtin_test.go
@@ -990,15 +990,15 @@ func Test_BuiltIn_Repeat(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	{
 		tc := tcTemp{
-			info: "test repeat('ab', num) with num = -1, 0, 1, 3, null, 1000000000000",
+			info: "test repeat('ab', num) with num = -1, 0, 1, 3, null, 1000000000000, 4611686018427387904",
 			inputs: []FunctionTestInput{
 				NewFunctionTestConstInput(types.T_varchar.ToType(),
 					[]string{"ab"}, nil),
 				NewFunctionTestInput(types.T_int64.ToType(),
-					[]int64{-1, 0, 1, 3, 0, 1000000000000}, []bool{false, false, false, false, true, false}),
+					[]int64{-1, 0, 1, 3, 0, 1000000000000, 1 << 62}, []bool{false, false, false, false, true, false, false}),
 			},
 			expect: NewFunctionTestResult(types.T_varchar.ToType(), false,
-				[]string{"", "", "ab", "ababab", "", ""}, []bool{false, false, false, false, true, true}),
+				[]string{"", "", "ab", "ababab", "", "", ""}, []bool{false, false, false, false, true, true, true}),
 		}
 		tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, builtInRepeat)
 		succeed, info := tcc.Run()


### PR DESCRIPTION
Fixes #27322

## Summary

- Guard the `REPEAT()` result-length calculation before multiplying the source length by the repeat count.
- Return the normal NULL result for counts that exceed `types.MaxVarcharLen`, including counts that would overflow the previous `int64` multiplication.
- Add a regression case for the `2^62` repeat count while preserving the existing negative, zero, NULL, and normal-count coverage.

## Testing

- `go test ./pkg/sql/plan/function -run '^Test_BuiltIn_Repeat$' -count=1 -v`
- `go test ./pkg/sql/plan/function -count=1`
- `make build-with-prebuilt-native`
- Build a local `mo-service` and start the standalone launch configuration.
- Execute:

```sql
SELECT REPEAT('ab', 4611686018427387904);
SELECT REPEAT('ab', 3);
```

Observed results:

- The large-count query returns `NULL` without an internal error or panic.
- The control query returns `ababab`.

## Notes

The previous implementation evaluated `sourceLen * n` before checking the maximum result length. For a valid large `INT64` count, that multiplication could overflow to a negative value and bypass the guard before reaching `strings.Repeat`. The fix uses division-based bounds checking and handles an empty source string separately.
