### PR TITLE
fix(dml): preserve join scope for indexed deletes

### DIFF
--- a/pkg/sql/plan/bind_delete.go
+++ b/pkg/sql/plan/bind_delete.go
@@ -56,6 +56,20 @@ func canDeleteRewriteToTruncate(ctx CompilerContext, dmlCtx *DMLContext) (bool, 
 	return true, nil
 }
 
+// isUnrestrictedDelete reports whether the statement targets every row of one
+// table without evaluating a row-producing or row-filtering clause.  Keep this
+// semantic classification separate from the physical truncate checks: foreign
+// keys, partitions, session settings, and RETURNING can still prevent a
+// truncate implementation for an otherwise unrestricted delete.
+func isUnrestrictedDelete(stmt *tree.Delete, targetCount int) bool {
+	return stmt != nil &&
+		targetCount == 1 &&
+		stmt.Where == nil &&
+		stmt.Limit == nil &&
+		len(stmt.TableRefs) == 0 &&
+		len(stmt.PartitionNames) == 0
+}
+
 func (builder *QueryBuilder) bindDelete(ctx CompilerContext, stmt *tree.Delete, bindCtx *BindContext) (int32, error) {
 	if len(stmt.Tables) != 1 {
 		return 0, moerr.NewUnsupportedDML(builder.GetContext(), "delete from multiple tables")
@@ -84,7 +98,7 @@ func (builder *QueryBuilder) bindDelete(ctx CompilerContext, stmt *tree.Delete, 
 	}
 
 	//FIXME: optimize truncate table?
-	if !stmt.HasReturning() && stmt.Where == nil && stmt.Limit == nil && len(stmt.TableRefs) == 0 {
+	if !stmt.HasReturning() && isUnrestrictedDelete(stmt, len(dmlCtx.tableDefs)) {
 		var cantrucate bool
 		cantrucate, err = canDeleteRewriteToTruncate(ctx, dmlCtx)
 		if err != nil {

--- a/pkg/sql/plan/build_delete.go
+++ b/pkg/sql/plan/build_delete.go
@@ -69,8 +69,8 @@ func buildDelete(stmt *tree.Delete, ctx CompilerContext, isPrepareStmt bool) (*P
 	beginIdx := 0
 	// needLockTable := !tblInfo.isMulti && stmt.Where == nil && stmt.Limit == nil
 	// todo will do not lock table now.
-	isDeleteWithoutFilters := !tblInfo.isMulti && stmt.Where == nil && stmt.Limit == nil
-	needLockTable := isDeleteWithoutFilters
+	unrestrictedDelete := isUnrestrictedDelete(stmt, len(tblInfo.tableDefs))
+	needLockTable := unrestrictedDelete
 	for i, tableDef := range tblInfo.tableDefs {
 		deleteBindCtx := NewBindContext(builder, nil)
 		delPlanCtx := getDmlPlanCtx()
@@ -85,7 +85,7 @@ func buildDelete(stmt *tree.Delete, ctx CompilerContext, isPrepareStmt bool) (*P
 		delPlanCtx.allDelTableIDs = allDelTableIDs
 		delPlanCtx.allDelTables = allDelTables
 		delPlanCtx.lockTable = needLockTable
-		delPlanCtx.isDeleteWithoutFilters = isDeleteWithoutFilters
+		delPlanCtx.isUnrestrictedDelete = unrestrictedDelete
 
 		lastNodeId = appendSinkScanNode(builder, deleteBindCtx, sourceStep)
 		lastNodeId, err = makePreUpdateDeletePlan(ctx, builder, deleteBindCtx, delPlanCtx, lastNodeId)

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -102,19 +102,21 @@ type dmlPlanCtx struct {
 	// and an isnotnull(row_id) filter for join-target NULL-row protection. After
 	// an upstream row_number() window handles the dedup (dedupByRowNumber) only
 	// the aggregation is skipped; the NULL-row filter must stay.
-	needAggFilter          bool
-	dedupByRowNumber       bool
-	updateColLength        int
-	rowIdPos               int
-	insertColPos           []int
-	updateColPosMap        map[string]int
-	allDelTableIDs         map[uint64]struct{}
-	allDelTables           map[FkReferKey]struct{}
-	isFkRecursionCall      bool //if update plan was recursion called by parent table( ref foreign key), we do not check parent's foreign key contraint
-	lockTable              bool //we need lock table in stmt: delete from tbl
-	updatePkCol            bool //if update stmt will update the primary key or one of pks
-	pkFilterExprs          []*Expr
-	isDeleteWithoutFilters bool
+	needAggFilter     bool
+	dedupByRowNumber  bool
+	updateColLength   int
+	rowIdPos          int
+	insertColPos      []int
+	updateColPosMap   map[string]int
+	allDelTableIDs    map[uint64]struct{}
+	allDelTables      map[FkReferKey]struct{}
+	isFkRecursionCall bool //if update plan was recursion called by parent table( ref foreign key), we do not check parent's foreign key contraint
+	lockTable         bool //we need lock table in stmt: delete from tbl
+	updatePkCol       bool //if update stmt will update the primary key or one of pks
+	pkFilterExprs     []*Expr
+	// isUnrestrictedDelete means the statement semantically selects the entire
+	// target table. Physical truncate eligibility is decided separately.
+	isUnrestrictedDelete bool
 	// skipTargetDelete reuses the parent-reference action planner for a row set
 	// whose base-table delete is owned by another operator (modern REPLACE).
 	// Recursive child actions still build their normal delete/update branches.
@@ -1027,7 +1029,7 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 	// Refer to this PR:https://github.com/matrixorigin/matrixone/pull/12093
 	// we have build SK using UK code path. So we might see UK in function signature even thought it could be for
 	// both UK and SK. To handle SK case, we will have flags to indicate if it's UK or SK.
-	canTruncate := delCtx.isDeleteWithoutFilters
+	canTruncate := delCtx.isUnrestrictedDelete
 
 	enabled, err := IsForeignKeyChecksEnabled(ctx)
 	if err != nil {
@@ -5974,7 +5976,7 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 			var entriesTblPkPos int
 			var entriesTblPkTyp Type
 
-			if delCtx.isDeleteWithoutFilters {
+			if delCtx.isUnrestrictedDelete {
 				lastNodeId, err = appendDeleteIndexTablePlanWithoutFilters(builder, bindCtx, entriesObjRef, entriesTableDef)
 				entriesDeleteIdx = getRowIdPos(entriesTableDef)
 				entriesTblPkPos, entriesTblPkTyp = getPkPos(entriesTableDef, false)
@@ -6257,7 +6259,7 @@ func buildDeleteRegularIndex(ctx CompilerContext, builder *QueryBuilder, bindCtx
 	var uniqueTblPkPos int
 	var uniqueTblPkTyp Type
 
-	if delCtx.isDeleteWithoutFilters {
+	if delCtx.isUnrestrictedDelete {
 		lastNodeId, err = appendDeleteIndexTablePlanWithoutFilters(builder, bindCtx, uniqueObjRef, uniqueTableDef)
 		uniqueDeleteIdx = getRowIdPos(uniqueTableDef)
 		uniqueTblPkPos, uniqueTblPkTyp = getPkPos(uniqueTableDef, false)
@@ -6463,7 +6465,7 @@ func buildDeleteMasterIndex(ctx CompilerContext, builder *QueryBuilder, bindCtx 
 	var masterTblPkPos int
 	var masterTblPkTyp Type
 
-	if delCtx.isDeleteWithoutFilters {
+	if delCtx.isUnrestrictedDelete {
 		lastNodeId, err = appendDeleteIndexTablePlanWithoutFilters(builder, bindCtx, masterObjRef, masterTableDef)
 		masterDeleteIdx = getRowIdPos(masterTableDef)
 		masterTblPkPos, masterTblPkTyp = getPkPos(masterTableDef, false)
@@ -6647,7 +6649,7 @@ func buildDeleteIndexPlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *
 	// both UK and SK. To handle SK case, we will have flags to indicate if it's UK or SK.
 	hasUniqueKey := haveUniqueKey(delCtx.tableDef)
 	hasSecondaryKey := haveSecondaryKey(delCtx.tableDef)
-	canTruncate := delCtx.isDeleteWithoutFilters
+	canTruncate := delCtx.isUnrestrictedDelete
 
 	accountId, err := ctx.GetAccountId()
 	if err != nil {
@@ -6988,7 +6990,7 @@ func buildPreInsertFullTextIndex(stmt *tree.Insert, ctx CompilerContext, builder
 func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindContext, delCtx *dmlPlanCtx,
 	indexObjRef *ObjectRef, indexTableDef *TableDef, indexdef *plan.IndexDef, typMap map[string]plan.Type, posMap map[string]int) (int32, int, int, Type, error) {
 
-	if delCtx.isDeleteWithoutFilters {
+	if delCtx.isUnrestrictedDelete {
 		// truncate and create a table scan of index table
 
 		scanNodeProject := make([]*Expr, len(indexTableDef.Cols))
@@ -7324,7 +7326,7 @@ func buildPostDeleteFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 	}
 
 	return buildPostDmlFullTextIndex(ctx, builder, bindCtx, indexObjRef, indexTableDef, delCtx.tableDef,
-		delCtx.sourceStep, indexdef, idx, isDelete, isInsert, delCtx.isDeleteWithoutFilters)
+		delCtx.sourceStep, indexdef, idx, isDelete, isInsert, delCtx.isUnrestrictedDelete)
 }
 
 // Post Insert FullText Index to use PostDml node to save INSERT SQL and execute after the pipelines

--- a/pkg/sql/plan/delete_scope_test.go
+++ b/pkg/sql/plan/delete_scope_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUnrestrictedDelete(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		targetCount int
+		want        bool
+	}{
+		{name: "plain", sql: "delete from t", targetCount: 1, want: true},
+		{name: "order only", sql: "delete from t order by a", targetCount: 1, want: true},
+		{name: "where", sql: "delete from t where true", targetCount: 1},
+		{name: "limit zero", sql: "delete from t limit 0", targetCount: 1},
+		{name: "join without where", sql: "delete t from t join s on t.a = s.a", targetCount: 1},
+		{name: "using without where", sql: "delete from t using t join s on t.a = s.a", targetCount: 1},
+		{name: "partition", sql: "delete from t partition (p0)", targetCount: 1},
+		{name: "multiple targets", sql: "delete t, s from t join s on t.a = s.a", targetCount: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stmt, err := mysql.ParseOne(t.Context(), test.sql, 1)
+			require.NoError(t, err)
+			defer stmt.Free()
+			deleteStmt, ok := stmt.(*tree.Delete)
+			require.True(t, ok)
+			require.Equal(t, test.want, isUnrestrictedDelete(deleteStmt, test.targetCount))
+		})
+	}
+
+	require.False(t, isUnrestrictedDelete(nil, 1))
+}
+
+func TestIrregularIndexDeleteJoinIsRowScoped(t *testing.T) {
+	logicPlan, err := runOneStmt(
+		NewMockOptimizer(true),
+		t,
+		"delete d from constraint_test.docs_ft d join constraint_test.dept s on d.id = s.deptno",
+	)
+	require.NoError(t, err)
+
+	query := logicPlan.GetQuery()
+	require.NotNil(t, query)
+
+	var originDelete *planpb.Node
+	fulltextDeleteCount := 0
+	for _, node := range query.Nodes {
+		if node.NodeType != planpb.Node_DELETE || node.DeleteCtx == nil || node.DeleteCtx.TableDef == nil {
+			continue
+		}
+		switch node.DeleteCtx.TableDef.Name {
+		case "docs_ft":
+			originDelete = node
+		case catalog.FullTextIndexTableNamePrefix + "docs_ft_body":
+			fulltextDeleteCount++
+		}
+	}
+
+	require.NotNil(t, originDelete, "missing origin-table delete")
+	require.False(t, originDelete.DeleteCtx.CanTruncate, "a join must be evaluated before deleting target rows")
+	require.Equal(t, 1, fulltextDeleteCount, "row-scoped fulltext maintenance must not be skipped")
+}

--- a/test/distributed/cases/dml/delete/delete_multiple_table.result
+++ b/test/distributed/cases/dml/delete/delete_multiple_table.result
@@ -215,6 +215,40 @@ select count(*) from tj_c;
 1
 drop table tj_c;
 drop table tj_d;
+create table tj_ft (
+id int primary key,
+body text,
+fulltext ft_body(body)
+);
+create table tj_ft_src (id int);
+insert into tj_ft values
+(1, 'join survivor alpha'),
+(2, 'join match beta'),
+(3, 'join survivor gamma');
+set delete_opt_to_truncate = 0;
+delete d from tj_ft d join tj_ft_src s on d.id = s.id;
+select id from tj_ft order by id;
+➤ id[4,32,0]  𝄀
+1  𝄀
+2  𝄀
+3
+select id from tj_ft where match(body) against('alpha') order by id;
+➤ id[4,32,0]  𝄀
+1
+set delete_opt_to_truncate = 1;
+insert into tj_ft_src values (2), (2);
+delete d from tj_ft d join tj_ft_src s on d.id = s.id;
+select id from tj_ft order by id;
+➤ id[4,32,0]  𝄀
+1  𝄀
+3
+select id from tj_ft where match(body) against('beta') order by id;
+➤ id[4,32,0]
+select id from tj_ft where match(body) against('gamma') order by id;
+➤ id[4,32,0]  𝄀
+3
+drop table tj_ft;
+drop table tj_ft_src;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t3;

--- a/test/distributed/cases/dml/delete/delete_multiple_table.sql
+++ b/test/distributed/cases/dml/delete/delete_multiple_table.sql
@@ -168,6 +168,36 @@ select count(*) from tj_c;
 drop table tj_c;
 drop table tj_d;
 
+-- Regression for #28309: a target with an irregular index takes the legacy
+-- DML planner. JOIN predicates must still define the delete set when WHERE is
+-- absent. Disabling truncate also proves that index maintenance does not use
+-- an independent delete-all shortcut.
+create table tj_ft (
+    id int primary key,
+    body text,
+    fulltext ft_body(body)
+);
+create table tj_ft_src (id int);
+insert into tj_ft values
+    (1, 'join survivor alpha'),
+    (2, 'join match beta'),
+    (3, 'join survivor gamma');
+
+set delete_opt_to_truncate = 0;
+delete d from tj_ft d join tj_ft_src s on d.id = s.id;
+select id from tj_ft order by id;
+select id from tj_ft where match(body) against('alpha') order by id;
+
+set delete_opt_to_truncate = 1;
+insert into tj_ft_src values (2), (2);
+delete d from tj_ft d join tj_ft_src s on d.id = s.id;
+select id from tj_ft order by id;
+select id from tj_ft where match(body) against('beta') order by id;
+select id from tj_ft where match(body) against('gamma') order by id;
+
+drop table tj_ft;
+drop table tj_ft_src;
+
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t3;
@@ -210,4 +240,3 @@ select count(*) from tj_part_c;
 
 drop table tj_part_c;
 drop table tj_part_d;
-


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug

## What this PR does / why we need it

Irregular indexes currently route `DELETE` through the legacy DML planner. That planner classified every single-target statement without `WHERE`/`LIMIT` as an unrestricted whole-table delete, even when `TableRefs` contained a JOIN or USING source. The resulting plan could truncate the base table or independently delete every hidden-index row without evaluating the join.

This change establishes one shared semantic predicate for an unrestricted delete: exactly one target, no WHERE, no LIMIT, no additional table references, and no partition restriction. Both modern truncate rewriting and the legacy fallback use that predicate. Physical truncate eligibility remains a separate decision for RETURNING, foreign keys, partitions, session settings, and other table metadata.

The internal flag is renamed to `isUnrestrictedDelete` so all base-table, regular-index, IVF, MASTER, FULLTEXT, and POSTDML consumers express the actual contract.

Closes #28309.

## Test plan

### Automated

- Planner UT covers plain DELETE, ORDER BY-only, WHERE, LIMIT 0, JOIN, USING, partition restriction, multiple targets, and nil input.
- Planner shape UT forces the synchronous FULLTEXT legacy fallback and asserts the origin DELETE cannot truncate and row-scoped hidden-index maintenance is retained.
- Distributed SQL regression covers:
  - empty JOIN with `delete_opt_to_truncate=0`, verifying both base rows and FULLTEXT contents survive;
  - duplicate matches with truncate enabled, verifying one target row is deleted once and surviving/deleted FULLTEXT terms agree with the base table.

### Validation

Linux/amd64 on 10.222.1.55, base `4fdb9e91615f9fc37703039ae28a47849206d1d6`, head `6c8f7fbe3c`:

- `make clean && make -j12`
- focused planner UT: pass
- focused planner UT with `-race`: pass
- `./pkg/sql/plan` and `./pkg/sql/colexec/postdml`: pass
- `delete_multiple_table.sql` through mo-tester normal comparison mode twice on the same instance: 128 pass, 0 fail, 2 pre-existing ignored (100%); 1.283s and 1.487s
- black-box FULLTEXT matrix: empty source, ON false, CROSS/RIGHT/LEFT JOIN, NULL key, derived empty source, USING, WHERE TRUE control, prepared-statement reuse, and duplicate matches: pass
- black-box MASTER hidden-table counts: empty JOIN 6 -> 6; partial duplicate match 6 -> 4 while base rows 3 -> 2
- full repository `golangci-lint` 2.6.2: 0 issues
- license header check: 5106 checked, 0 invalid
- `git diff --check` and gofmt: pass

The 55 test service and isolated data were removed after validation.