### PR TITLE
fix(fileservice): retry COS multipart init before request write (cherry-pick #28043)

### DIFF
--- a/pkg/fileservice/parallel_sdk_test.go
+++ b/pkg/fileservice/parallel_sdk_test.go
@@ -34,7 +34,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/panjf2000/ants/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	costypes "github.com/tencentyun/cos-go-sdk-v5"
 	"golang.org/x/sync/semaphore"
@@ -689,19 +691,24 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 		failPartStatus:     http.StatusBadRequest,
 		failCompleteStatus: http.StatusBadRequest,
 		failCreateStatus:   http.StatusBadRequest,
+		uploadID:           "cos-upload",
 		parts:              make(map[int][]byte),
 	}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && strings.Contains(r.URL.RawQuery, "uploads"):
-			state.initCalls.Add(1)
+			initCall := state.initCalls.Add(1)
 			if state.failCreate {
 				w.WriteHeader(state.failCreateStatus)
 				return
 			}
 			_, _ = io.ReadAll(r.Body)
+			uploadID := state.uploadID
+			if state.generateUploadIDs {
+				uploadID = fmt.Sprintf("%s-%d", uploadID, initCall)
+			}
 			w.Header().Set("Content-Type", "application/xml")
-			_, _ = fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>%s</UploadId></InitiateMultipartUploadResult>`, state.uploadID)
+			_, _ = fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>%s</UploadId></InitiateMultipartUploadResult>`, uploadID)
 		case r.Method == http.MethodPut && !strings.Contains(r.URL.RawQuery, "partNumber") && !strings.Contains(r.URL.RawQuery, "uploadId") && !strings.Contains(r.URL.RawQuery, "uploads"):
 			body, _ := io.ReadAll(r.Body)
 			state.mu.Lock()
@@ -731,6 +738,7 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 			}
 			state.mu.Lock()
 			state.completeBody = append([]byte{}, body...)
+			state.completedUploadID = r.URL.Query().Get("uploadId")
 			for partNum := 1; partNum < len(state.parts); partNum++ {
 				if len(state.parts[partNum]) < int(minMultipartPartSize) {
 					state.mu.Unlock()
@@ -768,6 +776,8 @@ type cosServerState struct {
 	failCreate         bool
 	failCreateStatus   int
 	uploadID           string
+	generateUploadIDs  bool
+	completedUploadID  string
 	initCalls          atomic.Int32
 	aborted            atomic.Bool
 	completed          atomic.Bool
@@ -788,6 +798,7 @@ func newTestCOSClient(t *testing.T, srv *httptest.Server) *QCloudSDK {
 		srv.Client(),
 	)
 	client.Conf.EnableCRC = false
+	client.Conf.RetryOpt.Count = 0
 
 	return &QCloudSDK{
 		name:   "cos-test",
@@ -1001,52 +1012,136 @@ func TestCOSMultipartUploadPartRetriesServerClosedIdleConnection(t *testing.T) {
 	}
 }
 
-func TestCOSMultipartInitDoesNotRetryEOFBeforeRequest(t *testing.T) {
+func TestCOSMultipartInitRecoversBeforeRequest(t *testing.T) {
 	server, state := newMockCOSServer(t, 0)
 	defer server.Close()
-	state.uploadID = "cos-uid-init-eof"
+	state.uploadID = "cos-uid-init-before-request"
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      sentinel,
+		failures: 1,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
 
-	baseClient := server.Client()
-	baseTransport := baseClient.Transport
-	if baseTransport == nil {
-		baseTransport = http.DefaultTransport
-	}
-	transport := &cosMultipartInitEOFTransport{base: baseTransport}
-	baseClient.Transport = transport
+	attemptsBefore := testutil.ToFloat64(metric.FSMultipartInitAttemptCounter)
+	ambiguousBefore := testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter)
+	recoveredBefore := testutil.ToFloat64(metric.FSMultipartInitRecoveredCounter)
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
+	require.Equal(t, int32(2), transport.initCalls.Load())
+	require.Equal(t, int32(1), state.initCalls.Load())
+	require.True(t, state.completed.Load())
+	require.Equal(t, attemptsBefore+2, testutil.ToFloat64(metric.FSMultipartInitAttemptCounter))
+	require.Equal(t, ambiguousBefore, testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
+	require.Equal(t, recoveredBefore+1, testutil.ToFloat64(metric.FSMultipartInitRecoveredCounter))
+}
 
-	baseURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatalf("parse url: %v", err)
+func TestCOSMultipartInitDoesNotAdoptAnotherInstanceUpload(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "upload"
+	state.generateUploadIDs = true
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      sentinel,
+		failures: 1,
+		onFailure: func() {
+			resp, err := http.Post(server.URL+"/object?uploads", "application/octet-stream", nil)
+			require.NoError(t, err)
+			_ = resp.Body.Close()
+		},
 	}
-	client := costypes.NewClient(
-		&costypes.BaseURL{BucketURL: baseURL},
-		baseClient,
-	)
-	client.Conf.EnableCRC = false
-	client.Conf.RetryOpt.Count = 0
-	sdk := &QCloudSDK{
-		name:   "cos-init-eof-test",
-		client: client,
-	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
 
 	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
 	size := int64(len(data))
-	err = sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, &ParallelMultipartOption{
-		PartSize:    minMultipartPartSize,
-		Concurrency: 1,
-	})
-	if err == nil {
-		t.Fatalf("expected multipart-init error")
+	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
+	require.Equal(t, int32(2), state.initCalls.Load(), "one external init and one init owned by this writer")
+	state.mu.Lock()
+	require.Equal(t, "upload-2", state.completedUploadID)
+	state.mu.Unlock()
+	require.False(t, state.aborted.Load())
+}
+
+func TestCOSMultipartInitDoesNotRequireListPermission(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-no-list-permission"
+	transport := &denyMultipartListTransport{base: server.Client().Transport}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	require.NoError(t, sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil))
+	require.Zero(t, transport.listCalls.Load())
+	require.Equal(t, int32(1), state.initCalls.Load())
+}
+
+func TestCOSMultipartInitCancellationCleansOwnedUpload(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.uploadID = "cos-uid-canceled"
+	ctx, cancel := context.WithCancel(context.Background())
+	transport := &cosMultipartInitCancelAfterResponseTransport{
+		base:   server.Client().Transport,
+		cancel: cancel,
 	}
-	if transport.initCalls.Load() != 1 {
-		t.Fatalf("expected no retry after multipart-init EOF, got %d attempts", transport.initCalls.Load())
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	cleanupBefore := testutil.ToFloat64(metric.FSMultipartInitCleanupCounter)
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(ctx, "object", bytes.NewReader(data), &size, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, state.aborted.Load())
+	require.False(t, state.completed.Load())
+	require.Equal(t, cleanupBefore+1, testutil.ToFloat64(metric.FSMultipartInitCleanupCounter))
+}
+
+func TestCOSMultipartInitCancellationOverridesRetryableError(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:      server.Client().Transport,
+		err:       errors.New("http: server closed idle connection"),
+		failures:  1,
+		onFailure: cancel,
 	}
-	if state.initCalls.Load() != 0 {
-		t.Fatalf("pre-request EOF unexpectedly reached COS, got %d server init calls", state.initCalls.Load())
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(ctx, "object", bytes.NewReader(data), &size, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, int32(1), transport.initCalls.Load())
+	require.Zero(t, state.initCalls.Load())
+}
+
+func TestCOSMultipartInitDefinitiveErrorOverridesEarlierRetryableError(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	state.failCreate = true
+	state.failCreateStatus = http.StatusForbidden
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      sentinel,
+		failures: 1,
 	}
-	if state.completed.Load() {
-		t.Fatalf("unexpected multipart upload completion")
-	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), sentinel.Error())
+	require.Contains(t, err.Error(), "403")
+	require.Equal(t, int32(2), transport.initCalls.Load())
+	require.Equal(t, int32(1), state.initCalls.Load())
 }
 
 func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
@@ -1062,6 +1157,7 @@ func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 		{name: "server closed connection", err: errors.New("http: server closed idle connection")},
 	}
 
+	ambiguousBefore := testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var initCalls atomic.Int32
@@ -1076,46 +1172,131 @@ func TestCOSMultipartInitDoesNotRetryAfterRequestCommitted(t *testing.T) {
 			}))
 			defer server.Close()
 
-			baseClient := server.Client()
-			baseTransport := baseClient.Transport
-			if baseTransport == nil {
-				baseTransport = http.DefaultTransport
-			}
-			baseClient.Transport = &cosMultipartInitResponseLostTransport{
-				base: baseTransport,
+			sdk := newTestCOSClientWithTransport(t, server, &cosMultipartInitResponseLostTransport{
+				base: server.Client().Transport,
 				err:  test.err,
-			}
+			})
+			data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+			size := int64(len(data))
+			err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+			require.ErrorContains(t, err, test.err.Error())
+			require.Equal(t, int32(1), initCalls.Load())
+		})
+	}
+	require.Equal(t, ambiguousBefore+float64(len(tests)), testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
+}
 
-			baseURL, err := url.Parse(server.URL)
-			if err != nil {
-				t.Fatalf("parse url: %v", err)
-			}
-			client := costypes.NewClient(&costypes.BaseURL{BucketURL: baseURL}, baseClient)
-			client.Conf.EnableCRC = false
-			client.Conf.RetryOpt.Count = 0
-			sdk := &QCloudSDK{name: "cos-init-response-lost-test", client: client}
+func TestCOSMultipartInitDoesNotRetryInvalidSuccessBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body func() io.ReadCloser
+		err  error
+	}{
+		{
+			name: "empty",
+			body: func() io.ReadCloser { return io.NopCloser(strings.NewReader("")) },
+			err:  io.EOF,
+		},
+		{
+			name: "truncated",
+			body: func() io.ReadCloser {
+				return io.NopCloser(io.MultiReader(
+					strings.NewReader(`<InitiateMultipartUploadResult><UploadId>`),
+					multipartInitErrorReader{err: io.ErrUnexpectedEOF},
+				))
+			},
+			err: io.ErrUnexpectedEOF,
+		},
+	}
+
+	ambiguousBefore := testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, state := newMockCOSServer(t, 0)
+			defer server.Close()
+			state.uploadID = "committed-upload"
+			sdk := newTestCOSClientWithTransport(t, server, &cosMultipartInitInvalidSuccessBodyTransport{
+				base: server.Client().Transport,
+				body: test.body,
+			})
 
 			data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
 			size := int64(len(data))
-			err = sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
-			if err == nil {
-				t.Fatalf("expected multipart-init error")
-			}
-			if initCalls.Load() != 1 {
-				t.Fatalf("response-lost error must not create additional uploads, got %d", initCalls.Load())
-			}
+			err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+			require.ErrorContains(t, err, test.err.Error())
+			require.Equal(t, int32(1), state.initCalls.Load())
+			require.False(t, state.completed.Load())
+			require.False(t, state.aborted.Load())
 		})
 	}
+	require.Equal(t, ambiguousBefore+float64(len(tests)), testutil.ToFloat64(metric.FSMultipartInitAmbiguousCounter))
 }
 
-type cosMultipartInitEOFTransport struct {
+func TestCOSMultipartInitRetriesAreBoundedBeforeRequest(t *testing.T) {
+	server, state := newMockCOSServer(t, 0)
+	defer server.Close()
+	sentinel := errors.New("http: server closed idle connection")
+	transport := &cosMultipartInitBeforeRequestTransport{
+		base:     server.Client().Transport,
+		err:      sentinel,
+		failures: qcloudMultipartInitMaxAttempts,
+	}
+	sdk := newTestCOSClientWithTransport(t, server, transport)
+
+	data := bytes.Repeat([]byte("r"), int(minMultipartPartSize+1))
+	size := int64(len(data))
+	err := sdk.WriteMultipartParallel(context.Background(), "object", bytes.NewReader(data), &size, nil)
+	require.ErrorContains(t, err, sentinel.Error())
+	require.Equal(t, int32(qcloudMultipartInitMaxAttempts), transport.initCalls.Load())
+	require.Zero(t, state.initCalls.Load())
+}
+
+type cosMultipartInitBeforeRequestTransport struct {
 	base      http.RoundTripper
+	err       error
+	failures  int32
 	initCalls atomic.Int32
+	onFailure func()
 }
 
 type cosMultipartInitResponseLostTransport struct {
 	base http.RoundTripper
 	err  error
+}
+
+type cosMultipartInitInvalidSuccessBodyTransport struct {
+	base http.RoundTripper
+	body func() io.ReadCloser
+}
+
+type multipartInitErrorReader struct {
+	err error
+}
+
+func (r multipartInitErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+type denyMultipartListTransport struct {
+	base      http.RoundTripper
+	listCalls atomic.Int32
+}
+
+type cosMultipartInitCancelAfterResponseTransport struct {
+	base   http.RoundTripper
+	cancel context.CancelFunc
+}
+
+func newTestCOSClientWithTransport(t *testing.T, server *httptest.Server, transport http.RoundTripper) *QCloudSDK {
+	t.Helper()
+	baseURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	httpClient := server.Client()
+	httpClient.Transport = transport
+	client := costypes.NewClient(&costypes.BaseURL{BucketURL: baseURL}, httpClient)
+	client.Conf.EnableCRC = false
+	client.Conf.RetryOpt.Count = 0
+	return &QCloudSDK{name: "cos-multipart-init-test", client: client}
 }
 
 func (t *cosMultipartInitResponseLostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -1131,14 +1312,62 @@ func (t *cosMultipartInitResponseLostTransport) RoundTrip(req *http.Request) (*h
 	return resp, nil
 }
 
-func (t *cosMultipartInitEOFTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *cosMultipartInitInvalidSuccessBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
 	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
-		if t.initCalls.Add(1) == 1 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		resp.Body = t.body()
+		resp.ContentLength = -1
+	}
+	return resp, nil
+}
+
+func (t *cosMultipartInitCancelAfterResponseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.ContentLength = int64(len(body))
+		t.cancel()
+	}
+	return resp, nil
+}
+
+func (t *cosMultipartInitBeforeRequestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodPost && req.URL.Query().Has("uploads") {
+		if t.initCalls.Add(1) <= t.failures {
 			if req.Body != nil {
 				_ = req.Body.Close()
 			}
-			return nil, io.EOF
+			if t.onFailure != nil {
+				t.onFailure()
+			}
+			return nil, t.err
 		}
+	}
+	return t.base.RoundTrip(req)
+}
+
+func (t *denyMultipartListTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodGet && req.URL.Query().Has("uploads") {
+		t.listCalls.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("Access Denied")),
+			Request:    req,
+		}, nil
 	}
 	return t.base.RoundTrip(req)
 }

--- a/pkg/fileservice/qcloud_sdk.go
+++ b/pkg/fileservice/qcloud_sdk.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"iter"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"os"
 	gotrace "runtime/trace"
@@ -35,6 +36,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/tencentyun/cos-go-sdk-v5"
 	"go.uber.org/zap"
@@ -49,7 +51,11 @@ type QCloudSDK struct {
 	listMaxKeys          int
 }
 
-const qcloudMultipartAbortTimeout = 30 * time.Second
+const (
+	qcloudMultipartAbortTimeout    = 30 * time.Second
+	qcloudMultipartInitTimeout     = 30 * time.Second
+	qcloudMultipartInitMaxAttempts = 3
+)
 
 func NewQCloudSDK(
 	ctx context.Context,
@@ -341,6 +347,98 @@ func (a *QCloudSDK) SupportsParallelMultipart() bool {
 	return true
 }
 
+func waitQCloudMultipartInitRetry(ctx context.Context, attempt int) error {
+	delay := initialRetryInterval
+	for i := 0; i < attempt && delay < maxRetryInterval; i++ {
+		delay = time.Duration(float64(delay) * retryIntervalFactor)
+	}
+	if delay > maxRetryInterval {
+		delay = maxRetryInterval
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (a *QCloudSDK) initiateMultipartUpload(
+	ctx context.Context,
+	key string,
+	opt *cos.InitiateMultipartUploadOptions,
+) (*cos.InitiateMultipartUploadResult, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, qcloudMultipartInitTimeout, context.DeadlineExceeded)
+	defer cancel()
+
+	var lastErr error
+	for attempt := 0; attempt < qcloudMultipartInitMaxAttempts; attempt++ {
+		var wroteRequest atomic.Bool
+		attemptCtx := httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+			WroteRequest: func(httptrace.WroteRequestInfo) {
+				wroteRequest.Store(true)
+			},
+		})
+
+		metric.FSMultipartInitAttemptCounter.Inc()
+		output, response, createErr := a.client.Object.InitiateMultipartUpload(attemptCtx, key, opt)
+		if createErr == nil && (output == nil || output.UploadID == "") {
+			createErr = moerr.NewInternalErrorNoCtxf("cos initiate multipart upload returned an empty upload id for key %q", key)
+		}
+		lastErr = createErr
+		if output != nil && output.UploadID != "" {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				cleanupCtx, cleanupCancel := context.WithTimeoutCause(
+					context.WithoutCancel(ctx),
+					qcloudMultipartAbortTimeout,
+					context.DeadlineExceeded,
+				)
+				defer cleanupCancel()
+				if err := a.abortMultipartUpload(cleanupCtx, key, output.UploadID); err != nil {
+					logutil.Warn("failed to clean up canceled cos multipart init", zap.Error(err))
+				} else {
+					metric.FSMultipartInitCleanupCounter.Inc()
+				}
+				return nil, ctxErr
+			}
+			if attempt > 0 || createErr != nil {
+				metric.FSMultipartInitRecoveredCounter.Inc()
+			}
+			return output, nil
+		}
+		definitiveFailure := response != nil && response.Response != nil &&
+			(response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices)
+		commitAmbiguous := !definitiveFailure && (response != nil || wroteRequest.Load())
+		if commitAmbiguous {
+			metric.FSMultipartInitAmbiguousCounter.Inc()
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if commitAmbiguous {
+			// Without an UploadID, no client can distinguish this request's
+			// server-side state from another CN's upload. Do not list, claim, or
+			// abort candidates here; COS bucket lifecycle must reclaim any orphan.
+			logutil.Warn("cos multipart init is commit-ambiguous; bucket lifecycle must abort incomplete uploads",
+				zap.Error(createErr))
+			return nil, createErr
+		}
+		if !IsRetryableError(createErr) || attempt+1 >= qcloudMultipartInitMaxAttempts {
+			return nil, createErr
+		}
+		// WroteRequest is emitted by net/http once writing starts, including
+		// write failures. Its absence proves this attempt never crossed the
+		// transport write boundary. A non-2xx server response also proves the
+		// attempt failed, so either outcome is safe to retry.
+		if err := waitQCloudMultipartInitRetry(ctx, attempt); err != nil {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
 func (a *QCloudSDK) WriteMultipartParallel(
 	ctx context.Context,
 	key string,
@@ -430,10 +528,7 @@ func (a *QCloudSDK) WriteMultipartParallel(
 			Expires: expiresHeader,
 		},
 	}
-	// InitiateMultipartUpload creates server-side state and has no idempotency
-	// key. Any error without a usable UploadID is commit-ambiguous, so retrying
-	// could create an unreachable multipart upload that this caller cannot abort.
-	output, _, createErr := a.client.Object.InitiateMultipartUpload(ctx, key, initOpt)
+	output, createErr := a.initiateMultipartUpload(ctx, key, initOpt)
 	if createErr != nil {
 		releasePartBuffer(firstPart)
 		return createErr

--- a/pkg/util/metric/v2/fileservice.go
+++ b/pkg/util/metric/v2/fileservice.go
@@ -142,6 +142,20 @@ var (
 )
 
 var (
+	fsMultipartInitCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "fs",
+			Name:      "multipart_init_total",
+			Help:      "Total number of multipart initialization lifecycle events.",
+		}, []string{"event"})
+	FSMultipartInitAttemptCounter   = fsMultipartInitCounter.WithLabelValues("attempt")
+	FSMultipartInitAmbiguousCounter = fsMultipartInitCounter.WithLabelValues("ambiguous")
+	FSMultipartInitRecoveredCounter = fsMultipartInitCounter.WithLabelValues("recovered")
+	FSMultipartInitCleanupCounter   = fsMultipartInitCounter.WithLabelValues("cleanup")
+)
+
+var (
 	FSObjectStorageOperations = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "mo",

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -121,6 +121,7 @@ func initFileServiceMetrics() {
 	registry.MustRegister(ioMergerCounter)
 	registry.MustRegister(ioMergerDuration)
 	registry.MustRegister(fsReadWriteDuration)
+	registry.MustRegister(fsMultipartInitCounter)
 	registry.MustRegister(FSObjectStorageOperations)
 
 	registry.MustRegister(FSHTTPTraceCounter)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28028. This PR intentionally does not close the issue because safe client-side reclamation of a commit-ambiguous upload still requires a cross-CN ownership protocol.

## What this PR does / why we need it:

- Uses `net/http/httptrace.WroteRequest` to retry Tencent COS multipart initialization only when the request did not cross the transport write boundary, or when COS returned a definitive retryable error response.
- Returns the current terminal result: caller cancellation/deadline wins, and a later definitive response such as 403 is not hidden by an earlier transient error.
- Counts `ambiguous` only when a request was written but no COS response or usable UploadID was returned.
- Never infers UploadID ownership from bucket listings, so it cannot adopt, complete, or abort another SDK/CN's multipart upload.
- Keeps the normal multipart path compatible with credentials that do not grant `cos:ListMultipartUploads`; no bucket LIST is added.
- Keeps retries and backoff bounded without changing upload-part concurrency or HTTP connection reuse.

Operational contract and remaining scope:

- If a request was written but its response was lost, MatrixOne cannot safely identify the resulting UploadID across CNs. It fails conservatively and emits an `ambiguous` metric plus a warning.
- COS buckets must configure a lifecycle rule that aborts incomplete multipart uploads to reclaim such ownerless state.
- A future complete fix for response-loss reclamation requires a server-visible, cross-CN ownership mechanism; #28028 remains open for that work.

Validation:

- Focused COS/QCloud tests pass.
- Cross-instance ownership, pre-request recovery, committed-response loss, IAM compatibility, cancellation precedence, terminal 403 precedence, and owned cleanup tests pass with focused race validation.
- `pkg/util/metric/v2` tests pass.
- Multipart-init helper changed-logic coverage remains above 75%.
- `go vet ./pkg/fileservice ./pkg/util/metric/v2` passes with the repository CGo environment.

