### PR TITLE
test(window): update sampled ANALYZE result

### DIFF
--- a/test/distributed/cases/window/window_hash_partition.result
+++ b/test/distributed/cases/window/window_hash_partition.result
@@ -11,8 +11,8 @@ insert into t
 select result, result % 50, cast(result % 50 as char(3)), result
 from generate_series(1, 10000) g;
 analyze table t(k, ck);
-approx_count_distinct(k)	approx_count_distinct(ck)
-50	50
+table_name	mode	coverage	columns_analyzed	population_rows	population_exact	sample_rows	sample_blocks	sample_bytes	status	message
+window_hash_partition.t	AUTO	SNAPSHOT_VISIBLE_V1	2	10000	1	10000	3	760000	OK	q=1/1
 explain (check '["Partition"]')
 select sum(v) over (partition by k) from t;
 -- @regex("Hash Partition", false)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28171

## What this PR does / why we need it:

### Root cause

The sampled-statistics change `e89cd75352` changed the successful `ANALYZE TABLE` result from the legacy two-column NDV row to an 11-column structured status row. The window hash-partition case retained the old `approx_count_distinct(k)` / `approx_count_distinct(ck)` expectation, so mo-tester failed at `ANALYZE TABLE t(k, ck)` before reaching the window assertions. The SQL fixture and window behavior are otherwise unchanged.

### Changes

- Update `test/distributed/cases/window/window_hash_partition.result` to expect the supported sampled-ANALYZE status row:
  `window_hash_partition.t | AUTO | SNAPSHOT_VISIBLE_V1 | 2 | 10000 | 1 | 10000 | 3 | 760000 | OK | q=1/1`.
- Keep the existing 10,000-row fixture, INT and CHAR partition controls, explain assertions, window-function coverage, and teardown unchanged.

### Issue-to-test proof

- Before the change, the exact case on a freshly built `d300619bb4` service reproduced the issue: 14/15 SQL statements passed and `ANALYZE TABLE t(k, ck)` failed because the expected result had 2 columns while the actual result had 11.
- After the change, the exact case passed in normal comparison mode with 15/15 statements and 100% success.
- A second run against the same instance also passed 15/15 and 100%, covering the case cleanup/reuse path.

### Tests run

- `make build` — passed on darwin/arm64; only the existing duplicate-library linker warning was emitted.
- `./run.sh -n -g -o -p <matrixone>/test/distributed/cases/ -i window_hash_partition -r 100` — passed twice; each run selected `window/window_hash_partition.sql` and reported 15 total, 15 success, 0 failed, 0 ignored.

### Residual risks

This is a test-oracle-only change. It does not alter production code, query planning, window execution, sampling, topology, or resource behavior. The expected summary values are deterministic for the existing fixture and match the service output at the sampled-statistics contract revision.