### PR TITLE
fix(frontend): retain primary keys in data branch projections

### DIFF
--- a/docs/design/data_branch_privilege.md
+++ b/docs/design/data_branch_privilege.md
@@ -434,8 +434,10 @@ Output modes:
   `validateOutputDirPath`; it does not require table write privileges.
 - `OUTPUT AS table_name` materializes an ordinary persistent physical table.
   It is not a data-branch node and has no `mo_branch_metadata` row. The table
-  starts with `__mo_diff_source` and `__mo_diff_flag`, followed by the visible
-  source columns in the requested `COLUMNS` order. If a projected source column
+  starts with `__mo_diff_source` and `__mo_diff_flag`. With `COLUMNS`, explicit
+  primary-key columns come first in primary-key order, followed by the
+  requested non-PK visible source columns in `COLUMNS` order; without it, all
+  visible source columns retain table order. If a projected source column
   already uses either metadata name, the generated metadata name receives a
   numeric suffix.
 - `OUTPUT AS` additionally requires `CREATE TABLE`, `DatabaseAll`, or
@@ -842,9 +844,10 @@ Implement these decisions in this change:
 
 1. `DATA BRANCH DIFF OUTPUT AS table_name`
    - Materialize a persistent ordinary table with the diff source/flag columns
-     followed by the requested visible source columns. Require `CREATE TABLE`
-     on the destination database; do not allow a destination snapshot or
-     overwrite an existing table.
+     followed by explicit primary-key columns in primary-key order and then the
+     requested visible non-PK source columns. Require `CREATE TABLE` on the
+     destination database; do not allow a destination snapshot or overwrite an
+     existing table.
 2. Empty database created by `DATA BRANCH CREATE DATABASE`
    - Reject `DATA BRANCH DELETE DATABASE` if validation finds no active branch
      child tables. Current metadata is table-level only and cannot distinguish

--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -461,8 +461,11 @@ func mergeDiffs(
 	return
 }
 
-// resolveProjectedIdxes resolves the user-specified COLUMNS list to a subset
-// of visibleIdxes. Returns nil if no COLUMNS clause was specified.
+// resolveProjectedIdxes resolves the user-specified COLUMNS list to the
+// effective visible output columns. Explicit primary-key columns are emitted
+// first, in primary-key order, followed by the requested columns in request
+// order. A fake primary key represents all visible columns and is not added to
+// a projection. Returns nil if no COLUMNS clause was specified.
 func resolveProjectedIdxes(columns tree.IdentifierList, tblStuff tableStuff) ([]int, error) {
 	if columns == nil {
 		return nil, nil
@@ -473,8 +476,18 @@ func resolveProjectedIdxes(columns tree.IdentifierList, tblStuff tableStuff) ([]
 		nameToIdx[strings.ToLower(tblStuff.def.colNames[idx])] = idx
 	}
 
-	projected := make([]int, 0, len(columns))
-	seen := make(map[int]bool, len(columns))
+	projected := make([]int, 0, len(columns)+len(tblStuff.def.pkColIdxes))
+	seen := make(map[int]bool, len(columns)+len(tblStuff.def.pkColIdxes))
+	if tblStuff.def.pkKind != fakeKind {
+		for _, idx := range tblStuff.def.pkColIdxes {
+			if seen[idx] {
+				continue
+			}
+			seen[idx] = true
+			projected = append(projected, idx)
+		}
+	}
+
 	for _, col := range columns {
 		idx, ok := nameToIdx[strings.ToLower(string(col))]
 		if !ok {

--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -282,6 +282,9 @@ func TestDataBranchOutputTableSpec(t *testing.T) {
 		types.T_varchar.ToType(),
 	}
 	tblStuff.def.visibleIdxes = []int{0, 1, 2, 3}
+	tblStuff.def.pkKind = normalKind
+	tblStuff.def.pkColIdx = 0
+	tblStuff.def.pkColIdxes = []int{0}
 
 	outName := tree.NewTableName(
 		tree.Identifier("diff_out"),
@@ -326,7 +329,7 @@ func TestDataBranchOutputTableSpec(t *testing.T) {
 		require.NotContains(t, sql, "{mo_ts=")
 	})
 
-	t.Run("projected columns retain request order", func(t *testing.T) {
+	t.Run("projected primary key precedes requested columns", func(t *testing.T) {
 		output, err := newDiffOutputTable(ctx, ses, &tree.DataBranchDiff{
 			OutputOpt: &tree.DiffOutputOpt{As: *outName},
 			Columns: tree.IdentifierList{
@@ -334,8 +337,8 @@ func TestDataBranchOutputTableSpec(t *testing.T) {
 			},
 		}, tblStuff)
 		require.NoError(t, err)
-		require.Equal(t, []int{1, 0}, output.projectedIdxes)
-		require.Equal(t, []string{"__mo_diff_source", "__mo_diff_flag", "name", "id"}, output.columnNames)
+		require.Equal(t, []int{0, 1}, output.projectedIdxes)
+		require.Equal(t, []string{"__mo_diff_source", "__mo_diff_flag", "id", "name"}, output.columnNames)
 	})
 
 	t.Run("target-only column uses target type and remains nullable", func(t *testing.T) {
@@ -593,6 +596,9 @@ func TestDataBranchOutputBuildOutputSchema(t *testing.T) {
 	tblStuff.def.colNames = []string{"id", "name"}
 	tblStuff.def.colTypes = []types.Type{types.T_int64.ToType(), types.T_varchar.ToType()}
 	tblStuff.def.visibleIdxes = []int{0, 1}
+	tblStuff.def.pkKind = normalKind
+	tblStuff.def.pkColIdx = 0
+	tblStuff.def.pkColIdxes = []int{0}
 
 	target := tree.NewTableName(tree.Identifier("t2"), tree.ObjectNamePrefix{}, nil)
 	base := tree.NewTableName(tree.Identifier("t1"), tree.ObjectNamePrefix{}, nil)
@@ -805,11 +811,14 @@ func TestDataBranchOutputBuildOutputSchema(t *testing.T) {
 		require.NoError(t, buildOutputSchema(ctx, ses, stmt, tblStuff))
 
 		mrs := ses.GetMysqlResultSet()
-		// 2 meta columns (diff header + flag) + 1 projected column
-		require.Equal(t, uint64(3), mrs.GetColumnCount())
+		// 2 meta columns (diff header + flag) + the PK and requested column
+		require.Equal(t, uint64(4), mrs.GetColumnCount())
 		col2, err := mrs.GetColumn(ctx, 2)
 		require.NoError(t, err)
-		require.Equal(t, "name", col2.Name())
+		require.Equal(t, "id", col2.Name())
+		col3, err := mrs.GetColumn(ctx, 3)
+		require.NoError(t, err)
+		require.Equal(t, "name", col3.Name())
 	})
 
 	t.Run("columns projection with limit", func(t *testing.T) {
@@ -961,6 +970,66 @@ func TestDataBranchOutputLimitUsesFinalPKOrder(t *testing.T) {
 	}
 }
 
+func TestDataBranchOutputColumnsIncludeCompositePrimaryKey(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ses := newValidateSession(t)
+	ses.SetMysqlResultSet(&MysqlResultSet{})
+
+	ctrl := gomock.NewController(t)
+	tblStuff := newTestBranchTableStuff(ctrl)
+	tblStuff.def.colNames = []string{"org_id", "event_id", "val", "note"}
+	tblStuff.def.colTypes = []types.Type{
+		types.T_int64.ToType(),
+		types.T_int64.ToType(),
+		types.T_int64.ToType(),
+		types.T_varchar.ToType(),
+	}
+	tblStuff.def.visibleIdxes = []int{0, 1, 2, 3}
+	tblStuff.def.pkKind = compositeKind
+	tblStuff.def.pkColIdx = 0
+	tblStuff.def.pkColIdxes = []int{0, 1}
+	t.Cleanup(func() {
+		tblStuff.retPool.freeAllRetBatches(ses.proc.Mp())
+	})
+
+	stmt := &tree.DataBranchDiff{
+		Columns: tree.IdentifierList{tree.Identifier("val")},
+	}
+	require.NoError(t, buildOutputSchema(ctx, ses, stmt, tblStuff))
+	require.Equal(t, uint64(5), ses.GetMysqlResultSet().GetColumnCount())
+	for idx, name := range []string{"diff target against base", "flag", "org_id", "event_id", "val"} {
+		col, err := ses.GetMysqlResultSet().GetColumn(ctx, uint64(idx))
+		require.NoError(t, err)
+		require.Equal(t, name, col.Name())
+	}
+
+	bat := tblStuff.retPool.acquireRetBatch(tblStuff, false)
+	require.NoError(t, vector.AppendFixed(bat.Vecs[0], int64(1), false, ses.proc.Mp()))
+	require.NoError(t, vector.AppendFixed(bat.Vecs[1], int64(1), false, ses.proc.Mp()))
+	require.NoError(t, vector.AppendFixed(bat.Vecs[2], int64(19), false, ses.proc.Mp()))
+	require.NoError(t, vector.AppendBytes(bat.Vecs[3], []byte("upd"), false, ses.proc.Mp()))
+	bat.SetRowCount(1)
+
+	retCh := make(chan batchWithKind, 1)
+	retCh <- batchWithKind{name: "target", kind: diffUpdate, batch: bat}
+	close(retCh)
+	require.NoError(t, satisfyDiffOutputOpt(
+		ctx,
+		cancel,
+		func() {},
+		ses,
+		nil,
+		stmt,
+		branchMetaInfo{},
+		tblStuff,
+		retCh,
+	))
+
+	row, err := ses.GetMysqlResultSet().GetRow(ctx, 0)
+	require.NoError(t, err)
+	require.Equal(t, []any{"target", diffUpdate, int64(1), int64(1), int64(19)}, row)
+}
+
 func BenchmarkDataBranchOutputLimitWideRows(b *testing.B) {
 	const (
 		rowCount    = 64
@@ -1032,6 +1101,8 @@ func TestDataBranchOutputResolveProjectedIdxes(t *testing.T) {
 	tblStuff := tableStuff{}
 	tblStuff.def.colNames = []string{"id", "name", "age"}
 	tblStuff.def.visibleIdxes = []int{0, 1, 2}
+	tblStuff.def.pkKind = normalKind
+	tblStuff.def.pkColIdxes = []int{0}
 
 	t.Run("nil columns returns nil", func(t *testing.T) {
 		got, err := resolveProjectedIdxes(nil, tblStuff)
@@ -1042,7 +1113,7 @@ func TestDataBranchOutputResolveProjectedIdxes(t *testing.T) {
 	t.Run("single column", func(t *testing.T) {
 		got, err := resolveProjectedIdxes(tree.IdentifierList{tree.Identifier("name")}, tblStuff)
 		require.NoError(t, err)
-		require.Equal(t, []int{1}, got)
+		require.Equal(t, []int{0, 1}, got)
 	})
 
 	t.Run("multiple columns preserve order", func(t *testing.T) {
@@ -1050,7 +1121,7 @@ func TestDataBranchOutputResolveProjectedIdxes(t *testing.T) {
 			tree.Identifier("age"), tree.Identifier("id"),
 		}, tblStuff)
 		require.NoError(t, err)
-		require.Equal(t, []int{2, 0}, got)
+		require.Equal(t, []int{0, 2}, got)
 	})
 
 	t.Run("duplicate columns deduplicated", func(t *testing.T) {
@@ -1064,7 +1135,7 @@ func TestDataBranchOutputResolveProjectedIdxes(t *testing.T) {
 	t.Run("case insensitive", func(t *testing.T) {
 		got, err := resolveProjectedIdxes(tree.IdentifierList{tree.Identifier("NAME")}, tblStuff)
 		require.NoError(t, err)
-		require.Equal(t, []int{1}, got)
+		require.Equal(t, []int{0, 1}, got)
 	})
 
 	t.Run("unknown column returns error", func(t *testing.T) {
@@ -1072,6 +1143,54 @@ func TestDataBranchOutputResolveProjectedIdxes(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput))
 		require.Contains(t, err.Error(), "xxx")
+	})
+
+	t.Run("composite primary key columns precede requested columns", func(t *testing.T) {
+		compositeTblStuff := tableStuff{}
+		compositeTblStuff.def.colNames = []string{"region", "dept", "emp_id", "salary"}
+		compositeTblStuff.def.visibleIdxes = []int{0, 1, 2, 3}
+		compositeTblStuff.def.pkKind = compositeKind
+		compositeTblStuff.def.pkColIdxes = []int{0, 1, 2}
+
+		got, err := resolveProjectedIdxes(
+			tree.IdentifierList{tree.Identifier("salary")}, compositeTblStuff,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []int{0, 1, 2, 3}, got)
+
+		got, err = resolveProjectedIdxes(
+			tree.IdentifierList{tree.Identifier("salary"), tree.Identifier("dept")}, compositeTblStuff,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []int{0, 1, 2, 3}, got)
+	})
+
+	t.Run("composite primary key follows definition order", func(t *testing.T) {
+		orderedTblStuff := tableStuff{}
+		orderedTblStuff.def.colNames = []string{"value", "event_id", "org_id"}
+		orderedTblStuff.def.visibleIdxes = []int{0, 1, 2}
+		orderedTblStuff.def.pkKind = compositeKind
+		orderedTblStuff.def.pkColIdxes = []int{2, 1}
+
+		got, err := resolveProjectedIdxes(
+			tree.IdentifierList{tree.Identifier("value")}, orderedTblStuff,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []int{2, 1, 0}, got)
+	})
+
+	t.Run("fake primary key is not added to projection", func(t *testing.T) {
+		fakeTblStuff := tableStuff{}
+		fakeTblStuff.def.colNames = []string{"a", "b", "c"}
+		fakeTblStuff.def.visibleIdxes = []int{0, 1, 2}
+		fakeTblStuff.def.pkKind = fakeKind
+		fakeTblStuff.def.pkColIdxes = []int{0, 1, 2}
+
+		got, err := resolveProjectedIdxes(
+			tree.IdentifierList{tree.Identifier("c")}, fakeTblStuff,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []int{2}, got)
 	})
 }
 
@@ -2385,7 +2504,7 @@ func TestNewApplyBatchInfoExcludesGeneratedColumns(t *testing.T) {
 		tree.IdentifierList{tree.Identifier("generated_value")}, tblStuff,
 	)
 	require.NoError(t, err)
-	require.Equal(t, []int{2}, projected)
+	require.Equal(t, []int{0, 2}, projected)
 
 	info := newApplyBatchInfo(ctx, ses, tblStuff, []int{0}, false)
 	require.NotNil(t, info)

--- a/pkg/tests/dml/dml_test.go
+++ b/pkg/tests/dml/dml_test.go
@@ -843,7 +843,7 @@ func runDiffOutputLimitSubset(t *testing.T, parentCtx context.Context, db *sql.D
 	projectedFullRows := fetchDiffRowsAsStrings(t, ctx, db, projectedFullStmt)
 	require.GreaterOrEqual(t, len(projectedFullRows), 6)
 	for _, row := range projectedFullRows {
-		require.Len(t, row, 4, "projected diff should only include table, flag, and requested columns")
+		require.Len(t, row, 5, "projected diff should include table, flag, primary key, and requested columns")
 	}
 
 	projectedLimitStmt := fmt.Sprintf("data branch diff %s against %s columns (val, note) output limit %d", branch, base, limit)
@@ -856,7 +856,7 @@ func runDiffOutputLimitSubset(t *testing.T, parentCtx context.Context, db *sql.D
 		projectedFullSet[strings.Join(row, "||")] = struct{}{}
 	}
 	for _, row := range projectedLimitedRows {
-		require.Len(t, row, 4, "projected limited diff should only include table, flag, and requested columns")
+		require.Len(t, row, 5, "projected limited diff should include table, flag, primary key, and requested columns")
 		_, ok := projectedFullSet[strings.Join(row, "||")]
 		require.Truef(t, ok, "projected limited diff row not contained in projected full diff: %v", row)
 	}

--- a/test/distributed/cases/git4data/branch/diff/diff_11.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_11.result
@@ -24,25 +24,25 @@ c1_br	UPDATE	1	alice_v2	1500.50	2024-01-01 10:00:00	1990-03-15
 c1_br	DELETE	2	bob	2000.75	2024-01-02 11:00:00	1985-07-20
 c1_br	INSERT	4	dave	4000.00	2024-02-01 09:00:00	1988-12-25
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (name);
-diff c1_br against c1	flag	name
-c1_br	UPDATE	alice_v2
-c1_br	DELETE	bob
-c1_br	INSERT	dave
+diff c1_br against c1	flag	id	name
+c1_br	UPDATE	1	alice_v2
+c1_br	DELETE	2	bob
+c1_br	INSERT	4	dave
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (name, balance);
-diff c1_br against c1	flag	name	balance
-c1_br	UPDATE	alice_v2	1500.50
-c1_br	DELETE	bob	2000.75
-c1_br	INSERT	dave	4000.00
+diff c1_br against c1	flag	id	name	balance
+c1_br	UPDATE	1	alice_v2	1500.50
+c1_br	DELETE	2	bob	2000.75
+c1_br	INSERT	4	dave	4000.00
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (id, balance);
 diff c1_br against c1	flag	id	balance
 c1_br	UPDATE	1	1500.50
 c1_br	DELETE	2	2000.75
 c1_br	INSERT	4	4000.00
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (created_at, birthday);
-diff c1_br against c1	flag	created_at	birthday
-c1_br	UPDATE	2024-01-01 10:00:00	1990-03-15
-c1_br	DELETE	2024-01-02 11:00:00	1985-07-20
-c1_br	INSERT	2024-02-01 09:00:00	1988-12-25
+diff c1_br against c1	flag	id	created_at	birthday
+c1_br	UPDATE	1	2024-01-01 10:00:00	1990-03-15
+c1_br	DELETE	2	2024-01-02 11:00:00	1985-07-20
+c1_br	INSERT	4	2024-02-01 09:00:00	1988-12-25
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (id, name, balance, created_at, birthday);
 diff c1_br against c1	flag	id	name	balance	created_at	birthday
 c1_br	UPDATE	1	alice_v2	1500.50	2024-01-01 10:00:00	1990-03-15
@@ -77,20 +77,20 @@ c2_br	UPDATE	5001	FX001	spot	130000.0	0.5000	0.12
 c2_br	DELETE	5003	CB200	spot	62000.0	0.0050	0.01
 c2_br	INSERT	5004	IR300	swap	45000.0	0.2500	0.03
 data branch diff c2_br against c2{snapshot="c2_sp0"} columns (exposure, delta, margin);
-diff c2_br against c2	flag	exposure	delta	margin
-c2_br	UPDATE	130000.0	0.5000	0.12
-c2_br	DELETE	62000.0	0.0050	0.01
-c2_br	INSERT	45000.0	0.2500	0.03
+diff c2_br against c2	flag	account_id	instrument	bucket	exposure	delta	margin
+c2_br	UPDATE	5001	FX001	spot	130000.0	0.5000	0.12
+c2_br	DELETE	5003	CB200	spot	62000.0	0.0050	0.01
+c2_br	INSERT	5004	IR300	swap	45000.0	0.2500	0.03
 data branch diff c2_br against c2{snapshot="c2_sp0"} columns (account_id, instrument, exposure);
-diff c2_br against c2	flag	account_id	instrument	exposure
-c2_br	UPDATE	5001	FX001	130000.0
-c2_br	DELETE	5003	CB200	62000.0
-c2_br	INSERT	5004	IR300	45000.0
+diff c2_br against c2	flag	account_id	instrument	bucket	exposure
+c2_br	UPDATE	5001	FX001	spot	130000.0
+c2_br	DELETE	5003	CB200	spot	62000.0
+c2_br	INSERT	5004	IR300	swap	45000.0
 data branch diff c2_br against c2{snapshot="c2_sp0"} columns (delta);
-diff c2_br against c2	flag	delta
-c2_br	UPDATE	0.5000
-c2_br	DELETE	0.0050
-c2_br	INSERT	0.2500
+diff c2_br against c2	flag	account_id	instrument	bucket	delta
+c2_br	UPDATE	5001	FX001	spot	0.5000
+c2_br	DELETE	5003	CB200	spot	0.0050
+c2_br	INSERT	5004	IR300	swap	0.2500
 drop snapshot c2_sp0;
 drop table c2;
 drop table c2_br;
@@ -158,17 +158,17 @@ c4_br	UPDATE	2	bob	95	improved	null
 c4_br	DELETE	3	null	80	ok	2024-01-03 00:00:00
 c4_br	INSERT	5	null	null	null	null
 data branch diff c4_br against c4{snapshot="c4_sp0"} columns (name, score);
-diff c4_br against c4	flag	name	score
-c4_br	UPDATE	null	null
-c4_br	UPDATE	bob	95
-c4_br	DELETE	null	80
-c4_br	INSERT	null	null
+diff c4_br against c4	flag	id	name	score
+c4_br	UPDATE	1	null	null
+c4_br	UPDATE	2	bob	95
+c4_br	DELETE	3	null	80
+c4_br	INSERT	5	null	null
 data branch diff c4_br against c4{snapshot="c4_sp0"} columns (memo, ts);
-diff c4_br against c4	flag	memo	ts
-c4_br	UPDATE	good	2024-01-01 00:00:00
-c4_br	UPDATE	improved	null
-c4_br	DELETE	ok	2024-01-03 00:00:00
-c4_br	INSERT	null	null
+diff c4_br against c4	flag	id	memo	ts
+c4_br	UPDATE	1	good	2024-01-01 00:00:00
+c4_br	UPDATE	2	improved	null
+c4_br	DELETE	3	ok	2024-01-03 00:00:00
+c4_br	INSERT	5	null	null
 data branch diff c4_br against c4{snapshot="c4_sp0"} columns (id, memo);
 diff c4_br against c4	flag	id	memo
 c4_br	UPDATE	1	good
@@ -234,23 +234,23 @@ c6_br	INSERT	south	3	301	7000.00	2024-01-01	new hire
 c6_br	UPDATE	west	2	201	6000.00	2022-01-01	null
 c6_br	DELETE	west	2	202	3500.00	2023-03-10	junior
 data branch diff c6_br against c6{snapshot="c6_sp0"} columns (salary, notes);
-diff c6_br against c6	flag	salary	notes
-c6_br	UPDATE	5500.00	promoted
-c6_br	INSERT	7000.00	new hire
-c6_br	UPDATE	6000.00	null
-c6_br	DELETE	3500.00	junior
+diff c6_br against c6	flag	region	dept	emp_id	salary	notes
+c6_br	UPDATE	east	1	101	5500.00	promoted
+c6_br	INSERT	south	3	301	7000.00	new hire
+c6_br	UPDATE	west	2	201	6000.00	null
+c6_br	DELETE	west	2	202	3500.00	junior
 data branch diff c6_br against c6{snapshot="c6_sp0"} columns (region, emp_id, salary);
-diff c6_br against c6	flag	region	emp_id	salary
-c6_br	UPDATE	east	101	5500.00
-c6_br	INSERT	south	301	7000.00
-c6_br	UPDATE	west	201	6000.00
-c6_br	DELETE	west	202	3500.00
+diff c6_br against c6	flag	region	dept	emp_id	salary
+c6_br	UPDATE	east	1	101	5500.00
+c6_br	INSERT	south	3	301	7000.00
+c6_br	UPDATE	west	2	201	6000.00
+c6_br	DELETE	west	2	202	3500.00
 data branch diff c6_br against c6{snapshot="c6_sp0"} columns (hire_date);
-diff c6_br against c6	flag	hire_date
-c6_br	UPDATE	2020-01-15
-c6_br	INSERT	2024-01-01
-c6_br	UPDATE	2022-01-01
-c6_br	DELETE	2023-03-10
+diff c6_br against c6	flag	region	dept	emp_id	hire_date
+c6_br	UPDATE	east	1	101	2020-01-15
+c6_br	INSERT	south	3	301	2024-01-01
+c6_br	UPDATE	west	2	201	2022-01-01
+c6_br	DELETE	west	2	202	2023-03-10
 drop snapshot c6_sp0;
 drop table c6;
 drop table c6_br;
@@ -295,8 +295,8 @@ create snapshot c8_sp0 for table test_diff_columns c8;
 data branch create table c8_br from c8{snapshot="c8_sp0"};
 update c8_br set a = 15 where id = 1;
 data branch diff c8_br against c8{snapshot="c8_sp0"} columns (a, a, b);
-diff c8_br against c8	flag	a	b
-c8_br	UPDATE	15	100
+diff c8_br against c8	flag	id	a	b
+c8_br	UPDATE	1	15	100
 drop snapshot c8_sp0;
 drop table c8;
 drop table c8_br;
@@ -307,8 +307,8 @@ create snapshot c9_sp0 for table test_diff_columns c9;
 data branch create table c9_br from c9{snapshot="c9_sp0"};
 update c9_br set Score = 100 where Id = 1;
 data branch diff c9_br against c9{snapshot="c9_sp0"} columns (NAME, score);
-diff c9_br against c9	flag	name	score
-c9_br	UPDATE	test	100
+diff c9_br against c9	flag	id	name	score
+c9_br	UPDATE	1	test	100
 drop snapshot c9_sp0;
 drop table c9;
 drop table c9_br;
@@ -321,17 +321,17 @@ insert into c10 values (3, 30, 'v3');
 drop snapshot if exists c10_sp1;
 create snapshot c10_sp1 for table test_diff_columns c10;
 data branch diff c10{snapshot="c10_sp1"} against c10{snapshot="c10_sp0"} columns (b);
-diff c10 against c10	flag	b
-c10	UPDATE	15
-c10	INSERT	30
+diff c10 against c10	flag	a	b
+c10	UPDATE	1	15
+c10	INSERT	3	30
 data branch diff c10{snapshot="c10_sp1"} against c10{snapshot="c10_sp0"} columns (c);
-diff c10 against c10	flag	c
-c10	UPDATE	v1_mod
-c10	INSERT	v3
+diff c10 against c10	flag	a	c
+c10	UPDATE	1	v1_mod
+c10	INSERT	3	v3
 data branch diff c10{snapshot="c10_sp1"} against c10{snapshot="c10_sp0"} columns (b, c);
-diff c10 against c10	flag	b	c
-c10	UPDATE	15	v1_mod
-c10	INSERT	30	v3
+diff c10 against c10	flag	a	b	c
+c10	UPDATE	1	15	v1_mod
+c10	INSERT	3	30	v3
 drop snapshot c10_sp0;
 drop snapshot c10_sp1;
 drop table c10;

--- a/test/distributed/cases/git4data/branch/diff/diff_11.sql
+++ b/test/distributed/cases/git4data/branch/diff/diff_11.sql
@@ -30,16 +30,16 @@ insert into c1_br values (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25
 -- full diff (baseline for comparison)
 data branch diff c1_br against c1{snapshot="c1_sp0"};
 
--- project single column
+-- project single non-PK column; explicit PK columns are retained automatically
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (name);
 
--- project two columns (non-PK)
+-- project two non-PK columns; explicit PK columns are retained automatically
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (name, balance);
 
 -- project PK + one column
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (id, balance);
 
--- project temporal columns only
+-- project temporal columns only; explicit PK columns are retained automatically
 data branch diff c1_br against c1{snapshot="c1_sp0"} columns (created_at, birthday);
 
 -- project all columns explicitly (same as no COLUMNS)
@@ -80,13 +80,13 @@ insert into c2_br values (5004, 'IR300', 'swap', 45000.00, 0.2500, 0.03);
 -- full diff
 data branch diff c2_br against c2{snapshot="c2_sp0"};
 
--- project only non-PK columns
+-- project only non-PK columns; all composite PK columns are retained automatically
 data branch diff c2_br against c2{snapshot="c2_sp0"} columns (exposure, delta, margin);
 
--- project partial PK + one value column
+-- project partial PK + one value column; the complete PK is retained in PK order
 data branch diff c2_br against c2{snapshot="c2_sp0"} columns (account_id, instrument, exposure);
 
--- project single non-PK column
+-- project single non-PK column; the complete PK is retained automatically
 data branch diff c2_br against c2{snapshot="c2_sp0"} columns (delta);
 
 drop snapshot c2_sp0;
@@ -163,10 +163,10 @@ insert into c4_br values (5, null, null, null, null);
 -- full diff
 data branch diff c4_br against c4{snapshot="c4_sp0"};
 
--- project columns with NULLs
+-- project columns with NULLs; the explicit PK is retained automatically
 data branch diff c4_br against c4{snapshot="c4_sp0"} columns (name, score);
 
--- project memo and ts (mix of null transitions)
+-- project memo and ts (mix of null transitions); the explicit PK is retained
 data branch diff c4_br against c4{snapshot="c4_sp0"} columns (memo, ts);
 
 -- project PK + one nullable column
@@ -238,13 +238,13 @@ insert into c6_br values ('south', 3, 301, 7000.00, '2024-01-01', 'new hire');
 -- full diff
 data branch diff c6_br against c6{snapshot="c6_sp0"};
 
--- project only value columns (no PK in projection)
+-- project only value columns; all composite PK columns are retained automatically
 data branch diff c6_br against c6{snapshot="c6_sp0"} columns (salary, notes);
 
--- project partial PK + value
+-- project partial PK + value; the complete PK is retained in PK order
 data branch diff c6_br against c6{snapshot="c6_sp0"} columns (region, emp_id, salary);
 
--- project hire_date which has NULL transitions
+-- project hire_date which has NULL transitions; the composite PK is retained
 data branch diff c6_br against c6{snapshot="c6_sp0"} columns (hire_date);
 
 drop snapshot c6_sp0;

--- a/test/distributed/cases/git4data/branch/diff/diff_13.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_13.result
@@ -318,17 +318,17 @@ t9  ¦  INSERT  ¦  104  𝄀
 t9  ¦  INSERT  ¦  109  𝄀
 t0  ¦  INSERT  ¦  200
 data branch diff t9 against t0 columns (b);
-➤ diff t9 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  b[4,0,0]  𝄀
-t9  ¦  UPDATE  ¦  10000  𝄀
-t0  ¦  UPDATE  ¦  99999  𝄀
-t9  ¦  UPDATE  ¦  40000  𝄀
-t9  ¦  UPDATE  ¦  90000  𝄀
-t9  ¦  DELETE  ¦  11  𝄀
-t9  ¦  DELETE  ¦  16  𝄀
-t9  ¦  INSERT  ¦  101  𝄀
-t9  ¦  INSERT  ¦  104  𝄀
-t9  ¦  INSERT  ¦  109  𝄀
-t0  ¦  INSERT  ¦  200
+➤ diff t9 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  1  ¦  10000  𝄀
+t0  ¦  UPDATE  ¦  1  ¦  99999  𝄀
+t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t9  ¦  INSERT  ¦  101  ¦  101  𝄀
+t9  ¦  INSERT  ¦  104  ¦  104  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109  𝄀
+t0  ¦  INSERT  ¦  200  ¦  200
 drop table t9;
 drop table t10;
 drop table t11;

--- a/test/distributed/cases/git4data/branch/diff/diff_17.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_17.result
@@ -66,8 +66,8 @@ show create table diff_projected;
 diff_projected  ¦  CREATE TABLE `diff_projected` (
   `__mo_diff_source` varchar(255) DEFAULT NULL,
   `__mo_diff_flag` varchar(16) DEFAULT NULL,
-  `flag` varchar(20) DEFAULT NULL,
   `id` int NOT NULL,
+  `flag` varchar(20) DEFAULT NULL,
   `amount` decimal(12,2) DEFAULT NULL
 )
 select __mo_diff_source, __mo_diff_flag, flag, id, amount
@@ -85,6 +85,7 @@ show create table diff_projected_dedup;
 diff_projected_dedup  ¦  CREATE TABLE `diff_projected_dedup` (
   `__mo_diff_source` varchar(255) DEFAULT NULL,
   `__mo_diff_flag` varchar(16) DEFAULT NULL,
+  `id` int NOT NULL,
   `amount` decimal(12,2) DEFAULT NULL,
   `source` varchar(20) DEFAULT NULL
 )

--- a/test/distributed/cases/git4data/branch/diff/diff_17.sql
+++ b/test/distributed/cases/git4data/branch/diff/diff_17.sql
@@ -1,9 +1,9 @@
 -- DATA BRANCH DIFF OUTPUT AS coverage.
 --
 -- OUTPUT AS materializes a normal persistent table.  Its two metadata columns
--- are __mo_diff_source and __mo_diff_flag; the remaining columns retain the
--- requested source-column order and types.  The result table is never itself
--- a data branch.
+-- are __mo_diff_source and __mo_diff_flag; explicit primary-key columns precede
+-- the remaining requested source columns.  The result table is never itself a
+-- data branch.
 
 drop database if exists test_diff_output_as_dst;
 drop database if exists test_diff_output_as;
@@ -54,8 +54,9 @@ select __mo_diff_source, __mo_diff_flag, id
     from test_diff_output_as.diff_full order by id;
 -- @session
 
--- Case 2: COLUMNS controls result-table schema and column order.  Duplicate
--- names are deduplicated just as they are for ordinary DIFF output.
+-- Case 2: COLUMNS controls result-table schema and column order.  Explicit
+-- primary-key columns are retained first, and duplicate names are deduplicated
+-- just as they are for ordinary DIFF output.
 data branch diff branch_full against base_full
     columns (flag, id, amount) output as diff_projected;
 show create table diff_projected;

--- a/test/distributed/cases/git4data/branch/diff/diff_composite_pk_columns.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_composite_pk_columns.result
@@ -1,0 +1,77 @@
+drop database if exists issue_25244_diff_columns_pk;
+create database issue_25244_diff_columns_pk;
+use issue_25244_diff_columns_pk;
+create table base (
+org_id int,
+event_id int,
+val int,
+note varchar(64),
+primary key (org_id, event_id)
+);
+insert into base values
+(1, 1, 10, 'seed'),
+(1, 2, 20, 'seed'),
+(2, 1, 30, 'seed'),
+(2, 2, 40, 'seed');
+data branch create table target from base;
+update target
+set val = val + 9, note = 'upd'
+where org_id = 1 and event_id = 1;
+data branch diff target against base columns (val);
+➤ diff target against base[12,0,0]  ¦  flag[12,0,0]  ¦  org_id[4,32,0]  ¦  event_id[4,32,0]  ¦  val[4,32,0]  𝄀
+target  ¦  UPDATE  ¦  1  ¦  1  ¦  19
+data branch diff target against base columns (note, event_id, note);
+➤ diff target against base[12,0,0]  ¦  flag[12,0,0]  ¦  org_id[4,32,0]  ¦  event_id[4,32,0]  ¦  note[12,64,0]  𝄀
+target  ¦  UPDATE  ¦  1  ¦  1  ¦  upd
+delete from target where org_id = 2 and event_id = 2;
+insert into target values (3, 3, 50, 'new');
+data branch diff target against base columns (note) output limit 1;
+➤ diff target against base[12,0,0]  ¦  flag[12,0,0]  ¦  org_id[4,32,0]  ¦  event_id[4,32,0]  ¦  note[12,64,0]  𝄀
+target  ¦  UPDATE  ¦  1  ¦  1  ¦  upd
+data branch diff target against base columns (note);
+➤ diff target against base[12,0,0]  ¦  flag[12,0,0]  ¦  org_id[4,32,0]  ¦  event_id[4,32,0]  ¦  note[12,64,0]  𝄀
+target  ¦  UPDATE  ¦  1  ¦  1  ¦  upd  𝄀
+target  ¦  DELETE  ¦  2  ¦  2  ¦  seed  𝄀
+target  ¦  INSERT  ¦  3  ¦  3  ¦  new
+create table unrelated_base (
+org_id int,
+event_id int,
+note varchar(64),
+primary key (org_id, event_id)
+);
+create table unrelated_target (
+org_id int,
+event_id int,
+note varchar(64),
+primary key (org_id, event_id)
+);
+insert into unrelated_base values (8, 1, 'keep'), (8, 2, 'delete');
+insert into unrelated_target values (8, 1, 'keep'), (8, 2, 'delete');
+delete from unrelated_target where org_id = 8 and event_id = 2;
+data branch diff unrelated_target against unrelated_base columns (note);
+➤ diff unrelated_target against unrelated_base[12,0,0]  ¦  flag[12,0,0]  ¦  org_id[4,32,0]  ¦  event_id[4,32,0]  ¦  note[12,64,0]  𝄀
+unrelated_base  ¦  INSERT  ¦  8  ¦  2  ¦  delete
+data branch diff target against base columns (note) output as diff_as;
+➤ TABLE CREATED[12,0,0]  𝄀
+`issue_25244_diff_columns_pk`.`diff_as`
+show create table diff_as;
+➤ Table[12,7,0]  ¦  Create Table[12,205,0]  𝄀
+diff_as  ¦  CREATE TABLE `diff_as` (
+  `__mo_diff_source` varchar(255) DEFAULT NULL,
+  `__mo_diff_flag` varchar(16) DEFAULT NULL,
+  `org_id` int NOT NULL,
+  `event_id` int NOT NULL,
+  `note` varchar(64) DEFAULT NULL
+)
+select __mo_diff_source, __mo_diff_flag, org_id, event_id, note
+from diff_as order by org_id, event_id;
+➤ __mo_diff_source[12,255,0]  ¦  __mo_diff_flag[12,16,0]  ¦  org_id[4,32,0]  ¦  event_id[4,32,0]  ¦  note[12,64,0]  𝄀
+target  ¦  UPDATE  ¦  1  ¦  1  ¦  upd  𝄀
+target  ¦  DELETE  ¦  2  ¦  2  ¦  seed  𝄀
+target  ¦  INSERT  ¦  3  ¦  3  ¦  new
+drop table diff_as;
+drop table unrelated_target;
+drop table unrelated_base;
+drop table target;
+drop table base;
+drop database issue_25244_diff_columns_pk;

--- a/test/distributed/cases/git4data/branch/diff/diff_composite_pk_columns.sql
+++ b/test/distributed/cases/git4data/branch/diff/diff_composite_pk_columns.sql
@@ -1,0 +1,73 @@
+-- DATA BRANCH DIFF COLUMNS must retain every explicit primary-key column.
+-- This covers the issue #25244 reproduction, projected LIMIT output, a
+-- non-lineage DELETE, and OUTPUT AS schema materialization.
+
+drop database if exists issue_25244_diff_columns_pk;
+create database issue_25244_diff_columns_pk;
+use issue_25244_diff_columns_pk;
+
+create table base (
+    org_id int,
+    event_id int,
+    val int,
+    note varchar(64),
+    primary key (org_id, event_id)
+);
+
+insert into base values
+    (1, 1, 10, 'seed'),
+    (1, 2, 20, 'seed'),
+    (2, 1, 30, 'seed'),
+    (2, 2, 40, 'seed');
+
+data branch create table target from base;
+update target
+    set val = val + 9, note = 'upd'
+    where org_id = 1 and event_id = 1;
+
+-- Exact issue reproduction: COLUMNS (val) still includes the complete PK.
+data branch diff target against base columns (val);
+
+-- The PK remains in definition order, and a requested PK is not duplicated.
+data branch diff target against base columns (note, event_id, note);
+
+delete from target where org_id = 2 and event_id = 2;
+insert into target values (3, 3, 50, 'new');
+
+-- LIMIT uses the same final PK-aware projection and retains the winning row's PK.
+data branch diff target against base columns (note) output limit 1;
+
+-- The complete changed set keeps PK columns for UPDATE, DELETE, and INSERT.
+data branch diff target against base columns (note);
+
+-- The same projection contract applies to unrelated tables; a row removed from
+-- the target is represented by the base-side INSERT in this diff direction.
+create table unrelated_base (
+    org_id int,
+    event_id int,
+    note varchar(64),
+    primary key (org_id, event_id)
+);
+create table unrelated_target (
+    org_id int,
+    event_id int,
+    note varchar(64),
+    primary key (org_id, event_id)
+);
+insert into unrelated_base values (8, 1, 'keep'), (8, 2, 'delete');
+insert into unrelated_target values (8, 1, 'keep'), (8, 2, 'delete');
+delete from unrelated_target where org_id = 8 and event_id = 2;
+data branch diff unrelated_target against unrelated_base columns (note);
+
+-- OUTPUT AS uses the same effective column list as ordinary row output.
+data branch diff target against base columns (note) output as diff_as;
+show create table diff_as;
+select __mo_diff_source, __mo_diff_flag, org_id, event_id, note
+    from diff_as order by org_id, event_id;
+
+drop table diff_as;
+drop table unrelated_target;
+drop table unrelated_base;
+drop table target;
+drop table base;
+drop database issue_25244_diff_columns_pk;

--- a/test/distributed/cases/git4data/branch/edge/branch_output_limit_order.result
+++ b/test/distributed/cases/git4data/branch/edge/branch_output_limit_order.result
@@ -14,8 +14,8 @@ data branch diff child against base output limit 1;
 ➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[12,-1,0]  𝄀
 base  ¦  INSERT  ¦  1  ¦  base-low
 data branch diff child against base columns (v) output limit 1;
-➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  v[12,-1,0]  𝄀
-base  ¦  INSERT  ¦  base-low
+➤ diff child against base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  v[12,-1,0]  𝄀
+base  ¦  INSERT  ¦  1  ¦  base-low
 insert into base values (2, 'base-mid');
 insert into child values (99, 'child-mid');
 data branch diff child against base output limit 2;

--- a/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_generated_column.result
@@ -23,10 +23,10 @@ stored_branch  ¦  UPDATE  ¦  1  ¦  11  ¦  20  ¦  31  𝄀
 stored_branch  ¦  DELETE  ¦  2  ¦  30  ¦  40  ¦  70  𝄀
 stored_branch  ¦  INSERT  ¦  3  ¦  50  ¦  60  ¦  110
 data branch diff stored_branch against stored_base columns(c, id);
-➤ diff stored_branch against stored_base[12,0,0]  ¦  flag[12,0,0]  ¦  c[4,32,0]  ¦  id[4,32,0]  𝄀
-stored_branch  ¦  UPDATE  ¦  31  ¦  1  𝄀
-stored_branch  ¦  DELETE  ¦  70  ¦  2  𝄀
-stored_branch  ¦  INSERT  ¦  110  ¦  3
+➤ diff stored_branch against stored_base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  c[4,32,0]  𝄀
+stored_branch  ¦  UPDATE  ¦  1  ¦  31  𝄀
+stored_branch  ¦  DELETE  ¦  2  ¦  70  𝄀
+stored_branch  ¦  INSERT  ¦  3  ¦  110
 data branch diff stored_branch against stored_base columns(c, id) output as stored_generated_diff;
 ➤ TABLE CREATED[12,0,0]  𝄀
 `data_branch_generated_column`.`stored_generated_diff`


### PR DESCRIPTION
# What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

# Which issue(s) this PR fixes:

Related to #25244

# What this PR does / why we need it:

## Root cause

When `DATA BRANCH DIFF` used `COLUMNS`, `resolveProjectedIdxes` returned only the requested visible columns. The row path temporarily extracted primary-key values for `OUTPUT LIMIT` sorting, but final row compaction and result-schema construction still used the requested-only list. Composite primary-key values were therefore absent from both the result rows and their metadata. `OUTPUT AS` reused the same incomplete list.

The older worker-pool leak finding recorded in #25244 is already addressed on current `main` by #26369 (`09855ae9b1`) and is not changed here.

## Changes

- Make the shared projection resolver emit explicit primary-key columns first in primary-key definition order, then requested non-PK visible columns in request order, with deduplication.
- Reuse that effective projection for ordinary diff result rows, result metadata, and `OUTPUT AS` table schemas.
- Preserve existing fake-PK/no-PK behavior and leave `COUNT`, `SUMMARY`, and `OUTPUT FILE` behavior unchanged.
- Add focused unit coverage, an exact composite-PK regression BVT, related boundary assertions, and update the documented `OUTPUT AS` contract.

## Issue-to-test proof

- `TestDataBranchOutputColumnsIncludeCompositePrimaryKey` asserts the exact five-column metadata (`diff`, `flag`, both PK columns, and `val`) and the exact update row values.
- `TestDataBranchOutputResolveProjectedIdxes` covers normal and composite PKs, definition order different from physical order, duplicate/case-insensitive requests, unknown columns, and the fake-PK control case. Table-schema tests cover ordinary output and `OUTPUT AS` ordering.
- `diff_composite_pk_columns.sql` covers the issue reproduction, partial/duplicate PK requests, UPDATE/DELETE/INSERT rows, projected `OUTPUT LIMIT`, unrelated tables, and `OUTPUT AS` metadata plus rows.
- Existing `diff_11`, `diff_13`, `diff_17`, `branch_output_limit_order`, and `merge_generated_column` cases cover the broader data types, lineage depth, materialized schema, limit ordering, and generated-column interactions affected by the shared resolver.

## Tests run

- `make build`
- Full `pkg/frontend` CGo test package: passed.
- Focused frontend regression tests: passed.
- New composite-PK BVT twice with metadata comparison enabled: `28/28` each run.
- Existing related BVTs: `diff_11` `158/158`; `diff_13` `137/137`; `diff_17` `154/154`; `branch_output_limit_order` `21/21`; `merge_generated_column` `80/80`; remaining branch edge cases `314/314`.

The existing `diff_13`, `diff_17`, and edge/merge result files use historical metadata-width encodings that do not compare cleanly with the current tester. Those runs used `-n`, which still compared all SQL output, column names/order, and row values. The new regression result was checked twice with metadata comparison enabled.

## Residual risks

For explicit-PK tables, callers using `COLUMNS` will now receive additional PK columns, in PK definition order, as required for row identity. Fake-PK/no-PK tables and non-row output modes retain their prior behavior. This change does not alter concurrency, storage, or resource-lifecycle code; #25244 remains open for manual validation.

## CI follow-up

- Updated the existing `pkg/tests/dml` output-limit regression assertion to expect the retained primary-key column introduced by this fix; focused `TestDataBranchDiffAsFile` passes locally.

## Rebase follow-up

- Rebased the issue branch onto origin/main at fa829e5c50 without conflicts or scope changes.
- Re-ran the focused frontend regression tests and TestDataBranchDiffAsFile after the rebase; both passed locally.