### PR TITLE
test(sysview): wait for distributed lock visibility

### DIFF
--- a/test/distributed/cases/pessimistic_transaction/system_view.result
+++ b/test/distributed/cases/pessimistic_transaction/system_view.result
@@ -16,12 +16,21 @@ update t1 set b = b + 1 where a = 1;
 select count(distinct txn_id) = 2 from mo_transactions() t where t.user_txn = 'true';
 ➤ count(distinct txn_id) = 2[-7,1,0]  𝄀
 1
-select count(*) = 2 from (
-select txn_id from mo_locks() l where l.txn_id <> ''
+with target_table_ids as (
+select rel_id from mo_catalog.mo_tables
+where reldatabase in ('sv_sys_db', 'sv_tenant_db') and relname = 't1'
+), visible_txns as (
+select txn_id from mo_locks() l join target_table_ids t on l.table_id = t.rel_id
+where l.txn_id <> ''
 union
-select lock_wait from mo_locks() l where l.lock_wait <> ''
-) as visible_txns;
-➤ count(*) = 2[-7,1,0]  𝄀
+select lock_wait from mo_locks() l join target_table_ids t on l.table_id = t.rel_id
+where l.lock_wait <> ''
+)
+select count(distinct t.txn_id) = 2
+from mo_transactions() t
+join visible_txns v on t.txn_id = v.txn_id
+where t.user_txn = 'true';
+➤ count(distinct t.txn_id) = 2[-7,1,0]  𝄀
 1
 select count(distinct txn_id) = 1 from mo_transactions() t where t.user_txn = 'true';
 ➤ count(distinct txn_id) = 1[-7,1,0]  𝄀

--- a/test/distributed/cases/pessimistic_transaction/system_view.sql
+++ b/test/distributed/cases/pessimistic_transaction/system_view.sql
@@ -24,7 +24,9 @@ begin;
 update t1 set b = b + 1 where a = 1;
 -- @session}
 
--- The sys account sees both active user transactions and their locks.
+-- The tenant session is asynchronous. Wait until both transactions are active
+-- before checking their identities and the locks they hold.
+-- @wait_expect(1, 10)
 select count(distinct txn_id) = 2 from mo_transactions() t where t.user_txn = 'true';
 -- The tenant session is asynchronous. Poll the public lock view until both
 -- intended table locks have been acquired and published across the CNs.

--- a/test/distributed/cases/pessimistic_transaction/system_view.sql
+++ b/test/distributed/cases/pessimistic_transaction/system_view.sql
@@ -27,13 +27,22 @@ update t1 set b = b + 1 where a = 1;
 -- The sys account sees both active user transactions and their locks.
 select count(distinct txn_id) = 2 from mo_transactions() t where t.user_txn = 'true';
 -- The tenant session is asynchronous. Poll the public lock view until both
--- transactions have acquired and published their locks across the CNs.
+-- intended table locks have been acquired and published across the CNs.
 -- @wait_expect(1, 10)
-select count(*) = 2 from (
-    select txn_id from mo_locks() l where l.txn_id <> ''
+with target_table_ids as (
+    select rel_id from mo_catalog.mo_tables
+    where reldatabase in ('sv_sys_db', 'sv_tenant_db') and relname = 't1'
+), visible_txns as (
+    select txn_id from mo_locks() l join target_table_ids t on l.table_id = t.rel_id
+    where l.txn_id <> ''
     union
-    select lock_wait from mo_locks() l where l.lock_wait <> ''
-) as visible_txns;
+    select lock_wait from mo_locks() l join target_table_ids t on l.table_id = t.rel_id
+    where l.lock_wait <> ''
+)
+select count(distinct t.txn_id) = 2
+from mo_transactions() t
+join visible_txns v on t.txn_id = v.txn_id
+where t.user_txn = 'true';
 
 -- A regular tenant sees only its own transaction through both table functions
 -- and catalog views.

--- a/test/distributed/cases/pessimistic_transaction/system_view.sql
+++ b/test/distributed/cases/pessimistic_transaction/system_view.sql
@@ -26,6 +26,9 @@ update t1 set b = b + 1 where a = 1;
 
 -- The sys account sees both active user transactions and their locks.
 select count(distinct txn_id) = 2 from mo_transactions() t where t.user_txn = 'true';
+-- The tenant session is asynchronous. Poll the public lock view until both
+-- transactions have acquired and published their locks across the CNs.
+-- @wait_expect(1, 10)
 select count(*) = 2 from (
     select txn_id from mo_locks() l where l.txn_id <> ''
     union


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] ENHANCEMENT
- [ ] FEATURE
- [ ] DOCUMENTATION
- [ ] TEST
- [ ] CI
- [ ] CHORE

## Which issue(s) this PR fixes:

Related to #27979

## What this PR does / why we need it:

### Root cause

The multi-CN pessimistic BVT launches the tenant transaction in an asynchronous session. The case read `mo_transactions()` and then `mo_locks()` without waiting for either asynchronous state to converge. The failing exact-topology artifact proves the first race: the immediate active-user-transaction assertion returned `0`. The original #27979 artifact proved the subsequent race: both transactions were registered while `mo_locks()` still returned no visible locks. `mo_locks()` already broadcasts to every CN for `sys`; this is test synchronization, not missing cross-CN or tenant visibility logic.

### Changes

Use the existing bounded `@wait_expect(1, 10)` BVT primitive for both readiness boundaries: first wait until exactly two active user transactions are visible, then wait until the locks for `sv_sys_db.t1` and `sv_tenant_db.t1` are published. The lock oracle unions only those tables' holder/waiter IDs, joins them to active user transactions, and requires exactly two distinct transactions. Unrelated global `sys` locks cannot satisfy it. Tenant-isolation, catalog-view, identity, rollback, and cleanup assertions remain unchanged.

### Issue-to-test proof

- #27979: `test/distributed/cases/pessimistic_transaction/system_view.sql` now proves the two intended transactions become active and their intended locks become visible across CNs; both assertions require result `1`.
- The former exact Standalone multi-CN COMPOSE/PESSIMISTIC run at [33554673629](https://github.com/matrixorigin/matrixone/actions/runs/33554673629) executed this case with the target-lock identity oracle and passed 29/29 assertions in 2.081 seconds (job 100015725300).
- The next exact-topology run at [33559889977](https://github.com/matrixorigin/matrixone/actions/runs/33559889977) exposed the remaining unbounded active-transaction assertion: `system_view.sql` was 28/29 and the artifact records its expected `1`, actual `0`. This commit bounds that same readiness check; a new exact-head run is required.

### Tests

- PASS: exact Standalone multi-CN COMPOSE/PESSIMISTIC BVT for the target-lock identity oracle, `pessimistic_transaction/system_view.sql` 29/29 (run 33554673629, job 100015725300).
- PASS: `git diff --check origin/main...HEAD` after rebase onto `753fd95b65`; the upstream changes do not touch this case or its BVT harness.
- PASS: local `mo-tester` executed the updated case and confirmed `@wait_expect(1, 10)` retried the active-transaction assertion to its deadline. That local service does not include the #27948 tenant-visibility behavior, so it correctly remained `0` and is not treated as functional passing evidence.
- PENDING: exact-head Standalone multi-CN COMPOSE/PESSIMISTIC BVT.
- UNRELATED CI BLOCKER: ARM64 SCA self-hosted-runner communication loss is tracked by #27742; its attempt-1 failed job was rerun once.

### Residual risk

Both waits are bounded to ten seconds and preserve the strict expected value. If either target transaction never becomes active or either intended lock is absent, the case fails after its deadline.
