### PR TITLE
fix: preserve sequences in database clone and restore

### DIFF
--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -1148,6 +1148,34 @@ func handleCloneDatabaseWithSource(
 		}
 	}
 	restoreSnapshotTS := generatedCloneRestoreSnapshotTS(ses, snapshotTS)
+	sequenceSnapshotTS := restoreSnapshotTS
+	if source.snapshot != nil && source.snapshot.TS != nil {
+		sequenceSnapshotTS = source.snapshot.TS.PhysicalTime
+	}
+
+	cloneSequence := func(srcTbl *tableInfo) error {
+		createSQL, rewriteErr := rewriteCloneSequenceCreateSQL(
+			srcTbl.createSql,
+			stmt.DstDatabase.String(),
+			srcTbl.tblName,
+			parserLowerCaseTableNames(ses),
+		)
+		if rewriteErr != nil {
+			return rewriteErr
+		}
+		return restoreSequence(
+			reqCtx,
+			bh,
+			createSQL,
+			source.srcResolveDBName,
+			srcTbl.tblName,
+			stmt.DstDatabase.String(),
+			srcTbl.tblName,
+			sequenceSnapshotTS,
+			fromAccountID,
+			source.toAccountId,
+		)
+	}
 
 	cloneTable := func(dstDb, dstTbl, srcDb, srcTbl string) error {
 		srcTable := newQualifiedCloneTableName(srcDb, srcTbl, stmt.AtTsExpr)
@@ -1193,13 +1221,21 @@ func handleCloneDatabaseWithSource(
 	}
 
 	for _, srcTbl := range source.srcTblInfos {
+		if isSequence(srcTbl) {
+			if err = cloneSequence(srcTbl); err != nil {
+				return
+			}
+		}
+	}
+
+	for _, srcTbl := range source.srcTblInfos {
 
 		key := genKey(srcTbl.dbName, srcTbl.tblName)
 		if _, ok := source.fkTableMap[key]; ok {
 			continue
 		}
 
-		if srcTbl.typ == view {
+		if srcTbl.typ == view || isSequence(srcTbl) {
 			continue
 		}
 
@@ -1354,6 +1390,31 @@ func rewriteCloneCreateSQL(sql, srcDBName, dstDBName string, lowerCaseTableNames
 		rewritten += ";"
 	}
 	return rewritten, nil
+}
+
+func rewriteCloneSequenceCreateSQL(
+	sql string,
+	dstDBName string,
+	dstTblName string,
+	lowerCaseTableNames int64,
+) (string, error) {
+	stmt, err := parsers.ParseOne(context.Background(), dialect.MYSQL, sql, lowerCaseTableNames)
+	if err != nil {
+		return "", err
+	}
+	createSequence, ok := stmt.(*tree.CreateSequence)
+	if !ok {
+		return "", moerr.NewInternalErrorNoCtxf(
+			"clone sequence SQL is %T, expected *tree.CreateSequence", stmt)
+	}
+	targetName := newQualifiedCloneTableName(dstDBName, dstTblName, nil)
+	createSequence.Name = &targetName
+	return tree.StringWithOpts(
+		createSequence,
+		dialect.MYSQL,
+		tree.WithSingleQuoteString(),
+		tree.WithQuoteIdentifier(),
+	), nil
 }
 
 func tryToIncreaseTxnPhysicalTS(

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -48,7 +48,7 @@ type cloneDatabaseAccountResolution struct {
 func (source *cloneDatabaseSource) branchTableCount() int64 {
 	var count int64
 	for _, table := range source.srcTblInfos {
-		if table.typ != view {
+		if table.typ != view && !isSequence(table) {
 			count++
 		}
 	}

--- a/pkg/frontend/clone_database_source_test.go
+++ b/pkg/frontend/clone_database_source_test.go
@@ -28,15 +28,54 @@ import (
 )
 
 func TestCloneDatabaseSourceBranchTableCount(t *testing.T) {
-	source := cloneDatabaseSource{
-		srcTblInfos: []*tableInfo{
-			{tblName: "regular"},
-			{tblName: "foreign_key"},
-			{tblName: "view", typ: view},
+	tests := []struct {
+		name   string
+		tables []*tableInfo
+		want   int64
+	}{
+		{
+			name: "empty database consumes no branch table quota",
+			want: 0,
+		},
+		{
+			name: "mixed objects count only receipt-backed tables",
+			tables: []*tableInfo{
+				{tblName: "regular"},
+				{tblName: "sequence", relKind: catalog.SystemSequenceRel},
+				{tblName: "view", typ: view},
+			},
+			want: 1,
+		},
+		{
+			name: "sequence-only database consumes no branch table quota",
+			tables: []*tableInfo{
+				{tblName: "sequence", relKind: catalog.SystemSequenceRel},
+			},
+			want: 0,
+		},
+		{
+			name: "view-only database consumes no branch table quota",
+			tables: []*tableInfo{
+				{tblName: "view", typ: view},
+			},
+			want: 0,
+		},
+		{
+			name: "ordinary tables each consume branch table quota",
+			tables: []*tableInfo{
+				{tblName: "regular"},
+				{tblName: "foreign_key"},
+			},
+			want: 2,
 		},
 	}
 
-	require.Equal(t, int64(2), source.branchTableCount())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := cloneDatabaseSource{srcTblInfos: test.tables}
+			require.Equal(t, test.want, source.branchTableCount())
+		})
+	}
 }
 
 func TestValidateCloneDatabaseAccounts(t *testing.T) {

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -54,6 +54,22 @@ func TestWithCloneLockContext(t *testing.T) {
 	require.Same(t, oldCtx, proc.Ctx)
 }
 
+func TestRewriteCloneSequenceCreateSQL(t *testing.T) {
+	got, err := rewriteCloneSequenceCreateSQL(
+		"create sequence `source-db`.`seq-name` as bigint increment by 3 minvalue 1 maxvalue 99 start with 7 no cycle",
+		"target-db",
+		"seq-name",
+		0,
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		"create sequence `target-db`.`seq-name` as bigint increment by 3 minvalue 1 maxvalue 99 start with 7 no cycle",
+		got)
+
+	_, err = rewriteCloneSequenceCreateSQL("create table t(a int)", "target-db", "seq-name", 0)
+	require.ErrorContains(t, err, "expected *tree.CreateSequence")
+}
+
 func TestCloneCatalogLockBatch(t *testing.T) {
 	ses := newValidateSession(t)
 	mp := ses.proc.Mp()

--- a/pkg/frontend/data_branch_privilege.go
+++ b/pkg/frontend/data_branch_privilege.go
@@ -702,6 +702,8 @@ func validateDataBranchDeleteDatabaseTarget(
 
 func branchDeleteDatabaseTableIDsSQL(accId uint32, dbName string) string {
 	whereClause := buildTableInfoListWhereClause(dbName, "", accId)
+	// Sequences and views do not have data-branch metadata receipts.
+	whereClause += fmt.Sprintf(" and relkind != %s", quoteSQLStringLiteral(catalog.SystemSequenceRel))
 	whereClause += fmt.Sprintf(" and relkind != %s", quoteSQLStringLiteral(catalog.SystemViewRel))
 	return fmt.Sprintf(
 		"select rel_id, relname from %s.%s where %s",

--- a/pkg/frontend/data_branch_privilege_test.go
+++ b/pkg/frontend/data_branch_privilege_test.go
@@ -79,6 +79,7 @@ func TestBranchDeleteDatabaseTableIDsSQLReusesCloneObjectFilter(t *testing.T) {
 		dbName           = "db1"
 	)
 	expectedWhere := buildTableInfoListWhereClause(dbName, "", accountID) +
+		fmt.Sprintf(" and relkind != %s", quoteSQLStringLiteral(catalog.SystemSequenceRel)) +
 		fmt.Sprintf(" and relkind != %s", quoteSQLStringLiteral(catalog.SystemViewRel))
 	expected := fmt.Sprintf(
 		"select rel_id, relname from %s.%s where %s",

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -4034,6 +4034,14 @@ func Test_statement_type(t *testing.T) {
 		convey.So(NeedToBeCommittedInActiveTransaction(&tree.SetVar{}), convey.ShouldBeFalse)
 		convey.So(NeedToBeCommittedInActiveTransaction(&tree.SetTransaction{}), convey.ShouldBeFalse)
 		convey.So(needToFinishTransactionAtStatementEnd(&ExecCtx{
+			ses:  &backSession{},
+			stmt: &tree.CreateSequence{},
+		}), convey.ShouldBeFalse)
+		convey.So(needToFinishTransactionAtStatementEnd(&ExecCtx{
+			ses:  &backSession{},
+			stmt: &tree.DropSequence{},
+		}), convey.ShouldBeFalse)
+		convey.So(needToFinishTransactionAtStatementEnd(&ExecCtx{
 			stmt: &tree.SetVar{},
 			txnOpt: FeTxnOption{
 				activeTxnAtStartKnown: true,

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -1505,6 +1505,24 @@ func reCreateTableWithPitr(
 	if isExternalTable(tblInfo) {
 		return newExternalTableRestoreError(ctx, tblInfo, "pitr")
 	}
+	if isSequence(tblInfo) {
+		accountID, accountErr := defines.GetAccountId(ctx)
+		if accountErr != nil {
+			return accountErr
+		}
+		return restoreSequence(
+			ctx,
+			bh,
+			tblInfo.createSql,
+			tblInfo.dbName,
+			tblInfo.tblName,
+			tblInfo.dbName,
+			tblInfo.tblName,
+			ts,
+			accountID,
+			accountID,
+		)
+	}
 
 	getLogger(sid).Info(fmt.Sprintf("[%s] start to restore table: '%v' at timestamp %d", pitrName, tblInfo.tblName, ts))
 
@@ -1578,6 +1596,17 @@ func getTableInfoWithPitr(
 		pitrName,
 		tableInfos,
 		func(tblInfo *tableInfo) (string, error) {
+			if isSequence(tblInfo) {
+				return getCreateSequenceSQL(
+					ctx,
+					ts,
+					tblInfo.dbName,
+					tblInfo.tblName,
+					func(queryCtx context.Context, sql string, colIndices ...uint64) ([][]string, error) {
+						return getStringColsList(queryCtx, bh, sql, colIndices...)
+					},
+				)
+			}
 			return getCreateTableSqlWithTs(ctx, bh, ts, tblInfo.dbName, tblInfo.tblName)
 		},
 	)

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -2380,6 +2380,38 @@ func getCreateSequenceSQL(
 	), nil
 }
 
+func dropCurrentRestoreObject(
+	ctx context.Context,
+	bh BackgroundExec,
+	dbName string,
+	tblName string,
+) error {
+	tableInfos, err := showFullTables(ctx, "", bh, nil, dbName, tblName)
+	if err != nil {
+		return err
+	}
+	if len(tableInfos) == 0 {
+		return nil
+	}
+	if len(tableInfos) != 1 {
+		return moerr.NewInternalErrorf(ctx,
+			"found %d current objects named %s.%s during restore", len(tableInfos), dbName, tblName)
+	}
+
+	current := tableInfos[0]
+	name := qualifiedTableName(dbName, tblName)
+	var dropSQL string
+	switch current.relKind {
+	case catalog.SystemSequenceRel:
+		dropSQL = "drop sequence if exists " + name
+	case catalog.SystemViewRel:
+		dropSQL = "drop view if exists " + name
+	default:
+		dropSQL = dropTableIfExistsSQL(dbName, tblName)
+	}
+	return bh.Exec(ctx, dropSQL)
+}
+
 func restoreSequence(
 	ctx context.Context,
 	bh BackgroundExec,
@@ -2394,7 +2426,7 @@ func restoreSequence(
 ) error {
 	toCtx := defines.AttachAccountId(ctx, toAccountID)
 	dstName := qualifiedTableName(dstDBName, dstTblName)
-	if err := bh.Exec(toCtx, "drop sequence if exists "+dstName); err != nil {
+	if err := dropCurrentRestoreObject(toCtx, bh, dstDBName, dstTblName); err != nil {
 		return err
 	}
 	if err := bh.Exec(toCtx, createSQL); err != nil {

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -1725,6 +1725,24 @@ func recreateTable(
 	if isExternalTable(tblInfo) {
 		return newExternalTableRestoreError(ctx, tblInfo, "snapshot")
 	}
+	if isSequence(tblInfo) {
+		curAccountID, accountErr := defines.GetAccountId(ctx)
+		if accountErr != nil {
+			return accountErr
+		}
+		return restoreSequence(
+			ctx,
+			bh,
+			tblInfo.createSql,
+			tblInfo.dbName,
+			tblInfo.tblName,
+			tblInfo.dbName,
+			tblInfo.tblName,
+			snapshotTs,
+			curAccountID,
+			toAccountId,
+		)
+	}
 
 	getLogger(sid).Debug(
 		fmt.Sprintf("[%s] start to restore table: %v, restore timestamp: %d",
@@ -2212,7 +2230,6 @@ func buildTableInfoListWhereClause(dbName string, tblName string, accountId uint
 	if len(tblName) > 0 {
 		whereClause += fmt.Sprintf(" and relname = %s", quoteSQLStringLiteral(tblName))
 	}
-	whereClause += fmt.Sprintf(" and relkind != %s", quoteSQLStringLiteral(catalog.SystemSequenceRel))
 	return whereClause
 }
 
@@ -2262,9 +2279,142 @@ func getTableInfos(
 		fmt.Sprint(snapshot),
 		tableInfos,
 		func(tblInfo *tableInfo) (string, error) {
+			if isSequence(tblInfo) {
+				sequenceCtx := ctx
+				if snapshot != nil && snapshot.Tenant != nil {
+					sequenceCtx = defines.AttachAccountId(sequenceCtx, snapshot.Tenant.TenantID)
+				}
+				return getCreateSequenceSQL(
+					sequenceCtx,
+					snapshotPhysicalTime(snapshot),
+					tblInfo.dbName,
+					tblInfo.tblName,
+					func(queryCtx context.Context, sql string, colIndices ...uint64) ([][]string, error) {
+						return getStringColsList(queryCtx, bh, sql, colIndices...)
+					},
+				)
+			}
 			return getCreateTableSql(ctx, bh, snapshot, tblInfo.dbName, tblInfo.tblName)
 		},
 	)
+}
+
+type restoreStringRows func(context.Context, string, ...uint64) ([][]string, error)
+
+func snapshotPhysicalTime(snapshot *plan.Snapshot) int64 {
+	if snapshot == nil || snapshot.TS == nil {
+		return 0
+	}
+	return snapshot.TS.PhysicalTime
+}
+
+func isSequence(tblInfo *tableInfo) bool {
+	return tblInfo != nil && tblInfo.relKind == catalog.SystemSequenceRel
+}
+
+func getCreateSequenceSQL(
+	ctx context.Context,
+	snapshotTS int64,
+	dbName string,
+	tblName string,
+	query restoreStringRows,
+) (string, error) {
+	snapshotSpec := ""
+	if snapshotTS > 0 {
+		snapshotSpec = fmt.Sprintf(" {MO_TS = %d}", snapshotTS)
+	}
+
+	typeSQL := fmt.Sprintf(
+		"select mo_show_visible_bin(atttyp, 2) from %s.mo_columns%s where att_database = %s and att_relname = %s and attname = %s",
+		moCatalog,
+		snapshotSpec,
+		quoteSQLStringLiteral(dbName),
+		quoteSQLStringLiteral(tblName),
+		quoteSQLStringLiteral(plan.Sequence_cols_name[0]),
+	)
+	typeRows, err := query(ctx, typeSQL, 0)
+	if err != nil {
+		return "", err
+	}
+	if len(typeRows) != 1 || len(typeRows[0]) != 1 || typeRows[0][0] == "" {
+		return "", moerr.NewNoSuchTable(ctx, dbName, tblName)
+	}
+
+	stateSQL := fmt.Sprintf(
+		"select %s, %s, %s, %s, %s from %s%s",
+		quoteIdentifierForSQL(plan.Sequence_cols_name[1]),
+		quoteIdentifierForSQL(plan.Sequence_cols_name[2]),
+		quoteIdentifierForSQL(plan.Sequence_cols_name[3]),
+		quoteIdentifierForSQL(plan.Sequence_cols_name[4]),
+		quoteIdentifierForSQL(plan.Sequence_cols_name[5]),
+		qualifiedTableName(dbName, tblName),
+		snapshotSpec,
+	)
+	stateRows, err := query(ctx, stateSQL, 0, 1, 2, 3, 4)
+	if err != nil {
+		return "", err
+	}
+	if len(stateRows) != 1 || len(stateRows[0]) != 5 {
+		return "", moerr.NewNoSuchTable(ctx, dbName, tblName)
+	}
+
+	cycleSQL := "no cycle"
+	switch strings.ToLower(stateRows[0][4]) {
+	case "1", "true":
+		cycleSQL = "cycle"
+	case "0", "false":
+	default:
+		return "", moerr.NewInternalErrorf(ctx,
+			"invalid cycle state %q for sequence %s.%s", stateRows[0][4], dbName, tblName)
+	}
+
+	return fmt.Sprintf(
+		"create sequence %s as %s increment by %s minvalue %s maxvalue %s start with %s %s",
+		qualifiedTableName(dbName, tblName),
+		typeRows[0][0],
+		stateRows[0][3],
+		stateRows[0][0],
+		stateRows[0][1],
+		stateRows[0][2],
+		cycleSQL,
+	), nil
+}
+
+func restoreSequence(
+	ctx context.Context,
+	bh BackgroundExec,
+	createSQL string,
+	srcDBName string,
+	srcTblName string,
+	dstDBName string,
+	dstTblName string,
+	snapshotTS int64,
+	fromAccountID uint32,
+	toAccountID uint32,
+) error {
+	toCtx := defines.AttachAccountId(ctx, toAccountID)
+	dstName := qualifiedTableName(dstDBName, dstTblName)
+	if err := bh.Exec(toCtx, "drop sequence if exists "+dstName); err != nil {
+		return err
+	}
+	if err := bh.Exec(toCtx, createSQL); err != nil {
+		return err
+	}
+	if err := bh.Exec(toCtx, "delete from "+dstName+" where true"); err != nil {
+		return err
+	}
+
+	snapshotSpec := ""
+	if snapshotTS > 0 {
+		snapshotSpec = fmt.Sprintf(" {MO_TS = %d}", snapshotTS)
+	}
+	copySQL := fmt.Sprintf(
+		"insert into %s select * from %s%s",
+		dstName,
+		qualifiedTableName(srcDBName, srcTblName),
+		snapshotSpec,
+	)
+	return bh.ExecRestore(toCtx, copySQL, fromAccountID, toAccountID)
 }
 
 func fillTableCreateSQLsForRestore(
@@ -2273,6 +2423,7 @@ func fillTableCreateSQLsForRestore(
 	tableInfos []*tableInfo,
 	getCreateSQL func(*tableInfo) (string, error),
 ) ([]*tableInfo, error) {
+	sequences := make([]*tableInfo, 0)
 	restorable := make([]*tableInfo, 0, len(tableInfos))
 	for _, tblInfo := range tableInfos {
 		createSQL, err := getCreateSQL(tblInfo)
@@ -2291,9 +2442,13 @@ func fillTableCreateSQLsForRestore(
 		}
 
 		tblInfo.createSql = createSQL
-		restorable = append(restorable, tblInfo)
+		if isSequence(tblInfo) {
+			sequences = append(sequences, tblInfo)
+		} else {
+			restorable = append(restorable, tblInfo)
+		}
 	}
-	return restorable, nil
+	return append(sequences, restorable...), nil
 }
 
 const legacyViewParserSQLModeForRestore = "PIPES_AS_CONCAT"
@@ -2670,7 +2825,7 @@ func getFkDepsFromTableInfos(
 ) (map[string][]string, error) {
 	deps := make(map[string][]string)
 	for _, info := range tableInfos {
-		if info == nil || info.typ == view || info.createSql == "" {
+		if info == nil || info.typ == view || isSequence(info) || info.createSql == "" {
 			continue
 		}
 		statements, err := parsers.Parse(ctx, dialect.MYSQL, info.createSql, 0)

--- a/pkg/frontend/snapshot_restore_with_ts.go
+++ b/pkg/frontend/snapshot_restore_with_ts.go
@@ -180,6 +180,17 @@ func getTableInfosFromTS(ctx context.Context,
 		fmt.Sprintf("%d:%d", from, ts),
 		tableInfos,
 		func(tblInfo *tableInfo) (string, error) {
+			if isSequence(tblInfo) {
+				return getCreateSequenceSQL(
+					newCtx,
+					ts,
+					tblInfo.dbName,
+					tblInfo.tblName,
+					func(queryCtx context.Context, sql string, colIndices ...uint64) ([][]string, error) {
+						return getStringColsListFromTS(queryCtx, bh, sql, from, to, colIndices...)
+					},
+				)
+			}
 			return getCreateTableSqlFromTS(newCtx, bh, tblInfo.dbName, tblInfo.tblName, ts, from, to)
 		},
 	)
@@ -523,6 +534,20 @@ func recreateTableFromTS(
 ) (err error) {
 	if isExternalTable(tblInfo) {
 		return newExternalTableRestoreError(ctx, tblInfo, "snapshot")
+	}
+	if isSequence(tblInfo) {
+		return restoreSequence(
+			ctx,
+			bh,
+			tblInfo.createSql,
+			tblInfo.dbName,
+			tblInfo.tblName,
+			tblInfo.dbName,
+			tblInfo.tblName,
+			snapshotTs,
+			restoreAccount,
+			toAccountId,
+		)
 	}
 
 	getLogger(sid).Info(fmt.Sprintf("[%d:%d] start to restore table: %v, restore timestamp: %d", restoreAccount, snapshotTs, tblInfo.tblName, snapshotTs))

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -75,6 +75,12 @@ func TestGetFkDepsFromTableInfos(t *testing.T) {
 			typ:       view,
 			createSql: "create view `d`.`v` as select 1",
 		},
+		{
+			dbName:    "d",
+			tblName:   "seq",
+			relKind:   catalog.SystemSequenceRel,
+			createSql: "create sequence `d`.`seq` as bigint no cycle",
+		},
 	}
 
 	deps, err := getFkDepsFromTableInfos(context.Background(), tableInfos)
@@ -82,6 +88,92 @@ func TestGetFkDepsFromTableInfos(t *testing.T) {
 	require.Equal(t, []string{genKey("d", "parent")}, deps[genKey("d", "child")])
 	require.Equal(t, []string{genKey("d", "self_ref")}, deps[genKey("d", "self_ref")])
 	require.NotContains(t, deps, genKey("d", "v"))
+	require.NotContains(t, deps, genKey("d", "seq"))
+}
+
+func TestSequenceRestoreMetadataAndOrdering(t *testing.T) {
+	t.Run("table enumeration includes sequences", func(t *testing.T) {
+		whereClause := buildTableInfoListWhereClause("db1", "", uint32(sysAccountID))
+		require.NotContains(t, whereClause,
+			fmt.Sprintf("relkind != %s", quoteSQLStringLiteral(catalog.SystemSequenceRel)))
+		require.Contains(t, whereClause, "relkind not in")
+		require.Contains(t, whereClause,
+			fmt.Sprintf("relkind != %s", quoteSQLStringLiteral(catalog.SystemPartitionRel)))
+	})
+
+	t.Run("sequence DDL is reconstructed from historical type and state", func(t *testing.T) {
+		const snapshotTS = int64(12345)
+		var queries []string
+		query := func(_ context.Context, sql string, _ ...uint64) ([][]string, error) {
+			queries = append(queries, sql)
+			if strings.Contains(sql, "mo_catalog.mo_columns") {
+				return [][]string{{"BIGINT UNSIGNED"}}, nil
+			}
+			return [][]string{{"1", "18446744073709551615", "11", "3", "1"}}, nil
+		}
+
+		createSQL, err := getCreateSequenceSQL(
+			context.Background(), snapshotTS, "db-name", "seq-name", query)
+		require.NoError(t, err)
+		require.Equal(t,
+			"create sequence `db-name`.`seq-name` as BIGINT UNSIGNED increment by 3 minvalue 1 maxvalue 18446744073709551615 start with 11 cycle",
+			createSQL)
+		require.Len(t, queries, 2)
+		require.Contains(t, queries[0], "mo_catalog.mo_columns {MO_TS = 12345}")
+		require.Contains(t, queries[1], "from `db-name`.`seq-name` {MO_TS = 12345}")
+	})
+
+	t.Run("sequences are restored before tables and views", func(t *testing.T) {
+		ordinary := &tableInfo{tblName: "ordinary", relKind: catalog.SystemOrdinaryRel}
+		sequence := &tableInfo{tblName: "sequence", relKind: catalog.SystemSequenceRel}
+		viewInfo := &tableInfo{tblName: "view", relKind: catalog.SystemViewRel}
+
+		ordered, err := fillTableCreateSQLsForRestore(
+			"", "test", []*tableInfo{ordinary, sequence, viewInfo},
+			func(tblInfo *tableInfo) (string, error) { return tblInfo.tblName, nil })
+		require.NoError(t, err)
+		require.Equal(t, []*tableInfo{sequence, ordinary, viewInfo}, ordered)
+	})
+}
+
+func TestRestoreSequenceState(t *testing.T) {
+	ctx := defines.AttachAccountId(context.Background(), uint32(10))
+	const createSQL = "create sequence `dst-db`.`seq` as BIGINT increment by 3 minvalue 1 maxvalue 100 start with 7 no cycle"
+
+	t.Run("copies the exact historical state", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"drop sequence if exists `dst-db`.`seq`",
+			createSQL,
+			"delete from `dst-db`.`seq` where true",
+			"insert into `dst-db`.`seq` select * from `src-db`.`seq` {MO_TS = 12345}",
+		}, bh.executedSQLs)
+	})
+
+	t.Run("stops before copying state when creation fails", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		wantErr := moerr.NewInternalErrorNoCtx("create failed")
+		bh.sql2err[createSQL] = wantErr
+
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.ErrorIs(t, err, wantErr)
+		require.Equal(t, []string{
+			"drop sequence if exists `dst-db`.`seq`",
+			createSQL,
+		}, bh.executedSQLs)
+	})
 }
 
 func TestMongoDBMappingsFollowExternalTableRestoreSkipPolicy(t *testing.T) {

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -196,13 +196,36 @@ func TestGetCreateSequenceSQLErrors(t *testing.T) {
 	})
 }
 
+func setCurrentRestoreObject(
+	bh *backgroundExecTest,
+	dbName string,
+	tblName string,
+	accountID uint32,
+	relKind string,
+) string {
+	sql := buildTableInfoListSQL(dbName, tblName, 0, accountID)
+	var rows [][]interface{}
+	if relKind != "" {
+		typ := "BASE TABLE"
+		if relKind == catalog.SystemViewRel {
+			typ = "VIEW"
+		}
+		rows = [][]interface{}{{tblName, typ, relKind, ""}}
+	}
+	bh.sql2result[sql] = newMrsForRestoreStringRows(
+		[]string{"relname", "table_type", "relkind", "viewdef"}, rows)
+	return sql
+}
+
 func TestRestoreSequenceState(t *testing.T) {
 	ctx := defines.AttachAccountId(context.Background(), uint32(10))
 	const createSQL = "create sequence `dst-db`.`seq` as BIGINT increment by 3 minvalue 1 maxvalue 100 start with 7 no cycle"
+	currentObjectSQL := buildTableInfoListSQL("dst-db", "seq", 0, 20)
 
 	t.Run("copies the exact historical state", func(t *testing.T) {
 		bh := &backgroundExecTest{}
 		bh.init()
+		setCurrentRestoreObject(bh, "dst-db", "seq", 20, catalog.SystemSequenceRel)
 		err := restoreSequence(
 			ctx, bh, createSQL,
 			"src-db", "seq", "dst-db", "seq",
@@ -210,6 +233,7 @@ func TestRestoreSequenceState(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, []string{
+			currentObjectSQL,
 			"drop sequence if exists `dst-db`.`seq`",
 			createSQL,
 			"delete from `dst-db`.`seq` where true",
@@ -217,9 +241,63 @@ func TestRestoreSequenceState(t *testing.T) {
 		}, bh.executedSQLs)
 	})
 
+	t.Run("creates when the destination object is absent", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		setCurrentRestoreObject(bh, "dst-db", "seq", 20, "")
+
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			currentObjectSQL,
+			createSQL,
+			"delete from `dst-db`.`seq` where true",
+			"insert into `dst-db`.`seq` select * from `src-db`.`seq` {MO_TS = 12345}",
+		}, bh.executedSQLs)
+	})
+
+	t.Run("stops when reading the destination object fails", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		wantErr := moerr.NewInternalErrorNoCtx("lookup failed")
+		bh.sql2err[currentObjectSQL] = wantErr
+
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.ErrorIs(t, err, wantErr)
+		require.Equal(t, []string{currentObjectSQL}, bh.executedSQLs)
+	})
+
+	t.Run("rejects ambiguous destination metadata", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[currentObjectSQL] = newMrsForRestoreStringRows(
+			[]string{"relname", "table_type", "relkind", "viewdef"},
+			[][]interface{}{
+				{"seq", "BASE TABLE", catalog.SystemOrdinaryRel, ""},
+				{"seq", "VIEW", catalog.SystemViewRel, ""},
+			})
+
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.ErrorContains(t, err, "found 2 current objects named dst-db.seq during restore")
+		require.Equal(t, []string{currentObjectSQL}, bh.executedSQLs)
+	})
+
 	t.Run("stops before copying state when creation fails", func(t *testing.T) {
 		bh := &backgroundExecTest{}
 		bh.init()
+		setCurrentRestoreObject(bh, "dst-db", "seq", 20, catalog.SystemSequenceRel)
 		wantErr := moerr.NewInternalErrorNoCtx("create failed")
 		bh.sql2err[createSQL] = wantErr
 
@@ -230,6 +308,7 @@ func TestRestoreSequenceState(t *testing.T) {
 		)
 		require.ErrorIs(t, err, wantErr)
 		require.Equal(t, []string{
+			currentObjectSQL,
 			"drop sequence if exists `dst-db`.`seq`",
 			createSQL,
 		}, bh.executedSQLs)
@@ -238,6 +317,7 @@ func TestRestoreSequenceState(t *testing.T) {
 	t.Run("stops when dropping the destination fails", func(t *testing.T) {
 		bh := &backgroundExecTest{}
 		bh.init()
+		setCurrentRestoreObject(bh, "dst-db", "seq", 20, catalog.SystemSequenceRel)
 		dropSQL := "drop sequence if exists `dst-db`.`seq`"
 		wantErr := moerr.NewInternalErrorNoCtx("drop failed")
 		bh.sql2err[dropSQL] = wantErr
@@ -248,12 +328,13 @@ func TestRestoreSequenceState(t *testing.T) {
 			12345, 10, 20,
 		)
 		require.ErrorIs(t, err, wantErr)
-		require.Equal(t, []string{dropSQL}, bh.executedSQLs)
+		require.Equal(t, []string{currentObjectSQL, dropSQL}, bh.executedSQLs)
 	})
 
 	t.Run("stops before copying state when delete fails", func(t *testing.T) {
 		bh := &backgroundExecTest{}
 		bh.init()
+		setCurrentRestoreObject(bh, "dst-db", "seq", 20, catalog.SystemSequenceRel)
 		deleteSQL := "delete from `dst-db`.`seq` where true"
 		wantErr := moerr.NewInternalErrorNoCtx("delete failed")
 		bh.sql2err[deleteSQL] = wantErr
@@ -265,9 +346,33 @@ func TestRestoreSequenceState(t *testing.T) {
 		)
 		require.ErrorIs(t, err, wantErr)
 		require.Equal(t, []string{
+			currentObjectSQL,
 			"drop sequence if exists `dst-db`.`seq`",
 			createSQL,
 			deleteSQL,
+		}, bh.executedSQLs)
+	})
+
+	t.Run("returns the historical state copy error", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		setCurrentRestoreObject(bh, "dst-db", "seq", 20, catalog.SystemSequenceRel)
+		copySQL := "insert into `dst-db`.`seq` select * from `src-db`.`seq` {MO_TS = 12345}"
+		wantErr := moerr.NewInternalErrorNoCtx("copy failed")
+		bh.sql2err[copySQL] = wantErr
+
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.ErrorIs(t, err, wantErr)
+		require.Equal(t, []string{
+			currentObjectSQL,
+			"drop sequence if exists `dst-db`.`seq`",
+			createSQL,
+			"delete from `dst-db`.`seq` where true",
+			copySQL,
 		}, bh.executedSQLs)
 	})
 }
@@ -283,32 +388,38 @@ func TestSequenceRestoreEntryPoints(t *testing.T) {
 		relKind:   catalog.SystemSequenceRel,
 		createSql: createSQL,
 	}
-	wantSQL := []string{
-		"drop sequence if exists `db1`.`seq1`",
-		createSQL,
-		"delete from `db1`.`seq1` where true",
-		"insert into `db1`.`seq1` select * from `db1`.`seq1` {MO_TS = 12345}",
-	}
 	accountCtx := defines.AttachAccountId(context.Background(), uint32(10))
 
 	tests := []struct {
-		name string
-		run  func(BackgroundExec) error
+		name        string
+		toAccountID uint32
+		currentKind string
+		wantDropSQL string
+		run         func(BackgroundExec) error
 	}{
 		{
-			name: "same-account snapshot restore",
+			name:        "same-account snapshot restore replaces a table",
+			toAccountID: 10,
+			currentKind: catalog.SystemOrdinaryRel,
+			wantDropSQL: "drop table if exists `db1`.`seq1`",
 			run: func(bh BackgroundExec) error {
 				return recreateTable(accountCtx, "", bh, "snapshot1", sequence, 10, snapshotTS)
 			},
 		},
 		{
-			name: "PITR restore",
+			name:        "PITR restore replaces a view",
+			toAccountID: 10,
+			currentKind: catalog.SystemViewRel,
+			wantDropSQL: "drop view if exists `db1`.`seq1`",
 			run: func(bh BackgroundExec) error {
 				return reCreateTableWithPitr(accountCtx, "", bh, "pitr1", snapshotTS, sequence)
 			},
 		},
 		{
-			name: "cross-account snapshot restore",
+			name:        "cross-account snapshot restore replaces a sequence",
+			toAccountID: 20,
+			currentKind: catalog.SystemSequenceRel,
+			wantDropSQL: "drop sequence if exists `db1`.`seq1`",
 			run: func(bh BackgroundExec) error {
 				return recreateTableFromTS(context.Background(), "", bh, sequence, snapshotTS, 10, 20)
 			},
@@ -319,9 +430,17 @@ func TestSequenceRestoreEntryPoints(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			bh := &backgroundExecTest{}
 			bh.init()
+			currentObjectSQL := setCurrentRestoreObject(
+				bh, "db1", "seq1", tc.toAccountID, tc.currentKind)
 
 			require.NoError(t, tc.run(bh))
-			require.Equal(t, wantSQL, bh.executedSQLs)
+			require.Equal(t, []string{
+				currentObjectSQL,
+				tc.wantDropSQL,
+				createSQL,
+				"delete from `db1`.`seq1` where true",
+				"insert into `db1`.`seq1` select * from `db1`.`seq1` {MO_TS = 12345}",
+			}, bh.executedSQLs)
 		})
 	}
 

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -176,6 +176,73 @@ func TestRestoreSequenceState(t *testing.T) {
 	})
 }
 
+func TestSequenceRestoreEntryPoints(t *testing.T) {
+	const (
+		snapshotTS = int64(12345)
+		createSQL  = "create sequence `db1`.`seq1` as BIGINT increment by 3 minvalue 1 maxvalue 100 start with 7 no cycle"
+	)
+	sequence := &tableInfo{
+		dbName:    "db1",
+		tblName:   "seq1",
+		relKind:   catalog.SystemSequenceRel,
+		createSql: createSQL,
+	}
+	wantSQL := []string{
+		"drop sequence if exists `db1`.`seq1`",
+		createSQL,
+		"delete from `db1`.`seq1` where true",
+		"insert into `db1`.`seq1` select * from `db1`.`seq1` {MO_TS = 12345}",
+	}
+	accountCtx := defines.AttachAccountId(context.Background(), uint32(10))
+
+	tests := []struct {
+		name string
+		run  func(BackgroundExec) error
+	}{
+		{
+			name: "same-account snapshot restore",
+			run: func(bh BackgroundExec) error {
+				return recreateTable(accountCtx, "", bh, "snapshot1", sequence, 10, snapshotTS)
+			},
+		},
+		{
+			name: "PITR restore",
+			run: func(bh BackgroundExec) error {
+				return reCreateTableWithPitr(accountCtx, "", bh, "pitr1", snapshotTS, sequence)
+			},
+		},
+		{
+			name: "cross-account snapshot restore",
+			run: func(bh BackgroundExec) error {
+				return recreateTableFromTS(context.Background(), "", bh, sequence, snapshotTS, 10, 20)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bh := &backgroundExecTest{}
+			bh.init()
+
+			require.NoError(t, tc.run(bh))
+			require.Equal(t, wantSQL, bh.executedSQLs)
+		})
+	}
+
+	t.Run("account identity is required", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+
+		err := recreateTable(context.Background(), "", bh, "snapshot1", sequence, 10, snapshotTS)
+		require.Error(t, err)
+		require.Empty(t, bh.executedSQLs)
+
+		err = reCreateTableWithPitr(context.Background(), "", bh, "pitr1", snapshotTS, sequence)
+		require.Error(t, err)
+		require.Empty(t, bh.executedSQLs)
+	})
+}
+
 func TestMongoDBMappingsFollowExternalTableRestoreSkipPolicy(t *testing.T) {
 	info := &tableInfo{dbName: moCatalog, tblName: sqlmongodb.TableMappings, typ: "BASE TABLE"}
 	for _, accountID := range []uint32{sysAccountID, 7} {

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -136,6 +136,66 @@ func TestSequenceRestoreMetadataAndOrdering(t *testing.T) {
 	})
 }
 
+func TestGetCreateSequenceSQLErrors(t *testing.T) {
+	ctx := context.Background()
+	wantErr := moerr.NewInternalErrorNoCtx("query failed")
+
+	t.Run("type query error", func(t *testing.T) {
+		_, err := getCreateSequenceSQL(ctx, 42, "db1", "seq1",
+			func(context.Context, string, ...uint64) ([][]string, error) {
+				return nil, wantErr
+			})
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("missing type metadata", func(t *testing.T) {
+		_, err := getCreateSequenceSQL(ctx, 42, "db1", "seq1",
+			func(context.Context, string, ...uint64) ([][]string, error) {
+				return nil, nil
+			})
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+
+	t.Run("state query error", func(t *testing.T) {
+		queryCount := 0
+		_, err := getCreateSequenceSQL(ctx, 42, "db1", "seq1",
+			func(context.Context, string, ...uint64) ([][]string, error) {
+				queryCount++
+				if queryCount == 1 {
+					return [][]string{{"BIGINT"}}, nil
+				}
+				return nil, wantErr
+			})
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("missing state metadata", func(t *testing.T) {
+		queryCount := 0
+		_, err := getCreateSequenceSQL(ctx, 42, "db1", "seq1",
+			func(context.Context, string, ...uint64) ([][]string, error) {
+				queryCount++
+				if queryCount == 1 {
+					return [][]string{{"BIGINT"}}, nil
+				}
+				return nil, nil
+			})
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+
+	t.Run("invalid cycle state", func(t *testing.T) {
+		queryCount := 0
+		_, err := getCreateSequenceSQL(ctx, 42, "db1", "seq1",
+			func(context.Context, string, ...uint64) ([][]string, error) {
+				queryCount++
+				if queryCount == 1 {
+					return [][]string{{"BIGINT"}}, nil
+				}
+				return [][]string{{"1", "100", "7", "3", "invalid"}}, nil
+			})
+		require.ErrorContains(t, err, "invalid cycle state")
+	})
+}
+
 func TestRestoreSequenceState(t *testing.T) {
 	ctx := defines.AttachAccountId(context.Background(), uint32(10))
 	const createSQL = "create sequence `dst-db`.`seq` as BIGINT increment by 3 minvalue 1 maxvalue 100 start with 7 no cycle"
@@ -172,6 +232,42 @@ func TestRestoreSequenceState(t *testing.T) {
 		require.Equal(t, []string{
 			"drop sequence if exists `dst-db`.`seq`",
 			createSQL,
+		}, bh.executedSQLs)
+	})
+
+	t.Run("stops when dropping the destination fails", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		dropSQL := "drop sequence if exists `dst-db`.`seq`"
+		wantErr := moerr.NewInternalErrorNoCtx("drop failed")
+		bh.sql2err[dropSQL] = wantErr
+
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.ErrorIs(t, err, wantErr)
+		require.Equal(t, []string{dropSQL}, bh.executedSQLs)
+	})
+
+	t.Run("stops before copying state when delete fails", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		deleteSQL := "delete from `dst-db`.`seq` where true"
+		wantErr := moerr.NewInternalErrorNoCtx("delete failed")
+		bh.sql2err[deleteSQL] = wantErr
+
+		err := restoreSequence(
+			ctx, bh, createSQL,
+			"src-db", "seq", "dst-db", "seq",
+			12345, 10, 20,
+		)
+		require.ErrorIs(t, err, wantErr)
+		require.Equal(t, []string{
+			"drop sequence if exists `dst-db`.`seq`",
+			createSQL,
+			deleteSQL,
 		}, bh.executedSQLs)
 	})
 }

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -989,6 +989,12 @@ func needToFinishTransactionAtStatementEnd(execCtx *ExecCtx) bool {
 	if IsParameterModificationStatement(execCtx.stmt) {
 		return execCtx.txnOpt.activeTxnAtStartKnown && !execCtx.txnOpt.activeTxnAtStart
 	}
+	// Sequence DDL normally finishes an active user transaction. In a background
+	// executor it is nested inside an enclosing clone or restore transaction and
+	// must not finish that transaction early.
+	if execCtx.ses != nil && execCtx.ses.IsBackgroundSession() && IsCreateDropSequence(execCtx.stmt) {
+		return false
+	}
 	if NeedToBeCommittedInActiveTransaction(execCtx.stmt) {
 		return true
 	}

--- a/test/distributed/cases/git4data/clone/clone_database_sequence.result
+++ b/test/distributed/cases/git4data/clone/clone_database_sequence.result
@@ -1,5 +1,7 @@
 drop snapshot if exists issue27049_sp;
 drop snapshot if exists issue27049_table_sp;
+drop snapshot if exists issue27049_kind_table_sp;
+drop snapshot if exists issue27049_kind_view_sp;
 drop database if exists issue27049_seq_only_src;
 drop database if exists issue27049_seq_only_dst;
 drop database if exists issue27049_src;
@@ -225,6 +227,45 @@ select * from issue27049_src.seq_table_restore;
 select nextval('seq_table_restore');
 ➤ nextval(seq_table_restore)[12,65535,0]  𝄀
 25
+create sequence seq_kind_table increment by 5 start with 41 no cycle;
+select nextval('seq_kind_table');
+➤ nextval(seq_kind_table)[12,65535,0]  𝄀
+41
+create snapshot issue27049_kind_table_sp for table issue27049_src seq_kind_table;
+drop sequence seq_kind_table;
+create table seq_kind_table(a int);
+insert into seq_kind_table values (1);
+restore table issue27049_src.seq_kind_table{snapshot = 'issue27049_kind_table_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_src' and relname = 'seq_kind_table';
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq_kind_table  ¦  S
+select * from issue27049_src.seq_kind_table;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+41  ¦  1  ¦  9223372036854775807  ¦  41  ¦  5  ¦  0  ¦  1
+select nextval('seq_kind_table');
+➤ nextval(seq_kind_table)[12,65535,0]  𝄀
+46
+create sequence seq_kind_view increment by 6 start with 51 no cycle;
+select nextval('seq_kind_view');
+➤ nextval(seq_kind_view)[12,65535,0]  𝄀
+51
+create snapshot issue27049_kind_view_sp for table issue27049_src seq_kind_view;
+drop sequence seq_kind_view;
+create view seq_kind_view as select 999 as n;
+restore table issue27049_src.seq_kind_view{snapshot = 'issue27049_kind_view_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_src' and relname = 'seq_kind_view';
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq_kind_view  ¦  S
+select * from issue27049_src.seq_kind_view;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+51  ¦  1  ¦  9223372036854775807  ¦  51  ¦  6  ¦  0  ¦  1
+select nextval('seq_kind_view');
+➤ nextval(seq_kind_view)[12,65535,0]  𝄀
+57
 create database issue27049_atomic_src;
 create sequence issue27049_atomic_src.seq1 start with 5;
 create table issue27049_atomic_src.t1(a int);
@@ -251,6 +292,8 @@ where reldatabase = 'issue27049_atomic_dst';
 ➤ atomic_relation_count[-5,64,0]  𝄀
 0
 drop snapshot if exists issue27049_table_sp;
+drop snapshot if exists issue27049_kind_table_sp;
+drop snapshot if exists issue27049_kind_view_sp;
 drop snapshot if exists issue27049_sp;
 drop database if exists issue27049_seq_only_src;
 drop database if exists issue27049_seq_only_dst;

--- a/test/distributed/cases/git4data/clone/clone_database_sequence.result
+++ b/test/distributed/cases/git4data/clone/clone_database_sequence.result
@@ -1,0 +1,263 @@
+drop snapshot if exists issue27049_sp;
+drop snapshot if exists issue27049_table_sp;
+drop database if exists issue27049_seq_only_src;
+drop database if exists issue27049_seq_only_dst;
+drop database if exists issue27049_src;
+drop database if exists issue27049_live;
+drop database if exists issue27049_snap;
+drop database if exists issue27049_branch;
+drop database if exists issue27049_atomic_src;
+drop database if exists issue27049_atomic_dst;
+drop account if exists issue27049_acc;
+create database issue27049_seq_only_src;
+create sequence issue27049_seq_only_src.seq1 as int unsigned
+increment by 2 minvalue 1 maxvalue 100 start with 11 no cycle;
+create database issue27049_seq_only_dst clone issue27049_seq_only_src;
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_seq_only_dst'
+order by relname;
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq1  ¦  S
+select * from issue27049_seq_only_dst.seq1;
+➤ last_seq_num[4,32,0]  ¦  min_value[4,32,0]  ¦  max_value[4,32,0]  ¦  start_value[4,32,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+11  ¦  1  ¦  100  ¦  11  ¦  2  ¦  0  ¦  0
+use issue27049_seq_only_dst;
+select nextval('seq1');
+➤ nextval(seq1)[12,65535,0]  𝄀
+11
+create database issue27049_src;
+use issue27049_src;
+create sequence seq_state as bigint
+increment by 3 minvalue 1 maxvalue 100 start with 7 no cycle;
+create sequence seq_uncalled as int unsigned
+increment by 2 minvalue 1 maxvalue 100 start with 11 cycle;
+create sequence seq_altered as bigint start with 1;
+alter sequence seq_altered as smallint increment by -2
+minvalue 3 maxvalue 9 start with 9 cycle;
+create table t1(id bigint primary key default nextval('seq_state'), payload varchar(20));
+insert into t1 values (1, 'snapshot-row');
+create view seq_view as select nextval('seq_state') as n;
+select * from seq_view;
+➤ n[12,65535,0]  𝄀
+7
+select nextval('seq_altered');
+➤ nextval(seq_altered)[12,65535,0]  𝄀
+1
+create snapshot issue27049_sp for database issue27049_src;
+select * from seq_view;
+➤ n[12,65535,0]  𝄀
+10
+select nextval('seq_altered');
+➤ nextval(seq_altered)[12,65535,0]  𝄀
+9
+insert into t1 values (2, 'live-row');
+create sequence seq_after_snapshot start with 31;
+create database issue27049_live clone issue27049_src;
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_live'
+order by relname;
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq_after_snapshot  ¦  S  𝄀
+seq_altered  ¦  S  𝄀
+seq_state  ¦  S  𝄀
+seq_uncalled  ¦  S  𝄀
+seq_view  ¦  v  𝄀
+t1  ¦  r
+select * from issue27049_live.seq_state;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+10  ¦  1  ¦  100  ¦  7  ¦  3  ¦  0  ¦  1
+select * from issue27049_live.seq_uncalled;
+➤ last_seq_num[4,32,0]  ¦  min_value[4,32,0]  ¦  max_value[4,32,0]  ¦  start_value[4,32,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+11  ¦  1  ¦  100  ¦  11  ¦  2  ¦  1  ¦  0
+select * from issue27049_live.seq_altered;
+➤ last_seq_num[5,16,0]  ¦  min_value[5,16,0]  ¦  max_value[5,16,0]  ¦  start_value[5,16,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+9  ¦  3  ¦  9  ¦  9  ¦  -2  ¦  1  ¦  1
+use issue27049_live;
+select * from seq_view;
+➤ n[12,65535,0]  𝄀
+13
+select nextval('seq_uncalled');
+➤ nextval(seq_uncalled)[12,65535,0]  𝄀
+11
+select nextval('seq_altered');
+➤ nextval(seq_altered)[12,65535,0]  𝄀
+7
+insert into t1(payload) values ('cloned-default');
+select * from t1 order by id;
+➤ id[-5,64,0]  ¦  payload[12,20,0]  𝄀
+1  ¦  snapshot-row  𝄀
+2  ¦  live-row  𝄀
+16  ¦  cloned-default
+create database issue27049_snap clone issue27049_src {snapshot = 'issue27049_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_snap'
+order by relname;
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq_altered  ¦  S  𝄀
+seq_state  ¦  S  𝄀
+seq_uncalled  ¦  S  𝄀
+seq_view  ¦  v  𝄀
+t1  ¦  r
+select * from issue27049_snap.seq_state;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+7  ¦  1  ¦  100  ¦  7  ¦  3  ¦  0  ¦  1
+select * from issue27049_snap.seq_uncalled;
+➤ last_seq_num[4,32,0]  ¦  min_value[4,32,0]  ¦  max_value[4,32,0]  ¦  start_value[4,32,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+11  ¦  1  ¦  100  ¦  11  ¦  2  ¦  1  ¦  0
+select * from issue27049_snap.seq_altered;
+➤ last_seq_num[5,16,0]  ¦  min_value[5,16,0]  ¦  max_value[5,16,0]  ¦  start_value[5,16,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+1  ¦  3  ¦  9  ¦  9  ¦  -2  ¦  1  ¦  1
+use issue27049_snap;
+select * from seq_view;
+➤ n[12,65535,0]  𝄀
+10
+select nextval('seq_uncalled');
+➤ nextval(seq_uncalled)[12,65535,0]  𝄀
+11
+select nextval('seq_altered');
+➤ nextval(seq_altered)[12,65535,0]  𝄀
+9
+select * from t1 order by id;
+➤ id[-5,64,0]  ¦  payload[12,20,0]  𝄀
+1  ¦  snapshot-row
+create account issue27049_acc admin_name "root1" identified by "111";
+create database issue27049_cross clone issue27049_src
+{snapshot = 'issue27049_sp'} to account issue27049_acc;
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_cross'
+order by relname;
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq_altered  ¦  S  𝄀
+seq_state  ¦  S  𝄀
+seq_uncalled  ¦  S  𝄀
+seq_view  ¦  v  𝄀
+t1  ¦  r
+select * from issue27049_cross.seq_state;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+7  ¦  1  ¦  100  ¦  7  ¦  3  ¦  0  ¦  1
+use issue27049_cross;
+select * from seq_view;
+➤ n[12,65535,0]  𝄀
+10
+select nextval('seq_uncalled');
+➤ nextval(seq_uncalled)[12,65535,0]  𝄀
+11
+select nextval('seq_altered');
+➤ nextval(seq_altered)[12,65535,0]  𝄀
+9
+select * from t1 order by id;
+➤ id[-5,64,0]  ¦  payload[12,20,0]  𝄀
+1  ¦  snapshot-row
+data branch create database issue27049_branch from issue27049_src;
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_branch'
+order by relname;
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq_after_snapshot  ¦  S  𝄀
+seq_altered  ¦  S  𝄀
+seq_state  ¦  S  𝄀
+seq_uncalled  ¦  S  𝄀
+seq_view  ¦  v  𝄀
+t1  ¦  r
+select * from issue27049_branch.seq_state;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+10  ¦  1  ¦  100  ¦  7  ¦  3  ¦  0  ¦  1
+use issue27049_branch;
+select * from seq_view;
+➤ n[12,65535,0]  𝄀
+13
+select nextval('seq_uncalled');
+➤ nextval(seq_uncalled)[12,65535,0]  𝄀
+11
+select nextval('seq_altered');
+➤ nextval(seq_altered)[12,65535,0]  𝄀
+7
+restore database issue27049_src{snapshot = 'issue27049_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_src'
+order by relname;
+➤ relname[12,5000,0]  ¦  relkind[12,5000,0]  𝄀
+seq_altered  ¦  S  𝄀
+seq_state  ¦  S  𝄀
+seq_uncalled  ¦  S  𝄀
+seq_view  ¦  v  𝄀
+t1  ¦  r
+select * from issue27049_src.seq_state;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+7  ¦  1  ¦  100  ¦  7  ¦  3  ¦  0  ¦  1
+select * from issue27049_src.seq_uncalled;
+➤ last_seq_num[4,32,0]  ¦  min_value[4,32,0]  ¦  max_value[4,32,0]  ¦  start_value[4,32,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+11  ¦  1  ¦  100  ¦  11  ¦  2  ¦  1  ¦  0
+select * from issue27049_src.seq_altered;
+➤ last_seq_num[5,16,0]  ¦  min_value[5,16,0]  ¦  max_value[5,16,0]  ¦  start_value[5,16,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+1  ¦  3  ¦  9  ¦  9  ¦  -2  ¦  1  ¦  1
+use issue27049_src;
+select * from seq_view;
+➤ n[12,65535,0]  𝄀
+10
+select nextval('seq_uncalled');
+➤ nextval(seq_uncalled)[12,65535,0]  𝄀
+11
+select nextval('seq_altered');
+➤ nextval(seq_altered)[12,65535,0]  𝄀
+9
+select * from t1 order by id;
+➤ id[-5,64,0]  ¦  payload[12,20,0]  𝄀
+1  ¦  snapshot-row
+create sequence seq_table_restore increment by 4 start with 21 no cycle;
+select nextval('seq_table_restore');
+➤ nextval(seq_table_restore)[12,65535,0]  𝄀
+21
+create snapshot issue27049_table_sp for table issue27049_src seq_table_restore;
+select nextval('seq_table_restore');
+➤ nextval(seq_table_restore)[12,65535,0]  𝄀
+25
+restore table issue27049_src.seq_table_restore{snapshot = 'issue27049_table_sp'};
+select * from issue27049_src.seq_table_restore;
+➤ last_seq_num[-5,64,0]  ¦  min_value[-5,64,0]  ¦  max_value[-5,64,0]  ¦  start_value[-5,64,0]  ¦  increment_value[-5,64,0]  ¦  cycle[-7,1,0]  ¦  is_called[-7,1,0]  𝄀
+21  ¦  1  ¦  9223372036854775807  ¦  21  ¦  4  ¦  0  ¦  1
+select nextval('seq_table_restore');
+➤ nextval(seq_table_restore)[12,65535,0]  𝄀
+25
+create database issue27049_atomic_src;
+create sequence issue27049_atomic_src.seq1 start with 5;
+create table issue27049_atomic_src.t1(a int);
+select enable_fault_injection();
+➤ enable_fault_injection()[-7,1,0]  𝄀
+1
+select add_fault_point('fj/cn/clone_fails',':::','echo',40,'issue27049_atomic_dst.t1');
+➤ add_fault_point(fj/cn/clone_fails, :::, echo, 40, issue27049_atomic_dst.t1)[-7,1,0]  𝄀
+1
+create database issue27049_atomic_dst clone issue27049_atomic_src;
+-- @regex("internal error", true)
+internal error: injected table clone error
+select disable_fault_injection();
+➤ disable_fault_injection()[-7,1,0]  𝄀
+1
+select count(*) as atomic_database_count
+from mo_catalog.mo_database
+where datname = 'issue27049_atomic_dst';
+➤ atomic_database_count[-5,64,0]  𝄀
+0
+select count(*) as atomic_relation_count
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_atomic_dst';
+➤ atomic_relation_count[-5,64,0]  𝄀
+0
+drop snapshot if exists issue27049_table_sp;
+drop snapshot if exists issue27049_sp;
+drop database if exists issue27049_seq_only_src;
+drop database if exists issue27049_seq_only_dst;
+drop database if exists issue27049_src;
+drop database if exists issue27049_live;
+drop database if exists issue27049_snap;
+drop database if exists issue27049_branch;
+drop database if exists issue27049_atomic_src;
+drop database if exists issue27049_atomic_dst;
+drop account if exists issue27049_acc;

--- a/test/distributed/cases/git4data/clone/clone_database_sequence.sql
+++ b/test/distributed/cases/git4data/clone/clone_database_sequence.sql
@@ -3,6 +3,8 @@
 
 drop snapshot if exists issue27049_sp;
 drop snapshot if exists issue27049_table_sp;
+drop snapshot if exists issue27049_kind_table_sp;
+drop snapshot if exists issue27049_kind_view_sp;
 drop database if exists issue27049_seq_only_src;
 drop database if exists issue27049_seq_only_dst;
 drop database if exists issue27049_src;
@@ -137,6 +139,33 @@ restore table issue27049_src.seq_table_restore{snapshot = 'issue27049_table_sp'}
 select * from issue27049_src.seq_table_restore;
 select nextval('seq_table_restore');
 
+-- Restoring a historical sequence must replace a current object with the same
+-- name according to its actual relkind, rather than assuming it is a sequence.
+create sequence seq_kind_table increment by 5 start with 41 no cycle;
+select nextval('seq_kind_table');
+create snapshot issue27049_kind_table_sp for table issue27049_src seq_kind_table;
+drop sequence seq_kind_table;
+create table seq_kind_table(a int);
+insert into seq_kind_table values (1);
+restore table issue27049_src.seq_kind_table{snapshot = 'issue27049_kind_table_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_src' and relname = 'seq_kind_table';
+select * from issue27049_src.seq_kind_table;
+select nextval('seq_kind_table');
+
+create sequence seq_kind_view increment by 6 start with 51 no cycle;
+select nextval('seq_kind_view');
+create snapshot issue27049_kind_view_sp for table issue27049_src seq_kind_view;
+drop sequence seq_kind_view;
+create view seq_kind_view as select 999 as n;
+restore table issue27049_src.seq_kind_view{snapshot = 'issue27049_kind_view_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_src' and relname = 'seq_kind_view';
+select * from issue27049_src.seq_kind_view;
+select nextval('seq_kind_view');
+
 -- A failure after sequence creation must still roll back the whole database.
 create database issue27049_atomic_src;
 create sequence issue27049_atomic_src.seq1 start with 5;
@@ -154,6 +183,8 @@ from mo_catalog.mo_tables
 where reldatabase = 'issue27049_atomic_dst';
 
 drop snapshot if exists issue27049_table_sp;
+drop snapshot if exists issue27049_kind_table_sp;
+drop snapshot if exists issue27049_kind_view_sp;
 drop snapshot if exists issue27049_sp;
 drop database if exists issue27049_seq_only_src;
 drop database if exists issue27049_seq_only_dst;

--- a/test/distributed/cases/git4data/clone/clone_database_sequence.sql
+++ b/test/distributed/cases/git4data/clone/clone_database_sequence.sql
@@ -1,0 +1,166 @@
+-- issue#27049: database clone, data branch, and snapshot restore must preserve
+-- sequence definitions and state, including sequences referenced by views.
+
+drop snapshot if exists issue27049_sp;
+drop snapshot if exists issue27049_table_sp;
+drop database if exists issue27049_seq_only_src;
+drop database if exists issue27049_seq_only_dst;
+drop database if exists issue27049_src;
+drop database if exists issue27049_live;
+drop database if exists issue27049_snap;
+drop database if exists issue27049_branch;
+drop database if exists issue27049_atomic_src;
+drop database if exists issue27049_atomic_dst;
+drop account if exists issue27049_acc;
+
+-- Minimal sequence-only database clone.
+create database issue27049_seq_only_src;
+create sequence issue27049_seq_only_src.seq1 as int unsigned
+  increment by 2 minvalue 1 maxvalue 100 start with 11 no cycle;
+create database issue27049_seq_only_dst clone issue27049_seq_only_src;
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_seq_only_dst'
+order by relname;
+select * from issue27049_seq_only_dst.seq1;
+use issue27049_seq_only_dst;
+select nextval('seq1');
+
+-- A sequence-backed default and view, an uncalled sequence, and a sequence
+-- whose stored catalog DDL is ALTER SEQUENCE rather than CREATE SEQUENCE.
+create database issue27049_src;
+use issue27049_src;
+create sequence seq_state as bigint
+  increment by 3 minvalue 1 maxvalue 100 start with 7 no cycle;
+create sequence seq_uncalled as int unsigned
+  increment by 2 minvalue 1 maxvalue 100 start with 11 cycle;
+create sequence seq_altered as bigint start with 1;
+alter sequence seq_altered as smallint increment by -2
+  minvalue 3 maxvalue 9 start with 9 cycle;
+create table t1(id bigint primary key default nextval('seq_state'), payload varchar(20));
+insert into t1 values (1, 'snapshot-row');
+create view seq_view as select nextval('seq_state') as n;
+select * from seq_view;
+select nextval('seq_altered');
+
+create snapshot issue27049_sp for database issue27049_src;
+select * from seq_view;
+select nextval('seq_altered');
+insert into t1 values (2, 'live-row');
+create sequence seq_after_snapshot start with 31;
+
+-- Live clone preserves current definitions/state and creates sequences before
+-- dependent tables and views.
+create database issue27049_live clone issue27049_src;
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_live'
+order by relname;
+select * from issue27049_live.seq_state;
+select * from issue27049_live.seq_uncalled;
+select * from issue27049_live.seq_altered;
+use issue27049_live;
+select * from seq_view;
+select nextval('seq_uncalled');
+select nextval('seq_altered');
+insert into t1(payload) values ('cloned-default');
+select * from t1 order by id;
+
+-- Named-snapshot clone uses sequence definition and state from the snapshot,
+-- not the current source relation.
+create database issue27049_snap clone issue27049_src {snapshot = 'issue27049_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_snap'
+order by relname;
+select * from issue27049_snap.seq_state;
+select * from issue27049_snap.seq_uncalled;
+select * from issue27049_snap.seq_altered;
+use issue27049_snap;
+select * from seq_view;
+select nextval('seq_uncalled');
+select nextval('seq_altered');
+select * from t1 order by id;
+
+-- Cross-account snapshot clone resolves sequence metadata in the source
+-- tenant and restores the sequence relation in the target tenant.
+create account issue27049_acc admin_name "root1" identified by "111";
+create database issue27049_cross clone issue27049_src
+  {snapshot = 'issue27049_sp'} to account issue27049_acc;
+-- @session:id=1&user=issue27049_acc:root1&password=111
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_cross'
+order by relname;
+select * from issue27049_cross.seq_state;
+use issue27049_cross;
+select * from seq_view;
+select nextval('seq_uncalled');
+select nextval('seq_altered');
+select * from t1 order by id;
+-- @session
+
+-- DATA BRANCH shares the live database source collector.
+data branch create database issue27049_branch from issue27049_src;
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_branch'
+order by relname;
+select * from issue27049_branch.seq_state;
+use issue27049_branch;
+select * from seq_view;
+select nextval('seq_uncalled');
+select nextval('seq_altered');
+
+-- Database snapshot restore restores sequence state and removes objects created
+-- after the snapshot, while leaving dependent objects usable.
+restore database issue27049_src{snapshot = 'issue27049_sp'};
+select relname, relkind
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_src'
+order by relname;
+select * from issue27049_src.seq_state;
+select * from issue27049_src.seq_uncalled;
+select * from issue27049_src.seq_altered;
+use issue27049_src;
+select * from seq_view;
+select nextval('seq_uncalled');
+select nextval('seq_altered');
+select * from t1 order by id;
+
+-- Table-level snapshot restore uses the same sequence restore primitive.
+create sequence seq_table_restore increment by 4 start with 21 no cycle;
+select nextval('seq_table_restore');
+create snapshot issue27049_table_sp for table issue27049_src seq_table_restore;
+select nextval('seq_table_restore');
+restore table issue27049_src.seq_table_restore{snapshot = 'issue27049_table_sp'};
+select * from issue27049_src.seq_table_restore;
+select nextval('seq_table_restore');
+
+-- A failure after sequence creation must still roll back the whole database.
+create database issue27049_atomic_src;
+create sequence issue27049_atomic_src.seq1 start with 5;
+create table issue27049_atomic_src.t1(a int);
+select enable_fault_injection();
+select add_fault_point('fj/cn/clone_fails',':::','echo',40,'issue27049_atomic_dst.t1');
+-- @regex("internal error",true)
+create database issue27049_atomic_dst clone issue27049_atomic_src;
+select disable_fault_injection();
+select count(*) as atomic_database_count
+from mo_catalog.mo_database
+where datname = 'issue27049_atomic_dst';
+select count(*) as atomic_relation_count
+from mo_catalog.mo_tables
+where reldatabase = 'issue27049_atomic_dst';
+
+drop snapshot if exists issue27049_table_sp;
+drop snapshot if exists issue27049_sp;
+drop database if exists issue27049_seq_only_src;
+drop database if exists issue27049_seq_only_dst;
+drop database if exists issue27049_src;
+drop database if exists issue27049_live;
+drop database if exists issue27049_snap;
+drop database if exists issue27049_branch;
+drop database if exists issue27049_atomic_src;
+drop database if exists issue27049_atomic_dst;
+drop account if exists issue27049_acc;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27049

## What this PR does / why we need it:

### Root cause

Database clone and restore source collection unconditionally filtered out `relkind = 'S'`. Views were still restored, so a sequence-backed view survived while its sequence did not.

Sequences also cannot use the ordinary table-clone path: their catalog DDL may contain the latest `ALTER SEQUENCE`, and their current value / `is_called` state lives in the sequence relation row. In addition, nested background `CREATE/DROP SEQUENCE` previously finished the enclosing transaction early, which would make Data Branch fail and leave partial clone state on a later error.

The initial sequence restore path also assumed that a current same-named object was a sequence. `DROP SEQUENCE IF EXISTS` intentionally does nothing for a table or view, so a historical sequence restore collided at `CREATE SEQUENCE` after a valid sequence→table/view generation change.

After sequences entered the shared source list, DATA BRANCH preflight quota counting treated them as receipt-backed tables even though sequence restore deliberately creates no `mo_branch_metadata` receipt. The preflight increment therefore exceeded the persisted quota usage.

### Changes

- Include sequences in the shared database clone/snapshot/PITR object collector while preserving consumer-specific exclusions for Data Branch deletion metadata.
- Reconstruct canonical `CREATE SEQUENCE` SQL from the historical column type and sequence definition at the selected timestamp, including signed/unsigned types, increment, bounds, start, and cycle mode.
- Restore sequences before dependent tables and views, then copy the complete historical sequence row so `last_seq_num` and `is_called` are preserved exactly.
- Reuse the same sequence restore primitive for live clone, named-snapshot clone, Data Branch, snapshot restore, PITR, and cross-account timestamp restore.
- Before recreating a historical sequence, resolve the current destination object's actual `relkind` and execute exactly one matching `DROP TABLE`, `DROP VIEW`, or `DROP SEQUENCE`; an absent object needs no drop, while inconsistent duplicate metadata fails explicitly.
- Keep nested background sequence DDL inside the enclosing clone/restore transaction; direct user sequence-DDL transaction behavior is unchanged.
- Count only receipt-backed ordinary tables toward the DATA BRANCH table quota; sequences and views consume no quota unit because neither creates a branch receipt.
- Add focused UTs for metadata reconstruction and its malformed/missing/error responses, SQL rewriting, ordering, exact state copy, destination relkind resolution, every restore-step error, transaction ownership, all three restore entry points, and missing-account errors.
- Add a self-contained BVT covering sequence-only sources, dependent views/defaults, live/snapshot/Data Branch/cross-account paths, database/table restore, sequence→table/view replacement, altered and uncalled sequences, and failure atomicity.

### Issue-to-test proof

`clone_database_sequence.sql` directly proves #27049 by asserting:

- destination catalog entries remain `relkind = 'S'`;
- definition and all seven state columns match live or historical source state;
- sequence-only database clone is non-empty;
- dependent views and sequence-backed defaults execute after clone;
- live clone, named-snapshot clone, Data Branch, cross-account clone, database snapshot restore, and table snapshot restore all preserve the intended state;
- table-level snapshot restore replaces current same-named tables and views with the historical sequence, preserving definition, state, and next-value behavior;
- a fault after sequence creation rolls back the destination database and every destination relation.

`TestSequenceRestoreEntryPoints` executes the same-account snapshot, PITR, and cross-account snapshot sequence branches and asserts the exact relkind-specific drop and restore statements. It directly proves snapshot sequence→table, PITR sequence→view, cross-account sequence→sequence, and missing-account behavior.

`TestGetCreateSequenceSQLErrors` proves type/state query failures, missing historical metadata, and invalid cycle state are returned rather than silently constructing bad DDL. The extended `TestRestoreSequenceState` covers absent/current/ambiguous destination metadata plus lookup, drop, create, delete, and historical-state-copy failures, proving each path stops at the exact failed operation.

`TestCloneDatabaseSourceBranchTableCount` proves the DATA BRANCH quota increment uses the same unit as persisted receipts: a mixed ordinary-table/sequence/view source counts as one, sequence-only/view-only/empty sources count as zero, and ordinary tables continue to count individually.

### Tests run

- `.agents/skills/mo-dev/scripts/mo-cgo-test -mod=readonly -count=1 -timeout=120s -run 'Test(SequenceRestoreMetadataAndOrdering|RestoreSequenceState|SequenceRestoreEntryPoints)$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run 'Test(GetCreateSequenceSQLErrors|RestoreSequenceState)$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -mod=readonly -count=1 -timeout=240s ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=15m ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s -run '^(TestGetFkDepsFromTableInfos|TestSequenceRestoreMetadataAndOrdering|TestRestoreSequenceState|TestRewriteCloneSequenceCreateSQL)$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s -run '^Test_statement_type$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s -run '^TestBranchDeleteDatabaseTableIDsSQLReusesCloneObjectFilter$' ./pkg/frontend`
- `mo-tester ... -m run -r 100 -i clone_database_sequence -g` — 108/108 passed; the pre-rebase change was also stable across 3/3 runs
- `mo-tester ... -m run -n -r 100 -i clone_sequence,clone_can_rollback -g` — 88/88 passed
- `GOWORK=off go list -mod=readonly ./pkg/frontend`
- `GOWORK=off ... go vet -mod=readonly ./pkg/frontend`
- `make build`
- `GOWORK=off go build -mod=readonly ./pkg/frontend`
- `GOWORK=off go vet -mod=readonly ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s -run '^(TestRestoreSequenceState|TestSequenceRestoreEntryPoints)$' ./pkg/frontend` — all 12 subtests passed
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=300s ./pkg/frontend` — passed
- `CGO_CFLAGS=... CGO_LDFLAGS=... GOWORK=off go vet -mod=readonly ./pkg/frontend` — passed
- `make build` after rebasing onto `origin/main` — passed
- `mo-tester ... -m genrs -i clone_database_sequence`, followed by manual semantic inspection of every new result
- `mo-tester ... -i clone_database_sequence -r 100` — 131/131 passed
- PR CI: frontend/full UT, SCA, shared build, BVT groups, UT coverage, and changed-code coverage passed. The changed-code coverage policy first reported 42/73 (57.53%), then 49/73 (67.12%); artifact inspection identified the exact remaining blocks, and the final run passed at 56/73 (76.71%, required >75%).
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s -run '^TestCloneDatabaseSourceBranchTableCount$' ./pkg/frontend` — passed all empty, sequence-only, view-only, mixed, and ordinary-table cases
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=600s ./pkg/frontend` — passed after the quota correction
- `CGO_CFLAGS=... CGO_LDFLAGS=... GOWORK=off go build -mod=readonly ./pkg/frontend` — passed
- `CGO_CFLAGS=... CGO_LDFLAGS=... GOWORK=off go vet -mod=readonly ./pkg/frontend` — passed

### Residual risk

There is no storage-format or wire-protocol change. Clone/restore adds three catalog reads and up to four transactional restore statements per sequence; this is bounded by the number of sequence objects and is outside query hot paths. Table-level `CREATE TABLE ... CLONE sequence` remains rejected as a non-base-table source.
