### PR TITLE
fix(proxy): reuse cached sessions after prepared close

### DIFF
--- a/pkg/proxy/client_conn.go
+++ b/pkg/proxy/client_conn.go
@@ -853,12 +853,13 @@ func (c *clientConn) handleQuitEventInternal(ctx context.Context, waitClientPipe
 				return
 			}
 		}
-		// COM_QUIT is cacheable only at a clean request/response boundary. A
-		// client can pipeline QUIT behind an outstanding query; pausing s2c then
-		// publishing that backend would leave the old response in the socket for
-		// the next generation's SET CONNECTION ID to consume. With c2s sealed and
-		// s2c stopped this state can no longer change, so discard conservatively.
-		if c.tun.hasUnsafeClientState() {
+		// COM_QUIT is cacheable only when no response can remain in the backend
+		// socket. A client can pipeline QUIT behind an outstanding query; pausing
+		// s2c then publishing that backend would leave the old response for the
+		// next generation's SET CONNECTION ID to consume. A completed forwarded
+		// COM_STMT_CLOSE tombstone is safe here because Push resets the old CN
+		// session before reuse.
+		if c.tun.hasUncacheableClientState() {
 			discardBackend()
 			return
 		}

--- a/pkg/proxy/client_conn_test.go
+++ b/pkg/proxy/client_conn_test.go
@@ -480,6 +480,7 @@ func TestClientConn_HandleQuitEventRequiresCleanResponseBoundary(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		makeUnsafe func(*tunnel)
+		wantCached bool
 	}{
 		{name: "outstanding response", makeUnsafe: func(tun *tunnel) {
 			tun.trackClientRequest(makeSimplePacket("select 1"))
@@ -492,7 +493,7 @@ func TestClientConn_HandleQuitEventRequiresCleanResponseBoundary(t *testing.T) {
 			commit := tun.trackClientRequest(
 				makeStmtCommandPacket(frontend.COM_STMT_CLOSE, 1))
 			tun.commitClientRequest(commit)
-		}},
+		}, wantCached: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tun := &tunnel{}
@@ -526,10 +527,15 @@ func TestClientConn_HandleQuitEventRequiresCleanResponseBoundary(t *testing.T) {
 			}
 
 			require.NoError(t, c.handleQuitCommand(context.Background()))
-			require.Zero(t, pushed, "unsafe protocol state must keep the backend out of the cache")
-			require.Equal(t, 1, closed)
+			if tc.wantCached {
+				require.Equal(t, 1, pushed)
+				require.Zero(t, closed)
+			} else {
+				require.Zero(t, pushed, "unsafe protocol state must keep the backend out of the cache")
+				require.Equal(t, 1, closed)
+			}
 			require.Zero(t, quit, "discard cleanup must not wait for a protocol-level QUIT response")
-			require.False(t, c.isConnCached())
+			require.Equal(t, tc.wantCached, c.isConnCached())
 		})
 	}
 }

--- a/pkg/proxy/conn_cache_test.go
+++ b/pkg/proxy/conn_cache_test.go
@@ -676,6 +676,11 @@ func TestPreparedShortConnectionQuitPublishesReusableBackend(t *testing.T) {
 		tun.trackClientRequest(prepare)
 		tun.trackServerResponse(makePrepareOKPacket(0, 0))
 		require.False(t, tun.hasInFlightClientRequest())
+		closeCommit := tun.trackClientRequest(
+			makeStmtCommandPacket(frontend.COM_STMT_CLOSE, 1))
+		tun.commitClientRequest(closeCommit)
+		require.True(t, tun.hasUnsafeClientState(),
+			"forwarded COM_STMT_CLOSE must remain migration-safe until its tombstone is reconciled")
 
 		clientSide, backendSide := net.Pipe()
 		defer clientSide.Close()

--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -539,6 +539,25 @@ func (t *tunnel) hasUnsafeClientState() bool {
 		len(t.requestBoundary.closedStatements) > 0
 }
 
+// hasUncacheableClientState reports state that can still leave a response in
+// the backend socket, or staged binary statement data that has not been
+// consumed. A completed no-response statement close is intentionally not
+// included: connCache.Push resets and discards the old CN session before the
+// backend can be reused.
+func (t *tunnel) hasUncacheableClientState() bool {
+	if t == nil {
+		return false
+	}
+	t.requestBoundary.Lock()
+	defer t.requestBoundary.Unlock()
+	return t.requestBoundary.inFlight ||
+		t.requestBoundary.requestContinuation ||
+		t.requestBoundary.localInfileUpload ||
+		t.requestBoundary.ambiguous ||
+		t.requestBoundary.pendingLongDataOverflow ||
+		len(t.requestBoundary.pendingLongData) > 0
+}
+
 func (t *tunnel) hasUntransferableClientState() bool {
 	if t == nil {
 		return false

--- a/pkg/proxy/tunnel_test.go
+++ b/pkg/proxy/tunnel_test.go
@@ -1276,6 +1276,7 @@ func TestTunnelRequestBoundaryTracker(t *testing.T) {
 		tun.trackClientRequest(quit)
 		require.False(t, tun.hasUntransferableClientState())
 		require.False(t, tun.hasUnsafeClientState())
+		require.False(t, nilTunnel.hasUncacheableClientState())
 	})
 
 	t.Run("orphan continuation stays conservative", func(t *testing.T) {
@@ -1375,6 +1376,7 @@ func TestTunnelRequestBoundaryTracker(t *testing.T) {
 		tun.commitClientRequest(commit)
 		require.False(t, tun.hasUntransferableClientState())
 		require.True(t, tun.hasUnsafeClientState())
+		require.False(t, tun.hasUncacheableClientState())
 	})
 
 	t.Run("fragmented long data closes after its final packet", func(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:

issue #20022

## What this PR does / why we need it:

The Proxy cache admission check used the migration-safety predicate for COM_QUIT. A successfully forwarded `COM_STMT_CLOSE` leaves a migration tombstone, so every prepared short connection was rejected from the cache before `ResetSession`, causing avoidable CN connection churn.

This change adds a cache-specific request-boundary predicate. It permits a completed forwarded `COM_STMT_CLOSE` to reach `connCache.Push` and `ResetSession`, while retaining the migration tombstone gate and rejecting outstanding responses, partial or ambiguous frames, local infile uploads, and staged binary statement data.

## Non-goals

- No change to migration safety or closed-statement tombstone filtering.
- No change to CN session reset, tenant isolation, or the external QA campaign.

## Validation

- Exact current-base regression: FAIL reproduced on `upstream/main@aa7b969f55e655f3f201fd3337589d070f994494` before the fix because `ResetSession` was not reached.
- PR-head focused proxy regression, full `pkg/proxy`, and race `pkg/proxy`: PASS.
- Independent race stress for the prepared-close and request-boundary tests: PASS, 100 iterations each.
- `git diff --check`: PASS.
- Semantic preflight manifest: PASS, exact diff hash `045cfbda573bdfcbb5dbf3a2ac8f5871bf17c4814c3559b4da14cb9f9e402cca`.
- BVT: N/A — this internal Proxy-to-CN cache handoff requires real binary prepared short connections on a 2-CN/2-Proxy deployment; the closest deterministic production-path regression covers `handleQuitCommand`, `connCache.Push`, QueryService `ResetSession`, and `connCache.Pop`.

## QA follow-up

Issue #20022 remains open with `phase/testing` and `test-verification-failed`. Re-run the original 2-CN/2-Proxy campaign on this PR head with cache enabled, alternating databases, binary prepared point lookups, short connections, and the existing 1-second pacing. Tester PASS is required before issue closure or testing-label cleanup.
