### PR TITLE
test: harden async lifecycle synchronization

### DIFF
--- a/pkg/fileservice/disk_cache_lifecycle_test.go
+++ b/pkg/fileservice/disk_cache_lifecycle_test.go
@@ -890,11 +890,17 @@ func TestDiskCacheCloseDrainsQueuedFileFinalize(t *testing.T) {
 	// Canceling a queued finalizer only cleans its temporary artifact; it must
 	// not claim that a previous disk-write failure recovered.
 	cache.writeFailures.failed.Store(true)
+	locker := installNotifyingDiskCacheLocker(cache)
 
 	closeCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	cache.Close(closeCtx)
 	require.ErrorIs(t, closeCtx.Err(), context.DeadlineExceeded)
+	// A timed-out Close starts the background drain but does not join it. Wait
+	// for the queued finalizer to release its path explicitly before inspecting
+	// the cleanup result; the first finalizer is still blocked in file.Sync, so
+	// this unlock can only come from the queued finalizer's doneUpdate path.
+	requireDiskCacheUnlock(t, locker)
 	require.False(t, cache.isUpdating(queuedPath))
 	require.True(t, cache.writeFailures.failed.Load())
 	_, err := os.Stat(queuedPath)

--- a/pkg/lockservice/lock_table_proxy_test.go
+++ b/pkg/lockservice/lock_table_proxy_test.go
@@ -1268,9 +1268,7 @@ func TestProxyRetryPreservesAppliedHandoffRepresentative(t *testing.T) {
 			// In the real service, an ordinary live txn is reported by the
 			// frontend iterator. Keep the late sharer visible while exercising the
 			// owner orphan check for the finished first replacement.
-			s2.cfg.TxnIterFunc = func(fn func([]byte) bool) {
-				fn(lateSharerTxn)
-			}
+			s2.cfg.TxnIterFunc = newTestTxnIterFunc(lateSharerTxn)
 			s1.activeTxnHolder.keepRemoteLockBindActive(s2.serviceID, owner.bind)
 			s1.events.checkOrphan(checkOrphan{
 				wait: waitTooLong,

--- a/pkg/lockservice/lock_table_remote_test.go
+++ b/pkg/lockservice/lock_table_remote_test.go
@@ -424,6 +424,8 @@ func TestRemoteCoarsenedLockTransportFailureKeepsBoundedRouting(t *testing.T) {
 }
 
 func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
+	holderTxn := []byte("remote-repeat-range")
+	waiterTxn := []byte("remote-repeat-range-waiter")
 	runLockServiceTestsWithAdjustConfig(
 		t,
 		[]string{"s1", "s2"},
@@ -441,16 +443,15 @@ func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
 			client.dropAt.Store(3)
 			origin.remote.client = client
 
-			txnID := []byte("remote-repeat-range")
 			rangeOptions := newTestRangeExclusiveOptions()
 			for range 2 {
 				_, err = origin.Lock(
-					ctx, table, newTestRows(1, 2), txnID, rangeOptions)
+					ctx, table, newTestRows(1, 2), holderTxn, rangeOptions)
 				require.NoError(t, err)
 			}
 
 			for idx, s := range []*service{owner, origin} {
-				txn := s.activeTxnHolder.getActiveTxn(txnID, false, "")
+				txn := s.activeTxnHolder.getActiveTxn(holderTxn, false, "")
 				require.NotNil(t, txn)
 				txn.RLock()
 				keys := txn.lockHolders[0].tableKeys[table].slice()
@@ -466,7 +467,7 @@ func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
 			}
 
 			_, err = origin.Lock(
-				ctx, table, newTestRows(3), txnID, newTestRowExclusiveOptions())
+				ctx, table, newTestRows(3), holderTxn, newTestRowExclusiveOptions())
 			require.Error(t, err, "the owner response must be lost after commit")
 
 			lt := owner.tableGroups.get(0, table).(*localLockTable)
@@ -482,7 +483,7 @@ func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
 			// The origin keeps its bounded table route. The owner-side ledger is the
 			// authoritative deadlock snapshot and unlock by txnID releases the owner's
 			// committed replacement even though the response never arrived.
-			originTxn := origin.activeTxnHolder.getActiveTxn(txnID, false, "")
+			originTxn := origin.activeTxnHolder.getActiveTxn(holderTxn, false, "")
 			require.NotNil(t, originTxn)
 			originTxn.RLock()
 			originKeys := originTxn.lockHolders[0].tableKeys[table].slice()
@@ -490,7 +491,6 @@ func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
 			require.Equal(t, newTestRows(1), originKeys.all())
 			originKeys.unref()
 
-			waiterTxn := []byte("remote-repeat-range-waiter")
 			waiterDone := make(chan error, 1)
 			go func() {
 				_, lockErr := owner.Lock(
@@ -504,7 +504,7 @@ func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
 			ok, err := originTxn.fetchWhoWaitingMe(
 				ctx,
 				origin.serviceID,
-				txnID,
+				holderTxn,
 				func(waiter pb.WaitTxn, _ string) bool {
 					seen[string(waiter.TxnID)] = struct{}{}
 					return true
@@ -515,7 +515,7 @@ func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
 			require.True(t, ok)
 			require.Contains(t, seen, string(waiterTxn))
 
-			require.NoError(t, origin.Unlock(ctx, txnID, timestamp.Timestamp{}))
+			require.NoError(t, origin.Unlock(ctx, holderTxn, timestamp.Timestamp{}))
 			require.NoError(t, <-waiterDone)
 			require.NoError(t, owner.Unlock(ctx, waiterTxn, timestamp.Timestamp{}))
 			probeTxn := []byte("remote-repeat-range-probe")
@@ -528,11 +528,17 @@ func TestRemoteRepeatedRangeLostReplacementResponseStillUnlocks(t *testing.T) {
 		func(c *Config) {
 			c.MaxLockRowCount = 2
 			c.MaxFixedSliceSize = 4
+			c.TxnIterFunc = newTestTxnIterFunc(holderTxn, waiterTxn)
 		},
 	)
 }
 
 func TestRemoteExactRetryUsesAuthoritativeOwnerSnapshot(t *testing.T) {
+	holderTxn := []byte("remote-exact-holder")
+	waiterTxns := [][]byte{
+		[]byte("remote-exact-waiter-2"),
+		[]byte("remote-exact-waiter-3"),
+	}
 	runLockServiceTestsWithAdjustConfig(
 		t,
 		[]string{"owner", "origin"},
@@ -550,7 +556,6 @@ func TestRemoteExactRetryUsesAuthoritativeOwnerSnapshot(t *testing.T) {
 			client.dropAt.Store(1)
 			origin.remote.client = client
 
-			holderTxn := []byte("remote-exact-holder")
 			rows := newTestRows(1, 2, 3)
 			_, err = origin.Lock(
 				ctx, table, rows, holderTxn, newTestRowExclusiveOptions())
@@ -567,10 +572,6 @@ func TestRemoteExactRetryUsesAuthoritativeOwnerSnapshot(t *testing.T) {
 			require.Equal(t, rows[:1], route.all())
 			route.unref()
 
-			waiterTxns := [][]byte{
-				[]byte("remote-exact-waiter-2"),
-				[]byte("remote-exact-waiter-3"),
-			}
 			waiterDone := make(chan error, len(waiterTxns))
 			for idx, txnID := range waiterTxns {
 				row := rows[idx+1]
@@ -609,6 +610,8 @@ func TestRemoteExactRetryUsesAuthoritativeOwnerSnapshot(t *testing.T) {
 		func(c *Config) {
 			c.MaxLockRowCount = 8
 			c.MaxFixedSliceSize = 8
+			c.TxnIterFunc = newTestTxnIterFunc(
+				append([][]byte{holderTxn}, waiterTxns...)...)
 		},
 	)
 }
@@ -686,6 +689,8 @@ func TestRemoteOwnerSnapshotCompactsOriginLedgerAcrossCapacitySkew(t *testing.T)
 }
 
 func TestRemoteCoarseningUsesOwnerRepresentationForDeadlockProbes(t *testing.T) {
+	holderTxn := []byte("remote-divergent-holder")
+	waiterTxn := []byte("remote-divergent-interior-waiter")
 	runLockServiceTestsWithAdjustConfig(
 		t,
 		[]string{"owner", "origin"},
@@ -704,7 +709,6 @@ func TestRemoteCoarseningUsesOwnerRepresentationForDeadlockProbes(t *testing.T) 
 				ctx, 0, table, nil, pb.Sharding_None)
 			require.NoError(t, err)
 
-			holderTxn := []byte("remote-divergent-holder")
 			rows := newTestRows(1, 2, 3)
 			_, err = origin.Lock(
 				ctx, table, rows, holderTxn, newTestRowExclusiveOptions())
@@ -713,7 +717,6 @@ func TestRemoteCoarseningUsesOwnerRepresentationForDeadlockProbes(t *testing.T) 
 				_ = origin.Unlock(context.Background(), holderTxn, timestamp.Timestamp{})
 			}()
 
-			waiterTxn := []byte("remote-divergent-interior-waiter")
 			waiterDone := make(chan error, 1)
 			go func() {
 				_, lockErr := owner.Lock(
@@ -751,6 +754,7 @@ func TestRemoteCoarseningUsesOwnerRepresentationForDeadlockProbes(t *testing.T) 
 		func(c *Config) {
 			c.MaxLockRowCount = 8
 			c.MaxFixedSliceSize = 8
+			c.TxnIterFunc = newTestTxnIterFunc(holderTxn, waiterTxn)
 		},
 	)
 }

--- a/pkg/lockservice/orphan_txn_test.go
+++ b/pkg/lockservice/orphan_txn_test.go
@@ -155,13 +155,7 @@ func TestCannotUnlockOrphanTxnWithCommittingInAllocator(t *testing.T) {
 		func(c *Config) {
 			c.RemoteLockTimeout.Duration = remoteLockTimeout
 			c.KeepRemoteLockDuration.Duration = time.Millisecond * 100
-			c.TxnIterFunc = func(f func([]byte) bool) {
-				for _, txn := range activeTxns {
-					if !f(txn) {
-						return
-					}
-				}
-			}
+			c.TxnIterFunc = newTestTxnIterFunc(activeTxns...)
 		},
 	)
 }
@@ -258,13 +252,7 @@ func TestUnlockOrphanTxnWhenBindHeartbeatMissing(t *testing.T) {
 		func(c *Config) {
 			c.RemoteLockTimeout.Duration = remoteLockTimeout
 			c.KeepRemoteLockDuration.Duration = time.Millisecond * 50
-			c.TxnIterFunc = func(f func([]byte) bool) {
-				for _, txn := range activeTxns {
-					if !f(txn) {
-						return
-					}
-				}
-			}
+			c.TxnIterFunc = newTestTxnIterFunc(activeTxns...)
 		},
 	)
 }
@@ -375,13 +363,7 @@ func TestCannotUnlockStaleBindTxnWithCommittingInAllocator(t *testing.T) {
 		func(c *Config) {
 			c.RemoteLockTimeout.Duration = remoteLockTimeout
 			c.KeepRemoteLockDuration.Duration = time.Millisecond * 50
-			c.TxnIterFunc = func(f func([]byte) bool) {
-				for _, txn := range activeTxns {
-					if !f(txn) {
-						return
-					}
-				}
-			}
+			c.TxnIterFunc = newTestTxnIterFunc(activeTxns...)
 		},
 	)
 }

--- a/pkg/lockservice/service_forward_test.go
+++ b/pkg/lockservice/service_forward_test.go
@@ -213,11 +213,7 @@ func TestForwardLockUsesEffectiveLockDeadline(t *testing.T) {
 			require.Less(t, time.Since(start), 3*time.Second)
 		},
 		func(c *Config) {
-			c.TxnIterFunc = func(fn func([]byte) bool) {
-				if fn(holderTxn) {
-					fn(waiterTxn)
-				}
-			}
+			c.TxnIterFunc = newTestTxnIterFunc(holderTxn, waiterTxn)
 		},
 	)
 }

--- a/pkg/lockservice/service_observability_test.go
+++ b/pkg/lockservice/service_observability_test.go
@@ -627,13 +627,7 @@ func TestIterLocks(t *testing.T) {
 			txn4 := newTestTxnID(4)
 			txn5 := newTestTxnID(5)
 
-			s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-				f(txn1)
-				f(txn2)
-				f(txn3)
-				f(txn4)
-				f(txn5)
-			}
+			s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3, txn4, txn5)
 
 			rows := newTestRows(1)
 			rangeRows := newTestRows(2, 3)

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -289,13 +289,7 @@ func TestFetchWhoWaitingMeUsesActiveRemoteWaiterSnapshots(t *testing.T) {
 			// TxnIterFunc in production. Keep the synthetic remote transactions
 			// visible so the orphan checker cannot legitimately remove the lock
 			// before this test snapshots its waiters.
-			cfg.TxnIterFunc = func(fn func([]byte) bool) {
-				for _, txnID := range [][]byte{holderTxn, activeWaiterTxn} {
-					if !fn(txnID) {
-						return
-					}
-				}
-			}
+			cfg.TxnIterFunc = newTestTxnIterFunc(holderTxn, activeWaiterTxn)
 		},
 	)
 }
@@ -2453,10 +2447,7 @@ func TestRemoteOwnerLocalDeadlockFastPathBreaksPartialLockRing(t *testing.T) {
 			require.NoError(t, origin.Unlock(ctx, txn1, timestamp.Timestamp{}))
 		},
 		func(cfg *Config) {
-			cfg.TxnIterFunc = func(fn func([]byte) bool) {
-				fn(txn1)
-				fn(txn2)
-			}
+			cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 		},
 	)
 }
@@ -2517,11 +2508,7 @@ func TestRemoteOwnerLocalDeadlockNormalizesEveryPendingOperation(t *testing.T) {
 			require.NoError(t, origin.Unlock(ctx, txn3, timestamp.Timestamp{}))
 		},
 		func(cfg *Config) {
-			cfg.TxnIterFunc = func(fn func([]byte) bool) {
-				fn(txn1)
-				fn(txn2)
-				fn(txn3)
-			}
+			cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3)
 		},
 	)
 }

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -53,6 +53,32 @@ var (
 	}
 )
 
+// newTestTxnIterFunc preserves Config.TxnIterFunc's early-stop contract: once
+// the visitor returns false, later transaction IDs must not be observed.
+func newTestTxnIterFunc(txnIDs ...[]byte) func(func([]byte) bool) {
+	return func(fn func([]byte) bool) {
+		for _, txnID := range txnIDs {
+			if !fn(txnID) {
+				return
+			}
+		}
+	}
+}
+
+func TestNewTestTxnIterFuncStopsWhenVisitorReturnsFalse(t *testing.T) {
+	txn1 := newTestTxnID(1)
+	txn2 := newTestTxnID(2)
+	txn3 := newTestTxnID(3)
+	var visited [][]byte
+
+	newTestTxnIterFunc(txn1, txn2, txn3)(func(txnID []byte) bool {
+		visited = append(visited, txnID)
+		return string(txnID) != string(txn2)
+	})
+
+	require.Equal(t, [][]byte{txn1, txn2}, visited)
+}
+
 func getRunner(remote bool) func(t *testing.T, table uint64, fn func(context.Context, *service, *localLockTable)) {
 	return func(
 		t *testing.T,
@@ -166,10 +192,7 @@ func TestRowLockWithSharedAndExclusive(t *testing.T) {
 					txn1 := newTestTxnID(1)
 					txn2 := newTestTxnID(2)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					// txn1 hold the lock
 					_, err := s.Lock(ctx, table, rows, txn1, option)
@@ -316,10 +339,7 @@ func TestRangeLockWithSharedAndExclusive(t *testing.T) {
 					txn2 := newTestTxnID(2)
 
 					// keep txn1 cannot close by orphan txn
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					// txn1 hold the lock
 					_, err := s.Lock(ctx, table, rows, txn1, option)
@@ -408,10 +428,7 @@ func TestRowLockWithConflict(t *testing.T) {
 					txn1 := newTestTxnID(1)
 					txn2 := newTestTxnID(2)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					// txn1 hold the lock
 					_, err := s.Lock(ctx, table, rows, txn1, option)
@@ -459,10 +476,7 @@ func TestRangeLockWithConflict(t *testing.T) {
 					txn1 := newTestTxnID(1)
 					txn2 := newTestTxnID(2)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					// txn1 hold the lock
 					_, err = s.Lock(ctx, table, rows, txn1, option)
@@ -513,11 +527,7 @@ func TestRowLockWithWaitQueue(t *testing.T) {
 					txn2 := newTestTxnID(2)
 					txn3 := newTestTxnID(3)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-						f(txn3)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3)
 
 					_, err := s.Lock(ctx, table, rows, txn1, option)
 					require.NoError(t, err)
@@ -586,11 +596,7 @@ func TestRangeLockWithWaitQueue(t *testing.T) {
 					txn2 := newTestTxnID(2)
 					txn3 := newTestTxnID(3)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-						f(txn3)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3)
 
 					_, err := s.Lock(ctx, table, rows, txn1, option)
 					require.NoError(t, err)
@@ -646,10 +652,7 @@ func TestRowLockWithSameTxnWithConflict(t *testing.T) {
 					txn1 := newTestTxnID(1)
 					txn2 := newTestTxnID(2)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					_, err := s.Lock(ctx, table, rows, txn1, option)
 					require.NoError(t, err)
@@ -705,10 +708,7 @@ func TestRangeLockWithSameTxnWithConflict(t *testing.T) {
 					txn1 := newTestTxnID(1)
 					txn2 := newTestTxnID(2)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					_, err := s.Lock(ctx, table, rows, txn1, option)
 					require.NoError(t, err)
@@ -831,10 +831,7 @@ func TestManyRowLockWithConflict(t *testing.T) {
 					txn1 := newTestTxnID(1)
 					txn2 := newTestTxnID(2)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					// txn1 hold the lock
 					_, err := s.Lock(ctx, table, rows, txn1, option)
@@ -883,10 +880,7 @@ func TestManyRangeLockWithConflict(t *testing.T) {
 					txn1 := newTestTxnID(1)
 					txn2 := newTestTxnID(2)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 					// txn1 hold the lock
 					_, err := s.Lock(ctx, table, rows, txn1, option)
@@ -1010,11 +1004,7 @@ func TestCtxCancelWhileWaiting(t *testing.T) {
 					txn2 := newTestTxnID(2)
 					txn3 := newTestTxnID(3)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-						f(txn3)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3)
 
 					// txn1 hold the lock
 					_, err := s.Lock(ctx, table, rows, txn1, option)
@@ -1276,12 +1266,7 @@ func TestDeadLockWithIndirectDependsOn(t *testing.T) {
 					txn3 := newTestTxnID(3)
 					txn4 := newTestTxnID(4)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-						f(txn3)
-						f(txn4)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3, txn4)
 
 					mustAddTestLock(t, ctx, s, table, txn1, row1, pb.Granularity_Row)
 					mustAddTestLock(t, ctx, s, table, txn4, row4, pb.Granularity_Row)
@@ -1394,11 +1379,7 @@ func TestWaiterAwakeOnDeadLock(t *testing.T) {
 					txn2 := newTestTxnID(2)
 					txn3 := newTestTxnID(3)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-						f(txn3)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3)
 
 					mustAddTestLock(t, ctx, s, table, txn1, row1, pb.Granularity_Row)
 
@@ -2624,9 +2605,7 @@ func TestIssue5176_2(t *testing.T) {
 		time.Second*1,
 		func(alloc *lockTableAllocator, s []*service) {
 			l := s[0]
-			l.cfg.TxnIterFunc = func(f func([]byte) bool) {
-				f([]byte("txn1"))
-			}
+			l.cfg.TxnIterFunc = newTestTxnIterFunc([]byte("txn1"))
 
 			ctx, cancel := context.WithTimeout(
 				context.Background(),
@@ -4901,10 +4880,7 @@ func TestRowLockWithConflictAndUnlock(t *testing.T) {
 			txn1 := newTestTxnID(1)
 			txn2 := newTestTxnID(2)
 
-			s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-				f(txn1)
-				f(txn2)
-			}
+			s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2)
 
 			// txn1 hold the lock
 			_, err := s.Lock(ctx, table, rows, txn1, option)
@@ -4948,11 +4924,7 @@ func TestUnlockRangeLockCanNotifyAllWaiters(t *testing.T) {
 			txn2 := newTestTxnID(2)
 			txn3 := newTestTxnID(3)
 
-			s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-				f(txn1)
-				f(txn2)
-				f(txn3)
-			}
+			s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3)
 
 			// txn1 hold the lock
 			_, err := s.Lock(ctx, table, rows, txn1, rangeOption)
@@ -5007,11 +4979,7 @@ func TestHasAnyHolderCannotNotifyWaiters(t *testing.T) {
 					txn2 := newTestTxnID(2)
 					txn3 := newTestTxnID(3)
 
-					s.cfg.TxnIterFunc = func(f func([]byte) bool) {
-						f(txn1)
-						f(txn2)
-						f(txn3)
-					}
+					s.cfg.TxnIterFunc = newTestTxnIterFunc(txn1, txn2, txn3)
 
 					// txn1 get lock
 					_, err := s.Lock(ctx, table, rows, txn1, option)

--- a/pkg/lockservice/shared_budget_regression_test.go
+++ b/pkg/lockservice/shared_budget_regression_test.go
@@ -279,6 +279,8 @@ func TestWaitingReplacementPreservesConcurrentSameTxnLocks(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			txnA := []byte("replacement-merge-a")
+			txnB := []byte("replacement-merge-b")
 			runLockServiceTestsWithAdjustConfig(
 				t,
 				tt.serviceIDs,
@@ -293,8 +295,6 @@ func TestWaitingReplacementPreservesConcurrentSameTxnLocks(t *testing.T) {
 						ctx, 0, table, nil, pb.Sharding_None)
 					require.NoError(t, err)
 
-					txnA := []byte("replacement-merge-a")
-					txnB := []byte("replacement-merge-b")
 					lockA := newTestRowExclusiveOptions()
 					if tt.forward {
 						lockA.ForwardTo = owner.serviceID
@@ -391,6 +391,7 @@ func TestWaitingReplacementPreservesConcurrentSameTxnLocks(t *testing.T) {
 				func(c *Config) {
 					c.MaxLockRowCount = 4
 					c.MaxFixedSliceSize = 8
+					c.TxnIterFunc = newTestTxnIterFunc(txnA, txnB)
 				},
 			)
 		})
@@ -410,6 +411,9 @@ func TestWaitingReplacementFallsBackAfterConcurrentSharedLock(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			txnA := []byte("replacement-mode-a")
+			txnB := []byte("replacement-mode-b")
+			txnC := []byte("replacement-mode-c")
 			runLockServiceTestsWithAdjustConfig(
 				t,
 				tt.serviceIDs,
@@ -424,9 +428,6 @@ func TestWaitingReplacementFallsBackAfterConcurrentSharedLock(t *testing.T) {
 						ctx, 0, table, nil, pb.Sharding_None)
 					require.NoError(t, err)
 
-					txnA := []byte("replacement-mode-a")
-					txnB := []byte("replacement-mode-b")
-					txnC := []byte("replacement-mode-c")
 					exclusive := newTestRowExclusiveOptions()
 					if tt.forward {
 						exclusive.ForwardTo = owner.serviceID
@@ -541,6 +542,7 @@ func TestWaitingReplacementFallsBackAfterConcurrentSharedLock(t *testing.T) {
 				func(c *Config) {
 					c.MaxLockRowCount = 3
 					c.MaxFixedSliceSize = 8
+					c.TxnIterFunc = newTestTxnIterFunc(txnA, txnB, txnC)
 				},
 			)
 		})
@@ -630,13 +632,7 @@ func TestRemoteSharedMergeSnapshotPreservesLogicalWaitFor(t *testing.T) {
 			// TxnIterFunc in production. Keep the synthetic transactions visible
 			// while the remote waiter is blocked so the orphan checker cannot
 			// invalidate the wait-for snapshot based on scheduler timing.
-			c.TxnIterFunc = func(fn func([]byte) bool) {
-				for _, txnID := range [][]byte{txnA, txnB, txnC} {
-					if !fn(txnID) {
-						return
-					}
-				}
-			}
+			c.TxnIterFunc = newTestTxnIterFunc(txnA, txnB, txnC)
 		},
 	)
 }
@@ -757,13 +753,7 @@ func TestLateSharedHolderCycleRemainsDeadlockDetectable(t *testing.T) {
 					// Production CheckActiveTxn reads frontend transaction liveness
 					// through TxnIterFunc. Keep these synthetic public-path transactions
 					// authoritative while the remote snapshot closes the wait-for cycle.
-					c.TxnIterFunc = func(fn func([]byte) bool) {
-						for _, txnID := range [][]byte{txnA, txnB, txnC} {
-							if !fn(txnID) {
-								return
-							}
-						}
-					}
+					c.TxnIterFunc = newTestTxnIterFunc(txnA, txnB, txnC)
 				},
 			)
 		})


### PR DESCRIPTION
## What

- synchronize the queued disk-cache finalizer test with its explicit done-update phase before checking cleanup state
- centralize synthetic lock-service transaction iteration in an early-stop-aware test helper
- keep remote holders and waiters authoritative during exact-retry, coarsening, replacement, and deadlock observations
- migrate the remaining static transaction iterator fixtures to the shared contract-safe helper

## Root cause

A timed-out DiskCache.Close starts background draining but does not join it, so the test asserted path cleanup without a happens-before edge.

The lock-service test harness runs orphan checks on a 50 ms interval. Several remote-wait tests omitted synthetic frontend transaction liveness, while two deadlock fixtures ignored the iterator visitor false return. A later transaction could therefore overwrite Active=true with false, causing a live remote holder to be fenced as orphan before waiter inspection.

These are test-fixture and observation defects; no production-code defect was found, and this PR changes test code only.

## Validation

- fileservice target: 100x under race
- lock-service remote core group: two successful 100x race runs, plus isolated 100x exact-retry
- shared replacement topology groups: 96x and 90x under race
- full pkg/fileservice and pkg/lockservice suites, normal and race
- go list, go build, go vet, and git diff --check

Fixes #27594
Fixes #27571