### PR TITLE
perf(aggexec): accelerate fixed-width COUNT(DISTINCT)

### DIFF
--- a/pkg/sql/colexec/aggexec/aggState.go
+++ b/pkg/sql/colexec/aggexec/aggState.go
@@ -131,6 +131,13 @@ type aggState struct {
 	length     int32
 	capacity   int32
 	allocation *AllocationAccount
+	// distinctKeyWidth enables the exact fixed-width deferred DISTINCT state.
+	// When enabled, the index is the membership/iteration source and the
+	// skiplist remains available for legacy/fallback states. A small hard-account
+	// merge destination may disable the empty optional index before publication.
+	distinctKeyWidth      int
+	distinctFixedDeferred bool
+	distinctIndex         distinctFixedIndex
 	// vecs are for agg state.
 	vecs []*vector.Vector
 	// MarshalerUnmarshaler, for state entries.
@@ -177,6 +184,9 @@ func (ag *aggState) initWithAllocation(
 	ag.length = l
 	ag.capacity = c
 	ag.allocation = allocation
+	ag.distinctKeyWidth = distinctFixedIndexWidth(info, int(c))
+	ag.distinctFixedDeferred = ag.distinctKeyWidth > 0
+	ag.distinctIndex.groupLimit = int(c)
 
 	var err error
 	if !info.saveArg {
@@ -292,6 +302,22 @@ func (ag *aggState) writeStateArg(
 			err := ag.iterInputOrder(mp, uint16(i), func(k []byte) error {
 				if err := types.WriteSizeBytes(k[kAggArgPrefixSz:], writer); err != nil {
 					return err
+				}
+				xcnt++
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		} else if ag.distinctFixedDeferred {
+			err := ag.iter(uint16(i), func(k []byte) error {
+				value := k[kAggArgPrefixSz:]
+				n, err := writer.Write(value)
+				if err != nil {
+					return err
+				}
+				if n != len(value) {
+					return io.ErrShortWrite
 				}
 				xcnt++
 				return nil
@@ -844,29 +870,48 @@ func (ag *aggState) appendFromStateArg(mp *mpool.MPool, otherOffset int32, other
 		}
 		ag.length += end - start
 	} else {
-		for i := start; i < end; i++ {
-			ag.argCnt[ag.length] = other.argCnt[i]
-			var lkb, ukb [kAggArgPrefixSz]byte
-			lk := lkb[:]
-			uk := ukb[:]
-			binary.BigEndian.PutUint16(lk, uint16(i))
-			binary.BigEndian.PutUint16(uk, uint16(i+1))
-			it := other.argSkl.NewIter(lk, uk)
-			for ok, k, value := it.SeekGE(lk); ok; ok, k, value = it.Next() {
-				kcpy, err := ag.resizeArgScratch(mp, len(k))
+		if info.isDistinct && ag.distinctFixedDeferred && other.distinctFixedDeferred &&
+			ag.distinctKeyWidth == other.distinctKeyWidth {
+			for i := start; i < end; i++ {
+				targetY := uint16(ag.length)
+				ag.argCnt[targetY] = 0
+				added, err := ag.distinctIndex.mergeInto(
+					mp, ag.allocation, targetY, &other.distinctIndex, uint16(i))
 				if err != nil {
-					it.Close()
 					return 0, err
 				}
-				copy(kcpy, k)
-				binary.BigEndian.PutUint16(kcpy[:kAggArgPrefixSz], uint16(ag.length))
-				if err := ag.insertArgValue(mp, kcpy, value); err != nil {
-					it.Close()
-					return 0, err
+				if added > math.MaxUint32-ag.argCnt[targetY] {
+					return 0, moerr.NewInternalErrorNoCtx(
+						"agg appendFromStateArg: too many distinct arguments")
 				}
+				ag.argCnt[targetY] += added
+				ag.length++
 			}
-			it.Close()
-			ag.length++
+		} else {
+			for i := start; i < end; i++ {
+				ag.argCnt[ag.length] = other.argCnt[i]
+				var lkb, ukb [kAggArgPrefixSz]byte
+				lk := lkb[:]
+				uk := ukb[:]
+				binary.BigEndian.PutUint16(lk, uint16(i))
+				binary.BigEndian.PutUint16(uk, uint16(i+1))
+				it := other.argSkl.NewIter(lk, uk)
+				for ok, k, value := it.SeekGE(lk); ok; ok, k, value = it.Next() {
+					kcpy, err := ag.resizeArgScratch(mp, len(k))
+					if err != nil {
+						it.Close()
+						return 0, err
+					}
+					copy(kcpy, k)
+					binary.BigEndian.PutUint16(kcpy[:kAggArgPrefixSz], uint16(ag.length))
+					if err := ag.insertArgValue(mp, kcpy, value); err != nil {
+						it.Close()
+						return 0, err
+					}
+				}
+				it.Close()
+				ag.length++
+			}
 		}
 	}
 	return end, nil
@@ -927,6 +972,43 @@ func (ag *aggState) insertArgValueWithInserter(
 	if ag.argSkl == nil {
 		return moerr.NewInternalErrorNoCtx("argSkl is not initialized")
 	}
+	var (
+		distinctIndexKey  uint64
+		distinctIndexGrp  uint16
+		distinctIndexUsed bool
+	)
+	if ag.distinctKeyWidth > 0 {
+		var ok bool
+		distinctIndexGrp, distinctIndexKey, ok = decodeDistinctFixedKey(kbuf, ag.distinctKeyWidth)
+		if !ok && ag.distinctFixedDeferred {
+			// A deferred fixed-width state has no skiplist source of truth:
+			// iterators, merge, and spill read the index directly.  Falling back
+			// to the empty compatibility skiplist for a malformed/retyped payload
+			// would publish argCnt without publishing an index key and silently
+			// lose the value at the next boundary.
+			return mpool.ErrAllocationAccountInvariant
+		}
+		if ok {
+			distinctIndexUsed = true
+			duplicate, err := ag.distinctIndex.prepare(
+				mp, ag.allocation, distinctIndexGrp, distinctIndexKey)
+			if err != nil {
+				return err
+			}
+			if duplicate {
+				return arenaskl.ErrRecordExists
+			}
+			if ag.distinctFixedDeferred {
+				return ag.distinctIndex.insert(distinctIndexGrp, distinctIndexKey)
+			}
+		}
+	}
+	publish := func(err error) error {
+		if err == nil && distinctIndexUsed && !ag.distinctFixedDeferred {
+			return ag.distinctIndex.insert(distinctIndexGrp, distinctIndexKey)
+		}
+		return err
+	}
 	if ag.allocation != nil {
 		if uint64(len(kbuf)) > math.MaxUint32 ||
 			uint64(len(value)) > math.MaxUint32 {
@@ -943,9 +1025,9 @@ func (ag *aggState) insertArgValueWithInserter(
 		if used <= math.MaxUint64-required &&
 			used+required <= uint64(ag.argSkl.Arena().Capacity()) {
 			if inserter != nil {
-				return inserter.AddWithPlan(ag.argSkl, kbuf, value, plan)
+				return publish(inserter.AddWithPlan(ag.argSkl, kbuf, value, plan))
 			}
-			return ag.argSkl.AddWithPlan(kbuf, value, plan)
+			return publish(ag.argSkl.AddWithPlan(kbuf, value, plan))
 		}
 		// Admission deliberately reserves no capacity for a DISTINCT key that is
 		// already present. Confirm that case before growing; doing this only at a
@@ -963,9 +1045,9 @@ func (ag *aggState) insertArgValueWithInserter(
 			// GrowArena relocates the backing buffer, so cached node pointers no
 			// longer refer to the current arena.
 			*inserter = arenaskl.Inserter{}
-			return inserter.AddWithPlan(ag.argSkl, kbuf, value, plan)
+			return publish(inserter.AddWithPlan(ag.argSkl, kbuf, value, plan))
 		}
-		return ag.argSkl.AddWithPlan(kbuf, value, plan)
+		return publish(ag.argSkl.AddWithPlan(kbuf, value, plan))
 	}
 
 	nodeSize, err := aggregateArgumentNodeSize(
@@ -980,7 +1062,7 @@ func (ag *aggState) insertArgValueWithInserter(
 		return list.Add(kbuf, value)
 	}
 	if err := add(ag.argSkl); err != arenaskl.ErrArenaFull {
-		return err
+		return publish(err)
 	}
 
 	// arena is full, we need to grow the arena. Grow by at least kAggArgArenaSize,
@@ -1032,7 +1114,7 @@ func (ag *aggState) insertArgValueWithInserter(
 	ag.argbuf = argBuf
 	ag.argSkl = newArgSkl
 	mp.Free(oldArgBuf)
-	return nil
+	return publish(nil)
 }
 
 func (ag *aggState) fillArg(mp *mpool.MPool, y uint16, val []byte, distinct bool) error {
@@ -1104,6 +1186,25 @@ func (ag *aggState) insertPreparedArg(
 }
 
 func (ag *aggState) mergeArgs(mp *mpool.MPool, y uint16, other *aggState, otherY uint16, info *aggInfo) error {
+	if info.isDistinct && ag.distinctFixedDeferred && other != nil &&
+		other.distinctFixedDeferred && ag.distinctKeyWidth == other.distinctKeyWidth {
+		if y >= uint16(len(ag.argCnt)) || otherY >= uint16(len(other.argCnt)) ||
+			other.argCnt[otherY] > math.MaxUint32-ag.argCnt[y] {
+			return moerr.NewInternalErrorNoCtx(
+				"agg mergeArgs: too many distinct arguments")
+		}
+		added, err := ag.distinctIndex.mergeInto(
+			mp, ag.allocation, y, &other.distinctIndex, otherY)
+		if added > math.MaxUint32-ag.argCnt[y] {
+			return moerr.NewInternalErrorNoCtx(
+				"agg mergeArgs: too many distinct arguments")
+		}
+		ag.argCnt[y] += added
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	var inserter arenaskl.Inserter
 	merge := func(k []byte) error {
 		kcpy, err := ag.resizeArgScratch(mp, len(k))
@@ -1142,6 +1243,28 @@ func (ag *aggState) mergeArgs(mp *mpool.MPool, y uint16, other *aggState, otherY
 }
 
 func (ag *aggState) iter(idx uint16, fn func(k []byte) error) error {
+	if ag.distinctFixedDeferred {
+		if int(idx) >= len(ag.argCnt) {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		// Empty fixed-index rows are valid before the first key is admitted.
+		// Their optional index columns are intentionally unallocated; callers
+		// such as spill drains and generic merge fallback still iterate every
+		// physical group row and must observe an empty stream, not an error.
+		if ag.argCnt[idx] == 0 {
+			return nil
+		}
+		if len(ag.distinctIndex.groupHead) == 0 {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		width := ag.distinctKeyWidth
+		var encoded [kAggArgPrefixSz + 8]byte
+		binary.BigEndian.PutUint16(encoded[:kAggArgPrefixSz], idx)
+		return ag.distinctIndex.forEach(idx, func(value uint64) error {
+			binary.LittleEndian.PutUint64(encoded[kAggArgPrefixSz:], value)
+			return fn(encoded[:kAggArgPrefixSz+width])
+		})
+	}
 	var lkb, ukb [kAggArgPrefixSz]byte
 	lk := lkb[:]
 	uk := ukb[:]
@@ -1218,6 +1341,9 @@ func aggPayloadFromKey(info *aggInfo, k []byte) []byte {
 }
 
 func (ag *aggState) free(mp *mpool.MPool) {
+	ag.distinctIndex.free(mp)
+	ag.distinctKeyWidth = 0
+	ag.distinctFixedDeferred = false
 	if cap(ag.argCnt) > 0 {
 		mpool.FreeSlice(mp, ag.argCnt)
 	}
@@ -1250,10 +1376,11 @@ func (ag *aggState) free(mp *mpool.MPool) {
 type aggExec struct {
 	mp *mpool.MPool
 	aggInfo
-	chunkSize  int
-	state      []aggState
-	standby    []aggState
-	allocation *AllocationAccount
+	chunkSize              int
+	state                  []aggState
+	standby                []aggState
+	allocation             *AllocationAccount
+	distinctFixedAdmission distinctFixedAdmissionPlan
 }
 
 func (ae *aggExec) finalizeStringSourcePreflights(groups []uint64) {
@@ -1955,6 +2082,7 @@ func (ae *aggExec) Size() int64 {
 }
 
 func (ae *aggExec) Free() {
+	ae.distinctFixedAdmission.reset()
 	for _, st := range ae.state {
 		st.free(ae.mp)
 	}
@@ -1997,6 +2125,25 @@ func copyCanonicalDistinctArgument(dst []byte, vec *vector.Vector, row int) int 
 	return copy(dst, vec.GetRawBytesAt(row))
 }
 
+func distinctFixedValue(vec *vector.Vector, row, width int) (uint64, error) {
+	if vec == nil || row < 0 || width <= 0 || width > 8 {
+		return 0, mpool.ErrAllocationAccountInvariant
+	}
+	if size, ok := canonicalDistinctArgumentSize(vec, row); ok {
+		if size != width {
+			return 0, mpool.ErrAllocationAccountInvariant
+		}
+		return 0, nil
+	}
+	raw := vec.GetRawBytesAt(row)
+	if len(raw) != width {
+		return 0, mpool.ErrAllocationAccountInvariant
+	}
+	var padded [8]byte
+	copy(padded[:], raw)
+	return binary.LittleEndian.Uint64(padded[:]), nil
+}
+
 func distinctArgumentRowsEqual(vec *vector.Vector, left, right int) bool {
 	leftZero := false
 	if _, ok := canonicalDistinctArgumentSize(vec, left); ok {
@@ -2031,7 +2178,153 @@ func (ag *aggState) fillDistinctVectorArg(
 	return ag.insertPreparedArg(mp, y, k, true)
 }
 
+func (ae *aggExec) fixedDistinctBatchWidth(groups []uint64, vec *vector.Vector) int {
+	if ae == nil || vec == nil || !ae.isDistinct || !ae.saveArg {
+		return 0
+	}
+	width := distinctFixedKeyWidth(&ae.aggInfo)
+	if width == 0 {
+		return 0
+	}
+	for _, group := range groups {
+		if group == GroupNotMatched {
+			continue
+		}
+		x, y := ae.getXY(group - 1)
+		if x < 0 || x >= len(ae.state) {
+			return 0
+		}
+		state := &ae.state[x]
+		if int(y) >= int(state.capacity) || !state.distinctFixedDeferred ||
+			state.distinctKeyWidth != width {
+			return 0
+		}
+	}
+	return width
+}
+
+func (ae *aggExec) batchFillFixedDistinctArgs(
+	offset int,
+	groups []uint64,
+	vec *vector.Vector,
+	width int,
+) error {
+	if ae.distinctFixedAdmission.matches(offset, groups, vec) {
+		plan := &ae.distinctFixedAdmission
+		plan.valid = false
+		for i, group := range groups {
+			if !plan.publish[i] {
+				continue
+			}
+			x, y := ae.getXY(group - 1)
+			if x < 0 || x >= len(ae.state) {
+				return mpool.ErrAllocationAccountInvariant
+			}
+			state := &ae.state[x]
+			if state.distinctKeyWidth != width ||
+				int(y) >= int(state.capacity) {
+				return mpool.ErrAllocationAccountInvariant
+			}
+			if state.argCnt[y] == math.MaxUint32 {
+				return moerr.NewInternalErrorNoCtx(
+					"agg fillArg: too many distinct arguments")
+			}
+			if err := state.distinctIndex.insert(y, plan.values[i]); err != nil {
+				return err
+			}
+			state.argCnt[y]++
+		}
+		return nil
+	}
+	ae.distinctFixedAdmission.reset()
+	var batch distinctFixedBatch
+	batch.reset()
+	for i, group := range groups {
+		if group == GroupNotMatched {
+			continue
+		}
+		x, y := ae.getXY(group - 1)
+		if x < 0 || x >= len(ae.state) {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		state := &ae.state[x]
+		row, err := preflightPhysicalRow(vec, offset+i)
+		if err != nil {
+			return err
+		}
+		if vec.IsNull(uint64(row)) {
+			continue
+		}
+		value, err := distinctFixedValue(vec, row, width)
+		if err != nil {
+			return err
+		}
+		if batch.seenOrInsert(group, value) {
+			continue
+		}
+		duplicate, err := state.distinctIndex.prepare(
+			ae.mp, state.allocation, y, value)
+		if err != nil {
+			return err
+		}
+		if duplicate {
+			continue
+		}
+		if state.argCnt[y] == math.MaxUint32 {
+			return moerr.NewInternalErrorNoCtx(
+				"agg fillArg: too many distinct arguments")
+		}
+		if err := state.distinctIndex.insert(y, value); err != nil {
+			return err
+		}
+		state.argCnt[y]++
+	}
+	return nil
+}
+
 func (ae *aggExec) batchFillArgs(offset int, groups []uint64, vectors []*vector.Vector, distinct bool) error {
+	if distinct && len(vectors) == 1 {
+		if width := ae.fixedDistinctBatchWidth(groups, vectors[0]); width > 0 {
+			return ae.batchFillFixedDistinctArgs(
+				offset, groups, vectors[0], width)
+		}
+	}
+	// BatchFill is fed UnitLimit-sized immutable work units. DISTINCT values
+	// that repeat inside one unit are guaranteed to be duplicates for the same
+	// aggregate group, so avoid probing the resident skiplist for every copy.
+	// Keep the tiny linear path for duplicate-heavy units and promote to the
+	// bounded open-addressing table only when the unit has more representatives.
+	var linear distinctArgumentLinearBatch
+	var hashed distinctArgumentBatch
+	hashedReady := false
+	seenDistinct := func(row int) (bool, error) {
+		if !distinct {
+			return false, nil
+		}
+		if hashedReady {
+			return hashed.seenOrInsert(groups, vectors, offset, row)
+		}
+		duplicate, err := linear.seen(groups, vectors, offset, row)
+		if err != nil || duplicate {
+			return duplicate, err
+		}
+		if linear.insertUnique(row) {
+			return false, nil
+		}
+		for i := uint16(0); i < linear.count; i++ {
+			duplicate, err = hashed.seenOrInsert(
+				groups, vectors, offset, int(linear.rows[i]))
+			if err != nil {
+				return false, err
+			}
+			if duplicate {
+				return false, mpool.ErrAllocationAccountInvariant
+			}
+		}
+		hashedReady = true
+		return hashed.seenOrInsert(groups, vectors, offset, row)
+	}
+
 	for i, group := range groups {
 		if group == GroupNotMatched {
 			continue
@@ -2046,6 +2339,13 @@ func (ae *aggExec) batchFillArgs(offset int, groups []uint64, vectors []*vector.
 				return err
 			}
 			if vectors[0].IsNull(uint64(row)) {
+				continue
+			}
+			duplicate, err := seenDistinct(i)
+			if err != nil {
+				return err
+			}
+			if duplicate {
 				continue
 			}
 			x, y := ae.getXY(group - 1)
@@ -2078,6 +2378,13 @@ func (ae *aggExec) batchFillArgs(offset int, groups []uint64, vectors []*vector.
 			}
 		}
 		if hasNull {
+			continue
+		}
+		duplicate, err := seenDistinct(i)
+		if err != nil {
+			return err
+		}
+		if duplicate {
 			continue
 		}
 
@@ -2174,6 +2481,26 @@ func (ae *aggExec) batchMergeArgs(next *aggExec, offset int, groups []uint64, di
 
 func (ag *aggState) checkArgsSkl() {
 	if ag.argSkl == nil {
+		return
+	}
+	if ag.distinctFixedDeferred {
+		for i := range ag.length {
+			if ag.argCnt[i] == 0 {
+				continue
+			}
+			var count uint32
+			if err := ag.distinctIndex.forEach(uint16(i), func(uint64) error {
+				count++
+				return nil
+			}); err != nil {
+				panic(err)
+			}
+			if count != ag.argCnt[i] {
+				panic(moerr.NewInternalErrorNoCtxf(
+					"invalid fixed distinct count: %d for y: %d, expected: %d",
+					count, i, ag.argCnt[i]))
+			}
+		}
 		return
 	}
 

--- a/pkg/sql/colexec/aggexec/aggState.go
+++ b/pkg/sql/colexec/aggexec/aggState.go
@@ -1187,24 +1187,19 @@ func (ag *aggState) insertPreparedArg(
 }
 
 func (ag *aggState) mergeArgs(mp *mpool.MPool, y uint16, other *aggState, otherY uint16, info *aggInfo) error {
-	if info.isDistinct && ag.distinctFixedDeferred && other != nil &&
-		other.distinctFixedDeferred && ag.distinctKeyWidth == other.distinctKeyWidth {
-		if y >= uint16(len(ag.argCnt)) || otherY >= uint16(len(other.argCnt)) ||
-			other.argCnt[otherY] > math.MaxUint32-ag.argCnt[y] {
-			return moerr.NewInternalErrorNoCtx(
-				"agg mergeArgs: too many distinct arguments")
+	if info.isDistinct && ag.distinctFixedDeferred && ag.distinctKeyWidth > 0 {
+		if other == nil {
+			return mpool.ErrAllocationAccountInvariant
 		}
-		added, err := ag.distinctIndex.mergeInto(
-			mp, ag.allocation, y, &other.distinctIndex, otherY)
-		if added > math.MaxUint32-ag.argCnt[y] {
-			return moerr.NewInternalErrorNoCtx(
-				"agg mergeArgs: too many distinct arguments")
+		if other.distinctFixedDeferred &&
+			ag.distinctKeyWidth == other.distinctKeyWidth {
+			return ag.mergeFixedDistinctArgs(mp, y, other, otherY)
 		}
-		ag.argCnt[y] += added
-		if err != nil {
-			return err
-		}
-		return nil
+		// A fixed target can receive a legacy source when the source was
+		// created under a smaller account or restored from the compatibility
+		// skiplist representation.  Keep the target's representation stable and
+		// import the source's fixed-width payloads directly into its index.
+		return ag.mergeLegacyDistinctArgsIntoFixed(mp, y, other, otherY)
 	}
 	var inserter arenaskl.Inserter
 	merge := func(k []byte) error {
@@ -1241,6 +1236,77 @@ func (ag *aggState) mergeArgs(mp *mpool.MPool, y uint16, other *aggState, otherY
 		return other.iterInputOrder(mp, otherY, merge)
 	}
 	return other.iter(otherY, merge)
+}
+
+// mergeFixedDistinctArgs imports a source fixed index without rebuilding the
+// compatibility key or re-entering the skiplist wrapper for every value.
+func (ag *aggState) mergeFixedDistinctArgs(
+	mp *mpool.MPool,
+	y uint16,
+	other *aggState,
+	otherY uint16,
+) error {
+	if y >= uint16(len(ag.argCnt)) || otherY >= uint16(len(other.argCnt)) ||
+		other.argCnt[otherY] > math.MaxUint32-ag.argCnt[y] {
+		return moerr.NewInternalErrorNoCtx(
+			"agg mergeArgs: too many distinct arguments")
+	}
+	added, err := ag.distinctIndex.mergeInto(
+		mp, ag.allocation, y, &other.distinctIndex, otherY)
+	if added > math.MaxUint32-ag.argCnt[y] {
+		return moerr.NewInternalErrorNoCtx(
+			"agg mergeArgs: too many distinct arguments")
+	}
+	ag.argCnt[y] += added
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// mergeLegacyDistinctArgsIntoFixed converts the source's compatibility
+// skiplist keys back to their fixed-width payload and publishes them directly
+// into the target index.  Preflight reserves an upper bound based on the source
+// argument count, so valid inputs do not allocate at publication time.
+func (ag *aggState) mergeLegacyDistinctArgsIntoFixed(
+	mp *mpool.MPool,
+	y uint16,
+	other *aggState,
+	otherY uint16,
+) error {
+	if ag == nil || other == nil || ag.distinctKeyWidth <= 0 ||
+		other.argSkl == nil ||
+		y >= uint16(len(ag.argCnt)) || otherY >= uint16(len(other.argCnt)) ||
+		other.argCnt[otherY] > math.MaxUint32-ag.argCnt[y] {
+		return moerr.NewInternalErrorNoCtx(
+			"agg mergeArgs: too many distinct arguments")
+	}
+	var added uint32
+	err := other.iter(otherY, func(key []byte) error {
+		_, value, ok := decodeDistinctFixedKey(key, ag.distinctKeyWidth)
+		if !ok {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		duplicate, err := ag.distinctIndex.prepare(
+			mp, ag.allocation, y, value)
+		if err != nil {
+			return err
+		}
+		if duplicate {
+			return nil
+		}
+		if err := ag.distinctIndex.insert(y, value); err != nil {
+			return err
+		}
+		added++
+		return nil
+	})
+	if added > math.MaxUint32-ag.argCnt[y] {
+		return moerr.NewInternalErrorNoCtx(
+			"agg mergeArgs: too many distinct arguments")
+	}
+	ag.argCnt[y] += added
+	return err
 }
 
 func (ag *aggState) iter(idx uint16, fn func(k []byte) error) error {
@@ -2461,6 +2527,31 @@ func (ae *aggExec) batchFillArgs(offset int, groups []uint64, vectors []*vector.
 			off += len(raw)
 		}
 		if err := state.insertPreparedArg(ae.mp, y, key, distinct); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// bulkFillDistinctArgs keeps the direct aggregate API safe for full vectors.
+// The batch-local DISTINCT admission tables intentionally use one bounded
+// hashmap.UnitLimit work unit; callers of BulkFill are not required to split
+// their vectors before entering this layer.
+func (ae *aggExec) bulkFillDistinctArgs(
+	groupIndex int,
+	vectors []*vector.Vector,
+) error {
+	if ae == nil || len(vectors) == 0 || vectors[0] == nil {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	length := vectors[0].Length()
+	var groups [hashmap.UnitLimit]uint64
+	for i := range groups {
+		groups[i] = uint64(groupIndex + 1)
+	}
+	for offset := 0; offset < length; offset += hashmap.UnitLimit {
+		n := min(hashmap.UnitLimit, length-offset)
+		if err := ae.batchFillArgs(offset, groups[:n], vectors, true); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/colexec/aggexec/aggState.go
+++ b/pkg/sql/colexec/aggexec/aggState.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/matrixorigin/matrixone/pkg/common/arenaskl"
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -2259,10 +2260,14 @@ func (ae *aggExec) batchFillFixedDistinctArgs(
 		if err != nil {
 			return err
 		}
-		if batch.seenOrInsert(group, value) {
+		duplicate, err := batch.seenOrInsert(group, value)
+		if err != nil {
+			return err
+		}
+		if duplicate {
 			continue
 		}
-		duplicate, err := state.distinctIndex.prepare(
+		duplicate, err = state.distinctIndex.prepare(
 			ae.mp, state.allocation, y, value)
 		if err != nil {
 			return err
@@ -2283,6 +2288,23 @@ func (ae *aggExec) batchFillFixedDistinctArgs(
 }
 
 func (ae *aggExec) batchFillArgs(offset int, groups []uint64, vectors []*vector.Vector, distinct bool) error {
+	// DISTINCT admission tables are bounded to one hashmap work unit.  BatchFill
+	// is also used directly by BulkFill and a few aggregate tests with a full
+	// vector, so preserve that API by processing large inputs as independent
+	// work units.  The resident index still supplies cross-unit deduplication.
+	if distinct && len(groups) > hashmap.UnitLimit {
+		for start := 0; start < len(groups); start += hashmap.UnitLimit {
+			end := start + hashmap.UnitLimit
+			if end > len(groups) {
+				end = len(groups)
+			}
+			if err := ae.batchFillArgs(
+				offset+start, groups[start:end], vectors, distinct); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	if distinct && len(vectors) == 1 {
 		if width := ae.fixedDistinctBatchWidth(groups, vectors[0]); width > 0 {
 			return ae.batchFillFixedDistinctArgs(

--- a/pkg/sql/colexec/aggexec/allocation_account_test.go
+++ b/pkg/sql/colexec/aggexec/allocation_account_test.go
@@ -1124,7 +1124,10 @@ func TestDistinctFillPreflightUsesPublishedNodeFootprints(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, exact, exactAgain)
 	require.Equal(t, uint32(rows), count)
-	_, count, err = run(exact-1, false)
+	// If the optional fixed index cannot be admitted, preflight may retry with
+	// the legacy skiplist representation. Leave exactly its initial arena
+	// budget available so this assertion exercises that fallback's own bound.
+	_, count, err = run(exact-(40<<10), false)
 	require.ErrorIs(t, err, mpool.ErrAllocationAccountCapacity)
 	require.Zero(t, count, "failed admission must not publish distinct keys")
 }

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -17,6 +17,7 @@ package aggexec
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"math"
 	"slices"
 
@@ -397,6 +398,142 @@ func preflightArgumentRowsEqual(
 const distinctArgumentBatchSlots = hashmap.UnitLimit * 2
 const distinctArgumentLinearLimit = 8
 
+// distinctFixedPreflightPlan accumulates the exact number of new fixed-width
+// DISTINCT keys for each state touched by one immutable work unit. The index
+// cannot publish reservations while preflight is running: preflight may be
+// retried, and a reservation would either leak into a failed BatchFill or make
+// the result depend on how many times the caller asked for admission. Keeping
+// the plan local lets us admit the table and its per-group log once, for the
+// complete candidate set, before publication starts.
+type distinctFixedPreflightPlan struct {
+	chunks [distinctArgumentBatchSlots]int
+	counts [distinctArgumentBatchSlots]uint64
+	count  int
+}
+
+// distinctFixedAdmissionPlan carries the exact publication decision from
+// PreflightBatchFill to the immediately following BatchFill.  The group
+// operator invokes those methods back-to-back for one immutable work unit; by
+// retaining the already-decoded values here, BatchFill need not probe the
+// resident index a second time.  The plan is deliberately bounded by
+// hashmap.UnitLimit and is invalidated on every new preflight or consumption.
+type distinctFixedAdmissionPlan struct {
+	offset  int
+	length  int
+	vec     *vector.Vector
+	groups  [hashmap.UnitLimit]uint64
+	values  [hashmap.UnitLimit]uint64
+	publish [hashmap.UnitLimit]bool
+	valid   bool
+}
+
+func (plan *distinctFixedAdmissionPlan) reset() {
+	if plan == nil {
+		return
+	}
+	plan.offset = 0
+	plan.length = 0
+	plan.vec = nil
+	plan.valid = false
+	clear(plan.groups[:])
+	clear(plan.values[:])
+	clear(plan.publish[:])
+}
+
+func (plan *distinctFixedAdmissionPlan) matches(
+	offset int,
+	groups []uint64,
+	vec *vector.Vector,
+) bool {
+	if plan == nil || !plan.valid || plan.offset != offset ||
+		plan.length != len(groups) || plan.vec != vec ||
+		len(groups) > len(plan.groups) {
+		return false
+	}
+	return slices.Equal(plan.groups[:len(groups)], groups)
+}
+
+func (plan *distinctFixedPreflightPlan) add(chunk int) error {
+	return plan.addN(chunk, 1)
+}
+
+func (plan *distinctFixedPreflightPlan) addN(chunk int, n uint64) error {
+	if plan == nil || chunk < 0 {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	if n == 0 {
+		return nil
+	}
+	for i := 0; i < plan.count; i++ {
+		if plan.chunks[i] != chunk {
+			continue
+		}
+		if plan.counts[i] > math.MaxUint64-n {
+			return mpool.ErrAllocationAllocatorLimit
+		}
+		plan.counts[i] += n
+		return nil
+	}
+	if plan.count >= len(plan.chunks) {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	plan.chunks[plan.count] = chunk
+	plan.counts[plan.count] = n
+	plan.count++
+	return nil
+}
+
+func (plan *distinctFixedPreflightPlan) apply(ae *aggExec) error {
+	if plan == nil || plan.count == 0 {
+		return nil
+	}
+	if ae == nil {
+		return mpool.ErrAllocationAccountInvariant
+	}
+	for i := 0; i < plan.count; i++ {
+		state := ae.preflightStateAt(plan.chunks[i])
+		if state == nil || !state.distinctFixedDeferred {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		if err := state.distinctIndex.ensureCapacityFor(
+			ae.mp, ae.allocation, plan.counts[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// disableEmptyDistinctFixedStates releases an unpublished optional index when
+// its account cannot admit the next work unit. A state with published fixed
+// keys cannot be switched in place: its deferred representation has no
+// skiplist entries to migrate. Such a state must be spilled/replaced by the
+// caller instead of silently losing its membership set. Empty states are safe
+// to fall back to the original skiplist implementation and let the normal
+// preflight retry decide whether that path fits.
+func (ae *aggExec) disableEmptyDistinctFixedStates() bool {
+	if ae == nil {
+		return false
+	}
+	disabled := false
+	disable := func(state *aggState) {
+		if state == nil || !state.distinctFixedDeferred ||
+			state.distinctIndex.count != 0 {
+			return
+		}
+		state.distinctIndex.free(ae.mp)
+		state.distinctKeyWidth = 0
+		state.distinctFixedDeferred = false
+		disabled = true
+	}
+	for i := range ae.state {
+		disable(&ae.state[i])
+	}
+	for i := range ae.standby {
+		disable(&ae.standby[i])
+	}
+	return disabled
+}
+
 // distinctArgumentLinearBatch keeps the low-cardinality path hash-free. Most
 // duplicate-heavy batches find a representative after one or two exact
 // comparisons, avoiding both hashing large payloads and clearing the larger
@@ -755,11 +892,30 @@ func (ae *aggExec) addDistinctArgumentCapacity(
 	vectors []*vector.Vector,
 	needs *[hashmap.UnitLimit]argumentChunkCapacity,
 	needCount *int,
+	fixedPlan *distinctFixedPreflightPlan,
 ) error {
 	key, err := state.preparePreflightArgumentKey(
 		ae.mp, y, vectors, logicalRow, payload, true, 0)
 	if err != nil {
 		return err
+	}
+	if state.distinctFixedDeferred {
+		group, value, ok := decodeDistinctFixedKey(key, state.distinctKeyWidth)
+		if !ok {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		if state.distinctIndex.lookup(group, value) {
+			return nil
+		}
+		if fixedPlan != nil {
+			return fixedPlan.add(x)
+		}
+		// Production admission supplies a batch plan. Keep a safe fallback for
+		// any future single-row caller that does not carry one.
+		return state.distinctIndex.ensureCapacityFor(ae.mp, ae.allocation, 1)
+	}
+	if state.distinctFixedIndexContains(key) {
+		return nil
 	}
 	if state.argSkl.Contains(key) {
 		return nil
@@ -772,8 +928,29 @@ func (ae *aggExec) preflightDistinctBatchFillArgs(
 	groups []uint64,
 	vectors []*vector.Vector,
 ) error {
+	err := ae.preflightDistinctBatchFillArgsOnce(offset, groups, vectors)
+	if errors.Is(err, mpool.ErrAllocationAccountCapacity) &&
+		ae.disableEmptyDistinctFixedStates() {
+		return ae.preflightDistinctBatchFillArgsOnce(offset, groups, vectors)
+	}
+	return err
+}
+
+func (ae *aggExec) preflightDistinctBatchFillArgsOnce(
+	offset int,
+	groups []uint64,
+	vectors []*vector.Vector,
+) error {
+	ae.distinctFixedAdmission.reset()
+	if width, err := ae.fixedDistinctPreflightWidth(groups, vectors); err != nil {
+		return err
+	} else if width > 0 {
+		return ae.preflightFixedDistinctBatchFillArgs(
+			offset, groups, vectors[0])
+	}
 	var needs [hashmap.UnitLimit]argumentChunkCapacity
 	needCount := 0
+	var fixedPlan distinctFixedPreflightPlan
 	var linear distinctArgumentLinearBatch
 	for i, group := range groups {
 		if group == GroupNotMatched {
@@ -823,7 +1000,8 @@ func (ae *aggExec) preflightDistinctBatchFillArgs(
 		}
 		if !linear.insertUnique(i) {
 			return ae.preflightDistinctBatchFillArgsHashed(
-				offset, groups, vectors, i, &linear, &needs, &needCount)
+				offset, groups, vectors, i, &linear, &needs, &needCount,
+				&fixedPlan)
 		}
 		if len(vectors) == 1 {
 			// Duplicate rows need neither a retained key nor its payload size.
@@ -834,11 +1012,91 @@ func (ae *aggExec) preflightDistinctBatchFillArgs(
 			return mpool.ErrAllocationAllocatorLimit
 		}
 		if err = ae.addDistinctArgumentCapacity(
-			x, y, state, logicalRow, payload, vectors, &needs, &needCount); err != nil {
+			x, y, state, logicalRow, payload, vectors, &needs, &needCount,
+			&fixedPlan); err != nil {
 			return err
 		}
 	}
+	if err := fixedPlan.apply(ae); err != nil {
+		return err
+	}
 	return ae.applyArgumentChunkCapacity(&needs, needCount)
+}
+
+func (ae *aggExec) fixedDistinctPreflightWidth(
+	groups []uint64,
+	vectors []*vector.Vector,
+) (int, error) {
+	if ae == nil || len(vectors) != 1 {
+		return 0, nil
+	}
+	width := distinctFixedKeyWidth(&ae.aggInfo)
+	if width == 0 {
+		return 0, nil
+	}
+	for _, group := range groups {
+		if group == GroupNotMatched {
+			continue
+		}
+		_, _, state, err := ae.validatePreflightTarget(group)
+		if err != nil {
+			return 0, err
+		}
+		if state == nil || !state.distinctFixedDeferred ||
+			state.distinctKeyWidth != width {
+			return 0, nil
+		}
+	}
+	return width, nil
+}
+
+func (ae *aggExec) preflightFixedDistinctBatchFillArgs(
+	offset int,
+	groups []uint64,
+	vec *vector.Vector,
+) error {
+	var plan distinctFixedPreflightPlan
+	var batch distinctFixedBatch
+	batch.reset()
+	admission := &ae.distinctFixedAdmission
+	for i, group := range groups {
+		if group == GroupNotMatched {
+			continue
+		}
+		x, y, state, err := ae.validatePreflightTarget(group)
+		if err != nil {
+			return err
+		}
+		row, err := preflightPhysicalRow(vec, offset+i)
+		if err != nil {
+			return err
+		}
+		if vec.IsNull(uint64(row)) {
+			continue
+		}
+		value, err := distinctFixedValue(vec, row, state.distinctKeyWidth)
+		if err != nil {
+			return err
+		}
+		if batch.seenOrInsert(group, value) || state.distinctIndex.lookup(y, value) {
+			continue
+		}
+		if err := plan.add(x); err != nil {
+			return err
+		}
+		admission.groups[i] = group
+		admission.values[i] = value
+		admission.publish[i] = true
+	}
+	if err := plan.apply(ae); err != nil {
+		admission.reset()
+		return err
+	}
+	admission.offset = offset
+	admission.length = len(groups)
+	admission.vec = vec
+	admission.valid = true
+	return nil
 }
 
 // preflightDistinctBatchFillArgsHashed owns the large table in a separate
@@ -853,6 +1111,7 @@ func (ae *aggExec) preflightDistinctBatchFillArgsHashed(
 	linear *distinctArgumentLinearBatch,
 	needs *[hashmap.UnitLimit]argumentChunkCapacity,
 	needCount *int,
+	fixedPlan *distinctFixedPreflightPlan,
 ) error {
 	if start < 0 || start >= len(groups) || linear == nil {
 		return mpool.ErrAllocationAccountInvalid
@@ -922,9 +1181,13 @@ func (ae *aggExec) preflightDistinctBatchFillArgsHashed(
 			return mpool.ErrAllocationAllocatorLimit
 		}
 		if err = ae.addDistinctArgumentCapacity(
-			x, y, state, logicalRow, payload, vectors, needs, needCount); err != nil {
+			x, y, state, logicalRow, payload, vectors, needs, needCount,
+			fixedPlan); err != nil {
 			return err
 		}
+	}
+	if err := fixedPlan.apply(ae); err != nil {
+		return err
 	}
 	return ae.applyArgumentChunkCapacity(needs, *needCount)
 }
@@ -936,6 +1199,54 @@ func (ae *aggExec) preflightBatchMergeArgs(
 ) error {
 	if other == nil || offset < 0 || offset > other.GetNumGroups()-len(groups) {
 		return mpool.ErrAllocationAccountInvalid
+	}
+	// A merge destination may already contain published fixed-index keys when
+	// a later work unit is admitted. Converting that representation to a
+	// skiplist would require a second copy, so small hard-account destinations
+	// use the spill-friendly legacy path from the beginning. Fill admission can
+	// still fall back safely while the state is empty.
+	mergeFixedAllowed := ae.allocation == nil || ae.allocation.account == nil ||
+		ae.allocation.account.Snapshot().Limit >= distinctFixedIndexMinAccountLimit
+	if !mergeFixedAllowed {
+		ae.disableEmptyDistinctFixedStates()
+	}
+	if mergeFixedAllowed {
+		if width := distinctFixedKeyWidth(&ae.aggInfo); width > 0 &&
+			distinctFixedKeyWidth(&other.aggInfo) == width {
+			fixedReady := true
+			for i, group := range groups {
+				if group == GroupNotMatched {
+					continue
+				}
+				x, _, target, err := ae.validatePreflightTarget(group)
+				if err != nil {
+					return err
+				}
+				otherX, otherY := other.getXY(uint64(offset + i))
+				if otherX < 0 || otherX >= len(other.state) ||
+					int(otherY) >= int(other.state[otherX].length) {
+					return mpool.ErrAllocationAccountInvariant
+				}
+				if target == nil || !target.distinctFixedDeferred ||
+					!other.state[otherX].distinctFixedDeferred {
+					fixedReady = false
+					break
+				}
+				xState := ae.preflightStateAt(x)
+				if xState == nil || xState.distinctKeyWidth != width {
+					fixedReady = false
+					break
+				}
+			}
+			if fixedReady {
+				err := ae.preflightFixedDistinctBatchMergeArgs(other, offset, groups)
+				if errors.Is(err, mpool.ErrAllocationAccountCapacity) &&
+					ae.disableEmptyDistinctFixedStates() {
+					return ae.preflightBatchMergeArgs(other, offset, groups)
+				}
+				return err
+			}
+		}
 	}
 	var needs [hashmap.UnitLimit]argumentChunkCapacity
 	needCount := 0
@@ -1030,6 +1341,76 @@ func (ae *aggExec) preflightBatchMergeArgs(
 		}
 	}
 	return ae.applyArgumentChunkCapacity(&needs, needCount)
+}
+
+func (ae *aggExec) preflightFixedDistinctBatchMergeArgs(
+	other *aggExec,
+	offset int,
+	groups []uint64,
+) error {
+	// A merge work unit can map several source groups into one target group. The
+	// source-side fixed index gives an exact per-group count without rebuilding a
+	// temporary skiplist. Sum those counts per target chunk: this is an upper
+	// bound on new keys (source groups can overlap), so all index/log capacity is
+	// admitted before BatchMerge starts publishing keys. The merge itself does
+	// the single exact membership probe needed for each source key.
+	var targetChunks [distinctArgumentBatchSlots]int
+	var targetCounts [distinctArgumentBatchSlots]uint64
+	targetCount := 0
+	reserve := func(chunk int, extra uint64) error {
+		if extra == 0 {
+			return nil
+		}
+		for i := 0; i < targetCount; i++ {
+			if targetChunks[i] != chunk {
+				continue
+			}
+			if targetCounts[i] > math.MaxUint64-extra {
+				return mpool.ErrAllocationAllocatorLimit
+			}
+			targetCounts[i] += extra
+			state := ae.preflightStateAt(chunk)
+			if state == nil {
+				return mpool.ErrAllocationAccountInvariant
+			}
+			return state.distinctIndex.ensureCapacityFor(
+				ae.mp, ae.allocation, targetCounts[i])
+		}
+		if targetCount >= len(targetChunks) {
+			return mpool.ErrAllocationAccountInvalid
+		}
+		targetChunks[targetCount] = chunk
+		targetCounts[targetCount] = extra
+		targetCount++
+		state := ae.preflightStateAt(chunk)
+		if state == nil {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		return state.distinctIndex.ensureCapacityFor(
+			ae.mp, ae.allocation, extra)
+	}
+	for i, group := range groups {
+		if group == GroupNotMatched {
+			continue
+		}
+		x, y, state, err := ae.validatePreflightTarget(group)
+		if err != nil {
+			return err
+		}
+		otherX, otherY := other.getXY(uint64(offset + i))
+		if otherX < 0 || otherX >= len(other.state) ||
+			int(otherY) >= int(other.state[otherX].length) {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		if y >= uint16(len(state.argCnt)) ||
+			int(otherY) >= len(other.state[otherX].argCnt) {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		if err := reserve(x, uint64(other.state[otherX].argCnt[otherY])); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type vectorAreaChunkCapacity struct {

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -1078,7 +1078,11 @@ func (ae *aggExec) preflightFixedDistinctBatchFillArgs(
 		if err != nil {
 			return err
 		}
-		if batch.seenOrInsert(group, value) || state.distinctIndex.lookup(y, value) {
+		duplicate, err := batch.seenOrInsert(group, value)
+		if err != nil {
+			return err
+		}
+		if duplicate || state.distinctIndex.lookup(y, value) {
 			continue
 		}
 		if err := plan.add(x); err != nil {

--- a/pkg/sql/colexec/aggexec/capacity_preflight.go
+++ b/pkg/sql/colexec/aggexec/capacity_preflight.go
@@ -1060,6 +1060,11 @@ func (ae *aggExec) preflightFixedDistinctBatchFillArgs(
 	batch.reset()
 	admission := &ae.distinctFixedAdmission
 	for i, group := range groups {
+		// Preserve the complete input mapping, including duplicates, NULL rows,
+		// and GroupNotMatched.  `publish` is the separate publication bitmap;
+		// leaving non-publishing entries at zero makes a valid admission plan
+		// fail its exact-input check and needlessly repeats all decode/probe work.
+		admission.groups[i] = group
 		if group == GroupNotMatched {
 			continue
 		}
@@ -1206,56 +1211,63 @@ func (ae *aggExec) preflightBatchMergeArgs(
 	}
 	// A merge destination may already contain published fixed-index keys when
 	// a later work unit is admitted. Converting that representation to a
-	// skiplist would require a second copy, so small hard-account destinations
-	// use the spill-friendly legacy path from the beginning. Fill admission can
-	// still fall back safely while the state is empty.
+	// skiplist would require a second copy, so only empty fixed states may be
+	// disabled when a small hard account cannot admit the index. Published
+	// states retain their representation and use the fixed merge plan below.
 	mergeFixedAllowed := ae.allocation == nil || ae.allocation.account == nil ||
 		ae.allocation.account.Snapshot().Limit >= distinctFixedIndexMinAccountLimit
 	if !mergeFixedAllowed {
 		ae.disableEmptyDistinctFixedStates()
 	}
-	if mergeFixedAllowed {
-		if width := distinctFixedKeyWidth(&ae.aggInfo); width > 0 &&
-			distinctFixedKeyWidth(&other.aggInfo) == width {
-			fixedReady := true
-			for i, group := range groups {
-				if group == GroupNotMatched {
-					continue
-				}
-				x, _, target, err := ae.validatePreflightTarget(group)
-				if err != nil {
-					return err
-				}
-				otherX, otherY := other.getXY(uint64(offset + i))
-				if otherX < 0 || otherX >= len(other.state) ||
-					int(otherY) >= int(other.state[otherX].length) {
-					return mpool.ErrAllocationAccountInvariant
-				}
-				if target == nil || !target.distinctFixedDeferred ||
-					!other.state[otherX].distinctFixedDeferred {
-					fixedReady = false
-					break
-				}
-				xState := ae.preflightStateAt(x)
-				if xState == nil || xState.distinctKeyWidth != width {
-					fixedReady = false
-					break
-				}
+	if width := distinctFixedKeyWidth(&ae.aggInfo); width > 0 &&
+		distinctFixedKeyWidth(&other.aggInfo) == width {
+		// Keep the fast aggregate plan when every mapped target is fixed.  A
+		// source may still be a legacy skiplist state (for example after a
+		// small-account fallback or an older spill restore); the merge path below
+		// imports those fixed-width payloads into the target index directly.
+		fixedReady := true
+		for i, group := range groups {
+			if group == GroupNotMatched {
+				continue
 			}
-			if fixedReady {
-				err := ae.preflightFixedDistinctBatchMergeArgs(other, offset, groups)
-				if errors.Is(err, mpool.ErrAllocationAccountCapacity) &&
-					ae.disableEmptyDistinctFixedStates() {
-					return ae.preflightBatchMergeArgs(other, offset, groups)
-				}
+			x, _, target, err := ae.validatePreflightTarget(group)
+			if err != nil {
 				return err
 			}
+			otherX, otherY := other.getXY(uint64(offset + i))
+			if otherX < 0 || otherX >= len(other.state) ||
+				int(otherY) >= int(other.state[otherX].length) {
+				return mpool.ErrAllocationAccountInvariant
+			}
+			if target == nil || !target.distinctFixedDeferred {
+				fixedReady = false
+				break
+			}
+			xState := ae.preflightStateAt(x)
+			if xState == nil || xState.distinctKeyWidth != width {
+				fixedReady = false
+				break
+			}
+			source := &other.state[otherX]
+			if source.distinctFixedDeferred && source.distinctKeyWidth != width {
+				fixedReady = false
+				break
+			}
+		}
+		if fixedReady {
+			err := ae.preflightFixedDistinctBatchMergeArgs(other, offset, groups)
+			if errors.Is(err, mpool.ErrAllocationAccountCapacity) &&
+				ae.disableEmptyDistinctFixedStates() {
+				return ae.preflightBatchMergeArgs(other, offset, groups)
+			}
+			return err
 		}
 	}
 	var needs [hashmap.UnitLimit]argumentChunkCapacity
 	needCount := 0
 	var progress [hashmap.UnitLimit]argumentTargetProgress
 	progressCount := 0
+	var fixedPlan distinctFixedPreflightPlan
 	for i, group := range groups {
 		if group == GroupNotMatched {
 			continue
@@ -1269,12 +1281,47 @@ func (ae *aggExec) preflightBatchMergeArgs(
 			int(otherY) >= int(other.state[otherX].length) {
 			return mpool.ErrAllocationAccountInvariant
 		}
-		var upper [kAggArgPrefixSz]byte
-		binary.BigEndian.PutUint16(upper[:], y+1)
+		if ae.isDistinct && state.distinctFixedDeferred {
+			source := &other.state[otherX]
+			if distinctFixedKeyWidth(&other.aggInfo) != state.distinctKeyWidth {
+				return mpool.ErrAllocationAccountInvariant
+			}
+			if source.distinctFixedDeferred &&
+				source.distinctKeyWidth != state.distinctKeyWidth {
+				return mpool.ErrAllocationAccountInvariant
+			}
+			// BatchMerge will use the target fixed index for both fixed and
+			// legacy source states. Reserve that representation here rather than
+			// reserving the target's compatibility skiplist arena.
+			if err := fixedPlan.addN(
+				x, uint64(source.argCnt[otherY])); err != nil {
+				return err
+			}
+			continue
+		}
+		sourceState := &other.state[otherX]
 		var targetIter *arenaskl.Iterator
 		var targetKey []byte
 		var targetOK bool
-		err = other.state[otherX].iter(otherY, func(key []byte) error {
+		targetStarted := false
+		if ae.isDistinct {
+			if state == nil || state.argSkl == nil {
+				return mpool.ErrAllocationAccountInvariant
+			}
+			if sourceState.distinctFixedDeferred {
+				// Fixed-index iteration is newest-first, so it cannot share the
+				// ordered target cursor used by legacy skiplists.  Membership
+				// checks for this source representation stay exact below.
+			} else {
+				if sourceState.argSkl == nil {
+					return mpool.ErrAllocationAccountInvariant
+				}
+				var upper [kAggArgPrefixSz]byte
+				binary.BigEndian.PutUint16(upper[:], y+1)
+				targetIter = state.argSkl.NewIter(nil, upper[:])
+			}
+		}
+		err = sourceState.iter(otherY, func(key []byte) error {
 			if len(key) < kAggArgPrefixSz {
 				return mpool.ErrAllocationAccountInvariant
 			}
@@ -1285,15 +1332,24 @@ func (ae *aggExec) preflightBatchMergeArgs(
 			copy(candidate, key)
 			binary.BigEndian.PutUint16(candidate[:kAggArgPrefixSz], y)
 			if ae.isDistinct {
-				if targetIter == nil {
-					targetIter = state.argSkl.NewIter(nil, upper[:])
-					targetOK, targetKey, _ = targetIter.SeekGE(candidate)
-				}
-				for targetOK && bytes.Compare(targetKey, candidate) < 0 {
-					targetOK, targetKey, _ = targetIter.Next()
-				}
-				if targetOK && bytes.Equal(targetKey, candidate) {
-					return nil
+				if sourceState.distinctFixedDeferred {
+					// Fixed-index iteration is reverse insertion order, so use
+					// exact target membership rather than an ordered cursor.
+					if state.argSkl.Contains(candidate) {
+						return nil
+					}
+				} else {
+					if !targetStarted {
+						targetOK, targetKey, _ = targetIter.SeekGE(candidate)
+						targetStarted = true
+					} else if targetOK {
+						for targetOK && bytes.Compare(targetKey, candidate) < 0 {
+							targetOK, targetKey, _ = targetIter.Next()
+						}
+					}
+					if targetOK && bytes.Equal(targetKey, candidate) {
+						return nil
+					}
 				}
 				// A merge work unit can map several source groups into the same
 				// target group. The target skiplist is immutable until admission,
@@ -1309,9 +1365,24 @@ func (ae *aggExec) preflightBatchMergeArgs(
 						int(earlierY) >= int(other.state[earlierX].length) {
 						return mpool.ErrAllocationAccountInvariant
 					}
+					earlierState := &other.state[earlierX]
+					if earlierState.distinctFixedDeferred {
+						_, value, ok := decodeDistinctFixedKey(
+							key, earlierState.distinctKeyWidth)
+						if !ok {
+							return mpool.ErrAllocationAccountInvariant
+						}
+						if earlierState.distinctIndex.lookup(earlierY, value) {
+							return nil
+						}
+						continue
+					}
+					if earlierState.argSkl == nil {
+						return mpool.ErrAllocationAccountInvariant
+					}
 					binary.BigEndian.PutUint16(
 						candidate[:kAggArgPrefixSz], earlierY)
-					if other.state[earlierX].argSkl.Contains(candidate) {
+					if earlierState.argSkl.Contains(candidate) {
 						return nil
 					}
 				}
@@ -1343,6 +1414,9 @@ func (ae *aggExec) preflightBatchMergeArgs(
 		if err != nil {
 			return err
 		}
+	}
+	if err := fixedPlan.apply(ae); err != nil {
+		return err
 	}
 	return ae.applyArgumentChunkCapacity(&needs, needCount)
 }
@@ -1409,6 +1483,11 @@ func (ae *aggExec) preflightFixedDistinctBatchMergeArgs(
 		if y >= uint16(len(state.argCnt)) ||
 			int(otherY) >= len(other.state[otherX].argCnt) {
 			return mpool.ErrAllocationAccountInvariant
+		}
+		if other.state[otherX].argCnt[otherY] >
+			math.MaxUint32-state.argCnt[y] {
+			return moerr.NewInternalErrorNoCtx(
+				"agg mergeArgs: too many distinct arguments")
 		}
 		if err := reserve(x, uint64(other.state[otherX].argCnt[otherY])); err != nil {
 			return err

--- a/pkg/sql/colexec/aggexec/count2.go
+++ b/pkg/sql/colexec/aggexec/count2.go
@@ -165,7 +165,13 @@ func (exec *countColumnExec) Fill(groupIndex int, row int, vectors []*vector.Vec
 }
 
 func (exec *countColumnExec) BulkFill(groupIndex int, vectors []*vector.Vector) error {
-	return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
+	if !exec.IsDistinct() {
+		return exec.BatchFill(
+			0,
+			slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()),
+			vectors)
+	}
+	return exec.bulkFillDistinctArgs(groupIndex, vectors)
 }
 
 func (exec *countColumnExec) BatchFill(offset int, groups []uint64, vectors []*vector.Vector) error {

--- a/pkg/sql/colexec/aggexec/count2_review_test.go
+++ b/pkg/sql/colexec/aggexec/count2_review_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggexec
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/arenaskl"
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountDistinctBulkFillChunksBeyondUnitLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		rows         int
+		disableFixed bool
+	}{
+		{name: "fixed-over-two-units", rows: hashmap.UnitLimit*2 + 1},
+		{name: "legacy-over-one-unit", rows: hashmap.UnitLimit + 1, disableFixed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := mpool.MustNewZero()
+			values := make([]int64, tc.rows)
+			for i := range values {
+				values[i] = int64(i)
+			}
+			vec := testutil.NewInt64Vector(
+				tc.rows, types.T_int64.ToType(), mp, false, nil, values)
+			exec := newCountColumnExec(
+				mp, AggIdOfCountColumn, true,
+				[]types.Type{types.T_int64.ToType()},
+			).(*countColumnExec)
+			require.NoError(t, exec.GroupGrow(1024))
+			if tc.disableFixed {
+				require.True(t, exec.disableEmptyDistinctFixedStates())
+			}
+
+			require.NoError(t, exec.BulkFill(0, []*vector.Vector{vec}))
+			result, err := exec.Flush()
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			require.Equal(t, int64(tc.rows),
+				vector.GetFixedAtNoTypeCheck[int64](result[0], 0))
+			for _, v := range result {
+				v.Free(mp)
+			}
+			exec.Free()
+			vec.Free(mp)
+			require.Zero(t, mp.CurrNB())
+		})
+	}
+}
+
+func TestCountDistinctBatchFillChunksAndBoundaryDuplicates(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		rows         int
+		disableFixed bool
+	}{
+		{name: "fixed-over-two-units", rows: hashmap.UnitLimit*2 + 1},
+		{name: "legacy-over-one-unit", rows: hashmap.UnitLimit + 1, disableFixed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := mpool.MustNewZero()
+			values := make([]int64, tc.rows)
+			for i := range values {
+				values[i] = int64(i)
+			}
+			// Keep one duplicate across a unit boundary.  The direct BatchFill
+			// wrapper must preserve the resident membership set while it splits
+			// the input into bounded admission units.
+			values[len(values)-1] = values[0]
+			vec := testutil.NewInt64Vector(
+				tc.rows, types.T_int64.ToType(), mp, false, nil, values)
+			exec := newCountColumnExec(
+				mp, AggIdOfCountColumn, true,
+				[]types.Type{types.T_int64.ToType()},
+			).(*countColumnExec)
+			require.NoError(t, exec.GroupGrow(1024))
+			if tc.disableFixed {
+				require.True(t, exec.disableEmptyDistinctFixedStates())
+			}
+			groups := make([]uint64, tc.rows)
+			for i := range groups {
+				groups[i] = 1
+			}
+
+			require.NoError(t, exec.BatchFill(0, groups, []*vector.Vector{vec}))
+			result, err := exec.Flush()
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			require.Equal(t, int64(tc.rows-1),
+				vector.GetFixedAtNoTypeCheck[int64](result[0], 0))
+			result[0].Free(mp)
+			exec.Free()
+			vec.Free(mp)
+			require.Zero(t, mp.CurrNB())
+		})
+	}
+}
+
+func TestDistinctFixedBatchProbeIsBounded(t *testing.T) {
+	var batch distinctFixedBatch
+	batch.reset()
+	for i := 0; i < len(batch.groups); i++ {
+		duplicate, err := batch.seenOrInsert(1, uint64(i))
+		require.NoError(t, err)
+		require.False(t, duplicate)
+	}
+	_, err := batch.seenOrInsert(1, uint64(len(batch.groups)))
+	require.ErrorIs(t, err, mpool.ErrAllocationAccountInvariant)
+}
+
+func TestCountDistinctFixedAdmissionRetainsNonPublishingRows(t *testing.T) {
+	mp := mpool.MustNewZero()
+	registry, account, allocation := newTestAggregateAllocation(t)
+	exec := newCountColumnExec(
+		mp, AggIdOfCountColumn, true,
+		[]types.Type{types.T_int64.ToType()},
+	).(*countColumnExec)
+	require.NoError(t, exec.SetAllocationAccount(allocation))
+	require.NoError(t, exec.GroupGrow(1024))
+
+	values := []int64{7, 7, 0, 8, 8, 9}
+	nulls := []bool{false, false, true, false, false, false}
+	groups := []uint64{1, 1, 1, 1, 1, GroupNotMatched}
+	vec := testutil.NewInt64Vector(
+		len(values), types.T_int64.ToType(), mp, false, nulls, values)
+	require.NoError(t, exec.PreflightBatchFill(
+		0, groups, []*vector.Vector{vec}))
+	require.Equal(t, groups,
+		exec.distinctFixedAdmission.groups[:len(groups)])
+	require.Equal(t,
+		[]bool{true, false, false, true, false, false},
+		exec.distinctFixedAdmission.publish[:len(groups)])
+	require.True(t, exec.distinctFixedAdmission.matches(0, groups, vec))
+	require.NoError(t, exec.BatchFill(0, groups, []*vector.Vector{vec}))
+
+	result, err := exec.Flush()
+	require.NoError(t, err)
+	require.Equal(t, int64(2),
+		vector.GetFixedAtNoTypeCheck[int64](result[0], 0))
+	result[0].Free(mp)
+	vec.Free(mp)
+	exec.Free()
+	require.NoError(t, exec.ClearAllocationAccount(allocation))
+	finishTestAggregateAllocation(t, registry, account)
+	require.Zero(t, mp.CurrNB())
+}
+
+func TestCountDistinctFixedMergeFromLegacySource(t *testing.T) {
+	mp := mpool.MustNewZero()
+	registry, account, allocation := newReviewAggregateAllocation(t, 2<<20)
+	makeExec := func() *countColumnExec {
+		exec := newCountColumnExec(
+			mp, AggIdOfCountColumn, true,
+			[]types.Type{types.T_int64.ToType()},
+		).(*countColumnExec)
+		require.NoError(t, exec.SetAllocationAccount(allocation))
+		require.NoError(t, exec.GroupGrow(1024))
+		return exec
+	}
+	source := makeExec()
+	target := makeExec()
+
+	// Force the source into the compatibility skiplist representation while
+	// retaining the target's fixed index.  This models a small-account/legacy
+	// spill source being merged into a current execution state.
+	require.True(t, source.disableEmptyDistinctFixedStates())
+	sourceValues := make([]int64, hashmap.UnitLimit-6)
+	for i := range sourceValues {
+		sourceValues[i] = int64(i)
+	}
+	targetValues := []int64{0}
+	fill := func(exec *countColumnExec, values []int64) {
+		vec := testutil.NewInt64Vector(
+			len(values), types.T_int64.ToType(), mp, false, nil, values)
+		groups := make([]uint64, len(values))
+		for i := range groups {
+			groups[i] = 1
+		}
+		require.NoError(t, exec.PreflightBatchFill(
+			0, groups, []*vector.Vector{vec}))
+		require.NoError(t, exec.BatchFill(0, groups, []*vector.Vector{vec}))
+		vec.Free(mp)
+	}
+	fill(source, sourceValues)
+	fill(target, targetValues)
+	require.False(t, source.state[0].distinctFixedDeferred)
+	require.True(t, target.state[0].distinctFixedDeferred)
+	require.Equal(t, 256, len(target.state[0].distinctIndex.slotKeys))
+
+	mergeGroups := []uint64{1}
+	require.NoError(t, target.PreflightBatchMerge(
+		source, 0, mergeGroups))
+	// The source has 250 candidates and the target already has one.  Fixed
+	// admission must grow the target index before publication (70% load bound),
+	// rather than reserving the compatibility skiplist arena.
+	require.Equal(t, 512, len(target.state[0].distinctIndex.slotKeys))
+	require.NoError(t, target.BatchMerge(source, 0, mergeGroups))
+
+	result, err := target.Flush()
+	require.NoError(t, err)
+	require.Equal(t, int64(250),
+		vector.GetFixedAtNoTypeCheck[int64](result[0], 0))
+	result[0].Free(mp)
+	source.Free()
+	target.Free()
+	require.NoError(t, source.ClearAllocationAccount(allocation))
+	require.NoError(t, target.ClearAllocationAccount(allocation))
+	finishTestAggregateAllocation(t, registry, account)
+	require.Zero(t, mp.CurrNB())
+}
+
+func newReviewAggregateAllocation(
+	t *testing.T,
+	limit uint64,
+) (*mpool.AllocationAccountRegistry, *mpool.AllocationAccount, *AllocationAccount) {
+	t.Helper()
+	registry, err := mpool.NewAllocationAccountRegistry(1, 512)
+	require.NoError(t, err)
+	account, err := registry.Open(limit)
+	require.NoError(t, err)
+	allocation, err := NewAllocationAccount(
+		account,
+		mpool.AllocationOwnerGroup,
+		AllocationAccountSites{
+			VectorData:     1,
+			VectorArea:     2,
+			VectorNulls:    3,
+			VectorGrouping: 4,
+			ArgumentCount:  5,
+			ArgumentArena:  6,
+		},
+	)
+	require.NoError(t, err)
+	return registry, account, allocation
+}
+
+func TestCountDistinctLegacyMergeFromFixedSource(t *testing.T) {
+	mp := mpool.MustNewZero()
+	registry, account, allocation := newReviewAggregateAllocation(t, 2<<20)
+	makeExec := func() *countColumnExec {
+		exec := newCountColumnExec(
+			mp, AggIdOfCountColumn, true,
+			[]types.Type{types.T_int64.ToType()},
+		).(*countColumnExec)
+		require.NoError(t, exec.SetAllocationAccount(allocation))
+		require.NoError(t, exec.GroupGrow(1024))
+		return exec
+	}
+	source := makeExec()
+	target := makeExec()
+	require.True(t, target.disableEmptyDistinctFixedStates())
+
+	fill := func(exec *countColumnExec, values []int64, groups []uint64) {
+		require.Len(t, groups, len(values))
+		vec := testutil.NewInt64Vector(
+			len(values), types.T_int64.ToType(), mp, false, nil, values)
+		for offset := 0; offset < len(groups); offset += hashmap.UnitLimit {
+			end := min(offset+hashmap.UnitLimit, len(groups))
+			require.NoError(t, exec.PreflightBatchFill(
+				offset, groups[offset:end], []*vector.Vector{vec}))
+			require.NoError(t, exec.BatchFill(
+				offset, groups[offset:end], []*vector.Vector{vec}))
+		}
+		vec.Free(mp)
+	}
+	makeKey := func(value int64) []byte {
+		key := make([]byte, kAggArgPrefixSz+8)
+		binary.BigEndian.PutUint16(key[:kAggArgPrefixSz], 0)
+		binary.LittleEndian.PutUint64(key[kAggArgPrefixSz:], uint64(value))
+		return key
+	}
+	keyNeed := func(value int64) uint64 {
+		plan := arenaskl.MakeAddPlan(makeKey(value))
+		consumed, trailing, ok := plan.ArenaFootprint(
+			kAggArgPrefixSz+8, 0)
+		require.True(t, ok)
+		return consumed + trailing
+	}
+	var targetValues []int64
+	var missingValues [2]int64
+	for value := int64(1); value < 10000; value++ {
+		arena := target.state[0].argSkl.Arena()
+		used := uint64(arena.Size())
+		capacity := uint64(arena.Capacity())
+		one := keyNeed(value)
+		two := one + keyNeed(value+1)
+		three := two + keyNeed(value+2)
+		if used+two <= capacity && used+three > capacity {
+			missingValues = [2]int64{value, value + 1}
+			break
+		}
+		targetValues = append(targetValues, value)
+		fill(target, []int64{value}, []uint64{1})
+	}
+	require.Greater(t, len(targetValues), 2)
+	require.NotEqual(t, [2]int64{}, missingValues)
+	missing := []int64{missingValues[0], missingValues[1]}
+	sourceValues := make([]int64, 0, (len(targetValues)+len(missing))*2)
+	sourceGroups := make([]uint64, 0, cap(sourceValues))
+	for _, value := range targetValues {
+		sourceValues = append(sourceValues, value)
+		sourceGroups = append(sourceGroups, 1)
+	}
+	for _, value := range missing {
+		sourceValues = append(sourceValues, value)
+		sourceGroups = append(sourceGroups, 1)
+	}
+	for _, value := range targetValues {
+		sourceValues = append(sourceValues, value)
+		sourceGroups = append(sourceGroups, 2)
+	}
+	for _, value := range missing {
+		sourceValues = append(sourceValues, value)
+		sourceGroups = append(sourceGroups, 2)
+	}
+	fill(source, sourceValues, sourceGroups)
+	require.True(t, source.state[0].distinctFixedDeferred)
+	require.False(t, target.state[0].distinctFixedDeferred)
+
+	mergeGroups := []uint64{1, 1}
+	beforeCapacity := target.state[0].argSkl.Arena().Capacity()
+	beforeSize := target.state[0].argSkl.Arena().Size()
+	require.NoError(t, target.PreflightBatchMerge(
+		source, 0, mergeGroups))
+	// The fixed source is iterated in reverse insertion order and both source
+	// groups map to the same legacy target group.  Only the two missing values
+	// are new; the exact preflight must deduplicate the reversed overlap and
+	// reserve exactly those two nodes without growing the already-boundary arena.
+	require.Equal(t, beforeCapacity, target.state[0].argSkl.Arena().Capacity())
+	require.Equal(t, beforeSize, target.state[0].argSkl.Arena().Size())
+	require.NoError(t, target.BatchMerge(source, 0, mergeGroups))
+	result, err := target.Flush()
+	require.NoError(t, err)
+	require.Equal(t, int64(len(targetValues)+len(missing)),
+		vector.GetFixedAtNoTypeCheck[int64](result[0], 0))
+	result[0].Free(mp)
+	source.Free()
+	target.Free()
+	require.NoError(t, source.ClearAllocationAccount(allocation))
+	require.NoError(t, target.ClearAllocationAccount(allocation))
+	finishTestAggregateAllocation(t, registry, account)
+	require.Zero(t, mp.CurrNB())
+}

--- a/pkg/sql/colexec/aggexec/count2_test.go
+++ b/pkg/sql/colexec/aggexec/count2_test.go
@@ -176,6 +176,56 @@ func TestCountDistinctSignedZeroUsesOneValue(t *testing.T) {
 	require.Zero(t, mp.CurrNB())
 }
 
+func TestCountDistinctFixedIndexPreservesFloatNaNIdentity(t *testing.T) {
+	mp := mpool.MustNewZero()
+	values := []float64{
+		math.Float64frombits(0x7ff8000000000001),
+		math.Float64frombits(0x7ff8000000000001),
+		math.Float64frombits(0x7ff8000000000002),
+		math.Copysign(0, -1),
+		0,
+	}
+
+	count := func(t *testing.T, groupCapacity int) int64 {
+		t.Helper()
+		vec := testutil.NewFloat64Vector(
+			len(values), types.T_float64.ToType(), mp, false, nil, values)
+		defer vec.Free(mp)
+		exec := newCountColumnExec(
+			mp, AggIdOfCountColumn, true,
+			[]types.Type{types.T_float64.ToType()},
+		).(*countColumnExec)
+		require.NoError(t, exec.GroupGrow(groupCapacity))
+		if groupCapacity >= distinctFixedIndexMinGroups {
+			require.True(t, exec.state[0].distinctFixedDeferred)
+		}
+		defer exec.Free()
+		groups := make([]uint64, len(values))
+		for i := range groups {
+			groups[i] = 1
+		}
+		require.NoError(t, exec.PreflightBatchFill(
+			0, groups, []*vector.Vector{vec}))
+		require.NoError(t, exec.BatchFill(
+			0, groups, []*vector.Vector{vec}))
+		result, err := exec.Flush()
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		got := vector.GetFixedAtNoTypeCheck[int64](result[0], 0)
+		result[0].Free(mp)
+		return got
+	}
+
+	// The fixed index must preserve the pre-existing byte-exact aggregate key
+	// contract: equal NaN payloads remain one key, distinct payloads remain
+	// distinct, and signed zeroes remain one key.
+	legacy := count(t, 1)
+	fixed := count(t, distinctFixedIndexMinGroups)
+	require.Equal(t, int64(3), legacy)
+	require.Equal(t, legacy, fixed)
+	require.Zero(t, mp.CurrNB())
+}
+
 func TestCountDistinctSignedZeroDoesNotAllocatePerRow(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -457,6 +507,145 @@ func TestCountMultiColumnDistinct(t *testing.T) {
 		}
 		require.Equal(t, curNB, mp.CurrNB())
 	})
+}
+
+func TestCountDistinctBatchDeduplicatesWithinUnit(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	const rows = hashmap.UnitLimit
+	values := make([]int64, rows)
+	groups := make([]uint64, rows)
+	for i := range values {
+		values[i] = int64(i % 17)
+		groups[i] = uint64(i%2 + 1)
+	}
+	vec := testutil.NewInt64Vector(rows, types.T_int64.ToType(), mp, false, nil, values)
+	defer vec.Free(mp)
+
+	exec := newCountColumnExec(mp, AggIdOfCountColumn, true, []types.Type{types.T_int64.ToType()})
+	require.NoError(t, exec.GroupGrow(2))
+	defer exec.Free()
+	require.NoError(t, exec.BatchFill(0, groups, []*vector.Vector{vec}))
+
+	results, err := exec.Flush()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	vals := vector.MustFixedColNoTypeCheck[int64](results[0])
+	require.Equal(t, []int64{17, 17}, vals)
+	results[0].Free(mp)
+}
+
+func TestCountDistinctFixedIndexBatchAndMerge(t *testing.T) {
+	mp := mpool.MustNewZero()
+	makeExec := func() *countColumnExec {
+		exec := newCountColumnExec(
+			mp, AggIdOfCountColumn, true, []types.Type{types.T_int64.ToType()})
+		concrete := exec.(*countColumnExec)
+		require.NoError(t, concrete.GroupGrow(1024))
+		require.True(t, concrete.state[0].distinctFixedDeferred)
+		return concrete
+	}
+	fill := func(exec *countColumnExec, values []int64) {
+		vec := vector.NewVec(types.T_int64.ToType())
+		defer vec.Free(mp)
+		for _, value := range values {
+			require.NoError(t, vector.AppendFixed(vec, value, false, mp))
+		}
+		groups := make([]uint64, len(values))
+		for i := range groups {
+			groups[i] = 1
+		}
+		require.NoError(t, exec.PreflightBatchFill(0, groups, []*vector.Vector{vec}))
+		require.NoError(t, exec.BatchFill(0, groups, []*vector.Vector{vec}))
+	}
+
+	source := makeExec()
+	target := makeExec()
+	fill(source, []int64{1, 2, 2})
+	fill(target, []int64{2, 3})
+	require.NoError(t, target.PreflightBatchMerge(source, 0, []uint64{1}))
+	require.NoError(t, target.BatchMerge(source, 0, []uint64{1}))
+	// A fixed-index chunk has many valid-but-empty group rows.  Draining the
+	// whole chunk must skip those rows without requiring an index allocation for
+	// each one.
+	drain, err := target.BeginArgumentDrain(nil)
+	require.NoError(t, err)
+	var drained int
+	require.NoError(t, drain.ForEach(func(int, []byte) error {
+		drained++
+		return nil
+	}))
+	require.Equal(t, 3, drained)
+	drain.Abort()
+	var encoded bytes.Buffer
+	require.NoError(t, target.SaveIntermediateResultOfChunk(0, &encoded))
+	restored := newCountColumnExec(
+		mp, AggIdOfCountColumn, true,
+		[]types.Type{types.T_int64.ToType()},
+	).(*countColumnExec)
+	require.NoError(t, restored.UnmarshalFromReader(
+		bytes.NewReader(encoded.Bytes()), mp))
+	require.True(t, restored.state[0].distinctFixedDeferred)
+	restoredResult, err := restored.Flush()
+	require.NoError(t, err)
+	require.Equal(t, int64(3), vector.GetFixedAtNoTypeCheck[int64](restoredResult[0], 0))
+	for _, vec := range restoredResult {
+		vec.Free(mp)
+	}
+	restored.Free()
+
+	result, err := target.Flush()
+	require.NoError(t, err)
+	require.Equal(t, int64(3), vector.GetFixedAtNoTypeCheck[int64](result[0], 0))
+	for _, vec := range result {
+		vec.Free(mp)
+	}
+	source.Free()
+	target.Free()
+
+	// The batch-local admission key must include the state chunk as well as the
+	// row within that chunk. Otherwise group 1 and group AggBatchSize+1 would
+	// alias when they receive the same value.
+	crossChunk := newCountColumnExec(
+		mp, AggIdOfCountColumn, true, []types.Type{types.T_int64.ToType()}).(*countColumnExec)
+	require.NoError(t, crossChunk.GroupGrow(AggBatchSize+1))
+	require.True(t, crossChunk.state[0].distinctFixedDeferred)
+	require.True(t, crossChunk.state[1].distinctFixedDeferred)
+	vec := vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixed(vec, int64(42), false, mp))
+	require.NoError(t, vector.AppendFixed(vec, int64(42), false, mp))
+	groups := []uint64{1, AggBatchSize + 1}
+	require.NoError(t, crossChunk.PreflightBatchFill(0, groups, []*vector.Vector{vec}))
+	require.NoError(t, crossChunk.BatchFill(0, groups, []*vector.Vector{vec}))
+	vec.Free(mp)
+	crossResult, err := crossChunk.Flush()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), vector.GetFixedAtNoTypeCheck[int64](crossResult[0], 0))
+	require.Equal(t, int64(1), vector.GetFixedAtNoTypeCheck[int64](crossResult[1], 0))
+	for _, vec := range crossResult {
+		vec.Free(mp)
+	}
+	crossChunk.Free()
+	require.Zero(t, mp.CurrNB())
+}
+
+func TestCountDistinctFixedIndexRejectsMismatchedPayload(t *testing.T) {
+	mp := mpool.MustNewZero()
+	exec := newCountColumnExec(
+		mp, AggIdOfCountColumn, true, []types.Type{types.T_int64.ToType()},
+	).(*countColumnExec)
+	require.NoError(t, exec.GroupGrow(1024))
+	defer exec.Free()
+
+	// Replayed exact-distinct spill payloads must retain the fixed-width
+	// contract.  A malformed/retyped payload cannot be put in the compatibility
+	// skiplist because deferred iteration reads only the fixed index.
+	err := exec.InsertDistinctArgument(0, []byte{1})
+	require.ErrorIs(t, err, mpool.ErrAllocationAccountInvariant)
+	require.Zero(t, exec.state[0].argCnt[0])
+	keys, _, err := exec.DistinctArgumentStats()
+	require.NoError(t, err)
+	require.Zero(t, keys)
 }
 
 func testAggExec(t *testing.T,

--- a/pkg/sql/colexec/aggexec/count2_test.go
+++ b/pkg/sql/colexec/aggexec/count2_test.go
@@ -535,6 +535,38 @@ func TestCountDistinctBatchDeduplicatesWithinUnit(t *testing.T) {
 	results[0].Free(mp)
 }
 
+func TestCountDistinctFixedIndexChunksLargeBatch(t *testing.T) {
+	mp := mpool.MustNewZero()
+	const rows = AggBatchSize + 17
+	values := make([]int32, rows)
+	groups := make([]uint64, rows)
+	for i := range values {
+		values[i] = int32(i % (hashmap.UnitLimit*2 + 1))
+		groups[i] = 1
+	}
+	vec := testutil.NewInt32Vector(rows, types.T_int32.ToType(), mp, false, nil, values)
+	defer vec.Free(mp)
+
+	exec := newCountColumnExec(
+		mp, AggIdOfCountColumn, true, []types.Type{types.T_int32.ToType()},
+	).(*countColumnExec)
+	require.NoError(t, exec.GroupGrow(distinctFixedIndexMinGroups))
+	require.True(t, exec.state[0].distinctFixedDeferred)
+	require.NoError(t, exec.BatchFill(0, groups, []*vector.Vector{vec}))
+
+	results, err := exec.Flush()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t,
+		int64(hashmap.UnitLimit*2+1),
+		vector.GetFixedAtNoTypeCheck[int64](results[0], 0))
+	for _, result := range results {
+		result.Free(mp)
+	}
+	exec.Free()
+	require.Zero(t, mp.CurrNB())
+}
+
 func TestCountDistinctFixedIndexBatchAndMerge(t *testing.T) {
 	mp := mpool.MustNewZero()
 	makeExec := func() *countColumnExec {

--- a/pkg/sql/colexec/aggexec/distinct_fixed_index.go
+++ b/pkg/sql/colexec/aggexec/distinct_fixed_index.go
@@ -77,20 +77,27 @@ func (batch *distinctFixedBatch) reset() {
 	}
 }
 
-func (batch *distinctFixedBatch) seenOrInsert(group uint64, value uint64) bool {
+func (batch *distinctFixedBatch) seenOrInsert(group uint64, value uint64) (bool, error) {
+	if batch == nil {
+		return false, mpool.ErrAllocationAccountInvalid
+	}
 	const mask = distinctArgumentBatchSlots - 1
 	hash := distinctFixedHash(group, value)
-	for slot := int(hash & mask); ; slot = (slot + 1) & mask {
+	for probes, slot := 0, int(hash&mask); probes < len(batch.groups); probes, slot = probes+1, (slot+1)&mask {
 		storedGroup := batch.groups[slot]
 		if storedGroup == distinctFixedBatchEmptyGroup {
 			batch.groups[slot] = group
 			batch.values[slot] = value
-			return false
+			return false, nil
 		}
 		if storedGroup == group && batch.values[slot] == value {
-			return true
+			return true, nil
 		}
 	}
+	// The caller normally limits a work unit to hashmap.UnitLimit, leaving at
+	// least half of this table empty. Return a controlled error if that
+	// contract is violated instead of spinning forever on a full table.
+	return false, mpool.ErrAllocationAccountInvariant
 }
 
 func distinctFixedIndexWidth(

--- a/pkg/sql/colexec/aggexec/distinct_fixed_index.go
+++ b/pkg/sql/colexec/aggexec/distinct_fixed_index.go
@@ -1,0 +1,533 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggexec
+
+import (
+	"encoding/binary"
+	"math"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+)
+
+// A DISTINCT aggregate still needs its ordered skiplist for state merge and
+// serialization. The skiplist is, however, a poor membership index for the
+// hot row path: every duplicate probes O(log N) nodes. For one fixed-width
+// argument we can keep an exact open-addressing index alongside it.
+//
+// The index stores complete keys (not only a hash), so hash collisions can
+// never change the result. Its key/group and log columns are deliberately
+// separate: Go pads a {uint64,uint16} entry to 16 bytes and a
+// {uint64,int32} entry to 16 bytes, while the columnar representation uses 10
+// and 12 bytes per retained key respectively. All columns are allocated via
+// the aggregate account and are included in retainedBytes.
+const (
+	distinctFixedIndexInitialSlots = 256
+	distinctFixedIndexSmallSlots   = 16
+	// A state with fewer groups is normally a single-group or short-lived
+	// work set; retaining an index there costs more than it saves.  Partial
+	// states read from a parallel aggregate can have fewer than AggBatchSize
+	// rows while still containing thousands of groups, so the activation gate
+	// must be lower than the physical chunk size.
+	distinctFixedIndexMinGroups       = 1024
+	distinctFixedIndexLoadNumerator   = 7
+	distinctFixedIndexLoadDenominator = 10
+	distinctFixedIndexEmptyGroup      = math.MaxUint16
+	distinctFixedBatchEmptyGroup      = math.MaxUint64
+	// See preflightBatchMergeArgs: once a destination has published fixed
+	// keys, switching its representation under a tight hard account would need
+	// a second copy. Small accounts therefore use the existing spill-friendly
+	// merge path from the beginning.
+	distinctFixedIndexMinAccountLimit = 8 << 20
+)
+
+type distinctFixedIndex struct {
+	slotKeys   []uint64
+	slotGroups []uint16
+	groupHead  []int32
+	logKeys    []uint64
+	logNext    []int32
+	count      uint32
+	groupLimit int
+}
+
+// distinctFixedBatch is the allocation-free admission set for one immutable
+// UnitLimit work unit. It mirrors the resident index's exact (group, value)
+// identity, so fixed-width preflight never needs to hash raw byte slices or
+// compare the same row with up to eight earlier representatives.
+type distinctFixedBatch struct {
+	groups [distinctArgumentBatchSlots]uint64
+	values [distinctArgumentBatchSlots]uint64
+}
+
+func (batch *distinctFixedBatch) reset() {
+	for i := range batch.groups {
+		batch.groups[i] = distinctFixedBatchEmptyGroup
+	}
+}
+
+func (batch *distinctFixedBatch) seenOrInsert(group uint64, value uint64) bool {
+	const mask = distinctArgumentBatchSlots - 1
+	hash := distinctFixedHash(group, value)
+	for slot := int(hash & mask); ; slot = (slot + 1) & mask {
+		storedGroup := batch.groups[slot]
+		if storedGroup == distinctFixedBatchEmptyGroup {
+			batch.groups[slot] = group
+			batch.values[slot] = value
+			return false
+		}
+		if storedGroup == group && batch.values[slot] == value {
+			return true
+		}
+	}
+}
+
+func distinctFixedIndexWidth(
+	info *aggInfo,
+	c int,
+) int {
+	if c < distinctFixedIndexMinGroups {
+		return 0
+	}
+	width := distinctFixedKeyWidth(info)
+	if width == 0 {
+		return 0
+	}
+	return width
+}
+
+func distinctFixedKeyWidth(info *aggInfo) int {
+	if info == nil || !info.isDistinct || !info.saveArg ||
+		info.preserveDistinctInputOrder || len(info.argTypes) != 1 {
+		return 0
+	}
+	size := int(info.argTypes[0].GetSize())
+	if size <= 0 || size > 8 || !info.argTypes[0].IsFixedLen() {
+		return 0
+	}
+	return size
+}
+
+func decodeDistinctFixedKey(key []byte, width int) (uint16, uint64, bool) {
+	if width <= 0 || width > 8 || len(key) != kAggArgPrefixSz+width {
+		return 0, 0, false
+	}
+	var raw [8]byte
+	copy(raw[:], key[kAggArgPrefixSz:])
+	return binary.BigEndian.Uint16(key[:kAggArgPrefixSz]),
+		binary.LittleEndian.Uint64(raw[:]), true
+}
+
+func (ag *aggState) distinctFixedIndexContains(key []byte) bool {
+	if ag == nil || ag.distinctKeyWidth == 0 {
+		return false
+	}
+	group, value, ok := decodeDistinctFixedKey(key, ag.distinctKeyWidth)
+	return ok && ag.distinctIndex.lookup(group, value)
+}
+
+func distinctFixedHash(group uint64, key uint64) uint64 {
+	// SplitMix64's finalizer gives a cheap, high-quality probe start even when
+	// values are sequential and all rows belong to one aggregate group.
+	x := key ^ (uint64(group) + 0x9e3779b97f4a7c15)
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	return x ^ (x >> 31)
+}
+
+func (index *distinctFixedIndex) lookup(group uint16, key uint64) bool {
+	if index == nil || len(index.slotKeys) == 0 ||
+		len(index.slotKeys) != len(index.slotGroups) {
+		return false
+	}
+	mask := uint64(len(index.slotKeys) - 1)
+	for probes, slot := 0, distinctFixedHash(uint64(group), key)&mask; probes < len(index.slotGroups); probes, slot = probes+1, (slot+1)&mask {
+		storedGroup := index.slotGroups[slot]
+		if storedGroup == distinctFixedIndexEmptyGroup {
+			return false
+		}
+		if storedGroup == group && index.slotKeys[slot] == key {
+			return true
+		}
+	}
+	// A valid index always leaves an empty slot because ensureCapacityFor keeps
+	// the load below 70%.  Treat a fully occupied/corrupt table as a miss; the
+	// subsequent insertion path returns the controlled invariant error instead
+	// of spinning forever.
+	return false
+}
+
+func (index *distinctFixedIndex) allocate(
+	mp *mpool.MPool,
+	allocation *AllocationAccount,
+	slots int,
+) ([]uint64, []uint16, error) {
+	if slots <= 0 || slots&(slots-1) != 0 {
+		return nil, nil, mpool.ErrAllocationAccountInvalid
+	}
+	var (
+		keys   []uint64
+		groups []uint16
+		err    error
+	)
+	if allocation == nil {
+		keys, err = mpool.MakeSlice[uint64](slots, mp, true)
+	} else {
+		keys, err = makeAccountedScratch[uint64](allocation, mp, slots)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	if allocation == nil {
+		groups, err = mpool.MakeSlice[uint16](slots, mp, true)
+	} else {
+		groups, err = makeAccountedScratch[uint16](allocation, mp, slots)
+	}
+	if err != nil {
+		mpool.FreeSlice(mp, keys)
+		return nil, nil, err
+	}
+	for i := range groups {
+		groups[i] = distinctFixedIndexEmptyGroup
+	}
+	return keys, groups, nil
+}
+
+func (index *distinctFixedIndex) allocateGroupHeads(
+	mp *mpool.MPool,
+	allocation *AllocationAccount,
+) error {
+	if len(index.groupHead) != 0 {
+		return nil
+	}
+	var (
+		heads []int32
+		err   error
+	)
+	groupLimit := index.groupLimit
+	if groupLimit <= 0 || groupLimit > AggBatchSize {
+		groupLimit = AggBatchSize
+	}
+	if allocation == nil {
+		heads, err = mpool.MakeSlice[int32](groupLimit, mp, true)
+	} else {
+		heads, err = makeAccountedScratch[int32](allocation, mp, groupLimit)
+	}
+	if err != nil {
+		return err
+	}
+	for i := range heads {
+		heads[i] = -1
+	}
+	index.groupHead = heads
+	return nil
+}
+
+func (index *distinctFixedIndex) ensureLogCapacity(
+	mp *mpool.MPool,
+	allocation *AllocationAccount,
+	required uint64,
+) error {
+	if required <= uint64(cap(index.logKeys)) {
+		return nil
+	}
+	capacity := uint64(cap(index.logKeys))
+	if capacity == 0 {
+		capacity = distinctFixedIndexInitialSlots
+	}
+	for capacity < required {
+		if capacity > math.MaxInt/2 {
+			return mpool.ErrAllocationAllocatorLimit
+		}
+		capacity *= 2
+	}
+	if capacity > uint64(math.MaxInt) {
+		return mpool.ErrAllocationAllocatorLimit
+	}
+	var (
+		keys []uint64
+		next []int32
+		err  error
+	)
+	if allocation == nil {
+		keys, err = mpool.MakeSlice[uint64](int(capacity), mp, true)
+	} else {
+		keys, err = makeAccountedScratch[uint64](allocation, mp, int(capacity))
+	}
+	if err != nil {
+		return err
+	}
+	if allocation == nil {
+		next, err = mpool.MakeSlice[int32](int(capacity), mp, true)
+	} else {
+		next, err = makeAccountedScratch[int32](allocation, mp, int(capacity))
+	}
+	if err != nil {
+		mpool.FreeSlice(mp, keys)
+		return err
+	}
+	copy(keys, index.logKeys)
+	copy(next, index.logNext)
+	oldKeys, oldNext := index.logKeys, index.logNext
+	index.logKeys, index.logNext = keys, next
+	if cap(oldKeys) > 0 {
+		mpool.FreeSlice(mp, oldKeys)
+	}
+	if cap(oldNext) > 0 {
+		mpool.FreeSlice(mp, oldNext)
+	}
+	return nil
+}
+
+func (index *distinctFixedIndex) free(mp *mpool.MPool) {
+	if index == nil {
+		return
+	}
+	if cap(index.slotKeys) > 0 {
+		mpool.FreeSlice(mp, index.slotKeys)
+	}
+	if cap(index.slotGroups) > 0 {
+		mpool.FreeSlice(mp, index.slotGroups)
+	}
+	if cap(index.groupHead) > 0 {
+		mpool.FreeSlice(mp, index.groupHead)
+	}
+	if cap(index.logKeys) > 0 {
+		mpool.FreeSlice(mp, index.logKeys)
+	}
+	if cap(index.logNext) > 0 {
+		mpool.FreeSlice(mp, index.logNext)
+	}
+	index.slotKeys = nil
+	index.slotGroups = nil
+	index.groupHead = nil
+	index.logKeys = nil
+	index.logNext = nil
+	index.count = 0
+	index.groupLimit = 0
+}
+
+func (index *distinctFixedIndex) grow(
+	mp *mpool.MPool,
+	allocation *AllocationAccount,
+) error {
+	oldSlots := len(index.slotKeys)
+	if oldSlots == 0 {
+		initial := distinctFixedIndexInitialSlots
+		if index.groupLimit > 0 && index.groupLimit < 64 {
+			initial = distinctFixedIndexSmallSlots
+		}
+		newKeys, newGroups, err := index.allocate(mp, allocation, initial)
+		if err != nil {
+			return err
+		}
+		if err = index.allocateGroupHeads(mp, allocation); err != nil {
+			mpool.FreeSlice(mp, newKeys)
+			mpool.FreeSlice(mp, newGroups)
+			return err
+		}
+		index.slotKeys = newKeys
+		index.slotGroups = newGroups
+		return nil
+	}
+	if oldSlots > math.MaxInt/2 {
+		return mpool.ErrAllocationAllocatorLimit
+	}
+	newKeys, newGroups, err := index.allocate(mp, allocation, oldSlots*2)
+	if err != nil {
+		return err
+	}
+	mask := uint64(len(newKeys) - 1)
+	for oldSlot, oldGroup := range index.slotGroups {
+		if oldGroup == distinctFixedIndexEmptyGroup {
+			continue
+		}
+		oldKey := index.slotKeys[oldSlot]
+		for slot := distinctFixedHash(uint64(oldGroup), oldKey) & mask; ; slot = (slot + 1) & mask {
+			if newGroups[slot] == distinctFixedIndexEmptyGroup {
+				newGroups[slot] = oldGroup
+				newKeys[slot] = oldKey
+				break
+			}
+		}
+	}
+	oldKeys, oldGroups := index.slotKeys, index.slotGroups
+	index.slotKeys, index.slotGroups = newKeys, newGroups
+	if cap(oldKeys) > 0 {
+		mpool.FreeSlice(mp, oldKeys)
+	}
+	if cap(oldGroups) > 0 {
+		mpool.FreeSlice(mp, oldGroups)
+	}
+	return nil
+}
+
+func (index *distinctFixedIndex) ensureCapacityFor(
+	mp *mpool.MPool,
+	allocation *AllocationAccount,
+	extra uint64,
+) error {
+	if extra == 0 {
+		return nil
+	}
+	if extra > math.MaxUint32 {
+		return mpool.ErrAllocationAllocatorLimit
+	}
+	if uint64(index.count) > math.MaxUint32-extra {
+		return mpool.ErrAllocationAllocatorLimit
+	}
+	required := uint64(index.count) + extra
+	if len(index.slotKeys) == 0 {
+		if err := index.grow(mp, allocation); err != nil {
+			return err
+		}
+	}
+	for required*distinctFixedIndexLoadDenominator >=
+		uint64(len(index.slotKeys))*distinctFixedIndexLoadNumerator {
+		if err := index.grow(mp, allocation); err != nil {
+			return err
+		}
+	}
+	return index.ensureLogCapacity(mp, allocation, required)
+}
+
+// prepare checks for an existing key and ensures one free slot for a new key.
+// The slot is not published until insert, so a later skiplist allocation
+// failure cannot leave the acceleration index ahead of the source of truth.
+func (index *distinctFixedIndex) prepare(
+	mp *mpool.MPool,
+	allocation *AllocationAccount,
+	group uint16,
+	key uint64,
+) (bool, error) {
+	if index.lookup(group, key) {
+		return true, nil
+	}
+	if err := index.ensureCapacityFor(mp, allocation, 1); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (index *distinctFixedIndex) insert(group uint16, key uint64) error {
+	if index == nil || len(index.slotKeys) == 0 ||
+		len(index.slotKeys) != len(index.slotGroups) ||
+		int(group) >= len(index.groupHead) ||
+		uint64(index.count) >= uint64(len(index.logKeys)) ||
+		len(index.logKeys) != len(index.logNext) {
+		return mpool.ErrAllocationAccountInvariant
+	}
+	mask := uint64(len(index.slotKeys) - 1)
+	for probes, slot := 0, distinctFixedHash(uint64(group), key)&mask; probes < len(index.slotGroups); probes, slot = probes+1, (slot+1)&mask {
+		if index.slotGroups[slot] == distinctFixedIndexEmptyGroup {
+			index.slotGroups[slot] = group
+			index.slotKeys[slot] = key
+			index.logKeys[index.count] = key
+			index.logNext[index.count] = index.groupHead[group]
+			index.groupHead[group] = int32(index.count)
+			index.count++
+			return nil
+		}
+		if index.slotGroups[slot] == group && index.slotKeys[slot] == key {
+			return nil
+		}
+	}
+	return mpool.ErrAllocationAccountInvariant
+}
+
+func (index *distinctFixedIndex) forEach(group uint16, fn func(uint64) error) error {
+	if index == nil || fn == nil || int(group) >= len(index.groupHead) ||
+		len(index.logKeys) != len(index.logNext) {
+		return mpool.ErrAllocationAccountInvalid
+	}
+	visited := uint32(0)
+	for pos := index.groupHead[group]; pos >= 0; pos = index.logNext[pos] {
+		if visited >= index.count {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		visited++
+		if int(pos) >= len(index.logKeys) {
+			return mpool.ErrAllocationAccountInvariant
+		}
+		if err := fn(index.logKeys[pos]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mergeInto imports one source group directly into a destination fixed index.
+// BatchMerge has already admitted the exact candidate count, so this path can
+// avoid rebuilding the [group|value] key and re-entering the skiplist wrapper
+// for every value.  prepare is retained as the safety boundary for callers
+// that do not share the normal preflight protocol: it is a no-op after the
+// reservation made by preflight and still returns a controlled capacity error
+// instead of allowing insert to observe an unallocated table.
+func (index *distinctFixedIndex) mergeInto(
+	mp *mpool.MPool,
+	allocation *AllocationAccount,
+	targetGroup uint16,
+	source *distinctFixedIndex,
+	sourceGroup uint16,
+) (uint32, error) {
+	if index == nil || source == nil ||
+		int(targetGroup) >= index.groupLimit ||
+		int(sourceGroup) >= source.groupLimit ||
+		len(source.logKeys) != len(source.logNext) {
+		return 0, mpool.ErrAllocationAccountInvariant
+	}
+	// An empty source has never needed to allocate its optional index columns.
+	// It is still a valid fixed-width state and contributes no keys.
+	if len(source.groupHead) == 0 {
+		return 0, nil
+	}
+	var added uint32
+	visited := uint32(0)
+	for pos := source.groupHead[sourceGroup]; pos >= 0; pos = source.logNext[pos] {
+		if visited >= source.count {
+			return added, mpool.ErrAllocationAccountInvariant
+		}
+		visited++
+		if int(pos) >= len(source.logKeys) {
+			return added, mpool.ErrAllocationAccountInvariant
+		}
+		value := source.logKeys[pos]
+		duplicate, err := index.prepare(
+			mp, allocation, targetGroup, value)
+		if err != nil {
+			return added, err
+		}
+		if duplicate {
+			continue
+		}
+		if err := index.insert(targetGroup, value); err != nil {
+			return added, err
+		}
+		added++
+	}
+	return added, nil
+}
+
+func (index *distinctFixedIndex) retainedBytes() uint64 {
+	if index == nil {
+		return 0
+	}
+	return uint64(cap(index.slotKeys))*8 +
+		uint64(cap(index.slotGroups))*2 +
+		uint64(cap(index.groupHead))*4 +
+		uint64(cap(index.logKeys))*8 +
+		uint64(cap(index.logNext))*4
+}

--- a/pkg/sql/colexec/aggexec/distinct_fixed_index_test.go
+++ b/pkg/sql/colexec/aggexec/distinct_fixed_index_test.go
@@ -132,3 +132,15 @@ func TestDistinctFixedIndexProbeStopsOnFullMalformedTable(t *testing.T) {
 	require.False(t, index.lookup(0, 99))
 	require.ErrorIs(t, index.insert(0, 99), mpool.ErrAllocationAccountInvariant)
 }
+
+func TestDistinctFixedBatchProbeStopsOnFullTable(t *testing.T) {
+	var batch distinctFixedBatch
+	batch.reset()
+	for i := range batch.groups {
+		batch.groups[i] = uint64(i)
+		batch.values[i] = uint64(i)
+	}
+
+	_, err := batch.seenOrInsert(1, ^uint64(0))
+	require.ErrorIs(t, err, mpool.ErrAllocationAccountInvariant)
+}

--- a/pkg/sql/colexec/aggexec/distinct_fixed_index_test.go
+++ b/pkg/sql/colexec/aggexec/distinct_fixed_index_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggexec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/arenaskl"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/stretchr/testify/require"
+)
+
+func fixedIndexKey(group uint16, value uint64) []byte {
+	key := make([]byte, kAggArgPrefixSz+8)
+	binary.BigEndian.PutUint16(key, group)
+	binary.LittleEndian.PutUint64(key[kAggArgPrefixSz:], value)
+	return key
+}
+
+func TestDistinctFixedIndexExactMembershipAndGrowth(t *testing.T) {
+	mp := mpool.MustNewZero()
+	index := distinctFixedIndex{}
+
+	const count = distinctFixedIndexInitialSlots * 3
+	for i := 0; i < count; i++ {
+		key := fixedIndexKey(uint16(i%7), uint64(i/7))
+		group, value, ok := decodeDistinctFixedKey(key, 8)
+		require.True(t, ok)
+		duplicate, err := index.prepare(mp, nil, group, value)
+		require.NoError(t, err)
+		require.False(t, duplicate)
+		require.NoError(t, index.insert(group, value))
+	}
+
+	require.GreaterOrEqual(t, len(index.slotKeys), count)
+	require.Equal(t, len(index.slotKeys), len(index.slotGroups))
+	require.Equal(t, uint32(count), index.count)
+	for i := 0; i < count; i++ {
+		key := fixedIndexKey(uint16(i%7), uint64(i/7))
+		group, value, ok := decodeDistinctFixedKey(key, 8)
+		require.True(t, ok)
+		require.True(t, index.lookup(group, value))
+		duplicate, err := index.prepare(mp, nil, group, value)
+		require.NoError(t, err)
+		require.True(t, duplicate)
+	}
+	require.False(t, index.lookup(0, ^uint64(0)))
+
+	index.free(mp)
+	require.Empty(t, index.slotKeys)
+	require.Empty(t, index.slotGroups)
+}
+
+func TestDistinctFixedIndexDoesNotChangeSkiplistDuplicateContract(t *testing.T) {
+	mp := mpool.MustNewZero()
+	buf, err := mp.Alloc(16*1024, true)
+	require.NoError(t, err)
+	list := arenaskl.NewSkiplist(arenaskl.NewArena(buf), bytes.Compare)
+	require.NoError(t, list.Add(fixedIndexKey(1, 42), nil))
+	require.ErrorIs(t, list.Add(fixedIndexKey(1, 42), nil), arenaskl.ErrRecordExists)
+	mp.Free(buf)
+}
+
+func TestDistinctFixedIndexMergeIntoDeduplicatesPerGroup(t *testing.T) {
+	mp := mpool.MustNewZero()
+	source := distinctFixedIndex{groupLimit: 4}
+	target := distinctFixedIndex{groupLimit: 4}
+	insert := func(index *distinctFixedIndex, group uint16, value uint64) {
+		t.Helper()
+		duplicate, err := index.prepare(mp, nil, group, value)
+		require.NoError(t, err)
+		if duplicate {
+			return
+		}
+		require.NoError(t, index.insert(group, value))
+	}
+
+	insert(&source, 1, 10)
+	insert(&source, 1, 20)
+	insert(&source, 2, 30)
+	insert(&target, 3, 20)
+
+	added, err := target.mergeInto(mp, nil, 3, &source, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), added,
+		"the value already present in the destination group is a duplicate")
+	added, err = target.mergeInto(mp, nil, 3, &source, 2)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), added,
+		"a value from another source group is new for the destination")
+
+	var got []uint64
+	require.NoError(t, target.forEach(3, func(value uint64) error {
+		got = append(got, value)
+		return nil
+	}))
+	require.ElementsMatch(t, []uint64{10, 20, 30}, got)
+	target.free(mp)
+	source.free(mp)
+}
+
+func TestDistinctFixedIndexProbeStopsOnFullMalformedTable(t *testing.T) {
+	// A valid table is kept below the 70% load factor.  A corrupt restored state
+	// can violate that invariant, so a miss must still terminate instead of
+	// looping around a full table forever.
+	const slots = 16
+	index := distinctFixedIndex{
+		slotKeys:   make([]uint64, slots),
+		slotGroups: make([]uint16, slots),
+		groupHead:  make([]int32, 1),
+		logKeys:    make([]uint64, slots),
+		logNext:    make([]int32, slots),
+		groupLimit: 1,
+	}
+	for i := range index.slotGroups {
+		index.slotGroups[i] = 0
+	}
+	require.False(t, index.lookup(0, 99))
+	require.ErrorIs(t, index.insert(0, 99), mpool.ErrAllocationAccountInvariant)
+}

--- a/pkg/sql/colexec/aggexec/distinct_spill.go
+++ b/pkg/sql/colexec/aggexec/distinct_spill.go
@@ -41,6 +41,7 @@ func initBoundedDistinctWorkState(
 	length int32,
 	capacity int32,
 	allocation *AllocationAccount,
+	distinctKeyWidth int,
 ) error {
 	if state == nil || mp == nil || length < 0 || capacity <= 0 ||
 		length > capacity || capacity > AggBatchSize {
@@ -62,6 +63,9 @@ func initBoundedDistinctWorkState(
 	state.length = length
 	state.capacity = capacity
 	state.allocation = allocation
+	state.distinctKeyWidth = distinctKeyWidth
+	state.distinctFixedDeferred = distinctKeyWidth > 0
+	state.distinctIndex.groupLimit = int(capacity)
 	state.argCnt = counts
 	state.argbuf = buffer
 	state.argSkl = arenaskl.NewSkiplist(arenaskl.NewArena(buffer), bytes.Compare)
@@ -115,14 +119,28 @@ func (exec *countColumnExec) DistinctArgumentStats() (
 			}
 			keys += uint64(count)
 		}
-		resident := uint64(cap(state.argbuf)) + uint64(cap(state.argScratch))
-		countBytes := uint64(cap(state.argCnt)) * uint64(4)
-		if resident > math.MaxUint64-countBytes ||
-			retainedBytes > math.MaxUint64-resident-countBytes {
+		argbufBytes := uint64(cap(state.argbuf))
+		scratchBytes := uint64(cap(state.argScratch))
+		countCapacity := uint64(cap(state.argCnt))
+		if countCapacity > math.MaxUint64/4 {
 			return 0, 0, moerr.NewInternalErrorNoCtx(
 				"exact distinct retained byte count overflow")
 		}
-		retainedBytes += resident + countBytes
+		countBytes := countCapacity * 4
+		indexBytes := state.distinctIndex.retainedBytes()
+		if countBytes > math.MaxUint64-indexBytes ||
+			argbufBytes > math.MaxUint64-indexBytes-countBytes ||
+			scratchBytes > math.MaxUint64-indexBytes-countBytes-argbufBytes {
+			return 0, 0, moerr.NewInternalErrorNoCtx(
+				"exact distinct retained byte count overflow")
+		}
+		resident := argbufBytes + scratchBytes
+		accounted := indexBytes + countBytes + resident
+		if retainedBytes > math.MaxUint64-accounted {
+			return 0, 0, moerr.NewInternalErrorNoCtx(
+				"exact distinct retained byte count overflow")
+		}
+		retainedBytes += accounted
 	}
 	return keys, retainedBytes, nil
 }
@@ -194,6 +212,7 @@ func (d *countDistinctArgumentDrain) Commit() error {
 			state.length,
 			state.capacity,
 			d.replacement,
+			state.distinctKeyWidth,
 		); err != nil {
 			return err
 		}
@@ -255,6 +274,7 @@ func (exec *countColumnExec) RehomeDistinctArgumentState(
 		var replacement aggState
 		if err := initBoundedDistinctWorkState(
 			&replacement, exec.mp, state.length, state.capacity, allocation,
+			state.distinctKeyWidth,
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/colexec/aggexec/distinct_spill_test.go
+++ b/pkg/sql/colexec/aggexec/distinct_spill_test.go
@@ -224,7 +224,11 @@ func TestCountDistinctSpillStateRejectsInvalidTransitions(t *testing.T) {
 	require.Error(t, exec.AddDistinctCountContribution(0, math.MaxUint64, nil))
 	require.NoError(t, exec.AddDistinctCountContribution(0, math.MaxInt64, nil))
 	require.ErrorContains(t, exec.AddDistinctCountContribution(0, 1, nil), "overflow")
-	require.NoError(t, exec.InsertDistinctArgument(0, []byte("key")))
+	// Fixed-width exact-distinct states accept the canonical payload emitted by
+	// their drain.  An arbitrary byte string would violate the type contract;
+	// malformed/retyped payloads are rejected before publication.
+	value := int64(7)
+	require.NoError(t, exec.InsertDistinctArgument(0, types.EncodeInt64(&value)))
 	require.ErrorContains(t, exec.RehomeDistinctArgumentState(nil), "non-empty")
 
 	drain, err := exec.BeginArgumentDrain(nil)

--- a/pkg/sql/colexec/aggexec/sum_decimal_fast.go
+++ b/pkg/sql/colexec/aggexec/sum_decimal_fast.go
@@ -18,8 +18,6 @@ package aggexec
 // Eliminates interface boxing, type switches, and per-add overflow checks.
 
 import (
-	"slices"
-
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -112,7 +110,7 @@ func (exec *sumDecimal64FastExec) Fill(groupIndex int, row int, vectors []*vecto
 
 func (exec *sumDecimal64FastExec) BulkFill(groupIndex int, vectors []*vector.Vector) error {
 	if exec.IsDistinct() {
-		return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
+		return exec.bulkFillDistinctArgs(groupIndex, vectors)
 	}
 	return exec.bulkFillSingleGroup(groupIndex, vectors)
 }
@@ -455,7 +453,7 @@ func (exec *sumDecimal128FastExec) Fill(groupIndex int, row int, vectors []*vect
 
 func (exec *sumDecimal128FastExec) BulkFill(groupIndex int, vectors []*vector.Vector) error {
 	if exec.IsDistinct() {
-		return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
+		return exec.bulkFillDistinctArgs(groupIndex, vectors)
 	}
 	return exec.bulkFillSingleGroup(groupIndex, vectors)
 }

--- a/pkg/sql/colexec/aggexec/sumavg2.go
+++ b/pkg/sql/colexec/aggexec/sumavg2.go
@@ -16,7 +16,6 @@ package aggexec
 
 import (
 	"math/bits"
-	"slices"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -262,7 +261,7 @@ func (exec *sumAvgExec[T, A]) removeWindowRow(row int, vectors []*vector.Vector)
 
 func (exec *sumAvgExec[T, A]) BulkFill(groupIndex int, vectors []*vector.Vector) error {
 	if exec.IsDistinct() {
-		return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
+		return exec.bulkFillDistinctArgs(groupIndex, vectors)
 	}
 	if exec.isSum {
 		return exec.bulkFillSumSingleGroup(groupIndex, vectors)
@@ -1188,7 +1187,7 @@ func (exec *sumAvgDecExec[A, S]) removeWindowRow(row int, vectors []*vector.Vect
 
 func (exec *sumAvgDecExec[A, S]) BulkFill(groupIndex int, vectors []*vector.Vector) error {
 	if exec.IsDistinct() {
-		return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
+		return exec.bulkFillDistinctArgs(groupIndex, vectors)
 	}
 	if exec.isSum {
 		return exec.bulkFillSumSingleGroup(groupIndex, vectors)

--- a/pkg/sql/colexec/aggexec/vardev2.go
+++ b/pkg/sql/colexec/aggexec/vardev2.go
@@ -72,6 +72,9 @@ func (exec *varStdDevExec[T, A]) Fill(groupIndex int, row int, vectors []*vector
 }
 
 func (exec *varStdDevExec[T, A]) BulkFill(groupIndex int, vectors []*vector.Vector) error {
+	if exec.IsDistinct() {
+		return exec.bulkFillDistinctArgs(groupIndex, vectors)
+	}
 	return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
 }
 

--- a/pkg/sql/colexec/group/distinct_spill_test.go
+++ b/pkg/sql/colexec/group/distinct_spill_test.go
@@ -1805,10 +1805,14 @@ func TestIntermediateDistinctSpillTerminalLeafContinuesWithinHardAccount(t *test
 			groups.SetRowCount(1)
 			groupValues := vector.MustFixedColNoTypeCheck[int32](groups.Vecs[0])
 			const records = 20_000
-			var payload [8]byte
+			var payload [4]byte
 			for row := 0; row < records; row++ {
 				groupValues[0] = int32(row % 32)
-				binary.BigEndian.PutUint64(payload[:], uint64(row))
+				// countDistinctAgg(1) uses an int32 argument.  The spill
+				// payload must use that argument's canonical fixed-width
+				// representation; an arbitrary 8-byte test payload would be a
+				// malformed record for the fixed-index recovery path.
+				binary.LittleEndian.PutUint32(payload[:], uint32(row))
 				_, err := controller.writeRecord(
 					partition.writer,
 					test.routeHash(row),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27672

## What this PR does / why we need it:

ClickBench Q10 is dominated by exact COUNT(DISTINCT) state maintenance. The old path probed an arena-backed ordered skiplist for every candidate and rebuilt that representation during state merges. This change keeps the existing skiplist wire/compatibility path for legacy and variable-width states, while adding an exact columnar open-addressing membership/index for one fixed-width DISTINCT argument.

The index stores complete (group, value) keys, so hash collisions cannot change results. Batch preflight performs bounded local deduplication and reserves the exact index/log capacity before publication; BatchFill reuses that admission decision. Fixed-state merges import keys directly, including cross-state-chunk groups, and spill/recovery preserves the fixed-width payload contract. Empty optional indexes can fall back before publication under a tight hard account; published states never switch representation silently. Malformed payloads and corrupt full-table probes fail with bounded invariant errors. Signed zero remains canonicalized and NaN payload identity remains unchanged from the existing aggregate key contract.

## Test plan

- `make -j12`
- `GOWORK=off .agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=300s ./pkg/sql/colexec/aggexec ./pkg/sql/colexec/group`
- `GOWORK=off .agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=300s ./pkg/sql/colexec/aggexec ./pkg/sql/colexec/group`
- Focused tests cover batch-local duplicates, cross-state-chunk group identity, merge deduplication, fixed-state serialization round-trip, NaN/plus-or-minus-zero equivalence with the legacy path, mismatched spill payload rejection, empty fixed rows, and a full malformed index probe.
- On 10.222.1.55, latest binary was run against 42,203,164 rows: `RegionID + COUNT(DISTINCT UserID)` completed in 0.844--0.875s (three runs); text-group surrogate completed in 1.077--1.109s; the existing composite SUM/COUNT/AVG/DISTINCT query completed in 1.842--2.047s.
- The official DuckDB Q10 is `MobilePhoneModel + COUNT(DISTINCT UserID)`; the checked-in 55 fixture has no `MobilePhoneModel`, so the text surrogate is reported separately rather than presented as an apples-to-apples result.
