### PR TITLE
fix(txn): preserve leak checker runtime state

### DIFF
--- a/pkg/txn/client/leak_checker.go
+++ b/pkg/txn/client/leak_checker.go
@@ -107,7 +107,8 @@ func (lc *leakChecker) doCheck() []ActiveTxn {
 	}
 	lc.RUnlock()
 
-	for _, txn := range values {
+	for i := range values {
+		txn := &values[i]
 		if txn.txnOp != nil {
 			txn.Options.Counter = txn.txnOp.counter()
 			txn.Options.InRunSql = txn.txnOp.inRunSql()

--- a/pkg/txn/client/leak_checker_test.go
+++ b/pkg/txn/client/leak_checker_test.go
@@ -94,6 +94,25 @@ func TestLeakCheckCloseClearsTrackedTransactions(t *testing.T) {
 	require.Empty(t, lc.actives)
 }
 
+func TestLeakCheckSnapshotsActiveTxnOptions(t *testing.T) {
+	runtime.SetupServiceBasedRuntime("", runtime.DefaultRuntime())
+	lc := newLeakCheck(0, func([]ActiveTxn) {})
+	defer lc.close()
+
+	op := &txnOperator{}
+	op.opts.options.SessionInfo = "test-session"
+	token, err := op.TryEnterRunSqlWithTokenAndSQL(nil, "select 1")
+	require.NoError(t, err)
+	defer op.ExitRunSqlWithToken(token)
+
+	lc.txnOpened(op, []byte("txn-id"), txn.TxnOptions{})
+	values := lc.doCheck()
+	require.Len(t, values, 1)
+	require.True(t, values[0].Options.InRunSql)
+	require.Contains(t, values[0].Options.Counter, "runSql: enter:1, exit:0")
+	require.Equal(t, "test-session", values[0].Options.SessionInfo)
+}
+
 func BenchmarkLeakCheckerTxnClosed(b *testing.B) {
 	// Create a leak checker instance
 	lc := newLeakCheck(10*time.Second, func([]ActiveTxn) {})


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Refs #27936

This is a partial hotfix for the runtime-state snapshot defect observed in #27936. It intentionally keeps the issue open for the broader owner-alive, owner-closed, unknown-state, grace-period, and repeated-profile deduplication work.

## What this PR does / why we need it:

`leakChecker.doCheck` copied aged transactions into a local slice, then sampled runtime state through a range variable. Because that variable was a copy, updates such as `InRunSql`, `Counter`, and `SessionInfo` were discarded before the slice reached the CN classifier. Healthy long-running SQL could therefore fall through to `found leak txn`.

This PR updates the slice elements in place while preserving the short leak-checker lock scope. It also adds a deterministic regression test that proves the active SQL flag and diagnostic fields survive the snapshot.

Validation:

- focused regression test
- full `pkg/txn/client` test suite
- focused race test with `-count=100`
- full `pkg/txn/client` race suite
- `go vet ./pkg/txn/client`
- `git diff --check`