### PR TITLE
fix(fulltext): preserve base rows for score-only MATCH expressions

### DIFF
--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -134,17 +134,8 @@ func (builder *QueryBuilder) applyIndicesForProjectionUsingFullTextIndex(nodeID 
 			if builder.jsonProbeFtNodes[id] {
 				continue
 			}
-			ftnode := builder.qry.Nodes[id]
 			orderByScore = append(orderByScore, &OrderBySpec{
-				Expr: &Expr{
-					Typ: ftnode.TableDef.Cols[1].Typ, // score column
-					Expr: &plan.Expr_Col{
-						Col: &plan.ColRef{
-							RelPos: ftnode.BindingTags[0],
-							ColPos: 1, // score column
-						},
-					},
-				},
+				Expr: builder.fullTextScoreExpr(id, served),
 				Flag: plan.OrderBySpec_DESC,
 			})
 		}
@@ -155,17 +146,8 @@ func (builder *QueryBuilder) applyIndicesForProjectionUsingFullTextIndex(nodeID 
 				continue
 			}
 
-			ftnode := builder.qry.Nodes[id]
 			orderByScore = append(orderByScore, &OrderBySpec{
-				Expr: &Expr{
-					Typ: ftnode.TableDef.Cols[1].Typ, // score column
-					Expr: &plan.Expr_Col{
-						Col: &plan.ColRef{
-							RelPos: ftnode.BindingTags[0],
-							ColPos: 1, // score column
-						},
-					},
-				},
+				Expr: builder.fullTextScoreExpr(id, served),
 				Flag: plan.OrderBySpec_DESC,
 			})
 		}
@@ -188,7 +170,7 @@ func (builder *QueryBuilder) applyIndicesForProjectionUsingFullTextIndex(nodeID 
 			if s.nodeID < 0 || ordered[s.nodeID] || builder.jsonProbeFtNodes[s.nodeID] {
 				continue
 			}
-			scoreExpr := builder.fullTextScoreColRef(s.nodeID)
+			scoreExpr := builder.fullTextScoreExpr(s.nodeID, served)
 			if scoreExpr == nil {
 				continue
 			}
@@ -226,16 +208,7 @@ func (builder *QueryBuilder) applyIndicesForProjectionUsingFullTextIndex(nodeID 
 	// replace the project with ColRef
 	for i, id := range proj_node_ids {
 		idx := projids[i]
-		ftnode := builder.qry.Nodes[id]
-		projNode.ProjectList[idx] = &Expr{
-			Typ: ftnode.TableDef.Cols[1].Typ, // score column
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{
-					RelPos: ftnode.BindingTags[0],
-					ColPos: 1, // score column
-				},
-			},
-		}
+		projNode.ProjectList[idx] = builder.fullTextScoreExpr(id, served)
 	}
 
 	// The loop above only rewrites projections that ARE a bare fulltext_match, because
@@ -406,6 +379,25 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	}
 	scanNode.FilterList = kept
 
+	// Only a membership-implying WHERE predicate may remove nonmatching rows.
+	// Projection/ORDER BY streams supply scores, not an intersection of doc IDs.
+	var drivingMatches []*plan.Expr
+	for _, expr := range wrappedMatchFilters {
+		drivingMatches = collectDrivingFullTextMatches(expr, drivingMatches)
+	}
+	required := make([]bool, len(ft_filters))
+	preserveRows := false
+	for i, expr := range ft_filters {
+		required[i] = i < len(filterids)
+		for _, driving := range drivingMatches {
+			if builder.equalsFullTextMatchFunc(expr.GetF(), driving.GetF()) {
+				required[i] = true
+				break
+			}
+		}
+		preserveRows = preserveRows || !required[i]
+	}
+
 	// fulltext2 INCLUDE/pk prefilter pushdown: when the driving index is a fulltext2 index
 	// WITH INCLUDE columns, peel the WHERE predicates on those INCLUDE columns (and the pk)
 	// out of scanNode.FilterList into the ivfpq-aligned predicate JSON, which fulltext2_search
@@ -416,7 +408,7 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	// Removing the peeled predicates lets the pre-filter second-scan below be skipped when no
 	// residual filter remains.
 	var ft2PredsJSON string
-	if len(indexDefs) > 0 && catalog.IsFullText2IndexAlgo(indexDefs[0].IndexAlgo) {
+	if !preserveRows && len(indexDefs) > 0 && catalog.IsFullText2IndexAlgo(indexDefs[0].IndexAlgo) {
 		if incCols := indexDefIncludedColumnsBestEffort(indexDefs[0]); len(incCols) > 0 {
 			pkColName := fulltext2PeelablePkColName(scanNode) // "" for a non-evaluable pk type
 			preds, serialized, residual, perr := buildFilterPredicateJSON(scanNode.FilterList, scanNode, incCols, pkColName, true)
@@ -430,7 +422,7 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	// Resolve the residual-WHERE prefilter before deciding whether the internal
 	// fulltext stream may keep only LIMIT+OFFSET candidates. The early LIMIT is
 	// correctness-safe only when that prefilter is exact.
-	pushdownEnabled := len(scanNode.FilterList) > 0
+	pushdownEnabled := !preserveRows && len(scanNode.FilterList) > 0
 	if pushdownEnabled && types.T(pkType.Id).IsInteger() &&
 		!localProtocolEnablesSortedMembershipFilter(builder.compCtx.GetProcess().GetService()) {
 		pushdownEnabled = false
@@ -459,13 +451,20 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 
 	// A lifted wrapped-MATCH predicate counts here exactly like a filter left on the scan. It
 	// runs above the join, so limiting the stream below it can under-fill the final result.
-	limitExpr := builder.buildFullTextCandidateLimit(
-		scanNode, wrappedMatchFilters, ft_filters, indexDefs, pushdownEnabled, exactPrefilter,
-		paginationLimit, paginationOffset)
+	var limitExpr *plan.Expr
+	if !preserveRows {
+		// An omitted matching document must not become a zero score after LEFT JOIN.
+		limitExpr = builder.buildFullTextCandidateLimit(
+			scanNode, wrappedMatchFilters, ft_filters, indexDefs, pushdownEnabled, exactPrefilter,
+			paginationLimit, paginationOffset)
+	}
 
 	// buildFullTextIndexScan
 	var last_node_id int32
 	var last_ftnode_pkcol *Expr
+	if preserveRows {
+		last_node_id = scanNode.NodeId
+	}
 
 	for i := 0; i < len(ft_filters); i++ {
 		ftidxscan := ft_filters[i]
@@ -499,6 +498,10 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 		// 2-member dispatch stays inline (not an index-plugin hook) because building the
 		// node needs QueryBuilder internals a plugin sub-package must not import.
 		var curr_ftnode_id int32
+		guardFilters := wrappedMatchFilters
+		if !required[i] {
+			guardFilters = nil
+		}
 		if catalog.IsFullText2IndexAlgo(idxdef.IndexAlgo) {
 			cfg, cfgErr := builder.buildFulltext2SearchCfg(scanNode, idxdef, mode)
 			if cfgErr != nil {
@@ -514,7 +517,7 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 			// from the predicates the lift moved above the join -- they stay there too, so the
 			// pushed (deliberately widened) range can only ever remove work, not rows.
 			var scoreRangeJSON string
-			if rng := builder.fulltext2ScoreRangeFromFilters(wrappedMatchFilters, fn); rng != nil {
+			if rng := builder.fulltext2ScoreRangeFromFilters(guardFilters, fn); rng != nil {
 				rb, rerr := json.Marshal(rng)
 				if rerr != nil {
 					return -1, nil, nil, nil, rerr
@@ -540,7 +543,7 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 			// Optional 6th argument: the zero-relevance guard for a threshold only known
 			// at EXECUTE. Arguments are positional, so the two optional JSON slots are
 			// padded when only the guard is needed.
-			guard, gerr := builder.fulltextRuntimeScoreGuard(wrappedMatchFilters, fn)
+			guard, gerr := builder.fulltextRuntimeScoreGuard(guardFilters, fn)
 			if gerr != nil {
 				return -1, nil, nil, nil, gerr
 			}
@@ -574,7 +577,7 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 			}
 			// Optional 5th argument: the zero-relevance guard for a threshold only known
 			// at EXECUTE. See fulltextRuntimeScoreGuard.
-			guard, gerr := builder.fulltextRuntimeScoreGuard(wrappedMatchFilters, fn)
+			guard, gerr := builder.fulltextRuntimeScoreGuard(guardFilters, fn)
 			if gerr != nil {
 				return -1, nil, nil, nil, gerr
 			}
@@ -652,7 +655,34 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 			curr_ftnode_id, curr_ftnode_pkcol = builder.dedupFulltextDocIDs(ctx, curr_ftnode_id, curr_ftnode_pkcol)
 		}
 
-		if i > 0 {
+		if preserveRows {
+			joinType := plan.Node_INNER
+			if !required[i] {
+				joinType = plan.Node_LEFT
+				score := builder.fullTextScoreColRef(served[i].nodeID)
+				score.Typ.NotNullable = false
+				served[i].score, err = BindFuncExprImplByPlanExpr(builder.GetContext(), "coalesce", []*Expr{
+					score, makePlan2Float32ConstExprWithType(0),
+				})
+				if err != nil {
+					return -1, nil, nil, nil, err
+				}
+			}
+			// Always join against the base PK, never a previous nullable stream's PK.
+			basePK := &Expr{Typ: pkType, Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{RelPos: scanNode.BindingTags[0], ColPos: pkPos},
+			}}
+			on, bindErr := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{basePK, curr_ftnode_pkcol})
+			if bindErr != nil {
+				return -1, nil, nil, nil, bindErr
+			}
+			last_node_id = builder.appendNode(&plan.Node{
+				NodeType: plan.Node_JOIN,
+				Children: []int32{last_node_id, curr_ftnode_id},
+				JoinType: joinType,
+				OnList:   []*Expr{on},
+			}, ctx)
+		} else if i > 0 {
 			// JOIN last_node_id and curr_ftnode_id
 			// JOIN INNER with children (curr_ftnode_id, last_node_id)
 
@@ -680,7 +710,9 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	// to reduce the number of doc_ids that fulltext_index_scan must process.
 	var joinnodeID int32
 
-	if pushdownEnabled {
+	if preserveRows {
+		joinnodeID = last_node_id
+	} else if pushdownEnabled {
 		// Pre-filter pushdown mode:
 		//   outerJoin( scanNode, innerJoin( ft_func_chain, secondScanProject ) )
 		//
@@ -1535,6 +1567,7 @@ func (builder *QueryBuilder) equalsFullTextMatchFunc(fn1 *plan.Function, fn2 *pl
 type fulltextServedMatch struct {
 	fn     *plan.Function
 	nodeID int32
+	score  *plan.Expr // Optional streams use COALESCE(score, 0) after LEFT JOIN.
 }
 
 // isServedFullTextMatch reports whether one of served is the SAME MATCH as fn.
@@ -1598,7 +1631,7 @@ func (builder *QueryBuilder) servedFullTextScoreSameTable(fn *plan.Function, ser
 		if s.fn == nil || len(s.fn.Args) < 2 || !builder.equalsFullTextMatchFuncSameTable(fn, s.fn) {
 			continue
 		}
-		if expr := builder.fullTextScoreColRef(s.nodeID); expr != nil {
+		if expr := builder.fullTextScoreExpr(s.nodeID, served); expr != nil {
 			return expr
 		}
 	}
@@ -1623,6 +1656,15 @@ func (builder *QueryBuilder) fullTextScoreColRef(nodeID int32) *plan.Expr {
 	}
 }
 
+func (builder *QueryBuilder) fullTextScoreExpr(nodeID int32, served []fulltextServedMatch) *plan.Expr {
+	for _, s := range served {
+		if s.nodeID == nodeID && s.score != nil {
+			return DeepCopyExpr(s.score)
+		}
+	}
+	return builder.fullTextScoreColRef(nodeID)
+}
+
 // servedFullTextScore returns the score column of the index scan built for fn, or nil when no
 // served scan answers this particular MATCH or its node is not usable. Only meaningful after
 // the build loop has filled in the node ids.
@@ -1634,7 +1676,7 @@ func (builder *QueryBuilder) servedFullTextScore(fn *plan.Function, served []ful
 		if s.fn == nil || len(s.fn.Args) < 2 || !builder.equalsFullTextMatchFunc(fn, s.fn) {
 			continue
 		}
-		if expr := builder.fullTextScoreColRef(s.nodeID); expr != nil {
+		if expr := builder.fullTextScoreExpr(s.nodeID, served); expr != nil {
 			return expr
 		}
 	}

--- a/pkg/sql/plan/apply_indices_fulltext_guard_test.go
+++ b/pkg/sql/plan/apply_indices_fulltext_guard_test.go
@@ -118,6 +118,57 @@ func TestFullTextGuardCoversWrappedProjectionMatch(t *testing.T) {
 				"the MATCH must be served by a fulltext index scan")
 			require.Zero(t, countReachableFullTextMatches(builder.qry),
 				"a fulltext_match surviving into the executed plan throws 20105")
+
+			sort := builder.qry.Nodes[projNode.Children[0]]
+			require.Equal(t, planpb.Node_SORT, sort.NodeType)
+			join := builder.qry.Nodes[sort.Children[0]]
+			require.Equal(t, planpb.Node_LEFT, join.JoinType,
+				"a projection MATCH cannot discard nonmatching base rows")
+			require.Equal(t, scanID, join.Children[0])
+			require.Empty(t, scanNode.RuntimeFilterProbeList,
+				"a score-only stream must not prune the preserved side")
+			score := projNode.ProjectList[0]
+			if !tc.bare {
+				score = score.GetF().Args[0]
+			}
+			require.NotNil(t, score.GetF())
+			require.Equal(t, "coalesce", score.GetF().Func.ObjName)
+			require.False(t, score.GetF().Args[0].Typ.NotNullable)
+			require.Equal(t, float32(0), score.GetF().Args[1].GetLit().GetFval())
+		})
+	}
+}
+
+func TestFullTextScoreMembershipControlsCandidateLimit(t *testing.T) {
+	for _, required := range []bool{false, true} {
+		t.Run(map[bool]string{false: "optional", true: "required"}[required], func(t *testing.T) {
+			builder, scanID, projID := buildWrappedMatchGuardPlan(t, true)
+			// No residual predicate: previously both forms admitted candidate LIMIT.
+			scan := builder.qry.Nodes[scanID]
+			scan.FilterList = nil
+			proj := builder.qry.Nodes[projID]
+			if required {
+				scan.FilterList = []*planpb.Expr{DeepCopyExpr(proj.ProjectList[0])}
+			}
+			proj.Limit = makePlan2Uint64ConstExprWithType(1)
+			builder.prepareSpecialIndexGuards(projID)
+			_, err := builder.applyIndices(projID, map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+			require.NoError(t, err)
+			sort := builder.qry.Nodes[proj.Children[0]]
+			require.Equal(t, planpb.Node_SORT, sort.NodeType)
+			require.Equal(t, uint64(1), sort.Limit.GetLit().GetU64Val())
+			join := builder.qry.Nodes[sort.Children[0]]
+			functions := collectFullTextFunctionScans(builder, proj.Children[0])
+			require.Len(t, functions, 1)
+			if required {
+				require.Equal(t, planpb.Node_INNER, join.JoinType)
+				require.NotNil(t, functions[0].Limit, "retain the ordinary WHERE MATCH fast path")
+				require.NotNil(t, proj.ProjectList[0].GetCol())
+			} else {
+				require.Equal(t, planpb.Node_LEFT, join.JoinType)
+				require.Nil(t, functions[0].Limit,
+					"truncating an optional stream would turn omitted matching scores into zero")
+			}
 		})
 	}
 }

--- a/pkg/sql/plan/issue_28327_test.go
+++ b/pkg/sql/plan/issue_28327_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func issue28327Plan(t *testing.T) (*QueryBuilder, int32, *plan.Node, *plan.IndexDef) {
+	t.Helper()
+
+	builder := NewQueryBuilder(plan.Query_SELECT, newFullTextJoinMockCompilerContext(), false, true)
+	ctx := NewBindContext(builder, nil)
+	tableDef := makeFullTextJoinTestTableDef("ft_28327", true)
+	registerFullTextJoinRegularIndexTable(builder, tableDef.Indexes[0].IndexTableName)
+	tag := builder.genNewBindTag()
+	scan := makeFullTextJoinTestScan(tableDef, tag, nil)
+	scanID := builder.appendNode(scan, ctx)
+	return builder, scanID, scan, tableDef.Indexes[0]
+}
+
+func issue28327Match(tableDef *plan.TableDef, tag int32, pattern string) *plan.Expr {
+	return makeFullTextMatchExpr(pattern, 0, tableDef, tag, []int32{2, 3})
+}
+
+func TestIssue28327OptionalFullTextStreamsAnchorAtBase(t *testing.T) {
+	builder, scanID, scan, indexDef := issue28327Plan(t)
+	alpha := issue28327Match(scan.TableDef, scan.BindingTags[0], "alpha")
+	beta := issue28327Match(scan.TableDef, scan.BindingTags[0], "beta")
+	proj := &plan.Node{ProjectList: []*plan.Expr{alpha, beta}}
+
+	rootID, _, _, served, err := builder.applyJoinFullTextIndices(
+		scanID, proj, scan, makePlan2Uint64ConstExprWithType(2), nil,
+		nil, nil, []int32{0, 1}, []*plan.IndexDef{indexDef, indexDef},
+		nil, nil, map[int32]int32{}, map[[2]int32]int{}, map[[2]int32]*plan.Expr{})
+	require.NoError(t, err)
+
+	root := builder.qry.Nodes[rootID]
+	require.Equal(t, plan.Node_JOIN, root.NodeType)
+	require.Equal(t, plan.Node_LEFT, root.JoinType)
+	first := builder.qry.Nodes[root.Children[0]]
+	require.Equal(t, plan.Node_JOIN, first.NodeType)
+	require.Equal(t, plan.Node_LEFT, first.JoinType)
+	require.Equal(t, scanID, first.Children[0], "every optional stream must join from the base result")
+	for _, join := range []*plan.Node{first, root} {
+		require.Equal(t, scan.BindingTags[0], join.OnList[0].GetF().Args[0].GetCol().RelPos,
+			"a later stream cannot join through an earlier nullable score stream")
+	}
+
+	require.Len(t, served, 2)
+	for _, match := range []*plan.Expr{alpha, beta} {
+		score := builder.servedFullTextScore(match.GetF(), served)
+		require.NotNil(t, score, "each optional MATCH must have a NULL-safe score expression")
+		require.NotNil(t, score.GetF())
+		require.Equal(t, "coalesce", score.GetF().Func.ObjName)
+	}
+	for _, fn := range collectFullTextFunctionScans(builder, rootID) {
+		require.Nil(t, fn.Limit, "optional streams must not be early-truncated")
+	}
+}

--- a/pkg/tests/issues/issue_28327_test.go
+++ b/pkg/tests/issues/issue_28327_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestIssue28327FulltextScorePreservesBaseRows(t *testing.T) {
-	embed.RunSingleCNBaseClusterTests(t, func(c embed.Cluster) {
+	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
 		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 		defer cancel()
 

--- a/pkg/tests/issues/issue_28327_test.go
+++ b/pkg/tests/issues/issue_28327_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue28327FulltextScorePreservesBaseRows(t *testing.T) {
+	embed.RunSingleCNBaseClusterTests(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		dbName := testutils.GetDatabaseName(t)
+		db, err := sql.Open("mysql", fmt.Sprintf(
+			"dump:111@tcp(127.0.0.1:%d)/", cn.GetServiceConfig().CN.Frontend.Port))
+		require.NoError(t, err)
+		defer db.Close()
+		db.SetMaxOpenConns(1)
+
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		defer func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cleanupCancel()
+			_, _ = conn.ExecContext(cleanupCtx, "drop database if exists "+quoteIssue28327Ident(dbName))
+		}()
+
+		execIssue28327(t, ctx, conn, `set ft_relevancy_algorithm="TF-IDF"`)
+		execIssue28327(t, ctx, conn, "set experimental_fulltext_index = 1")
+		execIssue28327(t, ctx, conn, "set experimental_fulltext2_index = 1")
+		execIssue28327(t, ctx, conn, "drop database if exists "+quoteIssue28327Ident(dbName))
+		execIssue28327(t, ctx, conn, "create database "+quoteIssue28327Ident(dbName))
+		execIssue28327(t, ctx, conn, "use "+quoteIssue28327Ident(dbName))
+		for _, algorithm := range []string{"fulltext", "fulltext2"} {
+			t.Run(algorithm, func(t *testing.T) {
+				execIssue28327(t, ctx, conn, "drop table if exists docs")
+				execIssue28327(t, ctx, conn, "create table docs(id int primary key, body text)")
+				execIssue28327(t, ctx, conn, "insert into docs values (1, 'alpha'), (2, 'beta'), (3, 'alpha beta')")
+				execIssue28327(t, ctx, conn, "create "+algorithm+" index ft on docs(body)")
+
+				got := queryIssue28327IDs(t, ctx, conn,
+					"select id from docs order by match(body) against('alpha') desc, id")
+				t.Logf("ORDER BY-only MATCH result: %v", got)
+				require.Equal(t, []int{1, 3, 2}, got)
+				require.Equal(t, []int{1, 2, 3}, queryIssue28327IDs(t, ctx, conn,
+					"select id from docs order by match(body) against('missing') desc, id"))
+				require.Equal(t, []int{3, 2}, queryIssue28327IDs(t, ctx, conn,
+					"select id from docs where id > 1 order by match(body) against('alpha') desc, id"))
+				// TF-IDF and BM25 rank the two positive scores differently; test zero
+				// membership and pagination without pinning their scoring formulas.
+				require.Equal(t, []int{2, 1}, queryIssue28327IDs(t, ctx, conn,
+					"select id from docs order by (match(body) against('alpha') > 0), id limit 2"))
+				require.Equal(t, []int{2}, queryIssue28327IDs(t, ctx, conn,
+					"select id from docs where match(body) against('alpha') <= 0 "+
+						"order by match(body) against('alpha'), id"))
+
+				require.Equal(t, []issue28327ScoreState{
+					{id: 1, hasScore: sql.NullBool{Bool: true, Valid: true}, zeroScore: sql.NullBool{Bool: false, Valid: true}},
+					{id: 2, hasScore: sql.NullBool{Bool: false, Valid: true}, zeroScore: sql.NullBool{Bool: true, Valid: true}},
+					{id: 3, hasScore: sql.NullBool{Bool: true, Valid: true}, zeroScore: sql.NullBool{Bool: false, Valid: true}},
+				}, queryIssue28327ScoreStates(t, ctx, conn,
+					"select id, match(body) against('alpha') > 0, match(body) against('alpha') = 0 "+
+						"from docs order by id"))
+				require.Equal(t, []issue28327ScoreState{
+					{id: 1, hasScore: sql.NullBool{Bool: true, Valid: true}, zeroScore: sql.NullBool{Bool: false, Valid: true}},
+					{id: 2, hasScore: sql.NullBool{Bool: false, Valid: true}, zeroScore: sql.NullBool{Bool: true, Valid: true}},
+					{id: 3, hasScore: sql.NullBool{Bool: true, Valid: true}, zeroScore: sql.NullBool{Bool: false, Valid: true}},
+				}, queryIssue28327ScoreStates(t, ctx, conn,
+					"select id, round(match(body) against('alpha'), 3) > 0, "+
+						"round(match(body) against('alpha'), 3) = 0 from docs order by id"))
+
+				require.Equal(t, []issue28327DualScoreState{
+					{id: 1, alpha: sql.NullBool{Bool: true, Valid: true}, beta: sql.NullBool{Bool: false, Valid: true}},
+					{id: 2, alpha: sql.NullBool{Bool: false, Valid: true}, beta: sql.NullBool{Bool: true, Valid: true}},
+					{id: 3, alpha: sql.NullBool{Bool: true, Valid: true}, beta: sql.NullBool{Bool: true, Valid: true}},
+				}, queryIssue28327DualScoreStates(t, ctx, conn,
+					"select id, match(body) against('alpha') > 0, match(body) against('beta') > 0 "+
+						"from docs order by id"))
+
+				require.Equal(t, []issue28327ScoreState{
+					{id: 3, hasScore: sql.NullBool{Bool: true, Valid: true}, zeroScore: sql.NullBool{Bool: false, Valid: true}},
+					{id: 1, hasScore: sql.NullBool{Bool: false, Valid: true}, zeroScore: sql.NullBool{Bool: true, Valid: true}},
+				}, queryIssue28327ScoreStates(t, ctx, conn,
+					"select id, match(body) against('beta') > 0, match(body) against('beta') = 0 "+
+						"from docs where match(body) against('alpha') "+
+						"order by match(body) against('beta') desc, id"))
+				require.Equal(t, []issue28327ScoreState{
+					{id: 3, hasScore: sql.NullBool{Bool: true, Valid: true}, zeroScore: sql.NullBool{Bool: false, Valid: true}},
+					{id: 1, hasScore: sql.NullBool{Bool: false, Valid: true}, zeroScore: sql.NullBool{Bool: true, Valid: true}},
+				}, queryIssue28327ScoreStates(t, ctx, conn,
+					"select id, match(body) against('beta') > 0, match(body) against('beta') = 0 "+
+						"from docs where match(body) against('alpha') > 0 "+
+						"order by match(body) against('beta') desc, id"))
+			})
+		}
+	})
+}
+
+type issue28327ScoreState struct {
+	id                  int
+	hasScore, zeroScore sql.NullBool
+}
+
+type issue28327DualScoreState struct {
+	id          int
+	alpha, beta sql.NullBool
+}
+
+func execIssue28327(t *testing.T, ctx context.Context, conn *sql.Conn, statement string) {
+	t.Helper()
+	_, err := conn.ExecContext(ctx, statement)
+	require.NoErrorf(t, err, "exec failed: %s", statement)
+}
+
+func queryIssue28327IDs(t *testing.T, ctx context.Context, conn *sql.Conn, statement string) []int {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx, statement)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var ids []int
+	for rows.Next() {
+		var id int
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+	return ids
+}
+
+func queryIssue28327ScoreStates(t *testing.T, ctx context.Context, conn *sql.Conn, statement string) []issue28327ScoreState {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx, statement)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var result []issue28327ScoreState
+	for rows.Next() {
+		var row issue28327ScoreState
+		require.NoError(t, rows.Scan(&row.id, &row.hasScore, &row.zeroScore))
+		result = append(result, row)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+func queryIssue28327DualScoreStates(t *testing.T, ctx context.Context, conn *sql.Conn, statement string) []issue28327DualScoreState {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx, statement)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var result []issue28327DualScoreState
+	for rows.Next() {
+		var row issue28327DualScoreState
+		require.NoError(t, rows.Scan(&row.id, &row.alpha, &row.beta))
+		result = append(result, row)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+func quoteIssue28327Ident(name string) string {
+	return "`" + name + "`"
+}

--- a/test/distributed/cases/ddl/table_kind.result
+++ b/test/distributed/cases/ddl/table_kind.result
@@ -266,7 +266,17 @@ select * from src1 where match(body, title) against('red');
 3  ¦  blue is not red  ¦  colorful
 select *, match(body, title) against('is red' in natural language mode) as score from src1;
 ➤ id[-5,64,0]  ¦  body[12,-1,0]  ¦  title[12,0,0]  ¦  score[7,5,0]  𝄀
-0  ¦  color is red  ¦  t1  ¦  1.6311431
+0  ¦  color is red  ¦  t1  ¦  1.6311431  𝄀
+1  ¦  car is yellow  ¦  crazy car  ¦  0.0  𝄀
+2  ¦  sky is blue  ¦  no limit  ¦  0.0  𝄀
+3  ¦  blue is not red  ¦  colorful  ¦  0.0  𝄀
+4  ¦  遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。  ¦  遠東兒童中文  ¦  0.0  𝄀
+5  ¦  每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。  ¦  遠東兒童中文  ¦  0.0  𝄀
+6  ¦  各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。  ¦  中文短篇小說  ¦  0.0  𝄀
+7  ¦  59個簡單的英文和中文短篇小說  ¦  適合初學者  ¦  0.0  𝄀
+8  ¦  null  ¦  NOT INCLUDED  ¦  0.0  𝄀
+9  ¦  NOT INCLUDED BODY  ¦  null  ¦  0.0  𝄀
+10  ¦  null  ¦  null  ¦  0.0
 select * from src1 where match(body, title) against('教學指引');
 ➤ id[-5,64,0]  ¦  body[12,-1,0]  ¦  title[12,0,0]  𝄀
 6  ¦  各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。  ¦  中文短篇小說
@@ -310,7 +320,18 @@ select * from src2 where match(body, title) against('red');
 3  ¦  blue is not red  ¦  colorful
 select *, match(body, title) against('is red' in natural language mode) as score from src2;
 ➤ id[-5,64,0]  ¦  body[12,-1,0]  ¦  title[12,0,0]  ¦  score[7,5,0]  𝄀
-0  ¦  color is red  ¦  t1  ¦  1.6311431
+0  ¦  color is red  ¦  t1  ¦  1.6311431  𝄀
+1  ¦  car is yellow  ¦  crazy car  ¦  0.0  𝄀
+2  ¦  sky is blue  ¦  no limit  ¦  0.0  𝄀
+3  ¦  blue is not red  ¦  colorful  ¦  0.0  𝄀
+4  ¦  遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。  ¦  遠東兒童中文  ¦  0.0  𝄀
+5  ¦  每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。  ¦  遠東兒童中文  ¦  0.0  𝄀
+6  ¦  各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。  ¦  中文短篇小說
+  ¦  0.0  𝄀
+7  ¦  59個簡單的英文和中文短篇小說  ¦  適合初學者  ¦  0.0  𝄀
+8  ¦  null  ¦  NOT INCLUDED  ¦  0.0  𝄀
+9  ¦  NOT INCLUDED BODY  ¦  null  ¦  0.0  𝄀
+10  ¦  null  ¦  null  ¦  0.0
 select * from src2 where match(body, title) against('教學指引');
 ➤ id[-5,64,0]  ¦  body[12,-1,0]  ¦  title[12,0,0]  𝄀
 6  ¦  各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。  ¦  中文短篇小說
@@ -328,6 +349,16 @@ select * from src2 where match(body, title) against('版一、二冊' in natural
 select *, match(body, title) against('遠東兒童中文' in natural language mode) as score from src2;
 ➤ id[-5,64,0]  ¦  body[12,-1,0]  ¦  title[12,0,0]  ¦  score[7,5,0]  𝄀
 4  ¦  遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。  ¦  遠東兒童中文  ¦  1.9542363  𝄀
-5  ¦  每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。  ¦  遠東兒童中文  ¦  0.97711813
+5  ¦  每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。  ¦  遠東兒童中文  ¦  0.97711813  𝄀
+0  ¦  color is red  ¦  t1  ¦  0.0  𝄀
+1  ¦  car is yellow  ¦  crazy car  ¦  0.0  𝄀
+2  ¦  sky is blue  ¦  no limit  ¦  0.0  𝄀
+3  ¦  blue is not red  ¦  colorful  ¦  0.0  𝄀
+6  ¦  各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。  ¦  中文短篇小說
+  ¦  0.0  𝄀
+7  ¦  59個簡單的英文和中文短篇小說  ¦  適合初學者  ¦  0.0  𝄀
+8  ¦  null  ¦  NOT INCLUDED  ¦  0.0  𝄀
+9  ¦  NOT INCLUDED BODY  ¦  null  ¦  0.0  𝄀
+10  ¦  null  ¦  null  ¦  0.0
 drop table src2;
 DROP DATABASE IF EXISTS db1;

--- a/test/distributed/cases/fulltext/fulltext.result
+++ b/test/distributed/cases/fulltext/fulltext.result
@@ -68,26 +68,6 @@ id    body    title    score
 3    blue is not red    colorful    0.0
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
 7    59個簡單的英文和中文短篇小說    適合初學者    0.0
 8    null    NOT INCLUDED    0.0
@@ -114,24 +94,6 @@ id    body    title    score
 1    car is yellow    crazy car    0.0
 2    sky is blue    no limit    0.0
 3    blue is not red    colorful    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
 7    59個簡單的英文和中文短篇小說    適合初學者    0.0
 8    null    NOT INCLUDED    0.0
@@ -140,16 +102,6 @@ id    body    title    score
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.8211576
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 0    color is red    t1    0.0
 1    car is yellow    crazy car    0.0
 2    sky is blue    no limit    0.0
@@ -204,24 +156,6 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.48855907
 3    blue is not red    colorful    0.48855907
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 0    color is red    t1    0.0
 1    car is yellow    crazy car    0.0
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
@@ -283,6 +217,16 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    1.6311431
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說
@@ -300,9 +244,28 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.9542363
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.97711813
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.8211576
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -334,6 +297,15 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.48855907
 3    blue is not red    colorful    0.48855907
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -369,8 +341,6 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09061906
 id3    3    blue red    t4    0.09061906
-id0    0    red    t1    0.0
-id1    1    yellow    t2    0.0
 id0    0    red    t1    0.0
 id1    1    yellow    t2    0.0
 update src2 set body = 'orange' where id1='id0';
@@ -468,6 +438,16 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    1.6311431
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n
@@ -485,6 +465,15 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.9542363
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.97711813
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -516,6 +505,15 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.48855907
 3    blue is not red    colorful    0.48855907
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -569,6 +567,8 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09061906
 id3    3    blue red    t4    0.09061906
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
 desc src2;
 Field    Type    Null    Key    Default    Extra    Comment
 id1    VARCHAR(65535)    NO    PRI    null        

--- a/test/distributed/cases/fulltext/fulltext.result
+++ b/test/distributed/cases/fulltext/fulltext.result
@@ -63,6 +63,36 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    1.6311431
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說
@@ -80,9 +110,56 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.9542363
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.97711813
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.8211576
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -127,6 +204,33 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.48855907
 3    blue is not red    colorful    0.48855907
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -163,6 +267,15 @@ select match(body) against('red') from src;
 MATCH (body) AGAINST (red)
 0.42668658
 0.42668658
+0
+0
+0
+0
+0
+0
+0
+0
+0
 select * from src where match(body, title) against('red');
 id    body    title
 0    color is red    t1
@@ -256,6 +369,10 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09061906
 id3    3    blue red    t4    0.09061906
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
 update src2 set body = 'orange' where id1='id0';
 select * from src2 where match(body, title) against('red');
 id1    id2    body    title

--- a/test/distributed/cases/fulltext/fulltext2.result
+++ b/test/distributed/cases/fulltext/fulltext2.result
@@ -484,12 +484,21 @@ against ('Tutorial' in natural language mode) as score
 from articles;
 ➤ id[4,32,0]  ¦  score[7,5,0]  𝄀
 1  ¦  0.2276447  𝄀
-3  ¦  0.2276447
+3  ¦  0.2276447  𝄀
+2  ¦  0.0  𝄀
+4  ¦  0.0  𝄀
+5  ¦  0.0  𝄀
+6  ¦  0.0
 select id, body, match (title, body)
 against ('MO tutorial DBMS stands for' in natural language mode) as score
 from articles;
 ➤ id[4,32,0]  ¦  body[12,0,0]  ¦  score[7,5,0]  𝄀
-1  ¦  DBMS stands for DataBase ...  ¦  3.0275967
+1  ¦  DBMS stands for DataBase ...  ¦  3.0275967  𝄀
+2  ¦  After you went through a ...  ¦  0.0  𝄀
+3  ¦  In this tutorial, we show ...  ¦  0.0  𝄀
+4  ¦  1. Never run MOd as root. 2. ...  ¦  0.0  𝄀
+5  ¦  In the following database comparison ...  ¦  0.0  𝄀
+6  ¦  When configured properly, MO ...  ¦  0.0
 select id, body, match (title, body)
 against ('MO tutorial DBMS stands for' in natural language mode) as score
 from articles
@@ -523,7 +532,11 @@ against ('DataBase' in natural language mode) as score
 from article;
 ➤ id[4,32,0]  ¦  score[7,5,0]  𝄀
 1  ¦  0.2276447  𝄀
-5  ¦  0.2276447
+5  ¦  0.2276447  𝄀
+2  ¦  0.0  𝄀
+3  ¦  0.0  𝄀
+4  ¦  0.0  𝄀
+6  ¦  0.0
 select id, body, match (body)
 against ('DBMS stands for Database' in natural language mode) as score
 from article

--- a/test/distributed/cases/fulltext/fulltext_bm25.result
+++ b/test/distributed/cases/fulltext/fulltext_bm25.result
@@ -66,26 +66,6 @@ id    body    title    score
 3    blue is not red    colorful    0.0
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
 7    59個簡單的英文和中文短篇小說    適合初學者    0.0
 8    null    NOT INCLUDED    0.0
@@ -112,24 +92,6 @@ id    body    title    score
 1    car is yellow    crazy car    0.0
 2    sky is blue    no limit    0.0
 3    blue is not red    colorful    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
 7    59個簡單的英文和中文短篇小說    適合初學者    0.0
 8    null    NOT INCLUDED    0.0
@@ -138,16 +100,6 @@ id    body    title    score
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.2537473
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 0    color is red    t1    0.0
 1    car is yellow    crazy car    0.0
 2    sky is blue    no limit    0.0
@@ -202,24 +154,6 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.7411132
 3    blue is not red    colorful    0.7411132
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 0    color is red    t1    0.0
 1    car is yellow    crazy car    0.0
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
@@ -281,6 +215,16 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    3.1378522
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說
@@ -298,9 +242,28 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.0109811
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.6560832
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.2537473
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -332,6 +295,15 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.7411132
 3    blue is not red    colorful    0.7411132
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -367,8 +339,6 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09538849
 id3    3    blue red    t4    0.07879918
-id0    0    red    t1    0.0
-id1    1    yellow    t2    0.0
 id0    0    red    t1    0.0
 id1    1    yellow    t2    0.0
 update src2 set body = 'orange' where id1='id0';
@@ -466,6 +436,16 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    3.1378522
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n
@@ -483,6 +463,15 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.0109811
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.6560832
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -514,6 +503,15 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.7411132
 3    blue is not red    colorful    0.7411132
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -574,6 +572,8 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09538849
 id3    3    blue red    t4    0.07879918
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
 desc src2;
 Field    Type    Null    Key    Default    Extra    Comment
 id1    VARCHAR(65535)    NO    PRI    null        

--- a/test/distributed/cases/fulltext/fulltext_bm25.result
+++ b/test/distributed/cases/fulltext/fulltext_bm25.result
@@ -61,6 +61,36 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    3.1378522
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說
@@ -78,9 +108,56 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.0109811
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.6560832
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    1.2537473
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -125,6 +202,33 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.7411132
 3    blue is not red    colorful    0.7411132
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說\n    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短>篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -161,6 +265,15 @@ select match(body) against('red') from src;
 MATCH (body) AGAINST (red)
 0.688839
 0.6640298
+0
+0
+0
+0
+0
+0
+0
+0
+0
 select * from src where match(body, title) against('red');
 id    body    title
 0    color is red    t1
@@ -254,6 +367,10 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09538849
 id3    3    blue red    t4    0.07879918
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
 update src2 set body = 'orange' where id1='id0';
 select * from src2 where match(body, title) against('red');
 id1    id2    body    title

--- a/test/distributed/cases/fulltext/fulltext_score_row_preservation.result
+++ b/test/distributed/cases/fulltext/fulltext_score_row_preservation.result
@@ -1,0 +1,68 @@
+set ft_relevancy_algorithm="TF-IDF";
+set experimental_fulltext_index = 1;
+drop database if exists ft_score_rows_28327;
+create database ft_score_rows_28327;
+use ft_score_rows_28327;
+create table docs(id int primary key, body text);
+insert into docs values (1,'alpha'),(2,'beta'),(3,'alpha beta');
+create fulltext index ft on docs(body);
+select id from docs order by match(body) against('alpha') desc, id;
+➤ id[4,32,0]  𝄀
+1  𝄀
+3  𝄀
+2
+select id, if(match(body) against('alpha') > 0, 1, 0) as has_score from docs order by id;
+➤ id[4,32,0]  ¦  has_score[-5,64,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  0  𝄀
+3  ¦  1
+select id, if(round(match(body) against('alpha'), 3) > 0, 1, 0) as has_score from docs order by id;
+➤ id[4,32,0]  ¦  has_score[-5,64,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  0  𝄀
+3  ¦  1
+select id from docs
+where round(match(body) against('alpha'), 3) >= 0
+order by round(match(body) against('alpha'), 3), id;
+➤ id[4,32,0]  𝄀
+2  𝄀
+1  𝄀
+3
+select id from docs where id > 1 order by match(body) against('alpha') desc, id;
+➤ id[4,32,0]  𝄀
+3  𝄀
+2
+select id from docs order by match(body) against('missing') desc, id;
+➤ id[4,32,0]  𝄀
+1  𝄀
+2  𝄀
+3
+select id from docs order by match(body) against('alpha') asc, id limit 2;
+➤ id[4,32,0]  𝄀
+2  𝄀
+1
+select id from docs order by match(body) against('alpha') desc, id limit 2;
+➤ id[4,32,0]  𝄀
+1  𝄀
+3
+select id,
+if(match(body) against('alpha') > 0, 1, 0) as alpha_score,
+if(match(body) against('beta') > 0, 1, 0) as beta_score
+from docs order by id;
+➤ id[4,32,0]  ¦  alpha_score[-5,64,0]  ¦  beta_score[-5,64,0]  𝄀
+1  ¦  1  ¦  0  𝄀
+2  ¦  0  ¦  1  𝄀
+3  ¦  1  ¦  1
+select id, if(match(body) against('beta') > 0, 1, 0) as beta_score
+from docs
+where match(body) against('alpha')
+order by match(body) against('beta') desc, id;
+➤ id[4,32,0]  ¦  beta_score[-5,64,0]  𝄀
+3  ¦  1  𝄀
+1  ¦  0
+select id from docs where match(body) against('alpha') order by id;
+➤ id[4,32,0]  𝄀
+1  𝄀
+3
+drop database ft_score_rows_28327;
+set ft_relevancy_algorithm="TF-IDF";

--- a/test/distributed/cases/fulltext/fulltext_score_row_preservation.sql
+++ b/test/distributed/cases/fulltext/fulltext_score_row_preservation.sql
@@ -1,0 +1,69 @@
+-- Copyright 2026 Matrix Origin
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Issue #28327: MATCH used only for ordering or scoring is optional. It must
+-- not turn the base-table/fulltext rewrite into an INNER JOIN that drops rows
+-- with relevance 0. MySQL's natural-language MATCH documentation shows the
+-- score-only form retaining nonmatching rows with a zero score.
+set ft_relevancy_algorithm="TF-IDF";
+set experimental_fulltext_index = 1;
+
+drop database if exists ft_score_rows_28327;
+create database ft_score_rows_28327;
+use ft_score_rows_28327;
+
+create table docs(id int primary key, body text);
+insert into docs values (1,'alpha'),(2,'beta'),(3,'alpha beta');
+create fulltext index ft on docs(body);
+
+-- ORDER BY-only MATCH preserves id 2, whose score is zero.
+select id from docs order by match(body) against('alpha') desc, id;
+
+-- Bare and wrapped projected scores expose zero rather than dropping id 2.
+-- Use boolean score predicates instead of algorithm-specific float goldens.
+select id, if(match(body) against('alpha') > 0, 1, 0) as has_score from docs order by id;
+select id, if(round(match(body) against('alpha'), 3) > 0, 1, 0) as has_score from docs order by id;
+
+-- A scalar score predicate and ORDER BY remain base-anchored when zero qualifies.
+select id from docs
+where round(match(body) against('alpha'), 3) >= 0
+order by round(match(body) against('alpha'), 3), id;
+
+-- A simple scalar base-table predicate must not make an optional score stream
+-- become an INNER JOIN, and a query with no hits still returns every base row.
+select id from docs where id > 1 order by match(body) against('alpha') desc, id;
+select id from docs order by match(body) against('missing') desc, id;
+
+-- LIMIT must apply after the complete base-anchored result is sorted.
+select id from docs order by match(body) against('alpha') asc, id limit 2;
+select id from docs order by match(body) against('alpha') desc, id limit 2;
+
+-- Two distinct optional streams each retain their own zero scores.
+select id,
+       if(match(body) against('alpha') > 0, 1, 0) as alpha_score,
+       if(match(body) against('beta') > 0, 1, 0) as beta_score
+from docs order by id;
+
+-- A required alpha stream filters, while an optional beta score still preserves
+-- the alpha-only row with beta score zero.
+select id, if(match(body) against('beta') > 0, 1, 0) as beta_score
+from docs
+where match(body) against('alpha')
+order by match(body) against('beta') desc, id;
+
+-- Existing bare positive WHERE behavior remains membership-filtered.
+select id from docs where match(body) against('alpha') order by id;
+
+drop database ft_score_rows_28327;
+set ft_relevancy_algorithm="TF-IDF";

--- a/test/distributed/cases/fulltext/fulltext_wrapped_score.result
+++ b/test/distributed/cases/fulltext/fulltext_wrapped_score.result
@@ -123,6 +123,9 @@ from two where match(body) against('hello') order by id;
 5  ¦  0.018783102  ¦  0.019
 select id, round(match(body) against('world'),3) as r from two where match(body) against('hello') order by id;
 ➤ id[4,32,0]  ¦  r[8,53,31]  𝄀
+1  ¦  0.0  𝄀
+2  ¦  0.0  𝄀
+3  ¦  0.0  𝄀
 5  ¦  0.158
 select id from two where match(body) against('hello') and match(body) against('world') > 0.1 order by id;
 ➤ id[4,32,0]  𝄀
@@ -156,6 +159,7 @@ select id, round(match(body) against('hello'),3) as r from two order by id;  -- 
 1  ¦  0.009  𝄀
 2  ¦  0.019  𝄀
 3  ¦  0.028  𝄀
+4  ¦  0.0  𝄀
 5  ¦  0.019
 select count(*) as n from two where match(body) against('hello') > 0.015;    -- and through an aggregate
 ➤ n[-5,64,0]  𝄀

--- a/test/distributed/cases/fulltext/gojieba.result
+++ b/test/distributed/cases/fulltext/gojieba.result
@@ -39,26 +39,6 @@ id    body    title    score
 8    null    NOT INCLUDED    0.0
 9    NOT INCLUDED BODY    null    0.0
 10    null    null    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說
@@ -84,37 +64,9 @@ id    body    title    score
 8    null    NOT INCLUDED    0.0
 9    NOT INCLUDED BODY    null    0.0
 10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    4.552894
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-2    sky is blue    no limit    0.0
-3    blue is not red    colorful    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 0    color is red    t1    0.0
 1    car is yellow    crazy car    0.0
 2    sky is blue    no limit    0.0
@@ -178,24 +130,6 @@ id    body    title    MATCH (body, title) AGAINST (blue)
 8    null    NOT INCLUDED    0.0
 9    NOT INCLUDED BODY    null    0.0
 10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
-0    color is red    t1    0.0
-1    car is yellow    crazy car    0.0
-4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
-5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
-6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
-7    59個簡單的英文和中文短篇小說    適合初學者    0.0
-8    null    NOT INCLUDED    0.0
-9    NOT INCLUDED BODY    null    0.0
-10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -248,6 +182,16 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    1.6311431
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說
@@ -264,9 +208,28 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    4.8855906
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    2.4427953
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    4.552894
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -298,6 +261,15 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.48855907
 3    blue is not red    colorful    0.48855907
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -333,8 +305,6 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09061906
 id3    3    blue red    t4    0.09061906
-id0    0    red    t1    0.0
-id1    1    yellow    t2    0.0
 id0    0    red    t1    0.0
 id1    1    yellow    t2    0.0
 update src2 set body = 'orange' where id1='id0';
@@ -374,6 +344,16 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    1.6311431
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說
@@ -390,6 +370,15 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    4.8855906
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    2.4427953
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -421,6 +410,15 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.48855907
 3    blue is not red    colorful    0.48855907
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -469,6 +467,8 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09061906
 id3    3    blue red    t4    0.09061906
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
 show create table src2;
 Table    Create Table
 src2    CREATE TABLE `src2` (\n  `id1` varchar(65535) NOT NULL,\n  `id2` bigint NOT NULL,\n  `body` char(128) DEFAULT NULL,\n  `title` text DEFAULT NULL,\n  PRIMARY KEY (`id1`,`id2`),\n FULLTEXT (`body`,`title`) WITH PARSER gojieba\n)

--- a/test/distributed/cases/fulltext/gojieba.result
+++ b/test/distributed/cases/fulltext/gojieba.result
@@ -29,6 +29,36 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    1.6311431
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說
@@ -45,9 +75,56 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    4.8855906
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    2.4427953
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select *, match(body) against('遠東兒童中文' in natural language mode) as score from src;
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    4.552894
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful
@@ -92,6 +169,33 @@ select src.*, match(body, title) against('blue') from src;
 id    body    title    MATCH (body, title) AGAINST (blue)
 2    sky is blue    no limit    0.48855907
 3    blue is not red    colorful    0.48855907
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select count(*) from src where match(title, body) against('red');
 count(*)
 2
@@ -128,6 +232,15 @@ select match(body) against('red') from src;
 MATCH (body) AGAINST (red)
 0.42668658
 0.42668658
+0
+0
+0
+0
+0
+0
+0
+0
+0
 select * from src where match(body, title) against('red');
 id    body    title
 0    color is red    t1
@@ -220,6 +333,10 @@ select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09061906
 id3    3    blue red    t4    0.09061906
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
+id0    0    red    t1    0.0
+id1    1    yellow    t2    0.0
 update src2 set body = 'orange' where id1='id0';
 select * from src2 where match(body, title) against('red');
 id1    id2    body    title
@@ -450,6 +567,16 @@ id    body    title
 select *, match(body, title) against('is red' in natural language mode) as score from src;
 id    body    title    score
 0    color is red    t1    3.0634575
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    0.0
+5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('教學指引');
 id    body    title
 6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說
@@ -457,6 +584,15 @@ select *, match(body, title) against('遠東兒童中文' in natural language mo
 id    body    title    score
 4    遠東兒童中文是針對6到9歲的小朋友精心設計的中文學習教材，共三冊，目前已出版一、二冊。    遠東兒童中文    2.6046562
 5    每冊均採用近百張全幅彩圖及照片，生動活潑、自然真實，加深兒童學習印象，洋溢學習樂趣。    遠東兒童中文    1.6553308
+0    color is red    t1    0.0
+1    car is yellow    crazy car    0.0
+2    sky is blue    no limit    0.0
+3    blue is not red    colorful    0.0
+6    各個單元主題內容涵蓋中華文化及生活應用的介紹。本套教材含課本、教學指引、生字卡、學生作業本與CD，中英對照，精美大字版。本系列有繁體字及簡體字兩種版本印行。    中文短篇小說    0.0
+7    59個簡單的英文和中文短篇小說    適合初學者    0.0
+8    null    NOT INCLUDED    0.0
+9    NOT INCLUDED BODY    null    0.0
+10    null    null    0.0
 select * from src where match(body, title) against('+red blue' in boolean mode);
 id    body    title
 3    blue is not red    colorful

--- a/test/distributed/cases/fulltext2/fulltext2_wrapped_score.result
+++ b/test/distributed/cases/fulltext2/fulltext2_wrapped_score.result
@@ -123,6 +123,9 @@ from two where match(body) against('hello') order by id;
 5  ¦  0.011558833  ¦  0.012
 select id, round(match(body) against('world'),3) as r from two where match(body) against('hello') order by id;
 ➤ id[4,32,0]  ¦  r[8,53,31]  𝄀
+1  ¦  0.0  𝄀
+2  ¦  0.0  𝄀
+3  ¦  0.0  𝄀
 5  ¦  0.129
 select id from two where match(body) against('hello') and match(body) against('world') > 0.1 order by id;
 ➤ id[4,32,0]  𝄀
@@ -155,6 +158,7 @@ select id, round(match(body) against('hello'),3) as r from two order by id;  -- 
 1  ¦  0.012  𝄀
 2  ¦  0.013  𝄀
 3  ¦  0.014  𝄀
+4  ¦  0.0  𝄀
 5  ¦  0.012
 select count(*) as n from two where match(body) against('hello') > 0.0132;   -- and through an aggregate
 ➤ n[-5,64,0]  𝄀


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28327

## What this PR does / why we need it:

### Root cause

The FULLTEXT planner used the same INNER JOIN intersection for membership filters and score-only MATCH expressions. Consequently, a SELECT without WHERE or LIMIT could lose base rows merely by ordering or projecting a MATCH score. Multiple independent score streams also incorrectly intersected one another.

With three documents `(1, 'alpha'), (2, 'beta'), (3, 'alpha beta')`, the unfixed main code returned `[1,3]` for `SELECT id FROM docs ORDER BY MATCH(body) AGAINST('alpha') DESC, id`; the complete result is `[1,3,2]`. This was reproduced through the MySQL protocol, not just a synthetic plan. It is separate from the cross-CN metadata issue addressed by #28289.

### Changes

- Distinguish membership-required MATCH streams using the existing WHERE predicate classifier.
- When optional score streams exist, anchor every join at the base-table primary key: INNER for required streams, LEFT for optional streams. Replace missing optional scores with a typed zero in direct and wrapped score consumers.
- Do not apply candidate limits, membership prefilters, or score-range pruning that could remove preserved rows or manufacture zero scores for omitted matching documents.
- Keep the existing all-required WHERE MATCH and FULLTEXT2 covered paths, including their applicable candidate-limit optimizations.
- Add planner assertions, real SQL regression coverage for classic FULLTEXT and FULLTEXT2, and BVT coverage. Update 51 legacy result blocks to preserve previously discarded zero-score rows without changing their SQL or existing positive scores.

### Validation

- The regression fails on the unfixed main planner and returns the missing row after this change.
- `pkg/sql/plan`: full package passed, including LEFT/base-PK anchoring, COALESCE, and required/optional limit controls.
- `TestIssue28327FulltextScorePreservesBaseRows`: passed for both FULLTEXT implementations. Covers non-NULL zero scores, no hits, scalar WHERE, pagination, independent MATCH scores, and both bare and wrapped required MATCH predicates.
- New focused BVT: 21/21 statements passed locally.
- Final local BVT rerun passed after correcting legacy expectations: classic FULLTEXT directory, 1548 statements (1545 success, 3 existing ignored, 0 failures); FULLTEXT2 wrapped-score, 71/71 success. Existing SQL and positive scores are preserved; zero-score rows are assigned to the corresponding occurrence of each repeated query. Task-owned standalone service was stopped after testing.
- Linux/server-50 real SQL A/B passed: baseline `e7cadcf031` plus the same test returned `[1,3]` and failed for both engines (exit 1, 20.472s); fixed `4e6d2c8c8d` returned `[1,3,2]` and passed both engines including non-NULL zero assertions (exit 0, 20.391s). Later result-only updates do not change this tested production/test code. The tests used independent embedded clusters through the real MySQL protocol, not the existing Docker deployment. Existing server-50 services were not modified or restarted.

### Scope and cost

Production changes are confined to the FULLTEXT planner rewrite. No fault hooks, session/configuration flags, background workers, persistent formats, or transaction/lock protocols are introduced. Score-only queries now process and return the rows they previously lost; they must not rely on matching-only candidate pruning. Ordinary membership-filtered searches retain their existing optimized path.
