### PR TITLE
test(objectio): synchronize dedupLoad waiter admission

### DIFF
--- a/pkg/objectio/meta_test.go
+++ b/pkg/objectio/meta_test.go
@@ -72,6 +72,8 @@ type dedupLoadWaiterContext struct {
 	once     sync.Once
 }
 
+const dedupLoadWaiterAdmissionTimeout = time.Second
+
 // dedupLoad calls Done only after it finds an existing load call. Observing
 // that call gives these tests a phase barrier without relying on scheduling.
 func (c *dedupLoadWaiterContext) Done() <-chan struct{} {
@@ -79,10 +81,66 @@ func (c *dedupLoadWaiterContext) Done() <-chan struct{} {
 	return c.Context.Done()
 }
 
-func newDedupLoadWaiterContext() *dedupLoadWaiterContext {
+func newDedupLoadWaiterContext() (*dedupLoadWaiterContext, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &dedupLoadWaiterContext{
-		Context:  context.Background(),
+		Context:  ctx,
 		admitted: make(chan struct{}),
+	}, cancel
+}
+
+func waitForDedupLoadWaiterAdmission(
+	t *testing.T,
+	waiterCtx *dedupLoadWaiterContext,
+	waiterDone <-chan struct{},
+	ownerDone <-chan struct{},
+	releaseOwner func(),
+	cancelWaiter context.CancelFunc,
+) {
+	t.Helper()
+
+	timer := time.NewTimer(dedupLoadWaiterAdmissionTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-waiterCtx.admitted:
+		return
+	case <-waiterDone:
+		cancelWaiter()
+		releaseOwner()
+		drainDedupLoadAfterAdmissionFailure(t, ownerDone, waiterDone)
+		t.Fatalf("dedup load waiter completed before admission")
+	case <-timer.C:
+		cancelWaiter()
+		releaseOwner()
+		drainDedupLoadAfterAdmissionFailure(t, ownerDone, waiterDone)
+		t.Fatalf("timed out waiting for dedup load waiter admission")
+	}
+}
+
+func drainDedupLoadAfterAdmissionFailure(
+	t *testing.T,
+	ownerDone <-chan struct{},
+	waiterDone <-chan struct{},
+) {
+	t.Helper()
+	if !waitForDedupLoadCompletion(ownerDone) {
+		t.Errorf("dedup load owner did not exit after admission failure")
+	}
+	if !waitForDedupLoadCompletion(waiterDone) {
+		t.Errorf("dedup load waiter did not exit after admission failure")
+	}
+}
+
+func waitForDedupLoadCompletion(done <-chan struct{}) bool {
+	timer := time.NewTimer(dedupLoadWaiterAdmissionTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
 	}
 }
 
@@ -97,11 +155,13 @@ func TestDedupLoadCleansUpAfterPanic(t *testing.T) {
 	key[0] = 1
 	started := make(chan struct{})
 	release := make(chan struct{})
-	panicDone := make(chan any, 1)
+	ownerDone := make(chan struct{})
+	var panicValue any
 
 	go func() {
 		defer func() {
-			panicDone <- recover()
+			panicValue = recover()
+			close(ownerDone)
 		}()
 		_, _ = dedupLoad(context.Background(), key, func() ([]byte, error) {
 			close(started)
@@ -111,21 +171,31 @@ func TestDedupLoadCleansUpAfterPanic(t *testing.T) {
 	}()
 
 	<-started
-	waiterCtx := newDedupLoadWaiterContext()
-	waiterDone := make(chan error, 1)
+	waiterCtx, cancelWaiter := newDedupLoadWaiterContext()
+	defer cancelWaiter()
+	waiterDone := make(chan struct{})
+	var waiterErr error
 	go func() {
-		_, err := dedupLoad(waiterCtx, key, func() ([]byte, error) {
+		_, waiterErr = dedupLoad(waiterCtx, key, func() ([]byte, error) {
 			return nil, errors.New("unexpected waiter load")
 		})
-		waiterDone <- err
+		close(waiterDone)
 	}()
 
-	<-waiterCtx.admitted
+	waitForDedupLoadWaiterAdmission(
+		t,
+		waiterCtx,
+		waiterDone,
+		ownerDone,
+		func() { close(release) },
+		cancelWaiter,
+	)
 	close(release)
-	assert.Equal(t, "boom", <-panicDone)
-	err := <-waiterDone
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dedup load did not complete")
+	<-ownerDone
+	<-waiterDone
+	assert.Equal(t, "boom", panicValue)
+	assert.Error(t, waiterErr)
+	assert.Contains(t, waiterErr.Error(), "dedup load did not complete")
 
 	metaLoadMu.Lock()
 	_, ok := metaLoadCalls[key]
@@ -150,12 +220,10 @@ func TestDedupLoadWaiterGetsSuccessfulOwnerValue(t *testing.T) {
 	key[0] = 8
 	started := make(chan struct{})
 	release := make(chan struct{})
-	waiterDone := make(chan struct {
-		val []byte
-		err error
-	}, 1)
+	ownerDone := make(chan struct{})
 
 	go func() {
+		defer close(ownerDone)
 		_, _ = dedupLoad(context.Background(), key, func() ([]byte, error) {
 			close(started)
 			<-release
@@ -164,22 +232,31 @@ func TestDedupLoadWaiterGetsSuccessfulOwnerValue(t *testing.T) {
 	}()
 	<-started
 
-	waiterCtx := newDedupLoadWaiterContext()
+	waiterCtx, cancelWaiter := newDedupLoadWaiterContext()
+	defer cancelWaiter()
+	waiterDone := make(chan struct{})
+	var waiterVal []byte
+	var waiterErr error
 	go func() {
-		v, err := dedupLoad(waiterCtx, key, func() ([]byte, error) {
+		waiterVal, waiterErr = dedupLoad(waiterCtx, key, func() ([]byte, error) {
 			return nil, errors.New("unexpected waiter load")
 		})
-		waiterDone <- struct {
-			val []byte
-			err error
-		}{v, err}
+		close(waiterDone)
 	}()
 
-	<-waiterCtx.admitted
+	waitForDedupLoadWaiterAdmission(
+		t,
+		waiterCtx,
+		waiterDone,
+		ownerDone,
+		func() { close(release) },
+		cancelWaiter,
+	)
 	close(release)
-	result := <-waiterDone
-	assert.NoError(t, result.err)
-	assert.Equal(t, []byte("ok"), result.val)
+	<-ownerDone
+	<-waiterDone
+	assert.NoError(t, waiterErr)
+	assert.Equal(t, []byte("ok"), waiterVal)
 }
 
 func TestDedupLoadWaiterTimeoutWhileOwnerStillLoading(t *testing.T) {
@@ -227,34 +304,47 @@ func TestDedupLoadCleansUpAfterLoadCancel(t *testing.T) {
 	var key mataCacheKey
 	key[0] = 2
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	started := make(chan struct{})
-	ownerDone := make(chan error, 1)
+	ownerDone := make(chan struct{})
+	var ownerErr error
 
 	go func() {
-		_, err := dedupLoad(ctx, key, func() ([]byte, error) {
+		defer close(ownerDone)
+		_, ownerErr = dedupLoad(ctx, key, func() ([]byte, error) {
 			close(started)
 			<-ctx.Done()
 			return nil, ctx.Err()
 		})
-		ownerDone <- err
 	}()
 	<-started
 
-	waiterCtx := newDedupLoadWaiterContext()
+	waiterCtx, cancelWaiter := newDedupLoadWaiterContext()
+	defer cancelWaiter()
 	var waiterLoadCount atomic.Int32
-	waiterDone := make(chan error, 1)
+	waiterDone := make(chan struct{})
+	var waiterErr error
 	go func() {
-		_, err := dedupLoad(waiterCtx, key, func() ([]byte, error) {
+		_, waiterErr = dedupLoad(waiterCtx, key, func() ([]byte, error) {
 			waiterLoadCount.Add(1)
 			return nil, errors.New("unexpected waiter load")
 		})
-		waiterDone <- err
+		close(waiterDone)
 	}()
 
-	<-waiterCtx.admitted
+	waitForDedupLoadWaiterAdmission(
+		t,
+		waiterCtx,
+		waiterDone,
+		ownerDone,
+		cancel,
+		cancelWaiter,
+	)
 	cancel()
-	assert.ErrorIs(t, <-ownerDone, context.Canceled)
-	assert.ErrorIs(t, <-waiterDone, context.Canceled)
+	<-ownerDone
+	<-waiterDone
+	assert.ErrorIs(t, ownerErr, context.Canceled)
+	assert.ErrorIs(t, waiterErr, context.Canceled)
 	assert.Zero(t, waiterLoadCount.Load())
 
 	metaLoadMu.Lock()

--- a/pkg/objectio/meta_test.go
+++ b/pkg/objectio/meta_test.go
@@ -17,6 +17,7 @@ package objectio
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -65,6 +66,26 @@ func TestBuildMetaData(t *testing.T) {
 	}
 }
 
+type dedupLoadWaiterContext struct {
+	context.Context
+	admitted chan struct{}
+	once     sync.Once
+}
+
+// dedupLoad calls Done only after it finds an existing load call. Observing
+// that call gives these tests a phase barrier without relying on scheduling.
+func (c *dedupLoadWaiterContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.admitted) })
+	return c.Context.Done()
+}
+
+func newDedupLoadWaiterContext() *dedupLoadWaiterContext {
+	return &dedupLoadWaiterContext{
+		Context:  context.Background(),
+		admitted: make(chan struct{}),
+	}
+}
+
 func TestDedupLoadCleansUpAfterPanic(t *testing.T) {
 	oldMetaCache := metaCache
 	metaCache = newMetaCache(fscache.ConstCapacity(1024))
@@ -90,15 +111,16 @@ func TestDedupLoadCleansUpAfterPanic(t *testing.T) {
 	}()
 
 	<-started
+	waiterCtx := newDedupLoadWaiterContext()
 	waiterDone := make(chan error, 1)
 	go func() {
-		_, err := dedupLoad(context.Background(), key, func() ([]byte, error) {
+		_, err := dedupLoad(waiterCtx, key, func() ([]byte, error) {
 			return nil, errors.New("unexpected waiter load")
 		})
 		waiterDone <- err
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	<-waiterCtx.admitted
 	close(release)
 	assert.Equal(t, "boom", <-panicDone)
 	err := <-waiterDone
@@ -142,8 +164,9 @@ func TestDedupLoadWaiterGetsSuccessfulOwnerValue(t *testing.T) {
 	}()
 	<-started
 
+	waiterCtx := newDedupLoadWaiterContext()
 	go func() {
-		v, err := dedupLoad(context.Background(), key, func() ([]byte, error) {
+		v, err := dedupLoad(waiterCtx, key, func() ([]byte, error) {
 			return nil, errors.New("unexpected waiter load")
 		})
 		waiterDone <- struct {
@@ -152,7 +175,7 @@ func TestDedupLoadWaiterGetsSuccessfulOwnerValue(t *testing.T) {
 		}{v, err}
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	<-waiterCtx.admitted
 	close(release)
 	result := <-waiterDone
 	assert.NoError(t, result.err)
@@ -217,17 +240,18 @@ func TestDedupLoadCleansUpAfterLoadCancel(t *testing.T) {
 	}()
 	<-started
 
+	waiterCtx := newDedupLoadWaiterContext()
 	var waiterLoadCount atomic.Int32
 	waiterDone := make(chan error, 1)
 	go func() {
-		_, err := dedupLoad(context.Background(), key, func() ([]byte, error) {
+		_, err := dedupLoad(waiterCtx, key, func() ([]byte, error) {
 			waiterLoadCount.Add(1)
 			return nil, errors.New("unexpected waiter load")
 		})
 		waiterDone <- err
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	<-waiterCtx.admitted
 	cancel()
 	assert.ErrorIs(t, <-ownerDone, context.Canceled)
 	assert.ErrorIs(t, <-waiterDone, context.Canceled)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27760

## What this PR does / why we need it:

### Root cause

The three `dedupLoad` waiter tests used a 10 ms scheduler sleep as the phase trigger. The existing `started` channel only proves that the owner entered its loader; it does not prove that the second goroutine acquired `metaLoadMu` and found the existing `metaLoadCalls[key]` entry. Under coverage or other load-sensitive scheduling, the owner could be released first, complete, and delete the call. The delayed second goroutine would then become a new owner and run its sentinel loader, producing the reported `unexpected waiter load` error. This is a test synchronization defect; the production `dedupLoad` ownership protocol is unchanged.

The first barrier revision also left the admission wait unbounded: if the waiter returned early or the internal seam changed, the test could hang instead of reporting the failed phase transition.

### Changes

- Add a reusable test-only context whose `Done` method observes the existing waiter branch. In `dedupLoad`, that method is evaluated only after an existing owner call has been found.
- Add a shared admission helper that selects among waiter admission, waiter completion, and a one-second watchdog. The watchdog is diagnostic only; the normal phase transition still comes from the `Done` observation.
- On early waiter completion or watchdog expiry, cancel the waiter context, release the owner through the test-provided release callback, drain both completion channels with bounded waits, and then report a diagnostic failure.
- Replace the scheduler sleeps in `TestDedupLoadWaiterGetsSuccessfulOwnerValue`, `TestDedupLoadCleansUpAfterPanic`, and `TestDedupLoadCleansUpAfterLoadCancel` with the admission helper.
- Keep the existing success, panic-cleanup, cancellation, map-cleanup, and no-second-load assertions intact. The timeout test is unchanged because its 10 ms duration is the behavior under test, not an admission trigger.

### Issue-to-test proof

- `TestDedupLoadWaiterGetsSuccessfulOwnerValue` waits until the waiter has observed the in-flight owner, then releases it and verifies the waiter gets `[]byte("ok")` without invoking its sentinel loader.
- `TestDedupLoadCleansUpAfterPanic` proves an admitted waiter receives the incomplete-load error, the call entry is removed, and a later owner can load successfully.
- `TestDedupLoadCleansUpAfterLoadCancel` proves an admitted waiter receives `context.Canceled` and its loader is never called.
- The shared admission helper covers early waiter completion and watchdog failure paths by canceling/releasing both sides, bounded-draining their completion channels, and failing with an explicit diagnostic.
- No BVT is added: this change is confined to an internal `_test.go` synchronization protocol and does not change SQL, frontend, wire, or production behavior.

### Tests run

- `make -j8 NATIVE_BUILD_JOBS=8 cgo`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -list '^TestDedupLoad(CleansUpAfterPanic|WaiterGetsSuccessfulOwnerValue|CleansUpAfterLoadCancel)$' ./pkg/objectio`
- The three changed tests with `-v -count=1`.
- The three changed tests with `-race -count=100`.
- Full `pkg/objectio` unit tests with `-count=1`.
- `go vet -mod=readonly ./pkg/objectio` with the repository CGo include and library paths.
- `git diff --check`

### Residual risks

The change is test-only and adds no production synchronization, allocation, I/O, or runtime overhead. The barrier intentionally observes the existing waiter-admission call through a local context wrapper. If that internal test seam changes, the helper now reports either early waiter completion or a bounded admission timeout and attempts bounded cleanup of both test goroutines instead of silently relying on scheduler timing.
