### PR TITLE
fix: eliminate load-sensitive timeout assumptions

### DIFF
--- a/pkg/bootstrap/service_upgrade_tenant.go
+++ b/pkg/bootstrap/service_upgrade_tenant.go
@@ -141,10 +141,11 @@ func shouldRunTenantUpgrade(createVersion string, upgrade versions.VersionUpgrad
 		versions.Compare(upgrade.FromVersion, upgrade.ToVersion) == 0
 }
 
-// asyncUpgradeTenantTask is a task to execute the tenant upgrade logic in
-// parallel based on the grouped tenant batch.
-func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
-	fn := func() (bool, error) {
+// newTenantUpgradePass returns one transactional tenant-upgrade pass. Keeping
+// the pass independent from the periodic task makes completion observable
+// without coupling callers (or tests) to the task's wall clock.
+func (s *service) newTenantUpgradePass(ctx context.Context) func() (bool, error) {
+	return func() (bool, error) {
 		ctx, cancel := context.WithTimeoutCause(ctx, time.Hour*24, moerr.CauseAsyncUpgradeTenantTask)
 		defer cancel()
 
@@ -337,7 +338,12 @@ func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
 		}
 		return hasUpgradeTenants, nil
 	}
+}
 
+// asyncUpgradeTenantTask is a task to execute the tenant upgrade logic in
+// parallel based on the grouped tenant batch.
+func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
+	fn := s.newTenantUpgradePass(ctx)
 	timer := time.NewTimer(s.upgrade.checkUpgradeTenantDuration)
 	defer timer.Stop()
 

--- a/pkg/bootstrap/service_upgrade_tenant_test.go
+++ b/pkg/bootstrap/service_upgrade_tenant_test.go
@@ -157,6 +157,23 @@ func TestDrainUpgradeTenantsStopsAfterCancellation(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+// drainToBarrier runs one full tenant-upgrade drain and encodes the
+// completion-barrier convention these tests share. A test whose SQL mock
+// cancels ctx at its barrier passes wantBarrier=true: ctx must end Canceled,
+// which proves the barrier was reached rather than the hang deadline
+// (DeadlineExceeded). A test whose drain finishes naturally passes
+// wantBarrier=false: ctx must carry no error at all.
+func drainToBarrier(t *testing.T, ctx context.Context, s *service, wantBarrier bool) {
+	t.Helper()
+	drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
+	if wantBarrier {
+		require.ErrorIs(t, ctx.Err(), context.Canceled,
+			"tenant upgrade did not reach its completion barrier")
+		return
+	}
+	require.NoError(t, ctx.Err(), "tenant upgrade hit the test hang guard")
+}
+
 func Test_asyncUpgradeTenantTask_SkipsTenantAtTargetVersion(t *testing.T) {
 	sid := ""
 	runtime.RunTest(
@@ -337,9 +354,7 @@ func Test_asyncUpgradeTenantTask_RunsSameVersionOffsetUpgrade(t *testing.T) {
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
-			require.ErrorIs(t, ctx.Err(), context.Canceled,
-				"tenant upgrade did not reach its completion barrier")
+			drainToBarrier(t, ctx, s, true)
 			require.True(t, taskReady.Load())
 			require.True(t, finalized.Load())
 			require.True(t, tenantVersionUpdated.Load())
@@ -413,9 +428,7 @@ func Test_asyncUpgradeTenantTask_AutoCompletesDeletedTenantTasks(t *testing.T) {
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
-			require.ErrorIs(t, ctx.Err(), context.Canceled,
-				"tenant upgrade did not reach its completion barrier")
+			drainToBarrier(t, ctx, s, true)
 			require.True(t, finalized.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},
@@ -474,9 +487,7 @@ func Test_asyncUpgradeTenantTask_ReconcilesReadyCountWhenTasksAlreadyFinished(t 
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
-			require.ErrorIs(t, ctx.Err(), context.Canceled,
-				"tenant upgrade did not reach its completion barrier")
+			drainToBarrier(t, ctx, s, true)
 			require.True(t, finalized.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},
@@ -538,8 +549,7 @@ func Test_asyncUpgradeTenantTask_SkipsReconcileWhenConflictTasksRemain(t *testin
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
-			require.NoError(t, ctx.Err(), "tenant upgrade hit the test hang guard")
+			drainToBarrier(t, ctx, s, false)
 			require.False(t, reconciled.Load())
 			require.False(t, upgraded.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
@@ -597,8 +607,7 @@ func Test_asyncUpgradeTenantTask_SkipsAlreadyReconciledUpgradeCounts(t *testing.
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
-			require.NoError(t, ctx.Err(), "tenant upgrade hit the test hang guard")
+			drainToBarrier(t, ctx, s, false)
 			require.False(t, upgraded.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},

--- a/pkg/bootstrap/service_upgrade_tenant_test.go
+++ b/pkg/bootstrap/service_upgrade_tenant_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 )
 
+const tenantUpgradeTestHangTimeout = 10 * time.Second
+
 func Test_asyncUpgradeTenantTask(t *testing.T) {
 	sid := ""
 	runtime.RunTest(
@@ -163,7 +165,7 @@ func Test_asyncUpgradeTenantTask_SkipsTenantAtTargetVersion(t *testing.T) {
 			var taskReady atomic.Bool
 			var finalized atomic.Bool
 			var tenantVersionUpdated atomic.Bool
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, cancel := context.WithTimeout(t.Context(), tenantUpgradeTestHangTimeout)
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -271,7 +273,7 @@ func Test_asyncUpgradeTenantTask_RunsSameVersionOffsetUpgrade(t *testing.T) {
 			var taskReady atomic.Bool
 			var finalized atomic.Bool
 			var tenantVersionUpdated atomic.Bool
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, cancel := context.WithTimeout(t.Context(), tenantUpgradeTestHangTimeout)
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -336,6 +338,8 @@ func Test_asyncUpgradeTenantTask_RunsSameVersionOffsetUpgrade(t *testing.T) {
 			}, txnOperator)
 
 			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
+			require.ErrorIs(t, ctx.Err(), context.Canceled,
+				"tenant upgrade did not reach its completion barrier")
 			require.True(t, taskReady.Load())
 			require.True(t, finalized.Load())
 			require.True(t, tenantVersionUpdated.Load())
@@ -351,7 +355,7 @@ func Test_asyncUpgradeTenantTask_AutoCompletesDeletedTenantTasks(t *testing.T) {
 		func(rt runtime.Runtime) {
 			var finalized atomic.Bool
 			var deletedTasksReconciled atomic.Bool
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, cancel := context.WithTimeout(t.Context(), tenantUpgradeTestHangTimeout)
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -410,6 +414,8 @@ func Test_asyncUpgradeTenantTask_AutoCompletesDeletedTenantTasks(t *testing.T) {
 			}, txnOperator)
 
 			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
+			require.ErrorIs(t, ctx.Err(), context.Canceled,
+				"tenant upgrade did not reach its completion barrier")
 			require.True(t, finalized.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},
@@ -422,7 +428,7 @@ func Test_asyncUpgradeTenantTask_ReconcilesReadyCountWhenTasksAlreadyFinished(t 
 		sid,
 		func(rt runtime.Runtime) {
 			var finalized atomic.Bool
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, cancel := context.WithTimeout(t.Context(), tenantUpgradeTestHangTimeout)
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -469,6 +475,8 @@ func Test_asyncUpgradeTenantTask_ReconcilesReadyCountWhenTasksAlreadyFinished(t 
 			}, txnOperator)
 
 			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
+			require.ErrorIs(t, ctx.Err(), context.Canceled,
+				"tenant upgrade did not reach its completion barrier")
 			require.True(t, finalized.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},
@@ -482,7 +490,7 @@ func Test_asyncUpgradeTenantTask_SkipsReconcileWhenConflictTasksRemain(t *testin
 		func(rt runtime.Runtime) {
 			var reconciled atomic.Bool
 			var upgraded atomic.Bool
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, cancel := context.WithTimeout(t.Context(), tenantUpgradeTestHangTimeout)
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -531,6 +539,7 @@ func Test_asyncUpgradeTenantTask_SkipsReconcileWhenConflictTasksRemain(t *testin
 			}, txnOperator)
 
 			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
+			require.NoError(t, ctx.Err(), "tenant upgrade hit the test hang guard")
 			require.False(t, reconciled.Load())
 			require.False(t, upgraded.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
@@ -544,7 +553,7 @@ func Test_asyncUpgradeTenantTask_SkipsAlreadyReconciledUpgradeCounts(t *testing.
 		sid,
 		func(rt runtime.Runtime) {
 			var upgraded atomic.Bool
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, cancel := context.WithTimeout(t.Context(), tenantUpgradeTestHangTimeout)
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -589,6 +598,7 @@ func Test_asyncUpgradeTenantTask_SkipsAlreadyReconciledUpgradeCounts(t *testing.
 			}, txnOperator)
 
 			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
+			require.NoError(t, ctx.Err(), "tenant upgrade hit the test hang guard")
 			require.False(t, upgraded.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},

--- a/pkg/bootstrap/service_upgrade_tenant_test.go
+++ b/pkg/bootstrap/service_upgrade_tenant_test.go
@@ -73,10 +73,8 @@ func Test_asyncUpgradeTenantTask(t *testing.T) {
 			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
 			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*3)
-			defer cancel()
-
-			b.asyncUpgradeTenantTask(ctx)
+			_, err := b.newTenantUpgradePass(t.Context())()
+			require.Error(t, err)
 		},
 	)
 }
@@ -165,7 +163,7 @@ func Test_asyncUpgradeTenantTask_SkipsTenantAtTargetVersion(t *testing.T) {
 			var taskReady atomic.Bool
 			var finalized atomic.Bool
 			var tenantVersionUpdated atomic.Bool
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -215,7 +213,7 @@ func Test_asyncUpgradeTenantTask_SkipsTenantAtTargetVersion(t *testing.T) {
 				func(s *service) {
 					s.handles = append(s.handles, h)
 				},
-				WithCheckUpgradeTenantDuration(time.Millisecond),
+				WithCheckUpgradeTenantDuration(0),
 			)
 
 			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
@@ -273,7 +271,7 @@ func Test_asyncUpgradeTenantTask_RunsSameVersionOffsetUpgrade(t *testing.T) {
 			var taskReady atomic.Bool
 			var finalized atomic.Bool
 			var tenantVersionUpdated atomic.Bool
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -337,7 +335,7 @@ func Test_asyncUpgradeTenantTask_RunsSameVersionOffsetUpgrade(t *testing.T) {
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			s.asyncUpgradeTenantTask(ctx)
+			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
 			require.True(t, taskReady.Load())
 			require.True(t, finalized.Load())
 			require.True(t, tenantVersionUpdated.Load())
@@ -353,7 +351,7 @@ func Test_asyncUpgradeTenantTask_AutoCompletesDeletedTenantTasks(t *testing.T) {
 		func(rt runtime.Runtime) {
 			var finalized atomic.Bool
 			var deletedTasksReconciled atomic.Bool
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -411,7 +409,7 @@ func Test_asyncUpgradeTenantTask_AutoCompletesDeletedTenantTasks(t *testing.T) {
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			s.asyncUpgradeTenantTask(ctx)
+			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
 			require.True(t, finalized.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},
@@ -424,7 +422,7 @@ func Test_asyncUpgradeTenantTask_ReconcilesReadyCountWhenTasksAlreadyFinished(t 
 		sid,
 		func(rt runtime.Runtime) {
 			var finalized atomic.Bool
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -470,7 +468,7 @@ func Test_asyncUpgradeTenantTask_ReconcilesReadyCountWhenTasksAlreadyFinished(t 
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			s.asyncUpgradeTenantTask(ctx)
+			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
 			require.True(t, finalized.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},
@@ -484,7 +482,7 @@ func Test_asyncUpgradeTenantTask_SkipsReconcileWhenConflictTasksRemain(t *testin
 		func(rt runtime.Runtime) {
 			var reconciled atomic.Bool
 			var upgraded atomic.Bool
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -532,7 +530,7 @@ func Test_asyncUpgradeTenantTask_SkipsReconcileWhenConflictTasksRemain(t *testin
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			s.asyncUpgradeTenantTask(ctx)
+			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
 			require.False(t, reconciled.Load())
 			require.False(t, upgraded.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
@@ -546,7 +544,7 @@ func Test_asyncUpgradeTenantTask_SkipsAlreadyReconciledUpgradeCounts(t *testing.
 		sid,
 		func(rt runtime.Runtime) {
 			var upgraded atomic.Bool
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
@@ -590,7 +588,7 @@ func Test_asyncUpgradeTenantTask_SkipsAlreadyReconciledUpgradeCounts(t *testing.
 				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
 			}, txnOperator)
 
-			s.asyncUpgradeTenantTask(ctx)
+			drainUpgradeTenants(ctx, s.newTenantUpgradePass(ctx))
 			require.False(t, upgraded.Load())
 			require.Zero(t, h.callHandleTenantUpgrade.Load())
 		},

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -241,6 +241,8 @@ type remoteBackend struct {
 		// concurrent request responds. overflow is sticky for the connection
 		// generation, bounding fault-path memory when timed-out requests keep
 		// arriving faster than the read timeout can recycle the transport.
+		// This tracker serves probe-enabled backends only; probe-less backends
+		// answer the same question via pendingRequestReadWindow (see its doc).
 		pending      map[uint64]struct{}
 		pendingSince int64
 		overflow     bool
@@ -253,6 +255,12 @@ type remoteBackend struct {
 		// draining seals new pool admission after data transport inactivity.
 		// Existing Futures remain owned by this backend and may still complete.
 		draining atomic.Bool
+		// lastStreamFlushAt is the livenessTick of the most recent successfully
+		// flushed user stream message. Probe-less backends grant stream traffic
+		// one complete read window from this stamp so a stream write admitted
+		// late in an idle read window is not charged the idle time; it is never
+		// reset because an old stamp only ever grants less time.
+		lastStreamFlushAt atomic.Int64
 	}
 
 	pool struct {
@@ -644,13 +652,21 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 						f.messageSent(err)
 					}
 				} else {
+					// Record only transport-complete writes. A request that merely
+					// reached the userspace buffer must not extend the read window
+					// when Flush ultimately fails. Every request in the batch became
+					// transport-complete at this flush, so one tick serves them all.
+					var flushedAt int64
+					if rb.options.readTimeout > 0 && rb.options.livenessProbe == nil {
+						flushedAt = rb.livenessTick()
+					}
 					for _, f := range written {
-						if !f.send.internal && !f.send.stream && !f.oneWay &&
-							rb.options.readTimeout > 0 && rb.options.livenessProbe == nil {
-							// Record only transport-complete writes. A request that merely
-							// reached the userspace buffer must not extend the read window
-							// when Flush ultimately fails.
-							f.writtenAt.Store(rb.livenessTick())
+						if flushedAt != 0 {
+							if f.isUserUnary() {
+								f.writtenAt.Store(flushedAt)
+							} else if f.send.stream && !f.send.internal {
+								rb.atomic.lastStreamFlushAt.Store(flushedAt)
+							}
 						}
 						f.messageSent(nil)
 					}
@@ -1339,6 +1355,11 @@ func (rb *remoteBackend) getPingTimeout() time.Duration {
 	return time.Duration(math.MaxInt64)
 }
 
+// keepDataConnectionAfterReadTimeout decides whether a socket read timeout may
+// recycle the data connection. A socket read can begin while the connection is
+// idle and inherit a deadline that is already mostly consumed when the next
+// request arrives. Idle time is not request latency, so admitted traffic is
+// judged against request-owned read windows instead of the socket's deadline.
 func (rb *remoteBackend) keepDataConnectionAfterReadTimeout(
 	ctx context.Context,
 	readErr error,
@@ -1351,34 +1372,43 @@ func (rb *remoteBackend) keepDataConnectionAfterReadTimeout(
 		return false
 	default:
 	}
+	if rb.options.livenessProbe == nil {
+		return rb.keepOrdinaryDataConnection()
+	}
+	return rb.keepProbedDataConnection(ctx)
+}
 
-	// A socket read can begin while the connection is idle and inherit a
-	// deadline that is already mostly consumed when the next request arrives.
-	// Idle time is not request latency: give newly written data one complete
-	// read window before declaring its transport stalled.
-	var oldestWritten int64
-	if rb.options.livenessProbe == nil {
-		var writePending bool
-		oldestWritten, writePending = rb.pendingRequestReadWindow()
-		// Preserve the ordinary backend's existing idle and stream timeout
-		// behavior. An admitted unary request keeps the old idle deadline from
-		// closing its transport while it is queued or being flushed. Once flushed,
-		// it owns one complete read window; a terminal send failure owns neither.
-		if oldestWritten == 0 {
-			return writePending
-		}
-	} else {
-		oldestWritten = rb.dataPendingSince()
-	}
-	if oldestWritten == 0 {
+// keepOrdinaryDataConnection is the probe-less policy. Every admitted user
+// unary request owns exactly one complete read window: it starts at admission,
+// restarts once at the successful flush, and a terminal send failure owns
+// none. The oldest window rules the decision: once the oldest admitted request
+// has waited one full window without any read progress, the transport is
+// stalled and a newer admission cannot rescue it — this also bounds a write
+// blocked against a dead peer to one window instead of letting the queued
+// state renew the connection until the request deadline. Stream traffic keeps
+// the coarser bound of one window from the most recent flushed stream message.
+// An idle backend (no open window at all) keeps the pre-existing idle-timeout
+// close behavior.
+func (rb *remoteBackend) keepOrdinaryDataConnection() bool {
+	now := rb.livenessTick()
+	if rb.withinReadWindow(now, rb.pendingRequestReadWindow()) {
 		return true
 	}
-	if elapsed := rb.livenessTick() - oldestWritten; elapsed >= 0 &&
-		elapsed < rb.options.readTimeout.Nanoseconds() {
+	return rb.withinReadWindow(now, rb.atomic.lastStreamFlushAt.Load())
+}
+
+// keepProbedDataConnection is the probe-enabled policy: response inactivity
+// beyond one read window stops admission (draining) and consults the
+// independent liveness probe, but never closes the data connection here — a
+// probe failure is inconclusive because the peer may still return a valid slow
+// response on the data connection.
+func (rb *remoteBackend) keepProbedDataConnection(ctx context.Context) bool {
+	pendingSince := rb.dataPendingSince()
+	if pendingSince == 0 {
 		return true
 	}
-	if rb.options.livenessProbe == nil {
-		return false
+	if rb.withinReadWindow(rb.livenessTick(), pendingSince) {
+		return true
 	}
 
 	rb.stateMu.Lock()
@@ -1437,6 +1467,13 @@ func (rb *remoteBackend) livenessTick() int64 {
 	return time.Since(rb.livenessEpoch).Nanoseconds() + 1
 }
 
+// withinReadWindow reports whether the read window that started at since is
+// still open at now. Zero means no window. A start observed slightly after now
+// (a flush racing this scan) is inside its window, never expired.
+func (rb *remoteBackend) withinReadWindow(now, since int64) bool {
+	return since != 0 && now-since < rb.options.readTimeout.Nanoseconds()
+}
+
 func (rb *remoteBackend) recordDataWrite(id uint64, at int64) {
 	rb.livenessMu.Lock()
 	if rb.livenessMu.pending == nil {
@@ -1486,30 +1523,46 @@ func (rb *remoteBackend) dataPendingSince() int64 {
 	return rb.livenessMu.pendingSince
 }
 
-func (rb *remoteBackend) pendingRequestReadWindow() (int64, bool) {
+// pendingRequestReadWindow returns the oldest read-window start among pending
+// user unary requests, or zero when none holds a window.
+//
+// This future scan is the probe-less twin of the livenessMu.pending machinery:
+// probe-enabled backends publish per-write progress into livenessMu
+// (recordDataWrite/recordDataProgress/resetDataProgress) because the probe
+// wants refresh-on-any-read semantics, while probe-less backends derive the
+// same "how long has user traffic been unanswered" answer from the
+// lifecycle-bounded future set. A timeout-policy change in one tracker usually
+// needs a matching look at the other.
+func (rb *remoteBackend) pendingRequestReadWindow() int64 {
 	rb.mu.RLock()
 	defer rb.mu.RUnlock()
 	oldest := int64(0)
-	writePending := false
 	for _, f := range rb.mu.futures {
-		if f.send.internal || f.send.stream || f.oneWay {
+		if !f.isUserUnary() {
 			continue
 		}
 		// Read the publication flag before the timestamp. The success path stores
 		// writtenAt and then publishes waiting=true; this order prevents observing
 		// the old zero timestamp together with the new success flag.
 		waiting := f.waiting.Load()
-		writtenAt := f.writtenAt.Load()
-		if writtenAt > 0 && (oldest == 0 || writtenAt < oldest) {
-			oldest = writtenAt
-		} else if writtenAt == 0 && !waiting {
-			// messageSent publishes waiting=true for both success and failure.
-			// Success publishes writtenAt first; therefore zero plus !waiting is
-			// exactly the admitted/queued/write-in-progress state.
-			writePending = true
+		start := f.writtenAt.Load()
+		if start == 0 {
+			if waiting {
+				// messageSent publishes waiting=true for both success and failure.
+				// Success publishes writtenAt first; therefore zero plus waiting is
+				// exactly the terminal-send-failure state, which owns no window.
+				continue
+			}
+			// Admitted/queued/write-in-progress: the window starts at admission.
+			// f.send is published by addFuture's lock and cleared only under the
+			// same lock in releaseFuture, so this read is synchronized.
+			start = f.send.createAt.Sub(rb.livenessEpoch).Nanoseconds() + 1
+		}
+		if oldest == 0 || start < oldest {
+			oldest = start
 		}
 	}
-	return oldest, writePending
+	return oldest
 }
 
 func (rb *remoteBackend) resetDataProgress() {

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -645,7 +645,7 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 					}
 				} else {
 					for _, f := range written {
-						if !f.send.internal && !f.send.stream &&
+						if !f.send.internal && !f.send.stream && !f.oneWay &&
 							rb.options.readTimeout > 0 && rb.options.livenessProbe == nil {
 							// Record only transport-complete writes. A request that merely
 							// reached the userspace buffer must not extend the read window
@@ -1356,15 +1356,19 @@ func (rb *remoteBackend) keepDataConnectionAfterReadTimeout(
 	// deadline that is already mostly consumed when the next request arrives.
 	// Idle time is not request latency: give newly written data one complete
 	// read window before declaring its transport stalled.
-	oldestWritten := rb.dataPendingSince()
+	var oldestWritten int64
 	if rb.options.livenessProbe == nil {
-		oldestWritten = rb.oldestPendingRequestAt()
+		var writePending bool
+		oldestWritten, writePending = rb.pendingRequestReadWindow()
 		// Preserve the ordinary backend's existing idle and stream timeout
-		// behavior. Only a successfully flushed unary request owns a fresh read
-		// window; no pending request still closes this connection.
+		// behavior. An admitted unary request keeps the old idle deadline from
+		// closing its transport while it is queued or being flushed. Once flushed,
+		// it owns one complete read window; a terminal send failure owns neither.
 		if oldestWritten == 0 {
-			return false
+			return writePending
 		}
+	} else {
+		oldestWritten = rb.dataPendingSince()
 	}
 	if oldestWritten == 0 {
 		return true
@@ -1482,20 +1486,30 @@ func (rb *remoteBackend) dataPendingSince() int64 {
 	return rb.livenessMu.pendingSince
 }
 
-func (rb *remoteBackend) oldestPendingRequestAt() int64 {
+func (rb *remoteBackend) pendingRequestReadWindow() (int64, bool) {
 	rb.mu.RLock()
 	defer rb.mu.RUnlock()
 	oldest := int64(0)
+	writePending := false
 	for _, f := range rb.mu.futures {
-		if f.send.internal || f.send.stream {
+		if f.send.internal || f.send.stream || f.oneWay {
 			continue
 		}
+		// Read the publication flag before the timestamp. The success path stores
+		// writtenAt and then publishes waiting=true; this order prevents observing
+		// the old zero timestamp together with the new success flag.
+		waiting := f.waiting.Load()
 		writtenAt := f.writtenAt.Load()
 		if writtenAt > 0 && (oldest == 0 || writtenAt < oldest) {
 			oldest = writtenAt
+		} else if writtenAt == 0 && !waiting {
+			// messageSent publishes waiting=true for both success and failure.
+			// Success publishes writtenAt first; therefore zero plus !waiting is
+			// exactly the admitted/queued/write-in-progress state.
+			writePending = true
 		}
 	}
-	return oldest
+	return oldest, writePending
 }
 
 func (rb *remoteBackend) resetDataProgress() {

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -645,6 +645,13 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 					}
 				} else {
 					for _, f := range written {
+						if !f.send.internal && !f.send.stream &&
+							rb.options.readTimeout > 0 && rb.options.livenessProbe == nil {
+							// Record only transport-complete writes. A request that merely
+							// reached the userspace buffer must not extend the read window
+							// when Flush ultimately fails.
+							f.writtenAt.Store(rb.livenessTick())
+						}
 						f.messageSent(nil)
 					}
 				}
@@ -743,7 +750,7 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 			msg, err := rb.conn.Read(goetty.ReadOptions{Timeout: rb.options.readTimeout})
 			n++
 			if err != nil || rb.options.disconnectAfterRead == n {
-				if err != nil && rb.keepDataConnectionAfterProbe(ctx, err) {
+				if err != nil && rb.keepDataConnectionAfterReadTimeout(ctx, err) {
 					continue
 				}
 				if err == nil {
@@ -1332,11 +1339,11 @@ func (rb *remoteBackend) getPingTimeout() time.Duration {
 	return time.Duration(math.MaxInt64)
 }
 
-func (rb *remoteBackend) keepDataConnectionAfterProbe(
+func (rb *remoteBackend) keepDataConnectionAfterReadTimeout(
 	ctx context.Context,
 	readErr error,
 ) bool {
-	if rb.options.livenessProbe == nil || !isTimeoutError(readErr) {
+	if !isTimeoutError(readErr) {
 		return false
 	}
 	select {
@@ -1345,17 +1352,29 @@ func (rb *remoteBackend) keepDataConnectionAfterProbe(
 	default:
 	}
 
-	// A read deadline on an otherwise idle data connection is not evidence of
-	// a stalled data path. In particular, do not make healthy data depend on a
-	// control transport that may be temporarily unavailable when there is no
-	// outstanding or unacknowledged user traffic to diagnose.
+	// A socket read can begin while the connection is idle and inherit a
+	// deadline that is already mostly consumed when the next request arrives.
+	// Idle time is not request latency: give newly written data one complete
+	// read window before declaring its transport stalled.
 	oldestWritten := rb.dataPendingSince()
+	if rb.options.livenessProbe == nil {
+		oldestWritten = rb.oldestPendingRequestAt()
+		// Preserve the ordinary backend's existing idle and stream timeout
+		// behavior. Only a successfully flushed unary request owns a fresh read
+		// window; no pending request still closes this connection.
+		if oldestWritten == 0 {
+			return false
+		}
+	}
 	if oldestWritten == 0 {
 		return true
 	}
 	if elapsed := rb.livenessTick() - oldestWritten; elapsed >= 0 &&
 		elapsed < rb.options.readTimeout.Nanoseconds() {
 		return true
+	}
+	if rb.options.livenessProbe == nil {
+		return false
 	}
 
 	rb.stateMu.Lock()
@@ -1461,6 +1480,22 @@ func (rb *remoteBackend) dataPendingSince() int64 {
 	rb.livenessMu.Lock()
 	defer rb.livenessMu.Unlock()
 	return rb.livenessMu.pendingSince
+}
+
+func (rb *remoteBackend) oldestPendingRequestAt() int64 {
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+	oldest := int64(0)
+	for _, f := range rb.mu.futures {
+		if f.send.internal || f.send.stream {
+			continue
+		}
+		writtenAt := f.writtenAt.Load()
+		if writtenAt > 0 && (oldest == 0 || writtenAt < oldest) {
+			oldest = writtenAt
+		}
+	}
+	return oldest
 }
 
 func (rb *remoteBackend) resetDataProgress() {

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -1386,13 +1386,16 @@ func (rb *remoteBackend) keepDataConnectionAfterReadTimeout(
 // stalled and a newer admission cannot rescue it — this also bounds a write
 // blocked against a dead peer to one window instead of letting the queued
 // state renew the connection until the request deadline. Stream traffic keeps
-// the coarser bound of one window from the most recent flushed stream message.
-// An idle backend (no open window at all) keeps the pre-existing idle-timeout
-// close behavior.
+// the coarser bound of one window from the most recent flushed stream message,
+// but only while no unary request owns a window. Once the oldest unary window
+// expires, newer stream traffic cannot rescue that already-stalled connection
+// generation. An idle backend (no open window at all) keeps the pre-existing
+// idle-timeout close behavior.
 func (rb *remoteBackend) keepOrdinaryDataConnection() bool {
 	now := rb.livenessTick()
-	if rb.withinReadWindow(now, rb.pendingRequestReadWindow()) {
-		return true
+	unaryWindow := rb.pendingRequestReadWindow()
+	if unaryWindow != 0 {
+		return rb.withinReadWindow(now, unaryWindow)
 	}
 	return rb.withinReadWindow(now, rb.atomic.lastStreamFlushAt.Load())
 }

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -561,6 +561,74 @@ func TestReadTimeout(t *testing.T) {
 	)
 }
 
+func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
+	rb := &remoteBackend{livenessEpoch: time.Now().Add(-2 * time.Second)}
+	rb.options.bufferSize = 1
+	rb.options.readTimeout = time.Second
+
+	// Preserve ordinary backends' existing idle-timeout behavior. The special
+	// case below applies only once a unary request has actually been flushed.
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded))
+	rb.mu.activeStreams = map[uint64]*stream{1: {}}
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"an active stream must retain the ordinary backend's timeout semantics")
+	clear(rb.mu.activeStreams)
+	internal := &Future{send: RPCMessage{internal: true}}
+	internal.writtenAt.Store(rb.livenessTick())
+	rb.mu.futures = map[uint64]*Future{1: internal}
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"internal traffic must not extend the user-request read window")
+
+	// If a request arrived during that old read window, it owns a fresh window
+	// measured from its write, rather than the remainder of the idle window.
+	pending := &Future{}
+	pending.writtenAt.Store(rb.livenessTick())
+	rb.mu.futures = map[uint64]*Future{1: pending}
+	require.True(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded))
+
+	// A backend without an independent liveness probe still closes once a full
+	// request-owned window has elapsed without progress.
+	pending.writtenAt.Store(rb.livenessTick() - rb.options.readTimeout.Nanoseconds())
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded))
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), errors.New("connection reset")))
+}
+
+func TestReadTimeoutTracksRequestsWithoutLivenessProbe(t *testing.T) {
+	requestReceived := make(chan struct{})
+	var received sync.Once
+	testBackendSend(t,
+		func(_ goetty.IOSession, message interface{}, _ uint64) error {
+			if !message.(RPCMessage).internal {
+				received.Do(func() { close(requestReceived) })
+			}
+			return nil
+		},
+		func(b *remoteBackend) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			f, err := b.Send(ctx, newTestMessage(1))
+			require.NoError(t, err)
+			defer f.Close()
+			require.NoError(t, f.waitSendCompleted())
+
+			select {
+			case <-requestReceived:
+			case <-ctx.Done():
+				t.Fatal("request did not reach server")
+			}
+			require.NotZero(t, b.oldestPendingRequestAt(),
+				"read-timeout accounting must not depend on a liveness probe")
+		},
+		WithBackendReadTimeout(200*time.Millisecond),
+	)
+}
+
 func TestHealthyLivenessProbePreservesSlowRequest(t *testing.T) {
 	requestReceived := make(chan struct{})
 	releaseResponse := make(chan struct{})
@@ -1133,7 +1201,7 @@ func TestIndependentControlBackendPreservesSlowDataRequest(t *testing.T) {
 
 	dataFactory := NewGoettyBasedBackendFactory(
 		newTestCodec(),
-		// keepDataConnectionAfterProbe gives the probe one fifth of this timeout.
+		// keepDataConnectionAfterReadTimeout gives the probe one fifth of this timeout.
 		// The probe gets a full second without making the test wait for a timeout.
 		WithBackendReadTimeout(dataReadTimeout),
 		WithBackendLivenessProbe(func(ctx context.Context, _ string) error {
@@ -1182,7 +1250,7 @@ func TestIndependentControlBackendPreservesSlowDataRequest(t *testing.T) {
 	dataBackend.livenessMu.Unlock()
 	// Drive the read-timeout branch directly. Waiting for a real socket deadline
 	// only tests the clock and was the source of this test's CI flakiness.
-	require.True(t, dataBackend.keepDataConnectionAfterProbe(ctx, context.DeadlineExceeded))
+	require.True(t, dataBackend.keepDataConnectionAfterReadTimeout(ctx, context.DeadlineExceeded))
 	require.False(t, dataBackend.admissionAvailable(),
 		"a successful control probe must drain the stalled data backend")
 	require.Zero(t, client.closeIdleBackends(),

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -86,7 +86,7 @@ func TestBackendRequestLifecycleMetricsEndToEnd(t *testing.T) {
 				b.metrics.requestCompletedCounters[requestOutcomeSuccess])
 			durationBefore, _ := observerHistogram(t, b.metrics.requestDurationHistogram)
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 			defer cancel()
 			f, err := b.Send(ctx, newTestMessage(1))
 			require.NoError(t, err)
@@ -563,7 +563,7 @@ func TestReadTimeout(t *testing.T) {
 
 func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
 	rb := &remoteBackend{livenessEpoch: time.Now().Add(-2 * time.Second)}
-	rb.options.bufferSize = 1
+	rb.options.bufferSize = 2
 	rb.options.readTimeout = time.Second
 
 	// Preserve ordinary backends' existing idle-timeout behavior. The special
@@ -581,20 +581,43 @@ func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
 		"internal traffic must not extend the user-request read window")
+	rb.mu.futures = map[uint64]*Future{1: {oneWay: true}}
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"one-way traffic must not create a response read window")
+	inFlight := &Future{}
+	rb.mu.futures = map[uint64]*Future{1: inFlight}
+	require.True(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"an admitted request must not inherit the remainder of an idle read window")
+	inFlight.waiting.Store(true)
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"a terminal send failure must not extend the read window")
 
 	// If a request arrived during that old read window, it owns a fresh window
 	// measured from its write, rather than the remainder of the idle window.
 	pending := &Future{}
 	pending.writtenAt.Store(rb.livenessTick())
+	pending.waiting.Store(true)
 	rb.mu.futures = map[uint64]*Future{1: pending}
 	require.True(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded))
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		canceledCtx, context.DeadlineExceeded),
+		"backend cancellation must win over a fresh request window")
 
 	// A backend without an independent liveness probe still closes once a full
 	// request-owned window has elapsed without progress.
 	pending.writtenAt.Store(rb.livenessTick() - rb.options.readTimeout.Nanoseconds())
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded))
+	rb.mu.futures[2] = &Future{}
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"new admissions must not keep an already-stalled request generation alive")
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), errors.New("connection reset")))
 }
@@ -622,8 +645,10 @@ func TestReadTimeoutTracksRequestsWithoutLivenessProbe(t *testing.T) {
 			case <-ctx.Done():
 				t.Fatal("request did not reach server")
 			}
-			require.NotZero(t, b.oldestPendingRequestAt(),
+			writtenAt, writePending := b.pendingRequestReadWindow()
+			require.NotZero(t, writtenAt,
 				"read-timeout accounting must not depend on a liveness probe")
+			require.False(t, writePending)
 		},
 		WithBackendReadTimeout(200*time.Millisecond),
 	)

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -573,7 +573,7 @@ func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
 	rb.mu.activeStreams = map[uint64]*stream{1: {}}
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
-		"an active stream must retain the ordinary backend's timeout semantics")
+		"a stream with no flushed message must retain the ordinary backend's timeout semantics")
 	clear(rb.mu.activeStreams)
 	internal := &Future{send: RPCMessage{internal: true}}
 	internal.writtenAt.Store(rb.livenessTick())
@@ -581,15 +581,23 @@ func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
 		"internal traffic must not extend the user-request read window")
-	rb.mu.futures = map[uint64]*Future{1: {oneWay: true}}
+	oneWay := &Future{oneWay: true}
+	oneWay.send.createAt = time.Now()
+	rb.mu.futures = map[uint64]*Future{1: oneWay}
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
 		"one-way traffic must not create a response read window")
 	inFlight := &Future{}
+	inFlight.send.createAt = time.Now()
 	rb.mu.futures = map[uint64]*Future{1: inFlight}
 	require.True(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
 		"an admitted request must not inherit the remainder of an idle read window")
+	inFlight.send.createAt = time.Now().Add(-rb.options.readTimeout)
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"a request stuck before flush must not renew the connection beyond one admission window")
+	inFlight.send.createAt = time.Now()
 	inFlight.waiting.Store(true)
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
@@ -614,12 +622,28 @@ func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
 	pending.writtenAt.Store(rb.livenessTick() - rb.options.readTimeout.Nanoseconds())
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded))
-	rb.mu.futures[2] = &Future{}
+	fresh := &Future{}
+	fresh.send.createAt = time.Now()
+	rb.mu.futures[2] = fresh
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
 		"new admissions must not keep an already-stalled request generation alive")
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), errors.New("connection reset")))
+
+	// Stream traffic owns one window from its most recent successful flush, so
+	// a stream message admitted late in an idle read window is not charged the
+	// idle time; once that window elapses the idle-close behavior returns.
+	clear(rb.mu.futures)
+	rb.atomic.lastStreamFlushAt.Store(rb.livenessTick())
+	require.True(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"a freshly flushed stream message owns one complete read window")
+	rb.atomic.lastStreamFlushAt.Store(
+		rb.livenessTick() - rb.options.readTimeout.Nanoseconds())
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"an expired stream window must not keep a silent connection open")
 }
 
 func TestReadTimeoutTracksRequestsWithoutLivenessProbe(t *testing.T) {
@@ -645,10 +669,39 @@ func TestReadTimeoutTracksRequestsWithoutLivenessProbe(t *testing.T) {
 			case <-ctx.Done():
 				t.Fatal("request did not reach server")
 			}
-			writtenAt, writePending := b.pendingRequestReadWindow()
-			require.NotZero(t, writtenAt,
+			require.NotZero(t, f.writtenAt.Load(),
+				"a flushed request must carry its flush stamp")
+			require.Equal(t, f.writtenAt.Load(), b.pendingRequestReadWindow(),
 				"read-timeout accounting must not depend on a liveness probe")
-			require.False(t, writePending)
+		},
+		WithBackendReadTimeout(200*time.Millisecond),
+	)
+}
+
+func TestReadTimeoutTracksStreamWritesWithoutLivenessProbe(t *testing.T) {
+	testBackendSend(t,
+		func(_ goetty.IOSession, _ interface{}, _ uint64) error {
+			// no response: only the write-side stamp is under test
+			return nil
+		},
+		func(b *remoteBackend) {
+			st, err := b.NewStream(false)
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, st.Close(false))
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			// Send returns only after the flush completed, so the stamp is
+			// already published.
+			require.NoError(t, st.Send(ctx, &testMessage{id: st.ID()}))
+
+			require.NotZero(t, b.atomic.lastStreamFlushAt.Load(),
+				"a flushed stream message must open a stream read window")
+			require.True(t, b.keepDataConnectionAfterReadTimeout(
+				context.Background(), context.DeadlineExceeded),
+				"a stream message admitted late in an idle read window must not be charged the idle time")
 		},
 		WithBackendReadTimeout(200*time.Millisecond),
 	)

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -622,6 +622,10 @@ func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
 	pending.writtenAt.Store(rb.livenessTick() - rb.options.readTimeout.Nanoseconds())
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded))
+	rb.atomic.lastStreamFlushAt.Store(rb.livenessTick())
+	require.False(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"fresh stream traffic must not rescue a generation with an expired unary request")
 	fresh := &Future{}
 	fresh.send.createAt = time.Now()
 	rb.mu.futures[2] = fresh
@@ -639,6 +643,12 @@ func TestReadTimeoutDoesNotChargeIdleTimeToNewRequest(t *testing.T) {
 	require.True(t, rb.keepDataConnectionAfterReadTimeout(
 		context.Background(), context.DeadlineExceeded),
 		"a freshly flushed stream message owns one complete read window")
+	failed := &Future{}
+	failed.waiting.Store(true)
+	rb.mu.futures[1] = failed
+	require.True(t, rb.keepDataConnectionAfterReadTimeout(
+		context.Background(), context.DeadlineExceeded),
+		"a terminal unary send failure owns no response window and must not suppress a live stream")
 	rb.atomic.lastStreamFlushAt.Store(
 		rb.livenessTick() - rb.options.readTimeout.Nanoseconds())
 	require.False(t, rb.keepDataConnectionAfterReadTimeout(

--- a/pkg/common/morpc/future.go
+++ b/pkg/common/morpc/future.go
@@ -246,6 +246,17 @@ func (f *Future) getSendMessageID() uint64 {
 	return f.id
 }
 
+// isUserUnary reports whether this Future carries an ordinary user unary
+// request: the only traffic class whose response owns a per-request read
+// window. The writeLoop flush stamp and pendingRequestReadWindow must use this
+// same predicate; a Future counted by the scan but never stamped would read as
+// pending forever, and one stamped but not scanned would lose its window.
+// (The probe-mode trackLiveness predicate in doWrite intentionally differs:
+// it also tracks one-way user traffic.)
+func (f *Future) isUserUnary() bool {
+	return !f.send.internal && !f.send.stream && !f.oneWay
+}
+
 func (f *Future) done(response Message, cb func()) bool {
 	f.mu.Lock()
 	if f.mu.notified || f.mu.closed || f.timeout() ||

--- a/pkg/common/morpc/future.go
+++ b/pkg/common/morpc/future.go
@@ -39,8 +39,9 @@ type Future struct {
 	c    chan Message
 	errC chan error
 	// used to check error for sending message
-	writtenC chan error
-	waiting  atomic.Bool
+	writtenC  chan error
+	waiting   atomic.Bool
+	writtenAt atomic.Int64
 	// requestMetricObserved makes terminal request accounting exactly once even
 	// when timeout, transport failure, response delivery, and Close race.
 	requestMetricObserved atomic.Bool
@@ -67,6 +68,7 @@ func (f *Future) init(send RPCMessage) {
 		panic("context deadline not set")
 	}
 	f.waiting.Store(false)
+	f.writtenAt.Store(0)
 	f.requestMetricObserved.Store(false)
 	f.requestMetrics = nil
 	f.send = send
@@ -314,6 +316,7 @@ func (f *Future) reset() {
 	default:
 	}
 	f.send = RPCMessage{}
+	f.writtenAt.Store(0)
 	f.sendRelease = nil
 	f.responseRelease = nil
 	f.requestMetrics = nil

--- a/pkg/common/morpc/future.go
+++ b/pkg/common/morpc/future.go
@@ -39,8 +39,11 @@ type Future struct {
 	c    chan Message
 	errC chan error
 	// used to check error for sending message
-	writtenC  chan error
-	waiting   atomic.Bool
+	writtenC chan error
+	waiting  atomic.Bool
+	// writtenAt is the backend-relative tick of a successfully flushed ordinary
+	// unary request. Zero plus waiting=false means write admission/in progress;
+	// zero plus waiting=true means terminal send failure.
 	writtenAt atomic.Int64
 	// requestMetricObserved makes terminal request accounting exactly once even
 	// when timeout, transport failure, response delivery, and Close race.

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2523,9 +2523,27 @@ func previewQuerySchedulingWithSQLMode(
 	}
 	previewCtx, cancel := context.WithTimeout(ctx, schedulingPreviewTimeout)
 	defer cancel()
+	return previewQuerySchedulingInContext(previewCtx, ses, query, txnHaveDDL, rawSQL, sqlMode)
+}
+
+// previewQuerySchedulingInContext computes a preview under the caller-owned
+// context. The frontend wrapper above owns the best-effort latency policy;
+// callers that need to observe the scheduling decision itself can provide a
+// lifecycle context without racing that decision against an unrelated clock.
+func previewQuerySchedulingInContext(
+	ctx context.Context,
+	ses *Session,
+	query *plan.Query,
+	txnHaveDDL bool,
+	rawSQL string,
+	sqlMode *string,
+) schedule.Trace {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if ses == nil {
 		return compile.PreviewQueryScheduling(compile.SchedulingPreviewRequest{
-			Context: previewCtx,
+			Context: ctx,
 			Query:   query,
 		})
 	}
@@ -2538,7 +2556,7 @@ func previewQuerySchedulingWithSQLMode(
 		intent = querySchedulingIntentForStatementWithSQLMode(ses, rawSQL, *sqlMode)
 	}
 	return compile.PreviewQueryScheduling(compile.SchedulingPreviewRequest{
-		Context:    previewCtx,
+		Context:    ctx,
 		Query:      query,
 		Engine:     ses.GetTxnHandler().GetStorage(),
 		Process:    ses.GetProc(),

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2538,9 +2538,6 @@ func previewQuerySchedulingInContext(
 	rawSQL string,
 	sqlMode *string,
 ) schedule.Trace {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if ses == nil {
 		return compile.PreviewQueryScheduling(compile.SchedulingPreviewRequest{
 			Context: ctx,

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2466,7 +2466,7 @@ func writeExplainResult(
 				sqlMode = &prepared.schedulingSQLMode
 			}
 		}
-		schedulingPreview := previewQuerySchedulingWithSQLMode(
+		schedulingPreview := previewQueryScheduling(
 			reqCtx, ses, exPlan.GetQuery(), txnHaveDDL, rawSQL, sqlMode)
 		appendSchedulingExplain(buffer, schedulingPreview)
 	}
@@ -2493,24 +2493,12 @@ func writeExplainResult(
 	return trySaveQueryResult(reqCtx, ses, mrs)
 }
 
+// previewQueryScheduling owns the production best-effort latency policy: the
+// preview runs under its own schedulingPreviewTimeout so a slow or blocked
+// engine cannot delay the EXPLAIN response. A nil sqlMode means "use the
+// session's current mode". Callers that need to observe the scheduling
+// decision itself use previewQuerySchedulingInContext below.
 func previewQueryScheduling(
-	ctx context.Context,
-	ses *Session,
-	query *plan.Query,
-	txnHaveDDL bool,
-	statementSQL ...string,
-) schedule.Trace {
-	rawSQL := ""
-	if ses != nil {
-		rawSQL = ses.GetSql()
-	}
-	if len(statementSQL) > 0 {
-		rawSQL = statementSQL[0]
-	}
-	return previewQuerySchedulingWithSQLMode(ctx, ses, query, txnHaveDDL, rawSQL, nil)
-}
-
-func previewQuerySchedulingWithSQLMode(
 	ctx context.Context,
 	ses *Session,
 	query *plan.Query,

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -7261,6 +7261,8 @@ func TestSchedulingPreviewHasIndependentTimeout(t *testing.T) {
 		ses,
 		&plan0.Query{Nodes: []*plan0.Node{{NodeType: plan0.Node_TABLE_SCAN}}},
 		false,
+		ses.GetSql(),
+		nil,
 	)
 
 	require.Less(t, time.Since(started), time.Second)
@@ -7299,6 +7301,8 @@ func TestSchedulingPreviewTimeoutBoundsPoolResolution(t *testing.T) {
 		ses,
 		&plan0.Query{Nodes: []*plan0.Node{{NodeType: plan0.Node_TABLE_SCAN}}},
 		false,
+		ses.GetSql(),
+		nil,
 	)
 
 	require.Less(t, time.Since(started), time.Second)
@@ -7340,6 +7344,8 @@ func TestSchedulingPreviewDoesNotCallBlockingLegacyEngine(t *testing.T) {
 			ses,
 			&plan0.Query{Nodes: []*plan0.Node{{NodeType: plan0.Node_TABLE_SCAN}}},
 			false,
+			ses.GetSql(),
+			nil,
 		)
 	}()
 

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -7007,9 +7007,11 @@ func TestDirectSessionStrictPoolWithoutLabelSelectorFailsClosed(t *testing.T) {
 	}
 	require.Empty(t, ses.getCNLabels())
 	require.NoError(t, ses.SetSessionSysVar(context.Background(), queryPoolStrict, int64(1)))
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
 
 	trace := previewQuerySchedulingInContext(
-		t.Context(),
+		ctx,
 		ses,
 		&plan0.Query{Nodes: []*plan0.Node{{NodeType: plan0.Node_TABLE_SCAN}}},
 		false,

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -7008,11 +7008,13 @@ func TestDirectSessionStrictPoolWithoutLabelSelectorFailsClosed(t *testing.T) {
 	require.Empty(t, ses.getCNLabels())
 	require.NoError(t, ses.SetSessionSysVar(context.Background(), queryPoolStrict, int64(1)))
 
-	trace := previewQueryScheduling(
-		context.Background(),
+	trace := previewQuerySchedulingInContext(
+		t.Context(),
 		ses,
 		&plan0.Query{Nodes: []*plan0.Node{{NodeType: plan0.Node_TABLE_SCAN}}},
 		false,
+		"",
+		nil,
 	)
 
 	require.Len(t, trace.Attempts, 1)

--- a/pkg/vm/engine/tae/db/merge/scheduler_test.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler_test.go
@@ -336,13 +336,17 @@ func TestScheduler(t *testing.T) {
 
 	{
 		// test policy patch
+		// Keep the patch alive beyond the test's hang guard. This block verifies
+		// policy composition, not expiration; expiration has a separate fake-clock
+		// test below.
+		policyPatchExpiry := sched.clock.Now().Add(time.Hour)
 
 		trigger := NewMMsgTaskTrigger(tables[0])
 		trigger.WithL0(DefaultLayerZeroOpts.Clone().WithToleranceDegressionCurve(20, 1, 10*time.Second, [4]float64{0, 0, 0, 0}))
 		trigger.WithLn(-1, 10, DefaultOverlapOpts.Clone().WithMinPointDepthPerCluster(4))
 		trigger.WithTombstone(DefaultTombstoneOpts.Clone().WithL2Count(10))
 		trigger.WithVacuumCheck(DefaultVacuumOpts.Clone().WithHollowTopK(20))
-		trigger.WithExpire(time.Now().Add(50 * time.Millisecond))
+		trigger.WithExpire(policyPatchExpiry)
 		sched.SendTrigger(trigger)
 
 		answer := requireQuery(t, sched, tables[0])
@@ -351,7 +355,7 @@ func TestScheduler(t *testing.T) {
 		// merge existing patch
 		sched.SendTrigger(
 			NewMMsgTaskTrigger(tables[0]).
-				WithExpire(time.Now().Add(25 * time.Millisecond)).
+				WithExpire(policyPatchExpiry).
 				WithTombstone(DefaultTombstoneOpts.Clone().WithL2Count(100)),
 		)
 
@@ -410,6 +414,42 @@ func TestScheduler(t *testing.T) {
 		require.Equal(t, answer.NotExists, true)
 	}
 
+}
+
+func TestSchedulerPolicyPatchExpirationUsesInjectedClock(t *testing.T) {
+	clock := newFakeClock()
+	db := catalog.MockDBEntryWithAccInfo(1, 1001)
+	table := catalog.ToMergeTable(catalog.MockTableEntryWithDB(db, 1001))
+	sched := NewMergeScheduler(
+		time.Hour,
+		&dummyCatalogSource{initTables: []catalog.MergeTable{table}},
+		&dummyExecutor{},
+		clock,
+	)
+	sched.PatchTestRscController(newSimRscController(16 * common.Const1GBytes))
+
+	expiresAt := clock.Now().Add(time.Minute)
+	sched.handleTaskTrigger(nil, NewMMsgTaskTrigger(table).
+		WithExpire(expiresAt).
+		WithTombstone(DefaultTombstoneOpts.Clone().WithL2Count(10)))
+	sched.handleTaskTrigger(nil, NewMMsgTaskTrigger(table).
+		WithExpire(expiresAt).
+		WithTombstone(DefaultTombstoneOpts.Clone().WithL2Count(100)))
+
+	supp := sched.supps[table.ID()]
+	require.NotNil(t, supp)
+	require.Len(t, supp.triggers, 1, "policy updates must merge in place")
+	require.Equal(t, 100, supp.triggers[0].tomb.L2Count)
+
+	// Expiration is strict: a patch remains valid at its deadline and is removed
+	// only after the injected clock moves past it.
+	clock.Advance(time.Minute)
+	sched.doSched(nil, supp.todo)
+	require.Len(t, supp.triggers, 1)
+
+	clock.Advance(time.Nanosecond)
+	sched.doSched(nil, supp.todo)
+	require.Empty(t, supp.triggers)
 }
 
 type blockingMergeTable struct {

--- a/pkg/vm/engine/tae/db/merge/scheduler_test.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler_test.go
@@ -46,13 +46,18 @@ func (e *dummyExecutor) ExecuteFor(table catalog.MergeTable, task mergeTask) boo
 
 type recordingExecutor struct {
 	executed chan uint64
+	overflow atomic.Bool
 }
 
 func (e *recordingExecutor) ExecuteFor(table catalog.MergeTable, task mergeTask) bool {
 	if task.doneCB != nil {
 		task.doneCB.OnExecDone(nil)
 	}
-	e.executed <- table.ID()
+	select {
+	case e.executed <- table.ID():
+	default:
+		e.overflow.Store(true)
+	}
 	return true
 }
 
@@ -117,16 +122,23 @@ func requireQuery(
 	table catalog.MergeTable,
 ) *QueryAnswer {
 	t.Helper()
-	answer, err := sched.Query(context.Background(), table)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	answer, err := sched.Query(ctx, table)
 	require.NoError(t, err)
 	return answer
 }
 
 type droppedMergeTable struct {
 	catalog.MergeTable
+	checked chan struct{}
+	once    sync.Once
 }
 
 func (t *droppedMergeTable) HasDropCommitted() bool {
+	if t.checked != nil {
+		t.once.Do(func() { close(t.checked) })
+	}
 	return true
 }
 
@@ -187,10 +199,14 @@ func TestScheduler(t *testing.T) {
 		return catalog.ToMergeTable(table)
 	}
 
+	dropped := &droppedMergeTable{
+		MergeTable: newTestTable(1, 1003),
+		checked:    make(chan struct{}),
+	}
 	tables := []catalog.MergeTable{
 		newTestTable(1, 1001),
 		newTestTable(1, 1002),
-		&droppedMergeTable{MergeTable: newTestTable(1, 1003)},
+		dropped,
 	}
 
 	dummySource := &dummyCatalogSource{
@@ -198,7 +214,8 @@ func TestScheduler(t *testing.T) {
 		initTables: tables,
 	}
 
-	executor := &recordingExecutor{executed: make(chan uint64, 16)}
+	t1002TaskCnt := bigDataTaskCntThreshold + 1
+	executor := &recordingExecutor{executed: make(chan uint64, t1002TaskCnt+2)}
 	sched := NewMergeScheduler(
 		1*time.Millisecond,
 		dummySource,
@@ -266,7 +283,6 @@ func TestScheduler(t *testing.T) {
 
 	}
 
-	t1002TaskCnt := bigDataTaskCntThreshold + 1
 	{
 		// make merge task
 		trigger := NewMMsgTaskTrigger(tables[1])
@@ -356,16 +372,19 @@ func TestScheduler(t *testing.T) {
 		for _, count := range expected {
 			remaining += count
 		}
+		timer := time.NewTimer(10 * time.Second)
+		defer timer.Stop()
 		for remaining > 0 {
 			select {
 			case tableID := <-executor.executed:
 				require.Positive(t, expected[tableID], "unexpected merge for table %d", tableID)
 				expected[tableID]--
 				remaining--
-			case <-time.After(10 * time.Second):
+			case <-timer.C:
 				t.Fatalf("merge scheduler did not execute all tasks: remaining=%v", expected)
 			}
 		}
+		require.False(t, executor.overflow.Load(), "merge executor observation buffer overflowed")
 
 		answer := requireQuery(t, sched, t1004)
 		require.Equal(t, answer.DataMergeCnt, 1)
@@ -380,11 +399,13 @@ func TestScheduler(t *testing.T) {
 
 	{
 		// dropped table will be removed from scheduler
-		require.NoError(t, sched.SendTrigger(NewMMsgTaskTrigger(tables[2])))
-		// The first query fences trigger dispatch. The scheduler processes the
-		// now-due table at the top of its next cycle; the second query observes
-		// that completed cycle.
-		requireQuery(t, sched, tables[2])
+		timer := time.NewTimer(10 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-dropped.checked:
+		case <-timer.C:
+			t.Fatal("merge scheduler did not inspect the dropped table")
+		}
 		answer := requireQuery(t, sched, tables[2])
 		require.Equal(t, answer.NotExists, true)
 	}

--- a/pkg/vm/engine/tae/db/merge/scheduler_test.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler_test.go
@@ -116,13 +116,31 @@ func (c *dummyCatalogSource) GetMergeSettingsBatchFn() func() (*batch.Batch, fun
 	return c.settingsFn
 }
 
+// schedulerTestHangTimeout bounds every synchronization wait in this file. A
+// wait that exceeds it is a hang, not CI load; keep every guard site on this
+// one constant so they cannot drift apart.
+const schedulerTestHangTimeout = 10 * time.Second
+
+// waitOrFatal waits for one signal on ch or fails the test at the shared hang
+// guard.
+func waitOrFatal(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	timer := time.NewTimer(schedulerTestHangTimeout)
+	defer timer.Stop()
+	select {
+	case <-ch:
+	case <-timer.C:
+		t.Fatal(msg)
+	}
+}
+
 func requireQuery(
 	t *testing.T,
 	sched *MergeScheduler,
 	table catalog.MergeTable,
 ) *QueryAnswer {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), schedulerTestHangTimeout)
 	defer cancel()
 	answer, err := sched.Query(ctx, table)
 	require.NoError(t, err)
@@ -315,7 +333,11 @@ func TestScheduler(t *testing.T) {
 		}
 
 		opts2 := NewVacuumOpts()
-		opts2.HollowTopK = 1
+		// Keep HollowTopK above the injected task count: a full HollowTopK arms a
+		// wall-clock 10s vacuum recheck whose persistent inject would emit an
+		// extra ExecuteFor event into the exactly-sized drain below under CI
+		// stalls. The recheck path has its own fake-clock test.
+		opts2.HollowTopK = 2
 		opts2.testInject = &vacuumTestInject{
 			compactTask: []mergeTask{
 				{
@@ -376,7 +398,7 @@ func TestScheduler(t *testing.T) {
 		for _, count := range expected {
 			remaining += count
 		}
-		timer := time.NewTimer(10 * time.Second)
+		timer := time.NewTimer(schedulerTestHangTimeout)
 		defer timer.Stop()
 		for remaining > 0 {
 			select {
@@ -403,17 +425,68 @@ func TestScheduler(t *testing.T) {
 
 	{
 		// dropped table will be removed from scheduler
-		timer := time.NewTimer(10 * time.Second)
-		defer timer.Stop()
-		select {
-		case <-dropped.checked:
-		case <-timer.C:
-			t.Fatal("merge scheduler did not inspect the dropped table")
-		}
+		waitOrFatal(t, dropped.checked,
+			"merge scheduler did not inspect the dropped table")
 		answer := requireQuery(t, sched, tables[2])
 		require.Equal(t, answer.NotExists, true)
 	}
 
+}
+
+func TestVacuumRecheckArmsOnFullHollowTopKUsingInjectedClock(t *testing.T) {
+	clock := newFakeClock()
+	db := catalog.MockDBEntryWithAccInfo(1, 1001)
+	table := catalog.ToMergeTable(catalog.MockTableEntryWithDB(db, 1001))
+	sched := NewMergeScheduler(
+		time.Hour,
+		&dummyCatalogSource{initTables: []catalog.MergeTable{table}},
+		&dummyExecutor{},
+		clock,
+	)
+	generation := newMergeSchedulerGeneration()
+
+	newOpts := func(hollowTopK int) *VacuumOpts {
+		opts := NewVacuumOpts()
+		opts.HollowTopK = hollowTopK
+		opts.testInject = &vacuumTestInject{
+			compactTask: []mergeTask{{
+				objs: []*objectio.ObjectStats{
+					newTestObjectStats(t, 1, 2, 30*common.Const1MBytes, 1000, 1, nil, 0),
+				},
+				note:  "test",
+				level: 1,
+			}},
+		}
+		return opts
+	}
+
+	// A partially hollow table (tasks < HollowTopK) sends only the compact
+	// trigger and must not arm the recheck.
+	sched.ioVacuumCheck(generation, MMsgVacuumCheck{Table: table, opts: newOpts(2)})
+	require.Len(t, sched.msgChan, 1)
+	clock.Advance(time.Minute)
+	require.Never(t, func() bool { return len(sched.msgChan) > 1 },
+		50*time.Millisecond, time.Millisecond,
+		"a partially hollow table must not schedule a vacuum recheck")
+
+	// A fully hollow table (tasks == HollowTopK) arms one recheck that fires
+	// only after the injected clock crosses the 10s deadline.
+	sched.ioVacuumCheck(generation, MMsgVacuumCheck{Table: table, opts: newOpts(1)})
+	require.Len(t, sched.msgChan, 2)
+	clock.Advance(10*time.Second - time.Nanosecond)
+	require.Never(t, func() bool { return len(sched.msgChan) > 2 },
+		50*time.Millisecond, time.Millisecond,
+		"the vacuum recheck must not fire before its deadline")
+	clock.Advance(time.Nanosecond)
+	require.Eventually(t, func() bool { return len(sched.msgChan) == 3 },
+		schedulerTestHangTimeout, time.Millisecond,
+		"the vacuum recheck must fire once the injected clock crosses the deadline")
+	<-sched.msgChan
+	<-sched.msgChan
+	recheck := <-sched.msgChan
+	require.Equal(t, MMsgKindTrigger, recheck.Kind)
+	trigger := recheck.Value.(*MMsgTaskTrigger)
+	require.NotNil(t, trigger.vacuum, "the recheck must carry a vacuum check")
 }
 
 func TestSchedulerPolicyPatchExpirationUsesInjectedClock(t *testing.T) {

--- a/pkg/vm/engine/tae/db/merge/scheduler_test.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler_test.go
@@ -44,6 +44,18 @@ func (e *dummyExecutor) ExecuteFor(table catalog.MergeTable, task mergeTask) boo
 	return true
 }
 
+type recordingExecutor struct {
+	executed chan uint64
+}
+
+func (e *recordingExecutor) ExecuteFor(table catalog.MergeTable, task mergeTask) bool {
+	if task.doneCB != nil {
+		task.doneCB.OnExecDone(nil)
+	}
+	e.executed <- table.ID()
+	return true
+}
+
 type delayedCompletionExecutor struct {
 	tasks chan mergeTask
 }
@@ -186,17 +198,20 @@ func TestScheduler(t *testing.T) {
 		initTables: tables,
 	}
 
+	executor := &recordingExecutor{executed: make(chan uint64, 16)}
 	sched := NewMergeScheduler(
 		1*time.Millisecond,
 		dummySource,
-		&dummyExecutor{},
+		executor,
 		NewStdClock(),
 	)
+	// Admission is part of scheduler behavior, but host memory pressure is not
+	// an input to this unit test. A deterministic controller keeps the test from
+	// silently changing meaning with the CI runner's cgroup state.
+	sched.PatchTestRscController(newSimRscController(16 * common.Const1GBytes))
 
 	sched.Start()
 	defer sched.Stop()
-
-	time.Sleep(3 * time.Millisecond)
 
 	{
 		// switch on/off
@@ -329,40 +344,47 @@ func TestScheduler(t *testing.T) {
 	}
 
 	{
-
-		var answer *QueryAnswer
-
-		for i := 0; i < 100; i++ {
-			answer = requireQuery(t, sched, t1004)
-			if answer.DataMergeCnt == 1 {
-				break
-			}
-			time.Sleep(5 * time.Millisecond)
+		// Wait on the executor boundary, not elapsed time. Receiving these events
+		// proves that both scheduler loops, resource admission, and completion
+		// accounting have handled every trigger under test.
+		expected := map[uint64]int{
+			t1004.ID():     1,
+			tables[1].ID(): t1002TaskCnt,
+			tables[0].ID(): 1,
 		}
+		remaining := 0
+		for _, count := range expected {
+			remaining += count
+		}
+		for remaining > 0 {
+			select {
+			case tableID := <-executor.executed:
+				require.Positive(t, expected[tableID], "unexpected merge for table %d", tableID)
+				expected[tableID]--
+				remaining--
+			case <-time.After(10 * time.Second):
+				t.Fatalf("merge scheduler did not execute all tasks: remaining=%v", expected)
+			}
+		}
+
+		answer := requireQuery(t, sched, t1004)
 		require.Equal(t, answer.DataMergeCnt, 1)
 
-		for i := 0; i < 100; i++ {
-			answer = requireQuery(t, sched, tables[1])
-			if answer.DataMergeCnt == t1002TaskCnt {
-				break
-			}
-			time.Sleep(5 * time.Millisecond)
-		}
+		answer = requireQuery(t, sched, tables[1])
 		require.Equal(t, answer.DataMergeCnt, t1002TaskCnt)
 		require.Equal(t, answer.VaccumTrigCount, 1)
 
-		for i := 0; i < 100; i++ {
-			answer = requireQuery(t, sched, tables[0])
-			if answer.DataMergeCnt == 1 {
-				break
-			}
-			time.Sleep(5 * time.Millisecond)
-		}
+		answer = requireQuery(t, sched, tables[0])
 		require.Equal(t, answer.DataMergeCnt, 1)
 	}
 
 	{
 		// dropped table will be removed from scheduler
+		require.NoError(t, sched.SendTrigger(NewMMsgTaskTrigger(tables[2])))
+		// The first query fences trigger dispatch. The scheduler processes the
+		// now-due table at the top of its next cycle; the second query observes
+		// that completed cycle.
+		requireQuery(t, sched, tables[2])
 		answer := requireQuery(t, sched, tables[2])
 		require.Equal(t, answer.NotExists, true)
 	}


### PR DESCRIPTION
## What changed

- give each ordinary MORPC unary request a complete read-timeout window from admission/flush, instead of charging it for socket-idle time before the request arrived
- distinguish admitted, successfully flushed, terminal-send-failed, and expired requests while preserving established idle, internal, and one-way behavior and giving stream writes their own bounded fallback window
- make tenant-upgrade tests execute the observable pass directly, bound every wait, and retain one end-to-end periodic-loop test
- make the merge scheduler test synchronize at the exact executor/table-check boundary, use deterministic resource admission, and prevent the test observer from blocking the scheduler
- separate frontend scheduling-preview computation from its production 100 ms best-effort latency policy so correctness tests do not race CI descheduling

## Root cause and design

The embedded-cluster failure was not a restore or privilege failure. `CREATE ACCOUNT` began during an already-running socket `Read` window and inherited only the remainder of a configured 20-second timeout. Merely increasing the timeout therefore could not guarantee a newly admitted request a full response window.

For a normal response-expecting unary request, the backend now models four relevant states:

1. admitted/queued or being flushed: retain the stale idle timeout because work is already pending;
2. successfully flushed: start one full response window at the successful flush timestamp;
3. terminal send failure: do not extend the connection lifetime;
4. expired response window: close the stalled backend; a newer admission cannot rescue it.

The timestamp is published before the terminal send-completion flag. The timeout scanner reads that flag before the timestamp, so it cannot observe an old zero timestamp paired with the new success flag. The hot path adds one atomic store only for normal unary traffic after a successful flush; the cold timeout path scans the existing lifecycle-bounded future set. Internal, one-way, probe-enabled, cancellation, and close semantics remain unchanged. Probe-less streams use one backend-level last-successful-flush window only when no unary response window exists; an expired unary remains authoritative.

The other failures had the same broad symptom but different mechanisms: correctness depended on a 20 ms asynchronous timer, host/cgroup memory plus 3/5 ms scheduler polling, or a production 100 ms best-effort preview timeout. Race instrumentation and package-parallel CI load can delay those operations without changing their business result. Tests now synchronize on observable state transitions, carry bounded parent contexts, and explicitly distinguish expected cancellation from a hang deadline.

The lifecycle audit found no new unbounded state or waits: future ownership remains reference-counted and backend-close bounded; the timeout scan covers only existing live futures; merge observation is nonblocking and overflow-checked; every new test wait has a 10-second guard.

Fixes #27963

## Test plan

Passed before rebase:

- MORPC state matrix under race: `TestReadTimeoutDoesNotChargeIdleTimeToNewRequest` (`-count=100`)
- actual MORPC request tracking under race: `TestReadTimeoutTracksRequestsWithoutLivenessProbe` (`-count=50`)
- merge scheduler under race: `TestScheduler` (`-count=100`)
- frontend strict-pool path under race: `TestDirectSessionStrictPoolWithoutLabelSelectorFailsClosed` (`-count=50`)
- all seven tenant-upgrade tests separately under race (`-count=20` each)
- full package tests: `pkg/common/morpc`, `pkg/bootstrap`, `pkg/frontend`, and `pkg/vm/engine/tae/db/merge`
- full `pkg/common/morpc` package under race
- targeted `go vet` for all four owning packages
- real embedded-cluster regression under race: `TestAuthenticatedTestsReuseBaseCluster` and `TestIssue26640ClusterRestoreRebindsSubscriptionPrivileges`

Rebased cleanly onto current `main` (`3f6856cc5f`). The two new upstream commits touched only frontend code, so the affected closure was rerun after rebase:

- full `pkg/frontend`: passed (13.974 s)
- strict-pool frontend counterexample under race, `-count=50`: passed (1.296 s)
- full `pkg/bootstrap`: passed (18.523 s)
- `go vet ./pkg/frontend ./pkg/bootstrap`: passed
- real embedded-cluster regressions under race: passed (36.040 s)
- `git diff --check`: passed

No SQL result, wire API, or planner contract changes are introduced, so no SQL BVT case is required; the embedded-cluster tests exercise the public transport/session path directly.

CI reruns for the unrelated failures on #27949 and #27946 were triggered separately; this PR does not wait for those reruns.

Post-review deterministic-clock closure (99e9d6c499):

- removed the remaining 25/50 ms wall-clock oracle from TestScheduler; policy composition now uses a lifetime longer than the test hang guard
- added TestSchedulerPolicyPatchExpirationUsesInjectedClock to prove in-place policy merging, exact-deadline validity, and removal immediately after the injected clock crosses the deadline
- focused normal tests passed; both scheduler tests passed separately under race detection with count 100; the full merge package passed