### PR TITLE
test(fileservice): release disk cache read vector

### DIFF
--- a/pkg/fileservice/disk_cache_lifecycle_test.go
+++ b/pkg/fileservice/disk_cache_lifecycle_test.go
@@ -504,6 +504,7 @@ func TestDiskCacheCurrentReaderReindexesUntrackedPath(t *testing.T) {
 		FilePath: "foo",
 		Entries:  []IOEntry{{Offset: 1, Size: 1}},
 	}
+	defer vector.Release()
 	require.NoError(t, cache.Read(ctx, vector))
 	require.True(t, vector.Entries[0].done)
 	require.Equal(t, []byte("b"), vector.Entries[0].Data)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27829

## What this PR does / why we need it:

### Root cause

`DiskCache.Read` successfully reads data into an allocator-backed `IOVector` entry. `IOEntry.prepareData` retains the allocated buffer after a successful read for the caller to own and release; the read path's deferred cleanup only handles errors. `DiskCache.Read` does not own or release the caller's vector. `TestDiskCacheCurrentReaderReindexesUntrackedPath` asserted the read and reindex behavior but never released its vector, so checked-allocator finalization later reported `missing free` in a subsequent test.

### Changes

- Register `defer vector.Release()` immediately after constructing the vector in `TestDiskCacheCurrentReaderReindexesUntrackedPath`.
- Keep the existing read, reindex, file-presence, and generation-cleanup assertions unchanged.
- No production code, allocator behavior, or public/database behavior changes.

The cleanup is registered before the read, so it also runs when the read fails or an assertion aborts the test.

### Issue-to-test proof

- Before the change, the exact coverage-style command with `MO_MALLOC_DEBUG=1`, running `TestDiskCacheCurrentReaderReindexesUntrackedPath` followed by `TestDiskCacheAsyncSetFileFinalizeErrorIsFailOpenAndObservable`, reproduced the checked-allocator `missing free` panic from `IOEntry.prepareData`.
- After the change, the same command passed for 20 repetitions, including the target test and the immediately following test.
- The target test remains the focused regression case: it reads through the current disk-cache reader, verifies reindexing of the untracked path, and now proves deterministic release of the returned allocator-backed data.
- BVT is not applicable because this is an internal Go resource-lifecycle defect with no SQL, protocol, or user-visible syntax behavior.

### Tests run

The focused validation listed below was rerun after rebasing onto `origin/main` at `1a4f656bb2b5b7f2fb1a6d951c4806ce7d124ba5`; the current PR head is `17dd11d411`, the PR diff remains one line, and the rebase had no conflicts.

Passed:

- `MO_MALLOC_DEBUG=1 .agents/skills/mo-dev/scripts/mo-cgo-test -vet=off -short -tags matrixone_test -covermode=set -count=20 -timeout=120s -run '^(TestDiskCacheCurrentReaderReindexesUntrackedPath|TestDiskCacheAsyncSetFileFinalizeErrorIsFailOpenAndObservable)$' ./pkg/fileservice`
- `... -race -count=100 -timeout=240s -run '^TestDiskCacheCurrentReaderReindexesUntrackedPath$' ./pkg/fileservice`
- `... -short -tags matrixone_test -count=1 -timeout=600s -json -run '^(TestDiskCache|TestIOEntry)' ./pkg/fileservice`
- `go vet -mod=readonly -tags matrixone_test ./pkg/fileservice`
- `gofmt -d pkg/fileservice/disk_cache_lifecycle_test.go`
- `git diff --check`

The exact target selection was also verified with `-list`, and the post-rebase target passed with the repository coverage flags.

The full `./pkg/fileservice` package run was attempted. Its only failure was `TestMinioSDK/file_service/basic`, which returned `Access Denied.` from the local MinIO test service; the changed test and the focused DiskCache/IOEntry suite passed. This environment-specific service failure is unrelated to the vector cleanup.

### Residual risks

The change is test-only and has no production execution or compatibility risk. The remaining validation limitation is the local MinIO authentication failure described above; the checked-allocator reproduction, focused coverage-style sequence, and race stress are green.
