### PR TITLE
[4.2] fix(mpool): make on-heap ownership observable

### DIFF
--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -31,6 +31,7 @@ import (
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/resource"
 	"github.com/matrixorigin/matrixone/pkg/util/stack"
+	"go.uber.org/zap"
 )
 
 // debugPoisonOnFree, when enabled, fills freed memory with 0xDD bytes before
@@ -55,6 +56,50 @@ type MPoolStats struct {
 	// xpool frees are really bugs.  we always record them for debugging.
 	mu        sync.Mutex
 	xpoolFree map[string]detailInfo
+}
+
+// OnHeapOwnershipStats tracks the minimum logical-ownership facts needed to
+// detect an on-heap allocation whose owner has not called Free. It is smaller
+// than MPoolStats because on-heap ownership does not participate in admission
+// and does not need cumulative allocation traffic counters.
+type OnHeapOwnershipStats struct {
+	NumCurrBytes   atomic.Int64
+	NumCurrObjects atomic.Int64
+	HighWaterMark  atomic.Int64
+}
+
+func (s *OnHeapOwnershipStats) recordAlloc(sz int64) {
+	curr := s.NumCurrBytes.Add(sz)
+	s.NumCurrObjects.Add(1)
+	for {
+		peak := s.HighWaterMark.Load()
+		if curr <= peak || s.HighWaterMark.CompareAndSwap(peak, curr) {
+			return
+		}
+	}
+}
+
+func (s *OnHeapOwnershipStats) recordFree(sz, objects int64) {
+	if sz < 0 || objects < 0 {
+		panic(moerr.NewInternalErrorNoCtx("mpool on-heap ownership freed a negative value"))
+	}
+	bytes := s.NumCurrBytes.Add(-sz)
+	count := s.NumCurrObjects.Add(-objects)
+	if bytes < 0 || count < 0 {
+		panic(moerr.NewInternalErrorNoCtx("mpool freed more on-heap ownership than allocated"))
+	}
+}
+
+func (s *OnHeapOwnershipStats) ReportJson() string {
+	if s.HighWaterMark.Load() == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		`{"currBytes": %d,"currObjects": %d,"highWaterMark": %d}`,
+		s.NumCurrBytes.Load(),
+		s.NumCurrObjects.Load(),
+		s.HighWaterMark.Load(),
+	)
 }
 
 // ResourcePeakEpoch is an opaque, statement-scoped observation token.  Its
@@ -266,15 +311,19 @@ type detailInfo struct {
 }
 
 type mpoolDetails struct {
-	mu    sync.Mutex
-	alloc map[string]detailInfo
-	free  map[string]detailInfo
+	mu          sync.Mutex
+	alloc       map[string]detailInfo
+	free        map[string]detailInfo
+	onHeapAlloc map[string]detailInfo
+	onHeapFree  map[string]detailInfo
 }
 
 func newMpoolDetails() *mpoolDetails {
 	mpd := mpoolDetails{}
 	mpd.alloc = make(map[string]detailInfo)
 	mpd.free = make(map[string]detailInfo)
+	mpd.onHeapAlloc = make(map[string]detailInfo)
+	mpd.onHeapFree = make(map[string]detailInfo)
 	return &mpd
 }
 
@@ -305,6 +354,30 @@ func (d *mpoolDetails) recordFree(k string, nb int64) {
 	d.free[k] = info
 }
 
+func (d *mpoolDetails) recordOnHeapAlloc(k string, nb int64) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	info := d.onHeapAlloc[k]
+	info.cnt++
+	info.bytes += nb
+	d.onHeapAlloc[k] = info
+}
+
+func (d *mpoolDetails) recordOnHeapFree(k string, nb int64) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	info := d.onHeapFree[k]
+	info.cnt++
+	info.bytes += nb
+	d.onHeapFree[k] = info
+}
+
 func (d *mpoolDetails) reportJson() string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -322,6 +395,20 @@ func (d *mpoolDetails) reportJson() string {
 		frees = append(frees, kvs)
 	}
 	ret += strings.Join(frees, ",")
+	ret += `}, "on_heap_alloc": {`
+	onHeapAllocs := make([]string, 0, len(d.onHeapAlloc))
+	for k, v := range d.onHeapAlloc {
+		kvs := fmt.Sprintf("\"%s\": [%d, %d]", k, v.cnt, v.bytes)
+		onHeapAllocs = append(onHeapAllocs, kvs)
+	}
+	ret += strings.Join(onHeapAllocs, ",")
+	ret += `}, "on_heap_free": {`
+	onHeapFrees := make([]string, 0, len(d.onHeapFree))
+	for k, v := range d.onHeapFree {
+		kvs := fmt.Sprintf("\"%s\": [%d, %d]", k, v.cnt, v.bytes)
+		onHeapFrees = append(onHeapFrees, kvs)
+	}
+	ret += strings.Join(onHeapFrees, ",")
 	ret += "}}"
 	return ret
 }
@@ -499,18 +586,35 @@ func (mp *MPool) Cap() int64 {
 }
 
 func (mp *MPool) destroy() {
+	onHeapBytes, onHeapObjects := mp.OnHeapOutstanding()
+	if onHeapBytes != 0 {
+		logutil.Warn(
+			"mpool closed with outstanding on-heap ownership",
+			zap.Int64("pool-id", mp.id),
+			zap.String("pool-tag", mp.tag),
+			zap.Int64("bytes", onHeapBytes),
+			zap.Int64("objects", onHeapObjects),
+		)
+	}
 	liveBytes := mp.stats.NumCurrBytes.Load()
 	if liveBytes != 0 {
 		logutil.Errorf("mp error: %s", mp.stats.Report(""))
-		if mp.noLock {
-			// A noLock pool exclusively owns its local pointer metadata, so its
-			// teardown is the physical deallocation event.
+	}
+	if mp.noLock && (liveBytes != 0 || onHeapBytes != 0) {
+		// A noLock pool exclusively owns its local pointer metadata, so its
+		// teardown is the terminal release event for every remaining block.
+		mp.deallocateAllPtrs()
+		if liveBytes != 0 {
 			nfree := mp.stats.NumAlloc.Load() - mp.stats.NumFree.Load()
-			mp.deallocateAllPtrs()
 			mp.stats.RecordManyFrees(mp.tag, nfree, liveBytes)
 			globalStats.RecordManyFrees(mp.tag, nfree, liveBytes)
 			mp.resource.recordFree(liveBytes)
 		}
+		if onHeapBytes != 0 {
+			globalOnHeapStats.recordFree(onHeapBytes, onHeapObjects)
+		}
+	}
+	if !mp.noLock && liveBytes != 0 {
 		// A normal pool may have handed allocations to another owner. Its
 		// global pointer metadata and account lease remain authoritative until
 		// a later physical Free, including after this pool is unregistered.
@@ -580,11 +684,14 @@ func MustNewZeroNoFixed() *MPool {
 func (mp *MPool) ReportJson() string {
 	ss := mp.stats.ReportJson()
 	if ss == "" {
-		return fmt.Sprintf("{\"%s\": \"\"}", mp.tag)
+		ss = `""`
 	}
 	ret := fmt.Sprintf("{\"%s\": %s", mp.tag, ss)
+	if bytes, objects := mp.OnHeapOutstanding(); objects != 0 {
+		ret += fmt.Sprintf(",\n \"on_heap\": {\"currBytes\": %d,\"currObjects\": %d}", bytes, objects)
+	}
 	if mp.details != nil {
-		ret += `,\n "detailed_alloc": `
+		ret += ",\n \"detailed_alloc\": "
 		ret += mp.details.reportJson()
 	}
 
@@ -593,6 +700,44 @@ func (mp *MPool) ReportJson() string {
 
 func (mp *MPool) CurrNB() int64 {
 	return mp.stats.NumCurrBytes.Load()
+}
+
+// OnHeapCurrNB returns the bytes whose Go-heap backing remains logically owned
+// by this MPool and has not yet passed through Free.
+func (mp *MPool) OnHeapCurrNB() int64 {
+	bytes, _ := mp.OnHeapOutstanding()
+	return bytes
+}
+
+// OnHeapOutstanding returns the live Go-heap-backed allocations whose
+// metadata still names this pool as owner. It scans the authoritative pointer
+// registry only at diagnostic boundaries; allocations do not update per-pool
+// counters on the hot path.
+func (mp *MPool) OnHeapOutstanding() (bytes, objects int64) {
+	if mp == nil {
+		return 0, 0
+	}
+	if mp.noLock {
+		for _, hdr := range mp.ptrs {
+			if !hdr.isOffHeap() {
+				bytes += int64(hdr.allocSz)
+				objects++
+			}
+		}
+		return bytes, objects
+	}
+	for i := range globalPtrShards {
+		shard := &globalPtrShards[i]
+		shard.mu.Lock()
+		for _, hdr := range shard.m {
+			if hdr.poolId == mp.id && !hdr.isOffHeap() {
+				bytes += int64(hdr.allocSz)
+				objects++
+			}
+		}
+		shard.mu.Unlock()
+	}
+	return bytes, objects
 }
 
 // ResourcePeakLiveBytes returns the peak observed by token.  Ended tokens
@@ -707,6 +852,7 @@ func DeleteMPool(mp *MPool) {
 var nextPool int64
 var globalCap atomic.Int64
 var globalStats MPoolStats
+var globalOnHeapStats OnHeapOwnershipStats
 var globalPools sync.Map
 
 // Sharded pointer map to reduce lock contention
@@ -743,6 +889,12 @@ func GlobalStats() *MPoolStats {
 	return &globalStats
 }
 
+// GlobalOnHeapStats reports logical ownership of all Go-heap-backed MPool
+// allocations. It is independent from the off-heap capacity controller.
+func GlobalOnHeapStats() *OnHeapOwnershipStats {
+	return &globalOnHeapStats
+}
+
 func GlobalCap() int64 {
 	n := globalCap.Load()
 	if n == 0 {
@@ -757,6 +909,9 @@ func maxAllocationSize() int64 {
 	return int64(CapLimit) - kMemHdrSz
 }
 
+// Alloc returns an MPool-owned block. The caller must eventually pass every
+// successful non-empty allocation to Free; DeleteMPool provides the terminal
+// release only for NoLock pools, whose allocations cannot outlive the pool.
 func (mp *MPool) Alloc(sz int, offHeap bool) ([]byte, error) {
 	detailk := mp.getDetailK()
 	return mp.allocWithDetailK(detailk, int64(sz), offHeap)
@@ -913,7 +1068,12 @@ func (mp *MPool) alloc(
 		}
 		return nil, err
 	}
-	if offHeap {
+	if !offHeap {
+		globalOnHeapStats.recordAlloc(sz)
+		if mp.details != nil {
+			mp.details.recordOnHeapAlloc(detailk, sz)
+		}
+	} else {
 		mp.recordResourcePeak(mp.resource.recordAlloc(sz))
 		if mp.details != nil {
 			mp.details.recordAlloc(detailk, sz)
@@ -1064,6 +1224,8 @@ func (mp *MPool) freePtr(detailk string, ptr unsafe.Pointer) {
 				if hdr.isAccounted() {
 					lease.release(uint64(sz))
 				}
+			} else {
+				globalOnHeapStats.recordFree(int64(hdr.allocSz), 1)
 			}
 		} else {
 			owner := otherPool.(*MPool)
@@ -1087,6 +1249,11 @@ func (mp *MPool) freePtrInternal(
 			panic(moerr.NewInternalErrorNoCtx(
 				"accounted allocation is not off-heap",
 			))
+		}
+		sz := int64(hdr.allocSz)
+		globalOnHeapStats.recordFree(sz, 1)
+		if mp.details != nil {
+			mp.details.recordOnHeapFree(detailk, sz)
 		}
 		return
 	}

--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -614,11 +614,6 @@ func (mp *MPool) destroy() {
 			globalOnHeapStats.recordFree(onHeapBytes, onHeapObjects)
 		}
 	}
-	if !mp.noLock && liveBytes != 0 {
-		// A normal pool may have handed allocations to another owner. Its
-		// global pointer metadata and account lease remain authoritative until
-		// a later physical Free, including after this pool is unregistered.
-	}
 }
 
 // New a MPool.   Tag is user supplied, used for debugging/diagnostics.

--- a/pkg/common/mpool/mpool_test.go
+++ b/pkg/common/mpool/mpool_test.go
@@ -16,6 +16,7 @@ package mpool
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sync"
@@ -98,6 +99,66 @@ func TestReportMemUsage(t *testing.T) {
 	t.Logf("mem usage: %s", j1)
 	t.Logf("global mem usage: %s", j2)
 	t.Logf("testjson mem usage: %s", j3)
+}
+
+func TestOnHeapStatsLifecycleAndReport(t *testing.T) {
+	mp := MustNew("onheap-stats-lifecycle")
+	defer DeleteMPool(mp)
+	mp.EnableDetailRecording()
+
+	globalBytesBefore := GlobalOnHeapStats().NumCurrBytes.Load()
+	globalObjectsBefore := GlobalOnHeapStats().NumCurrObjects.Load()
+
+	buf, err := mp.Alloc(128, false)
+	require.NoError(t, err)
+	require.Zero(t, mp.CurrNB(), "on-heap ownership must not change off-heap admission stats")
+	require.Equal(t, int64(128), mp.OnHeapCurrNB())
+	_, objects := mp.OnHeapOutstanding()
+	require.Equal(t, int64(1), objects)
+	require.Equal(t, globalBytesBefore+128, GlobalOnHeapStats().NumCurrBytes.Load())
+	require.Equal(t, globalObjectsBefore+1, GlobalOnHeapStats().NumCurrObjects.Load())
+
+	report := mp.ReportJson()
+	require.True(t, json.Valid([]byte(report)), report)
+	require.Contains(t, report, `"on_heap"`)
+	require.Contains(t, report, `"on_heap_alloc"`)
+
+	mp.Free(buf)
+	require.Zero(t, mp.OnHeapCurrNB())
+	require.Equal(t, globalBytesBefore, GlobalOnHeapStats().NumCurrBytes.Load())
+	require.Equal(t, globalObjectsBefore, GlobalOnHeapStats().NumCurrObjects.Load())
+	require.Contains(t, mp.ReportJson(), `"on_heap_free"`)
+}
+
+func TestOnHeapStatsNoLockAndGrow(t *testing.T) {
+	mp := MustNewNoLock("onheap-stats-nolock-grow")
+	defer DeleteMPool(mp)
+
+	buf, err := mp.Alloc(8, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(8), mp.OnHeapCurrNB())
+
+	grown, err := mp.Grow(buf, 1024, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(cap(grown)), mp.OnHeapCurrNB())
+	_, objects := mp.OnHeapOutstanding()
+	require.Equal(t, int64(1), objects)
+
+	mp.Free(grown)
+	require.Zero(t, mp.OnHeapCurrNB())
+	_, objects = mp.OnHeapOutstanding()
+	require.Zero(t, objects)
+}
+
+func TestOnHeapStatsFailedAllocationDoesNotAdvance(t *testing.T) {
+	mp := MustNew("onheap-stats-failed-allocation")
+	defer DeleteMPool(mp)
+
+	_, err := mp.Alloc(math.MaxInt, false)
+	require.Error(t, err)
+	require.Zero(t, mp.OnHeapCurrNB())
+	_, objects := mp.OnHeapOutstanding()
+	require.Zero(t, objects)
 }
 
 func TestMP(t *testing.T) {
@@ -530,12 +591,13 @@ func TestCrossPoolFreeOnHeap(t *testing.T) {
 	// Allocate on-heap from mp1
 	bs, err := mp1.Alloc(1024, false)
 	require.NoError(t, err)
+	require.Equal(t, int64(1024), mp1.OnHeapCurrNB())
+	globalBefore := GlobalOnHeapStats().NumCurrBytes.Load()
 
 	// Free from mp2 (cross-pool free) - should not panic
 	mp2.Free(bs)
-
-	// On-heap cross-pool free: no stats recorded since offHeap=false returns early
-	// This is expected behavior - on-heap memory is managed by Go GC
+	require.Zero(t, mp1.OnHeapCurrNB())
+	require.Equal(t, globalBefore-1024, GlobalOnHeapStats().NumCurrBytes.Load())
 
 	DeleteMPool(mp1)
 	DeleteMPool(mp2)
@@ -557,6 +619,21 @@ func TestMPoolTeardownTracksPhysicalLifetime(t *testing.T) {
 		require.Equal(t, globalBefore, GlobalStats().NumCurrBytes.Load())
 	})
 
+	t.Run("normal-pool-late-onheap-free", func(t *testing.T) {
+		owner := MustNew("teardown-normal-onheap-owner")
+		other := MustNew("teardown-normal-onheap-other")
+		defer DeleteMPool(other)
+
+		globalBefore := GlobalOnHeapStats().NumCurrBytes.Load()
+		buffer, err := owner.Alloc(64, false)
+		require.NoError(t, err)
+		DeleteMPool(owner)
+		require.Equal(t, globalBefore+64, GlobalOnHeapStats().NumCurrBytes.Load())
+
+		other.Free(buffer)
+		require.Equal(t, globalBefore, GlobalOnHeapStats().NumCurrBytes.Load())
+	})
+
 	t.Run("no-lock-pool-owns-teardown", func(t *testing.T) {
 		mp := MustNewNoLock("teardown-no-lock-owner")
 		globalBefore := GlobalStats().NumCurrBytes.Load()
@@ -566,51 +643,93 @@ func TestMPoolTeardownTracksPhysicalLifetime(t *testing.T) {
 		DeleteMPool(mp)
 		require.Equal(t, globalBefore, GlobalStats().NumCurrBytes.Load())
 	})
+
+	t.Run("no-lock-pool-owns-onheap-teardown", func(t *testing.T) {
+		mp := MustNewNoLock("teardown-no-lock-onheap-owner")
+		globalBefore := GlobalOnHeapStats().NumCurrBytes.Load()
+		_, err := mp.Alloc(64, false)
+		require.NoError(t, err)
+
+		DeleteMPool(mp)
+		require.Zero(t, mp.OnHeapCurrNB())
+		require.Equal(t, globalBefore, GlobalOnHeapStats().NumCurrBytes.Load())
+	})
 }
 
 // TestDoubleFree tests that double free is detected and panics.
 func TestDoubleFree(t *testing.T) {
-	mp := MustNew("double-free-test")
+	for _, offHeap := range []bool{false, true} {
+		t.Run(fmt.Sprintf("offheap=%t", offHeap), func(t *testing.T) {
+			mp := MustNew("double-free-test")
+			defer DeleteMPool(mp)
 
-	bs, err := mp.Alloc(1024, true)
-	require.NoError(t, err)
-
-	mp.Free(bs)
-
-	// Second free should panic
-	require.Panics(t, func() {
-		mp.Free(bs)
-	}, "double free should panic")
-
-	DeleteMPool(mp)
+			bs, err := mp.Alloc(1024, offHeap)
+			require.NoError(t, err)
+			mp.Free(bs)
+			require.Panics(t, func() {
+				mp.Free(bs)
+			}, "double free should panic")
+		})
+	}
 }
 
 // TestConcurrentAllocFree tests concurrent allocation and free with sharded locks.
 func TestConcurrentAllocFree(t *testing.T) {
-	mp := MustNew("concurrent-test")
-	var wg sync.WaitGroup
+	for _, offHeap := range []bool{false, true} {
+		t.Run(fmt.Sprintf("offheap=%t", offHeap), func(t *testing.T) {
+			mp := MustNew("concurrent-test")
+			defer DeleteMPool(mp)
+			var wg sync.WaitGroup
 
-	numGoroutines := 100
-	numOps := 1000
-
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := 0; j < numOps; j++ {
-				bs, err := mp.Alloc(64, true)
-				if err != nil {
-					t.Errorf("alloc failed: %v", err)
-					return
-				}
-				mp.Free(bs)
+			const numGoroutines = 100
+			const numOps = 1000
+			for i := 0; i < numGoroutines; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for j := 0; j < numOps; j++ {
+						bs, err := mp.Alloc(64, offHeap)
+						if err != nil {
+							t.Errorf("alloc failed: %v", err)
+							return
+						}
+						mp.Free(bs)
+					}
+				}()
 			}
-		}()
+			wg.Wait()
+			if offHeap {
+				require.Zero(t, mp.CurrNB())
+			} else {
+				require.Zero(t, mp.OnHeapCurrNB())
+			}
+		})
 	}
+}
 
-	wg.Wait()
-	require.Equal(t, int64(0), mp.CurrNB(), "all memory should be freed")
-	DeleteMPool(mp)
+func BenchmarkMPoolOnHeapAllocFree(b *testing.B) {
+	for _, noLock := range []bool{false, true} {
+		for _, size := range []int{64, 1024, 64 << 10} {
+			name := fmt.Sprintf("nolock=%t/bytes=%d", noLock, size)
+			b.Run(name, func(b *testing.B) {
+				flags := NoFixed
+				if noLock {
+					flags |= NoLock
+				}
+				mp, err := NewMPool(name, 0, flags)
+				require.NoError(b, err)
+				defer DeleteMPool(mp)
+				b.ReportAllocs()
+				for b.Loop() {
+					buf, err := mp.Alloc(size, false)
+					if err != nil {
+						b.Fatal(err)
+					}
+					mp.Free(buf)
+				}
+			})
+		}
+	}
 }
 
 // TestConcurrentCrossPoolFree tests concurrent cross-pool free operations.

--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -1149,6 +1149,7 @@ func TestDataBranchOutputShouldDiffAsCSV(t *testing.T) {
 		defer mpool.DeleteMPool(mp)
 
 		bat := batch.NewWithSize(1)
+		defer bat.Clean(mp)
 		bat.Vecs[0] = vector.NewVec(types.T_uint64.ToType())
 		require.NoError(t, vector.AppendFixed[uint64](bat.Vecs[0], 3, false, mp))
 		bat.SetRowCount(1)
@@ -1166,6 +1167,7 @@ func TestDataBranchOutputShouldDiffAsCSV(t *testing.T) {
 		defer mpool.DeleteMPool(mp)
 
 		bat := batch.NewWithSize(1)
+		defer bat.Clean(mp)
 		bat.Vecs[0] = vector.NewVec(types.T_uint64.ToType())
 		require.NoError(t, vector.AppendFixed[uint64](bat.Vecs[0], 0, false, mp))
 		bat.SetRowCount(1)

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -530,6 +530,7 @@ func TestAppendTupleValueToVector_VarlenaAndNull(t *testing.T) {
 	defer mpool.DeleteMPool(mp)
 
 	varcharVec := vector.NewVec(types.New(types.T_varchar, 64, 0))
+	defer varcharVec.Free(mp)
 	require.NoError(t, appendTupleValueToVector(varcharVec, []byte("hello"), mp))
 	require.Equal(t, 1, varcharVec.Length())
 	require.Equal(t, "hello", string(varcharVec.GetBytesAt(0)))
@@ -539,18 +540,21 @@ func TestAppendTupleValueToVector_VarlenaAndNull(t *testing.T) {
 	require.True(t, varcharVec.GetNulls().Contains(1))
 
 	decimalVec := vector.NewVec(types.New(types.T_decimal256, 65, 30))
+	defer decimalVec.Free(mp)
 	decimalValue, err := types.ParseDecimal256("42.000000000000000000000000000000", 65, 30)
 	require.NoError(t, err)
 	require.NoError(t, appendTupleValueToVector(decimalVec, types.EncodeDecimal256(&decimalValue), mp))
 	require.Equal(t, decimalValue, vector.GetFixedAtNoTypeCheck[types.Decimal256](decimalVec, 0))
 
 	datetimeVec := vector.NewVec(types.New(types.T_datetime, 0, 6))
+	defer datetimeVec.Free(mp)
 	err = appendTupleValueToVector(datetimeVec, []byte("not-raw-fixed"), mp)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected byte slice for fixed-width column")
 
 	decimalTyp := types.New(types.T_decimal256, 39, 4)
 	wideDecimalVec := vector.NewVec(decimalTyp)
+	defer wideDecimalVec.Free(mp)
 	decimalVal, err := types.ParseDecimal256("12345678901234567890123456789012344.1234", decimalTyp.Width, decimalTyp.Scale)
 	require.NoError(t, err)
 	require.NoError(t, appendTupleValueToVector(wideDecimalVec, types.EncodeDecimal256(&decimalVal), mp))
@@ -558,6 +562,7 @@ func TestAppendTupleValueToVector_VarlenaAndNull(t *testing.T) {
 	require.Equal(t, decimalVal, vector.GetFixedAtNoTypeCheck[types.Decimal256](wideDecimalVec, 0))
 
 	yearVec := vector.NewVec(types.T_year.ToType())
+	defer yearVec.Free(mp)
 	yearVal := types.MoYear(2024)
 	require.NoError(t, appendTupleValueToVector(yearVec, types.EncodeValue(yearVal, types.T_year), mp))
 	require.Equal(t, 1, yearVec.Length())

--- a/pkg/frontend/internal_executor_test.go
+++ b/pkg/frontend/internal_executor_test.go
@@ -183,7 +183,9 @@ func Test_internalProtocol_Write(t *testing.T) {
 		return bat
 	}
 	batch1 := mockBatch([]int64{100})
+	defer batch1.Clean(mp)
 	batch2 := mockBatch([]int64{200, 201})
+	defer batch2.Clean(mp)
 
 	// ======================= main ===================
 	ip.Reset(ses)

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -887,6 +887,7 @@ func Test_getDataFromPipeline(t *testing.T) {
 		}
 
 		batchCase1 := genBatch()
+		defer batchCase1.Clean(mp)
 		ec := newTestExecCtx(ctx, ctrl)
 		ec.ses = ses
 
@@ -902,6 +903,7 @@ func Test_getDataFromPipeline(t *testing.T) {
 			}
 			return bat
 		}()
+		defer batchCase2.Clean(mp)
 
 		err = getDataFromPipeline(ses, ec, batchCase2, nil)
 		convey.So(err, convey.ShouldBeNil)
@@ -975,6 +977,7 @@ func Test_getDataFromPipeline(t *testing.T) {
 			}
 			return bat
 		}()
+		defer batchCase2.Clean(mp)
 
 		err = getDataFromPipeline(ses, ec, batchCase2, nil)
 		convey.So(err, convey.ShouldBeNil)

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -1115,6 +1115,7 @@ func Test_makeExecuteSql(t *testing.T) {
 	testProc := process.NewTopProcess(context.Background(), mp, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	params1 := vector.NewVec(types.T_text.ToType())
+	defer params1.Free(testProc.GetMPool())
 	for i := 0; i < 3; i++ {
 		err = vector.AppendBytes(params1, []byte{}, false, testProc.GetMPool())
 		assert.NoError(t, err)

--- a/pkg/util/metric/mometric/metric.go
+++ b/pkg/util/metric/mometric/metric.go
@@ -171,6 +171,8 @@ func mpoolRelatedMetrics() {
 	v2.MemTotalCrossPoolFreeCounter.Add(float64(mpool.GlobalStats().NumCrossPoolFree.Load()))
 	v2.MemGlobalStatsAllocatedGauge.Set(float64(mpool.GlobalStats().NumCurrBytes.Load()))
 	v2.MemGlobalStatsHighWaterMarkGauge.Set(float64(mpool.GlobalStats().HighWaterMark.Load()))
+	v2.MemMPoolOnHeapOutstandingBytesGauge.Set(float64(mpool.GlobalOnHeapStats().NumCurrBytes.Load()))
+	v2.MemMPoolOnHeapOutstandingObjectsGauge.Set(float64(mpool.GlobalOnHeapStats().NumCurrObjects.Load()))
 }
 
 func IsEnable() bool {

--- a/pkg/util/metric/mometric/metric_test.go
+++ b/pkg/util/metric/mometric/metric_test.go
@@ -21,16 +21,38 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/util/metric"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 
 	"github.com/matrixorigin/matrixone/pkg/config"
 	prom "github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMPoolRelatedMetricsIncludesOnHeapOwnership(t *testing.T) {
+	mp := mpool.MustNew("mometric-onheap-ownership")
+	defer mpool.DeleteMPool(mp)
+	buf, err := mp.Alloc(96, false)
+	require.NoError(t, err)
+
+	mpoolRelatedMetrics()
+	require.Equal(t,
+		float64(mpool.GlobalOnHeapStats().NumCurrBytes.Load()),
+		promtest.ToFloat64(v2.MemMPoolOnHeapOutstandingBytesGauge))
+	require.Equal(t, float64(mpool.GlobalOnHeapStats().NumCurrObjects.Load()),
+		promtest.ToFloat64(v2.MemMPoolOnHeapOutstandingObjectsGauge))
+
+	mp.Free(buf)
+	mpoolRelatedMetrics()
+	require.Equal(t, float64(mpool.GlobalOnHeapStats().NumCurrBytes.Load()),
+		promtest.ToFloat64(v2.MemMPoolOnHeapOutstandingBytesGauge))
+}
 
 func TestMetric(t *testing.T) {
 	sqlch := make(chan string, 100)

--- a/pkg/util/metric/v2/mem.go
+++ b/pkg/util/metric/v2/mem.go
@@ -59,6 +59,23 @@ var (
 )
 
 var (
+	MemMPoolOnHeapOutstandingBytesGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "mo",
+			Subsystem: "mem",
+			Name:      "mpool_onheap_outstanding_bytes",
+			Help:      "Go-heap-backed bytes still logically owned by MPool and awaiting Free.",
+		})
+	MemMPoolOnHeapOutstandingObjectsGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "mo",
+			Subsystem: "mem",
+			Name:      "mpool_onheap_outstanding_objects",
+			Help:      "Go-heap-backed objects still logically owned by MPool and awaiting Free.",
+		})
+)
+
+var (
 	MemTotalCrossPoolFreeCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "mo",

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -74,6 +74,8 @@ func initMemMetrics() {
 	registry.MustRegister(memMPoolAllocatedSizeGauge)
 	registry.MustRegister(MemTotalCrossPoolFreeCounter)
 	registry.MustRegister(memMPoolHighWaterMarkGauge)
+	registry.MustRegister(MemMPoolOnHeapOutstandingBytesGauge)
+	registry.MustRegister(MemMPoolOnHeapOutstandingObjectsGauge)
 	registry.MustRegister(MallocCounter)
 	registry.MustRegister(MallocGauge)
 	registry.MustRegister(OffHeapInuseGauge)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27404

## What this PR does / why we need it:

Backport #27497 to 4.2-dev.

- Make live Go-heap-backed MPool ownership observable by global bytes/objects metrics and per-pool diagnostics.
- Preserve the explicit-Free contract and strong pointer provenance, including valid late Free after normal-pool deletion.
- Treat NoLock pool teardown as its terminal bulk-release boundary.
- Document the lifecycle contract and fix the test cleanup sites exposed by the ownership audit.

The two source commits applied cleanly to the newest 4.2-dev tip.

Validation:

- full pkg/common/mpool
- full pkg/util/metric/v2
- full pkg/util/metric/mometric
- full pkg/frontend
