### PR TITLE
fix(pipeline): preserve late remote terminal errors

### DIFF
--- a/pkg/sql/colexec/merge/merge.go
+++ b/pkg/sql/colexec/merge/merge.go
@@ -47,9 +47,9 @@ func (merge *Merge) Prepare(proc *process.Process) error {
 	}
 
 	if merge.Partial {
-		merge.ctr.receiver = process.InitPipelineSignalReceiver(proc.Ctx, proc.Reg.MergeReceivers[merge.StartIDX:merge.EndIDX])
+		merge.ctr.receiver = process.InitPipelineSignalReceiverFromProcess(proc, proc.Reg.MergeReceivers[merge.StartIDX:merge.EndIDX])
 	} else {
-		merge.ctr.receiver = process.InitPipelineSignalReceiver(proc.Ctx, proc.Reg.MergeReceivers)
+		merge.ctr.receiver = process.InitPipelineSignalReceiverFromProcess(proc, proc.Reg.MergeReceivers)
 	}
 	return nil
 }

--- a/pkg/sql/colexec/merge/merge_test.go
+++ b/pkg/sql/colexec/merge/merge_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+func TestMergePreservesQueryTerminalOverLateEdgeFailure(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		buildContext func(*process.Process) (context.Context, func())
+		wantErr      error
+	}{
+		{
+			name: "query cancellation",
+			buildContext: func(proc *process.Process) (context.Context, func()) {
+				queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
+				_, cancel := process.GetQueryCtxFromProc(proc)
+				return queryCtx, cancel
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "query deadline",
+			buildContext: func(proc *process.Process) (context.Context, func()) {
+				parentCtx, cancel := context.WithDeadline(proc.GetTopContext(), time.Now().Add(-time.Second))
+				return proc.Base.GetContextBase().BuildQueryCtx(parentCtx), cancel
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			queryCtx, cancelQuery := test.buildContext(proc)
+			proc.BuildPipelineContext(queryCtx)
+			t.Cleanup(func() {
+				proc.Cancel(nil)
+				cancelQuery()
+			})
+
+			edge := process.NewPipelineEdge(1, 1)
+			proc.Reg.MergeReceivers = []*process.WaitRegister{edge}
+			merge := NewArgument()
+			t.Cleanup(merge.Release)
+			if err := merge.Prepare(proc); err != nil {
+				t.Fatalf("Prepare returned error: %v", err)
+			}
+
+			edge.Ch2 <- process.NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
+			cancelQuery()
+			duplicateErr := moerr.NewDuplicateEntryNoCtx("6", "primary")
+			if edge.SendError(duplicateErr) {
+				t.Fatal("late error signal unexpectedly fit behind buffered data")
+			}
+
+			for attempt := 0; attempt < 2; attempt++ {
+				result, err := merge.Call(proc)
+				if err != nil {
+					if !errors.Is(err, test.wantErr) {
+						t.Fatalf("query terminal was replaced by late edge failure: got %v, want %v", err, test.wantErr)
+					}
+					return
+				}
+				if result.Batch == nil {
+					t.Fatalf("merge stopped without query terminal on attempt %d", attempt)
+				}
+			}
+			t.Fatal("merge returned buffered data without reporting the query terminal")
+		})
+	}
+}

--- a/pkg/sql/colexec/merge/types.go
+++ b/pkg/sql/colexec/merge/types.go
@@ -100,8 +100,8 @@ func (merge *Merge) ActivateReceiverRange(proc *process.Process, start, end int3
 	if merge.ctr.receiver != nil && merge.ctr.receiver.State().Alive != 0 {
 		return moerr.NewInternalErrorNoCtx("cannot replace an active merge receiver range")
 	}
-	merge.ctr.receiver = process.InitPipelineSignalReceiver(
-		proc.Ctx, proc.Reg.MergeReceivers[start:end])
+	merge.ctr.receiver = process.InitPipelineSignalReceiverFromProcess(
+		proc, proc.Reg.MergeReceivers[start:end])
 	return nil
 }
 
@@ -110,7 +110,7 @@ func (merge *Merge) ActivateReceiverRange(proc *process.Process, start, end int3
 // submitted. The containing pipeline still runs normal cleanup so its own
 // downstream connector receives the startup error.
 func (merge *Merge) DisableReceiverWaitForStartFailure(proc *process.Process) {
-	merge.ctr.receiver = process.InitPipelineSignalReceiver(proc.Ctx, nil)
+	merge.ctr.receiver = process.InitPipelineSignalReceiverFromProcess(proc, nil)
 }
 
 func (merge *Merge) Release() {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -700,33 +700,7 @@ func scopeRunQueryContext(proc *process.Process) context.Context {
 }
 
 func isScopeCancellationError(err error) bool {
-	if err == nil {
-		return false
-	}
-	// errors.Join must not turn a substantive execution failure into
-	// cancellation fallout merely because one of its siblings is a context
-	// error. Every leaf has to be cancellation-shaped before it is safe to
-	// suppress or replace the result.
-	if joined, ok := err.(interface{ Unwrap() []error }); ok {
-		children := joined.Unwrap()
-		if len(children) == 0 {
-			return false
-		}
-		for _, child := range children {
-			if !isScopeCancellationError(child) {
-				return false
-			}
-		}
-		return true
-	}
-	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
-		if child := wrapped.Unwrap(); child != nil {
-			return isScopeCancellationError(child)
-		}
-	}
-	return errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) ||
-		moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted)
+	return process.IsPipelineCancellationError(err)
 }
 
 // isScopeCancellationFrom reports whether every leaf in err can be attributed

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -794,13 +794,16 @@ func forwardRemoteBatchWithContext(
 	return true, nil
 }
 
-// no matter how we stop the remote-run, we should get the final remote cost here.
-func (sender *messageSenderOnClient) waitingTheStopResponse() {
+// waitingTheStopResponse asks an unfinished remote stream to stop and waits for
+// its terminal response. The terminal error remains part of execution state:
+// cancellation may have won the caller's receive select immediately before the
+// remote pipeline reported its actual failure.
+func (sender *messageSenderOnClient) waitingTheStopResponse() error {
 	sender.stateMu.Lock()
 	receiveClosed, safeToClose := sender.receiveClosed, sender.safeToClose
 	sender.stateMu.Unlock()
 	if receiveClosed || safeToClose {
-		return
+		return nil
 	}
 
 	// cannot use sender.ctx here, because ctx maybe done.
@@ -811,7 +814,7 @@ func (sender *messageSenderOnClient) waitingTheStopResponse() {
 	if err := sender.streamSender.Send(
 		maxWaitingTime,
 		generateStopSendingMessage(sender.streamSender.ID())); err != nil {
-		return
+		return nil
 	}
 
 	// wait an EndMessage response.
@@ -820,7 +823,7 @@ func (sender *messageSenderOnClient) waitingTheStopResponse() {
 		case val, ok := <-sender.receiveCh:
 			if !ok || val == nil {
 				sender.markReceiveClosed()
-				return
+				return nil
 			}
 
 			message := val.(*pipeline.Message)
@@ -829,17 +832,21 @@ func (sender *messageSenderOnClient) waitingTheStopResponse() {
 				if len(message.GetAnalyse()) > 0 {
 					_ = sender.dealRemoteTerminal(message.GetAnalyse())
 				}
+				if terminalErr, ok := message.TryToGetMoErr(); ok {
+					sender.markTerminal(message, false)
+					return terminalErr
+				}
 				// StopSending is also a clean teardown when the original server
 				// worker answers with its negotiated terminal response. The later FIN
 				// still waits for the same server cleanup barrier. Unnegotiated or
 				// mismatched terminal responses remain poisoned.
-				sender.markTerminal(message, message.IsEndMessage())
+				sender.markTerminal(message, true)
 				// in fact, we should deal the cost analysis information here.
-				return
+				return nil
 			}
 
 		case <-maxWaitingTime.Done():
-			return
+			return nil
 		}
 	}
 }
@@ -974,7 +981,7 @@ func (sender *messageSenderOnClient) close() {
 		// Ensure Gauge is decremented exactly once when this sender is torn down.
 		defer sender.gaugeDecOnce.Do(func() { v2.PipelineMessageSenderGauge.Dec() })
 
-		sender.waitingTheStopResponse()
+		_ = sender.waitingTheStopResponse()
 		sender.stateMu.Lock()
 		receiveClosed, reuseEligible := sender.receiveClosed, sender.reuseEligible
 		sender.stateMu.Unlock()

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -47,7 +47,10 @@ import (
 // this is just a number I casually wrote, the purpose of doing this is that any message sent through rpc need a clear deadline.
 const MaxRpcTime = time.Hour * 24
 
-var pipelineStreamFinishClientTimeout = 30 * time.Second
+var (
+	pipelineStopSendingClientTimeout  = 30 * time.Second
+	pipelineStreamFinishClientTimeout = 30 * time.Second
+)
 
 // remoteRun sends a scope to remote node for running.
 // and keep receiving the back results.
@@ -455,6 +458,7 @@ type messageSenderOnClient struct {
 	receiveClosed      bool
 	reuseEligible      bool
 	terminalNegotiated bool
+	stopResponseTried  bool
 	expectedEnd        pipeline.Method
 	stateMu            sync.Mutex
 	closeOnce          sync.Once
@@ -618,6 +622,7 @@ func (sender *messageSenderOnClient) markStreamActive(method pipeline.Method) {
 	sender.receiveClosed = false
 	sender.reuseEligible = false
 	sender.terminalNegotiated = false
+	sender.stopResponseTried = false
 	sender.allowCleanupCancellation = false
 	sender.expectedEnd = method
 }
@@ -800,21 +805,35 @@ func forwardRemoteBatchWithContext(
 // remote pipeline reported its actual failure.
 func (sender *messageSenderOnClient) waitingTheStopResponse() error {
 	sender.stateMu.Lock()
-	receiveClosed, safeToClose := sender.receiveClosed, sender.safeToClose
-	sender.stateMu.Unlock()
-	if receiveClosed || safeToClose {
+	if sender.receiveClosed || sender.safeToClose || sender.stopResponseTried {
+		sender.stateMu.Unlock()
 		return nil
 	}
+	// RemoteRun and close share this teardown owner. Claim the handshake before
+	// doing I/O so a terminal-less attempt cannot be repeated by close and add a
+	// second full timeout to the same statement.
+	sender.stopResponseTried = true
+	sender.stateMu.Unlock()
 
 	// cannot use sender.ctx here, because ctx maybe done.
-	maxWaitingTime, cancel := context.WithTimeoutCause(context.TODO(), 30*time.Second, moerr.CauseWaitingTheStopResponse)
+	maxWaitingTime, cancel := context.WithTimeoutCause(
+		context.Background(), pipelineStopSendingClientTimeout, moerr.CauseWaitingTheStopResponse)
 	defer cancel()
 
 	// send a stop sending message to message-receiver.
 	if err := sender.streamSender.Send(
 		maxWaitingTime,
 		generateStopSendingMessage(sender.streamSender.ID())); err != nil {
-		return nil
+		if maxWaitingTime.Err() != nil {
+			return moerr.NewRPCTimeout(maxWaitingTime)
+		}
+		// The handshake owns an independent live context. A cancellation-shaped
+		// Send result therefore describes a closed transport, not successful
+		// pipeline cancellation, and must not be suppressible by RemoteRun.
+		if isScopeCancellationError(err) {
+			return moerr.NewStreamClosedNoCtx()
+		}
+		return err
 	}
 
 	// wait an EndMessage response.
@@ -823,7 +842,7 @@ func (sender *messageSenderOnClient) waitingTheStopResponse() error {
 		case val, ok := <-sender.receiveCh:
 			if !ok || val == nil {
 				sender.markReceiveClosed()
-				return nil
+				return moerr.NewStreamClosedNoCtx()
 			}
 
 			message := val.(*pipeline.Message)
@@ -846,7 +865,7 @@ func (sender *messageSenderOnClient) waitingTheStopResponse() error {
 			}
 
 		case <-maxWaitingTime.Done():
-			return nil
+			return moerr.NewRPCTimeout(maxWaitingTime)
 		}
 	}
 }

--- a/pkg/sql/compile/remoterunClient_test.go
+++ b/pkg/sql/compile/remoterunClient_test.go
@@ -588,6 +588,27 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			wantStopSendingCount: 1,
 		},
 		{
+			name:                 "substantive cancellation cause survives StopSending send failure",
+			cancelCause:          duplicateErr,
+			stopSendErr:          moerr.NewBackendClosedNoCtx(),
+			wantErr:              duplicateErr,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "substantive cancellation cause survives StopSending response closure",
+			cancelCause:          duplicateErr,
+			closeStopResponse:    true,
+			wantErr:              duplicateErr,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "substantive cancellation cause survives StopSending timeout",
+			cancelCause:          duplicateErr,
+			timeoutStopResponse:  true,
+			wantErr:              duplicateErr,
+			wantStopSendingCount: 1,
+		},
+		{
 			name:                 "normal internal cancellation remains secondary",
 			wantStopSendingCount: 1,
 		},

--- a/pkg/sql/compile/remoterunClient_test.go
+++ b/pkg/sql/compile/remoterunClient_test.go
@@ -567,10 +567,13 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 
 	duplicateErr := moerr.NewDuplicateEntryNoCtx("1", "primary")
 	tests := []struct {
-		name        string
-		cancelCause error
-		cancelQuery bool
-		wantErr     error
+		name                       string
+		cancelCause                error
+		cancelQuery                bool
+		remoteErr                  error
+		stopResponseErr            error
+		assertTerminalBeforeCancel bool
+		wantErr                    error
 	}{
 		{
 			name:        "substantive cancellation cause survives",
@@ -584,6 +587,21 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			name:        "query cancellation remains terminal",
 			cancelQuery: true,
 			wantErr:     context.Canceled,
+		},
+		{
+			name:                       "remote failure reaches receiver before scope cancellation",
+			remoteErr:                  duplicateErr,
+			assertTerminalBeforeCancel: true,
+			wantErr:                    duplicateErr,
+		},
+		{
+			name:            "remote failure returned after internal cancellation survives",
+			stopResponseErr: duplicateErr,
+			wantErr:         duplicateErr,
+		},
+		{
+			name:            "remote cancellation returned after internal cancellation remains secondary",
+			stopResponseErr: moerr.NewQueryInterrupted(context.Background()),
 		},
 	}
 	for _, tt := range tests {
@@ -607,7 +625,12 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 					message := request.(*pipeline.Message)
 					switch message.GetCmd() {
 					case pipeline.Method_PipelineMessage:
-						if tt.cancelQuery {
+						if tt.remoteErr != nil {
+							response := &pipeline.Message{Sid: pipeline.Status_MessageEnd}
+							response.SetMessageType(pipeline.Method_PipelineMessage)
+							response.SetMoError(context.Background(), tt.remoteErr)
+							responses <- response
+						} else if tt.cancelQuery {
 							cancelQuery()
 						} else {
 							proc.Cancel(tt.cancelCause)
@@ -615,6 +638,9 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 					case pipeline.Method_StopSending:
 						response := &pipeline.Message{Sid: pipeline.Status_MessageEnd}
 						response.SetMessageType(pipeline.Method_PipelineMessage)
+						if tt.stopResponseErr != nil {
+							response.SetMoError(context.Background(), tt.stopResponseErr)
+						}
 						responses <- response
 					}
 					return nil
@@ -644,6 +670,14 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			reg := process.NewPipelineEdge(1, 0)
 			root := connector.NewArgument().WithReg(reg)
 			defer root.Release()
+			if tt.assertTerminalBeforeCancel {
+				originalCancel := proc.Cancel
+				proc.Cancel = func(cause error) {
+					require.True(t, moerr.IsMoErrCode(reg.Err(), moerr.ErrDuplicateEntry),
+						"remote root terminal must be published before its scope is canceled")
+					originalCancel(cause)
+				}
+			}
 			s := &Scope{
 				Magic:         Remote,
 				Proc:          proc,
@@ -655,6 +689,8 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			err := s.RemoteRun(c)
 			if tt.wantErr == nil {
 				require.NoError(t, err)
+			} else if tt.remoteErr != nil || tt.stopResponseErr != nil {
+				require.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 			} else {
 				require.ErrorIs(t, err, tt.wantErr)
 			}
@@ -667,7 +703,11 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 					require.NoError(t, terminalErr)
 				} else {
 					require.Equal(t, process.EventError, signal.EventType)
-					require.ErrorIs(t, terminalErr, tt.wantErr)
+					if tt.remoteErr != nil || tt.stopResponseErr != nil {
+						require.True(t, moerr.IsMoErrCode(terminalErr, moerr.ErrDuplicateEntry))
+					} else {
+						require.ErrorIs(t, terminalErr, tt.wantErr)
+					}
 				}
 			case <-time.After(time.Second):
 				t.Fatal("remote cleanup did not terminate its receiver")

--- a/pkg/sql/compile/remoterunClient_test.go
+++ b/pkg/sql/compile/remoterunClient_test.go
@@ -570,6 +570,7 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 		name                       string
 		cancelCause                error
 		cancelQuery                bool
+		deadlineQuery              bool
 		remoteErr                  error
 		stopResponseErr            error
 		stopSendErr                error
@@ -594,6 +595,48 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			name:                 "query cancellation remains terminal",
 			cancelQuery:          true,
 			wantErr:              context.Canceled,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "query cancellation survives StopSending send failure",
+			cancelQuery:          true,
+			stopSendErr:          moerr.NewBackendClosedNoCtx(),
+			wantErr:              context.Canceled,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "query cancellation survives StopSending response closure",
+			cancelQuery:          true,
+			closeStopResponse:    true,
+			wantErr:              context.Canceled,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "query cancellation survives StopSending timeout",
+			cancelQuery:          true,
+			timeoutStopResponse:  true,
+			wantErr:              context.Canceled,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "query deadline survives StopSending send failure",
+			deadlineQuery:        true,
+			stopSendErr:          moerr.NewBackendClosedNoCtx(),
+			wantErr:              context.DeadlineExceeded,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "query deadline survives StopSending response closure",
+			deadlineQuery:        true,
+			closeStopResponse:    true,
+			wantErr:              context.DeadlineExceeded,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "query deadline survives StopSending timeout",
+			deadlineQuery:        true,
+			timeoutStopResponse:  true,
+			wantErr:              context.DeadlineExceeded,
 			wantStopSendingCount: 1,
 		},
 		{
@@ -649,7 +692,13 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			}
 			ctrl := gomock.NewController(t)
 			proc := testutil.NewProcess(t)
-			queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
+			queryParent := proc.GetTopContext()
+			if tt.deadlineQuery {
+				var cancelDeadline context.CancelFunc
+				queryParent, cancelDeadline = context.WithDeadline(queryParent, time.Now().Add(-time.Second))
+				t.Cleanup(cancelDeadline)
+			}
+			queryCtx := proc.Base.GetContextBase().BuildQueryCtx(queryParent)
 			_, cancelQuery := process.GetQueryCtxFromProc(proc)
 			t.Cleanup(cancelQuery)
 			proc.BuildPipelineContext(queryCtx)

--- a/pkg/sql/compile/remoterunClient_test.go
+++ b/pkg/sql/compile/remoterunClient_test.go
@@ -572,40 +572,81 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 		cancelQuery                bool
 		remoteErr                  error
 		stopResponseErr            error
+		stopSendErr                error
+		closeStopResponse          bool
+		timeoutStopResponse        bool
 		assertTerminalBeforeCancel bool
 		wantErr                    error
+		wantErrCode                uint16
+		wantStopSendingCount       int
 	}{
 		{
-			name:        "substantive cancellation cause survives",
-			cancelCause: duplicateErr,
-			wantErr:     duplicateErr,
+			name:                 "substantive cancellation cause survives",
+			cancelCause:          duplicateErr,
+			wantErr:              duplicateErr,
+			wantStopSendingCount: 1,
 		},
 		{
-			name: "normal internal cancellation remains secondary",
+			name:                 "normal internal cancellation remains secondary",
+			wantStopSendingCount: 1,
 		},
 		{
-			name:        "query cancellation remains terminal",
-			cancelQuery: true,
-			wantErr:     context.Canceled,
+			name:                 "query cancellation remains terminal",
+			cancelQuery:          true,
+			wantErr:              context.Canceled,
+			wantStopSendingCount: 1,
 		},
 		{
 			name:                       "remote failure reaches receiver before scope cancellation",
 			remoteErr:                  duplicateErr,
 			assertTerminalBeforeCancel: true,
 			wantErr:                    duplicateErr,
+			wantErrCode:                moerr.ErrDuplicateEntry,
 		},
 		{
-			name:            "remote failure returned after internal cancellation survives",
-			stopResponseErr: duplicateErr,
-			wantErr:         duplicateErr,
+			name:                 "remote failure returned after internal cancellation survives",
+			stopResponseErr:      duplicateErr,
+			wantErr:              duplicateErr,
+			wantErrCode:          moerr.ErrDuplicateEntry,
+			wantStopSendingCount: 1,
 		},
 		{
-			name:            "remote cancellation returned after internal cancellation remains secondary",
-			stopResponseErr: moerr.NewQueryInterrupted(context.Background()),
+			name:                 "remote cancellation returned after internal cancellation remains secondary",
+			stopResponseErr:      moerr.NewQueryInterrupted(context.Background()),
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "StopSending send failure is terminal",
+			stopSendErr:          moerr.NewBackendClosedNoCtx(),
+			wantErrCode:          moerr.ErrBackendClosed,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "canceled StopSending send is a closed stream",
+			stopSendErr:          context.Canceled,
+			wantErrCode:          moerr.ErrStreamClosed,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "StopSending response channel closure is terminal",
+			closeStopResponse:    true,
+			wantErrCode:          moerr.ErrStreamClosed,
+			wantStopSendingCount: 1,
+		},
+		{
+			name:                 "StopSending timeout is terminal and attempted once",
+			timeoutStopResponse:  true,
+			wantErrCode:          moerr.ErrRPCTimeout,
+			wantStopSendingCount: 1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.timeoutStopResponse {
+				oldTimeout := pipelineStopSendingClientTimeout
+				pipelineStopSendingClientTimeout = 10 * time.Millisecond
+				defer func() { pipelineStopSendingClientTimeout = oldTimeout }()
+			}
 			ctrl := gomock.NewController(t)
 			proc := testutil.NewProcess(t)
 			queryCtx := proc.Base.GetContextBase().BuildQueryCtx(proc.GetTopContext())
@@ -620,6 +661,7 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			stream := mock_morpc.NewMockStream(ctrl)
 			stream.EXPECT().Receive().Return(responses, nil)
 			stream.EXPECT().ID().Return(uint64(3)).AnyTimes()
+			stopSendingCount := 0
 			stream.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, request morpc.Message) error {
 					message := request.(*pipeline.Message)
@@ -636,6 +678,17 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 							proc.Cancel(tt.cancelCause)
 						}
 					case pipeline.Method_StopSending:
+						stopSendingCount++
+						if tt.stopSendErr != nil {
+							return tt.stopSendErr
+						}
+						if tt.closeStopResponse {
+							close(responses)
+							return nil
+						}
+						if tt.timeoutStopResponse {
+							return nil
+						}
 						response := &pipeline.Message{Sid: pipeline.Status_MessageEnd}
 						response.SetMessageType(pipeline.Method_PipelineMessage)
 						if tt.stopResponseErr != nil {
@@ -687,24 +740,25 @@ func TestRemoteRunNormalizesPipelineCancellationCause(t *testing.T) {
 			}
 
 			err := s.RemoteRun(c)
-			if tt.wantErr == nil {
+			if tt.wantErrCode != 0 {
+				require.True(t, moerr.IsMoErrCode(err, tt.wantErrCode), err)
+			} else if tt.wantErr == nil {
 				require.NoError(t, err)
-			} else if tt.remoteErr != nil || tt.stopResponseErr != nil {
-				require.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 			} else {
 				require.ErrorIs(t, err, tt.wantErr)
 			}
+			require.Equal(t, tt.wantStopSendingCount, stopSendingCount)
 
 			select {
 			case signal := <-reg.Ch2:
 				_, terminalErr := signal.Action()
-				if tt.wantErr == nil {
+				if tt.wantErrCode == 0 && tt.wantErr == nil {
 					require.Equal(t, process.EventEnd, signal.EventType)
 					require.NoError(t, terminalErr)
 				} else {
 					require.Equal(t, process.EventError, signal.EventType)
-					if tt.remoteErr != nil || tt.stopResponseErr != nil {
-						require.True(t, moerr.IsMoErrCode(terminalErr, moerr.ErrDuplicateEntry))
+					if tt.wantErrCode != 0 {
+						require.True(t, moerr.IsMoErrCode(terminalErr, tt.wantErrCode), terminalErr)
 					} else {
 						require.ErrorIs(t, terminalErr, tt.wantErr)
 					}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -737,18 +737,30 @@ func (s *Scope) RemoteRun(c *Compile) error {
 
 	p := pipeline.New(0, nil, s.RootOp)
 	sender, err := s.remoteRun(c)
+	if sender != nil && isScopeCancellationError(err) {
+		// An internal cancellation can win the receive select just before the
+		// remote execution publishes its terminal response. Stop the producer
+		// through the existing cleanup handshake and arbitrate the returned
+		// terminal before cancellation normalization can classify the result as
+		// a successful early stop.
+		if terminalErr := sender.waitingTheStopResponse(); terminalErr != nil {
+			err = terminalErr
+		}
+	}
 
 	runErr, _ := normalizeScopeRunError(
 		err,
 		s.Proc.Ctx,
 		scopeRunQueryContext(s.Proc),
 	)
+	// The retained local root is the hand-off boundary from RemoteRun to its
+	// consumer. Publish its durable Error terminal before canceling this scope;
+	// otherwise the consumer can observe cancellation first and finish without
+	// the remote execution error that caused it.
+	p.CleanRootOperator(s.Proc, runErr != nil, c.isPrepare, runErr)
 	if runErr != nil && s.Proc.Cancel != nil {
 		s.Proc.Cancel(runErr)
 	}
-	// Normalize before cleanup mutates the pipeline context so a substantive
-	// cancellation cause remains available to the caller.
-	p.CleanRootOperator(s.Proc, runErr != nil, c.isPrepare, runErr)
 
 	// sender should be closed after cleanup (tell the children-pipeline that query was done).
 	if sender != nil {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -738,20 +738,13 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	p := pipeline.New(0, nil, s.RootOp)
 	sender, err := s.remoteRun(c)
 	queryCtx := scopeRunQueryContext(s.Proc)
+	var terminalErr error
 	if sender != nil && isScopeCancellationError(err) {
 		// An internal cancellation can win the receive select just before the
 		// remote execution publishes its terminal response. Stop the producer
-		// through the existing cleanup handshake and arbitrate the returned
-		// terminal before cancellation normalization can classify the result as
-		// a successful early stop.
-		if terminalErr := sender.waitingTheStopResponse(); terminalErr != nil &&
-			(queryCtx == nil || queryCtx.Err() == nil) {
-			// Query cancellation and deadlines own their terminal result. A failed
-			// teardown must not replace that externally requested outcome, while an
-			// internal pipeline cancellation still needs the handshake failure to
-			// prevent false success.
-			err = terminalErr
-		}
+		// through the existing cleanup handshake and retain its terminal for
+		// arbitration after resolving the cancellation's primary cause.
+		terminalErr = sender.waitingTheStopResponse()
 	}
 
 	runErr, _ := normalizeScopeRunError(
@@ -759,6 +752,13 @@ func (s *Scope) RemoteRun(c *Compile) error {
 		s.Proc.Ctx,
 		queryCtx,
 	)
+	if runErr == nil && terminalErr != nil {
+		// A query-owned terminal or substantive pipeline cancellation cause is
+		// primary. StopSending supplies the result only when the original
+		// cancellation was secondary; this still makes a terminal-less handshake
+		// fail closed without allowing teardown fallout to hide execution failure.
+		runErr, _ = normalizeScopeRunError(terminalErr, s.Proc.Ctx, queryCtx)
+	}
 	// The retained local root is the hand-off boundary from RemoteRun to its
 	// consumer. Publish its durable Error terminal before canceling this scope;
 	// otherwise the consumer can observe cancellation first and finish without

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -737,13 +737,19 @@ func (s *Scope) RemoteRun(c *Compile) error {
 
 	p := pipeline.New(0, nil, s.RootOp)
 	sender, err := s.remoteRun(c)
+	queryCtx := scopeRunQueryContext(s.Proc)
 	if sender != nil && isScopeCancellationError(err) {
 		// An internal cancellation can win the receive select just before the
 		// remote execution publishes its terminal response. Stop the producer
 		// through the existing cleanup handshake and arbitrate the returned
 		// terminal before cancellation normalization can classify the result as
 		// a successful early stop.
-		if terminalErr := sender.waitingTheStopResponse(); terminalErr != nil {
+		if terminalErr := sender.waitingTheStopResponse(); terminalErr != nil &&
+			(queryCtx == nil || queryCtx.Err() == nil) {
+			// Query cancellation and deadlines own their terminal result. A failed
+			// teardown must not replace that externally requested outcome, while an
+			// internal pipeline cancellation still needs the handshake failure to
+			// prevent false success.
 			err = terminalErr
 		}
 	}
@@ -751,7 +757,7 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	runErr, _ := normalizeScopeRunError(
 		err,
 		s.Proc.Ctx,
-		scopeRunQueryContext(s.Proc),
+		queryCtx,
 	)
 	// The retained local root is the hand-off boundary from RemoteRun to its
 	// consumer. Publish its durable Error terminal before canceling this scope;

--- a/pkg/vm/process/process_spoolr.go
+++ b/pkg/vm/process/process_spoolr.go
@@ -196,6 +196,35 @@ func ResolvePipelineSpoolAbortError(regs ...*WaitRegister) error {
 	return ErrPipelineEndSignalDeliveryFailed
 }
 
+// IsPipelineCancellationError reports whether every error leaf is cancellation
+// fallout rather than a substantive execution failure. A joined error is
+// cancellation-only only when all of its children are cancellation-shaped.
+func IsPipelineCancellationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		if len(children) == 0 {
+			return false
+		}
+		for _, child := range children {
+			if !IsPipelineCancellationError(child) {
+				return false
+			}
+		}
+		return true
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		if child := wrapped.Unwrap(); child != nil {
+			return IsPipelineCancellationError(child)
+		}
+	}
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted)
+}
+
 // BuildCleanupSignal returns the appropriate terminal signal for pipeline cleanup.
 // EventError is used when pipelineFailed=true or err!=nil; EventEnd otherwise.
 func BuildCleanupSignal(pipelineFailed bool, err error) PipelineSignal {
@@ -441,15 +470,11 @@ func (receiver *PipelineSignalReceiver) GetNextBatch(
 			start := time.Now()
 			chosen, msg = receiver.listenToAll()
 			analyzer.WaitStop(start)
-			if chosen == 0 {
-				return nil, nil
-			}
-
 		} else {
 			chosen, msg = receiver.listenToAll()
-			if chosen == 0 {
-				return nil, nil
-			}
+		}
+		if chosen == 0 {
+			return nil, receiver.contextDoneError()
 		}
 
 		// Handle typed terminal events: End, Error, Abort.
@@ -483,6 +508,34 @@ func (receiver *PipelineSignalReceiver) GetNextBatch(
 		}
 		return content, info
 	}
+}
+
+// contextDoneError resolves a canceled receiver against both sources of
+// terminal truth: its process CancelCause and the durable state of its input
+// edges. The latter closes the race where a sibling cancellation wakes the
+// receiver while a producer has already recorded a more specific failure but
+// could not enqueue every Error signal behind buffered data.
+//
+// A plain context.Canceled remains the intentional StopSending/early-stop path.
+// Query deadlines retain their classifiable sentinel even when
+// WithTimeoutCause carries a different diagnostic cause.
+func (receiver *PipelineSignalReceiver) contextDoneError() error {
+	if receiver == nil || receiver.usrCtx == nil {
+		return nil
+	}
+	if errors.Is(receiver.usrCtx.Err(), context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	cause := context.Cause(receiver.usrCtx)
+	if cause != nil && !IsPipelineCancellationError(cause) {
+		return cause
+	}
+	for _, reg := range receiver.srcReg {
+		if err := reg.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // idx is start from 0, this is the index of receiver at the receiver.regs.

--- a/pkg/vm/process/process_spoolr.go
+++ b/pkg/vm/process/process_spoolr.go
@@ -367,9 +367,10 @@ func (signal PipelineSignal) Action() (data *batch.Batch, info error) {
 }
 
 type PipelineSignalReceiver struct {
-	usrCtx context.Context
-	srcReg []*WaitRegister
-	doneCh []<-chan struct{}
+	usrCtx   context.Context
+	queryCtx context.Context
+	srcReg   []*WaitRegister
+	doneCh   []<-chan struct{}
 
 	alive int
 
@@ -392,6 +393,22 @@ type PipelineSignalReceiverState struct {
 }
 
 func InitPipelineSignalReceiver(runningCtx context.Context, regs []*WaitRegister) *PipelineSignalReceiver {
+	return initPipelineSignalReceiver(runningCtx, nil, regs)
+}
+
+// InitPipelineSignalReceiverFromProcess initializes a receiver with both levels
+// of execution context. The query context owns client cancellation and
+// deadlines, while proc.Ctx may also be canceled internally to stop a pipeline.
+func InitPipelineSignalReceiverFromProcess(proc *Process, regs []*WaitRegister) *PipelineSignalReceiver {
+	queryCtx, _ := GetQueryCtxFromProc(proc)
+	return initPipelineSignalReceiver(proc.Ctx, queryCtx, regs)
+}
+
+func initPipelineSignalReceiver(
+	runningCtx context.Context,
+	queryCtx context.Context,
+	regs []*WaitRegister,
+) *PipelineSignalReceiver {
 	nbs := make([]int, len(regs))
 	srcRegs := slices.Clone(regs)
 	doneCh := make([]<-chan struct{}, len(regs))
@@ -420,6 +437,7 @@ func InitPipelineSignalReceiver(runningCtx context.Context, regs []*WaitRegister
 
 	return &PipelineSignalReceiver{
 		usrCtx:        runningCtx,
+		queryCtx:      queryCtx,
 		srcReg:        srcRegs,
 		doneCh:        doneCh,
 		alive:         len(regs),
@@ -488,7 +506,7 @@ func (receiver *PipelineSignalReceiver) GetNextBatch(
 				continue
 			}
 			// EventError or EventAbort: propagate the error.
-			return nil, msg.terminalErr
+			return nil, receiver.resolveTerminalError(msg.terminalErr)
 		}
 
 		content, info = msg.Action()
@@ -497,7 +515,7 @@ func (receiver *PipelineSignalReceiver) GetNextBatch(
 			// GetDirectly as a per-sender end signal.
 			receiver.removeIdxReceiver(chosen)
 			if info != nil {
-				return nil, info
+				return nil, receiver.resolveTerminalError(info)
 			}
 			continue
 		}
@@ -523,6 +541,9 @@ func (receiver *PipelineSignalReceiver) contextDoneError() error {
 	if receiver == nil || receiver.usrCtx == nil {
 		return nil
 	}
+	if queryErr := receiver.queryContextError(); queryErr != nil {
+		return queryErr
+	}
 	if errors.Is(receiver.usrCtx.Err(), context.DeadlineExceeded) {
 		return context.DeadlineExceeded
 	}
@@ -530,12 +551,32 @@ func (receiver *PipelineSignalReceiver) contextDoneError() error {
 	if cause != nil && !IsPipelineCancellationError(cause) {
 		return cause
 	}
+	var cancellationErr error
 	for _, reg := range receiver.srcReg {
 		if err := reg.Err(); err != nil {
-			return err
+			if !IsPipelineCancellationError(err) {
+				return err
+			}
+			if cancellationErr == nil {
+				cancellationErr = err
+			}
 		}
 	}
-	return nil
+	return cancellationErr
+}
+
+func (receiver *PipelineSignalReceiver) resolveTerminalError(err error) error {
+	if queryErr := receiver.queryContextError(); queryErr != nil {
+		return queryErr
+	}
+	return err
+}
+
+func (receiver *PipelineSignalReceiver) queryContextError() error {
+	if receiver == nil || receiver.queryCtx == nil {
+		return nil
+	}
+	return receiver.queryCtx.Err()
 }
 
 // idx is start from 0, this is the index of receiver at the receiver.regs.

--- a/pkg/vm/process/process_spoolr_test.go
+++ b/pkg/vm/process/process_spoolr_test.go
@@ -119,6 +119,56 @@ func TestPipelineSignalReceiverCancellationPreservesDurableEdgeFailure(t *testin
 	}
 }
 
+func TestPipelineSignalReceiverDurableFailureSelectionIsOrderIndependent(t *testing.T) {
+	duplicateErr := moerr.NewDuplicateEntryNoCtx("5", "primary")
+	interruptedErr := moerr.NewQueryInterrupted(context.Background())
+
+	for _, test := range []struct {
+		name              string
+		errs              []error
+		wantSubstantiveErr bool
+	}{
+		{
+			name:              "cancellation before execution failure",
+			errs:              []error{interruptedErr, duplicateErr},
+			wantSubstantiveErr: true,
+		},
+		{
+			name:              "execution failure before cancellation",
+			errs:              []error{duplicateErr, interruptedErr},
+			wantSubstantiveErr: true,
+		},
+		{
+			name: "cancellation only",
+			errs: []error{interruptedErr, context.Canceled},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			regs := make([]*WaitRegister, len(test.errs))
+			for i, terminalErr := range test.errs {
+				regs[i] = NewPipelineEdge(1, 1)
+				regs[i].Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
+				if regs[i].SendError(terminalErr) {
+					t.Fatalf("error signal %d unexpectedly fit behind buffered data", i)
+				}
+			}
+
+			receiver := InitPipelineSignalReceiver(ctx, regs)
+			err := receiver.contextDoneError()
+			if test.wantSubstantiveErr {
+				if !errors.Is(err, duplicateErr) {
+					t.Fatalf("durable failure selection depended on edge order: got %v, want %v", err, duplicateErr)
+				}
+			} else if !IsPipelineCancellationError(err) {
+				t.Fatalf("cancellation-only edges returned non-cancellation error: %v", err)
+			}
+		})
+	}
+}
+
 func TestPipelineSignalReceiverWaitingEndUsesCleanupTimeout(t *testing.T) {
 	oldCleanupWaitTimeout := PipelineCleanupWaitTimeout
 	PipelineCleanupWaitTimeout = 10 * time.Millisecond

--- a/pkg/vm/process/process_spoolr_test.go
+++ b/pkg/vm/process/process_spoolr_test.go
@@ -16,12 +16,108 @@ package process
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 )
+
+func TestPipelineSignalReceiverCancellationPreservesExecutionCause(t *testing.T) {
+	tests := []struct {
+		name      string
+		cause     error
+		wantError error
+	}{
+		{
+			name:      "execution failure before terminal publication",
+			cause:     moerr.NewDuplicateEntryNoCtx("1", "primary"),
+			wantError: moerr.NewDuplicateEntryNoCtx("1", "primary"),
+		},
+		{
+			name:  "graceful pipeline cancellation",
+			cause: nil,
+		},
+		{
+			name:      "joined execution failure and cancellation",
+			cause:     errors.Join(context.Canceled, moerr.NewDuplicateEntryNoCtx("2", "primary")),
+			wantError: moerr.NewDuplicateEntryNoCtx("2", "primary"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancelCause(context.Background())
+			cancel(test.cause)
+			receiver := InitPipelineSignalReceiver(ctx, []*WaitRegister{NewPipelineEdge(1, 1)})
+
+			got, err := receiver.GetNextBatch(nil)
+			if got != nil {
+				t.Fatal("canceled receiver returned a batch")
+			}
+			if test.wantError == nil {
+				if err != nil {
+					t.Fatalf("graceful cancellation returned error: %v", err)
+				}
+				return
+			}
+			var gotMoErr *moerr.Error
+			var wantMoErr *moerr.Error
+			if !errors.As(test.wantError, &wantMoErr) {
+				t.Fatalf("test expectation is not a MatrixOne error: %v", test.wantError)
+			}
+			if !errors.As(err, &gotMoErr) || gotMoErr.ErrorCode() != wantMoErr.ErrorCode() {
+				t.Fatalf("cancellation lost execution cause: got %v, want code %d", err, wantMoErr.ErrorCode())
+			}
+		})
+	}
+}
+
+func TestPipelineSignalReceiverCancellationPreservesDeadlineClass(t *testing.T) {
+	diagnostic := moerr.NewDuplicateEntryNoCtx("3", "primary")
+	ctx, cancel := context.WithDeadlineCause(
+		context.Background(), time.Now().Add(-time.Second), diagnostic)
+	defer cancel()
+	receiver := InitPipelineSignalReceiver(ctx, []*WaitRegister{NewPipelineEdge(1, 1)})
+
+	got, err := receiver.GetNextBatch(nil)
+	if got != nil {
+		t.Fatal("deadline-canceled receiver returned a batch")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("deadline cancellation returned %v, want context deadline exceeded", err)
+	}
+	if errors.Is(err, diagnostic) {
+		t.Fatalf("deadline cancellation was replaced by diagnostic cause: %v", err)
+	}
+}
+
+func TestPipelineSignalReceiverCancellationPreservesDurableEdgeFailure(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		cause error
+	}{
+		{name: "plain context cancellation"},
+		{name: "query interrupted cancellation", cause: moerr.NewQueryInterrupted(context.Background())},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancelCause(context.Background())
+			cancel(test.cause)
+			edge := NewPipelineEdge(1, 1)
+			edge.Ch2 <- NewPipelineSignalToDirectly(batch.EmptyBatch, nil, nil)
+			duplicateErr := moerr.NewDuplicateEntryNoCtx("4", "primary")
+			if edge.SendError(duplicateErr) {
+				t.Fatal("error signal unexpectedly fit behind buffered data")
+			}
+			receiver := InitPipelineSignalReceiver(ctx, []*WaitRegister{edge})
+
+			if err := receiver.contextDoneError(); !errors.Is(err, duplicateErr) {
+				t.Fatalf("cancellation lost durable edge failure: got %v, want %v", err, duplicateErr)
+			}
+		})
+	}
+}
 
 func TestPipelineSignalReceiverWaitingEndUsesCleanupTimeout(t *testing.T) {
 	oldCleanupWaitTimeout := PipelineCleanupWaitTimeout

--- a/pkg/vm/process/process_spoolr_test.go
+++ b/pkg/vm/process/process_spoolr_test.go
@@ -124,18 +124,18 @@ func TestPipelineSignalReceiverDurableFailureSelectionIsOrderIndependent(t *test
 	interruptedErr := moerr.NewQueryInterrupted(context.Background())
 
 	for _, test := range []struct {
-		name              string
-		errs              []error
+		name               string
+		errs               []error
 		wantSubstantiveErr bool
 	}{
 		{
-			name:              "cancellation before execution failure",
-			errs:              []error{interruptedErr, duplicateErr},
+			name:               "cancellation before execution failure",
+			errs:               []error{interruptedErr, duplicateErr},
 			wantSubstantiveErr: true,
 		},
 		{
-			name:              "execution failure before cancellation",
-			errs:              []error{duplicateErr, interruptedErr},
+			name:               "execution failure before cancellation",
+			errs:               []error{duplicateErr, interruptedErr},
 			wantSubstantiveErr: true,
 		},
 		{

--- a/test/distributed/cases/ddl/comprimary_key.result
+++ b/test/distributed/cases/ddl/comprimary_key.result
@@ -66,6 +66,9 @@ col6    col7    col8    col18    col16    col19
 700    600    20    L/MN?OPQR.STU-_+=VWXYZabcdefghigklmnopqrstuvwxyz012    428.14    r@sina.com
 insert into cpk_table_5 select * from ex_table_cpk;
 Duplicate entry '(.*)' for key '(.*)'
+select count(*) from cpk_table_5;
+count(*)
+4
 show create table cpk_table_5;
 Table    Create Table
 cpk_table_5    CREATE TABLE `cpk_table_5` (\n  `col1` tinyint DEFAULT NULL,\n  `col2` smallint DEFAULT NULL,\n  `col3` int DEFAULT NULL,\n  `col4` bigint DEFAULT NULL,\n  `col5` tinyint unsigned DEFAULT NULL,\n  `col6` smallint unsigned NOT NULL,\n  `col7` int unsigned NOT NULL,\n  `col8` bigint unsigned NOT NULL,\n  `col9` float DEFAULT NULL,\n  `col10` double DEFAULT NULL,\n  `col11` varchar(255) DEFAULT NULL,\n  `col12` date DEFAULT NULL,\n  `col13` datetime DEFAULT NULL,\n  `col14` timestamp NULL DEFAULT NULL,\n  `col15` bool DEFAULT NULL,\n  `col16` decimal(5,2) NOT NULL,\n  `col17` text DEFAULT NULL,\n  `col18` char(255) NOT NULL,\n  `col19` varchar(255) NOT NULL,\n  `col20` varchar(255) DEFAULT NULL,\n  PRIMARY KEY (`col6`,`col7`,`col8`,`col18`,`col16`,`col19`)\n)
@@ -79,6 +82,9 @@ col1    col2    col3    col4    col5    col6    col7    col8    col9    col10   
 3    20    3    7    1    700    600    20    7.2914    1.1732    science    2020-05-08    1998-12-30 00:00:00    1985-01-12 23:59:59    0    428.14    U-_+=VWXYZabcdefghigklmnopqrstuvwxy    L/MN?OPQR.STU-_+=VWXYZabcdefghigklmnopqrstuvwxyz012    r@sina.com    bbbbbbccccc
 insert into cpk_table_6 select * from ex_table_cpk;
 Duplicate entry '(.*)' for key '(.*)'
+select count(*) from cpk_table_6;
+count(*)
+4
 create table cpk_table_7(a int,b float,c char(20),primary key(a,d));
 invalid input: column 'd' doesn't exist in table
 create table cpk_table_8(a int,b float,c char(20),primary key(e,f));

--- a/test/distributed/cases/ddl/comprimary_key.sql
+++ b/test/distributed/cases/ddl/comprimary_key.sql
@@ -58,6 +58,7 @@ select col6,col7,col8,col18,col16,col19 from cpk_table_5;
 -- @pattern
 insert into cpk_table_5 select * from ex_table_cpk;
 -- @bvt:issue
+select count(*) from cpk_table_5;
 show create table cpk_table_5;
 
 -- 复合主键19个
@@ -68,6 +69,7 @@ select * from cpk_table_6;
 -- @pattern
 insert into cpk_table_6 select * from ex_table_cpk;
 -- @bvt:issue
+select count(*) from cpk_table_6;
 -- 异常：复合主键列部分不存在
 create table cpk_table_7(a int,b float,c char(20),primary key(a,d));
 create table cpk_table_8(a int,b float,c char(20),primary key(e,f));


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28277

## What this PR does / why we need it:

### Root cause

A remote pipeline receive can observe internal context cancellation immediately before the execution CN publishes its terminal response. That cancellation was normalized as a successful early stop. The existing StopSending cleanup handshake subsequently consumed the remote terminal error but discarded it. At the local pipeline boundary, scope cancellation could also win before a retained connector Error terminal was observed, even though the PipelineEdge had already recorded the substantive failure durably.

The local multi-input receiver had two related arbitration gaps: it knew only the pipeline context and therefore could replace a query-owned cancellation with a late edge failure, and it returned the first durable edge error in source order even when that error was cancellation fallout and a later edge held the real execution failure. Together these races allowed an execution-side duplicate-key failure to reach the SQL client as success or allowed the wrong terminal class to win.

Remote StopSending arbitration also initially applied its teardown result before resolving the cancellation that triggered cleanup. When the pipeline already carried a substantive execution cause, a simultaneous StopSending send failure, response closure, or timeout could therefore replace that SQL error with a transport error.

### Changes

- Make the existing StopSending handshake return its terminal result, then resolve the original query/pipeline cancellation first. The handshake result supplies the outcome only when that original cancellation is secondary, so a known execution cause cannot be hidden by teardown while a cause-less terminal-less handshake still fails closed.
- Claim StopSending arbitration once under the sender state lock, so cleanup force-closes after a terminal-less attempt rather than waiting for the same 30-second deadline twice. Cleanup-only callers explicitly ignore the already-arbitrated result.
- Preserve query-owned cancellation, deadlines, and substantive pipeline execution causes when that bounded handshake fails without a terminal; cleanup still runs and force-closes the unhealthy stream.
- Publish the retained local root Error terminal before canceling the remote scope.
- Initialize production Merge receivers from the Process so they retain both the query context and the child pipeline context. Query cancellation/deadline now owns every receiver terminal return, including a directly received or durably synthesized Error signal.
- When the query remains active, resolve canceled receivers from the process cancellation cause and all durable input-edge failures. A substantive failure outranks cancellation-only fallout independent of input order; a cancellation error is retained only when every recorded edge error is cancellation-shaped.
- Extend the composite-primary-key BVT with post-failure row-count assertions for both six-column and nineteen-column composite keys.

### Issue-to-test proof

- `TestRemoteRunNormalizesPipelineCancellationCause/remote_failure_returned_after_internal_cancellation_survives` deterministically forces cancellation to win the first receive and releases the duplicate-key terminal only after StopSending. The test failed before the handshake return-value change and now requires the duplicate-key error at both `RemoteRun` and the retained root edge.
- The same unit test covers an immediate remote execution failure, terminal publication before scope cancellation, graceful internal cancellation, query cancellation, deadline cancellation, and a late remote QueryInterrupted terminal that must remain secondary.
- Its StopSending cases deterministically cover a substantive send failure, a cancellation-shaped send failure mapped to closed transport, response-channel closure before terminal, and an injected 10 ms timeout. Every case asserts the client/root error class, and the timeout case asserts exactly one StopSending request across arbitration and cleanup.
- Six cross-product cases combine query cancellation and query deadline with StopSending send failure, response-channel closure, and timeout. They require the query-owned terminal at both `RemoteRun` and the retained root while preserving substantive handshake failures for internal cancellation.
- Three cross-product cases combine a DuplicateEntry pipeline cancellation cause with StopSending send failure, response-channel closure, and timeout. All three failed before the final arbitration-order change with BackendClosed, StreamClosed, or RPCTimeout respectively; they now require DuplicateEntry at both `RemoteRun` and the retained root. The existing cause-less cases continue to require the teardown errors.
- `TestPipelineSignalReceiverCancellationPreservesExecutionCause`, `TestPipelineSignalReceiverCancellationPreservesDeadlineClass`, and `TestPipelineSignalReceiverCancellationPreservesDurableEdgeFailure` cover substantive process causes, joined errors, graceful cancellation, deadline identity, full-channel Error delivery, and QueryInterrupted cancellation.
- `TestPipelineSignalReceiverDurableFailureSelectionIsOrderIndependent` fills both input channels so Error publication can succeed only through durable edge state, then proves DuplicateEntry outranks QueryInterrupted in both edge orders and that an all-cancellation set remains cancellation-shaped. Its cancellation-first case failed before the production change.
- `TestMergePreservesQueryTerminalOverLateEdgeFailure` uses separate query and pipeline contexts through the real Merge `Prepare`/`Call` path. It cancels or deadlines the query before recording an undeliverable late DuplicateEntry and requires the query terminal in both cases. The cancellation case failed before the production change.
- `comprimary_key.sql` still requires the exact duplicate errors for `cpk_table_5` and `cpk_table_6`, and now proves failure atomicity by requiring four rows after each rejected `INSERT ... SELECT`.

### Tests run

- `make build` on committed head `1e1fbaaf69`
- Focused receiver, Merge, and remote arbitration regressions after the latest rebase; the Merge query-terminal case passed 20 repetitions
- Complete RemoteRun arbitration matrix on committed head `1e1fbaaf69` under `-race`, 100 repetitions; the three new pipeline-cause/StopSending cross-products also passed independently
- Focused receiver and Merge arbitration tests under `-race`, 100 repetitions
- Full `./pkg/sql/compile` normal and race suites on committed head `1e1fbaaf69`; full affected-package tests on rebased predecessor `3d829006a3`: `./pkg/vm/process`, `./pkg/sql/colexec/merge`, and `./pkg/sql/compile`
- Full race tests: `./pkg/vm/process` and `./pkg/sql/colexec/merge`
- Earlier unchanged closure coverage remains green for `./pkg/sql/colexec/connector` and `./pkg/sql/colexec/dispatch`
- `go vet -mod=readonly ./pkg/sql/compile` on committed head `1e1fbaaf69`; earlier full affected-package vet remains green
- Repository-configured `golangci-lint` 2.6.2 on all three changed package trees at `3d829006a3`: 0 issues. `gofmt -d` is empty for every changed Go file on `1e1fbaaf69`.
- Native two-CN Proxy BVT: `comprimary_key.sql`, 300 repetitions, 21,900/21,900 statements passed; all generated reports were inspected and contained no failures. After review and rebases, the case was repeatedly rerun on fresh two-CN Proxy clusters. On semantic head `9bc9c3ae60`, it passed 73/73 statements with an empty error report; the six-column duplicate was client-visible and the post-failure row count remained four. The subsequent commit changes only test whitespace.

The documented Docker topology could not be built locally because Docker Hub authentication returned EOF. The same repository `etc/launch-with-proxy` two-CN topology was run natively through Proxy with the rebuilt `mo-service`; no topology configuration is included in this PR.

### Rebase verification

Rebased onto main commit `6e5f82f568`. The new upstream commit changes JSON binary subtype handling and does not overlap this PR's production code, terminal tests, or BVT. The full receiver, Merge, and compile package suites plus repository-configured lint were rerun after rebase. The exact two-CN Proxy `comprimary_key.sql` BVT passed 73/73 with an empty error report at `9bc9c3ae60`; the later `3d829006a3` commit changed only test formatting. The final RemoteRun precedence change is covered by exact deterministic UT and a committed-head binary build, while fresh PR CI supplies the current-head Proxy BVT.

### Residual risks

The original CI symptom is timing-dependent. Forced unit tests provide deterministic coverage of cancellation-before-terminal ordering, terminal-less StopSending outcomes, query-vs-pipeline-vs-teardown ownership, and multi-edge priority independent of source order, while repeated Proxy BVT supplies end-to-end stress evidence. Terminal-less StopSending paths fail closed with explicit transport/protocol/timeout errors and have a single bounded wait; no retry, fallback channel, or unbounded resource lifecycle was added.
