### PR TITLE
perf(ivfflat): defer vectors until after include filters

### DIFF
--- a/pkg/vectorindex/ivfflat/plan_reader.go
+++ b/pkg/vectorindex/ivfflat/plan_reader.go
@@ -618,6 +618,12 @@ func (s *relationScanner) ScanRelation(req sqlexec.RelationScanRequest) (res exe
 			res.Batches = nil
 		}
 	}()
+	var earlyColumns []int
+	if req.PostFilterTopOnly {
+		// Storage Top-K has its own bounded vector path. Late materialization is
+		// only for the exact-filter-first fallback that deliberately disables it.
+		earlyColumns = relationFilterEarlyColumns(tableDef, req.Columns, req.Filter)
+	}
 
 	for _, reader := range readers {
 		if !req.PostFilterTopOnly {
@@ -628,7 +634,30 @@ func (s *relationScanner) ScanRelation(req sqlexec.RelationScanRequest) (res exe
 			if makeErr != nil {
 				return res, makeErr
 			}
-			end, readErr := reader.Read(ctx, req.Columns, req.Filter, s.proc.Mp(), bat)
+			var (
+				end           bool
+				readErr       error
+				filterApplied bool
+			)
+			if filterExecutor != nil && len(earlyColumns) > 0 {
+				if lateReader, ok := reader.(engine.LateMaterializationReader); ok {
+					end, readErr = lateReader.ReadWithFilter(
+						ctx,
+						req.Columns,
+						earlyColumns,
+						func(filtered *batch.Batch, loadedColumns []int) (engine.ReaderFilterResult, error) {
+							return filterRelationBatchRows(s.proc, filterExecutor, filtered, loadedColumns)
+						},
+						s.proc.Mp(),
+						bat,
+					)
+					filterApplied = true
+				} else {
+					end, readErr = reader.Read(ctx, req.Columns, req.Filter, s.proc.Mp(), bat)
+				}
+			} else {
+				end, readErr = reader.Read(ctx, req.Columns, req.Filter, s.proc.Mp(), bat)
+			}
 			if readErr != nil {
 				bat.Clean(s.proc.Mp())
 				return res, readErr
@@ -637,7 +666,7 @@ func (s *relationScanner) ScanRelation(req sqlexec.RelationScanRequest) (res exe
 				bat.Clean(s.proc.Mp())
 				break
 			}
-			if filterExecutor != nil && !bat.IsEmpty() {
+			if filterExecutor != nil && !filterApplied && !bat.IsEmpty() {
 				if readErr = filterRelationBatch(s.proc, filterExecutor, bat); readErr != nil {
 					bat.Clean(s.proc.Mp())
 					return res, readErr
@@ -683,9 +712,19 @@ func relationScanPolicy(partitionCount int32, ownsInMemory bool) engine.DataColl
 }
 
 func filterRelationBatch(proc *process.Process, executor colexec.ExpressionExecutor, bat *batch.Batch) error {
+	_, err := filterRelationBatchRows(proc, executor, bat, nil)
+	return err
+}
+
+func filterRelationBatchRows(
+	proc *process.Process,
+	executor colexec.ExpressionExecutor,
+	bat *batch.Batch,
+	loadedColumns []int,
+) (engine.ReaderFilterResult, error) {
 	result, err := executor.Eval(proc, []*batch.Batch{bat}, nil)
 	if err != nil {
-		return err
+		return engine.ReaderFilterResult{}, err
 	}
 	values := vector.GenerateFunctionFixedTypeParameter[bool](result)
 	sels := make([]int64, 0, bat.RowCount())
@@ -696,14 +735,115 @@ func filterRelationBatch(proc *process.Process, executor colexec.ExpressionExecu
 		}
 	}
 	if len(sels) == bat.RowCount() {
-		return nil
+		return engine.ReaderFilterResult{All: true}, nil
 	}
 	if len(sels) == 0 {
 		bat.CleanOnlyData()
+		return engine.ReaderFilterResult{Sels: sels}, nil
+	}
+	if loadedColumns == nil {
+		bat.Shrink(sels, false)
+	} else {
+		for _, pos := range loadedColumns {
+			bat.Vecs[pos].Shrink(sels, false)
+		}
+		bat.SetRowCount(len(sels))
+	}
+	return engine.ReaderFilterResult{Sels: sels}, nil
+}
+
+// relationFilterEarlyColumns returns the output positions that must be loaded
+// before evaluating an exact relation filter. Wide vector columns unused by
+// the predicate are delayed until after filtering, so INCLUDE predicates do
+// not copy every probed entry vector before discarding most rows.
+func relationFilterEarlyColumns(
+	tableDef *plan.TableDef,
+	columns []string,
+	filter *plan.Expr,
+) []int {
+	if tableDef == nil || filter == nil || len(columns) < 2 {
 		return nil
 	}
-	bat.Shrink(sels, false)
-	return nil
+	referenced := make(map[int32]struct{})
+	if !collectRelationFilterColumns(filter, int32(len(columns)), referenced) {
+		return nil
+	}
+	early := make([]int, 0, len(columns))
+	hasLateVector := false
+	for outputPos, name := range columns {
+		defPos, ok := tableDef.Name2ColIndex[name]
+		if !ok {
+			defPos, ok = tableDef.Name2ColIndex[strings.ToLower(name)]
+		}
+		if !ok || defPos < 0 || int(defPos) >= len(tableDef.Cols) || tableDef.Cols[defPos] == nil {
+			return nil
+		}
+		_, usedByFilter := referenced[int32(outputPos)]
+		if types.T(tableDef.Cols[defPos].Typ.Id).IsArrayRelate() && !usedByFilter {
+			hasLateVector = true
+			continue
+		}
+		early = append(early, outputPos)
+	}
+	if !hasLateVector || len(early) == 0 {
+		return nil
+	}
+	return early
+}
+
+func collectRelationFilterColumns(expr *plan.Expr, columnCount int32, columns map[int32]struct{}) bool {
+	if expr == nil {
+		return true
+	}
+	switch item := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		if item.Col == nil || item.Col.ColPos < 0 || item.Col.ColPos >= columnCount {
+			return false
+		}
+		columns[item.Col.ColPos] = struct{}{}
+		return true
+	case *plan.Expr_F:
+		if item.F == nil {
+			return false
+		}
+		for _, arg := range item.F.Args {
+			if !collectRelationFilterColumns(arg, columnCount, columns) {
+				return false
+			}
+		}
+		return true
+	case *plan.Expr_List:
+		if item.List == nil {
+			return false
+		}
+		for _, arg := range item.List.List {
+			if !collectRelationFilterColumns(arg, columnCount, columns) {
+				return false
+			}
+		}
+		return true
+	case *plan.Expr_Lit:
+		if item.Lit == nil {
+			return false
+		}
+		return collectRelationFilterColumns(item.Lit.Src, columnCount, columns)
+	case *plan.Expr_P:
+		return item.P != nil
+	case *plan.Expr_V:
+		return item.V != nil
+	case *plan.Expr_T:
+		return item.T != nil
+	case *plan.Expr_Max:
+		return item.Max != nil
+	case *plan.Expr_Vec:
+		return item.Vec != nil
+	case *plan.Expr_Fold:
+		return item.Fold != nil
+	case *plan.Expr_Raw, *plan.Expr_W, *plan.Expr_Sub, *plan.Expr_Corr:
+		return false
+	default:
+		return false
+	}
 }
 
 func relationVectorTopLimit(param *plan.IndexReaderParam, postFilterTopOnly bool) (int, bool) {

--- a/pkg/vectorindex/ivfflat/plan_reader_test.go
+++ b/pkg/vectorindex/ivfflat/plan_reader_test.go
@@ -1304,6 +1304,67 @@ func TestRelationScannerDefersWideVectorUntilAfterIncludeFilter(t *testing.T) {
 	require.Equal(t, 1, reader.closed)
 }
 
+func TestRelationScannerFallsBackWhenReaderCannotDelayVectorLoading(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	proc := testutil.NewProc(t)
+	t.Cleanup(proc.Free)
+	eng := mock_frontend.NewMockEngine(ctrl)
+	db := mock_frontend.NewMockDatabase(ctrl)
+	rel := mock_frontend.NewMockRelation(ctrl)
+	proc.Base.SessionInfo.StorageEngine = eng
+	tableDef := &plan.TableDef{
+		Name: "fallback_entries",
+		Cols: []*plan.ColDef{
+			{Name: "entry", Typ: plan.Type{Id: int32(types.T_array_float64), Width: 2}},
+			{Name: "filter_bucket", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Name2ColIndex: map[string]int32{"entry": 0, "filter_bucket": 1},
+	}
+	reader := &fillRelationReader{fill: func(out *batch.Batch, mp *mpool.MPool) error {
+		for _, row := range []struct {
+			entry  []float64
+			bucket int64
+		}{
+			{entry: []float64{1, 0}, bucket: 10},
+			{entry: []float64{2, 0}, bucket: 70},
+		} {
+			if err := vector.AppendArray(out.Vecs[0], row.entry, false, mp); err != nil {
+				return err
+			}
+			if err := vector.AppendFixed(out.Vecs[1], row.bucket, false, mp); err != nil {
+				return err
+			}
+		}
+		out.SetRowCount(2)
+		return nil
+	}}
+	eng.EXPECT().Database(gomock.Any(), "db", nil).Return(db, nil)
+	db.EXPECT().Relation(gomock.Any(), "fallback_entries", proc).Return(rel, nil)
+	rel.EXPECT().GetTableDef(gomock.Any()).Return(tableDef)
+	rel.EXPECT().Ranges(gomock.Any(), gomock.Any()).Return(nil, nil)
+	rel.EXPECT().BuildReaders(
+		gomock.Any(), proc, gomock.Any(), gomock.Nil(), 1, 0, false,
+		gomock.Any(), gomock.Any()).Return([]engine.Reader{reader}, nil)
+
+	filter, err := ivfFuncExpr(proc.Ctx, "=",
+		ivfColExpr(1, plan.Type{Id: int32(types.T_int64)}), ivfInt64Expr(10))
+	require.NoError(t, err)
+	res, err := (&relationScanner{proc: proc}).ScanRelation(sqlexec.RelationScanRequest{
+		Schema:            "db",
+		Table:             "fallback_entries",
+		Columns:           []string{"entry", "filter_bucket"},
+		Filter:            filter,
+		PostFilterTopOnly: true,
+	})
+	require.NoError(t, err)
+	defer res.Close()
+	require.Len(t, res.Batches, 1)
+	require.Equal(t, 1, res.Batches[0].RowCount())
+	require.Equal(t, []float64{1, 0}, types.BytesToArray[float64](res.Batches[0].Vecs[0].GetBytesAt(0)))
+	require.Equal(t, int64(10), vector.GetFixedAtNoTypeCheck[int64](res.Batches[0].Vecs[1], 0))
+	require.Equal(t, 1, reader.closed)
+}
+
 func TestPlanReaderShortCircuitsEmptySearches(t *testing.T) {
 	r := &planReader{req: searchplugin.Request{CandidateBudget: 0}}
 	require.NoError(t, r.initialize())

--- a/pkg/vectorindex/ivfflat/plan_reader_test.go
+++ b/pkg/vectorindex/ivfflat/plan_reader_test.go
@@ -825,6 +825,51 @@ func TestPlanReaderPureHelpersCoverDecodedQueriesAndScanBatches(t *testing.T) {
 		&plan.Expr{Expr: &plan.Expr_Corr{Corr: &plan.CorrColRef{ColPos: 1}}}))
 }
 
+func TestCollectRelationFilterColumnsAcceptsOnlySafeExpressionShapes(t *testing.T) {
+	column := ivfColExpr(1, plan.Type{Id: int32(types.T_int64)})
+	valid := []*plan.Expr{
+		nil,
+		{Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 1}}},
+		{Expr: &plan.Expr_F{F: &plan.Function{Args: []*plan.Expr{column}}}},
+		{Expr: &plan.Expr_List{List: &plan.ExprList{List: []*plan.Expr{column}}}},
+		{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Src: column}}},
+		{Expr: &plan.Expr_P{P: &plan.ParamRef{}}},
+		{Expr: &plan.Expr_V{V: &plan.VarRef{}}},
+		{Expr: &plan.Expr_T{T: &plan.TargetType{}}},
+		{Expr: &plan.Expr_Max{Max: &plan.MaxValue{}}},
+		{Expr: &plan.Expr_Vec{Vec: &plan.LiteralVec{}}},
+		{Expr: &plan.Expr_Fold{Fold: &plan.FoldVal{}}},
+	}
+	for _, expr := range valid {
+		columns := make(map[int32]struct{})
+		require.True(t, collectRelationFilterColumns(expr, 2, columns))
+	}
+
+	invalid := []*plan.Expr{
+		{Expr: &plan.Expr_Col{}},
+		{Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: -1}}},
+		{Expr: &plan.Expr_F{}},
+		{Expr: &plan.Expr_F{F: &plan.Function{Args: []*plan.Expr{{Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 2}}}}}}},
+		{Expr: &plan.Expr_List{}},
+		{Expr: &plan.Expr_List{List: &plan.ExprList{List: []*plan.Expr{{Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 2}}}}}}},
+		{Expr: &plan.Expr_Lit{}},
+		{Expr: &plan.Expr_P{}},
+		{Expr: &plan.Expr_V{}},
+		{Expr: &plan.Expr_T{}},
+		{Expr: &plan.Expr_Max{}},
+		{Expr: &plan.Expr_Vec{}},
+		{Expr: &plan.Expr_Fold{}},
+		{Expr: &plan.Expr_Raw{Raw: &plan.RawColRef{}}},
+		{Expr: &plan.Expr_W{W: &plan.WindowSpec{}}},
+		{Expr: &plan.Expr_Sub{Sub: &plan.SubqueryRef{}}},
+		{Expr: &plan.Expr_Corr{Corr: &plan.CorrColRef{}}},
+		{},
+	}
+	for _, expr := range invalid {
+		require.False(t, collectRelationFilterColumns(expr, 2, make(map[int32]struct{})))
+	}
+}
+
 type fixedRelationReader struct {
 	emitted bool
 	closed  int

--- a/pkg/vectorindex/ivfflat/plan_reader_test.go
+++ b/pkg/vectorindex/ivfflat/plan_reader_test.go
@@ -809,6 +809,20 @@ func TestPlanReaderPureHelpersCoverDecodedQueriesAndScanBatches(t *testing.T) {
 	bat.Clean(nil)
 	_, err = makeRelationScanBatch(tableDef, []string{"missing"})
 	require.ErrorContains(t, err, "hidden column \"missing\" not found")
+
+	wideDef := &plan.TableDef{
+		Cols: []*plan.ColDef{
+			{Name: "entry", Typ: plan.Type{Id: int32(types.T_array_float64)}},
+			{Name: "bucket", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Name2ColIndex: map[string]int32{"entry": 0, "bucket": 1},
+	}
+	require.Equal(t, []int{1}, relationFilterEarlyColumns(
+		wideDef, []string{"entry", "bucket"}, ivfColExpr(1, plan.Type{Id: int32(types.T_int64)})))
+	require.Nil(t, relationFilterEarlyColumns(
+		wideDef, []string{"entry", "bucket"}, ivfColExpr(0, plan.Type{Id: int32(types.T_array_float64)})))
+	require.Nil(t, relationFilterEarlyColumns(wideDef, []string{"entry", "bucket"},
+		&plan.Expr{Expr: &plan.Expr_Corr{Corr: &plan.CorrColRef{ColPos: 1}}}))
 }
 
 type fixedRelationReader struct {
@@ -868,6 +882,94 @@ func (*fillRelationReader) GetOrderBy() []*plan.OrderBySpec { return nil }
 func (*fillRelationReader) SetIndexParam(*plan.IndexReaderParam) {
 }
 func (*fillRelationReader) SetFilterZM(objectio.ZoneMap) {}
+
+type lateFilterRelationReader struct {
+	emitted         bool
+	closed          int
+	eagerReads      int
+	lateReads       int
+	earlyColumns    []int
+	wideWasDeferred bool
+}
+
+var _ engine.Reader = (*lateFilterRelationReader)(nil)
+var _ engine.LateMaterializationReader = (*lateFilterRelationReader)(nil)
+
+func (r *lateFilterRelationReader) Read(
+	context.Context,
+	[]string,
+	*plan.Expr,
+	*mpool.MPool,
+	*batch.Batch,
+) (bool, error) {
+	r.eagerReads++
+	return false, errors.New("IVF filtered scan used eager reader")
+}
+
+func (r *lateFilterRelationReader) ReadWithFilter(
+	_ context.Context,
+	_ []string,
+	earlyColumns []int,
+	filter engine.ReaderFilter,
+	mp *mpool.MPool,
+	out *batch.Batch,
+) (bool, error) {
+	if r.emitted {
+		return true, nil
+	}
+	r.lateReads++
+	r.earlyColumns = append([]int(nil), earlyColumns...)
+
+	rows := []struct {
+		version  int64
+		centroid int64
+		pk       int64
+		entry    []float64
+		bucket   int64
+	}{
+		{7, 2, 11, []float64{4, 0}, 10},
+		{7, 2, 12, []float64{9, 0}, 70},
+		{7, 2, 13, []float64{1, 0}, 10},
+	}
+	for _, row := range rows {
+		if err := vector.AppendFixed(out.Vecs[0], row.version, false, mp); err != nil {
+			return false, err
+		}
+		if err := vector.AppendFixed(out.Vecs[1], row.centroid, false, mp); err != nil {
+			return false, err
+		}
+		if err := vector.AppendFixed(out.Vecs[2], row.pk, false, mp); err != nil {
+			return false, err
+		}
+		if err := vector.AppendFixed(out.Vecs[4], row.bucket, false, mp); err != nil {
+			return false, err
+		}
+	}
+	out.SetRowCount(len(rows))
+	r.wideWasDeferred = out.Vecs[3].Length() == 0
+	filtered, err := filter(out, earlyColumns)
+	if err != nil {
+		return false, err
+	}
+	selected := filtered.Sels
+	if filtered.All {
+		selected = []int64{0, 1, 2}
+	}
+	for _, row := range selected {
+		if err := vector.AppendArray(out.Vecs[3], rows[row].entry, false, mp); err != nil {
+			return false, err
+		}
+	}
+	r.emitted = true
+	return false, nil
+}
+
+func (r *lateFilterRelationReader) Close() error                  { r.closed++; return nil }
+func (*lateFilterRelationReader) SetOrderBy([]*plan.OrderBySpec)  {}
+func (*lateFilterRelationReader) GetOrderBy() []*plan.OrderBySpec { return nil }
+func (*lateFilterRelationReader) SetIndexParam(*plan.IndexReaderParam) {
+}
+func (*lateFilterRelationReader) SetFilterZM(objectio.ZoneMap) {}
 
 func TestRelationScannerExecutesTypedReaderLifecycle(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -1129,6 +1231,76 @@ func TestRelationScannerFiltersBeforeApplyingTopLimit(t *testing.T) {
 	require.Len(t, res.Batches, 1)
 	require.Equal(t, 1, res.Batches[0].RowCount())
 	require.Equal(t, int64(2), vector.GetFixedAtNoTypeCheck[int64](res.Batches[0].Vecs[0], 0))
+	require.Equal(t, 1, reader.closed)
+}
+
+func TestRelationScannerDefersWideVectorUntilAfterIncludeFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	proc := testutil.NewProc(t)
+	t.Cleanup(proc.Free)
+	eng := mock_frontend.NewMockEngine(ctrl)
+	db := mock_frontend.NewMockDatabase(ctrl)
+	rel := mock_frontend.NewMockRelation(ctrl)
+	proc.Base.SessionInfo.StorageEngine = eng
+	tableDef := &plan.TableDef{
+		Name: "filtered_entries",
+		Cols: []*plan.ColDef{
+			{Name: "version", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "centroid", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "pk", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "entry", Typ: plan.Type{Id: int32(types.T_array_float64), Width: 2}},
+			{Name: "filter_bucket", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Name2ColIndex: map[string]int32{
+			"version": 0, "centroid": 1, "pk": 2, "entry": 3, "filter_bucket": 4,
+		},
+	}
+	reader := &lateFilterRelationReader{}
+	eng.EXPECT().Database(gomock.Any(), "db", nil).Return(db, nil)
+	db.EXPECT().Relation(gomock.Any(), "filtered_entries", proc).Return(rel, nil)
+	rel.EXPECT().GetTableDef(gomock.Any()).Return(tableDef)
+	rel.EXPECT().Ranges(gomock.Any(), gomock.Any()).Return(nil, nil)
+	rel.EXPECT().BuildReaders(
+		gomock.Any(), proc, gomock.Any(), gomock.Nil(), 1, 0, false,
+		gomock.Any(), gomock.Any()).Return([]engine.Reader{reader}, nil)
+
+	filter, err := ivfFuncExpr(proc.Ctx, "=",
+		ivfColExpr(4, plan.Type{Id: int32(types.T_int64)}), ivfInt64Expr(10))
+	require.NoError(t, err)
+	res, err := (&relationScanner{proc: proc}).ScanRelation(sqlexec.RelationScanRequest{
+		Schema:  "db",
+		Table:   "filtered_entries",
+		Columns: []string{"version", "centroid", "pk", "entry", "filter_bucket"},
+		Filter:  filter,
+		IndexParam: &plan.IndexReaderParam{
+			Limit:   ivfUint64Expr(1),
+			OrderBy: []*plan.OrderBySpec{{Flag: plan.OrderBySpec_ASC}},
+		},
+		PostFilterTopOnly: true,
+		BatchTransform: func(bat *batch.Batch) error {
+			require.Equal(t, bat.RowCount(), bat.Vecs[3].Length())
+			distances := vector.NewVec(types.T_float64.ToType())
+			for row := 0; row < bat.RowCount(); row++ {
+				entry := types.BytesToArray[float64](bat.Vecs[3].GetBytesAt(row))
+				if err := vector.AppendFixed(distances, entry[0]*entry[0], false, proc.Mp()); err != nil {
+					distances.Free(proc.Mp())
+					return err
+				}
+			}
+			bat.Vecs = append(bat.Vecs, distances)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	defer res.Close()
+	require.Zero(t, reader.eagerReads)
+	require.Equal(t, 1, reader.lateReads)
+	require.Equal(t, []int{0, 1, 2, 4}, reader.earlyColumns)
+	require.True(t, reader.wideWasDeferred)
+	require.Len(t, res.Batches, 1)
+	require.Equal(t, 1, res.Batches[0].RowCount())
+	require.Equal(t, int64(13), vector.GetFixedAtNoTypeCheck[int64](res.Batches[0].Vecs[2], 0))
+	require.Equal(t, int64(10), vector.GetFixedAtNoTypeCheck[int64](res.Batches[0].Vecs[4], 0))
 	require.Equal(t, 1, reader.closed)
 }
 

--- a/pkg/vm/engine/tae/blockio/read_bench_test.go
+++ b/pkg/vm/engine/tae/blockio/read_bench_test.go
@@ -1,0 +1,215 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+)
+
+const (
+	lateMaterializationBenchmarkRows         = 1024
+	lateMaterializationBenchmarkPayloadBytes = 4096
+	lateMaterializationBenchmarkSelectEvery  = 128
+)
+
+// BenchmarkBlockDataReadPersistedLateMaterialization measures the object-reader
+// boundary used by IVF INCLUDE scans: an inexpensive predicate column plus a
+// 4 KiB payload column. The low-selectivity case models the reported INCLUDE
+// filter, while all-match is the control for an eligible predicate that rejects
+// nothing. Both variants produce the same rows; payload-bytes/op records the
+// logical payload materialized into the result, rather than filesystem cache I/O.
+func BenchmarkBlockDataReadPersistedLateMaterialization(b *testing.B) {
+	fixture := newLateMaterializationBenchmarkFixture(b)
+	b.Cleanup(fixture.close)
+
+	for _, benchmark := range []struct {
+		name     string
+		late     bool
+		all      bool
+		payloads int
+	}{
+		{
+			name:     "eager_low_selectivity",
+			payloads: lateMaterializationBenchmarkRows,
+		},
+		{
+			name:     "late_low_selectivity",
+			late:     true,
+			payloads: lateMaterializationBenchmarkRows / lateMaterializationBenchmarkSelectEvery,
+		},
+		{
+			name:     "eager_all_match",
+			all:      true,
+			payloads: lateMaterializationBenchmarkRows,
+		},
+		{
+			name:     "late_all_match",
+			late:     true,
+			all:      true,
+			payloads: lateMaterializationBenchmarkRows,
+		},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(benchmark.payloads * lateMaterializationBenchmarkPayloadBytes))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rows, err := fixture.read(benchmark.late, benchmark.all)
+				if err != nil {
+					b.Fatal(err)
+				}
+				expected := lateMaterializationBenchmarkRows / lateMaterializationBenchmarkSelectEvery
+				if benchmark.all {
+					expected = lateMaterializationBenchmarkRows
+				}
+				if rows != expected {
+					b.Fatalf("got %d rows, want %d", rows, expected)
+				}
+			}
+			b.ReportMetric(
+				float64(benchmark.payloads*lateMaterializationBenchmarkPayloadBytes),
+				"payload-bytes/op",
+			)
+		})
+	}
+}
+
+type lateMaterializationBenchmarkFixture struct {
+	ctx      context.Context
+	fs       fileservice.FileService
+	info     objectio.BlockInfo
+	columns  []uint16
+	colTypes []types.Type
+	ds       engine.DataSource
+}
+
+func newLateMaterializationBenchmarkFixture(b *testing.B) *lateMaterializationBenchmarkFixture {
+	b.Helper()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_text.ToType())
+	payload := makeBenchmarkPayload(lateMaterializationBenchmarkPayloadBytes)
+	for row := 0; row < lateMaterializationBenchmarkRows; row++ {
+		if err := vector.AppendFixed(input.Vecs[0], int32(row), false, mp); err != nil {
+			b.Fatal(err)
+		}
+		payload[0] = byte(row)
+		if err := vector.AppendBytes(input.Vecs[1], payload, false, mp); err != nil {
+			b.Fatal(err)
+		}
+	}
+	input.SetRowCount(lateMaterializationBenchmarkRows)
+	writer := ioutil.ConstructWriter(0, []uint16{0, 1}, -1, false, false, fs)
+	if _, err := writer.WriteBatch(input); err != nil {
+		b.Fatal(err)
+	}
+	if _, _, err := writer.Sync(context.Background()); err != nil {
+		b.Fatal(err)
+	}
+	stats := writer.GetObjectStats()
+	input.Clean(mp)
+	if bytes := mp.CurrNB(); bytes != 0 {
+		b.Fatalf("writer mpool retained %d bytes", bytes)
+	}
+	mpool.DeleteMPool(mp)
+
+	return &lateMaterializationBenchmarkFixture{
+		ctx:      context.Background(),
+		fs:       fs,
+		info:     stats.ConstructBlockInfo(0),
+		columns:  []uint16{0, 1},
+		colTypes: []types.Type{types.T_int32.ToType(), types.T_text.ToType()},
+		ds:       &blockReadTestDataSource{},
+	}
+}
+
+func (f *lateMaterializationBenchmarkFixture) close() {}
+
+func (f *lateMaterializationBenchmarkFixture) read(late, all bool) (int, error) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+	output := batch.NewWithSize(len(f.columns))
+	for i, typ := range f.colTypes {
+		output.Vecs[i] = vector.NewOffHeapVecWithType(typ)
+	}
+	defer output.Clean(mp)
+	cacheVectors := containers.NewVectors(len(f.columns) + 2)
+	defer cacheVectors.Free(mp)
+
+	filter := func(bat *batch.Batch, loaded []int) (engine.ReaderFilterResult, error) {
+		if all {
+			return engine.ReaderFilterResult{All: true}, nil
+		}
+		values := vector.MustFixedColWithTypeCheck[int32](bat.Vecs[0])
+		sels := make([]int64, 0, len(values)/lateMaterializationBenchmarkSelectEvery)
+		for row, value := range values {
+			if value%lateMaterializationBenchmarkSelectEvery == 0 {
+				sels = append(sels, int64(row))
+			}
+		}
+		for _, pos := range loaded {
+			bat.Vecs[pos].Shrink(sels, false)
+		}
+		bat.SetRowCount(len(sels))
+		return engine.ReaderFilterResult{Sels: sels}, nil
+	}
+
+	if late {
+		_, err := BlockDataReadWithFilter(
+			f.ctx, &f.info, f.ds, f.columns, f.colTypes, -1, timestamp.Timestamp{},
+			nil, nil, objectio.BlockReadFilter{}, fileservice.Policy(0),
+			"ivfflat-include-benchmark", output, cacheVectors, mp, f.fs,
+			[]int{0}, filter,
+		)
+		return output.RowCount(), err
+	}
+	err := BlockDataRead(
+		f.ctx, &f.info, f.ds, f.columns, f.colTypes, -1, timestamp.Timestamp{},
+		nil, nil, objectio.BlockReadFilter{}, nil, fileservice.Policy(0),
+		"ivfflat-include-benchmark", output, cacheVectors, mp, f.fs,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if _, err = filter(output, []int{0, 1}); err != nil {
+		return 0, err
+	}
+	return output.RowCount(), nil
+}
+
+func makeBenchmarkPayload(size int) []byte {
+	payload := make([]byte, size)
+	state := uint32(1)
+	for i := range payload {
+		state = state*1664525 + 1013904223
+		payload[i] = byte(state >> 24)
+	}
+	return payload
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27891

## What this PR does / why we need it:

perf(ivfflat): defer vectors until after include filters