### PR TITLE
fix(compile): normalize remote notify cancellation

### DIFF
--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -2881,10 +2881,12 @@ func TestSendNotifyMessageReportsSenderFactoryError(t *testing.T) {
 func TestSendNotifyMessageNormalizesPipelineCancellationCause(t *testing.T) {
 	duplicateErr := moerr.NewDuplicateEntryNoCtx("1", "primary")
 	tests := []struct {
-		name        string
-		cancelCause error
-		factoryErr  func(context.Context) error
-		wantErr     error
+		name               string
+		cancelCause        error
+		cancelQuery        bool
+		keepPipelineActive bool
+		factoryErr         func(context.Context) error
+		wantErr            error
 	}{
 		{
 			name:        "query interruption recovers substantive cancellation cause",
@@ -2909,7 +2911,22 @@ func TestSendNotifyMessageNormalizesPipelineCancellationCause(t *testing.T) {
 			wantErr: duplicateErr,
 		},
 		{
-			name: "raw cancellation without substantive cause remains visible",
+			name: "raw pipeline cancellation without substantive cause is secondary",
+			factoryErr: func(context.Context) error {
+				return context.Canceled
+			},
+		},
+		{
+			name:        "raw query cancellation remains visible",
+			cancelQuery: true,
+			factoryErr: func(context.Context) error {
+				return context.Canceled
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name:               "raw cancellation while pipeline is active remains visible",
+			keepPipelineActive: true,
 			factoryErr: func(context.Context) error {
 				return context.Canceled
 			},
@@ -2922,7 +2939,13 @@ func TestSendNotifyMessageNormalizesPipelineCancellationCause(t *testing.T) {
 			queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
 			proc.BuildPipelineContext(queryCtx)
 			scopeProc := proc.NewContextChildProc(1)
-			scopeProc.Cancel(tt.cancelCause)
+			if tt.cancelQuery {
+				_, cancelQuery := process.GetQueryCtxFromProc(proc)
+				require.NotNil(t, cancelQuery)
+				cancelQuery()
+			} else if !tt.keepPipelineActive {
+				scopeProc.Cancel(tt.cancelCause)
+			}
 
 			uid, err := uuid.NewV7()
 			require.NoError(t, err)
@@ -3248,7 +3271,8 @@ func TestSendNotifyMessageSuccessfulAttachUsesQueryContext(t *testing.T) {
 
 func TestSendNotifyMessageStopsRetryWhenQueryContextCanceled(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	proc.BuildPipelineContext(context.Background())
+	queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
+	proc.BuildPipelineContext(queryCtx)
 	scopeProc := proc.NewContextChildProc(1)
 
 	uid, err := uuid.NewV7()
@@ -3298,7 +3322,9 @@ func TestSendNotifyMessageStopsRetryWhenQueryContextCanceled(t *testing.T) {
 	resultCh := make(chan notifyMessageResult, 1)
 	s.sendNotifyMessageWithFactoryAndWait(&wg, resultCh, factory, waitRetry)
 	<-retryEntered
-	scopeProc.Cancel(nil)
+	_, cancelQuery := process.GetQueryCtxFromProc(proc)
+	require.NotNil(t, cancelQuery)
+	cancelQuery()
 
 	select {
 	case result := <-resultCh:

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1269,18 +1269,11 @@ func (s *Scope) sendNotifyMessageWithFactoryAndWait(
 ) {
 	// if context has done, it means the user or other part of the pipeline stops this query.
 	closeWithError := func(err error, reg *process.WaitRegister, sender *messageSenderOnClient) {
-		originalErr := err
-		normalizedErr, _ := normalizeScopeRunError(
+		err, _ = normalizeScopeRunError(
 			err,
 			s.Proc.Ctx,
 			scopeRunQueryContext(s.Proc),
 		)
-		// QueryInterrupted is normal pipeline fallout and may be suppressed.
-		// Preserve a raw context cancellation when it has no stronger cause so
-		// registration-retry cancellation retains its historical classification.
-		if normalizedErr != nil || moerr.IsMoErrCode(originalErr, moerr.ErrQueryInterrupted) {
-			err = normalizedErr
-		}
 		s.cancelMergeSiblingsOnError(err)
 		sendRemoteNotifyCleanupTerminal(s.Proc, reg, err)
 		resultChan <- notifyMessageResult{err: err, sender: sender}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27261

## What this PR does / why we need it:

A downstream early stop can cancel a remote-notify pipeline while the query context remains active. The shared cancellation normalizer correctly classifies the resulting raw context.Canceled as secondary pipeline fallout, but the notify path restored that raw error and failed the whole query.

This change makes remote-notify cleanup use the normalized result consistently. Substantive pipeline causes, query-level cancellation, and independent cancellation while the pipeline is active remain visible; only cancellation caused by normal pipeline teardown is suppressed.

It also corrects the retry-cancellation test so it cancels the query context it claims to cover, and adds controls for pipeline cancellation, query cancellation, active-pipeline cancellation, and substantive causes.

Validation:

- focused cancellation regressions, count=100
- focused race tests, count=100 per test
- full pkg/sql/compile unit-test package
- full pkg/sql/compile race suite
- go build and go vet for pkg/sql/compile