### PR TITLE
fix: skip folder markers during ETL merge

### DIFF
--- a/pkg/util/export/merge.go
+++ b/pkg/util/export/merge.go
@@ -258,6 +258,9 @@ func (m *Merge) Main(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
+				if f.IsDir || !isETLFile(f.Name) {
+					continue
+				}
 				filepath := path.Join(rootPath, f.Name)
 				totalSize += f.Size
 				files = append(files, &FileMeta{filepath, f.Size})
@@ -583,14 +586,15 @@ func newETLReader(
 	service string,
 	tbl *table.Table,
 	fs fileservice.FileService,
-	path string,
+	filePath string,
 	size int64,
 	mp *mpool.MPool,
 ) (ETLReader, error) {
-	if strings.LastIndex(path, table.CsvExtension) > 0 {
-		return NewCSVReader(ctx, service, fs, path)
-	} else if strings.LastIndex(path, table.TaeExtension) > 0 {
-		r, err := etl.NewTaeReader(ctx, tbl, path, size, fs, mp)
+	switch path.Ext(filePath) {
+	case table.CsvExtension:
+		return NewCSVReader(ctx, service, fs, filePath)
+	case table.TaeExtension:
+		r, err := etl.NewTaeReader(ctx, tbl, filePath, size, fs, mp)
 		if err != nil {
 			r.Close()
 			return nil, err
@@ -601,9 +605,14 @@ func newETLReader(
 			return nil, err
 		}
 		return r, nil
-	} else {
-		panic("NOT Implements")
+	default:
+		return nil, moerr.NewNotSupportedf(ctx, "unsupported ETL file: %s", filePath)
 	}
+}
+
+func isETLFile(filePath string) bool {
+	ext := path.Ext(filePath)
+	return ext == table.CsvExtension || ext == table.TaeExtension
 }
 
 // NewCSVReader create new csv reader.

--- a/pkg/util/export/merge_test.go
+++ b/pkg/util/export/merge_test.go
@@ -348,6 +348,61 @@ func TestMergeTaskExecutorFactory(t *testing.T) {
 	}
 }
 
+func TestMergeMainSkipsNonETLEntries(t *testing.T) {
+	ctx := trace.Generate(context.Background())
+	fs := testutil.NewETLFS()
+	ts, err := time.Parse("2006-01-02 15:04:05", "2026-08-27 00:00:00")
+	require.NoError(t, err)
+
+	rootPath := dummyTable.PathBuilder.Build(
+		dummyTable.Account,
+		table.MergeLogTypeLogs,
+		ts,
+		dummyTable.Database,
+		dummyTable.GetName(),
+	)
+	markerPath := rootPath + "/"
+	nestedPath := path.Join(rootPath, "nested", "file")
+	for _, filePath := range []string{markerPath, nestedPath} {
+		require.NoError(t, fs.Write(ctx, fileservice.IOVector{FilePath: filePath}))
+	}
+	entries, err := fileservice.SortedList(fs.List(ctx, rootPath))
+	require.NoError(t, err)
+	require.Equal(t, []fileservice.DirEntry{
+		{Name: "", IsDir: false, Size: 0},
+		{Name: "nested", IsDir: true, Size: 0},
+	}, entries)
+
+	merge, err := NewMerge(ctx, "", WithFileService(fs), WithTable(dummyTable))
+	require.NoError(t, err)
+	require.NoError(t, merge.Main(ctx))
+
+	for _, filePath := range []string{markerPath, nestedPath} {
+		_, err = fs.StatFile(ctx, filePath)
+		require.NoError(t, err)
+	}
+}
+
+func TestIsETLFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     bool
+	}{
+		{name: "csv", filePath: "rawlog.csv", want: true},
+		{name: "tae", filePath: "rawlog.tae", want: true},
+		{name: "folder marker", filePath: "rawlog/", want: false},
+		{name: "folder marker name", filePath: "rawlog", want: false},
+		{name: "empty marker name", filePath: "", want: false},
+		{name: "extension is not suffix", filePath: "rawlog.csv.tmp", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isETLFile(tt.filePath))
+		})
+	}
+}
+
 func TestCreateCronTask(t *testing.T) {
 	store := taskservice.NewMemTaskStorage()
 	s := taskservice.NewTaskService(runtime.DefaultRuntime(), store)
@@ -474,6 +529,15 @@ func Test_newETLReader(t *testing.T) {
 			defer got.Close()
 		})
 	}
+
+	t.Run("unsupported", func(t *testing.T) {
+		filePath := "sys/logs/2026/08/27/rawlog/"
+		got, err := newETLReader(ctx, "", dummyTable, fs, filePath, 0, mp)
+		require.Nil(t, got)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNotSupported))
+		require.ErrorContains(t, err, filePath)
+	})
 }
 
 func TestInitMerge(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27740

## What this PR does / why we need it:

S3-compatible object stores can expose zero-byte folder marker objects while
ETL merge scans a log directory. The merge task previously treated every
listed entry as a data file, so a marker without a `.csv` or `.tae` extension
reached `newETLReader` and panicked the CN.

This change:

- filters directory and unsupported entries before adding them to an ETL merge
  batch;
- dispatches readers by the exact final file extension;
- returns `ErrNotSupported` instead of panicking if an unsupported path reaches
  `newETLReader`;
- adds deterministic regression coverage for zero-byte marker objects,
  directory entries, supported ETL files, and misleading suffixes.

Validation:

- focused `TestMergeMainSkipsNonETLEntries`, `TestIsETLFile`, and
  `Test_newETLReader` tests passed with non-empty selection;
- full `./pkg/util/export` package tests passed;
- `molint` passed for `./pkg/util/export`;
- `golangci-lint -c .golangci.yml ./pkg/util/export` passed with 0 issues.

BVT is not applicable because this changes only the internal ETL background
file-selection contract and has no SQL-visible behavior.
