### PR TITLE
test: synchronize data branch quota probe

### DIFF
--- a/pkg/tests/issues/issue_26087_test.go
+++ b/pkg/tests/issues/issue_26087_test.go
@@ -81,6 +81,7 @@ func TestIssue26087ConcurrentDataBranchQuota(t *testing.T) {
 			execSQLRequire(t, ctx, tenantDB, "create database branch_quota_race")
 			execSQLRequire(t, ctx, tenantDB, "create table branch_quota_race.src (a int primary key)")
 			execSQLRequire(t, ctx, tenantDB, "create table branch_quota_race.mode_probe (a int primary key)")
+			execSQLRequire(t, ctx, tenantDB, "create table branch_quota_race.logtail_marker (a int primary key)")
 			execSQLRequire(t, ctx, tenantDB, "insert into branch_quota_race.src values (1)")
 			execSQLRequire(t, ctx, tenantDB, "create snapshot issue_26087_sp for table branch_quota_race src")
 			waitForCatalog := func(
@@ -304,7 +305,24 @@ func TestIssue26087ConcurrentDataBranchQuota(t *testing.T) {
 			require.Zero(t, fixedSnapshotProbe,
 				"feature-limit freshness must not advance the outer SI transaction")
 			require.NoError(t, execConn(conn1, "rollback"))
-			require.NoError(t, execConn(conn2, "delete from branch_quota_race.mode_probe where a = 2"))
+			cleanupResult, err := conn2.ExecContext(execCtx,
+				"delete from branch_quota_race.mode_probe where a = 2")
+			require.NoError(t, err)
+			cleanupRows, err := cleanupResult.RowsAffected()
+			require.NoError(t, err)
+			require.EqualValues(t, 1, cleanupRows)
+			// The driver acknowledges conn2's commit before CN0 necessarily applies
+			// its logtail. Commit a later write marker and wait for its frontier before
+			// conn1 opens the next SI snapshot.
+			markerCommitTS := testutils.ExecSQLWithReadResultAndAccount(
+				t,
+				accountID,
+				"branch_quota_race",
+				cn,
+				nil,
+				"insert into branch_quota_race.logtail_marker values (1)",
+			)
+			require.False(t, markerCommitTS.IsEmpty())
 
 			require.NoError(t, execConn(conn1, "set autocommit = 0"))
 			var modeProbeCount int


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27847

## What this PR does / why we need it:

### Root cause

The fixture opened conn1 next SI transaction immediately after conn2 received a successful cleanup-delete response. That response confirms the TN commit, but it does not guarantee that the same CN has applied the delete logtail. The next SI snapshot could therefore use an older CN frontier and still see `mode_probe.a = 2`.

### Changes

- Assert that the cleanup delete affected exactly one row.
- Commit a later write marker in the test account and wait for its commit frontier to apply on the same CN before conn1 opens the next SI transaction.
- Assert that the marker transaction returned a non-empty commit timestamp, so the wait has a real write frontier.

The change is test-only; it adds no production behavior or fallback path.

### Issue-to-test proof

`TestIssue26087ConcurrentDataBranchQuota` now proves the cleanup row was removed and that the next implicit SI transaction observes an applied frontier before checking both the empty probe table and DATA BRANCH transaction-mode behavior.

BVT is not appropriate: SQL BVT cannot observe the in-process CN logtail frontier that caused this intermittent fixture failure. The existing two-CN Go integration test is the direct test layer.

### Tests

- `.agents/skills/mo-dev/scripts/mo-cgo-test -tags matrixone_test -count=20 -timeout=30m -run "^TestIssue26087ConcurrentDataBranchQuota$" ./pkg/tests/issues` (pass, 122.547s)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -tags matrixone_test -vet=off -count=1 -timeout=10m -run "^TestIssue26087ConcurrentDataBranchQuota$" ./pkg/tests/issues` (pass, 52.579s)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -tags matrixone_test -count=1 -timeout=30m ./pkg/tests/issues` (pass, 92.918s)

### Risks

The marker table and row exist only in the isolated test account. The added synchronization waits at most 10 seconds through the shared test helper and fails explicitly if the required logtail frontier is not applied.