### PR TITLE
[4.2] fix: resolve secondary indexes in subscriptions

### DIFF
--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -585,6 +585,7 @@ func (tcc *TxnCompilerContext) ResolveIndexTableByRef(
 	if ref.PubInfo != nil {
 		subMeta = &plan.SubscriptionMeta{
 			AccountId: ref.PubInfo.TenantId,
+			DbName:    ref.SchemaName,
 		}
 	}
 

--- a/test/distributed/cases/publication_subscription/pub_sub_secondary_index.result
+++ b/test/distributed/cases/publication_subscription/pub_sub_secondary_index.result
@@ -1,0 +1,47 @@
+drop publication if exists pub_secondary_idx;
+drop account if exists sub_secondary_idx;
+drop database if exists pub_secondary_idx_db;
+create account sub_secondary_idx admin_name = 'admin' identified by '111';
+create database pub_secondary_idx_db;
+create table pub_secondary_idx_db.audit_events (
+id int primary key,
+event_type varchar(32),
+created_at bigint,
+index idx_event_type (event_type),
+index idx_created_at (created_at)
+);
+insert into pub_secondary_idx_db.audit_events
+select g.result,
+if(g.result in (42, 4242), 'login_success', 'other'),
+g.result
+from generate_series(1, 100000) g;
+select mo_ctl('dn', 'flush', 'pub_secondary_idx_db.audit_events');
+mo_ctl(dn, flush, pub_secondary_idx_db.audit_events)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select sleep(1);
+sleep(1)
+0
+create publication pub_secondary_idx database pub_secondary_idx_db account sub_secondary_idx;
+drop database if exists sub_secondary_idx_db;
+create database sub_secondary_idx_db from sys publication pub_secondary_idx;
+explain select count(*) as login_count from sub_secondary_idx_db.audit_events force index (idx_event_type)
+where event_type = 'login_success';
+TP QUERY PLAN
+Project
+  ->  Aggregate
+        Aggregate Functions: starcount(1)
+        ->  Index Table Scan on audit_events.idx_event_type
+              Filter Cond: prefix_eq(__mo_index_idx_col)
+              Block Filter Cond: prefix_eq(__mo_index_idx_col)
+select count(*) as login_count from sub_secondary_idx_db.audit_events force index (idx_event_type)
+where event_type = 'login_success';
+login_count
+2
+select count(*) as recent_count from sub_secondary_idx_db.audit_events force index (idx_created_at)
+where created_at >= 99999;
+recent_count
+2
+drop database sub_secondary_idx_db;
+drop publication pub_secondary_idx;
+drop database pub_secondary_idx_db;
+drop account sub_secondary_idx;

--- a/test/distributed/cases/publication_subscription/pub_sub_secondary_index.sql
+++ b/test/distributed/cases/publication_subscription/pub_sub_secondary_index.sql
@@ -1,0 +1,40 @@
+drop publication if exists pub_secondary_idx;
+drop account if exists sub_secondary_idx;
+drop database if exists pub_secondary_idx_db;
+create account sub_secondary_idx admin_name = 'admin' identified by '111';
+
+create database pub_secondary_idx_db;
+create table pub_secondary_idx_db.audit_events (
+    id int primary key,
+    event_type varchar(32),
+    created_at bigint,
+    index idx_event_type (event_type),
+    index idx_created_at (created_at)
+);
+insert into pub_secondary_idx_db.audit_events
+select g.result,
+       if(g.result in (42, 4242), 'login_success', 'other'),
+       g.result
+from generate_series(1, 100000) g;
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'pub_secondary_idx_db.audit_events');
+select sleep(1);
+create publication pub_secondary_idx database pub_secondary_idx_db account sub_secondary_idx;
+
+-- @session:id=1&user=sub_secondary_idx:admin&password=111
+drop database if exists sub_secondary_idx_db;
+create database sub_secondary_idx_db from sys publication pub_secondary_idx;
+-- @separator:table
+-- @regex("Index Table Scan.*idx_event_type", true)
+explain select count(*) as login_count from sub_secondary_idx_db.audit_events force index (idx_event_type)
+where event_type = 'login_success';
+select count(*) as login_count from sub_secondary_idx_db.audit_events force index (idx_event_type)
+where event_type = 'login_success';
+select count(*) as recent_count from sub_secondary_idx_db.audit_events force index (idx_created_at)
+where created_at >= 99999;
+drop database sub_secondary_idx_db;
+-- @session
+
+drop publication pub_secondary_idx;
+drop database pub_secondary_idx_db;
+drop account sub_secondary_idx;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28279

## What this PR does / why we need it:

Regular secondary-index scans over a subscribed database resolve the hidden index table under the publisher account. `ResolveIndexTableByRef` carried the publisher account ID but omitted the publisher database name, so `getRelation` replaced the valid source database with an empty name and returned `no such table <publisher_db>.__mo_index_secondary_*`.

This PR:

- sets `SubscriptionMeta.DbName` from the planner-resolved published table reference;
- adds a deterministic publication/subscription BVT with a different subscription alias, 100,000 flushed rows, and forced scans over two regular secondary indexes;
- asserts that the plan actually uses `idx_event_type`, preventing the regression case from silently falling back to a table scan.

This is the focused `4.2-dev` backport of the subscription metadata fix already merged into `main` by #26702. It does not backport the unrelated FULLTEXT implementation from that PR.

Validation:

- Base `c8b8e2c046`: the regression SQL reproduced the production failure for both hidden secondary-index tables.
- Head `7f32413fbb`: `pub_sub_secondary_index` passed, 19/19 statements.
- The fixed BVT query pair also passed three consecutive runs before adding the explicit plan assertion.
- `make build` passed.
- `git diff --check` passed.

QA required: yes. The BVT reproduces and verifies the single-node planner/resolver path; normal 4.2 CI and publication/subscription testing should run on the PR.
