### PR TITLE
fix(colexec): isolate prepared parameter null state (cherry-pick #26915)

### DIFF
--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -386,7 +386,8 @@ type ParamExpressionExecutor struct {
 	pos        int
 	typ        types.Type
 
-	folded bool
+	folded     bool
+	foldedNull bool
 }
 
 func (expr *ParamExpressionExecutor) Eval(proc *process.Process, batches []*batch.Batch, selectList []bool) (*vector.Vector, error) {
@@ -401,15 +402,12 @@ func (expr *ParamExpressionExecutor) Eval(proc *process.Process, batches []*batc
 		return expr.maskedNull, nil
 	}
 	if expr.folded {
-		if expr.null != nil {
+		if expr.foldedNull {
 			return expr.null, nil
 		}
-		if expr.vec != nil {
-			return expr.vec, nil
-		}
+		return expr.vec, nil
 	}
 
-	expr.folded = true
 	val, err := proc.GetPrepareParamsAt(expr.pos)
 	if err != nil {
 		return nil, err
@@ -422,6 +420,8 @@ func (expr *ParamExpressionExecutor) Eval(proc *process.Process, batches []*batc
 				return nil, err
 			}
 		}
+		expr.folded = true
+		expr.foldedNull = true
 		return expr.null, nil
 	}
 
@@ -435,6 +435,8 @@ func (expr *ParamExpressionExecutor) Eval(proc *process.Process, batches []*batc
 	if err == nil {
 		expr.vec.SetIsBin(proc.GetPrepareParamIsBin(expr.pos))
 		expr.vec.SetPrepareParamKind(proc.GetPrepareParamKind(expr.pos))
+		expr.folded = true
+		expr.foldedNull = false
 	}
 	return expr.vec, err
 }
@@ -446,9 +448,11 @@ func (expr *ParamExpressionExecutor) EvalWithoutResultReusing(proc *process.Proc
 	}
 	if vec == expr.null {
 		expr.null = nil
-		return vec, nil
+	} else {
+		expr.vec = nil
 	}
-	expr.vec = nil
+	expr.folded = false
+	expr.foldedNull = false
 	return vec, nil
 }
 

--- a/pkg/sql/colexec/evalExpressionReset.go
+++ b/pkg/sql/colexec/evalExpressionReset.go
@@ -326,6 +326,7 @@ func (expr *ParamExpressionExecutor) ResetForNextQuery() {
 		expr.vec.CleanOnlyData()
 	}
 	expr.folded = false
+	expr.foldedNull = false
 }
 
 func (expr *VarExpressionExecutor) ResetForNextQuery() {

--- a/pkg/sql/colexec/evalExpression_test.go
+++ b/pkg/sql/colexec/evalExpression_test.go
@@ -1751,6 +1751,170 @@ func TestExpressionReset(t *testing.T) {
 	}
 }
 
+func TestVolatileStringAssignmentCastReset(t *testing.T) {
+	targets := []struct {
+		name string
+		typ  types.Type
+	}{
+		{name: "char", typ: types.New(types.T_char, 20, 0)},
+		{name: "varchar", typ: types.New(types.T_varchar, 20, 0)},
+		{name: "tinytext", typ: types.New(types.T_text, 255, 0)},
+	}
+	for _, target := range targets {
+		t.Run(target.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			defer proc.Free()
+			proc.SetBaseProcessRunningStatus(true)
+			proc.Base.SessionInfo.SqlMode = "STRICT_TRANS_TABLES"
+
+			sourceType := types.T_text.ToType()
+			fn, err := function.GetFunctionByName(proc.Ctx, "cast_assign", []types.Type{sourceType, target.typ})
+			require.NoError(t, err)
+			expr := &plan.Expr{
+				Typ: plan.Type{Id: int32(target.typ.Oid), Width: target.typ.Width, Scale: target.typ.Scale},
+				Expr: &plan.Expr_F{F: &plan.Function{
+					Func: &plan.ObjectRef{Obj: fn.GetEncodedOverloadID(), ObjName: "cast_assign"},
+					Args: []*plan.Expr{
+						{
+							Typ:  plan.Type{Id: int32(sourceType.Oid), Width: sourceType.Width, Scale: sourceType.Scale},
+							Expr: &plan.Expr_P{P: &plan.ParamRef{Pos: 0}},
+						},
+						{
+							Typ:  plan.Type{Id: int32(target.typ.Oid), Width: target.typ.Width, Scale: target.typ.Scale},
+							Expr: &plan.Expr_T{T: &plan.TargetType{}},
+						},
+					},
+				}},
+			}
+			executor, err := NewExpressionExecutor(proc, expr)
+			require.NoError(t, err)
+			defer executor.Free()
+
+			eval := func(value *string, kind vector.PrepareParamKind) *vector.Vector {
+				t.Helper()
+				params := vector.NewVec(sourceType)
+				if value == nil {
+					require.NoError(t, vector.AppendBytes(params, nil, true, proc.Mp()))
+				} else {
+					require.NoError(t, vector.AppendBytes(params, []byte(*value), false, proc.Mp()))
+					params.SetPrepareParamKind(kind)
+				}
+				proc.SetPrepareParams(params)
+				result, evalErr := executor.Eval(proc, nil, nil)
+				require.NoError(t, evalErr)
+				require.False(t, executor.(*FunctionExpressionExecutor).folded.canFold)
+				proc.SetPrepareParams(nil)
+				params.Free(proc.Mp())
+				return result
+			}
+
+			first := "before"
+			result := eval(&first, vector.PrepareParamNone)
+			require.False(t, result.IsNull(0))
+			require.Equal(t, first, result.GetStringAt(0))
+
+			executor.ResetForNextQuery()
+			result = eval(nil, vector.PrepareParamNone)
+			require.True(t, result.IsNull(0))
+
+			executor.ResetForNextQuery()
+			after := "after"
+			result = eval(&after, vector.PrepareParamNone)
+			require.False(t, result.IsNull(0))
+			require.Equal(t, after, result.GetStringAt(0))
+
+			executor.ResetForNextQuery()
+			result = eval(nil, vector.PrepareParamNone)
+			require.True(t, result.IsNull(0))
+
+			executor.ResetForNextQuery()
+			integer := "7"
+			result = eval(&integer, vector.PrepareParamInteger)
+			require.False(t, result.IsNull(0))
+			require.Equal(t, integer, result.GetStringAt(0))
+		})
+	}
+}
+
+func TestParamExpressionExecutorDoesNotCacheLookupFailure(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+
+	executor := NewParamExpressionExecutor(proc.Mp(), 0, types.T_varchar.ToType())
+	defer executor.Free()
+
+	var (
+		result *vector.Vector
+		err    error
+	)
+	func() {
+		emptyParams := vector.NewVec(types.T_varchar.ToType())
+		proc.SetPrepareParams(emptyParams)
+		defer func() {
+			proc.SetPrepareParams(nil)
+			emptyParams.Free(proc.Mp())
+		}()
+
+		result, err = executor.Eval(proc, nil, nil)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.False(t, executor.folded)
+	}()
+
+	params := vector.NewVec(types.T_varchar.ToType())
+	require.NoError(t, vector.AppendBytes(params, []byte("recovered"), false, proc.Mp()))
+	proc.SetPrepareParams(params)
+	defer func() {
+		proc.SetPrepareParams(nil)
+		params.Free(proc.Mp())
+	}()
+
+	result, err = executor.Eval(proc, nil, nil)
+	require.NoError(t, err)
+	require.True(t, executor.folded)
+	require.False(t, executor.foldedNull)
+	require.Equal(t, "recovered", result.GetStringAt(0))
+}
+
+func TestParamExpressionExecutorReevaluatesAfterResultTransfer(t *testing.T) {
+	tests := []struct {
+		name  string
+		null  bool
+		value string
+	}{
+		{name: "non-null", value: "repeated"},
+		{name: "null", null: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			defer proc.Free()
+
+			params := vector.NewVec(types.T_varchar.ToType())
+			require.NoError(t, vector.AppendBytes(params, []byte(test.value), test.null, proc.Mp()))
+			proc.SetPrepareParams(params)
+			defer func() {
+				proc.SetPrepareParams(nil)
+				params.Free(proc.Mp())
+			}()
+
+			executor := NewParamExpressionExecutor(proc.Mp(), 0, types.T_varchar.ToType())
+			defer executor.Free()
+
+			for i := 0; i < 2; i++ {
+				result, err := executor.EvalWithoutResultReusing(proc, nil, nil)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, test.null, result.IsNull(0))
+				if !test.null {
+					require.Equal(t, test.value, result.GetStringAt(0))
+				}
+				result.Free(proc.Mp())
+			}
+		})
+	}
+}
+
 func TestJsonOrderingWithTextPrepareParamExact(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/sql/colexec/mergetop/top_test.go
+++ b/pkg/sql/colexec/mergetop/top_test.go
@@ -148,6 +148,38 @@ func TestMergeTopMaxUint64LimitReturnsAllRows(t *testing.T) {
 	require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
 }
 
+func TestMergeTopReevaluatesPreparedOrderExpressionForEachBatch(t *testing.T) {
+	paramExpr := &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_varchar)},
+		Expr: &plan.Expr_P{P: &plan.ParamRef{Pos: 0}},
+	}
+	tc := newTestCase(t, []bool{false}, []types.Type{types.T_int64.ToType()}, 4,
+		[]*plan.OrderBySpec{{Expr: paramExpr}})
+
+	params := vector.NewVec(types.T_varchar.ToType())
+	require.NoError(t, vector.AppendBytes(params, []byte("same-key"), false, tc.proc.Mp()))
+	tc.proc.SetPrepareParams(params)
+	defer func() {
+		tc.proc.SetPrepareParams(nil)
+		params.Free(tc.proc.Mp())
+		tc.proc.Free()
+		require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
+	}()
+
+	require.NoError(t, tc.arg.Prepare(tc.proc))
+	resetChildren(tc.arg, []*batch.Batch{
+		newBatch(tc.types, tc.proc, 2),
+		newBatch(tc.types, tc.proc, 2),
+	})
+	defer tc.arg.GetChildren(0).Free(tc.proc, false, nil)
+	defer tc.arg.Free(tc.proc, false, nil)
+
+	result, err := vm.Exec(tc.arg, tc.proc)
+	require.NoError(t, err)
+	require.NotNil(t, result.Batch)
+	require.Equal(t, 4, result.Batch.RowCount())
+}
+
 func TestMergeTopFloatNaNLastAndPeerTieBreak(t *testing.T) {
 	tc := newTestCase(t, []bool{false, false}, []types.Type{types.T_float64.ToType(), types.T_int64.ToType()}, 5,
 		[]*plan.OrderBySpec{{Expr: newExpression(0)}, {Expr: newExpression(1)}})

--- a/pkg/tests/issues/issue_26874_test.go
+++ b/pkg/tests/issues/issue_26874_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	mysqlDriver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
+)
+
+func TestIssue26874BinaryPreparedStringAssignmentRecoversAfterNull(t *testing.T) {
+	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		dsn := fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/?interpolateParams=false", port)
+		db, err := sql.Open("mysql", dsn)
+		require.NoError(t, err)
+		defer db.Close()
+
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		dbName := testutils.GetDatabaseName(t)
+		mustExec(t, ctx, conn, fmt.Sprintf("create database `%s`", dbName))
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cleanupCancel()
+			_, _ = db.ExecContext(cleanupCtx, fmt.Sprintf("drop database if exists `%s`", dbName))
+		}()
+		mustExec(t, ctx, conn, fmt.Sprintf("use `%s`", dbName))
+		mustExec(t, ctx, conn, `create table nullable_strings(
+			id int primary key,
+			c char(20),
+			v varchar(20),
+			t tinytext,
+			plain text)`)
+
+		insertStmt, err := conn.PrepareContext(ctx,
+			"insert into nullable_strings values (?, ?, ?, ?, ?)")
+		require.NoError(t, err)
+		defer insertStmt.Close()
+		for _, args := range [][]any{
+			{1, "before-c", "before-v", "before-t", "before-text"},
+			{2, nil, nil, nil, nil},
+			{3, "after-c", "after-v", "after-t", "after-text"},
+			{4, int64(7), float64(8), true, "control-text"},
+		} {
+			_, err = insertStmt.ExecContext(ctx, args...)
+			require.NoError(t, err, "prepared insert args %v", args)
+		}
+		requireIssue26874Strings(t, ctx, conn, 3,
+			"after-c", "after-v", "after-t", "after-text")
+		requireIssue26874Strings(t, ctx, conn, 4,
+			"7", "8", "1", "control-text")
+
+		mustExec(t, ctx, conn, "insert into nullable_strings values (10, 'seed', 'seed', 'seed', 'seed')")
+		updateStmt, err := conn.PrepareContext(ctx,
+			"update nullable_strings set c=?, v=?, t=?, plain=? where id=10")
+		require.NoError(t, err)
+		defer updateStmt.Close()
+		for _, args := range [][]any{
+			{"first-c", "first-v", "first-t", "first-text"},
+			{nil, nil, nil, nil},
+			{"last-c", "last-v", "last-t", "last-text"},
+		} {
+			_, err = updateStmt.ExecContext(ctx, args...)
+			require.NoError(t, err, "prepared update args %v", args)
+		}
+		requireIssue26874Strings(t, ctx, conn, 10,
+			"last-c", "last-v", "last-t", "last-text")
+
+		mustExec(t, ctx, conn, "create table required_string(id int primary key, v varchar(4) not null)")
+		mustExec(t, ctx, conn, "insert into required_string values (1, 'seed')")
+		requiredStmt, err := conn.PrepareContext(ctx, "update required_string set v=? where id=1")
+		require.NoError(t, err)
+		defer requiredStmt.Close()
+		_, err = requiredStmt.ExecContext(ctx, nil)
+		requireIssue26874MySQLError(t, err, 3819)
+		_, err = requiredStmt.ExecContext(ctx, "okay")
+		require.NoError(t, err)
+		var required string
+		require.NoError(t, conn.QueryRowContext(ctx, "select v from required_string where id=1").Scan(&required))
+		require.Equal(t, "okay", required)
+
+		_, err = requiredStmt.ExecContext(ctx, "toolong")
+		requireIssue26874MySQLError(t, err, 1406)
+		_, err = requiredStmt.ExecContext(ctx, "done")
+		require.NoError(t, err)
+		require.NoError(t, conn.QueryRowContext(ctx, "select v from required_string where id=1").Scan(&required))
+		require.Equal(t, "done", required)
+	})
+}
+
+func requireIssue26874Strings(
+	t *testing.T,
+	ctx context.Context,
+	conn *sql.Conn,
+	id int,
+	wantChar, wantVarchar, wantTinyText, wantText string,
+) {
+	t.Helper()
+	var gotChar, gotVarchar, gotTinyText, gotText string
+	err := conn.QueryRowContext(ctx,
+		"select c, v, t, plain from nullable_strings where id=?", id).
+		Scan(&gotChar, &gotVarchar, &gotTinyText, &gotText)
+	require.NoError(t, err)
+	require.Equal(t, []string{wantChar, wantVarchar, wantTinyText, wantText},
+		[]string{gotChar, gotVarchar, gotTinyText, gotText})
+}
+
+func requireIssue26874MySQLError(t *testing.T, err error, number uint16) {
+	t.Helper()
+	require.Error(t, err)
+	var mysqlErr *mysqlDriver.MySQLError
+	require.ErrorAs(t, err, &mysqlErr)
+	require.Equal(t, number, mysqlErr.Number)
+}

--- a/test/distributed/cases/prepare/prepare_string_null_reset.result
+++ b/test/distributed/cases/prepare/prepare_string_null_reset.result
@@ -1,0 +1,99 @@
+drop database if exists prepared_string_null_reset;
+create database prepared_string_null_reset;
+use prepared_string_null_reset;
+create table string_values (
+id int primary key,
+c char(20),
+v varchar(20),
+t tinytext,
+plain text
+);
+prepare insert_values from 'insert into string_values values (?, ?, ?, ?, ?)';
+set @id = 1, @c = 'before-c', @v = 'before-v', @t = 'before-t', @plain = 'before-text';
+execute insert_values using @id, @c, @v, @t, @plain;
+set @id = 2, @c = null, @v = null, @t = null, @plain = null;
+execute insert_values using @id, @c, @v, @t, @plain;
+set @id = 3, @c = 'after-c', @v = 'after-v', @t = 'after-t', @plain = 'after-text';
+execute insert_values using @id, @c, @v, @t, @plain;
+set @id = 4, @c = 7, @v = 8.5, @t = true, @plain = 'control-text';
+execute insert_values using @id, @c, @v, @t, @plain;
+deallocate prepare insert_values;
+select id, ifnull(c, 'NULL'), ifnull(v, 'NULL'), ifnull(t, 'NULL'), ifnull(plain, 'NULL')
+from string_values order by id;
+➤ id[4,32,0]  ¦  ifnull(c, NULL)[12,20,0]  ¦  ifnull(v, NULL)[12,20,0]  ¦  ifnull(t, NULL)[12,0,0]  ¦  ifnull(plain, NULL)[12,0,0]  𝄀
+1  ¦  before-c  ¦  before-v  ¦  before-t  ¦  before-text  𝄀
+2  ¦  NULL  ¦  NULL  ¦  NULL  ¦  NULL  𝄀
+3  ¦  after-c  ¦  after-v  ¦  after-t  ¦  after-text  𝄀
+4  ¦  7  ¦  8.5  ¦  true  ¦  control-text
+insert into string_values values (10, 'seed', 'seed', 'seed', 'seed');
+prepare update_values from 'update string_values set c=?, v=?, t=?, plain=? where id=10';
+set @c = 'first-c', @v = 'first-v', @t = 'first-t', @plain = 'first-text';
+execute update_values using @c, @v, @t, @plain;
+set @c = null, @v = null, @t = null, @plain = null;
+execute update_values using @c, @v, @t, @plain;
+set @c = 'last-c', @v = 'last-v', @t = 'last-t', @plain = 'last-text';
+execute update_values using @c, @v, @t, @plain;
+deallocate prepare update_values;
+select id, c, v, t, plain from string_values where id = 10;
+➤ id[4,32,0]  ¦  c[1,20,0]  ¦  v[12,20,0]  ¦  t[-1,255,0]  ¦  plain[12,0,0]  𝄀
+10  ¦  last-c  ¦  last-v  ¦  last-t  ¦  last-text
+prepare replace_values from 'replace into string_values values (?, null, ?, null, ?)';
+set @id = 20, @v = 'replace-before', @plain = 'text-before';
+execute replace_values using @id, @v, @plain;
+set @id = 21, @v = null, @plain = null;
+execute replace_values using @id, @v, @plain;
+set @id = 22, @v = 'replace-after', @plain = 'text-after';
+execute replace_values using @id, @v, @plain;
+deallocate prepare replace_values;
+select id, ifnull(v, 'NULL'), ifnull(plain, 'NULL') from string_values where id between 20 and 22 order by id;
+➤ id[4,32,0]  ¦  ifnull(v, NULL)[12,20,0]  ¦  ifnull(plain, NULL)[12,0,0]  𝄀
+20  ¦  replace-before  ¦  text-before  𝄀
+21  ¦  NULL  ¦  NULL  𝄀
+22  ¦  replace-after  ¦  text-after
+prepare insert_select_values from 'insert into string_values(id, v, plain) select ?, ?, ?';
+set @id = 30, @v = 'select-before', @plain = 'text-before';
+execute insert_select_values using @id, @v, @plain;
+set @id = 31, @v = null, @plain = null;
+execute insert_select_values using @id, @v, @plain;
+set @id = 32, @v = 'select-after', @plain = 'text-after';
+execute insert_select_values using @id, @v, @plain;
+deallocate prepare insert_select_values;
+select id, ifnull(v, 'NULL'), ifnull(plain, 'NULL') from string_values where id between 30 and 32 order by id;
+➤ id[4,32,0]  ¦  ifnull(v, NULL)[12,20,0]  ¦  ifnull(plain, NULL)[12,0,0]  𝄀
+30  ¦  select-before  ¦  text-before  𝄀
+31  ¦  NULL  ¦  NULL  𝄀
+32  ¦  select-after  ¦  text-after
+insert into string_values(id, v, plain) values (40, 'seed', 'seed');
+prepare upsert_value from
+'insert into string_values(id, v, plain) values (40, ?, ?) on duplicate key update v=values(v), plain=values(plain)';
+set @v = 'upsert-before', @plain = 'text-before';
+execute upsert_value using @v, @plain;
+set @v = null, @plain = null;
+execute upsert_value using @v, @plain;
+set @v = 'upsert-after', @plain = 'text-after';
+execute upsert_value using @v, @plain;
+deallocate prepare upsert_value;
+select id, v, plain from string_values where id = 40;
+➤ id[4,32,0]  ¦  v[12,20,0]  ¦  plain[12,0,0]  𝄀
+40  ¦  upsert-after  ¦  text-after
+create table required_value (id int primary key, v varchar(4) not null);
+insert into required_value values (1, 'seed');
+prepare update_required from 'update required_value set v=? where id=1';
+set @v = null;
+execute update_required using @v;
+constraint violation: Column 'v' cannot be null
+set @v = 'okay';
+execute update_required using @v;
+select * from required_value;
+➤ id[4,32,0]  ¦  v[12,4,0]  𝄀
+1  ¦  okay
+set @v = 'toolong';
+execute update_required using @v;
+Data truncation: Can't cast 'toolong' to VARCHAR type. Src length 7 is larger than Dest length 4
+set @v = 'done';
+execute update_required using @v;
+select * from required_value;
+➤ id[4,32,0]  ¦  v[12,4,0]  𝄀
+1  ¦  done
+deallocate prepare update_required;
+drop database prepared_string_null_reset;

--- a/test/distributed/cases/prepare/prepare_string_null_reset.sql
+++ b/test/distributed/cases/prepare/prepare_string_null_reset.sql
@@ -1,0 +1,84 @@
+drop database if exists prepared_string_null_reset;
+create database prepared_string_null_reset;
+use prepared_string_null_reset;
+
+create table string_values (
+    id int primary key,
+    c char(20),
+    v varchar(20),
+    t tinytext,
+    plain text
+);
+
+prepare insert_values from 'insert into string_values values (?, ?, ?, ?, ?)';
+set @id = 1, @c = 'before-c', @v = 'before-v', @t = 'before-t', @plain = 'before-text';
+execute insert_values using @id, @c, @v, @t, @plain;
+set @id = 2, @c = null, @v = null, @t = null, @plain = null;
+execute insert_values using @id, @c, @v, @t, @plain;
+set @id = 3, @c = 'after-c', @v = 'after-v', @t = 'after-t', @plain = 'after-text';
+execute insert_values using @id, @c, @v, @t, @plain;
+set @id = 4, @c = 7, @v = 8.5, @t = true, @plain = 'control-text';
+execute insert_values using @id, @c, @v, @t, @plain;
+deallocate prepare insert_values;
+select id, ifnull(c, 'NULL'), ifnull(v, 'NULL'), ifnull(t, 'NULL'), ifnull(plain, 'NULL')
+from string_values order by id;
+
+insert into string_values values (10, 'seed', 'seed', 'seed', 'seed');
+prepare update_values from 'update string_values set c=?, v=?, t=?, plain=? where id=10';
+set @c = 'first-c', @v = 'first-v', @t = 'first-t', @plain = 'first-text';
+execute update_values using @c, @v, @t, @plain;
+set @c = null, @v = null, @t = null, @plain = null;
+execute update_values using @c, @v, @t, @plain;
+set @c = 'last-c', @v = 'last-v', @t = 'last-t', @plain = 'last-text';
+execute update_values using @c, @v, @t, @plain;
+deallocate prepare update_values;
+select id, c, v, t, plain from string_values where id = 10;
+
+prepare replace_values from 'replace into string_values values (?, null, ?, null, ?)';
+set @id = 20, @v = 'replace-before', @plain = 'text-before';
+execute replace_values using @id, @v, @plain;
+set @id = 21, @v = null, @plain = null;
+execute replace_values using @id, @v, @plain;
+set @id = 22, @v = 'replace-after', @plain = 'text-after';
+execute replace_values using @id, @v, @plain;
+deallocate prepare replace_values;
+select id, ifnull(v, 'NULL'), ifnull(plain, 'NULL') from string_values where id between 20 and 22 order by id;
+
+prepare insert_select_values from 'insert into string_values(id, v, plain) select ?, ?, ?';
+set @id = 30, @v = 'select-before', @plain = 'text-before';
+execute insert_select_values using @id, @v, @plain;
+set @id = 31, @v = null, @plain = null;
+execute insert_select_values using @id, @v, @plain;
+set @id = 32, @v = 'select-after', @plain = 'text-after';
+execute insert_select_values using @id, @v, @plain;
+deallocate prepare insert_select_values;
+select id, ifnull(v, 'NULL'), ifnull(plain, 'NULL') from string_values where id between 30 and 32 order by id;
+
+insert into string_values(id, v, plain) values (40, 'seed', 'seed');
+prepare upsert_value from
+    'insert into string_values(id, v, plain) values (40, ?, ?) on duplicate key update v=values(v), plain=values(plain)';
+set @v = 'upsert-before', @plain = 'text-before';
+execute upsert_value using @v, @plain;
+set @v = null, @plain = null;
+execute upsert_value using @v, @plain;
+set @v = 'upsert-after', @plain = 'text-after';
+execute upsert_value using @v, @plain;
+deallocate prepare upsert_value;
+select id, v, plain from string_values where id = 40;
+
+create table required_value (id int primary key, v varchar(4) not null);
+insert into required_value values (1, 'seed');
+prepare update_required from 'update required_value set v=? where id=1';
+set @v = null;
+execute update_required using @v;
+set @v = 'okay';
+execute update_required using @v;
+select * from required_value;
+set @v = 'toolong';
+execute update_required using @v;
+set @v = 'done';
+execute update_required using @v;
+select * from required_value;
+deallocate prepare update_required;
+
+drop database prepared_string_null_reset;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28138

## What this PR does / why we need it:

Cherry-picks #26915 to `4.2-dev` so a cached binary-protocol prepared statement does not reuse a NULL parameter shape after the same parameter is rebound to a non-NULL value.

The backport preserves the original production fix and regression coverage. Target-branch-only adaptations keep the existing MergeTop NaN test, use the equivalent TINYTEXT width literal because #26697 is not on `4.2-dev`, and exercise the same lookup-error path with an empty non-nil parameter vector because #26705 is not on `4.2-dev`.

Validation:

- focused colexec, MergeTop, and binary-protocol integration tests
- focused race tests (`-count=100`)
- owning-package normal and race tests
- `go vet` for all changed Go packages
- `make build`
- prepared-string NULL-reset BVT twice on the same clean instance: 68/68 passed each run