### PR TITLE
fix: keep lockservice discovery available before CN admission

### DIFF
--- a/pkg/clusterservice/cluster.go
+++ b/pkg/clusterservice/cluster.go
@@ -122,8 +122,10 @@ func GetCNServiceWithoutWorkingStateWithContext(
 }
 
 // GetCNServiceRawWithContext returns the unadmitted built-in inventory. It is
-// intentionally narrow: a CN uses it only to prove that its own heartbeat
-// generation reached the authoritative snapshot before finishing bootstrap.
+// intentionally narrow: callers must be bootstrap or internal control-plane
+// protocols whose listeners are live before public admission and whose own
+// request identities fence stale service generations. Query scheduling and
+// other new-work routing must use the admission-aware inventory instead.
 func GetCNServiceRawWithContext(
 	ctx context.Context,
 	service MOCluster,
@@ -142,8 +144,8 @@ func GetCNServiceRawWithContext(
 	builtIn, ok := service.(*cluster)
 	if !ok {
 		// External implementations cannot expose the built-in snapshot directly.
-		// This helper is used only by CN-local bootstrap, so retain their existing
-		// synchronous inventory contract and cancellation checks.
+		// Retain their existing synchronous inventory contract and cancellation
+		// checks; implementations that apply extra admission policy remain safe.
 		service.GetCNServiceWithoutWorkingState(selector, apply)
 		return ctx.Err()
 	}

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -300,6 +300,27 @@ func (c *client) AsyncSend(ctx context.Context, request *pb.Request) (*morpc.Fut
 	return c.asyncSend(ctx, request, true)
 }
 
+// lookupLockServiceAddress resolves an internal lock protocol endpoint from
+// the raw CN inventory. A CN starts and identity-fences its lock RPC server
+// before it becomes eligible for new SQL work, so public admission filtering
+// must not hide an existing lock-table owner during that startup window.
+func (c *client) lookupLockServiceAddress(
+	ctx context.Context,
+	serviceID string,
+) (string, error) {
+	var address string
+	err := clusterservice.GetCNServiceRawWithContext(
+		ctx,
+		c.cluster,
+		clusterservice.NewServiceIDSelector(serviceID),
+		func(s metadata.CNService) bool {
+			address = s.LockServiceAddress
+			return false
+		},
+	)
+	return address, err
+}
+
 func (c *client) asyncSend(
 	ctx context.Context,
 	request *pb.Request,
@@ -319,18 +340,6 @@ func (c *client) asyncSend(
 		}
 		return nil, err
 	}
-	lookupCN := func(
-		selector clusterservice.Selector,
-		apply func(metadata.CNService) bool,
-	) error {
-		return clusterservice.GetCNServiceWithoutWorkingStateWithContext(
-			ctx,
-			c.cluster,
-			selector,
-			apply,
-		)
-	}
-
 	var sid = ""
 	var address string
 	for i := 0; i < 2; i++ {
@@ -338,12 +347,7 @@ func (c *client) asyncSend(
 		switch request.Method {
 		case pb.Method_ForwardLock:
 			sid = getUUIDFromServiceIdentifier(request.Lock.Options.ForwardTo)
-			lookupErr = lookupCN(
-				clusterservice.NewServiceIDSelector(sid),
-				func(s metadata.CNService) bool {
-					address = s.LockServiceAddress
-					return false
-				})
+			address, lookupErr = c.lookupLockServiceAddress(ctx, sid)
 		case pb.Method_Lock,
 			pb.Method_Unlock,
 			pb.Method_BatchUnlock,
@@ -351,53 +355,23 @@ func (c *client) asyncSend(
 			pb.Method_GetLockHolder,
 			pb.Method_KeepRemoteLock:
 			sid = getUUIDFromServiceIdentifier(request.LockTable.ServiceID)
-			lookupErr = lookupCN(
-				clusterservice.NewServiceIDSelector(sid),
-				func(s metadata.CNService) bool {
-					address = s.LockServiceAddress
-					return false
-				})
+			address, lookupErr = c.lookupLockServiceAddress(ctx, sid)
 		case pb.Method_ValidateService:
 			sid = getUUIDFromServiceIdentifier(request.ValidateService.ServiceID)
-			lookupErr = lookupCN(
-				clusterservice.NewServiceIDSelector(sid),
-				func(s metadata.CNService) bool {
-					address = s.LockServiceAddress
-					return false
-				})
+			address, lookupErr = c.lookupLockServiceAddress(ctx, sid)
 		case pb.Method_GetWaitingList,
 			pb.Method_GetTxnWaitingListOnLockTable:
 			sid = getUUIDFromServiceIdentifier(request.GetWaitingList.Txn.CreatedOn)
-			lookupErr = lookupCN(
-				clusterservice.NewServiceIDSelector(sid),
-				func(s metadata.CNService) bool {
-					address = s.LockServiceAddress
-					return false
-				})
+			address, lookupErr = c.lookupLockServiceAddress(ctx, sid)
 		case pb.Method_GetActiveTxn:
 			sid = getUUIDFromServiceIdentifier(request.GetActiveTxn.ServiceID)
-			lookupErr = lookupCN(
-				clusterservice.NewServiceIDSelector(sid),
-				func(s metadata.CNService) bool {
-					address = s.LockServiceAddress
-					return false
-				})
+			address, lookupErr = c.lookupLockServiceAddress(ctx, sid)
 		case pb.Method_CheckActiveTxn:
 			sid = getUUIDFromServiceIdentifier(request.CheckActiveTxn.ServiceID)
-			lookupErr = lookupCN(
-				clusterservice.NewServiceIDSelector(sid),
-				func(s metadata.CNService) bool {
-					address = s.LockServiceAddress
-					return false
-				})
+			address, lookupErr = c.lookupLockServiceAddress(ctx, sid)
 		case pb.Method_AbortRemoteDeadlockTxn:
 			sid = getUUIDFromServiceIdentifier(request.AbortRemoteDeadlockTxn.Txn.WaiterAddress)
-			lookupErr = lookupCN(
-				clusterservice.NewServiceIDSelector(sid),
-				func(s metadata.CNService) bool {
-					address = s.LockServiceAddress
-					return false
-				})
+			address, lookupErr = c.lookupLockServiceAddress(ctx, sid)
 		default:
 			values := c.cluster.GetAllTNServices()
 			if len(values) > 0 {
@@ -427,7 +401,9 @@ func (c *client) asyncSend(
 	}
 	if address == "" {
 		var cns []string
-		if err := lookupCN(
+		if err := clusterservice.GetCNServiceRawWithContext(
+			ctx,
+			c.cluster,
 			clusterservice.NewSelectAll(),
 			func(s metadata.CNService) bool {
 				cns = append(cns, s.ServiceID)
@@ -439,7 +415,8 @@ func (c *client) asyncSend(
 			zap.String("target", sid),
 			zap.Any("cns", cns),
 			zap.String("request", request.DebugString()))
-
+		return returnError(moerr.NewBackendCannotConnectNoCtx(
+			"lockservice service " + sid + " is absent from cluster inventory"))
 	}
 	transport := c.client
 	if keeperOwnsRequest {
@@ -673,15 +650,7 @@ func (c *client) ResetBackend(parent context.Context, serviceID string) (err err
 	}
 
 	lookupAddress := func() (string, error) {
-		var address string
-		err := clusterservice.GetCNServiceWithoutWorkingStateWithContext(
-			ctx,
-			c.cluster,
-			clusterservice.NewServiceIDSelector(sid),
-			func(s metadata.CNService) bool {
-				address = s.LockServiceAddress
-				return false
-			})
+		address, err := c.lookupLockServiceAddress(ctx, sid)
 		if err != nil {
 			return "", moerr.AttachCause(ctx, err)
 		}
@@ -802,16 +771,7 @@ func (c *client) ResetValidationBackend(
 	}
 	sid := getUUIDFromServiceIdentifier(serviceID)
 	lookupAddress := func() (string, error) {
-		var address string
-		err := clusterservice.GetCNServiceWithoutWorkingStateWithContext(
-			ctx,
-			c.cluster,
-			clusterservice.NewServiceIDSelector(sid),
-			func(s metadata.CNService) bool {
-				address = s.LockServiceAddress
-				return false
-			},
-		)
+		address, err := c.lookupLockServiceAddress(ctx, sid)
 		if err != nil {
 			return "", moerr.AttachCause(ctx, err)
 		}

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -86,6 +86,17 @@ type blockedClusterClient struct {
 	release chan struct{}
 }
 
+type fixedClusterClient struct {
+	details logpb.ClusterDetails
+}
+
+func (c *fixedClusterClient) GetClusterDetails(ctx context.Context) (logpb.ClusterDetails, error) {
+	if err := ctx.Err(); err != nil {
+		return logpb.ClusterDetails{}, err
+	}
+	return c.details, nil
+}
+
 func (c *blockedClusterClient) GetClusterDetails(ctx context.Context) (logpb.ClusterDetails, error) {
 	select {
 	case c.started <- struct{}{}:
@@ -1368,6 +1379,106 @@ func TestNewClientWithMOCluster(t *testing.T) {
 	defer func() {
 		assert.NoError(t, c.Close())
 	}()
+}
+
+func TestLockServiceDiscoveryUsesPendingCNInventory(t *testing.T) {
+	service := t.Name()
+	runtime.SetupServiceBasedRuntime(service, runtime.DefaultRuntime())
+	cluster := clusterservice.NewMOCluster(
+		service,
+		&fixedClusterClient{details: logpb.ClusterDetails{
+			ViewMetadataAdmission: &logpb.ViewMetadataAdmission{
+				Enabled: true,
+				Epoch:   4,
+			},
+			CNStores: []logpb.CNStore{{
+				UUID:                            "cn-id",
+				LockServiceAddress:              "cn.example:18101",
+				WorkState:                       metadata.WorkState_Working,
+				ViewMetadataAdmissionGeneration: 11,
+			}},
+		}},
+		time.Hour,
+	)
+	defer cluster.Close()
+	require.NoError(t,
+		cluster.(clusterservice.AuthoritativeRefresher).Refresh(context.Background()))
+
+	var publicRoutes int
+	require.NoError(t, clusterservice.GetCNServiceWithoutWorkingStateWithContext(
+		context.Background(),
+		cluster,
+		clusterservice.NewServiceIDSelector("cn-id"),
+		func(metadata.CNService) bool {
+			publicRoutes++
+			return true
+		},
+	))
+	require.Zero(t, publicRoutes,
+		"a pending CN must remain unavailable to public query routing")
+
+	normalRPCClient := &closeTrackingRPCClient{}
+	activeTxnRPCClient := &closeTrackingRPCClient{}
+	validationRPCClient := &closeTrackingRPCClient{}
+	c := &client{
+		service:          service,
+		cluster:          cluster,
+		client:           normalRPCClient,
+		activeTxnClient:  activeTxnRPCClient,
+		validationClient: validationRPCClient,
+		logger:           getLogger(service),
+		recoveryBackends: make(map[string]recoveryBackend),
+		resolveBackend: func(_ context.Context, address string) (string, error) {
+			return address, nil
+		},
+	}
+	serviceID := "0000000000000000000cn-id"
+
+	_, err := c.AsyncSend(context.Background(), &lock.Request{
+		Method:    lock.Method_Unlock,
+		LockTable: lock.LockTable{ServiceID: serviceID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cn.example:18101"}, normalRPCClient.sent)
+
+	require.NoError(t, c.ResetBackend(context.Background(), serviceID))
+	require.Equal(t,
+		[]string{"cn.example:18101", "cn.example:18101"},
+		activeTxnRPCClient.closed,
+	)
+
+	require.NoError(t, c.ResetValidationBackend(context.Background(), serviceID))
+	require.Equal(t,
+		[]string{"cn.example:18101", "cn.example:18101"},
+		validationRPCClient.closed,
+	)
+}
+
+func TestAsyncSendMissingLockServiceRouteDoesNotReachTransport(t *testing.T) {
+	service := t.Name()
+	runtime.SetupServiceBasedRuntime(service, runtime.DefaultRuntime())
+	cluster := clusterservice.NewMOCluster(
+		service,
+		nil,
+		0,
+		clusterservice.WithDisableRefresh(),
+	)
+	defer cluster.Close()
+	transport := &closeTrackingRPCClient{}
+	c := &client{
+		service: service,
+		cluster: cluster,
+		client:  transport,
+		logger:  getLogger(service),
+	}
+
+	_, err := c.AsyncSend(context.Background(), &lock.Request{
+		Method:    lock.Method_Unlock,
+		LockTable: lock.LockTable{ServiceID: "missing"},
+	})
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect))
+	require.Empty(t, transport.sent,
+		"an unresolved route must not be delegated to an RPC transport")
 }
 
 func TestResetBackendPinsAndReplacesResolvedEndpoint(t *testing.T) {


### PR DESCRIPTION
Fixes #27699.

## Root cause
The admission-aware CN inventory is correct for new SQL work, but lockservice used it to resolve existing internal lock-protocol owners. A CN lock RPC server is live before public ingress is admission-ready, so startup could hide the owner and send an empty backend address.

## Change
- use the raw built-in CN inventory only for incarnation-fenced lockservice RPC discovery
- route async sends, active-txn backend reset, and validation backend reset through the same lookup
- preserve `ErrBackendCannotConnect` for a genuinely absent route and avoid passing an empty address to MORPC
- document the raw-inventory boundary and add deterministic pending-CN and missing-route regressions

## Safety and performance
Public query scheduling remains admission-filtered. No new retries, waits, goroutines, locks, or persistent state; normal lookup remains one O(CN) snapshot scan.

## Validation
- `pkg/lockservice` full normal and race
- `pkg/clusterservice` normal and race
- focused regression race x20
- `pkg/tests/partition -run ^TestAlterTableDropPartition$` normal and race
- `go vet ./pkg/clusterservice ./pkg/lockservice`
- `git diff --check`