### PR TITLE
fix: preserve transaction ownership for database clone

### DIFF
--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -573,6 +573,25 @@ func getBackExecutor(
 	ses *Session,
 	opts ...*BackgroundExecOption,
 ) (BackgroundExec, func(error) error, error) {
+	return getBackExecutorInternal(ctx, ses, false, opts...)
+}
+
+// getBackExecutorWithTxnHandler is used by database clone, which can run
+// immediately after BEGIN before the process transaction operator is refreshed.
+func getBackExecutorWithTxnHandler(
+	ctx context.Context,
+	ses *Session,
+	opts ...*BackgroundExecOption,
+) (BackgroundExec, func(error) error, error) {
+	return getBackExecutorInternal(ctx, ses, true, opts...)
+}
+
+func getBackExecutorInternal(
+	ctx context.Context,
+	ses *Session,
+	useTxnHandler bool,
+	opts ...*BackgroundExecOption,
+) (BackgroundExec, func(error) error, error) {
 
 	var (
 		err      error
@@ -580,7 +599,15 @@ func getBackExecutor(
 		deferred func(error) error
 	)
 
-	if ses.proc.GetTxnOperator().TxnOptions().ByBegin {
+	var explicitTxn bool
+	if useTxnHandler {
+		// TxnHandler is authoritative for an explicit transaction. The process
+		// operator is not refreshed by the BEGIN statement itself.
+		explicitTxn = ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN)
+	} else {
+		explicitTxn = ses.proc.GetTxnOperator().TxnOptions().ByBegin
+	}
+	if explicitTxn {
 		bh = ses.GetShareTxnBackgroundExec(ctx, false)
 		bh.ClearExecResultSet()
 		return bh, func(err error) error {
@@ -1042,7 +1069,7 @@ func handleCloneDatabaseWithSource(
 			// re-checks the target with that fresh snapshot.
 			options[0].cloneSnapshotUsesBackgroundTxn = true
 		}
-		if bh, deferred, err = getBackExecutor(reqCtx, ses, options...); err != nil {
+		if bh, deferred, err = getBackExecutorWithTxnHandler(reqCtx, ses, options...); err != nil {
 			return
 		}
 

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -690,6 +690,29 @@ func TestGetBackExecutorClosesWhenBeginFails(t *testing.T) {
 	require.Equal(t, 2, backExec.closeCalls)
 }
 
+func TestGetBackExecutorWithTxnHandlerUsesTxnHandlerBeginState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ses := newTestSession(t, ctrl)
+	t.Cleanup(ses.Close)
+
+	staleTxn := mock_frontend.NewMockTxnOperator(ctrl)
+	sharedTxn := mock_frontend.NewMockTxnOperator(ctrl)
+	sharedTxn.EXPECT().SetFootPrints(gomock.Any(), gomock.Any()).AnyTimes()
+	ses.proc.Base.TxnOperator = staleTxn
+	ses.GetTxnHandler().txnOp = sharedTxn
+	ses.GetTxnHandler().SetOptionBits(OPTION_BEGIN)
+
+	bh, cleanup, err := getBackExecutorWithTxnHandler(context.Background(), ses)
+	require.NoError(t, err)
+	require.NotNil(t, bh)
+	require.NotNil(t, cleanup)
+	back := bh.(*backExec)
+	require.Same(t, sharedTxn, back.backSes.GetTxnHandler().GetTxn())
+	require.True(t, back.backSes.GetTxnHandler().IsShareTxn())
+	require.Same(t, staleTxn, ses.proc.GetTxnOperator())
+	require.NoError(t, cleanup(nil))
+}
+
 func TestHandleCloneDatabaseWithSourceIfNotExistsSkipsExistingTarget(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ses := newTestSession(t, ctrl)

--- a/pkg/tests/issues/issue_27055_test.go
+++ b/pkg/tests/issues/issue_27055_test.go
@@ -50,6 +50,7 @@ func TestIssue27055DatabaseCloneReadsExplicitTransactionSource(t *testing.T) {
 		const (
 			sourceDB       = "issue_27055_source"
 			targetDB       = "issue_27055_target"
+			directTarget   = "issue_27055_direct_target"
 			autocommitDB   = "issue_27055_autocommit"
 			snapshotDB     = "issue_27055_snapshot"
 			createdSource  = "issue_27055_created_source"
@@ -59,7 +60,7 @@ func TestIssue27055DatabaseCloneReadsExplicitTransactionSource(t *testing.T) {
 			snapshotName   = "issue_27055_snapshot_point"
 		)
 		allDatabases := []string{
-			targetDB, autocommitDB, snapshotDB, createdTarget, createdSource,
+			targetDB, directTarget, autocommitDB, snapshotDB, createdTarget, createdSource,
 			rollbackTarget, rollbackSource, sourceDB,
 		}
 		defer func() {
@@ -117,6 +118,21 @@ func TestIssue27055DatabaseCloneReadsExplicitTransactionSource(t *testing.T) {
 		exec("commit")
 		assertItems(sourceDB, "items", transactionItems)
 		assertItems(targetDB, "items", transactionItems)
+		exec("use " + targetDB)
+		var targetCount, targetSum int
+		require.NoError(t, conn.QueryRowContext(ctx,
+			"select count(*), sum(id) from items").Scan(&targetCount, &targetSum))
+		require.Equal(t, 3, targetCount)
+		require.Equal(t, 7, targetSum)
+		exec("use " + sourceDB)
+
+		// A clone immediately after BEGIN must use the transaction handler state,
+		// even when no statement has refreshed the frontend process yet.
+		exec("begin")
+		exec("create database " + directTarget + " clone " + sourceDB)
+		assertItems(directTarget, "items", transactionItems)
+		exec("commit")
+		assertItems(directTarget, "items", transactionItems)
 
 		// Table clone remains a shared-transaction reader as established by #26293.
 		exec("begin")

--- a/test/distributed/cases/git4data/clone/issue_27055_clone_database_transaction.result
+++ b/test/distributed/cases/git4data/clone/issue_27055_clone_database_transaction.result
@@ -1,0 +1,81 @@
+drop snapshot if exists issue_27055_bvt_snapshot;
+drop database if exists issue_27055_bvt_rollback_target;
+drop database if exists issue_27055_bvt_snapshot_target;
+drop database if exists issue_27055_bvt_autocommit_target;
+drop database if exists issue_27055_bvt_direct_target;
+drop database if exists issue_27055_bvt_new_target;
+drop database if exists issue_27055_bvt_new_source;
+drop database if exists issue_27055_bvt_target;
+drop database if exists issue_27055_bvt_source;
+create database issue_27055_bvt_source;
+create table issue_27055_bvt_source.t(id int primary key, v int);
+insert into issue_27055_bvt_source.t values (1, 1), (2, 2), (3, 3);
+begin;
+insert into issue_27055_bvt_source.t values (4, 4);
+create database issue_27055_bvt_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_source.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+4  ¦  10  ¦  10
+select count(*), sum(id), sum(v) from issue_27055_bvt_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+4  ¦  10  ¦  10
+commit;
+select count(*), sum(id), sum(v) from issue_27055_bvt_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+4  ¦  10  ¦  10
+begin;
+create database issue_27055_bvt_direct_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_direct_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+4  ¦  10  ¦  10
+commit;
+begin;
+create database issue_27055_bvt_new_source;
+create table issue_27055_bvt_new_source.t(id int primary key, v int);
+insert into issue_27055_bvt_new_source.t values (7, 70);
+create database issue_27055_bvt_new_target clone issue_27055_bvt_new_source;
+show tables from issue_27055_bvt_new_target;
+➤ Tables_in_issue_27055_bvt_new_target[12,5000,0]  𝄀
+t
+select count(*), sum(id), sum(v) from issue_27055_bvt_new_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+1  ¦  7  ¦  70
+commit;
+select count(*), sum(id), sum(v) from issue_27055_bvt_new_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+1  ¦  7  ¦  70
+begin;
+insert into issue_27055_bvt_source.t values (5, 5);
+create database issue_27055_bvt_rollback_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_rollback_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+5  ¦  15  ¦  15
+rollback;
+select count(*), sum(id), sum(v) from issue_27055_bvt_source.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+4  ¦  10  ¦  10
+select count(*) from mo_catalog.mo_database
+where account_id = 0 and datname = 'issue_27055_bvt_rollback_target';
+➤ count(*)[-5,64,0]  𝄀
+0
+select 1;
+➤ 1[-5,64,0]  𝄀
+1
+create database issue_27055_bvt_autocommit_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_autocommit_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+4  ¦  10  ¦  10
+create snapshot issue_27055_bvt_snapshot for database issue_27055_bvt_source;
+insert into issue_27055_bvt_source.t values (6, 6);
+create database issue_27055_bvt_snapshot_target clone issue_27055_bvt_source {snapshot = "issue_27055_bvt_snapshot"};
+select count(*), sum(id), sum(v) from issue_27055_bvt_snapshot_target.t;
+➤ count(*)[-5,64,0]  ¦  sum(id)[-5,64,0]  ¦  sum(v)[-5,64,0]  𝄀
+4  ¦  10  ¦  10
+drop snapshot issue_27055_bvt_snapshot;
+drop database issue_27055_bvt_snapshot_target;
+drop database issue_27055_bvt_autocommit_target;
+drop database issue_27055_bvt_new_target;
+drop database issue_27055_bvt_new_source;
+drop database issue_27055_bvt_direct_target;
+drop database issue_27055_bvt_target;
+drop database issue_27055_bvt_source;

--- a/test/distributed/cases/git4data/clone/issue_27055_clone_database_transaction.sql
+++ b/test/distributed/cases/git4data/clone/issue_27055_clone_database_transaction.sql
@@ -1,0 +1,67 @@
+drop snapshot if exists issue_27055_bvt_snapshot;
+drop database if exists issue_27055_bvt_rollback_target;
+drop database if exists issue_27055_bvt_snapshot_target;
+drop database if exists issue_27055_bvt_autocommit_target;
+drop database if exists issue_27055_bvt_direct_target;
+drop database if exists issue_27055_bvt_new_target;
+drop database if exists issue_27055_bvt_new_source;
+drop database if exists issue_27055_bvt_target;
+drop database if exists issue_27055_bvt_source;
+
+create database issue_27055_bvt_source;
+create table issue_27055_bvt_source.t(id int primary key, v int);
+insert into issue_27055_bvt_source.t values (1, 1), (2, 2), (3, 3);
+
+-- The issue reproduction: an INSERT on an existing source must be cloned.
+begin;
+insert into issue_27055_bvt_source.t values (4, 4);
+create database issue_27055_bvt_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_source.t;
+select count(*), sum(id), sum(v) from issue_27055_bvt_target.t;
+commit;
+select count(*), sum(id), sum(v) from issue_27055_bvt_target.t;
+
+-- A clone immediately after BEGIN must still use the shared transaction.
+begin;
+create database issue_27055_bvt_direct_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_direct_target.t;
+commit;
+
+-- Source database and table metadata created in the transaction must be enumerable.
+begin;
+create database issue_27055_bvt_new_source;
+create table issue_27055_bvt_new_source.t(id int primary key, v int);
+insert into issue_27055_bvt_new_source.t values (7, 70);
+create database issue_27055_bvt_new_target clone issue_27055_bvt_new_source;
+show tables from issue_27055_bvt_new_target;
+select count(*), sum(id), sum(v) from issue_27055_bvt_new_target.t;
+commit;
+select count(*), sum(id), sum(v) from issue_27055_bvt_new_target.t;
+
+-- Clone and all transaction-local changes must disappear together on rollback.
+begin;
+insert into issue_27055_bvt_source.t values (5, 5);
+create database issue_27055_bvt_rollback_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_rollback_target.t;
+rollback;
+select count(*), sum(id), sum(v) from issue_27055_bvt_source.t;
+select count(*) from mo_catalog.mo_database
+where account_id = 0 and datname = 'issue_27055_bvt_rollback_target';
+select 1;
+
+-- Existing autocommit and named-snapshot behavior remains unchanged.
+create database issue_27055_bvt_autocommit_target clone issue_27055_bvt_source;
+select count(*), sum(id), sum(v) from issue_27055_bvt_autocommit_target.t;
+create snapshot issue_27055_bvt_snapshot for database issue_27055_bvt_source;
+insert into issue_27055_bvt_source.t values (6, 6);
+create database issue_27055_bvt_snapshot_target clone issue_27055_bvt_source {snapshot = "issue_27055_bvt_snapshot"};
+select count(*), sum(id), sum(v) from issue_27055_bvt_snapshot_target.t;
+
+drop snapshot issue_27055_bvt_snapshot;
+drop database issue_27055_bvt_snapshot_target;
+drop database issue_27055_bvt_autocommit_target;
+drop database issue_27055_bvt_new_target;
+drop database issue_27055_bvt_new_source;
+drop database issue_27055_bvt_direct_target;
+drop database issue_27055_bvt_target;
+drop database issue_27055_bvt_source;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27055

## What this PR does / why we need it:

### Root cause

`CREATE DATABASE ... CLONE` acquired its background executor through `getBackExecutor`, which determined whether an explicit transaction already existed from `ses.proc.GetTxnOperator().TxnOptions().ByBegin`. The `BEGIN` statement publishes the active transaction and `OPTION_BEGIN` in `TxnHandler`, but returns before refreshing the frontend process operator. A database clone issued immediately after `BEGIN` could therefore create a private background transaction instead of reusing the caller transaction. Source enumeration and nested table restore then had split visibility, producing the transaction-local clone failures and missing uncommitted state reported in #27055.

The generated restore-timestamp behavior introduced for database clone remains intact: explicit transactions still omit the generated `MO_TS`, while autocommit and explicit named snapshots retain their existing behavior.

### Changes

- Factor the common background-executor lifecycle into one internal helper and add a database-clone entry point that reads explicit-transaction state from the authoritative `TxnHandler`.
- Keep the existing process-operator check for other `getBackExecutor` callers, so DATA BRANCH and unrelated paths do not change as part of this issue.
- Add a unit test that models a stale process operator and an active `TxnHandler`, and verifies that database-clone acquisition reuses the shared transaction.
- Extend `TestIssue27055DatabaseCloneReadsExplicitTransactionSource` with a clone immediately after `BEGIN` and an exact target count/sum assertion.
- Add distributed BVT coverage for the uncommitted INSERT reproduction, immediate-`BEGIN` clone, transaction-local source database/table, rollback atomicity, autocommit, and named-snapshot controls.

### Issue-to-test proof

- Uncommitted DML omission: the embedded regression asserts exact source and target rows after INSERT, UPDATE, DELETE, and ALTER before and after COMMIT; the distributed BVT asserts matching 4/10/10 source and target aggregates for the exact INSERT reproduction.
- Transaction-local source relation failure: the embedded regression and BVT create the source database/table in the explicit transaction, clone it, enumerate the target table, and assert the cloned row.
- Immediate `BEGIN` ownership boundary: the unit test, embedded regression, and BVT all cover a database clone immediately after `BEGIN` without an intervening statement.
- Atomicity and compatibility: the embedded regression and BVT verify rollback removes transaction-local source/target state, while autocommit, named snapshot, and table-clone controls retain their expected visibility.

### Tests run

- `./.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=300s -run '^(TestCloneSnapshotTxnOperator|TestGetBackExecutorClosesWhenBeginFails|TestGetBackExecutorWithTxnHandlerUsesTxnHandlerBeginState)$' ./pkg/frontend` — PASS.
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=600s ./pkg/frontend` — PASS (26.027s).
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=600s -run '^TestIssue27055DatabaseCloneReadsExplicitTransactionSource$' ./pkg/tests/issues` — PASS (test 15.19s; package 17.077s).
- mo-tester BVT `issue_27055_clone_database_transaction` — PASS (54/54); generated output was inspected against the intended SQL semantics.
- `GOWORK=off go list -mod=readonly ./pkg/frontend ./pkg/tests/issues` — PASS.
- `go build` for `./pkg/frontend` and `go vet` for `./pkg/frontend ./pkg/tests/issues` with the repository CGo include/library paths used by `mo-cgo-test` — PASS.
- `git diff --check` — PASS.

### Risk / compatibility

The production change is limited to explicit-transaction ownership detection when database clone must acquire its own executor. Existing nested executor reuse, table clone, DATA BRANCH, autocommit, and named-snapshot paths remain unchanged. No new transaction, goroutine, lock, or resource lifecycle is introduced.

The embedded regression is the proof for UPDATE/DELETE semantics. The distributed BVT uses the exact INSERT issue path because a separate pre-existing distributed-tae physical-version behavior exposes historical UPDATE/DELETE versions in that topology; this PR does not change that unrelated behavior.
