### PR TITLE
[4.1-dev] fix: preserve legacy dummy partition behavior

### DIFF
--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -495,8 +495,6 @@ func ConstructCreateTableSQL(
 	if tableDef.Partition != nil {
 		ps := ctx.GetProcess().GetPartitionService()
 		if ps.Enabled() {
-			partitionBy := " partition by "
-
 			txn := ctx.GetProcess().GetTxnOperator()
 			newCtx := ctx.GetContext()
 			if snapshot != nil && snapshot.TS != nil {
@@ -512,26 +510,7 @@ func ConstructCreateTableSQL(
 				return "", nil, err
 			}
 
-			partitionBy += meta.Description
-
-			switch meta.Method {
-			case partition.PartitionMethod_Hash,
-				partition.PartitionMethod_LinearHash,
-				partition.PartitionMethod_Key,
-				partition.PartitionMethod_LinearKey:
-				partitionBy += fmt.Sprintf(" partitions %d", len(meta.Partitions))
-			default:
-				partitionBy += " ("
-				for i, p := range meta.Partitions {
-					if i > 0 {
-						partitionBy += ", "
-					}
-					partitionBy += "partition" + " " + p.Name + " " + p.ExprStr
-				}
-				partitionBy += ")"
-			}
-
-			createStr += partitionBy
+			createStr += constructPartitionSQL(meta)
 		}
 	}
 
@@ -659,6 +638,31 @@ func ConstructCreateTableSQL(
 		stmt, err = getRewriteSQLStmt(ctx, rewriteStr)
 	}
 	return createStr, stmt, err
+}
+
+func constructPartitionSQL(meta partition.PartitionMetadata) string {
+	if meta.IsEmpty() {
+		return ""
+	}
+
+	partitionBy := " partition by " + meta.Description
+	switch meta.Method {
+	case partition.PartitionMethod_Hash,
+		partition.PartitionMethod_LinearHash,
+		partition.PartitionMethod_Key,
+		partition.PartitionMethod_LinearKey:
+		partitionBy += fmt.Sprintf(" partitions %d", len(meta.Partitions))
+	default:
+		partitionBy += " ("
+		for i, p := range meta.Partitions {
+			if i > 0 {
+				partitionBy += ", "
+			}
+			partitionBy += "partition" + " " + p.Name + " " + p.ExprStr
+		}
+		partitionBy += ")"
+	}
+	return partitionBy
 }
 
 func extractTopLevelCheckDefs(tableDef *plan.TableDef) []string {

--- a/pkg/sql/plan/build_show_util_test.go
+++ b/pkg/sql/plan/build_show_util_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/partition"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
@@ -156,6 +157,47 @@ func Test_buildTestShowCreateTable(t *testing.T) {
 			if tt.want != got {
 				t.Errorf("buildShow failed. \nExpected/Got:\n%s\n%s", tt.want, got)
 			}
+		})
+	}
+}
+
+func TestConstructPartitionSQL(t *testing.T) {
+	tests := []struct {
+		name string
+		meta partition.PartitionMetadata
+		want string
+	}{
+		{
+			name: "legacy metadata-only partition",
+		},
+		{
+			name: "hash partition",
+			meta: partition.PartitionMetadata{
+				TableID:     1,
+				Method:      partition.PartitionMethod_Hash,
+				Description: "hash(id)",
+				Partitions:  []partition.Partition{{}, {}, {}},
+			},
+			want: " partition by hash(id) partitions 3",
+		},
+		{
+			name: "range partition",
+			meta: partition.PartitionMetadata{
+				TableID:     1,
+				Method:      partition.PartitionMethod_Range,
+				Description: "range(id)",
+				Partitions: []partition.Partition{
+					{Name: "p0", ExprStr: "values less than (10)"},
+					{Name: "p1", ExprStr: "values less than (20)"},
+				},
+			},
+			want: " partition by range(id) (partition p0 values less than (10), partition p1 values less than (20))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, constructPartitionSQL(tt.meta))
 		})
 	}
 }

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -40,10 +40,12 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
+	"github.com/matrixorigin/matrixone/pkg/pb/partition"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	"github.com/matrixorigin/matrixone/pkg/shardservice"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/features"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
@@ -179,27 +181,33 @@ func newTxnTable(
 				if err != nil {
 					return nil, err
 				}
-				combined = newCombinedTxnTable(
-					tbl.origin,
-					getPartitionTableFunc(proc, metadata, db),
-					getPruneTablesFunc(proc, metadata, db),
-					getPartitionPrunePKFunc(proc, metadata, db),
-				)
+				combined, err = tbl.configurePartitionTable(ctx, metadata, proc, db)
+				if err != nil {
+					return nil, err
+				}
 			} else {
 				relations, err := tbl.getPartitionIndexesTables(process)
 				if err != nil {
 					return nil, err
 				}
-				combined = newCombinedTxnTable(
-					tbl.origin,
-					getArrayTableFunc(relations),
-					getArrayPruneTablesFunc(relations),
-					getArrayPrunePKFunc(relations),
-				)
+				if len(relations) > 0 {
+					combined = newCombinedTxnTable(
+						tbl.origin,
+						getArrayTableFunc(relations),
+						getArrayPruneTablesFunc(relations),
+						getArrayPrunePKFunc(relations),
+					)
+				}
 			}
 
-			tbl.combined.tbl = combined
-			tbl.combined.is = true
+			// Tables created before partition metadata was introduced have no
+			// physical relations known to the partition service. Keep the
+			// partition definition as compatibility-only metadata and use the
+			// logical table through the ordinary relation path.
+			if combined != nil {
+				tbl.combined.tbl = combined
+				tbl.combined.is = true
+			}
 		}
 
 		tbl.shard.service = shardservice.GetService(process.GetService())
@@ -218,6 +226,55 @@ func newTxnTable(
 	}
 
 	return tbl, nil
+}
+
+func (tbl *txnTableDelegate) configurePartitionTable(
+	ctx context.Context,
+	metadata partition.PartitionMetadata,
+	proc *process.Process,
+	db *txnDatabase,
+) (*combinedTxnTable, error) {
+	if metadata.IsEmpty() {
+		tbl.useOrdinaryTableForLegacyPartition()
+		return nil, nil
+	}
+	if len(metadata.Partitions) == 0 {
+		return nil, moerr.NewInternalErrorf(
+			ctx,
+			"partition metadata for table %d has no partitions",
+			metadata.TableID,
+		)
+	}
+
+	return newCombinedTxnTable(
+		tbl.origin,
+		getPartitionTableFunc(proc, metadata, db),
+		getPruneTablesFunc(proc, metadata, db),
+		getPartitionPrunePKFunc(proc, metadata, db),
+	), nil
+}
+
+// useOrdinaryTableForLegacyPartition preserves the behavior of tables created
+// while partition syntax was metadata-only. Those tables have the legacy
+// partition marker but no partition-service metadata, and all their data lives
+// in the logical table. Normalize the relation-local schema so every planner,
+// DML, DDL, and SHOW path treats it as an ordinary table.
+func (tbl *txnTableDelegate) useOrdinaryTableForLegacyPartition() {
+	origin := tbl.origin
+	origin.partitioned = 0
+	origin.partition = ""
+
+	// TableItem schema objects belong to the shared catalog cache. Clone before
+	// clearing the compatibility-only marker on this relation.
+	origin.tableDef = plan2.DeepCopyTableDef(origin.tableDef, true)
+	origin.tableDef.FeatureFlag &^= features.Partitioned
+	origin.tableDef.Partition = nil
+
+	if origin.extraInfo != nil {
+		extra := *origin.extraInfo
+		extra.FeatureFlag &^= features.Partitioned
+		origin.extraInfo = &extra
+	}
 }
 
 func (tbl *txnTable) getEngine() engine.Engine {

--- a/pkg/vm/engine/disttae/txn_table_delegate.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate.go
@@ -1211,8 +1211,14 @@ func (tbl *txnTableDelegate) getPartitionIndexesTables(
 }
 
 func (tbl *txnTableDelegate) IsPartitionIndexTable() bool {
-	return tbl.parent != nil &&
-		features.IsPartitioned(tbl.parent.GetExtraInfo().FeatureFlag)
+	if tbl.parent == nil || tbl.origin == nil {
+		return false
+	}
+	if catalog.IsFullTextIndexTableType(tbl.origin.relKind, tbl.origin.tableName) {
+		return false
+	}
+	extra := tbl.parent.GetExtraInfo()
+	return extra != nil && features.IsPartitioned(extra.FeatureFlag)
 }
 
 // Just for UT.

--- a/pkg/vm/engine/disttae/txn_table_delegate_test.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate_test.go
@@ -18,13 +18,155 @@ import (
 	"context"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/pb/api"
+	"github.com/matrixorigin/matrixone/pkg/pb/partition"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/features"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestTxnTableDelegateIsPartitionIndexTable(t *testing.T) {
+	parent := &txnTableDelegate{origin: &txnTable{
+		extraInfo: &api.SchemaExtra{FeatureFlag: features.Partitioned},
+	}}
+
+	tests := []struct {
+		name      string
+		tableName string
+		tableType string
+		expected  bool
+	}{
+		{
+			name:      "regular partition index",
+			tableName: catalog.IndexTableNamePrefix + "regular",
+			tableType: catalog.SystemIndexRel,
+			expected:  true,
+		},
+		{
+			name:      "fulltext table type uses global table",
+			tableName: catalog.IndexTableNamePrefix + "fulltext",
+			tableType: catalog.FullTextIndex_TblType,
+		},
+		{
+			name:      "legacy fulltext name uses global table",
+			tableName: catalog.FullTextIndexTableNamePrefix + "legacy",
+			tableType: catalog.SystemIndexRel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := &txnTableDelegate{
+				origin: &txnTable{
+					tableName: tt.tableName,
+					relKind:   tt.tableType,
+				},
+				parent: parent,
+			}
+			require.Equal(t, tt.expected, table.IsPartitionIndexTable())
+		})
+	}
+}
+
+func TestUseOrdinaryTableForLegacyPartition(t *testing.T) {
+	sharedDef := &plan.TableDef{
+		FeatureFlag: features.Partitioned | features.IndexTable,
+		Partition:   &plan.Partition{},
+	}
+	sharedExtra := &api.SchemaExtra{
+		FeatureFlag: features.Partitioned | features.IndexTable,
+	}
+	table := &txnTableDelegate{origin: &txnTable{
+		tableDef:    sharedDef,
+		extraInfo:   sharedExtra,
+		partitioned: 1,
+		partition:   "partition by range (id)",
+	}}
+
+	table.useOrdinaryTableForLegacyPartition()
+
+	require.NotSame(t, sharedDef, table.origin.tableDef)
+	require.NotSame(t, sharedExtra, table.origin.extraInfo)
+	require.False(t, features.IsPartitioned(table.origin.tableDef.FeatureFlag))
+	require.False(t, features.IsPartitioned(table.origin.extraInfo.FeatureFlag))
+	require.True(t, features.IsIndexTable(table.origin.tableDef.FeatureFlag))
+	require.True(t, features.IsIndexTable(table.origin.extraInfo.FeatureFlag))
+	require.Nil(t, table.origin.tableDef.Partition)
+	require.Zero(t, table.origin.partitioned)
+	require.Empty(t, table.origin.partition)
+
+	// The relation-local downgrade must not mutate the shared catalog entry.
+	require.True(t, features.IsPartitioned(sharedDef.FeatureFlag))
+	require.True(t, features.IsPartitioned(sharedExtra.FeatureFlag))
+	require.NotNil(t, sharedDef.Partition)
+}
+
+func TestConfigurePartitionTableMetadataBoundary(t *testing.T) {
+	newTable := func() *txnTableDelegate {
+		return &txnTableDelegate{origin: &txnTable{
+			tableDef: &plan.TableDef{
+				FeatureFlag: features.Partitioned,
+				Partition:   &plan.Partition{},
+			},
+			extraInfo:   &api.SchemaExtra{FeatureFlag: features.Partitioned},
+			partitioned: 1,
+			partition:   "partition by range (id)",
+		}}
+	}
+
+	t.Run("missing metadata is a legacy ordinary table", func(t *testing.T) {
+		table := newTable()
+		combined, err := table.configurePartitionTable(
+			context.Background(),
+			partition.PartitionMetadata{},
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		require.Nil(t, combined)
+		require.False(t, table.combined.is)
+		require.Nil(t, table.combined.tbl)
+		require.False(t, features.IsPartitioned(table.origin.tableDef.FeatureFlag))
+	})
+
+	t.Run("published empty metadata is corruption", func(t *testing.T) {
+		table := newTable()
+		combined, err := table.configurePartitionTable(
+			context.Background(),
+			partition.PartitionMetadata{TableID: 42},
+			nil,
+			nil,
+		)
+		require.Nil(t, combined)
+		require.ErrorContains(t, err, "partition metadata for table 42 has no partitions")
+		require.False(t, table.combined.is)
+		require.True(t, features.IsPartitioned(table.origin.tableDef.FeatureFlag))
+	})
+
+	t.Run("published metadata keeps physical partition routing", func(t *testing.T) {
+		table := newTable()
+		combined, err := table.configurePartitionTable(
+			context.Background(),
+			partition.PartitionMetadata{
+				TableID:    42,
+				Partitions: []partition.Partition{{PartitionID: 43}},
+			},
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, combined)
+		require.Same(t, table.origin, combined.primary)
+		require.True(t, features.IsPartitioned(table.origin.tableDef.FeatureFlag))
+	})
+}
 
 func TestTxnTableDelegate_CollectChanges(t *testing.T) {
 	table := &txnTableDelegate{}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27808

## What this PR does / why we need it:

Tables created by versions where partition syntax was metadata-only retain the legacy partition marker but have no partition-service metadata. After upgrade, 4.1 treated them as physical partition tables, produced zero readers, and could panic in `buildScanParallelRun`.

This change:
- keeps missing-metadata legacy partition tables on the ordinary logical-table path;
- treats published-but-empty metadata as catalog corruption;
- keeps real partition tables on physical routing;
- keeps FULLTEXT hidden tables on their logical/global relation;
- omits an invalid partition clause from `SHOW CREATE TABLE` for legacy dummy tables.

Validation:
- `go test -count=1 ./pkg/sql/plan ./pkg/vm/engine/disttae`
- official v3.0.4 data directory upgraded to patched 4.1-dev: SELECT/DML/index/FULLTEXT/DDL/restart/SHOW/TRUNCATE all passed;
- fresh 4.1-dev physical RANGE partition table retained metadata, routing, FULLTEXT, and SHOW behavior.