### PR TITLE
fix(snapshot): rebuild role privileges after restore

### DIFF
--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -95,8 +95,8 @@ var (
 
 	// systemCatalogRestorePolicies is the ownership boundary for mo_catalog
 	// restore semantics. Most catalog tables are either rebuilt by normal DDL or
-	// can be copied verbatim. Tables containing object IDs must opt into a
-	// post-copy transform instead of relying on incidental physical-ID equality.
+	// can be copied verbatim. Tables containing object IDs must opt into an
+	// owner rebuild instead of relying on incidental physical-ID equality.
 	systemCatalogRestorePolicies = map[string]systemCatalogRestorePolicy{
 		"mo_database":         systemCatalogRestoreSkip,
 		"mo_tables":           systemCatalogRestoreSkip,
@@ -117,7 +117,7 @@ var (
 		"mo_role":                       systemCatalogRestoreCopy,
 		"mo_user_grant":                 systemCatalogRestoreCopy,
 		"mo_role_grant":                 systemCatalogRestoreCopy,
-		"mo_role_privs":                 systemCatalogRestoreCopyThenTransform,
+		"mo_role_privs":                 systemCatalogRestoreRebuild,
 		"mo_role_rule":                  systemCatalogRestoreCopy,
 		"mo_user_defined_function":      systemCatalogRestoreCopy,
 		"mo_stored_procedure":           systemCatalogRestoreCopy,
@@ -1955,11 +1955,11 @@ func needSkipDb(dbName string) bool {
 func needSkipTable(accountId uint32, dbName string, tblName string) bool {
 	if accountId == sysAccountID {
 		policy, registered := systemCatalogRestorePolicies[tblName]
-		return dbName == moCatalog && registered && policy == systemCatalogRestoreSkip
+		return dbName == moCatalog && registered && policy.skipsBulkRestore()
 	} else {
 		if dbName == moCatalog {
 			if policy, ok := systemCatalogRestorePolicies[tblName]; ok {
-				return policy == systemCatalogRestoreSkip
+				return policy.skipsBulkRestore()
 			} else {
 				return true
 			}
@@ -1971,10 +1971,10 @@ func needSkipTable(accountId uint32, dbName string, tblName string) bool {
 func needSkipSystemTable(accountId uint32, tblinfo *tableInfo) bool {
 	if accountId == sysAccountID {
 		policy, registered := systemCatalogRestorePolicies[tblinfo.tblName]
-		return tblinfo.dbName == moCatalog && registered && policy == systemCatalogRestoreSkip
+		return tblinfo.dbName == moCatalog && registered && policy.skipsBulkRestore()
 	} else {
 		policy, registered := systemCatalogRestorePolicies[tblinfo.tblName]
-		return tblinfo.dbName == moCatalog && (tblinfo.typ == clusterTable || registered && policy == systemCatalogRestoreSkip)
+		return tblinfo.dbName == moCatalog && (tblinfo.typ == clusterTable || registered && policy.skipsBulkRestore())
 	}
 }
 

--- a/pkg/frontend/snapshot_catalog_restore.go
+++ b/pkg/frontend/snapshot_catalog_restore.go
@@ -35,10 +35,14 @@ const (
 	// systemCatalogRestoreCopy is safe only for catalog rows whose identifiers
 	// retain their meaning in the target account.
 	systemCatalogRestoreCopy
-	// systemCatalogRestoreCopyThenTransform copies the table first, then lets the
-	// table owner rebind identity-bearing columns after every object is restored.
-	systemCatalogRestoreCopyThenTransform
+	// systemCatalogRestoreRebuild skips the generic table copy and lets the table
+	// owner rebuild its rows after every referenced object is restored.
+	systemCatalogRestoreRebuild
 )
+
+func (policy systemCatalogRestorePolicy) skipsBulkRestore() bool {
+	return policy == systemCatalogRestoreSkip || policy == systemCatalogRestoreRebuild
+}
 
 type systemCatalogRestoreContext struct {
 	ctx           context.Context
@@ -63,7 +67,7 @@ type systemCatalogPostRestoreHandler struct {
 
 // The slice is deliberately ordered. To add another identity-bearing catalog:
 //
-//  1. mark it systemCatalogRestoreCopyThenTransform in the policy table;
+//  1. mark it systemCatalogRestoreRebuild in the policy table;
 //  2. register its owner-specific handler here, after any catalog it consumes;
 //  3. test both its ID semantics and every account-restore entry point.
 //
@@ -153,18 +157,18 @@ func restoreSystemCatalogsAfterObjects(
 func validateSystemCatalogRestoreHandlers(ctx context.Context) error {
 	registered := make(map[string]struct{}, len(systemCatalogPostRestoreHandlers))
 	for _, entry := range systemCatalogPostRestoreHandlers {
-		if systemCatalogRestorePolicies[entry.tableName] != systemCatalogRestoreCopyThenTransform {
-			return moerr.NewInternalErrorf(ctx, "catalog restore handler for %s has no transform policy", entry.tableName)
+		if systemCatalogRestorePolicies[entry.tableName] != systemCatalogRestoreRebuild {
+			return moerr.NewInternalErrorf(ctx, "catalog restore handler for %s has no rebuild policy", entry.tableName)
 		}
 		if _, exists := registered[entry.tableName]; exists {
-			return moerr.NewInternalErrorf(ctx, "catalog restore transform for %s has multiple handlers", entry.tableName)
+			return moerr.NewInternalErrorf(ctx, "catalog restore rebuild for %s has multiple handlers", entry.tableName)
 		}
 		registered[entry.tableName] = struct{}{}
 	}
 	for tableName, policy := range systemCatalogRestorePolicies {
-		if policy == systemCatalogRestoreCopyThenTransform {
+		if policy == systemCatalogRestoreRebuild {
 			if _, ok := registered[tableName]; !ok {
-				return moerr.NewInternalErrorf(ctx, "catalog restore transform for %s has no handler", tableName)
+				return moerr.NewInternalErrorf(ctx, "catalog restore rebuild for %s has no handler", tableName)
 			}
 		}
 	}

--- a/pkg/frontend/snapshot_catalog_restore_test.go
+++ b/pkg/frontend/snapshot_catalog_restore_test.go
@@ -260,17 +260,21 @@ func TestRemapRolePrivilegeObjectID(t *testing.T) {
 	}
 }
 
-func TestSystemCatalogTransformPoliciesHaveHandlers(t *testing.T) {
+func TestSystemCatalogRebuildPoliciesHaveHandlers(t *testing.T) {
 	require.NoError(t, validateSystemCatalogRestoreHandlers(t.Context()))
 	handlers := make(map[string]struct{}, len(systemCatalogPostRestoreHandlers))
 	for _, entry := range systemCatalogPostRestoreHandlers {
-		require.Equal(t, systemCatalogRestoreCopyThenTransform, systemCatalogRestorePolicies[entry.tableName])
+		require.Equal(t, systemCatalogRestoreRebuild, systemCatalogRestorePolicies[entry.tableName])
+		require.True(t, needSkipTable(sysAccountID, moCatalog, entry.tableName))
+		require.True(t, needSkipSystemTable(sysAccountID, &tableInfo{
+			dbName: moCatalog, tblName: entry.tableName, typ: "BASE TABLE",
+		}))
 		_, duplicate := handlers[entry.tableName]
 		require.False(t, duplicate)
 		handlers[entry.tableName] = struct{}{}
 	}
 	for tableName, policy := range systemCatalogRestorePolicies {
-		if policy == systemCatalogRestoreCopyThenTransform {
+		if policy == systemCatalogRestoreRebuild {
 			_, ok := handlers[tableName]
 			require.Truef(t, ok, "missing restore handler for %s", tableName)
 		}
@@ -287,10 +291,10 @@ func TestValidateSystemCatalogRestoreHandlersRejectsIncompleteRegistry(t *testin
 		slices.Clone(originalHandlers),
 		systemCatalogPostRestoreHandler{tableName: "mo_user"},
 	)
-	require.ErrorContains(t, validateSystemCatalogRestoreHandlers(t.Context()), "has no transform policy")
+	require.ErrorContains(t, validateSystemCatalogRestoreHandlers(t.Context()), "has no rebuild policy")
 	require.ErrorContains(t,
 		restoreSystemCatalogsAfterObjects(t.Context(), "", nil, 0, 0, 0),
-		"has no transform policy",
+		"has no rebuild policy",
 	)
 
 	systemCatalogPostRestoreHandlers = append(slices.Clone(originalHandlers), originalHandlers[0])
@@ -307,7 +311,7 @@ func TestValidateSystemCatalogRestoreHandlersRejectsIncompleteRegistry(t *testin
 
 	systemCatalogPostRestoreHandlers = originalHandlers
 	originalPolicy := systemCatalogRestorePolicies["mo_user"]
-	systemCatalogRestorePolicies["mo_user"] = systemCatalogRestoreCopyThenTransform
+	systemCatalogRestorePolicies["mo_user"] = systemCatalogRestoreRebuild
 	t.Cleanup(func() {
 		systemCatalogRestorePolicies["mo_user"] = originalPolicy
 	})

--- a/test/distributed/cases/snapshot/cluster_level_snapshot_restore_to_sys_account.result
+++ b/test/distributed/cases/snapshot/cluster_level_snapshot_restore_to_sys_account.result
@@ -494,8 +494,14 @@ drop database test02;
 drop database test03;
 drop snapshot snap01;
 drop snapshot if exists sp05;
+drop role if exists issue_28206_snapshot_role;
+drop role if exists issue_28206_post_snapshot_role;
+create role issue_28206_snapshot_role;
+grant create database on account * to issue_28206_snapshot_role;
 create snapshot sp05 for cluster;
 create database db01;
+create role issue_28206_post_snapshot_role;
+grant create database on account * to issue_28206_post_snapshot_role;
 restore account sys{snapshot="sp05"};
 show databases;
 Database
@@ -507,7 +513,23 @@ mo_task
 mysql
 system
 system_metrics
+select count(*) from mo_catalog.mo_role where role_name = 'issue_28206_snapshot_role';
+count(*)
+1
+select count(*) from mo_catalog.mo_role where role_name = 'issue_28206_post_snapshot_role';
+count(*)
+0
+select count(*) from mo_catalog.mo_role_privs
+where role_name = 'issue_28206_snapshot_role' and privilege_name = 'create database';
+count(*)
+1
+select count(*) from mo_catalog.mo_role_privs
+where role_name = 'issue_28206_post_snapshot_role' and privilege_name = 'create database';
+count(*)
+0
 drop snapshot sp05;
+drop role issue_28206_snapshot_role;
+drop role if exists issue_28206_post_snapshot_role;
 drop database if exists db01;
 create database db01;
 use db01;

--- a/test/distributed/cases/snapshot/cluster_level_snapshot_restore_to_sys_account.sql
+++ b/test/distributed/cases/snapshot/cluster_level_snapshot_restore_to_sys_account.sql
@@ -310,11 +310,25 @@ drop snapshot snap01;
 
 -- restore null
 drop snapshot if exists sp05;
+drop role if exists issue_28206_snapshot_role;
+drop role if exists issue_28206_post_snapshot_role;
+create role issue_28206_snapshot_role;
+grant create database on account * to issue_28206_snapshot_role;
 create snapshot sp05 for cluster;
 create database db01;
+create role issue_28206_post_snapshot_role;
+grant create database on account * to issue_28206_post_snapshot_role;
 restore account sys{snapshot="sp05"};
 show databases;
+select count(*) from mo_catalog.mo_role where role_name = 'issue_28206_snapshot_role';
+select count(*) from mo_catalog.mo_role where role_name = 'issue_28206_post_snapshot_role';
+select count(*) from mo_catalog.mo_role_privs
+where role_name = 'issue_28206_snapshot_role' and privilege_name = 'create database';
+select count(*) from mo_catalog.mo_role_privs
+where role_name = 'issue_28206_post_snapshot_role' and privilege_name = 'create database';
 drop snapshot sp05;
+drop role issue_28206_snapshot_role;
+drop role if exists issue_28206_post_snapshot_role;
 
 
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28206

## What this PR does / why we need it:

### Root cause

Account restore treated `mo_role_privs` as both a generic copy target and an owner-rebuilt catalog. The generic phase dropped, recreated, and copied the table; the post-object handler then deleted its rows and rebuilt privileges with restored object IDs. In one transaction, DistTAE could consequently find both the old system-catalog row and the newly inserted row for `mo_catalog.mo_role_privs`, violating `deleteTable`'s unique catalog-row invariant and panicking.

### Changes

- Define owner-rebuilt system catalogs as a distinct restore policy which skips generic bulk restore.
- Apply that policy to `mo_role_privs`; its existing post-object handler remains the sole owner of privilege restoration and ID remapping.
- Centralize the bulk-skip predicate and validate that every rebuild policy has exactly one registered handler.
- Extend the cluster snapshot BVT to prove both removal of post-snapshot privileges and preservation of snapshot privileges.

### Issue-to-test proof

- `TestSystemCatalogRebuildPoliciesHaveHandlers` proves owner-rebuilt catalogs cannot re-enter either generic catalog-restore discovery path and that each has exactly one handler.
- `TestValidateSystemCatalogRestoreHandlersRejectsIncompleteRegistry` proves incomplete and duplicate ownership declarations fail closed.
- `cluster_level_snapshot_restore_to_sys_account.sql` exercises the reported cluster snapshot sequence, verifies `db01` is removed, verifies the snapshot role privilege is restored, and verifies the post-snapshot role privilege is removed.

### Tests

- `make build`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=15m ./pkg/frontend`
- Target BVT on the rebased commit through Proxy: 393/393 statements passed.
- The same target BVT also passed twice consecutively before the final rebase; teardown queries confirmed zero residual test roles, privileges, snapshots, and `db01` rows.
- Exact-head CI: Ubuntu/x86 UT, Linux/arm64 SCA, UT coverage, multi-CN Compose/Proxy BVT, and multi-CN Compose/Pessimistic BVT passed.

### Residual risks

The restore transaction and DistTAE uniqueness invariant are unchanged. The policy change removes one redundant catalog recreation and does not alter privilege remapping or transaction boundaries. Exact-head multi-CN CI closes the topology-specific validation gap from the local environment.
