### PR TITLE
[4.2] fix(frontend): release query result metadata batch

### DIFF
--- a/pkg/frontend/query_result.go
+++ b/pkg/frontend/query_result.go
@@ -329,6 +329,9 @@ func saveMeta(ctx context.Context, ses *Session) error {
 	if err != nil {
 		return err
 	}
+	// objectWriterV1 serializes the batch into writer-owned buffers during Write,
+	// so saveMeta retains ownership of this temporary batch on every return path.
+	defer metaBat.Clean(ses.pool)
 	metaPath := catalog.BuildQueryResultMetaPath(ses.GetTenantInfo().GetTenant(), uuid.UUID(ses.GetStmtId()).String())
 	metaWriter, err := objectio.NewObjectWriterSpecial(objectio.WriterQueryResult, metaPath, fs)
 	if err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27405

## What this PR does / why we need it:

Backport #27454 to 4.2-dev.

Release the temporary query-result metadata batch after object serialization completes. The writer stores serialized buffers rather than the input batch, so saveMeta retains ownership through every success and writer-error path and can safely clean it on return.

The source commit applied cleanly to the newest 4.2-dev tip.

Validation:

- full pkg/frontend suite
