### PR TITLE
[4.1] fix(ddl): create fulltext index on partitioned tables

### DIFF
--- a/pkg/sql/compile/util.go
+++ b/pkg/sql/compile/util.go
@@ -317,10 +317,8 @@ func genInsertMOIndexesSql(eg engine.Engine, proc *process.Process, databaseId s
 					fmt.Fprintf(buffer, "%d, ", i+1)
 
 					// 14. index vec_options
-					if indexDef.Option != nil {
-						if indexDef.Option.ParserName != "" {
-							fmt.Fprintf(buffer, "'parser=%s,ngram_token_size=%d', ", indexDef.Option.ParserName, indexDef.Option.NgramTokenSize)
-						}
+					if indexDef.Option != nil && indexDef.Option.ParserName != "" {
+						fmt.Fprintf(buffer, "'parser=%s,ngram_token_size=%d', ", indexDef.Option.ParserName, indexDef.Option.NgramTokenSize)
 					} else {
 						fmt.Fprintf(buffer, "%s, ", NULL_VALUE)
 					}

--- a/pkg/sql/compile/util_mo_indexes_test.go
+++ b/pkg/sql/compile/util_mo_indexes_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+)
+
+func TestGenInsertMOIndexesSqlAlwaysEmitsOptionsValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		option   *planpb.IndexOption
+		wantTail string
+	}{
+		{
+			name:     "nil option",
+			wantTail: ", 1, null, '__mo_index_secondary_test');",
+		},
+		{
+			name:     "option without parser",
+			option:   &planpb.IndexOption{CreateExtraTable: true},
+			wantTail: ", 1, null, '__mo_index_secondary_test');",
+		},
+		{
+			name:     "gojieba parser",
+			option:   &planpb.IndexOption{ParserName: "gojieba", NgramTokenSize: 3},
+			wantTail: ", 1, 'parser=gojieba,ngram_token_size=3', '__mo_index_secondary_test');",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEngine := mock_frontend.NewMockEngine(ctrl)
+			mockEngine.EXPECT().AllocateIDByKey(gomock.Any(), ALLOCID_INDEX_KEY).Return(uint64(1), nil)
+
+			proc := testutil.NewProcess(t)
+			tableDef := &planpb.TableDef{
+				Name2ColIndex: map[string]int32{"body": 0},
+				Cols:          []*planpb.ColDef{{Name: "body", OriginName: "body"}},
+			}
+			ct := &engine.ConstraintDef{Cts: []engine.Constraint{
+				&engine.IndexDef{Indexes: []*planpb.IndexDef{{
+					IndexName:          "ft_biz_name",
+					Parts:              []string{"body"},
+					IndexAlgo:          catalog.MOIndexFullTextAlgo.ToString(),
+					IndexAlgoParams:    `{"parser":"gojieba"}`,
+					IndexTableName:     "__mo_index_secondary_test",
+					IndexAlgoTableType: "",
+					TableExist:         true,
+					Option:             tt.option,
+				}}},
+			}}
+
+			sql, err := genInsertMOIndexesSql(mockEngine, proc, "123", 456, ct, tableDef)
+			require.NoError(t, err)
+			require.Equal(t, "insert into mo_catalog.mo_indexes values(1, 456, 123, 'ft_biz_name', 'FULLTEXT', 'fulltext', '', '{\"parser\":\"gojieba\"}', 1, 0, '', 'body'"+tt.wantTail, sql)
+		})
+	}
+}

--- a/pkg/sql/plan/deepcopy.go
+++ b/pkg/sql/plan/deepcopy.go
@@ -404,6 +404,8 @@ func DeepCopyIndexOption(indexOption *plan.IndexOption) *plan.IndexOption {
 	}
 	newIndexOption := &plan.IndexOption{
 		CreateExtraTable: indexOption.CreateExtraTable,
+		ParserName:       indexOption.ParserName,
+		NgramTokenSize:   indexOption.NgramTokenSize,
 	}
 
 	return newIndexOption

--- a/pkg/sql/plan/deepcopy_index_option_test.go
+++ b/pkg/sql/plan/deepcopy_index_option_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepCopyIndexOptionPreservesFullTextParser(t *testing.T) {
+	original := &planpb.IndexOption{
+		CreateExtraTable: true,
+		ParserName:       "gojieba",
+		NgramTokenSize:   3,
+	}
+
+	copy := DeepCopyIndexOption(original)
+	require.Equal(t, original, copy)
+
+	copy.ParserName = "ngram"
+	copy.NgramTokenSize = 2
+	require.Equal(t, "gojieba", original.ParserName)
+	require.Equal(t, int32(3), original.NgramTokenSize)
+}
+
+func TestDeepCopyIndexOptionNil(t *testing.T) {
+	require.Nil(t, DeepCopyIndexOption(nil))
+}

--- a/test/distributed/cases/fulltext/gojieba.result
+++ b/test/distributed/cases/fulltext/gojieba.result
@@ -510,17 +510,33 @@ partition p202607 values less than (to_days('2026-08-01')),
 partition p202608 values less than (to_days('2026-09-01'))
 );
 create fulltext index ft_body on ft_partitioned_gojieba(body) with parser gojieba;
-show index from ft_partitioned_gojieba;
-➤ Table[12,-1,0]  ¦  Non_unique[-5,64,0]  ¦  Key_name[12,-1,0]  ¦  Seq_in_index[4,32,0]  ¦  Column_name[12,-1,0]  ¦  Collation[12,-1,0]  ¦  Cardinality[-5,64,0]  ¦  Sub_part[12,-1,0]  ¦  Packed[12,-1,0]  ¦  Null[12,-1,0]  ¦  Index_type[12,-1,0]  ¦  Comment[1,0,0]  ¦  Index_comment[12,-1,0]  ¦  Index_params[12,-1,0]  ¦  Visible[12,-1,0]  ¦  Expression[12,-1,0]  𝄀
-ft_partitioned_gojieba  ¦  0  ¦  PRIMARY  ¦  1  ¦  id  ¦  A  ¦  0  ¦  NULL  ¦  NULL  ¦    ¦    ¦    ¦    ¦    ¦  YES  ¦  id  𝄀
-ft_partitioned_gojieba  ¦  0  ¦  PRIMARY  ¦  2  ¦  created_at  ¦  A  ¦  0  ¦  NULL  ¦  NULL  ¦    ¦    ¦    ¦    ¦    ¦  YES  ¦  created_at  𝄀
-ft_partitioned_gojieba  ¦  1  ¦  ft_body  ¦  1  ¦  body  ¦  A  ¦  0  ¦  NULL  ¦  NULL  ¦  YES  ¦  fulltext  ¦    ¦    ¦    ¦  YES  ¦  body
-select count(*) from mo_catalog.mo_indexes
-where name = 'ft_body'
-and type = 'FULLTEXT'
-and algo_params = '{"parser":"gojieba"}'
-and options = 'parser=gojieba,ngram_token_size=3'
-and index_table_name <> '';
-count(*)
-3
+select count(*) as index_rows,
+count(distinct idx.table_id) as physical_tables,
+count(distinct idx.index_table_name) as index_tables
+from mo_catalog.mo_indexes idx
+join mo_catalog.mo_tables ptbl
+on ptbl.rel_id = idx.table_id
+join mo_catalog.mo_partition_tables pt
+on pt.partition_id = ptbl.rel_id
+and pt.partition_table_name = ptbl.relname
+and ptbl.reldatabase = database()
+join mo_catalog.mo_partition_metadata pm
+on pm.table_id = pt.primary_table_id
+join mo_catalog.mo_tables ltbl
+on ltbl.rel_id = pm.table_id
+and ltbl.rel_id = pt.primary_table_id
+and ltbl.reldatabase = ptbl.reldatabase
+and ltbl.account_id = ptbl.account_id
+where ltbl.reldatabase = database()
+and ltbl.relname = 'ft_partitioned_gojieba'
+and ltbl.account_id = current_account_id()
+and pm.table_name = ltbl.relname
+and pm.database_name = ltbl.reldatabase
+and idx.name = 'ft_body'
+and idx.type = 'FULLTEXT'
+and idx.algo_params = '{"parser":"gojieba"}'
+and idx.options = 'parser=gojieba,ngram_token_size=3'
+and idx.index_table_name <> '';
+index_rows  ¦  physical_tables  ¦  index_tables
+3  ¦  3  ¦  3
 drop table ft_partitioned_gojieba;

--- a/test/distributed/cases/fulltext/gojieba.result
+++ b/test/distributed/cases/fulltext/gojieba.result
@@ -498,3 +498,29 @@ from (values row(1, '我来到北京清华大学'))
 cross apply fulltext_index_tokenize('{"parser":"gojieba"}', 23, id, body) as f;
 count(*)
 5
+drop table if exists ft_partitioned_gojieba;
+create table ft_partitioned_gojieba (
+id bigint not null,
+body text not null,
+created_at datetime not null,
+primary key (id, created_at)
+) partition by range (to_days(created_at)) (
+partition p202606 values less than (to_days('2026-07-01')),
+partition p202607 values less than (to_days('2026-08-01')),
+partition p202608 values less than (to_days('2026-09-01'))
+);
+create fulltext index ft_body on ft_partitioned_gojieba(body) with parser gojieba;
+show index from ft_partitioned_gojieba;
+➤ Table[12,-1,0]  ¦  Non_unique[-5,64,0]  ¦  Key_name[12,-1,0]  ¦  Seq_in_index[4,32,0]  ¦  Column_name[12,-1,0]  ¦  Collation[12,-1,0]  ¦  Cardinality[-5,64,0]  ¦  Sub_part[12,-1,0]  ¦  Packed[12,-1,0]  ¦  Null[12,-1,0]  ¦  Index_type[12,-1,0]  ¦  Comment[1,0,0]  ¦  Index_comment[12,-1,0]  ¦  Index_params[12,-1,0]  ¦  Visible[12,-1,0]  ¦  Expression[12,-1,0]  𝄀
+ft_partitioned_gojieba  ¦  0  ¦  PRIMARY  ¦  1  ¦  id  ¦  A  ¦  0  ¦  NULL  ¦  NULL  ¦    ¦    ¦    ¦    ¦    ¦  YES  ¦  id  𝄀
+ft_partitioned_gojieba  ¦  0  ¦  PRIMARY  ¦  2  ¦  created_at  ¦  A  ¦  0  ¦  NULL  ¦  NULL  ¦    ¦    ¦    ¦    ¦    ¦  YES  ¦  created_at  𝄀
+ft_partitioned_gojieba  ¦  1  ¦  ft_body  ¦  1  ¦  body  ¦  A  ¦  0  ¦  NULL  ¦  NULL  ¦  YES  ¦  fulltext  ¦    ¦    ¦    ¦  YES  ¦  body
+select count(*) from mo_catalog.mo_indexes
+where name = 'ft_body'
+and type = 'FULLTEXT'
+and algo_params = '{"parser":"gojieba"}'
+and options = 'parser=gojieba,ngram_token_size=3'
+and index_table_name <> '';
+count(*)
+3
+drop table ft_partitioned_gojieba;

--- a/test/distributed/cases/fulltext/gojieba.sql
+++ b/test/distributed/cases/fulltext/gojieba.sql
@@ -428,3 +428,25 @@ from (values row(1, '我来到北京清华大学'))
 ) as src
 cross apply fulltext_index_tokenize('{"parser":"gojieba"}', 23, id, body) as f;
 
+-- Partitioned fulltext DDL must preserve the parser option for every
+-- physical partition when the CREATE INDEX plan is cloned.
+drop table if exists ft_partitioned_gojieba;
+create table ft_partitioned_gojieba (
+    id bigint not null,
+    body text not null,
+    created_at datetime not null,
+    primary key (id, created_at)
+) partition by range (to_days(created_at)) (
+    partition p202606 values less than (to_days('2026-07-01')),
+    partition p202607 values less than (to_days('2026-08-01')),
+    partition p202608 values less than (to_days('2026-09-01'))
+);
+create fulltext index ft_body on ft_partitioned_gojieba(body) with parser gojieba;
+show index from ft_partitioned_gojieba;
+select count(*) from mo_catalog.mo_indexes
+where name = 'ft_body'
+  and type = 'FULLTEXT'
+  and algo_params = '{"parser":"gojieba"}'
+  and options = 'parser=gojieba,ngram_token_size=3'
+  and index_table_name <> '';
+drop table ft_partitioned_gojieba;

--- a/test/distributed/cases/fulltext/gojieba.sql
+++ b/test/distributed/cases/fulltext/gojieba.sql
@@ -442,11 +442,34 @@ create table ft_partitioned_gojieba (
     partition p202608 values less than (to_days('2026-09-01'))
 );
 create fulltext index ft_body on ft_partitioned_gojieba(body) with parser gojieba;
-show index from ft_partitioned_gojieba;
-select count(*) from mo_catalog.mo_indexes
-where name = 'ft_body'
-  and type = 'FULLTEXT'
-  and algo_params = '{"parser":"gojieba"}'
-  and options = 'parser=gojieba,ngram_token_size=3'
-  and index_table_name <> '';
+-- SHOW INDEX currently reads logical-table mo_columns, while these index rows
+-- are attached to physical partition table IDs; keep this DDL fix scoped to
+-- catalog metadata and verify all three physical partitions directly.
+select count(*) as index_rows,
+       count(distinct idx.table_id) as physical_tables,
+       count(distinct idx.index_table_name) as index_tables
+from mo_catalog.mo_indexes idx
+join mo_catalog.mo_tables ptbl
+  on ptbl.rel_id = idx.table_id
+join mo_catalog.mo_partition_tables pt
+  on pt.partition_id = ptbl.rel_id
+ and pt.partition_table_name = ptbl.relname
+ and ptbl.reldatabase = database()
+join mo_catalog.mo_partition_metadata pm
+  on pm.table_id = pt.primary_table_id
+join mo_catalog.mo_tables ltbl
+  on ltbl.rel_id = pm.table_id
+ and ltbl.rel_id = pt.primary_table_id
+ and ltbl.reldatabase = ptbl.reldatabase
+ and ltbl.account_id = ptbl.account_id
+where ltbl.reldatabase = database()
+  and ltbl.relname = 'ft_partitioned_gojieba'
+  and ltbl.account_id = current_account_id()
+  and pm.table_name = ltbl.relname
+  and pm.database_name = ltbl.reldatabase
+  and idx.name = 'ft_body'
+  and idx.type = 'FULLTEXT'
+  and idx.algo_params = '{"parser":"gojieba"}'
+  and idx.options = 'parser=gojieba,ngram_token_size=3'
+  and idx.index_table_name <> '';
 drop table ft_partitioned_gojieba;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27887

## What this PR does / why we need it:

On `4.1-dev`, partitioned `CREATE FULLTEXT INDEX ... WITH PARSER gojieba` clones the index plan before writing `mo_catalog.mo_indexes`. The clone dropped `ParserName` and `NgramTokenSize`, and the catalog writer omitted the options value when an option was non-nil but had no parser. That shifted `index_table_name` into the wrong position and caused `ERROR 1136`.

This change preserves all three 4.1 `IndexOption` fields and always emits the fifteenth catalog value (`parser=...,ngram_token_size=...` or `NULL`). It adds white-box and generator regressions plus a partitioned gojieba BVT case that checks the parser metadata on all physical catalog rows. `SHOW INDEX` remains out of scope because the 4.1 formatter still resolves logical-table columns while these rows are keyed by physical partition table IDs.

## Validation

- The exact unmodified base `a300787ade00137c72529db9f2933b71e858dd2c` fails the new deepcopy and empty-parser generator counterexamples.
- Fixed worktree focused tests and complete `pkg/sql/plan` and `pkg/sql/compile` package tests pass with the repository CGo/rpath contract.
- `go vet ./pkg/sql/plan ./pkg/sql/compile` and `git diff --check` pass.
- BVT coverage is in `test/distributed/cases/fulltext/gojieba.sql`; it must run in the standard MatrixOne BVT environment.

QA required: yes. This changes user-visible partitioned DDL and persisted catalog metadata.
