### PR TITLE
test(lockservice): isolate forwarded lock timeout assertion

### DIFF
--- a/pkg/lockservice/service_forward_test.go
+++ b/pkg/lockservice/service_forward_test.go
@@ -272,7 +272,6 @@ func TestForwardLockUsesEffectiveLockDeadline(t *testing.T) {
 
 			options := newTestRowExclusiveOptions()
 			options.ForwardTo = owner.serviceID
-			options.LockWaitTimeout = 1
 			// Forwarded txns are normally created by the frontend txn lifecycle on
 			// the origin CN. Register both here so owner-side orphan detection sees
 			// the same liveness state as production while the waiter is blocked.
@@ -281,10 +280,13 @@ func TestForwardLockUsesEffectiveLockDeadline(t *testing.T) {
 
 			// A deadline-less background context previously reached morpc.Send
 			// unchanged and panicked. Service entry must inject and propagate the
-			// effective lock deadline to the forwarded RPC.
+			// effective safety deadline to the forwarded RPC. Establish this
+			// uncontended holder separately from the one-second budget asserted by
+			// the waiter below: each Lock call owns an independent wait budget.
 			_, err = origin.Lock(context.Background(), tableID, [][]byte{{1}}, holderTxn, options)
 			require.NoError(t, err)
 
+			options.LockWaitTimeout = 1
 			start := time.Now()
 			_, err = origin.Lock(context.Background(), tableID, [][]byte{{1}}, waiterTxn, options)
 			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockWaitTimeout), "unexpected error: %v", err)


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Test and CI

## Which issue(s) this PR fixes:

Related to #27810

## What this PR does / why we need it:

The race failure was a test-fixture timing error, not a lockservice production failure. The test used LockWaitTimeout = 1 for both the uncontended forwarded holder setup and the blocked waiter assertion. Each Lock call receives an independent end-to-end effective deadline, so scheduling, binding, forwarding, and owner admission can legitimately exhaust the holder setup request before the test reaches the waiter assertion.

This change leaves the holder request on the existing service safety deadline, preserving the background-context deadline-injection coverage. It applies the one-second lock wait timeout only to the subsequent conflicting waiter, which is the operation whose ErrLockWaitTimeout behavior and timing the test asserts. No production code or protocol behavior changes.

Issue-to-test proof:

- #27810: TestForwardLockUsesEffectiveLockDeadline now proves an uncontended forwarded holder succeeds independently of the waiter budget, then proves the forwarded waiter returns ErrLockWaitTimeout after its one-second effective deadline.

Tests run:

- Before rebase: pkg/lockservice, normal mode (105.036s) and race mode (110.050s).
- Rebased onto main at 67ac89c058: TestForwardLockUsesEffectiveLockDeadline, normal mode.
- Rebased onto main at 67ac89c058: TestForwardLockUsesEffectiveLockDeadline, race mode (test body 1.27s; command exit status 0).
- Rebased onto main at 67ac89c058: TestForwardLockUsesEffectiveLockDeadline, race mode, count=23 (29.508s; exit status 0).
- Rebased onto main at 4cbdc2cf46: TestForwardLockUsesEffectiveLockDeadline, normal and race modes.
- Rebased onto main at 2e1be09278: TestForwardLockUsesEffectiveLockDeadline, normal mode (1.13s) and race mode (1.14s).
- Rebased onto main at 52336df805: TestForwardLockUsesEffectiveLockDeadline, normal mode (1.16s) and race mode (1.99s).
- Rebased onto main at 0d7f4dd69a: TestForwardLockUsesEffectiveLockDeadline, normal mode (1.13s) and race mode (1.15s).
- Rebased onto main at 117714dd98: TestForwardLockUsesEffectiveLockDeadline, normal mode (test body 1.14s; package 1.439s) and race mode (test body 1.18s; package 2.986s).

BVT is not applicable: this is an internal lockservice forwarding fixture and does not change SQL-visible behavior.

Residual risk:

- Validation ran on macOS arm64 with the repository CGo test wrapper; Ubuntu x86 CI remains the cross-platform confirmation. The changed assertion no longer charges holder setup against the waiter-specific one-second budget.
