### PR TITLE
test: cover mixed Fulltext2 and HNSW clones

### DIFF
--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_hnsw_clone.result
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_hnsw_clone.result
@@ -1,0 +1,348 @@
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+drop database if exists ft2_hnsw_table_clone;
+create database ft2_hnsw_table_clone;
+use ft2_hnsw_table_clone;
+create table src(id bigint primary key, body text, v vecf32(3));
+create fulltext2 index ft on src(body);
+create index hnsw_idx using hnsw on src(v) op_type 'vector_l2_ops' max_index_capacity 1000;
+insert into src values
+(1, 'alpha copied', '[0,0,0]'),
+(2, 'beta copied', '[10,10,10]');
+set @t_src_ft = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @t_src_hmeta = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @t_src_ready_sql = concat(
+'select coalesce((select max(chunk_id) >= 0 from `', database(), '`.`', @t_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), false) and ',
+'(select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @t_src_hmeta, '`) as ready'
+);
+prepare wait_t_src_ready from @t_src_ready_sql;
+execute wait_t_src_ready;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_t_src_ready;
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;
+create table dst clone src;
+set @t_dst_ft = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+limit 1
+);
+set @t_dst_hmeta = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+limit 1
+);
+set @t_dst_ready_sql = concat(
+'select (select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @t_dst_hmeta, '`) as ready'
+);
+prepare wait_t_dst_ready from @t_dst_ready_sql;
+execute wait_t_dst_ready;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_t_dst_ready;
+set @t_before_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), ',
+'(select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_dst_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), ',
+'(select checksum from `', database(), '`.`', @t_src_hmeta, '` limit 1), ',
+'(select checksum from `', database(), '`.`', @t_dst_hmeta,
+'` limit 1) into @t_src_tail_before, @t_dst_tail_before, @t_src_h_before, @t_dst_h_before'
+);
+prepare capture_t_before from @t_before_sql;
+execute capture_t_before;
+deallocate prepare capture_t_before;
+insert into src values (4, 'alpha source incremental', '[0.1,0.1,0.1]');
+insert into dst values (3, 'alpha destination incremental', '[0.1,0.1,0.1]');
+set @t_tail_advanced_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1) > @t_src_tail_before and ',
+'(select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_dst_ft,
+'` where index_id = ''cdc_tail'' and tag = 1) > @t_dst_tail_before and ',
+'(select checksum from `', database(), '`.`', @t_src_hmeta, '` limit 1) <> @t_src_h_before and ',
+'(select checksum from `', database(), '`.`', @t_dst_hmeta, '` limit 1) <> @t_dst_h_before as ready'
+);
+prepare wait_t_tail_advanced from @t_tail_advanced_sql;
+execute wait_t_tail_advanced;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_t_tail_advanced;
+select id from src where match(body) against('alpha' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+4
+select id from dst where match(body) against('alpha' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+3
+select id from dst where match(body) against('beta' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+2
+select id from src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+➤ id[-5,64,0]  𝄀
+4  𝄀
+1
+select id from dst order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+➤ id[-5,64,0]  𝄀
+3  𝄀
+1
+create table dst clone src;
+table dst already exists
+select count(*) from dst;
+➤ count(*)[-5,64,0]  𝄀
+3
+drop database ft2_hnsw_table_clone;
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+drop database if exists ft2_hnsw_db_clone_src;
+drop database if exists ft2_hnsw_db_clone_dst;
+create database ft2_hnsw_db_clone_src;
+use ft2_hnsw_db_clone_src;
+create table src(id bigint primary key, body text, v vecf32(3));
+create fulltext2 index ft on src(body);
+create index hnsw_idx using hnsw on src(v) op_type 'vector_l2_ops' max_index_capacity 1000;
+insert into src values
+(1, 'alpha copied', '[0,0,0]'),
+(2, 'beta copied', '[10,10,10]');
+set @d_src_db = database();
+set @d_src_ft = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @d_src_hmeta = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @d_src_ready_sql = concat(
+'select coalesce((select max(chunk_id) >= 0 from `', @d_src_db, '`.`', @d_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), false) and ',
+'(select count(*) = 1 and min(filesize) > 0 from `', @d_src_db, '`.`', @d_src_hmeta, '`) as ready'
+);
+prepare wait_d_src_ready from @d_src_ready_sql;
+execute wait_d_src_ready;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_d_src_ready;
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;
+create database ft2_hnsw_db_clone_dst clone ft2_hnsw_db_clone_src;
+use ft2_hnsw_db_clone_dst;
+set @d_dst_db = database();
+set @d_dst_ft = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @d_dst_hmeta = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @d_dst_ready_sql = concat(
+'select (select count(*) = 1 and min(filesize) > 0 from `', @d_dst_db, '`.`', @d_dst_hmeta, '`) as ready'
+);
+prepare wait_d_dst_ready from @d_dst_ready_sql;
+execute wait_d_dst_ready;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_d_dst_ready;
+set @d_before_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', @d_src_db, '`.`', @d_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), ',
+'(select coalesce(max(chunk_id), -1) from `', @d_dst_db, '`.`', @d_dst_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), ',
+'(select checksum from `', @d_src_db, '`.`', @d_src_hmeta, '` limit 1), ',
+'(select checksum from `', @d_dst_db, '`.`', @d_dst_hmeta,
+'` limit 1) into @d_src_tail_before, @d_dst_tail_before, @d_src_h_before, @d_dst_h_before'
+);
+prepare capture_d_before from @d_before_sql;
+execute capture_d_before;
+deallocate prepare capture_d_before;
+insert into ft2_hnsw_db_clone_src.src values (4, 'alpha source incremental', '[0.1,0.1,0.1]');
+insert into ft2_hnsw_db_clone_dst.src values (3, 'alpha destination incremental', '[0.1,0.1,0.1]');
+set @d_tail_advanced_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', @d_src_db, '`.`', @d_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1) > @d_src_tail_before and ',
+'(select coalesce(max(chunk_id), -1) from `', @d_dst_db, '`.`', @d_dst_ft,
+'` where index_id = ''cdc_tail'' and tag = 1) > @d_dst_tail_before and ',
+'(select checksum from `', @d_src_db, '`.`', @d_src_hmeta, '` limit 1) <> @d_src_h_before and ',
+'(select checksum from `', @d_dst_db, '`.`', @d_dst_hmeta, '` limit 1) <> @d_dst_h_before as ready'
+);
+prepare wait_d_tail_advanced from @d_tail_advanced_sql;
+execute wait_d_tail_advanced;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_d_tail_advanced;
+select id from ft2_hnsw_db_clone_src.src where match(body) against('alpha' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+4
+select id from ft2_hnsw_db_clone_dst.src where match(body) against('alpha' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+3
+select id from ft2_hnsw_db_clone_dst.src where match(body) against('beta' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+2
+select id from ft2_hnsw_db_clone_src.src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+➤ id[-5,64,0]  𝄀
+4  𝄀
+1
+select id from ft2_hnsw_db_clone_dst.src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+➤ id[-5,64,0]  𝄀
+3  𝄀
+1
+create database ft2_hnsw_db_clone_dst clone ft2_hnsw_db_clone_src;
+database ft2_hnsw_db_clone_dst already exists
+select count(*) from ft2_hnsw_db_clone_dst.src;
+➤ count(*)[-5,64,0]  𝄀
+3
+drop database ft2_hnsw_db_clone_dst;
+drop database ft2_hnsw_db_clone_src;
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+drop database if exists ft2_hnsw_snapshot_clone;
+drop snapshot if exists ft2_hnsw_clone_sp;
+create database ft2_hnsw_snapshot_clone;
+use ft2_hnsw_snapshot_clone;
+create table src(id bigint primary key, body text, v vecf32(3));
+create fulltext2 index ft on src(body);
+create index hnsw_idx using hnsw on src(v) op_type 'vector_l2_ops' max_index_capacity 1000;
+insert into src values
+(1, 'alpha copied', '[0,0,0]'),
+(2, 'beta copied', '[10,10,10]');
+set @s_src_ft = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @s_src_hmeta = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+limit 1
+);
+set @s_src_ready_sql = concat(
+'select coalesce((select max(chunk_id) >= 0 from `', database(), '`.`', @s_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), false) and ',
+'(select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @s_src_hmeta, '`) as ready'
+);
+prepare wait_s_src_ready from @s_src_ready_sql;
+execute wait_s_src_ready;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_s_src_ready;
+set @s_src_before_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), ',
+'(select checksum from `', database(), '`.`', @s_src_hmeta,
+'` limit 1) into @s_src_tail_before, @s_src_h_before'
+);
+prepare capture_s_src_before from @s_src_before_sql;
+execute capture_s_src_before;
+deallocate prepare capture_s_src_before;
+create snapshot ft2_hnsw_clone_sp for table ft2_hnsw_snapshot_clone src;
+insert into src values (4, 'alpha source after snapshot', '[0.1,0.1,0.1]');
+set @s_src_advanced_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_src_ft,
+'` where index_id = ''cdc_tail'' and tag = 1) > @s_src_tail_before and ',
+'(select checksum from `', database(), '`.`', @s_src_hmeta, '` limit 1) <> @s_src_h_before as ready'
+);
+prepare wait_s_src_advanced from @s_src_advanced_sql;
+execute wait_s_src_advanced;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_s_src_advanced;
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;
+create table dst clone src {snapshot = 'ft2_hnsw_clone_sp'};
+set @s_dst_ft = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+limit 1
+);
+set @s_dst_hmeta = (
+select index_table_name from mo_catalog.mo_indexes
+where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+limit 1
+);
+set @s_dst_ready_sql = concat(
+'select (select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @s_dst_hmeta, '`) as ready'
+);
+prepare wait_s_dst_ready from @s_dst_ready_sql;
+execute wait_s_dst_ready;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_s_dst_ready;
+set @s_dst_before_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_dst_ft,
+'` where index_id = ''cdc_tail'' and tag = 1), ',
+'(select checksum from `', database(), '`.`', @s_dst_hmeta,
+'` limit 1) into @s_dst_tail_before, @s_dst_h_before'
+);
+prepare capture_s_dst_before from @s_dst_before_sql;
+execute capture_s_dst_before;
+deallocate prepare capture_s_dst_before;
+insert into dst values (3, 'alpha destination incremental', '[0.1,0.1,0.1]');
+set @s_dst_advanced_sql = concat(
+'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_dst_ft,
+'` where index_id = ''cdc_tail'' and tag = 1) > @s_dst_tail_before and ',
+'(select checksum from `', database(), '`.`', @s_dst_hmeta, '` limit 1) <> @s_dst_h_before as ready'
+);
+prepare wait_s_dst_advanced from @s_dst_advanced_sql;
+execute wait_s_dst_advanced;
+➤ ready[-7,1,0]  𝄀
+1
+deallocate prepare wait_s_dst_advanced;
+select id from src where match(body) against('alpha' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+4
+select id from dst where match(body) against('alpha' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+3
+select id from dst where match(body) against('beta' in boolean mode) order by id;
+➤ id[-5,64,0]  𝄀
+2
+select count(*) from dst where id = 4;
+➤ count(*)[-5,64,0]  𝄀
+0
+select id from src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+➤ id[-5,64,0]  𝄀
+4  𝄀
+1
+select id from dst order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+➤ id[-5,64,0]  𝄀
+3  𝄀
+1
+create table dst clone src {snapshot = 'ft2_hnsw_clone_sp'};
+table dst already exists
+select count(*) from dst;
+➤ count(*)[-5,64,0]  𝄀
+3
+drop snapshot ft2_hnsw_clone_sp;
+drop database ft2_hnsw_snapshot_clone;

--- a/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_hnsw_clone.sql
+++ b/test/distributed/cases/pessimistic_transaction/fulltext2/fulltext2_hnsw_clone.sql
@@ -1,0 +1,327 @@
+-- Regression for #27971: a clone may restore more than one CDC-backed index
+-- on the same table. Fulltext2's watermark InitSQL and HNSW's FORCE_SYNC
+-- reindex must both complete; neither CDC job may be left permanently failed.
+--
+-- Each scenario proves source and destination incremental maintenance with a
+-- durable Fulltext2 tail, an HNSW metadata generation change, MATCH, and an
+-- HNSW Top-K. The three clone syntaxes share Scope.RestoreTable but enter it
+-- through distinct DDL paths: table clone, database clone, and table snapshot
+-- clone. Experimental gates are off while cloning to verify existing indexes
+-- are restored rather than re-created through the gated DDL path.
+
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+
+-- ========================= table clone =========================
+drop database if exists ft2_hnsw_table_clone;
+create database ft2_hnsw_table_clone;
+use ft2_hnsw_table_clone;
+
+create table src(id bigint primary key, body text, v vecf32(3));
+create fulltext2 index ft on src(body);
+create index hnsw_idx using hnsw on src(v) op_type 'vector_l2_ops' max_index_capacity 1000;
+insert into src values
+    (1, 'alpha copied', '[0,0,0]'),
+    (2, 'beta copied', '[10,10,10]');
+
+set @t_src_ft = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @t_src_hmeta = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @t_src_ready_sql = concat(
+    'select coalesce((select max(chunk_id) >= 0 from `', database(), '`.`', @t_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), false) and ',
+    '(select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @t_src_hmeta, '`) as ready'
+);
+prepare wait_t_src_ready from @t_src_ready_sql;
+-- @wait_expect(2, 60)
+execute wait_t_src_ready;
+deallocate prepare wait_t_src_ready;
+
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;
+create table dst clone src;
+
+set @t_dst_ft = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+    limit 1
+);
+set @t_dst_hmeta = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+    limit 1
+);
+set @t_dst_ready_sql = concat(
+    'select (select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @t_dst_hmeta, '`) as ready'
+);
+prepare wait_t_dst_ready from @t_dst_ready_sql;
+-- @wait_expect(2, 60)
+execute wait_t_dst_ready;
+deallocate prepare wait_t_dst_ready;
+
+set @t_before_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), ',
+    '(select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_dst_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), ',
+    '(select checksum from `', database(), '`.`', @t_src_hmeta, '` limit 1), ',
+    '(select checksum from `', database(), '`.`', @t_dst_hmeta,
+    '` limit 1) into @t_src_tail_before, @t_dst_tail_before, @t_src_h_before, @t_dst_h_before'
+);
+prepare capture_t_before from @t_before_sql;
+execute capture_t_before;
+deallocate prepare capture_t_before;
+
+insert into src values (4, 'alpha source incremental', '[0.1,0.1,0.1]');
+insert into dst values (3, 'alpha destination incremental', '[0.1,0.1,0.1]');
+
+set @t_tail_advanced_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1) > @t_src_tail_before and ',
+    '(select coalesce(max(chunk_id), -1) from `', database(), '`.`', @t_dst_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1) > @t_dst_tail_before and ',
+    '(select checksum from `', database(), '`.`', @t_src_hmeta, '` limit 1) <> @t_src_h_before and ',
+    '(select checksum from `', database(), '`.`', @t_dst_hmeta, '` limit 1) <> @t_dst_h_before as ready'
+);
+prepare wait_t_tail_advanced from @t_tail_advanced_sql;
+-- @wait_expect(2, 60)
+execute wait_t_tail_advanced;
+deallocate prepare wait_t_tail_advanced;
+
+select id from src where match(body) against('alpha' in boolean mode) order by id;
+select id from dst where match(body) against('alpha' in boolean mode) order by id;
+select id from dst where match(body) against('beta' in boolean mode) order by id;
+select id from src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+select id from dst order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+
+-- Existing targets must remain unchanged when a duplicate clone is rejected.
+create table dst clone src;
+select count(*) from dst;
+drop database ft2_hnsw_table_clone;
+
+-- ========================= database clone =========================
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+drop database if exists ft2_hnsw_db_clone_src;
+drop database if exists ft2_hnsw_db_clone_dst;
+create database ft2_hnsw_db_clone_src;
+use ft2_hnsw_db_clone_src;
+
+create table src(id bigint primary key, body text, v vecf32(3));
+create fulltext2 index ft on src(body);
+create index hnsw_idx using hnsw on src(v) op_type 'vector_l2_ops' max_index_capacity 1000;
+insert into src values
+    (1, 'alpha copied', '[0,0,0]'),
+    (2, 'beta copied', '[10,10,10]');
+
+set @d_src_db = database();
+set @d_src_ft = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @d_src_hmeta = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @d_src_ready_sql = concat(
+    'select coalesce((select max(chunk_id) >= 0 from `', @d_src_db, '`.`', @d_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), false) and ',
+    '(select count(*) = 1 and min(filesize) > 0 from `', @d_src_db, '`.`', @d_src_hmeta, '`) as ready'
+);
+prepare wait_d_src_ready from @d_src_ready_sql;
+-- @wait_expect(2, 60)
+execute wait_d_src_ready;
+deallocate prepare wait_d_src_ready;
+
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;
+create database ft2_hnsw_db_clone_dst clone ft2_hnsw_db_clone_src;
+use ft2_hnsw_db_clone_dst;
+set @d_dst_db = database();
+set @d_dst_ft = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @d_dst_hmeta = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @d_dst_ready_sql = concat(
+    'select (select count(*) = 1 and min(filesize) > 0 from `', @d_dst_db, '`.`', @d_dst_hmeta, '`) as ready'
+);
+prepare wait_d_dst_ready from @d_dst_ready_sql;
+-- @wait_expect(2, 60)
+execute wait_d_dst_ready;
+deallocate prepare wait_d_dst_ready;
+
+set @d_before_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', @d_src_db, '`.`', @d_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), ',
+    '(select coalesce(max(chunk_id), -1) from `', @d_dst_db, '`.`', @d_dst_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), ',
+    '(select checksum from `', @d_src_db, '`.`', @d_src_hmeta, '` limit 1), ',
+    '(select checksum from `', @d_dst_db, '`.`', @d_dst_hmeta,
+    '` limit 1) into @d_src_tail_before, @d_dst_tail_before, @d_src_h_before, @d_dst_h_before'
+);
+prepare capture_d_before from @d_before_sql;
+execute capture_d_before;
+deallocate prepare capture_d_before;
+
+insert into ft2_hnsw_db_clone_src.src values (4, 'alpha source incremental', '[0.1,0.1,0.1]');
+insert into ft2_hnsw_db_clone_dst.src values (3, 'alpha destination incremental', '[0.1,0.1,0.1]');
+
+set @d_tail_advanced_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', @d_src_db, '`.`', @d_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1) > @d_src_tail_before and ',
+    '(select coalesce(max(chunk_id), -1) from `', @d_dst_db, '`.`', @d_dst_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1) > @d_dst_tail_before and ',
+    '(select checksum from `', @d_src_db, '`.`', @d_src_hmeta, '` limit 1) <> @d_src_h_before and ',
+    '(select checksum from `', @d_dst_db, '`.`', @d_dst_hmeta, '` limit 1) <> @d_dst_h_before as ready'
+);
+prepare wait_d_tail_advanced from @d_tail_advanced_sql;
+-- @wait_expect(2, 60)
+execute wait_d_tail_advanced;
+deallocate prepare wait_d_tail_advanced;
+
+select id from ft2_hnsw_db_clone_src.src where match(body) against('alpha' in boolean mode) order by id;
+select id from ft2_hnsw_db_clone_dst.src where match(body) against('alpha' in boolean mode) order by id;
+select id from ft2_hnsw_db_clone_dst.src where match(body) against('beta' in boolean mode) order by id;
+select id from ft2_hnsw_db_clone_src.src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+select id from ft2_hnsw_db_clone_dst.src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+
+create database ft2_hnsw_db_clone_dst clone ft2_hnsw_db_clone_src;
+select count(*) from ft2_hnsw_db_clone_dst.src;
+drop database ft2_hnsw_db_clone_dst;
+drop database ft2_hnsw_db_clone_src;
+
+-- ========================= snapshot table clone =========================
+set experimental_fulltext2_index = 1;
+set experimental_hnsw_index = 1;
+drop database if exists ft2_hnsw_snapshot_clone;
+drop snapshot if exists ft2_hnsw_clone_sp;
+create database ft2_hnsw_snapshot_clone;
+use ft2_hnsw_snapshot_clone;
+
+create table src(id bigint primary key, body text, v vecf32(3));
+create fulltext2 index ft on src(body);
+create index hnsw_idx using hnsw on src(v) op_type 'vector_l2_ops' max_index_capacity 1000;
+insert into src values
+    (1, 'alpha copied', '[0,0,0]'),
+    (2, 'beta copied', '[10,10,10]');
+
+set @s_src_ft = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @s_src_hmeta = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'src')
+    limit 1
+);
+set @s_src_ready_sql = concat(
+    'select coalesce((select max(chunk_id) >= 0 from `', database(), '`.`', @s_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), false) and ',
+    '(select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @s_src_hmeta, '`) as ready'
+);
+prepare wait_s_src_ready from @s_src_ready_sql;
+-- @wait_expect(2, 60)
+execute wait_s_src_ready;
+deallocate prepare wait_s_src_ready;
+set @s_src_before_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), ',
+    '(select checksum from `', database(), '`.`', @s_src_hmeta,
+    '` limit 1) into @s_src_tail_before, @s_src_h_before'
+);
+prepare capture_s_src_before from @s_src_before_sql;
+execute capture_s_src_before;
+deallocate prepare capture_s_src_before;
+
+create snapshot ft2_hnsw_clone_sp for table ft2_hnsw_snapshot_clone src;
+insert into src values (4, 'alpha source after snapshot', '[0.1,0.1,0.1]');
+set @s_src_advanced_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_src_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1) > @s_src_tail_before and ',
+    '(select checksum from `', database(), '`.`', @s_src_hmeta, '` limit 1) <> @s_src_h_before as ready'
+);
+prepare wait_s_src_advanced from @s_src_advanced_sql;
+-- @wait_expect(2, 60)
+execute wait_s_src_advanced;
+deallocate prepare wait_s_src_advanced;
+
+set experimental_fulltext2_index = 0;
+set experimental_hnsw_index = 0;
+create table dst clone src {snapshot = 'ft2_hnsw_clone_sp'};
+set @s_dst_ft = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'ft' and algo = 'fulltext2' and algo_table_type = 'ftv2_index'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+    limit 1
+);
+set @s_dst_hmeta = (
+    select index_table_name from mo_catalog.mo_indexes
+    where name = 'hnsw_idx' and algo = 'hnsw' and algo_table_type = 'hnsw_meta'
+      and table_id = (select rel_id from mo_catalog.mo_tables where reldatabase = database() and relname = 'dst')
+    limit 1
+);
+set @s_dst_ready_sql = concat(
+    'select (select count(*) = 1 and min(filesize) > 0 from `', database(), '`.`', @s_dst_hmeta, '`) as ready'
+);
+prepare wait_s_dst_ready from @s_dst_ready_sql;
+-- @wait_expect(2, 60)
+execute wait_s_dst_ready;
+deallocate prepare wait_s_dst_ready;
+set @s_dst_before_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_dst_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1), ',
+    '(select checksum from `', database(), '`.`', @s_dst_hmeta,
+    '` limit 1) into @s_dst_tail_before, @s_dst_h_before'
+);
+prepare capture_s_dst_before from @s_dst_before_sql;
+execute capture_s_dst_before;
+deallocate prepare capture_s_dst_before;
+
+insert into dst values (3, 'alpha destination incremental', '[0.1,0.1,0.1]');
+set @s_dst_advanced_sql = concat(
+    'select (select coalesce(max(chunk_id), -1) from `', database(), '`.`', @s_dst_ft,
+    '` where index_id = ''cdc_tail'' and tag = 1) > @s_dst_tail_before and ',
+    '(select checksum from `', database(), '`.`', @s_dst_hmeta, '` limit 1) <> @s_dst_h_before as ready'
+);
+prepare wait_s_dst_advanced from @s_dst_advanced_sql;
+-- @wait_expect(2, 60)
+execute wait_s_dst_advanced;
+deallocate prepare wait_s_dst_advanced;
+
+select id from src where match(body) against('alpha' in boolean mode) order by id;
+select id from dst where match(body) against('alpha' in boolean mode) order by id;
+select id from dst where match(body) against('beta' in boolean mode) order by id;
+select count(*) from dst where id = 4;
+select id from src order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+select id from dst order by l2_distance(v, '[0.1,0.1,0.1]') limit 2;
+
+create table dst clone src {snapshot = 'ft2_hnsw_clone_sp'};
+select count(*) from dst;
+drop snapshot ft2_hnsw_clone_sp;
+drop database ft2_hnsw_snapshot_clone;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27971

## What this PR does / why we need it:

### Root cause

A clone restores one CDC-backed initialization job for each index. Fulltext2
uses a watermark barrier, while HNSW rebuilds its index. Before the scheduler
change merged as #27973, both `Init` jobs could be placed in one ISCP iteration,
so the Fulltext2 job was not re-armed after the clone.

### Changes

- Rebased semantically onto `main` at `311d2c447a`, which includes the upstream
  scheduler fix in #27973 that isolates `Init` jobs from shared iterations.
- Keep a focused distributed BVT that proves the behavior for table clone,
  database clone, and snapshot-table clone.

This PR deliberately carries no duplicate production implementation: the
upstream scheduler change is the shared, complete fix at the correct ownership
boundary.

### Issue-to-test proof

`fulltext2_hnsw_clone` verifies, for every clone syntax:

- source and destination Fulltext2 durable tails and HNSW metadata advance after
  independent post-clone DML;
- Fulltext2 `MATCH` results are source `1,4`, destination `1,3`, and copied
  destination row `2` remains searchable;
- HNSW Top-K returns source `4,1` and destination `3,1`;
- duplicate clone targets fail without changing the existing target; and
- snapshot clones preserve snapshot isolation.

### Validation

- `make build` on final `main` base `311d2c447a`; verified the rebuilt
  `mo-service` and the staged `lib/libmo.dylib`.
- Fresh isolated single-CN/single-TN BVT:
  `fulltext2_hnsw_clone` — `143/143` assertions passed in `132.898s`.
- Reviewed the tester report and empty error report; teardown left no matching
  test databases or snapshots.

### Residual risks

No known functional residual. The local validation is single-CN/single-TN;
the PR's multi-CN BVT will exercise the same regression under CI.
