### PR TITLE
test(cdc): stabilize watermark drop race observation

### DIFF
--- a/pkg/tests/issues/cdc_txn_race_test.go
+++ b/pkg/tests/issues/cdc_txn_race_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/stretchr/testify/require"
 )
@@ -183,6 +184,56 @@ func TestCDCRaceTxn(t *testing.T) {
 			}}, nil)
 			// Do not release, cancel, or join: registered cleanup owns all three.
 		})
+	})
+}
+
+func TestCDCWaiterProbe(t *testing.T) {
+	t.Run("requires the contender transaction", func(t *testing.T) {
+		found, observedTxnIDs := cdcWaiterMatches([]lockpb.WaitTxn{
+			{TxnID: []byte("unrelated")},
+		}, []byte("contender"))
+		require.False(t, found)
+		require.Equal(t, []string{"756e72656c61746564"}, observedTxnIDs)
+
+		found, observedTxnIDs = cdcWaiterMatches([]lockpb.WaitTxn{
+			{TxnID: []byte("unrelated")},
+			{TxnID: []byte("contender")},
+		}, []byte("contender"))
+		require.True(t, found)
+		require.Equal(t, []string{"756e72656c61746564", "636f6e74656e646572"}, observedTxnIDs)
+	})
+
+	t.Run("cancellation joins the in-flight probe", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		probeEntered := make(chan struct{})
+		done := make(chan struct{})
+		var observedTxnIDs []string
+		var err error
+		go func() {
+			observedTxnIDs, err = waitForCDCWaiter(ctx, func(ctx context.Context) (bool, []string, error) {
+				close(probeEntered)
+				<-ctx.Done()
+				return false, []string{"blocked"}, ctx.Err()
+			})
+			close(done)
+		}()
+
+		joinCtx, joinCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer joinCancel()
+		select {
+		case <-probeEntered:
+		case <-joinCtx.Done():
+			t.Fatal("waiter probe did not start")
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-joinCtx.Done():
+			t.Fatal("waiter probe did not stop after cancellation")
+		}
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, []string{"blocked"}, observedTxnIDs)
 	})
 }
 

--- a/pkg/tests/issues/issue_27666_test.go
+++ b/pkg/tests/issues/issue_27666_test.go
@@ -15,6 +15,7 @@
 package issues
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -24,6 +25,8 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/matrixorigin/matrixone/pkg/cdc"
 	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
+	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/stretchr/testify/require"
@@ -48,12 +51,8 @@ func TestIssue27666CDCWatermarkWriteSerializesWithDrop(t *testing.T) {
 		queryDB := openDB(cn0.GetServiceConfig().CN.Frontend.Port)
 		dropExec := testutils.GetSQLExecutor(cn0)
 		writerExec := testutils.GetSQLExecutor(cn1)
-
-		var taskTableID uint64
-		require.NoError(t, queryDB.QueryRowContext(ctx,
-			"select rel_id from mo_catalog.mo_tables where account_id = 0 and reldatabase = 'mo_catalog' and relname = 'mo_cdc_task'",
-		).Scan(&taskTableID))
-		require.NotZero(t, taskTableID)
+		dropLockService := lockservice.GetLockServiceByServiceID(cn0.ServiceID())
+		writerLockService := lockservice.GetLockServiceByServiceID(cn1.ServiceID())
 
 		testCases := []struct {
 			name        string
@@ -83,7 +82,9 @@ func TestIssue27666CDCWatermarkWriteSerializesWithDrop(t *testing.T) {
 					),
 					fmt.Sprintf("(account_id = 0 AND task_id = '%s')", tc.taskID),
 				)
-				testCDCWatermarkDropRace(t, ctx, c, dropExec, writerExec, taskTableID, tc.taskID, writerSQL, tc.writerFirst)
+				testCDCWatermarkDropRace(t, ctx,
+					dropExec, writerExec, dropLockService, writerLockService,
+					tc.taskID, writerSQL, tc.writerFirst)
 
 				var taskCount, watermarkCount int
 				require.NoError(t, queryDB.QueryRowContext(ctx,
@@ -102,14 +103,14 @@ func TestIssue27666CDCWatermarkWriteSerializesWithDrop(t *testing.T) {
 func testCDCWatermarkDropRace(
 	t *testing.T,
 	ctx context.Context,
-	c embed.Cluster,
 	dropExec, writerExec executor.SQLExecutor,
-	taskTableID uint64,
+	dropLockService, writerLockService lockservice.LockService,
 	taskID, writerSQL string,
 	writerFirst bool,
 ) {
 	t.Helper()
 	holderExec, contenderExec := dropExec, writerExec
+	holderLockService := dropLockService
 	holderSQL := []string{
 		fmt.Sprintf("delete from mo_catalog.mo_cdc_task where account_id = 0 and task_id = '%s'", taskID),
 		fmt.Sprintf("delete from mo_catalog.mo_cdc_watermark where account_id = 0 and task_id = '%s'", taskID),
@@ -117,17 +118,23 @@ func testCDCWatermarkDropRace(
 	contenderSQL := []string{writerSQL}
 	if writerFirst {
 		holderExec, contenderExec = contenderExec, holderExec
+		holderLockService = writerLockService
 		holderSQL, contenderSQL = contenderSQL, holderSQL
 	}
 
 	releaseHolder := make(chan struct{})
-	holder := startCDCRaceTxn(t, ctx, holderExec, releaseHolder, holderSQL...)
+	holder := startCDCRaceTxnWithTxnID(t, ctx, holderExec, releaseHolder, holderSQL...)
 	require.NoError(t, holder.waitReady(ctx))
-	contender := startCDCRaceTxn(t, ctx, contenderExec, nil, contenderSQL...)
-	require.Eventually(t, func() bool {
-		return clusterHasLockWaiter(c, taskTableID)
-	}, 30*time.Second, 10*time.Millisecond,
-		"contender did not wait for the holder's task-row lock")
+	contender := startCDCRaceTxnWithTxnID(t, ctx, contenderExec, nil, contenderSQL...)
+	require.NoError(t, contender.waitTxnID(ctx))
+	probeCtx, cancelProbe := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelProbe()
+	observedWaiterTxnIDs, err := waitForCDCWaiter(probeCtx, func(probeCtx context.Context) (bool, []string, error) {
+		return holder.hasWaiter(probeCtx, holderLockService, contender.txnID)
+	})
+	require.NoError(t, err,
+		"contender transaction %x did not wait for holder transaction %x; observed waiter transaction IDs: %v",
+		contender.txnID, holder.txnID, observedWaiterTxnIDs)
 
 	close(releaseHolder)
 	finishCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -136,19 +143,47 @@ func testCDCWatermarkDropRace(
 	require.NoError(t, contender.wait(finishCtx))
 }
 
-// cdcRaceTxn publishes readiness only after all statements succeed, and completion
-// on every ExecTxn return, including errors before the callback is entered.
+// cdcRaceTxn publishes its transaction ID, when requested, as ExecTxn enters
+// its callback; readiness only after all statements succeed; and completion on
+// every ExecTxn return, including errors before the callback is entered.
 // Closing done publishes err and lets both the assertion and cleanup join it.
 type cdcRaceTxn struct {
-	ready chan struct{}
-	done  chan struct{}
-	err   error
+	started chan struct{}
+	ready   chan struct{}
+	done    chan struct{}
+	err     error
+	txnID   []byte
 }
 
 func startCDCRaceTxn(t *testing.T, parent context.Context, sqlExec executor.SQLExecutor, release <-chan struct{}, statements ...string) *cdcRaceTxn {
+	return startCDCRaceTxnInternal(t, parent, sqlExec, release, false, statements...)
+}
+
+func startCDCRaceTxnWithTxnID(
+	t *testing.T,
+	parent context.Context,
+	sqlExec executor.SQLExecutor,
+	release <-chan struct{},
+	statements ...string,
+) *cdcRaceTxn {
+	return startCDCRaceTxnInternal(t, parent, sqlExec, release, true, statements...)
+}
+
+func startCDCRaceTxnInternal(
+	t *testing.T,
+	parent context.Context,
+	sqlExec executor.SQLExecutor,
+	release <-chan struct{},
+	captureTxnID bool,
+	statements ...string,
+) *cdcRaceTxn {
 	t.Helper()
 	ctx, cancel := context.WithCancel(parent)
-	run := &cdcRaceTxn{ready: make(chan struct{}), done: make(chan struct{})}
+	run := &cdcRaceTxn{
+		started: make(chan struct{}),
+		ready:   make(chan struct{}),
+		done:    make(chan struct{}),
+	}
 	// Register before launching work: even a failed readiness assertion must
 	// cancel and join the transaction before the fixture's catalog cleanup.
 	t.Cleanup(func() {
@@ -164,6 +199,10 @@ func startCDCRaceTxn(t *testing.T, parent context.Context, sqlExec executor.SQLE
 	go func() {
 		defer close(run.done)
 		run.err = sqlExec.ExecTxn(ctx, func(txn executor.TxnExecutor) error {
+			if captureTxnID {
+				run.txnID = append(run.txnID[:0], txn.Txn().Txn().ID...)
+			}
+			close(run.started)
 			for _, statement := range statements {
 				if err := execInternalTxnSQL(txn, statement); err != nil {
 					return err
@@ -184,6 +223,20 @@ func startCDCRaceTxn(t *testing.T, parent context.Context, sqlExec executor.SQLE
 	return run
 }
 
+func (r *cdcRaceTxn) waitTxnID(ctx context.Context) error {
+	select {
+	case <-r.started:
+		if len(r.txnID) == 0 {
+			return fmt.Errorf("CDC race transaction did not publish a transaction ID")
+		}
+		return nil
+	case <-r.done:
+		return r.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (r *cdcRaceTxn) waitReady(ctx context.Context) error {
 	select {
 	case <-r.ready:
@@ -201,6 +254,81 @@ func (r *cdcRaceTxn) wait(ctx context.Context) error {
 		return r.err
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+// hasWaiter asks the holder's lock service for the wait graph rooted at the
+// holder transaction. Unlike IterLocks, the query follows the holder's
+// authoritative lock route when the table is bound to another CN.
+func (r *cdcRaceTxn) hasWaiter(
+	ctx context.Context,
+	lockService lockservice.LockService,
+	waiterTxnID []byte,
+) (bool, []string, error) {
+	if lockService == nil {
+		return false, nil, fmt.Errorf("holder transaction has no lock service")
+	}
+	if len(r.txnID) == 0 {
+		return false, nil, fmt.Errorf("holder transaction has no transaction ID")
+	}
+	if len(waiterTxnID) == 0 {
+		return false, nil, fmt.Errorf("contender transaction has no transaction ID")
+	}
+	found, waiters, err := lockService.GetWaitingList(ctx, r.txnID)
+	if err != nil {
+		return false, nil, err
+	}
+	if !found {
+		return false, nil, fmt.Errorf("holder transaction is not active on lock service %q", lockService.GetServiceID())
+	}
+	foundWaiter, observedTxnIDs := cdcWaiterMatches(waiters, waiterTxnID)
+	return foundWaiter, observedTxnIDs, nil
+}
+
+func cdcWaiterMatches(waiters []lockpb.WaitTxn, waiterTxnID []byte) (bool, []string) {
+	observedTxnIDs := make([]string, 0, len(waiters))
+	for _, waiter := range waiters {
+		observedTxnIDs = append(observedTxnIDs, fmt.Sprintf("%x", waiter.TxnID))
+		if bytes.Equal(waiter.TxnID, waiterTxnID) {
+			return true, observedTxnIDs
+		}
+	}
+	return false, observedTxnIDs
+}
+
+// waitForCDCWaiter performs each lock-service query in the caller goroutine.
+// The probe context bounds both the retry window and any in-flight remote
+// query, so transaction cleanup cannot overlap an observation goroutine.
+func waitForCDCWaiter(
+	ctx context.Context,
+	probe func(context.Context) (bool, []string, error),
+) ([]string, error) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastWaiterTxnIDs []string
+	var lastErr error
+	for {
+		found, waiterTxnIDs, err := probe(ctx)
+		lastWaiterTxnIDs = waiterTxnIDs
+		lastErr = err
+		if err == nil && found {
+			return waiterTxnIDs, nil
+		}
+		if ctx.Err() != nil {
+			if lastErr != nil {
+				return lastWaiterTxnIDs, lastErr
+			}
+			return lastWaiterTxnIDs, ctx.Err()
+		}
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return lastWaiterTxnIDs, fmt.Errorf("%w (last probe error: %v)", ctx.Err(), lastErr)
+			}
+			return lastWaiterTxnIDs, ctx.Err()
+		case <-ticker.C:
+		}
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR relates to:

Related to #28282

## What this PR does / why we need it:

### Root cause

The regression scanned `IterLocks` across CNs. That observer enumerates only local lock tables, so it can miss a waiter when the task-table lock is represented by a remote or bound table. The holder transaction itself has the authoritative wait graph.

### Change

The two-CN regression obtains each executor CN lock service, captures both holder and contender transaction IDs immediately when `ExecTxn` enters its callback, and keeps the holder readiness barrier after its lock-producing statements. It queries `GetWaitingList` from the holder lock service, whose routed query reaches the authoritative owner, and accepts the observation only when the wait graph contains that exact contender ID.

The lock probe now uses a dedicated 30-second context and synchronous retry loop. Thus the budget bounds an in-flight remote query as well as the retry window; cleanup cannot overlap an orphaned observation goroutine. On failure it reports the last probe error and observed waiter IDs. The generic transaction helper API remains unchanged; transaction metadata is captured only for this lock-waiter scenario.

### Issue-to-test proof

`TestIssue27666CDCWatermarkWriteSerializesWithDrop` directly proves #28282: in both drop-first and writer-first orderings, it holds the task-row lock, observes the exact competing transaction in the holder wait graph, then proves that neither the CDC task nor either watermark row survives. `TestCDCWaiterProbe` proves the oracle rejects an unrelated waiter and that cancellation joins an in-flight probe. `TestCDCRaceTxn` retains coverage of readiness, cancellation, cleanup, and transaction errors.

A BVT is not appropriate for this test-only failure: reproducing it requires pinned uncommitted internal transactions and inspecting the private lock-service wait graph. The embedded two-CN unit test is the boundary that can deterministically assert that state while also exercising the public SQL effects.

### Tests run

- Rebased onto `origin/main` at `a6ee717132`; the last base increment changes ordered-upsert DML/compiler paths, so the focused two-CN regression and full owning package were rerun.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=240s -run "^(TestIssue27666CDCWatermarkWriteSerializesWithDrop|TestCDCRaceTxn|TestCDCWaiterProbe)$" ./pkg/tests/issues` (PASS on `a6ee717132`, 14.088s)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=600s ./pkg/tests/issues` (PASS on `a6ee717132`, 68.325s)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=2 -timeout=300s -run "^(TestIssue27666CDCWatermarkWriteSerializesWithDrop|TestCDCRaceTxn|TestCDCWaiterProbe)$" ./pkg/tests/issues` (PASS, 59.666s, before the final base-only rebase; the test change itself is identical)
- A fresh GitHub CI run was triggered for `012d0b7ad4`; results are pending.

### Residual risk

This changes test observation only; no CDC or lock-service production path changes. Darwin/x86 UT and configured disabled variants are skipped by the workflow.