### PR TITLE
test: speed up spill and shuffle BVTs without reducing coverage

### DIFF
--- a/test/distributed/cases/join/spill.result
+++ b/test/distributed/cases/join/spill.result
@@ -404,6 +404,9 @@ select sum(b) from t1;
 ➤ sum(b)[-5,64,0]  𝄀
 100000
 update t1 set b = b + 1 where a mod 5 = 0;
+select disable_fault_injection();
+➤ disable_fault_injection()[-7,1,0]  𝄀
+1
 select count(distinct object_name) > @before_object_count as update_created_object,
 sum(rows_cnt) = 120000 as update_rows_flushed
 from metadata_scan('test.t1', 'a') m;
@@ -412,7 +415,4 @@ from metadata_scan('test.t1', 'a') m;
 select sum(b) from t1;
 ➤ sum(b)[-5,64,0]  𝄀
 120000
-select disable_fault_injection();
-➤ disable_fault_injection()[-7,1,0]  𝄀
-1
 drop database if exists test;

--- a/test/distributed/cases/join/spill.result
+++ b/test/distributed/cases/join/spill.result
@@ -5,11 +5,15 @@ drop table if exists t1;
 drop table if exists t2;
 create table t1(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
 create table t2(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
-insert into t1 select *,*,* from generate_series(5000000) g;
-insert into t2 select *,*,* from generate_series(4000000) g;
+insert into t1
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(100000) g;
+insert into t2
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(80000) g;
 set @@join_spill_mem = 1000;
 select mo_ctl('dn', 'flush', 'd1.t1');
-➤ mo_ctl(dn, flush, d1.t1)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t1)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -20,7 +24,7 @@ select mo_ctl('dn', 'flush', 'd1.t1');
 }
 
 select mo_ctl('dn', 'flush', 'd1.t2');
-➤ mo_ctl(dn, flush, d1.t2)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t2)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -33,8 +37,26 @@ select mo_ctl('dn', 'flush', 'd1.t2');
 select Sleep(1);
 ➤ Sleep(1)[-6,8,0]  𝄀
 0
-explain select count(*) from t1,t2 where t1.c1=t2.c1;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+set @spill_t1_stats = '{"table_cnt":5000000,"block_number":640,"accurate_object_number":40,"approx_object_number":40,"ndv_map":{"c1":5000000,"c2":5000000,"c3":5000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":5000000,"c2":5000000,"c3":5000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]}}}';
+set @spill_t2_stats = '{"table_cnt":4000000,"block_number":520,"accurate_object_number":33,"approx_object_number":33,"ndv_map":{"c1":4000000,"c2":4000000,"c3":4000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":4000000,"c2":4000000,"c3":4000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]}}}';
+select table_cnt from table_stats(
+'d1.t1',
+'patch',
+@spill_t1_stats
+) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats(
+'d1.t2',
+'patch',
+@spill_t2_stats
+) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c1=t2.c1;
+-- @regex("(?i)ap query plan on multicn", true)
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -45,9 +67,28 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1,t2 where t1.c1=t2.c1;
 ➤ count(*)[-5,64,0]  𝄀
-4000000
-explain select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+80000
+explain (analyze true, check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c1=t2.c1;
+-- @regex("SpillRows=[1-9][0-9]*", true)
+-- @regex("SpillSize=[1-9][0-9.]* [KMGT]iB", true)
+➤ ap query plan on multicn(16 core)[12,-1,0]  𝄀
+Project  𝄀
+  Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀
+  ->  Aggregate  𝄀
+        Analyze: timeConsumed=13ms group_time=[total=3ms,min=0ms,max=1ms,dop=32] mergegroup_time=[0ms] waitTime=79ms inputRows=80000 outputRows=1 (min=1, max=1) InputSize=0 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=1.75 MiB (min=128.00 KiB, max=128.00 KiB)  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Join  𝄀
+              Analyze: timeConsumed=641ms probe_time=[total=189ms,min=0ms,max=11ms,dop=32] build_time=[total=88ms,min=0ms,max=4ms,dop=32] waitTime=852ms inputRows=180000 outputRows=80000 (min=0, max=3126) InputSize=703.12 KiB OutputSize=0 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=1.07 MiB (min=0 bytes, max=438.50 KiB) SpillRows=161248 SpillSize=802.12 KiB (min=0 bytes, max=15.52 KiB)  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (t1.c1 = t2.c1) shuffle: range(t1.c1)  𝄀
+              ->  Table Scan on d1.t1  𝄀
+                    Analyze: timeConsumed=8ms scan_time=[total=0ms,min=0ms,max=0ms,dop=32] waitTime=29ms inputBlocks=0 inputRows=100000 outputRows=100000 (min=1696, max=8192) InputSize=390.62 KiB OutputSize=390.62 KiB ReadSize=392.66 KiB|0 bytes|0 bytes MemorySize=781.25 KiB (min=13.25 KiB, max=64.00 KiB)  𝄀
+              ->  Table Scan on d1.t2  𝄀
+                    Analyze: timeConsumed=0ms scan_time=[total=0ms,min=0ms,max=0ms,dop=32] waitTime=0ms inputBlocks=0 inputRows=80000 outputRows=80000 (min=6272, max=8192) InputSize=312.50 KiB OutputSize=312.50 KiB ReadSize=314.11 KiB|0 bytes|0 bytes MemorySize=625.00 KiB (min=49.00 KiB, max=64.00 KiB)
+explain (check '["Group Key: t1.c1 shuffle: REUSE", "Join Type: INNER", "shuffle: range"]')
+select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Group Key: t1.c1 shuffle: REUSE  𝄀
@@ -60,8 +101,9 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 ➤ cnt[-5,64,0]
-explain select count(*) from t1,t2 where t1.c2=t2.c2;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c2=t2.c2;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -72,39 +114,28 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1,t2 where t1.c2=t2.c2;
 ➤ count(*)[-5,64,0]  𝄀
-4000000
+80000
 explain select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<500000;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: INNER  𝄀
-              Join Cond: (t1.c2 = t2.c2) shuffle: range(t1.c2)  𝄀
-              ->  Table Scan on d1.t1  𝄀
-              ->  Table Scan on d1.t2  𝄀
-                    Filter Cond: (t2.c3 < 500000)  𝄀
-                    Block Filter Cond: (t2.c3 < 500000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<500000;
 ➤ count(*)[-5,64,0]  𝄀
-499999
+9999
 explain select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: INNER  𝄀
-              Join Cond: (t1.c2 = t2.c2) shuffle: range(t1.c2)  𝄀
-              ->  Table Scan on d1.t1  𝄀
-              ->  Table Scan on d1.t2  𝄀
-                    Filter Cond: (t2.c3 < 1500000)  𝄀
-                    Block Filter Cond: (t2.c3 < 1500000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
 ➤ count(*)[-5,64,0]  𝄀
-1499999
+29999
 explain select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: SEMI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -117,9 +148,18 @@ Project  𝄀
                     Block Filter Cond: (t2.c3 > 100000)
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 ➤ count(*)[-5,64,0]  𝄀
-3900000
+78000
 explain select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -132,9 +172,18 @@ Project  𝄀
                     Block Filter Cond: t2.c3 BETWEEN 100 AND 700000
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 ➤ count(*)[-5,64,0]  𝄀
-4300099
+86001
 explain select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
-➤ AP QUERY PLAN ON ONE CN(32 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
+➤ AP QUERY PLAN ON ONE CN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -149,43 +198,20 @@ Project  𝄀
                     Block Filter Cond: t2.c3 BETWEEN 10000 AND 600000
 select count(*) from t1 where  t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 ➤ count(*)[-5,64,0]  𝄀
-209998
+4198
 explain select count(*) from t1 where t1.c1 <300000 and  t1.c2 in ( select c2 from t2 where t2.c3>100000 );
-➤ AP QUERY PLAN ON ONE CN(32 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: RIGHT SEMI  𝄀
-              Join Cond: (t2.c2 = t1.c2) shuffle: range(t2.c2)  𝄀
-              ->  Table Scan on d1.t2  𝄀
-                    Filter Cond: (t2.c3 > 100000)  𝄀
-                    Block Filter Cond: (t2.c3 > 100000)  𝄀
-              ->  Table Scan on d1.t1  𝄀
-                    Filter Cond: (t1.c1 < 300000)  𝄀
-                    Block Filter Cond: (t1.c1 < 300000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1 where t1.c1 <300000 and  t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 ➤ count(*)[-5,64,0]  𝄀
-199999
+3999
 explain select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
-➤ TP QUERY PLAN[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: RIGHT  𝄀
-              Join Cond: (t2.c1 = t1.c1)  𝄀
-              Runtime Filter Build: #[-1,0]  𝄀
-              ->  Table Scan on d1.t2 [ForceOneCN]  𝄀
-                    Runtime Filter Probe: t2.c1  𝄀
-              ->  Table Scan on d1.t1 [ForceOneCN]  𝄀
-                    Filter Cond: (t1.c3 > 5000000)  𝄀
-                    Block Filter Cond: (t1.c3 > 5000000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
 ➤ count(*)[-5,64,0]  𝄀
 0
-explain select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+explain (check '["Join Type: LEFT", "shuffle: range"]')
+select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -196,15 +222,15 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 ➤ count(*)[-5,64,0]  𝄀
-5000000
+100000
 select count(*) from t2 right join t1 on t1.c1=t2.c1;
 ➤ count(*)[-5,64,0]  𝄀
-5000000
+100000
 select count(*) from t1, t2 where t1.c1=t2.c1 and t1.c2=t2.c2;
 ➤ count(*)[-5,64,0]  𝄀
-4000000
+80000
 set @@max_dop = 1;
-explain (check '["Join Type: MARK", "shuffle"]')
+explain (check '["Join Type: MARK", "shuffle: range"]')
 select sum(case when marker is true then 1 else 0 end) as true_count,
 sum(case when marker is false then 1 else 0 end) as false_count,
 sum(case when marker is null then 1 else 0 end) as null_count
@@ -212,7 +238,7 @@ from (
 select t1.c1 in (select c1 from t2) as marker
 from t1
 ) s;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: sum(CASE WHEN (#[0,0] IS TRUE) THEN 1 ELSE 0 END), sum(CASE WHEN (#[0,0] IS FALSE) THEN 1 ELSE 0 END), sum(CASE WHEN (#[0,0] IS NULL) THEN 1 ELSE 0 END)  𝄀
@@ -229,12 +255,14 @@ select t1.c1 in (select c1 from t2) as marker
 from t1
 ) s;
 ➤ true_count[3,38,0]  ¦  false_count[3,38,0]  ¦  null_count[3,38,0]  𝄀
-4000000  ¦  1000000  ¦  0
+80000  ¦  20000  ¦  0
 set @@max_dop = 0;
 create table t3(c1 int not null, c2 int not null)cluster by c1;
-insert into t3 select *,* from generate_series(1,1000000)g;
+insert into t3
+select result * 5 + result % 5, result * 5 + result % 5
+from generate_series(1,200000)g;
 select mo_ctl('dn', 'flush', 'd1.t3');
-➤ mo_ctl(dn, flush, d1.t3)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t3)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -245,35 +273,27 @@ select mo_ctl('dn', 'flush', 'd1.t3');
 }
 
 explain select count(*) from t3 where t3.c2 in (select c3 from t1 where t1.c2!=20000 and  t1.c2 not in ( select c2 from t2 where t2.c3>150000 ));
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: SEMI  𝄀
-              Join Cond: (t3.c2 = t1.c3)  𝄀
-              Runtime Filter Build: #[-1,0]  𝄀
-              ->  Table Scan on d1.t3  𝄀
-                    Runtime Filter Probe: t3.c2  𝄀
-              ->  Join  𝄀
-                    Join Type: ANTI  𝄀
-                    Join Cond: (t1.c2 = t2.c2) shuffle: range(t1.c2)  𝄀
-                    ->  Table Scan on d1.t1  𝄀
-                          Filter Cond: (t1.c2 <> 20000)  𝄀
-                    ->  Table Scan on d1.t2  𝄀
-                          Filter Cond: (t2.c3 > 150000)  𝄀
-                          Block Filter Cond: (t2.c3 > 150000)
+[unknown result because it is related to issue#19733]
 select count(*) from t3 where t3.c2 in (select c3 from t1 where t1.c2!=20000 and  t1.c2 not in ( select c2 from t2 where t2.c3>150000 ));
 ➤ count(*)[-5,64,0]  𝄀
-149999
+599
 select count(*) from t3 where t3.c1<100000 and t3.c2 not in (select c3 from t1 where t1.c2!=30000 and  t1.c2  in ( select c2 from t2 where t2.c3<850000 ));
 ➤ count(*)[-5,64,0]  𝄀
-1
+19601
 select count(*) from t1,t2,t3 where t1.c1=t2.c1 and t1.c2=t3.c2 and t2.c2<900000 and t3.c1<500000;
 ➤ count(*)[-5,64,0]  𝄀
-499999
+1999
 explain select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
-➤ AP QUERY PLAN ON MULTICN(32 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: INNER", "shuffle: REUSE", "Group Key: t1.c1 shuffle: range"]')
+select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -288,19 +308,23 @@ Project  𝄀
                     Block Filter Cond: (t2.c2 < 1000000)
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 ➤ count(*)[-5,64,0]  𝄀
-999999
+19999
 delete from t1 where c3%5=1;
 insert into t1 values(-1,-2,-3);
 insert into t1 values(10,11,12);
 select count(*) from t1 where c3!=0;
 ➤ count(*)[-5,64,0]  𝄀
-4000002
+80002
 drop table t3;
 create table t4(c1 int not null, c2  int unsigned) cluster by c1;
-insert into t4 select *,* from generate_series(1000000) g;
-insert into t4 select result+10000000,result+10000000 from generate_series(1000000) g;
+insert into t4
+select result * 10 + result % 10, result * 10 + result % 10
+from generate_series(100000) g;
+insert into t4
+select result * 10 + result % 10 + 10000000, result * 10 + result % 10 + 10000000
+from generate_series(100000) g;
 select mo_ctl('dn', 'flush', 'd1.t4');
-➤ mo_ctl(dn, flush, d1.t4)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t4)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -310,8 +334,9 @@ select mo_ctl('dn', 'flush', 'd1.t4');
   ]
 }
 
-explain select count(*) as cnt from t4 group by c1 having cnt>1;
-➤ AP QUERY PLAN ON ONE CN(32 core)[12,0,0]  𝄀
+explain (check '["Group Key: t4.c1 shuffle: range"]')
+select count(*) as cnt from t4 group by c1 having cnt>1;
+➤ AP QUERY PLAN ON ONE CN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Group Key: t4.c1 shuffle: range(t4.c1)  𝄀
@@ -320,8 +345,9 @@ Project  𝄀
         ->  Table Scan on d1.t4
 select count(*) as cnt from t4 group by c1 having cnt>1;
 ➤ cnt[-5,64,0]
-explain select count(*) as cnt from t4 group by c2 having cnt>1;
-➤ AP QUERY PLAN ON ONE CN(32 core)[12,0,0]  𝄀
+explain (check '["Group Key: t4.c2 shuffle: range"]')
+select count(*) as cnt from t4 group by c2 having cnt>1;
+➤ AP QUERY PLAN ON ONE CN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Group Key: t4.c2 shuffle: range(t4.c2)  𝄀
@@ -334,6 +360,20 @@ drop table if exists t_dedup_spill;
 create table t_dedup_spill (id int primary key, val int);
 insert into t_dedup_spill select *,* from generate_series(400000) g;
 set @@join_spill_mem = 1000;
+explain (check '["Join Type: DEDUP", "shuffle: hash"]')
+insert into t_dedup_spill select *, 0 from generate_series(200000, 600000) g
+on duplicate key update val = val + 1;
+➤ AP QUERY PLAN ON ONE CN(16 core)[12,-1,0]  𝄀
+Multi Update  𝄀
+  ->  Filter  𝄀
+        Filter Cond: ((t_dedup_spill.__mo_rowid IS NULL) or (not (t_dedup_spill.val <=> #[0,3])))  𝄀
+        ->  Join  𝄀
+              Join Type: DEDUP (UPDATE)  𝄀
+              Join Cond: (t_dedup_spill.id = #[1,0]) shuffle: hash(t_dedup_spill.id)  𝄀
+              ->  Table Scan on d1.t_dedup_spill  𝄀
+              ->  Lock  𝄀
+                    ->  Project  𝄀
+                          ->  Table Function on generate_series
 insert into t_dedup_spill select *, 0 from generate_series(200000, 600000) g
 on duplicate key update val = val + 1;
 select count(*) from t_dedup_spill;
@@ -351,14 +391,27 @@ select enable_fault_injection();
 select add_fault_point('fj/cn/flush_small_objs',':::','echo',40,'test.t1');
 ➤ add_fault_point(fj/cn/flush_small_objs, :::, echo, 40, test.t1)[-7,1,0]  𝄀
 1
-insert into t1 select *, 1 from generate_series(1, 1000*1000*10)g;
+insert into t1 select *, 1 from generate_series(1, 100*1000)g;
+set @before_object_count = (
+select count(distinct object_name) from metadata_scan('test.t1', 'a') m
+);
+select @before_object_count > 1 as multiple_objects,
+sum(rows_cnt) = 100000 as all_rows_flushed
+from metadata_scan('test.t1', 'a') m;
+➤ multiple_objects[-7,1,0]  ¦  all_rows_flushed[-7,1,0]  𝄀
+1  ¦  1
 select sum(b) from t1;
 ➤ sum(b)[-5,64,0]  𝄀
-10000000
-update t1 set b = b + 1 where a mod 100 = 0;
+100000
+update t1 set b = b + 1 where a mod 5 = 0;
+select count(distinct object_name) > @before_object_count as update_created_object,
+sum(rows_cnt) = 120000 as update_rows_flushed
+from metadata_scan('test.t1', 'a') m;
+➤ update_created_object[-7,1,0]  ¦  update_rows_flushed[-7,1,0]  𝄀
+1  ¦  1
 select sum(b) from t1;
 ➤ sum(b)[-5,64,0]  𝄀
-10100000
+120000
 select disable_fault_injection();
 ➤ disable_fault_injection()[-7,1,0]  𝄀
 1

--- a/test/distributed/cases/join/spill.sql
+++ b/test/distributed/cases/join/spill.sql
@@ -223,9 +223,10 @@ from metadata_scan('test.t1', 'a') m;
 select sum(b) from t1;
 -- Updating 20% keeps the small dataset above the fault-injected S3 threshold.
 update t1 set b = b + 1 where a mod 5 = 0;
+-- The injected update is complete; release global FI state before assertions.
+select disable_fault_injection();
 select count(distinct object_name) > @before_object_count as update_created_object,
        sum(rows_cnt) = 120000 as update_rows_flushed
 from metadata_scan('test.t1', 'a') m;
 select sum(b) from t1;
-select disable_fault_injection();
 drop database if exists test;

--- a/test/distributed/cases/join/spill.sql
+++ b/test/distributed/cases/join/spill.sql
@@ -35,6 +35,7 @@ select table_cnt from table_stats(
 ) g;
 -- @separator:table
 -- @regex("(?i)ap query plan on multicn", true)
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c1=t2.c1;
 select count(*) from t1,t2 where t1.c1=t2.c1;
@@ -47,10 +48,12 @@ select count(*) from t1,t2 where t1.c1=t2.c1;
 explain (analyze true, check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c1=t2.c1;
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t1.c1 shuffle: REUSE", "Join Type: INNER", "shuffle: range"]')
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c2=t2.c2;
 select count(*) from t1,t2 where t1.c2=t2.c2;
@@ -70,6 +73,7 @@ explain select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>1
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: SEMI", "shuffle: range"]')
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
@@ -79,6 +83,7 @@ explain select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: ANTI", "shuffle: range"]')
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
@@ -88,6 +93,7 @@ explain select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: ANTI", "shuffle: range"]')
 select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 select count(*) from t1 where  t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
@@ -102,6 +108,7 @@ explain select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000
 -- @bvt:issue
 select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: LEFT", "shuffle: range"]')
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
@@ -154,6 +161,7 @@ explain select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: REUSE", "Group Key: t1.c1 shuffle: range"]')
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
@@ -172,10 +180,12 @@ from generate_series(100000) g;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t4');
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t4.c1 shuffle: range"]')
 select count(*) as cnt from t4 group by c1 having cnt>1;
 select count(*) as cnt from t4 group by c1 having cnt>1;
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t4.c2 shuffle: range"]')
 select count(*) as cnt from t4 group by c2 having cnt>1;
 select count(*) as cnt from t4 group by c2 having cnt>1;
@@ -184,6 +194,7 @@ drop table if exists t_dedup_spill;
 create table t_dedup_spill (id int primary key, val int);
 insert into t_dedup_spill select *,* from generate_series(400000) g;
 set @@join_spill_mem = 1000;
+-- @ignore:0
 explain (check '["Join Type: DEDUP", "shuffle: hash"]')
 insert into t_dedup_spill select *, 0 from generate_series(200000, 600000) g
 on duplicate key update val = val + 1;

--- a/test/distributed/cases/join/spill.sql
+++ b/test/distributed/cases/join/spill.sql
@@ -5,22 +5,54 @@ drop table if exists t1;
 drop table if exists t2;
 create table t1(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
 create table t2(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
-insert into t1 select *,*,* from generate_series(5000000) g;
-insert into t2 select *,*,* from generate_series(4000000) g;
+-- Sample the original 5M/4M key domains. Patched statistics below preserve
+-- the original planner thresholds while the persisted test data stays small.
+insert into t1
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(100000) g;
+insert into t2
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(80000) g;
 set @@join_spill_mem = 1000;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t1');
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t2');
 select Sleep(1);
+-- Keep the production planner's original 5M/4M estimates. Unlike forcing an
+-- exec type, patched table statistics still exercise shuffle selection.
+set @spill_t1_stats = '{"table_cnt":5000000,"block_number":640,"accurate_object_number":40,"approx_object_number":40,"ndv_map":{"c1":5000000,"c2":5000000,"c3":5000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":5000000,"c2":5000000,"c3":5000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]}}}';
+set @spill_t2_stats = '{"table_cnt":4000000,"block_number":520,"accurate_object_number":33,"approx_object_number":33,"ndv_map":{"c1":4000000,"c2":4000000,"c3":4000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":4000000,"c2":4000000,"c3":4000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]}}}';
+select table_cnt from table_stats(
+    'd1.t1',
+    'patch',
+    @spill_t1_stats
+) g;
+select table_cnt from table_stats(
+    'd1.t2',
+    'patch',
+    @spill_t2_stats
+) g;
 -- @separator:table
-explain select count(*) from t1,t2 where t1.c1=t2.c1;
+-- @regex("(?i)ap query plan on multicn", true)
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c1=t2.c1;
+select count(*) from t1,t2 where t1.c1=t2.c1;
+-- Prove that the forced-spill setting reaches the join spill path, not merely
+-- a shuffle-capable logical plan. The following count remains the independent
+-- semantic oracle.
+-- @ignore:0
+-- @regex("SpillRows=[1-9][0-9]*", true)
+-- @regex("SpillSize=[1-9][0-9.]* [KMGT]iB", true)
+explain (analyze true, check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c1=t2.c1;
 -- @separator:table
-explain select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
+explain (check '["Group Key: t1.c1 shuffle: REUSE", "Join Type: INNER", "shuffle: range"]')
+select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 -- @separator:table
-explain select count(*) from t1,t2 where t1.c2=t2.c2;
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c2=t2.c2;
 select count(*) from t1,t2 where t1.c2=t2.c2;
 -- @bvt:issue#19733
 -- @separator:table
@@ -36,16 +68,28 @@ select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
 -- @separator:table
 explain select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+explain (check '["Join Type: SEMI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 -- @bvt:issue#19733
 -- @separator:table
 explain select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 -- @bvt:issue#19733
 -- @separator:table
 explain select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 select count(*) from t1 where  t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 -- @bvt:issue#19733
 -- @separator:table
@@ -58,7 +102,8 @@ explain select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000
 -- @bvt:issue
 select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
 -- @separator:table
-explain select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
+explain (check '["Join Type: LEFT", "shuffle: range"]')
+select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 -- right outer join (preserves all t1 rows)
 select count(*) from t2 right join t1 on t1.c1=t2.c1;
@@ -71,7 +116,7 @@ set @@max_dop = 1;
 -- Projected IN is planned as MARK. Both keys are NOT NULL, so every exact
 -- match is co-located and bucket-local state is sufficient for FALSE misses.
 -- @ignore:0
-explain (check '["Join Type: MARK", "shuffle"]')
+explain (check '["Join Type: MARK", "shuffle: range"]')
 select sum(case when marker is true then 1 else 0 end) as true_count,
        sum(case when marker is false then 1 else 0 end) as false_count,
        sum(case when marker is null then 1 else 0 end) as null_count
@@ -91,7 +136,9 @@ from (
 set @@max_dop = 0;
 
 create table t3(c1 int not null, c2 int not null)cluster by c1;
-insert into t3 select *,* from generate_series(1,1000000)g;
+insert into t3
+select result * 5 + result % 5, result * 5 + result % 5
+from generate_series(1,200000)g;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t3');
 -- @bvt:issue#19733
@@ -105,6 +152,10 @@ select count(*) from t1,t2,t3 where t1.c1=t2.c1 and t1.c2=t3.c2 and t2.c2<900000
 -- @separator:table
 explain select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @spill_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @spill_t2_stats) g;
+explain (check '["Join Type: INNER", "shuffle: REUSE", "Group Key: t1.c1 shuffle: range"]')
+select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 delete from t1 where c3%5=1;
 insert into t1 values(-1,-2,-3);
@@ -112,21 +163,30 @@ insert into t1 values(10,11,12);
 select count(*) from t1 where c3!=0;
 drop table t3;
 create table t4(c1 int not null, c2  int unsigned) cluster by c1;
-insert into t4 select *,* from generate_series(1000000) g;
-insert into t4 select result+10000000,result+10000000 from generate_series(1000000) g;
+insert into t4
+select result * 10 + result % 10, result * 10 + result % 10
+from generate_series(100000) g;
+insert into t4
+select result * 10 + result % 10 + 10000000, result * 10 + result % 10 + 10000000
+from generate_series(100000) g;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t4');
 -- @separator:table
-explain select count(*) as cnt from t4 group by c1 having cnt>1;
+explain (check '["Group Key: t4.c1 shuffle: range"]')
+select count(*) as cnt from t4 group by c1 having cnt>1;
 select count(*) as cnt from t4 group by c1 having cnt>1;
 -- @separator:table
-explain select count(*) as cnt from t4 group by c2 having cnt>1;
+explain (check '["Group Key: t4.c2 shuffle: range"]')
+select count(*) as cnt from t4 group by c2 having cnt>1;
 select count(*) as cnt from t4 group by c2 having cnt>1;
 -- dedup join spill: large ODKU with low join_spill_mem
 drop table if exists t_dedup_spill;
 create table t_dedup_spill (id int primary key, val int);
 insert into t_dedup_spill select *,* from generate_series(400000) g;
 set @@join_spill_mem = 1000;
+explain (check '["Join Type: DEDUP", "shuffle: hash"]')
+insert into t_dedup_spill select *, 0 from generate_series(200000, 600000) g
+on duplicate key update val = val + 1;
 insert into t_dedup_spill select *, 0 from generate_series(200000, 600000) g
 on duplicate key update val = val + 1;
 select count(*) from t_dedup_spill;
@@ -139,9 +199,22 @@ use test;
 create table t1(a int primary key, b int);
 select enable_fault_injection();
 select add_fault_point('fj/cn/flush_small_objs',':::','echo',40,'test.t1');
-insert into t1 select *, 1 from generate_series(1, 1000*1000*10)g;
+-- One hundred thousand rows still creates multiple fault-forced small objects
+-- and exercises the same update path without making a spill regression own a
+-- 10M-row DML.
+insert into t1 select *, 1 from generate_series(1, 100*1000)g;
+set @before_object_count = (
+    select count(distinct object_name) from metadata_scan('test.t1', 'a') m
+);
+select @before_object_count > 1 as multiple_objects,
+       sum(rows_cnt) = 100000 as all_rows_flushed
+from metadata_scan('test.t1', 'a') m;
 select sum(b) from t1;
-update t1 set b = b + 1 where a mod 100 = 0;
+-- Updating 20% keeps the small dataset above the fault-injected S3 threshold.
+update t1 set b = b + 1 where a mod 5 = 0;
+select count(distinct object_name) > @before_object_count as update_created_object,
+       sum(rows_cnt) = 120000 as update_rows_flushed
+from metadata_scan('test.t1', 'a') m;
 select sum(b) from t1;
 select disable_fault_injection();
 drop database if exists test;

--- a/test/distributed/cases/optimizer/shuffle.result
+++ b/test/distributed/cases/optimizer/shuffle.result
@@ -5,10 +5,14 @@ drop table if exists t1;
 drop table if exists t2;
 create table t1(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
 create table t2(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
-insert into t1 select *,*,* from generate_series(5000000) g;
-insert into t2 select *,*,* from generate_series(4000000) g;
+insert into t1
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(100000) g;
+insert into t2
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(80000) g;
 select mo_ctl('dn', 'flush', 'd1.t1');
-➤ mo_ctl(dn, flush, d1.t1)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t1)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -19,7 +23,7 @@ select mo_ctl('dn', 'flush', 'd1.t1');
 }
 
 select mo_ctl('dn', 'flush', 'd1.t2');
-➤ mo_ctl(dn, flush, d1.t2)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t2)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -32,8 +36,26 @@ select mo_ctl('dn', 'flush', 'd1.t2');
 select Sleep(1);
 ➤ Sleep(1)[-6,8,0]  𝄀
 0
-explain select count(*) from t1,t2 where t1.c1=t2.c1;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+set @shuffle_t1_stats = '{"table_cnt":5000000,"block_number":640,"accurate_object_number":40,"approx_object_number":40,"ndv_map":{"c1":5000000,"c2":5000000,"c3":5000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":5000000,"c2":5000000,"c3":5000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]}}}';
+set @shuffle_t2_stats = '{"table_cnt":4000000,"block_number":520,"accurate_object_number":33,"approx_object_number":33,"ndv_map":{"c1":4000000,"c2":4000000,"c3":4000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":4000000,"c2":4000000,"c3":4000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]}}}';
+select table_cnt from table_stats(
+'d1.t1',
+'patch',
+@shuffle_t1_stats
+) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats(
+'d1.t2',
+'patch',
+@shuffle_t2_stats
+) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c1=t2.c1;
+-- @regex("(?i)ap query plan on multicn", true)
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -44,9 +66,10 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1,t2 where t1.c1=t2.c1;
 ➤ count(*)[-5,64,0]  𝄀
-4000000
-explain select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+80000
+explain (check '["Group Key: t1.c1 shuffle: REUSE", "Join Type: INNER", "shuffle: range"]')
+select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Group Key: t1.c1 shuffle: REUSE  𝄀
@@ -59,8 +82,9 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 ➤ cnt[-5,64,0]
-explain select count(*) from t1,t2 where t1.c1=t2.c2;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c1=t2.c2;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -71,9 +95,10 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1,t2 where t1.c1=t2.c2;
 ➤ count(*)[-5,64,0]  𝄀
-4000000
-explain select count(*) from t1,t2 where t1.c2=t2.c1;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+80000
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c2=t2.c1;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -84,9 +109,10 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1,t2 where t1.c2=t2.c1;
 ➤ count(*)[-5,64,0]  𝄀
-4000000
-explain select count(*) from t1,t2 where t1.c2=t2.c2;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+80000
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c2=t2.c2;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -97,39 +123,20 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1,t2 where t1.c2=t2.c2;
 ➤ count(*)[-5,64,0]  𝄀
-4000000
+80000
 explain select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<500000;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: INNER  𝄀
-              Join Cond: (t1.c2 = t2.c2) shuffle: range(t1.c2)  𝄀
-              ->  Table Scan on d1.t1  𝄀
-              ->  Table Scan on d1.t2  𝄀
-                    Filter Cond: (t2.c3 < 500000)  𝄀
-                    Block Filter Cond: (t2.c3 < 500000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<500000;
 ➤ count(*)[-5,64,0]  𝄀
-499999
+9999
 explain select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: INNER  𝄀
-              Join Cond: (t1.c2 = t2.c2) shuffle: range(t1.c2)  𝄀
-              ->  Table Scan on d1.t1  𝄀
-              ->  Table Scan on d1.t2  𝄀
-                    Filter Cond: (t2.c3 < 1500000)  𝄀
-                    Block Filter Cond: (t2.c3 < 1500000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
 ➤ count(*)[-5,64,0]  𝄀
-1499999
-explain select count(*) from t1 group by c1 limit 5;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+29999
+explain (check '["Group Key: t1.c1 shuffle: range"]')
+select count(*) from t1 group by c1 limit 5;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   Limit: 5  𝄀
   ->  Aggregate  𝄀
@@ -143,8 +150,9 @@ select count(*) from t1 group by c1 limit 5;
 1  𝄀
 1  𝄀
 1
-explain select count(*) from t1 group by c2 limit 5;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+explain (check '["Group Key: t1.c2 shuffle: range"]')
+select count(*) from t1 group by c2 limit 5;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   Limit: 5  𝄀
   ->  Aggregate  𝄀
@@ -159,7 +167,16 @@ select count(*) from t1 group by c2 limit 5;
 1  𝄀
 1
 explain select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: SEMI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -172,9 +189,18 @@ Project  𝄀
                     Block Filter Cond: (t2.c3 > 100000)
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 ➤ count(*)[-5,64,0]  𝄀
-3900000
+78000
 explain select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -187,9 +213,18 @@ Project  𝄀
                     Block Filter Cond: t2.c3 BETWEEN 100 AND 700000
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 ➤ count(*)[-5,64,0]  𝄀
-4300099
+86001
 explain select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
-➤ AP QUERY PLAN ON ONE CN(4 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
+➤ AP QUERY PLAN ON ONE CN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -204,43 +239,20 @@ Project  𝄀
                     Block Filter Cond: t2.c3 BETWEEN 10000 AND 600000
 select count(*) from t1 where  t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 ➤ count(*)[-5,64,0]  𝄀
-209998
+4198
 explain select count(*) from t1 where t1.c1 <300000 and  t1.c2 in ( select c2 from t2 where t2.c3>100000 );
-➤ AP QUERY PLAN ON ONE CN(4 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: RIGHT SEMI  𝄀
-              Join Cond: (t2.c2 = t1.c2) shuffle: range(t2.c2)  𝄀
-              ->  Table Scan on d1.t2  𝄀
-                    Filter Cond: (t2.c3 > 100000)  𝄀
-                    Block Filter Cond: (t2.c3 > 100000)  𝄀
-              ->  Table Scan on d1.t1  𝄀
-                    Filter Cond: (t1.c1 < 300000)  𝄀
-                    Block Filter Cond: (t1.c1 < 300000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1 where t1.c1 <300000 and  t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 ➤ count(*)[-5,64,0]  𝄀
-199999
+3999
 explain select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
-➤ TP QUERY PLAN[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: RIGHT  𝄀
-              Join Cond: (t2.c1 = t1.c1)  𝄀
-              Runtime Filter Build: #[-1,0]  𝄀
-              ->  Table Scan on d1.t2 [ForceOneCN]  𝄀
-                    Runtime Filter Probe: t2.c1  𝄀
-              ->  Table Scan on d1.t1 [ForceOneCN]  𝄀
-                    Filter Cond: (t1.c3 > 5000000)  𝄀
-                    Block Filter Cond: (t1.c3 > 5000000)
+[unknown result because it is related to issue#19733]
 select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
 ➤ count(*)[-5,64,0]  𝄀
 0
-explain select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+explain (check '["Join Type: LEFT", "shuffle: range"]')
+select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -251,9 +263,10 @@ Project  𝄀
               ->  Table Scan on d1.t2
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 ➤ count(*)[-5,64,0]  𝄀
-5000000
-explain select count(*) from t1 full join t2 on t1.c1=t2.c1;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+100000
+explain (check '["Join Type: FULL OUTER", "shuffle: range"]')
+select count(*) from t1 full join t2 on t1.c1=t2.c1;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -264,9 +277,10 @@ Project  𝄀
               ->  Table Scan on d1.t1
 select count(*) from t1 full join t2 on t1.c1=t2.c1;
 ➤ count(*)[-5,64,0]  𝄀
-5000000
-explain select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+100000
+explain (check '["Join Type: FULL OUTER", "shuffle: range"]')
+select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -277,7 +291,8 @@ Project  𝄀
               ->  Table Scan on d1.t1
 select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
 ➤ count(*)[-5,64,0]  𝄀
-5000000
+100000
+explain (check '["Window", "Partition Top N", "Join Type: FULL OUTER", "shuffle: range"]')
 with
 l as (
 select c2 as k from t1 where c2 % 100 = 0
@@ -304,13 +319,63 @@ from ranked
 where rn <= 2
 group by join_side
 order by join_side;
-➤ join_side[12,-1,0]  ¦  cnt[-5,64,0]  𝄀
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: ranked.join_side INTERNAL  𝄀
+        ->  Aggregate  𝄀
+              Group Key: joined.join_side  𝄀
+              Aggregate Functions: starcount(1)  𝄀
+              ->  Window  𝄀
+                    Window Function: row_number(); Partition By: joined.join_side; Order By: joined.k  𝄀
+                    Filter Cond: (row_number() over (partition by joined.join_side order by joined.k range unbounded preceding) <= 2)  𝄀
+                    ->  Partition Top N  𝄀
+                          Partition Key: joined.join_side INTERNAL  𝄀
+                          Sort Key: joined.k INTERNAL  𝄀
+                          Limit: 2  𝄀
+                          ->  Project  𝄀
+                                ->  Join  𝄀
+                                      Join Type: FULL OUTER  𝄀
+                                      Join Cond: (t2.c2 = t1.c2) shuffle: range(t2.c2)  𝄀
+                                      ->  Table Scan on d1.t2  𝄀
+                                            Filter Cond: ((cast(t2.c2 AS BIGINT) % 100) = 0)  𝄀
+                                      ->  Table Scan on d1.t1  𝄀
+                                            Filter Cond: ((cast(t1.c2 AS BIGINT) % 100) = 0)
+with
+l as (
+select c2 as k from t1 where c2 % 100 = 0
+),
+r as (
+select c2 as k from t2 where c2 % 100 = 0
+),
+joined as (
+select case
+when l.k is not null and r.k is not null then 'both'
+when l.k is not null then 'left_only'
+else 'right_only'
+end as join_side,
+coalesce(l.k, r.k) as k
+from l full outer join r on l.k = r.k
+),
+ranked as (
+select join_side,
+row_number() over (partition by join_side order by k) as rn
+from joined
+)
+select join_side, count(*) as cnt
+from ranked
+where rn <= 2
+group by join_side
+order by join_side;
+➤ join_side[12,10,0]  ¦  cnt[-5,64,0]  𝄀
 both  ¦  2  𝄀
 left_only  ¦  2
 create table t3(c1 int not null, c2 int not null)cluster by c1;
-insert into t3 select *,* from generate_series(1,1000000)g;
+insert into t3
+select result * 5 + result % 5, result * 5 + result % 5
+from generate_series(1,200000)g;
 select mo_ctl('dn', 'flush', 'd1.t3');
-➤ mo_ctl(dn, flush, d1.t3)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t3)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -321,35 +386,27 @@ select mo_ctl('dn', 'flush', 'd1.t3');
 }
 
 explain select count(*) from t3 where t3.c2 in (select c3 from t1 where t1.c2!=20000 and  t1.c2 not in ( select c2 from t2 where t2.c3>150000 ));
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
-Project  𝄀
-  ->  Aggregate  𝄀
-        Aggregate Functions: starcount(1)  𝄀
-        ->  Join  𝄀
-              Join Type: SEMI  𝄀
-              Join Cond: (t3.c2 = t1.c3)  𝄀
-              Runtime Filter Build: #[-1,0]  𝄀
-              ->  Table Scan on d1.t3  𝄀
-                    Runtime Filter Probe: t3.c2  𝄀
-              ->  Join  𝄀
-                    Join Type: ANTI  𝄀
-                    Join Cond: (t1.c2 = t2.c2) shuffle: range(t1.c2)  𝄀
-                    ->  Table Scan on d1.t1  𝄀
-                          Filter Cond: (t1.c2 <> 20000)  𝄀
-                    ->  Table Scan on d1.t2  𝄀
-                          Filter Cond: (t2.c3 > 150000)  𝄀
-                          Block Filter Cond: (t2.c3 > 150000)
+[unknown result because it is related to issue#19733]
 select count(*) from t3 where t3.c2 in (select c3 from t1 where t1.c2!=20000 and  t1.c2 not in ( select c2 from t2 where t2.c3>150000 ));
 ➤ count(*)[-5,64,0]  𝄀
-149999
+599
 select count(*) from t3 where t3.c1<100000 and t3.c2 not in (select c3 from t1 where t1.c2!=30000 and  t1.c2  in ( select c2 from t2 where t2.c3<850000 ));
 ➤ count(*)[-5,64,0]  𝄀
-1
+19601
 select count(*) from t1,t2,t3 where t1.c1=t2.c1 and t1.c2=t3.c2 and t2.c2<900000 and t3.c1<500000;
 ➤ count(*)[-5,64,0]  𝄀
-499999
+1999
 explain select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
-➤ AP QUERY PLAN ON MULTICN(4 core)[12,0,0]  𝄀
+[unknown result because it is related to issue#19733]
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+5000000.0
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+➤ table_cnt[8,53,31]  𝄀
+4000000.0
+explain (check '["Join Type: INNER", "shuffle: REUSE", "Group Key: t1.c1 shuffle: range"]')
+select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
+➤ AP QUERY PLAN ON MULTICN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
@@ -364,19 +421,23 @@ Project  𝄀
                     Block Filter Cond: (t2.c2 < 1000000)
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 ➤ count(*)[-5,64,0]  𝄀
-999999
+19999
 delete from t1 where c3%5=1;
 insert into t1 values(-1,-2,-3);
 insert into t1 values(10,11,12);
 select count(*) from t1 where c3!=0;
 ➤ count(*)[-5,64,0]  𝄀
-4000002
+80002
 drop table t3;
 create table t4(c1 int not null, c2  int unsigned) cluster by c1;
-insert into t4 select *,* from generate_series(1000000) g;
-insert into t4 select result+10000000,result+10000000 from generate_series(1000000) g;
+insert into t4
+select result * 10 + result % 10, result * 10 + result % 10
+from generate_series(100000) g;
+insert into t4
+select result * 10 + result % 10 + 10000000, result * 10 + result % 10 + 10000000
+from generate_series(100000) g;
 select mo_ctl('dn', 'flush', 'd1.t4');
-➤ mo_ctl(dn, flush, d1.t4)[12,-1,0]  𝄀
+➤ mo_ctl(dn, flush, d1.t4)[12,65535,0]  𝄀
 {
   "method": "Flush",
   "result": [
@@ -386,8 +447,9 @@ select mo_ctl('dn', 'flush', 'd1.t4');
   ]
 }
 
-explain select count(*) as cnt from t4 group by c1 having cnt>1;
-➤ AP QUERY PLAN ON ONE CN(4 core)[12,0,0]  𝄀
+explain (check '["Group Key: t4.c1 shuffle: range"]')
+select count(*) as cnt from t4 group by c1 having cnt>1;
+➤ AP QUERY PLAN ON ONE CN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Group Key: t4.c1 shuffle: range(t4.c1)  𝄀
@@ -396,8 +458,9 @@ Project  𝄀
         ->  Table Scan on d1.t4
 select count(*) as cnt from t4 group by c1 having cnt>1;
 ➤ cnt[-5,64,0]
-explain select count(*) as cnt from t4 group by c2 having cnt>1;
-➤ AP QUERY PLAN ON ONE CN(4 core)[12,0,0]  𝄀
+explain (check '["Group Key: t4.c2 shuffle: range"]')
+select count(*) as cnt from t4 group by c2 having cnt>1;
+➤ AP QUERY PLAN ON ONE CN(16 core)[12,-1,0]  𝄀
 Project  𝄀
   ->  Aggregate  𝄀
         Group Key: t4.c2 shuffle: range(t4.c2)  𝄀
@@ -407,25 +470,3 @@ Project  𝄀
 select count(*) as cnt from t4 group by c2 having cnt>1;
 ➤ cnt[-5,64,0]
 drop database if exists d1;
-drop database if exists test;
-create database test;
-use test;
-create table t1(a int primary key, b int);
-select enable_fault_injection();
-➤ enable_fault_injection()[-7,1,0]  𝄀
-1
-select add_fault_point('fj/cn/flush_small_objs',':::','echo',40,'test.t1');
-➤ add_fault_point(fj/cn/flush_small_objs, :::, echo, 40, test.t1)[-7,1,0]  𝄀
-1
-insert into t1 select *, 1 from generate_series(1, 1000*1000*10)g;
-select sum(b) from t1;
-➤ sum(b)[-5,64,0]  𝄀
-10000000
-update t1 set b = b + 1 where a mod 100 = 0;
-select sum(b) from t1;
-➤ sum(b)[-5,64,0]  𝄀
-10100000
-select disable_fault_injection();
-➤ disable_fault_injection()[-7,1,0]  𝄀
-1
-drop database if exists test;

--- a/test/distributed/cases/optimizer/shuffle.test
+++ b/test/distributed/cases/optimizer/shuffle.test
@@ -5,27 +5,53 @@ drop table if exists t1;
 drop table if exists t2;
 create table t1(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
 create table t2(c1 int not null, c2 int not null, c3 int not null) cluster by c1;
-insert into t1 select *,*,* from generate_series(5000000) g;
-insert into t2 select *,*,* from generate_series(4000000) g;
+-- Sample the original 5M/4M key domains. Patched statistics below preserve
+-- the original planner thresholds while the persisted test data stays small.
+insert into t1
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(100000) g;
+insert into t2
+select result * 50 + result % 50, result * 50 + result % 50, result * 50 + result % 50
+from generate_series(80000) g;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t1');
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t2');
 select Sleep(1);
+-- Keep the production planner's original 5M/4M estimates. Unlike forcing an
+-- exec type, patched table statistics still exercise shuffle selection.
+set @shuffle_t1_stats = '{"table_cnt":5000000,"block_number":640,"accurate_object_number":40,"approx_object_number":40,"ndv_map":{"c1":5000000,"c2":5000000,"c3":5000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":5000000,"c2":5000000,"c3":5000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1250000,2500000,3750000,5000000]}}}';
+set @shuffle_t2_stats = '{"table_cnt":4000000,"block_number":520,"accurate_object_number":33,"approx_object_number":33,"ndv_map":{"c1":4000000,"c2":4000000,"c3":4000000},"min_val_map":{"c1":1,"c2":1,"c3":1},"max_val_map":{"c1":4000000,"c2":4000000,"c3":4000000},"shuffle_range_map":{"c1":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c2":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]},"c3":{"overlap":0.1,"uniform":1,"result":[1,1000000,2000000,3000000,4000000]}}}';
+select table_cnt from table_stats(
+    'd1.t1',
+    'patch',
+    @shuffle_t1_stats
+) g;
+select table_cnt from table_stats(
+    'd1.t2',
+    'patch',
+    @shuffle_t2_stats
+) g;
 -- @separator:table
-explain select count(*) from t1,t2 where t1.c1=t2.c1;
+-- @regex("(?i)ap query plan on multicn", true)
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c1=t2.c1;
 select count(*) from t1,t2 where t1.c1=t2.c1;
 -- @separator:table
-explain select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
+explain (check '["Group Key: t1.c1 shuffle: REUSE", "Join Type: INNER", "shuffle: range"]')
+select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 -- @separator:table
-explain select count(*) from t1,t2 where t1.c1=t2.c2;
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c1=t2.c2;
 select count(*) from t1,t2 where t1.c1=t2.c2;
 -- @separator:table
-explain select count(*) from t1,t2 where t1.c2=t2.c1;
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c2=t2.c1;
 select count(*) from t1,t2 where t1.c2=t2.c1;
 -- @separator:table
-explain select count(*) from t1,t2 where t1.c2=t2.c2;
+explain (check '["Join Type: INNER", "shuffle: range"]')
+select count(*) from t1,t2 where t1.c2=t2.c2;
 select count(*) from t1,t2 where t1.c2=t2.c2;
 -- @bvt:issue#19733
 -- @separator:table
@@ -38,25 +64,39 @@ explain select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
 -- @bvt:issue
 select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
 -- @separator:table
-explain select count(*) from t1 group by c1 limit 5;
+explain (check '["Group Key: t1.c1 shuffle: range"]')
+select count(*) from t1 group by c1 limit 5;
 select count(*) from t1 group by c1 limit 5;
 -- @separator:table
-explain select count(*) from t1 group by c2 limit 5;
+explain (check '["Group Key: t1.c2 shuffle: range"]')
+select count(*) from t1 group by c2 limit 5;
 select count(*) from t1 group by c2 limit 5;
 -- @bvt:issue#19733
 -- @separator:table
 explain select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+explain (check '["Join Type: SEMI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 -- @bvt:issue#19733
 -- @separator:table
 explain select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 -- @bvt:issue#19733
 -- @separator:table
 explain select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+explain (check '["Join Type: ANTI", "shuffle: range"]')
+select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 select count(*) from t1 where  t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 -- @bvt:issue#19733
 -- @separator:table
@@ -69,20 +109,51 @@ explain select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000
 -- @bvt:issue
 select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
 -- @separator:table
-explain select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
+explain (check '["Join Type: LEFT", "shuffle: range"]')
+select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 -- FULL OUTER JOIN: range shuffle on cluster-by key (c1).
 -- @separator:table
-explain select count(*) from t1 full join t2 on t1.c1=t2.c1;
+explain (check '["Join Type: FULL OUTER", "shuffle: range"]')
 select count(*) from t1 full join t2 on t1.c1=t2.c1;
--- FULL OUTER JOIN synonym + non-cluster key (c2): hash shuffle.
+select count(*) from t1 full join t2 on t1.c1=t2.c1;
+-- FULL OUTER JOIN synonym + non-cluster key (c2): range shuffle inferred from stats.
 -- @separator:table
-explain select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
+explain (check '["Join Type: FULL OUTER", "shuffle: range"]')
+select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
 select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
 -- A global WINDOW must keep each CN's shuffle buckets in one RemoteRun tree.
 -- The modulo filters retain a multi-CN scan and a shuffle build above the
--- right/full-join threshold while bounding the window input to about 50K rows.
+-- right/full-join threshold while bounding the physical window input.
 -- @separator:table
+explain (check '["Window", "Partition Top N", "Join Type: FULL OUTER", "shuffle: range"]')
+with
+l as (
+    select c2 as k from t1 where c2 % 100 = 0
+),
+r as (
+    select c2 as k from t2 where c2 % 100 = 0
+),
+joined as (
+    select case
+             when l.k is not null and r.k is not null then 'both'
+             when l.k is not null then 'left_only'
+             else 'right_only'
+           end as join_side,
+           coalesce(l.k, r.k) as k
+    from l full outer join r on l.k = r.k
+),
+ranked as (
+    select join_side,
+           row_number() over (partition by join_side order by k) as rn
+    from joined
+)
+select join_side, count(*) as cnt
+from ranked
+where rn <= 2
+group by join_side
+order by join_side;
+
 with
 l as (
     select c2 as k from t1 where c2 % 100 = 0
@@ -110,7 +181,9 @@ where rn <= 2
 group by join_side
 order by join_side;
 create table t3(c1 int not null, c2 int not null)cluster by c1;
-insert into t3 select *,* from generate_series(1,1000000)g;
+insert into t3
+select result * 5 + result % 5, result * 5 + result % 5
+from generate_series(1,200000)g;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t3');
 -- @bvt:issue#19733
@@ -124,6 +197,10 @@ select count(*) from t1,t2,t3 where t1.c1=t2.c1 and t1.c2=t3.c2 and t2.c2<900000
 -- @separator:table
 explain select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 -- @bvt:issue
+select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
+select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+explain (check '["Join Type: INNER", "shuffle: REUSE", "Group Key: t1.c1 shuffle: range"]')
+select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 delete from t1 where c3%5=1;
 insert into t1 values(-1,-2,-3);
@@ -131,26 +208,20 @@ insert into t1 values(10,11,12);
 select count(*) from t1 where c3!=0;
 drop table t3;
 create table t4(c1 int not null, c2  int unsigned) cluster by c1;
-insert into t4 select *,* from generate_series(1000000) g;
-insert into t4 select result+10000000,result+10000000 from generate_series(1000000) g;
+insert into t4
+select result * 10 + result % 10, result * 10 + result % 10
+from generate_series(100000) g;
+insert into t4
+select result * 10 + result % 10 + 10000000, result * 10 + result % 10 + 10000000
+from generate_series(100000) g;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t4');
 -- @separator:table
-explain select count(*) as cnt from t4 group by c1 having cnt>1;
+explain (check '["Group Key: t4.c1 shuffle: range"]')
+select count(*) as cnt from t4 group by c1 having cnt>1;
 select count(*) as cnt from t4 group by c1 having cnt>1;
 -- @separator:table
-explain select count(*) as cnt from t4 group by c2 having cnt>1;
+explain (check '["Group Key: t4.c2 shuffle: range"]')
+select count(*) as cnt from t4 group by c2 having cnt>1;
 select count(*) as cnt from t4 group by c2 having cnt>1;
 drop database if exists d1;
-drop database if exists test;
-create database test;
-use test;
-create table t1(a int primary key, b int);
-select enable_fault_injection();
-select add_fault_point('fj/cn/flush_small_objs',':::','echo',40,'test.t1');
-insert into t1 select *, 1 from generate_series(1, 1000*1000*10)g;
-select sum(b) from t1;
-update t1 set b = b + 1 where a mod 100 = 0;
-select sum(b) from t1;
-select disable_fault_injection();
-drop database if exists test;

--- a/test/distributed/cases/optimizer/shuffle.test
+++ b/test/distributed/cases/optimizer/shuffle.test
@@ -34,22 +34,27 @@ select table_cnt from table_stats(
 ) g;
 -- @separator:table
 -- @regex("(?i)ap query plan on multicn", true)
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c1=t2.c1;
 select count(*) from t1,t2 where t1.c1=t2.c1;
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t1.c1 shuffle: REUSE", "Join Type: INNER", "shuffle: range"]')
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 select count(*) as cnt from t1,t2 where t1.c1=t2.c1 group by t1.c1 having cnt>1;
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c1=t2.c2;
 select count(*) from t1,t2 where t1.c1=t2.c2;
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c2=t2.c1;
 select count(*) from t1,t2 where t1.c2=t2.c1;
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: range"]')
 select count(*) from t1,t2 where t1.c2=t2.c2;
 select count(*) from t1,t2 where t1.c2=t2.c2;
@@ -64,10 +69,12 @@ explain select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
 -- @bvt:issue
 select count(*) from t1,t2 where t1.c2=t2.c2 and t2.c3<1500000;
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t1.c1 shuffle: range"]')
 select count(*) from t1 group by c1 limit 5;
 select count(*) from t1 group by c1 limit 5;
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t1.c2 shuffle: range"]')
 select count(*) from t1 group by c2 limit 5;
 select count(*) from t1 group by c2 limit 5;
@@ -77,6 +84,7 @@ explain select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>1
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: SEMI", "shuffle: range"]')
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
 select count(*) from t1 where t1.c2 in ( select c2 from t2 where t2.c3>100000 );
@@ -86,6 +94,7 @@ explain select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: ANTI", "shuffle: range"]')
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
 select count(*) from t1 where t1.c2 not in ( select c3 from t2 where t2.c3 between 100 and 700000 );
@@ -95,6 +104,7 @@ explain select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: ANTI", "shuffle: range"]')
 select count(*) from t1 where t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
 select count(*) from t1 where  t1.c3<800000 and t1.c2 not in ( select c3 from t2 where t2.c3 between 10000 and 600000 );
@@ -109,16 +119,19 @@ explain select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000
 -- @bvt:issue
 select count(*) from t1 left join t2 on t1.c1=t2.c1 where t1.c3 >5000000;
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: LEFT", "shuffle: range"]')
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 select count(*) from t1 left join t2 on t1.c1=t2.c1 and t1.c3 >t2.c3;
 -- FULL OUTER JOIN: range shuffle on cluster-by key (c1).
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: FULL OUTER", "shuffle: range"]')
 select count(*) from t1 full join t2 on t1.c1=t2.c1;
 select count(*) from t1 full join t2 on t1.c1=t2.c1;
 -- FULL OUTER JOIN synonym + non-cluster key (c2): range shuffle inferred from stats.
 -- @separator:table
+-- @ignore:0
 explain (check '["Join Type: FULL OUTER", "shuffle: range"]')
 select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
 select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
@@ -126,6 +139,7 @@ select count(*) from t1 full outer join t2 on t1.c2=t2.c2;
 -- The modulo filters retain a multi-CN scan and a shuffle build above the
 -- right/full-join threshold while bounding the physical window input.
 -- @separator:table
+-- @ignore:0
 explain (check '["Window", "Partition Top N", "Join Type: FULL OUTER", "shuffle: range"]')
 with
 l as (
@@ -199,6 +213,7 @@ explain select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=
 -- @bvt:issue
 select table_cnt from table_stats('d1.t1', 'patch', @shuffle_t1_stats) g;
 select table_cnt from table_stats('d1.t2', 'patch', @shuffle_t2_stats) g;
+-- @ignore:0
 explain (check '["Join Type: INNER", "shuffle: REUSE", "Group Key: t1.c1 shuffle: range"]')
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
 select count(*) from (select c1 from t1 group by c1) s1, t2 where s1.c1=t2.c1 and t2.c2<1000000;
@@ -217,10 +232,12 @@ from generate_series(100000) g;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t4');
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t4.c1 shuffle: range"]')
 select count(*) as cnt from t4 group by c1 having cnt>1;
 select count(*) as cnt from t4 group by c1 having cnt>1;
 -- @separator:table
+-- @ignore:0
 explain (check '["Group Key: t4.c2 shuffle: range"]')
 select count(*) as cnt from t4 group by c2 having cnt>1;
 select count(*) as cnt from t4 group by c2 having cnt>1;


### PR DESCRIPTION
## Summary

- reduce persisted spill/shuffle BVT data while sampling the original key domains
- patch the original planner statistics so MULTICN and shuffle thresholds remain covered
- add deterministic plan checks and runtime assertions for non-zero join spill
- prove fault-injected insert and update paths create persisted objects
- remove the duplicated 10M-row fault-injection workload from shuffle.test

## Validation

Validated against main commit 6dccc954a1 on a real two-CN deployment.

- spill.sql: 104 total, 95 success, 9 ignored, 0 failed, 0 abnormal; 16s versus 62.069s baseline
- shuffle.test: 87 total, 78 success, 9 ignored, 0 failed, 0 abnormal; 11.431s versus 45.912s baseline
- combined case time: 27.431s versus 107.981s baseline, a 74.6% reduction
- runtime join analyzer: SpillRows=161248, SpillSize=802.12 KiB
- physical plan: MULTICN dispatch shuffle with cross-CN receivers on both CNs
- repeated strict runs passed with report-level FAILED=0 and ABNORMAL=0 checks
- git diff --check passed