### PR TITLE
fix(compile): close materialized sources per attempt

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -884,28 +884,29 @@ func (c *Compile) printPipeline() {
 // for example
 // 1. lock table.
 // 2. init data source.
-func (c *Compile) prePipelineInitializer() (err error) {
+func (c *Compile) prePipelineInitializer() (startedSources []*materialized.Source, err error) {
 	// do table lock.
 	if err = c.lockMeta.doLock(c.e, c.proc); err != nil {
-		return err
+		return nil, err
 	}
 	if err = c.lockTable(); err != nil {
-		return err
+		return nil, err
 	}
 	if err = c.maybePromoteLoadUniqueIndexes(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// init data source.
 	for _, s := range c.scopes {
 		if err = s.InitAllDataSource(c); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	var spillBudget materialized.SpillBudget
 	if len(c.materializedSources) > 0 {
 		spillBudget = newMaterializedSpillBudget(c.proc)
 	}
+	startedSources = make([]*materialized.Source, 0, len(c.materializedSources))
 	for _, source := range c.materializedSources {
 		if err = source.Begin(c.proc.Mp(), materialized.SpillConfig{FileFactory: func(name string) (*os.File, error) {
 			spillFS, spillErr := c.proc.GetSpillFileService()
@@ -914,10 +915,30 @@ func (c *Compile) prePipelineInitializer() (err error) {
 			}
 			return spillFS.CreateAndRemoveFile(c.proc.Ctx, name)
 		}, Budget: spillBudget}); err != nil {
-			return err
+			return startedSources, err
 		}
+		startedSources = append(startedSources, source)
 	}
-	return nil
+	return startedSources, nil
+}
+
+func closeMaterializedSourceGenerations(sources []*materialized.Source) {
+	for _, source := range sources {
+		source.Close()
+	}
+}
+
+// runPipelineAttempt owns every materialized-source generation opened by its
+// initializer. The callback may start no scopes, return an error, or panic;
+// after it returns, all submitted scope goroutines have quiesced and the
+// attempt closes both executed and statically planned-but-unstarted owners.
+func (c *Compile) runPipelineAttempt(run func() error) (err error) {
+	startedSources, err := c.prePipelineInitializer()
+	defer closeMaterializedSourceGenerations(startedSources)
+	if err != nil {
+		return err
+	}
+	return run()
 }
 
 func newMaterializedSpillBudget(proc *process.Process) materialized.SpillBudget {

--- a/pkg/sql/compile/compile2.go
+++ b/pkg/sql/compile/compile2.go
@@ -453,22 +453,22 @@ func (c *Compile) Run(_ uint64) (queryResult *util2.RunResult, err error) {
 			allocationAttempt, err = runC.beginAllocationAccountAttempt()
 		}
 		if err == nil {
-			err = runC.prePipelineInitializer()
-		}
-		if err == nil {
-			preRunWall = carriedPreRunWall + time.Since(preRunOnceStart)
-			attemptPreRunWall = preRunWall
-			runC.MessageBoard.BeforeRunonce()
-			// Calculate time spent between the start and runOnce execution
-			if !isInExecutor {
-				stats.StoreCompilePreRunOnceDuration(time.Since(preRunOnceStart))
-			}
-			coordinatorPhaseStart = time.Time{}
-			coordinatorPhaseBase = 0
+			err = runC.runPipelineAttempt(func() error {
+				preRunWall = carriedPreRunWall + time.Since(preRunOnceStart)
+				attemptPreRunWall = preRunWall
+				runC.MessageBoard.BeforeRunonce()
+				// Calculate time spent between the start and runOnce execution
+				if !isInExecutor {
+					stats.StoreCompilePreRunOnceDuration(time.Since(preRunOnceStart))
+				}
+				coordinatorPhaseStart = time.Time{}
+				coordinatorPhaseBase = 0
 
-			if err = runC.runOnce(); err == nil {
-				err = runC.proc.GetQueryContextError()
-			}
+				if runErr := runC.runOnce(); runErr != nil {
+					return runErr
+				}
+				return runC.proc.GetQueryContextError()
+			})
 			if err == nil {
 				if runC.anal != nil {
 					runC.anal.retryTimes = retryTimes

--- a/pkg/sql/compile/cte_sink_fanout_test.go
+++ b/pkg/sql/compile/cte_sink_fanout_test.go
@@ -129,6 +129,74 @@ func TestCTESinkFanoutRegistersEveryConsumer(t *testing.T) {
 	require.Same(t, leftScan.MaterializedSource, fanout.MaterializedSource)
 }
 
+func TestPipelineAttemptAlwaysClosesMaterializedSources(t *testing.T) {
+	wantErr := moerr.NewInternalErrorNoCtx("execution failed before operator cleanup")
+	tests := []struct {
+		name    string
+		run     func(*Compile, *materialized.Source) error
+		wantErr error
+	}{
+		{
+			name: "lazy branch leaves one reader unstarted",
+			run: func(c *Compile, source *materialized.Source) error {
+				// The producer and one reader completed, while LIMIT stopped a
+				// lazy UNION ALL before its later reader branch was submitted.
+				source.Finish(nil)
+				source.ReleaseReader(0)
+				return c.runOnce()
+			},
+		},
+		{
+			name: "execution fails before operators reset",
+			run: func(_ *Compile, _ *materialized.Source) error {
+				return wantErr
+			},
+			wantErr: wantErr,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := NewMockCompile(t)
+			c.pn = &plan.Plan{Plan: &plan.Plan_Query{Query: &plan.Query{}}}
+			c.lockMeta = NewLockMeta()
+			source := materialized.NewSource(2)
+			c.materializedSources = map[int32]*materialized.Source{0: source}
+
+			err := c.runPipelineAttempt(func() error { return test.run(c, source) })
+			if test.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, test.wantErr)
+			}
+
+			// A prepared compile reuses this Source. Every attempt outcome must
+			// leave the next generation equivalent to a fresh source.
+			require.NoError(t, source.Begin(c.proc.Mp()))
+			source.Finish(nil)
+			source.ReleaseReader(0)
+			source.ReleaseReader(1)
+		})
+	}
+}
+
+func TestPipelineAttemptClosesMaterializedSourcesAfterPanic(t *testing.T) {
+	c := NewMockCompile(t)
+	c.lockMeta = NewLockMeta()
+	source := materialized.NewSource(1)
+	c.materializedSources = map[int32]*materialized.Source{0: source}
+	wantPanic := "pipeline panic"
+
+	func() {
+		defer func() { require.Equal(t, wantPanic, recover()) }()
+		_ = c.runPipelineAttempt(func() error { panic(wantPanic) })
+	}()
+
+	require.NoError(t, source.Begin(c.proc.Mp()))
+	source.Finish(nil)
+	source.ReleaseReader(0)
+}
+
 func TestMaterializedCTESinkGroupsShuffleBucketsByCN(t *testing.T) {
 	c := NewMockCompile(t)
 	c.cnList = engine.Nodes{

--- a/pkg/sql/internal/materialized/source.go
+++ b/pkg/sql/internal/materialized/source.go
@@ -130,7 +130,9 @@ func (s *Source) Begin(mp *mpool.MPool, spillConfig ...SpillConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.active && !s.allReleasedLocked() {
-		return moerr.NewInternalErrorNoCtx("materialized sink source reused before all owners released")
+		return moerr.NewInternalErrorNoCtxf(
+			"materialized sink source reused before all owners released: generation=%d producer_released=%t unreleased_readers=%v",
+			s.generation, s.producerReleased, s.unreleasedReaderIDsLocked())
 	}
 	s.cleanLocked()
 	s.generation++
@@ -486,6 +488,9 @@ func (s *Source) Close() {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if !s.active {
+		return
+	}
 	s.cleanLocked()
 	s.generation++
 	s.active = false
@@ -495,6 +500,16 @@ func (s *Source) Close() {
 		s.readerReleased[i] = true
 	}
 	s.wakeLocked()
+}
+
+func (s *Source) unreleasedReaderIDsLocked() []int {
+	unreleased := make([]int, 0, len(s.readerReleased))
+	for readerID, released := range s.readerReleased {
+		if !released {
+			unreleased = append(unreleased, readerID)
+		}
+	}
+	return unreleased
 }
 
 func (s *Source) wakeLocked() {

--- a/pkg/sql/internal/materialized/source_test.go
+++ b/pkg/sql/internal/materialized/source_test.go
@@ -210,6 +210,32 @@ func TestSharedMaterializedSourceCancellationAndReuse(t *testing.T) {
 	source.ReleaseReader(0)
 }
 
+func TestSharedMaterializedSourceReuseErrorIdentifiesOwners(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() { mpool.DeleteMPool(mp) })
+	source := NewSource(2)
+	require.NoError(t, source.Begin(mp))
+
+	err := source.Begin(mp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "generation=1")
+	require.Contains(t, err.Error(), "producer_released=false")
+	require.Contains(t, err.Error(), "unreleased_readers=[0 1]")
+
+	source.Finish(nil)
+	source.ReleaseReader(0)
+	err = source.Begin(mp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "producer_released=true")
+	require.Contains(t, err.Error(), "unreleased_readers=[1]")
+
+	source.Close()
+	require.NoError(t, source.Begin(mp))
+	source.Finish(nil)
+	source.ReleaseReader(0)
+	source.ReleaseReader(1)
+}
+
 func TestSharedMaterializedSourceCancellationWhileWaiting(t *testing.T) {
 	mp := mpool.MustNewZeroNoFixed()
 	t.Cleanup(func() { mpool.DeleteMPool(mp) })

--- a/test/distributed/cases/metadata/information_schema.result
+++ b/test/distributed/cases/metadata/information_schema.result
@@ -162,4 +162,15 @@ ordinal_position    column_name    data_type
 1    a    int
 2    b    int
 3    v    varchar
+set @metadata_schema = 'information_schema_data_type_case';
+set @metadata_table = 'composite_pk_probe';
+set @metadata_column = 'v';
+prepare metadata_limit_reuse from 'select column_name from information_schema.columns where table_schema = ? and table_name = ? and column_name = ? limit 1';
+execute metadata_limit_reuse using @metadata_schema, @metadata_table, @metadata_column;
+column_name
+v
+execute metadata_limit_reuse using @metadata_schema, @metadata_table, @metadata_column;
+column_name
+v
+deallocate prepare metadata_limit_reuse;
 drop database information_schema_data_type_case;

--- a/test/distributed/cases/metadata/information_schema.sql
+++ b/test/distributed/cases/metadata/information_schema.sql
@@ -76,4 +76,15 @@ from information_schema.columns
 where table_schema = 'information_schema_data_type_case'
   and table_name = 'composite_pk_probe'
 order by ordinal_position;
+
+-- LIMIT may stop a lazy UNION ALL before every statically planned
+-- materialized-CTE reader starts. Reusing the prepared plan must still begin a
+-- fresh source generation.
+set @metadata_schema = 'information_schema_data_type_case';
+set @metadata_table = 'composite_pk_probe';
+set @metadata_column = 'v';
+prepare metadata_limit_reuse from 'select column_name from information_schema.columns where table_schema = ? and table_name = ? and column_name = ? limit 1';
+execute metadata_limit_reuse using @metadata_schema, @metadata_table, @metadata_column;
+execute metadata_limit_reuse using @metadata_schema, @metadata_table, @metadata_column;
+deallocate prepare metadata_limit_reuse;
 drop database information_schema_data_type_case;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28266

## What this PR does / why we need it:

A prepared information_schema.COLUMNS lookup with LIMIT can stop lazy UNION ALL before all statically planned readers of the shared mo_current_roles CTE start. Operator Reset therefore cannot release those unstarted readers, and the next prepared execution rejects the still-active materialized source generation.

This change makes one pipeline execution attempt the final owner of every materialized generation it successfully opens. Operator cleanup remains the eager path; an attempt-level deferred cleanup closes skipped readers on success, initialization or execution errors, and panics. Partial initialization returns only sources opened by that attempt, so an active source owned elsewhere is never closed accidentally.

The reuse error now reports the generation and unreleased owner IDs. Normal already-released generations use a fast no-op Close, and planner materialization plus lazy UNION behavior remain unchanged.

## Validation

- make build
- full normal tests for ./pkg/sql/internal/materialized and ./pkg/sql/compile
- full race tests for both owning packages
- go vet for both owning packages
- repeated focused race tests for success, execution-error, panic, cancellation, and prepared-reuse lifecycle cases
- fresh quickstart black-box execution of the exact parameterized information_schema.COLUMNS LIMIT query across hit, miss, repeated execution, and schema recreation
- EXPLAIN confirms mo_current_roles materialization, UNION ALL, LIMIT, and Sink Scan reuse remain enabled
- distributed metadata regression executes the prepared query twice on one connection