### PR TITLE
fix(mongodb): prevent primary-key insert-select hang

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -2435,7 +2435,7 @@ func (c *Compile) compileExternScanWithPlanNodeID(node *plan.Node, planNodeID in
 		if err := c.hydrateMongoScan(node); err != nil {
 			return nil, err
 		}
-		scope := c.constructScopeForExternal(c.addr, false)
+		scope := c.constructMongoScanScope()
 		currentFirstFlag := c.anal.isFirst
 		op := mongoscan.NewArgument().WithScan(node.ExternScan.MongodbScan)
 		op.SetAnalyzeControl(c.anal.curNodeIdx, currentFirstFlag)
@@ -2578,6 +2578,29 @@ func (c *Compile) compileDatastreamScan(node *plan.Node, strictSqlMode bool) ([]
 	scope.setRootOperator(op)
 	c.anal.isFirst = false
 	return []*Scope{scope}, nil
+}
+
+// constructMongoScanScope keeps the single MongoDB reader in the scheduled
+// query-worker set. This matters when a downstream DEDUP join builds a
+// distributed shuffle: a coordinator-local source outside that set has no
+// receiver tree to start it, leaving every shuffle receiver waiting forever.
+func (c *Compile) constructMongoScanScope() *Scope {
+	current := c.materializeScheduledWorker(c.currentCNWorker())
+	node := current
+	stageNodes := c.queryWorkerStageNodes()
+	if len(stageNodes) > 0 {
+		node = stageNodes[0]
+		for _, candidate := range stageNodes {
+			if sameExecutionNode(candidate, current) {
+				node = candidate
+				break
+			}
+		}
+	}
+
+	scope := c.constructScopeForExternalNode(node, !sameExecutionNode(node, current))
+	scope.NodeInfo.Mcpu = 1
+	return scope
 }
 
 func (c *Compile) hydrateMongoScan(node *plan.Node) error {

--- a/pkg/sql/compile/max_dop_test.go
+++ b/pkg/sql/compile/max_dop_test.go
@@ -16,10 +16,12 @@ package compile
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/apply"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/schedule"
@@ -230,6 +232,83 @@ func TestConstructScopeForExternalNodeKeepsWorkerIdentity(t *testing.T) {
 	require.Equal(t, "remote", scope.NodeInfo.Id)
 	require.Equal(t, "remote:6001", scope.NodeInfo.Addr)
 	require.Equal(t, 1, scope.NodeInfo.Mcpu)
+}
+
+func TestConstructMongoScanScopeUsesScheduledQueryWorker(t *testing.T) {
+	tests := []struct {
+		name      string
+		workers   engine.Nodes
+		wantID    string
+		wantAddr  string
+		wantMagic magicType
+	}{
+		{
+			name: "current CN remains local when scheduled",
+			workers: engine.Nodes{
+				{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+				{Id: "cn-local", Addr: "cn-local:6001", Mcpu: 8},
+			},
+			wantID: "cn-local", wantAddr: "cn-local:6001", wantMagic: Merge,
+		},
+		{
+			name: "remote query worker owns source when coordinator is not scheduled",
+			workers: engine.Nodes{
+				{Id: "cn-remote", Addr: "cn-remote:6001", Mcpu: 8},
+			},
+			wantID: "cn-remote", wantAddr: "cn-remote:6001", wantMagic: Remote,
+		},
+		{
+			name:     "current CN is fallback without query workers",
+			wantAddr: "cn-local:6001", wantMagic: Merge,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := NewMockCompile(t)
+			c.addr = "cn-local:6001"
+			c.cnList = test.workers
+			c.anal = &AnalyzeModule{qry: &plan.Query{}}
+
+			scope := c.constructMongoScanScope()
+
+			require.Equal(t, test.wantID, scope.NodeInfo.Id)
+			require.Equal(t, test.wantAddr, scope.NodeInfo.Addr)
+			require.Equal(t, 1, scope.NodeInfo.Mcpu)
+			require.Equal(t, test.wantMagic, scope.Magic)
+		})
+	}
+}
+
+func TestMongoScanScopeIsStartedByDistributedDedupShuffle(t *testing.T) {
+	c := NewMockCompile(t)
+	c.addr = "cn-coordinator:6001"
+	c.cnList = engine.Nodes{
+		{Id: "cn-a", Addr: "cn-a:6001", Mcpu: 1},
+		{Id: "cn-b", Addr: "cn-b:6001", Mcpu: 1},
+	}
+	c.execType = plan2.ExecTypeAP_MULTICN
+	c.anal = &AnalyzeModule{qry: &plan.Query{}}
+
+	mongoScope := c.constructMongoScanScope()
+	mongoScope.setRootOperator(colexec.NewMockOperator())
+	buildScope := newShuffleJoinTestScope(t, c.cnList[1], 1)
+	joinNode := newShuffleJoinTestNode(1)
+	joinNode.JoinType = plan.Node_DEDUP
+	stageNodes := c.queryWorkerStageNodes()
+
+	receivers := c.newShuffleJoinScopeListAt(
+		[]*Scope{mongoScope}, []*Scope{buildScope}, joinNode, stageNodes, false)
+
+	var sourceAttached bool
+	for _, receiver := range receivers {
+		if sameExecutionNode(receiver.NodeInfo, mongoScope.NodeInfo) {
+			sourceAttached = slices.Contains(receiver.PreScopes, mongoScope)
+			break
+		}
+	}
+	require.True(t, sourceAttached,
+		"the DEDUP shuffle receiver on the MongoDB worker must own the source scope")
 }
 
 func TestSameExecutionNodeUsesIdentityAndDoesNotMatchEmptyAddressToRemote(t *testing.T) {

--- a/pkg/sql/plan/mongodb_insert_test.go
+++ b/pkg/sql/plan/mongodb_insert_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/features"
+	"github.com/matrixorigin/matrixone/pkg/sql/mongodb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMongoDBInsertSelectPrimaryKeyUsesShuffleDedup(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	mapping := mongodb.TableMapping{
+		Connection: "mongodb_ci", Database: "mongodb_source", Collection: "nation",
+		SchemaMode: mongodb.SchemaExplicit, Conversion: mongodb.ConversionStrict, MaxParallelism: 1,
+		Columns: []mongodb.ColumnMapping{
+			{Name: "n_nationkey", Path: "n_nationkey", TypeID: int32(types.T_int32), Conversion: mongodb.ConversionStrict},
+			{Name: "n_name", Path: "n_name", TypeID: int32(types.T_varchar), Width: 25, Conversion: mongodb.ConversionStrict},
+			{Name: "n_regionkey", Path: "n_regionkey", TypeID: int32(types.T_int32), Conversion: mongodb.ConversionStrict},
+			{Name: "n_comment", Path: "n_comment", TypeID: int32(types.T_varchar), Width: 152, Conversion: mongodb.ConversionStrict},
+		},
+	}
+	mock.ctxt.objects["mongo_nation"] = &planpb.ObjectRef{SchemaName: "tpch", ObjName: "mongo_nation", Obj: 4242}
+	mock.ctxt.tables["mongo_nation"] = &planpb.TableDef{
+		Name: "mongo_nation", TableType: catalog.SystemExternalRel,
+		FeatureFlag: features.MongoDBExternal,
+		Createsql:   mongodb.BuildCreateSQLEnvelope(mapping),
+		Cols: []*planpb.ColDef{
+			{Name: "n_nationkey", Typ: planpb.Type{Id: int32(types.T_int32)}},
+			{Name: "n_name", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 25}},
+			{Name: "n_regionkey", Typ: planpb.Type{Id: int32(types.T_int32)}},
+			{Name: "n_comment", Typ: planpb.Type{Id: int32(types.T_varchar), Width: 152}},
+		},
+	}
+
+	logicPlan, err := runOneStmt(mock, t,
+		"insert into tpch.nation select n_nationkey,n_name,n_regionkey,n_comment from tpch.mongo_nation where n_nationkey=1")
+	require.NoError(t, err)
+	query := logicPlan.GetQuery()
+	require.NotNil(t, query)
+	require.Len(t, query.Steps, 1)
+	require.Equal(t, planpb.Node_MULTI_UPDATE, query.Nodes[query.Steps[0]].NodeType)
+
+	var foundMongoScan, foundShuffleDedup bool
+	for _, node := range query.Nodes {
+		if node.NodeType == planpb.Node_EXTERNAL_SCAN && node.ExternScan != nil &&
+			node.ExternScan.Type == int32(planpb.ExternType_MONGODB_TB) {
+			foundMongoScan = true
+		}
+		if node.NodeType == planpb.Node_JOIN && node.JoinType == planpb.Node_DEDUP &&
+			node.Stats != nil && node.Stats.HashmapStats != nil && node.Stats.HashmapStats.Shuffle {
+			foundShuffleDedup = true
+		}
+	}
+	require.True(t, foundMongoScan)
+	require.True(t, foundShuffleDedup)
+}

--- a/test/mongodb/mongodb_e2e_local.go
+++ b/test/mongodb/mongodb_e2e_local.go
@@ -152,6 +152,11 @@ func runWithDSN(ctx context.Context, db *sql.DB, dsn, host string, r *report) er
 	}
 	r.Cases = append(r.Cases, "scan-projection-pushdown-null-conversion")
 
+	if err := verifyPrimaryKeyInsertSelect(ctx, db); err != nil {
+		return err
+	}
+	r.Cases = append(r.Cases, "insert-select-primary-key-target")
+
 	// BSON DateTime preserves milliseconds, while DATETIME(0) truncates them.
 	// The source predicate must therefore remain residual-only: an exact MongoDB
 	// equality on 10:00:05.000 would incorrectly exclude this .100 source row.
@@ -291,6 +296,20 @@ func runWithDSN(ctx context.Context, db *sql.DB, dsn, host string, r *report) er
 	}
 	r.Cases = append(r.Cases, "connection-disable-enable")
 	return nil
+}
+
+func verifyPrimaryKeyInsertSelect(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx,
+		"create table mongodb_ci.events_insert_target(mongo_id char(24) primary key, device_id varchar(20), site_id varchar(10), ts datetime(3), measurement double, source_batch varchar(50))"); err != nil {
+		return fmt.Errorf("create primary-key insert target: %w", err)
+	}
+	insertCtx, cancelInsert := context.WithTimeout(ctx, 15*time.Second)
+	defer cancelInsert()
+	if _, err := db.ExecContext(insertCtx,
+		"insert into mongodb_ci.events_insert_target select mongo_id,device_id,site_id,ts,measurement,source_batch from mongodb_ci.events where mongo_id='66a7b7000000000000000001'"); err != nil {
+		return fmt.Errorf("insert-select into primary-key target: %w", err)
+	}
+	return expectScalar(ctx, db, "select count(*) from mongodb_ci.events_insert_target", "1")
 }
 
 func verifyAuthorizationBoundary(ctx context.Context, adminDB *sql.DB, dsn string) error {

--- a/test/mongodb/mongodb_e2e_local_test.go
+++ b/test/mongodb/mongodb_e2e_local_test.go
@@ -85,6 +85,9 @@ func TestMongoDBLocalE2ERunContract(t *testing.T) {
 	mock.ExpectQuery("select mongo_id").WillReturnRows(fixtureRows)
 	expectMongoDBE2EScalar(mock, "3")
 	expectMongoDBE2EScalar(mock, "3")
+	mock.ExpectExec("create table mongodb_ci.events_insert_target").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("insert into mongodb_ci.events_insert_target").WillReturnResult(sqlmock.NewResult(0, 1))
+	expectMongoDBE2EScalar(mock, "1")
 	expectMongoDBE2EScalar(mock, "1")
 	mock.ExpectQuery("select payload_1").WillReturnError(errors.New("MongoDB decoded batch byte limit exceeded"))
 	// A pre-canceled context is rejected by database/sql before it reaches the
@@ -128,6 +131,7 @@ func TestMongoDBLocalE2ERunContract(t *testing.T) {
 		"json-relaxed-extended-conversion",
 		"fixed-binary-padding",
 		"scan-projection-pushdown-null-conversion",
+		"insert-select-primary-key-target",
 		"low-precision-temporal-residual",
 		"decoded-vector-budget-enforced",
 		"multi-batch-cancel-recovery",
@@ -174,6 +178,65 @@ func TestMongoDBLocalE2ERunPropagatesRelaxedJSONQueryFailures(t *testing.T) {
 
 			err = run(t.Context(), db, "127.0.0.1:27017", &report{})
 			require.ErrorContains(t, err, "relaxed JSON query failed")
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestMongoDBPrimaryKeyInsertSelect(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(sqlmock.Sqlmock)
+		wantErr string
+	}{
+		{
+			name: "create target fails",
+			prepare: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("create table mongodb_ci.events_insert_target").
+					WillReturnError(errors.New("catalog unavailable"))
+			},
+			wantErr: "create primary-key insert target: catalog unavailable",
+		},
+		{
+			name: "insert select fails",
+			prepare: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("create table mongodb_ci.events_insert_target").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into mongodb_ci.events_insert_target").
+					WillReturnError(errors.New("source scan failed"))
+			},
+			wantErr: "insert-select into primary-key target: source scan failed",
+		},
+		{
+			name: "inserted row count is validated",
+			prepare: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("create table mongodb_ci.events_insert_target").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into mongodb_ci.events_insert_target").WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectQuery("select count\\(\\*\\) from mongodb_ci.events_insert_target").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow("0"))
+			},
+			wantErr: "expected \"1\"",
+		},
+		{
+			name: "single source row is inserted",
+			prepare: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("create table mongodb_ci.events_insert_target").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into mongodb_ci.events_insert_target").WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectQuery("select count\\(\\*\\) from mongodb_ci.events_insert_target").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow("1"))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock := newMongoDBE2ESQLMock(t)
+			test.prepare(mock)
+			err := verifyPrimaryKeyInsertSelect(t.Context(), db)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27417

## What this PR does / why we need it:

fix(mongodb): prevent primary-key insert-select hang