### PR TITLE
[4.2] fix(lockservice): avoid bind fence cleanup deadlock

### DIFF
--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -1719,6 +1719,9 @@ type mapBasedTxnHolder struct {
 	serviceID string
 	logger    *log.MOLogger
 	fsp       *fixedSlicePool
+	// beforeFenceTxnLock is a test-only phase hook for holder/transaction lock
+	// interleavings.
+	beforeFenceTxnLock func(*activeTxn)
 	// validTxn returns an authoritative liveness result only when err is nil.
 	// Any error means the remote transaction state is unknown; transport
 	// reachability is not evidence that the transaction is inactive.
@@ -1879,12 +1882,43 @@ func (h *mapBasedTxnHolder) fenceByBindChanged(bind pb.LockTable) int {
 	for i := range h.activeTxns {
 		shard := &h.activeTxns[i]
 		shard.RLock()
-		for _, entry := range shard.txns {
-			if entry.txn.fenceByBindChanged(bind, h.logger) {
-				n++
-			}
+		txnKeys := make([]string, 0, len(shard.txns))
+		for txnKey := range shard.txns {
+			txnKeys = append(txnKeys, txnKey)
 		}
 		shard.RUnlock()
+
+		for _, txnKey := range txnKeys {
+			for {
+				shard.RLock()
+				entry, ok := shard.txns[txnKey]
+				if !ok {
+					shard.RUnlock()
+					break
+				}
+				if h.beforeFenceTxnLock != nil {
+					h.beforeFenceTxnLock(entry.txn)
+				}
+
+				// Unknown-commit cleanup holds txn.Lock while releasing owner
+				// locks, then removes the transaction from this shard. Never
+				// wait for txn.Lock while retaining shard.RLock: doing so
+				// reverses that order and deadlocks both cleanup paths. TryLock
+				// keeps the pooled transaction alive under shard.RLock; on
+				// contention, release the shard so cleanup can make progress.
+				if !entry.txn.TryLock() {
+					shard.RUnlock()
+					time.Sleep(time.Millisecond)
+					continue
+				}
+				if entry.txn.fenceByBindChangedLocked(bind, h.logger) {
+					n++
+				}
+				entry.txn.Unlock()
+				shard.RUnlock()
+				break
+			}
+		}
 	}
 	return n
 }

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -968,6 +968,75 @@ func TestMapBasedTxnHolderConcurrentGetAndDelete(t *testing.T) {
 	})
 }
 
+func TestMapBasedTxnHolderFenceReleasesShardWhileTxnIsBusy(t *testing.T) {
+	reuse.RunReuseTests(func() {
+		hold := newMapBasedTxnHandler(
+			"s1",
+			getLogger(""),
+			newFixedSlicePool(16),
+			func(string) (bool, error) { return true, nil },
+			func([]pb.OrphanTxn) (pb.CannotCommitResponse, error) {
+				return pb.CannotCommitResponse{}, nil
+			},
+			func(pb.WaitTxn) (bool, error) { return true, nil },
+		).(*mapBasedTxnHolder)
+		defer hold.close()
+
+		bind := pb.LockTable{
+			Group: 0, Table: 24766, ServiceID: "s1", Version: 1, Valid: true,
+		}
+		txnID := []byte("busy-bind-fence")
+		txn := hold.getActiveTxn(txnID, true, "")
+		txn.Lock()
+		txnLocked := true
+		defer func() {
+			if txnLocked {
+				txn.Unlock()
+			}
+		}()
+		require.NoError(t, txn.lockAdded(bind.Group, bind, [][]byte{{1}}, hold.logger))
+
+		fenceEntered := make(chan struct{}, 1)
+		hold.beforeFenceTxnLock = func(candidate *activeTxn) {
+			if candidate == txn {
+				select {
+				case fenceEntered <- struct{}{}:
+				default:
+				}
+			}
+		}
+		fenceDone := make(chan int, 1)
+		changedBind := bind
+		changedBind.Version++
+		go func() {
+			fenceDone <- hold.fenceByBindChanged(changedBind)
+		}()
+		<-fenceEntered
+
+		shard := hold.getActiveTxnShard(string(txnID))
+		require.Eventually(t, func() bool {
+			if !shard.TryLock() {
+				return false
+			}
+			shard.Unlock()
+			return true
+		}, time.Second, time.Millisecond,
+			"bind fencing must not retain the shard while waiting for txn.Lock")
+
+		txn.Unlock()
+		txnLocked = false
+		select {
+		case count := <-fenceDone:
+			require.Equal(t, 1, count)
+		case <-time.After(time.Second):
+			t.Fatal("bind fencing did not resume after the transaction unlocked")
+		}
+		txn.RLock()
+		require.True(t, txn.bindChanged)
+		txn.RUnlock()
+	})
+}
+
 func TestMapBasedTxnHolderVisitsAndClosesAllShards(t *testing.T) {
 	reuse.RunReuseTests(func() {
 		hold := newMapBasedTxnHandler(

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -529,7 +529,10 @@ func (txn *activeTxn) abort(
 func (txn *activeTxn) fenceByBindChanged(bind pb.LockTable, logger *log.MOLogger) bool {
 	txn.Lock()
 	defer txn.Unlock()
+	return txn.fenceByBindChangedLocked(bind, logger)
+}
 
+func (txn *activeTxn) fenceByBindChangedLocked(bind pb.LockTable, logger *log.MOLogger) bool {
 	h, ok := txn.lockHolders[bind.Group]
 	if !ok {
 		return false

--- a/pkg/lockservice/unknown_commit_test.go
+++ b/pkg/lockservice/unknown_commit_test.go
@@ -186,6 +186,76 @@ func TestUnknownCommitRemoveCallbackCanReenterClose(t *testing.T) {
 	})
 }
 
+func TestUnknownCommitCleanupDoesNotDeadlockBindFence(t *testing.T) {
+	runLockServiceTests(t, []string{"s1"}, func(_ *lockTableAllocator, services []*service) {
+		service := services[0]
+		tableID := uint64(24766)
+		bind := pb.LockTable{
+			Group:     0,
+			Table:     tableID,
+			ServiceID: service.serviceID,
+			Version:   1,
+			Valid:     true,
+		}
+		lockTable := &blockingUnlockTestTable{
+			retryableUnlockTestTable: retryableUnlockTestTable{bind: bind},
+			started:                  make(chan struct{}),
+			release:                  make(chan struct{}),
+		}
+
+		txnID := []byte("unknown-commit-bind-fence")
+		txn := service.activeTxnHolder.getActiveTxn(txnID, true, "")
+		txn.Lock()
+		require.NoError(t, txn.lockAdded(bind.Group, bind, [][]byte{{1}}, service.logger))
+		txn.Unlock()
+		service.incRef(bind.Group, bind.Table)
+
+		holder := service.activeTxnHolder.(*mapBasedTxnHolder)
+		fenceEntered := make(chan struct{}, 1)
+		holder.beforeFenceTxnLock = func(candidate *activeTxn) {
+			if candidate == txn {
+				select {
+				case fenceEntered <- struct{}{}:
+				default:
+				}
+			}
+		}
+		service.tableGroups.set(bind.Group, bind.Table, lockTable)
+
+		unlockDone := make(chan error, 1)
+		go func() {
+			unlockDone <- service.unlockUnknownCommit(
+				context.Background(),
+				txnID,
+				timestamp.Timestamp{},
+			)
+		}()
+		<-lockTable.started
+
+		fenceDone := make(chan int, 1)
+		changedBind := bind
+		changedBind.Version++
+		go func() {
+			fenceDone <- holder.fenceByBindChanged(changedBind)
+		}()
+		<-fenceEntered
+		close(lockTable.release)
+
+		select {
+		case err := <-unlockDone:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("unknown-commit cleanup deadlocked with bind fencing")
+		}
+		select {
+		case <-fenceDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("bind fencing deadlocked with unknown-commit cleanup")
+		}
+		require.False(t, holder.hasActiveTxn(txnID))
+	})
+}
+
 func TestUnknownCommitBatchFencesOnlyNonCommittingTxns(t *testing.T) {
 	runLockServiceTests(t, []string{"s1"}, func(allocator *lockTableAllocator, services []*service) {
 		service := services[0]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27562

Backport of #26749 to `4.2-dev`.

## What this PR does / why we need it:

After a TN failure produces an unknown commit, `unlockUnknownCommit` can retain `activeTxn.Lock` while deleting the transaction from its holder shard:

```text
activeTxn.Lock -> activeTxnHolder shard.Lock
```

At the same time stale-bind fencing in the affected 4.2 code retains `shard.RLock` while waiting for the transaction mutex:

```text
activeTxnHolder shard.RLock -> activeTxn.Lock
```

The bind-fence path also holds `bindChangeMu.Lock`, so the inversion blocks every later `service.Lock` request at `bindChangeMu.RLock`. Production goroutine profiles from #27562 contain both opposing stacks for the same five-minute interval and accumulating lock requests; restarting the affected CN clears the process-local deadlock.

This backport snapshots transaction keys under each holder shard, uses `TryLock` while the shard protects the pooled transaction pointer, and releases the shard before retrying a busy transaction. This lets unknown-commit deletion finish without changing normal Lock, Unlock, Commit, allocator-fence, or proxy semantics.

The cherry-pick applied cleanly to current `4.2-dev`; its patch-id is identical to the merged main fix.

Validation:

- `go build -mod=readonly ./pkg/lockservice`
- `go vet -mod=readonly ./pkg/lockservice`
- focused regression tests selected explicitly
- both focused regressions with `-race -count=100`
- complete `pkg/lockservice` test package
- complete `pkg/lockservice` test package with `-race`
