### PR TITLE
test: reduce high-cost integration fixtures deterministically

### DIFF
--- a/pkg/tests/dml/dml_test.go
+++ b/pkg/tests/dml/dml_test.go
@@ -37,117 +37,108 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/util/fault"
 )
 
-func TestDeleteAndSelect(t *testing.T) {
-	embed.RunBaseClusterTests(t,
-		func(c embed.Cluster) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
-			defer cancel()
-
-			cn1, err := c.GetCNService(0)
-			require.NoError(t, err)
-
-			exec := testutils.GetSQLExecutor(cn1)
-
-			db := testutils.GetDatabaseName(t)
-			table := "debug"
-
-			res, err := exec.Exec(
-				ctx,
-				"create database "+db,
-				executor.Options{},
-			)
-			require.NoError(t, err)
-			res.Close()
-
-			res, err = exec.Exec(
-				ctx,
-				"create table "+table+" (a varchar primary key, b varchar)",
-				executor.Options{}.WithDatabase(db),
-			)
-			require.NoError(t, err)
-			res.Close()
-
-			//insert 3 blocks into t;
-			res, err = exec.Exec(
-				ctx,
-				"insert into "+table+" select *, * from generate_series(1,24576)g",
-				executor.Options{}.WithDatabase(db),
-			)
-			require.NoError(t, err)
-			res.Close()
-
-			plan.SetForceScanOnMultiCN(true)
-			defer plan.SetForceScanOnMultiCN(false)
-			//select * from t where a > 24500;
-			res, err = exec.Exec(
-				ctx,
-				"select * from "+table+" where a > 24500",
-				executor.Options{}.WithDatabase(db),
-			)
-			require.NoError(t, err)
-			res.Close()
-
-			//res, err = exec.Exec(
-			//	ctx,
-			//	"delete from "+table+" where a > 3",
-			//	executor.Options{}.WithDatabase(db),
-			//)
-			//require.NoError(t, err)
-			//res.Close()
-
-			//select b from t2 where a between 1 and 3 order by b asc;
-			//res, err = exec.Exec(
-			//	ctx,
-			//	"select b from "+table+" where a between 1 and 3 order by b asc",
-			//	executor.Options{}.WithDatabase(db),
-			//)
-			//require.NoError(t, err)
-			//rows := 0
-			//for _, b := range res.Batches {
-			//	rows += b.RowCount()
-			//}
-			//require.Equal(t, 3, rows)
-			//res.Close()
-		},
-	)
-}
-
-func TestInsertIgnoreSpecialTypeOnRemoteCN(t *testing.T) {
+func TestForcedMultiCNDeleteAndInsertIgnore(t *testing.T) {
 	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 
 		cn, err := c.GetCNService(0)
 		require.NoError(t, err)
+		internalExec := testutils.GetSQLExecutor(cn)
 		port := cn.GetServiceConfig().CN.Frontend.Port
 		db, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
 		require.NoError(t, err)
 		defer db.Close()
+		db.SetMaxOpenConns(1)
 
-		dbName := testutils.GetDatabaseName(t)
-		execSQLDB(t, ctx, db, "create database `"+dbName+"`")
-		defer func() {
-			execSQLDB(t, ctx, db, "use mo_catalog")
-			execSQLDB(t, ctx, db, "drop database if exists `"+dbName+"`")
-		}()
-		execSQLDB(t, ctx, db, "use `"+dbName+"`")
+		dbPrefix := testutils.GetDatabaseName(t)
+		deleteDB := dbPrefix + "_delete"
+		castDB := dbPrefix + "_cast"
+		defer cleanupTestDatabases(t, db, deleteDB, castDB)
+		execSQLDB(t, ctx, db, "create database `"+deleteDB+"`")
+		execSQLDB(t, ctx, db, "create database `"+castDB+"`")
+
+		const deleteTable = "forced_delete"
+		deleteOpts := executor.Options{}.WithDatabase(deleteDB)
+		for _, statement := range []string{
+			"create table " + deleteTable + " (a varchar primary key, b varchar)",
+			"insert into " + deleteTable + " values ('1','1'),('2','2'),('3','3'),('7','7'),('8','8')",
+		} {
+			res, execErr := internalExec.Exec(ctx, statement, deleteOpts)
+			require.NoError(t, execErr)
+			res.Close()
+		}
+
+		execSQLDB(t, ctx, db, "use `"+castDB+"`")
 		execSQLDB(t, ctx, db, "set session sql_mode = 'STRICT_TRANS_TABLES'")
-		execSQLDB(t, ctx, db, "create table src (v int)")
-		// Multiple source blocks ensure the forced AP multi-CN scan evaluates
-		// assignment casts on remote scan scopes, not only on the coordinator.
-		execSQLDB(t, ctx, db, "insert into src select 31 from generate_series(1, 24576) g")
-		execSQLDB(t, ctx, db, "create table dst (b bit(4))")
+		execSQLDB(t, ctx, db, "create table forced_src (v int)")
+		execSQLDB(t, ctx, db, "insert into forced_src values (31),(31),(31),(31)")
+		execSQLDB(t, ctx, db, "create table forced_dst (b bit(4))")
 
-		plan.SetForceScanOnMultiCN(true)
+		// Force only the operations under test. Applying this process-wide test
+		// hook to fixture DDL would exercise an unrelated execution path and can
+		// make setup contend with the test's frontend session.
 		defer plan.SetForceScanOnMultiCN(false)
-		execSQLDB(t, ctx, db, "insert ignore into dst select v from src")
+		plan.SetForceScanOnMultiCN(true)
 
-		var count, min, max int
-		err = db.QueryRowContext(ctx, "select count(*), min(b + 0), max(b + 0) from dst").Scan(&count, &min, &max)
-		require.NoError(t, err)
-		require.Equal(t, 24576, count)
-		require.Equal(t, 15, min)
-		require.Equal(t, 15, max)
+		t.Run("delete and select retain exact rows", func(t *testing.T) {
+			execSQLDB(t, ctx, db, "use `"+deleteDB+"`")
+			planResult, planErr := testutils.QueryTextResult(ctx, db,
+				"explain phyplan select * from "+deleteTable+" where a >= '7'")
+			require.NoError(t, planErr)
+			require.Contains(t, strings.ToUpper(planResult.ColumnName), "PHYPLAN ON MULTICN(")
+			require.Contains(t, planResult.Text, "Magic: Remote",
+				"the small fixture must still compile a real remote scan scope")
+
+			selected, execErr := internalExec.Exec(ctx,
+				"select a,b from "+deleteTable+" where a >= '7' order by a", deleteOpts)
+			require.NoError(t, execErr)
+			var selectedRows [][2]string
+			for _, batch := range selected.Batches {
+				as := executor.GetStringRows(batch.Vecs[0])
+				bs := executor.GetStringRows(batch.Vecs[1])
+				for i := range as {
+					selectedRows = append(selectedRows, [2]string{as[i], bs[i]})
+				}
+			}
+			selected.Close()
+			require.Equal(t, [][2]string{{"7", "7"}, {"8", "8"}}, selectedRows)
+
+			deleted, execErr := internalExec.Exec(ctx,
+				"delete from "+deleteTable+" where a >= '7'", deleteOpts)
+			require.NoError(t, execErr)
+			require.Equal(t, uint64(2), deleted.AffectedRows)
+			deleted.Close()
+
+			remaining, execErr := internalExec.Exec(ctx,
+				"select a from "+deleteTable+" order by a", deleteOpts)
+			require.NoError(t, execErr)
+			var remainingKeys []string
+			for _, batch := range remaining.Batches {
+				remainingKeys = append(remainingKeys, executor.GetStringRows(batch.Vecs[0])...)
+			}
+			remaining.Close()
+			require.Equal(t, []string{"1", "2", "3"}, remainingKeys)
+		})
+
+		t.Run("insert ignore evaluates assignment cast remotely", func(t *testing.T) {
+			execSQLDB(t, ctx, db, "use `"+castDB+"`")
+			planResult, planErr := testutils.QueryTextResult(ctx, db,
+				"explain phyplan select v from forced_src")
+			require.NoError(t, planErr)
+			require.Contains(t, strings.ToUpper(planResult.ColumnName), "PHYPLAN ON MULTICN(")
+			require.Contains(t, planResult.Text, "Magic: Remote",
+				"the insert source must be scanned by a real remote scope")
+
+			execSQLDB(t, ctx, db, "insert ignore into forced_dst select v from forced_src")
+			var count, min, max int
+			err = db.QueryRowContext(ctx,
+				"select count(*), min(b + 0), max(b + 0) from forced_dst").Scan(&count, &min, &max)
+			require.NoError(t, err)
+			require.Equal(t, 4, count)
+			require.Equal(t, 15, min)
+			require.Equal(t, 15, max)
+		})
 	})
 }
 
@@ -165,68 +156,84 @@ func TestDataBranchDiffAsFile(t *testing.T) {
 			sqlDB, err := sql.Open("mysql", dsn)
 			require.NoError(t, err)
 			defer sqlDB.Close()
+			sqlDB.SetMaxOpenConns(1)
 
-			t.Log("single primary key diff with base snapshot")
-			runSinglePKWithBase(t, ctx, sqlDB)
+			dbName := testutils.GetDatabaseName(t)
+			defer cleanupTestDatabases(t, sqlDB, dbName)
+			execSQLDB(t, ctx, sqlDB, fmt.Sprintf("create database `%s`", dbName))
+			execSQLDB(t, ctx, sqlDB, fmt.Sprintf("use `%s`", dbName))
 
-			t.Log("multi primary key diff with base snapshot")
-			runMultiPKWithBase(t, ctx, sqlDB)
-
-			t.Log("single primary key diff without branch base relationship")
-			runSinglePKNoBase(t, ctx, sqlDB)
-
-			t.Log("multi primary key diff without branch base relationship")
-			runMultiPKNoBase(t, ctx, sqlDB)
-
-			t.Log("large composite diff with multi column workload")
-			runLargeCompositeDiff(t, ctx, sqlDB)
-
-			t.Log("diff output splits updates into delete + insert (single pk)")
-			runUpdateSplitDiffAsFile(t, ctx, sqlDB)
-
-			t.Log("diff output splits updates into delete + insert (composite pk)")
-			runCompositeUpdateSplitDiffAsFile(t, ctx, sqlDB)
-
-			t.Log("diff output handles no-pk duplicates and null deletes")
-			runNoPKDuplicateDiffAsFile(t, ctx, sqlDB)
-
-			t.Log("diff output handles mixed types and string edge cases")
-			runComplexTypeDiffAsFile(t, ctx, sqlDB)
-
-			t.Log("sql diff handles rows containing NULL values")
-			runSQLDiffHandlesNulls(t, ctx, sqlDB)
-
-			t.Log("data branch create database populates metadata")
-			runBranchDatabaseMetadata(t, ctx, sqlDB)
-
-			t.Log("csv diff emits large range dataset that can be loaded back")
-			runCSVLoadSimple(t, ctx, sqlDB)
-
-			t.Log("csv diff covers rich data type payloads")
-			runCSVLoadRichTypes(t, ctx, sqlDB)
-
-			t.Log("diff output limit returns subset of full diff")
-			runDiffOutputLimitSubset(t, ctx, sqlDB)
-
-			t.Log("diff output limit without branch relationship returns subset of full diff")
-			runDiffOutputLimitNoBase(t, ctx, sqlDB)
-
-			t.Log("diff output limit with large base workload still returns subset of full diff")
-			runDiffOutputLimitLargeBase(t, ctx, sqlDB)
-
-			t.Log("diff output summary validates complex snapshot and branch divergence scenarios")
-			runDiffOutputSummaryComplex(t, ctx, sqlDB)
-
-			t.Log("diff output to stage and load via datalink")
-			runDiffOutputToStage(t, ctx, sqlDB)
+			t.Run("single_pk_with_base", func(t *testing.T) {
+				runSinglePKWithBase(t, ctx, sqlDB, dbName)
+			})
+			t.Run("composite_pk_with_base", func(t *testing.T) {
+				runMultiPKWithBase(t, ctx, sqlDB, dbName)
+			})
+			t.Run("single_pk_without_base", func(t *testing.T) {
+				runSinglePKNoBase(t, ctx, sqlDB, dbName)
+			})
+			t.Run("composite_pk_without_base", func(t *testing.T) {
+				runMultiPKNoBase(t, ctx, sqlDB, dbName)
+			})
+			t.Run("composite_multi_column_mutations", func(t *testing.T) {
+				runCompositeDiffMultiColumn(t, ctx, sqlDB, dbName)
+			})
+			t.Run("single_pk_update_split", func(t *testing.T) {
+				runUpdateSplitDiffAsFile(t, ctx, sqlDB, dbName)
+			})
+			t.Run("composite_pk_update_split", func(t *testing.T) {
+				runCompositeUpdateSplitDiffAsFile(t, ctx, sqlDB, dbName)
+			})
+			t.Run("no_pk_duplicates_and_null_delete", func(t *testing.T) {
+				runNoPKDuplicateDiffAsFile(t, ctx, sqlDB, dbName)
+			})
+			t.Run("complex_types_and_string_edges", func(t *testing.T) {
+				runComplexTypeDiffAsFile(t, ctx, sqlDB, dbName)
+			})
+			t.Run("sql_null_values", func(t *testing.T) {
+				runSQLDiffHandlesNulls(t, ctx, sqlDB, dbName)
+			})
+			t.Run("database_branch_metadata", func(t *testing.T) {
+				runBranchDatabaseMetadata(t, ctx, sqlDB, dbName+"_metadata")
+				execSQLDB(t, ctx, sqlDB, fmt.Sprintf("use `%s`", dbName))
+			})
+			t.Run("csv_multi_block_round_trip", func(t *testing.T) {
+				runCSVLoadSimple(t, ctx, sqlDB, dbName)
+			})
+			t.Run("csv_rich_types_round_trip", func(t *testing.T) {
+				runCSVLoadRichTypes(t, ctx, sqlDB, dbName)
+			})
+			t.Run("output_limit_subset", func(t *testing.T) {
+				runDiffOutputLimitSubset(t, ctx, sqlDB, dbName)
+			})
+			t.Run("output_limit_without_base", func(t *testing.T) {
+				runDiffOutputLimitNoBase(t, ctx, sqlDB, dbName)
+			})
+			t.Run("output_limit_multi_block", func(t *testing.T) {
+				runDiffOutputLimitMultiBlockBase(t, ctx, sqlDB, dbName)
+			})
+			t.Run("output_summary", func(t *testing.T) {
+				runDiffOutputSummaryComplex(t, ctx, sqlDB, dbName)
+			})
+			t.Run("stage_round_trip", func(t *testing.T) {
+				runDiffOutputToStage(t, ctx, sqlDB, dbName)
+			})
 		})
 }
 
-func dataBranchScaleRows(full, short int) int {
-	if testing.Short() {
-		return short
+func cleanupTestDatabases(t *testing.T, db *sql.DB, names ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := db.ExecContext(ctx, "use mo_catalog"); err != nil {
+		t.Errorf("select cleanup database: %v", err)
 	}
-	return full
+	for _, name := range names {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("drop database if exists `%s`", name)); err != nil {
+			t.Errorf("drop cleanup database %s: %v", name, err)
+		}
+	}
 }
 
 func TestCloneCommitFailureRollbackKeepsSourceFiles(t *testing.T) {
@@ -310,24 +317,16 @@ func runCloneCommitFailureRollbackKeepsSourceFiles(t *testing.T, parentCtx conte
 	require.Equal(t, 50, queryRowCount(t, ctx, db, "select count(*) from src where id mod 100 = 0"))
 }
 
-func runSinglePKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runSinglePKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "single_pk_base"
 	branch := "single_pk_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (id int primary key, value int, note varchar(32))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into `%s` values (1, 10, 'seed'), (2, 20, 'seed'), (3, 30, 'seed')", base))
@@ -350,24 +349,16 @@ func runSinglePKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runMultiPKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runMultiPKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "multi_pk_base"
 	branch := "multi_pk_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (org_id int, event_id int, quantity int, status varchar(16), primary key (org_id, event_id))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into `%s` values (1, 1, 100, 'seed'), (1, 2, 200, 'seed'), (2, 1, 300, 'seed')", base))
@@ -391,24 +382,16 @@ func runMultiPKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runSinglePKNoBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runSinglePKNoBase(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "single_pk_nobranch_base"
 	target := "single_pk_nobranch_target"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (id int primary key, label varchar(20), amount int)", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (id int primary key, label varchar(20), amount int)", target))
@@ -431,24 +414,16 @@ func runSinglePKNoBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	assertTablesEqual(t, ctx, db, dbName, target, base)
 }
 
-func runMultiPKNoBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runMultiPKNoBase(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "multi_pk_nobranch_base"
 	target := "multi_pk_nobranch_target"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (region int, device_id int, reading int, note varchar(24), primary key (region, device_id))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (region int, device_id int, reading int, note varchar(24), primary key (region, device_id))", target))
@@ -471,26 +446,20 @@ func runMultiPKNoBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	assertTablesEqual(t, ctx, db, dbName, target, base)
 }
 
-func runLargeCompositeDiff(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runCompositeDiffMultiColumn(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*150)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "composite_base"
 	branch := "composite_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-	baseRows := dataBranchScaleRows(10000, 2000)
-	insertRows := dataBranchScaleRows(800, 200)
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
+	const (
+		baseRows   = 2000
+		insertRows = 200
+	)
 
 	execSQLDB(t, ctx, db, fmt.Sprintf(`
 create table %s (
@@ -553,24 +522,16 @@ from generate_series(%d, %d) as g`, branch, baseRows+1, baseRows+insertRows)
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runSQLDiffHandlesNulls(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runSQLDiffHandlesNulls(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*120)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "sql_null_base"
 	branch := "sql_null_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf(`
 create table %s (
@@ -606,25 +567,18 @@ insert into %s values
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runCSVLoadSimple(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runCSVLoadSimple(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*180)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
-	base := "csv_massive_base"
-	target := "csv_massive_target"
+	base := "csv_range_base"
+	target := "csv_range_target"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-	rowCount := dataBranchScaleRows(1000*100, int(objectio.BlockMaxRows)*2)
+	rowCount := int(objectio.BlockMaxRows) * 2
 
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table %s (a int primary key, b int)", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table %s like %s", target, base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into %s select *, * from generate_series(1, %d) g", target, rowCount))
@@ -638,24 +592,17 @@ func runCSVLoadSimple(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	assertTablesEqual(t, ctx, db, dbName, target, base)
 }
 
-func runCSVLoadRichTypes(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runCSVLoadRichTypes(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*180)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "csv_rich_types_base"
 	target := "csv_rich_types_target"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
 
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 	execSQLDB(t, ctx, db, fmt.Sprintf(`
 create table %s (
 	id int primary key,
@@ -688,22 +635,14 @@ insert into %s values
 	assertTablesEqual(t, ctx, db, dbName, target, base)
 }
 
-func runDiffOutputLimitSubset(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runDiffOutputLimitSubset(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "limit_base"
 	branch := "limit_branch"
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table %s (id int primary key, val int, note varchar(16))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into %s values (1, 10, 'seed'), (2, 20, 'seed'), (3, 30, 'seed'), (4, 40, 'seed'), (5, 50, 'seed'), (6, 60, 'seed')", base))
@@ -756,22 +695,14 @@ func runDiffOutputLimitSubset(t *testing.T, parentCtx context.Context, db *sql.D
 	}
 }
 
-func runDiffOutputLimitNoBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runDiffOutputLimitNoBase(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "limit_nobranch_base"
 	target := "limit_nobranch_target"
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table %s (id int primary key, val int, note varchar(16))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table %s (id int primary key, val int, note varchar(16))", target))
@@ -801,37 +732,22 @@ func runDiffOutputLimitNoBase(t *testing.T, parentCtx context.Context, db *sql.D
 	}
 }
 
-func runDiffOutputLimitLargeBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runDiffOutputLimitMultiBlockBase(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*180)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
-	base := "limit_large_t1"
-	branch := "limit_large_t2"
-	rowCount := dataBranchScaleRows(8192*100, int(objectio.BlockMaxRows)*3+100)
-	updateEnd := 10000
-	branchUpdateStart := 10000
-	branchUpdateEnd := 10001
-	deleteStart := 30000
-	deleteEnd := 100000
-	if testing.Short() {
-		// Keep at least three blocks and both update/delete sides of the diff;
-		// the 100-block volume is reserved for explicit non-short stress runs.
-		updateEnd = rowCount / 4
-		branchUpdateStart = updateEnd
-		branchUpdateEnd = updateEnd + 1
-		deleteStart = rowCount / 2
-		deleteEnd = rowCount * 3 / 4
-	}
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
+	base := "limit_multiblock_base"
+	branch := "limit_multiblock_branch"
+	// Three full blocks plus a tail block are the minimum deterministic shape
+	// needed by this case. Larger volumes repeat the same diff/limit paths.
+	rowCount := int(objectio.BlockMaxRows)*3 + 100
+	updateEnd := rowCount / 4
+	branchUpdateStart := updateEnd
+	branchUpdateEnd := updateEnd + 1
+	deleteStart := rowCount / 2
+	deleteEnd := rowCount * 3 / 4
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table %s (a int primary key, b int, c time)", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into %s select *, *, '12:34:56' from generate_series(1, %d)g", base, rowCount))
@@ -868,25 +784,17 @@ func runDiffOutputLimitLargeBase(t *testing.T, parentCtx context.Context, db *sq
 	limitQuery(len(fullRows) * 20 / 100)
 }
 
-func runDiffOutputSummaryComplex(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runDiffOutputSummaryComplex(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*150)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	seed := "summary_seed"
 	left := "summary_left"
 	right := "summary_right"
 	standaloneBase := "summary_standalone_base"
 	standaloneTarget := "summary_standalone_target"
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	// Divergent branch scenario to verify both target/base columns can be non-zero per metric.
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table %s (id int primary key, val int)", seed))
@@ -928,28 +836,22 @@ func runDiffOutputSummaryComplex(t *testing.T, parentCtx context.Context, db *sq
 	require.Greater(t, standaloneCount, int64(0), "standalone summary/count should report non-zero diff rows")
 }
 
-func runDiffOutputToStage(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runDiffOutputToStage(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*120)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "stage_base"
 	branch := "stage_branch"
 
 	stageDir := t.TempDir()
-	stageName := "stage_local_" + strings.ToLower(testutils.GetDatabaseName(t))
+	stageName := "stage_local_" + strings.ToLower(dbName)
 	stageURL := fmt.Sprintf("file://%s", stageDir)
 
 	execSQLDB(t, ctx, db, "set role moadmin")
 	execSQLDB(t, ctx, db, fmt.Sprintf("create stage %s url = '%s'", stageName, stageURL))
 	defer execSQLDB(t, ctx, db, fmt.Sprintf("drop stage if exists %s", stageName))
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s`.`%s` (id int primary key, val int)", dbName, base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into `%s`.`%s` values (1, 10), (2, 20), (3, 30)", dbName, base))
@@ -1004,24 +906,16 @@ func runDiffOutputToStage(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "split_pk_base"
 	branch := "split_pk_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (id int primary key, score int, note varchar(32))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into `%s` values (1, 10, 'seed'), (2, 20, 'seed'), (3, 30, 'seed')", base))
@@ -1044,24 +938,16 @@ func runUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.D
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runCompositeUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runCompositeUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "split_comp_base"
 	branch := "split_comp_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (org_id int, event_id int, qty int, note varchar(32), primary key (org_id, event_id))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf("insert into `%s` values (1, 1, 10, 'seed'), (1, 2, 20, 'seed'), (2, 1, 30, 'seed')", base))
@@ -1086,24 +972,16 @@ func runCompositeUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, 
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runNoPKDuplicateDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runNoPKDuplicateDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*120)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "no_pk_base"
 	branch := "no_pk_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (id int, grp int, note varchar(32))", base))
 	execSQLDB(t, ctx, db, fmt.Sprintf(`insert into %s values
@@ -1141,24 +1019,16 @@ func runNoPKDuplicateDiffAsFile(t *testing.T, parentCtx context.Context, db *sql
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runComplexTypeDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runComplexTypeDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*120)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	base := "complex_base"
 	branch := "complex_branch"
 	diffDir := t.TempDir()
 	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
 	execSQLDB(t, ctx, db, fmt.Sprintf(`
 create table %s (
@@ -1200,21 +1070,17 @@ create table %s (
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
 }
 
-func runBranchDatabaseMetadata(t *testing.T, parentCtx context.Context, db *sql.DB) {
+func runBranchDatabaseMetadata(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
 	defer cancel()
 
-	dbName := testutils.GetDatabaseName(t)
 	copyDB := dbName + "_copy"
 	tables := []string{"tbl_one", "tbl_two"}
 
+	defer cleanupTestDatabases(t, db, copyDB, dbName)
 	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	defer func() {
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", copyDB))
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
-	}()
 
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s`.`%s` (id int primary key)", dbName, tables[0]))
 	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s`.`%s` (id int primary key)", dbName, tables[1]))

--- a/pkg/tests/dml/pick_regression_retest_test.go
+++ b/pkg/tests/dml/pick_regression_retest_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 )
 
 func openRetestSQLDB(t *testing.T, c embed.Cluster) *sql.DB {
@@ -38,92 +39,11 @@ func openRetestSQLDB(t *testing.T, c embed.Cluster) *sql.DB {
 	dsn := fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port)
 	db, err := sql.Open("mysql", dsn)
 	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
 	return db
 }
 
-func TestDataBranchPickRetestCompositePKChunkProbe(t *testing.T) {
-	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
-		defer cancel()
-
-		db := openRetestSQLDB(t, c)
-		defer db.Close()
-		execSQLDB(t, ctx, db, "set role moadmin")
-
-		_, cleanup := pickDB(t, ctx, db)
-		defer cleanup()
-
-		execSQLDB(t, ctx, db, "create table base (k1 int, k2 int, val bigint, primary key (k1, k2))")
-		baseRows := dataBranchScaleRows(1000000, int(objectio.BlockMaxRows)*4)
-		execSQLDB(t, ctx, db, fmt.Sprintf(
-			"insert into base select 1, result, result * 10 from generate_series(1,%d) g",
-			baseRows))
-
-		execSQLDB(t, ctx, db, "data branch create table src from base")
-		execSQLDB(t, ctx, db, "data branch create table dst from base")
-		execSQLDB(t, ctx, db, "update src set val = val + 1 where k2 between 1 and 8192")
-
-		execSQLDB(t, ctx, db, "create table pick_keys (k1 int, k2 int)")
-		execSQLDB(t, ctx, db,
-			"insert into pick_keys select 1, result from generate_series(10000,18191) g")
-		execSQLDB(t, ctx, db,
-			"insert into pick_keys select 1, result from generate_series(1,8192) g")
-
-		firstChunk := queryStringRows(t, ctx, db,
-			"select min(k2), max(k2), count(*) from (select k1, k2 from pick_keys order by 1, 2 limit 8192) t")
-		secondChunk := queryStringRows(t, ctx, db,
-			"select min(k2), max(k2), count(*) from (select k1, k2 from pick_keys order by 1, 2 limit 8192 offset 8192) t")
-		t.Logf("composite chunk layout after fix: first=%v second=%v", firstChunk, secondChunk)
-
-		execSQLDB(t, ctx, db, "data branch pick src into dst keys(select k1, k2 from pick_keys)")
-
-		updatedCnt := queryRowCount(t, ctx, db,
-			"select count(*) from dst where k1 = 1 and k2 between 1 and 8192 and val = k2 * 10 + 1")
-		unchangedCnt := queryRowCount(t, ctx, db,
-			"select count(*) from dst where k1 = 1 and k2 between 1 and 8192 and val = k2 * 10")
-		totalCnt := queryRowCount(t, ctx, db,
-			"select count(*) from dst where k1 = 1 and k2 between 1 and 8192")
-		t.Logf("composite retest counts: updated=%d unchanged=%d total=%d", updatedCnt, unchangedCnt, totalCnt)
-
-		require.Equal(t, 8192, totalCnt)
-		require.Equal(t, 8192, updatedCnt)
-		require.Equal(t, 0, unchangedCnt)
-	})
-}
-
-func TestDataBranchPickRetestNoPKSubqueryFakePK(t *testing.T) {
-	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer cancel()
-
-		db := openRetestSQLDB(t, c)
-		defer db.Close()
-		execSQLDB(t, ctx, db, "set role moadmin")
-
-		_, cleanup := pickDB(t, ctx, db)
-		defer cleanup()
-
-		execSQLDB(t, ctx, db, "create table base (id int, payload varchar(32))")
-		execSQLDB(t, ctx, db, "insert into base values (1, 'one'), (2, 'two'), (3, 'three')")
-		execSQLDB(t, ctx, db, "data branch create table src from base")
-		execSQLDB(t, ctx, db, "data branch create table dst from base")
-
-		execSQLDB(t, ctx, db, "create table pick_keys (fpk bigint unsigned)")
-		execSQLDB(t, ctx, db, "insert into pick_keys select `__mo_fake_pk_col` from src where id in (1, 2) order by id")
-
-		execSQLDB(t, ctx, db, "update src set payload = 'ONE' where id = 1")
-		execSQLDB(t, ctx, db, "delete from src where id = 2")
-		execSQLDB(t, ctx, db, "insert into src values (4, 'four')")
-		execSQLDB(t, ctx, db, "insert into pick_keys select `__mo_fake_pk_col` from src where id = 4")
-
-		errMsg := execExpectError(t, ctx, db,
-			"data branch pick src into dst keys(select fpk from pick_keys order by fpk)")
-		t.Logf("no-pk retest error: %s", errMsg)
-		require.Contains(t, errMsg, "requires a table with a primary key")
-	})
-}
-
-func TestDataBranchPickRetestDatePKLiteral(t *testing.T) {
+func TestDataBranchPickRetestRegressions(t *testing.T) {
 	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
@@ -132,19 +52,85 @@ func TestDataBranchPickRetestDatePKLiteral(t *testing.T) {
 		defer db.Close()
 		execSQLDB(t, ctx, db, "set role moadmin")
 
-		_, cleanup := pickDB(t, ctx, db)
-		defer cleanup()
+		dbName := testutils.GetDatabaseName(t)
+		defer cleanupTestDatabases(t, db, dbName)
+		execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
+		execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
 
-		execSQLDB(t, ctx, db, "create table base (d date primary key, v int)")
-		execSQLDB(t, ctx, db, "insert into base values ('2025-01-01', 10), ('2025-01-02', 20)")
-		execSQLDB(t, ctx, db, "data branch create table src from base")
-		execSQLDB(t, ctx, db, "data branch create table dst from base")
-		execSQLDB(t, ctx, db, "insert into src values ('2025-01-03', 30)")
+		t.Run("composite_pk_chunk_boundary", func(t *testing.T) {
+			defer cleanupPickCaseTables(t, db)
+			execSQLDB(t, ctx, db, "create table base (k1 int, k2 int, val bigint, primary key (k1, k2))")
+			// Four blocks cover both 8192-key chunks plus untouched source rows.
+			// Additional rows do not change the chunk-boundary regression contract.
+			baseRows := int(objectio.BlockMaxRows) * 4
+			execSQLDB(t, ctx, db, fmt.Sprintf(
+				"insert into base select 1, result, result * 10 from generate_series(1,%d) g",
+				baseRows))
+			execSQLDB(t, ctx, db, "data branch create table src from base")
+			execSQLDB(t, ctx, db, "data branch create table dst from base")
+			execSQLDB(t, ctx, db, "update src set val = val + 1 where k2 between 1 and 8192")
+			execSQLDB(t, ctx, db, "create table pick_keys (k1 int, k2 int)")
+			execSQLDB(t, ctx, db,
+				"insert into pick_keys select 1, result from generate_series(10000,18191) g")
+			execSQLDB(t, ctx, db,
+				"insert into pick_keys select 1, result from generate_series(1,8192) g")
 
-		execSQLDB(t, ctx, db, "data branch pick src into dst keys('2025-01-03')")
+			firstChunk := queryStringRows(t, ctx, db,
+				"select min(k2), max(k2), count(*) from (select k1, k2 from pick_keys order by 1, 2 limit 8192) t")
+			secondChunk := queryStringRows(t, ctx, db,
+				"select min(k2), max(k2), count(*) from (select k1, k2 from pick_keys order by 1, 2 limit 8192 offset 8192) t")
+			require.Equal(t, [][]string{{"1", "8192", "8192"}}, firstChunk)
+			require.Equal(t, [][]string{{"10000", "18191", "8192"}}, secondChunk)
 
-		rows := queryStringRows(t, ctx, db, "select cast(d as char), cast(v as char) from dst where d = '2025-01-03'")
-		t.Logf("date-pk retest rows: %v", rows)
-		require.Equal(t, [][]string{{"2025-01-03", "30"}}, rows)
+			execSQLDB(t, ctx, db, "data branch pick src into dst keys(select k1, k2 from pick_keys)")
+			updatedCnt := queryRowCount(t, ctx, db,
+				"select count(*) from dst where k1 = 1 and k2 between 1 and 8192 and val = k2 * 10 + 1")
+			unchangedCnt := queryRowCount(t, ctx, db,
+				"select count(*) from dst where k1 = 1 and k2 between 1 and 8192 and val = k2 * 10")
+			totalCnt := queryRowCount(t, ctx, db,
+				"select count(*) from dst where k1 = 1 and k2 between 1 and 8192")
+			untouchedCnt := queryRowCount(t, ctx, db, fmt.Sprintf(
+				"select count(*) from dst where k1 = 1 and k2 in (8193,18192,%d) and val = k2 * 10",
+				baseRows))
+			require.Equal(t, 8192, totalCnt)
+			require.Equal(t, 8192, updatedCnt)
+			require.Equal(t, 0, unchangedCnt)
+			require.Equal(t, 3, untouchedCnt)
+		})
+
+		t.Run("no_pk_subquery_rejected", func(t *testing.T) {
+			defer cleanupPickCaseTables(t, db)
+			execSQLDB(t, ctx, db, "create table base (id int, payload varchar(32))")
+			execSQLDB(t, ctx, db, "insert into base values (1, 'one'), (2, 'two'), (3, 'three')")
+			execSQLDB(t, ctx, db, "data branch create table src from base")
+			execSQLDB(t, ctx, db, "data branch create table dst from base")
+			execSQLDB(t, ctx, db, "create table pick_keys (fpk bigint unsigned)")
+			execSQLDB(t, ctx, db, "insert into pick_keys select `__mo_fake_pk_col` from src where id in (1, 2) order by id")
+			execSQLDB(t, ctx, db, "update src set payload = 'ONE' where id = 1")
+			execSQLDB(t, ctx, db, "delete from src where id = 2")
+			execSQLDB(t, ctx, db, "insert into src values (4, 'four')")
+			execSQLDB(t, ctx, db, "insert into pick_keys select `__mo_fake_pk_col` from src where id = 4")
+
+			errMsg := execExpectError(t, ctx, db,
+				"data branch pick src into dst keys(select fpk from pick_keys order by fpk)")
+			require.Contains(t, errMsg, "requires a table with a primary key")
+			require.Equal(t, [][]string{{"1", "one"}, {"2", "two"}, {"3", "three"}},
+				queryStringRows(t, ctx, db, "select id, payload from dst order by id"),
+				"a rejected pick must leave the destination unchanged")
+		})
+
+		t.Run("date_pk_literal", func(t *testing.T) {
+			defer cleanupPickCaseTables(t, db)
+			execSQLDB(t, ctx, db, "create table base (d date primary key, v int)")
+			execSQLDB(t, ctx, db, "insert into base values ('2025-01-01', 10), ('2025-01-02', 20)")
+			execSQLDB(t, ctx, db, "data branch create table src from base")
+			execSQLDB(t, ctx, db, "data branch create table dst from base")
+			execSQLDB(t, ctx, db, "insert into src values ('2025-01-03', 30)")
+			execSQLDB(t, ctx, db, "data branch pick src into dst keys('2025-01-03')")
+
+			rows := queryStringRows(t, ctx, db,
+				"select cast(d as char), cast(v as char) from dst where d = '2025-01-03'")
+			require.Equal(t, [][]string{{"2025-01-03", "30"}}, rows)
+		})
 	})
 }

--- a/pkg/tests/dml/pick_test.go
+++ b/pkg/tests/dml/pick_test.go
@@ -19,7 +19,6 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -45,54 +44,49 @@ func TestDataBranchPick(t *testing.T) {
 			sqlDB, err := sql.Open("mysql", dsn)
 			require.NoError(t, err)
 			defer sqlDB.Close()
+			sqlDB.SetMaxOpenConns(1)
 
-			t.Log("pick specific rows by PK value list")
-			runPickByKeyValues(t, ctx, sqlDB)
+			dbName := testutils.GetDatabaseName(t)
+			defer cleanupTestDatabases(t, sqlDB, dbName)
+			execSQLDB(t, ctx, sqlDB, fmt.Sprintf("create database `%s`", dbName))
+			execSQLDB(t, ctx, sqlDB, fmt.Sprintf("use `%s`", dbName))
 
-			t.Log("pick all rows (no KEYS clause)")
-			runPickAll(t, ctx, sqlDB)
-
-			t.Log("pick with DELETE propagation")
-			runPickWithDelete(t, ctx, sqlDB)
-
-			t.Log("pick conflict matrix")
-			runPickConflictMatrix(t, ctx, sqlDB)
-
-			t.Log("pick with subquery KEYS")
-			runPickSubqueryKeys(t, ctx, sqlDB)
-
-			t.Log("pick with subquery key coercion")
-			runPickSubqueryKeyCoercion(t, ctx, sqlDB)
-
-			t.Log("pick subquery rejects NULL keys")
-			runPickSubqueryRejectsNullKey(t, ctx, sqlDB)
-
-			t.Log("pick subquery rejects invalid key coercion")
-			runPickSubqueryRejectsInvalidCoercion(t, ctx, sqlDB)
-
-			t.Log("large-scale pick (1000 rows, pick 50)")
-			runPickLargeScale(t, ctx, sqlDB)
-
-			t.Log("pick with varchar primary key")
-			runPickVarcharPK(t, ctx, sqlDB)
-
-			t.Log("pick varchar delete/update conflict handles escaped keys on LCA path")
-			runPickVarcharPKLCAEscapedDeleteUpdate(t, ctx, sqlDB)
-
-			t.Log("pick consecutive: two picks from same source")
-			runPickConsecutive(t, ctx, sqlDB)
-
-			t.Log("pick into table with pre-existing non-overlapping data")
-			runPickIntoExistingData(t, ctx, sqlDB)
-
-			t.Log("pick with mixed INSERT + UPDATE + DELETE in source")
-			runPickMixedOperations(t, ctx, sqlDB)
-
-			t.Log("pick rejects destination snapshots")
-			runPickRejectDstSnapshot(t, ctx, sqlDB)
-
-			t.Log("pick rejects explicit transactions")
-			runPickRejectExplicitTransaction(t, ctx, sqlDB)
+			t.Run("key_values_and_consecutive_pick", func(t *testing.T) {
+				runPickByKeyValues(t, ctx, sqlDB)
+			})
+			t.Run("conflict_policies", func(t *testing.T) {
+				runPickConflictMatrix(t, ctx, sqlDB)
+			})
+			t.Run("subquery_keys", func(t *testing.T) {
+				runPickSubqueryKeys(t, ctx, sqlDB)
+			})
+			t.Run("subquery_key_coercion", func(t *testing.T) {
+				runPickSubqueryKeyCoercion(t, ctx, sqlDB)
+			})
+			t.Run("subquery_rejects_null_key", func(t *testing.T) {
+				runPickSubqueryRejectsNullKey(t, ctx, sqlDB)
+			})
+			t.Run("subquery_rejects_invalid_coercion", func(t *testing.T) {
+				runPickSubqueryRejectsInvalidCoercion(t, ctx, sqlDB)
+			})
+			t.Run("varchar_primary_key", func(t *testing.T) {
+				runPickVarcharPK(t, ctx, sqlDB)
+			})
+			t.Run("varchar_escaped_lca_conflict", func(t *testing.T) {
+				runPickVarcharPKLCAEscapedDeleteUpdate(t, ctx, sqlDB)
+			})
+			t.Run("non_overlapping_destination_data", func(t *testing.T) {
+				runPickIntoExistingData(t, ctx, sqlDB)
+			})
+			t.Run("mixed_insert_update_delete", func(t *testing.T) {
+				runPickMixedOperations(t, ctx, sqlDB)
+			})
+			t.Run("rejects_destination_snapshot", func(t *testing.T) {
+				runPickRejectDstSnapshot(t, ctx, sqlDB)
+			})
+			t.Run("rejects_explicit_transaction", func(t *testing.T) {
+				runPickRejectExplicitTransaction(t, ctx, sqlDB)
+			})
 		})
 }
 
@@ -168,15 +162,17 @@ func execExpectError(t *testing.T, ctx context.Context, db *sql.DB, stmt string)
 	return err.Error()
 }
 
-// pickDB creates a unique database and returns (dbName, cleanup).
-func pickDB(t *testing.T, ctx context.Context, db *sql.DB) (string, func()) {
+// cleanupPickCaseTables lets the orthogonal pick scenarios share one database
+// while retaining fresh table state. Descendants are listed before their base
+// tables so branch metadata is removed in dependency order.
+func cleanupPickCaseTables(t *testing.T, db *sql.DB) {
 	t.Helper()
-	dbName := testutils.GetDatabaseName(t)
-	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
-	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
-	return dbName, func() {
-		execSQLDB(t, ctx, db, "use mo_catalog")
-		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(ctx,
+		"drop table if exists dst, src, base, pick_keys, ckeys, csrc, cbase")
+	if err != nil {
+		t.Errorf("clean up shared data branch pick tables: %v", err)
 	}
 }
 
@@ -184,14 +180,14 @@ func pickDB(t *testing.T, ctx context.Context, db *sql.DB) (string, func()) {
 // test cases
 // ---------------------------------------------------------------------------
 
-// runPickByKeyValues: pick 2 out of 5 inserted rows by KEYS(2,4).
+// runPickByKeyValues covers subset selection, an already-identical key, and a
+// second pick from the same source without rebuilding an equivalent fixture.
 func runPickByKeyValues(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10),(2,20),(3,30)")
@@ -209,53 +205,12 @@ func runPickByKeyValues(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	var b int
 	require.NoError(t, db.QueryRowContext(ctx, "select b from base where a=4").Scan(&b))
 	require.Equal(t, 40, b)
-}
 
-// runPickAll: pick everything (no KEYS clause) from branch into base.
-func runPickAll(t *testing.T, parentCtx context.Context, db *sql.DB) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
-	defer cancel()
-
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
-
-	execSQLDB(t, ctx, db, "create table base (a int primary key, b varchar(32))")
-	execSQLDB(t, ctx, db, "insert into base values (1,'one'),(2,'two')")
-	execSQLDB(t, ctx, db, "data branch create table src from base")
-	execSQLDB(t, ctx, db, "insert into src values (3,'three'),(4,'four'),(5,'five')")
-
-	execSQLDB(t, ctx, db, "data branch pick src into base keys(1,2,3,4,5)")
-
-	cnt := queryRowCount(t, ctx, db, "select count(*) from base")
-	require.Equal(t, 5, cnt)
-
-	pks := queryIntColumn(t, ctx, db, "select a from base order by a")
+	// A second pick proves the source remains usable and completes the set. This
+	// subsumes the old duplicate "pick all" and "consecutive" fixtures.
+	execSQLDB(t, ctx, db, "data branch pick src into base keys(5)")
+	pks = queryIntColumn(t, ctx, db, "select a from base order by a")
 	require.Equal(t, []int{1, 2, 3, 4, 5}, pks)
-}
-
-// runPickWithDelete: source branch deletes rows, pick propagates deletion.
-func runPickWithDelete(t *testing.T, parentCtx context.Context, db *sql.DB) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
-	defer cancel()
-
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
-
-	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
-	execSQLDB(t, ctx, db, "insert into base values (1,10),(2,20),(3,30),(4,40),(5,50)")
-	execSQLDB(t, ctx, db, "data branch create table src from base")
-
-	// Delete rows 2 and 4 in src
-	execSQLDB(t, ctx, db, "delete from src where a in (2,4)")
-	// Also insert a new row
-	execSQLDB(t, ctx, db, "insert into src values (6,60)")
-
-	execSQLDB(t, ctx, db, "data branch pick src into base keys(1,2,3,4,5,6)")
-
-	pks := queryIntColumn(t, ctx, db, "select a from base order by a")
-	require.Equal(t, []int{1, 3, 5, 6}, pks)
 }
 
 // runPickConflictMatrix covers four conflict shapes against all three policies.
@@ -269,9 +224,6 @@ func runPickConflictMatrix(t *testing.T, parentCtx context.Context, db *sql.DB) 
 	// deadline than they had as independent tests on slower CI runners.
 	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel()
-
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
 
 	execSQLDB(t, ctx, db, "create table conflict_base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into conflict_base values (1,10),(2,20)")
@@ -384,8 +336,7 @@ func runPickSubqueryKeys(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10),(2,20),(3,30)")
@@ -415,8 +366,7 @@ func runPickSubqueryKeyCoercion(t *testing.T, parentCtx context.Context, db *sql
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a bigint primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10)")
@@ -448,8 +398,7 @@ func runPickSubqueryRejectsNullKey(t *testing.T, parentCtx context.Context, db *
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10)")
@@ -469,8 +418,7 @@ func runPickSubqueryRejectsInvalidCoercion(t *testing.T, parentCtx context.Conte
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10)")
@@ -485,57 +433,13 @@ func runPickSubqueryRejectsInvalidCoercion(t *testing.T, parentCtx context.Conte
 	require.Equal(t, []int{1}, queryIntColumn(t, ctx, db, "select a from base order by a"))
 }
 
-// runPickLargeScale: 1000-row table, branch inserts 500 more, pick 50 specific.
-func runPickLargeScale(t *testing.T, parentCtx context.Context, db *sql.DB) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(parentCtx, 120*time.Second)
-	defer cancel()
-
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
-
-	execSQLDB(t, ctx, db, "create table base (a int primary key, b varchar(64))")
-
-	// Insert 1000 seed rows
-	execSQLDB(t, ctx, db,
-		"insert into base select result, concat('seed_', cast(result as char)) from generate_series(1,1000) g")
-
-	execSQLDB(t, ctx, db, "data branch create table src from base")
-
-	// Insert 500 new rows in src (1001..1500)
-	execSQLDB(t, ctx, db,
-		"insert into src select result, concat('new_', cast(result as char)) from generate_series(1001,1500) g")
-
-	// Pick 50 specific new rows: 1001,1011,1021,...,1491
-	keyList := make([]string, 50)
-	for i := 0; i < 50; i++ {
-		keyList[i] = strconv.Itoa(1001 + i*10)
-	}
-	keysCSV := strings.Join(keyList, ",")
-
-	execSQLDB(t, ctx, db, fmt.Sprintf("data branch pick src into base keys(%s)", keysCSV))
-
-	cnt := queryRowCount(t, ctx, db, "select count(*) from base")
-	require.Equal(t, 1050, cnt) // 1000 seed + 50 picked
-
-	// Spot-check: key 1001 should exist with value 'new_1001'
-	var b string
-	require.NoError(t, db.QueryRowContext(ctx, "select b from base where a=1001").Scan(&b))
-	require.Equal(t, "new_1001", b)
-
-	// Key 1002 should NOT exist (we didn't pick it)
-	cnt = queryRowCount(t, ctx, db, "select count(*) from base where a=1002")
-	require.Equal(t, 0, cnt)
-}
-
 // runPickVarcharPK: pick with non-integer PK.
 func runPickVarcharPK(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (name varchar(64) primary key, score int)")
 	execSQLDB(t, ctx, db, "insert into base values ('alice',85),('bob',90)")
@@ -557,8 +461,7 @@ func runPickVarcharPKLCAEscapedDeleteUpdate(t *testing.T, parentCtx context.Cont
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (name varchar(64) primary key, score int)")
 	execSQLDB(t, ctx, db,
@@ -576,39 +479,13 @@ func runPickVarcharPKLCAEscapedDeleteUpdate(t *testing.T, parentCtx context.Cont
 	require.Equal(t, [][]string{{"plain", "95"}}, rows)
 }
 
-// runPickConsecutive: two consecutive picks from the same source.
-func runPickConsecutive(t *testing.T, parentCtx context.Context, db *sql.DB) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
-	defer cancel()
-
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
-
-	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
-	execSQLDB(t, ctx, db, "insert into base values (1,10)")
-	execSQLDB(t, ctx, db, "data branch create table src from base")
-	execSQLDB(t, ctx, db, "insert into src values (2,20),(3,30),(4,40),(5,50)")
-
-	// First pick: keys 2,3
-	execSQLDB(t, ctx, db, "data branch pick src into base keys(2,3)")
-	pks := queryIntColumn(t, ctx, db, "select a from base order by a")
-	require.Equal(t, []int{1, 2, 3}, pks)
-
-	// Second pick: keys 4,5
-	execSQLDB(t, ctx, db, "data branch pick src into base keys(4,5)")
-	pks = queryIntColumn(t, ctx, db, "select a from base order by a")
-	require.Equal(t, []int{1, 2, 3, 4, 5}, pks)
-}
-
 // runPickIntoExistingData: dst already has rows that don't overlap with src.
 func runPickIntoExistingData(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10)")
@@ -632,8 +509,7 @@ func runPickMixedOperations(t *testing.T, parentCtx context.Context, db *sql.DB)
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int, c varchar(32))")
 	execSQLDB(t, ctx, db, "insert into base values (1,10,'x'),(2,20,'y'),(3,30,'z'),(4,40,'w'),(5,50,'v')")
@@ -675,8 +551,7 @@ func runPickRejectDstSnapshot(t *testing.T, parentCtx context.Context, db *sql.D
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10)")
@@ -694,8 +569,7 @@ func runPickRejectExplicitTransaction(t *testing.T, parentCtx context.Context, d
 	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
 	defer cancel()
 
-	_, cleanup := pickDB(t, ctx, db)
-	defer cleanup()
+	defer cleanupPickCaseTables(t, db)
 
 	execSQLDB(t, ctx, db, "create table base (a int primary key, b int)")
 	execSQLDB(t, ctx, db, "insert into base values (1,10)")

--- a/pkg/tests/issues/isolated/hashbuild_recovery_test.go
+++ b/pkg/tests/issues/isolated/hashbuild_recovery_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -33,7 +34,11 @@ import (
 
 const (
 	hashBuildRecoveryQueryCap = int64(28 << 20)
-	hashBuildRecoveryRows     = 1_000_000
+	// Ninety-six full three-BIGINT batches contain 18 MiB of vector data. Hash
+	// cells then cross the original 28 MiB hard budget after batch retention,
+	// preserving the map-admission recovery path without a million-row fixture.
+	// A small tail also exercises partial-batch recovery accounting.
+	hashBuildRecoveryRows = colexec.DefaultBatchSize*96 + colexec.DefaultBatchSize/16
 )
 
 // TestHashBuildSharedBudgetRecoverySQL is the SQL-protocol counterexample for
@@ -117,7 +122,7 @@ func TestHashBuildSharedBudgetRecoverySQL(t *testing.T) {
 	require.NotEqualf(t, -1, probeScan, "probe scan missing from plan:\n%s", plan)
 	require.NotEqualf(t, -1, buildScan, "build scan missing from plan:\n%s", plan)
 	require.Lessf(t, probeScan, buildScan,
-		"the million-row table must remain the right/hash-build input:\n%s", plan)
+		"the larger table must remain the right/hash-build input:\n%s", plan)
 
 	spillBefore := promtestutil.ToFloat64(
 		metricv2.HashBuildSpillDepthCounter.WithLabelValues("spill", "1"))

--- a/pkg/tests/issues/isolated/issue_25782_broadcast_budget_test.go
+++ b/pkg/tests/issues/isolated/issue_25782_broadcast_budget_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -35,7 +36,11 @@ import (
 
 const (
 	issue25782QueryBudget = int64(1 << 20)
-	issue25782BuildRows   = int64(200_000)
+	// Eight full two-BIGINT batches contain exactly 1 MiB of vector data.
+	// Hash cells and vector metadata therefore make the resident broadcast
+	// build exceed the 1 MiB hard budget without an oversized fixture. A small
+	// tail also retains non-full-batch ingestion behavior from the old fixture.
+	issue25782BuildRows = int64(colexec.DefaultBatchSize*8 + colexec.DefaultBatchSize/16)
 )
 
 // TestIssue25782BroadcastHashBuildFailsClosedUnderHardBudget proves the

--- a/pkg/tests/issues/issue_26095_test.go
+++ b/pkg/tests/issues/issue_26095_test.go
@@ -47,7 +47,8 @@ func runIssue26095ConcurrentDataBranchDeletion(t *testing.T, c embed.Cluster) {
 	execSQLRequire(t, ctx, rootDB, fmt.Sprintf(
 		"create account `%s` admin_name 'admin' identified by '111'", tenantName,
 	))
-	defer execSQLMaybe(t, ctx, rootDB, fmt.Sprintf("drop account if exists `%s`", tenantName))
+	defer cleanupIssue26095SQL(t, rootDB,
+		fmt.Sprintf("drop account if exists `%s`", tenantName))
 	tenantID := queryIssue26095AccountID(t, ctx, rootDB, tenantName)
 	require.NotZero(t, tenantID)
 	tenantDB := openIssue26095DB(t, ctx, fmt.Sprintf(
@@ -57,86 +58,84 @@ func runIssue26095ConcurrentDataBranchDeletion(t *testing.T, c embed.Cluster) {
 	require.Equal(t, tenantID, queryIssue26095CurrentAccountID(t, ctx, tenantDB))
 
 	accounts := []struct {
-		name       string
-		id         uint32
-		db         *sql.DB
-		roundCount int
+		name string
+		id   uint32
+		db   *sql.DB
 	}{
-		{name: "sys", id: 0, db: rootDB, roundCount: 3},
-		{name: "tenant", id: tenantID, db: tenantDB, roundCount: 1},
+		{name: "sys", id: 0, db: rootDB},
+		{name: "tenant", id: tenantID, db: tenantDB},
 	}
-	if testing.Short() {
-		// Each round covers the same three concurrent deletion contracts. Keep
-		// one system-account sample in CI and retain the full repetition for
-		// explicit stress runs.
-		accounts[0].roundCount = 1
-	}
-	// Leave room for the account, operation, and round suffixes below.
+	// Leave room for the account and operation suffixes below.
 	base := fmt.Sprintf("db_issue26095_%d", time.Now().Nanosecond())
 	for _, account := range accounts {
 		t.Run(account.name, func(t *testing.T) {
-			for round := 0; round < account.roundCount; round++ {
-				t.Run(fmt.Sprintf("plain_drop_table_round_%d", round), func(t *testing.T) {
-					dbName := fmt.Sprintf("%s_%s_plain_%d", base, account.name, round)
-					defer execSQLMaybe(t, ctx, account.db, fmt.Sprintf("drop database if exists `%s`", dbName))
-					createSiblingBranches(t, ctx, account.db, dbName)
-					tableIDs := queryIssue26095TableIDs(t, ctx, rootDB, account.id, dbName, "b%")
-					requireIssue26095ReclaimPending(t, ctx, rootDB, tableIDs)
+			t.Run("plain_drop_table", func(t *testing.T) {
+				dbName := fmt.Sprintf("%s_%s_plain", base, account.name)
+				defer cleanupIssue26095SQL(t, account.db,
+					fmt.Sprintf("drop database if exists `%s`", dbName))
+				createSiblingBranches(t, ctx, account.db, dbName)
+				tableIDs := queryIssue26095TableIDs(t, ctx, rootDB, account.id, dbName, "b%")
+				requireIssue26095ReclaimPending(t, ctx, rootDB, tableIDs)
 
-					statements := make([]string, 4)
-					for i := range statements {
-						statements[i] = fmt.Sprintf("drop table `%s`.`b%d`", dbName, i)
-					}
-					runConcurrentStatements(t, ctx, account.db, statements)
-					require.Equal(t, 0, countIssue26095Tables(t, ctx, account.db, dbName))
-					requireIssue26095Reclaimed(t, ctx, rootDB, tableIDs)
+				statements := make([]string, issue26095SiblingBranches)
+				for i := range statements {
+					statements[i] = fmt.Sprintf("drop table `%s`.`b%d`", dbName, i)
+				}
+				runConcurrentStatements(t, ctx, account.db, statements)
+				require.Equal(t, 0, countIssue26095Tables(t, ctx, account.db, dbName))
+				requireIssue26095Reclaimed(t, ctx, rootDB, tableIDs)
+			})
+
+			t.Run("branch_delete_table", func(t *testing.T) {
+				dbName := fmt.Sprintf("%s_%s_branch", base, account.name)
+				defer cleanupIssue26095SQL(t, account.db,
+					fmt.Sprintf("drop database if exists `%s`", dbName))
+				createSiblingBranches(t, ctx, account.db, dbName)
+				tableIDs := queryIssue26095TableIDs(t, ctx, rootDB, account.id, dbName, "b%")
+				requireIssue26095ReclaimPending(t, ctx, rootDB, tableIDs)
+
+				statements := make([]string, issue26095SiblingBranches)
+				for i := range statements {
+					statements[i] = fmt.Sprintf("data branch delete table `%s`.`b%d`", dbName, i)
+				}
+				runConcurrentStatements(t, ctx, account.db, statements)
+				require.Equal(t, 0, countIssue26095Tables(t, ctx, account.db, dbName))
+				requireIssue26095Reclaimed(t, ctx, rootDB, tableIDs)
+			})
+
+			t.Run("branch_delete_database", func(t *testing.T) {
+				source := fmt.Sprintf("%s_%s_source", base, account.name)
+				left := fmt.Sprintf("%s_%s_left", base, account.name)
+				right := fmt.Sprintf("%s_%s_right", base, account.name)
+				defer cleanupIssue26095SQL(t, account.db,
+					fmt.Sprintf("drop database if exists `%s`", left),
+					fmt.Sprintf("drop database if exists `%s`", right),
+					fmt.Sprintf("drop database if exists `%s`", source))
+				execSQLRequire(t, ctx, account.db, fmt.Sprintf("create database `%s`", source))
+				execSQLRequire(t, ctx, account.db, fmt.Sprintf("create table `%s`.`t1` (id int primary key)", source))
+				execSQLRequire(t, ctx, account.db, fmt.Sprintf("create table `%s`.`t2` (id bigint primary key)", source))
+				execSQLRequire(t, ctx, account.db, fmt.Sprintf("data branch create database `%s` from `%s`", left, source))
+				execSQLRequire(t, ctx, account.db, fmt.Sprintf("data branch create database `%s` from `%s`", right, source))
+				tableIDs := append(
+					queryIssue26095TableIDs(t, ctx, rootDB, account.id, left, "t%"),
+					queryIssue26095TableIDs(t, ctx, rootDB, account.id, right, "t%")...,
+				)
+				requireIssue26095ReclaimPending(t, ctx, rootDB, tableIDs)
+
+				runConcurrentStatements(t, ctx, account.db, []string{
+					fmt.Sprintf("data branch delete database `%s`", left),
+					fmt.Sprintf("data branch delete database `%s`", right),
 				})
-
-				t.Run(fmt.Sprintf("branch_delete_table_round_%d", round), func(t *testing.T) {
-					dbName := fmt.Sprintf("%s_%s_branch_%d", base, account.name, round)
-					defer execSQLMaybe(t, ctx, account.db, fmt.Sprintf("drop database if exists `%s`", dbName))
-					createSiblingBranches(t, ctx, account.db, dbName)
-					tableIDs := queryIssue26095TableIDs(t, ctx, rootDB, account.id, dbName, "b%")
-					requireIssue26095ReclaimPending(t, ctx, rootDB, tableIDs)
-
-					statements := make([]string, 4)
-					for i := range statements {
-						statements[i] = fmt.Sprintf("data branch delete table `%s`.`b%d`", dbName, i)
-					}
-					runConcurrentStatements(t, ctx, account.db, statements)
-					require.Equal(t, 0, countIssue26095Tables(t, ctx, account.db, dbName))
-					requireIssue26095Reclaimed(t, ctx, rootDB, tableIDs)
-				})
-
-				t.Run(fmt.Sprintf("branch_delete_database_round_%d", round), func(t *testing.T) {
-					source := fmt.Sprintf("%s_%s_source_%d", base, account.name, round)
-					left := fmt.Sprintf("%s_%s_left_%d", base, account.name, round)
-					right := fmt.Sprintf("%s_%s_right_%d", base, account.name, round)
-					for _, name := range []string{left, right, source} {
-						defer execSQLMaybe(t, ctx, account.db, fmt.Sprintf("drop database if exists `%s`", name))
-					}
-					execSQLRequire(t, ctx, account.db, fmt.Sprintf("create database `%s`", source))
-					execSQLRequire(t, ctx, account.db, fmt.Sprintf("create table `%s`.`t1` (id int primary key)", source))
-					execSQLRequire(t, ctx, account.db, fmt.Sprintf("create table `%s`.`t2` (id bigint primary key)", source))
-					execSQLRequire(t, ctx, account.db, fmt.Sprintf("data branch create database `%s` from `%s`", left, source))
-					execSQLRequire(t, ctx, account.db, fmt.Sprintf("data branch create database `%s` from `%s`", right, source))
-					tableIDs := append(
-						queryIssue26095TableIDs(t, ctx, rootDB, account.id, left, "t%"),
-						queryIssue26095TableIDs(t, ctx, rootDB, account.id, right, "t%")...,
-					)
-					requireIssue26095ReclaimPending(t, ctx, rootDB, tableIDs)
-
-					runConcurrentStatements(t, ctx, account.db, []string{
-						fmt.Sprintf("data branch delete database `%s`", left),
-						fmt.Sprintf("data branch delete database `%s`", right),
-					})
-					require.Equal(t, 0, countIssue26095Databases(t, ctx, account.db, left, right))
-					requireIssue26095Reclaimed(t, ctx, rootDB, tableIDs)
-				})
-			}
+				require.Equal(t, 0, countIssue26095Databases(t, ctx, account.db, left, right))
+				requireIssue26095Reclaimed(t, ctx, rootDB, tableIDs)
+			})
 		})
 	}
 }
+
+// The reported table-level deadlock used four independent sessions. Keep that
+// concurrency degree and remove only repeated rounds of the same contract.
+const issue26095SiblingBranches = 4
 
 func openIssue26095DB(t *testing.T, ctx context.Context, dsn string) *sql.DB {
 	t.Helper()
@@ -171,7 +170,7 @@ func createSiblingBranches(t *testing.T, ctx context.Context, db *sql.DB, dbName
 	t.Helper()
 	execSQLRequire(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
 	execSQLRequire(t, ctx, db, fmt.Sprintf("create table `%s`.`root_t` (id int primary key)", dbName))
-	for i := 0; i < 4; i++ {
+	for i := 0; i < issue26095SiblingBranches; i++ {
 		execSQLRequire(t, ctx, db, fmt.Sprintf(
 			"data branch create table `%s`.`b%d` from `%s`.`root_t`",
 			dbName, i, dbName,
@@ -252,6 +251,7 @@ func queryIssue26095Count(t *testing.T, ctx context.Context, db *sql.DB, query s
 
 func runConcurrentStatements(t *testing.T, ctx context.Context, db *sql.DB, statements []string) {
 	t.Helper()
+	require.GreaterOrEqual(t, len(statements), 2)
 	connections := make([]*sql.Conn, len(statements))
 	for i := range connections {
 		conn, err := db.Conn(ctx)
@@ -261,22 +261,38 @@ func runConcurrentStatements(t *testing.T, ctx context.Context, db *sql.DB, stat
 	}
 
 	start := make(chan struct{})
+	ready := make(chan struct{}, len(statements))
 	errs := make(chan error, len(statements))
 	var wg sync.WaitGroup
 	wg.Add(len(statements))
 	for i, statement := range statements {
 		go func(conn *sql.Conn, sqlText string) {
 			defer wg.Done()
+			ready <- struct{}{}
 			<-start
 			_, err := conn.ExecContext(ctx, sqlText)
 			errs <- err
 		}(connections[i], statement)
+	}
+	for range statements {
+		<-ready
 	}
 	close(start)
 	wg.Wait()
 	close(errs)
 	for err := range errs {
 		require.NoError(t, err)
+	}
+}
+
+func cleanupIssue26095SQL(t *testing.T, db *sql.DB, statements ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for _, statement := range statements {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			t.Errorf("issue 26095 cleanup failed for %q: %v", statement, err)
+		}
 	}
 }
 

--- a/pkg/tests/issues/issue_26111_test.go
+++ b/pkg/tests/issues/issue_26111_test.go
@@ -22,11 +22,8 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/matrixorigin/matrixone/pkg/cnservice"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
-	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,45 +103,36 @@ func TestIssue26111DataBranchDatabaseWithCyclicForeignKeys(t *testing.T) {
 			require.Error(t, err)
 		}
 
-		testutils.WaitDatabaseCreatedWithAccount(t, targetAccountID, accountBranch, cn)
-		testutils.WaitTableCreatedWithAccount(t, targetAccountID, accountBranch, "a", cn)
-		testutils.WaitTableCreatedWithAccount(t, targetAccountID, accountBranch, "b", cn)
-		tenantCtx := defines.AttachAccountId(ctx, uint32(targetAccountID))
-		tenantExec := cn.RawService().(cnservice.Service).GetSQLExecutor()
-		tenantOpts := executor.Options{}.WithAccountID(uint32(targetAccountID)).WithDatabase(accountBranch)
-
-		result, err := tenantExec.Exec(tenantCtx,
-			"select count(*) from `a` a join `b` b on a.b_id = b.id and b.a_id = a.id", tenantOpts)
+		// The cross-account DDL returns only after commit. Verify visibility and FK
+		// enforcement through the target account's public SQL path instead of three
+		// open-ended catalog polling loops.
+		targetDB, err := sql.Open("mysql", fmt.Sprintf(
+			"%s#root#accountadmin:111@tcp(127.0.0.1:%d)/%s", targetAccount, port, accountBranch,
+		))
 		require.NoError(t, err)
-		require.Equal(t, 1, testutils.ReadCount(result))
-		result.Close()
+		defer targetDB.Close()
+		require.NoError(t, targetDB.PingContext(ctx))
+		require.NoError(t, targetDB.QueryRowContext(ctx,
+			"select count(*) from `a` a join `b` b on a.b_id = b.id and b.a_id = a.id").Scan(&count))
+		require.Equal(t, 1, count)
+		require.NoError(t, targetDB.QueryRowContext(ctx,
+			"select count(*) from mo_catalog.mo_foreign_keys where db_name = '"+accountBranch+"' and refer_db_name = '"+accountBranch+"' and ((table_name = 'a' and refer_table_name = 'b') or (table_name = 'b' and refer_table_name = 'a'))").Scan(&count))
+		require.Equal(t, 2, count)
 
-		result, err = tenantExec.Exec(tenantCtx,
-			"select count(*) from mo_catalog.mo_foreign_keys where db_name = '"+accountBranch+"' and refer_db_name = '"+accountBranch+"' and ((table_name = 'a' and refer_table_name = 'b') or (table_name = 'b' and refer_table_name = 'a'))", tenantOpts)
-		require.NoError(t, err)
-		require.Equal(t, 2, testutils.ReadCount(result))
-		result.Close()
-
-		result, err = tenantExec.Exec(tenantCtx, "insert into `a` values (2, 999)", tenantOpts)
-		result.Close()
+		_, err = targetDB.ExecContext(ctx, "insert into `a` values (2, 999)")
 		require.Error(t, err)
-		result, err = tenantExec.Exec(tenantCtx, "insert into `b` values (2, 999)", tenantOpts)
-		result.Close()
+		_, err = targetDB.ExecContext(ctx, "insert into `b` values (2, 999)")
 		require.Error(t, err)
 
 		_, err = db.ExecContext(ctx, "data branch create database `"+accountBranch+"` from `"+sourceDB+"` {snapshot='"+snapshotName+"'} to account `"+targetAccount+"`")
 		require.Error(t, err)
 		require.NoError(t, db.QueryRowContext(ctx, "select @@session.foreign_key_checks").Scan(&foreignKeyChecks))
 		require.Equal(t, 1, foreignKeyChecks)
-		result, err = tenantExec.Exec(tenantCtx,
-			"select count(*) from mo_catalog.mo_tables where reldatabase = '"+accountBranch+"' and relkind = 'r'", tenantOpts)
-		require.NoError(t, err)
-		require.Equal(t, 2, testutils.ReadCount(result))
-		result.Close()
-		result, err = tenantExec.Exec(tenantCtx,
-			"select count(*) from mo_catalog.mo_foreign_keys where db_name = '"+accountBranch+"' and refer_db_name = '"+accountBranch+"'", tenantOpts)
-		require.NoError(t, err)
-		require.Equal(t, 2, testutils.ReadCount(result))
-		result.Close()
+		require.NoError(t, targetDB.QueryRowContext(ctx,
+			"select count(*) from mo_catalog.mo_tables where reldatabase = '"+accountBranch+"' and relkind = 'r'").Scan(&count))
+		require.Equal(t, 2, count)
+		require.NoError(t, targetDB.QueryRowContext(ctx,
+			"select count(*) from mo_catalog.mo_foreign_keys where db_name = '"+accountBranch+"' and refer_db_name = '"+accountBranch+"'").Scan(&count))
+		require.Equal(t, 2, count)
 	})
 }

--- a/pkg/tests/issues/issue_26121_test.go
+++ b/pkg/tests/issues/issue_26121_test.go
@@ -40,27 +40,16 @@ func TestIssue26121DatabaseOperationsKeepOrdinaryInternalLookingTables(t *testin
 		execSQLRequire(t, ctx, db, "set role moadmin")
 
 		const (
-			sourceDB         = "issue_26121_source"
-			branchDB         = "issue_26121_branch"
-			cloneDB          = "issue_26121_clone"
-			fullTextDB       = "issue_26121_fulltext"
-			fullTextCloneDB  = "issue_26121_fulltext_clone"
-			fullTextBranchDB = "issue_26121_fulltext_branch"
-			restoreDB        = "issue_26121_after_snapshot"
-			snapshotName     = "issue_26121_account_snapshot"
+			sourceDB     = "issue_26121_source"
+			branchDB     = "issue_26121_branch"
+			cloneDB      = "issue_26121_clone"
+			deleteDB     = "issue_26121_delete"
+			restoreDB    = "issue_26121_after_snapshot"
+			snapshotName = "issue_26121_account_snapshot"
 		)
-		deleteCases := []struct {
-			dbName    string
-			tableName string
-		}{
-			{dbName: "issue_26121_delete_tmp", tableName: "__mo_tmp_user_keep"},
-			{dbName: "issue_26121_delete_lock", tableName: "__mo_account_lock"},
-			{dbName: "issue_26121_delete_auto", tableName: "mo_increment_columns"},
-		}
-		cleanupDBs := []string{branchDB, cloneDB, sourceDB, fullTextBranchDB, fullTextCloneDB, fullTextDB, restoreDB}
-		for _, tc := range deleteCases {
-			cleanupDBs = append(cleanupDBs, tc.dbName)
-		}
+		deleteCases := []string{"__mo_tmp_user_keep", "__mo_account_lock", "mo_increment_columns"}
+		cleanupDBs := []string{branchDB, cloneDB, sourceDB, deleteDB, restoreDB}
+		execSQLMaybe(t, ctx, db, "drop snapshot if exists "+snapshotName)
 		for _, name := range cleanupDBs {
 			execSQLMaybe(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", name))
 		}
@@ -70,6 +59,7 @@ func TestIssue26121DatabaseOperationsKeepOrdinaryInternalLookingTables(t *testin
 			for _, name := range cleanupDBs {
 				execSQLMaybe(t, cleanupCtx, db, fmt.Sprintf("drop database if exists `%s`", name))
 			}
+			execSQLMaybe(t, cleanupCtx, db, "drop snapshot if exists "+snapshotName)
 		}()
 
 		t.Run("account restore skips bootstrap index tables", func(t *testing.T) {
@@ -84,7 +74,7 @@ func TestIssue26121DatabaseOperationsKeepOrdinaryInternalLookingTables(t *testin
 			execSQLRequire(t, ctx, db, "drop snapshot `"+snapshotName+"`")
 		})
 
-		t.Run("database copies preserve ordinary tables", func(t *testing.T) {
+		t.Run("database copies", func(t *testing.T) {
 			execSQLRequire(t, ctx, db, "create database `"+sourceDB+"`")
 			tableNames := []string{"__mo_tmp_user_data", "__mo_account_lock", "mo_increment_columns"}
 			for i, tableName := range tableNames {
@@ -95,70 +85,66 @@ func TestIssue26121DatabaseOperationsKeepOrdinaryInternalLookingTables(t *testin
 					"insert into `%s`.`%s` values (%d, 'ordinary-user-row')",
 					sourceDB, tableName, i+1))
 			}
+			execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`docs` (id bigint primary key, body text)")
+			execSQLRequire(t, ctx, db, "create fulltext index `ft_body` on `"+sourceDB+"`.`docs` (`body`)")
+			execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`.`docs` values (1, 'one document')")
+			var sourceHidden int
+			require.NoError(t, db.QueryRowContext(ctx,
+				"select count(*) from mo_catalog.mo_tables where reldatabase = ? and relname like '__mo_index_%'",
+				sourceDB).Scan(&sourceHidden))
+			require.Equal(t, 1, sourceHidden)
 
 			execSQLRequire(t, ctx, db, "data branch create database `"+branchDB+"` from `"+sourceDB+"`")
 			execSQLRequire(t, ctx, db, "create database `"+cloneDB+"` clone `"+sourceDB+"`")
 
-			for _, copiedDB := range []string{branchDB, cloneDB} {
-				for _, tableName := range tableNames {
-					var count int
-					err = db.QueryRowContext(ctx, fmt.Sprintf(
-						"select count(*) from `%s`.`%s`", copiedDB, tableName)).Scan(&count)
-					require.NoErrorf(t, err, "%s.%s must be copied", copiedDB, tableName)
-					require.Equal(t, 1, count, "%s.%s must retain its row", copiedDB, tableName)
+			t.Run("ordinary internal-looking tables", func(t *testing.T) {
+				for _, copiedDB := range []string{branchDB, cloneDB} {
+					for _, tableName := range tableNames {
+						var count int
+						err = db.QueryRowContext(ctx, fmt.Sprintf(
+							"select count(*) from `%s`.`%s`", copiedDB, tableName)).Scan(&count)
+						require.NoErrorf(t, err, "%s.%s must be copied", copiedDB, tableName)
+						require.Equal(t, 1, count, "%s.%s must retain its row", copiedDB, tableName)
+					}
 				}
-			}
-		})
+			})
 
-		t.Run("database copies do not copy fulltext storage independently", func(t *testing.T) {
-			execSQLRequire(t, ctx, db, "create database `"+fullTextDB+"`")
-			execSQLRequire(t, ctx, db, "create table `"+fullTextDB+"`.`docs` (id bigint primary key, body text)")
-			execSQLRequire(t, ctx, db, "create fulltext index `ft_body` on `"+fullTextDB+"`.`docs` (`body`)")
-			execSQLRequire(t, ctx, db, "insert into `"+fullTextDB+"`.`docs` values (1, 'one document')")
-
-			var sourceHidden int
-			require.NoError(t, db.QueryRowContext(ctx,
-				"select count(*) from mo_catalog.mo_tables where reldatabase = ? and relname like '__mo_index_%'",
-				fullTextDB).Scan(&sourceHidden))
-			require.Equal(t, 1, sourceHidden)
-
-			execSQLRequire(t, ctx, db, "create database `"+fullTextCloneDB+"` clone `"+fullTextDB+"`")
-			execSQLRequire(t, ctx, db, "data branch create database `"+fullTextBranchDB+"` from `"+fullTextDB+"`")
-
-			assertFullTextCopy := func(database string) {
-				var targetHidden int
-				require.NoError(t, db.QueryRowContext(ctx,
-					"select count(*) from mo_catalog.mo_tables where reldatabase = ? and relname like '__mo_index_%'",
-					database).Scan(&targetHidden))
-				require.Equal(t, sourceHidden, targetHidden)
-				var rows int
-				require.NoError(t, db.QueryRowContext(ctx,
-					"select count(*) from `"+database+"`.`docs`").Scan(&rows))
-				require.Equal(t, 1, rows)
-			}
-			assertFullTextCopy(fullTextCloneDB)
-			assertFullTextCopy(fullTextBranchDB)
+			t.Run("fulltext storage", func(t *testing.T) {
+				for _, copiedDB := range []string{branchDB, cloneDB} {
+					var targetHidden int
+					require.NoError(t, db.QueryRowContext(ctx,
+						"select count(*) from mo_catalog.mo_tables where reldatabase = ? and relname like '__mo_index_%'",
+						copiedDB).Scan(&targetHidden))
+					require.Equal(t, sourceHidden, targetHidden)
+					var rows int
+					require.NoError(t, db.QueryRowContext(ctx,
+						"select count(*) from `"+copiedDB+"`.`docs`").Scan(&rows))
+					require.Equal(t, 1, rows)
+				}
+			})
 		})
 
 		t.Run("delete validation sees ordinary tables", func(t *testing.T) {
-			for _, tc := range deleteCases {
-				t.Run(tc.tableName, func(t *testing.T) {
-					execSQLRequire(t, ctx, db, "create database `"+tc.dbName+"`")
-					execSQLRequire(t, ctx, db, "create table `"+tc.dbName+"`.`base` (id int primary key)")
-					execSQLRequire(t, ctx, db, "insert into `"+tc.dbName+"`.`base` values (1)")
-					execSQLRequire(t, ctx, db, "data branch create table `"+tc.dbName+"`.`branch_t` from `"+tc.dbName+"`.`base`")
-					execSQLRequire(t, ctx, db, "drop table `"+tc.dbName+"`.`base`")
-					execSQLRequire(t, ctx, db, "create table `"+tc.dbName+"`.`"+tc.tableName+"` (id int primary key)")
-					execSQLRequire(t, ctx, db, "insert into `"+tc.dbName+"`.`"+tc.tableName+"` values (1)")
+			execSQLRequire(t, ctx, db, "create database `"+deleteDB+"`")
+			execSQLRequire(t, ctx, db, "create table `"+deleteDB+"`.`base` (id int primary key)")
+			execSQLRequire(t, ctx, db, "insert into `"+deleteDB+"`.`base` values (1)")
+			execSQLRequire(t, ctx, db, "data branch create table `"+deleteDB+"`.`branch_t` from `"+deleteDB+"`.`base`")
+			execSQLRequire(t, ctx, db, "drop table `"+deleteDB+"`.`base`")
 
-					_, err = db.ExecContext(ctx, "data branch delete database `"+tc.dbName+"`")
+			for _, tableName := range deleteCases {
+				t.Run(tableName, func(t *testing.T) {
+					execSQLRequire(t, ctx, db, "create table `"+deleteDB+"`.`"+tableName+"` (id int primary key)")
+					execSQLRequire(t, ctx, db, "insert into `"+deleteDB+"`.`"+tableName+"` values (1)")
+
+					_, err = db.ExecContext(ctx, "data branch delete database `"+deleteDB+"`")
 					require.Error(t, err)
 					require.Contains(t, err.Error(), "is not an active branch table")
 
 					var count int
 					require.NoError(t, db.QueryRowContext(ctx,
-						"select count(*) from `"+tc.dbName+"`.`"+tc.tableName+"`").Scan(&count))
+						"select count(*) from `"+deleteDB+"`.`"+tableName+"`").Scan(&count))
 					require.Equal(t, 1, count)
+					execSQLRequire(t, ctx, db, "drop table `"+deleteDB+"`.`"+tableName+"`")
 				})
 			}
 		})

--- a/pkg/tests/issues/issue_26123_test.go
+++ b/pkg/tests/issues/issue_26123_test.go
@@ -70,34 +70,42 @@ func TestIssue26123DatabaseCopiesKeepLikeMetacharacterFKTables(t *testing.T) {
 			{name: "backslash", tableName: `child\fk`, tableNameSQL: "`child\\fk`"},
 		}
 
+		const sourceDB = "issue_26123_source"
+		execSQLRequire(t, ctx, db, "drop database if exists `"+sourceDB+"`")
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+sourceDB+"`")
+		}()
+		execSQLRequire(t, ctx, db, "create database `"+sourceDB+"`")
+		execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`parent_t` (id int primary key)")
+		execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`.`parent_t` values (1)")
+		execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`a0b` (id int primary key)")
+		execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`.`a0b` values (22)")
+		for _, tc := range tableCases {
+			execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`."+tc.tableNameSQL+
+				" (id int primary key, parent_id int, foreign key (parent_id) references `"+
+				sourceDB+"`.`parent_t`(id))")
+			execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`."+tc.tableNameSQL+" values (11, 1)")
+		}
+
 		for _, mode := range copyModes {
-			for _, tc := range tableCases {
-				t.Run(mode.name+"/"+tc.name, func(t *testing.T) {
-					sourceDB := "issue_26123_" + mode.key + "_" + tc.name + "_src"
-					targetDB := "issue_26123_" + mode.key + "_" + tc.name + "_dst"
-					defer func() {
-						cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-						defer cleanupCancel()
-						execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+targetDB+"`")
-						execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+sourceDB+"`")
-					}()
+			t.Run(mode.name, func(t *testing.T) {
+				targetDB := "issue_26123_" + mode.key + "_target"
+				defer func() {
+					cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cleanupCancel()
+					execSQLMaybe(t, cleanupCtx, db, "drop database if exists `"+targetDB+"`")
+				}()
+				execSQLRequire(t, ctx, db, "drop database if exists `"+targetDB+"`")
+				execSQLRequire(t, ctx, db, mode.copy(sourceDB, targetDB))
 
-					execSQLRequire(t, ctx, db, "drop database if exists `"+targetDB+"`")
-					execSQLRequire(t, ctx, db, "drop database if exists `"+sourceDB+"`")
-					execSQLRequire(t, ctx, db, "create database `"+sourceDB+"`")
-					execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`parent_t` (id int primary key)")
-					if tc.collisionTable != "" {
-						execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`."+tc.collisionTable+" (id int primary key)")
-						execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`."+tc.collisionTable+" values (22)")
-					}
-					execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`."+tc.tableNameSQL+" (id int primary key, parent_id int, foreign key (parent_id) references `"+sourceDB+"`.`parent_t`(id))")
-					execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`.`parent_t` values (1)")
-					execSQLRequire(t, ctx, db, "insert into `"+sourceDB+"`."+tc.tableNameSQL+" values (11, 1)")
-
-					execSQLRequire(t, ctx, db, mode.copy(sourceDB, targetDB))
-					assertIssue26123CopiedFKTable(t, ctx, db, sourceDB, targetDB, tc.tableName, tc.tableNameSQL, tc.collisionTable)
-				})
-			}
+				for _, tc := range tableCases {
+					t.Run(tc.name, func(t *testing.T) {
+						assertIssue26123CopiedFKTable(t, ctx, db, sourceDB, targetDB, tc.tableName, tc.tableNameSQL, tc.collisionTable)
+					})
+				}
+			})
 		}
 	})
 }
@@ -131,16 +139,16 @@ func assertIssue26123CopiedFKTable(
 		databaseName, tableName).Scan(&count))
 	require.Equal(t, 1, count)
 	require.NoError(t, db.QueryRowContext(ctx,
-		"select count(*) from mo_catalog.mo_foreign_keys where db_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
-		databaseName, databaseName).Scan(&count))
+		"select count(*) from mo_catalog.mo_foreign_keys where db_name = ? and table_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
+		databaseName, tableName, databaseName).Scan(&count))
 	require.Equal(t, 1, count)
 	var sourceFKTableName, targetFKTableName string
 	require.NoError(t, db.QueryRowContext(ctx,
-		"select table_name from mo_catalog.mo_foreign_keys where db_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
-		sourceDatabaseName, sourceDatabaseName).Scan(&sourceFKTableName))
+		"select table_name from mo_catalog.mo_foreign_keys where db_name = ? and table_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
+		sourceDatabaseName, tableName, sourceDatabaseName).Scan(&sourceFKTableName))
 	require.NoError(t, db.QueryRowContext(ctx,
-		"select table_name from mo_catalog.mo_foreign_keys where db_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
-		databaseName, databaseName).Scan(&targetFKTableName))
+		"select table_name from mo_catalog.mo_foreign_keys where db_name = ? and table_name = ? and refer_db_name = ? and refer_table_name = 'parent_t'",
+		databaseName, tableName, databaseName).Scan(&targetFKTableName))
 	require.Equal(t, sourceFKTableName, targetFKTableName)
 
 	_, err := db.ExecContext(ctx,

--- a/pkg/tests/issues/issue_26131_test.go
+++ b/pkg/tests/issues/issue_26131_test.go
@@ -65,24 +65,31 @@ func TestIssue26131Q15SharedCTEExecutesBothConsumers(t *testing.T) {
 		execSQLRequire(t, ctx, db, "use "+database)
 		execSQLRequire(t, ctx, db, "create table supplier (s_suppkey int primary key, s_name varchar(32))")
 		execSQLRequire(t, ctx, db, "create table lineitem (l_suppkey int, l_extendedprice decimal(15,2), l_discount decimal(15,2), l_shipdate date)")
-		execSQLRequire(t, ctx, db, "insert into supplier select result, concat('supplier-', cast(result as char)) from generate_series(1,100) g")
-		execSQLRequire(t, ctx, db, "insert into lineitem select mod(result - 1, 100) + 1, if(mod(result - 1, 100) + 1 = 42, 2, 1), 0, '1995-12-15' from generate_series(1,100000) g")
+		execSQLRequire(t, ctx, db, "insert into supplier values (1, 'supplier-1'), (42, 'supplier-42')")
+		// Two rows per group preserve real SUM accumulation. The shared-CTE
+		// topology is asserted from EXPLAIN below and does not depend on volume.
+		execSQLRequire(t, ctx, db, `insert into lineitem values
+			(1, 1, 0, '1995-12-15'), (1, 1, 0, '1995-12-15'),
+			(42, 2, 0, '1995-12-15'), (42, 2, 0, '1995-12-15')`)
 		execSQLRequire(t, ctx, db, "analyze table supplier, lineitem")
 
 		planText := explainSQL(t, ctx, db, "explain "+issue26131Q15)
-		require.GreaterOrEqual(t, strings.Count(planText, "Sink Scan"), 2,
-			"the real plan must route both the join and scalar MAX consumers through the shared CTE")
+		require.Equal(t, 1, strings.Count(planText, ".lineitem"),
+			"the shared CTE must have exactly one lineitem producer:\n%s", planText)
+		require.Equal(t, 2, strings.Count(planText, "Sink Scan"),
+			"the join and scalar MAX must be the only shared-CTE consumers:\n%s", planText)
 
 		rows, err := db.QueryContext(ctx, issue26131Q15)
 		require.NoError(t, err)
 		defer rows.Close()
 		require.True(t, rows.Next())
 		var supplierKey int
-		var supplierName, revenue string
+		var supplierName string
+		var revenue float64
 		require.NoError(t, rows.Scan(&supplierKey, &supplierName, &revenue))
 		require.Equal(t, 42, supplierKey)
 		require.Equal(t, "supplier-42", supplierName)
-		require.NotEmpty(t, revenue)
+		require.Equal(t, 4.0, revenue)
 		require.False(t, rows.Next(), "both consumers must drain to one terminal result")
 		require.NoError(t, rows.Err())
 		require.NoError(t, rows.Close())

--- a/pkg/tests/issues/issue_26232_test.go
+++ b/pkg/tests/issues/issue_26232_test.go
@@ -101,6 +101,15 @@ func TestIssue26232ViewDefaultAndCTASContracts(t *testing.T) {
 			defer cleanupCancel()
 			execSQLMaybe(t, cleanupCtx, dbConn, "drop database if exists "+db)
 		}()
+		infoDefaults := issue26232InformationSchemaDefaults(t, ctx, dbConn, db)
+		defaultFor := func(table, column string) sql.NullString {
+			key := issue26232ColumnKey{table: table, column: column}
+			value, ok := infoDefaults[key]
+			require.Truef(t, ok, "missing information_schema default for %s.%s", table, column)
+			return value
+		}
+		sourceDescDefaults := issue26232DescDefaults(t, ctx, dbConn, db+".v_source_t")
+		ctasDescDefaults := issue26232DescDefaults(t, ctx, dbConn, db+".ctas_view")
 
 		for _, test := range []struct {
 			viewName  string
@@ -122,11 +131,7 @@ func TestIssue26232ViewDefaultAndCTASContracts(t *testing.T) {
 			{viewName: "v_source_t", column: "priority", wantValue: "'medium'"},
 			{viewName: "v_source_t", column: "flags", wantValue: "'a'"},
 		} {
-			var got sql.NullString
-			require.NoError(t, dbConn.QueryRowContext(ctx,
-				"select column_default from information_schema.columns "+
-					"where table_schema = ? and table_name = ? and column_name = ?",
-				db, test.viewName, test.column).Scan(&got), test.viewName+"."+test.column)
+			got := defaultFor(test.viewName, test.column)
 			require.True(t, got.Valid, test.viewName+"."+test.column)
 			require.Equal(t, test.wantValue, got.String, test.viewName+"."+test.column)
 		}
@@ -135,22 +140,16 @@ func TestIssue26232ViewDefaultAndCTASContracts(t *testing.T) {
 			"v_constant", "v_function", "v_arithmetic", "v_aggregate",
 			"v_union", "v_union_all", "v_recursive",
 		} {
-			var got sql.NullString
-			require.NoError(t, dbConn.QueryRowContext(ctx,
-				"select column_default from information_schema.columns "+
-					"where table_schema = ? and table_name = ? and column_name = 'qty'",
-				db, viewName).Scan(&got), viewName)
+			got := defaultFor(viewName, "qty")
 			require.False(t, got.Valid, viewName)
 		}
 
-		var nullableDefault sql.NullString
-		require.NoError(t, dbConn.QueryRowContext(ctx,
-			"select column_default from information_schema.columns "+
-				"where table_schema = ? and table_name = 'v_source_t' and column_name = 'nullable_col'",
-			db).Scan(&nullableDefault))
+		nullableDefault := defaultFor("v_source_t", "nullable_col")
 		require.False(t, nullableDefault.Valid)
 
-		require.Equal(t, "7", descColumnDefault(t, ctx, dbConn, db+".v_source_t", "qty").String)
+		sourceQtyDefault, ok := sourceDescDefaults["qty"]
+		require.True(t, ok, "v_source_t.qty")
+		require.Equal(t, "7", sourceQtyDefault.String)
 		var viewName, viewSQL, charset, collation string
 		require.NoError(t, dbConn.QueryRowContext(ctx, "show create view "+db+".v_source_t").
 			Scan(&viewName, &viewSQL, &charset, &collation))
@@ -186,14 +185,11 @@ func TestIssue26232ViewDefaultAndCTASContracts(t *testing.T) {
 			{column: "nullable_expr", wantInfo: sql.NullString{String: "(uuid())", Valid: true}, wantDesc: sql.NullString{String: "(uuid())", Valid: true}},
 			{column: "expr_col", wantInfo: sql.NullString{String: "(uuid())", Valid: true}, wantDesc: sql.NullString{String: "(uuid())", Valid: true}},
 		} {
-			var infoDefault sql.NullString
-			require.NoError(t, dbConn.QueryRowContext(ctx,
-				"select column_default from information_schema.columns "+
-					"where table_schema = ? and table_name = 'ctas_view' and column_name = ?",
-				db, test.column).Scan(&infoDefault), test.column)
+			infoDefault := defaultFor("ctas_view", test.column)
 			require.Equal(t, test.wantInfo, infoDefault, test.column)
-			require.Equal(t, test.wantDesc,
-				descColumnDefault(t, ctx, dbConn, db+".ctas_view", test.column), test.column)
+			descDefault, ok := ctasDescDefaults[test.column]
+			require.True(t, ok, test.column)
+			require.Equal(t, test.wantDesc, descDefault, test.column)
 		}
 
 		for _, column := range []string{
@@ -201,18 +197,13 @@ func TestIssue26232ViewDefaultAndCTASContracts(t *testing.T) {
 			"date_expr", "datetime_expr", "timestamp_expr", "time_expr", "year_expr",
 			"nullable_int_expr", "nullable_varchar_expr",
 		} {
-			var viewDefault, ctasDefault sql.NullString
-			require.NoError(t, dbConn.QueryRowContext(ctx,
-				"select column_default from information_schema.columns "+
-					"where table_schema = ? and table_name = 'v_source_t' and column_name = ?",
-				db, column).Scan(&viewDefault), column)
-			require.NoError(t, dbConn.QueryRowContext(ctx,
-				"select column_default from information_schema.columns "+
-					"where table_schema = ? and table_name = 'ctas_view' and column_name = ?",
-				db, column).Scan(&ctasDefault), column)
+			viewDefault := defaultFor("v_source_t", column)
+			ctasDefault := defaultFor("ctas_view", column)
 			require.True(t, viewDefault.Valid, column)
 			require.Equal(t, viewDefault, ctasDefault, column)
-			require.Equal(t, ctasDefault, descColumnDefault(t, ctx, dbConn, db+".ctas_view", column), column)
+			descDefault, ok := ctasDescDefaults[column]
+			require.True(t, ok, column)
+			require.Equal(t, ctasDefault, descDefault, column)
 		}
 
 		var tableName, createTableSQL string
@@ -323,22 +314,50 @@ func TestIssue26232ViewDefaultAndCTASContracts(t *testing.T) {
 	})
 }
 
-func descColumnDefault(
-	t *testing.T, ctx context.Context, dbConn *sql.DB, tableName, columnName string,
-) sql.NullString {
+type issue26232ColumnKey struct {
+	table  string
+	column string
+}
+
+func issue26232InformationSchemaDefaults(
+	t *testing.T, ctx context.Context, dbConn *sql.DB, database string,
+) map[issue26232ColumnKey]sql.NullString {
+	t.Helper()
+	rows, err := dbConn.QueryContext(ctx,
+		"select table_name, column_name, column_default from information_schema.columns where table_schema = ?",
+		database)
+	require.NoError(t, err)
+	defer rows.Close()
+	defaults := make(map[issue26232ColumnKey]sql.NullString)
+	for rows.Next() {
+		var table, column string
+		var defaultValue sql.NullString
+		require.NoError(t, rows.Scan(&table, &column, &defaultValue))
+		key := issue26232ColumnKey{table: table, column: column}
+		require.NotContains(t, defaults, key)
+		defaults[key] = defaultValue
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, defaults)
+	return defaults
+}
+
+func issue26232DescDefaults(
+	t *testing.T, ctx context.Context, dbConn *sql.DB, tableName string,
+) map[string]sql.NullString {
 	t.Helper()
 	rows, err := dbConn.QueryContext(ctx, "desc "+tableName)
 	require.NoError(t, err)
 	defer rows.Close()
+	defaults := make(map[string]sql.NullString)
 	for rows.Next() {
 		var field, typ, nullable, key, extra, comment string
 		var defaultValue sql.NullString
 		require.NoError(t, rows.Scan(&field, &typ, &nullable, &key, &defaultValue, &extra, &comment))
-		if field == columnName {
-			return defaultValue
-		}
+		require.NotContains(t, defaults, field)
+		defaults[field] = defaultValue
 	}
 	require.NoError(t, rows.Err())
-	require.FailNow(t, "column not found in DESC", tableName+"."+columnName)
-	return sql.NullString{}
+	require.NotEmpty(t, defaults)
+	return defaults
 }

--- a/pkg/tests/issues/issue_26568_test.go
+++ b/pkg/tests/issues/issue_26568_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	issue26568Rows                = 130_000
 	issue26568TPPlanTitle         = "TP QUERY PLAN"
 	issue26568MultiCNPlanTitle    = "AP QUERY PLAN ON MULTICN("
 	issue26568MultiCNPhyPlanTitle = "AP QUERY PHYPLAN ON MULTICN("
@@ -171,10 +170,12 @@ func setupIssue26568Tables(t *testing.T, ctx context.Context, port int64, dbName
 	issue26568Exec(t, ctx, conn, "use `"+dbName+"`")
 	issue26568Exec(t, ctx, conn, "create table po_l (id bigint primary key)")
 	issue26568Exec(t, ctx, conn, "create table po_r (id bigint primary key)")
-	issue26568Exec(t, ctx, conn, fmt.Sprintf(
-		"insert into po_l select result from generate_series(1, %d) g", issue26568Rows))
-	issue26568Exec(t, ctx, conn, fmt.Sprintf(
-		"insert into po_r select result from generate_series(1, %d) g", issue26568Rows))
+	// Every attack below replaces optimizer stats and fixes execType explicitly,
+	// so row volume cannot strengthen the renderer contract. Keep two matching
+	// rows to preserve a real hash-join shape without paying to materialize
+	// 260,000 values that the optimizer is instructed to ignore.
+	issue26568Exec(t, ctx, conn, "insert into po_l values (1), (2)")
+	issue26568Exec(t, ctx, conn, "insert into po_r values (1), (2)")
 }
 
 func openIssue26568Conn(t *testing.T, ctx context.Context, port int64) *sql.Conn {

--- a/pkg/tests/issues/issue_test.go
+++ b/pkg/tests/issues/issue_test.go
@@ -656,38 +656,39 @@ func TestLockNeedUpgrade(t *testing.T) {
 				cn2,
 			)
 
-			_ = testutils.ExecSQL(
-				t,
-				db,
-				cn1,
-				"truncate table "+table+";",
-				"insert into "+table+" select result, result from generate_series(1,5000) g;",
-			)
+			exec1 := testutils.GetSQLExecutor(cn1)
+			getTableID := func() uint64 {
+				var tableID uint64
+				err := exec1.ExecTxn(
+					ctx,
+					func(txn executor.TxnExecutor) error {
+						tableID = testutils.GetTableID(t, db, table, txn)
+						return nil
+					},
+					executor.Options{}.
+						WithDatabase("mo_catalog").
+						WithWaitCommittedLogApplied(),
+				)
+				require.NoError(t, err)
+				require.NotZero(t, tableID)
+				return tableID
+			}
 
-			_ = testutils.ExecSQL(
-				t,
-				db,
-				cn1,
-				"insert into "+table+" select result, result from generate_series(5001,10000) g;",
-			)
-
-			_ = testutils.ExecSQL(
-				t,
-				db,
-				cn1,
-				"insert into "+table+" select result, result from generate_series(10001,15000) g;",
-			)
-
+			lockOwner := lockservice.GetLockServiceByServiceID(cn1.ServiceID())
+			lockBudget := int(lockOwner.GetConfig().MaxLockRowCount)
+			require.Greater(t, lockBudget, 0)
+			fixtureRows := lockBudget + 2
 			committedAt := testutils.ExecSQL(
 				t,
 				db,
 				cn1,
-				"insert into "+table+" select result, result from generate_series(15001,20000) g;",
+				"truncate table "+table+";",
+				fmt.Sprintf("insert into %s select result, result from generate_series(1,%d) g;", table, fixtureRows),
 			)
+			tableID := getTableID()
 
 			// case 1
-			// test for local LocalTable that need upgrade row level lock to table level lock
-			exec1 := testutils.GetSQLExecutor(cn1)
+			// Test coarsening at the local lock-table owner.
 			err = exec1.ExecTxn(
 				ctx,
 				func(txn executor.TxnExecutor) error {
@@ -697,6 +698,7 @@ func TestLockNeedUpgrade(t *testing.T) {
 					)
 					require.NoError(t, err)
 					res.Close()
+					requireIssueLockCoarsened(t, lockOwner, tableID)
 					return nil
 				},
 				executor.Options{}.
@@ -704,38 +706,23 @@ func TestLockNeedUpgrade(t *testing.T) {
 					WithMinCommittedTS(committedAt),
 			)
 			require.NoError(t, err)
-
-			_ = testutils.ExecSQL(
-				t,
-				db,
-				cn1,
-				"truncate table "+table+";",
-				"insert into "+table+" select result, result from generate_series(1,5000) g;",
-			)
-
-			_ = testutils.ExecSQL(
-				t,
-				db,
-				cn1,
-				"insert into "+table+" select result, result from generate_series(5001,10000) g;",
-			)
-
-			_ = testutils.ExecSQL(
-				t,
-				db,
-				cn1,
-				"insert into "+table+" select result, result from generate_series(10001,15000) g;",
-			)
+			res, err := exec1.Exec(ctx, "select count(*) from "+table,
+				executor.Options{}.WithDatabase(db).WithWaitCommittedLogApplied())
+			require.NoError(t, err)
+			require.Equal(t, 1, testutils.ReadCount(res))
+			res.Close()
 
 			committedAt = testutils.ExecSQL(
 				t,
 				db,
 				cn1,
-				"insert into "+table+" select result, result from generate_series(15001,20000) g;",
+				"truncate table "+table+";",
+				fmt.Sprintf("insert into %s select result, result from generate_series(1,%d) g;", table, fixtureRows),
 			)
+			tableID = getTableID()
 
 			// case 2
-			// test for remote LockTable that need upgrade row level lock to table level lock
+			// Test the same coarsening through a remote lock-table proxy.
 			exec2 := testutils.GetSQLExecutor(cn2)
 			err = exec2.ExecTxn(
 				ctx,
@@ -746,6 +733,7 @@ func TestLockNeedUpgrade(t *testing.T) {
 					)
 					require.NoError(t, err)
 					res.Close()
+					requireIssueLockCoarsened(t, lockOwner, tableID)
 					return nil
 				},
 				executor.Options{}.
@@ -753,8 +741,30 @@ func TestLockNeedUpgrade(t *testing.T) {
 					WithMinCommittedTS(committedAt),
 			)
 			require.NoError(t, err)
+			res, err = exec2.Exec(ctx, "select count(*) from "+table,
+				executor.Options{}.WithDatabase(db).WithWaitCommittedLogApplied())
+			require.NoError(t, err)
+			require.Equal(t, 1, testutils.ReadCount(res))
+			res.Close()
 		},
 	)
+}
+
+func requireIssueLockCoarsened(
+	t *testing.T,
+	lockService lockservice.LockService,
+	tableID uint64,
+) {
+	t.Helper()
+	rangeLocks := 0
+	lockService.IterLocks(func(lockedTableID uint64, keys [][]byte, _ lockservice.Lock) bool {
+		if lockedTableID == tableID && len(keys) == 2 {
+			rangeLocks++
+		}
+		return true
+	})
+	require.Greater(t, rangeLocks, 0,
+		"the over-budget DELETE must replace row locks with a range lock")
 }
 
 func TestIssue19551(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #27571

## What this PR does / why we need it:

This reduces high-cost integration-test setup while preserving the original semantic matrices and strengthening deterministic oracles. No production code is changed.

### Data Branch DML fixtures

- Shares database and cluster fixtures across compatible diff, pick, and regression scenarios while keeping isolated tables and fresh-context cleanup.
- Replaces oversized inputs with the smallest structural boundaries that retain multiple object blocks, three blocks plus a tail, and two 8192-key pick chunks plus untouched rows.
- Keeps conflict policies, key types/coercion, mixed DML, snapshots, transaction rejection, remote multi-CN scope, and unhappy paths.
- Replaces log-only/no-error checks with exact chunk layouts, affected-row counts, unchanged-state checks, and exact result sets.
- Reduces issue 26568 from 260,000 generated values to two matching rows per side because its renderer contract is driven by explicitly patched optimizer statistics.

### High-cost issues and resource fixtures

- Keeps the issue 26095 matrix at 2 account contexts x 3 deletion entry points. Table deletion retains the reported four independent sessions, but removes duplicate system-account rounds. A ready barrier admits every connection before release; catalog rows, branch snapshots, and object deletion are checked exactly.
- Builds the issue 26123 source schema once and copies it once per Data Branch/CLONE mode. All 2 modes x 3 LIKE-metacharacter identifiers remain named subtests, including collision tables, exact FK catalog identity, copied rows, and rejected invalid FK writes.
- Reduces issue 26131 from 100,000 lineitem rows to two real SUM groups with four rows. EXPLAIN now requires exactly one lineitem producer and exactly two Sink Scan consumers, and the result is exact.
- Derives TestLockNeedUpgrade input from the real MaxLockRowCount boundary (10,002 rows in the default cluster instead of 20,000 twice). Both local-owner and remote-proxy paths inspect the live lock service for range-lock coarsening and verify the terminal row count.
- Reduces the broadcast hard-budget fixture from 200,000 to 66,048 rows while retaining the grouped-child/broadcast topology, controlled OOM classification, no-spill assertion, no partial result, and post-error health check.
- Reduces the eight-worker HashBuild recovery fixture from 1,000,000 to 786,944 rows while retaining the original 28 MiB cap, late map-admission recovery, expression-key shuffle topology, exact result, spill metric, and post-query health check.

### Metadata and account integration fixtures

- Reuses one source database for ordinary internal-looking tables and fulltext storage across Data Branch and CLONE. The 2 copy modes, 3 ordinary names, hidden fulltext storage, and copied data remain exact named assertions.
- Reuses one branch lineage across the 3 delete-validation identifier cases. Each case still independently proves the exact rejection and unchanged row, while cleanup now removes snapshots on failure.
- Batches issue 26232 `information_schema.columns` and `DESC` reads without removing any per-view or per-column default assertion.
- Replaces issue 26111's three open-ended internal catalog polling loops with direct target-tenant SQL checks after the cross-account DDL commits. Cyclic rows, both FK catalog entries, both invalid writes, duplicate-create state, and session restoration are still checked exactly through the public user path.

### Coverage and timing evidence

- DML A/B coverage across frontend, compile, and plan increased from 26.7% to 27.4%; the frontend data_branch target has no baseline-only blocks, and data_branch_pick.go keeps the exact same covered-block set.
- Instrumented HashBuild/HashJoin/Group A/B coverage increased from 45.0% to 45.1%. The late map-admission and recovery blocks are retained; residual block-set differences are limited to concurrent spill-buffer empty/full and sealed-mailbox scheduling branches.
- Instrumented isolated resource tests improved from 29.065s to 25.660s on the same host, saving 3.405s (11.7%).
- The named issue-test bodies improved from 2.67s to 1.29s on the same host, saving 1.38s (51.7%); shared cluster startup is excluded.
- The selected DML matrix improved from 17.057s to 14.021s, saving 3.036s (17.8%).
- In the additional batch, issue 26121 improved from 0.80s to 0.58s and issue 26232 from 0.59s to 0.13s on the same shared-cluster run, saving 0.68s (48.9%) across those test bodies.
- A/B statement coverage for `pkg/frontend` and `pkg/sql/compile` is unchanged at 23.3%. The semantic matrices above are unchanged; issue 26111 intentionally moves incidental coverage from the internal executor to the real frontend authentication/session path.

### Validation

- `go test ./pkg/tests/dml -count=1`
- `go test -race ./pkg/tests/dml -count=1`
- Normal and race runs for all changed issue tests
- Normal and race runs for both isolated HashBuild resource tests
- Final recovery diagnostics: all 8 shuffle workers reported one spill and no pipeline failure
- Final broadcast diagnostics: exact 1 MiB hard-budget rejection and no HashBuild spill
- Deliberate FailNow probe for the shared DML fixture cleanup
- Post-rebase exact normal run for the three additional issue tests
- `gofmt` and `git diff --check`

The branch is rebased on `428ce80cb8` (current `origin/main` when pushed).
