### PR TITLE
fix(json): return composite values from JSON_VALUE

### DIFF
--- a/pkg/sql/plan/function/func_builtin_json.go
+++ b/pkg/sql/plan/function/func_builtin_json.go
@@ -3345,10 +3345,6 @@ func JsonValue(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc
 			rs.AppendMustNullForBytesResult()
 			continue
 		}
-		if val.Type == bytejson.TpCodeObject || val.Type == bytejson.TpCodeArray {
-			rs.AppendMustNullForBytesResult()
-			continue
-		}
 		// Unquote → extract text value (strip JSON string quotes).
 		s, err := val.Unquote()
 		if err != nil {

--- a/pkg/sql/plan/function/func_json_valid_test.go
+++ b/pkg/sql/plan/function/func_json_valid_test.go
@@ -993,20 +993,44 @@ func TestJsonValue(t *testing.T) {
 		require.True(t, s, info)
 	})
 
-	t.Run("object and array matches return null", func(t *testing.T) {
+	t.Run("object and array matches return json text", func(t *testing.T) {
 		tc := tcTemp{
 			info: "json_value non scalar",
 			inputs: []FunctionTestInput{
 				NewFunctionTestInput(types.T_varchar.ToType(),
-					[]string{`{"a":[1]}`, `{"a":{"b":1}}`, `{"a":true}`},
-					[]bool{false, false, false}),
+					[]string{`{"a":[1]}`, `{"a":{"b":1}}`, `[1,2]`, `{}`, `[]`, `[{}]`, `{"a":true}`},
+					[]bool{false, false, false, false, false, false, false}),
 				NewFunctionTestInput(types.T_varchar.ToType(),
-					[]string{`$.a`, `$.a`, `$.a`},
-					[]bool{false, false, false}),
+					[]string{`$.a`, `$.a`, `$`, `$`, `$`, `$[*]`, `$.a`},
+					[]bool{false, false, false, false, false, false, false}),
 			},
 			expect: NewFunctionTestResult(types.T_varchar.ToType(), false,
-				[]string{"", "", "true"},
-				[]bool{true, true, false}),
+				[]string{`[1]`, `{"b": 1}`, `[1, 2]`, `{}`, `[]`, `{}`, "true"},
+				[]bool{false, false, false, false, false, false, false}),
+		}
+		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, JsonValue)
+		s, info := fcTC.Run()
+		require.True(t, s, info)
+	})
+
+	t.Run("json typed object and array matches return json text", func(t *testing.T) {
+		documents := []string{`{"a":[12]}`, `{"a":{"k":1}}`}
+		encoded := make([]string, len(documents))
+		for i, document := range documents {
+			bj, err := types.ParseStringToByteJson(document)
+			require.NoError(t, err)
+			data, err := bj.Marshal()
+			require.NoError(t, err)
+			encoded[i] = string(data)
+		}
+		tc := tcTemp{
+			info: "json_value typed non scalar",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_json.ToType(), encoded, []bool{false, false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{`$.a`, `$.a`}, []bool{false, false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false,
+				[]string{`[12]`, `{"k": 1}`}, []bool{false, false}),
 		}
 		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, JsonValue)
 		s, info := fcTC.Run()

--- a/pkg/sql/plan/function/func_json_valid_test.go
+++ b/pkg/sql/plan/function/func_json_valid_test.go
@@ -106,6 +106,7 @@ func TestJsonLength(t *testing.T) {
 		s, info := fcTC.Run()
 		require.True(t, s, info)
 	})
+
 }
 
 func TestJsonKeys(t *testing.T) {
@@ -1079,6 +1080,25 @@ func TestJsonValue(t *testing.T) {
 		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, JsonValue)
 		s, info := fcTC.Run()
 		require.True(t, s, info)
+	})
+
+	t.Run("invalid document and path return errors", func(t *testing.T) {
+		for _, inputs := range [][]FunctionTestInput{
+			{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{`not json`}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{`$.a`}, []bool{false}),
+			},
+			{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{`{"a":1}`}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{`$[`}, []bool{false}),
+			},
+		} {
+			tc := NewFunctionTestCase(proc, inputs,
+				NewFunctionTestResult(types.T_varchar.ToType(), false, []string{""}, []bool{false}),
+				JsonValue)
+			s, _ := tc.Run()
+			require.False(t, s)
+		}
 	})
 }
 

--- a/test/distributed/cases/function/func_json_value.result
+++ b/test/distributed/cases/function/func_json_value.result
@@ -69,3 +69,51 @@ null
 select json_value('{"a":1,"b":2}', '$**.a');
 json_value({"a":1,"b":2}, $**.a)
 1
+select json_value('{"x":[12],"o":{"k":1},"s":12}', '$.x');
+json_value({"x":[12],"o":{"k":1},"s":12}, $.x)
+[12]
+select json_value('{"x":[12],"o":{"k":1},"s":12}', '$.o');
+json_value({"x":[12],"o":{"k":1},"s":12}, $.o)
+{"k": 1}
+select json_value('{"x":[12],"o":{"k":1},"s":12}', '$.s');
+json_value({"x":[12],"o":{"k":1},"s":12}, $.s)
+12
+select json_value('[1,2,3]', '$');
+json_value([1,2,3], $)
+[1, 2, 3]
+select json_value('{"a":"b"}', '$');
+json_value({"a":"b"}, $)
+{"a": "b"}
+select json_value('{}', '$');
+json_value({}, $)
+{}
+select json_value('[]', '$');
+json_value([], $)
+[]
+select json_value('[{}]', '$[*]');
+json_value([{}], $[*])
+{}
+drop table if exists json_value_generated_idx;
+create table json_value_generated_idx (id int primary key, doc json not null, extracted varchar(64) as (json_value(doc, '$.x')) stored, index extracted_idx(extracted));
+insert into json_value_generated_idx(id, doc) values (1, '{"x":[12]}'), (2, '{"x":{"k":1}}'), (3, '{"x":"scalar"}');
+select id, extracted from json_value_generated_idx order by id;
+id	extracted
+1	[12]
+2	{"k": 1}
+3	scalar
+select id from json_value_generated_idx force index(extracted_idx) where extracted = '[12]';
+id
+1
+select id from json_value_generated_idx force index(extracted_idx) where extracted = '{"k": 1}';
+id
+2
+update json_value_generated_idx set doc = '{"x":[99]}' where id = 3;
+select id, extracted from json_value_generated_idx where id = 3;
+id	extracted
+3	[99]
+select id from json_value_generated_idx force index(extracted_idx) where extracted = 'scalar';
+id
+select id from json_value_generated_idx force index(extracted_idx) where extracted = '[99]';
+id
+3
+drop table json_value_generated_idx;

--- a/test/distributed/cases/function/func_json_value.test
+++ b/test/distributed/cases/function/func_json_value.test
@@ -45,3 +45,26 @@ select json_value(json_array(1, 2, 3), '$[2]');
 select json_value('{"a":1,"b":2}', '$.*');
 select json_value('{"a":1,"b":2}', '$[*]');
 select json_value('{"a":1,"b":2}', '$**.a');
+
+-- object and array matches return canonical JSON text
+select json_value('{"x":[12],"o":{"k":1},"s":12}', '$.x');
+select json_value('{"x":[12],"o":{"k":1},"s":12}', '$.o');
+select json_value('{"x":[12],"o":{"k":1},"s":12}', '$.s');
+select json_value('[1,2,3]', '$');
+select json_value('{"a":"b"}', '$');
+select json_value('{}', '$');
+select json_value('[]', '$');
+select json_value('[{}]', '$[*]');
+
+-- stored generated columns and their indexes retain extracted composite values
+drop table if exists json_value_generated_idx;
+create table json_value_generated_idx (id int primary key, doc json not null, extracted varchar(64) as (json_value(doc, '$.x')) stored, index extracted_idx(extracted));
+insert into json_value_generated_idx(id, doc) values (1, '{"x":[12]}'), (2, '{"x":{"k":1}}'), (3, '{"x":"scalar"}');
+select id, extracted from json_value_generated_idx order by id;
+select id from json_value_generated_idx force index(extracted_idx) where extracted = '[12]';
+select id from json_value_generated_idx force index(extracted_idx) where extracted = '{"k": 1}';
+update json_value_generated_idx set doc = '{"x":[99]}' where id = 3;
+select id, extracted from json_value_generated_idx where id = 3;
+select id from json_value_generated_idx force index(extracted_idx) where extracted = 'scalar';
+select id from json_value_generated_idx force index(extracted_idx) where extracted = '[99]';
+drop table json_value_generated_idx;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28071

## What this PR does / why we need it:

`JSON_VALUE` returned SQL `NULL` when a path selected one JSON object or array. That wrong value could be persisted by a STORED generated column and indexed, causing index queries to miss rows.

This removes the composite-value shortcut and sends every non-null single match through `ByteJson.Unquote()`. Objects and arrays now return canonical JSON text, while scalar, JSON null, missing-path, multi-match, and invalid-input behavior stays unchanged. The result matches the current MySQL 8.0 [MTR input](https://github.com/mysql/mysql-server/blob/9fc8d60003b4eee32767c1e30942f222c3508c31/mysql-test/suite/json/t/json_value.test#L83-L86) and [expected output](https://github.com/mysql/mysql-server/blob/9fc8d60003b4eee32767c1e30942f222c3508c31/mysql-test/suite/json/r/json_value.result#L189-L198).

Regression coverage includes VARCHAR and `T_json` input, root/nested/empty/unique-wildcard composites, STORED generated-column persistence, forced secondary-index reads, and scalar-to-array update maintenance.

Historical STORED generated values are not recomputed automatically. QA must create affected data and its index on the old version, upgrade, confirm the stale value remains, then verify recovery by dropping the dependent index, dropping and recreating the generated column with its original definition, and recreating the index. Both full-scan and `FORCE INDEX` array/object queries must pass after recovery.

Validation and exact-head evidence:

- Previous head `c6da227ae94c75a68f1bc2557a415b99febeea67`: focused `TestJsonValue` (including invalid JSON document/path errors), `pkg/sql/plan/function`, final binary build, and single-CN `func_json_value.test` twice (44/44 each): PASS.
- Rebase verification: `git range-diff` maps both PR commits 1:1 onto current head `93478345d163f437ce75a281ccedc432c64b0aa1`; no semantic patch change.
- Current head `93478345d163f437ce75a281ccedc432c64b0aa1`: `git diff --check`: PASS; schema-v6 semantic preflight: `PASS semantic=PASS`, diff hash `cda0fc93541ef16c013a71762e35e99cc8c96e4a62faa5343ce361520b17355b`.
- Current exact-head CI run `34079746431`: in progress (shared build passed; UT, coverage, and arm64 SCA running).
- Local CGo `TestJsonValue` rerun: blocked because this temporary worktree has no `cgo/libmo.dylib`; CI is the authoritative current-head execution.

QA Required, including the old-version-to-new-version generated-column/index upgrade and recovery scenario above.

