### PR TITLE
[4.2] fix(frontend): clean partial query result metadata batch

### DIFF
--- a/pkg/frontend/query_result.go
+++ b/pkg/frontend/query_result.go
@@ -610,8 +610,11 @@ func getTablesFromPlan(p *plan.Plan) string {
 }
 
 func buildQueryResultMetaBatch(m *catalog.Meta, mp *mpool.MPool) (*batch.Batch, error) {
-	var err error
 	bat := batch.NewWithSize(len(catalog.MetaColTypes))
+	return populateQueryResultMetaBatch(bat, m, mp)
+}
+
+func populateQueryResultMetaBatch(bat *batch.Batch, m *catalog.Meta, mp *mpool.MPool) (_ *batch.Batch, err error) {
 	completed := false
 	defer func() {
 		if !completed {

--- a/pkg/frontend/query_result.go
+++ b/pkg/frontend/query_result.go
@@ -609,6 +609,12 @@ func getTablesFromPlan(p *plan.Plan) string {
 func buildQueryResultMetaBatch(m *catalog.Meta, mp *mpool.MPool) (*batch.Batch, error) {
 	var err error
 	bat := batch.NewWithSize(len(catalog.MetaColTypes))
+	completed := false
+	defer func() {
+		if !completed {
+			bat.Clean(mp)
+		}
+	}()
 	bat.SetAttributes(catalog.MetaColNames)
 	for i, t := range catalog.MetaColTypes {
 		bat.Vecs[i] = vector.NewVec(t)
@@ -661,6 +667,7 @@ func buildQueryResultMetaBatch(m *catalog.Meta, mp *mpool.MPool) (*batch.Batch, 
 	if err = vector.AppendFixed(bat.Vecs[catalog.QUERY_ROW_COUNT_IDX], m.QueryRowCount, false, mp); err != nil {
 		return nil, err
 	}
+	completed = true
 	return bat, nil
 }
 

--- a/pkg/frontend/query_result_test.go
+++ b/pkg/frontend/query_result_test.go
@@ -126,11 +126,18 @@ func TestBuildQueryResultMetaBatchCleansPartialBatchOnAppendFailure(t *testing.T
 	mp := mpool.MustNewZero()
 	defer mpool.DeleteMPool(mp)
 
-	bat, err := buildQueryResultMetaBatch(&catalog.Meta{
-		Statement: strings.Repeat("x", 256),
-	}, mp)
+	meta := &catalog.Meta{Statement: strings.Repeat("x", 256)}
+	result, err := buildQueryResultMetaBatch(meta, mp)
 	require.Error(t, err)
-	require.Nil(t, bat)
+	require.Nil(t, result)
+
+	// Retain the helper input so the test can observe Batch.Clean's terminal
+	// state directly; 4.2 does not account Go-heap-backed vectors in CurrNB.
+	bat := batch.NewWithSize(len(catalog.MetaColTypes))
+	_, err = populateQueryResultMetaBatch(bat, meta, mp)
+	require.Error(t, err)
+	require.Nil(t, bat.Vecs)
+	require.Nil(t, bat.Attrs)
 }
 
 func Test_saveQueryResultMeta(t *testing.T) {

--- a/pkg/frontend/query_result_test.go
+++ b/pkg/frontend/query_result_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prashantv/gostub"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -115,6 +116,21 @@ func newBatch(ts []types.Type, rows int, proc *process.Process) *batch.Batch {
 		}
 	}
 	return bat
+}
+
+func TestBuildQueryResultMetaBatchCleansPartialBatchOnAppendFailure(t *testing.T) {
+	originalCapLimit := mpool.CapLimit
+	mpool.CapLimit = 128
+	t.Cleanup(func() { mpool.CapLimit = originalCapLimit })
+
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	bat, err := buildQueryResultMetaBatch(&catalog.Meta{
+		Statement: strings.Repeat("x", 256),
+	}, mp)
+	require.Error(t, err)
+	require.Nil(t, bat)
 }
 
 func Test_saveQueryResultMeta(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27406

## What this PR does / why we need it:

Backport #27455 to 4.2-dev.

Keep ownership of the query-result metadata batch inside the builder until every metadata field is appended. Any append error releases all previously populated vectors before returning; a successful return transfers the completed batch to its caller.

The production fix applied cleanly to the newest 4.2-dev tip. Its regression test was placed into the older 4.2 test layout without bringing unrelated main-only tests.

Validation:

- TestBuildQueryResultMetaBatchCleansPartialBatchOnAppendFailure
- full pkg/frontend suite
