### PR TITLE
fix(embed): align HAKeeper transport timeout under race

### DIFF
--- a/pkg/embed/cluster.go
+++ b/pkg/embed/cluster.go
@@ -450,6 +450,9 @@ func (c *cluster) createServiceOperators(from int) error {
 				cfg.LogService.HAKeeperConfig.CNStoreTimeout.Duration = c.options.storeTimeout
 			})
 		}
+		if c.options.testing {
+			s.Adjust(applyTestingHAKeeperBackendReadTimeout)
+		}
 
 		if c.options.preStart != nil {
 			c.options.preStart(s)
@@ -457,6 +460,15 @@ func (c *cluster) createServiceOperators(from int) error {
 		c.services = append(c.services, s)
 	}
 	return nil
+}
+
+func applyTestingHAKeeperBackendReadTimeout(cfg *ServiceConfig) {
+	// The race detector can stall the embedded HAKeeper longer than its
+	// production transport budget. Do not let that transport deadline preempt
+	// the test heartbeat recovery window. Explicit service configuration wins.
+	if cfg.HAKeeperClient.BackendReadTimeout.Duration == 0 {
+		cfg.HAKeeperClient.BackendReadTimeout.Duration = testHAKeeperBackendReadTimeout
+	}
 }
 
 func applyHAKeeperHeartbeatTimeout(

--- a/pkg/embed/cluster_test.go
+++ b/pkg/embed/cluster_test.go
@@ -530,20 +530,37 @@ func TestWithTestingBoundsHeartbeatRecoveryInsideStoreLiveness(t *testing.T) {
 
 	for _, svc := range c.services {
 		cfg := svc.GetServiceConfig()
+		require.Equal(t, testHAKeeperBackendReadTimeout,
+			cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		switch svc.ServiceType() {
 		case metadata.ServiceType_CN:
 			require.Equal(t, testHAKeeperHeartbeatTimeout,
 				cfg.CN.HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t, cfg.CN.HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_TN:
 			require.Equal(t, testHAKeeperHeartbeatTimeout,
 				cfg.getTNServiceConfig().HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t, cfg.getTNServiceConfig().HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_LOG:
 			require.Equal(t, testHAKeeperStoreTimeout,
 				cfg.LogService.HAKeeperConfig.TNStoreTimeout.Duration)
 			require.Equal(t, testHAKeeperStoreTimeout,
 				cfg.LogService.HAKeeperConfig.CNStoreTimeout.Duration)
+			require.Less(t, cfg.HAKeeperClient.BackendReadTimeout.Duration,
+				cfg.LogService.HAKeeperConfig.TNStoreTimeout.Duration)
 		}
 	}
+}
+
+func TestTestingHAKeeperBackendReadTimeoutPreservesExplicitValue(t *testing.T) {
+	const explicit = 7 * time.Second
+	cfg := newServiceConfig()
+	cfg.HAKeeperClient.BackendReadTimeout.Duration = explicit
+
+	applyTestingHAKeeperBackendReadTimeout(&cfg)
+	require.Equal(t, explicit, cfg.HAKeeperClient.BackendReadTimeout.Duration)
 }
 
 func TestWithTestingPreservesExplicitHeartbeatTimeout(t *testing.T) {

--- a/pkg/embed/config_test.go
+++ b/pkg/embed/config_test.go
@@ -43,6 +43,7 @@ func TestParseTNConfig(t *testing.T) {
 	max-size = 512
 
 	[hakeeper-client]
+	backend-read-timeout = "20s"
 	service-addresses = [
 		"1",
 		"2"
@@ -75,6 +76,7 @@ func TestParseTNConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, tnservice.StorageMEMKV, cfg.getTNServiceConfig().Txn.Storage.Backend)
 	assert.Equal(t, 2, len(cfg.FileServices))
+	assert.Equal(t, 20*time.Second, cfg.HAKeeperClient.BackendReadTimeout.Duration)
 	assert.Equal(t, "local", cfg.FileServices[0].Name)
 	assert.Equal(t, defines.SharedFileServiceName, cfg.FileServices[1].Name)
 	assert.Equal(t, 2, len(cfg.getTNServiceConfig().HAKeeper.ClientConfig.ServiceAddresses))

--- a/pkg/embed/options.go
+++ b/pkg/embed/options.go
@@ -19,11 +19,12 @@ import "time"
 const (
 	// Test clusters run under the race detector and may lose several seconds to
 	// scheduler instrumentation while a catalog-heavy transaction is active.
-	// Keep the heartbeat request alive long enough for the managed HAKeeper
-	// client to observe and replace a stalled transport, while retaining several
-	// independent retry opportunities inside the store-liveness window.
-	testHAKeeperHeartbeatTimeout = 15 * time.Second
-	testHAKeeperStoreTimeout     = 60 * time.Second
+	// Keep the heartbeat request alive through a transient scheduler stall, and
+	// keep the shared transport alive longer than that request. Both remain
+	// bounded well inside the store-liveness window so real failures are retried.
+	testHAKeeperHeartbeatTimeout   = 15 * time.Second
+	testHAKeeperBackendReadTimeout = 20 * time.Second
+	testHAKeeperStoreTimeout       = 60 * time.Second
 )
 
 func WithConfigs(

--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -292,8 +292,9 @@ func (c *Config) GetHAKeeperClientConfig() HAKeeperClientConfig {
 	saddr := make([]string, 0)
 	saddr = append(saddr, c.HAKeeperClientConfig.ServiceAddresses...)
 	return HAKeeperClientConfig{
-		DiscoveryAddress: c.HAKeeperClientConfig.DiscoveryAddress,
-		ServiceAddresses: saddr,
+		DiscoveryAddress:   c.HAKeeperClientConfig.DiscoveryAddress,
+		ServiceAddresses:   saddr,
+		BackendReadTimeout: c.HAKeeperClientConfig.BackendReadTimeout,
 	}
 }
 
@@ -607,6 +608,17 @@ type HAKeeperClientConfig struct {
 	AllocateIDBatch uint64 `toml:"allocate-id-batch"`
 	// EnableCompress enable compress
 	EnableCompress bool `toml:"enable-compress"`
+	// BackendReadTimeout bounds how long the shared HAKeeper transport waits
+	// without a response before replacing the connection. Caller contexts
+	// independently bound individual requests.
+	BackendReadTimeout toml.Duration `toml:"backend-read-timeout"`
+}
+
+func (c HAKeeperClientConfig) backendReadTimeout() time.Duration {
+	if c.BackendReadTimeout.Duration == 0 {
+		return defaultBackendReadTimeout
+	}
+	return c.BackendReadTimeout.Duration
 }
 
 // Validate validates the HAKeeperClientConfig.
@@ -616,6 +628,11 @@ func (c *HAKeeperClientConfig) Validate() error {
 	}
 	if c.AllocateIDBatch == 0 {
 		c.AllocateIDBatch = 100
+	}
+	if c.BackendReadTimeout.Duration == 0 {
+		c.BackendReadTimeout.Duration = c.backendReadTimeout()
+	} else if c.BackendReadTimeout.Duration < 0 {
+		return moerr.NewBadConfigNoCtx("backend-read-timeout must be positive")
 	}
 	return nil
 }

--- a/pkg/logservice/config_test.go
+++ b/pkg/logservice/config_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -248,32 +249,66 @@ func TestClientConfigValidate(t *testing.T) {
 
 func TestHAKeeperClientConfigValidate(t *testing.T) {
 	tests := []struct {
-		cfg HAKeeperClientConfig
-		ok  bool
+		name        string
+		cfg         HAKeeperClientConfig
+		ok          bool
+		wantTimeout time.Duration
 	}{
 		{
-			HAKeeperClientConfig{}, true,
+			"defaults", HAKeeperClientConfig{}, true, defaultBackendReadTimeout,
 		},
 		{
-			HAKeeperClientConfig{DiscoveryAddress: "localhost:9090"}, true,
+			"discovery address", HAKeeperClientConfig{DiscoveryAddress: "localhost:9090"}, true,
+			defaultBackendReadTimeout,
 		},
 		{
-			HAKeeperClientConfig{ServiceAddresses: []string{"localhost:9090"}}, true,
+			"service address", HAKeeperClientConfig{ServiceAddresses: []string{"localhost:9090"}}, true,
+			defaultBackendReadTimeout,
 		},
 		{
+			"both address forms",
 			HAKeeperClientConfig{
 				DiscoveryAddress: "localhost:9091",
 				ServiceAddresses: []string{"localhost:9090"},
-			}, true,
+			},
+			true,
+			defaultBackendReadTimeout,
+		},
+		{
+			"explicit backend timeout",
+			HAKeeperClientConfig{
+				BackendReadTimeout: toml.Duration{Duration: 20 * time.Second},
+			},
+			true,
+			20 * time.Second,
+		},
+		{
+			"negative backend timeout",
+			HAKeeperClientConfig{
+				BackendReadTimeout: toml.Duration{Duration: -time.Second},
+			},
+			false,
+			0,
 		},
 	}
 
 	for _, tt := range tests {
-		err := tt.cfg.Validate()
-		if tt.ok {
-			assert.NoError(t, err)
-		} else {
-			assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.ok {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantTimeout, tt.cfg.BackendReadTimeout.Duration)
+			} else {
+				assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+			}
+		})
 	}
+}
+
+func TestGetHAKeeperClientConfigPreservesBackendReadTimeout(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.HAKeeperClientConfig.BackendReadTimeout.Duration = 20 * time.Second
+
+	clientCfg := cfg.GetHAKeeperClientConfig()
+	require.Equal(t, 20*time.Second, clientCfg.BackendReadTimeout.Duration)
 }

--- a/pkg/logservice/hakeeper_client.go
+++ b/pkg/logservice/hakeeper_client.go
@@ -1397,7 +1397,7 @@ func connectToHAKeeper(
 			c.respPool,
 			defaultMaxMessageSize,
 			cfg.EnableCompress,
-			defaultBackendReadTimeout,
+			cfg.backendReadTimeout(),
 			"connectToHAKeeper",
 		)
 		if err != nil {
@@ -1583,7 +1583,7 @@ func (c *hakeeperClient) getScheduleCommandClient(ctx context.Context) (morpc.RP
 		c.respPool,
 		defaultMaxMessageSize,
 		c.cfg.EnableCompress,
-		defaultBackendReadTimeout,
+		c.cfg.backendReadTimeout(),
 		"schedule-command-poll",
 	)
 	if err != nil {

--- a/pkg/tests/issues/authenticated_cluster_test.go
+++ b/pkg/tests/issues/authenticated_cluster_test.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	authenticatedClusterHeartbeatTimeout = 15 * time.Second
+	authenticatedClusterBackendTimeout   = 20 * time.Second
 	authenticatedClusterStoreTimeout     = 60 * time.Second
 )
 
@@ -49,17 +50,24 @@ func TestAuthenticatedTestsReuseBaseCluster(t *testing.T) {
 	var cnCount, tnCount, logCount int
 	authenticatedCluster.ForeachServices(func(svc embed.ServiceOperator) bool {
 		cfg := svc.GetServiceConfig()
+		require.Equal(t, authenticatedClusterBackendTimeout,
+			cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		switch svc.ServiceType() {
 		case metadata.ServiceType_CN:
 			cnCount++
 			require.False(t, cfg.CN.Frontend.SkipCheckUser)
 			require.Equal(t, authenticatedClusterHeartbeatTimeout,
 				cfg.CN.HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t, cfg.CN.HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_TN:
 			tnCount++
 			require.NotNil(t, cfg.TN_please_use_getTNServiceConfig)
 			require.Equal(t, authenticatedClusterHeartbeatTimeout,
 				cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t,
+				cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_LOG:
 			logCount++
 			require.Equal(
@@ -76,6 +84,8 @@ func TestAuthenticatedTestsReuseBaseCluster(t *testing.T) {
 				cfg.LogService.HAKeeperConfig.TNStoreTimeout.Duration)
 			require.Less(t, authenticatedClusterHeartbeatTimeout,
 				cfg.LogService.HAKeeperConfig.CNStoreTimeout.Duration)
+			require.Less(t, cfg.HAKeeperClient.BackendReadTimeout.Duration,
+				cfg.LogService.HAKeeperConfig.TNStoreTimeout.Duration)
 		}
 		return true
 	})


### PR DESCRIPTION
## What changed

- make the HAKeeper backend read timeout configurable while preserving the 8s production default;
- give embedded test clusters a 20s transport budget between the existing 15s heartbeat RPC deadline and 60s store-liveness window;
- propagate the timeout to CN, TN, LogService, and the independent schedule-command transport;
- preserve explicit test/service overrides and reject negative configuration;
- pin the timeout hierarchy in the shared authenticated-cluster fixture used by the reported test.

## Root cause

At current main `a15139da62`, `WithTesting()` extends CN/TN heartbeat RPCs to 15s, but every HAKeeper MORPC backend still uses the hard-coded 8s read timeout. Under race/full-UT scheduler pressure, the backend therefore closes the shared transport at 8s, before the heartbeat recovery window expires. The reported job shows both CN backends timing out at 12:13:46 and the `volume_files` DDL failing on the same transport.

The failure occurred after #27744 had already merged, so that heartbeat-only fix does not close this remaining timeout inversion.

## Correctness and risk

The test-only default is now:

`15s heartbeat < 20s backend read < 60s store liveness`

Caller contexts still bound individual requests, cluster close still interrupts the connection, and a genuinely dead test transport remains bounded and gets multiple replacement opportunities before store expiry. Production behavior and hot paths are unchanged; the production default remains exactly 8s and the new value is read only when a client connection is created.

## Validation

- `pkg/logservice` full package: PASS (111.424s)
- `pkg/embed` full package: PASS (47.479s)
- focused config/default/negative/copy tests: PASS
- TOML parsing for `backend-read-timeout`: PASS
- `TestAuthenticatedTestsReuseBaseCluster` with `-race`: PASS (12.43s)
- `TestIssue24727MultiRowPreparedInsertUUIDStrings` with `-race`: PASS, including both interpolation modes (14.50s)
- `go vet ./pkg/logservice ./pkg/embed`: PASS

No BVT is added because this changes only embedded-test control-plane timing; the SQL behavior and production topology contract are unchanged.

Fixes #27846