### PR TITLE
feat(llm): add OrcaRouter as a named LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ Storage-compute separation. Deploy anywhere. Elastic scaling. Kubernetes-native.
   <img alt="MatrixOne" height="450" src="https://github.com/matrixorigin/artwork/blob/main/docs/overview/architecture/architeture241113_en.png?raw=true">
 </p>
 
+### 🤖 **Use OrcaRouter as your LLM gateway**
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway that routes chat requests to the best available model through a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+MatrixOne's built-in `llm_chat` function supports `orcarouter` as a named server. Set the `ORCAROUTER_API_KEY` environment variable and route chat queries through the gateway:
+
+```sql
+-- Route chat through the OrcaRouter smart-routing model
+SELECT llm_chat('orcarouter', '', 'orcarouter/auto', '{"temperature": 0.1}',
+  '[{"role": "user", "content": "What is MatrixOne?"}]');
+```
+
 ## ⚡️ Get Started in 60 Seconds
 
 ### 1️⃣ Launch MatrixOne

--- a/README_CN.md
+++ b/README_CN.md
@@ -141,6 +141,18 @@ MatrixOne (OLTP + OLAP + 全文检索 + 向量检索)
   <img alt="MatrixOne" height="450" src="https://github.com/matrixorigin/artwork/blob/main/docs/overview/architecture/architeture241113_en.png?raw=true">
 </p>
 
+### 🤖 **使用 OrcaRouter 作为 LLM 网关**
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容的模型网关，通过单一端点把聊天请求路由到可用的最优模型。它在同一端点上还为 AI agents 提供网关级、零信任的安全防护——在默认拒绝的基础上审查每一次 prompt/response 并对每一次工具调用进行管控，无需任何应用代码改动。
+
+MatrixOne 内置的 `llm_chat` 函数支持将 `orcarouter` 作为命名 server。设置 `ORCAROUTER_API_KEY` 环境变量后即可通过网关路由聊天查询：
+
+```sql
+-- 通过 OrcaRouter 智能路由模型发起聊天
+SELECT llm_chat('orcarouter', '', 'orcarouter/auto', '{"temperature": 0.1}',
+  '[{"role": "user", "content": "What is MatrixOne?"}]');
+```
+
 ## ⚡️ 60秒快速上手
 
 ### 1️⃣ 启动 MatrixOne

--- a/pkg/monlp/llm/llm.go
+++ b/pkg/monlp/llm/llm.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	MockServer   = ""
-	OllamaServer = "ollama"
+	MockServer    = ""
+	OllamaServer  = "ollama"
+	OrcaRouterSvr = OrcaRouterServer
 
 	MockEchoModel = "echo"
 
@@ -49,6 +50,8 @@ func NewLLMClient(server string, addr string, model string, options string) (LLM
 		return NewMockClient(model, options)
 	case OllamaServer:
 		return NewOllamaClient(addr, model, options)
+	case OrcaRouterSvr:
+		return NewOrcaRouterClient(addr, model, options)
 	default:
 		return nil, moerr.NewInvalidInputf(context.TODO(), "invalid server: %s", server)
 	}

--- a/pkg/monlp/llm/orcarouter.go
+++ b/pkg/monlp/llm/orcarouter.go
@@ -1,0 +1,124 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai"
+)
+
+const (
+	OrcaRouterServer = "orcarouter"
+
+	OrcaRouterDefaultBaseURL = "https://api.orcarouter.ai/v1"
+	OrcaRouterDefaultModel   = "orcarouter/auto"
+
+	orcaRouterAPIKeyEnv = "ORCAROUTER_API_KEY"
+)
+
+type OrcaRouterClient struct {
+	model       string
+	llm         *openai.LLM
+	temperature float64
+	opts        map[string]any
+}
+
+// NewOrcaRouterClient creates a client that routes chat requests through the
+// OrcaRouter gateway (an OpenAI-compatible model router). The api key is read
+// from the ORCAROUTER_API_KEY environment variable, and addr is ignored since
+// the gateway base URL is fixed to https://api.orcarouter.ai/v1.
+func NewOrcaRouterClient(addr string, model string, options string) (*OrcaRouterClient, error) {
+	var cli OrcaRouterClient
+	var err error
+	cli.model = model
+	if cli.model == "" {
+		cli.model = OrcaRouterDefaultModel
+	}
+
+	token := os.Getenv(orcaRouterAPIKeyEnv)
+	if token == "" {
+		return nil, moerr.NewInvalidInputf(context.TODO(), "missing ORCAROUTER_API_KEY environment variable")
+	}
+
+	cli.llm, err = openai.New(
+		openai.WithToken(token),
+		openai.WithBaseURL(OrcaRouterDefaultBaseURL),
+		openai.WithModel(cli.model),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if options != "" {
+		err = json.Unmarshal([]byte(options), &cli.opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	temp, ok := cli.opts["temperature"]
+	if ok {
+		cli.temperature, ok = temp.(float64)
+		if !ok || cli.temperature < 0 || cli.temperature > 1 {
+			return nil, moerr.NewInvalidInputf(context.TODO(), "invalid temperature: %v", temp)
+		}
+	} else {
+		// default temperature is 0.1, it is relatively low so the model will be more deterministic
+		cli.temperature = 0.1
+	}
+
+	return &cli, nil
+}
+
+func (o *OrcaRouterClient) ChatMsg(ctx context.Context, messages []Message) (string, error) {
+	if o.llm == nil {
+		return "", moerr.NewInvalidInputf(ctx, "orcarouter client not initialized")
+	}
+
+	chatMessages := make([]llms.MessageContent, len(messages))
+	for i, msg := range messages {
+		chatMessages[i] = llms.TextParts(mapRole(msg.Role), msg.Content)
+	}
+
+	response, err := o.llm.GenerateContent(ctx, chatMessages, llms.WithTemperature(o.temperature))
+	if err != nil {
+		return "", err
+	}
+
+	if len(response.Choices) == 0 {
+		return "", moerr.NewInternalError(ctx, "no response from orcarouter")
+	}
+	// TODO: handle multiple choices, currently we only return the first choice.
+	return response.Choices[0].Content, nil
+}
+
+func (o *OrcaRouterClient) Chat(ctx context.Context, prompt string) (string, error) {
+	messages, err := stringToMessage(prompt)
+	if err != nil {
+		return "", err
+	}
+	return o.ChatMsg(ctx, messages)
+}
+
+// CreateEmbedding is not supported by OrcaRouter, which is a chat-only
+// gateway that routes LLM chat requests.
+func (o *OrcaRouterClient) CreateEmbedding(ctx context.Context, text string) ([]float32, error) {
+	return nil, moerr.NewNotSupportedf(ctx, "orcarouter does not support embeddings")
+}

--- a/pkg/monlp/llm/orcarouter_test.go
+++ b/pkg/monlp/llm/orcarouter_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestOrcaRouterParams(t *testing.T) {
+	t.Setenv(orcaRouterAPIKeyEnv, "test-key")
+
+	client, err := NewOrcaRouterClient("", "orcarouter/auto", "[\"temperature\", 0.1]")
+	if client != nil || err == nil {
+		t.Error("should not create orcarouter client with invalid options, must be json object")
+	}
+
+	client, err = NewOrcaRouterClient("", "orcarouter/auto", "{\"temperature\": 2.5}")
+	if client != nil || err == nil {
+		t.Error("should not create orcarouter client with invalid temperature")
+	}
+
+	client, err = NewOrcaRouterClient("", "orcarouter/auto", "{\"temperature\": 0.5}")
+	if client == nil || err != nil || client.temperature != 0.5 {
+		t.Error("should create orcarouter client with valid temperature 0.5")
+	}
+
+	client, err = NewOrcaRouterClient("", "orcarouter/auto", "")
+	if client == nil || err != nil || client.temperature != 0.1 {
+		t.Error("should create orcarouter client with valid temperature 0.1")
+	}
+
+	// default model is used when model is empty
+	client, err = NewOrcaRouterClient("", "", "")
+	if client == nil || err != nil || client.model != OrcaRouterDefaultModel {
+		t.Error("should create orcarouter client with default model")
+	}
+
+	// Use factory method
+	cli, err := NewLLMClient(OrcaRouterSvr, "", "orcarouter/auto", "")
+	if cli == nil || err != nil {
+		t.Error("should create orcarouter client via factory with valid temperature 0.1")
+	}
+
+	cli, err = NewLLMClient("foo", "", "orcarouter/auto", "")
+	if cli != nil || err == nil {
+		t.Error("should fail to create orcarouter client with invalid server")
+	}
+}
+
+func TestOrcaRouterMissingKey(t *testing.T) {
+	if v, ok := os.LookupEnv(orcaRouterAPIKeyEnv); ok {
+		t.Setenv(orcaRouterAPIKeyEnv, v)
+	} else {
+		t.Setenv(orcaRouterAPIKeyEnv, "")
+	}
+
+	client, err := NewOrcaRouterClient("", "orcarouter/auto", "")
+	if client != nil || err == nil {
+		t.Error("should fail to create orcarouter client without ORCAROUTER_API_KEY")
+	}
+}
+
+func TestOrcaRouterEmbeddingNotSupported(t *testing.T) {
+	t.Setenv(orcaRouterAPIKeyEnv, "test-key")
+
+	client, err := NewOrcaRouterClient("", "orcarouter/auto", "")
+	if client == nil || err != nil {
+		t.Fatal("should create orcarouter client with valid key")
+	}
+
+	_, err = client.CreateEmbedding(context.Background(), "Hello, world!")
+	if err == nil {
+		t.Error("should fail to create embedding with orcarouter client")
+	}
+}

--- a/test/distributed/cases/function/func_llm.result
+++ b/test/distributed/cases/function/func_llm.result
@@ -21,6 +21,8 @@ select llm_chat('', null, 'echo', '', 'hello world');
 invalid input: llm_chat: addr must not be null
 select llm_chat('', '', null, '', 'hello world');
 invalid input: llm_chat: model must not be null
+select llm_chat('orcarouter', '', 'orcarouter/auto', '', '[{"role": "user", "content": "hello world"}]');
+invalid input: missing ORCAROUTER_API_KEY environment variable
 select llm_chat('', '', 'echo', '', col1) from parse_jsonl_data($$["echo", [{"role":"user", "content":"foo"}]]
 ["echo", [{"role":"user", "content":"bar"}]]
 $$, 'ss'

--- a/test/distributed/cases/function/func_llm.sql
+++ b/test/distributed/cases/function/func_llm.sql
@@ -12,6 +12,9 @@ select llm_chat(123, '', '', '', 'hello world');
 select llm_chat('', null, 'echo', '', 'hello world');
 select llm_chat('', '', null, '', 'hello world');
 
+-- orcarouter requires an api key
+select llm_chat('orcarouter', '', 'orcarouter/auto', '', '[{"role": "user", "content": "hello world"}]');
+
 select llm_chat('', '', 'echo', '', col1) from parse_jsonl_data($$["echo", [{"role":"user", "content":"foo"}]]
 ["echo", [{"role":"user", "content":"bar"}]]
 $$, 'ss'


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [x] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Closes #27422

## What this PR does / why we need it:

Adds `orcarouter` as a named LLM provider for MatrixOne's built-in `llm_chat` function, mirroring the existing `ollama` wiring.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway that routes chat requests to the best available model through a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Changes

- **`pkg/monlp/llm/orcarouter.go`** (new): `OrcaRouterClient` built on `langchaingo/llms/openai`, pointing at the gateway base URL `https://api.orcarouter.ai/v1` with the `ORCAROUTER_API_KEY` environment variable and default model `orcarouter/auto`. Embeddings are explicitly unsupported (the gateway is chat-only) and return a clear error.
- **`pkg/monlp/llm/llm.go`**: dispatch the `orcarouter` server in `NewLLMClient`.
- **`pkg/monlp/llm/orcarouter_test.go`** (new): unit tests for option validation, default model, missing-key error, factory dispatch, and unsupported embeddings.
- **`test/distributed/cases/function/func_llm.{sql,result}`**: BVT case for the missing-`ORCAROUTER_API_KEY` error path.
- **`README.md` / `README_CN.md`**: named usage example.

Usage:

```sql
SELECT llm_chat('orcarouter', '', 'orcarouter/auto', '{"temperature": 0.1}',
  '[{"role": "user", "content": "What is MatrixOne?"}]');
```

### Verification

- `go build ./pkg/monlp/llm/`, `go vet`, `gofmt` clean.
- `go test ./pkg/monlp/llm/` passes (existing + new tests).
- Live-tested against the gateway with a real key through the actual `NewLLMClient` code path: `orcarouter/auto` returns a valid response, and embeddings return the expected "not supported" error.

Disclosure: I'm an engineer on the OrcaRouter team.
