### PR TITLE
fix(frontend): invalidate revoked active roles in existing sessions

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -1890,7 +1890,10 @@ func getSqlForCheckUserGrant(roleId, userId int64) string {
 }
 
 func getSqlForCheckUserGrantForAuthorization(roleId, userId int64) string {
-	return strings.TrimSuffix(getSqlForCheckUserGrant(roleId, userId), ";") + " for update;"
+	// Authorization only needs a latest-committed membership read from the
+	// private RC transaction. A locking read serializes every cold authorization
+	// for the same user/role without improving the committed-REVOKE boundary.
+	return getSqlForCheckUserGrant(roleId, userId)
 }
 
 func getSqlForCheckUserHasRole(ctx context.Context, userName string, roleId int64) (string, error) {
@@ -2644,12 +2647,14 @@ type privilegeCache struct {
 	// catalog state. Keep the validation in the same cache generation as the
 	// privilege entries so clear_privilege_cache rechecks both before either
 	// can authorize another statement.
-	activeRoleGrant atomic.Pointer[activeRoleGrantCacheEntry]
+	activeRoleGrant           atomic.Pointer[activeRoleGrantCacheEntry]
+	activeRoleGrantGeneration atomic.Uint64
 }
 
 type activeRoleGrantCacheEntry struct {
-	key   uint64
-	valid bool
+	key        uint64
+	valid      bool
+	generation uint64
 }
 
 func activeRoleGrantKey(userID, roleID uint32) uint64 {
@@ -2660,8 +2665,9 @@ func (pc *privilegeCache) getActiveRoleGrant(userID, roleID uint32) (valid bool,
 	if pc == nil {
 		return false, false
 	}
+	generation := pc.activeRoleGrantGeneration.Load()
 	entry := pc.activeRoleGrant.Load()
-	if entry == nil || entry.key != activeRoleGrantKey(userID, roleID) {
+	if entry == nil || entry.generation != generation || entry.key != activeRoleGrantKey(userID, roleID) {
 		return false, false
 	}
 	return entry.valid, true
@@ -2671,10 +2677,34 @@ func (pc *privilegeCache) setActiveRoleGrant(userID, roleID uint32, valid bool) 
 	if pc == nil {
 		return
 	}
+	pc.setActiveRoleGrantForGeneration(
+		userID, roleID, valid, pc.activeRoleGrantGeneration.Load())
+}
+
+func (pc *privilegeCache) getActiveRoleGrantGeneration() uint64 {
+	if pc == nil {
+		return 0
+	}
+	return pc.activeRoleGrantGeneration.Load()
+}
+
+// setActiveRoleGrantForGeneration publishes a catalog decision only if the
+// privilege-cache generation that initiated the read is still current. Even
+// if invalidate races with Store, getActiveRoleGrant rejects the old generation.
+func (pc *privilegeCache) setActiveRoleGrantForGeneration(
+	userID, roleID uint32,
+	valid bool,
+	generation uint64,
+) bool {
+	if pc == nil || pc.activeRoleGrantGeneration.Load() != generation {
+		return false
+	}
 	pc.activeRoleGrant.Store(&activeRoleGrantCacheEntry{
-		key:   activeRoleGrantKey(userID, roleID),
-		valid: valid,
+		key:        activeRoleGrantKey(userID, roleID),
+		valid:      valid,
+		generation: generation,
 	})
+	return pc.activeRoleGrantGeneration.Load() == generation
 }
 
 // has checks the cache has privilege on a table
@@ -2794,6 +2824,9 @@ func (pc *privilegeCache) invalidate() {
 	if pc == nil {
 		return
 	}
+	// Advance first so a validation that started in the old generation can
+	// never become visible even if its atomic Store races with the clear below.
+	pc.activeRoleGrantGeneration.Add(1)
 	// total := pc.total.Swap(0)
 	// hit := pc.hit.Swap(0)
 	for i := privilegeLevelStar; i < privilegeLevelEnd; i++ {
@@ -8025,6 +8058,7 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 	roleGrantNeedsCheck := activeRoleGrantNeedsCheck(tenant)
 	var roleGrantValid bool
 	roleGrantCached := !roleGrantNeedsCheck
+	var roleGrantCacheGeneration uint64
 	cache := ses.GetPrivilegeCache()
 	if roleGrantNeedsCheck && enableCache && cache != nil {
 		roleGrantValid, roleGrantCached = cache.getActiveRoleGrant(
@@ -8086,22 +8120,46 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 	roleSetOfKthIteration.Insert((int64)(tenant.GetDefaultRoleID()))
 
 	err = bh.Exec(ctx, "begin;")
+	txnFinished := false
+	publishRoleGrant := false
 	defer func() {
+		if txnFinished {
+			return
+		}
 		err = finishTxn(ctx, bh, err)
+		if err == nil && publishRoleGrant && enableCache && cache != nil {
+			cache.setActiveRoleGrantForGeneration(
+				tenant.GetUserID(), tenant.GetDefaultRoleID(), roleGrantValid,
+				roleGrantCacheGeneration)
+		}
 	}()
 	if err != nil {
 		return false, stats, err
 	}
 
 	if !roleGrantCached {
+		if enableCache && cache != nil {
+			roleGrantCacheGeneration = cache.getActiveRoleGrantGeneration()
+		}
 		roleGrantValid, err = activeRoleGrantIsValid(ctx, bh, tenant)
 		if err != nil {
 			return false, stats, err
 		}
-		if enableCache && cache != nil {
-			cache.setActiveRoleGrant(tenant.GetUserID(), tenant.GetDefaultRoleID(), roleGrantValid)
-		}
+		publishRoleGrant = true
 		if !roleGrantValid {
+			// A negative membership result is a successful catalog transaction,
+			// even though it denies the statement. Commit that read before caching
+			// it, then return the authorization error to the caller.
+			err = finishTxn(ctx, bh, nil)
+			txnFinished = true
+			if err != nil {
+				return false, stats, err
+			}
+			if enableCache && cache != nil {
+				cache.setActiveRoleGrantForGeneration(
+					tenant.GetUserID(), tenant.GetDefaultRoleID(), false,
+					roleGrantCacheGeneration)
+			}
 			return false, stats, activeRoleGrantAuthorizationError(ctx)
 		}
 
@@ -8250,12 +8308,14 @@ func activeRoleGrantNeedsCheck(tenant *TenantInfo) bool {
 	if tenant == nil {
 		return false
 	}
-	switch tenant.GetDefaultRoleID() {
-	case moAdminRoleID, publicRoleID, accountAdminRoleID:
+	roleID := tenant.GetDefaultRoleID()
+	if roleID == publicRoleID {
 		return false
-	default:
-		return true
 	}
+	if tenant.IsSysTenant() {
+		return roleID != moAdminRoleID
+	}
+	return roleID != accountAdminRoleID
 }
 
 func activeRoleGrantIsValid(ctx context.Context, bh BackgroundExec, tenant *TenantInfo) (bool, error) {
@@ -8297,11 +8357,13 @@ func validateActiveRoleGrantForAuthorization(
 		return false, stats, err
 	}
 	cache := ses.GetPrivilegeCache()
+	var cacheGeneration uint64
 	if enableCache && cache != nil {
 		if valid, cached := cache.getActiveRoleGrant(
 			tenant.GetUserID(), tenant.GetDefaultRoleID()); cached {
 			return valid, stats, nil
 		}
+		cacheGeneration = cache.getActiveRoleGrantGeneration()
 	}
 
 	// WITH GRANT OPTION authorization can bypass the general privilege walk,
@@ -8313,19 +8375,18 @@ func validateActiveRoleGrantForAuthorization(
 	}()
 
 	err = bh.Exec(ctx, "begin;")
-	defer func() {
-		err = finishTxn(ctx, bh, err)
-	}()
 	if err != nil {
 		return false, stats, err
 	}
 
 	ret, err = activeRoleGrantIsValid(ctx, bh, tenant)
+	err = finishTxn(ctx, bh, err)
 	if err != nil {
 		return false, stats, err
 	}
 	if enableCache && cache != nil {
-		cache.setActiveRoleGrant(tenant.GetUserID(), tenant.GetDefaultRoleID(), ret)
+		cache.setActiveRoleGrantForGeneration(
+			tenant.GetUserID(), tenant.GetDefaultRoleID(), ret, cacheGeneration)
 	}
 	return ret, stats, nil
 }

--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -8023,7 +8023,7 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 
 	tenant := ses.GetTenantInfo()
 	roleGrantNeedsCheck := activeRoleGrantNeedsCheck(tenant)
-	roleGrantValid := !roleGrantNeedsCheck
+	var roleGrantValid bool
 	roleGrantCached := !roleGrantNeedsCheck
 	cache := ses.GetPrivilegeCache()
 	if roleGrantNeedsCheck && enableCache && cache != nil {

--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -3727,6 +3727,10 @@ func doSwitchRole(ctx context.Context, ses *Session, sr *tree.SetRole) (err erro
 		if err != nil {
 			return err
 		}
+		enableCache, err := privilegeCacheIsEnabled(ctx, ses)
+		if err != nil {
+			return err
+		}
 
 		// step3 : switch the default role and role id;
 		account.SetDefaultRoleID(uint32(roleId))
@@ -3734,7 +3738,12 @@ func doSwitchRole(ctx context.Context, ses *Session, sr *tree.SetRole) (err erro
 		// then, reset secondary role to none
 		account.SetUseSecondaryRole(false)
 		ses.InvalidatePrivilegeCache()
-		ses.markActiveRoleGrantValid()
+		// SET ROLE validated membership in the transaction above, but a session
+		// with privilege caching disabled must not leave a grant decision behind
+		// for a later OFF -> ON transition to reuse after REVOKE.
+		if enableCache {
+			ses.markActiveRoleGrantValid()
+		}
 
 		return err
 	}

--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -1889,6 +1889,10 @@ func getSqlForCheckUserGrant(roleId, userId int64) string {
 	return fmt.Sprintf(checkUserGrantFormat, roleId, userId)
 }
 
+func getSqlForCheckUserGrantForAuthorization(roleId, userId int64) string {
+	return strings.TrimSuffix(getSqlForCheckUserGrant(roleId, userId), ";") + " for update;"
+}
+
 func getSqlForCheckUserHasRole(ctx context.Context, userName string, roleId int64) (string, error) {
 	err := inputNameIsInvalid(ctx, userName)
 	if err != nil {
@@ -2635,6 +2639,42 @@ type privilegeCache struct {
 	storeForAccount [int(privilegeLevelEnd)]btree.Set[PrivilegeType]
 	total           atomic.Uint64
 	hit             atomic.Uint64
+
+	// The active primary role is session state, while its grant to the user is
+	// catalog state. Keep the validation in the same cache generation as the
+	// privilege entries so clear_privilege_cache rechecks both before either
+	// can authorize another statement.
+	activeRoleGrant atomic.Pointer[activeRoleGrantCacheEntry]
+}
+
+type activeRoleGrantCacheEntry struct {
+	key   uint64
+	valid bool
+}
+
+func activeRoleGrantKey(userID, roleID uint32) uint64 {
+	return uint64(userID)<<32 | uint64(roleID)
+}
+
+func (pc *privilegeCache) getActiveRoleGrant(userID, roleID uint32) (valid bool, cached bool) {
+	if pc == nil {
+		return false, false
+	}
+	entry := pc.activeRoleGrant.Load()
+	if entry == nil || entry.key != activeRoleGrantKey(userID, roleID) {
+		return false, false
+	}
+	return entry.valid, true
+}
+
+func (pc *privilegeCache) setActiveRoleGrant(userID, roleID uint32, valid bool) {
+	if pc == nil {
+		return
+	}
+	pc.activeRoleGrant.Store(&activeRoleGrantCacheEntry{
+		key:   activeRoleGrantKey(userID, roleID),
+		valid: valid,
+	})
 }
 
 // has checks the cache has privilege on a table
@@ -2767,6 +2807,7 @@ func (pc *privilegeCache) invalidate() {
 	pc.storeForView2.Clear()
 	pc.storeForView3.Clear()
 	pc.storeForDatabase2.Clear()
+	pc.activeRoleGrant.Store(nil)
 	// ratio := float64(0)
 	// if total == 0 {
 	//	ratio = 0
@@ -3660,6 +3701,7 @@ func doSwitchRole(ctx context.Context, ses *Session, sr *tree.SetRole) (err erro
 		// then, reset secondary role to none
 		account.SetUseSecondaryRole(false)
 		ses.InvalidatePrivilegeCache()
+		ses.markActiveRoleGrantValid()
 
 		return err
 	}
@@ -5847,7 +5889,11 @@ func doRevokeRole(ctx context.Context, ses *Session, rr *tree.RevokeRole) (err e
 	}
 
 	account := ses.GetTenantInfo()
-	bh := ses.GetBackgroundExec(ctx)
+	// Role membership changes must commit with the same latest-committed
+	// semantics used by active-session authorization refreshes. Otherwise an
+	// SI snapshot can make a committed REVOKE temporarily invisible even to a
+	// fresh private authorization transaction.
+	bh := ses.GetBackgroundExec(ctx, &BackgroundExecOption{forcePessimisticRC: true})
 	defer bh.Close()
 
 	// step1 : check Roles exists or not
@@ -7974,7 +8020,24 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 	if err != nil {
 		return false, stats, err
 	}
-	if enableCache && !priv.needMatchedRole {
+
+	tenant := ses.GetTenantInfo()
+	roleGrantNeedsCheck := activeRoleGrantNeedsCheck(tenant)
+	roleGrantValid := !roleGrantNeedsCheck
+	roleGrantCached := !roleGrantNeedsCheck
+	cache := ses.GetPrivilegeCache()
+	if roleGrantNeedsCheck && enableCache && cache != nil {
+		roleGrantValid, roleGrantCached = cache.getActiveRoleGrant(
+			tenant.GetUserID(), tenant.GetDefaultRoleID())
+		if roleGrantCached && !roleGrantValid {
+			return false, stats, activeRoleGrantAuthorizationError(ctx)
+		}
+	}
+
+	// A privilege hit is usable only after the active role membership from the
+	// same cache generation has been validated. Otherwise a revoked role can
+	// keep authorizing statements solely through stale session state.
+	if roleGrantCached && enableCache && !priv.needMatchedRole {
 		yes, err = checkPrivilegeInCache(ctx, ses, priv, enableCache)
 		if err != nil {
 			return false, stats, err
@@ -7985,8 +8048,16 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 		}
 	}
 
-	tenant := ses.GetTenantInfo()
-	bh := ses.GetBackgroundExec(ctx)
+	var backgroundExecOptions []*BackgroundExecOption
+	if roleGrantNeedsCheck && !roleGrantCached {
+		// Active role membership is external authorization state. Revalidate it
+		// in a private RC transaction so a user transaction opened before REVOKE
+		// cannot continue authorizing through its older catalog snapshot.
+		backgroundExecOptions = append(backgroundExecOptions, &BackgroundExecOption{
+			forcePessimisticRC: true,
+		})
+	}
+	bh := ses.GetBackgroundExec(ctx, backgroundExecOptions...)
 	defer func() {
 		stats = bh.GetExecStatsArray()
 		bh.Close()
@@ -8020,6 +8091,32 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 	}()
 	if err != nil {
 		return false, stats, err
+	}
+
+	if !roleGrantCached {
+		roleGrantValid, err = activeRoleGrantIsValid(ctx, bh, tenant)
+		if err != nil {
+			return false, stats, err
+		}
+		if enableCache && cache != nil {
+			cache.setActiveRoleGrant(tenant.GetUserID(), tenant.GetDefaultRoleID(), roleGrantValid)
+		}
+		if !roleGrantValid {
+			return false, stats, activeRoleGrantAuthorizationError(ctx)
+		}
+
+		// This is the first authorization in the cache generation. Reuse any
+		// compatible privilege entries only after membership has been proved.
+		if enableCache && !priv.needMatchedRole {
+			yes, err = checkPrivilegeInCache(ctx, ses, priv, enableCache)
+			if err != nil {
+				return false, stats, err
+			}
+			if yes {
+				priv.matchedRoleID = int64(tenant.GetDefaultRoleID())
+				return true, stats, nil
+			}
+		}
 	}
 
 	// step 2: The Set R2 {the roleid granted to the userid}
@@ -8147,6 +8244,100 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 		roleSetOfKthIteration, roleSetOfKPlusOneThIteration = roleSetOfKPlusOneThIteration, roleSetOfKthIteration
 	}
 	return ret, stats, err
+}
+
+func activeRoleGrantNeedsCheck(tenant *TenantInfo) bool {
+	if tenant == nil {
+		return false
+	}
+	switch tenant.GetDefaultRoleID() {
+	case moAdminRoleID, publicRoleID, accountAdminRoleID:
+		return false
+	default:
+		return true
+	}
+}
+
+func activeRoleGrantIsValid(ctx context.Context, bh BackgroundExec, tenant *TenantInfo) (bool, error) {
+	if !activeRoleGrantNeedsCheck(tenant) {
+		return true, nil
+	}
+
+	bh.ClearExecResultSet()
+	if err := bh.Exec(ctx, getSqlForCheckUserGrantForAuthorization(
+		int64(tenant.GetDefaultRoleID()), int64(tenant.GetUserID()))); err != nil {
+		return false, err
+	}
+	erArray, err := getResultSet(ctx, bh)
+	if err != nil {
+		return false, err
+	}
+	return execResultArrayHasData(erArray), nil
+}
+
+func activeRoleGrantAuthorizationError(ctx context.Context) error {
+	return moerr.NewInternalError(ctx, "do not have privilege to execute the statement")
+}
+
+// validateActiveRoleGrantForAuthorization covers authorization paths that use
+// the active role but do not pass through determineUserHasPrivilegeSet, such as
+// a privilege grant authorized solely by WITH GRANT OPTION.
+func validateActiveRoleGrantForAuthorization(
+	ctx context.Context,
+	ses *Session,
+) (ret bool, stats statistic.StatsArray, err error) {
+	stats.Reset()
+	tenant := ses.GetTenantInfo()
+	if !activeRoleGrantNeedsCheck(tenant) {
+		return true, stats, nil
+	}
+
+	enableCache, err := privilegeCacheIsEnabled(ctx, ses)
+	if err != nil {
+		return false, stats, err
+	}
+	cache := ses.GetPrivilegeCache()
+	if enableCache && cache != nil {
+		if valid, cached := cache.getActiveRoleGrant(
+			tenant.GetUserID(), tenant.GetDefaultRoleID()); cached {
+			return valid, stats, nil
+		}
+	}
+
+	// WITH GRANT OPTION authorization can bypass the general privilege walk,
+	// but must use the same latest-committed membership semantics.
+	bh := ses.GetBackgroundExec(ctx, &BackgroundExecOption{forcePessimisticRC: true})
+	defer func() {
+		stats = bh.GetExecStatsArray()
+		bh.Close()
+	}()
+
+	err = bh.Exec(ctx, "begin;")
+	defer func() {
+		err = finishTxn(ctx, bh, err)
+	}()
+	if err != nil {
+		return false, stats, err
+	}
+
+	ret, err = activeRoleGrantIsValid(ctx, bh, tenant)
+	if err != nil {
+		return false, stats, err
+	}
+	if enableCache && cache != nil {
+		cache.setActiveRoleGrant(tenant.GetUserID(), tenant.GetDefaultRoleID(), ret)
+	}
+	return ret, stats, nil
+}
+
+func (ses *Session) markActiveRoleGrantValid() {
+	tenant := ses.GetTenantInfo()
+	if !activeRoleGrantNeedsCheck(tenant) {
+		return
+	}
+	if cache := ses.GetPrivilegeCache(); cache != nil {
+		cache.setActiveRoleGrant(tenant.GetUserID(), tenant.GetDefaultRoleID(), true)
+	}
 }
 
 func matchedActiveRoleID(priv *privilege, matchedRoleID int64, roleRoot map[int64]int64) int64 {
@@ -9912,6 +10103,11 @@ func authenticateUserCanExecuteStatementWithObjectTypeNone(ctx context.Context, 
 			// in the version 0.6, only the moAdmin and accountAdmin can grant the privilege.
 			if tenant.IsAdminRole() {
 				return true, temp, nil
+			}
+			valid, delta, err := validateActiveRoleGrantForAuthorization(ctx, ses)
+			temp.Add(&delta)
+			if err != nil || !valid {
+				return false, temp, err
 			}
 			return determineUserCanGrantPrivilegesToOthers(ctx, ses, g)
 		}

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -914,6 +914,9 @@ func Test_determineCreateAccount(t *testing.T) {
 			getSqlForRoleIdOfUserId(2): newMrsForRoleIdOfUserId([][]interface{}{
 				{2, false},
 			}),
+			getSqlForCheckUserGrantForAuthorization(2, 2): newMrsForCheckUserGrant([][]interface{}{
+				{2, 2, false},
+			}),
 			getSqlForCheckRoleHasAccountLevelForStarWithSysScope(2, PrivilegeTypeCreateAccount, true): newMrsForCheckRoleHasPrivilege([][]interface{}{
 				{PrivilegeTypeAccountAll, false},
 			}),
@@ -948,6 +951,9 @@ func Test_determineCreateAccount(t *testing.T) {
 		sql2result := map[string]ExecResult{
 			getSqlForRoleIdOfUserId(2): newMrsForRoleIdOfUserId([][]interface{}{
 				{2, false},
+			}),
+			getSqlForCheckUserGrantForAuthorization(2, 2): newMrsForCheckUserGrant([][]interface{}{
+				{2, 2, false},
 			}),
 			getSqlForCheckRoleHasAccountLevelForStarWithSysScope(2, PrivilegeTypeAlterAccount, true): newMrsForCheckRoleHasPrivilege([][]interface{}{
 				{PrivilegeTypeAccountAll, false},
@@ -1086,6 +1092,9 @@ func Test_determineCreateAccount(t *testing.T) {
 			getSqlForRoleIdOfUserId(2): newMrsForRoleIdOfUserId([][]interface{}{
 				{2, false},
 			}),
+			getSqlForCheckUserGrantForAuthorization(2, 2): newMrsForCheckUserGrant([][]interface{}{
+				{2, 2, false},
+			}),
 			getSqlForCheckRoleHasAccountLevelForStarWithSysScope(2, PrivilegeTypeDropAccount, true): newMrsForCheckRoleHasPrivilege([][]interface{}{
 				{PrivilegeTypeAccountAll, false},
 			}),
@@ -1122,6 +1131,9 @@ func Test_determineCreateAccount(t *testing.T) {
 		sql2result := map[string]ExecResult{
 			getSqlForRoleIdOfUserId(2): newMrsForRoleIdOfUserId([][]interface{}{
 				{2, false},
+			}),
+			getSqlForCheckUserGrantForAuthorization(2, 2): newMrsForCheckUserGrant([][]interface{}{
+				{2, 2, false},
 			}),
 			getSqlForCheckRoleHasAccountLevelForStarWithSysScope(2, PrivilegeTypeUpgradeAccount, true): newMrsForCheckRoleHasPrivilege([][]interface{}{
 				{PrivilegeTypeAccountAll, false},
@@ -12088,10 +12100,7 @@ func newBh(ctrl *gomock.Controller, sql2result map[string]ExecResult) Background
 		return nil
 	}).AnyTimes()
 	bh.EXPECT().GetExecResultSet().DoAndReturn(func() []interface{} {
-		result, ok := sql2result[currentSql]
-		if !ok {
-			result = sql2result[backgroundExecTestFixtureSQL(currentSql)]
-		}
+		result := sql2result[currentSql]
 		return []interface{}{result}
 	}).AnyTimes()
 	bh.EXPECT().GetExecStatsArray().DoAndReturn(func() statistic.StatsArray {
@@ -12108,6 +12117,7 @@ type backgroundExecTest struct {
 	sql2result                     map[string]ExecResult
 	sql2err                        map[string]error
 	executedSQLs                   []string
+	beforeExec                     func(string)
 	dropDatabaseIgnoresForeignKeys bool
 	systemCTELimits                []bool
 	executionAccountIDs            []uint32
@@ -12200,6 +12210,9 @@ func (bt *backgroundExecTest) GetExecStatsArray() statistic.StatsArray {
 }
 
 func (bt *backgroundExecTest) Exec(ctx context.Context, s string) error {
+	if bt.beforeExec != nil {
+		bt.beforeExec(s)
+	}
 	bt.currentSql = s
 	bt.executedSQLs = append(bt.executedSQLs, s)
 	bt.systemCTELimits = append(bt.systemCTELimits, process.HasSystemCTELimits(ctx))
@@ -12211,15 +12224,7 @@ func (bt *backgroundExecTest) Exec(ctx context.Context, s string) error {
 	if err, ok := bt.sql2err[s]; ok {
 		return err
 	}
-	return bt.sql2err[backgroundExecTestFixtureSQL(s)]
-}
-
-func backgroundExecTestFixtureSQL(sql string) string {
-	if strings.HasPrefix(sql, "select role_id,user_id,with_grant_option from mo_catalog.mo_user_grant ") &&
-		strings.HasSuffix(sql, " for update;") {
-		return strings.TrimSuffix(sql, " for update;") + ";"
-	}
-	return sql
+	return nil
 }
 
 func (bt *backgroundExecTest) ExecWithSQLMode(ctx context.Context, s string, sqlMode string) error {
@@ -12235,9 +12240,6 @@ func (bt *backgroundExecTest) ExecRestore(ctx context.Context, s string, from ui
 
 func (bt *backgroundExecTest) GetExecResultSet() []interface{} {
 	result, ok := bt.sql2result[bt.currentSql]
-	if !ok {
-		result, ok = bt.sql2result[backgroundExecTestFixtureSQL(bt.currentSql)]
-	}
 	if !ok &&
 		strings.HasPrefix(bt.currentSql, "select granted_id,with_grant_option from mo_catalog.mo_role_grant where grantee_id = ") {
 		return []interface{}{newMrsForInheritedRoleIdOfRoleId([][]interface{}{})}
@@ -13244,6 +13246,29 @@ func TestActiveRoleGrantCacheLifecycle(t *testing.T) {
 	require.False(t, valid)
 }
 
+func TestActiveRoleGrantCacheRejectsStaleGeneration(t *testing.T) {
+	var nilCache *privilegeCache
+	require.Zero(t, nilCache.getActiveRoleGrantGeneration())
+
+	cache := &privilegeCache{}
+	generation := cache.getActiveRoleGrantGeneration()
+	cache.invalidate()
+
+	require.False(t, cache.setActiveRoleGrantForGeneration(2, 3, true, generation))
+	_, cached := cache.getActiveRoleGrant(2, 3)
+	require.False(t, cached)
+
+	// Model the narrow race where an old validation stores after invalidate's
+	// clear. The generation embedded in the entry still makes it unusable.
+	cache.activeRoleGrant.Store(&activeRoleGrantCacheEntry{
+		key:        activeRoleGrantKey(2, 3),
+		valid:      true,
+		generation: generation,
+	})
+	_, cached = cache.getActiveRoleGrant(2, 3)
+	require.False(t, cached)
+}
+
 func TestActiveRoleGrantCachePublishesKeyAndValueAtomically(t *testing.T) {
 	cache := &privilegeCache{}
 	const iterations = 10_000
@@ -13275,8 +13300,12 @@ func TestActiveRoleGrantCachePublishesKeyAndValueAtomically(t *testing.T) {
 }
 
 func TestActiveRoleGrantValidationCompatibility(t *testing.T) {
-	for _, roleID := range []uint32{moAdminRoleID, publicRoleID, accountAdminRoleID} {
-		tenant := &TenantInfo{DefaultRoleID: roleID}
+	for _, tenant := range []*TenantInfo{
+		{Tenant: sysAccountName, TenantID: sysAccountID, DefaultRoleID: moAdminRoleID},
+		{Tenant: sysAccountName, TenantID: sysAccountID, DefaultRoleID: publicRoleID},
+		{Tenant: "acc1", TenantID: 1, DefaultRoleID: accountAdminRoleID},
+		{Tenant: "acc1", TenantID: 1, DefaultRoleID: publicRoleID},
+	} {
 		require.False(t, activeRoleGrantNeedsCheck(tenant))
 		valid, err := activeRoleGrantIsValid(context.Background(), nil, tenant)
 		require.NoError(t, err)
@@ -13284,7 +13313,129 @@ func TestActiveRoleGrantValidationCompatibility(t *testing.T) {
 	}
 
 	require.False(t, activeRoleGrantNeedsCheck(nil))
-	require.True(t, activeRoleGrantNeedsCheck(&TenantInfo{DefaultRoleID: 3}))
+	require.True(t, activeRoleGrantNeedsCheck(&TenantInfo{
+		Tenant: sysAccountName, TenantID: sysAccountID, DefaultRoleID: accountAdminRoleID,
+	}))
+	require.True(t, activeRoleGrantNeedsCheck(&TenantInfo{
+		Tenant: "acc1", TenantID: 1, DefaultRoleID: moAdminRoleID,
+	}))
+	require.True(t, activeRoleGrantNeedsCheck(&TenantInfo{
+		Tenant: "acc1", TenantID: 1, DefaultRoleID: 3,
+	}))
+}
+
+func TestActiveRoleGrantAuthorizationUsesNonLockingRead(t *testing.T) {
+	sql := getSqlForCheckUserGrantForAuthorization(3, 2)
+	require.Equal(t, getSqlForCheckUserGrant(3, 2), sql)
+	require.NotContains(t, strings.ToLower(sql), "for update")
+}
+
+func TestSysTenantCustomRoleIDTwoIsRevalidated(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+
+	cache := &privilegeCache{}
+	ses := &Session{cache: cache}
+	ses.SetTenantInfo(&TenantInfo{
+		Tenant:        sysAccountName,
+		TenantID:      sysAccountID,
+		User:          "alice",
+		UserID:        2,
+		DefaultRole:   "custom_role",
+		DefaultRoleID: accountAdminRoleID,
+	})
+	bh := &backgroundExecTest{}
+	bh.init()
+	roleGrantSQL := getSqlForCheckUserGrantForAuthorization(accountAdminRoleID, 2)
+	bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(nil)
+	backgroundExecStub := gostub.StubFunc(&NewBackgroundExec, bh)
+	defer backgroundExecStub.Reset()
+
+	valid, _, err := validateActiveRoleGrantForAuthorization(context.Background(), ses)
+	require.NoError(t, err)
+	require.False(t, valid)
+	require.Contains(t, bh.executedSQLs, roleGrantSQL)
+	cachedValid, cached := cache.getActiveRoleGrant(2, accountAdminRoleID)
+	require.True(t, cached)
+	require.False(t, cachedValid)
+}
+
+func TestActiveRoleGrantAuthorizationDoesNotSerializeSameUser(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return false, nil
+	})
+	defer cacheEnabledStub.Reset()
+
+	roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+	arrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	executors := make([]BackgroundExec, 2)
+	for i := range executors {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(
+			[][]interface{}{{int64(3), int64(2), false}})
+		bh.beforeExec = func(sql string) {
+			if sql == roleGrantSQL {
+				arrived <- struct{}{}
+				<-release
+			}
+		}
+		executors[i] = bh
+	}
+
+	var executorMu sync.Mutex
+	nextExecutor := 0
+	backgroundExecStub := gostub.Stub(&NewBackgroundExec, func(
+		_ context.Context,
+		_ FeSession,
+		_ ...*BackgroundExecOption,
+	) BackgroundExec {
+		executorMu.Lock()
+		defer executorMu.Unlock()
+		executor := executors[nextExecutor]
+		nextExecutor++
+		return executor
+	})
+	defer backgroundExecStub.Reset()
+
+	results := make(chan error, 2)
+	start := time.Now()
+	for range 2 {
+		ses := &Session{cache: &privilegeCache{}}
+		ses.SetTenantInfo(&TenantInfo{
+			Tenant:        "acc1",
+			User:          "alice",
+			TenantID:      1,
+			UserID:        2,
+			DefaultRole:   "reader",
+			DefaultRoleID: 3,
+		})
+		go func() {
+			_, _, err := validateActiveRoleGrantForAuthorization(context.Background(), ses)
+			results <- err
+		}()
+	}
+
+	deadline := time.After(time.Second)
+	for range 2 {
+		select {
+		case <-arrived:
+		case <-deadline:
+			close(release)
+			for range 2 {
+				<-results
+			}
+			t.Fatal("same-user authorization reads did not reach the catalog concurrently")
+		}
+	}
+	close(release)
+	for range 2 {
+		require.NoError(t, <-results)
+	}
+	require.Less(t, time.Since(start), 2*time.Second)
 }
 
 func TestValidateActiveRoleGrantForAuthorizationDoesNotCacheCatalogErrors(t *testing.T) {
@@ -13331,6 +13482,193 @@ func TestValidateActiveRoleGrantForAuthorizationDoesNotCacheCatalogErrors(t *tes
 	valid, _, err = validateActiveRoleGrantForAuthorization(context.Background(), ses)
 	require.NoError(t, err)
 	require.True(t, valid)
+}
+
+func TestValidateActiveRoleGrantForAuthorizationPublishesOnlyAfterCommit(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+
+	for _, tc := range []struct {
+		name  string
+		rows  [][]interface{}
+		valid bool
+	}{
+		{name: "granted", rows: [][]interface{}{{int64(3), int64(2), false}}, valid: true},
+		{name: "revoked", valid: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := &privilegeCache{}
+			ses := &Session{cache: cache}
+			ses.SetTenantInfo(&TenantInfo{
+				Tenant:        "acc1",
+				User:          "alice",
+				TenantID:      1,
+				UserID:        2,
+				DefaultRole:   "reader",
+				DefaultRoleID: 3,
+			})
+			bh := &backgroundExecTest{}
+			bh.init()
+			roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+			bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(tc.rows)
+			commitErr := errors.New("commit failed")
+			bh.sql2err["commit;"] = commitErr
+			backgroundExecStub := gostub.StubFunc(&NewBackgroundExec, bh)
+			defer backgroundExecStub.Reset()
+
+			valid, _, err := validateActiveRoleGrantForAuthorization(context.Background(), ses)
+			require.False(t, valid)
+			require.ErrorIs(t, err, commitErr)
+			require.Contains(t, bh.executedSQLs, "rollback;")
+			_, cached := cache.getActiveRoleGrant(2, 3)
+			require.False(t, cached)
+		})
+	}
+}
+
+func TestDetermineUserHasPrivilegeSetPublishesRoleGrantOnlyAfterCommit(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+	cacheHitStub := gostub.Stub(&checkPrivilegeInCache, func(context.Context, *Session, *privilege, bool) (bool, error) {
+		return true, nil
+	})
+	defer cacheHitStub.Reset()
+
+	for _, tc := range []struct {
+		name string
+		rows [][]interface{}
+	}{
+		{name: "granted", rows: [][]interface{}{{int64(3), int64(2), false}}},
+		{name: "revoked"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := &privilegeCache{}
+			ses := &Session{cache: cache}
+			ses.SetTenantInfo(&TenantInfo{
+				Tenant:        "acc1",
+				User:          "alice",
+				TenantID:      1,
+				UserID:        2,
+				DefaultRole:   "reader",
+				DefaultRoleID: 3,
+			})
+			bh := &backgroundExecTest{}
+			bh.init()
+			roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+			bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(tc.rows)
+			commitErr := errors.New("commit failed")
+			bh.sql2err["commit;"] = commitErr
+			backgroundExecStub := gostub.StubFunc(&NewBackgroundExec, bh)
+			defer backgroundExecStub.Reset()
+
+			priv := determinePrivilegeSetOfStatement(&tree.ShowDatabases{})
+			_, _, err := determineUserHasPrivilegeSet(context.Background(), ses, priv)
+			require.ErrorIs(t, err, commitErr)
+			require.Contains(t, bh.executedSQLs, "rollback;")
+			_, cached := cache.getActiveRoleGrant(2, 3)
+			require.False(t, cached)
+		})
+	}
+}
+
+func TestDetermineUserHasPrivilegeSetPublishesRoleGrantAfterSuccessfulCommit(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+	cacheHitStub := gostub.Stub(&checkPrivilegeInCache, func(context.Context, *Session, *privilege, bool) (bool, error) {
+		return true, nil
+	})
+	defer cacheHitStub.Reset()
+
+	for _, tc := range []struct {
+		name      string
+		rows      [][]interface{}
+		wantValid bool
+		wantError bool
+	}{
+		{name: "granted", rows: [][]interface{}{{int64(3), int64(2), false}}, wantValid: true},
+		{name: "revoked", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := &privilegeCache{}
+			ses := &Session{cache: cache}
+			ses.SetTenantInfo(&TenantInfo{
+				Tenant:        "acc1",
+				User:          "alice",
+				TenantID:      1,
+				UserID:        2,
+				DefaultRole:   "reader",
+				DefaultRoleID: 3,
+			})
+			bh := &backgroundExecTest{}
+			bh.init()
+			roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+			bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(tc.rows)
+			bh.beforeExec = func(sql string) {
+				if sql == "commit;" {
+					_, cached := cache.getActiveRoleGrant(2, 3)
+					require.False(t, cached)
+				}
+			}
+			backgroundExecStub := gostub.StubFunc(&NewBackgroundExec, bh)
+			defer backgroundExecStub.Reset()
+
+			priv := determinePrivilegeSetOfStatement(&tree.ShowDatabases{})
+			valid, _, err := determineUserHasPrivilegeSet(context.Background(), ses, priv)
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantValid, valid)
+			cachedValid, cached := cache.getActiveRoleGrant(2, 3)
+			require.True(t, cached)
+			require.Equal(t, tc.wantValid, cachedValid)
+		})
+	}
+}
+
+func TestValidateActiveRoleGrantForAuthorizationDoesNotPublishAcrossInvalidation(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+
+	cache := &privilegeCache{}
+	ses := &Session{cache: cache}
+	ses.SetTenantInfo(&TenantInfo{
+		Tenant:        "acc1",
+		User:          "alice",
+		TenantID:      1,
+		UserID:        2,
+		DefaultRole:   "reader",
+		DefaultRoleID: 3,
+	})
+	bh := &backgroundExecTest{}
+	bh.init()
+	roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+	bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(
+		[][]interface{}{{int64(3), int64(2), false}})
+	bh.beforeExec = func(sql string) {
+		if sql == "commit;" {
+			_, cached := cache.getActiveRoleGrant(2, 3)
+			require.False(t, cached)
+			cache.invalidate()
+		}
+	}
+	backgroundExecStub := gostub.StubFunc(&NewBackgroundExec, bh)
+	defer backgroundExecStub.Reset()
+
+	valid, _, err := validateActiveRoleGrantForAuthorization(context.Background(), ses)
+	require.NoError(t, err)
+	require.True(t, valid)
+	_, cached := cache.getActiveRoleGrant(2, 3)
+	require.False(t, cached)
 }
 
 func TestRevokedActiveRoleCannotUseAuthorizationFallbacks(t *testing.T) {

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2517,6 +2518,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 				UserID:        1001,
 				DefaultRoleID: 1001,
 			}
+			ses.markActiveRoleGrantValid()
 			ses.SetDatabaseName("db")
 			//TODO: make sql2result
 			bh.init()
@@ -2694,6 +2696,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 				UserID:        1001,
 				DefaultRoleID: 1001,
 			}
+			ses.markActiveRoleGrantValid()
 			ses.SetDatabaseName("db")
 			//TODO: make sql2result
 			bh.init()
@@ -2844,6 +2847,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		bh.init()
 
 		checkSql, err := getSqlForCheckDatabase(ses.GetTxnHandler().GetTxnCtx(), "db")
@@ -2900,6 +2904,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -2962,6 +2967,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3016,6 +3022,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3071,6 +3078,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		bh.init()
 
 		checkSql, err := getSqlForCheckDatabase(ses.GetTxnHandler().GetTxnCtx(), "db1")
@@ -3131,6 +3139,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3199,6 +3208,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3275,6 +3285,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3351,6 +3362,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3425,6 +3437,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3478,6 +3491,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3552,6 +3566,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3638,6 +3653,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3701,6 +3717,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3771,6 +3788,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3846,6 +3864,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3904,6 +3923,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -3971,6 +3991,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: 1001,
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -4028,6 +4049,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: uint32(internRoleID),
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -4092,6 +4114,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: uint32(internRoleID),
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -4167,6 +4190,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: uint32(internRoleID),
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -4251,6 +4275,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 			UserID:        1001,
 			DefaultRoleID: uint32(internRoleID),
 		}
+		ses.markActiveRoleGrantValid()
 		ctx := ses.GetTxnHandler().GetTxnCtx()
 		bh.init()
 
@@ -4326,6 +4351,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 				UserID:        1001,
 				DefaultRoleID: 1001,
 			}
+			ses.markActiveRoleGrantValid()
 			ses.SetDatabaseName("db")
 			//TODO: make sql2result
 			bh.init()
@@ -4407,6 +4433,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 				UserID:        1001,
 				DefaultRoleID: 1001,
 			}
+			ses.markActiveRoleGrantValid()
 			ses.SetDatabaseName("db")
 			//TODO: make sql2result
 			bh.init()
@@ -4479,6 +4506,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 				UserID:        1001,
 				DefaultRoleID: 1001,
 			}
+			ses.markActiveRoleGrantValid()
 			ses.SetDatabaseName("db")
 			//TODO: make sql2result
 			bh.init()
@@ -4540,6 +4568,7 @@ func Test_determineGrantPrivilege(t *testing.T) {
 				UserID:        1001,
 				DefaultRoleID: 1001,
 			}
+			ses.markActiveRoleGrantValid()
 			ses.SetDatabaseName("db")
 			//TODO: make sql2result
 			bh.init()
@@ -6298,7 +6327,9 @@ func TestAuthenticateMongoDBExternalScanSelectPrivilege(t *testing.T) {
 				DefaultRoleID: roleID,
 			})
 
-			sql2result := makeSql2ExecResult2(userID, nil, nil, nil, nil, nil, nil, nil, nil)
+			sql2result := makeSql2ExecResult2(userID, [][]interface{}{
+				{roleID, false},
+			}, nil, nil, nil, nil, nil, nil, nil)
 			addTablePrivilegeResultsForRole(t, sql2result, roleID, dbName, tableName, map[PrivilegeType]bool{
 				PrivilegeTypeSelect: tc.tableSelect,
 			})
@@ -8058,7 +8089,15 @@ func Test_doRevokeRole(t *testing.T) {
 		bh := &backgroundExecTest{}
 		bh.init()
 
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
+		var forcedPessimisticRC bool
+		bhStub := gostub.Stub(&NewBackgroundExec, func(
+			_ context.Context,
+			_ FeSession,
+			opts ...*BackgroundExecOption,
+		) BackgroundExec {
+			forcedPessimisticRC = len(opts) == 1 && opts[0] != nil && opts[0].forcePessimisticRC
+			return bh
+		})
 		defer bhStub.Reset()
 
 		stmt := &tree.RevokeRole{
@@ -8111,6 +8150,7 @@ func Test_doRevokeRole(t *testing.T) {
 
 		err := doRevokeRole(ses.GetTxnHandler().GetTxnCtx(), ses, stmt)
 		convey.So(err, convey.ShouldBeNil)
+		convey.So(forcedPessimisticRC, convey.ShouldBeTrue)
 	})
 
 	convey.Convey("revoke role from role succ (if exists = true, miss role before FROM)", t, func() {
@@ -10259,6 +10299,9 @@ func TestDoSwitchRolePrimaryRoleInvalidatesRuleCache(t *testing.T) {
 		convey.So(tenant.GetDefaultRoleID(), convey.ShouldEqual, uint32(6))
 		convey.So(tenant.GetDefaultRole(), convey.ShouldEqual, "role2")
 		convey.So(tenant.GetUseSecondaryRole(), convey.ShouldBeFalse)
+		valid, cached := ses.GetPrivilegeCache().getActiveRoleGrant(tenant.GetUserID(), 6)
+		convey.So(cached, convey.ShouldBeTrue)
+		convey.So(valid, convey.ShouldBeTrue)
 
 		ses.ruleCacheMu.RLock()
 		cacheIsNil := ses.ruleCache == nil
@@ -12045,7 +12088,11 @@ func newBh(ctrl *gomock.Controller, sql2result map[string]ExecResult) Background
 		return nil
 	}).AnyTimes()
 	bh.EXPECT().GetExecResultSet().DoAndReturn(func() []interface{} {
-		return []interface{}{sql2result[currentSql]}
+		result, ok := sql2result[currentSql]
+		if !ok {
+			result = sql2result[backgroundExecTestFixtureSQL(currentSql)]
+		}
+		return []interface{}{result}
 	}).AnyTimes()
 	bh.EXPECT().GetExecStatsArray().DoAndReturn(func() statistic.StatsArray {
 		var stats statistic.StatsArray
@@ -12161,7 +12208,18 @@ func (bt *backgroundExecTest) Exec(ctx context.Context, s string) error {
 	if strings.HasPrefix(s, "drop database if exists ") {
 		bt.dropDatabaseIgnoresForeignKeys, _ = ctx.Value(defines.IgnoreForeignKey{}).(bool)
 	}
-	return bt.sql2err[s]
+	if err, ok := bt.sql2err[s]; ok {
+		return err
+	}
+	return bt.sql2err[backgroundExecTestFixtureSQL(s)]
+}
+
+func backgroundExecTestFixtureSQL(sql string) string {
+	if strings.HasPrefix(sql, "select role_id,user_id,with_grant_option from mo_catalog.mo_user_grant ") &&
+		strings.HasSuffix(sql, " for update;") {
+		return strings.TrimSuffix(sql, " for update;") + ";"
+	}
+	return sql
 }
 
 func (bt *backgroundExecTest) ExecWithSQLMode(ctx context.Context, s string, sqlMode string) error {
@@ -12176,11 +12234,15 @@ func (bt *backgroundExecTest) ExecRestore(ctx context.Context, s string, from ui
 }
 
 func (bt *backgroundExecTest) GetExecResultSet() []interface{} {
-	if _, ok := bt.sql2result[bt.currentSql]; !ok &&
+	result, ok := bt.sql2result[bt.currentSql]
+	if !ok {
+		result, ok = bt.sql2result[backgroundExecTestFixtureSQL(bt.currentSql)]
+	}
+	if !ok &&
 		strings.HasPrefix(bt.currentSql, "select granted_id,with_grant_option from mo_catalog.mo_role_grant where grantee_id = ") {
 		return []interface{}{newMrsForInheritedRoleIdOfRoleId([][]interface{}{})}
 	}
-	return []interface{}{bt.sql2result[bt.currentSql]}
+	return []interface{}{result}
 }
 
 func (bt *backgroundExecTest) ClearExecResultSet() {
@@ -12888,6 +12950,17 @@ func makeRowsOfMoRole(sql2result map[string]ExecResult, roleNames []string, rows
 
 func makeRowsOfMoUserGrant(sql2result map[string]ExecResult, userId int, rows [][]interface{}) {
 	sql2result[getSqlForRoleIdOfUserId(userId)] = newMrsForRoleIdOfUserId(rows)
+	for _, row := range rows {
+		if len(row) < 2 {
+			continue
+		}
+		roleID, err := strconv.ParseInt(fmt.Sprint(row[0]), 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("invalid role id %v in mo_user_grant fixture: %v", row[0], err))
+		}
+		sql2result[getSqlForCheckUserGrant(roleID, int64(userId))] = newMrsForCheckUserGrant(
+			[][]interface{}{{roleID, int64(userId), row[1]}})
+	}
 }
 
 func makeRowsOfMoRolePrivs(sql2result map[string]ExecResult, roleIds []int, entries []privilegeEntry, rowsOfMoRolePrivs [][]interface{}) {
@@ -13137,6 +13210,193 @@ func Test_cache(t *testing.T) {
 			ret = cache1.has(objectTypeTable, privilegeLevelStar, a.db, a.table, PrivilegeTypeCreateObject)
 			convey.So(ret, convey.ShouldBeFalse)
 		}
+	})
+}
+
+func TestActiveRoleGrantCacheLifecycle(t *testing.T) {
+	var nilCache *privilegeCache
+	_, cached := nilCache.getActiveRoleGrant(2, 3)
+	require.False(t, cached)
+	nilCache.setActiveRoleGrant(2, 3, true)
+
+	cache := &privilegeCache{}
+
+	_, cached = cache.getActiveRoleGrant(2, 3)
+	require.False(t, cached)
+
+	cache.setActiveRoleGrant(2, 3, true)
+	valid, cached := cache.getActiveRoleGrant(2, 3)
+	require.True(t, cached)
+	require.True(t, valid)
+
+	// Switching the session's active role cannot reuse the previous role's
+	// membership decision.
+	_, cached = cache.getActiveRoleGrant(2, 4)
+	require.False(t, cached)
+
+	cache.invalidate()
+	_, cached = cache.getActiveRoleGrant(2, 3)
+	require.False(t, cached)
+
+	cache.setActiveRoleGrant(2, 3, false)
+	valid, cached = cache.getActiveRoleGrant(2, 3)
+	require.True(t, cached)
+	require.False(t, valid)
+}
+
+func TestActiveRoleGrantCachePublishesKeyAndValueAtomically(t *testing.T) {
+	cache := &privilegeCache{}
+	const iterations = 10_000
+
+	var writers sync.WaitGroup
+	writers.Add(2)
+	go func() {
+		defer writers.Done()
+		for range iterations {
+			cache.setActiveRoleGrant(2, 3, true)
+		}
+	}()
+	go func() {
+		defer writers.Done()
+		for range iterations {
+			cache.setActiveRoleGrant(4, 5, false)
+		}
+	}()
+
+	for range iterations {
+		if valid, cached := cache.getActiveRoleGrant(2, 3); cached {
+			require.True(t, valid)
+		}
+		if valid, cached := cache.getActiveRoleGrant(4, 5); cached {
+			require.False(t, valid)
+		}
+	}
+	writers.Wait()
+}
+
+func TestActiveRoleGrantValidationCompatibility(t *testing.T) {
+	for _, roleID := range []uint32{moAdminRoleID, publicRoleID, accountAdminRoleID} {
+		tenant := &TenantInfo{DefaultRoleID: roleID}
+		require.False(t, activeRoleGrantNeedsCheck(tenant))
+		valid, err := activeRoleGrantIsValid(context.Background(), nil, tenant)
+		require.NoError(t, err)
+		require.True(t, valid)
+	}
+
+	require.False(t, activeRoleGrantNeedsCheck(nil))
+	require.True(t, activeRoleGrantNeedsCheck(&TenantInfo{DefaultRoleID: 3}))
+}
+
+func TestValidateActiveRoleGrantForAuthorizationDoesNotCacheCatalogErrors(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+
+	ses := &Session{cache: &privilegeCache{}}
+	ses.SetTenantInfo(&TenantInfo{
+		Tenant:        "acc1",
+		User:          "alice",
+		TenantID:      1,
+		UserID:        2,
+		DefaultRole:   "reader",
+		DefaultRoleID: 3,
+	})
+	bh := &backgroundExecTest{}
+	bh.init()
+	roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+	catalogErr := errors.New("role grant catalog unavailable")
+	bh.sql2err[roleGrantSQL] = catalogErr
+	var forcedPessimisticRC bool
+	backgroundExecStub := gostub.Stub(&NewBackgroundExec, func(
+		_ context.Context,
+		_ FeSession,
+		opts ...*BackgroundExecOption,
+	) BackgroundExec {
+		forcedPessimisticRC = len(opts) == 1 && opts[0] != nil && opts[0].forcePessimisticRC
+		return bh
+	})
+	defer backgroundExecStub.Reset()
+
+	valid, _, err := validateActiveRoleGrantForAuthorization(context.Background(), ses)
+	require.False(t, valid)
+	require.ErrorIs(t, err, catalogErr)
+	require.True(t, forcedPessimisticRC)
+	_, cached := ses.GetPrivilegeCache().getActiveRoleGrant(2, 3)
+	require.False(t, cached)
+
+	delete(bh.sql2err, roleGrantSQL)
+	bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(
+		[][]interface{}{{int64(3), int64(2), false}})
+	valid, _, err = validateActiveRoleGrantForAuthorization(context.Background(), ses)
+	require.NoError(t, err)
+	require.True(t, valid)
+}
+
+func TestRevokedActiveRoleCannotUseAuthorizationFallbacks(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+
+	newRevokedSession := func(priv *privilege) *Session {
+		ses := &Session{cache: &privilegeCache{}, priv: priv}
+		ses.SetFromRealUser(true)
+		ses.SetTenantInfo(&TenantInfo{
+			Tenant:        "acc1",
+			User:          "alice",
+			TenantID:      1,
+			UserID:        2,
+			DefaultRole:   "reader",
+			DefaultRoleID: 3,
+		})
+		ses.GetPrivilegeCache().setActiveRoleGrant(2, 3, false)
+		return ses
+	}
+
+	t.Run("database ownership", func(t *testing.T) {
+		stmt := &tree.DropDatabase{Name: tree.Identifier("owned_db")}
+		ses := newRevokedSession(determinePrivilegeSetOfStatement(stmt))
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[getSqlForGetOwnerOfDatabase("owned_db")] = newMrsForOwner(
+			[][]interface{}{{int64(3)}})
+		backgroundExecStub := gostub.StubFunc(&NewBackgroundExec, bh)
+		defer backgroundExecStub.Reset()
+
+		ok, _, err := authenticateUserCanExecuteStatementWithObjectTypeAccountAndDatabase(
+			context.Background(), ses, stmt)
+		require.False(t, ok)
+		require.Error(t, err)
+		require.Empty(t, bh.executedSQLs, "revoked role must not reach ownership fallback")
+	})
+
+	t.Run("privilege grant option", func(t *testing.T) {
+		stmt := &tree.GrantPrivilege{
+			Privileges: []*tree.Privilege{{Type: tree.PRIVILEGE_TYPE_STATIC_SELECT}},
+			ObjType:    tree.OBJECT_TYPE_TABLE,
+			Level:      &tree.PrivilegeLevel{Level: tree.PRIVILEGE_LEVEL_TYPE_STAR_STAR},
+		}
+		ses := newRevokedSession(determinePrivilegeSetOfStatement(stmt))
+		bh := &backgroundExecTest{}
+		bh.init()
+		backgroundExecStub := gostub.StubFunc(&NewBackgroundExec, bh)
+		defer backgroundExecStub.Reset()
+
+		ok, _, err := authenticateUserCanExecuteStatementWithObjectTypeNone(
+			context.Background(), ses, stmt)
+		require.False(t, ok)
+		require.NoError(t, err)
+		require.Empty(t, bh.executedSQLs, "revoked role must not reach WITH GRANT OPTION traversal")
+	})
+
+	t.Run("role switch remains available", func(t *testing.T) {
+		stmt := &tree.SetRole{}
+		ses := newRevokedSession(determinePrivilegeSetOfStatement(stmt))
+		ok, _, err := authenticateUserCanExecuteStatementWithObjectTypeNone(
+			context.Background(), ses, stmt)
+		require.True(t, ok)
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -10315,6 +10315,23 @@ func TestDoSwitchRolePrimaryRoleInvalidatesRuleCache(t *testing.T) {
 		convey.So(cached, convey.ShouldBeTrue)
 		convey.So(valid, convey.ShouldBeTrue)
 
+		// A role switch while privilege caching is disabled must not publish a
+		// membership decision that a later cache enable could reuse.
+		convey.So(ses.SetSessionSysVar(context.Background(), "enable_privilege_cache", int8(0)), convey.ShouldBeNil)
+		roleSQL, err = getSqlForRoleIdOfRole(context.Background(), "role3")
+		convey.So(err, convey.ShouldBeNil)
+		bh.sql2result[roleSQL] = newMrsForRoleIdOfRole([][]interface{}{{int64(7)}})
+		bh.sql2result[getSqlForCheckUserGrant(7, int64(tenant.UserID))] = newMrsForCheckUserGrant([][]interface{}{
+			{int64(7), int64(tenant.UserID), false},
+		})
+		err = doSwitchRole(ses.GetTxnHandler().GetTxnCtx(), ses, &tree.SetRole{
+			Role: &tree.Role{UserName: "role3"},
+		})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(tenant.GetDefaultRoleID(), convey.ShouldEqual, uint32(7))
+		_, cached = ses.GetPrivilegeCache().getActiveRoleGrant(tenant.GetUserID(), 7)
+		convey.So(cached, convey.ShouldBeFalse)
+
 		ses.ruleCacheMu.RLock()
 		cacheIsNil := ses.ruleCache == nil
 		ses.ruleCacheMu.RUnlock()

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1596,13 +1596,16 @@ func doSetVar(
 				}
 			}
 		} else if assign.System && name == "enable_privilege_cache" {
-			ok, err = valueIsBoolTrue(value)
+			_, err = valueIsBoolTrue(value)
 			if err != nil {
 				return err
 			}
 
-			//disable privilege cache. clean the cache.
-			if !ok {
+			// Every session cache-mode assignment is a synchronization boundary.
+			// In particular, enabling must discard decisions that may have been
+			// produced while caching was disabled before a concurrent REVOKE.
+			// SET GLOBAL does not change this session's cache mode.
+			if !assign.Global {
 				cache := ses.GetPrivilegeCache()
 				if cache != nil {
 					cache.invalidate()

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1581,6 +1581,14 @@ func doSetVar(
 					if cache != nil {
 						cache.invalidate()
 					}
+					// Clearing the cache is also the explicit synchronization point
+					// for externally changed role membership. Refresh it now, outside
+					// the caller's transaction snapshot, instead of allowing the next
+					// authorization check to repopulate the cache from stale state.
+					_, _, err = validateActiveRoleGrantForAuthorization(execCtx.reqCtx, ses)
+					if err != nil {
+						return err
+					}
 				}
 				err = setVarFunc(assign.System, assign.Global, name, value, sql)
 				if err != nil {

--- a/pkg/frontend/prepared_explain_test.go
+++ b/pkg/frontend/prepared_explain_test.go
@@ -297,6 +297,8 @@ func TestPreparedExplainAuthorizationRechecksExecutionPrivilege(t *testing.T) {
 			defer prepareStmt.Close()
 			stub := gostub.StubFunc(&NewBackgroundExec, bh)
 			defer stub.Reset()
+			bh.sql2result[getSqlForCheckUserGrantForAuthorization(3, 2)] = newMrsForCheckUserGrant(
+				[][]interface{}{{int64(3), int64(2), false}})
 
 			err := runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, tc.binary, true)
 			require.NoError(t, err, "a granted prepared statement must reach the compile path")
@@ -314,6 +316,112 @@ func TestPreparedExplainAuthorizationRechecksExecutionPrivilege(t *testing.T) {
 			require.NoError(t, err, "a re-granted prepared statement must be executable again")
 		})
 	}
+}
+
+func TestPreparedAuthorizationRejectsRevokedActiveRole(t *testing.T) {
+	cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+		return true, nil
+	})
+	defer cacheEnabledStub.Reset()
+
+	for _, tc := range []struct {
+		name   string
+		binary bool
+	}{
+		{name: "text execute", binary: false},
+		{name: "binary execute", binary: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ses, prepareStmt, innerPlan, bh := newPreparedAuthorizationFixture(t, "select * from db1.t1")
+			defer prepareStmt.Close()
+			var forcedPessimisticRC bool
+			stub := gostub.Stub(&NewBackgroundExec, func(
+				_ context.Context,
+				_ FeSession,
+				opts ...*BackgroundExecOption,
+			) BackgroundExec {
+				forcedPessimisticRC = len(opts) == 1 && opts[0] != nil && opts[0].forcePessimisticRC
+				return bh
+			})
+			defer stub.Reset()
+
+			roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+			bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant([][]interface{}{{int64(3), int64(2), false}})
+			require.NoError(t, runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, tc.binary, true))
+			require.True(t, forcedPessimisticRC)
+
+			// Revoking the active role leaves the role's table privilege intact. The
+			// same prepared handle must still be rejected after the session cache is
+			// cleared because the user no longer owns the active role.
+			bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(nil)
+			ses.InvalidatePrivilegeCache()
+			err := runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, tc.binary, true)
+			require.Error(t, err)
+
+			// A committed re-grant plus another cache refresh restores the same
+			// session and prepared handle.
+			bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant([][]interface{}{{int64(3), int64(2), false}})
+			ses.InvalidatePrivilegeCache()
+			require.NoError(t, runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, tc.binary, true))
+		})
+	}
+}
+
+func TestPreparedAuthorizationActiveRoleGrantCacheBoundaries(t *testing.T) {
+	t.Run("catalog error is not cached", func(t *testing.T) {
+		cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+			return true, nil
+		})
+		defer cacheEnabledStub.Reset()
+
+		ses, prepareStmt, innerPlan, bh := newPreparedAuthorizationFixture(t, "select * from db1.t1")
+		defer prepareStmt.Close()
+		stub := gostub.StubFunc(&NewBackgroundExec, bh)
+		defer stub.Reset()
+
+		roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+		catalogErr := errors.New("role grant catalog unavailable")
+		bh.sql2err[roleGrantSQL] = catalogErr
+		err := runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, false, true)
+		require.ErrorIs(t, err, catalogErr)
+		_, cached := ses.GetPrivilegeCache().getActiveRoleGrant(2, 3)
+		require.False(t, cached)
+
+		delete(bh.sql2err, roleGrantSQL)
+		bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant([][]interface{}{{int64(3), int64(2), false}})
+		require.NoError(t, runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, false, true))
+	})
+
+	t.Run("disabled cache rechecks every execution", func(t *testing.T) {
+		cacheEnabledStub := gostub.Stub(&privilegeCacheIsEnabled, func(context.Context, *Session) (bool, error) {
+			return false, nil
+		})
+		defer cacheEnabledStub.Reset()
+
+		ses, prepareStmt, innerPlan, bh := newPreparedAuthorizationFixture(t, "select * from db1.t1")
+		defer prepareStmt.Close()
+		stub := gostub.StubFunc(&NewBackgroundExec, bh)
+		defer stub.Reset()
+
+		roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+		bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant([][]interface{}{{int64(3), int64(2), false}})
+		tablePrivilegeSQL := getSqlForCheckRoleHasTableLevelForStarStarWithObjType(
+			objectTypeTable, 3, PrivilegeTypeSelect)
+		bh.sql2result[tablePrivilegeSQL] = newMrsForCheckRoleHasPrivilege(
+			[][]interface{}{{int64(3), false}})
+		require.NoError(t, runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, false, true))
+
+		bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(nil)
+		require.Error(t, runPreparedAuthorizationCompile(t, ses, prepareStmt, innerPlan, false, true))
+
+		var roleGrantChecks int
+		for _, sql := range bh.executedSQLs {
+			if sql == roleGrantSQL {
+				roleGrantChecks++
+			}
+		}
+		require.Equal(t, 2, roleGrantChecks)
+	})
 }
 
 func TestHandlePreparedExplainDoesNotRebuildUnderlyingStatement(t *testing.T) {

--- a/pkg/frontend/routine_test.go
+++ b/pkg/frontend/routine_test.go
@@ -1003,6 +1003,42 @@ func TestClearPrivilegeCacheRefreshesActiveRoleGrant(t *testing.T) {
 	}
 }
 
+func TestEnablePrivilegeCacheInvalidatesDisabledModeRoleGrant(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ses := newTestSession(t, ctrl)
+	ses.SetTenantInfo(&TenantInfo{
+		Tenant:        "test_account",
+		User:          "reader_user",
+		DefaultRole:   "reader_role",
+		TenantID:      1,
+		UserID:        2,
+		DefaultRoleID: 3,
+	})
+	ctx := defines.AttachAccountId(context.Background(), 1)
+	require.NoError(t, ses.SetSessionSysVar(ctx, "enable_privilege_cache", int8(0)))
+	// Model the stale entry produced by the old OFF -> SET ROLE path.
+	ses.GetPrivilegeCache().setActiveRoleGrant(2, 3, true)
+
+	stmt, err := parsers.ParseOne(ctx, dialect.MYSQL, "set session enable_privilege_cache = on", 1)
+	require.NoError(t, err)
+	require.NoError(t, doSetVar(ses, newTestExecCtx(ctx, ctrl), stmt.(*tree.SetVar), "", false))
+	_, cached := ses.GetPrivilegeCache().getActiveRoleGrant(2, 3)
+	require.False(t, cached)
+
+	bh := &backgroundExecTest{}
+	bh.init()
+	roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+	bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(nil)
+	stub := gostub.StubFunc(&NewBackgroundExec, bh)
+	defer stub.Reset()
+
+	valid, _, err := validateActiveRoleGrantForAuthorization(ctx, ses)
+	require.NoError(t, err)
+	require.False(t, valid)
+	require.Contains(t, bh.executedSQLs, roleGrantSQL)
+}
+
 func TestCancelledNextTransactionIsolationRemainsReplayable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/frontend/routine_test.go
+++ b/pkg/frontend/routine_test.go
@@ -941,6 +941,68 @@ func TestMigrateConnectionFromMarksTypedSystemSnapshotTooLargeForLegacyReplay(t 
 	require.True(t, resp.SystemVariablesReplayable)
 }
 
+func TestClearPrivilegeCacheRefreshesActiveRoleGrant(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		catalogErr error
+	}{
+		{name: "revoked membership is cached"},
+		{name: "catalog errors fail closed", catalogErr: fmt.Errorf("role grant catalog unavailable")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ses := newTestSession(t, ctrl)
+			ses.SetTenantInfo(&TenantInfo{
+				Tenant:        "test_account",
+				User:          "reader_user",
+				DefaultRole:   "reader_role",
+				TenantID:      1,
+				UserID:        2,
+				DefaultRoleID: 3,
+			})
+			ctx := defines.AttachAccountId(context.Background(), 1)
+			require.NoError(t, ses.SetSessionSysVar(ctx, "enable_privilege_cache", int8(1)))
+			ses.GetPrivilegeCache().setActiveRoleGrant(2, 3, true)
+
+			bh := &backgroundExecTest{}
+			bh.init()
+			roleGrantSQL := getSqlForCheckUserGrantForAuthorization(3, 2)
+			if tc.catalogErr != nil {
+				bh.sql2err[roleGrantSQL] = tc.catalogErr
+			} else {
+				bh.sql2result[roleGrantSQL] = newMrsForCheckUserGrant(nil)
+			}
+			var forcedPessimisticRC bool
+			stub := gostub.Stub(&NewBackgroundExec, func(
+				_ context.Context,
+				_ FeSession,
+				opts ...*BackgroundExecOption,
+			) BackgroundExec {
+				forcedPessimisticRC = len(opts) == 1 && opts[0] != nil && opts[0].forcePessimisticRC
+				return bh
+			})
+			defer stub.Reset()
+
+			stmt, err := parsers.ParseOne(ctx, dialect.MYSQL, "set session clear_privilege_cache = on", 1)
+			require.NoError(t, err)
+			err = doSetVar(ses, newTestExecCtx(ctx, ctrl), stmt.(*tree.SetVar), "", false)
+			require.True(t, forcedPessimisticRC)
+			require.Contains(t, bh.executedSQLs, roleGrantSQL)
+			if tc.catalogErr != nil {
+				require.ErrorIs(t, err, tc.catalogErr)
+				_, cached := ses.GetPrivilegeCache().getActiveRoleGrant(2, 3)
+				require.False(t, cached)
+				return
+			}
+			require.NoError(t, err)
+			valid, cached := ses.GetPrivilegeCache().getActiveRoleGrant(2, 3)
+			require.True(t, cached)
+			require.False(t, valid)
+		})
+	}
+}
+
 func TestCancelledNextTransactionIsolationRemainsReplayable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.result
+++ b/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.result
@@ -1,0 +1,64 @@
+drop user if exists issue27650_user;
+drop role if exists issue27650_target;
+drop role if exists issue27650_reader;
+drop database if exists issue27650_db;
+create role issue27650_reader;
+create role issue27650_target;
+create database issue27650_db;
+create table issue27650_db.t(v int);
+insert into issue27650_db.t values (27650);
+create user issue27650_user identified by '123456' default role issue27650_reader;
+grant connect on account * to issue27650_reader;
+grant select on table issue27650_db.t to issue27650_reader with grant option;
+grant issue27650_reader to issue27650_user;
+set session enable_privilege_cache = on;
+select current_role();
+➤ current_role()[12,65535,0]  𝄀
+issue27650_reader
+prepare issue27650_stmt from 'select v from issue27650_db.t';
+execute issue27650_stmt;
+➤ v[4,32,0]  𝄀
+27650
+begin;
+revoke issue27650_reader from issue27650_user;
+select count(*) from mo_catalog.mo_user_grant ug
+join mo_catalog.mo_role r on ug.role_id = r.role_id
+join mo_catalog.mo_user u on ug.user_id = u.user_id
+where r.role_name = 'issue27650_reader' and u.user_name = 'issue27650_user';
+➤ count(*)[-5,64,0]  𝄀
+0
+set session clear_privilege_cache = on;
+select v from issue27650_db.t;
+internal error: do not have privilege to execute the statement
+execute issue27650_stmt;
+internal error: do not have privilege to execute the statement
+rollback;
+grant select on table issue27650_db.t to issue27650_target;
+internal error: do not have privilege to execute the statement
+set role public;
+select current_role();
+➤ current_role()[12,65535,0]  𝄀
+public
+set role issue27650_reader;
+internal error: the role issue27650_reader has not be granted to the user issue27650_user
+set session enable_privilege_cache = on;
+select v from issue27650_db.t;
+internal error: do not have privilege to execute the statement
+grant issue27650_reader to issue27650_user;
+begin;
+commit;
+set role issue27650_reader;
+execute issue27650_stmt;
+➤ v[4,32,0]  𝄀
+27650
+set session enable_privilege_cache = on;
+select current_role();
+➤ current_role()[12,65535,0]  𝄀
+issue27650_reader
+select v from issue27650_db.t;
+➤ v[4,32,0]  𝄀
+27650
+drop user if exists issue27650_user;
+drop role if exists issue27650_target;
+drop role if exists issue27650_reader;
+drop database if exists issue27650_db;

--- a/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.result
+++ b/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.result
@@ -20,6 +20,12 @@ execute issue27650_stmt;
 ➤ v[4,32,0]  𝄀
 27650
 begin;
+set session enable_privilege_cache = off;
+set role issue27650_reader;
+prepare issue27650_toggle_stmt from 'select v from issue27650_db.t';
+execute issue27650_toggle_stmt;
+➤ v[4,32,0]  𝄀
+27650
 revoke issue27650_reader from issue27650_user;
 select count(*) from mo_catalog.mo_user_grant ug
 join mo_catalog.mo_role r on ug.role_id = r.role_id
@@ -27,6 +33,11 @@ join mo_catalog.mo_user u on ug.user_id = u.user_id
 where r.role_name = 'issue27650_reader' and u.user_name = 'issue27650_user';
 ➤ count(*)[-5,64,0]  𝄀
 0
+set session enable_privilege_cache = on;
+select v from issue27650_db.t;
+internal error: do not have privilege to execute the statement
+execute issue27650_toggle_stmt;
+internal error: do not have privilege to execute the statement
 set session clear_privilege_cache = on;
 select v from issue27650_db.t;
 internal error: do not have privilege to execute the statement

--- a/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.sql
+++ b/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.sql
@@ -23,11 +23,26 @@ execute issue27650_stmt;
 begin;
 -- @session}
 
+-- Exercise the cache OFF -> SET ROLE -> REVOKE -> ON transition on a second
+-- already-open connection, including both text and prepared authorization.
+-- @session:id=4&user=sys:issue27650_user:issue27650_reader&password=123456{
+set session enable_privilege_cache = off;
+set role issue27650_reader;
+prepare issue27650_toggle_stmt from 'select v from issue27650_db.t';
+execute issue27650_toggle_stmt;
+-- @session}
+
 revoke issue27650_reader from issue27650_user;
 select count(*) from mo_catalog.mo_user_grant ug
 join mo_catalog.mo_role r on ug.role_id = r.role_id
 join mo_catalog.mo_user u on ug.user_id = u.user_id
 where r.role_name = 'issue27650_reader' and u.user_name = 'issue27650_user';
+
+-- @session:id=4&user=sys:issue27650_user:issue27650_reader&password=123456{
+set session enable_privilege_cache = on;
+select v from issue27650_db.t;
+execute issue27650_toggle_stmt;
+-- @session}
 
 -- @session:id=1&user=sys:issue27650_user:issue27650_reader&password=123456{
 set session clear_privilege_cache = on;

--- a/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.sql
+++ b/test/distributed/cases/zz_accesscontrol/revoke_active_role_session.sql
@@ -1,0 +1,69 @@
+drop user if exists issue27650_user;
+drop role if exists issue27650_target;
+drop role if exists issue27650_reader;
+drop database if exists issue27650_db;
+
+create role issue27650_reader;
+create role issue27650_target;
+create database issue27650_db;
+create table issue27650_db.t(v int);
+insert into issue27650_db.t values (27650);
+create user issue27650_user identified by '123456' default role issue27650_reader;
+grant connect on account * to issue27650_reader;
+grant select on table issue27650_db.t to issue27650_reader with grant option;
+grant issue27650_reader to issue27650_user;
+
+-- Keep this connection and its prepared statement open across the main
+-- session's REVOKE and re-grant.
+-- @session:id=1&user=sys:issue27650_user:issue27650_reader&password=123456{
+set session enable_privilege_cache = on;
+select current_role();
+prepare issue27650_stmt from 'select v from issue27650_db.t';
+execute issue27650_stmt;
+begin;
+-- @session}
+
+revoke issue27650_reader from issue27650_user;
+select count(*) from mo_catalog.mo_user_grant ug
+join mo_catalog.mo_role r on ug.role_id = r.role_id
+join mo_catalog.mo_user u on ug.user_id = u.user_id
+where r.role_name = 'issue27650_reader' and u.user_name = 'issue27650_user';
+
+-- @session:id=1&user=sys:issue27650_user:issue27650_reader&password=123456{
+set session clear_privilege_cache = on;
+select v from issue27650_db.t;
+execute issue27650_stmt;
+rollback;
+grant select on table issue27650_db.t to issue27650_target;
+set role public;
+select current_role();
+set role issue27650_reader;
+-- @session}
+
+-- A new implicit-role connection must not regain the revoked role's table
+-- privilege on its first protected statement.
+-- @session:id=2&user=sys:issue27650_user&password=123456
+set session enable_privilege_cache = on;
+select v from issue27650_db.t;
+-- @session
+
+grant issue27650_reader to issue27650_user;
+begin;
+commit;
+
+-- @session:id=1&user=sys:issue27650_user:issue27650_reader&password=123456{
+set role issue27650_reader;
+execute issue27650_stmt;
+-- @session}
+
+-- A new explicit-role connection is valid again after the committed re-grant.
+-- @session:id=3&user=sys:issue27650_user:issue27650_reader&password=123456
+set session enable_privilege_cache = on;
+select current_role();
+select v from issue27650_db.t;
+-- @session
+
+drop user if exists issue27650_user;
+drop role if exists issue27650_target;
+drop role if exists issue27650_reader;
+drop database if exists issue27650_db;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27650

## What this PR does / why we need it:

`REVOKE role FROM user` clears the privilege cache, but an already-active session could refill that cache while continuing to authorize through the revoked active role and its older transaction snapshot. This change:

- caches and revalidates the active user-role grant together with the session privilege cache generation;
- reads active-role membership in a private pessimistic RC transaction with a locking catalog read, and applies the same RC semantics to role revocation;
- refreshes active-role membership synchronously at the explicit `clear_privilege_cache` boundary;
- performs that validation before privilege-cache hits and before owner or grant-option fallback paths;
- keeps built-in roles compatible and marks a successfully selected role as valid;
- returns catalog errors without caching them, so transient failures remain retryable;
- adds focused unit/race coverage and a 42-statement multi-session BVT for existing/new sessions, prepared statements, transaction boundaries, role switching, error paths, and regrant recovery.

Validation on commit `4e2be0b0eae7576bf291b5be928c45a0d2e6b1de` (based on `origin/main` `424fe3d821e45fe883ab93af5b404d77686d05a0`):

- `mo-cgo-test -count=1 -coverprofile=frontend-cover.out ./pkg/frontend/...`
- `mo-cgo-test -race -count=1 ./pkg/frontend/...`
- seven focused authorization/cache tests with `-race -count=7`
- `go vet -mod=readonly ./pkg/frontend/...`
- `make config`
- `make err-check`
- `git diff --check`
- `mo-tester` BVT: 10 consecutive runs, 42/42 statements, 100%
- local real-server E2E covering revoke and regrant behavior

The new helper functions have 80%-100% function coverage; the main changed authorization/revoke functions are above the repository's 75% threshold.
