### PR TITLE
perf(plan): use equi-joins for REPLACE conflicts

### DIFF
--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -75,6 +75,379 @@ func (builder *QueryBuilder) bindReplace(stmt *tree.Replace, bindCtx *BindContex
 	return builder.appendDedupAndMultiUpdateNodesForBindReplace(bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx, irregularIndexes)
 }
 
+func (builder *QueryBuilder) appendReplaceConflictLookup(
+	bindCtx *BindContext,
+	lastNodeID int32,
+	selectTag int32,
+	fullProjTag int32,
+	selectNode *plan.Node,
+	objRef *plan.ObjectRef,
+	tableDef *plan.TableDef,
+	idxObjRefs []*plan.ObjectRef,
+	idxTableDefs []*plan.TableDef,
+	colName2Idx map[string]int32,
+	skipUniqueIdx []bool,
+	oldColName2Idx map[string][2]int32,
+	needsOldIndexMaintenance bool,
+) (int32, []*plan.Expr, error) {
+	branchCount := 0
+	if tableDef.Pkey.PkeyColName != catalog.FakePrimaryKeyColName {
+		branchCount++
+	}
+	for i, idxDef := range tableDef.Indexes {
+		if idxDef.Unique && !skipUniqueIdx[i] {
+			branchCount++
+		}
+	}
+
+	replacementColumnCount := len(selectNode.ProjectList)
+	var sourceOrdinalType plan.Type
+	sourceOrdinalPos := int32(-1)
+	sourceStep := int32(-1)
+	if branchCount > 1 {
+		// Every lookup branch is a LEFT JOIN so an insert-only source row survives,
+		// but the same source/old-row pair may be found by several constraints.
+		// Carry a per-input ordinal through UNION DISTINCT: it removes only those
+		// duplicate candidates, without collapsing equal source rows that the
+		// downstream keep-last logic must still see.
+		rowNumberFunc, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "row_number", nil)
+		if err != nil {
+			return 0, nil, err
+		}
+		sourceOrdinalType = rowNumberFunc.Typ
+		ordinalTag := builder.genNewBindTag()
+		windowID := builder.appendNode(&plan.Node{
+			NodeType: plan.Node_WINDOW,
+			Children: []int32{lastNodeID},
+			WinSpecList: []*plan.Expr{{
+				Typ: rowNumberFunc.Typ,
+				Expr: &plan.Expr_W{W: &plan.WindowSpec{
+					WindowFunc: rowNumberFunc,
+					Name:       "row_number",
+					Frame: &plan.FrameClause{
+						Type:  plan.FrameClause_ROWS,
+						Start: &plan.FrameBound{Type: plan.FrameBound_PRECEDING, UnBounded: true},
+						End:   &plan.FrameBound{Type: plan.FrameBound_FOLLOWING, UnBounded: true},
+					},
+				}},
+			}},
+			WindowIdx:   0,
+			BindingTags: []int32{ordinalTag},
+		}, bindCtx)
+
+		sourceTag := builder.genNewBindTag()
+		sourceProjection := make([]*plan.Expr, 0, replacementColumnCount+1)
+		for i, expr := range selectNode.ProjectList {
+			sourceProjection = append(sourceProjection, &plan.Expr{
+				Typ: expr.Typ,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: selectTag,
+					ColPos: int32(i),
+				}},
+			})
+		}
+		sourceOrdinalPos = int32(len(sourceProjection))
+		sourceProjection = append(sourceProjection, &plan.Expr{
+			Typ: rowNumberFunc.Typ,
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{
+				RelPos: ordinalTag,
+				ColPos: 0,
+			}},
+		})
+		lastNodeID = builder.appendNode(&plan.Node{
+			NodeType:    plan.Node_PROJECT,
+			Children:    []int32{windowID},
+			ProjectList: sourceProjection,
+			BindingTags: []int32{sourceTag},
+		}, bindCtx)
+		selectTag = sourceTag
+
+		sourceSinkID := appendSinkNode(builder, bindCtx, lastNodeID)
+		sourceStep = builder.appendStep(sourceSinkID)
+	}
+	newSource := func() (int32, int32) {
+		if sourceStep < 0 {
+			return lastNodeID, selectTag
+		}
+		tag := builder.genNewBindTag()
+		nodeID := appendSinkScanNode(builder, bindCtx, sourceStep)
+		builder.qry.Nodes[nodeID].BindingTags = []int32{tag}
+		return nodeID, tag
+	}
+	newMainScan := func() (int32, int32) {
+		tag := builder.genNewBindTag()
+		builder.addNameByColRef(tag, tableDef)
+		nodeID := builder.appendNode(&plan.Node{
+			NodeType:     plan.Node_TABLE_SCAN,
+			TableDef:     CloneTableDefForPlan(tableDef, true),
+			ObjRef:       objRef,
+			BindingTags:  []int32{tag},
+			ScanSnapshot: bindCtx.snapshot,
+		}, bindCtx)
+		return nodeID, tag
+	}
+
+	ordinalOutputPos := int32(-1)
+	buildProjection := func(sourceTag, oldScanTag int32) ([]*plan.Expr, error) {
+		projection := make([]*plan.Expr, 0, replacementColumnCount+len(tableDef.Cols)+len(tableDef.Indexes)+1)
+		for i, expr := range selectNode.ProjectList[:replacementColumnCount] {
+			projection = append(projection, &plan.Expr{
+				Typ: expr.Typ,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: sourceTag,
+					ColPos: int32(i),
+				}},
+			})
+		}
+		for i, col := range tableDef.Cols {
+			oldColName2Idx[tableDef.Name+"."+col.Name] = [2]int32{fullProjTag, int32(len(projection))}
+			projection = append(projection, &plan.Expr{
+				Typ: col.Typ,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: oldScanTag,
+					ColPos: int32(i),
+				}},
+			})
+		}
+
+		for i, idxDef := range tableDef.Indexes {
+			if skipUniqueIdx[i] && !needsOldIndexMaintenance {
+				continue
+			}
+			prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+			if err != nil {
+				return nil, err
+			}
+			oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTablePrimaryColName] =
+				oldColName2Idx[tableDef.Name+"."+tableDef.Pkey.PkeyColName]
+
+			if !indexTableStoresSerializedKey(idxDef) {
+				partName := indexPrimaryPartName(idxDef)
+				if prefixLengths[partName] == 0 {
+					oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTableIndexColName] =
+						oldColName2Idx[tableDef.Name+"."+partName]
+					continue
+				}
+				colIdx := tableDef.Name2ColIndex[partName]
+				partExpr := &plan.Expr{
+					Typ: tableDef.Cols[colIdx].Typ,
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: oldScanTag,
+						ColPos: colIdx,
+					}},
+				}
+				idxExpr, err := builder.makeIndexPartExprFromInputExpr(partExpr, partName, prefixLengths)
+				if err != nil {
+					return nil, err
+				}
+				oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTableIndexColName] =
+					[2]int32{fullProjTag, int32(len(projection))}
+				projection = append(projection, idxExpr)
+				continue
+			}
+
+			args := make([]*plan.Expr, len(idxDef.Parts))
+			for j, part := range idxDef.Parts {
+				partName := catalog.ResolveAlias(part)
+				colIdx := tableDef.Name2ColIndex[partName]
+				args[j] = &plan.Expr{
+					Typ: tableDef.Cols[colIdx].Typ,
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: oldScanTag,
+						ColPos: colIdx,
+					}},
+				}
+				if prefixLengths[partName] > 0 {
+					args[j], err = builder.makeIndexPartExprFromInputExpr(args[j], partName, prefixLengths)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+			idxExpr := args[0]
+			if len(args) > 1 {
+				funcName := "serial"
+				if !idxDef.Unique {
+					funcName = "serial_full"
+				}
+				idxExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), funcName, args)
+			}
+			oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTableIndexColName] =
+				[2]int32{fullProjTag, int32(len(projection))}
+			projection = append(projection, idxExpr)
+		}
+		if sourceOrdinalPos >= 0 {
+			ordinalOutputPos = int32(len(projection))
+			projection = append(projection, &plan.Expr{
+				Typ: sourceOrdinalType,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: sourceTag,
+					ColPos: sourceOrdinalPos,
+				}},
+			})
+		}
+
+		return projection, nil
+	}
+
+	branchIDs := make([]int32, 0, branchCount)
+	branchTags := make([]int32, 0, branchCount)
+	appendBranch := func(sourceTag, oldScanNodeID, oldScanTag int32) error {
+		branchTag := builder.genNewBindTag()
+		projection, err := buildProjection(sourceTag, oldScanTag)
+		if err != nil {
+			return err
+		}
+		branchIDs = append(branchIDs, builder.appendNode(&plan.Node{
+			NodeType:    plan.Node_PROJECT,
+			Children:    []int32{oldScanNodeID},
+			ProjectList: projection,
+			BindingTags: []int32{branchTag},
+		}, bindCtx))
+		branchTags = append(branchTags, branchTag)
+		return nil
+	}
+
+	if tableDef.Pkey.PkeyColName != catalog.FakePrimaryKeyColName {
+		sourceNodeID, sourceTag := newSource()
+		oldScanNodeID, oldScanTag := newMainScan()
+		pkPos := tableDef.Name2ColIndex[tableDef.Pkey.PkeyColName]
+		newPkPos := colName2Idx[tableDef.Name+"."+tableDef.Pkey.PkeyColName]
+		condition, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{
+			{Typ: tableDef.Cols[pkPos].Typ, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: sourceTag, ColPos: newPkPos}}},
+			{Typ: tableDef.Cols[pkPos].Typ, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: oldScanTag, ColPos: pkPos}}},
+		})
+		joinID := builder.appendNode(&plan.Node{
+			NodeType: plan.Node_JOIN,
+			Children: []int32{sourceNodeID, oldScanNodeID},
+			JoinType: plan.Node_LEFT,
+			OnList:   []*plan.Expr{condition},
+		}, bindCtx)
+		if err := appendBranch(sourceTag, joinID, oldScanTag); err != nil {
+			return 0, nil, err
+		}
+	}
+
+	for i, idxDef := range tableDef.Indexes {
+		if !idxDef.Unique || skipUniqueIdx[i] {
+			continue
+		}
+		sourceNodeID, sourceTag := newSource()
+		idxTag := builder.genNewBindTag()
+		builder.addNameByColRef(idxTag, idxTableDefs[i])
+		idxScanID := builder.appendNode(&plan.Node{
+			NodeType:     plan.Node_TABLE_SCAN,
+			TableDef:     idxTableDefs[i],
+			ObjRef:       idxObjRefs[i],
+			BindingTags:  []int32{idxTag},
+			ScanSnapshot: bindCtx.snapshot,
+		}, bindCtx)
+		newIndexPos, ok := colName2Idx[idxDef.IndexTableName+"."+catalog.IndexTableIndexColName]
+		if !ok {
+			return 0, nil, moerr.NewInternalErrorf(builder.GetContext(),
+				"bind replace err, can not find new unique index key for %s", idxDef.IndexTableName)
+		}
+		idxKeyPos := idxTableDefs[i].Name2ColIndex[catalog.IndexTableIndexColName]
+		idxKeyTyp := idxTableDefs[i].Cols[idxKeyPos].Typ
+		indexCondition, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{
+			{Typ: idxKeyTyp, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: sourceTag, ColPos: newIndexPos}}},
+			{Typ: idxKeyTyp, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: idxTag, ColPos: idxKeyPos}}},
+		})
+		indexJoinID := builder.appendNode(&plan.Node{
+			NodeType: plan.Node_JOIN,
+			Children: []int32{sourceNodeID, idxScanID},
+			JoinType: plan.Node_LEFT,
+			OnList:   []*plan.Expr{indexCondition},
+		}, bindCtx)
+
+		oldScanNodeID, oldScanTag := newMainScan()
+		idxPrimaryPos := idxTableDefs[i].Name2ColIndex[catalog.IndexTablePrimaryColName]
+		oldPkPos := tableDef.Name2ColIndex[tableDef.Pkey.PkeyColName]
+		oldPkTyp := tableDef.Cols[oldPkPos].Typ
+		mainCondition, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{
+			{Typ: oldPkTyp, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: idxTag, ColPos: idxPrimaryPos}}},
+			{Typ: oldPkTyp, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: oldScanTag, ColPos: oldPkPos}}},
+		})
+		mainJoinID := builder.appendNode(&plan.Node{
+			NodeType: plan.Node_JOIN,
+			Children: []int32{indexJoinID, oldScanNodeID},
+			JoinType: plan.Node_LEFT,
+			OnList:   []*plan.Expr{mainCondition},
+		}, bindCtx)
+		if err := appendBranch(sourceTag, mainJoinID, oldScanTag); err != nil {
+			return 0, nil, err
+		}
+	}
+
+	if len(branchIDs) == 0 {
+		return 0, nil, moerr.NewInternalError(builder.GetContext(), "bind replace err, no conflict lookup branch")
+	}
+	if len(branchIDs) == 1 {
+		builder.qry.Nodes[branchIDs[0]].BindingTags[0] = fullProjTag
+		return branchIDs[0], builder.qry.Nodes[branchIDs[0]].ProjectList, nil
+	}
+
+	unionID := branchIDs[0]
+	unionInputTag := branchTags[0]
+	for branchIdx := 1; branchIdx < len(branchIDs); branchIdx++ {
+		leftNode := builder.qry.Nodes[unionID]
+		rightNode := builder.qry.Nodes[branchIDs[branchIdx]]
+		unionProjection := make([]*plan.Expr, len(leftNode.ProjectList))
+		for i, expr := range leftNode.ProjectList {
+			unionProjection[i] = &plan.Expr{
+				Typ: setOperationOutputType(plan.Node_UNION, expr.Typ, rightNode.ProjectList[i].Typ),
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: unionInputTag,
+					ColPos: int32(i),
+				}},
+			}
+		}
+		unionTag := builder.genNewBindTag()
+		unionID = builder.appendNode(&plan.Node{
+			NodeType:    plan.Node_UNION,
+			Children:    []int32{unionID, branchIDs[branchIdx]},
+			ProjectList: unionProjection,
+			BindingTags: []int32{unionTag},
+		}, bindCtx)
+		unionInputTag = unionTag
+	}
+
+	// UNION DISTINCT is unordered. Restore source order before the DEDUP joins so
+	// duplicate VALUES rows retain REPLACE's existing keep-last semantics.
+	orderedUnionID := builder.appendNode(&plan.Node{
+		NodeType: plan.Node_SORT,
+		Children: []int32{unionID},
+		OrderBy: []*plan.OrderBySpec{{
+			Expr: &plan.Expr{
+				Typ: sourceOrdinalType,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: unionInputTag,
+					ColPos: ordinalOutputPos,
+				}},
+			},
+			Flag: plan.OrderBySpec_ASC | plan.OrderBySpec_INTERNAL,
+		}},
+		SpillMem: builder.sortSpillMem,
+	}, bindCtx)
+	finalProjection := make([]*plan.Expr, ordinalOutputPos)
+	for i := range finalProjection {
+		finalProjection[i] = &plan.Expr{
+			Typ: builder.qry.Nodes[unionID].ProjectList[i].Typ,
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{
+				RelPos: unionInputTag,
+				ColPos: int32(i),
+			}},
+		}
+	}
+	finalID := builder.appendNode(&plan.Node{
+		NodeType:    plan.Node_PROJECT,
+		Children:    []int32{orderedUnionID},
+		ProjectList: finalProjection,
+		BindingTags: []int32{fullProjTag},
+	}, bindCtx)
+	return finalID, finalProjection, nil
+}
+
 func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 	bindCtx *BindContext,
 	dmlCtx *DMLContext,
@@ -160,6 +533,17 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 		}
 	}
 	needsOldIndexMaintenance := !isFakePK || hasUniqueIdx
+	for i, idxDef := range tableDef.Indexes {
+		if skipUniqueIdx[i] && !needsOldIndexMaintenance {
+			continue
+		}
+		idxObjRefs[i], idxTableDefs[i], err = builder.compCtx.ResolveIndexTableByRef(
+			objRef, idxDef.IndexTableName, bindCtx.snapshot)
+		if err != nil {
+			return 0, err
+		}
+		ensureName2ColIndexForReplace(idxTableDefs[i])
+	}
 
 	// get old columns from existing main table
 	//
@@ -185,9 +569,8 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 		}
 	}
 	// Merged-scan is disabled when the table has unique secondary indexes because
-	// a unique-key conflict (without a PK conflict) requires the LEFT JOIN to
-	// retrieve old-row columns for deletion. The merged-scan path only captures
-	// old columns on PK conflict, leaving them NULL when only a UK conflicts.
+	// one incoming row can conflict with different old rows through different keys.
+	// Those tables use one equality-only lookup branch per constraint below.
 	useMergedMainScan := !isFakePK && !hasMultiPartIdx && !hasUniqueIdx
 	if isFakePK && !hasUniqueIdx {
 		// No PK/UK: use NULL expressions for old columns so MULTI_UPDATE only inserts
@@ -223,16 +606,10 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			})
 		}
 
-		var err error
 		for i, idxDef := range tableDef.Indexes {
 			if skipUniqueIdx[i] && !needsOldIndexMaintenance {
 				continue
 			}
-			idxObjRefs[i], idxTableDefs[i], err = builder.compCtx.ResolveIndexTableByRef(objRef, idxDef.IndexTableName, bindCtx.snapshot)
-			if err != nil {
-				return 0, err
-			}
-			ensureName2ColIndexForReplace(idxTableDefs[i])
 
 			// Spatial indexes look up the old index-table row via the primary
 			// column (indexLookupColumnName returns IndexTablePrimaryColName).
@@ -256,274 +633,25 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			BindingTags: []int32{fullProjTag},
 		}, bindCtx)
 	} else {
-		oldScanTag := builder.genNewBindTag()
-
-		builder.addNameByColRef(oldScanTag, tableDef)
-
-		oldScanNodeID := builder.appendNode(&plan.Node{
-			NodeType:     plan.Node_TABLE_SCAN,
-			TableDef:     CloneTableDefForPlan(tableDef, true),
-			ObjRef:       objRef,
-			BindingTags:  []int32{oldScanTag},
-			ScanSnapshot: bindCtx.snapshot,
-		}, bindCtx)
-
-		for i, col := range tableDef.Cols {
-			oldColName2Idx[tableDef.Name+"."+col.Name] = [2]int32{fullProjTag, int32(len(fullProjList))}
-			fullProjList = append(fullProjList, &plan.Expr{
-				Typ: col.Typ,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						RelPos: oldScanTag,
-						ColPos: int32(i),
-					},
-				},
-			})
+		lastNodeID, fullProjList, err = builder.appendReplaceConflictLookup(
+			bindCtx,
+			lastNodeID,
+			selectTag,
+			fullProjTag,
+			selectNode,
+			objRef,
+			tableDef,
+			idxObjRefs,
+			idxTableDefs,
+			colName2Idx,
+			skipUniqueIdx,
+			oldColName2Idx,
+			needsOldIndexMaintenance,
+		)
+		if err != nil {
+			return 0, err
 		}
-
-		for i, idxDef := range tableDef.Indexes {
-			if skipUniqueIdx[i] && !needsOldIndexMaintenance {
-				continue
-			}
-			prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
-			if err != nil {
-				return 0, err
-			}
-			idxObjRefs[i], idxTableDefs[i], err = builder.compCtx.ResolveIndexTableByRef(objRef, idxDef.IndexTableName, bindCtx.snapshot)
-			if err != nil {
-				return 0, err
-			}
-			ensureName2ColIndexForReplace(idxTableDefs[i])
-			oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTablePrimaryColName] = oldColName2Idx[tableDef.Name+"."+tableDef.Pkey.PkeyColName]
-
-			if !indexTableStoresSerializedKey(idxDef) {
-				partName := indexPrimaryPartName(idxDef)
-				if prefixLengths[partName] > 0 {
-					colIdx := tableDef.Name2ColIndex[partName]
-					partExpr := &plan.Expr{
-						Typ: tableDef.Cols[colIdx].Typ,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{RelPos: oldScanTag, ColPos: colIdx},
-						},
-					}
-					idxExpr, err := builder.makeIndexPartExprFromInputExpr(partExpr, partName, prefixLengths)
-					if err != nil {
-						return 0, err
-					}
-					oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTableIndexColName] = [2]int32{
-						fullProjTag, int32(len(fullProjList)),
-					}
-					fullProjList = append(fullProjList, idxExpr)
-				} else {
-					oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTableIndexColName] = oldColName2Idx[tableDef.Name+"."+partName]
-				}
-			} else {
-				args := make([]*plan.Expr, len(idxDef.Parts))
-				for j, part := range idxDef.Parts {
-					partName := catalog.ResolveAlias(part)
-					colIdx := tableDef.Name2ColIndex[partName]
-					args[j] = &plan.Expr{
-						Typ: tableDef.Cols[colIdx].Typ,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: oldScanTag,
-								ColPos: colIdx,
-							},
-						},
-					}
-					if prefixLengths[partName] > 0 {
-						args[j], err = builder.makeIndexPartExprFromInputExpr(args[j], partName, prefixLengths)
-						if err != nil {
-							return 0, err
-						}
-					}
-				}
-
-				idxExpr := args[0]
-				if len(idxDef.Parts) > 1 {
-					funcName := "serial"
-					if !idxDef.Unique {
-						funcName = "serial_full"
-					}
-					idxExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), funcName, args)
-				}
-
-				oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTableIndexColName] = [2]int32{fullProjTag, int32(len(fullProjList))}
-				fullProjList = append(fullProjList, idxExpr)
-			}
-		}
-
-		// Build the LEFT JOIN ON list: for real-PK tables the PK equality OR'd
-		// with one (AND-of-parts) condition per unique key; for fake-PK tables
-		// (no real PK) the OR of one condition per unique key. An old row
-		// conflicting on the PK or ANY unique key is fetched in a single join.
-		// A single new row may match several old rows (fan-out); the conflicting
-		// old rows are all deleted and the new row inserted once, handled by the
-		// keep-last / delete-marker logic in hashbuild downstream.
-		var joinConds []*plan.Expr
-		if isFakePK {
-			// Fake-PK tables previously joined on only the first unique key,
-			// missing conflicts on the others; OR one condition per unique key.
-			for i, idxDef := range tableDef.Indexes {
-				if !idxDef.Unique || skipUniqueIdx[i] {
-					continue
-				}
-				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
-				if err != nil {
-					return 0, err
-				}
-				var ukPartConds []*plan.Expr
-				for _, part := range idxDef.Parts {
-					colName := catalog.ResolveAlias(part)
-					colIdx := tableDef.Name2ColIndex[colName]
-					colTyp := tableDef.Cols[colIdx].Typ
-					lExpr := &plan.Expr{
-						Typ: colTyp,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: selectTag,
-								ColPos: colName2Idx[tableDef.Name+"."+colName],
-							},
-						},
-					}
-					rExpr := &plan.Expr{
-						Typ: colTyp,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: oldScanTag,
-								ColPos: colIdx,
-							},
-						},
-					}
-					if prefixLengths[colName] > 0 {
-						lExpr, err = builder.makeIndexPartExprFromInputExpr(lExpr, colName, prefixLengths)
-						if err != nil {
-							return 0, err
-						}
-						rExpr, err = builder.makeIndexPartExprFromInputExpr(rExpr, colName, prefixLengths)
-						if err != nil {
-							return 0, err
-						}
-					}
-					partCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{lExpr, rExpr})
-					ukPartConds = append(ukPartConds, partCond)
-				}
-				if len(ukPartConds) == 0 {
-					continue
-				}
-				ukCond := ukPartConds[0]
-				for _, c := range ukPartConds[1:] {
-					ukCond, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*plan.Expr{ukCond, c})
-				}
-				joinConds = append(joinConds, ukCond)
-			}
-		} else {
-			pkPos := tableDef.Name2ColIndex[pkName]
-			pkTyp := tableDef.Cols[pkPos].Typ
-			leftExpr := &plan.Expr{
-				Typ: pkTyp,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						RelPos: selectTag,
-						ColPos: colName2Idx[tableDef.Name+"."+pkName],
-					},
-				},
-			}
-			rightExpr := &plan.Expr{
-				Typ: pkTyp,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						RelPos: oldScanTag,
-						ColPos: pkPos,
-					},
-				},
-			}
-			pkCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{leftExpr, rightExpr})
-			joinConds = append(joinConds, pkCond)
-
-			for i, idxDef := range tableDef.Indexes {
-				if !idxDef.Unique || skipUniqueIdx[i] {
-					continue
-				}
-				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
-				if err != nil {
-					return 0, err
-				}
-				var ukPartConds []*plan.Expr
-				for _, part := range idxDef.Parts {
-					colName := catalog.ResolveAlias(part)
-					colIdx := tableDef.Name2ColIndex[colName]
-					colTyp := tableDef.Cols[colIdx].Typ
-					lExpr := &plan.Expr{
-						Typ: colTyp,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: selectTag,
-								ColPos: colName2Idx[tableDef.Name+"."+colName],
-							},
-						},
-					}
-					rExpr := &plan.Expr{
-						Typ: colTyp,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: oldScanTag,
-								ColPos: colIdx,
-							},
-						},
-					}
-					if prefixLengths[colName] > 0 {
-						lExpr, err = builder.makeIndexPartExprFromInputExpr(lExpr, colName, prefixLengths)
-						if err != nil {
-							return 0, err
-						}
-						rExpr, err = builder.makeIndexPartExprFromInputExpr(rExpr, colName, prefixLengths)
-						if err != nil {
-							return 0, err
-						}
-					}
-					partCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{lExpr, rExpr})
-					ukPartConds = append(ukPartConds, partCond)
-				}
-				var ukCond *plan.Expr
-				if len(ukPartConds) == 1 {
-					ukCond = ukPartConds[0]
-				} else {
-					ukCond = ukPartConds[0]
-					for _, c := range ukPartConds[1:] {
-						ukCond, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*plan.Expr{ukCond, c})
-					}
-				}
-				joinConds = append(joinConds, ukCond)
-			}
-		}
-
-		var joinOnList []*plan.Expr
-		if len(joinConds) == 1 {
-			joinOnList = joinConds
-		} else if len(joinConds) > 1 {
-			combined := joinConds[0]
-			for _, c := range joinConds[1:] {
-				combined, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "or", []*plan.Expr{combined, c})
-			}
-			joinOnList = []*plan.Expr{combined}
-		}
-
-		lastNodeID = builder.appendNode(&plan.Node{
-			NodeType: plan.Node_JOIN,
-			Children: []int32{lastNodeID, oldScanNodeID},
-			JoinType: plan.Node_LEFT,
-			OnList:   joinOnList,
-		}, bindCtx)
-
-		lastNodeID = builder.appendNode(&plan.Node{
-			NodeType:    plan.Node_PROJECT,
-			ProjectList: fullProjList,
-			Children:    []int32{lastNodeID},
-			BindingTags: []int32{fullProjTag},
-		}, bindCtx)
 	}
-
 	oldMainRowIDPos := oldColName2Idx[tableDef.Name+"."+catalog.Row_ID]
 	oldMainPKPos := oldColName2Idx[tableDef.Name+"."+tableDef.Pkey.PkeyColName]
 	buildParentFKActions := len(tableDef.RefChildTbls) > 0

--- a/pkg/sql/plan/bind_replace_conflict_test.go
+++ b/pkg/sql/plan/bind_replace_conflict_test.go
@@ -1,0 +1,112 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceConflictLookupUsesEquiJoins(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantUnion bool
+	}{
+		{
+			name:      "primary and unique keys",
+			sql:       "REPLACE INTO dept VALUES (1, 'Sales', 'NY')",
+			wantUnion: true,
+		},
+		{
+			name:      "primary and composite unique keys",
+			sql:       "REPLACE INTO dept_composite_uk VALUES (1, 'Sales', 'NY')",
+			wantUnion: true,
+		},
+		{
+			name:      "primary key only",
+			sql:       "REPLACE INTO self_ref VALUES (1, NULL, 'root')",
+			wantUnion: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logicPlan, err := runOneStmt(NewMockOptimizer(true), t, test.sql)
+			require.NoError(t, err)
+
+			requireReplaceConflictLookupPlan(t, logicPlan.GetQuery(), test.wantUnion)
+		})
+	}
+}
+
+func requireReplaceConflictLookupPlan(t *testing.T, query *planpb.Query, wantBranchMerge bool) {
+	t.Helper()
+	require.NotNil(t, query)
+	hasConflictUnion := false
+	hasSourceOrdinal := false
+	hasOrdinalSort := false
+	joinCount := 0
+	for _, node := range query.Nodes {
+		if node.NodeType == planpb.Node_UNION {
+			hasConflictUnion = true
+		}
+		require.NotEqual(t, planpb.Node_UNION_ALL, node.NodeType,
+			"conflict candidates must be deduplicated across lookup branches")
+		if node.NodeType == planpb.Node_WINDOW {
+			for _, spec := range node.WinSpecList {
+				if spec.GetW().GetName() == "row_number" {
+					hasSourceOrdinal = true
+				}
+			}
+		}
+		if node.NodeType == planpb.Node_SORT {
+			hasOrdinalSort = true
+		}
+		if node.NodeType != planpb.Node_JOIN {
+			continue
+		}
+		joinCount++
+		for _, condition := range node.OnList {
+			require.False(t, expressionContainsFunction(condition, "or"),
+				"REPLACE conflict lookup must not contain an OR join predicate")
+		}
+	}
+	require.Equal(t, wantBranchMerge, hasConflictUnion)
+	require.Equal(t, wantBranchMerge, hasSourceOrdinal)
+	require.Equal(t, wantBranchMerge, hasOrdinalSort)
+	require.Positive(t, joinCount)
+}
+
+func expressionContainsFunction(expr *planpb.Expr, name string) bool {
+	if expr == nil {
+		return false
+	}
+	fn := expr.GetF()
+	if fn == nil {
+		return false
+	}
+	if fn.Func != nil && fn.Func.ObjName == name {
+		return true
+	}
+	for _, arg := range fn.Args {
+		if expressionContainsFunction(arg, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sql/plan/index_table_dml_test.go
+++ b/pkg/sql/plan/index_table_dml_test.go
@@ -442,10 +442,8 @@ func TestMultiTableUpdate(t *testing.T) {
 }
 
 // TestBindReplaceWithUniqueSecondaryIndex verifies that REPLACE INTO on a table
-// with both an AUTO_INCREMENT PK and a unique secondary index disables the
-// merged-scan optimization and falls back to the legacy LEFT JOIN path with
-// OR'ed unique-key conditions, so unique-key conflicts can be resolved by
-// deleting the old row instead of raising a duplicate-entry error.
+// with both an AUTO_INCREMENT PK and a unique secondary index uses independent
+// equality lookup branches instead of an OR join over the base table.
 func TestBindReplaceWithUniqueSecondaryIndex(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	sql := "replace into constraint_test.dept(dname, loc) values ('SALES', 'CHICAGO')"
@@ -485,30 +483,12 @@ func TestBindReplaceWithUniqueSecondaryIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, rootID)
 
-	leftJoinFound := false
-	leftJoinHasOr := false
-	for _, n := range builder.qry.Nodes {
-		if n.NodeType != planpb.Node_JOIN || n.JoinType != planpb.Node_LEFT {
-			continue
-		}
-		leftJoinFound = true
-		for _, cond := range n.OnList {
-			if f := cond.GetF(); f != nil && f.Func != nil && f.Func.ObjName == "or" {
-				leftJoinHasOr = true
-				break
-			}
-		}
-		if leftJoinHasOr {
-			break
-		}
-	}
-	require.True(t, leftJoinFound, "REPLACE on table with unique secondary index should use legacy LEFT JOIN path")
-	require.True(t, leftJoinHasOr, "LEFT JOIN ON clause should combine PK and UK equality with OR")
+	requireReplaceConflictLookupPlan(t, builder.qry, true)
 }
 
 // TestBindReplaceWithCompositeUniqueIndex verifies that for tables with a
-// composite unique secondary index the planner generates an AND-chain for the
-// UK parts inside the OR-combined LEFT JOIN ON clause.
+// composite unique secondary index the planner probes the serialized hidden
+// index key through the same equality-only conflict lookup path.
 func TestBindReplaceWithCompositeUniqueIndex(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	sql := "replace into constraint_test.dept_composite_uk(dname, loc) values ('SALES', 'CHICAGO')"
@@ -539,32 +519,7 @@ func TestBindReplaceWithCompositeUniqueIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, rootID)
 
-	// The LEFT JOIN ON clause should be: pk_match OR (dname_match AND loc_match).
-	// Verify that the OR node contains an AND child (the composite UK condition).
-	leftJoinFound := false
-	orHasAndChild := false
-	for _, n := range builder.qry.Nodes {
-		if n.NodeType != planpb.Node_JOIN || n.JoinType != planpb.Node_LEFT {
-			continue
-		}
-		leftJoinFound = true
-		for _, cond := range n.OnList {
-			f := cond.GetF()
-			if f == nil || f.Func == nil || f.Func.ObjName != "or" {
-				continue
-			}
-			for _, arg := range f.Args {
-				if af := arg.GetF(); af != nil && af.Func != nil && af.Func.ObjName == "and" {
-					orHasAndChild = true
-				}
-			}
-		}
-		if orHasAndChild {
-			break
-		}
-	}
-	require.True(t, leftJoinFound, "REPLACE on table with composite unique index should use LEFT JOIN path")
-	require.True(t, orHasAndChild, "OR clause should contain an AND child for composite UK parts")
+	requireReplaceConflictLookupPlan(t, builder.qry, true)
 }
 
 func TestBindReplaceSkipsUniqueIndexForStaticNull(t *testing.T) {

--- a/test/distributed/cases/dml/replace/replace_conflict_lookup.result
+++ b/test/distributed/cases/dml/replace/replace_conflict_lookup.result
@@ -1,0 +1,67 @@
+drop database if exists replace_conflict_lookup_27141;
+create database replace_conflict_lookup_27141;
+use replace_conflict_lookup_27141;
+create table replace_record (
+id bigint primary key,
+external_key varchar(80) not null unique,
+payload varchar(120) not null,
+revision int not null
+);
+insert into replace_record values
+(1, 'key-1', 'initial', 0),
+(2, 'key-2', 'initial', 0),
+(3, 'key-3', 'initial', 0),
+(4, 'key-4', 'initial', 0),
+(5, 'key-5', 'initial', 0),
+(6, 'key-6', 'initial', 0);
+begin;
+replace into replace_record values (1, 'key-1', 'replaced-same-row', 1);
+select row_count();
+row_count()
+2
+replace into replace_record values (2, 'key-3', 'replaced-split-row', 1);
+select row_count();
+row_count()
+3
+replace into replace_record values (4, 'key-8', 'replaced-pk-only', 1);
+select row_count();
+row_count()
+2
+replace into replace_record values (7, 'key-5', 'replaced-uk-only', 1);
+select row_count();
+row_count()
+2
+replace into replace_record values (10, 'key-10', 'replaced-insert-only', 1);
+select row_count();
+row_count()
+1
+replace into replace_record values
+(6, 'key-6', 'replaced-batch-conflict', 1),
+(9, 'key-9', 'replaced-batch-insert', 1);
+select row_count();
+row_count()
+3
+replace into replace_record values
+(11, 'key-11', 'replaced-duplicate-first', 1),
+(12, 'key-11', 'replaced-duplicate-last', 1);
+select id, payload from replace_record where external_key = 'key-11';
+id    payload
+12    replaced-duplicate-last
+commit;
+select count(*) as total,
+sum(case when revision = 1 then 1 else 0 end) as replaced,
+sum(case when payload like 'replaced-%' then 1 else 0 end) as payload_replaced
+from replace_record;
+total    replaced    payload_replaced
+8    8    8
+select * from replace_record order by id;
+id    external_key    payload    revision
+1    key-1    replaced-same-row    1
+2    key-3    replaced-split-row    1
+4    key-8    replaced-pk-only    1
+6    key-6    replaced-batch-conflict    1
+7    key-5    replaced-uk-only    1
+9    key-9    replaced-batch-insert    1
+10    key-10    replaced-insert-only    1
+12    key-11    replaced-duplicate-last    1
+drop database replace_conflict_lookup_27141;

--- a/test/distributed/cases/dml/replace/replace_conflict_lookup.sql
+++ b/test/distributed/cases/dml/replace/replace_conflict_lookup.sql
@@ -1,0 +1,64 @@
+-- @suite
+
+-- @case
+-- @desc: REPLACE conflict lookup with a primary key and a secondary unique key
+-- @label:bvt
+drop database if exists replace_conflict_lookup_27141;
+create database replace_conflict_lookup_27141;
+use replace_conflict_lookup_27141;
+
+create table replace_record (
+    id bigint primary key,
+    external_key varchar(80) not null unique,
+    payload varchar(120) not null,
+    revision int not null
+);
+insert into replace_record values
+    (1, 'key-1', 'initial', 0),
+    (2, 'key-2', 'initial', 0),
+    (3, 'key-3', 'initial', 0),
+    (4, 'key-4', 'initial', 0),
+    (5, 'key-5', 'initial', 0),
+    (6, 'key-6', 'initial', 0);
+
+begin;
+-- Both constraints find the same old row; it must be deleted only once.
+replace into replace_record values (1, 'key-1', 'replaced-same-row', 1);
+select row_count();
+
+-- The PK and UK find different old rows; both must be deleted before inserting once.
+replace into replace_record values (2, 'key-3', 'replaced-split-row', 1);
+select row_count();
+
+-- Only the PK finds an old row; the UK branch is unmatched.
+replace into replace_record values (4, 'key-8', 'replaced-pk-only', 1);
+select row_count();
+
+-- Only the UK finds an old row; the PK branch is unmatched.
+replace into replace_record values (7, 'key-5', 'replaced-uk-only', 1);
+select row_count();
+
+-- No constraint finds an old row.
+replace into replace_record values (10, 'key-10', 'replaced-insert-only', 1);
+select row_count();
+
+-- A VALUES batch mixes replacement and insertion in the same transaction.
+replace into replace_record values
+    (6, 'key-6', 'replaced-batch-conflict', 1),
+    (9, 'key-9', 'replaced-batch-insert', 1);
+select row_count();
+
+-- Branch merging must preserve the source order used by keep-last deduplication.
+replace into replace_record values
+    (11, 'key-11', 'replaced-duplicate-first', 1),
+    (12, 'key-11', 'replaced-duplicate-last', 1);
+select id, payload from replace_record where external_key = 'key-11';
+commit;
+
+select count(*) as total,
+       sum(case when revision = 1 then 1 else 0 end) as replaced,
+       sum(case when payload like 'replaced-%' then 1 else 0 end) as payload_replaced
+from replace_record;
+select * from replace_record order by id;
+
+drop database replace_conflict_lookup_27141;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27141

## What this PR does / why we need it:

### Root cause

`REPLACE` old-row discovery combined the primary-key predicate and every unique-key predicate into one `LEFT JOIN ... ON pk_match OR uk_match`. The OR predicate prevented the equality hash-join/runtime-filter path, so even the first statement could execute as a loop join against the full base table.

### Changes

- Materialize the normalized REPLACE source once when more than one uniqueness constraint must be checked.
- Build one equality-only lookup branch per constraint:
  - PK branch: source PK to base-table PK.
  - UK branch: serialized source key to the hidden unique-index key, then hidden-index PK to base-table PK.
- Merge candidate old rows with an input-row ordinal plus `UNION DISTINCT`, then restore input order before the existing DEDUP joins. The ordinal prevents equal source rows from being collapsed, while distinct union removes duplicate candidates when several constraints find the same old row.
- Remove the old OR-join construction and reuse this lookup path for the existing non-merged REPLACE cases.

### Issue-to-test proof

- Planner regression tests assert that PK+UK and PK+composite-UK REPLACE plans contain the ordered branch merge, contain no `UNION ALL`, and contain no OR join predicate. The PK-only path remains on its existing merged-scan plan.
- The new BVT uses the issue's exact PK+UK schema and checks same-row dual conflicts, different-row PK/UK conflicts, PK-only conflicts, UK-only conflicts, insert-only rows, mixed batches, affected-row counts, transaction commit results, and keep-last ordering for duplicate input keys.
- The complete existing REPLACE BVT directory covers auto-increment, multiple unique indexes, composite keys, NULL/NOT NULL handling, cross-key fanout, and workspace behavior.

### Validation

- `make -j8 cgo`
- `make -j8 build`
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 ./pkg/sql/plan`
- `mo-tester -n -g -p test/distributed/cases/dml/replace`: 521/521 statements, 100%
- New BVT repeated twice on one service instance: 24/24 statements each, 100%
- Latest post-rebase validation on `3f7a346236` over base `e7bb057223`: stable patch-id `55042ece61ee` matches the prior green head; focused planner test passed all 3 subcases; `make -j8 build` and `git diff --check` passed.
- Exact BVT on patch-identical head `957d37db7c`: `replace_conflict_lookup` passed 24/24 twice; resolved blocker case `window_hash_partition` passed 15/15 twice; both test databases were absent after teardown.
- Reduced issue workload on commit `0278591bd2` (10,000 preloaded rows; 12 statements x 25,000 VALUES):
  - statement latency: min 1.712s, median 1.818s, max 2.223s
  - transaction execution: 22.010s
  - commit: 8.29ms
  - final validation: `300000,300000,300000`
- `EXPLAIN VERBOSE` on the final commit contains equality join conditions and runtime-filter probes for both PK and hidden UK paths; it contains no loop join and no OR join condition.

### Residual risks

- Multi-constraint REPLACE now pays source materialization, distinct-union, and ordinal-sort cost proportional to input rows and constraint count. The exact reduced workload above exercises that path; PK-only plans do not take it.
- The 20-million-row original workload was not run locally. Its reported nonlinear operator is removed by plan construction, and the final plan exposes runtime filters on both lookup paths, but that scale still needs manual environment validation.