### PR TITLE
fix(disttae): transfer tombstones only for objects deleted in window

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
@@ -207,8 +207,10 @@ func (p *PartitionState) GetChangedTombstoneObjsBetween(from types.TS) (objs []o
 	return
 }
 
-// GetChangedObjsBetween get changed objects between [begin, end],
-// notice that if an object is created after begin and deleted before end, it will be ignored.
+// GetChangedObjsBetween gets object changes in (begin, end]. Objects at begin
+// are already part of the transaction snapshot. An object created and deleted
+// wholly inside the interval is ignored because the transaction cannot have a
+// tombstone that references it.
 func (p *PartitionState) GetChangedObjsBetween(
 	begin types.TS,
 	end types.TS,
@@ -229,6 +231,9 @@ func (p *PartitionState) GetChangedObjsBetween(
 
 		if entry.Time.GT(&end) {
 			break
+		}
+		if !entry.Time.GT(&begin) {
+			continue
 		}
 
 		if entry.IsDelete {
@@ -282,6 +287,11 @@ func (p *PartitionState) CollectObjectsBetween(
 		if entry.Time.GT(&end) {
 			break
 		}
+		// start is the transaction snapshot already observed by the caller;
+		// only object transitions after it require RowID transfer.
+		if !entry.Time.GT(&start) {
+			continue
+		}
 
 		var ss objectio.ObjectStats
 		objectio.SetObjectStatsShortName(&ss, &entry.ShortObjName)
@@ -294,53 +304,21 @@ func (p *PartitionState) CollectObjectsBetween(
 			continue
 		}
 
-		// case1: no soft delete
-		if val.DeleteTime.IsEmpty() {
-			insertList = append(insertList, val.ObjectStats)
-		} else {
-			if val.CreateTime.LT(&start) {
-				// create --------- delete
-				//          start -------- end
-				if val.DeleteTime.LE(&end) {
-					deletedList = append(deletedList, val.ObjectStats)
-				}
-			} else {
-				//        create ---------- delete
-				// start ------------ end
-				if val.DeleteTime.GT(&end) {
-					insertList = append(insertList, val.ObjectStats)
-				}
+		if entry.IsDelete {
+			// A source object visible at start and deleted in (start, end]
+			// needs its transaction tombstones transferred.
+			if val.CreateTime.LE(&start) {
+				deletedList = append(deletedList, val.ObjectStats)
 			}
+		} else if val.DeleteTime.IsEmpty() || val.DeleteTime.GT(&end) {
+			// Keep only replacement objects that survive through end. Objects
+			// created and deleted wholly inside the interval are not visible to
+			// the transaction and cannot be transfer sources or final targets.
+			insertList = append(insertList, val.ObjectStats)
 		}
 	}
 
 	return
-}
-
-func (p *PartitionState) CheckIfObjectDeletedBeforeTS(
-	ts types.TS,
-	isTombstone bool,
-	objId *objectio.ObjectId,
-) bool {
-
-	var tree *btree.BTreeG[objectio.ObjectEntry]
-	if isTombstone {
-		tree = p.tombstoneObjectsNameIndex
-	} else {
-		tree = p.dataObjectsNameIndex
-	}
-
-	var stats objectio.ObjectStats
-	objectio.SetObjectStatsShortName(&stats, (*objectio.ObjectNameShort)(objId))
-	val, exist := tree.Get(objectio.ObjectEntry{
-		ObjectStats: stats,
-	})
-
-	if !exist {
-		return true
-	}
-
-	return !val.DeleteTime.IsEmpty() && val.DeleteTime.LE(&ts)
 }
 
 func (p *PartitionState) GetObject(name objectio.ObjectNameShort) (objectio.ObjectEntry, bool) {

--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
@@ -129,7 +129,6 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 
 		require.Equal(t, inserted,
 			[]objectio.ObjectStats{
-				obj1.ObjectStats,
 				obj2.ObjectStats,
 				obj3.ObjectStats,
 			})
@@ -138,7 +137,9 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 	// check 2
 	{
 		inserted, deleted := pState.CollectObjectsBetween(t1, t4)
-		require.Nil(t, deleted)
+		// obj1 is visible at the start boundary and is deleted in the
+		// transfer window, so tombstones created at t1 can reference it.
+		require.Equal(t, deleted, []objectio.ObjectStats{obj1.ObjectStats})
 		require.Equal(t, inserted,
 			[]objectio.ObjectStats{obj2.ObjectStats, obj3.ObjectStats, obj4.ObjectStats})
 	}
@@ -148,7 +149,23 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 		inserted, deleted := pState.CollectObjectsBetween(t2, t4)
 		require.Equal(t, deleted, []objectio.ObjectStats{obj1.ObjectStats})
 		require.Equal(t, inserted,
-			[]objectio.ObjectStats{obj2.ObjectStats, obj3.ObjectStats, obj4.ObjectStats})
+			[]objectio.ObjectStats{obj3.ObjectStats, obj4.ObjectStats})
+	}
+
+	// The in-memory and persisted tombstone transfer paths must use the same
+	// (start, end] boundary. obj1 is visible at t1, while obj2-4 are created
+	// after it; the create event for obj1 at the boundary must not cancel its
+	// later delete event.
+	{
+		deleted, inserted := pState.GetChangedObjsBetween(t1, t4)
+		require.Equal(t, map[objectio.ObjectNameShort]struct{}{
+			*obj1.ObjectShortName(): {},
+		}, deleted)
+		require.Equal(t, map[objectio.ObjectNameShort]struct{}{
+			*obj2.ObjectShortName(): {},
+			*obj3.ObjectShortName(): {},
+			*obj4.ObjectShortName(): {},
+		}, inserted)
 	}
 
 	// t5: delete obj2, insert obj5
@@ -218,10 +235,10 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 				require.True(t, ok)
 
 				if obj.DeleteTime.IsEmpty() {
-					ok = obj.CreateTime.GE(&tx) && obj.CreateTime.LE(&ty)
+					ok = obj.CreateTime.GT(&tx) && obj.CreateTime.LE(&ty)
 					require.True(t, ok)
 				} else {
-					ok = obj.CreateTime.GE(&tx) && obj.CreateTime.LE(&ty) && obj.DeleteTime.GT(&ty)
+					ok = obj.CreateTime.GT(&tx) && obj.CreateTime.LE(&ty) && obj.DeleteTime.GT(&ty)
 					require.True(t, ok)
 				}
 			}
@@ -232,7 +249,7 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 
 				require.False(t, obj.DeleteTime.IsEmpty())
 
-				ok = obj.CreateTime.LT(&tx) && obj.DeleteTime.GE(&tx) && obj.DeleteTime.LE(&ty)
+				ok = obj.CreateTime.LE(&tx) && obj.DeleteTime.GT(&tx) && obj.DeleteTime.LE(&ty)
 				require.True(t, ok)
 			}
 
@@ -240,6 +257,107 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 
 		}
 	}
+}
+
+func TestPartitionState_TransferObjectWindowBoundaries(t *testing.T) {
+	state := NewPartitionState("", false, 0x3fff, false)
+	start := types.BuildTS(10, 0)
+	end := types.BuildTS(20, 0)
+
+	type objectLifecycle struct {
+		name       string
+		createTime types.TS
+		deleteTime types.TS
+	}
+	lifecycles := []objectLifecycle{
+		// Already invisible at start: not a transfer source.
+		{name: "deleted-at-start", createTime: types.BuildTS(5, 0), deleteTime: start},
+		// Visible at start, including the equality boundary: transfer sources.
+		{name: "created-before-start", createTime: types.BuildTS(5, 0), deleteTime: types.BuildTS(15, 0)},
+		{name: "created-at-start", createTime: start, deleteTime: types.BuildTS(15, 0)},
+		// Created after the snapshot and gone before end: neither source nor target.
+		{name: "transient-in-window", createTime: types.BuildTS(11, 0), deleteTime: types.BuildTS(15, 0)},
+		// New objects that survive through end: transfer targets.
+		{name: "created-after-start", createTime: types.BuildTS(11, 0)},
+		{name: "deleted-after-end", createTime: types.BuildTS(12, 0), deleteTime: types.BuildTS(21, 0)},
+		{name: "created-at-end", createTime: end},
+		// Existing live state and future state are outside the change window.
+		{name: "live-at-start", createTime: start},
+		{name: "created-after-end", createTime: types.BuildTS(21, 0)},
+	}
+
+	entries := make(map[string]objectio.ObjectEntry, len(lifecycles))
+	for _, lifecycle := range lifecycles {
+		var stats objectio.ObjectStats
+		require.NoError(t, objectio.SetObjectStatsObjectName(
+			&stats, objectio.ObjectName(lifecycle.name)))
+		entry := objectio.ObjectEntry{
+			ObjectStats: stats,
+			CreateTime:  lifecycle.createTime,
+			DeleteTime:  lifecycle.deleteTime,
+		}
+		entries[lifecycle.name] = entry
+		state.dataObjectsNameIndex.Set(entry)
+		state.dataObjectTSIndex.Set(ObjectIndexByTSEntry{
+			Time:         entry.CreateTime,
+			ShortObjName: *entry.ObjectShortName(),
+		})
+		if !entry.DeleteTime.IsEmpty() {
+			state.dataObjectTSIndex.Set(ObjectIndexByTSEntry{
+				Time:         entry.DeleteTime,
+				ShortObjName: *entry.ObjectShortName(),
+				IsDelete:     true,
+			})
+		}
+	}
+
+	toNameSet := func(stats []objectio.ObjectStats) map[objectio.ObjectNameShort]struct{} {
+		result := make(map[objectio.ObjectNameShort]struct{}, len(stats))
+		for i := range stats {
+			result[*stats[i].ObjectShortName()] = struct{}{}
+		}
+		return result
+	}
+	shortName := func(name string) objectio.ObjectNameShort {
+		entry := entries[name]
+		return *entry.ObjectShortName()
+	}
+	objectID := func(name string) *types.Objectid {
+		entry := entries[name]
+		return entry.ObjectName().ObjectId()
+	}
+	// Prove the reachability behind the equality case rather than treating it
+	// as a theoretical timestamp permutation.
+	require.True(t, state.IsDataObjectVisible(objectID("created-at-start"), start))
+	require.False(t, state.IsDataObjectVisible(objectID("deleted-at-start"), start))
+	require.False(t, state.IsDataObjectVisible(objectID("transient-in-window"), start))
+
+	wantDeleted := map[objectio.ObjectNameShort]struct{}{
+		shortName("created-before-start"): {},
+		shortName("created-at-start"):     {},
+	}
+	wantInserted := map[objectio.ObjectNameShort]struct{}{
+		shortName("created-after-start"): {},
+		shortName("deleted-after-end"):   {},
+		shortName("created-at-end"):      {},
+	}
+
+	insertedStats, deletedStats := state.CollectObjectsBetween(start, end)
+	require.Equal(t, wantInserted, toNameSet(insertedStats))
+	require.Equal(t, wantDeleted, toNameSet(deletedStats))
+
+	deletedNames, insertedNames := state.GetChangedObjsBetween(start, end)
+	require.Equal(t, wantInserted, insertedNames)
+	require.Equal(t, wantDeleted, deletedNames)
+
+	// A zero-width snapshot interval contains no transitions: objects at the
+	// boundary already belong to the observed snapshot state.
+	insertedStats, deletedStats = state.CollectObjectsBetween(start, start)
+	require.Empty(t, insertedStats)
+	require.Empty(t, deletedStats)
+	deletedNames, insertedNames = state.GetChangedObjsBetween(start, start)
+	require.Empty(t, insertedNames)
+	require.Empty(t, deletedNames)
 }
 
 func TestPartitionState_NewBlocksIter(t *testing.T) {

--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
@@ -273,11 +273,13 @@ func TestPartitionState_TransferObjectWindowBoundaries(t *testing.T) {
 		// Already invisible at start: not a transfer source.
 		{name: "deleted-at-start", createTime: types.BuildTS(5, 0), deleteTime: start},
 		// Visible at start, including the equality boundary: transfer sources.
+		{name: "deleted-at-successor", createTime: types.BuildTS(5, 0), deleteTime: start.Next()},
 		{name: "created-before-start", createTime: types.BuildTS(5, 0), deleteTime: types.BuildTS(15, 0)},
 		{name: "created-at-start", createTime: start, deleteTime: types.BuildTS(15, 0)},
 		// Created after the snapshot and gone before end: neither source nor target.
 		{name: "transient-in-window", createTime: types.BuildTS(11, 0), deleteTime: types.BuildTS(15, 0)},
 		// New objects that survive through end: transfer targets.
+		{name: "created-at-successor", createTime: start.Next()},
 		{name: "created-after-start", createTime: types.BuildTS(11, 0)},
 		{name: "deleted-after-end", createTime: types.BuildTS(12, 0), deleteTime: types.BuildTS(21, 0)},
 		{name: "created-at-end", createTime: end},
@@ -333,13 +335,15 @@ func TestPartitionState_TransferObjectWindowBoundaries(t *testing.T) {
 	require.False(t, state.IsDataObjectVisible(objectID("transient-in-window"), start))
 
 	wantDeleted := map[objectio.ObjectNameShort]struct{}{
+		shortName("deleted-at-successor"): {},
 		shortName("created-before-start"): {},
 		shortName("created-at-start"):     {},
 	}
 	wantInserted := map[objectio.ObjectNameShort]struct{}{
-		shortName("created-after-start"): {},
-		shortName("deleted-after-end"):   {},
-		shortName("created-at-end"):      {},
+		shortName("created-at-successor"): {},
+		shortName("created-after-start"):  {},
+		shortName("deleted-after-end"):    {},
+		shortName("created-at-end"):       {},
 	}
 
 	insertedStats, deletedStats := state.CollectObjectsBetween(start, end)

--- a/pkg/vm/engine/disttae/transfer_util.go
+++ b/pkg/vm/engine/disttae/transfer_util.go
@@ -36,6 +36,19 @@ type UT_ForceTransCheck struct{}
 
 type TransferOption func(*TransferFlow)
 
+func newDeletedObjectFilter(
+	deletedObjects []objectio.ObjectStats,
+) func(*objectio.ObjectId) bool {
+	deletedObjectIDs := make(map[types.Objectid]struct{}, len(deletedObjects))
+	for i := range deletedObjects {
+		deletedObjectIDs[*deletedObjects[i].ObjectName().ObjectId()] = struct{}{}
+	}
+	return func(objID *objectio.ObjectId) bool {
+		_, deleted := deletedObjectIDs[*objID]
+		return deleted
+	}
+}
+
 func ConstructCNTombstoneObjectsTransferFlow(
 	ctx context.Context,
 	start, end types.TS,
@@ -51,10 +64,6 @@ func ConstructCNTombstoneObjectsTransferFlow(
 		return nil, nil, err
 	}
 
-	isObjectDeletedFn := func(objId *objectio.ObjectId) bool {
-		return state.CheckIfObjectDeletedBeforeTS(end, false, objId)
-	}
-
 	var logs []zap.Field
 
 	newDataObjects, deletedObjects := state.CollectObjectsBetween(start, end)
@@ -67,13 +76,14 @@ func ConstructCNTombstoneObjectsTransferFlow(
 		return nil, logs, nil
 	}
 
+	deletedObjectPos := 0
 	deletedObjectsIter := func() *types.Objectid {
-		if len(deletedObjects) == 0 {
+		if deletedObjectPos == len(deletedObjects) {
 			return nil
 		}
 
-		id := deletedObjects[0].ObjectName().ObjectId()
-		deletedObjects = deletedObjects[1:]
+		id := deletedObjects[deletedObjectPos].ObjectName().ObjectId()
+		deletedObjectPos++
 		return id
 	}
 
@@ -102,6 +112,12 @@ func ConstructCNTombstoneObjectsTransferFlow(
 	}
 
 	logs = append(logs, zap.Int("coarse-tombstoneObjects", len(tombstoneObjects)))
+
+	// Only tombstones that point at an object deleted in this exact transfer
+	// window need to move. Live appendable objects are intentionally absent
+	// from PartitionState's persisted-object index, so treating an unknown
+	// object as deleted would incorrectly stage their tombstones.
+	isObjectDeletedFn := newDeletedObjectFilter(deletedObjects)
 
 	pkColIdx := table.tableDef.Name2ColIndex[table.tableDef.Pkey.PkeyColName]
 	pkCol := table.tableDef.Cols[pkColIdx]

--- a/pkg/vm/engine/disttae/transfer_util.go
+++ b/pkg/vm/engine/disttae/transfer_util.go
@@ -36,6 +36,29 @@ type UT_ForceTransCheck struct{}
 
 type TransferOption func(*TransferFlow)
 
+const (
+	// RowID transfer has a material fixed cost: every batch constructs an IN
+	// filter, prunes replacement objects, and builds a reader.  One object block
+	// (8192 rows) made large updates pay that setup cost thousands of times.
+	// Aggregate up to eight blocks, with an 8 MiB soft limit that flushes wide
+	// primary keys at the next source-batch boundary.
+	transferBatchRowLimit  = objectio.BlockMaxRows * 8
+	transferBatchSizeLimit = mpool.MB * 8
+)
+
+func transferBatchLimitReached(rowCount, byteSize int, sourceBatchDone bool) bool {
+	if rowCount == 0 {
+		return false
+	}
+	if rowCount >= transferBatchRowLimit {
+		return true
+	}
+	// Computing Batch.Size for every row would add work to the hot path.  The
+	// source reader already bounds its batches, so enforce the byte limit once
+	// per source batch and bound any overshoot by that source batch.
+	return sourceBatchDone && byteSize >= transferBatchSizeLimit
+}
+
 func newDeletedObjectFilter(
 	deletedObjects []objectio.ObjectStats,
 ) func(*objectio.ObjectId) bool {
@@ -280,12 +303,15 @@ func (flow *TransferFlow) processOneBatch(ctx context.Context, buffer *batch.Bat
 		flow.transferred.rowCnt++
 		flow.transferred.objDetails[objectid.ShortStringEx()]++
 
-		if staged.Vecs[0].Length() >= objectio.BlockMaxRows {
+		if transferBatchLimitReached(staged.RowCount(), 0, false) {
 			if err := flow.transferStaged(ctx); err != nil {
 				return err
 			}
 			staged = flow.getStaged()
 		}
+	}
+	if transferBatchLimitReached(staged.RowCount(), staged.Size(), true) {
+		return flow.transferStaged(ctx)
 	}
 	return nil
 }

--- a/pkg/vm/engine/disttae/transfer_util_test.go
+++ b/pkg/vm/engine/disttae/transfer_util_test.go
@@ -1,0 +1,171 @@
+// Copyright 2021-2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeletedObjectFilterUsesExactTransferWindow(t *testing.T) {
+	emptyFilter := newDeletedObjectFilter(nil)
+	require.False(t, emptyFilter(objectio.MockObjectName().ObjectId()))
+
+	deletedName := objectio.MockObjectName()
+	var deletedStats objectio.ObjectStats
+	require.NoError(t, objectio.SetObjectStatsObjectName(&deletedStats, deletedName))
+
+	filter := newDeletedObjectFilter([]objectio.ObjectStats{deletedStats})
+	require.True(t, filter(deletedName.ObjectId()))
+
+	// A live appendable object has no entry in PartitionState's persisted-object
+	// index. It must not be mistaken for an object deleted in this window.
+	liveAppendableName := objectio.MockObjectName()
+	require.False(t, filter(liveAppendableName.ObjectId()))
+
+	// Nor should an object deleted before a previous transfer window be moved
+	// again merely because its tombstone shares a file with an affected object.
+	previouslyDeletedName := objectio.MockObjectName()
+	require.False(t, filter(previouslyDeletedName.ObjectId()))
+}
+
+func TestTransferFlowStagesOnlyObjectsDeletedInWindow(t *testing.T) {
+	mp := mpool.MustNewZero()
+	ctx := context.Background()
+	state := logtailreplay.NewPartitionState("", false, 42, false)
+	start := types.BuildTS(10, 0)
+	end := types.BuildTS(20, 0)
+
+	// Reproduce the root ownership boundary: CN intentionally does not add a
+	// live appendable object's create event to the persisted-object index.
+	liveAppendableID := objectio.NewObjectid()
+	liveAppendableStats := objectio.NewObjectStatsWithObjectID(
+		&liveAppendableID, true, false, false)
+	require.NoError(t, objectio.SetObjectStatsSize(liveAppendableStats, 1))
+	require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+		ObjectStats: *liveAppendableStats,
+		CreateTime:  types.BuildTS(5, 0),
+	}, false))
+	_, exists := state.GetObject(*liveAppendableStats.ObjectShortName())
+	require.False(t, exists)
+
+	// A persisted source object visible at start is deleted during the window,
+	// and a replacement object is created by the same merge.
+	deletedID := objectio.NewObjectid()
+	deletedStats := objectio.NewObjectStatsWithObjectID(
+		&deletedID, false, false, false)
+	require.NoError(t, objectio.SetObjectStatsSize(deletedStats, 1))
+	require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+		ObjectStats: *deletedStats,
+		CreateTime:  types.BuildTS(5, 0),
+		DeleteTime:  types.BuildTS(15, 0),
+	}, false))
+
+	replacementID := objectio.NewObjectid()
+	replacementStats := objectio.NewObjectStatsWithObjectID(
+		&replacementID, false, false, false)
+	require.NoError(t, objectio.SetObjectStatsSize(replacementStats, 1))
+	require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+		ObjectStats: *replacementStats,
+		CreateTime:  types.BuildTS(15, 0),
+	}, false))
+
+	newDataObjects, deletedObjects := state.CollectObjectsBetween(start, end)
+	require.Len(t, newDataObjects, 1)
+	require.Equal(t, replacementID, *newDataObjects[0].ObjectName().ObjectId())
+	require.Len(t, deletedObjects, 1)
+	require.Equal(t, deletedID, *deletedObjects[0].ObjectName().ObjectId())
+
+	liveAppendableName := liveAppendableStats.ObjectName()
+	deletedName := deletedStats.ObjectName()
+
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	defer input.Clean(mp)
+
+	liveRowID := types.NewRowIDWithObjectIDBlkNumAndRowID(
+		*liveAppendableName.ObjectId(), 0, 0,
+	)
+	deletedRowID := types.NewRowIDWithObjectIDBlkNumAndRowID(
+		*deletedName.ObjectId(), 0, 0,
+	)
+	require.NoError(t, vector.AppendFixed(input.Vecs[0], liveRowID, false, mp))
+	require.NoError(t, vector.AppendFixed(input.Vecs[1], int64(1), false, mp))
+	require.NoError(t, vector.AppendFixed(input.Vecs[0], deletedRowID, false, mp))
+	require.NoError(t, vector.AppendFixed(input.Vecs[1], int64(2), false, mp))
+	input.SetRowCount(2)
+
+	staged := batch.NewWithSize(2)
+	staged.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	staged.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	flow := &TransferFlow{
+		isObjectDeletedFn: newDeletedObjectFilter(deletedObjects),
+		staged:            staged,
+		mp:                mp,
+	}
+	flow.transferred.objDetails = make(map[string]int)
+	defer flow.staged.Clean(mp)
+
+	require.NoError(t, flow.processOneBatch(ctx, input))
+	require.Equal(t, 1, flow.staged.RowCount())
+	require.Equal(t, deletedRowID,
+		vector.MustFixedColWithTypeCheck[types.Rowid](flow.staged.Vecs[0])[0])
+	require.Equal(t, int64(2),
+		vector.MustFixedColWithTypeCheck[int64](flow.staged.Vecs[1])[0])
+	require.Equal(t, 1, flow.transferred.rowCnt)
+	require.Equal(t, map[string]int{deletedName.ObjectId().ShortStringEx(): 1},
+		flow.transferred.objDetails)
+}
+
+func BenchmarkDeletedObjectFilter(b *testing.B) {
+	for _, objectCount := range []int{1, 16, 256, 4096} {
+		deletedObjects := make([]objectio.ObjectStats, objectCount)
+		for i := range deletedObjects {
+			require.NoError(b, objectio.SetObjectStatsObjectName(
+				&deletedObjects[i], objectio.MockObjectName()))
+		}
+
+		b.Run(fmt.Sprintf("build/%d", objectCount), func(b *testing.B) {
+			b.ReportAllocs()
+			var filter func(*objectio.ObjectId) bool
+			for i := 0; i < b.N; i++ {
+				filter = newDeletedObjectFilter(deletedObjects)
+			}
+			runtime.KeepAlive(filter)
+		})
+
+		filter := newDeletedObjectFilter(deletedObjects)
+		objectID := deletedObjects[objectCount-1].ObjectName().ObjectId()
+		b.Run(fmt.Sprintf("lookup/%d", objectCount), func(b *testing.B) {
+			b.ReportAllocs()
+			var deleted bool
+			for i := 0; i < b.N; i++ {
+				deleted = filter(objectID)
+			}
+			runtime.KeepAlive(deleted)
+		})
+	}
+}

--- a/pkg/vm/engine/disttae/transfer_util_test.go
+++ b/pkg/vm/engine/disttae/transfer_util_test.go
@@ -51,6 +51,93 @@ func TestDeletedObjectFilterUsesExactTransferWindow(t *testing.T) {
 	require.False(t, filter(previouslyDeletedName.ObjectId()))
 }
 
+func TestTransferBatchLimit(t *testing.T) {
+	tests := []struct {
+		name            string
+		rowCount        int
+		byteSize        int
+		sourceBatchDone bool
+		want            bool
+	}{
+		{name: "empty", byteSize: transferBatchSizeLimit, sourceBatchDone: true},
+		{
+			name:     "below both limits",
+			rowCount: transferBatchRowLimit - 1,
+			byteSize: transferBatchSizeLimit - 1,
+		},
+		{
+			name:     "row limit",
+			rowCount: transferBatchRowLimit,
+			want:     true,
+		},
+		{
+			name:            "size limit after source batch",
+			rowCount:        1,
+			byteSize:        transferBatchSizeLimit,
+			sourceBatchDone: true,
+			want:            true,
+		},
+		{
+			name:     "size is not measured per row",
+			rowCount: 1,
+			byteSize: transferBatchSizeLimit,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, transferBatchLimitReached(
+				test.rowCount, test.byteSize, test.sourceBatchDone))
+		})
+	}
+}
+
+func TestTransferFlowBatchesAcrossObjectBlocks(t *testing.T) {
+	mp := mpool.MustNewZero()
+	ctx := context.Background()
+	objectID := objectio.NewObjectid()
+	rowID := types.NewRowIDWithObjectIDBlkNumAndRowID(objectID, 0, 0)
+	rowCount := int(objectio.BlockMaxRows)
+
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixedList(
+		input.Vecs[0], makeRepeated(rowID, rowCount), nil, mp))
+	require.NoError(t, vector.AppendFixedList(
+		input.Vecs[1], makeRepeated(int64(1), rowCount), nil, mp))
+	input.SetRowCount(rowCount)
+	defer input.Clean(mp)
+
+	staged := batch.NewWithSize(2)
+	staged.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	staged.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	flow := &TransferFlow{
+		isObjectDeletedFn: func(*objectio.ObjectId) bool { return true },
+		staged:            staged,
+		mp:                mp,
+	}
+	flow.transferred.objDetails = make(map[string]int)
+	defer flow.staged.Clean(mp)
+
+	// The former one-block policy invoked RowID lookup after the first call.
+	// Keeping both blocks staged proves the expensive lookup setup is amortized
+	// without changing which rows are selected for transfer.
+	require.NoError(t, flow.processOneBatch(ctx, input))
+	require.Equal(t, rowCount, flow.staged.RowCount())
+	require.NoError(t, flow.processOneBatch(ctx, input))
+	require.Equal(t, rowCount*2, flow.staged.RowCount())
+	require.Equal(t, rowCount*2, flow.transferred.rowCnt)
+}
+
+func makeRepeated[T any](value T, count int) []T {
+	values := make([]T, count)
+	for i := range values {
+		values[i] = value
+	}
+	return values
+}
+
 func TestTransferFlowStagesOnlyObjectsDeletedInWindow(t *testing.T) {
 	mp := mpool.MustNewZero()
 	ctx := context.Background()

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2816,7 +2816,10 @@ func (tbl *txnTable) PKPersistedBetween(
 
 	// Only check data objects. A matching object/block can still be an older
 	// version, so later row-level commit-ts checks narrow the final answer.
-	delObjs, cObjs = p.GetChangedObjsBetween(from.Next(), types.MaxTs())
+	// GetChangedObjsBetween already selects (from, end]. Advancing from here
+	// would skip an object transition committed at the valid HLC timestamp
+	// from.Next(), weakening the PK-conflict check at that exact boundary.
+	delObjs, cObjs = p.GetChangedObjsBetween(from, types.MaxTs())
 
 	if pkCheckBailoutOnChangedObjects(len(cObjs)) {
 		reason = "changed_objects_bailout"


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27878

## What this PR does / why we need it:

CN tombstone transfer previously used absence from `PartitionState`'s persisted-object index as evidence that an object had been deleted. Live appendable objects are intentionally absent from that index, so their tombstones could be staged for transfer even though the source object was still alive. Since the replacement-object list only contains objects created for objects actually deleted in the transfer window, RowID lookup then failed its cardinality invariant and rolled back large indexed DML.

This PR:

- classifies a tombstone for transfer only when its source ObjectID belongs to the exact `deletedObjects` set returned for the current `(start, end]` window;
- makes both in-memory and persisted transfer paths use the same `(start, end]` transition window: objects created exactly at `start` are already visible snapshot state, while a later delete of that object must still be transferred;
- removes the unsafe absent-means-deleted helper;
- preserves existing ZoneMap/Bloom pruning and the cardinality guard, with no fallback or global scan;
- keeps PK-conflict object discovery on the same `(from, end]` contract without advancing `from` twice, so an object transition committed at the valid HLC timestamp `from.Next()` is not skipped;
- amortizes the existing RowID lookup setup over at most eight source blocks, with an 8 MiB soft size limit. Table processing and each transaction's transfer path remain serial: no goroutine, worker pool, or additional concurrent S3 I/O is introduced. With `N` concurrent transactions the node still has `N` serial transfer flows, not `2N` per-transaction workers;
- adds mixed live/deleted, previous-window, zero-width-window, exact-HLC-successor, and lifecycle-boundary coverage.

The set is allocated only after the coarse tombstone filter finds affected work and changes per-row classification to O(1) membership.

## QA test plan

Run on a fresh standalone instance and an empty data directory. Execute the statements continuously so the final insert/UPDATE overlaps the normal background object merges, matching the original 100%-repro procedure:

```sql
drop database if exists transfer_rowid_qa;
create database transfer_rowid_qa;
use transfer_rowid_qa;

create table write_100m (
  id bigint primary key,
  col3 int,
  col4 bigint,
  key(col3),
  unique key(col4)
);

insert into write_100m values (1, 1, 1);
insert into write_100m select id + 1,        col3, col4 + 1        from write_100m;
insert into write_100m select id + 2,        col3, col4 + 2        from write_100m;
insert into write_100m select id + 4,        col3, col4 + 4        from write_100m;
insert into write_100m select id + 8,        col3, col4 + 8        from write_100m;
insert into write_100m select id + 16,       col3, col4 + 16       from write_100m;
insert into write_100m select id + 32,       col3, col4 + 32       from write_100m;
insert into write_100m select id + 64,       col3, col4 + 64       from write_100m;
insert into write_100m select id + 128,      col3, col4 + 128      from write_100m;
insert into write_100m select id + 256,      col3, col4 + 256      from write_100m;
insert into write_100m select id + 512,      col3, col4 + 512      from write_100m;
insert into write_100m select id + 1024,     col3, col4 + 1024     from write_100m;
insert into write_100m select id + 2048,     col3, col4 + 2048     from write_100m;
insert into write_100m select id + 4096,     col3, col4 + 4096     from write_100m;
insert into write_100m select id + 8192,     col3, col4 + 8192     from write_100m;
insert into write_100m select id + 16384,    col3, col4 + 16384    from write_100m;
insert into write_100m select id + 32768,    col3, col4 + 32768    from write_100m;
insert into write_100m select id + 65536,    col3, col4 + 65536    from write_100m;
insert into write_100m select id + 131072,   col3, col4 + 131072   from write_100m;
insert into write_100m select id + 262144,   col3, col4 + 262144   from write_100m;
insert into write_100m select id + 524288,   col3, col4 + 524288   from write_100m;
insert into write_100m select id + 1048576,  col3, col4 + 1048576  from write_100m;
insert into write_100m select id + 2097152,  col3, col4 + 2097152  from write_100m;
insert into write_100m select id + 4194304,  col3, col4 + 4194304  from write_100m;
insert into write_100m select id + 8388608,  col3, col4 + 8388608  from write_100m;
insert into write_100m select id + 16777216, col3, col4 + 16777216 from write_100m;
insert into write_100m
  select id + 33554432, col3, col4 + 33554432
  from write_100m where id <= 16445568;

select count(*) from write_100m; -- 50000000
update write_100m set col3 = col3 + 1;

select count(*), min(id), max(id), min(col3), max(col3),
       sum(id), sum(col4),
       sum(if(id <> col4 or col3 <> 2, 1, 0)) as invalid_rows
from write_100m;
-- 50000000, 1, 50000000, 2, 2,
-- 1250000025000000, 1250000025000000, 0

explain select * from write_100m force index(col3) where col3 = 2 limit 10;
select count(*) from write_100m force index(col3) where col3 = 2; -- 50000000
select count(*) from write_100m force index(col3) where col3 = 1; -- 0
select * from write_100m where col4 in (1, 8192, 8388608, 33554432, 50000000)
order by col4;
```

Acceptance:

1. The UPDATE commits without `TRANSFER-ROWIDS-ERROR-LEN-MISMATCH`, PK mismatch, retry exhaustion, or transaction rollback.
2. All exact SQL oracles above match, and `EXPLAIN` contains `Index Table Scan on write_100m.col3` plus `Join Type: INDEX`.
3. Stop the service cleanly, restart it on the same data directory, and rerun the final aggregate, forced-secondary-index counts, and unique-index point lookups; results must remain identical.
4. For performance, record UPDATE client wall time and each `CN-TRANSFER-TOMBSTONE-OBJ time-spent` on the same host/configuration. Compare with this PR's pre-optimization baseline: UPDATE 232 s end-to-end, base-table transfer 57 s, hidden-secondary-index transfer 107 s. Performance is judged by same-machine before/after comparison, not an absolute CI timeout.

Validation:

- `go test ./pkg/vm/engine/disttae/logtailreplay ./pkg/vm/engine/disttae -count=1`
- focused `logtailreplay` window tests and `disttae` transfer tests passed 10 times under `-race`;
- the root regression now exercises `HandleObjectEntry` (live appendable omitted from the persisted index), real window object collection, and mixed-row staging in one deterministic chain; restoring the old absent-means-deleted behavior makes it fail with 2 staged rows instead of 1;
- `make build`;
- lookup microbenchmark: approximately 6.2–6.7 ns/op with 0 B/op and 0 allocs/op; building a 4096-object set takes approximately 52 us and 164 KB once per actual transfer;
- exact original 100%-repro 50M black-box procedure on a fresh process and fresh data directory at `160d8ca207`: create the same primary/secondary/unique-indexed table, use the same doubling inserts plus the final `id <= 16445568` insert to reach exactly 50,000,000 rows, then run the same full-table `UPDATE col3 = col3 + 1` while base/index merges replace objects. It committed without RowID mismatch or rollback. Final oracle: `count(*)=50000000`, `min(id)=1`, `max(id)=50000000`, `min(col3)=max(col3)=2`. Transfer evidence: base table transferred 33,222,784 rows from 20 deleted objects; hidden secondary index transferred 35,704,960 rows from 23 deleted objects.
- post-commit persistence and index-integrity verification after two clean service restarts: the base table has no row where `id != col4` or `col3 != 2`, and `sum(id)=sum(col4)=1250000025000000`; the hidden unique-index table has exactly 50,000,000 rows, key/ref range `1..50000000`, equal sums, and zero key/ref mismatches; the hidden secondary-index table has exactly 50,000,000 rows with the same ref range and sum, zero dangling refs, and zero base rows missing an index ref. A forced secondary-index plan returned 50,000,000 rows for `col3=2` and zero for `col3=1`.
- bounded batching optimization at `caf968f0f3` (executable production code identical; the only post-build change was a comment), using the same fresh-process/fresh-data 50M procedure: UPDATE wall time improved from 232 s to 203.127 s (-12.5%); base-table transfer improved from 57.166 s to 41.066 s (-28.2%); hidden-secondary-index transfer improved from 107.035 s to 95.839 s (-10.5%). All exact aggregate and forced-index oracles passed with no mismatch or rollback. The full script, including loading and validation queries, took 4m00.64s versus 4m24.22s before batching.
