### PR TITLE
fix(plan): require global ownership for aggregate shuffle reuse

### DIFF
--- a/docs/rfcs/00000000_stats_independent_analytic_plan_rewrites.md
+++ b/docs/rfcs/00000000_stats_independent_analytic_plan_rewrites.md
@@ -281,9 +281,17 @@ only on the right, a computed key, or propagated uniqueness does not qualify.
 ### Shuffle lineage
 
 An exact left distribution may survive a left-preserving join only when the
-next join uses the same bare left key. The proof follows explicit column
+next consumer uses the same bare left key. The proof follows explicit column
 lineage after final remapping. Right/build lineage, changed or computed keys,
 ambiguous projections, and RIGHT/FULL joins force the existing reshuffle.
+
+Distribution scope is part of that proof. A simple multi-CN shuffle gives one
+cluster-global owner for each key and may be reused by an aggregate on the same
+key. A hybrid join keeps probe rows partitioned only within their originating
+CN; another hybrid join may reuse that local partition because its build side
+is delivered to every CN's matching bucket, but an aggregate must reshuffle to
+establish cluster-global key ownership. Exact key lineage alone never upgrades
+local ownership to global ownership.
 
 ## Compatibility and security
 

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -418,7 +418,7 @@ func reusableShuffleChild(
 		return nil, false
 	}
 	child := builder.qry.Nodes[childID]
-	if reusableJoinShuffleChild(col, child, builder, afterRemap) {
+	if reusableJoinShuffleChild(col, node, child, builder, afterRemap) {
 		return child, true
 	}
 	if child == nil || child.NodeType != plan.Node_AGG || child.Stats == nil ||
@@ -454,25 +454,37 @@ func reusableShuffleChild(
 	return child, true
 }
 
-// reusableJoinShuffleChild proves distribution lineage through a join whose
-// output preserves its logical left rows. A shuffled join remains partitioned
-// by its left equality key, so a following join on that exact output key can
-// reuse the distribution instead of falling back to a broadcast build.
+// reusableJoinShuffleChild proves both distribution lineage through a join and
+// that the resulting ownership scope satisfies the consumer. A shuffled join
+// remains partitioned by its logical-left equality key. Hybrid shuffle owns
+// that key only within each CN: another join can reuse it because its build side
+// is sent to every CN's matching bucket, but an aggregate needs one owner for
+// the key across the whole cluster.
 //
 // Keep this deliberately narrower than general equivalence propagation:
 // right/full preserving joins, expressions, and keys projected from the build
 // side fail closed because unmatched rows do not preserve those properties.
 func reusableJoinShuffleChild(
 	col *plan.ColRef,
+	consumer *plan.Node,
 	child *plan.Node,
 	builder *QueryBuilder,
 	afterRemap bool,
 ) bool {
-	if col == nil || child == nil || builder == nil || builder.qry == nil ||
-		builder.outerAntiPlanningDisabled() ||
+	if col == nil || consumer == nil || child == nil || builder == nil || builder.qry == nil ||
 		child.NodeType != plan.Node_JOIN || child.IsRightJoin ||
 		child.Stats == nil || child.Stats.HashmapStats == nil ||
 		!child.Stats.HashmapStats.Shuffle {
+		return false
+	}
+	// Join-chain lineage reuse belongs to the outer/ANTI rollout cohort.
+	// Aggregate reuse predates that cohort and keeps its established rollback
+	// behavior, subject to the stricter ownership check below.
+	if consumer.NodeType == plan.Node_JOIN && builder.outerAntiPlanningDisabled() {
+		return false
+	}
+	if consumer.NodeType == plan.Node_AGG &&
+		child.Stats.HashmapStats.ShuffleTypeForMultiCN == plan.ShuffleTypeForMultiCN_Hybrid {
 		return false
 	}
 	switch child.JoinType {
@@ -1365,26 +1377,6 @@ func determineShuffleForGroupBy(node *plan.Node, builder *QueryBuilder) {
 		}
 	}
 
-	//shuffle join-> shuffle group ,if they use the same hask key, the group can reuse the shuffle method
-	if child.NodeType == plan.Node_JOIN {
-		if node.Stats.HashmapStats.Shuffle && child.Stats.HashmapStats.Shuffle {
-			// shuffle group can reuse shuffle join
-			if node.Stats.HashmapStats.ShuffleType == child.Stats.HashmapStats.ShuffleType && node.Stats.HashmapStats.ShuffleTypeForMultiCN == child.Stats.HashmapStats.ShuffleTypeForMultiCN {
-				groupHashCol, _ := GetHashColumn(node.GroupBy[node.Stats.HashmapStats.ShuffleColIdx])
-				switch exprImpl := child.OnList[child.Stats.HashmapStats.ShuffleColIdx].Expr.(type) {
-				case *plan.Expr_F:
-					for _, arg := range exprImpl.F.Args {
-						joinHashCol, _ := GetHashColumn(arg)
-						if joinHashCol != nil && groupHashCol != nil && groupHashCol.RelPos == joinHashCol.RelPos && groupHashCol.ColPos == joinHashCol.ColPos {
-							node.Stats.HashmapStats.ShuffleMethod = plan.ShuffleMethod_Reuse
-							return
-						}
-					}
-				}
-			}
-		}
-	}
-
 }
 
 func countDistinctStateNDV(node *plan.Node, builder *QueryBuilder) float64 {
@@ -1581,7 +1573,11 @@ func determineShuffleMethod2(nodeID, parentID int32, builder *QueryBuilder) {
 
 	if node.NodeType == plan.Node_JOIN && node.Stats.HashmapStats.ShuffleTypeForMultiCN == plan.ShuffleTypeForMultiCN_Hybrid {
 		if parent.NodeType == plan.Node_AGG && parent.Stats.HashmapStats.ShuffleMethod == plan.ShuffleMethod_Reuse {
-			return
+			// Hybrid keeps the probe key local to each CN. It can feed another
+			// hybrid join, but a grouped aggregate needs one cluster-global owner
+			// for every key. Normalize stale or future invalid reuse decisions.
+			parent.Stats.HashmapStats.ShuffleMethod = plan.ShuffleMethod_Normal
+			parent.Stats.HashmapStats.ShuffleTypeForMultiCN = plan.ShuffleTypeForMultiCN_Simple
 		}
 		if node.Stats.HashmapStats.HashmapSize <= threshHoldForHybirdShuffle {
 			node.Stats.HashmapStats.Shuffle = false

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -1121,6 +1121,19 @@ func TestDetermineShuffleForJoinReusesLeftKeyThroughJoinChain(t *testing.T) {
 		require.Equal(t, plan.ShuffleType_Range, parent.Stats.HashmapStats.ShuffleType)
 	})
 
+	t.Run("following join may reuse hybrid local ownership", func(t *testing.T) {
+		builder, parent := makeChildJoin(plan.Node_LEFT)
+		builder.qry.Nodes[2].Stats.HashmapStats.ShuffleTypeForMultiCN =
+			plan.ShuffleTypeForMultiCN_Hybrid
+
+		determineShuffleForJoin(parent, builder)
+
+		require.True(t, parent.Stats.HashmapStats.Shuffle)
+		require.Equal(t, plan.ShuffleMethod_Reuse, parent.Stats.HashmapStats.ShuffleMethod)
+		require.Equal(t, plan.ShuffleTypeForMultiCN_Hybrid,
+			parent.Stats.HashmapStats.ShuffleTypeForMultiCN)
+	})
+
 	t.Run("full join does not preserve one side as a distribution key", func(t *testing.T) {
 		builder, parent := makeChildJoin(plan.Node_OUTER)
 
@@ -1173,11 +1186,161 @@ func TestReusableJoinShuffleChildAfterRemap(t *testing.T) {
 		makeShuffleJoinTestChild(10, 1),
 		makeShuffleJoinTestChild(20, 1),
 	}}}
+	consumer := &plan.Node{NodeType: plan.Node_JOIN}
 
 	require.True(t, reusableJoinShuffleChild(
-		&plan.ColRef{RelPos: 0, ColPos: 0}, child, builder, true))
+		&plan.ColRef{RelPos: 0, ColPos: 0}, consumer, child, builder, true))
 	require.False(t, reusableJoinShuffleChild(
-		&plan.ColRef{RelPos: 0, ColPos: 1}, child, builder, true))
+		&plan.ColRef{RelPos: 0, ColPos: 1}, consumer, child, builder, true))
+}
+
+func TestDetermineShuffleForGroupByRequiresGlobalJoinOwnership(t *testing.T) {
+	tests := []struct {
+		name        string
+		multiCN     plan.ShuffleTypeForMultiCN
+		groupRel    int32
+		rollback    bool
+		wantMethod  plan.ShuffleMethod
+		wantMultiCN plan.ShuffleTypeForMultiCN
+	}{
+		{
+			name:        "hybrid left key is only locally partitioned",
+			multiCN:     plan.ShuffleTypeForMultiCN_Hybrid,
+			groupRel:    10,
+			wantMethod:  plan.ShuffleMethod_Normal,
+			wantMultiCN: plan.ShuffleTypeForMultiCN_Simple,
+		},
+		{
+			name:        "simple left key has global ownership",
+			multiCN:     plan.ShuffleTypeForMultiCN_Simple,
+			groupRel:    10,
+			wantMethod:  plan.ShuffleMethod_Reuse,
+			wantMultiCN: plan.ShuffleTypeForMultiCN_Simple,
+		},
+		{
+			name:        "rollback keeps established global aggregate reuse",
+			multiCN:     plan.ShuffleTypeForMultiCN_Simple,
+			groupRel:    10,
+			rollback:    true,
+			wantMethod:  plan.ShuffleMethod_Reuse,
+			wantMultiCN: plan.ShuffleTypeForMultiCN_Simple,
+		},
+		{
+			name:        "nullable build key does not preserve ownership",
+			multiCN:     plan.ShuffleTypeForMultiCN_Simple,
+			groupRel:    20,
+			wantMethod:  plan.ShuffleMethod_Normal,
+			wantMultiCN: plan.ShuffleTypeForMultiCN_Simple,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			left := makeShuffleJoinTestChild(10, 10_000_000)
+			right := makeShuffleJoinTestChild(20, 3_000_000)
+			childJoin := &plan.Node{
+				NodeId:   2,
+				NodeType: plan.Node_JOIN,
+				JoinType: plan.Node_LEFT,
+				Children: []int32{0, 1},
+				OnList: []*plan.Expr{
+					makeShuffleJoinEquality(t, types.T_int64, 100_000, 10, 20, 0),
+				},
+				Stats: &plan.Stats{
+					Outcnt:      10_000_000,
+					Selectivity: 1,
+					HashmapStats: &plan.HashMapStats{
+						Shuffle:               true,
+						ShuffleColIdx:         0,
+						ShuffleType:           plan.ShuffleType_Hash,
+						ShuffleTypeForMultiCN: tt.multiCN,
+					},
+				},
+			}
+			agg := &plan.Node{
+				NodeId:   3,
+				NodeType: plan.Node_AGG,
+				Children: []int32{2},
+				GroupBy: []*plan.Expr{{
+					Typ:  plan.Type{Id: int32(types.T_int64)},
+					Ndv:  100_000,
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: tt.groupRel, ColPos: 0}},
+				}},
+				Stats: &plan.Stats{
+					Outcnt:      10_000_000,
+					Selectivity: 1,
+					HashmapStats: &plan.HashMapStats{
+						HashmapSize: 3_000_000,
+					},
+				},
+			}
+			builder := &QueryBuilder{qry: &plan.Query{Nodes: []*plan.Node{
+				left, right, childJoin, agg,
+			}}}
+			if tt.rollback {
+				builder.optimizerHints = &OptimizerHints{outerAntiPlanning: 1}
+			}
+
+			determineShuffleForGroupBy(agg, builder)
+
+			require.True(t, agg.Stats.HashmapStats.Shuffle)
+			require.Equal(t, tt.wantMethod, agg.Stats.HashmapStats.ShuffleMethod)
+			require.Equal(t, tt.wantMultiCN, agg.Stats.HashmapStats.ShuffleTypeForMultiCN)
+		})
+	}
+}
+
+func TestDetermineShuffleMethod2RejectsHybridAggregateReuse(t *testing.T) {
+	tests := []struct {
+		name            string
+		hashmapSize     float64
+		wantJoinShuffle bool
+	}{
+		{
+			name:            "small build also drops the unnecessary hybrid join",
+			hashmapSize:     threshHoldForHybirdShuffle,
+			wantJoinShuffle: false,
+		},
+		{
+			name:            "large build keeps the hybrid join but globally repartitions the aggregate",
+			hashmapSize:     threshHoldForHybirdShuffle + 1,
+			wantJoinShuffle: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			childJoin := &plan.Node{
+				NodeId:   0,
+				NodeType: plan.Node_JOIN,
+				Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+					Shuffle:               true,
+					ShuffleType:           plan.ShuffleType_Range,
+					ShuffleTypeForMultiCN: plan.ShuffleTypeForMultiCN_Hybrid,
+					HashmapSize:           tt.hashmapSize,
+				}},
+			}
+			agg := &plan.Node{
+				NodeId:   1,
+				NodeType: plan.Node_AGG,
+				Children: []int32{0},
+				Stats: &plan.Stats{HashmapStats: &plan.HashMapStats{
+					Shuffle:               true,
+					ShuffleType:           plan.ShuffleType_Range,
+					ShuffleTypeForMultiCN: plan.ShuffleTypeForMultiCN_Hybrid,
+					ShuffleMethod:         plan.ShuffleMethod_Reuse,
+				}},
+			}
+			builder := &QueryBuilder{qry: &plan.Query{Nodes: []*plan.Node{childJoin, agg}}}
+
+			determineShuffleMethod2(agg.NodeId, -1, builder)
+
+			require.Equal(t, tt.wantJoinShuffle, childJoin.Stats.HashmapStats.Shuffle)
+			require.Equal(t, plan.ShuffleMethod_Normal, agg.Stats.HashmapStats.ShuffleMethod)
+			require.Equal(t, plan.ShuffleTypeForMultiCN_Simple,
+				agg.Stats.HashmapStats.ShuffleTypeForMultiCN)
+		})
+	}
 }
 
 func TestDetermineShuffleForJoinReuseMatchesChildPartition(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [x] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28102

## What this PR does / why we need it:

TPCH SF1000 Q16 exposed an invalid distributed aggregate plan. A hybrid
shuffle join partitions its probe rows only within each CN, but join-output
shuffle lineage was copied to the following aggregate as
`ShuffleMethod_Reuse`. The compiler then skipped the cluster-wide aggregate
shuffle, allowing the same DISTINCT key to be counted once per CN.

This change makes shuffle reuse consumer-aware:

- an aggregate can reuse join output only when the join provides one
  cluster-global owner for the grouping key;
- another hybrid join may still reuse the same local left-key partition because
  its build side is delivered to every CN's matching bucket;
- right/build lineage and ambiguous join outputs fail closed;
- the second shuffle-planning pass normalizes any stale
  `Hybrid -> Aggregate Reuse` state to a normal global shuffle;
- the duplicate aggregate-specific reuse path is removed so all join-output
  reuse goes through the same lineage and ownership proof;
- the analytic-rewrite RFC now records distribution scope as part of the reuse
  contract.

Validation:

- The new planner regressions fail on the unfixed code for hybrid aggregate
  reuse, nullable build-key reuse, and both sides of the hybrid-size boundary.
- Focused planner regressions: PASS.
- `go test -mod=readonly -count=1 -timeout 10m ./pkg/sql/plan`: PASS.
- Multi-CN aggregate compiler topology
  `TestCompileShuffleGroupKeepsNormalShuffleAcrossCNsAtDopOne`: PASS.
- `go vet -mod=readonly ./pkg/sql/plan`: PASS.
- `git diff --check`: PASS.

The final external acceptance check is TPCH SF1000 Q16 on the reported 3-CN
topology, comparing the complete result with the golden output. That dataset and
topology are not available in the local unit-test environment.
