### PR TITLE
fix: stabilize HAKeeper in issue 26114 tests

### DIFF
--- a/pkg/embed/cluster.go
+++ b/pkg/embed/cluster.go
@@ -445,6 +445,9 @@ func (c *cluster) createServiceOperators(from int) error {
 				cfg.LogService.HAKeeperConfig.CNStoreTimeout.Duration = c.options.storeTimeout
 			})
 		}
+		if c.options.testing {
+			s.Adjust(applyTestingHAKeeperBackendReadTimeout)
+		}
 
 		if c.options.preStart != nil {
 			c.options.preStart(s)
@@ -452,6 +455,15 @@ func (c *cluster) createServiceOperators(from int) error {
 		c.services = append(c.services, s)
 	}
 	return nil
+}
+
+func applyTestingHAKeeperBackendReadTimeout(cfg *ServiceConfig) {
+	// The race detector can stall the embedded HAKeeper longer than its
+	// production transport budget. Do not let that transport deadline preempt
+	// the test heartbeat recovery window. Explicit service configuration wins.
+	if cfg.HAKeeperClient.BackendReadTimeout.Duration == 0 {
+		cfg.HAKeeperClient.BackendReadTimeout.Duration = testHAKeeperBackendReadTimeout
+	}
 }
 
 func applyHAKeeperHeartbeatTimeout(

--- a/pkg/embed/cluster_test.go
+++ b/pkg/embed/cluster_test.go
@@ -513,32 +513,65 @@ func TestClusterAdmissionCoversFullLifecycle(t *testing.T) {
 	require.Nil(t, c.testAdmission)
 }
 
-func TestWithTestingExtendsStoreLivenessWithoutExtendingHeartbeatDeadline(t *testing.T) {
+func TestWithTestingBoundsHeartbeatRecoveryInsideStoreLiveness(t *testing.T) {
 	clusterValue, err := NewCluster(WithTesting())
 	if clusterValue != nil {
 		t.Cleanup(func() { require.NoError(t, clusterValue.Close()) })
 	}
 	require.NoError(t, err)
 	c := clusterValue.(*cluster)
-	// The heartbeat loop performs RPCs serially. A test mode must allow
-	// temporarily missing stores without turning a failed heartbeat into a
-	// long-lived blocked request that prevents the next scheduling command from
-	// being observed.
-	require.Zero(t, c.options.heartbeatTimeout)
+	require.Equal(t, testHAKeeperHeartbeatTimeout, c.options.heartbeatTimeout)
+	require.Less(t, c.options.heartbeatTimeout, c.options.storeTimeout)
 
 	for _, svc := range c.services {
 		cfg := svc.GetServiceConfig()
+		require.Equal(t, testHAKeeperBackendReadTimeout,
+			cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		switch svc.ServiceType() {
 		case metadata.ServiceType_CN:
-			require.Zero(t, cfg.CN.HAKeeper.HeatbeatTimeout.Duration)
+			require.Equal(t, testHAKeeperHeartbeatTimeout,
+				cfg.CN.HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t, cfg.CN.HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_TN:
-			require.Zero(t, cfg.getTNServiceConfig().HAKeeper.HeatbeatTimeout.Duration)
+			require.Equal(t, testHAKeeperHeartbeatTimeout,
+				cfg.getTNServiceConfig().HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t, cfg.getTNServiceConfig().HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_LOG:
 			require.Equal(t, testHAKeeperStoreTimeout,
 				cfg.LogService.HAKeeperConfig.TNStoreTimeout.Duration)
 			require.Equal(t, testHAKeeperStoreTimeout,
 				cfg.LogService.HAKeeperConfig.CNStoreTimeout.Duration)
+			require.Less(t, cfg.HAKeeperClient.BackendReadTimeout.Duration,
+				cfg.LogService.HAKeeperConfig.TNStoreTimeout.Duration)
 		}
+	}
+}
+
+func TestTestingHAKeeperBackendReadTimeoutPreservesExplicitValue(t *testing.T) {
+	const explicit = 7 * time.Second
+	cfg := newServiceConfig()
+	cfg.HAKeeperClient.BackendReadTimeout.Duration = explicit
+
+	applyTestingHAKeeperBackendReadTimeout(&cfg)
+	require.Equal(t, explicit, cfg.HAKeeperClient.BackendReadTimeout.Duration)
+}
+
+func TestWithTestingPreservesExplicitHeartbeatTimeout(t *testing.T) {
+	const explicit = 7 * time.Second
+	for name, options := range map[string][]Option{
+		"before testing mode": {WithHAKeeperHeartbeatTimeout(explicit), WithTesting()},
+		"after testing mode":  {WithTesting(), WithHAKeeperHeartbeatTimeout(explicit)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := new(cluster)
+			for _, option := range options {
+				option(c)
+			}
+			require.Equal(t, explicit, c.options.heartbeatTimeout)
+			require.Equal(t, testHAKeeperStoreTimeout, c.options.storeTimeout)
+		})
 	}
 }
 

--- a/pkg/embed/config_test.go
+++ b/pkg/embed/config_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
@@ -39,6 +40,7 @@ func TestParseTNConfig(t *testing.T) {
 	max-size = 512
 
 	[hakeeper-client]
+	backend-read-timeout = "20s"
 	service-addresses = [
 		"1",
 		"2"
@@ -71,6 +73,7 @@ func TestParseTNConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, tnservice.StorageMEMKV, cfg.getTNServiceConfig().Txn.Storage.Backend)
 	assert.Equal(t, 2, len(cfg.FileServices))
+	assert.Equal(t, 20*time.Second, cfg.HAKeeperClient.BackendReadTimeout.Duration)
 	assert.Equal(t, "local", cfg.FileServices[0].Name)
 	assert.Equal(t, defines.SharedFileServiceName, cfg.FileServices[1].Name)
 	assert.Equal(t, 2, len(cfg.getTNServiceConfig().HAKeeper.ClientConfig.ServiceAddresses))

--- a/pkg/embed/options.go
+++ b/pkg/embed/options.go
@@ -17,7 +17,14 @@ package embed
 import "time"
 
 const (
-	testHAKeeperStoreTimeout = 60 * time.Second
+	// Test clusters run under the race detector and may lose several seconds to
+	// scheduler instrumentation while a catalog-heavy transaction is active.
+	// Keep the heartbeat request alive through a transient scheduler stall, and
+	// keep the shared transport alive longer than that request. Both remain
+	// bounded well inside the store-liveness window so real failures are retried.
+	testHAKeeperHeartbeatTimeout   = 15 * time.Second
+	testHAKeeperBackendReadTimeout = 20 * time.Second
+	testHAKeeperStoreTimeout       = 60 * time.Second
 )
 
 func WithConfigs(
@@ -47,6 +54,9 @@ func WithCNCount(
 func WithTesting() Option {
 	return func(c *cluster) {
 		c.options.testing = true
+		if c.options.heartbeatTimeout == 0 {
+			c.options.heartbeatTimeout = testHAKeeperHeartbeatTimeout
+		}
 		if c.options.storeTimeout == 0 {
 			c.options.storeTimeout = testHAKeeperStoreTimeout
 		}

--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -288,8 +288,9 @@ func (c *Config) GetHAKeeperClientConfig() HAKeeperClientConfig {
 	saddr := make([]string, 0)
 	saddr = append(saddr, c.HAKeeperClientConfig.ServiceAddresses...)
 	return HAKeeperClientConfig{
-		DiscoveryAddress: c.HAKeeperClientConfig.DiscoveryAddress,
-		ServiceAddresses: saddr,
+		DiscoveryAddress:   c.HAKeeperClientConfig.DiscoveryAddress,
+		ServiceAddresses:   saddr,
+		BackendReadTimeout: c.HAKeeperClientConfig.BackendReadTimeout,
 	}
 }
 
@@ -597,6 +598,17 @@ type HAKeeperClientConfig struct {
 	AllocateIDBatch uint64 `toml:"allocate-id-batch"`
 	// EnableCompress enable compress
 	EnableCompress bool `toml:"enable-compress"`
+	// BackendReadTimeout bounds how long the shared HAKeeper transport waits
+	// without a response before replacing the connection. Caller contexts
+	// independently bound individual requests.
+	BackendReadTimeout toml.Duration `toml:"backend-read-timeout"`
+}
+
+func (c HAKeeperClientConfig) backendReadTimeout() time.Duration {
+	if c.BackendReadTimeout.Duration == 0 {
+		return defaultBackendReadTimeout
+	}
+	return c.BackendReadTimeout.Duration
 }
 
 // Validate validates the HAKeeperClientConfig.
@@ -606,6 +618,11 @@ func (c *HAKeeperClientConfig) Validate() error {
 	}
 	if c.AllocateIDBatch == 0 {
 		c.AllocateIDBatch = 100
+	}
+	if c.BackendReadTimeout.Duration == 0 {
+		c.BackendReadTimeout.Duration = c.backendReadTimeout()
+	} else if c.BackendReadTimeout.Duration < 0 {
+		return moerr.NewBadConfigNoCtx("backend-read-timeout must be positive")
 	}
 	return nil
 }

--- a/pkg/logservice/config_test.go
+++ b/pkg/logservice/config_test.go
@@ -16,8 +16,10 @@ package logservice
 
 import (
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -233,32 +235,66 @@ func TestClientConfigValidate(t *testing.T) {
 
 func TestHAKeeperClientConfigValidate(t *testing.T) {
 	tests := []struct {
-		cfg HAKeeperClientConfig
-		ok  bool
+		name        string
+		cfg         HAKeeperClientConfig
+		ok          bool
+		wantTimeout time.Duration
 	}{
 		{
-			HAKeeperClientConfig{}, true,
+			"defaults", HAKeeperClientConfig{}, true, defaultBackendReadTimeout,
 		},
 		{
-			HAKeeperClientConfig{DiscoveryAddress: "localhost:9090"}, true,
+			"discovery address", HAKeeperClientConfig{DiscoveryAddress: "localhost:9090"}, true,
+			defaultBackendReadTimeout,
 		},
 		{
-			HAKeeperClientConfig{ServiceAddresses: []string{"localhost:9090"}}, true,
+			"service address", HAKeeperClientConfig{ServiceAddresses: []string{"localhost:9090"}}, true,
+			defaultBackendReadTimeout,
 		},
 		{
+			"both address forms",
 			HAKeeperClientConfig{
 				DiscoveryAddress: "localhost:9091",
 				ServiceAddresses: []string{"localhost:9090"},
-			}, true,
+			},
+			true,
+			defaultBackendReadTimeout,
+		},
+		{
+			"explicit backend timeout",
+			HAKeeperClientConfig{
+				BackendReadTimeout: toml.Duration{Duration: 20 * time.Second},
+			},
+			true,
+			20 * time.Second,
+		},
+		{
+			"negative backend timeout",
+			HAKeeperClientConfig{
+				BackendReadTimeout: toml.Duration{Duration: -time.Second},
+			},
+			false,
+			0,
 		},
 	}
 
 	for _, tt := range tests {
-		err := tt.cfg.Validate()
-		if tt.ok {
-			assert.NoError(t, err)
-		} else {
-			assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.ok {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantTimeout, tt.cfg.BackendReadTimeout.Duration)
+			} else {
+				assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+			}
+		})
 	}
+}
+
+func TestGetHAKeeperClientConfigPreservesBackendReadTimeout(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.HAKeeperClientConfig.BackendReadTimeout.Duration = 20 * time.Second
+
+	clientCfg := cfg.GetHAKeeperClientConfig()
+	require.Equal(t, 20*time.Second, clientCfg.BackendReadTimeout.Duration)
 }

--- a/pkg/logservice/hakeeper_client.go
+++ b/pkg/logservice/hakeeper_client.go
@@ -1150,7 +1150,7 @@ func connectToHAKeeper(
 			c.respPool,
 			defaultMaxMessageSize,
 			cfg.EnableCompress,
-			defaultBackendReadTimeout,
+			cfg.backendReadTimeout(),
 			"connectToHAKeeper",
 		)
 		if err != nil {

--- a/pkg/tests/issues/authenticated_cluster_test.go
+++ b/pkg/tests/issues/authenticated_cluster_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 const (
-	authenticatedClusterStoreTimeout = 60 * time.Second
+	authenticatedClusterHeartbeatTimeout = 15 * time.Second
+	authenticatedClusterBackendTimeout   = 20 * time.Second
+	authenticatedClusterStoreTimeout     = 60 * time.Second
 )
 
 func runAuthenticatedClusterTest(t *testing.T, fn func(embed.Cluster)) {
@@ -48,16 +50,24 @@ func TestAuthenticatedTestsReuseBaseCluster(t *testing.T) {
 	var cnCount, tnCount, logCount int
 	authenticatedCluster.ForeachServices(func(svc embed.ServiceOperator) bool {
 		cfg := svc.GetServiceConfig()
+		require.Equal(t, authenticatedClusterBackendTimeout,
+			cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		switch svc.ServiceType() {
 		case metadata.ServiceType_CN:
 			cnCount++
 			require.False(t, cfg.CN.Frontend.SkipCheckUser)
-			require.Zero(t, cfg.CN.HAKeeper.HeatbeatTimeout.Duration)
+			require.Equal(t, authenticatedClusterHeartbeatTimeout,
+				cfg.CN.HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t, cfg.CN.HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_TN:
 			tnCount++
 			require.NotNil(t, cfg.TN_please_use_getTNServiceConfig)
-			require.Zero(t,
+			require.Equal(t, authenticatedClusterHeartbeatTimeout,
 				cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration)
+			require.Less(t,
+				cfg.TN_please_use_getTNServiceConfig.HAKeeper.HeatbeatTimeout.Duration,
+				cfg.HAKeeperClient.BackendReadTimeout.Duration)
 		case metadata.ServiceType_LOG:
 			logCount++
 			require.Equal(
@@ -70,6 +80,8 @@ func TestAuthenticatedTestsReuseBaseCluster(t *testing.T) {
 				authenticatedClusterStoreTimeout,
 				cfg.LogService.HAKeeperConfig.CNStoreTimeout.Duration,
 			)
+			require.Less(t, cfg.HAKeeperClient.BackendReadTimeout.Duration,
+				cfg.LogService.HAKeeperConfig.TNStoreTimeout.Duration)
 		}
 		return true
 	})

--- a/pkg/tests/issues/isolated/issue_26114_test.go
+++ b/pkg/tests/issues/isolated/issue_26114_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package issues
+package isolated
 
 import (
 	"context"
@@ -24,13 +24,46 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/stretchr/testify/require"
 )
 
+func runIssue26114ClusterTest(t *testing.T, fn func(embed.Cluster)) {
+	t.Helper()
+	cluster, err := embed.StartTestCluster(
+		embed.WithCNCount(1),
+		embed.WithPreStart(func(service embed.ServiceOperator) {
+			if service.ServiceType() != metadata.ServiceType_CN {
+				return
+			}
+			service.Adjust(func(config *embed.ServiceConfig) {
+				config.CN.LockService.MaxFixedSliceSize = 10001
+				config.CN.LockService.MaxLockRowCount = 10000
+				config.CN.Frontend.SkipCheckUser = false
+			})
+		}),
+	)
+	if cluster != nil {
+		t.Cleanup(func() { require.NoError(t, cluster.Close()) })
+	}
+	require.NoError(t, err)
+	fn(cluster)
+}
+
+func execIssue26114SQLRequire(t *testing.T, ctx context.Context, db *sql.DB, statement string) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, statement)
+	require.NoErrorf(t, err, "exec failed: %s", statement)
+}
+
+func execIssue26114SQLMaybe(ctx context.Context, db *sql.DB, statement string) {
+	_, _ = db.ExecContext(ctx, statement)
+}
+
 func TestIssue26114CrossAccountBranchUsesTargetQuotaAndOwnership(t *testing.T) {
-	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
+	runIssue26114ClusterTest(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
 		defer cancel()
 
@@ -41,7 +74,7 @@ func TestIssue26114CrossAccountBranchUsesTargetQuotaAndOwnership(t *testing.T) {
 		require.NoError(t, err)
 		defer sysDB.Close()
 		sysDB.SetMaxOpenConns(4)
-		execSQLRequire(t, ctx, sysDB, "set role moadmin")
+		execIssue26114SQLRequire(t, ctx, sysDB, "set role moadmin")
 
 		const (
 			accountName   = "issue_26114_target"
@@ -55,36 +88,36 @@ func TestIssue26114CrossAccountBranchUsesTargetQuotaAndOwnership(t *testing.T) {
 		defer func() {
 			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cleanupCancel()
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop snapshot if exists "+tableSnapshot)
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop snapshot if exists "+dbSnapshot)
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop database if exists `"+sourceDB+"`")
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop database if exists `"+dbSource+"`")
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop account if exists "+accountName)
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop snapshot if exists "+tableSnapshot)
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop snapshot if exists "+dbSnapshot)
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop database if exists `"+sourceDB+"`")
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop database if exists `"+dbSource+"`")
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop account if exists "+accountName)
 		}()
 
-		execSQLMaybe(t, ctx, sysDB, "drop account if exists "+accountName)
+		execIssue26114SQLMaybe(ctx, sysDB, "drop account if exists "+accountName)
 		accountID := testutils.CreateAccount(t, c, accountName, "111")
-		execSQLRequire(t, ctx, sysDB, "select mo_feature_registry_upsert('branch', 'Branch feature', '{\"allowed_scope\":[]}', true)")
-		execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+		execIssue26114SQLRequire(t, ctx, sysDB, "select mo_feature_registry_upsert('branch', 'Branch feature', '{\"allowed_scope\":[]}', true)")
+		execIssue26114SQLRequire(t, ctx, sysDB, fmt.Sprintf(
 			"select mo_feature_limit_upsert(%d, 'branch', '', 0)", accountID))
 
 		tenantDB, err := sql.Open("mysql", fmt.Sprintf(
 			"%s#root#accountadmin:111@tcp(127.0.0.1:%d)/", accountName, port))
 		require.NoError(t, err)
 		defer tenantDB.Close()
-		execSQLRequire(t, ctx, tenantDB, "create database `"+targetDB+"`")
+		execIssue26114SQLRequire(t, ctx, tenantDB, "create database `"+targetDB+"`")
 
-		execSQLRequire(t, ctx, sysDB, "create database `"+sourceDB+"`")
-		execSQLRequire(t, ctx, sysDB, "create table `"+sourceDB+"`.`base` (id int primary key)")
-		execSQLRequire(t, ctx, sysDB, "insert into `"+sourceDB+"`.`base` values (1)")
-		execSQLRequire(t, ctx, sysDB, "create snapshot "+tableSnapshot+" for table `"+sourceDB+"` `base`")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create database `"+sourceDB+"`")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create table `"+sourceDB+"`.`base` (id int primary key)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "insert into `"+sourceDB+"`.`base` values (1)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create snapshot "+tableSnapshot+" for table `"+sourceDB+"` `base`")
 
-		execSQLRequire(t, ctx, sysDB, "create database `"+dbSource+"`")
-		execSQLRequire(t, ctx, sysDB, "create table `"+dbSource+"`.`t1` (id int primary key)")
-		execSQLRequire(t, ctx, sysDB, "create table `"+dbSource+"`.`t2` (id int primary key)")
-		execSQLRequire(t, ctx, sysDB, "insert into `"+dbSource+"`.`t1` values (1)")
-		execSQLRequire(t, ctx, sysDB, "insert into `"+dbSource+"`.`t2` values (2)")
-		execSQLRequire(t, ctx, sysDB, "create snapshot "+dbSnapshot+" for database `"+dbSource+"`")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create database `"+dbSource+"`")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create table `"+dbSource+"`.`t1` (id int primary key)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create table `"+dbSource+"`.`t2` (id int primary key)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "insert into `"+dbSource+"`.`t1` values (1)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "insert into `"+dbSource+"`.`t2` values (2)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create snapshot "+dbSnapshot+" for database `"+dbSource+"`")
 
 		_, err = sysDB.ExecContext(ctx, "data branch create table `"+targetDB+"`.`blocked` from `"+
 			sourceDB+"`.`base`{snapshot='"+tableSnapshot+"'} to account "+accountName)
@@ -104,7 +137,7 @@ func TestIssue26114CrossAccountBranchUsesTargetQuotaAndOwnership(t *testing.T) {
 			"select count(*) from mo_catalog.mo_database where datname = '"+dbDestination+"'").Scan(&count))
 		require.Zero(t, count)
 
-		execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+		execIssue26114SQLRequire(t, ctx, sysDB, fmt.Sprintf(
 			"select mo_feature_limit_upsert(%d, 'branch', '', 1)", accountID))
 		start := make(chan struct{})
 		results := make(chan error, 2)
@@ -134,11 +167,11 @@ func TestIssue26114CrossAccountBranchUsesTargetQuotaAndOwnership(t *testing.T) {
 			"select count(*) from mo_catalog.mo_tables where reldatabase = '"+targetDB+"' and relname in ('race_one', 'race_two')").Scan(&count))
 		require.Equal(t, 1, count)
 
-		execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+		execIssue26114SQLRequire(t, ctx, sysDB, fmt.Sprintf(
 			"select mo_feature_limit_upsert(%d, 'branch', '', 4)", accountID))
-		execSQLRequire(t, ctx, sysDB, "data branch create table `"+targetDB+"`.`allowed` from `"+
+		execIssue26114SQLRequire(t, ctx, sysDB, "data branch create table `"+targetDB+"`.`allowed` from `"+
 			sourceDB+"`.`base`{snapshot='"+tableSnapshot+"'} to account "+accountName)
-		execSQLRequire(t, ctx, sysDB, "data branch create database `"+dbDestination+"` from `"+
+		execIssue26114SQLRequire(t, ctx, sysDB, "data branch create database `"+dbDestination+"` from `"+
 			dbSource+"`{snapshot='"+dbSnapshot+"'} to account "+accountName)
 
 		require.NoError(t, sysDB.QueryRowContext(ctx, fmt.Sprintf(
@@ -149,7 +182,7 @@ func TestIssue26114CrossAccountBranchUsesTargetQuotaAndOwnership(t *testing.T) {
 }
 
 func TestIssue26114LegacyCrossAccountMetadataCountsTowardTargetQuota(t *testing.T) {
-	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
+	runIssue26114ClusterTest(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
 		defer cancel()
 
@@ -159,7 +192,7 @@ func TestIssue26114LegacyCrossAccountMetadataCountsTowardTargetQuota(t *testing.
 		sysDB, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", port))
 		require.NoError(t, err)
 		defer sysDB.Close()
-		execSQLRequire(t, ctx, sysDB, "set role moadmin")
+		execIssue26114SQLRequire(t, ctx, sysDB, "set role moadmin")
 
 		const (
 			accountName = "issue_26114_legacy_target"
@@ -170,29 +203,29 @@ func TestIssue26114LegacyCrossAccountMetadataCountsTowardTargetQuota(t *testing.
 		defer func() {
 			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cleanupCancel()
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop snapshot if exists "+snapshot)
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop database if exists `"+sourceDB+"`")
-			execSQLMaybe(t, cleanupCtx, sysDB, "drop account if exists "+accountName)
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop snapshot if exists "+snapshot)
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop database if exists `"+sourceDB+"`")
+			execIssue26114SQLMaybe(cleanupCtx, sysDB, "drop account if exists "+accountName)
 		}()
 
-		execSQLMaybe(t, ctx, sysDB, "drop account if exists "+accountName)
+		execIssue26114SQLMaybe(ctx, sysDB, "drop account if exists "+accountName)
 		accountID := testutils.CreateAccount(t, c, accountName, "111")
-		execSQLRequire(t, ctx, sysDB, "select mo_feature_registry_upsert('branch', 'Branch feature', '{\"allowed_scope\":[]}', true)")
-		execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+		execIssue26114SQLRequire(t, ctx, sysDB, "select mo_feature_registry_upsert('branch', 'Branch feature', '{\"allowed_scope\":[]}', true)")
+		execIssue26114SQLRequire(t, ctx, sysDB, fmt.Sprintf(
 			"select mo_feature_limit_upsert(%d, 'branch', '', -1)", accountID))
 
 		tenantDB, err := sql.Open("mysql", fmt.Sprintf(
 			"%s#root#accountadmin:111@tcp(127.0.0.1:%d)/", accountName, port))
 		require.NoError(t, err)
 		defer tenantDB.Close()
-		execSQLRequire(t, ctx, tenantDB, "create database `"+targetDB+"`")
+		execIssue26114SQLRequire(t, ctx, tenantDB, "create database `"+targetDB+"`")
 
-		execSQLRequire(t, ctx, sysDB, "create database `"+sourceDB+"`")
-		execSQLRequire(t, ctx, sysDB, "create table `"+sourceDB+"`.`base` (id int primary key)")
-		execSQLRequire(t, ctx, sysDB, "insert into `"+sourceDB+"`.`base` values (1)")
-		execSQLRequire(t, ctx, sysDB, "create snapshot "+snapshot+" for table `"+sourceDB+"` `base`")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create database `"+sourceDB+"`")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create table `"+sourceDB+"`.`base` (id int primary key)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "insert into `"+sourceDB+"`.`base` values (1)")
+		execIssue26114SQLRequire(t, ctx, sysDB, "create snapshot "+snapshot+" for table `"+sourceDB+"` `base`")
 
-		execSQLRequire(t, ctx, sysDB, "data branch create table `"+targetDB+"`.`legacy` from `"+
+		execIssue26114SQLRequire(t, ctx, sysDB, "data branch create table `"+targetDB+"`.`legacy` from `"+
 			sourceDB+"`.`base`{snapshot='"+snapshot+"'} to account "+accountName)
 
 		var legacyTableID uint64
@@ -206,7 +239,7 @@ func TestIssue26114LegacyCrossAccountMetadataCountsTowardTargetQuota(t *testing.
 			executor.Options{}.WithDatabase("mo_catalog").WithAccountID(0))
 		require.NoError(t, err)
 		result.Close()
-		execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
+		execIssue26114SQLRequire(t, ctx, sysDB, fmt.Sprintf(
 			"select mo_feature_limit_upsert(%d, 'branch', '', 1)", accountID))
 
 		_, err = sysDB.ExecContext(ctx, "data branch create table `"+targetDB+"`.`should_reject` from `"+


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #26441

## What this PR does / why we need it:

- Isolates the issue 26114 cross-account branch tests on a dedicated embedded cluster with an independent lifecycle, avoiding interference from the shared authenticated test cluster.
- Aligns test-mode HAKeeper timing as `15s heartbeat < 20s backend transport < 60s store liveness`.
- Propagates the configurable HAKeeper backend read timeout through service configuration while preserving production defaults and explicit values.
- Keeps the existing quota, ownership, legacy metadata, and concurrent branch assertions.

Validation:

- `pkg/embed` coverage: 84.3%
- `pkg/logservice` coverage: 79.7%
- Focused and owning-package normal/race tests passed.
- `go list`, CGo-aware build/vet, gofmt, and diff checks passed.
