### PR TITLE
test(lock): strengthen bulk lock regression checks

### DIFF
--- a/pkg/lockservice/txn_test.go
+++ b/pkg/lockservice/txn_test.go
@@ -310,6 +310,7 @@ func TestCommittedCoarseningRemainsMonotonicAcrossBatches(t *testing.T) {
 		rows, opts, replace := txn.coarsenLockRequest(
 			bind.Group, bind.Table, [][]byte{[]byte("h")}, exclusive, 3)
 		require.True(t, replace)
+		require.Equal(t, pb.Granularity_Range, opts.Granularity)
 		require.Equal(t, [][]byte{[]byte("b"), []byte("h")}, rows)
 		require.NoError(t, txn.replaceLocks(bind.Group, bind, rows, getLogger("")))
 		require.Contains(t, txn.lockHolders[bind.Group].coarsenedTables(), bind.Table)

--- a/pkg/lockservice/unlock_benchmark_test.go
+++ b/pkg/lockservice/unlock_benchmark_test.go
@@ -293,8 +293,8 @@ func BenchmarkExclusiveLockBudgetAcrossBatches(b *testing.B) {
 			}
 
 			b.ReportAllocs()
-			b.ReportMetric(batchSize*batches, "rows/op")
 			b.ResetTimer()
+			b.ReportMetric(batchSize*batches, "rows/op")
 			b.StartTimer()
 			for _, txnID := range txnIDs {
 				for _, batch := range rows {


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Test and CI

## What this PR does / why we need it

The arm64 SCA job in https://github.com/matrixorigin/matrixone/actions/runs/33041632154/job/98416334180 failed because `TestCommittedCoarseningRemainsMonotonicAcrossBatches` assigned the returned lock options without asserting them, triggering `ineffassign`.

This change:

- asserts that the initial budget coarsening returns range granularity, strengthening the regression oracle and fixing the SCA failure;
- reports the bulk-lock benchmark `rows/op` metric after `ResetTimer`, so the custom metric is retained in benchmark output.

## Validation

- `TestCommittedCoarseningRemainsMonotonicAcrossBatches` passed with exact non-empty selection.
- `BenchmarkExclusiveLockBudgetAcrossBatches` passed and reported `2048 rows/op`.
- `golangci-lint v2.6.2 -c .golangci.yml ./pkg/lockservice` passed with 0 issues.
- `./pkg/lockservice` owning package passed in 96.528s.