### PR TITLE
[4.2-dev] fix(disttae): transfer tombstones only for deleted objects

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
@@ -207,8 +207,10 @@ func (p *PartitionState) GetChangedTombstoneObjsBetween(from types.TS) (objs []o
 	return
 }
 
-// GetChangedObjsBetween get changed objects between [begin, end],
-// notice that if an object is created after begin and deleted before end, it will be ignored.
+// GetChangedObjsBetween gets object changes in (begin, end]. Objects at begin
+// are already part of the transaction snapshot. An object created and deleted
+// wholly inside the interval is ignored because the transaction cannot have a
+// tombstone that references it.
 func (p *PartitionState) GetChangedObjsBetween(
 	begin types.TS,
 	end types.TS,
@@ -229,6 +231,9 @@ func (p *PartitionState) GetChangedObjsBetween(
 
 		if entry.Time.GT(&end) {
 			break
+		}
+		if !entry.Time.GT(&begin) {
+			continue
 		}
 
 		if entry.IsDelete {
@@ -282,6 +287,11 @@ func (p *PartitionState) CollectObjectsBetween(
 		if entry.Time.GT(&end) {
 			break
 		}
+		// start is the transaction snapshot already observed by the caller;
+		// only object transitions after it require RowID transfer.
+		if !entry.Time.GT(&start) {
+			continue
+		}
 
 		var ss objectio.ObjectStats
 		objectio.SetObjectStatsShortName(&ss, &entry.ShortObjName)
@@ -294,53 +304,21 @@ func (p *PartitionState) CollectObjectsBetween(
 			continue
 		}
 
-		// case1: no soft delete
-		if val.DeleteTime.IsEmpty() {
-			insertList = append(insertList, val.ObjectStats)
-		} else {
-			if val.CreateTime.LT(&start) {
-				// create --------- delete
-				//          start -------- end
-				if val.DeleteTime.LE(&end) {
-					deletedList = append(deletedList, val.ObjectStats)
-				}
-			} else {
-				//        create ---------- delete
-				// start ------------ end
-				if val.DeleteTime.GT(&end) {
-					insertList = append(insertList, val.ObjectStats)
-				}
+		if entry.IsDelete {
+			// A source object visible at start and deleted in (start, end]
+			// needs its transaction tombstones transferred.
+			if val.CreateTime.LE(&start) {
+				deletedList = append(deletedList, val.ObjectStats)
 			}
+		} else if val.DeleteTime.IsEmpty() || val.DeleteTime.GT(&end) {
+			// Keep only replacement objects that survive through end. Objects
+			// created and deleted wholly inside the interval are not visible to
+			// the transaction and cannot be transfer sources or final targets.
+			insertList = append(insertList, val.ObjectStats)
 		}
 	}
 
 	return
-}
-
-func (p *PartitionState) CheckIfObjectDeletedBeforeTS(
-	ts types.TS,
-	isTombstone bool,
-	objId *objectio.ObjectId,
-) bool {
-
-	var tree *btree.BTreeG[objectio.ObjectEntry]
-	if isTombstone {
-		tree = p.tombstoneObjectsNameIndex
-	} else {
-		tree = p.dataObjectsNameIndex
-	}
-
-	var stats objectio.ObjectStats
-	objectio.SetObjectStatsShortName(&stats, (*objectio.ObjectNameShort)(objId))
-	val, exist := tree.Get(objectio.ObjectEntry{
-		ObjectStats: stats,
-	})
-
-	if !exist {
-		return true
-	}
-
-	return !val.DeleteTime.IsEmpty() && val.DeleteTime.LE(&ts)
 }
 
 func (p *PartitionState) GetObject(name objectio.ObjectNameShort) (objectio.ObjectEntry, bool) {

--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
@@ -129,7 +129,6 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 
 		require.Equal(t, inserted,
 			[]objectio.ObjectStats{
-				obj1.ObjectStats,
 				obj2.ObjectStats,
 				obj3.ObjectStats,
 			})
@@ -138,7 +137,9 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 	// check 2
 	{
 		inserted, deleted := pState.CollectObjectsBetween(t1, t4)
-		require.Nil(t, deleted)
+		// obj1 is visible at the start boundary and is deleted in the
+		// transfer window, so tombstones created at t1 can reference it.
+		require.Equal(t, deleted, []objectio.ObjectStats{obj1.ObjectStats})
 		require.Equal(t, inserted,
 			[]objectio.ObjectStats{obj2.ObjectStats, obj3.ObjectStats, obj4.ObjectStats})
 	}
@@ -148,7 +149,23 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 		inserted, deleted := pState.CollectObjectsBetween(t2, t4)
 		require.Equal(t, deleted, []objectio.ObjectStats{obj1.ObjectStats})
 		require.Equal(t, inserted,
-			[]objectio.ObjectStats{obj2.ObjectStats, obj3.ObjectStats, obj4.ObjectStats})
+			[]objectio.ObjectStats{obj3.ObjectStats, obj4.ObjectStats})
+	}
+
+	// The in-memory and persisted tombstone transfer paths must use the same
+	// (start, end] boundary. obj1 is visible at t1, while obj2-4 are created
+	// after it; the create event for obj1 at the boundary must not cancel its
+	// later delete event.
+	{
+		deleted, inserted := pState.GetChangedObjsBetween(t1, t4)
+		require.Equal(t, map[objectio.ObjectNameShort]struct{}{
+			*obj1.ObjectShortName(): {},
+		}, deleted)
+		require.Equal(t, map[objectio.ObjectNameShort]struct{}{
+			*obj2.ObjectShortName(): {},
+			*obj3.ObjectShortName(): {},
+			*obj4.ObjectShortName(): {},
+		}, inserted)
 	}
 
 	// t5: delete obj2, insert obj5
@@ -218,10 +235,10 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 				require.True(t, ok)
 
 				if obj.DeleteTime.IsEmpty() {
-					ok = obj.CreateTime.GE(&tx) && obj.CreateTime.LE(&ty)
+					ok = obj.CreateTime.GT(&tx) && obj.CreateTime.LE(&ty)
 					require.True(t, ok)
 				} else {
-					ok = obj.CreateTime.GE(&tx) && obj.CreateTime.LE(&ty) && obj.DeleteTime.GT(&ty)
+					ok = obj.CreateTime.GT(&tx) && obj.CreateTime.LE(&ty) && obj.DeleteTime.GT(&ty)
 					require.True(t, ok)
 				}
 			}
@@ -232,7 +249,7 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 
 				require.False(t, obj.DeleteTime.IsEmpty())
 
-				ok = obj.CreateTime.LT(&tx) && obj.DeleteTime.GE(&tx) && obj.DeleteTime.LE(&ty)
+				ok = obj.CreateTime.LE(&tx) && obj.DeleteTime.GT(&tx) && obj.DeleteTime.LE(&ty)
 				require.True(t, ok)
 			}
 
@@ -240,6 +257,107 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 
 		}
 	}
+}
+
+func TestPartitionState_TransferObjectWindowBoundaries(t *testing.T) {
+	state := NewPartitionState("", false, 0x3fff, false)
+	start := types.BuildTS(10, 0)
+	end := types.BuildTS(20, 0)
+
+	type objectLifecycle struct {
+		name       string
+		createTime types.TS
+		deleteTime types.TS
+	}
+	lifecycles := []objectLifecycle{
+		// Already invisible at start: not a transfer source.
+		{name: "deleted-at-start", createTime: types.BuildTS(5, 0), deleteTime: start},
+		// Visible at start, including the equality boundary: transfer sources.
+		{name: "created-before-start", createTime: types.BuildTS(5, 0), deleteTime: types.BuildTS(15, 0)},
+		{name: "created-at-start", createTime: start, deleteTime: types.BuildTS(15, 0)},
+		// Created after the snapshot and gone before end: neither source nor target.
+		{name: "transient-in-window", createTime: types.BuildTS(11, 0), deleteTime: types.BuildTS(15, 0)},
+		// New objects that survive through end: transfer targets.
+		{name: "created-after-start", createTime: types.BuildTS(11, 0)},
+		{name: "deleted-after-end", createTime: types.BuildTS(12, 0), deleteTime: types.BuildTS(21, 0)},
+		{name: "created-at-end", createTime: end},
+		// Existing live state and future state are outside the change window.
+		{name: "live-at-start", createTime: start},
+		{name: "created-after-end", createTime: types.BuildTS(21, 0)},
+	}
+
+	entries := make(map[string]objectio.ObjectEntry, len(lifecycles))
+	for _, lifecycle := range lifecycles {
+		var stats objectio.ObjectStats
+		require.NoError(t, objectio.SetObjectStatsObjectName(
+			&stats, objectio.ObjectName(lifecycle.name)))
+		entry := objectio.ObjectEntry{
+			ObjectStats: stats,
+			CreateTime:  lifecycle.createTime,
+			DeleteTime:  lifecycle.deleteTime,
+		}
+		entries[lifecycle.name] = entry
+		state.dataObjectsNameIndex.Set(entry)
+		state.dataObjectTSIndex.Set(ObjectIndexByTSEntry{
+			Time:         entry.CreateTime,
+			ShortObjName: *entry.ObjectShortName(),
+		})
+		if !entry.DeleteTime.IsEmpty() {
+			state.dataObjectTSIndex.Set(ObjectIndexByTSEntry{
+				Time:         entry.DeleteTime,
+				ShortObjName: *entry.ObjectShortName(),
+				IsDelete:     true,
+			})
+		}
+	}
+
+	toNameSet := func(stats []objectio.ObjectStats) map[objectio.ObjectNameShort]struct{} {
+		result := make(map[objectio.ObjectNameShort]struct{}, len(stats))
+		for i := range stats {
+			result[*stats[i].ObjectShortName()] = struct{}{}
+		}
+		return result
+	}
+	shortName := func(name string) objectio.ObjectNameShort {
+		entry := entries[name]
+		return *entry.ObjectShortName()
+	}
+	objectID := func(name string) *types.Objectid {
+		entry := entries[name]
+		return entry.ObjectName().ObjectId()
+	}
+	// Prove the reachability behind the equality case rather than treating it
+	// as a theoretical timestamp permutation.
+	require.True(t, state.IsDataObjectVisible(objectID("created-at-start"), start))
+	require.False(t, state.IsDataObjectVisible(objectID("deleted-at-start"), start))
+	require.False(t, state.IsDataObjectVisible(objectID("transient-in-window"), start))
+
+	wantDeleted := map[objectio.ObjectNameShort]struct{}{
+		shortName("created-before-start"): {},
+		shortName("created-at-start"):     {},
+	}
+	wantInserted := map[objectio.ObjectNameShort]struct{}{
+		shortName("created-after-start"): {},
+		shortName("deleted-after-end"):   {},
+		shortName("created-at-end"):      {},
+	}
+
+	insertedStats, deletedStats := state.CollectObjectsBetween(start, end)
+	require.Equal(t, wantInserted, toNameSet(insertedStats))
+	require.Equal(t, wantDeleted, toNameSet(deletedStats))
+
+	deletedNames, insertedNames := state.GetChangedObjsBetween(start, end)
+	require.Equal(t, wantInserted, insertedNames)
+	require.Equal(t, wantDeleted, deletedNames)
+
+	// A zero-width snapshot interval contains no transitions: objects at the
+	// boundary already belong to the observed snapshot state.
+	insertedStats, deletedStats = state.CollectObjectsBetween(start, start)
+	require.Empty(t, insertedStats)
+	require.Empty(t, deletedStats)
+	deletedNames, insertedNames = state.GetChangedObjsBetween(start, start)
+	require.Empty(t, insertedNames)
+	require.Empty(t, deletedNames)
 }
 
 func TestPartitionState_NewBlocksIter(t *testing.T) {

--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
@@ -273,11 +273,13 @@ func TestPartitionState_TransferObjectWindowBoundaries(t *testing.T) {
 		// Already invisible at start: not a transfer source.
 		{name: "deleted-at-start", createTime: types.BuildTS(5, 0), deleteTime: start},
 		// Visible at start, including the equality boundary: transfer sources.
+		{name: "deleted-at-successor", createTime: types.BuildTS(5, 0), deleteTime: start.Next()},
 		{name: "created-before-start", createTime: types.BuildTS(5, 0), deleteTime: types.BuildTS(15, 0)},
 		{name: "created-at-start", createTime: start, deleteTime: types.BuildTS(15, 0)},
 		// Created after the snapshot and gone before end: neither source nor target.
 		{name: "transient-in-window", createTime: types.BuildTS(11, 0), deleteTime: types.BuildTS(15, 0)},
 		// New objects that survive through end: transfer targets.
+		{name: "created-at-successor", createTime: start.Next()},
 		{name: "created-after-start", createTime: types.BuildTS(11, 0)},
 		{name: "deleted-after-end", createTime: types.BuildTS(12, 0), deleteTime: types.BuildTS(21, 0)},
 		{name: "created-at-end", createTime: end},
@@ -333,13 +335,15 @@ func TestPartitionState_TransferObjectWindowBoundaries(t *testing.T) {
 	require.False(t, state.IsDataObjectVisible(objectID("transient-in-window"), start))
 
 	wantDeleted := map[objectio.ObjectNameShort]struct{}{
+		shortName("deleted-at-successor"): {},
 		shortName("created-before-start"): {},
 		shortName("created-at-start"):     {},
 	}
 	wantInserted := map[objectio.ObjectNameShort]struct{}{
-		shortName("created-after-start"): {},
-		shortName("deleted-after-end"):   {},
-		shortName("created-at-end"):      {},
+		shortName("created-at-successor"): {},
+		shortName("created-after-start"):  {},
+		shortName("deleted-after-end"):    {},
+		shortName("created-at-end"):       {},
 	}
 
 	insertedStats, deletedStats := state.CollectObjectsBetween(start, end)

--- a/pkg/vm/engine/disttae/transfer_util.go
+++ b/pkg/vm/engine/disttae/transfer_util.go
@@ -36,6 +36,19 @@ type UT_ForceTransCheck struct{}
 
 type TransferOption func(*TransferFlow)
 
+func newDeletedObjectFilter(
+	deletedObjects []objectio.ObjectStats,
+) func(*objectio.ObjectId) bool {
+	deletedObjectIDs := make(map[types.Objectid]struct{}, len(deletedObjects))
+	for i := range deletedObjects {
+		deletedObjectIDs[*deletedObjects[i].ObjectName().ObjectId()] = struct{}{}
+	}
+	return func(objID *objectio.ObjectId) bool {
+		_, deleted := deletedObjectIDs[*objID]
+		return deleted
+	}
+}
+
 func ConstructCNTombstoneObjectsTransferFlow(
 	ctx context.Context,
 	start, end types.TS,
@@ -51,10 +64,6 @@ func ConstructCNTombstoneObjectsTransferFlow(
 		return nil, nil, err
 	}
 
-	isObjectDeletedFn := func(objId *objectio.ObjectId) bool {
-		return state.CheckIfObjectDeletedBeforeTS(end, false, objId)
-	}
-
 	var logs []zap.Field
 
 	newDataObjects, deletedObjects := state.CollectObjectsBetween(start, end)
@@ -67,13 +76,14 @@ func ConstructCNTombstoneObjectsTransferFlow(
 		return nil, logs, nil
 	}
 
+	deletedObjectPos := 0
 	deletedObjectsIter := func() *types.Objectid {
-		if len(deletedObjects) == 0 {
+		if deletedObjectPos == len(deletedObjects) {
 			return nil
 		}
 
-		id := deletedObjects[0].ObjectName().ObjectId()
-		deletedObjects = deletedObjects[1:]
+		id := deletedObjects[deletedObjectPos].ObjectName().ObjectId()
+		deletedObjectPos++
 		return id
 	}
 
@@ -102,6 +112,12 @@ func ConstructCNTombstoneObjectsTransferFlow(
 	}
 
 	logs = append(logs, zap.Int("coarse-tombstoneObjects", len(tombstoneObjects)))
+
+	// Only tombstones that point at an object deleted in this exact transfer
+	// window need to move. Live appendable objects are intentionally absent
+	// from PartitionState's persisted-object index, so treating an unknown
+	// object as deleted would incorrectly stage their tombstones.
+	isObjectDeletedFn := newDeletedObjectFilter(deletedObjects)
 
 	pkColIdx := table.tableDef.Name2ColIndex[table.tableDef.Pkey.PkeyColName]
 	pkCol := table.tableDef.Cols[pkColIdx]

--- a/pkg/vm/engine/disttae/transfer_util.go
+++ b/pkg/vm/engine/disttae/transfer_util.go
@@ -36,6 +36,29 @@ type UT_ForceTransCheck struct{}
 
 type TransferOption func(*TransferFlow)
 
+const (
+	// RowID transfer has a material fixed cost: every batch constructs an IN
+	// filter, prunes replacement objects, and builds a reader.  One object block
+	// (8192 rows) made large updates pay that setup cost thousands of times.
+	// Aggregate up to eight blocks, with an 8 MiB soft limit that flushes wide
+	// primary keys at the next source-batch boundary.
+	transferBatchRowLimit  = objectio.BlockMaxRows * 8
+	transferBatchSizeLimit = mpool.MB * 8
+)
+
+func transferBatchLimitReached(rowCount, byteSize int, sourceBatchDone bool) bool {
+	if rowCount == 0 {
+		return false
+	}
+	if rowCount >= transferBatchRowLimit {
+		return true
+	}
+	// Computing Batch.Size for every row would add work to the hot path.  The
+	// source reader already bounds its batches, so enforce the byte limit once
+	// per source batch and bound any overshoot by that source batch.
+	return sourceBatchDone && byteSize >= transferBatchSizeLimit
+}
+
 func newDeletedObjectFilter(
 	deletedObjects []objectio.ObjectStats,
 ) func(*objectio.ObjectId) bool {
@@ -280,12 +303,15 @@ func (flow *TransferFlow) processOneBatch(ctx context.Context, buffer *batch.Bat
 		flow.transferred.rowCnt++
 		flow.transferred.objDetails[objectid.ShortStringEx()]++
 
-		if staged.Vecs[0].Length() >= objectio.BlockMaxRows {
+		if transferBatchLimitReached(staged.RowCount(), 0, false) {
 			if err := flow.transferStaged(ctx); err != nil {
 				return err
 			}
 			staged = flow.getStaged()
 		}
+	}
+	if transferBatchLimitReached(staged.RowCount(), staged.Size(), true) {
+		return flow.transferStaged(ctx)
 	}
 	return nil
 }

--- a/pkg/vm/engine/disttae/transfer_util_test.go
+++ b/pkg/vm/engine/disttae/transfer_util_test.go
@@ -1,0 +1,171 @@
+// Copyright 2021-2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeletedObjectFilterUsesExactTransferWindow(t *testing.T) {
+	emptyFilter := newDeletedObjectFilter(nil)
+	require.False(t, emptyFilter(objectio.MockObjectName().ObjectId()))
+
+	deletedName := objectio.MockObjectName()
+	var deletedStats objectio.ObjectStats
+	require.NoError(t, objectio.SetObjectStatsObjectName(&deletedStats, deletedName))
+
+	filter := newDeletedObjectFilter([]objectio.ObjectStats{deletedStats})
+	require.True(t, filter(deletedName.ObjectId()))
+
+	// A live appendable object has no entry in PartitionState's persisted-object
+	// index. It must not be mistaken for an object deleted in this window.
+	liveAppendableName := objectio.MockObjectName()
+	require.False(t, filter(liveAppendableName.ObjectId()))
+
+	// Nor should an object deleted before a previous transfer window be moved
+	// again merely because its tombstone shares a file with an affected object.
+	previouslyDeletedName := objectio.MockObjectName()
+	require.False(t, filter(previouslyDeletedName.ObjectId()))
+}
+
+func TestTransferFlowStagesOnlyObjectsDeletedInWindow(t *testing.T) {
+	mp := mpool.MustNewZero()
+	ctx := context.Background()
+	state := logtailreplay.NewPartitionState("", false, 42, false)
+	start := types.BuildTS(10, 0)
+	end := types.BuildTS(20, 0)
+
+	// Reproduce the root ownership boundary: CN intentionally does not add a
+	// live appendable object's create event to the persisted-object index.
+	liveAppendableID := objectio.NewObjectid()
+	liveAppendableStats := objectio.NewObjectStatsWithObjectID(
+		&liveAppendableID, true, false, false)
+	require.NoError(t, objectio.SetObjectStatsSize(liveAppendableStats, 1))
+	require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+		ObjectStats: *liveAppendableStats,
+		CreateTime:  types.BuildTS(5, 0),
+	}, false))
+	_, exists := state.GetObject(*liveAppendableStats.ObjectShortName())
+	require.False(t, exists)
+
+	// A persisted source object visible at start is deleted during the window,
+	// and a replacement object is created by the same merge.
+	deletedID := objectio.NewObjectid()
+	deletedStats := objectio.NewObjectStatsWithObjectID(
+		&deletedID, false, false, false)
+	require.NoError(t, objectio.SetObjectStatsSize(deletedStats, 1))
+	require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+		ObjectStats: *deletedStats,
+		CreateTime:  types.BuildTS(5, 0),
+		DeleteTime:  types.BuildTS(15, 0),
+	}, false))
+
+	replacementID := objectio.NewObjectid()
+	replacementStats := objectio.NewObjectStatsWithObjectID(
+		&replacementID, false, false, false)
+	require.NoError(t, objectio.SetObjectStatsSize(replacementStats, 1))
+	require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+		ObjectStats: *replacementStats,
+		CreateTime:  types.BuildTS(15, 0),
+	}, false))
+
+	newDataObjects, deletedObjects := state.CollectObjectsBetween(start, end)
+	require.Len(t, newDataObjects, 1)
+	require.Equal(t, replacementID, *newDataObjects[0].ObjectName().ObjectId())
+	require.Len(t, deletedObjects, 1)
+	require.Equal(t, deletedID, *deletedObjects[0].ObjectName().ObjectId())
+
+	liveAppendableName := liveAppendableStats.ObjectName()
+	deletedName := deletedStats.ObjectName()
+
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	defer input.Clean(mp)
+
+	liveRowID := types.NewRowIDWithObjectIDBlkNumAndRowID(
+		*liveAppendableName.ObjectId(), 0, 0,
+	)
+	deletedRowID := types.NewRowIDWithObjectIDBlkNumAndRowID(
+		*deletedName.ObjectId(), 0, 0,
+	)
+	require.NoError(t, vector.AppendFixed(input.Vecs[0], liveRowID, false, mp))
+	require.NoError(t, vector.AppendFixed(input.Vecs[1], int64(1), false, mp))
+	require.NoError(t, vector.AppendFixed(input.Vecs[0], deletedRowID, false, mp))
+	require.NoError(t, vector.AppendFixed(input.Vecs[1], int64(2), false, mp))
+	input.SetRowCount(2)
+
+	staged := batch.NewWithSize(2)
+	staged.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	staged.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	flow := &TransferFlow{
+		isObjectDeletedFn: newDeletedObjectFilter(deletedObjects),
+		staged:            staged,
+		mp:                mp,
+	}
+	flow.transferred.objDetails = make(map[string]int)
+	defer flow.staged.Clean(mp)
+
+	require.NoError(t, flow.processOneBatch(ctx, input))
+	require.Equal(t, 1, flow.staged.RowCount())
+	require.Equal(t, deletedRowID,
+		vector.MustFixedColWithTypeCheck[types.Rowid](flow.staged.Vecs[0])[0])
+	require.Equal(t, int64(2),
+		vector.MustFixedColWithTypeCheck[int64](flow.staged.Vecs[1])[0])
+	require.Equal(t, 1, flow.transferred.rowCnt)
+	require.Equal(t, map[string]int{deletedName.ObjectId().ShortStringEx(): 1},
+		flow.transferred.objDetails)
+}
+
+func BenchmarkDeletedObjectFilter(b *testing.B) {
+	for _, objectCount := range []int{1, 16, 256, 4096} {
+		deletedObjects := make([]objectio.ObjectStats, objectCount)
+		for i := range deletedObjects {
+			require.NoError(b, objectio.SetObjectStatsObjectName(
+				&deletedObjects[i], objectio.MockObjectName()))
+		}
+
+		b.Run(fmt.Sprintf("build/%d", objectCount), func(b *testing.B) {
+			b.ReportAllocs()
+			var filter func(*objectio.ObjectId) bool
+			for i := 0; i < b.N; i++ {
+				filter = newDeletedObjectFilter(deletedObjects)
+			}
+			runtime.KeepAlive(filter)
+		})
+
+		filter := newDeletedObjectFilter(deletedObjects)
+		objectID := deletedObjects[objectCount-1].ObjectName().ObjectId()
+		b.Run(fmt.Sprintf("lookup/%d", objectCount), func(b *testing.B) {
+			b.ReportAllocs()
+			var deleted bool
+			for i := 0; i < b.N; i++ {
+				deleted = filter(objectID)
+			}
+			runtime.KeepAlive(deleted)
+		})
+	}
+}

--- a/pkg/vm/engine/disttae/transfer_util_test.go
+++ b/pkg/vm/engine/disttae/transfer_util_test.go
@@ -51,6 +51,93 @@ func TestDeletedObjectFilterUsesExactTransferWindow(t *testing.T) {
 	require.False(t, filter(previouslyDeletedName.ObjectId()))
 }
 
+func TestTransferBatchLimit(t *testing.T) {
+	tests := []struct {
+		name            string
+		rowCount        int
+		byteSize        int
+		sourceBatchDone bool
+		want            bool
+	}{
+		{name: "empty", byteSize: transferBatchSizeLimit, sourceBatchDone: true},
+		{
+			name:     "below both limits",
+			rowCount: transferBatchRowLimit - 1,
+			byteSize: transferBatchSizeLimit - 1,
+		},
+		{
+			name:     "row limit",
+			rowCount: transferBatchRowLimit,
+			want:     true,
+		},
+		{
+			name:            "size limit after source batch",
+			rowCount:        1,
+			byteSize:        transferBatchSizeLimit,
+			sourceBatchDone: true,
+			want:            true,
+		},
+		{
+			name:     "size is not measured per row",
+			rowCount: 1,
+			byteSize: transferBatchSizeLimit,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, transferBatchLimitReached(
+				test.rowCount, test.byteSize, test.sourceBatchDone))
+		})
+	}
+}
+
+func TestTransferFlowBatchesAcrossObjectBlocks(t *testing.T) {
+	mp := mpool.MustNewZero()
+	ctx := context.Background()
+	objectID := objectio.NewObjectid()
+	rowID := types.NewRowIDWithObjectIDBlkNumAndRowID(objectID, 0, 0)
+	rowCount := int(objectio.BlockMaxRows)
+
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixedList(
+		input.Vecs[0], makeRepeated(rowID, rowCount), nil, mp))
+	require.NoError(t, vector.AppendFixedList(
+		input.Vecs[1], makeRepeated(int64(1), rowCount), nil, mp))
+	input.SetRowCount(rowCount)
+	defer input.Clean(mp)
+
+	staged := batch.NewWithSize(2)
+	staged.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	staged.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	flow := &TransferFlow{
+		isObjectDeletedFn: func(*objectio.ObjectId) bool { return true },
+		staged:            staged,
+		mp:                mp,
+	}
+	flow.transferred.objDetails = make(map[string]int)
+	defer flow.staged.Clean(mp)
+
+	// The former one-block policy invoked RowID lookup after the first call.
+	// Keeping both blocks staged proves the expensive lookup setup is amortized
+	// without changing which rows are selected for transfer.
+	require.NoError(t, flow.processOneBatch(ctx, input))
+	require.Equal(t, rowCount, flow.staged.RowCount())
+	require.NoError(t, flow.processOneBatch(ctx, input))
+	require.Equal(t, rowCount*2, flow.staged.RowCount())
+	require.Equal(t, rowCount*2, flow.transferred.rowCnt)
+}
+
+func makeRepeated[T any](value T, count int) []T {
+	values := make([]T, count)
+	for i := range values {
+		values[i] = value
+	}
+	return values
+}
+
 func TestTransferFlowStagesOnlyObjectsDeletedInWindow(t *testing.T) {
 	mp := mpool.MustNewZero()
 	ctx := context.Background()

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2674,7 +2674,10 @@ func (tbl *txnTable) PKPersistedBetween(
 
 	// Only check data objects. A matching object/block can still be an older
 	// version, so later row-level commit-ts checks narrow the final answer.
-	delObjs, cObjs = p.GetChangedObjsBetween(from.Next(), types.MaxTs())
+	// GetChangedObjsBetween already selects (from, end]. Advancing from here
+	// would skip an object transition committed at the valid HLC timestamp
+	// from.Next(), weakening the PK-conflict check at that exact boundary.
+	delObjs, cObjs = p.GetChangedObjsBetween(from, types.MaxTs())
 
 	if pkCheckBailoutOnChangedObjects(len(cObjs)) {
 		reason = "changed_objects_bailout"


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27878

Backport of #27879 to `4.2-dev`.

## What this PR does / why we need it:

CN tombstone transfer must move a RowID only when its source object belongs to the exact set deleted in the current `(start, end]` window. Absence from the persisted-object index is not evidence of deletion because live appendable objects are intentionally absent. Violating this invariant can make large indexed DML fail commit-time RowID cardinality validation and roll back.

This backport:

- uses exact deleted-object membership for tombstone transfer;
- aligns in-memory and persisted transfer windows to `(start, end]`;
- preserves the same boundary for PK-conflict object discovery, including an object transition committed at `from.Next()`;
- keeps ZoneMap/Bloom pruning and the cardinality guard;
- batches at most eight source blocks with an 8 MiB soft limit, without adding goroutines, worker pools, or concurrent S3 I/O.

The three commits were cherry-picked cleanly from #27879. Their stable patch IDs match the source commits exactly; no 4.2-specific production-code adaptation was needed.

## Validation

### Deterministic tests and build

- Exact selected regression tests were listed and executed on the backport head:
  - `TestPartitionState_TransferObjectWindowBoundaries`
  - `TestDeletedObjectFilterUsesExactTransferWindow`
  - `TestTransferBatchLimit`
  - `TestTransferFlowBatchesAcrossObjectBlocks`
  - `TestTransferFlowStagesOnlyObjectsDeletedInWindow`
- CGo-controlled owning-package tests passed:
  - `./pkg/vm/engine/disttae/logtailreplay`
  - `./pkg/vm/engine/disttae`
- `make build-with-prebuilt-native` passed with `libmo.dylib` built from the `4.2-dev` worktree's own source.

### Real 50M black-box QA on this backport head

Validated commit `235ad329ce37a4dbc3c3da1847ebe7a7855f0164` with a newly built `mo-service`, a fresh data directory, and an isolated SQL port. The database was populated from scratch; no prior data was reused.

QA procedure:

1. Create one table with a BIGINT primary key, an indexed `col3`, and a unique indexed `col4`.
2. Populate exactly 50,000,000 rows by doubling inserts plus the final bounded insert.
3. Execute `UPDATE write_100m SET col3 = col3 + 1` so the update rewrites every base row and its secondary-index entry while background merges can replace source objects.
4. Check the base-table count/range/checksums and every row predicate.
5. Check public secondary-index predicates and unique-index point lookups.
6. Query both generated hidden index tables directly for index cardinality.
7. Stop the service cleanly, restart a new process on the same data directory, and repeat all correctness/index checks.

Observed results:

- Full fresh-data load + UPDATE + first verification: **214.15s**.
- 50M-row UPDATE: **162.644668s**.
- Base table before and after restart:
  - rows: `50,000,000`
  - `id` range: `1..50,000,000`
  - `col3` range: `2..2`
  - `sum(id) = sum(col4) = 1,250,000,025,000,000`
  - rows violating `id = col4 AND col3 = 2`: `0`
- Secondary-index predicates before and after restart:
  - `col3 = 2`: `50,000,000`
  - `col3 = 1`: `0`
- Direct hidden-index cardinality after restart:
  - secondary index table: `50,000,000`
  - unique index table: `50,000,000`, key range `1..50,000,000`
- Unique-index point lookups for `1`, `8192`, `8388608`, `33554432`, and `50000000` returned the exact expected rows after restart.
- Restarted verification completed in **6.60s**.
- Transfer phases observed on the updated base/index objects completed in **33.99s** and **90.76s**.
- No `TRANSFER-ROWIDS-ERROR`, panic, or fatal log was emitted.

No BVT is added: the public failure requires large data plus background-merge timing, while the violated object-lifecycle and exact-window contracts are covered deterministically by the focused tests. The real 50M procedure above is the scale/regression acceptance evidence for this backport.
