### PR TITLE
fix: prevent plan coverage OOM from leaked test services

### DIFF
--- a/pkg/testutil/util_new.go
+++ b/pkg/testutil/util_new.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -83,8 +84,43 @@ func SetupAutoIncrService(sid string) {
 			incrservice.Config{}))
 }
 
+// Processes created without a testing.TB have no cleanup owner. Reuse their
+// auto-increment services so repeated mock process creation cannot leak one
+// service and its background workers per call.
+var nilProcessAutoIncrServices = struct {
+	sync.Mutex
+	services map[string]incrservice.AutoIncrementService
+}{
+	services: make(map[string]incrservice.AutoIncrementService),
+}
+
+func setupAutoIncrServiceForProcess(t testing.TB, sid string) {
+	if t != nil {
+		SetupAutoIncrService(sid)
+		return
+	}
+
+	nilProcessAutoIncrServices.Lock()
+	defer nilProcessAutoIncrServices.Unlock()
+
+	rt := runtime.ServiceRuntime(sid)
+	if rt == nil {
+		rt = runtime.DefaultRuntime()
+		runtime.SetupServiceBasedRuntime(sid, rt)
+	}
+	service := nilProcessAutoIncrServices.services[sid]
+	if service == nil {
+		service = incrservice.NewIncrService(
+			"",
+			incrservice.NewMemStore(),
+			incrservice.Config{})
+		nilProcessAutoIncrServices.services[sid] = service
+	}
+	rt.SetGlobalVariables(runtime.AutoIncrementService, service)
+}
+
 func NewProcessWithMPool(t testing.TB, sid string, mp *mpool.MPool) *process.Process {
-	SetupAutoIncrService(sid)
+	setupAutoIncrServiceForProcess(t, sid)
 	ctx := defines.AttachAccountId(context.Background(), catalog.System_Account)
 	proc := process.NewTopProcess(
 		ctx,

--- a/pkg/testutil/util_new_test.go
+++ b/pkg/testutil/util_new_test.go
@@ -15,10 +15,12 @@
 package testutil
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/incrservice"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,6 +33,53 @@ func TestNewBatch(t *testing.T) {
 	bat := NewBatch([]types.Type{types.New(types.T_int8, 0, 0)}, true, Rows, m)
 	bat.Clean(m)
 	require.Equal(t, int64(0), m.CurrNB())
+}
+
+func TestNilTBProcessesShareAutoIncrService(t *testing.T) {
+	first := NewProcessWithMPool(nil, "", mpool.MustNewZeroNoFixed())
+	second := NewProcessWithMPool(nil, "", mpool.MustNewZeroNoFixed())
+
+	require.True(t, first.GetIncrService() == second.GetIncrService())
+
+	setupAutoIncrServiceForProcess(nil, "nil-tb-first")
+	firstSID := incrservice.GetAutoIncrementService("nil-tb-first")
+	setupAutoIncrServiceForProcess(nil, "nil-tb-other")
+	otherSID := incrservice.GetAutoIncrementService("nil-tb-other")
+	require.True(t, firstSID != otherSID)
+}
+
+func TestNilTBProcessRestoresSharedAutoIncrService(t *testing.T) {
+	const sid = ""
+	shared := NewProcessWithMPool(nil, sid, mpool.MustNewZeroNoFixed()).GetIncrService()
+	replacement := incrservice.NewIncrService(
+		"",
+		incrservice.NewMemStore(),
+		incrservice.Config{})
+	t.Cleanup(replacement.Close)
+	incrservice.SetAutoIncrementServiceByID(sid, replacement)
+
+	restored := NewProcessWithMPool(nil, sid, mpool.MustNewZeroNoFixed()).GetIncrService()
+	require.True(t, shared == restored)
+}
+
+func TestNilTBProcessesShareAutoIncrServiceConcurrently(t *testing.T) {
+	const count = 16
+	const sid = ""
+	services := make([]incrservice.AutoIncrementService, count)
+	var wg sync.WaitGroup
+	for i := range services {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			proc := NewProcessWithMPool(nil, sid, mpool.MustNewZeroNoFixed())
+			services[index] = proc.GetIncrService()
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < count; i++ {
+		require.True(t, services[0] == services[i], "service %d", i)
+	}
 }
 
 func TestVector(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27478

## What this PR does / why we need it:

`MockCompilerContext.GetProcess` creates processes without a `testing.TB` cleanup owner. Each process previously replaced the runtime auto-increment service with a newly allocated service whose background workers kept it alive. The retained services made `pkg/sql/plan` grow to roughly 12 GB RSS under repository-wide coverage and eventually triggered the CI runner's OOM killer.

This change:

- reuses one testutil-owned auto-increment service per service ID when the process has no `testing.TB`;
- restores that shared service if another test overwrites the runtime registration;
- serializes first creation so concurrent process construction cannot create duplicate services;
- preserves the existing fresh-service behavior for processes with a non-nil `testing.TB`.

Validation:

- `pkg/testutil` focused tests and full package tests pass;
- all three new focused tests pass with `-race -count=100`;
- the full `pkg/testutil` package passes under the race detector;
- `pkg/testutil` and `pkg/sql/plan` pass `go build` and `go vet -tags matrixone_test`;
- `TestUpdateParentForeignKeyLocksPrecedeChildConsumers` passes 20 consecutive runs;
- the full `pkg/sql/plan` package passes, including 10 consecutive package runs without RSS growth;
- the plan test heap profile drops from about 15.9 GB to about 109 MB of in-use memory.
