### PR TITLE
[4.2] fix(dedupjoin): handle build-only ODKU result columns

### DIFF
--- a/pkg/sql/colexec/dedupjoin/join.go
+++ b/pkg/sql/colexec/dedupjoin/join.go
@@ -1014,10 +1014,12 @@ func (ctr *container) probe(bat *batch.Batch, ap *DedupJoin, proc *process.Proce
 					}
 					for j, rp := range ap.Result {
 						if rp.Rel == 1 {
-							//if last index is row_id, meams need fetch right child's partition column
-							//@FIXME should have better way to get right child's partition column
+							// UPDATE normally emits the post-update probe row. Row IDs and
+							// columns that exist only in the build row (for example the
+							// planner's conflict-target primary key) must come from the
+							// matched stored row instead.
 							var srcVec *vector.Vector
-							if ctr.joinBat1.Vecs[rp.Pos].GetType().Oid == types.T_Rowid {
+							if int(rp.Pos) >= len(ctr.joinBat1.Vecs) || ctr.joinBat1.Vecs[rp.Pos].GetType().Oid == types.T_Rowid {
 								srcVec = ctr.joinBat2.Vecs[rp.Pos]
 							} else {
 								srcVec = ctr.joinBat1.Vecs[rp.Pos]

--- a/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
+++ b/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
@@ -193,6 +193,62 @@ func TestDedupJoinUpdateRestoresProbeVectors(t *testing.T) {
 	}
 }
 
+// TestDedupJoinUpdateUsesBuildOnlyResultColumn covers an asymmetric ODKU row
+// layout: the stored build row carries a conflict-target column that is absent
+// from the incoming probe row.
+func TestDedupJoinUpdateUsesBuildOnlyResultColumn(t *testing.T) {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+
+	int32Typ := types.T_int32.ToType()
+	tag++
+	curTag := tag
+	buildBat := makeInt32Batch(proc.Mp(), [][]int32{{10}, {9001}}, nil)
+	probeBat := makeInt32Batch(proc.Mp(), [][]int32{{10}}, nil)
+	conditions := [][]*plan.Expr{
+		{newExpr(0, int32Typ)},
+		{newExpr(0, int32Typ)},
+	}
+
+	dedupArg := &DedupJoin{
+		LeftTypes:               []types.Type{int32Typ},
+		RightTypes:              []types.Type{int32Typ, int32Typ},
+		Conditions:              conditions,
+		Result:                  []colexec.ResultPos{colexec.NewResultPos(1, 1)},
+		OnDuplicateAction:       plan.Node_UPDATE,
+		DelColIdx:               -1,
+		DedupDeleteMarkerColIdx: -1,
+		JoinMapTag:              curTag,
+		OperatorBase:            vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:             true,
+		NeedBatches:             true,
+		NeedAllocateSels:        true,
+		Conditions:              conditions[1],
+		IsDedup:                 true,
+		OnDuplicateAction:       plan.Node_UPDATE,
+		DelColIdx:               -1,
+		DedupDeleteMarkerColIdx: -1,
+		JoinMapTag:              curTag,
+		JoinMapRefCnt:           1,
+		OperatorBase:            vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	t.Cleanup(func() {
+		dedupArg.Reset(proc, false, nil)
+		buildArg.Reset(proc, false, nil)
+		dedupArg.Free(proc, false, nil)
+		buildArg.Free(proc, false, nil)
+		proc.Free()
+		require.Equal(t, int64(0), proc.Mp().CurrNB())
+	})
+
+	out := runFinalizeFixture(t, dedupArg, buildArg, proc, buildBat, probeBat)
+	require.Len(t, out, 1)
+	require.Equal(t, 1, out[0].RowCount())
+	require.Equal(t, []int32{9001}, vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[0]))
+}
+
 // TestDedupJoinFinalizeMatchedZero_NonCapture exercises the non-capture
 // fast path at finalize() lines 312-360: matched.Count()==0 and no capture
 // columns, so each Result column with rp.Rel==1 is transferred from the

--- a/test/distributed/cases/dml/insert/on_duplicate_key_modern.result
+++ b/test/distributed/cases/dml/insert/on_duplicate_key_modern.result
@@ -358,3 +358,23 @@ select id, u, v, updated_at > @ts_sec as ts_advanced from t_odku_sec_uk order by
 ➤ id[4,32,0]  ¦  u[4,32,0]  ¦  v[4,32,0]  ¦  ts_advanced[-7,1,0]  𝄀
 1  ¦  10  ¦  6  ¦  1
 drop table if exists t_odku_sec_uk;
+drop table if exists t_odku_fk_uk_child;
+drop table if exists t_odku_fk_uk_parent;
+create table t_odku_fk_uk_parent(pid int primary key);
+create table t_odku_fk_uk_child(
+id bigint auto_increment primary key,
+pid int not null,
+attr_id int not null,
+val varchar(20),
+unique key uk_pid_attr(pid, attr_id),
+foreign key(pid) references t_odku_fk_uk_parent(pid)
+);
+insert into t_odku_fk_uk_parent values (1);
+insert into t_odku_fk_uk_child(pid, attr_id, val) values (1, 5, 'old');
+insert into t_odku_fk_uk_child(pid, attr_id, val) values (1, 5, 'new')
+on duplicate key update val = values(val);
+select id, pid, attr_id, val from t_odku_fk_uk_child order by id;
+➤ id[-5,64,0]  ¦  pid[4,32,0]  ¦  attr_id[4,32,0]  ¦  val[12,20,0]  𝄀
+1  ¦  1  ¦  5  ¦  new
+drop table if exists t_odku_fk_uk_child;
+drop table if exists t_odku_fk_uk_parent;

--- a/test/distributed/cases/dml/insert/on_duplicate_key_modern.sql
+++ b/test/distributed/cases/dml/insert/on_duplicate_key_modern.sql
@@ -370,3 +370,25 @@ select id, u, v, updated_at = @ts_sec as ts_unchanged from t_odku_sec_uk order b
 insert into t_odku_sec_uk(id, u, v) values (3, 10, 5) on duplicate key update v = v + 1;
 select id, u, v, updated_at > @ts_sec as ts_advanced from t_odku_sec_uk order by id;
 drop table if exists t_odku_sec_uk;
+
+-- A child table with an auto-increment primary key and a secondary UNIQUE key
+-- can make the DEDUP build row wider than the incoming row. The conflict-target
+-- primary key exists only on the stored row and must survive the FK lock barrier.
+drop table if exists t_odku_fk_uk_child;
+drop table if exists t_odku_fk_uk_parent;
+create table t_odku_fk_uk_parent(pid int primary key);
+create table t_odku_fk_uk_child(
+  id bigint auto_increment primary key,
+  pid int not null,
+  attr_id int not null,
+  val varchar(20),
+  unique key uk_pid_attr(pid, attr_id),
+  foreign key(pid) references t_odku_fk_uk_parent(pid)
+);
+insert into t_odku_fk_uk_parent values (1);
+insert into t_odku_fk_uk_child(pid, attr_id, val) values (1, 5, 'old');
+insert into t_odku_fk_uk_child(pid, attr_id, val) values (1, 5, 'new')
+  on duplicate key update val = values(val);
+select id, pid, attr_id, val from t_odku_fk_uk_child order by id;
+drop table if exists t_odku_fk_uk_child;
+drop table if exists t_odku_fk_uk_parent;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28027

## What this PR does / why we need it:

Backport the DedupJoin ODKU fix from mainline PR #27974 to the `4.2-dev` release branch. ODKU UPDATE normally emits values from the post-update probe row, but an auto-increment primary key resolved through a secondary UNIQUE conflict can exist only in the matched build row. The old DedupJoin code indexed that build-only position in the narrower probe batch and panicked. The backport reads row IDs and build-only result columns from the matched stored row and carries the original operator and SQL regression coverage.

### Prerequisite and branch lineage

- **Source prerequisite:** mainline PR #27974 was reviewed and merged as commit `5bbc6f93c1b4d98bf8300aa18b7ee68a36ed79c6`. This PR's first commit `1ecab08e63b1fc182e1729798dcbe0ce1369e102` is the cherry-picked backport of that exact fix.
- **Target prerequisite:** the patch must be applied to `4.2-dev`, whose PR base was `cdcbb74313dd80f98f864ce13ec21247cc374367`; it is a release backport and must not be replayed on `main` as a substitute for #27974.
- **Merge result:** the backport branch was validated at head `94d3d488f9ba6b793e97f8028b1f6b85f61e8796` and merged by the `release-4.2` queue as `c8b8e2c0467fed7e7ddb0d5125f97cb36511daf1` on 2026-09-06.
- **Unrelated work:** this PR has no dependency on the JSON sequence #28089, #28090, or #28091. Those changes must follow their own `main` merge order and do not belong on `4.2-dev` through this backport.

Validation on exact pre-merge head `94d3d488f9ba6b793e97f8028b1f6b85f61e8796`:

- Original #28027 SQL on `v4.2.1@d2393868a7`: reproduced `ERROR 20101`, `index out of range [5] with length 5`; no partial write.
- Same SQL on this backport: passed; one existing row retained with `id=1`.
- Focused `TestDedupJoinUpdateUsesBuildOnlyResultColumn`: passed.
- Full `pkg/sql/colexec/dedupjoin`: passed.
- `on_duplicate_key_modern.sql`: 203/203 statements passed twice on the same clean local 4.2 service; no leftover test tables and no panic in the service log.
- Required release-4.2 CI at the pre-merge head passed: Ubuntu UT, arm64 SCA, coverage, Proxy BVT, and pessimistic multi-CN BVT.
- The PR is merged; any post-merge TKE workflow result is a separate operational/QA follow-up and is not a prerequisite for the already completed release-4.2 merge.

QA required: yes — verify the ODKU secondary-UNIQUE plus foreign-key production path on the merged `4.2-dev` build and record formal acceptance against issue #28027's testing gate.
