### PR TITLE
[4.2] fix(frontend): resolve subscription index tables in publisher database

### DIFF
--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -585,6 +585,7 @@ func (tcc *TxnCompilerContext) ResolveIndexTableByRef(
 	if ref.PubInfo != nil {
 		subMeta = &plan.SubscriptionMeta{
 			AccountId: ref.PubInfo.TenantId,
+			DbName:    ref.SchemaName,
 		}
 	}
 

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -450,6 +450,74 @@ func TestSession_TxnCompilerContext(t *testing.T) {
 	})
 }
 
+func TestResolveIndexTableByRefUsesPublisherDatabaseAndAccount(t *testing.T) {
+	const (
+		service             = "resolve-index-publisher-context"
+		subscriberAccountID = uint32(7)
+		publisherAccountID  = uint32(42)
+		publisherDatabase   = "publisher_db"
+		indexTable          = "__mo_index_secondary_test"
+	)
+
+	ctrl := gomock.NewController(t)
+	ctx := defines.AttachAccountId(context.Background(), subscriberAccountID)
+	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOperator.EXPECT().Txn().Return(txn.TxnMeta{}).AnyTimes()
+	txnClient := mock_frontend.NewMockTxnClient(ctrl)
+
+	indexRelation := mock_frontend.NewMockRelation(ctrl)
+	indexRelation.EXPECT().GetTableID(gomock.Any()).Return(uint64(10))
+	indexRelation.EXPECT().GetTableDef(gomock.Any()).Return(&plan.TableDef{Name: indexTable})
+
+	assertPublisherContext := func(callCtx context.Context) {
+		accountID, err := defines.GetAccountId(callCtx)
+		require.NoError(t, err)
+		require.Equal(t, publisherAccountID, accountID)
+	}
+	db := mock_frontend.NewMockDatabase(ctrl)
+	db.EXPECT().Relation(gomock.Any(), indexTable, nil).
+		DoAndReturn(func(callCtx context.Context, _ string, _ any) (engine.Relation, error) {
+			assertPublisherContext(callCtx)
+			return indexRelation, nil
+		})
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().Hints().Return(engine.Hints{CommitOrRollbackTimeout: time.Second}).AnyTimes()
+	eng.EXPECT().Database(gomock.Any(), publisherDatabase, txnOperator).
+		DoAndReturn(func(callCtx context.Context, _ string, _ client.TxnOperator) (engine.Database, error) {
+			assertPublisherContext(callCtx)
+			return db, nil
+		})
+
+	pu := config.NewParameterUnit(&config.FrontendParameters{}, eng, txnClient, nil)
+	InitServerLevelVars(service)
+	setPu(service, pu)
+	setSessionAlloc(service, NewLeakCheckAllocator())
+	sv, err := getSystemVariables("test/system_vars_config.toml")
+	require.NoError(t, err)
+	ioses, err := NewIOSession(&testConn{}, pu, service)
+	require.NoError(t, err)
+	proto := NewMysqlClientProtocol("", 0, ioses, 1024, sv)
+	ses := NewSession(ctx, service, proto, nil)
+	defer ses.Close()
+	ses.GetTxnHandler().txnOp = txnOperator
+	ses.txnCompileCtx.execCtx = &ExecCtx{reqCtx: ctx, ses: ses}
+
+	ref := &plan.ObjectRef{
+		SchemaName: publisherDatabase,
+		PubInfo:    &plan.PubInfo{TenantId: int32(publisherAccountID)},
+	}
+	obj, tableDef, err := ses.GetTxnCompileCtx().ResolveIndexTableByRef(ref, indexTable, &plan2.Snapshot{})
+	require.NoError(t, err)
+	require.Equal(t, publisherDatabase, obj.SchemaName)
+	require.Equal(t, indexTable, obj.ObjName)
+	require.Equal(t, indexTable, tableDef.Name)
+
+	accountID, err := defines.GetAccountId(ctx)
+	require.NoError(t, err)
+	require.Equal(t, subscriberAccountID, accountID)
+}
+
 func TestSession_ResolveTempIndexTable(t *testing.T) {
 	convey.Convey("test resolve temp index table", t, func() {
 		ctrl := gomock.NewController(t)

--- a/test/distributed/cases/publication_subscription/pub_sub_secondary_index.result
+++ b/test/distributed/cases/publication_subscription/pub_sub_secondary_index.result
@@ -1,0 +1,52 @@
+drop account if exists pub_idx_28279;
+drop account if exists sub_idx_28279_a;
+drop account if exists sub_idx_28279_b;
+create account pub_idx_28279 admin_name = 'admin' identified by '111';
+create account sub_idx_28279_a admin_name = 'admin' identified by '111';
+create account sub_idx_28279_b admin_name = 'admin' identified by '111';
+create database `pub-idx-28279`;
+create table `pub-idx-28279`.events (
+id bigint primary key,
+event_type varchar(32),
+created_at bigint,
+key idx_event_type(event_type),
+key idx_created_at(created_at)
+);
+insert into `pub-idx-28279`.events values
+(1, 'login', 10),
+(2, 'other', 20),
+(3, 'login', 30);
+create table `pub-idx-28279`.secret_events (id bigint primary key);
+insert into `pub-idx-28279`.secret_events values (99);
+create publication pub_idx_28279 database `pub-idx-28279` table events account sub_idx_28279_a, sub_idx_28279_b;
+create database sub_idx_alias_a from pub_idx_28279 publication pub_idx_28279;
+use sub_idx_alias_a;
+select id from events ignore index (idx_event_type, idx_created_at) where event_type = 'login' order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+3
+select id from events ignore index (idx_event_type, idx_created_at) where created_at = 20 order by id;
+➤ id[-5,64,0]  𝄀
+2
+select id from events where event_type = 'login' order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+3
+select id from events where created_at = 20 order by id;
+➤ id[-5,64,0]  𝄀
+2
+select * from secret_events;
+SQL parser error: table "secret_events" does not exist
+create database sub_idx_alias_b from pub_idx_28279 publication pub_idx_28279;
+use sub_idx_alias_b;
+select id from events where event_type = 'login' order by id;
+➤ id[-5,64,0]  𝄀
+1  𝄀
+3
+drop database sub_idx_alias_b;
+drop database sub_idx_alias_a;
+drop publication pub_idx_28279;
+drop database `pub-idx-28279`;
+drop account sub_idx_28279_a;
+drop account sub_idx_28279_b;
+drop account pub_idx_28279;

--- a/test/distributed/cases/publication_subscription/pub_sub_secondary_index.sql
+++ b/test/distributed/cases/publication_subscription/pub_sub_secondary_index.sql
@@ -1,0 +1,60 @@
+-- Queries through a subscription must resolve ordinary secondary-index tables
+-- in the publisher account and physical database, not in the subscription alias.
+drop account if exists pub_idx_28279;
+drop account if exists sub_idx_28279_a;
+drop account if exists sub_idx_28279_b;
+create account pub_idx_28279 admin_name = 'admin' identified by '111';
+create account sub_idx_28279_a admin_name = 'admin' identified by '111';
+create account sub_idx_28279_b admin_name = 'admin' identified by '111';
+
+-- @session:id=1&user=pub_idx_28279:admin&password=111
+create database `pub-idx-28279`;
+create table `pub-idx-28279`.events (
+    id bigint primary key,
+    event_type varchar(32),
+    created_at bigint,
+    key idx_event_type(event_type),
+    key idx_created_at(created_at)
+);
+insert into `pub-idx-28279`.events values
+    (1, 'login', 10),
+    (2, 'other', 20),
+    (3, 'login', 30);
+create table `pub-idx-28279`.secret_events (id bigint primary key);
+insert into `pub-idx-28279`.secret_events values (99);
+create publication pub_idx_28279 database `pub-idx-28279` table events account sub_idx_28279_a, sub_idx_28279_b;
+-- @session
+
+-- @session:id=2&user=sub_idx_28279_a:admin&password=111
+create database sub_idx_alias_a from pub_idx_28279 publication pub_idx_28279;
+use sub_idx_alias_a;
+-- Base-table controls.
+select id from events ignore index (idx_event_type, idx_created_at) where event_type = 'login' order by id;
+select id from events ignore index (idx_event_type, idx_created_at) where created_at = 20 order by id;
+-- On this minimum fixture, each natural predicate selects a distinct hidden
+-- ordinary secondary-index table on 4.2.
+select id from events where event_type = 'login' order by id;
+select id from events where created_at = 20 order by id;
+-- A resolved publisher context must not broaden the publication boundary.
+select * from secret_events;
+-- @session
+
+-- @session:id=3&user=sub_idx_28279_b:admin&password=111
+create database sub_idx_alias_b from pub_idx_28279 publication pub_idx_28279;
+use sub_idx_alias_b;
+select id from events where event_type = 'login' order by id;
+drop database sub_idx_alias_b;
+-- @session
+
+-- @session:id=2&user=sub_idx_28279_a:admin&password=111
+drop database sub_idx_alias_a;
+-- @session
+
+-- @session:id=1&user=pub_idx_28279:admin&password=111
+drop publication pub_idx_28279;
+drop database `pub-idx-28279`;
+-- @session
+
+drop account sub_idx_28279_a;
+drop account sub_idx_28279_b;
+drop account pub_idx_28279;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28279

## What this PR does / why we need it:

Subscription table planning already carries the publisher tenant and physical database in `ObjectRef`. When the optimizer resolves a hidden ordinary secondary-index table, `ResolveIndexTableByRef` preserved only the publisher account and left `SubscriptionMeta.DbName` empty. `getRelation` then replaced the valid publisher database with that empty value, causing indexed subscriber predicates to fail with `ERROR 1146` even though the base-table path succeeded.

This PR backports only the relevant one-line context fix already present on main through #26702:

```go
DbName: ref.SchemaName,
```

It deliberately does not cherry-pick all of #26702 because that PR also contains a much larger Fulltext/protobuf/remote-pipeline change that is outside this 4.2 ordinary-index defect.

Coverage added:

- a focused frontend unit test proving both publisher account and publisher database reach the engine lookup while the subscriber request context remains unchanged;
- a publication/subscription BVT with two ordinary indexes, two subscriber aliases, base-table controls, natural index-selected predicates, and unpublished-table denial.

Counterexample evidence on exact `4.2-dev@c8b8e2c0467fed7e7ddb0d5125f97cb36511daf1`:

- both natural indexed predicates failed with `ERROR 1146`, each naming its corresponding hidden index table;
- both `IGNORE INDEX` controls returned the expected rows;
- removing this one-line fix makes the focused unit test fail because the engine receives an empty database name.

Fixed evidence:

- both natural predicates use `Index Table Scan` and return the expected rows;
- a second subscription alias returns the same result;
- the unpublished table remains inaccessible;
- current `mo-tester@334d3e124bbfbdcd6b5cc63439278d172c72b706`: `29/29` statements passed;
- focused unit test and the full `pkg/frontend` package passed through the repository CGo-aware test wrapper;
- `git diff --check` passed.

The production change does not alter catalog, wire, or protobuf formats and introduces no new shared state or runtime wait.
