### PR TITLE
fix(window): handle signed integer range bounds

### DIFF
--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -1664,11 +1664,11 @@ func searchLeft(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, plu
 			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[int8], cmpl)
 		} else {
 			c := int8(expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I8Val).I8Val)
-			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[int8], cmpl)
-			} else {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[int8], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, !plus)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			left = genericSearchLeft(start, end-1, col, bound, genericEqual[int8], cmpl)
 		}
 	case types.T_int16:
 		col := vector.MustFixedColNoTypeCheck[int16](vec)
@@ -1680,11 +1680,11 @@ func searchLeft(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, plu
 			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[int16], cmpl)
 		} else {
 			c := int16(expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I16Val).I16Val)
-			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[int16], cmpl)
-			} else {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[int16], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, !plus)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			left = genericSearchLeft(start, end-1, col, bound, genericEqual[int16], cmpl)
 		}
 	case types.T_int32:
 		col := vector.MustFixedColNoTypeCheck[int32](vec)
@@ -1696,11 +1696,11 @@ func searchLeft(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, plu
 			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[int32], cmpl)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I32Val).I32Val
-			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[int32], cmpl)
-			} else {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[int32], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, !plus)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			left = genericSearchLeft(start, end-1, col, bound, genericEqual[int32], cmpl)
 		}
 	case types.T_int64:
 		col := vector.MustFixedColNoTypeCheck[int64](vec)
@@ -1712,11 +1712,11 @@ func searchLeft(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, plu
 			left = genericSearchLeft(start, end-1, col, col[rowIdx], genericEqual[int64], cmpl)
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I64Val).I64Val
-			if plus {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]+c, genericEqual[int64], cmpl)
-			} else {
-				left = genericSearchLeft(start, end-1, col, col[rowIdx]-c, genericEqual[int64], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, !plus)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			left = genericSearchLeft(start, end-1, col, bound, genericEqual[int64], cmpl)
 		}
 	case types.T_uint8:
 		col := vector.MustFixedColNoTypeCheck[uint8](vec)
@@ -2082,11 +2082,11 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[int8])
 		} else {
 			c := int8(expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I8Val).I8Val)
-			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[int8], cmpl)
-			} else {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[int8], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, sub)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			right = genericSearchRight(start, end-1, col, bound, genericEqual[int8], cmpl)
 		}
 	case types.T_int16:
 		col := vector.MustFixedColNoTypeCheck[int16](vec)
@@ -2098,11 +2098,11 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[int16])
 		} else {
 			c := int16(expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I16Val).I16Val)
-			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[int16], cmpl)
-			} else {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[int16], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, sub)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			right = genericSearchRight(start, end-1, col, bound, genericEqual[int16], cmpl)
 		}
 	case types.T_int32:
 		col := vector.MustFixedColNoTypeCheck[int32](vec)
@@ -2114,11 +2114,11 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[int32])
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I32Val).I32Val
-			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[int32], cmpl)
-			} else {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[int32], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, sub)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			right = genericSearchRight(start, end-1, col, bound, genericEqual[int32], cmpl)
 		}
 	case types.T_int64:
 		col := vector.MustFixedColNoTypeCheck[int64](vec)
@@ -2130,11 +2130,11 @@ func searchRight(start, end, rowIdx int, vec *vector.Vector, expr *plan.Expr, su
 			right = genericSearchEqualRight(rowIdx, end-1, col, col[rowIdx], genericEqual[int64])
 		} else {
 			c := expr.Expr.(*plan.Expr_Lit).Lit.Value.(*plan.Literal_I64Val).I64Val
-			if sub {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]-c, genericEqual[int64], cmpl)
-			} else {
-				right = genericSearchRight(start, end-1, col, col[rowIdx]+c, genericEqual[int64], cmpl)
+			bound, aboveDomain, ok := signedRangeBound(col[rowIdx], c, sub)
+			if !ok {
+				return outOfDomainRangeBoundary(start, end, aboveDomain, desc), nil
 			}
+			right = genericSearchRight(start, end-1, col, bound, genericEqual[int64], cmpl)
 		}
 	case types.T_uint8:
 		col := vector.MustFixedColNoTypeCheck[uint8](vec)
@@ -2422,8 +2422,31 @@ func uint64RangeBound(value, offset uint64, subtract bool) (bound uint64, aboveD
 	return value + offset, false, true
 }
 
-// outOfDomainRangeBoundary maps a conceptual search key outside uint64 to its
-// insertion boundary in the current SQL sort direction.
+type signedRangeInteger interface {
+	~int8 | ~int16 | ~int32 | ~int64
+}
+
+// signedRangeBound computes a finite RANGE search key without allowing signed
+// arithmetic to wrap into the opposite end of the type domain. aboveDomain
+// distinguishes overflow above the maximum from underflow below the minimum.
+func signedRangeBound[T signedRangeInteger](value, offset T, subtract bool) (bound T, aboveDomain bool, ok bool) {
+	if subtract {
+		bound = value - offset
+		if (offset > 0 && bound > value) || (offset < 0 && bound < value) {
+			return 0, offset < 0, false
+		}
+		return bound, false, true
+	}
+
+	bound = value + offset
+	if (offset > 0 && bound < value) || (offset < 0 && bound > value) {
+		return 0, offset > 0, false
+	}
+	return bound, false, true
+}
+
+// outOfDomainRangeBoundary maps a conceptual search key outside a numeric type
+// domain to its insertion boundary in the current SQL sort direction.
 func outOfDomainRangeBoundary(start, end int, aboveDomain, desc bool) int {
 	if aboveDomain != desc {
 		return end

--- a/pkg/sql/colexec/window/window_test.go
+++ b/pkg/sql/colexec/window/window_test.go
@@ -2821,6 +2821,126 @@ func TestBuildRangeIntervalUint64Boundaries(t *testing.T) {
 	})
 }
 
+func signedRangeOffset(oid types.T, value int64) *plan.Expr {
+	lit := &plan.Literal{}
+	switch oid {
+	case types.T_int8:
+		lit.Value = &plan.Literal_I8Val{I8Val: int32(value)}
+	case types.T_int16:
+		lit.Value = &plan.Literal_I16Val{I16Val: int32(value)}
+	case types.T_int32:
+		lit.Value = &plan.Literal_I32Val{I32Val: int32(value)}
+	case types.T_int64:
+		lit.Value = &plan.Literal_I64Val{I64Val: value}
+	default:
+		panic("unsupported signed RANGE type")
+	}
+	return &plan.Expr{Expr: &plan.Expr_Lit{Lit: lit}}
+}
+
+func TestSignedRangeBound(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		value       int8
+		offset      int8
+		subtract    bool
+		wantBound   int8
+		wantAbove   bool
+		wantInRange bool
+	}{
+		{name: "add", value: 1, offset: 1, wantBound: 2, wantInRange: true},
+		{name: "subtract", value: 1, offset: 1, subtract: true, wantBound: 0, wantInRange: true},
+		{name: "add maximum zero", value: math.MaxInt8, wantBound: math.MaxInt8, wantInRange: true},
+		{name: "subtract minimum zero", value: math.MinInt8, subtract: true, wantBound: math.MinInt8, wantInRange: true},
+		{name: "add overflow", value: math.MaxInt8, offset: 1, wantAbove: true},
+		{name: "subtract underflow", value: math.MinInt8, offset: 1, subtract: true},
+		{name: "add negative underflow", value: math.MinInt8, offset: -1},
+		{name: "subtract negative overflow", value: math.MaxInt8, offset: -1, subtract: true, wantAbove: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bound, above, ok := signedRangeBound(tc.value, tc.offset, tc.subtract)
+			require.Equal(t, tc.wantBound, bound)
+			require.Equal(t, tc.wantAbove, above)
+			require.Equal(t, tc.wantInRange, ok)
+		})
+	}
+
+	require.Equal(t, 0, outOfDomainRangeBoundary(0, 3, false, false))
+	require.Equal(t, 3, outOfDomainRangeBoundary(0, 3, true, false))
+	require.Equal(t, 3, outOfDomainRangeBoundary(0, 3, false, true))
+	require.Equal(t, 0, outOfDomainRangeBoundary(0, 3, true, true))
+}
+
+func testBuildRangeIntervalSignedBoundaries[T types.OrderedT](
+	t *testing.T,
+	mp *mpool.MPool,
+	oid types.T,
+	minValue T,
+	maxValue T,
+) {
+	t.Helper()
+
+	currentToFollowing := &plan.FrameClause{
+		Type:  plan.FrameClause_RANGE,
+		Start: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+		End: &plan.FrameBound{
+			Type: plan.FrameBound_FOLLOWING,
+			Val:  signedRangeOffset(oid, 1),
+		},
+	}
+	precedingToCurrent := &plan.FrameClause{
+		Type: plan.FrameClause_RANGE,
+		Start: &plan.FrameBound{
+			Type: plan.FrameBound_PRECEDING,
+			Val:  signedRangeOffset(oid, 1),
+		},
+		End: &plan.FrameBound{Type: plan.FrameBound_CURRENT_ROW},
+	}
+	check := func(t *testing.T, values []T, desc bool, row int, frame *plan.FrameClause, wantStart, wantEnd int) {
+		t.Helper()
+		vec := makeFixedVec(t, mp, oid, values)
+		defer vec.Free(mp)
+		ctr := &container{
+			orderVecs: []colexec.ExprEvalVector{{Vec: []*vector.Vector{vec}}},
+			desc:      []bool{desc},
+		}
+		start, end, err := ctr.buildRangeInterval(row, 0, len(values), frame)
+		require.NoError(t, err)
+		require.Equal(t, wantStart, start)
+		require.Equal(t, wantEnd, end)
+	}
+
+	var zeroValue T
+	asc := []T{minValue, zeroValue, maxValue}
+	desc := []T{maxValue, zeroValue, minValue}
+
+	// ASC addition overflow and subtraction underflow both retain the current row.
+	check(t, asc, false, 2, currentToFollowing, 2, 3)
+	check(t, asc, false, 0, precedingToCurrent, 0, 1)
+
+	// DESC reverses the arithmetic direction while preserving the same frame invariant.
+	check(t, desc, true, 2, currentToFollowing, 2, 3)
+	check(t, desc, true, 0, precedingToCurrent, 0, 1)
+}
+
+func TestBuildRangeIntervalSignedBoundaries(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer func() { require.Equal(t, int64(0), mp.CurrNB()) }()
+
+	t.Run("int8", func(t *testing.T) {
+		testBuildRangeIntervalSignedBoundaries(t, mp, types.T_int8, int8(math.MinInt8), int8(math.MaxInt8))
+	})
+	t.Run("int16", func(t *testing.T) {
+		testBuildRangeIntervalSignedBoundaries(t, mp, types.T_int16, int16(math.MinInt16), int16(math.MaxInt16))
+	})
+	t.Run("int32", func(t *testing.T) {
+		testBuildRangeIntervalSignedBoundaries(t, mp, types.T_int32, int32(math.MinInt32), int32(math.MaxInt32))
+	})
+	t.Run("int64", func(t *testing.T) {
+		testBuildRangeIntervalSignedBoundaries(t, mp, types.T_int64, int64(math.MinInt64), int64(math.MaxInt64))
+	})
+}
+
 // TestSearchLeftRightAllFloatTypes covers float32/64.
 func TestSearchLeftRightAllFloatTypes(t *testing.T) {
 	mp := mpool.MustNewZero()

--- a/test/distributed/cases/window/window_signed_range_bound.result
+++ b/test/distributed/cases/window/window_signed_range_bound.result
@@ -1,0 +1,91 @@
+drop database if exists window_signed_range_27574;
+create database window_signed_range_27574;
+use window_signed_range_27574;
+create table extrema(
+id int primary key,
+i8 tinyint,
+i16 smallint,
+i32 int,
+i64 bigint,
+v int
+);
+insert into extrema values
+(1, -128, -32768, -2147483648, -9223372036854775808, 10),
+(2, 0, 0, 0, 0, 20),
+(3, 127, 32767, 2147483647, 9223372036854775807, 30);
+select id,
+count(*) over (order by i8 range between current row and 1 following) as f_c,
+sum(v) over (order by i8 range between current row and 1 following) as f_s,
+count(*) over (order by i8 range between 1 preceding and current row) as p_c,
+sum(v) over (order by i8 range between 1 preceding and current row) as p_s
+from extrema order by id;
+id    f_c    f_s    p_c    p_s
+1    1    10    1    10
+2    1    20    1    20
+3    1    30    1    30
+select id,
+count(*) over (order by i16 range between current row and 1 following) as f_c,
+sum(v) over (order by i16 range between current row and 1 following) as f_s,
+count(*) over (order by i16 range between 1 preceding and current row) as p_c,
+sum(v) over (order by i16 range between 1 preceding and current row) as p_s
+from extrema order by id;
+id    f_c    f_s    p_c    p_s
+1    1    10    1    10
+2    1    20    1    20
+3    1    30    1    30
+select id,
+count(*) over (order by i32 range between current row and 1 following) as f_c,
+sum(v) over (order by i32 range between current row and 1 following) as f_s,
+count(*) over (order by i32 range between 1 preceding and current row) as p_c,
+sum(v) over (order by i32 range between 1 preceding and current row) as p_s
+from extrema order by id;
+id    f_c    f_s    p_c    p_s
+1    1    10    1    10
+2    1    20    1    20
+3    1    30    1    30
+select id,
+count(*) over (order by i64 range between current row and 1 following) as f_c,
+sum(v) over (order by i64 range between current row and 1 following) as f_s,
+count(*) over (order by i64 range between 1 preceding and current row) as p_c,
+sum(v) over (order by i64 range between 1 preceding and current row) as p_s
+from extrema order by id;
+id    f_c    f_s    p_c    p_s
+1    1    10    1    10
+2    1    20    1    20
+3    1    30    1    30
+select id,
+count(*) over (order by i64 desc range between current row and 1 following) as f_c,
+sum(v) over (order by i64 desc range between current row and 1 following) as f_s,
+count(*) over (order by i64 desc range between 1 preceding and current row) as p_c,
+sum(v) over (order by i64 desc range between 1 preceding and current row) as p_s
+from extrema order by id;
+id    f_c    f_s    p_c    p_s
+1    1    10    1    10
+2    1    20    1    20
+3    1    30    1    30
+select id,
+count(*) over (order by i64 range between 1 preceding and 1 preceding) as empty_c,
+sum(v) over (order by i64 range between 1 preceding and 1 preceding) as empty_s
+from extrema order by id;
+id    empty_c    empty_s
+1    0    null
+2    0    null
+3    0    null
+create table nullable_t(id int primary key, k bigint, v int);
+insert into nullable_t values
+(1, null, 10),
+(2, null, 20),
+(3, -9223372036854775808, 30),
+(4, 9223372036854775807, 40);
+select id, if(k is null, 'NULL', cast(k as char)) as k_label,
+count(*) over (order by k range between current row and 1 following) as f_c,
+sum(v) over (order by k range between current row and 1 following) as f_s,
+count(*) over (order by k range between 1 preceding and current row) as p_c,
+sum(v) over (order by k range between 1 preceding and current row) as p_s
+from nullable_t order by k is not null, k, id;
+id    k_label    f_c    f_s    p_c    p_s
+1    NULL    2    30    2    30
+2    NULL    2    30    2    30
+3    -9223372036854775808    1    30    1    30
+4    9223372036854775807    1    40    1    40
+drop database window_signed_range_27574;

--- a/test/distributed/cases/window/window_signed_range_bound.sql
+++ b/test/distributed/cases/window/window_signed_range_bound.sql
@@ -1,0 +1,77 @@
+-- @suite
+
+-- @case
+-- @desc: issue #27574 signed integer RANGE bounds must not wrap at type extrema
+-- @label:bvt
+
+drop database if exists window_signed_range_27574;
+create database window_signed_range_27574;
+use window_signed_range_27574;
+
+create table extrema(
+  id int primary key,
+  i8 tinyint,
+  i16 smallint,
+  i32 int,
+  i64 bigint,
+  v int
+);
+insert into extrema values
+  (1, -128, -32768, -2147483648, -9223372036854775808, 10),
+  (2, 0, 0, 0, 0, 20),
+  (3, 127, 32767, 2147483647, 9223372036854775807, 30);
+
+select id,
+       count(*) over (order by i8 range between current row and 1 following) as f_c,
+       sum(v) over (order by i8 range between current row and 1 following) as f_s,
+       count(*) over (order by i8 range between 1 preceding and current row) as p_c,
+       sum(v) over (order by i8 range between 1 preceding and current row) as p_s
+from extrema order by id;
+
+select id,
+       count(*) over (order by i16 range between current row and 1 following) as f_c,
+       sum(v) over (order by i16 range between current row and 1 following) as f_s,
+       count(*) over (order by i16 range between 1 preceding and current row) as p_c,
+       sum(v) over (order by i16 range between 1 preceding and current row) as p_s
+from extrema order by id;
+
+select id,
+       count(*) over (order by i32 range between current row and 1 following) as f_c,
+       sum(v) over (order by i32 range between current row and 1 following) as f_s,
+       count(*) over (order by i32 range between 1 preceding and current row) as p_c,
+       sum(v) over (order by i32 range between 1 preceding and current row) as p_s
+from extrema order by id;
+
+select id,
+       count(*) over (order by i64 range between current row and 1 following) as f_c,
+       sum(v) over (order by i64 range between current row and 1 following) as f_s,
+       count(*) over (order by i64 range between 1 preceding and current row) as p_c,
+       sum(v) over (order by i64 range between 1 preceding and current row) as p_s
+from extrema order by id;
+
+select id,
+       count(*) over (order by i64 desc range between current row and 1 following) as f_c,
+       sum(v) over (order by i64 desc range between current row and 1 following) as f_s,
+       count(*) over (order by i64 desc range between 1 preceding and current row) as p_c,
+       sum(v) over (order by i64 desc range between 1 preceding and current row) as p_s
+from extrema order by id;
+
+select id,
+       count(*) over (order by i64 range between 1 preceding and 1 preceding) as empty_c,
+       sum(v) over (order by i64 range between 1 preceding and 1 preceding) as empty_s
+from extrema order by id;
+
+create table nullable_t(id int primary key, k bigint, v int);
+insert into nullable_t values
+  (1, null, 10),
+  (2, null, 20),
+  (3, -9223372036854775808, 30),
+  (4, 9223372036854775807, 40);
+select id, if(k is null, 'NULL', cast(k as char)) as k_label,
+       count(*) over (order by k range between current row and 1 following) as f_c,
+       sum(v) over (order by k range between current row and 1 following) as f_s,
+       count(*) over (order by k range between 1 preceding and current row) as p_c,
+       sum(v) over (order by k range between 1 preceding and current row) as p_s
+from nullable_t order by k is not null, k, id;
+
+drop database window_signed_range_27574;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27574

## What this PR does / why we need it:

Prevent signed integer RANGE frame boundary arithmetic from wrapping at the minimum and maximum values of TINYINT, SMALLINT, INT, and BIGINT. Out-of-domain search keys are now mapped to the correct insertion boundary for both ascending and descending order.

Add unit coverage for overflow, underflow, PRECEDING/FOLLOWING, and ASC/DESC behavior, plus a BVT covering all signed integer types, empty frames, and NULL peer groups.

Local validation:
- Window package unit tests
- Window package race tests
- Window package go vet
- Package coverage: 84.2%; changed statements: 52/52 (100%)
- BVT expected-result comparison repeated 3 times
- 500,010-row boundary validation repeated 2 times