### PR TITLE
test: replace fulltext2 BVT sleeps with readiness waits

### DIFF
--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_async.result
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_async.result
@@ -10,9 +10,30 @@ insert into src values (0, 'color is red', 't1'), (1, 'car is yellow', 'crazy ca
 (10, NULL, NULL);
 create table src2 (id1 varchar, id2 bigint, body char(128), title text, primary key (id1, id2), FULLTEXT2 ftidx(body, title));
 insert into src2 values ('id0', 0, 'red', 't1'), ('id1', 1, 'yellow', 't2'), ('id2', 2, 'blue', 't3'), ('id3', 3, 'blue red', 't4'), ('id4', 4, 'bright red null', NULL);
-select sleep(30);
-sleep(30)
-0
+set @src_ft2_index = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ftidx' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @src2_ft2_index = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ftidx' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src2')
+limit 1
+);
+set @wait_initial_ft2_sql = concat(
+'select ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src_ft2_index,
+'` where index_id = ''cdc_tail'' and tag = 1) as src_ready, ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src2_ft2_index,
+'` where index_id = ''cdc_tail'' and tag = 1) as src2_ready'
+);
+prepare wait_initial_ft2 from @wait_initial_ft2_sql;
+execute wait_initial_ft2;
+➤ src_ready[-7,1,0]  ¦  src2_ready[-7,1,0]  𝄀
+1  ¦  1
+deallocate prepare wait_initial_ft2;
 show create table src;
 Table    Create Table
 src    CREATE TABLE `src` (\n  `id` bigint NOT NULL,\n  `body` varchar(65535) DEFAULT NULL,\n  `title` text DEFAULT NULL,\n  PRIMARY KEY (`id`),\n FULLTEXT2 `ftidx`(`body`,`title`) WITH PARSER ngram\n)
@@ -23,11 +44,42 @@ id3    3
 show create table src2;
 Table    Create Table
 src2    CREATE TABLE `src2` (\n  `id1` varchar(65535) NOT NULL,\n  `id2` bigint NOT NULL,\n  `body` char(128) DEFAULT NULL,\n  `title` text DEFAULT NULL,\n  PRIMARY KEY (`id1`,`id2`),\n FULLTEXT2 `ftidx`(`body`,`title`) WITH PARSER ngram\n)
+set @capture_src_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @src_tail_before_mutation from `', database(), '`.`', @src_ft2_index,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_tail from @capture_src_tail_sql;
+execute capture_src_tail;
+deallocate prepare capture_src_tail;
 update src set body = 'color is green' where id = 0;
+set @wait_src_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @src_tail_before_mutation,
+' as src_update_ready from `', database(), '`.`', @src_ft2_index,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_mutation from @wait_src_mutation_sql;
+execute wait_src_mutation;
+➤ src_update_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_src_mutation;
+set @capture_src_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @src_tail_before_mutation from `', database(), '`.`', @src_ft2_index,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_tail from @capture_src_tail_sql;
+execute capture_src_tail;
+deallocate prepare capture_src_tail;
 delete from src where id = 3;
-select sleep(30);
-sleep(30)
-0
+set @wait_src_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @src_tail_before_mutation,
+' as src_delete_ready from `', database(), '`.`', @src_ft2_index,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_mutation from @wait_src_mutation_sql;
+execute wait_src_mutation;
+➤ src_delete_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_src_mutation;
 select id from src where match(body, title) against('red') order by id;
 id
 select id from src where match(body, title) against('green') order by id;

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_async.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_async.sql
@@ -1,8 +1,8 @@
 -- fulltext2 CDC (always-async) — ported from pessimistic_transaction/fulltext
 -- (fulltext_async). fulltext2 is AlwaysAsync (no ASYNC keyword): the inline index
 -- builds an empty tag=0 base at CREATE, then post-create INSERT/UPDATE/DELETE flow
--- into the tag=1 CdcTail via ISCP CDC. sleep() waits for CDC to settle, then MATCH
--- reflects the mutations.
+-- into the tag=1 CdcTail via ISCP CDC. Poll that durable tail before MATCH so the
+-- test waits only as long as needed and cannot silently search before CDC settles.
 
 -- CREATE FULLTEXT2 INDEX is gated behind experimental_fulltext2_index (default off).
 set experimental_fulltext2_index = 1;
@@ -24,8 +24,32 @@ create table src2 (id1 varchar, id2 bigint, body char(128), title text, primary 
 
 insert into src2 values ('id0', 0, 'red', 't1'), ('id1', 1, 'yellow', 't2'), ('id2', 2, 'blue', 't3'), ('id3', 3, 'blue red', 't4'), ('id4', 4, 'bright red null', NULL);
 
--- wait for the initial CDC sync of src and src2
-select sleep(30);
+-- Wait for the initial CDC sync of src and src2. Do not poll MATCH: an early
+-- MATCH can pin a stale per-CN cache. A cdc_tail chunk is the durable readiness
+-- signal produced in the same transaction that advances the CDC watermark.
+set @src_ft2_index = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ftidx' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @src2_ft2_index = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ftidx' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src2')
+    limit 1
+);
+set @wait_initial_ft2_sql = concat(
+    'select ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src_ft2_index,
+    '` where index_id = ''cdc_tail'' and tag = 1) as src_ready, ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src2_ft2_index,
+    '` where index_id = ''cdc_tail'' and tag = 1) as src2_ready'
+);
+prepare wait_initial_ft2 from @wait_initial_ft2_sql;
+-- @wait_expect(2, 120)
+execute wait_initial_ft2;
+deallocate prepare wait_initial_ft2;
 
 -- src's initial-sync state is verified via src2 below (a never-re-mutated table).
 -- src itself is deliberately NOT searched here: fulltext2's per-CN index cache is
@@ -40,9 +64,40 @@ select id1, id2 from src2 where match(body, title) against('red') order by id1;
 show create table src2;
 
 -- post-create UPDATE + DELETE flow through CDC too
+set @capture_src_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @src_tail_before_mutation from `', database(), '`.`', @src_ft2_index,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_tail from @capture_src_tail_sql;
+execute capture_src_tail;
+deallocate prepare capture_src_tail;
 update src set body = 'color is green' where id = 0;
+set @wait_src_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @src_tail_before_mutation,
+    ' as src_update_ready from `', database(), '`.`', @src_ft2_index,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_mutation from @wait_src_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_src_mutation;
+deallocate prepare wait_src_mutation;
+set @capture_src_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @src_tail_before_mutation from `', database(), '`.`', @src_ft2_index,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_tail from @capture_src_tail_sql;
+execute capture_src_tail;
+deallocate prepare capture_src_tail;
 delete from src where id = 3;
-select sleep(30);
+set @wait_src_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @src_tail_before_mutation,
+    ' as src_delete_ready from `', database(), '`.`', @src_ft2_index,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_mutation from @wait_src_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_src_mutation;
+deallocate prepare wait_src_mutation;
 
 -- doc 0's old text (red) is superseded, doc 3 is deleted -> 'red' now empty.
 -- This is src's FIRST MATCH, so its per-CN cache loads the fresh post-update index.

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_bugfix.result
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_bugfix.result
@@ -14,9 +14,22 @@ insert into j1 values (1,'{"title":"quantum physics","tag":"science"}'), (2,'{"t
 create table j2 (id bigint primary key, a json, b json);
 create fulltext2 index ftidx on j2(a,b) with parser json;
 insert into j2 values (1,'{"x":"hello world"}','{"y":"foo bar"}'), (2,'{"x":"lorem ipsum"}','{"y":"dolor sit"}');
-select sleep(45);
-sleep(45)
-0
+set @pk_dt_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'pk_dt') limit 1);
+set @pk_dec_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'pk_dec') limit 1);
+set @j1_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'j1') limit 1);
+set @j2_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'j2') limit 1);
+set @wait_bugfix_initial_sql = concat(
+'select ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @pk_dt_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as pk_dt_ready, ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @pk_dec_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as pk_dec_ready, ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @j1_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as j1_ready, ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @j2_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as j2_ready'
+);
+prepare wait_bugfix_initial from @wait_bugfix_initial_sql;
+execute wait_bugfix_initial;
+➤ pk_dt_ready[-7,1,0]  ¦  pk_dec_ready[-7,1,0]  ¦  j1_ready[-7,1,0]  ¦  j2_ready[-7,1,0]  𝄀
+1  ¦  1  ¦  1  ¦  1
+deallocate prepare wait_bugfix_initial;
 select id from pk_dt where match(body) against('beta') order by id;
 id
 2020-01-02 03:04:05
@@ -46,9 +59,16 @@ id
 create table reb (id bigint primary key, body text);
 create fulltext2 index ftidx on reb(body);
 insert into reb values (1,'stale zebra'),(2,'stale zebra');
-select sleep(45);
-sleep(45)
-0
+set @reb_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'reb') limit 1);
+set @wait_reb_initial_sql = concat(
+'select coalesce(max(chunk_id), -1) >= 0 as reb_ready from `', database(), '`.`', @reb_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_reb_initial from @wait_reb_initial_sql;
+execute wait_reb_initial;
+➤ reb_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_reb_initial;
 select count(*) from reb where match(body) against('zebra');
 count(*)
 2

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_bugfix.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_bugfix.sql
@@ -8,7 +8,7 @@
 --   #6 REBUILD over an emptied table drops the stale tag=0 base — no longer serves
 --      deleted docs when the rebuild sees zero source rows.
 -- All four are CDC/async-path bugs, so the index is created on an empty table and the
--- rows flow in through ISCP CDC; sleep() waits for CDC to settle.
+-- rows flow in through ISCP CDC; durable tail polling waits for the exact work.
 set experimental_fulltext2_index = 1;
 drop database if exists ft2_bugfix;
 create database ft2_bugfix;
@@ -34,8 +34,23 @@ create table j2 (id bigint primary key, a json, b json);
 create fulltext2 index ftidx on j2(a,b) with parser json;
 insert into j2 values (1,'{"x":"hello world"}','{"y":"foo bar"}'), (2,'{"x":"lorem ipsum"}','{"y":"dolor sit"}');
 
--- wait for the initial CDC drain of all four tables
-select sleep(45);
+-- Wait for every table's committed CDC tail. One completed table is not enough:
+-- each independent writer must persist a chunk before its semantic checks run.
+set @pk_dt_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'pk_dt') limit 1);
+set @pk_dec_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'pk_dec') limit 1);
+set @j1_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'j1') limit 1);
+set @j2_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'j2') limit 1);
+set @wait_bugfix_initial_sql = concat(
+    'select ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @pk_dt_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as pk_dt_ready, ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @pk_dec_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as pk_dec_ready, ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @j1_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as j1_ready, ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @j2_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as j2_ready'
+);
+prepare wait_bugfix_initial from @wait_bugfix_initial_sql;
+-- @wait_expect(2, 120)
+execute wait_bugfix_initial;
+deallocate prepare wait_bugfix_initial;
 
 -- #1: both temporal/decimal-PK tables searchable => the consumer did not crash
 select id from pk_dt where match(body) against('beta') order by id;
@@ -55,7 +70,15 @@ select id from j2 where match(a,b) against('dolor') order by id;
 create table reb (id bigint primary key, body text);
 create fulltext2 index ftidx on reb(body);
 insert into reb values (1,'stale zebra'),(2,'stale zebra');
-select sleep(45);
+set @reb_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'reb') limit 1);
+set @wait_reb_initial_sql = concat(
+    'select coalesce(max(chunk_id), -1) >= 0 as reb_ready from `', database(), '`.`', @reb_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_reb_initial from @wait_reb_initial_sql;
+-- @wait_expect(2, 120)
+execute wait_reb_initial;
+deallocate prepare wait_reb_initial;
 -- both rows searchable before the rebuild
 select count(*) from reb where match(body) against('zebra');
 -- empty the table, then REBUILD (rebuilds the base from the now-empty source)

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink.result
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink.result
@@ -2,9 +2,16 @@ set experimental_fulltext2_index = 1;
 create stage ft2stage URL='file://$resources/fulltext/';
 create table dl (id bigint primary key, fpath datalink, FULLTEXT2 ftidx(fpath));
 insert into dl values (0, 'stage://ft2stage/mo.pdf'), (1, 'stage://ft2stage/chinese.pdf');
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @dl_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dl') limit 1);
+set @wait_dl_initial_sql = concat(
+'select coalesce(max(chunk_id), -1) >= 0 as dl_ready from `', database(), '`.`', @dl_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_dl_initial from @wait_dl_initial_sql;
+execute wait_dl_initial;
+➤ dl_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_dl_initial;
 select id from dl where match(fpath) against('matrixone');
 ➤ id[-5,64,0]  𝄀
 0
@@ -17,13 +24,34 @@ select id from dl where match(fpath) against('mo');
 ➤ id[-5,64,0]
 create table dl2 (id bigint primary key, fpath datalink, FULLTEXT2 ftidx(fpath));
 insert into dl2 values (0, 'stage://ft2stage/mo.pdf');
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @dl2_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dl2') limit 1);
+set @wait_dl2_initial_sql = concat(
+'select coalesce(max(chunk_id), -1) >= 0 as dl2_ready from `', database(), '`.`', @dl2_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_dl2_initial from @wait_dl2_initial_sql;
+execute wait_dl2_initial;
+➤ dl2_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_dl2_initial;
+set @capture_dl2_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @dl2_tail_before_update from `', database(), '`.`', @dl2_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_dl2_tail from @capture_dl2_tail_sql;
+execute capture_dl2_tail;
+deallocate prepare capture_dl2_tail;
 update dl2 set fpath='stage://ft2stage/file-sample_100kB.docx' where id=0;
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @wait_dl2_update_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @dl2_tail_before_update,
+' as dl2_update_ready from `', database(), '`.`', @dl2_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_dl2_update from @wait_dl2_update_sql;
+execute wait_dl2_update;
+➤ dl2_update_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_dl2_update;
 select id from dl2 where match(fpath) against('Nulla facilisi' in natural language mode);
 ➤ id[-5,64,0]  𝄀
 0

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink.sql
@@ -4,9 +4,9 @@
 -- inline index builds an empty tag=0 base at CREATE and the datalink rows below flow through
 -- ISCP CDC; the fulltext2 CDC writer resolves each datalink via SELECT load_text(...) run by
 -- the internal SQL executor (which has a full proc: FileService + catalog for stage://).
--- sleep() waits for CDC to settle (the per-CN search cache is not cross-invalidated, so a
--- too-early MATCH can pin a stale snapshot), then MATCH against the file CONTENT must find
--- them. Regression guard for the CDC-vs-build datalink parity fix.
+-- durable cdc_tail polling waits for CDC to settle (the per-CN search cache is not
+-- cross-invalidated, so a too-early MATCH can pin a stale snapshot), then MATCH against
+-- the file CONTENT must find them. Regression guard for CDC-vs-build datalink parity.
 set experimental_fulltext2_index = 1;
 
 create stage ft2stage URL='file://$resources/fulltext/';
@@ -16,7 +16,15 @@ create stage ft2stage URL='file://$resources/fulltext/';
 -- chinese.pdf contains '慢慢地'.
 create table dl (id bigint primary key, fpath datalink, FULLTEXT2 ftidx(fpath));
 insert into dl values (0, 'stage://ft2stage/mo.pdf'), (1, 'stage://ft2stage/chinese.pdf');
-select sleep(30);
+set @dl_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dl') limit 1);
+set @wait_dl_initial_sql = concat(
+    'select coalesce(max(chunk_id), -1) >= 0 as dl_ready from `', database(), '`.`', @dl_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_dl_initial from @wait_dl_initial_sql;
+-- @wait_expect(2, 120)
+execute wait_dl_initial;
+deallocate prepare wait_dl_initial;
 
 -- CDC must have indexed the resolved CONTENT, not the URL string.
 select id from dl where match(fpath) against('matrixone');
@@ -32,9 +40,32 @@ select id from dl where match(fpath) against('mo');
 -- new file's terms.
 create table dl2 (id bigint primary key, fpath datalink, FULLTEXT2 ftidx(fpath));
 insert into dl2 values (0, 'stage://ft2stage/mo.pdf');
-select sleep(30);
+set @dl2_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dl2') limit 1);
+set @wait_dl2_initial_sql = concat(
+    'select coalesce(max(chunk_id), -1) >= 0 as dl2_ready from `', database(), '`.`', @dl2_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_dl2_initial from @wait_dl2_initial_sql;
+-- @wait_expect(2, 120)
+execute wait_dl2_initial;
+deallocate prepare wait_dl2_initial;
+set @capture_dl2_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @dl2_tail_before_update from `', database(), '`.`', @dl2_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_dl2_tail from @capture_dl2_tail_sql;
+execute capture_dl2_tail;
+deallocate prepare capture_dl2_tail;
 update dl2 set fpath='stage://ft2stage/file-sample_100kB.docx' where id=0;
-select sleep(30);
+set @wait_dl2_update_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @dl2_tail_before_update,
+    ' as dl2_update_ready from `', database(), '`.`', @dl2_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_dl2_update from @wait_dl2_update_sql;
+-- @wait_expect(2, 120)
+execute wait_dl2_update;
+deallocate prepare wait_dl2_update;
 
 -- id 0's content is now the docx ('Nulla facilisi'); the old mo.pdf 'matrixone' is gone.
 select id from dl2 where match(fpath) against('Nulla facilisi' in natural language mode);

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink_tenant.result
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink_tenant.result
@@ -6,9 +6,16 @@ use ft2db;
 create stage ft2stage URL='file://$resources/fulltext/';
 create table dl (id bigint primary key, fpath datalink, FULLTEXT2 ftidx(fpath));
 insert into dl values (0, 'stage://ft2stage/mo.pdf'), (1, 'stage://ft2stage/chinese.pdf');
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @dl_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dl') limit 1);
+set @wait_tenant_dl_sql = concat(
+'select coalesce(max(chunk_id), -1) >= 0 as tenant_dl_ready from `', database(), '`.`', @dl_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_tenant_dl from @wait_tenant_dl_sql;
+execute wait_tenant_dl;
+➤ tenant_dl_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_tenant_dl;
 select id from dl where match(fpath) against('matrixone');
 ➤ id[-5,64,0]  𝄀
 0

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink_tenant.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_datalink_tenant.sql
@@ -17,7 +17,17 @@ use ft2db;
 create stage ft2stage URL='file://$resources/fulltext/';
 create table dl (id bigint primary key, fpath datalink, FULLTEXT2 ftidx(fpath));
 insert into dl values (0, 'stage://ft2stage/mo.pdf'), (1, 'stage://ft2stage/chinese.pdf');
-select sleep(30);
+-- Poll the tenant-owned hidden tail from the tenant session. This proves that
+-- its CDC writer resolved and durably indexed the rows before the first MATCH.
+set @dl_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dl') limit 1);
+set @wait_tenant_dl_sql = concat(
+    'select coalesce(max(chunk_id), -1) >= 0 as tenant_dl_ready from `', database(), '`.`', @dl_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_tenant_dl from @wait_tenant_dl_sql;
+-- @wait_expect(2, 120)
+execute wait_tenant_dl;
+deallocate prepare wait_tenant_dl;
 
 -- CDC must have resolved the datalink CONTENT under this tenant's mo_stages: 'matrixone'
 -- (mo.pdf), '慢慢地' (chinese.pdf). If the resolver ran under System_Account, the tenant's

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_include_async.result
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_include_async.result
@@ -12,9 +12,18 @@ insert into src_upd values
 (10, 'silver fox hunts', 'active',   100),
 (11, 'golden fox naps',  'active',   200),
 (12, 'bronze fox digs',  'archived', 300);
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @src_ins_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src_ins') limit 1);
+set @src_upd_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src_upd') limit 1);
+set @wait_include_initial_sql = concat(
+'select ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src_ins_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as src_ins_ready, ',
+'(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src_upd_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as src_upd_ready'
+);
+prepare wait_include_initial from @wait_include_initial_sql;
+execute wait_include_initial;
+➤ src_ins_ready[-7,1,0]  ¦  src_upd_ready[-7,1,0]  𝄀
+1  ¦  1
+deallocate prepare wait_include_initial;
 select id, status, prio from src_ins where match(body) against('fox') order by id;
 ➤ id[-5,64,0]  ¦  status[12,20,0]  ¦  prio[4,32,0]  𝄀
 1  ¦  active  ¦  10  𝄀
@@ -28,11 +37,42 @@ select id, prio from src_ins where match(body) against('fox') and prio > 15 orde
 ➤ id[-5,64,0]  ¦  prio[4,32,0]  𝄀
 2  ¦  20  𝄀
 3  ¦  30
+set @capture_src_upd_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @src_upd_tail_before_mutation from `', database(), '`.`', @src_upd_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_upd_tail from @capture_src_upd_tail_sql;
+execute capture_src_upd_tail;
+deallocate prepare capture_src_upd_tail;
 update src_upd set status = 'archived', prio = 999 where id = 10;
+set @wait_src_upd_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @src_upd_tail_before_mutation,
+' as src_upd_update_ready from `', database(), '`.`', @src_upd_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_upd_mutation from @wait_src_upd_mutation_sql;
+execute wait_src_upd_mutation;
+➤ src_upd_update_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_src_upd_mutation;
+set @capture_src_upd_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @src_upd_tail_before_mutation from `', database(), '`.`', @src_upd_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_upd_tail from @capture_src_upd_tail_sql;
+execute capture_src_upd_tail;
+deallocate prepare capture_src_upd_tail;
 delete from src_upd where id = 11;
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @wait_src_upd_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @src_upd_tail_before_mutation,
+' as src_upd_delete_ready from `', database(), '`.`', @src_upd_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_upd_mutation from @wait_src_upd_mutation_sql;
+execute wait_src_upd_mutation;
+➤ src_upd_delete_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_src_upd_mutation;
 select id, status, prio from src_upd where match(body) against('fox') order by id;
 ➤ id[-5,64,0]  ¦  status[12,20,0]  ¦  prio[4,32,0]  𝄀
 10  ¦  archived  ¦  999  𝄀
@@ -51,13 +91,37 @@ FULLTEXT2 ftidx (body) INCLUDE (status, prio));
 insert into src_phantom values
 (20, 'silver fox alpha', 'active', 500),
 (21, 'golden fox beta',  'active', 600);
+set @src_phantom_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src_phantom') limit 1);
+set @wait_phantom_initial_sql = concat(
+'select coalesce(max(chunk_id), -1) >= 0 as src_phantom_ready from `', database(), '`.`', @src_phantom_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_phantom_initial from @wait_phantom_initial_sql;
+execute wait_phantom_initial;
+➤ src_phantom_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_phantom_initial;
+set @capture_phantom_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @phantom_tail_before_mutation from `', database(), '`.`', @src_phantom_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_phantom_tail from @capture_phantom_tail_sql;
+execute capture_phantom_tail;
+deallocate prepare capture_phantom_tail;
 begin;
 update src_phantom set body = 'silver fox gamma', status = 'updated', prio = 999 where id = 20;
 delete from src_phantom where id = 20;
 commit;
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @wait_phantom_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @phantom_tail_before_mutation,
+' as src_phantom_mutation_ready from `', database(), '`.`', @src_phantom_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_phantom_mutation from @wait_phantom_mutation_sql;
+execute wait_phantom_mutation;
+➤ src_phantom_mutation_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_phantom_mutation;
 explain select id, status, prio from src_phantom where match(body) against('fox');
 ➤ TP QUERY PLAN[12,0,0]  𝄀
 Project  𝄀

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_include_async.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_include_async.sql
@@ -1,7 +1,7 @@
 -- fulltext2 INCLUDE columns over CDC (always-async) — the actual include values
 -- (status, prio) must travel through the ISCP CDC tail on INSERT/UPDATE/DELETE, so
 -- the in-index prefilter + covering projection reflect the mutations. Modeled on
--- fulltext2_async: inline FULLTEXT2 is AlwaysAsync, sleep() waits for CDC to settle.
+-- fulltext2_async: inline FULLTEXT2 is AlwaysAsync, so durable tail state is polled.
 -- Cache-safe (per-CN index cache is not cross-invalidated): each table is searched
 -- only AFTER its final mutation has settled, so its cache loads fresh.
 set experimental_fulltext2_index = 1;
@@ -23,8 +23,19 @@ insert into src_upd values
 (11, 'golden fox naps',  'active',   200),
 (12, 'bronze fox digs',  'archived', 300);
 
--- wait for the initial CDC sync
-select sleep(30);
+-- Wait for both initial CDC tails; the semantic MATCH checks stay single-shot so
+-- an early probe cannot pin a stale per-CN search cache.
+set @src_ins_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src_ins') limit 1);
+set @src_upd_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src_upd') limit 1);
+set @wait_include_initial_sql = concat(
+    'select ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src_ins_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as src_ins_ready, ',
+    '(select coalesce(max(chunk_id), -1) >= 0 from `', database(), '`.`', @src_upd_ft2, '` where index_id = ''cdc_tail'' and tag = 1) as src_upd_ready'
+);
+prepare wait_include_initial from @wait_include_initial_sql;
+-- @wait_expect(2, 120)
+execute wait_include_initial;
+deallocate prepare wait_include_initial;
 
 -- src_ins is never re-mutated: safe to search now (first search loads fresh cache).
 -- covering projection carries include values; cat(4) has no 'fox'.
@@ -34,9 +45,40 @@ select id from src_ins where match(body) against('fox') and status = 'active' or
 select id, prio from src_ins where match(body) against('fox') and prio > 15 order by id;
 
 -- mutate src_upd: UPDATE an include value (LWW) + DELETE, BEFORE its first search.
+set @capture_src_upd_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @src_upd_tail_before_mutation from `', database(), '`.`', @src_upd_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_upd_tail from @capture_src_upd_tail_sql;
+execute capture_src_upd_tail;
+deallocate prepare capture_src_upd_tail;
 update src_upd set status = 'archived', prio = 999 where id = 10;
+set @wait_src_upd_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @src_upd_tail_before_mutation,
+    ' as src_upd_update_ready from `', database(), '`.`', @src_upd_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_upd_mutation from @wait_src_upd_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_src_upd_mutation;
+deallocate prepare wait_src_upd_mutation;
+set @capture_src_upd_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @src_upd_tail_before_mutation from `', database(), '`.`', @src_upd_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_src_upd_tail from @capture_src_upd_tail_sql;
+execute capture_src_upd_tail;
+deallocate prepare capture_src_upd_tail;
 delete from src_upd where id = 11;
-select sleep(30);
+set @wait_src_upd_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @src_upd_tail_before_mutation,
+    ' as src_upd_delete_ready from `', database(), '`.`', @src_upd_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_src_upd_mutation from @wait_src_upd_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_src_upd_mutation;
+deallocate prepare wait_src_upd_mutation;
 
 -- src_upd's FIRST search (fresh cache post-mutation): id10 include values updated
 -- (active/100 -> archived/999), id11 gone, id12 unchanged.
@@ -57,14 +99,45 @@ create table src_phantom (id bigint primary key, body varchar(200), status varch
 insert into src_phantom values
 (20, 'silver fox alpha', 'active', 500),
 (21, 'golden fox beta',  'active', 600);
+set @src_phantom_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ftidx' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src_phantom') limit 1);
+set @wait_phantom_initial_sql = concat(
+    'select coalesce(max(chunk_id), -1) >= 0 as src_phantom_ready from `', database(), '`.`', @src_phantom_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_phantom_initial from @wait_phantom_initial_sql;
+-- @wait_expect(2, 120)
+execute wait_phantom_initial;
+deallocate prepare wait_phantom_initial;
+set @capture_phantom_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @phantom_tail_before_mutation from `', database(), '`.`', @src_phantom_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_phantom_tail from @capture_phantom_tail_sql;
+execute capture_phantom_tail;
+deallocate prepare capture_phantom_tail;
 -- upsert then delete the SAME pk in one txn: the exact upsert->delete phantom case.
 begin;
 update src_phantom set body = 'silver fox gamma', status = 'updated', prio = 999 where id = 20;
 delete from src_phantom where id = 20;
 commit;
-select sleep(30);
+set @wait_phantom_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @phantom_tail_before_mutation,
+    ' as src_phantom_mutation_ready from `', database(), '`.`', @src_phantom_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_phantom_mutation from @wait_phantom_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_phantom_mutation;
+deallocate prepare wait_phantom_mutation;
 
 -- covered fast path (0-JOIN: Project -> Sort(score) -> Table Function, no base Table Scan/Join).
+-- Assert only the stable operator contract: the plan header's runtime counters
+-- can be 0 or -1 without changing the physical path.
+-- @regex("Project", true)
+-- @regex("Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC", true)
+-- @regex("Table Function on fulltext2_search", true)
+-- @regex("Table Scan on src_phantom", false)
+-- @regex("Join", false)
 explain select id, status, prio from src_phantom where match(body) against('fox');
 -- pk 20 must be GONE (no phantom, no stale 'updated'/999); only pk 21 remains.
 select id, status, prio from src_phantom where match(body) against('fox') order by match(body) against('fox') desc, id;

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_include_async.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_include_async.sql
@@ -131,13 +131,9 @@ execute wait_phantom_mutation;
 deallocate prepare wait_phantom_mutation;
 
 -- covered fast path (0-JOIN: Project -> Sort(score) -> Table Function, no base Table Scan/Join).
--- Assert only the stable operator contract: the plan header's runtime counters
--- can be 0 or -1 without changing the physical path.
--- @regex("Project", true)
--- @regex("Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC", true)
--- @regex("Table Function on fulltext2_search", true)
--- @regex("Table Scan on src_phantom", false)
--- @regex("Join", false)
+-- Compare every plan row exactly while ignoring only JDBC metadata: the plan
+-- column's reported precision can be 0 or -1 without changing the physical path.
+-- @metacmp(false)
 explain select id, status, prio from src_phantom where match(body) against('fox');
 -- pk 20 must be GONE (no phantom, no stale 'updated'/999); only pk 21 remains.
 select id, status, prio from src_phantom where match(body) against('fox') order by match(body) against('fox') desc, id;

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_position_free_merge.result
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_position_free_merge.result
@@ -5,11 +5,43 @@ use ft2_posfree_cdc;
 create table t (id bigint primary key, body text);
 insert into t values (1,'我家有三个人'),(2,'三个人都住在我家'),(3,'我家的花园很漂亮');
 create fulltext2 index ft on t(body) with parser gojieba position_free = true;
+set @t_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ft' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 't') limit 1);
+set @capture_t_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 insert into t values (4,'教室里有三个人'),(5,'昨天我家有三个人来吃饭');
+set @wait_t_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+' as t_insert_ready from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+execute wait_t_mutation;
+➤ t_insert_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_t_mutation;
+set @capture_t_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 delete from t where id = 3;
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @wait_t_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+' as t_delete_ready from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+execute wait_t_mutation;
+➤ t_delete_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_t_mutation;
 select id from t where match(body) against('我家' in bm25 mode) order by id;
 ➤ id[-5,64,0]  𝄀
 1  𝄀
@@ -29,11 +61,42 @@ select id from t where match(body) against('我家' in bm25 mode) order by id;
 5
 select id from t where match(body) against('我家' in boolean mode) order by id;
 invalid input: fulltext2 index "ft" is POSITION_FREE (bag-of-words only): query it with MATCH(...) AGAINST(... IN BM25 MODE); it has no positions for natural-language / boolean phrase matching
+set @capture_t_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 insert into t values (6,'我家门口有三个人');
+set @wait_t_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+' as t_insert_ready from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+execute wait_t_mutation;
+➤ t_insert_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_t_mutation;
+set @capture_t_tail_sql = concat(
+'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 update t set body = '教室里没有人' where id = 4;
-select sleep(30);
-➤ sleep(30)[-6,8,0]  𝄀
-0
+set @wait_t_mutation_sql = concat(
+'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+' as t_update_ready from `', database(), '`.`', @t_ft2,
+'` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+execute wait_t_mutation;
+➤ t_update_ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_t_mutation;
 alter table t alter reindex ft fulltext2;
 select algo_params from mo_catalog.mo_indexes where name = 'ft' and algo_params like '%parser%' limit 1;
 ➤ algo_params[12,2048,0]  𝄀

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_position_free_merge.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_position_free_merge.sql
@@ -3,7 +3,7 @@
 -- (the tag=1 CdcTail is built position-free — slice 2b-tail), a REINDEX MERGE that folds
 -- the tail into the tag=0 base (reconstructs from tf, no positions — slice 2b-compact),
 -- and a REINDEX REBUILD from source. IN BM25 MODE reflects the mutations at each step;
--- BOOLEAN phrase stays rejected (no positions). sleep() waits for the always-async CDC.
+-- BOOLEAN phrase stays rejected (no positions). Durable tail advancement gates CDC checks.
 set experimental_fulltext2_index = 1;
 drop database if exists ft2_posfree_cdc;
 create database ft2_posfree_cdc;
@@ -12,11 +12,43 @@ use ft2_posfree_cdc;
 create table t (id bigint primary key, body text);
 insert into t values (1,'我家有三个人'),(2,'三个人都住在我家'),(3,'我家的花园很漂亮');
 create fulltext2 index ft on t(body) with parser gojieba position_free = true;
+set @t_ft2 = (select index_table_name from mo_catalog.mo_indexes where name = 'ft' and algo_table_type = 'ftv2_index' and table_id in (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 't') limit 1);
+set @capture_t_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 
 -- post-create INSERT/DELETE flow through the CDC tail (built position-free)
 insert into t values (4,'教室里有三个人'),(5,'昨天我家有三个人来吃饭');
+set @wait_t_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+    ' as t_insert_ready from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_t_mutation;
+deallocate prepare wait_t_mutation;
+set @capture_t_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 delete from t where id = 3;
-select sleep(30);
+set @wait_t_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+    ' as t_delete_ready from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_t_mutation;
+deallocate prepare wait_t_mutation;
 
 -- IN BM25 MODE reflects the mutations: 我家 now in docs 1,2,5 (doc 3 deleted); 教室 in doc 4
 select id from t where match(body) against('我家' in bm25 mode) order by id;
@@ -30,9 +62,40 @@ select id from t where match(body) against('我家' in bm25 mode) order by id;
 select id from t where match(body) against('我家' in boolean mode) order by id;
 
 -- more mutations, then REINDEX REBUILD (rebuild the base from source, stays position-free)
+set @capture_t_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 insert into t values (6,'我家门口有三个人');
+set @wait_t_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+    ' as t_insert_ready from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_t_mutation;
+deallocate prepare wait_t_mutation;
+set @capture_t_tail_sql = concat(
+    'select coalesce(max(chunk_id), -1) into @t_tail_before_mutation from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare capture_t_tail from @capture_t_tail_sql;
+execute capture_t_tail;
+deallocate prepare capture_t_tail;
 update t set body = '教室里没有人' where id = 4;
-select sleep(30);
+set @wait_t_mutation_sql = concat(
+    'select coalesce(max(chunk_id), -1) > ', @t_tail_before_mutation,
+    ' as t_update_ready from `', database(), '`.`', @t_ft2,
+    '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_t_mutation from @wait_t_mutation_sql;
+-- @wait_expect(2, 120)
+execute wait_t_mutation;
+deallocate prepare wait_t_mutation;
 alter table t alter reindex ft fulltext2;
 select algo_params from mo_catalog.mo_indexes where name = 'ft' and algo_params like '%parser%' limit 1;
 select id from t where match(body) against('我家' in bm25 mode) order by id;


### PR DESCRIPTION
## What

- Replace 13 fixed 30s/45s sleeps in six fulltext2 async BVT files with 18 bounded, adaptive readiness checks against the durable `cdc_tail`.
- Gate every independent post-create DML on a strict per-index `chunk_id` advance; initial multi-table cases require every table tail to be ready.
- Keep MATCH single-shot to avoid pinning a stale per-CN fulltext2 cache.
- Keep the covered fast-path EXPLAIN comparison exact, ignoring only unstable JDBC result metadata (`precision` 0 versus -1).

## Coverage and failure behavior

- All existing MATCH, INCLUDE, datalink, tenant, position-free, MERGE/REBUILD, error-path, and exact result assertions remain.
- Readiness is asserted explicitly instead of inferred from elapsed time. A deterministic negative control (`ready = 0`) timed out and failed as expected; it cannot silently pass without exercising CDC.
- EXPLAIN metadata mismatch passes with `@metacmp(false)`, while a deliberately corrupted plan row fails exactly. Extra, missing, or changed plan rows therefore remain detectable.
- 28 prepared statements are paired with 28 deallocations. No production code changes.

## Validation

- Rebased on current `main`: `705d5fbb625d32090b9a8acadcead08c3e1d9dc3`
- Six-file strict run on the preceding main revision: **252/252 passed**, failed 0, abnormal 0; runner cost **175s**, wall **204s**
- Same-base before/after (`e866c535`): runner cost **461s -> 196s** (-57.5%); wall **521s -> 241s** (-53.7%)
- Three additional complete runs: **252/252** each, runner costs 192s / 180s / 192s
- Current-main targeted final run: **60/60 passed**, failed 0, abnormal 0; runner cost **50.582s**
- EXPLAIN assertion controls: metadata-only difference **60/60 passed**; corrupted `Project` row **failed as expected (59/60)**
- `git diff --check` clean; 18 readiness checks; no fixed sleeps remain in the six files

The 120s value is a failure budget, not a delay: polling is every 2s and exits immediately when the durable state advances.