### PR TITLE
[4.2] fix(ddl): make database creation fail closed

### DIFF
--- a/pkg/frontend/status_stmt.go
+++ b/pkg/frontend/status_stmt.go
@@ -15,16 +15,34 @@
 package frontend
 
 import (
+	"context"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/util"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+func databaseWasCreated(runResult *util.RunResult) bool {
+	return runResult != nil && runResult.AffectRows != 0
+}
+
+func grantDatabaseOwnershipAfterCreate(
+	ctx context.Context,
+	ses *Session,
+	stmt tree.Statement,
+	runResult *util.RunResult,
+) error {
+	if !databaseWasCreated(runResult) {
+		return nil
+	}
+	return doGrantPrivilegeImplicitly(ctx, ses, stmt)
+}
 
 func isPerformStatement(stmt tree.Statement) bool {
 	selectStmt, ok := stmt.(*tree.Select)
@@ -207,7 +225,7 @@ func executeStatusStmt(ses *Session, execCtx *ExecCtx) (err error) {
 		switch execCtx.stmt.(type) {
 		case *tree.CreateDatabase:
 			// must execute after run to get database id
-			err = doGrantPrivilegeImplicitly(execCtx.reqCtx, ses, st)
+			err = grantDatabaseOwnershipAfterCreate(execCtx.reqCtx, ses, st, execCtx.runResult)
 			if err != nil {
 				return
 			}
@@ -331,7 +349,9 @@ func (resper *MysqlResp) respStatus(ses *Session,
 				ses.SetLastInsertID(execCtx.proc.GetLastInsertID())
 			}
 		case *tree.CreateDatabase:
-			_ = insertRecordToMoMysqlCompatibilityMode(execCtx.reqCtx, ses, execCtx.stmt)
+			if databaseWasCreated(execCtx.runResult) {
+				_ = insertRecordToMoMysqlCompatibilityMode(execCtx.reqCtx, ses, execCtx.stmt)
+			}
 		case *tree.DropDatabase:
 			_ = deleteRecordToMoMysqlCompatbilityMode(execCtx.reqCtx, ses, execCtx.stmt)
 			err = doDropFunctionWithDB(execCtx.reqCtx, ses, execCtx.stmt, func(path string) error {

--- a/pkg/frontend/status_stmt_create_database_test.go
+++ b/pkg/frontend/status_stmt_create_database_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/util"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+func TestDatabaseWasCreated(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		result    *util.RunResult
+		wasCreate bool
+	}{
+		{name: "physical creation", result: &util.RunResult{AffectRows: 1}, wasCreate: true},
+		{name: "if not exists no-op", result: &util.RunResult{}},
+		{name: "missing result"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.wasCreate, databaseWasCreated(tc.result))
+		})
+	}
+}
+
+func TestGrantDatabaseOwnershipSkipsNoopCreate(t *testing.T) {
+	stmt := &tree.CreateDatabase{Name: tree.Identifier("ownership_db")}
+	require.NoError(t, grantDatabaseOwnershipAfterCreate(
+		context.Background(), nil, stmt, &util.RunResult{},
+	))
+	require.NoError(t, grantDatabaseOwnershipAfterCreate(
+		context.Background(), nil, stmt, nil,
+	))
+}
+
+func TestRespStatusCreateDatabaseWritesCompatibilityOnlyAfterCreation(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		result     *util.RunResult
+		wantInsert bool
+	}{
+		{name: "physical creation", result: &util.RunResult{AffectRows: 1}, wantInsert: true},
+		{name: "if not exists no-op", result: &util.RunResult{}},
+		{name: "missing result"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ses := &Session{
+				seqLastValue:  new(string),
+				feSessionImpl: feSessionImpl{txnHandler: &TxnHandler{}},
+			}
+			ses.SetTenantInfo(&TenantInfo{
+				Tenant:        sysAccountName,
+				User:          rootName,
+				DefaultRole:   moAdminRoleName,
+				TenantID:      sysAccountID,
+				UserID:        rootID,
+				DefaultRoleID: moAdminRoleID,
+			})
+
+			bh := &backgroundExecTest{}
+			bh.init()
+			bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
+			defer bhStub.Reset()
+
+			writer := &countingMysqlWriter{testMysqlWriter: &testMysqlWriter{}}
+			proc := &process.Process{Base: &process.BaseProcess{}}
+			proc.InitSeq()
+			execCtx := &ExecCtx{
+				reqCtx:    context.Background(),
+				stmt:      &tree.CreateDatabase{Name: tree.Identifier("metadata_db")},
+				proc:      proc,
+				runResult: tc.result,
+			}
+
+			require.NoError(t, NewMysqlResp(writer).respStatus(ses, execCtx))
+			require.Len(t, writer.responses, 1)
+			if tc.wantInsert {
+				require.Len(t, bh.executedSQLs, 3)
+				require.Equal(t, "begin", bh.executedSQLs[0])
+				require.True(t, strings.HasPrefix(
+					bh.executedSQLs[1],
+					"insert into mo_catalog.mo_mysql_compatibility_mode(",
+				))
+				require.Equal(t, "commit;", bh.executedSQLs[2])
+			} else {
+				require.Empty(t, bh.executedSQLs)
+			}
+		})
+	}
+}

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -441,12 +441,7 @@ func (c *Compile) run(s *Scope) error {
 		c.addAffectedRows(s.affectedRows())
 		return err
 	case CreateDatabase:
-		err := s.CreateDatabase(c)
-		if err != nil {
-			return err
-		}
-		c.setAffectedRows(1)
-		return nil
+		return s.CreateDatabase(c)
 	case DropDatabase:
 		err := s.DropDatabase(c)
 		if err != nil {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -141,6 +141,7 @@ func NewCompile(
 	c.cnLabel = cnLabel
 	c.startAt = startAt
 	c.disableRetry = false
+	c.retryTimes = 0
 	c.ncpu = system.GoMaxProcs()
 	c.lockMeta = NewLockMeta()
 	// TODO: The action of updating the WriteOffset logic should be executed in the `func (c *Compile) Run(_ uint64)` method.
@@ -220,6 +221,7 @@ func (c *Compile) Reset(proc *process.Process, startAt time.Time, fill func(*bat
 	c.sql = sql
 	c.affectRows.Store(0)
 	c.executionGeneration = 0
+	c.retryTimes = 0
 	c.anal.Reset(c.isPrepare, c.IsTpQuery())
 
 	if c.lockMeta != nil {
@@ -303,6 +305,7 @@ func (c *Compile) clear() {
 	c.fill = nil
 	c.resultSink = nil
 	c.executionGeneration = 0
+	c.retryTimes = 0
 	c.affectRows.Store(0)
 	c.addr = ""
 	c.db = ""

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -84,14 +84,21 @@ func (s *Scope) CreateDatabase(c *Compile) error {
 
 	createDatabase := s.Plan.GetDdl().GetCreateDatabase()
 	dbName := createDatabase.GetDatabase()
+
+	// The existence decision and the create must be serialized by the same
+	// catalog-key lock. In particular, every transparent RC retry must cross
+	// this boundary again instead of turning a transient catalog view into an
+	// IF NOT EXISTS no-op.
+	if err := lockMoDatabase(c, dbName, lock.LockMode_Exclusive); err != nil {
+		return err
+	}
+
 	if _, err := c.e.Database(ctx, dbName, c.proc.GetTxnOperator()); err == nil {
 		if createDatabase.GetIfNotExists() {
 			return nil
 		}
 		return moerr.NewDBAlreadyExists(ctx, dbName)
-	}
-
-	if err := lockMoDatabase(c, dbName, lock.LockMode_Exclusive); err != nil {
+	} else if !moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
 		return err
 	}
 
@@ -106,7 +113,11 @@ func (s *Scope) CreateDatabase(c *Compile) error {
 	}
 
 	ctx = context.WithValue(ctx, defines.DatTypKey{}, datType)
-	return c.e.Create(ctx, dbName, c.proc.GetTxnOperator())
+	if err := c.e.Create(ctx, dbName, c.proc.GetTxnOperator()); err != nil {
+		return err
+	}
+	c.setAffectedRows(1)
+	return nil
 }
 
 func (s *Scope) DropDatabase(c *Compile) error {

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -85,10 +85,20 @@ func (s *Scope) CreateDatabase(c *Compile) error {
 	createDatabase := s.Plan.GetDdl().GetCreateDatabase()
 	dbName := createDatabase.GetDatabase()
 
-	// The existence decision and the create must be serialized by the same
-	// catalog-key lock. In particular, every transparent RC retry must cross
-	// this boundary again instead of turning a transient catalog view into an
-	// IF NOT EXISTS no-op.
+	// A positive catalog lookup is already authoritative for this transaction's
+	// snapshot and must not wait behind unrelated DDL that holds a shared
+	// database lock. Only the absence-to-create transition needs serialization.
+	if _, err := c.e.Database(ctx, dbName, c.proc.GetTxnOperator()); err == nil {
+		if createDatabase.GetIfNotExists() {
+			return nil
+		}
+		return moerr.NewDBAlreadyExists(ctx, dbName)
+	} else if !moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
+		return err
+	}
+
+	// Serialize competing creators, then recheck under the lock. Another
+	// transaction may have created the database after the optimistic lookup.
 	if err := lockMoDatabase(c, dbName, lock.LockMode_Exclusive); err != nil {
 		return err
 	}

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -137,6 +137,118 @@ func TestCreateDatabaseSerializesExistenceAndReportsPhysicalCreation(t *testing.
 	}
 }
 
+func TestCompileRunRetriesCreateDatabaseAtCatalogLockBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		ifNotExists   bool
+		existsOnRetry bool
+		wantCreate    bool
+		wantAffected  uint64
+	}{
+		{
+			name:         "retry then physical create",
+			wantCreate:   true,
+			wantAffected: 1,
+		},
+		{
+			name:          "retry observes concurrent create as valid no-op",
+			ifNotExists:   true,
+			existsOnRetry: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			eng := mock_frontend.NewMockEngine(ctrl)
+			lockCalls := 0
+			lockStub := gostub.Stub(&lockMoDatabase, func(_ *Compile, name string, mode lock.LockMode) error {
+				require.Equal(t, "retry_db", name)
+				require.Equal(t, lock.LockMode_Exclusive, mode)
+				lockCalls++
+				if lockCalls == 1 {
+					return moerr.NewTxnNeedRetryNoCtx()
+				}
+				return nil
+			})
+			defer lockStub.Reset()
+
+			var db engine.Database
+			var lookupErr error = moerr.GetOkExpectedEOB()
+			if tc.existsOnRetry {
+				db = mock_frontend.NewMockDatabase(ctrl)
+				lookupErr = nil
+			}
+			eng.EXPECT().Database(gomock.Any(), "retry_db", gomock.Any()).DoAndReturn(
+				func(context.Context, string, client.TxnOperator) (engine.Database, error) {
+					require.Equal(t, 2, lockCalls, "catalog lookup must occur in the retried, locked attempt")
+					return db, lookupErr
+				},
+			).Times(1)
+			if tc.wantCreate {
+				eng.EXPECT().Create(gomock.Any(), "retry_db", gomock.Any()).Return(nil).Times(1)
+			}
+
+			ctx := defines.AttachAccountId(context.Background(), sysAccountId)
+			proc := testutil.NewProcess(t)
+			proc.GetSessionInfo().Buf = buffer.New()
+			proc.Ctx = ctx
+			proc.ReplaceTopCtx(ctx)
+			txnClient, txnOp := newTestTxnClientAndOpWithIsolation(ctrl, txn.TxnIsolation_RC)
+			proc.Base.TxnClient = txnClient
+			proc.Base.TxnOperator = txnOp
+			pn := &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+				DdlType: plan2.DataDefinition_CREATE_DATABASE,
+				Definition: &plan2.DataDefinition_CreateDatabase{CreateDatabase: &plan2.CreateDatabase{
+					Database:    "retry_db",
+					IfNotExists: tc.ifNotExists,
+				}},
+			}}}
+			c := NewCompile("test", "", "create database retry_db", "", "", eng, proc, nil, false, nil, time.Now())
+			require.NoError(t, c.Compile(ctx, pn, nil))
+
+			result, err := c.Run(0)
+			require.NoError(t, err)
+			require.Equal(t, 2, lockCalls)
+			require.Equal(t, 1, c.retryTimes)
+			require.Equal(t, tc.wantAffected, result.AffectRows)
+			c.Release()
+			proc.GetSessionInfo().Buf.Free()
+		})
+	}
+
+	t.Run("non-retry lock failure has no catalog side effects", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		eng := mock_frontend.NewMockEngine(ctrl)
+		lockErr := errors.New("catalog lock unavailable")
+		lockStub := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error {
+			return lockErr
+		})
+		defer lockStub.Reset()
+
+		ctx := defines.AttachAccountId(context.Background(), sysAccountId)
+		proc := testutil.NewProcess(t)
+		proc.GetSessionInfo().Buf = buffer.New()
+		proc.Ctx = ctx
+		proc.ReplaceTopCtx(ctx)
+		txnClient, txnOp := newTestTxnClientAndOpWithIsolation(ctrl, txn.TxnIsolation_RC)
+		proc.Base.TxnClient = txnClient
+		proc.Base.TxnOperator = txnOp
+		pn := &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			DdlType: plan2.DataDefinition_CREATE_DATABASE,
+			Definition: &plan2.DataDefinition_CreateDatabase{CreateDatabase: &plan2.CreateDatabase{
+				Database: "retry_db",
+			}},
+		}}}
+		c := NewCompile("test", "", "create database retry_db", "", "", eng, proc, nil, false, nil, time.Now())
+		require.NoError(t, c.Compile(ctx, pn, nil))
+
+		_, err := c.Run(0)
+		require.ErrorIs(t, err, lockErr)
+		require.Zero(t, c.retryTimes)
+		c.Release()
+		proc.GetSessionInfo().Buf.Free()
+	})
+}
+
 type mongoDBMappingTestExecutor struct {
 	results map[string]executor.Result
 	sqls    []string

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -16,8 +16,10 @@ package compile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -54,6 +56,86 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+func TestCreateDatabaseSerializesExistenceAndReportsPhysicalCreation(t *testing.T) {
+	lookupErr := errors.New("catalog lookup failed")
+	lockErr := errors.New("catalog lock failed")
+	createErr := errors.New("catalog create failed")
+
+	for _, tc := range []struct {
+		name         string
+		existing     bool
+		ifNotExists  bool
+		lookupErr    error
+		lockErr      error
+		createErr    error
+		wantCreate   bool
+		wantErr      error
+		wantErrCode  uint16
+		wantAffected uint64
+	}{
+		{name: "physical creation", lookupErr: moerr.GetOkExpectedEOB(), wantCreate: true, wantAffected: 1},
+		{name: "if not exists no-op", existing: true, ifNotExists: true},
+		{name: "strict duplicate", existing: true, wantErrCode: moerr.ErrDBAlreadyExists},
+		{name: "lookup failure is not absence", lookupErr: lookupErr, wantErr: lookupErr},
+		{name: "lock failure stops before lookup", lockErr: lockErr, wantErr: lockErr},
+		{name: "create failure has no affected row", lookupErr: moerr.GetOkExpectedEOB(), createErr: createErr, wantCreate: true, wantErr: createErr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			eng := mock_frontend.NewMockEngine(ctrl)
+			lockCalled := false
+			lockStub := gostub.Stub(&lockMoDatabase, func(_ *Compile, name string, mode lock.LockMode) error {
+				require.Equal(t, "db1", name)
+				require.Equal(t, lock.LockMode_Exclusive, mode)
+				lockCalled = true
+				return tc.lockErr
+			})
+			defer lockStub.Reset()
+
+			if tc.lockErr == nil {
+				var db engine.Database
+				if tc.existing {
+					db = mock_frontend.NewMockDatabase(ctrl)
+				}
+				eng.EXPECT().Database(gomock.Any(), "db1", gomock.Any()).DoAndReturn(
+					func(context.Context, string, client.TxnOperator) (engine.Database, error) {
+						require.True(t, lockCalled, "existence must be checked under the catalog lock")
+						return db, tc.lookupErr
+					},
+				)
+			}
+			if tc.wantCreate {
+				eng.EXPECT().Create(gomock.Any(), "db1", gomock.Any()).Return(tc.createErr)
+			}
+
+			proc := testutil.NewProcess(t)
+			ctx := defines.AttachAccountId(context.Background(), sysAccountId)
+			proc.Ctx = ctx
+			proc.ReplaceTopCtx(ctx)
+			c := &Compile{e: eng, proc: proc, affectRows: new(atomic.Uint64)}
+			s := &Scope{
+				Magic: CreateDatabase,
+				Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+					Definition: &plan2.DataDefinition_CreateDatabase{CreateDatabase: &plan2.CreateDatabase{
+						Database:    "db1",
+						IfNotExists: tc.ifNotExists,
+					}},
+				}}},
+			}
+
+			err := c.run(s)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else if tc.wantErrCode != 0 {
+				require.True(t, moerr.IsMoErrCode(err, tc.wantErrCode), "unexpected error: %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantAffected, c.getAffectedRows())
+		})
+	}
+}
 
 type mongoDBMappingTestExecutor struct {
 	results map[string]executor.Result

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -57,56 +57,135 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
-func TestCreateDatabaseSerializesExistenceAndReportsPhysicalCreation(t *testing.T) {
-	lookupErr := errors.New("catalog lookup failed")
+func TestCreateDatabaseChecksExistingBeforeSerializingAbsence(t *testing.T) {
+	lookupFailure := errors.New("catalog lookup failed")
 	lockErr := errors.New("catalog lock failed")
 	createErr := errors.New("catalog create failed")
 
+	type lookupResult struct {
+		existing bool
+		err      error
+	}
 	for _, tc := range []struct {
 		name         string
-		existing     bool
 		ifNotExists  bool
-		lookupErr    error
+		lookups      []lookupResult
 		lockErr      error
 		createErr    error
 		wantCreate   bool
 		wantErr      error
 		wantErrCode  uint16
 		wantAffected uint64
+		wantEvents   []string
 	}{
-		{name: "physical creation", lookupErr: moerr.GetOkExpectedEOB(), wantCreate: true, wantAffected: 1},
-		{name: "if not exists no-op", existing: true, ifNotExists: true},
-		{name: "strict duplicate", existing: true, wantErrCode: moerr.ErrDBAlreadyExists},
-		{name: "lookup failure is not absence", lookupErr: lookupErr, wantErr: lookupErr},
-		{name: "lock failure stops before lookup", lockErr: lockErr, wantErr: lockErr},
-		{name: "create failure has no affected row", lookupErr: moerr.GetOkExpectedEOB(), createErr: createErr, wantCreate: true, wantErr: createErr},
+		{
+			name: "physical creation",
+			lookups: []lookupResult{
+				{err: moerr.GetOkExpectedEOB()},
+				{err: moerr.GetOkExpectedEOB()},
+			},
+			wantCreate:   true,
+			wantAffected: 1,
+			wantEvents:   []string{"lookup", "lock", "lookup", "create"},
+		},
+		{
+			name:        "if not exists fast no-op",
+			ifNotExists: true,
+			lookups:     []lookupResult{{existing: true}},
+			wantEvents:  []string{"lookup"},
+		},
+		{
+			name:        "strict duplicate fast failure",
+			lookups:     []lookupResult{{existing: true}},
+			wantErrCode: moerr.ErrDBAlreadyExists,
+			wantEvents:  []string{"lookup"},
+		},
+		{
+			name:       "initial lookup failure is not absence",
+			lookups:    []lookupResult{{err: lookupFailure}},
+			wantErr:    lookupFailure,
+			wantEvents: []string{"lookup"},
+		},
+		{
+			name:       "lock failure stops before locked recheck",
+			lookups:    []lookupResult{{err: moerr.GetOkExpectedEOB()}},
+			lockErr:    lockErr,
+			wantErr:    lockErr,
+			wantEvents: []string{"lookup", "lock"},
+		},
+		{
+			name: "locked recheck failure is not absence",
+			lookups: []lookupResult{
+				{err: moerr.GetOkExpectedEOB()},
+				{err: lookupFailure},
+			},
+			wantErr:    lookupFailure,
+			wantEvents: []string{"lookup", "lock", "lookup"},
+		},
+		{
+			name:        "concurrent create becomes if not exists no-op",
+			ifNotExists: true,
+			lookups: []lookupResult{
+				{err: moerr.GetOkExpectedEOB()},
+				{existing: true},
+			},
+			wantEvents: []string{"lookup", "lock", "lookup"},
+		},
+		{
+			name: "concurrent create becomes strict duplicate",
+			lookups: []lookupResult{
+				{err: moerr.GetOkExpectedEOB()},
+				{existing: true},
+			},
+			wantErrCode: moerr.ErrDBAlreadyExists,
+			wantEvents:  []string{"lookup", "lock", "lookup"},
+		},
+		{
+			name: "create failure has no affected row",
+			lookups: []lookupResult{
+				{err: moerr.GetOkExpectedEOB()},
+				{err: moerr.GetOkExpectedEOB()},
+			},
+			createErr:  createErr,
+			wantCreate: true,
+			wantErr:    createErr,
+			wantEvents: []string{"lookup", "lock", "lookup", "create"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			eng := mock_frontend.NewMockEngine(ctrl)
-			lockCalled := false
+			events := make([]string, 0, 4)
 			lockStub := gostub.Stub(&lockMoDatabase, func(_ *Compile, name string, mode lock.LockMode) error {
 				require.Equal(t, "db1", name)
 				require.Equal(t, lock.LockMode_Exclusive, mode)
-				lockCalled = true
+				events = append(events, "lock")
 				return tc.lockErr
 			})
 			defer lockStub.Reset()
 
-			if tc.lockErr == nil {
-				var db engine.Database
-				if tc.existing {
-					db = mock_frontend.NewMockDatabase(ctrl)
-				}
+			if len(tc.lookups) != 0 {
+				db := mock_frontend.NewMockDatabase(ctrl)
+				lookup := 0
 				eng.EXPECT().Database(gomock.Any(), "db1", gomock.Any()).DoAndReturn(
 					func(context.Context, string, client.TxnOperator) (engine.Database, error) {
-						require.True(t, lockCalled, "existence must be checked under the catalog lock")
-						return db, tc.lookupErr
+						events = append(events, "lookup")
+						result := tc.lookups[lookup]
+						lookup++
+						if result.existing {
+							return db, result.err
+						}
+						return nil, result.err
 					},
-				)
+				).Times(len(tc.lookups))
 			}
 			if tc.wantCreate {
-				eng.EXPECT().Create(gomock.Any(), "db1", gomock.Any()).Return(tc.createErr)
+				eng.EXPECT().Create(gomock.Any(), "db1", gomock.Any()).DoAndReturn(
+					func(context.Context, string, client.TxnOperator) error {
+						events = append(events, "create")
+						return tc.createErr
+					},
+				)
 			}
 
 			proc := testutil.NewProcess(t)
@@ -133,6 +212,7 @@ func TestCreateDatabaseSerializesExistenceAndReportsPhysicalCreation(t *testing.
 				require.NoError(t, err)
 			}
 			require.Equal(t, tc.wantAffected, c.getAffectedRows())
+			require.Equal(t, tc.wantEvents, events)
 		})
 	}
 }
@@ -144,25 +224,34 @@ func TestCompileRunRetriesCreateDatabaseAtCatalogLockBoundary(t *testing.T) {
 		existsOnRetry bool
 		wantCreate    bool
 		wantAffected  uint64
+		wantLockCalls int
+		wantEvents    []string
 	}{
 		{
-			name:         "retry then physical create",
-			wantCreate:   true,
-			wantAffected: 1,
+			name:          "retry then physical create",
+			wantCreate:    true,
+			wantAffected:  1,
+			wantLockCalls: 2,
+			wantEvents:    []string{"lookup", "lock", "lookup", "lock", "lookup", "create"},
 		},
 		{
 			name:          "retry observes concurrent create as valid no-op",
 			ifNotExists:   true,
 			existsOnRetry: true,
+			wantLockCalls: 1,
+			wantEvents:    []string{"lookup", "lock", "lookup"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			eng := mock_frontend.NewMockEngine(ctrl)
 			lockCalls := 0
+			lookupCalls := 0
+			events := make([]string, 0, 6)
 			lockStub := gostub.Stub(&lockMoDatabase, func(_ *Compile, name string, mode lock.LockMode) error {
 				require.Equal(t, "retry_db", name)
 				require.Equal(t, lock.LockMode_Exclusive, mode)
+				events = append(events, "lock")
 				lockCalls++
 				if lockCalls == 1 {
 					return moerr.NewTxnNeedRetryNoCtx()
@@ -171,20 +260,28 @@ func TestCompileRunRetriesCreateDatabaseAtCatalogLockBoundary(t *testing.T) {
 			})
 			defer lockStub.Reset()
 
-			var db engine.Database
-			var lookupErr error = moerr.GetOkExpectedEOB()
+			db := mock_frontend.NewMockDatabase(ctrl)
+			wantLookupCalls := 3
 			if tc.existsOnRetry {
-				db = mock_frontend.NewMockDatabase(ctrl)
-				lookupErr = nil
+				wantLookupCalls = 2
 			}
 			eng.EXPECT().Database(gomock.Any(), "retry_db", gomock.Any()).DoAndReturn(
 				func(context.Context, string, client.TxnOperator) (engine.Database, error) {
-					require.Equal(t, 2, lockCalls, "catalog lookup must occur in the retried, locked attempt")
-					return db, lookupErr
+					events = append(events, "lookup")
+					lookupCalls++
+					if tc.existsOnRetry && lookupCalls == 2 {
+						return db, nil
+					}
+					return nil, moerr.GetOkExpectedEOB()
 				},
-			).Times(1)
+			).Times(wantLookupCalls)
 			if tc.wantCreate {
-				eng.EXPECT().Create(gomock.Any(), "retry_db", gomock.Any()).Return(nil).Times(1)
+				eng.EXPECT().Create(gomock.Any(), "retry_db", gomock.Any()).DoAndReturn(
+					func(context.Context, string, client.TxnOperator) error {
+						events = append(events, "create")
+						return nil
+					},
+				).Times(1)
 			}
 
 			ctx := defines.AttachAccountId(context.Background(), sysAccountId)
@@ -207,9 +304,10 @@ func TestCompileRunRetriesCreateDatabaseAtCatalogLockBoundary(t *testing.T) {
 
 			result, err := c.Run(0)
 			require.NoError(t, err)
-			require.Equal(t, 2, lockCalls)
+			require.Equal(t, tc.wantLockCalls, lockCalls)
 			require.Equal(t, 1, c.retryTimes)
 			require.Equal(t, tc.wantAffected, result.AffectRows)
+			require.Equal(t, tc.wantEvents, events)
 			c.Release()
 			proc.GetSessionInfo().Buf.Free()
 		})
@@ -219,7 +317,15 @@ func TestCompileRunRetriesCreateDatabaseAtCatalogLockBoundary(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		eng := mock_frontend.NewMockEngine(ctrl)
 		lockErr := errors.New("catalog lock unavailable")
+		lookupCalled := false
+		eng.EXPECT().Database(gomock.Any(), "retry_db", gomock.Any()).DoAndReturn(
+			func(context.Context, string, client.TxnOperator) (engine.Database, error) {
+				lookupCalled = true
+				return nil, moerr.GetOkExpectedEOB()
+			},
+		).Times(1)
 		lockStub := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error {
+			require.True(t, lookupCalled)
 			return lockErr
 		})
 		defer lockStub.Reset()

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -98,9 +98,25 @@ type GCReport struct {
 	DStaleCpk  int
 }
 
+// deleteCatalogVersions deletes a newest-first group from oldest to newest.
+// When the newest collected version is a tombstone, keeping it until all
+// superseded live versions are gone prevents concurrent readers from briefly
+// observing a dropped database or table as live again.
+func deleteCatalogVersions[T any](items []T, deleteItem func(T)) {
+	for i := len(items) - 1; i >= 0; i-- {
+		deleteItem(items[i])
+	}
+}
+
 func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 	cc.gcMu.Lock()
 	defer cc.gcMu.Unlock()
+
+	// Stop serving snapshots whose retained history is about to be removed
+	// before the first destructive operation. Readers at an older snapshot
+	// must fall back to storage rather than interpreting a partially retired
+	// cache as an authoritative miss.
+	cc.UpdateStart(types.TimestampToTS(ts))
 
 	/*
 							GC
@@ -123,15 +139,20 @@ func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 
 	r := GCReport{}
 	{ // table cache gc
+		var prevAccountId uint32
 		var prevName string
 		var prevDbId uint64
 		deletedCpkey := make([]*TableItem, 0, 16)
 		deletedItems := make([]*TableItem, 0, 16)
+		seenGroup := false
 		seenLargest := false
 		cc.tables.data.Scan(func(item *TableItem) bool {
-			if item.DatabaseId != prevDbId {
+			if !seenGroup || item.AccountId != prevAccountId || item.DatabaseId != prevDbId {
+				prevAccountId = item.AccountId
 				prevDbId = item.DatabaseId
 				prevName = ""
+				seenGroup = true
+				seenLargest = false
 			}
 
 			if item.Name != prevName {
@@ -157,22 +178,26 @@ func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 		})
 		r.TStaleItem = len(deletedItems)
 		r.TStaleCpk = len(deletedCpkey)
-		for _, item := range deletedItems {
+		deleteCatalogVersions(deletedItems, func(item *TableItem) {
 			cc.tables.data.Delete(item)
-		}
+		})
 		for _, item := range deletedCpkey {
 			cc.tables.cpkeyIndex.Delete(item)
 		}
 
 	}
 	{ // database cache gc
+		var prevAccountId uint32
 		var prevName string
 		deletedCpkey := make([]*DatabaseItem, 0, 16)
 		deletedItems := make([]*DatabaseItem, 0, 16)
+		seenGroup := false
 		seenLargest := false
 		cc.databases.data.Scan(func(item *DatabaseItem) bool {
-			if item.Name != prevName {
+			if !seenGroup || item.AccountId != prevAccountId || item.Name != prevName {
+				prevAccountId = item.AccountId
 				prevName = item.Name
+				seenGroup = true
 				seenLargest = false
 			}
 			if item.Ts.Less(ts) {
@@ -194,14 +219,13 @@ func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 
 		r.DStaleItem = len(deletedItems)
 		r.DStaleCpk = len(deletedCpkey)
-		for _, item := range deletedItems {
+		deleteCatalogVersions(deletedItems, func(item *DatabaseItem) {
 			cc.databases.data.Delete(item)
-		}
+		})
 		for _, item := range deletedCpkey {
 			cc.databases.cpkeyIndex.Delete(item)
 		}
 	}
-	cc.UpdateStart(types.TimestampToTS(ts))
 	return r
 }
 

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -98,6 +98,13 @@ type GCReport struct {
 	DStaleCpk  int
 }
 
+type catalogGCDeleteKind uint8
+
+const (
+	catalogGCDeleteTable catalogGCDeleteKind = iota
+	catalogGCDeleteDatabase
+)
+
 // deleteCatalogVersions deletes a newest-first group from oldest to newest.
 // When the newest collected version is a tombstone, keeping it until all
 // superseded live versions are gone prevents concurrent readers from briefly
@@ -180,6 +187,9 @@ func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 		r.TStaleCpk = len(deletedCpkey)
 		deleteCatalogVersions(deletedItems, func(item *TableItem) {
 			cc.tables.data.Delete(item)
+			if cc.gcDeleteObserverForTesting != nil {
+				cc.gcDeleteObserverForTesting(catalogGCDeleteTable)
+			}
 		})
 		for _, item := range deletedCpkey {
 			cc.tables.cpkeyIndex.Delete(item)
@@ -221,6 +231,9 @@ func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 		r.DStaleCpk = len(deletedCpkey)
 		deleteCatalogVersions(deletedItems, func(item *DatabaseItem) {
 			cc.databases.data.Delete(item)
+			if cc.gcDeleteObserverForTesting != nil {
+				cc.gcDeleteObserverForTesting(catalogGCDeleteDatabase)
+			}
 		})
 		for _, item := range deletedCpkey {
 			cc.databases.cpkeyIndex.Delete(item)

--- a/pkg/vm/engine/disttae/cache/catalog_test.go
+++ b/pkg/vm/engine/disttae/cache/catalog_test.go
@@ -65,6 +65,114 @@ func TestCatalogCacheConcurrentGC(t *testing.T) {
 	wg.Wait()
 }
 
+func TestCatalogGCVersionRetirementPreservesVisibility(t *testing.T) {
+	t.Run("database tombstone remains authoritative", func(t *testing.T) {
+		cc := NewCatalog()
+		cc.UpdateDuration(types.TS{}, types.MaxTs())
+		oldLive := &DatabaseItem{
+			AccountId: 1, Name: "dropped_db", Id: 41,
+			Ts: timestamp.Timestamp{PhysicalTime: 10},
+		}
+		tombstone := &DatabaseItem{
+			AccountId: 1, Name: "dropped_db", Id: 41, deleted: true,
+			Ts: timestamp.Timestamp{PhysicalTime: 20},
+		}
+		cc.databases.data.Set(oldLive)
+		cc.databases.data.Set(tombstone)
+		cc.UpdateStart(types.BuildTS(30, 0))
+
+		deleteCatalogVersions([]*DatabaseItem{tombstone, oldLive}, func(item *DatabaseItem) {
+			cc.databases.data.Delete(item)
+			require.False(t, cc.CanServe(types.BuildTS(15, 0)),
+				"snapshots whose history is being retired must fall back to storage")
+			query := &DatabaseItem{
+				AccountId: 1, Name: "dropped_db",
+				Ts: timestamp.Timestamp{PhysicalTime: 40},
+			}
+			require.False(t, cc.GetDatabase(query),
+				"catalog GC must never expose a superseded live database version")
+		})
+	})
+
+	t.Run("table tombstone remains authoritative", func(t *testing.T) {
+		cc := NewCatalog()
+		oldLive := &TableItem{
+			AccountId: 1, DatabaseId: 2, Name: "dropped_table", Id: 41,
+			Ts: timestamp.Timestamp{PhysicalTime: 10},
+		}
+		tombstone := &TableItem{
+			AccountId: 1, DatabaseId: 2, Name: "dropped_table", Id: 41, deleted: true,
+			Ts: timestamp.Timestamp{PhysicalTime: 20},
+		}
+		cc.tables.data.Set(oldLive)
+		cc.tables.data.Set(tombstone)
+
+		deleteCatalogVersions([]*TableItem{tombstone, oldLive}, func(item *TableItem) {
+			cc.tables.data.Delete(item)
+			query := &TableItem{
+				AccountId: 1, DatabaseId: 2, Name: "dropped_table",
+				Ts: timestamp.Timestamp{PhysicalTime: 40},
+			}
+			require.False(t, cc.GetTable(query),
+				"catalog GC must never expose a superseded live table version")
+		})
+	})
+
+	t.Run("GC retains newest live recreation", func(t *testing.T) {
+		cc := NewCatalog()
+		cc.UpdateDuration(types.TS{}, types.MaxTs())
+		cc.databases.data.Set(&DatabaseItem{
+			AccountId: 1, Name: "recreated_db", Id: 41,
+			Ts: timestamp.Timestamp{PhysicalTime: 10},
+		})
+		cc.databases.data.Set(&DatabaseItem{
+			AccountId: 1, Name: "recreated_db", Id: 41, deleted: true,
+			Ts: timestamp.Timestamp{PhysicalTime: 20},
+		})
+		cc.databases.data.Set(&DatabaseItem{
+			AccountId: 1, Name: "recreated_db", Id: 42,
+			Ts: timestamp.Timestamp{PhysicalTime: 20},
+		})
+
+		cc.GC(timestamp.Timestamp{PhysicalTime: 30})
+		query := &DatabaseItem{
+			AccountId: 1, Name: "recreated_db",
+			Ts: timestamp.Timestamp{PhysicalTime: 40},
+		}
+		require.True(t, cc.GetDatabase(query))
+		require.Equal(t, uint64(42), query.Id)
+	})
+
+	t.Run("GC isolates identical names by account", func(t *testing.T) {
+		cc := NewCatalog()
+		cc.UpdateDuration(types.TS{}, types.MaxTs())
+		for _, accountID := range []uint32{1, 2} {
+			cc.databases.data.Set(&DatabaseItem{
+				AccountId: accountID, Name: "shared_name", Id: uint64(40 + accountID),
+				Ts: timestamp.Timestamp{PhysicalTime: 10},
+			})
+			cc.tables.data.Set(&TableItem{
+				AccountId: accountID, DatabaseId: 7, Name: "shared_name", Id: uint64(40 + accountID),
+				Ts: timestamp.Timestamp{PhysicalTime: 10},
+			})
+		}
+
+		cc.GC(timestamp.Timestamp{PhysicalTime: 30})
+		for _, accountID := range []uint32{1, 2} {
+			dbQuery := &DatabaseItem{
+				AccountId: accountID, Name: "shared_name",
+				Ts: timestamp.Timestamp{PhysicalTime: 40},
+			}
+			require.True(t, cc.GetDatabase(dbQuery), "database for account %d was retired", accountID)
+			tableQuery := &TableItem{
+				AccountId: accountID, DatabaseId: 7, Name: "shared_name",
+				Ts: timestamp.Timestamp{PhysicalTime: 40},
+			}
+			require.True(t, cc.GetTable(tableQuery), "table for account %d was retired", accountID)
+		}
+	})
+}
+
 func TestCrossDBGet(t *testing.T) {
 	cc := NewCatalog()
 	cc.tables.data.Set(&TableItem{

--- a/pkg/vm/engine/disttae/cache/catalog_test.go
+++ b/pkg/vm/engine/disttae/cache/catalog_test.go
@@ -66,56 +66,52 @@ func TestCatalogCacheConcurrentGC(t *testing.T) {
 }
 
 func TestCatalogGCVersionRetirementPreservesVisibility(t *testing.T) {
-	t.Run("database tombstone remains authoritative", func(t *testing.T) {
+	t.Run("real GC keeps tombstones authoritative during retirement", func(t *testing.T) {
 		cc := NewCatalog()
 		cc.UpdateDuration(types.TS{}, types.MaxTs())
-		oldLive := &DatabaseItem{
+		cc.databases.data.Set(&DatabaseItem{
 			AccountId: 1, Name: "dropped_db", Id: 41,
 			Ts: timestamp.Timestamp{PhysicalTime: 10},
-		}
-		tombstone := &DatabaseItem{
+		})
+		cc.databases.data.Set(&DatabaseItem{
 			AccountId: 1, Name: "dropped_db", Id: 41, deleted: true,
 			Ts: timestamp.Timestamp{PhysicalTime: 20},
-		}
-		cc.databases.data.Set(oldLive)
-		cc.databases.data.Set(tombstone)
-		cc.UpdateStart(types.BuildTS(30, 0))
-
-		deleteCatalogVersions([]*DatabaseItem{tombstone, oldLive}, func(item *DatabaseItem) {
-			cc.databases.data.Delete(item)
-			require.False(t, cc.CanServe(types.BuildTS(15, 0)),
-				"snapshots whose history is being retired must fall back to storage")
-			query := &DatabaseItem{
-				AccountId: 1, Name: "dropped_db",
-				Ts: timestamp.Timestamp{PhysicalTime: 40},
-			}
-			require.False(t, cc.GetDatabase(query),
-				"catalog GC must never expose a superseded live database version")
 		})
-	})
-
-	t.Run("table tombstone remains authoritative", func(t *testing.T) {
-		cc := NewCatalog()
-		oldLive := &TableItem{
+		cc.tables.data.Set(&TableItem{
 			AccountId: 1, DatabaseId: 2, Name: "dropped_table", Id: 41,
 			Ts: timestamp.Timestamp{PhysicalTime: 10},
-		}
-		tombstone := &TableItem{
+		})
+		cc.tables.data.Set(&TableItem{
 			AccountId: 1, DatabaseId: 2, Name: "dropped_table", Id: 41, deleted: true,
 			Ts: timestamp.Timestamp{PhysicalTime: 20},
-		}
-		cc.tables.data.Set(oldLive)
-		cc.tables.data.Set(tombstone)
-
-		deleteCatalogVersions([]*TableItem{tombstone, oldLive}, func(item *TableItem) {
-			cc.tables.data.Delete(item)
-			query := &TableItem{
-				AccountId: 1, DatabaseId: 2, Name: "dropped_table",
-				Ts: timestamp.Timestamp{PhysicalTime: 40},
-			}
-			require.False(t, cc.GetTable(query),
-				"catalog GC must never expose a superseded live table version")
 		})
+
+		deleteCounts := make(map[catalogGCDeleteKind]int)
+		cc.gcDeleteObserverForTesting = func(kind catalogGCDeleteKind) {
+			deleteCounts[kind]++
+			require.False(t, cc.CanServe(types.BuildTS(15, 0)),
+				"snapshots whose history is being retired must fall back to storage")
+			switch kind {
+			case catalogGCDeleteDatabase:
+				query := &DatabaseItem{
+					AccountId: 1, Name: "dropped_db",
+					Ts: timestamp.Timestamp{PhysicalTime: 40},
+				}
+				require.False(t, cc.GetDatabase(query),
+					"catalog GC must never expose a superseded live database version")
+			case catalogGCDeleteTable:
+				query := &TableItem{
+					AccountId: 1, DatabaseId: 2, Name: "dropped_table",
+					Ts: timestamp.Timestamp{PhysicalTime: 40},
+				}
+				require.False(t, cc.GetTable(query),
+					"catalog GC must never expose a superseded live table version")
+			}
+		}
+
+		cc.GC(timestamp.Timestamp{PhysicalTime: 30})
+		require.Equal(t, 2, deleteCounts[catalogGCDeleteDatabase])
+		require.Equal(t, 2, deleteCounts[catalogGCDeleteTable])
 	})
 
 	t.Run("GC retains newest live recreation", func(t *testing.T) {

--- a/pkg/vm/engine/disttae/cache/types.go
+++ b/pkg/vm/engine/disttae/cache/types.go
@@ -61,8 +61,11 @@ type CatalogCache struct {
 		start types.TS
 		end   types.TS
 	}
-	gcMu        sync.Mutex
-	tableChange struct {
+	gcMu sync.Mutex
+	// gcDeleteObserverForTesting is nil in production. Tests use it to inspect
+	// the reader-visible state between separately locked B-tree deletions.
+	gcDeleteObserverForTesting func(catalogGCDeleteKind)
+	tableChange                struct {
 		sync.RWMutex
 		// Account IDs hash into a fixed number of monotonic high-watermark
 		// buckets. Collisions can only cause conservative replanning; they

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -428,7 +428,11 @@ func (e *Engine) Database(
 	// check the database is deleted or not
 	key := genDatabaseKey(accountId, name)
 	if txn.databaseOps.existAndDeleted(key) {
-		return nil, moerr.NewParseErrorf(ctx, "database %q does not exist", name)
+		// Keep all authoritative "database does not exist" results on the same
+		// typed contract.  In particular, DROP DATABASE followed by CREATE
+		// DATABASE in the same transaction (used by PITR and snapshot restore)
+		// reaches this transaction-local tombstone before consulting the catalog.
+		return nil, moerr.GetOkExpectedEOB()
 	}
 
 	if v := txn.databaseOps.existAndActive(key); v != nil {

--- a/pkg/vm/engine/disttae/engine_test.go
+++ b/pkg/vm/engine/disttae/engine_test.go
@@ -181,6 +181,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -199,6 +200,17 @@ import (
 
 type engineNodesClusterClient struct {
 	details logpb.ClusterDetails
+}
+
+func TestDatabaseTreatsTransactionLocalDropAsNotFound(t *testing.T) {
+	ctx := defines.AttachAccountId(context.Background(), uint32(7))
+	txn := &Transaction{databaseOps: newDbOps()}
+	txn.databaseOps.addDeleteDatabase(genDatabaseKey(7, "restore_db"), 1, 42)
+	op := newTxnOperatorForTestWithWorkspace(t, txn)
+
+	db, err := (&Engine{}).Database(ctx, "restore_db", op)
+	require.Nil(t, db)
+	require.True(t, moerr.IsMoErrCode(err, moerr.OkExpectedEOB), "unexpected error: %v", err)
 }
 
 func (c *engineNodesClusterClient) GetClusterDetails(context.Context) (logpb.ClusterDetails, error) {

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -40,6 +40,10 @@ func genWriteReqs(
 	txnCommit *Transaction,
 ) ([]txn.TxnRequest, error) {
 	writes, tablesInVain, op := txnCommit.writes, txnCommit.tablesInVain, txnCommit.op
+	var pendingDatabaseCreates map[string]string
+	if txnCommit.haveDDL.Load() {
+		pendingDatabaseCreates = txnCommit.pendingCreatedDatabaseWrites()
+	}
 	var pkChkByTN int8
 	if v := ctx.Value(defines.PkCheckByTN{}); v != nil {
 		pkChkByTN = v.(int8)
@@ -63,6 +67,12 @@ func genWriteReqs(
 		if err != nil {
 			return nil, err
 		}
+		if len(pendingDatabaseCreates) != 0 &&
+			e.typ == INSERT &&
+			e.databaseId == catalog.MO_CATALOG_ID &&
+			e.tableId == catalog.MO_DATABASE_ID {
+			delete(pendingDatabaseCreates, e.note)
+		}
 		// --sql
 		// create table t (a int);
 		// begin;
@@ -82,6 +92,9 @@ func genWriteReqs(
 		}
 
 		entries = append(entries, pe)
+	}
+	if len(pendingDatabaseCreates) != 0 {
+		return nil, missingCreatedDatabaseWriteError(ctx, pendingDatabaseCreates)
 	}
 
 	requireAutoIncrEpochFence := requiresAutoIncrEpochFenceCommit(entries)

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -40,7 +40,7 @@ func genWriteReqs(
 	txnCommit *Transaction,
 ) ([]txn.TxnRequest, error) {
 	writes, tablesInVain, op := txnCommit.writes, txnCommit.tablesInVain, txnCommit.op
-	var pendingDatabaseCreates map[string]string
+	var pendingDatabaseCreates map[databaseKey]uint64
 	if txnCommit.haveDDL.Load() {
 		pendingDatabaseCreates = txnCommit.pendingCreatedDatabaseWrites()
 	}
@@ -71,7 +71,7 @@ func genWriteReqs(
 			e.typ == INSERT &&
 			e.databaseId == catalog.MO_CATALOG_ID &&
 			e.tableId == catalog.MO_DATABASE_ID {
-			delete(pendingDatabaseCreates, e.note)
+			consumeCreatedDatabaseWrites(pendingDatabaseCreates, e.bat)
 		}
 		// --sql
 		// create table t (a int);

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2749,7 +2749,7 @@ func (txn *Transaction) Commit(ctx context.Context) (reqs []txn.TxnRequest, err 
 // pendingCreatedDatabaseWrites returns the physical catalog inserts required
 // by the transaction-local database view. It allocates only for transactions
 // that have an active CREATE DATABASE operation.
-func (txn *Transaction) pendingCreatedDatabaseWrites() map[string]string {
+func (txn *Transaction) pendingCreatedDatabaseWrites() map[databaseKey]uint64 {
 	if txn.databaseOps == nil {
 		return nil
 	}
@@ -2757,33 +2757,85 @@ func (txn *Transaction) pendingCreatedDatabaseWrites() map[string]string {
 	txn.databaseOps.RLock()
 	defer txn.databaseOps.RUnlock()
 
-	var pending map[string]string
+	var pending map[databaseKey]uint64
 	for key, ops := range txn.databaseOps.names {
 		if len(ops) == 0 || ops[len(ops)-1].kind != INSERT {
 			continue
 		}
 		if pending == nil {
-			pending = make(map[string]string)
+			pending = make(map[databaseKey]uint64)
 		}
-		pending[noteForCreate(uint64(key.accountId), key.name)] = key.name
+		pending[key] = ops[len(ops)-1].databaseId
 	}
 	return pending
 }
 
-func missingCreatedDatabaseWriteError(ctx context.Context, pending map[string]string) error {
-	var name string
-	for _, candidate := range pending {
-		if name == "" || candidate < name {
-			name = candidate
+// consumeCreatedDatabaseWrites reconciles active transaction-local CREATE
+// DATABASE operations with the authoritative catalog tuples that will be sent
+// to TN.  It intentionally derives identity from tuple data instead of Entry.note:
+// notes are diagnostic metadata and must not be able to certify a wrong tenant,
+// name, or allocated database ID.
+func consumeCreatedDatabaseWrites(pending map[databaseKey]uint64, bat *batch.Batch) {
+	if len(pending) == 0 || bat == nil || bat.RowCount() == 0 {
+		return
+	}
+
+	findAttr := func(name string) int {
+		for i := range bat.Attrs {
+			if bat.Attrs[i] == name {
+				return i
+			}
+		}
+		return -1
+	}
+	idIdx := findAttr(catalog.SystemDBAttr_ID)
+	nameIdx := findAttr(catalog.SystemDBAttr_Name)
+	accountIdx := findAttr(catalog.SystemDBAttr_AccID)
+	if idIdx < 0 || nameIdx < 0 || accountIdx < 0 ||
+		idIdx >= len(bat.Vecs) || nameIdx >= len(bat.Vecs) || accountIdx >= len(bat.Vecs) ||
+		bat.Vecs[idIdx] == nil || bat.Vecs[nameIdx] == nil || bat.Vecs[accountIdx] == nil {
+		return
+	}
+
+	idVec, nameVec, accountVec := bat.Vecs[idIdx], bat.Vecs[nameIdx], bat.Vecs[accountIdx]
+	rows := bat.RowCount()
+	if idVec.Length() < rows || nameVec.Length() < rows || accountVec.Length() < rows {
+		return
+	}
+	for row := range rows {
+		if idVec.IsNull(uint64(row)) || nameVec.IsNull(uint64(row)) || accountVec.IsNull(uint64(row)) {
+			continue
+		}
+		key := genDatabaseKey(
+			vector.GetFixedAtNoTypeCheck[uint32](accountVec, row),
+			string(nameVec.GetBytesAt(row)),
+		)
+		if expectedID, ok := pending[key]; ok &&
+			expectedID == vector.GetFixedAtNoTypeCheck[uint64](idVec, row) {
+			delete(pending, key)
 		}
 	}
-	if name == "" {
+}
+
+func missingCreatedDatabaseWriteError(ctx context.Context, pending map[databaseKey]uint64) error {
+	var key databaseKey
+	var id uint64
+	found := false
+	for candidate, candidateID := range pending {
+		if !found || candidate.accountId < key.accountId ||
+			(candidate.accountId == key.accountId && candidate.name < key.name) {
+			key, id, found = candidate, candidateID, true
+		}
+	}
+	if !found {
 		return nil
 	}
 	return moerr.NewInternalErrorf(
 		ctx,
-		"cannot commit CREATE DATABASE %q: catalog insert is missing",
-		name,
+		"cannot commit CREATE DATABASE %q (account %d, id %d): catalog insert is missing or inconsistent",
+		key.name,
+		key.accountId,
+		id,
 	)
 }
 

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2668,6 +2668,11 @@ func (txn *Transaction) Commit(ctx context.Context) (reqs []txn.TxnRequest, err 
 	})
 
 	if txn.readOnly.Load() {
+		if txn.haveDDL.Load() {
+			if pending := txn.pendingCreatedDatabaseWrites(); len(pending) != 0 {
+				return nil, missingCreatedDatabaseWriteError(ctx, pending)
+			}
+		}
 		return nil, nil
 	}
 
@@ -2739,6 +2744,47 @@ func (txn *Transaction) Commit(ctx context.Context) (reqs []txn.TxnRequest, err 
 	}
 
 	return reqs, nil
+}
+
+// pendingCreatedDatabaseWrites returns the physical catalog inserts required
+// by the transaction-local database view. It allocates only for transactions
+// that have an active CREATE DATABASE operation.
+func (txn *Transaction) pendingCreatedDatabaseWrites() map[string]string {
+	if txn.databaseOps == nil {
+		return nil
+	}
+
+	txn.databaseOps.RLock()
+	defer txn.databaseOps.RUnlock()
+
+	var pending map[string]string
+	for key, ops := range txn.databaseOps.names {
+		if len(ops) == 0 || ops[len(ops)-1].kind != INSERT {
+			continue
+		}
+		if pending == nil {
+			pending = make(map[string]string)
+		}
+		pending[noteForCreate(uint64(key.accountId), key.name)] = key.name
+	}
+	return pending
+}
+
+func missingCreatedDatabaseWriteError(ctx context.Context, pending map[string]string) error {
+	var name string
+	for _, candidate := range pending {
+		if name == "" || candidate < name {
+			name = candidate
+		}
+	}
+	if name == "" {
+		return nil
+	}
+	return moerr.NewInternalErrorf(
+		ctx,
+		"cannot commit CREATE DATABASE %q: catalog insert is missing",
+		name,
+	)
 }
 
 func (txn *Transaction) FinalizeCommit(context.Context) {

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -33,6 +33,7 @@ import (
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	txnpb "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
@@ -52,74 +53,226 @@ func TestValidateAutoIncrEpochAdvance(t *testing.T) {
 	require.Error(t, validateAutoIncrEpochAdvance(math.MaxUint32-1, 2))
 }
 
-func TestPendingCreatedDatabaseWrites(t *testing.T) {
-	newTxn := func() *Transaction {
-		return &Transaction{databaseOps: newDbOps()}
-	}
-	addCreate := func(txn *Transaction, accountID uint32, name string) {
-		txn.databaseOps.addCreateDatabase(
-			genDatabaseKey(accountID, name),
-			1,
-			&txnDatabase{accountId: accountID, databaseId: 42, databaseName: name},
-		)
-	}
-	validCreateEntry := func(accountID uint32, name string) Entry {
-		bat := batch.NewWithSize(0)
-		bat.SetRowCount(1)
-		return Entry{
-			typ:          INSERT,
-			databaseId:   catalog.MO_CATALOG_ID,
-			tableId:      catalog.MO_DATABASE_ID,
-			databaseName: catalog.MO_CATALOG,
-			tableName:    catalog.MO_DATABASE,
-			note:         noteForCreate(uint64(accountID), name),
-			bat:          bat,
-		}
-	}
+func TestGenWriteReqsValidatesCreatedDatabaseCatalogWrites(t *testing.T) {
+	t.Run("matching production tuple is encoded", func(t *testing.T) {
+		txn := newCatalogCreateTxnForTest(t)
+		defer cleanTxnWritesForTest(txn)
+		addActiveDatabaseCreateForTest(txn, 7, "db", 42, 1)
+		appendCreateDatabaseTupleForTest(t, txn, 7, "db", 42, 7, "db", false)
 
-	t.Run("matching catalog insert", func(t *testing.T) {
-		txn := newTxn()
-		addCreate(txn, 7, "db")
-		txn.writes = append(txn.writes, validCreateEntry(7, "db"))
-		pending := txn.pendingCreatedDatabaseWrites()
-		for i := range txn.writes {
-			delete(pending, txn.writes[i].note)
-		}
-		require.Empty(t, pending)
+		reqs, err := genWriteReqs(context.Background(), txn)
+		require.NoError(t, err)
+		require.Len(t, reqs, 1)
+		cmd := decodePrecommitWriteCmdForTest(t, reqs[0])
+		require.Len(t, cmd.EntryList, 1)
+		entry := cmd.EntryList[0]
+		require.Equal(t, uint64(catalog.MO_CATALOG_ID), entry.DatabaseId)
+		require.Equal(t, uint64(catalog.MO_DATABASE_ID), entry.TableId)
+		bat, err := batch.ProtoBatchToBatch(entry.Bat)
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), vector.GetFixedAtNoTypeCheck[uint64](bat.Vecs[catalog.MO_DATABASE_DAT_ID_IDX], 0))
+		require.Equal(t, "db", string(bat.Vecs[catalog.MO_DATABASE_DAT_NAME_IDX].GetBytesAt(0)))
+		require.Equal(t, uint32(7), vector.GetFixedAtNoTypeCheck[uint32](bat.Vecs[catalog.MO_DATABASE_ACCOUNT_ID_IDX], 0))
 	})
 
-	t.Run("missing catalog insert fails closed", func(t *testing.T) {
-		txn := newTxn()
-		addCreate(txn, 7, "db")
-		err := missingCreatedDatabaseWriteError(context.Background(), txn.pendingCreatedDatabaseWrites())
+	for _, tc := range []struct {
+		name         string
+		tupleAccount uint32
+		tupleName    string
+		tupleID      uint64
+		empty        bool
+	}{
+		{name: "empty tuple", tupleAccount: 7, tupleName: "db", tupleID: 42, empty: true},
+		{name: "wrong tenant", tupleAccount: 8, tupleName: "db", tupleID: 42},
+		{name: "wrong name", tupleAccount: 7, tupleName: "other", tupleID: 42},
+		{name: "wrong database id", tupleAccount: 7, tupleName: "db", tupleID: 43},
+	} {
+		t.Run(tc.name+" fails closed", func(t *testing.T) {
+			txn := newCatalogCreateTxnForTest(t)
+			defer cleanTxnWritesForTest(txn)
+			addActiveDatabaseCreateForTest(txn, 7, "db", 42, 1)
+			// Keep the expected note deliberately: tuple contents, not diagnostic
+			// metadata, must certify the physical catalog write.
+			appendCreateDatabaseTupleForTest(t, txn, tc.tupleAccount, tc.tupleName, tc.tupleID, 7, "db", tc.empty)
+
+			reqs, err := genWriteReqs(context.Background(), txn)
+			require.Nil(t, reqs)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "catalog insert is missing or inconsistent")
+		})
+	}
+
+	t.Run("nil catalog batch fails closed", func(t *testing.T) {
+		txn := newCatalogCreateTxnForTest(t)
+		addActiveDatabaseCreateForTest(txn, 7, "db", 42, 1)
+		txn.writes = append(txn.writes, Entry{
+			typ: INSERT, databaseId: catalog.MO_CATALOG_ID, tableId: catalog.MO_DATABASE_ID,
+			databaseName: catalog.MO_CATALOG, tableName: catalog.MO_DATABASE,
+			note: noteForCreate(7, "db"), tnStore: catalogCreateTNStoreForTest(),
+		})
+
+		reqs, err := genWriteReqs(context.Background(), txn)
+		require.Nil(t, reqs)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "catalog insert is missing")
 	})
 
-	t.Run("empty catalog insert is not encoded", func(t *testing.T) {
-		txn := newTxn()
-		addCreate(txn, 7, "db")
-		entry := validCreateEntry(7, "db")
-		entry.bat.SetRowCount(0)
-		txn.writes = append(txn.writes, entry)
-		require.NotEmpty(t, txn.pendingCreatedDatabaseWrites())
+	t.Run("multiple databases are independently certified", func(t *testing.T) {
+		txn := newCatalogCreateTxnForTest(t)
+		defer cleanTxnWritesForTest(txn)
+		addActiveDatabaseCreateForTest(txn, 7, "alpha", 41, 1)
+		addActiveDatabaseCreateForTest(txn, 8, "beta", 42, 1)
+		appendCreateDatabaseTupleForTest(t, txn, 7, "alpha", 41, 7, "alpha", false)
+		appendCreateDatabaseTupleForTest(t, txn, 8, "beta", 42, 8, "beta", false)
+
+		reqs, err := genWriteReqs(context.Background(), txn)
+		require.NoError(t, err)
+		require.Len(t, reqs, 1)
+		require.Len(t, decodePrecommitWriteCmdForTest(t, reqs[0]).EntryList, 2)
 	})
 
-	t.Run("different tenant does not satisfy create", func(t *testing.T) {
-		txn := newTxn()
-		addCreate(txn, 7, "db")
-		txn.writes = append(txn.writes, validCreateEntry(8, "db"))
-		pending := txn.pendingCreatedDatabaseWrites()
-		delete(pending, txn.writes[0].note)
-		require.NotEmpty(t, pending)
+	t.Run("superseded create cannot certify recreated database id", func(t *testing.T) {
+		txn := newCatalogCreateTxnForTest(t)
+		defer cleanTxnWritesForTest(txn)
+		addActiveDatabaseCreateForTest(txn, 7, "db", 41, 1)
+		txn.databaseOps.addDeleteDatabase(genDatabaseKey(7, "db"), 2, 41)
+		addActiveDatabaseCreateForTest(txn, 7, "db", 42, 3)
+		// Only the superseded ID is encoded. Matching account/name is not enough.
+		appendCreateDatabaseTupleForTest(t, txn, 7, "db", 41, 7, "db", false)
+
+		reqs, err := genWriteReqs(context.Background(), txn)
+		require.Nil(t, reqs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "id 42")
 	})
 
 	t.Run("create then drop is a valid net no-op", func(t *testing.T) {
-		txn := newTxn()
-		addCreate(txn, 7, "db")
+		txn := newCatalogCreateTxnForTest(t)
+		addActiveDatabaseCreateForTest(txn, 7, "db", 42, 1)
 		txn.databaseOps.addDeleteDatabase(genDatabaseKey(7, "db"), 2, 42)
 		require.Empty(t, txn.pendingCreatedDatabaseWrites())
 	})
+
+	t.Run("statement rollback removes create and tuple together", func(t *testing.T) {
+		txn := newCatalogCreateTxnForTest(t)
+		txn.isCCPRTxn = true
+		txn.deletedBlocks = &deletedBlocks{offsets: make(map[types.Blockid][]int64)}
+		txn.tableCache = new(sync.Map)
+		txn.tableOps = newTableOps()
+		txn.batchSelectList = make(map[*batch.Batch][]int64)
+		txn.op.(*mock_frontend.MockTxnOperator).EXPECT().EnterRollbackStmt()
+		txn.op.(*mock_frontend.MockTxnOperator).EXPECT().ExitRollbackStmt()
+		addActiveDatabaseCreateForTest(txn, 7, "db", 42, 1)
+		appendCreateDatabaseTupleForTest(t, txn, 7, "db", 42, 7, "db", false)
+		txn.statementID = 1
+		txn.offsets = []int{0}
+
+		require.NoError(t, txn.RollbackLastStatement(context.Background()))
+		require.Empty(t, txn.writes)
+		require.Empty(t, txn.pendingCreatedDatabaseWrites())
+		reqs, err := genWriteReqs(context.Background(), txn)
+		require.NoError(t, err)
+		require.Nil(t, reqs)
+	})
+}
+
+func newCatalogCreateTxnForTest(t *testing.T) *Transaction {
+	t.Helper()
+	proc := testutil.NewProc(t)
+	txn := &Transaction{
+		proc:            proc,
+		databaseOps:     newDbOps(),
+		tablesInVain:    make(map[uint64]int),
+		batchSelectList: make(map[*batch.Batch][]int64),
+	}
+	txn.op = newTxnOperatorForTestWithWorkspace(t, txn)
+	txn.haveDDL.Store(true)
+	return txn
+}
+
+func catalogCreateTNStoreForTest() DNStore {
+	return DNStore{
+		ServiceID:         "tn-test",
+		TxnServiceAddress: "tn-test-address",
+		Shards: []metadata.TNShard{{
+			TNShardRecord: metadata.TNShardRecord{ShardID: 1},
+			ReplicaID:     1,
+		}},
+	}
+}
+
+func addActiveDatabaseCreateForTest(
+	txn *Transaction,
+	accountID uint32,
+	name string,
+	databaseID uint64,
+	statementID int,
+) {
+	txn.databaseOps.addCreateDatabase(
+		genDatabaseKey(accountID, name),
+		statementID,
+		&txnDatabase{accountId: accountID, databaseId: databaseID, databaseName: name},
+	)
+}
+
+func appendCreateDatabaseTupleForTest(
+	t *testing.T,
+	txn *Transaction,
+	tupleAccountID uint32,
+	tupleName string,
+	tupleDatabaseID uint64,
+	noteAccountID uint32,
+	noteName string,
+	empty bool,
+) {
+	t.Helper()
+	packer := types.NewPacker()
+	defer packer.Close()
+	bat, err := catalog.GenCreateDatabaseTuple(
+		"create database "+tupleName,
+		tupleAccountID,
+		1,
+		1,
+		tupleName,
+		tupleDatabaseID,
+		"",
+		txn.proc.Mp(),
+		packer,
+	)
+	require.NoError(t, err)
+	_, err = txn.WriteBatch(
+		INSERT,
+		noteForCreate(uint64(noteAccountID), noteName),
+		catalog.System_Account,
+		catalog.MO_CATALOG_ID,
+		catalog.MO_DATABASE_ID,
+		catalog.MO_CATALOG,
+		catalog.MO_DATABASE,
+		bat,
+		catalogCreateTNStoreForTest(),
+	)
+	require.NoError(t, err)
+	if empty {
+		// Exercise the encoder's empty-entry filter after the production write
+		// path has built a structurally valid catalog batch (including rowid).
+		txn.writes[len(txn.writes)-1].bat.SetRowCount(0)
+	}
+}
+
+func decodePrecommitWriteCmdForTest(t *testing.T, req txnpb.TxnRequest) *api.PrecommitWriteCmd {
+	t.Helper()
+	require.NotNil(t, req.CNRequest)
+	cmd := new(api.PrecommitWriteCmd)
+	require.NoError(t, types.Decode(req.CNRequest.Payload, cmd))
+	return cmd
+}
+
+func cleanTxnWritesForTest(txn *Transaction) {
+	for i := range txn.writes {
+		if txn.writes[i].bat != nil {
+			txn.writes[i].bat.Clean(txn.proc.Mp())
+			txn.writes[i].bat = nil
+		}
+	}
 }
 
 func TestCommitRejectsReadOnlyWorkspaceWithActiveDatabaseCreate(t *testing.T) {

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -52,6 +52,110 @@ func TestValidateAutoIncrEpochAdvance(t *testing.T) {
 	require.Error(t, validateAutoIncrEpochAdvance(math.MaxUint32-1, 2))
 }
 
+func TestPendingCreatedDatabaseWrites(t *testing.T) {
+	newTxn := func() *Transaction {
+		return &Transaction{databaseOps: newDbOps()}
+	}
+	addCreate := func(txn *Transaction, accountID uint32, name string) {
+		txn.databaseOps.addCreateDatabase(
+			genDatabaseKey(accountID, name),
+			1,
+			&txnDatabase{accountId: accountID, databaseId: 42, databaseName: name},
+		)
+	}
+	validCreateEntry := func(accountID uint32, name string) Entry {
+		bat := batch.NewWithSize(0)
+		bat.SetRowCount(1)
+		return Entry{
+			typ:          INSERT,
+			databaseId:   catalog.MO_CATALOG_ID,
+			tableId:      catalog.MO_DATABASE_ID,
+			databaseName: catalog.MO_CATALOG,
+			tableName:    catalog.MO_DATABASE,
+			note:         noteForCreate(uint64(accountID), name),
+			bat:          bat,
+		}
+	}
+
+	t.Run("matching catalog insert", func(t *testing.T) {
+		txn := newTxn()
+		addCreate(txn, 7, "db")
+		txn.writes = append(txn.writes, validCreateEntry(7, "db"))
+		pending := txn.pendingCreatedDatabaseWrites()
+		for i := range txn.writes {
+			delete(pending, txn.writes[i].note)
+		}
+		require.Empty(t, pending)
+	})
+
+	t.Run("missing catalog insert fails closed", func(t *testing.T) {
+		txn := newTxn()
+		addCreate(txn, 7, "db")
+		err := missingCreatedDatabaseWriteError(context.Background(), txn.pendingCreatedDatabaseWrites())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "catalog insert is missing")
+	})
+
+	t.Run("empty catalog insert is not encoded", func(t *testing.T) {
+		txn := newTxn()
+		addCreate(txn, 7, "db")
+		entry := validCreateEntry(7, "db")
+		entry.bat.SetRowCount(0)
+		txn.writes = append(txn.writes, entry)
+		require.NotEmpty(t, txn.pendingCreatedDatabaseWrites())
+	})
+
+	t.Run("different tenant does not satisfy create", func(t *testing.T) {
+		txn := newTxn()
+		addCreate(txn, 7, "db")
+		txn.writes = append(txn.writes, validCreateEntry(8, "db"))
+		pending := txn.pendingCreatedDatabaseWrites()
+		delete(pending, txn.writes[0].note)
+		require.NotEmpty(t, pending)
+	})
+
+	t.Run("create then drop is a valid net no-op", func(t *testing.T) {
+		txn := newTxn()
+		addCreate(txn, 7, "db")
+		txn.databaseOps.addDeleteDatabase(genDatabaseKey(7, "db"), 2, 42)
+		require.Empty(t, txn.pendingCreatedDatabaseWrites())
+	})
+}
+
+func TestCommitRejectsReadOnlyWorkspaceWithActiveDatabaseCreate(t *testing.T) {
+	txn := &Transaction{
+		op:          newTxnOperatorForTest(t),
+		databaseOps: newDbOps(),
+	}
+	txn.databaseOps.addCreateDatabase(
+		genDatabaseKey(7, "db"),
+		1,
+		&txnDatabase{accountId: 7, databaseId: 42, databaseName: "db"},
+	)
+	txn.readOnly.Store(true)
+	txn.haveDDL.Store(true)
+
+	reqs, err := txn.Commit(context.Background())
+	require.Nil(t, reqs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "catalog insert is missing")
+}
+
+func TestGenWriteReqsRejectsMissingDatabaseCreate(t *testing.T) {
+	txn := &Transaction{databaseOps: newDbOps()}
+	txn.databaseOps.addCreateDatabase(
+		genDatabaseKey(7, "db"),
+		1,
+		&txnDatabase{accountId: 7, databaseId: 42, databaseName: "db"},
+	)
+	txn.haveDDL.Store(true)
+
+	reqs, err := genWriteReqs(context.Background(), txn)
+	require.Nil(t, reqs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "catalog insert is missing")
+}
+
 func TestTransactionAutoIncrEpochFenceCapabilityUsesTargetSnapshot(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/test/distributed/cases/database/create_database.result
+++ b/test/distributed/cases/database/create_database.result
@@ -5,7 +5,20 @@ drop database if exists test05;
 drop database if exists `测试数据库`;
 drop database if exists t01234567890123456789012345678901234567890123456789012345678901234567890123456789;
 create database test01;
+select row_count();
+➤ row_count()[-5,64,0]  𝄀
+1
 create database IF NOT EXISTS test01;
+select row_count();
+➤ row_count()[-5,64,0]  𝄀
+0
+select count(*) as compatibility_rows
+from mo_catalog.mo_mysql_compatibility_mode
+where account_id = 0
+and dat_name = 'test01'
+and variable_name = 'version_compatibility';
+➤ compatibility_rows[-5,64,0]  𝄀
+1
 create database `测试数据库`;
 create database t01234567890123456789012345678901234567890123456789012345678901234567890123456789;
 show databases;

--- a/test/distributed/cases/database/create_database.result
+++ b/test/distributed/cases/database/create_database.result
@@ -45,6 +45,45 @@ create database if not exists `TPCH_0.01G`;
 use `TPCH_0.01G`;
 drop database if exists `TPCH_0.01G`;
 drop database if exists db1;
+drop database if exists create_database_txn_target;
+drop database if exists create_database_txn_audit;
+create database create_database_txn_audit;
+create table create_database_txn_audit.ids (id bigint unsigned);
+create database create_database_txn_target;
+create table create_database_txn_target.original_table (id int);
+insert into create_database_txn_target.original_table values (7);
+insert into create_database_txn_audit.ids
+select dat_id from mo_catalog.mo_database where datname = 'create_database_txn_target';
+begin;
+drop database create_database_txn_target;
+create database create_database_txn_target;
+create table create_database_txn_target.recreated_table (id int);
+insert into create_database_txn_target.recreated_table values (8);
+commit;
+select dat_id <> (select id from create_database_txn_audit.ids) as recreated_with_new_id
+from mo_catalog.mo_database where datname = 'create_database_txn_target';
+recreated_with_new_id
+true
+select * from create_database_txn_target.recreated_table;
+id
+8
+truncate table create_database_txn_audit.ids;
+insert into create_database_txn_audit.ids
+select dat_id from mo_catalog.mo_database where datname = 'create_database_txn_target';
+begin;
+drop database create_database_txn_target;
+create database create_database_txn_target;
+create table create_database_txn_target.rolled_back_table (id int);
+rollback;
+select dat_id = (select id from create_database_txn_audit.ids) as rollback_kept_original_id
+from mo_catalog.mo_database where datname = 'create_database_txn_target';
+rollback_kept_original_id
+true
+select * from create_database_txn_target.recreated_table;
+id
+8
+drop database create_database_txn_target;
+drop database create_database_txn_audit;
 create database if not exists db1;
 show schemas;
 Database

--- a/test/distributed/cases/database/create_database.result
+++ b/test/distributed/cases/database/create_database.result
@@ -63,7 +63,7 @@ commit;
 select dat_id <> (select id from create_database_txn_audit.ids) as recreated_with_new_id
 from mo_catalog.mo_database where datname = 'create_database_txn_target';
 recreated_with_new_id
-true
+1
 select * from create_database_txn_target.recreated_table;
 id
 8
@@ -78,7 +78,7 @@ rollback;
 select dat_id = (select id from create_database_txn_audit.ids) as rollback_kept_original_id
 from mo_catalog.mo_database where datname = 'create_database_txn_target';
 rollback_kept_original_id
-true
+1
 select * from create_database_txn_target.recreated_table;
 id
 8

--- a/test/distributed/cases/database/create_database.test
+++ b/test/distributed/cases/database/create_database.test
@@ -48,6 +48,45 @@ create database if not exists `TPCH_0.01G`;
 use `TPCH_0.01G`;
 drop database if exists `TPCH_0.01G`;
 drop database if exists db1;
+
+-- @case
+-- @desc:transaction-local drop and recreate must create a physical catalog row
+-- @label:bvt
+drop database if exists create_database_txn_target;
+drop database if exists create_database_txn_audit;
+create database create_database_txn_audit;
+create table create_database_txn_audit.ids (id bigint unsigned);
+create database create_database_txn_target;
+create table create_database_txn_target.original_table (id int);
+insert into create_database_txn_target.original_table values (7);
+insert into create_database_txn_audit.ids
+select dat_id from mo_catalog.mo_database where datname = 'create_database_txn_target';
+begin;
+drop database create_database_txn_target;
+create database create_database_txn_target;
+create table create_database_txn_target.recreated_table (id int);
+insert into create_database_txn_target.recreated_table values (8);
+commit;
+select dat_id <> (select id from create_database_txn_audit.ids) as recreated_with_new_id
+from mo_catalog.mo_database where datname = 'create_database_txn_target';
+select * from create_database_txn_target.recreated_table;
+
+-- A rolled-back replacement must restore both the original catalog identity
+-- and the original database contents.
+truncate table create_database_txn_audit.ids;
+insert into create_database_txn_audit.ids
+select dat_id from mo_catalog.mo_database where datname = 'create_database_txn_target';
+begin;
+drop database create_database_txn_target;
+create database create_database_txn_target;
+create table create_database_txn_target.rolled_back_table (id int);
+rollback;
+select dat_id = (select id from create_database_txn_audit.ids) as rollback_kept_original_id
+from mo_catalog.mo_database where datname = 'create_database_txn_target';
+select * from create_database_txn_target.recreated_table;
+drop database create_database_txn_target;
+drop database create_database_txn_audit;
+
 create database if not exists db1;
 show schemas;
 drop database if exists db1;

--- a/test/distributed/cases/database/create_database.test
+++ b/test/distributed/cases/database/create_database.test
@@ -11,7 +11,14 @@ drop database if exists t0123456789012345678901234567890123456789012345678901234
 -- @desc:test for create database
 -- @label:bvt
 create database test01;
+select row_count();
 create database IF NOT EXISTS test01;
+select row_count();
+select count(*) as compatibility_rows
+from mo_catalog.mo_mysql_compatibility_mode
+where account_id = 0
+  and dat_name = 'test01'
+  and variable_name = 'version_compatibility';
 -- @case
 -- @desc:test for create database with chinese name
 -- @label:bvt


### PR DESCRIPTION
## Summary

This PR hardens `CREATE DATABASE [IF NOT EXISTS]` on `4.2-dev` after the false-success incident in #28276. Success now means either:

- the transaction snapshot contains a real database, or
- the transaction contains a physical `mo_catalog.mo_database` insert that commit can encode and send to TN.

It also fixes the catalog-GC conditions that could make a retired live version temporarily reappear after its newer tombstone was removed.

## Changes

1. Use an optimistic catalog lookup for the existing-database path. A positive result is authoritative for the transaction snapshot and returns immediately.
2. Only a typed `OkExpectedEOB` absence proceeds to the exclusive `(account, database)` catalog-key lock. Recheck after the lock before creating, so competing creators remain serialized without blocking ordinary DDL on an already-existing database.
3. Treat every other lookup error as an error instead of absence.
4. Normalize transaction-local database tombstones to the same typed absence contract. This preserves same-transaction `DROP DATABASE` -> `CREATE DATABASE`, including database-level PITR and snapshot restore.
5. Set affected rows to 1 only after `Engine.Create` succeeds. An `IF NOT EXISTS` no-op reports 0.
6. Skip ownership and compatibility-metadata side effects for a no-op.
7. Fail commit when an active transaction-local database create is not backed by a non-empty catalog tuple.
8. Certify that tuple from its actual `(account_id, datname, dat_id)` columns, not from `Entry.note`.
9. Reset pooled/prepared `Compile.retryTimes` at every new execution boundary.
10. Retire catalog-cache versions oldest-first so a tombstone remains authoritative until every superseded live version is gone.
11. Publish the GC start watermark before destructive retirement, forcing pre-cutoff snapshots to fall back to storage.
12. Include account identity in database/table GC grouping so equal names in different tenants do not share a version chain.

## Root cause and CI follow-up

The original issue recorded this externally visible sequence after a retained-data restart:

```sql
CREATE DATABASE IF NOT EXISTS ann;   -- returned OK
DROP TABLE IF EXISTS ann.items_gist; -- returned OK
CREATE TABLE ann.items_gist (...);   -- Unknown database: ann
```

The failed generation had no TN create-database handling or catalog commit for `ann`. The cache GC implementation could delete a newest tombstone before its older live version and published the cache cutoff only after deletion. A concurrent reader could therefore observe the superseded live version and incorrectly select the `IF NOT EXISTS` no-op path. Cross-tenant version grouping was also incomplete.

The first CI run after the initial fix exposed a separate locking regression in `pessimistic_transaction/atomicity.sql`: an existing database lookup had been moved behind the exclusive catalog-key lock. Concurrent `CREATE TABLE` holds a shared database lock, so a duplicate `CREATE DATABASE` waited for the 120-second lock timeout instead of immediately returning `DBAlreadyExists`. The final design is positive-fast-path plus double-checked locking for absence.

If another creator commits between the first lookup and lock acquisition, the lock service reports the newer `mo_database` key timestamp. RC detects the new version and retries the statement; the retry sees the committed database. Thus creation remains serialized without imposing a lock wait on confirmed-existing paths.

The other two BVT failures were result-oracle errors: MatrixOne renders the new boolean ID comparisons as `1`, not `true`. The result file now matches the actual typed output.

## Correctness and unhappy paths

- physical create: lookup absence, lock, locked recheck, one catalog create, affected rows 1;
- existing database + `IF NOT EXISTS`: one lookup, no lock, affected rows 0, no metadata/ownership duplication;
- strict duplicate: one lookup, no lock, immediate `DBAlreadyExists`;
- concurrent creator after initial absence: locked recheck or RC retry resolves to no-op/duplicate;
- lock failure after confirmed absence: no locked lookup or catalog mutation;
- initial and locked-recheck non-absence errors: propagated;
- engine create failure: affected rows remains 0;
- transaction-local drop/recreate: typed absence and a new database ID;
- rollback of drop/recreate: preserves the original database ID and data;
- missing, nil, empty, wrong-tenant, wrong-name, wrong-ID, and superseded-ID catalog writes: commit fails closed;
- create then drop: valid net no-op;
- statement rollback removes both logical create state and physical tuple;
- catalog GC never exposes an old insert after deleting a newer tombstone;
- pre-cutoff snapshots fall back to storage before the first destructive delete;
- identical database/table names in different tenants retain independent newest versions;
- no new goroutine, unbounded state, retry loop, or production logging.

## Performance

- Existing-database `IF NOT EXISTS` and strict duplicate paths perform one catalog lookup and acquire no new lock.
- Physical creation adds one cache lookup before the existing lock and locked recheck; this is a cold DDL path.
- Lock keys include account and database name, so unrelated database creation remains independent.
- Commit validation allocates/scans only when `haveDDL` and an active database create are both present; reconciliation is folded into the existing write-encoding traversal.
- Ordinary query/DML paths and cache-reader locking are unchanged.
- GC traverses the same already-collected deletion slices in reverse order.

## Validation

Validated through head `155d46e19c5` on base `33640a3adf4bd933de3881b28ab47c157a5ad209`:

- `make build`
- `make cgo`
- `GOWORK=off go vet -mod=readonly ./pkg/sql/compile ./pkg/vm/engine/disttae`
- full normal tests: `pkg/sql/compile`, `pkg/vm/engine/disttae`
- full `-race` tests: `pkg/sql/compile`, `pkg/vm/engine/disttae`
- focused create-database fast-path/retry tests under `-race -count=100`
- focused frontend status and disttae commit-validation regressions
- deterministic catalog-GC deletion-boundary and cross-tenant regressions under race stress
- live transaction test: commit produced a new database ID and usable table; rollback preserved the prior ID and data
- live database-level snapshot restore: restored rows and immediately accepted table DDL
- `git diff --check`

CI remains responsible for rerunning the full distributed suite on the updated head.

## Scope

This PR targets `4.2-dev`. The separate `main` port is #28290; `main` already contains part of the affected-row/frontend behavior from #27696.
