### PR TITLE
test: cover secondary indexes in publication subscriptions

### DIFF
--- a/pkg/frontend/compiler_context_test.go
+++ b/pkg/frontend/compiler_context_test.go
@@ -22,9 +22,12 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,6 +142,49 @@ func TestResolveViewDependencyAccount(t *testing.T) {
 			require.Equal(t, test.want, got)
 		})
 	}
+}
+
+func TestResolveIndexTableByRefUsesPublisherDatabase(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := defines.AttachAccountId(context.Background(), 7)
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	storage := mock_frontend.NewMockEngine(ctrl)
+	database := mock_frontend.NewMockDatabase(ctrl)
+	relation := mock_frontend.NewMockRelation(ctrl)
+
+	storage.EXPECT().Database(gomock.Any(), "publisher_db", txnOp).DoAndReturn(
+		func(gotCtx context.Context, _ string, _ client.TxnOperator) (engine.Database, error) {
+			accountID, err := defines.GetAccountId(gotCtx)
+			require.NoError(t, err)
+			require.Equal(t, uint32(42), accountID)
+			return database, nil
+		},
+	).Times(1)
+	database.EXPECT().Relation(gomock.Any(), "__mo_index_secondary_events", gomock.Nil()).
+		Return(relation, nil)
+	relation.EXPECT().GetTableID(gomock.Any()).Return(uint64(99))
+	relation.EXPECT().GetTableDef(gomock.Any()).Return(&pbplan.TableDef{Name: "__mo_index_secondary_events"})
+
+	ses, _ := newObservedProtocolSession()
+	ses.txnHandler = InitTxnHandler("", storage, ctx, txnOp)
+	tcc := &TxnCompilerContext{execCtx: &ExecCtx{reqCtx: ctx, ses: ses}}
+	ref := &plan2.ObjectRef{
+		SchemaName:       "publisher_db",
+		ObjName:          "events",
+		SubscriptionName: "subscriber_alias",
+		PubInfo:          &pbplan.PubInfo{TenantId: 42},
+	}
+
+	gotRef, gotDef, err := tcc.ResolveIndexTableByRef(ref, "__mo_index_secondary_events", nil)
+	require.NoError(t, err)
+	require.Equal(t, &plan2.ObjectRef{
+		SchemaName:       "publisher_db",
+		ObjName:          "__mo_index_secondary_events",
+		Obj:              99,
+		SubscriptionName: "subscriber_alias",
+		PubInfo:          ref.PubInfo,
+	}, gotRef)
+	require.Equal(t, "__mo_index_secondary_events", gotDef.Name)
 }
 
 func TestGetConfig(t *testing.T) {

--- a/test/distributed/cases/publication_subscription/pub_sub_secondary_index.result
+++ b/test/distributed/cases/publication_subscription/pub_sub_secondary_index.result
@@ -1,0 +1,131 @@
+drop publication if exists mo28279_pub_table;
+drop publication if exists mo28279_pub_sec;
+drop account if exists mo28279_sub_a;
+drop account if exists mo28279_sub_b;
+drop database if exists mo28279_pub_db;
+create account mo28279_sub_a admin_name = 'admin' identified by '111';
+create account mo28279_sub_b admin_name = 'admin' identified by '111';
+create database mo28279_pub_db;
+create table mo28279_pub_db.audit_events (
+id int primary key,
+event_type varchar(32),
+created_at bigint,
+index idx_event_type (event_type),
+index idx_created_at (created_at)
+);
+insert into mo28279_pub_db.audit_events
+select g.result,
+if(g.result in (42, 4242), 'login_success', concat('other_', g.result)),
+g.result
+from generate_series(1, 100000) g;
+create table mo28279_pub_db.private_events (id int primary key);
+insert into mo28279_pub_db.private_events values (99);
+select mo_ctl('dn', 'flush', 'mo28279_pub_db.audit_events');
+➤ mo_ctl(dn, flush, mo28279_pub_db.audit_events)[12,65535,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+create publication mo28279_pub_sec database mo28279_pub_db account mo28279_sub_a, mo28279_sub_b;
+create publication mo28279_pub_table database mo28279_pub_db table audit_events account mo28279_sub_a;
+drop database if exists mo28279_sub_a_db;
+create database mo28279_sub_a_db from sys publication mo28279_pub_sec;
+select count(*) as total_count from mo28279_sub_a_db.audit_events;
+➤ total_count[-5,64,0]  𝄀
+100000
+explain select count(*) as login_count from mo28279_sub_a_db.audit_events
+where event_type = 'login_success';
+-- @regex("Index Table Scan.*idx_event_type", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Index Table Scan on audit_events.idx_event_type  𝄀
+              Filter Cond: prefix_eq(__mo_index_idx_col), (serial_extract(__mo_index_idx_col, 0, VARCHAR)) = 'login_success')  𝄀
+              Block Filter Cond: prefix_eq(__mo_index_idx_col)
+select count(*) as login_count from mo28279_sub_a_db.audit_events
+where event_type = 'login_success';
+➤ login_count[-5,64,0]  𝄀
+2
+explain select count(*) as recent_count from mo28279_sub_a_db.audit_events
+where created_at >= 99999;
+-- @regex("Index Table Scan.*idx_created_at", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Index Table Scan on audit_events.idx_created_at  𝄀
+              Filter Cond: (__mo_index_idx_col >= '<opaque>')  𝄀
+              Block Filter Cond: (__mo_index_idx_col >= '<opaque>')
+select count(*) as recent_count from mo28279_sub_a_db.audit_events
+where created_at >= 99999;
+➤ recent_count[-5,64,0]  𝄀
+2
+select count(*) as login_count from mo28279_sub_a_db.audit_events
+ignore index (idx_event_type, idx_created_at)
+where event_type = 'login_success';
+➤ login_count[-5,64,0]  𝄀
+2
+select * from mo28279_sub_a_db.private_events;
+➤ id[4,32,0]  𝄀
+99
+prepare indexed_stmt from 'select count(*) from mo28279_sub_a_db.audit_events where event_type = \'login_success\'';
+execute indexed_stmt;
+➤ count(*)[-5,64,0]  𝄀
+2
+create database mo28279_sub_a_table_db from sys publication mo28279_pub_table;
+explain select count(*) as table_pub_login_count from mo28279_sub_a_table_db.audit_events
+where event_type = 'login_success';
+-- @regex("Index Table Scan.*idx_event_type", true)
+➤ TP QUERY PLAN[12,-1,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Index Table Scan on audit_events.idx_event_type  𝄀
+              Filter Cond: prefix_eq(__mo_index_idx_col), (serial_extract(__mo_index_idx_col, 0, VARCHAR)) = 'login_success')  𝄀
+              Block Filter Cond: prefix_eq(__mo_index_idx_col)
+select count(*) as table_pub_login_count from mo28279_sub_a_table_db.audit_events
+where event_type = 'login_success';
+➤ table_pub_login_count[-5,64,0]  𝄀
+2
+select * from mo28279_sub_a_table_db.private_events;
+SQL parser error: table "private_events" does not exist
+prepare table_indexed_stmt from 'select count(*) from mo28279_sub_a_table_db.audit_events where event_type = \'login_success\'';
+execute table_indexed_stmt;
+➤ count(*)[-5,64,0]  𝄀
+2
+drop database if exists mo28279_sub_b_db;
+create database mo28279_sub_b_db from sys publication mo28279_pub_sec;
+prepare second_indexed_stmt from 'select count(*) from mo28279_sub_b_db.audit_events where created_at >= 99999';
+execute second_indexed_stmt;
+➤ count(*)[-5,64,0]  𝄀
+2
+alter publication mo28279_pub_sec account mo28279_sub_b;
+execute indexed_stmt;
+internal error: the account mo28279_sub_a is not allowed to subscribe the publication mo28279_pub_sec
+select count(*) from mo28279_sub_a_db.audit_events where event_type = 'login_success';
+internal error: the account mo28279_sub_a is not allowed to subscribe the publication mo28279_pub_sec
+alter publication mo28279_pub_sec account mo28279_sub_a, mo28279_sub_b;
+execute indexed_stmt;
+➤ count(*)[-5,64,0]  𝄀
+2
+drop publication mo28279_pub_sec;
+execute second_indexed_stmt;
+internal error: there is no publication mo28279_pub_sec
+deallocate prepare second_indexed_stmt;
+drop database mo28279_sub_b_db;
+deallocate prepare indexed_stmt;
+drop database mo28279_sub_a_db;
+drop publication mo28279_pub_table;
+execute table_indexed_stmt;
+internal error: there is no publication mo28279_pub_table
+deallocate prepare table_indexed_stmt;
+drop database mo28279_sub_a_table_db;
+drop database if exists mo28279_pub_db;
+drop account mo28279_sub_a;
+drop account mo28279_sub_b;

--- a/test/distributed/cases/publication_subscription/pub_sub_secondary_index.sql
+++ b/test/distributed/cases/publication_subscription/pub_sub_secondary_index.sql
@@ -1,0 +1,99 @@
+drop publication if exists mo28279_pub_table;
+drop publication if exists mo28279_pub_sec;
+drop account if exists mo28279_sub_a;
+drop account if exists mo28279_sub_b;
+drop database if exists mo28279_pub_db;
+create account mo28279_sub_a admin_name = 'admin' identified by '111';
+create account mo28279_sub_b admin_name = 'admin' identified by '111';
+
+create database mo28279_pub_db;
+create table mo28279_pub_db.audit_events (
+    id int primary key,
+    event_type varchar(32),
+    created_at bigint,
+    index idx_event_type (event_type),
+    index idx_created_at (created_at)
+);
+insert into mo28279_pub_db.audit_events
+select g.result,
+       if(g.result in (42, 4242), 'login_success', concat('other_', g.result)),
+       g.result
+from generate_series(1, 100000) g;
+create table mo28279_pub_db.private_events (id int primary key);
+insert into mo28279_pub_db.private_events values (99);
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'mo28279_pub_db.audit_events');
+create publication mo28279_pub_sec database mo28279_pub_db account mo28279_sub_a, mo28279_sub_b;
+create publication mo28279_pub_table database mo28279_pub_db table audit_events account mo28279_sub_a;
+
+-- @session:id=1&user=mo28279_sub_a:admin&password=111
+drop database if exists mo28279_sub_a_db;
+create database mo28279_sub_a_db from sys publication mo28279_pub_sec;
+select count(*) as total_count from mo28279_sub_a_db.audit_events;
+-- The predicate is intentionally natural: the plan must choose the regular index.
+-- @regex("Index Table Scan.*idx_event_type", true)
+explain select count(*) as login_count from mo28279_sub_a_db.audit_events
+where event_type = 'login_success';
+select count(*) as login_count from mo28279_sub_a_db.audit_events
+where event_type = 'login_success';
+-- @regex("Index Table Scan.*idx_created_at", true)
+explain select count(*) as recent_count from mo28279_sub_a_db.audit_events
+where created_at >= 99999;
+select count(*) as recent_count from mo28279_sub_a_db.audit_events
+where created_at >= 99999;
+select count(*) as login_count from mo28279_sub_a_db.audit_events
+ignore index (idx_event_type, idx_created_at)
+where event_type = 'login_success';
+select * from mo28279_sub_a_db.private_events;
+prepare indexed_stmt from 'select count(*) from mo28279_sub_a_db.audit_events where event_type = \'login_success\'';
+execute indexed_stmt;
+create database mo28279_sub_a_table_db from sys publication mo28279_pub_table;
+-- @regex("Index Table Scan.*idx_event_type", true)
+explain select count(*) as table_pub_login_count from mo28279_sub_a_table_db.audit_events
+where event_type = 'login_success';
+select count(*) as table_pub_login_count from mo28279_sub_a_table_db.audit_events
+where event_type = 'login_success';
+select * from mo28279_sub_a_table_db.private_events;
+prepare table_indexed_stmt from 'select count(*) from mo28279_sub_a_table_db.audit_events where event_type = \'login_success\'';
+execute table_indexed_stmt;
+-- @session
+
+-- @session:id=2&user=mo28279_sub_b:admin&password=111
+drop database if exists mo28279_sub_b_db;
+create database mo28279_sub_b_db from sys publication mo28279_pub_sec;
+prepare second_indexed_stmt from 'select count(*) from mo28279_sub_b_db.audit_events where created_at >= 99999';
+execute second_indexed_stmt;
+-- @session
+
+-- Publisher-side membership changes must invalidate the same indexed subscription query.
+-- @session:id=3&user=sys:dump&password=111
+alter publication mo28279_pub_sec account mo28279_sub_b;
+-- @session:id=1&user=mo28279_sub_a:admin&password=111
+execute indexed_stmt;
+select count(*) from mo28279_sub_a_db.audit_events where event_type = 'login_success';
+-- @session:id=3&user=sys:dump&password=111
+alter publication mo28279_pub_sec account mo28279_sub_a, mo28279_sub_b;
+-- @session:id=1&user=mo28279_sub_a:admin&password=111
+execute indexed_stmt;
+-- @session:id=3&user=sys:dump&password=111
+drop publication mo28279_pub_sec;
+-- @session:id=2&user=mo28279_sub_b:admin&password=111
+execute second_indexed_stmt;
+deallocate prepare second_indexed_stmt;
+drop database mo28279_sub_b_db;
+-- @session:id=1&user=mo28279_sub_a:admin&password=111
+deallocate prepare indexed_stmt;
+drop database mo28279_sub_a_db;
+-- @session
+
+-- @session:id=3&user=sys:dump&password=111
+drop publication mo28279_pub_table;
+-- @session:id=1&user=mo28279_sub_a:admin&password=111
+execute table_indexed_stmt;
+deallocate prepare table_indexed_stmt;
+drop database mo28279_sub_a_table_db;
+-- @session
+
+drop database if exists mo28279_pub_db;
+drop account mo28279_sub_a;
+drop account mo28279_sub_b;


### PR DESCRIPTION
## What type of PR is this?
- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28279

## What this PR does / why we need it:

### Root cause

On v4.1.4 (`a185c23b375956afe098320baf8df39000a43936`) and v4.2.1 (`d2393868a7aaa6343518d80849fe4696aa3577e9`), `TxnCompilerContext.ResolveIndexTableByRef` rebuilt subscription metadata with the publisher tenant only. `getRelation` uses `SubscriptionMeta.DbName`; the empty value replaced the publisher database name, so a planner-selected hidden regular-index table was looked up in the wrong database and the query failed with `no such table ...__mo_index_secondary_<uuid>`.

The current `main` branch already contains the production correction, `DbName: ref.SchemaName`, from merged PR #26702. This PR adds executable regression coverage for the ordinary secondary-index path described by #28279 and intentionally does not duplicate or alter that production logic.

### Changes

- Add `TestResolveIndexTableByRefUsesPublisherDatabase`, which asserts the publisher database name, publisher tenant context, hidden-index relation, and returned `ObjectRef` at the frontend resolver boundary.
- Add a publication/subscription BVT with 100,000 rows and two regular secondary indexes. It covers natural optimizer selection of both indexes, base-table and `IGNORE INDEX` controls, separate subscription aliases/accounts, database-level and table-level publications, unpublished-object denial, membership revoke/restore, publication removal, prepared statements, and cleanup.
- Keep the change test-only: no fallback path, duplicate resolver logic, or unrelated `SHOW INDEX` behavior is included.

### Issue-to-test proof

| #28279 behavior | Regression proof |
| --- | --- |
| The resolver must retain the publisher database while resolving a hidden secondary-index table. | `TestResolveIndexTableByRefUsesPublisherDatabase` requires `Database(..., "publisher_db", ...)`; temporarily removing the existing `DbName: ref.SchemaName` line made this test fail because the database argument was empty. |
| Database publication queries must work when the optimizer selects either regular secondary index. | `pub_sub_secondary_index.sql` asserts `EXPLAIN` selects `idx_event_type` and `idx_created_at`, and both queries return the expected count of 2. |
| Indexed and base-table paths must agree, while bypassing indexes remains a control. | The BVT checks `COUNT(*) = 100000`, both natural indexed predicates, and the equivalent `IGNORE INDEX` query. |
| Subscription context must remain scoped to the authorized object and survive normal aliases. | The BVT uses two subscriber accounts, separate database aliases, a table-level publication, and verifies that the unpublished `private_events` table is denied by the table-level subscription. |
| Publication membership and removal must invalidate indexed prepared queries cleanly. | The BVT verifies the expected authorization error after revocation, success after membership restore, and the expected missing-publication error after publication removal. |

### Investigation and baseline

- The exact missing field was confirmed in both reported release tags; the corresponding line is present on current `main` through #26702.
- A clean v4.1.2 instance also reproduced the hidden-index lookup failure with a natural indexed predicate.
- The generated BVT result was manually inspected against the SQL semantics before acceptance: 100,000 total rows, two matching rows for each indexed predicate, successful database-publication access, table-publication denial for `private_events`, and the expected revoke/removal errors.

### Tests run

- `NATIVE_BUILD_JOBS=4 make cgo`
- `NATIVE_BUILD_JOBS=4 make build`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -run '^TestResolveIndexTableByRefUsesPublisherDatabase$' ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -p=1 -count=1 -timeout=20m ./pkg/frontend`
- Generated and ran `pub_sub_secondary_index` with `mo-tester` against an isolated service built from current `main`; the final run passed `54/54` with a 100% success rate.

### Residual risks

- The local BVT used one direct CN because the shared local Docker service occupied port 6001; the SQL case is written for the repository's distributed runner and does not depend on a single-CN cache.
- This PR targets `main` and contains the regression guard. Release branches that do not yet contain `DbName: ref.SchemaName` still require the scoped production backport and their normal release validation.
