### PR TITLE
fix: preserve Data Branch lineage across TRUNCATE

### DIFF
--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -283,6 +283,7 @@ func (c *Compile) lockDataBranchLineageOwnerLifecycle() error {
 func (c *Compile) prepareAlterDataBranchLineage(
 	oldTableID uint64,
 	databaseName, tableName string,
+	statement string,
 ) (alterDataBranchLineagePlan, error) {
 	participates, err := c.alterTableParticipatesInDataBranch(oldTableID)
 	if err != nil {
@@ -302,7 +303,7 @@ func (c *Compile) prepareAlterDataBranchLineage(
 			op := c.proc.GetTxnOperator()
 			opts := op.TxnOptions()
 			if err = validateAlterDataBranchLineageTxn(
-				opts.GetByBegin(), opts.GetAutocommit(), op.Txn().IsPessimistic(),
+				statement, opts.GetByBegin(), opts.GetAutocommit(), op.Txn().IsPessimistic(),
 			); err != nil {
 				return alterDataBranchLineagePlan{}, err
 			}
@@ -334,10 +335,10 @@ func (c *Compile) prepareAlterDataBranchLineage(
 	}, nil
 }
 
-func validateAlterDataBranchLineageTxn(byBegin, autocommit, _ bool) error {
+func validateAlterDataBranchLineageTxn(statement string, byBegin, autocommit, _ bool) error {
 	if isExplicitAlterTxn(byBegin, autocommit) {
-		return moerr.NewNotSupportedNoCtx(
-			"ALTER on a data-branch lineage is not supported inside an explicit transaction",
+		return moerr.NewNotSupportedNoCtxf(
+			"%s on a data-branch lineage is not supported inside an explicit transaction", statement,
 		)
 	}
 	return nil
@@ -1176,7 +1177,7 @@ func (s *Scope) alterTableCopy(c *Compile, cleanup *alterAutoIncrementResetClean
 	if err = c.lockDataBranchLineageOwnerLifecycle(); err != nil {
 		return err
 	}
-	lineagePlan, err = c.prepareAlterDataBranchLineage(oldId, dbName, tblName)
+	lineagePlan, err = c.prepareAlterDataBranchLineage(oldId, dbName, tblName, "ALTER")
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -242,11 +242,12 @@ func TestAlterDataBranchLineageMetadata(t *testing.T) {
 }
 
 func TestValidateAlterDataBranchLineageTxn(t *testing.T) {
-	require.NoError(t, validateAlterDataBranchLineageTxn(false, true, true))
-	require.NoError(t, validateAlterDataBranchLineageTxn(false, true, false))
+	require.NoError(t, validateAlterDataBranchLineageTxn("ALTER", false, true, true))
+	require.NoError(t, validateAlterDataBranchLineageTxn("ALTER", false, true, false))
 
 	for _, tc := range []struct {
 		name        string
+		statement   string
 		byBegin     bool
 		autocommit  bool
 		pessimistic bool
@@ -254,6 +255,7 @@ func TestValidateAlterDataBranchLineageTxn(t *testing.T) {
 	}{
 		{
 			name:        "explicit begin",
+			statement:   "ALTER",
 			byBegin:     true,
 			autocommit:  true,
 			pessimistic: true,
@@ -261,13 +263,22 @@ func TestValidateAlterDataBranchLineageTxn(t *testing.T) {
 		},
 		{
 			name:        "autocommit disabled",
+			statement:   "ALTER",
 			autocommit:  false,
 			pessimistic: true,
 			want:        "not supported inside an explicit transaction",
 		},
+		{
+			name:        "truncate explicit begin identifies statement",
+			statement:   "TRUNCATE",
+			byBegin:     true,
+			autocommit:  true,
+			pessimistic: true,
+			want:        "TRUNCATE on a data-branch lineage is not supported inside an explicit transaction",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateAlterDataBranchLineageTxn(tc.byBegin, tc.autocommit, tc.pessimistic)
+			err := validateAlterDataBranchLineageTxn(tc.statement, tc.byBegin, tc.autocommit, tc.pessimistic)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.want)
 		})
@@ -308,7 +319,7 @@ func TestPrepareAlterDataBranchLineageAllowsHistoricalSourceTxn(t *testing.T) {
 				t, c.proc.Mp(), types.T_int32.ToType(), []int32{1},
 			)
 
-			lineagePlan, err := c.prepareAlterDataBranchLineage(oldTableID, database, table)
+			lineagePlan, err := c.prepareAlterDataBranchLineage(oldTableID, database, table, "ALTER")
 			require.NoError(t, err)
 			require.True(t, lineagePlan.enabled)
 			require.True(t, lineagePlan.preserveHistoricalSource)
@@ -366,7 +377,7 @@ func TestPrepareAlterDataBranchLineageAllowsHistoricalOnlyGenerationInExplicitTx
 		t, c.proc.Mp(), nil, nil, nil, nil, nil, nil, nil,
 	)
 
-	lineagePlan, err := c.prepareAlterDataBranchLineage(oldTableID, database, table)
+	lineagePlan, err := c.prepareAlterDataBranchLineage(oldTableID, database, table, "ALTER")
 	require.NoError(t, err)
 	require.True(t, lineagePlan.enabled)
 	require.False(t, lineagePlan.preserveHistoricalSource)

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -285,6 +285,37 @@ func TestValidateAlterDataBranchLineageTxn(t *testing.T) {
 	}
 }
 
+func TestPrepareAlterDataBranchLineageRejectsLiveBranchTxnWithStatement(t *testing.T) {
+	const (
+		oldTableID    = uint64(42)
+		parentTableID = uint64(41)
+		database      = "test"
+		table         = "dept"
+	)
+	ctrl := gomock.NewController(t)
+	spyExec := &alterCopyInsertSpyExecutor{results: make(map[string]executor.Result)}
+	c := newAlterCopyPrecheckCompile(t, ctrl, spyExec)
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().TxnOptions().Return(txn.TxnOptions{ByBegin: true, Autocommit: true})
+	txnOp.EXPECT().Txn().Return(txn.TxnMeta{})
+	c.proc.Base.TxnOperator = txnOp
+
+	participationSQL := alterDataBranchParticipationSQL(oldTableID)
+	metadataSQL := "select table_id, p_table_id, clone_ts, creator, level, table_deleted from mo_catalog.mo_branch_metadata"
+	spyExec.results[participationSQL] = newAlterCopyFixedResult(
+		t, c.proc.Mp(), types.T_int32.ToType(), []int32{1},
+	)
+	spyExec.results[metadataSQL] = newAlterLineageMetadataResult(
+		t, c.proc.Mp(), []uint64{oldTableID}, []uint64{parentTableID}, []int64{100},
+		[]uint64{uint64(catalog.System_Account)}, []string{"table"}, []bool{false},
+	)
+
+	lineagePlan, err := c.prepareAlterDataBranchLineage(oldTableID, database, table, "TRUNCATE")
+	require.ErrorContains(t, err, "TRUNCATE on a data-branch lineage is not supported inside an explicit transaction")
+	require.False(t, lineagePlan.enabled)
+	require.Equal(t, []string{participationSQL, metadataSQL}, spyExec.executedSQLs)
+}
+
 func TestPrepareAlterDataBranchLineageAllowsHistoricalSourceTxn(t *testing.T) {
 	const (
 		oldTableID = uint64(42)

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -511,6 +511,7 @@ func (c *Compile) clear() {
 	c.ignorePublish = false
 	c.adjustTableExtraFunc = nil
 	c.disableDropAutoIncrement = false
+	c.skipDataBranchReclaim = false
 	c.keepAutoIncrement = 0
 	c.disableLock = false
 	c.icebergScanPlanner = nil

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -53,6 +53,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/shardservice"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/lockop"
 	"github.com/matrixorigin/matrixone/pkg/sql/features"
@@ -2565,6 +2566,17 @@ func (c *Compile) reclaimBranchProtectSnapshots(deadTIDs []uint64) (bool, error)
 	)
 }
 
+// reclaimAndCompactBranchProtectSnapshots completes the branch part of a
+// physical-table removal. Replacement paths publish their new lineage edge
+// first, then use this same lifecycle transition as an ordinary DROP.
+func (c *Compile) reclaimAndCompactBranchProtectSnapshots(deadTIDs []uint64) error {
+	branchParticipates, err := c.reclaimBranchProtectSnapshots(deadTIDs)
+	if err != nil || !branchParticipates {
+		return err
+	}
+	return c.compactExpiredAlterDataBranchLineage(time.Time{})
+}
+
 func (s *Scope) CreateView(c *Compile) error {
 	if s.ScopeAnalyzer == nil {
 		s.ScopeAnalyzer = NewScopeAnalyzer()
@@ -3449,7 +3461,6 @@ func (s *Scope) TruncateTable(c *Compile) error {
 	defer s.ScopeAnalyzer.Stop()
 
 	truncate := s.Plan.GetDdl().GetTruncateTable()
-	oldID := truncate.GetTableId()
 	db := truncate.GetDatabase()
 	table := truncate.GetTable()
 
@@ -3469,6 +3480,7 @@ func (s *Scope) TruncateTable(c *Compile) error {
 	if err != nil {
 		return err
 	}
+	oldID := rel.GetTableID(c.proc.Ctx)
 
 	// Check if target table is a CCPR shared table (from publication)
 	if c.shouldBlockCCPRReadOnly(rel.GetTableDef(c.proc.Ctx)) {
@@ -3501,6 +3513,64 @@ func (s *Scope) TruncateTable(c *Compile) error {
 		}
 	}
 
+	// TRUNCATE is a copy-and-swap rebuild: it creates a replacement relation
+	// before the ordinary DROP path retires the old physical generation. Reuse
+	// ALTER's lineage publication protocol so the replacement remains the live
+	// branch child and the old generation stays protected for DIFF/MERGE.
+	lineagePlan := alterDataBranchLineagePlan{}
+	lineageTxnOp := c.proc.GetTxnOperator()
+	lineageSnapshotAdvanced := false
+	lineageCloneTS := int64(0)
+	lineageOriginalSnapshot := timestamp.Timestamp{}
+	lineageRestoreSnapshot := false
+	defer func() {
+		if lineageRestoreSnapshot {
+			lineageTxnOp.SetSnapshotTS(lineageOriginalSnapshot)
+		}
+	}()
+	if shouldAdvanceAlterDataBranchLineageSnapshot(
+		lineageTxnOp.Txn().IsPessimistic(), lineageTxnOp.Txn().IsRCIsolation(),
+	) {
+		lineageOriginalSnapshot = lineageTxnOp.SnapshotTS()
+		lineageRestoreSnapshot = true
+		if lineageCloneTS, err = c.advanceAlterDataBranchLineageSnapshot(); err != nil {
+			return err
+		}
+		lineageSnapshotAdvanced = true
+	}
+	if err = c.lockDataBranchLineageOwnerLifecycle(); err != nil {
+		return err
+	}
+	if lineagePlan, err = c.prepareAlterDataBranchLineage(oldID, db, table, "TRUNCATE"); err != nil {
+		return err
+	}
+	if !lineagePlan.enabled {
+		var hasLatestHistory bool
+		if hasLatestHistory, err = c.alterTableHasLatestHistoricalBranchSource(oldID, db, table); err != nil {
+			return err
+		}
+		if hasLatestHistory {
+			lineagePlan.enabled = true
+			lineagePlan.preserveHistoricalSource = true
+		}
+	}
+	if lineagePlan.enabled {
+		if lineageSnapshotAdvanced {
+			lineagePlan.cloneTS = lineageCloneTS
+		} else {
+			lineagePlan.cloneTS = lineageTxnOp.SnapshotTS().PhysicalTime
+		}
+	}
+	if lineageSnapshotAdvanced {
+		rel, err = dbSource.Relation(c.proc.Ctx, table, nil)
+		if err != nil {
+			return err
+		}
+		if rel.GetTableID(c.proc.Ctx) != oldID {
+			return moerr.NewTxnNeedRetryWithDefChanged(c.proc.Ctx)
+		}
+	}
+
 	// delete from tables => truncate, need keep increment value
 	// Get logicalId from tableDef and pass it when creating the new table
 	tableDef := rel.GetTableDef(c.proc.Ctx)
@@ -3519,6 +3589,11 @@ func (s *Scope) TruncateTable(c *Compile) error {
 		c.addAffectedRows(rows)
 		dropOpts = dropOpts.WithDisableDropIncrStatement()
 		createOpts = createOpts.WithKeepAutoIncrement(oldID)
+	}
+	if lineagePlan.enabled {
+		// The successor edge is published after CREATE obtains its physical ID.
+		// Keep the old edge until then; the shared reclaim below retires it.
+		dropOpts = dropOpts.WithSkipDataBranchReclaim()
 	}
 
 	r, err := c.runSqlWithResultAndOptions(
@@ -3562,6 +3637,16 @@ func (s *Scope) TruncateTable(c *Compile) error {
 		return err
 	}
 	newID := rel.GetTableID(c.proc.Ctx)
+	if lineagePlan.enabled {
+		if err = c.preserveAlterDataBranchLineage(
+			lineagePlan, oldID, newID, db, table,
+		); err != nil {
+			return err
+		}
+		if err = c.reclaimAndCompactBranchProtectSnapshots([]uint64{oldID}); err != nil {
+			return err
+		}
+	}
 
 	for _, ftblId := range truncate.ForeignTbl {
 		_, _, fkRelation, err := c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), ftblId)
@@ -4118,17 +4203,9 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 	// `__mo_branch_*` snapshots. This must run synchronously so drop paths have
 	// identical semantics in the frontend and compile-layer paths (design
 	// §5.3 / §9.2).
-	var branchParticipates bool
-	if branchParticipates, err = c.reclaimBranchProtectSnapshots([]uint64{tblID}); err != nil {
-		logutil.Error("reclaim branch protect snapshots failed",
-			zap.Uint64("tblID", tblID),
-			zap.Error(err),
-		)
-		return err
-	}
-	if branchParticipates {
-		if err = c.compactExpiredAlterDataBranchLineage(time.Time{}); err != nil {
-			logutil.Error("compact historical ALTER lineage failed",
+	if !c.skipDataBranchReclaim {
+		if err = c.reclaimAndCompactBranchProtectSnapshots([]uint64{tblID}); err != nil {
+			logutil.Error("reclaim branch protect snapshots failed",
 				zap.Uint64("tblID", tblID),
 				zap.Error(err),
 			)

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -514,6 +514,7 @@ func (exec *txnExecutor) Exec(
 	c.SetOriginSQL(sql)
 	c.adjustTableExtraFunc = exec.opts.AdjustTableExtraFunc()
 	c.disableDropAutoIncrement = statementOption.DisableDropIncrStatement()
+	c.skipDataBranchReclaim = statementOption.SkipDataBranchReclaim()
 	c.keepAutoIncrement = statementOption.KeepAutoIncrement()
 	c.disableRetry = exec.opts.DisableIncrStatement()
 	c.ignorePublish = statementOption.IgnorePublish()

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -407,6 +407,7 @@ type Compile struct {
 
 	adjustTableExtraFunc     func(*api.SchemaExtra) error
 	disableDropAutoIncrement bool
+	skipDataBranchReclaim    bool
 	keepAutoIncrement        uint64
 	ignorePublish            bool
 	ignoreCheckExperimental  bool

--- a/pkg/util/executor/options.go
+++ b/pkg/util/executor/options.go
@@ -456,6 +456,18 @@ func (opts StatementOption) WithDisableDropIncrStatement() StatementOption {
 	return opts
 }
 
+// WithSkipDataBranchReclaim leaves branch metadata intact for an internal
+// replacement DROP. The replacement path must publish its successor edge and
+// then invoke the shared reclaim routine itself in the same transaction.
+func (opts StatementOption) WithSkipDataBranchReclaim() StatementOption {
+	opts.skipDataBranchReclaim = true
+	return opts
+}
+
+func (opts StatementOption) SkipDataBranchReclaim() bool {
+	return opts.skipDataBranchReclaim
+}
+
 func (opts StatementOption) KeepAutoIncrement() uint64 {
 	return opts.keepAutoIncrement
 }

--- a/pkg/util/executor/types.go
+++ b/pkg/util/executor/types.go
@@ -102,6 +102,7 @@ type StatementOption struct {
 	paramNulls               []bool
 	alterCopyOpt             *plan.AlterCopyOpt
 	disableDropAutoIncrement bool
+	skipDataBranchReclaim    bool
 	keepAutoIncrement        uint64
 	keepLogicalId            uint64
 	disableLock              bool

--- a/pkg/vm/engine/test/publication_test.go
+++ b/pkg/vm/engine/test/publication_test.go
@@ -2356,6 +2356,12 @@ func TestCCPRGC(t *testing.T) {
 	require.NoError(t, err)
 	err = exec_sql(disttaeEngine, systemCtx, frontend.MoCatalogFeatureRegistryInitData)
 	require.NoError(t, err)
+	err = exec_sql(disttaeEngine, systemCtx, frontend.MoCatalogMoSnapshotsDDL)
+	require.NoError(t, err)
+	err = exec_sql(disttaeEngine, systemCtx, frontend.MoCatalogMoPitrDDL)
+	require.NoError(t, err)
+	err = exec_sql(disttaeEngine, systemCtx, frontend.MoCatalogBranchMetadataDDL)
+	require.NoError(t, err)
 
 	// Create mo_ccpr_log table using system account context
 	err = exec_sql(disttaeEngine, systemCtx, frontend.MoCatalogMoCcprLogDDL)

--- a/test/distributed/cases/git4data/branch/metadata/branch_rebuild_lifecycle.result
+++ b/test/distributed/cases/git4data/branch/metadata/branch_rebuild_lifecycle.result
@@ -1,0 +1,189 @@
+drop database if exists issue26064_rebuild;
+create database issue26064_rebuild;
+use issue26064_rebuild;
+create table rebuild_base(id int primary key, existing_value int default 5, removable_value int);
+insert into rebuild_base values (1, 10, 100), (2, 20, 200);
+data branch create table rebuild_branch from rebuild_base;
+set @rebuild_before_truncate = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'rebuild_branch'
+);
+truncate table rebuild_branch;
+set @rebuild_after_truncate = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'rebuild_branch'
+);
+delete from rebuild_branch;
+set @rebuild_after_delete = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'rebuild_branch'
+);
+select @rebuild_before_truncate <> @rebuild_after_truncate
+and @rebuild_after_truncate <> @rebuild_after_delete
+as truncate_and_delete_replace_physical_tables;
+➤ truncate_and_delete_replace_physical_tables[-7,1,0]  𝄀
+1
+select count(*) as retired_rebuild_generations
+from mo_catalog.mo_branch_metadata
+where table_id in (@rebuild_before_truncate, @rebuild_after_truncate)
+and table_deleted;
+➤ retired_rebuild_generations[-5,64,0]  𝄀
+2
+select p_table_id = @rebuild_after_truncate
+and level = 'alter:table'
+and not table_deleted as active_rebuild_branch
+from mo_catalog.mo_branch_metadata
+where table_id = @rebuild_after_delete;
+➤ active_rebuild_branch[-7,1,0]  𝄀
+1
+select count(*) as rebuild_protection_snapshots
+from mo_catalog.mo_snapshots
+where kind = 'branch'
+and sname in (
+concat('__mo_branch_', cast(@rebuild_before_truncate as char)),
+concat('__mo_branch_', cast(@rebuild_after_truncate as char)),
+concat('__mo_branch_', cast(@rebuild_after_delete as char))
+);
+➤ rebuild_protection_snapshots[-5,64,0]  𝄀
+3
+data branch diff rebuild_branch against rebuild_base;
+➤ diff rebuild_branch against rebuild_base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  existing_value[4,32,0]  ¦  removable_value[4,32,0]
+data branch delete table rebuild_branch;
+select count(*) as rebuild_snapshots_after_branch_delete
+from mo_catalog.mo_snapshots
+where kind = 'branch'
+and sname in (
+concat('__mo_branch_', cast(@rebuild_before_truncate as char)),
+concat('__mo_branch_', cast(@rebuild_after_truncate as char)),
+concat('__mo_branch_', cast(@rebuild_after_delete as char))
+);
+➤ rebuild_snapshots_after_branch_delete[-5,64,0]  𝄀
+0
+create table evolve_base(id int primary key, existing_value int default 5, removable_value int);
+insert into evolve_base values (1, 10, 100), (2, 20, 200);
+data branch create table evolve_branch from evolve_base;
+set @evolve_initial = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+alter table evolve_branch add column extra_value int default 0;
+set @evolve_after_add = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+data branch diff evolve_branch against evolve_base;
+➤ diff evolve_branch against evolve_base[12,0,0]  ¦  flag[12,0,0]  ¦  id[4,32,0]  ¦  existing_value[4,32,0]  ¦  removable_value[4,32,0]  ¦  extra_value[4,32,0]
+alter table evolve_branch alter column existing_value set default 7;
+set @evolve_after_set_default = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+alter table evolve_branch drop column removable_value;
+set @evolve_after_drop_column = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+alter table evolve_branch alter column existing_value drop default;
+set @evolve_after_drop_default = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+select @evolve_initial <> @evolve_after_add
+and @evolve_after_add <> @evolve_after_set_default
+and @evolve_after_set_default <> @evolve_after_drop_column
+and @evolve_after_drop_column <> @evolve_after_drop_default
+as each_alter_rebuild_replaces_physical_table;
+➤ each_alter_rebuild_replaces_physical_table[-7,1,0]  𝄀
+1
+select count(*) as retired_alter_generations
+from mo_catalog.mo_branch_metadata
+where table_id in (
+@evolve_initial, @evolve_after_add, @evolve_after_set_default, @evolve_after_drop_column
+) and table_deleted;
+➤ retired_alter_generations[-5,64,0]  𝄀
+4
+select p_table_id = @evolve_after_drop_column
+and level = 'alter:table'
+and not table_deleted as active_alter_branch
+from mo_catalog.mo_branch_metadata
+where table_id = @evolve_after_drop_default;
+➤ active_alter_branch[-7,1,0]  𝄀
+1
+select count(*) as alter_protection_snapshots
+from mo_catalog.mo_snapshots
+where kind = 'branch'
+and sname in (
+concat('__mo_branch_', cast(@evolve_initial as char)),
+concat('__mo_branch_', cast(@evolve_after_add as char)),
+concat('__mo_branch_', cast(@evolve_after_set_default as char)),
+concat('__mo_branch_', cast(@evolve_after_drop_column as char)),
+concat('__mo_branch_', cast(@evolve_after_drop_default as char))
+);
+➤ alter_protection_snapshots[-5,64,0]  𝄀
+5
+data branch delete table evolve_branch;
+select count(*) as alter_snapshots_after_branch_delete
+from mo_catalog.mo_snapshots
+where kind = 'branch'
+and sname in (
+concat('__mo_branch_', cast(@evolve_initial as char)),
+concat('__mo_branch_', cast(@evolve_after_add as char)),
+concat('__mo_branch_', cast(@evolve_after_set_default as char)),
+concat('__mo_branch_', cast(@evolve_after_drop_column as char)),
+concat('__mo_branch_', cast(@evolve_after_drop_default as char))
+);
+➤ alter_snapshots_after_branch_delete[-5,64,0]  𝄀
+0
+create table control_base(id int primary key, v int);
+insert into control_base values (1, 10), (2, 20);
+data branch create table control_branch from control_base;
+set @control_before_delete = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'control_branch'
+);
+delete from control_branch where true;
+set @control_after_delete = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'control_branch'
+);
+select @control_before_delete = @control_after_delete as predicate_delete_keeps_physical_table;
+➤ predicate_delete_keeps_physical_table[-7,1,0]  𝄀
+1
+select level = 'table' and not table_deleted as predicate_delete_keeps_active_branch
+from mo_catalog.mo_branch_metadata
+where table_id = @control_after_delete;
+➤ predicate_delete_keeps_active_branch[-7,1,0]  𝄀
+1
+select count(*) as predicate_delete_protection_snapshots
+from mo_catalog.mo_snapshots
+where kind = 'branch'
+and sname = concat('__mo_branch_', cast(@control_after_delete as char));
+➤ predicate_delete_protection_snapshots[-5,64,0]  𝄀
+1
+data branch delete table control_branch;
+create table txn_base(id int primary key, v int);
+insert into txn_base values (1, 10), (2, 20);
+data branch create table txn_branch from txn_base;
+set @txn_before_truncate = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'txn_branch'
+);
+begin;
+truncate table txn_branch;
+-- @regex("TRUNCATE on a data-branch lineage is not supported inside an explicit transaction", true)
+not supported: TRUNCATE on a data-branch lineage is not supported inside an explicit transaction
+rollback;
+set @txn_after_truncate = (
+select rel_id from mo_catalog.mo_tables
+where reldatabase = 'issue26064_rebuild' and relname = 'txn_branch'
+);
+select @txn_before_truncate = @txn_after_truncate as rejected_truncate_is_atomic;
+➤ rejected_truncate_is_atomic[-7,1,0]  𝄀
+1
+select level = 'table' and not table_deleted as rejected_truncate_keeps_active_branch
+from mo_catalog.mo_branch_metadata
+where table_id = @txn_after_truncate;
+➤ rejected_truncate_keeps_active_branch[-7,1,0]  𝄀
+1
+data branch delete table txn_branch;
+drop database issue26064_rebuild;

--- a/test/distributed/cases/git4data/branch/metadata/branch_rebuild_lifecycle.sql
+++ b/test/distributed/cases/git4data/branch/metadata/branch_rebuild_lifecycle.sql
@@ -1,0 +1,177 @@
+-- Regression for issue #26064: every copy-and-swap rebuild of an active
+-- data branch must retain a live lineage edge and both protection snapshots
+-- until DATA BRANCH DELETE reclaims the complete physical-generation chain.
+
+drop database if exists issue26064_rebuild;
+create database issue26064_rebuild;
+use issue26064_rebuild;
+
+-- TRUNCATE and DELETE without WHERE both use Scope.TruncateTable. Run them
+-- consecutively to prove that a replacement generation can be rebuilt again.
+create table rebuild_base(id int primary key, existing_value int default 5, removable_value int);
+insert into rebuild_base values (1, 10, 100), (2, 20, 200);
+data branch create table rebuild_branch from rebuild_base;
+
+set @rebuild_before_truncate = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'rebuild_branch'
+);
+truncate table rebuild_branch;
+set @rebuild_after_truncate = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'rebuild_branch'
+);
+delete from rebuild_branch;
+set @rebuild_after_delete = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'rebuild_branch'
+);
+
+select @rebuild_before_truncate <> @rebuild_after_truncate
+  and @rebuild_after_truncate <> @rebuild_after_delete
+  as truncate_and_delete_replace_physical_tables;
+select count(*) as retired_rebuild_generations
+  from mo_catalog.mo_branch_metadata
+ where table_id in (@rebuild_before_truncate, @rebuild_after_truncate)
+   and table_deleted;
+select p_table_id = @rebuild_after_truncate
+  and level = 'alter:table'
+  and not table_deleted as active_rebuild_branch
+  from mo_catalog.mo_branch_metadata
+ where table_id = @rebuild_after_delete;
+select count(*) as rebuild_protection_snapshots
+  from mo_catalog.mo_snapshots
+ where kind = 'branch'
+   and sname in (
+     concat('__mo_branch_', cast(@rebuild_before_truncate as char)),
+     concat('__mo_branch_', cast(@rebuild_after_truncate as char)),
+     concat('__mo_branch_', cast(@rebuild_after_delete as char))
+   );
+data branch diff rebuild_branch against rebuild_base;
+data branch delete table rebuild_branch;
+select count(*) as rebuild_snapshots_after_branch_delete
+  from mo_catalog.mo_snapshots
+ where kind = 'branch'
+   and sname in (
+     concat('__mo_branch_', cast(@rebuild_before_truncate as char)),
+     concat('__mo_branch_', cast(@rebuild_after_truncate as char)),
+     concat('__mo_branch_', cast(@rebuild_after_delete as char))
+   );
+
+-- The four ALTER copy forms in the report already use the same lineage
+-- protocol. Exercise them as one chain to keep their active ownership and
+-- reclaim behavior covered alongside the TRUNCATE caller.
+create table evolve_base(id int primary key, existing_value int default 5, removable_value int);
+insert into evolve_base values (1, 10, 100), (2, 20, 200);
+data branch create table evolve_branch from evolve_base;
+set @evolve_initial = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+alter table evolve_branch add column extra_value int default 0;
+set @evolve_after_add = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+data branch diff evolve_branch against evolve_base;
+alter table evolve_branch alter column existing_value set default 7;
+set @evolve_after_set_default = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+alter table evolve_branch drop column removable_value;
+set @evolve_after_drop_column = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+alter table evolve_branch alter column existing_value drop default;
+set @evolve_after_drop_default = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'evolve_branch'
+);
+
+select @evolve_initial <> @evolve_after_add
+  and @evolve_after_add <> @evolve_after_set_default
+  and @evolve_after_set_default <> @evolve_after_drop_column
+  and @evolve_after_drop_column <> @evolve_after_drop_default
+  as each_alter_rebuild_replaces_physical_table;
+select count(*) as retired_alter_generations
+  from mo_catalog.mo_branch_metadata
+ where table_id in (
+   @evolve_initial, @evolve_after_add, @evolve_after_set_default, @evolve_after_drop_column
+ ) and table_deleted;
+select p_table_id = @evolve_after_drop_column
+  and level = 'alter:table'
+  and not table_deleted as active_alter_branch
+  from mo_catalog.mo_branch_metadata
+ where table_id = @evolve_after_drop_default;
+select count(*) as alter_protection_snapshots
+  from mo_catalog.mo_snapshots
+ where kind = 'branch'
+   and sname in (
+     concat('__mo_branch_', cast(@evolve_initial as char)),
+     concat('__mo_branch_', cast(@evolve_after_add as char)),
+     concat('__mo_branch_', cast(@evolve_after_set_default as char)),
+     concat('__mo_branch_', cast(@evolve_after_drop_column as char)),
+     concat('__mo_branch_', cast(@evolve_after_drop_default as char))
+   );
+data branch delete table evolve_branch;
+select count(*) as alter_snapshots_after_branch_delete
+  from mo_catalog.mo_snapshots
+ where kind = 'branch'
+   and sname in (
+     concat('__mo_branch_', cast(@evolve_initial as char)),
+     concat('__mo_branch_', cast(@evolve_after_add as char)),
+     concat('__mo_branch_', cast(@evolve_after_set_default as char)),
+     concat('__mo_branch_', cast(@evolve_after_drop_column as char)),
+     concat('__mo_branch_', cast(@evolve_after_drop_default as char))
+   );
+
+-- A predicate keeps DELETE on the ordinary DML path: it must not create a
+-- replacement generation or a second branch protection snapshot.
+create table control_base(id int primary key, v int);
+insert into control_base values (1, 10), (2, 20);
+data branch create table control_branch from control_base;
+set @control_before_delete = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'control_branch'
+);
+delete from control_branch where true;
+set @control_after_delete = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'control_branch'
+);
+select @control_before_delete = @control_after_delete as predicate_delete_keeps_physical_table;
+select level = 'table' and not table_deleted as predicate_delete_keeps_active_branch
+  from mo_catalog.mo_branch_metadata
+ where table_id = @control_after_delete;
+select count(*) as predicate_delete_protection_snapshots
+  from mo_catalog.mo_snapshots
+ where kind = 'branch'
+   and sname = concat('__mo_branch_', cast(@control_after_delete as char));
+data branch delete table control_branch;
+
+-- Explicit transactions cannot safely publish a replacement generation; the
+-- statement is rejected before changing either table identity or metadata.
+create table txn_base(id int primary key, v int);
+insert into txn_base values (1, 10), (2, 20);
+data branch create table txn_branch from txn_base;
+set @txn_before_truncate = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'txn_branch'
+);
+begin;
+-- @regex("TRUNCATE on a data-branch lineage is not supported inside an explicit transaction", true)
+truncate table txn_branch;
+rollback;
+set @txn_after_truncate = (
+  select rel_id from mo_catalog.mo_tables
+  where reldatabase = 'issue26064_rebuild' and relname = 'txn_branch'
+);
+select @txn_before_truncate = @txn_after_truncate as rejected_truncate_is_atomic;
+select level = 'table' and not table_deleted as rejected_truncate_keeps_active_branch
+  from mo_catalog.mo_branch_metadata
+ where table_id = @txn_after_truncate;
+data branch delete table txn_branch;
+
+drop database issue26064_rebuild;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] FEATURE
- [ ] ENHANCEMENT
- [ ] DOC
- [ ] TEST
- [ ] CI
- [ ] CHORE

## Which issue(s) this PR fixes:

Related to #26064

## What this PR does / why we need it:

Root cause: `Scope.TruncateTable` drops the old physical relation before the replacement ID exists. The normal DROP hook therefore retires the active Data Branch row and reclaims its protection snapshot; the replacement has no lineage metadata. `DELETE FROM t` without a predicate uses this same path.

Changes:

- Use the established COPY ALTER lineage preparation, snapshot barrier, and owner-lifecycle lock for TRUNCATE.
- Delay only the internal replacement DROP branch reclaim. After CREATE provides the new physical ID, publish the successor `alter:table` edge and protection snapshot, then invoke the same shared reclaim-and-compaction lifecycle used by ordinary DROP.
- Reject a live Data Branch TRUNCATE in an explicit transaction with an operation-specific error, matching the existing COPY ALTER safety boundary.
- Add a BVT covering consecutive TRUNCATE and predicate-free DELETE rebuilds, all four reported COPY ALTER forms, metadata/protection-snapshot transitions, `DATA BRANCH DIFF`, `DATA BRANCH DELETE`, predicate DELETE, and explicit-transaction atomicity.
- Complete `TestCCPRGC`'s intentionally minimal system catalog with the snapshots, PITR, and branch-metadata tables now read by its predicate-free DELETE/TRUNCATE path. Missing production catalog tables still surface as errors; this fixture now matches bootstrap.

Issue-to-test proof:

- #26064: `test/distributed/cases/git4data/branch/metadata/branch_rebuild_lifecycle.sql` proves every reported rebuild form obtains a new physical ID while retaining a live lineage edge and all required protection snapshots. It also proves DIFF and DELETE succeed, and that DELETE reclaims the full generation chain.
- CI regression: `TestCCPRGC` exercises its five CCPR GC states through predicate-free DELETE after initializing every required system catalog dependency.

Tests run:

- `make build`
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=15m ./pkg/sql/compile`
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 ./pkg/util/executor`
- `./run.sh -p test/distributed/cases/git4data/branch/metadata -m genrs -i branch_rebuild_lifecycle` with mo-tester (generated result inspected)
- `./run.sh -p test/distributed/cases/git4data/branch/metadata -m run -i branch_rebuild_lifecycle` with mo-tester — 59/59 passed
- Rebase verification on `494e6a7723`: the `pkg/sql/compile` and `pkg/util/executor` CGo suites passed again; BVT `branch_rebuild_lifecycle` passed again, 59/59.
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=10m -run '^TestCCPRGC$' ./pkg/vm/engine/test` — passed.
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=15m ./pkg/vm/engine/test` — passed in 146.851s.
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=20m ./pkg/sql/compile` — passed.
- Rebase verification on `149219181f`: `pkg/sql/compile` CGo suite passed in 6.080s; `TestCCPRGC` passed in 4.079s.
- Rebase verification on `8a83e3e31e`: `make build` passed; `pkg/sql/compile` CGo suite passed in 9.548s; `TestCCPRGC` passed in 4.120s; `branch_rebuild_lifecycle` BVT passed 59/59 in normal comparison mode on a clean single-node instance. Report and error report were inspected.
- Rebase verification on `e6b25ee772`: controlled CGo `pkg/sql/compile` passed in 6.702s and `TestCCPRGC` passed in 4.473s. The upstream change is limited to window-frame binding and its tests, with no Data Branch/DDL overlap; the prior clean-instance lifecycle BVT evidence remains applicable.
- Rebase verification on `0fdc39e236`: controlled CGo `pkg/sql/compile` passed in 8.040s and `TestCCPRGC` passed in 4.153s. Upstream touched GROUP spill performance, BOOL aggregate compatibility, and unrelated BVT expectations, with no Data Branch/DDL lifecycle overlap; the prior clean-instance lifecycle BVT evidence remains applicable.
- Rebase verification on `243b77a742`: controlled CGo `pkg/sql/compile` passed in 7.235s and `TestCCPRGC` passed in 5.575s. Upstream changed cluster-table INSERT planning only, with no Data Branch/DDL lifecycle overlap; the prior clean-instance lifecycle BVT evidence remains applicable.
- Rebase verification on `4356759714`: controlled CGo `pkg/sql/compile` passed in 7.315s and `TestCCPRGC` passed in 5.173s. Upstream added bounded exact DISTINCT spill support and a portable SCA-cache workflow tweak, with no Data Branch/DDL lifecycle overlap; the prior clean-instance lifecycle BVT evidence remains applicable.
- Rebase verification on `425da14974`: `make build` passed; controlled CGo `pkg/sql/compile` passed in 8.041s; `TestCCPRGC` passed in 4.002s; and the clean-single-node `branch_rebuild_lifecycle` BVT passed 59/59 in normal comparison mode. The report and error report were inspected. Upstream changed float table-lock keyspace coverage, adjacent to the lock boundary, so this public regression was rerun.
- Rebase verification on `922e792ebf`: `make build` passed; controlled CGo `pkg/sql/compile` passed in 6.080s; `TestCCPRGC` passed in 5.327s; and the clean-single-node `branch_rebuild_lifecycle` BVT passed 59/59 in normal comparison mode. The report and error report were inspected. Upstream changes lock-owner recovery, a lifecycle concurrency dependency, so this public regression was rerun.
- Coverage follow-up after the 73.91% changed-code CI result: added `TestPrepareAlterDataBranchLineageRejectsLiveBranchTxnWithStatement`, which reaches active-lineage DAG admission and proves the exact `TRUNCATE` explicit-transaction rejection before compaction or replacement. The focused controlled-CGo suite passed in 2.432s and the owning `pkg/sql/compile` package passed in 6.208s.
- Rebase verification on `26d008dbd0`: the two upstream commits modify aggregate recovery and grant-test cleanup only; they do not touch Data Branch or lifecycle dependencies. The public lifecycle BVT evidence from the prior exact production revision remains valid.
- Rebase verification on `fa829e5c50`: `make build` passed; the focused controlled-CGo lifecycle suite passed in 1.320s; the owning `pkg/sql/compile` package passed in 6.886s; and the clean-single-node `branch_rebuild_lifecycle` BVT passed 59/59 with an empty error report. Upstream exposes subscription tables and hardens HAKeeper replica removal; the former is adjacent to clone behavior, so the public Data Branch regression was rerun.
- Rebase verification on `2bf4dddb3c`: `make build` passed; focused controlled-CGo lineage and Data Branch projection suites passed in 1.306s and 1.416s; owning `pkg/sql/compile` and `pkg/frontend` packages passed in 7.593s and 18.644s; the race-enabled `pkg/sql/compile` package passed in 9.129s. On a clean ready single-node service, upstream `diff_composite_pk_columns` passed 28/28 twice and `branch_rebuild_lifecycle` passed 59/59 twice; every error report was empty and the service log emitted no fatal or panic record. The upstream primary-key projection change is a direct DIFF consumer, so both public paths were rerun.

- Rebase verification on `522285b47a`: on the preceding `3facd79c8a` rebase, `make build` passed; the combined upstream hash-partition and lineage gate suite passed in 2.490s; full and race-enabled `pkg/sql/compile` passed in 6.350s and 8.477s. On the exact final head, the lineage gate passed in 1.325s and the upstream owning `pkg/sql/colexec/aggexec` and `pkg/sql/colexec/window` packages passed in 23.401s and 1.233s. The first upstream commit changed compiler hash-partition protocol gating; the second is confined to bounded-RANGE aggregate/window execution. Neither alters Data Branch DDL lifecycle state. A concurrent issue #27141 run owned the shared mo-tester `run.yml` and reports, so its cleanup failed before this BVT executed; no new BVT pass/fail status is claimed. The direct clean-instance lifecycle BVT evidence remains documented above.

- Rebase verification on `d300619bb4`: the sampled-statistics and Iceberg manifest-bound commits do not change the Data Branch TRUNCATE protocol or its compiler/executor/test/BVT files. On exact head `e9498ef2a3`, controlled CGo lineage admission tests passed in 1.413s and `TestCCPRGC` passed in 4.111s, covering the explicit-transaction gate and predicate-free DELETE cleanup consumer. Prior full compiler/race and clean-instance lifecycle BVT evidence remains semantically valid.

Residual risks:

- The lineage edge, replacement relation, and reclaim transition remain in one transaction. Any failure aborts the replacement rather than exposing a detached active table.

## Rebase verification

Rebased onto `e74cdbe5df`, including `313991b503` (PR #28172), which corrects the sampled `ANALYZE` expectation behind the previously unrelated `window_hash_partition` BVT failure. The Data Branch lineage diff is unchanged by the rebase. Focused CGo validation passed for the compile lineage gates and `pkg/vm/engine/test` CCPR GC coverage.