### PR TITLE
fix(plan): narrow UNION decimal literal domains

### DIFF
--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -3970,11 +3970,25 @@ func (builder *QueryBuilder) buildUnionWithResultLen(
 		// we don't cast null as any type in function
 		// but we will cast null as some target type in union/intersect/minus
 		var tmpArgsType []types.Type
+		hasDecimalInput := false
+		for branchIdx, typ := range argsType {
+			if !setBranchPureNull[branchIdx][columnIdx] && typ.Oid.IsDecimal() {
+				hasDecimalInput = true
+				break
+			}
+		}
 		for branchIdx, typ := range argsType {
 			// A top-level NULL is carried as legacy T_text only so the binder has
 			// a concrete container. It has no collation or width of its own and
 			// must not change the common type chosen from real values.
 			if typ.Oid != types.T_any && !setBranchPureNull[branchIdx][columnIdx] {
+				if hasDecimalInput && columnIdx < len(subCtxList[branchIdx].results) {
+					if exact, ok := setOperationIntegerLiteralDecimalType(
+						subCtxList[branchIdx].results[columnIdx],
+					); ok {
+						typ = exact
+					}
+				}
 				tmpArgsType = append(tmpArgsType, typ)
 			}
 		}
@@ -4526,6 +4540,69 @@ func (builder *QueryBuilder) buildUnionWithResultLen(
 	}
 
 	return lastNodeID, nil
+}
+
+// setOperationIntegerLiteralDecimalType returns the value domain of a direct
+// integer literal when a set-operation column also contains DECIMAL values.
+// MySQL joins literal precision, not the full BIGINT/UNSIGNED BIGINT domain:
+// for example, 1 UNION 2.5 is DECIMAL(2,1), while an integer column or an
+// explicit CAST(... AS SIGNED) continues to contribute its complete domain.
+func setOperationIntegerLiteralDecimalType(expr *plan.Expr) (types.Type, bool) {
+	for expr != nil {
+		fn := expr.GetF()
+		if fn == nil || fn.GetFunc() == nil || len(fn.Args) != 1 {
+			break
+		}
+		switch fn.GetFunc().GetObjName() {
+		case "unary_minus", "unary_plus":
+			expr = fn.Args[0]
+		default:
+			return types.Type{}, false
+		}
+	}
+	if expr == nil {
+		return types.Type{}, false
+	}
+	literal := expr.GetLit()
+	if literal == nil || literal.Isnull {
+		return types.Type{}, false
+	}
+
+	var digits int
+	switch value := literal.Value.(type) {
+	case *plan.Literal_I8Val:
+		digits = signedIntegerLiteralDigits(int64(value.I8Val))
+	case *plan.Literal_I16Val:
+		digits = signedIntegerLiteralDigits(int64(value.I16Val))
+	case *plan.Literal_I32Val:
+		digits = signedIntegerLiteralDigits(int64(value.I32Val))
+	case *plan.Literal_I64Val:
+		digits = signedIntegerLiteralDigits(value.I64Val)
+	case *plan.Literal_U8Val:
+		digits = len(strconv.FormatUint(uint64(value.U8Val), 10))
+	case *plan.Literal_U16Val:
+		digits = len(strconv.FormatUint(uint64(value.U16Val), 10))
+	case *plan.Literal_U32Val:
+		digits = len(strconv.FormatUint(uint64(value.U32Val), 10))
+	case *plan.Literal_U64Val:
+		digits = len(strconv.FormatUint(value.U64Val, 10))
+	default:
+		return types.Type{}, false
+	}
+
+	oid := types.T_decimal64
+	if digits > 18 {
+		oid = types.T_decimal128
+	}
+	return types.New(oid, int32(digits), 0), true
+}
+
+func signedIntegerLiteralDigits(value int64) int {
+	formatted := strconv.FormatInt(value, 10)
+	if formatted[0] == '-' {
+		return len(formatted) - 1
+	}
+	return len(formatted)
 }
 
 func (builder *QueryBuilder) numericSetProjectionTypes(ctx *BindContext, stmts []tree.Statement) []Type {

--- a/pkg/sql/plan/union_common_type_test.go
+++ b/pkg/sql/plan/union_common_type_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnionDecimalLiteralCommonType(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		sql      string
+		oid      types.T
+		width    int32
+		scale    int32
+		nullable bool
+	}{
+		{
+			name:  "small positive integer literal",
+			sql:   "select 1 as x union all select 2.5 as x",
+			oid:   types.T_decimal64,
+			width: 2,
+			scale: 1,
+		},
+		{
+			name:  "negative integer literal",
+			sql:   "select -123 as x union select 2.50 as x",
+			oid:   types.T_decimal64,
+			width: 5,
+			scale: 2,
+		},
+		{
+			name:  "bigint boundary literal",
+			sql:   "select 9223372036854775807 as x union all select 0.1 as x",
+			oid:   types.T_decimal128,
+			width: 20,
+			scale: 1,
+		},
+		{
+			name:  "explicit signed domain is not narrowed",
+			sql:   "select cast(1 as signed) as x union all select 2.5 as x",
+			oid:   types.T_decimal128,
+			width: 20,
+			scale: 1,
+		},
+		{
+			name:     "pure null remains neutral and nullable",
+			sql:      "select 1 as x union all select null union all select 2.5",
+			oid:      types.T_decimal64,
+			width:    2,
+			scale:    1,
+			nullable: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			typ := buildFirstQueryResultType(t, test.sql)
+			require.Equal(t, int32(test.oid), typ.Id)
+			require.Equal(t, test.width, typ.Width)
+			require.Equal(t, test.scale, typ.Scale)
+			require.Equal(t, !test.nullable, typ.NotNullable)
+		})
+	}
+}
+
+func TestCTASUnionDecimalLiteralMetadata(t *testing.T) {
+	stmt, err := parsers.ParseOne(context.Background(), dialect.MYSQL,
+		"create table t_ctas_union_decimal as select 1 as x union all select 2.5 as x", 1)
+	require.NoError(t, err)
+	defer stmt.Free()
+
+	logicPlan, err := BuildPlan(NewMockCompilerContext(true), stmt, false)
+	require.NoError(t, err)
+
+	var visible []*planpb.ColDef
+	for _, col := range logicPlan.GetDdl().GetCreateTable().GetTableDef().GetCols() {
+		if !col.Hidden {
+			visible = append(visible, col)
+		}
+	}
+	require.Len(t, visible, 1)
+	require.Equal(t, "x", visible[0].Name)
+	require.Equal(t, int32(types.T_decimal64), visible[0].Typ.Id)
+	require.Equal(t, int32(2), visible[0].Typ.Width)
+	require.Equal(t, int32(1), visible[0].Typ.Scale)
+	require.True(t, visible[0].Typ.NotNullable)
+	require.NotNil(t, visible[0].Default)
+	require.False(t, visible[0].Default.NullAbility)
+}
+
+func buildFirstQueryResultType(t *testing.T, sql string) planpb.Type {
+	t.Helper()
+	stmt, err := parsers.ParseOne(context.Background(), dialect.MYSQL, sql, 1)
+	require.NoError(t, err)
+	defer stmt.Free()
+
+	logicPlan, err := BuildPlan(NewMockCompilerContext(true), stmt, false)
+	require.NoError(t, err)
+	query := logicPlan.GetQuery()
+	require.NotEmpty(t, query.Steps)
+	root := query.Nodes[query.Steps[len(query.Steps)-1]]
+	require.NotEmpty(t, root.ProjectList)
+	return root.ProjectList[0].Typ
+}

--- a/pkg/sql/plan/union_common_type_test.go
+++ b/pkg/sql/plan/union_common_type_test.go
@@ -106,6 +106,123 @@ func TestCTASUnionDecimalLiteralMetadata(t *testing.T) {
 	require.False(t, visible[0].Default.NullAbility)
 }
 
+func TestSetOperationIntegerLiteralDecimalType(t *testing.T) {
+	literalExpr := func(literal *planpb.Literal) *planpb.Expr {
+		return &planpb.Expr{Expr: &planpb.Expr_Lit{Lit: literal}}
+	}
+
+	for _, test := range []struct {
+		name  string
+		expr  *planpb.Expr
+		oid   types.T
+		width int32
+		ok    bool
+	}{
+		{
+			name:  "int8",
+			expr:  literalExpr(&planpb.Literal{Value: &planpb.Literal_I8Val{I8Val: -12}}),
+			oid:   types.T_decimal64,
+			width: 2,
+			ok:    true,
+		},
+		{
+			name:  "int16",
+			expr:  literalExpr(&planpb.Literal{Value: &planpb.Literal_I16Val{I16Val: -123}}),
+			oid:   types.T_decimal64,
+			width: 3,
+			ok:    true,
+		},
+		{
+			name:  "int32",
+			expr:  literalExpr(&planpb.Literal{Value: &planpb.Literal_I32Val{I32Val: 12345}}),
+			oid:   types.T_decimal64,
+			width: 5,
+			ok:    true,
+		},
+		{
+			name: "int64 minimum",
+			expr: literalExpr(&planpb.Literal{Value: &planpb.Literal_I64Val{
+				I64Val: int64(-9223372036854775807 - 1),
+			}}),
+			oid:   types.T_decimal128,
+			width: 19,
+			ok:    true,
+		},
+		{
+			name:  "uint8",
+			expr:  literalExpr(&planpb.Literal{Value: &planpb.Literal_U8Val{U8Val: 255}}),
+			oid:   types.T_decimal64,
+			width: 3,
+			ok:    true,
+		},
+		{
+			name:  "uint16",
+			expr:  literalExpr(&planpb.Literal{Value: &planpb.Literal_U16Val{U16Val: 65535}}),
+			oid:   types.T_decimal64,
+			width: 5,
+			ok:    true,
+		},
+		{
+			name:  "uint32",
+			expr:  literalExpr(&planpb.Literal{Value: &planpb.Literal_U32Val{U32Val: 4294967295}}),
+			oid:   types.T_decimal64,
+			width: 10,
+			ok:    true,
+		},
+		{
+			name: "uint64 maximum",
+			expr: literalExpr(&planpb.Literal{Value: &planpb.Literal_U64Val{
+				U64Val: uint64(18446744073709551615),
+			}}),
+			oid:   types.T_decimal128,
+			width: 20,
+			ok:    true,
+		},
+		{
+			name: "nested unary operators",
+			expr: &planpb.Expr{Expr: &planpb.Expr_F{F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "unary_plus"},
+				Args: []*planpb.Expr{{Expr: &planpb.Expr_F{F: &planpb.Function{
+					Func: &planpb.ObjectRef{ObjName: "unary_minus"},
+					Args: []*planpb.Expr{literalExpr(&planpb.Literal{Value: &planpb.Literal_I8Val{I8Val: 7}})},
+				}}}},
+			}}},
+			oid:   types.T_decimal64,
+			width: 1,
+			ok:    true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			actual, ok := setOperationIntegerLiteralDecimalType(test.expr)
+			require.Equal(t, test.ok, ok)
+			require.Equal(t, types.New(test.oid, test.width, 0), actual)
+		})
+	}
+
+	invalidExprs := []*planpb.Expr{
+		nil,
+		{},
+		literalExpr(nil),
+		literalExpr(&planpb.Literal{Isnull: true}),
+		literalExpr(&planpb.Literal{Value: &planpb.Literal_Sval{Sval: "1"}}),
+		{Expr: &planpb.Expr_F{F: &planpb.Function{}}},
+		{Expr: &planpb.Expr_F{F: &planpb.Function{Func: &planpb.ObjectRef{ObjName: "unary_plus"}}}},
+		{Expr: &planpb.Expr_F{F: &planpb.Function{
+			Func: &planpb.ObjectRef{ObjName: "unary_plus"},
+			Args: []*planpb.Expr{nil},
+		}}},
+		{Expr: &planpb.Expr_F{F: &planpb.Function{
+			Func: &planpb.ObjectRef{ObjName: "abs"},
+			Args: []*planpb.Expr{literalExpr(&planpb.Literal{Value: &planpb.Literal_I8Val{I8Val: 1}})},
+		}}},
+	}
+	for i, expr := range invalidExprs {
+		actual, ok := setOperationIntegerLiteralDecimalType(expr)
+		require.False(t, ok, "invalid expression %d", i)
+		require.Equal(t, types.Type{}, actual)
+	}
+}
+
 func buildFirstQueryResultType(t *testing.T, sql string) planpb.Type {
 	t.Helper()
 	stmt, err := parsers.ParseOne(context.Background(), dialect.MYSQL, sql, 1)

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -2204,3 +2204,17 @@ select id, payload from target_explicit where payload = 'explicit-default';
 ➤ id[4,32,0]  ¦  payload[12,20,0]  𝄀
 42  ¦  explicit-default
 drop database ctas_auto_increment_24436;
+drop database if exists ctas_union_decimal_24436;
+create database ctas_union_decimal_24436;
+use ctas_union_decimal_24436;
+create table literal_union as select 1 as x union all select 2.5 as x;
+show create table literal_union;
+➤ Table[12,-1,0]  ¦  Create Table[12,-1,0]  𝄀
+literal_union  ¦  CREATE TABLE `literal_union` (
+  `x` decimal(2,1) NOT NULL
+)
+select * from literal_union order by x;
+➤ x[3,2,1]  𝄀
+1.0  𝄀
+2.5
+drop database ctas_union_decimal_24436;

--- a/test/distributed/cases/ddl/create_table_as_select.sql
+++ b/test/distributed/cases/ddl/create_table_as_select.sql
@@ -1510,3 +1510,12 @@ as select id, payload from source_ai;
 insert into target_explicit(payload) values ('explicit-default');
 select id, payload from target_explicit where payload = 'explicit-default';
 drop database ctas_auto_increment_24436;
+
+-- UNION must use integer literal precision when joining a DECIMAL result domain.
+drop database if exists ctas_union_decimal_24436;
+create database ctas_union_decimal_24436;
+use ctas_union_decimal_24436;
+create table literal_union as select 1 as x union all select 2.5 as x;
+show create table literal_union;
+select * from literal_union order by x;
+drop database ctas_union_decimal_24436;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24436

## What this PR does / why we need it:

- use the actual digit precision of direct integer literals when a UNION, INTERSECT, or MINUS output is joined with DECIMAL branches
- keep integer columns and explicit CAST AS SIGNED expressions on their complete integer domain
- retain pure NULL branches as neutral inputs while preserving output nullability
- align the tracker reproduction from DECIMAL(20,1) to MySQL-compatible DECIMAL(2,1)
- add planner, CTAS, boundary, explicit-cast, NULL, and distributed BVT coverage

The VARCHAR(65535) half of the original two-column reproduction comes from REPEAT result-width inference and overlaps #27841, so it is intentionally excluded from this PR.

Validation:
- full pkg/sql/plan and pkg/sql/plan/function tests
- go vet for both packages
- make build
- local mo-service CTAS reproduction, SHOW CREATE, and value verification