### PR TITLE
[4.2] fix: reuse remote backend after early stop

### DIFF
--- a/pkg/sql/compile/remoterunClient_test.go
+++ b/pkg/sql/compile/remoterunClient_test.go
@@ -522,6 +522,141 @@ func TestRemoteRun(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestIssue27757RemoteRunCancellationClassification(t *testing.T) {
+	oldRuntime := runtime.ServiceRuntime("")
+	testRuntime := runtime.DefaultRuntime()
+	runtime.SetupServiceBasedRuntime("", testRuntime)
+	t.Cleanup(func() {
+		runtime.SetupServiceBasedRuntime("", oldRuntime)
+	})
+	catalog.SetupDefines("")
+
+	substantiveErr := moerr.NewInternalErrorNoCtx("remote execution failed")
+	tests := []struct {
+		name        string
+		cancelQuery bool
+		cancelCause error
+		wantErr     error
+		wantEvent   process.PipelineEventType
+		poison      bool
+	}{
+		{
+			name:      "internal early stop is successful and reuses backend",
+			wantEvent: process.EventEnd,
+		},
+		{
+			name:        "query cancellation is terminal and poisons backend",
+			cancelQuery: true,
+			wantErr:     context.Canceled,
+			wantEvent:   process.EventError,
+			poison:      true,
+		},
+		{
+			name:        "substantive error is terminal and poisons backend",
+			cancelCause: substantiveErr,
+			wantErr:     substantiveErr,
+			wantEvent:   process.EventError,
+			poison:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			proc := testutil.NewProcess(t)
+			queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
+			_, cancelQuery := process.GetQueryCtxFromProc(proc)
+			t.Cleanup(cancelQuery)
+			proc.BuildPipelineContext(queryCtx)
+			txnCli, txnOp := newTestTxnClientAndOp(ctrl)
+			proc.Base.TxnClient = txnCli
+			proc.Base.TxnOperator = txnOp
+
+			responses := make(chan morpc.Message, 2)
+			stream := mock_morpc.NewMockStream(ctrl)
+			stream.EXPECT().Receive().Return(responses, nil)
+			stream.EXPECT().ID().Return(uint64(27757)).AnyTimes()
+			stream.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, request morpc.Message) error {
+					message := request.(*pipeline.Message)
+					switch message.GetCmd() {
+					case pipeline.Method_PipelineMessage:
+						if tt.cancelQuery {
+							cancelQuery()
+						} else {
+							proc.Cancel(tt.cancelCause)
+						}
+					case pipeline.Method_StopSending:
+						responses <- &pipeline.Message{
+							Id:                   27757,
+							Cmd:                  pipeline.Method_PipelineMessage,
+							Sid:                  pipeline.Status_MessageEnd,
+							AcceptedTeardownMode: pipeline.StreamTeardownMode_FinishAck,
+						}
+					case pipeline.Method_PipelineStreamFinish:
+						responses <- &pipeline.Message{
+							Id:                   27757,
+							Cmd:                  pipeline.Method_PipelineStreamFinishAck,
+							Sid:                  pipeline.Status_MessageEnd,
+							AcceptedTeardownMode: pipeline.StreamTeardownMode_FinishAck,
+						}
+					}
+					return nil
+				}).AnyTimes()
+			stream.EXPECT().Close(tt.poison).Return(nil)
+			testRuntime.SetGlobalVariables(runtime.PipelineClient, &testPipelineClient{
+				genStream: func(context.Context, string) (morpc.Stream, error) {
+					return stream, nil
+				},
+			})
+
+			c := NewCompile(
+				"local-cn:6002",
+				"test",
+				"select id from ivf_entries order by distance limit 10",
+				"",
+				"",
+				newStubEngine(),
+				proc,
+				nil,
+				false,
+				nil,
+				time.Now(),
+			)
+			c.anal = &AnalyzeModule{qry: &plan.Query{}}
+
+			reg := process.NewPipelineEdge(1, 0)
+			root := connector.NewArgument().WithReg(reg)
+			t.Cleanup(root.Release)
+			s := &Scope{
+				Magic:         Remote,
+				Proc:          proc,
+				RootOp:        root,
+				ScopeAnalyzer: &ScopeAnalyzer{},
+				NodeInfo:      engine.Node{Addr: "remote-cn:6002", Mcpu: 1},
+			}
+
+			runErr := s.RemoteRun(c)
+			if tt.wantErr == nil {
+				require.NoError(t, runErr)
+			} else {
+				require.ErrorIs(t, runErr, tt.wantErr)
+			}
+			select {
+			case signal := <-reg.Ch2:
+				_, terminalErr := signal.Action()
+				require.Equal(t, tt.wantEvent, signal.EventType)
+				if tt.wantErr == nil {
+					require.NoError(t, terminalErr)
+				} else {
+					require.ErrorIs(t, terminalErr, tt.wantErr)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("remote cleanup did not terminate its receiver")
+			}
+		})
+	}
+}
+
 func TestRemoteRunFailureReleasesPendingRetainedDispatchAttach(t *testing.T) {
 	oldRuntime := runtime.ServiceRuntime("")
 	testRuntime := runtime.DefaultRuntime()

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -629,21 +629,21 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	sender, err := s.remoteRun(c)
 
 	runErr := err
-	runErr = suppressRemoteRunCancelError(s.Proc.Ctx, runErr)
-	if err != nil && s.Proc.Cancel != nil {
-		cancelErr := runErr
-		if cancelErr == nil {
-			cancelErr = err
-		}
-		s.Proc.Cancel(cancelErr)
+	runErr = suppressRemoteRunCancelError(
+		s.Proc.Ctx,
+		scopeRunQueryContext(s.Proc),
+		runErr,
+	)
+	if runErr != nil && s.Proc.Cancel != nil {
+		s.Proc.Cancel(runErr)
 	}
 	// this clean-up action shouldn't be called before context check.
 	// because the clean-up action will cancel the context, and error will be suppressed.
-	p.CleanRootOperator(s.Proc, err != nil, c.isPrepare, runErr)
+	p.CleanRootOperator(s.Proc, runErr != nil, c.isPrepare, runErr)
 
 	// sender should be closed after cleanup (tell the children-pipeline that query was done).
 	if sender != nil {
-		if err == nil {
+		if runErr == nil {
 			sender.prepareForLocalCleanup()
 		}
 		sender.close()
@@ -1308,15 +1308,44 @@ func logRemoteNotifyCleanupSendFailure(
 		err)
 }
 
-func suppressRemoteRunCancelError(procCtx context.Context, err error) error {
+func scopeRunQueryContext(proc *process.Process) context.Context {
+	if proc == nil || proc.Base == nil {
+		return nil
+	}
+	queryCtx, _ := process.GetQueryCtxFromProc(proc)
+	if queryCtx != nil {
+		return queryCtx
+	}
+	return proc.GetTopContext()
+}
+
+func suppressRemoteRunCancelError(
+	procCtx context.Context,
+	queryCtx context.Context,
+	err error,
+) error {
 	if err == nil {
 		return nil
 	}
-	if procCtx != nil && procCtx.Err() != nil &&
-		(moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted) || errors.Is(err, context.Canceled)) {
-		return nil
+	if procCtx == nil || procCtx.Err() == nil ||
+		(!moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted) &&
+			!errors.Is(err, context.Canceled)) {
+		return err
 	}
-	return err
+	// A canceled query owns the terminal result. Only cancellation of this
+	// pipeline alone can be treated as successful downstream early-stop.
+	if queryCtx != nil && queryCtx.Err() != nil {
+		if cause := context.Cause(queryCtx); cause != nil {
+			return cause
+		}
+		return queryCtx.Err()
+	}
+	if cause := context.Cause(procCtx); cause != nil &&
+		!moerr.IsMoErrCode(cause, moerr.ErrQueryInterrupted) &&
+		!errors.Is(cause, context.Canceled) {
+		return cause
+	}
+	return nil
 }
 
 func suppressRemoteNotifyCancelError(procCtx context.Context, err error) error {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1319,33 +1319,111 @@ func scopeRunQueryContext(proc *process.Process) context.Context {
 	return proc.GetTopContext()
 }
 
+func isScopeCancellationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// A joined result is cancellation fallout only when every leaf is
+	// cancellation-shaped. One cancellation sibling must not hide a
+	// substantive execution failure.
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		if len(children) == 0 {
+			return false
+		}
+		for _, child := range children {
+			if !isScopeCancellationError(child) {
+				return false
+			}
+		}
+		return true
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		if child := wrapped.Unwrap(); child != nil {
+			return isScopeCancellationError(child)
+		}
+	}
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted)
+}
+
+func isScopeCancellationFrom(err error, contextErr error) bool {
+	if err == nil || contextErr == nil {
+		return false
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		if len(children) == 0 {
+			return false
+		}
+		for _, child := range children {
+			if !isScopeCancellationFrom(child, contextErr) {
+				return false
+			}
+		}
+		return true
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		if child := wrapped.Unwrap(); child != nil {
+			return isScopeCancellationFrom(child, contextErr)
+		}
+	}
+	return errors.Is(err, contextErr) ||
+		moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted)
+}
+
+// normalizeScopeRunError distinguishes a substantive execution failure from
+// cancellation fallout. An internally canceled pipeline may finish
+// successfully, while query cancellation and substantive cancel causes remain
+// terminal and must poison the remote stream.
+func normalizeScopeRunError(
+	err error,
+	pipelineCtx context.Context,
+	queryCtx context.Context,
+) (error, bool) {
+	if err == nil || !isScopeCancellationError(err) ||
+		pipelineCtx == nil || pipelineCtx.Err() == nil {
+		return err, false
+	}
+	if queryCtx != nil {
+		if queryErr := queryCtx.Err(); queryErr != nil {
+			// WithTimeoutCause keeps DeadlineExceeded in Err and stores only
+			// diagnostics in Cause. Preserve the public timeout classification.
+			if errors.Is(queryErr, context.DeadlineExceeded) {
+				return queryErr, true
+			}
+			if !isScopeCancellationFrom(err, queryErr) {
+				return err, false
+			}
+			if cause := context.Cause(queryCtx); cause != nil {
+				return cause, true
+			}
+			return queryErr, true
+		}
+	}
+
+	// Cancellation is secondary only when every error leaf came from this
+	// pipeline. Preserve an independent error that merely raced cancellation.
+	if !isScopeCancellationFrom(err, pipelineCtx.Err()) {
+		return err, false
+	}
+	if cause := context.Cause(pipelineCtx); cause != nil {
+		err = cause
+	}
+	if isScopeCancellationError(err) && queryCtx != nil && queryCtx.Err() == nil {
+		return nil, true
+	}
+	return err, true
+}
+
 func suppressRemoteRunCancelError(
 	procCtx context.Context,
 	queryCtx context.Context,
 	err error,
 ) error {
-	if err == nil {
-		return nil
-	}
-	if procCtx == nil || procCtx.Err() == nil ||
-		(!moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted) &&
-			!errors.Is(err, context.Canceled)) {
-		return err
-	}
-	// A canceled query owns the terminal result. Only cancellation of this
-	// pipeline alone can be treated as successful downstream early-stop.
-	if queryCtx != nil && queryCtx.Err() != nil {
-		if cause := context.Cause(queryCtx); cause != nil {
-			return cause
-		}
-		return queryCtx.Err()
-	}
-	if cause := context.Cause(procCtx); cause != nil &&
-		!moerr.IsMoErrCode(cause, moerr.ErrQueryInterrupted) &&
-		!errors.Is(cause, context.Canceled) {
-		return cause
-	}
-	return nil
+	err, _ = normalizeScopeRunError(err, procCtx, queryCtx)
+	return err
 }
 
 func suppressRemoteNotifyCancelError(procCtx context.Context, err error) error {

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -2121,15 +2122,17 @@ func TestNotifyMessageClean(t *testing.T) {
 
 func TestSuppressRemoteRunCancelError(t *testing.T) {
 	t.Run("suppress query interrupted after proc cancel", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		queryCtx := context.Background()
+		ctx, cancel := context.WithCancel(queryCtx)
 		cancel()
-		require.NoError(t, suppressRemoteRunCancelError(ctx, nil, moerr.NewQueryInterrupted(ctx)))
+		require.NoError(t, suppressRemoteRunCancelError(ctx, queryCtx, moerr.NewQueryInterrupted(ctx)))
 	})
 
 	t.Run("suppress raw context cancellation after proc cancel", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		queryCtx := context.Background()
+		ctx, cancel := context.WithCancel(queryCtx)
 		cancel()
-		require.NoError(t, suppressRemoteRunCancelError(ctx, nil, fmt.Errorf("open remote stream: %w", context.Canceled)))
+		require.NoError(t, suppressRemoteRunCancelError(ctx, queryCtx, fmt.Errorf("open remote stream: %w", context.Canceled)))
 	})
 
 	t.Run("keep rpc timeout after proc cancel", func(t *testing.T) {
@@ -2168,6 +2171,42 @@ func TestSuppressRemoteRunCancelError(t *testing.T) {
 		substantiveErr := moerr.NewInternalErrorNoCtx("remote execution failed")
 		cancelPipeline(substantiveErr)
 		err := suppressRemoteRunCancelError(pipelineCtx, queryCtx, context.Canceled)
+		require.ErrorIs(t, err, substantiveErr)
+	})
+
+	t.Run("keep deadline classification instead of timeout cause", func(t *testing.T) {
+		diagnostic := moerr.NewInternalErrorNoCtx("request timeout diagnostic")
+		requestCtx, cancelRequest := context.WithDeadlineCause(
+			context.Background(),
+			time.Now().Add(-time.Second),
+			diagnostic,
+		)
+		defer cancelRequest()
+		queryCtx, cancelQuery := context.WithCancel(requestCtx)
+		defer cancelQuery()
+		pipelineCtx, cancelPipeline := context.WithCancelCause(queryCtx)
+		defer cancelPipeline(nil)
+
+		<-pipelineCtx.Done()
+		require.ErrorIs(t, queryCtx.Err(), context.DeadlineExceeded)
+		require.Equal(t, diagnostic, context.Cause(queryCtx))
+		err := suppressRemoteRunCancelError(
+			pipelineCtx,
+			queryCtx,
+			moerr.NewQueryInterrupted(pipelineCtx),
+		)
+		require.Equal(t, context.DeadlineExceeded, err)
+	})
+
+	t.Run("keep substantive error joined with cancellation", func(t *testing.T) {
+		queryCtx := context.Background()
+		pipelineCtx, cancelPipeline := context.WithCancel(queryCtx)
+		cancelPipeline()
+		substantiveErr := moerr.NewInternalErrorNoCtx("operator failed")
+		joined := errors.Join(context.Canceled, substantiveErr)
+
+		err := suppressRemoteRunCancelError(pipelineCtx, queryCtx, joined)
+		require.ErrorIs(t, err, context.Canceled)
 		require.ErrorIs(t, err, substantiveErr)
 	})
 }

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -2123,34 +2123,52 @@ func TestSuppressRemoteRunCancelError(t *testing.T) {
 	t.Run("suppress query interrupted after proc cancel", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		require.NoError(t, suppressRemoteRunCancelError(ctx, moerr.NewQueryInterrupted(ctx)))
+		require.NoError(t, suppressRemoteRunCancelError(ctx, nil, moerr.NewQueryInterrupted(ctx)))
 	})
 
 	t.Run("suppress raw context cancellation after proc cancel", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		require.NoError(t, suppressRemoteRunCancelError(ctx, fmt.Errorf("open remote stream: %w", context.Canceled)))
+		require.NoError(t, suppressRemoteRunCancelError(ctx, nil, fmt.Errorf("open remote stream: %w", context.Canceled)))
 	})
 
 	t.Run("keep rpc timeout after proc cancel", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		err := suppressRemoteRunCancelError(ctx, moerr.NewRPCTimeout(ctx))
+		err := suppressRemoteRunCancelError(ctx, nil, moerr.NewRPCTimeout(ctx))
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrRPCTimeout))
 	})
 
 	t.Run("keep query interrupted while proc still active", func(t *testing.T) {
 		ctx := context.Background()
-		err := suppressRemoteRunCancelError(ctx, moerr.NewQueryInterrupted(ctx))
+		err := suppressRemoteRunCancelError(ctx, nil, moerr.NewQueryInterrupted(ctx))
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted))
 	})
 
 	t.Run("keep raw context cancellation while proc still active", func(t *testing.T) {
 		ctx := context.Background()
-		err := suppressRemoteRunCancelError(ctx, context.Canceled)
+		err := suppressRemoteRunCancelError(ctx, nil, context.Canceled)
 		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("keep query cancellation after pipeline cancel", func(t *testing.T) {
+		queryCtx, cancelQuery := context.WithCancel(context.Background())
+		pipelineCtx, cancelPipeline := context.WithCancel(queryCtx)
+		cancelQuery()
+		cancelPipeline()
+		err := suppressRemoteRunCancelError(pipelineCtx, queryCtx, context.Canceled)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("keep substantive pipeline cancellation cause", func(t *testing.T) {
+		queryCtx := context.Background()
+		pipelineCtx, cancelPipeline := context.WithCancelCause(queryCtx)
+		substantiveErr := moerr.NewInternalErrorNoCtx("remote execution failed")
+		cancelPipeline(substantiveErr)
+		err := suppressRemoteRunCancelError(pipelineCtx, queryCtx, context.Canceled)
+		require.ErrorIs(t, err, substantiveErr)
 	})
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes

Issue #27757.

## What this PR does / why we need it

- reuse the negotiated remote backend after a successful internal early stop such as LIMIT completion
- keep query cancellation, query deadline, and substantive execution failures terminal so their streams are poisoned rather than returned to the pool
- backport main cancellation normalization semantics, including `WithTimeoutCause` deadline classification and joined-error preservation
- publish `EventEnd` only for a successful internal early stop; publish `EventError` for terminal cancellation/failure

No wire-format or timeout-default change is introduced. The normal success path retains an immediate nil-error fast path.

## Validation

- `TestSuppressRemoteRunCancelError`: pass
- `TestIssue27757RemoteRunCancellationClassification`: pass
- each focused test under `-race -count=100`: pass
- full `pkg/sql/compile`: pass
- full `pkg/sql/compile` under `-race`: pass
- `go vet ./pkg/sql/compile`: pass
- `git diff --check`: pass