### PR TITLE
fix: validate implicit default role grants

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -1330,6 +1330,8 @@ const (
 	// operations on the mo_user_grant
 	getRoleOfUserFormat = `select r.role_id from  mo_catalog.mo_role r, mo_catalog.mo_user_grant ug where ug.role_id = r.role_id and ug.user_id = %d and r.role_name = "%s";`
 
+	getRoleNameOfUserRoleFormat = `select r.role_name from mo_catalog.mo_role r, mo_catalog.mo_user_grant ug where ug.role_id = r.role_id and ug.user_id = %d and r.role_id = %d;`
+
 	getRoleIdOfUserIdFormat = `select role_id,with_grant_option from mo_catalog.mo_user_grant where user_id = %d;`
 
 	checkUserGrantFormat = `select role_id,user_id,with_grant_option from mo_catalog.mo_user_grant where role_id = %d and user_id = %d;`
@@ -1868,6 +1870,10 @@ func getSqlForRoleOfUser(ctx context.Context, userID int64, roleName string) (st
 		return "", err
 	}
 	return fmt.Sprintf(getRoleOfUserFormat, userID, roleName), nil
+}
+
+func getSqlForRoleNameOfUserRole(userID, roleID int64) string {
+	return fmt.Sprintf(getRoleNameOfUserRoleFormat, userID, roleID)
 }
 
 func getSqlForRoleIdOfUserId(userId int) string {

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -2118,21 +2118,21 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 		return nil, err
 	}
 
-	//the default_role in the mo_user table.
-	//the default_role is always valid. public or other valid role.
-	defaultRoleID, err = userRsset[0].GetInt64(tenantCtx, 0, 2)
+	// The catalog value may be NULL or stale after a prior REVOKE. Do not use
+	// it as an active role until the implicit-login path validates the grant.
+	defaultRoleID, defaultRoleIDValid, err := readStoredDefaultRoleID(tenantCtx, userRsset[0])
 	if err != nil {
 		return nil, err
 	}
 
 	tenant.SetUserID(uint32(userID))
-	tenant.SetDefaultRoleID(uint32(defaultRoleID))
 	ses.timestampMap[TSCheckUserEnd] = time.Now()
 	v2.CheckUserDurationHistogram.Observe(ses.timestampMap[TSCheckUserEnd].Sub(ses.timestampMap[TSCheckUserStart]).Seconds())
 
 	/*
 		login case 1: tenant:user
 		1.get the default_role of the user in mo_user
+		2.validate that the role is still granted, otherwise use the public grant
 
 		login case 2: tenant:user:role
 		1.check the role has been granted to the user
@@ -2182,21 +2182,13 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 		v2.CheckRoleDurationHistogram.Observe(ses.timestampMap[TSCheckRoleEnd].Sub(ses.timestampMap[TSCheckRoleStart]).Seconds())
 	} else {
 		ses.timestampMap[TSCheckRoleStart] = time.Now()
-		ses.Debugf(tenantCtx, "check designated role of user %s.", tenant)
-		//the get name of default_role from mo_role
-		sql := getSqlForRoleNameOfRoleId(defaultRoleID)
-		rsset, err = executeSQLInBackgroundSession(tenantCtx, bh, sql)
+		ses.Debugf(tenantCtx, "validate implicit default role of user %s.", tenant)
+		defaultRoleID, defaultRole, err = resolveImplicitDefaultRole(
+			tenantCtx, bh, userID, defaultRoleID, defaultRoleIDValid)
 		if err != nil {
 			return nil, err
 		}
-		if !execResultArrayHasData(rsset) {
-			return nil, moerr.NewInternalErrorf(tenantCtx, "get the default role of the user %s failed", tenant.GetUser())
-		}
-
-		defaultRole, err = rsset[0].GetString(tenantCtx, 0, 0)
-		if err != nil {
-			return nil, err
-		}
+		tenant.SetDefaultRoleID(uint32(defaultRoleID))
 		tenant.SetDefaultRole(defaultRole)
 		ses.timestampMap[TSCheckRoleEnd] = time.Now()
 		v2.CheckRoleDurationHistogram.Observe(ses.timestampMap[TSCheckRoleEnd].Sub(ses.timestampMap[TSCheckRoleStart]).Seconds())
@@ -2358,6 +2350,72 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 	ses.SetCreateVersion(createVersion)
 
 	return GetPassWord(pwd)
+}
+
+func readStoredDefaultRoleID(ctx context.Context, userResult ExecResult) (int64, bool, error) {
+	isNull, err := userResult.ColumnIsNull(ctx, 0, 2)
+	if err != nil {
+		return 0, false, err
+	}
+	if isNull {
+		return 0, false, nil
+	}
+
+	roleID, err := userResult.GetInt64(ctx, 0, 2)
+	if err != nil {
+		return 0, false, err
+	}
+	if roleID < 0 || roleID > int64(^uint32(0)) {
+		return 0, false, nil
+	}
+	return roleID, true, nil
+}
+
+// resolveImplicitDefaultRole returns a role that is currently granted to the
+// user. A stale, NULL, invalid, or missing catalog default falls back to the
+// user's public grant; it is never activated directly from mo_user metadata.
+func resolveImplicitDefaultRole(
+	ctx context.Context,
+	bh BackgroundExec,
+	userID int64,
+	storedRoleID int64,
+	storedRoleIDValid bool,
+) (int64, string, error) {
+	roleID := storedRoleID
+	if !storedRoleIDValid {
+		roleID = publicRoleID
+	}
+
+	for {
+		sql := getSqlForRoleNameOfUserRole(userID, roleID)
+		rsset, err := executeSQLInBackgroundSession(ctx, bh, sql)
+		if err != nil {
+			return 0, "", err
+		}
+		if execResultArrayHasData(rsset) {
+			roleNameIsNull, err := rsset[0].ColumnIsNull(ctx, 0, 0)
+			if err != nil {
+				return 0, "", err
+			}
+			roleName, err := rsset[0].GetString(ctx, 0, 0)
+			if err != nil {
+				return 0, "", err
+			}
+			roleNameValid := !roleNameIsNull && roleName != ""
+			if roleID == publicRoleID {
+				roleNameValid = roleNameValid && isPublicRole(roleName)
+			}
+			if roleNameValid {
+				return roleID, roleName, nil
+			}
+		}
+
+		if roleID == publicRoleID {
+			return 0, "", moerr.NewInternalErrorf(ctx,
+				"get a valid default role of the user %d failed", userID)
+		}
+		roleID = publicRoleID
+	}
 }
 
 func (ses *Session) MaybeUpgradeTenant(ctx context.Context, curVersion string, tenantID int64) error {

--- a/pkg/frontend/session_authenticate_test.go
+++ b/pkg/frontend/session_authenticate_test.go
@@ -1,0 +1,217 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+)
+
+func TestResolveImplicitDefaultRole(t *testing.T) {
+	const (
+		userID   = int64(42)
+		readerID = int64(7)
+	)
+	ctx := context.Background()
+	readerSQL := getSqlForRoleNameOfUserRole(userID, readerID)
+	publicSQL := getSqlForRoleNameOfUserRole(userID, publicRoleID)
+
+	t.Run("granted default role", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[readerSQL] = newMrsForRoleName([][]interface{}{{"reader"}})
+
+		roleID, roleName, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+		require.NoError(t, err)
+		require.Equal(t, readerID, roleID)
+		require.Equal(t, "reader", roleName)
+		require.Equal(t, []string{readerSQL}, bh.executedSQLs)
+	})
+
+	for _, name := range []string{
+		"revoked default role",
+		"missing default role metadata",
+		"NULL default role name",
+		"empty default role name",
+	} {
+		t.Run(name, func(t *testing.T) {
+			bh := &backgroundExecTest{}
+			bh.init()
+			switch name {
+			case "NULL default role name":
+				bh.sql2result[readerSQL] = newMrsForRoleName([][]interface{}{{nil}})
+			case "empty default role name":
+				bh.sql2result[readerSQL] = newMrsForRoleName([][]interface{}{{""}})
+			default:
+				bh.sql2result[readerSQL] = newMrsForRoleName(nil)
+			}
+			bh.sql2result[publicSQL] = newMrsForRoleName([][]interface{}{{publicRoleName}})
+
+			roleID, roleName, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+			require.NoError(t, err)
+			require.Equal(t, int64(publicRoleID), roleID)
+			require.Equal(t, publicRoleName, roleName)
+			require.Equal(t, []string{readerSQL, publicSQL}, bh.executedSQLs)
+		})
+	}
+
+	for _, tc := range []struct {
+		name  string
+		id    int64
+		valid bool
+	}{
+		{name: "NULL catalog default", valid: false},
+		{name: "negative catalog default", id: -1, valid: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bh := &backgroundExecTest{}
+			bh.init()
+			bh.sql2result[publicSQL] = newMrsForRoleName([][]interface{}{{publicRoleName}})
+
+			roleID, roleName, err := resolveImplicitDefaultRole(ctx, bh, userID, tc.id, tc.valid)
+			require.NoError(t, err)
+			require.Equal(t, int64(publicRoleID), roleID)
+			require.Equal(t, publicRoleName, roleName)
+			require.Equal(t, []string{publicSQL}, bh.executedSQLs)
+		})
+	}
+
+	t.Run("regrant restores stored default", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[readerSQL] = newMrsForRoleName([][]interface{}{{"reader"}})
+
+		roleID, roleName, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+		require.NoError(t, err)
+		require.Equal(t, readerID, roleID)
+		require.Equal(t, "reader", roleName)
+	})
+
+	t.Run("missing public grant rejects login", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[readerSQL] = newMrsForRoleName(nil)
+		bh.sql2result[publicSQL] = newMrsForRoleName(nil)
+
+		_, _, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+		require.ErrorContains(t, err, "get a valid default role")
+	})
+
+	for _, tc := range []struct {
+		name  string
+		value interface{}
+	}{
+		{name: "NULL public role name", value: nil},
+		{name: "empty public role name", value: ""},
+		{name: "mismatched public role name", value: "reader"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bh := &backgroundExecTest{}
+			bh.init()
+			bh.sql2result[publicSQL] = newMrsForRoleName([][]interface{}{{tc.value}})
+
+			_, _, err := resolveImplicitDefaultRole(ctx, bh, userID, 0, false)
+			require.ErrorContains(t, err, "get a valid default role")
+		})
+	}
+
+	t.Run("catalog query error is returned", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		wantErr := moerr.NewInternalErrorNoCtx("role lookup failed")
+		bh.sql2err[readerSQL] = wantErr
+
+		_, _, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("public fallback query error is returned", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[readerSQL] = newMrsForRoleName(nil)
+		wantErr := moerr.NewInternalErrorNoCtx("public role lookup failed")
+		bh.sql2err[publicSQL] = wantErr
+
+		_, _, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+		require.ErrorIs(t, err, wantErr)
+		require.Equal(t, []string{readerSQL, publicSQL}, bh.executedSQLs)
+	})
+
+	t.Run("invalid role name type is returned", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[readerSQL] = newMrsForRoleName([][]interface{}{{struct{}{}}})
+
+		_, _, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+		require.Error(t, err)
+	})
+
+	t.Run("role name NULL check error is returned", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		result := mock_frontend.NewMockExecResult(ctrl)
+		result.EXPECT().GetRowCount().Return(uint64(1))
+		wantErr := moerr.NewInternalErrorNoCtx("role name NULL check failed")
+		result.EXPECT().ColumnIsNull(gomock.Any(), uint64(0), uint64(0)).Return(false, wantErr)
+
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[readerSQL] = result
+
+		_, _, err := resolveImplicitDefaultRole(ctx, bh, userID, readerID, true)
+		require.ErrorIs(t, err, wantErr)
+	})
+}
+
+func TestReadStoredDefaultRoleID(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name      string
+		value     interface{}
+		wantID    int64
+		wantValid bool
+	}{
+		{name: "valid", value: int64(7), wantID: 7, wantValid: true},
+		{name: "NULL", value: nil},
+		{name: "negative", value: int64(-1)},
+		{name: "out of range", value: uint64(^uint32(0)) + 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := newMrsForPasswordOfUser([][]interface{}{{int64(42), "password", tc.value}})
+			roleID, valid, err := readStoredDefaultRoleID(ctx, result)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantID, roleID)
+			require.Equal(t, tc.wantValid, valid)
+		})
+	}
+
+	t.Run("missing row returns error", func(t *testing.T) {
+		result := newMrsForPasswordOfUser(nil)
+		_, _, err := readStoredDefaultRoleID(ctx, result)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid type returns error", func(t *testing.T) {
+		result := newMrsForPasswordOfUser([][]interface{}{{int64(42), "password", struct{}{}}})
+		_, _, err := readStoredDefaultRoleID(ctx, result)
+		require.Error(t, err)
+	})
+}

--- a/test/distributed/cases/zz_accesscontrol/revoked_default_role_login.result
+++ b/test/distributed/cases/zz_accesscontrol/revoked_default_role_login.result
@@ -1,0 +1,66 @@
+set global enable_privilege_cache = on;
+drop database if exists revoked_default_role_db;
+drop user if exists revoked_default_role_user;
+drop role if exists revoked_default_role_reader;
+drop role if exists revoked_default_role_secondary;
+create database revoked_default_role_db;
+create table revoked_default_role_db.protected(value int);
+insert into revoked_default_role_db.protected values (27651);
+create role revoked_default_role_reader;
+create role revoked_default_role_secondary;
+create user revoked_default_role_user identified by '123456' default role revoked_default_role_reader;
+grant connect on account * to revoked_default_role_reader;
+grant connect on account * to revoked_default_role_secondary;
+grant select on table revoked_default_role_db.protected to revoked_default_role_reader;
+grant revoked_default_role_reader to revoked_default_role_user;
+grant revoked_default_role_secondary to revoked_default_role_user;
+select current_role();
+current_role()
+revoked_default_role_reader
+select * from revoked_default_role_db.protected;
+value
+27651
+set role revoked_default_role_secondary;
+select current_role();
+current_role()
+revoked_default_role_secondary
+revoke revoked_default_role_secondary from revoked_default_role_user;
+select current_role();
+current_role()
+revoked_default_role_reader
+select * from revoked_default_role_db.protected;
+value
+27651
+set role revoked_default_role_secondary;
+internal error: the role revoked_default_role_secondary has not be granted to the user revoked_default_role_user
+revoke revoked_default_role_reader from revoked_default_role_user;
+select current_role();
+current_role()
+public
+select * from revoked_default_role_db.protected;
+internal error: do not have privilege to execute the statement
+set role revoked_default_role_reader;
+internal error: the role revoked_default_role_reader has not be granted to the user revoked_default_role_user
+select current_role();
+current_role()
+revoked_default_role_reader
+select * from revoked_default_role_db.protected;
+value
+27651
+grant revoked_default_role_reader to revoked_default_role_user;
+select current_role();
+current_role()
+revoked_default_role_reader
+select * from revoked_default_role_db.protected;
+value
+27651
+select current_role();
+current_role()
+revoked_default_role_reader
+select * from revoked_default_role_db.protected;
+value
+27651
+drop user revoked_default_role_user;
+drop role revoked_default_role_reader;
+drop role revoked_default_role_secondary;
+drop database revoked_default_role_db;

--- a/test/distributed/cases/zz_accesscontrol/revoked_default_role_login.sql
+++ b/test/distributed/cases/zz_accesscontrol/revoked_default_role_login.sql
@@ -1,0 +1,68 @@
+set global enable_privilege_cache = on;
+drop database if exists revoked_default_role_db;
+drop user if exists revoked_default_role_user;
+drop role if exists revoked_default_role_reader;
+drop role if exists revoked_default_role_secondary;
+
+create database revoked_default_role_db;
+create table revoked_default_role_db.protected(value int);
+insert into revoked_default_role_db.protected values (27651);
+create role revoked_default_role_reader;
+create role revoked_default_role_secondary;
+create user revoked_default_role_user identified by '123456' default role revoked_default_role_reader;
+grant connect on account * to revoked_default_role_reader;
+grant connect on account * to revoked_default_role_secondary;
+grant select on table revoked_default_role_db.protected to revoked_default_role_reader;
+grant revoked_default_role_reader to revoked_default_role_user;
+grant revoked_default_role_secondary to revoked_default_role_user;
+
+-- Existing implicit session starts with the granted default role.
+-- @session:id=2&user=sys:revoked_default_role_user&password=123456
+select current_role();
+select * from revoked_default_role_db.protected;
+-- @session
+
+-- Revoking a non-default secondary role must not disturb the valid default.
+-- @session:id=6&user=sys:revoked_default_role_user&password=123456
+set role revoked_default_role_secondary;
+select current_role();
+-- @session
+revoke revoked_default_role_secondary from revoked_default_role_user;
+-- @session:id=7&user=sys:revoked_default_role_user&password=123456
+select current_role();
+select * from revoked_default_role_db.protected;
+set role revoked_default_role_secondary;
+-- @session
+
+revoke revoked_default_role_reader from revoked_default_role_user;
+
+-- A new implicit session must fall back to public and cannot recover the role
+-- through SET ROLE or use its protected table privilege.
+-- @session:id=3&user=sys:revoked_default_role_user&password=123456
+select current_role();
+select * from revoked_default_role_db.protected;
+set role revoked_default_role_reader;
+-- @session
+
+-- The separate existing-session revocation behavior is intentionally unchanged.
+-- @session:id=2&user=sys:revoked_default_role_user&password=123456
+select current_role();
+select * from revoked_default_role_db.protected;
+-- @session
+
+grant revoked_default_role_reader to revoked_default_role_user;
+
+-- Regranting restores the stored default for both implicit and explicit login.
+-- @session:id=4&user=sys:revoked_default_role_user&password=123456
+select current_role();
+select * from revoked_default_role_db.protected;
+-- @session
+-- @session:id=5&user=sys:revoked_default_role_user:revoked_default_role_reader&password=123456
+select current_role();
+select * from revoked_default_role_db.protected;
+-- @session
+
+drop user revoked_default_role_user;
+drop role revoked_default_role_reader;
+drop role revoked_default_role_secondary;
+drop database revoked_default_role_db;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

close #27651

## What this PR does / why we need it:

Implicit login trusted `mo_user.default_role` without confirming that the role was still granted to the user. After revoking the default role, a new implicit session could therefore activate that role and retain its privileges, while explicit-role login correctly rejected it.

This change:

- validates an implicit default role against both `mo_role` and `mo_user_grant` before activation;
- falls back to a valid `public` grant when the stored default is stale, NULL, invalid, or missing, and fails closed when no valid fallback exists;
- preserves explicit-role validation, existing-session behavior, and default-role recovery after regrant;
- adds focused unit coverage for valid, revoked, regranted, NULL, missing, malformed, out-of-range, and query-error paths;
- adds BVT coverage for explicit and implicit role behavior, new and existing sessions, protected privileges, secondary-role revoke control, and regrant recovery.

Local verification:

- `go test ./pkg/frontend/... -count=1`
- `go test -race ./pkg/frontend/... -count=1`
- `go vet ./pkg/frontend/...`
- changed functions coverage: 100%; frontend package coverage: 63.7%
- revoked_default_role_login BVT: 39/39 passed
- local 1 Log / 1 TN / 1 CN protocol E2E with privilege cache enabled and disabled
- `make config`
- `make err-check`
- `make build-with-prebuilt-native`
- `git diff --check`
