### PR TITLE
fix(clone): skip external tables in database clone

### DIFF
--- a/clients/python/docs/clone_guide.rst
+++ b/clients/python/docs/clone_guide.rst
@@ -185,9 +185,11 @@ External Tables and Dependent Objects
 
 Database cloning intentionally omits external tables because their data and
 files are managed outside MatrixOne. Views, SQL functions, and stored
-procedures that directly or transitively depend on an omitted external table
-or an omitted dependent view are omitted as well. Independent SQL routine
-families are copied and rewritten for the target database. UDF overloads with
+procedures that directly or transitively depend on an omitted external table,
+view, or routine are omitted as well. This closure is applied in both
+directions, so a view that calls an omitted SQL function is omitted before view
+restoration. Independent SQL routine families are copied and rewritten for the
+target database. UDF overloads with
 the same database, name, and kind are treated as one family: if dependency
 inspection omits one overload, the whole family is omitted because clone-time
 metadata inspection does not resolve overload types at every call site.

--- a/clients/python/docs/clone_guide.rst
+++ b/clients/python/docs/clone_guide.rst
@@ -189,16 +189,19 @@ procedures that directly or transitively depend on an omitted external table,
 view, or routine are omitted as well. This closure is applied in both
 directions, so a view that calls an omitted SQL function is omitted before view
 restoration. Independent SQL routine families are copied and rewritten for the
-target database. UDF overloads with
+target database. Supported non-SQL UDFs with inline bodies are opaque to the
+SQL dependency walker and are copied without body rewriting; imported
+non-SQL UDF packages are rejected before the target database is created because
+their package objects are not snapshot-versioned. UDF overloads with
 the same database, name, and kind are treated as one family: if dependency
 inspection omits one overload, the whole family is omitted because clone-time
 metadata inspection does not resolve overload types at every call site.
-Routines whose bodies cannot be structurally inspected are also omitted when
-the source contains an omitted relation. Executable ``USE`` statements are
-treated as uninspectable for this purpose because control-flow branches can
-make more than one default database reachable; this avoids assigning an
-unqualified reference to the wrong database. Explicit single-table cloning of
-an external table remains unsupported.
+SQL routines whose bodies cannot be structurally inspected are omitted when the
+source contains an omitted relation. Executable ``USE`` statements are treated
+as uninspectable for this purpose because control-flow branches can make more
+than one default database reachable; this avoids assigning an unqualified
+reference to the wrong database. Explicit single-table cloning of an external
+table remains unsupported.
 
 Schema-Only Cloning
 ~~~~~~~~~~~~~~~~~~~

--- a/clients/python/docs/clone_guide.rst
+++ b/clients/python/docs/clone_guide.rst
@@ -192,8 +192,11 @@ the same database, name, and kind are treated as one family: if dependency
 inspection omits one overload, the whole family is omitted because clone-time
 metadata inspection does not resolve overload types at every call site.
 Routines whose bodies cannot be structurally inspected are also omitted when
-the source contains an omitted relation. Explicit single-table cloning of an
-external table remains unsupported.
+the source contains an omitted relation. Executable ``USE`` statements are
+treated as uninspectable for this purpose because control-flow branches can
+make more than one default database reachable; this avoids assigning an
+unqualified reference to the wrong database. Explicit single-table cloning of
+an external table remains unsupported.
 
 Schema-Only Cloning
 ~~~~~~~~~~~~~~~~~~~

--- a/clients/python/docs/clone_guide.rst
+++ b/clients/python/docs/clone_guide.rst
@@ -8,7 +8,7 @@ Overview
 
 MatrixOne's cloning system provides:
 
-* **Database Cloning**: Create complete copies of databases with all tables and data
+* **Database Cloning**: Create copies of MatrixOne-managed database tables and data
 * **Table Cloning**: Clone individual tables with or without data
 * **Schema-Only Cloning**: Clone database structure without data
 * **Selective Cloning**: Clone specific tables or schemas
@@ -154,7 +154,7 @@ Full Database Cloning
 
 .. code-block:: python
 
-   # Clone entire database with all data
+   # Clone the entire database with MatrixOne-managed data
    clone_result = clone_manager.clone_database(
        source_database="production_db",
        target_database="test_db",
@@ -179,6 +179,18 @@ Full Database Cloning
        target_server="backup-server:6001",
        include_data=True
    )
+
+External Tables and Dependent Objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Database cloning intentionally omits external tables because their data and
+files are managed outside MatrixOne. Views, SQL functions, and stored
+procedures that directly or transitively depend on an omitted external table
+or an omitted dependent view are omitted as well. Independent SQL routines
+are copied and rewritten for the target database. Routines whose bodies cannot
+be structurally inspected are also omitted when the source contains an omitted
+relation. Explicit single-table cloning of an external table remains
+unsupported.
 
 Schema-Only Cloning
 ~~~~~~~~~~~~~~~~~~~

--- a/clients/python/docs/clone_guide.rst
+++ b/clients/python/docs/clone_guide.rst
@@ -186,11 +186,14 @@ External Tables and Dependent Objects
 Database cloning intentionally omits external tables because their data and
 files are managed outside MatrixOne. Views, SQL functions, and stored
 procedures that directly or transitively depend on an omitted external table
-or an omitted dependent view are omitted as well. Independent SQL routines
-are copied and rewritten for the target database. Routines whose bodies cannot
-be structurally inspected are also omitted when the source contains an omitted
-relation. Explicit single-table cloning of an external table remains
-unsupported.
+or an omitted dependent view are omitted as well. Independent SQL routine
+families are copied and rewritten for the target database. UDF overloads with
+the same database, name, and kind are treated as one family: if dependency
+inspection omits one overload, the whole family is omitted because clone-time
+metadata inspection does not resolve overload types at every call site.
+Routines whose bodies cannot be structurally inspected are also omitted when
+the source contains an omitted relation. Explicit single-table cloning of an
+external table remains unsupported.
 
 Schema-Only Cloning
 ~~~~~~~~~~~~~~~~~~~

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -1302,9 +1302,18 @@ func handleCloneDatabaseWithSource(
 		}
 	}
 
-	// Sort views before filtering routines. The sort marks views whose
-	// definitions depend on omitted external relations, allowing the routine
-	// filter to apply the same omission contract transitively.
+	lowerCaseTableNames := parserLowerCaseTableNames(ses)
+	// Build one omission closure before sorting views. Views and routines can
+	// depend on each other, so filtering routines after view planning would
+	// allow a view to bind an omitted UDF and fail during restoration.
+	omissions, err := collectCloneDatabaseOmissionSet(
+		reqCtx, source, lowerCaseTableNames,
+	)
+	if err != nil {
+		return
+	}
+	applyCloneDatabaseOmissionSet(&source, omissions, lowerCaseTableNames)
+
 	if len(source.viewMap) != 0 {
 		viewSnapshot := prepareCloneViewSnapshot(source.snapshot, restoreSnapshotTS)
 		fromAccount := source.opAccountId
@@ -1319,11 +1328,6 @@ func handleCloneDatabaseWithSource(
 		}
 	}
 
-	if source.userDefinedFuncs, source.storedProcedures, err = filterCloneDatabaseRoutines(
-		reqCtx, source, parserLowerCaseTableNames(ses),
-	); err != nil {
-		return
-	}
 	if err = validateCloneUserDefinedFunctions(source.userDefinedFuncs); err != nil {
 		return
 	}
@@ -1332,7 +1336,7 @@ func handleCloneDatabaseWithSource(
 		source.userDefinedFuncs,
 		source.srcResolveDBName,
 		stmt.DstDatabase.String(),
-		parserLowerCaseTableNames(ses),
+		lowerCaseTableNames,
 	); err != nil {
 		return
 	}
@@ -1341,7 +1345,7 @@ func handleCloneDatabaseWithSource(
 		source.storedProcedures,
 		source.srcResolveDBName,
 		stmt.DstDatabase.String(),
-		parserLowerCaseTableNames(ses),
+		lowerCaseTableNames,
 	); err != nil {
 		return
 	}

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -510,7 +510,7 @@ func lockDataBranchCloneDatabaseSources(
 		return tables[i].tblName < tables[j].tblName
 	})
 	for _, table := range tables {
-		if table.typ == view {
+		if table.typ == view || shouldSkipRestoreTableInBulk(table) {
 			continue
 		}
 		if err := lockDataBranchCloneSource(
@@ -551,7 +551,7 @@ func forEachCloneDatabaseSourceTable(
 	fn func(*tableInfo) error,
 ) error {
 	for _, table := range source.srcTblInfos {
-		if table.typ == view {
+		if table.typ == view || shouldSkipRestoreTableInBulk(table) {
 			continue
 		}
 		if err := fn(table); err != nil {
@@ -1298,7 +1298,7 @@ func handleCloneDatabaseWithSource(
 			continue
 		}
 
-		if srcTbl.typ == view || isSequence(srcTbl) {
+		if srcTbl.typ == view || isSequence(srcTbl) || shouldSkipRestoreTableInBulk(srcTbl) {
 			continue
 		}
 
@@ -1313,6 +1313,9 @@ func handleCloneDatabaseWithSource(
 	// clone foreign key related table
 	for _, key := range source.sortedFkTbls {
 		if tblInfo := source.fkTableMap[key]; tblInfo != nil {
+			if shouldSkipRestoreTableInBulk(tblInfo) {
+				continue
+			}
 			if err = cloneTable(
 				stmt.DstDatabase.String(), tblInfo.tblName,
 				stmt.SrcDatabase.String(), tblInfo.tblName,

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -502,7 +502,7 @@ func lockDataBranchCloneDatabaseSources(
 	if source.snapshot != nil && source.snapshot.Tenant != nil {
 		fromAccountID = source.snapshot.Tenant.TenantID
 	}
-	tables := append([]*tableInfo(nil), source.srcTblInfos...)
+	tables := append([]*tableInfo(nil), source.sourceTableInfosForLifecycle()...)
 	sort.Slice(tables, func(i, j int) bool {
 		if tables[i].dbName != tables[j].dbName {
 			return tables[i].dbName < tables[j].dbName
@@ -510,9 +510,6 @@ func lockDataBranchCloneDatabaseSources(
 		return tables[i].tblName < tables[j].tblName
 	})
 	for _, table := range tables {
-		if table.typ == view || shouldSkipRestoreTableInBulk(table) {
-			continue
-		}
 		if err := lockDataBranchCloneSource(
 			ctx, ses, bh, fromAccountID, table.dbName, table.tblName,
 		); err != nil {
@@ -550,10 +547,7 @@ func forEachCloneDatabaseSourceTable(
 	source cloneDatabaseSource,
 	fn func(*tableInfo) error,
 ) error {
-	for _, table := range source.srcTblInfos {
-		if table.typ == view || shouldSkipRestoreTableInBulk(table) {
-			continue
-		}
+	for _, table := range source.sourceTableInfosForLifecycle() {
 		if err := fn(table); err != nil {
 			return err
 		}
@@ -1053,7 +1047,9 @@ func handleCloneDatabaseWithSource(
 
 		ctx1 context.Context
 
-		sortedViews []string
+		sortedViews      []string
+		rewrittenViewMap map[string]*tableInfo
+		rewrittenViews   []string
 
 		snapshotTS int64
 		source     cloneDatabaseSource
@@ -1142,25 +1138,6 @@ func handleCloneDatabaseWithSource(
 	if err = revalidateTimestampDataBranchCloneDatabaseSource(reqCtx, ses, bh, source); err != nil {
 		return
 	}
-	if source.userDefinedFuncs, err = rewriteCloneUserDefinedFunctionBodies(
-		reqCtx,
-		source.userDefinedFuncs,
-		source.srcResolveDBName,
-		stmt.DstDatabase.String(),
-		parserLowerCaseTableNames(ses),
-	); err != nil {
-		return
-	}
-	if source.storedProcedures, err = rewriteCloneStoredProcedureBodies(
-		reqCtx,
-		source.storedProcedures,
-		source.srcResolveDBName,
-		stmt.DstDatabase.String(),
-		parserLowerCaseTableNames(ses),
-	); err != nil {
-		return
-	}
-
 	if source.hasFkCycle {
 		oldForeignKeyChecksReplayable, hadForeignKeyChecksReplayability :=
 			ses.getMigrationSystemVarReplayability("foreign_key_checks")
@@ -1283,7 +1260,7 @@ func handleCloneDatabaseWithSource(
 		return nil
 	}
 
-	for _, srcTbl := range source.srcTblInfos {
+	for _, srcTbl := range source.cloneableTableInfos() {
 		if isSequence(srcTbl) {
 			if err = cloneSequence(srcTbl); err != nil {
 				return
@@ -1291,14 +1268,14 @@ func handleCloneDatabaseWithSource(
 		}
 	}
 
-	for _, srcTbl := range source.srcTblInfos {
+	for _, srcTbl := range source.cloneableTableInfos() {
 
 		key := genKey(srcTbl.dbName, srcTbl.tblName)
 		if _, ok := source.fkTableMap[key]; ok {
 			continue
 		}
 
-		if srcTbl.typ == view || isSequence(srcTbl) || shouldSkipRestoreTableInBulk(srcTbl) {
+		if srcTbl.typ == view || isSequence(srcTbl) {
 			continue
 		}
 
@@ -1313,7 +1290,7 @@ func handleCloneDatabaseWithSource(
 	// clone foreign key related table
 	for _, key := range source.sortedFkTbls {
 		if tblInfo := source.fkTableMap[key]; tblInfo != nil {
-			if shouldSkipRestoreTableInBulk(tblInfo) {
+			if !isCloneableCloneDatabaseTable(tblInfo) {
 				continue
 			}
 			if err = cloneTable(
@@ -1323,6 +1300,50 @@ func handleCloneDatabaseWithSource(
 				return
 			}
 		}
+	}
+
+	// Sort views before filtering routines. The sort marks views whose
+	// definitions depend on omitted external relations, allowing the routine
+	// filter to apply the same omission contract transitively.
+	if len(source.viewMap) != 0 {
+		viewSnapshot := prepareCloneViewSnapshot(source.snapshot, restoreSnapshotTS)
+		fromAccount := source.opAccountId
+		if viewSnapshot != nil && viewSnapshot.Tenant != nil {
+			fromAccount = viewSnapshot.Tenant.TenantID
+		}
+
+		if sortedViews, err = sortedViewInfos(
+			reqCtx, ses, bh, "", viewSnapshot, source.viewMap, fromAccount, source.toAccountId,
+		); err != nil {
+			return
+		}
+	}
+
+	if source.userDefinedFuncs, source.storedProcedures, err = filterCloneDatabaseRoutines(
+		reqCtx, source, parserLowerCaseTableNames(ses),
+	); err != nil {
+		return
+	}
+	if err = validateCloneUserDefinedFunctions(source.userDefinedFuncs); err != nil {
+		return
+	}
+	if source.userDefinedFuncs, err = rewriteCloneUserDefinedFunctionBodies(
+		reqCtx,
+		source.userDefinedFuncs,
+		source.srcResolveDBName,
+		stmt.DstDatabase.String(),
+		parserLowerCaseTableNames(ses),
+	); err != nil {
+		return
+	}
+	if source.storedProcedures, err = rewriteCloneStoredProcedureBodies(
+		reqCtx,
+		source.storedProcedures,
+		source.srcResolveDBName,
+		stmt.DstDatabase.String(),
+		parserLowerCaseTableNames(ses),
+	); err != nil {
+		return
 	}
 
 	// Routines are catalog metadata rather than mo_tables. Restore functions
@@ -1349,20 +1370,6 @@ func handleCloneDatabaseWithSource(
 
 	// clone view table
 	if len(source.viewMap) != 0 {
-		viewSnapshot := prepareCloneViewSnapshot(source.snapshot, restoreSnapshotTS)
-		fromAccount := source.opAccountId
-		if viewSnapshot != nil && viewSnapshot.Tenant != nil {
-			fromAccount = viewSnapshot.Tenant.TenantID
-		}
-
-		if sortedViews, err = sortedViewInfos(
-			reqCtx, ses, bh, "", viewSnapshot, source.viewMap, fromAccount, source.toAccountId,
-		); err != nil {
-			return
-		}
-
-		var rewrittenViewMap map[string]*tableInfo
-		var rewrittenViews []string
 		rewrittenViewMap, rewrittenViews, err = rewriteCloneViewInfos(
 			source.viewMap,
 			sortedViews,

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -57,7 +57,7 @@ type cloneDatabaseAccountResolution struct {
 func (source *cloneDatabaseSource) branchTableCount() int64 {
 	var count int64
 	for _, table := range source.srcTblInfos {
-		if table.typ != view && !isSequence(table) {
+		if table.typ != view && !isSequence(table) && !shouldSkipRestoreTableInBulk(table) {
 			count++
 		}
 	}

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -381,17 +381,6 @@ func collectCloneDatabaseOmissionSet(
 	return omissions, nil
 }
 
-// omittedCloneDatabaseObjects retains the relation-only view of the omission
-// graph for callers that only need the catalog objects absent from the target.
-func omittedCloneDatabaseObjects(
-	ctx context.Context,
-	source cloneDatabaseSource,
-	lowerCaseTableNames int64,
-) (map[string]struct{}, error) {
-	omissions, err := collectCloneDatabaseOmissionSet(ctx, source, lowerCaseTableNames)
-	return omissions.objects, err
-}
-
 func applyCloneDatabaseOmissionSet(
 	source *cloneDatabaseSource,
 	omissions cloneDatabaseOmissionSet,

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -54,14 +54,387 @@ type cloneDatabaseAccountResolution struct {
 	snapshot    *plan.Snapshot
 }
 
+// isCloneableCloneDatabaseTable is the single relation-kind policy for a
+// database clone. External tables are catalog objects, but their data lives
+// outside MatrixOne and the database-clone contract intentionally omits them.
+func isCloneableCloneDatabaseTable(tblInfo *tableInfo) bool {
+	return tblInfo != nil && !shouldSkipRestoreTableInBulk(tblInfo)
+}
+
+func (source cloneDatabaseSource) cloneableTableInfos() []*tableInfo {
+	tables := make([]*tableInfo, 0, len(source.srcTblInfos))
+	for _, table := range source.srcTblInfos {
+		if isCloneableCloneDatabaseTable(table) {
+			tables = append(tables, table)
+		}
+	}
+	return tables
+}
+
+// sourceTableInfosForLifecycle contains every non-view source relation whose
+// catalog row may be consulted after source collection. External tables stay
+// in this set even though they are not cloneable: live DATA BRANCH clones
+// re-plan views after advancing the timestamp, and that dependency planning
+// reads the external relation metadata. The lifecycle fence must therefore
+// cover the row without granting, accounting, or materializing the table.
+func (source cloneDatabaseSource) sourceTableInfosForLifecycle() []*tableInfo {
+	tables := make([]*tableInfo, 0, len(source.srcTblInfos))
+	for _, table := range source.srcTblInfos {
+		if table != nil && table.typ != view {
+			tables = append(tables, table)
+		}
+	}
+	return tables
+}
+
 func (source *cloneDatabaseSource) branchTableCount() int64 {
 	var count int64
-	for _, table := range source.srcTblInfos {
-		if table.typ != view && !isSequence(table) && !shouldSkipRestoreTableInBulk(table) {
+	for _, table := range source.cloneableTableInfos() {
+		if table.typ != view && !isSequence(table) {
 			count++
 		}
 	}
 	return count
+}
+
+const (
+	cloneRoutineFunctionKind  = "function"
+	cloneRoutineProcedureKind = "procedure"
+)
+
+type cloneRoutineReferences struct {
+	tables     map[string]struct{}
+	procedures map[string]struct{}
+	functions  map[string]struct{}
+}
+
+type cloneRoutineDependency struct {
+	key         string
+	references  cloneRoutineReferences
+	inspectable bool
+	skipped     bool
+}
+
+func cloneDatabaseObjectKey(databaseName, objectName string, lowerCaseTableNames int64) string {
+	return genKey(
+		tree.NewCStr(databaseName, lowerCaseTableNames).Compare(),
+		tree.NewCStr(objectName, lowerCaseTableNames).Compare(),
+	)
+}
+
+func cloneRoutineKey(kind, databaseName, routineName string, lowerCaseTableNames int64) string {
+	return kind + KeySep + cloneDatabaseObjectKey(databaseName, routineName, lowerCaseTableNames)
+}
+
+func cloneDatabaseSourceObjectKey(source cloneDatabaseSource, tblInfo *tableInfo, lowerCaseTableNames int64) string {
+	databaseName := tblInfo.dbName
+	if databaseName == "" {
+		databaseName = source.srcResolveDBName
+	}
+	return cloneDatabaseObjectKey(databaseName, tblInfo.tblName, lowerCaseTableNames)
+}
+
+func collectCloneViewTableDependencies(
+	ctx context.Context,
+	tblInfo *tableInfo,
+	lowerCaseTableNames int64,
+) (map[string]struct{}, error) {
+	dependencies := make(map[string]struct{})
+	statements, err := parseViewCreateSQLForRestore(ctx, tblInfo, lowerCaseTableNames)
+	if err != nil {
+		return nil, err
+	}
+	defer freeStatements(statements)
+	if len(statements) != 1 {
+		return nil, moerr.NewInternalErrorNoCtxf(
+			"clone view SQL for %s.%s produced %d statements",
+			tblInfo.dbName, tblInfo.tblName, len(statements),
+		)
+	}
+	createView, ok := statements[0].(*tree.CreateView)
+	if !ok {
+		return nil, moerr.NewInternalErrorNoCtxf(
+			"clone view SQL for %s.%s is %T, expected *tree.CreateView",
+			tblInfo.dbName, tblInfo.tblName, statements[0],
+		)
+	}
+	remapDbInSelect(createView.AsSource, remapDbContext{
+		collectTableName: func(name *tree.TableName) {
+			databaseName := tblInfo.dbName
+			if name.ExplicitSchema {
+				databaseName = string(name.SchemaName)
+			}
+			dependencies[cloneDatabaseObjectKey(
+				databaseName, string(name.ObjectName), lowerCaseTableNames,
+			)] = struct{}{}
+		},
+	})
+	return dependencies, nil
+}
+
+// omittedCloneDatabaseObjects returns the relation objects that will not be
+// present in the target. View sorting must run before this helper so that a
+// view whose definition depends on an omitted external relation is included
+// in the same omission set as the external relation itself.
+func omittedCloneDatabaseObjects(
+	ctx context.Context,
+	source cloneDatabaseSource,
+	lowerCaseTableNames int64,
+) (map[string]struct{}, error) {
+	omitted := make(map[string]struct{})
+	for _, tblInfo := range source.srcTblInfos {
+		if tblInfo != nil && !isCloneableCloneDatabaseTable(tblInfo) {
+			omitted[cloneDatabaseSourceObjectKey(source, tblInfo, lowerCaseTableNames)] = struct{}{}
+		}
+	}
+	viewDependencies := make(map[string]map[string]struct{}, len(source.viewMap))
+	for _, tblInfo := range source.viewMap {
+		if tblInfo == nil {
+			continue
+		}
+		viewKey := cloneDatabaseSourceObjectKey(source, tblInfo, lowerCaseTableNames)
+		if tblInfo.unservable {
+			omitted[viewKey] = struct{}{}
+		}
+		dependencies, err := collectCloneViewTableDependencies(ctx, tblInfo, lowerCaseTableNames)
+		if err != nil {
+			return nil, err
+		}
+		viewDependencies[viewKey] = dependencies
+	}
+	changed := true
+	for changed {
+		changed = false
+		for viewKey, dependencies := range viewDependencies {
+			if _, alreadyOmitted := omitted[viewKey]; alreadyOmitted {
+				continue
+			}
+			for dependency := range dependencies {
+				if _, dependencyOmitted := omitted[dependency]; dependencyOmitted {
+					omitted[viewKey] = struct{}{}
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return omitted, nil
+}
+
+func collectCloneRoutineReferences(
+	ctx context.Context,
+	body string,
+	lang string,
+	sqlMode string,
+	srcDBName string,
+	lowerCaseTableNames int64,
+	isFunction bool,
+) (cloneRoutineReferences, bool, error) {
+	references := cloneRoutineReferences{
+		tables:     make(map[string]struct{}),
+		procedures: make(map[string]struct{}),
+		functions:  make(map[string]struct{}),
+	}
+	if !strings.EqualFold(lang, string(tree.SQL)) {
+		return references, false, nil
+	}
+
+	parseBody := body
+	parseAsExpression := isFunction && !cloneSQLFunctionBodyIsQuery(body)
+	if parseAsExpression {
+		// SQL UDF metadata stores scalar bodies without a SELECT wrapper. Parse
+		// them as a projection so calls to another SQL UDF remain visible to the
+		// dependency graph without changing the stored definition.
+		parseBody = "select " + body
+	}
+	statements, err := parsers.ParseWithSQLMode(
+		ctx, dialect.MYSQL, parseBody, lowerCaseTableNames, sqlMode,
+	)
+	if err != nil {
+		if parseAsExpression {
+			// Existing scalar UDF clone support does not parse these bodies. Keep
+			// that compatibility behavior, but let the caller omit an
+			// uninspectable routine whenever the clone already omits a relation.
+			return references, false, nil
+		}
+		return references, false, err
+	}
+	defer freeStatements(statements)
+
+	unsupported := false
+	remappable := remapDbInStatements(statements, remapDbContext{
+		lowerCaseTableNames: lowerCaseTableNames,
+		unsupported:         &unsupported,
+		collectTableName: func(name *tree.TableName) {
+			databaseName := srcDBName
+			if name.ExplicitSchema {
+				databaseName = string(name.SchemaName)
+			}
+			references.tables[cloneDatabaseObjectKey(
+				databaseName, string(name.ObjectName), lowerCaseTableNames,
+			)] = struct{}{}
+		},
+		collectProcedureName: func(name *tree.ProcedureName) {
+			databaseName := srcDBName
+			if name.Name.ExplicitSchema {
+				databaseName = string(name.Name.SchemaName)
+			}
+			references.procedures[cloneRoutineKey(
+				cloneRoutineProcedureKind, databaseName,
+				string(name.Name.ObjectName), lowerCaseTableNames,
+			)] = struct{}{}
+		},
+		collectFunctionName: func(name *tree.UnresolvedName) {
+			if name == nil || name.NumParts == 0 {
+				return
+			}
+			databaseName := srcDBName
+			if name.NumParts >= 3 {
+				databaseName = name.DbNameOrigin()
+			} else if name.NumParts >= 2 {
+				databaseName = name.TblNameOrigin()
+			}
+			references.functions[cloneRoutineKey(
+				cloneRoutineFunctionKind, databaseName,
+				name.ColNameOrigin(), lowerCaseTableNames,
+			)] = struct{}{}
+		},
+	})
+	return references, remappable && !unsupported, nil
+}
+
+// filterCloneDatabaseRoutines keeps independent routines and omits routines
+// whose direct or transitive dependencies cannot exist in the target. A
+// non-SQL or otherwise uninspectable routine is omitted when the source has an
+// omitted relation; persisting it would report success while retaining a
+// dependency that this clone cannot verify.
+func filterCloneDatabaseRoutines(
+	ctx context.Context,
+	source cloneDatabaseSource,
+	lowerCaseTableNames int64,
+) ([]userDefinedFunctionDefinition, []storedProcedureDefinition, error) {
+	omittedObjects, err := omittedCloneDatabaseObjects(ctx, source, lowerCaseTableNames)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(omittedObjects) == 0 {
+		return slices.Clone(source.userDefinedFuncs), slices.Clone(source.storedProcedures), nil
+	}
+
+	dependencies := make([]cloneRoutineDependency, 0, len(source.userDefinedFuncs)+len(source.storedProcedures))
+	functionKeys := make(map[string]struct{}, len(source.userDefinedFuncs))
+	procedureKeys := make(map[string]struct{}, len(source.storedProcedures))
+	for _, definition := range source.userDefinedFuncs {
+		key := cloneRoutineKey(
+			cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+		)
+		functionKeys[key] = struct{}{}
+		dependencies = append(dependencies, cloneRoutineDependency{key: key})
+	}
+	for _, definition := range source.storedProcedures {
+		key := cloneRoutineKey(
+			cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+		)
+		procedureKeys[key] = struct{}{}
+		dependencies = append(dependencies, cloneRoutineDependency{key: key})
+	}
+
+	dependencyIndex := 0
+	for _, definition := range source.userDefinedFuncs {
+		references, inspectable, err := collectCloneRoutineReferences(
+			ctx, definition.body, definition.lang, definition.sqlMode,
+			source.srcResolveDBName, lowerCaseTableNames, true,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		dependencies[dependencyIndex].references = references
+		dependencies[dependencyIndex].inspectable = inspectable
+		dependencyIndex++
+	}
+	for _, definition := range source.storedProcedures {
+		references, inspectable, err := collectCloneRoutineReferences(
+			ctx, definition.body, definition.lang, definition.sqlMode,
+			source.srcResolveDBName, lowerCaseTableNames, false,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		dependencies[dependencyIndex].references = references
+		dependencies[dependencyIndex].inspectable = inspectable
+		dependencyIndex++
+	}
+
+	skippedRoutines := make(map[string]struct{})
+	for i := range dependencies {
+		dependency := &dependencies[i]
+		if !dependency.inspectable {
+			dependency.skipped = true
+		} else {
+			for tableKey := range dependency.references.tables {
+				if _, ok := omittedObjects[tableKey]; ok {
+					dependency.skipped = true
+					break
+				}
+			}
+		}
+		if dependency.skipped {
+			skippedRoutines[dependency.key] = struct{}{}
+		}
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for i := range dependencies {
+			dependency := &dependencies[i]
+			if dependency.skipped {
+				continue
+			}
+			for functionKey := range dependency.references.functions {
+				if _, known := functionKeys[functionKey]; known {
+					if _, skipped := skippedRoutines[functionKey]; skipped {
+						dependency.skipped = true
+						break
+					}
+				}
+			}
+			if !dependency.skipped {
+				for procedureKey := range dependency.references.procedures {
+					if _, known := procedureKeys[procedureKey]; known {
+						if _, skipped := skippedRoutines[procedureKey]; skipped {
+							dependency.skipped = true
+							break
+						}
+					}
+				}
+			}
+			if dependency.skipped {
+				skippedRoutines[dependency.key] = struct{}{}
+				changed = true
+			}
+		}
+	}
+
+	filteredFunctions := make([]userDefinedFunctionDefinition, 0, len(source.userDefinedFuncs))
+	for _, definition := range source.userDefinedFuncs {
+		key := cloneRoutineKey(
+			cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+		)
+		if _, skipped := skippedRoutines[key]; !skipped {
+			filteredFunctions = append(filteredFunctions, definition)
+		}
+	}
+	filteredProcedures := make([]storedProcedureDefinition, 0, len(source.storedProcedures))
+	for _, definition := range source.storedProcedures {
+		key := cloneRoutineKey(
+			cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+		)
+		if _, skipped := skippedRoutines[key]; !skipped {
+			filteredProcedures = append(filteredProcedures, definition)
+		}
+	}
+	return filteredFunctions, filteredProcedures, nil
 }
 
 func collectCloneDatabaseSource(
@@ -426,7 +799,18 @@ func rewriteCloneUserDefinedFunctionBodies(
 	return rewritten, nil
 }
 
-// SQL UDF query bodies follow the same case-sensitive parsing rule as the
+func cloneSQLFunctionBodyIsQuery(body string) bool {
+	trimmed := strings.TrimSpace(body)
+	lower := strings.ToLower(trimmed)
+	return strings.HasPrefix(lower, "select ") ||
+		strings.HasPrefix(lower, "select\n") ||
+		strings.HasPrefix(lower, "select\t") ||
+		strings.HasPrefix(lower, "with ") ||
+		strings.HasPrefix(lower, "with\n") ||
+		strings.HasPrefix(lower, "with\t")
+}
+
+// SQL UDF query bodies need the same case-insensitive query detection as the
 // binder. Scalar expressions cannot contain a qualified table reference, so
 // they need no database remap and remain byte-for-byte unchanged.
 func rewriteCloneSQLFunctionBody(
@@ -437,7 +821,7 @@ func rewriteCloneSQLFunctionBody(
 	dstDBName string,
 	lowerCaseTableNames int64,
 ) (string, error) {
-	if !strings.Contains(body, "select") {
+	if !cloneSQLFunctionBodyIsQuery(body) {
 		return body, nil
 	}
 	return rewriteCloneSQLRoutineBody(

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -98,8 +98,9 @@ func (source *cloneDatabaseSource) branchTableCount() int64 {
 }
 
 const (
-	cloneRoutineFunctionKind  = "function"
-	cloneRoutineProcedureKind = "procedure"
+	cloneRoutineFunctionKind    = "function"
+	cloneRoutineProcedureKind   = "procedure"
+	cloneDatabaseObjectNodeKind = "object"
 )
 
 type cloneRoutineReferences struct {
@@ -108,11 +109,23 @@ type cloneRoutineReferences struct {
 	functions  map[string]struct{}
 }
 
-type cloneRoutineDependency struct {
-	key         string
-	references  cloneRoutineReferences
-	inspectable bool
-	skipped     bool
+type cloneDatabaseOmissionSet struct {
+	objects    map[string]struct{}
+	functions  map[string]struct{}
+	procedures map[string]struct{}
+}
+
+type cloneDatabaseDependencyNode struct {
+	kind string
+	key  string
+}
+
+func newCloneRoutineReferences() cloneRoutineReferences {
+	return cloneRoutineReferences{
+		tables:     make(map[string]struct{}),
+		procedures: make(map[string]struct{}),
+		functions:  make(map[string]struct{}),
+	}
 }
 
 func cloneDatabaseObjectKey(databaseName, objectName string, lowerCaseTableNames int64) string {
@@ -139,26 +152,48 @@ func cloneDatabaseSourceObjectKey(source cloneDatabaseSource, tblInfo *tableInfo
 	return cloneDatabaseObjectKey(databaseName, tblInfo.tblName, lowerCaseTableNames)
 }
 
-func collectCloneViewTableDependencies(
+func collectCloneFunctionReference(
+	references *cloneRoutineReferences,
+	defaultDBName string,
+	lowerCaseTableNames int64,
+) func(*tree.UnresolvedName) {
+	return func(name *tree.UnresolvedName) {
+		if name == nil || name.NumParts == 0 {
+			return
+		}
+		databaseName := defaultDBName
+		if name.NumParts >= 3 {
+			databaseName = name.DbNameOrigin()
+		} else if name.NumParts >= 2 {
+			databaseName = name.TblNameOrigin()
+		}
+		references.functions[cloneRoutineFamilyKey(
+			cloneRoutineFunctionKind, databaseName,
+			name.ColNameOrigin(), lowerCaseTableNames,
+		)] = struct{}{}
+	}
+}
+
+func collectCloneViewDependencies(
 	ctx context.Context,
 	tblInfo *tableInfo,
 	lowerCaseTableNames int64,
-) (map[string]struct{}, error) {
-	dependencies := make(map[string]struct{})
+) (cloneRoutineReferences, error) {
+	references := newCloneRoutineReferences()
 	statements, err := parseViewCreateSQLForRestore(ctx, tblInfo, lowerCaseTableNames)
 	if err != nil {
-		return nil, err
+		return references, err
 	}
 	defer freeStatements(statements)
 	if len(statements) != 1 {
-		return nil, moerr.NewInternalErrorNoCtxf(
+		return references, moerr.NewInternalErrorNoCtxf(
 			"clone view SQL for %s.%s produced %d statements",
 			tblInfo.dbName, tblInfo.tblName, len(statements),
 		)
 	}
 	createView, ok := statements[0].(*tree.CreateView)
 	if !ok {
-		return nil, moerr.NewInternalErrorNoCtxf(
+		return references, moerr.NewInternalErrorNoCtxf(
 			"clone view SQL for %s.%s is %T, expected *tree.CreateView",
 			tblInfo.dbName, tblInfo.tblName, statements[0],
 		)
@@ -170,64 +205,229 @@ func collectCloneViewTableDependencies(
 			if name.ExplicitSchema {
 				databaseName = string(name.SchemaName)
 			}
-			dependencies[cloneDatabaseObjectKey(
+			references.tables[cloneDatabaseObjectKey(
 				databaseName, string(name.ObjectName), lowerCaseTableNames,
 			)] = struct{}{}
 		},
+		collectFunctionName: collectCloneFunctionReference(
+			&references, tblInfo.dbName, lowerCaseTableNames,
+		),
 	})
-	return dependencies, nil
+	return references, nil
 }
 
-// omittedCloneDatabaseObjects returns the relation objects that will not be
-// present in the target. View sorting must run before this helper so that a
-// view whose definition depends on an omitted external relation is included
-// in the same omission set as the external relation itself.
-func omittedCloneDatabaseObjects(
+// collectCloneDatabaseOmissionSet builds one closure over tables, views,
+// functions, and procedures. A routine can depend on a view, and a view can
+// depend on a routine; keeping these edges in one graph prevents either
+// restoration order from publishing metadata whose dependency was omitted.
+// Reverse edges let each omission propagate to its direct dependents once,
+// rather than rescanning every object for every level of a dependency chain.
+func collectCloneDatabaseOmissionSet(
 	ctx context.Context,
 	source cloneDatabaseSource,
 	lowerCaseTableNames int64,
-) (map[string]struct{}, error) {
-	omitted := make(map[string]struct{})
+) (cloneDatabaseOmissionSet, error) {
+	omissions := cloneDatabaseOmissionSet{
+		objects:    make(map[string]struct{}),
+		functions:  make(map[string]struct{}),
+		procedures: make(map[string]struct{}),
+	}
+	dependents := make(map[cloneDatabaseDependencyNode]map[cloneDatabaseDependencyNode]struct{})
+	queue := make([]cloneDatabaseDependencyNode, 0)
+
+	enqueue := func(node cloneDatabaseDependencyNode) {
+		var omissionsForKind map[string]struct{}
+		switch node.kind {
+		case cloneDatabaseObjectNodeKind:
+			omissionsForKind = omissions.objects
+		case cloneRoutineFunctionKind:
+			omissionsForKind = omissions.functions
+		case cloneRoutineProcedureKind:
+			omissionsForKind = omissions.procedures
+		default:
+			return
+		}
+		if _, alreadyOmitted := omissionsForKind[node.key]; alreadyOmitted {
+			return
+		}
+		omissionsForKind[node.key] = struct{}{}
+		queue = append(queue, node)
+	}
+	addDependency := func(dependent, dependency cloneDatabaseDependencyNode) {
+		if dependents[dependency] == nil {
+			dependents[dependency] = make(map[cloneDatabaseDependencyNode]struct{})
+		}
+		dependents[dependency][dependent] = struct{}{}
+	}
+
 	for _, tblInfo := range source.srcTblInfos {
 		if tblInfo != nil && !isCloneableCloneDatabaseTable(tblInfo) {
-			omitted[cloneDatabaseSourceObjectKey(source, tblInfo, lowerCaseTableNames)] = struct{}{}
+			enqueue(cloneDatabaseDependencyNode{
+				kind: cloneDatabaseObjectNodeKind,
+				key:  cloneDatabaseSourceObjectKey(source, tblInfo, lowerCaseTableNames),
+			})
 		}
 	}
-	if len(omitted) == 0 {
-		return omitted, nil
+	for _, tblInfo := range source.viewMap {
+		if tblInfo != nil && tblInfo.unservable {
+			enqueue(cloneDatabaseDependencyNode{
+				kind: cloneDatabaseObjectNodeKind,
+				key:  cloneDatabaseSourceObjectKey(source, tblInfo, lowerCaseTableNames),
+			})
+		}
 	}
-	viewDependencies := make(map[string]map[string]struct{}, len(source.viewMap))
+	if len(queue) == 0 {
+		return omissions, nil
+	}
+
 	for _, tblInfo := range source.viewMap {
 		if tblInfo == nil {
 			continue
 		}
 		viewKey := cloneDatabaseSourceObjectKey(source, tblInfo, lowerCaseTableNames)
-		if tblInfo.unservable {
-			omitted[viewKey] = struct{}{}
-		}
-		dependencies, err := collectCloneViewTableDependencies(ctx, tblInfo, lowerCaseTableNames)
+		dependencies, err := collectCloneViewDependencies(ctx, tblInfo, lowerCaseTableNames)
 		if err != nil {
-			return nil, err
+			return omissions, err
 		}
-		viewDependencies[viewKey] = dependencies
-	}
-	changed := true
-	for changed {
-		changed = false
-		for viewKey, dependencies := range viewDependencies {
-			if _, alreadyOmitted := omitted[viewKey]; alreadyOmitted {
-				continue
-			}
-			for dependency := range dependencies {
-				if _, dependencyOmitted := omitted[dependency]; dependencyOmitted {
-					omitted[viewKey] = struct{}{}
-					changed = true
-					break
-				}
-			}
+		viewNode := cloneDatabaseDependencyNode{
+			kind: cloneDatabaseObjectNodeKind,
+			key:  viewKey,
+		}
+		for tableKey := range dependencies.tables {
+			addDependency(viewNode, cloneDatabaseDependencyNode{
+				kind: cloneDatabaseObjectNodeKind,
+				key:  tableKey,
+			})
+		}
+		for functionKey := range dependencies.functions {
+			addDependency(viewNode, cloneDatabaseDependencyNode{
+				kind: cloneRoutineFunctionKind,
+				key:  functionKey,
+			})
+		}
+		for procedureKey := range dependencies.procedures {
+			addDependency(viewNode, cloneDatabaseDependencyNode{
+				kind: cloneRoutineProcedureKind,
+				key:  procedureKey,
+			})
 		}
 	}
-	return omitted, nil
+
+	addRoutineDependencies := func(
+		routineNode cloneDatabaseDependencyNode,
+		references cloneRoutineReferences,
+		inspectable bool,
+	) {
+		if !inspectable {
+			enqueue(routineNode)
+		}
+		for tableKey := range references.tables {
+			addDependency(routineNode, cloneDatabaseDependencyNode{
+				kind: cloneDatabaseObjectNodeKind,
+				key:  tableKey,
+			})
+		}
+		for functionKey := range references.functions {
+			addDependency(routineNode, cloneDatabaseDependencyNode{
+				kind: cloneRoutineFunctionKind,
+				key:  functionKey,
+			})
+		}
+		for procedureKey := range references.procedures {
+			addDependency(routineNode, cloneDatabaseDependencyNode{
+				kind: cloneRoutineProcedureKind,
+				key:  procedureKey,
+			})
+		}
+	}
+	for _, definition := range source.userDefinedFuncs {
+		references, inspectable, err := collectCloneRoutineReferences(
+			ctx, definition.body, definition.lang, definition.sqlMode,
+			source.srcResolveDBName, lowerCaseTableNames, true,
+		)
+		if err != nil {
+			return omissions, err
+		}
+		addRoutineDependencies(cloneDatabaseDependencyNode{
+			kind: cloneRoutineFunctionKind,
+			key: cloneRoutineFamilyKey(
+				cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+			),
+		}, references, inspectable)
+	}
+	for _, definition := range source.storedProcedures {
+		references, inspectable, err := collectCloneRoutineReferences(
+			ctx, definition.body, definition.lang, definition.sqlMode,
+			source.srcResolveDBName, lowerCaseTableNames, false,
+		)
+		if err != nil {
+			return omissions, err
+		}
+		addRoutineDependencies(cloneDatabaseDependencyNode{
+			kind: cloneRoutineProcedureKind,
+			key: cloneRoutineFamilyKey(
+				cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+			),
+		}, references, inspectable)
+	}
+
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		for dependent := range dependents[node] {
+			enqueue(dependent)
+		}
+	}
+	return omissions, nil
+}
+
+// omittedCloneDatabaseObjects retains the relation-only view of the omission
+// graph for callers that only need the catalog objects absent from the target.
+func omittedCloneDatabaseObjects(
+	ctx context.Context,
+	source cloneDatabaseSource,
+	lowerCaseTableNames int64,
+) (map[string]struct{}, error) {
+	omissions, err := collectCloneDatabaseOmissionSet(ctx, source, lowerCaseTableNames)
+	return omissions.objects, err
+}
+
+func applyCloneDatabaseOmissionSet(
+	source *cloneDatabaseSource,
+	omissions cloneDatabaseOmissionSet,
+	lowerCaseTableNames int64,
+) {
+	filteredFunctions := make([]userDefinedFunctionDefinition, 0, len(source.userDefinedFuncs))
+	for _, definition := range source.userDefinedFuncs {
+		key := cloneRoutineFamilyKey(
+			cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+		)
+		if _, skipped := omissions.functions[key]; !skipped {
+			filteredFunctions = append(filteredFunctions, definition)
+		}
+	}
+	filteredProcedures := make([]storedProcedureDefinition, 0, len(source.storedProcedures))
+	for _, definition := range source.storedProcedures {
+		key := cloneRoutineFamilyKey(
+			cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
+		)
+		if _, skipped := omissions.procedures[key]; !skipped {
+			filteredProcedures = append(filteredProcedures, definition)
+		}
+	}
+	filteredViews := make(map[string]*tableInfo, len(source.viewMap))
+	for key, view := range source.viewMap {
+		if view == nil {
+			continue
+		}
+		viewKey := cloneDatabaseSourceObjectKey(*source, view, lowerCaseTableNames)
+		if _, skipped := omissions.objects[viewKey]; !skipped {
+			filteredViews[key] = view
+		}
+	}
+	source.userDefinedFuncs = filteredFunctions
+	source.storedProcedures = filteredProcedures
+	source.viewMap = filteredViews
 }
 
 func collectCloneRoutineReferences(
@@ -239,11 +439,7 @@ func collectCloneRoutineReferences(
 	lowerCaseTableNames int64,
 	isFunction bool,
 ) (cloneRoutineReferences, bool, error) {
-	references := cloneRoutineReferences{
-		tables:     make(map[string]struct{}),
-		procedures: make(map[string]struct{}),
-		functions:  make(map[string]struct{}),
-	}
+	references := newCloneRoutineReferences()
 	if !strings.EqualFold(lang, string(tree.SQL)) {
 		return references, false, nil
 	}
@@ -294,21 +490,9 @@ func collectCloneRoutineReferences(
 				string(name.Name.ObjectName), lowerCaseTableNames,
 			)] = struct{}{}
 		},
-		collectFunctionName: func(name *tree.UnresolvedName) {
-			if name == nil || name.NumParts == 0 {
-				return
-			}
-			databaseName := srcDBName
-			if name.NumParts >= 3 {
-				databaseName = name.DbNameOrigin()
-			} else if name.NumParts >= 2 {
-				databaseName = name.TblNameOrigin()
-			}
-			references.functions[cloneRoutineFamilyKey(
-				cloneRoutineFunctionKind, databaseName,
-				name.ColNameOrigin(), lowerCaseTableNames,
-			)] = struct{}{}
-		},
+		collectFunctionName: collectCloneFunctionReference(
+			&references, srcDBName, lowerCaseTableNames,
+		),
 	})
 	return references, remappable && !unsupported, nil
 }
@@ -325,128 +509,12 @@ func filterCloneDatabaseRoutines(
 	source cloneDatabaseSource,
 	lowerCaseTableNames int64,
 ) ([]userDefinedFunctionDefinition, []storedProcedureDefinition, error) {
-	omittedObjects, err := omittedCloneDatabaseObjects(ctx, source, lowerCaseTableNames)
+	omissions, err := collectCloneDatabaseOmissionSet(ctx, source, lowerCaseTableNames)
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(omittedObjects) == 0 {
-		return slices.Clone(source.userDefinedFuncs), slices.Clone(source.storedProcedures), nil
-	}
-
-	dependencies := make([]cloneRoutineDependency, 0, len(source.userDefinedFuncs)+len(source.storedProcedures))
-	functionKeys := make(map[string]struct{}, len(source.userDefinedFuncs))
-	procedureKeys := make(map[string]struct{}, len(source.storedProcedures))
-	for _, definition := range source.userDefinedFuncs {
-		key := cloneRoutineFamilyKey(
-			cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
-		)
-		functionKeys[key] = struct{}{}
-		dependencies = append(dependencies, cloneRoutineDependency{key: key})
-	}
-	for _, definition := range source.storedProcedures {
-		key := cloneRoutineFamilyKey(
-			cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
-		)
-		procedureKeys[key] = struct{}{}
-		dependencies = append(dependencies, cloneRoutineDependency{key: key})
-	}
-
-	dependencyIndex := 0
-	for _, definition := range source.userDefinedFuncs {
-		references, inspectable, err := collectCloneRoutineReferences(
-			ctx, definition.body, definition.lang, definition.sqlMode,
-			source.srcResolveDBName, lowerCaseTableNames, true,
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-		dependencies[dependencyIndex].references = references
-		dependencies[dependencyIndex].inspectable = inspectable
-		dependencyIndex++
-	}
-	for _, definition := range source.storedProcedures {
-		references, inspectable, err := collectCloneRoutineReferences(
-			ctx, definition.body, definition.lang, definition.sqlMode,
-			source.srcResolveDBName, lowerCaseTableNames, false,
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-		dependencies[dependencyIndex].references = references
-		dependencies[dependencyIndex].inspectable = inspectable
-		dependencyIndex++
-	}
-
-	skippedRoutines := make(map[string]struct{})
-	for i := range dependencies {
-		dependency := &dependencies[i]
-		if !dependency.inspectable {
-			dependency.skipped = true
-		} else {
-			for tableKey := range dependency.references.tables {
-				if _, ok := omittedObjects[tableKey]; ok {
-					dependency.skipped = true
-					break
-				}
-			}
-		}
-		if dependency.skipped {
-			skippedRoutines[dependency.key] = struct{}{}
-		}
-	}
-
-	changed := true
-	for changed {
-		changed = false
-		for i := range dependencies {
-			dependency := &dependencies[i]
-			if dependency.skipped {
-				continue
-			}
-			for functionKey := range dependency.references.functions {
-				if _, known := functionKeys[functionKey]; known {
-					if _, skipped := skippedRoutines[functionKey]; skipped {
-						dependency.skipped = true
-						break
-					}
-				}
-			}
-			if !dependency.skipped {
-				for procedureKey := range dependency.references.procedures {
-					if _, known := procedureKeys[procedureKey]; known {
-						if _, skipped := skippedRoutines[procedureKey]; skipped {
-							dependency.skipped = true
-							break
-						}
-					}
-				}
-			}
-			if dependency.skipped {
-				skippedRoutines[dependency.key] = struct{}{}
-				changed = true
-			}
-		}
-	}
-
-	filteredFunctions := make([]userDefinedFunctionDefinition, 0, len(source.userDefinedFuncs))
-	for _, definition := range source.userDefinedFuncs {
-		key := cloneRoutineFamilyKey(
-			cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
-		)
-		if _, skipped := skippedRoutines[key]; !skipped {
-			filteredFunctions = append(filteredFunctions, definition)
-		}
-	}
-	filteredProcedures := make([]storedProcedureDefinition, 0, len(source.storedProcedures))
-	for _, definition := range source.storedProcedures {
-		key := cloneRoutineFamilyKey(
-			cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
-		)
-		if _, skipped := skippedRoutines[key]; !skipped {
-			filteredProcedures = append(filteredProcedures, definition)
-		}
-	}
-	return filteredFunctions, filteredProcedures, nil
+	applyCloneDatabaseOmissionSet(&source, omissions, lowerCaseTableNames)
+	return source.userDefinedFuncs, source.storedProcedures, nil
 }
 
 func collectCloneDatabaseSource(

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -122,7 +122,12 @@ func cloneDatabaseObjectKey(databaseName, objectName string, lowerCaseTableNames
 	)
 }
 
-func cloneRoutineKey(kind, databaseName, routineName string, lowerCaseTableNames int64) string {
+// cloneRoutineFamilyKey intentionally identifies a SQL routine family by kind,
+// database, and name. The dependency walker does not resolve UDF overloads at
+// every call site, so omitting one overload conservatively omits the whole
+// same-name family instead of risking a copied overload that still references
+// omitted metadata.
+func cloneRoutineFamilyKey(kind, databaseName, routineName string, lowerCaseTableNames int64) string {
 	return kind + KeySep + cloneDatabaseObjectKey(databaseName, routineName, lowerCaseTableNames)
 }
 
@@ -159,6 +164,7 @@ func collectCloneViewTableDependencies(
 		)
 	}
 	remapDbInSelect(createView.AsSource, remapDbContext{
+		lowerCaseTableNames: lowerCaseTableNames,
 		collectTableName: func(name *tree.TableName) {
 			databaseName := tblInfo.dbName
 			if name.ExplicitSchema {
@@ -186,6 +192,9 @@ func omittedCloneDatabaseObjects(
 		if tblInfo != nil && !isCloneableCloneDatabaseTable(tblInfo) {
 			omitted[cloneDatabaseSourceObjectKey(source, tblInfo, lowerCaseTableNames)] = struct{}{}
 		}
+	}
+	if len(omitted) == 0 {
+		return omitted, nil
 	}
 	viewDependencies := make(map[string]map[string]struct{}, len(source.viewMap))
 	for _, tblInfo := range source.viewMap {
@@ -279,7 +288,7 @@ func collectCloneRoutineReferences(
 			if name.Name.ExplicitSchema {
 				databaseName = string(name.Name.SchemaName)
 			}
-			references.procedures[cloneRoutineKey(
+			references.procedures[cloneRoutineFamilyKey(
 				cloneRoutineProcedureKind, databaseName,
 				string(name.Name.ObjectName), lowerCaseTableNames,
 			)] = struct{}{}
@@ -294,7 +303,7 @@ func collectCloneRoutineReferences(
 			} else if name.NumParts >= 2 {
 				databaseName = name.TblNameOrigin()
 			}
-			references.functions[cloneRoutineKey(
+			references.functions[cloneRoutineFamilyKey(
 				cloneRoutineFunctionKind, databaseName,
 				name.ColNameOrigin(), lowerCaseTableNames,
 			)] = struct{}{}
@@ -303,11 +312,13 @@ func collectCloneRoutineReferences(
 	return references, remappable && !unsupported, nil
 }
 
-// filterCloneDatabaseRoutines keeps independent routines and omits routines
-// whose direct or transitive dependencies cannot exist in the target. A
-// non-SQL or otherwise uninspectable routine is omitted when the source has an
-// omitted relation; persisting it would report success while retaining a
-// dependency that this clone cannot verify.
+// filterCloneDatabaseRoutines keeps independent routine families and omits
+// families whose direct or transitive dependencies cannot exist in the target.
+// A non-SQL or otherwise uninspectable routine is omitted when the source has
+// an omitted relation; persisting it would report success while retaining a
+// dependency that this clone cannot verify. UDF overloads are one family here:
+// call sites do not carry enough resolved type information for this metadata
+// pass to distinguish overloads safely.
 func filterCloneDatabaseRoutines(
 	ctx context.Context,
 	source cloneDatabaseSource,
@@ -325,14 +336,14 @@ func filterCloneDatabaseRoutines(
 	functionKeys := make(map[string]struct{}, len(source.userDefinedFuncs))
 	procedureKeys := make(map[string]struct{}, len(source.storedProcedures))
 	for _, definition := range source.userDefinedFuncs {
-		key := cloneRoutineKey(
+		key := cloneRoutineFamilyKey(
 			cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
 		)
 		functionKeys[key] = struct{}{}
 		dependencies = append(dependencies, cloneRoutineDependency{key: key})
 	}
 	for _, definition := range source.storedProcedures {
-		key := cloneRoutineKey(
+		key := cloneRoutineFamilyKey(
 			cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
 		)
 		procedureKeys[key] = struct{}{}
@@ -418,7 +429,7 @@ func filterCloneDatabaseRoutines(
 
 	filteredFunctions := make([]userDefinedFunctionDefinition, 0, len(source.userDefinedFuncs))
 	for _, definition := range source.userDefinedFuncs {
-		key := cloneRoutineKey(
+		key := cloneRoutineFamilyKey(
 			cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
 		)
 		if _, skipped := skippedRoutines[key]; !skipped {
@@ -427,7 +438,7 @@ func filterCloneDatabaseRoutines(
 	}
 	filteredProcedures := make([]storedProcedureDefinition, 0, len(source.storedProcedures))
 	for _, definition := range source.storedProcedures {
-		key := cloneRoutineKey(
+		key := cloneRoutineFamilyKey(
 			cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
 		)
 		if _, skipped := skippedRoutines[key]; !skipped {

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -272,8 +272,9 @@ func collectCloneRoutineReferences(
 
 	unsupported := false
 	remappable := remapDbInStatements(statements, remapDbContext{
-		lowerCaseTableNames: lowerCaseTableNames,
-		unsupported:         &unsupported,
+		lowerCaseTableNames:   lowerCaseTableNames,
+		unsupported:           &unsupported,
+		rejectUseStateChanges: true,
 		collectTableName: func(name *tree.TableName) {
 			databaseName := srcDBName
 			if name.ExplicitSchema {

--- a/pkg/frontend/clone_database_source.go
+++ b/pkg/frontend/clone_database_source.go
@@ -120,6 +120,14 @@ type cloneDatabaseDependencyNode struct {
 	key  string
 }
 
+type cloneRoutineDependencyStatus uint8
+
+const (
+	cloneRoutineDependenciesInspected cloneRoutineDependencyStatus = iota
+	cloneRoutineDependenciesOpaque
+	cloneRoutineDependenciesUninspectable
+)
+
 func newCloneRoutineReferences() cloneRoutineReferences {
 	return cloneRoutineReferences{
 		tables:     make(map[string]struct{}),
@@ -316,9 +324,9 @@ func collectCloneDatabaseOmissionSet(
 	addRoutineDependencies := func(
 		routineNode cloneDatabaseDependencyNode,
 		references cloneRoutineReferences,
-		inspectable bool,
+		status cloneRoutineDependencyStatus,
 	) {
-		if !inspectable {
+		if status == cloneRoutineDependenciesUninspectable {
 			enqueue(routineNode)
 		}
 		for tableKey := range references.tables {
@@ -341,7 +349,7 @@ func collectCloneDatabaseOmissionSet(
 		}
 	}
 	for _, definition := range source.userDefinedFuncs {
-		references, inspectable, err := collectCloneRoutineReferences(
+		references, status, err := collectCloneRoutineReferences(
 			ctx, definition.body, definition.lang, definition.sqlMode,
 			source.srcResolveDBName, lowerCaseTableNames, true,
 		)
@@ -353,10 +361,10 @@ func collectCloneDatabaseOmissionSet(
 			key: cloneRoutineFamilyKey(
 				cloneRoutineFunctionKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
 			),
-		}, references, inspectable)
+		}, references, status)
 	}
 	for _, definition := range source.storedProcedures {
-		references, inspectable, err := collectCloneRoutineReferences(
+		references, status, err := collectCloneRoutineReferences(
 			ctx, definition.body, definition.lang, definition.sqlMode,
 			source.srcResolveDBName, lowerCaseTableNames, false,
 		)
@@ -368,7 +376,7 @@ func collectCloneDatabaseOmissionSet(
 			key: cloneRoutineFamilyKey(
 				cloneRoutineProcedureKind, source.srcResolveDBName, definition.name, lowerCaseTableNames,
 			),
-		}, references, inspectable)
+		}, references, status)
 	}
 
 	for len(queue) > 0 {
@@ -427,10 +435,17 @@ func collectCloneRoutineReferences(
 	srcDBName string,
 	lowerCaseTableNames int64,
 	isFunction bool,
-) (cloneRoutineReferences, bool, error) {
+) (cloneRoutineReferences, cloneRoutineDependencyStatus, error) {
 	references := newCloneRoutineReferences()
 	if !strings.EqualFold(lang, string(tree.SQL)) {
-		return references, false, nil
+		if isFunction {
+			// Non-SQL UDFs are persisted as opaque bodies. Imported packages are
+			// rejected by validateCloneUserDefinedFunctions before this graph is
+			// built; accepted inline UDFs do not contain SQL relation metadata for
+			// this walker to inspect.
+			return references, cloneRoutineDependenciesOpaque, nil
+		}
+		return references, cloneRoutineDependenciesUninspectable, nil
 	}
 
 	parseBody := body
@@ -447,11 +462,12 @@ func collectCloneRoutineReferences(
 	if err != nil {
 		if parseAsExpression {
 			// Existing scalar UDF clone support does not parse these bodies. Keep
-			// that compatibility behavior, but let the caller omit an
-			// uninspectable routine whenever the clone already omits a relation.
-			return references, false, nil
+			// that compatibility behavior, but let the caller omit this
+			// uninspectable SQL routine whenever the clone already omits a
+			// relation.
+			return references, cloneRoutineDependenciesUninspectable, nil
 		}
-		return references, false, err
+		return references, cloneRoutineDependenciesUninspectable, err
 	}
 	defer freeStatements(statements)
 
@@ -483,16 +499,20 @@ func collectCloneRoutineReferences(
 			&references, srcDBName, lowerCaseTableNames,
 		),
 	})
-	return references, remappable && !unsupported, nil
+	if !remappable || unsupported {
+		return references, cloneRoutineDependenciesUninspectable, nil
+	}
+	return references, cloneRoutineDependenciesInspected, nil
 }
 
 // filterCloneDatabaseRoutines keeps independent routine families and omits
 // families whose direct or transitive dependencies cannot exist in the target.
-// A non-SQL or otherwise uninspectable routine is omitted when the source has
-// an omitted relation; persisting it would report success while retaining a
-// dependency that this clone cannot verify. UDF overloads are one family here:
-// call sites do not carry enough resolved type information for this metadata
-// pass to distinguish overloads safely.
+// SQL routines whose bodies cannot be inspected are omitted when the source
+// has an omitted relation. Supported non-SQL UDFs are opaque but cloneable and
+// are preserved after validateCloneUserDefinedFunctions rejects imported
+// package bodies. UDF overloads are one family here: call sites do not carry
+// enough resolved type information for this metadata pass to distinguish
+// overloads safely.
 func filterCloneDatabaseRoutines(
 	ctx context.Context,
 	source cloneDatabaseSource,

--- a/pkg/frontend/clone_database_source_test.go
+++ b/pkg/frontend/clone_database_source_test.go
@@ -578,6 +578,9 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 		storedProcedures: []storedProcedureDefinition{
 			{name: "p_external", lang: "sql", body: "begin select * from source_db.ext_t; end"},
 			{name: "p_transitive", lang: "sql", body: "begin call p_external(); end"},
+			{name: "p_dml_cte_shadow", lang: "sql", body: "begin with ext_t as (select 1 as n) insert into source_db.sink select n from ext_t; end"},
+			{name: "p_returning_external", lang: "sql", body: "begin update source_db.control_t set id = id returning f_external(id); end"},
+			{name: "p_use_other_db", lang: "sql", body: "begin use other_db; select * from ext_t; end"},
 			{name: "p_independent", lang: "sql", body: "begin select 1; end"},
 		},
 	}
@@ -587,7 +590,7 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{"f_cte_shadow", "f_cte_view", "f_independent"}, routineNames(functions))
-	require.Equal(t, []string{"p_independent"}, procedureNames(procedures))
+	require.Equal(t, []string{"p_dml_cte_shadow", "p_independent"}, procedureNames(procedures))
 
 	t.Run("same-name overloads are conservatively one family", func(t *testing.T) {
 		overloadSource := cloneDatabaseSource{
@@ -613,9 +616,12 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 
 func TestCollectCloneRoutineReferencesScopesCTEs(t *testing.T) {
 	tests := []struct {
-		name       string
-		body       string
-		wantTables []string
+		name              string
+		body              string
+		isProcedure       bool
+		wantTables        []string
+		wantFunctions     []string
+		wantUninspectable bool
 	}{
 		{
 			name: "cte shadows external table",
@@ -635,19 +641,72 @@ func TestCollectCloneRoutineReferencesScopesCTEs(t *testing.T) {
 			body:       "with ext_t as (select 1 as n) select n from source_db.ext_t",
 			wantTables: []string{"ext_t"},
 		},
+		{
+			name:        "insert body keeps outer cte scope",
+			body:        "begin with ext_t as (select 1 as n) insert into source_db.sink select n from ext_t; end",
+			isProcedure: true,
+			wantTables:  []string{"sink"},
+		},
+		{
+			name:        "update body keeps outer cte scope",
+			body:        "begin with ext_t as (select 1 as n) update source_db.sink set id = id where id in (select n from ext_t); end",
+			isProcedure: true,
+			wantTables:  []string{"sink"},
+		},
+		{
+			name:        "delete body keeps outer cte scope",
+			body:        "begin with ext_t as (select 1 as n) delete from source_db.sink where id in (select n from ext_t); end",
+			isProcedure: true,
+			wantTables:  []string{"sink"},
+		},
+		{
+			name:        "merge body keeps outer cte scope",
+			body:        "begin with ext_t as (select 1 as n) merge into source_db.sink using ext_t on source_db.sink.id = ext_t.n when matched then update set id = ext_t.n; end",
+			isProcedure: true,
+			wantTables:  []string{"sink"},
+		},
+		{
+			name:        "multi insert body keeps outer cte scope",
+			body:        "begin with ext_t as (select 1 as n) insert all into source_db.sink (id) values (n) select n from ext_t; end",
+			isProcedure: true,
+			wantTables:  []string{"sink"},
+		},
+		{
+			name:          "dml returning collects routine dependency",
+			body:          "begin update source_db.control_t set id = id returning f_external(id); end",
+			isProcedure:   true,
+			wantTables:    []string{"control_t"},
+			wantFunctions: []string{"f_external"},
+		},
+		{
+			name:              "use state fails closed",
+			body:              "begin use other_db; select * from ext_t; end",
+			isProcedure:       true,
+			wantUninspectable: true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			references, inspectable, err := collectCloneRoutineReferences(
-				context.Background(), test.body, "sql", "", "source_db", 1, true,
+				context.Background(), test.body, "sql", "", "source_db", 1, !test.isProcedure,
 			)
 			require.NoError(t, err)
+			if test.wantUninspectable {
+				require.False(t, inspectable)
+				return
+			}
 			require.True(t, inspectable)
 			for _, table := range test.wantTables {
 				require.Contains(t, references.tables, cloneDatabaseObjectKey("source_db", table, 1))
 			}
+			for _, function := range test.wantFunctions {
+				require.Contains(t, references.functions, cloneRoutineFamilyKey(
+					cloneRoutineFunctionKind, "source_db", function, 1,
+				))
+			}
 			require.Len(t, references.tables, len(test.wantTables))
+			require.Len(t, references.functions, len(test.wantFunctions))
 		})
 	}
 }

--- a/pkg/frontend/clone_database_source_test.go
+++ b/pkg/frontend/clone_database_source_test.go
@@ -562,11 +562,17 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 				dbName: "source_db", tblName: "ext_v", typ: view,
 				createSql: "create view source_db.ext_v as select * from source_db.ext_t",
 			},
+			genKey("source_db", "cte_v"): {
+				dbName: "source_db", tblName: "cte_v", typ: view,
+				createSql: "create view source_db.cte_v as with ext_t as (select 1 as n) select n from ext_t",
+			},
 		},
 		userDefinedFuncs: []userDefinedFunctionDefinition{
 			{name: "f_external", lang: "sql", body: "select count(*) from source_db.ext_t"},
 			{name: "f_transitive", lang: "sql", body: "f_external()"},
 			{name: "f_view", lang: "sql", body: "select * from source_db.ext_v"},
+			{name: "f_cte_shadow", lang: "sql", body: "with ext_t as (select 1 as n) select n from ext_t"},
+			{name: "f_cte_view", lang: "sql", body: "select * from source_db.cte_v"},
 			{name: "f_independent", lang: "sql", body: "1 + 1"},
 		},
 		storedProcedures: []storedProcedureDefinition{
@@ -580,8 +586,70 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 		context.Background(), source, 1,
 	)
 	require.NoError(t, err)
-	require.Equal(t, []string{"f_independent"}, routineNames(functions))
+	require.Equal(t, []string{"f_cte_shadow", "f_cte_view", "f_independent"}, routineNames(functions))
 	require.Equal(t, []string{"p_independent"}, procedureNames(procedures))
+
+	t.Run("same-name overloads are conservatively one family", func(t *testing.T) {
+		overloadSource := cloneDatabaseSource{
+			srcResolveDBName: "source_db",
+			srcTblInfos: []*tableInfo{{
+				dbName: "source_db", tblName: "ext_t", relKind: catalog.SystemExternalRel,
+			}},
+			userDefinedFuncs: []userDefinedFunctionDefinition{
+				{name: "f_overloaded", argTypes: `["int"]`, lang: "sql", body: "select * from source_db.ext_t"},
+				{name: "f_overloaded", argTypes: `["varchar"]`, lang: "sql", body: "1 + 1"},
+				{name: "f_overloaded_caller", lang: "sql", body: "f_overloaded(1)"},
+			},
+		}
+
+		functions, procedures, err := filterCloneDatabaseRoutines(
+			context.Background(), overloadSource, 1,
+		)
+		require.NoError(t, err)
+		require.Empty(t, functions)
+		require.Empty(t, procedures)
+	})
+}
+
+func TestCollectCloneRoutineReferencesScopesCTEs(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantTables []string
+	}{
+		{
+			name: "cte shadows external table",
+			body: "with ext_t as (select 1 as n) select n from ext_t",
+		},
+		{
+			name:       "nested cte keeps qualified source reference",
+			body:       "with ext_t as (select 1 as n) select n from (with ext_t as (select * from source_db.inner_t) select n from ext_t) as nested",
+			wantTables: []string{"inner_t"},
+		},
+		{
+			name: "recursive cte shadows itself",
+			body: "with recursive ext_t as (select 1 as n union all select n + 1 from ext_t where n < 2) select n from ext_t",
+		},
+		{
+			name:       "qualified reference bypasses cte shadow",
+			body:       "with ext_t as (select 1 as n) select n from source_db.ext_t",
+			wantTables: []string{"ext_t"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			references, inspectable, err := collectCloneRoutineReferences(
+				context.Background(), test.body, "sql", "", "source_db", 1, true,
+			)
+			require.NoError(t, err)
+			require.True(t, inspectable)
+			for _, table := range test.wantTables {
+				require.Contains(t, references.tables, cloneDatabaseObjectKey("source_db", table, 1))
+			}
+			require.Len(t, references.tables, len(test.wantTables))
+		})
+	}
 }
 
 func routineNames(functions []userDefinedFunctionDefinition) []string {

--- a/pkg/frontend/clone_database_source_test.go
+++ b/pkg/frontend/clone_database_source_test.go
@@ -574,6 +574,7 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 			{name: "f_cte_shadow", lang: "sql", body: "with ext_t as (select 1 as n) select n from ext_t"},
 			{name: "f_cte_view", lang: "sql", body: "select * from source_db.cte_v"},
 			{name: "f_independent", lang: "sql", body: "1 + 1"},
+			{name: "py_add", lang: "python", body: `{"handler":"py_add","import":false,"body":"return x + 1"}`},
 		},
 		storedProcedures: []storedProcedureDefinition{
 			{name: "p_external", lang: "sql", body: "begin select * from source_db.ext_t; end"},
@@ -589,7 +590,7 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 		context.Background(), source, 1,
 	)
 	require.NoError(t, err)
-	require.Equal(t, []string{"f_cte_shadow", "f_cte_view", "f_independent"}, routineNames(functions))
+	require.Equal(t, []string{"f_cte_shadow", "f_cte_view", "f_independent", "py_add"}, routineNames(functions))
 	require.Equal(t, []string{"p_dml_cte_shadow", "p_independent"}, procedureNames(procedures))
 
 	t.Run("same-name overloads are conservatively one family", func(t *testing.T) {
@@ -737,15 +738,15 @@ func TestCollectCloneRoutineReferencesScopesCTEs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			references, inspectable, err := collectCloneRoutineReferences(
+			references, status, err := collectCloneRoutineReferences(
 				context.Background(), test.body, "sql", "", "source_db", 1, !test.isProcedure,
 			)
 			require.NoError(t, err)
 			if test.wantUninspectable {
-				require.False(t, inspectable)
+				require.Equal(t, cloneRoutineDependenciesUninspectable, status)
 				return
 			}
-			require.True(t, inspectable)
+			require.Equal(t, cloneRoutineDependenciesInspected, status)
 			for _, table := range test.wantTables {
 				require.Contains(t, references.tables, cloneDatabaseObjectKey("source_db", table, 1))
 			}
@@ -758,6 +759,24 @@ func TestCollectCloneRoutineReferencesScopesCTEs(t *testing.T) {
 			require.Len(t, references.functions, len(test.wantFunctions))
 		})
 	}
+}
+
+func TestCollectCloneRoutineReferencesPreservesInlineNonSQLUDFs(t *testing.T) {
+	references, status, err := collectCloneRoutineReferences(
+		context.Background(),
+		`{"handler":"py_add","import":false,"body":"return x + 1"}`,
+		"python", "", "source_db", 1, true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, cloneRoutineDependenciesOpaque, status)
+	require.Empty(t, references.tables)
+	require.Empty(t, references.functions)
+
+	_, status, err = collectCloneRoutineReferences(
+		context.Background(), "opaque", "python", "", "source_db", 1, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, cloneRoutineDependenciesUninspectable, status)
 }
 
 func routineNames(functions []userDefinedFunctionDefinition) []string {

--- a/pkg/frontend/clone_database_source_test.go
+++ b/pkg/frontend/clone_database_source_test.go
@@ -614,6 +614,55 @@ func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
 	})
 }
 
+func TestCloneDatabaseOmissionSetPropagatesRoutineDependenciesToViews(t *testing.T) {
+	source := cloneDatabaseSource{
+		srcResolveDBName: "source_db",
+		srcTblInfos: []*tableInfo{
+			{dbName: "source_db", tblName: "ext_t", relKind: catalog.SystemExternalRel},
+		},
+		viewMap: map[string]*tableInfo{
+			genKey("source_db", "udf_v"): {
+				dbName: "source_db", tblName: "udf_v", typ: view,
+				createSql: "create view source_db.udf_v as select f_external()",
+			},
+			genKey("source_db", "udf_chain_v"): {
+				dbName: "source_db", tblName: "udf_chain_v", typ: view,
+				createSql: "create view source_db.udf_chain_v as select * from source_db.udf_v",
+			},
+			genKey("source_db", "independent_v"): {
+				dbName: "source_db", tblName: "independent_v", typ: view,
+				createSql: "create view source_db.independent_v as select 1 as n",
+			},
+		},
+		userDefinedFuncs: []userDefinedFunctionDefinition{
+			{name: "f_external", lang: "sql", body: "select count(*) from source_db.ext_t"},
+			{name: "f_view", lang: "sql", body: "select * from source_db.udf_v"},
+			{name: "f_independent", lang: "sql", body: "1 + 1"},
+		},
+	}
+
+	omissions, err := collectCloneDatabaseOmissionSet(context.Background(), source, 1)
+	require.NoError(t, err)
+	require.Contains(t, omissions.objects, cloneDatabaseObjectKey("source_db", "udf_v", 1))
+	require.Contains(t, omissions.objects, cloneDatabaseObjectKey("source_db", "udf_chain_v", 1))
+	require.Contains(t, omissions.functions, cloneRoutineFamilyKey(
+		cloneRoutineFunctionKind, "source_db", "f_external", 1,
+	))
+	require.Contains(t, omissions.functions, cloneRoutineFamilyKey(
+		cloneRoutineFunctionKind, "source_db", "f_view", 1,
+	))
+	require.NotContains(t, omissions.objects, cloneDatabaseObjectKey("source_db", "independent_v", 1))
+	require.NotContains(t, omissions.functions, cloneRoutineFamilyKey(
+		cloneRoutineFunctionKind, "source_db", "f_independent", 1,
+	))
+
+	applyCloneDatabaseOmissionSet(&source, omissions, 1)
+	require.Len(t, source.viewMap, 1)
+	_, independentViewKept := source.viewMap[genKey("source_db", "independent_v")]
+	require.True(t, independentViewKept)
+	require.Equal(t, []string{"f_independent"}, routineNames(source.userDefinedFuncs))
+}
+
 func TestCollectCloneRoutineReferencesScopesCTEs(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/frontend/clone_database_source_test.go
+++ b/pkg/frontend/clone_database_source_test.go
@@ -551,6 +551,55 @@ func TestRewriteCloneUserDefinedFunctionBodies(t *testing.T) {
 	require.Equal(t, "select count(*) from SOURCE_DB.control_t where id = $1", functions[0].body)
 }
 
+func TestFilterCloneDatabaseRoutinesSkipsUncloneableDependencies(t *testing.T) {
+	source := cloneDatabaseSource{
+		srcResolveDBName: "source_db",
+		srcTblInfos: []*tableInfo{
+			{dbName: "source_db", tblName: "ext_t", relKind: catalog.SystemExternalRel},
+		},
+		viewMap: map[string]*tableInfo{
+			genKey("source_db", "ext_v"): {
+				dbName: "source_db", tblName: "ext_v", typ: view,
+				createSql: "create view source_db.ext_v as select * from source_db.ext_t",
+			},
+		},
+		userDefinedFuncs: []userDefinedFunctionDefinition{
+			{name: "f_external", lang: "sql", body: "select count(*) from source_db.ext_t"},
+			{name: "f_transitive", lang: "sql", body: "f_external()"},
+			{name: "f_view", lang: "sql", body: "select * from source_db.ext_v"},
+			{name: "f_independent", lang: "sql", body: "1 + 1"},
+		},
+		storedProcedures: []storedProcedureDefinition{
+			{name: "p_external", lang: "sql", body: "begin select * from source_db.ext_t; end"},
+			{name: "p_transitive", lang: "sql", body: "begin call p_external(); end"},
+			{name: "p_independent", lang: "sql", body: "begin select 1; end"},
+		},
+	}
+
+	functions, procedures, err := filterCloneDatabaseRoutines(
+		context.Background(), source, 1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"f_independent"}, routineNames(functions))
+	require.Equal(t, []string{"p_independent"}, procedureNames(procedures))
+}
+
+func routineNames(functions []userDefinedFunctionDefinition) []string {
+	names := make([]string, len(functions))
+	for i := range functions {
+		names[i] = functions[i].name
+	}
+	return names
+}
+
+func procedureNames(procedures []storedProcedureDefinition) []string {
+	names := make([]string, len(procedures))
+	for i := range procedures {
+		names[i] = procedures[i].name
+	}
+	return names
+}
+
 func TestCloneDatabaseSourceBranchTableCount(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -678,10 +727,24 @@ func TestLockDataBranchCloneDatabaseSourcesSkipsSourcesWithoutTables(t *testing.
 	for _, source := range []cloneDatabaseSource{
 		{},
 		{srcTblInfos: []*tableInfo{{tblName: "view", typ: view}}},
-		{srcTblInfos: []*tableInfo{{tblName: "external", relKind: catalog.SystemExternalRel}}},
 	} {
 		require.NoError(t, lockDataBranchCloneDatabaseSources(ctx, nil, nil, source))
 	}
+}
+
+func TestCloneDatabaseSourceLifecycleTablesIncludeExternalDependencies(t *testing.T) {
+	source := cloneDatabaseSource{srcTblInfos: []*tableInfo{
+		{tblName: "ordinary"},
+		{tblName: "external", relKind: catalog.SystemExternalRel},
+		{tblName: "view", typ: view},
+	}}
+
+	tables := source.sourceTableInfosForLifecycle()
+	names := make([]string, len(tables))
+	for i, table := range tables {
+		names[i] = table.tblName
+	}
+	require.Equal(t, []string{"ordinary", "external"}, names)
 }
 
 func TestCloneFkTableOrder(t *testing.T) {

--- a/pkg/frontend/clone_database_source_test.go
+++ b/pkg/frontend/clone_database_source_test.go
@@ -565,6 +565,7 @@ func TestCloneDatabaseSourceBranchTableCount(t *testing.T) {
 			name: "mixed objects count only receipt-backed tables",
 			tables: []*tableInfo{
 				{tblName: "regular"},
+				{tblName: "external", relKind: catalog.SystemExternalRel},
 				{tblName: "sequence", relKind: catalog.SystemSequenceRel},
 				{tblName: "view", typ: view},
 			},
@@ -677,6 +678,7 @@ func TestLockDataBranchCloneDatabaseSourcesSkipsSourcesWithoutTables(t *testing.
 	for _, source := range []cloneDatabaseSource{
 		{},
 		{srcTblInfos: []*tableInfo{{tblName: "view", typ: view}}},
+		{srcTblInfos: []*tableInfo{{tblName: "external", relKind: catalog.SystemExternalRel}}},
 	} {
 		require.NoError(t, lockDataBranchCloneDatabaseSources(ctx, nil, nil, source))
 	}

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/frontend/databranchutils"
@@ -624,6 +625,7 @@ func TestTimestampDataBranchDatabaseRevalidatesEveryTableAfterAllLocks(t *testin
 		source := cloneDatabaseSource{srcTblInfos: []*tableInfo{
 			{dbName: "db", tblName: "t1"},
 			{dbName: "db", tblName: "v", typ: view},
+			{dbName: "db", tblName: "external", relKind: catalog.SystemExternalRel},
 			{dbName: "db", tblName: "t2"},
 		}}
 		done <- forEachCloneDatabaseSourceTable(source, func(table *tableInfo) error {

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -607,17 +607,19 @@ func TestValidateTimestampDataBranchSourceAfterLockFailures(t *testing.T) {
 	), wantErr)
 }
 
-func TestTimestampDataBranchDatabaseRevalidatesEveryTableAfterAllLocks(t *testing.T) {
+func TestTimestampDataBranchDatabaseRevalidatesEveryLifecycleTableAfterAllLocks(t *testing.T) {
 	timestampSource := &plan.Snapshot{TS: &timestamp.Timestamp{PhysicalTime: 42}}
 	var catalogRows sync.RWMutex
 	catalogRows.Lock() // COPY ALTER holds one source row exclusively.
 
 	enteredLockPath := make(chan struct{})
 	allLocksHeld := make(chan struct{})
-	validated := make(chan string, 2)
+	validated := make(chan string, 3)
 	done := make(chan error, 1)
 	go func() {
 		// Database clone acquires all source locks before revalidating any table.
+		// The external row is part of this fence because view dependency sorting
+		// consults its catalog metadata after the timestamp advances.
 		close(enteredLockPath)
 		catalogRows.RLock()
 		close(allLocksHeld)
@@ -662,7 +664,7 @@ func TestTimestampDataBranchDatabaseRevalidatesEveryTableAfterAllLocks(t *testin
 		t.Fatal("database clone did not acquire all source locks")
 	}
 	require.NoError(t, <-done)
-	require.ElementsMatch(t, []string{"t1", "t2"}, []string{<-validated, <-validated})
+	require.ElementsMatch(t, []string{"t1", "external", "t2"}, []string{<-validated, <-validated, <-validated})
 }
 
 func TestTimestampDataBranchValidationLockCoversPublication(t *testing.T) {

--- a/pkg/frontend/data_branch_privilege.go
+++ b/pkg/frontend/data_branch_privilege.go
@@ -166,7 +166,7 @@ func authenticateDataBranchCreateDatabaseSourceTables(
 		delta statistic.StatsArray
 		err   error
 	)
-	for _, tblInfo := range source.srcTblInfos {
+	for _, tblInfo := range source.cloneableTableInfos() {
 		srcName := makeBranchTableName(
 			source.srcPrivilegeDBName,
 			tblInfo.tblName,

--- a/pkg/frontend/remap_db.go
+++ b/pkg/frontend/remap_db.go
@@ -23,10 +23,14 @@ import (
 )
 
 type remapDbContext struct {
-	databases            map[string]string
-	lowerCaseTableNames  int64
-	remapUseDatabase     bool
-	unsupported          *bool
+	databases           map[string]string
+	lowerCaseTableNames int64
+	remapUseDatabase    bool
+	unsupported         *bool
+	// cteNames is populated only while dependency collection/remapping walks a
+	// SELECT. It prevents an unqualified CTE reference from being collected as
+	// a source table while preserving qualified references such as db.cte.
+	cteNames             map[string]struct{}
 	collectTableName     func(*tree.TableName)
 	collectProcedureName func(*tree.ProcedureName)
 	collectFunctionName  func(*tree.UnresolvedName)
@@ -35,6 +39,34 @@ type remapDbContext struct {
 func (remap remapDbContext) lookup(database string) (string, bool) {
 	target, ok := remap.databases[tree.NewCStr(database, remap.lowerCaseTableNames).Compare()]
 	return target, ok
+}
+
+func (remap remapDbContext) withVisibleCTEs(ctes ...*tree.CTE) remapDbContext {
+	if len(ctes) == 0 {
+		return remap
+	}
+	scoped := remap
+	scoped.cteNames = make(map[string]struct{}, len(remap.cteNames)+len(ctes))
+	for name := range remap.cteNames {
+		scoped.cteNames[name] = struct{}{}
+	}
+	for _, cte := range ctes {
+		if cte == nil || cte.Name == nil || cte.Name.Alias == "" {
+			continue
+		}
+		scoped.cteNames[tree.NewCStr(
+			string(cte.Name.Alias), remap.lowerCaseTableNames,
+		).Compare()] = struct{}{}
+	}
+	return scoped
+}
+
+func (remap remapDbContext) isVisibleCTE(name string) bool {
+	if len(remap.cteNames) == 0 {
+		return false
+	}
+	_, ok := remap.cteNames[tree.NewCStr(name, remap.lowerCaseTableNames).Compare()]
+	return ok
 }
 
 // applyRemapDb substitutes the database of qualified table and column
@@ -521,10 +553,18 @@ func remapDbInWith(w *tree.With, remap remapDbContext) {
 	if w == nil {
 		return
 	}
+	recursiveScope := remap.withVisibleCTEs(w.CTEs...)
+	sequentialScope := remap
 	for _, cte := range w.CTEs {
-		if cte != nil {
-			remapDbInStmt(cte.Stmt, remap)
+		if cte == nil {
+			continue
 		}
+		cteScope := sequentialScope
+		if w.IsRecursive {
+			cteScope = recursiveScope
+		}
+		remapDbInStmt(cte.Stmt, cteScope)
+		sequentialScope = sequentialScope.withVisibleCTEs(cte)
 	}
 }
 
@@ -533,10 +573,14 @@ func remapDbInSelect(sel *tree.Select, remap remapDbContext) {
 		return
 	}
 	remapDbInWith(sel.With, remap)
-	remapDbInSelectStatement(sel.Select, remap)
-	remapDbInTimeWindow(sel.TimeWindow, remap)
-	remapDbInOrderBy(sel.OrderBy, remap)
-	remapDbInLimit(sel.Limit, remap)
+	scoped := remap
+	if sel.With != nil {
+		scoped = remap.withVisibleCTEs(sel.With.CTEs...)
+	}
+	remapDbInSelectStatement(sel.Select, scoped)
+	remapDbInTimeWindow(sel.TimeWindow, scoped)
+	remapDbInOrderBy(sel.OrderBy, scoped)
+	remapDbInLimit(sel.Limit, scoped)
 }
 
 func remapDbInSelectStatement(s tree.SelectStatement, remap remapDbContext) {
@@ -933,7 +977,8 @@ func remapTableName(tn *tree.TableName, remap remapDbContext) {
 	if tn == nil {
 		return
 	}
-	if remap.collectTableName != nil {
+	if remap.collectTableName != nil && tn.ObjectName != "" &&
+		(tn.ExplicitSchema || !remap.isVisibleCTE(string(tn.ObjectName))) {
 		remap.collectTableName(tn)
 	}
 	if tn.ExplicitSchema {

--- a/pkg/frontend/remap_db.go
+++ b/pkg/frontend/remap_db.go
@@ -27,6 +27,11 @@ type remapDbContext struct {
 	lowerCaseTableNames int64
 	remapUseDatabase    bool
 	unsupported         *bool
+	// rejectUseStateChanges makes dependency collection fail closed for routine
+	// bodies that execute USE. The default database is then path-dependent for
+	// control-flow branches, and assigning one database to every unqualified
+	// reference would risk both false omission and an unsafe persisted body.
+	rejectUseStateChanges bool
 	// cteNames is populated only while dependency collection/remapping walks a
 	// SELECT. It prevents an unqualified CTE reference from being collected as
 	// a source table while preserving qualified references such as db.cte.
@@ -230,25 +235,26 @@ func remapDbInStmt(stmt tree.Statement, remap remapDbContext) bool {
 	case *tree.ParenSelect:
 		remapDbInSelect(s.Select, remap)
 	case *tree.Insert:
-		remapDbInWith(s.With, remap)
-		remapDbInTableExpr(s.Table, remap)
-		remapInsertTarget(s.ColumnNames, &s.TargetDatabaseName, remap)
+		scoped := remapDbInWithScope(s.With, remap)
+		remapDbInTableExpr(s.Table, scoped)
+		remapInsertTarget(s.ColumnNames, &s.TargetDatabaseName, scoped)
 		if s.Rows != nil {
-			remapDbInSelect(s.Rows, remap)
+			remapDbInSelect(s.Rows, scoped)
 		}
-		remapDbInUpdateExprs(s.OnDuplicateUpdate, remap)
+		remapDbInUpdateExprs(s.OnDuplicateUpdate, scoped)
+		remapDbInSelectExprs(s.Returning, scoped)
 	case *tree.MultiInsert:
-		remapDbInWith(s.With, remap)
+		scoped := remapDbInWithScope(s.With, remap)
 		for _, target := range s.AllTargets() {
-			remapDbInTableExpr(target.Table, remap)
-			remapInsertTarget(target.ColumnNames, nil, remap)
-			remapDbInExprs(target.Values, remap)
+			remapDbInTableExpr(target.Table, scoped)
+			remapInsertTarget(target.ColumnNames, nil, scoped)
+			remapDbInExprs(target.Values, scoped)
 		}
 		for _, when := range s.Whens {
-			remapDbInExpr(when.Cond, remap)
+			remapDbInExpr(when.Cond, scoped)
 		}
 		if s.Source != nil {
-			remapDbInSelect(s.Source, remap)
+			remapDbInSelect(s.Source, scoped)
 		}
 	case *tree.Replace:
 		remapDbInTableExpr(s.Table, remap)
@@ -256,23 +262,26 @@ func remapDbInStmt(stmt tree.Statement, remap remapDbContext) bool {
 		if s.Rows != nil {
 			remapDbInSelect(s.Rows, remap)
 		}
+		remapDbInSelectExprs(s.Returning, remap)
 	case *tree.Update:
-		remapDbInWith(s.With, remap)
-		remapDbInTableExprs(s.Tables, remap)
+		scoped := remapDbInWithScope(s.With, remap)
+		remapDbInTableExprs(s.Tables, scoped)
 		if s.From != nil {
-			remapDbInTableExprs(s.From.Tables, remap)
+			remapDbInTableExprs(s.From.Tables, scoped)
 		}
-		remapDbInUpdateExprs(s.Exprs, remap)
-		remapDbInWhere(s.Where, remap)
-		remapDbInOrderBy(s.OrderBy, remap)
-		remapDbInLimit(s.Limit, remap)
+		remapDbInUpdateExprs(s.Exprs, scoped)
+		remapDbInWhere(s.Where, scoped)
+		remapDbInOrderBy(s.OrderBy, scoped)
+		remapDbInLimit(s.Limit, scoped)
+		remapDbInSelectExprs(s.Returning, scoped)
 	case *tree.Delete:
-		remapDbInWith(s.With, remap)
-		remapDbInTableExprs(s.Tables, remap)
-		remapDbInTableExprs(s.TableRefs, remap)
-		remapDbInWhere(s.Where, remap)
-		remapDbInOrderBy(s.OrderBy, remap)
-		remapDbInLimit(s.Limit, remap)
+		scoped := remapDbInWithScope(s.With, remap)
+		remapDbInTableExprs(s.Tables, scoped)
+		remapDbInTableExprs(s.TableRefs, scoped)
+		remapDbInWhere(s.Where, scoped)
+		remapDbInOrderBy(s.OrderBy, scoped)
+		remapDbInLimit(s.Limit, scoped)
+		remapDbInSelectExprs(s.Returning, scoped)
 	case *tree.ValuesStatement:
 		for _, row := range s.Rows {
 			remapDbInExprs(row, remap)
@@ -302,21 +311,19 @@ func remapDbInStmt(stmt tree.Statement, remap remapDbContext) bool {
 	case *tree.Do:
 		remapDbInExprs(s.Exprs, remap)
 	case *tree.Merge:
-		remapDbInWith(s.With, remap)
-		remapDbInTableExpr(s.Target, remap)
-		remapDbInTableExpr(s.Source, remap)
-		remapDbInExpr(s.On, remap)
+		scoped := remapDbInWithScope(s.With, remap)
+		remapDbInTableExpr(s.Target, scoped)
+		remapDbInTableExpr(s.Source, scoped)
+		remapDbInExpr(s.On, scoped)
 		for _, clause := range s.Clauses {
 			if clause == nil {
 				continue
 			}
-			remapDbInExpr(clause.Condition, remap)
-			remapDbInUpdateExprs(clause.UpdateExprs, remap)
-			remapDbInExprs(clause.InsertValues, remap)
+			remapDbInExpr(clause.Condition, scoped)
+			remapDbInUpdateExprs(clause.UpdateExprs, scoped)
+			remapDbInExprs(clause.InsertValues, scoped)
 		}
-		for _, returning := range s.Returning {
-			remapDbInExpr(returning.Expr, remap)
-		}
+		remapDbInSelectExprs(s.Returning, scoped)
 	case *tree.Load:
 		remapTableName(s.Table, remap)
 	case *tree.DumpTable:
@@ -420,6 +427,9 @@ func remapDbInStmt(stmt tree.Statement, remap remapDbContext) bool {
 		// These forms carry no database or table identity. Their nested expression
 		// fields, where present, are handled by their dedicated cases above.
 	case *tree.Use:
+		if remap.rejectUseStateChanges && !s.IsUseRole() {
+			remap.markUnsupported()
+		}
 		if remap.remapUseDatabase {
 			remapUseDatabase(s, remap)
 		}
@@ -549,6 +559,14 @@ func remapDbInStatements(stmts []tree.Statement, remap remapDbContext) bool {
 	return remappable
 }
 
+func remapDbInWithScope(w *tree.With, remap remapDbContext) remapDbContext {
+	remapDbInWith(w, remap)
+	if w == nil {
+		return remap
+	}
+	return remap.withVisibleCTEs(w.CTEs...)
+}
+
 func remapDbInWith(w *tree.With, remap remapDbContext) {
 	if w == nil {
 		return
@@ -565,6 +583,12 @@ func remapDbInWith(w *tree.With, remap remapDbContext) {
 		}
 		remapDbInStmt(cte.Stmt, cteScope)
 		sequentialScope = sequentialScope.withVisibleCTEs(cte)
+	}
+}
+
+func remapDbInSelectExprs(exprs tree.SelectExprs, remap remapDbContext) {
+	for _, expr := range exprs {
+		remapDbInExpr(expr.Expr, remap)
 	}
 }
 
@@ -915,8 +939,11 @@ func remapDbInExpr(expr tree.Expr, remap remapDbContext) {
 	case *tree.VarExpr:
 		remapDbInExpr(e.Expr, remap)
 	case *tree.FuncExpr:
-		if name, ok := e.Func.FunctionReference.(*tree.UnresolvedName); ok && remap.collectFunctionName != nil {
-			remap.collectFunctionName(name)
+		if name, ok := e.Func.FunctionReference.(*tree.UnresolvedName); ok {
+			if remap.collectFunctionName != nil {
+				remap.collectFunctionName(name)
+			}
+			remapFunctionName(name, remap)
 		}
 		remapDbInExprs(e.Exprs, remap)
 		remapDbInOrderBy(e.OrderBy, remap)
@@ -1015,6 +1042,25 @@ func remapColumnName(name *tree.UnresolvedName, remap remapDbContext) {
 	}
 	if target, ok := remap.lookup(name.DbName()); ok {
 		name.CStrParts[2] = tree.NewCStr(target, remap.lowerCaseTableNames)
+	}
+}
+
+// remapFunctionName substitutes a qualified function's database component.
+// Function references are safe to treat separately from column names because
+// the parser has already classified this UnresolvedName as a function name;
+// a two-part name is therefore db.function rather than table.column.
+func remapFunctionName(name *tree.UnresolvedName, remap remapDbContext) {
+	if name == nil || name.NumParts < 2 {
+		return
+	}
+	part := 1
+	database := name.TblName()
+	if name.NumParts >= 3 {
+		part = 2
+		database = name.DbName()
+	}
+	if target, ok := remap.lookup(database); ok {
+		name.CStrParts[part] = tree.NewCStr(target, remap.lowerCaseTableNames)
 	}
 }
 

--- a/pkg/frontend/remap_db.go
+++ b/pkg/frontend/remap_db.go
@@ -23,10 +23,13 @@ import (
 )
 
 type remapDbContext struct {
-	databases           map[string]string
-	lowerCaseTableNames int64
-	remapUseDatabase    bool
-	unsupported         *bool
+	databases            map[string]string
+	lowerCaseTableNames  int64
+	remapUseDatabase     bool
+	unsupported          *bool
+	collectTableName     func(*tree.TableName)
+	collectProcedureName func(*tree.ProcedureName)
+	collectFunctionName  func(*tree.UnresolvedName)
 }
 
 func (remap remapDbContext) lookup(database string) (string, bool) {
@@ -868,6 +871,9 @@ func remapDbInExpr(expr tree.Expr, remap remapDbContext) {
 	case *tree.VarExpr:
 		remapDbInExpr(e.Expr, remap)
 	case *tree.FuncExpr:
+		if name, ok := e.Func.FunctionReference.(*tree.UnresolvedName); ok && remap.collectFunctionName != nil {
+			remap.collectFunctionName(name)
+		}
 		remapDbInExprs(e.Exprs, remap)
 		remapDbInOrderBy(e.OrderBy, remap)
 		remapDbInWindowSpec(e.WindowSpec, remap)
@@ -927,6 +933,9 @@ func remapTableName(tn *tree.TableName, remap remapDbContext) {
 	if tn == nil {
 		return
 	}
+	if remap.collectTableName != nil {
+		remap.collectTableName(tn)
+	}
 	if tn.ExplicitSchema {
 		if target, ok := remap.lookup(string(tn.SchemaName)); ok {
 			tn.SchemaName = tree.Identifier(target)
@@ -938,7 +947,13 @@ func remapTableName(tn *tree.TableName, remap remapDbContext) {
 }
 
 func remapProcedureName(name *tree.ProcedureName, remap remapDbContext) {
-	if name == nil || !name.Name.ExplicitSchema {
+	if name == nil {
+		return
+	}
+	if remap.collectProcedureName != nil {
+		remap.collectProcedureName(name)
+	}
+	if !name.Name.ExplicitSchema {
 		return
 	}
 	if target, ok := remap.lookup(string(name.Name.SchemaName)); ok {

--- a/pkg/frontend/remap_db_test.go
+++ b/pkg/frontend/remap_db_test.go
@@ -450,6 +450,54 @@ func TestApplyRemapDbDMLExpressionContainers(t *testing.T) {
 	}
 }
 
+func TestApplyRemapDbDMLWithAndReturning(t *testing.T) {
+	remap := map[string]string{"src": "dst"}
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "insert",
+			sql:  "with ext_t as (select 1 as n) insert into src.sink select n from ext_t returning src.sink.id",
+		},
+		{
+			name: "replace",
+			sql:  "replace into src.sink values (1) returning src.sink.id",
+		},
+		{
+			name: "update",
+			sql:  "with ext_t as (select 1 as n) update src.sink set id = id where id in (select n from ext_t) returning src.sink.id",
+		},
+		{
+			name: "delete",
+			sql:  "with ext_t as (select 1 as n) delete from src.sink where id in (select n from ext_t) returning src.sink.id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := applyRemapDbToSQL(t, test.sql, remap)
+			require.Contains(t, out, "dst.sink.id")
+			require.NotContains(t, out, "src.sink.id")
+			require.Contains(t, out, "dst.sink")
+		})
+	}
+
+	qualifiedFunction := tree.NewUnresolvedName(
+		tree.NewCStr("src", 1), tree.NewCStr("f_external", 1),
+	)
+	remapDbInStmt(&tree.Update{
+		Returning: tree.SelectExprs{{Expr: &tree.FuncExpr{
+			Func:     tree.FuncName2ResolvableFunctionReference(qualifiedFunction),
+			FuncName: tree.NewCStr("f_external", 1),
+		}}},
+	}, remapDbContext{
+		databases:           remap,
+		lowerCaseTableNames: 1,
+	})
+	require.Equal(t, "dst", qualifiedFunction.TblNameOrigin())
+}
+
 func TestRemapDbInStmtRewritesExecutableWrapperReferences(t *testing.T) {
 	remap := remapDbContext{
 		databases:           map[string]string{"src": "dst"},

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -1983,6 +1983,7 @@ func isExternalTable(tblInfo *tableInfo) bool {
 }
 
 func shouldSkipRestoreTableInBulk(tblInfo *tableInfo) bool {
+	// Database clone follows the same bulk-restore policy as snapshot and PITR.
 	return isExternalTable(tblInfo)
 }
 

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
@@ -28,6 +28,8 @@ infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
 create function issue_27103_live_src.f_control() returns int language sql as
 'select count(*) from issue_27103_live_src.control_t';
+create function issue_27103_live_src.py_add(x int) returns int language python as
+'return x + 1' handler 'py_add';
 create function issue_27103_live_src.f_external() returns int language sql as
 'select count(*) from issue_27103_live_src.ext_t';
 create function issue_27103_live_src.f_transitive() returns int language sql as
@@ -82,6 +84,10 @@ select count(*) as live_independent_functions from mo_catalog.mo_user_defined_fu
 where db = 'issue_27103_live_dst' and name = 'f_control';
 live_independent_functions
 1
+select count(*) as live_opaque_python_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_live_dst' and name = 'py_add';
+live_opaque_python_functions
+1
 select count(*) as live_external_functions from mo_catalog.mo_user_defined_function
 where db = 'issue_27103_live_dst' and name in ('f_external', 'f_transitive', 'f_view');
 live_external_functions
@@ -105,6 +111,8 @@ infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
 create function issue_27103_snapshot_src.f_control() returns int language sql as
 'select count(*) from issue_27103_snapshot_src.control_t';
+create function issue_27103_snapshot_src.py_add(x int) returns int language python as
+'return x + 1' handler 'py_add';
 create function issue_27103_snapshot_src.f_external() returns int language sql as
 'select count(*) from issue_27103_snapshot_src.ext_t';
 create function issue_27103_snapshot_src.f_transitive() returns int language sql as
@@ -161,6 +169,10 @@ answer
 select count(*) as snapshot_independent_functions from mo_catalog.mo_user_defined_function
 where db = 'issue_27103_snapshot_dst' and name = 'f_control';
 snapshot_independent_functions
+1
+select count(*) as snapshot_opaque_python_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_snapshot_dst' and name = 'py_add';
+snapshot_opaque_python_functions
 1
 select count(*) as snapshot_external_functions from mo_catalog.mo_user_defined_function
 where db = 'issue_27103_snapshot_dst' and name in ('f_external', 'f_transitive', 'f_view');

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
@@ -1,3 +1,4 @@
+drop account if exists issue_27103_branch_acc;
 drop snapshot if exists issue_27103_snapshot;
 drop database if exists issue_27103_live_src;
 drop database if exists issue_27103_live_dst;
@@ -5,13 +6,39 @@ drop database if exists issue_27103_snapshot_src;
 drop database if exists issue_27103_snapshot_dst;
 drop database if exists issue_27103_external_only_src;
 drop database if exists issue_27103_external_only_dst;
+select count(*) as stale_objects from mo_catalog.mo_database
+where datname in ('issue_27103_live_src', 'issue_27103_live_dst',
+'issue_27103_snapshot_src', 'issue_27103_snapshot_dst',
+'issue_27103_external_only_src', 'issue_27103_external_only_dst');
+stale_objects
+0
+select count(*) as stale_snapshots from mo_catalog.mo_snapshots
+where sname = 'issue_27103_snapshot';
+stale_snapshots
+0
+select count(*) as stale_accounts from mo_catalog.mo_account
+where account_name = 'issue_27103_branch_acc';
+stale_accounts
+0
 create database issue_27103_live_src;
 create table issue_27103_live_src.control_t(id int primary key, payload varchar(20));
 insert into issue_27103_live_src.control_t values (1, 'ordinary');
 create external table issue_27103_live_src.ext_t(id int, payload varchar(32))
 infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
+create function issue_27103_live_src.f_control() returns int language sql as
+'select count(*) from issue_27103_live_src.control_t';
+create function issue_27103_live_src.f_external() returns int language sql as
+'select count(*) from issue_27103_live_src.ext_t';
+create function issue_27103_live_src.f_transitive() returns int language sql as
+'issue_27103_live_src.f_external()';
 create view issue_27103_live_src.ext_v as select * from issue_27103_live_src.ext_t;
+create function issue_27103_live_src.f_view() returns int language sql as
+'select count(*) from issue_27103_live_src.ext_v';
+create procedure issue_27103_live_src.p_control() 'begin select count(*) as answer from issue_27103_live_src.control_t; end';
+create procedure issue_27103_live_src.p_external() 'begin select count(*) as answer from issue_27103_live_src.ext_t; end';
+create procedure issue_27103_live_src.p_transitive() 'begin call issue_27103_live_src.p_external(); end';
+create procedure issue_27103_live_src.p_view() 'begin select count(*) as answer from issue_27103_live_src.ext_v; end';
 select count(*) as source_external_rows from issue_27103_live_src.ext_t;
 source_external_rows
 3
@@ -38,6 +65,29 @@ select count(*) as live_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relname = 'control_t' and relkind = 'r';
 live_target_control_tables
 1
+use issue_27103_live_dst;
+select f_control() as live_independent_function_result;
+live_independent_function_result
+1
+call issue_27103_live_dst.p_control();
+answer
+1
+select count(*) as live_independent_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_live_dst' and name = 'f_control';
+live_independent_functions
+1
+select count(*) as live_external_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_live_dst' and name in ('f_external', 'f_transitive', 'f_view');
+live_external_functions
+0
+select count(*) as live_independent_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_live_dst' and name = 'p_control';
+live_independent_procedures
+1
+select count(*) as live_external_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_live_dst' and name in ('p_external', 'p_transitive', 'p_view');
+live_external_procedures
+0
 select count(*) as source_external_rows_after_clone from issue_27103_live_src.ext_t;
 source_external_rows_after_clone
 3
@@ -47,7 +97,19 @@ insert into issue_27103_snapshot_src.control_t values (2, 'snapshot');
 create external table issue_27103_snapshot_src.ext_t(id int, payload varchar(32))
 infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
+create function issue_27103_snapshot_src.f_control() returns int language sql as
+'select count(*) from issue_27103_snapshot_src.control_t';
+create function issue_27103_snapshot_src.f_external() returns int language sql as
+'select count(*) from issue_27103_snapshot_src.ext_t';
+create function issue_27103_snapshot_src.f_transitive() returns int language sql as
+'issue_27103_snapshot_src.f_external()';
 create view issue_27103_snapshot_src.ext_v as select * from issue_27103_snapshot_src.ext_t;
+create function issue_27103_snapshot_src.f_view() returns int language sql as
+'select count(*) from issue_27103_snapshot_src.ext_v';
+create procedure issue_27103_snapshot_src.p_control() 'begin select count(*) as answer from issue_27103_snapshot_src.control_t; end';
+create procedure issue_27103_snapshot_src.p_external() 'begin select count(*) as answer from issue_27103_snapshot_src.ext_t; end';
+create procedure issue_27103_snapshot_src.p_transitive() 'begin call issue_27103_snapshot_src.p_external(); end';
+create procedure issue_27103_snapshot_src.p_view() 'begin select count(*) as answer from issue_27103_snapshot_src.ext_v; end';
 select count(*) as snapshot_source_external_rows from issue_27103_snapshot_src.ext_t;
 snapshot_source_external_rows
 3
@@ -77,6 +139,29 @@ select count(*) as snapshot_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relname = 'control_t' and relkind = 'r';
 snapshot_target_control_tables
 1
+use issue_27103_snapshot_dst;
+select f_control() as snapshot_independent_function_result;
+snapshot_independent_function_result
+1
+call issue_27103_snapshot_dst.p_control();
+answer
+1
+select count(*) as snapshot_independent_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_snapshot_dst' and name = 'f_control';
+snapshot_independent_functions
+1
+select count(*) as snapshot_external_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_snapshot_dst' and name in ('f_external', 'f_transitive', 'f_view');
+snapshot_external_functions
+0
+select count(*) as snapshot_independent_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_snapshot_dst' and name = 'p_control';
+snapshot_independent_procedures
+1
+select count(*) as snapshot_external_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_snapshot_dst' and name in ('p_external', 'p_transitive', 'p_view');
+snapshot_external_procedures
+0
 create database issue_27103_external_only_src;
 create external table issue_27103_external_only_src.ext_t(id int, payload varchar(32))
 infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
@@ -90,6 +175,35 @@ select count(*) as external_only_target_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_external_only_dst';
 external_only_target_tables
 0
+create account issue_27103_branch_acc admin_name = 'admin' identified by '111';
+create database issue_27103_branch_src;
+create table issue_27103_branch_src.control_t(id int primary key);
+insert into issue_27103_branch_src.control_t values (11);
+create external table issue_27103_branch_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create role issue_27103_branch_role;
+grant connect on account * to issue_27103_branch_role;
+grant create database on account * to issue_27103_branch_role;
+create user issue_27103_branch_user identified by '111' default role issue_27103_branch_role;
+grant select on table issue_27103_branch_src.control_t to issue_27103_branch_role;
+data branch create database issue_27103_branch_dst from issue_27103_branch_src;
+select count(*) as branch_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_branch_dst';
+branch_target_database
+1
+select count(*) as branch_target_control_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_branch_dst' and relname = 'control_t' and relkind = 'r';
+branch_target_control_tables
+1
+select count(*) as branch_target_external_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_branch_dst' and relkind = 'e';
+branch_target_external_tables
+0
+select * from issue_27103_branch_dst.control_t;
+id
+11
+drop account issue_27103_branch_acc;
 drop snapshot if exists issue_27103_snapshot;
 drop database if exists issue_27103_live_src;
 drop database if exists issue_27103_live_dst;

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
@@ -1,0 +1,99 @@
+drop snapshot if exists issue_27103_snapshot;
+drop database if exists issue_27103_live_src;
+drop database if exists issue_27103_live_dst;
+drop database if exists issue_27103_snapshot_src;
+drop database if exists issue_27103_snapshot_dst;
+drop database if exists issue_27103_external_only_src;
+drop database if exists issue_27103_external_only_dst;
+create database issue_27103_live_src;
+create table issue_27103_live_src.control_t(id int primary key, payload varchar(20));
+insert into issue_27103_live_src.control_t values (1, 'ordinary');
+create external table issue_27103_live_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create view issue_27103_live_src.ext_v as select * from issue_27103_live_src.ext_t;
+select count(*) as source_external_rows from issue_27103_live_src.ext_t;
+source_external_rows
+3
+create database issue_27103_live_dst clone issue_27103_live_src;
+select count(*) as live_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_live_dst';
+live_target_database
+1
+show tables from issue_27103_live_dst;
+Tables_in_issue_27103_live_dst
+control_t
+select * from issue_27103_live_dst.control_t order by id;
+id    payload
+1    ordinary
+select count(*) as live_target_external_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relkind = 'e';
+live_target_external_tables
+0
+select count(*) as live_target_external_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relkind = 'v' and relname = 'ext_v';
+live_target_external_views
+0
+select count(*) as live_target_control_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relname = 'control_t' and relkind = 'r';
+live_target_control_tables
+1
+select count(*) as source_external_rows_after_clone from issue_27103_live_src.ext_t;
+source_external_rows_after_clone
+3
+create database issue_27103_snapshot_src;
+create table issue_27103_snapshot_src.control_t(id int primary key, payload varchar(20));
+insert into issue_27103_snapshot_src.control_t values (2, 'snapshot');
+create external table issue_27103_snapshot_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create view issue_27103_snapshot_src.ext_v as select * from issue_27103_snapshot_src.ext_t;
+select count(*) as snapshot_source_external_rows from issue_27103_snapshot_src.ext_t;
+snapshot_source_external_rows
+3
+create snapshot issue_27103_snapshot for database issue_27103_snapshot_src;
+drop database issue_27103_snapshot_src;
+create database issue_27103_snapshot_dst clone issue_27103_snapshot_src
+{snapshot = "issue_27103_snapshot"};
+select count(*) as snapshot_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_snapshot_dst';
+snapshot_target_database
+1
+show tables from issue_27103_snapshot_dst;
+Tables_in_issue_27103_snapshot_dst
+control_t
+select * from issue_27103_snapshot_dst.control_t order by id;
+id    payload
+2    snapshot
+select count(*) as snapshot_target_external_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'e';
+snapshot_target_external_tables
+0
+select count(*) as snapshot_target_external_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'v' and relname = 'ext_v';
+snapshot_target_external_views
+0
+select count(*) as snapshot_target_control_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relname = 'control_t' and relkind = 'r';
+snapshot_target_control_tables
+1
+create database issue_27103_external_only_src;
+create external table issue_27103_external_only_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create database issue_27103_external_only_dst clone issue_27103_external_only_src;
+select count(*) as external_only_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_external_only_dst';
+external_only_target_database
+1
+select count(*) as external_only_target_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_external_only_dst';
+external_only_target_tables
+0
+drop snapshot if exists issue_27103_snapshot;
+drop database if exists issue_27103_live_src;
+drop database if exists issue_27103_live_dst;
+drop database if exists issue_27103_snapshot_src;
+drop database if exists issue_27103_snapshot_dst;
+drop database if exists issue_27103_external_only_src;
+drop database if exists issue_27103_external_only_dst;

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.result
@@ -33,6 +33,8 @@ create function issue_27103_live_src.f_external() returns int language sql as
 create function issue_27103_live_src.f_transitive() returns int language sql as
 'issue_27103_live_src.f_external()';
 create view issue_27103_live_src.ext_v as select * from issue_27103_live_src.ext_t;
+use issue_27103_live_src;
+create view issue_27103_live_src.udf_v as select f_external();
 create function issue_27103_live_src.f_view() returns int language sql as
 'select count(*) from issue_27103_live_src.ext_v';
 create procedure issue_27103_live_src.p_control() 'begin select count(*) as answer from issue_27103_live_src.control_t; end';
@@ -60,6 +62,10 @@ live_target_external_tables
 select count(*) as live_target_external_views from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relkind = 'v' and relname = 'ext_v';
 live_target_external_views
+0
+select count(*) as live_target_omitted_udf_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relkind = 'v' and relname = 'udf_v';
+live_target_omitted_udf_views
 0
 select count(*) as live_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relname = 'control_t' and relkind = 'r';
@@ -104,6 +110,8 @@ create function issue_27103_snapshot_src.f_external() returns int language sql a
 create function issue_27103_snapshot_src.f_transitive() returns int language sql as
 'issue_27103_snapshot_src.f_external()';
 create view issue_27103_snapshot_src.ext_v as select * from issue_27103_snapshot_src.ext_t;
+use issue_27103_snapshot_src;
+create view issue_27103_snapshot_src.udf_v as select f_external();
 create function issue_27103_snapshot_src.f_view() returns int language sql as
 'select count(*) from issue_27103_snapshot_src.ext_v';
 create procedure issue_27103_snapshot_src.p_control() 'begin select count(*) as answer from issue_27103_snapshot_src.control_t; end';
@@ -134,6 +142,10 @@ snapshot_target_external_tables
 select count(*) as snapshot_target_external_views from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'v' and relname = 'ext_v';
 snapshot_target_external_views
+0
+select count(*) as snapshot_target_omitted_udf_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'v' and relname = 'udf_v';
+snapshot_target_omitted_udf_views
 0
 select count(*) as snapshot_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relname = 'control_t' and relkind = 'r';

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
@@ -10,15 +10,15 @@ drop database if exists issue_27103_snapshot_src;
 drop database if exists issue_27103_snapshot_dst;
 drop database if exists issue_27103_external_only_src;
 drop database if exists issue_27103_external_only_dst;
--- @wait_expect(0, 30)
+-- @wait_expect(1, 30)
 select count(*) as stale_objects from mo_catalog.mo_database
 where datname in ('issue_27103_live_src', 'issue_27103_live_dst',
                   'issue_27103_snapshot_src', 'issue_27103_snapshot_dst',
                   'issue_27103_external_only_src', 'issue_27103_external_only_dst');
--- @wait_expect(0, 30)
+-- @wait_expect(1, 30)
 select count(*) as stale_snapshots from mo_catalog.mo_snapshots
 where sname = 'issue_27103_snapshot';
--- @wait_expect(0, 30)
+-- @wait_expect(1, 30)
 select count(*) as stale_accounts from mo_catalog.mo_account
 where account_name = 'issue_27103_branch_acc';
 

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
@@ -1,0 +1,77 @@
+-- Database CLONE follows the bulk-restore policy for external tables: the
+-- external relation is skipped, while ordinary tables and the target database
+-- are still cloned successfully.
+-- Allow the previous test run's asynchronous DDL cleanup to finish before
+-- reusing names.
+-- @sleep:2
+drop snapshot if exists issue_27103_snapshot;
+drop database if exists issue_27103_live_src;
+drop database if exists issue_27103_live_dst;
+drop database if exists issue_27103_snapshot_src;
+drop database if exists issue_27103_snapshot_dst;
+drop database if exists issue_27103_external_only_src;
+drop database if exists issue_27103_external_only_dst;
+
+create database issue_27103_live_src;
+create table issue_27103_live_src.control_t(id int primary key, payload varchar(20));
+insert into issue_27103_live_src.control_t values (1, 'ordinary');
+create external table issue_27103_live_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create view issue_27103_live_src.ext_v as select * from issue_27103_live_src.ext_t;
+select count(*) as source_external_rows from issue_27103_live_src.ext_t;
+
+create database issue_27103_live_dst clone issue_27103_live_src;
+select count(*) as live_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_live_dst';
+show tables from issue_27103_live_dst;
+select * from issue_27103_live_dst.control_t order by id;
+select count(*) as live_target_external_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relkind = 'e';
+select count(*) as live_target_external_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relkind = 'v' and relname = 'ext_v';
+select count(*) as live_target_control_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relname = 'control_t' and relkind = 'r';
+select count(*) as source_external_rows_after_clone from issue_27103_live_src.ext_t;
+
+create database issue_27103_snapshot_src;
+create table issue_27103_snapshot_src.control_t(id int primary key, payload varchar(20));
+insert into issue_27103_snapshot_src.control_t values (2, 'snapshot');
+create external table issue_27103_snapshot_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create view issue_27103_snapshot_src.ext_v as select * from issue_27103_snapshot_src.ext_t;
+select count(*) as snapshot_source_external_rows from issue_27103_snapshot_src.ext_t;
+create snapshot issue_27103_snapshot for database issue_27103_snapshot_src;
+drop database issue_27103_snapshot_src;
+
+create database issue_27103_snapshot_dst clone issue_27103_snapshot_src
+{snapshot = "issue_27103_snapshot"};
+select count(*) as snapshot_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_snapshot_dst';
+show tables from issue_27103_snapshot_dst;
+select * from issue_27103_snapshot_dst.control_t order by id;
+select count(*) as snapshot_target_external_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'e';
+select count(*) as snapshot_target_external_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'v' and relname = 'ext_v';
+select count(*) as snapshot_target_control_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relname = 'control_t' and relkind = 'r';
+
+create database issue_27103_external_only_src;
+create external table issue_27103_external_only_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create database issue_27103_external_only_dst clone issue_27103_external_only_src;
+select count(*) as external_only_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_external_only_dst';
+select count(*) as external_only_target_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_external_only_dst';
+
+drop snapshot if exists issue_27103_snapshot;
+drop database if exists issue_27103_live_src;
+drop database if exists issue_27103_live_dst;
+drop database if exists issue_27103_snapshot_src;
+drop database if exists issue_27103_snapshot_dst;
+drop database if exists issue_27103_external_only_src;
+drop database if exists issue_27103_external_only_dst;

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
@@ -1,9 +1,8 @@
 -- Database CLONE follows the bulk-restore policy for external tables: the
 -- external relation is skipped, while ordinary tables and the target database
 -- are still cloned successfully.
--- Allow the previous test run's asynchronous DDL cleanup to finish before
--- reusing names.
--- @sleep:2
+-- Poll catalog state after the previous run's cleanup before reusing names.
+drop account if exists issue_27103_branch_acc;
 drop snapshot if exists issue_27103_snapshot;
 drop database if exists issue_27103_live_src;
 drop database if exists issue_27103_live_dst;
@@ -11,6 +10,17 @@ drop database if exists issue_27103_snapshot_src;
 drop database if exists issue_27103_snapshot_dst;
 drop database if exists issue_27103_external_only_src;
 drop database if exists issue_27103_external_only_dst;
+-- @wait_expect(0, 30)
+select count(*) as stale_objects from mo_catalog.mo_database
+where datname in ('issue_27103_live_src', 'issue_27103_live_dst',
+                  'issue_27103_snapshot_src', 'issue_27103_snapshot_dst',
+                  'issue_27103_external_only_src', 'issue_27103_external_only_dst');
+-- @wait_expect(0, 30)
+select count(*) as stale_snapshots from mo_catalog.mo_snapshots
+where sname = 'issue_27103_snapshot';
+-- @wait_expect(0, 30)
+select count(*) as stale_accounts from mo_catalog.mo_account
+where account_name = 'issue_27103_branch_acc';
 
 create database issue_27103_live_src;
 create table issue_27103_live_src.control_t(id int primary key, payload varchar(20));
@@ -18,7 +28,19 @@ insert into issue_27103_live_src.control_t values (1, 'ordinary');
 create external table issue_27103_live_src.ext_t(id int, payload varchar(32))
 infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
+create function issue_27103_live_src.f_control() returns int language sql as
+'select count(*) from issue_27103_live_src.control_t';
+create function issue_27103_live_src.f_external() returns int language sql as
+'select count(*) from issue_27103_live_src.ext_t';
+create function issue_27103_live_src.f_transitive() returns int language sql as
+'issue_27103_live_src.f_external()';
 create view issue_27103_live_src.ext_v as select * from issue_27103_live_src.ext_t;
+create function issue_27103_live_src.f_view() returns int language sql as
+'select count(*) from issue_27103_live_src.ext_v';
+create procedure issue_27103_live_src.p_control() 'begin select count(*) as answer from issue_27103_live_src.control_t; end';
+create procedure issue_27103_live_src.p_external() 'begin select count(*) as answer from issue_27103_live_src.ext_t; end';
+create procedure issue_27103_live_src.p_transitive() 'begin call issue_27103_live_src.p_external(); end';
+create procedure issue_27103_live_src.p_view() 'begin select count(*) as answer from issue_27103_live_src.ext_v; end';
 select count(*) as source_external_rows from issue_27103_live_src.ext_t;
 
 create database issue_27103_live_dst clone issue_27103_live_src;
@@ -32,6 +54,17 @@ select count(*) as live_target_external_views from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relkind = 'v' and relname = 'ext_v';
 select count(*) as live_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relname = 'control_t' and relkind = 'r';
+use issue_27103_live_dst;
+select f_control() as live_independent_function_result;
+call issue_27103_live_dst.p_control();
+select count(*) as live_independent_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_live_dst' and name = 'f_control';
+select count(*) as live_external_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_live_dst' and name in ('f_external', 'f_transitive', 'f_view');
+select count(*) as live_independent_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_live_dst' and name = 'p_control';
+select count(*) as live_external_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_live_dst' and name in ('p_external', 'p_transitive', 'p_view');
 select count(*) as source_external_rows_after_clone from issue_27103_live_src.ext_t;
 
 create database issue_27103_snapshot_src;
@@ -40,7 +73,19 @@ insert into issue_27103_snapshot_src.control_t values (2, 'snapshot');
 create external table issue_27103_snapshot_src.ext_t(id int, payload varchar(32))
 infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
+create function issue_27103_snapshot_src.f_control() returns int language sql as
+'select count(*) from issue_27103_snapshot_src.control_t';
+create function issue_27103_snapshot_src.f_external() returns int language sql as
+'select count(*) from issue_27103_snapshot_src.ext_t';
+create function issue_27103_snapshot_src.f_transitive() returns int language sql as
+'issue_27103_snapshot_src.f_external()';
 create view issue_27103_snapshot_src.ext_v as select * from issue_27103_snapshot_src.ext_t;
+create function issue_27103_snapshot_src.f_view() returns int language sql as
+'select count(*) from issue_27103_snapshot_src.ext_v';
+create procedure issue_27103_snapshot_src.p_control() 'begin select count(*) as answer from issue_27103_snapshot_src.control_t; end';
+create procedure issue_27103_snapshot_src.p_external() 'begin select count(*) as answer from issue_27103_snapshot_src.ext_t; end';
+create procedure issue_27103_snapshot_src.p_transitive() 'begin call issue_27103_snapshot_src.p_external(); end';
+create procedure issue_27103_snapshot_src.p_view() 'begin select count(*) as answer from issue_27103_snapshot_src.ext_v; end';
 select count(*) as snapshot_source_external_rows from issue_27103_snapshot_src.ext_t;
 create snapshot issue_27103_snapshot for database issue_27103_snapshot_src;
 drop database issue_27103_snapshot_src;
@@ -57,6 +102,17 @@ select count(*) as snapshot_target_external_views from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'v' and relname = 'ext_v';
 select count(*) as snapshot_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relname = 'control_t' and relkind = 'r';
+use issue_27103_snapshot_dst;
+select f_control() as snapshot_independent_function_result;
+call issue_27103_snapshot_dst.p_control();
+select count(*) as snapshot_independent_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_snapshot_dst' and name = 'f_control';
+select count(*) as snapshot_external_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_snapshot_dst' and name in ('f_external', 'f_transitive', 'f_view');
+select count(*) as snapshot_independent_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_snapshot_dst' and name = 'p_control';
+select count(*) as snapshot_external_procedures from mo_catalog.mo_stored_procedure
+where db = 'issue_27103_snapshot_dst' and name in ('p_external', 'p_transitive', 'p_view');
 
 create database issue_27103_external_only_src;
 create external table issue_27103_external_only_src.ext_t(id int, payload varchar(32))
@@ -67,6 +123,35 @@ select count(*) as external_only_target_database from mo_catalog.mo_database
 where datname = 'issue_27103_external_only_dst';
 select count(*) as external_only_target_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_external_only_dst';
+
+-- DATA BRANCH uses the same cloneable-object set for source authorization.
+-- The non-admin has SELECT only on the ordinary table; the external table is
+-- deliberately not granted because it will not be materialized in the branch.
+create account issue_27103_branch_acc admin_name = 'admin' identified by '111';
+-- @session:id=11&user=issue_27103_branch_acc:admin&password=111
+create database issue_27103_branch_src;
+create table issue_27103_branch_src.control_t(id int primary key);
+insert into issue_27103_branch_src.control_t values (11);
+create external table issue_27103_branch_src.ext_t(id int, payload varchar(32))
+infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
+fields terminated by ',';
+create role issue_27103_branch_role;
+grant connect on account * to issue_27103_branch_role;
+grant create database on account * to issue_27103_branch_role;
+create user issue_27103_branch_user identified by '111' default role issue_27103_branch_role;
+grant select on table issue_27103_branch_src.control_t to issue_27103_branch_role;
+-- @session:id=12&user=issue_27103_branch_acc:issue_27103_branch_user:issue_27103_branch_role&password=111
+data branch create database issue_27103_branch_dst from issue_27103_branch_src;
+-- @session:id=11
+select count(*) as branch_target_database from mo_catalog.mo_database
+where datname = 'issue_27103_branch_dst';
+select count(*) as branch_target_control_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_branch_dst' and relname = 'control_t' and relkind = 'r';
+select count(*) as branch_target_external_tables from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_branch_dst' and relkind = 'e';
+select * from issue_27103_branch_dst.control_t;
+-- @session
+drop account issue_27103_branch_acc;
 
 drop snapshot if exists issue_27103_snapshot;
 drop database if exists issue_27103_live_src;

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
@@ -30,6 +30,8 @@ infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
 create function issue_27103_live_src.f_control() returns int language sql as
 'select count(*) from issue_27103_live_src.control_t';
+create function issue_27103_live_src.py_add(x int) returns int language python as
+'return x + 1' handler 'py_add';
 create function issue_27103_live_src.f_external() returns int language sql as
 'select count(*) from issue_27103_live_src.ext_t';
 create function issue_27103_live_src.f_transitive() returns int language sql as
@@ -63,6 +65,8 @@ select f_control() as live_independent_function_result;
 call issue_27103_live_dst.p_control();
 select count(*) as live_independent_functions from mo_catalog.mo_user_defined_function
 where db = 'issue_27103_live_dst' and name = 'f_control';
+select count(*) as live_opaque_python_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_live_dst' and name = 'py_add';
 select count(*) as live_external_functions from mo_catalog.mo_user_defined_function
 where db = 'issue_27103_live_dst' and name in ('f_external', 'f_transitive', 'f_view');
 select count(*) as live_independent_procedures from mo_catalog.mo_stored_procedure
@@ -79,6 +83,8 @@ infile{"filepath"='$resources/external_table_file/aaa.csv','format'='csv'}
 fields terminated by ',';
 create function issue_27103_snapshot_src.f_control() returns int language sql as
 'select count(*) from issue_27103_snapshot_src.control_t';
+create function issue_27103_snapshot_src.py_add(x int) returns int language python as
+'return x + 1' handler 'py_add';
 create function issue_27103_snapshot_src.f_external() returns int language sql as
 'select count(*) from issue_27103_snapshot_src.ext_t';
 create function issue_27103_snapshot_src.f_transitive() returns int language sql as
@@ -115,6 +121,8 @@ select f_control() as snapshot_independent_function_result;
 call issue_27103_snapshot_dst.p_control();
 select count(*) as snapshot_independent_functions from mo_catalog.mo_user_defined_function
 where db = 'issue_27103_snapshot_dst' and name = 'f_control';
+select count(*) as snapshot_opaque_python_functions from mo_catalog.mo_user_defined_function
+where db = 'issue_27103_snapshot_dst' and name = 'py_add';
 select count(*) as snapshot_external_functions from mo_catalog.mo_user_defined_function
 where db = 'issue_27103_snapshot_dst' and name in ('f_external', 'f_transitive', 'f_view');
 select count(*) as snapshot_independent_procedures from mo_catalog.mo_stored_procedure

--- a/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
+++ b/test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql
@@ -35,6 +35,8 @@ create function issue_27103_live_src.f_external() returns int language sql as
 create function issue_27103_live_src.f_transitive() returns int language sql as
 'issue_27103_live_src.f_external()';
 create view issue_27103_live_src.ext_v as select * from issue_27103_live_src.ext_t;
+use issue_27103_live_src;
+create view issue_27103_live_src.udf_v as select f_external();
 create function issue_27103_live_src.f_view() returns int language sql as
 'select count(*) from issue_27103_live_src.ext_v';
 create procedure issue_27103_live_src.p_control() 'begin select count(*) as answer from issue_27103_live_src.control_t; end';
@@ -52,6 +54,8 @@ select count(*) as live_target_external_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relkind = 'e';
 select count(*) as live_target_external_views from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relkind = 'v' and relname = 'ext_v';
+select count(*) as live_target_omitted_udf_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_live_dst' and relkind = 'v' and relname = 'udf_v';
 select count(*) as live_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_live_dst' and relname = 'control_t' and relkind = 'r';
 use issue_27103_live_dst;
@@ -80,6 +84,8 @@ create function issue_27103_snapshot_src.f_external() returns int language sql a
 create function issue_27103_snapshot_src.f_transitive() returns int language sql as
 'issue_27103_snapshot_src.f_external()';
 create view issue_27103_snapshot_src.ext_v as select * from issue_27103_snapshot_src.ext_t;
+use issue_27103_snapshot_src;
+create view issue_27103_snapshot_src.udf_v as select f_external();
 create function issue_27103_snapshot_src.f_view() returns int language sql as
 'select count(*) from issue_27103_snapshot_src.ext_v';
 create procedure issue_27103_snapshot_src.p_control() 'begin select count(*) as answer from issue_27103_snapshot_src.control_t; end';
@@ -100,6 +106,8 @@ select count(*) as snapshot_target_external_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'e';
 select count(*) as snapshot_target_external_views from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'v' and relname = 'ext_v';
+select count(*) as snapshot_target_omitted_udf_views from mo_catalog.mo_tables
+where reldatabase = 'issue_27103_snapshot_dst' and relkind = 'v' and relname = 'udf_v';
 select count(*) as snapshot_target_control_tables from mo_catalog.mo_tables
 where reldatabase = 'issue_27103_snapshot_dst' and relname = 'control_t' and relkind = 'r';
 use issue_27103_snapshot_dst;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27103

## What this PR does / why we need it:

### Root cause

Database CLONE enumerated external relations with the source table list. The
general clone loop excluded views and sequences only, so an external relation
was sent through the base-table clone path and failed with `is not BASE TABLE`.
The same unfiltered list also drove DATA BRANCH source authorization, table
quota accounting, source locking, and timestamp revalidation.

### Changes

- Define one cloneable relation set from the existing bulk-restore external
  table policy and reuse it for database-clone execution, foreign-key routing,
  DATA BRANCH authorization, and quota accounting.
- Keep external catalog rows in the DATA BRANCH lifecycle lock and timestamp
  revalidation fence because post-lock view dependency planning reads their
  metadata; this prevents concurrent DROP/ALTER from changing the generation
  being resolved.
- Skip external relations while preserving the target database and all
  supported ordinary tables. An external-only source therefore creates an
  empty target database without copying external files or data.
- Compute the omitted external/view dependency closure with the existing SQL
  AST walker. SQL UDFs and stored procedures that directly or transitively
  depend on an omitted relation or routine are omitted; independent SQL
  routine families are copied and rewritten for the target database.
- Track visible CTE names, including nested and recursive WITH scopes, so
  unqualified CTE references are not falsely collected as base-table
  dependencies while qualified references remain visible.
- Treat UDF overloads with the same database, name, and kind as one conservative
  family. If dependency inspection omits one overload, the whole family is
  omitted because clone-time metadata inspection cannot safely resolve overload
  types at every call site. This contract is documented in the clone guide and
  covered by mixed-overload/caller propagation tests.
- Uninspectable routines are conservatively omitted when the source contains an
  omitted relation.
- Document the external-table and dependent-object contract in the clone guide.
- Replace fixed BVT sleep with catalog readiness polling and deterministic
  cleanup assertions, using a valid one-second polling interval for mo-tester.
- Return early from dependency-closure analysis when no relation is initially
  omitted, avoiding a second parse of every view in the normal clone path.

### Issue-to-test proof

- `test/distributed/cases/git4data/clone/issue_27103_clone_external_table.sql`
  uses a local-file external table plus an ordinary table and covers live and
  snapshot database CLONE. It verifies the target database, ordinary rows,
  absence of external-table metadata, skipped dependent views, independent SQL
  UDF/procedure execution, omission of direct and transitive dependent UDFs and
  procedures, and source external-table readability after live cloning.
- The same BVT covers an external-only source and a non-admin DATA BRANCH source
  where SELECT is granted only on the ordinary table; both succeed and omit the
  external relation.
- Frontend UTs cover the cloneable relation set, routine dependency closure,
  nested/recursive CTE scoping, mixed UDF overload-family conservatism and
  caller propagation, lifecycle inclusion of external dependency rows, branch
  quota accounting, source locking, timestamp revalidation, and SQL routine
  rewriting.

### Tests

- Reproduced the reported mixed-source failure before the change: `CREATE
  DATABASE ... CLONE` returned `is not BASE TABLE` and left no target database.
- `source /Users/ghs-mo/.zshrc && moenv && GOWORK=off go test -mod=readonly ./pkg/frontend -count=1`
  (pass).
- Focused `go test -race` after the review fix (pass), including CTE scope,
  overload-family, routine, lifecycle-fence, quota, locking, revalidation, and
  rewrite tests.
- `source /Users/ghs-mo/.zshrc && moenv && make build` (pass).
- The inspected `issue_27103_clone_external_table.sql` result passed twice
  immediately on the same rebuilt service at head `a428213146`: 98/98
  successful, 0 failures, 0 abnormal results, and an empty error report on
  each run.
- The branch was rebased conflict-free onto latest `origin/main` `2f11b2bd48`; the reviewed 10-file PR diff is unchanged by the base update.
- `git diff --check` (pass).

### Residual risks

External tables, their external files/data, dependent views, and dependent SQL
routines are intentionally not recreated by database CLONE. This matches the
existing snapshot/PITR bulk-restore policy and is documented in the clone
guide. Explicit single-table CLONE of an external table remains unsupported.
Routine dependency inspection is AST-based; when a routine cannot be safely
inspected in the presence of an omitted relation, it is omitted rather than
persisted with an unverifiable source dependency. UDF overloads sharing a
database/name/kind are intentionally handled as one conservative family.

### Review follow-up at 7c80e4cf42

- DML WITH scopes now flow through the shared remap context for INSERT, MultiInsert, UPDATE, DELETE, and MERGE bodies, including nested query expressions.
- INSERT, REPLACE, UPDATE, DELETE, and MERGE RETURNING expressions are visited by the same walker used for dependency collection and SQL rewriting. Qualified SQL UDF references are remapped with their database component.
- Executable USE in routine dependency analysis now fails closed when omitted source relations are present, because path-dependent default-database state cannot be assigned safely to one source database. The clone guide documents this contract.
- Validation on this head: full pkg/frontend UT passed; focused dependency/remap UT passed under -race; make build passed; git diff --check passed. The exact target-clone BVT remains covered by the existing same-instance 98/98 evidence from the preceding reviewed head.

### Review follow-up at 06bdb843fa

- The omission analysis now uses one bidirectional dependency graph for external objects, views, SQL UDF families, and stored procedures. Omitted routines propagate back to dependent views, including transitive view chains, so view restoration never attempts metadata whose routine dependency was omitted.
- Reverse dependency edges are processed with a work queue, giving one propagation step per discovered dependency instead of repeated full scans of every object in a long chain.
- The clone pipeline applies the complete omission set before view sorting and routine rewriting. The clone guide documents the two-way omission contract.
- Added a frontend regression for external table to SQL UDF to view propagation, plus live and snapshot public-path BVT assertions that the dependent view is absent while independent metadata remains usable.
- Validation on this head: full pkg/frontend UT passed (26.970s); focused dependency/remap UT passed under race; make build passed; git diff --check passed; the target clone BVT passed twice immediately on one rebuilt service with 104/104 success, 0 failures, 0 abnormal results, and an empty error report each run.
- No workflow, permission, or unrelated files were changed.

### Rebase follow-up at 44d330e0be

- Rebased the same PR branch conflict-free onto latest origin/main 0cee094f15. The reviewed clone changes remain intact; no workflow or permission files were touched.
- Revalidated the rebased head: full pkg/frontend UT passed in 27.876s; focused dependency/remap UT passed under race in 3.423s; make build passed; git diff --check passed.
- The exact issue_27103_clone_external_table.sql BVT passed twice immediately on the same rebuilt rebased service: 104/104 each run, 0 failures, 0 abnormal results, and an empty error report.


### CI follow-up at 627a1b330b

- Linux/arm64 SCA failed because the refactor left the now-unused omittedCloneDatabaseObjects wrapper in pkg/frontend/clone_database_source.go.
- Removed only that obsolete wrapper; clone behavior and the reviewed dependency graph are unchanged.
- Package-level golangci-lint passed with 0 issues; focused frontend race UT passed; git diff --check passed.

### Rebase follow-up at 70794bc609

- Rebased the existing PR branch conflict-free onto latest origin/main 845fff8ee9. The reviewed clone diff is unchanged by the base update; no workflow or permission files were touched.
- Revalidated the rebased head with the focused frontend race UT (pass, 4.490s) and git diff --check.
- The previous head's Linux/arm64 SCA passed after 627a1b330b; the unrelated Iceberg UT Coverage failure is tracked in issue 28260 and remains outside this PR.

### Review follow-up at 63d299ed1b

- The dependency graph now distinguishes inspected SQL routines, safely opaque non-SQL UDFs, and genuinely uninspectable routines. Supported inline non-SQL UDFs are preserved when an external relation seeds the omission closure; imported non-SQL UDF packages remain rejected before target creation by the existing snapshot-versioning guard.
- Added frontend coverage for an external table plus an independent inline Python UDF, including the explicit opaque/uninspectable status contract. The issue_27103_clone_external_table.sql BVT and result now assert that the Python UDF remains in both live and snapshot target catalogs.
- Updated clients/python/docs/clone_guide.rst to document the language-specific omission boundary.
- Validation on this head: full pkg/frontend UT passed (28.253s); focused dependency/remap UT passed under race (2.958s); make build passed; git diff --check passed.
- The BVT result was updated from the deterministic case contract; local execution was not run because port 6001 is occupied by an unrelated Docker service, so the new CI run must validate the rebuilt service.
- No workflows, permissions, or unrelated files were changed.