### PR TITLE
fix(proxy): synchronize test CN server global variables

### DIFF
--- a/pkg/proxy/server_conn_test.go
+++ b/pkg/proxy/server_conn_test.go
@@ -143,9 +143,10 @@ type testCNServer struct {
 	started  bool
 	quit     chan interface{}
 
-	globalVars map[string]string
-	tlsCfg     tlsConfig
-	tlsConfig  *tls.Config
+	globalVarsMu sync.RWMutex
+	globalVars   map[string]string
+	tlsCfg       tlsConfig
+	tlsConfig    *tls.Config
 
 	beforeHandle func()
 	handle       func(*testHandler)
@@ -220,6 +221,23 @@ func startTestCNServer(t *testing.T, ctx context.Context, addr string, cfg *tlsC
 	return func() error {
 		return b.Stop()
 	}
+}
+
+func (s *testCNServer) setGlobalVar(name, value string) {
+	s.globalVarsMu.Lock()
+	defer s.globalVarsMu.Unlock()
+	s.globalVars[name] = value
+}
+
+func (s *testCNServer) globalVarsSnapshot() map[string]string {
+	s.globalVarsMu.RLock()
+	defer s.globalVarsMu.RUnlock()
+
+	vars := make(map[string]string, len(s.globalVars))
+	for name, value := range s.globalVars {
+		vars[name] = value
+	}
+	return vars
 }
 
 func (s *testCNServer) waitCNServerReady() bool {
@@ -382,7 +400,7 @@ func (h *testHandler) handleSetVar(packet *frontend.Packet) {
 }
 
 func (h *testHandler) handleKillConn() {
-	h.server.globalVars["killed"] = "yes"
+	h.server.setGlobalVar("killed", "yes")
 	h.mysqlProto.SetSequenceID(1)
 	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, uint64(h.connID), h.status, 0, ""))
 }
@@ -466,7 +484,7 @@ func (h *testHandler) handleShowGlobalVar() {
 		}
 	}
 	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeEOFPayload(0, h.status))
-	for k, v := range h.server.globalVars {
+	for k, v := range h.server.globalVarsSnapshot() {
 		row := make([]interface{}, 2)
 		row[0] = k
 		row[1] = v
@@ -540,6 +558,36 @@ func (s *testCNServer) Stop() error {
 	close(s.quit)
 	_ = s.listener.Close()
 	return nil
+}
+
+func TestCNServerGlobalVarsConcurrentAccess(t *testing.T) {
+	server := &testCNServer{globalVars: make(map[string]string)}
+	const workers = 8
+	const iterations = 16
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				server.setGlobalVar("killed", "yes")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				_ = server.globalVarsSnapshot()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, map[string]string{"killed": "yes"}, server.globalVarsSnapshot())
 }
 
 func TestServerConn_Create(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27771

## What this PR does / why we need it:

### Root cause

`testCNServer` handles backend connections in separate goroutines. `handleKillConn` wrote `testCNServer.globalVars` while another handler could iterate the same map in `handleShowGlobalVar`. Under coverage scheduling, `TestHandler_HandleEventKill` could therefore terminate the test process with `fatal error: concurrent map writes`.

### Changes

- Add an `RWMutex` owned by `testCNServer` and centralize global-variable access in `setGlobalVar` and `globalVarsSnapshot`.
- Serialize writes and copy the map under a read lock before `handleShowGlobalVar` builds and sends its result, so the lock is not held during network work.
- Add `TestCNServerGlobalVarsConcurrentAccess`, which starts concurrent writers and readers with a barrier, waits for every goroutine, and verifies the final state.

### Issue-to-test proof

- `TestCNServerGlobalVarsConcurrentAccess` directly exercises the shared writer/reader boundary and verifies that concurrent access remains safe.
- `TestHandler_HandleEventKill` exercises the reported proxy kill-dispatch path and passes with the synchronized test server.
- No BVT is added because this is an internal `_test.go` fixture concurrency defect; production code and public SQL behavior are unchanged, so focused unit tests are the appropriate proof.

### Tests run

- Focused unit tests for `TestCNServerGlobalVarsConcurrentAccess` and `TestHandler_HandleEventKill`.
- `-race` focused tests, each repeated 100 times.
- Full `pkg/proxy` unit test package with and without `-race`.
- The reported kill test under `-tags matrixone_test -covermode=set` coverage flags.
- `go vet ./pkg/proxy` with the repository CGo include and library paths.

### Residual risks

The change is limited to the proxy test fixture. Snapshot creation is bounded by the existing small test map, and all direct reads and writes are now routed through the synchronized helpers; no production execution path is changed.
