### PR TITLE
ci: share native dependency fingerprint with builder image

### DIFF
--- a/optools/images/Dockerfile
+++ b/optools/images/Dockerfile
@@ -20,7 +20,7 @@ FROM build-base AS builder
 # GOPROXY affects Go modules, not native dependencies. Keeping it out of the
 # native stage preserves that expensive cache when build environments differ.
 ARG GOPROXY="https://proxy.golang.org,direct"
-RUN go env -w GOPROXY=${GOPROXY}
+RUN go env -w GOPROXY="${GOPROXY}"
 
 # Typecheck: enable type checking for ToSliceNoTypeCheck and ToSliceNoTypeCheck2
 # Default: 0 (disabled), set to 1 to enable

--- a/optools/images/Dockerfile.ci
+++ b/optools/images/Dockerfile.ci
@@ -7,7 +7,7 @@ FROM ${BUILDER_IMAGE} AS native
 
 ARG GOPROXY="https://proxy.golang.org,direct"
 ENV GOWORK=off
-RUN go env -w GOPROXY=${GOPROXY}
+RUN go env -w GOPROXY="${GOPROXY}"
 
 WORKDIR /go/src/github.com/matrixorigin/matrixone
 COPY thirdparties thirdparties
@@ -21,7 +21,7 @@ FROM ${NATIVE_IMAGE} AS builder
 
 ARG GOPROXY="https://proxy.golang.org,direct"
 ENV GOWORK=off
-RUN go env -w GOPROXY=${GOPROXY}
+RUN go env -w GOPROXY="${GOPROXY}"
 
 WORKDIR /go/src/github.com/matrixorigin/matrixone
 

--- a/optools/images/Dockerfile.ci-builder
+++ b/optools/images/Dockerfile.ci-builder
@@ -79,17 +79,18 @@ RUN if cover_scope=$(go list -mod=readonly ./... | grep -v 'driver\|engine/aoe\|
 
 # Fingerprint the native inputs the prebuilt thirdparties were produced
 # from. Consumers restore thirdparties/install only on an exact match, so a
-# PR that changes thirdparties/, a different architecture, or a branch
-# whose native tree diverges from this image all rebuild from source
-# instead of silently testing stale native code. Bump schema= whenever the
-# native build contract (base image, compiler, layout) changes.
-RUN { \
-      echo "schema=1"; \
-      echo "os=$(uname -s)"; \
-      echo "arch=$(uname -m)"; \
-      echo "thirdparties_tree=$(git rev-parse HEAD:thirdparties)"; \
-    } > /mo-prebuilt/thirdparties.fingerprint && \
-    cat /mo-prebuilt/thirdparties.fingerprint
+# PR that changes thirdparties/, cgo, the compiler, or the native build
+# contract rebuilds from source instead of silently testing stale native code.
+# Keep this script in MatrixOne so the producer and every consumer use the
+# same contract. Bump schema= whenever the native layout changes.
+RUN if [ -x optools/images/ci-builder-fingerprint.sh ]; then \
+      optools/images/ci-builder-fingerprint.sh > /mo-prebuilt/thirdparties.fingerprint; \
+    else \
+      echo "schema=1" > /mo-prebuilt/thirdparties.fingerprint; \
+      echo "os=$(uname -s)" >> /mo-prebuilt/thirdparties.fingerprint; \
+      echo "arch=$(uname -m)" >> /mo-prebuilt/thirdparties.fingerprint; \
+      echo "thirdparties_tree=$(git rev-parse HEAD:thirdparties)" >> /mo-prebuilt/thirdparties.fingerprint; \
+    fi && cat /mo-prebuilt/thirdparties.fingerprint
 
 # Keep only the caches and prebuilt native artifacts; dropping the source
 # tree (and its .git) keeps the nightly image as small as the caches allow.

--- a/optools/images/Dockerfile.prebuilt
+++ b/optools/images/Dockerfile.prebuilt
@@ -9,7 +9,9 @@
 # CI assembles this context from the shared build artifact produced by
 # matrixorigin/CI .github/workflows/build-mo.yaml; the resulting image is
 # equivalent to the runtime stage of optools/images/Dockerfile.
-FROM matrixorigin/ubuntu:22.04
+ARG RUNTIME_IMAGE=matrixorigin/ubuntu:22.04
+
+FROM ${RUNTIME_IMAGE}
 
 COPY --chmod=0755 mo-service /mo-service
 COPY etc /etc

--- a/optools/images/ci-builder-fingerprint.sh
+++ b/optools/images/ci-builder-fingerprint.sh
@@ -8,11 +8,16 @@ set -eu
 
 root=${CI_BUILDER_SOURCE_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
 cd "$root"
+# Keep tool discovery independent of the caller's login/non-login shell. The
+# producer runs during docker build and consumers run in a non-login shell;
+# both must probe the same system tool locations.
+PATH=${CI_BUILDER_TOOL_PATH:-/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}
+export PATH
 
 hash_files() {
 	find "$@" -type f -print0 |
 		LC_ALL=C sort -z |
-		xargs -0 sha256sum |
+		xargs -r -0 sha256sum |
 		sha256sum |
 		awk '{print $1}'
 }
@@ -20,9 +25,13 @@ hash_files() {
 hash_thirdparties() {
 	(
 		cd thirdparties
-		find . -maxdepth 1 -type f -print0 |
+		# Include source-side CUDA headers and every other checked-in native
+		# input, while excluding generated install/build output.
+		find . -type f \
+			-not -path './install/*' \
+			-not -path './_*' -print0 |
 			LC_ALL=C sort -z |
-			xargs -0 sha256sum
+			xargs -r -0 sha256sum
 	) | sha256sum | awk '{print $1}'
 }
 
@@ -32,7 +41,7 @@ hash_cgo() {
 		-o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.go' \
 		-o -name 'Makefile' \) -print0 |
 		LC_ALL=C sort -z |
-		xargs -0 sha256sum |
+		xargs -r -0 sha256sum |
 		sha256sum |
 		awk '{print $1}'
 }
@@ -49,10 +58,15 @@ compiler_version() {
 }
 
 cmake_version=$(cmake --version 2>/dev/null | sed -n '1p' || true)
-go_version=$(go env GOVERSION 2>/dev/null || true)
+cmake_version=${cmake_version:-unavailable}
+# Read the version of the image's local go binary without allowing a PR's
+# go.mod toolchain directive to switch/download another toolchain. Native
+# dependencies are produced and consumed by the same image toolchain.
+go_version=$(CDPATH= cd / && GOTOOLCHAIN=local go version 2>/dev/null | awk '{print $3}' || true)
+go_version=${go_version:-unavailable}
 
 cat <<EOF
-schema=2
+schema=3
 os=$(uname -s)
 arch=$(uname -m)
 go=${go_version}

--- a/optools/images/ci-builder-fingerprint.sh
+++ b/optools/images/ci-builder-fingerprint.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Print the native-build contract shared by ci-builder producers and
+# consumers.  The output is deliberately independent of the checkout path so
+# it can be compared between a Docker build context and a mounted PR tree.
+
+set -eu
+
+root=${CI_BUILDER_SOURCE_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
+cd "$root"
+
+hash_files() {
+	find "$@" -type f -print0 |
+		LC_ALL=C sort -z |
+		xargs -0 sha256sum |
+		sha256sum |
+		awk '{print $1}'
+}
+
+hash_thirdparties() {
+	(
+		cd thirdparties
+		find . -maxdepth 1 -type f -print0 |
+			LC_ALL=C sort -z |
+			xargs -0 sha256sum
+	) | sha256sum | awk '{print $1}'
+}
+
+hash_cgo() {
+	find cgo -type f \
+		\( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cu' \
+		-o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.go' \
+		-o -name 'Makefile' \) -print0 |
+		LC_ALL=C sort -z |
+		xargs -0 sha256sum |
+		sha256sum |
+		awk '{print $1}'
+}
+
+compiler_version() {
+	compiler=$1
+	if command -v "$compiler" >/dev/null 2>&1; then
+		printf '%s-%s' \
+			"$($compiler -dumpmachine 2>/dev/null || true)" \
+			"$($compiler -dumpfullversion -dumpversion 2>/dev/null || true)"
+	else
+		printf 'unavailable'
+	fi
+}
+
+cmake_version=$(cmake --version 2>/dev/null | sed -n '1p' || true)
+go_version=$(go env GOVERSION 2>/dev/null || true)
+
+cat <<EOF
+schema=2
+os=$(uname -s)
+arch=$(uname -m)
+go=${go_version}
+cc=$(compiler_version cc)
+cxx=$(compiler_version c++)
+cmake=${cmake_version}
+root_makefile=$(hash_files Makefile)
+cgo=$(hash_cgo)
+thirdparties=$(hash_thirdparties)
+EOF


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27333

## What this PR does / why we need it:

- Adds `optools/images/ci-builder-fingerprint.sh`, the canonical native-build contract shared by the Basic Image producer and CI consumers.
- Includes the Go/toolchain, compiler/CMake, root Makefile, cgo sources, and third-party recipe inputs while ignoring generated native outputs and checkout paths.
- Updates `Dockerfile.ci-builder` to emit the new fingerprint, with a schema-1 compatibility fallback for CI/MatrixOne merge-order safety.

The companion CI change is [matrixorigin/CI#426](https://github.com/matrixorigin/CI/pull/426). It consumes this fingerprint in TKE, restores prebuilt native dependencies only on an exact match, and falls back to source builds otherwise.

