### PR TITLE
ci: parallelize native builds in UT jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ UT_PARALLEL ?= 1
 # omit -j and preserve recursive make's jobserver contract: a plain make stays
 # serial while a developer's `make -jN` remains parallel.
 NATIVE_BUILD_JOBS ?= $(if $(filter-out 1,$(UT_PARALLEL)),$(UT_PARALLEL))
-ifeq ($(NATIVE_BUILD_JOBS),0)
+ifeq ($(strip $(NATIVE_BUILD_JOBS)),0)
 $(error NATIVE_BUILD_JOBS and UT_PARALLEL must be positive)
 endif
 ENABLE_UT ?= "false"

--- a/Makefile
+++ b/Makefile
@@ -292,11 +292,11 @@ endif
 
 .PHONY: cgo
 cgo: thirdparties
-	@(cd cgo; ${MAKE} ${CGO_DEBUG_OPT})
+	@(cd cgo; ${MAKE} -j$(NATIVE_BUILD_JOBS) ${CGO_DEBUG_OPT})
 
 .PHONY: thirdparties
 thirdparties:
-	@(cd thirdparties; ${MAKE})
+	@(cd thirdparties; ${MAKE} -j$(NATIVE_BUILD_JOBS))
 	cp -r $(THIRDPARTIES_INSTALL_DIR)/lib $(ROOT_DIR)/
 
 # Stage the jieba dictionary next to the binary, the same way thirdparties/lib
@@ -411,6 +411,11 @@ endif
 # bvt and unit test
 ###############################################################################
 UT_PARALLEL ?= 1
+# Native compilation runs before Go tests, so it can use the same bounded CPU
+# budget without increasing peak race-test memory. Developer builds stay
+# serial by default; CI's explicit UT_PARALLEL value enables parallel native
+# compilation as well.
+NATIVE_BUILD_JOBS ?= $(UT_PARALLEL)
 ENABLE_UT ?= "false"
 # These are public mirrors, not policy gatekeepers. Fall through on transient
 # errors as well as 404/410 responses so one unhealthy mirror cannot block CI.

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,14 @@ build-typecheck: build
 # Excluding frontend test cases temporarily
 # Argument SKIP_TEST to skip a specific go test
 .PHONY: ut
-ut: config cgo thirdparties
+UT_PREREQUISITES := cgo thirdparties
+# CI times config separately to monitor module-proxy health. Let that caller
+# attest that the exact checkout already passed config instead of verifying the
+# same package graph twice; direct developer invocations retain the prerequisite.
+ifneq ($(UT_CONFIGURED),1)
+UT_PREREQUISITES += config
+endif
+ut: $(UT_PREREQUISITES)
 	$(info [Unit testing])
 ifeq ($(UNAME_S),darwin)
 	@cd optools && ./run_ut.sh UT $(SKIP_TEST)

--- a/Makefile
+++ b/Makefile
@@ -292,11 +292,11 @@ endif
 
 .PHONY: cgo
 cgo: thirdparties
-	@(cd cgo; ${MAKE} -j$(NATIVE_BUILD_JOBS) ${CGO_DEBUG_OPT})
+	@(cd cgo; ${MAKE} $(if $(NATIVE_BUILD_JOBS),-j$(NATIVE_BUILD_JOBS)) ${CGO_DEBUG_OPT})
 
 .PHONY: thirdparties
 thirdparties:
-	@(cd thirdparties; ${MAKE} -j$(NATIVE_BUILD_JOBS))
+	@(cd thirdparties; ${MAKE} $(if $(NATIVE_BUILD_JOBS),-j$(NATIVE_BUILD_JOBS)))
 	cp -r $(THIRDPARTIES_INSTALL_DIR)/lib $(ROOT_DIR)/
 
 # Stage the jieba dictionary next to the binary, the same way thirdparties/lib
@@ -418,11 +418,14 @@ endif
 # bvt and unit test
 ###############################################################################
 UT_PARALLEL ?= 1
-# Native compilation runs before Go tests, so it can use the same bounded CPU
-# budget without increasing peak race-test memory. Developer builds stay
-# serial by default; CI's explicit UT_PARALLEL value enables parallel native
-# compilation as well.
-NATIVE_BUILD_JOBS ?= $(UT_PARALLEL)
+# Native compilation runs before Go tests, so it can use an explicit UT CPU
+# budget without increasing peak race-test memory. With the default UT value,
+# omit -j and preserve recursive make's jobserver contract: a plain make stays
+# serial while a developer's `make -jN` remains parallel.
+NATIVE_BUILD_JOBS ?= $(if $(filter-out 1,$(UT_PARALLEL)),$(UT_PARALLEL))
+ifeq ($(NATIVE_BUILD_JOBS),0)
+$(error NATIVE_BUILD_JOBS and UT_PARALLEL must be positive)
+endif
 ENABLE_UT ?= "false"
 # These are public mirrors, not policy gatekeepers. Fall through on transient
 # errors as well as 404/410 responses so one unhealthy mirror cannot block CI.

--- a/thirdparties/Makefile
+++ b/thirdparties/Makefile
@@ -98,7 +98,7 @@ init:
 	mkdir -p install
 	mkdir -p install/include install/lib
 
-usearch: stringzilla fp16 simsimd install/include/usearch.h
+usearch: install/include/usearch.h
 
 stringzilla: install/include/stringzilla/stringzilla.h
 
@@ -110,28 +110,28 @@ simsimd: install/include/simsimd/simsimd.h
 
 xxhash: install/include/xxhash.h
 
-install/include/xxhash.h:
+install/include/xxhash.h: | init
 	mkdir -p $(XXHASH_TMP)
-	tar zxvf $(XXHASH_TAR) -C $(XXHASH_TMP) --strip-components=1
+	tar zxf $(XXHASH_TAR) -C $(XXHASH_TMP) --strip-components=1
 	cp $(XXHASH_TMP)/xxhash.h install/include
 	rm -rf $(XXHASH_TMP)
 
-install/include/fp16.h:
+install/include/fp16.h: | init
 	rm -rf $(FP16_DIR)
 	mkdir -p $(FP16_DIR)
-	tar zxvf $(FP16_TAR) -C $(FP16_DIR) --strip-components=1
+	tar zxf $(FP16_TAR) -C $(FP16_DIR) --strip-components=1
 	cp -r $(FP16_DIR)/include/* install/include
 
-install/include/simsimd/simsimd.h:
+install/include/simsimd/simsimd.h: | init
 	rm -rf $(SIMSIMD_DIR)
 	mkdir -p $(SIMSIMD_DIR)
-	tar zxvf $(SIMSIMD_TAR) -C $(SIMSIMD_DIR) --strip-components=1
+	tar zxf $(SIMSIMD_TAR) -C $(SIMSIMD_DIR) --strip-components=1
 	cp -r $(SIMSIMD_DIR)/include/* install/include
 
-install/include/stringzilla/stringzilla.h:
+install/include/stringzilla/stringzilla.h: | init
 	rm -rf $(STRINGZILLA_DIR)
 	mkdir -p $(STRINGZILLA_DIR)
-	tar zxvf $(STRINGZILLA_TAR) -C $(STRINGZILLA_DIR) --strip-components=1
+	tar zxf $(STRINGZILLA_TAR) -C $(STRINGZILLA_DIR) --strip-components=1
 	cp -r $(STRINGZILLA_DIR)/include/* install/include
 
 USEARCH_CMAKE_FLAG := -DUSEARCH_BUILD_BENCH_CPP=OFF -DUSEARCH_BUILD_TEST_C=OFF -DUSEARCH_BUILD_TEST_CPP=OFF -DUSEARCH_BUILD_LIB_C=ON -DCMAKE_CXX_FLAGS=-I$(PWD)/install/include -DCMAKE_POLICY_VERSION_MINIMUM=3.5
@@ -151,10 +151,10 @@ ifeq ($(MO_CL_SIMSIMD),1)
   endif
 endif
 
-install/include/usearch.h:
+install/include/usearch.h: install/include/fp16.h install/include/simsimd/simsimd.h install/include/stringzilla/stringzilla.h | init
 	rm -rf $(USEARCH_DIR)
 	mkdir -p $(USEARCH_DIR)
-	tar zxvf $(USEARCH_TAR) -C $(USEARCH_DIR) --strip-components=1
+	tar zxf $(USEARCH_TAR) -C $(USEARCH_DIR) --strip-components=1
 	mkdir -p $(USEARCH_DIR)/fp16 $(USEARCH_DIR)/simsimd $(USEARCH_DIR)/stringzilla
 	cp -r $(FP16_DIR)/* $(USEARCH_DIR)/fp16
 	cp -r $(SIMSIMD_DIR)/* $(USEARCH_DIR)/simsimd
@@ -183,7 +183,7 @@ jemalloc: install/lib/libjemalloc.a
 # jemalloc is statically linked into mo-service and all public symbols are
 # prefixed with mo_je_. This keeps Memory Cache's allocator independent from
 # libc malloc and the C/C++ dependencies already linked into MatrixOne.
-install/lib/libjemalloc.a:
+install/lib/libjemalloc.a: | init
 	@actual="$$(shasum -a 256 $(JEMALLOC_TAR) | awk '{print $$1}')"; \
 	if [ "$$actual" != "$(JEMALLOC_SHA256)" ]; then \
 		echo "jemalloc tarball checksum mismatch: $$actual" >&2; \
@@ -200,7 +200,7 @@ install/lib/libjemalloc.a:
 
 # Build CRoaring as a static lib from its single-file amalgamation, and install
 # the amalgamated header. Used by the cgo doc_id filter (roaring64 bitset).
-install/lib/libroaring.a:
+install/lib/libroaring.a: | init
 	rm -rf $(CROARING_TMP)
 	mkdir -p $(CROARING_TMP)
 	tar zxf $(CROARING_TAR) -C $(CROARING_TMP) --strip-components=1


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27705

## What this PR does / why we need it:

The UT runner already receives an explicit `UT_PARALLEL` CPU budget, but native third-party/CGo preparation ignored it and built serially before race testing began. The analyzed job spent about 5m03s in this phase (about 4m22s in third parties and 33s in CGo).

This change:

- reuses the existing bounded UT CPU budget for third-party and CGo compilation;
- makes the third-party dependency graph safe for parallel make by declaring generated-header and install-directory prerequisites;
- keeps ordinary developer builds serial by default;
- adds an opt-in for CI to attest that the exact checkout already passed the separately timed `config` canary, avoiding duplicate package-graph verification;
- reduces archive extraction log volume.

No Go test, package selection, race flag, coverage path, assertion, timeout, or fixture is changed. Native compilation completes before race tests, so this does not raise the race phase process or memory budget.

The companion workflow change is matrixorigin/CI#433. It is backward-compatible with older MatrixOne branches, which ignore the new variable and retain the duplicate verification.

### Validation

Same commit, clean native build:

- baseline serial: 80.43s wall;
- candidate parallel run 1: 18.92s wall;
- candidate parallel run 2: 17.75s wall;
- reduction: 76.5% to 77.9%.

Correctness checks:

- default `NATIVE_BUILD_JOBS=1` path completed successfully;
- serial and parallel `libmo.so` / `libmo.a` SHA256 hashes are identical;
- forced compiler failure propagates through recursive make with non-zero status;
- native library/archive formats and exported `libmo` symbols verified;
- deterministic CGo-transitive external-link test passed with `-count=1`;
- CGo-direct package compiled and linked successfully;
- default `make -n ut` retains one config verification, while `UT_CONFIGURED=1` removes only that prerequisite and retains the full native/UT path;
- `git diff --check` passed.

The analyzed explicit config took 28.158s; the companion change avoids repeating the same phony prerequisite while preserving the proxy canary. Full critical-path analysis and follow-up constraints are tracked in #27705.