### PR TITLE
fix(frontend): serialize concurrent snapshot quota checks

### DIFF
--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -16403,8 +16403,13 @@ func TestDoCreateSnapshot(t *testing.T) {
 		bh := &backgroundExecTest{}
 		bh.init()
 
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-		defer bhStub.Reset()
+		oldNewBackgroundExec := NewBackgroundExec
+		defer func() { NewBackgroundExec = oldNewBackgroundExec }()
+		var forcedPessimisticRC bool
+		NewBackgroundExec = func(_ context.Context, _ FeSession, opts ...*BackgroundExecOption) BackgroundExec {
+			forcedPessimisticRC = len(opts) == 1 && opts[0] != nil && opts[0].forcePessimisticRC
+			return bh
+		}
 
 		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
 		pu.SV.SetDefaultValues()
@@ -16452,6 +16457,7 @@ func TestDoCreateSnapshot(t *testing.T) {
 
 		err := doCreateSnapshot(ctx, ses, cs)
 		convey.So(err, convey.ShouldBeNil)
+		convey.So(forcedPessimisticRC, convey.ShouldBeTrue)
 
 		commitErr := errors.New("snapshot commit conflict")
 		bh.sql2err["commit;"] = commitErr

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -280,7 +280,7 @@ func doCreateSnapshot(ctx context.Context, ses *Session, stmt *tree.CreateSnapSh
 		return err
 	}
 
-	bh := ses.GetBackgroundExec(ctx)
+	bh := ses.GetBackgroundExec(ctx, &BackgroundExecOption{forcePessimisticRC: true})
 	defer bh.Close()
 	err = bh.Exec(ctx, "begin;")
 	defer func() {

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -294,12 +294,6 @@ func doCreateSnapshot(ctx context.Context, ses *Session, stmt *tree.CreateSnapSh
 	currentAccount := tenantInfo.GetTenant()
 	snapshotLevel = stmt.Object.SLevel.Level
 
-	if snapshotLevel != tree.SNAPSHOTLEVELCLUSTER {
-		if err = checkSnapshotQuota(ctx, ses, bh, 1, snapshotLevel.String()); err != nil {
-			return err
-		}
-	}
-
 	pubAccountName := string(stmt.Object.AccountName)
 	pubName := string(stmt.Object.PubName)
 
@@ -336,6 +330,14 @@ func doCreateSnapshot(ctx context.Context, ses *Session, stmt *tree.CreateSnapSh
 	// an empty owner set and forces an optimistic loser to retry.
 	if err = lockDataBranchLineageOwnerPublication(ctx, bh); err != nil {
 		return err
+	}
+	// Keep quota admission and snapshot publication in the same serialized
+	// transaction. Otherwise concurrent creators can all observe the old count
+	// before any of them publishes its mo_snapshots row.
+	if snapshotLevel != tree.SNAPSHOTLEVELCLUSTER {
+		if err = checkSnapshotQuota(ctx, ses, bh, 1, snapshotLevel.String()); err != nil {
+			return err
+		}
 	}
 
 	// 3.1 generate snapshot id

--- a/pkg/tests/issues/issue_27718_test.go
+++ b/pkg/tests/issues/issue_27718_test.go
@@ -23,21 +23,29 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/embed"
+	pbtxn "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIssue27718ConcurrentSnapshotQuota(t *testing.T) {
 	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
-		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 360*time.Second)
 		defer cancel()
 
-		cn, err := c.GetCNService(0)
+		cn0, err := c.GetCNService(0)
 		require.NoError(t, err)
-		port := cn.GetServiceConfig().CN.Frontend.Port
+		cn1, err := c.GetCNService(1)
+		require.NoError(t, err)
+		cns := []embed.ServiceOperator{cn0, cn1}
+		ports := []int64{
+			cn0.GetServiceConfig().CN.Frontend.Port,
+			cn1.GetServiceConfig().CN.Frontend.Port,
+		}
 
-		sysDB, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
+		sysDB, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", ports[0]))
 		require.NoError(t, err)
 		defer sysDB.Close()
 		execSQLRequire(t, ctx, sysDB, "set role moadmin")
@@ -53,100 +61,188 @@ func TestIssue27718ConcurrentSnapshotQuota(t *testing.T) {
 		execSQLRequire(t, ctx, sysDB,
 			"select mo_feature_registry_upsert('snapshot', 'Snapshot feature', '{\"allowed_scope\":[\"account\",\"database\",\"table\"]}', true)")
 
-		tenantDB, err := sql.Open("mysql", fmt.Sprintf("%s#root#accountadmin:111@tcp(127.0.0.1:%d)/", accountName, port))
+		tenantDB, err := sql.Open("mysql", fmt.Sprintf(
+			"%s#root#accountadmin:111@tcp(127.0.0.1:%d)/", accountName, ports[0]))
 		require.NoError(t, err)
 		defer tenantDB.Close()
-		const creators = 4
-		tenantDB.SetMaxOpenConns(creators + 1)
 		execSQLRequire(t, ctx, tenantDB, "create database issue_27718_db")
 		execSQLRequire(t, ctx, tenantDB, "create table issue_27718_db.t (id int primary key)")
 		execSQLRequire(t, ctx, tenantDB, "insert into issue_27718_db.t values (1)")
+		testutils.WaitDatabaseCreatedWithAccount(t, accountID, "issue_27718_db", cn1)
+		testutils.WaitTableCreatedWithAccount(t, accountID, "issue_27718_db", "t", cn1)
 
-		connections := make([]*sql.Conn, creators)
-		for i := range connections {
-			connections[i], err = tenantDB.Conn(ctx)
-			require.NoError(t, err)
-			defer connections[i].Close()
-			var probe int
-			require.NoError(t, connections[i].QueryRowContext(ctx, "select 1").Scan(&probe))
-			require.Equal(t, 1, probe)
+		modes := []struct {
+			name      string
+			mode      pbtxn.TxnMode
+			isolation pbtxn.TxnIsolation
+		}{
+			{name: "pessimistic_rc", mode: pbtxn.TxnMode_Pessimistic, isolation: pbtxn.TxnIsolation_RC},
+			{name: "optimistic_si", mode: pbtxn.TxnMode_Optimistic, isolation: pbtxn.TxnIsolation_SI},
 		}
-		runConcurrentCreates := func(prefix string, quota, expectedSuccesses int) []string {
-			t.Helper()
-			execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
-				"select mo_feature_limit_upsert(%d, 'snapshot', 'table', %d)", accountID, quota))
-
-			type createResult struct {
-				name string
-				err  error
-			}
-			start := make(chan struct{})
-			results := make(chan createResult, creators)
-			for i := 1; i <= creators; i++ {
-				name := fmt.Sprintf("%s_%d", prefix, i)
-				conn := connections[i-1]
-				go func(conn *sql.Conn, name string) {
-					<-start
-					_, createErr := conn.ExecContext(ctx, fmt.Sprintf(
-						"create snapshot %s for table issue_27718_db t", name))
-					results <- createResult{name: name, err: createErr}
-				}(conn, name)
-			}
-			close(start)
-
-			successes := make([]string, 0, creators)
-			for i := 0; i < creators; i++ {
-				select {
-				case result := <-results:
-					if result.err == nil {
-						successes = append(successes, result.name)
-						continue
-					}
-					if quota == 0 {
-						require.Contains(t, result.err.Error(),
-							"feature SNAPSHOT with scope table has disabled for account "+accountName)
-					} else {
-						require.Contains(t, result.err.Error(), fmt.Sprintf(
-							"feature SNAPSHOT with scope table has reached the limit of %d", quota))
-					}
-					require.NotContains(t, strings.ToLower(result.err.Error()), "txn need retry")
-				case <-time.After(30 * time.Second):
-					t.Fatal("concurrent snapshot creator did not finish")
-				}
-			}
-			require.Len(t, successes, expectedSuccesses)
-
-			var persisted int
-			require.NoError(t, tenantDB.QueryRowContext(ctx,
-				"select count(*) from mo_catalog.mo_snapshots where account_name = ? and sname in (?, ?, ?, ?)",
-				accountName, prefix+"_1", prefix+"_2", prefix+"_3", prefix+"_4").Scan(&persisted))
-			require.Equal(t, expectedSuccesses, persisted)
-			return successes
-		}
-
-		quotaOneSnapshots := runConcurrentCreates("issue27718_q1", 1, 1)
-		execSQLRequire(t, ctx, tenantDB, "drop snapshot "+quotaOneSnapshots[0])
-		execSQLRequire(t, ctx, tenantDB, "create snapshot issue27718_replacement for table issue_27718_db t")
-		_, err = tenantDB.ExecContext(ctx, "create snapshot issue27718_over_limit for table issue_27718_db t")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "feature SNAPSHOT with scope table has reached the limit of 1")
-		var overLimitRows int
-		require.NoError(t, tenantDB.QueryRowContext(ctx,
-			"select count(*) from mo_catalog.mo_snapshots where account_name = ? and sname = 'issue27718_over_limit'",
-			accountName).Scan(&overLimitRows))
-		require.Zero(t, overLimitRows)
-		execSQLRequire(t, ctx, tenantDB, "drop snapshot issue27718_replacement")
-
-		quotaTwoSnapshots := runConcurrentCreates("issue27718_q2", 2, 2)
-		for _, name := range quotaTwoSnapshots {
-			execSQLRequire(t, ctx, tenantDB, "drop snapshot "+name)
-		}
-
-		runConcurrentCreates("issue27718_disabled", 0, 0)
-
-		unlimitedSnapshots := runConcurrentCreates("issue27718_unlimited", -1, creators)
-		for _, name := range unlimitedSnapshots {
-			execSQLRequire(t, ctx, tenantDB, "drop snapshot "+name)
+		for _, mode := range modes {
+			mode := mode
+			t.Run(mode.name, func(t *testing.T) {
+				restore := setIssue27718TxnConfig(cns, mode.mode, mode.isolation)
+				defer restore()
+				runIssue27718SnapshotQuotaMode(
+					t, ctx, sysDB, tenantDB, accountName, accountID, ports, mode.name)
+			})
 		}
 	})
+}
+
+func setIssue27718TxnConfig(
+	cns []embed.ServiceOperator,
+	mode pbtxn.TxnMode,
+	isolation pbtxn.TxnIsolation,
+) func() {
+	type previousTxnConfig struct {
+		runtime      moruntime.Runtime
+		mode         any
+		hadMode      bool
+		isolation    any
+		hadIsolation bool
+	}
+	previous := make([]previousTxnConfig, 0, len(cns))
+	for _, cn := range cns {
+		rt := moruntime.ServiceRuntime(cn.ServiceID())
+		oldMode, hadMode := rt.GetGlobalVariables(moruntime.TxnMode)
+		oldIsolation, hadIsolation := rt.GetGlobalVariables(moruntime.TxnIsolation)
+		previous = append(previous, previousTxnConfig{
+			runtime: rt, mode: oldMode, hadMode: hadMode,
+			isolation: oldIsolation, hadIsolation: hadIsolation,
+		})
+		rt.SetGlobalVariables(moruntime.TxnMode, mode)
+		rt.SetGlobalVariables(moruntime.TxnIsolation, isolation)
+	}
+	return func() {
+		for _, config := range previous {
+			if config.hadMode {
+				config.runtime.SetGlobalVariables(moruntime.TxnMode, config.mode)
+			} else {
+				config.runtime.SetGlobalVariables(moruntime.TxnMode, pbtxn.TxnMode_Pessimistic)
+			}
+			if config.hadIsolation {
+				config.runtime.SetGlobalVariables(moruntime.TxnIsolation, config.isolation)
+			} else {
+				config.runtime.SetGlobalVariables(moruntime.TxnIsolation, pbtxn.TxnIsolation_RC)
+			}
+		}
+	}
+}
+
+func runIssue27718SnapshotQuotaMode(
+	t *testing.T,
+	ctx context.Context,
+	sysDB *sql.DB,
+	tenantDB *sql.DB,
+	accountName string,
+	accountID int32,
+	ports []int64,
+	modeName string,
+) {
+	t.Helper()
+	const creators = 4
+	tenantDBs := make([]*sql.DB, len(ports))
+	for i, port := range ports {
+		db, err := sql.Open("mysql", fmt.Sprintf(
+			"%s#root#accountadmin:111@tcp(127.0.0.1:%d)/", accountName, port))
+		require.NoError(t, err)
+		db.SetMaxOpenConns(creators/len(ports) + 1)
+		tenantDBs[i] = db
+		defer db.Close()
+	}
+
+	connections := make([]*sql.Conn, creators)
+	for i := range connections {
+		conn, err := tenantDBs[i%len(tenantDBs)].Conn(ctx)
+		require.NoError(t, err)
+		connections[i] = conn
+		defer conn.Close()
+		var probe int
+		require.NoError(t, conn.QueryRowContext(ctx, "select 1").Scan(&probe))
+		require.Equal(t, 1, probe)
+	}
+
+	runConcurrentCreates := func(prefix string, quota, expectedSuccesses int) []string {
+		t.Helper()
+		execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+			"select mo_feature_limit_upsert(%d, 'snapshot', 'table', %d)", accountID, quota))
+
+		type createResult struct {
+			name string
+			err  error
+		}
+		start := make(chan struct{})
+		results := make(chan createResult, creators)
+		for i := 1; i <= creators; i++ {
+			name := fmt.Sprintf("%s_%d", prefix, i)
+			conn := connections[i-1]
+			go func() {
+				<-start
+				_, createErr := conn.ExecContext(ctx, fmt.Sprintf(
+					"create snapshot %s for table issue_27718_db t", name))
+				results <- createResult{name: name, err: createErr}
+			}()
+		}
+		close(start)
+
+		successes := make([]string, 0, creators)
+		for i := 0; i < creators; i++ {
+			select {
+			case result := <-results:
+				if result.err == nil {
+					successes = append(successes, result.name)
+					continue
+				}
+				if quota == 0 {
+					require.Contains(t, result.err.Error(),
+						"feature SNAPSHOT with scope table has disabled for account "+accountName)
+				} else {
+					require.Contains(t, result.err.Error(), fmt.Sprintf(
+						"feature SNAPSHOT with scope table has reached the limit of %d", quota))
+				}
+				require.NotContains(t, strings.ToLower(result.err.Error()), "txn need retry")
+			case <-time.After(30 * time.Second):
+				t.Fatal("concurrent snapshot creator did not finish")
+			}
+		}
+		require.Len(t, successes, expectedSuccesses)
+
+		var persisted int
+		require.NoError(t, tenantDB.QueryRowContext(ctx,
+			"select count(*) from mo_catalog.mo_snapshots where account_name = ? and sname in (?, ?, ?, ?)",
+			accountName, prefix+"_1", prefix+"_2", prefix+"_3", prefix+"_4").Scan(&persisted))
+		require.Equal(t, expectedSuccesses, persisted)
+		return successes
+	}
+
+	prefix := "issue27718_" + strings.ReplaceAll(modeName, "_", "")
+	quotaOneSnapshots := runConcurrentCreates(prefix+"_q1", 1, 1)
+	execSQLRequire(t, ctx, tenantDB, "drop snapshot "+quotaOneSnapshots[0])
+	replacement := prefix + "_replacement"
+	overLimit := prefix + "_over_limit"
+	execSQLRequire(t, ctx, tenantDB, fmt.Sprintf(
+		"create snapshot %s for table issue_27718_db t", replacement))
+	_, err := tenantDB.ExecContext(ctx, fmt.Sprintf(
+		"create snapshot %s for table issue_27718_db t", overLimit))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "feature SNAPSHOT with scope table has reached the limit of 1")
+	var overLimitRows int
+	require.NoError(t, tenantDB.QueryRowContext(ctx,
+		"select count(*) from mo_catalog.mo_snapshots where account_name = ? and sname = ?",
+		accountName, overLimit).Scan(&overLimitRows))
+	require.Zero(t, overLimitRows)
+	execSQLRequire(t, ctx, tenantDB, "drop snapshot "+replacement)
+
+	quotaTwoSnapshots := runConcurrentCreates(prefix+"_q2", 2, 2)
+	for _, name := range quotaTwoSnapshots {
+		execSQLRequire(t, ctx, tenantDB, "drop snapshot "+name)
+	}
+	runConcurrentCreates(prefix+"_disabled", 0, 0)
+
+	unlimitedSnapshots := runConcurrentCreates(prefix+"_unlimited", -1, creators)
+	for _, name := range unlimitedSnapshots {
+		execSQLRequire(t, ctx, tenantDB, "drop snapshot "+name)
+	}
 }

--- a/pkg/tests/issues/issue_27718_test.go
+++ b/pkg/tests/issues/issue_27718_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue27718ConcurrentSnapshotQuota(t *testing.T) {
+	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+
+		sysDB, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
+		require.NoError(t, err)
+		defer sysDB.Close()
+		execSQLRequire(t, ctx, sysDB, "set role moadmin")
+
+		const accountName = "issue_27718"
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			execSQLMaybe(t, cleanupCtx, sysDB, "drop account if exists "+accountName)
+		}()
+		execSQLRequire(t, ctx, sysDB, "drop account if exists "+accountName)
+		accountID := testutils.CreateAccount(t, c, accountName, "111")
+		execSQLRequire(t, ctx, sysDB,
+			"select mo_feature_registry_upsert('snapshot', 'Snapshot feature', '{\"allowed_scope\":[\"account\",\"database\",\"table\"]}', true)")
+
+		tenantDB, err := sql.Open("mysql", fmt.Sprintf("%s#root#accountadmin:111@tcp(127.0.0.1:%d)/", accountName, port))
+		require.NoError(t, err)
+		defer tenantDB.Close()
+		const creators = 4
+		tenantDB.SetMaxOpenConns(creators + 1)
+		execSQLRequire(t, ctx, tenantDB, "create database issue_27718_db")
+		execSQLRequire(t, ctx, tenantDB, "create table issue_27718_db.t (id int primary key)")
+		execSQLRequire(t, ctx, tenantDB, "insert into issue_27718_db.t values (1)")
+
+		connections := make([]*sql.Conn, creators)
+		for i := range connections {
+			connections[i], err = tenantDB.Conn(ctx)
+			require.NoError(t, err)
+			defer connections[i].Close()
+			var probe int
+			require.NoError(t, connections[i].QueryRowContext(ctx, "select 1").Scan(&probe))
+			require.Equal(t, 1, probe)
+		}
+		runConcurrentCreates := func(prefix string, quota, expectedSuccesses int) []string {
+			t.Helper()
+			execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+				"select mo_feature_limit_upsert(%d, 'snapshot', 'table', %d)", accountID, quota))
+
+			type createResult struct {
+				name string
+				err  error
+			}
+			start := make(chan struct{})
+			results := make(chan createResult, creators)
+			for i := 1; i <= creators; i++ {
+				name := fmt.Sprintf("%s_%d", prefix, i)
+				conn := connections[i-1]
+				go func(conn *sql.Conn, name string) {
+					<-start
+					_, createErr := conn.ExecContext(ctx, fmt.Sprintf(
+						"create snapshot %s for table issue_27718_db t", name))
+					results <- createResult{name: name, err: createErr}
+				}(conn, name)
+			}
+			close(start)
+
+			successes := make([]string, 0, creators)
+			for i := 0; i < creators; i++ {
+				select {
+				case result := <-results:
+					if result.err == nil {
+						successes = append(successes, result.name)
+						continue
+					}
+					if quota == 0 {
+						require.Contains(t, result.err.Error(),
+							"feature SNAPSHOT with scope table has disabled for account "+accountName)
+					} else {
+						require.Contains(t, result.err.Error(), fmt.Sprintf(
+							"feature SNAPSHOT with scope table has reached the limit of %d", quota))
+					}
+					require.NotContains(t, strings.ToLower(result.err.Error()), "txn need retry")
+				case <-time.After(30 * time.Second):
+					t.Fatal("concurrent snapshot creator did not finish")
+				}
+			}
+			require.Len(t, successes, expectedSuccesses)
+
+			var persisted int
+			require.NoError(t, tenantDB.QueryRowContext(ctx,
+				"select count(*) from mo_catalog.mo_snapshots where account_name = ? and sname in (?, ?, ?, ?)",
+				accountName, prefix+"_1", prefix+"_2", prefix+"_3", prefix+"_4").Scan(&persisted))
+			require.Equal(t, expectedSuccesses, persisted)
+			return successes
+		}
+
+		quotaOneSnapshots := runConcurrentCreates("issue27718_q1", 1, 1)
+		execSQLRequire(t, ctx, tenantDB, "drop snapshot "+quotaOneSnapshots[0])
+		execSQLRequire(t, ctx, tenantDB, "create snapshot issue27718_replacement for table issue_27718_db t")
+		_, err = tenantDB.ExecContext(ctx, "create snapshot issue27718_over_limit for table issue_27718_db t")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "feature SNAPSHOT with scope table has reached the limit of 1")
+		var overLimitRows int
+		require.NoError(t, tenantDB.QueryRowContext(ctx,
+			"select count(*) from mo_catalog.mo_snapshots where account_name = ? and sname = 'issue27718_over_limit'",
+			accountName).Scan(&overLimitRows))
+		require.Zero(t, overLimitRows)
+		execSQLRequire(t, ctx, tenantDB, "drop snapshot issue27718_replacement")
+
+		quotaTwoSnapshots := runConcurrentCreates("issue27718_q2", 2, 2)
+		for _, name := range quotaTwoSnapshots {
+			execSQLRequire(t, ctx, tenantDB, "drop snapshot "+name)
+		}
+
+		runConcurrentCreates("issue27718_disabled", 0, 0)
+
+		unlimitedSnapshots := runConcurrentCreates("issue27718_unlimited", -1, creators)
+		for _, name := range unlimitedSnapshots {
+			execSQLRequire(t, ctx, tenantDB, "drop snapshot "+name)
+		}
+	})
+}

--- a/pkg/tests/issues/issue_27718_test.go
+++ b/pkg/tests/issues/issue_27718_test.go
@@ -80,7 +80,6 @@ func TestIssue27718ConcurrentSnapshotQuota(t *testing.T) {
 			{name: "optimistic_si", mode: pbtxn.TxnMode_Optimistic, isolation: pbtxn.TxnIsolation_SI},
 		}
 		for _, mode := range modes {
-			mode := mode
 			t.Run(mode.name, func(t *testing.T) {
 				restore := setIssue27718TxnConfig(cns, mode.mode, mode.isolation)
 				defer restore()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27718

## What this PR does / why we need it:

`CREATE SNAPSHOT` checked the tenant quota before acquiring the existing
snapshot lineage-publication barrier. Concurrent transactions could therefore
all read the same old `mo_snapshots` count, then cross the barrier one by one
and each publish a metadata row. Sequential execution did not expose this
time-of-check/time-of-use race because each later check observed the previous
commit.

This PR moves snapshot quota admission after the stable
`mo_feature_registry` write barrier and before snapshot timestamp generation
and metadata insertion. The quota read, usage count, and `mo_snapshots`
publication are now in the same serialized background transaction, which is
held through commit or rolled back on any error.

The independent transaction that owns that barrier is explicitly created as
pessimistic/read-committed. Without that ownership-level mode, an
optimistic/SI CN let concurrent losers reach commit and expose `Error 20619:
w-w conflict` instead of waiting and returning the configured quota-limit
error. Only this internal snapshot transaction is forced to pessimistic/RC;
the user session and service defaults are unchanged. The change reuses the
existing background-executor option and publication lock, with no schema,
lock row, retry fallback, or duplicated quota implementation.

`TestIssue27718ConcurrentSnapshotQuota` proves #27718 by releasing four
pre-opened tenant SQL connections from one start barrier. Two connections use
CN0 and two use CN1, so a process-local lock cannot satisfy the test. The full
matrix runs under both pessimistic/RC and optimistic/SI and asserts:

- quota 1: exactly one creator succeeds, the other three return the quota
  error, and exactly one candidate metadata row persists;
- quota 2: exactly two creators succeed and exactly two rows persist;
- quota 0: all creators are rejected and no candidate row persists;
- quota -1: all four creators succeed;
- dropping the admitted snapshot frees capacity for a replacement; and
- a rejected over-limit create leaves no metadata residue and does not expose
  a transaction retry/conflict error to the client.

`TestDoCreateSnapshot` additionally verifies that snapshot creation requests
the pessimistic/RC background executor at the transaction ownership boundary.

Before the original change, the issue's four-session reproduction was run
against a fresh local single-CN service: all four clients returned success and
the final snapshot count was 4 with quota 1. Before the ownership-mode fix,
the expanded two-CN regression passed under pessimistic/RC but failed under
optimistic/SI because three losers returned `Error 20619 (HY000): w-w
conflict` instead of the quota-limit error.

Validation after rebasing the same patch onto base
`66f2ac48c403091616c1eb3e3def3e68bbc89266`, on local head
`77ee66e99d5d1c8231b968c9bb1816f458c0993d`:

- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s -run '^TestDoCreateSnapshot$' -v ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=180s -run '^TestIssue27718ConcurrentSnapshotQuota$' -v ./pkg/tests/issues`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=240s -run '^TestIssue27718ConcurrentSnapshotQuota$' -v ./pkg/tests/issues`
- `golangci-lint run --no-config --enable-only copyloopvar ./pkg/tests/issues/...`
- `git diff --check origin/main...HEAD`
- `git range-diff 66f2ac48c403091616c1eb3e3def3e68bbc89266...a7b13d353d4b7f9358deb2f03f06b356c90c1190 66f2ac48c403091616c1eb3e3def3e68bbc89266...77ee66e99d5d1c8231b968c9bb1816f458c0993d` (all three commits patch-equivalent)

The tested local head and merged PR head
`a7b13d353d4b7f9358deb2f03f06b356c90c1190` have the same stable aggregate
patch-id, `7dd68641c27df24a1632fa09c4231a4e2d4614cf`. GitHub merged the PR as squash
commit `0725c8c1151df0d70b29e069f83e54793b65b655`.

The SCA-reported Go 1.22+ redundant loop-variable copy was removed without
changing test behavior; the exact `copyloopvar` check and the full two-mode,
two-CN regression pass on the resulting patch.

No BVT fixture is added because mo-tester session directives switch active
connections but execute SQL commands serially; they cannot release multiple
`CREATE SNAPSHOT` statements concurrently. Existing snapshot feature-limit BVT
fixtures already cover sequential table/database/account quotas, disabled and
unlimited limits, dynamic updates, and capacity reuse. The authenticated
cluster regression supplies the missing concurrent executable proof.

Residual risk: quota catalog reads now run inside the pre-existing global
snapshot publication critical section, slightly extending its hold time. No
new contention domain is introduced. Forcing the independent internal
transaction to pessimistic/RC makes its distributed lock-wait semantics
independent of the CN service's user-transaction default.
