### PR TITLE
perf: parallelize high-cardinality mixed DISTINCT aggregation

### DIFF
--- a/pkg/common/arenaskl/skl.go
+++ b/pkg/common/arenaskl/skl.go
@@ -201,6 +201,51 @@ func (s *Skiplist) Arena() *Arena { return s.arena }
 // Size returns the number of bytes that have allocated from the arena.
 func (s *Skiplist) Size() uint32 { return s.arena.Size() }
 
+// GrowArena relocates the skiplist into an independent, larger backing buffer
+// without rebuilding its nodes. Every internal link is an arena-relative
+// offset; only the arena plus the external head and tail pointers need to be
+// rebound.
+//
+// The caller must have exclusive access to the skiplist and must not retain an
+// iterator, Inserter, or Arena handle across this call. A failed arena allocation
+// can advance Arena.Size past the old backing buffer; a list in that state cannot
+// be relocated this way because the last valid allocation boundary is no longer
+// available.
+func (s *Skiplist) GrowArena(buf []byte) error {
+	if s == nil || s.arena == nil || s.head == nil || s.tail == nil {
+		return moerr.NewInternalErrorNoCtx("cannot grow an uninitialized skiplist")
+	}
+	if len(buf) > maxArenaSize {
+		return moerr.NewInvalidInputNoCtxf(
+			"skiplist arena size %d exceeds maximum %d", len(buf), maxArenaSize)
+	}
+	oldArena := s.arena
+	if len(buf) <= len(oldArena.buf) {
+		return ErrArenaFull
+	}
+	oldStart := uintptr(unsafe.Pointer(unsafe.SliceData(oldArena.buf)))
+	newStart := uintptr(unsafe.Pointer(unsafe.SliceData(buf)))
+	overlaps := oldStart <= newStart && newStart-oldStart < uintptr(len(oldArena.buf)) ||
+		newStart < oldStart && oldStart-newStart < uintptr(len(buf))
+	if overlaps {
+		return moerr.NewInvalidInputNoCtx("skiplist arena buffers overlap")
+	}
+	used := oldArena.n.Load()
+	if used > uint64(len(oldArena.buf)) || used > uint64(len(buf)) {
+		return ErrArenaFull
+	}
+	headOffset := oldArena.getPointerOffset(unsafe.Pointer(s.head))
+	tailOffset := oldArena.getPointerOffset(unsafe.Pointer(s.tail))
+	copy(buf[:used], oldArena.buf[:used])
+
+	newArena := NewArena(buf)
+	newArena.n.Store(used)
+	s.arena = newArena
+	s.head = (*node)(newArena.getPointer(headOffset))
+	s.tail = (*node)(newArena.getPointer(tailOffset))
+	return nil
+}
+
 // Add adds a new key if it does not yet exist. If the key already exists, then
 // Add returns ErrRecordExists. If there isn't enough room in the arena, then
 // Add returns ErrArenaFull.

--- a/pkg/common/arenaskl/skl_test.go
+++ b/pkg/common/arenaskl/skl_test.go
@@ -122,6 +122,51 @@ func makeInserterAdd(s *Skiplist) func(key []byte, value []byte) error {
 	}
 }
 
+func TestSkiplistGrowArenaPreservesNodesAndLinks(t *testing.T) {
+	list := NewSkiplist(newArena(64<<10), bytes.Compare)
+	const rows = 500
+	for i := 0; i < rows; i++ {
+		require.NoError(t, list.Add(makeIntKey(i), makeValue(i)))
+	}
+	originalSize := list.Size()
+	originalHeight := list.Height()
+	require.ErrorIs(t, list.GrowArena(make([]byte, originalSize-1)), ErrArenaFull)
+
+	require.NoError(t, list.GrowArena(make([]byte, 256<<10)))
+	require.Equal(t, originalSize, list.Size())
+	require.Equal(t, originalHeight, list.Height())
+	require.Equal(t, rows, length(list))
+	require.Equal(t, rows, lengthRev(list))
+	it := list.NewIter(nil, nil)
+	i := 0
+	for ok, key, value := it.First(); ok; ok, key, value = it.Next() {
+		require.Equal(t, makeIntKey(i), key)
+		require.Equal(t, makeValue(i), value)
+		i++
+	}
+	it.Close()
+	require.Equal(t, rows, i)
+	require.ErrorIs(t, list.Add(makeIntKey(rows/2), nil), ErrRecordExists)
+	require.NoError(t, list.Add(makeIntKey(rows), makeValue(rows)))
+	require.Equal(t, rows+1, length(list))
+}
+
+func TestSkiplistGrowArenaRejectsPoisonedArena(t *testing.T) {
+	list := NewSkiplist(newArena(1000), bytes.Compare)
+	require.ErrorIs(t, list.Add(make([]byte, 2000), nil), ErrArenaFull)
+	require.ErrorIs(t, list.GrowArena(make([]byte, 64<<10)), ErrArenaFull)
+	require.Error(t, (&Skiplist{}).GrowArena(make([]byte, 64<<10)))
+}
+
+func TestSkiplistGrowArenaRequiresIndependentLargerBuffer(t *testing.T) {
+	backing := make([]byte, 128<<10)
+	list := NewSkiplist(NewArena(backing[:64<<10]), bytes.Compare)
+	require.NoError(t, list.Add(makeIntKey(1), makeValue(1)))
+	require.ErrorIs(t, list.GrowArena(make([]byte, 64<<10)), ErrArenaFull)
+	require.Error(t, list.GrowArena(backing))
+	require.True(t, list.Contains(makeIntKey(1)))
+}
+
 func TestInserterAddWithPlanDeduplicatesSortedOverlap(t *testing.T) {
 	list := NewSkiplist(newArena(64<<10), bytes.Compare)
 	var inserter Inserter

--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -925,6 +925,14 @@ func maxAllocationSize() int64 {
 	return int64(CapLimit) - kMemHdrSz
 }
 
+// MaxAllocationSize returns the largest payload accepted by one MPool
+// allocation. Callers may use it to cap speculative growth before asking the
+// allocator; it is not a reservation and does not bypass account or pool
+// capacity admission.
+func MaxAllocationSize() int64 {
+	return maxAllocationSize()
+}
+
 // Alloc returns an MPool-owned block. The caller must eventually pass every
 // successful non-empty allocation to Free; DeleteMPool provides the terminal
 // release only for NoLock pools, whose allocations cannot outlive the pool.

--- a/pkg/common/mpool/mpool_test.go
+++ b/pkg/common/mpool/mpool_test.go
@@ -444,6 +444,7 @@ func TestGrowCapacityValidation(t *testing.T) {
 	require.Equal(t, int64(128), capacity)
 
 	maxCapacity := maxAllocationSize()
+	require.Equal(t, maxCapacity, MaxAllocationSize())
 	capacity, ok = GrowCapacity(maxCapacity, maxCapacity)
 	require.True(t, ok)
 	require.Equal(t, maxCapacity, capacity)

--- a/pkg/sql/colexec/aggexec/aggState.go
+++ b/pkg/sql/colexec/aggexec/aggState.go
@@ -896,6 +896,14 @@ func (ag *aggState) insertArg(mp *mpool.MPool, kbuf []byte) error {
 }
 
 func (ag *aggState) insertArgValue(mp *mpool.MPool, kbuf, value []byte) error {
+	return ag.insertArgValueWithInserter(mp, kbuf, value, nil)
+}
+
+func (ag *aggState) insertArgValueWithInserter(
+	mp *mpool.MPool,
+	kbuf, value []byte,
+	inserter *arenaskl.Inserter,
+) error {
 	if ag.argSkl == nil {
 		return moerr.NewInternalErrorNoCtx("argSkl is not initialized")
 	}
@@ -907,7 +915,14 @@ func (ag *aggState) insertArgValue(mp *mpool.MPool, kbuf, value []byte) error {
 
 	add := func(list *arenaskl.Skiplist, key []byte) error {
 		if ag.allocation != nil {
-			return list.AddWithPlan(key, value, arenaskl.MakeAddPlan(key))
+			plan := arenaskl.MakeAddPlan(key)
+			if inserter != nil {
+				return inserter.AddWithPlan(list, key, value, plan)
+			}
+			return list.AddWithPlan(key, value, plan)
+		}
+		if inserter != nil {
+			return inserter.Add(list, key, value)
 		}
 		return list.Add(key, value)
 	}
@@ -979,6 +994,9 @@ func (ag *aggState) insertArgValue(mp *mpool.MPool, kbuf, value []byte) error {
 		}
 	}
 	it.Close()
+	if inserter != nil {
+		*inserter = arenaskl.Inserter{}
+	}
 	if err = add(newArgSkl, kbuf); err != nil {
 		mp.Free(argBuf)
 		return err
@@ -1060,6 +1078,7 @@ func (ag *aggState) insertPreparedArg(
 }
 
 func (ag *aggState) mergeArgs(mp *mpool.MPool, y uint16, other *aggState, otherY uint16, info *aggInfo) error {
+	var inserter arenaskl.Inserter
 	merge := func(k []byte) error {
 		kcpy, err := ag.resizeArgScratch(mp, len(k))
 		if err != nil {
@@ -1073,7 +1092,7 @@ func (ag *aggState) mergeArgs(mp *mpool.MPool, y uint16, other *aggState, otherY
 		if info.preserveDistinctInputOrder {
 			return ag.fillDistinctArgInInputOrder(mp, y, kcpy)
 		}
-		fnerr := ag.insertArg(mp, kcpy)
+		fnerr := ag.insertArgValueWithInserter(mp, kcpy, nil, &inserter)
 		if fnerr == nil {
 			ag.argCnt[y] += 1
 			if ag.argCnt[y] == 0 {

--- a/pkg/sql/colexec/aggexec/aggexec_bench_test.go
+++ b/pkg/sql/colexec/aggexec/aggexec_bench_test.go
@@ -416,6 +416,115 @@ func BenchmarkCountDistinctSavedArguments(b *testing.B) {
 	}
 }
 
+func BenchmarkCountDistinctSavedArgumentMerge(b *testing.B) {
+	const (
+		sourceCount   = 16
+		rowsPerSource = 1_000_000 / sourceCount
+		groupCount    = 100
+	)
+
+	mp := mpool.MustNewZero()
+	registry, err := mpool.NewAllocationAccountRegistry(1, 512)
+	if err != nil {
+		b.Fatal(err)
+	}
+	account, err := registry.Open(512 << 20)
+	if err != nil {
+		b.Fatal(err)
+	}
+	allocation, err := NewAllocationAccount(
+		account, mpool.AllocationOwnerGroup, AllocationAccountSites{
+			VectorData: 1, VectorArea: 2, VectorNulls: 3,
+			VectorGrouping: 4, ArgumentCount: 5, ArgumentArena: 6,
+		})
+	if err != nil {
+		b.Fatal(err)
+	}
+	mergeGroups := make([]uint64, groupCount)
+	for i := range mergeGroups {
+		mergeGroups[i] = uint64(i + 1)
+	}
+
+	sources := make([]AggFuncExec, sourceCount)
+	for sourceIndex := range sources {
+		input := vector.NewVec(types.T_int64.ToType())
+		for row := 0; row < rowsPerSource; row++ {
+			value := int64(sourceIndex*rowsPerSource + row)
+			if err = vector.AppendFixed(input, value, false, mp); err != nil {
+				b.Fatal(err)
+			}
+		}
+		groups := make([]uint64, hashmap.UnitLimit)
+		for row := range groups {
+			groups[row] = uint64(row%groupCount + 1)
+		}
+		source := newCountColumnExec(
+			mp, AggIdOfCountColumn, true, []types.Type{types.T_int64.ToType()})
+		if err = source.(AllocationAccountOwner).SetAllocationAccount(allocation); err != nil {
+			b.Fatal(err)
+		}
+		if err = source.GroupGrow(groupCount); err != nil {
+			b.Fatal(err)
+		}
+		for offset := 0; offset < rowsPerSource; offset += hashmap.UnitLimit {
+			workGroups := groups[:min(hashmap.UnitLimit, rowsPerSource-offset)]
+			if err = source.(BatchCapacityPreflight).PreflightBatchFill(
+				offset, workGroups, []*vector.Vector{input}); err != nil {
+				b.Fatal(err)
+			}
+			if err = source.BatchFill(
+				offset, workGroups, []*vector.Vector{input}); err != nil {
+				b.Fatal(err)
+			}
+		}
+		input.Free(mp)
+		sources[sourceIndex] = source
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(1_000_000 * 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		target := newCountColumnExec(
+			mp, AggIdOfCountColumn, true, []types.Type{types.T_int64.ToType()})
+		if err = target.(AllocationAccountOwner).SetAllocationAccount(allocation); err != nil {
+			b.Fatal(err)
+		}
+		if err = target.GroupGrow(groupCount); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		for _, source := range sources {
+			if err = target.(BatchCapacityPreflight).PreflightBatchMerge(
+				source, 0, mergeGroups); err != nil {
+				b.Fatal(err)
+			}
+			if err = target.BatchMerge(source, 0, mergeGroups); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+		target.Free()
+		if err = target.(AllocationAccountOwner).ClearAllocationAccount(allocation); err != nil {
+			b.Fatal(err)
+		}
+	}
+	for _, source := range sources {
+		source.Free()
+		if err = source.(AllocationAccountOwner).ClearAllocationAccount(allocation); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if account.Snapshot().Used != 0 {
+		b.Fatalf("account retains %d bytes", account.Snapshot().Used)
+	}
+	account.Seal()
+	if _, err = registry.Finalize(account); err != nil {
+		b.Fatal(err)
+	}
+}
+
 func BenchmarkArgumentPreflightCardinality(b *testing.B) {
 	type benchmarkCase struct {
 		name        string

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -200,7 +200,21 @@ func (ag *aggState) preflightArgumentCapacity(
 	if err != nil {
 		return err
 	}
+	fallbackCapacity, err := nextLinearArgumentArenaCapacity(
+		uint64(len(ag.argbuf)), required)
+	if err != nil {
+		return err
+	}
 	next, err := ag.allocation.allocArgumentArena(mp, int(capacity))
+	if err != nil && capacity != fallbackCapacity &&
+		mpool.IsRetryableAllocationCapacity(err) {
+		// Geometric growth keeps repeated relocation linear in the final state
+		// size, but the old arena remains charged until relocation publishes.
+		// Under memory pressure, retain the former chunked-growth availability
+		// envelope instead of failing a query solely because of speculative
+		// spare capacity.
+		next, err = ag.allocation.allocArgumentArena(mp, int(fallbackCapacity))
+	}
 	if err != nil {
 		return err
 	}
@@ -234,6 +248,27 @@ func nextArgumentArenaCapacity(current, required uint64) (uint64, error) {
 		}
 	}
 	if capacity > uint64(math.MaxInt) {
+		return 0, mpool.ErrAllocationAllocatorLimit
+	}
+	return capacity, nil
+}
+
+func nextLinearArgumentArenaCapacity(current, required uint64) (uint64, error) {
+	if required <= current {
+		return current, nil
+	}
+	if current > math.MaxUint32 || required > math.MaxUint32 {
+		return 0, mpool.ErrAllocationAllocatorLimit
+	}
+	missing := required - current
+	chunk := uint64(kAggArgArenaSize)
+	steps := (missing + chunk - 1) / chunk
+	grow := steps * chunk
+	capacity := uint64(math.MaxUint32)
+	if grow <= math.MaxUint32-current {
+		capacity = current + grow
+	}
+	if capacity < required || capacity > uint64(math.MaxInt) {
 		return 0, mpool.ErrAllocationAllocatorLimit
 	}
 	return capacity, nil

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -195,47 +195,48 @@ func (ag *aggState) preflightArgumentCapacity(
 		return nil
 	}
 
-	capacity := uint64(len(ag.argbuf))
-	missing := required - capacity
-	steps := (missing + kAggArgArenaSize - 1) / kAggArgArenaSize
-	if steps > (math.MaxUint32-capacity)/kAggArgArenaSize {
-		return mpool.ErrAllocationAllocatorLimit
+	capacity, err := nextArgumentArenaCapacity(
+		uint64(len(ag.argbuf)), required)
+	if err != nil {
+		return err
 	}
-	capacity += steps * kAggArgArenaSize
-	if capacity > uint64(math.MaxInt) {
-		return mpool.ErrAllocationAllocatorLimit
+	next, err := ag.allocation.allocArgumentArena(mp, int(capacity))
+	if err != nil {
+		return err
 	}
-	for {
-		next, err := ag.allocation.allocArgumentArena(mp, int(capacity))
-		if err != nil {
-			return err
-		}
-		nextArena := arenaskl.NewArena(next)
-		nextSkiplist := arenaskl.NewSkiplist(nextArena, bytes.Compare)
-		err = nil
-		it := ag.argSkl.NewIter(nil, nil)
-		for ok, key, value := it.First(); ok; ok, key, value = it.Next() {
-			err = nextSkiplist.AddWithPlan(
-				key, value, arenaskl.MakeAddPlan(key))
-			if err != nil {
-				break
-			}
-		}
-		it.Close()
-		if err == nil {
-			old := ag.argbuf
-			ag.argbuf = next
-			ag.argSkl = nextSkiplist
-			mp.Free(old)
-			return nil
-		}
+	if err = ag.argSkl.GrowArena(next); err != nil {
 		mp.Free(next)
-		if err != arenaskl.ErrArenaFull ||
-			capacity > math.MaxUint32-kAggArgArenaSize {
-			return err
-		}
-		capacity += kAggArgArenaSize
+		return err
 	}
+	old := ag.argbuf
+	ag.argbuf = next
+	mp.Free(old)
+	return nil
+}
+
+func nextArgumentArenaCapacity(current, required uint64) (uint64, error) {
+	if required <= current {
+		return current, nil
+	}
+	if current > math.MaxUint32 || required > math.MaxUint32 {
+		return 0, mpool.ErrAllocationAllocatorLimit
+	}
+	capacity := current
+	for capacity < required {
+		grow := max(capacity, uint64(kAggArgArenaSize))
+		if grow > math.MaxUint32-capacity {
+			capacity = math.MaxUint32
+		} else {
+			capacity += grow
+		}
+		if capacity == math.MaxUint32 && capacity < required {
+			return 0, mpool.ErrAllocationAllocatorLimit
+		}
+	}
+	if capacity > uint64(math.MaxInt) {
+		return 0, mpool.ErrAllocationAllocatorLimit
+	}
+	return capacity, nil
 }
 
 func validatePreflightVectors(
@@ -880,6 +881,11 @@ func (ae *aggExec) preflightBatchMergeArgs(
 			int(otherY) >= int(other.state[otherX].length) {
 			return mpool.ErrAllocationAccountInvariant
 		}
+		var upper [kAggArgPrefixSz]byte
+		binary.BigEndian.PutUint16(upper[:], y+1)
+		var targetIter *arenaskl.Iterator
+		var targetKey []byte
+		var targetOK bool
 		err = other.state[otherX].iter(otherY, func(key []byte) error {
 			if len(key) < kAggArgPrefixSz {
 				return mpool.ErrAllocationAccountInvariant
@@ -891,7 +897,14 @@ func (ae *aggExec) preflightBatchMergeArgs(
 			copy(candidate, key)
 			binary.BigEndian.PutUint16(candidate[:kAggArgPrefixSz], y)
 			if ae.isDistinct {
-				if state.argSkl.Contains(candidate) {
+				if targetIter == nil {
+					targetIter = state.argSkl.NewIter(nil, upper[:])
+					targetOK, targetKey, _ = targetIter.SeekGE(candidate)
+				}
+				for targetOK && bytes.Compare(targetKey, candidate) < 0 {
+					targetOK, targetKey, _ = targetIter.Next()
+				}
+				if targetOK && bytes.Equal(targetKey, candidate) {
 					return nil
 				}
 				// A merge work unit can map several source groups into the same
@@ -936,6 +949,9 @@ func (ae *aggExec) preflightBatchMergeArgs(
 			return addArgumentChunkCapacityWithValue(
 				&needs, &needCount, x, candidate, valueSize)
 		})
+		if targetIter != nil {
+			targetIter.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -205,6 +205,16 @@ func (ag *aggState) preflightArgumentCapacity(
 	if err != nil {
 		return err
 	}
+	// Geometric growth is speculative spare capacity. Clamp both candidates to
+	// the physical single-allocation limit before admission so crossing that
+	// boundary neither logs a failed oversized allocation nor rejects a smaller
+	// arena that still satisfies required.
+	maxAllocation := mpool.MaxAllocationSize()
+	if maxAllocation <= 0 || required > uint64(maxAllocation) {
+		return mpool.ErrAllocationAllocatorLimit
+	}
+	capacity = min(capacity, uint64(maxAllocation))
+	fallbackCapacity = min(fallbackCapacity, uint64(maxAllocation))
 	next, err := ag.allocation.allocArgumentArena(mp, int(capacity))
 	if err != nil && capacity != fallbackCapacity &&
 		mpool.IsRetryableAllocationCapacity(err) {

--- a/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
@@ -15,11 +15,13 @@
 package aggexec
 
 import (
+	"bytes"
 	"context"
 	"math"
 	"strings"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/arenaskl"
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
@@ -396,6 +398,68 @@ func TestNextArgumentArenaCapacityUsesGeometricGrowth(t *testing.T) {
 
 	_, err = nextArgumentArenaCapacity(math.MaxUint32, uint64(math.MaxUint32)+1)
 	require.ErrorIs(t, err, mpool.ErrAllocationAllocatorLimit)
+
+	capacity, err = nextLinearArgumentArenaCapacity(
+		2*kAggArgArenaSize, 2*kAggArgArenaSize+1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3*kAggArgArenaSize), capacity)
+
+	capacity, err = nextLinearArgumentArenaCapacity(
+		math.MaxUint32-1, math.MaxUint32)
+	require.NoError(t, err)
+	require.Equal(t, uint64(math.MaxUint32), capacity)
+
+	_, err = nextLinearArgumentArenaCapacity(
+		math.MaxUint32, uint64(math.MaxUint32)+1)
+	require.ErrorIs(t, err, mpool.ErrAllocationAllocatorLimit)
+}
+
+func TestArgumentArenaGrowthFallsBackUnderCapacityPressure(t *testing.T) {
+	const current = 2 * kAggArgArenaSize
+	preferred, err := nextArgumentArenaCapacity(current, current+1)
+	require.NoError(t, err)
+	fallback, err := nextLinearArgumentArenaCapacity(current, current+1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2*current), preferred)
+	require.Equal(t, uint64(current+kAggArgArenaSize), fallback)
+
+	mp := mpool.MustNewZero()
+	registry, err := mpool.NewAllocationAccountRegistry(1, 8)
+	require.NoError(t, err)
+	// The old arena and the linear fallback fit together exactly. The preferred
+	// geometric arena does not, proving that retry preserves availability rather
+	// than merely selecting the same capacity through another branch.
+	account, err := registry.Open(current + fallback)
+	require.NoError(t, err)
+	allocation, err := NewAllocationAccount(
+		account, mpool.AllocationOwnerGroup, AllocationAccountSites{
+			VectorData: 1, VectorArea: 2, VectorNulls: 3,
+			VectorGrouping: 4, ArgumentCount: 5, ArgumentArena: 6,
+		})
+	require.NoError(t, err)
+
+	buf, err := allocation.allocArgumentArena(mp, current)
+	require.NoError(t, err)
+	state := aggState{
+		allocation: allocation,
+		argbuf:     buf,
+		argSkl:     arenaskl.NewSkiplist(arenaskl.NewArena(buf), bytes.Compare),
+	}
+	require.NoError(t, state.argSkl.Add([]byte("kept"), nil))
+	used := uint64(state.argSkl.Arena().Size())
+	require.Less(t, used, uint64(current+1))
+	require.NoError(t, state.preflightArgumentCapacity(
+		mp, uint64(current+1)-used, 0))
+	require.Equal(t, int(fallback), len(state.argbuf))
+	require.True(t, state.argSkl.Contains([]byte("kept")))
+	require.Equal(t, fallback, account.Snapshot().Used)
+
+	mp.Free(state.argbuf)
+	require.Zero(t, account.Snapshot().Used)
+	account.Seal()
+	_, err = registry.Finalize(account)
+	require.NoError(t, err)
+	require.Zero(t, mp.CurrNB())
 }
 
 func TestConcreteAggregatePreflightsRejectOversizedWorkUnits(t *testing.T) {

--- a/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
@@ -462,6 +462,61 @@ func TestArgumentArenaGrowthFallsBackUnderCapacityPressure(t *testing.T) {
 	require.Zero(t, mp.CurrNB())
 }
 
+func TestArgumentArenaGrowthFallsBackAtAllocatorLimit(t *testing.T) {
+	const current = 2 * kAggArgArenaSize
+	preferred, err := nextArgumentArenaCapacity(current, current+1)
+	require.NoError(t, err)
+	fallback, err := nextLinearArgumentArenaCapacity(current, current+1)
+	require.NoError(t, err)
+	require.Greater(t, preferred, fallback)
+
+	oldCapLimit := mpool.CapLimit
+	mpool.CapLimit = int(preferred)
+	t.Cleanup(func() {
+		mpool.CapLimit = oldCapLimit
+	})
+
+	mp := mpool.MustNewZero()
+	registry, err := mpool.NewAllocationAccountRegistry(1, 8)
+	require.NoError(t, err)
+	account, err := registry.Open(current + fallback)
+	require.NoError(t, err)
+	state := aggState{}
+	t.Cleanup(func() {
+		if state.argbuf != nil {
+			mp.Free(state.argbuf)
+			state.argbuf = nil
+		}
+		account.Seal()
+		_, finalizeErr := registry.Finalize(account)
+		require.NoError(t, finalizeErr)
+		require.Zero(t, mp.CurrNB())
+	})
+	allocation, err := NewAllocationAccount(
+		account, mpool.AllocationOwnerGroup, AllocationAccountSites{
+			VectorData: 1, VectorArea: 2, VectorNulls: 3,
+			VectorGrouping: 4, ArgumentCount: 5, ArgumentArena: 6,
+		})
+	require.NoError(t, err)
+
+	buf, err := allocation.allocArgumentArena(mp, current)
+	require.NoError(t, err)
+	state = aggState{
+		allocation: allocation,
+		argbuf:     buf,
+		argSkl:     arenaskl.NewSkiplist(arenaskl.NewArena(buf), bytes.Compare),
+	}
+
+	require.NoError(t, state.argSkl.Add([]byte("kept"), nil))
+	used := uint64(state.argSkl.Arena().Size())
+	require.Less(t, used, uint64(current+1))
+	require.NoError(t, state.preflightArgumentCapacity(
+		mp, uint64(current+1)-used, 0))
+	require.Equal(t, int(fallback), len(state.argbuf))
+	require.True(t, state.argSkl.Contains([]byte("kept")))
+	require.Equal(t, fallback, account.Snapshot().Used)
+}
+
 func TestConcreteAggregatePreflightsRejectOversizedWorkUnits(t *testing.T) {
 	tests := []aggregateAllocationTestCase{
 		{name: "any", id: AggIdOfAny, params: []types.Type{types.T_varchar.ToType()}},

--- a/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight_edge_test.go
@@ -377,6 +377,27 @@ func TestNonDistinctMultiArgumentPreflightRemainsPublicationFree(t *testing.T) {
 	require.Zero(t, mp.CurrNB())
 }
 
+func TestNextArgumentArenaCapacityUsesGeometricGrowth(t *testing.T) {
+	capacity, err := nextArgumentArenaCapacity(1024, 1024)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1024), capacity)
+
+	capacity, err = nextArgumentArenaCapacity(16<<10, 16<<10+1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(16<<10+kAggArgArenaSize), capacity)
+
+	capacity, err = nextArgumentArenaCapacity(kAggArgArenaSize, kAggArgArenaSize+1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2*kAggArgArenaSize), capacity)
+
+	capacity, err = nextArgumentArenaCapacity(math.MaxUint32-1, math.MaxUint32)
+	require.NoError(t, err)
+	require.Equal(t, uint64(math.MaxUint32), capacity)
+
+	_, err = nextArgumentArenaCapacity(math.MaxUint32, uint64(math.MaxUint32)+1)
+	require.ErrorIs(t, err, mpool.ErrAllocationAllocatorLimit)
+}
+
 func TestConcreteAggregatePreflightsRejectOversizedWorkUnits(t *testing.T) {
 	tests := []aggregateAllocationTestCase{
 		{name: "any", id: AggIdOfAny, params: []types.Type{types.T_varchar.ToType()}},

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -1704,25 +1704,14 @@ func (c *Compile) compilePlanScopeWithUnionAllDemand(
 
 		c.setAnalyzeCurrent(ss, int(curNodeIdx))
 		ss = c.ensureCoordinatorOnlyFunctions(node, ss)
-		orderedGroupConcat := hasOrderedGroupConcat(node)
-		orderedSetPercentile := hasOrderedSetPercentile(node)
 		if c.canCompileShuffleGroup(node) {
 			ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node, c.compileShuffleGroup(node, ss, nodes))))
 			return ss, nil
 		}
-		if orderedGroupConcat || orderedSetPercentile {
-			ss = c.compileOrderedAggregateSingleStage(node, ss, nodes)
-			ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node, ss)))
-			return ss, nil
-		}
-		if c.IsSingleScope(ss) {
-			ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node, c.compileTPGroup(node, ss, nodes))))
-			return ss, nil
-		} else {
-			ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node,
-				c.compileMergeGroup(node, ss, nodes, distinctRequiresSingleStage))))
-			return ss, nil
-		}
+		ss = c.compileGroupWithoutShuffle(
+			node, ss, nodes, distinctRequiresSingleStage)
+		ss = c.compileSort(node, c.compileProjection(node, c.compileRestrict(node, ss)))
+		return ss, nil
 	case plan.Node_SAMPLE:
 		ss, err = c.compilePlanScope(step, node.Children[0], nodes)
 		if err != nil {
@@ -6173,6 +6162,22 @@ func (c *Compile) compileTPGroup(node *plan.Node, ss []*Scope, ns []*plan.Node) 
 	return ss
 }
 
+func (c *Compile) compileGroupWithoutShuffle(
+	node *plan.Node,
+	ss []*Scope,
+	ns []*plan.Node,
+	distinctRequiresSingleStage bool,
+) []*Scope {
+	if hasOrderedGroupConcat(node) || hasOrderedSetPercentile(node) {
+		return c.compileOrderedAggregateSingleStage(node, ss, ns)
+	}
+	if c.IsSingleScope(ss) {
+		return c.compileTPGroup(node, ss, ns)
+	}
+	return c.compileMergeGroup(
+		node, ss, ns, distinctRequiresSingleStage)
+}
+
 func (c *Compile) compileMergeGroup(
 	node *plan.Node,
 	ss []*Scope,
@@ -6452,6 +6457,18 @@ func (c *Compile) compileShuffleGroup(node *plan.Node, inputSS []*Scope, nodes [
 		}
 		c.anal.isFirst = false
 		return inputSS
+	}
+	// A normal shuffle is useful only when it creates more than one physical
+	// aggregate owner. In particular, max_dop=1 on one CN would otherwise hash
+	// every row into one bucket and add a dispatch/receiver pipeline with no
+	// reduction in retained aggregate state.
+	if node.Stats.Dop <= 1 && len(stageNodes) <= 1 {
+		return c.compileGroupWithoutShuffle(
+			node,
+			inputSS,
+			nodes,
+			plan2.RequiresSingleStageDistinctAgg(node),
+		)
 	}
 	if len(stageNodes) == 1 && len(inputSS) == 1 && inputSS[0].NodeInfo.Mcpu > 1 && inputSS[0].NodeInfo.Mcpu == int(node.Stats.Dop) {
 		return c.compileLocalShuffleGroup(node, inputSS, nodes)

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -1470,6 +1470,93 @@ func TestCompileShuffleGroupUsesDistributedPathWhenScopeMcpuDiffersFromDop(t *te
 	require.IsType(t, &shuffle.Shuffle{}, result[0].PreScopes[0].RootOp.GetOperatorBase().GetChildren(0))
 }
 
+func TestCompileShuffleGroupSkipsNormalShuffleWithSingleOwner(t *testing.T) {
+	c := newCompileForShuffleGroupTest(t)
+	aggNode, nodes := newShuffleGroupTestNodes(1)
+	scope := newShuffleGroupInputScope(t, 1)
+	input := scope.RootOp
+
+	result := c.compileShuffleGroup(aggNode, []*Scope{scope}, nodes)
+
+	require.Len(t, result, 1)
+	require.Same(t, scope, result[0])
+	groupOp, ok := result[0].RootOp.(*group.Group)
+	require.True(t, ok)
+	require.Same(t, input, groupOp.GetOperatorBase().GetChildren(0),
+		"one physical owner must not pay for a one-bucket shuffle and dispatch")
+}
+
+func TestCompileShuffleGroupSkipsSingleOwnerWithoutDroppingInputs(t *testing.T) {
+	c := newCompileForShuffleGroupTest(t)
+	aggNode, nodes := newShuffleGroupTestNodes(1)
+	inputs := []*Scope{
+		newShuffleGroupInputScope(t, 1),
+		newShuffleGroupInputScope(t, 1),
+	}
+
+	result := c.compileShuffleGroup(aggNode, inputs, nodes)
+
+	require.Len(t, result, 1)
+	require.IsType(t, &group.MergeGroup{}, result[0].RootOp)
+	require.Len(t, result[0].PreScopes, len(inputs))
+	for _, input := range result[0].PreScopes {
+		require.IsType(t, &group.Group{},
+			input.RootOp.GetOperatorBase().GetChildren(0))
+	}
+}
+
+func TestCompileShuffleGroupKeepsOrderedSingleOwnerSingleStage(t *testing.T) {
+	c := newCompileForShuffleGroupTest(t)
+	c.proc.SetResolveVariableFunc(func(name string, system, global bool) (interface{}, error) {
+		require.Equal(t, "group_concat_max_len", name)
+		require.True(t, system)
+		require.False(t, global)
+		return int64(1024), nil
+	})
+	aggNode, nodes := newShuffleGroupTestNodes(1)
+	aggNode.AggList = []*plan.Expr{{
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{
+				ObjName: plan2.NameGroupConcat,
+			},
+			AggConfigType: plan.AggregateConfigType_AGG_CONFIG_GROUP_CONCAT_ORDER,
+		}},
+	}}
+	scope := newShuffleGroupInputScope(t, 1)
+
+	result := c.compileShuffleGroup(aggNode, []*Scope{scope}, nodes)
+
+	require.Len(t, result, 1)
+	groupOp, ok := result[0].RootOp.(*group.Group)
+	require.True(t, ok)
+	require.True(t, groupOp.NeedEval)
+	require.Len(t, result[0].PreScopes, 1)
+	require.Same(t, scope, result[0].PreScopes[0])
+}
+
+func TestCompileShuffleGroupKeepsNormalShuffleAcrossCNsAtDopOne(t *testing.T) {
+	c := newCompileForShuffleGroupTest(t)
+	c.addr = "cn-1:6001"
+	c.cnList = engine.Nodes{
+		{Id: "cn-1", Addr: "cn-1:6001", Mcpu: 1},
+		{Id: "cn-2", Addr: "cn-2:6001", Mcpu: 1},
+	}
+	aggNode, nodes := newShuffleGroupTestNodes(1)
+	scope := newShuffleGroupInputScope(t, 1)
+	scope.NodeInfo = c.cnList[0]
+
+	result := c.compileShuffleGroup(aggNode, []*Scope{scope}, nodes)
+
+	require.Len(t, result, 2,
+		"DOP one on each CN still exposes two physical aggregate owners")
+	for _, resultScope := range result {
+		require.IsType(t, &group.Group{}, resultScope.RootOp)
+	}
+	require.Len(t, result[0].PreScopes, 1)
+	require.IsType(t, &shuffle.Shuffle{},
+		result[0].PreScopes[0].RootOp.GetOperatorBase().GetChildren(0))
+}
+
 func TestCompileShuffleGroupSupportsOrderedGroupConcat(t *testing.T) {
 	c := newCompileForShuffleGroupTest(t)
 	c.proc.SetResolveVariableFunc(func(name string, system, global bool) (interface{}, error) {

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -1221,13 +1221,25 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 	// it remains a valid distribution key even when it is omitted from the
 	// local hash table. Preserve the highest-NDV choice to avoid skewing a
 	// composite primary key on one of its lower-cardinality components.
-	idx := 0
-	highestNDV := node.GroupBy[idx].Ndv
+	idx := -1
+	highestNDV := float64(0)
 	for i := range node.GroupBy {
-		if node.GroupBy[i].Ndv > highestNDV {
+		// Grouping-set branches replace inactive keys with the rollup
+		// constant inside Group. A shuffle must happen before Group, so an
+		// inactive key is not a valid distribution key: all rows would be
+		// partitioned by their raw values and then collapse to one logical
+		// group without a downstream MergeGroup. An empty grouping set has no
+		// safe key and must retain the ordinary merge topology.
+		if i < len(node.GroupingFlag) && !node.GroupingFlag[i] {
+			continue
+		}
+		if idx < 0 || node.GroupBy[i].Ndv > highestNDV {
 			highestNDV = node.GroupBy[i].Ndv
 			idx = i
 		}
+	}
+	if idx < 0 {
+		return
 	}
 	minimumGroupNDV := float64(ShuffleThreshHoldOfNDV)
 	if distinctStateShuffle {

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -1174,6 +1174,14 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 	if len(node.GroupBy) == 0 {
 		return
 	}
+	// Non-COUNT DISTINCT states cannot be combined by MergeGroup today. DOP
+	// planning therefore keeps the complete aggregate on one CN. A shuffle in
+	// front of that single owner adds hashing and dispatch without exposing any
+	// parallel aggregate owner, so it is never a useful group-shuffle topology.
+	if RequiresSingleStageDistinctAgg(node) {
+		node.Stats.HashmapStats.Shuffle = false
+		return
+	}
 
 	child := builder.qry.Nodes[node.Children[0]]
 
@@ -1193,12 +1201,17 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 	distinctStateNDV := countDistinctStateNDV(node, builder)
 	distinctStateShuffle := false
 	if distinctStateNDV > 0 && child.Stats.Outcnt > 0 {
-		// Base-column NDV can exceed the filtered child cardinality. The exact
-		// state cannot retain more distinct tuples than rows reaching this node.
-		distinctStateRows := min(distinctStateNDV, child.Stats.Outcnt)
-		distinctRatio := distinctStateRows / child.Stats.Outcnt
-		distinctFactor := 1 / math.Pow(distinctRatio, 0.8)
-		distinctStateShuffle = distinctStateRows >= threshHoldForShuffleGroup*distinctFactor
+		// Base-column statistics are not conditional on filters or joins. Apply
+		// the same selectivity exponent used by aggregate cardinality costing,
+		// then cap by rows reaching this node. This keeps the rule conservative
+		// when a globally high-NDV column becomes low-NDV after selection.
+		distinctStateRows := estimateNDVAfterSelection(
+			distinctStateNDV, child.Stats)
+		if distinctStateRows > 0 {
+			distinctRatio := distinctStateRows / child.Stats.Outcnt
+			distinctFactor := 1 / math.Pow(distinctRatio, 0.8)
+			distinctStateShuffle = distinctStateRows >= threshHoldForShuffleGroup*distinctFactor
+		}
 	}
 	if !standardShuffle && !distinctStateShuffle {
 		return
@@ -1222,6 +1235,7 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 		// Hash/range shuffle then sends every row for one logical group to exactly
 		// one Group operator, removing the exact-state MergeGroup altogether.
 		minimumGroupNDV = shuffleDistinctGroupMinNDV
+		highestNDV = estimateNDVAfterSelection(highestNDV, child.Stats)
 	}
 	if highestNDV < minimumGroupNDV {
 		return
@@ -1298,6 +1312,23 @@ func countDistinctStateNDV(node *plan.Node, builder *QueryBuilder) float64 {
 		}
 	}
 	return maxNDV
+}
+
+func estimateNDVAfterSelection(ndv float64, stats *plan.Stats) float64 {
+	if ndv <= 0 || math.IsNaN(ndv) || math.IsInf(ndv, 0) ||
+		stats == nil || stats.Outcnt <= 0 ||
+		math.IsNaN(stats.Outcnt) || math.IsInf(stats.Outcnt, 0) {
+		return -1
+	}
+	estimate := min(ndv, stats.Outcnt)
+	selectivity := stats.Selectivity
+	// Zero is also the protobuf/default value for an unavailable estimate. Do
+	// not turn missing statistics into a certain empty result.
+	if selectivity > 0 && selectivity < 1 &&
+		!math.IsNaN(selectivity) && !math.IsInf(selectivity, 0) {
+		estimate = min(estimate, ndv*math.Pow(selectivity, 0.8))
+	}
+	return estimate
 }
 
 // default shuffle type for scan is hash

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
@@ -40,6 +41,7 @@ const (
 	ShuffleThreshHoldOfNDV          = 50000
 	ShuffleTypeThreshHoldLowerLimit = 16
 	ShuffleTypeThreshHoldUpperLimit = 1024
+	shuffleDistinctGroupMinNDV      = 64
 
 	overlapThreshold = 0.95
 	uniformThreshold = 0.3
@@ -1181,7 +1183,24 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 	}
 
 	factor := 1 / math.Pow((node.Stats.Outcnt/node.Stats.Selectivity/child.Stats.Outcnt), 0.8)
-	if node.Stats.HashmapStats.HashmapSize < threshHoldForShuffleGroup*factor {
+	standardShuffle := node.Stats.HashmapStats.HashmapSize >= threshHoldForShuffleGroup*factor
+
+	// The ordinary group estimate only accounts for the final number of groups.
+	// A mergeable COUNT(DISTINCT) also retains its exact argument set, which can
+	// be orders of magnitude larger. Compare that state with the input using the
+	// same reduction-factor model: shuffling a large input is justified only when
+	// the retained exact state is itself a material fraction of that input.
+	distinctStateNDV := countDistinctStateNDV(node, builder)
+	distinctStateShuffle := false
+	if distinctStateNDV > 0 && child.Stats.Outcnt > 0 {
+		// Base-column NDV can exceed the filtered child cardinality. The exact
+		// state cannot retain more distinct tuples than rows reaching this node.
+		distinctStateRows := min(distinctStateNDV, child.Stats.Outcnt)
+		distinctRatio := distinctStateRows / child.Stats.Outcnt
+		distinctFactor := 1 / math.Pow(distinctRatio, 0.8)
+		distinctStateShuffle = distinctStateRows >= threshHoldForShuffleGroup*distinctFactor
+	}
+	if !standardShuffle && !distinctStateShuffle {
 		return
 	}
 
@@ -1197,7 +1216,14 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 			idx = i
 		}
 	}
-	if highestNDV < ShuffleThreshHoldOfNDV {
+	minimumGroupNDV := float64(ShuffleThreshHoldOfNDV)
+	if distinctStateShuffle {
+		// Keep enough logical groups to expose useful parallel ownership.
+		// Hash/range shuffle then sends every row for one logical group to exactly
+		// one Group operator, removing the exact-state MergeGroup altogether.
+		minimumGroupNDV = shuffleDistinctGroupMinNDV
+	}
+	if highestNDV < minimumGroupNDV {
 		return
 	}
 
@@ -1211,7 +1237,9 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 		node.Stats.HashmapStats.ShuffleColIdx = int32(idx)
 		node.Stats.HashmapStats.Shuffle = true
 		determineShuffleType(hashCol, node, builder)
-		if node.Stats.HashmapStats.ShuffleType == plan.ShuffleType_Hash && node.Stats.HashmapStats.HashmapSize < threshHoldForHashShuffle {
+		if node.Stats.HashmapStats.ShuffleType == plan.ShuffleType_Hash &&
+			node.Stats.HashmapStats.HashmapSize < threshHoldForHashShuffle &&
+			!distinctStateShuffle {
 			node.Stats.HashmapStats.Shuffle = false
 		}
 	}
@@ -1236,6 +1264,40 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 		}
 	}
 
+}
+
+func countDistinctStateNDV(node *plan.Node, builder *QueryBuilder) float64 {
+	maxNDV := float64(-1)
+	if node == nil {
+		return maxNDV
+	}
+	for _, expr := range node.AggList {
+		if expr == nil {
+			continue
+		}
+		agg := expr.GetF()
+		if agg == nil || agg.Func == nil ||
+			uint64(agg.Func.Obj)&function.Distinct == 0 {
+			continue
+		}
+		baseID := int64(uint64(agg.Func.Obj) & function.DistinctMask)
+		functionID, _ := function.DecodeOverloadID(baseID)
+		if functionID != function.COUNT {
+			continue
+		}
+		for _, arg := range agg.Args {
+			if arg == nil {
+				continue
+			}
+			// Aggregate arguments do not normally have Expr.Ndv populated by
+			// ReCalcNodeStats. Resolve the estimate through the same table/expression
+			// statistics path used elsewhere in the planner. Retain Expr.Ndv as a
+			// fallback for remapped or synthesized expressions whose source column
+			// is no longer available in tag2Table.
+			maxNDV = max(maxNDV, arg.Ndv, getExprNdv(arg, builder))
+		}
+	}
+	return maxNDV
 }
 
 // default shuffle type for scan is hash

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -651,6 +651,25 @@ func TestDetermineShuffleForGroupByAccountsForCountDistinctState(t *testing.T) {
 	require.False(t, lowGroupNDV.Stats.HashmapStats.Shuffle,
 		"too few groups would serialize the high-cardinality distinct state")
 
+	emptyGroupingSet := newAggregate(1_000_000)
+	emptyGroupingSet.GroupingFlag = []bool{false}
+	determineShuffleForGroupBy(emptyGroupingSet, builder)
+	require.False(t, emptyGroupingSet.Stats.HashmapStats.Shuffle,
+		"an empty grouping set has no raw child key safe for pre-group shuffle")
+
+	activeGroupingKey := newAggregate(1_000_000)
+	activeGroupingKey.GroupBy = append(activeGroupingKey.GroupBy, &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_int32)},
+		Ndv:  1_000_000,
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 1, ColPos: 0}},
+	})
+	activeGroupingKey.GroupingFlag = []bool{false, true}
+	determineShuffleForGroupBy(activeGroupingKey, builder)
+	require.True(t, activeGroupingKey.Stats.HashmapStats.Shuffle,
+		"a grouping-set branch may still shuffle on an active key")
+	require.Equal(t, int32(1), activeGroupingKey.Stats.HashmapStats.ShuffleColIdx,
+		"inactive high-NDV keys must not become the distribution key")
+
 	child.Stats.Outcnt = 100_000_000
 	lowStateRatio := newAggregate(1_000_000)
 	determineShuffleForGroupBy(lowStateRatio, builder)

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -562,6 +562,99 @@ func TestDetermineShuffleForGroupByCanUseDependentHighNDVColumn(t *testing.T) {
 		"a logical group column determined by the physical key remains a safe distribution key")
 }
 
+func TestDetermineShuffleForGroupByAccountsForCountDistinctState(t *testing.T) {
+	statsCache := NewStatsCache()
+	stats := NewStatsInfo()
+	stats.TableCnt = 1_000_000
+	stats.NdvMap["user_id"] = 1_000_000
+	statsCache.Set(1, stats)
+	ctx := &statsCacheCompilerContext{
+		MockCompilerContext: &MockCompilerContext{ctx: context.Background()},
+		statsCache:          statsCache,
+	}
+	child := &plan.Node{
+		NodeType: plan.Node_TABLE_SCAN,
+		Stats: &plan.Stats{
+			Outcnt:       1_000_000,
+			HashmapStats: &plan.HashMapStats{},
+		},
+	}
+	groupBy := &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_int32)},
+		Ndv:  100,
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 1, ColPos: 0}},
+	}
+	countID := function.EncodeOverloadID(function.COUNT, 0)
+	newAggregate := func(distinctNDV float64) *plan.Node {
+		stats.NdvMap["user_id"] = distinctNDV
+		arg := &plan.Expr{
+			Typ:  plan.Type{Id: int32(types.T_int64)},
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 1, ColPos: 1}},
+		}
+		return &plan.Node{
+			NodeType: plan.Node_AGG,
+			Children: []int32{0},
+			GroupBy:  []*plan.Expr{DeepCopyExpr(groupBy)},
+			// Keep a regular aggregate beside COUNT(DISTINCT), matching the mixed
+			// aggregate shape that cannot use optimizeDistinctAgg's single-aggregate
+			// rewrite.
+			AggList: []*plan.Expr{
+				{
+					Expr: &plan.Expr_F{F: &plan.Function{
+						Func: &plan.ObjectRef{Obj: countID},
+						Args: []*plan.Expr{DeepCopyExpr(arg)},
+					}},
+				},
+				{
+					Expr: &plan.Expr_F{F: &plan.Function{
+						Func: &plan.ObjectRef{Obj: int64(uint64(countID) | function.Distinct)},
+						Args: []*plan.Expr{arg},
+					}},
+				},
+			},
+			Stats: &plan.Stats{
+				Outcnt:      100,
+				Selectivity: 1,
+				HashmapStats: &plan.HashMapStats{
+					HashmapSize: 100,
+				},
+			},
+		}
+	}
+	builder := &QueryBuilder{
+		qry:     &plan.Query{Nodes: []*plan.Node{child}},
+		compCtx: ctx,
+		tag2Table: map[int32]*plan.TableDef{1: {
+			TblId: 1,
+			Cols: []*plan.ColDef{
+				{Name: "region_id", Typ: plan.Type{Id: int32(types.T_int32)}},
+				{Name: "user_id", Typ: plan.Type{Id: int32(types.T_int64)}},
+			},
+		}},
+	}
+
+	large := newAggregate(1_000_000)
+	determineShuffleForGroupBy(large, builder)
+	require.True(t, large.Stats.HashmapStats.Shuffle)
+	require.Equal(t, int32(0), large.Stats.HashmapStats.ShuffleColIdx)
+
+	small := newAggregate(threshHoldForShuffleGroup)
+	determineShuffleForGroupBy(small, builder)
+	require.False(t, small.Stats.HashmapStats.Shuffle)
+
+	lowGroupNDV := newAggregate(1_000_000)
+	lowGroupNDV.GroupBy[0].Ndv = shuffleDistinctGroupMinNDV - 1
+	determineShuffleForGroupBy(lowGroupNDV, builder)
+	require.False(t, lowGroupNDV.Stats.HashmapStats.Shuffle,
+		"too few groups would serialize the high-cardinality distinct state")
+
+	child.Stats.Outcnt = 100_000_000
+	lowStateRatio := newAggregate(1_000_000)
+	determineShuffleForGroupBy(lowStateRatio, builder)
+	require.False(t, lowStateRatio.Stats.HashmapStats.Shuffle,
+		"do not redistribute a large input for a comparatively small exact state")
+}
+
 func TestDetermineShuffleForJoinFindsEligibleConditionAcrossPredicateOrder(t *testing.T) {
 	joinTypes := []plan.Node_JoinType{
 		plan.Node_INNER,

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 	"unsafe"
@@ -576,6 +577,7 @@ func TestDetermineShuffleForGroupByAccountsForCountDistinctState(t *testing.T) {
 		NodeType: plan.Node_TABLE_SCAN,
 		Stats: &plan.Stats{
 			Outcnt:       1_000_000,
+			Selectivity:  1,
 			HashmapStats: &plan.HashMapStats{},
 		},
 	}
@@ -585,6 +587,7 @@ func TestDetermineShuffleForGroupByAccountsForCountDistinctState(t *testing.T) {
 		Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 1, ColPos: 0}},
 	}
 	countID := function.EncodeOverloadID(function.COUNT, 0)
+	sumID := function.EncodeOverloadID(function.SUM, 0)
 	newAggregate := func(distinctNDV float64) *plan.Node {
 		stats.NdvMap["user_id"] = distinctNDV
 		arg := &plan.Expr{
@@ -653,6 +656,44 @@ func TestDetermineShuffleForGroupByAccountsForCountDistinctState(t *testing.T) {
 	determineShuffleForGroupBy(lowStateRatio, builder)
 	require.False(t, lowStateRatio.Stats.HashmapStats.Shuffle,
 		"do not redistribute a large input for a comparatively small exact state")
+
+	stats.TableCnt = 100_000_000
+	child.Stats.Outcnt = 1_000_000
+	child.Stats.Selectivity = 0.01
+	selective := newAggregate(1_000_000)
+	selective.GroupBy[0].Ndv = 100_000
+	determineShuffleForGroupBy(selective, builder)
+	require.False(t, selective.Stats.HashmapStats.Shuffle,
+		"table-level NDV must not claim that all distinct values survive selection")
+	selectiveManyOwners := newAggregate(100_000_000)
+	selectiveManyOwners.GroupBy[0].Ndv = 100_000
+	determineShuffleForGroupBy(selectiveManyOwners, builder)
+	require.True(t, selectiveManyOwners.Stats.HashmapStats.Shuffle,
+		"selection may retain shuffle when enough estimated owners and exact state remain")
+
+	child.Stats.Selectivity = 1
+	singleStage := newAggregate(100_000_000)
+	singleStage.Stats.HashmapStats.HashmapSize = 3_000_000
+	singleStage.Stats.HashmapStats.Shuffle = true
+	arg := DeepCopyExpr(singleStage.AggList[1].GetF().Args[0])
+	singleStage.AggList = append(singleStage.AggList, &plan.Expr{
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{Obj: int64(uint64(sumID) | function.Distinct)},
+			Args: []*plan.Expr{arg},
+		}},
+	})
+	determineShuffleForGroupBy(singleStage, builder)
+	require.False(t, singleStage.Stats.HashmapStats.Shuffle,
+		"an aggregate forced to one CN must clear even stale shuffle state")
+}
+
+func TestEstimateNDVAfterSelectionRejectsInvalidStats(t *testing.T) {
+	require.Equal(t, float64(-1), estimateNDVAfterSelection(100, nil))
+	require.Equal(t, float64(-1), estimateNDVAfterSelection(math.NaN(), &plan.Stats{Outcnt: 10}))
+	require.Equal(t, float64(-1), estimateNDVAfterSelection(100, &plan.Stats{Outcnt: math.Inf(1)}))
+	require.Equal(t, float64(10), estimateNDVAfterSelection(100, &plan.Stats{Outcnt: 10}))
+	require.InDelta(t, 100*math.Pow(0.01, 0.8),
+		estimateNDVAfterSelection(100, &plan.Stats{Outcnt: 100, Selectivity: 0.01}), 1e-9)
 }
 
 func TestDetermineShuffleForJoinFindsEligibleConditionAcrossPredicateOrder(t *testing.T) {


### PR DESCRIPTION
## What changed

Fixes #27672.

This change removes the serial high-NDV exact-state bottleneck exposed by ClickBench Q10 while preserving exact `COUNT(DISTINCT)` semantics.

- Teach group-shuffle planning to account for mergeable `COUNT(DISTINCT)` argument state, not only the small final group hash table. For a large exact state with enough logical groups, rows are partitioned by the group key before final aggregation, so each logical group has one owner and no exact-state MergeGroup is required.
- Estimate the DISTINCT state and effective group owners after selection. Low state/input ratios, too few surviving owners, unknown statistics, and unsupported keys stay on the existing topology.
- Explicitly disable shuffle for aggregate nodes that contain a non-mergeable DISTINCT state and are forced to one CN, including stale/reused shuffle state.
- At compile time, skip a normal group shuffle when the scheduled topology exposes only one physical aggregate owner. Single-CN `max_dop=1` reuses the ordinary non-shuffle topology; multi-CN DOP 1 and reused shuffles retain their parallel layouts.
- Relocate arena-backed skiplists during preflight capacity growth instead of rebuilding every retained node, and grow arenas geometrically.
- Clamp speculative geometric growth to MPool's real single-allocation limit before allocation. If account or pool capacity rejects the preferred arena while the old arena is live, retry the smaller former chunked-growth capacity. Terminal ownership/invariant errors are not retried.
- Use one monotonic target iterator and one cached Inserter for sorted state merges instead of restarting target searches for every candidate.

The independent cached-Inserter correctness fix and batch-fill preflight optimization are owned by #27688 and are already in `main`.

## Root cause

The single-aggregate DISTINCT rewrite does not apply to Q10 because the node also contains `SUM`, `COUNT`, and `AVG`. Exact `COUNT(DISTINCT)` states therefore remain inside each local Group operator. The planner costed shuffle from roughly 100 final `RegionID` groups and ignored the roughly one-million retained `UserID` values, so many partial ordered states converged on a serial MergeGroup. Fixed-size arena growth then repeatedly rebuilt historical state, while preflight and publication restarted ordered searches.

Two boundary regressions found during review are also closed:

- a geometric request could exceed MPool's roughly 2 GiB single-allocation ceiling and fail around a 1 GiB current arena even though the linear fallback still fit;
- a single-CN, single-owner plan could still compile a one-bucket Shuffle plus Dispatch, adding per-row hashing and pipeline overhead without exposing parallel aggregate ownership.

## Design and boundaries

DuckDB uses a separate radix-partitioned table keyed by group keys plus DISTINCT arguments, then finalizes those unique tuples into the regular aggregate table in parallel. This PR adopts the same partition-before-finalize principle through MatrixOne's existing shuffle-group topology; it does not introduce a second aggregate framework.

The planner rule is deliberately bounded:

- only mergeable `COUNT(DISTINCT)` contributes exact-state cost;
- table/expression NDV is capped by input rows and conservatively adjusted by available selection statistics;
- low exact-state/input ratios do not trigger a full-row shuffle;
- fewer than 64 estimated logical owners do not trigger;
- existing supported integer/string shuffle keys are required;
- non-mergeable DISTINCT aggregates retain the single-stage contract and cannot retain stale shuffle state;
- a normal shuffle must expose at least two physical aggregate owners after DOP and CN placement are known.

Extreme single-group or strongly skewed distributions cannot be solved by group-key shuffle and remain on the optimized executor merge path. A full independent radix DISTINCT pipeline could cover those shapes, but needs a separate design-reviewed change and better conditional/top-frequency statistics.

## Performance and memory

`BenchmarkCountDistinctSavedArgumentMerge` models 1,000,000 unique values, 16 partial states, and 100 groups on the same Apple M4 host:

- before this PR: 1.632 s/op;
- latest head, 5 runs: 146.6-153.5 ms/op, median 148.1 ms/op;
- improvement: about 10.6x-11.1x;
- latest allocation sample: 21-23 KiB/op and 4,813-4,819 allocs/op.

The allocator ceiling is checked only when an arena actually needs relocation, not per row or per key. Successful growth still uses the largest admissible geometric capacity; the smaller retry remains limited to classified account/pool capacity pressure.

## Validation

- full UT: `pkg/common/mpool`, `pkg/common/arenaskl`, `pkg/sql/colexec/aggexec`, `pkg/sql/colexec/group`, `pkg/sql/plan`, and `pkg/sql/compile`;
- full race: `pkg/common/arenaskl`, `pkg/sql/colexec/aggexec`, `pkg/sql/colexec/group`, and `pkg/sql/plan`;
- 100 race repetitions of arena relocation, account-pressure and allocator-ceiling fallback, and each new single-owner/multi-CN compiler topology counterexample;
- `go vet` on the affected/consumer packages with the repository CGo environment;
- `git diff --check`.

The tests cover forward/reverse arena links, values, duplicate rejection, post-growth insertion, poisoned/overlapping arenas, transactional allocation failure, account pressure, allocator ceiling, filtered NDV, insufficient logical owners, low state/input ratio, invalid statistics, stale single-stage shuffle state, single-owner single/multiple inputs, ordered aggregates, and multi-CN DOP 1. No sleeps, large-data UTs, or weakened assertions were added.
