### PR TITLE
fix(frontend): linearize feature quota admission

### DIFF
--- a/docs/design/authentication_catalog_freshness.md
+++ b/docs/design/authentication_catalog_freshness.md
@@ -276,8 +276,8 @@ White-box tests must establish:
   timestamps;
 - authentication preserves a later existing session minimum and fails closed
   on every missing/error capability;
-- protocol 38 uses the correct legacy fallback and protocol 39 uses the new
-  primitive.
+- protocol v38 and below use the correct legacy fallback, while protocol v39
+  uses the new primitive.
 
 Black-box validation must cover at least two CNs and both mutation directions:
 

--- a/docs/design/feature_quota_admission.md
+++ b/docs/design/feature_quota_admission.md
@@ -1,0 +1,220 @@
+# Linearizable feature-quota admission
+
+- Status: Review required
+- Issues: [#27833](https://github.com/matrixorigin/matrixone/issues/27833),
+  [#27718](https://github.com/matrixorigin/matrixone/issues/27718), and
+  [#26087](https://github.com/matrixorigin/matrixone/issues/26087)
+- Implementation: [#27844](https://github.com/matrixorigin/matrixone/pull/27844)
+- Protocol dependency: [#27842](https://github.com/matrixorigin/matrixone/pull/27842)
+
+## 1. Problem and contract
+
+`mo_feature_registry` and `mo_feature_limit` are admission-control state. A
+committed administrator change must constrain every feature operation that is
+invoked afterwards, including an operation routed to another CN. CN logtail
+application is asynchronous, so starting an ordinary local transaction is not
+enough to provide that guarantee.
+
+The required invariants are:
+
+1. **Real-time freshness:** if a registry or quota update commits before a
+   feature operation starts, the operation observes that update.
+2. **Atomic finite admission:** successful concurrent creates never publish
+   more owned objects than the finite quota permits.
+3. **Transactional publication:** the serialization lock is retained until the
+   admitted snapshot or branch metadata commits or rolls back.
+4. **Isolation preservation:** quota admission never advances a caller's fixed
+   SI snapshot or silently changes its transaction mode.
+5. **Fail closed:** a missing dependency, canceled wait, malformed result, or
+   unavailable freshness barrier rejects the feature operation.
+
+The negation of (1) is the production bug: CN-A commits `quota = 0`, then CN-B
+uses its lagging catalog snapshot and admits a branch or snapshot. The negation
+of (2) is the concurrent bug: two creators both count the same old metadata and
+both commit past the limit.
+
+## 2. Scope and non-goals
+
+This design covers `CREATE SNAPSHOT` and `DATA BRANCH CREATE` admission. It does
+not put a global barrier on ordinary SQL, cache reads, DML, or unrelated DDL.
+Deletes do not consume quota and remain outside quota admission serialization.
+
+The design does not make feature state available when TN/logtail is unavailable.
+Availability during that failure would require admitting work without knowing
+the committed policy, which violates the control-plane contract.
+
+## 3. Freshness primitive and linearization
+
+On protocol v39 and later, the CN asks TN for a read barrier. TN places the
+barrier marker in the same FIFO publication queue as transaction logtails. The
+returned timestamp therefore follows all transactions published before the
+marker. The CN waits until that frontier is applied locally and advances the
+owning RC workspace to it before reading quota state.
+
+The initial barrier is the real-time fence for every registry or quota commit
+that completed before the operation was invoked. Policy changes that overlap
+the operation may be ordered on either side. The remaining admission points
+are:
+
+- disabled and unlimited admission linearize at the fresh quota read;
+- finite branch quota, usage, and publication linearize while holding the
+  account's quota row; the post-lock barrier closes commits observed while
+  waiting without changing the operation's invocation-time freshness contract;
+- finite snapshot admission linearizes while holding the stable lineage-owner
+  publication row.
+
+## 4. Snapshot admission
+
+`CREATE SNAPSHOT` already acquires the lineage-owner publication lock before
+checking quota. The flow is:
+
+1. begin the owning pessimistic RC background transaction;
+2. acquire the stable lineage-owner publication lock;
+3. acquire a TN-ordered read barrier and advance the workspace;
+4. read registry state, quota, and current user-owned snapshot count;
+5. publish the snapshot row in the same transaction;
+6. commit, or roll back on every error.
+
+The lineage lock serializes concurrent snapshot publishers even when no
+snapshot row exists yet. Advancing after acquiring it is essential: a waiter
+can otherwise retain the snapshot from before the preceding owner committed.
+Branch-managed protection snapshots remain excluded from user snapshot usage.
+
+## 5. DATA BRANCH admission
+
+Branch quota is account-wide and covers both table and database branches. The
+quota row `(account_id, 'BRANCH', '')` is the stable serialization owner.
+
+The normal flow is:
+
+1. acquire a fresh frontier and read registry/quota;
+2. reject immediately when disabled, or continue without a lock when unlimited;
+3. for a finite quota, require a pessimistic RC owning transaction;
+4. lock the quota row with `SELECT ... FOR UPDATE`;
+5. while retaining the row lock, acquire another TN-ordered frontier, advance
+   the workspace, and re-read the locked quota;
+6. count live branch metadata and admit only if `usage + increment <= quota`;
+7. publish all table metadata for the table or database branch in the same
+   transaction and retain the quota lock through commit.
+
+The second frontier is not redundant. A creator can wait behind a previous
+creator or an administrator update; the transaction's pre-wait snapshot may not
+contain the commit that released the lock. Re-reading the quota also closes
+finite-to-disabled and finite-to-unlimited transitions.
+
+Database branch admission passes the number of source tables as `increment`, so
+a single statement is rejected atomically rather than partially publishing up
+to the remaining capacity.
+
+## 6. Fixed-snapshot transactions
+
+Advancing an active SI workspace would violate repeatable-read semantics. When
+DATA BRANCH runs with a fixed caller snapshot, a short independent pessimistic
+RC control transaction performs the barrier and initial quota read:
+
+- disabled rejects the operation;
+- unlimited permits the operation without changing the outer snapshot;
+- finite rejects with an actionable instruction to retry outside the active
+  transaction, because its serialization lock cannot safely be transferred to
+  the outer SI transaction.
+
+The control transaction is request-owned, has one begin/finish lifecycle, and
+is closed after commit or rollback. Cancellation is propagated to transaction
+creation and barrier waits, while background-session cleanup retains an
+independent transaction context for rollback.
+
+## 7. Lock order, ownership, and unhappy paths
+
+The branch create lock order is:
+
+```text
+optional target-account lock
+    -> branch quota row
+        -> existing clone/branch metadata locks
+            -> publication and commit
+```
+
+Snapshot creation acquires the lineage-owner lock and then performs quota reads;
+it does not acquire the branch quota row. Feature-limit administration only
+updates the quota row. Branch deletion can reduce usage without acquiring the
+quota row and therefore cannot cause over-admission.
+
+There is one owner for each resource:
+
+| Resource | Owner | Release condition |
+| --- | --- | --- |
+| TN read-barrier admission | barrier request | response, cancellation, send failure, or stream close |
+| independent control transaction | `queryQuotaInIndependentTxn` | commit/rollback followed by executor close |
+| finite branch quota lock | branch background transaction | branch publication commit/rollback |
+| snapshot lineage lock | snapshot background transaction | snapshot publication commit/rollback |
+| copied executor result | feature checker | function return |
+
+All barrier, lock, and SQL failures return an error before publication. A
+canceled request cannot turn into an allow decision. The outer deferred
+transaction finalizer rolls back clone/snapshot work, and background executor
+close supplies a final cleanup path if the request context is already canceled.
+
+## 8. Rolling upgrades and compatibility
+
+Protocol v39 advertises the TN-ordered barrier. While any live service keeps the
+cluster protocol below v39, admission uses the legacy HLC fence:
+
+1. select a timestamp strictly beyond the local uncertainty interval;
+2. wait for CN logtail application to reach that timestamp;
+3. advance the workspace and read quota.
+
+The fallback preserves correctness but can wait roughly one `MaxOffset` for
+disabled/unlimited and two for finite branch admission. The v39 wire capability
+must remain disabled until every live service supports it. No catalog schema or
+SQL syntax changes are introduced by this PR.
+
+## 9. Performance model
+
+The new cost is paid only by snapshot and DATA BRANCH create statements:
+
+| Path | v39 barriers | Quota serialization |
+| --- | ---: | --- |
+| snapshot | 1 | existing lineage-owner lock |
+| branch disabled | 1 | none |
+| branch unlimited | 1 | none |
+| branch finite | 2 | one account quota-row lock |
+| ordinary SQL | 0 | none |
+
+Finite branch creation is intentionally serialized per target account because
+the quota itself is account-wide. Different accounts use different quota rows
+and remain concurrent. No polling, retry sleep, unbounded map, goroutine, or
+additional cluster process is added by feature admission.
+
+## 10. Validation matrix
+
+Required evidence before merge:
+
+- unit tests for v39 barrier success, v38 fallback, below-fence rejection,
+  missing transaction/workspace, and barrier/workspace failures;
+- unit tests proving finite branch takes and re-reads the quota lock, while
+  disabled/unlimited avoid it and an explicit owner account is used;
+- race-tested TN queue, manager, RPC correlation, cancellation, and CN consumer
+  barrier paths from #27842;
+- two-CN authentication acceptance from #27842;
+- two-CN branch transitions `1 -> 0 -> -1 -> 0 -> 1` using a connection opened
+  before CN-A mutates quota;
+- concurrent finite table/database branch admission and optimistic/SI behavior;
+- concurrent snapshot disabled, finite, and unlimited admission on both CNs.
+
+Topology assertions use distinct frontend ports. Setup waits are allowed only
+to make source schema visible; the quota mutation-to-admission assertion has no
+sleep or retry that could hide stale-state behavior.
+
+## 11. Alternatives rejected
+
+- **Read the local catalog directly:** violates real-time cross-CN freshness.
+- **Sleep or retry in tests/production:** probabilistic, adds latency, and has no
+  ordering relationship with TN publication.
+- **Use only a quota-row lock:** a waiter can still retain a pre-wait RC snapshot;
+  disabled/unlimited paths would also take unnecessary locks.
+- **Advance the caller's SI workspace:** breaks repeatable-read semantics.
+- **Always run DATA BRANCH in an independent transaction:** changes the atomicity
+  contract of explicit user transactions and can publish work the caller later
+  rolls back.
+- **Serialize all accounts on one global row:** correct but creates an avoidable
+  cross-tenant bottleneck.

--- a/pkg/frontend/feature_limit.go
+++ b/pkg/frontend/feature_limit.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/frontend/databranchutils"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	pbtxn "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 )
@@ -122,7 +122,21 @@ func featureLimitCheckerForAccount(
 		sqlRet.Close()
 	}()
 
-	if limitQuota, err = queryQuota(ctx, ses, bh, accId, featureCode, featureScope); err != nil {
+	// Feature limits are admission-control state. Establish the operation's
+	// cross-CN linearization point before deciding whether the feature is
+	// disabled, finite, or unlimited. A branch running inside an explicit SI
+	// transaction uses an independent short RC transaction for this control-plane
+	// read; advancing the caller's fixed snapshot would violate its isolation.
+	if featureCode == featureCodeBranch && featureLimitTxnUsesFixedSnapshot(bh) {
+		limitQuota, err = queryQuotaInIndependentTxn(
+			ctx, ses, accId, featureCode, featureScope,
+		)
+	} else {
+		if err = advanceFeatureLimitSnapshot(ctx, ses, bh); err == nil {
+			limitQuota, err = queryQuota(ctx, ses, bh, accId, featureCode, featureScope)
+		}
+	}
+	if err != nil {
 		return err
 	}
 	// Serialize finite branch quota checks on the account's quota row. The lock
@@ -214,6 +228,104 @@ func checkBranchQuotaTxn(bh BackgroundExec) error {
 	return nil
 }
 
+func featureLimitTxnUsesFixedSnapshot(bh BackgroundExec) bool {
+	backExec, ok := bh.(*backExec)
+	if !ok || backExec == nil || backExec.backSes == nil || backExec.backSes.GetTxnHandler() == nil {
+		return false
+	}
+	txnOp := backExec.backSes.GetTxnHandler().GetTxn()
+	return txnOp != nil && !txnOp.Txn().IsRCIsolation()
+}
+
+func queryQuotaInIndependentTxn(
+	ctx context.Context,
+	ses *Session,
+	accID uint32,
+	featureCode string,
+	featureScope string,
+) (quota int64, err error) {
+	bh := ses.GetBackgroundExec(ctx, &BackgroundExecOption{
+		forcePessimisticRC:         true,
+		cancelTxnCreateWithRequest: true,
+	})
+	defer bh.Close()
+
+	if err = bh.Exec(ctx, "begin"); err != nil {
+		return 0, err
+	}
+	defer func() {
+		err = finishTxn(ctx, bh, err)
+	}()
+
+	if err = advanceFeatureLimitSnapshot(ctx, ses, bh); err != nil {
+		return 0, err
+	}
+	return queryQuota(ctx, ses, bh, accID, featureCode, featureScope)
+}
+
+func advanceFeatureLimitSnapshot(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+) error {
+	backExec, ok := bh.(*backExec)
+	if !ok {
+		// Lightweight executor doubles do not expose a transaction. Production
+		// feature admission always uses backExec.
+		return nil
+	}
+	if backExec == nil || backExec.backSes == nil || backExec.backSes.GetTxnHandler() == nil {
+		return moerr.NewInternalErrorNoCtx("missing transaction handler for feature-limit snapshot refresh")
+	}
+	txnOp := backExec.backSes.GetTxnHandler().GetTxn()
+	if txnOp == nil {
+		return moerr.NewInternalErrorNoCtx("missing transaction for feature-limit snapshot refresh")
+	}
+	return advanceFeatureLimitTxnSnapshot(ctx, ses, txnOp)
+}
+
+func advanceFeatureLimitTxnSnapshot(
+	ctx context.Context,
+	ses *Session,
+	txnOp TxnOperator,
+) error {
+	if txnOp == nil {
+		return moerr.NewInternalErrorNoCtx("missing transaction for feature-limit snapshot refresh")
+	}
+	var (
+		frontier timestamp.Timestamp
+		err      error
+	)
+
+	if logtailReadBarrierSupported(ses) {
+		frontier, err = ses.acquireLogtailReadBarrier(ctx)
+	} else {
+		var minimum timestamp.Timestamp
+		minimum, err = ses.legacyLogtailReadFence(ctx)
+		if err == nil {
+			pu := getPuIfPresent(ses.GetService())
+			if pu == nil || pu.TxnClient == nil {
+				return moerr.NewInternalError(
+					ctx, "missing transaction client for feature-limit snapshot refresh")
+			}
+			frontier, err = pu.TxnClient.WaitLogTailAppliedAt(ctx, minimum)
+			if err == nil && frontier.Less(minimum) {
+				return moerr.NewInternalError(
+					ctx, "feature-limit snapshot did not reach the required timestamp")
+			}
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	workspace := txnOp.GetWorkspace()
+	if workspace == nil {
+		return moerr.NewInternalErrorNoCtx("missing workspace for feature-limit snapshot refresh")
+	}
+	return workspace.AdvanceSnapshot(ctx, frontier)
+}
+
 func lockFeatureQuota(
 	ctx context.Context,
 	ses *Session,
@@ -241,35 +353,12 @@ func lockFeatureQuota(
 	sqlRet.Close()
 	sqlRet = executor.Result{}
 
-	// A locking read can wait without refreshing its transaction snapshot.
-	// Advance it while retaining the quota-row lock, then re-read the quota and
-	// active branch metadata from a snapshot that includes the prior creator.
-	if backExec, ok := bh.(*backExec); ok {
-		txnOp := backExec.backSes.GetTxnHandler().GetTxn()
-		if txnOp == nil {
-			return 0, moerr.NewInternalErrorNoCtx("missing transaction for branch quota snapshot refresh")
-		}
-		txnMeta := txnOp.Txn()
-		if txnMeta.Mode != pbtxn.TxnMode_Pessimistic || txnMeta.Isolation != pbtxn.TxnIsolation_RC {
-			return 0, moerr.NewInternalErrorNoCtx(
-				"finite branch quota requires a pessimistic read committed transaction; retry outside the active transaction")
-		}
-		rt := moruntime.ServiceRuntime(ses.service)
-		if rt == nil {
-			return 0, moerr.NewInternalErrorNoCtx("missing service runtime for branch quota snapshot refresh")
-		}
-		now, _ := rt.Clock().Now()
-		txnClient := getPu(ses.service).TxnClient
-		if txnClient == nil {
-			return 0, moerr.NewInternalErrorNoCtx("missing transaction client for branch quota snapshot refresh")
-		}
-		applied, waitErr := txnClient.WaitLogTailAppliedAt(ctx, now)
-		if waitErr != nil {
-			return 0, waitErr
-		}
-		if err = txnOp.GetWorkspace().AdvanceSnapshot(ctx, applied); err != nil {
-			return 0, err
-		}
+	// A locking read can wait behind the previous creator without refreshing
+	// this transaction's snapshot. Retain the quota-row lock while installing a
+	// new TN-ordered frontier, so both the locked quota and prior branch metadata
+	// are visible to the re-read below.
+	if err = advanceFeatureLimitSnapshot(ctx, ses, bh); err != nil {
+		return 0, err
 	}
 
 	if sqlRet, err = runSqlWithBackExec(ctx, ses, bh, sql); err != nil {

--- a/pkg/frontend/feature_limit_test.go
+++ b/pkg/frontend/feature_limit_test.go
@@ -21,19 +21,37 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	pbtxn "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
+
+type featureLimitBarrierEngine struct {
+	engine.Engine
+	acquire func(context.Context) (timestamp.Timestamp, error)
+}
+
+func (e *featureLimitBarrierEngine) AcquireLogtailReadBarrier(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
+	return e.acquire(ctx)
+}
 
 func newFeatureLimitTestSession(t *testing.T) *Session {
 	t.Helper()
@@ -50,6 +68,185 @@ func newFeatureLimitTestSession(t *testing.T) *Session {
 		feSessionImpl: feSessionImpl{service: service},
 		proc:          proc,
 	}
+}
+
+func TestAdvanceFeatureLimitTxnSnapshotUsesTNOrderedBarrier(t *testing.T) {
+	ses := newFeatureLimitTestSession(t)
+	rt := moruntime.NewRuntime(metadata.ServiceType_CN, ses.GetService(), nil)
+	moruntime.SetupServiceBasedRuntime(ses.GetService(), rt)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion39)
+
+	frontier := timestamp.Timestamp{PhysicalTime: 80, LogicalTime: 9}
+	setPu(ses.GetService(), &config.ParameterUnit{
+		StorageEngine: &featureLimitBarrierEngine{acquire: func(context.Context) (
+			timestamp.Timestamp, error,
+		) {
+			return frontier, nil
+		}},
+	})
+
+	ctrl := gomock.NewController(t)
+	workspace := mock_frontend.NewMockWorkspace(ctrl)
+	workspace.EXPECT().AdvanceSnapshot(gomock.Any(), frontier).Return(nil)
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().GetWorkspace().Return(workspace)
+
+	require.NoError(t, advanceFeatureLimitTxnSnapshot(t.Context(), ses, txnOp))
+}
+
+func TestFeatureLimitTxnUsesIndependentSnapshotForSI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnHandler := &TxnHandler{}
+	txnHandler.SetShareTxn(txnOp)
+	bh := &backExec{backSes: &backSession{
+		feSessionImpl: feSessionImpl{txnHandler: txnHandler},
+	}}
+
+	txnOp.EXPECT().Txn().Return(pbtxn.TxnMeta{Isolation: pbtxn.TxnIsolation_SI})
+	require.True(t, featureLimitTxnUsesFixedSnapshot(bh))
+	txnOp.EXPECT().Txn().Return(pbtxn.TxnMeta{Isolation: pbtxn.TxnIsolation_RC})
+	require.False(t, featureLimitTxnUsesFixedSnapshot(bh))
+	require.False(t, featureLimitTxnUsesFixedSnapshot(&backgroundExecTest{}))
+	require.False(t, featureLimitTxnUsesFixedSnapshot((*backExec)(nil)))
+}
+
+func TestAdvanceFeatureLimitTxnSnapshotUsesRollingUpgradeFence(t *testing.T) {
+	ses := newFeatureLimitTestSession(t)
+	rt := moruntime.NewRuntime(
+		metadata.ServiceType_CN,
+		ses.GetService(),
+		nil,
+		moruntime.WithClock(clock.NewHLCClock(func() int64 { return 100 }, 20*time.Nanosecond)),
+	)
+	moruntime.SetupServiceBasedRuntime(ses.GetService(), rt)
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion38)
+
+	minimum := timestamp.Timestamp{PhysicalTime: 121}
+	applied := timestamp.Timestamp{PhysicalTime: 125, LogicalTime: 3}
+	ctrl := gomock.NewController(t)
+	txnClient := mock_frontend.NewMockTxnClient(ctrl)
+	txnClient.EXPECT().WaitLogTailAppliedAt(gomock.Any(), minimum).Return(applied, nil)
+	setPu(ses.GetService(), &config.ParameterUnit{TxnClient: txnClient})
+	workspace := mock_frontend.NewMockWorkspace(ctrl)
+	workspace.EXPECT().AdvanceSnapshot(gomock.Any(), applied).Return(nil)
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().GetWorkspace().Return(workspace)
+
+	require.NoError(t, advanceFeatureLimitTxnSnapshot(t.Context(), ses, txnOp))
+}
+
+func TestAdvanceFeatureLimitTxnSnapshotFailsClosed(t *testing.T) {
+	t.Run("missing transaction handler", func(t *testing.T) {
+		ses := newFeatureLimitTestSession(t)
+		require.ErrorContains(t,
+			advanceFeatureLimitSnapshot(t.Context(), ses, (*backExec)(nil)),
+			"missing transaction handler",
+		)
+	})
+
+	t.Run("missing transaction", func(t *testing.T) {
+		ses := newFeatureLimitTestSession(t)
+		require.ErrorContains(t,
+			advanceFeatureLimitTxnSnapshot(t.Context(), ses, nil),
+			"missing transaction",
+		)
+	})
+
+	t.Run("missing workspace", func(t *testing.T) {
+		ses := newFeatureLimitTestSession(t)
+		rt := moruntime.NewRuntime(metadata.ServiceType_CN, ses.GetService(), nil)
+		moruntime.SetupServiceBasedRuntime(ses.GetService(), rt)
+		rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion39)
+		frontier := timestamp.Timestamp{PhysicalTime: 80}
+		setPu(ses.GetService(), &config.ParameterUnit{
+			StorageEngine: &featureLimitBarrierEngine{acquire: func(context.Context) (
+				timestamp.Timestamp, error,
+			) {
+				return frontier, nil
+			}},
+		})
+		ctrl := gomock.NewController(t)
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		txnOp.EXPECT().GetWorkspace().Return(nil)
+
+		require.ErrorContains(t,
+			advanceFeatureLimitTxnSnapshot(t.Context(), ses, txnOp),
+			"missing workspace",
+		)
+	})
+
+	t.Run("barrier failure", func(t *testing.T) {
+		ses := newFeatureLimitTestSession(t)
+		rt := moruntime.NewRuntime(metadata.ServiceType_CN, ses.GetService(), nil)
+		moruntime.SetupServiceBasedRuntime(ses.GetService(), rt)
+		rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion39)
+		wantErr := moerr.NewInternalErrorNoCtx("barrier unavailable")
+		setPu(ses.GetService(), &config.ParameterUnit{
+			StorageEngine: &featureLimitBarrierEngine{acquire: func(context.Context) (
+				timestamp.Timestamp, error,
+			) {
+				return timestamp.Timestamp{}, wantErr
+			}},
+		})
+		ctrl := gomock.NewController(t)
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+
+		require.ErrorIs(t,
+			advanceFeatureLimitTxnSnapshot(t.Context(), ses, txnOp),
+			wantErr,
+		)
+	})
+
+	t.Run("legacy waiter below fence", func(t *testing.T) {
+		ses := newFeatureLimitTestSession(t)
+		rt := moruntime.NewRuntime(
+			metadata.ServiceType_CN,
+			ses.GetService(),
+			nil,
+			moruntime.WithClock(clock.NewHLCClock(func() int64 { return 100 }, 20*time.Nanosecond)),
+		)
+		moruntime.SetupServiceBasedRuntime(ses.GetService(), rt)
+		rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion38)
+		ctrl := gomock.NewController(t)
+		txnClient := mock_frontend.NewMockTxnClient(ctrl)
+		txnClient.EXPECT().WaitLogTailAppliedAt(
+			gomock.Any(), timestamp.Timestamp{PhysicalTime: 121},
+		).Return(timestamp.Timestamp{PhysicalTime: 120}, nil)
+		setPu(ses.GetService(), &config.ParameterUnit{TxnClient: txnClient})
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+
+		require.ErrorContains(t,
+			advanceFeatureLimitTxnSnapshot(t.Context(), ses, txnOp),
+			"did not reach the required timestamp",
+		)
+	})
+
+	t.Run("workspace failure", func(t *testing.T) {
+		ses := newFeatureLimitTestSession(t)
+		rt := moruntime.NewRuntime(metadata.ServiceType_CN, ses.GetService(), nil)
+		moruntime.SetupServiceBasedRuntime(ses.GetService(), rt)
+		rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion39)
+		frontier := timestamp.Timestamp{PhysicalTime: 80}
+		setPu(ses.GetService(), &config.ParameterUnit{
+			StorageEngine: &featureLimitBarrierEngine{acquire: func(context.Context) (
+				timestamp.Timestamp, error,
+			) {
+				return frontier, nil
+			}},
+		})
+		ctrl := gomock.NewController(t)
+		wantErr := moerr.NewInternalErrorNoCtx("advance failed")
+		workspace := mock_frontend.NewMockWorkspace(ctrl)
+		workspace.EXPECT().AdvanceSnapshot(gomock.Any(), frontier).Return(wantErr)
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		txnOp.EXPECT().GetWorkspace().Return(workspace)
+
+		require.ErrorIs(t,
+			advanceFeatureLimitTxnSnapshot(t.Context(), ses, txnOp),
+			wantErr,
+		)
+	})
 }
 
 func TestCheckBranchQuotaLocksFiniteQuota(t *testing.T) {

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -83,7 +83,7 @@ func currentProtocolVersion(proc *process.Process) int64 {
 	return version
 }
 
-func authenticationLogtailReadBarrierSupported(ses *Session) bool {
+func logtailReadBarrierSupported(ses *Session) bool {
 	rt := moruntime.ServiceRuntime(ses.GetService())
 	if rt == nil {
 		return false
@@ -94,6 +94,26 @@ func authenticationLogtailReadBarrierSupported(ses *Session) bool {
 	}
 	version, ok := value.(int64)
 	return ok && version >= defines.MORPCVersion39
+}
+
+func (ses *Session) acquireLogtailReadBarrier(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
+	pu := getPuIfPresent(ses.GetService())
+	if pu == nil {
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "missing parameter unit for logtail read barrier")
+	}
+	if pu.StorageEngine == nil {
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "missing storage engine for logtail read barrier")
+	}
+	barrier, ok := pu.StorageEngine.(engine.LogtailReadBarrier)
+	if !ok {
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "storage engine does not support logtail read barrier")
+	}
+	return barrier.AcquireLogtailReadBarrier(ctx)
 }
 
 // reusablePlanGenerationSupported reports whether every live service in the
@@ -2325,30 +2345,47 @@ func (ses *Session) skipAuthForSpecialUser() bool {
 // the full clock uncertainty interval, so new clusters use the generic engine
 // barrier in prepareAuthenticationSnapshot instead.
 func (ses *Session) advanceAuthenticationSnapshot(ctx context.Context) error {
+	minimum, err := ses.legacyLogtailReadFence(ctx)
+	if err != nil {
+		return err
+	}
+	ses.updateLastCommitTS(minimum)
+	return nil
+}
+
+// legacyLogtailReadFence returns a timestamp strictly beyond the local HLC
+// uncertainty window. It is the rolling-upgrade fallback for catalog reads
+// that require cross-CN freshness before the TN-ordered barrier is available.
+func (ses *Session) legacyLogtailReadFence(
+	ctx context.Context,
+) (timestamp.Timestamp, error) {
 	rt := moruntime.ServiceRuntime(ses.GetService())
 	if rt == nil {
-		return moerr.NewInternalError(ctx, "missing service runtime for authentication snapshot")
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "missing service runtime for catalog read fence")
 	}
 	txnClock := rt.Clock()
 	if txnClock == nil {
-		return moerr.NewInternalError(ctx, "missing transaction clock for authentication snapshot")
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "missing transaction clock for catalog read fence")
 	}
 	if txnClock.MaxOffset() < 0 {
-		return moerr.NewInternalError(ctx, "negative transaction clock offset for authentication snapshot")
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "negative transaction clock offset for catalog read fence")
 	}
 
 	_, upperBound := txnClock.Now()
 	if upperBound.PhysicalTime < 0 || upperBound.PhysicalTime == math.MaxInt64 {
-		return moerr.NewInternalError(ctx, "authentication snapshot timestamp overflow")
+		return timestamp.Timestamp{}, moerr.NewInternalError(
+			ctx, "catalog read fence timestamp overflow")
 	}
 
 	// HLC ordering compares the logical component when physical times are equal.
 	// Moving to the next physical tick dominates every logical timestamp at the
 	// uncertainty upper bound, including a remote commit at that exact tick.
-	ses.updateLastCommitTS(timestamp.Timestamp{
+	return timestamp.Timestamp{
 		PhysicalTime: upperBound.PhysicalTime + 1,
-	})
-	return nil
+	}, nil
 }
 
 // prepareAuthenticationSnapshot installs a session snapshot minimum only after
@@ -2362,15 +2399,8 @@ func (ses *Session) prepareAuthenticationSnapshot(ctx context.Context) error {
 		return moerr.NewInternalError(ctx, "missing transaction client for authentication snapshot")
 	}
 
-	if authenticationLogtailReadBarrierSupported(ses) {
-		if pu.StorageEngine == nil {
-			return moerr.NewInternalError(ctx, "missing storage engine for authentication snapshot")
-		}
-		barrier, ok := pu.StorageEngine.(engine.LogtailReadBarrier)
-		if !ok {
-			return moerr.NewInternalError(ctx, "storage engine does not support logtail read barrier")
-		}
-		frontier, err := barrier.AcquireLogtailReadBarrier(ctx)
+	if logtailReadBarrierSupported(ses) {
+		frontier, err := ses.acquireLogtailReadBarrier(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/frontend/session_authenticate_test.go
+++ b/pkg/frontend/session_authenticate_test.go
@@ -141,6 +141,17 @@ func TestAdvanceAuthenticationSnapshot(t *testing.T) {
 	})
 }
 
+func TestLogtailReadBarrierSupportedProtocolBoundary(t *testing.T) {
+	ses := newAuthenticationSnapshotTestSession(t, 100, 20*time.Nanosecond)
+	rt := moruntime.ServiceRuntime(ses.GetService())
+
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion38)
+	require.False(t, logtailReadBarrierSupported(ses),
+		"v38 advertises temporary-table migration, not the logtail read barrier")
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion39)
+	require.True(t, logtailReadBarrierSupported(ses))
+}
+
 func TestPrepareAuthenticationSnapshotFailsClosed(t *testing.T) {
 	t.Run("missing parameter unit", func(t *testing.T) {
 		ses := newAuthenticationSnapshotTestSession(t, 100, 20*time.Nanosecond)

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -701,11 +701,11 @@ func (th *TxnHandler) createTxnOpUnsafe(execCtx *ExecCtx) error {
 		if execCtx.reqCtx == nil {
 			return moerr.NewInternalErrorNoCtx("request context is required for cancellable transaction creation")
 		}
-		// Authentication owns a short-lived background transaction. Its handshake
-		// deadline is the single timeout owner of the freshness wait; applying the
-		// ordinary CreateTxnOpTimeout here would silently shorten a configuration
-		// that was validated against ConnectTimeout. The child still guarantees
-		// prompt cleanup when TxnClient.New returns before the handshake does.
+		// The request owns this short-lived frontend control-plane transaction.
+		// Its deadline is the single timeout owner of the freshness wait; applying
+		// the ordinary CreateTxnOpTimeout here would silently shorten that owning
+		// request. The child still guarantees prompt cleanup when TxnClient.New
+		// returns before the request does.
 		tempCtx, tempCancel = context.WithCancel(execCtx.reqCtx)
 	} else {
 		// Ordinary session transaction creation intentionally keeps the long-lived

--- a/pkg/tests/issues/issue_26087_test.go
+++ b/pkg/tests/issues/issue_26087_test.go
@@ -17,6 +17,7 @@ package issues
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -40,7 +41,12 @@ func TestIssue26087ConcurrentDataBranchQuota(t *testing.T) {
 
 			cn, err := c.GetCNService(0)
 			require.NoError(t, err)
+			admissionCN, err := c.GetCNService(1)
+			require.NoError(t, err)
 			port := cn.GetServiceConfig().CN.Frontend.Port
+			admissionPort := admissionCN.GetServiceConfig().CN.Frontend.Port
+			require.NotEqual(t, port, admissionPort,
+				"the quota mutation and admission check must use distinct CNs")
 
 			sysDB, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
 			require.NoError(t, err)
@@ -77,6 +83,76 @@ func TestIssue26087ConcurrentDataBranchQuota(t *testing.T) {
 			execSQLRequire(t, ctx, tenantDB, "create table branch_quota_race.mode_probe (a int primary key)")
 			execSQLRequire(t, ctx, tenantDB, "insert into branch_quota_race.src values (1)")
 			execSQLRequire(t, ctx, tenantDB, "create snapshot issue_26087_sp for table branch_quota_race src")
+			waitForCatalog := func(
+				description string,
+				probe func(context.Context) (bool, error),
+			) {
+				t.Helper()
+				waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)
+				defer waitCancel()
+				require.NoError(t, waitForCatalogVisibility(waitCtx, probe), description)
+			}
+			waitForCatalog("source database did not become visible on the admission CN",
+				func(probeCtx context.Context) (bool, error) {
+					return testutils.DBExistsWithAccountE(
+						probeCtx, accountID, "branch_quota_race", admissionCN)
+				})
+			waitForCatalog("source table did not become visible on the admission CN",
+				func(probeCtx context.Context) (bool, error) {
+					return testutils.TableExistsWithAccountE(
+						probeCtx, accountID, "branch_quota_race", "src", admissionCN)
+				})
+
+			// Keep one connection on CN-B alive across quota mutations committed on
+			// CN-A. This excludes login/setup convergence from the assertion: each
+			// DATA BRANCH statement must install its own TN-ordered catalog frontier.
+			admissionDB, err := sql.Open("mysql", fmt.Sprintf(
+				"%s#root#accountadmin:111@tcp(127.0.0.1:%d)/", accountName, admissionPort))
+			require.NoError(t, err)
+			defer admissionDB.Close()
+			admissionDB.SetMaxOpenConns(1)
+			admissionConn, err := admissionDB.Conn(ctx)
+			require.NoError(t, err)
+			defer admissionConn.Close()
+			var quotaProbe int
+			require.NoError(t, admissionConn.QueryRowContext(ctx, "select 1").Scan(&quotaProbe))
+			require.Equal(t, 1, quotaProbe)
+
+			setBranchQuota := func(quota int) {
+				t.Helper()
+				execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+					"select mo_feature_limit_upsert(%d, 'branch', '', %d)", accountID, quota))
+			}
+			createCrossCNBranch := func(name string) error {
+				t.Helper()
+				_, createErr := admissionConn.ExecContext(ctx, fmt.Sprintf(
+					"data branch create table branch_quota_race.%s from branch_quota_race.src", name))
+				return createErr
+			}
+			deleteCrossCNBranch := func(name string) error {
+				t.Helper()
+				_, deleteErr := admissionConn.ExecContext(ctx, fmt.Sprintf(
+					"data branch delete table branch_quota_race.%s", name))
+				return deleteErr
+			}
+			assertCrossCNDenied := func(name string) {
+				t.Helper()
+				createErr := createCrossCNBranch(name)
+				require.Error(t, createErr)
+				require.Contains(t, createErr.Error(),
+					"feature BRANCH with scope  has disabled for account "+accountName)
+			}
+
+			setBranchQuota(0)
+			assertCrossCNDenied("cross_cn_disabled_from_finite")
+			setBranchQuota(-1)
+			require.NoError(t, createCrossCNBranch("cross_cn_unlimited_from_disabled"))
+			require.NoError(t, deleteCrossCNBranch("cross_cn_unlimited_from_disabled"))
+			setBranchQuota(0)
+			assertCrossCNDenied("cross_cn_disabled_from_unlimited")
+			setBranchQuota(1)
+			require.NoError(t, createCrossCNBranch("cross_cn_finite_from_disabled"))
+			require.NoError(t, deleteCrossCNBranch("cross_cn_finite_from_disabled"))
 
 			conn1, err := tenantDB.Conn(ctx)
 			require.NoError(t, err)
@@ -211,12 +287,24 @@ func TestIssue26087ConcurrentDataBranchQuota(t *testing.T) {
 			require.NoError(t, execConn(conn2, "set session transaction isolation level repeatable read"))
 
 			require.NoError(t, execConn(conn1, "begin"))
+			var fixedSnapshotProbe int
+			require.NoError(t, conn1.QueryRowContext(execCtx,
+				"select count(*) from branch_quota_race.mode_probe where a = 2",
+			).Scan(&fixedSnapshotProbe))
+			require.Zero(t, fixedSnapshotProbe)
+			require.NoError(t, execConn(conn2, "insert into branch_quota_race.mode_probe values (2)"))
 			explicitErr := execConn(conn1,
 				"data branch create table branch_quota_race.explicit_branch from branch_quota_race.src{snapshot='issue_26087_sp'}")
 			require.Error(t, explicitErr)
 			require.Contains(t, explicitErr.Error(),
 				"finite branch quota requires a pessimistic read committed transaction; retry outside the active transaction")
+			require.NoError(t, conn1.QueryRowContext(execCtx,
+				"select count(*) from branch_quota_race.mode_probe where a = 2",
+			).Scan(&fixedSnapshotProbe))
+			require.Zero(t, fixedSnapshotProbe,
+				"feature-limit freshness must not advance the outer SI transaction")
 			require.NoError(t, execConn(conn1, "rollback"))
+			require.NoError(t, execConn(conn2, "delete from branch_quota_race.mode_probe where a = 2"))
 
 			require.NoError(t, execConn(conn1, "set autocommit = 0"))
 			var modeProbeCount int
@@ -302,4 +390,45 @@ func TestIssue26087ConcurrentDataBranchQuota(t *testing.T) {
 			).Scan(&optimisticBranchCount))
 			require.Equal(t, 1, optimisticBranchCount)
 		})
+}
+
+func waitForCatalogVisibility(
+	ctx context.Context,
+	probe func(context.Context) (bool, error),
+) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		visible, err := probe(ctx)
+		if err == nil && visible {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			cause := context.Cause(ctx)
+			if lastErr != nil {
+				return fmt.Errorf("%w; last catalog probe failed: %w", cause, lastErr)
+			}
+			return cause
+		case <-ticker.C:
+		}
+	}
+}
+
+func TestWaitForCatalogVisibilityPreservesProbeError(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	probeErr := errors.New("catalog query failed")
+
+	err := waitForCatalogVisibility(ctx, func(context.Context) (bool, error) {
+		return false, probeErr
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, probeErr)
 }

--- a/pkg/tests/issues/issue_27718_test.go
+++ b/pkg/tests/issues/issue_27718_test.go
@@ -190,6 +190,12 @@ func runIssue27718SnapshotQuotaMode(
 		for i := 0; i < creators; i++ {
 			select {
 			case result := <-results:
+				if quota < 0 {
+					require.NoError(t, result.err,
+						"unlimited quota must admit snapshot %s", result.name)
+					successes = append(successes, result.name)
+					continue
+				}
 				if result.err == nil {
 					successes = append(successes, result.name)
 					continue

--- a/pkg/tests/testutils/test_utils.go
+++ b/pkg/tests/testutils/test_utils.go
@@ -390,6 +390,20 @@ func DBExistsWithAccount(
 	ctx, cancel := context.WithTimeoutCause(context.Background(), 10*time.Second, moerr.CauseDBExists)
 	defer cancel()
 
+	exists, err := DBExistsWithAccountE(ctx, account, name, cn)
+	require.NoError(t, err)
+	return exists
+}
+
+// DBExistsWithAccountE is the non-asserting form of DBExistsWithAccount. It is
+// safe to use from bounded polling code that must preserve query errors instead
+// of calling testing.T from a polling goroutine.
+func DBExistsWithAccountE(
+	ctx context.Context,
+	account int32,
+	name string,
+	cn embed.ServiceOperator,
+) (bool, error) {
 	ctx = defines.AttachAccountId(ctx, uint32(account))
 
 	exec := cn.RawService().(cnservice.Service).GetSQLExecutor()
@@ -398,9 +412,11 @@ func DBExistsWithAccount(
 		"show databases",
 		executor.Options{}.WithAccountID(uint32(account)),
 	)
-	require.NoError(t, moerr.AttachCause(ctx, err))
-
-	return HasName(name, res)
+	if err != nil {
+		res.Close()
+		return false, moerr.AttachCause(ctx, err)
+	}
+	return HasName(name, res), nil
 }
 
 func TableExists(
@@ -428,6 +444,20 @@ func TableExistsWithAccount(
 	ctx, cancel := context.WithTimeoutCause(context.Background(), 10*time.Second, moerr.CauseTableExists)
 	defer cancel()
 
+	exists, err := TableExistsWithAccountE(ctx, account, db, name, cn)
+	require.NoError(t, err)
+	return exists
+}
+
+// TableExistsWithAccountE is the non-asserting form of
+// TableExistsWithAccount. The caller owns the query deadline and error policy.
+func TableExistsWithAccountE(
+	ctx context.Context,
+	account int32,
+	db string,
+	name string,
+	cn embed.ServiceOperator,
+) (bool, error) {
 	ctx = defines.AttachAccountId(ctx, uint32(account))
 
 	exec := cn.RawService().(cnservice.Service).GetSQLExecutor()
@@ -436,9 +466,11 @@ func TableExistsWithAccount(
 		"show tables",
 		executor.Options{}.WithDatabase(db).WithAccountID(uint32(account)),
 	)
-	require.NoError(t, moerr.AttachCause(ctx, err))
-
-	return HasName(name, res)
+	if err != nil {
+		res.Close()
+		return false, moerr.AttachCause(ctx, err)
+	}
+	return HasName(name, res), nil
 }
 
 func WaitClusterAppliedTo(


### PR DESCRIPTION
Fixes #27833.
Related to #27718 and #26087.

Rebased onto `main@fcc8ff3b03`, which contains the merged TN-ordered logtail barrier from #27842. The complete feature-only range is now `fcc8ff3b03..66e95cf25b`; no dependency merge history remains in this PR.

Design: [`docs/design/feature_quota_admission.md`](https://github.com/matrixorigin/matrixone/blob/codex/issue27833-feature-limit-barrier/docs/design/feature_quota_admission.md) (**Review required**).

## Why

Feature quota is admission-control state, but `CREATE SNAPSHOT` and `DATA BRANCH CREATE` could read a stale CN catalog snapshot immediately after an administrator committed `mo_feature_limit_upsert` on another CN. A stale lower value falsely rejects an allowed operation; a stale higher value can persist an object after the feature was disabled or reduced. Concurrent creators could also count the same pre-publication metadata and exceed a finite limit.

Required contract:

- a registry/quota commit completed before an operation starts constrains it on every CN;
- finite admission and metadata publication are one serialized transaction;
- the check does not advance or downgrade a caller's fixed SI transaction;
- cancellation, missing dependencies, and freshness failures fail closed.

## What changed

- Establish a TN-ordered logtail barrier before reading feature registry/quota state, then advance the owning RC workspace to the applied frontier.
- For finite branch quota, retain the account quota-row lock, establish a second frontier after any lock wait, re-read the locked quota, count usage, and publish metadata in the same transaction.
- Preserve explicit SI semantics with an independent short pessimistic-RC control transaction. Disabled rejects, unlimited proceeds, and finite quota asks the caller to retry outside the active transaction.
- Preserve rolling-upgrade compatibility: protocol v38 and below use the HLC uncertainty fallback; v39 uses the TN-ordered barrier.
- Fail closed for barrier, logtail, workspace, transaction, and typed-nil executor failures.
- Add a bounded two-CN branch acceptance sequence on one pre-opened CN-B connection: `1 -> 0 -> -1 -> 0 -> 1`, with no sleep or retry between CN-A's committed quota mutation and admission.
- Reuse the existing shared two-CN cluster; no extra embedded-cluster startup was added.
- Make catalog-readiness polling synchronous and context-bounded, preserve the last SQL error, close partial executor results, and avoid calling `testing.T` from a polling worker goroutine.
- Strengthen unlimited snapshot and SI snapshot-preservation assertions.

## Performance and risk

- Ordinary SQL and authentication add no new barrier, lock, scan, allocation, or goroutine from this feature change.
- Snapshot create: one v39 barrier and the existing lineage-owner lock.
- Disabled/unlimited branch create: one v39 barrier and no quota lock.
- Finite branch create: two v39 barriers and serialization only on that target account's quota row; different accounts remain concurrent.
- The v38 fallback is correct but can wait about one `MaxOffset` for disabled/unlimited and two for finite branch admission.
- Every wait is request-context-bound; topology readiness has one 30-second total bound and preserves the causal probe error.

The merged #27842 queue/RPC hot path is byte-identical to `main`. On this final tree, `BenchmarkSafeQueueEnqueue` (Apple M4, 1s x3) reports 0 alloc/op; the background path is 72.08/65.79/65.25 ns/op (median 65.79 ns/op), and the request-context path is 93.54/109.6/87.28 ns/op. TPCH acceptance belongs to the already-merged barrier change; this feature-only delta does not add work to TPCH query execution.

## Validation

Exact head `66e95cf25b` on `main@fcc8ff3b03`:

- 17 selected frontend quota/authentication/protocol-boundary test functions, including all nested fail-closed cases: PASS (`pkg/frontend`, 1.067s).
- `BenchmarkSafeQueueEnqueue`, background and request-context paths, 1s x3: PASS, 0 alloc/op.
- `git diff --check origin/main...HEAD`: PASS.
- `git range-diff` against the pre-rebase feature commit: patch-equivalent.
- Production and test trees are byte-identical to the previously validated #27844 head; the rebase changed ancestry and the two design clarifications only.

Semantically reused because the relevant code, tests, build mode, topology, and current-main dependency tree are unchanged:

- `TestIssue26087ConcurrentDataBranchQuota`, `TestIssue27718ConcurrentSnapshotQuota`, and `TestWaitForCatalogVisibilityPreservesProbeError`: PASS on the shared two-CN cluster (15.310s on the pre-rebase identical tree).
- v38 temporary-table migration compatibility tests across frontend/proxy.
- normal and focused race evidence for the TN queue, manager, service/RPC correlation, cancellation, CN consumer apply, and authentication barrier paths from merged #27842.
- two-CN authentication acceptance and dependency SCA validation from merged #27842.

Fresh CI was triggered by the force-rebase and was not awaited.
