### PR TITLE
fix(logtail): add linearizable read barrier

### DIFF
--- a/docs/design/authentication_catalog_freshness.md
+++ b/docs/design/authentication_catalog_freshness.md
@@ -1,350 +1,276 @@
-# Authentication Catalog Freshness Across CNs
+# TN-Ordered Logtail Read Barrier and Authentication Catalog Freshness
 
 - Status: Review required
-- Base revision: `745d8364c589524a9e5c99772d34824fa9808203`
-- Incident evidence: [PR #27758 CI job](https://github.com/matrixorigin/matrixone/actions/runs/33067372509/job/98502820591?pr=27758)
-- Related changes: [PR #27717](https://github.com/matrixorigin/matrixone/pull/27717), [PR #27737](https://github.com/matrixorigin/matrixone/pull/27737)
-- Last updated: 2026-08-28
+- Related issue: #27834
+- Last updated: 2026-08-29
 
 ## 1. Summary
 
-MatrixOne deliberately permits ordinary transactions to start from the latest
-logtail already applied by their local CN. This avoids a physical freshness wait
-on the transaction hot path, but a newly routed connection can consequently
-authenticate from an older catalog snapshot than a security change that has
-already committed on another CN.
+MatrixOne normally allows a transaction to start from the newest logtail that
+its local CN has already applied. That policy avoids a global freshness round
+trip on ordinary SQL, but it does not provide the real-time ordering required
+by operations such as authentication: a catalog mutation may have committed on
+one CN while a later login on another CN still reads the older catalog state.
 
-The observed failure was a `REVOKE` followed by a `GRANT` of a user's stored
-default role. The grant returned successfully, but a new implicit login routed
-to another CN still saw the revoked generation, selected `public`, and rejected
-a table read that the regranted role permits. The same shape applies to account
-status, user/password state, explicit role grants, and every other catalog row
-read by `AuthenticateUser`.
+The previous repair advanced the login snapshot beyond the local HLC
+uncertainty upper bound. It was safe only under the configured clock-skew
+assumption, and an idle healthy cluster paid approximately the default 500ms
+maximum clock offset on every connection. The delay was unrelated to actual
+logtail lag.
 
-Authentication must therefore opt out of sacrificed freshness. Immediately
-before its background transaction is created, it establishes a session minimum
-snapshot at a timestamp strictly beyond the local HLC's uncertainty upper
-bound and waits for the local logtail to reach it. The authentication transaction
-then inherits that same minimum and confirms it without holding an admission
-slot during the uncertainty wait. All authentication reads remain in one
-transaction and therefore observe one complete catalog generation.
+This design introduces a generic, linearizable logtail read barrier. The TN
+places a marker in the same FIFO as committed transactions, the existing
+single logtail publisher sends the marker response after all preceding update
+responses, and the CN waits for its normal apply pipeline to reach the exact
+frontier returned by the marker. Authentication is the first consumer, not a
+special implementation path.
 
-## 2. Scope
+## 2. Required Contract
 
-This change covers normal user authentication on a CN, including:
+For one successful call `AcquireLogtailReadBarrier(ctx)` on a CN:
 
-- account existence and suspended/restricted status;
-- user existence, password, lock, and password-expiration metadata;
-- implicit and explicit default-role existence and grants;
-- system variables and an optional login database resolved by the same
-  authentication transaction.
+```text
+commit C completes before barrier B begins
+    => C precedes B in the TN publication order
+    => C's logtail response precedes B's response on the CN stream
+    => B returns only after the local apply pipeline has applied C
+```
+
+The barrier may order a commit concurrent with the call on either side. It must
+not return while a commit that completed before the call remains invisible.
+
+The negations are useful review and test oracles:
+
+- a completed commit remains invisible after a successful barrier;
+- a no-work barrier waits for a fixed clock-uncertainty interval;
+- a barrier response overtakes an earlier update response;
+- cancellation, reconnect, shutdown, or queue pressure leaks a waiter or
+  blocks global logtail publication.
+
+## 3. Scope
+
+The primitive is an optional engine capability. It is suitable for callers
+that need a real-time read boundary without changing the default transaction
+freshness policy. Authentication uses it for all catalog state involved in a
+normal login, including account, user, password, role, grant, system-variable,
+and login-database checks.
 
 This change does not:
 
-- alter the bootstrap-only special-user path, which intentionally does not read
-  catalog authentication state;
-- invalidate privilege state in an already authenticated session; that is the
-  separate active-session lifecycle addressed by PR #27737;
-- change the default ordinary-SQL freshness policy; the freshness-preserving
-  transaction branch only stops discarding an existing caller minimum;
-- add a QueryService command, a cluster membership dependency, or persisted
+- impose a barrier on ordinary transaction creation;
+- add catalog-table or authentication-specific logic to TN or disttae;
+- fan out to every CN or depend on a CN membership snapshot;
+- change transaction isolation or split authentication across snapshots;
+- persist barrier state;
+- change the bootstrap-only special-user path.
+
+## 4. Ordering Proof
+
+The implementation closes four existing ordering stages rather than inventing
+a second replication path.
+
+### 4.1 Commit completion to TN queue order
+
+`OnEndPrepareWAL` admits a transaction into the logtail manager FIFO before the
+transaction can complete. Therefore every commit whose successful response was
+observed before a later barrier request has already entered the FIFO before the
+barrier marker can enter it.
+
+### 4.2 TN queue order to publication frontier
+
+The manager collects transaction logtails in parallel but publishes them in
+FIFO/PrepareTS order. A barrier splits a batch into transaction segments:
+transactions before it are fully published first, the marker then captures
+`previousSaveTS`, and transactions after it are scheduled afterwards. Work
+that cannot contribute to the barrier therefore cannot delay it by competing
+for collection workers.
+
+The returned timestamp is the exact last published frontier. It is not
+`clock.Now()`, an uncertainty estimate, or a timestamp that forces future
+progress.
+
+### 4.3 Publication order to stream response order
+
+TN transaction callbacks and barrier markers enter the same notifier channel.
+The single logtail sender processes that channel in order and enqueues both
+update and barrier responses on the same per-session response queue. A barrier
+response therefore cannot overtake an earlier accepted update response.
+
+Normal publication may omit a response when all table tails in an event are
+irrelevant to one session. Before acknowledging a barrier, the sender therefore
+forces an empty progress update to the exact frontier when that session has not
+already been advanced through it. This is not a synthetic data apply: the
+ordered empty update proves that every relevant earlier update has already
+entered the same response sequence. It also prevents barrier latency from
+depending on the periodic transport-heartbeat interval.
+
+### 4.4 Stream response order to local visibility
+
+The CN receive loop consumes barrier responses internally and correlates them
+by request ID. Receiving the response proves only that prior update responses
+were received in order; application may still be asynchronous. The engine
+therefore waits on the existing timestamp waiter until the local apply frontier
+reaches the returned TN frontier. Only then does the public engine barrier
+return. A forced empty progress update traverses the same per-consumer apply
+queues, so it cannot advance the waiter past an earlier queued table update.
+
+## 5. Authentication Integration
+
+Immediately before constructing the authentication background executor, the
+frontend:
+
+1. invokes the engine's generic logtail read barrier;
+2. monotonically installs the returned frontier as a session minimum;
+3. asks the transaction client to confirm the effective session minimum;
+4. creates one background transaction for every catalog read used by the
+   authentication decision.
+
+The second transaction-client check is normally immediate because the engine
+barrier already waited for local apply. It remains necessary when an upstream
+or reused session already carries a minimum later than the returned frontier.
+The session minimum is never lowered.
+
+A failure is fail-closed. Missing engine/transaction-client capabilities,
+protocol errors, cancellation, stream failure, timestamp-wait failure, or an
+applied timestamp below the required minimum rejects the login.
+
+## 6. Concurrency, Ownership, and Boundedness
+
+- A manager barrier owns one buffered completion channel. Once admitted, TN
+  queue progress never depends on whether its caller is still waiting.
+- Queue admission is context-aware. A canceled producer withdraws its pending
+  count before ownership transfers; shutdown can still drain all admitted
+  items without waiting forever.
+- A CN client owns one pending-map entry per in-flight barrier. Request IDs are
+  monotonic and responses may complete out of order. Return, cancellation,
+  stream breakage, and client closure all remove or abandon the entry without
+  spawning a per-request goroutine.
+- The normal receive goroutine remains the only stream reader. Barrier
+  responses are control messages and are not exposed to the logtail dispatcher.
+- The existing per-session response queue remains bounded. A congested session
+  fails and reconnects instead of blocking the global publisher.
+- Reconnect swaps the concrete logtail client under a dedicated lock. A caller
+  that captured the previous client observes stream closure and fails; it never
+  races an unsynchronized pointer replacement.
+
+## 7. Failure and Restart Semantics
+
+- Cancellation before queue admission admits no marker.
+- Cancellation after admission stops the caller, while the buffered marker
+  completion lets the queue continue independently.
+- TN shutdown rejects new admission and drains already admitted queue work
+  under the existing queue lifecycle.
+- CN stream send or receive failure marks the stream broken. Pending barriers
+  fail and reconnect obtains a new stream; barrier IDs and responses never
+  cross stream generations.
+- A barrier is ephemeral. Restart requires no replay or cleanup of persisted
   state.
+- If an earlier logtail callback cannot transfer ownership to the notifier,
+  the same stream cannot provide a successful ordered barrier response; the
+  operation fails rather than claiming visibility.
 
-## 3. Root Cause
+## 8. Rolling Upgrade Compatibility
 
-With `enable-sacrificing-freshness` enabled, transaction creation uses the
-session's last commit timestamp as its minimum snapshot. A new session has no
-last commit, so its authentication transaction may start at the latest logtail
-already applied on that CN. That timestamp can precede a catalog commit that a
-different CN has already acknowledged to its client.
+The request and response are introduced at `MORPCVersion39`. Deployment keeps
+the active protocol version at the oldest live service. While it is below 39,
+authentication uses the previous HLC-uncertainty fence, which is slower but
+preserves the existing correctness contract. Only a fully upgraded cluster
+sends the new wire messages.
 
-PR #27717 correctly stopped trusting `mo_user.default_role` by itself, but its
-new `mo_user_grant` validation runs inside the same potentially stale
-transaction. It can therefore correctly interpret the wrong catalog generation.
+The fallback and its clock-offset configuration validation remain until the
+old protocol is no longer supported. There is no persisted-data migration.
 
-The violated boundary is real-time authorization ordering:
+## 9. Performance Model
 
-```text
-authorization mutation commits and returns
-    -> a later login begins on any healthy CN
-    -> that login must not authenticate from a pre-mutation catalog generation
-```
+The barrier adds no work to ordinary SQL or the transaction commit path beyond
+recognizing a rare control marker in the existing queue.
 
-## 4. Invariants and Linearization
-
-1. **Freshness:** before creating a normal user's authentication transaction,
-   the session minimum snapshot is advanced to a fence strictly greater than
-   the HLC uncertainty upper bound captured for that login.
-2. **Local application:** the authentication transaction may be created only
-   after the CN's timestamp waiter reports that logtail through the fence has
-   been applied.
-3. **Single generation:** every catalog read used to accept or reject one login
-   uses the same transaction snapshot. A concurrent security mutation belongs
-   either before or after that snapshot; authentication never combines both
-   generations.
-4. **Fail closed:** a missing runtime/clock, invalid clock offset, timestamp
-   overflow, cancellation, timeout, closed transaction client, or stalled
-   logtail rejects the login. No path falls back to the locally applied stale
-   timestamp.
-5. **Monotonic session state:** installing the authentication fence can advance
-   but never lower the session minimum timestamp. SQL executed after login also
-   cannot start behind the catalog generation that authenticated the session.
-6. **Isolation:** bootstrap special users retain their existing catalog-free
-   behavior, and unrelated sessions and CNs share no new mutable state.
-
-The login freshness linearization point is the HLC upper-bound capture. A
-security commit concurrent with that capture may legally appear on either side;
-a security commit whose success was observed before a later login request is
-covered by the clock uncertainty bound and must be visible.
-
-## 5. Chosen Design
-
-Add a small frontend helper that:
-
-1. obtains the service runtime and transaction clock;
-2. captures the clock's uncertainty upper bound;
-3. constructs the smallest physical timestamp strictly greater than every HLC
-   timestamp at that upper-bound physical time;
-4. advances `Session.lastCommitTS` through the existing monotonic update path;
-5. asks the transaction client to wait for local logtail through the effective
-   session minimum before transaction admission.
-
-`AuthenticateUser` calls the helper after the special-user bypass and before
-constructing its background executor. `TxnClient.WaitLogTailAppliedAt` owns the
-pre-admission wait and rejects a missing or regressing applied timestamp. The
-background session then inherits the upstream session's minimum timestamp.
-`TxnClient.New` rechecks that minimum through the same monotonic timestamp
-waiter. In the default sacrificing-freshness mode the fence check is therefore
-immediate while preserving the transaction snapshot contract. The non-default
-freshness-preserving mode retains its existing wait for the later of the current
-clock and the caller minimum.
-
-The configured `max-clock-offset` is the uncertainty bound even when
-`enable-check-clock-offset` is false. The boolean controls only active local
-clock-jump monitoring; it must not erase a timestamp-ordering invariant. Both
-the process launcher and embedded launcher preserve the default 500ms bound,
-reject a negative bound, and pass the monitoring decision separately to the HLC
-constructor. A deployment that disables monitoring still owns the external
-invariant that actual inter-node skew stays within the configured bound.
-
-The transaction client's freshness-preserving branch must choose
-`max(clock.Now(), caller minimum)`. It previously replaced the minimum with
-`clock.Now()`, which would silently discard the authentication fence whenever
-`enable-sacrificing-freshness` was disabled. The default sacrificing-freshness
-branch remains unchanged.
-
-The authentication transaction keeps the configured SI or RC isolation. In
-particular, the repair does not force RC: one fresh SI snapshot is preferable
-to several individually fresh statements because authentication is a compound
-security decision.
-
-Authentication also marks its background transaction creation as
-request-cancellable. The transaction handler continues to use its long-lived
-session context for ordinary statements, but the authentication call to
-`TxnClient.New` derives its context only from the handshake request. The
-handshake deadline is the single timeout owner of both the pre-admission
-timestamp wait and any later admission wait; `createTxnOpTimeout` remains the
-owner for ordinary transaction creation but must not silently shorten a
-connection budget already validated for strict authentication freshness.
-
-The configuration budget follows the complete clock geometry. Let `O` be the
-configured pairwise `max-clock-offset`. Authentication captures a fence at
-`CN-now + O + 1ns`. If that CN is `O` ahead of the TN, the TN progress clock can
-start at `CN-now - O`, so reaching the fence takes almost `2O + 1ns`, not `O`.
-CN startup therefore requires:
+For a barrier caller, cost is:
 
 ```text
-connectTimeout > 2 * max-clock-offset + 1ns
+one bounded request/response on the existing TN logtail stream
+    + publication of transactions already ahead of the marker
+    + actual local apply lag to the returned frontier
 ```
 
-This clock geometry is the only lower bound that a CN can prove from its local
-configuration. Passing it is necessary, but does not guarantee that a login
-finishes within the deadline: client/TLS protocol work, transport delay, the
-configurable TN logtail progress cadence, and application delay all consume the
-remaining budget at runtime. Those inputs are not bounded by a CN configuration
-validator, so attaching fixed reserves would create an unverifiable admission
-policy rather than a safety proof. The request deadline remains the hard
-termination and fail-closed owner. Operators must size it for their topology,
-logtail configuration, and load. The formula and overflow handling live once in
-`pkg/config`; process and embedded launchers delegate to that owner so their
-accepted configuration sets cannot drift.
+When intervening commits contain no table subscribed by the caller, the server
+may add one empty progress response before the barrier response. Its size and
+apply work are constant; it replaces an otherwise unbounded wait for the next
+periodic heartbeat.
 
-## 6. Alternatives Rejected
+There is no fixed sleep, no clock-offset wait, no all-CN fan-out, and no scan of
+catalog tables. In an idle healthy cluster, latency should be network and queue
+scheduling scale rather than the configured 500ms uncertainty interval. Under
+load, the wait reflects real causal work that must become visible.
 
-### Force read committed isolation
+The marker divides manager batches so post-barrier collection does not consume
+workers needed by pre-barrier transactions. Collection and publication for
+normal transaction-only batches retain their previous parallel/ordered shape.
 
-RC advances each statement to the latest timestamp already applied locally. It
-does not teach a lagging CN about a remote commit, so it does not close the
-observed race. It also permits account, user, role, and lock checks from
-different catalog generations.
+## 10. Alternatives Rejected
 
-### Query every CN during every login
+### Remove the authentication wait
 
-Collecting `GetCommit` from all CNs and synchronizing the maximum can provide a
-fence, but adds O(cluster size) RPCs, depends on a membership snapshot, and
-requires a security policy for partial responses. The HLC/logtail mechanism is
-already the transaction layer's freshness primitive and has no fan-out cost.
+This restores low latency by violating the real-time authorization invariant.
+It can authenticate against catalog state older than an already acknowledged
+security mutation.
 
-### Broadcast every authorization commit
+### Use local or current HLC time
 
-Synchronous `SyncCommit` fan-out moves cost to the rarer DCL path, but a remote
-failure occurs after the catalog transaction has irreversibly committed. The
-client would receive an ambiguous error for a successful security mutation,
-and other authentication mutations would still need separate integration.
+A local timestamp does not prove which TN commits have entered publication. A
+future uncertainty timestamp forces idle wall-clock progress and couples
+latency to clock configuration instead of causal logtail work.
+
+### Query or synchronize every CN
+
+The required owner is TN commit/publication order, not the set of current CNs.
+Fan-out adds O(cluster size) work and still needs a policy for membership races
+and partial failures.
+
+### Broadcast every security mutation
+
+This overfits one catalog category, moves coordination to the mutation path,
+and creates ambiguous commit results when broadcast fails after commit. Other
+linearizable-read consumers would still need another mechanism.
 
 ### Disable sacrificed freshness globally
 
-This would impose a logtail freshness wait on every transaction, including TP
-hot paths unrelated to security. The required boundary is login, not all SQL.
+That imposes freshness coordination on unrelated SQL hot paths. The engine
+barrier lets only operations with an explicit real-time contract pay for it.
 
-### Clear the offset when active monitoring is disabled
+## 11. Validation Matrix
 
-Monitoring and uncertainty are different concerns. Clearing the bound makes a
-disabled watchdog equivalent to claiming zero inter-node skew, which invalidates
-the cross-CN ordering proof. Keeping the bound without the watchdog preserves
-correctness under the configured external NTP/PTP assumption.
+White-box tests must establish:
 
-## 7. Failure, Restart, and Compatibility Semantics
+- queue cancellation withdraws pending ownership and shutdown completes;
+- the manager returns the exact published frontier and rejects missing
+  publishers or canceled callers;
+- parallel barrier requests are correlated correctly even when responses
+  arrive out of order;
+- send failure breaks the stream and cancellation removes pending state;
+- an update accepted before a barrier is written before its response;
+- filtered logtails force ordered empty progress instead of waiting for a
+  periodic heartbeat;
+- the engine waits for local apply and rejects missing waiters or regressing
+  timestamps;
+- authentication preserves a later existing session minimum and fails closed
+  on every missing/error capability;
+- protocol 38 uses the correct legacy fallback and protocol 39 uses the new
+  primitive.
 
-- The caller's authentication context is the deadline and cancellation owner
-  of the pre-admission timestamp wait and transaction creation. A failed
-  pre-admission wait creates no operator; the timestamp waiter removes its own
-  entry. A later creation failure uses the existing transaction-client abort
-  path for the unpublished operator.
-- A lagging but healthy CN waits and then authenticates from the complete
-  snapshot. A CN whose logtail cannot reach the fence rejects the login rather
-  than authorizing stale state.
-- Restart creates no recovery work: a new CN establishes a new fence for each
-  login and waits for its own logtail.
-- No wire or persisted format changes are introduced. Rolling upgrades are
-  protocol-compatible; the stronger guarantee applies to logins routed to an
-  upgraded CN and becomes cluster-wide after all serving CNs are upgraded.
-- Retrying a failed login creates a new, monotonic fence. Duplicate attempts do
-  not accumulate state or weaken the boundary.
-- The fence inherits MatrixOne's HLC clock contract. The configured maximum
-  offset is always included; disabling the monitor changes detection only, not
-  the bound. Operators must keep actual skew within that bound.
-- This corrects prior configuration behavior: disabling offset monitoring no
-  longer changes `Clock.MaxOffset()` to zero. The default bound is 500ms and a
-  negative value is rejected during startup. There is no wire or persisted-data
-  compatibility impact, but connection-latency dashboards can show the newly
-  enforced uncertainty wait after rollout.
-- A CN with catalog authentication enabled rejects startup when
-  `cn.frontend.connectTimeout` is not strictly greater than the mathematically
-  necessary pairwise-skew fence above. `skipCheckUser=true` makes the fence
-  unreachable and therefore bypasses only this authentication-specific deadline
-  check; general clock validation remains mandatory. Passing the budget does not
-  certify an operational latency guarantee: the request still fails closed if
-  runtime logtail or network progress consumes the deadline. Duration arithmetic
-  is checked before multiplication/addition. An extreme offset that would
-  overflow the clock budget fails startup instead of wrapping into an accepted
-  negative or small timeout.
-- Embedded `WithPreStart`/`ServiceOperator.Adjust` callbacks run after the
-  configuration file is first validated. `Start` therefore re-applies clock
-  defaulting and validates the adjusted clock/authentication budget before it
-  creates a stopper, file service, listener, or other service-owned resource.
+Black-box validation must cover at least two CNs and both mutation directions:
 
-## 8. Performance Budget
+```text
+CN-A: revoke/suspend/drop/change credential; commit returns
+CN-B: later login must observe the mutation
 
-- Default ordinary SQL transaction creation, compilation, privilege-cache
-  hits, and execution receive no new branch, lock, allocation, RPC, or cache
-  operation.
-- The non-default freshness-preserving transaction branch replaces one
-  assignment with one timestamp comparison so its documented caller-minimum
-  contract is monotonic; the default transaction hot path is unchanged.
-- Each normal login adds one local HLC read and reuses the existing transaction
-  timestamp waiter before opening its authentication transaction; it adds no
-  cluster RPC, goroutine, or new per-login collection.
-- A healthy synchronized deployment normally adds approximately the configured
-  uncertainty interval (500ms by default) to normal-user connection setup. It
-  can be shorter when the applied logtail watermark is already ahead and longer
-  when logtail is delayed; cancellation and the existing timeouts bound broken
-  paths. The cost is intentionally isolated to connection establishment, and
-  connection pooling amortizes it for TP workloads. The wait occurs before
-  transaction admission, so the uncertainty interval does not occupy a
-  `max-active` user-transaction slot.
-- Active clock monitoring has no per-login branch. Disabling it saves only the
-  monitor work and does not trade away the authentication correctness bound.
-- Removing the nested `createTxnOpTimeout` from authentication does not extend a
-  connection beyond `connectTimeout`; it removes an earlier, independently
-  configured deadline. Ordinary transaction creation retains the existing
-  timeout path. The authentication path replaces one timer context with a
-  cheaper cancel-only child context.
-- The built-in timestamp waiter observes transaction-client closure directly
-  during the pre-admission wait, avoiding a derived context and
-  `context.AfterFunc` allocation per login. The public transaction-client API
-  retains its derived-context fallback for legacy waiter implementations.
-- Retaining the bound also gives TN commit-deadline validation and the
-  lockservice orphan-recovery fence their configured skew tolerance. The latter
-  may add the bound to ambiguous-commit recovery, which is an unhappy path; at
-  the 500ms default it does not enlarge the lockservice's existing one-second
-  post-deadline grace. Normal lock acquisition and commit latency do not wait on
-  this fence.
-- No new process-lifetime or per-session collection is introduced.
+CN-A: grant/resume/create/change credential; commit returns
+CN-B: later login must observe the mutation
+```
 
-## 9. Validation Map
-
-| Behavior | Evidence |
-| --- | --- |
-| Fence uses the HLC uncertainty upper bound and dominates its logical range | focused frontend unit test with a deterministic clock |
-| Disabling active clock monitoring retains the configured uncertainty bound in process and embedded launchers | focused clock and launcher-config unit tests |
-| A handshake budget at or below the necessary pairwise clock fence fails during CN configuration, while the first representable value above it is accepted; overflow fails closed | shared config model plus process and embedded config unit tests |
-| `skipCheckUser=true` bypasses only the unreachable authentication deadline check while general clock validation remains active | process and embedded config unit tests through both validation entry points |
-| A public embedded pre-start adjustment cannot bypass clock/authentication validation by changing either a budget value or the operator's immutable service type, and fails before resource creation | focused embedded operator unit tests plus owning-package normal/race suites |
-| Existing larger session minimum is never lowered | focused frontend unit test |
-| Missing runtime/clock/transaction client, invalid offset, timestamp overflow, wait failure, and a returned watermark below the fence fail closed | focused frontend unit tests |
-| Authentication applies the fence before background transaction creation and therefore before user-transaction admission | focused frontend unit test at the executor seam |
-| Both transaction freshness modes preserve a later caller minimum | focused txn-client unit test |
-| Authentication freshness waiting and transaction creation are owned only by the request deadline, ignore a shorter ordinary create timeout, and exit on request cancellation | deterministic frontend deadline/barrier test plus existing txn-client timestamp-waiter tests |
-| Transaction-client close terminates both the built-in close-aware waiter and a legacy waiter without changing public errors | deterministic txn-client barrier test under normal and race modes |
-| Revoke fallback and immediate regrant are visible to new implicit/explicit sessions | existing `revoked_default_role_login` BVT on multi-CN topology |
-| Public authentication behavior remains unchanged on one CN | repeated existing BVT and frontend owning-package tests |
-
-The existing BVT is the exact public reproduction and already contains the
-positive grant, revoke fallback, denied privilege, regrant recovery, implicit
-login, explicit login, and secondary-role control. Adding another SQL case
-would duplicate its fixture and oracles, so this change reuses it unchanged.
-
-## 10. Acceptance Criteria
-
-1. The previously failing multi-CN BVT passes without sleeps, polling, retries,
-   or result weakening.
-2. Authentication cannot continue when the freshness fence cannot be built or
-   reached.
-3. The final diff contains no change to the default
-   sacrificing-freshness ordinary-query hot path and no protocol or
-   persisted-state change. The non-default freshness-preserving path adds only
-   the comparison required to honor a caller-provided minimum timestamp.
-4. Focused and owning-package frontend tests pass in normal and applicable race
-   modes; formatting, vet, build, and diff checks pass for every changed Go
-   package.
-
-## 11. Decision Log
-
-- 2026-08-28: full TN progress-chain analysis showed that logtail publication
-  cadence is configurable and runtime transport/application latency has no
-  finite local bound. The validator therefore enforces only the provable
-  `2O + 1ns` clock lower bound; fixed handshake/logtail reserves were removed so
-  validation does not pretend to guarantee an operational deadline it cannot
-  observe. The connection deadline remains the runtime fail-closed owner.
-- 2026-08-28: request-changes review proved that comparing `connectTimeout` to
-  one `max-clock-offset` admitted two guaranteed-failure configurations. The
-  design now accounts for the `2O` pairwise CN/TN clock geometry and checked
-  arithmetic.
-- 2026-08-28: authentication no longer composes the request deadline with
-  `createTxnOpTimeout`. Two independent timeout owners made the effective budget
-  the smaller value and forced operators to coordinate unrelated settings.
-  Keeping the handshake deadline as the sole owner preserves the public
-  connection bound, simplifies Q2 termination reasoning, and leaves ordinary
-  transactions unchanged.
-- 2026-08-28: process and embedded validation delegate to one `pkg/config`
-  budget function. Duplicating the formula at launcher boundaries would make a
-  later policy correction another cross-launcher consistency risk.
-- 2026-08-28: embedded startup revalidates the adjusted clock/authentication
-  contract because the public pre-start callback intentionally runs after file
-  parsing. Validation occurs before resource creation, so invalid programmatic
-  settings fail without a partial-start cleanup obligation.
-- 2026-08-28: embedded startup validates authentication against the operator's
-  immutable service type and rejects a callback that mutates the config's copy.
-  Otherwise a CN operator could still start as a CN after presenting itself as
-  a TN to the authentication-budget validator.
+The test must route the mutation and login to distinct CNs, avoid sleeps as a
+correctness mechanism, and repeat enough times to exercise stream scheduling.
+Performance validation compares fresh-connection latency on the same binary,
+configuration, host, and warm state. Coverage is not satisfied by a mocked
+frontend-only test; the real TN queue, stream response, CN apply waiter, and
+authentication transaction must all be exercised.

--- a/docs/design/authentication_catalog_freshness.md
+++ b/docs/design/authentication_catalog_freshness.md
@@ -137,14 +137,25 @@ applied timestamp below the required minimum rejects the login.
 ## 6. Concurrency, Ownership, and Boundedness
 
 - A manager barrier owns one buffered completion channel. Once admitted, TN
-  queue progress never depends on whether its caller is still waiting.
+  queue progress never depends on whether its caller is still waiting. The
+  marker, not the canceled caller, retains and eventually releases admission.
 - Queue admission is context-aware. A canceled producer withdraws its pending
   count before ownership transfers; shutdown can still drain all admitted
   items without waiting forever.
-- A CN client owns one pending-map entry per in-flight barrier. Request IDs are
-  monotonic and responses may complete out of order. Return, cancellation,
-  stream breakage, and client closure all remove or abandon the entry without
-  spawning a per-request goroutine.
+- Each CN admits at most 100 concurrent barriers before allocating request IDs
+  and pending-map entries. Additional callers wait context-aware, so connection
+  bursts cannot grow retained correlation state or the stream request queue
+  without bound. Request IDs are monotonic and responses may complete out of
+  order. Return, cancellation, stream breakage, and client closure all remove
+  or abandon the entry without spawning a per-request goroutine.
+- The logtail server admits at most 100 barriers globally across the complete
+  shared publication path. A slot remains owned through TN marker processing,
+  notifier ordering, and response hand-off; shutdown draining releases queued
+  events. The manager independently admits at most 100 markers, equal to one
+  queue batch. Thus authentication load can neither fill the 10,000-entry
+  commit FIFO nor accumulate in the notifier and backpressure ordinary logtail
+  publication. Additional server calls wait before the FIFO and honor their
+  request context.
 - The normal receive goroutine remains the only stream reader. Barrier
   responses are control messages and are not exposed to the logtail dispatcher.
 - The existing per-session response queue remains bounded. A congested session
@@ -182,8 +193,11 @@ old protocol is no longer supported. There is no persisted-data migration.
 
 ## 9. Performance Model
 
-The barrier adds no work to ordinary SQL or the transaction commit path beyond
-recognizing a rare control marker in the existing queue.
+The barrier adds no work to ordinary SQL. The transaction-only manager path
+performs one atomic pending-barrier load and then follows the original
+collection/publication code without scanning or type-asserting the batch twice.
+The generic `SafeQueue.Enqueue` path remains the original direct channel send;
+only the new request-scoped API pays context checks and a cancellation select.
 
 For a barrier caller, cost is:
 
@@ -206,6 +220,9 @@ load, the wait reflects real causal work that must become visible.
 The marker divides manager batches so post-barrier collection does not consume
 workers needed by pre-barrier transactions. Collection and publication for
 normal transaction-only batches retain their previous parallel/ordered shape.
+Adjacent barriers at the same FIFO position share one captured frontier and do
+not create empty collection segments. Admission is concurrency-bounded rather
+than rate-limited, so an uncontended login pays no artificial pacing delay.
 
 ## 10. Alternatives Rejected
 
@@ -243,6 +260,10 @@ barrier lets only operations with an explicit real-time contract pay for it.
 White-box tests must establish:
 
 - queue cancellation withdraws pending ownership and shutdown completes;
+- CN and TN admission bounds stop correlation/FIFO growth, canceled waiters
+  exit, and completed markers make their slots reusable;
+- a caller canceled after TN admission cannot release the marker's slot before
+  the queue has processed that marker;
 - the manager returns the exact published frontier and rejects missing
   publishers or canceled callers;
 - parallel barrier requests are correlated correctly even when responses
@@ -274,3 +295,8 @@ Performance validation compares fresh-connection latency on the same binary,
 configuration, host, and warm state. Coverage is not satisfied by a mocked
 frontend-only test; the real TN queue, stream response, CN apply waiter, and
 authentication transaction must all be exercised.
+
+`TestIssue27834CrossCNAuthenticationReadsLatestCatalog` provides that topology
+cell on the shared two-CN embedded cluster. CN-0 repeatedly changes credentials
+and revokes/grants an explicit role; each committed mutation is immediately
+checked through a fresh connection to CN-1 without retry or sleep.

--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -74,7 +74,8 @@ const (
 	MORPCVersion36     int64 = 36 // prepared JSON comparison execution and exact parameter types
 	MORPCVersion37     int64 = 37 // independent prepared-parameter string source
 	MORPCVersion38     int64 = 38 // session temporary-table connection migration
-	MORPCLatestVersion       = MORPCVersion38
+	MORPCVersion39     int64 = 39 // linearizable TN-ordered logtail read barrier
+	MORPCLatestVersion       = MORPCVersion39
 )
 
 // DefaultLockWaitTimeoutSeconds is shared by the frontend default and by

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -60,6 +60,7 @@ import (
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -80,6 +81,19 @@ func currentProtocolVersion(proc *process.Process) int64 {
 		return defines.MORPCVersion4
 	}
 	return version
+}
+
+func authenticationLogtailReadBarrierSupported(ses *Session) bool {
+	rt := moruntime.ServiceRuntime(ses.GetService())
+	if rt == nil {
+		return false
+	}
+	value, ok := rt.GetGlobalVariables(moruntime.MOProtocolVersion)
+	if !ok {
+		return false
+	}
+	version, ok := value.(int64)
+	return ok && version >= defines.MORPCVersion39
 }
 
 // reusablePlanGenerationSupported reports whether every live service in the
@@ -2306,10 +2320,10 @@ func (ses *Session) skipAuthForSpecialUser() bool {
 	return false
 }
 
-// advanceAuthenticationSnapshot installs a session minimum timestamp that is
-// strictly beyond the clock uncertainty window captured for this login. The
-// authentication background transaction inherits this timestamp and waits for
-// the local logtail before reading security catalog state.
+// advanceAuthenticationSnapshot is the rolling-upgrade fallback for services
+// predating the TN-ordered logtail read barrier. It is correct but may wait for
+// the full clock uncertainty interval, so new clusters use the generic engine
+// barrier in prepareAuthenticationSnapshot instead.
 func (ses *Session) advanceAuthenticationSnapshot(ctx context.Context) error {
 	rt := moruntime.ServiceRuntime(ses.GetService())
 	if rt == nil {
@@ -2337,23 +2351,35 @@ func (ses *Session) advanceAuthenticationSnapshot(ctx context.Context) error {
 	return nil
 }
 
-// prepareAuthenticationSnapshot installs the authentication fence and waits
-// for the local logtail before creating the user transaction. Waiting outside
-// TxnClient.New keeps the uncertainty interval from consuming a user-transaction
-// admission slot. The transaction still inherits the same session minimum, so
-// the default sacrificing-freshness path confirms it immediately and preserves
-// the snapshot contract. Freshness-preserving mode retains its existing wait for
-// the later of the current clock and this minimum.
+// prepareAuthenticationSnapshot installs a session snapshot minimum only after
+// a generic TN publication barrier has reached this CN's normal apply pipeline.
+// The protocol gate preserves correctness during rolling upgrades by falling
+// back to the legacy HLC uncertainty fence until every service supports the
+// barrier wire contract.
 func (ses *Session) prepareAuthenticationSnapshot(ctx context.Context) error {
-	if err := ses.advanceAuthenticationSnapshot(ctx); err != nil {
-		return err
-	}
-
-	minimum := ses.getLastCommitTS()
 	pu := getPuIfPresent(ses.GetService())
 	if pu == nil || pu.TxnClient == nil {
 		return moerr.NewInternalError(ctx, "missing transaction client for authentication snapshot")
 	}
+
+	if authenticationLogtailReadBarrierSupported(ses) {
+		if pu.StorageEngine == nil {
+			return moerr.NewInternalError(ctx, "missing storage engine for authentication snapshot")
+		}
+		barrier, ok := pu.StorageEngine.(engine.LogtailReadBarrier)
+		if !ok {
+			return moerr.NewInternalError(ctx, "storage engine does not support logtail read barrier")
+		}
+		frontier, err := barrier.AcquireLogtailReadBarrier(ctx)
+		if err != nil {
+			return err
+		}
+		ses.updateLastCommitTS(frontier)
+	} else if err := ses.advanceAuthenticationSnapshot(ctx); err != nil {
+		return err
+	}
+
+	minimum := ses.getLastCommitTS()
 	applied, err := pu.TxnClient.WaitLogTailAppliedAt(ctx, minimum)
 	if err != nil {
 		return err

--- a/pkg/frontend/session_authenticate_test.go
+++ b/pkg/frontend/session_authenticate_test.go
@@ -26,11 +26,28 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	mo_config "github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
+
+type authenticationBarrierEngine struct {
+	engine.Engine
+	acquire func(context.Context) (timestamp.Timestamp, error)
+}
+
+type unsupportedAuthenticationBarrierEngine struct {
+	engine.Engine
+}
+
+func (e *authenticationBarrierEngine) AcquireLogtailReadBarrier(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
+	return e.acquire(ctx)
+}
 
 func newAuthenticationSnapshotTestSession(
 	t *testing.T,
@@ -49,6 +66,7 @@ func newAuthenticationSnapshotTestSession(
 		)),
 	)
 	moruntime.SetupServiceBasedRuntime(service, rt)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion38)
 	InitServerLevelVars(service)
 	return &Session{feSessionImpl: feSessionImpl{service: service}}
 }
@@ -172,6 +190,96 @@ func TestPrepareAuthenticationSnapshotFailsClosed(t *testing.T) {
 	})
 }
 
+func TestPrepareAuthenticationSnapshotUsesTNOrderedBarrier(t *testing.T) {
+	ses := newAuthenticationSnapshotTestSession(t, 100, 20*time.Nanosecond)
+	rt := moruntime.ServiceRuntime(ses.GetService())
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion39)
+
+	barrierFrontier := timestamp.Timestamp{PhysicalTime: 80, LogicalTime: 9}
+	ctrl := gomock.NewController(t)
+	txnClient := mock_frontend.NewMockTxnClient(ctrl)
+	txnClient.EXPECT().WaitLogTailAppliedAt(gomock.Any(), barrierFrontier).
+		Return(barrierFrontier.Next(), nil)
+	setPu(ses.GetService(), &mo_config.ParameterUnit{
+		TxnClient: txnClient,
+		StorageEngine: &authenticationBarrierEngine{acquire: func(context.Context) (
+			timestamp.Timestamp, error,
+		) {
+			return barrierFrontier, nil
+		}},
+	})
+
+	require.NoError(t, ses.prepareAuthenticationSnapshot(t.Context()))
+	require.Equal(t, barrierFrontier, ses.getLastCommitTS())
+}
+
+func TestPrepareAuthenticationSnapshotBarrierPreservesLaterSessionMinimum(t *testing.T) {
+	ses := newAuthenticationSnapshotTestSession(t, 100, 20*time.Nanosecond)
+	moruntime.ServiceRuntime(ses.GetService()).SetGlobalVariables(
+		moruntime.MOProtocolVersion, defines.MORPCVersion39)
+	barrierFrontier := timestamp.Timestamp{PhysicalTime: 80, LogicalTime: 9}
+	wantMinimum := timestamp.Timestamp{PhysicalTime: 200, LogicalTime: 7}
+	ses.lastCommitTS = wantMinimum
+
+	ctrl := gomock.NewController(t)
+	txnClient := mock_frontend.NewMockTxnClient(ctrl)
+	txnClient.EXPECT().WaitLogTailAppliedAt(gomock.Any(), wantMinimum).
+		Return(wantMinimum.Next(), nil)
+	setPu(ses.GetService(), &mo_config.ParameterUnit{
+		TxnClient: txnClient,
+		StorageEngine: &authenticationBarrierEngine{acquire: func(context.Context) (
+			timestamp.Timestamp, error,
+		) {
+			return barrierFrontier, nil
+		}},
+	})
+
+	require.NoError(t, ses.prepareAuthenticationSnapshot(t.Context()))
+	require.Equal(t, wantMinimum, ses.getLastCommitTS())
+}
+
+func TestPrepareAuthenticationSnapshotBarrierFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		engine  engine.Engine
+		wantErr string
+	}{
+		{name: "missing engine", wantErr: "missing storage engine"},
+		{name: "unsupported engine", engine: &unsupportedAuthenticationBarrierEngine{}, wantErr: "does not support"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ses := newAuthenticationSnapshotTestSession(t, 100, 20*time.Nanosecond)
+			moruntime.ServiceRuntime(ses.GetService()).SetGlobalVariables(
+				moruntime.MOProtocolVersion, defines.MORPCVersion39)
+			ctrl := gomock.NewController(t)
+			setPu(ses.GetService(), &mo_config.ParameterUnit{
+				TxnClient:     mock_frontend.NewMockTxnClient(ctrl),
+				StorageEngine: test.engine,
+			})
+			require.ErrorContains(t, ses.prepareAuthenticationSnapshot(t.Context()), test.wantErr)
+			require.True(t, ses.getLastCommitTS().IsEmpty())
+		})
+	}
+
+	t.Run("barrier failure", func(t *testing.T) {
+		ses := newAuthenticationSnapshotTestSession(t, 100, 20*time.Nanosecond)
+		moruntime.ServiceRuntime(ses.GetService()).SetGlobalVariables(
+			moruntime.MOProtocolVersion, defines.MORPCVersion39)
+		ctrl := gomock.NewController(t)
+		wantErr := moerr.NewInternalErrorNoCtx("barrier unavailable")
+		setPu(ses.GetService(), &mo_config.ParameterUnit{
+			TxnClient: mock_frontend.NewMockTxnClient(ctrl),
+			StorageEngine: &authenticationBarrierEngine{acquire: func(context.Context) (
+				timestamp.Timestamp, error,
+			) {
+				return timestamp.Timestamp{}, wantErr
+			}},
+		})
+		require.ErrorIs(t, ses.prepareAuthenticationSnapshot(t.Context()), wantErr)
+		require.True(t, ses.getLastCommitTS().IsEmpty())
+	})
+}
+
 func TestPrepareAuthenticationSnapshotWaitsForEffectiveSessionMinimum(t *testing.T) {
 	ses := newAuthenticationSnapshotTestSession(t, 100, 20*time.Nanosecond)
 	wantMinimum := timestamp.Timestamp{PhysicalTime: 200, LogicalTime: 7}
@@ -223,7 +331,7 @@ func TestPrepareAuthenticationSnapshotHonorsRequestCancellation(t *testing.T) {
 	}
 }
 
-func TestAuthenticateUserAdvancesSnapshotBeforeBackgroundTransaction(t *testing.T) {
+func TestAuthenticateUserWaitsForLogtailBarrierBeforeBackgroundTransaction(t *testing.T) {
 	const physicalTime = int64(100)
 	const maxOffset = 20 * time.Nanosecond
 	service := "authenticate-snapshot-integration"
@@ -237,17 +345,28 @@ func TestAuthenticateUserAdvancesSnapshotBeforeBackgroundTransaction(t *testing.
 		)),
 	)
 	moruntime.SetupServiceBasedRuntime(service, rt)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion39)
 	InitServerLevelVars(service)
 	ctrl := gomock.NewController(t)
 	txnClient := mock_frontend.NewMockTxnClient(ctrl)
-	wantMinimum := timestamp.Timestamp{PhysicalTime: 121}
+	wantMinimum := timestamp.Timestamp{PhysicalTime: 80, LogicalTime: 7}
+	barrierCompleted := false
 	waitCompleted := false
 	txnClient.EXPECT().WaitLogTailAppliedAt(gomock.Any(), wantMinimum).
 		DoAndReturn(func(context.Context, timestamp.Timestamp) (timestamp.Timestamp, error) {
+			require.True(t, barrierCompleted)
 			waitCompleted = true
 			return wantMinimum.Next(), nil
 		})
-	setPu(service, &mo_config.ParameterUnit{TxnClient: txnClient})
+	setPu(service, &mo_config.ParameterUnit{
+		TxnClient: txnClient,
+		StorageEngine: &authenticationBarrierEngine{acquire: func(context.Context) (
+			timestamp.Timestamp, error,
+		) {
+			barrierCompleted = true
+			return wantMinimum, nil
+		}},
+	})
 
 	ses := &Session{
 		feSessionImpl: feSessionImpl{service: service},

--- a/pkg/pb/logtail/logtail.pb.go
+++ b/pkg/pb/logtail/logtail.pb.go
@@ -122,6 +122,56 @@ func (m *UnsubscribeRequest) GetTable() *api.TableID {
 	return nil
 }
 
+// ReadBarrierRequest asks the TN logtail publisher for a linearizable
+// publication frontier. barrier_id is scoped to one stream and correlates the
+// asynchronous response with its caller.
+type ReadBarrierRequest struct {
+	BarrierId            uint64   `protobuf:"varint,1,opt,name=barrier_id,json=barrierId,proto3" json:"barrier_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ReadBarrierRequest) Reset()         { *m = ReadBarrierRequest{} }
+func (m *ReadBarrierRequest) String() string { return proto.CompactTextString(m) }
+func (*ReadBarrierRequest) ProtoMessage()    {}
+func (*ReadBarrierRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3604137dacc8e6bf, []int{2}
+}
+func (m *ReadBarrierRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ReadBarrierRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ReadBarrierRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ReadBarrierRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadBarrierRequest.Merge(m, src)
+}
+func (m *ReadBarrierRequest) XXX_Size() int {
+	return m.ProtoSize()
+}
+func (m *ReadBarrierRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ReadBarrierRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ReadBarrierRequest proto.InternalMessageInfo
+
+func (m *ReadBarrierRequest) GetBarrierId() uint64 {
+	if m != nil {
+		return m.BarrierId
+	}
+	return 0
+}
+
 // TableLogtail describes total or additional logtail for a table.
 type TableLogtail struct {
 	CkpLocation          string               `protobuf:"bytes,1,opt,name=ckp_location,json=ckpLocation,proto3" json:"ckp_location,omitempty"`
@@ -137,7 +187,7 @@ func (m *TableLogtail) Reset()         { *m = TableLogtail{} }
 func (m *TableLogtail) String() string { return proto.CompactTextString(m) }
 func (*TableLogtail) ProtoMessage()    {}
 func (*TableLogtail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{2}
+	return fileDescriptor_3604137dacc8e6bf, []int{3}
 }
 func (m *TableLogtail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -209,7 +259,7 @@ func (m *Status) Reset()         { *m = Status{} }
 func (m *Status) String() string { return proto.CompactTextString(m) }
 func (*Status) ProtoMessage()    {}
 func (*Status) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{3}
+	return fileDescriptor_3604137dacc8e6bf, []int{4}
 }
 func (m *Status) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -265,7 +315,7 @@ func (m *ErrorResponse) Reset()         { *m = ErrorResponse{} }
 func (m *ErrorResponse) String() string { return proto.CompactTextString(m) }
 func (*ErrorResponse) ProtoMessage()    {}
 func (*ErrorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{4}
+	return fileDescriptor_3604137dacc8e6bf, []int{5}
 }
 func (m *ErrorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -322,7 +372,7 @@ func (m *SubscribeResponse) Reset()         { *m = SubscribeResponse{} }
 func (m *SubscribeResponse) String() string { return proto.CompactTextString(m) }
 func (*SubscribeResponse) ProtoMessage()    {}
 func (*SubscribeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{5}
+	return fileDescriptor_3604137dacc8e6bf, []int{6}
 }
 func (m *SubscribeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -375,7 +425,7 @@ func (m *UpdateResponse) Reset()         { *m = UpdateResponse{} }
 func (m *UpdateResponse) String() string { return proto.CompactTextString(m) }
 func (*UpdateResponse) ProtoMessage()    {}
 func (*UpdateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{6}
+	return fileDescriptor_3604137dacc8e6bf, []int{7}
 }
 func (m *UpdateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -437,7 +487,7 @@ func (m *UnSubscribeResponse) Reset()         { *m = UnSubscribeResponse{} }
 func (m *UnSubscribeResponse) String() string { return proto.CompactTextString(m) }
 func (*UnSubscribeResponse) ProtoMessage()    {}
 func (*UnSubscribeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{7}
+	return fileDescriptor_3604137dacc8e6bf, []int{8}
 }
 func (m *UnSubscribeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -473,12 +523,71 @@ func (m *UnSubscribeResponse) GetTable() *api.TableID {
 	return nil
 }
 
+// ReadBarrierResponse is sent only after every logtail event ordered before
+// the corresponding request has been admitted to this stream's response
+// sequence. The CN must still wait until it has applied this timestamp.
+type ReadBarrierResponse struct {
+	BarrierId            uint64               `protobuf:"varint,1,opt,name=barrier_id,json=barrierId,proto3" json:"barrier_id,omitempty"`
+	Timestamp            *timestamp.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
+	XXX_unrecognized     []byte               `json:"-"`
+	XXX_sizecache        int32                `json:"-"`
+}
+
+func (m *ReadBarrierResponse) Reset()         { *m = ReadBarrierResponse{} }
+func (m *ReadBarrierResponse) String() string { return proto.CompactTextString(m) }
+func (*ReadBarrierResponse) ProtoMessage()    {}
+func (*ReadBarrierResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3604137dacc8e6bf, []int{9}
+}
+func (m *ReadBarrierResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ReadBarrierResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ReadBarrierResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ReadBarrierResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadBarrierResponse.Merge(m, src)
+}
+func (m *ReadBarrierResponse) XXX_Size() int {
+	return m.ProtoSize()
+}
+func (m *ReadBarrierResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ReadBarrierResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ReadBarrierResponse proto.InternalMessageInfo
+
+func (m *ReadBarrierResponse) GetBarrierId() uint64 {
+	if m != nil {
+		return m.BarrierId
+	}
+	return 0
+}
+
+func (m *ReadBarrierResponse) GetTimestamp() *timestamp.Timestamp {
+	if m != nil {
+		return m.Timestamp
+	}
+	return nil
+}
+
 // logtail stream request
 type LogtailRequest struct {
 	RequestId uint64 `protobuf:"varint,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
 	// Types that are valid to be assigned to Request:
 	//	*LogtailRequest_SubscribeTable
 	//	*LogtailRequest_UnsubscribeTable
+	//	*LogtailRequest_ReadBarrier
 	Request              isLogtailRequest_Request `protobuf_oneof:"request"`
 	XXX_NoUnkeyedLiteral struct{}                 `json:"-"`
 	XXX_unrecognized     []byte                   `json:"-"`
@@ -489,7 +598,7 @@ func (m *LogtailRequest) Reset()         { *m = LogtailRequest{} }
 func (m *LogtailRequest) String() string { return proto.CompactTextString(m) }
 func (*LogtailRequest) ProtoMessage()    {}
 func (*LogtailRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{8}
+	return fileDescriptor_3604137dacc8e6bf, []int{10}
 }
 func (m *LogtailRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -530,9 +639,13 @@ type LogtailRequest_SubscribeTable struct {
 type LogtailRequest_UnsubscribeTable struct {
 	UnsubscribeTable *UnsubscribeRequest `protobuf:"bytes,3,opt,name=unsubscribe_table,json=unsubscribeTable,proto3,oneof" json:"unsubscribe_table,omitempty"`
 }
+type LogtailRequest_ReadBarrier struct {
+	ReadBarrier *ReadBarrierRequest `protobuf:"bytes,4,opt,name=read_barrier,json=readBarrier,proto3,oneof" json:"read_barrier,omitempty"`
+}
 
 func (*LogtailRequest_SubscribeTable) isLogtailRequest_Request()   {}
 func (*LogtailRequest_UnsubscribeTable) isLogtailRequest_Request() {}
+func (*LogtailRequest_ReadBarrier) isLogtailRequest_Request()      {}
 
 func (m *LogtailRequest) GetRequest() isLogtailRequest_Request {
 	if m != nil {
@@ -562,11 +675,19 @@ func (m *LogtailRequest) GetUnsubscribeTable() *UnsubscribeRequest {
 	return nil
 }
 
+func (m *LogtailRequest) GetReadBarrier() *ReadBarrierRequest {
+	if x, ok := m.GetRequest().(*LogtailRequest_ReadBarrier); ok {
+		return x.ReadBarrier
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*LogtailRequest) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
 		(*LogtailRequest_SubscribeTable)(nil),
 		(*LogtailRequest_UnsubscribeTable)(nil),
+		(*LogtailRequest_ReadBarrier)(nil),
 	}
 }
 
@@ -578,6 +699,7 @@ type LogtailResponse struct {
 	//	*LogtailResponse_UnsubscribeResponse
 	//	*LogtailResponse_UpdateResponse
 	//	*LogtailResponse_Error
+	//	*LogtailResponse_ReadBarrierResponse
 	Response             isLogtailResponse_Response `protobuf_oneof:"response"`
 	XXX_NoUnkeyedLiteral struct{}                   `json:"-"`
 	XXX_unrecognized     []byte                     `json:"-"`
@@ -588,7 +710,7 @@ func (m *LogtailResponse) Reset()         { *m = LogtailResponse{} }
 func (m *LogtailResponse) String() string { return proto.CompactTextString(m) }
 func (*LogtailResponse) ProtoMessage()    {}
 func (*LogtailResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{9}
+	return fileDescriptor_3604137dacc8e6bf, []int{11}
 }
 func (m *LogtailResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -635,11 +757,15 @@ type LogtailResponse_UpdateResponse struct {
 type LogtailResponse_Error struct {
 	Error *ErrorResponse `protobuf:"bytes,5,opt,name=error,proto3,oneof" json:"error,omitempty"`
 }
+type LogtailResponse_ReadBarrierResponse struct {
+	ReadBarrierResponse *ReadBarrierResponse `protobuf:"bytes,6,opt,name=read_barrier_response,json=readBarrierResponse,proto3,oneof" json:"read_barrier_response,omitempty"`
+}
 
 func (*LogtailResponse_SubscribeResponse) isLogtailResponse_Response()   {}
 func (*LogtailResponse_UnsubscribeResponse) isLogtailResponse_Response() {}
 func (*LogtailResponse_UpdateResponse) isLogtailResponse_Response()      {}
 func (*LogtailResponse_Error) isLogtailResponse_Response()               {}
+func (*LogtailResponse_ReadBarrierResponse) isLogtailResponse_Response() {}
 
 func (m *LogtailResponse) GetResponse() isLogtailResponse_Response {
 	if m != nil {
@@ -683,6 +809,13 @@ func (m *LogtailResponse) GetError() *ErrorResponse {
 	return nil
 }
 
+func (m *LogtailResponse) GetReadBarrierResponse() *ReadBarrierResponse {
+	if x, ok := m.GetResponse().(*LogtailResponse_ReadBarrierResponse); ok {
+		return x.ReadBarrierResponse
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*LogtailResponse) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
@@ -690,6 +823,7 @@ func (*LogtailResponse) XXX_OneofWrappers() []interface{} {
 		(*LogtailResponse_UnsubscribeResponse)(nil),
 		(*LogtailResponse_UpdateResponse)(nil),
 		(*LogtailResponse_Error)(nil),
+		(*LogtailResponse_ReadBarrierResponse)(nil),
 	}
 }
 
@@ -709,7 +843,7 @@ func (m *MessageSegment) Reset()         { *m = MessageSegment{} }
 func (m *MessageSegment) String() string { return proto.CompactTextString(m) }
 func (*MessageSegment) ProtoMessage()    {}
 func (*MessageSegment) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3604137dacc8e6bf, []int{10}
+	return fileDescriptor_3604137dacc8e6bf, []int{12}
 }
 func (m *MessageSegment) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -776,12 +910,14 @@ func (m *MessageSegment) GetPayload() []byte {
 func init() {
 	proto.RegisterType((*SubscribeRequest)(nil), "logtail.SubscribeRequest")
 	proto.RegisterType((*UnsubscribeRequest)(nil), "logtail.UnsubscribeRequest")
+	proto.RegisterType((*ReadBarrierRequest)(nil), "logtail.ReadBarrierRequest")
 	proto.RegisterType((*TableLogtail)(nil), "logtail.TableLogtail")
 	proto.RegisterType((*Status)(nil), "logtail.Status")
 	proto.RegisterType((*ErrorResponse)(nil), "logtail.ErrorResponse")
 	proto.RegisterType((*SubscribeResponse)(nil), "logtail.SubscribeResponse")
 	proto.RegisterType((*UpdateResponse)(nil), "logtail.UpdateResponse")
 	proto.RegisterType((*UnSubscribeResponse)(nil), "logtail.UnSubscribeResponse")
+	proto.RegisterType((*ReadBarrierResponse)(nil), "logtail.ReadBarrierResponse")
 	proto.RegisterType((*LogtailRequest)(nil), "logtail.LogtailRequest")
 	proto.RegisterType((*LogtailResponse)(nil), "logtail.LogtailResponse")
 	proto.RegisterType((*MessageSegment)(nil), "logtail.MessageSegment")
@@ -790,53 +926,58 @@ func init() {
 func init() { proto.RegisterFile("logtail.proto", fileDescriptor_3604137dacc8e6bf) }
 
 var fileDescriptor_3604137dacc8e6bf = []byte{
-	// 734 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x55, 0x4f, 0x4f, 0xdb, 0x4a,
-	0x10, 0x8f, 0x43, 0x42, 0xc8, 0x24, 0x24, 0xb0, 0xf0, 0xde, 0xcb, 0xcb, 0x7b, 0x0d, 0xd4, 0xea,
-	0x21, 0x87, 0x92, 0x20, 0xaa, 0xa2, 0xf6, 0xd2, 0x43, 0x04, 0x55, 0x42, 0x41, 0x6a, 0x37, 0xe1,
-	0xd2, 0x4b, 0xb4, 0x76, 0xb6, 0xae, 0x45, 0xec, 0x75, 0xbd, 0x6b, 0x09, 0xfa, 0x69, 0x38, 0x55,
-	0xea, 0x37, 0xe1, 0xd0, 0x43, 0xd5, 0x0f, 0x50, 0x55, 0xf4, 0x8b, 0x54, 0xd9, 0x5d, 0xff, 0x09,
-	0x01, 0x54, 0xf5, 0x36, 0x33, 0x3b, 0xf3, 0x9b, 0xfd, 0xfd, 0x66, 0xd6, 0x86, 0xd5, 0x29, 0x73,
-	0x04, 0x71, 0xa7, 0x9d, 0x20, 0x64, 0x82, 0xa1, 0x92, 0x76, 0x9b, 0x3b, 0x8e, 0x2b, 0xde, 0x47,
-	0x56, 0xc7, 0x66, 0x5e, 0xd7, 0x61, 0x0e, 0xeb, 0xca, 0x73, 0x2b, 0x7a, 0x27, 0x3d, 0xe9, 0x48,
-	0x4b, 0xd5, 0x35, 0xeb, 0xc2, 0xf5, 0x28, 0x17, 0xc4, 0x0b, 0x74, 0xa0, 0x4c, 0x02, 0x57, 0x99,
-	0xe6, 0x3e, 0xac, 0x0d, 0x23, 0x8b, 0xdb, 0xa1, 0x6b, 0x51, 0x4c, 0x3f, 0x44, 0x94, 0x0b, 0x64,
-	0x42, 0x51, 0x10, 0x6b, 0x4a, 0x1b, 0xc6, 0xb6, 0xd1, 0xae, 0xec, 0x55, 0x3b, 0xb3, 0xf4, 0xd1,
-	0x2c, 0x32, 0x38, 0xc0, 0xea, 0xc8, 0x7c, 0x06, 0xe8, 0xd4, 0xe7, 0x7f, 0x52, 0xf9, 0xd9, 0x80,
-	0xaa, 0x0c, 0x1d, 0x2b, 0x36, 0xe8, 0x21, 0x54, 0xed, 0xb3, 0x60, 0x3c, 0x65, 0x36, 0x11, 0x2e,
-	0xf3, 0x65, 0x6d, 0x19, 0x57, 0xec, 0xb3, 0xe0, 0x58, 0x87, 0xd0, 0x23, 0xc8, 0x0b, 0xde, 0xc8,
-	0x4b, 0xd0, 0xcd, 0x4e, 0x4a, 0x67, 0x14, 0x5b, 0x38, 0x2f, 0x78, 0xda, 0x7d, 0xe9, 0xce, 0xee,
-	0xe8, 0x31, 0xac, 0xd8, 0xcc, 0xf3, 0x88, 0x3f, 0xe1, 0x8d, 0xc2, 0xf6, 0x52, 0xbb, 0xb2, 0x07,
-	0x32, 0xed, 0xd0, 0x17, 0xe1, 0x45, 0xaf, 0x70, 0xf5, 0x7d, 0x2b, 0x87, 0x93, 0x0c, 0x73, 0x1f,
-	0x96, 0x87, 0x82, 0x88, 0x88, 0x23, 0x04, 0x05, 0x9b, 0x4d, 0x14, 0xb1, 0x55, 0x2c, 0x6d, 0xd4,
-	0x80, 0x92, 0x47, 0x39, 0x27, 0x0e, 0x95, 0x57, 0x2b, 0xe3, 0xd8, 0x35, 0x2d, 0x58, 0x3d, 0x0c,
-	0x43, 0x16, 0x62, 0xca, 0x03, 0xe6, 0x73, 0x8a, 0x76, 0x60, 0x99, 0x4b, 0x20, 0xad, 0x4c, 0xbd,
-	0x13, 0x8f, 0x56, 0xe1, 0xeb, 0xce, 0x3a, 0x29, 0x65, 0x92, 0xbf, 0x5b, 0xc7, 0x23, 0x58, 0xcf,
-	0x4c, 0x4e, 0xf7, 0x79, 0x0a, 0xf1, 0x92, 0xe8, 0x46, 0x7f, 0x25, 0x8d, 0xb2, 0x9a, 0xeb, 0x76,
-	0x71, 0xae, 0x79, 0x69, 0x40, 0xed, 0x34, 0x98, 0x10, 0x91, 0x22, 0xb5, 0xa1, 0xf0, 0x32, 0x64,
-	0x9e, 0x86, 0xb9, 0x5d, 0x74, 0x99, 0x31, 0x1b, 0xce, 0x88, 0xdd, 0x3f, 0x9c, 0x11, 0x43, 0x2f,
-	0xa0, 0xaa, 0xbb, 0x8d, 0xa7, 0x2e, 0x17, 0x8d, 0x25, 0x29, 0xfe, 0xbd, 0xd7, 0xab, 0xe8, 0xb3,
-	0x63, 0x97, 0x0b, 0xf3, 0x39, 0x6c, 0x9c, 0xfa, 0x8b, 0x84, 0x7f, 0x67, 0xe3, 0xbe, 0x18, 0x50,
-	0xd3, 0xc8, 0xf1, 0xa2, 0x3e, 0x00, 0x08, 0x95, 0x39, 0x76, 0x27, 0xb2, 0xb6, 0x80, 0xcb, 0x3a,
-	0x32, 0x98, 0xa0, 0x03, 0xa8, 0x27, 0xbb, 0x3d, 0xce, 0x4e, 0xe2, 0xdf, 0x74, 0x6e, 0x37, 0x76,
-	0xbf, 0x9f, 0xc3, 0xb5, 0xa4, 0x46, 0x5e, 0x00, 0x1d, 0xc1, 0x7a, 0xe4, 0xdf, 0xc4, 0x51, 0xbb,
-	0xf9, 0x5f, 0x82, 0xb3, 0xf8, 0x8a, 0xfa, 0x39, 0xbc, 0x96, 0xa9, 0x93, 0x58, 0xbd, 0x32, 0x94,
-	0xf4, 0xf5, 0xcc, 0x6f, 0x79, 0xa8, 0x27, 0x74, 0xb4, 0x0c, 0x5b, 0x50, 0x09, 0xb5, 0x9d, 0x12,
-	0x82, 0x38, 0x34, 0x98, 0xa0, 0x57, 0x80, 0xd2, 0x9b, 0xc4, 0x71, 0x4d, 0xaa, 0x79, 0x1b, 0x29,
-	0x95, 0xd1, 0xcf, 0xe1, 0x75, 0xbe, 0x20, 0xfa, 0x1b, 0xd8, 0xcc, 0x12, 0x4b, 0xe0, 0x14, 0xb7,
-	0xff, 0x33, 0xdc, 0x6e, 0x03, 0xdc, 0x88, 0xfc, 0x45, 0xc8, 0x1e, 0xd4, 0x23, 0xb9, 0x80, 0x29,
-	0x5a, 0x41, 0xa2, 0xfd, 0x93, 0xa2, 0xcd, 0x2d, 0xe8, 0x4c, 0xef, 0x68, 0x7e, 0x65, 0x3b, 0x50,
-	0xa4, 0xb3, 0x57, 0xd7, 0x28, 0xca, 0xca, 0xbf, 0x93, 0xca, 0xb9, 0xb7, 0xd8, 0xcf, 0x61, 0x95,
-	0xd6, 0x03, 0x58, 0x89, 0x9b, 0x99, 0x9f, 0x0c, 0xa8, 0x9d, 0xa8, 0xd7, 0x3b, 0xa4, 0x8e, 0x47,
-	0x7d, 0x81, 0x9a, 0xb0, 0x32, 0x14, 0x21, 0x25, 0xde, 0xe0, 0x40, 0x0b, 0x9a, 0xf8, 0x68, 0x1b,
-	0x2a, 0x71, 0xb6, 0xfb, 0x51, 0xe9, 0x58, 0xc4, 0xd9, 0x90, 0xac, 0x9e, 0x0d, 0xcc, 0xb7, 0x95,
-	0x2e, 0x45, 0x9c, 0xf8, 0xb2, 0x9a, 0x9c, 0x27, 0xc7, 0x05, 0x5d, 0x9d, 0x86, 0x66, 0x9f, 0x96,
-	0xd7, 0xe4, 0x62, 0xca, 0xc8, 0x44, 0x92, 0xa9, 0xe2, 0xd8, 0xdd, 0x3b, 0x81, 0x52, 0xfc, 0xe1,
-	0xec, 0xa5, 0x66, 0xaa, 0xd2, 0xfc, 0xa2, 0x37, 0x1b, 0x8b, 0x07, 0x9a, 0x71, 0xae, 0x6d, 0xec,
-	0x1a, 0xbd, 0xde, 0xd5, 0x75, 0xcb, 0xf8, 0x7a, 0xdd, 0x32, 0x7e, 0x5c, 0xb7, 0x72, 0x97, 0x3f,
-	0x5b, 0xc6, 0xdb, 0xdd, 0xcc, 0xcf, 0xc5, 0x23, 0x22, 0x74, 0xcf, 0x59, 0xe8, 0x3a, 0xae, 0x1f,
-	0x3b, 0x3e, 0xed, 0x06, 0x67, 0x4e, 0x37, 0xb0, 0xba, 0x1a, 0xd9, 0x5a, 0x96, 0xbf, 0x92, 0x27,
-	0xbf, 0x02, 0x00, 0x00, 0xff, 0xff, 0xbd, 0xae, 0x7f, 0xca, 0xaf, 0x06, 0x00, 0x00,
+	// 815 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x55, 0xcd, 0x6e, 0xdb, 0x46,
+	0x10, 0x26, 0x65, 0xc9, 0xb6, 0x46, 0xb2, 0x15, 0xaf, 0x93, 0x96, 0x55, 0x5b, 0xc7, 0x25, 0x7a,
+	0xf0, 0xa1, 0x91, 0x02, 0x07, 0x0d, 0xda, 0x4b, 0x51, 0x10, 0x4e, 0x21, 0xa5, 0x0e, 0xd0, 0xae,
+	0xe4, 0x4b, 0x2f, 0xc2, 0x92, 0xdc, 0x32, 0x84, 0x45, 0x2e, 0xbb, 0xbb, 0x04, 0x92, 0x3e, 0x44,
+	0x9f, 0x21, 0xa7, 0x00, 0x7d, 0x93, 0x1c, 0xfb, 0x04, 0x45, 0xe1, 0xbe, 0x48, 0xc1, 0xdd, 0xe5,
+	0x8f, 0x7e, 0x22, 0x14, 0xb9, 0xcd, 0xcc, 0xce, 0x7c, 0xb3, 0xf3, 0xcd, 0xcc, 0x2e, 0x1c, 0x2d,
+	0x59, 0x24, 0x49, 0xbc, 0x1c, 0x65, 0x9c, 0x49, 0x86, 0x0e, 0x8c, 0x3a, 0x7c, 0x14, 0xc5, 0xf2,
+	0x65, 0xee, 0x8f, 0x02, 0x96, 0x8c, 0x23, 0x16, 0xb1, 0xb1, 0x3a, 0xf7, 0xf3, 0x5f, 0x95, 0xa6,
+	0x14, 0x25, 0xe9, 0xb8, 0xe1, 0x40, 0xc6, 0x09, 0x15, 0x92, 0x24, 0x99, 0x31, 0x74, 0x49, 0x16,
+	0x6b, 0xd1, 0x7d, 0x0a, 0xf7, 0x66, 0xb9, 0x2f, 0x02, 0x1e, 0xfb, 0x14, 0xd3, 0xdf, 0x72, 0x2a,
+	0x24, 0x72, 0xa1, 0x23, 0x89, 0xbf, 0xa4, 0x8e, 0x7d, 0x6e, 0x5f, 0xf4, 0x2e, 0xfb, 0xa3, 0xc2,
+	0x7d, 0x5e, 0x58, 0xa6, 0x57, 0x58, 0x1f, 0xb9, 0xdf, 0x00, 0xba, 0x49, 0xc5, 0x87, 0x44, 0x3e,
+	0x01, 0x84, 0x29, 0x09, 0x3d, 0xc2, 0x79, 0x4c, 0x79, 0x19, 0xf9, 0x39, 0x80, 0xaf, 0x2d, 0x8b,
+	0x38, 0x54, 0xe1, 0x6d, 0xdc, 0x35, 0x96, 0x69, 0xe8, 0xfe, 0x69, 0x43, 0x5f, 0xe1, 0x5c, 0x6b,
+	0x0a, 0xd0, 0x17, 0xd0, 0x0f, 0x6e, 0xb3, 0xc5, 0x92, 0x05, 0x44, 0xc6, 0x2c, 0x55, 0x11, 0x5d,
+	0xdc, 0x0b, 0x6e, 0xb3, 0x6b, 0x63, 0x42, 0x5f, 0x42, 0x4b, 0x0a, 0xa7, 0xa5, 0x6e, 0x72, 0x7f,
+	0x54, 0x73, 0x30, 0x2f, 0x25, 0xdc, 0x92, 0xa2, 0xbe, 0xf2, 0xde, 0x7b, 0xaf, 0x8c, 0xbe, 0x82,
+	0xc3, 0x80, 0x25, 0x09, 0x49, 0x43, 0xe1, 0xb4, 0xcf, 0xf7, 0x2e, 0x7a, 0x97, 0xa0, 0xdc, 0x9e,
+	0xa5, 0x92, 0xbf, 0xf6, 0xda, 0xef, 0xfe, 0x7e, 0x68, 0xe1, 0xca, 0xc3, 0x7d, 0x0a, 0xfb, 0x33,
+	0x49, 0x64, 0x2e, 0x10, 0x82, 0x76, 0xc0, 0x42, 0xcd, 0xc6, 0x11, 0x56, 0x32, 0x72, 0xe0, 0x20,
+	0xa1, 0x42, 0x90, 0x88, 0xaa, 0xab, 0x75, 0x71, 0xa9, 0xba, 0x3e, 0x1c, 0x3d, 0xe3, 0x9c, 0x71,
+	0x4c, 0x45, 0xc6, 0x52, 0x41, 0xd1, 0x23, 0xd8, 0x17, 0x0a, 0xc8, 0xd0, 0x39, 0x18, 0x95, 0xf3,
+	0xa0, 0xf1, 0x4d, 0x66, 0xe3, 0x54, 0x57, 0xd2, 0x7a, 0x3f, 0xf9, 0xcf, 0xe1, 0xa4, 0xd1, 0x6e,
+	0x93, 0xe7, 0x6b, 0x28, 0x27, 0xcb, 0x24, 0x7a, 0x50, 0x25, 0x6a, 0x72, 0x6e, 0xd2, 0x95, 0xbe,
+	0xee, 0x1b, 0x1b, 0x8e, 0x6f, 0xb2, 0x90, 0xc8, 0x1a, 0xe9, 0x02, 0xda, 0x3f, 0x70, 0x96, 0x18,
+	0x98, 0xed, 0xa4, 0x2b, 0x8f, 0xa2, 0x39, 0x73, 0xb6, 0xbb, 0x39, 0x73, 0x86, 0xbe, 0x83, 0xbe,
+	0xc9, 0xb6, 0x58, 0xc6, 0x42, 0x3a, 0x7b, 0x8a, 0xfc, 0x9d, 0xd7, 0xeb, 0x99, 0xb3, 0xeb, 0x58,
+	0x48, 0xf7, 0x5b, 0x38, 0xbd, 0x49, 0x37, 0x0b, 0xfe, 0x3f, 0x63, 0xfa, 0x12, 0x4e, 0x57, 0xc6,
+	0xd4, 0x84, 0xee, 0x9e, 0x53, 0x74, 0x09, 0xdd, 0xaa, 0x96, 0x9d, 0xd5, 0xd5, 0x6e, 0xee, 0x1f,
+	0x2d, 0x38, 0x36, 0x35, 0x34, 0xb6, 0x81, 0x6b, 0xb1, 0x91, 0xc5, 0x58, 0xa6, 0x21, 0xba, 0x82,
+	0x41, 0xb5, 0x7a, 0x8b, 0x66, 0xcf, 0x3f, 0xa9, 0x27, 0x64, 0x6d, 0x35, 0x27, 0x16, 0x3e, 0xae,
+	0x62, 0x54, 0xa9, 0xe8, 0x39, 0x9c, 0xe4, 0xe9, 0x3a, 0x8e, 0xde, 0x82, 0x4f, 0x2b, 0x9c, 0xcd,
+	0x25, 0x9f, 0x58, 0xf8, 0x5e, 0x23, 0x4e, 0x63, 0x7d, 0x0f, 0x7d, 0x4e, 0x49, 0xb8, 0x30, 0x4c,
+	0x38, 0xed, 0x35, 0x98, 0xcd, 0x8d, 0x9f, 0x58, 0xb8, 0xc7, 0x6b, 0xab, 0xd7, 0x85, 0x03, 0x53,
+	0xa0, 0xfb, 0x76, 0x0f, 0x06, 0x15, 0x21, 0x86, 0xf7, 0x87, 0xd0, 0xe3, 0x46, 0xae, 0x29, 0x81,
+	0xd2, 0x34, 0x0d, 0xd1, 0x8f, 0x80, 0xea, 0x5a, 0x4a, 0xbb, 0xa1, 0x65, 0xb8, 0x8d, 0x16, 0xed,
+	0x31, 0xb1, 0xf0, 0x89, 0xd8, 0x18, 0x90, 0x9f, 0xe1, 0x7e, 0x93, 0x9a, 0x0a, 0x4e, 0xb3, 0xf3,
+	0x59, 0x83, 0x9d, 0x6d, 0x80, 0xa7, 0x79, 0xba, 0x09, 0xe9, 0xc1, 0x20, 0x57, 0xcb, 0x52, 0xa3,
+	0x69, 0x92, 0x3e, 0xae, 0xd1, 0x56, 0x96, 0xa9, 0xe8, 0x58, 0xbe, 0xba, 0x5e, 0x23, 0xe8, 0xd0,
+	0xe2, 0x85, 0x70, 0x3a, 0x2a, 0xf2, 0xa3, 0x2a, 0x72, 0xe5, 0xdd, 0x98, 0x58, 0x58, 0xbb, 0x21,
+	0x0c, 0x0f, 0x9a, 0x5d, 0xa9, 0x33, 0xef, 0xaf, 0xd5, 0xb1, 0x65, 0xd2, 0x8b, 0x3a, 0xf8, 0xa6,
+	0xd9, 0x03, 0x38, 0x2c, 0x61, 0xdc, 0xb7, 0x36, 0x1c, 0xbf, 0xd0, 0xaf, 0xd7, 0x8c, 0x46, 0x09,
+	0x4d, 0x25, 0x1a, 0xc2, 0xe1, 0x4c, 0x72, 0x4a, 0x92, 0xe9, 0x95, 0x69, 0x52, 0xa5, 0xa3, 0x73,
+	0xe8, 0x95, 0xde, 0xf1, 0xef, 0xba, 0x37, 0x1d, 0xdc, 0x34, 0xa9, 0xe8, 0x62, 0x08, 0xd2, 0x40,
+	0x73, 0xdd, 0xc1, 0x95, 0xae, 0xa2, 0xc9, 0xab, 0xea, 0xb8, 0x6d, 0xa2, 0x6b, 0x53, 0xf1, 0xb4,
+	0xfe, 0x44, 0x5e, 0x2f, 0x19, 0x09, 0x15, 0x41, 0x7d, 0x5c, 0xaa, 0x97, 0x2f, 0xe0, 0xa0, 0xfc,
+	0x38, 0xbc, 0x5a, 0xac, 0x99, 0x5f, 0x5d, 0xbf, 0xa1, 0xb3, 0x79, 0x60, 0x2a, 0xb6, 0x2e, 0xec,
+	0xc7, 0xb6, 0xe7, 0xbd, 0xbb, 0x3b, 0xb3, 0xff, 0xba, 0x3b, 0xb3, 0xff, 0xb9, 0x3b, 0xb3, 0xde,
+	0xfc, 0x7b, 0x66, 0xff, 0xf2, 0xb8, 0xf1, 0x23, 0x27, 0x44, 0xf2, 0xf8, 0x15, 0xe3, 0x71, 0x14,
+	0xa7, 0xa5, 0x92, 0xd2, 0x71, 0x76, 0x1b, 0x8d, 0x33, 0x7f, 0x6c, 0x90, 0xfd, 0x7d, 0xf5, 0xff,
+	0x3e, 0xf9, 0x2f, 0x00, 0x00, 0xff, 0xff, 0x69, 0x4b, 0xd2, 0x42, 0xe4, 0x07, 0x00, 0x00,
 }
 
 func (m *SubscribeRequest) Marshal() (dAtA []byte, err error) {
@@ -913,6 +1054,38 @@ func (m *UnsubscribeRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		}
 		i--
 		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ReadBarrierRequest) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ReadBarrierRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ReadBarrierRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.BarrierId != 0 {
+		i = encodeVarintLogtail(dAtA, i, uint64(m.BarrierId))
+		i--
+		dAtA[i] = 0x8
 	}
 	return len(dAtA) - i, nil
 }
@@ -1218,6 +1391,50 @@ func (m *UnSubscribeResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ReadBarrierResponse) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ReadBarrierResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ReadBarrierResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.Timestamp != nil {
+		{
+			size, err := m.Timestamp.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintLogtail(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.BarrierId != 0 {
+		i = encodeVarintLogtail(dAtA, i, uint64(m.BarrierId))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *LogtailRequest) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
@@ -1298,6 +1515,27 @@ func (m *LogtailRequest_UnsubscribeTable) MarshalToSizedBuffer(dAtA []byte) (int
 		}
 		i--
 		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *LogtailRequest_ReadBarrier) MarshalTo(dAtA []byte) (int, error) {
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *LogtailRequest_ReadBarrier) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.ReadBarrier != nil {
+		{
+			size, err := m.ReadBarrier.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintLogtail(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
 	}
 	return len(dAtA) - i, nil
 }
@@ -1426,6 +1664,27 @@ func (m *LogtailResponse_Error) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+func (m *LogtailResponse_ReadBarrierResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *LogtailResponse_ReadBarrierResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.ReadBarrierResponse != nil {
+		{
+			size, err := m.ReadBarrierResponse.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintLogtail(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x32
+	}
+	return len(dAtA) - i, nil
+}
 func (m *MessageSegment) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
@@ -1516,6 +1775,21 @@ func (m *UnsubscribeRequest) ProtoSize() (n int) {
 	if m.Table != nil {
 		l = m.Table.ProtoSize()
 		n += 1 + l + sovLogtail(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *ReadBarrierRequest) ProtoSize() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BarrierId != 0 {
+		n += 1 + sovLogtail(uint64(m.BarrierId))
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -1646,6 +1920,25 @@ func (m *UnSubscribeResponse) ProtoSize() (n int) {
 	return n
 }
 
+func (m *ReadBarrierResponse) ProtoSize() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BarrierId != 0 {
+		n += 1 + sovLogtail(uint64(m.BarrierId))
+	}
+	if m.Timestamp != nil {
+		l = m.Timestamp.ProtoSize()
+		n += 1 + l + sovLogtail(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *LogtailRequest) ProtoSize() (n int) {
 	if m == nil {
 		return 0
@@ -1684,6 +1977,18 @@ func (m *LogtailRequest_UnsubscribeTable) ProtoSize() (n int) {
 	_ = l
 	if m.UnsubscribeTable != nil {
 		l = m.UnsubscribeTable.ProtoSize()
+		n += 1 + l + sovLogtail(uint64(l))
+	}
+	return n
+}
+func (m *LogtailRequest_ReadBarrier) ProtoSize() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ReadBarrier != nil {
+		l = m.ReadBarrier.ProtoSize()
 		n += 1 + l + sovLogtail(uint64(l))
 	}
 	return n
@@ -1750,6 +2055,18 @@ func (m *LogtailResponse_Error) ProtoSize() (n int) {
 	_ = l
 	if m.Error != nil {
 		l = m.Error.ProtoSize()
+		n += 1 + l + sovLogtail(uint64(l))
+	}
+	return n
+}
+func (m *LogtailResponse_ReadBarrierResponse) ProtoSize() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ReadBarrierResponse != nil {
+		l = m.ReadBarrierResponse.ProtoSize()
 		n += 1 + l + sovLogtail(uint64(l))
 	}
 	return n
@@ -1940,6 +2257,76 @@ func (m *UnsubscribeRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipLogtail(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ReadBarrierRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowLogtail
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ReadBarrierRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ReadBarrierRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BarrierId", wireType)
+			}
+			m.BarrierId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLogtail
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BarrierId |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipLogtail(dAtA[iNdEx:])
@@ -2701,6 +3088,112 @@ func (m *UnSubscribeResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *ReadBarrierResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowLogtail
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ReadBarrierResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ReadBarrierResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BarrierId", wireType)
+			}
+			m.BarrierId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLogtail
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BarrierId |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLogtail
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Timestamp == nil {
+				m.Timestamp = &timestamp.Timestamp{}
+			}
+			if err := m.Timestamp.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipLogtail(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *LogtailRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2818,6 +3311,41 @@ func (m *LogtailRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			m.Request = &LogtailRequest_UnsubscribeTable{v}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReadBarrier", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLogtail
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &ReadBarrierRequest{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Request = &LogtailRequest_ReadBarrier{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3028,6 +3556,41 @@ func (m *LogtailResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			m.Response = &LogtailResponse_Error{v}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReadBarrierResponse", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowLogtail
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthLogtail
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &ReadBarrierResponse{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Response = &LogtailResponse_ReadBarrierResponse{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/tests/issues/issue_27834_test.go
+++ b/pkg/tests/issues/issue_27834_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue27834CrossCNAuthenticationReadsLatestCatalog(t *testing.T) {
+	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+		defer cancel()
+
+		mutationCN, err := c.GetCNService(0)
+		require.NoError(t, err)
+		loginCN, err := c.GetCNService(1)
+		require.NoError(t, err)
+		mutationPort := mutationCN.GetServiceConfig().CN.Frontend.Port
+		loginPort := loginCN.GetServiceConfig().CN.Frontend.Port
+		require.NotEqual(t, mutationPort, loginPort,
+			"the acceptance test must route mutation and login to distinct CNs")
+
+		adminDB, err := sql.Open("mysql", fmt.Sprintf(
+			"dump:111@tcp(127.0.0.1:%d)/", mutationPort))
+		require.NoError(t, err)
+		defer adminDB.Close()
+		execSQLRequire(t, ctx, adminDB, "set role moadmin")
+
+		const (
+			userName = "issue_27834_user"
+			roleName = "issue_27834_role"
+		)
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(
+				context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			execSQLMaybe(t, cleanupCtx, adminDB, "drop user if exists "+userName)
+			execSQLMaybe(t, cleanupCtx, adminDB, "drop role if exists "+roleName)
+		}()
+		execSQLRequire(t, ctx, adminDB, "drop user if exists "+userName)
+		execSQLRequire(t, ctx, adminDB, "drop role if exists "+roleName)
+		execSQLRequire(t, ctx, adminDB, "create role "+roleName)
+		execSQLRequire(t, ctx, adminDB,
+			"create user "+userName+" identified by 'Issue27834Pass01' default role "+roleName)
+		execSQLRequire(t, ctx, adminDB, "grant "+roleName+" to "+userName)
+		execSQLRequire(t, ctx, adminDB, "grant connect on account * to "+roleName)
+
+		assertLogin := func(password string, wantSuccess bool) {
+			t.Helper()
+			db, openErr := sql.Open("mysql", fmt.Sprintf(
+				"sys#%s#%s:%s@tcp(127.0.0.1:%d)/",
+				userName, roleName, password, loginPort))
+			require.NoError(t, openErr)
+			db.SetMaxIdleConns(0)
+			defer db.Close()
+			pingErr := db.PingContext(ctx)
+			if !wantSuccess {
+				require.Error(t, pingErr,
+					"a fresh connection on CN-B accepted stale authentication state")
+				return
+			}
+			require.NoError(t, pingErr,
+				"a fresh connection on CN-B rejected committed authentication state")
+			var one int
+			require.NoError(t, db.QueryRowContext(ctx, "select 1").Scan(&one))
+			require.Equal(t, 1, one)
+		}
+
+		passwords := []string{
+			"Issue27834Pass01",
+			"Issue27834Pass02",
+			"Issue27834Pass03",
+			"Issue27834Pass04",
+		}
+		assertLogin(passwords[0], true)
+		for i := 1; i < len(passwords); i++ {
+			execSQLRequire(t, ctx, adminDB, fmt.Sprintf(
+				"alter user %s identified by '%s'", userName, passwords[i]))
+			assertLogin(passwords[i-1], false)
+			assertLogin(passwords[i], true)
+		}
+
+		execSQLRequire(t, ctx, adminDB, "revoke "+roleName+" from "+userName)
+		assertLogin(passwords[len(passwords)-1], false)
+		execSQLRequire(t, ctx, adminDB, "grant "+roleName+" to "+userName)
+		assertLogin(passwords[len(passwords)-1], true)
+	})
+}

--- a/pkg/util/status/logtail_server_test.go
+++ b/pkg/util/status/logtail_server_test.go
@@ -61,6 +61,11 @@ func (m *logtailer) RangeLogtail(
 func (m *logtailer) RegisterCallback(cb func(from, to timestamp.Timestamp, closeCB func(), tails ...logtail.TableLogtail) error) {
 }
 
+func (m *logtailer) ReadBarrier(context.Context) (timestamp.Timestamp, error) {
+	frontier, _ := m.Now()
+	return frontier, nil
+}
+
 func (m *logtailer) TableLogtail(
 	ctx context.Context, table api.TableID, from, to timestamp.Timestamp,
 ) (logtail.TableLogtail, func(), error) {

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -59,6 +59,7 @@ import (
 
 var _ engine.Engine = new(Engine)
 var _ engine.StatsRefresher = new(Engine)
+var _ engine.LogtailReadBarrier = new(Engine)
 
 const (
 	workspaceRSSCacheFamilyEvictTimeout   = 10 * time.Second
@@ -1318,6 +1319,12 @@ func (e *Engine) PackerPool() *fileservice.Pool[*types.Packer] {
 
 func (e *Engine) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return e.pClient.LatestLogtailAppliedTime()
+}
+
+func (e *Engine) AcquireLogtailReadBarrier(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
+	return e.pClient.AcquireLogtailReadBarrier(ctx)
 }
 
 // RunGCScheduler runs all GC tasks in a single goroutine with different intervals

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -220,6 +220,48 @@ func (c *PushClient) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return c.receivedLogTailTime.getTimestamp()
 }
 
+// AcquireLogtailReadBarrier obtains a TN-ordered publication frontier and
+// waits until the normal CN logtail apply pipeline reaches it. It does not
+// bypass, duplicate, or special-case catalog application.
+func (c *PushClient) AcquireLogtailReadBarrier(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
+	if c.subscriber == nil {
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "logtail subscriber is not initialized")
+	}
+	return acquireAppliedLogtailReadBarrier(
+		ctx, c.timestampWaiter, c.subscriber.readBarrier,
+	)
+}
+
+func acquireAppliedLogtailReadBarrier(
+	ctx context.Context,
+	timestampWaiter client.TimestampWaiter,
+	readBarrier func(context.Context) (timestamp.Timestamp, error),
+) (timestamp.Timestamp, error) {
+	if timestampWaiter == nil {
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "logtail timestamp waiter is not initialized")
+	}
+	frontier, err := readBarrier(ctx)
+	if err != nil {
+		return timestamp.Timestamp{}, moerr.AttachCause(ctx, err)
+	}
+	applied, err := timestampWaiter.GetTimestamp(ctx, frontier)
+	if err != nil {
+		return timestamp.Timestamp{}, moerr.AttachCause(ctx, err)
+	}
+	if applied.Less(frontier) {
+		return timestamp.Timestamp{}, moerr.NewInternalErrorf(
+			ctx,
+			"logtail waiter returned %s before read barrier %s",
+			applied.DebugString(), frontier.DebugString(),
+		)
+	}
+	return frontier, nil
+}
+
 func (c *PushClient) GetState() State {
 	c.subscribed.rw.RLock()
 	defer c.subscribed.rw.RUnlock()
@@ -301,9 +343,14 @@ func (c *PushClient) init(
 ) error {
 
 	c.serviceID = e.GetService()
-	c.timestampWaiter = timestampWaiter
 	if c.subscriber == nil {
 		c.subscriber = newLogTailSubscriber()
+	}
+	if !c.initialized {
+		// The waiter belongs to the PushClient generation, not to an individual
+		// transport connection. Reconnect reuses it and must not race barrier
+		// callers by rewriting the same field.
+		c.timestampWaiter = timestampWaiter
 	}
 
 	// lock all.
@@ -652,7 +699,7 @@ func (c *PushClient) pause(s bool) {
 	// Note
 	// If subSysTables fails to send a successful request, receiveLogtails will receive nothing until the context is done. In this case, we attempt to stop the receiveLogtails goroutine immediately.
 	// The break signal left in the channel will interrupt the normal receiving process, but this is not an issue because reconnecting will create a new channel.
-	c.subscriber.logTailClient.BreakoutReceive()
+	c.subscriber.breakoutReceive()
 	select {
 	case c.pauseC <- s:
 		c.mu.paused = true
@@ -1656,7 +1703,7 @@ func (c *PushClient) isNotUnsubscribing(ctx context.Context, dbId, tblId uint64)
 func (c *PushClient) Disconnect() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.subscriber.logTailClient.Close()
+	return c.subscriber.closeClient()
 }
 
 func (s *subscribedTable) setTableSubNotExist(dbId, tblId uint64) {
@@ -1870,9 +1917,8 @@ func (s *logTailSubscriber) init(
 	// clear the old status.
 	s.sendSubscribe = clientIsPreparing
 	s.sendUnSubscribe = clientIsPreparing
-	if s.logTailClient != nil {
-		_ = s.logTailClient.Close()
-		s.logTailClient = nil
+	if oldClient := s.swapClient(nil); oldClient != nil {
+		_ = oldClient.Close()
 	}
 
 	rpcClient, rpcStream, err := rpcStreamFactory(ctx, sid, serviceAddr, s.rpcClient)
@@ -1889,7 +1935,7 @@ func (s *logTailSubscriber) init(
 	s.rpcStream = rpcStream
 
 	// new the log tail client.
-	s.logTailClient, err = service.NewLogtailClient(
+	logTailClient, err := service.NewLogtailClient(
 		ctx,
 		s.rpcStream,
 		service.WithClientRequestPerSecond(maxSubscribeRequestPerSecond),
@@ -1897,10 +1943,40 @@ func (s *logTailSubscriber) init(
 	if err != nil {
 		return err
 	}
+	s.swapClient(logTailClient)
 
 	s.sendSubscribe = s.subscribeTable
 	s.sendUnSubscribe = s.unSubscribeTable
 	return nil
+}
+
+func (s *logTailSubscriber) swapClient(client *service.LogtailClient) *service.LogtailClient {
+	s.mu.Lock()
+	old := s.logTailClient
+	s.logTailClient = client
+	s.mu.Unlock()
+	return old
+}
+
+func (s *logTailSubscriber) client() *service.LogtailClient {
+	s.mu.RLock()
+	client := s.logTailClient
+	s.mu.RUnlock()
+	return client
+}
+
+func (s *logTailSubscriber) closeClient() error {
+	client := s.client()
+	if client == nil {
+		return nil
+	}
+	return client.Close()
+}
+
+func (s *logTailSubscriber) breakoutReceive() {
+	if client := s.client(); client != nil {
+		client.BreakoutReceive()
+	}
 }
 
 func (s *logTailSubscriber) setReady() {
@@ -1951,27 +2027,77 @@ func (s *logTailSubscriber) waitReady(ctx context.Context) error {
 	return nil
 }
 
+// waitReadyClient captures the client belonging to the ready stream
+// generation under the same lock as the ready flag. A reconnect can either
+// close that captured old client or publish a later ready generation, but a
+// caller can never observe the new client while it is still initializing.
+func (s *logTailSubscriber) waitReadyClient(
+	ctx context.Context,
+) (*service.LogtailClient, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stop := context.AfterFunc(ctx, func() {
+		s.mu.Lock()
+		s.mu.cond.Broadcast()
+		s.mu.Unlock()
+	})
+	defer stop()
+	for !s.mu.ready {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		s.mu.cond.Wait()
+	}
+	if s.logTailClient == nil {
+		return nil, moerr.NewStreamClosedNoCtx()
+	}
+	return s.logTailClient, nil
+}
+
 // can't call this method directly.
 func (s *logTailSubscriber) subscribeTable(
 	ctx context.Context, tblId api.TableID) error {
-	err := s.logTailClient.Subscribe(ctx, tblId)
+	client := s.client()
+	if client == nil {
+		return moerr.NewStreamClosedNoCtx()
+	}
+	err := client.Subscribe(ctx, tblId)
 	return moerr.AttachCause(ctx, err)
 }
 
 // can't call this method directly.
 func (s *logTailSubscriber) unSubscribeTable(
 	ctx context.Context, tblId api.TableID) error {
-	err := s.logTailClient.Unsubscribe(ctx, tblId)
+	client := s.client()
+	if client == nil {
+		return moerr.NewStreamClosedNoCtx()
+	}
+	err := client.Unsubscribe(ctx, tblId)
 	return moerr.AttachCause(ctx, err)
 }
 
 func (s *logTailSubscriber) receiveResponse(deadlineCtx context.Context) logTailSubscriberResponse {
-	r, err := s.logTailClient.Receive(deadlineCtx)
+	client := s.client()
+	if client == nil {
+		return logTailSubscriberResponse{err: moerr.NewStreamClosedNoCtx()}
+	}
+	r, err := client.Receive(deadlineCtx)
 	resp := logTailSubscriberResponse{
 		response: r,
 		err:      err,
 	}
 	return resp
+}
+
+func (s *logTailSubscriber) readBarrier(ctx context.Context) (timestamp.Timestamp, error) {
+	client, err := s.waitReadyClient(ctx)
+	if err != nil {
+		return timestamp.Timestamp{}, err
+	}
+	return client.ReadBarrier(ctx)
 }
 
 func waitServerReady(addr string) {

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail/service"
 )
 
 /*
@@ -88,6 +89,11 @@ func (m *logtailer) RangeLogtail(
 }
 
 func (m *logtailer) RegisterCallback(cb func(from, to timestamp.Timestamp, closeCB func(), tails ...logtail.TableLogtail) error) {
+}
+
+func (m *logtailer) ReadBarrier(context.Context) (timestamp.Timestamp, error) {
+	frontier, _ := m.Now()
+	return frontier, nil
 }
 
 func (m *logtailer) TableLogtail(
@@ -227,6 +233,19 @@ func runTestWithLogTailServer(t *testing.T, test func(ctx context.Context, e *En
 }
 */
 
+type barrierTimestampWaiter struct {
+	get func(context.Context, timestamp.Timestamp) (timestamp.Timestamp, error)
+}
+
+func (w *barrierTimestampWaiter) GetTimestamp(
+	ctx context.Context, ts timestamp.Timestamp,
+) (timestamp.Timestamp, error) {
+	return w.get(ctx, ts)
+}
+func (*barrierTimestampWaiter) NotifyLatestCommitTS(timestamp.Timestamp) {}
+func (*barrierTimestampWaiter) Close()                                   {}
+func (*barrierTimestampWaiter) LatestTS() timestamp.Timestamp            { return timestamp.Timestamp{} }
+
 func TestPushClient_LatestLogtailAppliedTime(t *testing.T) {
 	var c PushClient
 	tw := client.NewTimestampWaiter(runtime.GetLogger(""))
@@ -239,6 +258,68 @@ func TestPushClient_LatestLogtailAppliedTime(t *testing.T) {
 		c.receivedLogTailTime.updateTimestamp(i, ts, time.Now())
 	}
 	assert.Equal(t, ts, c.LatestLogtailAppliedTime())
+}
+
+func TestAcquireAppliedLogtailReadBarrier(t *testing.T) {
+	frontier := timestamp.Timestamp{PhysicalTime: 20, LogicalTime: 2}
+	waiter := &barrierTimestampWaiter{get: func(
+		_ context.Context, target timestamp.Timestamp,
+	) (timestamp.Timestamp, error) {
+		require.Equal(t, frontier, target)
+		return target.Next(), nil
+	}}
+
+	got, err := acquireAppliedLogtailReadBarrier(
+		t.Context(), waiter, func(context.Context) (timestamp.Timestamp, error) {
+			return frontier, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, frontier, got)
+}
+
+func TestAcquireAppliedLogtailReadBarrierFailsClosed(t *testing.T) {
+	frontier := timestamp.Timestamp{PhysicalTime: 20}
+	wantErr := moerr.NewInternalErrorNoCtx("barrier failed")
+
+	t.Run("missing waiter", func(t *testing.T) {
+		_, err := acquireAppliedLogtailReadBarrier(
+			t.Context(), nil, func(context.Context) (timestamp.Timestamp, error) {
+				t.Fatal("barrier must not run without an apply waiter")
+				return timestamp.Timestamp{}, nil
+			},
+		)
+		require.ErrorContains(t, err, "waiter is not initialized")
+	})
+
+	t.Run("barrier failure", func(t *testing.T) {
+		waiter := &barrierTimestampWaiter{get: func(
+			context.Context, timestamp.Timestamp,
+		) (timestamp.Timestamp, error) {
+			t.Fatal("apply wait must not run after barrier failure")
+			return timestamp.Timestamp{}, nil
+		}}
+		_, err := acquireAppliedLogtailReadBarrier(
+			t.Context(), waiter, func(context.Context) (timestamp.Timestamp, error) {
+				return timestamp.Timestamp{}, wantErr
+			},
+		)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("apply waiter regresses", func(t *testing.T) {
+		waiter := &barrierTimestampWaiter{get: func(
+			context.Context, timestamp.Timestamp,
+		) (timestamp.Timestamp, error) {
+			return timestamp.Timestamp{PhysicalTime: 19}, nil
+		}}
+		_, err := acquireAppliedLogtailReadBarrier(
+			t.Context(), waiter, func(context.Context) (timestamp.Timestamp, error) {
+				return frontier, nil
+			},
+		)
+		require.ErrorContains(t, err, "before read barrier")
+	})
 }
 
 func TestPushClient_GetState(t *testing.T) {
@@ -1467,6 +1548,40 @@ func TestLogTailSubscriberWaitReadyReturnsOnContextCancel(t *testing.T) {
 		// Release the waiter so a failed assertion does not leak the goroutine.
 		subscriber.setReady()
 		t.Fatal("waitReady did not observe context cancellation")
+	}
+}
+
+func TestLogTailSubscriberWaitReadyClientDoesNotExposeInitializingClient(t *testing.T) {
+	subscriber := newLogTailSubscriber()
+	subscriber.swapClient(&service.LogtailClient{})
+	base, cancel := context.WithCancel(context.Background())
+	ctx := &waitReadyObservedContext{
+		Context: base,
+		checked: make(chan struct{}),
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := subscriber.waitReadyClient(ctx)
+		done <- err
+	}()
+
+	select {
+	case <-ctx.checked:
+	case <-time.After(time.Second):
+		t.Fatal("waitReadyClient did not reach its wait loop")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("initializing client escaped before ready: %v", err)
+	default:
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		subscriber.setReady()
+		t.Fatal("waitReadyClient did not observe context cancellation")
 	}
 }
 

--- a/pkg/vm/engine/entire_engine.go
+++ b/pkg/vm/engine/entire_engine.go
@@ -17,6 +17,7 @@ package engine
 import (
 	"context"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -29,6 +30,17 @@ func (e *EntireEngine) New(ctx context.Context, op client.TxnOperator) error {
 
 func (e *EntireEngine) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return e.Engine.LatestLogtailAppliedTime()
+}
+
+func (e *EntireEngine) AcquireLogtailReadBarrier(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
+	barrier, ok := e.Engine.(LogtailReadBarrier)
+	if !ok {
+		return timestamp.Timestamp{}, moerr.NewNotSupported(
+			ctx, "logtail read barrier")
+	}
+	return barrier.AcquireLogtailReadBarrier(ctx)
 }
 
 func (e *EntireEngine) Delete(ctx context.Context, databaseName string, op client.TxnOperator) error {

--- a/pkg/vm/engine/tae/logstore/sm/safeq.go
+++ b/pkg/vm/engine/tae/logstore/sm/safeq.go
@@ -141,17 +141,45 @@ func (q *safeQueue) waitStop() {
 }
 
 func (q *safeQueue) Enqueue(item any) (any, error) {
-	return q.enqueue(context.Background(), item)
+	if q.state.Load() != Running {
+		return item, ErrClose
+	}
+
+	if q.blocking {
+		q.pending.Add(1)
+		// Stop may begin after the first state check. Register before the
+		// second check so Stop keeps the receiver alive until this producer
+		// either sends or withdraws its pending item.
+		if q.state.Load() != Running {
+			q.pending.Add(-1)
+			return item, ErrClose
+		}
+		// Keep the established background-producer hot path exact: unlike a
+		// request-scoped enqueue it has no context checks and no select. Stop
+		// waits for pending to reach zero, so the receiver remains alive until
+		// this send is handled.
+		q.queue <- item
+		return item, nil
+	}
+
+	q.pending.Add(1)
+	if q.state.Load() != Running {
+		q.pending.Add(-1)
+		return item, ErrClose
+	}
+	select {
+	case q.queue <- item:
+		return item, nil
+	default:
+		q.pending.Add(-1)
+		return item, ErrFull
+	}
 }
 
 func (q *safeQueue) EnqueueWithContext(ctx context.Context, item any) (any, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return q.enqueue(ctx, item)
-}
-
-func (q *safeQueue) enqueue(ctx context.Context, item any) (any, error) {
 	if err := ctx.Err(); err != nil {
 		return item, context.Cause(ctx)
 	}
@@ -178,21 +206,21 @@ func (q *safeQueue) enqueue(ctx context.Context, item any) (any, error) {
 			q.pending.Add(-1)
 			return item, context.Cause(ctx)
 		}
-	} else {
-		q.pending.Add(1)
-		if q.state.Load() != Running {
-			q.pending.Add(-1)
-			return item, ErrClose
-		}
-		select {
-		case q.queue <- item:
-			return item, nil
-		case <-ctx.Done():
-			q.pending.Add(-1)
-			return item, context.Cause(ctx)
-		default:
-			q.pending.Add(-1)
-			return item, ErrFull
-		}
+	}
+
+	q.pending.Add(1)
+	if q.state.Load() != Running {
+		q.pending.Add(-1)
+		return item, ErrClose
+	}
+	select {
+	case q.queue <- item:
+		return item, nil
+	case <-ctx.Done():
+		q.pending.Add(-1)
+		return item, context.Cause(ctx)
+	default:
+		q.pending.Add(-1)
+		return item, ErrFull
 	}
 }

--- a/pkg/vm/engine/tae/logstore/sm/safeq.go
+++ b/pkg/vm/engine/tae/logstore/sm/safeq.go
@@ -141,6 +141,20 @@ func (q *safeQueue) waitStop() {
 }
 
 func (q *safeQueue) Enqueue(item any) (any, error) {
+	return q.enqueue(context.Background(), item)
+}
+
+func (q *safeQueue) EnqueueWithContext(ctx context.Context, item any) (any, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return q.enqueue(ctx, item)
+}
+
+func (q *safeQueue) enqueue(ctx context.Context, item any) (any, error) {
+	if err := ctx.Err(); err != nil {
+		return item, context.Cause(ctx)
+	}
 	if q.state.Load() != Running {
 		return item, ErrClose
 	}
@@ -154,12 +168,16 @@ func (q *safeQueue) Enqueue(item any) (any, error) {
 			q.pending.Add(-1)
 			return item, ErrClose
 		}
-		// A blocking send intentionally has no cancellation branch: Stop waits for
-		// pending to reach zero before canceling q.ctx, and this producer contributes
-		// to pending until its item has been handled. Adding q.ctx.Done() here would
-		// therefore not unblock a sender and would obscure that shutdown contract.
-		q.queue <- item
-		return item, nil
+		// Stop waits for pending to reach zero before canceling q.ctx. Caller
+		// cancellation is different: this producer can withdraw its own pending
+		// item before it has transferred ownership to the receiver.
+		select {
+		case q.queue <- item:
+			return item, nil
+		case <-ctx.Done():
+			q.pending.Add(-1)
+			return item, context.Cause(ctx)
+		}
 	} else {
 		q.pending.Add(1)
 		if q.state.Load() != Running {
@@ -169,6 +187,9 @@ func (q *safeQueue) Enqueue(item any) (any, error) {
 		select {
 		case q.queue <- item:
 			return item, nil
+		case <-ctx.Done():
+			q.pending.Add(-1)
+			return item, context.Cause(ctx)
 		default:
 			q.pending.Add(-1)
 			return item, ErrFull

--- a/pkg/vm/engine/tae/logstore/sm/sm_test.go
+++ b/pkg/vm/engine/tae/logstore/sm/sm_test.go
@@ -15,6 +15,7 @@
 package sm
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -100,6 +101,55 @@ func TestSafeQueueWithoutHandlerStops(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("queue with nil handler did not stop")
 	}
+}
+
+func TestSafeQueueEnqueueWithContextWithdrawsPendingItem(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	queue := NewSafeQueue(1, 1, func(...any) {
+		select {
+		case <-entered:
+		default:
+			close(entered)
+		}
+		<-release
+	})
+	queue.Start()
+
+	_, err := queue.Enqueue("being handled")
+	require.NoError(t, err)
+	<-entered
+	_, err = queue.Enqueue("fills buffer")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, enqueueErr := queue.EnqueueWithContext(ctx, "must withdraw")
+		done <- enqueueErr
+	}()
+	require.Eventually(t, func() bool {
+		return queue.pending.Load() == 3
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.Equal(t, int64(2), queue.pending.Load())
+
+	close(release)
+	queue.Stop()
+	require.Zero(t, queue.pending.Load())
+}
+
+func TestSafeQueueRejectsAlreadyCanceledContext(t *testing.T) {
+	queue := NewSafeQueue(1, 1, func(...any) {})
+	queue.Start()
+	defer queue.Stop()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := queue.EnqueueWithContext(ctx, "not admitted")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, queue.pending.Load())
 }
 
 func TestNewNonBlockingQueue(t *testing.T) {

--- a/pkg/vm/engine/tae/logstore/sm/sm_test.go
+++ b/pkg/vm/engine/tae/logstore/sm/sm_test.go
@@ -152,6 +152,41 @@ func TestSafeQueueRejectsAlreadyCanceledContext(t *testing.T) {
 	require.Zero(t, queue.pending.Load())
 }
 
+func BenchmarkSafeQueueEnqueue(b *testing.B) {
+	benchmarks := []struct {
+		name    string
+		enqueue func(*safeQueue, any) (any, error)
+	}{
+		{
+			name: "background-hot-path",
+			enqueue: func(queue *safeQueue, item any) (any, error) {
+				return queue.Enqueue(item)
+			},
+		},
+		{
+			name: "request-context",
+			enqueue: func(queue *safeQueue, item any) (any, error) {
+				return queue.EnqueueWithContext(context.Background(), item)
+			},
+		},
+	}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			queue := NewSafeQueue(10_000, 100, nil)
+			queue.Start()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := benchmark.enqueue(queue, i); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			queue.Stop()
+		})
+	}
+}
+
 func TestNewNonBlockingQueue(t *testing.T) {
 	wait := sync.WaitGroup{}
 	wait.Add(1)

--- a/pkg/vm/engine/tae/logstore/sm/types.go
+++ b/pkg/vm/engine/tae/logstore/sm/types.go
@@ -15,6 +15,7 @@
 package sm
 
 import (
+	"context"
 	"sync/atomic"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -54,6 +55,17 @@ type Queue interface {
 	// it will return directly when if it is an unblocking queue and there has no more free space,
 	// and ErrFull will be return to notify the producer.
 	Enqueue(any) (any, error)
+}
+
+// ContextQueue extends Queue for request-scoped producers that must be able to
+// withdraw while waiting for capacity. Existing background-only queue users do
+// not need to implement the extra method.
+type ContextQueue interface {
+	Queue
+	// EnqueueWithContext has the same ordering and shutdown guarantees as
+	// Enqueue, but lets request-scoped producers stop waiting for queue capacity
+	// when their caller is canceled.
+	EnqueueWithContext(context.Context, any) (any, error)
 }
 
 type StateMachine interface {

--- a/pkg/vm/engine/tae/logtail/logtailer.go
+++ b/pkg/vm/engine/tae/logtail/logtailer.go
@@ -45,6 +45,10 @@ type Logtailer interface {
 	// from Now and use the timestamp to collect logtail, in that case, all txn prepared
 	// before it are visible.
 	Now() (timestamp.Timestamp, timestamp.Timestamp)
+
+	// ReadBarrier returns an exact logtail frontier ordered after every
+	// transaction that entered the TN logtail manager before the barrier.
+	ReadBarrier(context.Context) (timestamp.Timestamp, error)
 }
 
 var _ Logtailer = (*LogtailerImpl)(nil)
@@ -76,6 +80,10 @@ func (l *LogtailerImpl) Now() (timestamp.Timestamp, timestamp.Timestamp) {
 	ts := l.mgr.nowClock() // now in logtail manager is the same with the one in TxnManager
 
 	return ts.ToTimestamp(), timestamp.Timestamp{}
+}
+
+func (l *LogtailerImpl) ReadBarrier(ctx context.Context) (timestamp.Timestamp, error) {
+	return l.mgr.ReadBarrier(ctx)
 }
 
 // TableLogtail returns logtail for the specified table.

--- a/pkg/vm/engine/tae/logtail/mgr.go
+++ b/pkg/vm/engine/tae/logtail/mgr.go
@@ -39,6 +39,9 @@ import (
 
 const (
 	LogtailHeartbeatDuration = time.Millisecond * 2
+
+	logtailQueueBatchSize  = 100
+	maxPendingReadBarriers = logtailQueueBatchSize
 )
 
 func MockCallback(from, to timestamp.Timestamp, closeCB func(), tails ...logtail.TableLogtail) error {
@@ -91,8 +94,13 @@ type Manager struct {
 	previousSaveTS  types.TS
 	logtailCallback atomic.Pointer[callback]
 	logtailQueue    sm.ContextQueue
-	eventOnce       sync.Once
-	nextCompactTS   types.TS
+	// readBarrierSlots bounds control-plane work admitted to the same FIFO as
+	// commit logtails. Its capacity is one queue batch, so any number of login
+	// attempts can add at most one batch of markers ahead of commit producers.
+	readBarrierSlots    chan struct{}
+	pendingReadBarriers atomic.Int64
+	eventOnce           sync.Once
+	nextCompactTS       types.TS
 
 	collectPool *ants.Pool
 }
@@ -112,7 +120,6 @@ func NewManager(
 		nowClock: nowClock,
 	}
 
-	const batSize = 100
 	// Re-panic from ants's internal recover so a panic inside a
 	// collect goroutine crashes the process instead of being silently
 	// swallowed. If we only logged and continued, a committed txn
@@ -124,7 +131,12 @@ func NewManager(
 		runtime.NumCPU(),
 		ants.WithPanicHandler(func(v any) { panic(v) }),
 	)
-	mgr.logtailQueue = sm.NewSafeQueue(batSize*batSize, batSize, mgr.onTxnLogTails)
+	mgr.logtailQueue = sm.NewSafeQueue(
+		logtailQueueBatchSize*logtailQueueBatchSize,
+		logtailQueueBatchSize,
+		mgr.onTxnLogTails,
+	)
+	mgr.readBarrierSlots = make(chan struct{}, maxPendingReadBarriers)
 
 	return mgr
 }
@@ -139,17 +151,29 @@ type txnWithLogtails struct {
 // the manager reaches it, every transaction queued before the marker has been
 // collected and handed to the logtail publisher in PrepareTS order.
 type readBarrier struct {
-	done chan timestamp.Timestamp
+	done    chan timestamp.Timestamp
+	release func()
+	once    sync.Once
 }
 
-func newReadBarrier() *readBarrier {
-	return &readBarrier{done: make(chan timestamp.Timestamp, 1)}
+func newReadBarrier(release func()) *readBarrier {
+	return &readBarrier{
+		done:    make(chan timestamp.Timestamp, 1),
+		release: release,
+	}
 }
 
 func (b *readBarrier) complete(ts timestamp.Timestamp) {
-	// The channel is buffered because the request may be canceled after the
-	// marker was admitted. Queue progress must never depend on that caller.
-	b.done <- ts
+	b.once.Do(func() {
+		// The channel is buffered because the request may be canceled after the
+		// marker was admitted. Queue progress must never depend on that caller.
+		b.done <- ts
+		b.release()
+	})
+}
+
+func (b *readBarrier) abort() {
+	b.once.Do(b.release)
 }
 
 // orderedCollectAndPublish collects logtails for n items in parallel via submit,
@@ -289,48 +313,73 @@ func (mgr *Manager) onTxnLogTails(items ...any) {
 		return builder.CollectLogtail(txn)
 	}
 
+	// This is the normal commit path. Do not scan and type-assert the batch a
+	// second time when no barrier is outstanding. A marker acquired after this
+	// load cannot be part of items, which the queue already removed atomically.
+	if mgr.pendingReadBarriers.Load() == 0 {
+		mgr.collectAndPublishTxnSegment(items, collect)
+		return
+	}
+
 	// A barrier splits a queue batch into ordered transaction segments. Work
 	// after the barrier is deliberately not scheduled before the marker: it
 	// cannot contribute to the frontier and must not compete with the work the
 	// caller is waiting for. Each segment retains parallel collection and
 	// PrepareTS-ordered publication through orderedCollectAndPublish.
 	segmentStart := 0
-	flush := func(segmentEnd int) {
-		segment := items[segmentStart:segmentEnd]
-		orderedCollectAndPublish(
-			len(segment),
-			func(i int) bool {
-				txn, ok := segment[i].(txnif.AsyncTxn)
-				if !ok {
-					panic(fmt.Sprintf("unknown logtail queue item %T", segment[i]))
-				}
-				return txn.IsReplay()
-			},
-			func(fn func()) {
-				if err := mgr.collectPool.Submit(fn); err != nil {
-					panic(err)
-				}
-			},
-			func(i int) *txnWithLogtails {
-				return collectOneTxn(segment[i].(txnif.AsyncTxn), collect)
-			},
-			mgr.generateLogtailWithTxn,
-		)
-	}
-
-	for i, item := range items {
+	for i := 0; i < len(items); {
+		item := items[i]
 		barrier, ok := item.(*readBarrier)
 		if !ok {
 			if _, ok := item.(txnif.AsyncTxn); !ok {
 				panic(fmt.Sprintf("unknown logtail queue item %T", item))
 			}
+			i++
 			continue
 		}
-		flush(i)
-		barrier.complete(mgr.previousSaveTS.ToTimestamp())
-		segmentStart = i + 1
+		mgr.collectAndPublishTxnSegment(items[segmentStart:i], collect)
+		frontier := mgr.previousSaveTS.ToTimestamp()
+		// Adjacent barriers share exactly the same FIFO frontier. Complete them
+		// together without creating empty transaction segments between markers.
+		for i < len(items) {
+			barrier, ok = items[i].(*readBarrier)
+			if !ok {
+				break
+			}
+			barrier.complete(frontier)
+			i++
+		}
+		segmentStart = i
 	}
-	flush(len(items))
+	mgr.collectAndPublishTxnSegment(items[segmentStart:], collect)
+}
+
+func (mgr *Manager) collectAndPublishTxnSegment(
+	segment []any,
+	collect txnLogtailCollector,
+) {
+	if len(segment) == 0 {
+		return
+	}
+	orderedCollectAndPublish(
+		len(segment),
+		func(i int) bool {
+			txn, ok := segment[i].(txnif.AsyncTxn)
+			if !ok {
+				panic(fmt.Sprintf("unknown logtail queue item %T", segment[i]))
+			}
+			return txn.IsReplay()
+		},
+		func(fn func()) {
+			if err := mgr.collectPool.Submit(fn); err != nil {
+				panic(err)
+			}
+		},
+		func(i int) *txnWithLogtails {
+			return collectOneTxn(segment[i].(txnif.AsyncTxn), collect)
+		},
+		mgr.generateLogtailWithTxn,
+	)
 }
 
 // ReadBarrier returns the latest logtail frontier after all transactions that
@@ -345,8 +394,18 @@ func (mgr *Manager) ReadBarrier(ctx context.Context) (timestamp.Timestamp, error
 		return timestamp.Timestamp{}, context.Cause(ctx)
 	}
 
-	barrier := newReadBarrier()
+	select {
+	case mgr.readBarrierSlots <- struct{}{}:
+		mgr.pendingReadBarriers.Add(1)
+	case <-ctx.Done():
+		return timestamp.Timestamp{}, context.Cause(ctx)
+	}
+	barrier := newReadBarrier(func() {
+		mgr.pendingReadBarriers.Add(-1)
+		<-mgr.readBarrierSlots
+	})
 	if _, err := mgr.logtailQueue.EnqueueWithContext(ctx, barrier); err != nil {
+		barrier.abort()
 		return timestamp.Timestamp{}, err
 	}
 

--- a/pkg/vm/engine/tae/logtail/mgr.go
+++ b/pkg/vm/engine/tae/logtail/mgr.go
@@ -329,7 +329,7 @@ func (mgr *Manager) onTxnLogTails(items ...any) {
 	segmentStart := 0
 	for i := 0; i < len(items); {
 		item := items[i]
-		barrier, ok := item.(*readBarrier)
+		_, ok := item.(*readBarrier)
 		if !ok {
 			if _, ok := item.(txnif.AsyncTxn); !ok {
 				panic(fmt.Sprintf("unknown logtail queue item %T", item))
@@ -342,7 +342,7 @@ func (mgr *Manager) onTxnLogTails(items ...any) {
 		// Adjacent barriers share exactly the same FIFO frontier. Complete them
 		// together without creating empty transaction segments between markers.
 		for i < len(items) {
-			barrier, ok = items[i].(*readBarrier)
+			barrier, ok := items[i].(*readBarrier)
 			if !ok {
 				break
 			}

--- a/pkg/vm/engine/tae/logtail/mgr.go
+++ b/pkg/vm/engine/tae/logtail/mgr.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
@@ -89,7 +90,7 @@ type Manager struct {
 
 	previousSaveTS  types.TS
 	logtailCallback atomic.Pointer[callback]
-	logtailQueue    sm.Queue
+	logtailQueue    sm.ContextQueue
 	eventOnce       sync.Once
 	nextCompactTS   types.TS
 
@@ -132,6 +133,23 @@ type txnWithLogtails struct {
 	txn     txnif.AsyncTxn
 	tails   *[]logtail.TableLogtail
 	closeCB func()
+}
+
+// readBarrier is a marker in the same FIFO as committed transactions. Once
+// the manager reaches it, every transaction queued before the marker has been
+// collected and handed to the logtail publisher in PrepareTS order.
+type readBarrier struct {
+	done chan timestamp.Timestamp
+}
+
+func newReadBarrier() *readBarrier {
+	return &readBarrier{done: make(chan timestamp.Timestamp, 1)}
+}
+
+func (b *readBarrier) complete(ts timestamp.Timestamp) {
+	// The channel is buffered because the request may be canceled after the
+	// marker was admitted. Queue progress must never depend on that caller.
+	b.done <- ts
 }
 
 // orderedCollectAndPublish collects logtails for n items in parallel via submit,
@@ -266,25 +284,78 @@ func collectOneTxn(
 }
 
 func (mgr *Manager) onTxnLogTails(items ...any) {
-	// Collect logtails for all txns in parallel via collectPool.
-	// A slow txn only blocks the publisher up to its slot, not the
-	// collection of later slots nor the publishing of earlier already-ready
-	// slots. generateLogtailWithTxn is still called in PrepareTS order.
 	collect := func(txn txnif.AsyncTxn) (*[]logtail.TableLogtail, func()) {
 		builder := NewTxnLogtailRespBuilder(mgr.rt)
 		return builder.CollectLogtail(txn)
 	}
-	orderedCollectAndPublish(
-		len(items),
-		func(i int) bool {
-			return items[i].(txnif.AsyncTxn).IsReplay()
-		},
-		func(fn func()) { _ = mgr.collectPool.Submit(fn) },
-		func(i int) *txnWithLogtails {
-			return collectOneTxn(items[i].(txnif.AsyncTxn), collect)
-		},
-		mgr.generateLogtailWithTxn,
-	)
+
+	// A barrier splits a queue batch into ordered transaction segments. Work
+	// after the barrier is deliberately not scheduled before the marker: it
+	// cannot contribute to the frontier and must not compete with the work the
+	// caller is waiting for. Each segment retains parallel collection and
+	// PrepareTS-ordered publication through orderedCollectAndPublish.
+	segmentStart := 0
+	flush := func(segmentEnd int) {
+		segment := items[segmentStart:segmentEnd]
+		orderedCollectAndPublish(
+			len(segment),
+			func(i int) bool {
+				txn, ok := segment[i].(txnif.AsyncTxn)
+				if !ok {
+					panic(fmt.Sprintf("unknown logtail queue item %T", segment[i]))
+				}
+				return txn.IsReplay()
+			},
+			func(fn func()) {
+				if err := mgr.collectPool.Submit(fn); err != nil {
+					panic(err)
+				}
+			},
+			func(i int) *txnWithLogtails {
+				return collectOneTxn(segment[i].(txnif.AsyncTxn), collect)
+			},
+			mgr.generateLogtailWithTxn,
+		)
+	}
+
+	for i, item := range items {
+		barrier, ok := item.(*readBarrier)
+		if !ok {
+			if _, ok := item.(txnif.AsyncTxn); !ok {
+				panic(fmt.Sprintf("unknown logtail queue item %T", item))
+			}
+			continue
+		}
+		flush(i)
+		barrier.complete(mgr.previousSaveTS.ToTimestamp())
+		segmentStart = i + 1
+	}
+	flush(len(items))
+}
+
+// ReadBarrier returns the latest logtail frontier after all transactions that
+// entered the manager before this call have been published. The returned
+// timestamp is an exact committed frontier, not a wall-clock estimate.
+func (mgr *Manager) ReadBarrier(ctx context.Context) (timestamp.Timestamp, error) {
+	if mgr.logtailCallback.Load() == nil {
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "logtail publisher is not registered")
+	}
+	if err := ctx.Err(); err != nil {
+		return timestamp.Timestamp{}, context.Cause(ctx)
+	}
+
+	barrier := newReadBarrier()
+	if _, err := mgr.logtailQueue.EnqueueWithContext(ctx, barrier); err != nil {
+		return timestamp.Timestamp{}, err
+	}
+
+	select {
+	case ts := <-barrier.done:
+		return ts, nil
+	case <-ctx.Done():
+		return timestamp.Timestamp{}, context.Cause(ctx)
+	}
 }
 
 func (mgr *Manager) Stop() {

--- a/pkg/vm/engine/tae/logtail/mgr_test.go
+++ b/pkg/vm/engine/tae/logtail/mgr_test.go
@@ -39,6 +39,33 @@ func goSubmit(fn func()) { go fn() }
 // collect effectively runs on the caller.
 func syncSubmit(fn func()) { fn() }
 
+type captureContextQueue struct {
+	items      chan any
+	enqueueErr error
+}
+
+func (q *captureContextQueue) Start() {}
+func (q *captureContextQueue) Stop()  {}
+
+func (q *captureContextQueue) Enqueue(item any) (any, error) {
+	return q.EnqueueWithContext(context.Background(), item)
+}
+
+func (q *captureContextQueue) EnqueueWithContext(
+	ctx context.Context,
+	item any,
+) (any, error) {
+	if q.enqueueErr != nil {
+		return item, q.enqueueErr
+	}
+	select {
+	case q.items <- item:
+		return item, nil
+	case <-ctx.Done():
+		return item, context.Cause(ctx)
+	}
+}
+
 func TestManagerTruncateTSConcurrentAccess(t *testing.T) {
 	mgr := &Manager{
 		table: NewTxnTable(1, func() types.TS { return types.TS{} }),
@@ -74,7 +101,10 @@ func TestManagerTruncateTSConcurrentAccess(t *testing.T) {
 
 func TestManagerReadBarrierReturnsPublishedFrontier(t *testing.T) {
 	want := types.BuildTS(42, 7)
-	mgr := &Manager{previousSaveTS: want}
+	mgr := &Manager{
+		previousSaveTS:   want,
+		readBarrierSlots: make(chan struct{}, maxPendingReadBarriers),
+	}
 	mgr.logtailQueue = sm.NewSafeQueue(4, 4, mgr.onTxnLogTails)
 	require.NoError(t, mgr.RegisterCallback(func(
 		timestamp.Timestamp, timestamp.Timestamp, func(), ...logtail.TableLogtail,
@@ -87,6 +117,111 @@ func TestManagerReadBarrierReturnsPublishedFrontier(t *testing.T) {
 	got, err := mgr.ReadBarrier(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, want.ToTimestamp(), got)
+}
+
+func TestManagerReadBarrierMarkerOwnsAdmissionAfterCallerCancel(t *testing.T) {
+	queue := &captureContextQueue{items: make(chan any, 2)}
+	mgr := &Manager{
+		logtailQueue:     queue,
+		readBarrierSlots: make(chan struct{}, 1),
+	}
+	require.NoError(t, mgr.RegisterCallback(func(
+		timestamp.Timestamp, timestamp.Timestamp, func(), ...logtail.TableLogtail,
+	) error {
+		return nil
+	}))
+
+	firstCtx, cancelFirst := context.WithCancel(t.Context())
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.ReadBarrier(firstCtx)
+		firstDone <- err
+	}()
+	first := (<-queue.items).(*readBarrier)
+	cancelFirst()
+	require.ErrorIs(t, <-firstDone, context.Canceled)
+	require.Equal(t, int64(1), mgr.pendingReadBarriers.Load())
+	require.Len(t, mgr.readBarrierSlots, 1)
+
+	blockedCtx, cancelBlocked := context.WithCancel(t.Context())
+	blockedDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.ReadBarrier(blockedCtx)
+		blockedDone <- err
+	}()
+	cancelBlocked()
+	require.ErrorIs(t, <-blockedDone, context.Canceled)
+	select {
+	case unexpected := <-queue.items:
+		t.Fatalf("barrier admission exceeded its bound: %T", unexpected)
+	default:
+	}
+
+	first.complete(timestamp.Timestamp{PhysicalTime: 1})
+	require.Zero(t, mgr.pendingReadBarriers.Load())
+	require.Empty(t, mgr.readBarrierSlots)
+
+	type barrierResult struct {
+		ts  timestamp.Timestamp
+		err error
+	}
+	lastDone := make(chan barrierResult, 1)
+	go func() {
+		ts, err := mgr.ReadBarrier(t.Context())
+		lastDone <- barrierResult{ts: ts, err: err}
+	}()
+	last := (<-queue.items).(*readBarrier)
+	want := timestamp.Timestamp{PhysicalTime: 2, LogicalTime: 3}
+	last.complete(want)
+	result := <-lastDone
+	require.NoError(t, result.err)
+	require.Equal(t, want, result.ts)
+	require.Zero(t, mgr.pendingReadBarriers.Load())
+	require.Empty(t, mgr.readBarrierSlots)
+}
+
+func TestManagerReadBarrierQueueRejectionReleasesAdmission(t *testing.T) {
+	mgr := &Manager{
+		logtailQueue: &captureContextQueue{
+			enqueueErr: sm.ErrClose,
+		},
+		readBarrierSlots: make(chan struct{}, 1),
+	}
+	require.NoError(t, mgr.RegisterCallback(func(
+		timestamp.Timestamp, timestamp.Timestamp, func(), ...logtail.TableLogtail,
+	) error {
+		return nil
+	}))
+
+	_, err := mgr.ReadBarrier(t.Context())
+	require.ErrorIs(t, err, sm.ErrClose)
+	require.Zero(t, mgr.pendingReadBarriers.Load())
+	require.Empty(t, mgr.readBarrierSlots)
+}
+
+func TestManagerReadBarrierCoalescesAdjacentMarkerFrontier(t *testing.T) {
+	want := types.BuildTS(42, 7).ToTimestamp()
+	mgr := &Manager{
+		previousSaveTS:   types.TimestampToTS(want),
+		readBarrierSlots: make(chan struct{}, 2),
+	}
+
+	newAdmittedBarrier := func() *readBarrier {
+		mgr.readBarrierSlots <- struct{}{}
+		mgr.pendingReadBarriers.Add(1)
+		return newReadBarrier(func() {
+			mgr.pendingReadBarriers.Add(-1)
+			<-mgr.readBarrierSlots
+		})
+	}
+	first := newAdmittedBarrier()
+	second := newAdmittedBarrier()
+
+	mgr.onTxnLogTails(first, second)
+	require.Equal(t, want, <-first.done)
+	require.Equal(t, want, <-second.done)
+	require.Zero(t, mgr.pendingReadBarriers.Load())
+	require.Empty(t, mgr.readBarrierSlots)
 }
 
 func TestManagerReadBarrierRequiresPublisher(t *testing.T) {

--- a/pkg/vm/engine/tae/logtail/mgr_test.go
+++ b/pkg/vm/engine/tae/logtail/mgr_test.go
@@ -24,7 +24,9 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/logtail"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logstore/sm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +70,42 @@ func TestManagerTruncateTSConcurrentAccess(t *testing.T) {
 	close(start)
 	wg.Wait()
 	require.Equal(t, types.BuildTS(iterations, 0), mgr.GetTruncateTS())
+}
+
+func TestManagerReadBarrierReturnsPublishedFrontier(t *testing.T) {
+	want := types.BuildTS(42, 7)
+	mgr := &Manager{previousSaveTS: want}
+	mgr.logtailQueue = sm.NewSafeQueue(4, 4, mgr.onTxnLogTails)
+	require.NoError(t, mgr.RegisterCallback(func(
+		timestamp.Timestamp, timestamp.Timestamp, func(), ...logtail.TableLogtail,
+	) error {
+		return nil
+	}))
+	mgr.logtailQueue.Start()
+	defer mgr.logtailQueue.Stop()
+
+	got, err := mgr.ReadBarrier(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, want.ToTimestamp(), got)
+}
+
+func TestManagerReadBarrierRequiresPublisher(t *testing.T) {
+	mgr := &Manager{}
+	_, err := mgr.ReadBarrier(t.Context())
+	require.ErrorContains(t, err, "publisher is not registered")
+}
+
+func TestManagerReadBarrierHonorsCanceledContext(t *testing.T) {
+	mgr := &Manager{}
+	require.NoError(t, mgr.RegisterCallback(func(
+		timestamp.Timestamp, timestamp.Timestamp, func(), ...logtail.TableLogtail,
+	) error {
+		return nil
+	}))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := mgr.ReadBarrier(ctx)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestOrderedCollectAndPublish_Empty(t *testing.T) {

--- a/pkg/vm/engine/tae/logtail/service/client.go
+++ b/pkg/vm/engine/tae/logtail/service/client.go
@@ -17,6 +17,7 @@ package service
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/ratelimit"
@@ -27,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/logtail"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 )
 
@@ -59,11 +61,22 @@ type LogtailClient struct {
 	broken    chan struct{} // mark morpc stream as broken when necessary
 	once      sync.Once
 
+	nextBarrierID atomic.Uint64
+	barriers      struct {
+		sync.Mutex
+		pending map[uint64]chan readBarrierResult
+	}
+
 	options struct {
 		rps int
 	}
 
 	limiter ratelimit.Limiter
+}
+
+type readBarrierResult struct {
+	timestamp timestamp.Timestamp
+	err       error
 }
 
 // NewLogtailClient constructs LogtailClient.
@@ -77,6 +90,7 @@ func NewLogtailClient(ctx context.Context, stream morpc.Stream, opts ...ClientOp
 		broken:    make(chan struct{}),
 		breakChan: make(chan struct{}, 10),
 	}
+	client.barriers.pending = make(map[uint64]chan readBarrierResult)
 
 	recvChan, err := stream.Receive()
 	if err != nil {
@@ -152,6 +166,73 @@ func (c *LogtailClient) Unsubscribe(
 	return c.sendRequest(ctx, request)
 }
 
+// ReadBarrier waits for the response to a stream-scoped publication barrier.
+// The returned timestamp identifies the exact TN logtail frontier; callers
+// must still wait until their local apply pipeline reaches it.
+func (c *LogtailClient) ReadBarrier(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
+	if c.streamBroken() {
+		return timestamp.Timestamp{}, moerr.NewStreamClosedNoCtx()
+	}
+
+	barrierID := c.nextBarrierID.Add(1)
+	resultC := make(chan readBarrierResult, 1)
+	c.barriers.Lock()
+	c.barriers.pending[barrierID] = resultC
+	c.barriers.Unlock()
+	defer c.removeReadBarrier(barrierID, resultC)
+
+	request := &LogtailRequest{}
+	request.Request = &logtail.LogtailRequest_ReadBarrier{
+		ReadBarrier: &logtail.ReadBarrierRequest{BarrierId: barrierID},
+	}
+	if err := c.sendRequest(ctx, request); err != nil {
+		return timestamp.Timestamp{}, err
+	}
+
+	select {
+	case result := <-resultC:
+		return result.timestamp, result.err
+	case <-ctx.Done():
+		return timestamp.Timestamp{}, context.Cause(ctx)
+	case <-c.ctx.Done():
+		return timestamp.Timestamp{}, c.ctx.Err()
+	case <-c.broken:
+		return timestamp.Timestamp{}, moerr.NewStreamClosedNoCtx()
+	}
+}
+
+func (c *LogtailClient) removeReadBarrier(
+	barrierID uint64,
+	resultC chan readBarrierResult,
+) {
+	c.barriers.Lock()
+	if current, ok := c.barriers.pending[barrierID]; ok && current == resultC {
+		delete(c.barriers.pending, barrierID)
+	}
+	c.barriers.Unlock()
+}
+
+func (c *LogtailClient) completeReadBarrier(response *logtail.ReadBarrierResponse) {
+	result := readBarrierResult{}
+	if response.Timestamp == nil {
+		result.err = moerr.NewInternalErrorNoCtx("logtail read barrier response has no timestamp")
+	} else {
+		result.timestamp = *response.Timestamp
+	}
+
+	c.barriers.Lock()
+	resultC, ok := c.barriers.pending[response.BarrierId]
+	if ok {
+		delete(c.barriers.pending, response.BarrierId)
+	}
+	c.barriers.Unlock()
+	if ok {
+		resultC <- result
+	}
+}
+
 func (c *LogtailClient) BreakoutReceive() {
 	c.breakChan <- struct{}{}
 }
@@ -182,7 +263,7 @@ func (c *LogtailClient) Receive(ctx context.Context) (*LogtailResponse, error) {
 				)
 
 				// mark stream as broken
-				c.once.Do(func() { close(c.broken) })
+				c.markStreamBroken()
 				return nil, moerr.NewStreamClosedNoCtx()
 			}
 			v2.LogTailReceiveQueueSizeGauge.Set(float64(len(c.recvChan)))
@@ -190,28 +271,34 @@ func (c *LogtailClient) Receive(ctx context.Context) (*LogtailResponse, error) {
 		}
 	}
 
-	prev, err := recvFunc()
-	if err != nil {
-		return nil, err
-	}
-	buf := make([]byte, 0, prev.MessageSize)
-	buf = AppendChunk(buf, prev.GetPayload())
-
-	for prev.Sequence < prev.MaxSequence {
-		segment, err := recvFunc()
+	for {
+		prev, err := recvFunc()
 		if err != nil {
 			return nil, err
 		}
-		buf = AppendChunk(buf, segment.GetPayload())
-		prev = segment
-	}
+		buf := make([]byte, 0, prev.MessageSize)
+		buf = AppendChunk(buf, prev.GetPayload())
 
-	resp := &LogtailResponse{}
-	if err := resp.Unmarshal(buf); err != nil {
-		logutil.Error("logtail client: fail to unmarshal logtail response", zap.Error(err))
-		return nil, err
+		for prev.Sequence < prev.MaxSequence {
+			segment, err := recvFunc()
+			if err != nil {
+				return nil, err
+			}
+			buf = AppendChunk(buf, segment.GetPayload())
+			prev = segment
+		}
+
+		resp := &LogtailResponse{}
+		if err := resp.Unmarshal(buf); err != nil {
+			logutil.Error("logtail client: fail to unmarshal logtail response", zap.Error(err))
+			return nil, err
+		}
+		if barrier := resp.GetReadBarrierResponse(); barrier != nil {
+			c.completeReadBarrier(barrier)
+			continue
+		}
+		return resp, nil
 	}
-	return resp, nil
 }
 
 // streamBroken returns true if stream is borken.
@@ -224,12 +311,27 @@ func (c *LogtailClient) streamBroken() bool {
 	return false
 }
 
+func (c *LogtailClient) markStreamBroken() {
+	c.once.Do(func() { close(c.broken) })
+}
+
 func (c *LogtailClient) sendRequest(ctx context.Context, request *LogtailRequest) error {
+	if err := ctx.Err(); err != nil {
+		return context.Cause(ctx)
+	}
+	if err := c.ctx.Err(); err != nil {
+		return err
+	}
+	if c.streamBroken() {
+		return moerr.NewStreamClosedNoCtx()
+	}
 	select {
 	case <-c.ctx.Done():
 		return c.ctx.Err()
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-c.broken:
+		return moerr.NewStreamClosedNoCtx()
 
 	case c.requestC <- request:
 		return nil
@@ -251,7 +353,9 @@ func (c *LogtailClient) sendWorker() error {
 
 		case request := <-c.requestC:
 			if err := sendFn(request); err != nil {
-				logutil.Error("logtail client: fail to send sub/unsub request via morpc stream", zap.Error(err))
+				logutil.Error("logtail client: fail to send request via morpc stream", zap.Error(err))
+				c.markStreamBroken()
+				return err
 			}
 		}
 	}

--- a/pkg/vm/engine/tae/logtail/service/client.go
+++ b/pkg/vm/engine/tae/logtail/service/client.go
@@ -34,6 +34,10 @@ import (
 
 const (
 	defaultRequestChanSize = 512
+	// Read barriers are control-plane requests sharing publication resources
+	// with ordinary logtails. Apply the same bound per client and globally at
+	// the server without rate-limiting the uncontended login path.
+	defaultMaxConcurrentReadBarriers = 100
 	// defaultRequestDeadline : default deadline for every request (subscribe and unsubscribe).
 	defaultRequestDeadline = 2 * time.Minute
 )
@@ -61,8 +65,9 @@ type LogtailClient struct {
 	broken    chan struct{} // mark morpc stream as broken when necessary
 	once      sync.Once
 
-	nextBarrierID atomic.Uint64
-	barriers      struct {
+	nextBarrierID    atomic.Uint64
+	readBarrierSlots chan struct{}
+	barriers         struct {
 		sync.Mutex
 		pending map[uint64]chan readBarrierResult
 	}
@@ -89,6 +94,9 @@ func NewLogtailClient(ctx context.Context, stream morpc.Stream, opts ...ClientOp
 		stream:    stream,
 		broken:    make(chan struct{}),
 		breakChan: make(chan struct{}, 10),
+		readBarrierSlots: make(
+			chan struct{}, defaultMaxConcurrentReadBarriers,
+		),
 	}
 	client.barriers.pending = make(map[uint64]chan readBarrierResult)
 
@@ -172,9 +180,22 @@ func (c *LogtailClient) Unsubscribe(
 func (c *LogtailClient) ReadBarrier(
 	ctx context.Context,
 ) (timestamp.Timestamp, error) {
+	if err := ctx.Err(); err != nil {
+		return timestamp.Timestamp{}, context.Cause(ctx)
+	}
 	if c.streamBroken() {
 		return timestamp.Timestamp{}, moerr.NewStreamClosedNoCtx()
 	}
+	select {
+	case c.readBarrierSlots <- struct{}{}:
+	case <-ctx.Done():
+		return timestamp.Timestamp{}, context.Cause(ctx)
+	case <-c.ctx.Done():
+		return timestamp.Timestamp{}, context.Cause(c.ctx)
+	case <-c.broken:
+		return timestamp.Timestamp{}, moerr.NewStreamClosedNoCtx()
+	}
+	defer func() { <-c.readBarrierSlots }()
 
 	barrierID := c.nextBarrierID.Add(1)
 	resultC := make(chan readBarrierResult, 1)

--- a/pkg/vm/engine/tae/logtail/service/client_barrier_test.go
+++ b/pkg/vm/engine/tae/logtail/service/client_barrier_test.go
@@ -101,6 +101,70 @@ func TestLogtailClientReadBarrierCorrelatesConcurrentResponses(t *testing.T) {
 	require.Equal(t, firstTS, first.ts)
 }
 
+func TestLogtailClientReadBarrierBoundsPendingCorrelationState(t *testing.T) {
+	requests := make(chan uint64, 2)
+	client := newBarrierTestClient(t, func(request *LogtailRequest) error {
+		requests <- request.GetReadBarrier().BarrierId
+		return nil
+	})
+	client.readBarrierSlots = make(chan struct{}, 1)
+
+	type result struct {
+		ts  timestamp.Timestamp
+		err error
+	}
+	firstDone := make(chan result, 1)
+	go func() {
+		ts, err := client.ReadBarrier(t.Context())
+		firstDone <- result{ts: ts, err: err}
+	}()
+	firstID := <-requests
+
+	blockedCtx, cancelBlocked := context.WithCancel(t.Context())
+	blockedDone := make(chan error, 1)
+	go func() {
+		_, err := client.ReadBarrier(blockedCtx)
+		blockedDone <- err
+	}()
+	cancelBlocked()
+	require.ErrorIs(t, <-blockedDone, context.Canceled)
+	select {
+	case unexpected := <-requests:
+		t.Fatalf("read-barrier correlation state exceeded its bound: %d", unexpected)
+	default:
+	}
+
+	firstTS := timestamp.Timestamp{PhysicalTime: 1, LogicalTime: 1}
+	client.completeReadBarrier(&logtail.ReadBarrierResponse{
+		BarrierId: firstID,
+		Timestamp: &firstTS,
+	})
+	first := <-firstDone
+	require.NoError(t, first.err)
+	require.Equal(t, firstTS, first.ts)
+
+	lastDone := make(chan result, 1)
+	go func() {
+		ts, err := client.ReadBarrier(t.Context())
+		lastDone <- result{ts: ts, err: err}
+	}()
+	lastID := <-requests
+	lastTS := timestamp.Timestamp{PhysicalTime: 2, LogicalTime: 2}
+	client.completeReadBarrier(&logtail.ReadBarrierResponse{
+		BarrierId: lastID,
+		Timestamp: &lastTS,
+	})
+	last := <-lastDone
+	require.NoError(t, last.err)
+	require.Equal(t, lastTS, last.ts)
+
+	client.barriers.Lock()
+	pending := len(client.barriers.pending)
+	client.barriers.Unlock()
+	require.Zero(t, pending)
+	require.Empty(t, client.readBarrierSlots)
+}
+
 func TestLogtailClientReceiveConsumesBarrierControlResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	stream := mock_morpc.NewMockStream(ctrl)
@@ -239,6 +303,7 @@ func TestLogtailClientReadBarrierSendFailureBreaksStream(t *testing.T) {
 	_, err := client.ReadBarrier(ctx)
 	require.Error(t, err)
 	require.True(t, client.streamBroken())
+	require.Empty(t, client.readBarrierSlots)
 	require.Error(t, client.Subscribe(t.Context(), api.TableID{}),
 		"requests after a broken stream must fail instead of entering an orphaned send queue")
 }

--- a/pkg/vm/engine/tae/logtail/service/client_barrier_test.go
+++ b/pkg/vm/engine/tae/logtail/service/client_barrier_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+	mock_morpc "github.com/matrixorigin/matrixone/pkg/common/morpc/mock_morpc"
+	"github.com/matrixorigin/matrixone/pkg/pb/api"
+	"github.com/matrixorigin/matrixone/pkg/pb/logtail"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+)
+
+func newBarrierTestClient(
+	t *testing.T,
+	send func(*LogtailRequest) error,
+) *LogtailClient {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	stream := mock_morpc.NewMockStream(ctrl)
+	stream.EXPECT().Receive().Return(make(chan morpc.Message), nil)
+	stream.EXPECT().ID().AnyTimes().Return(uint64(1))
+	stream.EXPECT().Send(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+		func(_ context.Context, message morpc.Message) error {
+			return send(message.(*LogtailRequest))
+		},
+	)
+	stream.EXPECT().Close(true).AnyTimes().Return(nil)
+	client, err := NewLogtailClient(t.Context(), stream)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	return client
+}
+
+func TestLogtailClientReadBarrierCorrelatesConcurrentResponses(t *testing.T) {
+	requests := make(chan uint64, 2)
+	client := newBarrierTestClient(t, func(request *LogtailRequest) error {
+		requests <- request.GetReadBarrier().BarrierId
+		return nil
+	})
+
+	type result struct {
+		ts  timestamp.Timestamp
+		err error
+	}
+	firstC := make(chan result, 1)
+	go func() {
+		ts, err := client.ReadBarrier(t.Context())
+		firstC <- result{ts: ts, err: err}
+	}()
+	firstID := <-requests
+
+	secondC := make(chan result, 1)
+	go func() {
+		ts, err := client.ReadBarrier(t.Context())
+		secondC <- result{ts: ts, err: err}
+	}()
+	secondID := <-requests
+	require.NotEqual(t, firstID, secondID)
+
+	secondTS := timestamp.Timestamp{PhysicalTime: 22, LogicalTime: 2}
+	client.completeReadBarrier(&logtail.ReadBarrierResponse{
+		BarrierId: secondID,
+		Timestamp: &secondTS,
+	})
+	second := <-secondC
+	require.NoError(t, second.err)
+	require.Equal(t, secondTS, second.ts)
+
+	select {
+	case <-firstC:
+		t.Fatal("response for the second barrier completed the first request")
+	default:
+	}
+	firstTS := timestamp.Timestamp{PhysicalTime: 11, LogicalTime: 1}
+	client.completeReadBarrier(&logtail.ReadBarrierResponse{
+		BarrierId: firstID,
+		Timestamp: &firstTS,
+	})
+	first := <-firstC
+	require.NoError(t, first.err)
+	require.Equal(t, firstTS, first.ts)
+}
+
+func TestLogtailClientReceiveConsumesBarrierControlResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := mock_morpc.NewMockStream(ctrl)
+	recvC := make(chan morpc.Message, 2)
+	stream.EXPECT().Receive().Return(recvC, nil)
+	stream.EXPECT().ID().Return(uint64(1))
+	stream.EXPECT().Close(true).AnyTimes().Return(nil)
+
+	frontier := timestamp.Timestamp{PhysicalTime: 33, LogicalTime: 3}
+	stream.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, message morpc.Message) error {
+			request := message.(*LogtailRequest).GetReadBarrier()
+			barrierSegment, err := encodeBarrierTestResponse(&LogtailResponse{
+				LogtailResponse: logtail.LogtailResponse{
+					Response: newReadBarrierResponse(request.BarrierId, frontier),
+				},
+			})
+			if err != nil {
+				return err
+			}
+			recvC <- barrierSegment
+			updateTo := frontier.Next()
+			updateSegment, err := encodeBarrierTestResponse(&LogtailResponse{
+				LogtailResponse: logtail.LogtailResponse{
+					Response: newUpdateResponse(frontier, updateTo),
+				},
+			})
+			if err != nil {
+				return err
+			}
+			recvC <- updateSegment
+			return nil
+		},
+	)
+
+	client, err := NewLogtailClient(t.Context(), stream)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	type receiveResult struct {
+		response *LogtailResponse
+		err      error
+	}
+	receiveC := make(chan receiveResult, 1)
+	go func() {
+		response, receiveErr := client.Receive(t.Context())
+		receiveC <- receiveResult{response: response, err: receiveErr}
+	}()
+
+	got, err := client.ReadBarrier(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, frontier, got)
+	received := <-receiveC
+	require.NoError(t, received.err)
+	require.NotNil(t, received.response.GetUpdateResponse(),
+		"barrier control responses must not escape to the logtail dispatcher")
+}
+
+func encodeBarrierTestResponse(
+	response *LogtailResponse,
+) (*LogtailResponseSegment, error) {
+	payload, err := response.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return &LogtailResponseSegment{MessageSegment: logtail.MessageSegment{
+		MessageSize: int32(len(payload)),
+		Sequence:    1,
+		MaxSequence: 1,
+		Payload:     payload,
+	}}, nil
+}
+
+func TestLogtailClientReadBarrierCancellationRemovesPendingRequest(t *testing.T) {
+	requestSent := make(chan struct{}, 1)
+	client := newBarrierTestClient(t, func(*LogtailRequest) error {
+		requestSent <- struct{}{}
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.ReadBarrier(ctx)
+		done <- err
+	}()
+	<-requestSent
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+
+	client.barriers.Lock()
+	pending := len(client.barriers.pending)
+	client.barriers.Unlock()
+	require.Zero(t, pending)
+}
+
+func TestLogtailClientReadBarrierCloseRemovesPendingRequest(t *testing.T) {
+	requestSent := make(chan struct{}, 1)
+	client := newBarrierTestClient(t, func(*LogtailRequest) error {
+		requestSent <- struct{}{}
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.ReadBarrier(t.Context())
+		done <- err
+	}()
+	<-requestSent
+	require.NoError(t, client.Close())
+	require.Error(t, <-done)
+
+	client.barriers.Lock()
+	pending := len(client.barriers.pending)
+	client.barriers.Unlock()
+	require.Zero(t, pending)
+}
+
+func TestLogtailClientReadBarrierRejectsMissingTimestamp(t *testing.T) {
+	client := &LogtailClient{}
+	client.barriers.pending = make(map[uint64]chan readBarrierResult)
+	resultC := make(chan readBarrierResult, 1)
+	client.barriers.pending[1] = resultC
+
+	client.completeReadBarrier(&logtail.ReadBarrierResponse{BarrierId: 1})
+	result := <-resultC
+	require.ErrorContains(t, result.err, "has no timestamp")
+	require.True(t, result.timestamp.IsEmpty())
+}
+
+func TestLogtailClientReadBarrierSendFailureBreaksStream(t *testing.T) {
+	wantErr := errors.New("send failed")
+	client := newBarrierTestClient(t, func(*LogtailRequest) error { return wantErr })
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, err := client.ReadBarrier(ctx)
+	require.Error(t, err)
+	require.True(t, client.streamBroken())
+	require.Error(t, client.Subscribe(t.Context(), api.TableID{}),
+		"requests after a broken stream must fail instead of entering an orphaned send queue")
+}

--- a/pkg/vm/engine/tae/logtail/service/event.go
+++ b/pkg/vm/engine/tae/logtail/service/event.go
@@ -92,6 +92,9 @@ func (n *Notifier) Drain() {
 			if event.closeCB != nil {
 				callbacks = append(callbacks, event.closeCB)
 			}
+			if event.barrier != nil && event.barrier.release != nil {
+				callbacks = append(callbacks, event.barrier.release)
+			}
 		default:
 			n.mu.Unlock()
 			for _, callback := range callbacks {

--- a/pkg/vm/engine/tae/logtail/service/event.go
+++ b/pkg/vm/engine/tae/logtail/service/event.go
@@ -60,6 +60,25 @@ func (n *Notifier) NotifyLogtail(
 	return nil
 }
 
+func (n *Notifier) NotifyReadBarrier(
+	ctx context.Context,
+	barrier readBarrierEvent,
+) error {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	if n.closed {
+		return context.Canceled
+	}
+	select {
+	case <-n.ctx.Done():
+		return n.ctx.Err()
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case n.C <- event{barrier: &barrier}:
+		return nil
+	}
+}
+
 // Drain releases events which were accepted by the notifier but cannot be
 // published because the server is shutting down. Call it only after all event
 // consumers have stopped, otherwise ownership would race with publication.
@@ -87,4 +106,5 @@ type event struct {
 	from, to timestamp.Timestamp
 	closeCB  func()
 	logtails []logtail.TableLogtail
+	barrier  *readBarrierEvent
 }

--- a/pkg/vm/engine/tae/logtail/service/server.go
+++ b/pkg/vm/engine/tae/logtail/service/server.go
@@ -104,6 +104,7 @@ type readBarrierEvent struct {
 	barrierID uint64
 	timestamp timestamp.Timestamp
 	session   *Session
+	release   func()
 }
 
 // LogtailServer handles logtail push logic.
@@ -145,6 +146,12 @@ type LogtailServer struct {
 	pullWorkerPool chan struct{}
 
 	event *Notifier
+	// readBarrierSlots bounds barrier work across the entire shared publication
+	// path, from TN queue admission through notifier ordering to the per-session
+	// response hand-off. Releasing at the manager frontier would be too early:
+	// a multi-CN login flood could otherwise accumulate in the notifier and
+	// backpressure ordinary logtail publication.
+	readBarrierSlots chan struct{}
 
 	logtailer taelogtail.Logtailer
 
@@ -211,6 +218,7 @@ func NewLogtailServer(
 		subReqChan:             make(chan subscription, 100),
 		subTailChan:            make(chan *LogtailPhase, 300),
 		pullWorkerPool:         make(chan struct{}, cfg.PullWorkerPoolSize),
+		readBarrierSlots:       make(chan struct{}, defaultMaxConcurrentReadBarriers),
 		logtailer:              logtailer,
 	}
 	s.pendingSessionErrors.items = make(map[*Session]error)
@@ -320,6 +328,24 @@ func (s *LogtailServer) onReadBarrier(
 	stream morpcStream,
 	req *logtail.ReadBarrierRequest,
 ) error {
+	select {
+	case s.readBarrierSlots <- struct{}{}:
+	case <-sendCtx.Done():
+		return context.Cause(sendCtx)
+	case <-s.rootCtx.Done():
+		return context.Cause(s.rootCtx)
+	}
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { <-s.readBarrierSlots })
+	}
+	transferred := false
+	defer func() {
+		if !transferred {
+			release()
+		}
+	}()
+
 	session, err := s.getSession(stream)
 	if err != nil {
 		return err
@@ -328,12 +354,18 @@ func (s *LogtailServer) onReadBarrier(
 	if err != nil {
 		return err
 	}
-	return s.event.NotifyReadBarrier(sendCtx, readBarrierEvent{
+	err = s.event.NotifyReadBarrier(sendCtx, readBarrierEvent{
 		timeout:   ContextTimeout(sendCtx, s.cfg.ResponseSendTimeout),
 		barrierID: req.BarrierId,
 		timestamp: target,
 		session:   session,
+		release:   release,
 	})
+	if err != nil {
+		return err
+	}
+	transferred = true
+	return nil
 }
 
 // onSubscription handls subscription.
@@ -683,6 +715,9 @@ bootstrap:
 }
 
 func (s *LogtailServer) sendReadBarrier(ctx context.Context, barrier readBarrierEvent) {
+	if barrier.release != nil {
+		defer barrier.release()
+	}
 	sendCtx, cancel := context.WithTimeout(ctx, barrier.timeout)
 	defer cancel()
 	// A normal publish may omit an update when none of its table tails are

--- a/pkg/vm/engine/tae/logtail/service/server.go
+++ b/pkg/vm/engine/tae/logtail/service/server.go
@@ -99,6 +99,13 @@ type subscription struct {
 	session    *Session
 }
 
+type readBarrierEvent struct {
+	timeout   time.Duration
+	barrierID uint64
+	timestamp timestamp.Timestamp
+	session   *Session
+}
+
 // LogtailServer handles logtail push logic.
 type LogtailServer struct {
 	pool struct {
@@ -300,7 +307,33 @@ func (s *LogtailServer) onMessage(
 		return s.onUnsubscription(ctx, stream, req)
 	}
 
+	if req := msg.GetReadBarrier(); req != nil {
+		logger.Debug("on read barrier", zap.Uint64("barrier-id", req.BarrierId))
+		return s.onReadBarrier(ctx, stream, req)
+	}
+
 	return moerr.NewInvalidArg(ctx, "request", msg)
+}
+
+func (s *LogtailServer) onReadBarrier(
+	sendCtx context.Context,
+	stream morpcStream,
+	req *logtail.ReadBarrierRequest,
+) error {
+	session, err := s.getSession(stream)
+	if err != nil {
+		return err
+	}
+	target, err := s.logtailer.ReadBarrier(sendCtx)
+	if err != nil {
+		return err
+	}
+	return s.event.NotifyReadBarrier(sendCtx, readBarrierEvent{
+		timeout:   ContextTimeout(sendCtx, s.cfg.ResponseSendTimeout),
+		barrierID: req.BarrierId,
+		timestamp: target,
+		session:   session,
+	})
 }
 
 // onSubscription handls subscription.
@@ -577,24 +610,32 @@ func (s *LogtailServer) logtailSender(ctx context.Context) {
 	// every later subscription snapshot and incremental event is ordered after
 	// this timestamp. Advancing from Logtailer.Now would skip accepted events
 	// that have not reached the publisher yet.
-	select {
-	case <-ctx.Done():
-		s.logger.Info("context done", zap.Error(ctx.Err()))
-		return
-	case e, ok := <-s.event.C:
-		if !ok {
-			s.logger.Info("publishment channel closed")
+bootstrap:
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("context done", zap.Error(ctx.Err()))
 			return
-		}
-		s.waterline.Advance(e.to)
-		s.logger.Info(
-			"logtail.service.init.waterline",
-			zap.String("ts", e.to.String()),
-		)
-		if e.closeCB != nil {
-			// The bootstrap event is expected to be metadata-only. Preserve
-			// ownership safety if a custom producer violates that contract.
-			e.closeCB()
+		case e, ok := <-s.event.C:
+			if !ok {
+				s.logger.Info("publishment channel closed")
+				return
+			}
+			if e.barrier != nil {
+				s.sendReadBarrier(ctx, *e.barrier)
+				continue
+			}
+			s.waterline.Advance(e.to)
+			s.logger.Info(
+				"logtail.service.init.waterline",
+				zap.String("ts", e.to.String()),
+			)
+			if e.closeCB != nil {
+				// The bootstrap event is expected to be metadata-only. Preserve
+				// ownership safety if a custom producer violates that contract.
+				e.closeCB()
+			}
+			break bootstrap
 		}
 	}
 
@@ -632,8 +673,40 @@ func (s *LogtailServer) logtailSender(ctx context.Context) {
 				s.logger.Info("publishment channel closed")
 				return
 			}
-			s.publishEvent(ctx, e)
+			if e.barrier != nil {
+				s.sendReadBarrier(ctx, *e.barrier)
+			} else {
+				s.publishEvent(ctx, e)
+			}
 		}
+	}
+}
+
+func (s *LogtailServer) sendReadBarrier(ctx context.Context, barrier readBarrierEvent) {
+	sendCtx, cancel := context.WithTimeout(ctx, barrier.timeout)
+	defer cancel()
+	// A normal publish may omit an update when none of its table tails are
+	// subscribed by this session. Force the exact TN frontier through the
+	// ordinary CN apply queues before acknowledging the barrier, otherwise a
+	// correct read could still wait for the periodic transport heartbeat.
+	if err := barrier.session.TrySendProgressResponse(sendCtx, barrier.timestamp); err != nil {
+		s.logger.Error(
+			"fail to send read barrier progress",
+			zap.Uint64("barrier-id", barrier.barrierID),
+			zap.Error(err),
+		)
+		s.NotifySessionError(barrier.session, err)
+		return
+	}
+	if err := barrier.session.TrySendReadBarrierResponse(
+		sendCtx, barrier.barrierID, barrier.timestamp,
+	); err != nil {
+		s.logger.Error(
+			"fail to send read barrier response",
+			zap.Uint64("barrier-id", barrier.barrierID),
+			zap.Error(err),
+		)
+		s.NotifySessionError(barrier.session, err)
 	}
 }
 

--- a/pkg/vm/engine/tae/logtail/service/server_test.go
+++ b/pkg/vm/engine/tae/logtail/service/server_test.go
@@ -162,6 +162,34 @@ func TestReadBarrierResponseFollowsEarlierLogtailUpdate(t *testing.T) {
 	require.NotNil(t, barrier)
 	require.Equal(t, uint64(7), barrier.BarrierId)
 	require.Equal(t, frontier, *barrier.Timestamp)
+	require.Empty(t, server.readBarrierSlots,
+		"the end-to-end admission slot must be released after response hand-off")
+}
+
+func TestReadBarrierServerAdmissionHonorsCancellation(t *testing.T) {
+	barrierCalled := false
+	logtailer := &controlledLogtailer{
+		barrierFn: func(context.Context) (timestamp.Timestamp, error) {
+			barrierCalled = true
+			return timestamp.Timestamp{}, nil
+		},
+	}
+	server := newUnitLogtailServer(t, logtailer)
+	server.readBarrierSlots = make(chan struct{}, 1)
+	server.readBarrierSlots <- struct{}{}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err := server.onReadBarrier(
+		ctx,
+		newCaptureStream(newCaptureSession()),
+		&logtail.ReadBarrierRequest{BarrierId: 1},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, barrierCalled)
+	require.Len(t, server.readBarrierSlots, 1,
+		"a canceled waiter must not release another request's slot")
+	<-server.readBarrierSlots
 }
 
 func TestReadBarrierForcesFilteredProgressBeforeResponse(t *testing.T) {

--- a/pkg/vm/engine/tae/logtail/service/server_test.go
+++ b/pkg/vm/engine/tae/logtail/service/server_test.go
@@ -122,6 +122,152 @@ func TestService(t *testing.T) {
 	}
 }
 
+func TestReadBarrierResponseFollowsEarlierLogtailUpdate(t *testing.T) {
+	frontier := timestamp.Timestamp{PhysicalTime: 20, LogicalTime: 2}
+	logtailer := &controlledLogtailer{
+		now: frontier,
+		barrierFn: func(context.Context) (timestamp.Timestamp, error) {
+			return frontier, nil
+		},
+	}
+	server := newUnitLogtailServer(t, logtailer)
+	transport := newCaptureSession()
+	stream := newCaptureStream(transport)
+	session, err := server.getSession(stream)
+	require.NoError(t, err)
+
+	table := mockTable(1, 2, 3)
+	id := MarshalTableID(&table)
+	repeated, generation := session.RegisterWithGeneration(id, table)
+	require.False(t, repeated)
+	completed, err := session.CompleteSubscription(
+		t.Context(), id, generation, mockLogtail(table, timestamp.Timestamp{}), nil,
+	)
+	require.True(t, completed)
+	require.NoError(t, err)
+	require.NotNil(t, receiveCapturedLogtailResponse(t, transport).GetSubscribeResponse())
+
+	from := timestamp.Timestamp{PhysicalTime: 10, LogicalTime: 1}
+	tail := mockLogtail(table, frontier)
+	require.NoError(t, logtailer.notify(from, frontier, nil, tail))
+	require.NoError(t, server.onReadBarrier(
+		t.Context(), stream, &logtail.ReadBarrierRequest{BarrierId: 7},
+	))
+
+	update := receiveCapturedLogtailResponse(t, transport)
+	require.NotNil(t, update.GetUpdateResponse())
+	require.Equal(t, frontier, *update.GetUpdateResponse().To)
+
+	barrier := receiveCapturedLogtailResponse(t, transport).GetReadBarrierResponse()
+	require.NotNil(t, barrier)
+	require.Equal(t, uint64(7), barrier.BarrierId)
+	require.Equal(t, frontier, *barrier.Timestamp)
+}
+
+func TestReadBarrierForcesFilteredProgressBeforeResponse(t *testing.T) {
+	frontier := timestamp.Timestamp{PhysicalTime: 30, LogicalTime: 3}
+	logtailer := &controlledLogtailer{
+		now: frontier,
+		barrierFn: func(context.Context) (timestamp.Timestamp, error) {
+			return frontier, nil
+		},
+	}
+	server := newUnitLogtailServer(t, logtailer)
+	transport := newCaptureSession()
+	stream := newCaptureStream(transport)
+	session, err := server.getSession(stream)
+	require.NoError(t, err)
+
+	subscribed := mockTable(1, 2, 3)
+	id := MarshalTableID(&subscribed)
+	repeated, generation := session.RegisterWithGeneration(id, subscribed)
+	require.False(t, repeated)
+	completed, err := session.CompleteSubscription(
+		t.Context(), id, generation, mockLogtail(subscribed, timestamp.Timestamp{}), nil,
+	)
+	require.True(t, completed)
+	require.NoError(t, err)
+	require.NotNil(t, receiveCapturedLogtailResponse(t, transport).GetSubscribeResponse())
+
+	// Initialize the session frontier below the barrier, then publish a commit
+	// for an unsubscribed table. Publish deliberately filters that tail and its
+	// periodic heartbeat is not due, so the barrier must supply progress.
+	from := timestamp.Timestamp{PhysicalTime: 10, LogicalTime: 1}
+	visible := timestamp.Timestamp{PhysicalTime: 20, LogicalTime: 2}
+	require.NoError(t, logtailer.notify(
+		from, visible, nil, mockLogtail(subscribed, visible),
+	))
+	update := receiveCapturedLogtailResponse(t, transport).GetUpdateResponse()
+	require.NotNil(t, update)
+	require.Equal(t, visible, *update.To)
+
+	unsubscribed := mockTable(9, 9, 9)
+	require.NoError(t, logtailer.notify(
+		visible, frontier, nil, mockLogtail(unsubscribed, frontier),
+	))
+	require.NoError(t, server.onReadBarrier(
+		t.Context(), stream, &logtail.ReadBarrierRequest{BarrierId: 8},
+	))
+
+	progress := receiveCapturedLogtailResponse(t, transport).GetUpdateResponse()
+	require.NotNil(t, progress)
+	require.Empty(t, progress.LogtailList)
+	require.Equal(t, visible, *progress.From)
+	require.Equal(t, frontier, *progress.To)
+
+	barrier := receiveCapturedLogtailResponse(t, transport).GetReadBarrierResponse()
+	require.NotNil(t, barrier)
+	require.Equal(t, uint64(8), barrier.BarrierId)
+	require.Equal(t, frontier, *barrier.Timestamp)
+}
+
+func TestReadBarrierDoesNotRegressNewerSessionProgress(t *testing.T) {
+	barrierFrontier := timestamp.Timestamp{PhysicalTime: 30, LogicalTime: 3}
+	newerFrontier := timestamp.Timestamp{PhysicalTime: 40, LogicalTime: 4}
+	logtailer := &controlledLogtailer{
+		now: barrierFrontier,
+		barrierFn: func(context.Context) (timestamp.Timestamp, error) {
+			return barrierFrontier, nil
+		},
+	}
+	server := newUnitLogtailServer(t, logtailer)
+	transport := newCaptureSession()
+	stream := newCaptureStream(transport)
+	session, err := server.getSession(stream)
+	require.NoError(t, err)
+
+	table := mockTable(1, 2, 3)
+	id := MarshalTableID(&table)
+	repeated, generation := session.RegisterWithGeneration(id, table)
+	require.False(t, repeated)
+	completed, err := session.CompleteSubscription(
+		t.Context(), id, generation, mockLogtail(table, timestamp.Timestamp{}), nil,
+	)
+	require.True(t, completed)
+	require.NoError(t, err)
+	require.NotNil(t, receiveCapturedLogtailResponse(t, transport).GetSubscribeResponse())
+
+	// A transaction ordered after the manager marker may reach the global
+	// sender before the barrier event. The session must keep the newer frontier
+	// and enqueue no regressing progress update.
+	from := timestamp.Timestamp{PhysicalTime: 20, LogicalTime: 2}
+	require.NoError(t, logtailer.notify(
+		from, newerFrontier, nil, mockLogtail(table, newerFrontier),
+	))
+	update := receiveCapturedLogtailResponse(t, transport).GetUpdateResponse()
+	require.NotNil(t, update)
+	require.Equal(t, newerFrontier, *update.To)
+
+	require.NoError(t, server.onReadBarrier(
+		t.Context(), stream, &logtail.ReadBarrierRequest{BarrierId: 9},
+	))
+	barrier := receiveCapturedLogtailResponse(t, transport).GetReadBarrierResponse()
+	require.NotNil(t, barrier)
+	require.Equal(t, uint64(9), barrier.BarrierId)
+	require.Equal(t, barrierFrontier, *barrier.Timestamp)
+	require.Empty(t, transport.writes, "barrier must not enqueue a regressing update")
+}
+
 func TestNewLogtailServerRejectsSmallRPCMessageSize(t *testing.T) {
 	cfg := options.NewDefaultLogtailServerCfg()
 	cfg.RpcMaxMessageSize = 1
@@ -197,6 +343,11 @@ func (m *logtailer) RangeLogtail(
 }
 
 func (m *logtailer) RegisterCallback(cb func(from, to timestamp.Timestamp, closeCB func(), tails ...logtail.TableLogtail) error) {
+}
+
+func (m *logtailer) ReadBarrier(context.Context) (timestamp.Timestamp, error) {
+	frontier, _ := m.Now()
+	return frontier, nil
 }
 
 func (m *logtailer) TableLogtail(

--- a/pkg/vm/engine/tae/logtail/service/session.go
+++ b/pkg/vm/engine/tae/logtail/service/session.go
@@ -835,6 +835,50 @@ func (ss *Session) TrySendUpdateResponse(
 	return ss.sendResponse(sendCtx, resp, false)
 }
 
+// TrySendProgressResponse makes to observable through the ordinary CN apply
+// pipeline even when every preceding logtail was filtered out for this
+// session. Responses are admitted by the global logtail sender, so holding
+// publishMu across the non-blocking hand-off preserves the same per-session
+// frontier order as Publish.
+func (ss *Session) TrySendProgressResponse(
+	sendCtx context.Context,
+	to timestamp.Timestamp,
+) error {
+	ss.publishMu.Lock()
+	defer ss.publishMu.Unlock()
+
+	// A ready subscriber has already applied its subscription snapshots. If no
+	// incremental response initialized exactFrom yet, that snapshot is at least
+	// as new as the barrier frontier and no extra progress response is needed.
+	ss.publishInit.Do(func() {
+		ss.exactFrom = to
+	})
+	if to.LessEq(ss.exactFrom) {
+		return nil
+	}
+
+	resp := ss.responses.Acquire()
+	resp.Response = newUpdateResponse(ss.exactFrom, to)
+	if err := ss.sendResponse(sendCtx, resp, false); err != nil {
+		return err
+	}
+	ss.exactFrom = to
+	return nil
+}
+
+// TrySendReadBarrierResponse preserves global logtail progress: a congested
+// session reconnects instead of blocking every other subscriber behind its
+// barrier response.
+func (ss *Session) TrySendReadBarrierResponse(
+	sendCtx context.Context,
+	barrierID uint64,
+	ts timestamp.Timestamp,
+) error {
+	resp := ss.responses.Acquire()
+	resp.Response = newReadBarrierResponse(barrierID, ts)
+	return ss.sendResponse(sendCtx, resp, false)
+}
+
 // SendResponse sends response.
 //
 // If the sender of Session finished, it would block until
@@ -986,6 +1030,18 @@ func newUnsubscriptionResponse(
 	return &logtail.LogtailResponse_UnsubscribeResponse{
 		UnsubscribeResponse: &logtail.UnSubscribeResponse{
 			Table: &table,
+		},
+	}
+}
+
+func newReadBarrierResponse(
+	barrierID uint64,
+	ts timestamp.Timestamp,
+) *logtail.LogtailResponse_ReadBarrierResponse {
+	return &logtail.LogtailResponse_ReadBarrierResponse{
+		ReadBarrierResponse: &logtail.ReadBarrierResponse{
+			BarrierId: barrierID,
+			Timestamp: &ts,
 		},
 	}
 }

--- a/pkg/vm/engine/tae/logtail/service/test_fixture_test.go
+++ b/pkg/vm/engine/tae/logtail/service/test_fixture_test.go
@@ -32,10 +32,11 @@ import (
 // controlledLogtailer makes the server's asynchronous boundaries deterministic:
 // tests decide when a callback arrives and can block either subscription phase.
 type controlledLogtailer struct {
-	mu       sync.Mutex
-	callback func(timestamp.Timestamp, timestamp.Timestamp, func(), ...logtail.TableLogtail) error
-	now      timestamp.Timestamp
-	tableFn  func(context.Context, api.TableID, timestamp.Timestamp, timestamp.Timestamp) (logtail.TableLogtail, func(), error)
+	mu        sync.Mutex
+	callback  func(timestamp.Timestamp, timestamp.Timestamp, func(), ...logtail.TableLogtail) error
+	now       timestamp.Timestamp
+	tableFn   func(context.Context, api.TableID, timestamp.Timestamp, timestamp.Timestamp) (logtail.TableLogtail, func(), error)
+	barrierFn func(context.Context) (timestamp.Timestamp, error)
 }
 
 var _ taelogtail.Logtailer = (*controlledLogtailer)(nil)
@@ -70,6 +71,17 @@ func (l *controlledLogtailer) Now() (timestamp.Timestamp, timestamp.Timestamp) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.now, timestamp.Timestamp{}
+}
+
+func (l *controlledLogtailer) ReadBarrier(ctx context.Context) (timestamp.Timestamp, error) {
+	l.mu.Lock()
+	fn := l.barrierFn
+	frontier := l.now
+	l.mu.Unlock()
+	if fn != nil {
+		return fn(ctx)
+	}
+	return frontier, nil
 }
 
 func (l *controlledLogtailer) notify(

--- a/pkg/vm/engine/tae/logtail/service/unhappy_path_test.go
+++ b/pkg/vm/engine/tae/logtail/service/unhappy_path_test.go
@@ -1181,6 +1181,20 @@ func TestNotifierDrainIsIdempotent(t *testing.T) {
 		"an event accepted after the final drain would leak its callback")
 }
 
+func TestNotifierDrainReleasesReadBarrierAdmission(t *testing.T) {
+	notifier := NewNotifier(context.Background(), 1)
+	var released atomic.Int32
+	require.NoError(t, notifier.NotifyReadBarrier(
+		t.Context(),
+		readBarrierEvent{release: func() { released.Add(1) }},
+	))
+
+	notifier.Drain()
+	notifier.Drain()
+	require.Equal(t, int32(1), released.Load(),
+		"a queued barrier must release end-to-end admission exactly once")
+}
+
 func TestSubscriptionWaitsForOrderedBootstrapEvent(t *testing.T) {
 	phaseOneCalled := make(chan struct{})
 	var phaseOneOnce sync.Once

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -1335,6 +1335,14 @@ type StatsRefresher interface {
 	RefreshTableStats(ctx context.Context, key pb.StatsInfoKey) (*pb.StatsInfo, error)
 }
 
+// LogtailReadBarrier is an optional engine capability that establishes a
+// linearizable read boundary against the TN commit/logtail publication order.
+// On success, all commits completed before the boundary are visible through
+// this local engine instance and frontier is the exact applied logtail target.
+type LogtailReadBarrier interface {
+	AcquireLogtailReadBarrier(ctx context.Context) (frontier timestamp.Timestamp, err error)
+}
+
 type VectorPool interface {
 	PutBatch(bat *batch.Batch)
 	GetVector(typ types.Type) *vector.Vector

--- a/proto/logtail.proto
+++ b/proto/logtail.proto
@@ -35,6 +35,13 @@ message UnsubscribeRequest {
     api.TableID table = 1;
 }
 
+// ReadBarrierRequest asks the TN logtail publisher for a linearizable
+// publication frontier. barrier_id is scoped to one stream and correlates the
+// asynchronous response with its caller.
+message ReadBarrierRequest {
+    uint64 barrier_id = 1;
+}
+
 // TableLogtail describes total or additional logtail for a table.
 message TableLogtail {
     string ckp_location         = 1;
@@ -80,12 +87,21 @@ message UnSubscribeResponse {
     api.TableID table = 1;
 }
 
+// ReadBarrierResponse is sent only after every logtail event ordered before
+// the corresponding request has been admitted to this stream's response
+// sequence. The CN must still wait until it has applied this timestamp.
+message ReadBarrierResponse {
+    uint64 barrier_id              = 1;
+    timestamp.Timestamp timestamp  = 2;
+}
+
 // logtail stream request
 message LogtailRequest {
     uint64 request_id = 1;
     oneof request {
         SubscribeRequest subscribe_table     = 2;
         UnsubscribeRequest unsubscribe_table = 3;
+        ReadBarrierRequest read_barrier       = 4;
     }
 };
 
@@ -97,6 +113,7 @@ message LogtailResponse {
         UnSubscribeResponse unsubscribe_response = 3;
         UpdateResponse update_response           = 4;
         ErrorResponse error                      = 5;
+        ReadBarrierResponse read_barrier_response = 6;
     }
 };
 


### PR DESCRIPTION
## What changed

Replace the fixed HLC uncertainty wait used by authentication with a generic,
TN-ordered logtail read barrier:

- place a barrier marker in the same TN FIFO as committed transactions and
  return the exact published frontier;
- order logtail updates, forced filtered progress, and the barrier response
  through the existing per-session stream;
- correlate concurrent barrier requests and wait for the normal CN apply
  pipeline before returning;
- use the generic engine capability from authentication without adding
  catalog-specific TN logic;
- fail closed on cancellation, reconnect, missing capabilities, queue
  pressure, and regressing apply timestamps;
- introduce the wire contract at MORPC v39; protocol <=38 retains the legacy
  HLC fence during rolling upgrades.

The invariant is:

```text
commit completes before barrier begins
  => commit precedes TN marker
  => its logtail precedes the barrier response
  => CN apply reaches the exact frontier before the barrier returns
```

The full ordering, ownership, upgrade, and failure model is documented in
`docs/design/authentication_catalog_freshness.md`.

## Systemic overload and hot-path fixes

The final design bounds barrier work across every shared stage instead of only
making queue insertion cancellable:

- each CN retains at most 100 in-flight request correlations;
- the logtail server admits at most 100 barriers globally and keeps each slot
  owned through TN processing, notifier ordering, and response hand-off;
- the manager independently caps markers at 100, one queue batch, so barriers
  cannot fill the 10,000-entry commit FIFO;
- shutdown drains queued barrier ownership, while cancellation before and
  after TN admission has distinct, exactly-once cleanup;
- adjacent markers at one FIFO frontier are completed together without empty
  collection segments.

Normal commit traffic keeps the original direct `SafeQueue.Enqueue` channel
send. Context checks/selects exist only in `EnqueueWithContext`; transaction-
only manager batches perform one atomic pending-barrier load and do not scan or
type-assert the batch twice.

## Root cause and performance

#27763 fenced every login beyond the HLC uncertainty upper bound. With the
default 500ms max clock offset, each fresh connection paid about 500ms even
when there was no real logtail lag. TPCH reconnects for each query, so 22
queries accumulated about 11 seconds, matching #27834's regression.

Initial candidate validation on `10.222.1.55` (exact commit `14c0181070`):

| Check | Result |
|---|---:|
| main fresh login | about 513-527ms each |
| main, 22 sequential fresh connections | 11.415s |
| candidate, 30 sequential fresh connections | 649ms total, 21ms average, p95 31ms |
| password mutation followed immediately by login | 20/20 new password accepted; 0 stale old-password accepts |
| role revoke/grant followed immediately by authorization | 0 stale revoke accepts; 20/20 regrants visible |

On the final code, the focused `SafeQueue` benchmark (Apple M4, 1s x 3,
0 alloc/op) changed from a median 76.95ns/op at the prior PR head to
58.59ns/op after restoring the background hot path, about 24% lower.

Actual TPCH-10G must still be rerun on the final head as a merge acceptance
gate; synthetic connection timing is supporting evidence, not a replacement.

## Validation

- rebased onto `main@f779dff860`; historical main-merge commits were removed, the three logical commits were preserved, and range-diff is patch-equivalent except for the required v38-to-v39 capability allocation;
- focused rebase validation passed for the v38 legacy authentication fallback, v39 TN-ordered barrier, fail-closed/cancellation paths, and the independent v38 temporary-table migration contract;
- CGo-aware normal tests passed for logstore/sm, TAE logtail manager/service,
  disttae, engine/frontend, and status;
- race tests passed three times for logstore/sm, TAE logtail manager/service;
- the new shared-cluster acceptance test ran three times: CN-0 repeatedly
  changes credentials and revokes/grants an explicit role, while each fresh
  login is immediately routed to CN-1 with no sleep or retry;
- deterministic tests cover CN/server/manager admission bounds, caller cancel,
  post-admission cancel, queue/send failure, shutdown Drain, response
  correlation, ordered progress, and slot reuse;
- `git diff --check` passes; tests are additive and do not reduce coverage or
  assertions.

Fixes #27834