### PR TITLE
fix(readutil): preserve nested PK OR branches

### DIFF
--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -1118,6 +1118,26 @@ func TestConstructBasePKFilterWithOr(t *testing.T) {
 			},
 		},
 		{
+			name: "nested eq or keeps every branch",
+			expr: MakeFunctionExprForTest("or", []*plan.Expr{
+				MakeFunctionExprForTest("or", []*plan.Expr{
+					MakeFunctionExprForTest("or", []*plan.Expr{makeEq(1), makeEq(2)}),
+					MakeFunctionExprForTest("or", []*plan.Expr{makeEq(3), makeEq(4)}),
+				}),
+				makeEq(5),
+			}),
+			expect: expect{
+				valid: true,
+				disjuncts: []BasePKFilter{
+					{Valid: true, Op: function.EQUAL, LB: encodeVal(1), Oid: types.T_int64},
+					{Valid: true, Op: function.EQUAL, LB: encodeVal(2), Oid: types.T_int64},
+					{Valid: true, Op: function.EQUAL, LB: encodeVal(3), Oid: types.T_int64},
+					{Valid: true, Op: function.EQUAL, LB: encodeVal(4), Oid: types.T_int64},
+					{Valid: true, Op: function.EQUAL, LB: encodeVal(5), Oid: types.T_int64},
+				},
+			},
+		},
+		{
 			name: "eq or in",
 			expr: MakeFunctionExprForTest("or", []*plan.Expr{
 				makeEq(1),

--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -1071,8 +1071,14 @@ func TestConstructBasePKFilterWithOr(t *testing.T) {
 		})
 	}
 
-	makeLessThan := func(v int64) *plan.Expr {
-		return MakeFunctionExprForTest("<", []*plan.Expr{
+	makeLessEqual := func(v int64) *plan.Expr {
+		return MakeFunctionExprForTest("<=", []*plan.Expr{
+			MakeColExprForTest(0, types.T_int64),
+			plan2.MakePlan2Int64ConstExprWithType(v),
+		})
+	}
+	makeGreaterThan := func(v int64) *plan.Expr {
+		return MakeFunctionExprForTest(">", []*plan.Expr{
 			MakeColExprForTest(0, types.T_int64),
 			plan2.MakePlan2Int64ConstExprWithType(v),
 		})
@@ -1170,20 +1176,33 @@ func TestConstructBasePKFilterWithOr(t *testing.T) {
 			},
 		},
 		{
-			name: "and distribute",
+			name: "disjunction and atomic keeps atomic",
 			expr: MakeFunctionExprForTest("and", []*plan.Expr{
 				MakeFunctionExprForTest("or", []*plan.Expr{
 					makeEq(1),
-					makeEq(2),
+					makeGreaterThan(3),
 				}),
-				makeLessThan(3),
+				makeLessEqual(10),
 			}),
 			expect: expect{
 				valid: true,
-				disjuncts: []BasePKFilter{
-					{Valid: true, Op: function.EQUAL, LB: encodeVal(1), Oid: types.T_int64},
-					{Valid: true, Op: function.EQUAL, LB: encodeVal(2), Oid: types.T_int64},
-				},
+				op:    function.LESS_EQUAL,
+				lb:    encodeVal(10),
+			},
+		},
+		{
+			name: "atomic and disjunction keeps atomic",
+			expr: MakeFunctionExprForTest("and", []*plan.Expr{
+				makeLessEqual(10),
+				MakeFunctionExprForTest("or", []*plan.Expr{
+					makeEq(1),
+					makeGreaterThan(3),
+				}),
+			}),
+			expect: expect{
+				valid: true,
+				op:    function.LESS_EQUAL,
+				lb:    encodeVal(10),
 			},
 		},
 		{
@@ -1250,6 +1269,7 @@ func TestConstructBasePKFilterWithOr(t *testing.T) {
 		}
 
 		if testCases[i].expect.valid {
+			require.Equal(t, types.T_int64, basePKFilter.Oid, testCases[i].name)
 			require.Equal(t, testCases[i].expect.op, basePKFilter.Op, testCases[i].name)
 			require.Equal(t, testCases[i].expect.lb, basePKFilter.LB, testCases[i].name)
 			require.Equal(t, testCases[i].expect.ub, basePKFilter.UB, testCases[i].name)

--- a/pkg/vm/engine/readutil/pk_filter.go
+++ b/pkg/vm/engine/readutil/pk_filter.go
@@ -1457,8 +1457,6 @@ func mergeFilters(
 ) (finalFilter BasePKFilter, err error) {
 	unsafeInput := false
 	defer func() {
-		finalFilter.Oid = left.Oid
-
 		if !finalFilter.Valid && connector == function.AND && !unsafeInput {
 			// Keep one atomic conjunct when representing the full intersection
 			// would require distributing AND over OR.  It remains a safe early
@@ -1479,7 +1477,10 @@ func mergeFilters(
 					(*left).Vec = nil
 				}
 			}
+			return
 		}
+
+		finalFilter.Oid = left.Oid
 	}()
 	unsafeInput = (len(left.Disjuncts) == 0 && !validBasePKMergeOperand(*left)) ||
 		(len(right.Disjuncts) == 0 && !validBasePKMergeOperand(*right))
@@ -1487,6 +1488,14 @@ func mergeFilters(
 		(len(left.Disjuncts) == 0 && len(right.Disjuncts) == 0 && left.Oid != right.Oid) ||
 		(left.Op != function.IN && len(left.Disjuncts) == 0 && !validEncodedBasePKValue(left.Oid, left.LB)) ||
 		(right.Op != function.IN && len(right.Disjuncts) == 0 && !validEncodedBasePKValue(right.Oid, right.LB)) {
+		return BasePKFilter{}, nil
+	}
+	// A disjunctive filter is a container, not an atomic predicate. Its zero
+	// value Op happens to equal function.EQUAL, so entering either connector's
+	// atomic merge can compare empty bounds and produce a false-negative filter.
+	// Return an invalid merge: OR will flatten both containers, while AND's
+	// deferred fallback keeps one safe atomic conjunct.
+	if len(left.Disjuncts) > 0 || len(right.Disjuncts) > 0 {
 		return BasePKFilter{}, nil
 	}
 
@@ -1662,13 +1671,6 @@ func mergeFilters(
 		}
 
 	case function.OR:
-		// A disjunctive filter is a container, not an atomic predicate. Its zero
-		// value Op happens to equal function.EQUAL, so attempting an atomic merge
-		// compares empty bounds and can discard an entire nested OR branch. Return
-		// an invalid merge and let constructBasePKFilter flatten both containers.
-		if len(left.Disjuncts) > 0 || len(right.Disjuncts) > 0 {
-			return BasePKFilter{}, nil
-		}
 		switch left.Op {
 		case function.IN:
 			switch right.Op {

--- a/pkg/vm/engine/readutil/pk_filter.go
+++ b/pkg/vm/engine/readutil/pk_filter.go
@@ -1662,6 +1662,13 @@ func mergeFilters(
 		}
 
 	case function.OR:
+		// A disjunctive filter is a container, not an atomic predicate. Its zero
+		// value Op happens to equal function.EQUAL, so attempting an atomic merge
+		// compares empty bounds and can discard an entire nested OR branch. Return
+		// an invalid merge and let constructBasePKFilter flatten both containers.
+		if len(left.Disjuncts) > 0 || len(right.Disjuncts) > 0 {
+			return BasePKFilter{}, nil
+		}
 		switch left.Op {
 		case function.IN:
 			switch right.Op {

--- a/test/distributed/cases/optimizer/pk_filter_nested_boolean.result
+++ b/test/distributed/cases/optimizer/pk_filter_nested_boolean.result
@@ -1,0 +1,41 @@
+drop database if exists pk_filter_nested_boolean;
+create database pk_filter_nested_boolean;
+use pk_filter_nested_boolean;
+create table v (a varchar(20) primary key);
+insert into v values (''), ('a'), ('b'), ('c'), ('z'), ('zz');
+set @upper = 'z';
+set @equal = 'a';
+set @lower = 'm';
+prepare atomic_first from 'select a from v where a <= ? and (a = ? or a > ?) order by a';
+execute atomic_first using @upper, @equal, @lower;
+➤ a[12,20,0]  𝄀
+a  𝄀
+z
+deallocate prepare atomic_first;
+prepare container_first from 'select a from v where (a = ? or a > ?) and a <= ? order by a';
+execute container_first using @equal, @lower, @upper;
+➤ a[12,20,0]  𝄀
+a  𝄀
+z
+deallocate prepare container_first;
+create table t001 (id int primary key);
+create table t002 (id int primary key);
+create table t003 (id int primary key);
+create table t004 (id int primary key);
+create table t005 (id int primary key);
+set @schema_name = 'pk_filter_nested_boolean';
+set @n1 = 't001';
+set @n2 = 't002';
+set @n3 = 't003';
+set @n4 = 't004';
+set @n5 = 't005';
+prepare nested_or from 'select table_name from information_schema.tables where table_schema = ? and table_name in (?,?,?,?,?) order by table_name';
+execute nested_or using @schema_name, @n1, @n2, @n3, @n4, @n5;
+➤ table_name[12,5000,0]  𝄀
+t001  𝄀
+t002  𝄀
+t003  𝄀
+t004  𝄀
+t005
+deallocate prepare nested_or;
+drop database pk_filter_nested_boolean;

--- a/test/distributed/cases/optimizer/pk_filter_nested_boolean.sql
+++ b/test/distributed/cases/optimizer/pk_filter_nested_boolean.sql
@@ -1,0 +1,39 @@
+-- @suite
+-- @case
+drop database if exists pk_filter_nested_boolean;
+create database pk_filter_nested_boolean;
+use pk_filter_nested_boolean;
+
+create table v (a varchar(20) primary key);
+insert into v values (''), ('a'), ('b'), ('c'), ('z'), ('zz');
+
+set @upper = 'z';
+set @equal = 'a';
+set @lower = 'm';
+
+prepare atomic_first from 'select a from v where a <= ? and (a = ? or a > ?) order by a';
+execute atomic_first using @upper, @equal, @lower;
+deallocate prepare atomic_first;
+
+prepare container_first from 'select a from v where (a = ? or a > ?) and a <= ? order by a';
+execute container_first using @equal, @lower, @upper;
+deallocate prepare container_first;
+
+create table t001 (id int primary key);
+create table t002 (id int primary key);
+create table t003 (id int primary key);
+create table t004 (id int primary key);
+create table t005 (id int primary key);
+
+set @schema_name = 'pk_filter_nested_boolean';
+set @n1 = 't001';
+set @n2 = 't002';
+set @n3 = 't003';
+set @n4 = 't004';
+set @n5 = 't005';
+
+prepare nested_or from 'select table_name from information_schema.tables where table_schema = ? and table_name in (?,?,?,?,?) order by table_name';
+execute nested_or using @schema_name, @n1, @n2, @n3, @n4, @n5;
+deallocate prepare nested_or;
+
+drop database pk_filter_nested_boolean;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27503

## What this PR does / why we need it:

This ports the root fix from #27502 to `main`. `main` contains the composite-PK block-pruning path introduced by #25596, but it does not contain either nested-disjunction guard from the 4.2 fix.

A `BasePKFilter` with `Disjuncts` is a container, not an atomic predicate. Its zero-value `Op` is `function.EQUAL`; allowing it into the atomic merge switch can compare empty bounds and drop an OR branch, producing a false-negative pruning filter.

The change rejects container merges before either AND or OR enters the atomic path. OR then flattens all disjuncts, while AND retains one safe atomic conjunct and leaves full predicate evaluation to the residual filter. The AND fallback now also preserves the selected atomic filter's OID.

Regression coverage adds nested OR and both AND operand orders to the `readutil` unit test, plus the prepared SQL BVT `pk_filter_nested_boolean`. The BVT result was generated against `main`; its three metadata-width entries differ from 4.2 while all SQL values remain identical.

Rebased onto `upstream/main` at `6a8e7ecc530539948663a35a52259224ee1d128a`.

Validation on that base plus this branch:

- `make build`
- `go test ./pkg/vm/engine/readutil -count=1`
- `go test -race ./pkg/vm/engine/readutil -run '^TestConstructBasePKFilterWithOr$' -count=10`
- `go vet ./pkg/vm/engine/readutil`
- `mo-tester` BVT `pk_filter_nested_boolean`: 29/29 statements, 100%