### PR TITLE
fix: preserve NULL prepared BIT values

### DIFF
--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -8163,7 +8163,7 @@ func strToBit(
 	for i := 0; i < length; i++ {
 		v, null := from.GetStrValue(uint64(i))
 		if null {
-			if err := to.AppendBytes(nil, true); err != nil {
+			if err := to.Append(0, true); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -214,6 +214,22 @@ func TestPreparedTypedTextToBit(t *testing.T) {
 	})
 	succeed, info := mixed.Run()
 	require.True(t, succeed, info)
+
+	for _, width := range []int32{1, 8, 64} {
+		t.Run(fmt.Sprintf("null bit%d", width), func(t *testing.T) {
+			bitType := types.New(types.T_bit, width, 0)
+			tcc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{"", "1"}, []bool{true, false}),
+					NewFunctionTestInput(bitType, []uint64{}, nil),
+				},
+				NewFunctionTestResult(bitType, false, []uint64{0, 1}, []bool{true, false}), NewCast)
+			tcc.parameters[0].SetPrepareParamKind(vector.PrepareParamInteger)
+			succeed, info := tcc.Run()
+			require.True(t, succeed, info)
+		})
+	}
+
 	run("negative string rejected", vector.PrepareParamNone,
 		[]string{"-6109877384019645241"}, bit64, nil, true)
 	run("narrow integer rejected", vector.PrepareParamInteger, []string{"-1"}, bit63, nil, true)

--- a/pkg/tests/issues/issue_27635_test.go
+++ b/pkg/tests/issues/issue_27635_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/embed"
+)
+
+// TestIssue27635PreparedBitNull exercises the server-prepared path used by
+// Connector/J. database/sql prepares once and go-sql-driver/mysql sends every
+// execution through COM_STMT_EXECUTE, including its NULL bitmap and cached
+// parameter-type metadata.
+func TestIssue27635PreparedBitNull(t *testing.T) {
+	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		db, err := sql.Open("mysql", fmt.Sprintf(
+			"dump:111@tcp(127.0.0.1:%d)/?interpolateParams=false", port))
+		require.NoError(t, err)
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		defer db.Close()
+
+		const dbName = "issue_27635_prepared_bit_null"
+		execSQLMaybe(t, ctx, db, "drop database if exists "+dbName)
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			execSQLMaybe(t, cleanupCtx, db, "drop database if exists "+dbName)
+		}()
+		execSQLRequire(t, ctx, db, "create database "+dbName)
+		execSQLRequire(t, ctx, db,
+			"create table "+dbName+".t(id int primary key, b1 bit(1), b8 bit(8), b64 bit(64))")
+
+		stmt, err := db.PrepareContext(ctx,
+			"insert into "+dbName+".t(id, b1, b8, b64) values (?, ?, ?, ?)")
+		require.NoError(t, err)
+		defer stmt.Close()
+
+		// First execution: all BIT parameters are NULL in COM_STMT_EXECUTE's bitmap.
+		_, err = stmt.ExecContext(ctx, 1, nil, nil, nil)
+		require.NoError(t, err)
+		// Rebind all widths to non-NULL values on the same server statement.
+		_, err = stmt.ExecContext(ctx, 2, true, int64(0xa5), uint64(1)<<63)
+		require.NoError(t, err)
+		// Reuse the statement once more; NULL must not retain the preceding values.
+		_, err = stmt.ExecContext(ctx, 3, nil, nil, nil)
+		require.NoError(t, err)
+
+		rows, err := db.QueryContext(ctx,
+			"select id, b1 is null, b8 is null, b64 is null, hex(b1), hex(b8), hex(b64) "+
+				"from "+dbName+".t order by id")
+		require.NoError(t, err)
+		defer rows.Close()
+
+		type expectedRow struct {
+			id               int
+			b1Null, b8Null   int
+			b64Null          int
+			h1, h8, h64      string
+			hexValuesAreNull bool
+		}
+		expected := []expectedRow{
+			{id: 1, b1Null: 1, b8Null: 1, b64Null: 1, hexValuesAreNull: true},
+			{id: 2, h1: "1", h8: "A5", h64: "8000000000000000"},
+			{id: 3, b1Null: 1, b8Null: 1, b64Null: 1, hexValuesAreNull: true},
+		}
+		for _, want := range expected {
+			require.True(t, rows.Next())
+			var id, b1Null, b8Null, b64Null int
+			var h1, h8, h64 sql.NullString
+			require.NoError(t, rows.Scan(&id, &b1Null, &b8Null, &b64Null, &h1, &h8, &h64))
+			require.Equal(t, want.id, id)
+			require.Equal(t, want.b1Null, b1Null)
+			require.Equal(t, want.b8Null, b8Null)
+			require.Equal(t, want.b64Null, b64Null)
+			if want.hexValuesAreNull {
+				require.False(t, h1.Valid)
+				require.False(t, h8.Valid)
+				require.False(t, h64.Valid)
+			} else {
+				require.Equal(t, want.h1, h1.String)
+				require.Equal(t, want.h8, h8.String)
+				require.Equal(t, want.h64, h64.String)
+			}
+		}
+		require.False(t, rows.Next())
+		require.NoError(t, rows.Err())
+	})
+}

--- a/test/distributed/cases/dtype/bit.result
+++ b/test/distributed/cases/dtype/bit.result
@@ -235,3 +235,20 @@ select * from t1;
 5  ¦  5  𝄀
 1023  ¦  1023  𝄀
 6  ¦  6
+DROP TABLE IF EXISTS prepared_bit_null;
+CREATE TABLE prepared_bit_null (id INT PRIMARY KEY, b1 BIT(1), b8 BIT(8), b64 BIT(64));
+PREPARE prepared_bit_insert FROM 'INSERT INTO prepared_bit_null VALUES (?, ?, ?, ?)';
+SET @id = 1, @b1 = NULL, @b8 = NULL, @b64 = NULL;
+EXECUTE prepared_bit_insert USING @id, @b1, @b8, @b64;
+SET @id = 2, @b1 = 1, @b8 = 165, @b64 = 9223372036854775808;
+EXECUTE prepared_bit_insert USING @id, @b1, @b8, @b64;
+SET @id = 3, @b1 = NULL, @b8 = NULL, @b64 = NULL;
+EXECUTE prepared_bit_insert USING @id, @b1, @b8, @b64;
+SELECT id, b1 IS NULL, b8 IS NULL, b64 IS NULL, HEX(b1), HEX(b8), HEX(b64)
+FROM prepared_bit_null ORDER BY id;
+➤ id[4,32,0]  ¦  b1 is null[-7,1,0]  ¦  b8 is null[-7,1,0]  ¦  b64 is null[-7,1,0]  ¦  HEX(b1)[12,65535,0]  ¦  HEX(b8)[12,65535,0]  ¦  HEX(b64)[12,65535,0]  𝄀
+1  ¦  1  ¦  1  ¦  1  ¦  null  ¦  null  ¦  null  𝄀
+2  ¦  0  ¦  0  ¦  0  ¦  1  ¦  A5  ¦  8000000000000000  𝄀
+3  ¦  1  ¦  1  ¦  1  ¦  null  ¦  null  ¦  null
+DEALLOCATE PREPARE prepared_bit_insert;
+DROP TABLE prepared_bit_null;

--- a/test/distributed/cases/dtype/bit.sql
+++ b/test/distributed/cases/dtype/bit.sql
@@ -95,3 +95,18 @@ select * from t1;
 ALTER TABLE t1 CHANGE a new_a int;
 show create table t1;
 select * from t1;
+
+-- prepared parameters preserve NULL across first execution and statement reuse
+DROP TABLE IF EXISTS prepared_bit_null;
+CREATE TABLE prepared_bit_null (id INT PRIMARY KEY, b1 BIT(1), b8 BIT(8), b64 BIT(64));
+PREPARE prepared_bit_insert FROM 'INSERT INTO prepared_bit_null VALUES (?, ?, ?, ?)';
+SET @id = 1, @b1 = NULL, @b8 = NULL, @b64 = NULL;
+EXECUTE prepared_bit_insert USING @id, @b1, @b8, @b64;
+SET @id = 2, @b1 = 1, @b8 = 165, @b64 = 9223372036854775808;
+EXECUTE prepared_bit_insert USING @id, @b1, @b8, @b64;
+SET @id = 3, @b1 = NULL, @b8 = NULL, @b64 = NULL;
+EXECUTE prepared_bit_insert USING @id, @b1, @b8, @b64;
+SELECT id, b1 IS NULL, b8 IS NULL, b64 IS NULL, HEX(b1), HEX(b8), HEX(b64)
+FROM prepared_bit_null ORDER BY id;
+DEALLOCATE PREPARE prepared_bit_insert;
+DROP TABLE prepared_bit_null;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27635

## What this PR does / why we need it:

`strToBit` used the variable-length `AppendBytes` API when its source value was NULL, even though the cast result is a fixed-width `uint64` vector. That failed to publish the NULL bit and left the result as zero or a previously materialized value.

Use the fixed-width `Append(0, true)` API so nullable BIT casts preserve SQL NULL. Add focused coverage for BIT(1), BIT(8), and BIT(64), plus:

- a SQL prepared-statement BVT covering first-execution NULL, a non-NULL control, and value-to-NULL statement reuse;
- an embedded-cluster integration test using a real server-prepared client connection (`interpolateParams=false`) so all three executions traverse COM_STMT_EXECUTE, its NULL bitmap, and reused statement metadata; persisted rows are checked independently with `IS NULL` and `HEX()`.

Validation:

- `mo-cgo-test -run ^TestPreparedTypedTextToBit$ ./pkg/sql/plan/function`
- `mo-cgo-test -count=1 -timeout=300s ./pkg/sql/plan/function`
- `mo-cgo-test -run ^TestIssue27635PreparedBitNull$ ./pkg/tests/issues` (passed, 22.638s)
- `go vet -mod=readonly ./pkg/tests/issues ./pkg/sql/plan/function`
- `test/distributed/cases/dtype/bit.sql` via mo-tester normal comparison mode twice on the same clean instance: 70/70 passed each run
