### PR TITLE
to 4.2-dev: fix(plan): preserve INSERT IGNORE lock keys through CHECK filter

### DIFF
--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -1744,7 +1744,6 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 			lastNodeID, selectTag, selectNode = builder.appendInsertLockKeyProjection(
 				bindCtx,
 				lastNodeID,
-				selectTag,
 			)
 			if err = builder.materializeInsertUniqueLockKeys(tableDef, skipUniqueIdx, colName2Idx, selectNode); err != nil {
 				return 0, err
@@ -2877,9 +2876,8 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 func (builder *QueryBuilder) appendInsertLockKeyProjection(
 	bindCtx *BindContext,
 	lastNodeID int32,
-	selectTag int32,
 ) (int32, int32, *plan.Node) {
-	selectTag = builder.genNewBindTag()
+	selectTag := builder.genNewBindTag()
 	lastNodeID = builder.appendNode(&plan.Node{
 		NodeType:    plan.Node_PROJECT,
 		Children:    []int32{lastNodeID},

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -1731,6 +1731,28 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	//     the surviving rows — MySQL's row-skip semantics.
 	// ON DUPLICATE KEY UPDATE runs its own in-plan assert over the final merged
 	// image (handled earlier, with appendOnDupIrregularMaintSource).
+	// INSERT IGNORE applies CHECK constraints as a FILTER. Materialize unique-key
+	// lock columns before that filter so its pass-through projection preserves the
+	// physical vectors consumed by LockOp.
+	lockKeysMaterializedBeforeChecks := false
+	if onDupAction == plan.Node_IGNORE && len(tableDef.Checks) > 0 {
+		needsLockKeyProjection, err := hasMaterializedInsertUniqueLockKey(tableDef, skipUniqueIdx)
+		if err != nil {
+			return 0, err
+		}
+		if needsLockKeyProjection {
+			lastNodeID, selectTag, selectNode = builder.appendInsertLockKeyProjection(
+				bindCtx,
+				lastNodeID,
+				selectTag,
+			)
+			if err = builder.materializeInsertUniqueLockKeys(tableDef, skipUniqueIdx, colName2Idx, selectNode); err != nil {
+				return 0, err
+			}
+			lockKeysMaterializedBeforeChecks = true
+		}
+	}
+
 	if onDupAction == plan.Node_FAIL {
 		fkEnabled, err := builder.modernInsertFkCheckEnabled(tableDef)
 		if err != nil {
@@ -1799,47 +1821,10 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 
 	// Materialize lock keys for composite and prefix unique indexes in advance.
 	// This guarantees the lock target can find __mo_index_idx_col in colName2Idx.
-	for i, idxDef := range tableDef.Indexes {
-		prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
-		if err != nil {
+	if !lockKeysMaterializedBeforeChecks {
+		if err = builder.materializeInsertUniqueLockKeys(tableDef, skipUniqueIdx, colName2Idx, selectNode); err != nil {
 			return 0, err
 		}
-		if !idxDef.Unique || skipUniqueIdx[i] || (len(idxDef.Parts) <= 1 && len(prefixLengths) == 0) {
-			continue
-		}
-		lockColName := idxDef.IndexTableName + "." + catalog.IndexTableIndexColName
-		if _, ok := colName2Idx[lockColName]; ok {
-			continue
-		}
-
-		var lockExpr *plan.Expr
-		if len(idxDef.Parts) == 1 {
-			partName := catalog.ResolveAlias(idxDef.Parts[0])
-			partPos, ok := colName2Idx[tableDef.Name+"."+partName]
-			if !ok {
-				return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
-			}
-			lockExpr, err = builder.makeIndexPartExprFromInputExpr(selectNode.ProjectList[partPos], partName, prefixLengths)
-			if err != nil {
-				return 0, err
-			}
-		} else {
-			args := make([]*plan.Expr, len(idxDef.Parts))
-			for k := range idxDef.Parts {
-				partName := catalog.ResolveAlias(idxDef.Parts[k])
-				partPos, ok := colName2Idx[tableDef.Name+"."+partName]
-				if !ok {
-					return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
-				}
-				args[k], err = builder.makeIndexPartExprFromInputExpr(selectNode.ProjectList[partPos], partName, prefixLengths)
-				if err != nil {
-					return 0, err
-				}
-			}
-			lockExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", args)
-		}
-		colName2Idx[lockColName] = int32(len(selectNode.ProjectList))
-		selectNode.ProjectList = append(selectNode.ProjectList, lockExpr)
 	}
 
 	// real-PK ON DUPLICATE KEY UPDATE: resolve a single UPDATE target up front so a
@@ -2884,6 +2869,102 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	lastNodeID = builder.appendNode(dmlNode, bindCtx)
 
 	return lastNodeID, nil
+}
+
+// appendInsertLockKeyProjection creates an executable row image for computed
+// unique-index lock keys. The new PROJECT reads from the preceding PROJECT's
+// binding tag, so lock-key expressions never self-reference their own output.
+func (builder *QueryBuilder) appendInsertLockKeyProjection(
+	bindCtx *BindContext,
+	lastNodeID int32,
+	selectTag int32,
+) (int32, int32, *plan.Node) {
+	selectTag = builder.genNewBindTag()
+	lastNodeID = builder.appendNode(&plan.Node{
+		NodeType:    plan.Node_PROJECT,
+		Children:    []int32{lastNodeID},
+		ProjectList: getProjectionByLastNodeWithTag(builder, lastNodeID, selectTag),
+		BindingTags: []int32{selectTag},
+	}, bindCtx)
+	return lastNodeID, selectTag, builder.qry.Nodes[lastNodeID]
+}
+
+// materializeInsertUniqueLockKeys appends the computed lock key for each
+// composite or prefix unique index to the insert row image. It must run while
+// selectNode is an executable PROJECT, because LockOp consumes the resulting
+// physical vectors rather than expressions in a pass-through FILTER.
+func (builder *QueryBuilder) materializeInsertUniqueLockKeys(
+	tableDef *TableDef,
+	skipUniqueIdx []bool,
+	colName2Idx map[string]int32,
+	selectNode *plan.Node,
+) error {
+	for i, idxDef := range tableDef.Indexes {
+		prefixLengths, materialize, err := insertUniqueLockKeyPrefixLengths(idxDef, skipUniqueIdx[i])
+		if err != nil {
+			return err
+		}
+		if !materialize {
+			continue
+		}
+		lockColName := idxDef.IndexTableName + "." + catalog.IndexTableIndexColName
+		if _, ok := colName2Idx[lockColName]; ok {
+			continue
+		}
+
+		var lockExpr *plan.Expr
+		if len(idxDef.Parts) == 1 {
+			partName := catalog.ResolveAlias(idxDef.Parts[0])
+			partPos, ok := colName2Idx[tableDef.Name+"."+partName]
+			if !ok {
+				return moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
+			}
+			lockExpr, err = builder.makeIndexPartExprFromInputExpr(selectNode.ProjectList[partPos], partName, prefixLengths)
+			if err != nil {
+				return err
+			}
+		} else {
+			args := make([]*plan.Expr, len(idxDef.Parts))
+			for k := range idxDef.Parts {
+				partName := catalog.ResolveAlias(idxDef.Parts[k])
+				partPos, ok := colName2Idx[tableDef.Name+"."+partName]
+				if !ok {
+					return moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
+				}
+				args[k], err = builder.makeIndexPartExprFromInputExpr(selectNode.ProjectList[partPos], partName, prefixLengths)
+				if err != nil {
+					return err
+				}
+			}
+			lockExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", args)
+		}
+
+		colName2Idx[lockColName] = int32(len(selectNode.ProjectList))
+		selectNode.ProjectList = append(selectNode.ProjectList, lockExpr)
+	}
+	return nil
+}
+
+func hasMaterializedInsertUniqueLockKey(tableDef *TableDef, skipUniqueIdx []bool) (bool, error) {
+	for i, idxDef := range tableDef.Indexes {
+		_, materialize, err := insertUniqueLockKeyPrefixLengths(idxDef, skipUniqueIdx[i])
+		if err != nil {
+			return false, err
+		}
+		if materialize {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func insertUniqueLockKeyPrefixLengths(idxDef *IndexDef, skip bool) (map[string]int, bool, error) {
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	if err != nil {
+		return nil, false, err
+	}
+	return prefixLengths, idxDef.Unique && !skip &&
+		(len(idxDef.Parts) > 1 || len(prefixLengths) > 0), nil
 }
 
 // getInsertColsFromStmt retrieves the list of column names to be inserted into a table

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -3519,31 +3519,27 @@ func TestAssignmentCastRollingUpgradePlanGate(t *testing.T) {
 	require.Contains(t, upgradedPlan, `"obj_name":"cast_assign"`)
 }
 
+func addPositiveCheck(t *testing.T, mock *MockOptimizer, tableName, columnName string) {
+	t.Helper()
+	tableDef := mock.ctxt.tables[tableName]
+	colPos := tableDef.Name2ColIndex[columnName]
+	checkExpr, err := BindFuncExprImplByPlanExpr(
+		t.Context(),
+		">",
+		[]*plan.Expr{
+			{Typ: tableDef.Cols[colPos].Typ, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 0, ColPos: colPos}}},
+			MakePlan2Int64ConstExprWithType(0),
+		},
+	)
+	require.NoError(t, err)
+	tableDef.Checks = []*plan.CheckDef{{Name: "positive_check", Check: checkExpr}}
+}
+
 func TestInsertAddsCheckConstraintFilter(t *testing.T) {
-	addDeptCheck := func(mock *MockOptimizer) {
-		tableDef := mock.ctxt.tables["dept"]
-		colPos := tableDef.Name2ColIndex["deptno"]
-		colExpr := &plan.Expr{
-			Typ: tableDef.Cols[colPos].Typ,
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{RelPos: 0, ColPos: colPos},
-			},
-		}
-		checkExpr, err := BindFuncExprImplByPlanExpr(
-			t.Context(),
-			">",
-			[]*plan.Expr{colExpr, MakePlan2Int64ConstExprWithType(0)},
-		)
-		require.NoError(t, err)
-		tableDef.Checks = []*plan.CheckDef{{
-			Name:  "dept_chk_1",
-			Check: checkExpr,
-		}}
-	}
 
 	build := func(sql string) *plan.Query {
 		mock := NewMockOptimizer(true)
-		addDeptCheck(mock)
+		addPositiveCheck(t, mock, "dept", "deptno")
 
 		stmt, err := mysql.ParseOne(t.Context(), sql, 1)
 		require.NoError(t, err)
@@ -3571,7 +3567,7 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 
 	t.Run("replace rejects mixed-version cluster", func(t *testing.T) {
 		mock := NewMockOptimizer(true)
-		addDeptCheck(mock)
+		addPositiveCheck(t, mock, "dept", "deptno")
 		proc := testutil.NewProc(nil)
 		rt := moruntime.ServiceRuntime(proc.GetService())
 		defer rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
@@ -3686,6 +3682,32 @@ func TestInsertIgnoreCheckCompositeUniqueNeedsLockKeyProjection(t *testing.T) {
 	needsProjection, err = hasMaterializedInsertUniqueLockKey(tableDef, []bool{false, true})
 	require.NoError(t, err)
 	require.False(t, needsProjection)
+}
+
+func TestInsertIgnoreCheckCompositeUniqueBuildsPlan(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	tableDef := mock.ctxt.tables["dept_composite_uk"]
+	addPositiveCheck(t, mock, tableDef.Name, "deptno")
+
+	stmt, err := mysql.ParseOne(
+		t.Context(),
+		"insert ignore into dept_composite_uk values (1, 'Sales', 'NY')",
+		1,
+	)
+	require.NoError(t, err)
+	query, err := mock.Optimize(stmt)
+	require.NoError(t, err)
+
+	foundCheckFilter := false
+	for _, node := range query.Nodes {
+		if node.NodeType != plan.Node_FILTER {
+			continue
+		}
+		for _, expr := range node.FilterList {
+			foundCheckFilter = foundCheckFilter || exprContainsFuncName(expr, "coalesce")
+		}
+	}
+	require.True(t, foundCheckFilter)
 }
 
 func TestReplaceSetColRefAsDefault(t *testing.T) {

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -3606,11 +3606,12 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 
 	t.Run("insert ignore materializes composite unique lock key before check filter", func(t *testing.T) {
 		mock := NewMockOptimizer(true)
-		addPositiveCheck(mock, "emp", "empno")
+		addPositiveCheck(mock, "dept", "deptno")
+		mock.ctxt.tables["dept"].Indexes[1].Unique = true
 
 		stmt, err := mysql.ParseOne(
 			t.Context(),
-			"insert ignore into emp values (1, 'Alice', 'Engineer', 1, '2024-01-01', 1.00, 1.00, 1)",
+			"insert ignore into dept values (1, 'Alice', 'NY')",
 			1,
 		)
 		require.NoError(t, err)

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -3520,9 +3520,9 @@ func TestAssignmentCastRollingUpgradePlanGate(t *testing.T) {
 }
 
 func TestInsertAddsCheckConstraintFilter(t *testing.T) {
-	addPositiveCheck := func(mock *MockOptimizer, tableName, columnName string) {
-		tableDef := mock.ctxt.tables[tableName]
-		colPos := tableDef.Name2ColIndex[columnName]
+	addDeptCheck := func(mock *MockOptimizer) {
+		tableDef := mock.ctxt.tables["dept"]
+		colPos := tableDef.Name2ColIndex["deptno"]
 		colExpr := &plan.Expr{
 			Typ: tableDef.Cols[colPos].Typ,
 			Expr: &plan.Expr_Col{
@@ -3543,7 +3543,7 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 
 	build := func(sql string) *plan.Query {
 		mock := NewMockOptimizer(true)
-		addPositiveCheck(mock, "dept", "deptno")
+		addDeptCheck(mock)
 
 		stmt, err := mysql.ParseOne(t.Context(), sql, 1)
 		require.NoError(t, err)
@@ -3571,7 +3571,7 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 
 	t.Run("replace rejects mixed-version cluster", func(t *testing.T) {
 		mock := NewMockOptimizer(true)
-		addPositiveCheck(mock, "dept", "deptno")
+		addDeptCheck(mock)
 		proc := testutil.NewProc(nil)
 		rt := moruntime.ServiceRuntime(proc.GetService())
 		defer rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
@@ -3602,44 +3602,6 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 			}
 		}
 		require.True(t, found)
-	})
-
-	t.Run("insert ignore materializes composite unique lock key before check filter", func(t *testing.T) {
-		mock := NewMockOptimizer(true)
-		addPositiveCheck(mock, "dept", "deptno")
-		mock.ctxt.tables["dept"].Indexes[1].Unique = true
-
-		stmt, err := mysql.ParseOne(
-			t.Context(),
-			"insert ignore into dept values (1, 'Alice', 'NY')",
-			1,
-		)
-		require.NoError(t, err)
-		query, err := mock.Optimize(stmt)
-		require.NoError(t, err)
-
-		var checkFilter *plan.Node
-		for _, node := range query.Nodes {
-			if node.NodeType != plan.Node_FILTER {
-				continue
-			}
-			for _, expr := range node.FilterList {
-				if exprContainsFuncName(expr, "coalesce") {
-					checkFilter = node
-					break
-				}
-			}
-		}
-		require.NotNil(t, checkFilter)
-		require.Len(t, checkFilter.Children, 1)
-
-		lockKeyInput := query.Nodes[checkFilter.Children[0]]
-		hasSerialLockKey := false
-		for _, expr := range lockKeyInput.ProjectList {
-			hasSerialLockKey = hasSerialLockKey || exprContainsFuncName(expr, "serial")
-		}
-		require.True(t, hasSerialLockKey,
-			"the composite unique lock key must be materialized before the CHECK filter")
 	})
 
 	for _, sql := range []string{
@@ -3709,6 +3671,21 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 		}
 		require.True(t, found)
 	})
+}
+
+func TestInsertIgnoreCheckCompositeUniqueNeedsLockKeyProjection(t *testing.T) {
+	tableDef := &plan.TableDef{Indexes: []*plan.IndexDef{
+		{Unique: true, Parts: []string{"a"}},
+		{Unique: true, Parts: []string{"a", "b"}},
+	}}
+
+	needsProjection, err := hasMaterializedInsertUniqueLockKey(tableDef, []bool{false, false})
+	require.NoError(t, err)
+	require.True(t, needsProjection)
+
+	needsProjection, err = hasMaterializedInsertUniqueLockKey(tableDef, []bool{false, true})
+	require.NoError(t, err)
+	require.False(t, needsProjection)
 }
 
 func TestReplaceSetColRefAsDefault(t *testing.T) {

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -3520,9 +3520,9 @@ func TestAssignmentCastRollingUpgradePlanGate(t *testing.T) {
 }
 
 func TestInsertAddsCheckConstraintFilter(t *testing.T) {
-	addDeptCheck := func(mock *MockOptimizer) {
-		tableDef := mock.ctxt.tables["dept"]
-		colPos := tableDef.Name2ColIndex["deptno"]
+	addPositiveCheck := func(mock *MockOptimizer, tableName, columnName string) {
+		tableDef := mock.ctxt.tables[tableName]
+		colPos := tableDef.Name2ColIndex[columnName]
 		colExpr := &plan.Expr{
 			Typ: tableDef.Cols[colPos].Typ,
 			Expr: &plan.Expr_Col{
@@ -3543,7 +3543,7 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 
 	build := func(sql string) *plan.Query {
 		mock := NewMockOptimizer(true)
-		addDeptCheck(mock)
+		addPositiveCheck(mock, "dept", "deptno")
 
 		stmt, err := mysql.ParseOne(t.Context(), sql, 1)
 		require.NoError(t, err)
@@ -3571,7 +3571,7 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 
 	t.Run("replace rejects mixed-version cluster", func(t *testing.T) {
 		mock := NewMockOptimizer(true)
-		addDeptCheck(mock)
+		addPositiveCheck(mock, "dept", "deptno")
 		proc := testutil.NewProc(nil)
 		rt := moruntime.ServiceRuntime(proc.GetService())
 		defer rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
@@ -3602,6 +3602,44 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 			}
 		}
 		require.True(t, found)
+	})
+
+	t.Run("insert ignore materializes composite unique lock key before check filter", func(t *testing.T) {
+		mock := NewMockOptimizer(true)
+		addPositiveCheck(mock, "emp", "empno")
+
+		stmt, err := mysql.ParseOne(
+			t.Context(),
+			"insert ignore into emp values (1, 'Alice', 'Engineer', 1, '2024-01-01', 1.00, 1.00, 1)",
+			1,
+		)
+		require.NoError(t, err)
+		query, err := mock.Optimize(stmt)
+		require.NoError(t, err)
+
+		var checkFilter *plan.Node
+		for _, node := range query.Nodes {
+			if node.NodeType != plan.Node_FILTER {
+				continue
+			}
+			for _, expr := range node.FilterList {
+				if exprContainsFuncName(expr, "coalesce") {
+					checkFilter = node
+					break
+				}
+			}
+		}
+		require.NotNil(t, checkFilter)
+		require.Len(t, checkFilter.Children, 1)
+
+		lockKeyProjection := query.Nodes[checkFilter.Children[0]]
+		require.Equal(t, plan.Node_PROJECT, lockKeyProjection.NodeType)
+		hasSerialLockKey := false
+		for _, expr := range lockKeyProjection.ProjectList {
+			hasSerialLockKey = hasSerialLockKey || exprContainsFuncName(expr, "serial")
+		}
+		require.True(t, hasSerialLockKey,
+			"the composite unique lock key must be materialized before the CHECK filter")
 	})
 
 	for _, sql := range []string{

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -3682,6 +3682,13 @@ func TestInsertIgnoreCheckCompositeUniqueNeedsLockKeyProjection(t *testing.T) {
 	needsProjection, err = hasMaterializedInsertUniqueLockKey(tableDef, []bool{false, true})
 	require.NoError(t, err)
 	require.False(t, needsProjection)
+
+	_, err = hasMaterializedInsertUniqueLockKey(&plan.TableDef{Indexes: []*plan.IndexDef{{
+		Unique:          true,
+		Parts:           []string{"a", "b"},
+		IndexAlgoParams: "not-json",
+	}}}, []bool{false})
+	require.Error(t, err)
 }
 
 func TestInsertIgnoreCheckCompositeUniqueBuildsPlan(t *testing.T) {

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -3632,10 +3632,9 @@ func TestInsertAddsCheckConstraintFilter(t *testing.T) {
 		require.NotNil(t, checkFilter)
 		require.Len(t, checkFilter.Children, 1)
 
-		lockKeyProjection := query.Nodes[checkFilter.Children[0]]
-		require.Equal(t, plan.Node_PROJECT, lockKeyProjection.NodeType)
+		lockKeyInput := query.Nodes[checkFilter.Children[0]]
 		hasSerialLockKey := false
-		for _, expr := range lockKeyProjection.ProjectList {
+		for _, expr := range lockKeyInput.ProjectList {
 			hasSerialLockKey = hasSerialLockKey || exprContainsFuncName(expr, "serial")
 		}
 		require.True(t, hasSerialLockKey,

--- a/test/distributed/cases/dml/insert/check_constraint.result
+++ b/test/distributed/cases/dml/insert/check_constraint.result
@@ -67,4 +67,16 @@ select * from replace_check order by id;
 id    v
 1    20
 2    NULL
+create table insert_ignore_check_composite_unique(
+a int not null,
+b int not null,
+c int not null,
+primary key(a, b),
+unique key uk(a, b, c),
+constraint positive_c check(c > 0)
+);
+insert ignore into insert_ignore_check_composite_unique values (1, 2, 3), (4, 5, -1);
+select * from insert_ignore_check_composite_unique order by a, b, c;
+a    b    c
+1    2    3
 drop database check_constraint_test;

--- a/test/distributed/cases/dml/insert/check_constraint.test
+++ b/test/distributed/cases/dml/insert/check_constraint.test
@@ -47,4 +47,15 @@ replace into replace_check values (1, 20);
 replace into replace_check values (2, null);
 select * from replace_check order by id;
 
+create table insert_ignore_check_composite_unique(
+    a int not null,
+    b int not null,
+    c int not null,
+    primary key(a, b),
+    unique key uk(a, b, c),
+    constraint positive_c check(c > 0)
+);
+insert ignore into insert_ignore_check_composite_unique values (1, 2, 3), (4, 5, -1);
+select * from insert_ignore_check_composite_unique order by a, b, c;
+
 drop database check_constraint_test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27919.

Backport of #27921 to `4.2-dev`.

## What this PR does / why we need it:

`INSERT IGNORE` applies CHECK constraints with a semantic-boundary `FILTER`. The composite/prefix UNIQUE lock-key builder previously ran after that filter and appended `serial(...)` to the filter's `ProjectList`. A filter forwards its input batch and does not evaluate a newly appended projection expression, but `LockOp` still used the recorded vector position. This caused an out-of-range `Batch.GetVector` panic.

This backport:

- detects when an INSERT requires a materialized composite/prefix UNIQUE lock key;
- adds an executable PROJECT before the CHECK filter, with a distinct binding tag, and computes the lock key there;
- retains the existing materialization location for all other insert paths;
- adds planner unit coverage for the composite-UNIQUE eligibility decision, invalid index-metadata error propagation, and the actual `INSERT IGNORE` + CHECK + composite-UNIQUE binding path; and
- adds an always-active distributed BVT regression covering `INSERT IGNORE`, CHECK, composite primary key, and composite UNIQUE key.

## Validation

- `git diff --check HEAD^` passes.
- The original planner change was functionally validated in #27921 with `go test ./pkg/sql/plan`, a local build, and `check_constraint.test` at 69/69 before the coverage-unit-test commit.
- This clean `4.2-dev` worktree does not contain compatible native CGo dependencies; local `go test ./pkg/sql/plan` stops before Go compilation on missing `xxhash.h`, `roaring.h`, and `usearch.h`. CI is validating the full updated branch.
