### PR TITLE
fix(compile): keep remote receiver stop non-terminal

### DIFF
--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -154,9 +154,10 @@ func CnServerMessageHandler(
 	// response and FIN still need the same cleanup barrier.
 	handlerErr := handlePipelineMessage(&receiver)
 	if handlerErr == nil && lifecycle != nil && lifecycle.batchFlow != nil {
-		handlerErr = lifecycle.batchFlow.waitUntilDrained(
+		handlerErr = waitUntilPipelineBatchFlowDrained(
 			receiver.messageCtx,
 			receiver.connectionCtx,
+			lifecycle.batchFlow,
 			func(count int, bytes uint64) {
 				logutil.Warn("pipeline batch drain delayed before terminal response",
 					zap.Uint64("stream-id", receiver.messageId),
@@ -205,6 +206,33 @@ func CnServerMessageHandler(
 	return err
 }
 
+// waitUntilPipelineBatchFlowDrained preserves the ownership boundary between
+// an internal receiver-driven StopSending and cancellation of the query or its
+// connection.  StopSending aborts outstanding batch credits so this wait can
+// finish, but it is a successful terminal path only while both external
+// contexts remain active.
+func waitUntilPipelineBatchFlowDrained(
+	messageCtx context.Context,
+	connectionCtx context.Context,
+	flow *pipelineBatchFlow,
+	onDelayed func(count int, bytes uint64),
+) error {
+	err := flow.waitUntilDrained(messageCtx, connectionCtx, onDelayed)
+	if err == nil {
+		return nil
+	}
+	if messageCtx != nil && messageCtx.Err() != nil {
+		return moerr.AttachCause(messageCtx, messageCtx.Err())
+	}
+	if connectionCtx != nil && connectionCtx.Err() != nil {
+		return moerr.NewStreamClosed(messageCtx)
+	}
+	if flow.wasStoppedByReceiver() && isScopeCancellationError(err) {
+		return nil
+	}
+	return err
+}
+
 // waitUntilDisconnectedOrCancelled blocks until either the client connection is
 // closed or the message context is cancelled (e.g. the query was killed). It
 // keeps listening so a remote dispatch can still stream data back, but no longer
@@ -228,7 +256,7 @@ func (receiver *messageReceiverOnServer) abortBatchFlowForPendingStop() {
 	if receiver.colexecServer.HasPendingPipelineCancellation(
 		receiver.clientSession, receiver.messageId,
 	) {
-		receiver.streamLifecycle.batchFlow.abort(
+		receiver.streamLifecycle.batchFlow.stop(
 			moerr.NewQueryInterrupted(receiver.messageCtx),
 		)
 	}

--- a/pkg/sql/compile/remoterun_batch_flow.go
+++ b/pkg/sql/compile/remoterun_batch_flow.go
@@ -41,6 +41,9 @@ type pipelineBatchFlow struct {
 	pending  map[uint64]uint64
 	changed  chan struct{}
 	abortErr error
+	// stoppedByReceiver distinguishes an internal StopSending from query or
+	// connection cancellation at the terminal-response drain boundary.
+	stoppedByReceiver bool
 }
 
 func newPipelineBatchFlow(requestedCount uint32, requestedBytes uint64) *pipelineBatchFlow {
@@ -110,6 +113,18 @@ func (f *pipelineBatchFlow) reserve(
 // credit waiters and the terminal-response drain barrier. The first abort cause
 // owns the terminal state; later StopSending messages and late ACKs are benign.
 func (f *pipelineBatchFlow) abort(cause error) {
+	f.terminate(cause, false)
+}
+
+// stop releases batch-credit waiters after the downstream receiver has
+// intentionally stopped consuming.  The marker lets the terminal-response
+// path treat this internal cancellation as success without hiding cancellation
+// of the owning query context.
+func (f *pipelineBatchFlow) stop(cause error) {
+	f.terminate(cause, true)
+}
+
+func (f *pipelineBatchFlow) terminate(cause error, stoppedByReceiver bool) {
 	if f == nil {
 		return
 	}
@@ -119,11 +134,21 @@ func (f *pipelineBatchFlow) abort(cause error) {
 	f.mu.Lock()
 	if f.abortErr == nil {
 		f.abortErr = cause
+		f.stoppedByReceiver = stoppedByReceiver
 		clear(f.pending)
 		f.bytes = 0
 		f.notifyLocked()
 	}
 	f.mu.Unlock()
+}
+
+func (f *pipelineBatchFlow) wasStoppedByReceiver() bool {
+	if f == nil {
+		return false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stoppedByReceiver
 }
 
 func (f *pipelineBatchFlow) rollback(seq uint64) {
@@ -213,7 +238,7 @@ func abortPipelineBatchFlow(cs morpc.ClientSession, id uint64, cause error) {
 	if !ok {
 		return
 	}
-	value.(*pipelineStreamLifecycle).batchFlow.abort(cause)
+	value.(*pipelineStreamLifecycle).batchFlow.stop(cause)
 }
 
 func handlePipelineBatchAck(message *pipeline.Message, cs morpc.ClientSession) error {

--- a/pkg/sql/compile/remoterun_batch_flow_test.go
+++ b/pkg/sql/compile/remoterun_batch_flow_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
 	"github.com/stretchr/testify/require"
 )
@@ -139,7 +140,9 @@ func TestPipelineBatchFlowAbortWakesWaitersAndReleasesAccounting(t *testing.T) {
 
 	firstCause := errors.New("stop sending")
 	flow.abort(firstCause)
-	flow.abort(errors.New("later abort"))
+	flow.stop(errors.New("later receiver stop"))
+	require.False(t, flow.wasStoppedByReceiver(),
+		"a late StopSending must not reclassify an earlier substantive abort")
 
 	select {
 	case err := <-reserveDone:
@@ -159,6 +162,94 @@ func TestPipelineBatchFlowAbortWakesWaitersAndReleasesAccounting(t *testing.T) {
 	require.Zero(t, flow.bytes)
 	flow.mu.Unlock()
 	require.NoError(t, flow.acknowledge(seq), "an ACK already in flight must be harmless after abort")
+}
+
+func TestPipelineBatchFlowDrainClassifiesReceiverStop(t *testing.T) {
+	newOutstandingFlow := func(t *testing.T) *pipelineBatchFlow {
+		flow := newPipelineBatchFlow(1, 1024)
+		_, err := flow.reserve(context.Background(), context.Background(), 10)
+		require.NoError(t, err)
+		return flow
+	}
+	waitAsync := func(
+		flow *pipelineBatchFlow,
+		messageCtx context.Context,
+		connectionCtx context.Context,
+	) (<-chan struct{}, <-chan error) {
+		started := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			close(started)
+			done <- waitUntilPipelineBatchFlowDrained(
+				messageCtx, connectionCtx, flow, nil)
+		}()
+		return started, done
+	}
+	requireResult := func(t *testing.T, done <-chan error) error {
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(time.Second):
+			t.Fatal("pipeline batch drain did not observe its terminal event")
+			return nil
+		}
+	}
+
+	t.Run("internal receiver stop is successful", func(t *testing.T) {
+		flow := newOutstandingFlow(t)
+		started, done := waitAsync(flow, context.Background(), context.Background())
+		<-started
+		flow.stop(moerr.NewQueryInterrupted(context.Background()))
+		flow.abort(errors.New("later abort"))
+		require.True(t, flow.wasStoppedByReceiver(),
+			"a late abort must not reclassify the receiver stop")
+		require.NoError(t, requireResult(t, done))
+	})
+
+	t.Run("query cancellation remains terminal", func(t *testing.T) {
+		flow := newOutstandingFlow(t)
+		queryCtx, cancelQuery := context.WithCancelCause(context.Background())
+		started, done := waitAsync(flow, queryCtx, context.Background())
+		<-started
+		cancelQuery(context.Canceled)
+
+		err := requireResult(t, done)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("query cancellation wins a recorded receiver stop", func(t *testing.T) {
+		flow := newOutstandingFlow(t)
+		flow.stop(moerr.NewQueryInterrupted(context.Background()))
+		queryCtx, cancelQuery := context.WithCancelCause(context.Background())
+		cancelQuery(context.Canceled)
+
+		err := waitUntilPipelineBatchFlowDrained(
+			queryCtx, context.Background(), flow, nil)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("connection cancellation remains terminal", func(t *testing.T) {
+		flow := newOutstandingFlow(t)
+		connectionCtx, closeConnection := context.WithCancel(context.Background())
+		started, done := waitAsync(flow, context.Background(), connectionCtx)
+		<-started
+		closeConnection()
+
+		err := requireResult(t, done)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrStreamClosed), err)
+	})
+
+	t.Run("substantive abort remains terminal", func(t *testing.T) {
+		flow := newOutstandingFlow(t)
+		cause := errors.New("remote execution failed")
+		started, done := waitAsync(flow, context.Background(), context.Background())
+		<-started
+		flow.abort(cause)
+
+		err := requireResult(t, done)
+		require.ErrorIs(t, err, cause)
+	})
 }
 
 func TestHandlePipelineBatchAck(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27757

## What this PR does / why we need it:


  Fix remote pipeline cancellation handling for issue #27757.

  This change distinguishes receiver-driven StopSending from actual query or connection cancellation:

  - Treat internal downstream early-stop, such as LIMIT, as successful and allow connection reuse.
  - Keep query cancellation and connection cancellation terminal, returning an error and poisoning the
    connection.

  - Keep substantive remote execution errors terminal.
  - Preserve the first terminal batch-flow classification to avoid cancellation races.
  - Add regression tests covering internal early-stop, query cancellation, connection cancellation, and
    substantive errors.