### PR TITLE
fix(optimizer): bound correlated scalar aggregate point scans

### DIFF
--- a/pkg/sql/plan/flatten_subquery.go
+++ b/pkg/sql/plan/flatten_subquery.go
@@ -169,6 +169,9 @@ func (builder *QueryBuilder) flattenSubquery(
 	}
 
 	filterPreds, joinPreds := decreaseDepthAndDispatch(preds)
+	if subquery.Typ == plan.SubqueryRef_SCALAR && len(subCtx.aggregates) > 0 {
+		builder.pushdownScalarAggregateKeys(subID, joinPreds, ctx)
+	}
 
 	if len(filterPreds) > 0 {
 		deepScalarAggregate := subquery.Typ == plan.SubqueryRef_SCALAR &&
@@ -958,6 +961,447 @@ func (builder *QueryBuilder) findNonEqPred(preds []*plan.Expr) bool {
 			return true
 		}
 	}
+	return false
+}
+
+// pushdownScalarAggregateKeys limits a decorrelated scalar aggregate to keys
+// that can actually occur in the outer relation. Decorrelating
+//
+//	... where inner.key = outer.key
+//
+// currently adds inner.key to the aggregate GROUP BY, but leaves the
+// aggregate input independent of the filtered outer relation. For a complete
+// primary-key point domain, a SEMI join provides the missing dependency
+// without duplicating rows. If the aggregate input is a direct base-table
+// scan, the same constants are also copied to that scan so the regular index
+// pass can bound the physical read.
+//
+// This is deliberately conservative: the correlation must be direct equality
+// on pulled-up group keys, all outer keys must come from one base-table
+// binding, and that table must have a deterministic local WHERE predicate.
+// Copying only that predicate domain is safe because it is a superset of the
+// outer rows that survive the complete query. Volatile, computed-key,
+// multi-table, derived, and unfiltered shapes retain the existing
+// decorrelation plan.
+func (builder *QueryBuilder) pushdownScalarAggregateKeys(subID int32, preds []*plan.Expr, ctx *BindContext) {
+	aggNode := builder.findAggNodeBelow(subID)
+	if aggNode == nil || len(aggNode.Children) != 1 || len(aggNode.BindingTags) == 0 {
+		return
+	}
+
+	pairs := make([]scalarAggregateKeyPair, 0, len(preds))
+	outerTag := int32(-1)
+
+	for _, pred := range splitPlanConjunctions(preds) {
+		f := pred.GetF()
+		if f == nil || f.Func == nil {
+			return
+		}
+		if f.Func.ObjName == "istrue" && len(f.Args) == 1 {
+			f = f.Args[0].GetF()
+			if f == nil || f.Func == nil {
+				return
+			}
+		}
+		if len(f.Args) != 2 || (f.Func.ObjName != "=" && !IsEqualFunc(f.Func.GetObj())) {
+			return
+		}
+
+		left := f.Args[0].GetCol()
+		right := f.Args[1].GetCol()
+		if left == nil || right == nil {
+			return
+		}
+
+		leftGroupPos, leftIsGroup := builder.scalarAggregateGroupPos(subID, aggNode, left)
+		rightGroupPos, rightIsGroup := builder.scalarAggregateGroupPos(subID, aggNode, right)
+		var outer *plan.ColRef
+		var groupPos int32
+		switch {
+		case leftIsGroup && !rightIsGroup:
+			groupPos, outer = leftGroupPos, right
+		case rightIsGroup && !leftIsGroup:
+			groupPos, outer = rightGroupPos, left
+		default:
+			return
+		}
+		if groupPos < 0 || int(groupPos) >= len(aggNode.GroupBy) ||
+			ctx == nil || ctx.bindingByTag[outer.RelPos] == nil {
+			return
+		}
+		// pullupThroughAgg can add an arbitrary inner expression to GROUP BY.
+		// Referencing that expression from both the aggregate and the new SEMI
+		// predicate would evaluate it twice. Restrict this rewrite to direct
+		// columns so volatile, stateful, or merely expensive computed keys keep
+		// their original single-evaluation semantics.
+		if aggNode.GroupBy[groupPos].GetCol() == nil {
+			return
+		}
+		if outerTag >= 0 && outerTag != outer.RelPos {
+			return
+		}
+		outerTag = outer.RelPos
+		pairs = append(pairs, scalarAggregateKeyPair{
+			outerPos: outer.ColPos,
+			groupPos: groupPos,
+		})
+	}
+	if len(pairs) == 0 {
+		return
+	}
+
+	outerBinding := ctx.bindingByTag[outerTag]
+	if outerBinding == nil || outerBinding.nodeId < 0 || int(outerBinding.nodeId) >= len(builder.qry.Nodes) {
+		return
+	}
+	outerScan := builder.qry.Nodes[outerBinding.nodeId]
+	if outerScan.NodeType != plan.Node_TABLE_SCAN || len(outerScan.Children) != 0 ||
+		len(outerScan.BindingTags) == 0 || outerScan.BindingTags[0] != outerTag {
+		return
+	}
+
+	outerTags := map[int32]bool{outerTag: true}
+	domainFilters := make([]*plan.Expr, 0, len(ctx.whereFilters))
+	for _, filter := range splitPlanConjunctions(ctx.whereFilters) {
+		if !hasSubquery(filter) && !scalarAggregateDomainContainsVolatile(filter) &&
+			containsTag(filter, outerTag) && containsOnlyTags(filter, outerTags) {
+			domainFilters = append(domainFilters, DeepCopyExpr(filter))
+		}
+	}
+	if len(domainFilters) == 0 {
+		return
+	}
+	// The general SEMI shape adds a second domain scan. Keep this rewrite
+	// limited to point lookups, where the copied primary-key constants also
+	// bound the aggregate input and pay for that extra scan. Broad/range and
+	// non-key domains retain the existing plan until a cost-based admission
+	// rule is available.
+	if !scalarAggregateDomainHasPrimaryKeyPointFilter(outerBinding, outerScan, domainFilters) {
+		return
+	}
+
+	for _, pair := range pairs {
+		if pair.outerPos < 0 || int(pair.outerPos) >= len(outerBinding.types) {
+			return
+		}
+	}
+	domainScan := DeepCopyNode(outerScan)
+	domainScan.ScanSnapshot = DeepCopySnapshot(outerScan.ScanSnapshot)
+	for _, filter := range domainFilters {
+		domainScan.FilterList = append(domainScan.FilterList, DeepCopyExpr(filter))
+	}
+	builder.rebindScanNode(domainScan)
+	domainTag := domainScan.BindingTags[0]
+	joinPreds := make([]*plan.Expr, len(pairs))
+	for i, pair := range pairs {
+		innerKey := DeepCopyExpr(aggNode.GroupBy[pair.groupPos])
+		domainKey := &plan.Expr{
+			Typ: *outerBinding.types[pair.outerPos],
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{
+				RelPos: domainTag,
+				ColPos: pair.outerPos,
+			}},
+		}
+		cond, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{innerKey, domainKey})
+		if err != nil {
+			return
+		}
+		joinPreds[i] = cond
+	}
+	// The key-domain join is logically sufficient, but the regular index pass
+	// only sees filters on a scan; it does not necessarily turn this newly-
+	// created join into an index join. Copy the proven point filters to the
+	// aggregate input after all join predicates have been built. If the
+	// aggregate input is not a plain scan with direct group-key columns, the
+	// helper leaves it unchanged and the duplicate-safe SEMI shape still
+	// applies.
+	builder.pushScalarAggregatePointFilters(
+		aggNode, aggNode.Children[0], outerBinding, outerScan, pairs, domainFilters)
+
+	domainID := builder.appendNode(domainScan, ctx)
+	joinID := builder.appendNode(&plan.Node{
+		NodeType: plan.Node_JOIN,
+		Children: []int32{aggNode.Children[0], domainID},
+		JoinType: plan.Node_SEMI,
+		OnList:   joinPreds,
+		SpillMem: builder.joinSpillMem,
+	}, ctx)
+	aggNode.Children[0] = joinID
+}
+
+type scalarAggregateKeyPair struct {
+	outerPos int32
+	groupPos int32
+}
+
+func scalarAggregatePrimaryKeyPositions(binding *Binding, scan *plan.Node) ([]int32, bool) {
+	if binding == nil || scan == nil || scan.TableDef == nil || scan.TableDef.Pkey == nil {
+		return nil, false
+	}
+	pkeyNames := make([]string, 0, len(scan.TableDef.Pkey.Names))
+	for _, name := range scan.TableDef.Pkey.Names {
+		// Some older/synthetic TableDef producers leave empty padding entries
+		// in Names.  They do not describe a key column and must not make an
+		// otherwise valid composite-key proof fail closed.
+		if catalog.ToLower(name) != "" {
+			pkeyNames = append(pkeyNames, name)
+		}
+	}
+	if len(pkeyNames) == 0 && scan.TableDef.Pkey.PkeyColName != "" {
+		pkeyNames = []string{scan.TableDef.Pkey.PkeyColName}
+	}
+	if len(pkeyNames) == 0 {
+		return nil, false
+	}
+
+	positions := make([]int32, 0, len(pkeyNames))
+	seen := make(map[int32]struct{}, len(pkeyNames))
+	for _, name := range pkeyNames {
+		pos, ok := binding.colIdByName[catalog.ToLower(name)]
+		if !ok || pos < 0 || int(pos) >= len(binding.cols) {
+			return nil, false
+		}
+		if _, ok := seen[pos]; ok {
+			continue
+		}
+		seen[pos] = struct{}{}
+		positions = append(positions, pos)
+	}
+	return positions, len(positions) > 0
+}
+
+// scalarAggregateDomainHasPrimaryKeyPointFilter is a cost guard for
+// scan-level point pushdown. A point domain is cheap to materialize and gives
+// the optimizer a bounded input for the aggregate scan. For a broad
+// predicate, keep the existing decorrelation plan without forcing a second
+// wide key-domain scan or many index probes.
+func scalarAggregateDomainHasPrimaryKeyPointFilter(
+	binding *Binding,
+	scan *plan.Node,
+	filters []*plan.Expr,
+) bool {
+	pkeyPositions, ok := scalarAggregatePrimaryKeyPositions(binding, scan)
+	if !ok {
+		return false
+	}
+	required := make(map[int32]struct{}, len(pkeyPositions))
+	for _, pos := range pkeyPositions {
+		required[pos] = struct{}{}
+	}
+	matched := make(map[int32]struct{}, len(required))
+	for _, filter := range splitPlanConjunctions(filters) {
+		f := filter.GetF()
+		if f == nil || f.Func == nil || f.Func.ObjName == "" {
+			continue
+		}
+		if f.Func.ObjName == "istrue" && len(f.Args) == 1 {
+			f = f.Args[0].GetF()
+			if f == nil || f.Func == nil {
+				continue
+			}
+		}
+		if f.Func.ObjName != "=" || len(f.Args) != 2 {
+			continue
+		}
+
+		var col *plan.ColRef
+		var value *plan.Expr
+		if left := f.Args[0].GetCol(); left != nil && left.RelPos == binding.tag {
+			col, value = left, f.Args[1]
+		} else if right := f.Args[1].GetCol(); right != nil && right.RelPos == binding.tag {
+			col, value = right, f.Args[0]
+		}
+		if col == nil || !isRuntimeConstExpr(value) {
+			continue
+		}
+		if _, ok := required[col.ColPos]; ok {
+			matched[col.ColPos] = struct{}{}
+		}
+	}
+	return len(matched) == len(required)
+}
+
+// pushScalarAggregatePointFilters copies a complete primary-key point domain
+// from the outer table to the aggregate input.  The copy is valid only when
+// every correlation key is the corresponding base-table column: for any
+// surviving outer row, outer.pk = const and inner.pk = outer.pk imply
+// inner.pk = const.  Keeping this as a separate proof also prevents a filter
+// on a projection, cast, OR arm, or non-key column from being pushed into the
+// aggregate by accident.
+func (builder *QueryBuilder) pushScalarAggregatePointFilters(
+	aggNode *plan.Node,
+	aggInputID int32,
+	binding *Binding,
+	outerScan *plan.Node,
+	pairs []scalarAggregateKeyPair,
+	filters []*plan.Expr,
+) bool {
+	if aggNode == nil || binding == nil || outerScan == nil ||
+		aggInputID < 0 || int(aggInputID) >= len(builder.qry.Nodes) {
+		return false
+	}
+	aggInput := builder.qry.Nodes[aggInputID]
+	for aggInput != nil && aggInput.NodeType == plan.Node_FILTER && len(aggInput.Children) == 1 {
+		aggInput = builder.qry.Nodes[aggInput.Children[0]]
+	}
+	if aggInput == nil || aggInput.NodeType != plan.Node_TABLE_SCAN || len(aggInput.BindingTags) == 0 {
+		return false
+	}
+
+	groupPosByOuterPos := make(map[int32]int32, len(pairs))
+	for _, pair := range pairs {
+		if pair.outerPos < 0 || pair.groupPos < 0 ||
+			int(pair.groupPos) >= len(aggNode.GroupBy) {
+			return false
+		}
+		groupExpr := aggNode.GroupBy[pair.groupPos]
+		groupCol := groupExpr.GetCol()
+		if groupCol == nil || groupCol.RelPos != aggInput.BindingTags[0] {
+			return false
+		}
+		groupPosByOuterPos[pair.outerPos] = pair.groupPos
+	}
+
+	pkeyPositions, ok := scalarAggregatePrimaryKeyPositions(binding, outerScan)
+	if !ok {
+		return false
+	}
+	matched := make(map[int32]struct{}, len(pkeyPositions))
+	newFilters := make([]*plan.Expr, 0, len(pkeyPositions))
+	for _, filter := range splitPlanConjunctions(filters) {
+		f := filter.GetF()
+		if f == nil || f.Func == nil {
+			continue
+		}
+		if f.Func.ObjName == "istrue" && len(f.Args) == 1 {
+			f = f.Args[0].GetF()
+			if f == nil || f.Func == nil {
+				continue
+			}
+		}
+		if f.Func.ObjName != "=" || len(f.Args) != 2 {
+			continue
+		}
+
+		var outerCol *plan.ColRef
+		var value *plan.Expr
+		if left := f.Args[0].GetCol(); left != nil && left.RelPos == binding.tag {
+			outerCol, value = left, f.Args[1]
+		} else if right := f.Args[1].GetCol(); right != nil && right.RelPos == binding.tag {
+			outerCol, value = right, f.Args[0]
+		}
+		if outerCol == nil || !isRuntimeConstExpr(value) {
+			continue
+		}
+		groupPos, ok := groupPosByOuterPos[outerCol.ColPos]
+		if !ok {
+			continue
+		}
+		isPrimaryKeyPart := false
+		for _, pkeyPos := range pkeyPositions {
+			if pkeyPos == outerCol.ColPos {
+				isPrimaryKeyPart = true
+				break
+			}
+		}
+		if !isPrimaryKeyPart {
+			continue
+		}
+		if _, ok := matched[outerCol.ColPos]; ok {
+			continue
+		}
+
+		pushed, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{
+			DeepCopyExpr(aggNode.GroupBy[groupPos]),
+			DeepCopyExpr(value),
+		})
+		if err != nil {
+			return false
+		}
+		newFilters = append(newFilters, pushed)
+		matched[outerCol.ColPos] = struct{}{}
+	}
+	if len(matched) != len(pkeyPositions) {
+		return false
+	}
+	aggInput.FilterList = append(aggInput.FilterList, newFilters...)
+	return true
+}
+
+// scalarAggregateGroupPos resolves a pulled-up predicate column through the
+// transparent unary projections above aggNode. It returns an AGG group-output
+// position, never an aggregate-output position.
+func (builder *QueryBuilder) scalarAggregateGroupPos(
+	nodeID int32,
+	aggNode *plan.Node,
+	col *plan.ColRef,
+) (int32, bool) {
+	if col == nil || aggNode == nil || len(aggNode.BindingTags) == 0 {
+		return 0, false
+	}
+	ref := *col
+	for nodeID != aggNode.NodeId {
+		if nodeID < 0 || int(nodeID) >= len(builder.qry.Nodes) {
+			return 0, false
+		}
+		node := builder.qry.Nodes[nodeID]
+		if node.NodeType == plan.Node_PROJECT && len(node.BindingTags) > 0 && ref.RelPos == node.BindingTags[0] {
+			if ref.ColPos < 0 || int(ref.ColPos) >= len(node.ProjectList) {
+				return 0, false
+			}
+			projected := node.ProjectList[ref.ColPos].GetCol()
+			if projected == nil {
+				return 0, false
+			}
+			ref = *projected
+		}
+		if len(node.Children) != 1 {
+			return 0, false
+		}
+		nodeID = node.Children[0]
+	}
+	if ref.RelPos != aggNode.BindingTags[0] || ref.ColPos < 0 || int(ref.ColPos) >= len(aggNode.GroupBy) {
+		return 0, false
+	}
+	return ref.ColPos, true
+}
+
+// scalarAggregateDomainContainsVolatile reports whether evaluating expr more than once can
+// change its value. A copied predicate is evaluated by both the original
+// outer scan and the aggregate-domain scan, so volatile or unknown functions
+// must never be copied into the latter.
+func scalarAggregateDomainContainsVolatile(expr *plan.Expr) bool {
+	if expr == nil {
+		return true
+	}
+
+	switch exprImpl := expr.Expr.(type) {
+	case *plan.Expr_Sub:
+		return true
+	case *plan.Expr_F:
+		if exprImpl.F == nil || exprImpl.F.Func == nil {
+			return true
+		}
+		overload, ok := function.GetFunctionByIdWithoutError(exprImpl.F.Func.Obj)
+		if !ok || overload.CannotFold() {
+			return true
+		}
+		for _, arg := range exprImpl.F.Args {
+			if scalarAggregateDomainContainsVolatile(arg) {
+				return true
+			}
+		}
+	case *plan.Expr_List:
+		if exprImpl.List == nil {
+			return true
+		}
+		for _, item := range exprImpl.List.List {
+			if scalarAggregateDomainContainsVolatile(item) {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 

--- a/pkg/sql/plan/issue_28158_test.go
+++ b/pkg/sql/plan/issue_28158_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue28158CorrelatedScalarAggregateUsesOuterKeyDomain(t *testing.T) {
+	logicPlan, err := runOneStmt(NewMockOptimizer(true), t, `
+		SELECT o.o_orderkey,
+		       CASE WHEN o.o_orderstatus IN ('O', 'F') THEN
+		         (SELECT MAX(l.l_quantity)
+		            FROM lineitem l
+		           WHERE l.l_orderkey = o.o_orderkey
+		             AND l.l_partkey = o.o_custkey
+		             AND l.l_returnflag = 'A')
+		       ELSE NULL END AS latest_seq
+		  FROM orders o
+		  LEFT JOIN lineitem next_event
+		    ON next_event.l_orderkey = o.o_orderkey
+		   AND next_event.l_partkey = o.o_custkey
+		 WHERE o.o_orderkey = 1
+		   AND o.o_custkey = 2
+		 ORDER BY next_event.l_linenumber`)
+	require.NoError(t, err)
+
+	query := logicPlan.GetQuery()
+	agg := issue28158FindAggregate(query, "max")
+	require.NotNil(t, agg)
+	require.Len(t, agg.Children, 1)
+
+	join := query.Nodes[agg.Children[0]]
+	require.Equal(t, plan.Node_JOIN, join.NodeType)
+	// Keep the duplicate-safe SEMI shape even when the outer domain is a
+	// primary-key point.  The point constants are copied to the aggregate scan
+	// separately so index selection does not depend on join reordering.
+	require.Equal(t, plan.Node_SEMI, join.JoinType)
+	require.Len(t, join.Children, 2)
+	require.Len(t, join.OnList, 2)
+
+	var domain *plan.Node
+	for _, childID := range join.Children {
+		child := query.Nodes[childID]
+		if child.NodeType == plan.Node_TABLE_SCAN && child.TableDef != nil && child.TableDef.Name == "orders" {
+			domain = child
+			break
+		}
+	}
+	require.NotNil(t, domain)
+	require.Equal(t, plan.Node_TABLE_SCAN, domain.NodeType)
+	require.Equal(t, "orders", domain.TableDef.Name)
+	require.Len(t, domain.FilterList, 2)
+	aggregateScan := issue28158FindTableScanUnder(query, agg.Children[0], "lineitem")
+	require.NotNil(t, aggregateScan)
+	// lineitem already has the local returnflag predicate.  The additional
+	// orderkey predicate is the proof-backed point filter copied from orders;
+	// it protects the physical index path, not just the logical SEMI shape.
+	require.Len(t, aggregateScan.FilterList, 2)
+	foundOrderKey := false
+	for _, filter := range aggregateScan.FilterList {
+		foundOrderKey = foundOrderKey || exprContainsColName(filter, "l_orderkey")
+	}
+	require.True(t, foundOrderKey)
+}
+
+func TestIssue28158PointPushdownIsOrderIndependent(t *testing.T) {
+	whereClauses := []string{
+		"o.o_orderkey = 1 AND o.o_custkey = 2",
+		"o.o_custkey = 2 AND o.o_orderkey = 1",
+	}
+	for _, where := range whereClauses {
+		logicPlan, err := runOneStmt(NewMockOptimizer(true), t, `
+			SELECT o.o_orderkey,
+			       (SELECT MAX(l.l_quantity)
+			          FROM lineitem l
+			         WHERE l.l_orderkey = o.o_orderkey)
+			  FROM orders o
+			 WHERE `+where)
+		require.NoError(t, err)
+
+		agg := issue28158FindAggregate(logicPlan.GetQuery(), "max")
+		require.NotNil(t, agg)
+		aggregateScan := issue28158FindTableScanUnder(logicPlan.GetQuery(), agg.Children[0], "lineitem")
+		require.NotNil(t, aggregateScan)
+		require.True(t, issue28158HasColumnFilter(aggregateScan.FilterList, "l_orderkey"))
+	}
+}
+
+func TestIssue28158WhereScalarPredicateOrderIsIndependent(t *testing.T) {
+	whereClauses := []string{
+		`(SELECT MAX(l.l_quantity)
+		    FROM lineitem l
+		   WHERE l.l_orderkey = o.o_orderkey) > 0
+		AND o.o_orderkey = 1
+		AND o.o_custkey = 2`,
+		`o.o_orderkey = 1
+		AND o.o_custkey = 2
+		AND (SELECT MAX(l.l_quantity)
+		       FROM lineitem l
+		      WHERE l.l_orderkey = o.o_orderkey) > 0`,
+	}
+	for _, where := range whereClauses {
+		logicPlan, err := runOneStmt(NewMockOptimizer(true), t, `
+			SELECT o.o_orderkey
+			  FROM orders o
+			 WHERE `+where)
+		require.NoError(t, err)
+
+		agg := issue28158FindAggregate(logicPlan.GetQuery(), "max")
+		require.NotNil(t, agg)
+		require.Len(t, agg.Children, 1)
+		join := logicPlan.GetQuery().Nodes[agg.Children[0]]
+		require.Equal(t, plan.Node_JOIN, join.NodeType)
+		require.Equal(t, plan.Node_SEMI, join.JoinType)
+		aggregateScan := issue28158FindTableScanUnder(logicPlan.GetQuery(), agg.Children[0], "lineitem")
+		require.NotNil(t, aggregateScan)
+		require.True(t, issue28158HasColumnFilter(aggregateScan.FilterList, "l_orderkey"))
+	}
+}
+
+func TestIssue28158SkipsNonPointOuterDomains(t *testing.T) {
+	logicPlan, err := runOneStmt(NewMockOptimizer(true), t, `
+		SELECT n.n_nationkey,
+		       (SELECT MAX(l.l_quantity)
+		          FROM lineitem l
+		         WHERE l.l_partkey = n.n_regionkey)
+		  FROM nation n
+		 WHERE n.n_regionkey = 1`)
+	require.NoError(t, err)
+
+	agg := issue28158FindAggregate(logicPlan.GetQuery(), "max")
+	require.NotNil(t, agg)
+	require.Len(t, agg.Children, 1)
+	child := logicPlan.GetQuery().Nodes[agg.Children[0]]
+	// A non-key/range-like domain would add work without the point-domain
+	// index payoff; keep the existing plan until admission is cost based.
+	require.NotEqual(t, plan.Node_JOIN, child.NodeType)
+}
+
+func TestIssue28158SkipsCompositeNonPointDomain(t *testing.T) {
+	logicPlan, err := runOneStmt(NewMockOptimizer(true), t, `
+		SELECT ps.ps_partkey,
+		       (SELECT MAX(l.l_quantity)
+		          FROM lineitem l
+		         WHERE l.l_partkey = ps.ps_partkey
+		           AND l.l_suppkey = ps.ps_suppkey)
+		  FROM partsupp ps
+		 WHERE ps.ps_partkey = 1`)
+	require.NoError(t, err)
+
+	agg := issue28158FindAggregate(logicPlan.GetQuery(), "max")
+	require.NotNil(t, agg)
+	require.Len(t, agg.Children, 1)
+	child := logicPlan.GetQuery().Nodes[agg.Children[0]]
+	// Only one component of partsupp's composite primary key is fixed, so this
+	// is not a point domain and must not add a broad SEMI scan.
+	require.NotEqual(t, plan.Node_JOIN, child.NodeType)
+}
+
+func TestIssue28158CompositePrimaryKeyProofRequiresAllKeyParts(t *testing.T) {
+	binding := &Binding{
+		tag:         7,
+		cols:        []string{"workspace_id", "task_id"},
+		colIdByName: map[string]int32{"workspace_id": 0, "task_id": 1},
+	}
+	scan := &plan.Node{TableDef: &plan.TableDef{Pkey: &plan.PrimaryKeyDef{
+		Names: []string{"workspace_id", "task_id"},
+	}}}
+	filters := []*plan.Expr{
+		issue28158EqualityFilter(binding.tag, 0, 1),
+		issue28158EqualityFilter(binding.tag, 1, 2),
+	}
+	require.True(t, scalarAggregateDomainHasPrimaryKeyPointFilter(binding, scan, filters))
+	require.False(t, scalarAggregateDomainHasPrimaryKeyPointFilter(binding, scan, filters[:1]))
+	orFilter := &plan.Expr{Expr: &plan.Expr_F{F: &plan.Function{
+		Func: &plan.ObjectRef{ObjName: "or"},
+		Args: []*plan.Expr{filters[0], filters[1]},
+	}}}
+	require.False(t, scalarAggregateDomainHasPrimaryKeyPointFilter(binding, scan, []*plan.Expr{orFilter}))
+}
+
+func issue28158EqualityFilter(tag, colPos int32, value int64) *plan.Expr {
+	return &plan.Expr{Expr: &plan.Expr_F{F: &plan.Function{
+		Func: &plan.ObjectRef{ObjName: "="},
+		Args: []*plan.Expr{
+			{Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: tag, ColPos: colPos}}},
+			{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_I64Val{I64Val: value}}}},
+		},
+	}}}
+}
+
+func TestIssue28158KeepsUnsafeOrUnfilteredShapesUnchanged(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "unfiltered outer relation",
+			sql: `
+			SELECT o.o_orderkey,
+			       (SELECT MAX(l.l_quantity)
+			          FROM lineitem l
+			         WHERE l.l_orderkey = o.o_orderkey)
+			  FROM orders o`,
+		},
+		{
+			name: "volatile outer predicate",
+			sql: `
+			SELECT o.o_orderkey,
+			       (SELECT MAX(l.l_quantity)
+			          FROM lineitem l
+			         WHERE l.l_orderkey = o.o_orderkey)
+			  FROM orders o
+			 WHERE o.o_orderkey > FLOOR(RAND() * 100)`,
+		},
+		{
+			name: "computed inner key",
+			sql: `
+			SELECT o.o_orderkey,
+			       (SELECT MAX(l.l_quantity)
+			          FROM lineitem l
+			         WHERE l.l_orderkey + 1 = o.o_orderkey)
+			  FROM orders o
+			 WHERE o.o_orderkey = 1`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logicPlan, err := runOneStmt(NewMockOptimizer(true), t, test.sql)
+			require.NoError(t, err)
+			agg := issue28158FindAggregate(logicPlan.GetQuery(), "max")
+			require.NotNil(t, agg)
+			require.Len(t, agg.Children, 1)
+			child := logicPlan.GetQuery().Nodes[agg.Children[0]]
+			// No safe point-domain rewrite exists in these cases, so no key-domain
+			// join may be introduced.
+			require.NotEqual(t, plan.Node_JOIN, child.NodeType)
+		})
+	}
+}
+
+func TestIssue28158CopiesOnlyDeterministicOuterConjunct(t *testing.T) {
+	logicPlan, err := runOneStmt(NewMockOptimizer(true), t, `
+		SELECT o.o_orderkey,
+		       (SELECT MAX(l.l_quantity)
+		          FROM lineitem l
+		         WHERE l.l_orderkey = o.o_orderkey)
+		  FROM orders o
+		 WHERE o.o_orderkey = 1
+		   AND o.o_custkey > FLOOR(RAND() * 100)`)
+	require.NoError(t, err)
+
+	query := logicPlan.GetQuery()
+	agg := issue28158FindAggregate(query, "max")
+	require.NotNil(t, agg)
+	require.Len(t, agg.Children, 1)
+	join := query.Nodes[agg.Children[0]]
+	require.Equal(t, plan.Node_JOIN, join.NodeType)
+	require.Equal(t, plan.Node_SEMI, join.JoinType)
+
+	var domain *plan.Node
+	for _, childID := range join.Children {
+		child := query.Nodes[childID]
+		if child.NodeType == plan.Node_TABLE_SCAN && child.TableDef != nil && child.TableDef.Name == "orders" {
+			domain = child
+			break
+		}
+	}
+	require.NotNil(t, domain)
+	require.Len(t, domain.FilterList, 1)
+	require.False(t, exprContainsFuncName(domain.FilterList[0], "rand"))
+	aggregateScan := issue28158FindTableScanUnder(query, agg.Children[0], "lineitem")
+	require.NotNil(t, aggregateScan)
+	require.Len(t, aggregateScan.FilterList, 1)
+	require.False(t, exprContainsFuncName(aggregateScan.FilterList[0], "rand"))
+	require.True(t, exprContainsColName(aggregateScan.FilterList[0], "l_orderkey"))
+}
+
+func issue28158FindAggregate(query *plan.Query, functionName string) *plan.Node {
+	for _, node := range query.Nodes {
+		if node.NodeType != plan.Node_AGG {
+			continue
+		}
+		for _, expr := range node.AggList {
+			if exprContainsFuncName(expr, functionName) {
+				return node
+			}
+		}
+	}
+	return nil
+}
+
+func issue28158FindTableScanUnder(query *plan.Query, nodeID int32, tableName string) *plan.Node {
+	return issue28158FindTableScanUnderSeen(query, nodeID, tableName, make(map[int32]struct{}))
+}
+
+func issue28158FindTableScanUnderSeen(
+	query *plan.Query,
+	nodeID int32,
+	tableName string,
+	seen map[int32]struct{},
+) *plan.Node {
+	if query == nil || nodeID < 0 || int(nodeID) >= len(query.Nodes) {
+		return nil
+	}
+	if _, ok := seen[nodeID]; ok {
+		return nil
+	}
+	seen[nodeID] = struct{}{}
+	node := query.Nodes[nodeID]
+	if node.NodeType == plan.Node_TABLE_SCAN && node.TableDef != nil && node.TableDef.Name == tableName {
+		return node
+	}
+	for _, childID := range node.Children {
+		if scan := issue28158FindTableScanUnderSeen(query, childID, tableName, seen); scan != nil {
+			return scan
+		}
+	}
+	return nil
+}
+
+func issue28158HasColumnFilter(filters []*plan.Expr, columnName string) bool {
+	for _, filter := range filters {
+		if exprContainsColName(filter, columnName) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -6722,6 +6722,11 @@ func (builder *QueryBuilder) bindWhere(
 	if err != nil {
 		return
 	}
+	// Scalar-subquery decorrelation may need a safe outer-key domain while it
+	// is flattening one conjunct. Publish the complete bound WHERE list before
+	// walking it so the optimization is independent of SQL predicate order.
+	// The list is replaced with the flattened predicates below.
+	ctx.whereFilters = whereList
 	var expr *plan.Expr
 	for _, cond := range whereList {
 		if nodeID, expr, err = builder.flattenFilterSubqueries(nodeID, cond, ctx); err != nil {
@@ -6738,6 +6743,7 @@ func (builder *QueryBuilder) bindWhere(
 			return
 		}
 	}
+	ctx.whereFilters = boundFilterList
 
 	newNodeID = nodeID
 	return

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -485,6 +485,10 @@ type BindContext struct {
 	bindingByTag   map[int32]*Binding //rel_pos
 	bindingByTable map[string]*Binding
 	bindingByCol   map[string]*Binding
+	// whereFilters keeps the complete bound WHERE domain while correlated
+	// subqueries are being flattened. It is cleared/replaced with the
+	// flattened filters once the walk is complete.
+	whereFilters []*plan.Expr
 	// outerUsingCols maps an unqualified column name to the ordered list of
 	// leaf tables whose values must be COALESCEd to produce the merged value.
 	// Only populated when the column has been merged through at least one

--- a/test/distributed/cases/optimizer/issue_28158.result
+++ b/test/distributed/cases/optimizer/issue_28158.result
@@ -1,0 +1,98 @@
+DROP DATABASE IF EXISTS issue_28158_reg;
+CREATE DATABASE issue_28158_reg;
+USE issue_28158_reg;
+CREATE TABLE tasks (
+workspace_id VARCHAR(20) NOT NULL,
+task_id VARCHAR(20) NOT NULL,
+state VARCHAR(20) NOT NULL,
+PRIMARY KEY (workspace_id, task_id)
+);
+CREATE TABLE events (
+event_id INT NOT NULL,
+workspace_id VARCHAR(20) NOT NULL,
+task_id VARCHAR(20) NOT NULL,
+seq INT NOT NULL,
+visible BOOL NOT NULL,
+a2a_state VARCHAR(20) NOT NULL,
+PRIMARY KEY (event_id),
+KEY task_event_key (workspace_id, task_id)
+);
+INSERT INTO tasks VALUES
+('w1', 'same', 'running'),
+('w2', 'same', 'running'),
+('w1', 'empty', 'running');
+INSERT INTO events VALUES
+(1, 'w1', 'same', 1, TRUE, 'completed'),
+(2, 'w1', 'same', 2, TRUE, 'completed'),
+(3, 'w2', 'same', 100, TRUE, 'completed'),
+(4, 'w1', 'same', 3, FALSE, 'completed'),
+(5, 'w1', 'same', 4, TRUE, 'pending');
+SELECT t.workspace_id, t.task_id,
+(SELECT COUNT(*)
+FROM events e
+WHERE e.task_id = t.task_id
+AND e.visible = TRUE) AS event_count,
+(SELECT SUM(e.seq)
+FROM events e
+WHERE e.task_id = t.task_id
+AND e.visible = TRUE) AS seq_sum
+FROM tasks t
+WHERE t.task_id = 'same'
+ORDER BY t.workspace_id;
+➤ workspace_id[12,-1,0]  ¦  task_id[12,-1,0]  ¦  event_count[-5,64,0]  ¦  seq_sum[-5,64,0]  𝄀
+w1  ¦  same  ¦  4  ¦  107  𝄀
+w2  ¦  same  ¦  4  ¦  107
+SELECT t.workspace_id, t.task_id,
+(SELECT COUNT(*)
+FROM events e
+WHERE e.workspace_id = t.workspace_id
+AND e.task_id = t.task_id
+AND e.visible = TRUE
+AND e.a2a_state IN ('completed', 'failed')) AS event_count,
+(SELECT SUM(e.seq)
+FROM events e
+WHERE e.workspace_id = t.workspace_id
+AND e.task_id = t.task_id
+AND e.visible = TRUE
+AND e.a2a_state IN ('completed', 'failed')) AS seq_sum,
+(SELECT MAX(e.seq)
+FROM events e
+WHERE e.workspace_id = t.workspace_id
+AND e.task_id = t.task_id
+AND e.visible = TRUE
+AND e.a2a_state IN ('completed', 'failed')) AS max_seq
+FROM tasks t
+WHERE t.workspace_id = 'w1'
+AND t.task_id = 'same';
+➤ workspace_id[12,-1,0]  ¦  task_id[12,-1,0]  ¦  event_count[-5,64,0]  ¦  seq_sum[-5,64,0]  ¦  max_seq[4,32,0]  𝄀
+w1  ¦  same  ¦  2  ¦  3  ¦  2
+SELECT t.workspace_id, t.task_id,
+(SELECT COUNT(*)
+FROM events e
+WHERE e.workspace_id = t.workspace_id
+AND e.task_id = t.task_id
+AND e.visible = TRUE
+AND e.a2a_state IN ('completed', 'failed')) AS event_count,
+(SELECT SUM(e.seq)
+FROM events e
+WHERE e.workspace_id = t.workspace_id
+AND e.task_id = t.task_id
+AND e.visible = TRUE
+AND e.a2a_state IN ('completed', 'failed')) AS seq_sum,
+(SELECT MAX(e.seq)
+FROM events e
+WHERE e.workspace_id = t.workspace_id
+AND e.task_id = t.task_id
+AND e.visible = TRUE
+AND e.a2a_state IN ('completed', 'failed')) AS max_seq
+FROM tasks t
+LEFT JOIN events next_event
+ON next_event.workspace_id = t.workspace_id
+AND next_event.task_id = t.task_id
+AND next_event.seq > 0
+WHERE t.workspace_id = 'w1'
+AND t.task_id = 'empty'
+ORDER BY next_event.seq;
+➤ workspace_id[12,-1,0]  ¦  task_id[12,-1,0]  ¦  event_count[-5,64,0]  ¦  seq_sum[-5,64,0]  ¦  max_seq[4,32,0]  𝄀
+w1  ¦  empty  ¦  0  ¦  null  ¦  null
+DROP DATABASE issue_28158_reg;

--- a/test/distributed/cases/optimizer/issue_28158.sql
+++ b/test/distributed/cases/optimizer/issue_28158.sql
@@ -1,0 +1,110 @@
+-- Issue #28158: a correlated scalar aggregate must not aggregate unrelated
+-- rows after decorrelation.  The execution checks below also protect the
+-- duplicate/multiplicity contract of the optimizer's key-domain join.
+
+DROP DATABASE IF EXISTS issue_28158_reg;
+CREATE DATABASE issue_28158_reg;
+USE issue_28158_reg;
+
+CREATE TABLE tasks (
+    workspace_id VARCHAR(20) NOT NULL,
+    task_id VARCHAR(20) NOT NULL,
+    state VARCHAR(20) NOT NULL,
+    PRIMARY KEY (workspace_id, task_id)
+);
+
+CREATE TABLE events (
+    event_id INT NOT NULL,
+    workspace_id VARCHAR(20) NOT NULL,
+    task_id VARCHAR(20) NOT NULL,
+    seq INT NOT NULL,
+    visible BOOL NOT NULL,
+    a2a_state VARCHAR(20) NOT NULL,
+    PRIMARY KEY (event_id),
+    KEY task_event_key (workspace_id, task_id)
+);
+
+INSERT INTO tasks VALUES
+    ('w1', 'same', 'running'),
+    ('w2', 'same', 'running'),
+    ('w1', 'empty', 'running');
+
+INSERT INTO events VALUES
+    (1, 'w1', 'same', 1, TRUE, 'completed'),
+    (2, 'w1', 'same', 2, TRUE, 'completed'),
+    (3, 'w2', 'same', 100, TRUE, 'completed'),
+    (4, 'w1', 'same', 3, FALSE, 'completed'),
+    (5, 'w1', 'same', 4, TRUE, 'pending');
+
+-- Only task_id is correlated.  The two workspaces deliberately share that
+-- value; this partial-key control remains outside the point-domain rewrite
+-- and verifies that the original workspace-agnostic correlation is preserved.
+SELECT t.workspace_id, t.task_id,
+       (SELECT COUNT(*)
+          FROM events e
+         WHERE e.task_id = t.task_id
+           AND e.visible = TRUE) AS event_count,
+       (SELECT SUM(e.seq)
+          FROM events e
+         WHERE e.task_id = t.task_id
+           AND e.visible = TRUE) AS seq_sum
+  FROM tasks t
+ WHERE t.task_id = 'same'
+ ORDER BY t.workspace_id;
+
+-- All composite primary-key columns are correlated and fixed to one row.
+-- COUNT/SUM/MAX protect the multiplicity and empty-input contracts.
+SELECT t.workspace_id, t.task_id,
+       (SELECT COUNT(*)
+          FROM events e
+         WHERE e.workspace_id = t.workspace_id
+           AND e.task_id = t.task_id
+           AND e.visible = TRUE
+           AND e.a2a_state IN ('completed', 'failed')) AS event_count,
+       (SELECT SUM(e.seq)
+          FROM events e
+         WHERE e.workspace_id = t.workspace_id
+           AND e.task_id = t.task_id
+           AND e.visible = TRUE
+           AND e.a2a_state IN ('completed', 'failed')) AS seq_sum,
+       (SELECT MAX(e.seq)
+          FROM events e
+         WHERE e.workspace_id = t.workspace_id
+           AND e.task_id = t.task_id
+           AND e.visible = TRUE
+           AND e.a2a_state IN ('completed', 'failed')) AS max_seq
+  FROM tasks t
+ WHERE t.workspace_id = 'w1'
+   AND t.task_id = 'same';
+
+-- No matching event rows: COUNT is zero, SUM/MAX are NULL, and the outer
+-- task row is retained by the surrounding LEFT JOIN shape.
+SELECT t.workspace_id, t.task_id,
+       (SELECT COUNT(*)
+          FROM events e
+         WHERE e.workspace_id = t.workspace_id
+           AND e.task_id = t.task_id
+           AND e.visible = TRUE
+           AND e.a2a_state IN ('completed', 'failed')) AS event_count,
+       (SELECT SUM(e.seq)
+          FROM events e
+         WHERE e.workspace_id = t.workspace_id
+           AND e.task_id = t.task_id
+           AND e.visible = TRUE
+           AND e.a2a_state IN ('completed', 'failed')) AS seq_sum,
+       (SELECT MAX(e.seq)
+          FROM events e
+         WHERE e.workspace_id = t.workspace_id
+           AND e.task_id = t.task_id
+           AND e.visible = TRUE
+           AND e.a2a_state IN ('completed', 'failed')) AS max_seq
+  FROM tasks t
+  LEFT JOIN events next_event
+    ON next_event.workspace_id = t.workspace_id
+   AND next_event.task_id = t.task_id
+   AND next_event.seq > 0
+ WHERE t.workspace_id = 'w1'
+   AND t.task_id = 'empty'
+ ORDER BY next_event.seq;
+
+DROP DATABASE issue_28158_reg;


### PR DESCRIPTION
## Summary

Fixes #28158.

The 4.2 optimizer decorrelates a scalar aggregate such as:

```sql
SELECT MAX(e.seq)
FROM agent_runtime_events AS e
WHERE e.workspace_id = task.workspace_id
  AND e.task_id = task.id;
```

by adding the correlated columns to the aggregate `GROUP BY`. The aggregate input can nevertheless remain independent of the filtered outer task. For a point lookup this makes the event relation scan unrelated workspaces/tasks before the grouped result is joined back to the task.

## Design

This change adds a deliberately narrow admission rule for the concrete incident shape:

1. Recognize only direct equality correlations that become aggregate group keys.
2. Require the outer relation to be one base-table scan with a complete primary-key point domain (`pk1 = constant AND ... AND pkn = constant`). Range, `IN`, `OR`, partial-key, non-key, derived, multi-table, and unfiltered domains keep the existing plan.
3. Add a duplicate-safe `SEMI` join from the aggregate input to a deep-copied outer key domain. `SEMI` is intentional: an ordinary inner join could multiply aggregate input when the outer relation contains duplicate keys.
4. Copy only deterministic outer predicates to the cloned domain. Deep-copy expressions and snapshots, allocate a fresh binding tag, and do not mutate the original scan or its read view.
5. When the aggregate input is a direct base-table scan and each correlation key is the corresponding direct scan column, copy the proven primary-key point predicates to that scan. This lets the normal index-selection path bound the physical read; the logical `SEMI` remains the correctness-preserving domain restriction.
6. Reject computed inner group keys for this rewrite. Reusing a computed/volatile key in both the aggregate and the new `SEMI` condition could evaluate it twice and change semantics. Unsafe shapes fall back to the pre-existing decorrelation behavior.

The complete `WHERE` list is made available while its conjuncts are flattened, so the admission decision does not depend on SQL predicate order. The temporary state is replaced by the flattened list after the walk.

## Correctness and risk decisions

- `SEMI` preserves inner-row multiplicity; it does not multiply `COUNT`, `SUM`, or `MAX` inputs.
- Empty-input behavior remains intact: `COUNT(*) = 0`, while `SUM`/`MAX` remain `NULL`; the surrounding outer row is retained.
- Composite keys require every key component to have a runtime-constant equality. Missing components and disjunctive/range predicates do not admit the optimization.
- Volatile/unknown functions and subqueries are not copied. A safe key equality may still be copied while unrelated unsafe conjuncts remain only on the original outer path.
- A failed predicate bind or unsupported shape returns before attaching the new node or aggregate filters, avoiding partial plan mutation.
- No new runtime synchronization, goroutine, retry, or resource-lifecycle path is introduced.
- The optimization intentionally does not attempt a cost model for broad domains. The point-only scope avoids adding a second wide domain scan or many unbounded probes.

## Validation

Local validation was run on the final commit:

- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=300s ./pkg/sql/plan`
- `./.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -run 'TestIssue28158' -timeout=300s ./pkg/sql/plan`
- `go vet ./pkg/sql/plan`
- `make err-check`
- `make build`
- mo-tester optimizer regression: 11/11, 100%
- `git diff --check`

The regression covers complete and partial composite-key correlations, duplicate keys, empty aggregate input, `COUNT`/`SUM`/`MAX`, volatile predicates, computed inner keys, disjunctions, incomplete key domains, and predicate-order independence.

For a local 100,000-event reproduction with only 100 rows belonging to the target task, the final `EXPLAIN ANALYZE` showed 100 rows read by the aggregate-side event scan, 100 rows from the `task_event_key` index domain, and 50 rows entering the aggregate after the completion predicate. Without the copied scan-level point filters, the aggregate-side event scan read 100,000 rows. This is plan evidence for the issue's point-lookup shape, not a claim about every workload.

CI was not awaited locally; GitHub CI remains the final platform/build matrix.
