### PR TITLE
fix(disttae): inspect catalog tombstones before retrying DDL

### DIFF
--- a/pkg/vm/engine/disttae/catalog_tombstone_test.go
+++ b/pkg/vm/engine/disttae/catalog_tombstone_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/stretchr/testify/require"
+)
+
+func newCatalogTombstoneFixture(t testing.TB, rows int, cn bool) (*process.Process, fileservice.FileService, *logtailreplay.PartitionState) {
+	t.Helper()
+	proc := testutil.NewProc(t)
+	mp := proc.Mp()
+	t.Cleanup(func() {
+		proc.Free()
+		proc.GetFileService().Close(context.Background())
+		require.Zero(t, mp.CurrNB())
+	})
+	fs, err := fileservice.Get[fileservice.FileService](proc.GetFileService(), defines.SharedFileServiceName)
+	require.NoError(t, err)
+	ctx := proc.Ctx
+	pkType := types.T_varchar.ToType()
+	selection := objectio.HiddenColumnSelection_CommitTS
+	columns := 3
+	if cn {
+		selection = objectio.HiddenColumnSelection_None
+		columns = 2
+	}
+	writer := ioutil.ConstructTombstoneWriter(selection, fs)
+	bat := batch.NewWithSize(columns)
+	bat.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	bat.Vecs[1] = vector.NewVec(pkType)
+	if !cn {
+		bat.Vecs[2] = vector.NewVec(types.T_TS.ToType())
+	}
+	t.Cleanup(func() { bat.Clean(mp) })
+	objectID := objectio.NewObjectid()
+	for row := 0; row < rows; row++ {
+		require.NoError(t, vector.AppendFixed(bat.Vecs[0], types.NewRowIDWithObjectIDBlkNumAndRowID(
+			objectID, uint16(row/objectio.BlockMaxRows), uint32(row%objectio.BlockMaxRows)), false, mp))
+		require.NoError(t, vector.AppendBytes(bat.Vecs[1], []byte(fmt.Sprintf("other-%05d", rows-row)), false, mp))
+		if !cn {
+			require.NoError(t, vector.AppendFixed(bat.Vecs[2], types.BuildTS(20, 0), false, mp))
+		}
+		if bat.Vecs[0].Length() == objectio.BlockMaxRows || row == rows-1 {
+			bat.SetRowCount(bat.Vecs[0].Length())
+			_, err = writer.WriteBatch(bat)
+			require.NoError(t, err)
+			bat.CleanOnlyData()
+		}
+	}
+	_, _, err = writer.Sync(ctx)
+	require.NoError(t, err)
+	stats := writer.GetObjectStats()
+	if cn {
+		objectio.WithCNCreated()(&stats)
+	}
+	require.EqualValues(t, rows, stats.Rows())
+	state := logtailreplay.NewPartitionState("", true, 0, false)
+	require.NoError(t, state.HandleObjectEntry(ctx, fs, objectio.ObjectEntry{
+		ObjectStats: stats, CreateTime: types.BuildTS(40, 0),
+	}, true))
+	return proc, fs, state
+}
+
+// Exercise the production caller, not just a policy helper. One immutable
+// persisted fixture crosses the old 50,000-row boundary. PKs are deliberately
+// unrelated to rowid ordering, as in catalog tombstones after compaction.
+func TestCatalogTombstonePKCheck(t *testing.T) {
+	proc, fs, state := newCatalogTombstoneFixture(t, 50001, false)
+	mp, ctx := proc.Mp(), proc.Ctx
+	pkType := types.T_varchar.ToType()
+	txn := &Transaction{engine: &Engine{fs: fs}}
+	op := newTxnOperatorForTestWithWorkspace(t, txn)
+	tbl := &txnTable{
+		db: &txnDatabase{op: op}, primaryIdx: 0,
+		tableDef: &plan.TableDef{
+			Cols: []*plan.ColDef{{Name: "pk", Typ: plan.Type{Id: int32(types.T_varchar)}}},
+			Pkey: &plan.PrimaryKeyDef{PkeyColName: "pk"}, Name2ColIndex: map[string]int32{"pk": 0},
+		},
+	}
+	tbl.proc.Store(proc)
+	for _, tc := range []struct {
+		name     string
+		id       uint64
+		key      string
+		from, to int64
+		changed  bool
+	}{
+		{"unrelated-tables", catalog.MO_TABLES_ID, "target", 10, 30, false},
+		{"unrelated-databases", catalog.MO_DATABASE_ID, "target", 10, 30, false},
+		{"unrelated-columns", catalog.MO_COLUMNS_ID, "target", 10, 30, false},
+		{"unrelated-logical-id-index", catalog.MO_TABLES_LOGICAL_ID_INDEX_ID, "target", 10, 30, false},
+		{"real-delete-last-block", catalog.MO_TABLES_ID, "other-00001", 10, 20, true},
+		{"old-delete-compacted-after-snapshot", catalog.MO_TABLES_ID, "other-00001", 20, 30, false},
+		{"delete-after-upper-bound", catalog.MO_TABLES_ID, "other-00001", 10, 19, false},
+		{"user-table-keeps-cost-guard", 1000, "target", 10, 30, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tbl.tableId = tc.id
+			key := vector.NewVec(pkType)
+			defer key.Free(mp)
+			require.NoError(t, vector.AppendBytes(key, []byte(tc.key), false, mp))
+			baseline := mp.CurrNB()
+			changed, err := tbl.PKPersistedBetween(state, types.BuildTS(tc.from, 0), types.BuildTS(tc.to, 0), key, true)
+			require.NoError(t, err)
+			require.Equal(t, tc.changed, changed)
+			require.Equal(t, baseline, mp.CurrNB())
+			require.Empty(t, pkCheckSemaphore, "the check must release its I/O permit")
+		})
+	}
+	// Cancellation must not turn into a successful negative check, or into an
+	// apparent metadata conflict which can restart the expensive statement.
+	t.Run("cancelled", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		proc.Ctx = cancelCtx
+		defer func() { proc.Ctx = ctx }()
+		tbl.tableId = catalog.MO_TABLES_ID
+		key := vector.NewVec(pkType)
+		defer key.Free(mp)
+		require.NoError(t, vector.AppendBytes(key, []byte("target"), false, mp))
+		_, err := tbl.PKPersistedBetween(state, types.BuildTS(10, 0), types.BuildTS(30, 0), key, true)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Empty(t, pkCheckSemaphore)
+	})
+}
+
+type tombstoneReadFS struct {
+	fileservice.FileService
+	read func(context.Context, *fileservice.IOVector) error
+}
+
+func (fs tombstoneReadFS) Read(ctx context.Context, v *fileservice.IOVector) error {
+	return fs.read(ctx, v)
+}
+
+type tombstoneWaitContext struct {
+	context.Context
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (ctx *tombstoneWaitContext) Done() <-chan struct{} {
+	ctx.once.Do(func() { close(ctx.entered) })
+	return ctx.Context.Done()
+}
+
+func TestCatalogTombstoneCancellationAndFailure(t *testing.T) {
+	proc, fs, state := newCatalogTombstoneFixture(t, 1, false)
+	mp := proc.Mp()
+	key := vector.NewVec(types.T_varchar.ToType())
+	defer key.Free(mp)
+	require.NoError(t, vector.AppendBytes(key, []byte("target"), false, mp))
+	check := func(ctx context.Context, fs fileservice.FileService) (bool, string, error) {
+		return tombstonePKExistsInRange(ctx, catalog.MO_TABLES_ID, state,
+			types.BuildTS(10, 0), types.BuildTS(30, 0), key, *key.GetType(), fs, mp)
+	}
+	t.Run("read-error-remains-conservative", func(t *testing.T) {
+		changed, reason, err := check(proc.Ctx, tombstoneReadFS{FileService: fs,
+			read: func(context.Context, *fileservice.IOVector) error { return errors.New("injected read failure") },
+		})
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.Equal(t, "tombstone_read_error", reason)
+		require.Empty(t, pkCheckSemaphore)
+	})
+	for _, phase := range []string{"permit-wait", "read"} {
+		t.Run(phase, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(proc.Ctx, 10*time.Second)
+			defer cancel()
+			entered := make(chan struct{})
+			var checkCtx context.Context = ctx
+			var checkFS fileservice.FileService = fs
+			if phase == "permit-wait" {
+				for i := 0; i < cap(pkCheckSemaphore); i++ {
+					pkCheckSemaphore <- struct{}{}
+				}
+				defer func() {
+					for i := 0; i < cap(pkCheckSemaphore); i++ {
+						releasePKCheckSemaphore()
+					}
+				}()
+				checkCtx = &tombstoneWaitContext{Context: ctx, entered: entered}
+			} else {
+				var once sync.Once
+				checkFS = tombstoneReadFS{FileService: fs, read: func(ctx context.Context, _ *fileservice.IOVector) error {
+					once.Do(func() { close(entered) })
+					<-ctx.Done()
+					return ctx.Err()
+				}}
+			}
+			done := make(chan error, 1)
+			finished := make(chan struct{})
+			go func() {
+				defer close(finished)
+				_, _, err := check(checkCtx, checkFS)
+				done <- err
+			}()
+			defer func() { cancel(); <-finished }()
+			select {
+			case <-entered:
+			case <-ctx.Done():
+				t.Fatal("check did not reach the controlled wait", ctx.Err())
+			}
+			cancel()
+			require.ErrorIs(t, <-done, context.Canceled)
+			if phase == "read" {
+				require.Empty(t, pkCheckSemaphore)
+			}
+		})
+	}
+	changed, _, err := check(proc.Ctx, fs)
+	require.NoError(t, err)
+	require.False(t, changed, "cancellation must not poison subsequent checks")
+	require.Empty(t, pkCheckSemaphore)
+}
+
+func TestCatalogCNTombstonePKCheck(t *testing.T) {
+	proc, fs, state := newCatalogTombstoneFixture(t, 50001, true)
+	key := vector.NewVec(types.T_varchar.ToType())
+	defer key.Free(proc.Mp())
+	for _, value := range []string{"target", "other-00001"} {
+		key.CleanOnlyData()
+		require.NoError(t, vector.AppendBytes(key, []byte(value), false, proc.Mp()))
+		changed, _, err := tombstonePKExistsInRange(proc.Ctx, catalog.MO_TABLES_ID, state,
+			types.BuildTS(10, 0), types.BuildTS(30, 0), key, *key.GetType(), fs, proc.Mp())
+		require.NoError(t, err)
+		require.Equal(t, value != "target", changed)
+	}
+	require.Empty(t, pkCheckSemaphore)
+}
+
+func BenchmarkCatalogTombstonePKCheck(b *testing.B) {
+	for _, rows := range []int{1, 50000, 50001, 100000} {
+		b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {
+			proc, fs, state := newCatalogTombstoneFixture(b, rows, false)
+			key := vector.NewVec(types.T_varchar.ToType())
+			defer key.Free(proc.Mp())
+			require.NoError(b, vector.AppendBytes(key, []byte("target"), false, proc.Mp()))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				changed, _, err := tombstonePKExistsInRange(proc.Ctx, catalog.MO_TABLES_ID, state,
+					types.BuildTS(10, 0), types.BuildTS(30, 0), key, *key.GetType(), fs, proc.Mp())
+				if err != nil || changed {
+					b.Fatalf("changed=%v err=%v", changed, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2997,8 +2997,8 @@ func (tbl *txnTable) PKPersistedBetween(
 	if len(candidateBlks) > 0 {
 		// Acquire semaphore to limit concurrent block I/O across all transactions.
 		// This prevents 1000 goroutines from simultaneously reading blocks and
-		// exhausting mpool capacity. Scoped to the block loop only — tombstone
-		// checking below is not rate-limited by this semaphore.
+		// exhausting mpool capacity. Release before the tombstone phase, which
+		// acquires its own permit (never nest acquisitions).
 		if err := acquirePKCheckSemaphore(ctx); err != nil {
 			return false, err
 		}
@@ -3070,7 +3070,7 @@ func (tbl *txnTable) PKPersistedBetween(
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
 		pkType := plan2.ExprType2Type(&pkDef.Typ)
 		changed, tombstoneReason, err := tombstonePKExistsInRange(
-			ctx, p, from, to, keys, pkType, fs, tbl.proc.Load().GetMPool(),
+			ctx, tbl.tableId, p, from, to, keys, pkType, fs, tbl.proc.Load().GetMPool(),
 		)
 		if changed {
 			reason = tombstoneReason
@@ -3082,9 +3082,13 @@ func (tbl *txnTable) PKPersistedBetween(
 
 // tombstonePKExistsInRange checks whether any tombstone object created or deleted
 // after 'from' contains a PK that intersects with 'keys'.
-// If the total tombstone rows exceed the threshold, it conservatively returns true.
+// User tables retain a row-count cost guard. System catalog checks must inspect
+// the requested keys: unrelated DDL/compaction can rewrite many historical
+// tombstones, and a false conflict restarts the entire (potentially expensive)
+// DDL statement. Object row counts are not evidence of a catalog-key change.
 func tombstonePKExistsInRange(
 	ctx context.Context,
+	tableID uint64,
 	p *logtailreplay.PartitionState,
 	from types.TS,
 	to types.TS,
@@ -3093,17 +3097,36 @@ func tombstonePKExistsInRange(
 	fs fileservice.FileService,
 	mp *mpool.MPool,
 ) (bool, string, error) {
+	if err := ctx.Err(); err != nil {
+		return false, "", err
+	}
 	tombObjs := p.GetChangedTombstoneObjsBetween(from)
 	if len(tombObjs) == 0 {
 		return false, "", nil
 	}
 	const tombstoneRowsThreshold = 50000
-	var totalRows uint32
-	for i := range tombObjs {
-		totalRows += tombObjs[i].Rows()
-		if totalRows > tombstoneRowsThreshold {
-			return true, "tombstone_rows_bailout", nil
+	if !catalog.IsSystemTable(tableID) {
+		var totalRows uint64
+		for i := range tombObjs {
+			totalRows += uint64(tombObjs[i].Rows())
+			if totalRows > tombstoneRowsThreshold {
+				return true, "tombstone_rows_bailout", nil
+			}
 		}
+	}
+	// Bound concurrent pinned/decoded blocks, not the number of unrelated
+	// catalog rows. Each iteration releases its block before reading the next.
+	if err := acquirePKCheckSemaphore(ctx); err != nil {
+		return false, "", err
+	}
+	defer releasePKCheckSemaphore()
+	// Preserve conservative I/O-failure handling, but do not turn cancellation
+	// into a metadata-change retry. All readers receive the same caller context.
+	readFailure := func() (bool, string, error) {
+		if err := ctx.Err(); err != nil {
+			return false, "", err
+		}
+		return true, "tombstone_read_error", nil
 	}
 	searchKeys := LinearSearchOffsetByValFactory(keys)
 	var cachedSearch *objectio.ReadFilterSearch
@@ -3120,6 +3143,9 @@ func tombstonePKExistsInRange(
 	}
 	for _, obj := range tombObjs {
 		for blkIdx := uint32(0); blkIdx < obj.BlkCnt(); blkIdx++ {
+			if err := ctx.Err(); err != nil {
+				return false, "", err
+			}
 			loc := obj.BlockLocation(uint16(blkIdx), objectio.BlockMaxRows)
 			isCNCreated := obj.GetCNCreated()
 			if cachedSearch != nil {
@@ -3140,7 +3166,7 @@ func tombstonePKExistsInRange(
 						fileservice.Policy(0),
 					)
 					if err != nil {
-						return true, "tombstone_read_error", nil
+						return readFailure()
 					}
 					if len(hits) > 0 {
 						return true, "tombstone_cn_hit", nil
@@ -3163,7 +3189,7 @@ func tombstonePKExistsInRange(
 					fileservice.Policy(0),
 				)
 				if err != nil {
-					return true, "tombstone_read_error", nil
+					return readFailure()
 				}
 				if !usable || changed {
 					if usable {
@@ -3181,7 +3207,7 @@ func tombstonePKExistsInRange(
 			tombVectors := containers.NewVectors(vecCount)
 			_, release, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType)
 			if err != nil {
-				return true, "tombstone_read_error", nil
+				return readFailure()
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -194,26 +194,26 @@ func TestTombstonePKExistsInRange(t *testing.T) {
 	// Case 1: search for PK=200, should find it
 	keys1 := vector.NewVec(int32Type)
 	require.NoError(t, vector.AppendFixed[int32](keys1, 200, false, proc.GetMPool()))
-	changed, _, err := tombstonePKExistsInRange(ctx, pState, from, types.MaxTs(), keys1, int32Type, fs, proc.GetMPool())
+	changed, _, err := tombstonePKExistsInRange(ctx, 0, pState, from, types.MaxTs(), keys1, int32Type, fs, proc.GetMPool())
 	require.NoError(t, err)
 	require.True(t, changed)
 
 	// Case 2: search for PK=999, should not find it
 	keys2 := vector.NewVec(int32Type)
 	require.NoError(t, vector.AppendFixed[int32](keys2, 999, false, proc.GetMPool()))
-	changed, _, err = tombstonePKExistsInRange(ctx, pState, from, types.MaxTs(), keys2, int32Type, fs, proc.GetMPool())
+	changed, _, err = tombstonePKExistsInRange(ctx, 0, pState, from, types.MaxTs(), keys2, int32Type, fs, proc.GetMPool())
 	require.NoError(t, err)
 	require.False(t, changed)
 
 	// Case 3: search for PK=500, should find it in second tombstone
 	keys3 := vector.NewVec(int32Type)
 	require.NoError(t, vector.AppendFixed[int32](keys3, 500, false, proc.GetMPool()))
-	changed, _, err = tombstonePKExistsInRange(ctx, pState, from, types.MaxTs(), keys3, int32Type, fs, proc.GetMPool())
+	changed, _, err = tombstonePKExistsInRange(ctx, 0, pState, from, types.MaxTs(), keys3, int32Type, fs, proc.GetMPool())
 	require.NoError(t, err)
 	require.True(t, changed)
 
 	// Case 4: no tombstone objects changed after from=25
-	changed, _, err = tombstonePKExistsInRange(ctx, pState, types.BuildTS(25, 0), types.MaxTs(), keys1, int32Type, fs, proc.GetMPool())
+	changed, _, err = tombstonePKExistsInRange(ctx, 0, pState, types.BuildTS(25, 0), types.MaxTs(), keys1, int32Type, fs, proc.GetMPool())
 	require.NoError(t, err)
 	require.False(t, changed)
 }
@@ -271,6 +271,7 @@ func TestTombstonePKExistsInRangeVarcharScopedSearch(t *testing.T) {
 
 	changed, reason, err := tombstonePKExistsInRange(
 		ctx,
+		0,
 		tnState,
 		types.BuildTS(15, 0),
 		types.BuildTS(25, 0),
@@ -286,6 +287,7 @@ func TestTombstonePKExistsInRangeVarcharScopedSearch(t *testing.T) {
 
 	changed, reason, err = tombstonePKExistsInRange(
 		ctx,
+		0,
 		tnState,
 		types.BuildTS(20, 0),
 		types.BuildTS(30, 0),
@@ -303,6 +305,7 @@ func TestTombstonePKExistsInRangeVarcharScopedSearch(t *testing.T) {
 	require.NoError(t, vector.AppendBytes(missing, []byte("missing"), false, mp))
 	changed, reason, err = tombstonePKExistsInRange(
 		ctx,
+		0,
 		tnState,
 		types.BuildTS(15, 0),
 		types.BuildTS(25, 0),
@@ -340,6 +343,7 @@ func TestTombstonePKExistsInRangeVarcharScopedSearch(t *testing.T) {
 	}, true))
 	changed, reason, err = tombstonePKExistsInRange(
 		ctx,
+		0,
 		cnState,
 		types.BuildTS(15, 0),
 		types.BuildTS(25, 0),


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement
- [ ] API-change
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28357

This fixes the reproduced catalog tombstone-row bailout mechanism; keep the issue's original large-scale nightly acceptance separate from the focused evidence below.

## What this PR does / why we need it:

### Design intent and root cause

#23868 (`728817e98f`) introduced PK-aware tombstone checks specifically to prevent unrelated catalog changes from restarting long IVF builds. However, `tombstonePKExistsInRange` still returned `changed=true` once selected objects contained more than 50,000 rows, **before checking the requested PK or row commit timestamp**.

The selection includes physically created/deleted tombstone objects. Compaction can therefore select historical deletes unrelated to the requested catalog key; object row counts do not establish a logical metadata change. The consumer chain is `LockMeta -> LockRows -> PrimaryKeysMayBeModified -> PKPersistedBetween`. A conservative positive becomes an RC/definition retry, and `Compile.Run` rolls back/rebuilds the complete statement. A late index-update registration can consequently redo clustering and the entire mapping phase.

The issue records three `tombstone_rows_bailout` retries during one client CREATE INDEX. That incident evidence and the deterministic source-level mechanism are consistent, but this PR does not independently identify every concurrent tombstone producer or prove that each historical target key was unchanged.

### Changes and preserved behavior

- Thread the physical table ID into tombstone checking. The four canonical IDs recognized by `catalog.IsSystemTable` inspect copied PKs instead of using the row-count shortcut. No index-algorithm, table-name, account, or issue-specific special case.
- Preserve the strict `>50,000` cost guard for user tables; count with `uint64`.
- Use the existing 16-permit PK I/O semaphore for tombstone scans. The data phase releases its permit first; acquisition is never nested. Readers release each block before advancing, and the scan releases its permit with `defer` on every return.
- Check the process context before scanning and between blocks. Propagate caller/process cancellation during reads instead of converting it into another apparent metadata-change retry. Ordinary read errors still conservatively return changed.
- Preserve real PK hits, TN `(from, to]` and abort checks, conservative CN hits, unknown visibility handling, lock/version fences, and statement rollback semantics. Tombstones remain searched linearly by copied PK, not by their rowid sort order.

### Risks, performance, and deliberate limits

This trades additional catalog validation I/O for avoiding a complete expensive statement restart. It is not a zero-cost change: a missing key scans selected tombstone blocks, with work proportional to that history and key search cost. The semaphore bounds concurrent block readers, not total elapsed time, object metadata, or the existing shared cache. Slow storage can still prolong a check; process cancellation remains the termination mechanism, and no new fixed timeout, worker, retry loop, cache, configuration, or logging stream is introduced.

The existing `changed_objects_bailout` and `candidate_blocks_bailout` remain unchanged. Real conflicts and unavailable evidence may still require retries. This is **not** a blanket promise of zero catalog/DDL retries, nor a redesign of multi-phase index building. Prelocking alone would not close reentrant validation; suppressing the retry or retrying only the final REPLACE would weaken transaction/snapshot correctness.

Local Darwin/arm64 Apple M4, Go 1.26.4, LocalFS (disabled MO caches, OS cache possible), three one-second microbenchmark samples:

| Selected tombstone rows | Scan time/op | Allocated bytes/op |
|---:|---:|---:|
| 1 | 19–21 us | ~5.3 KB |
| 50,000 | 0.78–0.83 ms | ~30 KB |
| 50,001 | 0.76–0.86 ms | ~30 KB |
| 100,000 | 1.59–2.24 ms | ~54 KB |

These measure successful negative checks, not a comparison to the old incorrect constant-time bailout, not peak RSS, and not remote-S3/nightly latency. The 10M-row/768-dimensional/109-minute nightly was not rerun locally; no numeric end-to-end speedup is claimed.

### Validation and counterexamples

Base: latest main `62770aedaa0cf3b5613bb7a42371bb08ef14ed5c`. Three changed files, production behavior localized to disttae.

- **Red before green:** the same `PKPersistedBetween` regression using a real encoded 50,001-row TN tombstone object failed on `0b195e4f5a` with `tombstone_rows_bailout`: absent catalog keys and out-of-range deletes returned true; an already-cancelled context returned no error. It passes with the fix.
- Reused lightweight file-service/process fixtures, no new cluster UT. Tests cover all canonical catalog policies, retained user-table guard, CN and TN objects, a real hit in the last block, compaction of historical deletes, open lower/closed upper timestamp boundaries, mpool accounting, read errors, cancellation before work/while awaiting a saturated permit/during I/O, permit release, and a successful subsequent check. Phase barriers, not sleeps, trigger cancellation; cleanup joins the worker and closes owned file services.
- Full disttae normal suite passed (final run 8.238 s); full disttae race suite passed (final run 11.118 s). Focused cancellation race test measured 0.02 s, then ran 100 times in one process (final run 3.637 s). Existing tombstone and timestamp/abort tests remain enabled.
- Full lockop consumer suite passed. `go vet` for disttae and `make -j8 build` passed. Native artifacts were built through the platform-aware `make cgo` owner, with verified source provenance.
- Existing `vector_index_plugin_smoke.sql` ran in normal mo-tester comparison mode on a fresh, test-owned standalone service after SQL and ISCP readiness: **22/22 twice**, 0.262 s and 0.192 s. It validates HNSW/IVF creation, catalog metadata, SHOW CREATE, search, and rejection with the feature disabled. Database and table catalog residue were both zero after each run. No SQL/result files or mo-tester changes. An initial absolute dotted temporary-path invocation failed result-file discovery and executed no SQL; it is not counted as BVT evidence.
- Rebased from `0b195e4f5a` to `62770aedaa` (only frontend clone/lineage locking and its tests changed upstream). Disttae and lockop suites were rerun after rebase; race/benchmark/IVF evidence is reused because those exercised paths and native inputs are unchanged.

### Review

Self-review plus an independent read-only counterexample/ownership audit found no production blocker. Verified permit ownership across data/tombstone phases, no nested semaphore acquisition, and no reverse lock edge through tombstone I/O. No wire, persisted catalog format, configuration, or index implementation changes. The existing `PKPersistedBetween` process-context contract is unchanged; arbitrary contexts differing from `tbl.proc.Ctx` are not newly promised.

| Audit | Ownership / termination |
|---|---|
| Q1: cleanup | Per-block readers release buffers; deferred scan permit release; test-owned FS/process cleanup and zero mpool residue |
| Q2: waits | Non-nested semaphore admission observes context; readers receive that context; cancellation needs no metadata lock or semaphore permit |
| Q3: growth | Existing 16-permit block-I/O admission; sequential block lifetime; no new queue, worker, retry state, or diagnostic cardinality; selected-object metadata remains snapshot-proportional |
