### PR TITLE
fix: extend CN TN shard readiness wait

### DIFF
--- a/cmd/mo-service/config_test.go
+++ b/cmd/mo-service/config_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
@@ -27,6 +28,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWaitAnyShardReadyTimeout(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, waitAnyShardReadyTimeout)
+}
 
 func TestParseTNConfig(t *testing.T) {
 	data := `

--- a/cmd/mo-service/launch.go
+++ b/cmd/mo-service/launch.go
@@ -44,6 +44,8 @@ var (
 	launchSleep             = time.Sleep
 )
 
+const waitAnyShardReadyTimeout = 5 * time.Minute
+
 func startCluster(
 	ctx context.Context,
 	stopper *stopper.Stopper,
@@ -384,7 +386,7 @@ func waitHAKeeperRunning(client logservice.CNHAKeeperClient) error {
 }
 
 func waitAnyShardReady(client logservice.CNHAKeeperClient) error {
-	ctx, cancel := context.WithTimeoutCause(context.TODO(), time.Second*30, moerr.CauseWaitAnyShardReady)
+	ctx, cancel := context.WithTimeoutCause(context.TODO(), waitAnyShardReadyTimeout, moerr.CauseWaitAnyShardReady)
 	defer cancel()
 
 	// wait shard ready


### PR DESCRIPTION
## Summary
- extend the CN startup wait for a ready TN shard from 30 seconds to 5 minutes
- keep the deployment workflow timeout unchanged
- add a regression test for the default wait duration

## Validation
- `go test ./cmd/mo-service -run "^TestWaitAnyShardReadyTimeout$"`

This reduces repeated CN CrashLoopBackOff during a transient LogService/TN recovery window; it does not mask a persistently unavailable TN shard.