### PR TITLE
test(morpc): guard backend pool assertion against idle GC

### DIFF
--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -1702,7 +1702,10 @@ func TestGetBackendWithCreateBackend(t *testing.T) {
 	}
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
-	assert.Equal(t, 1, len(c.mu.backends["b1"]))
+	c.mu.Lock()
+	backendCount := len(c.mu.backends["b1"])
+	c.mu.Unlock()
+	assert.Equal(t, 1, backendCount)
 }
 
 func TestCloseIdleBackends(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27835

## What this PR does / why we need it:

### Root cause

`TestGetBackendWithCreateBackend` read `len(c.mu.backends["b1"])` after `getBackend` returned without holding `c.mu`. The process-wide `clientGCManager` can concurrently invoke `closeIdleBackends`, which holds the same mutex while compacting and reassigning the backend slice in `c.mu.backends`. The test's unsynchronized map read therefore raced with a legitimate idle-GC lifecycle update.

The original race was reproduced before this change with `MORPC_GC_IDLE_INTERVAL=1ms` and the race-enabled test repeated 100 times; the run reported a race in `TestGetBackendWithCreateBackend` between `client_test.go:1705` and `client.go:1873`.

### Change

Read the backend count while holding `c.mu`, copy it to a local scalar, then release the mutex before performing the assertion. This preserves the existing backend-creation oracle and changes no production behavior.

### Issue-to-test proof

The existing `TestGetBackendWithCreateBackend` is the regression case for this issue. Its backend-count assertion now uses the same client mutex as `getBackend` and `closeIdleBackends`, so the exact reported map access is synchronized while the assertion still requires exactly one created backend.

BVT is not applicable: this is an internal MORPC unit-test synchronization issue with no SQL, wire-protocol, or public API behavior change.

### Validation

- `.agents/skills/mo-dev/scripts/mo-cgo-test -list '^TestGetBackendWithCreateBackend$' ./pkg/common/morpc`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^TestGetBackendWithCreateBackend$' ./pkg/common/morpc`
- `MORPC_GC_IDLE_INTERVAL=1ms .agents/skills/mo-dev/scripts/mo-cgo-test -race -v -count=100 -timeout=120s -run '^TestGetBackendWithCreateBackend$' ./pkg/common/morpc`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -v -count=1 -timeout=300s ./pkg/common/morpc`
- `GOWORK=off go vet -mod=readonly ./pkg/common/morpc`
- `GOWORK=off go build -mod=readonly ./pkg/common/morpc`

All commands passed after the change; the focused race stress completed all 100 iterations and the complete MORPC race suite passed.

### Scope and residual risk

The committed diff contains only the four-line synchronization adjustment in `pkg/common/morpc/client_test.go`. The process-wide idle-GC scheduler and asynchronous backend creation behavior remain unchanged; no known residual race remains for the reported assertion.
