### PR TITLE
test: remove redundant data branch teardown

### DIFF
--- a/pkg/tests/issues/isolated/issue_26111_test.go
+++ b/pkg/tests/issues/isolated/issue_26111_test.go
@@ -68,20 +68,11 @@ func TestIssue26111DataBranchDatabaseWithCyclicForeignKeys(t *testing.T) {
 		existingTarget = "issue_26111_existing"
 		targetAccount  = "i26111t"
 	)
-	execSQLRequire(t, ctx, db, "drop account if exists `"+targetAccount+"`")
-	execSQLRequire(t, ctx, db, "drop snapshot if exists "+snapshotName)
-	for _, name := range []string{branchDB, snapshotBranch, existingTarget, sourceDB} {
-		execSQLRequire(t, ctx, db, "drop database if exists `"+name+"`")
-	}
-	defer func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cleanupCancel()
-		execSQLMaybe(t, cleanupCtx, db, "drop account if exists `"+targetAccount+"`")
-		execSQLRequire(t, cleanupCtx, db, "drop snapshot if exists "+snapshotName)
-		for _, name := range []string{branchDB, snapshotBranch, existingTarget, sourceDB} {
-			execSQLRequire(t, cleanupCtx, db, "drop database if exists `"+name+"`")
-		}
-	}()
+	// This regression owns a fresh embedded cluster and its private data path.
+	// Closing that cluster makes all SQL state unreachable, so SQL-level pre-clean
+	// and teardown would only duplicate lifecycle ownership. In particular, DROP
+	// ACCOUNT expands with the tenant catalog and can exhaust a shared cleanup
+	// deadline before the remaining objects are visited.
 
 	execSQLRequire(t, ctx, db, "create database `"+sourceDB+"`")
 	execSQLRequire(t, ctx, db, "create table `"+sourceDB+"`.`a` (id int primary key, b_id int)")

--- a/pkg/tests/issues/isolated/issue_26111_test.go
+++ b/pkg/tests/issues/isolated/issue_26111_test.go
@@ -70,8 +70,8 @@ func TestIssue26111DataBranchDatabaseWithCyclicForeignKeys(t *testing.T) {
 	)
 	// This regression owns a fresh embedded cluster and its private data path.
 	// Closing that cluster makes all SQL state unreachable, so SQL-level pre-clean
-	// and teardown would only duplicate lifecycle ownership. In particular, DROP
-	// ACCOUNT expands with the tenant catalog and can exhaust a shared cleanup
+	// and bulk teardown would only duplicate lifecycle ownership. In particular,
+	// DROP ACCOUNT expands with the tenant catalog and can exhaust a shared cleanup
 	// deadline before the remaining objects are visited.
 
 	execSQLRequire(t, ctx, db, "create database `"+sourceDB+"`")
@@ -143,4 +143,8 @@ func TestIssue26111DataBranchDatabaseWithCyclicForeignKeys(t *testing.T) {
 	require.NoError(t, targetDB.QueryRowContext(ctx,
 		"select count(*) from mo_catalog.mo_foreign_keys where db_name = '"+accountBranch+"' and refer_db_name = '"+accountBranch+"'").Scan(&count))
 	require.Equal(t, 2, count)
+
+	// Keep database lifecycle as an explicit product oracle, separate from fixture
+	// cleanup: a branch with restored cyclic foreign keys must remain droppable.
+	execSQLRequire(t, ctx, db, "drop database `"+branchDB+"`")
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Code Refactoring
- [x] Test and CI

## Which issue(s) this PR fixes:

Fixes #28098

## Root cause

`TestIssue26111DataBranchDatabaseWithCyclicForeignKeys` owns a fresh embedded cluster with a unique private data path, but also performed SQL pre-clean and deferred teardown for an account, a snapshot, and four databases.

All deferred SQL cleanup shared one 30-second context. `DROP ACCOUNT` expands into many catalog DDL/DML operations, so its cost grows with the tenant catalog. In the failed CI run, functional assertions completed around 08:17:32; `DROP ACCOUNT` then consumed almost the entire cleanup budget, and the later `DROP DATABASE issue_26111_branch` inherited the expired context and failed. Connection-refused messages appeared only during subsequent cluster shutdown and were downstream noise.

## What this PR does

- Remove fixture pre-clean that cannot be needed in a fresh private cluster.
- Remove scale-dependent bulk SQL teardown; cluster ownership provides fixture isolation.
- Preserve `DROP DATABASE issue_26111_branch` as an explicit product oracle under the main 180-second test context. A branch with restored cyclic foreign keys must remain droppable.

This corrects lifecycle ownership; it does not increase a timeout or add retries.

## Correctness and coverage

The regression still verifies:

- existing-target rejection and restoration of session `foreign_key_checks`;
- current-state and snapshot branches;
- cross-account visibility;
- copied rows and cyclic foreign-key metadata remapping;
- FK enforcement in every created branch;
- duplicate cross-account target rejection without partial mutation;
- successful drop of a branch containing restored cyclic foreign keys.

Snapshot, source, auxiliary target, and account deletion were fixture cleanup rather than contracts of issue #26111. `DROP ACCOUNT` lifecycle behavior remains independently covered by `TestIssue27719DropAccountCleansSQLTaskLifecycle`.

## Risk and unhappy paths

- On any mid-test `FailNow`, opened `sql.DB` handles close through function defers before `t.Cleanup` closes the cluster.
- No later test can observe retained SQL state: `StartTestCluster` allocates a separate cluster and data path for this fixture.
- Body SQL and the explicit branch-drop oracle share the bounded 180-second context.
- Removing the shared cleanup chain removes a wait path whose duration scaled with catalog size.
- No production code, public SQL behavior, retry policy, or global timeout changes.

## Performance

Same machine and focused command:

- baseline: 16.52s;
- revised focused run: 13.03s;
- revised same-process repetitions: 15.93s, 13.08s, 15.88s.

Local steady-state change is small. On the loaded CI runner, this removes the approximately 30-second teardown tail and eliminates its catalog-size sensitivity.

## Validation

- focused test: PASS, 13.03s;
- focused race test: PASS, 19.16s, no race;
- same-process repetition: PASS 3/3;
- owning package `./pkg/tests/issues/isolated`: PASS 7/7, 136.14s;
- `git diff --check`: PASS.
