### PR TITLE
fix(iscp): isolate init jobs from shared iterations

### DIFF
--- a/pkg/iscp/consumer_entry.go
+++ b/pkg/iscp/consumer_entry.go
@@ -58,8 +58,10 @@ func NewJobEntryWithStatus(
 	dropAt types.Timestamp,
 ) *JobEntry {
 	var currentLSN uint64
+	stage := int8(JobStage_Running)
 	if jobStatus != nil {
 		currentLSN = jobStatus.LSN
+		stage = jobStatus.Stage
 	}
 	jobEntry := &JobEntry{
 		tableInfo:          tableInfo,
@@ -69,6 +71,7 @@ func NewJobEntryWithStatus(
 		watermark:          watermark,
 		persistedWatermark: watermark,
 		state:              state,
+		stage:              stage,
 		dropAt:             dropAt,
 		currentLSN:         currentLSN,
 		// Only the trigger spec is retained, so the consumer class is recorded
@@ -91,6 +94,12 @@ func (jobEntry *JobEntry) update(
 	jobEntry.dropAt = dropAt
 	if jobEntry.state == ISCPJobState_Error {
 		return
+	}
+	// Stage is monotonic within one job generation. In particular, InitSQL
+	// completion can persist Init -> Running without changing the job LSN or
+	// iteration state, so retain that transition independently of progress.
+	if jobEntry.stage < jobStatus.Stage {
+		jobEntry.stage = jobStatus.Stage
 	}
 	needApply := false
 	if jobEntry.currentLSN < jobStatus.LSN {

--- a/pkg/iscp/executor_test.go
+++ b/pkg/iscp/executor_test.go
@@ -171,6 +171,70 @@ func TestNewJobEntryRestoresPersistedLSN(t *testing.T) {
 	require.Equal(t, uint64(5), job.currentLSN)
 }
 
+func TestTableEntryDoesNotShareInitIterations(t *testing.T) {
+	exec := newRuntimeTestExecutor()
+	table := NewTableEntry(exec, 1, 2, 3, "db", "table")
+	spec := &JobSpec{
+		ConsumerInfo: ConsumerInfo{InitSQL: "select 1"},
+		TriggerSpec:  TriggerSpec{JobType: TriggerType_Default},
+	}
+	watermark := types.BuildTS(10, 0)
+	for i, name := range []string{"index_ft", "index_hv"} {
+		table.AddOrUpdateSinker(
+			context.Background(),
+			name,
+			spec,
+			&JobStatus{LSN: 5, Stage: JobStage_Init},
+			uint64(i+1),
+			watermark,
+			ISCPJobState_Completed,
+			0,
+		)
+	}
+
+	iters, _ := table.getCandidate()
+	require.Len(t, iters, 2)
+	for _, iter := range iters {
+		require.Len(t, iter.jobNames, 1)
+	}
+
+	// Once one job has initialized, it must still not share an iteration with
+	// the other job while that job remains in the Init stage.
+	table.AddOrUpdateSinker(
+		context.Background(),
+		"index_ft",
+		spec,
+		&JobStatus{LSN: 5, Stage: JobStage_Running},
+		1,
+		watermark,
+		ISCPJobState_Completed,
+		0,
+	)
+	require.Equal(t, int8(JobStage_Running), table.jobs[JobKey{JobName: "index_ft", JobID: 1}].stage)
+	require.Equal(t, uint64(5), table.jobs[JobKey{JobName: "index_ft", JobID: 1}].currentLSN)
+	iters, _ = table.getCandidate()
+	require.Len(t, iters, 2)
+	for _, iter := range iters {
+		require.Len(t, iter.jobNames, 1)
+	}
+
+	// Normal running jobs retain the existing shared-iteration behavior.
+	table.AddOrUpdateSinker(
+		context.Background(),
+		"index_hv",
+		spec,
+		&JobStatus{LSN: 5, Stage: JobStage_Running},
+		2,
+		watermark,
+		ISCPJobState_Completed,
+		0,
+	)
+	require.Equal(t, int8(JobStage_Running), table.jobs[JobKey{JobName: "index_hv", JobID: 2}].stage)
+	iters, _ = table.getCandidate()
+	require.Len(t, iters, 1)
+	require.ElementsMatch(t, []string{"index_ft", "index_hv"}, iters[0].jobNames)
+}
+
 func TestPublishRebuiltStateReplacesAbandonedGeneration(t *testing.T) {
 	exec := &ISCPTaskExecutor{tables: newISCPTableTree()}
 	oldTable := NewTableEntry(exec, 1, 2, 3, "db", "table")

--- a/pkg/iscp/table_entry.go
+++ b/pkg/iscp/table_entry.go
@@ -157,6 +157,7 @@ func (t *TableEntry) getCandidate() (iter []*IterationContext, minFromTS types.T
 		candidates = append(candidates, sinker)
 	}
 	iterations := make([]*IterationContext, 0, len(candidates))
+	shareableIterations := make([]*IterationContext, 0, len(candidates))
 	minFromTS = types.MaxTs()
 	for _, sinker := range candidates {
 		if sinker.watermark.IsEmpty() && sinker.state == ISCPJobState_Completed {
@@ -175,9 +176,14 @@ func (t *TableEntry) getCandidate() (iter []*IterationContext, minFromTS types.T
 		if !ok {
 			continue
 		}
+		// InitSQL is executed for exactly one job at a time. Keep its iteration
+		// out of the shared pool until the durable stage advances to Running.
+		if sinker.stage == JobStage_Init {
+			share = false
+		}
 		foundIteration := false
 		if share {
-			for _, iter := range iterations {
+			for _, iter := range shareableIterations {
 				if iter.fromTS.EQ(&from) && iter.toTS.EQ(&to) {
 					iter.jobNames = append(iter.jobNames, sinker.jobName)
 					iter.jobIDs = append(iter.jobIDs, sinker.jobID)
@@ -188,7 +194,7 @@ func (t *TableEntry) getCandidate() (iter []*IterationContext, minFromTS types.T
 			}
 		}
 		if !foundIteration {
-			iterations = append(iterations, &IterationContext{
+			iter := &IterationContext{
 				tableID:   t.tableID,
 				accountID: t.accountID,
 				jobNames:  []string{sinker.jobName},
@@ -196,7 +202,11 @@ func (t *TableEntry) getCandidate() (iter []*IterationContext, minFromTS types.T
 				lsn:       []uint64{sinker.currentLSN + 1},
 				fromTS:    from,
 				toTS:      to,
-			})
+			}
+			iterations = append(iterations, iter)
+			if sinker.stage != JobStage_Init {
+				shareableIterations = append(shareableIterations, iter)
+			}
 			if from.LT(&minFromTS) {
 				minFromTS = from
 			}

--- a/pkg/iscp/types.go
+++ b/pkg/iscp/types.go
@@ -203,6 +203,7 @@ type JobEntry struct {
 	watermark          types.TS
 	persistedWatermark types.TS
 	state              int8
+	stage              int8
 	dropAt             types.Timestamp
 	currentLSN         uint64
 	// isIndexJob marks a ConsumerType_IndexSync job, whose watermark is flushed

--- a/test/distributed/cases/git4data/branch/edge/branch_multi_index_restore_init.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_multi_index_restore_init.result
@@ -1,0 +1,114 @@
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+drop database if exists issue27950_branch_indexes;
+create database issue27950_branch_indexes;
+use issue27950_branch_indexes;
+create table base_t(
+id bigint primary key,
+body text,
+v vecf32(3)
+);
+insert into base_t values
+(1, 'alpha seed', '[1,0,0]'),
+(2, 'beta seed', '[0,1,0]');
+create fulltext2 index ft on base_t(body) max_index_capacity 64;
+create index hv using hnsw on base_t(v) op_type 'vector_l2_ops';
+alter table base_t alter reindex ft fulltext2 force_sync;
+alter table base_t alter reindex hv hnsw force_sync;
+data branch create table leaf_t from base_t;
+update leaf_t set body = 'branch token', v = '[9,0,0]' where id = 1;
+insert into leaf_t values (3, 'branch insert', '[0,0,0]');
+set @leaf_id = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = database() and relname = 'leaf_t'
+);
+set @leaf_ft2_index = (
+select index_table_name from mo_catalog.mo_indexes
+where table_id = @leaf_id and name = 'ft'
+and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+limit 1
+);
+set @leaf_ft2_ready_sql = concat(
+'select coalesce(max(chunk_id), -1) >= 0 as ready from `', database(), '`.`',
+@leaf_ft2_index, '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_leaf_ft2 from @leaf_ft2_ready_sql;
+set @leaf_hnsw_meta = (
+select index_table_name from mo_catalog.mo_indexes
+where table_id = @leaf_id and name = 'hv'
+and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+limit 1
+);
+set @leaf_hnsw_ready_sql = concat(
+'select count(*) > 0 as ready from `', database(), '`.`',
+@leaf_hnsw_meta, '`'
+);
+prepare wait_leaf_hnsw from @leaf_hnsw_ready_sql;
+execute wait_leaf_ft2;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_leaf_ft2;
+execute wait_leaf_hnsw;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_leaf_hnsw;
+select count(*) from mo_catalog.mo_iscp_log
+where table_id = @leaf_id and drop_at is null
+and job_name in ('index_ft', 'index_hv')
+and job_state = 4;
+➤ count(*)[-5,64,0]  𝄀
+0
+explain select id from leaf_t
+where match(body) against('+branch' in boolean mode) order by id;
+-- @regex("Table Function on fulltext2_search", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: leaf_t.id INTERNAL  𝄀
+        ->  Sort  𝄀
+              Sort Key: mo_fulltext_alias_0.__mo_ft_score DESC  𝄀
+              ->  Join  𝄀
+                    Join Type: INNER  𝄀
+                    Join Cond: (leaf_t.id = mo_fulltext_alias_0.__mo_ft_doc_id)  𝄀
+                    Runtime Filter Build: #[-1,0]  𝄀
+                    ->  Table Scan on issue27950_branch_indexes.leaf_t  𝄀
+                          Runtime Filter Probe: leaf_t.id  𝄀
+                    ->  Table Function on fulltext2_search
+select id from leaf_t
+where match(body) against('+branch' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+3
+explain select id from leaf_t
+order by l2_distance(v, '[0,0,0]') limit 2;
+-- @regex("Table Function on hnsw_search", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Sort  𝄀
+        Sort Key: mo_hnsw_alias_0.score INTERNAL  𝄀
+        Limit: 2  𝄀
+        ->  Join  𝄀
+              Join Type: INNER  𝄀
+              Join Cond: (leaf_t.id = mo_hnsw_alias_0.pkid)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on issue27950_branch_indexes.leaf_t  𝄀
+                    Runtime Filter Probe: leaf_t.id  𝄀
+              ->  Table Function on hnsw_search  𝄀
+                    Index Reader Param:  Limit: 2  𝄀
+                    Limit: 2
+select id from leaf_t
+order by l2_distance(v, '[0,0,0]') limit 2;
+➤ id[-5,64,0]  𝄀
+3  𝄀
+2
+select id from leaf_t
+order by (l2_distance(v, '[0,0,0]') + 0) limit 2;
+➤ id[-5,64,0]  𝄀
+3  𝄀
+2
+data branch diff leaf_t against base_t output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+2
+drop database issue27950_branch_indexes;
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;

--- a/test/distributed/cases/git4data/branch/edge/branch_multi_index_restore_init.sql
+++ b/test/distributed/cases/git4data/branch/edge/branch_multi_index_restore_init.sql
@@ -1,0 +1,93 @@
+-- A DATA BRANCH restores every derived index on the new base-table ID. When
+-- two restore jobs start from the same watermark, each InitSQL must run in its
+-- own ISCP iteration before either index is queried.
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+
+drop database if exists issue27950_branch_indexes;
+create database issue27950_branch_indexes;
+use issue27950_branch_indexes;
+
+create table base_t(
+  id bigint primary key,
+  body text,
+  v vecf32(3)
+);
+insert into base_t values
+  (1, 'alpha seed', '[1,0,0]'),
+  (2, 'beta seed', '[0,1,0]');
+create fulltext2 index ft on base_t(body) max_index_capacity 64;
+create index hv using hnsw on base_t(v) op_type 'vector_l2_ops';
+alter table base_t alter reindex ft fulltext2 force_sync;
+alter table base_t alter reindex hv hnsw force_sync;
+
+data branch create table leaf_t from base_t;
+update leaf_t set body = 'branch token', v = '[9,0,0]' where id = 1;
+insert into leaf_t values (3, 'branch insert', '[0,0,0]');
+
+set @leaf_id = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = database() and relname = 'leaf_t'
+);
+set @leaf_ft2_index = (
+  select index_table_name from mo_catalog.mo_indexes
+  where table_id = @leaf_id and name = 'ft'
+    and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+  limit 1
+);
+set @leaf_ft2_ready_sql = concat(
+  'select coalesce(max(chunk_id), -1) >= 0 as ready from `', database(), '`.`',
+  @leaf_ft2_index, '` where index_id = ''cdc_tail'' and tag = 1'
+);
+prepare wait_leaf_ft2 from @leaf_ft2_ready_sql;
+set @leaf_hnsw_meta = (
+  select index_table_name from mo_catalog.mo_indexes
+  where table_id = @leaf_id and name = 'hv'
+    and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+  limit 1
+);
+set @leaf_hnsw_ready_sql = concat(
+  'select count(*) > 0 as ready from `', database(), '`.`',
+  @leaf_hnsw_meta, '`'
+);
+prepare wait_leaf_hnsw from @leaf_hnsw_ready_sql;
+
+-- FULLTEXT2 publishes cdc_tail only after durable hidden storage is ready;
+-- HNSW publishes metadata only after its FORCE_SYNC RestoreInitSQL completes.
+-- @wait_expect(1, 60)
+execute wait_leaf_ft2;
+deallocate prepare wait_leaf_ft2;
+-- @wait_expect(1, 60)
+execute wait_leaf_hnsw;
+deallocate prepare wait_leaf_hnsw;
+
+-- Neither restore job may retain the permanent scheduler error caused by a
+-- shared Init iteration. The hidden-table waits above are the readiness guard
+-- before proving the optimizer paths.
+select count(*) from mo_catalog.mo_iscp_log
+where table_id = @leaf_id and drop_at is null
+  and job_name in ('index_ft', 'index_hv')
+  and job_state = 4;
+
+-- These assertions prove the fixed special-index paths, not a base-table
+-- fallback. The independent distance expression remains the exact oracle.
+-- @separator:table
+-- @regex("Table Function on fulltext2_search", true)
+explain select id from leaf_t
+where match(body) against('+branch' in boolean mode) order by id;
+select id from leaf_t
+where match(body) against('+branch' in boolean mode) order by id;
+
+-- @separator:table
+-- @regex("Table Function on hnsw_search", true)
+explain select id from leaf_t
+order by l2_distance(v, '[0,0,0]') limit 2;
+select id from leaf_t
+order by l2_distance(v, '[0,0,0]') limit 2;
+select id from leaf_t
+order by (l2_distance(v, '[0,0,0]') + 0) limit 2;
+data branch diff leaf_t against base_t output count;
+
+drop database issue27950_branch_indexes;
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Tool
- [ ] Other

## Which issue(s) this PR fixes:

Related to #27950

## What this PR does / why we need it:

### Root cause

`DATA BRANCH CREATE TABLE` registers one restore job per derived index. FULLTEXT2 and HNSW restore jobs use the same source table and start watermark, so the ISCP scheduler grouped them into one shared iteration. The executor's InitSQL contract is single-job only; the grouped iteration therefore emitted a permanent error and did not initialize both branch indexes.

The scheduler retained job state and LSN but discarded the durable `JobStatus.Stage`, so it could not distinguish an Init job from a normal Running job while forming shared iterations.

### Changes

- Retain each ISCP job's durable stage in `JobEntry`, including same-LSN Init-to-Running transitions after InitSQL completes.
- Keep Init jobs out of the shared-iteration pool. Once they reach Running, they use the existing sharing behavior again.
- Add deterministic unit coverage for two same-watermark Init jobs, a mixed Init/Running pair, and normal Running-job sharing.
- Add Git4Data BVT coverage for a table branch carrying FULLTEXT2 and HNSW together. It waits on each hidden index's durable readiness signal, verifies no live restore task is permanently errored, confirms both optimizer index paths, compares HNSW with an independent base-table oracle, checks FULLTEXT2 branch terms, and preserves the `DATA BRANCH DIFF` result.

### Issue-to-test proof

- #27950 scheduler root cause: `TestTableEntryDoesNotShareInitIterations` fails before this change because the two Init jobs form one iteration; it passes with two isolated iterations and verifies sharing resumes after both jobs are Running.
- #27950 SQL behavior: `branch_multi_index_restore_init.sql` covers the reported branch `UPDATE` + `INSERT`, FULLTEXT2 result `1,3`, HNSW and oracle result `3,2` (ascending distances 0 then 1), optimizer selection of `fulltext2_search` and `hnsw_search`, and `DIFF = 2`.

### Tests run

- `make build`
- `make build-with-prebuilt-native`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=15m ./pkg/iscp`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=10m ./pkg/iscp -run '^(TestTableEntryDoesNotShareInitIterations|TestMarkIterationPendingIsAtomic)$'`
- `mo-tester` `branch_multi_index_restore_init`: 35/35 passed, 100%, twice consecutively on a fresh local deployment
- Post-rebase on `a2d9070974`: `make build`
- Post-rebase on `a2d9070974`: `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=10m ./pkg/iscp -run '^TestTableEntryDoesNotShareInitIterations$'`
- Post-rebase DDL consumer check on `a2d9070974`: `mo-tester` `branch_multi_index_restore_init`, 35/35 passed twice against the same isolated 1 CN / 1 TN / 1 Log data instance; teardown database count independently verified as 0

### Residual risk

Init jobs now occupy separate worker iterations and may execute concurrently, as ordinary independent ISCP work already does. Existing admission, retry, fencing, and per-table catalog locking remain unchanged. The combined FULLTEXT2/HNSW BVT exercises this path. Normal asynchronous maintenance lag semantics are unchanged.
