### PR TITLE
fix(json): reject wildcard and range paths in JSON_KEYS

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -130,6 +130,7 @@ const (
 	// required argument depends on a runtime system variable.
 	ErrWrongParamCountToNativeFct uint16 = 20333
 	ErrAESInvalidIV               uint16 = 20334
+	ErrInvalidJSONPathWildcard uint16 = 20337
 
 	// Group 4: unexpected state and io errors
 	ErrInvalidState                             uint16 = 20400
@@ -450,34 +451,35 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrTruncatedWrongValue:         {ER_TRUNCATED_WRONG_VALUE, []string{"22007"}, "Truncated incorrect %-.64s value: '%-.128s'"},
 
 	// Group 3: invalid input
-	ErrBadConfig:            {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "invalid configuration: %s"},
-	ErrInvalidInput:         {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "invalid input: %s"},
-	ErrSyntaxError:          {ER_SYNTAX_ERROR, []string{"42000"}, "SQL syntax error: %s"},
-	ErrParseError:           {ER_PARSE_ERROR, []string{"42000"}, "SQL parser error: %s"},
-	ErrConstraintViolation:  {ER_CHECK_CONSTRAINT_VIOLATED, []string{MySQLDefaultSqlState}, "constraint violation: %s"},
-	ErrDuplicate:            {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "tae data: duplicate"},
-	ErrRoleGrantedToSelf:    {ER_ROLE_GRANTED_TO_ITSELF, []string{MySQLDefaultSqlState}, "cannot grant role %s to %s"},
-	ErrDuplicateEntry:       {ER_DUP_ENTRY, []string{"23000"}, "Duplicate entry '%s' for key '%s'"},
-	ErrWrongValueCountOnRow: {ER_WRONG_VALUE_COUNT_ON_ROW, []string{"21S01"}, "Column count doesn't match value count at row %d"},
-	ErrBadFieldError:        {ER_BAD_FIELD_ERROR, []string{"42S22"}, "Unknown column '%s' in '%s'"},
-	ErrWrongDatetimeSpec:    {ER_WRONG_DATETIME_SPEC, []string{MySQLDefaultSqlState}, "wrong date/time format specifier: %s"},
-	ErrUpgrateError:         {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "CN upgrade table or view '%s.%s' under tenant '%s:%d' reports error: %s"},
-	ErrUnsupportedDML:       {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "unsupported DML: %s"},
-	ErrOperandColumns:       {ER_OPERAND_COLUMNS, []string{"21000"}, "Operand should contain %d column(s)"},
-	ErrSubqueryNo1Row:       {ER_SUBQUERY_NO_1_ROW, []string{"21000"}, "Subquery returns more than 1 row"},
-	ErrInvalidTypeForJSON:   {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "Invalid data type for JSON data in argument %d to function %s; a JSON string or JSON type is required."},
-	ErrInvalidJSONCharset:   {ER_INVALID_JSON_CHARSET, []string{"22032"}, "Cannot create a JSON value from a string with CHARACTER SET '%s'."},
-	ErrUnknownStmtHandler:   {ER_UNKNOWN_STMT_HANDLER, []string{MySQLDefaultSqlState}, "Unknown prepared statement handler (%s) given to %s"},
-	ErrViewWrongList:        {ER_VIEW_WRONG_LIST, []string{MySQLDefaultSqlState}, "In definition of view, derived table or common table expression, SELECT list and column names list have different column counts"},
-	ErrWrongArguments:       {ER_WRONG_ARGUMENTS, []string{MySQLDefaultSqlState}, "Incorrect arguments to %s"},
-	ErrDerivedMustHaveAlias: {ER_DERIVED_MUST_HAVE_ALIAS, []string{"42000"}, "Every derived table must have its own alias"},
-	ErrWrongUsage:           {ER_WRONG_USAGE, []string{MySQLDefaultSqlState}, "Incorrect usage of %s and %s"},
-	ErrUpdateTableUsed:      {ER_UPDATE_TABLE_USED, []string{MySQLDefaultSqlState}, "You can't specify target table '%-.192s' for update in FROM clause"},
-	ErrWindowInvalidUse:     {ER_WINDOW_INVALID_WINDOW_FUNC_USE, []string{"HY000"}, "You cannot use the window function '%s' in this context"},
-	ErrViewSelectTmpTable:   {ER_VIEW_SELECT_TMPTABLE, []string{MySQLDefaultSqlState}, "View's SELECT refers to a temporary table '%-.192s'"},
-	ErrTooManyRows:          {ER_TOO_MANY_ROWS, []string{"42000"}, "Result consisted of more than one row"},
-	ErrCantChangeTxn:        {ER_CANT_CHANGE_TX_CHARACTERISTICS, []string{"25001"}, "Transaction characteristics can't be changed while a transaction is in progress"},
-	ErrInvalidGroupFuncUse:  {ER_INVALID_GROUP_FUNC_USE, []string{MySQLDefaultSqlState}, "Invalid use of group function"},
+	ErrBadConfig:               {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "invalid configuration: %s"},
+	ErrInvalidInput:            {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "invalid input: %s"},
+	ErrSyntaxError:             {ER_SYNTAX_ERROR, []string{"42000"}, "SQL syntax error: %s"},
+	ErrParseError:              {ER_PARSE_ERROR, []string{"42000"}, "SQL parser error: %s"},
+	ErrConstraintViolation:     {ER_CHECK_CONSTRAINT_VIOLATED, []string{MySQLDefaultSqlState}, "constraint violation: %s"},
+	ErrDuplicate:               {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "tae data: duplicate"},
+	ErrRoleGrantedToSelf:       {ER_ROLE_GRANTED_TO_ITSELF, []string{MySQLDefaultSqlState}, "cannot grant role %s to %s"},
+	ErrDuplicateEntry:          {ER_DUP_ENTRY, []string{"23000"}, "Duplicate entry '%s' for key '%s'"},
+	ErrWrongValueCountOnRow:    {ER_WRONG_VALUE_COUNT_ON_ROW, []string{"21S01"}, "Column count doesn't match value count at row %d"},
+	ErrBadFieldError:           {ER_BAD_FIELD_ERROR, []string{"42S22"}, "Unknown column '%s' in '%s'"},
+	ErrWrongDatetimeSpec:       {ER_WRONG_DATETIME_SPEC, []string{MySQLDefaultSqlState}, "wrong date/time format specifier: %s"},
+	ErrUpgrateError:            {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "CN upgrade table or view '%s.%s' under tenant '%s:%d' reports error: %s"},
+	ErrUnsupportedDML:          {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "unsupported DML: %s"},
+	ErrOperandColumns:          {ER_OPERAND_COLUMNS, []string{"21000"}, "Operand should contain %d column(s)"},
+	ErrSubqueryNo1Row:          {ER_SUBQUERY_NO_1_ROW, []string{"21000"}, "Subquery returns more than 1 row"},
+	ErrInvalidTypeForJSON:      {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "Invalid data type for JSON data in argument %d to function %s; a JSON string or JSON type is required."},
+	ErrInvalidJSONCharset:      {ER_INVALID_JSON_CHARSET, []string{"22032"}, "Cannot create a JSON value from a string with CHARACTER SET '%s'."},
+	ErrUnknownStmtHandler:      {ER_UNKNOWN_STMT_HANDLER, []string{MySQLDefaultSqlState}, "Unknown prepared statement handler (%s) given to %s"},
+	ErrViewWrongList:           {ER_VIEW_WRONG_LIST, []string{MySQLDefaultSqlState}, "In definition of view, derived table or common table expression, SELECT list and column names list have different column counts"},
+	ErrWrongArguments:          {ER_WRONG_ARGUMENTS, []string{MySQLDefaultSqlState}, "Incorrect arguments to %s"},
+	ErrDerivedMustHaveAlias:    {ER_DERIVED_MUST_HAVE_ALIAS, []string{"42000"}, "Every derived table must have its own alias"},
+	ErrWrongUsage:              {ER_WRONG_USAGE, []string{MySQLDefaultSqlState}, "Incorrect usage of %s and %s"},
+	ErrUpdateTableUsed:         {ER_UPDATE_TABLE_USED, []string{MySQLDefaultSqlState}, "You can't specify target table '%-.192s' for update in FROM clause"},
+	ErrWindowInvalidUse:        {ER_WINDOW_INVALID_WINDOW_FUNC_USE, []string{"HY000"}, "You cannot use the window function '%s' in this context"},
+	ErrViewSelectTmpTable:      {ER_VIEW_SELECT_TMPTABLE, []string{MySQLDefaultSqlState}, "View's SELECT refers to a temporary table '%-.192s'"},
+	ErrTooManyRows:             {ER_TOO_MANY_ROWS, []string{"42000"}, "Result consisted of more than one row"},
+	ErrCantChangeTxn:           {ER_CANT_CHANGE_TX_CHARACTERISTICS, []string{"25001"}, "Transaction characteristics can't be changed while a transaction is in progress"},
+	ErrInvalidGroupFuncUse:     {ER_INVALID_GROUP_FUNC_USE, []string{MySQLDefaultSqlState}, "Invalid use of group function"},
+	ErrInvalidJSONPathWildcard: {ER_INVALID_JSON_PATH_WILDCARD, []string{"42000"}, "In this situation, path expressions may not contain the * and ** tokens or an array range."},
 	// Maps to MySQL's ER_FT_MATCHING_KEY_NOT_FOUND (1191), which rejects the same no-index
 	// CREATE / ALTER / CREATE OR REPLACE VIEW, so clients see the code and text they expect.
 	ErrFtMatchingKeyNotFound:               {ER_FT_MATCHING_KEY_NOT_FOUND, []string{MySQLDefaultSqlState}, FtMatchingKeyNotFoundMsg},
@@ -1157,8 +1159,12 @@ func NewInvalidGroupFuncUse(ctx context.Context) *Error {
 	return newError(ctx, ErrInvalidGroupFuncUse)
 }
 
-func NewInvalidBitwiseAggregateOperandsSize(ctx context.Context) *Error {
-	return newError(ctx, ErrInvalidBitwiseAggregateOperandsSize)
+	func NewInvalidBitwiseAggregateOperandsSize(ctx context.Context) *Error {
+		return newError(ctx, ErrInvalidBitwiseAggregateOperandsSize)
+	}
+
+func NewInvalidJSONPathWildcard(ctx context.Context) *Error {
+	return newError(ctx, ErrInvalidJSONPathWildcard)
 }
 
 func NewInvalidTypeForJSON(ctx context.Context, argument int, function string) *Error {

--- a/pkg/common/moerr/error_test.go
+++ b/pkg/common/moerr/error_test.go
@@ -134,6 +134,22 @@ func TestInvalidGroupFuncUseMySQLError(t *testing.T) {
 	require.Equal(t, "Invalid use of group function", err.Error())
 }
 
+func TestNewInvalidJSONPathWildcard(t *testing.T) {
+	err := NewInvalidJSONPathWildcard(context.Background())
+	require.Equal(t, ErrInvalidJSONPathWildcard, err.ErrorCode())
+	require.Equal(t, ER_INVALID_JSON_PATH_WILDCARD, err.MySQLCode())
+	require.Equal(t, "42000", err.SqlState())
+	require.Equal(t,
+		"In this situation, path expressions may not contain the * and ** tokens or an array range.",
+		err.Error())
+
+	data, marshalErr := err.MarshalBinary()
+	require.NoError(t, marshalErr)
+	decoded := new(Error)
+	require.NoError(t, decoded.UnmarshalBinary(data))
+	require.Equal(t, err, decoded)
+}
+
 func TestViewSelectTmpTableMySQLError(t *testing.T) {
 	err := NewViewSelectTmpTable(context.Background(), "temp_for_view")
 	require.Equal(t, ErrViewSelectTmpTable, err.ErrorCode())

--- a/pkg/sql/plan/function/func_builtin_json.go
+++ b/pkg/sql/plan/function/func_builtin_json.go
@@ -2751,6 +2751,9 @@ func jsonKeysWithPath(ivecs []*vector.Vector, result vector.FunctionResultWrappe
 		if err != nil {
 			return moerr.NewInvalidArg(proc.Ctx, "json_keys", "invalid path expression")
 		}
+		if !path.IsSimple() {
+			return moerr.NewInvalidJSONPathWildcard(proc.Ctx)
+		}
 		val := bj.Query([]*bytejson.Path{&path})
 		if val.IsNull() || val.Type != bytejson.TpCodeObject {
 			rs.AppendMustNullForBytesResult()

--- a/pkg/sql/plan/function/func_json_valid_test.go
+++ b/pkg/sql/plan/function/func_json_valid_test.go
@@ -177,6 +177,147 @@ func TestJsonKeys(t *testing.T) {
 			}, nil)
 		require.Equal(t, `[["a", "b"]]`, jsonVectorRowString(t, composed, 0))
 	})
+
+	t.Run("simple path returns object keys", func(t *testing.T) {
+		vec := runJsonFunctionWithSelectList(t, proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{`{"a":{"x":1}}`}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{`$.a`}, []bool{false}),
+			},
+			types.T_json.ToType(), JsonKeys, nil)
+		require.Equal(t, `["x"]`, jsonVectorRowString(t, vec, 0))
+	})
+
+	t.Run("literal wildcard key remains simple", func(t *testing.T) {
+		vec := runJsonFunctionWithSelectList(t, proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{`{"*":{"x":1}}`}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{"$.\"*\""}, []bool{false}),
+			},
+			types.T_json.ToType(), JsonKeys, nil)
+		require.Equal(t, `["x"]`, jsonVectorRowString(t, vec, 0))
+	})
+
+	t.Run("path controls preserve existing semantics", func(t *testing.T) {
+		fcTC := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{
+						`{"a":{"x":1}}`,
+						`{"a":{"x":1}}`,
+						`{"a":{}}`,
+						`{"a":1}`,
+						`{"a":[1]}`,
+						``,
+						`{"a":{"x":1}}`,
+					},
+					[]bool{false, false, false, false, false, true, false}),
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{`$`, `$.a`, `$.a`, `$.b`, `$.a`, `$.a`, ``},
+					[]bool{false, false, false, false, false, false, true}),
+			},
+			NewFunctionTestResult(types.T_json.ToType(), false,
+				[]string{
+					mustJsonBinaryString(t, `["a"]`),
+					mustJsonBinaryString(t, `["x"]`),
+					mustJsonBinaryString(t, `[]`),
+					``, ``, ``, ``,
+				},
+				[]bool{false, false, false, true, true, true, true}),
+			JsonKeys)
+		s, info := fcTC.Run()
+		require.True(t, s, info)
+	})
+
+	t.Run("rejects non-simple paths", func(t *testing.T) {
+		paths := []struct {
+			name string
+			path string
+		}{
+			{name: "key wildcard", path: `$.*`},
+			{name: "array wildcard", path: `$[*]`},
+			{name: "double wildcard", path: `$**.x`},
+			{name: "array range", path: `$[0 to 1]`},
+		}
+
+		for _, path := range paths {
+			t.Run(path.name, func(t *testing.T) {
+				for _, doc := range []struct {
+					name  string
+					typ   types.Type
+					value string
+				}{
+					{name: "varchar", typ: types.T_varchar.ToType(), value: `{"a":{"x":1}}`},
+					{name: "json", typ: types.T_json.ToType(), value: mustJsonBinaryString(t, `{"a":{"x":1}}`)},
+				} {
+					t.Run(doc.name, func(t *testing.T) {
+						for _, pathInput := range []struct {
+							name    string
+							newPath func(types.Type, any, []bool) FunctionTestInput
+						}{
+							{name: "row path", newPath: NewFunctionTestInput},
+							{name: "const path", newPath: NewFunctionTestConstInput},
+						} {
+							t.Run(pathInput.name, func(t *testing.T) {
+								fcTC := NewFunctionTestCase(proc,
+									[]FunctionTestInput{
+										NewFunctionTestInput(doc.typ, []string{doc.value}, []bool{false}),
+										pathInput.newPath(types.T_varchar.ToType(), []string{path.path}, []bool{false}),
+									},
+									NewFunctionTestResult(types.T_json.ToType(), false, nil, nil),
+									JsonKeys)
+								require.NoError(t, fcTC.result.PreExtendAndReset(fcTC.fnLength))
+								_, err := fcTC.DebugRun()
+								require.Error(t, err)
+								var moErr *moerr.Error
+								require.ErrorAs(t, err, &moErr)
+								require.Equal(t, moerr.ErrInvalidJSONPathWildcard, moErr.ErrorCode())
+								require.Equal(t, uint16(moerr.ER_INVALID_JSON_PATH_WILDCARD), moErr.MySQLCode())
+								require.Equal(t, "42000", moErr.SqlState())
+							})
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("masked wildcard path is not evaluated", func(t *testing.T) {
+		fcTC := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{`{"a":1}`, `{"b":2}`}, []bool{false, false}),
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{`$`, `$.*`}, []bool{false, false}),
+			},
+			NewFunctionTestResult(types.T_json.ToType(), false,
+				[]string{mustJsonBinaryString(t, `["a"]`), ``}, []bool{false, true}),
+			JsonKeys).WithSelectList(&FunctionSelectList{
+			AnyNull:    true,
+			SelectList: []bool{true, false},
+		})
+		s, info := fcTC.Run()
+		require.True(t, s, info)
+	})
+
+	t.Run("invalid JSON takes precedence over wildcard path", func(t *testing.T) {
+		fcTC := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{`not json`}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{`$.*`}, []bool{false}),
+			},
+			NewFunctionTestResult(types.T_json.ToType(), false, nil, nil), JsonKeys)
+		require.NoError(t, fcTC.result.PreExtendAndReset(fcTC.fnLength))
+		_, err := fcTC.DebugRun()
+		require.Error(t, err)
+		var moErr *moerr.Error
+		require.ErrorAs(t, err, &moErr)
+		require.Equal(t, moerr.ErrInvalidArg, moErr.ErrorCode())
+	})
 }
 
 func TestJsonPretty(t *testing.T) {

--- a/pkg/sql/plan/function/func_json_valid_test.go
+++ b/pkg/sql/plan/function/func_json_valid_test.go
@@ -214,20 +214,21 @@ func TestJsonKeys(t *testing.T) {
 						`{"a":[1]}`,
 						``,
 						`{"a":{"x":1}}`,
+						``,
 					},
-					[]bool{false, false, false, false, false, true, false}),
+					[]bool{false, false, false, false, false, true, false, true}),
 				NewFunctionTestInput(types.T_varchar.ToType(),
-					[]string{`$`, `$.a`, `$.a`, `$.b`, `$.a`, `$.a`, ``},
-					[]bool{false, false, false, false, false, false, true}),
+					[]string{`$`, `$.a`, `$.a`, `$.b`, `$.a`, `$.a`, ``, `$.*`},
+					[]bool{false, false, false, false, false, false, true, false}),
 			},
 			NewFunctionTestResult(types.T_json.ToType(), false,
 				[]string{
 					mustJsonBinaryString(t, `["a"]`),
 					mustJsonBinaryString(t, `["x"]`),
 					mustJsonBinaryString(t, `[]`),
-					``, ``, ``, ``,
+					``, ``, ``, ``, ``,
 				},
-				[]bool{false, false, false, true, true, true, true}),
+				[]bool{false, false, false, true, true, true, true, true}),
 			JsonKeys)
 		s, info := fcTC.Run()
 		require.True(t, s, info)
@@ -280,6 +281,49 @@ func TestJsonKeys(t *testing.T) {
 								require.Equal(t, "42000", moErr.SqlState())
 							})
 						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("unmasked row error after valid row", func(t *testing.T) {
+		paths := []struct {
+			name string
+			path string
+		}{
+			{name: "key wildcard", path: `$.*`},
+			{name: "array wildcard", path: `$[*]`},
+			{name: "double wildcard", path: `$**.x`},
+			{name: "array range", path: `$[0 to 1]`},
+		}
+
+		for _, path := range paths {
+			t.Run(path.name, func(t *testing.T) {
+				for _, doc := range []struct {
+					name  string
+					typ   types.Type
+					value string
+				}{
+					{name: "varchar", typ: types.T_varchar.ToType(), value: `{"a":{"x":1}}`},
+					{name: "json", typ: types.T_json.ToType(), value: mustJsonBinaryString(t, `{"a":{"x":1}}`)},
+				} {
+					t.Run(doc.name, func(t *testing.T) {
+						fcTC := NewFunctionTestCase(proc,
+							[]FunctionTestInput{
+								NewFunctionTestInput(doc.typ, []string{doc.value, doc.value}, []bool{false, false}),
+								NewFunctionTestInput(types.T_varchar.ToType(), []string{`$`, path.path}, []bool{false, false}),
+							},
+							NewFunctionTestResult(types.T_json.ToType(), false, nil, nil),
+							JsonKeys)
+						require.NoError(t, fcTC.result.PreExtendAndReset(fcTC.fnLength))
+						_, err := fcTC.DebugRun()
+						require.Error(t, err)
+						var moErr *moerr.Error
+						require.ErrorAs(t, err, &moErr)
+						require.Equal(t, moerr.ErrInvalidJSONPathWildcard, moErr.ErrorCode())
+						require.Equal(t, uint16(moerr.ER_INVALID_JSON_PATH_WILDCARD), moErr.MySQLCode())
+						require.Equal(t, "42000", moErr.SqlState())
 					})
 				}
 			})

--- a/test/distributed/cases/function/func_json_keys.result
+++ b/test/distributed/cases/function/func_json_keys.result
@@ -28,6 +28,17 @@ null
 select json_keys('{"a": 1}', '$.b');
 json_keys({"a": 1}, $.b)
 null
+select json_keys('{"a": 1}', '$.*');
+In this situation, path expressions may not contain the * and ** tokens or an array range.
+select json_keys('{"a": 1}', '$[*]');
+In this situation, path expressions may not contain the * and ** tokens or an array range.
+select json_keys('{"a": {"x": 1}}', '$**.x');
+In this situation, path expressions may not contain the * and ** tokens or an array range.
+select json_keys('[{"a": 1}, {"b": 2}]', '$[0 to 1]');
+In this situation, path expressions may not contain the * and ** tokens or an array range.
+select json_keys('{"*": {"x": 1}}', '$."*"');
+json_keys({"*": {"x": 1}}, $."*")
+["x"]
 select json_keys(null);
 json_keys(null)
 null

--- a/test/distributed/cases/function/func_json_keys.result
+++ b/test/distributed/cases/function/func_json_keys.result
@@ -42,6 +42,9 @@ json_keys({"*": {"x": 1}}, $."*")
 select json_keys(null);
 json_keys(null)
 null
+select json_keys(null, '$.*');
+json_keys(null, $.*)
+null
 select json_keys('{"a":1}', null);
 json_keys({"a":1}, null)
 null

--- a/test/distributed/cases/function/func_json_keys.test
+++ b/test/distributed/cases/function/func_json_keys.test
@@ -16,6 +16,15 @@ select json_keys('{"a": [1,2,3]}', '$.a');
 -- path not matching → null
 select json_keys('{"a": 1}', '$.b');
 
+-- wildcard and range paths → error
+select json_keys('{"a": 1}', '$.*');
+select json_keys('{"a": 1}', '$[*]');
+select json_keys('{"a": {"x": 1}}', '$**.x');
+select json_keys('[{"a": 1}, {"b": 2}]', '$[0 to 1]');
+
+-- quoted wildcard is a literal key
+select json_keys('{"*": {"x": 1}}', '$."*"');
+
 -- null arguments
 select json_keys(null);
 select json_keys('{"a":1}', null);

--- a/test/distributed/cases/function/func_json_keys.test
+++ b/test/distributed/cases/function/func_json_keys.test
@@ -27,6 +27,7 @@ select json_keys('{"*": {"x": 1}}', '$."*"');
 
 -- null arguments
 select json_keys(null);
+select json_keys(null, '$.*');
 select json_keys('{"a":1}', null);
 
 -- via json functions


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28041

## What this PR does / why we need it:

`JSON_KEYS(json_doc, path)` currently accepts wildcard/range paths and returns SQL NULL after the query result is wrapped as a JSON array. This change rejects `$.*`, `$[*]`, `$**.x`, and `$[0 to 1]` with MySQL error 3149 / SQLSTATE 42000:

`In this situation, path expressions may not contain the * and ** tokens or an array range.`

The check uses `Path.IsSimple()` after JSON/path parsing and before `ByteJson.Query`. Simple paths, the literal key `$."*"`, missing paths, non-object results, SQL NULL, masked rows, and invalid-JSON error precedence retain their existing behavior. The shared parser, Query implementation, and other JSON functions are unchanged.

### Required merge dependency

**Depends on #27990. Merge order: #27990 -> this PR. Do not merge this PR before #27990.**

This Draft is published for early review from merge commit `005a9a619acf88c9d2173427784cd3197039910e`, based on frozen `main@bbbfb70cbcbe0dc1eca83b24cd6c78ac0aa4fc92`; it is not stacked on the unmerged #27990 head. The merge preserved main's adjacent Group 3 moerr allocations and moved `ErrInvalidJSONPathWildcard` to the next unused internal code `20338`; the public MySQL 3149 / SQLSTATE 42000 contract is unchanged. The final code must still be rechecked after #27990 merges.

Before this PR is eligible for Ready/merge:

- [ ] #27990 is merged.
- [ ] Sync this branch with the latest main, rescan Group 3 error numbers, and resolve any overlapping JSON-function changes.
- [ ] Revalidate the resulting head with focused and owning-package CGo unit tests, the error contract tests, and the canonical JSON_KEYS BVT twice on the same clean test instance.
- [ ] Complete final semantic/self-review and pass relevant CI/BVT on the published head; clear blocking reviews and unresolved threads and obtain the required XuPeng-SH approval.

Ready conversion requires separate explicit authorization. Target branch is main only; no release backport is planned.

### Validation

- Regression coverage: all four rejected path forms across varchar/JSON documents and constant/row paths; typed moerr assertions; masked rows; literal wildcard keys; ordinary object, missing, non-object and NULL controls; invalid JSON precedence.
- Error contract coverage: internal code, MySQL 3149, SQLSTATE 42000, full message, and marshal/unmarshal round trip.
- Recorded on the merged candidate: `go test ./pkg/common/moerr -count=1` PASS; JSON_KEYS/bytejson focused CGo tests are `BLOCKED_ENVIRONMENT` because `roaring.h`, `usearch.h`, and `jemalloc.h` are unavailable.
- Supplemental SQL validation recorded on the local candidate: a real MySQL client against a standalone MatrixOne instance confirmed the four `ERROR 3149 (42000)` results and controls in two runs. This is not a mo-tester BVT PASS or formal QA acceptance.
- BVT added to `test/distributed/cases/function/func_json_keys.test` and `.result`. Canonical mo-tester execution remains pending; the prior local attempt lacked a usable JDK.
- Publication check: `git diff --check` PASS. New head CI run [35705564800](https://github.com/matrixorigin/matrixone/actions/runs/35705564800) is in progress; canonical mo-tester BVT remains pending.

QA required: yes — this changes user-visible SQL error compatibility. QA must report the tested version/environment and per-case PASS/FAIL for the four invalid paths, ordinary paths, missing/non-object results, SQL NULL and `$."*"`. Keep issue #28041 open after merge until explicit QA PASS.
