### PR TITLE
fix(json): preserve MySQL binary subtype fidelity

### DIFF
--- a/pkg/common/hashmap/keycodec/keycodec_test.go
+++ b/pkg/common/hashmap/keycodec/keycodec_test.go
@@ -246,6 +246,19 @@ func TestCanonicalJSONBinaryContract(t *testing.T) {
 		AppendCanonicalJSON(nil, mustEncodeByteJSON(t, bit)),
 		AppendCanonicalJSON(nil, mustEncodeByteJSON(t, raw)),
 	)
+
+	malformed := stringByteJSON(bytejson.TpCodeBlob, "base64:type16:not-base64")
+	valid, err := bytejson.NewMySQLOpaque(bytejson.MySQLOpaqueProtocolVersion, 252, []byte(malformed.GetString()))
+	require.NoError(t, err)
+	malformedNested, err := bytejson.CreateByteJSON([]any{malformed})
+	require.NoError(t, err)
+	validNested, err := bytejson.CreateByteJSON([]any{valid})
+	require.NoError(t, err)
+	require.Zero(t, bytejson.CompareByteJson(malformedNested, validNested))
+	require.Equal(t,
+		AppendCanonicalJSON(nil, mustEncodeByteJSON(t, malformedNested)),
+		AppendCanonicalJSON(nil, mustEncodeByteJSON(t, validNested)),
+	)
 }
 
 func TestCanonicalJSONMatchesScalarEquality(t *testing.T) {

--- a/pkg/container/bytejson/bytejson.go
+++ b/pkg/container/bytejson/bytejson.go
@@ -377,7 +377,7 @@ func (bj ByteJson) getValEntry(off int) ByteJson {
 const (
 	persistedBitPrefix         = "~mo:json-bit:v1:"
 	mysqlOpaquePrefix          = "base64:type"
-	MySQLOpaqueProtocolVersion = defines.MORPCVersion46
+	MySQLOpaqueProtocolVersion = defines.MORPCVersion50
 )
 
 // NewMySQLOpaque creates the JSON representation MySQL uses for binary SQL

--- a/pkg/container/bytejson/bytejson.go
+++ b/pkg/container/bytejson/bytejson.go
@@ -40,6 +40,9 @@ func (bj ByteJson) String() string {
 
 func (bj ByteJson) Unquote() (string, error) {
 	if bj.Type == TpCodeBlob {
+		if _, _, ok := mysqlOpaqueValue(bj.GetString()); ok {
+			return string(bj.GetString()), nil
+		}
 		if payload, ok := bj.persistedBitPayload(); ok {
 			return base64.StdEncoding.EncodeToString(payload), nil
 		}
@@ -214,12 +217,15 @@ func (bj ByteJson) to(buf []byte) ([]byte, error) {
 		buf = append(buf, '"')
 	case TpCodeBlob:
 		buf = append(buf, '"')
-		if payload, ok := bj.persistedBitPayload(); ok {
+		data := bj.GetString()
+		if _, _, ok := mysqlOpaqueValue(data); ok {
+			buf = append(buf, data...)
+		} else if payload, ok := bj.persistedBitPayload(); ok {
 			start := len(buf)
 			buf = append(buf, make([]byte, base64.StdEncoding.EncodedLen(len(payload)))...)
 			base64.StdEncoding.Encode(buf[start:], payload)
 		} else {
-			buf = append(buf, bj.GetString()...)
+			buf = append(buf, data...)
 		}
 		buf = append(buf, '"')
 	case TpCodeOpaque, TpCodeBit:
@@ -367,13 +373,62 @@ func (bj ByteJson) getValEntry(off int) ByteJson {
 	return ByteJson{Type: TpCode(tpCode), Data: bj.Data[valOff : valOff+dataBytes]}
 }
 
-const persistedBitPrefix = "~mo:json-bit:v1:"
+const (
+	persistedBitPrefix = "~mo:json-bit:v1:"
+	mysqlOpaquePrefix  = "base64:type"
+)
+
+// NewMySQLOpaque creates the JSON representation MySQL uses for binary SQL
+// values. TpCodeBlob keeps the value readable by pre-TpCodeOpaque readers;
+// the standard text prefix retains the original MySQL field type.
+func NewMySQLOpaque(fieldType uint8, payload []byte) ByteJson {
+	return ByteJson{
+		Type: TpCodeBlob,
+		Data: appendBinaryString(nil, mysqlOpaqueText(fieldType, payload)),
+	}
+}
+
+func mysqlOpaqueText(fieldType uint8, payload []byte) string {
+	encodedLen := base64.StdEncoding.EncodedLen(len(payload))
+	buf := make([]byte, 0, len(mysqlOpaquePrefix)+3+1+encodedLen)
+	buf = append(buf, mysqlOpaquePrefix...)
+	buf = strconv.AppendUint(buf, uint64(fieldType), 10)
+	buf = append(buf, ':')
+	start := len(buf)
+	buf = append(buf, make([]byte, encodedLen)...)
+	base64.StdEncoding.Encode(buf[start:], payload)
+	return string(buf)
+}
+
+func mysqlOpaqueValue(payload []byte) (uint8, []byte, bool) {
+	if !bytes.HasPrefix(payload, []byte(mysqlOpaquePrefix)) {
+		return 0, nil, false
+	}
+	rest := payload[len(mysqlOpaquePrefix):]
+	colon := bytes.IndexByte(rest, ':')
+	if colon <= 0 {
+		return 0, nil, false
+	}
+	fieldType, err := strconv.ParseUint(string(rest[:colon]), 10, 8)
+	if err != nil {
+		return 0, nil, false
+	}
+	encoded := rest[colon+1:]
+	if _, ok := base64DecodedLen(encoded); !ok {
+		return 0, nil, false
+	}
+	return uint8(fieldType), encoded, true
+}
 
 func (bj ByteJson) persistedBitPayload() ([]byte, bool) {
 	if bj.Type != TpCodeBlob {
 		return nil, false
 	}
 	payload := bj.GetString()
+	if fieldType, encoded, ok := mysqlOpaqueValue(payload); ok && fieldType == 16 {
+		raw, err := base64.StdEncoding.DecodeString(string(encoded))
+		return raw, err == nil
+	}
 	if !bytes.HasPrefix(payload, []byte(persistedBitPrefix)) {
 		return nil, false
 	}
@@ -406,8 +461,9 @@ func (bj ByteJson) requiresLegacyBinaryEncoding() bool {
 
 // appendLegacyCompatibleJSON writes only type codes understood by readers
 // predating TpCodeOpaque and TpCodeBit. Opaque values use the legacy BLOB
-// representation; BIT values use a tagged BLOB payload whose subtype new
-// readers recover through TYPE, display, and comparison operations.
+// representation; BIT values keep the legacy sentinel so existing CAST AS JSON
+// display remains unchanged. Constructors that require MySQL's type16 tag use
+// NewMySQLOpaque directly and therefore do not enter this conversion.
 func appendLegacyCompatibleJSON(buf []byte, bj ByteJson) (TpCode, []byte, error) {
 	switch bj.Type {
 	case TpCodeOpaque:
@@ -490,8 +546,8 @@ func appendLegacyCompatibleValueEntry(buf []byte, docOff, valEntryOff int, bj By
 type binaryJSONSubtype uint8
 
 const (
-	binaryJSONBit binaryJSONSubtype = iota
-	binaryJSONBlob
+	binaryJSONBit  binaryJSONSubtype = 16
+	binaryJSONBlob binaryJSONSubtype = 252
 )
 
 const (
@@ -510,6 +566,13 @@ func binaryJSONValue(bj ByteJson) (binaryJSONValueView, bool) {
 	switch bj.Type {
 	case TpCodeBlob:
 		payload := bj.GetString()
+		if fieldType, encoded, ok := mysqlOpaqueValue(payload); ok {
+			return binaryJSONValueView{
+				subtype:       binaryJSONSubtype(fieldType),
+				legacyEncoded: encoded,
+				fallbackRaw:   payload,
+			}, true
+		}
 		if bytes.HasPrefix(payload, []byte(persistedBitPrefix)) {
 			encoded := payload[len(persistedBitPrefix):]
 			if _, ok := base64DecodedLen(encoded); ok {

--- a/pkg/container/bytejson/bytejson.go
+++ b/pkg/container/bytejson/bytejson.go
@@ -377,7 +377,7 @@ func (bj ByteJson) getValEntry(off int) ByteJson {
 const (
 	persistedBitPrefix         = "~mo:json-bit:v1:"
 	mysqlOpaquePrefix          = "base64:type"
-	MySQLOpaqueProtocolVersion = defines.MORPCVersion51
+	MySQLOpaqueProtocolVersion = defines.MORPCVersion52
 )
 
 // NewMySQLOpaque creates the JSON representation MySQL uses for binary SQL

--- a/pkg/container/bytejson/bytejson.go
+++ b/pkg/container/bytejson/bytejson.go
@@ -377,7 +377,7 @@ func (bj ByteJson) getValEntry(off int) ByteJson {
 const (
 	persistedBitPrefix         = "~mo:json-bit:v1:"
 	mysqlOpaquePrefix          = "base64:type"
-	MySQLOpaqueProtocolVersion = defines.MORPCVersion50
+	MySQLOpaqueProtocolVersion = defines.MORPCVersion51
 )
 
 // NewMySQLOpaque creates the JSON representation MySQL uses for binary SQL

--- a/pkg/container/bytejson/bytejson.go
+++ b/pkg/container/bytejson/bytejson.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	json2 "github.com/segmentio/encoding/json"
 )
 
@@ -374,18 +375,25 @@ func (bj ByteJson) getValEntry(off int) ByteJson {
 }
 
 const (
-	persistedBitPrefix = "~mo:json-bit:v1:"
-	mysqlOpaquePrefix  = "base64:type"
+	persistedBitPrefix         = "~mo:json-bit:v1:"
+	mysqlOpaquePrefix          = "base64:type"
+	MySQLOpaqueProtocolVersion = defines.MORPCVersion46
 )
 
 // NewMySQLOpaque creates the JSON representation MySQL uses for binary SQL
-// values. TpCodeBlob keeps the value readable by pre-TpCodeOpaque readers;
-// the standard text prefix retains the original MySQL field type.
-func NewMySQLOpaque(fieldType uint8, payload []byte) ByteJson {
+// values after the cluster-wide protocol admission has completed. The caller
+// must pass the minimum protocol version supported by every executing CN;
+// older readers compare tagged and legacy payloads differently.
+func NewMySQLOpaque(protocolVersion int64, fieldType uint8, payload []byte) (ByteJson, error) {
+	if protocolVersion < MySQLOpaqueProtocolVersion {
+		return ByteJson{}, moerr.NewNotSupportedNoCtxf(
+			"MySQL binary JSON type tags require MORPC protocol version %d",
+			MySQLOpaqueProtocolVersion)
+	}
 	return ByteJson{
 		Type: TpCodeBlob,
 		Data: appendBinaryString(nil, mysqlOpaqueText(fieldType, payload)),
-	}
+	}, nil
 }
 
 func mysqlOpaqueText(fieldType uint8, payload []byte) string {
@@ -400,24 +408,53 @@ func mysqlOpaqueText(fieldType uint8, payload []byte) string {
 	return string(buf)
 }
 
+// mysqlOpaqueValue parses only the bounded tag header. Consumers validate or
+// decode the returned payload once for their own terminal operation.
 func mysqlOpaqueValue(payload []byte) (uint8, []byte, bool) {
 	if !bytes.HasPrefix(payload, []byte(mysqlOpaquePrefix)) {
 		return 0, nil, false
 	}
 	rest := payload[len(mysqlOpaquePrefix):]
-	colon := bytes.IndexByte(rest, ':')
-	if colon <= 0 {
-		return 0, nil, false
+	fieldType := uint16(0)
+	for i, digit := range rest {
+		if digit == ':' {
+			if i == 0 {
+				return 0, nil, false
+			}
+			return uint8(fieldType), rest[i+1:], true
+		}
+		if i == 3 {
+			return 0, nil, false
+		}
+		if digit < '0' || digit > '9' {
+			return 0, nil, false
+		}
+		n := uint16(digit - '0')
+		if fieldType > (255-n)/10 {
+			return 0, nil, false
+		}
+		fieldType = fieldType*10 + n
 	}
-	fieldType, err := strconv.ParseUint(string(rest[:colon]), 10, 8)
-	if err != nil {
-		return 0, nil, false
+	return 0, nil, false
+}
+
+func (bj ByteJson) isPersistedBit() bool {
+	if bj.Type != TpCodeBlob {
+		return false
 	}
-	encoded := rest[colon+1:]
-	if _, ok := base64DecodedLen(encoded); !ok {
-		return 0, nil, false
+	payload := bj.GetString()
+	if fieldType, encoded, ok := mysqlOpaqueValue(payload); ok {
+		if fieldType != 16 {
+			return false
+		}
+		_, valid := base64DecodedLen(encoded)
+		return valid
 	}
-	return uint8(fieldType), encoded, true
+	if !bytes.HasPrefix(payload, []byte(persistedBitPrefix)) {
+		return false
+	}
+	_, valid := base64DecodedLen(payload[len(persistedBitPrefix):])
+	return valid
 }
 
 func (bj ByteJson) persistedBitPayload() ([]byte, bool) {
@@ -556,10 +593,12 @@ const (
 )
 
 type binaryJSONValueView struct {
-	subtype       binaryJSONSubtype
-	rawPayload    []byte
-	legacyEncoded []byte
-	fallbackRaw   []byte
+	subtype         binaryJSONSubtype
+	rawPayload      []byte
+	legacyEncoded   []byte
+	fallbackRaw     []byte
+	needsValidation bool
+	forceRaw        bool
 }
 
 func binaryJSONValue(bj ByteJson) (binaryJSONValueView, bool) {
@@ -568,19 +607,20 @@ func binaryJSONValue(bj ByteJson) (binaryJSONValueView, bool) {
 		payload := bj.GetString()
 		if fieldType, encoded, ok := mysqlOpaqueValue(payload); ok {
 			return binaryJSONValueView{
-				subtype:       binaryJSONSubtype(fieldType),
-				legacyEncoded: encoded,
-				fallbackRaw:   payload,
+				subtype:         binaryJSONSubtype(fieldType),
+				legacyEncoded:   encoded,
+				fallbackRaw:     payload,
+				needsValidation: true,
 			}, true
 		}
 		if bytes.HasPrefix(payload, []byte(persistedBitPrefix)) {
 			encoded := payload[len(persistedBitPrefix):]
-			if _, ok := base64DecodedLen(encoded); ok {
-				return binaryJSONValueView{
-					subtype:       binaryJSONBit,
-					legacyEncoded: encoded,
-				}, true
-			}
+			return binaryJSONValueView{
+				subtype:         binaryJSONBit,
+				legacyEncoded:   encoded,
+				fallbackRaw:     payload,
+				needsValidation: true,
+			}, true
 		}
 		return binaryJSONValueView{
 			subtype:       binaryJSONBlob,
@@ -602,6 +642,58 @@ func binaryJSONValue(bj ByteJson) (binaryJSONValueView, bool) {
 	}
 }
 
+func resolveBinaryJSONValue(value binaryJSONValueView) binaryJSONValueView {
+	if !value.needsValidation {
+		return value
+	}
+	if _, ok := base64DecodedLen(value.legacyEncoded); ok {
+		value.needsValidation = false
+		return value
+	}
+	return binaryJSONValueView{
+		subtype:       binaryJSONBlob,
+		legacyEncoded: value.fallbackRaw,
+		fallbackRaw:   value.fallbackRaw,
+		forceRaw:      true,
+	}
+}
+
+func binaryJSONFallbackBytes(value binaryJSONValueView) []byte {
+	if value.fallbackRaw != nil {
+		return value.fallbackRaw
+	}
+	if value.legacyEncoded != nil {
+		return value.legacyEncoded
+	}
+	return value.rawPayload
+}
+
+func compareBinaryJSONValues(left, right binaryJSONValueView) (int, bool) {
+	if left.subtype != right.subtype {
+		return int(left.subtype) - int(right.subtype), true
+	}
+	if left.forceRaw || right.forceRaw {
+		return bytes.Compare(binaryJSONFallbackBytes(left), binaryJSONFallbackBytes(right)), true
+	}
+	switch {
+	case left.legacyEncoded != nil && right.legacyEncoded != nil:
+		if cmp, ok := compareDecodedBase64Payloads(left.legacyEncoded, right.legacyEncoded); ok {
+			return cmp, true
+		}
+	case left.legacyEncoded != nil:
+		if cmp, ok := compareDecodedBase64WithRaw(left.legacyEncoded, right.rawPayload); ok {
+			return cmp, true
+		}
+	case right.legacyEncoded != nil:
+		if cmp, ok := compareDecodedBase64WithRaw(right.legacyEncoded, left.rawPayload); ok {
+			return -cmp, true
+		}
+	default:
+		return bytes.Compare(left.rawPayload, right.rawPayload), true
+	}
+	return bytes.Compare(binaryJSONFallbackBytes(left), binaryJSONFallbackBytes(right)), false
+}
+
 // CompareBinaryJSON compares opaque JSON values by their MySQL subtype and
 // original bytes. TpCodeBlob is the legacy BLOB encoding and aliases Opaque.
 func CompareBinaryJSON(left, right ByteJson) (int, bool) {
@@ -610,28 +702,17 @@ func CompareBinaryJSON(left, right ByteJson) (int, bool) {
 	if !leftOK || !rightOK {
 		return 0, false
 	}
-	if leftValue.subtype != rightValue.subtype {
-		return int(leftValue.subtype) - int(rightValue.subtype), true
+	if leftValue.needsValidation || rightValue.needsValidation {
+		if leftValue.subtype == rightValue.subtype {
+			if cmp, ok := compareBinaryJSONValues(leftValue, rightValue); ok {
+				return cmp, true
+			}
+		}
+		leftValue = resolveBinaryJSONValue(leftValue)
+		rightValue = resolveBinaryJSONValue(rightValue)
 	}
-	switch {
-	case leftValue.legacyEncoded != nil && rightValue.legacyEncoded != nil:
-		if cmp, ok := compareDecodedBase64Payloads(leftValue.legacyEncoded, rightValue.legacyEncoded); ok {
-			return cmp, true
-		}
-		return bytes.Compare(leftValue.fallbackRaw, rightValue.fallbackRaw), true
-	case leftValue.legacyEncoded != nil:
-		if cmp, ok := compareDecodedBase64WithRaw(leftValue.legacyEncoded, rightValue.rawPayload); ok {
-			return cmp, true
-		}
-		return bytes.Compare(leftValue.fallbackRaw, rightValue.rawPayload), true
-	case rightValue.legacyEncoded != nil:
-		if cmp, ok := compareDecodedBase64WithRaw(rightValue.legacyEncoded, leftValue.rawPayload); ok {
-			return -cmp, true
-		}
-		return bytes.Compare(leftValue.rawPayload, rightValue.fallbackRaw), true
-	default:
-		return bytes.Compare(leftValue.rawPayload, rightValue.rawPayload), true
-	}
+	cmp, _ := compareBinaryJSONValues(leftValue, rightValue)
+	return cmp, true
 }
 
 // BinaryJSONPayloadLen returns the decoded byte length of an opaque JSON
@@ -679,11 +760,11 @@ func AppendCanonicalBinary(dst []byte, bj ByteJson) ([]byte, bool) {
 	if !ok {
 		return dst, false
 	}
+	start := len(dst)
 	dst = append(dst, canonicalBinaryMarker, byte(value.subtype))
 	if value.legacyEncoded == nil {
 		return append(dst, value.rawPayload...), true
 	}
-	start := len(dst)
 	var decodedBuffer [binaryJSONCompareDecodedChunkSize]byte
 	for offset := 0; offset < len(value.legacyEncoded); {
 		n, nextOffset, decoded := decodeBase64Chunk(
@@ -693,6 +774,7 @@ func AppendCanonicalBinary(dst []byte, bj ByteJson) ([]byte, bool) {
 		)
 		if !decoded {
 			dst = dst[:start]
+			dst = append(dst, canonicalBinaryMarker, byte(binaryJSONBlob))
 			return append(dst, value.fallbackRaw...), true
 		}
 		dst = append(dst, decodedBuffer[:n]...)

--- a/pkg/container/bytejson/bytejson.go
+++ b/pkg/container/bytejson/bytejson.go
@@ -598,7 +598,6 @@ type binaryJSONValueView struct {
 	legacyEncoded   []byte
 	fallbackRaw     []byte
 	needsValidation bool
-	forceRaw        bool
 }
 
 func binaryJSONValue(bj ByteJson) (binaryJSONValueView, bool) {
@@ -651,10 +650,8 @@ func resolveBinaryJSONValue(value binaryJSONValueView) binaryJSONValueView {
 		return value
 	}
 	return binaryJSONValueView{
-		subtype:       binaryJSONBlob,
-		legacyEncoded: value.fallbackRaw,
-		fallbackRaw:   value.fallbackRaw,
-		forceRaw:      true,
+		subtype:    binaryJSONBlob,
+		rawPayload: value.fallbackRaw,
 	}
 }
 
@@ -671,9 +668,6 @@ func binaryJSONFallbackBytes(value binaryJSONValueView) []byte {
 func compareBinaryJSONValues(left, right binaryJSONValueView) (int, bool) {
 	if left.subtype != right.subtype {
 		return int(left.subtype) - int(right.subtype), true
-	}
-	if left.forceRaw || right.forceRaw {
-		return bytes.Compare(binaryJSONFallbackBytes(left), binaryJSONFallbackBytes(right)), true
 	}
 	switch {
 	case left.legacyEncoded != nil && right.legacyEncoded != nil:

--- a/pkg/container/bytejson/bytejson_compare_test.go
+++ b/pkg/container/bytejson/bytejson_compare_test.go
@@ -63,6 +63,28 @@ func TestCompareByteJsonOpaqueBinaryUsesRawBytes(t *testing.T) {
 	require.Equal(t, `"AA=="`, zero.String())
 	require.Equal(t, "AA==", mustUnquote(t, zero))
 	require.Equal(t, "AQ==", mustUnquote(t, bit))
+	require.Zero(t, CompareByteJson(NewMySQLOpaque(16, []byte{0x01}), bit))
+}
+
+func TestCompareByteJsonMySQLOpaqueUsesFieldTypeAndRawBytes(t *testing.T) {
+	varbinary := NewMySQLOpaque(15, []byte{0x00})
+	varbinaryNext := NewMySQLOpaque(15, []byte{0x01})
+	blob := NewMySQLOpaque(252, []byte{0x00})
+	legacyBlob := makeBinaryJson(TpCodeBlob, []byte("AA=="))
+	legacyOpaque := makeBinaryJson(TpCodeOpaque, []byte{0x00})
+
+	require.Less(t, CompareByteJson(varbinary, varbinaryNext), 0)
+	require.Less(t, CompareByteJson(varbinary, blob), 0)
+	require.Zero(t, CompareByteJson(blob, legacyBlob))
+	require.Zero(t, CompareByteJson(blob, legacyOpaque))
+	varbinaryKey, ok := AppendCanonicalBinary(nil, varbinary)
+	require.True(t, ok)
+	blobKey, ok := AppendCanonicalBinary(nil, blob)
+	require.True(t, ok)
+	require.NotEqual(t, varbinaryKey, blobKey)
+	blobSize, ok := CanonicalBinarySize(blob)
+	require.True(t, ok)
+	require.Equal(t, blobSize, len(blobKey))
 }
 
 func TestCompareByteJsonLegacyBlobLargePayloadAllocations(t *testing.T) {
@@ -174,9 +196,9 @@ func TestCompareByteJson_DecimalCrossType(t *testing.T) {
 }
 
 // TestCompareByteJson_Int64Uint64CrossType verifies that INT64-vs-UINT64
-// comparisons are handled correctly even though both report TYPE()="INTEGER"
-// (same jsonTpOrder).  Without the cross-type check, the same-type branch
-// would use the wrong accessor.
+// comparisons are handled correctly even though both share one numeric type
+// order. Without the cross-type check, the same-type branch would use the
+// wrong accessor.
 func TestCompareByteJson_Int64Uint64CrossType(t *testing.T) {
 	// INT64 == small UINT64
 	require.Equal(t, 0, CompareByteJson(makeJson(t, "42"), makeJson(t, "42")))

--- a/pkg/container/bytejson/bytejson_compare_test.go
+++ b/pkg/container/bytejson/bytejson_compare_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/defines"
 )
 
 func makeJson(t *testing.T, s string) ByteJson {
@@ -46,6 +48,13 @@ func makeBinaryJson(tp TpCode, payload []byte) ByteJson {
 	return ByteJson{Type: tp, Data: data[:n+len(payload)]}
 }
 
+func makeMySQLOpaque(t *testing.T, fieldType uint8, payload []byte) ByteJson {
+	t.Helper()
+	value, err := NewMySQLOpaque(defines.MORPCLatestVersion, fieldType, payload)
+	require.NoError(t, err)
+	return value
+}
+
 func TestCompareByteJsonOpaqueBinaryUsesRawBytes(t *testing.T) {
 	zero := makeBinaryJson(TpCodeOpaque, []byte{0x00})
 	d0 := makeBinaryJson(TpCodeOpaque, []byte{0xd0})
@@ -63,13 +72,13 @@ func TestCompareByteJsonOpaqueBinaryUsesRawBytes(t *testing.T) {
 	require.Equal(t, `"AA=="`, zero.String())
 	require.Equal(t, "AA==", mustUnquote(t, zero))
 	require.Equal(t, "AQ==", mustUnquote(t, bit))
-	require.Zero(t, CompareByteJson(NewMySQLOpaque(16, []byte{0x01}), bit))
+	require.Zero(t, CompareByteJson(makeMySQLOpaque(t, 16, []byte{0x01}), bit))
 }
 
 func TestCompareByteJsonMySQLOpaqueUsesFieldTypeAndRawBytes(t *testing.T) {
-	varbinary := NewMySQLOpaque(15, []byte{0x00})
-	varbinaryNext := NewMySQLOpaque(15, []byte{0x01})
-	blob := NewMySQLOpaque(252, []byte{0x00})
+	varbinary := makeMySQLOpaque(t, 15, []byte{0x00})
+	varbinaryNext := makeMySQLOpaque(t, 15, []byte{0x01})
+	blob := makeMySQLOpaque(t, 252, []byte{0x00})
 	legacyBlob := makeBinaryJson(TpCodeBlob, []byte("AA=="))
 	legacyOpaque := makeBinaryJson(TpCodeOpaque, []byte{0x00})
 
@@ -87,6 +96,16 @@ func TestCompareByteJsonMySQLOpaqueUsesFieldTypeAndRawBytes(t *testing.T) {
 	require.Equal(t, blobSize, len(blobKey))
 }
 
+func TestCompareByteJsonMalformedMySQLOpaqueTagFallsBackToBlob(t *testing.T) {
+	malformed := makeBinaryJson(TpCodeBlob, []byte("base64:type16:not-base64"))
+
+	require.Equal(t, "BLOB", malformed.TYPE())
+	require.NotZero(t, CompareByteJson(malformed, makeBinaryJson(TpCodeBit, []byte{0x00})))
+	key, ok := AppendCanonicalBinary(nil, malformed)
+	require.True(t, ok)
+	require.Equal(t, []byte{canonicalBinaryMarker, byte(binaryJSONBlob)}, key[:2])
+}
+
 func TestCompareByteJsonLegacyBlobLargePayloadAllocations(t *testing.T) {
 	payload := bytes.Repeat([]byte{0xab}, 1<<20)
 	legacy := makeBinaryJson(TpCodeBlob, []byte(base64.StdEncoding.EncodeToString(payload)))
@@ -98,6 +117,19 @@ func TestCompareByteJsonLegacyBlobLargePayloadAllocations(t *testing.T) {
 		}
 	})
 	require.Zero(t, allocs, "legacy blob compare should not allocate decoded payload buffers")
+}
+
+func TestCompareByteJsonMySQLOpaqueLargePayloadAllocations(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xab}, 1<<20)
+	left := makeBinaryJson(TpCodeBlob, []byte(mysqlOpaqueText(252, payload)))
+	right := makeBinaryJson(TpCodeBlob, []byte(mysqlOpaqueText(252, payload)))
+
+	allocs := testing.AllocsPerRun(10, func() {
+		if cmp := CompareByteJson(left, right); cmp != 0 {
+			t.Fatalf("unexpected compare result: %d", cmp)
+		}
+	})
+	require.Zero(t, allocs, "tagged blob compare should not allocate decoded payload buffers")
 }
 
 func TestCompareByteJsonLegacyBlobPreservesBase64Newlines(t *testing.T) {
@@ -128,6 +160,20 @@ func BenchmarkCompareByteJsonLegacyBlobLargePayload(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if cmp := CompareByteJson(legacyLeft, legacyRight); cmp != 0 {
+			b.Fatalf("unexpected compare result: %d", cmp)
+		}
+	}
+}
+
+func BenchmarkCompareByteJsonMySQLOpaqueLargePayload(b *testing.B) {
+	payload := bytes.Repeat([]byte{0xcd}, 1<<20)
+	left := makeBinaryJson(TpCodeBlob, []byte(mysqlOpaqueText(252, payload)))
+	right := makeBinaryJson(TpCodeBlob, []byte(mysqlOpaqueText(252, payload)))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if cmp := CompareByteJson(left, right); cmp != 0 {
 			b.Fatalf("unexpected compare result: %d", cmp)
 		}
 	}

--- a/pkg/container/bytejson/bytejson_compare_test.go
+++ b/pkg/container/bytejson/bytejson_compare_test.go
@@ -113,7 +113,7 @@ func TestCompareByteJsonMalformedBinaryPreservesCanonicalEquivalence(t *testing.
 	} {
 		t.Run(stored, func(t *testing.T) {
 			malformed := makeBinaryJson(TpCodeBlob, []byte(stored))
-			valid, err := NewMySQLOpaque(defines.MORPCVersion51, 252, []byte(stored))
+			valid, err := NewMySQLOpaque(defines.MORPCVersion52, 252, []byte(stored))
 			require.NoError(t, err)
 
 			require.Zero(t, CompareByteJson(malformed, valid))

--- a/pkg/container/bytejson/bytejson_compare_test.go
+++ b/pkg/container/bytejson/bytejson_compare_test.go
@@ -106,6 +106,37 @@ func TestCompareByteJsonMalformedMySQLOpaqueTagFallsBackToBlob(t *testing.T) {
 	require.Equal(t, []byte{canonicalBinaryMarker, byte(binaryJSONBlob)}, key[:2])
 }
 
+func TestCompareByteJsonMalformedBinaryPreservesCanonicalEquivalence(t *testing.T) {
+	for _, stored := range []string{
+		"base64:type16:not-base64",
+		"base64:type252:not-base64",
+	} {
+		t.Run(stored, func(t *testing.T) {
+			malformed := makeBinaryJson(TpCodeBlob, []byte(stored))
+			valid, err := NewMySQLOpaque(defines.MORPCVersion50, 252, []byte(stored))
+			require.NoError(t, err)
+
+			require.Zero(t, CompareByteJson(malformed, valid))
+			require.Zero(t, CompareByteJson(valid, malformed))
+			malformedKey, ok := AppendCanonicalBinary(nil, malformed)
+			require.True(t, ok)
+			validKey, ok := AppendCanonicalBinary(nil, valid)
+			require.True(t, ok)
+			require.Equal(t, malformedKey, validKey)
+		})
+	}
+
+	legacyMalformed := makeBinaryJson(TpCodeBlob, []byte("not-base64"))
+	raw := makeBinaryJson(TpCodeOpaque, []byte("not-base64"))
+	require.Zero(t, CompareByteJson(legacyMalformed, raw))
+	require.Zero(t, CompareByteJson(raw, legacyMalformed))
+	legacyKey, ok := AppendCanonicalBinary(nil, legacyMalformed)
+	require.True(t, ok)
+	rawKey, ok := AppendCanonicalBinary(nil, raw)
+	require.True(t, ok)
+	require.Equal(t, legacyKey, rawKey)
+}
+
 func TestCompareByteJsonLegacyBlobLargePayloadAllocations(t *testing.T) {
 	payload := bytes.Repeat([]byte{0xab}, 1<<20)
 	legacy := makeBinaryJson(TpCodeBlob, []byte(base64.StdEncoding.EncodeToString(payload)))

--- a/pkg/container/bytejson/bytejson_compare_test.go
+++ b/pkg/container/bytejson/bytejson_compare_test.go
@@ -113,7 +113,7 @@ func TestCompareByteJsonMalformedBinaryPreservesCanonicalEquivalence(t *testing.
 	} {
 		t.Run(stored, func(t *testing.T) {
 			malformed := makeBinaryJson(TpCodeBlob, []byte(stored))
-			valid, err := NewMySQLOpaque(defines.MORPCVersion50, 252, []byte(stored))
+			valid, err := NewMySQLOpaque(defines.MORPCVersion51, 252, []byte(stored))
 			require.NoError(t, err)
 
 			require.Zero(t, CompareByteJson(malformed, valid))

--- a/pkg/container/bytejson/bytejson_test.go
+++ b/pkg/container/bytejson/bytejson_test.go
@@ -136,7 +136,7 @@ func TestMySQLOpaqueTaggedValue(t *testing.T) {
 }
 
 func TestMySQLOpaqueRequiresRollingUpgradeAdmission(t *testing.T) {
-	require.Equal(t, int64(defines.MORPCVersion51), MySQLOpaqueProtocolVersion)
+	require.Equal(t, int64(defines.MORPCVersion52), MySQLOpaqueProtocolVersion)
 
 	_, err := NewMySQLOpaque(defines.MORPCVersion49, 252, []byte{0x00})
 	require.ErrorContains(t, err, "MORPC protocol version "+strconv.FormatInt(MySQLOpaqueProtocolVersion, 10))

--- a/pkg/container/bytejson/bytejson_test.go
+++ b/pkg/container/bytejson/bytejson_test.go
@@ -136,7 +136,7 @@ func TestMySQLOpaqueTaggedValue(t *testing.T) {
 }
 
 func TestMySQLOpaqueRequiresRollingUpgradeAdmission(t *testing.T) {
-	require.Equal(t, int64(defines.MORPCVersion50), MySQLOpaqueProtocolVersion)
+	require.Equal(t, int64(defines.MORPCVersion51), MySQLOpaqueProtocolVersion)
 
 	_, err := NewMySQLOpaque(defines.MORPCVersion49, 252, []byte{0x00})
 	require.ErrorContains(t, err, "MORPC protocol version "+strconv.FormatInt(MySQLOpaqueProtocolVersion, 10))

--- a/pkg/container/bytejson/bytejson_test.go
+++ b/pkg/container/bytejson/bytejson_test.go
@@ -136,8 +136,10 @@ func TestMySQLOpaqueTaggedValue(t *testing.T) {
 }
 
 func TestMySQLOpaqueRequiresRollingUpgradeAdmission(t *testing.T) {
-	_, err := NewMySQLOpaque(defines.MORPCVersion45, 252, []byte{0x00})
-	require.ErrorContains(t, err, "MORPC protocol version 46")
+	require.Equal(t, int64(defines.MORPCVersion50), MySQLOpaqueProtocolVersion)
+
+	_, err := NewMySQLOpaque(defines.MORPCVersion49, 252, []byte{0x00})
+	require.ErrorContains(t, err, "MORPC protocol version "+strconv.FormatInt(MySQLOpaqueProtocolVersion, 10))
 
 	value, err := NewMySQLOpaque(MySQLOpaqueProtocolVersion, 252, []byte{0x00})
 	require.NoError(t, err)

--- a/pkg/container/bytejson/bytejson_test.go
+++ b/pkg/container/bytejson/bytejson_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/defines"
 )
 
 func TestMarshalBinarySubtypesRemainLegacyReadable(t *testing.T) {
@@ -109,7 +111,8 @@ func TestMySQLOpaqueTaggedValue(t *testing.T) {
 		{name: "binary", fieldType: 254, want: "base64:type254:AP9B"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			value := NewMySQLOpaque(tc.fieldType, payload)
+			value, err := NewMySQLOpaque(defines.MORPCLatestVersion, tc.fieldType, payload)
+			require.NoError(t, err)
 			require.Equal(t, TpCodeBlob, value.Type)
 			wantType := "BLOB"
 			if tc.fieldType == 16 {
@@ -130,6 +133,28 @@ func TestMySQLOpaqueTaggedValue(t *testing.T) {
 			require.Equal(t, value.String(), restored.String())
 		})
 	}
+}
+
+func TestMySQLOpaqueRequiresRollingUpgradeAdmission(t *testing.T) {
+	_, err := NewMySQLOpaque(defines.MORPCVersion45, 252, []byte{0x00})
+	require.ErrorContains(t, err, "MORPC protocol version 46")
+
+	value, err := NewMySQLOpaque(MySQLOpaqueProtocolVersion, 252, []byte{0x00})
+	require.NoError(t, err)
+	require.Equal(t, `"base64:type252:AA=="`, value.String())
+}
+
+func TestMySQLOpaqueTypeDoesNotAllocatePayload(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x01}, 1<<20)
+	value, err := NewMySQLOpaque(defines.MORPCLatestVersion, 16, payload)
+	require.NoError(t, err)
+
+	allocs := testing.AllocsPerRun(10, func() {
+		if typ := value.TYPE(); typ != "BIT" {
+			t.Fatalf("unexpected type: %s", typ)
+		}
+	})
+	require.Zero(t, allocs, "tagged BIT TYPE should not materialize the payload")
 }
 
 func TestUint64TypeRemainsInteger(t *testing.T) {

--- a/pkg/container/bytejson/bytejson_test.go
+++ b/pkg/container/bytejson/bytejson_test.go
@@ -96,6 +96,48 @@ func TestMarshalBinarySubtypesRemainLegacyReadable(t *testing.T) {
 	}
 }
 
+func TestMySQLOpaqueTaggedValue(t *testing.T) {
+	payload := []byte{0x00, 0xff, 0x41}
+	for _, tc := range []struct {
+		name      string
+		fieldType uint8
+		want      string
+	}{
+		{name: "varbinary", fieldType: 15, want: "base64:type15:AP9B"},
+		{name: "bit", fieldType: 16, want: "base64:type16:AP9B"},
+		{name: "blob", fieldType: 252, want: "base64:type252:AP9B"},
+		{name: "binary", fieldType: 254, want: "base64:type254:AP9B"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			value := NewMySQLOpaque(tc.fieldType, payload)
+			require.Equal(t, TpCodeBlob, value.Type)
+			wantType := "BLOB"
+			if tc.fieldType == 16 {
+				wantType = "BIT"
+			}
+			require.Equal(t, wantType, value.TYPE())
+			require.Equal(t, strconv.Quote(tc.want), value.String())
+			require.Equal(t, tc.want, mustUnquote(t, value))
+			length, ok := BinaryJSONPayloadLen(value)
+			require.True(t, ok)
+			require.Equal(t, len(payload), length)
+
+			stored, err := value.Marshal()
+			require.NoError(t, err)
+			requireLegacyJSONReadable(t, stored)
+			var restored ByteJson
+			require.NoError(t, restored.Unmarshal(stored))
+			require.Equal(t, value.String(), restored.String())
+		})
+	}
+}
+
+func TestUint64TypeRemainsInteger(t *testing.T) {
+	value, err := CreateByteJSON(uint64(2024))
+	require.NoError(t, err)
+	require.Equal(t, "INTEGER", value.TYPE())
+}
+
 func TestBinaryJSONPayloadLenLegacyBlobLargePayloadAllocations(t *testing.T) {
 	payload := bytes.Repeat([]byte{0xef}, 1<<20)
 	legacy := makeBinaryJson(TpCodeBlob, []byte(base64.StdEncoding.EncodeToString(payload)))

--- a/pkg/container/bytejson/types.go
+++ b/pkg/container/bytejson/types.go
@@ -172,7 +172,7 @@ func (bj ByteJson) TYPE() string {
 	case TpCodeDatetime:
 		return "DATETIME"
 	case TpCodeBlob:
-		if _, ok := bj.persistedBitPayload(); ok {
+		if bj.isPersistedBit() {
 			return "BIT"
 		}
 		return "BLOB"

--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -87,7 +87,8 @@ const (
 	MORPCVersion49     int64 = 49 // vector-level grouping-set projection expansion
 	MORPCVersion50     int64 = 50 // ordered ODKU evaluation and logical affected-row metadata
 	MORPCVersion51     int64 = 51 // per-action ODKU validation and statement-local target arbitration
-	MORPCLatestVersion       = MORPCVersion51
+	MORPCVersion52     int64 = 52 // MySQL binary JSON subtype tags
+	MORPCLatestVersion       = MORPCVersion52
 )
 
 // DefaultLockWaitTimeoutSeconds is shared by the frontend default and by


### PR DESCRIPTION
## What type of PR is this?

<!-- Please delete all options that are not applicable. -->

- [x] Bug fix
- [ ] Feature
- [ ] Engineering

## Which issue(s) this PR fixes:

issue #28057
issue #28058

## What this PR does / why we need it:

Preserves MySQL binary subtypes and raw payload bytes in ByteJson without adding a persistent type code. BINARY, VARBINARY, and BLOB use legacy-readable `TpCodeBlob` values containing `base64:typeN` payloads. New readers accept legacy bare Base64, the prior BIT sentinel, and the new tags.

This update adds the rolling-upgrade admission contract before tagged values are produced: `NewMySQLOpaque` requires the minimum admitted MORPC version (`MORPCVersion50`, following the target's v46-v49 prefix) and rejects older writers before constructing tagged payloads. The stacked SQL constructor PR must pass that explicit admission value.

Tagged payload recognition now parses only the bounded `typeN:` header. Valid tagged terminal operations validate or decode the payload at most once; `TYPE` does not materialize the payload. Malformed tags fail closed as raw BLOB bytes across type inspection, comparison, payload length, and canonicalization.

QA required: yes — this is the storage/representation foundation for a compatibility stack and issues remain open until exact-version QA completes.

Production terminal covered by automation: ByteJson root/nested marshal, vector storage, merge, comparison/hash, payload length, legacy-reader compatibility, rolling-upgrade admission, malformed-tag fallback, and existing CAST constant folding.

## Remaining QA

Mixed-version disk reads and the full constructor SQL surface remain covered by the stacked PRs and tester handoff. The local CGo-transitive `pkg/sql/plan/function` check must be rerun when the native `cgo/libmo.dylib` prerequisite is available; the direct bytejson/vector/defines/keycodec validation is green.

## Validation:

- Focused exact-layer `go test` for `./pkg/container/bytejson`: PASS, including admission rejection/acceptance, legacy/sentinel compatibility, malformed fallback, and 1 MiB allocation checks.
- `go test` for `./pkg/container/vector`, `./pkg/defines`, and `./pkg/common/hashmap/keycodec`: PASS.
- ByteJson build and `go vet`: PASS.
- Semantic preflight manifest and final self-review: PASS.
- `git diff --check`: PASS.
- CGo-transitive `mo-cgo-test` for `./pkg/sql/plan/function`: BLOCKED — the isolated environment lacks `cgo/libmo.dylib` and the native third-party prerequisite; no test assertion failed.
- BVT: N/A — this layer exposes the representation/storage primitive; production constructor SQL changes begin in #28093.
- Equivalent regression: ByteJson root/array/object/merge/marshal/vector compatibility tests, protocol admission matrix, malformed-tag fallback, and hot-path allocation tests.
- Fresh CI: pending on pushed head; the prior exact-head Ubuntu UT failure was a runner/TLS setup failure before test execution.

