### PR TITLE
perf: linearize DISTINCT aggregate preflight deduplication

### DIFF
--- a/pkg/common/arenaskl/skl.go
+++ b/pkg/common/arenaskl/skl.go
@@ -122,6 +122,20 @@ func (ins *Inserter) Add(list *Skiplist, key, value []byte) error {
 	return list.addInternal(key, value, ins, nil)
 }
 
+// AddWithPlan adds a key with a precomputed physical node plan while retaining
+// this inserter's splice cache. It is useful for a caller publishing keys in
+// sorted order after reserving their exact arena footprint.
+func (ins *Inserter) AddWithPlan(
+	list *Skiplist,
+	key, value []byte,
+	plan AddPlan,
+) error {
+	if plan.height < 1 || plan.height > maxHeight {
+		return moerr.NewInternalErrorNoCtx("invalid skiplist add plan")
+	}
+	return list.addInternal(key, value, ins, &plan)
+}
+
 var (
 	probabilities [maxHeight]uint32
 )
@@ -437,6 +451,13 @@ func (s *Skiplist) findSplice(key []byte, ins *Inserter) (found bool) {
 				// Key lies after splice.
 				level = int(listHeight)
 				break
+			}
+			if level == 0 && spl.next != s.tail &&
+				s.cmp(spl.next.getKeyBytes(s.arena), key) == 0 {
+				// The cached base-level splice brackets key, but the regular
+				// descent below starts at level-1. Check equality here so a
+				// key matching the cached successor is not inserted twice.
+				return true
 			}
 			// The splice brackets the key!
 			prev = spl.prev

--- a/pkg/common/arenaskl/skl_test.go
+++ b/pkg/common/arenaskl/skl_test.go
@@ -122,6 +122,26 @@ func makeInserterAdd(s *Skiplist) func(key []byte, value []byte) error {
 	}
 }
 
+func TestInserterAddWithPlanDeduplicatesSortedOverlap(t *testing.T) {
+	list := NewSkiplist(newArena(64<<10), bytes.Compare)
+	var inserter Inserter
+	require.Error(t, inserter.AddWithPlan(list, []byte("invalid"), nil, AddPlan{}))
+	for i := 0; i < 100; i += 2 {
+		key := makeIntKey(i)
+		require.NoError(t, list.AddWithPlan(key, nil, MakeAddPlan(key)))
+	}
+	for i := 0; i < 100; i++ {
+		key := makeIntKey(i)
+		err := inserter.AddWithPlan(list, key, nil, MakeAddPlan(key))
+		if i%2 == 0 {
+			require.ErrorIs(t, err, ErrRecordExists, "key %d", i)
+		} else {
+			require.NoError(t, err, "key %d", i)
+		}
+	}
+	require.Equal(t, 100, length(list))
+}
+
 // length iterates over skiplist to give exact size.
 func length(s *Skiplist) int {
 	count := 0

--- a/pkg/sql/colexec/aggexec/aggexec_bench_test.go
+++ b/pkg/sql/colexec/aggexec/aggexec_bench_test.go
@@ -416,6 +416,128 @@ func BenchmarkCountDistinctSavedArguments(b *testing.B) {
 	}
 }
 
+func BenchmarkArgumentPreflightCardinality(b *testing.B) {
+	type benchmarkCase struct {
+		name        string
+		distinct    bool
+		cardinality int
+		varlen      bool
+	}
+	cases := make([]benchmarkCase, 0, 12)
+	for _, varlen := range []bool{false, true} {
+		kind := "fixed"
+		if varlen {
+			kind = "varlen-1KiB"
+		}
+		for _, cardinality := range []int{
+			1, 2, distinctArgumentLinearLimit,
+			distinctArgumentLinearLimit + 1, hashmap.UnitLimit,
+		} {
+			cases = append(cases, benchmarkCase{
+				name:        "distinct/" + kind + "/cardinality-" + strconv.Itoa(cardinality),
+				distinct:    true,
+				cardinality: cardinality,
+				varlen:      varlen,
+			})
+		}
+		cases = append(cases, benchmarkCase{
+			name:        "non-distinct/" + kind,
+			cardinality: hashmap.UnitLimit,
+			varlen:      varlen,
+		})
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			mp := mpool.MustNewZero()
+			typ := types.T_int64.ToType()
+			if tc.varlen {
+				typ = types.T_varchar.ToType()
+			}
+			input := vector.NewVec(typ)
+			if tc.varlen {
+				prefix := strings.Repeat("x", 1024)
+				for row := 0; row < hashmap.UnitLimit; row++ {
+					value := []byte(prefix + strconv.Itoa(row%tc.cardinality))
+					if err := vector.AppendBytes(input, value, false, mp); err != nil {
+						b.Fatal(err)
+					}
+				}
+			} else {
+				for row := 0; row < hashmap.UnitLimit; row++ {
+					if err := vector.AppendFixed(
+						input, int64(row%tc.cardinality), false, mp); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+			groups := make([]uint64, hashmap.UnitLimit)
+			for row := range groups {
+				groups[row] = 1
+			}
+
+			registry, err := mpool.NewAllocationAccountRegistry(1, 512)
+			if err != nil {
+				b.Fatal(err)
+			}
+			account, err := registry.Open(32 << 20)
+			if err != nil {
+				b.Fatal(err)
+			}
+			allocation, err := NewAllocationAccount(
+				account, mpool.AllocationOwnerGroup, AllocationAccountSites{
+					VectorData: 1, VectorArea: 2, VectorNulls: 3,
+					VectorGrouping: 4, ArgumentCount: 5, ArgumentArena: 6,
+				})
+			if err != nil {
+				b.Fatal(err)
+			}
+			info := aggInfo{
+				argTypes:   []types.Type{typ},
+				saveArg:    true,
+				isDistinct: tc.distinct,
+			}
+			state := aggState{}
+			if err = state.initWithAllocation(
+				mp, 1, 1, &info, false, allocation); err != nil {
+				b.Fatal(err)
+			}
+			exec := aggExec{
+				mp:         mp,
+				aggInfo:    info,
+				chunkSize:  AggBatchSize,
+				state:      []aggState{state},
+				allocation: allocation,
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err = exec.preflightBatchFillArgs(
+					0, groups, []*vector.Vector{input}, tc.distinct); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+
+			exec.state[0].free(mp)
+			exec.state = nil
+			exec.allocation = nil
+			input.Free(mp)
+			if account.Snapshot().Used != 0 {
+				b.Fatalf("account retains %d bytes", account.Snapshot().Used)
+			}
+			account.Seal()
+			if _, err = registry.Finalize(account); err != nil {
+				b.Fatal(err)
+			}
+			if mp.CurrNB() != 0 {
+				b.Fatalf("memory leak detected: %d bytes", mp.CurrNB())
+			}
+		})
+	}
+}
+
 func BenchmarkSumDecimal64FastCardinality(b *testing.B) {
 	mp := mpool.MustNewZero()
 	defer func() {

--- a/pkg/sql/colexec/aggexec/aggexec_bench_test.go
+++ b/pkg/sql/colexec/aggexec/aggexec_bench_test.go
@@ -340,6 +340,82 @@ func BenchmarkAggExecPaths(b *testing.B) {
 	})
 }
 
+func BenchmarkCountDistinctSavedArguments(b *testing.B) {
+	const (
+		rows   = hashmap.UnitLimit * 256
+		groups = 1
+	)
+
+	mp := mpool.MustNewZero()
+	input := vector.NewVec(types.T_int64.ToType())
+	for i := 0; i < rows; i++ {
+		if err := vector.AppendFixed(input, int64(i), false, mp); err != nil {
+			b.Fatal(err)
+		}
+	}
+	defer input.Free(mp)
+	vectors := []*vector.Vector{input}
+	groupIDs := make([]uint64, hashmap.UnitLimit)
+	for i := range groupIDs {
+		groupIDs[i] = uint64(i%groups + 1)
+	}
+
+	registry, err := mpool.NewAllocationAccountRegistry(1, 512)
+	if err != nil {
+		b.Fatal(err)
+	}
+	account, err := registry.Open(128 << 20)
+	if err != nil {
+		b.Fatal(err)
+	}
+	allocation, err := NewAllocationAccount(
+		account, mpool.AllocationOwnerGroup, AllocationAccountSites{
+			VectorData: 1, VectorArea: 2, VectorNulls: 3,
+			VectorGrouping: 4, ArgumentCount: 5, ArgumentArena: 6,
+		})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(rows * 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		agg := newCountColumnExec(
+			mp, AggIdOfCountColumn, true, []types.Type{types.T_int64.ToType()})
+		owner := AggFuncExec(agg).(AllocationAccountOwner)
+		if err = owner.SetAllocationAccount(allocation); err != nil {
+			b.Fatal(err)
+		}
+		if err = agg.GroupGrow(groups); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		for offset := 0; offset < rows; offset += hashmap.UnitLimit {
+			if err = agg.(BatchCapacityPreflight).PreflightBatchFill(
+				offset, groupIDs, vectors); err != nil {
+				b.Fatal(err)
+			}
+			if err = agg.BatchFill(offset, groupIDs, vectors); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+		agg.Free()
+		if err = owner.ClearAllocationAccount(allocation); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if account.Snapshot().Used != 0 {
+		b.Fatalf("account retains %d bytes", account.Snapshot().Used)
+	}
+	account.Seal()
+	if _, err = registry.Finalize(account); err != nil {
+		b.Fatal(err)
+	}
+}
+
 func BenchmarkSumDecimal64FastCardinality(b *testing.B) {
 	mp := mpool.MustNewZero()
 	defer func() {

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -321,6 +321,64 @@ func preflightArgumentRowsEqual(
 }
 
 const distinctArgumentBatchSlots = hashmap.UnitLimit * 2
+const distinctArgumentLinearLimit = 8
+
+// distinctArgumentLinearBatch keeps the low-cardinality path hash-free. Most
+// duplicate-heavy batches find a representative after one or two exact
+// comparisons, avoiding both hashing large payloads and clearing the larger
+// open-addressing table below.
+type distinctArgumentLinearBatch struct {
+	rows  [distinctArgumentLinearLimit]uint16
+	count uint16
+}
+
+func (batch *distinctArgumentLinearBatch) seen(
+	groups []uint64,
+	vectors []*vector.Vector,
+	offset int,
+	row int,
+) (bool, error) {
+	// Cardinality one is the common duplicate-heavy case. Keep its control
+	// flow as short as the former scan over earlier rows: one group check and
+	// one exact comparison, without entering the representative loop.
+	if batch.count > 0 {
+		earlier := int(batch.rows[0])
+		if groups[earlier] == groups[row] {
+			equal, err := preflightArgumentRowsEqual(
+				vectors, offset+earlier, offset+row)
+			if err != nil {
+				return false, err
+			}
+			if equal {
+				return true, nil
+			}
+		}
+	}
+	for i := uint16(1); i < batch.count; i++ {
+		earlier := int(batch.rows[i])
+		if groups[earlier] != groups[row] {
+			continue
+		}
+		equal, err := preflightArgumentRowsEqual(
+			vectors, offset+earlier, offset+row)
+		if err != nil {
+			return false, err
+		}
+		if equal {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (batch *distinctArgumentLinearBatch) insertUnique(row int) bool {
+	if batch.count == distinctArgumentLinearLimit {
+		return false
+	}
+	batch.rows[batch.count] = uint16(row)
+	batch.count++
+	return true
+}
 
 // distinctArgumentBatch suppresses duplicate candidates inside one immutable
 // preflight work unit. The table is deliberately fixed-size: UnitLimit bounds
@@ -496,15 +554,75 @@ func (ae *aggExec) preflightBatchFillArgs(
 	if err := validatePreflightVectors(vectors, offset, len(groups)); err != nil {
 		return err
 	}
+	if distinct {
+		return ae.preflightDistinctBatchFillArgs(offset, groups, vectors)
+	}
+	if len(vectors) == 1 {
+		return ae.preflightNonDistinctSingleBatchFillArg(
+			offset, groups, vectors)
+	}
+	return ae.preflightNonDistinctBatchFillArgs(offset, groups, vectors)
+}
+
+func (ae *aggExec) preflightNonDistinctSingleBatchFillArg(
+	offset int,
+	groups []uint64,
+	vectors []*vector.Vector,
+) error {
+	vec := vectors[0]
 	var needs [hashmap.UnitLimit]argumentChunkCapacity
 	needCount := 0
 	var progress [hashmap.UnitLimit]argumentTargetProgress
 	progressCount := 0
-	var distinctBatch distinctArgumentBatch
-	header := kAggArgPrefixSz
-	if !distinct {
-		header += kAggArgOrdinalSz
+	const header = kAggArgPrefixSz + kAggArgOrdinalSz
+	for i, group := range groups {
+		if group == GroupNotMatched {
+			continue
+		}
+		x, y, state, err := ae.validatePreflightTarget(group)
+		if err != nil {
+			return err
+		}
+		logicalRow := offset + i
+		row, err := preflightPhysicalRow(vec, logicalRow)
+		if err != nil {
+			return err
+		}
+		if vec.IsNull(uint64(row)) {
+			continue
+		}
+		payload := len(vec.GetRawBytesAt(row))
+		if payload > math.MaxInt-header {
+			return mpool.ErrAllocationAllocatorLimit
+		}
+		ordinal, err := nextArgumentOrdinal(
+			&progress, &progressCount, x, y, state.argCnt[y])
+		if err != nil {
+			return err
+		}
+		key, err := state.preparePreflightArgumentKey(
+			ae.mp, y, vectors, logicalRow, payload, false, ordinal)
+		if err != nil {
+			return err
+		}
+		if err = addArgumentChunkCapacity(
+			&needs, &needCount, x, key); err != nil {
+			return err
+		}
 	}
+	return ae.applyArgumentChunkCapacity(&needs, needCount)
+}
+
+func (ae *aggExec) preflightNonDistinctBatchFillArgs(
+	offset int,
+	groups []uint64,
+	vectors []*vector.Vector,
+) error {
+	var needs [hashmap.UnitLimit]argumentChunkCapacity
+	needCount := 0
+	var progress [hashmap.UnitLimit]argumentTargetProgress
+	progressCount := 0
+	const header = kAggArgPrefixSz + kAggArgOrdinalSz
 	for i, group := range groups {
 		if group == GroupNotMatched {
 			continue
@@ -515,15 +633,93 @@ func (ae *aggExec) preflightBatchFillArgs(
 		}
 		logicalRow := offset + i
 		payload := 0
-		if len(vectors) == 1 {
-			row, err := preflightPhysicalRow(vectors[0], logicalRow)
+		for _, vec := range vectors {
+			row, err := preflightPhysicalRow(vec, logicalRow)
 			if err != nil {
 				return err
 			}
-			if vectors[0].IsNull(uint64(row)) {
+			if vec.IsNull(uint64(row)) {
+				payload = -1
+				break
+			}
+			raw := vec.GetRawBytesAt(row)
+			if len(raw) > math.MaxInt-payload-4 {
+				return mpool.ErrAllocationAllocatorLimit
+			}
+			payload += 4 + len(raw)
+		}
+		if payload < 0 {
+			continue
+		}
+		if payload > math.MaxInt-header {
+			return mpool.ErrAllocationAllocatorLimit
+		}
+		ordinal, err := nextArgumentOrdinal(
+			&progress, &progressCount, x, y, state.argCnt[y])
+		if err != nil {
+			return err
+		}
+		key, err := state.preparePreflightArgumentKey(
+			ae.mp, y, vectors, logicalRow, payload, false, ordinal)
+		if err != nil {
+			return err
+		}
+		if err := addArgumentChunkCapacity(
+			&needs, &needCount, x, key); err != nil {
+			return err
+		}
+	}
+	return ae.applyArgumentChunkCapacity(&needs, needCount)
+}
+
+func (ae *aggExec) addDistinctArgumentCapacity(
+	x int,
+	y uint16,
+	state *aggState,
+	logicalRow int,
+	payload int,
+	vectors []*vector.Vector,
+	needs *[hashmap.UnitLimit]argumentChunkCapacity,
+	needCount *int,
+) error {
+	key, err := state.preparePreflightArgumentKey(
+		ae.mp, y, vectors, logicalRow, payload, true, 0)
+	if err != nil {
+		return err
+	}
+	if state.argSkl.Contains(key) {
+		return nil
+	}
+	return addArgumentChunkCapacity(needs, needCount, x, key)
+}
+
+func (ae *aggExec) preflightDistinctBatchFillArgs(
+	offset int,
+	groups []uint64,
+	vectors []*vector.Vector,
+) error {
+	var needs [hashmap.UnitLimit]argumentChunkCapacity
+	needCount := 0
+	var linear distinctArgumentLinearBatch
+	for i, group := range groups {
+		if group == GroupNotMatched {
+			continue
+		}
+		x, y, state, err := ae.validatePreflightTarget(group)
+		if err != nil {
+			return err
+		}
+		logicalRow := offset + i
+		payload := 0
+		physicalRow := 0
+		if len(vectors) == 1 {
+			physicalRow, err = preflightPhysicalRow(vectors[0], logicalRow)
+			if err != nil {
+				return err
+			}
+			if vectors[0].IsNull(uint64(physicalRow)) {
 				continue
 			}
-			payload = len(vectors[0].GetRawBytesAt(row))
 		} else {
 			for _, vec := range vectors {
 				row, err := preflightPhysicalRow(vec, logicalRow)
@@ -544,41 +740,119 @@ func (ae *aggExec) preflightBatchFillArgs(
 				continue
 			}
 		}
-		if payload > math.MaxInt-header {
-			return mpool.ErrAllocationAllocatorLimit
-		}
-		if distinct {
-			duplicate, err := distinctBatch.seenOrInsert(
-				groups, vectors, offset, i)
-			if err != nil {
-				return err
-			}
-			if duplicate {
-				continue
-			}
-		}
-		ordinal := uint32(0)
-		if !distinct {
-			ordinal, err = nextArgumentOrdinal(
-				&progress, &progressCount, x, y, state.argCnt[y])
-			if err != nil {
-				return err
-			}
-		}
-		key, err := state.preparePreflightArgumentKey(
-			ae.mp, y, vectors, logicalRow, payload, distinct, ordinal)
+		duplicate, err := linear.seen(groups, vectors, offset, i)
 		if err != nil {
 			return err
 		}
-		if distinct && state.argSkl.Contains(key) {
+		if duplicate {
 			continue
 		}
-		if err := addArgumentChunkCapacity(
-			&needs, &needCount, x, key); err != nil {
+		if !linear.insertUnique(i) {
+			return ae.preflightDistinctBatchFillArgsHashed(
+				offset, groups, vectors, i, &linear, &needs, &needCount)
+		}
+		if len(vectors) == 1 {
+			// Duplicate rows need neither a retained key nor its payload size.
+			// Delay the raw-value access until exact admission accepts this row.
+			payload = len(vectors[0].GetRawBytesAt(physicalRow))
+		}
+		if payload > math.MaxInt-kAggArgPrefixSz {
+			return mpool.ErrAllocationAllocatorLimit
+		}
+		if err = ae.addDistinctArgumentCapacity(
+			x, y, state, logicalRow, payload, vectors, &needs, &needCount); err != nil {
 			return err
 		}
 	}
 	return ae.applyArgumentChunkCapacity(&needs, needCount)
+}
+
+// preflightDistinctBatchFillArgsHashed owns the large table in a separate
+// frame and is called only after the exact representative set overflows. This
+// mirrors radix aggregation admission: hash work is paid only for a batch with
+// enough distinct tuples to amortize it.
+func (ae *aggExec) preflightDistinctBatchFillArgsHashed(
+	offset int,
+	groups []uint64,
+	vectors []*vector.Vector,
+	start int,
+	linear *distinctArgumentLinearBatch,
+	needs *[hashmap.UnitLimit]argumentChunkCapacity,
+	needCount *int,
+) error {
+	if start < 0 || start >= len(groups) || linear == nil {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	var hashed distinctArgumentBatch
+	for i := uint16(0); i < linear.count; i++ {
+		duplicate, err := hashed.seenOrInsert(
+			groups, vectors, offset, int(linear.rows[i]))
+		if err != nil {
+			return err
+		}
+		if duplicate {
+			return mpool.ErrAllocationAccountInvariant
+		}
+	}
+	for i := start; i < len(groups); i++ {
+		group := groups[i]
+		if group == GroupNotMatched {
+			continue
+		}
+		x, y, state, err := ae.validatePreflightTarget(group)
+		if err != nil {
+			return err
+		}
+		logicalRow := offset + i
+		payload := 0
+		physicalRow := 0
+		if len(vectors) == 1 {
+			physicalRow, err = preflightPhysicalRow(vectors[0], logicalRow)
+			if err != nil {
+				return err
+			}
+			if vectors[0].IsNull(uint64(physicalRow)) {
+				continue
+			}
+		} else {
+			for _, vec := range vectors {
+				row, err := preflightPhysicalRow(vec, logicalRow)
+				if err != nil {
+					return err
+				}
+				if vec.IsNull(uint64(row)) {
+					payload = -1
+					break
+				}
+				raw := vec.GetRawBytesAt(row)
+				if len(raw) > math.MaxInt-payload-4 {
+					return mpool.ErrAllocationAllocatorLimit
+				}
+				payload += 4 + len(raw)
+			}
+			if payload < 0 {
+				continue
+			}
+		}
+		duplicate, err := hashed.seenOrInsert(groups, vectors, offset, i)
+		if err != nil {
+			return err
+		}
+		if duplicate {
+			continue
+		}
+		if len(vectors) == 1 {
+			payload = len(vectors[0].GetRawBytesAt(physicalRow))
+		}
+		if payload > math.MaxInt-kAggArgPrefixSz {
+			return mpool.ErrAllocationAllocatorLimit
+		}
+		if err = ae.addDistinctArgumentCapacity(
+			x, y, state, logicalRow, payload, vectors, needs, needCount); err != nil {
+			return err
+		}
+	}
+	return ae.applyArgumentChunkCapacity(needs, *needCount)
 }
 
 func (ae *aggExec) preflightBatchMergeArgs(

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -20,8 +20,10 @@ import (
 	"math"
 	"slices"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/matrixorigin/matrixone/pkg/common/arenaskl"
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap/keycodec"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -318,14 +320,64 @@ func preflightArgumentRowsEqual(
 	return true, nil
 }
 
-func earlierDistinctArgumentRow(
+const distinctArgumentBatchSlots = hashmap.UnitLimit * 2
+
+// distinctArgumentBatch suppresses duplicate candidates inside one immutable
+// preflight work unit. The table is deliberately fixed-size: UnitLimit bounds
+// the input at 256 rows, so twice as many open-addressing slots keep the load
+// factor at or below 50% without row-frequency allocation.
+type distinctArgumentBatch struct {
+	rows   [distinctArgumentBatchSlots]uint16
+	hashes [distinctArgumentBatchSlots]uint64
+}
+
+func distinctArgumentRowHash(
+	group uint64,
+	vectors []*vector.Vector,
+	logicalRow int,
+) (uint64, error) {
+	// Start from the target group because DISTINCT is scoped to one aggregate
+	// group. Hash combination preserves column boundaries for multi-argument
+	// DISTINCT; full row comparison below remains the collision oracle.
+	hash := group * 0x9e3779b97f4a7c15
+	var zero [8]byte
+	for _, vec := range vectors {
+		row, err := preflightPhysicalRow(vec, logicalRow)
+		if err != nil {
+			return 0, err
+		}
+		value := vec.GetRawBytesAt(row)
+		if size, ok := canonicalDistinctArgumentSize(vec, row); ok {
+			value = zero[:size]
+		}
+		hash = keycodec.HashCombine(hash, xxhash.Sum64(value))
+	}
+	return hash, nil
+}
+
+func (batch *distinctArgumentBatch) seenOrInsert(
 	groups []uint64,
 	vectors []*vector.Vector,
 	offset int,
 	row int,
 ) (bool, error) {
-	for earlier := 0; earlier < row; earlier++ {
-		if groups[earlier] != groups[row] {
+	if batch == nil || row < 0 || row >= len(groups) || len(groups) > hashmap.UnitLimit {
+		return false, mpool.ErrAllocationAccountInvalid
+	}
+	hash, err := distinctArgumentRowHash(groups[row], vectors, offset+row)
+	if err != nil {
+		return false, err
+	}
+	const mask = distinctArgumentBatchSlots - 1
+	for slot := int(hash & uint64(mask)); ; slot = (slot + 1) & mask {
+		encodedRow := batch.rows[slot]
+		if encodedRow == 0 {
+			batch.rows[slot] = uint16(row + 1)
+			batch.hashes[slot] = hash
+			return false, nil
+		}
+		earlier := int(encodedRow - 1)
+		if batch.hashes[slot] != hash || groups[earlier] != groups[row] {
 			continue
 		}
 		equal, err := preflightArgumentRowsEqual(
@@ -337,7 +389,6 @@ func earlierDistinctArgumentRow(
 			return true, nil
 		}
 	}
-	return false, nil
 }
 
 func (ag *aggState) preparePreflightArgumentKey(
@@ -449,6 +500,7 @@ func (ae *aggExec) preflightBatchFillArgs(
 	needCount := 0
 	var progress [hashmap.UnitLimit]argumentTargetProgress
 	progressCount := 0
+	var distinctBatch distinctArgumentBatch
 	header := kAggArgPrefixSz
 	if !distinct {
 		header += kAggArgOrdinalSz
@@ -496,7 +548,7 @@ func (ae *aggExec) preflightBatchFillArgs(
 			return mpool.ErrAllocationAllocatorLimit
 		}
 		if distinct {
-			duplicate, err := earlierDistinctArgumentRow(
+			duplicate, err := distinctBatch.seenOrInsert(
 				groups, vectors, offset, i)
 			if err != nil {
 				return err

--- a/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
@@ -106,11 +106,21 @@ func TestCapacityPreflightPrimitiveBoundaries(t *testing.T) {
 	equal, err = preflightArgumentRowsEqual([]*vector.Vector{normal}, 1, 1)
 	require.NoError(t, err)
 	require.True(t, equal)
-	duplicate, err := earlierDistinctArgumentRow(
+	batch := distinctArgumentBatch{}
+	duplicate, err := batch.seenOrInsert(
+		[]uint64{1, 2, 1}, []*vector.Vector{normal}, 0, 0)
+	require.NoError(t, err)
+	require.False(t, duplicate)
+	duplicate, err = batch.seenOrInsert(
 		[]uint64{1, 2, 1}, []*vector.Vector{normal}, 0, 2)
 	require.NoError(t, err)
 	require.False(t, duplicate)
-	duplicate, err = earlierDistinctArgumentRow(
+	batch = distinctArgumentBatch{}
+	duplicate, err = batch.seenOrInsert(
+		[]uint64{1, 2, 1}, []*vector.Vector{constant}, 5, 0)
+	require.NoError(t, err)
+	require.False(t, duplicate)
+	duplicate, err = batch.seenOrInsert(
 		[]uint64{1, 2, 1}, []*vector.Vector{constant}, 5, 2)
 	require.NoError(t, err)
 	require.True(t, duplicate)
@@ -185,6 +195,45 @@ func TestCapacityPreflightPrimitiveBoundaries(t *testing.T) {
 	intValues.Free(mp)
 	finishTestAggregateAllocation(t, registry, account)
 	require.Zero(t, mp.CurrNB())
+}
+
+func TestDistinctArgumentBatchDeduplicatesFullWorkUnit(t *testing.T) {
+	const offset = 17
+	mp := mpool.MustNewZero()
+	input := vector.NewVec(types.T_int64.ToType())
+	for i := 0; i < offset; i++ {
+		require.NoError(t, vector.AppendFixed(input, int64(-1), false, mp))
+	}
+	groups := make([]uint64, hashmap.UnitLimit)
+	for i := range groups {
+		groups[i] = uint64(i%5 + 1)
+		require.NoError(t, vector.AppendFixed(input, int64(i%13), false, mp))
+	}
+	defer input.Free(mp)
+
+	batch := distinctArgumentBatch{}
+	seen := make(map[[2]uint64]struct{})
+	for row, group := range groups {
+		key := [2]uint64{group, uint64(row % 13)}
+		_, expectedDuplicate := seen[key]
+		duplicate, err := batch.seenOrInsert(
+			groups, []*vector.Vector{input}, offset, row)
+		require.NoError(t, err)
+		require.Equal(t, expectedDuplicate, duplicate, "row %d", row)
+		seen[key] = struct{}{}
+	}
+	for row := range groups {
+		duplicate, err := batch.seenOrInsert(
+			groups, []*vector.Vector{input}, offset, row)
+		require.NoError(t, err)
+		require.True(t, duplicate, "second visit to row %d", row)
+	}
+
+	_, err := batch.seenOrInsert(groups, []*vector.Vector{input}, offset, -1)
+	require.ErrorIs(t, err, mpool.ErrAllocationAccountInvalid)
+	_, err = batch.seenOrInsert(
+		make([]uint64, hashmap.UnitLimit+1), []*vector.Vector{input}, offset, 0)
+	require.ErrorIs(t, err, mpool.ErrAllocationAccountInvalid)
 }
 
 func TestConcreteAggregatePreflightsRejectOversizedWorkUnits(t *testing.T) {

--- a/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
@@ -206,21 +206,17 @@ func TestDistinctArgumentBatchDeduplicatesFullWorkUnit(t *testing.T) {
 	}
 	groups := make([]uint64, hashmap.UnitLimit)
 	for i := range groups {
-		groups[i] = uint64(i%5 + 1)
-		require.NoError(t, vector.AppendFixed(input, int64(i%13), false, mp))
+		groups[i] = 1
+		require.NoError(t, vector.AppendFixed(input, int64(i), false, mp))
 	}
 	defer input.Free(mp)
 
 	batch := distinctArgumentBatch{}
-	seen := make(map[[2]uint64]struct{})
-	for row, group := range groups {
-		key := [2]uint64{group, uint64(row % 13)}
-		_, expectedDuplicate := seen[key]
+	for row := range groups {
 		duplicate, err := batch.seenOrInsert(
 			groups, []*vector.Vector{input}, offset, row)
 		require.NoError(t, err)
-		require.Equal(t, expectedDuplicate, duplicate, "row %d", row)
-		seen[key] = struct{}{}
+		require.False(t, duplicate, "unique row %d", row)
 	}
 	for row := range groups {
 		duplicate, err := batch.seenOrInsert(
@@ -234,6 +230,151 @@ func TestDistinctArgumentBatchDeduplicatesFullWorkUnit(t *testing.T) {
 	_, err = batch.seenOrInsert(
 		make([]uint64, hashmap.UnitLimit+1), []*vector.Vector{input}, offset, 0)
 	require.ErrorIs(t, err, mpool.ErrAllocationAccountInvalid)
+}
+
+func TestDistinctArgumentLinearBatchTransitionsOnlyAfterUniqueLimit(t *testing.T) {
+	const offset = 3
+	mp := mpool.MustNewZero()
+	input := vector.NewVec(types.T_int64.ToType())
+	for range offset {
+		require.NoError(t, vector.AppendFixed(input, int64(-1), false, mp))
+	}
+	for i := range distinctArgumentLinearLimit {
+		require.NoError(t, vector.AppendFixed(input, int64(i), false, mp))
+	}
+	require.NoError(t, vector.AppendFixed(input, int64(0), false, mp))
+	require.NoError(t, vector.AppendFixed(input, int64(distinctArgumentLinearLimit), false, mp))
+	defer input.Free(mp)
+
+	groups := make([]uint64, distinctArgumentLinearLimit+2)
+	for i := range groups {
+		groups[i] = 1
+	}
+	batch := distinctArgumentLinearBatch{}
+	for row := range distinctArgumentLinearLimit {
+		duplicate, err := batch.seen(
+			groups, []*vector.Vector{input}, offset, row)
+		require.NoError(t, err)
+		require.False(t, duplicate)
+		require.True(t, batch.insertUnique(row))
+	}
+	duplicate, err := batch.seen(
+		groups, []*vector.Vector{input}, offset, distinctArgumentLinearLimit)
+	require.NoError(t, err)
+	require.True(t, duplicate,
+		"a duplicate stays on the exact linear path")
+
+	duplicate, err = batch.seen(
+		groups, []*vector.Vector{input}, offset, distinctArgumentLinearLimit+1)
+	require.NoError(t, err)
+	require.False(t, duplicate)
+	require.False(t, batch.insertUnique(distinctArgumentLinearLimit+1),
+		"the ninth unique tuple switches to hashed admission")
+}
+
+func TestDistinctArgumentAdaptivePreflightPreservesMultiColumnSemantics(t *testing.T) {
+	const offset = 2
+	mp := mpool.MustNewZero()
+	registry, account, allocation := newTestAggregateAllocation(t)
+	exec, err := MakeAgg(
+		mp, AggIdOfCountColumn, true,
+		types.T_varchar.ToType(), types.T_int64.ToType())
+	require.NoError(t, err)
+	owner := exec.(AllocationAccountOwner)
+	require.NoError(t, owner.SetAllocationAccount(allocation))
+	require.NoError(t, exec.GroupGrow(2))
+
+	stringsInput := vector.NewVec(types.T_varchar.ToType())
+	intsInput := vector.NewVec(types.T_int64.ToType())
+	for range offset {
+		require.NoError(t, vector.AppendBytes(stringsInput, []byte("ignored"), false, mp))
+		require.NoError(t, vector.AppendFixed(intsInput, int64(-1), false, mp))
+	}
+	groups := make([]uint64, hashmap.UnitLimit)
+	want := [2]map[string]struct{}{{}, {}}
+	for row := range groups {
+		group := uint64(row%2 + 1)
+		if row == 0 {
+			group = GroupNotMatched
+		}
+		groups[row] = group
+		value := []byte("value-" + string(rune('a'+row%32)))
+		null := row == 19
+		require.NoError(t, vector.AppendBytes(stringsInput, value, null, mp))
+		require.NoError(t, vector.AppendFixed(intsInput, int64(row%32), false, mp))
+		if group != GroupNotMatched && !null {
+			want[group-1][string(value)] = struct{}{}
+		}
+	}
+	vectors := []*vector.Vector{stringsInput, intsInput}
+	preflight := exec.(BatchCapacityPreflight)
+	require.NoError(t, preflight.PreflightBatchFill(offset, groups, vectors))
+	admitted := account.Snapshot().Used
+	require.NoError(t, exec.BatchFill(offset, groups, vectors))
+	require.Equal(t, admitted, account.Snapshot().Used,
+		"publication must stay within the adaptively admitted capacity")
+
+	// The second pass exercises both the in-batch hashed duplicate path and
+	// keys already present in the published skiplist.
+	require.NoError(t, preflight.PreflightBatchFill(offset, groups, vectors))
+	require.NoError(t, exec.BatchFill(offset, groups, vectors))
+	require.Equal(t, admitted, account.Snapshot().Used)
+	results, err := exec.Flush()
+	require.NoError(t, err)
+	for group := range want {
+		require.Equal(t, int64(len(want[group])),
+			vector.GetFixedAtNoTypeCheck[int64](results[0], group))
+	}
+	results[0].Free(mp)
+	stringsInput.Free(mp)
+	intsInput.Free(mp)
+	exec.Free()
+	require.NoError(t, owner.ClearAllocationAccount(allocation))
+	finishTestAggregateAllocation(t, registry, account)
+	require.Zero(t, mp.CurrNB())
+}
+
+func TestNonDistinctMultiArgumentPreflightRemainsPublicationFree(t *testing.T) {
+	mp := mpool.MustNewZero()
+	registry, account, allocation := newTestAggregateAllocation(t)
+	info := aggInfo{
+		argTypes: []types.Type{
+			types.T_varchar.ToType(), types.T_int64.ToType(),
+		},
+		saveArg: true,
+	}
+	state := aggState{}
+	require.NoError(t, state.initWithAllocation(
+		mp, 1, 1, &info, false, allocation))
+	exec := aggExec{
+		mp:         mp,
+		aggInfo:    info,
+		chunkSize:  AggBatchSize,
+		state:      []aggState{state},
+		allocation: allocation,
+	}
+	stringsInput := buildVarlenVec(t, mp, types.T_varchar.ToType(),
+		[]string{"ignored", "first", "null", "second"})
+	intsInput := buildFixedVec(t, mp, types.T_int64.ToType(),
+		[]int64{0, 1, 2, 3})
+	stringsInput.SetNull(2)
+	require.NoError(t, exec.preflightBatchFillArgs(
+		0,
+		[]uint64{GroupNotMatched, 1, 1, 1},
+		[]*vector.Vector{stringsInput, intsInput},
+		false,
+	))
+	require.Zero(t, exec.state[0].argCnt[0],
+		"capacity admission must not publish aggregate arguments")
+	require.Positive(t, len(exec.state[0].argScratch))
+
+	stringsInput.Free(mp)
+	intsInput.Free(mp)
+	exec.state[0].free(mp)
+	exec.state = nil
+	exec.allocation = nil
+	finishTestAggregateAllocation(t, registry, account)
+	require.Zero(t, mp.CurrNB())
 }
 
 func TestConcreteAggregatePreflightsRejectOversizedWorkUnits(t *testing.T) {


### PR DESCRIPTION
### What this changes

Make saved-argument DISTINCT preflight adaptive instead of forcing either quadratic scans or hashing every row:

- split DISTINCT and non-DISTINCT admission into separate functions, so ordinary aggregates do not clear or retain the DISTINCT hash table stack frame;
- keep up to 8 exact `(target group, DISTINCT arguments)` representatives and use exact equality only;
- initialize the fixed 512-slot open-addressing table only when the ninth unique tuple arrives, bounding high-cardinality admission to expected O(B) for the 256-row work unit;
- delay single-column payload access until a tuple is actually admitted, so duplicate-heavy fixed and varlen inputs are faster than the old scan;
- retain collision-safe canonical equality for NULL filtering, const vectors, offsets, multi-column boundaries, and floating-point signed zero;
- add a direct non-DISTINCT single-argument loop so splitting the paths does not regress ordinary saved arguments.

The implementation keeps regular and DISTINCT admission separate and pays the bounded hash-table cost only after the exact low-cardinality path overflows. A full aggregate-framework rewrite would be disproportionate for this bounded 256-row preflight unit.

### arenaskl correctness fix

A reused `arenaskl.Inserter` could miss equality when the requested key was exactly its cached base-level successor. The PR now checks that successor before leaving the cached-splice path and adds `Inserter.AddWithPlan` so sorted planned publications can safely retain the splice cache.

Fixes #27687.
Fixes #27691.
Related to #27672; the mixed-aggregation query optimization remains in #27693.

### Performance

Pinned to one CPU, `-cpu=1`, 256 rows, median of 3 runs (focused non-DISTINCT fixed result uses 5 runs at 2s):

| input | cardinality | base | head | result |
|---|---:|---:|---:|---:|
| INT64 DISTINCT | 1 | 7.813 us | 6.987 us | 10.6% faster |
| INT64 DISTINCT | 2 | 10.451 us | 9.959 us | 4.7% faster |
| INT64 DISTINCT | 8 | 25.741 us | 25.561 us | neutral / 0.7% faster |
| INT64 DISTINCT | 9 | 27.920 us | 10.896 us | 2.56x faster |
| INT64 DISTINCT | 256 | 648.647 us | 14.664 us | 44.2x faster |
| 1 KiB VARCHAR DISTINCT | 1 | 12.282 us | 10.770 us | 12.3% faster |
| 1 KiB VARCHAR DISTINCT | 2 | 16.562 us | 15.863 us | 4.2% faster |
| 1 KiB VARCHAR DISTINCT | 8 | 44.797 us | 43.617 us | 2.6% faster |
| 1 KiB VARCHAR DISTINCT | 9 | 48.153 us | 28.928 us | 1.66x faster |
| 1 KiB VARCHAR DISTINCT | 256 | 999.855 us | 46.526 us | 21.5x faster |
| INT64 non-DISTINCT | n/a | 7.632 us | 7.542 us | 1.2% faster |
| 1 KiB VARCHAR non-DISTINCT | n/a | 24.638 us | 24.605 us | neutral |

All focused cases remain at 0 B/op and 0 allocs/op. The existing 65,536-row `BenchmarkCountDistinctSavedArguments` remains about 48-49 ms/op.

Stack frames from the compiled test binary:

- base combined path: 12,832 bytes;
- head non-DISTINCT single path: 12,448 bytes;
- head low-cardinality DISTINCT path: 8,400 bytes;
- high-cardinality hash helper: 5,296 bytes in its separate frame.

### Regression coverage

- true 256-unique-candidate hash-table test plus a complete second duplicate pass;
- threshold transition at 8/9 unique tuples;
- end-to-end adaptive multi-column DISTINCT test with offsets, NULL, unmatched groups, two groups, repeat preflight, publication, and result cardinality;
- non-DISTINCT multi-argument preflight remains publication-free;
- cached Inserter sorted-overlap regression checks duplicate rejection and final cardinality;
- benchmark matrix covers cardinality 1, 2, 8, 9, and 256 for fixed/varlen plus non-DISTINCT controls.

Exact package coverage comparison (`pkg/common/arenaskl` + `pkg/sql/colexec/aggexec`):

- base: 10,520 / 13,316 statements = 79.002704%;
- head: 10,669 / 13,483 statements = 79.129274%.

### Validation

- full normal tests for both packages;
- full race tests for both packages;
- `go vet` for both packages;
- deterministic CGo compile/link/runtime environment;
- pinned-CPU benchmark matrix;
- `git diff --check`;
- rebased onto latest `origin/main` (`e8332cb8cc`).