### PR TITLE
fix: preserve instant in transaction timestamp conversion

### DIFF
--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -1166,41 +1166,46 @@ func TSToTimestamp(ivecs []*vector.Vector, result vector.FunctionResultWrapper, 
 	rs := vector.MustFunctionResult[types.Timestamp](result)
 	from := vector.GenerateFunctionFixedTypeParameter[types.TS](ivecs[0])
 	scale := int32(6)
-	if len(ivecs) == 2 && !ivecs[1].IsConstNull() {
-		scale = int32(vector.MustFixedColWithTypeCheck[int64](ivecs[1])[0])
+	if len(ivecs) == 2 {
+		if ivecs[1].IsConstNull() {
+			rs.TempSetType(types.New(types.T_timestamp, 0, scale))
+			rs.SetNullResult(uint64(length))
+			return nil
+		}
+		if !ivecs[1].IsConst() {
+			return moerr.NewInvalidInput(proc.Ctx, "the precision argument of ts_to_time must be constant")
+		}
+		precision := vector.MustFixedColWithTypeCheck[int64](ivecs[1])[0]
+		if precision < 0 || precision > 6 {
+			return moerr.NewErrTooBigPrecision(proc.Ctx, precision, "ts_to_time", 6)
+		}
+		scale = int32(precision)
 	}
 	rs.TempSetType(types.New(types.T_timestamp, 0, scale))
 	for i := 0; i < length; i++ {
 		tsVal, null := from.GetValue(uint64(i))
 		if null {
-			if err := rs.AppendBytes(nil, true); err != nil {
+			if err := rs.Append(0, true); err != nil {
 				return err
 			}
 			continue
 		}
 
-		physical := tsVal.Physical()
-		seconds := int64(physical / 1e9)
-		nanos := int64(physical % 1e9)
-		t := time.Unix(seconds, nanos).UTC()
-		timeStr := t.Format("2006-01-02 15:04:05.999999")
-
-		zone := time.Local
-		if proc != nil {
-			zone = proc.GetSessionInfo().TimeZone
-		}
-		val, err := types.ParseTimestamp(zone, timeStr, scale)
-		if err != nil {
+		if err := rs.Append(timestampFromTransactionTS(tsVal, scale), false); err != nil {
 			return err
 		}
-
-		if err = rs.Append(val, false); err != nil {
-			return err
-		}
-
 	}
 
 	return nil
+}
+
+// timestampFromTransactionTS converts the physical component of an HLC
+// transaction timestamp to the SQL TIMESTAMP representation. Both values are
+// absolute instants, so a session time zone must not participate in the
+// conversion. The logical component only orders events at the same physical
+// instant and therefore has no SQL TIMESTAMP representation.
+func timestampFromTransactionTS(ts types.TS, scale int32) types.Timestamp {
+	return types.UnixNanoToTimestamp(ts.Physical()).TruncateToScale(scale)
 }
 
 func ConvertTz(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) (err error) {

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -2811,7 +2811,7 @@ func tsToOthers(proc *process.Process,
 		return tsToStr(proc.Ctx, source, rs, length, toType, strictStringWidth...)
 	case types.T_timestamp:
 		rs := vector.MustFunctionResult[types.Timestamp](result)
-		return tsToTimestamp(proc, source, rs, length, toType)
+		return tsToTimestamp(source, rs, length, toType)
 	case types.T_int64:
 		rs := vector.MustFunctionResult[int64](result)
 		return tsToInt64(proc.Ctx, source, rs, length, toType)
@@ -8464,35 +8464,23 @@ func tsToStr(
 	return nil
 }
 func tsToTimestamp(
-	proc *process.Process,
 	from vector.FunctionParameterWrapper[types.TS],
 	to *vector.FunctionResult[types.Timestamp],
 	length int,
 	toType types.Type) error {
 
 	for i := 0; i < length; i++ {
-		tsVal, _ := from.GetValue(uint64(i))
-
-		physical := tsVal.Physical()
-		seconds := int64(physical / 1e9)
-		nanos := int64(physical % 1e9)
-		t := time.Unix(seconds, nanos).UTC()
-		timeStr := t.Format("2006-01-02 15:04:05.999999")
-
-		zone := time.Local
-		if proc != nil {
-			zone = proc.GetSessionInfo().TimeZone
+		tsVal, null := from.GetValue(uint64(i))
+		if null {
+			if err := to.Append(0, true); err != nil {
+				return err
+			}
+			continue
 		}
-		val, err := types.ParseTimestamp(zone, timeStr, toType.Scale)
 
-		if err != nil {
+		if err := to.Append(timestampFromTransactionTS(tsVal, toType.Scale), false); err != nil {
 			return err
 		}
-
-		if err = to.Append(val, false); err != nil {
-			return err
-		}
-
 	}
 
 	return nil

--- a/pkg/sql/plan/function/func_ts_to_time_test.go
+++ b/pkg/sql/plan/function/func_ts_to_time_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTSToTimestampPreservesAbsoluteInstant(t *testing.T) {
+	physical := time.Date(2026, time.August, 26, 5, 45, 12, 654321987, time.UTC).UnixNano()
+	values := []types.TS{
+		types.BuildTS(physical, 0),
+		types.BuildTS(physical, 42),
+		types.BuildTS(physical, 99),
+	}
+	want := types.UnixNanoToTimestamp(physical)
+
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name string
+		zone *time.Location
+	}{
+		{name: "UTC", zone: time.UTC},
+		{name: "UTC+8", zone: time.FixedZone("UTC+8", 8*60*60)},
+		{name: "America/New_York", zone: newYork},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			proc.GetSessionInfo().TimeZone = tc.zone
+			input := testutil.MakeTSVector(values, []uint64{2}, proc.Mp())
+			defer input.Free(proc.Mp())
+
+			result := vector.NewFunctionResultWrapper(types.T_timestamp.ToTypeWithScale(6), proc.Mp())
+			defer result.Free()
+			require.NoError(t, result.PreExtendAndReset(len(values)))
+			require.NoError(t, TSToTimestamp(
+				[]*vector.Vector{input}, result, proc, len(values), nil))
+
+			output := result.GetResultVector()
+			require.Equal(t, int32(6), output.GetType().Scale)
+			got := vector.MustFixedColWithTypeCheck[types.Timestamp](output)
+			require.Equal(t, want, got[0])
+			// The HLC logical component has no representation in SQL TIMESTAMP.
+			require.Equal(t, got[0], got[1])
+			require.True(t, output.GetNulls().Contains(2))
+		})
+	}
+}
+
+func TestCastTSToTimestampPreservesAbsoluteInstant(t *testing.T) {
+	physical := time.Date(2026, time.August, 26, 5, 45, 12, 654321987, time.UTC).UnixNano()
+	values := []types.TS{types.BuildTS(physical, 7), types.BuildTS(physical, 8)}
+	want := types.UnixNanoToTimestamp(physical)
+
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name string
+		zone *time.Location
+	}{
+		{name: "UTC", zone: time.UTC},
+		{name: "UTC+8", zone: time.FixedZone("UTC+8", 8*60*60)},
+		{name: "America/New_York", zone: newYork},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			proc.GetSessionInfo().TimeZone = tc.zone
+			input := testutil.MakeTSVector(values, []uint64{1}, proc.Mp())
+			defer input.Free(proc.Mp())
+			target := vector.NewConstNull(types.T_timestamp.ToTypeWithScale(6), len(values), proc.Mp())
+			defer target.Free(proc.Mp())
+			result := vector.NewFunctionResultWrapper(types.T_timestamp.ToTypeWithScale(6), proc.Mp())
+			defer result.Free()
+
+			require.NoError(t, result.PreExtendAndReset(len(values)))
+			require.NoError(t, NewCast(
+				[]*vector.Vector{input, target}, result, proc, len(values), nil))
+
+			output := result.GetResultVector()
+			got := vector.MustFixedColWithTypeCheck[types.Timestamp](output)
+			require.Equal(t, want, got[0])
+			require.True(t, output.GetNulls().Contains(1))
+		})
+	}
+}
+
+func TestTSToTimestampPrecisionContract(t *testing.T) {
+	physical := time.Date(2026, time.August, 26, 5, 45, 12, 125678987, time.UTC).UnixNano()
+	value := types.BuildTS(physical, 1)
+
+	for _, tc := range []struct {
+		name  string
+		scale int64
+	}{
+		{name: "scale-0", scale: 0},
+		{name: "scale-2", scale: 2},
+		{name: "scale-6", scale: 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			input := testutil.MakeTSVector([]types.TS{value}, nil, proc.Mp())
+			defer input.Free(proc.Mp())
+			precision, err := vector.NewConstFixed(types.T_int64.ToType(), tc.scale, 1, proc.Mp())
+			require.NoError(t, err)
+			defer precision.Free(proc.Mp())
+			result := vector.NewFunctionResultWrapper(types.T_timestamp.ToTypeWithScale(6), proc.Mp())
+			defer result.Free()
+
+			require.NoError(t, result.PreExtendAndReset(1))
+			require.NoError(t, TSToTimestamp(
+				[]*vector.Vector{input, precision}, result, proc, 1, nil))
+
+			output := result.GetResultVector()
+			got := vector.MustFixedColWithTypeCheck[types.Timestamp](output)
+			require.Equal(t, int32(tc.scale), output.GetType().Scale)
+			require.Equal(t,
+				types.UnixNanoToTimestamp(physical).TruncateToScale(int32(tc.scale)), got[0])
+
+		})
+	}
+}
+
+func TestTSToTimestampRejectsInvalidPrecision(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		scale int64
+	}{
+		{name: "negative", scale: -1},
+		{name: "too-large", scale: 7},
+		{name: "int32-overflow", scale: 1<<32 + 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			input := testutil.MakeTSVector([]types.TS{types.BuildTS(1, 0)}, nil, proc.Mp())
+			defer input.Free(proc.Mp())
+			precision, err := vector.NewConstFixed(types.T_int64.ToType(), tc.scale, 1, proc.Mp())
+			require.NoError(t, err)
+			defer precision.Free(proc.Mp())
+			result := vector.NewFunctionResultWrapper(types.T_timestamp.ToTypeWithScale(6), proc.Mp())
+			defer result.Free()
+
+			require.NoError(t, result.PreExtendAndReset(1))
+			err = TSToTimestamp([]*vector.Vector{input, precision}, result, proc, 1, nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "precision")
+
+		})
+	}
+}
+
+func TestTSToTimestampPrecisionMustBeConstantOrNull(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	values := []types.TS{types.BuildTS(1, 0), types.BuildTS(2, 0)}
+	input := testutil.MakeTSVector(values, nil, proc.Mp())
+	defer input.Free(proc.Mp())
+
+	t.Run("non-constant", func(t *testing.T) {
+		precision := testutil.MakeInt64Vector([]int64{2, 3}, nil, proc.Mp())
+		defer precision.Free(proc.Mp())
+		result := vector.NewFunctionResultWrapper(types.T_timestamp.ToTypeWithScale(6), proc.Mp())
+		defer result.Free()
+		require.NoError(t, result.PreExtendAndReset(len(values)))
+
+		err := TSToTimestamp(
+			[]*vector.Vector{input, precision}, result, proc, len(values), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be constant")
+	})
+
+	t.Run("constant-null", func(t *testing.T) {
+		precision := vector.NewConstNull(types.T_int64.ToType(), len(values), proc.Mp())
+		defer precision.Free(proc.Mp())
+		result := vector.NewFunctionResultWrapper(types.T_timestamp.ToTypeWithScale(6), proc.Mp())
+		defer result.Free()
+		require.NoError(t, result.PreExtendAndReset(len(values)))
+
+		require.NoError(t, TSToTimestamp(
+			[]*vector.Vector{input, precision}, result, proc, len(values), nil))
+		require.True(t, result.GetResultVector().GetNulls().Contains(0))
+		require.True(t, result.GetResultVector().GetNulls().Contains(1))
+	})
+
+	t.Run("untyped-null-resolves", func(t *testing.T) {
+		_, err := GetFunctionByName(context.Background(), "ts_to_time", []types.Type{
+			types.T_TS.ToType(),
+			types.T_any.ToType(),
+		})
+		require.NoError(t, err)
+	})
+}
+
+var benchmarkTransactionTimestamp types.Timestamp
+
+func BenchmarkTransactionTSToTimestamp(b *testing.B) {
+	physical := time.Date(2026, time.August, 26, 5, 45, 12, 654321987, time.UTC).UnixNano()
+	ts := types.BuildTS(physical, 42)
+
+	b.Run("direct", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchmarkTransactionTimestamp = timestampFromTransactionTS(ts, 6)
+		}
+	})
+
+	b.Run("legacy-string-round-trip", func(b *testing.B) {
+		b.ReportAllocs()
+		var err error
+		for i := 0; i < b.N; i++ {
+			physical := ts.Physical()
+			t := time.Unix(physical/1e9, physical%1e9).UTC()
+			benchmarkTransactionTimestamp, err = types.ParseTimestamp(
+				time.UTC, t.Format("2006-01-02 15:04:05.999999"), 6)
+		}
+		require.NoError(b, err)
+	})
+}

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -8881,7 +8881,8 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 			if len(inputs) == 1 && inputs[0].Oid == types.T_TS {
 				return newCheckResultWithSuccess(0)
 			}
-			if len(inputs) == 2 && inputs[0].Oid == types.T_TS && inputs[1].Oid == types.T_int64 {
+			if len(inputs) == 2 && inputs[0].Oid == types.T_TS &&
+				(inputs[1].Oid == types.T_int64 || inputs[1].Oid == types.T_any) {
 				return newCheckResultWithSuccess(0)
 			}
 			return newCheckResultWithFailure(failedFunctionParametersWrong)

--- a/test/distributed/cases/function/table_func_metadata_scan.result
+++ b/test/distributed/cases/function/table_func_metadata_scan.result
@@ -46,17 +46,32 @@ select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cre
 invalid argument operator >, bad value [TRANSACTION TIMESTAMP DECIMAL64]
 select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cast(create_ts as float) > 9.9;
 invalid argument operator cast, bad value [TRANSACTION TIMESTAMP FLOAT]
-select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cast(create_ts as TIMESTAMP) <= NOW();
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cast(create_ts as TIMESTAMP) = ts_to_time(create_ts, 0);
 ➤ count(*)[-5,64,0]  𝄀
 5
-select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts) <= NOW();
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts) = cast(create_ts as TIMESTAMP(6));
 ➤ count(*)[-5,64,0]  𝄀
 5
-select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts, 2) <= NOW();
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts, 2) = cast(create_ts as TIMESTAMP(2));
 ➤ count(*)[-5,64,0]  𝄀
 5
 select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(1) <= NOW();
 invalid argument function ts_to_time, bad value [BIGINT]
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts, null) is null;
+➤ count(*)[-5,64,0]  𝄀
+5
+set @metadata_scan_saved_time_zone = @@time_zone;
+set time_zone = '+08:00';
+set @metadata_scan_function_epoch = (select min(unix_timestamp(ts_to_time(create_ts))) from metadata_scan('table_func_metadata_scan.t', '*') g);
+set @metadata_scan_cast_epoch = (select min(unix_timestamp(cast(create_ts as timestamp(6)))) from metadata_scan('table_func_metadata_scan.t', '*') g);
+set time_zone = '-05:00';
+select min(unix_timestamp(ts_to_time(create_ts))) = @metadata_scan_function_epoch from metadata_scan('table_func_metadata_scan.t', '*') g;
+➤ min(unix_timestamp(ts_to_time(create_ts))) = @metadata_scan_function_epoch[-7,1,0]  𝄀
+1
+select min(unix_timestamp(cast(create_ts as timestamp(6)))) = @metadata_scan_cast_epoch from metadata_scan('table_func_metadata_scan.t', '*') g;
+➤ min(unix_timestamp(cast(create_ts as timestamp(6)))) = @metadata_scan_cast_epoch[-7,1,0]  𝄀
+1
+set time_zone = @metadata_scan_saved_time_zone;
 select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g;
 ➤ count(*)[-5,64,0]  𝄀
 5

--- a/test/distributed/cases/function/table_func_metadata_scan.sql
+++ b/test/distributed/cases/function/table_func_metadata_scan.sql
@@ -25,10 +25,23 @@ select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cre
 select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where create_ts > 0;
 select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where create_ts > 9.9;
 select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cast(create_ts as float) > 9.9;
-select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cast(create_ts as TIMESTAMP) <= NOW();
-select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts) <= NOW();
-select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts, 2) <= NOW();
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where cast(create_ts as TIMESTAMP) = ts_to_time(create_ts, 0);
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts) = cast(create_ts as TIMESTAMP(6));
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts, 2) = cast(create_ts as TIMESTAMP(2));
 select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(1) <= NOW();
+select count(*) from metadata_scan("table_func_metadata_scan.t", "*")g where ts_to_time(create_ts, null) is null;
+
+-- TS contains an absolute HLC physical instant. Changing the session time zone
+-- must not change the epoch value produced by either conversion entry point.
+set @metadata_scan_saved_time_zone = @@time_zone;
+set time_zone = '+08:00';
+set @metadata_scan_function_epoch = (select min(unix_timestamp(ts_to_time(create_ts))) from metadata_scan('table_func_metadata_scan.t', '*') g);
+set @metadata_scan_cast_epoch = (select min(unix_timestamp(cast(create_ts as timestamp(6)))) from metadata_scan('table_func_metadata_scan.t', '*') g);
+set time_zone = '-05:00';
+select min(unix_timestamp(ts_to_time(create_ts))) = @metadata_scan_function_epoch from metadata_scan('table_func_metadata_scan.t', '*') g;
+select min(unix_timestamp(cast(create_ts as timestamp(6)))) = @metadata_scan_cast_epoch from metadata_scan('table_func_metadata_scan.t', '*') g;
+set time_zone = @metadata_scan_saved_time_zone;
+
 select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'f') g;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27637

## What this PR does / why we need it:

A transaction TS physical component is Unix nanoseconds for an absolute HLC instant. The previous `ts_to_time` and `CAST(TS AS TIMESTAMP)` paths formatted that instant as a UTC wall-clock string and reparsed it in the session time zone, shifting the underlying instant by the zone offset and allocating/parsing a string for every row.

This PR converts the HLC physical component directly for both public conversion paths, ignores the non-SQL logical component, validates the original int64 precision before narrowing, and closes NULL handling. Existing TS-to-NOW coverage is retained. The metadata_scan BVT adds CAST/function equivalence and epoch invariance across +08:00 and -05:00 without new fixtures, data loads, sleeps, or cluster initialization.

## Validation

- owning package full UT: `mo-cgo-test ./pkg/sql/plan/function -count=1 -timeout=20m` — PASS, 12.285s
- focused UT after rebase to current main — PASS
- `go list`, `go build`, and `go vet` for `./pkg/sql/plan/function` — PASS
- real candidate service on `10.222.1.55`: metadata_scan executed the added function, CAST, NULL, and cross-time-zone epoch checks without unexpected errors
- benchmark: direct conversion 5.44-5.46 ns/op, 0 B/op, 0 allocs/op; legacy string round trip 181.9-185.9 ns/op, 32 B/op, 1 alloc/op