### PR TITLE
fix(morpc): avoid client stream sequence gaps

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -698,6 +698,11 @@ func (rb *remoteBackend) doWrite(id uint64, f *Future) time.Time {
 		return time.Time{}
 	}
 	deadline := time.Now().Add(v)
+	if f.streamOwner != nil &&
+		!f.streamOwner.assignSendSequence(&f.send) {
+		f.messageSent(backendClosed)
+		return time.Time{}
+	}
 
 	// For PayloadMessage, the internal Codec will write the Payload directly to the underlying socket
 	// instead of copying it to the buffer, so the write deadline of the underlying conn needs to be reset
@@ -1717,6 +1722,8 @@ type stream struct {
 	id                   uint64
 	sequence             uint32
 	lastReceivedSequence uint32
+	sendSequenceMu       sync.Mutex
+	sendSequenceClosed   bool
 	mu                   struct {
 		sync.RWMutex
 		closed   bool
@@ -1749,7 +1756,10 @@ func newStream(
 func (s *stream) init(id uint64, unlockAfterClose bool) {
 	s.id = id
 	s.unlockAfterClose = unlockAfterClose
+	s.sendSequenceMu.Lock()
 	s.sequence = 0
+	s.sendSequenceClosed = false
+	s.sendSequenceMu.Unlock()
 	s.lastReceivedSequence = 0
 	s.mu.closed = false
 	s.mu.terminal = false
@@ -1811,13 +1821,12 @@ func (s *stream) doSendLocked(
 	ctx context.Context,
 	f *Future,
 	request Message) error {
-	s.sequence++
 	f.init(RPCMessage{
-		Ctx:            ctx,
-		Message:        request,
-		stream:         true,
-		streamSequence: s.sequence,
+		Ctx:     ctx,
+		Message: request,
+		stream:  true,
 	})
+	f.streamOwner = s
 	f.ref()
 	err := s.sendFunc(f)
 	if err != nil {
@@ -1840,6 +1849,9 @@ func (s *stream) Receive() (chan Message, error) {
 
 func (s *stream) Close(closeConn bool) error {
 	s.cancel()
+	s.sendSequenceMu.Lock()
+	s.sendSequenceClosed = true
+	s.sendSequenceMu.Unlock()
 	if closeConn {
 		s.rb.logger.Info("stream call closed on client", append(s.rb.logFields(), zap.Uint64("stream-id", s.id))...)
 		s.rb.Close()
@@ -1864,6 +1876,21 @@ func (s *stream) Close(closeConn bool) error {
 		panic("BUG: stream close notification channel is full")
 	}
 	return nil
+}
+
+// assignSendSequence runs in the single backend write loop after a request has
+// passed filter and context checks. Assigning at Stream.Send time would consume
+// a sequence for a queued request that expires before transport write, making
+// the next control message look out of order to the server.
+func (s *stream) assignSendSequence(message *RPCMessage) bool {
+	s.sendSequenceMu.Lock()
+	defer s.sendSequenceMu.Unlock()
+	if s.sendSequenceClosed {
+		return false
+	}
+	s.sequence++
+	message.streamSequence = s.sequence
+	return true
 }
 
 func (s *stream) ID() uint64 {

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -182,6 +182,7 @@ type remoteBackend struct {
 	writeC          chan *Future
 	waitWriteC      chan struct{}
 	stopWriteC      chan struct{}
+	stopWriteOnce   sync.Once
 	resetConnC      chan error
 	stopper         *stopper.Stopper
 	readStopper     *stopper.Stopper
@@ -639,6 +640,7 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 					// Encoding may have written a partial frame (including directly
 					// to the socket). Never flush or reuse this connection after it.
 					rb.changeToStopping()
+					rb.stopWriteLoop()
 					rb.cancelActiveStreams()
 					for _, pending := range written {
 						pending.messageSent(err)
@@ -667,6 +669,7 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 						f.messageSent(err)
 					}
 					rb.changeToStopping()
+					rb.stopWriteLoop()
 					rb.cancelActiveStreams()
 					rb.makeAllWaitingFutureFailed(err)
 					return
@@ -1018,7 +1021,9 @@ func (rb *remoteBackend) removeActiveStream(s *stream) {
 }
 
 func (rb *remoteBackend) stopWriteLoop() {
-	close(rb.stopWriteC)
+	// Wake every admission waiter before termination waits for stream locks.
+	// The writer's failure path and Close may both own this notification.
+	rb.stopWriteOnce.Do(func() { close(rb.stopWriteC) })
 }
 
 func (rb *remoteBackend) requestDone(

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -625,7 +625,7 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 
 			var writeDeadline time.Time
 			written := messages[:0]
-			for _, f := range messages {
+			for idx, f := range messages {
 				rb.metrics.writeLatencyDurationHistogram.Observe(start.Sub(f.send.createAt).Seconds())
 
 				id := f.getSendMessageID()
@@ -634,7 +634,22 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 					continue
 				}
 
-				if deadline := rb.doWrite(id, f); !deadline.IsZero() {
+				deadline, err := rb.doWrite(id, f)
+				if err != nil {
+					// Encoding may have written a partial frame (including directly
+					// to the socket). Never flush or reuse this connection after it.
+					rb.changeToStopping()
+					rb.cancelActiveStreams()
+					for _, pending := range written {
+						pending.messageSent(err)
+					}
+					for _, pending := range messages[idx+1:] {
+						pending.messageSent(err)
+					}
+					rb.makeAllWaitingFutureFailed(err)
+					return
+				}
+				if !deadline.IsZero() {
 					writeDeadline = earliestDeadline(writeDeadline, deadline)
 					written = append(written, f)
 				}
@@ -651,6 +666,10 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 							append(rb.logFields(), zap.Uint64("request-id", id), zap.Error(err))...)
 						f.messageSent(err)
 					}
+					rb.changeToStopping()
+					rb.cancelActiveStreams()
+					rb.makeAllWaitingFutureFailed(err)
+					return
 				} else {
 					// Record only transport-complete writes. A request that merely
 					// reached the userspace buffer must not extend the read window
@@ -681,27 +700,27 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 	}
 }
 
-func (rb *remoteBackend) doWrite(id uint64, f *Future) time.Time {
+func (rb *remoteBackend) doWrite(id uint64, f *Future) (time.Time, error) {
 	if !rb.options.filter(f.send.Message, rb.remote) {
 		f.messageSent(messageSkipped)
-		return time.Time{}
+		return time.Time{}, nil
 	}
 	// already timeout in future, and future will get a ctx timeout
 	if f.send.Timeout() {
 		f.messageSent(f.send.Ctx.Err())
-		return time.Time{}
+		return time.Time{}, nil
 	}
 
 	v, err := f.send.GetTimeoutFromContext()
 	if err != nil {
 		f.messageSent(err)
-		return time.Time{}
+		return time.Time{}, nil
 	}
 	deadline := time.Now().Add(v)
 	if f.streamOwner != nil &&
 		!f.streamOwner.assignSendSequence(&f.send) {
 		f.messageSent(backendClosed)
-		return time.Time{}
+		return time.Time{}, nil
 	}
 
 	// For PayloadMessage, the internal Codec will write the Payload directly to the underlying socket
@@ -731,9 +750,9 @@ func (rb *remoteBackend) doWrite(id uint64, f *Future) time.Time {
 			"write request failed",
 			append(rb.logFields(), zap.Uint64("request-id", id), zap.Error(err))...)
 		f.messageSent(err)
-		return time.Time{}
+		return time.Time{}, err
 	}
-	return deadline
+	return deadline, nil
 }
 
 func (rb *remoteBackend) readLoop(ctx context.Context) {
@@ -1940,6 +1959,9 @@ func (s *stream) done(
 // unregister ownership with Stream.Close, as required by the Stream contract.
 func (s *stream) terminate() {
 	s.cancel()
+	s.sendSequenceMu.Lock()
+	s.sendSequenceClosed = true
+	s.sendSequenceMu.Unlock()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mu.closed || s.mu.terminal {

--- a/pkg/common/morpc/backend_failure_test.go
+++ b/pkg/common/morpc/backend_failure_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fagongzi/goetty/v2"
+	"github.com/matrixorigin/matrixone/pkg/common/stopper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type admissionBarrierContext struct {
+	context.Context
+	calls   atomic.Int32
+	waiting chan struct{}
+}
+
+func (c *admissionBarrierContext) Done() <-chan struct{} {
+	// doSend checks Done once while attempting admission, then waitWrite
+	// checks it again. The second call proves the full-queue branch was taken.
+	if c.calls.Add(1) == 2 {
+		close(c.waiting)
+	}
+	return c.Context.Done()
+}
+
+type blockedFailureSession struct {
+	*testIOSession
+	failFlush bool
+	entered   chan struct{}
+	release   chan struct{}
+	closeOnce sync.Once
+}
+
+func (s *blockedFailureSession) fail() error {
+	close(s.entered)
+	<-s.release
+	return assert.AnError
+}
+
+func (s *blockedFailureSession) Write(any, goetty.WriteOptions) error {
+	if !s.failFlush {
+		return s.fail()
+	}
+	return nil
+}
+
+func (s *blockedFailureSession) Flush(time.Duration) error { return s.fail() }
+
+func (s *blockedFailureSession) Close() error {
+	s.closeOnce.Do(func() { _ = s.testIOSession.Close() })
+	return nil
+}
+
+func TestBackendFailureWakesBlockedStreamAdmission(t *testing.T) {
+	for _, failFlush := range []bool{false, true} {
+		name := "write"
+		if failFlush {
+			name = "flush"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			conn := &blockedFailureSession{testIOSession: newTestIOSession(nil, nil), failFlush: failFlush, entered: make(chan struct{}), release: make(chan struct{})}
+			rb := &remoteBackend{
+				conn: conn, codec: newTestCodec(), metrics: newMetrics(t.Name()),
+				stopper: stopper.NewStopper(t.Name()), readStopper: stopper.NewStopper(t.Name()),
+				writeC: make(chan *Future, 1), waitWriteC: make(chan struct{}, 1), stopWriteC: make(chan struct{}),
+				resetConnC: make(chan error, 1), closeDone: make(chan struct{}),
+			}
+			rb.ctx, rb.cancel = context.WithCancel(context.Background())
+			rb.adjust()
+			rb.stateMu.state = stateRunning
+			rb.options.batchSendSize = 1
+			s := newStream(rb, make(chan Message, 1), func() *Future { return newFuture(nil) }, rb.doSend, rb.removeActiveStream, func() {})
+			s.init(10, false)
+			rb.mu.activeStreams = map[uint64]*stream{10: s}
+			rb.mu.futures = make(map[uint64]*Future)
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(conn.release) }) }
+			defer func() { release(); cancel(); rb.Close(); _ = s.Close(false) }()
+			queue := func(id uint64) *Future {
+				f := newFuture(nil)
+				f.init(RPCMessage{Ctx: ctx, Message: newTestMessage(id)})
+				f.ref()
+				rb.writeC <- f
+				rb.changeQueueDepth(1)
+				return f
+			}
+			first := queue(1)
+			defer first.Close()
+			done := make(chan struct{})
+			require.NoError(t, rb.stopper.RunTask(func(c context.Context) { rb.writeLoop(c); close(done) }))
+			select {
+			case <-conn.entered:
+			case <-ctx.Done():
+				t.Fatal("writer did not reach failure barrier")
+			}
+			queued := queue(2)
+			defer queued.Close()
+			// Consume the earlier fetch notification before admitting the sender.
+			select {
+			case <-rb.waitWriteC:
+			default:
+			}
+			admissionCtx := &admissionBarrierContext{Context: ctx, waiting: make(chan struct{})}
+			sent := make(chan error, 1)
+			go func() { sent <- s.Send(admissionCtx, newTestMessage(10)) }()
+			select {
+			case <-admissionCtx.waiting:
+			case <-ctx.Done():
+				t.Fatal("sender did not reach full queue")
+			}
+			release()
+			select {
+			case err := <-sent:
+				require.ErrorIs(t, err, backendClosed)
+			case <-ctx.Done():
+				t.Fatal("failure did not release admission")
+			}
+			select {
+			case message := <-s.c:
+				require.Nil(t, message)
+			case <-ctx.Done():
+				t.Fatal("failure did not terminate stream")
+			}
+			select {
+			case <-done:
+			case <-ctx.Done():
+				t.Fatal("failure did not finish writer")
+			}
+			require.Error(t, first.waitSendCompleted())
+			require.ErrorIs(t, queued.waitSendCompleted(), backendClosed)
+			require.NoError(t, ctx.Err(), "caller cancellation must not release cleanup")
+			// Failure owns the first stop broadcast; subsequent Close must join
+			// teardown without double-closing the signal or joining itself.
+			rb.Close()
+			rb.Close()
+		})
+	}
+}

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -1785,6 +1785,148 @@ func TestStreamSendFailureReleasesAndReusesFuture(t *testing.T) {
 	require.Equal(t, int32(2), releases.Load())
 }
 
+func TestSkippedStreamRequestDoesNotCreateSequenceGap(t *testing.T) {
+	sequences := make(chan uint32, 2)
+	var attempts atomic.Int32
+	testBackendSend(t,
+		func(_ goetty.IOSession, value interface{}, _ uint64) error {
+			sequences <- value.(RPCMessage).streamSequence
+			return nil
+		},
+		func(b *remoteBackend) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			stream, err := b.NewStream(false)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, stream.Close(false)) }()
+
+			require.NoError(t, stream.Send(ctx, newTestMessage(stream.ID())))
+			require.ErrorIs(t,
+				stream.Send(ctx, newTestMessage(stream.ID())),
+				messageSkipped)
+			require.NoError(t, stream.Send(ctx, newTestMessage(stream.ID())))
+
+			for _, expected := range []uint32{1, 2} {
+				select {
+				case sequence := <-sequences:
+					require.Equal(t, expected, sequence)
+				case <-ctx.Done():
+					t.Fatal("timed out waiting for stream request")
+				}
+			}
+		},
+		WithBackendBatchSendSize(1),
+		WithBackendFilter(func(Message, string) bool {
+			return attempts.Add(1) != 2
+		}),
+	)
+}
+
+func TestCanceledStreamRequestDoesNotCreateSequenceGap(t *testing.T) {
+	sequences := make(chan uint32, 1)
+	testBackendSend(t,
+		func(_ goetty.IOSession, value interface{}, _ uint64) error {
+			sequences <- value.(RPCMessage).streamSequence
+			return nil
+		},
+		func(b *remoteBackend) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			stream, err := b.NewStream(false)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, stream.Close(false)) }()
+
+			canceledCtx, cancelSend := context.WithTimeout(context.Background(), time.Second)
+			cancelSend()
+			require.ErrorIs(t,
+				stream.Send(canceledCtx, newTestMessage(stream.ID())),
+				context.Canceled)
+			require.NoError(t, stream.Send(ctx, newTestMessage(stream.ID())))
+
+			select {
+			case sequence := <-sequences:
+				require.Equal(t, uint32(1), sequence)
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for stream request")
+			}
+		},
+		WithBackendBatchSendSize(1),
+	)
+}
+
+func TestAssignStreamSequenceRejectsClosedStream(t *testing.T) {
+	stream := newStream(
+		nil,
+		make(chan Message, 1),
+		func() *Future { return newFuture(nil) },
+		func(*Future) error { return nil },
+		func(*stream) {},
+		func() {},
+	)
+	stream.init(1, false)
+	require.NoError(t, stream.Close(false))
+
+	message := RPCMessage{stream: true}
+	require.False(t, stream.assignSendSequence(&message))
+	require.Zero(t, message.streamSequence)
+	require.Zero(t, stream.sequence)
+}
+
+func TestAssignStreamSequenceProgressesWhileSendAdmissionBlocked(t *testing.T) {
+	sendEntered := make(chan struct{})
+	releaseSend := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseSend) }) }
+	defer release()
+	stream := newStream(
+		nil,
+		make(chan Message, 1),
+		func() *Future { return newFuture(nil) },
+		func(f *Future) error {
+			close(sendEntered)
+			<-releaseSend
+			f.messageSent(nil)
+			return nil
+		},
+		func(*stream) {},
+		func() {},
+	)
+	stream.init(1, false)
+	defer func() { require.NoError(t, stream.Close(false)) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- stream.Send(ctx, newTestMessage(stream.ID()))
+	}()
+	select {
+	case <-sendEntered:
+	case <-ctx.Done():
+		t.Fatal("send did not reach the admission barrier")
+	}
+
+	message := RPCMessage{stream: true}
+	assigned := make(chan bool, 1)
+	go func() { assigned <- stream.assignSendSequence(&message) }()
+	select {
+	case ok := <-assigned:
+		require.True(t, ok)
+		require.Equal(t, uint32(1), message.streamSequence)
+	case <-ctx.Done():
+		t.Fatal("sequence assignment blocked behind stream send admission")
+	}
+
+	release()
+	select {
+	case err := <-sendDone:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("blocked send did not finish")
+	}
+}
+
 func TestStreamClosedByConnReset(t *testing.T) {
 	testBackendSend(t,
 		func(conn goetty.IOSession, msg interface{}, seq uint64) error {

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -1978,7 +1978,7 @@ func TestAssignStreamSequenceProgressesWhileSendAdmissionBlocked(t *testing.T) {
 	releaseSend := make(chan struct{})
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(releaseSend) }) }
-	defer release()
+	var workers sync.WaitGroup
 	stream := newStream(
 		nil,
 		make(chan Message, 1),
@@ -1993,12 +1993,20 @@ func TestAssignStreamSequenceProgressesWhileSendAdmissionBlocked(t *testing.T) {
 		func() {},
 	)
 	stream.init(1, false)
-	defer func() { require.NoError(t, stream.Close(false)) }()
+	defer func() {
+		// Send holds the stream read lock while waiting on our barrier. Release
+		// it before joining workers or closing, including after FailNow.
+		release()
+		workers.Wait()
+		require.NoError(t, stream.Close(false))
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	sendDone := make(chan error, 1)
+	workers.Add(1)
 	go func() {
+		defer workers.Done()
 		sendDone <- stream.Send(ctx, newTestMessage(stream.ID()))
 	}()
 	select {
@@ -2009,7 +2017,11 @@ func TestAssignStreamSequenceProgressesWhileSendAdmissionBlocked(t *testing.T) {
 
 	message := RPCMessage{stream: true}
 	assigned := make(chan bool, 1)
-	go func() { assigned <- stream.assignSendSequence(&message) }()
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		assigned <- stream.assignSendSequence(&message)
+	}()
 	select {
 	case ok := <-assigned:
 		require.True(t, ok)

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -1955,7 +1955,7 @@ func TestBackendWriteFailureRetiresBatch(t *testing.T) {
 			}
 			done := make(chan struct{})
 			go func() { rb.writeLoop(ctx); close(done) }()
-			defer func() { close(rb.stopWriteC); <-done }()
+			defer func() { rb.stopWriteLoop(); <-done }()
 			select {
 			case <-done:
 			case <-ctx.Done():

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -1873,6 +1873,106 @@ func TestAssignStreamSequenceRejectsClosedStream(t *testing.T) {
 	require.Zero(t, stream.sequence)
 }
 
+func TestTerminatedStreamRejectsQueuedWrite(t *testing.T) {
+	conn := newTestIOSession(assert.AnError, nil)
+	defer conn.Close()
+	rb := &remoteBackend{conn: conn}
+	rb.options.filter = func(Message, string) bool { return true }
+	s := newStream(rb, make(chan Message, 1), nil, nil, func(*stream) {}, nil)
+	s.init(1, false)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	f := newFuture(nil)
+	f.init(RPCMessage{Ctx: ctx, Message: newTestMessage(1), stream: true})
+	f.streamOwner = s
+	f.ref()
+	defer f.Close()
+	// Connection reset seals old streams before publishing the new transport.
+	s.terminate()
+	deadline, err := rb.doWrite(1, f)
+	require.NoError(t, err)
+	require.True(t, deadline.IsZero())
+	require.ErrorIs(t, f.waitSendCompleted(), backendClosed)
+	require.Zero(t, conn.writeCount.Load(), "old request reached replacement transport")
+	require.Zero(t, s.sequence)
+}
+
+type deadlineEncodingSession struct {
+	*testIOSession
+	codec  Codec
+	cancel context.CancelFunc
+}
+
+func (s *deadlineEncodingSession) Write(value any, _ goetty.WriteOptions) error {
+	if s.writeCount.Add(1) == 2 {
+		s.cancel()
+	}
+	return s.codec.Encode(value, s.out, io.Discard)
+}
+
+func TestBackendWriteFailureRetiresBatch(t *testing.T) {
+	for _, failure := range []string{"write", "flush", "encode deadline"} {
+		t.Run(failure, func(t *testing.T) {
+			conn := newTestIOSessionWithWriteErrorAt(2, assert.AnError, nil)
+			if failure == "flush" {
+				conn.writeErr = nil
+				conn.flushErr = assert.AnError
+			}
+			rb := &remoteBackend{
+				conn: conn, metrics: newMetrics(t.Name()),
+				readStopper: stopper.NewStopper(t.Name()),
+				writeC:      make(chan *Future, 4), waitWriteC: make(chan struct{}, 1),
+				stopWriteC: make(chan struct{}),
+			}
+			rb.adjust()
+			rb.stateMu.state = stateRunning
+			rb.options.batchSendSize = 3
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+			encodeCtx := newManuallyExpiringContext(time.Now().Add(time.Minute))
+			if failure == "encode deadline" {
+				rb.conn = &deadlineEncodingSession{testIOSession: conn, codec: newTestCodec(), cancel: func() {
+					encodeCtx.deadline = time.Now().Add(-time.Minute)
+					encodeCtx.expire()
+				}}
+			}
+			var futures []*Future
+			for i := range 4 {
+				f := newFuture(nil)
+				requestCtx := ctx
+				if i == 1 && failure == "encode deadline" {
+					requestCtx = encodeCtx
+				}
+				f.init(RPCMessage{Ctx: requestCtx, Message: newTestMessage(uint64(i + 1)), stream: true})
+				s := newStream(rb, make(chan Message, 1), nil, nil, func(*stream) {}, nil)
+				s.init(uint64(i+1), false)
+				f.streamOwner = s
+				f.ref()
+				defer f.Close()
+				futures = append(futures, f)
+				rb.writeC <- f
+				rb.changeQueueDepth(1)
+			}
+			done := make(chan struct{})
+			go func() { rb.writeLoop(ctx); close(done) }()
+			defer func() { close(rb.stopWriteC); <-done }()
+			select {
+			case <-done:
+			case <-ctx.Done():
+				t.Fatal("write failure did not retire backend")
+			}
+			for _, f := range futures {
+				require.Error(t, f.waitSendCompleted())
+			}
+			require.Equal(t, stateStopping, rb.stateMu.state)
+			if failure != "flush" {
+				require.Equal(t, int32(2), conn.writeCount.Load())
+				require.Empty(t, conn.flushC, "partial batch was flushed after write failure")
+			}
+		})
+	}
+}
+
 func TestAssignStreamSequenceProgressesWhileSendAdmissionBlocked(t *testing.T) {
 	sendEntered := make(chan struct{})
 	releaseSend := make(chan struct{})

--- a/pkg/common/morpc/codec.go
+++ b/pkg/common/morpc/codec.go
@@ -303,6 +303,7 @@ func (c *baseCodec) Encode(data interface{}, out *buf.ByteBuf, conn io.Writer) e
 	// 2.4 Custom header size
 	n, err := c.encodeCustomHeaders(&msg, out)
 	if err != nil {
+		discardWritten()
 		return err
 	}
 	totalSize += n

--- a/pkg/common/morpc/codec_test.go
+++ b/pkg/common/morpc/codec_test.go
@@ -338,6 +338,24 @@ type failingContextHeaderCodec struct {
 	ctx context.Context
 }
 
+func TestHeaderEncodeFailureRestoresBufferAndPayload(t *testing.T) {
+	codec := newTestCodec().(*messageCodec)
+	codec.AddHeaderCodec(&failingContextHeaderCodec{})
+	out := buf.NewByteBuf(64)
+	defer out.Close()
+	_, err := out.Write([]byte("prior frame"))
+	require.NoError(t, err)
+	offset := out.GetWriteOffset()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	msg := newTestMessage(1)
+	msg.SetPayloadField([]byte("payload"))
+	err = codec.Encode(RPCMessage{Ctx: ctx, Message: msg}, out, io.Discard)
+	require.Error(t, err)
+	require.Equal(t, offset, out.GetWriteOffset())
+	require.Equal(t, []byte("payload"), msg.GetPayloadField())
+}
+
 func (c *failingContextHeaderCodec) Encode(*RPCMessage, *buf.ByteBuf) (int, error) {
 	return 0, errors.New("injected header encode failure")
 }

--- a/pkg/common/morpc/future.go
+++ b/pkg/common/morpc/future.go
@@ -36,8 +36,12 @@ func newFuture(releaseFunc func(f *Future)) *Future {
 type Future struct {
 	id   uint64
 	send RPCMessage
-	c    chan Message
-	errC chan error
+	// streamOwner is local-only send lifecycle state. It is deliberately kept
+	// out of RPCMessage so ordinary wire envelopes are not enlarged or coupled
+	// to a client-side stream object.
+	streamOwner *stream
+	c           chan Message
+	errC        chan error
 	// used to check error for sending message
 	writtenC chan error
 	waiting  atomic.Bool
@@ -75,6 +79,7 @@ func (f *Future) init(send RPCMessage) {
 	f.requestMetricObserved.Store(false)
 	f.requestMetrics = nil
 	f.send = send
+	f.streamOwner = nil
 	f.send.createAt = time.Now()
 	f.id = send.Message.GetID()
 	f.oneWay = send.oneWay
@@ -330,6 +335,7 @@ func (f *Future) reset() {
 	default:
 	}
 	f.send = RPCMessage{}
+	f.streamOwner = nil
 	f.writtenAt.Store(0)
 	f.sendRelease = nil
 	f.responseRelease = nil


### PR DESCRIPTION
## Problem

Client MORPC streams consumed request sequences before queued messages passed the write-loop filter and context checks. Skipping a canceled request could make the next control frame arrive as sequence 3 after sequence 1, causing the server to close the connection. The existing two-CN `TestIssue28313EmptyRemoteDispatch` reproduced this gap and `rpc stream closed` locally.

Related: #28313, #25811 (the analogous server-response fix). The placement-probing INFO message cited in #28313 is not sufficient evidence of the cause. The local reproduction establishes this failure mechanism; it does not independently establish the exact trigger of the original deployment incident.

## Change

- Assign request sequences in the single backend writer after skip checks. Keep stream ownership on the pooled Future and clear it on initialization/reset.
- Use a separate sequence lock so assignment does not depend on the lifecycle lock held by a sender waiting for queue admission.
- Seal sequence assignment on both explicit Close and transport termination. Old queued stream requests are rejected before writing to a replacement connection.
- Treat encoding/transport Write and Flush failures as terminal for the backend. Fail the current batch, retire active streams, fail waiting responses, and drain queued Futures through the existing writer cleanup. Do not flush a batch after a Write failure.
- Restore the output-buffer boundary and payload when custom-header encoding fails.
- Broadcast terminal admission shutdown before acquiring stream lifecycle locks on both Write and Flush failure; share an idempotent stop notification with Close.

## Failure policy and review corrections

Review identified two omissions in the initial implementation: the codec rechecks deadlines after sequence assignment, and connection-reset termination did not seal send-sequence state. Both are now covered at their production boundaries.

Follow-up review found a shutdown wait cycle: a real Stream.Send can hold the stream read lock while waiting for space in the backend queue, while fatal writer cleanup waits for that stream's exclusive lock before draining the queue. Stream cancellation alone does not wake queue admission. The failure paths now close the admission stop signal first, releasing senders before stream termination. A sync.Once shares this terminal broadcast with concurrent/repeated Close; the writer does not call Close or join itself. Deterministic tests force a full queue and a real blocked Stream.Send for both Write and Flush failure, then assert sender completion, receiver termination, queued Future completion, writer exit, and repeated Close without caller cancellation.

An encoding failure is not always reversible: payload encoding can already have written bytes directly to the socket. The backend therefore closes rather than rolling back a sequence and reusing potentially corrupted framing. This also fails other in-flight requests on that connection, including unary traffic. Recovery uses the existing backend replacement mechanism; this change adds no automatic request retry. Failures detected before entering transport encoding remain ordinary skipped requests and leave sequence continuity intact.

## Performance and compatibility

Wire format is unchanged. Normal stream frames incur one short sequence-lock operation; unary frames do not acquire it. No new queues, goroutines, timers, per-row work, or logging are introduced. Failure cleanup is proportional to the outstanding batch/requests. No throughput benchmark was run; normal-path performance claims are based on the code changes, not a measured zero-regression guarantee.

## Validation

Base: `fdc1e0ca8f9696ada9668408e8caffc1d3b7c924`.

Deterministic tests cover skipped/canceled requests, explicit close, blocked send admission, old queued writes after transport termination, and batch cleanup on Write/Flush failure. The encoding test advances the deadline after sequence assignment and invokes the real codec; it verifies that later requests are not written and the failed batch is not flushed. The header test verifies buffer/payload restoration.

- New review regression tests: each individually `-race -count=100`, passed.
- Full-queue admission shutdown regression (Write and Flush): `-race -count=100`, passed after the follow-up correction.
- Full MORPC package: normal and race, passed.
- Full compile package and the original two-CN SQL case (10 repetitions): passed.
- Dependent build, vet, and `git diff --check`: passed.

The earlier 50-repeat SQL run predates these review corrections and is retained only as historical evidence. Local validation uses darwin/arm64 with the repository CGo wrapper; Linux CI remains separate evidence.
