### PR TITLE
fix(protocol): order sorted membership before abort metadata

### DIFF
--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -45,8 +45,8 @@ const (
 	MORPCVersion7      int64 = 7  // structured CHECK constraint metadata and enforcement
 	MORPCVersion8      int64 = 8  // versioned exact runtime-filter key contract
 	MORPCVersion9      int64 = 9  // AUTO_INCREMENT epoch-fenced commit
-	MORPCVersion10     int64 = 10 // persisted appendable-object abort metadata
-	MORPCVersion11     int64 = 11 // bounded Sorted64 membership-filter wire format
+	MORPCVersion10     int64 = 10 // bounded Sorted64 membership-filter wire format
+	MORPCVersion11     int64 = 11 // persisted appendable-object abort metadata
 	MORPCVersion12     int64 = 12 // prepared-parameter provenance in remote process metadata and aggregate trailers
 	MORPCVersion13     int64 = 13 // lossless v2 prefix-index metadata
 	MORPCVersion14     int64 = 14 // utf8mb4 text MIN/MAX collation semantics

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -177,7 +177,7 @@ func localProtocolEnablesSortedMembershipFilter(sid string) bool {
 		return false
 	}
 	version, ok := value.(int64)
-	return ok && version >= defines.MORPCVersion11
+	return ok && version >= defines.MORPCVersion10
 }
 
 func (builder *QueryBuilder) exactRuntimeFilterPlanEncoding(

--- a/pkg/sql/plan/runtime_filter_test.go
+++ b/pkg/sql/plan/runtime_filter_test.go
@@ -834,13 +834,13 @@ func TestSortedMembershipFilterProtocolGate(t *testing.T) {
 	})
 
 	rt.SetGlobalVariables(
-		moruntime.MOProtocolVersion, defines.MORPCVersion10)
+		moruntime.MOProtocolVersion, defines.MORPCVersion9)
 	require.False(t, localProtocolEnablesSortedMembershipFilter(sid))
 	rt.SetGlobalVariables(
-		moruntime.MOProtocolVersion, defines.MORPCVersion11)
+		moruntime.MOProtocolVersion, defines.MORPCVersion10)
 	require.True(t, localProtocolEnablesSortedMembershipFilter(sid))
 	rt.SetGlobalVariables(
-		moruntime.MOProtocolVersion, defines.MORPCVersion10)
+		moruntime.MOProtocolVersion, defines.MORPCVersion9)
 	require.False(t, localProtocolEnablesSortedMembershipFilter(sid))
 }
 

--- a/pkg/vm/engine/tae/blockio/read_test.go
+++ b/pkg/vm/engine/tae/blockio/read_test.go
@@ -856,7 +856,7 @@ func TestBlockDataReadBackupCombinesAbortAndTombstoneMasks(t *testing.T) {
 		aborts   []bool
 	}{
 		{
-			name:     "v10-abort-column",
+			name:     "v11-abort-column",
 			seqnums:  []uint16{0, objectio.SEQNUM_COMMITTS, objectio.SEQNUM_ABORT},
 			commitTS: []types.TS{types.BuildTS(1, 0), types.BuildTS(1, 0), types.BuildTS(1, 0), types.BuildTS(1, 0)},
 			aborts:   []bool{false, true, false, false},

--- a/pkg/vm/engine/tae/db/dbutils/runtime.go
+++ b/pkg/vm/engine/tae/db/dbutils/runtime.go
@@ -226,7 +226,7 @@ func (r *Runtime) SID() string {
 // PersistedAObjectAbortSupported reports whether every reader in the current
 // rollout understands appendable objects with the persisted abort column.
 // Deployment keeps MOProtocolVersion at the oldest live service during a
-// rolling upgrade, so writers must retain the legacy layout until version 10 is
+// rolling upgrade, so writers must retain the legacy layout until version 11 is
 // active.
 func (r *Runtime) PersistedAObjectAbortSupported() bool {
 	serviceRuntime := runtime.ServiceRuntime(r.SID())
@@ -238,7 +238,7 @@ func (r *Runtime) PersistedAObjectAbortSupported() bool {
 		return false
 	}
 	version, ok := value.(int64)
-	return ok && version >= defines.MORPCVersion10
+	return ok && version >= defines.MORPCVersion11
 }
 
 func (r *Runtime) PoolUsageReport() {

--- a/pkg/vm/engine/tae/tables/functions_test.go
+++ b/pkg/vm/engine/tae/tables/functions_test.go
@@ -78,7 +78,7 @@ func TestPersistedAppendableDedupSkipsAbortedRow(t *testing.T) {
 		aborted  bool
 	}{
 		{
-			name:     "v10-abort-column",
+			name:     "v11-abort-column",
 			commitTS: types.BuildTS(5, 0),
 			aborted:  true,
 		},

--- a/pkg/vm/engine/tae/tables/object_test.go
+++ b/pkg/vm/engine/tae/tables/object_test.go
@@ -205,7 +205,7 @@ func TestMemoryNodeRollbackHoleVisibilityAndWriteLayout(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	rt := moruntime.ServiceRuntime("")
 	originalVersion, hadVersion := rt.GetGlobalVariables(moruntime.MOProtocolVersion)
-	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion10)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion11)
 	defer func() {
 		if hadVersion {
 			rt.SetGlobalVariables(moruntime.MOProtocolVersion, originalVersion)
@@ -273,7 +273,7 @@ func TestMemoryNodeRollbackHoleVisibilityAndWriteLayout(t *testing.T) {
 
 	// During a rolling upgrade, the TN keeps the legacy layout and marks abort
 	// holes uncommitted so old readers hide them without shifting RowID offsets.
-	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion9)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion10)
 	legacyBatches := make(map[uint32]*containers.BatchWithVersion)
 	err = mnode.getDataWindowOnWriteSchema(
 		context.Background(),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #26720

## What this PR does / why we need it:

  Reorders the cumulative protocol capabilities so the bounded Sorted64 membership-filter wire format is introduced
  before persisted appendable-object abort metadata.

  - Assigns MORPCVersion10 to the Sorted64 membership-filter format.
  - Assigns MORPCVersion11 to persisted appendable-object abort metadata.
  - Enables Sorted64 membership filters at protocol version 10.
  - Keeps appendable-object writers on the legacy commitTS layout at version 10 and enables the abort-column layout
    only at version 11.

  - Updates rollout-boundary and persisted-layout tests to match the corrected ordering.
  - Leaves MORPCLatestVersion and all version 12+ capabilities unchanged.

  This allows the 4.2 backport to advertise Sorted64 support without also claiming support for the cumulative abort-
  column storage contract.