### PR TITLE
test(logservice): bound refill admission regression

### DIFF
--- a/pkg/logservice/hakeeper_client_test.go
+++ b/pkg/logservice/hakeeper_client_test.go
@@ -2080,13 +2080,38 @@ func TestAllocateIDByKeyBurstSharesRefills(t *testing.T) {
 	require.Equal(t, int64(10), sendCalls.Load())
 }
 
+// contextDoneObserver makes the waiter's refill-wait admission observable
+// without adding a production-side synchronization hook.
+type contextDoneObserver struct {
+	context.Context
+	observed chan<- struct{}
+	once     sync.Once
+}
+
+func (c *contextDoneObserver) Done() <-chan struct{} {
+	c.once.Do(func() {
+		close(c.observed)
+	})
+	return c.Context.Done()
+}
+
 func TestAllocateIDByKeyWaiterRetriesAfterRefillFailure(t *testing.T) {
+	const phaseTimeout = time.Second
+
 	originalSend := sendCNAllocateIDFunc
 	defer func() {
 		sendCNAllocateIDFunc = originalSend
 	}()
 
 	firstRefillStarted := make(chan struct{})
+	firstRefillFailure := make(chan struct{})
+	var releaseFirstRefill sync.Once
+	releaseRefill := func() {
+		releaseFirstRefill.Do(func() {
+			close(firstRefillFailure)
+		})
+	}
+	defer releaseRefill()
 	var sendCalls atomic.Int64
 	sendCNAllocateIDFunc = func(
 		_ *hakeeperClient,
@@ -2096,8 +2121,13 @@ func TestAllocateIDByKeyWaiterRetriesAfterRefillFailure(t *testing.T) {
 	) (uint64, error) {
 		if sendCalls.Add(1) == 1 {
 			close(firstRefillStarted)
-			<-ctx.Done()
-			return 0, ctx.Err()
+			// Keep failure behind an explicit gate so context expiry cannot race
+			// the waiter's admission.
+			select {
+			case <-firstRefillFailure:
+			case <-ctx.Done():
+			}
+			return 0, context.DeadlineExceeded
 		}
 		return 200, nil
 	}
@@ -2107,21 +2137,62 @@ func TestAllocateIDByKeyWaiterRetriesAfterRefillFailure(t *testing.T) {
 	}
 	client := &hakeeperClient{}
 	c.mu.client = client
-	leaderCtx, cancelLeader := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	leaderCtx, cancelLeader := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelLeader()
 	leaderDone := make(chan error, 1)
 	go func() {
 		_, err := c.AllocateIDByKeyWithBatch(leaderCtx, "connection", 2)
 		leaderDone <- err
 	}()
-	<-firstRefillStarted
+	select {
+	case <-firstRefillStarted:
+	case err := <-leaderDone:
+		t.Fatalf("leader failed before first refill admission: %v", err)
+	case <-time.After(phaseTimeout):
+		t.Fatal("leader did not reach first refill admission")
+	}
 
-	waiterCtx, cancelWaiter := context.WithTimeout(context.Background(), time.Second)
+	waiterCtx, cancelWaiter := context.WithTimeout(context.Background(), phaseTimeout)
 	defer cancelWaiter()
-	waiterID, waiterErr := c.AllocateIDByKeyWithBatch(waiterCtx, "connection", 2)
-	require.NoError(t, waiterErr)
-	require.Equal(t, uint64(200), waiterID)
-	require.ErrorIs(t, <-leaderDone, context.DeadlineExceeded)
+	waiterWaiting := make(chan struct{})
+	waiterCtx = &contextDoneObserver{
+		Context:  waiterCtx,
+		observed: waiterWaiting,
+	}
+	waiterDone := make(chan struct {
+		id  uint64
+		err error
+	}, 1)
+	go func() {
+		id, err := c.AllocateIDByKeyWithBatch(waiterCtx, "connection", 2)
+		waiterDone <- struct {
+			id  uint64
+			err error
+		}{id: id, err: err}
+	}()
+	select {
+	case <-waiterWaiting:
+	case <-time.After(phaseTimeout):
+		t.Fatal("waiter did not reach the refill wait")
+	}
+	releaseRefill()
+	var waiterResult struct {
+		id  uint64
+		err error
+	}
+	select {
+	case waiterResult = <-waiterDone:
+	case <-time.After(phaseTimeout):
+		t.Fatal("waiter did not retry after refill failure")
+	}
+	require.NoError(t, waiterResult.err)
+	require.Equal(t, uint64(200), waiterResult.id)
+	select {
+	case err := <-leaderDone:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(phaseTimeout):
+		t.Fatal("leader did not finish after refill failure")
+	}
 	require.Equal(t, int64(2), sendCalls.Load())
 	require.Same(t, client, c.mu.client)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27818

## What this PR does / why we need it:

`TestAllocateIDByKeyWaiterRetriesAfterRefillFailure` used a 20 ms leader context both to start the first refill and to inject the refill failure. Under CI scheduling pressure, the leader could start after that context expired. `allocateID` returns from its early context check before calling `sendCNAllocateIDFunc`, so `firstRefillStarted` was never closed. The test then waited on an unbounded receive until the package-level 10-minute timeout.

This PR keeps the production implementation unchanged and makes the regression deterministic and bounded:

- gives the leader a long-lived deadline only to satisfy the client context contract;
- gates the first refill failure explicitly after the leader has entered the mock;
- observes the waiter reaching the same-key refill wait through a test-only context wrapper before releasing the failure;
- bounds leader admission, waiter retry, and leader completion with diagnostic one-second guards; and
- retains the existing takeover assertions: the waiter receives ID 200, the leader reports `context.DeadlineExceeded`, exactly two allocation sends occur, and the shared client is reused.

The first-refill release is one-shot and deferred for failure cleanup. The context wrapper is test-only; no production synchronization hook, API, wire format, or allocation behavior changes.

## Issue-to-test proof

| Issue | Test proof |
| --- | --- |
| #27818 | `TestAllocateIDByKeyWaiterRetriesAfterRefillFailure` now observes first-refill admission with a bounded select, observes the waiter in the refill wait, injects the first refill failure deterministically, and asserts successful waiter takeover, error propagation, exact send count, and client reuse. |

BVT is not applicable: the issue is an internal `pkg/logservice` test-fixture liveness failure in `managedHAKeeperClient` allocation coordination, not a SQL or public protocol contract.

## Validation

- `make NATIVE_BUILD_JOBS=8 cgo` — passed on macOS arm64 to provide the repository CGo test prerequisites.
- Baseline before the change: `.agents/skills/mo-dev/scripts/mo-cgo-test -list '^TestAllocateIDByKeyWaiterRetriesAfterRefillFailure$' ./pkg/logservice` selected the target; the original focused test passed under normal local scheduling. The CI reproduction and source control-flow analysis establish the delayed-start failure.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -short -v -count=1 -timeout=30s -run '^TestAllocateIDByKeyWaiterRetriesAfterRefillFailure$' ./pkg/logservice` — passed after the final rebase.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -json -count=1 -timeout=120s -run '^TestAllocateIDByKeyWaiterRetriesAfterRefillFailure$' ./pkg/logservice` — passed; the selected test completed with a terminal pass event.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=120s -run '^TestAllocateIDByKeyWaiterRetriesAfterRefillFailure$' ./pkg/logservice` — passed.
- Direct allocation regression group covering expired-context rejection, waiter cancellation, independent-key progress, burst sharing, refill takeover, batch consumption, cross-client uniqueness, and zero-batch rejection — selection and normal execution passed.
- `GOWORK=off CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib" go vet -mod=readonly ./pkg/logservice` — passed.

The full `pkg/logservice` normal run also reported `TestHAKeeperCanBootstrapAndRepairShards` and `TestRestoreIDWatermarksFromNonLeader` failures. Both had the same timeout/assertion signatures on a clean `origin/main` baseline (`117714dd98`) and are outside this one-file test change; they are not attributed to this PR.

## Risk

The change is test-only. It removes dependence on a scheduler-sensitive 20 ms admission window and converts the former unbounded admission wait into a short diagnostic failure. The explicit release gate and deferred cleanup keep the leader and waiter goroutines terminable on both success and assertion failure. No residual production behavior risk is expected; the two unrelated owning-package baseline failures remain environment/test-suite residuals.
