### PR TITLE
[4.2] fix(cnservice): bound stale pipeline backend retries

### DIFF
--- a/pkg/cnservice/cnclient/client.go
+++ b/pkg/cnservice/cnclient/client.go
@@ -55,6 +55,19 @@ type pipelineClient struct {
 	client              morpc.RPCClient
 }
 
+func pipelineBackendCreateOptions(cfg *PipelineConfig) []morpc.ClientOption {
+	// A scheduled Pipeline scope is pinned to one remote CN. Bound both global
+	// factory admission and all connect/retry attempts for that fixed address so
+	// a stale cluster-service route fails the statement instead of inheriting a
+	// potentially day-long SQL context. The existing per-connect timeout bounds
+	// each of the two wait phases, so the total wait is finite and at most twice
+	// that value. It is always positive after cfg.fill().
+	return []morpc.ClientOption{
+		morpc.WithClientAutoCreateQueueWaitTimeout(cfg.TimeOutForEachConnect),
+		morpc.WithClientAutoCreateWaitTimeout(cfg.TimeOutForEachConnect),
+	}
+}
+
 func NewPipelineClient(
 	sid string,
 	localServiceAddress string,
@@ -95,11 +108,15 @@ func NewPipelineClient(
 		morpc.WithBackendLogger(logger),
 	)
 
+	clientOptions := []morpc.ClientOption{
+		morpc.WithClientMaxBackendPerHost(cfg.MaxSenderNumber),
+		morpc.WithClientLogger(logger),
+	}
+	clientOptions = append(clientOptions, pipelineBackendCreateOptions(cfg)...)
 	cli, err := morpc.NewClient(
 		"pipeline-client",
 		factory,
-		morpc.WithClientMaxBackendPerHost(cfg.MaxSenderNumber),
-		morpc.WithClientLogger(logger),
+		clientOptions...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/cnservice/cnclient/client_test.go
+++ b/pkg/cnservice/cnclient/client_test.go
@@ -16,10 +16,15 @@ package cnclient
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 type testRPCClient struct {
@@ -52,4 +57,52 @@ func TestPipelineClient_NewStreamAllowsLocalBackend(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "127.0.0.1:1234", rpcClient.backend)
 	require.True(t, rpcClient.lock)
+}
+
+func TestNewPipelineClient(t *testing.T) {
+	sid := t.Name()
+	moruntime.SetupServiceBasedRuntime(sid, moruntime.DefaultRuntime())
+	client, err := NewPipelineClient(sid, "127.0.0.1:6001", &PipelineConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, client.(*pipelineClient).client)
+	require.NoError(t, client.Close())
+}
+
+type retryablePipelineBackendFactory struct {
+	calls atomic.Int32
+}
+
+func (f *retryablePipelineBackendFactory) Create(
+	string,
+	...morpc.BackendOption,
+) (morpc.Backend, error) {
+	f.calls.Add(1)
+	// resetConn reports this after its connect retry window expires. MORPC
+	// deliberately treats it as retryable, so the client-level recovery budget
+	// must terminate the retry loop.
+	return nil, moerr.NewRPCTimeoutNoCtx()
+}
+
+func TestPipelineBackendCreateOptionsBoundRetry(t *testing.T) {
+	cfg := &PipelineConfig{TimeOutForEachConnect: 37 * time.Millisecond}
+	cfg.fill()
+	factory := &retryablePipelineBackendFactory{}
+	options := pipelineBackendCreateOptions(cfg)
+	options = append(options,
+		morpc.WithClientDisableCircuitBreaker(),
+		morpc.WithClientLogger(zap.NewNop()),
+	)
+	client, err := morpc.NewClient(t.Name(), factory, options...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, client.Close()) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	started := time.Now()
+	stream, err := client.NewStream(ctx, "dead-pipeline-endpoint", false)
+	require.Nil(t, stream)
+	require.ErrorIs(t, err, morpc.ErrBackendCreateTimeout)
+	require.Less(t, time.Since(started), 500*time.Millisecond,
+		"pipeline recovery budget must expire before the query context")
+	require.Positive(t, factory.calls.Load())
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Backport of #27528 for `4.2-dev`.

Related issue: #27523.

## What this PR does / why we need it:

- Bounds Pipeline asynchronous backend-creation queue admission by the configured per-connect timeout.
- Bounds the subsequent connect/retry phase by the same timeout, so a stale scheduled CN route cannot inherit a potentially day-long SQL context.
- Keeps the scheduled CN endpoint fixed: recovery establishes that route within budget or fails the statement; it does not silently redirect work to another CN.
- Adds a regression using the retryable RPC-timeout error produced by the backend connect loop.

The backport patch-id is identical to the final two-file diff of #27528.

## Validation

- `GOWORK=off go list -mod=readonly ./pkg/cnservice/cnclient`
- `GOWORK=off go build -mod=readonly ./pkg/cnservice/cnclient`
- `GOWORK=off go vet -mod=readonly ./pkg/cnservice/cnclient`
- focused `TestPipelineBackendCreateOptionsBoundRetry`
- full `./pkg/cnservice/cnclient` tests
- focused race stress: `TestPipelineBackendCreateOptionsBoundRetry`, `-race -count=100`
- full `./pkg/cnservice/cnclient` race test
- full `./pkg/common/morpc` tests
- full `./pkg/sql/compile` tests
- `git diff --check`