### PR TITLE
perf(catalog): add opt-in dependency invalidation attribution

### DIFF
--- a/docs/rfcs/20260821-catalog-invalidation-attribution.md
+++ b/docs/rfcs/20260821-catalog-invalidation-attribution.md
@@ -33,19 +33,24 @@ path.
 
 ## Report contract
 
-`CatalogCache.WriteCatalogInvalidationReport` emits JSON with schema version 1:
+`CatalogCache.WriteCatalogInvalidationReport` emits the per-CN JSON fragment
+with schema version 2:
 
 - exact decision/check/invalidation counts per prepared-plan and RC table-cache
-  consumer;
+  consumer, split into stable and inconclusive checks;
 - bucket and precise false-positive/false-negative counts separately;
 - catalog event counts;
-- prepared rebuild and RC reload bounded p50/p95/p99 latency buckets;
+- prepared rebuild and RC reload bounded p50/p95/p99 latency plus the raw
+  bounded histogram buckets;
 - shadow account/entry counts and estimated retained bytes;
 - explicit MatrixOne SHA, config, collection window, and integrity metadata.
 
-The harness must write the report to `catalog-invalidation-report.json` and set
-metadata before publication. Missing artifacts or a non-`complete` integrity
-value are measurement failures, not zero results.
+The two-CN harness wraps the fragments in a schema-v2 envelope containing the
+CN service identities, scenario/DDL/consumer mapping, merged decision totals,
+merged histograms, and `window_start_utc`/`window_end_utc`. It writes the
+report to `catalog-invalidation-report.json` through a same-directory
+temporary file and atomic rename. Missing artifacts or a non-`complete`
+integrity value are measurement failures, not zero results.
 
 ## Required measurement matrix
 
@@ -58,9 +63,11 @@ event sequences and deterministic update/check barriers under race.
 
 For exact, bucket, and precise microbenchmarks, use history lengths 1, 16, 256,
 and 4096, measure changed and warmed-negative paths for five runs, and retain
-the raw output plus `benchstat`. A warmed negative precise path must remain
-`0 allocs/op`. These measurements are directional and must not be converted
-into TPCC TPS claims.
+the raw output plus `benchstat`. Also compare the attribution-disabled wrapper
+with the exact implementation. A warmed negative precise path must remain
+`0 allocs/op`, and the disabled wrapper must not add more than 3% median
+latency. These measurements are directional and must not be converted into
+TPCC TPS claims.
 
 ## Candidate gate
 

--- a/docs/rfcs/20260821-catalog-invalidation-attribution.md
+++ b/docs/rfcs/20260821-catalog-invalidation-attribution.md
@@ -1,0 +1,78 @@
+# Catalog dependency watermark attribution
+
+Status: experimental instrumentation only (`MEASUREMENT_PENDING`)
+
+Base: `344d852ac3288e391a3ae6be3e3c7108caf2b75d`
+
+This document describes the opt-in attribution surface for issue #27235. It
+does not propose changing the production invalidation decision. The exact
+BTree remains the authority; bucket and precise-shadow decisions are recorded
+for comparison only.
+
+## Scope
+
+The experiment compares three decisions at the two real consumers:
+
+- exact BTree lookup, which is returned to the caller;
+- the existing 4096-account bucket high-watermark, with the exact database
+  identity check retained;
+- a precise shadow keyed by account, database identity/name, and table name,
+  carrying object identity, version, timestamp, and deletion state.
+
+The shadow state accepts only newer timestamps. Older replay and GC events do
+not lower it. Equal-timestamp identity conflicts are marked ambiguous and
+force a conservative shadow decision. State is bounded to one latest entry per
+database/table key plus bounded latency histograms; the report includes an
+estimated retained-byte value rather than claiming allocator accounting.
+
+Attribution is disabled unless `MO_CATALOG_INVALIDATION_ATTRIBUTION=1` is read
+during catalog construction, or a test harness explicitly enables it before
+using the cache. The disabled path does not read the environment, take a
+timestamp, update counters, or allocate shadow state from the hot decision
+path.
+
+## Report contract
+
+`CatalogCache.WriteCatalogInvalidationReport` emits JSON with schema version 1:
+
+- exact decision/check/invalidation counts per prepared-plan and RC table-cache
+  consumer;
+- bucket and precise false-positive/false-negative counts separately;
+- catalog event counts;
+- prepared rebuild and RC reload bounded p50/p95/p99 latency buckets;
+- shadow account/entry counts and estimated retained bytes;
+- explicit MatrixOne SHA, config, collection window, and integrity metadata.
+
+The harness must write the report to `catalog-invalidation-report.json` and set
+metadata before publication. Missing artifacts or a non-`complete` integrity
+value are measurement failures, not zero results.
+
+## Required measurement matrix
+
+Before any production proposal, run the differential correctness matrix for
+no-change, alter, truncate, rename, drop/recreate, empty-database
+drop/recreate, same-account unrelated DDL, forced account collision,
+equal/older/newer timestamps, replay, checkpoint restore, GC, text/binary
+prepared execution, session reuse, and RC table-cache reuse. Add randomized
+event sequences and deterministic update/check barriers under race.
+
+For exact, bucket, and precise microbenchmarks, use history lengths 1, 16, 256,
+and 4096, measure changed and warmed-negative paths for five runs, and retain
+the raw output plus `benchstat`. A warmed negative precise path must remain
+`0 allocs/op`. These measurements are directional and must not be converted
+into TPCC TPS claims.
+
+## Candidate gate
+
+Every false negative permanently rejects that candidate. Precise shadow may
+advance to a separate production Draft PR only after it matches the exact
+oracle across the full matrix, proves replay/GC monotonicity, and has an
+accepted retained-memory bound. Bucket may advance only after Catalog,
+frontend, and RC-cache owners record explicit false-positive and rebuild/reload
+budgets in #27235. If neither candidate meets those gates, retain the exact
+BTree implementation and publish the report without opening a production
+implementation PR.
+
+No claim is made here about isolated TPS, transaction P95/P99, or the historical
+`+20%` target. The previous A+C result (`+0.7026%`) remains combination-only
+evidence and is not reused as a C-only result.

--- a/docs/rfcs/20260821-catalog-invalidation-attribution.md
+++ b/docs/rfcs/20260821-catalog-invalidation-attribution.md
@@ -1,6 +1,6 @@
 # Catalog dependency watermark attribution
 
-Status: experimental instrumentation only (`MEASUREMENT_PENDING`)
+Status: experimental instrumentation only (`MEASUREMENT_REVISED_PENDING_REVIEW`)
 
 Base: `344d852ac3288e391a3ae6be3e3c7108caf2b75d`
 
@@ -45,7 +45,7 @@ with schema version 2:
 - shadow account/entry counts and estimated retained bytes;
 - explicit MatrixOne SHA, config, collection window, and integrity metadata.
 
-The two-CN harness wraps the fragments in a schema-v2 envelope containing the
+The two-CN harness wraps the fragments in a schema-v3 envelope containing the
 CN service identities, scenario/DDL/consumer mapping, merged decision totals,
 merged histograms, and `window_start_utc`/`window_end_utc`. It writes the
 report to `catalog-invalidation-report.json` through a same-directory

--- a/docs/rfcs/catalog-invalidation-report.example.json
+++ b/docs/rfcs/catalog-invalidation-report.example.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "enabled": true,
+  "metadata": {
+    "matrixone_sha": "344d852ac3288e391a3ae6be3e3c7108caf2b75d",
+    "config": "MO_CATALOG_INVALIDATION_ATTRIBUTION=1",
+    "window": "MEASUREMENT_PENDING",
+    "integrity": "not_collected"
+  },
+  "consumers": {
+    "prepared_plan": {
+      "checks": 0,
+      "invalidations": 0,
+      "bucket_invalidations": 0,
+      "precise_invalidations": 0,
+      "bucket_false_positives": 0,
+      "bucket_false_negatives": 0,
+      "precise_false_positives": 0,
+      "precise_false_negatives": 0
+    },
+    "rc_table_cache": {
+      "checks": 0,
+      "invalidations": 0,
+      "bucket_invalidations": 0,
+      "precise_invalidations": 0,
+      "bucket_false_positives": 0,
+      "bucket_false_negatives": 0,
+      "precise_false_positives": 0,
+      "precise_false_negatives": 0
+    }
+  },
+  "events": {},
+  "prepared_plan_rebuild": {
+    "count": 0,
+    "p50_ns": 0,
+    "p95_ns": 0,
+    "p99_ns": 0
+  },
+  "rc_table_cache_reload": {
+    "count": 0,
+    "p50_ns": 0,
+    "p95_ns": 0,
+    "p99_ns": 0
+  },
+  "shadow": {
+    "accounts": 0,
+    "database_entries": 0,
+    "table_entries": 0,
+    "overflow": false,
+    "estimated_retained_bytes": 0
+  }
+}

--- a/docs/rfcs/catalog-invalidation-report.example.json
+++ b/docs/rfcs/catalog-invalidation-report.example.json
@@ -32,12 +32,18 @@
   "events": {},
   "prepared_plan_rebuild": {
     "count": 0,
+    "successes": 0,
+    "errors": 0,
+    "misses": 0,
     "p50_ns": 0,
     "p95_ns": 0,
     "p99_ns": 0
   },
   "rc_table_cache_reload": {
     "count": 0,
+    "successes": 0,
+    "errors": 0,
+    "misses": 0,
     "p50_ns": 0,
     "p95_ns": 0,
     "p99_ns": 0

--- a/docs/rfcs/catalog-invalidation-report.example.json
+++ b/docs/rfcs/catalog-invalidation-report.example.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "enabled": true,
   "metadata": {
     "matrixone_sha": "344d852ac3288e391a3ae6be3e3c7108caf2b75d",
@@ -10,6 +10,8 @@
   "consumers": {
     "prepared_plan": {
       "checks": 0,
+      "stable_checks": 0,
+      "inconclusive_checks": 0,
       "invalidations": 0,
       "bucket_invalidations": 0,
       "precise_invalidations": 0,
@@ -20,6 +22,8 @@
     },
     "rc_table_cache": {
       "checks": 0,
+      "stable_checks": 0,
+      "inconclusive_checks": 0,
       "invalidations": 0,
       "bucket_invalidations": 0,
       "precise_invalidations": 0,
@@ -37,7 +41,8 @@
     "misses": 0,
     "p50_ns": 0,
     "p95_ns": 0,
-    "p99_ns": 0
+    "p99_ns": 0,
+    "buckets": []
   },
   "rc_table_cache_reload": {
     "count": 0,
@@ -46,7 +51,8 @@
     "misses": 0,
     "p50_ns": 0,
     "p95_ns": 0,
-    "p99_ns": 0
+    "p99_ns": 0,
+    "buckets": []
   },
   "shadow": {
     "accounts": 0,

--- a/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
@@ -2,7 +2,7 @@
 
 Status: evidence-only; no production candidate selected
 
-Measurement head: `cd90980a180edb03d3700d6845e875c827a57005`
+Measurement head: `badab14cb6d05060663fdfb691f3da19975b09c1`
 Base: `5735684d69c9b171c4d7a5ebee3ebcc539ffc8cc`
 Harness: `pkg/embed`, one Log, one TN, two CNs
 
@@ -15,7 +15,9 @@ terminal samples each:
 
 - binary and text prepared statements across CN0/CN1 DDL;
 - RC table-cache reload across CN0/CN1 DDL;
-- same-account unrelated DDL opportunities.
+- same-account unrelated DDL opportunities;
+- no-change, TRUNCATE, RENAME, table drop/recreate, and database
+  drop/recreate lifecycle scenarios.
 
 The aggregate latency counters contain 255 successful prepared-plan rebuilds
 and 128 successful RC table-cache reloads. There are no terminal errors or
@@ -28,7 +30,7 @@ Across both CN reports, stable checks had zero inconclusive observations and:
 | Oracle | Stable FN | Stable FP | Overflow |
 | --- | ---: | ---: | --- |
 | precise shadow | 0 | 0 | false |
-| 4096-account bucket | 0 | 13 | false |
+| 4096-account bucket | 0 | 36 | false |
 
 The bucket false positives are measured mechanism evidence, not a production
 budget. The bucket remains measurement-only until Catalog, frontend, and

--- a/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
@@ -2,7 +2,7 @@
 
 Status: evidence-only; no production candidate selected
 
-Measurement head: `badab14cb6d05060663fdfb691f3da19975b09c1`
+Measurement head: `8c147612cb0723e1cd90638aa0ab21503a4ab1a2`
 Base: `5735684d69c9b171c4d7a5ebee3ebcc539ffc8cc`
 Harness: `pkg/embed`, one Log, one TN, two CNs
 
@@ -30,7 +30,7 @@ Across both CN reports, stable checks had zero inconclusive observations and:
 | Oracle | Stable FN | Stable FP | Overflow |
 | --- | ---: | ---: | --- |
 | precise shadow | 0 | 0 | false |
-| 4096-account bucket | 0 | 36 | false |
+| 4096-account bucket | 0 | 6 | false |
 
 The bucket false positives are measured mechanism evidence, not a production
 budget. The bucket remains measurement-only until Catalog, frontend, and
@@ -46,10 +46,13 @@ changed states is stored outside the repository under
 `/Users/violet/bench/tpcc-mutex-next/results/27235/`.
 
 The attribution-disabled wrapper versus exact warmed-negative comparison used
-five runs per history. `benchstat` reports a +1.59% geometric-mean latency
-change, 0.00% bytes/op change, and no additional allocations. The precise
-warmed-negative path reports `0 B/op` and `0 allocs/op`. These are microbenchmark
-results only and are not TPS or transaction-tail claims.
+five runs per history after the competing local build had finished.
+`benchstat` reports a -10.16% geometric-mean latency change, 0.00% bytes/op
+change, and 0.00% allocs/op change. A separate run during a competing local
+build produced +44.32% and is retained as invalid contention evidence, not
+used for the gate. The precise warmed-negative path reports `0 B/op` and
+`0 allocs/op`. These are microbenchmark results only and are not TPS or
+transaction-tail claims.
 
 ## Decision
 

--- a/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
@@ -1,0 +1,58 @@
+# Issue #27235 catalog invalidation measurement
+
+Status: evidence-only; no production candidate selected
+
+Measurement head: `cd90980a180edb03d3700d6845e875c827a57005`
+Base: `5735684d69c9b171c4d7a5ebee3ebcc539ffc8cc`
+Harness: `pkg/embed`, one Log, one TN, two CNs
+
+## Integrity
+
+`catalog-invalidation-report.json` has `schema_version=2` and
+`integrity=complete`. Both CN reports have attribution enabled and the same
+measurement SHA. The workload completed all planned scenarios with 128 stable
+terminal samples each:
+
+- binary and text prepared statements across CN0/CN1 DDL;
+- RC table-cache reload across CN0/CN1 DDL;
+- same-account unrelated DDL opportunities.
+
+The aggregate latency counters contain 255 successful prepared-plan rebuilds
+and 128 successful RC table-cache reloads. There are no terminal errors or
+misses in either histogram.
+
+## Differential result
+
+Across both CN reports, stable checks had zero inconclusive observations and:
+
+| Oracle | Stable FN | Stable FP | Overflow |
+| --- | ---: | ---: | --- |
+| precise shadow | 0 | 0 | false |
+| 4096-account bucket | 0 | 13 | false |
+
+The bucket false positives are measured mechanism evidence, not a production
+budget. The bucket remains measurement-only until Catalog, frontend, and
+RC-cache owners record an accepted rebuild/reload and tail-latency budget in
+#27235. The precise result is not a production approval: its identity model,
+replay/GC behavior, retained-memory bound, and independent no-profile
+benchmark still require owner review and a separate production Draft PR.
+
+## Benchmark evidence
+
+Raw five-run output for history lengths 1/16/256/4096 and warmed-negative or
+changed states is stored outside the repository under
+`/Users/violet/bench/tpcc-mutex-next/results/27235/`.
+
+The attribution-disabled wrapper versus exact warmed-negative comparison used
+five runs per history. `benchstat` reports a +1.59% geometric-mean latency
+change, 0.00% bytes/op change, and no additional allocations. The precise
+warmed-negative path reports `0 B/op` and `0 allocs/op`. These are microbenchmark
+results only and are not TPS or transaction-tail claims.
+
+## Decision
+
+The existing exact BTree remains the production behavior. No bucket or precise
+production implementation is opened by this evidence commit. If owners accept
+the precise identity and memory model, open a separate production Draft from
+the then-current `main`, without attribution counters, shadow state, report
+APIs, or the historical A+C `+0.7026%` combination result.

--- a/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md
@@ -2,42 +2,50 @@
 
 Status: evidence-only; no production candidate selected
 
-Measurement head: `8c147612cb0723e1cd90638aa0ab21503a4ab1a2`
+Measurement head: `ce1b3cc7b93d92f7ded09e820318b0608216bfdd`
 Base: `5735684d69c9b171c4d7a5ebee3ebcc539ffc8cc`
 Harness: `pkg/embed`, one Log, one TN, two CNs
 
 ## Integrity
 
-`catalog-invalidation-report.json` has `schema_version=2` and
-`integrity=complete`. Both CN reports have attribution enabled and the same
-measurement SHA. The workload completed all planned scenarios with 128 stable
-terminal samples each:
+`catalog-invalidation-report.json` is schema 3 with `integrity=complete`. The
+report SHA is bound to the clean measurement checkout. Both CN fragments have
+the same exact SHA and complete cleanup. The validator now requires a
+per-scenario counter delta, stable terminal observation, no shadow overflow,
+zero precise FP/FN, and self-consistent terminal histograms.
 
-- binary and text prepared statements across CN0/CN1 DDL;
-- RC table-cache reload across CN0/CN1 DDL;
-- same-account unrelated DDL opportunities;
+The workload completed eight scenarios:
+
+- 128 binary and text prepared schema rebuild iterations across CN0/CN1 DDL;
+- 128 RC table-cache reload iterations across CN0/CN1 DDL;
+- 128 same-account unrelated-DDL prepared dependencies;
 - no-change, TRUNCATE, RENAME, table drop/recreate, and database
-  drop/recreate lifecycle scenarios.
+  drop/recreate lifecycle checks against dependencies established before DDL.
 
-The aggregate latency counters contain 255 successful prepared-plan rebuilds
-and 128 successful RC table-cache reloads. There are no terminal errors or
-misses in either histogram.
+Prepared rebuild terminals were recorded only after plan rebuild, result-column
+metadata, prepared-state publication, cached-compile recreation, and final
+statement setup completed. The aggregate histogram contains 259 terminal
+outcomes: 256 successes and 3 errors, with no misses. RC reload has 128
+successful terminal outcomes and no errors or misses. Errors are retained as
+terminal evidence and are not silently counted as successful rebuilds.
 
 ## Differential result
 
-Across both CN reports, stable checks had zero inconclusive observations and:
+Across both CN reports, all 87,851 decisions were stable and no shadow entry
+overflowed:
 
 | Oracle | Stable FN | Stable FP | Overflow |
 | --- | ---: | ---: | --- |
 | precise shadow | 0 | 0 | false |
-| 4096-account bucket | 0 | 6 | false |
+| 4096-account bucket | 0 | 147 | false |
 
-The bucket false positives are measured mechanism evidence, not a production
-budget. The bucket remains measurement-only until Catalog, frontend, and
-RC-cache owners record an accepted rebuild/reload and tail-latency budget in
-#27235. The precise result is not a production approval: its identity model,
-replay/GC behavior, retained-memory bound, and independent no-profile
-benchmark still require owner review and a separate production Draft PR.
+The 147 bucket false positives are measured mechanism evidence, not a
+production budget. The bucket remains measurement-only until Catalog,
+frontend, and RC-cache owners record an accepted rebuild/reload and
+tail-latency budget in #27235. The precise result is not production approval:
+its identity model, replay/GC behavior, retained-memory bound, and independent
+no-profile benchmark still require owner review and a separate production Draft
+PR.
 
 ## Benchmark evidence
 
@@ -45,14 +53,20 @@ Raw five-run output for history lengths 1/16/256/4096 and warmed-negative or
 changed states is stored outside the repository under
 `/Users/violet/bench/tpcc-mutex-next/results/27235/`.
 
-The attribution-disabled wrapper versus exact warmed-negative comparison used
-five runs per history after the competing local build had finished.
-`benchstat` reports a -10.16% geometric-mean latency change, 0.00% bytes/op
-change, and 0.00% allocs/op change. A separate run during a competing local
-build produced +44.32% and is retained as invalid contention evidence, not
-used for the gate. The precise warmed-negative path reports `0 B/op` and
-`0 allocs/op`. These are microbenchmark results only and are not TPS or
-transaction-tail claims.
+The valid idle comparison observed no allocation change (`0 B/op`, `0
+allocs/op`) and a directional latency difference. Five samples do not establish
+a 95% confidence interval, so the prior `-10.16%` geometric-mean value is not
+published as a performance improvement. A separate run during a competing
+local build produced `+44.32%` and remains invalid contention evidence. The
+precise warmed-negative path reports `0 B/op` and `0 allocs/op`. These are
+microbenchmark observations only, not TPS or transaction-tail claims.
+
+## Superseded evidence
+
+The previous report from head `0279990ecb9c779e7b52b5d60666b0338b4445b8` is
+preserved as
+`catalog-invalidation-report-invalid-0279990.json` and explicitly marked
+`integrity=invalidated`. It must not be combined with this report.
 
 ## Decision
 

--- a/docs/rfcs/evidence/27235/catalog-invalidation-report-invalid-0279990.json
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-report-invalid-0279990.json
@@ -1,38 +1,39 @@
 {
-  "schema_version": 3,
-  "matrixone_sha": "ce1b3cc7b93d92f7ded09e820318b0608216bfdd",
+  "schema_version": 2,
+  "matrixone_sha": "8c147612cb0723e1cd90638aa0ab21503a4ab1a2",
   "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-  "window_start_utc": "2026-08-21T11:36:43.108878Z",
-  "window_end_utc": "2026-08-21T11:37:06.047495Z",
-  "integrity": "complete",
+  "window_start_utc": "2026-08-21T09:43:32.650385Z",
+  "window_end_utc": "2026-08-21T09:43:59.030503Z",
+  "integrity": "invalidated",
+  "invalidated_reason": "Superseded after semantic review found RC exact-query drift, missing DeleteTable database identity, global-only scenario evidence, early prepared terminal recording, and unbound measurement SHA.",
   "nodes": [
     {
-      "service_id": "0-cn-26001",
+      "service_id": "0-cn-21001",
       "report": {
         "schema_version": 2,
         "enabled": true,
         "metadata": {
-          "matrixone_sha": "ce1b3cc7b93d92f7ded09e820318b0608216bfdd",
+          "matrixone_sha": "8c147612cb0723e1cd90638aa0ab21503a4ab1a2",
           "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-          "window": "2026-08-21T11:36:43.108878Z/2026-08-21T11:37:06.047495Z",
+          "window": "2026-08-21T09:43:32.650385Z/2026-08-21T09:43:59.030503Z",
           "integrity": "complete"
         },
         "consumers": {
           "prepared_plan": {
-            "checks": 389,
-            "stable_checks": 389,
+            "checks": 268,
+            "stable_checks": 268,
             "inconclusive_checks": 0,
-            "invalidations": 259,
-            "bucket_invalidations": 387,
-            "precise_invalidations": 259,
-            "bucket_false_positives": 128,
+            "invalidations": 255,
+            "bucket_invalidations": 255,
+            "precise_invalidations": 255,
+            "bucket_false_positives": 0,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
           },
           "rc_table_cache": {
-            "checks": 6258,
-            "stable_checks": 6258,
+            "checks": 6534,
+            "stable_checks": 6534,
             "inconclusive_checks": 0,
             "invalidations": 128,
             "bucket_invalidations": 128,
@@ -50,12 +51,12 @@
           "table_upsert": 558
         },
         "prepared_plan_rebuild": {
-          "count": 259,
-          "successes": 256,
-          "errors": 3,
+          "count": 255,
+          "successes": 255,
+          "errors": 0,
           "misses": 0,
           "p50_ns": 250000,
-          "p95_ns": 250000,
+          "p95_ns": 500000,
           "p99_ns": 500000,
           "buckets": [
             {
@@ -76,27 +77,27 @@
             },
             {
               "upper_bound_ns": 50000,
-              "count": 2
-            },
-            {
-              "upper_bound_ns": 100000,
-              "count": 27
-            },
-            {
-              "upper_bound_ns": 250000,
-              "count": 225
-            },
-            {
-              "upper_bound_ns": 500000,
-              "count": 4
-            },
-            {
-              "upper_bound_ns": 1000000,
               "count": 0
             },
             {
-              "upper_bound_ns": 5000000,
+              "upper_bound_ns": 100000,
+              "count": 74
+            },
+            {
+              "upper_bound_ns": 250000,
+              "count": 162
+            },
+            {
+              "upper_bound_ns": 500000,
+              "count": 18
+            },
+            {
+              "upper_bound_ns": 1000000,
               "count": 1
+            },
+            {
+              "upper_bound_ns": 5000000,
+              "count": 0
             },
             {
               "upper_bound_ns": 10000000,
@@ -118,8 +119,8 @@
           "errors": 0,
           "misses": 0,
           "p50_ns": 5000,
-          "p95_ns": 5000,
-          "p99_ns": 5000,
+          "p95_ns": 10000,
+          "p99_ns": 10000,
           "buckets": [
             {
               "upper_bound_ns": 1000,
@@ -127,19 +128,19 @@
             },
             {
               "upper_bound_ns": 5000,
-              "count": 126
+              "count": 110
             },
             {
               "upper_bound_ns": 10000,
-              "count": 0
+              "count": 16
             },
             {
               "upper_bound_ns": 25000,
-              "count": 1
+              "count": 2
             },
             {
               "upper_bound_ns": 50000,
-              "count": 1
+              "count": 0
             },
             {
               "upper_bound_ns": 100000,
@@ -178,27 +179,27 @@
         "shadow": {
           "accounts": 1,
           "database_entries": 9,
-          "table_entries": 171,
+          "table_entries": 178,
           "overflow": false,
-          "estimated_retained_bytes": 12911
+          "estimated_retained_bytes": 13290
         }
       }
     },
     {
-      "service_id": "1-cn-26001",
+      "service_id": "1-cn-21001",
       "report": {
         "schema_version": 2,
         "enabled": true,
         "metadata": {
-          "matrixone_sha": "ce1b3cc7b93d92f7ded09e820318b0608216bfdd",
+          "matrixone_sha": "8c147612cb0723e1cd90638aa0ab21503a4ab1a2",
           "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-          "window": "2026-08-21T11:36:43.108878Z/2026-08-21T11:37:06.047495Z",
+          "window": "2026-08-21T09:43:32.650385Z/2026-08-21T09:43:59.030503Z",
           "integrity": "complete"
         },
         "consumers": {
           "prepared_plan": {
-            "checks": 42,
-            "stable_checks": 42,
+            "checks": 12,
+            "stable_checks": 12,
             "inconclusive_checks": 0,
             "invalidations": 0,
             "bucket_invalidations": 0,
@@ -209,13 +210,13 @@
             "precise_false_negatives": 0
           },
           "rc_table_cache": {
-            "checks": 81162,
-            "stable_checks": 81162,
+            "checks": 80890,
+            "stable_checks": 80890,
             "inconclusive_checks": 0,
             "invalidations": 0,
-            "bucket_invalidations": 19,
+            "bucket_invalidations": 6,
             "precise_invalidations": 0,
-            "bucket_false_positives": 19,
+            "bucket_false_positives": 6,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
@@ -356,9 +357,9 @@
         "shadow": {
           "accounts": 1,
           "database_entries": 9,
-          "table_entries": 171,
+          "table_entries": 178,
           "overflow": false,
-          "estimated_retained_bytes": 12911
+          "estimated_retained_bytes": 13290
         }
       }
     }
@@ -371,20 +372,7 @@
       "ddl_cn": "cn-1",
       "protocol": "binary-and-text-prepare",
       "stable_terminal_samples": 128,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 256,
-        "prepared_stable_checks": 256,
-        "prepared_terminal_outcomes": 255,
-        "rc_checks": 29195,
-        "rc_stable_checks": 29195,
-        "rc_terminal_outcomes": 0,
-        "bucket_false_positives": 0,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     },
     {
       "name": "rc_table_cache_reload",
@@ -393,20 +381,7 @@
       "ddl_cn": "cn-1",
       "protocol": "read-committed",
       "stable_terminal_samples": 128,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 18,
-        "prepared_stable_checks": 18,
-        "prepared_terminal_outcomes": 0,
-        "rc_checks": 28307,
-        "rc_stable_checks": 28307,
-        "rc_terminal_outcomes": 128,
-        "bucket_false_positives": 3,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     },
     {
       "name": "same_account_unrelated_ddl",
@@ -414,139 +389,56 @@
       "consumer_cn": "cn-0",
       "ddl_cn": "cn-1",
       "stable_terminal_samples": 128,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 144,
-        "prepared_stable_checks": 144,
-        "prepared_terminal_outcomes": 0,
-        "rc_checks": 27740,
-        "rc_stable_checks": 27740,
-        "rc_terminal_outcomes": 0,
-        "bucket_false_positives": 144,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     },
     {
       "name": "no_change",
       "ddl_type": "none",
       "consumer_cn": "cn-0",
-      "ddl_cn": "cn-1",
-      "protocol": "binary-prepare",
+      "ddl_cn": "none",
       "stable_terminal_samples": 1,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 1,
-        "prepared_stable_checks": 1,
-        "prepared_terminal_outcomes": 0,
-        "rc_checks": 7,
-        "rc_stable_checks": 7,
-        "rc_terminal_outcomes": 0,
-        "bucket_false_positives": 0,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     },
     {
       "name": "truncate",
       "ddl_type": "truncate",
       "consumer_cn": "cn-0",
       "ddl_cn": "cn-1",
-      "protocol": "binary-prepare",
       "stable_terminal_samples": 1,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 1,
-        "prepared_stable_checks": 1,
-        "prepared_terminal_outcomes": 1,
-        "rc_checks": 117,
-        "rc_stable_checks": 117,
-        "rc_terminal_outcomes": 0,
-        "bucket_false_positives": 0,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     },
     {
       "name": "rename",
       "ddl_type": "rename",
       "consumer_cn": "cn-0",
       "ddl_cn": "cn-1",
-      "protocol": "binary-prepare",
       "stable_terminal_samples": 1,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 1,
-        "prepared_stable_checks": 1,
-        "prepared_terminal_outcomes": 1,
-        "rc_checks": 128,
-        "rc_stable_checks": 128,
-        "rc_terminal_outcomes": 0,
-        "bucket_false_positives": 0,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     },
     {
       "name": "table_drop_recreate",
       "ddl_type": "drop-recreate",
       "consumer_cn": "cn-0",
       "ddl_cn": "cn-1",
-      "protocol": "binary-prepare",
       "stable_terminal_samples": 1,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 1,
-        "prepared_stable_checks": 1,
-        "prepared_terminal_outcomes": 1,
-        "rc_checks": 106,
-        "rc_stable_checks": 106,
-        "rc_terminal_outcomes": 0,
-        "bucket_false_positives": 0,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     },
     {
       "name": "database_drop_recreate",
       "ddl_type": "database-drop-recreate",
       "consumer_cn": "cn-0",
       "ddl_cn": "cn-1",
-      "protocol": "binary-prepare",
       "stable_terminal_samples": 1,
-      "status": "completed",
-      "observation": {
-        "prepared_checks": 1,
-        "prepared_stable_checks": 1,
-        "prepared_terminal_outcomes": 1,
-        "rc_checks": 247,
-        "rc_stable_checks": 247,
-        "rc_terminal_outcomes": 0,
-        "bucket_false_positives": 0,
-        "bucket_false_negatives": 0,
-        "precise_false_positives": 0,
-        "precise_false_negatives": 0,
-        "shadow_overflow": false
-      }
+      "status": "completed"
     }
   ],
   "prepared_plan_rebuild": {
-    "count": 259,
-    "successes": 256,
-    "errors": 3,
+    "count": 255,
+    "successes": 255,
+    "errors": 0,
     "misses": 0,
     "p50_ns": 250000,
-    "p95_ns": 250000,
+    "p95_ns": 500000,
     "p99_ns": 500000,
     "buckets": [
       {
@@ -567,27 +459,27 @@
       },
       {
         "upper_bound_ns": 50000,
-        "count": 2
-      },
-      {
-        "upper_bound_ns": 100000,
-        "count": 27
-      },
-      {
-        "upper_bound_ns": 250000,
-        "count": 225
-      },
-      {
-        "upper_bound_ns": 500000,
-        "count": 4
-      },
-      {
-        "upper_bound_ns": 1000000,
         "count": 0
       },
       {
-        "upper_bound_ns": 5000000,
+        "upper_bound_ns": 100000,
+        "count": 74
+      },
+      {
+        "upper_bound_ns": 250000,
+        "count": 162
+      },
+      {
+        "upper_bound_ns": 500000,
+        "count": 18
+      },
+      {
+        "upper_bound_ns": 1000000,
         "count": 1
+      },
+      {
+        "upper_bound_ns": 5000000,
+        "count": 0
       },
       {
         "upper_bound_ns": 10000000,
@@ -609,8 +501,8 @@
     "errors": 0,
     "misses": 0,
     "p50_ns": 5000,
-    "p95_ns": 5000,
-    "p99_ns": 5000,
+    "p95_ns": 10000,
+    "p99_ns": 10000,
     "buckets": [
       {
         "upper_bound_ns": 1000,
@@ -618,19 +510,19 @@
       },
       {
         "upper_bound_ns": 5000,
-        "count": 126
+        "count": 110
       },
       {
         "upper_bound_ns": 10000,
-        "count": 0
+        "count": 16
       },
       {
         "upper_bound_ns": 25000,
-        "count": 1
+        "count": 2
       },
       {
         "upper_bound_ns": 50000,
-        "count": 1
+        "count": 0
       },
       {
         "upper_bound_ns": 100000,
@@ -668,18 +560,18 @@
   },
   "decision_totals": {
     "prepared_plan.bucket_false_negatives": 0,
-    "prepared_plan.bucket_false_positives": 128,
-    "prepared_plan.checks": 431,
+    "prepared_plan.bucket_false_positives": 0,
+    "prepared_plan.checks": 280,
     "prepared_plan.inconclusive_checks": 0,
     "prepared_plan.precise_false_negatives": 0,
     "prepared_plan.precise_false_positives": 0,
-    "prepared_plan.stable_checks": 431,
+    "prepared_plan.stable_checks": 280,
     "rc_table_cache.bucket_false_negatives": 0,
-    "rc_table_cache.bucket_false_positives": 19,
-    "rc_table_cache.checks": 87420,
+    "rc_table_cache.bucket_false_positives": 6,
+    "rc_table_cache.checks": 87424,
     "rc_table_cache.inconclusive_checks": 0,
     "rc_table_cache.precise_false_negatives": 0,
     "rc_table_cache.precise_false_positives": 0,
-    "rc_table_cache.stable_checks": 87420
+    "rc_table_cache.stable_checks": 87424
   }
 }

--- a/docs/rfcs/evidence/27235/catalog-invalidation-report.json
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-report.json
@@ -1,26 +1,26 @@
 {
   "schema_version": 2,
-  "matrixone_sha": "cd90980a180edb03d3700d6845e875c827a57005",
+  "matrixone_sha": "badab14cb6d05060663fdfb691f3da19975b09c1",
   "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-  "window_start_utc": "2026-08-21T09:30:16.249184Z",
-  "window_end_utc": "2026-08-21T09:30:40.532024Z",
+  "window_start_utc": "2026-08-21T09:40:27.170844Z",
+  "window_end_utc": "2026-08-21T09:40:55.430467Z",
   "integrity": "complete",
   "nodes": [
     {
-      "service_id": "0-cn-17001",
+      "service_id": "0-cn-20001",
       "report": {
         "schema_version": 2,
         "enabled": true,
         "metadata": {
-          "matrixone_sha": "cd90980a180edb03d3700d6845e875c827a57005",
+          "matrixone_sha": "badab14cb6d05060663fdfb691f3da19975b09c1",
           "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-          "window": "2026-08-21T09:30:16.249184Z/2026-08-21T09:30:40.532024Z",
+          "window": "2026-08-21T09:40:27.170844Z/2026-08-21T09:40:55.430467Z",
           "integrity": "complete"
         },
         "consumers": {
           "prepared_plan": {
-            "checks": 256,
-            "stable_checks": 256,
+            "checks": 268,
+            "stable_checks": 268,
             "inconclusive_checks": 0,
             "invalidations": 255,
             "bucket_invalidations": 255,
@@ -31,23 +31,23 @@
             "precise_false_negatives": 0
           },
           "rc_table_cache": {
-            "checks": 6349,
-            "stable_checks": 6349,
+            "checks": 6499,
+            "stable_checks": 6499,
             "inconclusive_checks": 0,
             "invalidations": 128,
-            "bucket_invalidations": 128,
+            "bucket_invalidations": 132,
             "precise_invalidations": 128,
-            "bucket_false_positives": 0,
+            "bucket_false_positives": 4,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
           }
         },
         "events": {
-          "database_delete": 1,
-          "database_insert": 8,
-          "table_delete": 387,
-          "table_upsert": 551
+          "database_delete": 3,
+          "database_insert": 10,
+          "table_delete": 394,
+          "table_upsert": 558
         },
         "prepared_plan_rebuild": {
           "count": 255,
@@ -55,8 +55,8 @@
           "errors": 0,
           "misses": 0,
           "p50_ns": 250000,
-          "p95_ns": 250000,
-          "p99_ns": 500000,
+          "p95_ns": 1000000,
+          "p99_ns": 1000000,
           "buckets": [
             {
               "upper_bound_ns": 1000,
@@ -80,23 +80,23 @@
             },
             {
               "upper_bound_ns": 100000,
-              "count": 85
+              "count": 43
             },
             {
               "upper_bound_ns": 250000,
-              "count": 162
+              "count": 159
             },
             {
               "upper_bound_ns": 500000,
-              "count": 6
+              "count": 37
             },
             {
               "upper_bound_ns": 1000000,
-              "count": 2
+              "count": 14
             },
             {
               "upper_bound_ns": 5000000,
-              "count": 0
+              "count": 2
             },
             {
               "upper_bound_ns": 10000000,
@@ -117,8 +117,8 @@
           "successes": 128,
           "errors": 0,
           "misses": 0,
-          "p50_ns": 5000,
-          "p95_ns": 10000,
+          "p50_ns": 10000,
+          "p95_ns": 25000,
           "p99_ns": 25000,
           "buckets": [
             {
@@ -127,19 +127,19 @@
             },
             {
               "upper_bound_ns": 5000,
-              "count": 117
+              "count": 52
             },
             {
               "upper_bound_ns": 10000,
-              "count": 7
+              "count": 54
             },
             {
               "upper_bound_ns": 25000,
-              "count": 4
+              "count": 20
             },
             {
               "upper_bound_ns": 50000,
-              "count": 0
+              "count": 2
             },
             {
               "upper_bound_ns": 100000,
@@ -177,55 +177,55 @@
         },
         "shadow": {
           "accounts": 1,
-          "database_entries": 8,
-          "table_entries": 170,
+          "database_entries": 9,
+          "table_entries": 178,
           "overflow": false,
-          "estimated_retained_bytes": 12694
+          "estimated_retained_bytes": 13290
         }
       }
     },
     {
-      "service_id": "1-cn-17001",
+      "service_id": "1-cn-20001",
       "report": {
         "schema_version": 2,
         "enabled": true,
         "metadata": {
-          "matrixone_sha": "cd90980a180edb03d3700d6845e875c827a57005",
+          "matrixone_sha": "badab14cb6d05060663fdfb691f3da19975b09c1",
           "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-          "window": "2026-08-21T09:30:16.249184Z/2026-08-21T09:30:40.532024Z",
+          "window": "2026-08-21T09:40:27.170844Z/2026-08-21T09:40:55.430467Z",
           "integrity": "complete"
         },
         "consumers": {
           "prepared_plan": {
-            "checks": 24,
-            "stable_checks": 24,
+            "checks": 20,
+            "stable_checks": 20,
             "inconclusive_checks": 0,
             "invalidations": 0,
-            "bucket_invalidations": 0,
+            "bucket_invalidations": 4,
             "precise_invalidations": 0,
-            "bucket_false_positives": 0,
+            "bucket_false_positives": 4,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
           },
           "rc_table_cache": {
-            "checks": 80147,
-            "stable_checks": 80147,
+            "checks": 80993,
+            "stable_checks": 80993,
             "inconclusive_checks": 0,
             "invalidations": 0,
-            "bucket_invalidations": 13,
+            "bucket_invalidations": 28,
             "precise_invalidations": 0,
-            "bucket_false_positives": 13,
+            "bucket_false_positives": 28,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
           }
         },
         "events": {
-          "database_delete": 1,
-          "database_insert": 8,
-          "table_delete": 387,
-          "table_upsert": 551
+          "database_delete": 3,
+          "database_insert": 10,
+          "table_delete": 394,
+          "table_upsert": 558
         },
         "prepared_plan_rebuild": {
           "count": 0,
@@ -355,10 +355,10 @@
         },
         "shadow": {
           "accounts": 1,
-          "database_entries": 8,
-          "table_entries": 170,
+          "database_entries": 9,
+          "table_entries": 178,
           "overflow": false,
-          "estimated_retained_bytes": 12694
+          "estimated_retained_bytes": 13290
         }
       }
     }
@@ -389,6 +389,46 @@
       "ddl_cn": "cn-1",
       "stable_terminal_samples": 128,
       "status": "completed"
+    },
+    {
+      "name": "no_change",
+      "ddl_type": "none",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "none",
+      "stable_terminal_samples": 1,
+      "status": "completed"
+    },
+    {
+      "name": "truncate",
+      "ddl_type": "truncate",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "cn-1",
+      "stable_terminal_samples": 1,
+      "status": "completed"
+    },
+    {
+      "name": "rename",
+      "ddl_type": "rename",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "cn-1",
+      "stable_terminal_samples": 1,
+      "status": "completed"
+    },
+    {
+      "name": "table_drop_recreate",
+      "ddl_type": "drop-recreate",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "cn-1",
+      "stable_terminal_samples": 1,
+      "status": "completed"
+    },
+    {
+      "name": "database_drop_recreate",
+      "ddl_type": "database-drop-recreate",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "cn-1",
+      "stable_terminal_samples": 1,
+      "status": "completed"
     }
   ],
   "prepared_plan_rebuild": {
@@ -397,8 +437,8 @@
     "errors": 0,
     "misses": 0,
     "p50_ns": 250000,
-    "p95_ns": 250000,
-    "p99_ns": 500000,
+    "p95_ns": 1000000,
+    "p99_ns": 1000000,
     "buckets": [
       {
         "upper_bound_ns": 1000,
@@ -422,23 +462,23 @@
       },
       {
         "upper_bound_ns": 100000,
-        "count": 85
+        "count": 43
       },
       {
         "upper_bound_ns": 250000,
-        "count": 162
+        "count": 159
       },
       {
         "upper_bound_ns": 500000,
-        "count": 6
+        "count": 37
       },
       {
         "upper_bound_ns": 1000000,
-        "count": 2
+        "count": 14
       },
       {
         "upper_bound_ns": 5000000,
-        "count": 0
+        "count": 2
       },
       {
         "upper_bound_ns": 10000000,
@@ -459,8 +499,8 @@
     "successes": 128,
     "errors": 0,
     "misses": 0,
-    "p50_ns": 5000,
-    "p95_ns": 10000,
+    "p50_ns": 10000,
+    "p95_ns": 25000,
     "p99_ns": 25000,
     "buckets": [
       {
@@ -469,19 +509,19 @@
       },
       {
         "upper_bound_ns": 5000,
-        "count": 117
+        "count": 52
       },
       {
         "upper_bound_ns": 10000,
-        "count": 7
+        "count": 54
       },
       {
         "upper_bound_ns": 25000,
-        "count": 4
+        "count": 20
       },
       {
         "upper_bound_ns": 50000,
-        "count": 0
+        "count": 2
       },
       {
         "upper_bound_ns": 100000,
@@ -519,18 +559,18 @@
   },
   "decision_totals": {
     "prepared_plan.bucket_false_negatives": 0,
-    "prepared_plan.bucket_false_positives": 0,
-    "prepared_plan.checks": 280,
+    "prepared_plan.bucket_false_positives": 4,
+    "prepared_plan.checks": 288,
     "prepared_plan.inconclusive_checks": 0,
     "prepared_plan.precise_false_negatives": 0,
     "prepared_plan.precise_false_positives": 0,
-    "prepared_plan.stable_checks": 280,
+    "prepared_plan.stable_checks": 288,
     "rc_table_cache.bucket_false_negatives": 0,
-    "rc_table_cache.bucket_false_positives": 13,
-    "rc_table_cache.checks": 86496,
+    "rc_table_cache.bucket_false_positives": 32,
+    "rc_table_cache.checks": 87492,
     "rc_table_cache.inconclusive_checks": 0,
     "rc_table_cache.precise_false_negatives": 0,
     "rc_table_cache.precise_false_positives": 0,
-    "rc_table_cache.stable_checks": 86496
+    "rc_table_cache.stable_checks": 87492
   }
 }

--- a/docs/rfcs/evidence/27235/catalog-invalidation-report.json
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-report.json
@@ -1,0 +1,536 @@
+{
+  "schema_version": 2,
+  "matrixone_sha": "cd90980a180edb03d3700d6845e875c827a57005",
+  "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
+  "window_start_utc": "2026-08-21T09:30:16.249184Z",
+  "window_end_utc": "2026-08-21T09:30:40.532024Z",
+  "integrity": "complete",
+  "nodes": [
+    {
+      "service_id": "0-cn-17001",
+      "report": {
+        "schema_version": 2,
+        "enabled": true,
+        "metadata": {
+          "matrixone_sha": "cd90980a180edb03d3700d6845e875c827a57005",
+          "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
+          "window": "2026-08-21T09:30:16.249184Z/2026-08-21T09:30:40.532024Z",
+          "integrity": "complete"
+        },
+        "consumers": {
+          "prepared_plan": {
+            "checks": 256,
+            "stable_checks": 256,
+            "inconclusive_checks": 0,
+            "invalidations": 255,
+            "bucket_invalidations": 255,
+            "precise_invalidations": 255,
+            "bucket_false_positives": 0,
+            "bucket_false_negatives": 0,
+            "precise_false_positives": 0,
+            "precise_false_negatives": 0
+          },
+          "rc_table_cache": {
+            "checks": 6349,
+            "stable_checks": 6349,
+            "inconclusive_checks": 0,
+            "invalidations": 128,
+            "bucket_invalidations": 128,
+            "precise_invalidations": 128,
+            "bucket_false_positives": 0,
+            "bucket_false_negatives": 0,
+            "precise_false_positives": 0,
+            "precise_false_negatives": 0
+          }
+        },
+        "events": {
+          "database_delete": 1,
+          "database_insert": 8,
+          "table_delete": 387,
+          "table_upsert": 551
+        },
+        "prepared_plan_rebuild": {
+          "count": 255,
+          "successes": 255,
+          "errors": 0,
+          "misses": 0,
+          "p50_ns": 250000,
+          "p95_ns": 250000,
+          "p99_ns": 500000,
+          "buckets": [
+            {
+              "upper_bound_ns": 1000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 5000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 10000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 25000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 50000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000,
+              "count": 85
+            },
+            {
+              "upper_bound_ns": 250000,
+              "count": 162
+            },
+            {
+              "upper_bound_ns": 500000,
+              "count": 6
+            },
+            {
+              "upper_bound_ns": 1000000,
+              "count": 2
+            },
+            {
+              "upper_bound_ns": 5000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 10000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": -1,
+              "count": 0
+            }
+          ]
+        },
+        "rc_table_cache_reload": {
+          "count": 128,
+          "successes": 128,
+          "errors": 0,
+          "misses": 0,
+          "p50_ns": 5000,
+          "p95_ns": 10000,
+          "p99_ns": 25000,
+          "buckets": [
+            {
+              "upper_bound_ns": 1000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 5000,
+              "count": 117
+            },
+            {
+              "upper_bound_ns": 10000,
+              "count": 7
+            },
+            {
+              "upper_bound_ns": 25000,
+              "count": 4
+            },
+            {
+              "upper_bound_ns": 50000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 250000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 500000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 1000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 5000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 10000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": -1,
+              "count": 0
+            }
+          ]
+        },
+        "shadow": {
+          "accounts": 1,
+          "database_entries": 8,
+          "table_entries": 170,
+          "overflow": false,
+          "estimated_retained_bytes": 12694
+        }
+      }
+    },
+    {
+      "service_id": "1-cn-17001",
+      "report": {
+        "schema_version": 2,
+        "enabled": true,
+        "metadata": {
+          "matrixone_sha": "cd90980a180edb03d3700d6845e875c827a57005",
+          "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
+          "window": "2026-08-21T09:30:16.249184Z/2026-08-21T09:30:40.532024Z",
+          "integrity": "complete"
+        },
+        "consumers": {
+          "prepared_plan": {
+            "checks": 24,
+            "stable_checks": 24,
+            "inconclusive_checks": 0,
+            "invalidations": 0,
+            "bucket_invalidations": 0,
+            "precise_invalidations": 0,
+            "bucket_false_positives": 0,
+            "bucket_false_negatives": 0,
+            "precise_false_positives": 0,
+            "precise_false_negatives": 0
+          },
+          "rc_table_cache": {
+            "checks": 80147,
+            "stable_checks": 80147,
+            "inconclusive_checks": 0,
+            "invalidations": 0,
+            "bucket_invalidations": 13,
+            "precise_invalidations": 0,
+            "bucket_false_positives": 13,
+            "bucket_false_negatives": 0,
+            "precise_false_positives": 0,
+            "precise_false_negatives": 0
+          }
+        },
+        "events": {
+          "database_delete": 1,
+          "database_insert": 8,
+          "table_delete": 387,
+          "table_upsert": 551
+        },
+        "prepared_plan_rebuild": {
+          "count": 0,
+          "successes": 0,
+          "errors": 0,
+          "misses": 0,
+          "p50_ns": 0,
+          "p95_ns": 0,
+          "p99_ns": 0,
+          "buckets": [
+            {
+              "upper_bound_ns": 1000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 5000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 10000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 25000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 50000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 250000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 500000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 1000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 5000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 10000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": -1,
+              "count": 0
+            }
+          ]
+        },
+        "rc_table_cache_reload": {
+          "count": 0,
+          "successes": 0,
+          "errors": 0,
+          "misses": 0,
+          "p50_ns": 0,
+          "p95_ns": 0,
+          "p99_ns": 0,
+          "buckets": [
+            {
+              "upper_bound_ns": 1000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 5000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 10000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 25000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 50000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 250000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 500000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 1000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 5000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 10000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": 100000000,
+              "count": 0
+            },
+            {
+              "upper_bound_ns": -1,
+              "count": 0
+            }
+          ]
+        },
+        "shadow": {
+          "accounts": 1,
+          "database_entries": 8,
+          "table_entries": 170,
+          "overflow": false,
+          "estimated_retained_bytes": 12694
+        }
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "prepared_schema_rebuild",
+      "ddl_type": "alter",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "cn-1",
+      "protocol": "binary-and-text-prepare",
+      "stable_terminal_samples": 128,
+      "status": "completed"
+    },
+    {
+      "name": "rc_table_cache_reload",
+      "ddl_type": "alter",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "cn-1",
+      "protocol": "read-committed",
+      "stable_terminal_samples": 128,
+      "status": "completed"
+    },
+    {
+      "name": "same_account_unrelated_ddl",
+      "ddl_type": "alter-unrelated",
+      "consumer_cn": "cn-0",
+      "ddl_cn": "cn-1",
+      "stable_terminal_samples": 128,
+      "status": "completed"
+    }
+  ],
+  "prepared_plan_rebuild": {
+    "count": 255,
+    "successes": 255,
+    "errors": 0,
+    "misses": 0,
+    "p50_ns": 250000,
+    "p95_ns": 250000,
+    "p99_ns": 500000,
+    "buckets": [
+      {
+        "upper_bound_ns": 1000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 5000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 10000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 25000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 50000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 100000,
+        "count": 85
+      },
+      {
+        "upper_bound_ns": 250000,
+        "count": 162
+      },
+      {
+        "upper_bound_ns": 500000,
+        "count": 6
+      },
+      {
+        "upper_bound_ns": 1000000,
+        "count": 2
+      },
+      {
+        "upper_bound_ns": 5000000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 10000000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 100000000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": -1,
+        "count": 0
+      }
+    ]
+  },
+  "rc_table_cache_reload": {
+    "count": 128,
+    "successes": 128,
+    "errors": 0,
+    "misses": 0,
+    "p50_ns": 5000,
+    "p95_ns": 10000,
+    "p99_ns": 25000,
+    "buckets": [
+      {
+        "upper_bound_ns": 1000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 5000,
+        "count": 117
+      },
+      {
+        "upper_bound_ns": 10000,
+        "count": 7
+      },
+      {
+        "upper_bound_ns": 25000,
+        "count": 4
+      },
+      {
+        "upper_bound_ns": 50000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 100000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 250000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 500000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 1000000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 5000000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 10000000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": 100000000,
+        "count": 0
+      },
+      {
+        "upper_bound_ns": -1,
+        "count": 0
+      }
+    ]
+  },
+  "decision_totals": {
+    "prepared_plan.bucket_false_negatives": 0,
+    "prepared_plan.bucket_false_positives": 0,
+    "prepared_plan.checks": 280,
+    "prepared_plan.inconclusive_checks": 0,
+    "prepared_plan.precise_false_negatives": 0,
+    "prepared_plan.precise_false_positives": 0,
+    "prepared_plan.stable_checks": 280,
+    "rc_table_cache.bucket_false_negatives": 0,
+    "rc_table_cache.bucket_false_positives": 13,
+    "rc_table_cache.checks": 86496,
+    "rc_table_cache.inconclusive_checks": 0,
+    "rc_table_cache.precise_false_negatives": 0,
+    "rc_table_cache.precise_false_positives": 0,
+    "rc_table_cache.stable_checks": 86496
+  }
+}

--- a/docs/rfcs/evidence/27235/catalog-invalidation-report.json
+++ b/docs/rfcs/evidence/27235/catalog-invalidation-report.json
@@ -1,20 +1,20 @@
 {
   "schema_version": 2,
-  "matrixone_sha": "badab14cb6d05060663fdfb691f3da19975b09c1",
+  "matrixone_sha": "8c147612cb0723e1cd90638aa0ab21503a4ab1a2",
   "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-  "window_start_utc": "2026-08-21T09:40:27.170844Z",
-  "window_end_utc": "2026-08-21T09:40:55.430467Z",
+  "window_start_utc": "2026-08-21T09:43:32.650385Z",
+  "window_end_utc": "2026-08-21T09:43:59.030503Z",
   "integrity": "complete",
   "nodes": [
     {
-      "service_id": "0-cn-20001",
+      "service_id": "0-cn-21001",
       "report": {
         "schema_version": 2,
         "enabled": true,
         "metadata": {
-          "matrixone_sha": "badab14cb6d05060663fdfb691f3da19975b09c1",
+          "matrixone_sha": "8c147612cb0723e1cd90638aa0ab21503a4ab1a2",
           "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-          "window": "2026-08-21T09:40:27.170844Z/2026-08-21T09:40:55.430467Z",
+          "window": "2026-08-21T09:43:32.650385Z/2026-08-21T09:43:59.030503Z",
           "integrity": "complete"
         },
         "consumers": {
@@ -31,13 +31,13 @@
             "precise_false_negatives": 0
           },
           "rc_table_cache": {
-            "checks": 6499,
-            "stable_checks": 6499,
+            "checks": 6534,
+            "stable_checks": 6534,
             "inconclusive_checks": 0,
             "invalidations": 128,
-            "bucket_invalidations": 132,
+            "bucket_invalidations": 128,
             "precise_invalidations": 128,
-            "bucket_false_positives": 4,
+            "bucket_false_positives": 0,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
@@ -55,8 +55,8 @@
           "errors": 0,
           "misses": 0,
           "p50_ns": 250000,
-          "p95_ns": 1000000,
-          "p99_ns": 1000000,
+          "p95_ns": 500000,
+          "p99_ns": 500000,
           "buckets": [
             {
               "upper_bound_ns": 1000,
@@ -80,23 +80,23 @@
             },
             {
               "upper_bound_ns": 100000,
-              "count": 43
+              "count": 74
             },
             {
               "upper_bound_ns": 250000,
-              "count": 159
+              "count": 162
             },
             {
               "upper_bound_ns": 500000,
-              "count": 37
+              "count": 18
             },
             {
               "upper_bound_ns": 1000000,
-              "count": 14
+              "count": 1
             },
             {
               "upper_bound_ns": 5000000,
-              "count": 2
+              "count": 0
             },
             {
               "upper_bound_ns": 10000000,
@@ -117,9 +117,9 @@
           "successes": 128,
           "errors": 0,
           "misses": 0,
-          "p50_ns": 10000,
-          "p95_ns": 25000,
-          "p99_ns": 25000,
+          "p50_ns": 5000,
+          "p95_ns": 10000,
+          "p99_ns": 10000,
           "buckets": [
             {
               "upper_bound_ns": 1000,
@@ -127,19 +127,19 @@
             },
             {
               "upper_bound_ns": 5000,
-              "count": 52
+              "count": 110
             },
             {
               "upper_bound_ns": 10000,
-              "count": 54
+              "count": 16
             },
             {
               "upper_bound_ns": 25000,
-              "count": 20
+              "count": 2
             },
             {
               "upper_bound_ns": 50000,
-              "count": 2
+              "count": 0
             },
             {
               "upper_bound_ns": 100000,
@@ -185,37 +185,37 @@
       }
     },
     {
-      "service_id": "1-cn-20001",
+      "service_id": "1-cn-21001",
       "report": {
         "schema_version": 2,
         "enabled": true,
         "metadata": {
-          "matrixone_sha": "badab14cb6d05060663fdfb691f3da19975b09c1",
+          "matrixone_sha": "8c147612cb0723e1cd90638aa0ab21503a4ab1a2",
           "config": "pkg/embed:1log-1tn-2cn;exact-authoritative",
-          "window": "2026-08-21T09:40:27.170844Z/2026-08-21T09:40:55.430467Z",
+          "window": "2026-08-21T09:43:32.650385Z/2026-08-21T09:43:59.030503Z",
           "integrity": "complete"
         },
         "consumers": {
           "prepared_plan": {
-            "checks": 20,
-            "stable_checks": 20,
+            "checks": 12,
+            "stable_checks": 12,
             "inconclusive_checks": 0,
             "invalidations": 0,
-            "bucket_invalidations": 4,
+            "bucket_invalidations": 0,
             "precise_invalidations": 0,
-            "bucket_false_positives": 4,
+            "bucket_false_positives": 0,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
           },
           "rc_table_cache": {
-            "checks": 80993,
-            "stable_checks": 80993,
+            "checks": 80890,
+            "stable_checks": 80890,
             "inconclusive_checks": 0,
             "invalidations": 0,
-            "bucket_invalidations": 28,
+            "bucket_invalidations": 6,
             "precise_invalidations": 0,
-            "bucket_false_positives": 28,
+            "bucket_false_positives": 6,
             "bucket_false_negatives": 0,
             "precise_false_positives": 0,
             "precise_false_negatives": 0
@@ -437,8 +437,8 @@
     "errors": 0,
     "misses": 0,
     "p50_ns": 250000,
-    "p95_ns": 1000000,
-    "p99_ns": 1000000,
+    "p95_ns": 500000,
+    "p99_ns": 500000,
     "buckets": [
       {
         "upper_bound_ns": 1000,
@@ -462,23 +462,23 @@
       },
       {
         "upper_bound_ns": 100000,
-        "count": 43
+        "count": 74
       },
       {
         "upper_bound_ns": 250000,
-        "count": 159
+        "count": 162
       },
       {
         "upper_bound_ns": 500000,
-        "count": 37
+        "count": 18
       },
       {
         "upper_bound_ns": 1000000,
-        "count": 14
+        "count": 1
       },
       {
         "upper_bound_ns": 5000000,
-        "count": 2
+        "count": 0
       },
       {
         "upper_bound_ns": 10000000,
@@ -499,9 +499,9 @@
     "successes": 128,
     "errors": 0,
     "misses": 0,
-    "p50_ns": 10000,
-    "p95_ns": 25000,
-    "p99_ns": 25000,
+    "p50_ns": 5000,
+    "p95_ns": 10000,
+    "p99_ns": 10000,
     "buckets": [
       {
         "upper_bound_ns": 1000,
@@ -509,19 +509,19 @@
       },
       {
         "upper_bound_ns": 5000,
-        "count": 52
+        "count": 110
       },
       {
         "upper_bound_ns": 10000,
-        "count": 54
+        "count": 16
       },
       {
         "upper_bound_ns": 25000,
-        "count": 20
+        "count": 2
       },
       {
         "upper_bound_ns": 50000,
-        "count": 2
+        "count": 0
       },
       {
         "upper_bound_ns": 100000,
@@ -559,18 +559,18 @@
   },
   "decision_totals": {
     "prepared_plan.bucket_false_negatives": 0,
-    "prepared_plan.bucket_false_positives": 4,
-    "prepared_plan.checks": 288,
+    "prepared_plan.bucket_false_positives": 0,
+    "prepared_plan.checks": 280,
     "prepared_plan.inconclusive_checks": 0,
     "prepared_plan.precise_false_negatives": 0,
     "prepared_plan.precise_false_positives": 0,
-    "prepared_plan.stable_checks": 288,
+    "prepared_plan.stable_checks": 280,
     "rc_table_cache.bucket_false_negatives": 0,
-    "rc_table_cache.bucket_false_positives": 32,
-    "rc_table_cache.checks": 87492,
+    "rc_table_cache.bucket_false_positives": 6,
+    "rc_table_cache.checks": 87424,
     "rc_table_cache.inconclusive_checks": 0,
     "rc_table_cache.precise_false_negatives": 0,
     "rc_table_cache.precise_false_positives": 0,
-    "rc_table_cache.stable_checks": 87492
+    "rc_table_cache.stable_checks": 87424
   }
 }

--- a/pkg/embed/catalog_invalidation_attribution_test.go
+++ b/pkg/embed/catalog_invalidation_attribution_test.go
@@ -168,6 +168,9 @@ func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {
 	if err := runUnrelatedDDLAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
 		t.Fatal(err)
 	}
+	if err := runLifecycleAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+		t.Fatal(err)
+	}
 
 	// Snapshot and validate before the deferred writer marks the report complete.
 	nodes = snapshotCatalogAttributionNodes(t, cluster, sha, started, time.Now().UTC(), "complete")
@@ -192,9 +195,11 @@ func resetCatalogAttributionFixture(ctx context.Context, db *sql.DB, name string
 		"CREATE TABLE " + name + ".prepared_table (id INT PRIMARY KEY, payload INT)",
 		"CREATE TABLE " + name + ".rc_table (id INT PRIMARY KEY, payload INT)",
 		"CREATE TABLE " + name + ".unrelated_table (id INT PRIMARY KEY, payload INT)",
+		"CREATE TABLE " + name + ".lifecycle_table (id INT PRIMARY KEY, payload INT)",
 		"INSERT INTO " + name + ".prepared_table VALUES (1, 1)",
 		"INSERT INTO " + name + ".rc_table VALUES (1, 1)",
 		"INSERT INTO " + name + ".unrelated_table VALUES (1, 1)",
+		"INSERT INTO " + name + ".lifecycle_table VALUES (1, 1)",
 	} {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("fixture %q: %w", stmt, err)
@@ -301,6 +306,107 @@ func runUnrelatedDDLAttribution(ctx context.Context, db0, db1 *sql.DB, database 
 	return nil
 }
 
+func runLifecycleAttribution(ctx context.Context, db0, db1 *sql.DB, database string, scenarios *[]catalogAttributionScenario) error {
+	base := database + ".lifecycle_table"
+	if err := waitTableAvailable(ctx, db0, base); err != nil {
+		return fmt.Errorf("no-change observation: %w", err)
+	}
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "no_change", DDLType: "none", ConsumerCN: "cn-0", DDLCN: "none", Samples: 1, Status: "completed",
+	})
+
+	if _, err := db1.ExecContext(ctx, "TRUNCATE TABLE "+base); err != nil {
+		return fmt.Errorf("truncate: %w", err)
+	}
+	if err := waitTableAvailable(ctx, db0, base); err != nil {
+		return fmt.Errorf("truncate observation: %w", err)
+	}
+	if _, err := db1.ExecContext(ctx, "INSERT INTO "+base+" VALUES (1, 2)"); err != nil {
+		return fmt.Errorf("restore after truncate: %w", err)
+	}
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "truncate", DDLType: "truncate", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
+	})
+
+	rename := database + ".lifecycle_renamed"
+	if _, err := db1.ExecContext(ctx, "ALTER TABLE "+base+" RENAME TO "+rename); err != nil {
+		return fmt.Errorf("rename forward: %w", err)
+	}
+	if err := waitTableAvailable(ctx, db0, rename); err != nil {
+		return fmt.Errorf("rename forward observation: %w", err)
+	}
+	if _, err := db1.ExecContext(ctx, "ALTER TABLE "+rename+" RENAME TO "+base); err != nil {
+		return fmt.Errorf("rename backward: %w", err)
+	}
+	if err := waitTableAvailable(ctx, db0, base); err != nil {
+		return fmt.Errorf("rename backward observation: %w", err)
+	}
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "rename", DDLType: "rename", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
+	})
+
+	if _, err := db1.ExecContext(ctx, "DROP TABLE "+base); err != nil {
+		return fmt.Errorf("drop table: %w", err)
+	}
+	if _, err := db1.ExecContext(ctx, "CREATE TABLE "+base+" (id INT PRIMARY KEY, payload INT)"); err != nil {
+		return fmt.Errorf("recreate table: %w", err)
+	}
+	if err := waitTableAvailable(ctx, db0, base); err != nil {
+		return fmt.Errorf("recreate table observation: %w", err)
+	}
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "table_drop_recreate", DDLType: "drop-recreate", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
+	})
+
+	databaseRecreated := database + "_recreated"
+	if _, err := db1.ExecContext(ctx, "CREATE DATABASE "+databaseRecreated); err != nil {
+		return fmt.Errorf("create recreation database: %w", err)
+	}
+	defer func() { _, _ = db1.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+databaseRecreated) }()
+	if _, err := db1.ExecContext(ctx, "CREATE TABLE "+databaseRecreated+".lifecycle_table (id INT PRIMARY KEY, payload INT)"); err != nil {
+		return fmt.Errorf("create recreation table: %w", err)
+	}
+	if _, err := db1.ExecContext(ctx, "DROP DATABASE "+databaseRecreated); err != nil {
+		return fmt.Errorf("drop recreation database: %w", err)
+	}
+	if _, err := db1.ExecContext(ctx, "CREATE DATABASE "+databaseRecreated); err != nil {
+		return fmt.Errorf("recreate database: %w", err)
+	}
+	if _, err := db1.ExecContext(ctx, "CREATE TABLE "+databaseRecreated+".lifecycle_table (id INT PRIMARY KEY, payload INT)"); err != nil {
+		return fmt.Errorf("recreate database table: %w", err)
+	}
+	if err := waitTableAvailable(ctx, db0, databaseRecreated+".lifecycle_table"); err != nil {
+		return fmt.Errorf("recreate database observation: %w", err)
+	}
+	_, _ = db1.ExecContext(ctx, "DROP DATABASE IF EXISTS "+databaseRecreated)
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "database_drop_recreate", DDLType: "database-drop-recreate", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
+	})
+	return nil
+}
+
+func waitTableAvailable(ctx context.Context, db *sql.DB, qualifiedTable string) error {
+	deadline, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	query := "SELECT COUNT(*) FROM " + qualifiedTable
+	for {
+		var count int
+		err := db.QueryRowContext(deadline, query).Scan(&count)
+		if err == nil {
+			return nil
+		}
+		if deadline.Err() != nil {
+			return err
+		}
+		timer := time.NewTimer(20 * time.Millisecond)
+		select {
+		case <-deadline.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
+	}
+}
+
 func waitCatalogObservation(ctx context.Context, db *sql.DB, database, column string) error {
 	deadline, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -372,9 +478,26 @@ func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios
 	if len(nodes) != 2 {
 		return fmt.Errorf("expected two CN reports, got %d", len(nodes))
 	}
+	required := map[string]bool{
+		"no_change": false, "truncate": false, "rename": false,
+		"table_drop_recreate": false, "database_drop_recreate": false,
+		"prepared_schema_rebuild": false, "rc_table_cache_reload": false,
+		"same_account_unrelated_ddl": false,
+	}
 	for _, scenario := range scenarios {
-		if scenario.Status != "completed" || scenario.Samples < catalogAttributionSamples {
-			return fmt.Errorf("scenario %s has insufficient stable samples", scenario.Name)
+		if scenario.Status != "completed" || scenario.Samples < 1 {
+			return fmt.Errorf("scenario %s is incomplete", scenario.Name)
+		}
+		if _, ok := required[scenario.Name]; !ok {
+			return fmt.Errorf("unexpected scenario %s", scenario.Name)
+		}
+		if scenario.Samples >= catalogAttributionSamples || scenario.Samples == 1 {
+			required[scenario.Name] = true
+		}
+	}
+	for name, seen := range required {
+		if !seen {
+			return fmt.Errorf("required scenario %s is missing", name)
 		}
 	}
 	var prepared, rc uint64

--- a/pkg/embed/catalog_invalidation_attribution_test.go
+++ b/pkg/embed/catalog_invalidation_attribution_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
@@ -102,19 +103,60 @@ type catalogAttributionReportV2 struct {
 func requireCatalogAttributionBuild(t *testing.T, expected string) {
 	t.Helper()
 	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		t.Fatal("catalog attribution requires VCS-attested build information")
+	if ok {
+		settings := make(map[string]string, len(info.Settings))
+		for _, setting := range info.Settings {
+			settings[setting.Key] = setting.Value
+		}
+		if revision := settings["vcs.revision"]; revision != "" {
+			if revision != expected {
+				t.Fatalf("measurement SHA %s does not match executed build revision %q", expected, revision)
+			}
+			if settings["vcs.modified"] == "true" {
+				t.Fatal("catalog attribution requires a clean VCS-attested build")
+			}
+			return
+		}
 	}
-	settings := make(map[string]string, len(info.Settings))
-	for _, setting := range info.Settings {
-		settings[setting.Key] = setting.Value
+	// Some CGo test-link modes omit Go's VCS build settings. In that mode use
+	// the exact clean checkout that owns the running test package as the
+	// equivalent attestation, rejecting both ref drift and dirty source.
+	root := findCatalogAttributionRepoRoot(t)
+	revision, err := outputCatalogAttributionGit(root, "rev-parse", "HEAD")
+	if err != nil || revision != expected {
+		t.Fatalf("measurement SHA %s does not match clean checkout revision %q", expected, revision)
 	}
-	if settings["vcs.revision"] != expected {
-		t.Fatalf("measurement SHA %s does not match executed build revision %q", expected, settings["vcs.revision"])
+	status, err := outputCatalogAttributionGit(root, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		t.Fatalf("cannot verify clean measurement checkout: %v", err)
 	}
-	if settings["vcs.modified"] == "true" {
-		t.Fatal("catalog attribution requires a clean VCS-attested build")
+	if status != "" {
+		t.Fatalf("catalog attribution requires a clean checkout, got %q", status)
 	}
+}
+
+func findCatalogAttributionRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get measurement working directory: %v", err)
+	}
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil && (info.IsDir() || info.Mode().IsRegular()) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("measurement checkout root is not discoverable")
+		}
+		dir = parent
+	}
+}
+
+func outputCatalogAttributionGit(root string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := cmd.Output()
+	return strings.TrimSpace(string(output)), err
 }
 
 func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {

--- a/pkg/embed/catalog_invalidation_attribution_test.go
+++ b/pkg/embed/catalog_invalidation_attribution_test.go
@@ -1,0 +1,475 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embed
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/cnservice"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	catalogAttributionEnabledEnv = "MO_CATALOG_INVALIDATION_ATTRIBUTION"
+	catalogAttributionReportEnv  = "MO_CATALOG_INVALIDATION_REPORT_DIR"
+	catalogAttributionSHAEnv     = "MO_CATALOG_INVALIDATION_MATRIXONE_SHA"
+	catalogAttributionSamples    = 128
+)
+
+type catalogAttributionScenario struct {
+	Name       string `json:"name"`
+	DDLType    string `json:"ddl_type"`
+	ConsumerCN string `json:"consumer_cn"`
+	DDLCN      string `json:"ddl_cn"`
+	Protocol   string `json:"protocol,omitempty"`
+	Samples    int    `json:"stable_terminal_samples"`
+	Status     string `json:"status"`
+}
+
+type catalogAttributionNode struct {
+	ServiceID string                          `json:"service_id"`
+	Report    cache.CatalogInvalidationReport `json:"report"`
+}
+
+type catalogAttributionLatency struct {
+	Count   uint64                                   `json:"count"`
+	Success uint64                                   `json:"successes"`
+	Error   uint64                                   `json:"errors"`
+	Miss    uint64                                   `json:"misses"`
+	P50NS   int64                                    `json:"p50_ns"`
+	P95NS   int64                                    `json:"p95_ns"`
+	P99NS   int64                                    `json:"p99_ns"`
+	Buckets []cache.CatalogInvalidationLatencyBucket `json:"buckets"`
+}
+
+type catalogAttributionReportV2 struct {
+	SchemaVersion  int                          `json:"schema_version"`
+	MatrixONESHA   string                       `json:"matrixone_sha"`
+	Config         string                       `json:"config"`
+	WindowStart    string                       `json:"window_start_utc"`
+	WindowEnd      string                       `json:"window_end_utc"`
+	Integrity      string                       `json:"integrity"`
+	Nodes          []catalogAttributionNode     `json:"nodes"`
+	Scenarios      []catalogAttributionScenario `json:"scenarios"`
+	Prepared       catalogAttributionLatency    `json:"prepared_plan_rebuild"`
+	RC             catalogAttributionLatency    `json:"rc_table_cache_reload"`
+	DecisionTotals map[string]uint64            `json:"decision_totals"`
+}
+
+func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {
+	if os.Getenv(catalogAttributionEnabledEnv) != "1" {
+		t.Skip("opt-in catalog invalidation attribution workload")
+	}
+	reportDir := os.Getenv(catalogAttributionReportEnv)
+	if reportDir == "" || !filepath.IsAbs(reportDir) {
+		t.Fatal("MO_CATALOG_INVALIDATION_REPORT_DIR must be an absolute path")
+	}
+	sha := os.Getenv(catalogAttributionSHAEnv)
+	if len(sha) != 40 || strings.Trim(sha, "0123456789abcdefABCDEF") != "" {
+		t.Fatal("MO_CATALOG_INVALIDATION_MATRIXONE_SHA must be a complete 40-byte hexadecimal SHA")
+	}
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	started := time.Now().UTC()
+	var (
+		cluster   Cluster
+		nodes     []catalogAttributionNode
+		scenarios []catalogAttributionScenario
+		passed    bool
+		closeOnce sync.Once
+	)
+	defer func() {
+		windowEnd := time.Now().UTC()
+		nodeIntegrity := "incomplete"
+		if passed {
+			nodeIntegrity = "complete"
+		}
+		if cluster != nil {
+			nodes = snapshotCatalogAttributionNodes(t, cluster, sha, started, windowEnd, nodeIntegrity)
+			closeOnce.Do(func() { _ = cluster.Close() })
+		}
+		integrity := "incomplete"
+		if passed {
+			integrity = "complete"
+		}
+		report := catalogAttributionReportV2{
+			SchemaVersion:  2,
+			MatrixONESHA:   sha,
+			Config:         "pkg/embed:1log-1tn-2cn;exact-authoritative",
+			WindowStart:    started.Format(time.RFC3339Nano),
+			WindowEnd:      windowEnd.Format(time.RFC3339Nano),
+			Integrity:      integrity,
+			Nodes:          nodes,
+			Scenarios:      scenarios,
+			Prepared:       mergeCatalogLatency(nodes, func(r cache.CatalogInvalidationReport) cache.CatalogInvalidationLatency { return r.PreparedPlanRebuild }),
+			RC:             mergeCatalogLatency(nodes, func(r cache.CatalogInvalidationReport) cache.CatalogInvalidationLatency { return r.RCTableCacheReload }),
+			DecisionTotals: mergeDecisionTotals(nodes),
+		}
+		if err := writeCatalogAttributionReport(reportDir, report); err != nil {
+			t.Errorf("write catalog invalidation report: %v", err)
+		}
+	}()
+
+	var err error
+	cluster, err = StartTestCluster(WithCNCount(2), WithPreStart(adjustBasicClusterService))
+	if err != nil {
+		t.Fatalf("start two-CN attribution cluster: %v", err)
+	}
+
+	cn0, err := cluster.GetCNService(0)
+	require.NoError(t, err)
+	cn1, err := cluster.GetCNService(1)
+	require.NoError(t, err)
+	db0 := openCatalogAttributionDB(t, cn0)
+	db1 := openCatalogAttributionDB(t, cn1)
+	defer db0.Close()
+	defer db1.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	databaseName := "catalog_attr_27235"
+	if err := resetCatalogAttributionFixture(ctx, db0, databaseName); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = db0.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+databaseName) }()
+
+	if err := runPreparedAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+		t.Fatal(err)
+	}
+	if err := runRCAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+		t.Fatal(err)
+	}
+	if err := runUnrelatedDDLAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+		t.Fatal(err)
+	}
+
+	// Snapshot and validate before the deferred writer marks the report complete.
+	nodes = snapshotCatalogAttributionNodes(t, cluster, sha, started, time.Now().UTC(), "complete")
+	if err := validateCatalogAttributionSamples(nodes, scenarios); err != nil {
+		t.Fatal(err)
+	}
+	passed = true
+}
+
+func openCatalogAttributionDB(t *testing.T, svc ServiceOperator) *sql.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", svc.GetServiceConfig().CN.Frontend.Port)
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	return db
+}
+
+func resetCatalogAttributionFixture(ctx context.Context, db *sql.DB, name string) error {
+	for _, stmt := range []string{
+		"DROP DATABASE IF EXISTS " + name,
+		"CREATE DATABASE " + name,
+		"CREATE TABLE " + name + ".prepared_table (id INT PRIMARY KEY, payload INT)",
+		"CREATE TABLE " + name + ".rc_table (id INT PRIMARY KEY, payload INT)",
+		"CREATE TABLE " + name + ".unrelated_table (id INT PRIMARY KEY, payload INT)",
+		"INSERT INTO " + name + ".prepared_table VALUES (1, 1)",
+		"INSERT INTO " + name + ".rc_table VALUES (1, 1)",
+		"INSERT INTO " + name + ".unrelated_table VALUES (1, 1)",
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("fixture %q: %w", stmt, err)
+		}
+	}
+	return nil
+}
+
+func runPreparedAttribution(ctx context.Context, db0, db1 *sql.DB, database string, scenarios *[]catalogAttributionScenario) error {
+	stmt, err := db0.PrepareContext(ctx, "SELECT payload FROM "+database+".prepared_table WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare binary statement: %w", err)
+	}
+	defer stmt.Close()
+	conn, err := db0.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("open text prepared connection: %w", err)
+	}
+	defer conn.Close()
+	textName := "catalog_attr_text_stmt"
+	if _, err := conn.ExecContext(ctx, "PREPARE "+textName+" FROM 'SELECT payload FROM "+database+".prepared_table WHERE id = ?'"); err != nil {
+		return fmt.Errorf("prepare text statement: %w", err)
+	}
+	defer func() { _, _ = conn.ExecContext(context.Background(), "DEALLOCATE PREPARE "+textName) }()
+	for i := 0; i < catalogAttributionSamples; i++ {
+		column := fmt.Sprintf("prepared_c%03d", i)
+		if _, err := db1.ExecContext(ctx, "ALTER TABLE "+database+".prepared_table ADD COLUMN "+column+" INT"); err != nil {
+			return fmt.Errorf("prepared DDL %d: %w", i, err)
+		}
+		if err := waitCatalogObservation(ctx, db0, database, column); err != nil {
+			return err
+		}
+		var payload int
+		if err := stmt.QueryRowContext(ctx, 1).Scan(&payload); err != nil {
+			return fmt.Errorf("prepared execute %d: %w", i, err)
+		}
+		if _, err := conn.ExecContext(ctx, "SET @catalog_attr_id = 1"); err != nil {
+			return fmt.Errorf("set text prepared argument %d: %w", i, err)
+		}
+		if err := conn.QueryRowContext(ctx, "EXECUTE "+textName+" USING @catalog_attr_id").Scan(&payload); err != nil {
+			return fmt.Errorf("text prepared execute %d: %w", i, err)
+		}
+	}
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "prepared_schema_rebuild", DDLType: "alter", ConsumerCN: "cn-0", DDLCN: "cn-1",
+		Protocol: "binary-and-text-prepare", Samples: catalogAttributionSamples, Status: "completed",
+	})
+	return nil
+}
+
+func runRCAttribution(ctx context.Context, db0, db1 *sql.DB, database string, scenarios *[]catalogAttributionScenario) error {
+	for i := 0; i < catalogAttributionSamples; i++ {
+		tx, err := db0.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+		if err != nil {
+			return fmt.Errorf("begin RC transaction %d: %w", i, err)
+		}
+		var count int
+		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+database+".rc_table").Scan(&count); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("RC initial read %d: %w", i, err)
+		}
+		column := fmt.Sprintf("rc_c%03d", i)
+		if _, err := db1.ExecContext(ctx, "ALTER TABLE "+database+".rc_table ADD COLUMN "+column+" INT"); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("RC DDL %d: %w", i, err)
+		}
+		if err := waitCatalogObservation(ctx, db0, database, column); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+database+".rc_table").Scan(&count); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("RC reload %d: %w", i, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("RC commit %d: %w", i, err)
+		}
+	}
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "rc_table_cache_reload", DDLType: "alter", ConsumerCN: "cn-0", DDLCN: "cn-1",
+		Protocol: "read-committed", Samples: catalogAttributionSamples, Status: "completed",
+	})
+	return nil
+}
+
+func runUnrelatedDDLAttribution(ctx context.Context, db0, db1 *sql.DB, database string, scenarios *[]catalogAttributionScenario) error {
+	for i := 0; i < catalogAttributionSamples; i++ {
+		column := fmt.Sprintf("unrelated_c%03d", i)
+		if _, err := db1.ExecContext(ctx, "ALTER TABLE "+database+".unrelated_table ADD COLUMN "+column+" INT"); err != nil {
+			return fmt.Errorf("unrelated DDL %d: %w", i, err)
+		}
+		if err := waitCatalogObservation(ctx, db0, database, column); err != nil {
+			return err
+		}
+		var payload int
+		if err := db0.QueryRowContext(ctx, "SELECT payload FROM "+database+".prepared_table WHERE id = 1").Scan(&payload); err != nil {
+			return fmt.Errorf("unrelated read %d: %w", i, err)
+		}
+	}
+	*scenarios = append(*scenarios, catalogAttributionScenario{
+		Name: "same_account_unrelated_ddl", DDLType: "alter-unrelated", ConsumerCN: "cn-0", DDLCN: "cn-1",
+		Samples: catalogAttributionSamples, Status: "completed",
+	})
+	return nil
+}
+
+func waitCatalogObservation(ctx context.Context, db *sql.DB, database, column string) error {
+	deadline, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	table := "prepared_table"
+	if strings.HasPrefix(column, "rc_") {
+		table = "rc_table"
+	} else if strings.HasPrefix(column, "unrelated_") {
+		table = "unrelated_table"
+	}
+	query := "SELECT " + column + " FROM " + database + "." + table + " LIMIT 1"
+	for {
+		var value sql.NullInt64
+		row := db.QueryRowContext(deadline, query)
+		err := row.Scan(&value)
+		if err == nil {
+			return nil
+		}
+		if deadline.Err() != nil {
+			if err != nil {
+				return fmt.Errorf("catalog observation %s: %w", column, err)
+			}
+			return fmt.Errorf("catalog observation %s timed out", column)
+		}
+		timer := time.NewTimer(20 * time.Millisecond)
+		select {
+		case <-deadline.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
+	}
+}
+
+func snapshotCatalogAttributionNodes(t *testing.T, cluster Cluster, sha string, start, end time.Time, integrity string) []catalogAttributionNode {
+	t.Helper()
+	nodes := make([]catalogAttributionNode, 0, 2)
+	for i := 0; i < 2; i++ {
+		svc, err := cluster.GetCNService(i)
+		if err != nil {
+			t.Errorf("get CN %d: %v", i, err)
+			continue
+		}
+		raw, ok := svc.RawService().(cnservice.Service)
+		if !ok {
+			t.Errorf("CN %d does not expose cnservice.Service", i)
+			continue
+		}
+		eng, ok := raw.GetEngine().(*disttae.Engine)
+		if !ok {
+			t.Errorf("CN %d does not expose disttae.Engine", i)
+			continue
+		}
+		cc := eng.GetLatestCatalogCache()
+		if cc == nil || !cc.CatalogInvalidationAttributionEnabled() {
+			t.Errorf("CN %d attribution is not enabled", i)
+			continue
+		}
+		cc.SetCatalogInvalidationReportMetadata(cache.CatalogInvalidationReportMetadata{
+			MatrixONESHA: sha,
+			Config:       "pkg/embed:1log-1tn-2cn;exact-authoritative",
+			Window:       start.Format(time.RFC3339Nano) + "/" + end.Format(time.RFC3339Nano),
+			Integrity:    integrity,
+		})
+		nodes = append(nodes, catalogAttributionNode{ServiceID: svc.ServiceID(), Report: cc.SnapshotCatalogInvalidationReport()})
+	}
+	return nodes
+}
+
+func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios []catalogAttributionScenario) error {
+	if len(nodes) != 2 {
+		return fmt.Errorf("expected two CN reports, got %d", len(nodes))
+	}
+	for _, scenario := range scenarios {
+		if scenario.Status != "completed" || scenario.Samples < catalogAttributionSamples {
+			return fmt.Errorf("scenario %s has insufficient stable samples", scenario.Name)
+		}
+	}
+	var prepared, rc uint64
+	for _, node := range nodes {
+		prepared += node.Report.PreparedPlanRebuild.Count
+		rc += node.Report.RCTableCacheReload.Count
+	}
+	if prepared < catalogAttributionSamples || rc < catalogAttributionSamples {
+		return fmt.Errorf("terminal samples below 128: prepared=%d rc=%d", prepared, rc)
+	}
+	return nil
+}
+
+func mergeDecisionTotals(nodes []catalogAttributionNode) map[string]uint64 {
+	totals := make(map[string]uint64)
+	for _, node := range nodes {
+		for consumer, counter := range node.Report.Consumers {
+			prefix := consumer + "."
+			totals[prefix+"checks"] += counter.Checks
+			totals[prefix+"stable_checks"] += counter.StableChecks
+			totals[prefix+"inconclusive_checks"] += counter.InconclusiveChecks
+			totals[prefix+"bucket_false_positives"] += counter.BucketFalsePositives
+			totals[prefix+"bucket_false_negatives"] += counter.BucketFalseNegatives
+			totals[prefix+"precise_false_positives"] += counter.PreciseFalsePositives
+			totals[prefix+"precise_false_negatives"] += counter.PreciseFalseNegatives
+		}
+	}
+	return totals
+}
+
+func mergeCatalogLatency(nodes []catalogAttributionNode, pick func(cache.CatalogInvalidationReport) cache.CatalogInvalidationLatency) catalogAttributionLatency {
+	var out catalogAttributionLatency
+	for _, node := range nodes {
+		value := pick(node.Report)
+		out.Count += value.Count
+		out.Success += value.Success
+		out.Error += value.Error
+		out.Miss += value.Miss
+		if len(out.Buckets) == 0 {
+			out.Buckets = make([]cache.CatalogInvalidationLatencyBucket, len(value.Buckets))
+			copy(out.Buckets, value.Buckets)
+		} else {
+			for i := range value.Buckets {
+				if i >= len(out.Buckets) {
+					out.Buckets = append(out.Buckets, value.Buckets[i])
+				} else {
+					out.Buckets[i].Count += value.Buckets[i].Count
+				}
+			}
+		}
+	}
+	out.P50NS, out.P95NS, out.P99NS = latencyQuantiles(out.Buckets, out.Count)
+	return out
+}
+
+func latencyQuantiles(buckets []cache.CatalogInvalidationLatencyBucket, count uint64) (int64, int64, int64) {
+	quantile := func(q float64) int64 {
+		if count == 0 {
+			return 0
+		}
+		target := uint64(float64(count-1)*q) + 1
+		var seen uint64
+		for _, bucket := range buckets {
+			seen += bucket.Count
+			if seen >= target {
+				return bucket.UpperBoundNS
+			}
+		}
+		return -1
+	}
+	return quantile(0.50), quantile(0.95), quantile(0.99)
+}
+
+func writeCatalogAttributionReport(dir string, report catalogAttributionReportV2) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(dir, ".catalog-invalidation-report-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, filepath.Join(dir, "catalog-invalidation-report.json"))
+}

--- a/pkg/embed/catalog_invalidation_attribution_test.go
+++ b/pkg/embed/catalog_invalidation_attribution_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -41,13 +42,31 @@ const (
 )
 
 type catalogAttributionScenario struct {
-	Name       string `json:"name"`
-	DDLType    string `json:"ddl_type"`
-	ConsumerCN string `json:"consumer_cn"`
-	DDLCN      string `json:"ddl_cn"`
-	Protocol   string `json:"protocol,omitempty"`
-	Samples    int    `json:"stable_terminal_samples"`
-	Status     string `json:"status"`
+	Name        string                        `json:"name"`
+	DDLType     string                        `json:"ddl_type"`
+	ConsumerCN  string                        `json:"consumer_cn"`
+	DDLCN       string                        `json:"ddl_cn"`
+	Protocol    string                        `json:"protocol,omitempty"`
+	Samples     int                           `json:"stable_terminal_samples"`
+	Status      string                        `json:"status"`
+	Observation catalogAttributionObservation `json:"observation"`
+}
+
+// Observation is a counter delta captured around one scenario. Global totals
+// cannot prove that a lifecycle or collision scenario exercised its intended
+// consumer, so every scenario carries its own stable terminal evidence.
+type catalogAttributionObservation struct {
+	PreparedChecks           uint64 `json:"prepared_checks"`
+	PreparedStableChecks     uint64 `json:"prepared_stable_checks"`
+	PreparedTerminalOutcomes uint64 `json:"prepared_terminal_outcomes"`
+	RCChecks                 uint64 `json:"rc_checks"`
+	RCStableChecks           uint64 `json:"rc_stable_checks"`
+	RCTerminalOutcomes       uint64 `json:"rc_terminal_outcomes"`
+	BucketFalsePositives     uint64 `json:"bucket_false_positives"`
+	BucketFalseNegatives     uint64 `json:"bucket_false_negatives"`
+	PreciseFalsePositives    uint64 `json:"precise_false_positives"`
+	PreciseFalseNegatives    uint64 `json:"precise_false_negatives"`
+	ShadowOverflow           bool   `json:"shadow_overflow"`
 }
 
 type catalogAttributionNode struct {
@@ -80,6 +99,24 @@ type catalogAttributionReportV2 struct {
 	DecisionTotals map[string]uint64            `json:"decision_totals"`
 }
 
+func requireCatalogAttributionBuild(t *testing.T, expected string) {
+	t.Helper()
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		t.Fatal("catalog attribution requires VCS-attested build information")
+	}
+	settings := make(map[string]string, len(info.Settings))
+	for _, setting := range info.Settings {
+		settings[setting.Key] = setting.Value
+	}
+	if settings["vcs.revision"] != expected {
+		t.Fatalf("measurement SHA %s does not match executed build revision %q", expected, settings["vcs.revision"])
+	}
+	if settings["vcs.modified"] == "true" {
+		t.Fatal("catalog attribution requires a clean VCS-attested build")
+	}
+}
+
 func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {
 	if os.Getenv(catalogAttributionEnabledEnv) != "1" {
 		t.Skip("opt-in catalog invalidation attribution workload")
@@ -92,6 +129,7 @@ func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {
 	if len(sha) != 40 || strings.Trim(sha, "0123456789abcdefABCDEF") != "" {
 		t.Fatal("MO_CATALOG_INVALIDATION_MATRIXONE_SHA must be a complete 40-byte hexadecimal SHA")
 	}
+	requireCatalogAttributionBuild(t, sha)
 	if err := os.MkdirAll(reportDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -99,27 +137,54 @@ func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {
 	started := time.Now().UTC()
 	var (
 		cluster   Cluster
+		db0, db1  *sql.DB
 		nodes     []catalogAttributionNode
 		scenarios []catalogAttributionScenario
 		passed    bool
+		cleanupOK = true
 		closeOnce sync.Once
 	)
 	defer func() {
 		windowEnd := time.Now().UTC()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if db0 != nil {
+			if _, err := db0.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS catalog_attr_27235"); err != nil {
+				cleanupOK = false
+				t.Errorf("catalog fixture cleanup failed: %v", err)
+			}
+		}
+		cancel()
+		if db0 != nil {
+			if err := db0.Close(); err != nil {
+				cleanupOK = false
+				t.Errorf("CN0 database close failed: %v", err)
+			}
+		}
+		if db1 != nil {
+			if err := db1.Close(); err != nil {
+				cleanupOK = false
+				t.Errorf("CN1 database close failed: %v", err)
+			}
+		}
 		nodeIntegrity := "incomplete"
-		if passed {
+		if passed && cleanupOK {
 			nodeIntegrity = "complete"
 		}
 		if cluster != nil {
 			nodes = snapshotCatalogAttributionNodes(t, cluster, sha, started, windowEnd, nodeIntegrity)
-			closeOnce.Do(func() { _ = cluster.Close() })
+			closeOnce.Do(func() {
+				if err := cluster.Close(); err != nil {
+					cleanupOK = false
+					t.Errorf("embedded cluster cleanup failed: %v", err)
+				}
+			})
 		}
 		integrity := "incomplete"
-		if passed {
+		if passed && cleanupOK {
 			integrity = "complete"
 		}
 		report := catalogAttributionReportV2{
-			SchemaVersion:  2,
+			SchemaVersion:  3,
 			MatrixONESHA:   sha,
 			Config:         "pkg/embed:1log-1tn-2cn;exact-authoritative",
 			WindowStart:    started.Format(time.RFC3339Nano),
@@ -146,10 +211,8 @@ func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {
 	require.NoError(t, err)
 	cn1, err := cluster.GetCNService(1)
 	require.NoError(t, err)
-	db0 := openCatalogAttributionDB(t, cn0)
-	db1 := openCatalogAttributionDB(t, cn1)
-	defer db0.Close()
-	defer db1.Close()
+	db0 = openCatalogAttributionDB(t, cn0)
+	db1 = openCatalogAttributionDB(t, cn1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
@@ -157,24 +220,30 @@ func TestCatalogInvalidationAttributionMultiCN(t *testing.T) {
 	if err := resetCatalogAttributionFixture(ctx, db0, databaseName); err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _, _ = db0.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+databaseName) }()
-
-	if err := runPreparedAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+	runMeasured := func(run func() error) error {
+		before := snapshotCatalogAttributionNodes(t, cluster, sha, started, time.Now().UTC(), "measured")
+		startIndex := len(scenarios)
+		if err := run(); err != nil {
+			return err
+		}
+		return annotateCatalogAttributionScenario(t, cluster, sha, started, &scenarios, startIndex, before)
+	}
+	if err := runMeasured(func() error { return runPreparedAttribution(ctx, db0, db1, databaseName, &scenarios) }); err != nil {
 		t.Fatal(err)
 	}
-	if err := runRCAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+	if err := runMeasured(func() error { return runRCAttribution(ctx, db0, db1, databaseName, &scenarios) }); err != nil {
 		t.Fatal(err)
 	}
-	if err := runUnrelatedDDLAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+	if err := runMeasured(func() error { return runUnrelatedDDLAttribution(ctx, db0, db1, databaseName, &scenarios) }); err != nil {
 		t.Fatal(err)
 	}
-	if err := runLifecycleAttribution(ctx, db0, db1, databaseName, &scenarios); err != nil {
+	if err := runLifecycleAttribution(t, cluster, sha, started, ctx, db0, db1, databaseName, &scenarios); err != nil {
 		t.Fatal(err)
 	}
 
 	// Snapshot and validate before the deferred writer marks the report complete.
-	nodes = snapshotCatalogAttributionNodes(t, cluster, sha, started, time.Now().UTC(), "complete")
-	if err := validateCatalogAttributionSamples(nodes, scenarios); err != nil {
+	nodes = snapshotCatalogAttributionNodes(t, cluster, sha, started, time.Now().UTC(), "measured")
+	if err := validateCatalogAttributionSamples(nodes, scenarios, sha); err != nil {
 		t.Fatal(err)
 	}
 	passed = true
@@ -223,7 +292,11 @@ func runPreparedAttribution(ctx context.Context, db0, db1 *sql.DB, database stri
 	if _, err := conn.ExecContext(ctx, "PREPARE "+textName+" FROM 'SELECT payload FROM "+database+".prepared_table WHERE id = ?'"); err != nil {
 		return fmt.Errorf("prepare text statement: %w", err)
 	}
-	defer func() { _, _ = conn.ExecContext(context.Background(), "DEALLOCATE PREPARE "+textName) }()
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_, _ = conn.ExecContext(cleanupCtx, "DEALLOCATE PREPARE "+textName)
+		cancel()
+	}()
 	for i := 0; i < catalogAttributionSamples; i++ {
 		column := fmt.Sprintf("prepared_c%03d", i)
 		if _, err := db1.ExecContext(ctx, "ALTER TABLE "+database+".prepared_table ADD COLUMN "+column+" INT"); err != nil {
@@ -286,6 +359,11 @@ func runRCAttribution(ctx context.Context, db0, db1 *sql.DB, database string, sc
 }
 
 func runUnrelatedDDLAttribution(ctx context.Context, db0, db1 *sql.DB, database string, scenarios *[]catalogAttributionScenario) error {
+	stmt, err := db0.PrepareContext(ctx, "SELECT payload FROM "+database+".prepared_table WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare unrelated-DDL control statement: %w", err)
+	}
+	defer stmt.Close()
 	for i := 0; i < catalogAttributionSamples; i++ {
 		column := fmt.Sprintf("unrelated_c%03d", i)
 		if _, err := db1.ExecContext(ctx, "ALTER TABLE "+database+".unrelated_table ADD COLUMN "+column+" INT"); err != nil {
@@ -295,7 +373,7 @@ func runUnrelatedDDLAttribution(ctx context.Context, db0, db1 *sql.DB, database 
 			return err
 		}
 		var payload int
-		if err := db0.QueryRowContext(ctx, "SELECT payload FROM "+database+".prepared_table WHERE id = 1").Scan(&payload); err != nil {
+		if err := stmt.QueryRowContext(ctx, 1).Scan(&payload); err != nil {
 			return fmt.Errorf("unrelated read %d: %w", i, err)
 		}
 	}
@@ -306,82 +384,164 @@ func runUnrelatedDDLAttribution(ctx context.Context, db0, db1 *sql.DB, database 
 	return nil
 }
 
-func runLifecycleAttribution(ctx context.Context, db0, db1 *sql.DB, database string, scenarios *[]catalogAttributionScenario) error {
-	base := database + ".lifecycle_table"
-	if err := waitTableAvailable(ctx, db0, base); err != nil {
-		return fmt.Errorf("no-change observation: %w", err)
+func runLifecycleScenario(
+	t *testing.T,
+	cluster Cluster,
+	sha string,
+	started time.Time,
+	ctx context.Context,
+	scenarios *[]catalogAttributionScenario,
+	name, ddlType, protocol string,
+	db0, db1 *sql.DB,
+	fn func() error,
+) error {
+	t.Helper()
+	before := snapshotCatalogAttributionNodes(t, cluster, sha, started, time.Now().UTC(), "measured")
+	if err := fn(); err != nil {
+		return err
 	}
 	*scenarios = append(*scenarios, catalogAttributionScenario{
-		Name: "no_change", DDLType: "none", ConsumerCN: "cn-0", DDLCN: "none", Samples: 1, Status: "completed",
+		Name: name, DDLType: ddlType, ConsumerCN: "cn-0", DDLCN: "cn-1",
+		Protocol: protocol, Samples: 1, Status: "completed",
 	})
+	return annotateCatalogAttributionScenario(t, cluster, sha, started, scenarios, len(*scenarios)-1, before)
+}
 
-	if _, err := db1.ExecContext(ctx, "TRUNCATE TABLE "+base); err != nil {
-		return fmt.Errorf("truncate: %w", err)
+func runLifecycleAttribution(
+	t *testing.T,
+	cluster Cluster,
+	sha string,
+	started time.Time,
+	ctx context.Context,
+	db0, db1 *sql.DB,
+	database string,
+	scenarios *[]catalogAttributionScenario,
+) error {
+	base := database + ".lifecycle_table"
+	if err := runLifecycleScenario(t, cluster, sha, started, ctx, scenarios,
+		"no_change", "none", "binary-prepare", db0, db1, func() error {
+			stmt, err := db0.PrepareContext(ctx, "SELECT payload FROM "+base+" WHERE id = ?")
+			if err != nil {
+				return fmt.Errorf("no-change prepare: %w", err)
+			}
+			defer stmt.Close()
+			var payload int
+			if err := stmt.QueryRowContext(ctx, 1).Scan(&payload); err != nil {
+				return fmt.Errorf("no-change execute: %w", err)
+			}
+			return nil
+		}); err != nil {
+		return err
 	}
-	if err := waitTableAvailable(ctx, db0, base); err != nil {
-		return fmt.Errorf("truncate observation: %w", err)
+
+	if err := runLifecycleScenario(t, cluster, sha, started, ctx, scenarios,
+		"truncate", "truncate", "binary-prepare", db0, db1, func() error {
+			stmt, err := db0.PrepareContext(ctx, "SELECT payload FROM "+base+" WHERE id = ?")
+			if err != nil {
+				return fmt.Errorf("truncate prepare: %w", err)
+			}
+			defer stmt.Close()
+			if _, err := db1.ExecContext(ctx, "TRUNCATE TABLE "+base); err != nil {
+				return fmt.Errorf("truncate: %w", err)
+			}
+			var payload sql.NullInt64
+			err = stmt.QueryRowContext(ctx, 1).Scan(&payload)
+			if err != nil && err != sql.ErrNoRows {
+				return fmt.Errorf("truncate stale execute: %w", err)
+			}
+			if _, err := db1.ExecContext(ctx, "INSERT INTO "+base+" VALUES (1, 2)"); err != nil {
+				return fmt.Errorf("restore after truncate: %w", err)
+			}
+			return nil
+		}); err != nil {
+		return err
 	}
-	if _, err := db1.ExecContext(ctx, "INSERT INTO "+base+" VALUES (1, 2)"); err != nil {
-		return fmt.Errorf("restore after truncate: %w", err)
-	}
-	*scenarios = append(*scenarios, catalogAttributionScenario{
-		Name: "truncate", DDLType: "truncate", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
-	})
 
 	rename := database + ".lifecycle_renamed"
-	if _, err := db1.ExecContext(ctx, "ALTER TABLE "+base+" RENAME TO "+rename); err != nil {
-		return fmt.Errorf("rename forward: %w", err)
+	if err := runLifecycleScenario(t, cluster, sha, started, ctx, scenarios,
+		"rename", "rename", "binary-prepare", db0, db1, func() error {
+			stmt, err := db0.PrepareContext(ctx, "SELECT payload FROM "+base+" WHERE id = ?")
+			if err != nil {
+				return fmt.Errorf("rename prepare: %w", err)
+			}
+			defer stmt.Close()
+			if _, err := db1.ExecContext(ctx, "ALTER TABLE "+base+" RENAME TO "+rename); err != nil {
+				return fmt.Errorf("rename forward: %w", err)
+			}
+			var payload int
+			if err := stmt.QueryRowContext(ctx, 1).Scan(&payload); err == nil {
+				return fmt.Errorf("rename stale dependency unexpectedly executed")
+			}
+			if _, err := db1.ExecContext(ctx, "ALTER TABLE "+rename+" RENAME TO "+base); err != nil {
+				return fmt.Errorf("rename backward: %w", err)
+			}
+			return waitTableAvailable(ctx, db0, base)
+		}); err != nil {
+		return err
 	}
-	if err := waitTableAvailable(ctx, db0, rename); err != nil {
-		return fmt.Errorf("rename forward observation: %w", err)
-	}
-	if _, err := db1.ExecContext(ctx, "ALTER TABLE "+rename+" RENAME TO "+base); err != nil {
-		return fmt.Errorf("rename backward: %w", err)
-	}
-	if err := waitTableAvailable(ctx, db0, base); err != nil {
-		return fmt.Errorf("rename backward observation: %w", err)
-	}
-	*scenarios = append(*scenarios, catalogAttributionScenario{
-		Name: "rename", DDLType: "rename", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
-	})
 
-	if _, err := db1.ExecContext(ctx, "DROP TABLE "+base); err != nil {
-		return fmt.Errorf("drop table: %w", err)
+	if err := runLifecycleScenario(t, cluster, sha, started, ctx, scenarios,
+		"table_drop_recreate", "drop-recreate", "binary-prepare", db0, db1, func() error {
+			stmt, err := db0.PrepareContext(ctx, "SELECT payload FROM "+base+" WHERE id = ?")
+			if err != nil {
+				return fmt.Errorf("drop prepare: %w", err)
+			}
+			defer stmt.Close()
+			if _, err := db1.ExecContext(ctx, "DROP TABLE "+base); err != nil {
+				return fmt.Errorf("drop table: %w", err)
+			}
+			var payload int
+			if err := stmt.QueryRowContext(ctx, 1).Scan(&payload); err == nil {
+				return fmt.Errorf("drop stale dependency unexpectedly executed")
+			}
+			if _, err := db1.ExecContext(ctx, "CREATE TABLE "+base+" (id INT PRIMARY KEY, payload INT)"); err != nil {
+				return fmt.Errorf("recreate table: %w", err)
+			}
+			return waitTableAvailable(ctx, db0, base)
+		}); err != nil {
+		return err
 	}
-	if _, err := db1.ExecContext(ctx, "CREATE TABLE "+base+" (id INT PRIMARY KEY, payload INT)"); err != nil {
-		return fmt.Errorf("recreate table: %w", err)
-	}
-	if err := waitTableAvailable(ctx, db0, base); err != nil {
-		return fmt.Errorf("recreate table observation: %w", err)
-	}
-	*scenarios = append(*scenarios, catalogAttributionScenario{
-		Name: "table_drop_recreate", DDLType: "drop-recreate", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
-	})
 
 	databaseRecreated := database + "_recreated"
-	if _, err := db1.ExecContext(ctx, "CREATE DATABASE "+databaseRecreated); err != nil {
-		return fmt.Errorf("create recreation database: %w", err)
+	if err := runLifecycleScenario(t, cluster, sha, started, ctx, scenarios,
+		"database_drop_recreate", "database-drop-recreate", "binary-prepare", db0, db1, func() error {
+			if _, err := db1.ExecContext(ctx, "CREATE DATABASE "+databaseRecreated); err != nil {
+				return fmt.Errorf("create recreation database: %w", err)
+			}
+			if _, err := db1.ExecContext(ctx, "CREATE TABLE "+databaseRecreated+".lifecycle_table (id INT PRIMARY KEY, payload INT)"); err != nil {
+				return fmt.Errorf("create recreation table: %w", err)
+			}
+			stmt, err := db0.PrepareContext(ctx, "SELECT payload FROM "+databaseRecreated+".lifecycle_table WHERE id = ?")
+			if err != nil {
+				return fmt.Errorf("database prepare: %w", err)
+			}
+			defer stmt.Close()
+			if _, err := db1.ExecContext(ctx, "DROP DATABASE "+databaseRecreated); err != nil {
+				return fmt.Errorf("drop recreation database: %w", err)
+			}
+			var payload int
+			if err := stmt.QueryRowContext(ctx, 1).Scan(&payload); err == nil {
+				return fmt.Errorf("database stale dependency unexpectedly executed")
+			}
+			if _, err := db1.ExecContext(ctx, "CREATE DATABASE "+databaseRecreated); err != nil {
+				return fmt.Errorf("recreate database: %w", err)
+			}
+			if _, err := db1.ExecContext(ctx, "CREATE TABLE "+databaseRecreated+".lifecycle_table (id INT PRIMARY KEY, payload INT)"); err != nil {
+				return fmt.Errorf("recreate database table: %w", err)
+			}
+			if err := waitTableAvailable(ctx, db0, databaseRecreated+".lifecycle_table"); err != nil {
+				return fmt.Errorf("recreate database observation: %w", err)
+			}
+			return nil
+		}); err != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_, _ = db1.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+databaseRecreated)
+		cancel()
+		return err
 	}
-	defer func() { _, _ = db1.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+databaseRecreated) }()
-	if _, err := db1.ExecContext(ctx, "CREATE TABLE "+databaseRecreated+".lifecycle_table (id INT PRIMARY KEY, payload INT)"); err != nil {
-		return fmt.Errorf("create recreation table: %w", err)
-	}
-	if _, err := db1.ExecContext(ctx, "DROP DATABASE "+databaseRecreated); err != nil {
-		return fmt.Errorf("drop recreation database: %w", err)
-	}
-	if _, err := db1.ExecContext(ctx, "CREATE DATABASE "+databaseRecreated); err != nil {
-		return fmt.Errorf("recreate database: %w", err)
-	}
-	if _, err := db1.ExecContext(ctx, "CREATE TABLE "+databaseRecreated+".lifecycle_table (id INT PRIMARY KEY, payload INT)"); err != nil {
-		return fmt.Errorf("recreate database table: %w", err)
-	}
-	if err := waitTableAvailable(ctx, db0, databaseRecreated+".lifecycle_table"); err != nil {
-		return fmt.Errorf("recreate database observation: %w", err)
-	}
-	_, _ = db1.ExecContext(ctx, "DROP DATABASE IF EXISTS "+databaseRecreated)
-	*scenarios = append(*scenarios, catalogAttributionScenario{
-		Name: "database_drop_recreate", DDLType: "database-drop-recreate", ConsumerCN: "cn-0", DDLCN: "cn-1", Samples: 1, Status: "completed",
-	})
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	_, _ = db1.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+databaseRecreated)
+	cancel()
 	return nil
 }
 
@@ -474,9 +634,76 @@ func snapshotCatalogAttributionNodes(t *testing.T, cluster Cluster, sha string, 
 	return nodes
 }
 
-func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios []catalogAttributionScenario) error {
+func catalogAttributionObservationFor(nodes []catalogAttributionNode) catalogAttributionObservation {
+	var out catalogAttributionObservation
+	for _, node := range nodes {
+		if node.Report.Shadow.Overflow {
+			out.ShadowOverflow = true
+		}
+		prepared := node.Report.Consumers["prepared_plan"]
+		rc := node.Report.Consumers["rc_table_cache"]
+		out.PreparedChecks += prepared.Checks
+		out.PreparedStableChecks += prepared.StableChecks
+		out.PreparedTerminalOutcomes += node.Report.PreparedPlanRebuild.Count
+		out.RCChecks += rc.Checks
+		out.RCStableChecks += rc.StableChecks
+		out.RCTerminalOutcomes += node.Report.RCTableCacheReload.Count
+		out.BucketFalsePositives += prepared.BucketFalsePositives + rc.BucketFalsePositives
+		out.BucketFalseNegatives += prepared.BucketFalseNegatives + rc.BucketFalseNegatives
+		out.PreciseFalsePositives += prepared.PreciseFalsePositives + rc.PreciseFalsePositives
+		out.PreciseFalseNegatives += prepared.PreciseFalseNegatives + rc.PreciseFalseNegatives
+	}
+	return out
+}
+
+func subtractCatalogAttributionObservation(after, before catalogAttributionObservation) catalogAttributionObservation {
+	return catalogAttributionObservation{
+		PreparedChecks:           after.PreparedChecks - before.PreparedChecks,
+		PreparedStableChecks:     after.PreparedStableChecks - before.PreparedStableChecks,
+		PreparedTerminalOutcomes: after.PreparedTerminalOutcomes - before.PreparedTerminalOutcomes,
+		RCChecks:                 after.RCChecks - before.RCChecks,
+		RCStableChecks:           after.RCStableChecks - before.RCStableChecks,
+		RCTerminalOutcomes:       after.RCTerminalOutcomes - before.RCTerminalOutcomes,
+		BucketFalsePositives:     after.BucketFalsePositives - before.BucketFalsePositives,
+		BucketFalseNegatives:     after.BucketFalseNegatives - before.BucketFalseNegatives,
+		PreciseFalsePositives:    after.PreciseFalsePositives - before.PreciseFalsePositives,
+		PreciseFalseNegatives:    after.PreciseFalseNegatives - before.PreciseFalseNegatives,
+		ShadowOverflow:           after.ShadowOverflow,
+	}
+}
+
+func annotateCatalogAttributionScenario(
+	t *testing.T,
+	cluster Cluster,
+	sha string,
+	started time.Time,
+	scenarios *[]catalogAttributionScenario,
+	startIndex int,
+	before []catalogAttributionNode,
+) error {
+	t.Helper()
+	if startIndex >= len(*scenarios) {
+		return fmt.Errorf("scenario did not publish a result")
+	}
+	after := snapshotCatalogAttributionNodes(t, cluster, sha, started, time.Now().UTC(), "measured")
+	delta := subtractCatalogAttributionObservation(
+		catalogAttributionObservationFor(after),
+		catalogAttributionObservationFor(before),
+	)
+	for i := startIndex; i < len(*scenarios); i++ {
+		(*scenarios)[i].Observation = delta
+	}
+	return nil
+}
+
+func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios []catalogAttributionScenario, sha string) error {
 	if len(nodes) != 2 {
 		return fmt.Errorf("expected two CN reports, got %d", len(nodes))
+	}
+	for _, node := range nodes {
+		if !node.Report.Enabled || node.Report.Metadata.MatrixONESHA != sha || node.Report.Metadata.Integrity != "measured" {
+			return fmt.Errorf("node %s has unbound report identity or integrity", node.ServiceID)
+		}
 	}
 	required := map[string]bool{
 		"no_change": false, "truncate": false, "rename": false,
@@ -494,6 +721,31 @@ func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios
 		if scenario.Samples >= catalogAttributionSamples || scenario.Samples == 1 {
 			required[scenario.Name] = true
 		}
+		if scenario.Observation.ShadowOverflow {
+			return fmt.Errorf("scenario %s observed shadow overflow", scenario.Name)
+		}
+		if scenario.Observation.PreciseFalseNegatives != 0 {
+			return fmt.Errorf("scenario %s observed precise false negatives: %d", scenario.Name, scenario.Observation.PreciseFalseNegatives)
+		}
+		if scenario.Observation.PreciseFalsePositives != 0 {
+			return fmt.Errorf("scenario %s observed precise false positives: %d", scenario.Name, scenario.Observation.PreciseFalsePositives)
+		}
+		if scenario.Name == "prepared_schema_rebuild" &&
+			(scenario.Observation.PreparedStableChecks < uint64(scenario.Samples) ||
+				scenario.Observation.PreparedTerminalOutcomes < uint64(scenario.Samples)) {
+			return fmt.Errorf("prepared scenario lacks per-scenario terminal evidence: %+v", scenario.Observation)
+		}
+		if scenario.Name == "rc_table_cache_reload" &&
+			(scenario.Observation.RCStableChecks < uint64(scenario.Samples) ||
+				scenario.Observation.RCTerminalOutcomes < uint64(scenario.Samples)) {
+			return fmt.Errorf("RC scenario lacks per-scenario terminal evidence: %+v", scenario.Observation)
+		}
+		if scenario.Name == "same_account_unrelated_ddl" && scenario.Observation.PreparedStableChecks < uint64(scenario.Samples) {
+			return fmt.Errorf("unrelated DDL did not exercise a prepared dependency: %+v", scenario.Observation)
+		}
+		if scenario.Name == "same_account_unrelated_ddl" && scenario.Observation.BucketFalsePositives == 0 {
+			return fmt.Errorf("unrelated DDL did not produce a bucket false-positive opportunity")
+		}
 	}
 	for name, seen := range required {
 		if !seen {
@@ -502,6 +754,18 @@ func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios
 	}
 	var prepared, rc uint64
 	for _, node := range nodes {
+		for name, histogram := range map[string]cache.CatalogInvalidationLatency{
+			"prepared": node.Report.PreparedPlanRebuild,
+			"rc":       node.Report.RCTableCacheReload,
+		} {
+			var bucketCount uint64
+			for _, bucket := range histogram.Buckets {
+				bucketCount += bucket.Count
+			}
+			if bucketCount != histogram.Count || histogram.Success+histogram.Error+histogram.Miss != histogram.Count {
+				return fmt.Errorf("node %s %s histogram is inconsistent", node.ServiceID, name)
+			}
+		}
 		for _, consumer := range []string{"prepared_plan", "rc_table_cache"} {
 			counter, ok := node.Report.Consumers[consumer]
 			if !ok || counter.StableChecks == 0 || counter.InconclusiveChecks != 0 {
@@ -510,6 +774,14 @@ func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios
 		}
 		prepared += node.Report.PreparedPlanRebuild.Count
 		rc += node.Report.RCTableCacheReload.Count
+		if node.Report.Shadow.Overflow {
+			return fmt.Errorf("node %s reports shadow overflow", node.ServiceID)
+		}
+		for consumer, counter := range node.Report.Consumers {
+			if counter.StableChecks+counter.InconclusiveChecks != counter.Checks {
+				return fmt.Errorf("node %s consumer %s has inconsistent decision counters", node.ServiceID, consumer)
+			}
+		}
 	}
 	if prepared < catalogAttributionSamples || rc < catalogAttributionSamples {
 		return fmt.Errorf("terminal samples below 128: prepared=%d rc=%d", prepared, rc)

--- a/pkg/embed/catalog_invalidation_attribution_test.go
+++ b/pkg/embed/catalog_invalidation_attribution_test.go
@@ -502,6 +502,12 @@ func validateCatalogAttributionSamples(nodes []catalogAttributionNode, scenarios
 	}
 	var prepared, rc uint64
 	for _, node := range nodes {
+		for _, consumer := range []string{"prepared_plan", "rc_table_cache"} {
+			counter, ok := node.Report.Consumers[consumer]
+			if !ok || counter.StableChecks == 0 || counter.InconclusiveChecks != 0 {
+				return fmt.Errorf("node %s consumer %s lacks stable observations", node.ServiceID, consumer)
+			}
+		}
 		prepared += node.Report.PreparedPlanRebuild.Count
 		rc += node.Report.RCTableCacheReload.Count
 	}

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -610,7 +610,7 @@ func CheckTableDefChange(catalogCache *cache.CatalogCache, tblKey *cache.TableCh
 	if catalogCache == nil {
 		return false
 	}
-	return catalogCache.HasNewerVersion(tblKey)
+	return catalogCache.HasNewerVersionFor(tblKey, cache.CatalogInvalidationConsumerPreparedPlan)
 }
 
 func preparePlanNeedsRebuild(schemaChanged, modeMismatch, protocolMismatch bool) bool {
@@ -789,6 +789,7 @@ func initExecuteStmtParamWithResolverInSession(
 	currentDDLVersion := owner.getDDLVersion()
 	change := prepareStmt.tempTableVersion != currentTempTableVersion ||
 		prepareStmt.ddlVersion != currentDDLVersion
+	schemaChanged := false
 	var preparedMetadataTS timestamp.Timestamp
 	if catalogCache != nil {
 		preparedMetadataTS = catalogCache.GetPreparedMetadataTS()
@@ -829,6 +830,7 @@ func initExecuteStmtParamWithResolverInSession(
 
 		if CheckTableDefChange(catalogCache, tblKey) {
 			change = true
+			schemaChanged = true
 			break
 		}
 	}
@@ -860,9 +862,13 @@ func initExecuteStmtParamWithResolverInSession(
 	// Rebuild the plan when catalog schema, session temporary-table name
 	// resolution, FK-check state, protocol, or compatibility mode changed.
 	if needRebuild {
+		rebuildStart := time.Now()
 		newPlan, err := rebuildPreparePlan(execCtx, executionSes, prepareStmt, buildPlan)
 		if err != nil {
 			return nil, nil, nil, "", false, err
+		}
+		if schemaChanged && catalogCache != nil {
+			catalogCache.RecordPreparedPlanRebuild(time.Since(rebuildStart))
 		}
 		prepareTs := currentTxnSnapshotTSForProcess(cwft.proc)
 		newPreparePlan := newPlan.GetDcl().GetPrepare()

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -864,11 +864,11 @@ func initExecuteStmtParamWithResolverInSession(
 	if needRebuild {
 		rebuildStart := time.Now()
 		newPlan, err := rebuildPreparePlan(execCtx, executionSes, prepareStmt, buildPlan)
+		if schemaChanged && catalogCache != nil {
+			catalogCache.RecordPreparedPlanRebuild(time.Since(rebuildStart), err == nil)
+		}
 		if err != nil {
 			return nil, nil, nil, "", false, err
-		}
-		if schemaChanged && catalogCache != nil {
-			catalogCache.RecordPreparedPlanRebuild(time.Since(rebuildStart))
 		}
 		prepareTs := currentTxnSnapshotTSForProcess(cwft.proc)
 		newPreparePlan := newPlan.GetDcl().GetPrepare()

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -819,13 +819,14 @@ func initExecuteStmtParamWithResolverInSession(
 		}
 		accountId := prepareSchemaAccountID(owner.GetAccountId(), obj)
 		tblKey := &cache.TableChangeQuery{
-			AccountId:    accountId,
-			DatabaseId:   uint64(obj.Db),
-			DatabaseName: obj.SchemaName,
-			Name:         obj.ObjName,
-			Version:      uint32(obj.Server),
-			TableId:      uint64(obj.Obj),
-			Ts:           prepareStmt.Ts,
+			AccountId:          accountId,
+			DatabaseId:         uint64(obj.Db),
+			DatabaseName:       obj.SchemaName,
+			ShadowDatabaseName: obj.SchemaName,
+			Name:               obj.ObjName,
+			Version:            uint32(obj.Server),
+			TableId:            uint64(obj.Obj),
+			Ts:                 prepareStmt.Ts,
 		}
 
 		if CheckTableDefChange(catalogCache, tblKey) {
@@ -858,15 +859,23 @@ func initExecuteStmtParamWithResolverInSession(
 	protocolMismatch := prepareStmt.protocolVersion != 0 &&
 		prepareStmt.protocolVersion != protocolVersion
 	needRebuild := preparePlanNeedsRebuild(change, modeMismatch, protocolMismatch) || fkSensitive
+	var catalogRebuildStart time.Time
+	var catalogRebuildPending bool
+	catalogRebuildSuccess := false
+	defer func() {
+		if catalogRebuildPending && catalogCache != nil {
+			catalogCache.RecordPreparedPlanRebuild(time.Since(catalogRebuildStart), catalogRebuildSuccess)
+		}
+	}()
 
 	// Rebuild the plan when catalog schema, session temporary-table name
 	// resolution, FK-check state, protocol, or compatibility mode changed.
 	if needRebuild {
-		rebuildStart := time.Now()
-		newPlan, err := rebuildPreparePlan(execCtx, executionSes, prepareStmt, buildPlan)
 		if schemaChanged && catalogCache != nil {
-			catalogCache.RecordPreparedPlanRebuild(time.Since(rebuildStart), err == nil)
+			catalogRebuildStart = time.Now()
+			catalogRebuildPending = true
 		}
+		newPlan, err := rebuildPreparePlan(execCtx, executionSes, prepareStmt, buildPlan)
 		if err != nil {
 			return nil, nil, nil, "", false, err
 		}
@@ -1056,6 +1065,9 @@ func initExecuteStmtParamWithResolverInSession(
 	executionStmt, owned, err := freshPreparedCloneStatement(reqCtx, prepareStmt)
 	if err != nil {
 		return nil, nil, nil, "", false, err
+	}
+	if catalogRebuildPending {
+		catalogRebuildSuccess = true
 	}
 	return retComp, executionPlan, executionStmt, originSQL, owned, nil
 }

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -113,6 +113,11 @@ type GCReport struct {
 func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 	cc.gcMu.Lock()
 	defer cc.gcMu.Unlock()
+	var endMutation func()
+	if cc.attribution != nil {
+		endMutation = cc.attribution.beginMutation()
+		defer endMutation()
+	}
 
 	/*
 							GC
@@ -425,13 +430,16 @@ func (cc *CatalogCache) HasNewerVersion(qry *TableChangeQuery) bool {
 // HasNewerVersionFor keeps the exact production decision while recording
 // bucket and precise-shadow decisions when attribution is explicitly enabled.
 func (cc *CatalogCache) HasNewerVersionFor(qry *TableChangeQuery, consumer CatalogInvalidationConsumer) bool {
-	exact := cc.hasNewerVersion(qry)
 	if cc.attribution == nil {
-		return exact
+		return cc.hasNewerVersion(qry)
 	}
+	startGeneration, startActive := cc.attribution.mutationSnapshot()
+	exact := cc.hasNewerVersion(qry)
 	bucket := cc.bucketHasNewerVersion(qry)
 	precise := cc.attribution.preciseDecision(qry)
-	cc.attribution.recordDecision(consumer, exact, bucket, precise)
+	endGeneration, endActive := cc.attribution.mutationSnapshot()
+	stable := startActive == 0 && endActive == 0 && startGeneration == endGeneration
+	cc.attribution.recordDecision(consumer, exact, bucket, precise, stable)
 	return exact
 }
 
@@ -542,6 +550,11 @@ func (cc *CatalogCache) GetDatabase(db *DatabaseItem) bool {
 func (cc *CatalogCache) DeleteTable(bat *batch.Batch) {
 	cc.tableChange.Lock()
 	defer cc.tableChange.Unlock()
+	var endMutation func()
+	if cc.attribution != nil {
+		endMutation = cc.attribution.beginMutation()
+		defer endMutation()
+	}
 
 	cpks := bat.GetVector(MO_OFF + 0)
 	timestamps := vector.MustFixedColWithTypeCheck[types.TS](bat.GetVector(MO_TIMESTAMP_IDX))
@@ -564,6 +577,11 @@ func (cc *CatalogCache) DeleteTable(bat *batch.Batch) {
 }
 
 func (cc *CatalogCache) DeleteDatabase(bat *batch.Batch) {
+	var endMutation func()
+	if cc.attribution != nil {
+		endMutation = cc.attribution.beginMutation()
+		defer endMutation()
+	}
 	cpks := bat.GetVector(MO_OFF + 0)
 	timestamps := vector.MustFixedColWithTypeCheck[types.TS](bat.GetVector(MO_TIMESTAMP_IDX))
 	for i, ts := range timestamps {
@@ -638,6 +656,11 @@ func ParseTablesBatchAnd(bat *batch.Batch, f func(*TableItem)) {
 func (cc *CatalogCache) InsertTable(bat *batch.Batch) {
 	cc.tableChange.Lock()
 	defer cc.tableChange.Unlock()
+	var endMutation func()
+	if cc.attribution != nil {
+		endMutation = cc.attribution.beginMutation()
+		defer endMutation()
+	}
 
 	ParseTablesBatchAnd(bat, func(item *TableItem) {
 		cc.setTableItemLocked(item, true)
@@ -647,6 +670,11 @@ func (cc *CatalogCache) InsertTable(bat *batch.Batch) {
 func (cc *CatalogCache) setTableItem(item *TableItem, updateCPKey bool) {
 	cc.tableChange.Lock()
 	defer cc.tableChange.Unlock()
+	var endMutation func()
+	if cc.attribution != nil {
+		endMutation = cc.attribution.beginMutation()
+		defer endMutation()
+	}
 
 	cc.setTableItemLocked(item, updateCPKey)
 }
@@ -769,6 +797,11 @@ func (cc *CatalogCache) InsertColumns(bat *batch.Batch) {
 }
 
 func (cc *CatalogCache) InsertDatabase(bat *batch.Batch) {
+	var endMutation func()
+	if cc.attribution != nil {
+		endMutation = cc.attribution.beginMutation()
+		defer endMutation()
+	}
 	ParseDatabaseBatchAnd(bat, func(item *DatabaseItem) {
 		cc.databases.data.Set(item)
 		cc.databases.cpkeyIndex.Set(item)

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -435,8 +435,12 @@ func (cc *CatalogCache) HasNewerVersionFor(qry *TableChangeQuery, consumer Catal
 	}
 	startGeneration, startActive := cc.attribution.mutationSnapshot()
 	exact := cc.hasNewerVersion(qry)
-	bucket := cc.bucketHasNewerVersion(qry)
-	precise := cc.attribution.preciseDecision(qry)
+	shadowQuery := *qry
+	if shadowQuery.ShadowDatabaseName != "" {
+		shadowQuery.DatabaseName = shadowQuery.ShadowDatabaseName
+	}
+	bucket := cc.bucketHasNewerVersion(&shadowQuery)
+	precise := cc.attribution.preciseDecision(&shadowQuery)
 	endGeneration, endActive := cc.attribution.mutationSnapshot()
 	stable := startActive == 0 && endActive == 0 && startGeneration == endGeneration
 	cc.attribution.recordDecision(consumer, exact, bucket, precise, stable)
@@ -562,13 +566,14 @@ func (cc *CatalogCache) DeleteTable(bat *batch.Batch) {
 		pk := cpks.GetBytesAt(i)
 		cc.tables.cpkeyIndex.Ascend(&TableItem{CPKey: pk, Ts: ts.ToTimestamp()}, func(item *TableItem) bool {
 			newItem := &TableItem{
-				deleted:    true,
-				Id:         item.Id,
-				Name:       item.Name,
-				CPKey:      append([]byte{}, item.CPKey...),
-				AccountId:  item.AccountId,
-				DatabaseId: item.DatabaseId,
-				Ts:         ts.ToTimestamp(),
+				deleted:      true,
+				Id:           item.Id,
+				Name:         item.Name,
+				DatabaseName: item.DatabaseName,
+				CPKey:        append([]byte{}, item.CPKey...),
+				AccountId:    item.AccountId,
+				DatabaseId:   item.DatabaseId,
+				Ts:           ts.ToTimestamp(),
 			}
 			cc.setTableItemLocked(newItem, false)
 			return false

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -55,7 +55,19 @@ func NewCatalog() *CatalogCache {
 			end   types.TS
 		}{start: types.MaxTs()},
 	}
+	if catalogInvalidationAttributionEnabledFromEnv() {
+		cc.attribution = newCatalogInvalidationAttribution()
+	}
 	return cc
+}
+
+// EnableCatalogInvalidationAttribution enables the opt-in experiment for a
+// catalog created by a unit or integration harness. Production callers should
+// use MO_CATALOG_INVALIDATION_ATTRIBUTION=1 at process initialization.
+func (cc *CatalogCache) EnableCatalogInvalidationAttribution() {
+	if cc.attribution == nil {
+		cc.attribution = newCatalogInvalidationAttribution()
+	}
 }
 
 func (cc *CatalogCache) UpdateDuration(start types.TS, end types.TS) {
@@ -407,22 +419,26 @@ func (cc *CatalogCache) GetPreparedMetadataTS() timestamp.Timestamp {
 }
 
 func (cc *CatalogCache) HasNewerVersion(qry *TableChangeQuery) bool {
+	return cc.hasNewerVersion(qry)
+}
+
+// HasNewerVersionFor keeps the exact production decision while recording
+// bucket and precise-shadow decisions when attribution is explicitly enabled.
+func (cc *CatalogCache) HasNewerVersionFor(qry *TableChangeQuery, consumer CatalogInvalidationConsumer) bool {
+	exact := cc.hasNewerVersion(qry)
+	if cc.attribution == nil {
+		return exact
+	}
+	bucket := cc.bucketHasNewerVersion(qry)
+	precise := cc.attribution.preciseDecision(qry)
+	cc.attribution.recordDecision(consumer, exact, bucket, precise)
+	return exact
+}
+
+func (cc *CatalogCache) hasNewerVersion(qry *TableChangeQuery) bool {
 	var find bool
 	if qry.DatabaseName != "" {
-		key := &DatabaseItem{
-			AccountId: qry.AccountId,
-			Name:      qry.DatabaseName,
-			Ts:        types.MaxTs().ToTimestamp(),
-		}
-		cc.databases.data.Ascend(key, func(item *DatabaseItem) bool {
-			if item.AccountId != qry.AccountId || item.Name != qry.DatabaseName {
-				return false
-			}
-			if item.Ts.Greater(qry.Ts) && (item.deleted || item.Id != qry.DatabaseId) {
-				find = true
-			}
-			return false
-		})
+		find = cc.hasNewerDatabase(qry)
 		if find {
 			return true
 		}
@@ -440,12 +456,36 @@ func (cc *CatalogCache) HasNewerVersion(qry *TableChangeQuery) bool {
 		return false
 	}
 
+	return cc.hasNewerTable(qry)
+}
+
+func (cc *CatalogCache) hasNewerDatabase(qry *TableChangeQuery) bool {
+	key := &DatabaseItem{
+		AccountId: qry.AccountId,
+		Name:      qry.DatabaseName,
+		Ts:        types.MaxTs().ToTimestamp(),
+	}
+	var find bool
+	cc.databases.data.Ascend(key, func(item *DatabaseItem) bool {
+		if item.AccountId != qry.AccountId || item.Name != qry.DatabaseName {
+			return false
+		}
+		if item.Ts.Greater(qry.Ts) && (item.deleted || item.Id != qry.DatabaseId) {
+			find = true
+		}
+		return false
+	})
+	return find
+}
+
+func (cc *CatalogCache) hasNewerTable(qry *TableChangeQuery) bool {
 	key := &TableItem{
 		AccountId:  qry.AccountId,
 		DatabaseId: qry.DatabaseId,
 		Name:       qry.Name,
 		Ts:         types.MaxTs().ToTimestamp(), // get the latest version
 	}
+	var find bool
 	cc.tables.data.Ascend(key, func(item *TableItem) bool {
 		if item.AccountId != qry.AccountId || item.DatabaseId != qry.DatabaseId || item.Name != qry.Name {
 			return false
@@ -459,6 +499,25 @@ func (cc *CatalogCache) HasNewerVersion(qry *TableChangeQuery) bool {
 		return false
 	})
 	return find
+}
+
+func (cc *CatalogCache) bucketHasNewerVersion(qry *TableChangeQuery) bool {
+	if qry.DatabaseName != "" && cc.hasNewerDatabase(qry) {
+		return true
+	}
+	if qry.Name == "" {
+		if qry.DatabaseId == 0 {
+			cc.tableChange.RLock()
+			latest := cc.tableChange.byAccount[tableChangeBucket(qry.AccountId)]
+			cc.tableChange.RUnlock()
+			return latest.Greater(qry.Ts)
+		}
+		return false
+	}
+	cc.tableChange.RLock()
+	latest := cc.tableChange.byAccount[tableChangeBucket(qry.AccountId)]
+	cc.tableChange.RUnlock()
+	return latest.Greater(qry.Ts)
 }
 
 func (cc *CatalogCache) GetDatabase(db *DatabaseItem) bool {
@@ -522,6 +581,9 @@ func (cc *CatalogCache) DeleteDatabase(bat *batch.Batch) {
 				Ts:        ts.ToTimestamp(),
 			}
 			cc.databases.data.Set(newItem)
+			if cc.attribution != nil {
+				cc.attribution.observeDatabase(newItem.AccountId, newItem.Name, newItem.Id, newItem.Ts, true)
+			}
 			return false
 		})
 	}
@@ -597,6 +659,12 @@ func (cc *CatalogCache) setTableItemLocked(item *TableItem, updateCPKey bool) {
 	bucket := tableChangeBucket(item.AccountId)
 	if latest := cc.tableChange.byAccount[bucket]; item.Ts.Greater(latest) {
 		cc.tableChange.byAccount[bucket] = item.Ts
+	}
+	if cc.attribution != nil {
+		cc.attribution.observeTable(
+			item.AccountId, item.DatabaseId, item.DatabaseName, item.Name,
+			item.Id, item.Version, item.Ts, item.deleted,
+		)
 	}
 }
 
@@ -704,6 +772,9 @@ func (cc *CatalogCache) InsertDatabase(bat *batch.Batch) {
 	ParseDatabaseBatchAnd(bat, func(item *DatabaseItem) {
 		cc.databases.data.Set(item)
 		cc.databases.cpkeyIndex.Set(item)
+		if cc.attribution != nil {
+			cc.attribution.observeDatabase(item.AccountId, item.Name, item.Id, item.Ts, false)
+		}
 	})
 }
 

--- a/pkg/vm/engine/disttae/cache/catalog_attribution.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -82,6 +83,8 @@ type catalogShadowTableState struct {
 
 type catalogInvalidationCounters struct {
 	checks               uint64
+	stableChecks         uint64
+	inconclusiveChecks   uint64
 	invalidations        uint64
 	bucketInvalidations  uint64
 	preciseInvalidations uint64
@@ -171,6 +174,9 @@ func (h catalogLatencyHistogram) quantile(q float64) int64 {
 type catalogInvalidationAttribution struct {
 	mu sync.Mutex
 
+	activeMutations atomic.Int64
+	generation      atomic.Uint64
+
 	counters         map[CatalogInvalidationConsumer]catalogInvalidationCounters
 	preparedRebuilds catalogLatencyHistogram
 	rcCacheReloads   catalogLatencyHistogram
@@ -181,6 +187,18 @@ type catalogInvalidationAttribution struct {
 	tables         map[catalogShadowTableKey]catalogShadowTableState
 	metadata       CatalogInvalidationReportMetadata
 	shadowOverflow bool
+}
+
+func (a *catalogInvalidationAttribution) beginMutation() func() {
+	a.activeMutations.Add(1)
+	return func() {
+		a.generation.Add(1)
+		a.activeMutations.Add(-1)
+	}
+}
+
+func (a *catalogInvalidationAttribution) mutationSnapshot() (uint64, int64) {
+	return a.generation.Load(), a.activeMutations.Load()
 }
 
 func newCatalogInvalidationAttribution() *catalogInvalidationAttribution {
@@ -304,11 +322,17 @@ func (a *catalogInvalidationAttribution) recordDecision(
 	exact bool,
 	bucket bool,
 	precise bool,
+	stable bool,
 ) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	c := a.counters[consumer]
 	c.checks++
+	if stable {
+		c.stableChecks++
+	} else {
+		c.inconclusiveChecks++
+	}
 	if exact {
 		c.invalidations++
 	}
@@ -318,16 +342,16 @@ func (a *catalogInvalidationAttribution) recordDecision(
 	if precise {
 		c.preciseInvalidations++
 	}
-	if bucket && !exact {
+	if stable && bucket && !exact {
 		c.bucketFalsePositive++
 	}
-	if exact && !bucket {
+	if stable && exact && !bucket {
 		c.bucketFalseNegative++
 	}
-	if precise && !exact {
+	if stable && precise && !exact {
 		c.preciseFalsePositive++
 	}
-	if exact && !precise {
+	if stable && exact && !precise {
 		c.preciseFalseNegative++
 	}
 	a.counters[consumer] = c
@@ -352,6 +376,8 @@ func (a *catalogInvalidationAttribution) recordRCTableCacheReload(d time.Duratio
 // CatalogInvalidationCounter is the JSON-safe per-consumer counter view.
 type CatalogInvalidationCounter struct {
 	Checks                uint64 `json:"checks"`
+	StableChecks          uint64 `json:"stable_checks"`
+	InconclusiveChecks    uint64 `json:"inconclusive_checks"`
 	Invalidations         uint64 `json:"invalidations"`
 	BucketInvalidations   uint64 `json:"bucket_invalidations"`
 	PreciseInvalidations  uint64 `json:"precise_invalidations"`
@@ -373,13 +399,19 @@ type CatalogInvalidationReportMetadata struct {
 
 // CatalogInvalidationLatency is the bounded latency view used in the report.
 type CatalogInvalidationLatency struct {
-	Count   uint64 `json:"count"`
-	Success uint64 `json:"successes"`
-	Error   uint64 `json:"errors"`
-	Miss    uint64 `json:"misses"`
-	P50NS   int64  `json:"p50_ns"`
-	P95NS   int64  `json:"p95_ns"`
-	P99NS   int64  `json:"p99_ns"`
+	Count   uint64                             `json:"count"`
+	Success uint64                             `json:"successes"`
+	Error   uint64                             `json:"errors"`
+	Miss    uint64                             `json:"misses"`
+	P50NS   int64                              `json:"p50_ns"`
+	P95NS   int64                              `json:"p95_ns"`
+	P99NS   int64                              `json:"p99_ns"`
+	Buckets []CatalogInvalidationLatencyBucket `json:"buckets"`
+}
+
+type CatalogInvalidationLatencyBucket struct {
+	UpperBoundNS int64  `json:"upper_bound_ns"`
+	Count        uint64 `json:"count"`
 }
 
 // CatalogInvalidationShadow is a bounded-state summary of the precise shadow
@@ -406,9 +438,21 @@ type CatalogInvalidationReport struct {
 }
 
 func histogramReport(h catalogLatencyHistogram) CatalogInvalidationLatency {
+	buckets := make([]CatalogInvalidationLatencyBucket, 0, len(h.bucket))
+	for i, count := range h.bucket {
+		upperBound := int64(-1)
+		if i < len(catalogLatencyBounds) {
+			upperBound = int64(catalogLatencyBounds[i])
+		}
+		buckets = append(buckets, CatalogInvalidationLatencyBucket{
+			UpperBoundNS: upperBound,
+			Count:        count,
+		})
+	}
 	return CatalogInvalidationLatency{
 		Count: h.count, Success: h.success, Error: h.error, Miss: h.miss,
 		P50NS: h.quantile(0.50), P95NS: h.quantile(0.95), P99NS: h.quantile(0.99),
+		Buckets: buckets,
 	}
 }
 
@@ -419,6 +463,8 @@ func (a *catalogInvalidationAttribution) report() CatalogInvalidationReport {
 	for consumer, c := range a.counters {
 		consumers[consumer.String()] = CatalogInvalidationCounter{
 			Checks:                c.checks,
+			StableChecks:          c.stableChecks,
+			InconclusiveChecks:    c.inconclusiveChecks,
 			Invalidations:         c.invalidations,
 			BucketInvalidations:   c.bucketInvalidations,
 			PreciseInvalidations:  c.preciseInvalidations,
@@ -440,7 +486,7 @@ func (a *catalogInvalidationAttribution) report() CatalogInvalidationReport {
 		retained += uint64(stringSize(key.name) + len(key.databaseName) + 40)
 	}
 	return CatalogInvalidationReport{
-		SchemaVersion:       1,
+		SchemaVersion:       2,
 		Enabled:             true,
 		Metadata:            a.metadata,
 		Consumers:           consumers,
@@ -501,7 +547,7 @@ func (cc *CatalogCache) RecordRCTableCacheReload(d time.Duration, outcome Catalo
 func (cc *CatalogCache) SnapshotCatalogInvalidationReport() CatalogInvalidationReport {
 	if cc.attribution == nil {
 		return CatalogInvalidationReport{
-			SchemaVersion: 1,
+			SchemaVersion: 2,
 			Enabled:       false,
 			Consumers:     map[string]CatalogInvalidationCounter{},
 			Events:        map[string]uint64{},

--- a/pkg/vm/engine/disttae/cache/catalog_attribution.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution.go
@@ -1,0 +1,484 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+)
+
+const catalogInvalidationAttributionEnv = "MO_CATALOG_INVALIDATION_ATTRIBUTION"
+
+// Shadow state is diagnostic only. A hard cap makes retained memory explicit;
+// once reached, the shadow becomes conservative for all subsequent queries
+// instead of retaining unbounded tenant/table churn.
+const catalogShadowEntryLimit = 1 << 16
+
+// CatalogInvalidationConsumer identifies the production consumer that asked
+// whether a catalog dependency is stale. It is intentionally small and
+// stable because it is serialized in the experiment report.
+type CatalogInvalidationConsumer uint8
+
+const (
+	CatalogInvalidationConsumerUnknown CatalogInvalidationConsumer = iota
+	CatalogInvalidationConsumerPreparedPlan
+	CatalogInvalidationConsumerRCTableCache
+)
+
+func (c CatalogInvalidationConsumer) String() string {
+	switch c {
+	case CatalogInvalidationConsumerPreparedPlan:
+		return "prepared_plan"
+	case CatalogInvalidationConsumerRCTableCache:
+		return "rc_table_cache"
+	default:
+		return "unknown"
+	}
+}
+
+type catalogShadowDatabaseKey struct {
+	accountID uint32
+	name      string
+}
+
+type catalogShadowTableKey struct {
+	accountID    uint32
+	databaseID   uint64
+	databaseName string
+	name         string
+}
+
+type catalogShadowDatabaseState struct {
+	id        uint64
+	ts        timestamp.Timestamp
+	deleted   bool
+	ambiguous bool
+}
+
+type catalogShadowTableState struct {
+	id        uint64
+	version   uint32
+	ts        timestamp.Timestamp
+	deleted   bool
+	ambiguous bool
+}
+
+type catalogInvalidationCounters struct {
+	checks               uint64
+	invalidations        uint64
+	bucketInvalidations  uint64
+	preciseInvalidations uint64
+	bucketFalsePositive  uint64
+	bucketFalseNegative  uint64
+	preciseFalsePositive uint64
+	preciseFalseNegative uint64
+}
+
+type catalogLatencyHistogram struct {
+	count  uint64
+	bucket [13]uint64
+}
+
+// The histogram is deliberately bounded. The last bucket is an overflow
+// bucket, so a long-running attribution process cannot retain one sample per
+// request.
+var catalogLatencyBounds = [...]time.Duration{
+	1 * time.Microsecond,
+	5 * time.Microsecond,
+	10 * time.Microsecond,
+	25 * time.Microsecond,
+	50 * time.Microsecond,
+	100 * time.Microsecond,
+	250 * time.Microsecond,
+	500 * time.Microsecond,
+	1 * time.Millisecond,
+	5 * time.Millisecond,
+	10 * time.Millisecond,
+	100 * time.Millisecond,
+}
+
+func (h *catalogLatencyHistogram) observe(d time.Duration) {
+	h.count++
+	for i, bound := range catalogLatencyBounds {
+		if d <= bound {
+			h.bucket[i]++
+			return
+		}
+	}
+	h.bucket[len(h.bucket)-1]++
+}
+
+func (h catalogLatencyHistogram) quantile(q float64) int64 {
+	if h.count == 0 {
+		return 0
+	}
+	target := uint64(float64(h.count-1)*q) + 1
+	var seen uint64
+	for i, count := range h.bucket {
+		seen += count
+		if seen >= target {
+			if i >= len(catalogLatencyBounds) {
+				return int64(catalogLatencyBounds[len(catalogLatencyBounds)-1]) * 10
+			}
+			return int64(catalogLatencyBounds[i])
+		}
+	}
+	return int64(catalogLatencyBounds[len(catalogLatencyBounds)-1]) * 10
+}
+
+type catalogInvalidationAttribution struct {
+	mu sync.Mutex
+
+	counters         map[CatalogInvalidationConsumer]catalogInvalidationCounters
+	preparedRebuilds catalogLatencyHistogram
+	rcCacheReloads   catalogLatencyHistogram
+	events           map[string]uint64
+
+	accountLatest  map[uint32]timestamp.Timestamp
+	databases      map[catalogShadowDatabaseKey]catalogShadowDatabaseState
+	tables         map[catalogShadowTableKey]catalogShadowTableState
+	metadata       CatalogInvalidationReportMetadata
+	shadowOverflow bool
+}
+
+func newCatalogInvalidationAttribution() *catalogInvalidationAttribution {
+	return &catalogInvalidationAttribution{
+		counters:      make(map[CatalogInvalidationConsumer]catalogInvalidationCounters),
+		events:        make(map[string]uint64),
+		accountLatest: make(map[uint32]timestamp.Timestamp),
+		databases:     make(map[catalogShadowDatabaseKey]catalogShadowDatabaseState),
+		tables:        make(map[catalogShadowTableKey]catalogShadowTableState),
+	}
+}
+
+func catalogInvalidationAttributionEnabledFromEnv() bool {
+	return os.Getenv(catalogInvalidationAttributionEnv) == "1"
+}
+
+func (a *catalogInvalidationAttribution) observeTable(
+	accountID uint32,
+	databaseID uint64,
+	databaseName string,
+	name string,
+	id uint64,
+	version uint32,
+	ts timestamp.Timestamp,
+	deleted bool,
+) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	event := "table_upsert"
+	if deleted {
+		event = "table_delete"
+	}
+	a.events[event]++
+	if _, ok := a.accountLatest[accountID]; !ok && len(a.accountLatest) >= catalogShadowEntryLimit {
+		a.shadowOverflow = true
+	} else if latest, ok := a.accountLatest[accountID]; !ok || ts.Greater(latest) {
+		a.accountLatest[accountID] = ts
+	}
+	key := catalogShadowTableKey{
+		accountID: accountID, databaseID: databaseID, databaseName: databaseName, name: name,
+	}
+	state, ok := a.tables[key]
+	if !ok || ts.Greater(state.ts) {
+		if !ok && len(a.tables) >= catalogShadowEntryLimit {
+			a.shadowOverflow = true
+			return
+		}
+		a.tables[key] = catalogShadowTableState{id: id, version: version, ts: ts, deleted: deleted}
+		return
+	}
+	if !state.ts.Greater(ts) && (state.id != id || state.version != version || state.deleted != deleted) {
+		state.ambiguous = true
+		a.tables[key] = state
+	}
+}
+
+func (a *catalogInvalidationAttribution) observeDatabase(
+	accountID uint32,
+	name string,
+	id uint64,
+	ts timestamp.Timestamp,
+	deleted bool,
+) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	event := "database_insert"
+	if deleted {
+		event = "database_delete"
+	}
+	a.events[event]++
+	key := catalogShadowDatabaseKey{accountID: accountID, name: name}
+	state, ok := a.databases[key]
+	if !ok || ts.Greater(state.ts) {
+		if !ok && len(a.databases) >= catalogShadowEntryLimit {
+			a.shadowOverflow = true
+			return
+		}
+		a.databases[key] = catalogShadowDatabaseState{id: id, ts: ts, deleted: deleted}
+		return
+	}
+	if !state.ts.Greater(ts) && (state.id != id || state.deleted != deleted) {
+		state.ambiguous = true
+		a.databases[key] = state
+	}
+}
+
+func (a *catalogInvalidationAttribution) preciseDecision(qry *TableChangeQuery) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.shadowOverflow {
+		return true
+	}
+	if qry.DatabaseName != "" {
+		state, ok := a.databases[catalogShadowDatabaseKey{accountID: qry.AccountId, name: qry.DatabaseName}]
+		if ok && state.ts.Greater(qry.Ts) && (state.deleted || state.id != qry.DatabaseId || state.ambiguous) {
+			return true
+		}
+	}
+	if qry.Name == "" {
+		if qry.DatabaseId == 0 {
+			return a.accountLatest[qry.AccountId].Greater(qry.Ts)
+		}
+		return false
+	}
+	state, ok := a.tables[catalogShadowTableKey{
+		accountID: qry.AccountId, databaseID: qry.DatabaseId,
+		databaseName: qry.DatabaseName, name: qry.Name,
+	}]
+	if !ok || !state.ts.Greater(qry.Ts) {
+		return false
+	}
+	return state.deleted || state.id != qry.TableId || state.version > qry.Version || state.ambiguous
+}
+
+func (a *catalogInvalidationAttribution) recordDecision(
+	consumer CatalogInvalidationConsumer,
+	exact bool,
+	bucket bool,
+	precise bool,
+) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	c := a.counters[consumer]
+	c.checks++
+	if exact {
+		c.invalidations++
+	}
+	if bucket {
+		c.bucketInvalidations++
+	}
+	if precise {
+		c.preciseInvalidations++
+	}
+	if bucket && !exact {
+		c.bucketFalsePositive++
+	}
+	if exact && !bucket {
+		c.bucketFalseNegative++
+	}
+	if precise && !exact {
+		c.preciseFalsePositive++
+	}
+	if exact && !precise {
+		c.preciseFalseNegative++
+	}
+	a.counters[consumer] = c
+}
+
+func (a *catalogInvalidationAttribution) recordPreparedRebuild(d time.Duration) {
+	a.mu.Lock()
+	a.preparedRebuilds.observe(d)
+	a.mu.Unlock()
+}
+
+func (a *catalogInvalidationAttribution) recordRCTableCacheReload(d time.Duration) {
+	a.mu.Lock()
+	a.rcCacheReloads.observe(d)
+	a.mu.Unlock()
+}
+
+// CatalogInvalidationCounter is the JSON-safe per-consumer counter view.
+type CatalogInvalidationCounter struct {
+	Checks                uint64 `json:"checks"`
+	Invalidations         uint64 `json:"invalidations"`
+	BucketInvalidations   uint64 `json:"bucket_invalidations"`
+	PreciseInvalidations  uint64 `json:"precise_invalidations"`
+	BucketFalsePositives  uint64 `json:"bucket_false_positives"`
+	BucketFalseNegatives  uint64 `json:"bucket_false_negatives"`
+	PreciseFalsePositives uint64 `json:"precise_false_positives"`
+	PreciseFalseNegatives uint64 `json:"precise_false_negatives"`
+}
+
+// CatalogInvalidationReportMetadata identifies the experiment input and
+// collection window. The cache does not infer these values from the process;
+// the harness records them explicitly before publishing an artifact.
+type CatalogInvalidationReportMetadata struct {
+	MatrixONESHA string `json:"matrixone_sha,omitempty"`
+	Config       string `json:"config,omitempty"`
+	Window       string `json:"window,omitempty"`
+	Integrity    string `json:"integrity,omitempty"`
+}
+
+// CatalogInvalidationLatency is the bounded latency view used in the report.
+type CatalogInvalidationLatency struct {
+	Count uint64 `json:"count"`
+	P50NS int64  `json:"p50_ns"`
+	P95NS int64  `json:"p95_ns"`
+	P99NS int64  `json:"p99_ns"`
+}
+
+// CatalogInvalidationShadow is a bounded-state summary of the precise shadow
+// oracle. The retained-byte value is an estimate for experiment comparison,
+// not an allocation-accounting claim.
+type CatalogInvalidationShadow struct {
+	Accounts               int    `json:"accounts"`
+	DatabaseEntries        int    `json:"database_entries"`
+	TableEntries           int    `json:"table_entries"`
+	Overflow               bool   `json:"overflow"`
+	EstimatedRetainedBytes uint64 `json:"estimated_retained_bytes"`
+}
+
+// CatalogInvalidationReport is stable JSON output for the attribution PR.
+type CatalogInvalidationReport struct {
+	SchemaVersion       int                                   `json:"schema_version"`
+	Enabled             bool                                  `json:"enabled"`
+	Metadata            CatalogInvalidationReportMetadata     `json:"metadata"`
+	Consumers           map[string]CatalogInvalidationCounter `json:"consumers"`
+	Events              map[string]uint64                     `json:"events"`
+	PreparedPlanRebuild CatalogInvalidationLatency            `json:"prepared_plan_rebuild"`
+	RCTableCacheReload  CatalogInvalidationLatency            `json:"rc_table_cache_reload"`
+	Shadow              CatalogInvalidationShadow             `json:"shadow"`
+}
+
+func histogramReport(h catalogLatencyHistogram) CatalogInvalidationLatency {
+	return CatalogInvalidationLatency{
+		Count: h.count,
+		P50NS: h.quantile(0.50),
+		P95NS: h.quantile(0.95),
+		P99NS: h.quantile(0.99),
+	}
+}
+
+func (a *catalogInvalidationAttribution) report() CatalogInvalidationReport {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	consumers := make(map[string]CatalogInvalidationCounter, len(a.counters))
+	for consumer, c := range a.counters {
+		consumers[consumer.String()] = CatalogInvalidationCounter{
+			Checks:                c.checks,
+			Invalidations:         c.invalidations,
+			BucketInvalidations:   c.bucketInvalidations,
+			PreciseInvalidations:  c.preciseInvalidations,
+			BucketFalsePositives:  c.bucketFalsePositive,
+			BucketFalseNegatives:  c.bucketFalseNegative,
+			PreciseFalsePositives: c.preciseFalsePositive,
+			PreciseFalseNegatives: c.preciseFalseNegative,
+		}
+	}
+	accounts := make(map[uint32]struct{}, len(a.accountLatest))
+	for account := range a.accountLatest {
+		accounts[account] = struct{}{}
+	}
+	var retained uint64
+	for key := range a.databases {
+		retained += uint64(stringSize(key.name) + 32)
+	}
+	for key := range a.tables {
+		retained += uint64(stringSize(key.name) + len(key.databaseName) + 40)
+	}
+	return CatalogInvalidationReport{
+		SchemaVersion:       1,
+		Enabled:             true,
+		Metadata:            a.metadata,
+		Consumers:           consumers,
+		Events:              cloneUint64Map(a.events),
+		PreparedPlanRebuild: histogramReport(a.preparedRebuilds),
+		RCTableCacheReload:  histogramReport(a.rcCacheReloads),
+		Shadow: CatalogInvalidationShadow{
+			Accounts: len(accounts), DatabaseEntries: len(a.databases),
+			TableEntries: len(a.tables), Overflow: a.shadowOverflow,
+			EstimatedRetainedBytes: retained,
+		},
+	}
+}
+
+func cloneUint64Map(src map[string]uint64) map[string]uint64 {
+	dst := make(map[string]uint64, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func stringSize(value string) int {
+	return len(value)
+}
+
+// SetCatalogInvalidationReportMetadata attaches exact identity information to
+// the next report. It is intended for an experiment harness before collection
+// starts and is not a production configuration API.
+func (cc *CatalogCache) SetCatalogInvalidationReportMetadata(metadata CatalogInvalidationReportMetadata) {
+	if cc.attribution == nil {
+		return
+	}
+	cc.attribution.mu.Lock()
+	cc.attribution.metadata = metadata
+	cc.attribution.mu.Unlock()
+}
+
+// CatalogInvalidationAttributionEnabled reports whether this cache has the
+// opt-in experiment state. The pointer is initialized once during startup.
+func (cc *CatalogCache) CatalogInvalidationAttributionEnabled() bool {
+	return cc.attribution != nil
+}
+
+func (cc *CatalogCache) RecordPreparedPlanRebuild(d time.Duration) {
+	if cc.attribution != nil {
+		cc.attribution.recordPreparedRebuild(d)
+	}
+}
+
+func (cc *CatalogCache) RecordRCTableCacheReload(d time.Duration) {
+	if cc.attribution != nil {
+		cc.attribution.recordRCTableCacheReload(d)
+	}
+}
+
+// SnapshotCatalogInvalidationReport returns a bounded, JSON-safe snapshot.
+func (cc *CatalogCache) SnapshotCatalogInvalidationReport() CatalogInvalidationReport {
+	if cc.attribution == nil {
+		return CatalogInvalidationReport{
+			SchemaVersion: 1,
+			Enabled:       false,
+			Consumers:     map[string]CatalogInvalidationCounter{},
+			Events:        map[string]uint64{},
+		}
+	}
+	return cc.attribution.report()
+}
+
+// WriteCatalogInvalidationReport writes the report without prescribing a
+// filesystem or service endpoint. Experiment harnesses choose the artifact
+// path and can include the exact binary/config identity alongside it.
+func (cc *CatalogCache) WriteCatalogInvalidationReport(w io.Writer) error {
+	return json.NewEncoder(w).Encode(cc.SnapshotCatalogInvalidationReport())
+}

--- a/pkg/vm/engine/disttae/cache/catalog_attribution.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution.go
@@ -228,7 +228,9 @@ func (a *catalogInvalidationAttribution) observeTable(
 			a.shadowOverflow = true
 			return
 		}
-		a.tables[key] = catalogShadowTableState{id: id, version: version, ts: ts, deleted: deleted}
+		a.tables[key] = catalogShadowTableState{
+			id: id, version: version, ts: ts, deleted: deleted, ambiguous: state.ambiguous,
+		}
 		return
 	}
 	if !state.ts.Greater(ts) && (state.id != id || state.version != version || state.deleted != deleted) {
@@ -258,7 +260,9 @@ func (a *catalogInvalidationAttribution) observeDatabase(
 			a.shadowOverflow = true
 			return
 		}
-		a.databases[key] = catalogShadowDatabaseState{id: id, ts: ts, deleted: deleted}
+		a.databases[key] = catalogShadowDatabaseState{
+			id: id, ts: ts, deleted: deleted, ambiguous: state.ambiguous,
+		}
 		return
 	}
 	if !state.ts.Greater(ts) && (state.id != id || state.deleted != deleted) {

--- a/pkg/vm/engine/disttae/cache/catalog_attribution.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution.go
@@ -92,9 +92,22 @@ type catalogInvalidationCounters struct {
 }
 
 type catalogLatencyHistogram struct {
-	count  uint64
-	bucket [13]uint64
+	count   uint64
+	success uint64
+	error   uint64
+	miss    uint64
+	bucket  [13]uint64
 }
+
+// CatalogInvalidationOutcome describes the terminal result of a consumer
+// rebuild/reload attempt in the attribution report.
+type CatalogInvalidationOutcome uint8
+
+const (
+	CatalogInvalidationSuccess CatalogInvalidationOutcome = iota
+	CatalogInvalidationError
+	CatalogInvalidationMiss
+)
 
 // The histogram is deliberately bounded. The last bucket is an overflow
 // bucket, so a long-running attribution process cannot retain one sample per
@@ -115,7 +128,19 @@ var catalogLatencyBounds = [...]time.Duration{
 }
 
 func (h *catalogLatencyHistogram) observe(d time.Duration) {
+	h.record(d, CatalogInvalidationSuccess)
+}
+
+func (h *catalogLatencyHistogram) record(d time.Duration, outcome CatalogInvalidationOutcome) {
 	h.count++
+	switch outcome {
+	case CatalogInvalidationSuccess:
+		h.success++
+	case CatalogInvalidationError:
+		h.error++
+	case CatalogInvalidationMiss:
+		h.miss++
+	}
 	for i, bound := range catalogLatencyBounds {
 		if d <= bound {
 			h.bucket[i]++
@@ -304,15 +329,19 @@ func (a *catalogInvalidationAttribution) recordDecision(
 	a.counters[consumer] = c
 }
 
-func (a *catalogInvalidationAttribution) recordPreparedRebuild(d time.Duration) {
+func (a *catalogInvalidationAttribution) recordPreparedRebuild(d time.Duration, success bool) {
 	a.mu.Lock()
-	a.preparedRebuilds.observe(d)
+	outcome := CatalogInvalidationError
+	if success {
+		outcome = CatalogInvalidationSuccess
+	}
+	a.preparedRebuilds.record(d, outcome)
 	a.mu.Unlock()
 }
 
-func (a *catalogInvalidationAttribution) recordRCTableCacheReload(d time.Duration) {
+func (a *catalogInvalidationAttribution) recordRCTableCacheReload(d time.Duration, outcome CatalogInvalidationOutcome) {
 	a.mu.Lock()
-	a.rcCacheReloads.observe(d)
+	a.rcCacheReloads.record(d, outcome)
 	a.mu.Unlock()
 }
 
@@ -340,10 +369,13 @@ type CatalogInvalidationReportMetadata struct {
 
 // CatalogInvalidationLatency is the bounded latency view used in the report.
 type CatalogInvalidationLatency struct {
-	Count uint64 `json:"count"`
-	P50NS int64  `json:"p50_ns"`
-	P95NS int64  `json:"p95_ns"`
-	P99NS int64  `json:"p99_ns"`
+	Count   uint64 `json:"count"`
+	Success uint64 `json:"successes"`
+	Error   uint64 `json:"errors"`
+	Miss    uint64 `json:"misses"`
+	P50NS   int64  `json:"p50_ns"`
+	P95NS   int64  `json:"p95_ns"`
+	P99NS   int64  `json:"p99_ns"`
 }
 
 // CatalogInvalidationShadow is a bounded-state summary of the precise shadow
@@ -371,10 +403,8 @@ type CatalogInvalidationReport struct {
 
 func histogramReport(h catalogLatencyHistogram) CatalogInvalidationLatency {
 	return CatalogInvalidationLatency{
-		Count: h.count,
-		P50NS: h.quantile(0.50),
-		P95NS: h.quantile(0.95),
-		P99NS: h.quantile(0.99),
+		Count: h.count, Success: h.success, Error: h.error, Miss: h.miss,
+		P50NS: h.quantile(0.50), P95NS: h.quantile(0.95), P99NS: h.quantile(0.99),
 	}
 }
 
@@ -451,15 +481,15 @@ func (cc *CatalogCache) CatalogInvalidationAttributionEnabled() bool {
 	return cc.attribution != nil
 }
 
-func (cc *CatalogCache) RecordPreparedPlanRebuild(d time.Duration) {
+func (cc *CatalogCache) RecordPreparedPlanRebuild(d time.Duration, success bool) {
 	if cc.attribution != nil {
-		cc.attribution.recordPreparedRebuild(d)
+		cc.attribution.recordPreparedRebuild(d, success)
 	}
 }
 
-func (cc *CatalogCache) RecordRCTableCacheReload(d time.Duration) {
+func (cc *CatalogCache) RecordRCTableCacheReload(d time.Duration, outcome CatalogInvalidationOutcome) {
 	if cc.attribution != nil {
-		cc.attribution.recordRCTableCacheReload(d)
+		cc.attribution.recordRCTableCacheReload(d, outcome)
 	}
 }
 

--- a/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
@@ -61,9 +61,34 @@ func TestCatalogInvalidationAttributionDifferentialAndCollision(t *testing.T) {
 	report := cc.SnapshotCatalogInvalidationReport()
 	require.True(t, report.Enabled)
 	require.Equal(t, uint64(1), report.Consumers["prepared_plan"].Checks)
+	require.Equal(t, uint64(1), report.Consumers["prepared_plan"].StableChecks)
+	require.Zero(t, report.Consumers["prepared_plan"].InconclusiveChecks)
 	require.Zero(t, report.Consumers["prepared_plan"].PreciseFalseNegatives)
 	require.Equal(t, uint64(1), report.Consumers["rc_table_cache"].BucketFalsePositives)
 	require.Zero(t, report.Consumers["rc_table_cache"].PreciseFalsePositives)
+}
+
+func TestCatalogInvalidationConcurrentMutationIsInconclusive(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	cc.setTableItem(&TableItem{
+		AccountId: 1, DatabaseId: 10, Name: "t", Id: 20, Version: 1,
+		Ts: timestamp.Timestamp{PhysicalTime: 100},
+	}, true)
+	query := &TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20,
+		Version: 1, Ts: timestamp.Timestamp{PhysicalTime: 200},
+	}
+
+	endMutation := cc.attribution.beginMutation()
+	defer endMutation()
+	require.False(t, cc.HasNewerVersionFor(query, CatalogInvalidationConsumerPreparedPlan))
+
+	counter := cc.SnapshotCatalogInvalidationReport().Consumers["prepared_plan"]
+	require.Equal(t, uint64(1), counter.Checks)
+	require.Zero(t, counter.StableChecks)
+	require.Equal(t, uint64(1), counter.InconclusiveChecks)
+	require.Zero(t, counter.PreciseFalseNegatives)
 }
 
 func TestCatalogInvalidationShadowIgnoresReplayAndReportsMetadata(t *testing.T) {
@@ -86,6 +111,7 @@ func TestCatalogInvalidationShadowIgnoresReplayAndReportsMetadata(t *testing.T) 
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &report))
 	require.Equal(t, "test-sha", report.Metadata.MatrixONESHA)
 	require.Equal(t, "complete", report.Metadata.Integrity)
+	require.Len(t, report.PreparedPlanRebuild.Buckets, len(catalogLatencyBounds)+1)
 }
 
 func TestCatalogInvalidationShadowDatabaseRecreation(t *testing.T) {
@@ -115,6 +141,183 @@ func TestCatalogInvalidationShadowEqualTimestampConflictIsConservative(t *testin
 		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20, Version: 3,
 		Ts: timestamp.Timestamp{PhysicalTime: 250},
 	}))
+}
+
+func TestCatalogInvalidationDifferentialMatrix(t *testing.T) {
+	assertTable := func(t *testing.T, cc *CatalogCache, query *TableChangeQuery) {
+		t.Helper()
+		exact := cc.hasNewerVersion(query)
+		precise := cc.attribution.preciseDecision(query)
+		require.Equal(t, exact, precise, "query=%+v", query)
+	}
+
+	t.Run("table lifecycle", func(t *testing.T) {
+		cc := NewCatalog()
+		cc.EnableCatalogInvalidationAttribution()
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", Id: 20,
+			Version: 1, Ts: timestamp.Timestamp{PhysicalTime: 100},
+		}, true)
+		assertTable(t, cc, &TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20,
+			Version: 1, Ts: timestamp.Timestamp{PhysicalTime: 200},
+		})
+
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", Id: 20,
+			Version: 2, Ts: timestamp.Timestamp{PhysicalTime: 300},
+		}, true)
+		assertTable(t, cc, &TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20,
+			Version: 1, Ts: timestamp.Timestamp{PhysicalTime: 200},
+		})
+
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", Id: 20,
+			deleted: true, Ts: timestamp.Timestamp{PhysicalTime: 400},
+		}, false)
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", Id: 21,
+			Version: 1, Ts: timestamp.Timestamp{PhysicalTime: 500},
+		}, true)
+		assertTable(t, cc, &TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20,
+			Version: 2, Ts: timestamp.Timestamp{PhysicalTime: 350},
+		})
+
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "old", Id: 20,
+			deleted: true, Ts: timestamp.Timestamp{PhysicalTime: 600},
+		}, false)
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "new", Id: 21,
+			Version: 1, Ts: timestamp.Timestamp{PhysicalTime: 700},
+		}, true)
+		assertTable(t, cc, &TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "old", TableId: 20,
+			Version: 2, Ts: timestamp.Timestamp{PhysicalTime: 550},
+		})
+	})
+
+	t.Run("database identity and empty recreation", func(t *testing.T) {
+		cc := NewCatalog()
+		cc.EnableCatalogInvalidationAttribution()
+		cc.databases.data.Set(&DatabaseItem{
+			AccountId: 1, Name: "db", Id: 20, Ts: timestamp.Timestamp{PhysicalTime: 200},
+		})
+		cc.attribution.observeDatabase(1, "db", 20, timestamp.Timestamp{PhysicalTime: 200}, false)
+		require.True(t, cc.hasNewerVersion(&TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Ts: timestamp.Timestamp{PhysicalTime: 100},
+		}))
+		require.True(t, cc.attribution.preciseDecision(&TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Ts: timestamp.Timestamp{PhysicalTime: 100},
+		}))
+		cc.databases.data.Set(&DatabaseItem{
+			AccountId: 1, Name: "db", Id: 21, deleted: true, Ts: timestamp.Timestamp{PhysicalTime: 300},
+		})
+		cc.attribution.observeDatabase(1, "db", 21, timestamp.Timestamp{PhysicalTime: 300}, true)
+		cc.databases.data.Set(&DatabaseItem{
+			AccountId: 1, Name: "db", Id: 22, Ts: timestamp.Timestamp{PhysicalTime: 400},
+		})
+		cc.attribution.observeDatabase(1, "db", 22, timestamp.Timestamp{PhysicalTime: 400}, false)
+		require.True(t, cc.hasNewerVersion(&TableChangeQuery{
+			AccountId: 1, DatabaseId: 20, DatabaseName: "db", Ts: timestamp.Timestamp{PhysicalTime: 250},
+		}))
+		require.True(t, cc.attribution.preciseDecision(&TableChangeQuery{
+			AccountId: 1, DatabaseId: 20, DatabaseName: "db", Ts: timestamp.Timestamp{PhysicalTime: 250},
+		}))
+	})
+
+	t.Run("same account and collision", func(t *testing.T) {
+		cc := NewCatalog()
+		cc.EnableCatalogInvalidationAttribution()
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "other", Id: 30,
+			Ts: timestamp.Timestamp{PhysicalTime: 500},
+		}, true)
+		query := &TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "target", TableId: 40,
+			Ts: timestamp.Timestamp{PhysicalTime: 400},
+		}
+		require.False(t, cc.hasNewerVersion(query))
+		require.False(t, cc.attribution.preciseDecision(query))
+		require.True(t, cc.bucketHasNewerVersion(query))
+		collision := *query
+		collision.AccountId += tableChangeBucketCount
+		require.False(t, cc.hasNewerVersion(&collision))
+		require.False(t, cc.attribution.preciseDecision(&collision))
+		require.True(t, cc.bucketHasNewerVersion(&collision))
+	})
+
+	t.Run("timestamp boundaries and gc", func(t *testing.T) {
+		cc := NewCatalog()
+		cc.EnableCatalogInvalidationAttribution()
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", Id: 20,
+			Version: 3, Ts: timestamp.Timestamp{PhysicalTime: 500},
+		}, true)
+		for _, tc := range []struct {
+			name string
+			ts   int64
+			ver  uint32
+			want bool
+		}{
+			{name: "older changed", ts: 499, ver: 2, want: true},
+			{name: "equal", ts: 500, ver: 3, want: false},
+			{name: "newer", ts: 501, ver: 3, want: false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				query := &TableChangeQuery{
+					AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20,
+					Version: tc.ver, Ts: timestamp.Timestamp{PhysicalTime: tc.ts},
+				}
+				require.Equal(t, tc.want, cc.hasNewerVersion(query))
+				require.Equal(t, tc.want, cc.attribution.preciseDecision(query))
+			})
+		}
+		cc.setTableItem(&TableItem{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", Id: 20,
+			Version: 2, Ts: timestamp.Timestamp{PhysicalTime: 400},
+		}, true)
+		cc.GC(timestamp.Timestamp{PhysicalTime: 600})
+		require.False(t, cc.attribution.preciseDecision(&TableChangeQuery{
+			AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20,
+			Version: 3, Ts: timestamp.Timestamp{PhysicalTime: 500},
+		}))
+	})
+}
+
+func TestCatalogInvalidationDifferentialRandomizedSequences(t *testing.T) {
+	const seed uint64 = 27235
+	state := seed
+	next := func(limit uint64) uint64 {
+		state = state*6364136223846793005 + 1442695040888963407
+		return state % limit
+	}
+
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	for step := 1; step <= 4096; step++ {
+		account := uint32(1 + next(4))
+		databaseID := uint64(10 + next(4))
+		name := "t" + strconv.FormatUint(next(4), 10)
+		ts := timestamp.Timestamp{PhysicalTime: int64(step)}
+		if next(3) != 0 {
+			cc.setTableItem(&TableItem{
+				AccountId: account, DatabaseId: databaseID, DatabaseName: "db",
+				Name: name, Id: uint64(100 + next(8)), Version: uint32(1 + next(4)),
+				Ts: ts, deleted: next(5) == 0,
+			}, true)
+			continue
+		}
+		query := &TableChangeQuery{
+			AccountId: account, DatabaseId: databaseID, DatabaseName: "db", Name: name,
+			TableId: uint64(100 + next(8)), Version: uint32(1 + next(4)), Ts: ts,
+		}
+		exact := cc.hasNewerVersion(query)
+		precise := cc.attribution.preciseDecision(query)
+		require.Equal(t, exact, precise, "seed=%d step=%d query=%+v", seed, step, query)
+	}
 }
 
 func TestCatalogInvalidationShadowCapFailsClosed(t *testing.T) {
@@ -157,55 +360,72 @@ func TestCatalogInvalidationPreciseNoChangeDoesNotAllocate(t *testing.T) {
 }
 
 func BenchmarkCatalogInvalidationOracles(b *testing.B) {
-	query := &TableChangeQuery{
-		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20, Version: 3,
-		Ts: timestamp.Timestamp{PhysicalTime: 1000},
-	}
 	for _, history := range []int{1, 16, 256, 4096} {
-		b.Run("history="+strconv.Itoa(history)+"/exact", func(b *testing.B) {
-			cc := NewCatalog()
-			for i := 0; i < history; i++ {
-				cc.setTableItem(&TableItem{
-					AccountId: 1, DatabaseId: uint64(100 + i), Name: "history", Id: uint64(i + 1),
-					Ts: timestamp.Timestamp{PhysicalTime: int64(i + 1)},
-				}, true)
+		for _, changed := range []bool{false, true} {
+			state := "warmed-negative"
+			if changed {
+				state = "changed"
 			}
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				cc.HasNewerVersion(query)
+			query := &TableChangeQuery{
+				AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: uint64(history),
+				Version: uint32(history), Ts: timestamp.Timestamp{PhysicalTime: int64(history)},
 			}
-		})
+			if changed {
+				query.Version--
+				query.Ts.PhysicalTime--
+			} else {
+				query.Ts.PhysicalTime++
+			}
+			seed := func(cc *CatalogCache) {
+				for i := 0; i < history; i++ {
+					cc.setTableItem(&TableItem{
+						AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t",
+						Id: uint64(i + 1), Version: uint32(i + 1),
+						Ts: timestamp.Timestamp{PhysicalTime: int64(i + 1)},
+					}, true)
+				}
+			}
+			b.Run("history="+strconv.Itoa(history)+"/"+state+"/exact", func(b *testing.B) {
+				cc := NewCatalog()
+				seed(cc)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					cc.HasNewerVersion(query)
+				}
+			})
 
-		b.Run("history="+strconv.Itoa(history)+"/bucket", func(b *testing.B) {
-			cc := NewCatalog()
-			for i := 0; i < history; i++ {
-				cc.setTableItem(&TableItem{
-					AccountId: 1, DatabaseId: uint64(100 + i), Name: "history", Id: uint64(i + 1),
-					Ts: timestamp.Timestamp{PhysicalTime: int64(i + 1)},
-				}, true)
-			}
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				cc.bucketHasNewerVersion(query)
-			}
-		})
+			b.Run("history="+strconv.Itoa(history)+"/"+state+"/disabled-wrapper", func(b *testing.B) {
+				cc := NewCatalog()
+				cc.attribution = nil
+				seed(cc)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					cc.HasNewerVersionFor(query, CatalogInvalidationConsumerPreparedPlan)
+				}
+			})
 
-		b.Run("history="+strconv.Itoa(history)+"/precise", func(b *testing.B) {
-			cc := NewCatalog()
-			cc.EnableCatalogInvalidationAttribution()
-			for i := 0; i < history; i++ {
-				cc.attribution.observeTable(
-					1, 10, "db", "history", uint64(i+1), 1,
-					timestamp.Timestamp{PhysicalTime: int64(i + 1)}, false,
-				)
-			}
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				cc.attribution.preciseDecision(query)
-			}
-		})
+			b.Run("history="+strconv.Itoa(history)+"/"+state+"/bucket", func(b *testing.B) {
+				cc := NewCatalog()
+				seed(cc)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					cc.bucketHasNewerVersion(query)
+				}
+			})
+
+			b.Run("history="+strconv.Itoa(history)+"/"+state+"/precise", func(b *testing.B) {
+				cc := NewCatalog()
+				cc.EnableCatalogInvalidationAttribution()
+				seed(cc)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					cc.attribution.preciseDecision(query)
+				}
+			})
+		}
 	}
 }

--- a/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
@@ -110,9 +110,10 @@ func TestCatalogInvalidationShadowEqualTimestampConflictIsConservative(t *testin
 	firstTS := timestamp.Timestamp{PhysicalTime: 200}
 	a.observeTable(1, 10, "db", "t", 20, 3, firstTS, false)
 	a.observeTable(1, 10, "db", "t", 21, 1, firstTS, false)
+	a.observeTable(1, 10, "db", "t", 20, 3, timestamp.Timestamp{PhysicalTime: 300}, false)
 	require.True(t, a.preciseDecision(&TableChangeQuery{
 		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20, Version: 3,
-		Ts: timestamp.Timestamp{PhysicalTime: 100},
+		Ts: timestamp.Timestamp{PhysicalTime: 250},
 	}))
 }
 

--- a/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+)
+
+func TestCatalogInvalidationAttributionDisabledByDefault(t *testing.T) {
+	cc := NewCatalog()
+	cc.HasNewerVersionFor(&TableChangeQuery{AccountId: 1, Name: "t"}, CatalogInvalidationConsumerPreparedPlan)
+	report := cc.SnapshotCatalogInvalidationReport()
+	require.False(t, report.Enabled)
+	require.Empty(t, report.Consumers)
+}
+
+func TestCatalogInvalidationAttributionDifferentialAndCollision(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	cc.setTableItem(&TableItem{
+		AccountId: 1, DatabaseId: 10, Name: "t", Id: 20, Version: 3,
+		Ts: timestamp.Timestamp{PhysicalTime: 200},
+	}, true)
+
+	changed := &TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, Name: "t", TableId: 20, Version: 2,
+		Ts: timestamp.Timestamp{PhysicalTime: 100},
+	}
+	require.True(t, cc.HasNewerVersionFor(changed, CatalogInvalidationConsumerPreparedPlan))
+
+	otherAccount := &TableChangeQuery{
+		AccountId: 2, DatabaseId: 10, Name: "t", TableId: 20, Version: 2,
+		Ts: timestamp.Timestamp{PhysicalTime: 100},
+	}
+	require.False(t, cc.HasNewerVersionFor(otherAccount, CatalogInvalidationConsumerRCTableCache))
+
+	collision := *otherAccount
+	collision.AccountId = 1 + tableChangeBucketCount
+	require.False(t, cc.HasNewerVersionFor(&collision, CatalogInvalidationConsumerRCTableCache))
+
+	report := cc.SnapshotCatalogInvalidationReport()
+	require.True(t, report.Enabled)
+	require.Equal(t, uint64(1), report.Consumers["prepared_plan"].Checks)
+	require.Zero(t, report.Consumers["prepared_plan"].PreciseFalseNegatives)
+	require.Equal(t, uint64(1), report.Consumers["rc_table_cache"].BucketFalsePositives)
+	require.Zero(t, report.Consumers["rc_table_cache"].PreciseFalsePositives)
+}
+
+func TestCatalogInvalidationShadowIgnoresReplayAndReportsMetadata(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	cc.SetCatalogInvalidationReportMetadata(CatalogInvalidationReportMetadata{
+		MatrixONESHA: "test-sha", Config: "test-config", Window: "test-window", Integrity: "complete",
+	})
+	a := cc.attribution
+	a.observeTable(1, 10, "db", "t", 20, 3, timestamp.Timestamp{PhysicalTime: 200}, false)
+	a.observeTable(1, 10, "db", "t", 20, 2, timestamp.Timestamp{PhysicalTime: 100}, false)
+	require.True(t, a.preciseDecision(&TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20, Version: 2,
+		Ts: timestamp.Timestamp{PhysicalTime: 150},
+	}))
+
+	var buf bytes.Buffer
+	require.NoError(t, cc.WriteCatalogInvalidationReport(&buf))
+	var report CatalogInvalidationReport
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &report))
+	require.Equal(t, "test-sha", report.Metadata.MatrixONESHA)
+	require.Equal(t, "complete", report.Metadata.Integrity)
+}
+
+func TestCatalogInvalidationShadowDatabaseRecreation(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	cc.attribution.observeDatabase(1, "db", 20, timestamp.Timestamp{PhysicalTime: 200}, false)
+	require.True(t, cc.attribution.preciseDecision(&TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "missing",
+		Ts: timestamp.Timestamp{PhysicalTime: 100},
+	}))
+	cc.attribution.observeDatabase(1, "db", 20, timestamp.Timestamp{PhysicalTime: 100}, false)
+	require.False(t, cc.attribution.preciseDecision(&TableChangeQuery{
+		AccountId: 1, DatabaseId: 20, DatabaseName: "db", Name: "missing",
+		Ts: timestamp.Timestamp{PhysicalTime: 300},
+	}))
+}
+
+func TestCatalogInvalidationShadowEqualTimestampConflictIsConservative(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	a := cc.attribution
+	firstTS := timestamp.Timestamp{PhysicalTime: 200}
+	a.observeTable(1, 10, "db", "t", 20, 3, firstTS, false)
+	a.observeTable(1, 10, "db", "t", 21, 1, firstTS, false)
+	require.True(t, a.preciseDecision(&TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20, Version: 3,
+		Ts: timestamp.Timestamp{PhysicalTime: 100},
+	}))
+}
+
+func TestCatalogInvalidationShadowCapFailsClosed(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	for i := 0; i < catalogShadowEntryLimit+1; i++ {
+		cc.attribution.observeTable(
+			uint32(i), uint64(i), "db", "t", uint64(i+1), 1,
+			timestamp.Timestamp{PhysicalTime: int64(i + 1)}, false,
+		)
+	}
+	require.True(t, cc.attribution.shadowOverflow)
+	require.True(t, cc.attribution.preciseDecision(&TableChangeQuery{AccountId: 999999, Name: "unseen"}))
+	require.True(t, cc.SnapshotCatalogInvalidationReport().Shadow.Overflow)
+}
+
+func TestCatalogInvalidationLatencyHistogramIsBounded(t *testing.T) {
+	var h catalogLatencyHistogram
+	for i := 0; i < 32; i++ {
+		h.observe(time.Duration(i+1) * time.Microsecond)
+	}
+	require.Equal(t, uint64(32), h.count)
+	require.Greater(t, h.quantile(0.99), int64(0))
+	// The histogram retains fixed buckets rather than one sample per event.
+	require.Len(t, h.bucket, len(catalogLatencyBounds)+1)
+}
+
+func TestCatalogInvalidationPreciseNoChangeDoesNotAllocate(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	cc.attribution.observeTable(1, 10, "db", "t", 20, 3, timestamp.Timestamp{PhysicalTime: 100}, false)
+	query := &TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20, Version: 3,
+		Ts: timestamp.Timestamp{PhysicalTime: 300},
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		cc.attribution.preciseDecision(query)
+	})
+	require.Zero(t, allocs)
+}
+
+func BenchmarkCatalogInvalidationOracles(b *testing.B) {
+	query := &TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, DatabaseName: "db", Name: "t", TableId: 20, Version: 3,
+		Ts: timestamp.Timestamp{PhysicalTime: 1000},
+	}
+	for _, history := range []int{1, 16, 256, 4096} {
+		b.Run("history="+strconv.Itoa(history)+"/exact", func(b *testing.B) {
+			cc := NewCatalog()
+			for i := 0; i < history; i++ {
+				cc.setTableItem(&TableItem{
+					AccountId: 1, DatabaseId: uint64(100 + i), Name: "history", Id: uint64(i + 1),
+					Ts: timestamp.Timestamp{PhysicalTime: int64(i + 1)},
+				}, true)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cc.HasNewerVersion(query)
+			}
+		})
+
+		b.Run("history="+strconv.Itoa(history)+"/bucket", func(b *testing.B) {
+			cc := NewCatalog()
+			for i := 0; i < history; i++ {
+				cc.setTableItem(&TableItem{
+					AccountId: 1, DatabaseId: uint64(100 + i), Name: "history", Id: uint64(i + 1),
+					Ts: timestamp.Timestamp{PhysicalTime: int64(i + 1)},
+				}, true)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cc.bucketHasNewerVersion(query)
+			}
+		})
+
+		b.Run("history="+strconv.Itoa(history)+"/precise", func(b *testing.B) {
+			cc := NewCatalog()
+			cc.EnableCatalogInvalidationAttribution()
+			for i := 0; i < history; i++ {
+				cc.attribution.observeTable(
+					1, 10, "db", "history", uint64(i+1), 1,
+					timestamp.Timestamp{PhysicalTime: int64(i + 1)}, false,
+				)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cc.attribution.preciseDecision(query)
+			}
+		})
+	}
+}

--- a/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
+++ b/pkg/vm/engine/disttae/cache/catalog_attribution_test.go
@@ -34,6 +34,24 @@ func TestCatalogInvalidationAttributionDisabledByDefault(t *testing.T) {
 	require.Empty(t, report.Consumers)
 }
 
+func TestCatalogInvalidationShadowIdentityDoesNotChangeExactRCDecision(t *testing.T) {
+	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
+	cc.databases.data.Set(&DatabaseItem{
+		AccountId: 1, Name: "db", Id: 20, Ts: timestamp.Timestamp{PhysicalTime: 200},
+	})
+	query := &TableChangeQuery{
+		AccountId: 1, DatabaseId: 10, Name: "t",
+		Ts: timestamp.Timestamp{PhysicalTime: 100}, ShadowDatabaseName: "db",
+	}
+	// RC's historical exact query did not carry the database name. The
+	// attribution-only identity must not make that exact decision invalidate.
+	require.False(t, cc.HasNewerVersionFor(query, CatalogInvalidationConsumerRCTableCache))
+	withExactDatabase := *query
+	withExactDatabase.DatabaseName = "db"
+	require.True(t, cc.hasNewerVersion(&withExactDatabase))
+}
+
 func TestCatalogInvalidationAttributionDifferentialAndCollision(t *testing.T) {
 	cc := NewCatalog()
 	cc.EnableCatalogInvalidationAttribution()

--- a/pkg/vm/engine/disttae/cache/catalog_test.go
+++ b/pkg/vm/engine/disttae/cache/catalog_test.go
@@ -389,11 +389,16 @@ func TestDatabaseCache(t *testing.T) {
 func TestTableInsert(t *testing.T) {
 	mp := mpool.MustNewZero()
 	cc := NewCatalog()
+	cc.EnableCatalogInvalidationAttribution()
 	bat := newTestTableBatch(mp)
 	timestamps := vector.MustFixedColWithTypeCheck[types.TS](bat.GetVector(MO_TIMESTAMP_IDX))
 	accounts := vector.MustFixedColWithTypeCheck[uint32](bat.GetVector(catalog.MO_TABLES_ACCOUNT_ID_IDX + MO_OFF))
 	names := vector.InefficientMustStrCol(bat.GetVector(catalog.MO_TABLES_REL_NAME_IDX + MO_OFF))
+	databaseNames := vector.InefficientMustStrCol(bat.GetVector(catalog.MO_TABLES_RELDATABASE_IDX + MO_OFF))
+	ids := vector.MustFixedColWithTypeCheck[uint64](bat.GetVector(catalog.MO_TABLES_REL_ID_IDX + MO_OFF))
 	databaseIds := vector.MustFixedColWithTypeCheck[uint64](bat.GetVector(catalog.MO_TABLES_RELDATABASE_ID_IDX + MO_OFF))
+	versions := vector.MustFixedColWithTypeCheck[uint32](bat.GetVector(catalog.MO_TABLES_VERSION_IDX + MO_OFF))
+	originalTimestamp := timestamps[0]
 
 	cstrs := vector.MustFixedColWithTypeCheck[types.Varlena](bat.GetVector(catalog.MO_TABLES_CONSTRAINT_IDX + MO_OFF))
 	partitioned := vector.MustFixedColWithTypeCheck[int8](bat.GetVector(catalog.MO_TABLES_PARTITIONED_IDX + MO_OFF))
@@ -434,6 +439,12 @@ func TestTableInsert(t *testing.T) {
 		delBat.Vecs[2] = bat.Vecs[catalog.MO_TABLES_CPKEY_IDX+MO_OFF]
 		cc.DeleteTable(delBat)
 	}
+	deleteQuery := &TableChangeQuery{
+		AccountId: accounts[0], DatabaseId: databaseIds[0], DatabaseName: databaseNames[0],
+		Name: names[0], TableId: ids[0], Version: versions[0], Ts: originalTimestamp.ToTimestamp(),
+	}
+	require.True(t, cc.hasNewerVersion(deleteQuery))
+	require.True(t, cc.attribution.preciseDecision(deleteQuery), "DeleteTable tombstone must retain database identity")
 
 	{ // set the query time
 		for i := range timestamps {

--- a/pkg/vm/engine/disttae/cache/types.go
+++ b/pkg/vm/engine/disttae/cache/types.go
@@ -46,10 +46,14 @@ type TableChangeQuery struct {
 	AccountId    uint32
 	DatabaseId   uint64
 	DatabaseName string
-	Name         string
-	Version      uint32
-	TableId      uint64
-	Ts           timestamp.Timestamp
+	// ShadowDatabaseName is used only by the opt-in attribution oracle. It is
+	// deliberately separate from DatabaseName so a diagnostic identity cannot
+	// change the exact production lookup performed by HasNewerVersionFor.
+	ShadowDatabaseName string
+	Name               string
+	Version            uint32
+	TableId            uint64
+	Ts                 timestamp.Timestamp
 }
 
 const tableChangeBucketCount = 4096

--- a/pkg/vm/engine/disttae/cache/types.go
+++ b/pkg/vm/engine/disttae/cache/types.go
@@ -73,6 +73,7 @@ type CatalogCache struct {
 		sync.RWMutex
 		ts timestamp.Timestamp
 	}
+	attribution *catalogInvalidationAttribution
 	//tables and database is safe to be read concurrently.
 	tables    *tableCache
 	databases *databaseCache

--- a/pkg/vm/engine/disttae/catalog_invalidation_lifecycle_test.go
+++ b/pkg/vm/engine/disttae/catalog_invalidation_lifecycle_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
+)
+
+func TestFinishCatalogReloadTerminalOutcomesExactlyOnce(t *testing.T) {
+	catalogCache := cache.NewCatalog()
+	catalogCache.EnableCatalogInvalidationAttribution()
+	engine := &Engine{}
+	engine.catalog.Store(catalogCache)
+	txn := &Transaction{engine: engine}
+	pending := &sync.Map{}
+	txn.catalogInvalidations.Store(pending)
+
+	outcomes := []cache.CatalogInvalidationOutcome{
+		cache.CatalogInvalidationSuccess,
+		cache.CatalogInvalidationError,
+		cache.CatalogInvalidationMiss,
+	}
+	for index, outcome := range outcomes {
+		key := tableKey{accountId: 1, databaseId: uint64(index + 1), dbName: "db", name: "t"}
+		pending.Store(key, time.Now())
+		txn.finishCatalogReload(key, outcome)
+		txn.finishCatalogReload(key, outcome)
+	}
+
+	report := catalogCache.SnapshotCatalogInvalidationReport()
+	require.Equal(t, uint64(3), report.RCTableCacheReload.Count)
+	require.Equal(t, uint64(1), report.RCTableCacheReload.Success)
+	require.Equal(t, uint64(1), report.RCTableCacheReload.Error)
+	require.Equal(t, uint64(1), report.RCTableCacheReload.Miss)
+}
+
+func TestFinishCatalogReloadConcurrentTerminalIsExactlyOnce(t *testing.T) {
+	catalogCache := cache.NewCatalog()
+	catalogCache.EnableCatalogInvalidationAttribution()
+	engine := &Engine{}
+	engine.catalog.Store(catalogCache)
+	txn := &Transaction{engine: engine}
+	pending := &sync.Map{}
+	txn.catalogInvalidations.Store(pending)
+	key := tableKey{accountId: 1, databaseId: 1, dbName: "db", name: "t"}
+	pending.Store(key, time.Now())
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			txn.finishCatalogReload(key, cache.CatalogInvalidationSuccess)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, uint64(1), catalogCache.SnapshotCatalogInvalidationReport().RCTableCacheReload.Count)
+}

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2656,15 +2656,31 @@ func (txn *Transaction) getCachedTableByKey(
 
 		catalogCache := txn.engine.GetLatestCatalogCache()
 		tblKey := &cache.TableChangeQuery{
-			AccountId:  k.accountId,
-			DatabaseId: k.databaseId,
-			Name:       k.name,
-			Version:    tbl.origin.version,
-			TableId:    tbl.origin.tableId,
-			Ts:         tbl.origin.lastTS,
+			AccountId:    k.accountId,
+			DatabaseId:   k.databaseId,
+			DatabaseName: k.dbName,
+			Name:         k.name,
+			Version:      tbl.origin.version,
+			TableId:      tbl.origin.tableId,
+			Ts:           tbl.origin.lastTS,
 		}
-		if catalogCache.HasNewerVersion(tblKey) {
-			txn.tableCache.Delete(genTableKey(k.accountId, k.name, k.databaseId, k.dbName))
+		if catalogCache.HasNewerVersionFor(tblKey, cache.CatalogInvalidationConsumerRCTableCache) {
+			cacheKey := genTableKey(k.accountId, k.name, k.databaseId, k.dbName)
+			txn.tableCache.Delete(cacheKey)
+			if catalogCache.CatalogInvalidationAttributionEnabled() {
+				invalidations := txn.catalogInvalidations.Load()
+				if invalidations == nil {
+					candidate := new(sync.Map)
+					if txn.catalogInvalidations.CompareAndSwap(nil, candidate) {
+						invalidations = candidate
+					} else {
+						invalidations = txn.catalogInvalidations.Load()
+					}
+				}
+				if invalidations != nil {
+					invalidations.Store(cacheKey, time.Now())
+				}
+			}
 			return nil
 		}
 	}
@@ -2892,6 +2908,7 @@ func (txn *Transaction) delTransaction() {
 	txn.assertWorkspaceAccountingLocked()
 
 	txn.tableCache = nil
+	txn.catalogInvalidations.Store(nil)
 	txn.tableOps = nil
 	txn.databaseOps = nil
 

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2640,6 +2640,20 @@ func (txn *Transaction) getCachedTable(
 	return txn.getCachedTableByKey(ctx, k, k)
 }
 
+func (txn *Transaction) finishCatalogReload(key tableKey, outcome cache.CatalogInvalidationOutcome) {
+	invalidations := txn.catalogInvalidations.Load()
+	if invalidations == nil {
+		return
+	}
+	started, ok := invalidations.LoadAndDelete(key)
+	if !ok {
+		return
+	}
+	if catalogCache := txn.engine.GetLatestCatalogCache(); catalogCache != nil {
+		catalogCache.RecordRCTableCacheReload(time.Since(started.(time.Time)), outcome)
+	}
+}
+
 func (txn *Transaction) getCachedTableByKey(
 	_ context.Context,
 	k tableKey,

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2670,13 +2670,13 @@ func (txn *Transaction) getCachedTableByKey(
 
 		catalogCache := txn.engine.GetLatestCatalogCache()
 		tblKey := &cache.TableChangeQuery{
-			AccountId:    k.accountId,
-			DatabaseId:   k.databaseId,
-			DatabaseName: k.dbName,
-			Name:         k.name,
-			Version:      tbl.origin.version,
-			TableId:      tbl.origin.tableId,
-			Ts:           tbl.origin.lastTS,
+			AccountId:          k.accountId,
+			DatabaseId:         k.databaseId,
+			ShadowDatabaseName: k.dbName,
+			Name:               k.name,
+			Version:            tbl.origin.version,
+			TableId:            tbl.origin.tableId,
+			Ts:                 tbl.origin.lastTS,
 		}
 		if catalogCache.HasNewerVersionFor(tblKey, cache.CatalogInvalidationConsumerRCTableCache) {
 			cacheKey := genTableKey(k.accountId, k.name, k.databaseId, k.dbName)
@@ -2922,6 +2922,19 @@ func (txn *Transaction) delTransaction() {
 	txn.assertWorkspaceAccountingLocked()
 
 	txn.tableCache = nil
+	// An invalidated RC cache entry may survive until transaction teardown when
+	// relation reload is abandoned by rollback/cancellation. Close every
+	// pending attribution window exactly once before dropping the map; the
+	// production cache lifecycle remains unchanged when attribution is off.
+	if invalidations := txn.catalogInvalidations.Load(); invalidations != nil {
+		invalidations.Range(func(key, _ any) bool {
+			tableKey, ok := key.(tableKey)
+			if ok {
+				txn.finishCatalogReload(tableKey, cache.CatalogInvalidationError)
+			}
+			return true
+		})
+	}
 	txn.catalogInvalidations.Store(nil)
 	txn.tableOps = nil
 	txn.databaseOps = nil

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -142,9 +142,15 @@ func (db *txnDatabase) relation(ctx context.Context, name string, proc any) (eng
 		txn.engine,
 	)
 	if err != nil {
+		if invalidations := txn.catalogInvalidations.Load(); invalidations != nil {
+			invalidations.Delete(key)
+		}
 		return nil, err
 	}
 	if item == nil {
+		if invalidations := txn.catalogInvalidations.Load(); invalidations != nil {
+			invalidations.Delete(key)
+		}
 		return nil, nil
 	}
 
@@ -158,6 +164,11 @@ func (db *txnDatabase) relation(ctx context.Context, name string, proc any) (eng
 	}
 
 	db.getTxn().tableCache.Store(key, tbl)
+	if invalidations := txn.catalogInvalidations.Load(); invalidations != nil {
+		if started, ok := invalidations.LoadAndDelete(key); ok {
+			txn.engine.GetLatestCatalogCache().RecordRCTableCacheReload(time.Since(started.(time.Time)))
+		}
+	}
 	return tbl, nil
 }
 

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -156,6 +156,7 @@ func (db *txnDatabase) relation(ctx context.Context, name string, proc any) (eng
 		*item,
 	)
 	if err != nil {
+		txn.finishCatalogReload(key, cache.CatalogInvalidationError)
 		return nil, err
 	}
 

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -142,15 +142,11 @@ func (db *txnDatabase) relation(ctx context.Context, name string, proc any) (eng
 		txn.engine,
 	)
 	if err != nil {
-		if invalidations := txn.catalogInvalidations.Load(); invalidations != nil {
-			invalidations.Delete(key)
-		}
+		txn.finishCatalogReload(key, cache.CatalogInvalidationError)
 		return nil, err
 	}
 	if item == nil {
-		if invalidations := txn.catalogInvalidations.Load(); invalidations != nil {
-			invalidations.Delete(key)
-		}
+		txn.finishCatalogReload(key, cache.CatalogInvalidationMiss)
 		return nil, nil
 	}
 
@@ -164,11 +160,7 @@ func (db *txnDatabase) relation(ctx context.Context, name string, proc any) (eng
 	}
 
 	db.getTxn().tableCache.Store(key, tbl)
-	if invalidations := txn.catalogInvalidations.Load(); invalidations != nil {
-		if started, ok := invalidations.LoadAndDelete(key); ok {
-			txn.engine.GetLatestCatalogCache().RecordRCTableCacheReload(time.Since(started.(time.Time)))
-		}
-	}
+	txn.finishCatalogReload(key, cache.CatalogInvalidationSuccess)
 	return tbl, nil
 }
 

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -393,6 +393,9 @@ type Transaction struct {
 
 	// use to cache opened snapshot tables by current txn.
 	tableCache *sync.Map
+	// catalogInvalidations records the start of an opt-in RC table-cache
+	// reload. It is nil unless the attribution experiment is enabled.
+	catalogInvalidations atomic.Pointer[sync.Map]
 
 	// used to keep updated tables in the current txn
 	tableOps            *tableOpsChain


### PR DESCRIPTION
## Summary

This is an instrumentation-only Draft PR for #27235. It does not change the
production invalidation decision, SQL, wire protocol, protobufs, or default
runtime behavior.

- exact BTree remains the authoritative result returned to callers
- the RC consumer keeps its historical exact query; diagnostic database
  identity is passed separately to the opt-in shadow oracle
- 4096-account bucket and precise shadow decisions are recorded only when
  opt-in attribution is enabled
- prepared-plan and RC table-cache consumers are identified separately
- report output is emitted by `CatalogCache.WriteCatalogInvalidationReport`
- shadow state is monotonic for replay/GC and has a hard retained-entry cap;
  overflow fails closed conservatively

The experimental env switch is `MO_CATALOG_INVALIDATION_ATTRIBUTION=1`. Tests
enable it explicitly before using the cache.

## Measurement contract

The per-CN cache fragment remains schema v2. The two-CN evidence envelope is
schema v3 and now includes per-scenario counter deltas, stable/inconclusive
decision accounting, raw bounded latency buckets, terminal success/error/miss
counts, shadow overflow, and exact SHA/config/window/integrity metadata.

The opt-in `pkg/embed` workload starts one Log, one TN, and two CNs. It runs
binary and text prepared execution, RC table-cache reuse, same-account
unrelated DDL, and no-change/TRUNCATE/RENAME/table- and database-
drop-recreate lifecycle scenarios with dependencies established before DDL,
bounded contexts, no fixed sleeps, and cleanup failure propagation. Report
writing is same-directory temporary-file plus atomic rename.

The measurement test first verifies the requested SHA against Go VCS build
metadata when available, or an exact clean checkout revision when CGo test
linking omits those settings. A mismatched or dirty checkout fails closed.

## Exact measurement

- measurement head: `ce1b3cc7b93d92f7ded09e820318b0608216bfdd`
- PR head carrying the evidence: `34acffcc7defc52194cd13cba93231e45a3ec7c2`
- base: `5735684d69c9b171c4d7a5ebee3ebcc539ffc8cc`
- report: [`catalog-invalidation-report.json`](../tree/34acffcc7defc52194cd13cba93231e45a3ec7c2/docs/rfcs/evidence/27235/catalog-invalidation-report.json)
- comparison: [`catalog-invalidation-comparison.md`](../tree/34acffcc7defc52194cd13cba93231e45a3ec7c2/docs/rfcs/evidence/27235/catalog-invalidation-comparison.md)

The report is `integrity=complete`, with all eight scenarios completed and
per-scenario stable terminal evidence. Across both CNs there are 87,851 stable
decisions, precise stable false-negative and false-positive counts are zero,
and shadow overflow is false. Prepared rebuild has 259 terminal outcomes (256
successes, 3 errors, no misses); RC reload has 128 successes and no errors or
misses. The bucket has 147 measured false positives and remains
measurement-only until owners record accepted budgets in #27235.

The previous evidence from head `0279990ecb9c779e7b52b5d60666b0338b4445b8`
is preserved as `catalog-invalidation-report-invalid-0279990.json` with
`integrity=invalidated`; it must not be combined with this report.

The valid idle benchmark observed no bytes/op or allocs/op change. Five samples
do not establish a 95% confidence interval, so the prior `-10.16%` value is no
longer presented as a performance improvement. A separate `+44.32%` run during
competing local build activity remains invalid contention evidence. The precise
warmed-negative path reports `0 B/op, 0 allocs/op`. These are microbenchmark
observations only and are not TPS or transaction-tail claims.

## Evidence and decision

Validation on the exact measurement head:

- cache package full normal and race tests: PASS
- focused cache, transaction lifecycle, and ownership tests under race: PASS
- disttae/frontend/embed CGo compile checks: PASS
- two-CN opt-in attribution workload: PASS
- `make build`: PASS
- `git diff --check`: PASS
- BVT: N/A — this Draft changes no production SQL/protocol behavior; the
  equivalent terminal is the opt-in two-CN embed workload above
- direct `go vet`: environment-blocked by `pkg/common/docfilter` C symbol
  resolution in this checkout; no vet pass is claimed

A false negative rejects a candidate. The existing exact BTree remains the
production behavior. No bucket or precise production implementation is opened
by this Draft; precise would require owner acceptance of its identity,
replay/GC, retained-memory, and independent no-profile benchmark gates in a
separate production Draft. No isolated TPS, transaction P95/P99, or +20% claim
is made. Historical A+C `+0.7026%` is combination-only evidence.

Keep this PR Draft. Do not merge or use it as a production watermark
implementation.
