### PR TITLE
fix(vector): avoid redundant IVF vector reads

### DIFF
--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -308,6 +308,33 @@ func collectProjectedColumns(
 	return projected
 }
 
+// removeIvfCandidateImpliedNotNullFilter removes only a direct IS NOT NULL
+// predicate on the indexed vector column. ivf_search never emits an entry with
+// a NULL distance, so every candidate produced by a synchronously maintained
+// IVF index already satisfies this predicate. More complex expressions stay as
+// residual filters because candidate membership does not imply them.
+func removeIvfCandidateImpliedNotNullFilter(
+	filters []*plan.Expr,
+	scanTag, partPos int32,
+) (remaining, removed []*plan.Expr) {
+	remaining = make([]*plan.Expr, 0, len(filters))
+	for _, filter := range filters {
+		if filter == nil {
+			remaining = append(remaining, filter)
+			continue
+		}
+		fn := filter.GetF()
+		if fn != nil && fn.Func != nil && len(fn.Args) == 1 &&
+			(fn.Func.ObjName == "isnotnull" || fn.Func.ObjName == "is_not_null") &&
+			exprIsCol(fn.Args[0], scanTag, partPos) {
+			removed = append(removed, filter)
+			continue
+		}
+		remaining = append(remaining, filter)
+	}
+	return remaining, removed
+}
+
 func collectScanColumnsFromExpr(expr *plan.Expr, scanTag, partPos int32, tableDef *plan.TableDef, out map[string]struct{}) {
 	if expr == nil || tableDef == nil {
 		return
@@ -1389,6 +1416,24 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 	asyncIndex, err := catalog.IndexParamAsync(ivfCtx.metaDef.IndexAlgoParams)
 	if err != nil {
 		return nodeID, err
+	}
+	if !asyncIndex && !usePreFilter {
+		// Async entries may lag the base row, so they still require this
+		// base-table recheck. Synchronous IVF maintenance shares the base
+		// transaction and ivf_search excludes NULL-distance candidates.
+		var removedFilters []*plan.Expr
+		remainingFilters, removedFilters = removeIvfCandidateImpliedNotNullFilter(
+			remainingFilters, scanNode.BindingTags[0], ivfCtx.partPos)
+		// colRefCnt was computed before index rewrites. Keep it consistent with
+		// FilterList so the remapper can prune the wide vector column.
+		if colRefCnt != nil && len(removedFilters) > 0 {
+			key := [2]int32{scanNode.BindingTags[0], ivfCtx.partPos}
+			if count := colRefCnt[key]; count > len(removedFilters) {
+				colRefCnt[key] = count - len(removedFilters)
+			} else {
+				colRefCnt[key] = 0
+			}
+		}
 	}
 
 	// build ivf_search table function node

--- a/pkg/sql/plan/apply_indices_ivfflat_helpers_test.go
+++ b/pkg/sql/plan/apply_indices_ivfflat_helpers_test.go
@@ -117,6 +117,45 @@ func TestIvfIncludeHelperColumnCollection(t *testing.T) {
 	}, projected)
 }
 
+func TestRemoveIvfCandidateImpliedNotNullFilterIsNarrow(t *testing.T) {
+	_, _, scanNode, _, _ := newIvfIncludeModeTestBuilder(t)
+	scanTag := scanNode.BindingTags[0]
+	boolType := Type{Id: int32(types.T_bool)}
+
+	direct := makeIvfHelperFnExpr(
+		"is_not_null", boolType,
+		makeIvfHelperColExpr(scanTag, 1, scanNode.TableDef),
+	)
+	directAlias := makeIvfHelperFnExpr(
+		"isnotnull", boolType,
+		makeIvfHelperColExpr(scanTag, 1, scanNode.TableDef),
+	)
+	otherColumn := makeIvfHelperFnExpr(
+		"is_not_null", boolType,
+		makeIvfHelperColExpr(scanTag, 4, scanNode.TableDef),
+	)
+	isNull := makeIvfHelperFnExpr(
+		"is_null", boolType,
+		makeIvfHelperColExpr(scanTag, 1, scanNode.TableDef),
+	)
+	wrappedVector := makeIvfHelperFnExpr(
+		"is_not_null", boolType,
+		makeIvfHelperFnExpr(
+			"cast",
+			scanNode.TableDef.Cols[1].Typ,
+			makeIvfHelperColExpr(scanTag, 1, scanNode.TableDef),
+		),
+	)
+
+	remaining, removed := removeIvfCandidateImpliedNotNullFilter(
+		[]*Expr{direct, otherColumn, nil, directAlias, isNull, wrappedVector},
+		scanTag,
+		1,
+	)
+	require.Equal(t, []*Expr{otherColumn, nil, isNull, wrappedVector}, remaining)
+	require.Equal(t, []*Expr{direct, directAlias}, removed)
+}
+
 func TestIvfIncludeHelperFilterCoverageAndSerialization(t *testing.T) {
 	_, _, scanNode, _, _ := newIvfIncludeModeTestBuilder(t)
 	scanTag := scanNode.BindingTags[0]

--- a/pkg/sql/plan/ivfflat_include_modes_test.go
+++ b/pkg/sql/plan/ivfflat_include_modes_test.go
@@ -168,6 +168,24 @@ func setIvfIncludeModeTestPagination(vecCtx *vectorSortContext, limit, offset ui
 	vecCtx.sortNode.Offset = makePlan2Uint64ConstExprWithType(offset)
 }
 
+func makeIvfIncludeModeIsNotNullFilter(scanNode *plan.Node, colPos int32) *plan.Expr {
+	colDef := scanNode.TableDef.Cols[colPos]
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{ObjName: "is_not_null"},
+			Args: []*plan.Expr{{
+				Typ: colDef.Typ,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: scanNode.BindingTags[0],
+					ColPos: colPos,
+					Name:   colDef.Name,
+				}},
+			}},
+		}},
+	}
+}
+
 func findIvfTableFunctionNode(builder *QueryBuilder, nodeID int32) *plan.Node {
 	if int(nodeID) >= len(builder.qry.Nodes) || builder.qry.Nodes[nodeID] == nil {
 		return nil
@@ -244,6 +262,115 @@ func TestApplyIndicesForSortUsingIvfflat_PostModeDoesNotAutoUseIncludeOptimizati
 	require.Len(t, scanNode.FilterList, 2)
 	require.Equal(t, "category", scanNode.FilterList[0].GetF().Args[0].GetCol().Name)
 	require.Equal(t, "note", scanNode.FilterList[1].GetF().Args[0].GetCol().Name)
+}
+
+func TestApplyIndicesForSortUsingIvfflat_ElidesImpliedVectorNotNullOnlyForSyncPostMode(t *testing.T) {
+	t.Run("sync post", func(t *testing.T) {
+		builder, _, scanNode, scanNodeID, multiTableIndex := newIvfIncludeModeTestBuilder(t)
+		scanNode.FilterList = []*plan.Expr{makeIvfIncludeModeIsNotNullFilter(scanNode, 1)}
+		colRefCnt := map[[2]int32]int{{scanNode.BindingTags[0], 1}: 1}
+
+		vecCtx := newIvfIncludeModeVectorSortContext(scanNode, scanNodeID, "post", 0, 2)
+		_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, nil)
+		require.NoError(t, err)
+
+		require.Empty(t, scanNode.FilterList)
+		require.Zero(t, colRefCnt[[2]int32{scanNode.BindingTags[0], 1}])
+		tableFuncNode := findIvfTableFunctionNode(builder, vecCtx.projNode.Children[0])
+		require.NotNil(t, tableFuncNode)
+		require.Equal(t, uint64(2), tableFuncNode.Limit.GetLit().GetU64Val())
+		require.False(t, tableFuncNode.Stats.GetForceOneCN())
+	})
+
+	t.Run("sync default post", func(t *testing.T) {
+		builder, _, scanNode, scanNodeID, multiTableIndex := newIvfIncludeModeTestBuilder(t)
+		scanNode.FilterList = []*plan.Expr{makeIvfIncludeModeIsNotNullFilter(scanNode, 1)}
+
+		vecCtx := newIvfIncludeModeVectorSortContext(scanNode, scanNodeID, "", 0, 2)
+		_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, nil, nil)
+		require.NoError(t, err)
+
+		require.Empty(t, scanNode.FilterList)
+		tableFuncNode := findIvfTableFunctionNode(builder, vecCtx.projNode.Children[0])
+		require.NotNil(t, tableFuncNode)
+		require.Equal(t, uint64(2), tableFuncNode.Limit.GetLit().GetU64Val())
+		require.False(t, tableFuncNode.Stats.GetForceOneCN())
+	})
+
+	t.Run("sync post keeps projected vector reference", func(t *testing.T) {
+		builder, _, scanNode, scanNodeID, multiTableIndex := newIvfIncludeModeTestBuilder(t)
+		scanNode.FilterList = []*plan.Expr{makeIvfIncludeModeIsNotNullFilter(scanNode, 1)}
+		colRefCnt := map[[2]int32]int{{scanNode.BindingTags[0], 1}: 2}
+
+		vecCtx := newIvfIncludeModeVectorSortContext(scanNode, scanNodeID, "post", 0, 1)
+		_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, nil)
+		require.NoError(t, err)
+
+		require.Empty(t, scanNode.FilterList)
+		require.Equal(t, 1, colRefCnt[[2]int32{scanNode.BindingTags[0], 1}])
+	})
+
+	t.Run("sync post keeps other residual filter", func(t *testing.T) {
+		builder, _, scanNode, scanNodeID, multiTableIndex := newIvfIncludeModeTestBuilder(t)
+		otherFilter := makeIvfIncludeModeIsNotNullFilter(scanNode, 4)
+		colRefCnt := map[[2]int32]int{
+			{scanNode.BindingTags[0], 1}: 1,
+			{scanNode.BindingTags[0], 4}: 1,
+		}
+		scanNode.FilterList = []*plan.Expr{
+			makeIvfIncludeModeIsNotNullFilter(scanNode, 1),
+			otherFilter,
+		}
+
+		vecCtx := newIvfIncludeModeVectorSortContext(scanNode, scanNodeID, "post", 0, 2)
+		_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, []*plan.Expr{otherFilter}, scanNode.FilterList)
+		require.Zero(t, colRefCnt[[2]int32{scanNode.BindingTags[0], 1}])
+		require.Equal(t, 1, colRefCnt[[2]int32{scanNode.BindingTags[0], 4}])
+		tableFuncNode := findIvfTableFunctionNode(builder, vecCtx.projNode.Children[0])
+		require.NotNil(t, tableFuncNode)
+		require.Equal(t, uint64(12), tableFuncNode.Limit.GetLit().GetU64Val())
+		require.False(t, tableFuncNode.Stats.GetForceOneCN())
+	})
+
+	t.Run("async post", func(t *testing.T) {
+		builder, _, scanNode, scanNodeID, multiTableIndex := newIvfIncludeModeTestBuilder(t)
+		for _, indexDef := range multiTableIndex.IndexDefs {
+			indexDef.IndexAlgoParams = `{"op_type":"vector_l2_ops","async":"true"}`
+		}
+		scanNode.FilterList = []*plan.Expr{makeIvfIncludeModeIsNotNullFilter(scanNode, 1)}
+		colRefCnt := map[[2]int32]int{{scanNode.BindingTags[0], 1}: 1}
+
+		vecCtx := newIvfIncludeModeVectorSortContext(scanNode, scanNodeID, "post", 0, 2)
+		_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, nil)
+		require.NoError(t, err)
+
+		require.Len(t, scanNode.FilterList, 1)
+		require.Equal(t, 1, colRefCnt[[2]int32{scanNode.BindingTags[0], 1}])
+		tableFuncNode := findIvfTableFunctionNode(builder, vecCtx.projNode.Children[0])
+		require.NotNil(t, tableFuncNode)
+		require.Equal(t, uint64(12), tableFuncNode.Limit.GetLit().GetU64Val())
+		require.True(t, tableFuncNode.Stats.GetForceOneCN())
+	})
+
+	t.Run("sync pre", func(t *testing.T) {
+		builder, _, scanNode, scanNodeID, multiTableIndex := newIvfIncludeModeTestBuilder(t)
+		scanNode.FilterList = []*plan.Expr{makeIvfIncludeModeIsNotNullFilter(scanNode, 1)}
+		colRefCnt := map[[2]int32]int{{scanNode.BindingTags[0], 1}: 1}
+
+		vecCtx := newIvfIncludeModeVectorSortContext(scanNode, scanNodeID, "pre", 0, 2)
+		_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, nil)
+		require.NoError(t, err)
+
+		require.Len(t, scanNode.FilterList, 1)
+		require.Equal(t, 1, colRefCnt[[2]int32{scanNode.BindingTags[0], 1}])
+		tableFuncNode := findIvfTableFunctionNode(builder, vecCtx.projNode.Children[0])
+		require.NotNil(t, tableFuncNode)
+		require.Equal(t, uint64(2), tableFuncNode.Limit.GetLit().GetU64Val())
+		require.True(t, tableFuncNode.Stats.GetForceOneCN())
+	})
 }
 
 func TestApplyIndicesForSortUsingIvfflat_IncludeModePartialPushdownKeepsResidualFilter(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #27317

## What this PR does / why we need it:

A post/default IVF query that contains a direct `indexed_vector IS NOT NULL` predicate keeps that predicate on the base table scan. Although `ivf_search` already excludes candidates whose distance is NULL, the residual predicate makes column pruning retain the wide vector payload. The production qvec plan consequently read about 2 GB from disk for only 150 candidate rows.

This PR removes that one predicate only when the IVF index is synchronously maintained and the query uses post/default filtering. It also decrements the precomputed column reference count so final remapping can actually prune the vector column. If the query projects the vector, its independent reference remains.

The rewrite deliberately does not apply to async IVF, pre/include filtering, wrapped expressions, `IS NULL`, other columns, or any remaining base-table predicate. It does not change the join topology, runtime filters, RPC behavior, index format, or DML maintenance.

Evidence from the affected environment:

- exact qvec statement: 47.39 s wall time, 47.19 s base-scan wait, 2.243 GB read, 1.993 GB disk read, 150 output rows;
- same-connection A/B after removing only the redundant predicate: 5.209 s -> 0.852 s and 5.311 s -> 1.361 s;
- both variants returned the same ordered 30 rows.

Validation:

- `go test ./pkg/sql/plan -count=1`
- `go test -race ./pkg/sql/plan -run TestRemoveIvfCandidateImpliedNotNullFilterIsNarrow\|TestApplyIndicesForSortUsingIvfflat_ElidesImpliedVectorNotNullOnlyForSyncPostMode -count=1`
- `go test ./pkg/vectorindex/ivfflat ./pkg/sql/colexec/productl2 -count=1`
- `go vet ./pkg/sql/plan`

Regression coverage verifies sync post/default, projected-vector reference preservation, unrelated residual filters, async post, sync pre, aliases, other columns, `IS NULL`, wrapped expressions, and nil expressions.