### PR TITLE
fix(clone): hide catalog errors for missing named snapshots

### DIFF
--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -651,6 +651,8 @@ func resolveSnapshot(
 	return snapshot, nil
 }
 
+var resolveSnapshotForClone = resolveSnapshot
+
 func newMoTimestampHint(snapshotTS int64) *tree.AtTimeStamp {
 	origin := strconv.FormatInt(snapshotTS, 10)
 	return &tree.AtTimeStamp{
@@ -721,7 +723,7 @@ func getOpAndToAccountId(
 	atTsExpr *tree.AtTimeStamp,
 ) (opAccountId, toAccountId uint32, snapshot *plan2.Snapshot, err error) {
 
-	if snapshot, err = resolveSnapshot(ses, atTsExpr); err != nil {
+	if snapshot, err = resolveSnapshotForClone(ses, atTsExpr); err != nil {
 		if atTsExpr != nil && plan.IsSnapshotNotFound(err) {
 			return 0, 0, nil, plan.NewSnapshotNotFoundError(
 				reqCtx,

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -722,6 +722,12 @@ func getOpAndToAccountId(
 ) (opAccountId, toAccountId uint32, snapshot *plan2.Snapshot, err error) {
 
 	if snapshot, err = resolveSnapshot(ses, atTsExpr); err != nil {
+		if atTsExpr != nil && plan.IsSnapshotNotFound(err) {
+			return 0, 0, nil, plan.NewSnapshotNotFoundError(
+				reqCtx,
+				atTsExpr.SnapshotName,
+			)
+		}
 		return 0, 0, nil, err
 	}
 

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/util/sysview"
 )
 
@@ -106,6 +107,81 @@ func TestGeneratedCloneRestoreSnapshotTS(t *testing.T) {
 			require.Equal(t, test.want, generatedCloneRestoreSnapshotTS(ses, 42))
 		})
 	}
+}
+
+type cloneSnapshotResolutionCompilerContext struct {
+	*plan2.MockCompilerContext
+	ctx        context.Context
+	resolveErr error
+}
+
+func (c *cloneSnapshotResolutionCompilerContext) GetContext() context.Context {
+	return c.ctx
+}
+
+func (c *cloneSnapshotResolutionCompilerContext) GetSnapshot() *plan2.Snapshot {
+	return nil
+}
+
+func (c *cloneSnapshotResolutionCompilerContext) ResolveSnapshotWithSnapshotName(string) (*plan2.Snapshot, error) {
+	return nil, c.resolveErr
+}
+
+func TestGetOpAndToAccountIDNormalizesMissingNamedSnapshot(t *testing.T) {
+	const snapshotName = "missing_snapshot"
+	ctx := context.Background()
+
+	resolverContext := &cloneSnapshotResolutionCompilerContext{
+		MockCompilerContext: plan2.NewMockCompilerContext(false),
+		ctx:                 ctx,
+		resolveErr:          moerr.NewInternalErrorf(ctx, "find 0 snapshot records by name(%s), expect only 1", snapshotName),
+	}
+	atTsExpr := &tree.AtTimeStamp{
+		Type:         tree.ATTIMESTAMPSNAPSHOT,
+		SnapshotName: snapshotName,
+		Expr:         tree.NewNumVal(snapshotName, snapshotName, false, tree.P_char),
+	}
+	_, resolveErr := plan2.NewQueryBuilder(
+		plan.Query_INSERT, resolverContext, false, true,
+	).ResolveTsHint(atTsExpr)
+	require.Error(t, resolveErr)
+	require.True(t, plan2.IsSnapshotNotFound(resolveErr))
+
+	originalResolver := resolveSnapshotForClone
+	resolveSnapshotForClone = func(*Session, *tree.AtTimeStamp) (*plan2.Snapshot, error) {
+		return nil, resolveErr
+	}
+	t.Cleanup(func() {
+		resolveSnapshotForClone = originalResolver
+	})
+
+	_, _, snapshot, err := getOpAndToAccountId(ctx, nil, nil, nil, atTsExpr)
+	require.Nil(t, snapshot)
+	require.EqualError(t, err, "invalid input: snapshot 'missing_snapshot' not found")
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput))
+	require.NotContains(t, err.Error(), "internal error")
+	require.NotContains(t, err.Error(), "snapshot records")
+}
+
+func TestGetOpAndToAccountIDPropagatesOtherSnapshotErrors(t *testing.T) {
+	ctx := context.Background()
+	wantErr := moerr.NewInternalError(ctx, "snapshot catalog unavailable")
+	atTsExpr := &tree.AtTimeStamp{
+		Type:         tree.ATTIMESTAMPSNAPSHOT,
+		SnapshotName: "snapshot",
+	}
+
+	originalResolver := resolveSnapshotForClone
+	resolveSnapshotForClone = func(*Session, *tree.AtTimeStamp) (*plan2.Snapshot, error) {
+		return nil, wantErr
+	}
+	t.Cleanup(func() {
+		resolveSnapshotForClone = originalResolver
+	})
+
+	_, _, snapshot, err := getOpAndToAccountId(ctx, nil, nil, nil, atTsExpr)
+	require.Nil(t, snapshot)
+	require.ErrorIs(t, err, wantErr)
 }
 
 func TestCloneForeignKeyChecksRestoresMigrationReplayability(t *testing.T) {

--- a/pkg/sql/plan/build_table_clone.go
+++ b/pkg/sql/plan/build_table_clone.go
@@ -72,6 +72,12 @@ func buildCloneTable(
 	if stmt.SrcTable.AtTsExpr != nil {
 		bindCtx.snapshot, err = builder.ResolveTsHint(stmt.SrcTable.AtTsExpr)
 		if err != nil {
+			if IsSnapshotNotFound(err) {
+				return nil, NewSnapshotNotFoundError(
+					builder.GetContext(),
+					stmt.SrcTable.AtTsExpr.SnapshotName,
+				)
+			}
 			return nil, err
 		}
 

--- a/pkg/sql/plan/build_table_clone_test.go
+++ b/pkg/sql/plan/build_table_clone_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+)
+
+type cloneSnapshotCompilerContext struct {
+	*MockCompilerContext
+	snapshotErr error
+}
+
+func (c *cloneSnapshotCompilerContext) ResolveSnapshotWithSnapshotName(string) (*Snapshot, error) {
+	return nil, c.snapshotErr
+}
+
+func TestBuildCloneTableSnapshotResolutionErrors(t *testing.T) {
+	const snapshotName = "missing_snapshot"
+
+	tests := []struct {
+		name        string
+		snapshotErr error
+		wantErr     string
+		wantUserErr bool
+	}{
+		{
+			name: "missing named snapshot",
+			snapshotErr: moerr.NewInternalErrorf(
+				context.Background(),
+				"find 0 snapshot records by name(%s), expect only 1",
+				snapshotName,
+			),
+			wantErr:     "invalid input: snapshot 'missing_snapshot' not found",
+			wantUserErr: true,
+		},
+		{
+			name:        "other snapshot resolution error",
+			snapshotErr: moerr.NewInternalError(context.Background(), "snapshot catalog unavailable"),
+			wantErr:     "internal error: snapshot catalog unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stmt, err := parsers.ParseOne(
+				t.Context(),
+				dialect.MYSQL,
+				"create table clone_target clone tpch.nation {snapshot = 'missing_snapshot'}",
+				1,
+			)
+			require.NoError(t, err)
+			defer stmt.Free()
+
+			ctx := &cloneSnapshotCompilerContext{
+				MockCompilerContext: NewMockCompilerContext(false),
+				snapshotErr:         test.snapshotErr,
+			}
+			_, err = BuildPlan(ctx, stmt, false)
+			require.EqualError(t, err, test.wantErr)
+
+			if test.wantUserErr {
+				require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput))
+				require.NotContains(t, err.Error(), "internal error")
+				require.NotContains(t, err.Error(), "snapshot records")
+			}
+		})
+	}
+}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -71,6 +71,10 @@ func IsSnapshotNotFound(err error) bool {
 	return errors.As(err, &target)
 }
 
+func NewSnapshotNotFoundError(ctx context.Context, snapshotName string) error {
+	return moerr.NewInvalidInputf(ctx, "snapshot '%s' not found", snapshotName)
+}
+
 func NewQueryBuilder(queryType plan.Query_StatementType, ctx CompilerContext, isPrepareStatement bool, skipStats bool) *QueryBuilder {
 	//
 	// There is a class of variables that controls SQL behavior.  To add such a variable, first

--- a/test/distributed/cases/git4data/clone/clone_missing_named_snapshot.result
+++ b/test/distributed/cases/git4data/clone/clone_missing_named_snapshot.result
@@ -1,0 +1,54 @@
+drop snapshot if exists issue28049_valid_snapshot;
+drop database if exists issue28049_clone_missing_snapshot;
+create database issue28049_clone_missing_snapshot;
+create table issue28049_clone_missing_snapshot.src (
+id int primary key,
+doc json
+);
+insert into issue28049_clone_missing_snapshot.src values (1, '{"score":10}');
+create table issue28049_clone_missing_snapshot.missing_snapshot_clone
+clone issue28049_clone_missing_snapshot.src
+{snapshot = 'issue28049_missing_snapshot'};
+invalid input: snapshot 'issue28049_missing_snapshot' not found
+create table issue28049_clone_missing_snapshot.missing_snapshot_clone
+clone issue28049_clone_missing_snapshot.src
+{snapshot = 'issue28049_missing_snapshot'};
+invalid input: snapshot 'issue28049_missing_snapshot' not found
+create table issue28049_clone_missing_snapshot.missing_snapshot_clone
+clone issue28049_clone_missing_snapshot.src
+{snapshot = 'issue28049_missing_snapshot'};
+invalid input: snapshot 'issue28049_missing_snapshot' not found
+create table issue28049_clone_missing_snapshot.missing_snapshot_identifier_clone
+clone issue28049_clone_missing_snapshot.src
+{snapshot = issue28049_missing_snapshot};
+invalid input: snapshot 'issue28049_missing_snapshot' not found
+select count(*) as failed_clone_tables
+from mo_catalog.mo_tables
+where reldatabase = 'issue28049_clone_missing_snapshot'
+and relname in ('missing_snapshot_clone', 'missing_snapshot_identifier_clone');
+➤ failed_clone_tables[-5,64,0]  𝄀
+0
+select count(*) as failed_clone_columns
+from mo_catalog.mo_columns
+where att_database = 'issue28049_clone_missing_snapshot'
+and att_relname in ('missing_snapshot_clone', 'missing_snapshot_identifier_clone');
+➤ failed_clone_columns[-5,64,0]  𝄀
+0
+create snapshot issue28049_valid_snapshot
+for table issue28049_clone_missing_snapshot src;
+create table issue28049_clone_missing_snapshot.valid_snapshot_clone
+clone issue28049_clone_missing_snapshot.src
+{snapshot = 'issue28049_valid_snapshot'};
+select id, doc
+from issue28049_clone_missing_snapshot.valid_snapshot_clone
+order by id;
+➤ id[4,32,0]  ¦  doc[-1,2147483647,0]  𝄀
+1  ¦  {"score": 10}
+select count(*) as valid_clone_tables
+from mo_catalog.mo_tables
+where reldatabase = 'issue28049_clone_missing_snapshot'
+and relname = 'valid_snapshot_clone';
+➤ valid_clone_tables[-5,64,0]  𝄀
+1
+drop snapshot issue28049_valid_snapshot;
+drop database issue28049_clone_missing_snapshot;

--- a/test/distributed/cases/git4data/clone/clone_missing_named_snapshot.sql
+++ b/test/distributed/cases/git4data/clone/clone_missing_named_snapshot.sql
@@ -1,0 +1,53 @@
+-- issue#28049: a missing named snapshot in CREATE TABLE ... CLONE must be
+-- reported as a user input error without exposing catalog internals.
+drop snapshot if exists issue28049_valid_snapshot;
+drop database if exists issue28049_clone_missing_snapshot;
+create database issue28049_clone_missing_snapshot;
+create table issue28049_clone_missing_snapshot.src (
+  id int primary key,
+  doc json
+);
+insert into issue28049_clone_missing_snapshot.src values (1, '{"score":10}');
+
+-- Repeat the exact failing operation to prove that failed planning/execution
+-- leaves no target metadata behind.
+create table issue28049_clone_missing_snapshot.missing_snapshot_clone
+  clone issue28049_clone_missing_snapshot.src
+  {snapshot = 'issue28049_missing_snapshot'};
+create table issue28049_clone_missing_snapshot.missing_snapshot_clone
+  clone issue28049_clone_missing_snapshot.src
+  {snapshot = 'issue28049_missing_snapshot'};
+create table issue28049_clone_missing_snapshot.missing_snapshot_clone
+  clone issue28049_clone_missing_snapshot.src
+  {snapshot = 'issue28049_missing_snapshot'};
+
+-- The identifier form of the named snapshot option must use the same boundary.
+create table issue28049_clone_missing_snapshot.missing_snapshot_identifier_clone
+  clone issue28049_clone_missing_snapshot.src
+  {snapshot = issue28049_missing_snapshot};
+
+select count(*) as failed_clone_tables
+from mo_catalog.mo_tables
+where reldatabase = 'issue28049_clone_missing_snapshot'
+  and relname in ('missing_snapshot_clone', 'missing_snapshot_identifier_clone');
+select count(*) as failed_clone_columns
+from mo_catalog.mo_columns
+where att_database = 'issue28049_clone_missing_snapshot'
+  and att_relname in ('missing_snapshot_clone', 'missing_snapshot_identifier_clone');
+
+-- A valid named snapshot remains a successful JSON table clone.
+create snapshot issue28049_valid_snapshot
+  for table issue28049_clone_missing_snapshot src;
+create table issue28049_clone_missing_snapshot.valid_snapshot_clone
+  clone issue28049_clone_missing_snapshot.src
+  {snapshot = 'issue28049_valid_snapshot'};
+select id, doc
+from issue28049_clone_missing_snapshot.valid_snapshot_clone
+order by id;
+select count(*) as valid_clone_tables
+from mo_catalog.mo_tables
+where reldatabase = 'issue28049_clone_missing_snapshot'
+  and relname = 'valid_snapshot_clone';
+
+drop snapshot issue28049_valid_snapshot;
+drop database issue28049_clone_missing_snapshot;

--- a/test/distributed/cases/git4data/clone/clone_sys_db_table_to_new_db_table.result
+++ b/test/distributed/cases/git4data/clone/clone_sys_db_table_to_new_db_table.result
@@ -290,7 +290,7 @@ internal error: table test100.table01 does not exist
 drop database if exists db08;
 create database db08;
 create table db08.table01 clone test100.table01 {snapshot = 'sp08'};
-internal error: find 0 snapshot records by name(sp08), expect only 1
+invalid input: snapshot 'sp08' not found
 drop database test101;
 drop database db08;
 drop snapshot sp08;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28049

## What this PR does / why we need it:

### Root cause

`getSnapshotByName` reports a zero-record named-snapshot lookup with an internal catalog error containing the implementation detail `find 0 snapshot records ... expect only 1`. `ResolveTsHint` already identifies this expected missing-snapshot condition with `snapshotNotFoundError`, but that marker preserves the catalog error as its displayed message. The normal `CREATE TABLE ... CLONE ... {snapshot = ...}` path resolves the snapshot in frontend `getOpAndToAccountId` before entering `ExecRestore`, so the marker's internal cause was returned directly to the client. The direct planner clone-build boundary also propagated the marker unchanged.

### Changes

- Add the shared `plan.NewSnapshotNotFoundError` constructor, producing `invalid input: snapshot '<name>' not found`.
- Translate only `plan.IsSnapshotNotFound` errors at the frontend clone pre-resolution boundary and the planner `buildCloneTable` boundary.
- Preserve all unrelated snapshot-resolution errors unchanged; no broad fallback or catalog-error rewriting is introduced.
- Add frontend unit tests covering the missing-snapshot translation and preservation of unrelated errors at the frontend boundary.
- Add a planner unit test covering both the missing-snapshot translation and preservation of an unrelated internal error.
- Add a JSON clone BVT covering the exact three repeated missing-snapshot attempts, quoted and bare snapshot syntax, failure atomicity for both tables and columns, and a valid named-snapshot clone.
- Update the existing `clone_sys_db_table_to_new_db_table` BVT expectation for the same user-facing missing-snapshot error.

### Issue-to-test proof

- `pkg/frontend/clone_test.go` constructs a real `ResolveTsHint` missing-snapshot marker, invokes the frontend clone boundary, and verifies the exact user-facing invalid-input error without `internal error` or catalog record-count text. The same test file verifies that an unrelated snapshot error is propagated unchanged.
- `pkg/sql/plan/build_table_clone_test.go` parses a real `CREATE TABLE ... CLONE ... {snapshot = 'missing_snapshot'}` statement and verifies the planner boundary normalization. The same table-driven test verifies unrelated internal errors still propagate unchanged.
- `test/distributed/cases/git4data/clone/clone_missing_named_snapshot.sql` repeats the issue reproduction three times, checks both failed table and column counts remain zero, exercises bare identifier syntax, then verifies a valid named snapshot still clones the JSON value and creates exactly one table.
- The existing `clone_sys_db_table_to_new_db_table` case now asserts the normalized missing-snapshot error for its invalid named-snapshot clone.
- The checked-in BVT result was manually inspected against the SQL semantics.

### Tests run

- `make build`
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^TestBuildCloneTableSnapshotResolutionErrors$' ./pkg/sql/plan`
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^(TestGetOpAndToAccountID(NormalizesMissingNamedSnapshot|PropagatesOtherSnapshotErrors)|TestGeneratedCloneRestoreSnapshotTS)$' ./pkg/frontend`
- mo-tester result generation for `clone_missing_named_snapshot`: successful; generated output manually verified.
- mo-tester comparison run on a fresh service: 17/17 cases passed.
- mo-tester comparison run on the current HEAD after rebasing onto `origin/main` and updating the existing clone expectation: 17/17 cases passed for `clone_missing_named_snapshot`.
- CI run [33733826397](https://github.com/matrixorigin/matrixone/actions/runs/33733826397) was analyzed: the Proxy BVT mismatch was the stale expectation updated here, and its Coverage failure was a dependent prerequisite failure rather than an independent product regression.
- CI run [33741264811](https://github.com/matrixorigin/matrixone/actions/runs/33741264811) was analyzed: the coverage parser found 3/5 changed lines covered (60%) and reported 0% for `pkg/frontend/clone.go`; the frontend tests above cover those new branches. This PR-caused run was not rerun before the fix.
- mo-tester comparison run repeated on the same service instance: 17/17 cases passed.
- `git diff --check`

### Residual risks

The conversion is intentionally limited to the existing missing-named-snapshot marker and the two clone boundaries. Other catalog or snapshot-resolution failures retain their original behavior. Valid snapshot clone behavior and cleanup after repeated failures are covered by the BVT; the frontend resolver seam is test-only indirection and does not alter runtime resolution.

### Latest rebase validation

- Rebased onto 9f711e21346ff52aa082ccf86999c4cfb4f84943 without conflicts; current HEAD is 6ccc7824b895c3a639dc930fca6c91b6a143c721.
- Re-ran make build, the planner and frontend focused UTs, and the exact missing-snapshot BVT twice on the isolated service; both BVT runs were 17/17 successful.