### PR TITLE
fix(compile): preserve in-memory rows on single remote scans

### DIFF
--- a/pkg/sql/compile/remote_reader_test.go
+++ b/pkg/sql/compile/remote_reader_test.go
@@ -18,20 +18,33 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
 
 type readerPathCaptureEngine struct {
 	engine.Engine
+	database               engine.Database
 	buildBlockReadersCalls int
+}
+
+func (e *readerPathCaptureEngine) Database(
+	context.Context,
+	string,
+	client.TxnOperator,
+) (engine.Database, error) {
+	return e.database, nil
 }
 
 func (e *readerPathCaptureEngine) BuildBlockReaders(
@@ -48,18 +61,42 @@ func (e *readerPathCaptureEngine) BuildBlockReaders(
 	return []engine.Reader{new(readutil.EmptyReader)}, nil
 }
 
+type readerPathCaptureDatabase struct {
+	engine.Database
+	relation engine.Relation
+}
+
+func (db *readerPathCaptureDatabase) Relation(
+	context.Context,
+	string,
+	any,
+) (engine.Relation, error) {
+	return db.relation, nil
+}
+
 type readerPathCaptureRelation struct {
 	engine.Relation
 	buildReadersCalls int
+	rangesCalls       int
+	rangesData        engine.RelData
+	readerRelData     engine.RelData
 	ctx               context.Context
 	hint              engine.FilterHint
+}
+
+func (r *readerPathCaptureRelation) Ranges(
+	context.Context,
+	engine.RangesParam,
+) (engine.RelData, error) {
+	r.rangesCalls++
+	return r.rangesData, nil
 }
 
 func (r *readerPathCaptureRelation) BuildReaders(
 	ctx context.Context,
 	_ any,
 	_ *plan.Expr,
-	_ engine.RelData,
+	relData engine.RelData,
 	_ int,
 	_ int,
 	_ bool,
@@ -67,6 +104,7 @@ func (r *readerPathCaptureRelation) BuildReaders(
 	filterHint engine.FilterHint,
 ) ([]engine.Reader, error) {
 	r.buildReadersCalls++
+	r.readerRelData = relData
 	r.ctx = ctx
 	r.hint = filterHint
 	return []engine.Reader{new(readutil.EmptyReader)}, nil
@@ -83,12 +121,6 @@ func TestBuildReadersChoosesOwnerByScanPlacement(t *testing.T) {
 		{
 			name:              "local scope reads complete relation data",
 			cnCount:           2,
-			wantRelationCalls: 1,
-		},
-		{
-			name:              "single remote scope reads complete relation data",
-			isRemote:          true,
-			cnCount:           1,
 			wantRelationCalls: 1,
 		},
 		{
@@ -131,79 +163,102 @@ func TestBuildReadersChoosesOwnerByScanPlacement(t *testing.T) {
 	}
 }
 
-func TestSingleRemoteRelationReaderPreservesRemoteMetadata(t *testing.T) {
+func TestDecodedSingleRemoteScopeBuildsRelationReader(t *testing.T) {
 	tests := []struct {
-		name                     string
-		tableName                string
-		tableType                string
-		account                  *plan.PubInfo
-		serializedFilter         []byte
-		contextFilter            []byte
-		wantMembershipFilter     []byte
-		wantReaderContextAccount uint32
+		name                 string
+		tableName            string
+		tableType            string
+		pubInfo              *plan.PubInfo
+		membershipFilter     []byte
+		wantReaderAccount    uint32
+		wantMembershipFilter []byte
 	}{
 		{
-			name:                     "serialized fulltext metadata",
-			tableName:                "__mo_index_secondary_fulltext",
-			tableType:                catalog.FullTextIndex_TblType,
-			account:                  &plan.PubInfo{TenantId: 42},
-			serializedFilter:         []byte{1, 2, 3},
-			wantMembershipFilter:     []byte{1, 2, 3},
-			wantReaderContextAccount: 42,
+			name:                 "published fulltext table",
+			tableName:            "__mo_index_secondary_fulltext",
+			tableType:            catalog.FullTextIndex_TblType,
+			pubInfo:              &plan.PubInfo{TenantId: 42},
+			membershipFilter:     []byte{1, 2, 3},
+			wantReaderAccount:    42,
+			wantMembershipFilter: []byte{1, 2, 3},
 		},
 		{
-			name:                     "context fulltext metadata fallback",
-			tableName:                "__mo_index_secondary_fulltext",
-			tableType:                catalog.FullTextIndex_TblType,
-			account:                  &plan.PubInfo{TenantId: 43},
-			contextFilter:            []byte{4, 5, 6},
-			wantMembershipFilter:     []byte{4, 5, 6},
-			wantReaderContextAccount: 43,
-		},
-		{
-			name:                     "cluster table account",
-			tableName:                "cluster_table",
-			tableType:                catalog.SystemClusterRel,
-			wantReaderContextAccount: catalog.System_Account,
+			name:              "cluster table",
+			tableName:         "cluster_table",
+			tableType:         catalog.SystemClusterRel,
+			wantReaderAccount: catalog.System_Account,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			proc := testutil.NewProcess(t)
-			if len(test.contextFilter) > 0 {
-				proc.Ctx = context.WithValue(
-					proc.Ctx,
+			ctrl := gomock.NewController(t)
+			tableDef := &plan.TableDef{Name: test.tableName, TableType: test.tableType}
+			node := &plan.Node{
+				ObjRef: &plan.ObjectRef{
+					SchemaName: "test_db",
+					ObjName:    tableDef.Name,
+					PubInfo:    test.pubInfo,
+				},
+				TableDef: tableDef,
+			}
+			memoryRanges := readutil.NewBlockListRelationData(1)
+			captureRelation := &readerPathCaptureRelation{rangesData: memoryRanges}
+			captureEngine := &readerPathCaptureEngine{
+				database: &readerPathCaptureDatabase{relation: captureRelation},
+			}
+
+			senderProc := testutil.NewProcess(t)
+			if len(test.membershipFilter) > 0 {
+				senderProc.Ctx = context.WithValue(
+					senderProc.Ctx,
 					defines.FulltextMembershipFilter{},
-					test.contextFilter,
+					test.membershipFilter,
 				)
 			}
-			tableDef := &plan.TableDef{Name: test.tableName, TableType: test.tableType}
-			captureRelation := new(readerPathCaptureRelation)
-			scope := &Scope{
-				Proc:     proc,
-				IsRemote: true,
+			senderScope := &Scope{
+				Magic: Remote,
+				Proc:  senderProc,
 				DataSource: &Source{
-					Rel:                   captureRelation,
-					node:                  &plan.Node{TableDef: tableDef},
-					TableDef:              tableDef,
-					AccountId:             test.account,
-					MembershipFilterBytes: test.serializedFilter,
-					FilterList:            []*plan.Expr{plan2.MakeFalseExpr()},
+					Rel:          captureRelation,
+					node:         node,
+					TableDef:     tableDef,
+					SchemaName:   node.ObjRef.SchemaName,
+					RelationName: tableDef.Name,
 				},
 				NodeInfo: engine.Node{Mcpu: 1, CNCNT: 1},
 			}
-			compile := NewMockCompile(t)
-			compile.proc = proc
-			compile.e = new(readerPathCaptureEngine)
+			encodeCtx := &scopeContext{regs: make(map[*process.WaitRegister]int32)}
+			encodeCtx.root = encodeCtx
+			encoded, _, err := generatePipeline(senderScope, encodeCtx, 1)
+			require.NoError(t, err)
 
-			readers, err := scope.buildReaders(compile)
+			remoteProc := testutil.NewProcess(t)
+			remoteProc.Ctx = defines.AttachAccountId(remoteProc.Ctx, 99)
+			txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
+			txnOperator.EXPECT().GetWorkspace().Return(&Ws{}).AnyTimes()
+			remoteProc.Base.TxnOperator = txnOperator
+			decodeCtx := &scopeContext{regs: make(map[*process.WaitRegister]int32)}
+			decodeCtx.root = decodeCtx
+			decoded, err := generateScope(remoteProc, encoded, decodeCtx, true)
+			require.NoError(t, err)
+			require.Nil(t, decoded.DataSource.Rel,
+				"relation handles are local execution state and are not serialized")
+
+			compile := &Compile{proc: remoteProc, e: captureEngine}
+			readers, err := decoded.buildReaders(compile)
 			require.NoError(t, err)
 			require.Len(t, readers, 1)
+			require.Equal(t, 1, captureRelation.rangesCalls)
+			require.Equal(t, 1, captureRelation.buildReadersCalls)
+			require.Zero(t, captureEngine.buildBlockReadersCalls)
+			require.Same(t, memoryRanges, captureRelation.readerRelData)
+			firstBlock := captureRelation.readerRelData.GetBlockInfo(0)
+			require.True(t, firstBlock.IsMemBlk())
 			require.Equal(t, test.wantMembershipFilter, captureRelation.hint.MembershipFilterBytes)
 			accountID, err := defines.GetAccountId(captureRelation.ctx)
 			require.NoError(t, err)
-			require.Equal(t, test.wantReaderContextAccount, accountID)
+			require.Equal(t, test.wantReaderAccount, accountID)
 		})
 	}
 }

--- a/pkg/sql/compile/remote_reader_test.go
+++ b/pkg/sql/compile/remote_reader_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/readutil"
+	"github.com/stretchr/testify/require"
+)
+
+type readerPathCaptureEngine struct {
+	engine.Engine
+	buildBlockReadersCalls int
+}
+
+func (e *readerPathCaptureEngine) BuildBlockReaders(
+	context.Context,
+	any,
+	timestamp.Timestamp,
+	*plan.Expr,
+	*plan.TableDef,
+	engine.RelData,
+	int,
+	...engine.FilterHint,
+) ([]engine.Reader, error) {
+	e.buildBlockReadersCalls++
+	return []engine.Reader{new(readutil.EmptyReader)}, nil
+}
+
+type readerPathCaptureRelation struct {
+	engine.Relation
+	buildReadersCalls int
+	ctx               context.Context
+	hint              engine.FilterHint
+}
+
+func (r *readerPathCaptureRelation) BuildReaders(
+	ctx context.Context,
+	_ any,
+	_ *plan.Expr,
+	_ engine.RelData,
+	_ int,
+	_ int,
+	_ bool,
+	_ engine.TombstoneApplyPolicy,
+	filterHint engine.FilterHint,
+) ([]engine.Reader, error) {
+	r.buildReadersCalls++
+	r.ctx = ctx
+	r.hint = filterHint
+	return []engine.Reader{new(readutil.EmptyReader)}, nil
+}
+
+func TestBuildReadersChoosesOwnerByScanPlacement(t *testing.T) {
+	tests := []struct {
+		name               string
+		isRemote           bool
+		cnCount            int32
+		wantRelationCalls  int
+		wantBlockReadCalls int
+	}{
+		{
+			name:              "local scope reads complete relation data",
+			cnCount:           2,
+			wantRelationCalls: 1,
+		},
+		{
+			name:              "single remote scope reads complete relation data",
+			isRemote:          true,
+			cnCount:           1,
+			wantRelationCalls: 1,
+		},
+		{
+			name:               "distributed remote scope reads persisted blocks",
+			isRemote:           true,
+			cnCount:            2,
+			wantBlockReadCalls: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			captureEngine := new(readerPathCaptureEngine)
+			captureRelation := new(readerPathCaptureRelation)
+			scope := &Scope{
+				Proc:     proc,
+				IsRemote: test.isRemote,
+				DataSource: &Source{
+					Rel:                captureRelation,
+					TableDef:           &plan.TableDef{Name: "t"},
+					FilterList:         []*plan.Expr{plan2.MakeFalseExpr()},
+					RuntimeFilterSpecs: []*plan.RuntimeFilterSpec{},
+				},
+				NodeInfo: engine.Node{
+					Mcpu:  1,
+					CNCNT: test.cnCount,
+				},
+			}
+			compile := NewMockCompile(t)
+			compile.proc = proc
+			compile.e = captureEngine
+
+			readers, err := scope.buildReaders(compile)
+			require.NoError(t, err)
+			require.Len(t, readers, 1)
+			require.Equal(t, test.wantRelationCalls, captureRelation.buildReadersCalls)
+			require.Equal(t, test.wantBlockReadCalls, captureEngine.buildBlockReadersCalls)
+		})
+	}
+}
+
+func TestSingleRemoteRelationReaderPreservesRemoteMetadata(t *testing.T) {
+	tests := []struct {
+		name                     string
+		tableName                string
+		tableType                string
+		account                  *plan.PubInfo
+		serializedFilter         []byte
+		contextFilter            []byte
+		wantMembershipFilter     []byte
+		wantReaderContextAccount uint32
+	}{
+		{
+			name:                     "serialized fulltext metadata",
+			tableName:                "__mo_index_secondary_fulltext",
+			tableType:                catalog.FullTextIndex_TblType,
+			account:                  &plan.PubInfo{TenantId: 42},
+			serializedFilter:         []byte{1, 2, 3},
+			wantMembershipFilter:     []byte{1, 2, 3},
+			wantReaderContextAccount: 42,
+		},
+		{
+			name:                     "context fulltext metadata fallback",
+			tableName:                "__mo_index_secondary_fulltext",
+			tableType:                catalog.FullTextIndex_TblType,
+			account:                  &plan.PubInfo{TenantId: 43},
+			contextFilter:            []byte{4, 5, 6},
+			wantMembershipFilter:     []byte{4, 5, 6},
+			wantReaderContextAccount: 43,
+		},
+		{
+			name:                     "cluster table account",
+			tableName:                "cluster_table",
+			tableType:                catalog.SystemClusterRel,
+			wantReaderContextAccount: catalog.System_Account,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			if len(test.contextFilter) > 0 {
+				proc.Ctx = context.WithValue(
+					proc.Ctx,
+					defines.FulltextMembershipFilter{},
+					test.contextFilter,
+				)
+			}
+			tableDef := &plan.TableDef{Name: test.tableName, TableType: test.tableType}
+			captureRelation := new(readerPathCaptureRelation)
+			scope := &Scope{
+				Proc:     proc,
+				IsRemote: true,
+				DataSource: &Source{
+					Rel:                   captureRelation,
+					node:                  &plan.Node{TableDef: tableDef},
+					TableDef:              tableDef,
+					AccountId:             test.account,
+					MembershipFilterBytes: test.serializedFilter,
+					FilterList:            []*plan.Expr{plan2.MakeFalseExpr()},
+				},
+				NodeInfo: engine.Node{Mcpu: 1, CNCNT: 1},
+			}
+			compile := NewMockCompile(t)
+			compile.proc = proc
+			compile.e = new(readerPathCaptureEngine)
+
+			readers, err := scope.buildReaders(compile)
+			require.NoError(t, err)
+			require.Len(t, readers, 1)
+			require.Equal(t, test.wantMembershipFilter, captureRelation.hint.MembershipFilterBytes)
+			accountID, err := defines.GetAccountId(captureRelation.ctx)
+			require.NoError(t, err)
+			require.Equal(t, test.wantReaderContextAccount, accountID)
+		})
+	}
+}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1598,8 +1598,12 @@ func (s *Scope) buildReaders(c *Compile) (readers []engine.Reader, err error) {
 	}
 
 	switch {
-	// If this was a remote-run pipeline. Reader should be generated from Engine.
-	case s.IsRemote:
+	// A distributed remote scope only owns its assigned persisted blocks. Keep
+	// using the engine reader, which deliberately excludes the memory-block
+	// sentinel owned by the local scope. A single remote scope is different: it
+	// owns the complete scan, including committed rows in this CN's partition
+	// state, so it must use the relation reader below.
+	case s.IsRemote && (s.NodeInfo.CNCNT != 1 || s.DataSource.Rel == nil):
 		// this cannot use c.proc.Ctx directly, please refer to `default case`.
 		ctx := c.proc.Ctx
 		if util.TableIsClusterTable(s.DataSource.TableDef.GetTableType()) {
@@ -1632,9 +1636,17 @@ func (s *Scope) buildReaders(c *Compile) (readers []engine.Reader, err error) {
 		if err != nil {
 			return
 		}
-	// Reader can be generated from local relation.
+	// Reader can be generated from the relation on the executing CN.
 	case s.DataSource.Rel != nil:
 		ctx := c.proc.Ctx
+		if s.IsRemote {
+			if util.TableIsClusterTable(s.DataSource.TableDef.GetTableType()) {
+				ctx = defines.AttachAccountId(ctx, catalog.System_Account)
+			}
+			if s.DataSource.AccountId != nil {
+				ctx = defines.AttachAccountId(ctx, uint32(s.DataSource.AccountId.GetTenantId()))
+			}
+		}
 		stats := statistic.StatsInfoFromContext(ctx)
 		crs := new(perfcounter.CounterSet)
 		newCtx := perfcounter.AttachS3RequestKey(ctx, crs)
@@ -1643,8 +1655,11 @@ func (s *Scope) buildReaders(c *Compile) (readers []engine.Reader, err error) {
 		// Pass runtime membership filter bytes to reader via FilterHint (for fulltext index table).
 		if n := s.DataSource.node; n != nil && n.TableDef != nil &&
 			catalog.IsFullTextIndexTableType(n.TableDef.TableType, n.TableDef.Name) {
-			if bfVal := c.proc.Ctx.Value(defines.FulltextMembershipFilter{}); bfVal != nil {
-				if bf, ok := bfVal.([]byte); ok && len(bf) > 0 {
+			if s.IsRemote {
+				hint.MembershipFilterBytes = s.DataSource.MembershipFilterBytes
+			}
+			if len(hint.MembershipFilterBytes) == 0 {
+				if bf, ok := c.proc.Ctx.Value(defines.FulltextMembershipFilter{}).([]byte); ok {
 					hint.MembershipFilterBytes = bf
 				}
 			}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -926,6 +926,13 @@ func (s *Scope) getRelData(c *Compile, blockExprList []*plan.Expr) error {
 				return err
 			}
 		}
+		// Remote scope decoding intentionally does not carry relation handles.
+		// When this scope owns the complete scan, retain the relation opened on
+		// the executing CN so buildReaders can consume the in-memory sentinel
+		// returned by Policy_CollectAllData instead of stripping it.
+		if s.IsRemote {
+			s.DataSource.Rel = engine.NewRelationHandle(rel)
+		}
 		return nil
 	}
 
@@ -1643,8 +1650,12 @@ func (s *Scope) buildReaders(c *Compile) (readers []engine.Reader, err error) {
 			if util.TableIsClusterTable(s.DataSource.TableDef.GetTableType()) {
 				ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 			}
-			if s.DataSource.AccountId != nil {
-				ctx = defines.AttachAccountId(ctx, uint32(s.DataSource.AccountId.GetTenantId()))
+			account := s.DataSource.AccountId
+			if account == nil && s.DataSource.node != nil && s.DataSource.node.ObjRef != nil {
+				account = s.DataSource.node.ObjRef.PubInfo
+			}
+			if account != nil {
+				ctx = defines.AttachAccountId(ctx, uint32(account.GetTenantId()))
 			}
 		}
 		stats := statistic.StatsInfoFromContext(ctx)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27755

## What this PR does / why we need it:

A scan assigned to exactly one remote CN collects all relation data, including the memory-block sentinel for committed rows still held in that CN's partition state. The remote execution path previously always used block readers, which deliberately strip that sentinel for distributed scans, so a single remote scan could intermittently return an empty result before the rows were flushed into persisted objects.

This PR:

- uses the executing CN's relation reader when one remote CN owns the complete scan;
- keeps block readers for distributed remote scopes so only the local scope owns in-memory rows;
- preserves tenant/system account context and fulltext membership-filter metadata on the relation-reader path;
- adds deterministic unit coverage for local, single-remote, and distributed-remote reader ownership.

Validation:

- focused compile tests and race tests;
- full `pkg/sql/compile` and `pkg/tests/dml` package tests;
- `TestForcedMultiCNDeleteAndInsertIgnore` with `-count=20` and under `-race`;
- `go vet ./pkg/sql/compile ./pkg/tests/dml`.
