### PR TITLE
fix(frontend): keep data branch update staging retryable

### DIFF
--- a/pkg/frontend/data_branch_helpers.go
+++ b/pkg/frontend/data_branch_helpers.go
@@ -45,6 +45,8 @@ import (
 
 var snapConditionRegex = regexp.MustCompile(`\{[^}]+}`)
 
+const dataBranchApplyTablePrefix = "__mo_diff_"
+
 func isDataBranchFloatType(typ types.Type) bool {
 	return typ.Oid == types.T_float32 || typ.Oid == types.T_float64
 }
@@ -125,8 +127,7 @@ func compareDataBranchPrimaryKeyInVectors(
 }
 
 func containsDataBranchTempTableName(sqlLower string) bool {
-	return containsTempTableMarker(sqlLower, "__mo_diff_del_") ||
-		containsTempTableMarker(sqlLower, "__mo_diff_ins_")
+	return containsTempTableMarker(sqlLower, dataBranchApplyTablePrefix)
 }
 
 func dataBranchTempSQLNeedsBackExec(sqlLower string) bool {

--- a/pkg/frontend/data_branch_helpers.go
+++ b/pkg/frontend/data_branch_helpers.go
@@ -126,87 +126,6 @@ func compareDataBranchPrimaryKeyInVectors(
 	return 0, nil
 }
 
-func containsDataBranchTempTableName(sqlLower string) bool {
-	return containsTempTableMarker(sqlLower, dataBranchApplyTablePrefix)
-}
-
-func dataBranchTempSQLNeedsBackExec(sqlLower string) bool {
-	return containsDataBranchTempTableName(sqlLower)
-}
-
-func containsTempTableMarker(sqlLower, marker string) bool {
-	for idx := 0; idx < len(sqlLower); idx++ {
-		switch sqlLower[idx] {
-		case '\'', '"':
-			idx = skipSQLQuotedLiteral(sqlLower, idx, sqlLower[idx]) - 1
-			continue
-		case '-':
-			if idx+1 < len(sqlLower) && sqlLower[idx+1] == '-' {
-				idx = skipSQLLineComment(sqlLower, idx+2) - 1
-				continue
-			}
-		case '#':
-			idx = skipSQLLineComment(sqlLower, idx+1) - 1
-			continue
-		case '/':
-			if idx+1 < len(sqlLower) && sqlLower[idx+1] == '*' {
-				idx = skipSQLBlockComment(sqlLower, idx+2) - 1
-				continue
-			}
-		}
-		if strings.HasPrefix(sqlLower[idx:], marker) && isSQLIdentifierBoundary(sqlLower, idx) {
-			return true
-		}
-	}
-	return false
-}
-
-func skipSQLQuotedLiteral(sql string, start int, quote byte) int {
-	for idx := start + 1; idx < len(sql); idx++ {
-		if sql[idx] == '\\' {
-			idx++
-			continue
-		}
-		if sql[idx] == quote {
-			if idx+1 < len(sql) && sql[idx+1] == quote {
-				idx++
-				continue
-			}
-			return idx + 1
-		}
-	}
-	return len(sql)
-}
-
-func skipSQLLineComment(sql string, start int) int {
-	for idx := start; idx < len(sql); idx++ {
-		if sql[idx] == '\n' || sql[idx] == '\r' {
-			return idx + 1
-		}
-	}
-	return len(sql)
-}
-
-func skipSQLBlockComment(sql string, start int) int {
-	for idx := start; idx+1 < len(sql); idx++ {
-		if sql[idx] == '*' && sql[idx+1] == '/' {
-			return idx + 2
-		}
-	}
-	return len(sql)
-}
-
-func isSQLIdentifierBoundary(sql string, idx int) bool {
-	return idx == 0 || !isSQLIdentifierChar(sql[idx-1])
-}
-
-func isSQLIdentifierChar(ch byte) bool {
-	return ch == '_' ||
-		ch >= '0' && ch <= '9' ||
-		ch >= 'a' && ch <= 'z' ||
-		ch >= 'A' && ch <= 'Z'
-}
-
 func acquireBuffer(pool *sync.Pool) *bytes.Buffer {
 	if pool == nil {
 		return &bytes.Buffer{}
@@ -284,11 +203,6 @@ func runSqlWithMode(
 	trimmedLower := strings.ToLower(strings.TrimSpace(sql))
 	if !useBackExec && strings.HasPrefix(trimmedLower, "drop database") {
 		// Internal executor does not support DROP DATABASE (IsPublishing panics).
-		useBackExec = true
-	} else if !useBackExec && dataBranchTempSQLNeedsBackExec(trimmedLower) {
-		// Branch diff/merge/pick temp tables do repeated DDL/DML in one shared txn.
-		// The internal SQL fast path skips per-statement workspace increments and can
-		// hit ErrTxnNeedRetryWithDefChanged in RC mode while these temp definitions churn.
 		useBackExec = true
 	} else if !useBackExec && strings.Contains(strings.ToLower(snapConditionRegex.FindString(sql)), "snapshot") {
 		// SQLExecutor cannot resolve snapshot by name.

--- a/pkg/frontend/data_branch_helpers_test.go
+++ b/pkg/frontend/data_branch_helpers_test.go
@@ -195,6 +195,16 @@ func TestDataBranchTempSQLNeedsBackExec(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "update temp table",
+			sql:  "insert into `db1`.`__mo_diff_upd_x` values (1, 'new', 1)",
+			want: true,
+		},
+		{
+			name: "main table update reads temp table",
+			sql:  "update `db1`.`base` as branch_apply_base join `db1`.`__mo_diff_upd_x` as branch_apply_stage on branch_apply_base.`id` = branch_apply_stage.`branch_apply_key_0` set branch_apply_base.`name` = branch_apply_stage.`name`",
+			want: true,
+		},
+		{
 			name: "unknown temp table statement stays conservative",
 			sql:  "select * from test.__mo_diff_ins_merge_1",
 			want: true,

--- a/pkg/frontend/data_branch_helpers_test.go
+++ b/pkg/frontend/data_branch_helpers_test.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"bytes"
 	"context"
-	"strings"
 	"sync"
 	"testing"
 
@@ -140,89 +139,6 @@ func TestNewEmitter(t *testing.T) {
 	require.Equal(t, wrapped, <-retCh)
 }
 
-func TestContainsDataBranchTempTableName(t *testing.T) {
-	require.True(t, containsDataBranchTempTableName("delete from test.__mo_diff_del_merge_1"))
-	require.True(t, containsDataBranchTempTableName("insert into __mo_diff_ins_merge_1 values (1)"))
-	require.True(t, containsDataBranchTempTableName("drop table if exists `db1`.`__mo_diff_del_x`"))
-	require.False(t, containsDataBranchTempTableName("select '__mo_diff_del_merge_1'"))
-	require.False(t, containsDataBranchTempTableName("select 1 -- from __mo_diff_del_merge_1"))
-}
-
-func TestDataBranchTempSQLNeedsBackExec(t *testing.T) {
-	tests := []struct {
-		name string
-		sql  string
-		want bool
-	}{
-		{
-			name: "drop temp table",
-			sql:  "drop table if exists test.__mo_diff_del_merge_1",
-			want: true,
-		},
-		{
-			name: "create temp table",
-			sql:  "create table test.__mo_diff_ins_merge_1 as select id from test.t where 1 = 0",
-			want: true,
-		},
-		{
-			name: "insert into temp table",
-			sql:  "insert into test.__mo_diff_del_merge_1 values (1)",
-			want: true,
-		},
-		{
-			name: "delete from temp table",
-			sql:  "delete from test.__mo_diff_ins_merge_1",
-			want: true,
-		},
-		{
-			name: "quoted drop temp table",
-			sql:  "drop table if exists `db1`.`__mo_diff_del_x`",
-			want: true,
-		},
-		{
-			name: "quoted insert into temp table",
-			sql:  "insert into `db1`.`__mo_diff_del_x` values (1)",
-			want: true,
-		},
-		{
-			name: "main table delete reads temp table",
-			sql:  "delete from `db1`.`base` where `id` in (select `branch_apply_key_0` from `db1`.`__mo_diff_del_x`)",
-			want: true,
-		},
-		{
-			name: "main table insert reads temp table",
-			sql:  "insert into `db1`.`base` (`id`, `name`) select `id`, `name` from `db1`.`__mo_diff_ins_x`",
-			want: true,
-		},
-		{
-			name: "update temp table",
-			sql:  "insert into `db1`.`__mo_diff_upd_x` values (1, 'new', 1)",
-			want: true,
-		},
-		{
-			name: "main table update reads temp table",
-			sql:  "update `db1`.`base` as branch_apply_base join `db1`.`__mo_diff_upd_x` as branch_apply_stage on branch_apply_base.`id` = branch_apply_stage.`branch_apply_key_0` set branch_apply_base.`name` = branch_apply_stage.`name`",
-			want: true,
-		},
-		{
-			name: "unknown temp table statement stays conservative",
-			sql:  "select * from test.__mo_diff_ins_merge_1",
-			want: true,
-		},
-		{
-			name: "ordinary statement",
-			sql:  "delete from test.orders where id = 1",
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, dataBranchTempSQLNeedsBackExec(strings.ToLower(tt.sql)))
-		})
-	}
-}
-
 func TestRunSQL_BackgroundExecPaths(t *testing.T) {
 	ses := newValidateSession(t)
 
@@ -258,7 +174,7 @@ func TestRunSQL_BackgroundExecPaths(t *testing.T) {
 	})
 }
 
-func TestRunSQL_DataBranchTempTablesUseBackgroundExec(t *testing.T) {
+func TestExecRetryableSQLStatementsUsesBackgroundExec(t *testing.T) {
 	tests := []struct {
 		name string
 		sql  string
@@ -274,6 +190,14 @@ func TestRunSQL_DataBranchTempTablesUseBackgroundExec(t *testing.T) {
 		{
 			name: "insert main table using diff insert table",
 			sql:  "insert into `db1`.`base` (`id`, `name`) select `id`, `name` from `db1`.`__mo_diff_ins_x`",
+		},
+		{
+			name: "insert update staging row",
+			sql:  "insert into `db1`.`__mo_diff_upd_x` values (1, 'new', 1)",
+		},
+		{
+			name: "update main table using diff update table",
+			sql:  "update `db1`.`base` as branch_apply_base join `db1`.`__mo_diff_upd_x` as branch_apply_stage on branch_apply_base.`id` = branch_apply_stage.`branch_apply_key_0` set branch_apply_base.`name` = branch_apply_stage.`name`",
 		},
 	}
 
@@ -291,23 +215,34 @@ func TestRunSQL_DataBranchTempTablesUseBackgroundExec(t *testing.T) {
 			bh.EXPECT().GetExecResultSet().Return(nil).Times(1)
 			bh.EXPECT().ClearExecResultSet().Times(1)
 
-			_, err := runSql(context.Background(), ses, bh, tt.sql, nil, nil)
+			err := execRetryableSQLStatements(context.Background(), ses, bh, nil, []string{tt.sql})
 			require.NoError(t, err)
 			require.Empty(t, spyExec.sql)
 		})
 	}
 }
 
-func TestRunSQL_DataBranchOrdinaryMainTableDMLUsesInternalExec(t *testing.T) {
-	ses := newValidateSession(t)
-	spyExec := &pickStreamingExecutor{}
-	bh := newPickStreamingBackExecForTest(t, ses, spyExec)
+func TestRunSQL_DataBranchUserIdentifiersUseInternalExec(t *testing.T) {
+	statements := []string{
+		"delete from test.orders where id = 1",
+		"select * from test.__mo_diff_orders",
+		"select * from `__mo_diff_orders`.`orders`",
+		"select __mo_diff_flag from test.orders",
+		"select * from test.__mo_diff_upd_orders",
+	}
 
-	stmt := "delete from test.orders where id = 1"
-	ret, err := runSql(context.Background(), ses, bh, stmt, nil, nil)
-	require.NoError(t, err)
-	ret.Close()
-	require.Equal(t, stmt, spyExec.sql)
+	for _, stmt := range statements {
+		t.Run(stmt, func(t *testing.T) {
+			ses := newValidateSession(t)
+			spyExec := &pickStreamingExecutor{}
+			bh := newPickStreamingBackExecForTest(t, ses, spyExec)
+
+			ret, err := runSql(context.Background(), ses, bh, stmt, nil, nil)
+			require.NoError(t, err)
+			ret.Close()
+			require.Equal(t, stmt, spyExec.sql)
+		})
+	}
 }
 
 func TestScanSnapshotRelationByID_EarlyAndErrorPaths(t *testing.T) {

--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -264,9 +264,9 @@ func newApplyBatchInfo(
 	return &applyBatchInfo{
 		dbName:                 tblStuff.baseRel.GetTableDef(ctx).DbName,
 		baseTable:              tblStuff.baseRel.GetTableName(),
-		deleteTable:            fmt.Sprintf("__mo_diff_del_%s_%d", sessionTag, seq),
-		insertTable:            fmt.Sprintf("__mo_diff_ins_%s_%d", sessionTag, seq),
-		updateTable:            fmt.Sprintf("__mo_diff_upd_%s_%d", sessionTag, seq),
+		deleteTable:            fmt.Sprintf(dataBranchApplyTablePrefix+"del_%s_%d", sessionTag, seq),
+		insertTable:            fmt.Sprintf(dataBranchApplyTablePrefix+"ins_%s_%d", sessionTag, seq),
+		updateTable:            fmt.Sprintf(dataBranchApplyTablePrefix+"upd_%s_%d", sessionTag, seq),
 		deleteKeyNames:         deleteKeyNames,
 		deleteStageNames:       deleteStageNames,
 		deleteKeyTypes:         deleteKeyTypes,

--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -2846,6 +2846,27 @@ func execSQLStatements(
 	writeFile func([]byte) error,
 	stmts []string,
 ) error {
+	return execSQLStatementsWithMode(ctx, ses, bh, writeFile, stmts, false)
+}
+
+func execRetryableSQLStatements(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	writeFile func([]byte) error,
+	stmts []string,
+) error {
+	return execSQLStatementsWithMode(ctx, ses, bh, writeFile, stmts, true)
+}
+
+func execSQLStatementsWithMode(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	writeFile func([]byte) error,
+	stmts []string,
+	retryable bool,
+) error {
 	for _, stmt := range stmts {
 		if stmt == "" {
 			continue
@@ -2856,7 +2877,15 @@ func execSQLStatements(
 			}
 			continue
 		}
-		ret, err := runSql(ctx, ses, bh, stmt, nil, nil)
+		var (
+			ret executor.Result
+			err error
+		)
+		if retryable {
+			ret, err = runSqlWithBackExec(ctx, ses, bh, stmt)
+		} else {
+			ret, err = runSql(ctx, ses, bh, stmt, nil, nil)
+		}
 		if len(ret.Batches) > 0 && ret.Mp != nil {
 			ret.Close()
 		}
@@ -2923,7 +2952,7 @@ func initApplyTables(
 		)
 	}
 
-	return execSQLStatements(ctx, ses, bh, writeFile, stmts)
+	return execRetryableSQLStatements(ctx, ses, bh, writeFile, stmts)
 }
 
 func dropApplyTables(
@@ -2950,7 +2979,7 @@ func dropApplyTables(
 			fmt.Sprintf("drop table if exists %s", updateTable),
 		)
 	}
-	return execSQLStatements(ctx, ses, bh, writeFile, stmts)
+	return execRetryableSQLStatements(ctx, ses, bh, writeFile, stmts)
 }
 
 func flushStagedUpdateValues(
@@ -2987,7 +3016,7 @@ func flushStagedUpdateValues(
 	}
 	stmts = append(stmts, specialUpdateStmts...)
 	stmts = append(stmts, clearStmt)
-	return execSQLStatements(ctx, ses, bh, writeFile, stmts)
+	return execRetryableSQLStatements(ctx, ses, bh, writeFile, stmts)
 }
 
 // if `writeFile` is not nil, the sql will be flushed down into this file, or
@@ -3041,7 +3070,7 @@ func flushSqlValues(
 				return err
 			}
 			clearStmt := fmt.Sprintf("delete from %s", deleteTable)
-			return execSQLStatements(ctx, ses, bh, writeFile, []string{insertStmt, deleteStmt, clearStmt})
+			return execRetryableSQLStatements(ctx, ses, bh, writeFile, []string{insertStmt, deleteStmt, clearStmt})
 		}
 
 		if !batchInfo.disableInsertStage {
@@ -3052,7 +3081,7 @@ func flushSqlValues(
 				baseTable, cols, cols, insertTable,
 			)
 			clearStmt := fmt.Sprintf("delete from %s", insertTable)
-			return execSQLStatements(ctx, ses, bh, writeFile, []string{insertStmt, applyStmt, clearStmt})
+			return execRetryableSQLStatements(ctx, ses, bh, writeFile, []string{insertStmt, applyStmt, clearStmt})
 		}
 	}
 

--- a/pkg/tests/dml/dml_test.go
+++ b/pkg/tests/dml/dml_test.go
@@ -203,6 +203,9 @@ func TestDataBranchDiffAsFile(t *testing.T) {
 			t.Run("csv_rich_types_round_trip", func(t *testing.T) {
 				runCSVLoadRichTypes(t, ctx, sqlDB, dbName)
 			})
+			t.Run("csv_user_diff_prefix_identifier", func(t *testing.T) {
+				runCSVUserDiffPrefixIdentifier(t, ctx, sqlDB, dbName)
+			})
 			t.Run("output_limit_subset", func(t *testing.T) {
 				runDiffOutputLimitSubset(t, ctx, sqlDB, dbName)
 			})
@@ -797,6 +800,32 @@ insert into %s values
 	diffPath := execDiffAndFetchFile(t, ctx, db, diffStmt)
 	require.Equal(t, ".csv", filepath.Ext(diffPath))
 	require.True(t, strings.HasPrefix(diffPath, diffDir), "diff file %s not in dir %s", diffPath, diffDir)
+
+	loadDiffCSVIntoTable(t, ctx, db, base, diffPath)
+	assertTablesEqual(t, ctx, db, dbName, target, base)
+}
+
+func runCSVUserDiffPrefixIdentifier(t *testing.T, parentCtx context.Context, db *sql.DB, dbName string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(parentCtx, time.Second*90)
+	defer cancel()
+
+	base := "user_prefix_csv_base"
+	target := "__mo_diff_orders"
+	diffDir := t.TempDir()
+	diffLiteral := strings.ReplaceAll(diffDir, "'", "''")
+
+	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` (id int primary key, value varchar(32))", base))
+	execSQLDB(t, ctx, db, fmt.Sprintf("create table `%s` like `%s`", target, base))
+	execSQLDB(t, ctx, db, fmt.Sprintf("insert into `%s` values (1, 'first'), (2, 'second')", target))
+
+	diffStmt := fmt.Sprintf("data branch diff `%s` against `%s` output file '%s'", target, base, diffLiteral)
+	diffPath := execDiffAndFetchFile(t, ctx, db, diffStmt)
+	require.Equal(t, ".csv", filepath.Ext(diffPath))
+
+	records := readDiffCSVFile(t, diffPath)
+	require.ElementsMatch(t, [][]string{{"1", "first"}, {"2", "second"}}, records)
 
 	loadDiffCSVIntoTable(t, ctx, db, base, diffPath)
 	assertTablesEqual(t, ctx, db, dbName, target, base)

--- a/test/distributed/cases/git4data/branch/pick/pick_5.result
+++ b/test/distributed/cases/git4data/branch/pick/pick_5.result
@@ -125,4 +125,23 @@ select * from t1 order by a asc;
 drop table pick_keys;
 drop table t1;
 drop table t2;
+create table user_prefix_base (a int primary key, b int);
+insert into user_prefix_base values (1,10);
+data branch create table user_prefix_src from user_prefix_base;
+data branch create table user_prefix_dst from user_prefix_base;
+insert into user_prefix_src values (2,20),(3,30);
+create database __mo_diff_orders;
+create table __mo_diff_orders.__mo_diff_keys (__mo_diff_flag int);
+insert into __mo_diff_orders.__mo_diff_keys values (2),(3);
+data branch pick user_prefix_src into user_prefix_dst
+keys(select __mo_diff_flag from __mo_diff_orders.__mo_diff_keys);
+select * from user_prefix_dst order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  10  𝄀
+2  ¦  20  𝄀
+3  ¦  30
+drop database __mo_diff_orders;
+drop table user_prefix_base;
+drop table user_prefix_src;
+drop table user_prefix_dst;
 drop database test;

--- a/test/distributed/cases/git4data/branch/pick/pick_5.sql
+++ b/test/distributed/cases/git4data/branch/pick/pick_5.sql
@@ -155,4 +155,27 @@ drop table pick_keys;
 drop table t1;
 drop table t2;
 
+-- ----------------------------------------------------------------
+-- case 8: user identifiers sharing the internal diff prefix still stream
+-- ----------------------------------------------------------------
+
+create table user_prefix_base (a int primary key, b int);
+insert into user_prefix_base values (1,10);
+data branch create table user_prefix_src from user_prefix_base;
+data branch create table user_prefix_dst from user_prefix_base;
+insert into user_prefix_src values (2,20),(3,30);
+
+create database __mo_diff_orders;
+create table __mo_diff_orders.__mo_diff_keys (__mo_diff_flag int);
+insert into __mo_diff_orders.__mo_diff_keys values (2),(3);
+
+data branch pick user_prefix_src into user_prefix_dst
+keys(select __mo_diff_flag from __mo_diff_orders.__mo_diff_keys);
+select * from user_prefix_dst order by a;
+
+drop database __mo_diff_orders;
+drop table user_prefix_base;
+drop table user_prefix_src;
+drop table user_prefix_dst;
+
 drop database test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #24099

## What this PR does / why we need it:

### Root cause

Data branch merge applies row diffs through generated staging-table DDL and DML. The generic internal SQL executor disables statement increments, so it also bypasses the existing compile retry for `ErrTxnNeedRetryWithDefChanged`. Under multi-CN pessimistic catalog contention, that error could therefore escape from an apply statement.

The prior routing recognized delete and insert staging names by re-parsing SQL text. Extending that predicate to every `__mo_diff_` identifier fixed update staging but also classified legitimate user database, table, and column names. Streaming CSV diff and PICK callers discard collected BackExec batches and consume their stream channels, so such misclassification could silently lose rows and materialize an otherwise streamed result.

### Changes

- Keep one shared prefix for generated delete, insert, and update apply-table names.
- Remove execution-mode inference from SQL text.
- Make the apply-table owner explicitly execute staging DDL/DML through the existing retry-capable frontend statement path, including update-stage INSERT and base-table UPDATE JOIN statements.
- Keep generic user SQL on the internal streaming path, including identifiers beginning with `__mo_diff_`.
- Add public CSV and PICK regressions for ordinary user identifiers sharing that prefix.

Retry remains owned by the existing statement/compile boundary; this PR does not replay the merge transaction or add a retry loop.

### Issue-to-test proof

- Before the correction, focused tests showed every user `__mo_diff_*` database/table/column case entering BackExec and failing before the streaming executor was reached. The final unit cases prove those statements stay on internal execution while all generated delete/insert/update staging forms use BackExec.
- `TestDataBranchDiffAsFile/csv_user_diff_prefix_identifier` proves two CSV rows are streamed, reloaded, and equal to a user table named `__mo_diff_orders`.
- `pick_5.sql` proves a KEYS subquery using database `__mo_diff_orders`, table `__mo_diff_keys`, and column `__mo_diff_flag` preserves and applies rows 2 and 3. The checked-in result was inspected and matches the intended final rows 1, 2, and 3.
- Existing `merge_1.sql` covers the reported `DATA BRANCH MERGE t2 INTO t1` reproduction. `merge_schema_evolve.sql` covers insert/update/delete, composite-key, schema-evolution, rejection, and atomicity boundaries.

### Tests run

- `make build` — passed.
- Full CGo-enabled `pkg/frontend` — passed (`30.769s` on latest rebased head).
- Full CGo-enabled `pkg/sql/compile` — passed (`7.786s` on latest rebased head).
- Focused final-head routing and output tests — passed.
- Embedded-cluster CSV streaming regression — passed (`13.449s` on latest rebased head).
- Local BVT `pick_5.sql`, twice on the same instance — `94/94` each run; both error reports were empty.
- Local BVT `merge_1.sql`, substring-matched `merge_10.sql`, and `merge_schema_evolve.sql` — `244/244`; the error report was empty.

### Rebase follow-up

- Rebased onto `origin/main` at `109bf926fd` without conflicts. `git range-diff` shows both PR commits are patch-identical after the rebase.
- The new base adds shared-computation reuse for analytic plans. It does not overlap this PR's six files, but it changes the compile execution dependency used by the retry path, so frontend and compile evidence was treated as stale.
- On rebased head `6893b29606`, the focused routing/output tests, full frontend and compile packages, and embedded CSV streaming regression all passed. The pushed head also restarts repository CI, including multi-CN PESSIMISTIC BVT.

### Residual risks

The catalog conflict is nondeterministic. Deterministic unit coverage proves retry-capable routing for every generated apply family, while end-to-end BVT proves merge and streaming semantics. The pushed head will also run the repository's multi-CN PESSIMISTIC CI. No storage format, transaction-level retry, concurrency state, or resource ownership changes are introduced; #24099 remains open for manual validation.
