### PR TITLE
fix(frontend): preserve ODBC pagination parameter types

### DIFF
--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -930,10 +930,26 @@ func filterBinaryNumericPrefixCandidates(
 	paramVals []any,
 	paramTypes []byte,
 ) bool {
+	fixedIntegerPositions := plan2.PreparedPaginationParamPositions(preparePlan)
+	fixedIntegerPositions = append(
+		fixedIntegerPositions, plan2.PreparedLagLeadParamPositions(preparePlan)...)
+	slices.Sort(fixedIntegerPositions)
 	anyRelevant := false
 	for i := range paramVals {
 		param, ok := paramVals[i].(plan2.ParamValue)
 		if !ok {
+			continue
+		}
+		mysqlTypeEligible := i*2+1 < len(paramTypes) &&
+			binaryProtocolMayNeedNumericPrefix(defines.MysqlType(paramTypes[i*2]))
+		_, fixedInteger := slices.BinarySearch(fixedIntegerPositions, int32(i))
+		if !mysqlTypeEligible || fixedInteger {
+			// Numeric-prefix admission is position-local. A text-capable marker
+			// elsewhere in the plan must not reclassify BLOB values or parameters
+			// with a fixed unsigned-integer contract such as LIMIT/OFFSET.
+			param.EnableNumericPrefix = false
+			param.RetainParamRef = false
+			paramVals[i] = param
 			continue
 		}
 		candidates := append([]any(nil), paramVals...)

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -927,13 +927,10 @@ func applyBinaryDirectResultDecimalTypes(
 
 func filterBinaryNumericPrefixCandidates(
 	preparePlan *plan2.Plan,
+	fixedIntegerPositions []int32,
 	paramVals []any,
 	paramTypes []byte,
 ) bool {
-	fixedIntegerPositions := plan2.PreparedPaginationParamPositions(preparePlan)
-	fixedIntegerPositions = append(
-		fixedIntegerPositions, plan2.PreparedLagLeadParamPositions(preparePlan)...)
-	slices.Sort(fixedIntegerPositions)
 	anyRelevant := false
 	for i := range paramVals {
 		param, ok := paramVals[i].(plan2.ParamValue)
@@ -982,6 +979,24 @@ func filterBinaryNumericPrefixCandidates(
 		}
 	}
 	return anyRelevant
+}
+
+// preparedFixedIntegerParamPositions returns static execute-time metadata for
+// one prepared-plan generation. LIMIT/OFFSET and LAG/LEAD offsets have the
+// same fixed unsigned-integer contract, so retain one sorted position list for
+// all binary execute-time consumers.
+func preparedFixedIntegerParamPositions(preparePlan *plan2.Plan) ([]int32, bool, bool) {
+	paginationPositions := plan2.PreparedPaginationParamPositions(preparePlan)
+	lagLeadPositions := plan2.PreparedLagLeadParamPositions(preparePlan)
+	fixedIntegerPositions := append(paginationPositions, lagLeadPositions...)
+	slices.Sort(fixedIntegerPositions)
+	return fixedIntegerPositions, len(paginationPositions) > 0, len(lagLeadPositions) > 0
+}
+
+func (prepareStmt *PrepareStmt) refreshFixedIntegerParamPositions(preparePlan *plan2.Plan) {
+	prepareStmt.fixedIntegerParamPositions,
+		prepareStmt.hasPaginationParams,
+		prepareStmt.hasLagLeadParams = preparedFixedIntegerParamPositions(preparePlan)
 }
 
 func preparedPositionHasStaticExactNumericPeer(preparePlan *plan2.Plan, position int) bool {
@@ -1264,8 +1279,7 @@ func initExecuteStmtParamWithResolverInSession(
 			newPreparePlan.Plan, len(newPreparePlan.ParamTypes))
 		prepareStmt.numericOverloadParamPositions = plan2.PreparedPlanNumericFallbackParamPositions(
 			newPreparePlan.Plan)
-		prepareStmt.hasPaginationParams = plan2.PreparedPlanHasPaginationParams(newPreparePlan.Plan)
-		prepareStmt.hasLagLeadParams = len(plan2.PreparedLagLeadParamPositions(newPreparePlan.Plan)) > 0
+		prepareStmt.refreshFixedIntegerParamPositions(newPreparePlan.Plan)
 		prepareStmt.ColDefData = newColDefData
 		if execCtx.input != nil && execCtx.input.isBinaryProtExecute {
 			execCtx.prepareColDef = newColDefData
@@ -1450,7 +1464,8 @@ func initExecuteStmtParamWithResolverInSession(
 			}
 			if runtimeNumericPrefixCandidate && executionPlan.GetQuery() != nil {
 				runtimeNumericPrefixCandidate = filterBinaryNumericPrefixCandidates(
-					executionPlan, cwft.paramVals, prepareStmt.ParamTypes)
+					executionPlan, prepareStmt.fixedIntegerParamPositions,
+					cwft.paramVals, prepareStmt.ParamTypes)
 			}
 			if runtimeDirectResultCandidate && !runtimeNumericPrefixCandidate &&
 				!runtimeNumericOverloadCandidate && !needsRuntimeSpecialization {
@@ -1524,7 +1539,8 @@ func initExecuteStmtParamWithResolverInSession(
 		}
 	}
 	if prepareStmt.hasPaginationParams || prepareStmt.hasLagLeadParams {
-		if err := normalizePreparedOffsetBooleans(cwft.proc, preparePlan.Plan, cwft.paramVals); err != nil {
+		if err := normalizePreparedOffsetBooleans(
+			cwft.proc, prepareStmt.fixedIntegerParamPositions, cwft.paramVals); err != nil {
 			return nil, nil, nil, originSQL, false, err
 		}
 	}
@@ -2012,14 +2028,12 @@ func newPreparedExecutionRetry(
 	return retry
 }
 
-func normalizePreparedOffsetBooleans(proc *process.Process, preparePlan *plan.Plan, paramVals []any) error {
+func normalizePreparedOffsetBooleans(proc *process.Process, fixedIntegerPositions []int32, paramVals []any) error {
 	params := proc.GetPrepareParams()
 	if params == nil {
 		return nil
 	}
-	positions := plan2.PreparedPaginationParamPositions(preparePlan)
-	positions = append(positions, plan2.PreparedLagLeadParamPositions(preparePlan)...)
-	for _, position := range positions {
+	for _, position := range fixedIntegerPositions {
 		if position < 0 || int(position) >= len(paramVals) {
 			continue
 		}

--- a/pkg/frontend/computation_wrapper_test.go
+++ b/pkg/frontend/computation_wrapper_test.go
@@ -447,13 +447,37 @@ func TestPreparedParamValuesPreservesNullProtocolProvenance(t *testing.T) {
 
 func TestIssue27640InitExecuteStmtParamAcceptsODBCIntegerTextPagination(t *testing.T) {
 	for index, test := range []struct {
-		name   string
-		sql    string
-		values []string
+		name       string
+		sql        string
+		values     []string
+		mysqlTypes []defines.MysqlType
+		pagination []int32
+		prefix     []bool
 	}{
 		{name: "limit", sql: "select 1 limit ?", values: []string{"2"}},
 		{name: "limit offset", sql: "select 1 limit ? offset ?", values: []string{"2", "1"}},
 		{name: "offset", sql: "select 1 offset ?", values: []string{"1"}},
+		{
+			name: "having and limit", sql: "select sum(1) having sum(1) > ? limit ?",
+			values: []string{"0", "1"},
+			mysqlTypes: []defines.MysqlType{
+				defines.MYSQL_TYPE_BLOB,
+				defines.MYSQL_TYPE_STRING,
+			},
+			pagination: []int32{1},
+			prefix:     []bool{false, false},
+		},
+		{
+			name: "having and limit offset", sql: "select sum(1) having sum(1) > ? limit ? offset ?",
+			values: []string{"0", "1", "0"},
+			mysqlTypes: []defines.MysqlType{
+				defines.MYSQL_TYPE_BLOB,
+				defines.MYSQL_TYPE_STRING,
+				defines.MYSQL_TYPE_STRING,
+			},
+			pagination: []int32{1, 2},
+			prefix:     []bool{false, false, false},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
@@ -462,19 +486,31 @@ func TestIssue27640InitExecuteStmtParamAcceptsODBCIntegerTextPagination(t *testi
 				cw.proc.SetPrepareParams(nil)
 				prepareStmt.Close()
 			}()
+			if test.pagination != nil {
+				require.Equal(t, test.pagination, plan2.PreparedPaginationParamPositions(
+					prepareStmt.PreparePlan.GetDcl().GetPrepare().Plan))
+			}
 
 			// Connector/ODBC sends integer bindings as MYSQL_TYPE_STRING in
 			// COM_STMT_EXECUTE, so reproduce that wire representation directly.
 			prepareStmt.params = vector.NewVec(types.T_text.ToType())
 			prepareStmt.ParamTypes = make([]byte, 0, len(test.values)*2)
 			wantParamVals := make([]any, 0, len(test.values))
-			for _, value := range test.values {
+			for valueIndex, value := range test.values {
 				require.NoError(t, vector.AppendBytes(
 					prepareStmt.params, []byte(value), false, cw.proc.Mp()))
+				mysqlType := defines.MYSQL_TYPE_STRING
+				if valueIndex < len(test.mysqlTypes) {
+					mysqlType = test.mysqlTypes[valueIndex]
+				}
 				prepareStmt.ParamTypes = append(prepareStmt.ParamTypes,
-					byte(defines.MYSQL_TYPE_STRING), 0)
+					byte(mysqlType), 0)
+				enableNumericPrefix := true
+				if valueIndex < len(test.prefix) {
+					enableNumericPrefix = test.prefix[valueIndex]
+				}
 				wantParamVals = append(wantParamVals, plan2.ParamValue{
-					Value: value, IsBinaryProtocol: true, EnableNumericPrefix: true,
+					Value: value, IsBinaryProtocol: true, EnableNumericPrefix: enableNumericPrefix,
 				})
 			}
 

--- a/pkg/frontend/computation_wrapper_test.go
+++ b/pkg/frontend/computation_wrapper_test.go
@@ -310,6 +310,8 @@ func newPreparedExecuteEnvForSQLWithCompilerContext(
 	preparePlan, err := buildPlan(ctx, nil, compilerContext, prepareString)
 	require.NoError(t, err)
 
+	fixedIntegerParamPositions, hasPaginationParams, hasLagLeadParams :=
+		preparedFixedIntegerParamPositions(preparePlan.GetDcl().GetPrepare().Plan)
 	prepareStmt := &PrepareStmt{
 		Name:                       stmtName,
 		Sql:                        prepareString.Sql,
@@ -321,8 +323,9 @@ func newPreparedExecuteEnvForSQLWithCompilerContext(
 		getFromSendLongData:        make(map[int]struct{}),
 		protocolVersion:            currentProtocolVersion(proc),
 		directResultParamPositions: plan2.PreparedPlanDirectResultParamPositions(preparePlan.GetDcl().GetPrepare().Plan),
-		hasPaginationParams:        plan2.PreparedPlanHasPaginationParams(preparePlan.GetDcl().GetPrepare().Plan),
-		hasLagLeadParams:           len(plan2.PreparedLagLeadParamPositions(preparePlan.GetDcl().GetPrepare().Plan)) > 0,
+		fixedIntegerParamPositions: fixedIntegerParamPositions,
+		hasPaginationParams:        hasPaginationParams,
+		hasLagLeadParams:           hasLagLeadParams,
 	}
 	prepareStmt.refreshNumericPrefixConsumer(
 		preparePlan.GetDcl().GetPrepare().Plan,
@@ -489,6 +492,8 @@ func TestIssue27640InitExecuteStmtParamAcceptsODBCIntegerTextPagination(t *testi
 			if test.pagination != nil {
 				require.Equal(t, test.pagination, plan2.PreparedPaginationParamPositions(
 					prepareStmt.PreparePlan.GetDcl().GetPrepare().Plan))
+				require.Equal(t, test.pagination, prepareStmt.fixedIntegerParamPositions,
+					"prepared-plan installation must cache fixed integer parameter positions")
 			}
 
 			// Connector/ODBC sends integer bindings as MYSQL_TYPE_STRING in
@@ -1963,7 +1968,7 @@ func TestRuntimeSpecializationReplacementCommitsOnlyAfterCompileSuccess(t *testi
 	require.Nil(t, prepareStmt.runtimeCompile)
 }
 
-func BenchmarkInitExecuteStmtParamRepeatedDecimalSemanticCategory(b *testing.B) {
+func BenchmarkInitExecuteStmtParamRepeatedDecimalSemanticCategoryNoPagination(b *testing.B) {
 	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(b, 207, "select ?")
 	defer func() {
 		cw.proc.SetPrepareParams(nil)
@@ -1982,7 +1987,10 @@ func BenchmarkInitExecuteStmtParamRepeatedDecimalSemanticCategory(b *testing.B) 
 	prepareStmt.PreparePlan.GetDcl().GetPrepare().Plan = manualPlan
 	prepareStmt.directResultParamPositions = plan2.PreparedPlanDirectResultParamPositions(manualPlan)
 	prepareStmt.refreshNumericPrefixConsumer(manualPlan, 1)
+	prepareStmt.refreshFixedIntegerParamPositions(manualPlan)
 	require.True(b, prepareStmt.numericPrefixConsumer)
+	require.Empty(b, prepareStmt.fixedIntegerParamPositions,
+		"the no-pagination hot path must reuse empty fixed-position metadata")
 	prepareStmt.params = vector.NewVec(types.T_text.ToType())
 	require.NoError(b, vector.AppendBytes(prepareStmt.params, []byte("9.0"), false, cw.proc.Mp()))
 	prepareStmt.ParamTypes = []byte{byte(defines.MYSQL_TYPE_NEWDECIMAL), 0}

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2878,6 +2878,8 @@ func createPrepareStmtInSession(
 		}
 	}
 
+	fixedIntegerParamPositions, hasPaginationParams, hasLagLeadParams :=
+		preparedFixedIntegerParamPositions(prepareControl.Plan)
 	prepareStmt := &PrepareStmt{
 		Name:               preparePlan.GetDcl().GetPrepare().GetName(),
 		Sql:                originSQL,
@@ -2900,10 +2902,11 @@ func createPrepareStmtInSession(
 		directResultParamPositionsSet: true,
 		jsonComparisonParamPositions: plan2.PreparedJSONComparisonParamPositions(
 			prepareControl.Plan),
-		hasPaginationParams: plan2.PreparedPlanHasPaginationParams(prepareControl.Plan),
-		hasLagLeadParams:    len(plan2.PreparedLagLeadParamPositions(prepareControl.Plan)) > 0,
-		getFromSendLongData: make(map[int]struct{}),
-		schedulingSQLMode:   schedulingSQLMode,
+		fixedIntegerParamPositions: fixedIntegerParamPositions,
+		hasPaginationParams:        hasPaginationParams,
+		hasLagLeadParams:           hasLagLeadParams,
+		getFromSendLongData:        make(map[int]struct{}),
+		schedulingSQLMode:          schedulingSQLMode,
 	}
 	prepareStmt.refreshNumericPrefixConsumer(
 		prepareControl.Plan, len(prepareControl.ParamTypes))

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -351,10 +351,15 @@ type PrepareStmt struct {
 	numericPrefixConsumer         bool
 	directResultParamPositions    []int32
 	directResultParamPositionsSet bool
-	hasPaginationParams           bool
-	hasLagLeadParams              bool
-	paramKinds                    []vector.PrepareParamKind
-	paramMetadata                 []bool
+	// fixedIntegerParamPositions identifies parameters with a fixed unsigned-
+	// integer contract (LIMIT/OFFSET and LAG/LEAD offsets). It is installed
+	// with each prepared-plan generation so binary EXECUTE never walks the plan
+	// merely to classify a runtime parameter.
+	fixedIntegerParamPositions []int32
+	hasPaginationParams        bool
+	hasLagLeadParams           bool
+	paramKinds                 []vector.PrepareParamKind
+	paramMetadata              []bool
 	// jsonComparisonParamPositions is computed once per prepared-plan
 	// generation. Only these parameters need an exact SQL type in Process
 	// metadata; paramConcreteTypes is a reusable execution buffer.

--- a/pkg/tests/issues/issue_25408_pagination_test.go
+++ b/pkg/tests/issues/issue_25408_pagination_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,8 +27,77 @@ import (
 	mysqlDriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 )
+
+type issue27907ODBCTypeConn struct {
+	net.Conn
+
+	mu                sync.Mutex
+	rewriteParamCount int
+	rewritten         bool
+}
+
+func (c *issue27907ODBCTypeConn) rewriteNextExecute(paramCount int) {
+	c.mu.Lock()
+	c.rewriteParamCount = paramCount
+	c.rewritten = false
+	c.mu.Unlock()
+}
+
+func (c *issue27907ODBCTypeConn) wasRewritten() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rewritten
+}
+
+func (c *issue27907ODBCTypeConn) Write(data []byte) (int, error) {
+	c.mu.Lock()
+	if c.rewriteParamCount > 0 {
+		modified := append([]byte(nil), data...)
+		if issue27907RewriteFirstParamAsBlob(modified, c.rewriteParamCount) {
+			data = modified
+			c.rewriteParamCount = 0
+			c.rewritten = true
+		}
+	}
+	c.mu.Unlock()
+	return c.Conn.Write(data)
+}
+
+// issue27907RewriteFirstParamAsBlob reproduces Connector/ODBC's parameter
+// descriptors while retaining the driver's length-encoded string payloads.
+func issue27907RewriteFirstParamAsBlob(data []byte, paramCount int) bool {
+	const (
+		packetHeaderSize = 4
+		stmtExecute      = 0x17
+		executeHeaderLen = 1 + 4 + 1 + 4
+	)
+	if paramCount <= 0 {
+		return false
+	}
+	for pos := 0; pos+packetHeaderSize <= len(data); {
+		payloadLen := int(data[pos]) | int(data[pos+1])<<8 | int(data[pos+2])<<16
+		end := pos + packetHeaderSize + payloadLen
+		if end > len(data) {
+			return false
+		}
+		payload := data[pos+packetHeaderSize : end]
+		nullBitmapLen := (paramCount + 7) / 8
+		newTypesFlagPos := executeHeaderLen + nullBitmapLen
+		typePos := newTypesFlagPos + 1
+		if len(payload) > typePos+1 && payload[0] == stmtExecute &&
+			payload[newTypesFlagPos] == 1 &&
+			(payload[typePos] == byte(defines.MYSQL_TYPE_VAR_STRING) ||
+				payload[typePos] == byte(defines.MYSQL_TYPE_STRING)) {
+			payload[typePos] = byte(defines.MYSQL_TYPE_BLOB)
+			return true
+		}
+		pos = end
+	}
+	return false
+}
 
 func TestIssue25408PreparedPaginationParameters(t *testing.T) {
 	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
@@ -334,6 +405,70 @@ func TestIssue25408PreparedPaginationParameters(t *testing.T) {
 			defer ctas.Close()
 			_, err = ctas.ExecContext(ctx, "1.0")
 			assertMySQLError(t, err, 1210)
+		})
+
+		t.Run("Connector ODBC HAVING and pagination", func(t *testing.T) {
+			var connMu sync.Mutex
+			var wireConn *issue27907ODBCTypeConn
+			mysqlDriver.RegisterDialContext("issue27907odbc", func(ctx context.Context, addr string) (net.Conn, error) {
+				conn, dialErr := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+				if dialErr != nil {
+					return nil, dialErr
+				}
+				wrapped := &issue27907ODBCTypeConn{Conn: conn}
+				connMu.Lock()
+				wireConn = wrapped
+				connMu.Unlock()
+				return wrapped, nil
+			})
+			defer mysqlDriver.DeregisterDialContext("issue27907odbc")
+			cn, cnErr := c.GetCNService(0)
+			require.NoError(t, cnErr)
+			odbcDB, openErr := sql.Open("mysql", fmt.Sprintf(
+				"dump:111@issue27907odbc(127.0.0.1:%d)/?interpolateParams=false",
+				cn.GetServiceConfig().CN.Frontend.Port))
+			require.NoError(t, openErr)
+			odbcDB.SetMaxOpenConns(1)
+			odbcDB.SetMaxIdleConns(1)
+			defer odbcDB.Close()
+
+			for _, test := range []struct {
+				name string
+				sql  string
+				args []any
+			}{
+				{
+					name: "limit",
+					sql: "select id, sum(id) from " + dbName + ".page group by id " +
+						"having sum(id) > ? order by id limit ?",
+					args: []any{"1", "1"},
+				},
+				{
+					name: "limit offset",
+					sql: "select id, sum(id) from " + dbName + ".page group by id " +
+						"having sum(id) > ? order by id limit ? offset ?",
+					args: []any{"0", "1", "1"},
+				},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					stmt, prepareErr := odbcDB.PrepareContext(ctx, test.sql)
+					require.NoError(t, prepareErr)
+					defer stmt.Close()
+
+					connMu.Lock()
+					capturedConn := wireConn
+					connMu.Unlock()
+					require.NotNil(t, capturedConn)
+					capturedConn.rewriteNextExecute(len(test.args))
+
+					var id, total int
+					require.NoError(t, stmt.QueryRowContext(ctx, test.args...).Scan(&id, &total))
+					require.Equal(t, 2, id)
+					require.Equal(t, 2, total)
+					require.True(t, capturedConn.wasRewritten(),
+						"test did not send MYSQL_TYPE_BLOB for the HAVING parameter")
+				})
+			}
 		})
 
 		for index, paginationSQL := range []string{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27907

## What this PR does / why we need it:

fix(frontend): preserve ODBC pagination parameter types