### PR TITLE
perf(plan): use table locks for large full updates

### DIFF
--- a/pkg/sql/colexec/lock_range.go
+++ b/pkg/sql/colexec/lock_range.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colexec
+
+import "github.com/matrixorigin/matrixone/pkg/container/types"
+
+// SupportsTotalLockTableRange reports whether lockop can encode a range that
+// covers the type's complete physical keyspace. Keep this capability below the
+// lockop package so both physical compilation and logical-plan admission can
+// use the same predicate without creating a package cycle.
+func SupportsTotalLockTableRange(t types.Type) bool {
+	switch t.Oid {
+	case types.T_bool, types.T_bit,
+		types.T_int8, types.T_int16, types.T_int32, types.T_int64,
+		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
+		types.T_date, types.T_year, types.T_time, types.T_datetime, types.T_timestamp,
+		types.T_decimal64, types.T_decimal128, types.T_decimal256,
+		types.T_uuid, types.T_char, types.T_varchar, types.T_binary, types.T_varbinary,
+		types.T_enum:
+		return true
+	default:
+		// FLOAT/DOUBLE fetchers use finite endpoints and cannot cover infinities
+		// or every NaN payload. Other types have no lock-row fetcher.
+		return false
+	}
+}

--- a/pkg/sql/colexec/lockop/fetch.go
+++ b/pkg/sql/colexec/lockop/fetch.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/lock"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"golang.org/x/exp/constraints"
 )
 
@@ -106,8 +107,7 @@ func getFetchRowsFunc(t types.Type) FetchLockRowsFunc {
 // fetcher, but their current finite min/max endpoints do not cover infinities or
 // every NaN payload and therefore cannot prove full-domain exclusion.
 func SupportsTotalLockTableRange(t types.Type) bool {
-	return t.Oid != types.T_float32 && t.Oid != types.T_float64 &&
-		getFetchRowsFunc(t) != nil
+	return colexec.SupportsTotalLockTableRange(t)
 }
 
 // GetFetchRowsFunc get FetchLockRowsFunc based on primary key type

--- a/pkg/sql/colexec/lockop/fetch_test.go
+++ b/pkg/sql/colexec/lockop/fetch_test.go
@@ -1495,6 +1495,12 @@ func TestSupportsTotalLockTableRange(t *testing.T) {
 	require.False(t, SupportsTotalLockTableRange(types.T_float32.ToType()))
 	require.False(t, SupportsTotalLockTableRange(types.T_float64.ToType()))
 	require.False(t, SupportsTotalLockTableRange(types.T_blob.ToType()))
+	for oid := 0; oid <= math.MaxUint8; oid++ {
+		typ := types.Type{Oid: types.T(oid)}
+		want := getFetchRowsFunc(typ) != nil && typ.Oid != types.T_float32 && typ.Oid != types.T_float64
+		require.Equalf(t, want, SupportsTotalLockTableRange(typ),
+			"logical-plan admission drifted from lockop support for oid %d", oid)
+	}
 	require.NotPanics(t, func() { GetFetchRowsFunc(types.T_uint32.ToType()) })
 	require.Panics(t, func() { GetFetchRowsFunc(types.T_blob.ToType()) })
 }

--- a/pkg/sql/plan/bind_delete.go
+++ b/pkg/sql/plan/bind_delete.go
@@ -449,7 +449,7 @@ func (builder *QueryBuilder) bindDelete(ctx CompilerContext, stmt *tree.Delete, 
 			LockTargets: lockTargets,
 		}, bindCtx)
 
-		applySharedLockTableFallback(builder)
+		applyLockTableFallback(builder)
 	}
 
 	dmlNode.Children = append(dmlNode.Children, lastNodeID)

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -924,7 +924,7 @@ func (builder *QueryBuilder) finishIrregularIndexMaintenance(query *plan.Query, 
 	reduceSinkSinkScanNodes(query)
 	builder.tempOptimizeForDML()
 	builder.determineShuffleForDMLSteps()
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
 	return nil
 }
 
@@ -2137,7 +2137,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 			BindingTags: []int32{builder.genNewBindTag()},
 			LockTargets: lockTargets,
 		}, bindCtx)
-		applySharedLockTableFallback(builder)
+		applyLockTableFallback(builder)
 	}
 
 	/*

--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -1123,7 +1123,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			BindingTags: []int32{finalProjTag},
 			LockTargets: lockTargets,
 		}, bindCtx)
-		applySharedLockTableFallback(builder)
+		applyLockTableFallback(builder)
 	}
 
 	if len(replaceOldParentPos) > 0 {
@@ -1150,7 +1150,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			builder.preserveLockProjection = make(map[int32]struct{})
 		}
 		builder.preserveLockProjection[lockedSourceID] = struct{}{}
-		applySharedLockTableFallback(builder)
+		applyLockTableFallback(builder)
 
 		sharedSinkID := appendSinkNode(builder, bindCtx, lockedSourceID)
 		builder.preserveSinkProjection[sharedSinkID] = struct{}{}

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	indexplugin "github.com/matrixorigin/matrixone/pkg/indexplugin"
 	planplugin "github.com/matrixorigin/matrixone/pkg/indexplugin/plan"
+	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/internal/materialized"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
@@ -2291,6 +2292,16 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		}
 		return lockTargets[i].PrimaryColIdxInBat < lockTargets[j].PrimaryColIdxInBat
 	})
+	if isUnrestrictedSingleTargetUpdate(stmt, dmlCtx, updatedTargetCount) {
+		if builder.fullTableUpdateLockTargets == nil {
+			builder.fullTableUpdateLockTargets = make(map[*plan.LockTarget]struct{}, len(lockTargets))
+		}
+		for _, target := range lockTargets {
+			if target.Mode == lockpb.LockMode_Exclusive {
+				builder.fullTableUpdateLockTargets[target] = struct{}{}
+			}
+		}
+	}
 
 	// Synchronous irregular indexes share the exact final row image with the
 	// base-table MULTI_UPDATE. Their stale entries are deleted by the immutable
@@ -2402,7 +2413,7 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 			LockTargets: lockTargets,
 		}, bindCtx)
 	}
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
 
 	dmlNode.Children = append(dmlNode.Children, lastNodeID)
 	lastNodeID = builder.appendNode(dmlNode, bindCtx)
@@ -4597,6 +4608,22 @@ func updateHasMultipleSourceTables(stmt *tree.Update) bool {
 		return true
 	}
 	return len(stmt.Tables) == 1 && tableExprContainsJoin(stmt.Tables[0])
+}
+
+// isUnrestrictedSingleTargetUpdate proves the semantic precondition for the
+// large-UPDATE table-lock fast path. The proof deliberately stays narrower
+// than cardinality estimation: a predicate that happens to estimate to every
+// current row is still bounded and must preserve #26706's range-lock behavior.
+func isUnrestrictedSingleTargetUpdate(stmt *tree.Update, dmlCtx *DMLContext, updatedTargetCount int) bool {
+	if stmt == nil || dmlCtx == nil || updatedTargetCount != 1 || len(dmlCtx.tableDefs) != 1 ||
+		updateHasMultipleSourceTables(stmt) || len(stmt.OrderBy) != 0 || stmt.Limit != nil {
+		return false
+	}
+	if stmt.Where == nil {
+		return true
+	}
+	literal, ok := stmt.Where.Expr.(*tree.NumVal)
+	return ok && literal.ValType == tree.P_bool && literal.Bool()
 }
 
 func primaryKeyUpdated(tableDef *plan.TableDef, updateCols map[string]tree.Expr) bool {

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -28,6 +28,7 @@ import (
 	planplugin "github.com/matrixorigin/matrixone/pkg/indexplugin/plan"
 	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/internal/materialized"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	planutil "github.com/matrixorigin/matrixone/pkg/sql/util"
@@ -2292,7 +2293,9 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		}
 		return lockTargets[i].PrimaryColIdxInBat < lockTargets[j].PrimaryColIdxInBat
 	})
-	if isUnrestrictedSingleTargetUpdate(stmt, dmlCtx, updatedTargetCount) {
+	if !builder.hasExistingLockTargets() &&
+		isUnrestrictedSingleTargetUpdate(stmt, dmlCtx, updatedTargetCount) &&
+		lockTargetsCoverCompleteKeyspaces(lockTargets) {
 		if builder.fullTableUpdateLockTargets == nil {
 			builder.fullTableUpdateLockTargets = make(map[*plan.LockTarget]struct{}, len(lockTargets))
 		}
@@ -4624,6 +4627,37 @@ func isUnrestrictedSingleTargetUpdate(stmt *tree.Update, dmlCtx *DMLContext, upd
 	}
 	literal, ok := stmt.Where.Expr.(*tree.NumVal)
 	return ok && literal.ValType == tree.P_bool && literal.Bool()
+}
+
+// hasExistingLockTargets rejects plans that must lock another namespace before
+// the UPDATE's final base/index lock gate. Pulling only the final targets into
+// the compile-time table-lock phase would reverse that established order for
+// foreign-key checks/actions or an explicitly locking scalar subquery.
+func (builder *QueryBuilder) hasExistingLockTargets() bool {
+	for _, node := range builder.qry.Nodes {
+		if node.NodeType == plan.Node_LOCK_OP && len(node.LockTargets) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// lockTargetsCoverCompleteKeyspaces keeps table-lock admission atomic across
+// every namespace written by the UPDATE. A partial admission can invert lock
+// order against a bounded UPDATE, and FLOAT/DOUBLE table ranges do not cover
+// infinities or every NaN payload even though their ordinary row locks work.
+func lockTargetsCoverCompleteKeyspaces(lockTargets []*plan.LockTarget) bool {
+	foundExclusive := false
+	for _, target := range lockTargets {
+		if target == nil || target.Mode != lockpb.LockMode_Exclusive {
+			continue
+		}
+		foundExclusive = true
+		if !colexec.SupportsTotalLockTableRange(makeTypeByPlan2Type(target.PrimaryColTyp)) {
+			return false
+		}
+	}
+	return foundExclusive
 }
 
 func primaryKeyUpdated(tableDef *plan.TableDef, updateCols map[string]tree.Expr) bool {

--- a/pkg/sql/plan/build_delete.go
+++ b/pkg/sql/plan/build_delete.go
@@ -106,7 +106,7 @@ func buildDelete(stmt *tree.Delete, ctx CompilerContext, isPrepareStmt bool) (*P
 
 	reduceSinkSinkScanNodes(query)
 	builder.tempOptimizeForDML()
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
 	query.StmtType = plan.Query_DELETE
 	return &Plan{
 		Plan: &plan.Plan_Query{

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -208,7 +208,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 	query.DetectSqls = sqls
 	reduceSinkSinkScanNodes(query)
 	builder.tempOptimizeForDML()
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
 
 	return &Plan{
 		Plan: &plan.Plan_Query{

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -3020,6 +3020,32 @@ func TestLargeUpdateTableLockRequiresUnrestrictedSingleTarget(t *testing.T) {
 			maxRows:       1 << 30,
 			wantTableLock: false,
 		},
+		{
+			name:    "incomplete float keyspace stays row scoped",
+			sql:     "UPDATE NATION SET N_NAME = 'updated'",
+			maxRows: 1,
+			prepare: func(mock *MockOptimizer) {
+				tableDef := mock.ctxt.tables["nation"]
+				pkPos := tableDef.Name2ColIndex[tableDef.Pkey.PkeyColName]
+				tableDef.Cols[pkPos].Typ = plan.Type{Id: int32(types.T_float64)}
+			},
+		},
+		{
+			name:    "affected foreign key preserves lock order",
+			sql:     "UPDATE replace_fk_c SET pid = pid",
+			maxRows: 1,
+		},
+		{
+			name:          "unrelated column on foreign key table",
+			sql:           "UPDATE replace_fk_c SET id = id + 100",
+			maxRows:       1,
+			wantTableLock: true,
+		},
+		{
+			name:    "locking scalar subquery preserves lock order",
+			sql:     "UPDATE NATION SET N_NAME = (SELECT N_NAME FROM NATION2 LIMIT 1 FOR UPDATE)",
+			maxRows: 1,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -2898,7 +2899,6 @@ func TestLoadPlanKeepsUniqueIndexRowLockTarget(t *testing.T) {
 func TestLargeDMLKeepsRowScopedLockTarget(t *testing.T) {
 	sqls := []string{
 		"INSERT INTO NATION SELECT * FROM NATION2",
-		"UPDATE NATION SET N_NAME = 'updated'",
 		"DELETE FROM NATION",
 		"REPLACE INTO NATION SELECT * FROM NATION2",
 		"SELECT N_NATIONKEY FROM NATION FOR UPDATE",
@@ -2937,6 +2937,188 @@ func TestLargeDMLKeepsRowScopedLockTarget(t *testing.T) {
 				}
 			}
 			require.NotZero(t, lockNodeCount, "expected a lock operator: %s", sql)
+		})
+	}
+}
+
+func TestLargeUpdateTableLockRequiresUnrestrictedSingleTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		sql           string
+		maxRows       uint64
+		wantTableLock bool
+		prepare       func(*MockOptimizer)
+	}{
+		{
+			name:          "unfiltered single target",
+			sql:           "UPDATE NATION SET N_NAME = 'updated'",
+			maxRows:       1,
+			wantTableLock: true,
+		},
+		{
+			name:          "unfiltered primary key update",
+			sql:           "UPDATE NATION SET N_NATIONKEY = N_NATIONKEY + 100",
+			maxRows:       1,
+			wantTableLock: true,
+		},
+		{
+			name:          "literal true is statically unrestricted",
+			sql:           "UPDATE NATION SET N_NAME = 'updated' WHERE TRUE",
+			maxRows:       1,
+			wantTableLock: true,
+		},
+		{
+			name:          "partitioned full update",
+			sql:           "UPDATE NATION SET N_NAME = 'updated'",
+			maxRows:       1,
+			wantTableLock: true,
+			prepare: func(mock *MockOptimizer) {
+				mock.ctxt.tables["nation"].FeatureFlag |= features.Partitioned
+				mock.ctxt.tables["nation"].Partition = &plan.Partition{
+					PartitionDefs: []*plan.PartitionDef{{
+						Def: &plan.Expr{Expr: &plan.Expr_F{F: &plan.Function{Args: []*plan.Expr{
+							{Expr: &plan.Expr_Col{Col: &plan.ColRef{Name: "n_nationkey"}}},
+						}}}},
+					}},
+				}
+			},
+		},
+		{
+			name:    "bounded predicate stays row scoped",
+			sql:     "UPDATE NATION SET N_NAME = 'updated' WHERE N_NATIONKEY >= 0",
+			maxRows: 1,
+		},
+		{
+			name:    "constant false stays row scoped",
+			sql:     "UPDATE NATION SET N_NAME = 'updated' WHERE FALSE",
+			maxRows: 1,
+		},
+		{
+			name:    "nonliteral tautology is conservatively row scoped",
+			sql:     "UPDATE NATION SET N_NAME = 'updated' WHERE 1 = 1",
+			maxRows: 1,
+		},
+		{
+			name:    "ordered limit stays row scoped",
+			sql:     "UPDATE NATION SET N_NAME = 'updated' ORDER BY N_NATIONKEY LIMIT 10",
+			maxRows: 1,
+		},
+		{
+			name: "joined source stays row scoped",
+			sql: "UPDATE NATION n JOIN NATION2 n2 ON n.N_NATIONKEY = n2.N_NATIONKEY " +
+				"SET n.N_NAME = 'updated'",
+			maxRows: 1,
+		},
+		{
+			name:    "update from stays row scoped",
+			sql:     "UPDATE NATION n SET n.N_NAME = 'updated' FROM NATION2 n2 WHERE n.N_NATIONKEY = n2.N_NATIONKEY",
+			maxRows: 1,
+		},
+		{
+			name:          "small full update stays row scoped",
+			sql:           "UPDATE NATION SET N_NAME = 'updated'",
+			maxRows:       1 << 30,
+			wantTableLock: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			if test.prepare != nil {
+				test.prepare(mock)
+			}
+			proc := testutil.NewProc(t)
+			lockService := mock_lock.NewMockLockService(gomock.NewController(t))
+			lockService.EXPECT().GetConfig().Return(lockservice.Config{
+				ServiceID:       "plan-test",
+				MaxLockRowCount: toml.ByteSize(test.maxRows),
+			}).AnyTimes()
+			proc.Base.LockService = lockService
+			rt := moruntime.ServiceRuntime(proc.GetService())
+			if rt == nil {
+				rt = moruntime.DefaultRuntime()
+				moruntime.SetupServiceBasedRuntime(proc.GetService(), rt)
+			}
+			rt.SetGlobalVariables("optimizer_hints", "")
+			mock.ctxt.GetProcessFunc = func() *process.Process { return proc }
+
+			logicPlan, err := runOneStmt(mock, t, test.sql)
+			require.NoError(t, err)
+
+			exclusiveTargets := 0
+			for _, node := range logicPlan.GetQuery().Nodes {
+				if node.NodeType != plan.Node_LOCK_OP {
+					continue
+				}
+				for _, target := range node.LockTargets {
+					if target.Mode != lockpb.LockMode_Exclusive {
+						continue
+					}
+					exclusiveTargets++
+					require.Equal(t, test.wantTableLock, target.LockTable)
+				}
+			}
+			require.NotZero(t, exclusiveTargets)
+		})
+	}
+}
+
+func TestLargeUnrestrictedIndexedUpdateLocksEveryWrittenNamespace(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		sql           string
+		wantTableLock bool
+	}{
+		{
+			name:          "full update",
+			sql:           "UPDATE index_hint_t SET a = a + 1",
+			wantTableLock: true,
+		},
+		{
+			name: "bounded update",
+			sql:  "UPDATE index_hint_t SET a = a + 1 WHERE id >= 0",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			addIndexHintChoiceTableForTest(mock)
+			proc := testutil.NewProc(t)
+			lockService := mock_lock.NewMockLockService(gomock.NewController(t))
+			lockService.EXPECT().GetConfig().Return(lockservice.Config{
+				ServiceID:       "plan-test",
+				MaxLockRowCount: 1,
+			}).AnyTimes()
+			proc.Base.LockService = lockService
+			rt := moruntime.ServiceRuntime(proc.GetService())
+			if rt == nil {
+				rt = moruntime.DefaultRuntime()
+				moruntime.SetupServiceBasedRuntime(proc.GetService(), rt)
+			}
+			rt.SetGlobalVariables("optimizer_hints", "")
+			mock.ctxt.GetProcessFunc = func() *process.Process { return proc }
+
+			logicPlan, err := runOneStmt(mock, t, test.sql)
+			require.NoError(t, err)
+
+			targetTables := make(map[uint64]struct{})
+			exclusiveTargets := 0
+			for _, node := range logicPlan.GetQuery().Nodes {
+				if node.NodeType != plan.Node_LOCK_OP {
+					continue
+				}
+				for _, target := range node.LockTargets {
+					if target.Mode != lockpb.LockMode_Exclusive {
+						continue
+					}
+					exclusiveTargets++
+					targetTables[target.TableId] = struct{}{}
+					require.Equal(t, test.wantTableLock, target.LockTable)
+				}
+			}
+			require.GreaterOrEqual(t, exclusiveTargets, 2,
+				"base and affected unique-index namespaces must both be locked")
+			require.GreaterOrEqual(t, len(targetTables), 2)
 		})
 	}
 }
@@ -3000,10 +3182,16 @@ func TestLargeSharedLockTargetsKeepBoundedFallback(t *testing.T) {
 	}
 }
 
-func TestApplySharedLockTableFallbackGuardsAndModes(t *testing.T) {
+func TestApplyLockTableFallbackGuardsAndModes(t *testing.T) {
 	mock := NewMockOptimizer(true)
+	markedAtBoundary := &plan.LockTarget{Mode: lockpb.LockMode_Exclusive}
+	markedAboveBoundary := &plan.LockTarget{Mode: lockpb.LockMode_Exclusive}
 	builder := &QueryBuilder{
 		compCtx: &mock.ctxt,
+		fullTableUpdateLockTargets: map[*plan.LockTarget]struct{}{
+			markedAtBoundary:    {},
+			markedAboveBoundary: {},
+		},
 		qry: &plan.Query{Nodes: []*plan.Node{
 			{NodeType: plan.Node_TABLE_SCAN, Stats: &plan.Stats{Outcnt: 100}},
 			{NodeType: plan.Node_LOCK_OP},
@@ -3011,15 +3199,16 @@ func TestApplySharedLockTableFallbackGuardsAndModes(t *testing.T) {
 				NodeType: plan.Node_LOCK_OP,
 				Stats:    &plan.Stats{Outcnt: 3},
 				LockTargets: []*plan.LockTarget{
-					{Mode: lockpb.LockMode_Shared},
+					markedAtBoundary,
 				},
 			},
 			{
 				NodeType: plan.Node_LOCK_OP,
 				Stats:    &plan.Stats{Outcnt: 4},
 				LockTargets: []*plan.LockTarget{
-					{Mode: lockpb.LockMode_Exclusive},
+					markedAboveBoundary,
 					{Mode: lockpb.LockMode_Shared},
+					{Mode: lockpb.LockMode_Exclusive},
 				},
 			},
 		}},
@@ -3028,10 +3217,10 @@ func TestApplySharedLockTableFallbackGuardsAndModes(t *testing.T) {
 	// Planning without a process or without a real lock service is valid for
 	// internal and mock compiler contexts.
 	mock.ctxt.GetProcessFunc = func() *process.Process { return nil }
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
 	proc := testutil.NewProc(t)
 	mock.ctxt.GetProcessFunc = func() *process.Process { return proc }
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
 
 	lockService := mock_lock.NewMockLockService(gomock.NewController(t))
 	gomock.InOrder(
@@ -3039,15 +3228,17 @@ func TestApplySharedLockTableFallbackGuardsAndModes(t *testing.T) {
 		lockService.EXPECT().GetConfig().Return(lockservice.Config{MaxLockRowCount: 3}),
 	)
 	proc.Base.LockService = lockService
-	applySharedLockTableFallback(builder)
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
+	applyLockTableFallback(builder)
 
 	require.False(t, builder.qry.Nodes[2].LockTargets[0].LockTable,
 		"the configured budget is inclusive")
-	require.False(t, builder.qry.Nodes[3].LockTargets[0].LockTable,
-		"exclusive targets are bounded by owner-side range escalation")
+	require.True(t, builder.qry.Nodes[3].LockTargets[0].LockTable,
+		"a proven full-table update upgrades above the configured budget")
 	require.True(t, builder.qry.Nodes[3].LockTargets[1].LockTable,
 		"cardinality-known shared targets must upgrade before acquisition")
+	require.False(t, builder.qry.Nodes[3].LockTargets[2].LockTable,
+		"unmarked exclusive targets retain owner-side range escalation")
 }
 
 func TestInsertIntoMarkedTemporaryTableUsesModernPath(t *testing.T) {

--- a/pkg/sql/plan/build_util.go
+++ b/pkg/sql/plan/build_util.go
@@ -47,9 +47,10 @@ import (
 // first row lock is acquired. Shared targets need this planner fallback because
 // converting already-shared rows is not always possible without changing
 // Shared compatibility. Exclusive targets normally coarsen on the owner side;
-// the only planner exception is a statically unrestricted single-target UPDATE,
-// whose target universe is exactly the whole table. Bounded predicates must
-// retain row/range locks even when their estimated cardinality is large.
+// the only planner exception is an admitted unrestricted single-target UPDATE:
+// its target universe is the whole table, every written keyspace has a total
+// range, and no earlier lock target would have its order reversed. Bounded
+// predicates retain row/range locks even when their estimate is large.
 func applyLockTableFallback(builder *QueryBuilder) {
 	proc := builder.compCtx.GetProcess()
 	if proc == nil || proc.Base.LockService == nil {

--- a/pkg/sql/plan/build_util.go
+++ b/pkg/sql/plan/build_util.go
@@ -43,14 +43,14 @@ import (
 // 	return nodeID
 // }
 
-// applySharedLockTableFallback upgrades cardinality-known shared lock targets
-// before their first row lock is acquired. An exclusive owner can safely
-// coarsen its own rows later, but a shared row may already have other holders;
-// converting that ownership in the middle of a transaction is not always
-// possible without changing Shared compatibility. Estimates that are low and
-// transactions with many statements retain exact Shared rows up to the fixed
-// bookkeeping-pool ceiling rather than changing lock semantics at this budget.
-func applySharedLockTableFallback(builder *QueryBuilder) {
+// applyLockTableFallback upgrades cardinality-known lock targets before their
+// first row lock is acquired. Shared targets need this planner fallback because
+// converting already-shared rows is not always possible without changing
+// Shared compatibility. Exclusive targets normally coarsen on the owner side;
+// the only planner exception is a statically unrestricted single-target UPDATE,
+// whose target universe is exactly the whole table. Bounded predicates must
+// retain row/range locks even when their estimated cardinality is large.
+func applyLockTableFallback(builder *QueryBuilder) {
 	proc := builder.compCtx.GetProcess()
 	if proc == nil || proc.Base.LockService == nil {
 		return
@@ -68,6 +68,10 @@ func applySharedLockTableFallback(builder *QueryBuilder) {
 		}
 		for _, target := range node.LockTargets {
 			if target.Mode == lockpb.LockMode_Shared {
+				target.LockTable = true
+				continue
+			}
+			if _, ok := builder.fullTableUpdateLockTargets[target]; ok {
 				target.LockTable = true
 			}
 		}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -3755,7 +3755,7 @@ func (builder *QueryBuilder) createQuery() (*Query, error) {
 			}
 		}
 	}
-	applySharedLockTableFallback(builder)
+	applyLockTableFallback(builder)
 
 	for i := range builder.qry.Steps {
 		rootID := builder.qry.Steps[i]

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -362,6 +362,11 @@ type QueryBuilder struct {
 	preserveInsertProjection    map[int32]struct{}
 	preserveScanProjection      map[int32]struct{}
 	positionalSinkScans         map[int32]struct{}
+	// fullTableUpdateLockTargets contains only the exclusive targets produced by
+	// a statically unrestricted, single-target UPDATE. Keeping the proof as
+	// planner-local metadata lets the final cardinality pass choose table locks
+	// without weakening bounded UPDATE predicates into table-wide locks.
+	fullTableUpdateLockTargets map[*plan.LockTarget]struct{}
 	// userWindowNodes contains only WINDOW nodes produced from user
 	// SELECT window expressions. Internal ROW_NUMBER windows used by correlated
 	// LIMIT and DML deduplication must stay on their dedicated paths.

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -362,10 +362,10 @@ type QueryBuilder struct {
 	preserveInsertProjection    map[int32]struct{}
 	preserveScanProjection      map[int32]struct{}
 	positionalSinkScans         map[int32]struct{}
-	// fullTableUpdateLockTargets contains only the exclusive targets produced by
-	// a statically unrestricted, single-target UPDATE. Keeping the proof as
-	// planner-local metadata lets the final cardinality pass choose table locks
-	// without weakening bounded UPDATE predicates into table-wide locks.
+	// fullTableUpdateLockTargets contains only the exclusive targets admitted for
+	// an unrestricted, single-target UPDATE after complete-keyspace and lock-order
+	// checks. Planner-local metadata lets the final cardinality pass choose table
+	// locks without weakening bounded UPDATE predicates into table-wide locks.
 	fullTableUpdateLockTargets map[*plan.LockTarget]struct{}
 	// userWindowNodes contains only WINDOW nodes produced from user
 	// SELECT window expressions. Internal ROW_NUMBER windows used by correlated


### PR DESCRIPTION
Fixes #27853

## Why

The owner-side row-lock fallback preserves concurrency for bounded UPDATE predicates, but an unrestricted large UPDATE still pays per-row lock construction and acquisition costs. A controlled 1M-row reproduction shows the Lock operator dominates the regression.

## Design

Upgrade an UPDATE lock target only when all conditions hold:

- SQL semantics prove one unrestricted target table: no predicate except literal TRUE, no UPDATE FROM or joined/multi-table source, no ORDER BY, and no LIMIT.
- Every exclusive base/index lock namespace has a proven full-domain table range. FLOAT/DOUBLE and unknown/future key types remain row/range scoped.
- No foreign-key action, validation, or explicitly locking subquery has already established an earlier lock order.
- The optimized LOCK_OP cardinality exceeds MaxLockRowCount.

The proof is attached only to the exact exclusive lock targets produced for that UPDATE, including affected unique-index namespaces. Admission is atomic: if any written namespace is unsafe, none are pre-locked. Bounded predicates remain row/range scoped even if statistics estimate that they currently match every row. Existing shared-lock fallback behavior is unchanged.

## Test plan

- mo-cgo-test -race for the new planner and lock-range cases: passed.
- mo-cgo-test -count=1 -timeout=15m ./pkg/sql/plan: passed repeatedly after final changes.
- Full pkg/sql/colexec and pkg/sql/colexec/lockop tests: passed.
- Planner cases: unrestricted UPDATE, literal TRUE, primary-key update, partitioned table, affected unique index, bounded predicate, FALSE, nonliteral tautology, ORDER BY/LIMIT, JOIN, UPDATE FROM, small-table threshold, missing process/lock service, inclusive threshold, shared and unmarked exclusive targets, incomplete FLOAT/DOUBLE keyspaces, affected versus unrelated FK columns, and a FOR UPDATE scalar subquery.
- All 256 type IDs are checked against physical lock-range support so unknown/future IDs fail closed without panic.
- 55 host clean candidate build: make clean && make -j12 passed.
- 1M rows, 26-column table, PK + secondary index + unique index, same data directory and alternating +1/-1 updates:
  - unmodified main median: 10.42s over 6 runs
  - candidate median: 6.35s over 10 runs split before and after the main run
  - about 39% lower wall time, or 1.64x throughput
  - EXPLAIN ANALYZE Lock cumulative time: 83,077ms on main versus 0ms on candidate
- Runtime lock counterexample:
  - unrestricted UPDATE held a full-domain exclusive range; a competing point UPDATE waited for the statement
  - id <= 500000 held a bounded range; an out-of-range point UPDATE completed in 24ms while the large UPDATE was still running
- Real correctness matrix on 55: PK update, no-PK hidden rowid, four partitions, nullable unique index, WHERE FALSE, ORDER BY/LIMIT, JOIN UPDATE, forced-index scans; verified counts, sums, min/max, distinct keys, and restored baselines.

The host had unrelated system-disk load during wall-time sampling, so the reported result uses all runs and cross-over ordering rather than the best observed run.

Follow-up: #27947 tracks the pre-existing Shared FLOAT/DOUBLE full-range gap; the new Exclusive UPDATE admission in this PR fails closed for unsupported total ranges.
