### PR TITLE
fix(window): handle uint64 range bounds

### DIFF
--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -1648,14 +1648,11 @@ func searchLeft(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, plu
 			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[uint64], cmpl)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_U64Val).U64Val
-			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[uint64], cmpl)
-			} else {
-				if col[rowIdx] <= c {
-					return start, nil
-				}
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[uint64], cmpl)
+			bound, aboveDomain, ok := uint64RangeBound(col[rowIdx], c, !plus)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			left = genericSearchLeft(start, end-1, col, bound, genericEqual[uint64], cmpl)
 		}
 	case types.T_int8:
 		col := vector.MustFixedColNoTypeCheck[int8](vec)
@@ -1788,14 +1785,11 @@ func searchLeft(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, plu
 			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[uint64], cmpl)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_U64Val).U64Val
-			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[uint64], cmpl)
-			} else {
-				if col[rowIdx] <= c {
-					return start, nil
-				}
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[uint64], cmpl)
+			bound, aboveDomain, ok := uint64RangeBound(col[rowIdx], c, !plus)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			left = genericSearchLeft(start, end-1, col, bound, genericEqual[uint64], cmpl)
 		}
 	case types.T_float32:
 		col := vector.MustFixedColNoTypeCheck[float32](vec)
@@ -2072,14 +2066,11 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[uint64])
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_U64Val).U64Val
-			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[uint64], cmpl)
-			} else {
-				if col[rowIdx] <= c {
-					return start, nil
-				}
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[uint64], cmpl)
+			bound, aboveDomain, ok := uint64RangeBound(col[rowIdx], c, sub)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			right = genericSearchRight(start, end-1, col, bound, genericEqual[uint64], cmpl)
 		}
 	case types.T_int8:
 		col := vector.MustFixedColNoTypeCheck[int8](vec)
@@ -2212,14 +2203,11 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[uint64])
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_U64Val).U64Val
-			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[uint64], cmpl)
-			} else {
-				if col[rowIdx] <= c {
-					return start, nil
-				}
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[uint64], cmpl)
+			bound, aboveDomain, ok := uint64RangeBound(col[rowIdx], c, sub)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			right = genericSearchRight(start, end-1, col, bound, genericEqual[uint64], cmpl)
 		}
 	case types.T_float32:
 		col := vector.MustFixedColNoTypeCheck[float32](vec)
@@ -2416,6 +2404,31 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 	// genericSearchRight returns high in [start-1, end-1]. When all values > target,
 	// high = start-1, so right+1 = start (correct exclusive upper bound).
 	return right + 1, nil
+}
+
+// uint64RangeBound computes a finite RANGE search key without allowing
+// unsigned arithmetic to wrap into the opposite end of the type domain.
+// aboveDomain distinguishes addition overflow from subtraction underflow.
+func uint64RangeBound(value, offset uint64, subtract bool) (bound uint64, aboveDomain bool, ok bool) {
+	if subtract {
+		if value < offset {
+			return 0, false, false
+		}
+		return value - offset, false, true
+	}
+	if value > math.MaxUint64-offset {
+		return 0, true, false
+	}
+	return value + offset, false, true
+}
+
+// outOfDomainRangeBoundary maps a conceptual search key outside uint64 to its
+// insertion boundary in the current SQL sort direction.
+func outOfDomainRangeBoundary(start, end int, aboveDomain, desc bool) int {
+	if aboveDomain != desc {
+		return end
+	}
+	return start
 }
 
 func doDateAdd(start types.Date, diff int64, unit int64) (types.Date, error) {

--- a/pkg/sql/colexec/window/window_test.go
+++ b/pkg/sql/colexec/window/window_test.go
@@ -2704,6 +2704,123 @@ func TestSearchLeftRightAllUintTypes(t *testing.T) {
 	})
 }
 
+func uint64RangeOffset(value uint64) *plan.Expr {
+	return &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+		Value: &plan.Literal_U64Val{U64Val: value},
+	}}}
+}
+
+func TestUint64RangeBound(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		value       uint64
+		offset      uint64
+		subtract    bool
+		wantBound   uint64
+		wantAbove   bool
+		wantInRange bool
+	}{
+		{name: "add", value: 1, offset: 10, wantBound: 11, wantInRange: true},
+		{name: "subtract", value: 10, offset: 10, subtract: true, wantBound: 0, wantInRange: true},
+		{name: "subtract underflow", value: 9, offset: 10, subtract: true},
+		{name: "add maximum", value: math.MaxUint64, wantBound: math.MaxUint64, wantInRange: true},
+		{name: "add overflow", value: math.MaxUint64, offset: 1, wantAbove: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bound, above, ok := uint64RangeBound(tc.value, tc.offset, tc.subtract)
+			require.Equal(t, tc.wantBound, bound)
+			require.Equal(t, tc.wantAbove, above)
+			require.Equal(t, tc.wantInRange, ok)
+		})
+	}
+
+	require.Equal(t, 0, outOfDomainRangeBoundary(0, 21, false, false))
+	require.Equal(t, 21, outOfDomainRangeBoundary(0, 21, true, false))
+	require.Equal(t, 21, outOfDomainRangeBoundary(0, 21, false, true))
+	require.Equal(t, 0, outOfDomainRangeBoundary(0, 21, true, true))
+}
+
+func TestBuildRangeIntervalUint64Boundaries(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer func() { require.Equal(t, int64(0), mp.CurrNB()) }()
+
+	currentToFollowing := func(offset uint64) *plan.FrameClause {
+		return &plan.FrameClause{
+			Type:  plan.FrameClause_RANGE,
+			Start: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+			End: &plan.FrameBound{
+				Type: plan.FrameBound_FOLLOWING,
+				Val:  uint64RangeOffset(offset),
+			},
+		}
+	}
+	precedingOnly := func(offset uint64) *plan.FrameClause {
+		return &plan.FrameClause{
+			Type: plan.FrameClause_RANGE,
+			Start: &plan.FrameBound{
+				Type: plan.FrameBound_PRECEDING,
+				Val:  uint64RangeOffset(offset),
+			},
+			End: &plan.FrameBound{
+				Type: plan.FrameBound_PRECEDING,
+				Val:  uint64RangeOffset(offset),
+			},
+		}
+	}
+	check := func(t *testing.T, oid types.T, values []uint64, desc bool, row int, frame *plan.FrameClause, wantStart, wantEnd int) {
+		t.Helper()
+		vec := makeFixedVec(t, mp, oid, values)
+		defer vec.Free(mp)
+		ctr := &container{
+			orderVecs: []colexec.ExprEvalVector{{Vec: []*vector.Vector{vec}}},
+			desc:      []bool{desc},
+		}
+		start, end, err := ctr.buildRangeInterval(row, 0, len(values), frame)
+		require.NoError(t, err)
+		require.Equal(t, wantStart, start)
+		require.Equal(t, wantEnd, end)
+	}
+
+	asc := make([]uint64, 21)
+	desc := make([]uint64, 21)
+	for i := range asc {
+		asc[i] = uint64(i)
+		desc[i] = uint64(20 - i)
+	}
+
+	for _, oid := range []types.T{types.T_uint64, types.T_bit} {
+		t.Run(oid.String(), func(t *testing.T) {
+			check(t, oid, asc, false, 0, currentToFollowing(10), 0, 11)
+			check(t, oid, asc, false, 0, currentToFollowing(0), 0, 1)
+			check(t, oid, asc, false, 10, currentToFollowing(10), 10, 21)
+			check(t, oid, desc, true, 11, currentToFollowing(10), 11, 21)
+			check(t, oid, asc, false, 10, precedingOnly(10), 0, 1)
+			check(t, oid, asc, false, 5, precedingOnly(10), 0, 0)
+			check(t, oid, []uint64{math.MaxUint64 - 2, math.MaxUint64 - 1, math.MaxUint64}, false, 0, currentToFollowing(10), 0, 3)
+		})
+	}
+
+	t.Run("null peers", func(t *testing.T) {
+		vec := vector.NewVec(types.T_uint64.ToType())
+		for i, value := range []uint64{0, 0, 0, 1} {
+			require.NoError(t, vector.AppendFixed(vec, value, i < 2, mp))
+		}
+		defer vec.Free(mp)
+		ctr := &container{
+			orderVecs: []colexec.ExprEvalVector{{Vec: []*vector.Vector{vec}}},
+			desc:      []bool{false},
+		}
+		start, end, err := ctr.buildRangeInterval(0, 0, vec.Length(), currentToFollowing(10))
+		require.NoError(t, err)
+		require.Equal(t, 0, start)
+		require.Equal(t, 2, end)
+		start, end, err = ctr.buildRangeInterval(2, 0, vec.Length(), currentToFollowing(10))
+		require.NoError(t, err)
+		require.Equal(t, 2, start)
+		require.Equal(t, 4, end)
+	})
+}
+
 // TestSearchLeftRightAllFloatTypes covers float32/64.
 func TestSearchLeftRightAllFloatTypes(t *testing.T) {
 	mp := mpool.MustNewZero()

--- a/test/distributed/cases/window/window_uint64_range_bound.result
+++ b/test/distributed/cases/window/window_uint64_range_bound.result
@@ -1,0 +1,135 @@
+drop database if exists window_uint64_range_27565;
+create database window_uint64_range_27565;
+use window_uint64_range_27565;
+create table t(id bigint unsigned primary key);
+insert into t select result from generate_series(0,20) g;
+select id,
+count(*) over (
+order by id range between current row and 10 following
+) as c,
+sum(id) over (
+order by id range between current row and 10 following
+) as s
+from t order by id;
+id    c    s
+0    11    55
+1    11    66
+2    11    77
+3    11    88
+4    11    99
+5    11    110
+6    11    121
+7    11    132
+8    11    143
+9    11    154
+10    11    165
+11    10    155
+12    9    144
+13    8    132
+14    7    119
+15    6    105
+16    5    90
+17    4    74
+18    3    57
+19    2    39
+20    1    20
+select id,
+count(*) over (
+order by id desc range between current row and 10 following
+) as c,
+sum(id) over (
+order by id desc range between current row and 10 following
+) as s
+from t order by id desc;
+id    c    s
+20    11    165
+19    11    154
+18    11    143
+17    11    132
+16    11    121
+15    11    110
+14    11    99
+13    11    88
+12    11    77
+11    11    66
+10    11    55
+9    10    45
+8    9    36
+7    8    28
+6    7    21
+5    6    15
+4    5    10
+3    4    6
+2    3    3
+1    2    1
+0    1    0
+select id,
+count(*) over (
+order by id range between current row and 0 following
+) as zero_c,
+count(*) over (
+order by id range between 10 preceding and 10 preceding
+) as preceding_c,
+sum(id) over (
+order by id range between 10 preceding and 10 preceding
+) as preceding_s
+from t order by id;
+id    zero_c    preceding_c    preceding_s
+0    1    0    null
+1    1    0    null
+2    1    0    null
+3    1    0    null
+4    1    0    null
+5    1    0    null
+6    1    0    null
+7    1    0    null
+8    1    0    null
+9    1    0    null
+10    1    1    0
+11    1    1    1
+12    1    1    2
+13    1    1    3
+14    1    1    4
+15    1    1    5
+16    1    1    6
+17    1    1    7
+18    1    1    8
+19    1    1    9
+20    1    1    10
+create table max_t(k bigint unsigned primary key, v int);
+insert into max_t values
+(18446744073709551613, 1),
+(18446744073709551614, 2),
+(18446744073709551615, 3);
+select k,
+count(*) over (
+order by k range between current row and 10 following
+) as c,
+sum(v) over (
+order by k range between current row and 10 following
+) as s
+from max_t order by k;
+k    c    s
+18446744073709551613    3    6
+18446744073709551614    2    5
+18446744073709551615    1    3
+create table nullable_t(id int primary key, k bigint unsigned, v int);
+insert into nullable_t values
+(1, null, 10),
+(2, null, 20),
+(3, 0, 30),
+(4, 1, 40);
+select id, if(k is null, 'NULL', cast(k as char)) as k_label,
+count(*) over (
+order by k range between current row and 10 following
+) as c,
+sum(v) over (
+order by k range between current row and 10 following
+) as s
+from nullable_t order by k is not null, k, id;
+id    k_label    c    s
+1    NULL    2    30
+2    NULL    2    30
+3    0    2    70
+4    1    1    40
+drop database window_uint64_range_27565;

--- a/test/distributed/cases/window/window_uint64_range_bound.sql
+++ b/test/distributed/cases/window/window_uint64_range_bound.sql
@@ -1,0 +1,69 @@
+-- issue #27565: uint64 RANGE bounds must not wrap or return the wrong
+-- out-of-domain boundary for ASC or DESC order.
+drop database if exists window_uint64_range_27565;
+create database window_uint64_range_27565;
+use window_uint64_range_27565;
+
+create table t(id bigint unsigned primary key);
+insert into t select result from generate_series(0,20) g;
+
+select id,
+       count(*) over (
+         order by id range between current row and 10 following
+       ) as c,
+       sum(id) over (
+         order by id range between current row and 10 following
+       ) as s
+from t order by id;
+
+select id,
+       count(*) over (
+         order by id desc range between current row and 10 following
+       ) as c,
+       sum(id) over (
+         order by id desc range between current row and 10 following
+       ) as s
+from t order by id desc;
+
+select id,
+       count(*) over (
+         order by id range between current row and 0 following
+       ) as zero_c,
+       count(*) over (
+         order by id range between 10 preceding and 10 preceding
+       ) as preceding_c,
+       sum(id) over (
+         order by id range between 10 preceding and 10 preceding
+       ) as preceding_s
+from t order by id;
+
+create table max_t(k bigint unsigned primary key, v int);
+insert into max_t values
+  (18446744073709551613, 1),
+  (18446744073709551614, 2),
+  (18446744073709551615, 3);
+select k,
+       count(*) over (
+         order by k range between current row and 10 following
+       ) as c,
+       sum(v) over (
+         order by k range between current row and 10 following
+       ) as s
+from max_t order by k;
+
+create table nullable_t(id int primary key, k bigint unsigned, v int);
+insert into nullable_t values
+  (1, null, 10),
+  (2, null, 20),
+  (3, 0, 30),
+  (4, 1, 40);
+select id, if(k is null, 'NULL', cast(k as char)) as k_label,
+       count(*) over (
+         order by k range between current row and 10 following
+       ) as c,
+       sum(v) over (
+         order by k range between current row and 10 following
+       ) as s
+from nullable_t order by k is not null, k, id;
+
+drop database window_uint64_range_27565;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:

Fixes #27565

## What this PR does / why we need it:

Handle `BIGINT UNSIGNED` and `BIT` Window `RANGE` bounds without wrapping uint64 arithmetic or mapping out-of-domain bounds to the wrong ASC/DESC insertion boundary. This fixes low-key `RANGE ... FOLLOWING` frames that were incorrectly returned as empty and also covers subtraction underflow and addition overflow.

## Validation

- `go test ./pkg/sql/colexec/window/... -count=1`
- `go test -race ./pkg/sql/colexec/window/... -count=1`
- `go vet ./pkg/sql/colexec/window/...`
- `go test ./pkg/sql/colexec/... -count=1`
- `git diff --check origin/main...HEAD`
- `pkg/sql/colexec/window` coverage: 84.4%
- latest-main isolated SQL regression for ASC/DESC, zero offset, uint64 underflow/overflow, NULL peers, and empty frames
- 500,010-row independent-reference regression repeated 3 times: 261,910 wrong rows before the fix, 0 after the fix
