### PR TITLE
ci: warm plain builder flavor

### DIFF
--- a/optools/images/Dockerfile.ci-builder
+++ b/optools/images/Dockerfile.ci-builder
@@ -42,6 +42,11 @@ RUN mkdir -p /mo-prebuilt && touch /mo-prebuilt/warm-status
 # instrumentation changes the compiled objects.
 RUN make build GOBUILD_OPT=-cover
 
+# Warm the plain flavor consumed by merge-trigger-tke. Coverage instrumentation
+# changes Go's compile cache keys, so the normal post-merge binary needs its
+# own complete warm build instead of reusing only the -cover objects.
+RUN make build
+
 # Warm the UT compile flavors without running any test: -exec /bin/true
 # replaces test-binary execution and -vet=off keeps vet findings out of the
 # nightly warm (PR CI runs vet itself). The CGO_* values mirror


### PR DESCRIPTION
The CI TKE consumer builds the normal (non-coverage) MatrixOne binary with `make build`, but `Dockerfile.ci-builder` previously warmed only `make build GOBUILD_OPT=-cover`. Coverage instrumentation changes Go compile-cache keys, so the post-merge build missed most of the intended warm cache. Warm the plain flavor as a second build so matrixorigin/CI#426 can consume the matching cache.\n\nCompanion change for matrixorigin/CI#426 reviewer feedback.