### PR TITLE
feat: support ordinary functional indexes (#28053)

### DIFF
--- a/docs/rfcs/20260904_functional_indexes.md
+++ b/docs/rfcs/20260904_functional_indexes.md
@@ -168,8 +168,8 @@ access is disabled for functional indexes in the first release. Missing or
 malformed metadata fails closed to a normal table scan.
 
 Functional-index creation is gated on the cluster's oldest-live protocol
-capability. The implementation reserves the next available MORPC capability
-(version 46 at the start of this work) so a mixed-version CN cannot publish
+capability. The implementation reserves MORPC capability version 48 (the
+current main already uses 46 and 47) so a mixed-version CN cannot publish
 metadata it cannot render or safely alter.
 
 ### DDL foundation from #28052

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -37,6 +37,11 @@ const (
 	Row_ID           = objectio.PhysicalAddr_Attr
 	PrefixPriColName = "__mo_cpkey_"
 	PrefixCBColName  = "__mo_cbkey_"
+	// FunctionalIndexColumnPrefix identifies the generated column owned by a
+	// functional index.  The column is persisted in the catalog so the normal
+	// generated-column and secondary-index maintenance paths can be reused, but
+	// it is never part of the user-visible schema.
+	FunctionalIndexColumnPrefix = "__mo_fi_"
 
 	// Wildcard characters for partition subtable name
 	PartitionSubTableWildcard = "\\%!\\%%\\%!\\%%"
@@ -245,6 +250,12 @@ func IsReservedExternalColName(name string) bool {
 		return true
 	}
 	return false
+}
+
+// IsFunctionalIndexColumnName reports whether name belongs to the reserved
+// namespace used for hidden functional-index generated columns.
+func IsFunctionalIndexColumnName(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), FunctionalIndexColumnPrefix)
 }
 
 func IsHiddenTable(name string) bool {

--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -94,7 +94,8 @@ const (
 	MORPCVersion56     int64 = 56 // session-scoped AUTO_INCREMENT increment/offset and provenance
 	MORPCVersion57     int64 = 57 // Arrow LOAD external-scan pipeline payload
 	MORPCVersion58     int64 = 58 // binary-string function semantics and runtime-domain metadata
-	MORPCLatestVersion       = MORPCVersion58
+	MORPCVersion59     int64 = 59 // functional-index hidden generated-column contract
+	MORPCLatestVersion       = MORPCVersion59
 )
 
 // DefaultLockWaitTimeoutSeconds is shared by the frontend default and by

--- a/pkg/queryservice/client/query_client_test.go
+++ b/pkg/queryservice/client/query_client_test.go
@@ -35,7 +35,7 @@ func TestMongoDBClientRetireRequiresProtocolVersion5(t *testing.T) {
 }
 
 func TestRefreshSessionAuthRequiresCurrentProtocolVersion(t *testing.T) {
-	assert.Equal(t, defines.MORPCVersion58, defines.MORPCLatestVersion)
+	assert.Equal(t, defines.MORPCVersion59, defines.MORPCLatestVersion)
 	assert.Equal(t, defines.MORPCVersion54, methodVersions[query.CmdMethod_RefreshSessionAuth])
 	assert.GreaterOrEqual(t, defines.MORPCLatestVersion, methodVersions[query.CmdMethod_RefreshSessionAuth])
 }

--- a/pkg/sql/colexec/index_metadata.go
+++ b/pkg/sql/colexec/index_metadata.go
@@ -339,7 +339,11 @@ func buildInsertIndexMetaBatch(tableId uint64, databaseId uint64, ct *engine.Con
 					if err != nil {
 						return nil, err
 					}
-					err = vector.AppendFixed(vec_hidden, int8(0), false, proc.Mp())
+					hidden := int8(0)
+					if catalog.IsFunctionalIndexColumnName(part) {
+						hidden = 1
+					}
+					err = vector.AppendFixed(vec_hidden, hidden, false, proc.Mp())
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/sql/compile/util.go
+++ b/pkg/sql/compile/util.go
@@ -311,8 +311,14 @@ func genInsertMOIndexesSql(eg engine.Engine, proc *process.Process, databaseId s
 					}
 					fmt.Fprintf(buffer, "%d, ", visible)
 
-					// 10. index vec_hidden
-					fmt.Fprintf(buffer, "%d, ", INDEX_HIDDEN_NO)
+					// 10. index vec_hidden. A functional key part is backed by
+					// a reserved hidden generated column; keep the physical name
+					// in mo_indexes while marking it hidden for SHOW INDEX.
+					hidden := INDEX_HIDDEN_NO
+					if catalog.IsFunctionalIndexColumnName(catalog.ResolveAlias(part)) {
+						hidden = INDEX_HIDDEN_YES
+					}
+					fmt.Fprintf(buffer, "%d, ", hidden)
 
 					// 11. index vec_comment
 					fmt.Fprintf(buffer, "%s, ", sqlquote.String(indexDef.Comment))

--- a/pkg/sql/compile/util_mo_indexes_test.go
+++ b/pkg/sql/compile/util_mo_indexes_test.go
@@ -170,3 +170,28 @@ func TestGenInsertMOIndexesSqlPersistsInvisibleIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, sql, "'', '', '', 0, 0, '', 'a', 1, "+NULL_VALUE+", "+NULL_VALUE)
 }
+
+func TestGenInsertMOIndexesSqlMarksFunctionalKeyPartHidden(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEngine := mock_frontend.NewMockEngine(ctrl)
+	mockEngine.EXPECT().AllocateIDByKey(gomock.Any(), ALLOCID_INDEX_KEY).Return(uint64(272512), nil)
+
+	proc := testutil.NewProc(t)
+	hiddenName := catalog.FunctionalIndexColumnPrefix + "0123456789abcdef0123456789abcdef"
+	tableDef := &plan.TableDef{
+		Name2ColIndex: map[string]int32{hiddenName: 0},
+		Cols:          []*plan.ColDef{{Name: hiddenName, OriginName: hiddenName}},
+	}
+	ct := &engine.ConstraintDef{Cts: []engine.Constraint{&engine.IndexDef{Indexes: []*plan.IndexDef{{
+		IndexName:  "idx_expr",
+		Parts:      []string{hiddenName, catalog.CreateAlias("id")},
+		TableExist: true,
+	}}}}}
+
+	sql, err := genInsertMOIndexesSql(mockEngine, proc, "123456", 272466, ct, tableDef)
+	require.NoError(t, err)
+	require.Contains(t, sql, "1, 1, '', '"+hiddenName+"', 1")
+	require.Contains(t, sql, "1, 0, '', '__mo_alias_id', 2")
+}

--- a/pkg/sql/parsers/tree/create.go
+++ b/pkg/sql/parsers/tree/create.go
@@ -1776,6 +1776,16 @@ type KeyPart struct {
 }
 
 func (node *KeyPart) Format(ctx *FmtCtx) {
+	if node.Expr != nil {
+		ctx.WriteByte('(')
+		node.Expr.Format(ctx)
+		ctx.WriteByte(')')
+		if node.Direction != DefaultDirection {
+			ctx.WriteByte(' ')
+			ctx.WriteString(node.Direction.String())
+		}
+		return
+	}
 	if node.ColName != nil {
 		node.ColName.Format(ctx)
 	}
@@ -1792,15 +1802,6 @@ func (node *KeyPart) Format(ctx *FmtCtx) {
 		ctx.WriteByte(' ')
 		ctx.WriteString(node.Direction.String())
 		return
-	}
-	if node.Expr != nil {
-		ctx.WriteByte('(')
-		node.Expr.Format(ctx)
-		ctx.WriteByte(')')
-		if node.Direction != DefaultDirection {
-			ctx.WriteByte(' ')
-			ctx.WriteString(node.Direction.String())
-		}
 	}
 }
 

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -2197,6 +2197,9 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 	if len(node.FilterList) == 0 || len(node.TableDef.Indexes) == 0 {
 		return nodeID
 	}
+	if functionalID, applied := builder.applyFunctionalIndexEquality(nodeID, node); applied {
+		return functionalID
+	}
 
 	forceIndex := builder.scanHintsForceIndexes(node)
 	for i := range node.FilterList { // if already have filter on first pk column and have a good selectivity, no need to go index
@@ -2364,6 +2367,73 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 
 	//no index applied
 	return nodeID
+}
+
+// applyFunctionalIndexEquality handles the deliberately narrow v1 functional
+// index rule. The generated expression is replaced only in a private clone of
+// the equality used to probe the index table; the original predicate remains
+// on the base-table scan as a residual, so malformed/stale metadata can never
+// change query results. Range, IN, OR and covering/index-only paths are left to
+// the ordinary planner and therefore fail closed.
+func (builder *QueryBuilder) applyFunctionalIndexEquality(nodeID int32, node *plan.Node) (int32, bool) {
+	if builder == nil || node == nil || node.TableDef == nil || len(node.BindingTags) == 0 {
+		return nodeID, false
+	}
+	indexes := make([]*IndexDef, 0)
+	for _, idxDef := range node.TableDef.Indexes {
+		if idxDef == nil || !idxDef.TableExist || !isFunctionalIndexDef(node.TableDef, idxDef) {
+			continue
+		}
+		indexes = append(indexes, idxDef)
+	}
+	indexes = builder.filterRegularIndexesByScanHints(node, indexes)
+	if len(indexes) == 0 {
+		return nodeID, false
+	}
+	scanSnapshot := node.ScanSnapshot
+	if scanSnapshot == nil {
+		scanSnapshot = &Snapshot{}
+	}
+	for _, idxDef := range indexes {
+		generated, hiddenPos, ok := functionalIndexQueryExpr(node.TableDef, idxDef)
+		if !ok {
+			continue
+		}
+		for filterIdx, filter := range node.FilterList {
+			fn := filter.GetF()
+			if fn == nil || fn.Func == nil || fn.Func.ObjName != "=" || len(fn.Args) != 2 {
+				continue
+			}
+			columnArg, constantArg := fn.Args[0], fn.Args[1]
+			if columnArg == nil || constantArg == nil {
+				continue
+			}
+			if isRuntimeConstExpr(columnArg) && !isRuntimeConstExpr(constantArg) {
+				columnArg, constantArg = constantArg, columnArg
+			}
+			if isRuntimeConstExpr(columnArg) || !isRuntimeConstExpr(constantArg) || !functionalExpressionMatches(generated, columnArg) {
+				continue
+			}
+			probe := DeepCopyExpr(filter)
+			probeFn := probe.GetF()
+			if probeFn == nil || len(probeFn.Args) != 2 {
+				continue
+			}
+			if isRuntimeConstExpr(probeFn.Args[0]) {
+				probeFn.Args[0], probeFn.Args[1] = probeFn.Args[1], probeFn.Args[0]
+			}
+			probeFn.Args[0] = GetColExpr(node.TableDef.Cols[hiddenPos].Typ, node.BindingTags[0], hiddenPos)
+			original := node.FilterList[filterIdx]
+			node.FilterList[filterIdx] = probe
+			joinedID, indexScanID := builder.applyIndexJoin(idxDef, node, EqualIndexCondition, []int32{int32(filterIdx)}, scanSnapshot)
+			node.FilterList[filterIdx] = original
+			if indexScanID != -1 {
+				builder.applyExtraFiltersOnIndex(idxDef, node, builder.qry.Nodes[indexScanID], []int32{int32(filterIdx)})
+				return joinedID, true
+			}
+		}
+	}
+	return nodeID, false
 }
 
 func (builder *QueryBuilder) applyExtraFiltersOnIndex(idxDef *IndexDef, node *plan.Node, idxTableNode *plan.Node, filterIdx []int32) {

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -2414,6 +2414,9 @@ func (builder *QueryBuilder) applyFunctionalIndexEquality(nodeID int32, node *pl
 			if isRuntimeConstExpr(columnArg) || !isRuntimeConstExpr(constantArg) || !functionalExpressionMatches(generated, columnArg) {
 				continue
 			}
+			if err := validateFunctionalIndexExpression(context.Background(), columnArg, node.TableDef); err != nil {
+				continue
+			}
 			probe := DeepCopyExpr(filter)
 			probeFn := probe.GetF()
 			if probeFn == nil || len(probeFn.Args) != 2 {

--- a/pkg/sql/plan/build_alter_change_column.go
+++ b/pkg/sql/plan/build_alter_change_column.go
@@ -359,7 +359,7 @@ func checkIndexedColumnTypeChange(ctx context.Context, tableDef *plan.TableDef, 
 
 // Check if the column name is valid and conflicts with internal hidden columns
 func checkColumnNameValid(ctx context.Context, colName string) error {
-	if _, ok := catalog.InternalColumns[colName]; ok || catalog.IsAlias(colName) {
+	if _, ok := catalog.InternalColumns[colName]; ok || catalog.IsAlias(colName) || catalog.IsFunctionalIndexColumnName(colName) {
 		return moerr.NewErrWrongColumnName(ctx, colName)
 	}
 	return nil

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -253,6 +253,9 @@ func buildAlterTableCopy(stmt *tree.AlterTable, cctx CompilerContext) (*Plan, er
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx, schemaName, tableName)
 	}
+	if err := validateFunctionalIndexMetadata(ctx, tableDef); err != nil {
+		return nil, err
+	}
 
 	if tableDef.IsTemporary {
 		tableDef = DeepCopyTableDef(tableDef, true)
@@ -732,6 +735,9 @@ func buildAlterTable(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, error) 
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), schemaName, tableName)
 	}
 	if err := validateTableIndexDefinitions(tableDef); err != nil {
+		return nil, err
+	}
+	if err := validateFunctionalIndexMetadata(ctx.GetContext(), tableDef); err != nil {
 		return nil, err
 	}
 	if err := validateAlterTableIdentifierDestinations(ctx.GetContext(), stmt.Options); err != nil {

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -338,6 +338,62 @@ func buildAlterTableCopy(stmt *tree.AlterTable, cctx CompilerContext) (*Plan, er
 			case *tree.PrimaryKeyIndex:
 				err = AddPrimaryKey(cctx, alterTablePlan, optionAdd, alterTableCtx)
 				affectedAllIdxCols()
+			case *tree.Index:
+				if !hasFunctionalIndexKeyPart(optionAdd.KeyParts) {
+					return nil, moerr.NewInvalidInputf(ctx,
+						unsupportedErrorFmt, formatTreeNode(option))
+				}
+				if optionAdd.KeyType != tree.INDEX_TYPE_INVALID && optionAdd.KeyType != tree.INDEX_TYPE_BTREE {
+					return nil, moerr.NewNotSupported(ctx, "functional/index add in COPY mode only supports regular BTREE indexes")
+				}
+				currentColMap := make(map[string]*ColDef, len(copyTableDef.Cols))
+				for _, col := range copyTableDef.Cols {
+					if col != nil {
+						currentColMap[col.Name] = col
+					}
+				}
+				if err = checkDuplicateConstraint(
+					func() map[string]bool {
+						m := make(map[string]bool, len(copyTableDef.Indexes))
+						for _, idx := range copyTableDef.Indexes {
+							m[indexNameKey(idx.IndexName)] = true
+						}
+						return m
+					}(), optionAdd.Name, false, ctx); err != nil {
+					return nil, err
+				}
+				if optionAdd.Name == "" {
+					setEmptyIndexName(func() map[string]bool {
+						m := make(map[string]bool, len(copyTableDef.Indexes))
+						for _, idx := range copyTableDef.Indexes {
+							m[indexNameKey(idx.IndexName)] = true
+						}
+						return m
+					}(), optionAdd)
+				}
+				plannerIndex := optionAdd
+				if hasFunctionalIndexKeyPart(optionAdd.KeyParts) {
+					plannerIndex, err = lowerFunctionalIndex(cctx, optionAdd, copyTableDef)
+					if err != nil {
+						return nil, err
+					}
+					currentColMap = make(map[string]*ColDef, len(copyTableDef.Cols))
+					for _, col := range copyTableDef.Cols {
+						if col != nil {
+							currentColMap[col.Name] = col
+						}
+					}
+				}
+				if err = checkIndexKeypartSupportability(ctx, plannerIndex.KeyParts); err != nil {
+					return nil, err
+				}
+				indexInfo := &plan.CreateTable{TableDef: &TableDef{}}
+				oriPriKeyName := getTablePriKeyName(copyTableDef.Pkey)
+				if err = buildSecondaryIndexDef(indexInfo, []*tree.Index{plannerIndex}, currentColMap, copyTableDef.Indexes, oriPriKeyName, cctx); err != nil {
+					return nil, err
+				}
+				copyTableDef.Indexes = append(copyTableDef.Indexes, indexInfo.TableDef.Indexes...)
+				affectedIndexes = append(affectedIndexes, indexInfo.TableDef.Indexes[0].IndexName)
 			default:
 				// column adding is handled in *tree.AlterAddCol
 				// various indexes\fks adding are handled in inplace mode.
@@ -348,10 +404,39 @@ func buildAlterTableCopy(stmt *tree.AlterTable, cctx CompilerContext) (*Plan, er
 			switch option.Typ {
 			case tree.AlterTableDropColumn:
 				pkAffected, err = DropColumn(cctx, alterTablePlan, string(option.Name), alterTableCtx)
+				rebuildTableColumnIndex(copyTableDef)
 				affectedCols = append(affectedCols, string(option.Name))
 			case tree.AlterTableDropPrimaryKey:
 				err = DropPrimaryKey(cctx, alterTablePlan, alterTableCtx)
 				affectedAllIdxCols()
+			case tree.AlterTableDropIndex, tree.AlterTableDropKey:
+				resolvedName, found := resolveIndexName(copyTableDef.Indexes, string(option.Name))
+				if !found {
+					return nil, moerr.NewErrCantDropFieldOrKey(ctx, string(option.Name))
+				}
+				var target *plan.IndexDef
+				for _, idx := range copyTableDef.Indexes {
+					if idx != nil && idx.IndexName == resolvedName {
+						target = idx
+						break
+					}
+				}
+				if !isFunctionalIndexDef(copyTableDef, target) {
+					return nil, moerr.NewInvalidInputf(ctx, unsupportedErrorFmt, formatTreeNode(option))
+				}
+				hiddenName := catalog.ResolveAlias(target.Parts[0])
+				copyTableDef.Indexes = RemoveIf(copyTableDef.Indexes, func(idx *plan.IndexDef) bool {
+					return idx != nil && idx.IndexName == resolvedName
+				})
+				hidden := FindColumn(copyTableDef.Cols, hiddenName)
+				if hidden == nil || !hidden.Hidden || hidden.GeneratedCol == nil {
+					return nil, moerr.NewInternalErrorf(ctx, "functional index '%s' has incomplete generated-column metadata", resolvedName)
+				}
+				if err = handleDropColumnPosition(ctx, copyTableDef, hidden); err != nil {
+					return nil, err
+				}
+				rebuildTableColumnIndex(copyTableDef)
+				affectedIndexes = append(affectedIndexes, resolvedName)
 			default:
 				// various indexes\fks dropping are handled in inplace mode.
 				return nil, moerr.NewInvalidInputf(ctx,
@@ -359,6 +444,7 @@ func buildAlterTableCopy(stmt *tree.AlterTable, cctx CompilerContext) (*Plan, er
 			}
 		case *tree.AlterAddCol:
 			pkAffected, err = AddColumn(cctx, alterTablePlan, option, alterTableCtx)
+			rebuildTableColumnIndex(copyTableDef)
 			affectedCols = append(affectedCols, option.Column.Name.ColName())
 		case *tree.AlterTableModifyColumnClause:
 			pkAffected, err = ModifyColumn(cctx, alterTablePlan, option, alterTableCtx)
@@ -829,7 +915,11 @@ Loop:
 			case *tree.UniqueIndex:
 				algorithm = plan.AlterTable_INPLACE
 			case *tree.Index:
-				algorithm = plan.AlterTable_INPLACE
+				if index, ok := option.Def.(*tree.Index); ok && hasFunctionalIndexKeyPart(index.KeyParts) {
+					algorithm = plan.AlterTable_COPY
+				} else {
+					algorithm = plan.AlterTable_INPLACE
+				}
 			default:
 				algorithm = plan.AlterTable_INPLACE
 			}
@@ -837,10 +927,23 @@ Loop:
 			switch option.Typ {
 			case tree.AlterTableDropColumn:
 				algorithm = plan.AlterTable_COPY
-			case tree.AlterTableDropIndex:
-				algorithm = plan.AlterTable_INPLACE
-			case tree.AlterTableDropKey:
-				algorithm = plan.AlterTable_INPLACE
+			case tree.AlterTableDropIndex, tree.AlterTableDropKey:
+				functionalDrop := false
+				if tableDef != nil {
+					if resolved, found := resolveIndexName(tableDef.Indexes, string(option.Name)); found {
+						for _, indexDef := range tableDef.Indexes {
+							if indexDef != nil && indexDef.IndexName == resolved && hasFunctionalIndexColumnPart(indexDef) {
+								functionalDrop = true
+								break
+							}
+						}
+					}
+				}
+				if functionalDrop {
+					algorithm = plan.AlterTable_COPY
+				} else {
+					algorithm = plan.AlterTable_INPLACE
+				}
 			case tree.AlterTableDropPrimaryKey:
 				algorithm = plan.AlterTable_COPY
 			case tree.AlterTableDropForeignKey:

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -584,6 +584,9 @@ func setTableExprToDmlTableInfo(ctx CompilerContext, tbl tree.TableExpr, tblInfo
 	if err := validateTableIndexDefinitions(tableDef); err != nil {
 		return err
 	}
+	if err := validateFunctionalIndexMetadata(ctx.GetContext(), tableDef); err != nil {
+		return err
+	}
 
 	if err := checkTableType(ctx.GetContext(), tableDef, tblInfo.typ); err != nil {
 		return err

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -3110,6 +3110,9 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 			}
 			pksMap := map[string]bool{}
 			for _, key := range def.KeyParts {
+				if key == nil || key.Expr != nil || key.ColName == nil {
+					return moerr.NewNotSupported(ctx.GetContext(), "functional expressions are not supported in PRIMARY KEY")
+				}
 				name := key.ColName.ColName() // name of primary key column
 				if _, ok := pksMap[name]; ok {
 					return moerr.NewInvalidInputf(ctx.GetContext(), "duplicate column name '%s' in primary key", key.ColName.ColNameOrigin())
@@ -3125,16 +3128,14 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 				pksMap[name] = true
 			}
 		case *tree.Index:
-			err := checkIndexKeypartSupportability(ctx.GetContext(), def.KeyParts)
-			if err != nil {
-				return err
-			}
-			if err = checkSpatialIndexColumnSupport(ctx, def, colMap); err != nil {
-				return err
-			}
-
 			secondaryIndexInfos = append(secondaryIndexInfos, def)
 			for _, key := range def.KeyParts {
+				if key == nil || key.Expr != nil {
+					continue
+				}
+				if key.ColName == nil {
+					return moerr.NewInvalidInput(ctx.GetContext(), "index key part is missing a column or expression")
+				}
 				name := key.ColName.ColName()
 
 				if col, ok := colMap[name]; ok {
@@ -3144,6 +3145,11 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 				}
 			}
 		case *tree.UniqueIndex:
+			for _, key := range def.KeyParts {
+				if key != nil && key.Expr != nil {
+					return moerr.NewNotSupported(ctx.GetContext(), "functional expressions are not supported in UNIQUE indexes")
+				}
+			}
 			err := checkIndexKeypartSupportability(ctx.GetContext(), def.KeyParts)
 			if err != nil {
 				return err
@@ -3160,6 +3166,11 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 				}
 			}
 		case *tree.FullTextIndex:
+			for _, key := range def.KeyParts {
+				if key != nil && key.Expr != nil {
+					return moerr.NewNotSupported(ctx.GetContext(), "functional expressions are not supported in FULLTEXT indexes")
+				}
+			}
 			err := checkIndexKeypartSupportability(ctx.GetContext(), def.KeyParts)
 			if err != nil {
 				return err
@@ -3518,10 +3529,50 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 		}
 	}
 
-	// check Constraint Name (include index/ unique)
+	// Resolve names before lowering expression key parts. An unnamed inline
+	// functional index needs a unique stable name for its private column; the
+	// same helper also preserves the existing duplicate-name diagnostics.
 	err = checkConstraintNames(uniqueIndexInfos, secondaryIndexInfos, ctx.GetContext())
 	if err != nil {
 		return err
+	}
+
+	// Lower expression key parts only after all user and generated columns have
+	// been bound. This keeps forward references consistent with generated
+	// columns while leaving the original CREATE TABLE AST untouched for
+	// rel_createsql/SHOW CREATE TABLE.
+	for i, indexInfo := range secondaryIndexInfos {
+		hasExpr := false
+		for _, keyPart := range indexInfo.KeyParts {
+			if keyPart != nil && keyPart.Expr != nil {
+				hasExpr = true
+				break
+			}
+		}
+		if hasExpr {
+			if stmt.Temporary {
+				return moerr.NewNotSupported(ctx.GetContext(), "functional indexes are not supported on temporary tables")
+			}
+			if stmt.IsClusterTable {
+				return moerr.NewNotSupported(ctx.GetContext(), "functional indexes are not supported on cluster tables")
+			}
+			secondaryIndexInfos[i], err = lowerFunctionalIndex(ctx, indexInfo, createTable.TableDef)
+			if err != nil {
+				return err
+			}
+			for _, col := range createTable.TableDef.Cols {
+				if col != nil {
+					colMap[col.Name] = col
+				}
+			}
+			continue
+		}
+		if err = checkIndexKeypartSupportability(ctx.GetContext(), indexInfo.KeyParts); err != nil {
+			return err
+		}
+		if err = checkSpatialIndexColumnSupport(ctx, indexInfo, colMap); err != nil {
+			return err
+		}
 	}
 
 	// build index table
@@ -5232,6 +5283,29 @@ func buildCreateIndex(stmt *tree.CreateIndex, ctx CompilerContext) (*Plan, error
 	if _, found := resolveIndexName(tableDef.Indexes, indexName); found {
 		return nil, moerr.NewDuplicateKey(ctx.GetContext(), indexName)
 	}
+	// Standalone CREATE INDEX has to rebuild the base table when the key part
+	// owns a hidden generated column. Route it through the atomic COPY path so
+	// backfill, index-table creation, and catalog writes commit together.
+	if hasFunctionalIndexKeyPart(stmt.KeyParts) {
+		if stmt.IndexCat != tree.INDEX_CATEGORY_NONE {
+			return nil, moerr.NewNotSupported(ctx.GetContext(), "functional expressions are supported only by regular BTREE indexes")
+		}
+		keyType := tree.INDEX_TYPE_INVALID
+		if stmt.IndexOption != nil {
+			keyType = stmt.IndexOption.IType
+		}
+		return buildAlterTableCopy(&tree.AlterTable{
+			Table: stmt.Table,
+			Options: tree.AlterTableOptions{
+				tree.NewAlterOptionAdd(&tree.Index{
+					Name:        indexName,
+					KeyParts:    stmt.KeyParts,
+					KeyType:     keyType,
+					IndexOption: stmt.IndexOption,
+				}),
+			},
+		}, ctx)
+	}
 	// build index
 	var ftIdx *tree.FullTextIndex
 	var uIdx *tree.UniqueIndex
@@ -5501,6 +5575,18 @@ func buildDropIndex(stmt *tree.DropIndex, ctx CompilerContext) (*Plan, error) {
 		}
 	} else if err := checkDropReferencedKeyForeignKeyDependency(ctx, tableDef, dropIndex.IndexName, nil); err != nil {
 		return nil, err
+	}
+	if found {
+		for _, indexDef := range tableDef.Indexes {
+			if indexDef != nil && indexDef.IndexName == dropIndex.IndexName && hasFunctionalIndexColumnPart(indexDef) {
+				return buildAlterTableCopy(&tree.AlterTable{
+					Table: stmt.TableName,
+					Options: tree.AlterTableOptions{
+						&tree.AlterOptionDrop{Typ: tree.AlterTableDropIndex, Name: tree.Identifier(dropIndex.IndexName)},
+					},
+				}, ctx)
+			}
+		}
 	}
 
 	return &Plan{
@@ -5991,6 +6077,9 @@ func buildAlterTableInplace(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, 
 				if err := checkCreateIndexTableType(ctx.GetContext(), tableDef); err != nil {
 					return nil, err
 				}
+				if hasFunctionalIndexKeyPart(def.KeyParts) {
+					return nil, moerr.NewNotSupported(ctx.GetContext(), "functional expressions are not supported in UNIQUE indexes")
+				}
 				if err := checkIndexKeypartSupportability(
 					ctx.GetContext(),
 					def.KeyParts,
@@ -6039,6 +6128,9 @@ func buildAlterTableInplace(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, 
 			case *tree.FullTextIndex:
 				if err := checkCreateIndexTableType(ctx.GetContext(), tableDef); err != nil {
 					return nil, err
+				}
+				if hasFunctionalIndexKeyPart(def.KeyParts) {
+					return nil, moerr.NewNotSupported(ctx.GetContext(), "functional expressions are not supported in FULLTEXT indexes")
 				}
 				if err := checkIndexKeypartSupportability(
 					ctx.GetContext(),
@@ -6090,6 +6182,9 @@ func buildAlterTableInplace(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, 
 			case *tree.Index:
 				if err := checkCreateIndexTableType(ctx.GetContext(), tableDef); err != nil {
 					return nil, err
+				}
+				if hasFunctionalIndexKeyPart(def.KeyParts) {
+					return nil, moerr.NewNotSupported(ctx.GetContext(), "functional indexes require ALGORITHM=COPY")
 				}
 				if err := checkIndexKeypartSupportability(
 					ctx.GetContext(),

--- a/pkg/sql/plan/build_index_util.go
+++ b/pkg/sql/plan/build_index_util.go
@@ -118,7 +118,14 @@ func setEmptyUniqueIndexName(namesMap map[string]bool, indexConstr *tree.UniqueI
 // setEmptyIndexName Set name for index constraint with an empty name
 func setEmptyIndexName(namesMap map[string]bool, indexConstr *tree.Index) {
 	if indexConstr.Name == "" && len(indexConstr.KeyParts) > 0 {
-		colName := indexConstr.KeyParts[0].ColName.ColName()
+		// MySQL permits an unnamed functional key part in an inline CREATE
+		// TABLE/ALTER TABLE definition. There is no column name to derive the
+		// constraint name from, so use a stable generic seed and retain the
+		// existing numeric-suffix collision rule.
+		colName := "functional_index"
+		if keyPart := indexConstr.KeyParts[0]; keyPart != nil && keyPart.ColName != nil {
+			colName = keyPart.ColName.ColName()
+		}
 		constrName := colName
 		i := 2
 		if IndexNamesEqual(constrName, "PRIMARY") {
@@ -155,12 +162,13 @@ func setEmptyFullTextIndexName(namesMap map[string]bool, indexConstr *tree.FullT
 	}
 }
 
-// TODO
-// Currently, using expression as index keyparts are not supported in matrixone
 func checkIndexKeypartSupportability(context context.Context, keyParts []*tree.KeyPart) error {
 	for _, key := range keyParts {
+		if key == nil {
+			return moerr.NewInvalidInput(context, "index key part is nil")
+		}
 		if key.Expr != nil {
-			return moerr.NewInternalError(context, "unsupported index which using expression as keypart")
+			return moerr.NewNotSupported(context, "functional index expression was not lowered")
 		}
 	}
 	return nil

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -879,6 +879,9 @@ func buildShowIndex(stmt *tree.ShowIndex, ctx CompilerContext) (*Plan, error) {
 	if tableDef == nil {
 		return nil, moerr.NewNoSuchTable(ctx.GetContext(), dbName, tblName)
 	}
+	if err := validateFunctionalIndexMetadata(ctx.GetContext(), tableDef); err != nil {
+		return nil, err
+	}
 
 	ddlType := plan.DataDefinition_SHOW_INDEX
 
@@ -902,7 +905,7 @@ func buildShowIndex(stmt *tree.ShowIndex, ctx CompilerContext) (*Plan, error) {
 		"if(`idx`.`type` IN ('PRIMARY', 'UNIQUE'), 0, 1) as `Non_unique`, " +
 		"`idx`.`name` as `Key_name`, " +
 		"`idx`.`ordinal_position` as `Seq_in_index`, " +
-		"`idx`.`column_name` as `Column_name`, " +
+		"if(`idx`.`hidden` = 1, NULL, `idx`.`column_name`) as `Column_name`, " +
 		"'A' as `Collation`, 0 as `Cardinality`, " +
 		"'NULL' as `Sub_part`, " +
 		"'NULL' as `Packed`, " +
@@ -912,7 +915,7 @@ func buildShowIndex(stmt *tree.ShowIndex, ctx CompilerContext) (*Plan, error) {
 		"`idx`.`comment` as `Index_comment`, " +
 		"`idx`.`algo_params` as `Index_params`, " +
 		"if(`idx`.`is_visible` = 1, 'YES', 'NO') as `Visible`, " +
-		"`idx`.`column_name` as `Expression` " +
+		"if(`idx`.`hidden` = 1, mo_show_visible_bin(`tcl`.`attr_generated`, 5), `idx`.`column_name`) as `Expression` " +
 		"from `%s`.`mo_indexes` `idx` left join `%s`.`mo_columns` `tcl` " +
 		"on (`idx`.`table_id` = `tcl`.`att_relname_id` and `idx`.`column_name` = `tcl`.`attname`) " +
 		"where `tcl`.`att_database` = '%s' AND " +
@@ -942,7 +945,7 @@ func buildShowIndex(stmt *tree.ShowIndex, ctx CompilerContext) (*Plan, error) {
 		//| tbl   |          1 | idx1     |            1 | embedding   | A         |           0 | NULL     | NULL   | YES  | ivfflat    |         |               | {"lists":"2","op_type":"vector_l2_ops"} | YES     | NULL       |
 		//+-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+-----------------------------------------+---------+------------+
 		"GROUP BY `tcl`.`att_relname`, `idx`.`type`, `idx`.`name`, `idx`.`ordinal_position`, " +
-		"`idx`.`column_name`, `tcl`.`attnotnull`, `idx`.`algo`, `idx`.`comment`, " +
+		"`idx`.`column_name`, `idx`.`hidden`, `tcl`.`attnotnull`, `tcl`.`attr_generated`, `idx`.`algo`, `idx`.`comment`, " +
 		"`idx`.`algo_params`, `idx`.`is_visible` " +
 		// Match MySQL's index classes, then preserve catalog creation order within each class.
 		// MIN(id) supplies one stable key without defeating the GROUP BY deduplication above.

--- a/pkg/sql/plan/build_show_test.go
+++ b/pkg/sql/plan/build_show_test.go
@@ -175,9 +175,35 @@ func TestShowKeysUsesMySQLIndexOrder(t *testing.T) {
 			}
 			require.Len(t, sortNodes, 1)
 			require.Len(t, sortNodes[0].GetOrderBy(), 3)
-			require.Equal(t, "case", sortNodes[0].GetOrderBy()[0].GetExpr().GetF().GetFunc().GetObjName())
-			require.Equal(t, "MIN(idx.id)", sortNodes[0].GetOrderBy()[1].GetExpr().GetCol().GetName())
-			require.Equal(t, "idx.ordinal_position", sortNodes[0].GetOrderBy()[2].GetExpr().GetCol().GetName())
+			nodes := logicPlan.GetQuery().GetNodes()
+			resolveSortExpr := func(spec *plan.OrderBySpec) *plan.Expr {
+				expr := spec.GetExpr()
+				nodeID := sortNodes[0].GetChildren()[0]
+				for step := 0; step < len(nodes); step++ {
+					col := expr.GetCol()
+					if col == nil || col.GetRelPos() != 0 || col.GetColPos() < 0 || int(col.GetColPos()) >= len(nodes[nodeID].GetProjectList()) {
+						break
+					}
+					expr = nodes[nodeID].GetProjectList()[col.GetColPos()]
+					children := nodes[nodeID].GetChildren()
+					if len(children) == 0 {
+						break
+					}
+					nodeID = children[0]
+				}
+				return expr
+			}
+			firstOrderExpr := resolveSortExpr(sortNodes[0].GetOrderBy()[0])
+			require.NotNil(t, firstOrderExpr.GetF())
+			require.Equal(t, "case", firstOrderExpr.GetF().GetFunc().GetObjName())
+			secondOrderExpr := resolveSortExpr(sortNodes[0].GetOrderBy()[1])
+			if secondOrderExpr.GetF() != nil {
+				require.Equal(t, "MIN(idx.id)", secondOrderExpr.GetF().GetFunc().GetObjName())
+			} else {
+				require.Equal(t, "MIN(idx.id)", secondOrderExpr.GetCol().GetName())
+			}
+			thirdOrderExpr := resolveSortExpr(sortNodes[0].GetOrderBy()[2])
+			require.Equal(t, "idx.ordinal_position", thirdOrderExpr.GetCol().GetName())
 		})
 	}
 }

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -389,25 +389,35 @@ func constructCreateTableSQL(
 				}
 				indexStr += "("
 				rewriteIndexStr += "("
-				i := 0
-				for _, part := range indexdef.Parts {
-					if catalog.IsAlias(part) {
-						continue
-					}
-					if i > 0 {
-						indexStr += ","
-						rewriteIndexStr += ","
-					}
+				if origin, ok := functionalIndexOrigin(tableDef, indexdef); ok {
+					// Functional indexes are backed by a reserved hidden generated
+					// column. Render the original expression and never leak that
+					// implementation name into SHOW CREATE/clone DDL.
+					indexStr += "(" + origin + ")"
+					rewriteIndexStr += "(" + origin + ")"
+				} else if hasFunctionalIndexColumnPart(indexdef) {
+					return "", nil, moerr.NewInternalError(ctx.GetContext(), "functional index has incomplete generated-column metadata")
+				} else {
+					i := 0
+					for _, part := range indexdef.Parts {
+						if catalog.IsAlias(part) {
+							continue
+						}
+						if i > 0 {
+							indexStr += ","
+							rewriteIndexStr += ","
+						}
 
-					originPart := colNameToOriginName[part]
-					indexStr += sqlquote.Ident(originPart)
-					rewriteIndexStr += sqlquote.Ident(originPart)
-					if length, ok := prefixLengths[part]; ok {
-						prefixLength := fmt.Sprintf("(%d)", length)
-						indexStr += prefixLength
-						rewriteIndexStr += prefixLength
+						originPart := colNameToOriginName[part]
+						indexStr += sqlquote.Ident(originPart)
+						rewriteIndexStr += sqlquote.Ident(originPart)
+						if length, ok := prefixLengths[part]; ok {
+							prefixLength := fmt.Sprintf("(%d)", length)
+							indexStr += prefixLength
+							rewriteIndexStr += prefixLength
+						}
+						i++
 					}
-					i++
 				}
 
 				indexStr += ")"

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -79,6 +80,15 @@ func constructCreateTableSQL(
 	sourceSubscription *SubscriptionMeta,
 ) (string, tree.Statement, error) {
 	var err error
+	if tableDef != nil {
+		validationCtx := context.Background()
+		if ctx != nil {
+			validationCtx = ctx.GetContext()
+		}
+		if err := validateFunctionalIndexMetadata(validationCtx, tableDef); err != nil {
+			return "", nil, err
+		}
+	}
 	var createStr string
 	sqlMode := ""
 	if ctx != nil {

--- a/pkg/sql/plan/build_util.go
+++ b/pkg/sql/plan/build_util.go
@@ -1314,7 +1314,7 @@ func checkTableColumnNameValid(name string) bool {
 	if name == catalog.Row_ID || name == catalog.CPrimaryKeyColName ||
 		name == catalog.TableTailAttrDeleteRowID || name == catalog.TableTailAttrAborted ||
 		name == catalog.TableTailAttrPKVal || name == catalog.TableTailAttrCommitTs ||
-		catalog.IsAlias(name) {
+		catalog.IsAlias(name) || catalog.IsFunctionalIndexColumnName(name) {
 		return false
 	}
 	return true

--- a/pkg/sql/plan/dml_context.go
+++ b/pkg/sql/plan/dml_context.go
@@ -429,6 +429,9 @@ func (dmlCtx *DMLContext) resolveSingleTable(
 	if err := validateTableIndexDefinitions(tableDef); err != nil {
 		return err
 	}
+	if err := validateFunctionalIndexMetadata(ctx.GetContext(), tableDef); err != nil {
+		return err
+	}
 
 	// External tables are not handled by the modern DML binder. Writable ones
 	// (WRITE_FILE_PATTERN) emit a classified sentinel: INSERT/LOAD can select

--- a/pkg/sql/plan/functional_index.go
+++ b/pkg/sql/plan/functional_index.go
@@ -338,7 +338,8 @@ func isFunctionalIndexDef(tableDef *TableDef, indexDef *plan.IndexDef) bool {
 	name := catalog.ResolveAlias(indexDef.Parts[0])
 	col := FindColumn(tableDef.Cols, name)
 	return col != nil && col.Hidden && catalog.IsFunctionalIndexColumnName(col.Name) &&
-		col.GeneratedCol != nil && col.GeneratedCol.Expr != nil && strings.TrimSpace(col.GeneratedCol.OriginString) != ""
+		col.GeneratedCol != nil && !col.GeneratedCol.IsStored &&
+		col.GeneratedCol.Expr != nil && strings.TrimSpace(col.GeneratedCol.OriginString) != ""
 }
 
 func functionalIndexOrigin(tableDef *TableDef, indexDef *plan.IndexDef) (string, bool) {
@@ -435,6 +436,18 @@ func validateFunctionalIndexMetadata(ctx context.Context, tableDef *TableDef) er
 	if tableDef == nil {
 		return nil
 	}
+	functionalColumns := make(map[string]struct{})
+	for _, col := range tableDef.Cols {
+		if col == nil || !catalog.IsFunctionalIndexColumnName(col.Name) {
+			continue
+		}
+		if !col.Hidden || col.GeneratedCol == nil || col.GeneratedCol.IsStored ||
+			col.GeneratedCol.Expr == nil || strings.TrimSpace(col.GeneratedCol.OriginString) == "" {
+			return moerr.NewInternalError(ctx, "functional index has incomplete generated-column metadata")
+		}
+		functionalColumns[col.Name] = struct{}{}
+	}
+	functionalRefs := make(map[string]int)
 	for _, indexDef := range tableDef.Indexes {
 		if !hasFunctionalIndexColumnPart(indexDef) {
 			continue
@@ -444,6 +457,12 @@ func validateFunctionalIndexMetadata(ctx context.Context, tableDef *TableDef) er
 		}
 		if _, ok := functionalIndexOrigin(tableDef, indexDef); !ok {
 			return moerr.NewInternalError(ctx, "functional index has incomplete generated-column metadata")
+		}
+		functionalRefs[catalog.ResolveAlias(indexDef.Parts[0])]++
+	}
+	for name := range functionalColumns {
+		if functionalRefs[name] != 1 {
+			return moerr.NewInternalError(ctx, "functional index has orphaned hidden generated-column metadata")
 		}
 	}
 	return nil

--- a/pkg/sql/plan/functional_index.go
+++ b/pkg/sql/plan/functional_index.go
@@ -1,0 +1,450 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/sql/util"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+const functionalIndexProtocolError = "functional indexes require all CNs to support protocol version 48"
+
+func hasFunctionalIndexKeyPart(parts []*tree.KeyPart) bool {
+	for _, part := range parts {
+		if part != nil && part.Expr != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// requireFunctionalIndexProtocol protects the persisted hidden-column/index
+// contract during a rolling upgrade. A nil process is used by parser/planner
+// unit tests and has no deployment to gate.
+func requireFunctionalIndexProtocol(ctx context.Context, proc *process.Process) error {
+	if proc == nil {
+		return nil
+	}
+	rt := moruntime.ServiceRuntime(proc.GetService())
+	if rt == nil {
+		return moerr.NewNotSupported(ctx, functionalIndexProtocolError)
+	}
+	value, ok := rt.GetGlobalVariables(moruntime.MOProtocolVersion)
+	version := int64(0)
+	switch v := value.(type) {
+	case int64:
+		version = v
+	case int:
+		version = int64(v)
+	case uint64:
+		version = int64(v)
+	default:
+		ok = false
+	}
+	if !ok || version < defines.MORPCVersion48 {
+		return moerr.NewNotSupported(ctx, functionalIndexProtocolError)
+	}
+	return nil
+}
+
+func functionalIndexColumnName(indexName string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(indexName))))
+	return catalog.FunctionalIndexColumnPrefix + hex.EncodeToString(sum[:])[:32]
+}
+
+func cloneFunctionalIndex(indexInfo *tree.Index) *tree.Index {
+	if indexInfo == nil {
+		return nil
+	}
+	clone := *indexInfo
+	clone.KeyParts = make([]*tree.KeyPart, len(indexInfo.KeyParts))
+	for i, part := range indexInfo.KeyParts {
+		if part == nil {
+			continue
+		}
+		partClone := *part
+		clone.KeyParts[i] = &partClone
+	}
+	return &clone
+}
+
+func functionalIndexUsesRegularBTREE(indexInfo *tree.Index) bool {
+	if indexInfo == nil {
+		return false
+	}
+	if indexInfo.KeyType != tree.INDEX_TYPE_INVALID && indexInfo.KeyType != tree.INDEX_TYPE_BTREE {
+		return false
+	}
+	return indexInfo.IndexOption == nil || indexInfo.IndexOption.IType == tree.INDEX_TYPE_INVALID || indexInfo.IndexOption.IType == tree.INDEX_TYPE_BTREE
+}
+
+// lowerFunctionalIndex turns one supported expression key part into a hidden
+// virtual generated column. The returned AST index is planner-owned; the input
+// AST is intentionally left untouched because rel_createsql must retain the
+// user's expression rather than the reserved internal column name.
+func lowerFunctionalIndex(ctx CompilerContext, indexInfo *tree.Index, tableDef *TableDef) (*tree.Index, error) {
+	if indexInfo == nil || tableDef == nil {
+		return nil, moerr.NewInternalError(ctx.GetContext(), "functional index metadata is nil")
+	}
+	hasExpr := false
+	for _, part := range indexInfo.KeyParts {
+		if part != nil && part.Expr != nil {
+			hasExpr = true
+			break
+		}
+	}
+	if !hasExpr {
+		return indexInfo, nil
+	}
+	if tableDef.IsTemporary || tableDef.TableType == catalog.SystemTemporaryTable {
+		return nil, moerr.NewNotSupported(ctx.GetContext(), "functional indexes are not supported on temporary tables")
+	}
+	if util.TableIsClusterTable(tableDef.GetTableType()) {
+		return nil, moerr.NewNotSupported(ctx.GetContext(), "functional indexes are not supported on cluster tables")
+	}
+	if tableDef.TableType == catalog.SystemExternalRel {
+		return nil, moerr.NewNotSupported(ctx.GetContext(), "functional indexes are not supported on external tables")
+	}
+	if !functionalIndexUsesRegularBTREE(indexInfo) {
+		return nil, moerr.NewNotSupported(ctx.GetContext(), "functional indexes only support regular BTREE indexes")
+	}
+	if len(indexInfo.KeyParts) != 1 || indexInfo.KeyParts[0] == nil || indexInfo.KeyParts[0].Expr == nil {
+		return nil, moerr.NewNotSupported(ctx.GetContext(), "functional indexes require exactly one expression key part")
+	}
+	part := indexInfo.KeyParts[0]
+	if part.ColName != nil {
+		return nil, moerr.NewNotSupported(ctx.GetContext(), "functional index key part cannot mix a column and an expression")
+	}
+	if part.Length != 0 || part.Direction != tree.DefaultDirection {
+		return nil, moerr.NewNotSupported(ctx.GetContext(), "functional indexes do not support prefix or ASC/DESC key parts")
+	}
+	indexName := indexInfo.Name
+	if indexName == "" {
+		// Inline CREATE TABLE permits an unnamed secondary index. The regular
+		// constraint-name pass runs after functional lowering, so give this
+		// index the same stable seed that setEmptyIndexName uses; duplicate
+		// names are still rejected by that pass.
+		indexName = "functional_index"
+	}
+	if err := requireFunctionalIndexProtocol(ctx.GetContext(), ctx.GetProcess()); err != nil {
+		return nil, err
+	}
+
+	colNames := make([]string, len(tableDef.Cols))
+	colTypes := make([]plan.Type, len(tableDef.Cols))
+	for i, col := range tableDef.Cols {
+		if col == nil {
+			return nil, moerr.NewInternalError(ctx.GetContext(), "functional index references nil table column")
+		}
+		colNames[i] = col.Name
+		colTypes[i] = col.Typ
+	}
+	binder := NewGeneratedColBinder(ctx.GetContext(), colNames, colTypes)
+	bound, err := binder.BindExpr(part.Expr, 0, false)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkExprForVolatileFunc(ctx.GetContext(), bound); err != nil {
+		return nil, err
+	}
+	if err = checkGeneratedExprReferences(ctx.GetContext(), bound, indexName, tableDef.Cols, make(map[int32]bool)); err != nil {
+		return nil, err
+	}
+	if err = checkFunctionalIndexResultType(ctx.GetContext(), bound.Typ); err != nil {
+		return nil, err
+	}
+	genExpr, err := makePlan2AssignmentCastExpr(ctx.GetContext(), bound, bound.Typ)
+	if err != nil {
+		return nil, err
+	}
+	fmtCtx := tree.NewFmtCtx(dialect.MYSQL, tree.WithSingleQuoteString())
+	fmtCtx.PrintExpr(part.Expr, part.Expr, false)
+	origin := trimFunctionalOuterParentheses(fmtCtx.String())
+	if origin == "" {
+		return nil, moerr.NewInvalidInput(ctx.GetContext(), "functional index expression cannot be empty")
+	}
+
+	hiddenName := functionalIndexColumnName(indexName)
+	if existing := FindColumn(tableDef.Cols, hiddenName); existing != nil {
+		return nil, moerr.NewInvalidInputf(ctx.GetContext(), "functional index internal column '%s' already exists", hiddenName)
+	}
+	hidden := &ColDef{
+		ColId:      ^uint64(0),
+		Name:       hiddenName,
+		OriginName: hiddenName,
+		Hidden:     true,
+		Alg:        plan.CompressType_Lz4,
+		Typ:        bound.Typ,
+		Default:    &plan.Default{NullAbility: !bound.Typ.NotNullable},
+		GeneratedCol: &plan.GeneratedCol{
+			Expr:         genExpr,
+			OriginString: origin,
+			IsStored:     false,
+		},
+	}
+	// A table without an explicit primary key keeps the synthetic fake-PK as
+	// the final physical column. Insert the functional column immediately
+	// before it so the existing DML/TAE layout contract is unchanged.
+	if tableDef.Pkey != nil && catalog.IsFakePkName(tableDef.Pkey.PkeyColName) {
+		fakePos := -1
+		for i, col := range tableDef.Cols {
+			if col != nil && catalog.IsFakePkName(col.Name) {
+				fakePos = i
+				break
+			}
+		}
+		if fakePos >= 0 {
+			tableDef.Cols = append(tableDef.Cols, nil)
+			copy(tableDef.Cols[fakePos+1:], tableDef.Cols[fakePos:])
+			tableDef.Cols[fakePos] = hidden
+		} else {
+			tableDef.Cols = append(tableDef.Cols, hidden)
+		}
+	} else {
+		tableDef.Cols = append(tableDef.Cols, hidden)
+	}
+	rebuildTableColumnIndex(tableDef)
+
+	lowered := cloneFunctionalIndex(indexInfo)
+	lowered.Name = indexName
+	lowered.KeyParts[0] = &tree.KeyPart{ColName: tree.NewUnresolvedColName(hiddenName)}
+	return lowered, nil
+}
+
+// trimFunctionalOuterParentheses removes only one pair that encloses the
+// complete formatted expression. The index DDL renderer adds its own pair,
+// so retaining formatter-only grouping would otherwise produce (((expr))).
+func trimFunctionalOuterParentheses(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 || value[0] != '(' || value[len(value)-1] != ')' {
+		return value
+	}
+	depth := 0
+	var quote byte
+	escaped := false
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"', '`':
+			quote = ch
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i != len(value)-1 {
+				return value
+			}
+		}
+	}
+	if depth != 0 || quote != 0 {
+		return value
+	}
+	return strings.TrimSpace(value[1 : len(value)-1])
+}
+
+func rebuildTableColumnIndex(tableDef *TableDef) {
+	if tableDef == nil {
+		return
+	}
+	tableDef.Name2ColIndex = make(map[string]int32, len(tableDef.Cols))
+	for i, col := range tableDef.Cols {
+		if col != nil {
+			tableDef.Name2ColIndex[col.Name] = int32(i)
+		}
+	}
+}
+
+func checkFunctionalIndexResultType(ctx context.Context, typ Type) error {
+	switch types.T(typ.Id) {
+	case types.T_json, types.T_text, types.T_blob, types.T_datalink,
+		types.T_geometry, types.T_geometry32,
+		types.T_array_float32, types.T_array_float64, types.T_array_float16,
+		types.T_array_bf16, types.T_array_int8, types.T_array_uint8:
+		return moerr.NewNotSupportedf(ctx, "functional index expression returns unsupported type %s", types.T(typ.Id).String())
+	}
+	if typ.Id == int32(types.T_any) || typ.Id == 0 {
+		return moerr.NewNotSupported(ctx, "functional index expression has no stable result type")
+	}
+	return nil
+}
+
+func hasFunctionalIndexColumnPart(indexDef *plan.IndexDef) bool {
+	return indexDef != nil && len(indexDef.Parts) > 0 &&
+		catalog.IsFunctionalIndexColumnName(catalog.ResolveAlias(indexDef.Parts[0]))
+}
+
+// isFunctionalIndexDef recognizes the catalog representation without adding a
+// new protobuf field: the first key part names a reserved hidden generated col.
+func isFunctionalIndexDef(tableDef *TableDef, indexDef *plan.IndexDef) bool {
+	if tableDef == nil || indexDef == nil || indexDef.Unique || len(indexDef.Parts) != 2 {
+		return false
+	}
+	if tableDef.IsTemporary || tableDef.TableType == catalog.SystemTemporaryTable ||
+		util.TableIsClusterTable(tableDef.GetTableType()) || tableDef.TableType == catalog.SystemExternalRel {
+		return false
+	}
+	if !catalog.IsNullIndexAlgo(indexDef.IndexAlgo) && catalog.ToLower(indexDef.IndexAlgo) != catalog.MoIndexBTreeAlgo.ToString() {
+		return false
+	}
+	if !hasFunctionalIndexColumnPart(indexDef) {
+		return false
+	}
+	if !catalog.IsAlias(indexDef.Parts[1]) {
+		return false
+	}
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(indexDef.IndexAlgoParams)
+	if err != nil || len(prefixLengths) != 0 {
+		return false
+	}
+	name := catalog.ResolveAlias(indexDef.Parts[0])
+	col := FindColumn(tableDef.Cols, name)
+	return col != nil && col.Hidden && catalog.IsFunctionalIndexColumnName(col.Name) &&
+		col.GeneratedCol != nil && col.GeneratedCol.Expr != nil && strings.TrimSpace(col.GeneratedCol.OriginString) != ""
+}
+
+func functionalIndexOrigin(tableDef *TableDef, indexDef *plan.IndexDef) (string, bool) {
+	if !isFunctionalIndexDef(tableDef, indexDef) {
+		return "", false
+	}
+	col := FindColumn(tableDef.Cols, catalog.ResolveAlias(indexDef.Parts[0]))
+	if col == nil || col.GeneratedCol == nil || strings.TrimSpace(col.GeneratedCol.OriginString) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(col.GeneratedCol.OriginString), true
+}
+
+func normalizeFunctionalExpr(expr *plan.Expr) *plan.Expr {
+	if expr == nil {
+		return nil
+	}
+	clone := DeepCopyExpr(expr)
+	var walk func(*plan.Expr)
+	walk = func(current *plan.Expr) {
+		if current == nil {
+			return
+		}
+		if col := current.GetCol(); col != nil {
+			col.RelPos = 0
+		}
+		if fn := current.GetF(); fn != nil {
+			for _, arg := range fn.Args {
+				walk(arg)
+			}
+		}
+		if list := current.GetList(); list != nil {
+			for _, arg := range list.List {
+				walk(arg)
+			}
+		}
+	}
+	walk(clone)
+	return clone
+}
+
+func stripFunctionalAssignmentCast(expr *plan.Expr) *plan.Expr {
+	if expr == nil {
+		return nil
+	}
+	fn := expr.GetF()
+	if fn == nil || len(fn.Args) != 1 || fn.Func == nil {
+		return expr
+	}
+	switch strings.ToLower(fn.Func.ObjName) {
+	case "cast", "cast_strict", "cast_assign", "cast_ignore":
+		arg := fn.Args[0]
+		if arg != nil && arg.Typ.Id == expr.Typ.Id && arg.Typ.Width == expr.Typ.Width && arg.Typ.Scale == expr.Typ.Scale && arg.Typ.Charset == expr.Typ.Charset {
+			return arg
+		}
+	}
+	return expr
+}
+
+func functionalExpressionMatches(generated, query *plan.Expr) bool {
+	if generated == nil || query == nil {
+		return false
+	}
+	left := normalizeFunctionalExpr(stripFunctionalAssignmentCast(generated))
+	right := normalizeFunctionalExpr(stripFunctionalAssignmentCast(query))
+	return exprStructuralEqual(left, right)
+}
+
+// functionalIndexQueryExpr returns the generated expression and its hidden
+// column position for a catalog index. It is deliberately strict: malformed
+// metadata disables the optional optimization instead of changing results.
+func functionalIndexQueryExpr(tableDef *TableDef, indexDef *plan.IndexDef) (*plan.Expr, int32, bool) {
+	if !isFunctionalIndexDef(tableDef, indexDef) {
+		return nil, -1, false
+	}
+	name := catalog.ResolveAlias(indexDef.Parts[0])
+	pos, ok := tableDef.Name2ColIndex[name]
+	if !ok || pos < 0 || int(pos) >= len(tableDef.Cols) {
+		return nil, -1, false
+	}
+	col := tableDef.Cols[pos]
+	if col == nil || col.GeneratedCol == nil || col.GeneratedCol.Expr == nil {
+		return nil, -1, false
+	}
+	return col.GeneratedCol.Expr, pos, true
+}
+
+// validateFunctionalIndexMetadata checks every reserved index part before a
+// metadata-facing statement is planned. Reserved names are never treated as
+// ordinary user columns: a missing generated payload, an unexpected key shape,
+// or a stale algorithm must surface as an internal catalog error instead of
+// producing a DDL/SHOW result that cannot be restored faithfully.
+func validateFunctionalIndexMetadata(ctx context.Context, tableDef *TableDef) error {
+	if tableDef == nil {
+		return nil
+	}
+	for _, indexDef := range tableDef.Indexes {
+		if !hasFunctionalIndexColumnPart(indexDef) {
+			continue
+		}
+		if !isFunctionalIndexDef(tableDef, indexDef) {
+			return moerr.NewInternalError(ctx, "functional index has incomplete or unsupported metadata")
+		}
+		if _, ok := functionalIndexOrigin(tableDef, indexDef); !ok {
+			return moerr.NewInternalError(ctx, "functional index has incomplete generated-column metadata")
+		}
+	}
+	return nil
+}

--- a/pkg/sql/plan/functional_index.go
+++ b/pkg/sql/plan/functional_index.go
@@ -33,7 +33,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
-const functionalIndexProtocolError = "functional indexes require all CNs to support protocol version 57"
+const functionalIndexProtocolError = "functional indexes require all CNs to support protocol version 59"
 
 type functionalIndexExprKind uint8
 
@@ -89,7 +89,7 @@ func requireFunctionalIndexProtocol(ctx context.Context, proc *process.Process) 
 	default:
 		ok = false
 	}
-	if !ok || version < defines.MORPCVersion57 {
+	if !ok || version < defines.MORPCVersion59 {
 		return moerr.NewNotSupported(ctx, functionalIndexProtocolError)
 	}
 	return nil

--- a/pkg/sql/plan/functional_index.go
+++ b/pkg/sql/plan/functional_index.go
@@ -28,11 +28,34 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
-const functionalIndexProtocolError = "functional indexes require all CNs to support protocol version 56"
+const functionalIndexProtocolError = "functional indexes require all CNs to support protocol version 57"
+
+type functionalIndexExprKind uint8
+
+const (
+	functionalIndexExprInvalid functionalIndexExprKind = iota
+	functionalIndexExprInteger
+	functionalIndexExprString
+	functionalIndexExprJSON
+)
+
+type functionalIndexExprVisit uint8
+
+const (
+	functionalIndexExprUnvisited functionalIndexExprVisit = iota
+	functionalIndexExprVisiting
+	functionalIndexExprDone
+)
+
+type functionalIndexExprValue struct {
+	kind functionalIndexExprKind
+	typ  Type
+}
 
 func hasFunctionalIndexKeyPart(parts []*tree.KeyPart) bool {
 	for _, part := range parts {
@@ -66,10 +89,403 @@ func requireFunctionalIndexProtocol(ctx context.Context, proc *process.Process) 
 	default:
 		ok = false
 	}
-	if !ok || version < defines.MORPCVersion56 {
+	if !ok || version < defines.MORPCVersion57 {
 		return moerr.NewNotSupported(ctx, functionalIndexProtocolError)
 	}
 	return nil
+}
+
+// validateFunctionalIndexExpression is the single semantic admission check for
+// persisted functional-index expressions. It intentionally reasons over the
+// resolved plan expression rather than the SQL spelling: implicit casts,
+// overload selection, assignment wrappers, and generated-column dependencies
+// are all part of the value that writers and readers will execute.
+func validateFunctionalIndexExpression(ctx context.Context, expr *plan.Expr, tableDef *TableDef) error {
+	if expr == nil || tableDef == nil {
+		return moerr.NewNotSupported(ctx, "functional index expression is not resolvable")
+	}
+	_, err := validateFunctionalIndexExpressionValue(ctx, expr, tableDef)
+	return err
+}
+
+func validateFunctionalIndexExpressionValue(
+	ctx context.Context,
+	expr *plan.Expr,
+	tableDef *TableDef,
+) (functionalIndexExprValue, error) {
+	if expr == nil || tableDef == nil {
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression is not resolvable")
+	}
+	states := make(map[int32]functionalIndexExprVisit)
+	values := make(map[int32]functionalIndexExprValue)
+	return validateFunctionalIndexExprNode(ctx, expr, tableDef, states, values)
+}
+
+func validateFunctionalIndexExprNode(
+	ctx context.Context,
+	expr *plan.Expr,
+	tableDef *TableDef,
+	states map[int32]functionalIndexExprVisit,
+	values map[int32]functionalIndexExprValue,
+) (functionalIndexExprValue, error) {
+	if expr == nil {
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression contains a nil node")
+	}
+
+	switch e := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		if e.Col == nil || e.Col.ColPos < 0 || int(e.Col.ColPos) >= len(tableDef.Cols) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression references an invalid column")
+		}
+		pos := e.Col.ColPos
+		col := tableDef.Cols[pos]
+		if col == nil {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression references a missing column")
+		}
+		if col.GeneratedCol != nil {
+			return validateFunctionalIndexGeneratedColumn(ctx, pos, col, tableDef, states, values)
+		}
+		if col.Typ.AutoIncr {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression cannot depend on an auto-increment column")
+		}
+		value := functionalIndexValueForType(col.Typ)
+		if value.kind == functionalIndexExprInvalid {
+			return functionalIndexExprValue{}, moerr.NewNotSupportedf(ctx, "functional index expression references unsupported column type %s", types.T(col.Typ.Id).String())
+		}
+		return value, nil
+
+	case *plan.Expr_Lit:
+		value := functionalIndexValueForType(expr.Typ)
+		if value.kind == functionalIndexExprInvalid {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression contains an unsupported literal type")
+		}
+		if value.kind == functionalIndexExprString && (e.Lit == nil || e.Lit.Isnull) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression contains an untyped string literal")
+		}
+		return value, nil
+
+	case *plan.Expr_F:
+		if e.F == nil || e.F.Func == nil {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression contains an unresolved function")
+		}
+		fid, overload, ok := functionalIndexKnownOverload(e.F.Func.Obj)
+		if !ok {
+			return functionalIndexExprValue{}, moerr.NewNotSupportedf(ctx, "functional index expression uses an unknown overload for '%s'", e.F.Func.ObjName)
+		}
+		return validateFunctionalIndexFunction(ctx, fid, overload, e.F, expr, tableDef, states, values)
+
+	default:
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression contains an unsupported plan node")
+	}
+}
+
+func validateFunctionalIndexGeneratedColumn(
+	ctx context.Context,
+	pos int32,
+	col *ColDef,
+	tableDef *TableDef,
+	states map[int32]functionalIndexExprVisit,
+	values map[int32]functionalIndexExprValue,
+) (functionalIndexExprValue, error) {
+	switch states[pos] {
+	case functionalIndexExprVisiting:
+		return functionalIndexExprValue{}, moerr.NewNotSupportedf(ctx, "functional index expression has a cyclic generated-column dependency at '%s'", col.Name)
+	case functionalIndexExprDone:
+		return values[pos], nil
+	}
+	if col.GeneratedCol == nil || col.GeneratedCol.Expr == nil {
+		return functionalIndexExprValue{}, moerr.NewNotSupportedf(ctx, "functional index expression depends on generated column '%s' without an expression", col.Name)
+	}
+	states[pos] = functionalIndexExprVisiting
+	value, err := validateFunctionalIndexExprNode(ctx, col.GeneratedCol.Expr, tableDef, states, values)
+	if err != nil {
+		return functionalIndexExprValue{}, err
+	}
+	value, err = validateFunctionalIndexAssignmentTarget(ctx, value, col.Typ)
+	if err != nil {
+		return functionalIndexExprValue{}, moerr.NewNotSupportedf(ctx,
+			"functional index expression depends on generated column '%s': %s", col.Name, err)
+	}
+	states[pos] = functionalIndexExprDone
+	values[pos] = value
+	return value, nil
+}
+
+func functionalIndexKnownOverload(overloadID int64) (fid, overload int32, ok bool) {
+	fid, overload = function.DecodeOverloadID(overloadID)
+	if fid < 0 || overload < 0 {
+		return fid, overload, false
+	}
+	// Catalog metadata is not trusted input. The function package historically
+	// assumes a valid overload index and can panic for a malformed one, so keep
+	// the admission check total and fail closed at this boundary.
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	_, ok = function.GetFunctionByIdWithoutError(overloadID)
+	return fid, overload, ok
+}
+
+func functionalIndexValueForType(typ Type) functionalIndexExprValue {
+	switch types.T(typ.Id) {
+	case types.T_int8, types.T_int16, types.T_int32, types.T_int64,
+		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64:
+		return functionalIndexExprValue{kind: functionalIndexExprInteger, typ: typ}
+	case types.T_varchar:
+		if functionalIndexFixedVarchar(typ) {
+			return functionalIndexExprValue{kind: functionalIndexExprString, typ: typ}
+		}
+	case types.T_json:
+		return functionalIndexExprValue{kind: functionalIndexExprJSON, typ: typ}
+	}
+	return functionalIndexExprValue{kind: functionalIndexExprInvalid, typ: typ}
+}
+
+func functionalIndexFixedVarchar(typ Type) bool {
+	if typ.Id != int32(types.T_varchar) || typ.Width <= 0 || typ.Width > types.MaxVarcharLen || typ.PadSpace {
+		return false
+	}
+	switch typ.Charset {
+	case uint32(types.CharsetUTF8), uint32(types.CharsetUTF8MB4Bin):
+		return true
+	default:
+		return false
+	}
+}
+
+func functionalIndexJSONPathLiteral(expr *plan.Expr) bool {
+	if expr == nil || expr.GetLit() == nil || expr.GetLit().Isnull {
+		return false
+	}
+	return types.T(expr.Typ.Id).IsMySQLString() && expr.Typ.Id != int32(types.T_char) &&
+		expr.Typ.Id != int32(types.T_binary) && expr.Typ.Id != int32(types.T_varbinary)
+}
+
+func functionalIndexTypesEqual(a, b Type) bool {
+	return a.Id == b.Id && a.Width == b.Width && a.Scale == b.Scale &&
+		a.Charset == b.Charset && a.PadSpace == b.PadSpace
+}
+
+func functionalIndexIntegerBits(oid types.T) int {
+	switch oid {
+	case types.T_int8, types.T_uint8:
+		return 8
+	case types.T_int16, types.T_uint16:
+		return 16
+	case types.T_int32, types.T_uint32:
+		return 32
+	case types.T_int64, types.T_uint64:
+		return 64
+	default:
+		return 0
+	}
+}
+
+func functionalIndexIntegerWidening(source, target Type) bool {
+	if !types.T(source.Id).IsInteger() || !types.T(target.Id).IsInteger() {
+		return false
+	}
+	if source.Id == target.Id {
+		return true
+	}
+	sourceUnsigned := types.T(source.Id).IsUnsignedInt()
+	targetUnsigned := types.T(target.Id).IsUnsignedInt()
+	sourceBits, targetBits := functionalIndexIntegerBits(types.T(source.Id)), functionalIndexIntegerBits(types.T(target.Id))
+	if sourceBits == 0 || targetBits == 0 {
+		return false
+	}
+	if sourceUnsigned == targetUnsigned {
+		return targetBits >= sourceBits
+	}
+	// An unsigned value can widen to a signed type only when the destination is
+	// strictly wider.  The opposite direction can change the representable
+	// range and is therefore never an admission-safe cast.
+	return sourceUnsigned && !targetUnsigned && targetBits > sourceBits
+}
+
+// validateFunctionalIndexAssignmentTarget checks the conversion that the
+// generated-column declaration applies after evaluating its expression.  A
+// dependency is only safe when this boundary cannot truncate a value or turn
+// an error into a session-mode-dependent warning.
+func validateFunctionalIndexAssignmentTarget(
+	ctx context.Context,
+	source functionalIndexExprValue,
+	target Type,
+) (functionalIndexExprValue, error) {
+	targetValue := functionalIndexValueForType(target)
+	if targetValue.kind == functionalIndexExprInvalid {
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "generated-column declaration has an unsupported type")
+	}
+	if functionalIndexTypesEqual(source.typ, target) {
+		return targetValue, nil
+	}
+	switch targetValue.kind {
+	case functionalIndexExprInteger:
+		if source.kind == functionalIndexExprInteger && functionalIndexIntegerWidening(source.typ, target) {
+			return targetValue, nil
+		}
+	case functionalIndexExprString:
+		if source.kind == functionalIndexExprString && functionalIndexFixedVarchar(source.typ) &&
+			functionalIndexFixedVarchar(target) && source.typ.Charset == target.Charset &&
+			target.Width >= source.typ.Width {
+			return targetValue, nil
+		}
+	}
+	return functionalIndexExprValue{}, moerr.NewNotSupported(ctx,
+		"generated-column declaration changes value or assignment error semantics")
+}
+
+func validateFunctionalIndexFunction(
+	ctx context.Context,
+	fid int32,
+	overload int32,
+	fn *plan.Function,
+	expr *plan.Expr,
+	tableDef *TableDef,
+	states map[int32]functionalIndexExprVisit,
+	values map[int32]functionalIndexExprValue,
+) (functionalIndexExprValue, error) {
+	args := fn.Args
+	child := func(index int) (functionalIndexExprValue, error) {
+		if index < 0 || index >= len(args) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index expression has invalid function arguments")
+		}
+		return validateFunctionalIndexExprNode(ctx, args[index], tableDef, states, values)
+	}
+
+	switch fid {
+	case function.PLUS:
+		if overload != 0 || len(args) != 2 {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index integer addition requires two arguments")
+		}
+		left, err := child(0)
+		if err != nil {
+			return functionalIndexExprValue{}, err
+		}
+		right, err := child(1)
+		if err != nil {
+			return functionalIndexExprValue{}, err
+		}
+		if left.kind != functionalIndexExprInteger || right.kind != functionalIndexExprInteger || !types.T(expr.Typ.Id).IsInteger() {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index integer addition requires integer operands")
+		}
+		return functionalIndexExprValue{kind: functionalIndexExprInteger, typ: expr.Typ}, nil
+
+	case function.LOWER:
+		if overload != 0 || len(args) != 1 {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index lower requires one argument")
+		}
+		arg, err := child(0)
+		if err != nil {
+			return functionalIndexExprValue{}, err
+		}
+		if arg.kind != functionalIndexExprString || !functionalIndexFixedVarchar(arg.typ) || !functionalIndexFixedVarchar(expr.Typ) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index lower requires fixed UTF8MB4 VARCHAR semantics")
+		}
+		return functionalIndexExprValue{kind: functionalIndexExprString, typ: expr.Typ}, nil
+
+	case function.JSON_EXTRACT:
+		if overload != 0 || len(args) != 2 || args[0] == nil || args[0].Typ.Id != int32(types.T_json) || !functionalIndexJSONPathLiteral(args[1]) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index JSON extraction requires one constant path")
+		}
+		arg, err := child(0)
+		if err != nil {
+			return functionalIndexExprValue{}, err
+		}
+		if arg.kind != functionalIndexExprJSON || expr.Typ.Id != int32(types.T_json) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index JSON extraction requires a JSON value")
+		}
+		return functionalIndexExprValue{kind: functionalIndexExprJSON, typ: expr.Typ}, nil
+
+	case function.JSON_UNQUOTE:
+		if overload != 0 || len(args) != 1 {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index JSON_UNQUOTE requires one argument")
+		}
+		arg, err := child(0)
+		if err != nil {
+			return functionalIndexExprValue{}, err
+		}
+		argFn := args[0].GetF()
+		argFID := int32(-1)
+		if argFn != nil && argFn.Func != nil {
+			argFID, _, _ = functionalIndexKnownOverload(argFn.Func.Obj)
+		}
+		if arg.kind != functionalIndexExprJSON || argFID != function.JSON_EXTRACT || !functionalIndexFixedVarchar(expr.Typ) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index JSON_UNQUOTE requires a constant-path JSON extraction")
+		}
+		return functionalIndexExprValue{kind: functionalIndexExprString, typ: expr.Typ}, nil
+
+	case function.CAST, function.CAST_STRICT, function.CAST_ASSIGN, function.CAST_IGNORE:
+		if fid == function.CAST && overload > 1 {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast overload is not session-invariant")
+		}
+		if fid != function.CAST && overload != 0 {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast overload is not session-invariant")
+		}
+		return validateFunctionalIndexCast(ctx, fid, fn, expr, tableDef, states, values)
+
+	default:
+		return functionalIndexExprValue{}, moerr.NewNotSupportedf(ctx, "functional index function '%s' is not in the session-invariant allowlist", fn.Func.ObjName)
+	}
+}
+
+func validateFunctionalIndexCast(
+	ctx context.Context,
+	fid int32,
+	fn *plan.Function,
+	expr *plan.Expr,
+	tableDef *TableDef,
+	states map[int32]functionalIndexExprVisit,
+	values map[int32]functionalIndexExprValue,
+) (functionalIndexExprValue, error) {
+	if len(fn.Args) != 2 || fn.Args[1] == nil || fn.Args[1].GetT() == nil {
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast has no fixed target type")
+	}
+	source, err := validateFunctionalIndexExprNode(ctx, fn.Args[0], tableDef, states, values)
+	if err != nil {
+		return functionalIndexExprValue{}, err
+	}
+	target := fn.Args[1].Typ
+	targetValue := functionalIndexValueForType(target)
+	if targetValue.kind == functionalIndexExprInvalid {
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast targets an unsupported type")
+	}
+	switch targetValue.kind {
+	case functionalIndexExprInteger:
+		if source.kind != functionalIndexExprInteger || !functionalIndexIntegerWidening(source.typ, target) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast is not an integer widening conversion")
+		}
+	case functionalIndexExprString:
+		if source.kind != functionalIndexExprString || !functionalIndexFixedVarchar(target) {
+			return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast requires fixed UTF8MB4 VARCHAR semantics")
+		}
+		isAssignmentWrapper := fid != function.CAST
+		if !functionalIndexTypesEqual(source.typ, target) {
+			if isAssignmentWrapper {
+				if target.Charset != source.typ.Charset || target.PadSpace || target.Width < source.typ.Width {
+					return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index assignment cast may depend on session width or collation semantics")
+				}
+			} else if !functionalIndexJSONUnquoteExpr(fn.Args[0]) && target.Charset != source.typ.Charset {
+				return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast changes string collation semantics")
+			}
+		}
+	default:
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast result is not session-invariant")
+	}
+	if !functionalIndexTypesEqual(expr.Typ, target) {
+		return functionalIndexExprValue{}, moerr.NewNotSupported(ctx, "functional index cast result metadata is inconsistent")
+	}
+	return targetValue, nil
+}
+
+func functionalIndexJSONUnquoteExpr(expr *plan.Expr) bool {
+	if expr == nil || expr.GetF() == nil || expr.GetF().Func == nil {
+		return false
+	}
+	fid, _, ok := functionalIndexKnownOverload(expr.GetF().Func.Obj)
+	return ok && fid == function.JSON_UNQUOTE
 }
 
 func functionalIndexColumnName(indexName string) string {
@@ -173,6 +589,9 @@ func lowerFunctionalIndex(ctx CompilerContext, indexInfo *tree.Index, tableDef *
 		return nil, err
 	}
 	if err = checkGeneratedExprReferences(ctx.GetContext(), bound, indexName, tableDef.Cols, make(map[int32]bool)); err != nil {
+		return nil, err
+	}
+	if err = validateFunctionalIndexExpression(ctx.GetContext(), bound, tableDef); err != nil {
 		return nil, err
 	}
 	if err = checkFunctionalIndexResultType(ctx.GetContext(), bound.Typ); err != nil {
@@ -392,7 +811,7 @@ func stripFunctionalAssignmentCast(expr *plan.Expr) *plan.Expr {
 	switch strings.ToLower(fn.Func.ObjName) {
 	case "cast", "cast_strict", "cast_assign", "cast_ignore":
 		arg := fn.Args[0]
-		if arg != nil && arg.Typ.Id == expr.Typ.Id && arg.Typ.Width == expr.Typ.Width && arg.Typ.Scale == expr.Typ.Scale && arg.Typ.Charset == expr.Typ.Charset {
+		if arg != nil && functionalIndexTypesEqual(arg.Typ, expr.Typ) {
 			return arg
 		}
 	}
@@ -405,7 +824,39 @@ func functionalExpressionMatches(generated, query *plan.Expr) bool {
 	}
 	left := normalizeFunctionalExpr(stripFunctionalAssignmentCast(generated))
 	right := normalizeFunctionalExpr(stripFunctionalAssignmentCast(query))
-	return exprStructuralEqual(left, right)
+	return functionalIndexExprTypesEqual(left, right) && exprStructuralEqual(left, right)
+}
+
+func functionalIndexExprTypesEqual(left, right *plan.Expr) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left.Typ.PadSpace != right.Typ.PadSpace {
+		return false
+	}
+	switch l := left.Expr.(type) {
+	case *plan.Expr_F:
+		r, ok := right.Expr.(*plan.Expr_F)
+		if !ok || l.F == nil || r.F == nil || len(l.F.Args) != len(r.F.Args) {
+			return ok && l.F == r.F
+		}
+		for i := range l.F.Args {
+			if !functionalIndexExprTypesEqual(l.F.Args[i], r.F.Args[i]) {
+				return false
+			}
+		}
+	case *plan.Expr_List:
+		r, ok := right.Expr.(*plan.Expr_List)
+		if !ok || l.List == nil || r.List == nil || len(l.List.List) != len(r.List.List) {
+			return ok && l.List == r.List
+		}
+		for i := range l.List.List {
+			if !functionalIndexExprTypesEqual(l.List.List[i], r.List.List[i]) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // functionalIndexQueryExpr returns the generated expression and its hidden
@@ -413,6 +864,9 @@ func functionalExpressionMatches(generated, query *plan.Expr) bool {
 // metadata disables the optional optimization instead of changing results.
 func functionalIndexQueryExpr(tableDef *TableDef, indexDef *plan.IndexDef) (*plan.Expr, int32, bool) {
 	if !isFunctionalIndexDef(tableDef, indexDef) {
+		return nil, -1, false
+	}
+	if err := validateFunctionalIndexMetadata(context.Background(), tableDef); err != nil {
 		return nil, -1, false
 	}
 	name := catalog.ResolveAlias(indexDef.Parts[0])
@@ -449,6 +903,15 @@ func validateFunctionalIndexMetadata(ctx context.Context, tableDef *TableDef) er
 	}
 	functionalRefs := make(map[string]int)
 	for _, indexDef := range tableDef.Indexes {
+		if indexDef == nil {
+			return moerr.NewInternalError(ctx, "functional index has nil metadata")
+		}
+		for partPos, part := range indexDef.Parts {
+			if catalog.IsFunctionalIndexColumnName(catalog.ResolveAlias(part)) &&
+				(partPos != 0 || !hasFunctionalIndexColumnPart(indexDef)) {
+				return moerr.NewInternalError(ctx, "functional index hidden column is used by an unsupported key shape")
+			}
+		}
 		if !hasFunctionalIndexColumnPart(indexDef) {
 			continue
 		}
@@ -463,6 +926,21 @@ func validateFunctionalIndexMetadata(ctx context.Context, tableDef *TableDef) er
 	for name := range functionalColumns {
 		if functionalRefs[name] != 1 {
 			return moerr.NewInternalError(ctx, "functional index has orphaned hidden generated-column metadata")
+		}
+	}
+	for _, col := range tableDef.Cols {
+		if col == nil || !catalog.IsFunctionalIndexColumnName(col.Name) || col.GeneratedCol == nil {
+			continue
+		}
+		value, err := validateFunctionalIndexExpressionValue(ctx, col.GeneratedCol.Expr, tableDef)
+		if err != nil {
+			return moerr.NewInternalErrorf(ctx, "functional index column '%s' has session-dependent expression: %s", col.Name, err)
+		}
+		if _, err = validateFunctionalIndexAssignmentTarget(ctx, value, col.Typ); err != nil {
+			return moerr.NewInternalErrorf(ctx, "functional index column '%s' has unsafe declared type: %s", col.Name, err)
+		}
+		if err = checkFunctionalIndexResultType(ctx, col.Typ); err != nil {
+			return moerr.NewInternalErrorf(ctx, "functional index column '%s' has unsupported key type: %s", col.Name, err)
 		}
 	}
 	return nil

--- a/pkg/sql/plan/functional_index.go
+++ b/pkg/sql/plan/functional_index.go
@@ -32,7 +32,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
-const functionalIndexProtocolError = "functional indexes require all CNs to support protocol version 48"
+const functionalIndexProtocolError = "functional indexes require all CNs to support protocol version 56"
 
 func hasFunctionalIndexKeyPart(parts []*tree.KeyPart) bool {
 	for _, part := range parts {
@@ -66,7 +66,7 @@ func requireFunctionalIndexProtocol(ctx context.Context, proc *process.Process) 
 	default:
 		ok = false
 	}
-	if !ok || version < defines.MORPCVersion48 {
+	if !ok || version < defines.MORPCVersion56 {
 		return moerr.NewNotSupported(ctx, functionalIndexProtocolError)
 	}
 	return nil

--- a/pkg/sql/plan/functional_index.go
+++ b/pkg/sql/plan/functional_index.go
@@ -904,7 +904,7 @@ func validateFunctionalIndexMetadata(ctx context.Context, tableDef *TableDef) er
 	functionalRefs := make(map[string]int)
 	for _, indexDef := range tableDef.Indexes {
 		if indexDef == nil {
-			return moerr.NewInternalError(ctx, "functional index has nil metadata")
+			continue
 		}
 		for partPos, part := range indexDef.Parts {
 			if catalog.IsFunctionalIndexColumnName(catalog.ResolveAlias(part)) &&

--- a/pkg/sql/plan/functional_index_test.go
+++ b/pkg/sql/plan/functional_index_test.go
@@ -139,6 +139,13 @@ func TestFunctionalIndexDefRequiresCompleteHiddenGeneratedColumn(t *testing.T) {
 
 	table.Cols[0].GeneratedCol = nil
 	require.False(t, isFunctionalIndexDef(table, table.Indexes[0]))
+	table.Cols[0].GeneratedCol = &plan.GeneratedCol{
+		Expr:         &plan.Expr{Typ: Type{Id: int32(types.T_int64)}, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}}},
+		OriginString: "lower(name)",
+		IsStored:     true,
+	}
+	require.False(t, isFunctionalIndexDef(table, table.Indexes[0]))
+	require.Error(t, validateFunctionalIndexMetadata(context.Background(), table))
 
 	table.Cols[0].GeneratedCol = &plan.GeneratedCol{
 		Expr:         &plan.Expr{Typ: Type{Id: int32(types.T_int64)}},
@@ -146,6 +153,9 @@ func TestFunctionalIndexDefRequiresCompleteHiddenGeneratedColumn(t *testing.T) {
 	}
 	table.Indexes[0].Parts = append(table.Indexes[0].Parts, "b")
 	require.False(t, isFunctionalIndexDef(table, table.Indexes[0]))
+	require.Error(t, validateFunctionalIndexMetadata(context.Background(), table))
+	table.Indexes[0].Parts = table.Indexes[0].Parts[:2]
+	table.Indexes = nil
 	require.Error(t, validateFunctionalIndexMetadata(context.Background(), table))
 }
 

--- a/pkg/sql/plan/functional_index_test.go
+++ b/pkg/sql/plan/functional_index_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunctionalIndexColumnNameIsStableAndCaseInsensitive(t *testing.T) {
+	got := functionalIndexColumnName("Idx_JSON")
+	require.Equal(t, catalog.FunctionalIndexColumnPrefix+"8f9256a3501a5ab88af691888f120a86", got)
+	require.Equal(t, got, functionalIndexColumnName("  idx_json "))
+	require.NotEqual(t, got, functionalIndexColumnName("idx_json_2"))
+}
+
+func TestSetEmptyIndexNameForFunctionalKeyPart(t *testing.T) {
+	index := &tree.Index{KeyParts: []*tree.KeyPart{{Expr: tree.NewNumVal(int64(1), "1", false, tree.P_int64)}}}
+	names := map[string]bool{indexNameKey("functional_index"): true}
+	setEmptyIndexName(names, index)
+	require.Equal(t, "functional_index_2", index.Name)
+}
+
+func TestRequireFunctionalIndexProtocol(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	rt := runtime.ServiceRuntime(proc.GetService())
+	original, hadOriginal := rt.GetGlobalVariables(runtime.MOProtocolVersion)
+	defer func() {
+		if hadOriginal {
+			rt.SetGlobalVariables(runtime.MOProtocolVersion, original)
+		} else {
+			rt.CompareAndDeleteGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion48)
+		}
+	}()
+
+	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion45)
+	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 48")
+	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion48)
+	require.NoError(t, requireFunctionalIndexProtocol(context.Background(), proc))
+}
+
+func TestNormalAlterIndexKeyPartIsNotFunctional(t *testing.T) {
+	stmts, err := parsers.Parse(context.Background(), dialect.MYSQL, "ALTER TABLE t1 DROP INDEX idx, ADD INDEX idx(b)", 1)
+	require.NoError(t, err)
+	alter, ok := stmts[0].(*tree.AlterTable)
+	require.True(t, ok)
+	for _, option := range alter.Options {
+		if add, ok := option.(*tree.AlterOptionAdd); ok {
+			index, ok := add.Def.(*tree.Index)
+			require.True(t, ok)
+			require.False(t, hasFunctionalIndexKeyPart(index.KeyParts))
+		}
+	}
+	algorithm, err := ResolveAlterTableAlgorithm(context.Background(), alter.Options, &TableDef{})
+	require.NoError(t, err)
+	require.Equal(t, plan.AlterTable_INPLACE, algorithm)
+}
+
+func TestCheckFunctionalIndexResultTypeRejectsUnindexableTypes(t *testing.T) {
+	ctx := context.Background()
+	for _, id := range []types.T{types.T_json, types.T_text, types.T_blob, types.T_geometry, types.T_array_float32} {
+		err := checkFunctionalIndexResultType(ctx, Type{Id: int32(id)})
+		require.Error(t, err, id)
+	}
+	require.NoError(t, checkFunctionalIndexResultType(ctx, Type{Id: int32(types.T_varchar), Width: 64, Charset: uint32(types.CharsetType(types.T_varchar))}))
+}
+
+func TestFunctionalExpressionMatchesNormalizesRelationAndAssignmentCast(t *testing.T) {
+	typ := Type{Id: int32(types.T_int64), Width: 64}
+	generated := &plan.Expr{
+		Typ:  typ,
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 12, ColPos: 3}},
+	}
+	query := &plan.Expr{
+		Typ:  typ,
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 1, ColPos: 3}},
+	}
+	require.True(t, functionalExpressionMatches(generated, query))
+
+	casted := &plan.Expr{
+		Typ:  typ,
+		Expr: &plan.Expr_F{F: &plan.Function{Func: &plan.ObjectRef{ObjName: "cast_assign"}, Args: []*plan.Expr{query}}},
+	}
+	require.True(t, functionalExpressionMatches(generated, casted))
+
+	wrongColumn := DeepCopyExpr(query)
+	wrongColumn.GetCol().ColPos++
+	require.False(t, functionalExpressionMatches(generated, wrongColumn))
+}
+
+func TestFunctionalIndexDefRequiresCompleteHiddenGeneratedColumn(t *testing.T) {
+	table := &TableDef{
+		Cols: []*ColDef{{
+			Name:   "__mo_fi_deadbeef",
+			Hidden: true,
+			GeneratedCol: &plan.GeneratedCol{
+				Expr:         &plan.Expr{Typ: Type{Id: int32(types.T_int64)}, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}}},
+				OriginString: "lower(name)",
+			},
+		}},
+		Indexes: []*plan.IndexDef{{
+			IndexName: "idx_name",
+			IndexAlgo: "",
+			Parts:     []string{"__mo_fi_deadbeef", catalog.CreateAlias("id")},
+		}},
+	}
+	require.True(t, isFunctionalIndexDef(table, table.Indexes[0]))
+	require.Equal(t, "lower(name)", func() string {
+		origin, ok := functionalIndexOrigin(table, table.Indexes[0])
+		if !ok {
+			return ""
+		}
+		return origin
+	}())
+
+	table.Cols[0].GeneratedCol = nil
+	require.False(t, isFunctionalIndexDef(table, table.Indexes[0]))
+
+	table.Cols[0].GeneratedCol = &plan.GeneratedCol{
+		Expr:         &plan.Expr{Typ: Type{Id: int32(types.T_int64)}},
+		OriginString: "lower(name)",
+	}
+	table.Indexes[0].Parts = append(table.Indexes[0].Parts, "b")
+	require.False(t, isFunctionalIndexDef(table, table.Indexes[0]))
+	require.Error(t, validateFunctionalIndexMetadata(context.Background(), table))
+}
+
+func TestTrimFunctionalOuterParenthesesOnlyWhenTheyEncloseWholeExpr(t *testing.T) {
+	require.Equal(t, "a + 1", trimFunctionalOuterParentheses("(a + 1)"))
+	require.Equal(t, "(a + 1) * 2", trimFunctionalOuterParentheses("(a + 1) * 2"))
+	require.Equal(t, "json_extract(doc, '$.sku')", trimFunctionalOuterParentheses("(json_extract(doc, '$.sku'))"))
+	require.Equal(t, "(a + 1", trimFunctionalOuterParentheses("(a + 1"))
+}
+
+func TestLowerFunctionalIndexAddsPrivateVirtualGeneratedColumn(t *testing.T) {
+	stmts, err := parsers.Parse(context.Background(), dialect.MYSQL, "select a + 1", 1)
+	require.NoError(t, err)
+	selectStmt := stmts[0].(*tree.Select)
+	selectClause := selectStmt.Select.(*tree.SelectClause)
+
+	cctx := NewMockCompilerContext(false)
+	cctx.SetContext(context.Background())
+	table := &TableDef{
+		Name: "t",
+		Cols: []*ColDef{{
+			Name: "a",
+			Typ:  Type{Id: int32(types.T_int32), Width: 32},
+		}},
+	}
+	index := &tree.Index{
+		Name: "idx_a_plus_one",
+		KeyParts: []*tree.KeyPart{{
+			Expr: selectClause.Exprs[0].Expr,
+		}},
+	}
+	lowered, err := lowerFunctionalIndex(cctx, index, table)
+	require.NoError(t, err)
+	require.Len(t, table.Cols, 2)
+	hidden := table.Cols[1]
+	require.True(t, hidden.Hidden)
+	require.Equal(t, functionalIndexColumnName(index.Name), hidden.Name)
+	require.NotNil(t, hidden.GeneratedCol)
+	require.False(t, hidden.GeneratedCol.IsStored)
+	require.Equal(t, "a + 1", hidden.GeneratedCol.OriginString)
+	require.Equal(t, hidden.Name, lowered.KeyParts[0].ColName.ColName())
+	require.Nil(t, index.KeyParts[0].ColName)
+}
+
+func TestBuildCreateTableLowersInlineFunctionalIndex(t *testing.T) {
+	optimizer := NewMockOptimizer(false)
+	created, err := runOneStmt(optimizer, t, "create table functional_inline (id int primary key, a int, key idx_a ((a + 1)))")
+	require.NoError(t, err)
+	table := created.GetDdl().GetCreateTable().GetTableDef()
+	require.Len(t, table.Indexes, 1)
+	require.Len(t, table.Cols, 3)
+	hidden := table.Cols[2]
+	require.True(t, hidden.Hidden)
+	require.NotNil(t, hidden.GeneratedCol)
+	require.Equal(t, "a + 1", hidden.GeneratedCol.OriginString)
+	require.Equal(t, hidden.Name, table.Indexes[0].Parts[0])
+
+	jsonTable, err := runOneStmt(optimizer, t, "create table functional_json_text (id int primary key, doc json, key idx_sku ((json_unquote(json_extract(doc, '$.sku')))))")
+	require.NoError(t, err)
+	jsonDef := jsonTable.GetDdl().GetCreateTable().GetTableDef()
+	require.Len(t, jsonDef.GetIndexes(), 1)
+	jsonHidden := FindColumn(jsonDef.GetCols(), jsonDef.GetIndexes()[0].GetParts()[0])
+	require.NotNil(t, jsonHidden)
+	require.Equal(t, int32(types.T_varchar), jsonHidden.GetTyp().Id)
+
+	noPK, err := runOneStmt(optimizer, t, "create table functional_no_pk (a int, key idx_a ((a + 1)))")
+	require.NoError(t, err)
+	noPKDef := noPK.GetDdl().GetCreateTable().GetTableDef()
+	require.True(t, catalog.IsFakePkName(noPKDef.GetCols()[len(noPKDef.GetCols())-1].GetName()))
+	require.True(t, noPKDef.GetCols()[len(noPKDef.GetCols())-2].GetHidden())
+}
+
+func TestBuildStandaloneAndAlterFunctionalIndexUseCopyDDL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{name: "create index", sql: "create index idx_expr on constraint_test.t1 ((a + 1))"},
+		{name: "alter table", sql: "alter table constraint_test.t1 add index idx_expr2 ((a + 1))"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			optimizer := NewMockOptimizer(false)
+			got, err := buildSingleStmt(optimizer, t, tc.sql)
+			require.NoError(t, err)
+			alter := got.GetDdl().GetAlterTable()
+			require.NotNil(t, alter)
+			require.Equal(t, plan.AlterTable_COPY, alter.GetAlgorithmType())
+			require.NotNil(t, alter.GetCopyTableDef())
+			var functional *plan.IndexDef
+			for _, indexDef := range alter.GetCopyTableDef().GetIndexes() {
+				if indexDef != nil && indexDef.GetIndexName() != "PRIMARY" && isFunctionalIndexDef(alter.GetCopyTableDef(), indexDef) {
+					functional = indexDef
+					break
+				}
+			}
+			require.NotNil(t, functional)
+			name := catalog.ResolveAlias(functional.GetParts()[0])
+			hidden := FindColumn(alter.GetCopyTableDef().GetCols(), name)
+			require.NotNil(t, hidden)
+			require.True(t, hidden.GetHidden())
+			require.NotNil(t, hidden.GetGeneratedCol())
+		})
+	}
+}
+
+func TestBuildCreateTableRejectsUnsupportedFunctionalIndexShapes(t *testing.T) {
+	tests := []string{
+		"create table functional_unique (id int primary key, a int, unique key idx_a ((a + 1)))",
+		"create table functional_composite (id int primary key, a int, b int, key idx_ab ((a + 1), b))",
+		"create table functional_json (id int primary key, doc json, key idx_doc ((json_extract(doc, '$.sku'))))",
+	}
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			_, err := runOneStmt(NewMockOptimizer(false), t, sql)
+			require.Error(t, err)
+			require.Contains(t, strings.ToLower(err.Error()), "functional")
+		})
+	}
+}
+
+func TestShowCreateTableRendersFunctionalExpressionAndHidesImplementationColumn(t *testing.T) {
+	optimizer := NewMockOptimizer(false)
+	tableDef, err := buildTestCreateTableStmt(optimizer, "create table functional_show (id int primary key, a int, key idx_a ((a + 1)))")
+	require.NoError(t, err)
+	got, _, err := ConstructCreateTableSQL(&optimizer.ctxt, tableDef, nil, false, nil)
+	require.NoError(t, err)
+	require.Contains(t, got, "KEY `idx_a` ((a + 1))")
+	require.NotContains(t, got, catalog.FunctionalIndexColumnPrefix)
+
+	tableDef.Cols[len(tableDef.Cols)-1].GeneratedCol.OriginString = ""
+	_, _, err = ConstructCreateTableSQL(&optimizer.ctxt, tableDef, nil, false, nil)
+	require.Error(t, err)
+}

--- a/pkg/sql/plan/functional_index_test.go
+++ b/pkg/sql/plan/functional_index_test.go
@@ -53,13 +53,15 @@ func TestRequireFunctionalIndexProtocol(t *testing.T) {
 		if hadOriginal {
 			rt.SetGlobalVariables(runtime.MOProtocolVersion, original)
 		} else {
-			rt.CompareAndDeleteGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion57)
+			rt.CompareAndDeleteGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion59)
 		}
 	}()
 
 	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion56)
-	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 57")
-	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion57)
+	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 59")
+	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion58)
+	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 59")
+	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion59)
 	require.NoError(t, requireFunctionalIndexProtocol(context.Background(), proc))
 }
 

--- a/pkg/sql/plan/functional_index_test.go
+++ b/pkg/sql/plan/functional_index_test.go
@@ -53,13 +53,13 @@ func TestRequireFunctionalIndexProtocol(t *testing.T) {
 		if hadOriginal {
 			rt.SetGlobalVariables(runtime.MOProtocolVersion, original)
 		} else {
-			rt.CompareAndDeleteGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion48)
+			rt.CompareAndDeleteGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion56)
 		}
 	}()
 
-	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion45)
-	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 48")
-	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion48)
+	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion55)
+	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 56")
+	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion56)
 	require.NoError(t, requireFunctionalIndexProtocol(context.Background(), proc))
 }
 

--- a/pkg/sql/plan/functional_index_test.go
+++ b/pkg/sql/plan/functional_index_test.go
@@ -53,13 +53,13 @@ func TestRequireFunctionalIndexProtocol(t *testing.T) {
 		if hadOriginal {
 			rt.SetGlobalVariables(runtime.MOProtocolVersion, original)
 		} else {
-			rt.CompareAndDeleteGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion56)
+			rt.CompareAndDeleteGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion57)
 		}
 	}()
 
-	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion55)
-	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 56")
 	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion56)
+	require.ErrorContains(t, requireFunctionalIndexProtocol(context.Background(), proc), "version 57")
+	rt.SetGlobalVariables(runtime.MOProtocolVersion, defines.MORPCVersion57)
 	require.NoError(t, requireFunctionalIndexProtocol(context.Background(), proc))
 }
 
@@ -110,6 +110,12 @@ func TestFunctionalExpressionMatchesNormalizesRelationAndAssignmentCast(t *testi
 	wrongColumn := DeepCopyExpr(query)
 	wrongColumn.GetCol().ColPos++
 	require.False(t, functionalExpressionMatches(generated, wrongColumn))
+
+	stringType := Type{Id: int32(types.T_varchar), Width: 16, Charset: uint32(types.CharsetUTF8)}
+	stringGenerated := &plan.Expr{Typ: stringType, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 1}}}
+	stringQuery := DeepCopyExpr(stringGenerated)
+	stringQuery.Typ.PadSpace = true
+	require.False(t, functionalExpressionMatches(stringGenerated, stringQuery))
 }
 
 func TestFunctionalIndexDefRequiresCompleteHiddenGeneratedColumn(t *testing.T) {
@@ -155,6 +161,12 @@ func TestFunctionalIndexDefRequiresCompleteHiddenGeneratedColumn(t *testing.T) {
 	require.False(t, isFunctionalIndexDef(table, table.Indexes[0]))
 	require.Error(t, validateFunctionalIndexMetadata(context.Background(), table))
 	table.Indexes[0].Parts = table.Indexes[0].Parts[:2]
+	table.Indexes = append(table.Indexes, &plan.IndexDef{
+		IndexName: "idx_bad_shape",
+		Parts:     []string{catalog.CreateAlias("id"), "__mo_fi_deadbeef"},
+	})
+	require.Error(t, validateFunctionalIndexMetadata(context.Background(), table))
+	table.Indexes = table.Indexes[:1]
 	table.Indexes = nil
 	require.Error(t, validateFunctionalIndexMetadata(context.Background(), table))
 }
@@ -274,6 +286,82 @@ func TestBuildCreateTableRejectsUnsupportedFunctionalIndexShapes(t *testing.T) {
 			require.Contains(t, strings.ToLower(err.Error()), "functional")
 		})
 	}
+}
+
+func TestBuildCreateTableRejectsSessionDependentFunctionalCast(t *testing.T) {
+	_, err := runOneStmt(NewMockOptimizer(false), t,
+		"create table functional_time (id int primary key, ts timestamp, key idx_time ((cast(ts as char(19)))))")
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "functional")
+}
+
+func TestLowerFunctionalIndexRejectsSessionDependentCastBeforePublishingColumn(t *testing.T) {
+	stmts, err := parsers.Parse(context.Background(), dialect.MYSQL, "select cast(ts as char(19))", 1)
+	require.NoError(t, err)
+	selectClause := stmts[0].(*tree.Select).Select.(*tree.SelectClause)
+	table := &TableDef{
+		Cols: []*ColDef{
+			{Name: "id", Typ: Type{Id: int32(types.T_int32), Width: 32}},
+			{Name: "ts", Typ: Type{Id: int32(types.T_timestamp), Scale: 6}},
+		},
+	}
+	index := &tree.Index{Name: "idx_time", KeyParts: []*tree.KeyPart{{Expr: selectClause.Exprs[0].Expr}}}
+	_, err = lowerFunctionalIndex(NewMockCompilerContext(false), index, table)
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "functional")
+	require.Len(t, table.Cols, 2)
+}
+
+func TestFunctionalIndexAdmissionRejectsSessionDependentGeneratedDependency(t *testing.T) {
+	created, err := runOneStmt(NewMockOptimizer(false), t,
+		"create table functional_time_dependency (id int primary key, ts timestamp, g varchar(19) generated always as (cast(ts as char(19))) virtual)")
+	require.NoError(t, err)
+	table := created.GetDdl().GetCreateTable().GetTableDef()
+	generated := FindColumn(table.Cols, "g")
+	require.NotNil(t, generated)
+	require.NotNil(t, generated.GeneratedCol)
+	require.Error(t, validateFunctionalIndexExpression(context.Background(), generated.GeneratedCol.Expr, table))
+}
+
+func TestFunctionalIndexAdmissionRejectsUnknownOverload(t *testing.T) {
+	table := &TableDef{Cols: []*ColDef{{Name: "a", Typ: Type{Id: int32(types.T_int64), Width: 64}}}}
+	expr := &plan.Expr{
+		Typ: Type{Id: int32(types.T_int64), Width: 64},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{Obj: int64(1000000) << 32, ObjName: "unknown"},
+		}},
+	}
+	require.Error(t, validateFunctionalIndexExpression(context.Background(), expr, table))
+}
+
+func TestFunctionalIndexAdmissionRejectsGeneratedColumnCycle(t *testing.T) {
+	table := &TableDef{Cols: []*ColDef{
+		{Name: "a", Typ: Type{Id: int32(types.T_int64), Width: 64}, GeneratedCol: &plan.GeneratedCol{
+			Expr: &plan.Expr{Typ: Type{Id: int32(types.T_int64), Width: 64}, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 1}}},
+		}},
+		{Name: "b", Typ: Type{Id: int32(types.T_int64), Width: 64}, GeneratedCol: &plan.GeneratedCol{
+			Expr: &plan.Expr{Typ: Type{Id: int32(types.T_int64), Width: 64}, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}}},
+		}},
+	}}
+	expr := &plan.Expr{Typ: Type{Id: int32(types.T_int64), Width: 64}, Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}}}
+	require.Error(t, validateFunctionalIndexExpression(context.Background(), expr, table))
+}
+
+func TestFunctionalIndexQueryRejectsUnsafePersistedMetadata(t *testing.T) {
+	created, err := runOneStmt(NewMockOptimizer(false), t,
+		"create table functional_metadata (id int primary key, a int, key idx_a ((a + 1)))")
+	require.NoError(t, err)
+	table := created.GetDdl().GetCreateTable().GetTableDef()
+	hidden := FindColumn(table.Cols, table.Indexes[0].Parts[0])
+	require.NotNil(t, hidden)
+	hidden.GeneratedCol.Expr = &plan.Expr{
+		Typ: hidden.Typ,
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{Obj: int64(1000000) << 32, ObjName: "unknown"},
+		}},
+	}
+	_, _, ok := functionalIndexQueryExpr(table, table.Indexes[0])
+	require.False(t, ok)
 }
 
 func TestShowCreateTableRendersFunctionalExpressionAndHidesImplementationColumn(t *testing.T) {

--- a/pkg/sql/plan/functional_index_test.go
+++ b/pkg/sql/plan/functional_index_test.go
@@ -119,6 +119,9 @@ func TestFunctionalExpressionMatchesNormalizesRelationAndAssignmentCast(t *testi
 }
 
 func TestFunctionalIndexDefRequiresCompleteHiddenGeneratedColumn(t *testing.T) {
+	require.NoError(t, validateFunctionalIndexMetadata(context.Background(), &TableDef{
+		Indexes: []*plan.IndexDef{nil},
+	}))
 	table := &TableDef{
 		Cols: []*ColDef{{
 			Name:   "__mo_fi_deadbeef",

--- a/pkg/tools/checkpointtool/table_dump.go
+++ b/pkg/tools/checkpointtool/table_dump.go
@@ -1209,11 +1209,15 @@ func functionalGeneratedExpressionsFromMoColumns(view *LogicalTableView, tableID
 		if hasGeneratedCol >= len(row) || generatedCol >= len(row) || !isTruthyCatalogValue(row[hasGeneratedCol]) {
 			return nil, moerr.NewInternalErrorf(context.Background(), "hidden functional-index column %q has no generated metadata", name)
 		}
-		expr, _ := decodeMoColumnGenerated(row[generatedCol])
-		if strings.TrimSpace(expr) == "" {
+		expr, stored := decodeMoColumnGenerated(row[generatedCol])
+		if stored || strings.TrimSpace(expr) == "" {
 			return nil, moerr.NewInternalErrorf(context.Background(), "hidden functional-index column %q has corrupt generated metadata", name)
 		}
-		result[name] = strings.TrimSpace(expr)
+		expr = strings.TrimSpace(expr)
+		if previous, exists := result[name]; exists && previous != expr {
+			return nil, moerr.NewInternalErrorf(context.Background(), "hidden functional-index column %q has inconsistent generated metadata", name)
+		}
+		result[name] = expr
 	}
 	return result, nil
 }
@@ -4504,6 +4508,7 @@ func buildCreateIndexStatementsFromMoIndexesWithGenerated(
 	tableIDStr := strconv.FormatUint(tableID, 10)
 	matchedRows := 0
 	hiddenRows := 0
+	usedGenerated := make(map[string]bool)
 	dataOffset := logicalViewDataOffset(view)
 	for _, row := range view.Rows {
 		if len(row) < dataOffset {
@@ -4553,6 +4558,10 @@ func buildCreateIndexStatementsFromMoIndexesWithGenerated(
 		}
 		isHiddenFunctional := isReservedFunctional
 		if isHiddenFunctional {
+			if len(info.columns) > 0 || info.functionalExpression != "" {
+				return nil, moerr.NewInternalErrorf(context.Background(),
+					"functional index %q has mixed or repeated hidden key parts", name)
+			}
 			expression := strings.TrimSpace(generated[colName])
 			if expression == "" {
 				return nil, moerr.NewInternalErrorf(context.Background(),
@@ -4564,10 +4573,15 @@ func buildCreateIndexStatementsFromMoIndexesWithGenerated(
 					"functional index %q has inconsistent generated metadata", name)
 			}
 			info.functionalExpression = expression
+			usedGenerated[colName] = true
 			continue
 		}
 		if colName == "" || catalog.IsAlias(colName) {
 			continue
+		}
+		if info.functionalExpression != "" {
+			return nil, moerr.NewInternalErrorf(context.Background(),
+				"functional index %q has mixed functional and ordinary key parts", name)
 		}
 		ordinal := len(info.columns) + 1
 		if ordinalCol >= 0 && ordinalCol < len(dataRow) {
@@ -4577,6 +4591,12 @@ func buildCreateIndexStatementsFromMoIndexesWithGenerated(
 		}
 		if existing, ok := info.columns[colName]; !ok || ordinal < existing.ordinal {
 			info.columns[colName] = indexDDLColumn{name: colName, ordinal: ordinal}
+		}
+	}
+	for name := range generated {
+		if !usedGenerated[name] {
+			return nil, moerr.NewInternalErrorf(context.Background(),
+				"hidden functional-index column %q has no matching index metadata", name)
 		}
 	}
 

--- a/pkg/tools/checkpointtool/table_dump.go
+++ b/pkg/tools/checkpointtool/table_dump.go
@@ -246,14 +246,15 @@ type indexDDLColumn struct {
 }
 
 type indexDDLInfo struct {
-	name       string
-	indexType  string
-	algo       string
-	algoParams string
-	comment    string
-	columns    map[string]indexDDLColumn
-	order      int
-	catalogID  uint64
+	name                 string
+	indexType            string
+	algo                 string
+	algoParams           string
+	comment              string
+	columns              map[string]indexDDLColumn
+	functionalExpression string
+	order                int
+	catalogID            uint64
 }
 
 type CSVExportOption func(*CSVExportOptions)
@@ -1173,6 +1174,50 @@ func buildTableSchemasForIDs(
 	return schemas
 }
 
+// functionalGeneratedExpressionsFromMoColumns decodes the origin text for
+// hidden functional-index columns. A hidden reserved-name column without a
+// complete generated payload is unrecoverable: silently emitting a DDL that
+// drops the expression would change the restored schema, so callers fail
+// closed instead.
+func functionalGeneratedExpressionsFromMoColumns(view *LogicalTableView, tableID uint64) (map[string]string, error) {
+	result := make(map[string]string)
+	if view == nil {
+		return result, nil
+	}
+	relIDCol := fallbackCatalogColIndex(view, moColumnsID, catalog.SystemColAttr_RelID)
+	nameCol := fallbackCatalogColIndex(view, moColumnsID, catalog.SystemColAttr_Name)
+	hiddenCol := fallbackCatalogColIndex(view, moColumnsID, catalog.SystemColAttr_IsHidden)
+	hasGeneratedCol := fallbackCatalogColIndex(view, moColumnsID, catalog.SystemColAttr_HasGenerated)
+	generatedCol := fallbackCatalogColIndex(view, moColumnsID, catalog.SystemColAttr_Generated)
+	if relIDCol < 0 || nameCol < 0 || hiddenCol < 0 || hasGeneratedCol < 0 || generatedCol < 0 {
+		return result, nil
+	}
+	tableIDStr := strconv.FormatUint(tableID, 10)
+	for _, fullRow := range view.Rows {
+		dataOffset := logicalViewDataOffset(view)
+		if len(fullRow) < dataOffset {
+			continue
+		}
+		row := fullRow[dataOffset:]
+		if relIDCol >= len(row) || nameCol >= len(row) || hiddenCol >= len(row) || row[relIDCol] != tableIDStr || !isTruthyCatalogValue(row[hiddenCol]) {
+			continue
+		}
+		name := strings.TrimSpace(row[nameCol])
+		if !catalog.IsFunctionalIndexColumnName(name) {
+			continue
+		}
+		if hasGeneratedCol >= len(row) || generatedCol >= len(row) || !isTruthyCatalogValue(row[hasGeneratedCol]) {
+			return nil, moerr.NewInternalErrorf(context.Background(), "hidden functional-index column %q has no generated metadata", name)
+		}
+		expr, _ := decodeMoColumnGenerated(row[generatedCol])
+		if strings.TrimSpace(expr) == "" {
+			return nil, moerr.NewInternalErrorf(context.Background(), "hidden functional-index column %q has corrupt generated metadata", name)
+		}
+		result[name] = strings.TrimSpace(expr)
+	}
+	return result, nil
+}
+
 func groupCatalogRowsByUintColumn(view *LogicalTableView, columnName string) map[uint64][][]string {
 	result := make(map[uint64][][]string)
 	if view == nil {
@@ -1418,6 +1463,14 @@ func (r *CheckpointReader) PrepareTableDumpDataForTables(
 	partitionToPrimary := make(map[uint64]uint64)
 	partitionIDsByPrimary := make(map[uint64][]uint64)
 	schemasByID := buildTableSchemasForIDs(tableIDs, moTablesView, moColumnsView)
+	functionalGeneratedByTable := make(map[uint64]map[string]string, len(tableIDs))
+	for _, tableID := range tableIDs {
+		generated, genErr := functionalGeneratedExpressionsFromMoColumns(moColumnsView, tableID)
+		if genErr != nil {
+			return nil, genErr
+		}
+		functionalGeneratedByTable[tableID] = generated
+	}
 	for _, tableID := range tableIDs {
 		if _, ok := tableSet[tableID]; ok {
 			continue
@@ -1482,8 +1535,9 @@ func (r *CheckpointReader) PrepareTableDumpDataForTables(
 		for primaryID := range primaries {
 			data := result[primaryID]
 			tableIndexesView := logicalViewWithRows(moIndexesView, indexRowsByTableID[primaryID])
-			data.IndexDDLs, err = buildCreateIndexStatementsFromMoIndexes(
+			data.IndexDDLs, err = buildCreateIndexStatementsFromMoIndexesWithGenerated(
 				tableIndexesView, primaryID, data.Schema.TableName,
+				functionalGeneratedByTable[primaryID],
 			)
 			if err != nil {
 				return nil, err
@@ -4193,7 +4247,15 @@ func (r *CheckpointReader) ShowCreateIndexStatements(
 	if err != nil {
 		return nil, err
 	}
-	return buildCreateIndexStatementsFromMoIndexes(view, tableID, tableName)
+	moColumnsView, err := r.getTableLogicalView(ctx, moColumnsID, snapshotTS)
+	if err != nil {
+		return nil, moerr.NewInternalErrorf(ctx, "read mo_columns for index restore: %v", err)
+	}
+	generated, err := functionalGeneratedExpressionsFromMoColumns(moColumnsView, tableID)
+	if err != nil {
+		return nil, err
+	}
+	return buildCreateIndexStatementsFromMoIndexesWithGenerated(view, tableID, tableName, generated)
 }
 
 func (r *CheckpointReader) getPartitionMetadataView(
@@ -4404,6 +4466,15 @@ func buildCreateIndexStatementsFromMoIndexes(
 	tableID uint64,
 	tableName string,
 ) ([]string, error) {
+	return buildCreateIndexStatementsFromMoIndexesWithGenerated(view, tableID, tableName, nil)
+}
+
+func buildCreateIndexStatementsFromMoIndexesWithGenerated(
+	view *LogicalTableView,
+	tableID uint64,
+	tableName string,
+	generated map[string]string,
+) ([]string, error) {
 	if view == nil {
 		return nil, nil
 	}
@@ -4451,7 +4522,7 @@ func buildCreateIndexStatementsFromMoIndexes(
 		}
 		name := dataRow[nameCol]
 		colName := dataRow[columnNameCol]
-		if name == "" || strings.EqualFold(name, "PRIMARY") || colName == "" || catalog.IsAlias(colName) {
+		if name == "" || strings.EqualFold(name, "PRIMARY") {
 			continue
 		}
 		info := byName[name]
@@ -4474,6 +4545,30 @@ func buildCreateIndexStatementsFromMoIndexes(
 		if commentCol >= 0 && commentCol < len(dataRow) && info.comment == "" {
 			info.comment = dataRow[commentCol]
 		}
+		isReservedFunctional := catalog.IsFunctionalIndexColumnName(colName)
+		if isReservedFunctional && (hiddenCol < 0 || hiddenCol >= len(dataRow) || !isTruthyCatalogValue(dataRow[hiddenCol])) {
+			return nil, moerr.NewInternalErrorf(context.Background(),
+				"functional index %q references reserved column %q without hidden metadata",
+				name, colName)
+		}
+		isHiddenFunctional := isReservedFunctional
+		if isHiddenFunctional {
+			expression := strings.TrimSpace(generated[colName])
+			if expression == "" {
+				return nil, moerr.NewInternalErrorf(context.Background(),
+					"functional index %q references hidden column %q with missing generated metadata",
+					name, colName)
+			}
+			if info.functionalExpression != "" && info.functionalExpression != expression {
+				return nil, moerr.NewInternalErrorf(context.Background(),
+					"functional index %q has inconsistent generated metadata", name)
+			}
+			info.functionalExpression = expression
+			continue
+		}
+		if colName == "" || catalog.IsAlias(colName) {
+			continue
+		}
 		ordinal := len(info.columns) + 1
 		if ordinalCol >= 0 && ordinalCol < len(dataRow) {
 			if parsed, err := strconv.Atoi(dataRow[ordinalCol]); err == nil {
@@ -4487,7 +4582,7 @@ func buildCreateIndexStatementsFromMoIndexes(
 
 	names := make([]string, 0, len(byName))
 	for name, info := range byName {
-		if len(info.columns) > 0 {
+		if len(info.columns) > 0 || info.functionalExpression != "" {
 			names = append(names, name)
 		}
 	}
@@ -4843,7 +4938,7 @@ func needsExplicitPartitionDefinitions(method string) bool {
 }
 
 func renderCreateIndexStatement(tableName string, info *indexDDLInfo) (string, error) {
-	if info == nil || tableName == "" || len(info.columns) == 0 {
+	if info == nil || tableName == "" || (len(info.columns) == 0 && info.functionalExpression == "") {
 		return "", nil
 	}
 	cols := make([]indexDDLColumn, 0, len(info.columns))
@@ -4884,14 +4979,20 @@ func renderCreateIndexStatement(tableName string, info *indexDDLInfo) (string, e
 	if !fullText {
 		appendIndexAlgorithmDDL(&sb, info.algo)
 	}
-	sb.WriteString("(")
-	for i, col := range cols {
-		if i > 0 {
-			sb.WriteString(", ")
+	if info.functionalExpression != "" {
+		sb.WriteString("((")
+		sb.WriteString(info.functionalExpression)
+		sb.WriteString("))")
+	} else {
+		sb.WriteString("(")
+		for i, col := range cols {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(quoteDDLIdent(col.name))
 		}
-		sb.WriteString(quoteDDLIdent(col.name))
+		sb.WriteString(")")
 	}
-	sb.WriteString(")")
 	if err := appendIndexTrailingOptionsDDL(&sb, fullText, info.algoParams, info.comment); err != nil {
 		return "", err
 	}

--- a/pkg/tools/checkpointtool/table_dump_test.go
+++ b/pkg/tools/checkpointtool/table_dump_test.go
@@ -2358,6 +2358,45 @@ func TestBuildCreateIndexStatementsFromMoIndexes_FullTextParserAndCatalogOrder(t
 	}, got)
 }
 
+func TestBuildCreateIndexStatementsFromMoIndexes_FunctionalIndex(t *testing.T) {
+	internalName := catalog.FunctionalIndexColumnPrefix + "0123456789abcdef0123456789abcdef"
+	view := &LogicalTableView{
+		Headers: append([]string{"object", "block", "row"}, moIndexesHeaders...),
+		Rows: [][]string{func() []string {
+			data := make([]string, len(moIndexesHeaders))
+			set := func(header, value string) {
+				for i, h := range moIndexesHeaders {
+					if h == header {
+						data[i] = value
+						return
+					}
+				}
+				t.Fatalf("missing mo_indexes header %s", header)
+			}
+			set("id", "1")
+			set("table_id", "42")
+			set("name", "idx_doc_sku")
+			set("type", "MULTIPLE")
+			set(catalog.IndexAlgoName, "")
+			set("column_name", internalName)
+			set("ordinal_position", "1")
+			set("hidden", "1")
+			return append([]string{"obj", "0", "1"}, data...)
+		}()},
+	}
+
+	got, err := buildCreateIndexStatementsFromMoIndexesWithGenerated(
+		view, 42, "docs", map[string]string{internalName: "json_unquote(json_extract(doc, '$.sku'))"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"ALTER TABLE `docs` ADD KEY `idx_doc_sku`((json_unquote(json_extract(doc, '$.sku'))));",
+	}, got)
+
+	_, err = buildCreateIndexStatementsFromMoIndexesWithGenerated(view, 42, "docs", nil)
+	require.Error(t, err)
+}
+
 func TestDecodeMoColumnEncodedSQLType_TemporalScale(t *testing.T) {
 	sqlType, ok := decodeMoColumnEncodedSQLType(encodedSQLType(t, types.New(types.T_time, 0, 6)))
 	require.True(t, ok)

--- a/test/distributed/cases/ddl/functional_index.result
+++ b/test/distributed/cases/ddl/functional_index.result
@@ -1,0 +1,78 @@
+-- MySQL-style non-unique single-expression functional-index regression suite.
+drop database if exists functional_index;
+create database functional_index;
+use functional_index;
+create table fi_inline (
+id int primary key,
+doc json,
+name varchar(32),
+qty int,
+key idx_sku ((json_unquote(json_extract(doc, '$.sku'))))
+);
+insert into fi_inline (id, doc, name, qty) values
+(1, '{"sku":"alpha"}', 'Alice', 2),
+(2, '{"sku":"beta"}', 'Bob', 4),
+(3, '{"sku":null}', 'Carol', 6),
+(4, '{"other":"missing"}', 'Dora', 8);
+select id, json_unquote(json_extract(doc, '$.sku')) as sku from fi_inline order by id;
+id    sku
+1    alpha
+2    beta
+3    null
+4    null
+-- @regex("KEY `idx_sku`.*json_unquote", true)
+-- @regex("__mo_fi_", false)
+show create table fi_inline;
+Table    Create Table
+fi_inline    CREATE TABLE `fi_inline` (\n  `id` int NOT NULL,\n  `doc` json DEFAULT NULL,\n  `name` varchar(32) DEFAULT NULL,\n  `qty` int DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_sku` ((json_unquote(json_extract(doc, '$.sku'))))\n)
+-- @regex("idx_sku.*NULL.*json_unquote", true)
+show index from fi_inline;
+Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
+fi_inline    0    PRIMARY    1    id    A    0    NULL    NULL                        YES    id
+fi_inline    1    idx_sku    1    NULL    A    0    NULL    NULL    YES                    YES    json_unquote(json_extract(doc, '$.sku'))
+-- @regex("Index Table Scan.*idx_sku", true)
+explain select id from fi_inline where json_unquote(json_extract(doc, '$.sku')) = 'alpha';
+  ->  Index Table Scan on fi_inline.idx_sku
+select id from fi_inline where json_unquote(json_extract(doc, '$.sku')) = 'alpha';
+id
+1
+create index idx_name_lower on fi_inline ((lower(name)));
+alter table fi_inline add index idx_qty_plus ((qty + 1));
+insert into fi_inline (id, doc, name, qty) values (5, '{"sku":"gamma"}', 'Eve', 10);
+update fi_inline set doc = '{"sku":"delta"}', qty = 11 where id = 1;
+delete from fi_inline where id = 2;
+replace into fi_inline (id, doc, name, qty) values (3, '{"sku":"epsilon"}', 'Carol', 12);
+insert into fi_inline (id, doc, name, qty) values (1, '{"sku":"zeta"}', 'Alice', 13) on duplicate key update doc = values(doc), qty = values(qty);
+select id, json_unquote(json_extract(doc, '$.sku')) as sku, qty from fi_inline order by id;
+id    sku    qty
+1    zeta    13
+3    epsilon    12
+4    null    8
+5    gamma    10
+drop index idx_name_lower on fi_inline;
+alter table fi_inline drop index idx_qty_plus;
+drop index idx_sku on fi_inline;
+-- @regex("__mo_fi_", false)
+show create table fi_inline;
+Table    Create Table
+fi_inline    CREATE TABLE `fi_inline` (\n  `id` int NOT NULL,\n  `doc` json DEFAULT NULL,\n  `name` varchar(32) DEFAULT NULL,\n  `qty` int DEFAULT NULL,\n  PRIMARY KEY (`id`)\n)
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_inline' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_inline' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+-- Stable rejection matrix.
+-- @regex("functional", true)
+create table fi_unique (id int primary key, a int, unique key uq ((a + 1)));
+functional expressions are not supported in UNIQUE indexes
+-- @regex("functional", true)
+create table fi_composite (id int primary key, a int, b int, key bad ((a + 1), b));
+functional indexes require exactly one expression key part
+-- @regex("unsupported type", true)
+create table fi_json (id int primary key, doc json, key bad ((json_extract(doc, '$.sku'))));
+functional index expression returns unsupported type JSON
+-- @regex("functional", true)
+create temporary table fi_temp (id int, a int, key bad ((a + 1)));
+functional indexes are not supported on temporary tables
+drop database functional_index;

--- a/test/distributed/cases/ddl/functional_index.result
+++ b/test/distributed/cases/ddl/functional_index.result
@@ -49,6 +49,50 @@ id    sku    qty
 3    epsilon    12
 4    null    8
 5    gamma    10
+-- Accepted-expression writer/query session matrix. The indexed lower(name)
+-- result must remain equivalent to a forced index and a forced table scan
+-- after the writer and reader use different session settings.
+set @fi_matrix_old_time_zone = @@time_zone;
+set @fi_matrix_old_sql_mode = @@sql_mode;
+set time_zone = '+00:00';
+set sql_mode = '';
+create table fi_session_matrix (
+id int primary key,
+name varchar(32),
+key idx_lower ((lower(name)))
+);
+insert into fi_session_matrix (id, name) values (1, 'Alice'), (2, 'ALICE'), (3, 'Bob');
+set time_zone = '+08:00';
+set sql_mode = 'NO_UNSIGNED_SUBTRACTION';
+select id from fi_session_matrix where lower(name) = 'alice' order by id;
+id
+1
+2
+select id from fi_session_matrix force index (idx_lower) where lower(name) = 'alice' order by id;
+id
+1
+2
+select id from fi_session_matrix ignore index (idx_lower) where lower(name) = 'alice' order by id;
+id
+1
+2
+set time_zone = '-05:00';
+set sql_mode = 'STRICT_TRANS_TABLES';
+select id from fi_session_matrix where lower(name) = 'alice' order by id;
+id
+1
+2
+select id from fi_session_matrix force index (idx_lower) where lower(name) = 'alice' order by id;
+id
+1
+2
+select id from fi_session_matrix ignore index (idx_lower) where lower(name) = 'alice' order by id;
+id
+1
+2
+drop table fi_session_matrix;
+set sql_mode = @fi_matrix_old_sql_mode;
+set time_zone = @fi_matrix_old_time_zone;
 drop index idx_name_lower on fi_inline;
 alter table fi_inline drop index idx_qty_plus;
 drop index idx_sku on fi_inline;

--- a/test/distributed/cases/ddl/functional_index.result
+++ b/test/distributed/cases/ddl/functional_index.result
@@ -72,6 +72,61 @@ functional indexes require exactly one expression key part
 -- @regex("unsupported type", true)
 create table fi_json (id int primary key, doc json, key bad ((json_extract(doc, '$.sku'))));
 functional index expression returns unsupported type JSON
+-- A session-dependent temporal cast is rejected before a hidden column or
+-- index row is published, for both a direct expression and a generated-column
+-- dependency.
+-- @regex("functional", true)
+create table fi_time_inline (id int primary key, ts timestamp, key bad ((cast(ts as char(19)))));
+functional index expression references unsupported column type TIMESTAMP
+select count(*) from mo_catalog.mo_tables where relname = 'fi_time_inline' and reldatabase = 'functional_index';
+➤ count(*)[-5,64,0]  𝄀
+0
+-- @regex("functional", true)
+create table fi_time_inline_dep (id int primary key, ts timestamp, g varchar(19) generated always as (cast(ts as char(19))) virtual, key bad ((g)));
+functional index expression references unsupported column type TIMESTAMP
+select count(*) from mo_catalog.mo_tables where relname = 'fi_time_inline_dep' and reldatabase = 'functional_index';
+➤ count(*)[-5,64,0]  𝄀
+0
+create table fi_time_create (id int primary key, ts timestamp);
+-- @regex("functional", true)
+create index bad_time_create on fi_time_create ((cast(ts as char(19))));
+functional index expression references unsupported column type TIMESTAMP
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_create' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_create' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+create table fi_time_create_dep (id int primary key, ts timestamp, g varchar(19) generated always as (cast(ts as char(19))) virtual);
+-- @regex("functional", true)
+create index bad_time_create_dep on fi_time_create_dep ((g));
+functional index expression references unsupported column type TIMESTAMP
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_create_dep' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_create_dep' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+create table fi_time_alter (id int primary key, ts timestamp);
+-- @regex("functional", true)
+alter table fi_time_alter add index bad_time_alter ((cast(ts as char(19))));
+functional index expression references unsupported column type TIMESTAMP
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_alter' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_alter' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+create table fi_time_alter_dep (id int primary key, ts timestamp, g varchar(19) generated always as (cast(ts as char(19))) virtual);
+-- @regex("functional", true)
+alter table fi_time_alter_dep add index bad_time_alter_dep ((g));
+functional index expression references unsupported column type TIMESTAMP
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_alter_dep' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_alter_dep' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+➤ count(*)[-5,64,0]  𝄀
+0
 -- @regex("functional", true)
 create temporary table fi_temp (id int, a int, key bad ((a + 1)));
 functional indexes are not supported on temporary tables

--- a/test/distributed/cases/ddl/functional_index.sql
+++ b/test/distributed/cases/ddl/functional_index.sql
@@ -1,0 +1,55 @@
+-- MySQL-style non-unique single-expression functional-index regression suite.
+drop database if exists functional_index;
+create database functional_index;
+use functional_index;
+
+create table fi_inline (
+    id int primary key,
+    doc json,
+    name varchar(32),
+    qty int,
+    key idx_sku ((json_unquote(json_extract(doc, '$.sku'))))
+);
+insert into fi_inline (id, doc, name, qty) values
+    (1, '{"sku":"alpha"}', 'Alice', 2),
+    (2, '{"sku":"beta"}', 'Bob', 4),
+    (3, '{"sku":null}', 'Carol', 6),
+    (4, '{"other":"missing"}', 'Dora', 8);
+select id, json_unquote(json_extract(doc, '$.sku')) as sku from fi_inline order by id;
+-- @regex("KEY `idx_sku`.*json_unquote", true)
+-- @regex("__mo_fi_", false)
+show create table fi_inline;
+-- @regex("idx_sku.*NULL.*json_unquote", true)
+show index from fi_inline;
+-- @regex("Index Table Scan.*idx_sku", true)
+explain select id from fi_inline where json_unquote(json_extract(doc, '$.sku')) = 'alpha';
+select id from fi_inline where json_unquote(json_extract(doc, '$.sku')) = 'alpha';
+
+create index idx_name_lower on fi_inline ((lower(name)));
+alter table fi_inline add index idx_qty_plus ((qty + 1));
+insert into fi_inline (id, doc, name, qty) values (5, '{"sku":"gamma"}', 'Eve', 10);
+update fi_inline set doc = '{"sku":"delta"}', qty = 11 where id = 1;
+delete from fi_inline where id = 2;
+replace into fi_inline (id, doc, name, qty) values (3, '{"sku":"epsilon"}', 'Carol', 12);
+insert into fi_inline (id, doc, name, qty) values (1, '{"sku":"zeta"}', 'Alice', 13) on duplicate key update doc = values(doc), qty = values(qty);
+select id, json_unquote(json_extract(doc, '$.sku')) as sku, qty from fi_inline order by id;
+
+drop index idx_name_lower on fi_inline;
+alter table fi_inline drop index idx_qty_plus;
+drop index idx_sku on fi_inline;
+-- @regex("__mo_fi_", false)
+show create table fi_inline;
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_inline' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_inline' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+
+-- Stable rejection matrix.
+-- @regex("functional", true)
+create table fi_unique (id int primary key, a int, unique key uq ((a + 1)));
+-- @regex("functional", true)
+create table fi_composite (id int primary key, a int, b int, key bad ((a + 1), b));
+-- @regex("unsupported type", true)
+create table fi_json (id int primary key, doc json, key bad ((json_extract(doc, '$.sku'))));
+-- @regex("functional", true)
+create temporary table fi_temp (id int, a int, key bad ((a + 1)));
+
+drop database functional_index;

--- a/test/distributed/cases/ddl/functional_index.sql
+++ b/test/distributed/cases/ddl/functional_index.sql
@@ -49,6 +49,35 @@ create table fi_unique (id int primary key, a int, unique key uq ((a + 1)));
 create table fi_composite (id int primary key, a int, b int, key bad ((a + 1), b));
 -- @regex("unsupported type", true)
 create table fi_json (id int primary key, doc json, key bad ((json_extract(doc, '$.sku'))));
+-- A session-dependent temporal cast is rejected before a hidden column or
+-- index row is published, for both a direct expression and a generated-column
+-- dependency.
+-- @regex("functional", true)
+create table fi_time_inline (id int primary key, ts timestamp, key bad ((cast(ts as char(19)))));
+select count(*) from mo_catalog.mo_tables where relname = 'fi_time_inline' and reldatabase = 'functional_index';
+-- @regex("functional", true)
+create table fi_time_inline_dep (id int primary key, ts timestamp, g varchar(19) generated always as (cast(ts as char(19))) virtual, key bad ((g)));
+select count(*) from mo_catalog.mo_tables where relname = 'fi_time_inline_dep' and reldatabase = 'functional_index';
+create table fi_time_create (id int primary key, ts timestamp);
+-- @regex("functional", true)
+create index bad_time_create on fi_time_create ((cast(ts as char(19))));
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_create' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_create' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+create table fi_time_create_dep (id int primary key, ts timestamp, g varchar(19) generated always as (cast(ts as char(19))) virtual);
+-- @regex("functional", true)
+create index bad_time_create_dep on fi_time_create_dep ((g));
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_create_dep' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_create_dep' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+create table fi_time_alter (id int primary key, ts timestamp);
+-- @regex("functional", true)
+alter table fi_time_alter add index bad_time_alter ((cast(ts as char(19))));
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_alter' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_alter' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
+create table fi_time_alter_dep (id int primary key, ts timestamp, g varchar(19) generated always as (cast(ts as char(19))) virtual);
+-- @regex("functional", true)
+alter table fi_time_alter_dep add index bad_time_alter_dep ((g));
+select count(*) from mo_catalog.mo_columns where attrelname = 'fi_time_alter_dep' and attdatabase = 'functional_index' and attname like '__mo_fi_%';
+select count(*) from mo_catalog.mo_indexes where table_id = (select rel_id from mo_catalog.mo_tables where relname = 'fi_time_alter_dep' and reldatabase = 'functional_index') and column_name like '__mo_fi_%';
 -- @regex("functional", true)
 create temporary table fi_temp (id int, a int, key bad ((a + 1)));
 

--- a/test/distributed/cases/ddl/functional_index.sql
+++ b/test/distributed/cases/ddl/functional_index.sql
@@ -34,6 +34,33 @@ replace into fi_inline (id, doc, name, qty) values (3, '{"sku":"epsilon"}', 'Car
 insert into fi_inline (id, doc, name, qty) values (1, '{"sku":"zeta"}', 'Alice', 13) on duplicate key update doc = values(doc), qty = values(qty);
 select id, json_unquote(json_extract(doc, '$.sku')) as sku, qty from fi_inline order by id;
 
+-- Accepted-expression writer/query session matrix. The indexed lower(name)
+-- result must remain equivalent to a forced index and a forced table scan
+-- after the writer and reader use different session settings.
+set @fi_matrix_old_time_zone = @@time_zone;
+set @fi_matrix_old_sql_mode = @@sql_mode;
+set time_zone = '+00:00';
+set sql_mode = '';
+create table fi_session_matrix (
+    id int primary key,
+    name varchar(32),
+    key idx_lower ((lower(name)))
+);
+insert into fi_session_matrix (id, name) values (1, 'Alice'), (2, 'ALICE'), (3, 'Bob');
+set time_zone = '+08:00';
+set sql_mode = 'NO_UNSIGNED_SUBTRACTION';
+select id from fi_session_matrix where lower(name) = 'alice' order by id;
+select id from fi_session_matrix force index (idx_lower) where lower(name) = 'alice' order by id;
+select id from fi_session_matrix ignore index (idx_lower) where lower(name) = 'alice' order by id;
+set time_zone = '-05:00';
+set sql_mode = 'STRICT_TRANS_TABLES';
+select id from fi_session_matrix where lower(name) = 'alice' order by id;
+select id from fi_session_matrix force index (idx_lower) where lower(name) = 'alice' order by id;
+select id from fi_session_matrix ignore index (idx_lower) where lower(name) = 'alice' order by id;
+drop table fi_session_matrix;
+set sql_mode = @fi_matrix_old_sql_mode;
+set time_zone = @fi_matrix_old_time_zone;
+
 drop index idx_name_lower on fi_inline;
 alter table fi_inline drop index idx_qty_plus;
 drop index idx_sku on fi_inline;

--- a/test/distributed/cases/ddl/generated_column_index_atomic.result
+++ b/test/distributed/cases/ddl/generated_column_index_atomic.result
@@ -1,0 +1,55 @@
+-- Regression coverage for the generated-column + secondary-index atomic DDL
+-- foundation used by functional indexes.
+drop database if exists generated_column_index_atomic;
+create database generated_column_index_atomic;
+use generated_column_index_atomic;
+create table t_inline (
+id int primary key,
+source int,
+generated_key int generated always as (source * 2) stored,
+key idx_generated_key (generated_key)
+);
+insert into t_inline (id, source) values (1, 3), (2, 4);
+select id, source, generated_key from t_inline order by id;
+id    source    generated_key
+1    3    6
+2    4    8
+show create table t_inline;
+Table    Create Table
+t_inline    CREATE TABLE `t_inline` (\n  `id` int NOT NULL,\n  `source` int DEFAULT NULL,\n  `generated_key` int GENERATED ALWAYS AS (source * 2) STORED,\n  PRIMARY KEY (`id`),\n  KEY `idx_generated_key` (`generated_key`)\n)
+show index from t_inline;
+Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
+t_inline    0    PRIMARY    1    id    A    0    NULL    NULL                        YES    id
+t_inline    1    idx_generated_key    1    generated_key    A    0    NULL    NULL    YES                    YES    generated_key
+create table t_existing (id int primary key, source int);
+insert into t_existing values (1, 10), (2, 20);
+alter table t_existing add column generated_key int generated always as (source + 1) virtual;
+create index idx_existing_generated on t_existing (generated_key);
+select id, source, generated_key from t_existing order by id;
+id    source    generated_key
+1    10    11
+2    20    21
+show create table t_existing;
+Table    Create Table
+t_existing    CREATE TABLE `t_existing` (\n  `id` int NOT NULL,\n  `source` int DEFAULT NULL,\n  `generated_key` int GENERATED ALWAYS AS (source + 1) VIRTUAL,\n  PRIMARY KEY (`id`),\n  KEY `idx_existing_generated` (`generated_key`)\n)
+-- A failed compound DDL must not leave a generated column, index, or table
+-- catalog entry behind.
+-- @regex("Duplicate", true)
+create table t_failed (
+id int primary key,
+source int,
+generated_key int generated always as (source * 2) stored,
+key idx_failed (generated_key),
+key idx_failed (generated_key)
+);
+Duplicate key: idx_failed
+select count(*) from mo_catalog.mo_tables where relname = 't_failed' and reldatabase = 'generated_column_index_atomic';
+➤ count(*)[-5,64,0]  𝄀
+0
+select count(*) from mo_catalog.mo_columns where attrelname = 't_failed' and attdatabase = 'generated_column_index_atomic';
+➤ count(*)[-5,64,0]  𝄀
+0
+select count(*) from mo_catalog.mo_indexes where name = 'idx_failed';
+➤ count(*)[-5,64,0]  𝄀
+0
+drop database generated_column_index_atomic;

--- a/test/distributed/cases/ddl/generated_column_index_atomic.sql
+++ b/test/distributed/cases/ddl/generated_column_index_atomic.sql
@@ -1,0 +1,39 @@
+-- Regression coverage for the generated-column + secondary-index atomic DDL
+-- foundation used by functional indexes.
+drop database if exists generated_column_index_atomic;
+create database generated_column_index_atomic;
+use generated_column_index_atomic;
+
+create table t_inline (
+    id int primary key,
+    source int,
+    generated_key int generated always as (source * 2) stored,
+    key idx_generated_key (generated_key)
+);
+insert into t_inline (id, source) values (1, 3), (2, 4);
+select id, source, generated_key from t_inline order by id;
+show create table t_inline;
+show index from t_inline;
+
+create table t_existing (id int primary key, source int);
+insert into t_existing values (1, 10), (2, 20);
+alter table t_existing add column generated_key int generated always as (source + 1) virtual;
+create index idx_existing_generated on t_existing (generated_key);
+select id, source, generated_key from t_existing order by id;
+show create table t_existing;
+
+-- A failed compound DDL must not leave a generated column, index, or table
+-- catalog entry behind.
+-- @regex("Duplicate", true)
+create table t_failed (
+    id int primary key,
+    source int,
+    generated_key int generated always as (source * 2) stored,
+    key idx_failed (generated_key),
+    key idx_failed (generated_key)
+);
+select count(*) from mo_catalog.mo_tables where relname = 't_failed' and reldatabase = 'generated_column_index_atomic';
+select count(*) from mo_catalog.mo_columns where attrelname = 't_failed' and attdatabase = 'generated_column_index_atomic';
+select count(*) from mo_catalog.mo_indexes where name = 'idx_failed';
+
+drop database generated_column_index_atomic;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:

issue #28053

## What this PR does / why we need it:

This Draft PR adds MySQL-style non-unique, single-expression functional indexes for ordinary persistent tables. It supports inline `CREATE TABLE`, standalone `CREATE INDEX`, and `ALTER TABLE ADD INDEX`, and reuses generated-column DML maintenance plus regular BTREE secondary-index storage.

Each functional index owns one hidden VIRTUAL generated column named from `__mo_fi_` plus the first 32 hexadecimal characters of the normalized index-name SHA-256. Hidden-column publication, backfill, index-table creation, and removal use the atomic COPY path. `SHOW INDEX` exposes `Column_name=NULL` and the original expression; `SHOW CREATE TABLE`, clone, and checkpoint/restore retain the user expression without leaking the internal name.

Admission now uses one deny-by-default session-invariant checker over resolved overloads, type and collation metadata, casts, and recursive generated-column dependencies. Direct and transitive session-dependent temporal casts, unknown or malformed expression metadata, and unsafe assignment semantics are rejected before the hidden column or index metadata is published. DML, restored/catalog metadata, and optimizer eligibility reuse the same contract; malformed metadata fails closed and the equality-only optimizer path retains the base-table residual predicate.

The v1 optimizer path matches one structurally identical equality expression with a runtime constant. It does not use covering/index-only, range, `IN`, or `OR` paths. UNIQUE/composite/mixed parts, prefixes, directions, temporary/cluster/external tables, and special algorithms remain rejected.

This branch was merged with the verified current `main` at `f0c31cd4b830be32442cf329e0a3fb08aa9c16c3`. Main already uses MORPC 56 for session-scoped AUTO_INCREMENT and MORPC 57 for Arrow LOAD, so functional-index admission reserves cumulative capability MORPC 58.

## Dependencies and merge order

1. [#28052](https://github.com/matrixorigin/matrixone/issues/28052) remains OPEN, assigned to `aptend`, and has no dedicated PR in the current snapshot. Its atomic generated-column-plus-index DDL foundation remains the integration dependency for the complete acceptance path. This PR does not implement or change that issue.
2. [#28156](https://github.com/matrixorigin/matrixone/pull/28156), [#28090](https://github.com/matrixorigin/matrixone/pull/28090), [#28066](https://github.com/matrixorigin/matrixone/pull/28066), and [#28088](https://github.com/matrixorigin/matrixone/pull/28088) are merged. #28066 remains a shared-DML rebase trigger if its effective surface changes; #28088 is outside the ordinary-table v1 scope.
3. This PR remains Draft until the #28052 integration, exact-head CI/BVT, and required QA gates are complete and the formal CR is re-reviewed.

## Validation

Current exact head: `b57de1fd0aa6108660b278c847e91a876fe0c06b`

Current base and merge base: `f0c31cd4b830be32442cf329e0a3fb08aa9c16c3`

- Semantic preflight: `PASS`, schema v7, diff hash `b1543332f0cdb53b8336d8a730413e7a9e58f4e41f2c5c6937b1dc8b76b04219`; manifest is outside the worktree.
- `GOWORK=off go test -mod=readonly -count=1 ./pkg/defines`: PASS.
- `GOWORK=off go test -mod=readonly -count=1 ./pkg/sql/plan/function`: PASS.
- `GOWORK=off go test -mod=readonly -count=1 ./pkg/queryservice/client`: PASS.
- `GOWORK=off go vet -mod=readonly ./pkg/defines ./pkg/queryservice/client`: PASS.
- `git diff --check`: PASS.
- The controlled plan CGo test wrapper stopped before executing tests because this host and its primary worktree lack `cgo/libmo.dylib` and `thirdparties/install`; the ordinary plan build/vet has the same native docfilter prerequisite failure. This is an environment blocker, not a test assertion result.
- Current-head `pkg/sql/compile` and `pkg/tools/checkpointtool` package tests hit the same native docfilter CGo declaration prerequisite before test execution.
- Canonical BVT coverage now includes direct/transitive rejected DDL with no metadata, plus an accepted `lower(name)` writer/query matrix across different time zones and SQL modes with normal, forced-index, and forced-table-scan queries. Distributed BVT has not run locally because no clean distributed instance is available; exact-head CI is pending.

## QA Decision

QA is required after the dependency and CI gates: single CN, multi-CN, restart, backup/restore, clone/checkpoint reconstruction, rejected cluster-table use, and performance comparison with the explicit generated-column workaround.

## Status

This PR intentionally stays Draft and does not close Issue #28053. Do not add `Fixes #28053`. `phase/testing` should be added only after implementation merge and tester-reported version, environment, and explicit PASS/FAIL.
