### PR TITLE
[4.2] fix(top): order floating NaNs deterministically

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -21,7 +21,20 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
+// New constructs the generic vector comparator used by equality and identity
+// consumers. SQL ORDER BY operators must use NewOrder.
 func New(typ types.Type, desc, nullsLast bool) Compare {
+	return newCompareFor(typ, desc, nullsLast, false)
+}
+
+// NewOrder constructs a comparator for SQL ORDER BY. Scalar floating-point
+// values use the engine's explicit ordering relation: NaNs are peers and sort
+// last in both directions.
+func NewOrder(typ types.Type, desc, nullsLast bool) Compare {
+	return newCompareFor(typ, desc, nullsLast, true)
+}
+
+func newCompareFor(typ types.Type, desc, nullsLast, sqlOrder bool) Compare {
 	switch typ.Oid {
 	case types.T_bool:
 		if desc {
@@ -74,15 +87,27 @@ func New(typ types.Type, desc, nullsLast bool) Compare {
 		}
 		return newCompare(types.GenericAscCompare[uint64], genericCopy[uint64], nullsLast)
 	case types.T_float32:
-		if desc {
-			return newCompare(types.GenericDescCompare[float32], genericCopy[float32], nullsLast)
+		if !sqlOrder {
+			if desc {
+				return newCompare(types.GenericDescCompare[float32], genericCopy[float32], nullsLast)
+			}
+			return newCompare(types.GenericAscCompare[float32], genericCopy[float32], nullsLast)
 		}
-		return newCompare(types.GenericAscCompare[float32], genericCopy[float32], nullsLast)
+		if desc {
+			return newCompare(types.Float32OrderDescCompare, genericCopy[float32], nullsLast)
+		}
+		return newCompare(types.Float32OrderAscCompare, genericCopy[float32], nullsLast)
 	case types.T_float64:
-		if desc {
-			return newCompare(types.GenericDescCompare[float64], genericCopy[float64], nullsLast)
+		if !sqlOrder {
+			if desc {
+				return newCompare(types.GenericDescCompare[float64], genericCopy[float64], nullsLast)
+			}
+			return newCompare(types.GenericAscCompare[float64], genericCopy[float64], nullsLast)
 		}
-		return newCompare(types.GenericAscCompare[float64], genericCopy[float64], nullsLast)
+		if desc {
+			return newCompare(types.Float64OrderDescCompare, genericCopy[float64], nullsLast)
+		}
+		return newCompare(types.Float64OrderAscCompare, genericCopy[float64], nullsLast)
 	case types.T_date:
 		if desc {
 			return newCompare(types.GenericDescCompare[types.Date], genericCopy[types.Date], nullsLast)

--- a/pkg/compare/float_compare_test.go
+++ b/pkg/compare/float_compare_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+import (
+	"math"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFloatOrderCompareOrdersNaNAndNull(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		typ    types.Type
+		append func(*vector.Vector, *mpool.MPool) error
+	}{
+		{
+			name: "float32",
+			typ:  types.T_float32.ToType(),
+			append: func(vec *vector.Vector, mp *mpool.MPool) error {
+				for _, value := range []float32{1, math.Float32frombits(0x7fc00001), math.Float32frombits(0x7fc00002)} {
+					if err := vector.AppendFixed(vec, value, false, mp); err != nil {
+						return err
+					}
+				}
+				return vector.AppendFixed(vec, float32(0), true, mp)
+			},
+		},
+		{
+			name: "float64",
+			typ:  types.T_float64.ToType(),
+			append: func(vec *vector.Vector, mp *mpool.MPool) error {
+				for _, value := range []float64{1, math.Float64frombits(0x7ff8000000000001), math.Float64frombits(0x7ff8000000000002)} {
+					if err := vector.AppendFixed(vec, value, false, mp); err != nil {
+						return err
+					}
+				}
+				return vector.AppendFixed(vec, float64(0), true, mp)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := mpool.MustNewZero()
+			vec := vector.NewVec(tc.typ)
+			defer vec.Free(mp)
+			require.NoError(t, tc.append(vec, mp))
+
+			for _, desc := range []bool{false, true} {
+				cmp := NewOrder(tc.typ, desc, true)
+				cmp.Set(0, vec)
+				cmp.Set(1, vec)
+				require.Negative(t, cmp.Compare(0, 0, 0, 1))
+				require.Zero(t, cmp.Compare(0, 0, 1, 2))
+				require.Positive(t, cmp.Compare(0, 0, 3, 1))
+			}
+		})
+	}
+}

--- a/pkg/container/types/compare.go
+++ b/pkg/container/types/compare.go
@@ -59,6 +59,77 @@ func GenericAscCompare[T OrderedT](x, y T) int {
 	return 1
 }
 
+// Float32OrderAscCompare implements the SQL ORDER BY relation for FLOAT.
+// Infinities retain their numeric order. Signed zeroes and all NaN payloads
+// are peers, and NaNs sort after every numeric value.
+func Float32OrderAscCompare(x, y float32) int {
+	if x < y {
+		return -1
+	}
+	if x > y {
+		return 1
+	}
+	if x == y || x != x && y != y {
+		return 0
+	}
+	if x != x {
+		return 1
+	}
+	return -1
+}
+
+// Float32OrderDescCompare keeps NaNs last while reversing numeric order.
+func Float32OrderDescCompare(x, y float32) int {
+	if x > y {
+		return -1
+	}
+	if x < y {
+		return 1
+	}
+	if x == y || x != x && y != y {
+		return 0
+	}
+	if x != x {
+		return 1
+	}
+	return -1
+}
+
+// Float64OrderAscCompare is the float64 counterpart of
+// Float32OrderAscCompare.
+func Float64OrderAscCompare(x, y float64) int {
+	if x < y {
+		return -1
+	}
+	if x > y {
+		return 1
+	}
+	if x == y || x != x && y != y {
+		return 0
+	}
+	if x != x {
+		return 1
+	}
+	return -1
+}
+
+// Float64OrderDescCompare keeps NaNs last while reversing numeric order.
+func Float64OrderDescCompare(x, y float64) int {
+	if x > y {
+		return -1
+	}
+	if x < y {
+		return 1
+	}
+	if x == y || x != x && y != y {
+		return 0
+	}
+	if x != x {
+		return 1
+	}
+	return -1
+}
+
 func BoolDescCompare(x, y bool) int {
 	if x == y {
 		return 0

--- a/pkg/container/types/compare_float_test.go
+++ b/pkg/container/types/compare_float_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFloatOrderComparators(t *testing.T) {
+	float32Values := []float32{
+		float32(math.Inf(-1)), -1, math.Float32frombits(0x80000000), 0, 1, float32(math.Inf(1)),
+		math.Float32frombits(0x7fc00001), math.Float32frombits(0x7fc00002),
+	}
+	assertFloat32ComparatorOrder(t, float32Values)
+	require.Zero(t, Float32OrderAscCompare(math.Float32frombits(0x80000000), 0))
+	require.Zero(t, Float32OrderAscCompare(float32Values[6], float32Values[7]))
+	require.Zero(t, Float32OrderDescCompare(float32Values[6], float32Values[7]))
+
+	float64Values := []float64{
+		math.Inf(-1), -1, math.Float64frombits(0x8000000000000000), 0, 1, math.Inf(1),
+		math.Float64frombits(0x7ff8000000000001), math.Float64frombits(0x7ff8000000000002),
+	}
+	assertFloat64ComparatorOrder(t, float64Values)
+	require.Zero(t, Float64OrderAscCompare(math.Float64frombits(0x8000000000000000), 0))
+	require.Zero(t, Float64OrderAscCompare(float64Values[6], float64Values[7]))
+	require.Zero(t, Float64OrderDescCompare(float64Values[6], float64Values[7]))
+}
+
+func assertFloat32ComparatorOrder(t *testing.T, values []float32) {
+	t.Helper()
+	for i, x := range values {
+		for j, y := range values {
+			asc := Float32OrderAscCompare(x, y)
+			desc := Float32OrderDescCompare(x, y)
+			require.Equal(t, -asc, Float32OrderAscCompare(y, x), "asc pair %d,%d", i, j)
+			require.Equal(t, -desc, Float32OrderDescCompare(y, x), "desc pair %d,%d", i, j)
+			if i < j && !(i == 2 && j == 3) && !(i >= 6 && j >= 6) {
+				require.Negative(t, asc, "asc pair %d,%d", i, j)
+				if j >= 6 {
+					require.Negative(t, desc, "NaNs remain last for desc pair %d,%d", i, j)
+				} else {
+					require.Positive(t, desc, "desc pair %d,%d", i, j)
+				}
+			}
+		}
+	}
+	assertComparatorTransitive(t, values, Float32OrderAscCompare)
+	assertComparatorTransitive(t, values, Float32OrderDescCompare)
+}
+
+func assertFloat64ComparatorOrder(t *testing.T, values []float64) {
+	t.Helper()
+	for i, x := range values {
+		for j, y := range values {
+			asc := Float64OrderAscCompare(x, y)
+			desc := Float64OrderDescCompare(x, y)
+			require.Equal(t, -asc, Float64OrderAscCompare(y, x), "asc pair %d,%d", i, j)
+			require.Equal(t, -desc, Float64OrderDescCompare(y, x), "desc pair %d,%d", i, j)
+			if i < j && !(i == 2 && j == 3) && !(i >= 6 && j >= 6) {
+				require.Negative(t, asc, "asc pair %d,%d", i, j)
+				if j >= 6 {
+					require.Negative(t, desc, "NaNs remain last for desc pair %d,%d", i, j)
+				} else {
+					require.Positive(t, desc, "desc pair %d,%d", i, j)
+				}
+			}
+		}
+	}
+	assertComparatorTransitive(t, values, Float64OrderAscCompare)
+	assertComparatorTransitive(t, values, Float64OrderDescCompare)
+}
+
+func assertComparatorTransitive[T any](t *testing.T, values []T, compare func(T, T) int) {
+	t.Helper()
+	for i := range values {
+		for j := range values {
+			for k := range values {
+				if compare(values[i], values[j]) <= 0 && compare(values[j], values[k]) <= 0 {
+					require.LessOrEqual(t, compare(values[i], values[k]), 0, "triple %d,%d,%d", i, j, k)
+				}
+			}
+		}
+	}
+}

--- a/pkg/partition/partition.go
+++ b/pkg/partition/partition.go
@@ -73,6 +73,54 @@ func genericPartition[T types.FixedSizeT](sels []int64, diffs []bool, partitions
 	return partitions
 }
 
+func floatOrderPartition[T types.FixedSizeT](
+	sels []int64,
+	diffs []bool,
+	partitions []int64,
+	vec *vector.Vector,
+	compare func(T, T) int,
+) []int64 {
+	partitions = partitions[:0]
+	if len(sels) == 0 {
+		return partitions
+	}
+	diffs[0] = true
+	diffs = diffs[:len(sels)]
+
+	if !vec.IsConst() {
+		var n bool
+		var v T
+		vs := vector.MustFixedColWithTypeCheck[T](vec)
+		nsp := vec.GetNulls()
+		if nsp.Any() {
+			for i, sel := range sels {
+				w := vs[sel]
+				isNull := nulls.Contains(nsp, uint64(sel))
+				if n != isNull {
+					diffs[i] = true
+				} else if !isNull {
+					diffs[i] = diffs[i] || compare(v, w) != 0
+				}
+				n = isNull
+				v = w
+			}
+		} else {
+			for i, sel := range sels {
+				w := vs[sel]
+				diffs[i] = diffs[i] || compare(v, w) != 0
+				v = w
+			}
+		}
+	}
+
+	for i, j := int64(0), int64(len(diffs)); i < j; i++ {
+		if diffs[i] {
+			partitions = append(partitions, i)
+		}
+	}
+	return partitions
+}
+
 func bytesPartition(sels []int64, diffs []bool, partitions []int64, vec *vector.Vector) []int64 {
 	partitions = partitions[:0]
 	if len(sels) == 0 {
@@ -185,5 +233,19 @@ func Partition(sels []int64, diffs []bool, partitions []int64, vec *vector.Vecto
 		//Hence, we can use bytesPartition here.
 	default:
 		panic(moerr.NewNotSupportedNoCtx(vec.GetType().Oid.String()))
+	}
+}
+
+// PartitionForOrder returns peer-group boundaries for SQL ORDER BY. Generic
+// Partition intentionally retains value-identity semantics for GROUP BY,
+// PARTITION BY, and storage callers; only scalar NaN equality differs here.
+func PartitionForOrder(sels []int64, diffs []bool, partitions []int64, vec *vector.Vector) []int64 {
+	switch vec.GetType().Oid {
+	case types.T_float32:
+		return floatOrderPartition(sels, diffs, partitions, vec, types.Float32OrderAscCompare)
+	case types.T_float64:
+		return floatOrderPartition(sels, diffs, partitions, vec, types.Float64OrderAscCompare)
+	default:
+		return Partition(sels, diffs, partitions, vec)
 	}
 }

--- a/pkg/partition/partition_test.go
+++ b/pkg/partition/partition_test.go
@@ -15,6 +15,7 @@
 package partition
 
 import (
+	"math"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -150,6 +151,24 @@ func TestPartition(t *testing.T) {
 	Partition([]int64{1, 3, 5}, []bool{false, false, false}, partitions, v15)
 	require.Equal(t, []int64{0, 1}, partitions)
 
+}
+
+func TestPartitionForOrderTreatsNaNPayloadsAsPeers(t *testing.T) {
+	mp := mpool.MustNewZero()
+	vec := vector.NewVec(types.T_float64.ToType())
+	defer vec.Free(mp)
+	require.NoError(t, vector.AppendFixedList(vec, []float64{
+		math.Copysign(0, -1), 0,
+		math.Float64frombits(0x7ff8000000000001),
+		math.Float64frombits(0x7ff8000000000002),
+	}, nil, mp))
+	sels := []int64{0, 1, 2, 3}
+
+	identityDiffs := make([]bool, len(sels))
+	require.Equal(t, []int64{0, 2, 3}, Partition(sels, identityDiffs, nil, vec))
+
+	orderDiffs := make([]bool, len(sels))
+	require.Equal(t, []int64{0, 2}, PartitionForOrder(sels, orderDiffs, nil, vec))
 }
 
 // TestPartitionAccumulatesDiffs verifies that successive Partition calls on

--- a/pkg/sort/sort.go
+++ b/pkg/sort/sort.go
@@ -94,6 +94,17 @@ func RowidLess(a, b types.Rowid) bool     { return a.LT(&b) }
 func BlockidLess(a, b types.Blockid) bool { return a.LT(&b) }
 
 func Sort(desc, nullsLast, hasNull bool, os []int64, vec *vector.Vector) {
+	sortByVector(desc, nullsLast, hasNull, os, vec, false)
+}
+
+// SortForSQLOrder sorts selectors with the SQL ORDER BY relation. Keep Sort's
+// legacy floating-point behavior for physical/storage callers whose ordering
+// is part of an existing persisted-data contract.
+func SortForSQLOrder(desc, nullsLast, hasNull bool, os []int64, vec *vector.Vector) {
+	sortByVector(desc, nullsLast, hasNull, os, vec, true)
+}
+
+func sortByVector(desc, nullsLast, hasNull bool, os []int64, vec *vector.Vector, sqlOrder bool) {
 	if hasNull {
 		sz := len(os)
 		if nullsLast { // move null rows to the tail
@@ -202,14 +213,22 @@ func Sort(desc, nullsLast, hasNull bool, os []int64, vec *vector.Vector) {
 		}
 	case types.T_float32:
 		col := vector.MustFixedColNoTypeCheck[float32](vec)
-		if !desc {
+		if sqlOrder && !desc {
+			genericSort(col, os, float32OrderAscLess)
+		} else if sqlOrder {
+			genericSort(col, os, float32OrderDescLess)
+		} else if !desc {
 			genericSort(col, os, genericLess[float32])
 		} else {
 			genericSort(col, os, genericGreater[float32])
 		}
 	case types.T_float64:
 		col := vector.MustFixedColNoTypeCheck[float64](vec)
-		if !desc {
+		if sqlOrder && !desc {
+			genericSort(col, os, float64OrderAscLess)
+		} else if sqlOrder {
+			genericSort(col, os, float64OrderDescLess)
+		} else if !desc {
 			genericSort(col, os, genericLess[float64])
 		} else {
 			genericSort(col, os, genericGreater[float64])
@@ -396,7 +415,7 @@ func SortByVectors(
 	diffs := make([]bool, len(os))
 	previous := vectors[0]
 	for i := 1; i < len(vectors); i++ {
-		partitions = mopartition.Partition(os, diffs, partitions, previous)
+		partitions = mopartition.PartitionForOrder(os, diffs, partitions, previous)
 		vec := vectors[i]
 		if !vec.IsConst() {
 			for j := range partitions {
@@ -418,8 +437,24 @@ func sortSelectorsByVector(os []int64, vec *vector.Vector, desc, nullsLast bool)
 	}
 	nullCount := vec.GetNulls().Count()
 	if nullCount < vec.Length() {
-		Sort(desc, nullsLast, nullCount > 0, os, vec)
+		SortForSQLOrder(desc, nullsLast, nullCount > 0, os, vec)
 	}
+}
+
+func float32OrderAscLess(data []float32, i, j int64) bool {
+	return types.Float32OrderAscCompare(data[i], data[j]) < 0
+}
+
+func float32OrderDescLess(data []float32, i, j int64) bool {
+	return types.Float32OrderDescCompare(data[i], data[j]) < 0
+}
+
+func float64OrderAscLess(data []float64, i, j int64) bool {
+	return types.Float64OrderAscCompare(data[i], data[j]) < 0
+}
+
+func float64OrderDescLess(data []float64, i, j int64) bool {
+	return types.Float64OrderDescCompare(data[i], data[j]) < 0
 }
 
 func boolLess[T bool](data []T, i, j int64) bool {

--- a/pkg/sort/sort_test.go
+++ b/pkg/sort/sort_test.go
@@ -15,6 +15,7 @@
 package sort
 
 import (
+	"math"
 	"slices"
 	"sort"
 	"testing"
@@ -165,6 +166,60 @@ func TestSortByVectors(t *testing.T) {
 		[]bool{true, false},
 	)
 	require.Equal(t, []int64{2, 0, 1, 3, 4, 5}, selectors)
+}
+
+func TestSortByVectorsFloatOrderPeersUseSecondaryKey(t *testing.T) {
+	mp := mpool.MustNewZero()
+	first := vector.NewVec(types.T_float64.ToType())
+	second := vector.NewVec(types.T_int64.ToType())
+	defer first.Free(mp)
+	defer second.Free(mp)
+
+	require.NoError(t, vector.AppendFixedList(first, []float64{
+		math.Float64frombits(0x7ff8000000000002), math.Inf(1), math.Copysign(0, -1), 1,
+		math.Inf(-1), math.Float64frombits(0x7ff8000000000001), 0, -1,
+	}, nil, mp))
+	require.NoError(t, vector.AppendFixedList(second, []int64{2, 30, 20, 40, 50, 1, 10, 60}, nil, mp))
+
+	for _, tc := range []struct {
+		name string
+		desc bool
+		want []int64
+	}{
+		{name: "ascending", want: []int64{4, 7, 6, 2, 3, 1, 5, 0}},
+		{name: "descending", desc: true, want: []int64{1, 3, 6, 2, 7, 4, 5, 0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			selectors := []int64{0, 1, 2, 3, 4, 5, 6, 7}
+			SortByVectors(selectors, []*vector.Vector{first, second}, []bool{tc.desc, false}, []bool{false, false})
+			require.Equal(t, tc.want, selectors)
+		})
+	}
+}
+
+func TestSortForSQLOrderFloat32NaNLast(t *testing.T) {
+	mp := mpool.MustNewZero()
+	vec := vector.NewVec(types.T_float32.ToType())
+	defer vec.Free(mp)
+	require.NoError(t, vector.AppendFixedList(vec, []float32{
+		math.Float32frombits(0x7fc00002), 1, float32(math.Inf(-1)),
+		math.Float32frombits(0x7fc00001), float32(math.Inf(1)), -1,
+	}, nil, mp))
+
+	for _, tc := range []struct {
+		desc bool
+		want []int64
+	}{
+		{want: []int64{2, 5, 1, 4, 0, 3}},
+		{desc: true, want: []int64{4, 1, 5, 2, 0, 3}},
+	} {
+		selectors := []int64{0, 1, 2, 3, 4, 5}
+		SortForSQLOrder(tc.desc, false, false, selectors, vec)
+		require.Equal(t, tc.want[:4], selectors[:4])
+		for _, sel := range selectors[4:] {
+			require.True(t, math.IsNaN(float64(vector.MustFixedColWithTypeCheck[float32](vec)[sel])))
+		}
+	}
 }
 
 func BenchmarkSortInt(b *testing.B) {

--- a/pkg/sql/colexec/mergeorder/order.go
+++ b/pkg/sql/colexec/mergeorder/order.go
@@ -70,7 +70,7 @@ func (ctr *container) generateCompares(fs []*plan.OrderBySpec) {
 
 		exprTyp := fs[i].Expr.Typ
 		typ := types.New(types.T(exprTyp.Id), exprTyp.Width, exprTyp.Scale)
-		ctr.compares[i] = compare.New(typ, desc, nullsLast)
+		ctr.compares[i] = compare.NewOrder(typ, desc, nullsLast)
 	}
 }
 

--- a/pkg/sql/colexec/mergeorder/order_test.go
+++ b/pkg/sql/colexec/mergeorder/order_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"testing"
 
@@ -321,6 +322,49 @@ func TestOrder(t *testing.T) {
 		tc.proc.Free()
 		require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
 	}
+}
+
+func TestMergeOrderFloatNaNLastAndPeerTieBreak(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	arg := &MergeOrder{
+		OrderBySpecs: []*plan.OrderBySpec{
+			{Expr: newExpression(0, types.T_float64)},
+			{Expr: newExpression(1, types.T_int64)},
+		},
+		OperatorBase: vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	makeBatch := func(values []float64, ids []int64) *batch.Batch {
+		bat := batch.NewWithSize(2)
+		bat.Vecs[0] = vector.NewVec(types.T_float64.ToType())
+		bat.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+		require.NoError(t, vector.AppendFixedList(bat.Vecs[0], values, nil, proc.Mp()))
+		require.NoError(t, vector.AppendFixedList(bat.Vecs[1], ids, nil, proc.Mp()))
+		bat.SetRowCount(len(values))
+		return bat
+	}
+	resetChildren(arg, []*batch.Batch{
+		makeBatch([]float64{math.Inf(-1), 1, math.Float64frombits(0x7ff8000000000002)}, []int64{10, 40, 1}),
+		makeBatch([]float64{-1, math.Inf(1), math.Float64frombits(0x7ff8000000000001)}, []int64{20, 60, 2}),
+	})
+	require.NoError(t, arg.Prepare(proc))
+
+	var got []int64
+	for {
+		result, err := vm.Exec(arg, proc)
+		require.NoError(t, err)
+		if result.Batch != nil {
+			got = append(got, vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1])...)
+		}
+		if result.Status == vm.ExecStop {
+			break
+		}
+	}
+	require.Equal(t, []int64{10, 20, 40, 60, 1, 2}, got)
+
+	arg.Children[0].Free(proc, false, nil)
+	arg.Free(proc, false, nil)
+	proc.Free()
+	require.Zero(t, proc.Mp().CurrNB())
 }
 
 func TestOrderSpill(t *testing.T) {

--- a/pkg/sql/colexec/mergetop/top.go
+++ b/pkg/sql/colexec/mergetop/top.go
@@ -180,7 +180,7 @@ func (ctr *container) build(ap *MergeTop, proc *process.Process, analyzer proces
 				}
 				ctr.cmps = append(
 					ctr.cmps,
-					compare.New(*bat.Vecs[i].GetType(), desc, nullsLast),
+					compare.NewOrder(*bat.Vecs[i].GetType(), desc, nullsLast),
 				)
 			}
 

--- a/pkg/sql/colexec/mergetop/top_test.go
+++ b/pkg/sql/colexec/mergetop/top_test.go
@@ -17,6 +17,7 @@ package mergetop
 import (
 	"bytes"
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
@@ -144,6 +146,33 @@ func TestMergeTopMaxUint64LimitReturnsAllRows(t *testing.T) {
 	tc.arg.GetChildren(0).Free(tc.proc, false, nil)
 	tc.proc.Free()
 	require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
+}
+
+func TestMergeTopFloatNaNLastAndPeerTieBreak(t *testing.T) {
+	tc := newTestCase(t, []bool{false, false}, []types.Type{types.T_float64.ToType(), types.T_int64.ToType()}, 5,
+		[]*plan.OrderBySpec{{Expr: newExpression(0)}, {Expr: newExpression(1)}})
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = vector.NewVec(types.T_float64.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixedList(bat.Vecs[0], []float64{
+		math.Float64frombits(0x7ff8000000000001), 1, math.Inf(-1),
+		math.Float64frombits(0x7ff8000000000002), -1, math.Inf(1),
+	}, nil, tc.proc.Mp()))
+	require.NoError(t, vector.AppendFixedList(bat.Vecs[1], []int64{2, 40, 10, 1, 20, 60}, nil, tc.proc.Mp()))
+	bat.SetRowCount(6)
+	resetChildren(tc.arg, []*batch.Batch{bat})
+
+	result, err := vm.Exec(tc.arg, tc.proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	require.Equal(t, []int64{10, 20, 40, 60, 1}, vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1]))
+
+	tc.arg.Free(tc.proc, false, nil)
+	tc.arg.GetChildren(0).Free(tc.proc, false, nil)
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
 }
 
 func BenchmarkTop(b *testing.B) {

--- a/pkg/sql/colexec/top/top.go
+++ b/pkg/sql/colexec/top/top.go
@@ -249,7 +249,7 @@ func (ctr *container) build(ap *Top, bat *batch.Batch, proc *process.Process, an
 				}
 				ctr.cmps = append(
 					ctr.cmps,
-					compare.New(*bat.Vecs[pos].GetType(), desc, nullsLast),
+					compare.NewOrder(*bat.Vecs[pos].GetType(), desc, nullsLast),
 				)
 			}
 		} else {
@@ -267,7 +267,7 @@ func (ctr *container) build(ap *Top, bat *batch.Batch, proc *process.Process, an
 				}
 				ctr.cmps = append(
 					ctr.cmps,
-					compare.New(*bat.Vecs[i].GetType(), desc, nullsLast),
+					compare.NewOrder(*bat.Vecs[i].GetType(), desc, nullsLast),
 				)
 			}
 		}

--- a/pkg/sql/colexec/top/top_test.go
+++ b/pkg/sql/colexec/top/top_test.go
@@ -17,6 +17,7 @@ package top
 import (
 	"bytes"
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -167,6 +168,62 @@ func TestTopCopiesNullVarlenaRow(t *testing.T) {
 	tc.arg.GetChildren(0).Free(tc.proc, false, nil)
 	tc.proc.Free()
 	require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
+}
+
+func TestTopOrdersFloatNaNLastAndUsesSecondaryKey(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		flag plan.OrderBySpec_OrderByFlag
+		want []int64
+	}{
+		{
+			name: "ascending",
+			want: []int64{10, 20, 1},
+		},
+		{
+			name: "descending",
+			flag: plan.OrderBySpec_DESC,
+			want: []int64{20, 10, 1},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testCase := newTestCase(
+				t,
+				mpool.MustNewZero(),
+				[]types.Type{types.T_float64.ToType(), types.T_int64.ToType()},
+				3,
+				[]*plan.OrderBySpec{
+					{Expr: newExpression(0), Flag: tc.flag},
+					{Expr: newExpression(1)},
+				},
+			)
+			require.NoError(t, testCase.arg.Prepare(testCase.proc))
+
+			bat := batch.NewWithSize(2)
+			bat.Vecs[0] = vector.NewVec(types.T_float64.ToType())
+			for _, value := range []float64{
+				math.Float64frombits(0x7ff8000000000002), 1, -1,
+				math.Float64frombits(0x7ff8000000000001),
+			} {
+				require.NoError(t, vector.AppendFixed(bat.Vecs[0], value, false, testCase.proc.Mp()))
+			}
+			bat.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+			require.NoError(t, vector.AppendFixedList(bat.Vecs[1], []int64{2, 20, 10, 1}, nil, testCase.proc.Mp()))
+			bat.SetRowCount(4)
+			resetChildren(testCase.arg, []*batch.Batch{bat, batch.EmptyBatch})
+
+			result, err := vm.Exec(testCase.arg, testCase.proc)
+			require.NoError(t, err)
+			require.NotNil(t, result.Batch)
+			got := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[1])
+			require.Equal(t, tc.want, got)
+
+			testCase.arg.Free(testCase.proc, false, nil)
+			testCase.arg.GetChildren(0).Free(testCase.proc, false, nil)
+			testCase.proc.Free()
+			require.Zero(t, testCase.proc.Mp().CurrNB())
+		})
+	}
 }
 
 func TestTopSpill(t *testing.T) {

--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -1029,7 +1029,7 @@ func (ctr *container) processOrder(idx int, ap *Window, bat *batch.Batch, proc *
 		}
 		nullCnt := ovec.GetNulls().Count()
 		if nullCnt < ovec.Length() {
-			sort.Sort(ctr.desc[0], ctr.nullsLast[0], nullCnt > 0, ctr.sels, ovec)
+			sort.SortForSQLOrder(ctr.desc[0], ctr.nullsLast[0], nullCnt > 0, ctr.sels, ovec)
 		}
 		if err := checkCanceled(proc, 0); err != nil {
 			return false, err
@@ -1040,7 +1040,9 @@ func (ctr *container) processOrder(idx int, ap *Window, bat *batch.Batch, proc *
 	ds := make([]bool, len(ctr.sels))
 
 	w := ap.WinSpecList[idx].Expr.(*plan.Expr_W).W
-	n := len(w.PartitionBy)
+	// In 4.2, PARTITION BY has already split the input and orderVecs contains
+	// only SQL ORDER BY keys. Do not classify an order vector as a partition key.
+	n := 0
 
 	i, j := 1, len(ctr.orderVecs)
 	for ; i < j; i++ {
@@ -1049,21 +1051,22 @@ func (ctr *container) processOrder(idx int, ap *Window, bat *batch.Batch, proc *
 		}
 		desc := ctr.desc[i]
 		nullsLast := ctr.nullsLast[i]
-		ps = partition.Partition(ctr.sels, ds, ps, ovec)
+		ps = partition.PartitionForOrder(ctr.sels, ds, ps, ovec)
 		vec := ctr.orderVecs[i].Vec[0]
 		// skip sort for const vector
 		if !vec.IsConst() {
 			nullCnt := vec.GetNulls().Count()
 			if nullCnt < vec.Length() {
-				for i, j := 0, len(ps); i < j; i++ {
-					if err := checkCanceled(proc, i); err != nil {
+				for group, groupCount := 0, len(ps); group < groupCount; group++ {
+					if err := checkCanceled(proc, group); err != nil {
 						return false, err
 					}
-					if i == j-1 {
-						sort.Sort(desc, nullsLast, nullCnt > 0, ctr.sels[ps[i]:], vec)
-					} else {
-						sort.Sort(desc, nullsLast, nullCnt > 0, ctr.sels[ps[i]:ps[i+1]], vec)
+					start := ps[group]
+					end := int64(len(ctr.sels))
+					if group < groupCount-1 {
+						end = ps[group+1]
 					}
+					sort.SortForSQLOrder(desc, nullsLast, nullCnt > 0, ctr.sels[start:end], vec)
 				}
 			}
 		}
@@ -1085,8 +1088,8 @@ func (ctr *container) processOrder(idx int, ap *Window, bat *batch.Batch, proc *
 		ctr.ps = nil
 	}
 
-	if len(ap.WinSpecList[idx].Expr.(*plan.Expr_W).W.OrderBy) > 0 {
-		ctr.os = partition.Partition(ctr.sels, ds, ps, ovec)
+	if len(w.OrderBy) > 0 {
+		ctr.os = partition.PartitionForOrder(ctr.sels, ds, ps, ovec)
 	} else {
 		ctr.os = nil
 	}
@@ -1114,7 +1117,6 @@ func (ctr *container) processOrder(idx int, ap *Window, bat *batch.Batch, proc *
 	}
 
 	ctr.ps = nil
-
 	return false, nil
 }
 
@@ -1306,34 +1308,34 @@ func searchLeft(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, plu
 		}
 	case types.T_float32:
 		col := vector.MustFixedColNoTypeCheck[float32](vec)
-		cmpl := genericGreater[float32]
+		cmpl := float32OrderAscGreater
 		if desc {
-			cmpl = genericLess[float32]
+			cmpl = float32OrderDescGreater
 		}
 		if expr == nil {
-			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[float32], cmpl)
+			left = genericSearchLeft(start, end-1, col, col[rowIdx], float32OrderEqual, cmpl)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_Fval).Fval
 			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[float32], cmpl)
+				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, float32OrderEqual, cmpl)
 			} else {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[float32], cmpl)
+				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, float32OrderEqual, cmpl)
 			}
 		}
 	case types.T_float64:
 		col := vector.MustFixedColNoTypeCheck[float64](vec)
-		cmpl := genericGreater[float64]
+		cmpl := float64OrderAscGreater
 		if desc {
-			cmpl = genericLess[float64]
+			cmpl = float64OrderDescGreater
 		}
 		if expr == nil {
-			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[float64], cmpl)
+			left = genericSearchLeft(start, end-1, col, col[rowIdx], float64OrderEqual, cmpl)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_Dval).Dval
 			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[float64], cmpl)
+				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, float64OrderEqual, cmpl)
 			} else {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[float64], cmpl)
+				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, float64OrderEqual, cmpl)
 			}
 		}
 	case types.T_decimal64:
@@ -1730,34 +1732,34 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 		}
 	case types.T_float32:
 		col := vector.MustFixedColNoTypeCheck[float32](vec)
-		cmpl := genericGreater[float32]
+		cmpl := float32OrderAscGreater
 		if desc {
-			cmpl = genericLess[float32]
+			cmpl = float32OrderDescGreater
 		}
 		if expr == nil {
-			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[float32])
+			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], float32OrderEqual)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_Fval).Fval
 			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[float32], cmpl)
+				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, float32OrderEqual, cmpl)
 			} else {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[float32], cmpl)
+				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, float32OrderEqual, cmpl)
 			}
 		}
 	case types.T_float64:
 		col := vector.MustFixedColNoTypeCheck[float64](vec)
-		cmpl := genericGreater[float64]
+		cmpl := float64OrderAscGreater
 		if desc {
-			cmpl = genericLess[float64]
+			cmpl = float64OrderDescGreater
 		}
 		if expr == nil {
-			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[float64])
+			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], float64OrderEqual)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_Dval).Dval
 			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[float64], cmpl)
+				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, float64OrderEqual, cmpl)
 			} else {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[float64], cmpl)
+				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, float64OrderEqual, cmpl)
 			}
 		}
 	case types.T_decimal64:
@@ -2025,6 +2027,34 @@ func genericGreater[T types.OrderedT](a, b T) bool {
 
 func genericLess[T types.OrderedT](a, b T) bool {
 	return a < b
+}
+
+// The RANGE binary searches operate on vectors sorted with the SQL ORDER BY
+// relation. Native float comparisons do not provide the peer/equality and
+// boundary behavior required for NaNs, so keep the search predicates aligned
+// with the sort relation for both directions.
+func float32OrderEqual(a, b float32) bool {
+	return types.Float32OrderAscCompare(a, b) == 0
+}
+
+func float32OrderAscGreater(a, b float32) bool {
+	return types.Float32OrderAscCompare(a, b) > 0
+}
+
+func float32OrderDescGreater(a, b float32) bool {
+	return types.Float32OrderDescCompare(a, b) > 0
+}
+
+func float64OrderEqual(a, b float64) bool {
+	return types.Float64OrderAscCompare(a, b) == 0
+}
+
+func float64OrderAscGreater(a, b float64) bool {
+	return types.Float64OrderAscCompare(a, b) > 0
+}
+
+func float64OrderDescGreater(a, b float64) bool {
+	return types.Float64OrderDescCompare(a, b) > 0
 }
 
 func decimal64Equal(a, b types.Decimal64) bool {

--- a/pkg/sql/colexec/window/window_test.go
+++ b/pkg/sql/colexec/window/window_test.go
@@ -929,6 +929,255 @@ func TestWindowOrderResultAcrossChunks(t *testing.T) {
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
+func newOrderWindowAggExpr(t *testing.T, name string) aggexec.AggFuncExecExpression {
+	e, err := function.GetFunctionByName(context.Background(), name, nil)
+	require.NoError(t, err)
+	return aggexec.MakeAggFunctionExpression(e.GetEncodedOverloadID(), false, nil, nil)
+}
+
+// newJsonObjectAggExpr builds a two-argument aggregate expression:
+// json_objectagg(varchar_key, int32_value), using mock batch col 2 (varchar) and col 0 (int32).
+
+func collectFixedWindowColumn[T types.FixedSizeT](
+	t *testing.T,
+	arg *Window,
+	proc *process.Process,
+	column int,
+) []T {
+	t.Helper()
+	var values []T
+	for {
+		result, err := vm.Exec(arg, proc)
+		require.NoError(t, err)
+		if result.Batch == nil {
+			return values
+		}
+		require.LessOrEqual(t, result.Batch.RowCount(), colexec.DefaultBatchSize)
+		values = append(values, vector.MustFixedColWithTypeCheck[T](result.Batch.Vecs[column])...)
+	}
+}
+
+// TestWindowAggResultAcrossChunks verifies that a cumulative aggregate retains
+// its running state across bounded output batches.
+
+func TestWindowRankTreatsFloatNaNsAsLastPeerGroup(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = vector.NewVec(types.T_float64.ToType())
+	require.NoError(t, vector.AppendFixedList(bat.Vecs[0], []float64{
+		math.Float64frombits(0x7ff8000000000002), 1,
+		math.Float64frombits(0x7ff8000000000001), -1,
+	}, nil, proc.Mp()))
+	bat.SetRowCount(4)
+
+	orderExpr := newColExprWithType(0, types.T_float64.ToType())
+	arg := &Window{
+		WinSpecList: []*plan.Expr{{
+			Expr: &plan.Expr_W{W: &plan.WindowSpec{
+				Name:       "rank",
+				WindowFunc: newFunExpr("rank"),
+				OrderBy:    []*plan.OrderBySpec{{Expr: orderExpr}},
+			}},
+		}},
+		Aggs: []aggexec.AggFuncExecExpression{newOrderWindowAggExpr(t, "rank")},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	require.Equal(t, []int64{1, 2, 3, 3}, collectFixedWindowColumn[int64](t, arg, proc, 1))
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestWindowPartitionedRankTreatsFloatNaNsAsPeers(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 1, 1, 1}, nil, proc.Mp())
+	bat.Vecs[1] = vector.NewVec(types.T_float64.ToType())
+	require.NoError(t, vector.AppendFixedList(bat.Vecs[1], []float64{
+		math.Float64frombits(0x7ff8000000000002), 1,
+		math.Float64frombits(0x7ff8000000000001), -1,
+	}, nil, proc.Mp()))
+	bat.SetRowCount(4)
+
+	arg := &Window{
+		WinSpecList: []*plan.Expr{{
+			Expr: &plan.Expr_W{W: &plan.WindowSpec{
+				Name:        "rank",
+				WindowFunc:  newFunExpr("rank"),
+				PartitionBy: []*plan.Expr{newColExprWithType(0, types.T_int32.ToType())},
+				OrderBy: []*plan.OrderBySpec{{
+					Expr: newColExprWithType(1, types.T_float64.ToType()),
+				}},
+			}},
+		}},
+		Aggs: []aggexec.AggFuncExecExpression{newOrderWindowAggExpr(t, "rank")},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	require.Equal(t, []int64{1, 2, 3, 3}, collectFixedWindowColumn[int64](t, arg, proc, 2))
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestWindowPartitionedFloatNaNPeersUseLaterOrderKey(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	bat := batch.NewWithSize(3)
+	bat.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 1, 1}, nil, proc.Mp())
+	bat.Vecs[1] = vector.NewVec(types.T_float64.ToType())
+	require.NoError(t, vector.AppendFixedList(bat.Vecs[1], []float64{
+		math.Float64frombits(0x7ff8000000000001),
+		math.Float64frombits(0x7ff8000000000002),
+		-1,
+	}, nil, proc.Mp()))
+	bat.Vecs[2] = testutil.MakeInt32Vector([]int32{2, 1, 0}, nil, proc.Mp())
+	bat.SetRowCount(3)
+
+	arg := &Window{
+		WinSpecList: []*plan.Expr{{
+			Expr: &plan.Expr_W{W: &plan.WindowSpec{
+				Name:        "row_number",
+				WindowFunc:  newFunExpr("row_number"),
+				PartitionBy: []*plan.Expr{newColExprWithType(0, types.T_int32.ToType())},
+				OrderBy: []*plan.OrderBySpec{
+					{Expr: newColExprWithType(1, types.T_float64.ToType())},
+					{Expr: newColExprWithType(2, types.T_int32.ToType())},
+				},
+			}},
+		}},
+		Aggs: []aggexec.AggFuncExecExpression{newRowNumberAggExpr(t)},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+	}
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.AppendChild(op)
+
+	require.NoError(t, arg.Prepare(proc))
+	result, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	require.Equal(t, []int32{0, 1, 2},
+		vector.MustFixedColWithTypeCheck[int32](result.Batch.Vecs[2]))
+	require.Equal(t, []int64{1, 2, 3},
+		vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[3]))
+
+	arg.Free(proc, false, nil)
+	op.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+func TestBuildRangeIntervalFloatNaNsUseSQLOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		oid        types.T
+		ascValues  []any
+		descValues []any
+		literal    func() *plan.Expr
+	}{
+		{
+			name: "float32",
+			oid:  types.T_float32,
+			ascValues: []any{
+				float32(1), float32(2), math.Float32frombits(0x7fc00001), math.Float32frombits(0x7fc00002),
+			},
+			descValues: []any{
+				float32(2), float32(1), math.Float32frombits(0x7fc00001), math.Float32frombits(0x7fc00002),
+			},
+			literal: f32Lit,
+		},
+		{
+			name: "float64",
+			oid:  types.T_float64,
+			ascValues: []any{
+				float64(1), float64(2), math.Float64frombits(0x7ff8000000000001), math.Float64frombits(0x7ff8000000000002),
+			},
+			descValues: []any{
+				float64(2), float64(1), math.Float64frombits(0x7ff8000000000001), math.Float64frombits(0x7ff8000000000002),
+			},
+			literal: f64Lit,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := mpool.MustNewZero()
+			defer func() { require.Equal(t, int64(0), mp.CurrNB()) }()
+
+			for _, direction := range []struct {
+				name   string
+				values []any
+				desc   bool
+			}{
+				{name: "asc", values: tc.ascValues},
+				{name: "desc", values: tc.descValues, desc: true},
+			} {
+				t.Run(direction.name, func(t *testing.T) {
+					vec := vector.NewVec(tc.oid.ToType())
+					switch tc.oid {
+					case types.T_float32:
+						values := make([]float32, len(direction.values))
+						for i, value := range direction.values {
+							values[i] = value.(float32)
+						}
+						require.NoError(t, vector.AppendFixedList(vec, values, nil, mp))
+					case types.T_float64:
+						values := make([]float64, len(direction.values))
+						for i, value := range direction.values {
+							values[i] = value.(float64)
+						}
+						require.NoError(t, vector.AppendFixedList(vec, values, nil, mp))
+					}
+					defer vec.Free(mp)
+
+					ctr := &container{
+						orderVecs: []colexec.ExprEvalVector{{Vec: []*vector.Vector{vec}}},
+						desc:      []bool{direction.desc},
+					}
+					frame := &plan.FrameClause{
+						Type: plan.FrameClause_RANGE,
+						Start: &plan.FrameBound{
+							Type: plan.FrameBound_PRECEDING,
+							Val:  tc.literal(),
+						},
+						End: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+					}
+
+					// A finite row adjacent to the NaN peer group must still use
+					// the SQL relation for the binary search.
+					start, end, err := ctr.buildRangeInterval(1, 0, 4, frame)
+					require.NoError(t, err)
+					require.Equal(t, 0, start)
+					require.Equal(t, 2, end)
+
+					// All NaN payloads are one peer group, and an offset from a
+					// NaN remains NaN for RANGE boundary purposes.
+					start, end, err = ctr.buildRangeInterval(2, 0, 4, frame)
+					require.NoError(t, err)
+					require.Equal(t, 2, start)
+					require.Equal(t, 4, end)
+				})
+			}
+		})
+	}
+}
+
+// TestSearchLeftRightDecimalTypes covers decimal64/128.
+
 func TestWindowOrdersPartitionedInput(t *testing.T) {
 	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
 	bat := batch.NewWithSize(2)

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -737,6 +737,9 @@ func (builder *QueryBuilder) buildRegularIndexTopSortContext(projNode *plan.Node
 	}
 
 	orderExpr := sortProjectNode.ProjectList[orderByCol.ColPos]
+	if !encodedOrderMatchesSQLOrder(orderExpr) {
+		return nil
+	}
 	orderExprCol := orderExpr.GetCol()
 	if !canUseRegularIndexHiddenSortKey(scanNode, orderExprCol) {
 		return nil
@@ -969,7 +972,7 @@ func (builder *QueryBuilder) applyForceIndexHintToScan(scanNode *plan.Node, requ
 				continue
 			}
 			builder.protectedScans[scanNode.NodeId]++
-			if requirement.scope == forceIndexForOrder {
+			if requirement.scope == forceIndexForOrder && encodedOrderMatchesSQLOrder(requirement.columns...) {
 				idxNode := builder.qry.Nodes[idxNodeID]
 				idxNode.OrderBy = []*plan.OrderBySpec{{
 					Expr: GetColExpr(idxNode.TableDef.Cols[0].Typ, idxNode.BindingTags[0], 0),
@@ -1182,6 +1185,24 @@ func canPushRegularIndexOrderedLimit(scanNode *plan.Node) bool {
 	// Static reader limit is valid only when index scan candidates exactly match the SQL filter.
 	numKeyParts := len(scanNode.IndexScanInfo.Parts) - 1
 	return isRegularIndexFullPrefixEquality(scanNode.FilterList[0], numKeyParts)
+}
+
+// encodedOrderMatchesSQLOrder reports whether encoded regular-index keys and
+// storage metadata are proven to share the logical SQL ordering. Scalar float
+// encoding has an identity order over NaN payloads, while SQL makes all NaNs
+// peers and keeps them last in both directions, so encoded ordering cannot
+// replace the logical sort or drive early truncation.
+func encodedOrderMatchesSQLOrder(orderExprs ...*plan.Expr) bool {
+	for _, expr := range orderExprs {
+		if expr == nil {
+			return false
+		}
+		switch types.T(expr.Typ.Id) {
+		case types.T_float32, types.T_float64:
+			return false
+		}
+	}
+	return len(orderExprs) > 0
 }
 
 func isRegularIndexFullPrefixEquality(expr *plan.Expr, numKeyParts int) bool {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -280,6 +280,22 @@ func TestIndexHintOrderScopeSelectsCoveringIndexWithoutFilter(t *testing.T) {
 	require.NotEqual(t, "idx_a", findFirstIndexScanName(queryPlan))
 }
 
+func TestIndexHintOrderScopeKeepsFloatSortLogical(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	addIndexHintChoiceTableForTest(mock)
+	mock.ctxt.tables["index_hint_t"].Cols[1].Typ = planpb.Type{Id: int32(types.T_float64)}
+
+	queryPlan, err := runOneStmt(mock, t,
+		"select a from index_hint_t force index for order by(idx_a) order by a limit 10")
+	require.NoError(t, err)
+	indexScan := findFirstIndexScanNode(queryPlan)
+	require.NotNil(t, indexScan)
+	require.Equal(t, "idx_a", indexScan.IndexScanInfo.IndexName)
+	require.Empty(t, indexScan.OrderBy)
+	require.Nil(t, indexScan.IndexReaderParam)
+	require.True(t, planHasSort(queryPlan))
+}
+
 func TestIndexHintOrderScopePreservesCoveringIndexFilters(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	addIndexHintChoiceTableForTest(mock)
@@ -1513,6 +1529,18 @@ func planHasIndexJoin(p *Plan) bool {
 	}
 	for _, node := range p.GetQuery().Nodes {
 		if node.NodeType == planpb.Node_JOIN && node.JoinType == planpb.Node_INDEX {
+			return true
+		}
+	}
+	return false
+}
+
+func planHasSort(p *Plan) bool {
+	if p == nil || p.GetQuery() == nil {
+		return false
+	}
+	for _, node := range p.GetQuery().Nodes {
+		if node.NodeType == planpb.Node_SORT {
 			return true
 		}
 	}
@@ -2828,6 +2856,60 @@ func TestApplyIndicesForProjectPushesTopValueThroughRegularIndexPKOrderAsc(t *te
 	assert.Equal(t, catalog.IndexTableIndexColName, scanNode.IndexReaderParam.OrderBy[0].Expr.GetCol().Name)
 }
 
+func TestApplyIndicesForProjectSkipsOrderedLimitForFloatSortKey(t *testing.T) {
+	floatType := planpb.Type{Id: int32(types.T_float64)}
+	builder, rootNodeID := makeTestRegularIndexProjectBuilder(
+		t,
+		2,
+		GetColExpr(floatType, 100, 1),
+		planpb.OrderBySpec_DESC,
+	)
+	scanNode := builder.qry.Nodes[0]
+	sortNode := builder.qry.Nodes[2]
+	scanNode.TableDef.Cols[1].Typ = floatType
+	sortNode.OrderBy[0].Expr.Typ = floatType
+
+	_, err := builder.applyIndicesForProject(rootNodeID, builder.qry.Nodes[rootNodeID], map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+	require.NoError(t, err)
+
+	// The serialized hidden key is not SQL-order-compatible for floats. Keep
+	// the logical float Sort intact and use the index only as an access path.
+	require.Empty(t, scanNode.OrderBy)
+	require.Empty(t, scanNode.RecvMsgList)
+	require.Empty(t, sortNode.SendMsgList)
+	require.Equal(t, int32(types.T_float64), sortNode.OrderBy[0].Expr.Typ.Id)
+	require.Equal(t, int32(0), sortNode.OrderBy[0].Expr.GetCol().ColPos)
+	assert.Nil(t, scanNode.IndexReaderParam)
+}
+
+func TestApplyIndicesForProjectSkipsFloatCursorRangeRewrite(t *testing.T) {
+	floatType := planpb.Type{Id: int32(types.T_float64)}
+	builder, rootNodeID := makeTestRegularIndexProjectBuilder(
+		t,
+		2,
+		GetColExpr(floatType, 100, 1),
+		planpb.OrderBySpec_DESC,
+	)
+	scanNode := builder.qry.Nodes[0]
+	sortNode := builder.qry.Nodes[2]
+	scanNode.TableDef.Cols[1].Typ = floatType
+	sortNode.OrderBy[0].Expr.Typ = floatType
+	floatCursor, err := BindFuncExprImplByPlanExpr(context.Background(), "<", []*planpb.Expr{
+		GetColExpr(floatType, 100, 1),
+		MakePlan2Float64ConstExprWithType(4900),
+	})
+	require.NoError(t, err)
+	scanNode.FilterList = []*planpb.Expr{makeTestRegularIndexPrefixEq(t, 2), floatCursor}
+
+	_, err = builder.applyIndicesForProject(rootNodeID, builder.qry.Nodes[rootNodeID], map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+	require.NoError(t, err)
+
+	assert.Nil(t, scanNode.IndexReaderParam)
+	require.Empty(t, scanNode.OrderBy)
+	require.Empty(t, sortNode.SendMsgList)
+	assert.True(t, isRegularIndexFullPrefixEquality(scanNode.FilterList[0], 2))
+}
+
 func TestApplyIndicesForProjectSkipsOrderedLimitWithAdditionalResidualFilter(t *testing.T) {
 	builder, rootNodeID := makeTestRegularIndexProjectBuilder(
 		t,
@@ -2908,6 +2990,24 @@ func TestHandleMessageFromTopToScanRewritesRegularIndexPKOrderToHiddenKey(t *tes
 	assert.Equal(t, int32(100), indexParamCol.RelPos)
 	assert.Equal(t, int32(0), indexParamCol.ColPos)
 	assert.Equal(t, catalog.IndexTableIndexColName, indexParamCol.Name)
+}
+
+func TestHandleMessageFromTopToScanSkipsOrderedLimitForFloatSortKey(t *testing.T) {
+	builder, rootNodeID := makeTestRegularIndexMessageBuilder(t, 2, 1, planpb.OrderBySpec_DESC)
+	floatType := planpb.Type{Id: int32(types.T_float64)}
+	scanNode := builder.qry.Nodes[0]
+	sortNode := builder.qry.Nodes[1]
+	scanNode.TableDef.Cols[1].Typ = floatType
+	sortNode.OrderBy[0].Expr.Typ = floatType
+
+	builder.handleMessageFromTopToScan(rootNodeID)
+
+	require.Empty(t, scanNode.OrderBy)
+	require.Empty(t, scanNode.RecvMsgList)
+	require.Empty(t, sortNode.SendMsgList)
+	require.Equal(t, int32(types.T_float64), sortNode.OrderBy[0].Expr.Typ.Id)
+	require.Equal(t, int32(1), sortNode.OrderBy[0].Expr.GetCol().ColPos)
+	assert.Nil(t, scanNode.IndexReaderParam)
 }
 
 func TestHandleMessageFromTopToScanThroughDirectProjection(t *testing.T) {

--- a/pkg/sql/plan/message.go
+++ b/pkg/sql/plan/message.go
@@ -86,6 +86,9 @@ func (builder *QueryBuilder) handleMessageFromTopToScan(nodeID int32) {
 	if scanID == -1 || scanOrderExpr == nil {
 		return
 	}
+	if !encodedOrderMatchesSQLOrder(scanOrderExpr) {
+		return
+	}
 	scanOrderByCol := scanOrderExpr.GetCol()
 	if scanOrderByCol == nil {
 		return
@@ -101,7 +104,8 @@ func (builder *QueryBuilder) handleMessageFromTopToScan(nodeID int32) {
 	scanOrderBy.Expr = scanOrderExpr
 	enableOrderedLimit := false
 	if canUseRegularIndexHiddenSortKey(scanNode, scanOrderByCol) {
-		eligibleOrderedLimit := staticLimitSafe && node.Offset == nil && node.RankOption == nil && isPositiveLiteralLimit(node.Limit)
+		eligibleOrderedLimit := staticLimitSafe && node.Offset == nil && node.RankOption == nil &&
+			isPositiveLiteralLimit(node.Limit)
 		if eligibleOrderedLimit {
 			enableOrderedLimit = canPushRegularIndexOrderedLimit(scanNode)
 			if !enableOrderedLimit {

--- a/test/distributed/cases/optimizer/float_nan_order.result
+++ b/test/distributed/cases/optimizer/float_nan_order.result
@@ -1,0 +1,126 @@
+drop database if exists float_nan_order;
+create database float_nan_order;
+use float_nan_order;
+create table t_double_order (
+k double primary key,
+tenant int,
+id int,
+key idx_tenant(tenant)
+);
+insert into t_double_order values
+(bit_cast(unhex('000000000000f87f') as double), 1, 70),
+(bit_cast(unhex('010000000000f87f') as double), 1, 71),
+(cast('Inf' as double), 1, 60),
+(cast('-Inf' as double), 1, 10),
+(-1.0, 1, 20),
+(bit_cast(unhex('0000000000000080') as double), 1, 30),
+(0.0, 1, 31),
+(1.0, 1, 40);
+select id from t_double_order force index(idx_tenant)
+where tenant = 1 order by k asc limit 2;
+➤ id[4,32,0]  𝄀
+10  𝄀
+20
+select id from t_double_order force index(idx_tenant)
+where tenant = 1 order by k desc limit 2;
+➤ id[4,32,0]  𝄀
+60  𝄀
+40
+select id from t_double_order where tenant = 1 order by k asc, id asc;
+➤ id[4,32,0]  𝄀
+10  𝄀
+20  𝄀
+30  𝄀
+31  𝄀
+40  𝄀
+60  𝄀
+70  𝄀
+71
+select id from t_double_order where tenant = 1 order by k desc, id asc;
+➤ id[4,32,0]  𝄀
+60  𝄀
+40  𝄀
+30  𝄀
+31  𝄀
+20  𝄀
+10  𝄀
+70  𝄀
+71
+select id, rank() over (order by k) as r, dense_rank() over (order by k) as dr
+from t_double_order order by id;
+➤ id[4,32,0]  ¦  r[5,64,0]  ¦  dr[5,64,0]  𝄀
+10  ¦  1  ¦  1  𝄀
+20  ¦  2  ¦  2  𝄀
+30  ¦  3  ¦  3  𝄀
+31  ¦  3  ¦  3  𝄀
+40  ¦  5  ¦  4  𝄀
+60  ¦  6  ¦  5  𝄀
+70  ¦  7  ¦  6  𝄀
+71  ¦  7  ¦  6
+select id, rank() over (partition by tenant order by k) as r
+from t_double_order order by id;
+➤ id[4,32,0]  ¦  r[5,64,0]  𝄀
+10  ¦  1  𝄀
+20  ¦  2  𝄀
+30  ¦  3  𝄀
+31  ¦  3  𝄀
+40  ¦  5  𝄀
+60  ¦  6  𝄀
+70  ¦  7  𝄀
+71  ¦  7
+select id, row_number() over (partition by tenant order by k, id) as rn
+from t_double_order order by rn;
+➤ id[4,32,0]  ¦  rn[5,64,0]  𝄀
+10  ¦  1  𝄀
+20  ¦  2  𝄀
+30  ¦  3  𝄀
+31  ¦  4  𝄀
+40  ¦  5  𝄀
+60  ¦  6  𝄀
+70  ¦  7  𝄀
+71  ¦  8
+select id, rn from (
+select id, row_number() over (partition by tenant order by k asc, id asc) as rn
+from t_double_order
+) ranked where rn <= 2 order by rn;
+➤ id[4,32,0]  ¦  rn[5,64,0]  𝄀
+10  ¦  1  𝄀
+20  ¦  2
+select id, rn from (
+select id, row_number() over (partition by tenant order by k desc, id asc) as rn
+from t_double_order
+) ranked where rn <= 2 order by rn;
+➤ id[4,32,0]  ¦  rn[5,64,0]  𝄀
+60  ¦  1  𝄀
+40  ¦  2
+create table t_float_order(id int primary key, k float);
+insert into t_float_order values
+(70, bit_cast(unhex('0000c07f') as float)),
+(71, bit_cast(unhex('0100c07f') as float)),
+(60, cast('Inf' as float)),
+(10, cast('-Inf' as float)),
+(20, -1.0),
+(30, bit_cast(unhex('00000080') as float)),
+(31, 0.0),
+(40, 1.0);
+select id from t_float_order order by k asc, id asc;
+➤ id[4,32,0]  𝄀
+10  𝄀
+20  𝄀
+30  𝄀
+31  𝄀
+40  𝄀
+60  𝄀
+70  𝄀
+71
+select id from t_float_order order by k desc, id asc;
+➤ id[4,32,0]  𝄀
+60  𝄀
+40  𝄀
+30  𝄀
+31  𝄀
+20  𝄀
+10  𝄀
+70  𝄀
+71
+drop database float_nan_order;

--- a/test/distributed/cases/optimizer/float_nan_order.sql
+++ b/test/distributed/cases/optimizer/float_nan_order.sql
@@ -1,0 +1,71 @@
+-- @suite
+
+-- @case
+-- @desc: scalar FLOAT/DOUBLE ORDER BY keeps NaNs last and as peers
+-- @label:bvt
+
+drop database if exists float_nan_order;
+create database float_nan_order;
+use float_nan_order;
+
+-- A secondary index stores the DOUBLE primary key inside its encoded hidden
+-- key. The index remains a valid access path, but that encoding must not
+-- replace the logical float sort or drive an early LIMIT.
+create table t_double_order (
+  k double primary key,
+  tenant int,
+  id int,
+  key idx_tenant(tenant)
+);
+insert into t_double_order values
+  (bit_cast(unhex('000000000000f87f') as double), 1, 70),
+  (bit_cast(unhex('010000000000f87f') as double), 1, 71),
+  (cast('Inf' as double), 1, 60),
+  (cast('-Inf' as double), 1, 10),
+  (-1.0, 1, 20),
+  (bit_cast(unhex('0000000000000080') as double), 1, 30),
+  (0.0, 1, 31),
+  (1.0, 1, 40);
+
+select id from t_double_order force index(idx_tenant)
+where tenant = 1 order by k asc limit 2;
+select id from t_double_order force index(idx_tenant)
+where tenant = 1 order by k desc limit 2;
+
+select id from t_double_order where tenant = 1 order by k asc, id asc;
+select id from t_double_order where tenant = 1 order by k desc, id asc;
+
+select id, rank() over (order by k) as r, dense_rank() over (order by k) as dr
+from t_double_order order by id;
+
+select id, rank() over (partition by tenant order by k) as r
+from t_double_order order by id;
+
+select id, row_number() over (partition by tenant order by k, id) as rn
+from t_double_order order by rn;
+
+-- Exercise the bounded PARTITION child used for ROW_NUMBER() ... rn <= N.
+select id, rn from (
+  select id, row_number() over (partition by tenant order by k asc, id asc) as rn
+  from t_double_order
+) ranked where rn <= 2 order by rn;
+select id, rn from (
+  select id, row_number() over (partition by tenant order by k desc, id asc) as rn
+  from t_double_order
+) ranked where rn <= 2 order by rn;
+
+create table t_float_order(id int primary key, k float);
+insert into t_float_order values
+  (70, bit_cast(unhex('0000c07f') as float)),
+  (71, bit_cast(unhex('0100c07f') as float)),
+  (60, cast('Inf' as float)),
+  (10, cast('-Inf' as float)),
+  (20, -1.0),
+  (30, bit_cast(unhex('00000080') as float)),
+  (31, 0.0),
+  (40, 1.0);
+
+select id from t_float_order order by k asc, id asc;
+select id from t_float_order order by k desc, id asc;
+
+drop database float_nan_order;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #26941

Backport of #26956 to `4.2-dev`.

## What this PR does / why we need it:

Backports the explicit SQL ordering relation for scalar `FLOAT` and `DOUBLE`:

- ASC: `-Infinity < finite values < +Infinity < NaN`
- DESC: `+Infinity > finite values > -Infinity`, with NaN still last
- all NaN payloads are ordering peers, allowing later ORDER BY keys to break ties
- `-0` and `+0` are ordering peers
- NULL placement remains controlled independently by NULLS FIRST/LAST

The 4.2 full-sort, Top, MergeTop, MergeOrder, and window/range paths use this SQL relation. Generic comparison and storage sorting keep their existing contracts. Regular secondary indexes remain access paths for float keys, but cannot replace the logical sort or drive early LIMIT because their encoded NaN ordering is not SQL-equivalent.

Release-branch adaptation:

- `4.2-dev` does not contain main's PartitionTopN reducer/operator contract, so those two source/test files and their PartitionTopN-only window cases are intentionally omitted rather than resurrecting a removed subsystem.
- The 4.2 window operator receives only ORDER BY vectors after partitioning; the backport applies SQL ordering directly to that release-specific shape.
- 4.2 plan types do not carry the newer charset field, so MergeOrder preserves its existing type construction and changes only the comparator entry point.

Validation:

- full tests pass for `pkg/container/types`, `pkg/compare`, `pkg/partition`, `pkg/sort`, `pkg/sql/colexec/order`, `top`, `mergetop`, `mergeorder`, `window`, `aggexec`, and `pkg/sql/plan`
- affected packages pass `go build` and `go vet` against 4.2's locally built CGo/third-party artifacts
- `git diff --check` passes

(cherry picked from commit `99f4da5a092895fad6123a1862cf5e067e89a397`)
