### PR TITLE
test(fileservice): isolate external object storage tests

### DIFF
--- a/pkg/fileservice/object_storage_arguments_test.go
+++ b/pkg/fileservice/object_storage_arguments_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -68,14 +67,31 @@ func TestObjectStorageArguments(t *testing.T) {
 	})
 }
 
-func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []ObjectStorageArguments) {
+const runExternalObjectStorageTestsEnv = "MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS"
 
-	// disk
-	ret = append(ret, ObjectStorageArguments{
+func localObjectStorageArgumentsForTest(defaultName string, t *testing.T) []ObjectStorageArguments {
+	return []ObjectStorageArguments{{
 		Name:     defaultName,
 		Endpoint: "disk",
 		Bucket:   t.TempDir(),
-	})
+	}}
+}
+
+func shouldRunExternalObjectStorageTests(short bool, enabled string) bool {
+	return !short && enabled == "1"
+}
+
+func requireExternalObjectStorageTests(t *testing.T) {
+	t.Helper()
+	if shouldRunExternalObjectStorageTests(testing.Short(), os.Getenv(runExternalObjectStorageTestsEnv)) {
+		return
+	}
+	t.Skipf("external object storage tests require -short=false and %s=1", runExternalObjectStorageTestsEnv)
+}
+
+func externalObjectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []ObjectStorageArguments) {
+	t.Helper()
+	requireExternalObjectStorageTests(t)
 
 	// s3.json
 	content, err := os.ReadFile("s3.json")
@@ -90,19 +106,22 @@ func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []Obje
 				RoleARN   string `json:"role-arn"`
 			}
 
-			if err := json.Unmarshal(content, &config); err == nil {
-				ret = append(ret, ObjectStorageArguments{
-					Name:      "s3.json " + defaultName,
-					Endpoint:  config.Endpoint,
-					Region:    config.Region,
-					KeyID:     config.APIKey,
-					KeySecret: config.APISecret,
-					Bucket:    config.Bucket,
-					RoleARN:   config.RoleARN,
-					KeyPrefix: fmt.Sprintf("%v", rand.Int64()),
-				})
+			if err := json.Unmarshal(content, &config); err != nil {
+				t.Fatalf("parse s3.json: %v", err)
 			}
+			ret = append(ret, ObjectStorageArguments{
+				Name:      "s3.json " + defaultName,
+				Endpoint:  config.Endpoint,
+				Region:    config.Region,
+				KeyID:     config.APIKey,
+				KeySecret: config.APISecret,
+				Bucket:    config.Bucket,
+				RoleARN:   config.RoleARN,
+				KeyPrefix: fmt.Sprintf("%v", rand.Int64()),
+			})
 		}
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("read s3.json: %v", err)
 	}
 
 	// s3_fs_test_new.xml
@@ -112,15 +131,18 @@ func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []Obje
 			XMLName xml.Name               `xml:"Spec"`
 			Cases   []S3CredentialTestCase `xml:"Case"`
 		}
-		if err := xml.Unmarshal(content, &spec); err == nil {
-			for _, kase := range spec.Cases {
-				if kase.Skip {
-					continue
-				}
-				kase.KeyPrefix = fmt.Sprintf("%v", rand.Int64())
-				ret = append(ret, kase.ObjectStorageArguments)
-			}
+		if err := xml.Unmarshal(content, &spec); err != nil {
+			t.Fatalf("parse s3_fs_test_new.xml: %v", err)
 		}
+		for _, kase := range spec.Cases {
+			if kase.Skip {
+				continue
+			}
+			kase.KeyPrefix = fmt.Sprintf("%v", rand.Int64())
+			ret = append(ret, kase.ObjectStorageArguments)
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("read s3_fs_test_new.xml: %v", err)
 	}
 
 	// envs
@@ -141,20 +163,50 @@ func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []Obje
 		reader := csv.NewReader(strings.NewReader(value))
 		argStrs, err := reader.Read()
 		if err != nil {
-			logutil.Warn("bad S3FS test spec", zap.Any("spec", value))
-			continue
+			t.Fatalf("parse %s: %v", name, err)
 		}
 		var args ObjectStorageArguments
 		if err := args.SetFromString(argStrs); err != nil {
-			logutil.Warn("bad S3FS test spec", zap.Any("spec", value))
-			continue
+			t.Fatalf("parse %s: %v", name, err)
 		}
 		args.KeyPrefix = fmt.Sprintf("%v", rand.Int64())
 
 		ret = append(ret, args)
 	}
+	if len(ret) == 0 {
+		t.Fatalf("%s=1 but no external object storage test configuration was found", runExternalObjectStorageTestsEnv)
+	}
 
 	return ret
+}
+
+func TestShouldRunExternalObjectStorageTests(t *testing.T) {
+	testCases := []struct {
+		name    string
+		short   bool
+		enabled string
+		want    bool
+	}{
+		{name: "explicitly enabled", enabled: "1", want: true},
+		{name: "disabled by default"},
+		{name: "short mode wins", short: true, enabled: "1"},
+		{name: "invalid value", enabled: "true"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, shouldRunExternalObjectStorageTests(testCase.short, testCase.enabled))
+		})
+	}
+}
+
+func TestLocalObjectStorageArgumentsIgnoreExternalConfiguration(t *testing.T) {
+	t.Setenv("TEST_S3FS_ALIYUN", "name=aliyun,endpoint=https://127.0.0.1:1,bucket=test,key-id=id,key-secret=secret")
+	args := localObjectStorageArgumentsForTest("test", t)
+	if !assert.Len(t, args, 1) {
+		return
+	}
+	assert.Equal(t, "test", args[0].Name)
+	assert.Equal(t, "disk", args[0].Endpoint)
 }
 
 func TestQCloudRegion(t *testing.T) {

--- a/pkg/fileservice/object_storage_test.go
+++ b/pkg/fileservice/object_storage_test.go
@@ -224,7 +224,16 @@ func testObjectStorageWithParentContext[T ObjectStorage](
 }
 
 func TestObjectStorages(t *testing.T) {
-	for _, args := range objectStorageArgumentsForTest("test", t) {
+	testObjectStorages(t, localObjectStorageArgumentsForTest("test", t))
+}
+
+func TestObjectStoragesExternal(t *testing.T) {
+	testObjectStorages(t, externalObjectStorageArgumentsForTest("test", t))
+}
+
+func testObjectStorages(t *testing.T, testArguments []ObjectStorageArguments) {
+	t.Helper()
+	for _, args := range testArguments {
 
 		t.Run(args.Name, func(t *testing.T) {
 			specCtx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)

--- a/pkg/fileservice/qcloud_sdk_test.go
+++ b/pkg/fileservice/qcloud_sdk_test.go
@@ -35,9 +35,10 @@ import (
 )
 
 func TestQCloudSDK(t *testing.T) {
+	testArguments := externalObjectStorageArgumentsForTest("test", t)
 
 	t.Run("object storage", func(t *testing.T) {
-		for _, args := range objectStorageArgumentsForTest("test", t) {
+		for _, args := range testArguments {
 			if !strings.Contains(args.Endpoint, "myqcloud") {
 				continue
 			}
@@ -62,7 +63,7 @@ func TestQCloudSDK(t *testing.T) {
 	})
 
 	t.Run("file service", func(t *testing.T) {
-		for _, args := range objectStorageArgumentsForTest("test", t) {
+		for _, args := range testArguments {
 			if !strings.Contains(args.Endpoint, "myqcloud") {
 				continue
 			}

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -2659,13 +2659,14 @@ type S3CredentialTestCase struct {
 	ObjectStorageArguments
 }
 
-var s3CredentialTestCases = func() []S3CredentialTestCase {
+func s3CredentialTestCasesForTest(t *testing.T) []S3CredentialTestCase {
+	t.Helper()
 	content, err := os.ReadFile("s3_fs_test_new.xml")
 	if os.IsNotExist(err) {
 		return nil
 	}
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	var spec struct {
 		XMLName xml.Name               `xml:"Spec"`
@@ -2673,12 +2674,14 @@ var s3CredentialTestCases = func() []S3CredentialTestCase {
 	}
 	err = xml.Unmarshal(content, &spec)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	return spec.Cases
-}()
+}
 
 func TestNewS3FSFromSpec(t *testing.T) {
+	requireExternalObjectStorageTests(t)
+	s3CredentialTestCases := s3CredentialTestCasesForTest(t)
 	if len(s3CredentialTestCases) == 0 {
 		t.Skip("no case")
 	}
@@ -2953,8 +2956,16 @@ func BenchmarkS3FSAllocateCacheDataHighCardinality(b *testing.B) {
 }
 
 func TestS3FSFromSpecs(t *testing.T) {
+	testS3FSFromSpecs(t, localObjectStorageArgumentsForTest("test", t))
+}
 
-	for _, args := range objectStorageArgumentsForTest("test", t) {
+func TestS3FSFromExternalSpecs(t *testing.T) {
+	testS3FSFromSpecs(t, externalObjectStorageArgumentsForTest("test", t))
+}
+
+func testS3FSFromSpecs(t *testing.T, testArguments []ObjectStorageArguments) {
+	t.Helper()
+	for _, args := range testArguments {
 
 		t.Run(args.Name, func(t *testing.T) {
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26541

## What this PR does / why we need it:

### Root cause

The fileservice test argument helper mixed the local disk fixture with `s3.json`, `s3_fs_test_new.xml`, and all ambient `TEST_S3FS_*` variables. Consequently, coverage's `go test -short` could execute live Aliyun/QCloud tests whenever credentials were present, so an unrelated external TCP timeout failed the unit-test job.

### Changes

- split local disk and external object-storage argument sources
- retain shared object-storage and S3FS contract assertions while exposing explicit external test entry points
- require both non-short mode and `MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS=1` before external configuration is read or a provider can be contacted
- fail an explicitly enabled external run when its configuration is absent or malformed
- defer XML test configuration loading until the explicitly enabled external test starts

This is test-only: no production API, storage format, retry behavior, or runtime path changes.

### Issue-to-test proof

- `TestShouldRunExternalObjectStorageTests` covers the explicit opt-in contract, disabled default, short-mode precedence, and invalid values.
- `TestLocalObjectStorageArgumentsIgnoreExternalConfiguration` proves a poisoned `TEST_S3FS_ALIYUN` value cannot enter the local tier.
- The focused object-storage run with poisoned Aliyun/QCloud specs pointed at `127.0.0.1:1` executes only the disk fixture and passes in both short and normal modes.
- All external entry points explicitly skip without the opt-in, preventing ambient credentials from reaching a provider.

### Validation

- `TEST_S3FS_ALIYUN=...127.0.0.1:1 .agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -short -run '^(TestShouldRunExternalObjectStorageTests|TestLocalObjectStorageArgumentsIgnoreExternalConfiguration|TestObjectStorages)$' ./pkg/fileservice`
- `TEST_S3FS_ALIYUN=...127.0.0.1:1 .agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^(TestObjectStoragesExternal|TestS3FSFromExternalSpecs|TestNewS3FSFromSpec|TestQCloudSDK)$' ./pkg/fileservice`
- `TEST_S3FS_ALIYUN=...127.0.0.1:1 .agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=120s -run '^TestObjectStorages$' ./pkg/fileservice`
- `CGO_CFLAGS="-I$PWD/cgo -I$PWD/thirdparties/install/include" CGO_LDFLAGS="-L$PWD/thirdparties/install/lib" GOWORK=off go vet -mod=readonly ./pkg/fileservice`
- `git diff --check`

The full short package suite was also attempted with poisoned Aliyun/QCloud specs. It failed in the untouched local `TestMinioSDK/file_service` because the local MinIO process returned `Access Denied`; the same isolated test failed with that error.

### Residual risk

Live provider integration was intentionally not run: it requires a maintained endpoint and explicit credentials. This PR makes that dependency opt-in so provider/network availability can no longer make required unit coverage flaky.

### Landing condition

Do not land this PR alone. Current `matrixorigin/CI` coverage still provides `TEST_S3FS_ALIYUN` and `TEST_S3FS_QCLOUD` only to `go test -short`, so the new external tier would be skipped without a paired CI rollout. Before landing, a `matrixorigin/CI` change must remove provider credentials from coverage and add trusted, provider-isolated, non-short exact-head jobs with `MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS=1`, triggered pre-merge for fileservice/dependency paths and also scheduled/manual.

### Latest rebase validation (2026-09-12)

Rebased onto `e2580f993a5a742f562f3cfcd0f53ca89a9ee373`; head `5c5279f938f408c44d842c1a34bcc317a7c85f69`. No conflicts; `git range-diff` confirms the patch is unchanged and the PR still changes only the four fileservice test files.

The focused native-wrapper suite passed with `-v -count=1 -timeout=180s` in normal mode with `MO_RUN_EXTERNAL_OBJECT_STORAGE_TESTS=0` (2.451s), and in `-short` mode with the opt-in set to `1` (2.065s). Both runs supplied Aliyun/QCloud specs pointing to `http://127.0.0.1:1`. Selection included `TestShouldRunExternalObjectStorageTests`, `TestLocalObjectStorageArgumentsIgnoreExternalConfiguration`, `TestObjectStorages`, `TestS3FSFromSpecs`, and all four external entry points. Local contracts executed and passed; external entry points skipped as required. `git diff --check origin/main...HEAD` passed. No fresh live-provider or full-package pass is claimed.

The coverage-handoff P1 remains unresolved: `matrixorigin/CI@e43e7077e87ebdcefa66b12e3b1778b984cc3ce2` still exports provider specs into short coverage. Implementing the required paired automation needs the CI owners; MatrixOne `.github/workflows/**` and `.github/ci/**` are protected for this task. The landing condition above remains mandatory.

### Paired rollout status (2026-09-15)

- Draft CI implementation: matrixorigin/CI#452. It removes cloud credentials from required short coverage and adds the reusable, provider-isolated non-short job.
- Draft MatrixOne caller: #28899. It provides the trusted exact-head, path-filtered, scheduled/manual trigger.
- Required merge order remains: CI #452, then #28899, then rerun this PR's exact head against the new provider tier.

The existing P1 stays unresolved until those two supporting changes land and this PR demonstrates that the provider contracts actually execute.