### PR TITLE
ci: increase UT package parallelism to 8

### DIFF
--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -74,6 +74,8 @@ jobs:
     needs: check-pr-valid
     if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/ci.yaml@main
+    with:
+      ut_parallel: 8
     secrets: inherit
 
   matrixone-ut-coverage:


### PR DESCRIPTION
## Summary

- use the typed `ut_parallel` input provided by merged matrixorigin/CI#432
- raise MatrixOne's non-3.0 Ubuntu UT package parallelism from the default 6 to 8
- keep the reusable workflow on `matrixorigin/CI@main`; other callers and the 3.0 workflow are unchanged

## Why 8

The scoped parallelism-7 canary completed the Ubuntu UT job successfully in about 36 minutes, below the recent 38-53 minute range recorded at parallelism 6. With the input path now validated and matrixorigin/CI#432 merged, this PR advances the production setting to 8 and lets the normal PR CI validate the next step.

The MatrixOne repository currently has no `UT_PARALLEL` repository variable, so this typed caller value is effective. A future repository-variable override remains authoritative by design.

## Validation

- rebased onto the latest `main`
- parsed `.github/workflows/entrypoint.yaml` as YAML
- ran actionlint v1.7.12
- ran `git diff --check`

Depends on merged matrixorigin/CI#432.
