### PR TITLE
test: remove CDC timing races and isolate ISCP recovery checks

### DIFF
--- a/pkg/cdc/sinker_v2_executor_test.go
+++ b/pkg/cdc/sinker_v2_executor_test.go
@@ -475,7 +475,8 @@ func TestExecutor_execWithRetry_CircuitBreakerOpens(t *testing.T) {
 	}
 	executor.initRetryPolicy()
 	executor.circuitBreaker.maxFailures = 1
-	executor.circuitBreaker.coolDown = 50 * time.Millisecond
+	// Keep the closed-to-open assertion independent of scheduler pauses.
+	executor.circuitBreaker.coolDown = time.Hour
 
 	v2.CdcSinkerRetryCounter.Reset()
 	v2.CdcSinkerCircuitStateGauge.Reset()
@@ -501,7 +502,9 @@ func TestExecutor_execWithRetry_CircuitBreakerOpens(t *testing.T) {
 	require.Contains(t, err.Error(), "circuit breaker open")
 
 	// After cooldown, circuit should half-open and allow attempts
-	time.Sleep(60 * time.Millisecond)
+	executor.circuitBreaker.mu.Lock()
+	executor.circuitBreaker.openedAt = time.Now().Add(-executor.circuitBreaker.coolDown)
+	executor.circuitBreaker.mu.Unlock()
 	require.False(t, executor.circuitBreaker.IsOpen())
 	executor.circuitBreaker.maxFailures = 2
 	attempts = 0

--- a/pkg/cdc/table_change_stream_test.go
+++ b/pkg/cdc/table_change_stream_test.go
@@ -1761,9 +1761,7 @@ func TestTableChangeStream_RollbackFailure(t *testing.T) {
 }
 
 // TestTableChangeStream_FullPipeline_RandomDelaysAndErrors verifies the entire pipeline
-// under random delays and error injections, ensuring orderliness, idempotency, and consistency.
-// This test uses pausableChangesHandle, watermarkUpdaterStub, and error injection to simulate
-// realistic failure scenarios including StaleRead, commit failures, and rollback failures.
+// with deterministic error injection, ensuring recovery and terminal cleanup.
 func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 	updaterStub := newWatermarkUpdaterStub()
 	noopStop := func() {}
@@ -1781,10 +1779,8 @@ func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 
 	// Track operation order and counts for verification
 	var (
-		collectCalls         atomic.Int32
-		staleReadInjected    atomic.Bool
-		commitFailInjected   atomic.Bool
-		rollbackFailInjected atomic.Bool
+		collectCalls      atomic.Int32
+		staleReadInjected atomic.Bool
 	)
 
 	// Inject StaleRead error on first collect, then succeed
@@ -1813,162 +1809,42 @@ func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 		return ts
 	})
 
-	// Inject commit failure on first commit attempt, then succeed
+	// Install both faults before Run: observing SendCommit is not a barrier
+	// preventing its cleanup from already executing SendRollback.
 	commitErr := moerr.NewInternalError(h.Context(), "commit failure")
-	h.Sinker().setCommitError(commitErr)
-	commitFailInjected.Store(true)
-
-	ar := h.NewActiveRoutine()
-	errCh, done := h.RunStreamAsync(ar)
-
-	// Wait for stale read recovery (multiple collect calls)
-	// Use longer timeout for slow CI environments, but keep frequent checks
-	// Stale read recovery may involve retry backoff: base=5ms, max=20ms, factor=2.0, maxRetries=3
-	// Worst case delay per retry cycle: ~35ms, plus processing time
-	require.Eventually(t, func() bool {
-		return collectCalls.Load() >= 2
-	}, 10*time.Second, 10*time.Millisecond, "should see stale read recovery")
-
-	// Wait for commit attempt (which will fail)
-	// Use longer timeout for slow CI environments, but keep frequent checks
-	// Calculate worst-case retry delay: base=5ms, max=20ms, factor=2.0, maxRetries=3
-	// Worst case: 5ms + 10ms + 20ms = 35ms per retry cycle, plus processing time
-	// Use 10s timeout to handle multiple retry cycles and slow CI environments
-	require.Eventually(t, func() bool {
-		ops := h.Sinker().opsSnapshot()
-		for _, op := range ops {
-			if op == "commit" {
-				return true
-			}
-		}
-		return false
-	}, 10*time.Second, 10*time.Millisecond, "should see commit attempt")
-
-	// Keep commit error and inject rollback failure (rollback happens during cleanup after commit failure)
-	// To eliminate race condition: set rollback error immediately after confirming commit attempt,
-	// then add a small synchronization delay to ensure the error is set in sinker before cleanup rollback happens.
-	// This reduces the race window to near zero.
 	rollbackErr := moerr.NewInternalError(h.Context(), "rollback failure")
+	h.Sinker().setCommitError(commitErr)
 	h.Sinker().setRollbackError(rollbackErr)
-	rollbackFailInjected.Store(true)
-	// Small synchronization delay to ensure rollback error is set before cleanup rollback happens
-	// This eliminates the race condition where rollback might occur before error is set.
-	// 50ms is sufficient for error injection to propagate, even in slow environments.
-	time.Sleep(50 * time.Millisecond)
 
-	// Wait for rollback attempt (which will fail during cleanup after commit failure)
-	// Use longer timeout for slow CI environments, but keep frequent checks
-	// Rollback happens during EnsureCleanup after commit failure, which may have retry delays
-	require.Eventually(t, func() bool {
-		ops := h.Sinker().opsSnapshot()
-		for _, op := range ops {
-			if op == "rollback" {
-				return true
-			}
-		}
-		return false
-	}, 10*time.Second, 10*time.Millisecond, "should see rollback attempt")
-
-	// Verify that rollback failure marks stream as non-retryable (system state may be inconsistent)
-	// This is the core behavior: rollback failure indicates system state may be inconsistent,
-	// so the stream should not be retryable even if the original error (commit failure) is retryable
-	// Use longer timeout for slow CI environments to ensure state propagation, but keep frequent checks
-	// State propagation may take time due to retry backoff and processing delays
-	// To make the check more stable and reduce flakiness, we verify the state is stable by checking
-	// multiple consecutive times. This ensures the state has settled after recovery path + backoff + scheduling.
-	// The state must remain non-retryable for 3 consecutive checks (30ms total) to be considered stable.
-	var stableCount int
-	const requiredStableChecks = 3 // Require 3 consecutive checks to ensure state is stable
-	require.Eventually(t, func() bool {
-		isNonRetryable := !h.Stream().GetRetryable()
-		if isNonRetryable {
-			stableCount++
-			if stableCount >= requiredStableChecks {
-				return true
-			}
-		} else {
-			// State changed or not yet stable, reset counter
-			stableCount = 0
-		}
-		return false
-	}, 10*time.Second, 10*time.Millisecond, "stream should be non-retryable after rollback failure (with stable state check)")
-
-	// Clear rollback error so stream can remain retryable after rollback failure is verified
-	// Note: The test verifies that rollback failure marks stream as non-retryable.
-	// After clearing the rollback error, the next round will succeed (rollback will succeed),
-	// and cleanupRollbackErr will not be set, so the stream will become retryable again.
-	// However, this depends on other factors (e.g., no other errors), so we don't assert it here.
-	// The core behavior (rollback failure -> non-retryable) is already verified above.
-	h.Sinker().setRollbackError(nil)
-
-	// Cancel to exit
-	h.Cancel()
-	done()
-
-	var runErr error
-	// Use longer timeout for resource cleanup in slow CI environments
-	// Cleanup may involve rollback operations and state synchronization
+	errCh, done := h.RunStreamAsync(h.NewActiveRoutine())
+	defer done()
 	select {
-	case runErr = <-errCh:
+	case runErr := <-errCh:
+		require.ErrorIs(t, runErr, commitErr)
 	case <-time.After(10 * time.Second):
-		t.Fatal("stream did not exit after cancellation")
-	}
-	// The stream may return either the commit failure error or context.Canceled
-	if runErr != nil {
-		if !errors.Is(runErr, context.Canceled) {
-			// If not canceled, it should be the commit failure error
-			require.Contains(t, runErr.Error(), "commit failure", "if not canceled, should be commit failure")
-		}
+		t.Fatal("stream did not terminate after rollback failure")
 	}
 
-	// Verify orderliness: begin should always come before commit/rollback
-	ops := h.Sinker().opsSnapshot()
-	// Track the last begin index seen so far
-	lastBeginIdx := -1
-	for i, op := range ops {
+	// Run has completed: no polling of an intermediate retryability state.
+	require.False(t, h.Stream().GetRetryable())
+	require.True(t, staleReadInjected.Load())
+	require.GreaterOrEqual(t, collectCalls.Load(), int32(2))
+	require.GreaterOrEqual(t, h.Sinker().ResetCountSnapshot(), 1)
+	require.ErrorIs(t, h.Sinker().Error(), rollbackErr)
+
+	var txnOps []string
+	for _, op := range h.Sinker().opsSnapshot() {
 		switch op {
-		case "begin":
-			lastBeginIdx = i
-		case "commit":
-			require.Greater(t, i, lastBeginIdx, "commit at index %d should come after begin", i)
-		case "rollback":
-			require.Greater(t, i, lastBeginIdx, "rollback at index %d should come after begin", i)
+		case "begin", "commit", "rollback":
+			txnOps = append(txnOps, op)
 		}
 	}
-
-	// Verify idempotency: EnsureCleanup should be idempotent
-	// Count rollbacks - should be at least one, but not excessive
-	rollbackCount := 0
-	beginCount := 0
-	for _, op := range ops {
-		if op == "rollback" {
-			rollbackCount++
-		}
-		if op == "begin" {
-			beginCount++
-		}
-	}
-	require.GreaterOrEqual(t, rollbackCount, 1, "should have at least one rollback after commit failure")
-	require.GreaterOrEqual(t, beginCount, 1, "should have at least one begin")
-
-	// Verify consistency: retryable flag and sinker reset
-	// Note: After rollback failure, stream is marked as non-retryable (system state may be inconsistent).
-	// If rollback error was cleared and next round succeeded, stream should be retryable again.
-	// However, other factors (e.g., watermark mismatch) may also affect retryability.
-	// The core behavior (rollback failure -> non-retryable) is verified earlier in the test.
-	// Here we just verify that the stream has processed the scenarios (stale read, commit failure, rollback failure).
-	require.GreaterOrEqual(t, h.Sinker().ResetCountSnapshot(), 1, "sinker should reset at least once for stale read")
-
-	// Verify all error injections occurred
-	require.True(t, staleReadInjected.Load(), "stale read should have been injected")
-	require.True(t, commitFailInjected.Load(), "commit failure should have been injected")
-	require.True(t, rollbackFailInjected.Load(), "rollback failure should have been injected")
-
-	// Verify tracker state is consistent (may be nil if cleanup completed)
+	// One transaction, one commit attempt and exactly one cleanup rollback.
+	require.Equal(t, []string{"begin", "commit", "rollback"}, txnOps)
 	tracker := h.Stream().txnManager.GetTracker()
 	if tracker != nil {
-		// After EnsureCleanup, tracker should not need rollback (even if rollback failed)
-		require.False(t, tracker.NeedsRollback(), "tracker should be marked as not needing rollback after EnsureCleanup")
+		require.False(t, tracker.NeedsRollback())
+		require.True(t, tracker.IsCompleted())
 	}
 }
 

--- a/pkg/cdc/table_change_stream_test.go
+++ b/pkg/cdc/table_change_stream_test.go
@@ -1846,6 +1846,8 @@ func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 		require.False(t, tracker.NeedsRollback())
 		require.True(t, tracker.IsCompleted())
 	}
+	h.Sinker().releaseOutputs()
+	require.Zero(t, h.MP().CurrNB(), "terminal stream and sink must release all batch ownership")
 }
 
 type noopTxnOperator struct {
@@ -2263,6 +2265,7 @@ func (h *tableStreamHarness) Close() {
 		h.cancel()
 		h.stream.Close()
 		h.stream.Wait()
+		h.sinker.releaseOutputs()
 		for _, stub := range h.stubs {
 			stub.Reset()
 		}
@@ -2526,6 +2529,19 @@ func (s *tableStreamRecordingSinker) Reset() {
 	s.mu.Lock()
 	s.resetCnt++
 	s.mu.Unlock()
+}
+
+// The recording sink owns outputs just like a real sink, but retains them for
+// assertions. The harness calls this only after Run has joined, before deleting
+// the pool. Detaching the slice makes repeated teardown harmless.
+func (s *tableStreamRecordingSinker) releaseOutputs() {
+	s.mu.Lock()
+	outputs := s.sinkCalls
+	s.sinkCalls = nil
+	s.mu.Unlock()
+	for _, output := range outputs {
+		output.Close()
+	}
 }
 
 func (s *tableStreamRecordingSinker) reset() {

--- a/pkg/lockservice/lock_table_proxy_test.go
+++ b/pkg/lockservice/lock_table_proxy_test.go
@@ -1280,10 +1280,7 @@ func TestProxyRetryPreservesAppliedHandoffRepresentative(t *testing.T) {
 				txn:  pb.WaitTxn{TxnID: []byte("owner-waiter"), CreatedOn: s1.serviceID},
 			})
 
-			type result struct {
-				err error
-			}
-			exclusiveDone := make(chan result, 1)
+			exclusiveDone := make(chan error, 1)
 			// Waiter notification is asynchronous. Give this phase its own budget
 			// so setup time or temporary runner starvation cannot consume it.
 			exclusiveCtx, exclusiveCancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -1300,33 +1297,99 @@ func TestProxyRetryPreservesAppliedHandoffRepresentative(t *testing.T) {
 			go func() {
 				defer close(exclusiveExited)
 				_, err := s1.Lock(exclusiveCtx, tableID, [][]byte{row}, exclusiveTxn, newTestRowExclusiveOptions())
-				exclusiveDone <- result{err: err}
+				exclusiveDone <- err
 			}()
 			waitWaiters(t, s1, tableID, row, 1)
 			require.Never(t, func() bool {
 				select {
-				case r := <-exclusiveDone:
-					require.NoError(t, r.err)
+				case err := <-exclusiveDone:
+					require.NoError(t, err)
 					return true
 				default:
 					return false
 				}
 			}, 100*time.Millisecond, time.Millisecond)
 
-			require.NoError(t, s2.Unlock(ctx, lateSharerTxn, timestamp.Timestamp{}))
-			select {
-			case r := <-exclusiveDone:
-				if r.err != nil {
-					dumpProxyHandoffWait(t, owner, proxy, row)
-				}
-				require.NoError(t, r.err)
-			case <-exclusiveCtx.Done():
+			// These are separate RPC/cleanup phases, not extensions of the
+			// exclusive acquisition budget. Do not reuse setup's aging context.
+			releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			err = s2.Unlock(releaseCtx, lateSharerTxn, timestamp.Timestamp{})
+			releaseCancel()
+			require.NoError(t, err)
+			err = waitProxyLockResult(exclusiveCtx, exclusiveDone)
+			if err != nil {
 				dumpProxyHandoffWait(t, owner, proxy, row)
-				require.NoError(t, exclusiveCtx.Err())
 			}
-			require.NoError(t, s1.Unlock(ctx, exclusiveTxn, timestamp.Timestamp{}))
+			require.NoError(t, err)
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			err = s1.Unlock(cleanupCtx, exclusiveTxn, timestamp.Timestamp{})
+			cleanupCancel()
+			require.NoError(t, err)
 		},
 	)
+}
+
+// A completed result is authoritative even if the test goroutine resumes after
+// its hang guard expired. The deadline branch only rechecks; it never waits for
+// additional work or suppresses an actual Lock error.
+func waitProxyLockResult(ctx context.Context, done <-chan error) error {
+	var err error
+	var ok bool
+	select {
+	case err, ok = <-done:
+	case <-ctx.Done():
+		select {
+		case err, ok = <-done:
+		default:
+			return ctx.Err()
+		}
+	}
+	if !ok {
+		return errors.New("lock result channel closed without a result")
+	}
+	return err
+}
+
+func TestWaitProxyLockResult(t *testing.T) {
+	lockErr := errors.New("lock failed")
+	for _, tc := range []struct {
+		name    string
+		expired bool
+		send    bool
+		closed  bool
+		result  error
+		want    error
+	}{
+		{name: "success", send: true},
+		{name: "lock error", send: true, result: lockErr, want: lockErr},
+		{name: "success and deadline ready", expired: true, send: true},
+		{name: "lock error and deadline ready", expired: true, send: true, result: lockErr, want: lockErr},
+		{name: "deadline without result", expired: true, want: context.DeadlineExceeded},
+		{name: "closed without result", closed: true},
+		{name: "closed without result and deadline ready", expired: true, closed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.expired {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, time.Time{})
+				defer cancel()
+			}
+			done := make(chan error, 1)
+			if tc.send {
+				done <- tc.result
+			}
+			if tc.closed {
+				close(done)
+			}
+			err := waitProxyLockResult(ctx, done)
+			if tc.closed {
+				require.EqualError(t, err, "lock result channel closed without a result")
+			} else {
+				require.ErrorIs(t, err, tc.want)
+			}
+		})
+	}
 }
 
 // Failure-only diagnostics must not wait on the mutex that may explain the

--- a/pkg/lockservice/lock_table_proxy_test.go
+++ b/pkg/lockservice/lock_table_proxy_test.go
@@ -1254,9 +1254,11 @@ func TestProxyRetryPreservesAppliedHandoffRepresentative(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, firstReplacementTxn, holder.TxnID)
 			proxy.mu.RLock()
-			require.Equal(t, firstReplacementTxn, proxy.mu.currentHolder[string(row)])
-			require.Empty(t, proxy.mu.pendingRemoteHolders)
+			currentHolder := append([]byte(nil), proxy.mu.currentHolder[string(row)]...)
+			pendingHolders := len(proxy.mu.pendingRemoteHolders)
 			proxy.mu.RUnlock()
+			require.Equal(t, firstReplacementTxn, currentHolder)
+			require.Zero(t, pendingHolders)
 
 			// Let the first replacement finish. The owner must now move to the
 			// still-active late sharer, rather than retaining an orphan holder.

--- a/pkg/lockservice/lock_table_proxy_test.go
+++ b/pkg/lockservice/lock_table_proxy_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1284,8 +1285,18 @@ func TestProxyRetryPreservesAppliedHandoffRepresentative(t *testing.T) {
 			// Waiter notification is asynchronous. Give this phase its own budget
 			// so setup time or temporary runner starvation cannot consume it.
 			exclusiveCtx, exclusiveCancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer exclusiveCancel()
+			exclusiveExited := make(chan struct{})
+			defer func() {
+				exclusiveCancel()
+				select {
+				case <-exclusiveExited:
+				case <-time.After(5 * time.Second):
+					dumpProxyHandoffWait(t, owner, proxy, row)
+					t.Error("exclusive lock worker did not exit after cancellation")
+				}
+			}()
 			go func() {
+				defer close(exclusiveExited)
 				_, err := s1.Lock(exclusiveCtx, tableID, [][]byte{row}, exclusiveTxn, newTestRowExclusiveOptions())
 				exclusiveDone <- result{err: err}
 			}()
@@ -1303,13 +1314,49 @@ func TestProxyRetryPreservesAppliedHandoffRepresentative(t *testing.T) {
 			require.NoError(t, s2.Unlock(ctx, lateSharerTxn, timestamp.Timestamp{}))
 			select {
 			case r := <-exclusiveDone:
+				if r.err != nil {
+					dumpProxyHandoffWait(t, owner, proxy, row)
+				}
 				require.NoError(t, r.err)
 			case <-exclusiveCtx.Done():
+				dumpProxyHandoffWait(t, owner, proxy, row)
 				require.NoError(t, exclusiveCtx.Err())
 			}
 			require.NoError(t, s1.Unlock(ctx, exclusiveTxn, timestamp.Timestamp{}))
 		},
 	)
+}
+
+// Failure-only diagnostics must not wait on the mutex that may explain the
+// hang. Snapshots are per-lock, not an atomic view of owner and proxy together.
+func dumpProxyHandoffWait(t *testing.T, owner *localLockTable, proxy *localLockTableProxy, row []byte) {
+	t.Helper()
+	if owner.mu.TryRLock() {
+		lock, found := owner.mu.store.Get(row)
+		var state string
+		if found {
+			state = fmt.Sprintf("holders=%v", lock.holders.txns)
+			lock.waiters.iter(func(w *waiter) bool {
+				state += fmt.Sprintf(" waiter=%x status=%d notifications=%d", w.txn.TxnID, w.getStatus(), len(w.c))
+				return true
+			})
+		}
+		owner.mu.RUnlock()
+		t.Logf("handoff owner: found=%t %s", found, state)
+	} else {
+		t.Log("handoff owner mutex unavailable")
+	}
+	if proxy.mu.TryRLock() {
+		state := fmt.Sprintf("holder=%x pending=%v", proxy.mu.currentHolder[string(row)], proxy.mu.pendingRemoteHolders)
+		proxy.mu.RUnlock()
+		t.Logf("handoff proxy: %s", state)
+	} else {
+		t.Log("handoff proxy mutex unavailable")
+	}
+	t.Logf("handoff event queue: %d", len(owner.events.eventC))
+	stack := make([]byte, 2<<20)
+	n := runtime.Stack(stack, true)
+	t.Logf("handoff goroutines (truncated=%t):\n%s", n == len(stack), stack[:n])
 }
 
 func TestProxyAmbiguousDirectLockForcesTxnIDUnlock(t *testing.T) {

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -4271,11 +4271,24 @@ func TestInvalidTimestamp(t *testing.T) {
 
 	require.NoError(t, txn.Commit(ctxWithTimeout))
 
+	// The recovery budget must not include cold consumer DDL. Prepare only
+	// its empty destination; the executor still has to discover the job, copy
+	// the source row and advance the watermark after the fault is removed.
+	for _, sql := range []string{
+		fmt.Sprintf("create database if not exists %s", iscp.TargetDbName),
+		fmt.Sprintf("create table %s.test_table_%d_%s like srcdb.src_table", iscp.TargetDbName, tableID, jobName),
+	} {
+		result, err := execSql(disttaeEngine, ctxWithTimeout, sql)
+		require.NoError(t, err)
+		result.Close()
+	}
+
 	require.True(t, fault.Enable(), "fault injection was already enabled before TestInvalidTimestamp")
 	t.Cleanup(func() {
 		fault.Disable()
 	})
 	invalidTimestampFault := newISCPFaultBarrier(t, ctx, "invalid timestamp")
+	defer invalidTimestampFault.Remove()
 
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
 	require.NoError(t, err)
@@ -4314,6 +4327,7 @@ func TestInvalidTimestamp(t *testing.T) {
 		tableID,
 		jobName,
 	)
+	CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, jobName)
 }
 
 func TestCancelIteration1(t *testing.T) {

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/cdc"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -44,6 +45,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	pbtxn "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	cmd_util "github.com/matrixorigin/matrixone/pkg/vm/engine/cmd_util"
@@ -4274,13 +4276,18 @@ func TestInvalidTimestamp(t *testing.T) {
 	// The recovery budget must not include cold consumer DDL. Prepare only
 	// its empty destination; the executor still has to discover the job, copy
 	// the source row and advance the watermark after the fault is removed.
+	v, ok := moruntime.ServiceRuntime("").GetGlobalVariables(moruntime.InternalSQLExecutor)
+	require.True(t, ok)
+	sqlExecutor := v.(executor.SQLExecutor)
 	for _, sql := range []string{
 		fmt.Sprintf("create database if not exists %s", iscp.TargetDbName),
 		fmt.Sprintf("create table %s.test_table_%d_%s like srcdb.src_table", iscp.TargetDbName, tableID, jobName),
 	} {
-		result, err := execSql(disttaeEngine, ctxWithTimeout, sql)
-		require.NoError(t, err)
+		// No caller-owned transaction: Exec owns commit/rollback, including
+		// SQL errors. Release any result before a fatal assertion exits.
+		result, err := sqlExecutor.Exec(ctxWithTimeout, sql, executor.Options{})
 		result.Close()
+		require.NoError(t, err)
 	}
 
 	require.True(t, fault.Enable(), "fault injection was already enabled before TestInvalidTimestamp")
@@ -4292,7 +4299,7 @@ func TestInvalidTimestamp(t *testing.T) {
 
 	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
 	require.NoError(t, err)
-	ok, err := iscp.RegisterJob(
+	ok, err = iscp.RegisterJob(
 		ctx, "", txn,
 		&iscp.JobSpec{
 			ConsumerInfo: iscp.ConsumerInfo{
@@ -4327,7 +4334,25 @@ func TestInvalidTimestamp(t *testing.T) {
 		tableID,
 		jobName,
 	)
-	CheckTableData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", tableID, jobName)
+	// Compare both directions: watermark progress must represent copied data,
+	// not just job discovery. Let the SQL executor own these transactions too.
+	destination := fmt.Sprintf("%s.test_table_%d_%s", iscp.TargetDbName, tableID, jobName)
+	for _, sql := range []string{
+		fmt.Sprintf("select * from srcdb.src_table except select * from %s", destination),
+		fmt.Sprintf("select * from %s except select * from srcdb.src_table", destination),
+	} {
+		result, err := sqlExecutor.Exec(ctxWithTimeout, sql, executor.Options{})
+		rows := 0
+		if err == nil {
+			result.ReadRows(func(n int, _ []*vector.Vector) bool {
+				rows += n
+				return true
+			})
+		}
+		result.Close()
+		require.NoError(t, err)
+		require.Zero(t, rows, sql)
+	}
 }
 
 func TestCancelIteration1(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [x] Test and CI
- [x] BUG

## Which issue(s) this PR fixes:

Fixes #28167.
Addresses the demonstrated cold-start budget coupling in #27997; keep that issue open for CI confirmation.
Related to #27809: test-result arbitration, phase-local contexts and diagnostic/cleanup improvements, **not a claimed historical root-cause fix**.

## What this PR does / why we need it:

### Evidence and first-principles contracts

1. **#28167: fault injection races the operation it is supposed to fail.** The test observed a recorded commit, then installed rollback failure. Cleanup could already have read its rollback result; a later 50ms sleep cannot establish a happens-before relationship. Install both faults before starting the stream, wait for Run to finish, then assert the original commit error, terminal non-retryability, sink rollback error, stale-read recovery and exactly `begin -> commit -> rollback`. Remove cancellation-as-success, repeated stable-state polling and configuration-only injection flags. Keep the historical test name for traceability.
2. **#27997: the failed run recovered job discovery but spent the recovery budget on cold consumer initialization.** In [the failing CI job](https://github.com/matrixorigin/matrixone/actions/runs/33587927832/job/100115871094), `add or update job` follows the injected error. The worker then creates the destination database/table; job-state commit takes 3.54s and database creation commit takes 2.95s. The timeout occurs during destination table creation, not another logged invalid-timestamp failure. Prepare the *empty* destination schema before fault injection, leaving discovery, snapshot copying and watermark advancement in the unchanged 10s recovery budget. Add bidirectional source/destination data comparison. The injection barrier still proves the worker hit the fault and no job watermark exists before release. Defer barrier removal before executor shutdown on assertion failure. This isolates the recovery contract; it does not prove every possible watermark stall has been fixed. Other integration tests retain cold-start consumer DDL coverage.
3. **#27809: no proven blocked edge yet.** Current-main focused, race and coverage repetitions pass. Preserve the existing handoff/liveness assertions and 30s acquisition budget. On failure capture owner holders/waiters/status/notification count, proxy representative/pending handoffs, event-queue length and bounded all-goroutine stacks. Use TryRLock so diagnostics cannot wait on the potentially blocked mutex. Cancel and boundedly join the exclusive-lock worker before service teardown. The issue must remain open until a reproduced failure identifies the missing progress edge; no speculative lock-protocol change is included.
4. **Same-pattern audit: circuit breaker cooldown.** `TestExecutor_execWithRetry_CircuitBreakerOpens` assumed the next call occurred within a 50ms cooldown. A scheduler pause invalidates that assumption. Use a long open window and explicitly age `openedAt` under the existing mutex for the expiry phase. Keep both rejection-before-expiry and recovery-after-expiry assertions without a sleep. No production clock abstraction is added.

### Scope, risks and unhappy paths

- Four test files only; no production API, lock protocol, transaction/retry policy or runtime performance changes.
- Audited nearby CDC injection setters, sleep-based state assumptions and ISCP fault barriers. This is a targeted same-pattern audit, not a claim that all repository flakes are eliminated. Delays that intentionally model slow operations were not mechanically removed.
- Recovery still must propagate real data, not merely observe job existence. Destination preparation copies schema only, never source rows.
- Handoff diagnostics are failure-only and bounded (2MiB stack buffer per dump). Owner/proxy snapshots are individually locked, not a cross-service atomic snapshot. An unavailable lock and stack truncation are explicitly reported. Cancellation cleanup adds at most a 5s diagnostic budget, not extra time to pass the acquisition assertion.
- Repeated passes do not establish the cause of the historical #27809 timeout. Linux CI and its resource contention remain unverified locally.

### Validation

Base: `313991b503fb10d0b72daf811c716e57fe7f2a07`, macOS arm64, Go 1.26.4, native dependencies built with `make -j8 cgo`. All Go commands used `.agents/skills/mo-dev/scripts/mo-cgo-test` for platform-correct native linking.

- CDC full package: `-short -count=1 -timeout=12m ./pkg/cdc` — PASS.
- CDC full-pipeline and rollback-failure tests: 20 focused repetitions — PASS.
- CDC full-pipeline, rollback-failure and circuit-breaker tests: `-race -short -count=10 -timeout=15m` — PASS.
- `TestInvalidTimestamp`: 3 focused repetitions and `-race -short -count=5 -timeout=15m` — PASS, including the added data comparison.
- `TestProxyRetryPreservesAppliedHandoffRepresentative`: 20 baseline repetitions, 20 race repetitions and 50 coverage repetitions — PASS.
- `gofmt` and `git diff --check` — PASS.

Self-review checked fault-installation ordering, terminal-state assertions, failure-path teardown, snapshot lock safety, unchanged time budgets, retained data/ordering oracles and production-performance scope. No remaining defect found in these changes; historical #27809 remains unresolved.

### Follow-up deep review: failure paths and non-overfit checks

The first delivery review missed test-fixture cleanup problems; green exit status alone was insufficient. This follow-up traced ownership through assertion failure and inspected successful-test logs as well.

| Closure | Verified finding / resolution |
|---|---|
| Q1: recording sink output ownership | Even a passing full-pipeline test logged 24 bytes / 2 outstanding objects. The fake sink retained transferred DecoderOutput batches without releasing them. The shared harness now drains outputs **after Run joins and before pool destruction**; draining detaches the slice and is idempotent. The focal test explicitly requires zero remaining pool bytes. |
| Q1/Q2: newly added SQL steps | `execSql` uses a caller-owned transaction and returns on SQL error without rollback. New setup and both data-comparison queries now use SQLExecutor.Exec without an external transaction, so the executor owns commit/rollback; results are closed before fatal assertions. The unsafe legacy helper itself is not broadly refactored in this PR. |
| Q2: assertions under a mutex | The handoff test made fatal assertions while retaining proxy.mu.RLock. It now copies the representative and pending count under the lock, releases it, and then asserts. |
| Q3: cost and bounds | No production changes, added sleep, passing-timeout extension, new service fixture or retry-to-pass mechanism. Captured output batches are released at fixture termination rather than left behind. |

Counterexample validation deliberately disabled rollback failure in the focal CDC test. It failed at the non-retryability assertion in 0.44s and exited with status 1; after the cleanup fix that failure no longer left the outstanding-ownership warning. The temporary mutation was restored and is not delivered. This demonstrates a discriminating oracle and failure cleanup, not just repeated green runs.

Single-test race measurements (excluding build): CDC full pipeline 0.41s; TestInvalidTimestamp 1.60s; proxy handoff 0.23s. These are local observations, not flaky timing assertions or a claim of a statistically established speedup. Empty destination setup isolates the recovery phase; it does not remove total DDL work or claim to optimize slow TN commits. Cold-start DDL remains covered by other integration cases.

The broader statement “all three historical flakes are fixed and can never hang” is **not supported**: #27809's missing-progress edge is still unproven, and no change here repairs its unknown historical root cause. Keep that issue open. A bounded diagnostic join also is not a proof that arbitrary future production deadlocks can be interrupted by Go contexts.

### #27809 follow-up: confirmed test defects, historical cause still open

- A Go select can choose the deadline even when the successful Lock result is already buffered. The test now does one nonblocking result recheck on the deadline path. A completed result wins; an actual Lock error is preserved, and an expired context without a result still fails immediately. There is no additional waiting or retry-to-pass. This establishes completion, not a strict wall-clock latency SLA.
- Final shared-lock release and exclusive-lock cleanup now each use their own 5s context instead of reusing setup's aging 5s context. The exclusive acquisition retains its original 30s budget, including the release phase; these contexts do not restart or extend that budget.
- Seven no-sleep unit cases cover success, actual error, both-ready success/error, deadline without result, and closed-without-result with/without an expired deadline. Unexpected channel closure cannot masquerade as successful acquisition.
- Code tracing and temporary controlled experiments exercised notification before waiting and delayed progress after notification. Both progressed; no missing notification, abandoned representative or lock cycle was demonstrated. Temporary diagnostic experiments are not shipped. These findings do **not** establish which edge stalled in the historical Linux coverage runs, and #27809 must remain open.
- Scope remains test-only: no production lock protocol, retry policy or runtime hot-path cost changes. Actual acquisition errors still trigger bounded failure diagnostics and fail the test.

Validation of this final follow-up source (macOS arm64, same native wrapper): exact handoff + result-arbitration tests `-race -short -count=100 -timeout=120s` PASS (26.089s); the same selection `-cover -short -count=50 -timeout=120s` PASS (13.029s); owning `./pkg/lockservice` package `-short -count=1 -timeout=240s` PASS (89.516s). All seven result-arbitration cases executed. `gofmt` and `git diff --check` passed. Prior CDC/ISCP evidence is reused because this follow-up changes only the proxy test file. These passes are validation of the delivered changes, not proof that the historical Linux flake cannot recur.

Follow-up validation on the delivered source: CDC owning package normal PASS (12.618s, previous delivery 12.725s) and race PASS (14.496s); exact full-pipeline test race x73 PASS; exact invalid-timestamp test race x19 PASS; exact proxy-handoff test race x100 PASS. Repetition counts follow the measured test-body / 30s-budget rule. All commands terminated, and the temporary negative-control mutation was removed before the final tests and commit. Earlier circuit-breaker evidence is reused because its code and dependency contract did not change. Linux CI remains separate from these macOS results.
