### PR TITLE
ci: make jstfu compose builds reproducible

### DIFF
--- a/.github/workflows/jstfu-maven-cache.yaml
+++ b/.github/workflows/jstfu-maven-cache.yaml
@@ -1,0 +1,76 @@
+name: Warm jstfu Maven cache
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - xtool/jstfu/pom.xml
+      - xtool/jstfu/mvnw
+      - xtool/jstfu/.mvn/wrapper/maven-wrapper.properties
+      - .github/workflows/jstfu-maven-cache.yaml
+  schedule:
+    # GitHub evicts caches that have not been accessed for seven days. A daily
+    # trusted refresh also validates the Java tests independently of PR events.
+    - cron: "30 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: jstfu-maven-cache-main
+  cancel-in-progress: false
+
+jobs:
+  warm-jstfu-maven-cache:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    name: Warm jstfu Maven cache
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout trusted MatrixOne main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # Keep this key and path aligned with matrixorigin/CI build-mo.yaml. The
+      # relative root makes archives portable across runner home directories
+      # and contains both Maven dependencies and the wrapper distribution.
+      - name: Restore jstfu Maven cache
+        id: jstfu-maven-cache
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .jstfu-maven-cache
+          key: matrixone-jstfu-maven-v1-${{ runner.os }}-${{ runner.arch }}-jdk17-${{ hashFiles('xtool/jstfu/pom.xml', 'xtool/jstfu/.mvn/wrapper/maven-wrapper.properties', 'xtool/jstfu/mvnw') }}
+          restore-keys: |
+            matrixone-jstfu-maven-v1-${{ runner.os }}-${{ runner.arch }}-jdk17-
+
+      - name: Test and build jstfu
+        env:
+          MAVEN_USER_HOME: ${{ github.workspace }}/.jstfu-maven-cache
+          JSTFU_MVN_FLAGS: >-
+            -B --no-transfer-progress
+            -Dmaven.wagon.http.retryHandler.count=3
+            -Dmaven.repo.local=${{ github.workspace }}/.jstfu-maven-cache/repository
+        run: |
+          set -euo pipefail
+          if [ '${{ steps.jstfu-maven-cache.outputs.cache-hit }}' = 'true' ]; then
+            JSTFU_MVN_FLAGS="${JSTFU_MVN_FLAGS} --offline" make jstfu-test
+          else
+            # Resolve a new graph online, then prove that both dependencies and
+            # the Maven wrapper are complete before publishing the cache.
+            make jstfu-test
+            JSTFU_MVN_FLAGS="${JSTFU_MVN_FLAGS} --offline" make jstfu-test
+          fi
+
+      - name: Save jstfu Maven cache
+        if: ${{ steps.jstfu-maven-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .jstfu-maven-cache
+          key: ${{ steps.jstfu-maven-cache.outputs.cache-primary-key }}

--- a/Makefile
+++ b/Makefile
@@ -367,11 +367,19 @@ mo-tool: config cgo thirdparties
 # the build.  Override with MVN=/path/to/mvn to use a preinstalled Maven.  The
 # jar targets Java 8 bytecode so it runs on the BVT tester image's JDK 8.
 MVN ?= ./mvnw
+JSTFU_MVN_FLAGS ?= -B --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3
 .PHONY: jstfu
 jstfu:
 	$(info [Build jstfu datastream server])
-	@cd xtool/jstfu && $(MVN) -q -B -DskipTests package
+	@cd xtool/jstfu && $(MVN) $(JSTFU_MVN_FLAGS) -DskipTests package
 	@echo "built xtool/jstfu/target/jstfu.jar"
+
+.PHONY: jstfu-test
+jstfu-test:
+	$(info [Test and build jstfu datastream server])
+	@cd xtool/jstfu && $(MVN) $(JSTFU_MVN_FLAGS) verify
+	@test -s xtool/jstfu/target/jstfu.jar
+	@echo "tested and built xtool/jstfu/target/jstfu.jar"
 
 # build mo-service binary for debugging with go's race detector enabled
 # produced executable is 10x slower and consumes much more memory

--- a/etc/launch-tae-compose/README.md
+++ b/etc/launch-tae-compose/README.md
@@ -39,6 +39,10 @@ Prebuilt mode is fail-closed: a missing jar, malformed checksum, or checksum
 mismatch prevents the dependent jstfu sidecars and the BVT workload from
 starting.
 
+MatrixOne's trusted main-branch cache warmer keeps the Maven repository and
+wrapper distribution available to PR CI. Pull-request jobs restore that cache
+read-only; they never publish dependencies resolved from an untrusted head.
+
 ## Check log
 
 ```shell

--- a/etc/launch-tae-compose/README.md
+++ b/etc/launch-tae-compose/README.md
@@ -24,6 +24,21 @@ docker-compose -f etc/launch-tae-compose/compose.yaml --profile launch-multi-cn 
 docker-compose -f etc/launch-tae-compose/compose.yaml --profile launch-multi-cn up -d
 ```
 
+The default launch builds `xtool/jstfu` from source and publishes the jar
+through a Compose volume. CI can reuse an exact-head jar produced by its shared
+build by setting all three variables below:
+
+```bash
+JSTFU_USE_PREBUILT=1 \
+JSTFU_EXPECTED_SHA256=<sha256-of-xtool/jstfu/target/jstfu.jar> \
+JSTFU_BUILDER_IMAGE=matrixorigin/matrixone:latest \
+docker compose -f etc/launch-tae-compose/compose.yaml --profile launch-multi-cn up -d
+```
+
+Prebuilt mode is fail-closed: a missing jar, malformed checksum, or checksum
+mismatch prevents the dependent jstfu sidecars and the BVT workload from
+starting.
+
 ## Check log
 
 ```shell

--- a/etc/launch-tae-compose/compose.yaml
+++ b/etc/launch-tae-compose/compose.yaml
@@ -1,6 +1,10 @@
 # docker compose extension fields
 # https://github.com/docker/compose/pull/5140
 # https://stackoverflow.com/questions/45805380/meaning-of-ampersand-in-docker-compose-yml-file
+# Versioned producer/consumer marker used by shared CI before it spends time
+# building a prebuilt jstfu artifact for this exact MatrixOne head.
+x-jstfu-prebuilt-contract: "1"
+
 x-mo-common: &mo-common
     build:
       context: ../../

--- a/etc/launch-tae-compose/compose.yaml
+++ b/etc/launch-tae-compose/compose.yaml
@@ -143,13 +143,15 @@ services:
   # by test/distributed/cases/datastream.  The BVT cases address it as
   # 'server'='127.0.0.1','port'='4444' from whichever CN compiles the scan,
   # so one instance runs inside each CN's network namespace.  The jar is
-  # built once by jstfu-build (Java 8 bytecode via the pom's release
-  # profile) into a shared volume.  docker compose up -d does not return
-  # until jstfu-build completes, so BVT cannot start before the jar exists.
+  # prepared once by jstfu-build into a shared volume.  Local launches build
+  # Java 8 bytecode from source.  CI may supply an exact-head jar and use the
+  # already-local MatrixOne image only as a staging container, avoiding Maven
+  # downloads on every BVT runner.  Both modes validate the jar before it is
+  # published, and docker compose up -d cannot succeed without it.
   # ---------------------------------------------------------------------
   jstfu-build:
     container_name: jstfu-build
-    image: maven:3.9-eclipse-temurin-17
+    image: ${JSTFU_BUILDER_IMAGE:-maven:3.9.9-eclipse-temurin-17}
     profiles:
       - launch
       - launch-multi-cn
@@ -158,7 +160,30 @@ services:
       - jstfu_out:/jstfu-out
       - jstfu_m2:/root/.m2
     working_dir: /matrixone/xtool/jstfu
-    entrypoint: ["/bin/bash","-c","set -euo pipefail; mvn -q -B -DskipTests package && cp target/jstfu.jar /jstfu-out/jstfu.jar && echo 'jstfu.jar built'"]
+    environment:
+      JSTFU_USE_PREBUILT: ${JSTFU_USE_PREBUILT:-0}
+      JSTFU_EXPECTED_SHA256: ${JSTFU_EXPECTED_SHA256:-}
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        set -euo pipefail
+        if [ "$${JSTFU_USE_PREBUILT}" = "1" ]; then
+          printf '%s\n' "$${JSTFU_EXPECTED_SHA256}" | grep -Eq '^[0-9a-f]{64}$$'
+          test -s target/jstfu.jar
+          printf '%s  %s\n' "$${JSTFU_EXPECTED_SHA256}" target/jstfu.jar | sha256sum -c -
+          echo 'using exact-head prebuilt jstfu.jar'
+        else
+          mvn -B --no-transfer-progress \
+            -Dmaven.wagon.http.retryHandler.count=3 \
+            -DskipTests package
+        fi
+        install -m 0644 target/jstfu.jar /jstfu-out/jstfu.jar
+        test -s /jstfu-out/jstfu.jar
+        if [ "$${JSTFU_USE_PREBUILT}" = "1" ]; then
+          printf '%s  %s\n' "$${JSTFU_EXPECTED_SHA256}" /jstfu-out/jstfu.jar | sha256sum -c -
+        fi
+        echo 'jstfu.jar ready'
     networks:
       monet:
 

--- a/xtool/jstfu/pom.xml
+++ b/xtool/jstfu/pom.xml
@@ -28,6 +28,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.68.1</grpc.version>
     <protobuf.version>3.25.5</protobuf.version>
+    <!-- Pin every plugin reached by the package lifecycle.  Leaving these
+         implicit makes a clean CI runner resolve today's latest plugin,
+         which can change the build without a source revision. -->
+    <maven.compiler.version>3.11.0</maven.compiler.version>
+    <maven.resources.version>3.3.1</maven.resources.version>
+    <maven.jar.version>3.3.0</maven.jar.version>
   </properties>
 
   <profiles>
@@ -97,6 +103,21 @@
       </extension>
     </extensions>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>${maven.resources.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven.compiler.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven.jar.version}</version>
+      </plugin>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>


### PR DESCRIPTION
Part of #27866.

Companion CI change: matrixorigin/CI#439.

## Root cause and design

Compose BVT currently performs a cold Maven build in every active compose job. That makes BVT startup depend on Docker Hub and Maven Central before any SQL case runs; quiet Maven output also hides the actionable dependency error.

This change establishes the MatrixOne-owned side of a versioned producer/consumer contract:

- local/default Compose still builds jstfu from source;
- CI may stage an exact-head prebuilt jar through the existing shared volume;
- prebuilt mode requires a strict SHA-256 digest and verifies both source and published bytes;
- missing, malformed, or mismatched artifacts fail closed;
- Maven image and lifecycle plugin versions are pinned, downloads have bounded retries, and failures remain visible;
- `make jstfu-test` runs the Java tests before packaging;
- a trusted main-branch/scheduled workflow populates a 73MB cache containing both Maven dependencies and the Maven Wrapper distribution;
- the cache writer proves a new cache works offline before publishing it. Pull-request jobs only restore it and can never publish untrusted dependencies.

The explicit `x-jstfu-prebuilt-contract: "1"` marker lets the companion CI producer skip old or unrebased MatrixOne heads. Either PR can therefore merge first without breaking or slowing unsupported heads; keep #27866 open until both sides are merged.

## Performance and quality

- Previous cold Compose Maven build: about 1m53s on each of two parallel BVT runners.
- Empty isolated Maven+Wrapper cache: 129s locally.
- Exact cache warm/offline Maven execution: 15s locally, including all Java tests.
- Verified prebuilt staging: under 1s per consumer.
- Cache size: 73MB; run-scoped jar: 23MB.
- No BVT group, SQL case, datastream path, or Java test is removed.

The end-to-end GitHub critical-path delta also includes Actions cache restore and artifact transport and must be measured on the first integrated run after both PRs land.

## Validation

- `make jstfu-test`: 22 tests, 0 failures/errors; 3 existing environment-dependent E2E skips
- isolated cold cache, same-cache warm run, offline run, and cache copied to a different absolute path
- cold-cache Maven verify in `maven:3.9.9-eclipse-temurin-17`
- default cold-cache Compose source build
- prebuilt Compose staging with source and destination SHA-256 verification
- missing, malformed, and mismatched artifact rejection
- shaded jar started on `eclipse-temurin:8-jre`
- all 10,179 Java-8-reachable classes use class major <= 52
- default and prebuilt `docker compose config`
- actionlint with shellcheck for the new workflow
- cross-repository cache-key equality and old/new capability-gate checks
- `git diff --check`
