### PR TITLE
fix(frontend): order composite lineage lifecycle locks

### DIFF
--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -400,13 +400,26 @@ func restartCloneDatabaseTargetLockTxn(ctx context.Context, bh BackgroundExec) (
 	if locked, _ := ctx.Value(dataBranchCloneLockCtxKey{}).(bool); locked {
 		return false, nil
 	}
-	if err := bh.Exec(ctx, "rollback;"); err != nil {
-		return false, err
-	}
-	if err := bh.Exec(ctx, "begin;"); err != nil {
+	if err := restartOwnedCloneDatabaseTargetLockTxn(ctx, bh); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func restartOwnedCloneDatabaseTargetLockTxn(ctx context.Context, bh BackgroundExec) error {
+	if err := bh.Exec(ctx, "rollback;"); err != nil {
+		return err
+	}
+	if err := bh.Exec(ctx, "begin;"); err != nil {
+		return err
+	}
+	// The caller entered the lineage lifecycle before taking the target key.
+	// Re-enter it after replacing the owned transaction so the retry cannot
+	// continue with target/catalog locks but without the leading gate.
+	if err := lockDataBranchLineageOwnerLifecycle(ctx, bh); err != nil {
+		return err
+	}
+	return nil
 }
 
 func newDataBranchCloneLockProcess(
@@ -812,10 +825,11 @@ func handleCloneTable(
 	}
 
 	if bh == nil {
-		// do not open another transaction,
-		// if the clone already executed within a transaction.
-		if bh, deferred, err = getBackExecutor(
-			reqCtx, ses, &BackgroundExecOption{forcePessimisticRC: true},
+		// Public clone owns this transaction. Admit it before source/target
+		// resolution because nested restore DDL can cross both lineage and
+		// view-metadata lifecycle gates.
+		if bh, deferred, err = getCloneMutationExecutor(
+			reqCtx, ses, false, &BackgroundExecOption{forcePessimisticRC: true},
 		); err != nil {
 			return
 		}
@@ -1074,7 +1088,7 @@ func handleCloneDatabaseWithSource(
 			// re-checks the target with that fresh snapshot.
 			options[0].cloneSnapshotUsesBackgroundTxn = true
 		}
-		if bh, deferred, err = getBackExecutorWithTxnHandler(reqCtx, ses, options...); err != nil {
+		if bh, deferred, err = getCloneMutationExecutor(reqCtx, ses, true, options...); err != nil {
 			return
 		}
 

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -1137,6 +1137,52 @@ func TestIsCloneDatabaseTargetLockRetry(t *testing.T) {
 	require.False(t, isCloneDatabaseTargetLockRetry(errors.New("not retryable")))
 }
 
+func TestRestartOwnedCloneDatabaseTargetLockTxnReentersLifecycle(t *testing.T) {
+	gateSQL := databranchutils.LineageOwnerLifecycleLockSQL()
+	for _, test := range []struct {
+		name      string
+		failedSQL string
+		wantSQLs  []string
+	}{
+		{
+			name:     "success",
+			wantSQLs: []string{"rollback;", "begin;", gateSQL},
+		},
+		{
+			name:      "rollback failure",
+			failedSQL: "rollback;",
+			wantSQLs:  []string{"rollback;"},
+		},
+		{
+			name:      "begin failure",
+			failedSQL: "begin;",
+			wantSQLs:  []string{"rollback;", "begin;"},
+		},
+		{
+			name:      "lifecycle failure",
+			failedSQL: gateSQL,
+			wantSQLs:  []string{"rollback;", "begin;", gateSQL},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bh := &backgroundExecTestWithHistory{}
+			bh.init()
+			wantErr := errors.New("restart failed")
+			if test.failedSQL != "" {
+				bh.sql2err[test.failedSQL] = wantErr
+			}
+
+			err := restartOwnedCloneDatabaseTargetLockTxn(context.Background(), bh)
+			if test.failedSQL == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, wantErr)
+			}
+			require.Equal(t, test.wantSQLs, bh.executedSqls)
+		})
+	}
+}
+
 func Test_prepareCloneViewSnapshot(t *testing.T) {
 	original := &plan.Snapshot{
 		Tenant: &plan.SnapshotTenant{TenantID: 1001},

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -489,11 +489,54 @@ func getDataBranchMutationExecutor(
 	opts ...*BackgroundExecOption,
 ) (BackgroundExec, func(error) error, error) {
 	explicitTxn := ses.proc.GetTxnOperator().TxnOptions().ByBegin
-	bh, deferred, err := getBackExecutor(ctx, ses, opts...)
+	return getLineageOwnerMutationExecutor(
+		ctx, ses, featureLimited, explicitTxn, true, getBackExecutor, opts...,
+	)
+}
+
+type backgroundExecutorFactory func(
+	context.Context,
+	*Session,
+	...*BackgroundExecOption,
+) (BackgroundExec, func(error) error, error)
+
+func getCloneMutationExecutor(
+	ctx context.Context,
+	ses *Session,
+	useTxnHandler bool,
+	opts ...*BackgroundExecOption,
+) (BackgroundExec, func(error) error, error) {
+	if useTxnHandler {
+		return getLineageOwnerMutationExecutor(
+			ctx, ses, false,
+			ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN), false,
+			getBackExecutorWithTxnHandler, opts...,
+		)
+	}
+	return getLineageOwnerMutationExecutor(
+		ctx, ses, false,
+		ses.proc.GetTxnOperator().TxnOptions().ByBegin, false,
+		getBackExecutor, opts...,
+	)
+}
+
+func getLineageOwnerMutationExecutor(
+	ctx context.Context,
+	ses *Session,
+	featureLimited bool,
+	explicitTxn bool,
+	validateExplicitTxn bool,
+	factory backgroundExecutorFactory,
+	opts ...*BackgroundExecOption,
+) (BackgroundExec, func(error) error, error) {
+	bh, deferred, err := factory(ctx, ses, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
 	if explicitTxn {
+		if !validateExplicitTxn {
+			return bh, deferred, nil
+		}
 		// Preserve DATA BRANCH's transactional SQL contract without letting a
 		// client-controlled transaction own the global row after this statement.
 		// Successful owner-catalog work is validated with fast-fail admission at
@@ -888,25 +931,6 @@ func diffMergeAgency(
 		return err
 	}
 
-	// do not open another transaction,
-	// if this already executed within a transaction.
-	if bh, deferred, err = getBackExecutor(execCtx.reqCtx, ses); err != nil {
-		return
-	}
-
-	defer func() {
-		if deferred != nil {
-			err = deferred(err)
-		}
-	}()
-
-	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-	)
-
-	ctx, cancel = context.WithCancel(execCtx.reqCtx)
-
 	var (
 		dagInfo   branchMetaInfo
 		tblStuff  tableStuff
@@ -917,10 +941,6 @@ func diffMergeAgency(
 		pickStmt  *tree.DataBranchPick
 	)
 
-	defer func() {
-		cancel()
-	}()
-
 	if diffStmt, ok = stmt.(*tree.DataBranchDiff); !ok {
 		if mergeStmt, ok = stmt.(*tree.DataBranchMerge); !ok {
 			if pickStmt, ok = stmt.(*tree.DataBranchPick); !ok {
@@ -928,6 +948,23 @@ func diffMergeAgency(
 			}
 		}
 	}
+
+	// DIFF, PICK, and MERGE all create and drop apply tables. Enter the
+	// lineage-owner lifecycle before resolving either endpoint, so their nested
+	// DDL follows the same lineage -> view-metadata -> object lock order as
+	// ordinary DROP, clone, and restore paths.
+	bh, deferred, err = getDataBranchMutationExecutor(execCtx.reqCtx, ses, false)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if deferred != nil {
+			err = deferred(err)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(execCtx.reqCtx)
+	defer cancel()
 
 	if diffStmt != nil {
 		if diffStmt.OutputOpt != nil && len(diffStmt.OutputOpt.DirPath) != 0 {

--- a/pkg/frontend/data_branch_lineage_lock_test.go
+++ b/pkg/frontend/data_branch_lineage_lock_test.go
@@ -169,6 +169,31 @@ func TestGetDataBranchMutationExecutorAdmitsBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestGetCloneMutationExecutorAdmitsBeforeClone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ses := newTestSession(t, ctrl)
+	t.Cleanup(ses.Close)
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().TxnOptions().Return(txn.TxnOptions{}).Times(2)
+	ses.proc.Base.TxnOperator = txnOp
+
+	bh := &backgroundExecTestWithHistory{}
+	bh.init()
+	stub := gostub.StubFunc(&NewBackgroundExec, bh)
+	t.Cleanup(stub.Reset)
+
+	returned, cleanup, err := getCloneMutationExecutor(context.Background(), ses, false)
+	require.NoError(t, err)
+	require.Same(t, bh, returned)
+	require.NotNil(t, cleanup)
+	require.Equal(t, []string{
+		"begin",
+		databranchutils.LineageOwnerLifecycleLockSQL(),
+	}, bh.executedSqls)
+	require.NoError(t, cleanup(nil))
+	require.Equal(t, "commit;", bh.executedSqls[len(bh.executedSqls)-1])
+}
+
 func TestGetDataBranchMutationExecutorRollsBackOnAdmissionFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ses := newTestSession(t, ctrl)

--- a/pkg/tests/issues/issue_26404_test.go
+++ b/pkg/tests/issues/issue_26404_test.go
@@ -1,0 +1,417 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
+	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue26404MixedDataBranchLifecycleDoesNotDeadlock(t *testing.T) {
+	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cn0, err := c.GetCNService(0)
+		require.NoError(t, err)
+		cn1, err := c.GetCNService(1)
+		require.NoError(t, err)
+		openDB := func(port int64) *sql.DB {
+			db, openErr := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
+			require.NoError(t, openErr)
+			db.SetMaxOpenConns(1)
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			return db
+		}
+		pickDB := openDB(cn0.GetServiceConfig().CN.Frontend.Port)
+		holderDB := openDB(cn1.GetServiceConfig().CN.Frontend.Port)
+		dropDB := openDB(cn1.GetServiceConfig().CN.Frontend.Port)
+
+		t.Run("database clone", func(t *testing.T) {
+			runIssue26404CloneLifecycleOrderScenario(t, ctx, c, pickDB, holderDB)
+		})
+		t.Run("diff", func(t *testing.T) {
+			runIssue26404DiffLifecycleOrderScenario(t, ctx, c, pickDB, holderDB)
+		})
+		for _, operation := range []string{"pick", "merge"} {
+			t.Run(operation, func(t *testing.T) {
+				runIssue26404LifecycleOrderScenario(
+					t, ctx, c, pickDB, holderDB, dropDB, operation,
+				)
+			})
+		}
+	})
+}
+
+func runIssue26404CloneLifecycleOrderScenario(
+	t *testing.T,
+	ctx context.Context,
+	c embed.Cluster,
+	cloneDB *sql.DB,
+	holderDB *sql.DB,
+) {
+	const (
+		sourceDB = "issue_26404_clone_source"
+		targetDB = "issue_26404_clone_target"
+		otherDB  = "issue_26404_clone_unrelated"
+	)
+	cleanup := func(cleanupCtx context.Context) {
+		execSQLMaybe(t, cleanupCtx, cloneDB, "drop database if exists `"+targetDB+"`")
+		execSQLMaybe(t, cleanupCtx, cloneDB, "drop database if exists `"+otherDB+"`")
+		execSQLMaybe(t, cleanupCtx, cloneDB, "drop database if exists `"+sourceDB+"`")
+	}
+	cleanup(ctx)
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		cleanup(cleanupCtx)
+	}()
+
+	execSQLRequire(t, ctx, cloneDB, "create database `"+sourceDB+"`")
+	execSQLRequire(t, ctx, cloneDB, "create database `"+otherDB+"`")
+	execSQLRequire(t, ctx, cloneDB,
+		"create table `"+sourceDB+"`.`docs` (id int primary key, body text)")
+	execSQLRequire(t, ctx, cloneDB,
+		"insert into `"+sourceDB+"`.`docs` values (1, 'matrixone branch regression')")
+	execSQLRequire(t, ctx, cloneDB,
+		"create fulltext index `ft_body` on `"+sourceDB+"`.`docs` (`body`)")
+	execSQLRequire(t, ctx, cloneDB,
+		"create view `"+sourceDB+"`.`docs_view` as select id, body from `"+sourceDB+"`.`docs`")
+
+	holder, featureRegistryID := lockIssue26404LineageGate(t, ctx, cloneDB, holderDB)
+
+	operationCtx, cancelOperation := context.WithCancel(ctx)
+	clone := startIssue26404Operation(operationCtx, func(operationCtx context.Context) error {
+		_, operationErr := cloneDB.ExecContext(operationCtx,
+			"create database `"+targetDB+"` clone `"+sourceDB+"`")
+		return operationErr
+	})
+	defer func() {
+		cancelOperation()
+		joinCtx, joinCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer joinCancel()
+		if joinErr := clone.join(joinCtx); joinErr != nil {
+			t.Errorf("database clone did not stop: %v", joinErr)
+		}
+	}()
+	require.Eventually(t, func() bool {
+		return issue26404WaiterCount(c, featureRegistryID) > 0
+	}, 30*time.Second, 10*time.Millisecond,
+		"database clone did not wait at the lineage gate")
+	require.False(t, clone.completed(), "database clone returned before the lineage gate was released")
+
+	// This DROP takes the same global lineage -> catalog path as the mixed
+	// workload. It must finish while the clone is still waiting at lineage;
+	// a clone that reached catalog first closes the original two-transaction cycle.
+	_, err := holder.ExecContext(ctx, "drop database `"+otherDB+"`")
+	require.NoError(t, err)
+	require.NoError(t, holder.Commit())
+	finishCtx, finishCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer finishCancel()
+	require.NoError(t, clone.wait(finishCtx))
+
+	var clonedRows int
+	require.NoError(t, cloneDB.QueryRowContext(ctx,
+		"select count(*) from `"+targetDB+"`.`docs_view`").Scan(&clonedRows))
+	require.Equal(t, 1, clonedRows)
+	var databaseCount int
+	require.NoError(t, cloneDB.QueryRowContext(ctx,
+		"select count(*) from mo_catalog.mo_database where account_id=0 and datname=?", otherDB,
+	).Scan(&databaseCount))
+	require.Zero(t, databaseCount)
+}
+
+func runIssue26404DiffLifecycleOrderScenario(
+	t *testing.T,
+	ctx context.Context,
+	c embed.Cluster,
+	diffDB *sql.DB,
+	holderDB *sql.DB,
+) {
+	const (
+		branchDB = "issue_26404_diff_branch"
+		otherDB  = "issue_26404_diff_unrelated"
+	)
+	cleanup := func(cleanupCtx context.Context) {
+		execSQLMaybe(t, cleanupCtx, diffDB, "drop database if exists `"+otherDB+"`")
+		execSQLMaybe(t, cleanupCtx, diffDB, "drop database if exists `"+branchDB+"`")
+	}
+	cleanup(ctx)
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		cleanup(cleanupCtx)
+	}()
+
+	execSQLRequire(t, ctx, diffDB, "create database `"+branchDB+"`")
+	execSQLRequire(t, ctx, diffDB, "create database `"+otherDB+"`")
+	execSQLRequire(t, ctx, diffDB,
+		"create table `"+branchDB+"`.`base` (id int primary key, value int)")
+	execSQLRequire(t, ctx, diffDB,
+		"insert into `"+branchDB+"`.`base` values (1, 10), (2, 20)")
+	execSQLRequire(t, ctx, diffDB,
+		"data branch create table `"+branchDB+"`.`child` from `"+branchDB+"`.`base`")
+	execSQLRequire(t, ctx, diffDB,
+		"update `"+branchDB+"`.`child` set value = 200 where id = 2")
+
+	holder, featureRegistryID := lockIssue26404LineageGate(t, ctx, diffDB, holderDB)
+
+	operationCtx, cancelOperation := context.WithCancel(ctx)
+	var diffCount int
+	diff := startIssue26404Operation(operationCtx, func(operationCtx context.Context) error {
+		return diffDB.QueryRowContext(operationCtx,
+			"data branch diff `"+branchDB+"`.`child` against `"+branchDB+"`.`base` output count",
+		).Scan(&diffCount)
+	})
+	defer func() {
+		cancelOperation()
+		joinCtx, joinCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer joinCancel()
+		if joinErr := diff.join(joinCtx); joinErr != nil {
+			t.Errorf("Data Branch DIFF did not stop: %v", joinErr)
+		}
+	}()
+	require.Eventually(t, func() bool {
+		return issue26404WaiterCount(c, featureRegistryID) > 0
+	}, 30*time.Second, 10*time.Millisecond,
+		"Data Branch DIFF did not wait at the lineage gate")
+	require.False(t, diff.completed(), "Data Branch DIFF returned before the lineage gate was released")
+
+	_, err := holder.ExecContext(ctx, "drop database `"+otherDB+"`")
+	require.NoError(t, err)
+	require.NoError(t, holder.Commit())
+	finishCtx, finishCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer finishCancel()
+	require.NoError(t, diff.wait(finishCtx))
+	require.Equal(t, 1, diffCount)
+
+	var databaseCount int
+	require.NoError(t, diffDB.QueryRowContext(ctx,
+		"select count(*) from mo_catalog.mo_database where account_id=0 and datname=?", otherDB,
+	).Scan(&databaseCount))
+	require.Zero(t, databaseCount)
+}
+
+func lockIssue26404LineageGate(
+	t *testing.T,
+	ctx context.Context,
+	lookupDB *sql.DB,
+	holderDB *sql.DB,
+) (*sql.Tx, uint64) {
+	var featureRegistryID uint64
+	require.NoError(t, lookupDB.QueryRowContext(ctx,
+		"select rel_id from mo_catalog.mo_tables where account_id=0 and reldatabase='mo_catalog' and relname='mo_feature_registry'",
+	).Scan(&featureRegistryID))
+
+	holder, err := holderDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = holder.Rollback() })
+	_, err = holder.ExecContext(ctx,
+		"select feature_code from mo_catalog.mo_feature_registry "+
+			"where feature_code='SNAPSHOT' for update")
+	require.NoError(t, err)
+	return holder, featureRegistryID
+}
+
+func runIssue26404LifecycleOrderScenario(
+	t *testing.T,
+	ctx context.Context,
+	c embed.Cluster,
+	mutationDB *sql.DB,
+	holderDB *sql.DB,
+	dropDB *sql.DB,
+	operation string,
+) {
+	branchDB := "issue_26404_" + operation + "_branch"
+	otherDB := "issue_26404_" + operation + "_unrelated"
+	cleanup := func(cleanupCtx context.Context) {
+		execSQLMaybe(t, cleanupCtx, mutationDB, "drop database if exists `"+otherDB+"`")
+		execSQLMaybe(t, cleanupCtx, mutationDB, "drop database if exists `"+branchDB+"`")
+	}
+	cleanup(ctx)
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		cleanup(cleanupCtx)
+	}()
+
+	execSQLRequire(t, ctx, mutationDB, "create database `"+branchDB+"`")
+	execSQLRequire(t, ctx, mutationDB, "create database `"+otherDB+"`")
+	execSQLRequire(t, ctx, mutationDB,
+		"create table `"+branchDB+"`.`base` (id int primary key, value int)")
+	execSQLRequire(t, ctx, mutationDB,
+		"insert into `"+branchDB+"`.`base` values (1, 10), (2, 20)")
+	execSQLRequire(t, ctx, mutationDB,
+		"data branch create table `"+branchDB+"`.`dst` from `"+branchDB+"`.`base`")
+	execSQLRequire(t, ctx, mutationDB,
+		"data branch create table `"+branchDB+"`.`src` from `"+branchDB+"`.`base`")
+	execSQLRequire(t, ctx, mutationDB,
+		"update `"+branchDB+"`.`src` set value = 200 where id = 2")
+
+	var destinationTableID, featureRegistryID uint64
+	require.NoError(t, mutationDB.QueryRowContext(ctx,
+		"select rel_id from mo_catalog.mo_tables where account_id=0 and reldatabase=? and relname='dst'",
+		branchDB).Scan(&destinationTableID))
+	require.NoError(t, mutationDB.QueryRowContext(ctx,
+		"select rel_id from mo_catalog.mo_tables where account_id=0 and reldatabase='mo_catalog' and relname='mo_feature_registry'",
+	).Scan(&featureRegistryID))
+
+	holder, err := holderDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	holderOpen := true
+	defer func() {
+		if holderOpen {
+			_ = holder.Rollback()
+		}
+	}()
+	_, err = holder.ExecContext(ctx,
+		"update `"+branchDB+"`.`dst` set value = 100 where id = 2")
+	require.NoError(t, err)
+
+	operationCtx, cancelOperations := context.WithCancel(ctx)
+	operations := make([]*issue26404Operation, 0, 2)
+	defer func() {
+		cancelOperations()
+		joinCtx, joinCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer joinCancel()
+		for _, concurrentOperation := range operations {
+			if joinErr := concurrentOperation.join(joinCtx); joinErr != nil {
+				t.Errorf("concurrent catalog operation did not stop: %v", joinErr)
+			}
+		}
+	}()
+
+	mutationSQL := "data branch merge `" + branchDB + "`.`src` into `" + branchDB + "`.`dst` when conflict accept"
+	if operation == "pick" {
+		mutationSQL = "data branch pick `" + branchDB + "`.`src` into `" + branchDB + "`.`dst` keys(2) when conflict accept"
+	}
+	mutation := startIssue26404Operation(operationCtx, func(operationCtx context.Context) error {
+		_, operationErr := mutationDB.ExecContext(operationCtx, mutationSQL)
+		return operationErr
+	})
+	operations = append(operations, mutation)
+	require.Eventually(t, func() bool {
+		return issue26404WaiterCount(c, destinationTableID) > 0
+	}, 30*time.Second, 10*time.Millisecond,
+		"Data Branch %s did not wait for the destination row holder", operation)
+	require.False(t, mutation.completed(),
+		"Data Branch %s returned before the row holder committed", operation)
+
+	drop := startIssue26404Operation(operationCtx, func(operationCtx context.Context) error {
+		_, operationErr := dropDB.ExecContext(operationCtx, "drop database `"+otherDB+"`")
+		return operationErr
+	})
+	operations = append(operations, drop)
+	require.Eventually(t, func() bool {
+		return issue26404WaiterCount(c, featureRegistryID) > 0
+	}, 30*time.Second, 10*time.Millisecond,
+		"unrelated DROP DATABASE did not wait at the lineage gate before taking the view-metadata gate")
+	require.False(t, drop.completed(),
+		"DROP DATABASE returned before the %s gate was released", operation)
+
+	require.NoError(t, holder.Commit())
+	holderOpen = false
+	finishCtx, finishCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer finishCancel()
+	require.NoError(t, mutation.wait(finishCtx))
+	require.NoError(t, drop.wait(finishCtx))
+
+	var value int
+	require.NoError(t, mutationDB.QueryRowContext(ctx,
+		"select value from `"+branchDB+"`.`dst` where id = 2").Scan(&value))
+	require.Equal(t, 200, value)
+	var databaseCount int
+	require.NoError(t, mutationDB.QueryRowContext(ctx,
+		"select count(*) from mo_catalog.mo_database where account_id=0 and datname=?", otherDB,
+	).Scan(&databaseCount))
+	require.Zero(t, databaseCount)
+}
+
+type issue26404Operation struct {
+	done chan struct{}
+	err  error
+}
+
+func startIssue26404Operation(ctx context.Context, fn func(context.Context) error) *issue26404Operation {
+	operation := &issue26404Operation{done: make(chan struct{})}
+	go func() {
+		defer close(operation.done)
+		operation.err = fn(ctx)
+	}()
+	return operation
+}
+
+func (operation *issue26404Operation) completed() bool {
+	select {
+	case <-operation.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (operation *issue26404Operation) wait(ctx context.Context) error {
+	select {
+	case <-operation.done:
+		return operation.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (operation *issue26404Operation) join(ctx context.Context) error {
+	select {
+	case <-operation.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func issue26404WaiterCount(c embed.Cluster, tableIDs ...uint64) int {
+	waiters := 0
+	tableSet := make(map[uint64]struct{}, len(tableIDs))
+	for _, tableID := range tableIDs {
+		tableSet[tableID] = struct{}{}
+	}
+	c.ForeachServices(func(svc embed.ServiceOperator) bool {
+		if svc.ServiceType() != metadata.ServiceType_CN {
+			return true
+		}
+		lockService := lockservice.GetLockServiceByServiceID(svc.ServiceID())
+		lockService.IterLocks(func(tableID uint64, _ [][]byte, lock lockservice.Lock) bool {
+			if _, ok := tableSet[tableID]; !ok {
+				return true
+			}
+			lock.IterWaiters(func(_ lockpb.WaitTxn) bool {
+				waiters++
+				return true
+			})
+			return true
+		})
+		return true
+	})
+	return waiters
+}

--- a/pkg/tests/issues/issue_27040_test.go
+++ b/pkg/tests/issues/issue_27040_test.go
@@ -60,10 +60,12 @@ func TestIssue27040ConcurrentIfNotExistsDatabaseClone(t *testing.T) {
 		execSQLRequire(t, ctx, db, "create table `"+sourceDatabase+"`.payload (id int primary key)")
 		execSQLRequire(t, ctx, db, "insert into `"+sourceDatabase+"`.payload values (1)")
 
-		var moDatabaseTableID uint64
+		// Clone serializes through the lineage lifecycle gate before taking the
+		// target catalog key, so the second transaction must wait here first.
+		var lineageGateTableID uint64
 		require.NoError(t, db.QueryRowContext(ctx,
-			"select rel_id from mo_catalog.mo_tables where account_id = 0 and reldatabase = 'mo_catalog' and relname = 'mo_database'",
-		).Scan(&moDatabaseTableID))
+			"select rel_id from mo_catalog.mo_tables where account_id = 0 and reldatabase = 'mo_catalog' and relname = 'mo_feature_registry'",
+		).Scan(&lineageGateTableID))
 
 		first, err := db.Conn(ctx)
 		require.NoError(t, err)
@@ -107,9 +109,9 @@ func TestIssue27040ConcurrentIfNotExistsDatabaseClone(t *testing.T) {
 		secondPending = true
 
 		require.Eventually(t, func() bool {
-			return clusterHasLockWaiter(c, moDatabaseTableID)
+			return clusterHasLockWaiter(c, lineageGateTableID)
 		}, 30*time.Second, 10*time.Millisecond,
-			"second clone did not wait for the first clone's mo_database target lock")
+			"second clone did not wait for the first clone's lineage lifecycle lock")
 
 		select {
 		case cloneErr := <-secondDone:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26404

## What this PR does / why we need it:

### Root cause

Mixed DATA BRANCH and CLONE workflows used inconsistent lock order. DIFF, PICK, MERGE, and ordinary CLONE could first acquire catalog/view/object locks and only later enter nested scratch/restore/drop paths that acquire the existing lineage-owner lifecycle row lock. Concurrent DROP, SNAPSHOT, and branch operations acquire the lineage lock first and then catalog/view/object locks. Across CNs these two orders can form a distributed wait cycle even when the business database names are independent.

The previous revision of this PR tried to merge the view and lineage gates. That changed the restore catalog contract and caused both unit and broad BVT regressions when `mo_feature_registry` was unavailable in tenant/PITR restore contexts. This revision restores the two existing gates and corrects only composite-operation admission order.

### Changes

- Add one shared mutation-admission helper that acquires the existing lineage-owner lifecycle lock before composite autocommit work starts.
- Admit table/database CLONE and DATA BRANCH DIFF/PICK/MERGE before endpoint/catalog resolution.
- Reacquire the lineage lifecycle lock when database-clone target-lock retry restarts its owned transaction.
- Preserve existing explicit user-transaction validation and ownership semantics.
- Add deterministic two-CN regression coverage plus focused admission/retry failure-path unit tests.
- Update the existing concurrent `IF NOT EXISTS` clone regression to observe the new leading lineage lifecycle gate while preserving its transaction-order and result assertions.

### Issue-to-test proof

`TestIssue26404MixedDataBranchLifecycleDoesNotDeadlock` runs authenticated SQL through a real two-CN cluster. It uses lock-service waiter barriers rather than timing sleeps and covers:

- database CLONE with table data, full-text index, and view metadata while an unrelated database DROP runs;
- DIFF while an unrelated database DROP runs;
- PICK and MERGE with a destination-row conflict while an unrelated database DROP waits on the lineage gate;
- completion, result correctness, and unrelated-drop visibility after every interleaving.

The exact external regression set from #26404 was also run for 20 rounds at concurrency 9: 200/200 cases and 4,840/4,840 statements passed, with no deadlock or `20701` in runner/server logs.

### Validation

- rebased cleanly onto `main@0b195e4f5a`; `git range-diff` confirms both issue commits are unchanged
- focused frontend admission and retry tests, including rollback/begin/gate error propagation
- `TestIssue26404MixedDataBranchLifecycleDoesNotDeadlock`: `-count=3`
- `TestIssue26404MixedDataBranchLifecycleDoesNotDeadlock`: `-race -count=1`
- `TestIssue27040ConcurrentIfNotExistsDatabaseClone`: `-count=3`
- `TestIssue27040ConcurrentIfNotExistsDatabaseClone`: focused frontend coverage mode and `-race -count=1`
- full `./pkg/catalog ./pkg/frontend/databranchutils ./pkg/sql/compile ./pkg/frontend` after the shared SNAPSHOT/View-gate change landed
- full `./pkg/frontend`
- full `./pkg/tests/issues`
- exact adjacent regressions: `TestIssue26087ConcurrentDataBranchQuota`, `TestIssue26640AccountPITRUsesCatalogRestoreHandlers`, and `TestIssue28317ViewSnapshotGateOrderSQL`
- `go vet ./pkg/frontend ./pkg/tests/issues` with the repository CGo environment
- `make build`
- exact ten-case MOTR command from #26404 with `--repeat 20 -j 9`
- `temporary_table_clone` BVT after the temporary-DDL transaction change: 166/166 statements passed with JDBC metadata ignored
- `git diff --check`

After upstream #28322 unified SNAPSHOT -> View locking, the shared lock packages, frontend/compile packages, the real two-CN issue test, all three adjacent regressions, and the race case were rerun successfully. After upstream #28332 made temporary DDL transaction-independent, focused/full frontend and compile tests, the real two-CN issue test, `make build`, and the existing 166-statement temporary-clone BVT were rerun. The local machine has JDK 17 rather than the tester-required JDK 8: normal BVT comparison reported 12 JDBC display-width-only differences, each inspected against the SQL and expected data/DDL/error semantics; `-n` then proved all 166 semantic results. No result file was regenerated or changed.

The old-head Ubuntu UT, UT coverage, and pessimistic multi-CN BVT failures in workflow run 34098109436 all traced to the discarded shared-gate revision; local exact regression tests pass with this revision. They are not unrelated CI blockers.

Workflow run 34125753066 exposed one stale assertion in the existing #27040 regression: it still expected the second clone to wait at the target `mo_database` key, but this PR intentionally admits clone at the lineage lifecycle gate first. Commit `d71f4dbd` updates only that observation point; the original early-return, commit-order, uniqueness, and payload assertions remain intact. The same job also reproduced the unrelated #28313 shuffle-pool failure, while its pessimistic BVT job reproduced the then-unresolved #28352 temporary-table ALTER failure; the aggregate Coverage failure was a consequence of those failed producers.

After rebasing onto upstream #28343's remote-bind convergence change and #28096's frontend `MEMBER OF` support, the eight focused frontend admission/retry/error-path tests and the full `pkg/frontend` package passed. The real two-CN #26404 regression and the adjacent #27040 clone regression each passed three normal runs and one race run, validating the current lockservice dependency rather than reusing the older topology evidence. Main then advanced with #28356's executor-owned temporary ALTER COPY transaction fix, which resolved #28352. A second `range-diff` remained unchanged; the eight focused frontend tests and both two-CN regressions were rerun on `main@fdc1e0ca8f`, with three normal runs per regression and a combined race run passing.

Pre-rebase workflow run 34150466865 passed Linux UT, coverage UT, SCA, Proxy and pessimistic multi-CN BVT, and aggregate Coverage; the remaining completed jobs were successful, neutral, or intentionally skipped. Main then added only #28355's correlated scalar-aggregate planner optimization. A third `range-diff` remained unchanged, and the eight focused frontend tests plus both real two-CN regressions passed on `main@0b195e4f5a`; the existing race evidence remains valid because neither the PR's synchronization code nor its lockservice dependency changed.

### Residual risk

The corrected order intentionally serializes these composite autocommit workflows at the existing global lineage lifecycle boundary for their owned transaction. The 20-round exact workload completed without stalls. Explicit user-transaction behavior is unchanged and is outside the reported autocommit workload.
