### PR TITLE
[4.2-dev] fix(pipeline): make terminal completion durable

### DIFF
--- a/pkg/sql/colexec/connector/types_test.go
+++ b/pkg/sql/colexec/connector/types_test.go
@@ -121,7 +121,7 @@ func TestConnectorResetPreservesErrorAheadOfDeliveredTerminal(t *testing.T) {
 	require.Equal(t, int64(0), mp.CurrNB())
 }
 
-func TestConnectorResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing.T) {
+func TestConnectorResetRecordsEndWhenDataChannelIsFull(t *testing.T) {
 	oldSignalSendTimeout := process.PipelineSignalSendTimeout
 	process.PipelineSignalSendTimeout = 10 * time.Millisecond
 	t.Cleanup(func() {
@@ -161,25 +161,33 @@ func TestConnectorResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("Connector.Reset blocked after normal End delivery failed")
+		t.Fatal("Connector.Reset blocked while recording End on a full channel")
 	}
 	require.Nil(t, conn.ctr.sp)
-	require.Nil(t, conn.cleanupSpool)
-	require.Equal(t, int64(0), mp.CurrNB())
+	require.Same(t, sp, conn.cleanupSpool)
+	require.Greater(t, mp.CurrNB(), int64(0))
 	select {
 	case <-reg.Done():
 	default:
-		t.Fatal("fallback abort did not close Done")
+		t.Fatal("durable End did not close Done")
 	}
-	require.ErrorIs(t, reg.Err(), process.ErrPipelineEndSignalDeliveryFailed)
+	require.NoError(t, reg.Err())
 
-	staleSignal := <-reg.Ch2
-	got, info := staleSignal.Action()
+	receiver := process.InitPipelineSignalReceiver(context.Background(), []*process.WaitRegister{reg})
+	got, info := receiver.GetNextBatch(nil)
+	require.NoError(t, info)
+	require.NotNil(t, got)
+	require.Equal(t, 1024, got.RowCount())
+	got, info = receiver.GetNextBatch(nil)
 	require.Nil(t, got)
-	require.Same(t, process.ErrPipelineEndSignalDeliveryFailed, info)
+	require.NoError(t, info)
+
+	conn.CleanupDeferredSpool()
+	require.Nil(t, conn.cleanupSpool)
+	require.Equal(t, int64(0), mp.CurrNB())
 }
 
-func TestConnectorResetUndeliveredFallbackAbortWakesReceiver(t *testing.T) {
+func TestConnectorResetDurableEndWakesReceiverAfterBufferedData(t *testing.T) {
 	oldSignalSendTimeout := process.PipelineSignalSendTimeout
 	process.PipelineSignalSendTimeout = 10 * time.Millisecond
 	t.Cleanup(func() {
@@ -213,11 +221,11 @@ func TestConnectorResetUndeliveredFallbackAbortWakesReceiver(t *testing.T) {
 	select {
 	case result := <-resultCh:
 		require.Nil(t, result.bat)
-		require.ErrorIs(t, result.err, process.ErrPipelineEndSignalDeliveryFailed)
+		require.NoError(t, result.err)
 	case <-time.After(time.Second):
 		cancelReceiver()
 		<-resultCh
-		t.Fatal("receiver remained blocked after the fallback Abort failed to enter the full channel")
+		t.Fatal("receiver remained blocked after durable End")
 	}
 }
 
@@ -257,7 +265,7 @@ func TestConnectorResetPreservesRecordedTerminalError(t *testing.T) {
 	require.NotErrorIs(t, info, process.ErrPipelineEndSignalDeliveryFailed)
 }
 
-func TestConnectorResetUsesSharedTerminalSendBudget(t *testing.T) {
+func TestConnectorResetEndDoesNotWaitForChannelCapacity(t *testing.T) {
 	oldSignalSendTimeout := process.PipelineSignalSendTimeout
 	process.PipelineSignalSendTimeout = 200 * time.Millisecond
 	t.Cleanup(func() {
@@ -276,9 +284,9 @@ func TestConnectorResetUsesSharedTerminalSendBudget(t *testing.T) {
 	select {
 	case <-reg.Done():
 	default:
-		t.Fatal("fallback abort should mark the receiver edge terminal")
+		t.Fatal("durable End should mark the receiver edge terminal")
 	}
-	require.ErrorIs(t, reg.Err(), process.ErrPipelineEndSignalDeliveryFailed)
+	require.NoError(t, reg.Err())
 }
 
 func TestConnectorResetFailedNilErrorSendsTypedErrorWithCause(t *testing.T) {

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -697,7 +697,7 @@ func TestDispatchResetAbortsSpoolWhenSomeLocalRegIsFull(t *testing.T) {
 	}
 }
 
-func TestDispatchResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing.T) {
+func TestDispatchResetRecordsEndForFullAndAvailableChannels(t *testing.T) {
 	oldSignalSendTimeout := process.PipelineSignalSendTimeout
 	process.PipelineSignalSendTimeout = 10 * time.Millisecond
 	t.Cleanup(func() {
@@ -741,39 +741,42 @@ func TestDispatchResetFallsBackToAbortWhenEndSignalCannotBeDelivered(t *testing.
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("Dispatch.Reset blocked after normal End delivery failed")
+		t.Fatal("Dispatch.Reset blocked while recording normal End")
 	}
 	require.Nil(t, d.ctr)
-	require.Nil(t, d.cleanupSpool)
-	require.Equal(t, int64(0), mp.CurrNB())
+	require.Same(t, sp, d.cleanupSpool)
+	require.Greater(t, mp.CurrNB(), int64(0))
 
 	select {
 	case <-fullReg.Done():
 	default:
-		t.Fatal("fallback abort did not close Done for full receiver")
+		t.Fatal("durable End did not close Done for full receiver")
 	}
-	require.ErrorIs(t, fullReg.Err(), process.ErrPipelineEndSignalDeliveryFailed)
+	require.NoError(t, fullReg.Err())
 	select {
 	case <-healthyReg.Done():
 	default:
 		t.Fatal("End did not close Done for healthy receiver")
 	}
+	require.NoError(t, healthyReg.Err())
 
-	staleSignal := <-fullReg.Ch2
-	got, info := staleSignal.Action()
-	require.Nil(t, got)
-	require.Same(t, process.ErrPipelineEndSignalDeliveryFailed, info)
+	for _, reg := range []*process.WaitRegister{fullReg, healthyReg} {
+		receiver := process.InitPipelineSignalReceiver(context.Background(), []*process.WaitRegister{reg})
+		got, info := receiver.GetNextBatch(nil)
+		require.NoError(t, info)
+		require.NotNil(t, got)
+		require.Equal(t, 1024, got.RowCount())
+		got, info = receiver.GetNextBatch(nil)
+		require.Nil(t, got)
+		require.NoError(t, info)
+	}
 
-	staleSignal = <-healthyReg.Ch2
-	got, info = staleSignal.Action()
-	require.Nil(t, got)
-	require.Same(t, process.ErrPipelineEndSignalDeliveryFailed, info)
-
-	terminalSignal := <-healthyReg.Ch2
-	require.Equal(t, process.EventEnd, terminalSignal.EventType)
+	d.CleanupDeferredSpool()
+	require.Nil(t, d.cleanupSpool)
+	require.Equal(t, int64(0), mp.CurrNB())
 }
 
-func TestDispatchResetUsesSharedTerminalSendBudget(t *testing.T) {
+func TestDispatchResetEndDoesNotWaitForChannelCapacity(t *testing.T) {
 	oldSignalSendTimeout := process.PipelineSignalSendTimeout
 	process.PipelineSignalSendTimeout = 200 * time.Millisecond
 	t.Cleanup(func() {
@@ -796,9 +799,9 @@ func TestDispatchResetUsesSharedTerminalSendBudget(t *testing.T) {
 		select {
 		case <-reg.Done():
 		default:
-			t.Fatal("fallback abort should mark every failed receiver edge terminal")
+			t.Fatal("durable End should mark every receiver edge terminal")
 		}
-		require.ErrorIs(t, reg.Err(), process.ErrPipelineEndSignalDeliveryFailed)
+		require.NoError(t, reg.Err())
 	}
 }
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -500,30 +500,32 @@ func (c *Compile) isRetryErr(err error) bool {
 }
 
 type scopeRunResult struct {
-	err error
-	ctx context.Context
+	err      error
+	ctx      context.Context
+	queryCtx context.Context
 }
 
 func newScopeRunResult(err error, scope *Scope) scopeRunResult {
-	result := scopeRunResult{err: err}
-	if scope != nil && scope.Proc != nil {
-		result.ctx = scope.Proc.Ctx
+	if scope == nil {
+		return scopeRunResult{err: err}
 	}
+	return newScopeRunResultForProcess(err, scope.Proc)
+}
+
+func newScopeRunResultForProcess(err error, proc *process.Process) scopeRunResult {
+	result := scopeRunResult{err: err}
+	if proc == nil {
+		return result
+	}
+	result.ctx = proc.Ctx
+	result.queryCtx = scopeRunQueryContext(proc)
 	return result
 }
 
 func (r scopeRunResult) resolveCancelCause() (scopeRunResult, bool) {
-	if r.err == nil || r.ctx == nil ||
-		(!errors.Is(r.err, context.Canceled) &&
-			!errors.Is(r.err, context.DeadlineExceeded) &&
-			!moerr.IsMoErrCode(r.err, moerr.ErrQueryInterrupted)) {
-		return r, false
-	}
-	if cause := context.Cause(r.ctx); cause != nil {
-		r.err = cause
-		return r, true
-	}
-	return r, false
+	var normalized bool
+	r.err, normalized = normalizeScopeRunError(r.err, r.ctx, r.queryCtx)
+	return r, normalized
 }
 
 // preferPrimaryScopeResult keeps cleanup fallout from masking the execution
@@ -533,7 +535,7 @@ func (r scopeRunResult) resolveCancelCause() (scopeRunResult, bool) {
 // error, while an externally canceled query keeps its external cause.
 func preferPrimaryScopeResult(current, candidate scopeRunResult) scopeRunResult {
 	current, _ = current.resolveCancelCause()
-	candidate, candidateHasCause := candidate.resolveCancelCause()
+	candidate, candidateNormalized := candidate.resolveCancelCause()
 
 	if current.err == nil {
 		return candidate
@@ -543,13 +545,11 @@ func preferPrimaryScopeResult(current, candidate scopeRunResult) scopeRunResult 
 		errors.Is(candidate.err, process.ErrPipelineEndSignalDeliveryFailed) {
 		return current
 	}
-	// Without a cancellation cause, a canceled sibling does not prove that the
-	// cleanup fallback was secondary. Process-backed production results always
-	// carry their pipeline context, but keep this conservative for synthetic
-	// and start-failure results that do not.
-	if !candidateHasCause &&
-		(errors.Is(candidate.err, context.Canceled) ||
-			moerr.IsMoErrCode(candidate.err, moerr.ErrQueryInterrupted)) {
+	// An unresolved pure cancellation does not prove that the cleanup fallback
+	// was secondary. A mixed error tree is substantive, however, and must not be
+	// rejected merely because one leaf is context.Canceled.
+	if !candidateNormalized &&
+		isScopeCancellationFrom(candidate.err, context.Canceled) {
 		return current
 	}
 	return candidate

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -681,13 +681,24 @@ func TestDebugLogFor19288(t *testing.T) {
 func TestPreferPrimaryScopeResult(t *testing.T) {
 	cleanupErr := process.ErrPipelineEndSignalDeliveryFailed
 	executionErr := moerr.NewDuplicateEntryNoCtx("1000000", "")
+	joinedExecutionErr := errors.Join(executionErr, context.Canceled)
+	joinedDeadlineErr := errors.Join(context.DeadlineExceeded, context.Canceled)
 	queryInterrupted := moerr.NewQueryInterrupted(context.Background())
+	joinedCancellationErr := errors.Join(context.Canceled, queryInterrupted)
 	internalCancelCtx, cancelInternal := context.WithCancelCause(context.Background())
 	cancelInternal(executionErr)
+	internalNormalCancelCtx, cancelInternalNormal := context.WithCancelCause(context.Background())
+	cancelInternalNormal(nil)
+	activeQueryCtx := context.Background()
 	externalCancelCtx, cancelExternal := context.WithCancel(context.Background())
 	cancelExternal()
 	externalDeadlineCtx, cancelExternalDeadline := context.WithTimeout(context.Background(), 0)
 	defer cancelExternalDeadline()
+	queryDeadlineCauseCtx, cancelQueryDeadlineCause := context.WithTimeoutCause(
+		context.Background(), 0, moerr.CauseInternalExecutorExec)
+	defer cancelQueryDeadlineCause()
+	pipelineDeadlineCauseCtx, cancelPipelineDeadlineCause := context.WithCancelCause(queryDeadlineCauseCtx)
+	defer cancelPipelineDeadlineCause(nil)
 	externalCause := moerr.NewInternalErrorNoCtx("client canceled query")
 	externalCauseCtx, cancelExternalCause := context.WithCancelCause(context.Background())
 	cancelExternalCause(externalCause)
@@ -700,16 +711,21 @@ func TestPreferPrimaryScopeResult(t *testing.T) {
 	}{
 		{name: "first error", candidate: scopeRunResult{err: cleanupErr}, want: cleanupErr},
 		{name: "execution error replaces cleanup fallback", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: executionErr}, want: executionErr},
+		{name: "joined execution error replaces cleanup fallback", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: joinedExecutionErr}, want: joinedExecutionErr},
+		{name: "joined independent deadline replaces cleanup fallback", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: joinedDeadlineErr}, want: context.DeadlineExceeded},
 		{name: "causal cancellation replaces cleanup fallback with execution error", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: context.Canceled, ctx: internalCancelCtx}, want: executionErr},
 		{name: "external cancellation replaces cleanup fallback with external cause", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: context.Canceled, ctx: externalCauseCtx}, want: externalCause},
 		{name: "cleanup fallback does not replace execution error", current: scopeRunResult{err: executionErr}, candidate: scopeRunResult{err: cleanupErr}, want: executionErr},
 		{name: "unresolved canceled sibling is secondary", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: context.Canceled}, want: cleanupErr},
 		{name: "unresolved interrupted sibling is secondary", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: queryInterrupted}, want: cleanupErr},
+		{name: "unresolved joined cancellation is secondary", current: scopeRunResult{err: cleanupErr}, candidate: scopeRunResult{err: joinedCancellationErr}, want: cleanupErr},
 		{name: "internally canceled sibling resolves to execution error", current: scopeRunResult{err: context.Canceled, ctx: internalCancelCtx}, candidate: scopeRunResult{err: executionErr}, want: executionErr},
+		{name: "normal internal cancellation is secondary", current: scopeRunResult{err: context.Canceled, ctx: internalNormalCancelCtx, queryCtx: activeQueryCtx}, candidate: scopeRunResult{err: executionErr}, want: executionErr},
 		{name: "internally interrupted sibling resolves to execution error", current: scopeRunResult{err: queryInterrupted, ctx: internalCancelCtx}, candidate: scopeRunResult{err: executionErr}, want: executionErr},
-		{name: "plain external cancellation remains primary", current: scopeRunResult{err: context.Canceled, ctx: externalCancelCtx}, candidate: scopeRunResult{err: executionErr}, want: context.Canceled},
-		{name: "external deadline remains primary", current: scopeRunResult{err: context.DeadlineExceeded, ctx: externalDeadlineCtx}, candidate: scopeRunResult{err: executionErr}, want: context.DeadlineExceeded},
-		{name: "external cancellation cause remains primary", current: scopeRunResult{err: context.Canceled, ctx: externalCauseCtx}, candidate: scopeRunResult{err: executionErr}, want: externalCause},
+		{name: "plain external cancellation remains primary", current: scopeRunResult{err: context.Canceled, ctx: externalCancelCtx, queryCtx: externalCancelCtx}, candidate: scopeRunResult{err: executionErr}, want: context.Canceled},
+		{name: "external deadline remains primary", current: scopeRunResult{err: context.DeadlineExceeded, ctx: externalDeadlineCtx, queryCtx: externalDeadlineCtx}, candidate: scopeRunResult{err: executionErr}, want: context.DeadlineExceeded},
+		{name: "query deadline classification survives custom timeout cause", current: scopeRunResult{err: context.DeadlineExceeded, ctx: pipelineDeadlineCauseCtx, queryCtx: queryDeadlineCauseCtx}, candidate: scopeRunResult{err: executionErr}, want: context.DeadlineExceeded},
+		{name: "external cancellation cause remains primary", current: scopeRunResult{err: context.Canceled, ctx: externalCauseCtx, queryCtx: externalCauseCtx}, candidate: scopeRunResult{err: executionErr}, want: externalCause},
 		{name: "first substantive error remains", current: scopeRunResult{err: executionErr}, candidate: scopeRunResult{err: moerr.NewInternalErrorNoCtx("later")}, want: executionErr},
 	}
 
@@ -722,6 +738,142 @@ func TestPreferPrimaryScopeResult(t *testing.T) {
 			} else {
 				require.Same(t, tt.want, got.err)
 			}
+		})
+	}
+}
+
+type scopeRunCancelErrorOperator struct {
+	*colexec.MockOperator
+	cancelCause error
+	runErr      error
+}
+
+func (op *scopeRunCancelErrorOperator) Call(proc *process.Process) (vm.CallResult, error) {
+	proc.Cancel(op.cancelCause)
+	return vm.NewCallResult(), op.runErr
+}
+
+func TestScopeRunPreservesPrimaryErrorAcrossCancellation(t *testing.T) {
+	primaryErr := moerr.NewInternalErrorNoCtx("hash build memory budget exceeded")
+	tests := []struct {
+		name        string
+		cancelCause error
+		runErr      error
+		want        error
+	}{
+		{
+			name:        "substantive execution error survives normal sibling cancellation",
+			cancelCause: nil,
+			runErr:      primaryErr,
+			want:        primaryErr,
+		},
+		{
+			name:        "joined execution error survives normal sibling cancellation",
+			cancelCause: nil,
+			runErr:      errors.Join(primaryErr, context.Canceled),
+			want:        primaryErr,
+		},
+		{
+			name:        "cancellation resolves to substantive pipeline cause",
+			cancelCause: primaryErr,
+			runErr:      context.Canceled,
+			want:        primaryErr,
+		},
+		{
+			name:        "normal internal cancellation remains secondary",
+			cancelCause: nil,
+			runErr:      context.Canceled,
+			want:        nil,
+		},
+		{
+			name:        "independent operator deadline survives normal cancellation",
+			cancelCause: nil,
+			runErr:      context.DeadlineExceeded,
+			want:        context.DeadlineExceeded,
+		},
+		{
+			name:        "joined independent deadline survives normal cancellation",
+			cancelCause: nil,
+			runErr:      errors.Join(context.DeadlineExceeded, context.Canceled),
+			want:        context.DeadlineExceeded,
+		},
+		{
+			name:        "joined cancellation fallout remains secondary",
+			cancelCause: nil,
+			runErr: errors.Join(
+				context.Canceled,
+				moerr.NewQueryInterrupted(context.Background())),
+			want: nil,
+		},
+		{
+			name:        "joined cancellation fallout resolves to substantive cause",
+			cancelCause: primaryErr,
+			runErr: errors.Join(
+				context.Canceled,
+				moerr.NewQueryInterrupted(context.Background())),
+			want: primaryErr,
+		},
+		{
+			name:        "joined independent deadline survives substantive cancellation cause",
+			cancelCause: primaryErr,
+			runErr:      errors.Join(context.DeadlineExceeded, context.Canceled),
+			want:        context.DeadlineExceeded,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			proc.BuildPipelineContext(context.Background())
+			op := &scopeRunCancelErrorOperator{
+				MockOperator: colexec.NewMockOperator(),
+				cancelCause:  test.cancelCause,
+				runErr:       test.runErr,
+			}
+			scope := &Scope{RootOp: op, Proc: proc}
+			compile := &Compile{proc: proc}
+
+			got := scope.Run(compile)
+			if test.want == nil {
+				require.NoError(t, got)
+			} else {
+				require.ErrorIs(t, got, test.want)
+			}
+		})
+	}
+}
+
+func TestScopeRunPreservesQueryDeadlineClassification(t *testing.T) {
+	tests := []struct {
+		name   string
+		runErr error
+	}{
+		{name: "deadline", runErr: context.DeadlineExceeded},
+		{name: "canceled child", runErr: context.Canceled},
+		{name: "query interrupted", runErr: moerr.NewQueryInterrupted(context.Background())},
+		{name: "joined deadline and cancellation", runErr: errors.Join(context.DeadlineExceeded, context.Canceled)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			deadlineCtx, cancelDeadline := context.WithTimeoutCause(
+				context.Background(), 0, moerr.CauseInternalExecutorExec)
+			defer cancelDeadline()
+			queryCtx := proc.Base.GetContextBase().BuildQueryCtx(deadlineCtx)
+			proc.BuildPipelineContext(queryCtx)
+
+			op := &scopeRunCancelErrorOperator{
+				MockOperator: colexec.NewMockOperator(),
+				runErr:       test.runErr,
+			}
+			got := (&Scope{RootOp: op, Proc: proc}).Run(&Compile{proc: proc})
+			require.ErrorIs(t, got, context.DeadlineExceeded)
+			require.NotErrorIs(t, got, moerr.CauseInternalExecutorExec)
+
+			attached := moerr.AttachCause(deadlineCtx, got)
+			require.ErrorIs(t, attached, context.DeadlineExceeded)
+			require.ErrorIs(t, attached, moerr.CauseInternalExecutorExec)
 		})
 	}
 }

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -2305,6 +2305,124 @@ func TestSendNotifyMessageReportsSenderFactoryError(t *testing.T) {
 	wg.Wait()
 }
 
+func TestSendNotifyMessageNormalizesPipelineCancellationCause(t *testing.T) {
+	duplicateErr := moerr.NewDuplicateEntryNoCtx("1", "primary")
+	tests := []struct {
+		name               string
+		cancelCause        error
+		cancelQuery        bool
+		keepPipelineActive bool
+		factoryErr         func(context.Context) error
+		wantErr            error
+	}{
+		{
+			name:        "query interruption recovers substantive cancellation cause",
+			cancelCause: duplicateErr,
+			factoryErr: func(ctx context.Context) error {
+				return moerr.NewQueryInterrupted(ctx)
+			},
+			wantErr: duplicateErr,
+		},
+		{
+			name: "normal query interruption remains secondary",
+			factoryErr: func(ctx context.Context) error {
+				return moerr.NewQueryInterrupted(ctx)
+			},
+		},
+		{
+			name:        "raw cancellation recovers substantive cancellation cause",
+			cancelCause: duplicateErr,
+			factoryErr: func(context.Context) error {
+				return context.Canceled
+			},
+			wantErr: duplicateErr,
+		},
+		{
+			name: "raw pipeline cancellation without substantive cause is secondary",
+			factoryErr: func(context.Context) error {
+				return context.Canceled
+			},
+		},
+		{
+			name:        "raw query cancellation remains visible",
+			cancelQuery: true,
+			factoryErr: func(context.Context) error {
+				return context.Canceled
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name:               "raw cancellation while pipeline is active remains visible",
+			keepPipelineActive: true,
+			factoryErr: func(context.Context) error {
+				return context.Canceled
+			},
+			wantErr: context.Canceled,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
+			proc.BuildPipelineContext(queryCtx)
+			scopeProc := proc.NewContextChildProc(1)
+			if tt.cancelQuery {
+				_, cancelQuery := process.GetQueryCtxFromProc(proc)
+				require.NotNil(t, cancelQuery)
+				cancelQuery()
+			} else if !tt.keepPipelineActive {
+				scopeProc.Cancel(tt.cancelCause)
+			}
+
+			uid, err := uuid.NewV7()
+			require.NoError(t, err)
+			s := &Scope{
+				Proc: scopeProc,
+				RemoteReceivRegInfos: []RemoteReceivRegInfo{
+					{Idx: 0, Uuid: uid, FromAddr: "remote-cn"},
+				},
+			}
+			factory := func(
+				ctx context.Context,
+				_ string,
+				_ string,
+				_ *mpool.MPool,
+				_ *AnalyzeModule,
+			) (*messageSenderOnClient, error) {
+				return nil, tt.factoryErr(ctx)
+			}
+
+			var wg sync.WaitGroup
+			resultCh := make(chan notifyMessageResult, 1)
+			s.sendNotifyMessageWithFactory(&wg, resultCh, factory)
+
+			select {
+			case result := <-resultCh:
+				if tt.wantErr == nil {
+					require.NoError(t, result.err)
+				} else {
+					require.ErrorIs(t, result.err, tt.wantErr)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("remote notify did not report cancellation")
+			}
+
+			select {
+			case signal := <-scopeProc.Reg.MergeReceivers[0].Ch2:
+				_, terminalErr := signal.Action()
+				if tt.wantErr == nil {
+					require.NoError(t, terminalErr)
+				} else {
+					require.ErrorIs(t, terminalErr, tt.wantErr)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("remote notify cleanup did not terminate its receiver")
+			}
+			wg.Wait()
+		})
+	}
+}
+
 func TestSendNotifyMessageReportsStreamSendError(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	proc.BuildPipelineContext(context.Background())
@@ -2580,7 +2698,8 @@ func TestSendNotifyMessageSuccessfulAttachUsesQueryContext(t *testing.T) {
 
 func TestSendNotifyMessageStopsRetryWhenQueryContextCanceled(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	proc.BuildPipelineContext(context.Background())
+	queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
+	proc.BuildPipelineContext(queryCtx)
 	scopeProc := proc.NewContextChildProc(1)
 
 	uid, err := uuid.NewV7()
@@ -2630,7 +2749,9 @@ func TestSendNotifyMessageStopsRetryWhenQueryContextCanceled(t *testing.T) {
 	resultCh := make(chan notifyMessageResult, 1)
 	s.sendNotifyMessageWithFactoryAndWait(&wg, resultCh, factory, waitRetry)
 	<-retryEntered
-	scopeProc.Cancel(nil)
+	_, cancelQuery := process.GetQueryCtxFromProc(proc)
+	require.NotNil(t, cancelQuery)
+	cancelQuery()
 
 	select {
 	case result := <-resultCh:

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -3577,7 +3577,7 @@ func TestRemoteNotifyCleanupUsesTypedEndForSingleSender(t *testing.T) {
 	}
 }
 
-func TestRemoteNotifyCleanupUsesSharedTerminalSendBudget(t *testing.T) {
+func TestRemoteNotifyCleanupEndDoesNotWaitForChannelCapacity(t *testing.T) {
 	oldSignalSendTimeout := process.PipelineSignalSendTimeout
 	process.PipelineSignalSendTimeout = 200 * time.Millisecond
 	t.Cleanup(func() {
@@ -3585,19 +3585,27 @@ func TestRemoteNotifyCleanupUsesSharedTerminalSendBudget(t *testing.T) {
 	})
 
 	reg := process.NewPipelineEdge(1, 0)
-	reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, nil)
+	reg.Ch2 <- process.NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
 
 	start := time.Now()
-	require.False(t, sendRemoteNotifyCleanupTerminal(nil, reg, nil))
+	require.True(t, sendRemoteNotifyCleanupTerminal(nil, reg, nil))
 	elapsed := time.Since(start)
 
 	require.Less(t, elapsed, 300*time.Millisecond)
 	select {
 	case <-reg.Done():
 	default:
-		t.Fatal("fallback abort should mark the remote notify edge terminal")
+		t.Fatal("durable End should mark the remote notify edge terminal")
 	}
-	require.ErrorIs(t, reg.Err(), process.ErrPipelineEndSignalDeliveryFailed)
+	require.NoError(t, reg.Err())
+
+	receiver := process.InitPipelineSignalReceiver(context.Background(), []*process.WaitRegister{reg})
+	got, err := receiver.GetNextBatch(nil)
+	require.NoError(t, err)
+	require.Same(t, batch.EmptyBatch, got)
+	got, err = receiver.GetNextBatch(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
 }
 
 func TestReceiveMessageFromCnServerIfDispatch_PreservesCleanupOnOriginalRoot(t *testing.T) {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1175,7 +1175,11 @@ func (s *Scope) sendNotifyMessageWithFactoryAndWait(
 ) {
 	// if context has done, it means the user or other part of the pipeline stops this query.
 	closeWithError := func(err error, reg *process.WaitRegister, sender *messageSenderOnClient) {
-		err = suppressRemoteNotifyCancelError(s.Proc.Ctx, err)
+		err, _ = normalizeScopeRunError(
+			err,
+			s.Proc.Ctx,
+			scopeRunQueryContext(s.Proc),
+		)
 		s.cancelMergeSiblingsOnError(err)
 		sendRemoteNotifyCleanupTerminal(s.Proc, reg, err)
 		resultChan <- notifyMessageResult{err: err, sender: sender}
@@ -1419,16 +1423,6 @@ func suppressRemoteRunCancelError(
 	err error,
 ) error {
 	err, _ = normalizeScopeRunError(err, procCtx, queryCtx)
-	return err
-}
-
-func suppressRemoteNotifyCancelError(procCtx context.Context, err error) error {
-	if err == nil {
-		return nil
-	}
-	if procCtx != nil && procCtx.Err() != nil && moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted) {
-		return nil
-	}
 	return err
 }
 

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -280,7 +280,7 @@ func (s *Scope) resetForReuse(c *Compile) (err error) {
 	}
 
 	// The previous execution's cleanup delivered terminal signals into this
-	// scope's pipeline edges and marked them done (doneClosed/endDelivered).
+	// scope's pipeline edges and marked them done (doneClosed/endRecorded).
 	// A done edge silently rejects both data and End signals, so a reused
 	// pipeline would leave its receivers waiting forever. Clear the terminal
 	// state so the edges can carry the next execution's signals.
@@ -378,11 +378,7 @@ func (s *Scope) Run(c *Compile) (err error) {
 			_, err = p.RunWithReader(s.DataSource.R, tag, s.Proc)
 		}
 	}
-	select {
-	case <-s.Proc.Ctx.Done():
-		err = nil
-	default:
-	}
+	err, _ = normalizeScopeRunError(err, s.Proc.Ctx, scopeRunQueryContext(s.Proc))
 	return err
 }
 
@@ -508,7 +504,7 @@ func (s *Scope) MergeRun(c *Compile) (err error) {
 		wg.Wait()
 		err = collectMergeRunResults(
 			s.Proc,
-			scopeRunResult{err: err, ctx: s.Proc.Ctx},
+			newScopeRunResultForProcess(err, s.Proc),
 			preScopeResultReceiveChan,
 			notifyMessageResultReceiveChan)
 	}()
@@ -573,7 +569,7 @@ func collectMergeRunResults(
 	}
 	for len(notifyResults) > 0 {
 		result := <-notifyResults
-		current = preferPrimaryScopeResult(current, scopeRunResult{err: result.err, ctx: proc.Ctx})
+		current = preferPrimaryScopeResult(current, newScopeRunResultForProcess(result.err, proc))
 		result.clean(proc)
 	}
 	current, _ = current.resolveCancelCause()

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -2135,6 +2135,33 @@ func TestSuppressRemoteRunCancelError(t *testing.T) {
 		require.NoError(t, suppressRemoteRunCancelError(ctx, queryCtx, fmt.Errorf("open remote stream: %w", context.Canceled)))
 	})
 
+	t.Run("suppress joined cancellation fallout after proc cancel", func(t *testing.T) {
+		queryCtx := context.Background()
+		ctx, cancel := context.WithCancel(queryCtx)
+		cancel()
+		err := errors.Join(context.Canceled, moerr.NewQueryInterrupted(ctx))
+		require.NoError(t, suppressRemoteRunCancelError(ctx, queryCtx, err))
+	})
+
+	t.Run("keep independent deadline joined with cancellation", func(t *testing.T) {
+		queryCtx := context.Background()
+		ctx, cancel := context.WithCancel(queryCtx)
+		cancel()
+		err := suppressRemoteRunCancelError(
+			ctx, queryCtx, errors.Join(context.DeadlineExceeded, context.Canceled))
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("keep substantive error joined with cancellation", func(t *testing.T) {
+		queryCtx := context.Background()
+		ctx, cancel := context.WithCancel(queryCtx)
+		cancel()
+		primaryErr := moerr.NewInternalErrorNoCtx("remote execution failed")
+		err := suppressRemoteRunCancelError(
+			ctx, queryCtx, errors.Join(primaryErr, context.Canceled))
+		require.ErrorIs(t, err, primaryErr)
+	})
+
 	t.Run("keep rpc timeout after proc cancel", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()

--- a/pkg/vm/process/pipeline_edge.go
+++ b/pkg/vm/process/pipeline_edge.go
@@ -56,7 +56,7 @@ type PipelineEdge struct {
 	fatalTerminal  bool
 	fatalDelivered int
 	fatalRemaining int
-	endDelivered   int
+	endRecorded    int
 	doneClosed     bool
 	abortClosed    bool
 }
@@ -125,7 +125,7 @@ func (e *PipelineEdge) SetNilBatchCntForReuse(nilBatchCnt int) {
 }
 
 // ResetTerminalStateForReuse drains buffered stale signals and clears the
-// edge's terminal state (endDelivered/doneClosed/fatalTerminal) so a cached
+// edge's terminal state (endRecorded/doneClosed/fatalTerminal) so a cached
 // pipeline (e.g. a prepared statement's compile) can deliver data and End
 // signals through the edge again on its next execution. The channel buffer
 // and NilBatchCnt are preserved. It is reuse-time only and must not race
@@ -171,7 +171,7 @@ func (e *PipelineEdge) resetTerminalStateLocked() {
 	e.fatalTerminal = false
 	e.fatalDelivered = 0
 	e.fatalRemaining = 0
-	e.endDelivered = 0
+	e.endRecorded = 0
 	e.doneClosed = false
 	e.abortClosed = false
 }
@@ -194,7 +194,7 @@ func (e *PipelineEdge) AsWaitRegister() *WaitRegister {
 }
 
 // Done returns a channel that is closed once the whole edge is terminal:
-// all expected End signals have been delivered, or the edge receives Error/Abort.
+// all expected End signals have been recorded, or the edge receives Error/Abort.
 // It never blocks.
 func (e *PipelineEdge) Done() <-chan struct{} {
 	if e == nil {
@@ -259,8 +259,8 @@ func (e *PipelineEdge) SendDataDirect(ctx context.Context, bat *batch.Batch, mp 
 	return e.sendSignal(ctx, NewPipelineSignalToDirectly(bat, nil, mp))
 }
 
-// SendEnd sends one sender's End signal. Done closes after the edge has
-// delivered the expected number of End signals.
+// SendEnd records one sender's End signal. It also enqueues the signal when
+// capacity is available. Done closes after the expected number is recorded.
 func (e *PipelineEdge) SendEnd() bool {
 	return e.trySendTerminal(NewEndSignal())
 }
@@ -275,7 +275,8 @@ func (e *PipelineEdge) Abort(err error) bool {
 	return e.trySendTerminal(NewAbortSignal(err))
 }
 
-// TrySendEnd attempts a non-blocking End send. Returns true if delivered.
+// TrySendEnd records one sender's End without blocking. It returns false only
+// when this edge is already terminal or has recorded every expected End.
 func (e *PipelineEdge) TrySendEnd() bool {
 	return e.trySendTerminal(NewEndSignal())
 }
@@ -325,15 +326,15 @@ func (e *PipelineEdge) closeAbortLocked() {
 }
 
 func (e *PipelineEdge) canDeliverEndLocked() bool {
-	return !e.fatalTerminal && e.endDelivered < e.expectedEndCountLocked()
+	return !e.fatalTerminal && e.endRecorded < e.expectedEndCountLocked()
 }
 
-func (e *PipelineEdge) recordEndDeliveredLocked() {
+func (e *PipelineEdge) recordEndLocked() {
 	if e.fatalTerminal || e.doneClosed {
 		return
 	}
-	e.endDelivered++
-	if e.endDelivered >= e.expectedEndCountLocked() {
+	e.endRecorded++
+	if e.endRecorded >= e.expectedEndCountLocked() {
 		e.closeDoneLocked()
 	}
 }
@@ -343,7 +344,7 @@ func (e *PipelineEdge) recordFatalTerminalLocked(signal PipelineSignal) Pipeline
 		e.fatalTerminal = true
 		e.fatalSignal = signal
 		e.terminalErr = signal.TerminalErr()
-		e.fatalRemaining = e.expectedEndCountLocked() - e.endDelivered
+		e.fatalRemaining = e.expectedEndCountLocked() - e.endRecorded
 		if e.fatalRemaining <= 0 {
 			e.fatalRemaining = 1
 		}
@@ -371,13 +372,16 @@ func (e *PipelineEdge) trySendTerminal(signal PipelineSignal) bool {
 		if !e.canDeliverEndLocked() {
 			return false
 		}
+		// End is a durable edge state, not merely a best-effort channel
+		// message.  Record it even when buffered data occupies Ch2.  Once all
+		// expected senders have ended, Done wakes the receiver; the receiver
+		// drains Ch2 first and then synthesizes any End that did not fit.
 		select {
 		case e.Ch2 <- signal:
-			e.recordEndDeliveredLocked()
-			return true
 		default:
-			return false
 		}
+		e.recordEndLocked()
+		return true
 	}
 
 	if e.doneClosed && !e.fatalTerminal {
@@ -417,13 +421,15 @@ func (e *PipelineEdge) sendTerminalWithContext(ctx context.Context, signal Pipel
 		if !e.canDeliverEndLocked() {
 			return false
 		}
+		// Terminal progress must not depend on spare data-channel capacity.
+		// A non-blocking enqueue preserves the common fast path; durable state
+		// plus Done is the fallback delivery path.
 		select {
 		case e.Ch2 <- signal:
-			e.recordEndDeliveredLocked()
-			return true
-		case <-ctx.Done():
-			return false
+		default:
 		}
+		e.recordEndLocked()
+		return true
 	}
 
 	if e.doneClosed && !e.fatalTerminal {
@@ -505,7 +511,8 @@ func (e *PipelineEdge) trySend(signal PipelineSignal) bool {
 
 // --- send helpers ---
 
-// SendSignalWithTimeout sends a signal to the edge's channel with optional timeout.
+// SendSignalWithTimeout sends data with an optional timeout. Terminal state is
+// published without blocking; in particular, End does not wait for Ch2 space.
 func (e *PipelineEdge) SendSignalWithTimeout(signal PipelineSignal, timeout time.Duration) bool {
 	if e == nil || e.Ch2 == nil {
 		return false
@@ -513,7 +520,8 @@ func (e *PipelineEdge) SendSignalWithTimeout(signal PipelineSignal, timeout time
 	return SendPipelineSignalWithTimeout(e.AsWaitRegister(), signal, timeout)
 }
 
-// SendSignalWithContext sends a signal to the edge's channel with context.
+// SendSignalWithContext sends data with context. Terminal publication is
+// non-blocking, and End is recorded even when ctx has already been canceled.
 func (e *PipelineEdge) SendSignalWithContext(ctx context.Context, signal PipelineSignal) bool {
 	if e == nil || e.Ch2 == nil {
 		return false

--- a/pkg/vm/process/pipeline_edge_test.go
+++ b/pkg/vm/process/pipeline_edge_test.go
@@ -165,19 +165,85 @@ func TestWaitPipelineSignalCapacityReturnsOnTerminalEdge(t *testing.T) {
 	}
 }
 
-// TestPipelineEdgeTrySendEndOnFullChannel verifies that TrySendEnd
-// succeeds when the channel has buffer space.
+// TestPipelineEdgeTrySendEndOnFullChannel verifies that End is durably
+// observable even when buffered data occupies the signal channel.
 func TestPipelineEdgeTrySendEndOnFullChannel(t *testing.T) {
 	edge := NewPipelineEdge(1, 1)
+	edge.Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
 
 	if !edge.TrySendEnd() {
-		t.Fatal("TrySendEnd failed on empty channel")
+		t.Fatal("TrySendEnd failed to record End on a full channel")
 	}
 
 	select {
 	case <-edge.Done():
 	default:
 		t.Fatal("Done was not closed after TrySendEnd")
+	}
+	if edge.Err() != nil {
+		t.Fatalf("durable End recorded an error: %v", edge.Err())
+	}
+
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{edge})
+	got, err := receiver.GetNextBatch(nil)
+	if err != nil || got != batch.EmptyBatch {
+		t.Fatalf("buffered data was not drained before End: batch=%v err=%v", got, err)
+	}
+	got, err = receiver.GetNextBatch(nil)
+	if err != nil || got != nil {
+		t.Fatalf("durable End was not synthesized: batch=%v err=%v", got, err)
+	}
+}
+
+func TestPipelineEdgeSharedEndRecordsUndeliveredSenders(t *testing.T) {
+	edge := NewPipelineEdge(1, 2)
+	edge.Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
+
+	if !edge.SendEnd() {
+		t.Fatal("first End was not recorded")
+	}
+	select {
+	case <-edge.Done():
+		t.Fatal("Done closed before every sender ended")
+	default:
+	}
+	if !edge.SendEnd() {
+		t.Fatal("second End was not recorded")
+	}
+	select {
+	case <-edge.Done():
+	default:
+		t.Fatal("Done did not close after every sender ended")
+	}
+
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{edge})
+	got, err := receiver.GetNextBatch(nil)
+	if err != nil || got != batch.EmptyBatch {
+		t.Fatalf("buffered data was not drained before shared End: batch=%v err=%v", got, err)
+	}
+	got, err = receiver.GetNextBatch(nil)
+	if err != nil || got != nil {
+		t.Fatalf("shared durable End did not finish the receiver: batch=%v err=%v", got, err)
+	}
+}
+
+func TestPipelineEdgeSharedEndCombinesQueuedAndRecordedSignals(t *testing.T) {
+	edge := NewPipelineEdge(1, 2)
+
+	if !edge.SendEnd() {
+		t.Fatal("first End was not queued")
+	}
+	if !edge.SendEnd() {
+		t.Fatal("second End was not durably recorded")
+	}
+
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{edge})
+	got, err := receiver.GetNextBatch(nil)
+	if err != nil || got != nil {
+		t.Fatalf("queued and recorded Ends did not finish the receiver: batch=%v err=%v", got, err)
+	}
+	if state := receiver.State(); state.Alive != 0 {
+		t.Fatalf("receiver still has %d live edges after both Ends", state.Alive)
 	}
 }
 
@@ -510,16 +576,18 @@ func TestBuildCleanupSignalFailedNilErrorUsesSentinel(t *testing.T) {
 	}
 }
 
-// TestSendPipelineSignalTimeout verifies the timeout behavior.
-func TestSendPipelineSignalTimeout(t *testing.T) {
+func TestSendPipelineSignalEndRecordsOnFullChannel(t *testing.T) {
 	reg := &WaitRegister{Ch2: make(chan PipelineSignal, 1)}
 
-	// Fill the channel.
-	reg.Ch2 <- NewEndSignal()
+	reg.Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
 
-	// Try to send with timeout - should fail since channel is full.
-	if SendPipelineSignalWithTimeout(reg, NewEndSignal(), 10*time.Millisecond) {
-		t.Fatal("SendPipelineSignalWithTimeout succeeded on full channel")
+	if !SendPipelineSignalWithTimeout(reg, NewEndSignal(), 10*time.Millisecond) {
+		t.Fatal("SendPipelineSignalWithTimeout did not durably record End")
+	}
+	select {
+	case <-reg.Done():
+	default:
+		t.Fatal("durable End did not close Done")
 	}
 
 	// Nil register should return false.
@@ -541,24 +609,22 @@ func TestTrySendPipelineSignal(t *testing.T) {
 	}
 }
 
-// TestSendPipelineSignalWithContextCanceled verifies context cancellation.
-func TestSendPipelineSignalWithContextCanceled(t *testing.T) {
+func TestSendPipelineEndWithCanceledContextStillRecordsTerminal(t *testing.T) {
 	reg := &WaitRegister{Ch2: make(chan PipelineSignal, 1)}
 
-	// Fill the channel.
-	reg.Ch2 <- NewEndSignal()
+	reg.Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if SendPipelineSignalWithContext(ctx, reg, NewEndSignal()) {
-		t.Fatal("SendPipelineSignalWithContext succeeded with cancelled context")
+	if !SendPipelineSignalWithContext(ctx, reg, NewEndSignal()) {
+		t.Fatal("canceled cleanup context prevented durable End")
 	}
 
 	select {
 	case <-reg.Done():
-		t.Fatal("cancelled End send closed Done before receiver observed the terminal")
 	default:
+		t.Fatal("canceled cleanup context left the edge non-terminal")
 	}
 }
 

--- a/pkg/vm/process/process_spoolr.go
+++ b/pkg/vm/process/process_spoolr.go
@@ -36,7 +36,7 @@ var (
 	PipelineSignalSendTimeout = 30 * time.Second
 
 	// ErrPipelineEndSignalDeliveryFailed marks a successful cleanup path that
-	// could not enqueue its normal End signal and had to fall back to abort.
+	// could not durably record its normal End and had to fall back to abort.
 	ErrPipelineEndSignalDeliveryFailed = moerr.NewInternalErrorNoCtx("pipeline end signal delivery failed")
 
 	// ErrPipelineTerminalWithoutCause marks a failure/abort terminal event whose
@@ -566,18 +566,16 @@ func (receiver *PipelineSignalReceiver) listenToAll() (int, PipelineSignal) {
 
 // receiveSignalOrTerminal handles an edge whose Done channel is ready. Ch2
 // remains the ordered source of truth: buffered data and successfully enqueued
-// terminal signals must be consumed before a terminal that failed to enqueue is
-// synthesized from the edge's durable terminal state.
+// terminal signals must be consumed before a terminal recorded only in the
+// edge's durable state is synthesized.
 func (receiver *PipelineSignalReceiver) receiveSignalOrTerminal(idx int) (int, PipelineSignal) {
 	reg := receiver.srcReg[idx]
 	if signal, ok := tryReceivePipelineSignal(reg.Ch2); ok {
 		return idx + 1, signal
 	}
 
-	// Synchronize with an in-flight terminal sender. The sender closes Done
-	// before attempting a fatal enqueue, so it may enqueue after our first
-	// non-blocking receive. Recheck Ch2 after taking the snapshot to avoid
-	// synthesizing a duplicate terminal.
+	// Synchronize with an in-flight terminal sender. Recheck Ch2 after taking
+	// the snapshot to avoid synthesizing a duplicate terminal.
 	terminal := reg.terminalSignalSnapshot()
 	if signal, ok := tryReceivePipelineSignal(reg.Ch2); ok {
 		return idx + 1, signal


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27987

## What this PR does / why we need it:

Backports #26990 to 4.2-dev.

A normal pipeline End is now recorded as durable edge state even when the bounded data channel is full. The receiver drains buffered batches before observing the recorded End, preventing a slow full-table-scan consumer from turning graceful completion into pipeline end signal delivery failed.

The backport also preserves substantive execution errors across sibling-pipeline cancellation and keeps query deadline classification intact. Existing 4.2-dev cancellation helpers were retained while resolving the cherry-pick conflict.

Validation:

- Focused regression tests across process, connector, dispatch, and compile
- Full owning-package tests
- Focused race stress for concurrent terminal publication, count 100
- Full owning-package race tests
- go build and go vet for all affected packages