### PR TITLE
fix: reject ODKU changes to generated keys

### DIFF
--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -1875,6 +1875,61 @@ func (builder *QueryBuilder) appendInsertIgnoreMultiDedup(
 	return lastNodeID, outputTag, arbiterNode, nil
 }
 
+// collectGeneratedColumnDependents returns the set of columns that may change
+// when any column in seed is assigned during ODKU. Generated columns are
+// expanded to a fixed point so a generated column can depend on another
+// generated column. The returned names are canonical table column names.
+func collectGeneratedColumnDependents(ctx context.Context, tableDef *plan.TableDef, seed map[string]struct{}) (map[string]struct{}, error) {
+	possiblyChanged := make(map[string]struct{}, len(seed))
+	for name := range seed {
+		resolved := catalog.ResolveAlias(name)
+		colIdx, ok := tableDef.Name2ColIndex[resolved]
+		if !ok || colIdx < 0 || int(colIdx) >= len(tableDef.Cols) {
+			return nil, moerr.NewInternalErrorf(ctx,
+				"cannot resolve generated column dependency seed %q", name)
+		}
+		possiblyChanged[tableDef.Cols[colIdx].Name] = struct{}{}
+	}
+
+	for {
+		expanded := false
+		for _, col := range tableDef.Cols {
+			if col.GeneratedCol == nil {
+				continue
+			}
+			references := collectRefColPos(col.GeneratedCol.Expr)
+			for _, pos := range references {
+				if pos < 0 || int(pos) >= len(tableDef.Cols) {
+					return nil, moerr.NewInternalErrorf(ctx,
+						"invalid generated column reference position %d for column %q", pos, col.Name)
+				}
+			}
+			if _, alreadyChanged := possiblyChanged[col.Name]; alreadyChanged {
+				continue
+			}
+			for _, pos := range references {
+				if _, sourceChanged := possiblyChanged[tableDef.Cols[pos].Name]; sourceChanged {
+					possiblyChanged[col.Name] = struct{}{}
+					expanded = true
+					break
+				}
+			}
+		}
+		if !expanded {
+			return possiblyChanged, nil
+		}
+	}
+}
+
+func columnPossiblyChanged(tableDef *plan.TableDef, possiblyChanged map[string]struct{}, name string) bool {
+	resolved := catalog.ResolveAlias(name)
+	if colIdx, ok := tableDef.Name2ColIndex[resolved]; ok && colIdx >= 0 && int(colIdx) < len(tableDef.Cols) {
+		resolved = tableDef.Cols[colIdx].Name
+	}
+	_, ok := possiblyChanged[resolved]
+	return ok
+}
+
 func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	bindCtx *BindContext,
 	dmlCtx *DMLContext,
@@ -1932,6 +1987,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	selectTag := selectNode.BindingTags[0]
 	scanTag := builder.genNewBindTag()
 	updateExprs := make(map[string]*plan.Expr)
+	possiblyChangedCols := make(map[string]struct{})
 	autoUpdateCols := make(map[string]bool)
 	allExplicitAssignmentsSkipped := false
 
@@ -2035,6 +2091,20 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 			updateExprs[colName] = updateExpr
 		}
 
+		// Keep the dependency set separate from updateExprs: updateExprs is the
+		// final row image and receives every generated expression below, while
+		// possiblyChangedCols describes which keys may need maintenance.
+		seedCols := make(map[string]struct{}, len(updateExprs))
+		for colName := range updateExprs {
+			seedCols[colName] = struct{}{}
+		}
+		possiblyChangedCols, err = collectGeneratedColumnDependents(
+			builder.GetContext(), tableDef, seedCols,
+		)
+		if err != nil {
+			return 0, err
+		}
+
 		// Recompute generated columns from the final updated row image, so
 		// ON DUPLICATE KEY UPDATE stays consistent with regular UPDATE behavior.
 		finalRowExprs := make([]*plan.Expr, len(tableDef.Cols))
@@ -2069,12 +2139,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	}
 
 	for _, part := range tableDef.Pkey.Names {
-		if _, ok := updateExprs[part]; ok {
-			// Generated columns are auto-recomputed, not explicitly updated by the user.
-			// Allow them in PK even though they appear in updateExprs.
-			if idx, exists := tableDef.Name2ColIndex[part]; exists && tableDef.Cols[idx].GeneratedCol != nil {
-				continue
-			}
+		if columnPossiblyChanged(tableDef, possiblyChangedCols, part) {
 			return 0, moerr.NewUnsupportedDML(builder.GetContext(), "update primary key on duplicate")
 		}
 	}
@@ -2166,12 +2231,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	idxNeedUpdate := make([]bool, len(tableDef.Indexes))
 	for i, idxDef := range tableDef.Indexes {
 		for _, part := range idxDef.Parts {
-			resolved := catalog.ResolveAlias(part)
-			if _, ok := updateExprs[resolved]; ok {
-				// Skip generated columns in unique key check (auto-recomputed, not user-set)
-				if idx, exists := tableDef.Name2ColIndex[resolved]; exists && tableDef.Cols[idx].GeneratedCol != nil {
-					continue
-				}
+			if columnPossiblyChanged(tableDef, possiblyChangedCols, part) {
 				if idxDef.Unique {
 					return 0, moerr.NewUnsupportedDML(builder.GetContext(), "update unique key on duplicate")
 				} else {
@@ -2254,9 +2314,10 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		}
 		if len(idxDef.Parts) == 1 && len(prefixLengths) == 0 {
 			var ok bool
-			pkIdxInBat, ok = colName2Idx[tableDef.Name+"."+idxDef.Parts[0]]
+			partName := catalog.ResolveAlias(idxDef.Parts[0])
+			pkIdxInBat, ok = colName2Idx[tableDef.Name+"."+partName]
 			if !ok {
-				return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", idxDef.Parts[0])
+				return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
 			}
 		} else {
 			lockColName := idxDef.IndexTableName + "." + catalog.IndexTableIndexColName
@@ -2738,31 +2799,22 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		// generated value would defeat the no-op guard even when the user's
 		// explicit update changed nothing. A generated column whose source is a
 		// user-updated column is still caught by that source column's own <=>.
-		noopSkipCols := make(map[string]bool, len(autoUpdateCols))
+		noopSkipSeeds := make(map[string]struct{}, len(autoUpdateCols))
 		for name := range autoUpdateCols {
-			noopSkipCols[name] = true
+			noopSkipSeeds[name] = struct{}{}
 		}
-		for changed := true; changed; {
-			changed = false
-			for _, col := range tableDef.Cols {
-				if col.GeneratedCol == nil || noopSkipCols[col.Name] {
-					continue
-				}
-				for _, pos := range collectRefColPos(col.GeneratedCol.Expr) {
-					if int(pos) < len(tableDef.Cols) && noopSkipCols[tableDef.Cols[pos].Name] {
-						noopSkipCols[col.Name] = true
-						changed = true
-						break
-					}
-				}
-			}
+		noopSkipCols, err := collectGeneratedColumnDependents(
+			builder.GetContext(), tableDef, noopSkipSeeds,
+		)
+		if err != nil {
+			return 0, err
 		}
 		var allColsEqual *plan.Expr
 		for i, col := range tableDef.Cols {
 			if col.Name == catalog.Row_ID || col.Hidden {
 				continue
 			}
-			if noopSkipCols[col.Name] {
+			if _, skipped := noopSkipCols[col.Name]; skipped {
 				continue
 			}
 			// Only compare columns the update actually writes. A column absent from

--- a/pkg/sql/plan/bind_insert_generated_index_test.go
+++ b/pkg/sql/plan/bind_insert_generated_index_test.go
@@ -159,20 +159,30 @@ func mockTableColPos(t *testing.T, tableDef *planpb.TableDef, name string) int32
 	return -1
 }
 
-func TestCollectGeneratedColumnDependentsIncludesOnUpdateDependents(t *testing.T) {
-	mock := NewMockOptimizer(true)
+func configureMockOnUpdateGeneratedUniqueIndex(t *testing.T, mock *MockOptimizer) {
+	t.Helper()
 	base := mock.ctxt.tables["t_on_update_gen"]
-	base.Name2ColIndex = make(map[string]int32, len(base.Cols))
-	for i, col := range base.Cols {
-		base.Name2ColIndex[col.Name] = int32(i)
-	}
+	require.NotNil(t, base)
+	generatedCol := base.Cols[mockTableColPos(t, base, "g")]
+	indexTableName := catalog.SecondaryIndexTableNamePrefix + "odku-on-update-generated-g"
+	base.Indexes = []*planpb.IndexDef{{
+		IndexName:      "uk_on_update_generated_g",
+		Parts:          []string{catalog.CreateAlias("g")},
+		Unique:         true,
+		IndexTableName: indexTableName,
+		TableExist:     true,
+	}}
+	registerMockGeneratedIndexTable(t, mock, base, indexTableName, generatedCol)
+}
 
-	possiblyChanged, err := collectGeneratedColumnDependents(
-		context.Background(), base, map[string]struct{}{"updated_at": {}},
-	)
-	require.NoError(t, err)
-	require.Contains(t, possiblyChanged, "updated_at")
-	require.Contains(t, possiblyChanged, "g")
+func TestInsertOnDupOnUpdateGeneratedUniqueKeyRejected(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	configureMockOnUpdateGeneratedUniqueIndex(t, mock)
+
+	_, err := runOneStmt(mock, t,
+		"insert into constraint_test.t_on_update_gen (id, val) values (1, 2) "+
+			"on duplicate key update val = values(val)")
+	require.ErrorContains(t, err, "unsupported DML: update unique key on duplicate")
 }
 
 func configureMockGeneratedIndex(t *testing.T, mock *MockOptimizer, unique bool) string {

--- a/pkg/sql/plan/bind_insert_generated_index_test.go
+++ b/pkg/sql/plan/bind_insert_generated_index_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func generatedColumnRefExpr(typ planpb.Type, pos int32, name string) *planpb.Expr {
+	return &planpb.Expr{
+		Typ: typ,
+		Expr: &planpb.Expr_Col{
+			Col: &planpb.ColRef{
+				RelPos: 0,
+				ColPos: pos,
+				Name:   name,
+			},
+		},
+	}
+}
+
+func generatedDependencyTestTable() *planpb.TableDef {
+	typ := planpb.Type{Id: int32(types.T_int64)}
+	cols := []*planpb.ColDef{
+		{Name: "source", Typ: typ},
+		{Name: "middle", Typ: typ, GeneratedCol: &planpb.GeneratedCol{Expr: generatedColumnRefExpr(typ, 0, "source")}},
+		{Name: "tail", Typ: typ, GeneratedCol: &planpb.GeneratedCol{Expr: generatedColumnRefExpr(typ, 1, "middle")}},
+		{Name: "late_generated", Typ: typ, GeneratedCol: &planpb.GeneratedCol{Expr: generatedColumnRefExpr(typ, 4, "late_source")}},
+		{Name: "late_source", Typ: typ},
+		{Name: "other", Typ: typ},
+	}
+	name2ColIndex := make(map[string]int32, len(cols))
+	for i, col := range cols {
+		name2ColIndex[col.Name] = int32(i)
+	}
+	return &planpb.TableDef{Cols: cols, Name2ColIndex: name2ColIndex}
+}
+
+func TestCollectGeneratedColumnDependents(t *testing.T) {
+	tableDef := generatedDependencyTestTable()
+
+	possiblyChanged, err := collectGeneratedColumnDependents(
+		context.Background(), tableDef, map[string]struct{}{"source": {}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]struct{}{
+		"source": {},
+		"middle": {},
+		"tail":   {},
+	}, possiblyChanged)
+	require.False(t, columnPossiblyChanged(tableDef, possiblyChanged, "other"))
+	require.True(t, columnPossiblyChanged(tableDef, possiblyChanged, catalog.CreateAlias("tail")))
+	require.False(t, columnPossiblyChanged(tableDef, possiblyChanged, "late_generated"))
+
+	possiblyChanged, err = collectGeneratedColumnDependents(
+		context.Background(), tableDef, map[string]struct{}{"late_source": {}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]struct{}{
+		"late_source":    {},
+		"late_generated": {},
+	}, possiblyChanged)
+
+	possiblyChanged, err = collectGeneratedColumnDependents(
+		context.Background(), tableDef, map[string]struct{}{"other": {}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]struct{}{"other": {}}, possiblyChanged)
+}
+
+func TestCollectGeneratedColumnDependentsRejectsInvalidColPos(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pos  int32
+	}{
+		{name: "negative", pos: -1},
+		{name: "out of range", pos: 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tableDef := generatedDependencyTestTable()
+			tableDef.Cols[1].GeneratedCol.Expr = generatedColumnRefExpr(
+				tableDef.Cols[0].Typ, tc.pos, "source",
+			)
+			_, err := collectGeneratedColumnDependents(
+				context.Background(), tableDef, map[string]struct{}{"source": {}},
+			)
+			require.ErrorContains(t, err, "invalid generated column reference position")
+		})
+	}
+}
+
+func registerMockGeneratedIndexTable(t *testing.T, mock *MockOptimizer, base *planpb.TableDef, indexTableName string, keyCol *planpb.ColDef) {
+	t.Helper()
+	primaryCol := base.Cols[mockTableColPos(t, base, base.Pkey.PkeyColName)]
+	rowIDCol := base.Cols[mockTableColPos(t, base, catalog.Row_ID)]
+	indexKey := &planpb.ColDef{
+		Name:    catalog.IndexTableIndexColName,
+		Typ:     keyCol.Typ,
+		Default: &planpb.Default{NullAbility: true},
+	}
+	indexPrimary := &planpb.ColDef{
+		Name:    catalog.IndexTablePrimaryColName,
+		Typ:     primaryCol.Typ,
+		Default: &planpb.Default{NullAbility: true},
+	}
+	indexRowID := &planpb.ColDef{
+		Name:    catalog.Row_ID,
+		Typ:     rowIDCol.Typ,
+		Default: &planpb.Default{NullAbility: true},
+	}
+	hidden := &planpb.TableDef{
+		Name:      indexTableName,
+		TblId:     99051,
+		TableType: catalog.SystemIndexRel,
+		Cols:      []*planpb.ColDef{indexKey, indexPrimary, indexRowID},
+		Pkey: &planpb.PrimaryKeyDef{
+			PkeyColName: catalog.IndexTableIndexColName,
+			Names:       []string{catalog.IndexTableIndexColName},
+			Cols:        []uint64{0},
+			CompPkeyCol: indexKey,
+		},
+		Name2ColIndex: map[string]int32{
+			catalog.IndexTableIndexColName:   0,
+			catalog.IndexTablePrimaryColName: 1,
+			catalog.Row_ID:                   2,
+		},
+	}
+	objRef := &planpb.ObjectRef{SchemaName: "constraint_test", ObjName: indexTableName}
+	mock.ctxt.tables[indexTableName] = hidden
+	mock.ctxt.objects[indexTableName] = objRef
+}
+
+func mockTableColPos(t *testing.T, tableDef *planpb.TableDef, name string) int32 {
+	t.Helper()
+	for i, col := range tableDef.Cols {
+		if col.Name == name {
+			return int32(i)
+		}
+	}
+	t.Fatalf("column %q not found in table %q", name, tableDef.Name)
+	return -1
+}
+
+func TestCollectGeneratedColumnDependentsIncludesOnUpdateDependents(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	base := mock.ctxt.tables["t_on_update_gen"]
+	base.Name2ColIndex = make(map[string]int32, len(base.Cols))
+	for i, col := range base.Cols {
+		base.Name2ColIndex[col.Name] = int32(i)
+	}
+
+	possiblyChanged, err := collectGeneratedColumnDependents(
+		context.Background(), base, map[string]struct{}{"updated_at": {}},
+	)
+	require.NoError(t, err)
+	require.Contains(t, possiblyChanged, "updated_at")
+	require.Contains(t, possiblyChanged, "g")
+}
+
+func configureMockGeneratedIndex(t *testing.T, mock *MockOptimizer, unique bool) string {
+	t.Helper()
+	base := mock.ctxt.tables["t_on_update_gen"]
+	require.NotNil(t, base)
+	sourcePos := mockTableColPos(t, base, "val")
+	generatedPos := mockTableColPos(t, base, "g")
+	sourceCol := base.Cols[sourcePos]
+	generatedCol := base.Cols[generatedPos]
+	generatedCol.Typ = sourceCol.Typ
+	generatedCol.GeneratedCol = &planpb.GeneratedCol{
+		Expr:     generatedColumnRefExpr(sourceCol.Typ, sourcePos, sourceCol.Name),
+		IsStored: true,
+	}
+	// Keep this fixture focused on explicit ODKU dependencies rather than the
+	// separate ON UPDATE no-op behavior covered by bind_upsert_affect_rows_test.go.
+	base.Cols[mockTableColPos(t, base, "updated_at")].OnUpdate = nil
+
+	indexTableName := catalog.SecondaryIndexTableNamePrefix + "odku-generated-g"
+	base.Indexes = []*planpb.IndexDef{{
+		IndexName:      "idx_generated_g",
+		Parts:          []string{catalog.CreateAlias("g")},
+		Unique:         unique,
+		IndexTableName: indexTableName,
+		TableExist:     true,
+	}}
+	registerMockGeneratedIndexTable(t, mock, base, indexTableName, generatedCol)
+	return indexTableName
+}
+
+func configureMockGeneratedPrimaryKey(t *testing.T, mock *MockOptimizer) {
+	t.Helper()
+	base := mock.ctxt.tables["t_on_update_gen"]
+	require.NotNil(t, base)
+	sourcePos := mockTableColPos(t, base, "val")
+	idCol := base.Cols[mockTableColPos(t, base, "id")]
+	idCol.GeneratedCol = &planpb.GeneratedCol{
+		Expr:     generatedColumnRefExpr(idCol.Typ, sourcePos, "val"),
+		IsStored: true,
+	}
+	base.Cols[mockTableColPos(t, base, "updated_at")].OnUpdate = nil
+	base.Indexes = nil
+}
+
+func TestInsertOnDupGeneratedUniqueKeyRejected(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	configureMockGeneratedIndex(t, mock, true)
+
+	_, err := runOneStmt(mock, t,
+		"insert into constraint_test.t_on_update_gen (id, val, updated_at) values (1, 1, null) "+
+			"on duplicate key update val = values(val)")
+	require.ErrorContains(t, err, "unsupported DML: update unique key on duplicate")
+}
+
+func TestInsertOnDupUnrelatedColumnWithGeneratedUniqueKeySucceeds(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	configureMockGeneratedIndex(t, mock, true)
+
+	_, err := runOneStmt(mock, t,
+		"insert into constraint_test.t_on_update_gen (id, val, updated_at) values (1, 1, null) "+
+			"on duplicate key update updated_at = values(updated_at)")
+	require.NoError(t, err)
+}
+
+func TestInsertOnDupGeneratedPrimaryKeyRejected(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	configureMockGeneratedPrimaryKey(t, mock)
+
+	_, err := runOneStmt(mock, t,
+		"insert into constraint_test.t_on_update_gen (val, updated_at) values (1, null) "+
+			"on duplicate key update val = values(val)")
+	require.ErrorContains(t, err, "unsupported DML: update primary key on duplicate")
+}
+
+func findUpdateCtxByTableName(query *planpb.Query, tableName string) *planpb.UpdateCtx {
+	for _, node := range query.Nodes {
+		if node.NodeType != planpb.Node_MULTI_UPDATE {
+			continue
+		}
+		for _, updateCtx := range node.UpdateCtxList {
+			if updateCtx.TableDef != nil && updateCtx.TableDef.Name == tableName {
+				return updateCtx
+			}
+		}
+	}
+	return nil
+}
+
+func hasTableScanForTable(query *planpb.Query, tableName string) bool {
+	for _, node := range query.Nodes {
+		if node.NodeType == planpb.Node_TABLE_SCAN && node.TableDef != nil && node.TableDef.Name == tableName {
+			return true
+		}
+	}
+	return false
+}
+
+func TestInsertOnDupGeneratedNonUniqueIndexMaintainsOldAndNewKeys(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	indexTableName := configureMockGeneratedIndex(t, mock, false)
+
+	logicPlan, err := runOneStmt(mock, t,
+		"insert into constraint_test.t_on_update_gen (id, val, updated_at) values (1, 1, null) "+
+			"on duplicate key update val = values(val)")
+	require.NoError(t, err)
+
+	indexUpdateCtx := findUpdateCtxByTableName(logicPlan.GetQuery(), indexTableName)
+	require.NotNil(t, indexUpdateCtx)
+	require.NotEmpty(t, indexUpdateCtx.InsertCols)
+	require.Len(t, indexUpdateCtx.DeleteCols, 2)
+	require.True(t, hasTableScanForTable(logicPlan.GetQuery(), indexTableName))
+}
+
+func TestInsertOnDupUnrelatedColumnSkipsGeneratedIndexDelete(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	indexTableName := configureMockGeneratedIndex(t, mock, false)
+
+	logicPlan, err := runOneStmt(mock, t,
+		"insert into constraint_test.t_on_update_gen (id, val, updated_at) values (1, 1, null) "+
+			"on duplicate key update updated_at = values(updated_at)")
+	require.NoError(t, err)
+
+	indexUpdateCtx := findUpdateCtxByTableName(logicPlan.GetQuery(), indexTableName)
+	require.NotNil(t, indexUpdateCtx)
+	require.NotEmpty(t, indexUpdateCtx.InsertCols)
+	require.Empty(t, indexUpdateCtx.DeleteCols)
+	require.False(t, hasTableScanForTable(logicPlan.GetQuery(), indexTableName))
+}

--- a/test/distributed/cases/ddl/generated_column.result
+++ b/test/distributed/cases/ddl/generated_column.result
@@ -424,4 +424,8 @@ select id, generated_key from t44_odku_generated_index force index (idx_generate
 ➤ id[4,32,0]  ¦  generated_key[4,32,0]  𝄀
 1  ¦  4  𝄀
 2  ¦  4
+select id, generated_key from t44_odku_generated_index force index for order by (idx_generated_key) order by generated_key, id;
+➤ id[4,32,0]  ¦  generated_key[4,32,0]  𝄀
+1  ¦  4  𝄀
+2  ¦  4
 drop database test_generated_col;

--- a/test/distributed/cases/ddl/generated_column.result
+++ b/test/distributed/cases/ddl/generated_column.result
@@ -353,9 +353,10 @@ select * from t36_remap;
 create table t37_odku_pk (a int, b int generated always as (a*2) stored, primary key(b));
 insert into t37_odku_pk (a) values (1);
 insert into t37_odku_pk (a) values (1) on duplicate key update a=5;
+unsupported DML: update primary key on duplicate
 select * from t37_odku_pk;
 ➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
-5  ¦  10
+1  ¦  2
 create table t38_modify (a int, b int, c int generated always as (a + b) stored);
 alter table t38_modify modify column a bigint;
 invalid input: Cannot modify column 'a': generated column 'c' depends on it
@@ -389,4 +390,38 @@ select * from t42_churn where id between 1 and 5 order by id;
 3  ¦  3  ¦  6  ¦  9  𝄀
 4  ¦  7  ¦  8  ¦  15  𝄀
 5  ¦  5  ¦  15  ¦  20
+create table t43_odku_generated_unique (id int primary key, doc json, kind varchar(20) generated always as (doc ->> '$.kind') stored, payload int, unique key uk_kind(kind));
+insert into t43_odku_generated_unique (id, doc, payload) values (1, '{"kind":"alpha"}', 10), (2, '{"kind":"beta"}', 20);
+insert into t43_odku_generated_unique (id, doc, payload) values (3, '{"kind":"alpha"}', 30) on duplicate key update doc = json_set(doc, '$.kind', 'beta');
+unsupported DML: update unique key on duplicate
+select id, kind, payload from t43_odku_generated_unique order by id;
+➤ id[4,32,0]  ¦  kind[12,-1,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  alpha  ¦  10  𝄀
+2  ¦  beta  ¦  20
+select id, kind from t43_odku_generated_unique force index (uk_kind) order by id;
+➤ id[4,32,0]  ¦  kind[12,-1,0]  𝄀
+1  ¦  alpha  𝄀
+2  ¦  beta
+insert into t43_odku_generated_unique (id, doc, payload) values (1, '{"kind":"alpha"}', 99) on duplicate key update payload = values(payload);
+select id, kind, payload from t43_odku_generated_unique order by id;
+➤ id[4,32,0]  ¦  kind[12,-1,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  alpha  ¦  99  𝄀
+2  ¦  beta  ¦  20
+insert into t43_odku_generated_unique (id, doc, payload) values (1, '{"kind":"gamma"}', 111), (2, '{"kind":"delta"}', 222) on duplicate key update doc = values(doc);
+unsupported DML: update unique key on duplicate
+select id, kind, payload from t43_odku_generated_unique order by id;
+➤ id[4,32,0]  ¦  kind[12,-1,0]  ¦  payload[4,32,0]  𝄀
+1  ¦  alpha  ¦  99  𝄀
+2  ¦  beta  ¦  20
+update t43_odku_generated_unique set doc = json_set(doc, '$.kind', 'beta') where id = 1;
+Duplicate entry 'beta' for key 'kind'
+create table t44_odku_generated_index (id int primary key, source int, payload int, generated_key int generated always as (source * 2) stored, key idx_generated_key(generated_key));
+insert into t44_odku_generated_index (id, source, payload) values (1, 1, 10), (2, 2, 20);
+insert into t44_odku_generated_index (id, source, payload) values (1, 2, 11) on duplicate key update source = values(source);
+select id, generated_key from t44_odku_generated_index force index (idx_generated_key) where generated_key = 2;
+➤ id[4,32,0]  ¦  generated_key[4,32,0]
+select id, generated_key from t44_odku_generated_index force index (idx_generated_key) where generated_key = 4 order by id;
+➤ id[4,32,0]  ¦  generated_key[4,32,0]  𝄀
+1  ¦  4  𝄀
+2  ¦  4
 drop database test_generated_col;

--- a/test/distributed/cases/ddl/generated_column.sql
+++ b/test/distributed/cases/ddl/generated_column.sql
@@ -345,6 +345,7 @@ select * from t36_remap;
 -- ============================================================
 create table t37_odku_pk (a int, b int generated always as (a*2) stored, primary key(b));
 insert into t37_odku_pk (a) values (1);
+-- ODKU that can change a generated primary key is rejected as unsupported DML.
 insert into t37_odku_pk (a) values (1) on duplicate key update a=5;
 select * from t37_odku_pk;
 
@@ -385,6 +386,33 @@ select count(*) as bad_rows from t42_churn where c != a + b;
 select * from t42_churn where id between 1 and 5 order by id;
 
 -- ============================================================
--- 44. Cleanup
+-- 44. ODKU generated UNIQUE key safety (#28051)
+-- ============================================================
+create table t43_odku_generated_unique (id int primary key, doc json, kind varchar(20) generated always as (doc ->> '$.kind') stored, payload int, unique key uk_kind(kind));
+insert into t43_odku_generated_unique (id, doc, payload) values (1, '{"kind":"alpha"}', 10), (2, '{"kind":"beta"}', 20);
+-- The original #28051 shape must be rejected before it can make two rows share beta.
+insert into t43_odku_generated_unique (id, doc, payload) values (3, '{"kind":"alpha"}', 30) on duplicate key update doc = json_set(doc, '$.kind', 'beta');
+select id, kind, payload from t43_odku_generated_unique order by id;
+select id, kind from t43_odku_generated_unique force index (uk_kind) order by id;
+-- An update of an unrelated column remains supported.
+insert into t43_odku_generated_unique (id, doc, payload) values (1, '{"kind":"alpha"}', 99) on duplicate key update payload = values(payload);
+select id, kind, payload from t43_odku_generated_unique order by id;
+-- A multi-row statement is rejected atomically when its update may change the key.
+insert into t43_odku_generated_unique (id, doc, payload) values (1, '{"kind":"gamma"}', 111), (2, '{"kind":"delta"}', 222) on duplicate key update doc = values(doc);
+select id, kind, payload from t43_odku_generated_unique order by id;
+-- Ordinary UPDATE keeps its existing duplicate-key behavior as the control group.
+update t43_odku_generated_unique set doc = json_set(doc, '$.kind', 'beta') where id = 1;
+
+-- ============================================================
+-- 45. ODKU generated non-unique index maintenance
+-- ============================================================
+create table t44_odku_generated_index (id int primary key, source int, payload int, generated_key int generated always as (source * 2) stored, key idx_generated_key(generated_key));
+insert into t44_odku_generated_index (id, source, payload) values (1, 1, 10), (2, 2, 20);
+insert into t44_odku_generated_index (id, source, payload) values (1, 2, 11) on duplicate key update source = values(source);
+select id, generated_key from t44_odku_generated_index force index (idx_generated_key) where generated_key = 2;
+select id, generated_key from t44_odku_generated_index force index (idx_generated_key) where generated_key = 4 order by id;
+
+-- ============================================================
+-- 46. Cleanup
 -- ============================================================
 drop database test_generated_col;

--- a/test/distributed/cases/ddl/generated_column.sql
+++ b/test/distributed/cases/ddl/generated_column.sql
@@ -411,6 +411,8 @@ insert into t44_odku_generated_index (id, source, payload) values (1, 1, 10), (2
 insert into t44_odku_generated_index (id, source, payload) values (1, 2, 11) on duplicate key update source = values(source);
 select id, generated_key from t44_odku_generated_index force index (idx_generated_key) where generated_key = 2;
 select id, generated_key from t44_odku_generated_index force index (idx_generated_key) where generated_key = 4 order by id;
+-- A predicate-free forced index scan exposes a stale hidden key as a duplicate base row.
+select id, generated_key from t44_odku_generated_index force index for order by (idx_generated_key) order by generated_key, id;
 
 -- ============================================================
 -- 46. Cleanup


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28051

## What this PR does / why we need it:

This is the phase-one data-safety fix for ODKU statements that can indirectly change generated keys.

- Compute the alias-normalized fixed-point closure of columns that may change through generated-column dependencies, including implicit `ON UPDATE` columns.
- Reject ODKU during planning with the existing 20313 unsupported-DML error when a generated primary-key or UNIQUE part may change.
- Route affected generated non-unique indexes through the existing hidden-index delete/insert maintenance path.
- Keep unrelated generated indexes on the insert-only path.

This intentionally does not implement MySQL-style final-value uniqueness checking, change SQL/catalog/protobuf/storage formats, or repair indexes already damaged by an older version.

Validation on exact head `cfe6007254e1612eac97b611500b6a853f88be9e`:

- Focused generated-key ODKU planner tests: PASS.
- Full `pkg/sql/plan`: PASS.
- Isolated `generated_column.sql` BVT: 190/190 PASS, twice.
- The `ON UPDATE -> generated UNIQUE` regression now enters through `runOneStmt`, preserving the real `OnUpdate` metadata and proving the planner returns 20313.
- Generated non-unique maintenance now has a predicate-free forced-index scan; it returns exactly `(1,4)` and `(2,4)`, so a stale old hidden key cannot be masked by a base-table predicate.
- Semantic preflight: `PASS semantic=PASS`, diff hash `ad6aacd4b5dd3f46fdce246d31eff467f814b62e62fb1f67a0bea5fa6165744c`.
- `git diff --check`: PASS.

QA required: yes. This changes a user-visible ODKU error path and protects persisted secondary-index consistency. Keep the PR Draft until exact-head CI, review, and QA pass.
