### PR TITLE
fix: support empty subjects in regexp functions

### DIFF
--- a/pkg/sql/plan/function/func_builtin_regexp.go
+++ b/pkg/sql/plan/function/func_builtin_regexp.go
@@ -776,7 +776,7 @@ func (rs *regexpSet) regularMatchForLikeOpWithEscape(
 // return Nth (N = occurrence here) of match result
 func (rs *regexpSet) regularSubstr(pat string, str string, pos, occurrence int64) (match bool, substr string, err error) {
 	// check position
-	if pos < 1 || pos > int64(len(str)) {
+	if regexpSearchPositionOutOfBounds(str, pos) {
 		return false, "", moerr.NewInvalidInputNoCtxf("regexp_substr: Index out of bounds in regular expression search. Search start position: %d, Search string length: %d", pos, len(str))
 	}
 	// check occurrence
@@ -851,7 +851,7 @@ func (rs *regexpSet) regularReplace(pat string, str string, repl string, pos, oc
 // return 0 if match failed.
 func (rs *regexpSet) regularInstr(pat string, str string, pos, occurrence int64, retOption int8) (index int64, err error) {
 	// check position
-	if pos < 1 || pos > int64(len(str)) {
+	if regexpSearchPositionOutOfBounds(str, pos) {
 		return 0, moerr.NewInvalidInputNoCtxf("regexp_instr: Index out of bounds in regular expression search. Search start position: %d, Search string length: %d", pos, len(str))
 	}
 	// check occurrence
@@ -874,6 +874,11 @@ func (rs *regexpSet) regularInstr(pat string, str string, pos, occurrence int64,
 		return 0, nil
 	}
 	return int64(matches[occurrence-1][retOption]) + pos, nil
+}
+
+func regexpSearchPositionOutOfBounds(str string, pos int64) bool {
+	// Position 1 is the sole valid search start for an empty subject.
+	return pos < 1 || (pos > int64(len(str)) && !(len(str) == 0 && pos == 1))
 }
 
 func (rs *regexpSet) regularLike(pat string, str string, matchType string) (bool, error) {

--- a/pkg/sql/plan/function/func_builtin_regexp.go
+++ b/pkg/sql/plan/function/func_builtin_regexp.go
@@ -859,7 +859,7 @@ func (rs *regexpSet) regularInstr(pat string, str string, pos, occurrence int64,
 		return 0, moerr.NewInvalidInputNoCtxf("regexp_instr have Index out of bounds in regular expression search, return occurrence %d", occurrence)
 	}
 	// check retOption
-	if retOption > 1 {
+	if retOption < 0 || retOption > 1 {
 		return 0, moerr.NewInvalidInputNoCtxf("regexp_instr have Index out of bounds in regular expression search, return option %d", retOption)
 	}
 

--- a/pkg/sql/plan/function/func_builtin_regexp_test.go
+++ b/pkg/sql/plan/function/func_builtin_regexp_test.go
@@ -138,10 +138,38 @@ func Test_BuiltIn_RegexpEmptySubject(t *testing.T) {
 
 	_, err := op.regMap.regularInstr("^$", "", 1, 0, 0)
 	require.Error(t, err)
+	_, err = op.regMap.regularInstr("^$", "", 1, 1, -1)
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
 	_, err = op.regMap.regularInstr("^$", "", 1, 1, 2)
 	require.Error(t, err)
 	_, err = op.regMap.regularInstr("*", "", 1, 1, 0)
 	require.Error(t, err)
+
+	for _, tc := range []struct {
+		name    string
+		subject string
+		pattern string
+	}{
+		{name: "empty_subject", subject: "", pattern: "^$"},
+		{name: "nonempty_subject", subject: "Cat", pattern: "Cat"},
+	} {
+		t.Run("regexp_instr_negative_return_option_"+tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{tc.subject}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{tc.pattern}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{1}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{1}, nil),
+				NewFunctionTestInput(types.T_int8.ToType(), []int8{-1}, nil),
+			}
+			tcc := NewFunctionTestCase(proc, inputs,
+				NewFunctionTestResult(types.T_int64.ToType(), false, nil, nil),
+				op.builtInRegexpInstr)
+			_, err := tcc.DebugRun()
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+		})
+	}
 
 	_, _, err = op.regMap.regularSubstr("^$", "", 1, 0)
 	require.Error(t, err)

--- a/pkg/sql/plan/function/func_builtin_regexp_test.go
+++ b/pkg/sql/plan/function/func_builtin_regexp_test.go
@@ -67,6 +67,88 @@ func Test_BuiltIn_RegularInstr(t *testing.T) {
 	require.True(t, err != nil)
 }
 
+func Test_BuiltIn_RegexpEmptySubject(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	op := newOpBuiltInRegexp()
+
+	defaultInputs := []FunctionTestInput{
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"", "", "", ""}, []bool{false, false, true, false}),
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"^$", "x", "^$", "^$"}, []bool{false, false, false, true}),
+	}
+	for _, tc := range []struct {
+		name     string
+		fn       fEvalFn
+		expected FunctionTestResult
+	}{
+		{
+			name:     "regexp_instr_default_position",
+			fn:       op.builtInRegexpInstr,
+			expected: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{1, 0, 0, 0}, []bool{false, false, true, true}),
+		},
+		{
+			name:     "regexp_substr_default_position",
+			fn:       op.builtInRegexpSubstr,
+			expected: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"", "", "", ""}, []bool{false, true, true, true}),
+		},
+		{
+			name:     "regexp_like_control",
+			fn:       op.builtInRegexpLike,
+			expected: NewFunctionTestResult(types.T_bool.ToType(), false, []bool{true, false, false, false}, []bool{false, false, true, true}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tcc := NewFunctionTestCase(proc, defaultInputs, tc.expected, tc.fn)
+			succeed, errInfo := tcc.Run()
+			require.True(t, succeed, errInfo)
+		})
+	}
+
+	explicitInputs := append(defaultInputs[:2:2],
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{1, 1, 1, 1}, []bool{false, false, false, false}))
+	for _, tc := range []struct {
+		name     string
+		fn       fEvalFn
+		expected FunctionTestResult
+	}{
+		{
+			name:     "regexp_instr_explicit_position",
+			fn:       op.builtInRegexpInstr,
+			expected: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{1, 0, 0, 0}, []bool{false, false, true, true}),
+		},
+		{
+			name:     "regexp_substr_explicit_position",
+			fn:       op.builtInRegexpSubstr,
+			expected: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"", "", "", ""}, []bool{false, true, true, true}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tcc := NewFunctionTestCase(proc, explicitInputs, tc.expected, tc.fn)
+			succeed, errInfo := tcc.Run()
+			require.True(t, succeed, errInfo)
+		})
+	}
+
+	for _, pos := range []int64{0, 2} {
+		_, err := op.regMap.regularInstr("^$", "", pos, 1, 0)
+		require.Error(t, err)
+
+		_, _, err = op.regMap.regularSubstr("^$", "", pos, 1)
+		require.Error(t, err)
+	}
+
+	_, err := op.regMap.regularInstr("^$", "", 1, 0, 0)
+	require.Error(t, err)
+	_, err = op.regMap.regularInstr("^$", "", 1, 1, 2)
+	require.Error(t, err)
+	_, err = op.regMap.regularInstr("*", "", 1, 1, 0)
+	require.Error(t, err)
+
+	_, _, err = op.regMap.regularSubstr("^$", "", 1, 0)
+	require.Error(t, err)
+	_, _, err = op.regMap.regularSubstr("*", "", 1, 1)
+	require.Error(t, err)
+}
+
 func Test_BuiltIn_RegularLike(t *testing.T) {
 	op := newOpBuiltInRegexp()
 

--- a/test/distributed/cases/function/func_regular_instr.result
+++ b/test/distributed/cases/function/func_regular_instr.result
@@ -1,3 +1,18 @@
+SELECT REGEXP_LIKE('', '^$') AS like_control;
+like_control
+1
+SELECT REGEXP_INSTR('', '^$') AS default_pos_match;
+default_pos_match
+1
+SELECT REGEXP_INSTR('', 'x') AS default_pos_no_match;
+default_pos_no_match
+0
+SELECT REGEXP_INSTR('', '^$', 1) AS explicit_pos_match;
+explicit_pos_match
+1
+SELECT REGEXP_INSTR('', 'x', 1) AS explicit_pos_no_match;
+explicit_pos_no_match
+0
 SELECT REGEXP_INSTR('Cat', 'at') Result;
 result
 2

--- a/test/distributed/cases/function/func_regular_instr.test
+++ b/test/distributed/cases/function/func_regular_instr.test
@@ -1,10 +1,16 @@
+SELECT REGEXP_LIKE('', '^$') AS like_control;
+SELECT REGEXP_INSTR('', '^$') AS default_pos_match;
+SELECT REGEXP_INSTR('', 'x') AS default_pos_no_match;
+SELECT REGEXP_INSTR('', '^$', 1) AS explicit_pos_match;
+SELECT REGEXP_INSTR('', 'x', 1) AS explicit_pos_no_match;
+
 SELECT REGEXP_INSTR('Cat', 'at') Result;
 SELECT REGEXP_INSTR('Cat', '^at') Result;
 SELECT REGEXP_INSTR('at', '^at') Result;
 SELECT REGEXP_INSTR('Cat Cat', 'Cat', 2) Result;
 
 SELECT REGEXP_INSTR('Cat Cat', 'Cat', 2) AS 'Pos2';
-SELECT REGEXP_INSTR('Cat Cat', 'Cat', 3) AS 'Pos3'; 
+SELECT REGEXP_INSTR('Cat Cat', 'Cat', 3) AS 'Pos3';
 SELECT REGEXP_INSTR('Cat Cat', 'Cat', 5) AS 'Pos5';
 
 SELECT REGEXP_INSTR('Cat City is SO Cute!', 'C.t', 1) 'Pos1';

--- a/test/distributed/cases/function/func_regular_substr.result
+++ b/test/distributed/cases/function/func_regular_substr.result
@@ -1,3 +1,15 @@
+SELECT REGEXP_SUBSTR('', '^$') = '' AS default_pos_match;
+default_pos_match
+1
+SELECT REGEXP_SUBSTR('', 'x') IS NULL AS default_pos_no_match;
+default_pos_no_match
+1
+SELECT REGEXP_SUBSTR('', '^$', 1) = '' AS explicit_pos_match;
+explicit_pos_match
+1
+SELECT REGEXP_SUBSTR('', 'x', 1) IS NULL AS explicit_pos_no_match;
+explicit_pos_no_match
+1
 SELECT REGEXP_SUBSTR('Thailand or Cambodia', 'l.nd') Result;
 result
 land

--- a/test/distributed/cases/function/func_regular_substr.test
+++ b/test/distributed/cases/function/func_regular_substr.test
@@ -1,3 +1,8 @@
+SELECT REGEXP_SUBSTR('', '^$') = '' AS default_pos_match;
+SELECT REGEXP_SUBSTR('', 'x') IS NULL AS default_pos_no_match;
+SELECT REGEXP_SUBSTR('', '^$', 1) = '' AS explicit_pos_match;
+SELECT REGEXP_SUBSTR('', 'x', 1) IS NULL AS explicit_pos_no_match;
+
 SELECT REGEXP_SUBSTR('Thailand or Cambodia', 'l.nd') Result;
 
 SELECT REGEXP_SUBSTR('Lend for land', '^C') Result;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27573

## What this PR does / why we need it:

Allow position 1 as the sole valid search start for an empty subject in `REGEXP_INSTR` and `REGEXP_SUBSTR`. This lets zero-length patterns such as `^$` reach the regular expression engine while preserving errors for position 0, position 2, and other out-of-range positions.

The change keeps the existing semantics for non-empty subjects, NULL propagation, no-match results (`0` for `REGEXP_INSTR`, NULL for `REGEXP_SUBSTR`), invalid occurrences, invalid return options, and invalid patterns.

Regression coverage includes matching and non-matching patterns, default and explicit positions, NULL inputs, invalid positions, and `REGEXP_LIKE` controls. Distributed SQL fixtures and expected result files are updated in matching command order.

Validation:

- Reproduced the original rejection twice on an unmodified latest `origin/main` worktree.
- `go test ./... -count=1` in `pkg/sql/plan/function`
- `go test -race ./... -count=1` in `pkg/sql/plan/function`
- `go vet ./...` in `pkg/sql/plan/function`
- Changed functions have 100% statement coverage.
- `make config`
- `make err-check`
- `git diff --check`
- Two rounds of 16 focused SQL assertions against an isolated MatrixOne process built from this head.

The full Java `mo-tester` BVT harness was not run locally because the host has no JRE and dependencies were intentionally not downloaded. The corresponding BVT SQL and result fixtures are included for CI execution.
