### PR TITLE
fix(vector): preserve Area on admission failure for 4.2-dev

### DIFF
--- a/pkg/container/vector/area_admission_repro_test.go
+++ b/pkg/container/vector/area_admission_repro_test.go
@@ -81,6 +81,12 @@ func TestAreaGrowthAdmissionPreservesCleanup(t *testing.T) {
 			}
 			require.NoError(t, AppendBytes(src, bytes.Repeat([]byte("b"), tc.payload), false, mp))
 			oldArea := dst.GetArea()
+			oldBytes := bytes.Clone(oldArea)
+			oldLength := dst.Length()
+			oldRows := make([][]byte, oldLength)
+			for i := range oldRows {
+				oldRows[i] = bytes.Clone(dst.GetBytesAt(i))
+			}
 			oldUsed := state.account.Snapshot().Used
 			areaLost := false
 			var err error
@@ -102,13 +108,30 @@ func TestAreaGrowthAdmissionPreservesCleanup(t *testing.T) {
 						oldArea == nil, len(oldArea), cap(oldArea), unsafe.SliceData(oldArea),
 						dst.GetArea() == nil, len(dst.GetArea()), cap(dst.GetArea()), unsafe.SliceData(dst.GetArea()))
 				}
-				if !bytes.Equal(oldArea, dst.GetArea()) {
+				if !bytes.Equal(oldBytes, dst.GetArea()) {
 					t.Errorf("rejected growth changed owned bytes: before=%d after=%d", len(oldArea), len(dst.GetArea()))
 				}
 				require.Equal(t, oldUsed, state.account.Snapshot().Used)
+				if tc.method == "one" {
+					// UnionOne advances length before building varlena; this
+					// control checks ownership, not atomic append semantics.
+					require.Equal(t, oldLength+1, dst.Length())
+				} else {
+					require.Equal(t, oldLength, dst.Length())
+				}
 			} else {
 				require.NoError(t, err)
+				require.Equal(t, oldLength+1, dst.Length())
 				require.Equal(t, src.GetBytesAt(0), dst.GetBytesAt(dst.Length()-1))
+			}
+			// A lost Area is already a failure; avoid dereferencing its invalid
+			// varlena offsets so the production cleanup oracle still executes.
+			if !areaLost {
+				for i, want := range oldRows {
+					if !bytes.Equal(want, dst.GetBytesAt(i)) {
+						t.Errorf("row %d changed after append (denied=%t)", i, tc.denied)
+					}
+				}
 			}
 			dst.Free(mp)
 			dstFreed = true
@@ -119,6 +142,9 @@ func TestAreaGrowthAdmissionPreservesCleanup(t *testing.T) {
 			suspended := state.registry.AdmissionSuspended()
 			next, nextErr := state.registry.Open(1 << 20)
 			t.Logf("after Free: used=%d owner=%d site=%d live=%d suspended=%v error=%v next_admission=%v", remaining, snapshot.LiveOwner, snapshot.LiveSite, snapshot.LiveAllocations, suspended, terminalErr, nextErr)
+			if remaining != 0 || snapshot.LiveAllocations != 0 {
+				t.Errorf("production cleanup retained allocations: account=%d live=%d", remaining, snapshot.LiveAllocations)
+			}
 			if remaining > 0 && areaLost {
 				// The unpatched implementation loses the vector's slice header
 				// on a failed grow. The alias is retained solely to clean up the

--- a/pkg/container/vector/area_admission_repro_test.go
+++ b/pkg/container/vector/area_admission_repro_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Matrix Origin
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vector
+
+import (
+	"bytes"
+	"testing"
+	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/stretchr/testify/require"
+)
+
+func sameAreaOwnership(before, after []byte) bool {
+	if (before == nil) != (after == nil) || cap(before) != cap(after) {
+		return false
+	}
+	if cap(before) == 0 {
+		return true
+	}
+	return unsafe.SliceData(before) == unsafe.SliceData(after)
+}
+
+// This is a contract test, not a test which expects the leak. Only the
+// contiguous bulk-copy case with an existing area should expose the defect.
+func TestAreaGrowthAdmissionPreservesCleanup(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		initial int
+		areaCap int
+		payload int
+		method  string
+		denied  bool
+	}{
+		{"bulk_success", 4096, 0, 4096, "bulk", false},
+		{"bulk_empty_denied", 0, 4096, 65536, "bulk", true},
+		{"bulk_existing_denied", 4096, 0, 65536, "bulk", true},
+		{"selected_existing_denied", 4096, 0, 65536, "selected", true},
+		{"append_existing_denied", 4096, 0, 65536, "append", true},
+		{"union_one_existing_denied", 4096, 0, 65536, "one", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := mpool.MustNewZero()
+			state := newTestVectorAllocationAccount(t, 32768, 64)
+			dst := newAccountedTestVector(t, types.T_varchar.ToType(), state.selection)
+			src := NewVec(types.T_varchar.ToType())
+			var orphan []byte
+			dstFreed, srcFreed := false, false
+			t.Cleanup(func() {
+				if !dstFreed {
+					dst.Free(mp)
+				}
+				if !srcFreed {
+					src.Free(mp)
+				}
+				// Reclaim only a proven orphan, AFTER collecting the failed
+				// production cleanup evidence. Never hide it from the oracle.
+				if orphan != nil {
+					mp.Free(orphan)
+				}
+				require.Zero(t, mp.CurrNB())
+				mpool.DeleteMPool(mp)
+			})
+			if tc.areaCap > 0 {
+				require.NoError(t, dst.PreExtendWithArea(2, tc.areaCap, mp))
+			} else {
+				require.NoError(t, dst.PreExtend(2, mp))
+			}
+			if tc.initial > 0 {
+				require.NoError(t, AppendBytes(dst, bytes.Repeat([]byte("a"), tc.initial), false, mp))
+			}
+			require.NoError(t, AppendBytes(src, bytes.Repeat([]byte("b"), tc.payload), false, mp))
+			oldArea := dst.GetArea()
+			oldUsed := state.account.Snapshot().Used
+			areaLost := false
+			var err error
+			switch tc.method {
+			case "bulk":
+				err = dst.UnionBatch(src, 0, 1, nil, mp)
+			case "selected":
+				err = dst.UnionBatch(src, 0, 1, []uint8{1}, mp)
+			case "append":
+				err = AppendBytes(dst, src.GetBytesAt(0), false, mp)
+			case "one":
+				err = dst.UnionOne(src, 0, mp)
+			}
+			if tc.denied {
+				require.ErrorIs(t, err, mpool.ErrAllocationAccountCapacity)
+				if !sameAreaOwnership(oldArea, dst.GetArea()) {
+					areaLost = true
+					t.Errorf("rejected growth discarded owned area: before=(nil=%t,len=%d,cap=%d,ptr=%p) after=(nil=%t,len=%d,cap=%d,ptr=%p)",
+						oldArea == nil, len(oldArea), cap(oldArea), unsafe.SliceData(oldArea),
+						dst.GetArea() == nil, len(dst.GetArea()), cap(dst.GetArea()), unsafe.SliceData(dst.GetArea()))
+				}
+				if !bytes.Equal(oldArea, dst.GetArea()) {
+					t.Errorf("rejected growth changed owned bytes: before=%d after=%d", len(oldArea), len(dst.GetArea()))
+				}
+				require.Equal(t, oldUsed, state.account.Snapshot().Used)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, src.GetBytesAt(0), dst.GetBytesAt(dst.Length()-1))
+			}
+			dst.Free(mp)
+			dstFreed = true
+			src.Free(mp)
+			srcFreed = true
+			remaining := state.account.Snapshot().Used
+			snapshot, _, terminalErr := state.registry.CompleteTerminal(state.account)
+			suspended := state.registry.AdmissionSuspended()
+			next, nextErr := state.registry.Open(1 << 20)
+			t.Logf("after Free: used=%d owner=%d site=%d live=%d suspended=%v error=%v next_admission=%v", remaining, snapshot.LiveOwner, snapshot.LiveSite, snapshot.LiveAllocations, suspended, terminalErr, nextErr)
+			if remaining > 0 && areaLost {
+				// The unpatched implementation loses the vector's slice header
+				// on a failed grow. The alias is retained solely to clean up the
+				// known test allocation after recording the production failure.
+				orphan = oldArea
+			}
+			if terminalErr != nil {
+				t.Errorf("terminal invariant after production cleanup: %v", terminalErr)
+			}
+			if remaining > 0 && !suspended {
+				t.Errorf("admission was not suspended while residual allocation remained")
+			}
+			if remaining > 0 && nextErr == nil {
+				t.Errorf("next admission succeeded while residual allocation remained")
+			}
+			if remaining == 0 && nextErr != nil {
+				t.Errorf("next admission failed after production cleanup: %v", nextErr)
+			}
+			if nextErr == nil {
+				next.Seal()
+				if _, finalizeErr := state.registry.Finalize(next); finalizeErr != nil {
+					t.Errorf("next admission finalization failed: %v", finalizeErr)
+				}
+			}
+			if orphan != nil {
+				mp.Free(orphan)
+				orphan = nil
+			}
+			require.Zero(t, state.account.Snapshot().Used)
+			if nextErr != nil {
+				recovered, recoveredErr := state.registry.Open(1 << 20)
+				require.NoError(t, recoveredErr)
+				recovered.Seal()
+				_, recoveredErr = state.registry.Finalize(recovered)
+				require.NoError(t, recoveredErr)
+			}
+		})
+	}
+}

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -4619,11 +4619,11 @@ func (v *Vector) unionBatchContiguousVarlenRange(
 			}
 			v.area = append(v.area, payload...)
 		} else {
-			var err error
-			v.area, err = v.growArea2(mp, payload, baseOff+len(payload))
+			area, err := v.growArea2(mp, payload, baseOff+len(payload))
 			if err != nil {
 				return false, err
 			}
+			v.area = area
 		}
 	}
 

--- a/pkg/sql/colexec/hashjoin/area_admission_repro_test.go
+++ b/pkg/sql/colexec/hashjoin/area_admission_repro_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Matrix Origin
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashjoin
+
+import (
+	"bytes"
+	"testing"
+	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/message"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/stretchr/testify/require"
+)
+
+func sameAreaOwnership(before, after []byte) bool {
+	if (before == nil) != (after == nil) || cap(before) != cap(after) {
+		return false
+	}
+	if cap(before) == 0 {
+		return true
+	}
+	return unsafe.SliceData(before) == unsafe.SliceData(after)
+}
+
+// Exercise public Call -> emptyProbe -> UnionBatch -> Reset/Free with a real
+// HashBuild budget controller. No synthetic admission error is injected.
+func TestHashJoinAreaAdmissionTerminalCleanup(t *testing.T) {
+	for _, denied := range []bool{false, true} {
+		name := "success"
+		if denied {
+			name = "budget_denied_after_result_reuse"
+		}
+		t.Run(name, func(t *testing.T) {
+			proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+			proc.SetMessageBoard(message.NewMessageBoard())
+			budget := process.MustNewHashBuildBudget(32768, 32768)
+			generation, err := budget.OpenGeneration(1)
+			require.NoError(t, err)
+			registry, err := mpool.NewAllocationAccountRegistry(1, 64)
+			require.NoError(t, err)
+			account, err := registry.OpenWithController(1<<20, generation)
+			require.NoError(t, err)
+			arg := &HashJoin{JoinType: plan.Node_LEFT, NumCPU: 1,
+				JoinMapTag: 92003,
+				ResultCols: []colexec.ResultPos{{Rel: 0, Pos: 0}},
+				LeftTypes:  []types.Type{types.T_varchar.ToType()},
+				EqConds:    [][]*plan.Expr{{newExpr(0, types.T_varchar.ToType())}, {newExpr(0, types.T_varchar.ToType())}}}
+			require.NoError(t, arg.SetAllocationAccount(account))
+			var inputs []*batch.Batch
+			var orphan []byte
+			argCleaned := false
+			t.Cleanup(func() {
+				if !argCleaned {
+					arg.Reset(proc, true, nil)
+					arg.Free(proc, true, nil)
+				}
+				for _, input := range inputs {
+					input.Clean(proc.Mp())
+				}
+				if orphan != nil {
+					proc.Mp().Free(orphan)
+				}
+				proc.Free()
+				require.Zero(t, proc.Mp().CurrNB())
+			})
+			makeInput := func(n int) *batch.Batch {
+				b := batch.NewWithSize(1)
+				b.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+				require.NoError(t, vector.AppendBytes(b.Vecs[0], bytes.Repeat([]byte("x"), n), false, proc.Mp()))
+				b.SetRowCount(1)
+				inputs = append(inputs, b)
+				return b
+			}
+			nextSize := 4096
+			if denied {
+				nextSize = 65536
+			}
+			child := colexec.NewMockOperator().WithBatchs([]*batch.Batch{makeInput(4096), makeInput(nextSize)})
+			arg.AppendChild(child)
+			require.NoError(t, child.Prepare(proc))
+			require.NoError(t, arg.Prepare(proc))
+			message.SendJoinMapResult(message.NewJoinMapResult(nil), arg.JoinMapTag, false, 0, proc.GetMessageBoard())
+			result, err := arg.Call(proc)
+			require.NoError(t, err)
+			require.Equal(t, 1, result.Batch.RowCount())
+			require.Equal(t, bytes.Repeat([]byte("x"), 4096), result.Batch.Vecs[0].GetBytesAt(0))
+			oldArea := arg.ctr.resBat.Vecs[0].GetArea()
+			_, callErr := arg.Call(proc)
+			areaLost := false
+			if denied {
+				require.Error(t, callErr)
+				require.True(t, moerr.IsMoErrCode(callErr, moerr.ErrOOM), callErr)
+				require.Contains(t, callErr.Error(), "hash build memory budget exceeded")
+				currentArea := arg.ctr.resBat.Vecs[0].GetArea()
+				if !sameAreaOwnership(oldArea, currentArea) {
+					areaLost = true
+					t.Errorf("rejected result growth discarded owned area: before=(nil=%t,len=%d,cap=%d,ptr=%p) after=(nil=%t,len=%d,cap=%d,ptr=%p)",
+						oldArea == nil, len(oldArea), cap(oldArea), unsafe.SliceData(oldArea),
+						currentArea == nil, len(currentArea), cap(currentArea), unsafe.SliceData(currentArea))
+				}
+			} else {
+				require.NoError(t, callErr)
+			}
+			arg.Reset(proc, callErr != nil, callErr)
+			arg.Free(proc, callErr != nil, callErr)
+			argCleaned = true
+			require.NoError(t, arg.ClearAllocationAccount(account))
+			snapshot, _, terminalErr := registry.CompleteTerminal(account)
+			suspended := registry.AdmissionSuspended()
+			next, nextErr := registry.Open(1 << 20)
+			t.Logf("call=%v terminal=%v used=%d owner=%d site=%d live=%d budget=%d suspended=%v next_admission=%v", callErr, terminalErr, snapshot.Used, snapshot.LiveOwner, snapshot.LiveSite, snapshot.LiveAllocations, generation.Used(), suspended, nextErr)
+			if snapshot.Used > 0 && areaLost {
+				// The unpatched implementation discarded the Vector Area
+				// header. Reclaim the retained alias only after recording the
+				// production terminal snapshot.
+				orphan = oldArea
+			}
+			if terminalErr != nil {
+				t.Errorf("terminal invariant after production cleanup: %v", terminalErr)
+			}
+			if snapshot.Used > 0 && !suspended {
+				t.Errorf("admission was not suspended while residual allocation remained")
+			}
+			if snapshot.Used > 0 && nextErr == nil {
+				t.Errorf("next admission succeeded while residual allocation remained")
+			}
+			if snapshot.Used == 0 && nextErr != nil {
+				t.Errorf("next admission failed after production cleanup: %v", nextErr)
+			}
+			if nextErr == nil {
+				next.Seal()
+				if _, finalizeErr := registry.Finalize(next); finalizeErr != nil {
+					t.Errorf("next admission finalization failed: %v", finalizeErr)
+				}
+			}
+			if orphan != nil {
+				proc.Mp().Free(orphan)
+				orphan = nil
+			}
+			require.Zero(t, account.Snapshot().Used)
+			if nextErr != nil {
+				recovered, recoveredErr := registry.Open(1 << 20)
+				require.NoError(t, recoveredErr)
+				recovered.Seal()
+				_, recoveredErr = registry.Finalize(recovered)
+				require.NoError(t, recoveredErr)
+			}
+		})
+	}
+}

--- a/pkg/sql/colexec/hashjoin/area_admission_repro_test.go
+++ b/pkg/sql/colexec/hashjoin/area_admission_repro_test.go
@@ -126,6 +126,9 @@ func TestHashJoinAreaAdmissionTerminalCleanup(t *testing.T) {
 			suspended := registry.AdmissionSuspended()
 			next, nextErr := registry.Open(1 << 20)
 			t.Logf("call=%v terminal=%v used=%d owner=%d site=%d live=%d budget=%d suspended=%v next_admission=%v", callErr, terminalErr, snapshot.Used, snapshot.LiveOwner, snapshot.LiveSite, snapshot.LiveAllocations, generation.Used(), suspended, nextErr)
+			if snapshot.Used != 0 || snapshot.LiveAllocations != 0 || generation.Used() != 0 {
+				t.Errorf("production cleanup retained allocations: account=%d live=%d budget=%d", snapshot.Used, snapshot.LiveAllocations, generation.Used())
+			}
 			if snapshot.Used > 0 && areaLost {
 				// The unpatched implementation discarded the Vector Area
 				// header. Reclaim the retained alias only after recording the

--- a/test/distributed/cases/dml/select/merge_top_large_limit.result
+++ b/test/distributed/cases/dml/select/merge_top_large_limit.result
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS merge_top_large_src;
+DROP TABLE IF EXISTS merge_top_large_dst;
+CREATE TABLE merge_top_large_src (id BIGINT PRIMARY KEY, payload VARCHAR(64));
+CREATE TABLE merge_top_large_dst (id BIGINT, payload VARCHAR(64));
+INSERT INTO merge_top_large_src
+SELECT result, CONCAT('payload-', result) FROM generate_series(1, 20000) g;
+SET SESSION optimizer_hints = 'execType=2';
+INSERT INTO merge_top_large_dst
+SELECT id, payload FROM merge_top_large_src ORDER BY id DESC LIMIT 17000;
+SET SESSION optimizer_hints = '';
+SELECT COUNT(*), MIN(id), MAX(id), MIN(LENGTH(payload)), MAX(LENGTH(payload))
+FROM merge_top_large_dst;
+➤ COUNT(*)[-5,64,0]  ¦  MIN(id)[-5,64,0]  ¦  MAX(id)[-5,64,0]  ¦  MIN(LENGTH(payload))[-5,64,0]  ¦  MAX(LENGTH(payload))[-5,64,0]  𝄀
+17000  ¦  3001  ¦  20000  ¦  12  ¦  13
+TRUNCATE TABLE merge_top_large_dst;
+SET SESSION optimizer_hints = 'execType=2';
+PREPARE merge_top_dynamic_limit FROM
+'INSERT INTO merge_top_large_dst SELECT id, payload FROM merge_top_large_src ORDER BY id DESC LIMIT ?';
+SET @merge_top_limit = 17000;
+EXECUTE merge_top_dynamic_limit USING @merge_top_limit;
+DEALLOCATE PREPARE merge_top_dynamic_limit;
+SET SESSION optimizer_hints = '';
+SELECT COUNT(*), MIN(id), MAX(id), MIN(LENGTH(payload)), MAX(LENGTH(payload))
+FROM merge_top_large_dst;
+➤ COUNT(*)[-5,64,0]  ¦  MIN(id)[-5,64,0]  ¦  MAX(id)[-5,64,0]  ¦  MIN(LENGTH(payload))[-5,64,0]  ¦  MAX(LENGTH(payload))[-5,64,0]  𝄀
+17000  ¦  3001  ¦  20000  ¦  12  ¦  13
+DROP TABLE merge_top_large_dst;
+DROP TABLE merge_top_large_src;

--- a/test/distributed/cases/dml/select/merge_top_large_limit.result
+++ b/test/distributed/cases/dml/select/merge_top_large_limit.result
@@ -1,9 +1,9 @@
 DROP TABLE IF EXISTS merge_top_large_src;
 DROP TABLE IF EXISTS merge_top_large_dst;
-CREATE TABLE merge_top_large_src (id BIGINT PRIMARY KEY, payload VARCHAR(64));
-CREATE TABLE merge_top_large_dst (id BIGINT, payload VARCHAR(64));
+CREATE TABLE merge_top_large_src (id BIGINT PRIMARY KEY, payload VARCHAR(128));
+CREATE TABLE merge_top_large_dst (id BIGINT, payload VARCHAR(128));
 INSERT INTO merge_top_large_src
-SELECT result, CONCAT('payload-', result) FROM generate_series(1, 20000) g;
+SELECT result, CONCAT(REPEAT('x', 64), 'payload-', result) FROM generate_series(1, 20000) g;
 SET SESSION optimizer_hints = 'execType=2';
 INSERT INTO merge_top_large_dst
 SELECT id, payload FROM merge_top_large_src ORDER BY id DESC LIMIT 17000;
@@ -11,7 +11,7 @@ SET SESSION optimizer_hints = '';
 SELECT COUNT(*), MIN(id), MAX(id), MIN(LENGTH(payload)), MAX(LENGTH(payload))
 FROM merge_top_large_dst;
 ➤ COUNT(*)[-5,64,0]  ¦  MIN(id)[-5,64,0]  ¦  MAX(id)[-5,64,0]  ¦  MIN(LENGTH(payload))[-5,64,0]  ¦  MAX(LENGTH(payload))[-5,64,0]  𝄀
-17000  ¦  3001  ¦  20000  ¦  12  ¦  13
+17000  ¦  3001  ¦  20000  ¦  76  ¦  77
 TRUNCATE TABLE merge_top_large_dst;
 SET SESSION optimizer_hints = 'execType=2';
 PREPARE merge_top_dynamic_limit FROM
@@ -23,6 +23,6 @@ SET SESSION optimizer_hints = '';
 SELECT COUNT(*), MIN(id), MAX(id), MIN(LENGTH(payload)), MAX(LENGTH(payload))
 FROM merge_top_large_dst;
 ➤ COUNT(*)[-5,64,0]  ¦  MIN(id)[-5,64,0]  ¦  MAX(id)[-5,64,0]  ¦  MIN(LENGTH(payload))[-5,64,0]  ¦  MAX(LENGTH(payload))[-5,64,0]  𝄀
-17000  ¦  3001  ¦  20000  ¦  12  ¦  13
+17000  ¦  3001  ¦  20000  ¦  76  ¦  77
 DROP TABLE merge_top_large_dst;
 DROP TABLE merge_top_large_src;

--- a/test/distributed/cases/dml/select/merge_top_large_limit.sql
+++ b/test/distributed/cases/dml/select/merge_top_large_limit.sql
@@ -1,0 +1,27 @@
+-- @label:bvt
+
+DROP TABLE IF EXISTS merge_top_large_src;
+DROP TABLE IF EXISTS merge_top_large_dst;
+CREATE TABLE merge_top_large_src (id BIGINT PRIMARY KEY, payload VARCHAR(64));
+CREATE TABLE merge_top_large_dst (id BIGINT, payload VARCHAR(64));
+INSERT INTO merge_top_large_src
+SELECT result, CONCAT('payload-', result) FROM generate_series(1, 20000) g;
+-- Force a multi-scope AP plan; the large LIMIT must use Top -> MergeOrder -> Limit.
+SET SESSION optimizer_hints = 'execType=2';
+INSERT INTO merge_top_large_dst
+SELECT id, payload FROM merge_top_large_src ORDER BY id DESC LIMIT 17000;
+SET SESSION optimizer_hints = '';
+SELECT COUNT(*), MIN(id), MAX(id), MIN(LENGTH(payload)), MAX(LENGTH(payload))
+FROM merge_top_large_dst;
+TRUNCATE TABLE merge_top_large_dst;
+SET SESSION optimizer_hints = 'execType=2';
+PREPARE merge_top_dynamic_limit FROM
+'INSERT INTO merge_top_large_dst SELECT id, payload FROM merge_top_large_src ORDER BY id DESC LIMIT ?';
+SET @merge_top_limit = 17000;
+EXECUTE merge_top_dynamic_limit USING @merge_top_limit;
+DEALLOCATE PREPARE merge_top_dynamic_limit;
+SET SESSION optimizer_hints = '';
+SELECT COUNT(*), MIN(id), MAX(id), MIN(LENGTH(payload)), MAX(LENGTH(payload))
+FROM merge_top_large_dst;
+DROP TABLE merge_top_large_dst;
+DROP TABLE merge_top_large_src;

--- a/test/distributed/cases/dml/select/merge_top_large_limit.sql
+++ b/test/distributed/cases/dml/select/merge_top_large_limit.sql
@@ -2,11 +2,12 @@
 
 DROP TABLE IF EXISTS merge_top_large_src;
 DROP TABLE IF EXISTS merge_top_large_dst;
-CREATE TABLE merge_top_large_src (id BIGINT PRIMARY KEY, payload VARCHAR(64));
-CREATE TABLE merge_top_large_dst (id BIGINT, payload VARCHAR(64));
+CREATE TABLE merge_top_large_src (id BIGINT PRIMARY KEY, payload VARCHAR(128));
+CREATE TABLE merge_top_large_dst (id BIGINT, payload VARCHAR(128));
 INSERT INTO merge_top_large_src
-SELECT result, CONCAT('payload-', result) FROM generate_series(1, 20000) g;
--- Force a multi-scope AP plan; the large LIMIT must use Top -> MergeOrder -> Limit.
+SELECT result, CONCAT(REPEAT('x', 64), 'payload-', result) FROM generate_series(1, 20000) g;
+-- Wide-varlen success-path coverage. Budget rejection is tested separately
+-- under test/distributed/isolated/area_admission with an explicit CN cap.
 SET SESSION optimizer_hints = 'execType=2';
 INSERT INTO merge_top_large_dst
 SELECT id, payload FROM merge_top_large_src ORDER BY id DESC LIMIT 17000;

--- a/test/distributed/isolated/area_admission/README.md
+++ b/test/distributed/isolated/area_admission/README.md
@@ -1,0 +1,44 @@
+# HashJoin Area admission regression
+
+Run only on a disposable, dedicated single-CN local service. This test intentionally
+exhausts a query budget. The unfixed server suspends subsequent allocation
+admission; it must not be used against a shared instance. The tester also performs
+its normal database cleanup, so use an isolated tester configuration.
+
+Set the following public startup setting in the CN configuration before launch:
+
+```toml
+[cn.frontend]
+processLimitationSize = 8388608
+```
+
+Configure the official `mo-tester` to connect to this service, then run comparison
+mode (not result generation):
+
+Use `jdbc.paremeter.autoReconnect: "false"` in its `mo.yml` so a rejected new
+connection is reported immediately rather than hidden behind JDBC retries.
+
+```sh
+./run.sh -p /absolute/matrixone/test/distributed/isolated/area_admission/hashjoin_area.sql -m run
+```
+
+The fixture uses the supported `optimizer_hints` session variable to retain a
+single-CPU HashJoin with `src` on the probe side. The checked physical plan must
+contain `hash join` over `src` and a `hash build` over `rhs`. The filtered build
+side is empty. `EXPLAIN PHYPLAN` executes the query, so the exact query's plan is
+captured before adding the second, large batch. The first 8,192 probe strings are 64 bytes, allocating an Area;
+the next 8,192 strings are 2,048 bytes and force result-batch Area growth beyond
+the 8 MiB budget. Both widths exceed the 23-byte inline threshold. Do not replace
+the cap with `join_spill_mem`: that is not this fixture's admission limit.
+
+Expected repaired behavior is the ordinary budget-rejection error, followed by
+`COUNT(*) = 16384` on both the existing connection and a new session. On the
+unfixed implementation, the rejected query additionally reports an allocation
+account invariant failure (`owner=1`, `site=103`, `used=524288`, one live
+allocation); new-session admission is suspended. This is a red/green defect
+oracle, not a success-only large-LIMIT example.
+
+This directory is outside the default BVT cases because its expected error
+requires the explicit 8 MiB startup configuration. Run it separately in QA.
+`cases/dml/select/merge_top_large_limit.sql` covers wide-varlen success paths;
+it does not establish budget-denial cleanup or a specific compiler rewrite.

--- a/test/distributed/isolated/area_admission/hashjoin_area.result
+++ b/test/distributed/isolated/area_admission/hashjoin_area.result
@@ -1,0 +1,33 @@
+DROP DATABASE IF EXISTS hashjoin_area_regression;
+CREATE DATABASE hashjoin_area_regression;
+USE hashjoin_area_regression;
+CREATE TABLE src(id BIGINT, payload TEXT);
+CREATE TABLE rhs(id BIGINT, flag INT);
+INSERT INTO rhs VALUES (-1,0);
+INSERT INTO src SELECT result, REPEAT('a',64) FROM generate_series(1,8192) g;
+SET SESSION optimizer_hints='execType=1,joinOrdering=1';
+EXPLAIN PHYPLAN SELECT s.payload,r.flag FROM src s LEFT JOIN rhs r ON s.id=r.id AND r.flag=1;
+➤ tp query phyplan[12,-1,0]  𝄀
+Scope 1 (Magic: Remote, mcpu: 1, Receiver: [])  𝄀
+  DataSource: hashjoin_area_regression.src[id payload]  𝄀
+  Pipeline: └── output  𝄀
+                └── projection  𝄀
+                    └── hash join  𝄀
+                        └── tablescan  𝄀
+  PreScopes: {  𝄀
+    Scope 1 (Magic: Remote, mcpu: 1, Receiver: [])  𝄀
+      DataSource: hashjoin_area_regression.rhs[id flag]  𝄀
+      Pipeline: └── hash build  𝄀
+                    └── tablescan  𝄀
+  }
+INSERT INTO src SELECT result, REPEAT('b',2048) FROM generate_series(8193,16384) g;
+SELECT s.payload,r.flag FROM src s LEFT JOIN rhs r ON s.id=r.id AND r.flag=1;
+error: resource exhausted: hash build memory budget exceeded; reduce join build width or query concurrency, increase processLimitationSize, or lower join_spill_mem for an eligible shuffle join
+SELECT COUNT(*) FROM src;
+➤ COUNT(*)[-5,64,0]  𝄀
+16384
+SELECT COUNT(*) FROM hashjoin_area_regression.src;
+➤ COUNT(*)[-5,64,0]  𝄀
+16384
+SET SESSION optimizer_hints='';
+DROP DATABASE hashjoin_area_regression;

--- a/test/distributed/isolated/area_admission/hashjoin_area.sql
+++ b/test/distributed/isolated/area_admission/hashjoin_area.sql
@@ -1,0 +1,20 @@
+-- Requires a dedicated CN with [cn.frontend] processLimitationSize = 8388608.
+-- It deliberately rejects a query; do not run against a shared service.
+DROP DATABASE IF EXISTS hashjoin_area_regression;
+CREATE DATABASE hashjoin_area_regression;
+USE hashjoin_area_regression;
+CREATE TABLE src(id BIGINT, payload TEXT);
+CREATE TABLE rhs(id BIGINT, flag INT);
+INSERT INTO rhs VALUES (-1,0);
+INSERT INTO src SELECT result, REPEAT('a',64) FROM generate_series(1,8192) g;
+SET SESSION optimizer_hints='execType=1,joinOrdering=1';
+-- PHYPLAN executes the query: capture the same SQL before adding the large batch.
+EXPLAIN PHYPLAN SELECT s.payload,r.flag FROM src s LEFT JOIN rhs r ON s.id=r.id AND r.flag=1;
+INSERT INTO src SELECT result, REPEAT('b',2048) FROM generate_series(8193,16384) g;
+SELECT s.payload,r.flag FROM src s LEFT JOIN rhs r ON s.id=r.id AND r.flag=1;
+SELECT COUNT(*) FROM src;
+-- @session:id=2&user=dump&password=111
+SELECT COUNT(*) FROM hashjoin_area_regression.src;
+-- @session
+SET SESSION optimizer_hints='';
+DROP DATABASE hashjoin_area_regression;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #27968. Partial backport of #27999; not an automatic issue-closure request.

## What this PR does / why we need it:

Backport only the Area ownership fix from upstream commit `17c161a31b47a22e71ca222839143f66717ac365` to `4.2-dev`. A rejected `growArea2` does not release the old allocation. Receive its result into a temporary slice and publish `v.area` only on success, preserving the owner for normal cleanup.

No budget/admission policy, HashJoin cleanup mechanism, public API, MergeTop error classification, or compiler rewrite is changed.

### Review fixes

- Separate the retained Area slice (ownership/last-resort cleanup) from `bytes.Clone` snapshots (old bytes and logical row values). Assert row counts and appended values. Explicitly preserve the pre-existing `UnionOne` control's length-on-error behavior; this PR does not promise atomic append for that API.
- Check production account/live-allocation and HashJoin budget usage before any test-only orphan reclamation. Zero-length/non-zero-capacity reused Areas retain ownership.
- Widen the ordinary large-LIMIT fixture above the 23-byte inline threshold. It is explicitly success-path coverage, not evidence of budget-denial cleanup or an unbackported compiler rewrite.
- Add `test/distributed/isolated/area_admission/hashjoin_area.sql/.result` and instructions. On a dedicated single-CN service with the public `processLimitationSize=8388608`, the same HashJoin query first sees 8,192 64-byte strings, then 8,192 2,048-byte strings. Check its physical HashJoin plan before adding the large batch (`EXPLAIN PHYPLAN` executes), reject the later growth, then check COUNT on the original connection and a new session. This configuration-specific fixture is deliberately outside the default BVT cases and must be run separately in QA.

### Validation

Base: `588295fdabe01fbee49f48107dff98dcc26b6178`.
Reviewed head: `c7b726705276fca696afa3ce4e9a74f0eca94e77`.

- Same final Vector/HashJoin targeted regressions, `-count=10`: original product hunk restored to base => FAIL (exit 1); repaired => PASS. Failure is real production cleanup residue, not test double-free.
- Two complete packages with controlled `mo-cgo-test -v -count=1 -timeout=120s`: PASS.
- Targeted `-race -count=10 -timeout=240s`: PASS.
- `go list`, `go build`, `go vet` for both packages, formatting and `git diff --check`: PASS.
- Official mo-tester comparison mode, isolated SQL, identical fixture/config (`autoReconnect=false`): unpatched => exit 1, 11/15 successful with one mismatch and three admission-related abnormal results; repaired => exit 0, 15/15. Red SQL records `used=524288`, `owner=1`, `site=103`, `live-allocations=1`, followed by suspended new-session admission. Green returns the ordinary budget error without an invariant suffix, and both COUNT queries return 16384.
- Official mo-tester comparison mode, widened normal large-LIMIT case: exit 0, 19/19.
- Exact-content semantic preflight: PASS. Product executables differ only by the Area ownership hunk (test/doc-only follow-up changes do not enter the service binary).

The previous head's CI passed; that is not a claim about this new head's CI. Current-head CI and maintainer review remain independent gates. Ready for review is not merge approval.

QA required: yes

Reason: production memory ownership and admission recovery require deployment validation. Run the isolated 8 MiB regression separately, then verify actual deployed SHA and fresh-session admission before restarting the FULLTEXT2 campaign. Local tests do not prove shared-dev recovery or complete FULLTEXT2 acceptance. No shared dev objects were changed for this validation.
