### PR TITLE
fix(taskservice): atomically register cron tasks

### DIFF
--- a/pkg/taskservice/mysql_task_storage.go
+++ b/pkg/taskservice/mysql_task_storage.go
@@ -88,6 +88,12 @@ var (
 		"create_at," +
 		"update_at) values "
 
+	// cronTaskOnDuplicate is intentionally a no-op. Built-in cron tasks are
+	// registered independently by every CN, while task_metadata_id is unique.
+	// Preserving the winner's schedule state makes that registration atomic and
+	// idempotent without hiding non-duplicate SQL errors.
+	cronTaskOnDuplicate = " on duplicate key update cron_expr=cron_expr"
+
 	selectCronTask = "select " +
 		"cron_task_id," +
 		"task_metadata_id," +
@@ -558,17 +564,9 @@ func (m *mysqlTaskStorage) AddCronTask(ctx context.Context, cronTask ...task.Cro
 			t.UpdateAt,
 		)
 	}
-	exec, err := m.db.ExecContext(ctx, sqlStr[:len(sqlStr)-1], vals...)
+	exec, err := m.db.ExecContext(ctx, sqlStr[:len(sqlStr)-1]+cronTaskOnDuplicate, vals...)
 	if err != nil {
-		dup, err := removeDuplicateCronTasks(err, cronTask)
-		if err != nil {
-			return 0, err
-		}
-		add, err := m.AddCronTask(ctx, dup...)
-		if err != nil {
-			return add, err
-		}
-		return add, nil
+		return 0, err
 	}
 	affected, err := exec.RowsAffected()
 	if err != nil {
@@ -1410,23 +1408,6 @@ func sqlTaskEnabledValue(v bool) uint8 {
 }
 
 func removeDuplicateAsyncTasks(err error, tasks []task.AsyncTask) ([]task.AsyncTask, error) {
-	var me *mysql.MySQLError
-	if ok := errors.As(err, &me); !ok {
-		return nil, err
-	}
-	if me.Number != moerr.ER_DUP_ENTRY {
-		return nil, err
-	}
-	b := tasks[:0]
-	for _, t := range tasks {
-		if !strings.Contains(me.Message, t.Metadata.ID) {
-			b = append(b, t)
-		}
-	}
-	return b, nil
-}
-
-func removeDuplicateCronTasks(err error, tasks []task.CronTask) ([]task.CronTask, error) {
 	var me *mysql.MySQLError
 	if ok := errors.As(err, &me); !ok {
 		return nil, err

--- a/pkg/taskservice/mysql_task_storage_test.go
+++ b/pkg/taskservice/mysql_task_storage_test.go
@@ -252,7 +252,7 @@ func TestAsyncTaskInSqlMock(t *testing.T) {
 
 func TestCronTaskInSqlMock(t *testing.T) {
 	storage, mock := newMockStorage(t)
-	mock.ExpectExec(insertCronTask+"(?, ?, ?, ?, ?, ?, ?, ?, ?)").
+	mock.ExpectExec(insertCronTask+"(?, ?, ?, ?, ?, ?, ?, ?, ?)"+" on duplicate key update cron_expr=cron_expr").
 		WithArgs("a", 0, []byte(nil), "{}", "mock_cron_expr", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -890,10 +890,6 @@ func TestRemoveDuplicateTasks(t *testing.T) {
 		{Metadata: task.TaskMetadata{ID: "a"}},
 		{Metadata: task.TaskMetadata{ID: "b"}},
 	}
-	cronTasks := []task.CronTask{
-		{Metadata: task.TaskMetadata{ID: "a"}},
-		{Metadata: task.TaskMetadata{ID: "b"}},
-	}
 	daemonTasks := []task.DaemonTask{
 		{Metadata: task.TaskMetadata{ID: "a"}},
 		{Metadata: task.TaskMetadata{ID: "b"}},
@@ -910,19 +906,12 @@ func TestRemoveDuplicateTasks(t *testing.T) {
 	require.Len(t, remainingAsync, 1)
 	require.Equal(t, "b", remainingAsync[0].Metadata.ID)
 
-	remainingCron, err := removeDuplicateCronTasks(dupErr, cronTasks)
-	require.NoError(t, err)
-	require.Len(t, remainingCron, 1)
-	require.Equal(t, "b", remainingCron[0].Metadata.ID)
-
 	remainingDaemon, err := removeDuplicateDaemonTasks(dupErr, daemonTasks)
 	require.NoError(t, err)
 	require.Len(t, remainingDaemon, 1)
 	require.Equal(t, "b", remainingDaemon[0].Metadata.ID)
 
 	_, err = removeDuplicateAsyncTasks(otherErr, asyncTasks)
-	require.Error(t, err)
-	_, err = removeDuplicateCronTasks(otherErr, cronTasks)
 	require.Error(t, err)
 	_, err = removeDuplicateDaemonTasks(otherErr, daemonTasks)
 	require.Error(t, err)
@@ -952,23 +941,46 @@ func TestAddAsyncTaskWithDuplicateEntry(t *testing.T) {
 	require.NoError(t, storage.Close())
 }
 
-func TestAddCronTaskWithDuplicateEntry(t *testing.T) {
-	storage, mock := newMockStorage(t)
+func TestAddCronTaskAtomicallyIgnoresDuplicateMetadata(t *testing.T) {
+	for _, taskMetadataID := range []string{"data_branch_lineage_gc", "mo_table_stats"} {
+		t.Run(taskMetadataID, func(t *testing.T) {
+			storage, mock := newMockStorage(t)
+			cronTask := newTestCronTask(taskMetadataID, "0 */5 * * * *")
+			// A zero affected-row count models a concurrent CN winning the unique-key
+			// insert first. The storage must issue one atomic no-op upsert, not receive
+			// a duplicate-key error and retry a second statement.
+			mock.ExpectExec(insertCronTask+"(?, ?, ?, ?, ?, ?, ?, ?, ?)"+" on duplicate key update cron_expr=cron_expr").
+				WithArgs(
+					cronTask.Metadata.ID,
+					cronTask.Metadata.Executor,
+					cronTask.Metadata.Context,
+					"{}",
+					cronTask.CronExpr,
+					sqlmock.AnyArg(),
+					sqlmock.AnyArg(),
+					sqlmock.AnyArg(),
+					sqlmock.AnyArg(),
+				).
+				WillReturnResult(sqlmock.NewResult(0, 0))
 
-	c1 := newTestCronTask("cron-a", "* * * * * *")
-	c2 := newTestCronTask("cron-b", "* * * * * *")
-	dupErr := &mysqlDriver.MySQLError{
-		Number:  moerr.ER_DUP_ENTRY,
-		Message: "Duplicate entry 'cron-a' for key",
+			affected, err := storage.AddCronTask(context.Background(), cronTask)
+			require.NoError(t, err)
+			require.Zero(t, affected)
+
+			mock.ExpectClose()
+			require.NoError(t, storage.Close())
+		})
 	}
-	mock.ExpectExec(insertCronTask + "(?, ?, ?, ?, ?, ?, ?, ?, ?),(?, ?, ?, ?, ?, ?, ?, ?, ?)").
-		WillReturnError(dupErr)
-	mock.ExpectExec(insertCronTask + "(?, ?, ?, ?, ?, ?, ?, ?, ?)").
-		WillReturnResult(sqlmock.NewResult(1, 1))
+}
 
-	affected, err := storage.AddCronTask(context.Background(), c1, c2)
-	require.NoError(t, err)
-	require.Equal(t, 1, affected)
+func TestAddCronTaskPropagatesSQLFailure(t *testing.T) {
+	storage, mock := newMockStorage(t)
+	cronTask := newTestCronTask("data_branch_lineage_gc", "0 */5 * * * *")
+	mock.ExpectExec(insertCronTask + "(?, ?, ?, ?, ?, ?, ?, ?, ?)" + " on duplicate key update cron_expr=cron_expr").
+		WillReturnError(assert.AnError)
+
+	_, err := storage.AddCronTask(context.Background(), cronTask)
+	require.ErrorIs(t, err, assert.AnError)
 
 	mock.ExpectClose()
 	require.NoError(t, storage.Close())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26704

## What this PR does / why we need it:

### Root cause

Every CN registers the built-in cron tasks during startup. `sys_cron_task.task_metadata_id` is unique, so competing plain INSERTs reached the SQL duplicate-key error path. The old storage layer parsed that error and retried, so the persisted task was normally correct but startup still emitted a misleading ERROR log. A fresh 3-CN partition run confirms the reported initialization failure does not occur after the atomic registration.

### Changes

- Make `mysqlTaskStorage.AddCronTask` issue one INSERT ... ON DUPLICATE KEY UPDATE `cron_expr=cron_expr` statement.
- Keep the duplicate branch deliberately no-op, preserving the first CN's executor, schedule, next time, trigger count, and timestamps.
- Remove duplicate-error parsing and recursive retry for cron-task insertion; unrelated SQL failures still return to the caller.

### Issue-to-test proof

- `TestAddCronTaskAtomicallyIgnoresDuplicateMetadata` explicitly covers both `data_branch_lineage_gc` and `mo_table_stats`: a losing CN gets a zero-row no-op result from one atomic statement, with no retry.
- `TestAddCronTaskPropagatesSQLFailure` proves that non-duplicate database failures remain observable.
- `TestAffectedRows` exercises the issue's fresh three-CN partition configuration. It passed and its complete log contains neither target duplicate-entry error nor a data-branch initialization failure.

### Tests

- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^(TestCronTaskInSqlMock|TestAddCronTaskAtomicallyIgnoresDuplicateMetadata|TestAddCronTaskPropagatesSQLFailure|TestRemoveDuplicateTasks)$' ./pkg/taskservice`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=120s -run '^TestAddCronTaskAtomicallyIgnoresDuplicateMetadata$' ./pkg/taskservice`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s ./pkg/taskservice`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=240s ./pkg/taskservice`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=300s -run '^TestAffectedRows$' ./pkg/tests/partition`
- `go build -mod=readonly ./pkg/taskservice`
- `go vet -mod=readonly ./pkg/taskservice`

### Residual risk

No schema or migration changes are required. This uses MatrixOne's existing no-op ON DUPLICATE KEY UPDATE semantics, already covered for a secondary unique-key conflict in `test/distributed/cases/dml/insert/on_duplicate_key_modern.sql`; the first successfully inserted task remains authoritative.