### PR TITLE
[4.2] fix(fileservice): retry COS multipart init before request write

### DIFF
--- a/pkg/fileservice/parallel_sdk_test.go
+++ b/pkg/fileservice/parallel_sdk_test.go
@@ -1186,6 +1186,52 @@ func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 	require.Equal(t, ambiguousBefore+float64(len(tests)), testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
 }
 
+func TestCOSMultipartInitDoesNotRetryInvalidSuccessBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body func() io.ReadCloser
+		err  error
+	}{
+		{
+			name: "empty",
+			body: func() io.ReadCloser { return io.NopCloser(strings.NewReader("")) },
+			err:  io.EOF,
+		},
+		{
+			name: "truncated",
+			body: func() io.ReadCloser {
+				return io.NopCloser(io.MultiReader(
+					strings.NewReader(`<InitiateMultipartUploadResult><UploadId>`),
+					multipartInitErrorReader{err: io.ErrUnexpectedEOF},
+				))
+			},
+			err: io.ErrUnexpectedEOF,
+		},
+	}
+
+	ambiguousBefore := testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, state := newMockCOSServer(t, 0)
+			defer server.Close()
+			state.uploadID = "committed-upload"
+			sdk := newTestCOSClientWithTransport(t, server, &cosMultipartInitInvalidSuccessBodyTransport{
+				base: server.Client().Transport,
+				body: test.body,
+			})
+
+			data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+			size := int64(len(data))
+			err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+			require.ErrorContains(t, err, test.err.Error())
+			require.Equal(t, int32(1), state.initCalls.Load())
+			require.False(t, state.completed.Load())
+			require.False(t, state.aborted.Load())
+		})
+	}
+	require.Equal(t, ambiguousBefore+float64(len(tests)), testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
+}
+
 func TestCOSMultipartInitRetriesAreBoundedBeforeRequest(t *testing.T) {
 	server, state := newMockCOSServer(t, 0)
 	defer server.Close()
@@ -1216,6 +1262,19 @@ type cosMultipartInitBeforeRequestTransport struct {
 type cosMultipartInitResponseLostTransport struct {
 	base http.RoundTripper
 	err  error
+}
+
+type cosMultipartInitInvalidSuccessBodyTransport struct {
+	base http.RoundTripper
+	body func() io.ReadCloser
+}
+
+type multipartInitErrorReader struct {
+	err error
+}
+
+func (r multipartInitErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
 }
 
 type denyMultipartListTransport struct {
@@ -1249,6 +1308,20 @@ func (t *cosMultipartInitResponseLostTransport) RoundTrip(req *http.Request) (*h
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		return nil, t.err
+	}
+	return resp, nil
+}
+
+func (t *cosMultipartInitInvalidSuccessBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		resp.Body = t.body()
+		resp.ContentLength = -1
 	}
 	return resp, nil
 }

--- a/pkg/fileservice/parallel_sdk_test.go
+++ b/pkg/fileservice/parallel_sdk_test.go
@@ -691,34 +691,11 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 		failPartStatus:     http.StatusBadRequest,
 		failCompleteStatus: http.StatusBadRequest,
 		failCreateStatus:   http.StatusBadRequest,
-		failListStatus:     http.StatusBadRequest,
 		uploadID:           "cos-upload",
 		parts:              make(map[int][]byte),
-		activeUploads:      make(map[string]string),
 	}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Query().Has("uploads"):
-			state.listCalls.Add(1)
-			if state.failList {
-				w.WriteHeader(state.failListStatus)
-				return
-			}
-			prefix := r.URL.Query().Get("prefix")
-			state.mu.Lock()
-			uploads := make(map[string]string, len(state.activeUploads))
-			for id, key := range state.activeUploads {
-				if strings.HasPrefix(key, prefix) {
-					uploads[id] = key
-				}
-			}
-			state.mu.Unlock()
-			w.Header().Set("Content-Type", "application/xml")
-			_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>false</IsTruncated>`)
-			for id, key := range uploads {
-				_, _ = fmt.Fprintf(w, `<Upload><Key>%s</Key><UploadId>%s</UploadId></Upload>`, key, id)
-			}
-			_, _ = io.WriteString(w, `</ListMultipartUploadsResult>`)
 		case r.Method == http.MethodPost && strings.Contains(r.URL.RawQuery, "uploads"):
 			initCall := state.initCalls.Add(1)
 			if state.failCreate {
@@ -727,16 +704,9 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 			}
 			_, _ = io.ReadAll(r.Body)
 			uploadID := state.uploadID
-			if initCall > 1 {
+			if state.generateUploadIDs {
 				uploadID = fmt.Sprintf("%s-%d", uploadID, initCall)
 			}
-			key := strings.TrimPrefix(r.URL.Path, "/")
-			state.mu.Lock()
-			state.activeUploads[uploadID] = key
-			if state.addConcurrentUploadOnInit {
-				state.activeUploads[uploadID+"-concurrent"] = key
-			}
-			state.mu.Unlock()
 			w.Header().Set("Content-Type", "application/xml")
 			_, _ = fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>%s</UploadId></InitiateMultipartUploadResult>`, uploadID)
 		case r.Method == http.MethodPut && !strings.Contains(r.URL.RawQuery, "partNumber") && !strings.Contains(r.URL.RawQuery, "uploadId") && !strings.Contains(r.URL.RawQuery, "uploads"):
@@ -768,6 +738,7 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 			}
 			state.mu.Lock()
 			state.completeBody = append([]byte{}, body...)
+			state.completedUploadID = r.URL.Query().Get("uploadId")
 			for partNum := 1; partNum < len(state.parts); partNum++ {
 				if len(state.parts[partNum]) < int(minMultipartPartSize) {
 					state.mu.Unlock()
@@ -777,19 +748,12 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 					return
 				}
 			}
-			delete(state.activeUploads, r.URL.Query().Get("uploadId"))
-			responseBody := `<CompleteMultipartUploadResult><Location>loc</Location><Bucket>bucket</Bucket><Key>object</Key><ETag>etag</ETag></CompleteMultipartUploadResult>`
-			state.respBody = responseBody
 			state.mu.Unlock()
 			w.Header().Set("Content-Type", "application/xml")
+			state.respBody = `<CompleteMultipartUploadResult><Location>loc</Location><Bucket>bucket</Bucket><Key>object</Key><ETag>etag</ETag></CompleteMultipartUploadResult>`
 			state.completed.Store(true)
-			_, _ = w.Write([]byte(responseBody))
+			_, _ = w.Write([]byte(state.respBody))
 		case r.Method == http.MethodDelete && strings.Contains(r.URL.RawQuery, "uploadId"):
-			state.mu.Lock()
-			uploadID := r.URL.Query().Get("uploadId")
-			delete(state.activeUploads, uploadID)
-			state.abortedUploadIDs = append(state.abortedUploadIDs, uploadID)
-			state.mu.Unlock()
 			state.aborted.Store(true)
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -800,30 +764,26 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 }
 
 type cosServerState struct {
-	mu                        sync.Mutex
-	parts                     map[int][]byte
-	activeUploads             map[string]string
-	abortedUploadIDs          []string
-	addConcurrentUploadOnInit bool
-	completeBody              []byte
-	failPart                  int
-	failPartSeen              chan struct{}
-	failPartOnce              sync.Once
-	failPartStatus            int
-	failComplete              bool
-	failCompleteStatus        int
-	failCreate                bool
-	failCreateStatus          int
-	failList                  bool
-	failListStatus            int
-	uploadID                  string
-	initCalls                 atomic.Int32
-	listCalls                 atomic.Int32
-	aborted                   atomic.Bool
-	completed                 atomic.Bool
-	respBody                  string
-	putCount                  int
-	putBody                   []byte
+	mu                 sync.Mutex
+	parts              map[int][]byte
+	completeBody       []byte
+	failPart           int
+	failPartSeen       chan struct{}
+	failPartOnce       sync.Once
+	failPartStatus     int
+	failComplete       bool
+	failCompleteStatus int
+	failCreate         bool
+	failCreateStatus   int
+	uploadID           string
+	generateUploadIDs  bool
+	completedUploadID  string
+	initCalls          atomic.Int32
+	aborted            atomic.Bool
+	completed          atomic.Bool
+	respBody           string
+	putCount           int
+	putBody            []byte
 }
 
 func newTestCOSClient(t *testing.T, srv *httptest.Server) *QCloudSDK {
@@ -871,9 +831,6 @@ func TestCOSParallelMultipartSuccess(t *testing.T) {
 	}
 	if len(state.completeBody) == 0 {
 		t.Fatalf("complete body not recorded")
-	}
-	if got := state.listCalls.Load(); got != 1 {
-		t.Fatalf("expected one baseline multipart LIST, got %d", got)
 	}
 	if got := counter.FileService.S3.Put.Load(); got != 2 {
 		t.Fatalf("expected 2 physical PUT requests, got %d", got)
@@ -1059,10 +1016,10 @@ func TestCOSMultipartInitRecoversBeforeRequest(t *testing.T) {
 	server, state := newMockCOSServer(t, 0)
 	defer server.Close()
 	state.uploadID = "cos-uid-init-before-request"
-
+	sentinel := errors.New("http: server closed idle connection")
 	transport := &cosMultipartInitBeforeRequestTransport{
 		base:     server.Client().Transport,
-		err:      errors.New("http: server closed idle connection"),
+		err:      sentinel,
 		failures: 1,
 	}
 	sdk := newTestCOSClientWithTransport(t, server, transport)
@@ -1072,21 +1029,79 @@ func TestCOSMultipartInitRecoversBeforeRequest(t *testing.T) {
 	recoveredBefore := testutil.ToFloat64(metric.FSMultipartInitRecoveredCounter)
 	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
 	size := int64(len(data))
-	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, &ParallelMultipartOption{
-		PartSize:    minMultipartPartSize,
-		Concurrency: 1,
-	})
-	require.NoError(t, err)
+	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
 	require.Equal(t, int32(2), transport.initCalls.Load())
-	require.Equal(t, int32(1), state.initCalls.Load(), "retry must create exactly one server-side upload")
-	require.Equal(t, int32(2), state.listCalls.Load(), "normal baseline and failed-attempt reconciliation")
+	require.Equal(t, int32(1), state.initCalls.Load())
 	require.True(t, state.completed.Load())
 	require.Equal(t, attemptsBefore+2, testutil.ToFloat64(metric.FSMultipartInitAttemptCounter))
 	require.Equal(t, ambiguousBefore+1, testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
 	require.Equal(t, recoveredBefore+1, testutil.ToFloat64(metric.FSMultipartInitRecoveredCounter))
 }
 
-func TestCOSMultipartInitRecoversCommittedResponse(t *testing.T) {
+func TestCOSMultipartInitDoesNotAdoptAnotherInstanceUpload(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "upload"
+	state.generateUploadIDs = true
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      sentinel,
+		failures: 1,
+		onFailure: func() {
+			resp, err := http.Post(server.URL+"/object?uploads", "application/octet-stream", nil)
+			require.NoError(t, err)
+			_ = resp.Body.Close()
+		},
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
+	require.Equal(t, int32(2), state.initCalls.Load(), "one external init and one init owned by this writer")
+	state.mu.Lock()
+	require.Equal(t, "upload-2", state.completedUploadID)
+	state.mu.Unlock()
+	require.False(t, state.aborted.Load())
+}
+
+func TestCOSMultipartInitDoesNotRequireListPermission(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-no-list-permission"
+	transport := &denyMultipartListTransport{base: server.Client().Transport}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
+	require.Zero(t, transport.listCalls.Load())
+	require.Equal(t, int32(1), state.initCalls.Load())
+}
+
+func TestCOSMultipartInitCancellationCleansOwnedUpload(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-canceled"
+	ctx, cancel := context.WithCancel(context.Background())
+	transport := &cosMultipartInitCancelAfterResponseTransport{
+		base:   server.Client().Transport,
+		cancel: cancel,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	cleanupBefore := testutil.ToFloat64(metric.FSMultipartInitCleanupCounter)
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(ctx, "object", bytes.NewReader(data), &size, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, state.aborted.Load())
+	require.False(t, state.completed.Load())
+	require.Equal(t, cleanupBefore+1, testutil.ToFloat64(metric.FSMultipartInitCleanupCounter))
+}
+
+func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -1101,75 +1116,32 @@ func TestCOSMultipartInitRecoversCommittedResponse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			server, state := newMockCOSServer(t, 0)
+			var initCalls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || !r.URL.Query().Has("uploads") {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				uploadID := fmt.Sprintf("upload-%d", initCalls.Add(1))
+				w.Header().Set("Content-Type", "application/xml")
+				_, _ = fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>%s</UploadId></InitiateMultipartUploadResult>`, uploadID)
+			}))
 			defer server.Close()
-			state.uploadID = "cos-uid-response-lost"
-			transport := &cosMultipartInitResponseLostTransport{
+
+			sdk := newTestCOSClientWithTransport(t, server, &cosMultipartInitResponseLostTransport{
 				base: server.Client().Transport,
 				err:  test.err,
-			}
-			sdk := newTestCOSClientWithTransport(t, server, transport)
-
+			})
 			data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
 			size := int64(len(data))
 			err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
-			require.NoError(t, err)
-			require.Equal(t, int32(1), state.initCalls.Load(), "response loss must not create a second upload")
-			require.True(t, state.completed.Load())
-			state.mu.Lock()
-			require.Empty(t, state.activeUploads)
-			state.mu.Unlock()
+			require.ErrorContains(t, err, test.err.Error())
+			require.Equal(t, int32(1), initCalls.Load())
 		})
 	}
 }
 
-func TestCOSMultipartInitReconcileExcludesBaseline(t *testing.T) {
-	server, state := newMockCOSServer(t, 0)
-	defer server.Close()
-	state.uploadID = "cos-uid-new"
-	state.activeUploads["cos-uid-old"] = "object"
-	transport := &cosMultipartInitResponseLostTransport{
-		base: server.Client().Transport,
-		err:  errors.New("http: server closed idle connection"),
-	}
-	sdk := newTestCOSClientWithTransport(t, server, transport)
-
-	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
-	size := int64(len(data))
-	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
-	state.mu.Lock()
-	require.Equal(t, map[string]string{"cos-uid-old": "object"}, state.activeUploads)
-	require.NotContains(t, state.abortedUploadIDs, "cos-uid-old")
-	state.mu.Unlock()
-}
-
-func TestCOSMultipartInitCleansAmbiguousConcurrentUploads(t *testing.T) {
-	server, state := newMockCOSServer(t, 0)
-	defer server.Close()
-	state.uploadID = "cos-uid-ambiguous"
-	state.addConcurrentUploadOnInit = true
-	sentinel := errors.New("http: server closed idle connection")
-	transport := &cosMultipartInitResponseLostTransport{
-		base: server.Client().Transport,
-		err:  sentinel,
-	}
-	sdk := newTestCOSClientWithTransport(t, server, transport)
-
-	cleanupBefore := testutil.ToFloat64(metric.FSMultipartInitCleanupCounter)
-	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
-	size := int64(len(data))
-	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
-	require.ErrorContains(t, err, sentinel.Error())
-	require.Equal(t, int32(1), state.initCalls.Load())
-	require.False(t, state.completed.Load())
-	state.mu.Lock()
-	require.Empty(t, state.activeUploads)
-	require.Len(t, state.abortedUploadIDs, 2)
-	state.mu.Unlock()
-	require.Equal(t, cleanupBefore+2, testutil.ToFloat64(metric.FSMultipartInitCleanupCounter))
-}
-
-func TestCOSMultipartInitRetriesAreBounded(t *testing.T) {
+func TestCOSMultipartInitRetriesAreBoundedBeforeRequest(t *testing.T) {
 	server, state := newMockCOSServer(t, 0)
 	defer server.Close()
 	sentinel := errors.New("http: server closed idle connection")
@@ -1186,182 +1158,6 @@ func TestCOSMultipartInitRetriesAreBounded(t *testing.T) {
 	require.ErrorContains(t, err, sentinel.Error())
 	require.Equal(t, int32(qcloudMultipartInitMaxAttempts), transport.initCalls.Load())
 	require.Zero(t, state.initCalls.Load())
-	require.Equal(t, int32(qcloudMultipartInitMaxAttempts+1), state.listCalls.Load())
-	state.mu.Lock()
-	require.Empty(t, state.activeUploads)
-	state.mu.Unlock()
-}
-
-func TestCOSMultipartInitRequiresReconciliationBaseline(t *testing.T) {
-	server, state := newMockCOSServer(t, 0)
-	defer server.Close()
-	state.failList = true
-	sdk := newTestCOSClient(t, server)
-
-	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
-	size := int64(len(data))
-	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
-	require.Error(t, err)
-	require.Zero(t, state.initCalls.Load(), "init must not create state without a reconciliation baseline")
-}
-
-func TestCOSMultipartInitDoesNotRetryNonRetryableError(t *testing.T) {
-	server, state := newMockCOSServer(t, 0)
-	defer server.Close()
-	state.failCreate = true
-	sdk := newTestCOSClient(t, server)
-
-	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
-	size := int64(len(data))
-	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
-	require.Error(t, err)
-	require.Equal(t, int32(1), state.initCalls.Load())
-	require.Equal(t, int32(2), state.listCalls.Load())
-	state.mu.Lock()
-	require.Empty(t, state.activeUploads)
-	state.mu.Unlock()
-}
-
-func TestCOSMultipartInitCancellationCleansCommittedUpload(t *testing.T) {
-	server, state := newMockCOSServer(t, 0)
-	defer server.Close()
-	state.uploadID = "cos-uid-canceled"
-	ctx, cancel := context.WithCancel(context.Background())
-	sentinel := errors.New("http: server closed idle connection")
-	transport := &cosMultipartInitResponseLostTransport{
-		base:        server.Client().Transport,
-		err:         sentinel,
-		afterCommit: cancel,
-	}
-	sdk := newTestCOSClientWithTransport(t, server, transport)
-
-	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
-	size := int64(len(data))
-	err := sdk.WriteMultipartParallel(ctx, "object", bytes.NewReader(data), &size, nil)
-	require.ErrorContains(t, err, context.Canceled.Error())
-	require.True(t, state.aborted.Load())
-	state.mu.Lock()
-	require.Empty(t, state.activeUploads)
-	require.Equal(t, []string{"cos-uid-canceled"}, state.abortedUploadIDs)
-	state.mu.Unlock()
-}
-
-func TestCOSMultipartInitConcurrentWritersRecoverIndependently(t *testing.T) {
-	server, state := newMockCOSServer(t, 0)
-	defer server.Close()
-	state.uploadID = "cos-uid-concurrent"
-	transport := &cosMultipartInitResponseLostTransport{
-		base: server.Client().Transport,
-		err:  errors.New("http: server closed idle connection"),
-	}
-	sdk := newTestCOSClientWithTransport(t, server, transport)
-
-	start := make(chan struct{})
-	errs := make(chan error, 2)
-	for _, key := range []string{"object-a", "object-b"} {
-		go func(key string) {
-			<-start
-			data := bytes.Repeat([]byte(key), int(minMultipartPartSize/int64(len(key))+1))
-			size := int64(len(data))
-			errs <- sdk.WriteMultipartParallel(context.Background(), key, bytes.NewReader(data), &size, nil)
-		}(key)
-	}
-	close(start)
-	require.NoError(t, <-errs)
-	require.NoError(t, <-errs)
-	require.Equal(t, int32(2), state.initCalls.Load())
-	state.mu.Lock()
-	require.Empty(t, state.activeUploads)
-	state.mu.Unlock()
-}
-
-func TestQCloudListMultipartUploadIDsPagination(t *testing.T) {
-	var calls atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		call := calls.Add(1)
-		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "object", r.URL.Query().Get("prefix"))
-		w.Header().Set("Content-Type", "application/xml")
-		if call == 1 {
-			require.Empty(t, r.URL.Query().Get("key-marker"))
-			_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>true</IsTruncated><NextKeyMarker>object</NextKeyMarker><NextUploadIdMarker>id-1</NextUploadIdMarker><Upload><Key>object</Key><UploadId>id-1</UploadId></Upload><Upload><Key>object-suffix</Key><UploadId>ignored</UploadId></Upload></ListMultipartUploadsResult>`)
-			return
-		}
-		require.Equal(t, "object", r.URL.Query().Get("key-marker"))
-		require.Equal(t, "id-1", r.URL.Query().Get("upload-id-marker"))
-		_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>false</IsTruncated><Upload><Key>object</Key><UploadId>id-2</UploadId></Upload></ListMultipartUploadsResult>`)
-	}))
-	defer server.Close()
-
-	sdk := newTestCOSClient(t, server)
-	ids, err := sdk.listMultipartUploadIDs(context.Background(), "object")
-	require.NoError(t, err)
-	require.Equal(t, map[string]struct{}{"id-1": {}, "id-2": {}}, ids)
-	require.Equal(t, int32(2), calls.Load())
-}
-
-func TestQCloudListMultipartUploadIDsRejectsStalledPagination(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/xml")
-		_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>true</IsTruncated></ListMultipartUploadsResult>`)
-	}))
-	defer server.Close()
-
-	sdk := newTestCOSClient(t, server)
-	_, err := sdk.listMultipartUploadIDs(context.Background(), "object")
-	require.ErrorContains(t, err, "did not advance")
-}
-
-func TestQCloudMultipartInitGateHonorsCancellation(t *testing.T) {
-	sdk := new(QCloudSDK)
-	holderUnlock, err := sdk.multipartInitGate("object").lock(context.Background())
-	require.NoError(t, err)
-	defer func() {
-		if holderUnlock != nil {
-			holderUnlock()
-		}
-	}()
-
-	baseCtx, cancel := context.WithCancel(context.Background())
-	ctx := &doneObservedContext{
-		Context:  baseCtx,
-		observed: make(chan struct{}),
-	}
-	result := make(chan error, 1)
-	go func() {
-		_, lockErr := sdk.multipartInitGate("object").lock(ctx)
-		result <- lockErr
-	}()
-
-	select {
-	case <-ctx.observed:
-	case <-time.After(time.Second):
-		t.Fatal("gate waiter did not start")
-	}
-	cancel()
-	select {
-	case err = <-result:
-		require.ErrorIs(t, err, context.Canceled)
-	case <-time.After(time.Second):
-		t.Fatal("gate waiter did not observe cancellation")
-	}
-
-	holderUnlock()
-	holderUnlock = nil
-	unlock, err := sdk.multipartInitGate("object").lock(context.Background())
-	require.NoError(t, err)
-	unlock()
-}
-
-type doneObservedContext struct {
-	context.Context
-	once     sync.Once
-	observed chan struct{}
-}
-
-func (c *doneObservedContext) Done() <-chan struct{} {
-	c.once.Do(func() { close(c.observed) })
-	return c.Context.Done()
 }
 
 type cosMultipartInitBeforeRequestTransport struct {
@@ -1369,19 +1165,25 @@ type cosMultipartInitBeforeRequestTransport struct {
 	err       error
 	failures  int32
 	initCalls atomic.Int32
+	onFailure func()
 }
 
 type cosMultipartInitResponseLostTransport struct {
-	base        http.RoundTripper
-	err         error
-	afterCommit func()
+	base http.RoundTripper
+	err  error
 }
 
-func newTestCOSClientWithTransport(
-	t *testing.T,
-	server *httptest.Server,
-	transport http.RoundTripper,
-) *QCloudSDK {
+type denyMultipartListTransport struct {
+	base      http.RoundTripper
+	listCalls atomic.Int32
+}
+
+type cosMultipartInitCancelAfterResponseTransport struct {
+	base   http.RoundTripper
+	cancel context.CancelFunc
+}
+
+func newTestCOSClientWithTransport(t *testing.T, server *httptest.Server, transport http.RoundTripper) *QCloudSDK {
 	t.Helper()
 	baseURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
@@ -1401,10 +1203,25 @@ func (t *cosMultipartInitResponseLostTransport) RoundTrip(req *http.Request) (*h
 	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
-		if t.afterCommit != nil {
-			t.afterCommit()
-		}
 		return nil, t.err
+	}
+	return resp, nil
+}
+
+func (t *cosMultipartInitCancelAfterResponseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.ContentLength = int64(len(body))
+		t.cancel()
 	}
 	return resp, nil
 }
@@ -1415,8 +1232,24 @@ func (t *cosMultipartInitBeforeRequestTransport) RoundTrip(req *http.Request) (*
 			if req.Body != nil {
 				_ = req.Body.Close()
 			}
+			if t.onFailure != nil {
+				t.onFailure()
+			}
 			return nil, t.err
 		}
+	}
+	return t.base.RoundTrip(req)
+}
+
+func (t *denyMultipartListTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodGet && req.URL.Query().Has("uploads") {
+		t.listCalls.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("Access Denied")),
+			Request:    req,
+		}, nil
 	}
 	return t.base.RoundTrip(req)
 }

--- a/pkg/fileservice/parallel_sdk_test.go
+++ b/pkg/fileservice/parallel_sdk_test.go
@@ -34,7 +34,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/panjf2000/ants/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	costypes "github.com/tencentyun/cos-go-sdk-v5"
 	"golang.org/x/sync/semaphore"
@@ -689,19 +691,54 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 		failPartStatus:     http.StatusBadRequest,
 		failCompleteStatus: http.StatusBadRequest,
 		failCreateStatus:   http.StatusBadRequest,
+		failListStatus:     http.StatusBadRequest,
+		uploadID:           "cos-upload",
 		parts:              make(map[int][]byte),
+		activeUploads:      make(map[string]string),
 	}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("uploads"):
+			state.listCalls.Add(1)
+			if state.failList {
+				w.WriteHeader(state.failListStatus)
+				return
+			}
+			prefix := r.URL.Query().Get("prefix")
+			state.mu.Lock()
+			uploads := make(map[string]string, len(state.activeUploads))
+			for id, key := range state.activeUploads {
+				if strings.HasPrefix(key, prefix) {
+					uploads[id] = key
+				}
+			}
+			state.mu.Unlock()
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>false</IsTruncated>`)
+			for id, key := range uploads {
+				_, _ = fmt.Fprintf(w, `<Upload><Key>%s</Key><UploadId>%s</UploadId></Upload>`, key, id)
+			}
+			_, _ = io.WriteString(w, `</ListMultipartUploadsResult>`)
 		case r.Method == http.MethodPost && strings.Contains(r.URL.RawQuery, "uploads"):
-			state.initCalls.Add(1)
+			initCall := state.initCalls.Add(1)
 			if state.failCreate {
 				w.WriteHeader(state.failCreateStatus)
 				return
 			}
 			_, _ = io.ReadAll(r.Body)
+			uploadID := state.uploadID
+			if initCall > 1 {
+				uploadID = fmt.Sprintf("%s-%d", uploadID, initCall)
+			}
+			key := strings.TrimPrefix(r.URL.Path, "/")
+			state.mu.Lock()
+			state.activeUploads[uploadID] = key
+			if state.addConcurrentUploadOnInit {
+				state.activeUploads[uploadID+"-concurrent"] = key
+			}
+			state.mu.Unlock()
 			w.Header().Set("Content-Type", "application/xml")
-			_, _ = fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>%s</UploadId></InitiateMultipartUploadResult>`, state.uploadID)
+			_, _ = fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>%s</UploadId></InitiateMultipartUploadResult>`, uploadID)
 		case r.Method == http.MethodPut && !strings.Contains(r.URL.RawQuery, "partNumber") && !strings.Contains(r.URL.RawQuery, "uploadId") && !strings.Contains(r.URL.RawQuery, "uploads"):
 			body, _ := io.ReadAll(r.Body)
 			state.mu.Lock()
@@ -740,12 +777,19 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 					return
 				}
 			}
+			delete(state.activeUploads, r.URL.Query().Get("uploadId"))
+			responseBody := `<CompleteMultipartUploadResult><Location>loc</Location><Bucket>bucket</Bucket><Key>object</Key><ETag>etag</ETag></CompleteMultipartUploadResult>`
+			state.respBody = responseBody
 			state.mu.Unlock()
 			w.Header().Set("Content-Type", "application/xml")
-			state.respBody = `<CompleteMultipartUploadResult><Location>loc</Location><Bucket>bucket</Bucket><Key>object</Key><ETag>etag</ETag></CompleteMultipartUploadResult>`
 			state.completed.Store(true)
-			_, _ = w.Write([]byte(state.respBody))
+			_, _ = w.Write([]byte(responseBody))
 		case r.Method == http.MethodDelete && strings.Contains(r.URL.RawQuery, "uploadId"):
+			state.mu.Lock()
+			uploadID := r.URL.Query().Get("uploadId")
+			delete(state.activeUploads, uploadID)
+			state.abortedUploadIDs = append(state.abortedUploadIDs, uploadID)
+			state.mu.Unlock()
 			state.aborted.Store(true)
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -756,24 +800,30 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 }
 
 type cosServerState struct {
-	mu                 sync.Mutex
-	parts              map[int][]byte
-	completeBody       []byte
-	failPart           int
-	failPartSeen       chan struct{}
-	failPartOnce       sync.Once
-	failPartStatus     int
-	failComplete       bool
-	failCompleteStatus int
-	failCreate         bool
-	failCreateStatus   int
-	uploadID           string
-	initCalls          atomic.Int32
-	aborted            atomic.Bool
-	completed          atomic.Bool
-	respBody           string
-	putCount           int
-	putBody            []byte
+	mu                        sync.Mutex
+	parts                     map[int][]byte
+	activeUploads             map[string]string
+	abortedUploadIDs          []string
+	addConcurrentUploadOnInit bool
+	completeBody              []byte
+	failPart                  int
+	failPartSeen              chan struct{}
+	failPartOnce              sync.Once
+	failPartStatus            int
+	failComplete              bool
+	failCompleteStatus        int
+	failCreate                bool
+	failCreateStatus          int
+	failList                  bool
+	failListStatus            int
+	uploadID                  string
+	initCalls                 atomic.Int32
+	listCalls                 atomic.Int32
+	aborted                   atomic.Bool
+	completed                 atomic.Bool
+	respBody                  string
+	putCount                  int
+	putBody                   []byte
 }
 
 func newTestCOSClient(t *testing.T, srv *httptest.Server) *QCloudSDK {
@@ -788,6 +838,7 @@ func newTestCOSClient(t *testing.T, srv *httptest.Server) *QCloudSDK {
 		srv.Client(),
 	)
 	client.Conf.EnableCRC = false
+	client.Conf.RetryOpt.Count = 0
 
 	return &QCloudSDK{
 		name:   "cos-test",
@@ -820,6 +871,9 @@ func TestCOSParallelMultipartSuccess(t *testing.T) {
 	}
 	if len(state.completeBody) == 0 {
 		t.Fatalf("complete body not recorded")
+	}
+	if got := state.listCalls.Load(); got != 1 {
+		t.Fatalf("expected one baseline multipart LIST, got %d", got)
 	}
 	if got := counter.FileService.S3.Put.Load(); got != 2 {
 		t.Fatalf("expected 2 physical PUT requests, got %d", got)
@@ -1001,55 +1055,38 @@ func TestCOSMultipartUploadPartRetriesServerClosedIdleConnection(t *testing.T) {
 	}
 }
 
-func TestCOSMultipartInitDoesNotRetryEOFBeforeRequest(t *testing.T) {
+func TestCOSMultipartInitRecoversBeforeRequest(t *testing.T) {
 	server, state := newMockCOSServer(t, 0)
 	defer server.Close()
-	state.uploadID = "cos-uid-init-eof"
+	state.uploadID = "cos-uid-init-before-request"
 
-	baseClient := server.Client()
-	baseTransport := baseClient.Transport
-	if baseTransport == nil {
-		baseTransport = http.DefaultTransport
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      errors.New("http: server closed idle connection"),
+		failures: 1,
 	}
-	transport := &cosMultipartInitEOFTransport{base: baseTransport}
-	baseClient.Transport = transport
+	sdk := newTestCOSClientWithTransport(t, server, transport)
 
-	baseURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatalf("parse url: %v", err)
-	}
-	client := costypes.NewClient(
-		&costypes.BaseURL{BucketURL: baseURL},
-		baseClient,
-	)
-	client.Conf.EnableCRC = false
-	client.Conf.RetryOpt.Count = 0
-	sdk := &QCloudSDK{
-		name:   "cos-init-eof-test",
-		client: client,
-	}
-
+	attemptsBefore := testutil.ToFloat64(metric.FSMultipartInitAttemptCounter)
+	ambiguousBefore := testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter)
+	recoveredBefore := testutil.ToFloat64(metric.FSMultipartInitRecoveredCounter)
 	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
 	size := int64(len(data))
-	err = sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, &ParallelMultipartOption{
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, &ParallelMultipartOption{
 		PartSize:    minMultipartPartSize,
 		Concurrency: 1,
 	})
-	if err == nil {
-		t.Fatalf("expected multipart-init error")
-	}
-	if transport.initCalls.Load() != 1 {
-		t.Fatalf("expected no retry after multipart-init EOF, got %d attempts", transport.initCalls.Load())
-	}
-	if state.initCalls.Load() != 0 {
-		t.Fatalf("pre-request EOF unexpectedly reached COS, got %d server init calls", state.initCalls.Load())
-	}
-	if state.completed.Load() {
-		t.Fatalf("unexpected multipart upload completion")
-	}
+	require.NoError(t, err)
+	require.Equal(t, int32(2), transport.initCalls.Load())
+	require.Equal(t, int32(1), state.initCalls.Load(), "retry must create exactly one server-side upload")
+	require.Equal(t, int32(2), state.listCalls.Load(), "normal baseline and failed-attempt reconciliation")
+	require.True(t, state.completed.Load())
+	require.Equal(t, attemptsBefore+2, testutil.ToFloat64(metric.FSMultipartInitAttemptCounter))
+	require.Equal(t, ambiguousBefore+1, testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
+	require.Equal(t, recoveredBefore+1, testutil.ToFloat64(metric.FSMultipartInitRecoveredCounter))
 }
 
-func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
+func TestCOSMultipartInitRecoversCommittedResponse(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -1064,58 +1101,296 @@ func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var initCalls atomic.Int32
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodPost || !r.URL.Query().Has("uploads") {
-					w.WriteHeader(http.StatusNotFound)
-					return
-				}
-				uploadID := fmt.Sprintf("upload-%d", initCalls.Add(1))
-				w.Header().Set("Content-Type", "application/xml")
-				_, _ = fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>%s</UploadId></InitiateMultipartUploadResult>`, uploadID)
-			}))
+			server, state := newMockCOSServer(t, 0)
 			defer server.Close()
-
-			baseClient := server.Client()
-			baseTransport := baseClient.Transport
-			if baseTransport == nil {
-				baseTransport = http.DefaultTransport
-			}
-			baseClient.Transport = &cosMultipartInitResponseLostTransport{
-				base: baseTransport,
+			state.uploadID = "cos-uid-response-lost"
+			transport := &cosMultipartInitResponseLostTransport{
+				base: server.Client().Transport,
 				err:  test.err,
 			}
-
-			baseURL, err := url.Parse(server.URL)
-			if err != nil {
-				t.Fatalf("parse url: %v", err)
-			}
-			client := costypes.NewClient(&costypes.BaseURL{BucketURL: baseURL}, baseClient)
-			client.Conf.EnableCRC = false
-			client.Conf.RetryOpt.Count = 0
-			sdk := &QCloudSDK{name: "cos-init-response-lost-test", client: client}
+			sdk := newTestCOSClientWithTransport(t, server, transport)
 
 			data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
 			size := int64(len(data))
-			err = sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
-			if err == nil {
-				t.Fatalf("expected multipart-init error")
-			}
-			if initCalls.Load() != 1 {
-				t.Fatalf("response-lost error must not create additional uploads, got %d", initCalls.Load())
-			}
+			err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+			require.NoError(t, err)
+			require.Equal(t, int32(1), state.initCalls.Load(), "response loss must not create a second upload")
+			require.True(t, state.completed.Load())
+			state.mu.Lock()
+			require.Empty(t, state.activeUploads)
+			state.mu.Unlock()
 		})
 	}
 }
 
-type cosMultipartInitEOFTransport struct {
+func TestCOSMultipartInitReconcileExcludesBaseline(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-new"
+	state.activeUploads["cos-uid-old"] = "object"
+	transport := &cosMultipartInitResponseLostTransport{
+		base: server.Client().Transport,
+		err:  errors.New("http: server closed idle connection"),
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
+	state.mu.Lock()
+	require.Equal(t, map[string]string{"cos-uid-old": "object"}, state.activeUploads)
+	require.NotContains(t, state.abortedUploadIDs, "cos-uid-old")
+	state.mu.Unlock()
+}
+
+func TestCOSMultipartInitCleansAmbiguousConcurrentUploads(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-ambiguous"
+	state.addConcurrentUploadOnInit = true
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitResponseLostTransport{
+		base: server.Client().Transport,
+		err:  sentinel,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	cleanupBefore := testutil.ToFloat64(metric.FSMultipartInitCleanupCounter)
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+	require.ErrorContains(t, err, sentinel.Error())
+	require.Equal(t, int32(1), state.initCalls.Load())
+	require.False(t, state.completed.Load())
+	state.mu.Lock()
+	require.Empty(t, state.activeUploads)
+	require.Len(t, state.abortedUploadIDs, 2)
+	state.mu.Unlock()
+	require.Equal(t, cleanupBefore+2, testutil.ToFloat64(metric.FSMultipartInitCleanupCounter))
+}
+
+func TestCOSMultipartInitRetriesAreBounded(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      sentinel,
+		failures: qcloudMultipartInitMaxAttempts,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+	require.ErrorContains(t, err, sentinel.Error())
+	require.Equal(t, int32(qcloudMultipartInitMaxAttempts), transport.initCalls.Load())
+	require.Zero(t, state.initCalls.Load())
+	require.Equal(t, int32(qcloudMultipartInitMaxAttempts+1), state.listCalls.Load())
+	state.mu.Lock()
+	require.Empty(t, state.activeUploads)
+	state.mu.Unlock()
+}
+
+func TestCOSMultipartInitRequiresReconciliationBaseline(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.failList = true
+	sdk := newTestCOSClient(t, server)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+	require.Error(t, err)
+	require.Zero(t, state.initCalls.Load(), "init must not create state without a reconciliation baseline")
+}
+
+func TestCOSMultipartInitDoesNotRetryNonRetryableError(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.failCreate = true
+	sdk := newTestCOSClient(t, server)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+	require.Error(t, err)
+	require.Equal(t, int32(1), state.initCalls.Load())
+	require.Equal(t, int32(2), state.listCalls.Load())
+	state.mu.Lock()
+	require.Empty(t, state.activeUploads)
+	state.mu.Unlock()
+}
+
+func TestCOSMultipartInitCancellationCleansCommittedUpload(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-canceled"
+	ctx, cancel := context.WithCancel(context.Background())
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitResponseLostTransport{
+		base:        server.Client().Transport,
+		err:         sentinel,
+		afterCommit: cancel,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(ctx, "object", bytes.NewReader(data), &size, nil)
+	require.ErrorContains(t, err, context.Canceled.Error())
+	require.True(t, state.aborted.Load())
+	state.mu.Lock()
+	require.Empty(t, state.activeUploads)
+	require.Equal(t, []string{"cos-uid-canceled"}, state.abortedUploadIDs)
+	state.mu.Unlock()
+}
+
+func TestCOSMultipartInitConcurrentWritersRecoverIndependently(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-concurrent"
+	transport := &cosMultipartInitResponseLostTransport{
+		base: server.Client().Transport,
+		err:  errors.New("http: server closed idle connection"),
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, key := range []string{"object-a", "object-b"} {
+		go func(key string) {
+			<-start
+			data := bytes.Repeat([]byte(key), int(minMultipartPartSize/int64(len(key))+1))
+			size := int64(len(data))
+			errs <- sdk.WriteMultipartParallel(context.Background(), key, bytes.NewReader(data), &size, nil)
+		}(key)
+	}
+	close(start)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	require.Equal(t, int32(2), state.initCalls.Load())
+	state.mu.Lock()
+	require.Empty(t, state.activeUploads)
+	state.mu.Unlock()
+}
+
+func TestQCloudListMultipartUploadIDsPagination(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "object", r.URL.Query().Get("prefix"))
+		w.Header().Set("Content-Type", "application/xml")
+		if call == 1 {
+			require.Empty(t, r.URL.Query().Get("key-marker"))
+			_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>true</IsTruncated><NextKeyMarker>object</NextKeyMarker><NextUploadIdMarker>id-1</NextUploadIdMarker><Upload><Key>object</Key><UploadId>id-1</UploadId></Upload><Upload><Key>object-suffix</Key><UploadId>ignored</UploadId></Upload></ListMultipartUploadsResult>`)
+			return
+		}
+		require.Equal(t, "object", r.URL.Query().Get("key-marker"))
+		require.Equal(t, "id-1", r.URL.Query().Get("upload-id-marker"))
+		_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>false</IsTruncated><Upload><Key>object</Key><UploadId>id-2</UploadId></Upload></ListMultipartUploadsResult>`)
+	}))
+	defer server.Close()
+
+	sdk := newTestCOSClient(t, server)
+	ids, err := sdk.listMultipartUploadIDs(context.Background(), "object")
+	require.NoError(t, err)
+	require.Equal(t, map[string]struct{}{"id-1": {}, "id-2": {}}, ids)
+	require.Equal(t, int32(2), calls.Load())
+}
+
+func TestQCloudListMultipartUploadIDsRejectsStalledPagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = io.WriteString(w, `<ListMultipartUploadsResult><IsTruncated>true</IsTruncated></ListMultipartUploadsResult>`)
+	}))
+	defer server.Close()
+
+	sdk := newTestCOSClient(t, server)
+	_, err := sdk.listMultipartUploadIDs(context.Background(), "object")
+	require.ErrorContains(t, err, "did not advance")
+}
+
+func TestQCloudMultipartInitGateHonorsCancellation(t *testing.T) {
+	sdk := new(QCloudSDK)
+	holderUnlock, err := sdk.multipartInitGate("object").lock(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		if holderUnlock != nil {
+			holderUnlock()
+		}
+	}()
+
+	baseCtx, cancel := context.WithCancel(context.Background())
+	ctx := &doneObservedContext{
+		Context:  baseCtx,
+		observed: make(chan struct{}),
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, lockErr := sdk.multipartInitGate("object").lock(ctx)
+		result <- lockErr
+	}()
+
+	select {
+	case <-ctx.observed:
+	case <-time.After(time.Second):
+		t.Fatal("gate waiter did not start")
+	}
+	cancel()
+	select {
+	case err = <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("gate waiter did not observe cancellation")
+	}
+
+	holderUnlock()
+	holderUnlock = nil
+	unlock, err := sdk.multipartInitGate("object").lock(context.Background())
+	require.NoError(t, err)
+	unlock()
+}
+
+type doneObservedContext struct {
+	context.Context
+	once     sync.Once
+	observed chan struct{}
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+type cosMultipartInitBeforeRequestTransport struct {
 	base      http.RoundTripper
+	err       error
+	failures  int32
 	initCalls atomic.Int32
 }
 
 type cosMultipartInitResponseLostTransport struct {
-	base http.RoundTripper
-	err  error
+	base        http.RoundTripper
+	err         error
+	afterCommit func()
+}
+
+func newTestCOSClientWithTransport(
+	t *testing.T,
+	server *httptest.Server,
+	transport http.RoundTripper,
+) *QCloudSDK {
+	t.Helper()
+	baseURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	httpClient := server.Client()
+	httpClient.Transport = transport
+	client := costypes.NewClient(&costypes.BaseURL{BucketURL: baseURL}, httpClient)
+	client.Conf.EnableCRC = false
+	client.Conf.RetryOpt.Count = 0
+	return &QCloudSDK{name: "cos-multipart-init-test", client: client}
 }
 
 func (t *cosMultipartInitResponseLostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -1126,18 +1401,21 @@ func (t *cosMultipartInitResponseLostTransport) RoundTrip(req *http.Request) (*h
 	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
+		if t.afterCommit != nil {
+			t.afterCommit()
+		}
 		return nil, t.err
 	}
 	return resp, nil
 }
 
-func (t *cosMultipartInitEOFTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *cosMultipartInitBeforeRequestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
-		if t.initCalls.Add(1) == 1 {
+		if t.initCalls.Add(1) <= t.failures {
 			if req.Body != nil {
 				_ = req.Body.Close()
 			}
-			return nil, io.EOF
+			return nil, t.err
 		}
 	}
 	return t.base.RoundTrip(req)

--- a/pkg/fileservice/parallel_sdk_test.go
+++ b/pkg/fileservice/parallel_sdk_test.go
@@ -1034,7 +1034,7 @@ func TestCOSMultipartInitRecoversBeforeRequest(t *testing.T) {
 	require.Equal(t, int32(1), state.initCalls.Load())
 	require.True(t, state.completed.Load())
 	require.Equal(t, attemptsBefore+2, testutil.ToFloat64(metric.FSMultipartInitAttemptCounter))
-	require.Equal(t, ambiguousBefore+1, testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
+	require.Equal(t, ambiguousBefore, testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
 	require.Equal(t, recoveredBefore+1, testutil.ToFloat64(metric.FSMultipartInitRecoveredCounter))
 }
 
@@ -1101,6 +1101,49 @@ func TestCOSMultipartInitCancellationCleansOwnedUpload(t *testing.T) {
 	require.Equal(t, cleanupBefore+1, testutil.ToFloat64(metric.FSMultipartInitCleanupCounter))
 }
 
+func TestCOSMultipartInitCancellationOverridesRetryableError(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:      server.Client().Transport,
+		err:       errors.New("http: server closed idle connection"),
+		failures:  1,
+		onFailure: cancel,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(ctx, "object", bytes.NewReader(data), &size, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, int32(1), transport.initCalls.Load())
+	require.Zero(t, state.initCalls.Load())
+}
+
+func TestCOSMultipartInitDefinitiveErrorOverridesEarlierRetryableError(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.failCreate = true
+	state.failCreateStatus = http.StatusForbidden
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      sentinel,
+		failures: 1,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), sentinel.Error())
+	require.Contains(t, err.Error(), "403")
+	require.Equal(t, int32(2), transport.initCalls.Load())
+	require.Equal(t, int32(1), state.initCalls.Load())
+}
+
 func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1114,6 +1157,7 @@ func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 		{name: "server closed connection", err: errors.New("http: server closed idle connection")},
 	}
 
+	ambiguousBefore := testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var initCalls atomic.Int32
@@ -1139,6 +1183,7 @@ func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 			require.Equal(t, int32(1), initCalls.Load())
 		})
 	}
+	require.Equal(t, ambiguousBefore+float64(len(tests)), testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
 }
 
 func TestCOSMultipartInitRetriesAreBoundedBeforeRequest(t *testing.T) {

--- a/pkg/fileservice/qcloud_sdk.go
+++ b/pkg/fileservice/qcloud_sdk.go
@@ -373,7 +373,7 @@ func (a *QCloudSDK) initiateMultipartUpload(
 	ctx, cancel := context.WithTimeoutCause(ctx, qcloudMultipartInitTimeout, context.DeadlineExceeded)
 	defer cancel()
 
-	var firstErr error
+	var lastErr error
 	for attempt := 0; attempt < qcloudMultipartInitMaxAttempts; attempt++ {
 		var wroteRequest atomic.Bool
 		attemptCtx := httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
@@ -383,17 +383,12 @@ func (a *QCloudSDK) initiateMultipartUpload(
 		})
 
 		metric.FSMultipartInitAttemptCounter.Inc()
-		output, _, createErr := a.client.Object.InitiateMultipartUpload(attemptCtx, key, opt)
+		output, response, createErr := a.client.Object.InitiateMultipartUpload(attemptCtx, key, opt)
 		if createErr == nil && (output == nil || output.UploadID == "") {
 			createErr = moerr.NewInternalErrorNoCtxf("cos initiate multipart upload returned an empty upload id for key %q", key)
 		}
-		if createErr != nil && firstErr == nil {
-			firstErr = createErr
-		}
+		lastErr = createErr
 		if output != nil && output.UploadID != "" {
-			if createErr != nil {
-				metric.FSMultipartInitAmbiguousCounter.Inc()
-			}
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				cleanupCtx, cleanupCancel := context.WithTimeoutCause(
 					context.WithoutCancel(ctx),
@@ -406,30 +401,40 @@ func (a *QCloudSDK) initiateMultipartUpload(
 				} else {
 					metric.FSMultipartInitCleanupCounter.Inc()
 				}
-				if firstErr != nil {
-					return nil, firstErr
-				}
 				return nil, ctxErr
 			}
-			if firstErr != nil {
+			if attempt > 0 || createErr != nil {
 				metric.FSMultipartInitRecoveredCounter.Inc()
 			}
 			return output, nil
 		}
-
-		metric.FSMultipartInitAmbiguousCounter.Inc()
-		if ctx.Err() != nil || wroteRequest.Load() || !IsRetryableError(createErr) ||
-			attempt+1 >= qcloudMultipartInitMaxAttempts {
-			return nil, firstErr
+		commitAmbiguous := response == nil && wroteRequest.Load()
+		if commitAmbiguous {
+			metric.FSMultipartInitAmbiguousCounter.Inc()
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if commitAmbiguous {
+			// Without an UploadID, no client can distinguish this request's
+			// server-side state from another CN's upload. Do not list, claim, or
+			// abort candidates here; COS bucket lifecycle must reclaim any orphan.
+			logutil.Warn("cos multipart init is commit-ambiguous; bucket lifecycle must abort incomplete uploads",
+				zap.Error(createErr))
+			return nil, createErr
+		}
+		if !IsRetryableError(createErr) || attempt+1 >= qcloudMultipartInitMaxAttempts {
+			return nil, createErr
 		}
 		// WroteRequest is emitted by net/http once writing starts, including
 		// write failures. Its absence proves this attempt never crossed the
-		// transport write boundary, so retrying cannot duplicate an upload.
+		// transport write boundary. A server error response also proves the
+		// attempt failed, so either outcome is safe to retry.
 		if err := waitQCloudMultipartInitRetry(ctx, attempt); err != nil {
-			return nil, firstErr
+			return nil, err
 		}
 	}
-	return nil, firstErr
+	return nil, lastErr
 }
 
 func (a *QCloudSDK) WriteMultipartParallel(

--- a/pkg/fileservice/qcloud_sdk.go
+++ b/pkg/fileservice/qcloud_sdk.go
@@ -408,7 +408,9 @@ func (a *QCloudSDK) initiateMultipartUpload(
 			}
 			return output, nil
 		}
-		commitAmbiguous := response == nil && wroteRequest.Load()
+		definitiveFailure := response != nil && response.Response != nil &&
+			(response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices)
+		commitAmbiguous := !definitiveFailure && (response != nil || wroteRequest.Load())
 		if commitAmbiguous {
 			metric.FSMultipartInitAmbiguousCounter.Inc()
 		}
@@ -428,7 +430,7 @@ func (a *QCloudSDK) initiateMultipartUpload(
 		}
 		// WroteRequest is emitted by net/http once writing starts, including
 		// write failures. Its absence proves this attempt never crossed the
-		// transport write boundary. A server error response also proves the
+		// transport write boundary. A non-2xx server response also proves the
 		// attempt failed, so either outcome is safe to retry.
 		if err := waitQCloudMultipartInitRetry(ctx, attempt); err != nil {
 			return nil, err

--- a/pkg/fileservice/qcloud_sdk.go
+++ b/pkg/fileservice/qcloud_sdk.go
@@ -35,6 +35,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/tencentyun/cos-go-sdk-v5"
 	"go.uber.org/zap"
@@ -47,9 +48,42 @@ type QCloudSDK struct {
 	copyCredentialDomain objectStorageCopyCredentialDomain
 	perfCounterSets      []*perfcounter.CounterSet
 	listMaxKeys          int
+	multipartInitGates   [64]qcloudMultipartInitGate
 }
 
-const qcloudMultipartAbortTimeout = 30 * time.Second
+type qcloudMultipartInitGate struct {
+	once  sync.Once
+	token chan struct{}
+}
+
+func (g *qcloudMultipartInitGate) lock(ctx context.Context) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	g.once.Do(func() {
+		g.token = make(chan struct{}, 1)
+		g.token <- struct{}{}
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-g.token:
+		if err := ctx.Err(); err != nil {
+			g.token <- struct{}{}
+			return nil, err
+		}
+		return func() { g.token <- struct{}{} }, nil
+	}
+}
+
+const (
+	qcloudMultipartAbortTimeout       = 30 * time.Second
+	qcloudMultipartInitTimeout        = 30 * time.Second
+	qcloudMultipartInitMaxAttempts    = 3
+	qcloudMultipartListMaxAttempts    = 3
+	qcloudMultipartListMaxPages       = 16
+	qcloudMultipartListMaxUploadsPage = 1000
+)
 
 func NewQCloudSDK(
 	ctx context.Context,
@@ -341,6 +375,233 @@ func (a *QCloudSDK) SupportsParallelMultipart() bool {
 	return true
 }
 
+func (a *QCloudSDK) multipartInitGate(key string) *qcloudMultipartInitGate {
+	// FNV-1a keeps the lock table fixed-size while distributing object keys.
+	var hash uint32 = 2166136261
+	for i := 0; i < len(key); i++ {
+		hash ^= uint32(key[i])
+		hash *= 16777619
+	}
+	return &a.multipartInitGates[int(hash%uint32(len(a.multipartInitGates)))]
+}
+
+func (a *QCloudSDK) listMultipartUploadIDs(ctx context.Context, key string) (map[string]struct{}, error) {
+	ids := make(map[string]struct{})
+	var keyMarker, uploadIDMarker string
+	for page := 0; page < qcloudMultipartListMaxPages; page++ {
+		opts := &cos.ListMultipartUploadsOptions{
+			Prefix:         key,
+			MaxUploads:     qcloudMultipartListMaxUploadsPage,
+			KeyMarker:      keyMarker,
+			UploadIDMarker: uploadIDMarker,
+		}
+		result, err := DoWithRetryContext(ctx, "cos list multipart uploads", func() (*cos.ListMultipartUploadsResult, error) {
+			perfcounter.Update(ctx, func(counter *perfcounter.CounterSet) {
+				counter.FileService.S3.List.Add(1)
+			}, a.perfCounterSets...)
+			res, _, listErr := a.client.Bucket.ListMultipartUploads(ctx, opts)
+			return res, listErr
+		}, qcloudMultipartListMaxAttempts, IsRetryableError)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			return nil, moerr.NewInternalErrorNoCtxf("cos multipart upload listing returned no result for key %q", key)
+		}
+		for _, upload := range result.Uploads {
+			if upload.Key == key && upload.UploadID != "" {
+				ids[upload.UploadID] = struct{}{}
+			}
+		}
+		if !result.IsTruncated {
+			return ids, nil
+		}
+		nextKeyMarker := result.NextKeyMarker
+		nextUploadIDMarker := result.NextUploadIDMarker
+		if nextKeyMarker == keyMarker && nextUploadIDMarker == uploadIDMarker {
+			return nil, moerr.NewInternalErrorNoCtxf("cos multipart upload listing did not advance for key %q", key)
+		}
+		keyMarker, uploadIDMarker = nextKeyMarker, nextUploadIDMarker
+	}
+	return nil, moerr.NewInternalErrorNoCtxf(
+		"cos multipart upload listing exceeded %d pages for key %q",
+		qcloudMultipartListMaxPages,
+		key,
+	)
+}
+
+func newMultipartUploadIDs(current, baseline map[string]struct{}) []string {
+	ids := make([]string, 0, len(current))
+	for id := range current {
+		if _, existed := baseline[id]; !existed {
+			ids = append(ids, id)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func (a *QCloudSDK) cleanupMultipartUploadIDs(parentCtx context.Context, key string, uploadIDs []string) {
+	cleanupCtx, cleanupCancel := context.WithTimeoutCause(
+		context.WithoutCancel(parentCtx),
+		qcloudMultipartAbortTimeout,
+		context.DeadlineExceeded,
+	)
+	defer cleanupCancel()
+	a.cleanupMultipartUploadIDsWithContext(cleanupCtx, key, uploadIDs)
+}
+
+func (a *QCloudSDK) cleanupMultipartUploadIDsWithContext(ctx context.Context, key string, uploadIDs []string) {
+	for _, uploadID := range uploadIDs {
+		if err := ctx.Err(); err != nil {
+			logutil.Warn("stopped cos multipart-init cleanup",
+				zap.String("key", key),
+				zap.Error(err))
+			return
+		}
+		if err := a.abortMultipartUpload(ctx, key, uploadID); err != nil {
+			logutil.Warn("failed to clean up cos multipart upload after ambiguous init",
+				zap.String("key", key),
+				zap.Error(err))
+			if ctx.Err() != nil {
+				return
+			}
+			continue
+		}
+		metric.FSMultipartInitCleanupCounter.Inc()
+	}
+}
+
+func (a *QCloudSDK) cleanupNewMultipartUploads(
+	parentCtx context.Context,
+	key string,
+	baseline map[string]struct{},
+) {
+	cleanupCtx, cleanupCancel := context.WithTimeoutCause(
+		context.WithoutCancel(parentCtx),
+		qcloudMultipartAbortTimeout,
+		context.DeadlineExceeded,
+	)
+	defer cleanupCancel()
+	current, err := a.listMultipartUploadIDs(cleanupCtx, key)
+	if err != nil {
+		logutil.Warn("failed to reconcile ambiguous cos multipart upload",
+			zap.String("key", key),
+			zap.Error(err))
+		return
+	}
+	a.cleanupMultipartUploadIDsWithContext(cleanupCtx, key, newMultipartUploadIDs(current, baseline))
+}
+
+func waitQCloudMultipartInitRetry(ctx context.Context, attempt int) error {
+	delay := initialRetryInterval
+	for i := 0; i < attempt && delay < maxRetryInterval; i++ {
+		delay = time.Duration(float64(delay) * retryIntervalFactor)
+	}
+	if delay > maxRetryInterval {
+		delay = maxRetryInterval
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (a *QCloudSDK) initiateMultipartUpload(
+	ctx context.Context,
+	key string,
+	opt *cos.InitiateMultipartUploadOptions,
+) (*cos.InitiateMultipartUploadResult, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, qcloudMultipartInitTimeout, context.DeadlineExceeded)
+	defer cancel()
+
+	unlock, err := a.multipartInitGate(key).lock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	baseline, err := a.listMultipartUploadIDs(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	var firstErr error
+	for attempt := 0; attempt < qcloudMultipartInitMaxAttempts; attempt++ {
+		metric.FSMultipartInitAttemptCounter.Inc()
+		output, _, createErr := a.client.Object.InitiateMultipartUpload(ctx, key, opt)
+		if createErr == nil && (output == nil || output.UploadID == "") {
+			createErr = moerr.NewInternalErrorNoCtxf("cos initiate multipart upload returned an empty upload id for key %q", key)
+		}
+		if createErr != nil && firstErr == nil {
+			firstErr = createErr
+		}
+		if output != nil && output.UploadID != "" {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				a.cleanupMultipartUploadIDs(ctx, key, []string{output.UploadID})
+				if firstErr != nil {
+					return nil, firstErr
+				}
+				return nil, ctxErr
+			}
+			if createErr != nil {
+				metric.FSMultipartInitAmbiguousCounter.Inc()
+			}
+			if firstErr != nil {
+				metric.FSMultipartInitRecoveredCounter.Inc()
+			}
+			return output, nil
+		}
+
+		metric.FSMultipartInitAmbiguousCounter.Inc()
+		if ctx.Err() != nil {
+			a.cleanupNewMultipartUploads(ctx, key, baseline)
+			return nil, firstErr
+		}
+
+		current, reconcileErr := a.listMultipartUploadIDs(ctx, key)
+		if reconcileErr != nil {
+			a.cleanupNewMultipartUploads(ctx, key, baseline)
+			return nil, firstErr
+		}
+		newIDs := newMultipartUploadIDs(current, baseline)
+		switch len(newIDs) {
+		case 0:
+			// A retry is safe only after the strongly consistent multipart listing
+			// proves that this attempt did not create server-side state.
+		case 1:
+			if ctx.Err() != nil {
+				a.cleanupMultipartUploadIDs(ctx, key, newIDs)
+				return nil, firstErr
+			}
+			metric.FSMultipartInitRecoveredCounter.Inc()
+			return &cos.InitiateMultipartUploadResult{
+				Key:      key,
+				UploadID: newIDs[0],
+			}, nil
+		default:
+			// More than one new upload cannot be attributed safely. Same-key
+			// concurrent creates violate FileService's create-only ownership, so
+			// fail all contenders and reclaim their newly created state.
+			a.cleanupMultipartUploadIDs(ctx, key, newIDs)
+			return nil, firstErr
+		}
+
+		if !IsRetryableError(createErr) || attempt+1 >= qcloudMultipartInitMaxAttempts {
+			return nil, firstErr
+		}
+		if err := waitQCloudMultipartInitRetry(ctx, attempt); err != nil {
+			a.cleanupNewMultipartUploads(ctx, key, baseline)
+			return nil, firstErr
+		}
+	}
+	return nil, firstErr
+}
+
 func (a *QCloudSDK) WriteMultipartParallel(
 	ctx context.Context,
 	key string,
@@ -430,10 +691,7 @@ func (a *QCloudSDK) WriteMultipartParallel(
 			Expires: expiresHeader,
 		},
 	}
-	// InitiateMultipartUpload creates server-side state and has no idempotency
-	// key. Any error without a usable UploadID is commit-ambiguous, so retrying
-	// could create an unreachable multipart upload that this caller cannot abort.
-	output, _, createErr := a.client.Object.InitiateMultipartUpload(ctx, key, initOpt)
+	output, createErr := a.initiateMultipartUpload(ctx, key, initOpt)
 	if createErr != nil {
 		releasePartBuffer(firstPart)
 		return createErr

--- a/pkg/fileservice/qcloud_sdk.go
+++ b/pkg/fileservice/qcloud_sdk.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"iter"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"os"
 	gotrace "runtime/trace"
@@ -48,41 +49,12 @@ type QCloudSDK struct {
 	copyCredentialDomain objectStorageCopyCredentialDomain
 	perfCounterSets      []*perfcounter.CounterSet
 	listMaxKeys          int
-	multipartInitGates   [64]qcloudMultipartInitGate
-}
-
-type qcloudMultipartInitGate struct {
-	once  sync.Once
-	token chan struct{}
-}
-
-func (g *qcloudMultipartInitGate) lock(ctx context.Context) (func(), error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	g.once.Do(func() {
-		g.token = make(chan struct{}, 1)
-		g.token <- struct{}{}
-	})
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-g.token:
-		if err := ctx.Err(); err != nil {
-			g.token <- struct{}{}
-			return nil, err
-		}
-		return func() { g.token <- struct{}{} }, nil
-	}
 }
 
 const (
-	qcloudMultipartAbortTimeout       = 30 * time.Second
-	qcloudMultipartInitTimeout        = 30 * time.Second
-	qcloudMultipartInitMaxAttempts    = 3
-	qcloudMultipartListMaxAttempts    = 3
-	qcloudMultipartListMaxPages       = 16
-	qcloudMultipartListMaxUploadsPage = 1000
+	qcloudMultipartAbortTimeout    = 30 * time.Second
+	qcloudMultipartInitTimeout     = 30 * time.Second
+	qcloudMultipartInitMaxAttempts = 3
 )
 
 func NewQCloudSDK(
@@ -375,124 +347,6 @@ func (a *QCloudSDK) SupportsParallelMultipart() bool {
 	return true
 }
 
-func (a *QCloudSDK) multipartInitGate(key string) *qcloudMultipartInitGate {
-	// FNV-1a keeps the lock table fixed-size while distributing object keys.
-	var hash uint32 = 2166136261
-	for i := 0; i < len(key); i++ {
-		hash ^= uint32(key[i])
-		hash *= 16777619
-	}
-	return &a.multipartInitGates[int(hash%uint32(len(a.multipartInitGates)))]
-}
-
-func (a *QCloudSDK) listMultipartUploadIDs(ctx context.Context, key string) (map[string]struct{}, error) {
-	ids := make(map[string]struct{})
-	var keyMarker, uploadIDMarker string
-	for page := 0; page < qcloudMultipartListMaxPages; page++ {
-		opts := &cos.ListMultipartUploadsOptions{
-			Prefix:         key,
-			MaxUploads:     qcloudMultipartListMaxUploadsPage,
-			KeyMarker:      keyMarker,
-			UploadIDMarker: uploadIDMarker,
-		}
-		result, err := DoWithRetryContext(ctx, "cos list multipart uploads", func() (*cos.ListMultipartUploadsResult, error) {
-			perfcounter.Update(ctx, func(counter *perfcounter.CounterSet) {
-				counter.FileService.S3.List.Add(1)
-			}, a.perfCounterSets...)
-			res, _, listErr := a.client.Bucket.ListMultipartUploads(ctx, opts)
-			return res, listErr
-		}, qcloudMultipartListMaxAttempts, IsRetryableError)
-		if err != nil {
-			return nil, err
-		}
-		if result == nil {
-			return nil, moerr.NewInternalErrorNoCtxf("cos multipart upload listing returned no result for key %q", key)
-		}
-		for _, upload := range result.Uploads {
-			if upload.Key == key && upload.UploadID != "" {
-				ids[upload.UploadID] = struct{}{}
-			}
-		}
-		if !result.IsTruncated {
-			return ids, nil
-		}
-		nextKeyMarker := result.NextKeyMarker
-		nextUploadIDMarker := result.NextUploadIDMarker
-		if nextKeyMarker == keyMarker && nextUploadIDMarker == uploadIDMarker {
-			return nil, moerr.NewInternalErrorNoCtxf("cos multipart upload listing did not advance for key %q", key)
-		}
-		keyMarker, uploadIDMarker = nextKeyMarker, nextUploadIDMarker
-	}
-	return nil, moerr.NewInternalErrorNoCtxf(
-		"cos multipart upload listing exceeded %d pages for key %q",
-		qcloudMultipartListMaxPages,
-		key,
-	)
-}
-
-func newMultipartUploadIDs(current, baseline map[string]struct{}) []string {
-	ids := make([]string, 0, len(current))
-	for id := range current {
-		if _, existed := baseline[id]; !existed {
-			ids = append(ids, id)
-		}
-	}
-	slices.Sort(ids)
-	return ids
-}
-
-func (a *QCloudSDK) cleanupMultipartUploadIDs(parentCtx context.Context, key string, uploadIDs []string) {
-	cleanupCtx, cleanupCancel := context.WithTimeoutCause(
-		context.WithoutCancel(parentCtx),
-		qcloudMultipartAbortTimeout,
-		context.DeadlineExceeded,
-	)
-	defer cleanupCancel()
-	a.cleanupMultipartUploadIDsWithContext(cleanupCtx, key, uploadIDs)
-}
-
-func (a *QCloudSDK) cleanupMultipartUploadIDsWithContext(ctx context.Context, key string, uploadIDs []string) {
-	for _, uploadID := range uploadIDs {
-		if err := ctx.Err(); err != nil {
-			logutil.Warn("stopped cos multipart-init cleanup",
-				zap.String("key", key),
-				zap.Error(err))
-			return
-		}
-		if err := a.abortMultipartUpload(ctx, key, uploadID); err != nil {
-			logutil.Warn("failed to clean up cos multipart upload after ambiguous init",
-				zap.String("key", key),
-				zap.Error(err))
-			if ctx.Err() != nil {
-				return
-			}
-			continue
-		}
-		metric.FSMultipartInitCleanupCounter.Inc()
-	}
-}
-
-func (a *QCloudSDK) cleanupNewMultipartUploads(
-	parentCtx context.Context,
-	key string,
-	baseline map[string]struct{},
-) {
-	cleanupCtx, cleanupCancel := context.WithTimeoutCause(
-		context.WithoutCancel(parentCtx),
-		qcloudMultipartAbortTimeout,
-		context.DeadlineExceeded,
-	)
-	defer cleanupCancel()
-	current, err := a.listMultipartUploadIDs(cleanupCtx, key)
-	if err != nil {
-		logutil.Warn("failed to reconcile ambiguous cos multipart upload",
-			zap.String("key", key),
-			zap.Error(err))
-		return
-	}
-	a.cleanupMultipartUploadIDsWithContext(cleanupCtx, key, newMultipartUploadIDs(current, baseline))
-}
-
 func waitQCloudMultipartInitRetry(ctx context.Context, attempt int) error {
 	delay := initialRetryInterval
 	for i := 0; i < attempt && delay < maxRetryInterval; i++ {
@@ -519,21 +373,17 @@ func (a *QCloudSDK) initiateMultipartUpload(
 	ctx, cancel := context.WithTimeoutCause(ctx, qcloudMultipartInitTimeout, context.DeadlineExceeded)
 	defer cancel()
 
-	unlock, err := a.multipartInitGate(key).lock(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
-
-	baseline, err := a.listMultipartUploadIDs(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-
 	var firstErr error
 	for attempt := 0; attempt < qcloudMultipartInitMaxAttempts; attempt++ {
+		var wroteRequest atomic.Bool
+		attemptCtx := httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+			WroteRequest: func(httptrace.WroteRequestInfo) {
+				wroteRequest.Store(true)
+			},
+		})
+
 		metric.FSMultipartInitAttemptCounter.Inc()
-		output, _, createErr := a.client.Object.InitiateMultipartUpload(ctx, key, opt)
+		output, _, createErr := a.client.Object.InitiateMultipartUpload(attemptCtx, key, opt)
 		if createErr == nil && (output == nil || output.UploadID == "") {
 			createErr = moerr.NewInternalErrorNoCtxf("cos initiate multipart upload returned an empty upload id for key %q", key)
 		}
@@ -541,15 +391,25 @@ func (a *QCloudSDK) initiateMultipartUpload(
 			firstErr = createErr
 		}
 		if output != nil && output.UploadID != "" {
+			if createErr != nil {
+				metric.FSMultipartInitAmbiguousCounter.Inc()
+			}
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				a.cleanupMultipartUploadIDs(ctx, key, []string{output.UploadID})
+				cleanupCtx, cleanupCancel := context.WithTimeoutCause(
+					context.WithoutCancel(ctx),
+					qcloudMultipartAbortTimeout,
+					context.DeadlineExceeded,
+				)
+				defer cleanupCancel()
+				if err := a.abortMultipartUpload(cleanupCtx, key, output.UploadID); err != nil {
+					logutil.Warn("failed to clean up canceled cos multipart init", zap.Error(err))
+				} else {
+					metric.FSMultipartInitCleanupCounter.Inc()
+				}
 				if firstErr != nil {
 					return nil, firstErr
 				}
 				return nil, ctxErr
-			}
-			if createErr != nil {
-				metric.FSMultipartInitAmbiguousCounter.Inc()
 			}
 			if firstErr != nil {
 				metric.FSMultipartInitRecoveredCounter.Inc()
@@ -558,44 +418,14 @@ func (a *QCloudSDK) initiateMultipartUpload(
 		}
 
 		metric.FSMultipartInitAmbiguousCounter.Inc()
-		if ctx.Err() != nil {
-			a.cleanupNewMultipartUploads(ctx, key, baseline)
+		if ctx.Err() != nil || wroteRequest.Load() || !IsRetryableError(createErr) ||
+			attempt+1 >= qcloudMultipartInitMaxAttempts {
 			return nil, firstErr
 		}
-
-		current, reconcileErr := a.listMultipartUploadIDs(ctx, key)
-		if reconcileErr != nil {
-			a.cleanupNewMultipartUploads(ctx, key, baseline)
-			return nil, firstErr
-		}
-		newIDs := newMultipartUploadIDs(current, baseline)
-		switch len(newIDs) {
-		case 0:
-			// A retry is safe only after the strongly consistent multipart listing
-			// proves that this attempt did not create server-side state.
-		case 1:
-			if ctx.Err() != nil {
-				a.cleanupMultipartUploadIDs(ctx, key, newIDs)
-				return nil, firstErr
-			}
-			metric.FSMultipartInitRecoveredCounter.Inc()
-			return &cos.InitiateMultipartUploadResult{
-				Key:      key,
-				UploadID: newIDs[0],
-			}, nil
-		default:
-			// More than one new upload cannot be attributed safely. Same-key
-			// concurrent creates violate FileService's create-only ownership, so
-			// fail all contenders and reclaim their newly created state.
-			a.cleanupMultipartUploadIDs(ctx, key, newIDs)
-			return nil, firstErr
-		}
-
-		if !IsRetryableError(createErr) || attempt+1 >= qcloudMultipartInitMaxAttempts {
-			return nil, firstErr
-		}
+		// WroteRequest is emitted by net/http once writing starts, including
+		// write failures. Its absence proves this attempt never crossed the
+		// transport write boundary, so retrying cannot duplicate an upload.
 		if err := waitQCloudMultipartInitRetry(ctx, attempt); err != nil {
-			a.cleanupNewMultipartUploads(ctx, key, baseline)
 			return nil, firstErr
 		}
 	}

--- a/pkg/util/metric/v2/fileservice.go
+++ b/pkg/util/metric/v2/fileservice.go
@@ -142,6 +142,20 @@ var (
 )
 
 var (
+	fsMultipartInitCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "fs",
+			Name:      "multipart_init_total",
+			Help:      "Total number of multipart initialization lifecycle events.",
+		}, []string{"event"})
+	FSMultipartInitAttemptCounter   = fsMultipartInitCounter.WithLabelValues("attempt")
+	FSMultipartInitAmbiguousCounter = fsMultipartInitCounter.WithLabelValues("ambiguous")
+	FSMultipartInitRecoveredCounter = fsMultipartInitCounter.WithLabelValues("recovered")
+	FSMultipartInitCleanupCounter   = fsMultipartInitCounter.WithLabelValues("cleanup")
+)
+
+var (
 	FSObjectStorageOperations = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "mo",

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -117,6 +117,7 @@ func initFileServiceMetrics() {
 	registry.MustRegister(ioMergerCounter)
 	registry.MustRegister(ioMergerDuration)
 	registry.MustRegister(fsReadWriteDuration)
+	registry.MustRegister(fsMultipartInitCounter)
 	registry.MustRegister(FSObjectStorageOperations)
 
 	registry.MustRegister(FSHTTPTraceCounter)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28028. This PR intentionally does not close the issue because safe client-side reclamation of a commit-ambiguous upload still requires a cross-CN ownership protocol.

## What this PR does / why we need it:

- Uses `net/http/httptrace.WroteRequest` to retry Tencent COS multipart initialization only when the request did not cross the transport write boundary, or when COS returned a definitive retryable error response.
- Returns the current terminal result: caller cancellation/deadline wins, and a later definitive response such as 403 is not hidden by an earlier transient error.
- Counts `ambiguous` only when a request was written but no COS response or usable UploadID was returned.
- Never infers UploadID ownership from bucket listings, so it cannot adopt, complete, or abort another SDK/CN's multipart upload.
- Keeps the normal multipart path compatible with credentials that do not grant `cos:ListMultipartUploads`; no bucket LIST is added.
- Keeps retries and backoff bounded without changing upload-part concurrency or HTTP connection reuse.

Operational contract and remaining scope:

- If a request was written but its response was lost, MatrixOne cannot safely identify the resulting UploadID across CNs. It fails conservatively and emits an `ambiguous` metric plus a warning.
- COS buckets must configure a lifecycle rule that aborts incomplete multipart uploads to reclaim such ownerless state.
- A future complete fix for response-loss reclamation requires a server-visible, cross-CN ownership mechanism; #28028 remains open for that work.

Validation:

- Focused COS/QCloud tests pass.
- Cross-instance ownership, pre-request recovery, committed-response loss, IAM compatibility, cancellation precedence, terminal 403 precedence, and owned cleanup tests pass with focused race validation.
- `pkg/util/metric/v2` tests pass.
- Multipart-init helper changed-logic coverage remains above 75%.
- `go vet ./pkg/fileservice ./pkg/util/metric/v2` passes with the repository CGo environment.
