### PR TITLE
perf: enable right SINGLE filters for local queries without stats

### DIFF
--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -485,7 +485,17 @@ func (hashBuild *HashBuild) build(
 			}
 		}
 
-		err := ctr.hashmapBuilder.BuildHashmap(hashBuild.HashOnPK, hashBuild.NeedAllocateSels, needUniqueVec, proc)
+		runtimeFilterLimit := int32(-1)
+		if needUniqueVec && !hashBuild.RuntimeFilterSpec.UseMembershipFilter {
+			runtimeFilterLimit = hashBuild.RuntimeFilterSpec.UpperLimit
+		}
+		err := ctr.hashmapBuilder.buildHashmapWithRuntimeFilterLimit(
+			hashBuild.HashOnPK,
+			hashBuild.NeedAllocateSels,
+			needUniqueVec,
+			runtimeFilterLimit,
+			proc,
+		)
 		collectionFallback, _ :=
 			ctr.hashmapBuilder.runtimeFilterFallbackState()
 		rebuildSafe := ctr.hashmapBuilder.RetainedBatchRecoverySafe()

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -831,6 +831,131 @@ func TestHashmapBuilderUniqueGrowthFailureAbandonsOptionalKeysInPlace(
 	require.Zero(t, tc.proc.Mp().CurrNB())
 }
 
+func TestHashmapBuilderRuntimeFilterLimitAbandonsOptionalKeysInPlace(
+	t *testing.T,
+) {
+	for _, hashOnPK := range []bool{false, true} {
+		for _, test := range []struct {
+			name         string
+			limit        int32
+			rows         int
+			wantFallback bool
+		}{
+			{
+				name:  "at-limit",
+				limit: int32(hashmap.UnitLimit),
+				rows:  hashmap.UnitLimit,
+			},
+			{
+				name:         "over-limit",
+				limit:        int32(hashmap.UnitLimit + 1),
+				rows:         hashmap.UnitLimit * 3,
+				wantFallback: true,
+			},
+		} {
+			t.Run(fmt.Sprintf("hash-on-pk=%t/%s", hashOnPK, test.name), func(t *testing.T) {
+				typ := types.T_int32.ToType()
+				tc := newTestCase(
+					t,
+					[]bool{false},
+					[]types.Type{typ},
+					[]*plan.Expr{newExpr(0, typ)},
+				)
+				require.NoError(t, tc.arg.Prepare(tc.proc))
+
+				input := newBatch([]types.Type{typ}, tc.proc, int64(test.rows))
+				require.NoError(t,
+					tc.arg.ctr.hashmapBuilder.copyBuildBatch(input, tc.proc))
+				tc.arg.ctr.hashmapBuilder.InputBatchRowCount = test.rows
+				input.Clean(tc.proc.Mp())
+
+				require.NoError(t,
+					tc.arg.ctr.hashmapBuilder.buildHashmapWithRuntimeFilterLimit(
+						hashOnPK, false, true, test.limit, tc.proc))
+				fallback, rebuildSafe :=
+					tc.arg.ctr.hashmapBuilder.runtimeFilterFallbackState()
+				require.Equal(t, test.wantFallback, fallback)
+				require.True(t, rebuildSafe)
+				if test.wantFallback {
+					require.Nil(t, tc.arg.ctr.hashmapBuilder.UniqueJoinKeys)
+				} else {
+					require.Len(t, tc.arg.ctr.hashmapBuilder.UniqueJoinKeys, 1)
+					require.Equal(t, test.rows,
+						tc.arg.ctr.hashmapBuilder.UniqueJoinKeys[0].Length())
+				}
+				require.Equal(t, uint64(test.rows),
+					tc.arg.ctr.hashmapBuilder.GetGroupCount(),
+					"the mandatory JoinMap must still contain every key")
+
+				tc.arg.Free(tc.proc, false, nil)
+				tc.proc.Free()
+				require.Zero(t, tc.proc.Mp().CurrNB())
+			})
+		}
+	}
+}
+
+func TestHashBuildRuntimeFilterLimitFailsOpenWithoutLosingJoinKeys(
+	t *testing.T,
+) {
+	typ := types.T_int32.ToType()
+	tc := newTestCase(
+		t,
+		[]bool{false},
+		[]types.Type{typ},
+		[]*plan.Expr{newExpr(0, typ)},
+	)
+	tc.arg.RuntimeFilterSpec = rawRuntimeFilterSpec(
+		tc.arg.JoinMapTag+502, 5, typ)
+	tc.arg.SetChildren([]vm.Operator{tc.marg})
+	require.NoError(t, tc.marg.Prepare(tc.proc))
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+
+	input := newBatch([]types.Type{typ}, tc.proc, Rows)
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(input, nil, tc.proc.Mp())
+	tc.proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, tc.proc.Mp())
+
+	result, err := vm.Exec(tc.arg, tc.proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, result.Status)
+	require.Equal(t, int64(1),
+		tc.arg.OpAnalyzer.GetOpStats().ExtraStats["HashBuildRuntimeFilterCollectionFallbacks"])
+
+	receiver := message.NewMessageReceiver(
+		[]int32{tc.arg.RuntimeFilterSpec.Tag},
+		message.AddrBroadCastOnCurrentCN(),
+		tc.proc.GetMessageBoard(),
+	)
+	messages, done, err := receiver.ReceiveMessage(false, tc.proc.Ctx)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Len(t, messages, 1)
+	runtimeFilter, ok := messages[0].(message.RuntimeFilterMessage)
+	require.True(t, ok)
+	require.Equal(t, int32(message.RuntimeFilter_PASS), runtimeFilter.Typ)
+
+	joinResult, err := message.ReceiveJoinMapResult(
+		tc.arg.JoinMapTag,
+		false,
+		0,
+		tc.proc.GetMessageBoard(),
+		tc.proc.Ctx,
+	)
+	require.NoError(t, err)
+	require.True(t, joinResult.IsSuccess())
+	joinMap := joinResult.JoinMap()
+	require.NotNil(t, joinMap)
+	require.Equal(t, int64(Rows), joinMap.GetRowCount())
+	require.Equal(t, uint64(Rows), joinMap.GetGroupCount())
+	joinMap.Free()
+
+	tc.arg.Reset(tc.proc, false, nil)
+	tc.arg.Free(tc.proc, false, nil)
+	tc.marg.Reset(tc.proc, false, nil)
+	tc.proc.Free()
+	require.Zero(t, tc.proc.Mp().CurrNB())
+}
+
 func TestDedupBatchRewriteRecollectsOptionalKeysWithoutUnsafeReplay(
 	t *testing.T,
 ) {

--- a/pkg/sql/colexec/hashbuild/hashmap.go
+++ b/pkg/sql/colexec/hashbuild/hashmap.go
@@ -428,9 +428,33 @@ func (hb *HashmapBuilder) hasNonReflexiveFloatKey() bool {
 }
 
 func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, needUniqueVec bool, proc *process.Process) (retErr error) {
+	return hb.buildHashmapWithRuntimeFilterLimit(
+		hashOnPK, needAllocateSels, needUniqueVec, -1, proc)
+}
+
+// buildHashmapWithRuntimeFilterLimit bounds optional exact-runtime-filter key
+// retention independently of the mandatory JoinMap. A negative limit keeps
+// the legacy unbounded collection contract for callers that do not have a
+// RuntimeFilterSpec (including membership-filter consumers, which apply their
+// own policy). Exceeding the bound fails only the optional filter open; the
+// complete JoinMap continues to build.
+func (hb *HashmapBuilder) buildHashmapWithRuntimeFilterLimit(
+	hashOnPK bool,
+	needAllocateSels bool,
+	needUniqueVec bool,
+	runtimeFilterLimit int32,
+	proc *process.Process,
+) (retErr error) {
 	hb.runtimeFilterCollectionFallback = false
 	hb.retainedBatchRecoverySafe = true
-	return hb.buildHashmap(hashOnPK, needAllocateSels, needUniqueVec, hb.DedupBuildKeepLast, proc)
+	return hb.buildHashmap(
+		hashOnPK,
+		needAllocateSels,
+		needUniqueVec,
+		runtimeFilterLimit,
+		hb.DedupBuildKeepLast,
+		proc,
+	)
 }
 
 func (hb *HashmapBuilder) runtimeFilterFallbackState() (bool, bool) {
@@ -442,6 +466,21 @@ func (hb *HashmapBuilder) collectUniqueKeySlot(slot int) bool {
 	return len(hb.uniqueKeySlots) == 0 ||
 		(slot >= 0 && slot < len(hb.uniqueKeySlots) &&
 			hb.uniqueKeySlots[slot])
+}
+
+func (hb *HashmapBuilder) optionalRuntimeFilterKeysExceedLimit(limit int32) bool {
+	if limit < 0 {
+		return false
+	}
+	if hb.GetGroupCount() > uint64(limit) {
+		return true
+	}
+	for i, keys := range hb.UniqueJoinKeys {
+		if hb.collectUniqueKeySlot(i) && keys != nil && keys.Length() > int(limit) {
+			return true
+		}
+	}
+	return false
 }
 
 // RetainedBatchRecoverySafe reports whether the batches retained by this
@@ -458,6 +497,7 @@ func (hb *HashmapBuilder) buildHashmap(
 	hashOnPK bool,
 	needAllocateSels bool,
 	needUniqueVec bool,
+	runtimeFilterLimit int32,
 	dedupBuildKeepLast bool,
 	proc *process.Process,
 ) (retErr error) {
@@ -820,6 +860,15 @@ buildUnits:
 			}
 		}
 
+		if needUniqueVec &&
+			hb.optionalRuntimeFilterKeysExceedLimit(runtimeFilterLimit) {
+			if err := hb.abandonOptionalRuntimeFilterKeys(proc); err != nil {
+				return err
+			}
+			needUniqueVec = false
+			continue buildUnits
+		}
+
 		if needUniqueVec {
 			if len(hb.UniqueJoinKeys) == 0 {
 				if hb.uniqueKeyAllocation == nil {
@@ -904,6 +953,13 @@ buildUnits:
 					}
 				}
 			}
+			if needUniqueVec &&
+				hb.optionalRuntimeFilterKeysExceedLimit(runtimeFilterLimit) {
+				if err := hb.abandonOptionalRuntimeFilterKeys(proc); err != nil {
+					return err
+				}
+				needUniqueVec = false
+			}
 		}
 	}
 
@@ -934,7 +990,14 @@ buildUnits:
 		if err != nil {
 			return err
 		}
-		if err := hb.buildHashmap(hashOnPK, needAllocateSels, needUniqueVec, false, proc); err != nil {
+		if err := hb.buildHashmap(
+			hashOnPK,
+			needAllocateSels,
+			needUniqueVec,
+			runtimeFilterLimit,
+			false,
+			proc,
+		); err != nil {
 			return err
 		}
 		hb.InputBatchRowCount = totalRowCount
@@ -964,7 +1027,14 @@ buildUnits:
 		if err != nil {
 			return err
 		}
-		return hb.buildHashmap(hashOnPK, needAllocateSels, needUniqueVec, false, proc)
+		return hb.buildHashmap(
+			hashOnPK,
+			needAllocateSels,
+			needUniqueVec,
+			runtimeFilterLimit,
+			false,
+			proc,
+		)
 	}
 
 	if hb.delColIdx != -1 {

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -127,7 +127,7 @@ func (builder *QueryBuilder) canSatisfyRuntimeFilterDelivery(node *plan.Node, po
 	return builder.optimizerHints == nil || builder.optimizerHints.forceOneCN == 0
 }
 
-func rightSingleLocalDeliveryIsSafe(node, build *plan.Node, upperLimit int32) bool {
+func (builder *QueryBuilder) rightSingleLocalDeliveryIsSafe(node, build *plan.Node, upperLimit int32) bool {
 	if node.JoinType != plan.Node_SINGLE {
 		return true
 	}
@@ -135,10 +135,17 @@ func rightSingleLocalDeliveryIsSafe(node, build *plan.Node, upperLimit int32) bo
 		return false
 	}
 	// DefaultStats is an unavailable-statistics sentinel, not evidence that the
-	// complete build contains 1,000 rows.  Treating it as an exact upper bound
-	// can serialize an arbitrarily large scan only for hashbuild to send PASS.
+	// complete build contains 1,000 rows.  It is still safe to let HashBuild
+	// decide IN versus PASS at runtime when the query would already execute on a
+	// single CN: local delivery then adds no placement downgrade, while the
+	// runtime upper limit bounds the optional exact-key collection.  Keep forced
+	// multi-CN diagnostics and naturally distributed plans on the old fallback.
 	if IsDefaultStats(build.Stats) {
-		return false
+		if builder == nil || builder.qry == nil ||
+			(builder.optimizerHints != nil && builder.optimizerHints.execType == 3) {
+			return false
+		}
+		return GetExecType(builder.qry, false, false) != ExecTypeAP_MULTICN
 	}
 	// LOCAL_COLOCATED applies to the whole preserved/build subtree. Phase 1
 	// accepts only a direct scan whose full table cardinality and filtered
@@ -638,7 +645,7 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 		probeExpr := GetColExpr(tableDef.Cols[cpkeyPos].Typ, leftChild.BindingTags[0], cpkeyPos)
 		probeExpr.GetCol().Name = catalog.CPrimaryKeyColName
 		inLimit := GetInFilterCardLimitOnPK(sid, leftChild.Stats.TableCnt)
-		if !rightSingleLocalDeliveryIsSafe(node, rightChild, inLimit) {
+		if !builder.rightSingleLocalDeliveryIsSafe(node, rightChild, inLimit) {
 			return
 		}
 		rfTag := builder.genNewMsgTag()
@@ -710,7 +717,7 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 		// unique keys.  If the planner already knows the build cannot fit in an
 		// exact IN, hashbuild would send PASS after both scans were forced onto
 		// one CN.  Reject that no-benefit topology up front for right-SINGLE.
-		if !rightSingleLocalDeliveryIsSafe(node, rightChild, inLimit) {
+		if !builder.rightSingleLocalDeliveryIsSafe(node, rightChild, inLimit) {
 			return
 		}
 		if convertToCPKey {

--- a/pkg/sql/plan/runtime_filter_test.go
+++ b/pkg/sql/plan/runtime_filter_test.go
@@ -1121,9 +1121,18 @@ func TestRightSingleRuntimeFilterConservativeEligibility(t *testing.T) {
 			},
 		},
 		{
-			name: "unavailable build statistics are not an exact size bound",
+			name: "unavailable build statistics do not localize a naturally multi-CN query",
 			mutate: func(builder *QueryBuilder) {
 				builder.qry.Nodes[1].Stats = DefaultStats()
+				builder.qry.Nodes[0].Stats.Cost = float64(costThresholdForOneCN + 1)
+				builder.qry.Nodes[0].Stats.BlockNum = int32(BlockThresholdForOneCN + 1)
+			},
+		},
+		{
+			name: "forced multi-CN execution keeps unavailable build statistics on fallback",
+			mutate: func(builder *QueryBuilder) {
+				builder.qry.Nodes[1].Stats = DefaultStats()
+				builder.optimizerHints = &OptimizerHints{execType: 3}
 			},
 		},
 		{
@@ -1151,6 +1160,20 @@ func TestRightSingleRuntimeFilterConservativeEligibility(t *testing.T) {
 			require.Empty(t, builder.qry.Nodes[0].RuntimeFilterProbeList)
 		})
 	}
+
+	t.Run("unavailable build statistics use bounded runtime fallback when query is already local", func(t *testing.T) {
+		builder := newRuntimeFilterSingleTestBuilder(true)
+		builder.qry.Nodes[1].Stats = DefaultStats()
+		require.NotEqual(t, ExecTypeAP_MULTICN, GetExecType(builder.qry, false, false))
+
+		builder.generateRuntimeFilters(2)
+		builder.forceJoinOnOneCN(2, false)
+
+		require.Len(t, builder.qry.Nodes[2].RuntimeFilterBuildList, 1)
+		require.Len(t, builder.qry.Nodes[0].RuntimeFilterProbeList, 1)
+		require.True(t, builder.qry.Nodes[0].Stats.ForceOneCN)
+		require.True(t, builder.qry.Nodes[1].Stats.ForceOneCN)
+	})
 
 	t.Run("leading cluster key remains prunable with non-PK row filtering", func(t *testing.T) {
 		builder := newRuntimeFilterSingleTestBuilder(true)

--- a/test/distributed/cases/subquery/right_single_runtime_filter.result
+++ b/test/distributed/cases/subquery/right_single_runtime_filter.result
@@ -10,6 +10,20 @@ insert into small_lookup values
 (2, 5000, 49999),
 (3, 30000, 0),
 (4, null, 0);
+explain select s.id, (select b.v from big_pk b where b.id = s.lookup_id) as scalar_v
+from small_lookup s
+order by s.id;
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: s.id INTERNAL  𝄀
+        ->  Join  𝄀
+              Join Type: RIGHT SINGLE  𝄀
+              Join Cond: (b.id = s.lookup_id)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on right_single_rf.big_pk [ForceOneCN]  𝄀
+                    Runtime Filter Probe: b.id  𝄀
+              ->  Table Scan on right_single_rf.small_lookup [ForceOneCN]
 select s.id, (select b.v from big_pk b where b.id = s.lookup_id) as scalar_v
 from small_lookup s
 order by s.id;

--- a/test/distributed/cases/subquery/right_single_runtime_filter.sql
+++ b/test/distributed/cases/subquery/right_single_runtime_filter.sql
@@ -1,6 +1,7 @@
 -- @suite
--- This suite asserts SQL semantics only and is intentionally topology-agnostic:
--- the same file runs in standalone and multi-CN BVT jobs.
+-- This suite asserts SQL semantics plus the stable logical runtime-filter
+-- contract, while remaining deployment-topology agnostic: the same file runs
+-- in standalone and multi-CN BVT jobs.
 -- @setup
 drop database if exists right_single_rf;
 create database right_single_rf;
@@ -18,6 +19,13 @@ insert into small_lookup values
     (2, 5000, 49999),
     (3, 30000, 0),
     (4, null, 0);
+
+-- @case
+-- @desc: a naturally local query uses bounded right-SINGLE RF when small-build statistics are unavailable
+-- @label:bvt
+explain select s.id, (select b.v from big_pk b where b.id = s.lookup_id) as scalar_v
+from small_lookup s
+order by s.id;
 
 -- @case
 -- @desc: right-SINGLE exact-IN keeps match, missing and NULL preserved rows


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25862

## What this PR does / why we need it:

`DefaultStats` means statistics are unavailable; it is not proof that a build has exactly 1,000 rows. Rejecting every such right-SINGLE filter is safe but makes a common newly-created tiny lookup table force a full scan of the probe table.

This change bases the decision on the actual safety invariants:

- If the query would already execute on one CN, right-SINGLE may use the existing exact runtime-filter protocol. Local delivery does not reduce scan placement in that case.
- Naturally multi-CN queries, globally forced multi-CN scans, and `execType=3` diagnostics keep the no-filter fallback. A filter is never introduced by first downgrading a distributed scan.
- HashBuild now enforces `RuntimeFilterSpec.UpperLimit` while collecting optional exact-filter keys. Once actual build cardinality exceeds the limit, it immediately releases those keys, continues building the complete mandatory JoinMap, and publishes `PASS`. Unknown statistics therefore cannot turn this optimization into unbounded duplicate key retention.
- Membership-filter consumers retain their existing independent typed-key policy.
- Existing key/type/primary-key/cardinality and delivery guards remain unchanged.

The BVT change reuses the existing right-SINGLE fixture and adds only a zero-execution `EXPLAIN` assertion. It adds no data, setup, sleep, or duplicate semantic case; all existing semantic, duplicate-cardinality, DML, empty-input, and `LIMIT 0` cases remain.

### Validation on 10.222.1.55

The production files modified by this PR were copied checksum-for-checksum into the remote candidate worktree, compiled into a dedicated image, and run in an isolated fresh two-CN cluster. The image's `/mo-service` SHA256 was `da42201a0b627d4c4b3ceb41f3c1e69ce71b4d4ad322b4ee1eed9f792aedc95b`.

Probe table: 1,000,000 rows. Lookup table: 3 rows.

| mode | probe blocks | probe rows | read size | join input rows | result |
| --- | ---: | ---: | ---: | ---: | --- |
| RF enabled | 2 | 2 | 202.37 KiB | 5 | correct |
| RF disabled | 128 | 1,000,000 | 8.19 MiB | 1,000,003 | identical |
| forced multi-CN | full scan | 1,000,000 | 8.19 MiB | 1,000,003 | identical; completed without hang |

The enabled plan is `AP QUERY PLAN ON ONE CN` and contains `Runtime Filter Build`, `Runtime Filter Probe`, and `ForceOneCN` on the already-local scans. Forced `execType=3` is `AP QUERY PLAN ON MULTICN`, contains no right-SINGLE runtime filter or `ForceOneCN`, and completes on the same two-CN cluster.

Validation performed on the final code:

- complete `./pkg/sql/colexec/hashbuild` tests: pass
- complete `./pkg/sql/plan` tests: pass
- focused planner/cardinality/fail-open regressions: pass
- `go build -mod=readonly` and `go vet -mod=readonly` for both packages: pass
- coverage: hashbuild 76.1%, plan 78.5%; new planner guard and limit-aware build entry are 100% covered
- existing right-SINGLE BVT through CN1: 38/38, 100%, 5.869s
- the same BVT through CN2 after reuse/cleanup: 38/38, 100%, 6.057s
- cluster log audit: no panic, fatal, runtime-filter timeout, or topology error
