### PR TITLE
ci: allow superseded runs to cancel reusable BVT jobs

### DIFF
--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -94,14 +94,16 @@ jobs:
 
   # The BVT consumers wait for the shared build but must still run when it
   # fails for infrastructure reasons (artifact-service outage, timeout,
-  # runner eviction): always() + explicit gates instead of a plain hard
+  # runner eviction): !cancelled() + explicit gates instead of a plain hard
   # dependency, with an empty build_artifact steering the consumers onto
-  # their own from-source path. A genuine compile failure therefore costs
-  # two duplicate failures instead of silently skipping both BVT suites.
+  # their own from-source path. Unlike always(), !cancelled() also lets a newer
+  # run cancel these reusable BVT jobs instead of waiting behind stale work. A
+  # genuine compile failure therefore costs two duplicate failures instead of
+  # silently skipping both BVT suites.
   matrixone-compose-ci:
     name: Matrixone Compose CI
     needs: [check-pr-valid, bvt-group-plan, matrixone-shared-build]
-    if: ${{ always() && needs.check-pr-valid.outputs.pr_valid == 'true' && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
+    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/e2e-compose-parallel.yaml@main
     with:
       bvt_group: ${{ needs.bvt-group-plan.outputs.compose_group }}
@@ -112,7 +114,7 @@ jobs:
   matrixone-standalone-ci:
     name: Matrixone Standlone CI
     needs: [check-pr-valid, bvt-group-plan, matrixone-shared-build]
-    if: ${{ always() && needs.check-pr-valid.outputs.pr_valid == 'true' && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
+    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/e2e-standalone-parallel.yaml@main
     with:
       bvt_group: ${{ needs.bvt-group-plan.outputs.launch_group }}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27563

## What this PR does / why we need it:

A superseding PR run could remain `pending` behind stale reusable multi-CN BVT jobs. The caller jobs used job-level `always()`; GitHub re-evaluates job conditions during cancellation, and `always()` stays true, so those jobs survived `cancel-in-progress: true`.

Replace `always()` with the cancellation-aware `!cancelled()` guard on both Compose and Standalone BVT callers.

This preserves the intended fallback matrix:

| State | Result |
| --- | --- |
| Shared build succeeds | BVTs consume the shared artifact |
| Shared build fails | BVTs run their from-source fallback |
| Shared build is cancelled | BVT callers do not start |
| Workflow is superseded/cancelled | Running reusable BVT callers can terminate, releasing the concurrency group |

Observed failure evidence:

- blocked latest run: https://github.com/matrixorigin/matrixone/actions/runs/32801498500
- stale run whose UT/SCA cancelled while two reusable BVT jobs kept running: https://github.com/matrixorigin/matrixone/actions/runs/32799626682

GitHub documents `!cancelled()` as the recommended alternative when work should survive dependency failure but not workflow cancellation:
https://docs.github.com/en/actions/how-tos/troubleshoot-workflows#canceling-workflows

Validation:

- `git diff --check`
- YAML parse
- static assertions: exactly two shared-build BVT guards use `!cancelled()`, and none use `always()`
- full cancellation/failure truth-table review for both callers

Local `actionlint` installation was attempted twice; GitHub release asset downloads failed with TLS timeout before the binary was available.
