### PR TITLE
fix(plan): preserve TPCH Q19 hash key for widening CHAR casts

### DIFF
--- a/pkg/sql/plan/expr_hash_test.go
+++ b/pkg/sql/plan/expr_hash_test.go
@@ -671,6 +671,73 @@ func TestApplyDistributivityFindsJoinKeyBesideTernaryPredicate(t *testing.T) {
 	require.Equal(t, "or", conjuncts[1].GetF().Func.ObjName)
 }
 
+func TestApplyDistributivityFactorsCommonWideningCharPredicate(t *testing.T) {
+	ctx := context.Background()
+	intType := planpb.Type{Id: int32(types.T_int64)}
+	intCol := func(rel, pos int32) *planpb.Expr {
+		return &planpb.Expr{Typ: intType, Expr: &planpb.Expr_Col{
+			Col: &planpb.ColRef{RelPos: rel, ColPos: pos},
+		}}
+	}
+	bind := func(name string, args ...*planpb.Expr) *planpb.Expr {
+		expr, err := BindFuncExprImplByPlanExpr(ctx, name, args)
+		require.NoError(t, err)
+		return expr
+	}
+
+	joinKey := bind("=", intCol(0, 0), intCol(1, 0))
+	shipInstructType := planpb.Type{
+		Id:      int32(types.T_char),
+		Width:   25,
+		Charset: uint32(types.CharsetUTF8),
+	}
+	shipInstructCol := &planpb.Expr{Typ: shipInstructType, Expr: &planpb.Expr_Col{
+		Col: &planpb.ColRef{RelPos: 1, ColPos: 1},
+	}}
+	wideningCharLiteral := func(value string, target planpb.Type) *planpb.Expr {
+		literal, err := makePlan2CastExpr(
+			ctx, makePlan2StringConstExprWithType(value), target,
+		)
+		require.NoError(t, err)
+		return literal
+	}
+	commonShipInstruct := bind("=", shipInstructCol,
+		wideningCharLiteral("DELIVER IN PERSON", shipInstructType))
+	shipModeType := planpb.Type{
+		Id: int32(types.T_char), Width: 10, Charset: uint32(types.CharsetUTF8),
+	}
+	shipModeCol := &planpb.Expr{Typ: shipModeType, Expr: &planpb.Expr_Col{
+		Col: &planpb.ColRef{RelPos: 1, ColPos: 2},
+	}}
+	shipModes := &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_tuple)},
+		Expr: &planpb.Expr_List{List: &planpb.ExprList{List: []*planpb.Expr{
+			wideningCharLiteral("AIR", shipModeType),
+			wideningCharLiteral("AIR REG", shipModeType),
+		}}},
+	}
+	commonShipMode := bind("in", shipModeCol, shipModes)
+	leftOnly := bind("=", intCol(0, 2), intCol(1, 2))
+	rightOnly := bind("=", intCol(0, 3), intCol(1, 3))
+	branch := func(unique *planpb.Expr) *planpb.Expr {
+		return bind("and",
+			bind("and",
+				bind("and", DeepCopyExpr(joinKey), DeepCopyExpr(commonShipInstruct)),
+				DeepCopyExpr(commonShipMode)),
+			unique)
+	}
+	orExpr := bind("or", branch(leftOnly), branch(rightOnly))
+
+	result := applyDistributivity(ctx, orExpr)
+	conjuncts := splitPlanConjunction(result)
+	require.Len(t, conjuncts, 4)
+	require.True(t, exprStructuralEqual(joinKey, conjuncts[0]),
+		"the common equality must become a visible join key")
+	require.True(t, exprStructuralEqual(commonShipInstruct, conjuncts[1]))
+	require.True(t, exprStructuralEqual(commonShipMode, conjuncts[2]))
+	require.Equal(t, "or", conjuncts[3].GetF().Func.ObjName)
+}
+
 func TestApplyDistributivityKeepsSingleTableDNFForKeyFolding(t *testing.T) {
 	ctx := context.Background()
 	intType := planpb.Type{Id: int32(types.T_int64)}

--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -1834,6 +1834,15 @@ func singleRowCastIsTotal(source, target plan.Type) bool {
 	if isSameColumnType(source, target) {
 		return !sourceID.IsDecimal() || validDecimalPlanType(source)
 	}
+	// CHAR comparison binding casts text operands to the fixed CHAR domain.
+	// With the same charset and a target at least as wide as the declared
+	// source, that cast cannot reject or truncate any source value.
+	if targetID == types.T_char &&
+		(sourceID == types.T_char || sourceID == types.T_varchar) &&
+		source.Charset == target.Charset && source.Width > 0 &&
+		target.Width >= source.Width {
+		return true
+	}
 	if sourceID.IsDecimal() {
 		if !validDecimalPlanType(source) {
 			return false

--- a/pkg/sql/plan/pk_group_elimination_test.go
+++ b/pkg/sql/plan/pk_group_elimination_test.go
@@ -410,6 +410,9 @@ func TestSingleRowCastIsTotal(t *testing.T) {
 	typ := func(oid types.T) planpb.Type {
 		return planpb.Type{Id: int32(oid)}
 	}
+	stringType := func(oid types.T, width int32, charset uint32) planpb.Type {
+		return planpb.Type{Id: int32(oid), Width: width, Charset: charset}
+	}
 	decimal := func(oid types.T, width, scale int32) planpb.Type {
 		return planpb.Type{Id: int32(oid), Width: width, Scale: scale}
 	}
@@ -428,6 +431,12 @@ func TestSingleRowCastIsTotal(t *testing.T) {
 		{"malformed decimal source", decimal(types.T_decimal64, 19, 2), typ(types.T_float64), false},
 		{"malformed decimal target", decimal(types.T_decimal64, 7, 2), decimal(types.T_decimal64, 19, 2), false},
 		{"same malformed decimal", decimal(types.T_decimal64, 19, 2), decimal(types.T_decimal64, 19, 2), false},
+		{"varchar to wider char", stringType(types.T_varchar, 17, uint32(types.CharsetUTF8)), stringType(types.T_char, 25, uint32(types.CharsetUTF8)), true},
+		{"char widening", stringType(types.T_char, 10, uint32(types.CharsetUTF8)), stringType(types.T_char, 25, uint32(types.CharsetUTF8)), true},
+		{"varchar to narrower char", stringType(types.T_varchar, 25, uint32(types.CharsetUTF8)), stringType(types.T_char, 10, uint32(types.CharsetUTF8)), false},
+		{"unbounded varchar to char", stringType(types.T_varchar, 0, uint32(types.CharsetUTF8)), stringType(types.T_char, 25, uint32(types.CharsetUTF8)), false},
+		{"varchar to char charset change", stringType(types.T_varchar, 17, uint32(types.CharsetUTF8MB4Bin)), stringType(types.T_char, 25, uint32(types.CharsetUTF8)), false},
+		{"text to char", stringType(types.T_text, 17, uint32(types.CharsetUTF8)), stringType(types.T_char, 25, uint32(types.CharsetUTF8)), false},
 		{"text to integer", typ(types.T_varchar), typ(types.T_int64), false},
 		{"float widening", typ(types.T_float32), typ(types.T_float64), true},
 		{"float narrowing", typ(types.T_float64), typ(types.T_float32), false},

--- a/pkg/tests/issues/mark_exists_hash_test.go
+++ b/pkg/tests/issues/mark_exists_hash_test.go
@@ -51,10 +51,16 @@ func TestNullableExistsMarkKeepsHashEqualityAndBooleanResults(t *testing.T) {
 		execSQLRequire(t, ctx, db, "create table build_a (id int)")
 		execSQLRequire(t, ctx, db, "create table build_b (id int)")
 		execSQLRequire(t, ctx, db, "create table invalid_hll (payload varchar(20))")
+		execSQLRequire(t, ctx, db, "create table char_dnf_probe (id int primary key, shipmode char(10), shipinstruct char(25))")
+		execSQLRequire(t, ctx, db, "create table char_dnf_build (id int primary key, kind int)")
 		execSQLRequire(t, ctx, db, "insert into probe values (null), (1), (2), (3)")
 		execSQLRequire(t, ctx, db, "insert into build_a values (null), (2)")
 		execSQLRequire(t, ctx, db, "insert into build_b values (null), (3)")
 		execSQLRequire(t, ctx, db, "insert into invalid_hll values ('bad')")
+		execSQLRequire(t, ctx, db, `insert into char_dnf_probe values
+			(1, 'AIR', 'DELIVER IN PERSON'), (2, 'AIR REG', 'DELIVER IN PERSON'),
+			(3, 'SHIP', 'DELIVER IN PERSON'), (4, 'AIR', 'OTHER')`)
+		execSQLRequire(t, ctx, db, "insert into char_dnf_build values (1, 1), (2, 2), (3, 3), (4, 1)")
 
 		const query = `select p.id,
 			exists(select 1 from build_a a where a.id = p.id) as in_a,
@@ -133,6 +139,19 @@ func TestNullableExistsMarkKeepsHashEqualityAndBooleanResults(t *testing.T) {
 			order by p.id`
 		require.Equal(t, readIDs(`select distinct p.id from probe p join build_a a
 			on a.id = p.id and (p.id = 2 or p.id = 3) order by p.id`), readIDs(dnfQuery))
+
+		const charDNFQuery = `select distinct p.id from char_dnf_probe p join char_dnf_build b on
+			(b.id = p.id and p.shipmode in ('AIR', 'AIR REG') and p.shipinstruct = 'DELIVER IN PERSON' and b.kind = 1) or
+			(b.id = p.id and p.shipmode in ('AIR', 'AIR REG') and p.shipinstruct = 'DELIVER IN PERSON' and b.kind = 2) or
+			(b.id = p.id and p.shipmode in ('AIR', 'AIR REG') and p.shipinstruct = 'DELIVER IN PERSON' and b.kind = 3)
+			order by p.id`
+		charDNFPlan := explainSQL(t, ctx, db, "explain "+charDNFQuery)
+		require.Contains(t, charDNFPlan, "Join Type: INNER   hashOnPK")
+		require.Contains(t, charDNFPlan, "Join Cond: (b.id = p.id)")
+		require.Equal(t, readIDs(`select p.id from char_dnf_probe p join char_dnf_build b
+			on b.id = p.id and p.shipmode in ('AIR', 'AIR REG')
+			and p.shipinstruct = 'DELIVER IN PERSON' and b.kind in (1, 2, 3) order by p.id`),
+			readIDs(charDNFQuery))
 
 		// Keep fallible predicates on the legacy plan shapes. These inputs make
 		// the errors observable in the historical plans; the new hash-key and


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28030

## What this PR does / why we need it:

#27915 correctly keeps DNF factoring behind a totality check, but the check did not recognize the comparison casts from bounded VARCHAR/CHAR operands to a wider fixed CHAR domain. TPCH Q19 therefore kept its repeated full DNF as the join condition and lost the common `l_partkey = p_partkey` hash key.

This PR adds one narrow, type-domain proof: a CHAR/VARCHAR-to-CHAR cast is total only when both declared widths are bounded, the charset is unchanged, and the target is not narrower. The existing all-or-nothing safety gate remains unchanged; narrowing, unbounded, charset-changing, TEXT, and other fallible casts remain rejected.

Benefits and validation:

- TPCH SF=1 Q19 restores `INNER hashOnPK` with `l_partkey = p_partkey`; its plan is byte-for-byte equal to the compatibility-control plan.
- The issue reproduction took 20.06s on the regressed cold path. On this head, the first real Q19 execution after process startup took 203ms and returned the same `4028540.3287` result as the compatibility control (~99x restoration versus the reported regression).
- Across all 22 TPCH plans, only Q19 changes.
- Across all 99 TPC-DS SF=1000 plans, the stable plans are byte-for-byte unchanged.
- Added focused totality boundaries, a typed Q19-shaped DNF rewrite test, and a public SQL plan/result-equivalence regression.

Validation commands:

```text
.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=10m ./pkg/sql/plan
.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=5m -run '^TestNullableExistsMarkKeepsHashEqualityAndBooleanResults$' ./pkg/tests/issues
```
