### PR TITLE
fix: parallelize count distinct aggregation

### DIFF
--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -64,6 +64,15 @@ func countStarAgg() aggexec.AggFuncExecExpression {
 	return aggexec.MakeAggFunctionExpression(aggexec.AggIdOfCountStar, false, []*plan.Expr{colExpr(0, types.T_int32)}, nil)
 }
 
+func countDistinctAgg(pos int32) aggexec.AggFuncExecExpression {
+	return aggexec.MakeAggFunctionExpression(
+		aggexec.AggIdOfCountColumn,
+		true,
+		[]*plan.Expr{colExpr(pos, types.T_int32)},
+		nil,
+	)
+}
+
 func countStarLiteralAgg() aggexec.AggFuncExecExpression {
 	return aggexec.MakeAggFunctionExpression(
 		aggexec.AggIdOfCountStar,
@@ -1647,6 +1656,50 @@ func TestMergeGroupUsesReducedHashKey(t *testing.T) {
 	for _, partial := range partials {
 		partial.Clean(proc.Mp())
 	}
+	require.Zero(t, proc.Mp().CurrNB())
+}
+
+func TestMergeGroupDeduplicatesCountDistinctAcrossPartialGroups(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+
+	buildPartial := func(groups, values []int32, nulls []uint64) *batch.Batch {
+		input := batch.NewWithSize(2)
+		input.Vecs[0] = testutil.MakeInt32Vector(groups, nil, proc.Mp())
+		input.Vecs[1] = testutil.MakeInt32Vector(values, nulls, proc.Mp())
+		input.SetRowCount(len(groups))
+		child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{input})
+		partial := newGroupOp(
+			proc,
+			[]*plan.Expr{colExpr(0, types.T_int32)},
+			[]aggexec.AggFuncExecExpression{countDistinctAgg(1)},
+		)
+		partial.NeedEval = false
+		partial.AppendChild(child)
+		require.NoError(t, partial.Prepare(proc))
+		outputs := collectBatches(t, partial, proc)
+		require.Len(t, outputs, 1)
+		result := cloneBatch(t, proc, outputs[0])
+		partial.Free(proc, false, nil)
+		child.Free(proc, false, nil)
+		return result
+	}
+
+	partials := []*batch.Batch{
+		buildPartial([]int32{1, 1, 2, 3}, []int32{1, 2, 7, 0}, []uint64{3}),
+		buildPartial([]int32{1, 1, 2, 2, 3}, []int32{2, 3, 7, 8, 0}, []uint64{4}),
+	}
+	child := colexec.NewMockOperator().WithBatchs(partials)
+	merge := newMergeGroupOp([]aggexec.AggFuncExecExpression{countDistinctAgg(1)})
+	merge.AppendChild(child)
+	require.NoError(t, merge.Prepare(proc))
+	finals := collectBatches(t, merge, proc)
+	require.Len(t, finals, 1)
+	require.Equal(t, []int32{1, 2, 3}, vector.MustFixedColNoTypeCheck[int32](finals[0].Vecs[0]))
+	require.Equal(t, []int64{3, 2, 0}, vector.MustFixedColNoTypeCheck[int64](finals[0].Vecs[1]))
+
+	merge.Free(proc, false, nil)
+	child.Free(proc, false, nil)
 	require.Zero(t, proc.Mp().CurrNB())
 }
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -1682,7 +1682,7 @@ func (c *Compile) compilePlanScopeWithUnionAllDemand(
 		}
 		groupInfo := constructGroup(c.proc.Ctx, node, nodes[node.Children[0]], false, 0, c.proc)
 		defer groupInfo.Release()
-		anyDistinctAgg := groupInfo.AnyDistinctAgg()
+		distinctRequiresSingleStage := plan2.RequiresSingleStageDistinctAgg(node)
 
 		c.setAnalyzeCurrent(ss, int(curNodeIdx))
 		ss = c.ensureUserLevelLockSideEffectsOnCoordinator(node, ss)
@@ -1701,7 +1701,8 @@ func (c *Compile) compilePlanScopeWithUnionAllDemand(
 			ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node, c.compileTPGroup(node, ss, nodes))))
 			return ss, nil
 		} else {
-			ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node, c.compileMergeGroup(node, ss, nodes, anyDistinctAgg))))
+			ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node,
+				c.compileMergeGroup(node, ss, nodes, distinctRequiresSingleStage))))
 			return ss, nil
 		}
 	case plan.Node_SAMPLE:
@@ -5677,16 +5678,16 @@ func (c *Compile) compileTPGroup(node *plan.Node, ss []*Scope, ns []*plan.Node) 
 	return ss
 }
 
-func (c *Compile) compileMergeGroup(node *plan.Node, ss []*Scope, ns []*plan.Node, hasDistinct bool) []*Scope {
-	// for less memory usage while merge group,
-	// we do not run the group-operator in parallel once this has a distinct aggregation.
-	// because the parallel need to store all the source data in the memory for merging.
-	// we construct a pipeline like the following description for this case:
-	//
-	// all the operators from ss[0] to ss[last] send the data to only one group-operator.
-	// this group-operator sends its result to the merge-group-operator.
-	// todo: I cannot remove the merge-group action directly, because the merge-group action is used to fill the partial result.
-	if hasDistinct {
+func (c *Compile) compileMergeGroup(
+	node *plan.Node,
+	ss []*Scope,
+	ns []*plan.Node,
+	distinctRequiresSingleStage bool,
+) []*Scope {
+	// DISTINCT aggregates without an exact state-merge contract run one Group
+	// operator before MergeGroup. Parallel-mergeable DISTINCT aggregates use the
+	// ordinary local Group + MergeGroup pipeline below.
+	if distinctRequiresSingleStage {
 		ss = c.mergeShuffleScopesIfNeeded(ss, false)
 		mergeToGroup := c.newMergeScope(ss)
 

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -1780,6 +1780,81 @@ func TestCompileJoinGroupsExternalSinkScanOwner(t *testing.T) {
 	}
 }
 
+func TestCompileMergeGroupDistinctTopology(t *testing.T) {
+	var containsGroup func(vm.Operator) bool
+	containsGroup = func(op vm.Operator) bool {
+		if _, ok := op.(*group.Group); ok {
+			return true
+		}
+		for _, child := range op.GetOperatorBase().Children {
+			if containsGroup(child) {
+				return true
+			}
+		}
+		return false
+	}
+	makeAgg := func(name string, id int32, distinct bool, arg *plan.Expr) *plan.Expr {
+		encoded := function.EncodeOverloadID(id, 0)
+		if distinct {
+			encoded = int64(uint64(encoded) | uint64(function.Distinct))
+		}
+		return &plan.Expr{
+			Typ: plan.Type{Id: int32(types.T_int64)},
+			Expr: &plan.Expr_F{F: &plan.Function{
+				Func: &plan.ObjectRef{Obj: encoded, ObjName: name},
+				Args: []*plan.Expr{arg},
+			}},
+		}
+	}
+
+	t.Run("mixed count distinct uses local parallel groups", func(t *testing.T) {
+		c := newCompileForShuffleGroupTest(t)
+		node, nodes := newShuffleGroupTestNodes(2)
+		arg := nodes[0].ProjectList[0]
+		node.AggList = []*plan.Expr{
+			makeAgg("count", function.COUNT, false, arg),
+			makeAgg("count", function.COUNT, true, arg),
+		}
+		scopes := []*Scope{
+			newShuffleGroupInputScope(t, 1),
+			newShuffleGroupInputScope(t, 1),
+		}
+
+		requiresSingleStage := plan2.RequiresSingleStageDistinctAgg(node)
+		require.False(t, requiresSingleStage)
+		result := c.compileMergeGroup(node, scopes, nodes, requiresSingleStage)
+
+		require.Len(t, result, 1)
+		for _, scope := range scopes {
+			require.True(t, containsGroup(scope.RootOp),
+				"each input worker should aggregate before MergeGroup")
+		}
+	})
+
+	t.Run("unsupported distinct keeps one group", func(t *testing.T) {
+		c := newCompileForShuffleGroupTest(t)
+		node, nodes := newShuffleGroupTestNodes(2)
+		arg := nodes[0].ProjectList[0]
+		node.AggList = []*plan.Expr{makeAgg("avg", function.AVG, true, arg)}
+		scopes := []*Scope{
+			newShuffleGroupInputScope(t, 1),
+			newShuffleGroupInputScope(t, 1),
+		}
+
+		requiresSingleStage := plan2.RequiresSingleStageDistinctAgg(node)
+		require.True(t, requiresSingleStage)
+		result := c.compileMergeGroup(node, scopes, nodes, requiresSingleStage)
+
+		require.Len(t, result, 1)
+		for _, scope := range scopes {
+			require.False(t, containsGroup(scope.RootOp))
+		}
+		require.Len(t, result[0].PreScopes, 1)
+		require.True(t, containsGroup(result[0].PreScopes[0].RootOp),
+			"non-mergeable DISTINCT states must share one Group operator")
+	})
+}
+
 func newCompileForShuffleGroupTest(t *testing.T) *Compile {
 	c := NewMockCompile(t)
 	c.execType = plan2.ExecTypeAP_ONECN

--- a/pkg/sql/compile/max_dop_test.go
+++ b/pkg/sql/compile/max_dop_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/apply"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/schedule"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
@@ -31,29 +32,27 @@ import (
 )
 
 func TestForceSingleScanDistinctAgg(t *testing.T) {
-	node := &plan.Node{
-		AggList: []*plan.Expr{
-			{
-				Expr: &plan.Expr_F{
-					F: &plan.Function{
-						Func: &plan.ObjectRef{
-							ObjName: "sum",
+	newNode := func(name string, id int32) *plan.Node {
+		node := &plan.Node{
+			AggList: []*plan.Expr{{
+				Expr: &plan.Expr_F{F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: name},
+					Args: []*plan.Expr{{
+						Expr: &plan.Expr_Lit{
+							Lit: &plan.Literal{Value: &plan.Literal_I64Val{I64Val: 1}},
 						},
-						Args: []*plan.Expr{
-							{
-								Expr: &plan.Expr_Lit{
-									Lit: &plan.Literal{Value: &plan.Literal_I64Val{I64Val: 1}},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+					}},
+				}},
+			}},
+		}
+		encoded := function.EncodeOverloadID(id, 0)
+		node.AggList[0].GetF().Func.Obj = int64(uint64(encoded) | uint64(function.Distinct))
+		return node
 	}
-	node.AggList[0].Expr.(*plan.Expr_F).F.Func.Obj = -9223372036854775808
 
-	require.True(t, forceSingleScan(node))
+	require.False(t, forceSingleScan(newNode("count", function.COUNT)))
+	require.True(t, forceSingleScan(newNode("sum", function.SUM)))
+	require.True(t, forceSingleScan(newNode("avg", function.AVG)))
 }
 
 func TestToScheduledQueryWorkersKeepsLocalIdentityWithoutRoute(t *testing.T) {

--- a/pkg/sql/compile/scan_scheduler.go
+++ b/pkg/sql/compile/scan_scheduler.go
@@ -17,7 +17,6 @@ package compile
 import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
-	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/schedule"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
@@ -67,14 +66,7 @@ func forceSingleScan(node *plan.Node) bool {
 	if node.Stats != nil && node.Stats.ForceOneCN {
 		return true
 	}
-	for _, agg := range node.AggList {
-		if f, ok := agg.Expr.(*plan.Expr_F); ok {
-			if (uint64(f.F.Func.Obj) & function.Distinct) != 0 {
-				return true
-			}
-		}
-	}
-	return false
+	return plan2.RequiresSingleStageDistinctAgg(node)
 }
 
 func (c *Compile) localScanNodes(

--- a/pkg/sql/plan/distinct_agg.go
+++ b/pkg/sql/plan/distinct_agg.go
@@ -20,6 +20,33 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 )
 
+// RequiresSingleStageDistinctAgg reports whether an aggregate node contains a
+// DISTINCT state that MergeGroup cannot combine exactly. COUNT(DISTINCT ...)
+// stores its canonical arguments in the aggregate state, so BatchMerge can
+// deduplicate values that appeared in different local workers. Other DISTINCT
+// aggregates keep the conservative single-worker contract until their merge
+// behavior has equivalent end-to-end coverage.
+func RequiresSingleStageDistinctAgg(node *plan.Node) bool {
+	if node == nil {
+		return false
+	}
+	for _, expr := range node.AggList {
+		if expr == nil {
+			continue
+		}
+		agg := expr.GetF()
+		if agg == nil || agg.Func == nil || uint64(agg.Func.Obj)&function.Distinct == 0 {
+			continue
+		}
+		baseID := int64(uint64(agg.Func.Obj) & function.DistinctMask)
+		functionID, _ := function.DecodeOverloadID(baseID)
+		if functionID != function.COUNT {
+			return true
+		}
+	}
+	return false
+}
+
 func (builder *QueryBuilder) optimizeDistinctAgg(nodeID int32) {
 	node := builder.qry.Nodes[nodeID]
 

--- a/pkg/sql/plan/group_by_hash_key_test.go
+++ b/pkg/sql/plan/group_by_hash_key_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/stretchr/testify/require"
 )
 
@@ -184,6 +185,35 @@ func TestBuildPlanAnnotatesDistinctRewriteAggregate(t *testing.T) {
 				"the primary key determines both the payload and distinct argument")
 		})
 	}
+}
+
+func TestBuildPlanKeepsMixedCountDistinctParallelMergeable(t *testing.T) {
+	logicPlan, err := runOneStmt(
+		NewMockOptimizer(false),
+		t,
+		"select e.deptno, count(d.deptno), count(distinct d.loc) "+
+			"from constraint_test.emp e left join constraint_test.dept d on e.deptno = d.deptno "+
+			"group by e.deptno",
+	)
+	require.NoError(t, err)
+
+	var mixedAgg *pbplan.Node
+	for _, node := range logicPlan.GetQuery().Nodes {
+		if node.NodeType == pbplan.Node_AGG && len(node.AggList) == 2 {
+			mixedAgg = node
+			break
+		}
+	}
+	require.NotNil(t, mixedAgg)
+	require.False(t, RequiresSingleStageDistinctAgg(mixedAgg))
+	var distinctCount bool
+	for _, expr := range mixedAgg.AggList {
+		agg := expr.GetF()
+		if agg != nil && agg.Func != nil && uint64(agg.Func.Obj)&function.Distinct != 0 {
+			distinctCount = true
+		}
+	}
+	require.True(t, distinctCount, "mixed aggregates must retain COUNT(DISTINCT) for MergeGroup")
 }
 
 func TestBuildPlanAnnotatesJoinDistinctRewriteAggregate(t *testing.T) {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -36,7 +36,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
-	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
@@ -2325,24 +2324,8 @@ func CalcNodeDOP(p *plan.Plan, rootID int32, ncpu int32, lencn int) {
 		CalcNodeDOP(p, node.Children[i], ncpu, lencn)
 	}
 
-	// Check if node has distinct aggregation, which should run in single CPU
-	hasDistinctAgg := false
-	if node.NodeType == plan.Node_AGG && len(node.AggList) > 0 {
-		for _, agg := range node.AggList {
-			if f, ok := agg.Expr.(*plan.Expr_F); ok {
-				if (uint64(f.F.Func.Obj) & function.Distinct) != 0 {
-					hasDistinctAgg = true
-					break
-				}
-			}
-		}
-	}
-
-	if hasDistinctAgg {
-		// distinct aggregation should run in only one node and without any parallel
+	if node.NodeType == plan.Node_AGG && RequiresSingleStageDistinctAgg(node) {
 		if node.Stats == nil {
-			// If Stats is nil, create it first
-			// This should be rare for AGG nodes, but we handle it for safety
 			node.Stats = DefaultStats()
 		}
 		setNodeDOP(p, rootID, 1)

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -780,14 +780,11 @@ func TestUpdateStatsInfo_Decimal_DifferentScales(t *testing.T) {
 	}
 }
 
-// TestCalcNodeDOP_DistinctAggregation tests that distinct aggregation nodes
-// are correctly set to Dop=1 and ForceOneCN=true
-func TestCalcNodeDOP_DistinctAggregation(t *testing.T) {
-	// Create a plan with an AGG node containing COUNT(DISTINCT ...)
-	// Use a variable to avoid constant overflow when combining COUNT with Distinct flag
-	countVal := uint64(function.COUNT)
-	distinctVal := uint64(function.Distinct)
-	countWithDistinct := int64(countVal | distinctVal)
+// TestCalcNodeDOP_ParallelMergeableDistinctAggregation verifies that exact
+// DISTINCT states supported by MergeGroup retain the normal parallel DOP.
+func TestCalcNodeDOP_ParallelMergeableDistinctAggregation(t *testing.T) {
+	countID := function.EncodeOverloadID(function.COUNT, 0)
+	countWithDistinct := int64(uint64(countID) | uint64(function.Distinct))
 	p := &planpb.Plan{
 		Plan: &planpb.Plan_Query{
 			Query: &planpb.Query{
@@ -796,14 +793,14 @@ func TestCalcNodeDOP_DistinctAggregation(t *testing.T) {
 					{
 						NodeId:   0,
 						NodeType: planpb.Node_TABLE_SCAN,
-						Stats:    DefaultStats(),
+						Stats:    &planpb.Stats{BlockNum: 128, HashmapStats: &planpb.HashMapStats{}},
 					},
 					// AGG node with COUNT(DISTINCT ...)
 					{
 						NodeId:   1,
 						NodeType: planpb.Node_AGG,
 						Children: []int32{0},
-						Stats:    DefaultStats(),
+						Stats:    &planpb.Stats{BlockNum: 128, HashmapStats: &planpb.HashMapStats{}},
 						AggList: []*planpb.Expr{
 							{
 								Expr: &planpb.Expr_F{
@@ -839,16 +836,14 @@ func TestCalcNodeDOP_DistinctAggregation(t *testing.T) {
 	lencn := 2
 	CalcNodeDOP(p, 1, ncpu, lencn)
 
-	// Verify that the AGG node has Dop=1 and ForceOneCN=true
 	aggNode := p.GetQuery().Nodes[1]
 	require.NotNil(t, aggNode.Stats, "AGG node should have Stats")
-	require.Equal(t, int32(1), aggNode.Stats.Dop, "Distinct aggregation should have Dop=1")
-	require.True(t, aggNode.Stats.ForceOneCN, "Distinct aggregation should have ForceOneCN=true")
+	require.Equal(t, ncpu, aggNode.Stats.Dop)
+	require.False(t, aggNode.Stats.ForceOneCN)
 
-	// Verify that child node also has Dop=1 (recursively set)
 	childNode := p.GetQuery().Nodes[0]
 	require.NotNil(t, childNode.Stats, "Child node should have Stats")
-	require.Equal(t, int32(1), childNode.Stats.Dop, "Child node should have Dop=1 (recursively set)")
+	require.Equal(t, ncpu, childNode.Stats.Dop)
 }
 
 // TestCalcNodeDOP_NonDistinctAggregation tests that non-distinct aggregation nodes
@@ -912,14 +907,12 @@ func TestCalcNodeDOP_NonDistinctAggregation(t *testing.T) {
 	require.Greater(t, aggNode.Stats.Dop, int32(0), "Non-distinct aggregation should have Dop > 0")
 }
 
-// TestCalcNodeDOP_DistinctAggregationWithNilStats tests that distinct aggregation
-// nodes with nil Stats are handled correctly
-func TestCalcNodeDOP_DistinctAggregationWithNilStats(t *testing.T) {
-	// Create a plan with an AGG node containing COUNT(DISTINCT ...) but no Stats
-	// Use a variable to avoid constant overflow when combining COUNT with Distinct flag
-	countVal := uint64(function.COUNT)
-	distinctVal := uint64(function.Distinct)
-	countWithDistinct := int64(countVal | distinctVal)
+// TestCalcNodeDOP_NonMergeableDistinctAggregationWithNilStats keeps the
+// conservative single-stage fallback for DISTINCT aggregates without an exact
+// parallel merge contract.
+func TestCalcNodeDOP_NonMergeableDistinctAggregationWithNilStats(t *testing.T) {
+	avgID := function.EncodeOverloadID(function.AVG, 0)
+	avgWithDistinct := int64(uint64(avgID) | uint64(function.Distinct))
 	p := &planpb.Plan{
 		Plan: &planpb.Plan_Query{
 			Query: &planpb.Query{
@@ -930,21 +923,19 @@ func TestCalcNodeDOP_DistinctAggregationWithNilStats(t *testing.T) {
 						NodeType: planpb.Node_TABLE_SCAN,
 						Stats:    DefaultStats(),
 					},
-					// AGG node with COUNT(DISTINCT ...) but nil Stats
+					// AGG node with AVG(DISTINCT ...) but nil Stats
 					{
 						NodeId:   1,
 						NodeType: planpb.Node_AGG,
 						Children: []int32{0},
-						Stats:    nil, // nil Stats
+						Stats:    nil,
 						AggList: []*planpb.Expr{
 							{
 								Expr: &planpb.Expr_F{
 									F: &planpb.Function{
 										Func: &planpb.ObjectRef{
-											// COUNT with Distinct flag: use uint64 to avoid overflow, then convert to int64
-											// Similar to having_binder.go:144, we need to convert to uint64 first
-											Obj:     countWithDistinct,
-											ObjName: "count",
+											Obj:     avgWithDistinct,
+											ObjName: "avg",
 										},
 										Args: []*planpb.Expr{
 											{
@@ -974,8 +965,8 @@ func TestCalcNodeDOP_DistinctAggregationWithNilStats(t *testing.T) {
 	// Verify that Stats was created and set correctly
 	aggNode := p.GetQuery().Nodes[1]
 	require.NotNil(t, aggNode.Stats, "Stats should be created for distinct aggregation")
-	require.Equal(t, int32(1), aggNode.Stats.Dop, "Distinct aggregation should have Dop=1")
-	require.True(t, aggNode.Stats.ForceOneCN, "Distinct aggregation should have ForceOneCN=true")
+	require.Equal(t, int32(1), aggNode.Stats.Dop)
+	require.True(t, aggNode.Stats.ForceOneCN)
 }
 
 func TestGetExprNdv(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23072

## What this PR does / why we need it:

Queries that combine regular aggregates with `COUNT(DISTINCT ...)` cannot use the existing single-distinct rewrite. They therefore inherited the legacy blanket restriction that forced every DISTINCT aggregate pipeline onto one CN and one CPU, making large join-and-group workloads run serially.

The current COUNT DISTINCT aggregate state retains canonical arguments and `MergeGroup` can deduplicate them exactly across partial groups. This change narrows the legacy restriction accordingly:

- allows `COUNT(DISTINCT ...)` to keep the normal planner DOP and scan placement;
- compiles local `Group` operators per input scope and merges their exact distinct states through `MergeGroup`;
- keeps all other DISTINCT aggregates on the conservative single-stage path until they have equivalent end-to-end coverage;
- verifies the reported LEFT JOIN + mixed COUNT shape reaches the parallel-mergeable path;
- verifies cross-partial duplicates and NULL-only groups preserve COUNT DISTINCT semantics.

Validation:

- `GOWORK=off go list -mod=readonly ./pkg/sql/plan ./pkg/sql/compile ./pkg/sql/colexec/group`
- `GOWORK=off go build -mod=readonly ./pkg/sql/plan ./pkg/sql/compile ./pkg/sql/colexec/group`
- `GOWORK=off go vet -mod=readonly ./pkg/sql/plan ./pkg/sql/compile ./pkg/sql/colexec/group`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=240s ./pkg/sql/plan ./pkg/sql/compile ./pkg/sql/colexec/group`
