### PR TITLE
[4.2] fix: recreate missing character sets table

### DIFF
--- a/pkg/bootstrap/service_upgrade_tenant.go
+++ b/pkg/bootstrap/service_upgrade_tenant.go
@@ -128,6 +128,19 @@ func (s *service) MaybeUpgradeTenant(
 	return upgraded, nil
 }
 
+// shouldRunTenantUpgrade keeps the normal version-transition behavior (a tenant
+// already at the target version is skipped), but reruns an offset-only upgrade.
+// mo_account.create_version does not store a version offset, so FromVersion ==
+// ToVersion is the signal that an equal-version tenant still needs this step.
+func shouldRunTenantUpgrade(createVersion string, upgrade versions.VersionUpgrade) bool {
+	tenantVersionCompare := versions.Compare(createVersion, upgrade.ToVersion)
+	if tenantVersionCompare < 0 {
+		return true
+	}
+	return tenantVersionCompare == 0 &&
+		versions.Compare(upgrade.FromVersion, upgrade.ToVersion) == 0
+}
+
 // asyncUpgradeTenantTask is a task to execute the tenant upgrade logic in
 // parallel based on the grouped tenant batch.
 func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
@@ -247,8 +260,7 @@ func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
 						zap.String("tenant-version", createVersion),
 						zap.String("upgrade", upgrade.String()))
 
-					// createVersion >= upgrade.ToVersion already upgrade
-					if versions.Compare(createVersion, upgrade.ToVersion) >= 0 {
+					if !shouldRunTenantUpgrade(createVersion, upgrade) {
 						continue
 					}
 

--- a/pkg/bootstrap/service_upgrade_tenant_test.go
+++ b/pkg/bootstrap/service_upgrade_tenant_test.go
@@ -234,6 +234,118 @@ func Test_asyncUpgradeTenantTask_SkipsTenantAtTargetVersion(t *testing.T) {
 	)
 }
 
+func TestShouldRunTenantUpgrade(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		createVersion string
+		fromVersion   string
+		toVersion     string
+		want          bool
+	}{
+		{name: "older tenant on version transition", createVersion: "3.0.0", fromVersion: "3.0.0", toVersion: "3.0.1", want: true},
+		{name: "target tenant on version transition", createVersion: "3.0.1", fromVersion: "3.0.0", toVersion: "3.0.1"},
+		{name: "target tenant on offset upgrade", createVersion: "4.0.6", fromVersion: "4.0.6", toVersion: "4.0.6", want: true},
+		{name: "newer tenant on offset upgrade", createVersion: "4.0.7", fromVersion: "4.0.6", toVersion: "4.0.6"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			upgrade := versions.VersionUpgrade{
+				FromVersion: test.fromVersion,
+				ToVersion:   test.toVersion,
+			}
+			require.Equal(t, test.want, shouldRunTenantUpgrade(test.createVersion, upgrade))
+		})
+	}
+}
+
+func Test_asyncUpgradeTenantTask_RunsSameVersionOffsetUpgrade(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			const (
+				tenantID            = int32(10)
+				currentVersion      = "4.0.6"
+				newVersionOffset    = uint32(5)
+				upgradeID           = uint64(100)
+				upgradeTenantTaskID = uint64(200)
+			)
+
+			var taskReady atomic.Bool
+			var finalized atomic.Bool
+			var tenantVersionUpdated atomic.Bool
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where state = 1") &&
+					!strings.Contains(sql, "for update"):
+					if finalized.Load() {
+						return executor.Result{}, nil
+					}
+					return buildUpgradeVersionResult(upgradeID, versions.StateUpgradingTenant,
+						currentVersion, currentVersion, newVersionOffset, 0,
+						versions.Yes, versions.Yes, 1, 0), nil
+				case strings.Contains(sql, "from mo_upgrade_tenant where from_account_id >= 0"):
+					if taskReady.Load() {
+						return executor.Result{}, nil
+					}
+					return buildUpgradeTenantTaskRows(
+						[]uint64{upgradeTenantTaskID}, []int32{tenantID}, []int32{tenantID}), nil
+				case strings.Contains(sql, "select account_id, create_version from mo_account"):
+					return buildUpgradeTenantAccountRows([]int32{tenantID}, []string{currentVersion}), nil
+				case sql == fmt.Sprintf("update mo_account set create_version = '%s' where account_id = %d", currentVersion, tenantID):
+					tenantVersionUpdated.Store(true)
+					return executor.Result{AffectedRows: 1}, nil
+				case strings.Contains(sql, "update mo_upgrade_tenant set ready = 1") &&
+					strings.Contains(sql, fmt.Sprintf("where id = %d", upgradeTenantTaskID)):
+					taskReady.Store(true)
+					return executor.Result{AffectedRows: 1}, nil
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, fmt.Sprintf("where id = %d for update", upgradeID)):
+					return buildUpgradeVersionResult(upgradeID, versions.StateUpgradingTenant,
+						currentVersion, currentVersion, newVersionOffset, 0,
+						versions.Yes, versions.Yes, 1, 0), nil
+				case strings.Contains(sql, "update mo_upgrade set total_tenant = 1, ready_tenant = 1") &&
+					strings.Contains(sql, "state = 2"):
+					finalized.Store(true)
+					cancel()
+					return executor.Result{AffectedRows: 1}, nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			})
+
+			h := newTestVersionHandler(currentVersion, currentVersion, versions.Yes, versions.Yes, newVersionOffset)
+			s := newServiceForTest(
+				sid,
+				&memLocker{},
+				clock.NewHLCClock(func() int64 { return 0 }, 0),
+				nil,
+				sqlExecutor,
+				func(s *service) {
+					s.handles = append(s.handles, h)
+				},
+				WithCheckUpgradeTenantDuration(time.Millisecond),
+			)
+
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			s.exec = executor.NewMemExecutor2(func(sql string) (executor.Result, error) {
+				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
+			}, txnOperator)
+
+			s.asyncUpgradeTenantTask(ctx)
+			require.True(t, taskReady.Load())
+			require.True(t, finalized.Load())
+			require.True(t, tenantVersionUpdated.Load())
+			require.Equal(t, uint64(1), h.callHandleTenantUpgrade.Load())
+		},
+	)
+}
+
 func Test_asyncUpgradeTenantTask_AutoCompletesDeletedTenantTasks(t *testing.T) {
 	sid := ""
 	runtime.RunTest(

--- a/pkg/bootstrap/versions/v4_0_6/tenant_upgrade_list.go
+++ b/pkg/bootstrap/versions/v4_0_6/tenant_upgrade_list.go
@@ -24,7 +24,20 @@ import (
 var tenantUpgEntries = []versions.UpgradeEntry{
 	newMongoDBCatalogTable(mongodb.TableConnections, mongodb.ConnectionsDDL),
 	newMongoDBCatalogTable(mongodb.TableMappings, mongodb.MappingsDDL),
+	ensureInformationSchemaCharacterSetsTable(),
 	populateInformationSchemaCharacterSets(),
+}
+
+func ensureInformationSchemaCharacterSetsTable() versions.UpgradeEntry {
+	return versions.UpgradeEntry{
+		Schema:    sysview.InformationDBConst,
+		TableName: "CHARACTER_SETS",
+		UpgType:   versions.CREATE_NEW_TABLE,
+		UpgSql:    sysview.InformationSchemaCharacterSetsDDL,
+		CheckFunc: func(txn executor.TxnExecutor, accountID uint32) (bool, error) {
+			return versions.CheckTableDefinition(txn, accountID, sysview.InformationDBConst, "character_sets")
+		},
+	}
 }
 
 func populateInformationSchemaCharacterSets() versions.UpgradeEntry {

--- a/pkg/bootstrap/versions/v4_0_6/upgrade_test.go
+++ b/pkg/bootstrap/versions/v4_0_6/upgrade_test.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prashantv/gostub"
+
 	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/sql/mongodb"
@@ -27,7 +29,7 @@ import (
 )
 
 func TestUpgradeEntries(t *testing.T) {
-	require.Len(t, tenantUpgEntries, 3)
+	require.Len(t, tenantUpgEntries, 4)
 	require.Len(t, clusterUpgEntries, 1)
 	require.Equal(t, retireKafkaSinkDaemonTasks.UpgSql, clusterUpgEntries[0].UpgSql)
 	require.Equal(t, mongodb.TableConnections, tenantUpgEntries[0].TableName)
@@ -36,7 +38,12 @@ func TestUpgradeEntries(t *testing.T) {
 		require.Equal(t, versions.CREATE_NEW_TABLE, entry.UpgType)
 		require.Contains(t, strings.ToLower(entry.UpgSql), "create table mo_catalog.")
 	}
-	characterSets := tenantUpgEntries[2]
+	characterSetsTable := tenantUpgEntries[2]
+	require.Equal(t, sysview.InformationDBConst, characterSetsTable.Schema)
+	require.Equal(t, "CHARACTER_SETS", characterSetsTable.TableName)
+	require.Equal(t, versions.CREATE_NEW_TABLE, characterSetsTable.UpgType)
+	require.Equal(t, sysview.InformationSchemaCharacterSetsDDL, characterSetsTable.UpgSql)
+	characterSets := tenantUpgEntries[3]
 	require.Equal(t, sysview.InformationDBConst, characterSets.Schema)
 	require.Equal(t, "CHARACTER_SETS", characterSets.TableName)
 	require.Equal(t, versions.MODIFY_METADATA, characterSets.UpgType)
@@ -48,6 +55,34 @@ func TestUpgradeEntries(t *testing.T) {
 	require.Equal(t, "4.0.5", meta.MinUpgradeVersion)
 	require.Equal(t, versions.Yes, meta.UpgradeTenant)
 	require.Equal(t, uint32(len(tenantUpgEntries)+len(clusterUpgEntries)), meta.VersionOffset)
+}
+
+func TestEnsureInformationSchemaCharacterSetsTableIsIdempotent(t *testing.T) {
+	entry := ensureInformationSchemaCharacterSetsTable()
+	exists := false
+	stub := gostub.Stub(&versions.CheckTableDefinition, func(_ executor.TxnExecutor, accountID uint32, schema, table string) (bool, error) {
+		require.Equal(t, uint32(42), accountID)
+		require.Equal(t, sysview.InformationDBConst, schema)
+		require.Equal(t, "character_sets", table)
+		return exists, nil
+	})
+	defer stub.Reset()
+
+	var executed []string
+	txn := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+		executed = append(executed, sql)
+		if sql == entry.UpgSql {
+			exists = true
+		}
+		return executor.Result{}, nil
+	}, nil)
+
+	require.NoError(t, entry.Upgrade(txn, 42))
+	require.Equal(t, []string{sysview.InformationSchemaCharacterSetsDDL}, executed)
+
+	executed = nil
+	require.NoError(t, entry.Upgrade(txn, 42))
+	require.Empty(t, executed)
 }
 
 func TestPopulateInformationSchemaCharacterSetsIsIdempotent(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27287.

Backport of #27369 to `4.2-dev`.

## What this PR does / why we need it:

The v4.0.6 tenant upgrade populates `information_schema.CHARACTER_SETS`, but a legacy tenant can be missing the table entirely. The population check then fails before the repair can run.

This backport:

- creates a missing `CHARACTER_SETS` table from the canonical DDL before population;
- leaves an existing table unchanged and keeps population idempotent;
- advances the v4.0.6 `VersionOffset` through the additional upgrade entry;
- backports the same-version offset execution rule already present on `main`, because `4.2-dev` would otherwise skip tenants already recorded at v4.0.6.

Validation:

- `make thirdparties`;
- focused missing/existing-table and same-version offset regressions;
- complete `pkg/bootstrap` and `pkg/bootstrap/versions/v4_0_6` tests;
- `go list`, `go build`, `go vet`, and `git diff --check` for both owning packages.