### PR TITLE
fix(fileservice): serialize disk cache directory cleanup

### DIFF
--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -54,6 +54,7 @@ type DiskCache struct {
 
 	cache        *fifocache.Cache[string, struct{}]
 	capacityFunc fscache.CapacityFunc
+	directoryMu  sync.RWMutex
 
 	async         diskCacheAsyncState
 	writeFailures diskCacheWriteFailureState
@@ -62,6 +63,10 @@ type DiskCache struct {
 		cancel context.CancelFunc
 		done   chan struct{}
 	}
+	// beforeLoadDirectoryCleanup and beforeCacheTempFileCreate are test-only
+	// phase barriers. Production instances leave them nil.
+	beforeLoadDirectoryCleanup func(path string)
+	beforeCacheTempFileCreate  func()
 	// beforeFilePublication is a test-only phase barrier. Production instances
 	// leave it nil, so the publication hot path pays only one predictable branch.
 	beforeFilePublication func()
@@ -258,10 +263,8 @@ func (d *DiskCache) loadCache(ctx context.Context) {
 		}
 
 		if entry.IsDir() {
-			// try remove if empty. for cleaning old structure
 			if path != d.path {
-				// os.Remove will not delete non-empty directory
-				_ = os.Remove(path)
+				d.removeEmptyDirectory(path)
 			}
 			return nil
 
@@ -625,6 +628,28 @@ func (d *DiskCache) writeFile(
 	return d.writeFileWithFinalizeMode(ctx, diskPath, openReader, false, nil)
 }
 
+func (d *DiskCache) removeEmptyDirectory(path string) {
+	if d.beforeLoadDirectoryCleanup != nil {
+		d.beforeLoadDirectoryCleanup(path)
+	}
+	d.directoryMu.Lock()
+	defer d.directoryMu.Unlock()
+	// os.Remove will not delete a non-empty directory.
+	_ = os.Remove(path)
+}
+
+func (d *DiskCache) createCacheTempFile(dir string) (*os.File, error) {
+	d.directoryMu.RLock()
+	defer d.directoryMu.RUnlock()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+	if d.beforeCacheTempFileCreate != nil {
+		d.beforeCacheTempFileCreate()
+	}
+	return os.CreateTemp(dir, "*"+cacheFileTempSuffix)
+}
+
 func (d *DiskCache) writeFileWithFinalizeMode(
 	ctx context.Context,
 	diskPath string,
@@ -694,12 +719,7 @@ func (d *DiskCache) writeFileWithFinalizeMode(
 	}
 
 	// write data
-	dir := filepath.Dir(diskPath)
-	err = os.MkdirAll(dir, 0755)
-	if err != nil {
-		return false, err
-	}
-	f, err := os.CreateTemp(dir, "*"+cacheFileTempSuffix)
+	f, err := d.createCacheTempFile(filepath.Dir(diskPath))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/fileservice/disk_cache_lifecycle_test.go
+++ b/pkg/fileservice/disk_cache_lifecycle_test.go
@@ -1018,6 +1018,79 @@ func TestDiskCacheCloseOwnsAsyncLoaderGeneration(t *testing.T) {
 	require.Equal(t, []byte("new"), data)
 }
 
+func TestDiskCacheLoadCacheKeepsForegroundDirectory(t *testing.T) {
+	cache := newLifecycleTestDiskCache(t)
+	foregroundDir := filepath.Dir(cache.pathForFile("foo/bar"))
+
+	writerReachedTempFileCreate := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	unblockWriter := sync.OnceFunc(func() { close(releaseWriter) })
+	cache.beforeCacheTempFileCreate = func() {
+		close(writerReachedTempFileCreate)
+		<-releaseWriter
+	}
+	writerDone := make(chan struct{})
+	writerResult := make(chan struct {
+		file *os.File
+		err  error
+	}, 1)
+	go func() {
+		defer close(writerDone)
+		file, err := cache.createCacheTempFile(foregroundDir)
+		writerResult <- struct {
+			file *os.File
+			err  error
+		}{file: file, err: err}
+	}()
+	t.Cleanup(func() {
+		unblockWriter()
+		<-writerDone
+	})
+	select {
+	case <-writerReachedTempFileCreate:
+	case <-time.After(diskCacheLifecycleTestTimeout):
+		t.Fatal("foreground cache write did not reach temporary file creation")
+	}
+
+	loaderReachedDirectoryCleanup := make(chan struct{})
+	cache.beforeLoadDirectoryCleanup = func(path string) {
+		if path == foregroundDir {
+			close(loaderReachedDirectoryCleanup)
+		}
+	}
+	loadDone := make(chan struct{})
+	go func() {
+		cache.loadCache(context.Background())
+		close(loadDone)
+	}()
+	t.Cleanup(func() {
+		unblockWriter()
+		<-loadDone
+	})
+	select {
+	case <-loaderReachedDirectoryCleanup:
+	case <-time.After(diskCacheLifecycleTestTimeout):
+		t.Fatal("disk-cache loader did not process the foreground directory")
+	}
+
+	unblockWriter()
+	result := <-writerResult
+	if result.file != nil {
+		t.Cleanup(func() { _ = result.file.Close() })
+	}
+	require.NoError(t, result.err)
+	require.NoError(t, result.file.Close())
+	<-loadDone
+	require.DirExists(t, foregroundDir)
+
+	cache.beforeLoadDirectoryCleanup = nil
+	staleDir := filepath.Join(cache.path, "stale")
+	require.NoError(t, os.MkdirAll(staleDir, 0o755))
+	cache.loadCache(context.Background())
+	_, err := os.Stat(staleDir)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestDiskCacheCloseCancelsActiveFileFinalizeBeforePublish(t *testing.T) {
 	cache := newLifecycleTestDiskCache(t)
 	syncStarted, unblock := installBlockedDiskCacheFileSync(cache)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27832

## What this PR does / why we need it:

### Root cause

`DiskCache.loadCache` runs asynchronously during file-service initialization. It
removed every empty non-root directory while walking the cache tree. A concurrent
full-object cache fill creates its parent with `MkdirAll` and then calls
`CreateTemp`. If the loader removed that parent in between, the optional cache
write failed open and the S3 read fell back to a full-object buffer; a small
range then retained that entire backing allocation.

The historical #27520 issue is independent: it synchronized the later
post-publication cache-hit assertion. This failure is on the first range read
before that barrier.

### Changes

- Serialize startup empty-directory cleanup with the `MkdirAll` plus
  `CreateTemp` critical section using a per-`DiskCache` `RWMutex`.
- Keep concurrent cache writers compatible with the shared lock. The loader
  takes the exclusive lock only while attempting one empty-directory removal.
- Keep stale empty-directory cleanup; no new cache-directory retention path is
  introduced.
- Add deterministic lifecycle coverage with instance-local barriers. It forces
  the loader to reach cleanup while a foreground cache writer owns its parent
  directory, then verifies temp-file creation succeeds. A stale empty-directory
  control remains removable.

### Issue-to-test proof

- `TestDiskCacheLoadCacheKeepsForegroundDirectory` proves the exact
  `MkdirAll -> loader cleanup -> CreateTemp` ownership boundary without sleeps:
  the writer reaches the temporary-file phase under the shared lock, the loader
  reaches directory cleanup, and only then is the writer released. The cache
  temp file and its parent survive; a separate stale directory is removed.
- `TestS3FSFullObjectDiskCacheFillDoesNotRetainWholeObjectBuffer` covers the
  consumer contract: the first seven-byte range from a 1 MiB object has bounded
  capacity and one S3 Get; after `FlushCache`, a later range hits disk cache.

### Tests run

The branch was rebased without conflict onto `origin/main`
`7bb89155a2c43a3a97da0f0fb4d865fdf4855235`; the following were rerun on
`2232f3852c09cd11191fb047cb131e9bb7b3af6e`:

- Both issue-proving tests in CI-style coverage mode:
  `-short -tags matrixone_test -covermode=set`.
- Both directly affected tests under `-race -count=100`.
- The full `TestDiskCache|TestS3FSFullObject` group with
  `-short -tags matrixone_test`.
- `GOWORK=off go vet -mod=readonly -tags matrixone_test ./pkg/fileservice`.
- `git diff --check`.

The earlier CI-style coverage mode with the repository-wide `-coverpkg` scope
passed both selected tests and generated a profile with 89,738 lines. The
base-side commits incorporated by the rebases change only `pkg/fulltext2` and
`pkg/sql/plan`, not the fileservice code, dependencies, fixtures, or test modes
exercised here.

The normal and race `pkg/fileservice` package runs reached completion but failed
only at `TestMinioSDK/file_service` with `Access Denied` from the local MinIO
service. The same selected MinIO test fails with the same signature in an
isolated `origin/main` worktree, so it is unrelated to this diff.

### Residual risks

The loader can briefly wait for an in-progress parent-directory creation, but
the shared critical section contains only `MkdirAll` and `CreateTemp`; it does
not cover streaming, fsync, or publication. Cache writes retain their existing
fail-open behavior for real filesystem errors.
