### PR TITLE
test(iceberg): stop waiter polling after context deadline

### DIFF
--- a/test/iceberg/iceberg_e2e_local.go
+++ b/test/iceberg/iceberg_e2e_local.go
@@ -862,6 +862,12 @@ func waitForLifecycleFaultWaiters(ctx context.Context, db *sql.DB, waitersPoint 
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
+		// A slow query or instrumented test run can make the ticker and
+		// context deadline ready at the same time. Do not start another
+		// database poll after the context has expired.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		rows, err := queryLines(ctx, db, fmt.Sprintf("select trigger_fault_point(%s)", sqlString(waitersPoint)))
 		if err != nil {
 			return err

--- a/test/iceberg/iceberg_e2e_local_test.go
+++ b/test/iceberg/iceberg_e2e_local_test.go
@@ -857,6 +857,20 @@ func TestLocalE2EWaitForLifecycleFaultWaitersHonorsDeadline(t *testing.T) {
 	}
 }
 
+func TestLocalE2EWaitForLifecycleFaultWaitersStopsBeforePollingCanceledContext(t *testing.T) {
+	db, mock := newLocalE2ESQLMock(t)
+	defer db.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := waitForLifecycleFaultWaiters(ctx, db, icebergCreateAfterCatalogLockWaitersFault, 1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("lifecycle fault waiter ignored canceled context: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("canceled lifecycle-fault waiter issued a query: %v", err)
+	}
+}
+
 func TestLocalE2EConcurrentCreateMappingAndDropCaseReportsCleanupFailure(t *testing.T) {
 	db, mock := newLocalE2ESQLMock(t)
 	defer db.Close()

--- a/test/iceberg/iceberg_e2e_local_test.go
+++ b/test/iceberg/iceberg_e2e_local_test.go
@@ -842,18 +842,25 @@ func TestLocalE2EWaitForLifecycleFaultWaitersRejectsInvalidResponses(t *testing.
 	}
 }
 
-func TestLocalE2EWaitForLifecycleFaultWaitersHonorsDeadline(t *testing.T) {
-	db, mock := newLocalE2ESQLMock(t)
-	defer db.Close()
-	mock.ExpectQuery("select trigger_fault_point").
-		WillReturnRows(sqlmock.NewRows([]string{"waiters"}).AddRow(int64(0)))
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
-	defer cancel()
-	if err := waitForLifecycleFaultWaiters(ctx, db, icebergCreateAfterCatalogLockWaitersFault, 1); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("lifecycle fault waiter ignored deadline: %v", err)
+func TestLocalE2EWaitForLifecycleFaultWaitersStopsAfterPollingCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	driver := &lifecycleWaiterTestDriver{
+		cancel:           cancel,
+		firstQueryClosed: make(chan struct{}),
 	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Fatalf("lifecycle-fault waiter deadline expectation: %v", err)
+	db := sql.OpenDB(driver)
+	defer db.Close()
+
+	if err := waitForLifecycleFaultWaiters(ctx, db, icebergCreateAfterCatalogLockWaitersFault, 1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("lifecycle fault waiter ignored cancellation after polling: %v", err)
+	}
+	select {
+	case <-driver.firstQueryClosed:
+	default:
+		t.Fatal("lifecycle fault waiter returned before completing the first query")
+	}
+	if got := driver.queryCount(); got != 1 {
+		t.Fatalf("lifecycle fault waiter issued %d queries after cancellation", got)
 	}
 }
 
@@ -1115,6 +1122,82 @@ func TestLocalE2ERestoreSessionLockWaitTimeoutFailureDiscardsConnection(t *testi
 type sessionTimeoutTestDriver struct {
 	mu    sync.Mutex
 	conns []*sessionTimeoutTestConn
+}
+
+type lifecycleWaiterTestDriver struct {
+	mu               sync.Mutex
+	queries          int
+	cancel           context.CancelFunc
+	firstQueryClosed chan struct{}
+}
+
+func (d *lifecycleWaiterTestDriver) Connect(context.Context) (driver.Conn, error) {
+	return &lifecycleWaiterTestConn{driver: d}, nil
+}
+
+func (d *lifecycleWaiterTestDriver) Driver() driver.Driver { return d }
+
+func (d *lifecycleWaiterTestDriver) Open(string) (driver.Conn, error) {
+	return d.Connect(context.Background())
+}
+
+func (d *lifecycleWaiterTestDriver) recordQuery() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.queries++
+	return d.queries == 1
+}
+
+func (d *lifecycleWaiterTestDriver) queryCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.queries
+}
+
+type lifecycleWaiterTestConn struct {
+	driver *lifecycleWaiterTestDriver
+}
+
+func (c *lifecycleWaiterTestConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not supported by lifecycle waiter test driver")
+}
+
+func (c *lifecycleWaiterTestConn) Close() error { return nil }
+
+func (c *lifecycleWaiterTestConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not supported by lifecycle waiter test driver")
+}
+
+func (c *lifecycleWaiterTestConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	if !c.driver.recordQuery() {
+		return nil, errors.New("unexpected lifecycle waiter query after cancellation")
+	}
+	return &lifecycleWaiterTestRows{driver: c.driver}, nil
+}
+
+type lifecycleWaiterTestRows struct {
+	driver   *lifecycleWaiterTestDriver
+	closed   sync.Once
+	returned bool
+}
+
+func (r *lifecycleWaiterTestRows) Columns() []string { return []string{"waiters"} }
+
+func (r *lifecycleWaiterTestRows) Close() error {
+	r.closed.Do(func() {
+		close(r.driver.firstQueryClosed)
+		r.driver.cancel()
+	})
+	return nil
+}
+
+func (r *lifecycleWaiterTestRows) Next(dest []driver.Value) error {
+	if r.returned {
+		return io.EOF
+	}
+	dest[0] = int64(0)
+	r.returned = true
+	return nil
 }
 
 func (d *sessionTimeoutTestDriver) Connect(context.Context) (driver.Conn, error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28260

## What this PR does / why we need it:

### Root cause

`waitForLifecycleFaultWaiters` issues an immediate `trigger_fault_point` query, then waits on a 10 ms ticker or the caller context. Under coverage or a slow scheduler, the query and wait can run long enough for both the ticker and the context deadline to be ready. The select may choose the ticker, and the next loop issued another query without checking the expired context. The deadline regression test has exactly one SQL mock expectation, so that extra poll became the reported unexpected query instead of the expected `context.DeadlineExceeded`.

### Changes

- Check `ctx.Err()` before every lifecycle waiter SQL poll.
- Replace the scheduler-dependent 2 ms deadline regression with a deterministic test driver: the first poll returns a zero waiter count, completing the driver rows cancels the context, and the test verifies that no second poll is issued.
- Keep an already-canceled-context regression test proving that the guard issues no query when the context is already done.
- Keep the existing polling interval, successful waiter-count path, database-error path, and response parsing unchanged.

This is a test-harness-only lifecycle barrier change; it does not change MatrixOne SQL, catalog, or protocol behavior.

### Issue-to-test proof

- `#28260`: `TestLocalE2EWaitForLifecycleFaultWaitersStopsAfterPollingCanceledContext` completes exactly one zero-waiter query, cancels the context from the controlled driver's row-close barrier, asserts `context.Canceled`, and verifies the helper issued no second poll. This covers the expired-context path after a completed poll without relying on scheduler timing.
- The directly related guard path is covered by `TestLocalE2EWaitForLifecycleFaultWaitersStopsBeforePollingCanceledContext`, which passes an already-canceled context, asserts `context.Canceled`, and verifies that no SQL query was issued.
- Existing `TestLocalE2EWaitForLifecycleFaultWaiters` and `TestLocalE2EWaitForLifecycleFaultWaitersRejectsInvalidResponses` continue to cover the success, query failure, empty response, and invalid count paths.

BVT is not applicable: the changed function is an internal test E2E barrier and no public SQL or protocol contract changed.

### Tests run

Using `.agents/skills/mo-dev/scripts/mo-cgo-test` with the repository CGo/native test setup:

- `-list TestLocalE2EWaitForLifecycleFaultWaitersStopsAfterPollingCanceledContext|TestLocalE2EWaitForLifecycleFaultWaitersStopsBeforePollingCanceledContext|TestLocalE2EWaitForLifecycleFaultWaiters`
- focused waiter tests, normal `-count=100`, race `-count=100`, and coverage `-count=100`
- full `./test/iceberg` package, normal, coverage, and race modes (`-count=1`)
- `go vet -mod=readonly ./test/iceberg`

All completed successfully. The CGo test wrapper reused a clean, provenance-verified Darwin/arm64 native build with matching tracked native inputs. The pre-fix CI evidence is run `33961743746`, diagnostic artifact `9968464979`; it recorded the exact extra-query failure in `test/iceberg` with zero build failures.

### Residual risks

The helper still uses its existing 10 ms polling interval and real database fault-point query in the local E2E scenario. The change only suppresses polls after context cancellation/deadline, so it has no production runtime or compatibility impact. The local verification used Darwin/arm64 with a clean native artifact whose tracked `Makefile`, `cgo`, and `thirdparties` inputs matched this checkout; the all-package Linux coverage workload remains a CI validation boundary.
