### PR TITLE
ci: reuse preloaded ONNX Runtime artifact

### DIFF
--- a/optools/images/Dockerfile
+++ b/optools/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM matrixorigin/golang:1.26.4-ubuntu22.04 AS build-base
+FROM matrixorigin/golang:1.26.4-ubuntu22.04-matrixone-native-1 AS build-base
 
 ENV GOWORK=off
 

--- a/optools/images/Dockerfile.ci
+++ b/optools/images/Dockerfile.ci
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=matrixorigin/golang:1.26.4-ubuntu22.04
-ARG NATIVE_IMAGE=matrixorigin/golang:1.26.4-ubuntu22.04
+ARG BUILDER_IMAGE=matrixorigin/golang:1.26.4-ubuntu22.04-matrixone-native-1
+ARG NATIVE_IMAGE=matrixorigin/golang:1.26.4-ubuntu22.04-matrixone-native-1
 ARG GO_CACHE_IMAGE=matrixorigin/golang:1.26.4-ubuntu22.04
 ARG RUNTIME_IMAGE=matrixorigin/ubuntu:22.04
 

--- a/optools/images/Dockerfile.dev
+++ b/optools/images/Dockerfile.dev
@@ -4,7 +4,7 @@
 # - Binary is built inside container using local make build
 # - Much faster iteration cycle for development
 
-FROM matrixorigin/golang:1.26.4-ubuntu22.04
+FROM matrixorigin/golang:1.26.4-ubuntu22.04-matrixone-native-1
 
 # Install build dependencies and runtime libraries
 RUN apt-get update && apt-get install -y \

--- a/thirdparties/Makefile
+++ b/thirdparties/Makefile
@@ -60,6 +60,10 @@ JEMALLOC_CONFIGURE_FLAGS=--disable-shared --enable-static --enable-stats --with-
 ONNX_VERSION=1.26.0
 ONNX_REPO_COMMIT=655365097e21c4df0f82337063f9a12b66700593
 ONNX_BASE_URL=https://github.com/matrixorigin/thirdparty/raw/$(ONNX_REPO_COMMIT)/onnxrt/$(ONNX_VERSION)
+# The MatrixOne CI builder image ships these pinned artifacts. Keep this a
+# versioned directory so a base-image update cannot accidentally satisfy a
+# different ONNX Runtime version. A local build simply falls back to DOWNLOAD.
+ONNX_PREBUILT_DIR ?= /opt/matrixone/onnxruntime/$(ONNX_VERSION)
 ONNX_SUPPORTED=
 ifeq ($(UNAME_S)_$(UNAME_M),darwin_arm64)
   ONNX_SUPPORTED=1
@@ -213,7 +217,14 @@ install/lib/libroaring.a:
 #   macOS arm64  -> onnxruntime_arm64.dylib
 ifeq ($(ONNX_SUPPORTED),1)
 onnxruntime: | init
-	$(DOWNLOAD) "$(ONNX_BASE_URL)/$(ONNX_SRC)" "$(ONNX_SHA256)" "install/lib/$(ONNX_LIB)"
+	@if test -r "$(ONNX_PREBUILT_DIR)/$(ONNX_LIB)"; then \
+		echo "using prebuilt ONNX Runtime $(ONNX_VERSION) from $(ONNX_PREBUILT_DIR)"; \
+		install -m 0644 "$(ONNX_PREBUILT_DIR)/$(ONNX_LIB)" "install/lib/$(ONNX_LIB)"; \
+		actual_sha256="$$(sha256sum "install/lib/$(ONNX_LIB)" | awk '{print $$1}')"; \
+		test "$$actual_sha256" = "$(ONNX_SHA256)" || { echo "ONNX Runtime checksum mismatch: got $$actual_sha256, expected $(ONNX_SHA256)" >&2; rm -f "install/lib/$(ONNX_LIB)"; exit 1; }; \
+	else \
+		$(DOWNLOAD) "$(ONNX_BASE_URL)/$(ONNX_SRC)" "$(ONNX_SHA256)" "install/lib/$(ONNX_LIB)"; \
+	fi
 else
 onnxruntime:
 	$(error unsupported ONNX Runtime platform: $(UNAME_S)/$(UNAME_M))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26664

## What this PR does / why we need it:

Use the versioned MatrixOne Go build image that preloads ONNX Runtime, and copy the artifact into the native build only after SHA-256 verification. This removes the per-PR GitHub download that can time out in image builds.

Local and non-preloaded environments retain the existing verified downloader fallback.

The base image was published after [matrixorigin/ci-images#109](https://github.com/matrixorigin/ci-images/pull/109) merged as `matrixorigin/golang:1.26.4-ubuntu22.04-matrixone-native-1`.

Validation:

- Synthetic preloaded artifact: copied without invoking the downloader and installed mode is `0644`.
- Corrupt preloaded artifact: checksum verification fails and removes the destination.
- `make -C thirdparties -n onnxruntime` and `git diff --check`.