### PR TITLE
ci: return UT to single runner

### DIFF
--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -75,10 +75,7 @@ jobs:
     if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/ci.yaml@main
     with:
-      # Leave one runner CPU for race-detector/native work inside a package.
-      # Eight package slots made CPU-heavy HNSW tests the light-stage straggler.
-      ut_parallel: 7
-      ut_sharded: true
+      ut_parallel: 8
     secrets: inherit
 
   matrixone-ut-coverage:


### PR DESCRIPTION
## What changed

Disable the opt-in four-way race-UT matrix introduced by #27815 and restore the MatrixOne workflow caller to its previous single-runner configuration:

- remove `ut_sharded: true`;
- restore `ut_parallel: 8` in the caller.

## Resulting CI behavior

CI #438 remains backward compatible and defaults `ut_sharded` to `false`. Therefore this caller now expands to exactly one `all` matrix entry:

- one `UT Test on Ubuntu/x86` runner executes the complete race suite;
- `UT_SHARD=all` retains every light, HNSW, issues, embedded, heavy, engine, and plan stage;
- the shard summary job is skipped before runner allocation;
- the established required-check name remains unchanged.

This intentionally does not fully revert #27815. Its runner-local improvements remain: deterministic HNSW coverage with less duplicate work, global-mock restoration, temporary-file cleanup, package partition validation, and safer package grouping. Only the resource-expensive four-runner activation is rolled back.

CI #438 does not need to be reverted: it is opt-in, defaults to the old one-runner behavior, and its immutable-head checkout and fail-closed sharding support are harmless while disabled.

## Validation

- the MatrixOne entrypoint is byte-for-byte identical to the parent of #27815;
- YAML syntax parse: pass;
- `git diff --check`: pass;
- final delivery diff: one workflow file, 1 insertion and 4 deletions.