### PR TITLE
fix(pitr): reject unsafe recovery range expansion

### DIFF
--- a/pkg/frontend/databranchutils/branch_dag_test.go
+++ b/pkg/frontend/databranchutils/branch_dag_test.go
@@ -533,6 +533,74 @@ func TestPitrRetentionLowerBound(t *testing.T) {
 
 	_, err := PitrRetentionLowerBound(now, 1, "week")
 	require.Error(t, err)
+	_, err = PitrRetentionLowerBound(now, 0, "h")
+	require.Error(t, err)
+	_, err = PitrRetentionLowerBound(now, 101, "h")
+	require.Error(t, err)
+
+	monthEnd := time.Date(2025, time.March, 31, 12, 0, 0, 0, time.UTC)
+	got, err := PitrRetentionLowerBound(monthEnd, 1, "mo")
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2025, time.February, 28, 12, 0, 0, 0, time.UTC).UnixNano(), got)
+
+	leapDay := time.Date(2024, time.February, 29, 12, 0, 0, 0, time.UTC)
+	got, err = PitrRetentionLowerBound(leapDay, 1, "y")
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2023, time.February, 28, 12, 0, 0, 0, time.UTC).UnixNano(), got)
+}
+
+func TestPitrRetentionRangeDoesNotExpand(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		currentLength int
+		currentUnit   string
+		nextLength    int
+		nextUnit      string
+		want          bool
+	}{
+		{name: "same unit equal", currentLength: 2, currentUnit: "h", nextLength: 2, nextUnit: "h", want: true},
+		{name: "same unit shrink", currentLength: 2, currentUnit: "h", nextLength: 1, nextUnit: "h", want: true},
+		{name: "same unit expand", currentLength: 1, currentUnit: "h", nextLength: 2, nextUnit: "h", want: false},
+		{name: "fixed units equal", currentLength: 1, currentUnit: "d", nextLength: 24, nextUnit: "h", want: true},
+		{name: "fixed units expand", currentLength: 23, currentUnit: "h", nextLength: 1, nextUnit: "d", want: false},
+		{name: "calendar units equal", currentLength: 1, currentUnit: "y", nextLength: 12, nextUnit: "mo", want: true},
+		{name: "calendar units shrink", currentLength: 13, currentUnit: "mo", nextLength: 1, nextUnit: "y", want: true},
+		{name: "calendar units expand", currentLength: 11, currentUnit: "mo", nextLength: 1, nextUnit: "y", want: false},
+		{name: "calendar to fixed always shrinks", currentLength: 1, currentUnit: "mo", nextLength: 28, nextUnit: "d", want: true},
+		{name: "calendar to fixed can expand in February", currentLength: 1, currentUnit: "mo", nextLength: 29, nextUnit: "d", want: false},
+		{name: "fixed to calendar can expand in leap year", currentLength: 100, currentUnit: "d", nextLength: 1, nextUnit: "y", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PitrRetentionRangeDoesNotExpand(
+				tc.currentLength,
+				tc.currentUnit,
+				tc.nextLength,
+				tc.nextUnit,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	for _, tc := range []struct {
+		currentLength int
+		currentUnit   string
+		nextLength    int
+		nextUnit      string
+	}{
+		{currentLength: 0, currentUnit: "h", nextLength: 1, nextUnit: "h"},
+		{currentLength: 1, currentUnit: "week", nextLength: 1, nextUnit: "h"},
+		{currentLength: 1, currentUnit: "h", nextLength: 101, nextUnit: "h"},
+		{currentLength: 1, currentUnit: "h", nextLength: 1, nextUnit: "week"},
+	} {
+		_, err := PitrRetentionRangeDoesNotExpand(
+			tc.currentLength,
+			tc.currentUnit,
+			tc.nextLength,
+			tc.nextUnit,
+		)
+		require.Error(t, err)
+	}
 }
 
 func TestBuildAlterLineageDeleteSQL(t *testing.T) {

--- a/pkg/frontend/databranchutils/branch_dag_test.go
+++ b/pkg/frontend/databranchutils/branch_dag_test.go
@@ -538,13 +538,31 @@ func TestPitrRetentionLowerBound(t *testing.T) {
 	_, err = PitrRetentionLowerBound(now, 101, "h")
 	require.Error(t, err)
 
-	monthEnd := time.Date(2025, time.March, 31, 12, 0, 0, 0, time.UTC)
-	got, err := PitrRetentionLowerBound(monthEnd, 1, "mo")
-	require.NoError(t, err)
-	require.Equal(t, time.Date(2025, time.February, 28, 12, 0, 0, 0, time.UTC).UnixNano(), got)
+	for _, tc := range []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "May 31 clamps to April 30",
+			now:  time.Date(2025, time.May, 31, 12, 0, 0, 123456789, time.UTC),
+			want: time.Date(2025, time.April, 30, 12, 0, 0, 123456789, time.UTC),
+		},
+		{
+			name: "March 31 clamps to February 28",
+			now:  time.Date(2025, time.March, 31, 12, 0, 0, 0, time.UTC),
+			want: time.Date(2025, time.February, 28, 12, 0, 0, 0, time.UTC),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PitrRetentionLowerBound(tc.now, 1, "mo")
+			require.NoError(t, err)
+			require.Equal(t, tc.want.UnixNano(), got)
+		})
+	}
 
 	leapDay := time.Date(2024, time.February, 29, 12, 0, 0, 0, time.UTC)
-	got, err = PitrRetentionLowerBound(leapDay, 1, "y")
+	got, err := PitrRetentionLowerBound(leapDay, 1, "y")
 	require.NoError(t, err)
 	require.Equal(t, time.Date(2023, time.February, 28, 12, 0, 0, 0, time.UTC).UnixNano(), got)
 }

--- a/pkg/frontend/databranchutils/branch_dag_test.go
+++ b/pkg/frontend/databranchutils/branch_dag_test.go
@@ -621,6 +621,114 @@ func TestPitrRetentionRangeDoesNotExpand(t *testing.T) {
 	}
 }
 
+func TestMergePitrRetentionRanges(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		currentLength int
+		currentUnit   string
+		nextLength    int
+		nextUnit      string
+		wantLength    int
+		wantUnit      string
+	}{
+		{name: "preserve wider fixed range", currentLength: 2, currentUnit: "d", nextLength: 24, nextUnit: "h", wantLength: 2, wantUnit: "d"},
+		{name: "adopt wider calendar range", currentLength: 28, currentUnit: "d", nextLength: 1, nextUnit: "mo", wantLength: 1, wantUnit: "mo"},
+		{name: "month and thirty days need envelope", currentLength: 1, currentUnit: "mo", nextLength: 30, nextUnit: "d", wantLength: 31, wantUnit: "d"},
+		{name: "two months and sixty days need envelope", currentLength: 2, currentUnit: "mo", nextLength: 60, nextUnit: "d", wantLength: 62, wantUnit: "d"},
+		{name: "three months and ninety days need envelope", currentLength: 3, currentUnit: "mo", nextLength: 90, nextUnit: "d", wantLength: 93, wantUnit: "d"},
+		{name: "fixed range covers calendar maximum", currentLength: 100, currentUnit: "d", nextLength: 3, nextUnit: "mo", wantLength: 100, wantUnit: "d"},
+		{name: "year covers maximum fixed range", currentLength: 100, currentUnit: "d", nextLength: 1, nextUnit: "y", wantLength: 1, wantUnit: "y"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLength, gotUnit, err := MergePitrRetentionRanges(
+				tc.currentLength,
+				tc.currentUnit,
+				tc.nextLength,
+				tc.nextUnit,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantLength, gotLength)
+			require.Equal(t, tc.wantUnit, gotUnit)
+		})
+	}
+
+	_, _, err := MergePitrRetentionRanges(0, "d", 1, "d")
+	require.Error(t, err)
+	_, _, err = MergePitrRetentionRanges(1, "d", 1, "week")
+	require.Error(t, err)
+}
+
+func TestMergePitrRetentionRangesAlwaysCoversInputs(t *testing.T) {
+	units := []string{"h", "d", "mo", "y"}
+	for _, currentUnit := range units {
+		for currentLength := 1; currentLength <= 100; currentLength++ {
+			for _, nextUnit := range units {
+				for nextLength := 1; nextLength <= 100; nextLength++ {
+					mergedLength, mergedUnit, err := MergePitrRetentionRanges(
+						currentLength,
+						currentUnit,
+						nextLength,
+						nextUnit,
+					)
+					require.NoError(t, err)
+					require.GreaterOrEqual(t, mergedLength, 1)
+					require.LessOrEqual(t, mergedLength, 100)
+
+					coversCurrent, err := PitrRetentionRangeDoesNotExpand(
+						mergedLength,
+						mergedUnit,
+						currentLength,
+						currentUnit,
+					)
+					require.NoError(t, err)
+					coversNext, err := PitrRetentionRangeDoesNotExpand(
+						mergedLength,
+						mergedUnit,
+						nextLength,
+						nextUnit,
+					)
+					require.NoError(t, err)
+					if !coversCurrent || !coversNext {
+						t.Fatalf(
+							"merged %d%s does not cover %d%s and %d%s",
+							mergedLength,
+							mergedUnit,
+							currentLength,
+							currentUnit,
+							nextLength,
+							nextUnit,
+						)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestMergePitrRetentionRangesCoversMonthEndPivots(t *testing.T) {
+	mergedLength, mergedUnit, err := MergePitrRetentionRanges(1, "mo", 30, "d")
+	require.NoError(t, err)
+	require.Equal(t, 31, mergedLength)
+	require.Equal(t, "d", mergedUnit)
+
+	for _, pivot := range []time.Time{
+		time.Date(2024, time.February, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2025, time.January, 31, 12, 0, 0, 0, time.UTC),
+		time.Date(2025, time.March, 28, 12, 0, 0, 0, time.UTC),
+		time.Date(2025, time.March, 31, 12, 0, 0, 0, time.UTC),
+		time.Date(2025, time.April, 30, 12, 0, 0, 0, time.UTC),
+	} {
+		mergedLower, err := PitrRetentionLowerBound(pivot, mergedLength, mergedUnit)
+		require.NoError(t, err)
+		monthLower, err := PitrRetentionLowerBound(pivot, 1, "mo")
+		require.NoError(t, err)
+		daysLower, err := PitrRetentionLowerBound(pivot, 30, "d")
+		require.NoError(t, err)
+		require.LessOrEqual(t, mergedLower, monthLower)
+		require.LessOrEqual(t, mergedLower, daysLower)
+	}
+}
+
 func TestBuildAlterLineageDeleteSQL(t *testing.T) {
 	require.Equal(t,
 		"delete from mo_catalog.mo_snapshots where kind = 'branch' and sname in ('__mo_branch_2','__mo_branch_3')",

--- a/pkg/frontend/databranchutils/branch_protect_snapshot.go
+++ b/pkg/frontend/databranchutils/branch_protect_snapshot.go
@@ -206,18 +206,64 @@ func PitrRetentionRangeDoesNotExpand(
 	if err != nil {
 		return false, err
 	}
+	return pitrRetentionRangeDoesNotExpand(current, next), nil
+}
 
+// MergePitrRetentionRanges returns one persistable PITR range that covers both
+// inputs for every statement time. This is used by sys_mo_catalog_pitr, whose
+// range must remain an upper bound for all user PITRs as month lengths change.
+//
+// If neither input permanently covers the other (for example, one month and
+// thirty days), the result is their fixed-day upper envelope. With PITR lengths
+// limited to 100, an incomparable calendar range is at most three months, so
+// the envelope is always representable as at most 100 days.
+func MergePitrRetentionRanges(
+	currentLength int,
+	currentUnit string,
+	nextLength int,
+	nextUnit string,
+) (int, string, error) {
+	current, err := newPitrDuration(currentLength, currentUnit)
+	if err != nil {
+		return 0, "", err
+	}
+	next, err := newPitrDuration(nextLength, nextUnit)
+	if err != nil {
+		return 0, "", err
+	}
+
+	if pitrRetentionRangeDoesNotExpand(current, next) {
+		return currentLength, currentUnit, nil
+	}
+	if pitrRetentionRangeDoesNotExpand(next, current) {
+		return nextLength, nextUnit, nil
+	}
+
+	maxHours := current.maxHours
+	if next.maxHours > maxHours {
+		maxHours = next.maxHours
+	}
+	days := (maxHours + 24 - 1) / 24
+	if days > 100 {
+		return 0, "", moerr.NewInternalErrorNoCtxf(
+			"cannot represent merged PITR retention range %dh", maxHours,
+		)
+	}
+	return days, "d", nil
+}
+
+func pitrRetentionRangeDoesNotExpand(current, next pitrDuration) bool {
 	// Hours and days are fixed durations in UTC. Months and years share the
 	// same clamped calendar semantics, so twelve months exactly equal one year.
 	if current.kind == next.kind {
-		return next.normalized <= current.normalized, nil
+		return next.normalized <= current.normalized
 	}
 
 	// Across fixed and calendar units, require the longest possible next
 	// duration to fit inside the shortest possible current duration. The
 	// conservative bound makes the decision independent of month ends, leap
 	// years, and an unbounded delay before every GC consumer observes ALTER.
-	return next.maxHours <= current.minHours, nil
+	return next.maxHours <= current.minHours
 }
 
 type pitrDuration struct {

--- a/pkg/frontend/databranchutils/branch_protect_snapshot.go
+++ b/pkg/frontend/databranchutils/branch_protect_snapshot.go
@@ -168,7 +168,7 @@ func NewBranchReclaimDag(rows []DataBranchMetadata) BranchReclaimDag {
 // the supplied statement time. It never reads the wall clock itself, keeping
 // frontend and compile-layer decisions on the same boundary.
 func PitrRetentionLowerBound(now time.Time, length int, unit string) (int64, error) {
-	if length < 0 {
+	if length <= 0 || length > 100 {
 		return 0, moerr.NewInvalidInputNoCtxf("invalid PITR length %d", length)
 	}
 	now = now.UTC()
@@ -179,13 +179,104 @@ func PitrRetentionLowerBound(now time.Time, length int, unit string) (int64, err
 	case "d":
 		lower = now.AddDate(0, 0, -length)
 	case "mo":
-		lower = now.AddDate(0, -length, 0)
+		lower = addDateClamped(now, 0, -length)
 	case "y":
-		lower = now.AddDate(-length, 0, 0)
+		lower = addDateClamped(now, -length, 0)
 	default:
 		return 0, moerr.NewInvalidInputNoCtxf("unknown PITR unit %q", unit)
 	}
 	return lower.UnixNano(), nil
+}
+
+// PitrRetentionRangeDoesNotExpand reports whether replacing one PITR range
+// with another can never ask GC to retain older history. A point-in-time
+// comparison is insufficient for mixed fixed and calendar units: for example,
+// one month can be shorter than 30 days in February and longer in March.
+func PitrRetentionRangeDoesNotExpand(
+	currentLength int,
+	currentUnit string,
+	nextLength int,
+	nextUnit string,
+) (bool, error) {
+	current, err := newPitrDuration(currentLength, currentUnit)
+	if err != nil {
+		return false, err
+	}
+	next, err := newPitrDuration(nextLength, nextUnit)
+	if err != nil {
+		return false, err
+	}
+
+	// Hours and days are fixed durations in UTC. Months and years share the
+	// same clamped calendar semantics, so twelve months exactly equal one year.
+	if current.kind == next.kind {
+		return next.normalized <= current.normalized, nil
+	}
+
+	// Across fixed and calendar units, require the longest possible next
+	// duration to fit inside the shortest possible current duration. The
+	// conservative bound makes the decision independent of month ends, leap
+	// years, and an unbounded delay before every GC consumer observes ALTER.
+	return next.maxHours <= current.minHours, nil
+}
+
+type pitrDuration struct {
+	kind       byte
+	normalized int
+	minHours   int
+	maxHours   int
+}
+
+func newPitrDuration(length int, unit string) (pitrDuration, error) {
+	if length <= 0 || length > 100 {
+		return pitrDuration{}, moerr.NewInvalidInputNoCtxf("invalid PITR length %d", length)
+	}
+
+	switch unit {
+	case "h":
+		return pitrDuration{kind: 'f', normalized: length, minHours: length, maxHours: length}, nil
+	case "d":
+		hours := length * 24
+		return pitrDuration{kind: 'f', normalized: hours, minHours: hours, maxHours: hours}, nil
+	case "mo":
+		return pitrDuration{
+			kind:       'c',
+			normalized: length,
+			minHours:   length * 28 * 24,
+			maxHours:   length * 31 * 24,
+		}, nil
+	case "y":
+		return pitrDuration{
+			kind:       'c',
+			normalized: length * 12,
+			minHours:   length * 365 * 24,
+			maxHours:   length * 366 * 24,
+		}, nil
+	default:
+		return pitrDuration{}, moerr.NewInvalidInputNoCtxf("unknown PITR unit %q", unit)
+	}
+}
+
+// addDateClamped applies a calendar offset while clamping the day to the last
+// valid day in the target month. time.Time.AddDate normalizes February 31 into
+// March, which can move a rolling retention boundary backwards at month end.
+func addDateClamped(t time.Time, years int, months int) time.Time {
+	targetMonth := time.Date(
+		t.Year()+years,
+		t.Month()+time.Month(months),
+		1,
+		t.Hour(),
+		t.Minute(),
+		t.Second(),
+		t.Nanosecond(),
+		t.Location(),
+	)
+	lastDay := targetMonth.AddDate(0, 1, -1).Day()
+	day := t.Day()
+	if day > lastDay {
+		day = lastDay
+	}
+	return targetMonth.AddDate(0, 0, day-1)
 }
 
 func historicalSourceOwnsComponent(

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/sqlquote"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/frontend/databranchutils"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
@@ -78,19 +79,22 @@ var (
 )
 
 type pitrRecord struct {
-	pitrId        string
-	pitrName      string
-	createAccount uint64
-	createTime    int64
-	modifiedTime  int64
-	level         string
-	accountId     uint64
-	accountName   string
-	databaseName  string
-	tableName     string
-	objId         uint64
-	pitrValue     uint64
-	pitrUnit      string
+	pitrId            string
+	pitrName          string
+	createAccount     uint64
+	createTime        int64
+	modifiedTime      int64
+	level             string
+	accountId         uint64
+	accountName       string
+	databaseName      string
+	tableName         string
+	objId             uint64
+	pitrValue         uint64
+	pitrUnit          string
+	pitrStatus        uint8
+	statusChangedTime int64
+	hasStatus         bool
 }
 
 const (
@@ -865,7 +869,7 @@ func doAlterPitr(ctx context.Context, ses *Session, stmt *tree.AlterPitr) (err e
 	}
 
 	// check pitr value
-	if stmt.PitrValue < 0 || stmt.PitrValue > 100 {
+	if stmt.PitrValue <= 0 || stmt.PitrValue > 100 {
 		return moerr.NewInternalErrorf(ctx, "invalid pitr value %d", stmt.PitrValue)
 	}
 
@@ -902,8 +906,42 @@ func doAlterPitr(ctx context.Context, ses *Session, stmt *tree.AlterPitr) (err e
 			return err
 		}
 	} else {
+		currentPitr, getErr := getPitrByName(
+			ctx,
+			bh,
+			string(stmt.Name),
+			uint64(tenantInfo.GetTenantID()),
+		)
+		if getErr != nil {
+			return getErr
+		}
+		if currentPitr.hasStatus && currentPitr.pitrStatus != 1 {
+			return moerr.NewNotSupportedf(ctx, "cannot alter inactive pitr %s", stmt.Name)
+		}
+		doesNotExpand, rangeErr := databranchutils.PitrRetentionRangeDoesNotExpand(
+			int(currentPitr.pitrValue),
+			currentPitr.pitrUnit,
+			int(stmt.PitrValue),
+			pitrUnit,
+		)
+		if rangeErr != nil {
+			return rangeErr
+		}
+		if !doesNotExpand {
+			return moerr.NewNotSupportedf(
+				ctx,
+				"cannot expand PITR %s recovery range from %d %s to %d %s; create a new PITR instead",
+				string(stmt.Name),
+				currentPitr.pitrValue,
+				currentPitr.pitrUnit,
+				stmt.PitrValue,
+				pitrUnit,
+			)
+		}
+
+		alterTime := time.Now().UTC()
 		sql = getSqlForAlterPitr(
-			time.Now().UTC().UnixNano(),
+			alterTime.UnixNano(),
 			uint8(stmt.PitrValue),
 			pitrUnit,
 			string(stmt.Name),
@@ -920,7 +958,7 @@ func doAlterPitr(ctx context.Context, ses *Session, stmt *tree.AlterPitr) (err e
 		if err != nil {
 			return err
 		}
-		if err = compactHistoricalAlterLineageWithBH(ctx, bh, time.Now().UTC()); err != nil {
+		if err = compactHistoricalAlterLineageWithBH(ctx, bh, alterTime); err != nil {
 			return err
 		}
 	}
@@ -2035,6 +2073,23 @@ func getPitrRecords(ctx context.Context, bh BackgroundExec, sql string) ([]*pitr
 				if record.pitrUnit, err = er.GetString(ctx, row, 12); err != nil {
 					return nil, err
 				}
+				// pitr_status and pitr_status_changed_time were appended to the
+				// legacy 13-column schema. Keep old catalog rows readable during
+				// rolling upgrades, but reject malformed status values when present.
+				if er.GetColumnCount() > 14 {
+					status, statusErr := er.GetUint64(ctx, row, 13)
+					if statusErr != nil {
+						return nil, statusErr
+					}
+					if status > math.MaxUint8 {
+						return nil, moerr.NewInvalidInputf(ctx, "invalid PITR status %d", status)
+					}
+					record.pitrStatus = uint8(status)
+					if record.statusChangedTime, err = er.GetInt64(ctx, row, 14); err != nil {
+						return nil, err
+					}
+					record.hasStatus = true
+				}
 			}
 			records = append(records, &record)
 		}
@@ -2134,18 +2189,11 @@ func addTimeSpan(pivot time.Time, length int, unit string) (time.Time, error) {
 		now = time.Now().UTC()
 	}
 
-	switch unit {
-	case "h":
-		return now.Add(time.Duration(-length) * time.Hour), nil
-	case "d":
-		return now.AddDate(0, 0, -length), nil
-	case "mo":
-		return now.AddDate(0, -length, 0), nil
-	case "y":
-		return now.AddDate(-length, 0, 0), nil
-	default:
-		return time.Time{}, moerr.NewInternalErrorNoCtxf("unknown unit '%s'", unit)
+	lower, err := databranchutils.PitrRetentionLowerBound(now, length, unit)
+	if err != nil {
+		return time.Time{}, err
 	}
+	return time.Unix(0, lower).UTC(), nil
 }
 
 func checkPitrValidOrNot(pitrRecord *pitrRecord, stmt *tree.RestorePitr, tenantInfo *TenantInfo) (err error) {

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -659,9 +659,8 @@ func doCreatePitr(ctx context.Context, ses *Session, stmt *tree.CreatePitr) (err
 
 	if execResultArrayHasData(erArray) {
 		var (
-			sysPitrValue       uint64
-			sysPitrUnit        string
-			oldMinTs, newMinTs time.Time
+			sysPitrValue uint64
+			sysPitrUnit  string
 		)
 		for i := uint64(0); i < erArray[0].GetRowCount(); i++ {
 			sysPitrValue, err = erArray[0].GetUint64(ctx, i, 11)
@@ -674,19 +673,19 @@ func doCreatePitr(ctx context.Context, ses *Session, stmt *tree.CreatePitr) (err
 			}
 		}
 
-		oldMinTs, err = addTimeSpan(time.Time{}, int(sysPitrValue), sysPitrUnit)
+		mergedValue, mergedUnit, err := databranchutils.MergePitrRetentionRanges(
+			int(sysPitrValue),
+			sysPitrUnit,
+			int(pitrVal),
+			pitrUnit,
+		)
 		if err != nil {
 			return err
 		}
 
-		newMinTs, err = addTimeSpan(time.Time{}, int(pitrVal), pitrUnit)
-		if err != nil {
-			return err
-		}
-
-		if newMinTs.UnixNano() < oldMinTs.UnixNano() {
+		if mergedValue != int(sysPitrValue) || mergedUnit != sysPitrUnit {
 			// update sysMoCatalogPitr
-			sql = fmt.Sprintf("update mo_catalog.mo_pitr set pitr_length = %d, pitr_unit = '%s' where pitr_name = '%s';", pitrVal, pitrUnit, SYSMOCATALOGPITR)
+			sql = fmt.Sprintf("update mo_catalog.mo_pitr set pitr_length = %d, pitr_unit = '%s' where pitr_name = '%s';", mergedValue, mergedUnit, SYSMOCATALOGPITR)
 			getLogger(ses.GetService()).Info("update sys mo_catalog pitr", zap.String("sql", sql))
 			err = bh.Exec(ctx, sql)
 			if err != nil {

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -79,22 +79,21 @@ var (
 )
 
 type pitrRecord struct {
-	pitrId            string
-	pitrName          string
-	createAccount     uint64
-	createTime        int64
-	modifiedTime      int64
-	level             string
-	accountId         uint64
-	accountName       string
-	databaseName      string
-	tableName         string
-	objId             uint64
-	pitrValue         uint64
-	pitrUnit          string
-	pitrStatus        uint8
-	statusChangedTime int64
-	hasStatus         bool
+	pitrId        string
+	pitrName      string
+	createAccount uint64
+	createTime    int64
+	modifiedTime  int64
+	level         string
+	accountId     uint64
+	accountName   string
+	databaseName  string
+	tableName     string
+	objId         uint64
+	pitrValue     uint64
+	pitrUnit      string
+	pitrStatus    uint8
+	hasStatus     bool
 }
 
 const (
@@ -2073,10 +2072,12 @@ func getPitrRecords(ctx context.Context, bh BackgroundExec, sql string) ([]*pitr
 				if record.pitrUnit, err = er.GetString(ctx, row, 12); err != nil {
 					return nil, err
 				}
-				// pitr_status and pitr_status_changed_time were appended to the
-				// legacy 13-column schema. Keep old catalog rows readable during
-				// rolling upgrades, but reject malformed status values when present.
-				if er.GetColumnCount() > 14 {
+				// pitr_status was appended to the legacy 13-column schema before
+				// pitr_status_changed_time. Parse it as soon as it is present so a
+				// partially upgraded catalog cannot make an inactive PITR look
+				// active. The changed-time column is not needed by ALTER and has
+				// had different types across catalog versions, so do not read it.
+				if er.GetColumnCount() > 13 {
 					status, statusErr := er.GetUint64(ctx, row, 13)
 					if statusErr != nil {
 						return nil, statusErr
@@ -2085,9 +2086,6 @@ func getPitrRecords(ctx context.Context, bh BackgroundExec, sql string) ([]*pitr
 						return nil, moerr.NewInvalidInputf(ctx, "invalid PITR status %d", status)
 					}
 					record.pitrStatus = uint8(status)
-					if record.statusChangedTime, err = er.GetInt64(ctx, row, 14); err != nil {
-						return nil, err
-					}
 					record.hasStatus = true
 				}
 			}

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -3745,12 +3745,7 @@ func registerPitrRecordResultWithStatus(
 		statusColumn.SetName("pitr_status")
 		statusColumn.SetColumnType(defines.MYSQL_TYPE_TINY)
 		mrs.AddColumn(statusColumn)
-
-		changedTimeColumn := &MysqlColumn{}
-		changedTimeColumn.SetName("pitr_status_changed_time")
-		changedTimeColumn.SetColumnType(defines.MYSQL_TYPE_TIMESTAMP)
-		mrs.AddColumn(changedTimeColumn)
-		row = append(row, *pitrStatus, time.Now().UnixNano())
+		row = append(row, *pitrStatus)
 	}
 	mrs.AddRow(row)
 	bh.sql2result[sql] = mrs

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -2672,13 +2672,16 @@ func Test_doCreatePitr(t *testing.T) {
 				"",
 				uint64(1),
 				uint8(1),
-				"d",
+				"mo",
 			},
 		})
 		bh.sql2result[sql] = mrs
 
+		stmt.PitrValue = 30
 		err = doCreatePitr(ctx, ses, stmt)
 		assert.NoError(t, err)
+		assert.Contains(t, bh.executedSQLs,
+			"update mo_catalog.mo_pitr set pitr_length = 31, pitr_unit = 'd' where pitr_name = 'sys_mo_catalog_pitr';")
 
 		commitErr := errors.New("pitr commit conflict")
 		bh.sql2err["commit;"] = commitErr

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -3700,6 +3700,62 @@ func newPitrLifecycleTestSession(
 	return ses, bh, ctx
 }
 
+func registerPitrRecordResult(
+	bh *backgroundExecTest,
+	pitrName string,
+	accountID uint64,
+	pitrValue uint8,
+	pitrUnit string,
+) {
+	registerPitrRecordResultWithStatus(bh, pitrName, accountID, pitrValue, pitrUnit, nil)
+}
+
+func registerPitrRecordResultWithStatus(
+	bh *backgroundExecTest,
+	pitrName string,
+	accountID uint64,
+	pitrValue uint8,
+	pitrUnit string,
+	pitrStatus *uint8,
+) {
+	sql := fmt.Sprintf(
+		"%s where pitr_name = '%s' and create_account = %d",
+		getPitrFormat,
+		pitrName,
+		accountID,
+	)
+	row := []interface{}{
+		"pitr-id",
+		pitrName,
+		accountID,
+		time.Now().Add(-24 * time.Hour).UnixNano(),
+		time.Now().Add(-24 * time.Hour).UnixNano(),
+		"ACCOUNT",
+		accountID,
+		sysAccountName,
+		"",
+		"",
+		accountID,
+		pitrValue,
+		pitrUnit,
+	}
+	mrs := newMrsForPitrRecord(nil)
+	if pitrStatus != nil {
+		statusColumn := &MysqlColumn{}
+		statusColumn.SetName("pitr_status")
+		statusColumn.SetColumnType(defines.MYSQL_TYPE_TINY)
+		mrs.AddColumn(statusColumn)
+
+		changedTimeColumn := &MysqlColumn{}
+		changedTimeColumn.SetName("pitr_status_changed_time")
+		changedTimeColumn.SetColumnType(defines.MYSQL_TYPE_TIMESTAMP)
+		mrs.AddColumn(changedTimeColumn)
+		row = append(row, *pitrStatus, time.Now().UnixNano())
+	}
+	mrs.AddRow(row)
+	bh.sql2result[sql] = mrs
+}
+
 func TestDoDropPitrCompactsHistoricalAlterLineage(t *testing.T) {
 	ses, bh, ctx := newPitrLifecycleTestSession(t)
 	stmt := &tree.DropPitr{Name: "pitr01"}
@@ -3723,9 +3779,60 @@ func TestDoAlterPitrCompactsHistoricalAlterLineage(t *testing.T) {
 	checkSQL, err := getSqlForCheckPitr(ctx, "pitr01", sysAccountID)
 	require.NoError(t, err)
 	bh.sql2result[checkSQL] = newMrsForPitrRecord([][]interface{}{{"pitr-id"}})
+	registerPitrRecordResult(bh, "pitr01", sysAccountID, 2, "h")
 
 	require.NoError(t, doAlterPitr(ctx, ses, stmt))
 	require.Contains(t, bh.executedSQLs, historicalAlterLineageMetadataSQL())
+}
+
+func TestDoAlterPitrRejectsRecoveryRangeExpansion(t *testing.T) {
+	ses, bh, ctx := newPitrLifecycleTestSession(t)
+	stmt := &tree.AlterPitr{Name: "pitr01", PitrValue: 2, PitrUnit: "h"}
+
+	checkSQL, err := getSqlForCheckPitr(ctx, "pitr01", sysAccountID)
+	require.NoError(t, err)
+	bh.sql2result[checkSQL] = newMrsForPitrRecord([][]interface{}{{"pitr-id"}})
+	registerPitrRecordResult(bh, "pitr01", sysAccountID, 1, "h")
+
+	err = doAlterPitr(ctx, ses, stmt)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot expand PITR pitr01 recovery range")
+	require.Contains(t, bh.executedSQLs, "rollback;")
+	require.NotContains(t, bh.executedSQLs, "commit;")
+	require.NotContains(t, bh.executedSQLs, historicalAlterLineageMetadataSQL())
+	for _, sql := range bh.executedSQLs {
+		require.NotContains(t, sql, "update mo_catalog.mo_pitr set modified_time")
+	}
+}
+
+func TestDoAlterPitrRejectsInactivePitr(t *testing.T) {
+	ses, bh, ctx := newPitrLifecycleTestSession(t)
+	stmt := &tree.AlterPitr{Name: "pitr01", PitrValue: 2, PitrUnit: "mo"}
+
+	checkSQL, err := getSqlForCheckPitr(ctx, "pitr01", sysAccountID)
+	require.NoError(t, err)
+	bh.sql2result[checkSQL] = newMrsForPitrRecord([][]interface{}{{"pitr-id"}})
+	inactive := uint8(0)
+	registerPitrRecordResultWithStatus(bh, "pitr01", sysAccountID, 1, "y", &inactive)
+
+	err = doAlterPitr(ctx, ses, stmt)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot alter inactive pitr pitr01")
+	require.Contains(t, bh.executedSQLs, "rollback;")
+	require.NotContains(t, bh.executedSQLs, "commit;")
+	for _, sql := range bh.executedSQLs {
+		require.NotContains(t, sql, "update mo_catalog.mo_pitr set modified_time")
+	}
+}
+
+func TestDoAlterPitrRejectsZeroRangeBeforeTransaction(t *testing.T) {
+	ses, bh, ctx := newPitrLifecycleTestSession(t)
+	stmt := &tree.AlterPitr{Name: "pitr01", PitrValue: 0, PitrUnit: "h"}
+
+	err := doAlterPitr(ctx, ses, stmt)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid pitr value 0")
+	require.NotContains(t, bh.executedSQLs, "begin;")
 }
 
 // Test_unservableViewErrorIsIdentifiable pins the contract the restore paths rely on.

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -5599,16 +5599,23 @@ func (s *Scope) CreatePitr(c *Compile) error {
 
 	var needInsertSysPitr = true
 	var needUpdateSysPitr = false
+	var mergedSysPitrLength = uint64(createPitr.GetPitrValue())
+	var mergedSysPitrUnit = createPitr.GetPitrUnit()
 	if len(sysRes.Batches) > 0 && sysRes.Batches[0].RowCount() > 0 {
 		// sys_mo_catalog_pitr exists
-		needInsertSysPitr, needUpdateSysPitr, err = CheckSysMoCatalogPitrResult(c.proc.Ctx, sysRes.Batches[0].Vecs, uint64(createPitr.GetPitrValue()), createPitr.GetPitrUnit())
+		needInsertSysPitr, needUpdateSysPitr, mergedSysPitrLength, mergedSysPitrUnit, err = CheckSysMoCatalogPitrResult(
+			c.proc.Ctx,
+			sysRes.Batches[0].Vecs,
+			uint64(createPitr.GetPitrValue()),
+			createPitr.GetPitrUnit(),
+		)
 		if err != nil {
 			return err
 		}
 	}
 
 	if needUpdateSysPitr {
-		updateSql := fmt.Sprintf("UPDATE mo_catalog.mo_pitr SET pitr_length = %d, pitr_unit = '%s' WHERE pitr_name = '%s'", createPitr.GetPitrValue(), createPitr.GetPitrUnit(), sysMoCatalogPitr)
+		updateSql := fmt.Sprintf("UPDATE mo_catalog.mo_pitr SET pitr_length = %d, pitr_unit = '%s' WHERE pitr_name = '%s'", mergedSysPitrLength, mergedSysPitrUnit, sysMoCatalogPitr)
 		err = c.runSqlWithAccountIdAndOptions(updateSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
@@ -5717,23 +5724,6 @@ func (c *Compile) resolveCurrentPitrObjectID(createPitr *plan.CreatePitr) (uint6
 		return rel.GetTableID(ctx), nil
 	default:
 		return 0, moerr.NewInternalErrorf(ctx, "invalid pitr level %d", createPitr.GetLevel())
-	}
-}
-
-// addTimeSpan returns the UTC time that is 'length' units before now, where unit is one of "h", "d", "mo", "y"
-func addTimeSpan(length int, unit string) (time.Time, error) {
-	now := time.Now().UTC()
-	switch unit {
-	case "h":
-		return now.Add(time.Duration(-length) * time.Hour), nil
-	case "d":
-		return now.AddDate(0, 0, -length), nil
-	case "mo":
-		return now.AddDate(0, -length, 0), nil
-	case "y":
-		return now.AddDate(-length, 0, 0), nil
-	default:
-		return time.Time{}, moerr.NewInternalErrorNoCtxf("unknown unit '%s'", unit)
 	}
 }
 
@@ -5852,15 +5842,22 @@ func getSqlForCheckDupPitrFormat(accountId uint32, objId uint64) string {
 //
 //	needInsert: true if sys_mo_catalog_pitr does not exist
 //	needUpdate: true if it exists and needs update
-//	oldLength, oldUnit: the old values if exist (for debug)
+//	mergedLength, mergedUnit: a future-stable range covering old and new values
 //	err: error if any
-func CheckSysMoCatalogPitrResult(ctx context.Context, vecs []*vector.Vector, newLength uint64, newUnit string) (needInsert, needUpdate bool, err error) {
+func CheckSysMoCatalogPitrResult(
+	ctx context.Context,
+	vecs []*vector.Vector,
+	newLength uint64,
+	newUnit string,
+) (needInsert, needUpdate bool, mergedLength uint64, mergedUnit string, err error) {
 	needInsert = true
 	needUpdate = false
+	mergedLength = newLength
+	mergedUnit = newUnit
 	var oldLength uint64
 	oldUnit := ""
 	if len(vecs) < 2 {
-		return false, false, moerr.NewInternalErrorf(ctx, "unexpected sys_mo_catalog_pitr result columns")
+		return false, false, 0, "", moerr.NewInternalErrorf(ctx, "unexpected sys_mo_catalog_pitr result columns")
 	}
 	if vecs[0].Length() > 0 {
 		col := vector.MustFixedColNoTypeCheck[uint64](vecs[0])
@@ -5872,20 +5869,28 @@ func CheckSysMoCatalogPitrResult(ctx context.Context, vecs []*vector.Vector, new
 	}
 	if vecs[0].Length() > 0 && vecs[1].Length() > 0 {
 		needInsert = false
-		// Compare time ranges
-		oldMinTs, err1 := addTimeSpan(int(oldLength), oldUnit)
-		if err1 != nil {
-			return false, false, err1
+		if oldLength > 100 || newLength > 100 {
+			return false, false, 0, "", moerr.NewInvalidInputf(
+				ctx,
+				"invalid PITR lengths %d and %d",
+				oldLength,
+				newLength,
+			)
 		}
-		newMinTs, err2 := addTimeSpan(int(newLength), newUnit)
-		if err2 != nil {
-			return false, false, err2
+		merged, unit, mergeErr := databranchutils.MergePitrRetentionRanges(
+			int(oldLength),
+			oldUnit,
+			int(newLength),
+			newUnit,
+		)
+		if mergeErr != nil {
+			return false, false, 0, "", mergeErr
 		}
-		if newMinTs.UnixNano() < oldMinTs.UnixNano() {
-			needUpdate = true
-		}
+		mergedLength = uint64(merged)
+		mergedUnit = unit
+		needUpdate = mergedLength != oldLength || mergedUnit != oldUnit
 	}
-	return needInsert, needUpdate, nil
+	return needInsert, needUpdate, mergedLength, mergedUnit, nil
 }
 
 func getSqlForCheckPitrExists(pitrName string, accountId uint32) string {

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -1624,33 +1624,6 @@ func TestScope_Database(t *testing.T) {
 	})
 }
 
-func Test_addTimeSpan(t *testing.T) {
-	cases := []struct {
-		name    string
-		len     int
-		unit    string
-		wantOk  bool
-		wantMsg string
-	}{
-		{"hour", 1, "h", true, ""},
-		{"day", 2, "d", true, ""},
-		{"month", 3, "mo", true, ""},
-		{"year", 4, "y", true, ""},
-		{"invalid", 5, "xx", false, "unknown unit"},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			_, err := addTimeSpan(c.len, c.unit)
-			if c.wantOk {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), c.wantMsg)
-			}
-		})
-	}
-}
-
 func Test_getSqlForCheckPitrDup(t *testing.T) {
 	mk := func(level int32, origin bool) *plan2.CreatePitr {
 		return &plan2.CreatePitr{
@@ -1766,20 +1739,24 @@ func TestCheckSysMoCatalogPitrResult(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty vecs", func(t *testing.T) {
-		needInsert, needUpdate, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{}, 10, "d")
+		needInsert, needUpdate, length, unit, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{}, 10, "d")
 		assert.Error(t, err)
 		assert.False(t, needInsert)
 		assert.False(t, needUpdate)
+		assert.Zero(t, length)
+		assert.Empty(t, unit)
 	})
 
 	t.Run("insert needed", func(t *testing.T) {
 		v1 := vector.NewVec(types.T_uint64.ToType())
 		v2 := vector.NewVec(types.T_varchar.ToType())
 		// no data in vectors
-		needInsert, needUpdate, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{v1, v2}, 10, "d")
+		needInsert, needUpdate, length, unit, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{v1, v2}, 10, "d")
 		assert.NoError(t, err)
 		assert.True(t, needInsert)
 		assert.False(t, needUpdate)
+		assert.Equal(t, uint64(10), length)
+		assert.Equal(t, "d", unit)
 	})
 
 	t.Run("update needed", func(t *testing.T) {
@@ -1787,10 +1764,12 @@ func TestCheckSysMoCatalogPitrResult(t *testing.T) {
 		_ = vector.AppendFixed(v1, uint64(5), false, mp)
 		v2 := vector.NewVec(types.T_varchar.ToType())
 		_ = vector.AppendBytes(v2, []byte("d"), false, mp)
-		needInsert, needUpdate, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{v1, v2}, 10, "d")
+		needInsert, needUpdate, length, unit, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{v1, v2}, 10, "d")
 		assert.NoError(t, err)
 		assert.False(t, needInsert)
 		assert.True(t, needUpdate)
+		assert.Equal(t, uint64(10), length)
+		assert.Equal(t, "d", unit)
 	})
 
 	t.Run("no update needed", func(t *testing.T) {
@@ -1798,10 +1777,25 @@ func TestCheckSysMoCatalogPitrResult(t *testing.T) {
 		_ = vector.AppendFixed(v1, uint64(20), false, mp)
 		v2 := vector.NewVec(types.T_varchar.ToType())
 		_ = vector.AppendBytes(v2, []byte("d"), false, mp)
-		needInsert, needUpdate, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{v1, v2}, 10, "d")
+		needInsert, needUpdate, length, unit, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{v1, v2}, 10, "d")
 		assert.NoError(t, err)
 		assert.False(t, needInsert)
 		assert.False(t, needUpdate)
+		assert.Equal(t, uint64(20), length)
+		assert.Equal(t, "d", unit)
+	})
+
+	t.Run("mixed month and days use stable envelope", func(t *testing.T) {
+		v1 := vector.NewVec(types.T_uint64.ToType())
+		_ = vector.AppendFixed(v1, uint64(1), false, mp)
+		v2 := vector.NewVec(types.T_varchar.ToType())
+		_ = vector.AppendBytes(v2, []byte("mo"), false, mp)
+		needInsert, needUpdate, length, unit, err := CheckSysMoCatalogPitrResult(ctx, []*vector.Vector{v1, v2}, 30, "d")
+		assert.NoError(t, err)
+		assert.False(t, needInsert)
+		assert.True(t, needUpdate)
+		assert.Equal(t, uint64(31), length)
+		assert.Equal(t, "d", unit)
 	})
 }
 

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -2047,8 +2047,16 @@ func (sm *SnapshotMeta) AccountToTableSnapshots(
 			)
 		}
 
-		// get the pitr for the table
-		ts := pitr.GetTS(info.accountID, info.dbID, tid)
+		// Every active PITR can require historical mo_catalog metadata during
+		// restore. Protect all catalog tables with the global PITR lower bound,
+		// even when a legacy sys_mo_catalog_pitr row is narrower than another
+		// active PITR. Non-catalog tables keep their scoped PITR lookup.
+		var ts types.TS
+		if info.dbID == catalog2.MO_CATALOG_ID {
+			ts = sysPitr
+		} else {
+			ts = pitr.GetTS(info.accountID, info.dbID, tid)
+		}
 		tablePitrs[tid] = &ts
 	}
 	return

--- a/pkg/vm/engine/tae/logtail/snapshot_test.go
+++ b/pkg/vm/engine/tae/logtail/snapshot_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -186,6 +187,41 @@ func TestAccountToTableSnapshots(t *testing.T) {
 		assert.NotNil(t, tablePitrs[1002])
 		assert.NotNil(t, tablePitrs[2001])
 		assert.NotNil(t, tablePitrs[3001])
+	})
+
+	t.Run("AllMoCatalogTablesUseGlobalPitrLowerBound", func(t *testing.T) {
+		const catalogTableID = uint64(5001)
+		const userTableID = uint64(5002)
+		const userDatabaseID = uint64(100)
+		catalogMeta := &SnapshotMeta{
+			tableIDIndex: map[uint64]*tableInfo{
+				catalogTableID: {
+					accountID: uint32(catalog.System_Account),
+					dbID:      catalog.MO_CATALOG_ID,
+					tid:       catalogTableID,
+				},
+				userTableID: {
+					accountID: 7,
+					dbID:      userDatabaseID,
+					tid:       userTableID,
+				},
+			},
+		}
+		snapshots := NewSnapshotInfo()
+		pitr := NewPitrInfo()
+		globalLowerBound := types.BuildTS(1000, 0)
+		legacySysLowerBound := types.BuildTS(2000, 0)
+		userLowerBound := types.BuildTS(3000, 0)
+		pitr.account[42] = []types.TS{globalLowerBound}
+		pitr.database[catalog.MO_CATALOG_ID] = []types.TS{legacySysLowerBound}
+		pitr.database[userDatabaseID] = []types.TS{userLowerBound}
+
+		_, tablePitrs := catalogMeta.AccountToTableSnapshots(snapshots, pitr)
+
+		require.NotNil(t, tablePitrs[catalogTableID])
+		require.Equal(t, globalLowerBound, *tablePitrs[catalogTableID])
+		require.NotNil(t, tablePitrs[userTableID])
+		require.Equal(t, userLowerBound, *tablePitrs[userTableID])
 	})
 
 	t.Run("MultipleTableSnapshotsInSameDatabase", func(t *testing.T) {

--- a/test/distributed/cases/pitr/pitr.result
+++ b/test/distributed/cases/pitr/pitr.result
@@ -101,6 +101,7 @@ select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`,
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bd3c-70fa-ae01-a0699c57a124    $%^#    0    2024-12-25 09:22:15    2024-12-25 09:22:15    table    0    sys    test01    t1    317751    1    y
 alter pitr `$%^#` range 2 'mo';
+not supported: cannot alter inactive pitr $%^#
 drop pitr `$%^#`;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT

--- a/test/distributed/cases/pitr/pitr.result
+++ b/test/distributed/cases/pitr/pitr.result
@@ -9,12 +9,13 @@ select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`,
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bc8a-7c50-82c7-9702538eaf9d    pitr01    0    2024-12-25 09:22:15    2024-12-25 09:22:15    cluster    0                18446744073709551615    1    h
 alter pitr pitr01 range 10 'd';
+not supported: cannot expand PITR pitr01 recovery range from 1 h to 10 d; create a new PITR instead
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-pitr01    2024-12-25 17:22:15    2024-12-25 17:22:15    cluster    *    *    *    10    d
+pitr01    2024-12-25 17:22:15    2024-12-25 17:22:15    cluster    *    *    *    1    h
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
-0193fd1f-bc8a-7c50-82c7-9702538eaf9d    pitr01    0    2024-12-25 09:22:15    2024-12-25 09:22:15    cluster    0                18446744073709551615    10    d
+0193fd1f-bc8a-7c50-82c7-9702538eaf9d    pitr01    0    2024-12-25 09:22:15    2024-12-25 09:22:15    cluster    0                18446744073709551615    1    h
 drop pitr pitr01;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
@@ -28,13 +29,13 @@ p02    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    * 
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bcb6-7246-9d91-875413dfc702    p02    0    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    1    d
-alter pitr p02 range 100 'd';
+alter pitr p02 range 1 'h';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-p02    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    100    d
+p02    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    1    h
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
-0193fd1f-bcb6-7246-9d91-875413dfc702    p02    0    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    100    d
+0193fd1f-bcb6-7246-9d91-875413dfc702    p02    0    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    1    h
 drop pitr p02;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
@@ -48,13 +49,13 @@ select    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *   
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bce9-705d-bca9-7a795f93de07    select    30010    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    10    d
-alter pitr `select` range 30 'd';
+alter pitr `select` range 5 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-select    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    30    d
+select    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    5    d
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
-0193fd1f-bce9-705d-bca9-7a795f93de07    select    30010    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    30    d
+0193fd1f-bce9-705d-bca9-7a795f93de07    select    30010    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    5    d
 drop pitr `select`;
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
@@ -68,13 +69,13 @@ account    2024-12-25 17:22:15    2024-12-25 17:22:15    database    sys    test
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bd11-76d6-ae30-218792e1f7e9    account    0    2024-12-25 09:22:15    2024-12-25 09:22:15    database    0    sys    test01        317750    1    mo
-alter pitr account range 4 'mo';
+alter pitr account range 28 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-account    2024-12-25 17:22:15    2024-12-25 17:22:15    database    sys    test01    *    4    mo
+account    2024-12-25 17:22:15    2024-12-25 17:22:15    database    sys    test01    *    28    d
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
-0193fd1f-bd11-76d6-ae30-218792e1f7e9    account    0    2024-12-25 09:22:15    2024-12-25 09:22:15    database    0    sys    test01        317750    4    mo
+0193fd1f-bd11-76d6-ae30-218792e1f7e9    account    0    2024-12-25 09:22:15    2024-12-25 09:22:15    database    0    sys    test01        317750    28    d
 drop pitr account;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT

--- a/test/distributed/cases/pitr/pitr.sql
+++ b/test/distributed/cases/pitr/pitr.sql
@@ -27,7 +27,7 @@ create pitr p02 for account acc01 range 1 'd';
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
-alter pitr p02 range 100 'd';
+alter pitr p02 range 1 'h';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
@@ -49,7 +49,7 @@ show pitr;
 -- @ignore:0,2,3,4,6,7,10
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 -- @session:id=1&user=acc01:test_account&password=111
-alter pitr `select` range 30 'd';
+alter pitr `select` range 5 'd';
 -- @ignore:1,2
 show pitr;
 -- @session
@@ -70,7 +70,7 @@ create pitr account for database test01 range 1 'mo';
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
-alter pitr account range 4 'mo';
+alter pitr account range 28 'd';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10

--- a/test/distributed/cases/pitr/pitr1.result
+++ b/test/distributed/cases/pitr/pitr1.result
@@ -8,13 +8,13 @@ p_01    2025-01-16 15:57:56    2025-01-16 15:57:56    account    sys    *    *  
 select * from mo_catalog.mo_pitr Where pitr_name = 'p_01';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit    pitr_status    pitr_status_changed_time    kind
 019b3102-e508-7e15-8d19-9948b76699ed    p_01    0    1766053831945050000    1766053831945050000    account    0    sys            0    1    d    1    1766053831945050000    user
-alter pitr p_01 range 100 'd';
+alter pitr p_01 range 1 'h';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-p_01    2025-01-16 15:57:56    2025-01-16 15:57:56    account    sys    *    *    100    d
+p_01    2025-01-16 15:57:56    2025-01-16 15:57:56    account    sys    *    *    1    h
 select * from mo_catalog.mo_pitr Where pitr_name = 'p_01';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit    pitr_status    pitr_status_changed_time    kind
-01946e1e-72f2-7294-afca-fe8b9c3286be    p_01    0    2025-01-16 07:57:56    2025-01-16 07:57:56    account    0    sys            0    100    d    1    2025-01-16 07:52:03    user
+01946e1e-72f2-7294-afca-fe8b9c3286be    p_01    0    2025-01-16 07:57:56    2025-01-16 07:57:56    account    0    sys            0    1    h    1    2025-01-16 07:52:03    user
 drop pitr p_01;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
@@ -28,13 +28,13 @@ select    2025-01-16 15:57:56    2025-01-16 15:57:56    account    acc01    *   
 select * from mo_catalog.mo_pitr Where pitr_name = 'select';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit    pitr_status    pitr_status_changed_time    kind
 01946e1e-7370-7825-9e3e-bd50ee1ee09a    select    1    2025-01-16 07:57:56    2025-01-16 07:57:56    account    1    acc01            1    10    d    1    2025-01-16 07:52:03    user
-alter pitr `select` range 30 'd';
+alter pitr `select` range 5 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-select    2025-01-16 15:57:56    2025-01-16 15:57:57    account    acc01    *    *    30    d
+select    2025-01-16 15:57:56    2025-01-16 15:57:57    account    acc01    *    *    5    d
 select * from mo_catalog.mo_pitr Where pitr_name = 'select';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit    pitr_status    pitr_status_changed_time    kind
-01946e1e-7370-7825-9e3e-bd50ee1ee09a    select    1    2025-01-16 07:57:56    2025-01-16 07:57:57    account    1    acc01            1    30    d    1    2025-01-16 07:52:03    user
+01946e1e-7370-7825-9e3e-bd50ee1ee09a    select    1    2025-01-16 07:57:56    2025-01-16 07:57:57    account    1    acc01            1    5    d    1    2025-01-16 07:52:03    user
 drop pitr `select`;
 select * from mo_catalog.mo_pitr Where pitr_name = 'select';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit    pitr_status    pitr_status_changed_time    kind

--- a/test/distributed/cases/pitr/pitr1.sql
+++ b/test/distributed/cases/pitr/pitr1.sql
@@ -8,7 +8,7 @@ create pitr p_01 range 1 'd';
 show pitr;
 -- @ignore:0,2,3,4,6,7,10,14
 select * from mo_catalog.mo_pitr Where pitr_name = 'p_01';
-alter pitr p_01 range 100 'd';
+alter pitr p_01 range 1 'h';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10,14
@@ -30,7 +30,7 @@ show pitr;
 -- @ignore:0,2,3,4,6,7,10,14
 select * from mo_catalog.mo_pitr Where pitr_name = 'select';
 -- @session:id=1&user=acc01:test_account&password=111
-alter pitr `select` range 30 'd';
+alter pitr `select` range 5 'd';
 -- @ignore:1,2
 show pitr;
 -- @session

--- a/test/distributed/cases/pitr/pitr_basic.result
+++ b/test/distributed/cases/pitr/pitr_basic.result
@@ -105,7 +105,7 @@ PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATA
 pitr16    2024-12-25 16:34:55    2024-12-25 16:34:55    account    acc01    *    *    1    h
 pitr19    2024-12-25 16:34:55    2024-12-25 16:34:55    database    acc01    db01    *    1    h
 pitr21    2024-12-25 16:34:55    2024-12-25 16:34:55    table    acc01    db01    table01    1    h
-alter pitr pitr01 range 1 'd';
+alter pitr pitr01 range 1 'h';
 alter pitr pitr100 range 1 'd';
 internal error: pitr pitr100 does not exist
 alter pitr if exists pitr100 range 1 'd';
@@ -121,7 +121,7 @@ pitr05    2024-12-25 16:34:55    2024-12-25 16:34:55    cluster    *    *    *  
 pitr10    2024-12-25 16:34:55    2024-12-25 16:34:55    database    sys    db01    *    1    h
 pitr12    2024-12-25 16:34:55    2024-12-25 16:34:55    table    sys    db01    table01    1    h
 pitr14    2024-12-25 16:34:55    2024-12-25 16:34:55    account    acc01    *    *    1    h
-pitr01    2024-12-25 16:34:55    2024-12-25 16:34:55    account    sys    *    *    1    d
+pitr01    2024-12-25 16:34:55    2024-12-25 16:34:55    account    sys    *    *    1    h
 drop pitr pitr01;
 drop pitr pitr100;
 internal error: pitr pitr100 does not exist
@@ -132,7 +132,7 @@ pitr05    2024-12-25 16:34:55    2024-12-25 16:34:55    cluster    *    *    *  
 pitr10    2024-12-25 16:34:55    2024-12-25 16:34:55    database    sys    db01    *    1    h
 pitr12    2024-12-25 16:34:55    2024-12-25 16:34:55    table    sys    db01    table01    1    h
 pitr14    2024-12-25 16:34:55    2024-12-25 16:34:55    account    acc01    *    *    1    h
-alter pitr pitr16 range 1 'd';
+alter pitr pitr16 range 1 'h';
 alter pitr pitr100 range 1 'd';
 internal error: pitr pitr100 does not exist
 alter pitr if exists pitr100 range 1 'd';
@@ -146,7 +146,7 @@ show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr19    2024-12-25 16:34:55    2024-12-25 16:34:55    database    acc01    db01    *    1    h
 pitr21    2024-12-25 16:34:55    2024-12-25 16:34:55    table    acc01    db01    table01    1    h
-pitr16    2024-12-25 16:34:55    2024-12-25 16:34:55    account    acc01    *    *    1    d
+pitr16    2024-12-25 16:34:55    2024-12-25 16:34:55    account    acc01    *    *    1    h
 drop pitr pitr16;
 drop pitr pitr100;
 internal error: pitr pitr100 does not exist
@@ -195,13 +195,13 @@ create pitr pitr01 for account range 1 'h';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr01    2024-12-25 16:34:56    2024-12-25 16:34:56    account    acc02    *    *    1    h
-alter pitr pitr01 range 1 'd';
+alter pitr pitr01 range 1 'h';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-pitr01    2024-12-25 16:34:56    2024-12-25 16:34:57    account    acc02    *    *    1    d
+pitr01    2024-12-25 16:34:56    2024-12-25 16:34:57    account    acc02    *    *    1    h
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
-0193fcf4-67e2-71ad-9b82-dc69bd36f851    pitr01    30002    2024-12-25 08:34:56    2024-12-25 08:34:57    account    30002    acc02            30002    1    d
+0193fcf4-67e2-71ad-9b82-dc69bd36f851    pitr01    30002    2024-12-25 08:34:56    2024-12-25 08:34:57    account    30002    acc02            30002    1    h
 drop account if exists acc02;
 select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit

--- a/test/distributed/cases/pitr/pitr_basic.sql
+++ b/test/distributed/cases/pitr/pitr_basic.sql
@@ -92,7 +92,7 @@ show pitr;
 -- @session
 
 -- alter pitr success
-alter pitr pitr01 range 1 'd';
+alter pitr pitr01 range 1 'h';
 -- alter pitr failed
 alter pitr pitr100 range 1 'd';
 alter pitr if exists pitr100 range 1 'd';
@@ -113,7 +113,7 @@ show pitr;
 
 -- @session:id=1&user=acc01:test_account&password=111
 -- alter pitr success
-alter pitr pitr16 range 1 'd';
+alter pitr pitr16 range 1 'h';
 -- alter pitr failed
 alter pitr pitr100 range 1 'd';
 alter pitr if exists pitr100 range 1 'd';
@@ -163,7 +163,7 @@ create account acc02 admin_name = 'test_account' identified by '111';
 create pitr pitr01 for account range 1 'h';
 -- @ignore:1,2
 show pitr;
-alter pitr pitr01 range 1 'd';
+alter pitr pitr01 range 1 'h';
 -- @ignore:1,2
 show pitr;
 -- @session


### PR DESCRIPTION
## What changed

This branch was rewritten from current `main` to keep one focused PITR safety fix. It no longer contains the earlier retention-floor schema migration, TAE GC changes, RPC/version gates, lineage protocol redesign, or harness skill.

`ALTER PITR` now:

- allows an equal or provably shorter recovery range;
- rejects a range that can expose older history than the current range;
- rejects inactive PITRs;
- reads the optional `pitr_status` column without requiring later catalog columns, preserving legacy 13-column and partially upgraded catalog compatibility;
- performs validation and mutation under the existing lineage-owner lifecycle lock and rolls back before any update or compaction on rejection.

The shared frontend/compile PITR lower-bound helper now clamps month/year subtraction to the last valid day of the target month, matching the existing TAE calendar behavior. Cross-unit ALTER decisions are independent of statement date: hours/days and months/years compare exactly within their class; mixed fixed/calendar changes use conservative duration bounds so a later month end or leap year cannot reverse a previously accepted shrink.

Distributed PITR cases now cover:

- an expansion rejection with the old range unchanged;
- sys and tenant equal/shrink paths;
- fixed-unit and calendar-to-fixed changes;
- inactive PITR rejection after TRUNCATE.

## Why

GC may already have reclaimed history outside the current PITR range. Without a synchronous acknowledgement protocol from every GC consumer, expanding an existing rolling window can promise history that no longer exists. Rejecting expansion is the smallest behavior with a complete proof and requires no TAE GC, cross-service protocol, catalog-schema, permission, or security change.

To request a larger range, drop the existing PITR and create a new one. The new PITR's creation boundary makes the guarantee start from history that still exists; it does not claim that previously reclaimed history has been restored.

## Safety invariants

1. An accepted ALTER can never require an older retention boundary than the current PITR at any future time.
2. Rejected expansion, inactive state, malformed status, and invalid length/unit paths execute no catalog update or lineage compaction.
3. Month-end and leap-day arithmetic never normalizes forward into the wrong month.
4. Legacy rows without `pitr_status` remain readable; when status is present, inactive and malformed values fail closed.

## Validation

Rebased onto `main@86aeb0ecbf` before commit. Local validation on final code:

- full `./pkg/frontend`: pass;
- full `./pkg/frontend/databranchutils`: pass;
- focused `./pkg/sql/compile` PITR catalog-type regression: pass;
- focused ALTER success/rejection/rollback tests: pass;
- SQL/result ALTER statement lists for `pitr`, `pitr1`, and `pitr_basic`: exact match;
- `git diff --check`: pass.

Per requested scope, no 55-machine or remote harness validation was run. Fresh GitHub CI is the authoritative distributed BVT replay.

## Deep-review closure

- Q1 cleanup: no new resource owner; existing background executor close and transaction finish/rollback own every exit.
- Q2 liveness: no new wait edge or concurrency primitive; validation stays inside the existing lifecycle critical section.
- Q3 boundedness: one current-row read and constant-size duration comparison; no retry, goroutine, cache, or input-proportional growth.

The prior review threads and requested-changes decision refer to superseded broad commits. A fresh review should evaluate the current narrow head.
