### PR TITLE
perf: share vector decodes across fused INCLUDE reads

### DIFF
--- a/docs/design/fused_vector_decode_sharing.md
+++ b/docs/design/fused_vector_decode_sharing.md
@@ -1,0 +1,98 @@
+# Selected-vector sharing in fused reads
+
+- Status: in progress; approved in the conversation before implementation.
+- Base: main `9f87b6249889107c3c108c133a4c3c8f3bc273ee`.
+- Implementation branch: `perf/fused-vector-decode-sharing`, delivered in one PR.
+- Related issue: [#24097](https://github.com/matrixorigin/matrixone/issues/24097), following #28413 and #28434; does not close the umbrella issue.
+
+## Contract and scope
+
+Fused INCLUDE reads load filter columns, a vector and projected columns in one
+IOVector. The existing sharing guard accepts only single-entry requests, so
+concurrent fused reads cannot reuse uncached decoded vectors. Share exactly one
+selected vector entry at any position without changing the combined request,
+column order, policy, exact filtering, ranking or result materialization.
+
+The selected data is immutable and scoped to the complete IOVector. Only its
+conversion/validation result is shared; I/O and later cache updates remain local
+to each request. Do not include entry position, sibling columns, query vectors
+or predicates in the existing physical-extent/codec sharing key.
+
+The user chose one vector entry, not arbitrary multi-entry sharing. No buffer
+recycling, new pool, decoded idle cache, chunk-native fused execution, format
+change, additional parallelism or request splitting is included.
+
+## Integration
+
+Preserve ReadOneBlock and its existing single-column option. Add
+ReadOneBlockWithScopedDecode with a selected requested-list position, validated
+against the column/type inputs. The private builder marks only that requested
+position when it resolves to a normal stored array column. Missing/synthetic
+columns and custom factories remain unmarked. Mark before physical-entry
+compaction so a preceding synthetic column cannot shift the target.
+
+Thread a private selected-position argument through readColumnsData. Ordinary
+callers pass -1; LoadColumnsDataIntoAndTopN passes len(columns), the vector's
+position immediately after its filter columns. The public fused loader signature
+is unchanged. Other array columns are not implicitly opted in.
+
+After the initial memory-cache lookup, prepareSharedDecode scans for a sole
+nonempty sharing codec. Zero or multiple marked entries use ordinary reads.
+An already satisfied or otherwise ineligible selected entry is not wrapped.
+Keep existing service, policy, custom-cache, size, buffer and stream exclusions.
+
+Retain only the selected physical index, original converter and one lease;
+there is no collection of per-entry state. Preserve the existing read guard
+through all remaining sibling work and deferred cache updates. Finalize against
+the current entry at that index because storage helpers can replace entry values.
+Restore the converter and attach the ticket to the final result, or release the
+ticket if no result remains. ObjectIO relocation copies the complete IOEntry.
+
+## Ownership and failure closure
+
+| Audit | Required behavior |
+|---|---|
+| Q1: ownership | Each successful request owns its normal decoded reference and one ticket in the complete IOVector. Existing success/error cleanup releases both. A valid shared result survives an unrelated sibling or cache-update failure in another request. |
+| Q2: termination | The existing 200 ms follower bound, independent caller cancellation and Close behavior remain unchanged. The enclosing read guard spans sibling conversion and deferred updates; Close does not wait for Top-K consumers. |
+| Q3: bounds | Constant new per-request state; retain existing initial byte budget, 64 generations and 128 participants per generation. No new idle retention or capacity waits. Unmarked sibling allocations remain under their existing ownership. |
+
+The registry state machine, concrete validated-data representation and metrics
+remain unchanged. A failure before the selected converter runs must still end
+the read guard. A later failure must release an already acquired ticket through
+normal caller cleanup, not poison a complete vector result used by another query.
+Retry paths must not leave a converter wrapper or ticket attached to a stale
+entry copy. All-memory-hit reads still return before sharing preparation.
+
+## Alternatives and compatibility
+
+Splitting the vector into a separate request would discard the fused read's
+I/O benefit and is rejected. General multi-entry sharing adds wrapper collection
+and ordering/lifecycle state without helping this single-vector consumer yet.
+The selected-entry extension reuses the existing bounded sharing mechanism.
+
+There are no SQL, wire, catalog, storage or configuration changes. Other
+FileService implementations ignore the optional descriptor as before. Existing
+single-column and chunk-native callers retain their behavior. Rollback removes
+the fused opt-in without any data migration.
+
+## Validation and acceptance
+
+Use small combined-read fixtures with the target first, middle and last. Cover
+partial memory hits in either direction, all-hit and unmarked controls, multiple
+markers, invalid positions, synthetic relocation and other unmarked array columns.
+Exercise direct storage reads, streamed full-object capture and per-entry fallback,
+including converter restoration and success/error cleanup.
+
+Use barriers for errors before/after conversion, cancellation of either role,
+timeouts, Close, deferred-update failure and next-generation reuse. Reuse the
+existing sharing state-machine tests. A real fused consumer must retain independent
+filters, query vectors, thresholds and projected results while sharing identical
+validated vector backing; selector/materialization failures must release it.
+
+Run owning packages, focused adaptive race stress, coverage, relevant IVF INCLUDE
+BVT and full SCA. For performance, compare five matched main/candidate samples
+using the same combined request and legacy LZ4 data under pinned-cache pressure.
+Require one vector conversion across admitted overlapping readers, lower CPU and
+decoded allocation, and unchanged I/O request shape. Hot-cache, single-reader and
+unmarked controls must remain within 5% median regression. No unmeasured workload
+or Wiki-10M performance claim is made.

--- a/docs/design/fused_vector_decode_sharing.md
+++ b/docs/design/fused_vector_decode_sharing.md
@@ -1,6 +1,6 @@
 # Selected-vector sharing in fused reads
 
-- Status: in progress; approved in the conversation before implementation.
+- Status: implemented; approved in the conversation before implementation.
 - Base: main `9f87b6249889107c3c108c133a4c3c8f3bc273ee`.
 - Implementation branch: `perf/fused-vector-decode-sharing`, delivered in one PR.
 - Related issue: [#24097](https://github.com/matrixorigin/matrixone/issues/24097), following #28413 and #28434; does not close the umbrella issue.

--- a/pkg/fileservice/selected_decode_bench_test.go
+++ b/pkg/fileservice/selected_decode_bench_test.go
@@ -1,0 +1,138 @@
+//go:build linux || darwin
+
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"syscall"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
+	"github.com/pierrec/lz4/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// The fixture models a combined filter/vector/projection request. Overlap is
+// in consumer lifetimes, not scheduling: all eight IOVectors remain live until
+// the last read completes. Storage ranges and decoded native bytes are counted
+// separately from Go allocations; this is not a SQL workload benchmark.
+func BenchmarkSelectedDecode(b *testing.B) {
+	for _, mode := range []string{"overlap", "single", "unmarked", "hot_cache"} {
+		b.Run(mode, func(b *testing.B) {
+			ctx := context.Background()
+			capacity := toml.ByteSize(4 << 20)
+			fs, err := NewS3FS(ctx, ObjectStorageArguments{Name: "fused-bench", Endpoint: "disk", Bucket: b.TempDir()},
+				CacheConfig{MemoryCapacity: &capacity}, nil, false, false)
+			require.NoError(b, err)
+			b.Cleanup(func() { fs.Close(ctx) })
+			raw := make([]byte, 1<<20)
+			for i := 0; i < len(raw)/4; i++ {
+				binary.LittleEndian.PutUint32(raw[i*4:], uint32(i%768)*7919)
+			}
+			compressed := make([]byte, lz4.CompressBlockBound(len(raw)))
+			n, err := lz4.CompressBlock(raw, compressed, nil)
+			require.NoError(b, err)
+			require.Positive(b, n)
+			payload := append(bytes.Repeat([]byte{1}, 32), compressed[:n]...)
+			payload = append(payload, bytes.Repeat([]byte{2}, 128)...)
+			storage := &selectedDecodeBenchStorage{data: payload}
+			fs.storage = storage
+			if mode != "hot_cache" {
+				pinned := fs.AllocateCacheData(ctx, int(capacity))
+				b.Cleanup(pinned.Release)
+			}
+			var conversions, decodedBytes int64
+			convert := func(ctx context.Context, _ io.Reader, data []byte, a CacheDataAllocator) (fscache.Data, error) {
+				conversions++
+				out := a.AllocateCacheData(ctx, len(raw))
+				decodedBytes += out.Capacity()
+				if _, err := lz4.UncompressBlock(data, out.Bytes()); err != nil {
+					out.Release()
+					return nil, err
+				}
+				return out, nil
+			}
+			readers := 8
+			if mode == "single" {
+				readers = 1
+			}
+			vectors := make([]IOVector, readers)
+			run := func() {
+				for i := range vectors {
+					vectors[i] = IOVector{FilePath: "columns", Policy: SkipFullFilePreloads, Entries: []IOEntry{
+						{Size: 32, CachedDataSize: 32, ToCacheData: CacheOriginalData},
+						{Offset: 32, Size: int64(n), CachedDataSize: int64(len(raw)), ToCacheData: convert},
+						{Offset: int64(32 + n), Size: 128, CachedDataSize: 128, ToCacheData: CacheOriginalData},
+					}}
+					if mode != "unmarked" {
+						vectors[i].Entries[1].DecodeSharing = DecodeSharing{Codec: "bench-lz4-v1"}
+					}
+					if err := fs.Read(ctx, &vectors[i]); err != nil {
+						b.Fatal(err)
+					}
+				}
+				for i := range vectors {
+					vectors[i].Release()
+					vectors[i] = IOVector{}
+				}
+			}
+			b.Cleanup(func() {
+				for i := range vectors {
+					vectors[i].ReleaseReadResultOnError()
+				}
+			})
+			run()
+			storage.gets, storage.readBytes, conversions, decodedBytes = 0, 0, 0, 0
+			var before, after syscall.Rusage
+			require.NoError(b, syscall.Getrusage(syscall.RUSAGE_SELF, &before))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				run()
+			}
+			require.NoError(b, syscall.Getrusage(syscall.RUSAGE_SELF, &after))
+			b.ReportMetric(float64(after.Utime.Nano()+after.Stime.Nano()-before.Utime.Nano()-before.Stime.Nano())/float64(b.N), "cpu-ns/op")
+			b.ReportMetric(float64(conversions)/float64(b.N), "decodes/op")
+			b.ReportMetric(float64(decodedBytes)/float64(b.N), "decoded-B/op")
+			b.ReportMetric(float64(storage.gets)/float64(b.N), "gets/op")
+			b.ReportMetric(float64(storage.readBytes)/float64(b.N), "read-B/op")
+		})
+	}
+}
+
+type selectedDecodeBenchStorage struct {
+	dummyObjectStorage
+	data            []byte
+	gets, readBytes int64
+}
+
+func (s *selectedDecodeBenchStorage) Read(_ context.Context, _ string, min, max *int64) (io.ReadCloser, error) {
+	start, end := int64(0), int64(len(s.data))
+	if min != nil {
+		start = *min
+	}
+	if max != nil {
+		end = *max
+	}
+	s.gets++
+	s.readBytes += end - start
+	return io.NopCloser(bytes.NewReader(s.data[start:end])), nil
+}

--- a/pkg/fileservice/shared_decode.go
+++ b/pkg/fileservice/shared_decode.go
@@ -325,15 +325,30 @@ func (r *decodedReadRegistry) decode(ctx context.Context, key decodedReadKey, by
 // the enclosing read's deferred cache updates and transfers the ticket to the
 // final entry (which helper reads may have replaced).
 func (s *S3FS) prepareSharedDecode(vector *IOVector) (func(), error) {
-	if s.decodedReads == nil || len(vector.Entries) != 1 || len(vector.Caches) != 0 || vector.Policy.Any(SkipMemoryCache) {
+	if s.decodedReads == nil || len(vector.Caches) != 0 || vector.Policy.Any(SkipMemoryCache) {
 		return nil, nil
 	}
-	entry := &vector.Entries[0]
+	index := -1
+	for i := range vector.Entries {
+		if vector.Entries[i].DecodeSharing.Codec == "" {
+			continue
+		}
+		// One selected entry per request. Do not grow per-entry wrapper state
+		// or silently choose a winner when a caller marks multiple columns.
+		if index >= 0 {
+			return nil, nil
+		}
+		index = i
+	}
+	if index < 0 {
+		return nil, nil
+	}
+	entry := &vector.Entries[index]
 	sharing := entry.DecodeSharing
-	if sharing.Codec == "" || len(sharing.Codec) > 64 || len(vector.FilePath) > 4096 ||
+	if len(sharing.Codec) > 64 || len(vector.FilePath) > 4096 ||
 		entry.Offset < 0 || entry.Size <= 0 || entry.CachedDataSize <= 0 || entry.CachedDataSize > int64(^uint(0)>>1) ||
 		entry.ToCacheData == nil || entry.WriterForRead != nil || entry.ReadCloserForRead != nil || entry.ReaderForWrite != nil ||
-		entry.Data != nil || entry.CachedData != nil || entry.decodeLease != nil {
+		entry.done || entry.Data != nil || entry.CachedData != nil || entry.decodeLease != nil {
 		return nil, nil
 	}
 	path, err := parseFilePathAtService(vector.FilePath, s.name)
@@ -356,7 +371,7 @@ func (s *S3FS) prepareSharedDecode(vector *IOVector) (func(), error) {
 		return result, err
 	}
 	return func() {
-		entry := &vector.Entries[0]
+		entry := &vector.Entries[index]
 		entry.ToCacheData = original
 		if entry.CachedData != nil {
 			entry.decodeLease = lease

--- a/pkg/fileservice/shared_decode_test.go
+++ b/pkg/fileservice/shared_decode_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -343,7 +344,8 @@ func TestS3FSSharedDecodeEligibility(t *testing.T) {
 		{"stream", func(v *IOVector) { var closer io.ReadCloser; v.Entries[0].ReadCloserForRead = &closer }},
 		{"writer", func(v *IOVector) { v.Entries[0].WriterForRead = io.Discard }},
 		{"no converter", func(v *IOVector) { v.Entries[0].ToCacheData = nil }},
-		{"multiple entries", func(v *IOVector) { v.Entries = append(v.Entries, v.Entries[0]) }},
+		{"multiple marked entries", func(v *IOVector) { v.Entries = append(v.Entries, v.Entries[0]) }},
+		{"already done", func(v *IOVector) { v.Entries[0].done = true }},
 		{"custom cache", func(v *IOVector) { v.Caches = []IOVectorCache{nil} }},
 		{"skip memory writes", func(v *IOVector) { v.Policy = SkipMemoryCacheWrites }},
 		{"skip memory reads", func(v *IOVector) { v.Policy = SkipMemoryCacheReads }},
@@ -359,6 +361,238 @@ func TestS3FSSharedDecodeEligibility(t *testing.T) {
 			requireDecodeDrained(t, r)
 		})
 	}
+}
+
+// The same three-column request exercises each helper that copies IOEntry
+// values. Hold the first result to make overlap deterministic without sleeps.
+func TestS3FSSelectedDecodeReadPaths(t *testing.T) {
+	for _, path := range []string{"range", "stream", "individual"} {
+		t.Run(path, func(t *testing.T) {
+			ctx := t.Context()
+			fs := newSelectedDecodeFS(t, path == "stream")
+			pinned := fs.AllocateCacheData(ctx, 128<<10)
+			defer pinned.Release()
+			for selected := range 3 {
+				t.Run(string(rune('0'+selected)), func(t *testing.T) {
+					if path == "stream" {
+						require.NoError(t, fs.diskCache.DeletePaths(ctx, []string{"columns"}))
+					}
+					var calls [3]int
+					makeVector := func() IOVector {
+						v := selectedDecodeVector(selected)
+						if path == "stream" {
+							v.Policy = 0
+						}
+						for i := range v.Entries {
+							v.Entries[i].ToCacheData = func(ctx context.Context, _ io.Reader, data []byte, a CacheDataAllocator) (fscache.Data, error) {
+								calls[i]++
+								return a.CopyToCacheData(ctx, data), nil
+							}
+						}
+						return v
+					}
+					read := func(v *IOVector) {
+						original := reflect.ValueOf(v.Entries[selected].ToCacheData).Pointer()
+						if path == "individual" {
+							finish, err := fs.prepareSharedDecode(v)
+							require.NoError(t, err)
+							require.NotNil(t, finish)
+							err = fs.readEntriesIndividually(ctx, v)
+							finish()
+							require.NoError(t, err)
+						} else {
+							if path == "stream" {
+								require.True(t, fs.shouldStreamFullObjectToDiskCache(v))
+							}
+							require.NoError(t, fs.Read(ctx, v))
+						}
+						require.Equal(t, original, reflect.ValueOf(v.Entries[selected].ToCacheData).Pointer())
+					}
+					first, second := makeVector(), makeVector()
+					defer first.ReleaseReadResultOnError()
+					defer second.ReleaseReadResultOnError()
+					read(&first)
+					read(&second)
+					owner := first.Entries[selected].CachedData
+					for i := range first.Entries {
+						require.Equal(t, []byte("abcdefghi")[3*i:3*i+3], second.Entries[i].CachedData.Bytes())
+						if i == selected {
+							require.Equal(t, 1, calls[i])
+							require.Same(t, owner, second.Entries[i].CachedData)
+							require.NotNil(t, second.Entries[i].decodeLease)
+						} else {
+							require.Equal(t, 2, calls[i])
+							require.NotSame(t, first.Entries[i].CachedData, second.Entries[i].CachedData)
+							require.Nil(t, second.Entries[i].decodeLease)
+						}
+					}
+					first.ReleaseReadResultOnError()
+					require.Equal(t, []byte("abcdefghi")[3*selected:3*selected+3], owner.Bytes())
+					second.ReleaseReadResultOnError()
+					require.Zero(t, owner.(*Bytes).refs.Load())
+					requireDecodeDrained(t, fs.decodedReads)
+				})
+			}
+		})
+	}
+}
+
+func newSelectedDecodeFS(t *testing.T, disk bool) *S3FS {
+	t.Helper()
+	config := CacheConfig{MemoryCapacity: ptrTo[toml.ByteSize](128 << 10)}
+	if disk {
+		config.DiskPath = ptrTo(t.TempDir())
+		config.DiskCapacity = ptrTo[toml.ByteSize](1 << 20)
+	}
+	fs, err := NewS3FS(t.Context(), ObjectStorageArguments{Name: "selected-decode", Endpoint: "disk", Bucket: t.TempDir()}, config, nil, false, false)
+	require.NoError(t, err)
+	fs.SetAsyncUpdate(false)
+	t.Cleanup(func() { fs.Close(context.Background()) })
+	require.NoError(t, fs.Write(t.Context(), IOVector{FilePath: "columns", Policy: SkipAllCache,
+		Entries: []IOEntry{{Size: 9, Data: []byte("abcdefghi")}}}))
+	return fs
+}
+
+func selectedDecodeVector(selected int) IOVector {
+	v := IOVector{FilePath: "columns", Policy: SkipFullFilePreloads, Entries: make([]IOEntry, 3)}
+	for i := range v.Entries {
+		v.Entries[i] = IOEntry{Offset: int64(3 * i), Size: 3, CachedDataSize: 3, ToCacheData: CacheOriginalData}
+		if i == selected {
+			v.Entries[i].DecodeSharing = DecodeSharing{Codec: "test-copy"}
+		}
+	}
+	return v
+}
+
+func TestS3FSSelectedDecodeMemoryHits(t *testing.T) {
+	fs := newSelectedDecodeFS(t, false)
+	for _, hot := range [][]int{{0}, {1}, {0, 1, 2}} {
+		fs.FlushCache(t.Context())
+		prime := selectedDecodeVector(-1)
+		entries := make([]IOEntry, 0, len(hot))
+		for _, i := range hot {
+			entries = append(entries, prime.Entries[i])
+		}
+		prime.Entries = entries
+		t.Cleanup(prime.ReleaseReadResultOnError)
+		require.NoError(t, fs.Read(t.Context(), &prime))
+		v := selectedDecodeVector(1)
+		t.Cleanup(v.ReleaseReadResultOnError)
+		require.NoError(t, fs.Read(t.Context(), &v))
+		for j, i := range hot {
+			require.Same(t, prime.Entries[j].CachedData, v.Entries[i].CachedData)
+			require.Nil(t, v.Entries[i].decodeLease, "memory hits never join a generation")
+		}
+		if len(hot) == 1 && hot[0] == 0 {
+			require.NotNil(t, v.Entries[1].decodeLease, "a sibling hit must not disable the selected miss")
+		}
+		prime.ReleaseReadResultOnError()
+		v.ReleaseReadResultOnError()
+		requireDecodeDrained(t, fs.decodedReads)
+	}
+}
+
+type failingDecodeCache struct {
+	fscache.DataCache
+	calls int
+}
+
+func (f *failingDecodeCache) Set(context.Context, fscache.CacheKey, fscache.Data) (bool, error) {
+	f.calls++
+	return false, errors.New("injected cache update failure")
+}
+
+func TestS3FSSelectedDecodeFailureIsolation(t *testing.T) {
+	fs := newSelectedDecodeFS(t, false)
+	pinned := fs.AllocateCacheData(t.Context(), 128<<10)
+	defer pinned.Release()
+	first := selectedDecodeVector(1)
+	defer first.ReleaseReadResultOnError()
+	require.NoError(t, fs.Read(t.Context(), &first))
+	owner := first.Entries[1].CachedData
+	for _, failed := range []int{0, 2} {
+		v := selectedDecodeVector(1)
+		t.Cleanup(v.ReleaseReadResultOnError)
+		v.Entries[failed].ToCacheData = func(context.Context, io.Reader, []byte, CacheDataAllocator) (fscache.Data, error) {
+			return nil, errors.New("injected sibling failure")
+		}
+		require.ErrorContains(t, fs.Read(t.Context(), &v), "sibling failure")
+		if failed == 0 {
+			require.Nil(t, v.Entries[1].decodeLease)
+		} else {
+			require.Same(t, owner, v.Entries[1].CachedData)
+			require.NotNil(t, v.Entries[1].decodeLease)
+		}
+		v.ReleaseReadResultOnError()
+		require.Zero(t, fs.decodedReads.reads)
+		require.Equal(t, []byte("def"), owner.Bytes())
+	}
+	first.ReleaseReadResultOnError()
+	requireDecodeDrained(t, fs.decodedReads)
+
+	// Fail an admission-enabled deferred update after the target has decoded.
+	// S3FS currently keeps memory-cache update errors local; they must not
+	// invalidate the caller's data or detach its generation ticket.
+	fs = newSelectedDecodeFS(t, false)
+	failedCache := &failingDecodeCache{DataCache: fs.memCache.cache}
+	fs.memCache.cache = failedCache
+	v := selectedDecodeVector(1)
+	defer v.ReleaseReadResultOnError()
+	require.NoError(t, fs.Read(t.Context(), &v))
+	require.Equal(t, 1, failedCache.calls)
+	require.NotNil(t, v.Entries[1].decodeLease)
+	v.ReleaseReadResultOnError()
+	require.Zero(t, fs.decodedReads.reads)
+	requireDecodeDrained(t, fs.decodedReads)
+}
+
+func TestS3FSSelectedDecodeCloseDuringSibling(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	fs := newSelectedDecodeFS(t, false)
+	entered, unblock := make(chan struct{}), make(chan struct{})
+	unblockSibling := sync.OnceFunc(func() { close(unblock) })
+	t.Cleanup(unblockSibling)
+	v := selectedDecodeVector(1)
+	v.Entries[2].ToCacheData = func(ctx context.Context, r io.Reader, data []byte, a CacheDataAllocator) (fscache.Data, error) {
+		close(entered)
+		select {
+		case <-unblock:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return CacheOriginalData(ctx, r, data, a)
+	}
+	var readErr error
+	done := make(chan struct{})
+	go func() { readErr = fs.Read(ctx, &v); close(done) }()
+	t.Cleanup(func() {
+		unblockSibling()
+		<-done
+		v.ReleaseReadResultOnError()
+	})
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("sibling conversion did not start")
+	}
+	// Close must neither wait for the sibling nor retire the read's allocator.
+	closed := make(chan struct{})
+	go func() { fs.Close(ctx); close(closed) }()
+	select {
+	case <-closed:
+	case <-ctx.Done():
+		t.Fatal("close waited for sibling conversion")
+	}
+	require.False(t, fs.memCache.closed.Load())
+	unblockSibling()
+	<-done
+	require.NoError(t, readErr)
+	require.True(t, fs.memCache.closed.Load())
+	require.Equal(t, []byte("def"), v.Entries[1].CachedData.Bytes())
+	require.NotNil(t, v.Entries[1].decodeLease)
+	v.ReleaseReadResultOnError()
+	requireDecodeDrained(t, fs.decodedReads)
 }
 
 func TestS3FSSharedDecodeDiskHits(t *testing.T) {

--- a/pkg/objectio/funcs.go
+++ b/pkg/objectio/funcs.go
@@ -138,8 +138,27 @@ func ReadOneBlock(
 	policy fileservice.Policy,
 	options ...ReadOneBlockOption,
 ) (ioVec fileservice.IOVector, err error) {
+	sharedPosition := -1
+	if len(seqnums) == 1 && len(typs) == 1 && slices.Contains(options, ShareScopedDecodedColumn) {
+		sharedPosition = 0
+	}
 	return readOneBlockWithMeta(ctx, meta, name, blk, seqnums, typs, m, fs, columnCacheConstructorFactory, policy,
-		slices.Contains(options, ShareScopedDecodedColumn))
+		sharedPosition)
+}
+
+// ReadOneBlockWithScopedDecode opts one requested column into immutable decoded
+// sharing. The caller must keep the complete IOVector until all views are consumed.
+// Position is in seqnums/typs, not in the compacted physical-entry list.
+func ReadOneBlockWithScopedDecode(
+	ctx context.Context, meta *ObjectDataMeta, name string, blk uint16,
+	seqnums []uint16, typs []types.Type, m *mpool.MPool, fs fileservice.FileService,
+	policy fileservice.Policy, sharedPosition int,
+) (fileservice.IOVector, error) {
+	if sharedPosition < 0 || sharedPosition >= len(seqnums) || sharedPosition >= len(typs) {
+		return fileservice.IOVector{}, moerr.NewInvalidInputNoCtxf(
+			"scoped decode column position %d is outside column/type lists", sharedPosition)
+	}
+	return readOneBlockWithMeta(ctx, meta, name, blk, seqnums, typs, m, fs, columnCacheConstructorFactory, policy, sharedPosition)
 }
 
 func ReadOneBlockWithMeta(
@@ -154,13 +173,13 @@ func ReadOneBlockWithMeta(
 	factory CacheConstructorFactory,
 	policy fileservice.Policy,
 ) (ioVec fileservice.IOVector, err error) {
-	return readOneBlockWithMeta(ctx, meta, name, blk, seqnums, typs, m, fs, factory, policy, false)
+	return readOneBlockWithMeta(ctx, meta, name, blk, seqnums, typs, m, fs, factory, policy, -1)
 }
 
 func readOneBlockWithMeta(
 	ctx context.Context, meta *ObjectDataMeta, name string, blk uint16,
 	seqnums []uint16, typs []types.Type, m *mpool.MPool, fs fileservice.FileService,
-	factory CacheConstructorFactory, policy fileservice.Policy, shareDecode bool,
+	factory CacheConstructorFactory, policy fileservice.Policy, sharedPosition int,
 ) (ioVec fileservice.IOVector, err error) {
 	ioVec = fileservice.IOVector{
 		FilePath: name,
@@ -217,7 +236,7 @@ func readOneBlockWithMeta(
 		col := blkmeta.ColumnMeta(seqnum)
 		ext := col.Location()
 		entry := newColumnIOEntry(ext, factory)
-		if shareDecode && len(seqnums) == 1 && len(typs) == 1 && typs[0].Oid.IsArrayRelate() {
+		if i == sharedPosition && typs[i].Oid.IsArrayRelate() {
 			entry.DecodeSharing = fileservice.DecodeSharing{
 				Codec:      "objectio-validated-column-v1",
 				Parameters: [2]uint64{uint64(ext.Alg()), uint64(ext.OriginSize())},

--- a/pkg/objectio/ioutil/loadfuncs.go
+++ b/pkg/objectio/ioutil/loadfuncs.go
@@ -91,7 +91,7 @@ func readColumnsData(
 	extraTSColumn *uint16,
 	m *mpool.MPool,
 	policy fileservice.Policy,
-	options ...objectio.ReadOneBlockOption,
+	sharedPosition int,
 ) (ioVectors fileservice.IOVector, fromCache bool, err error) {
 	if len(columns) != len(typs) {
 		return ioVectors, false, moerr.NewInvalidInputNoCtxf(
@@ -120,18 +120,15 @@ func readColumnsData(
 	}
 	name := location.Name().UnsafeString()
 	dataMeta := meta.MustGetMeta(objectio.SchemaData)
-	ioVectors, err = objectio.ReadOneBlock(
-		ctx,
-		&dataMeta,
-		name,
-		location.ID(),
-		readColumns,
-		readTypes,
-		m,
-		fs,
-		policy,
-		options...,
-	)
+	if sharedPosition >= 0 {
+		ioVectors, err = objectio.ReadOneBlockWithScopedDecode(
+			ctx, &dataMeta, name, location.ID(), readColumns, readTypes, m, fs, policy, sharedPosition,
+		)
+	} else {
+		ioVectors, err = objectio.ReadOneBlock(
+			ctx, &dataMeta, name, location.ID(), readColumns, readTypes, m, fs, policy,
+		)
+	}
 	if err != nil {
 		return ioVectors, false, err
 	}
@@ -208,6 +205,7 @@ func LoadColumnsDataInto(
 		commitTSColumn,
 		m,
 		policy,
+		-1,
 	)
 	if err != nil {
 		return deleteMask, false, err
@@ -319,6 +317,7 @@ func LoadColumnDataBySearch(
 		commitTSColumn,
 		m,
 		policy,
+		-1,
 	)
 	if err != nil {
 		return nil, false, err
@@ -463,6 +462,7 @@ func LoadColumnsDataIntoAndTopN(
 		nil,
 		m,
 		policy,
+		len(columns),
 	)
 	if err != nil {
 		return nil, nil, false, err
@@ -545,6 +545,7 @@ func LoadColumnDataBySearchAndCheckTS(
 		nil,
 		m,
 		policy,
+		-1,
 	)
 	if err != nil {
 		return false, false, false, err

--- a/pkg/objectio/ioutil/shared_decode_test.go
+++ b/pkg/objectio/ioutil/shared_decode_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ioutil
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
+	"github.com/matrixorigin/matrixone/pkg/vectorindex/metric"
+	"github.com/stretchr/testify/require"
+)
+
+// Observe, but never wrap, the concrete validated cache data. Consumers must
+// retain its immutable-view contract as well as share its physical ownership.
+type fusedDecodeFS struct {
+	fileservice.FileService
+	t       *testing.T
+	decoded int
+	owners  []fscache.Data
+}
+
+func (f *fusedDecodeFS) Read(ctx context.Context, v *fileservice.IOVector) error {
+	selected := -1
+	for i := range v.Entries {
+		if v.Entries[i].DecodeSharing.Codec == "" {
+			continue
+		}
+		require.Equal(f.t, -1, selected, "only the Top-K column may be marked")
+		require.Equal(f.t, 1, i, "the synthetic predecessor must not shift the physical target")
+		require.Len(f.t, v.Entries, 3, "filter, target and deferred column stay in one read")
+		selected = i
+		original := v.Entries[i].ToCacheData
+		v.Entries[i].ToCacheData = func(ctx context.Context, r io.Reader, data []byte, a fileservice.CacheDataAllocator) (fscache.Data, error) {
+			f.decoded++
+			return original(ctx, r, data, a)
+		}
+	}
+	if err := f.FileService.Read(ctx, v); err != nil {
+		return err
+	}
+	if selected >= 0 {
+		f.owners = append(f.owners, v.Entries[selected].CachedData)
+	}
+	return nil
+}
+
+func TestFusedTopNSelectedDecodeIsolation(t *testing.T) {
+	ctx := t.Context()
+	capacity := toml.ByteSize(128 << 10)
+	storage, err := fileservice.NewS3FS(ctx,
+		fileservice.ObjectStorageArguments{Name: "fused-decode", Endpoint: "disk", Bucket: t.TempDir()},
+		fileservice.CacheConfig{MemoryCapacity: &capacity}, nil, false, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { storage.Close(context.Background()) })
+	fs := &fusedDecodeFS{FileService: storage, t: t}
+	mp := mpool.MustNewZero()
+	t.Cleanup(func() { require.Zero(t, mp.CurrNB()); mpool.DeleteMPool(mp) })
+	bat := batch.NewWithSize(3)
+	typs := []types.Type{types.T_int64.ToType(), types.T_array_float32.ToType(), types.T_array_float32.ToType()}
+	for i := range typs {
+		bat.Vecs[i] = vector.NewVec(typs[i])
+	}
+	t.Cleanup(func() { bat.Clean(mp) })
+	for row := range 4 {
+		require.NoError(t, vector.AppendFixed(bat.Vecs[0], int64(row), false, mp))
+		require.NoError(t, vector.AppendBytes(bat.Vecs[1], types.ArrayToBytes([]float32{float32(row + 1)}), false, mp))
+		require.NoError(t, vector.AppendBytes(bat.Vecs[2], types.ArrayToBytes([]float32{float32(row + 10)}), false, mp))
+	}
+	bat.SetRowCount(4)
+	id := objectio.NewObjectid()
+	name := objectio.BuildObjectNameWithObjectID(&id)
+	writer, err := objectio.NewObjectWriter(name, fs, 0, []uint16{0, 1, 2}, nil)
+	require.NoError(t, err)
+	_, err = writer.Write(bat)
+	require.NoError(t, err)
+	blocks, err := writer.WriteEnd(ctx)
+	require.NoError(t, err)
+	location := objectio.BuildLocation(name, blocks[0].GetExtent(), 4, 0)
+	_, err = objectio.FastLoadObjectMeta(ctx, &location, false, fs)
+	require.NoError(t, err)
+	storage.FlushCache(ctx)
+	pinned := storage.AllocateCacheData(ctx, int(capacity))
+	t.Cleanup(pinned.Release)
+
+	call := func(t *testing.T, query float32, bound plan.BoundType, materialize []int64, selectRows func(*vector.Vector) ([]int64, error)) ([]int64, []float64, []float32, error) {
+		pool := mpool.MustNewZero()
+		defer func() { require.Zero(t, pool.CurrNB()); mpool.DeleteMPool(pool) }()
+		missing, filter, projection := vector.NewVec(typs[0]), vector.NewVec(typs[0]), vector.NewVec(typs[2])
+		defer missing.Free(pool)
+		defer filter.Free(pool)
+		defer projection.Free(pool)
+		op := &objectio.IndexReaderTopOp{Typ: types.T_array_float32, MetricType: metric.Metric_L2Distance,
+			NumVec: types.ArrayToBytes([]float32{query}), Limit: 1, UpperBoundType: bound, UpperBound: 4}
+		rows, distances, _, err := LoadColumnsDataIntoAndTopN(ctx,
+			[]uint16{3, 0}, []types.Type{typs[0], typs[0]}, fs, location, []*vector.Vector{missing, filter}, materialize,
+			1, typs[1], []uint16{2}, []types.Type{typs[2]}, []*vector.Vector{projection},
+			func() ([]int64, error) { return selectRows(filter) }, op, pool, fileservice.SkipFullFilePreloads)
+		var projected []float32
+		for i := 0; i < projection.Length(); i++ {
+			projected = append(projected, types.BytesToArray[float32](projection.GetBytesAt(i))...)
+		}
+		return rows, distances, projected, err
+	}
+	all := func(*vector.Vector) ([]int64, error) { return []int64{0, 1, 2, 3}, nil }
+	rows, distances, projected, err := call(t, 0, plan.BoundType_UNBOUNDED, nil, func(filter *vector.Vector) ([]int64, error) {
+		require.Equal(t, []int64{0, 1, 2, 3}, vector.MustFixedColNoTypeCheck[int64](filter))
+		owner := fs.owners[0]
+		snapshot := owner.Bytes()
+		// Reentrant independent consumers overlap the outer selector's scoped
+		// lifetime deterministically, with no scheduler or wall-clock dependency.
+		t.Run("different filter query and projection", func(t *testing.T) {
+			r, d, p, err := call(t, 5, plan.BoundType_UNBOUNDED, nil, func(v *vector.Vector) ([]int64, error) {
+				require.Equal(t, []int64{0, 1, 2, 3}, vector.MustFixedColNoTypeCheck[int64](v))
+				return []int64{1, 2}, nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, []int64{2}, r)
+			require.Equal(t, []float64{4}, d)
+			require.Equal(t, []float32{12}, p)
+		})
+		t.Run("independent threshold", func(t *testing.T) {
+			r, _, p, err := call(t, 5, plan.BoundType_EXCLUSIVE, nil, func(*vector.Vector) ([]int64, error) { return []int64{1, 2}, nil })
+			require.NoError(t, err)
+			require.Empty(t, r)
+			require.Empty(t, p)
+		})
+		t.Run("selector error", func(t *testing.T) {
+			_, _, _, err := call(t, 0, plan.BoundType_UNBOUNDED, nil, func(*vector.Vector) ([]int64, error) {
+				return nil, moerr.NewInternalErrorNoCtx("injected selector failure")
+			})
+			require.ErrorContains(t, err, "selector failure")
+		})
+		t.Run("materialization error", func(t *testing.T) {
+			_, _, _, err := call(t, 0, plan.BoundType_UNBOUNDED, []int64{99}, all)
+			require.ErrorContains(t, err, "out of range")
+		})
+		for _, data := range fs.owners {
+			require.Same(t, owner, data)
+		}
+		require.Equal(t, snapshot, owner.Bytes())
+		require.Equal(t, 1, fs.decoded)
+		return all(filter)
+	})
+	require.NoError(t, err)
+	require.Equal(t, []int64{0}, rows)
+	require.Equal(t, []float64{1}, distances)
+	require.Equal(t, []float32{10}, projected)
+	_, _, _, err = call(t, 0, plan.BoundType_UNBOUNDED, nil, all)
+	require.NoError(t, err)
+	require.Equal(t, 2, fs.decoded, "every success/error scope must release its ticket before the next generation")
+	require.NotSame(t, fs.owners[0], fs.owners[len(fs.owners)-1])
+}

--- a/pkg/objectio/shared_decode_test.go
+++ b/pkg/objectio/shared_decode_test.go
@@ -17,6 +17,7 @@ package objectio
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -106,4 +107,82 @@ func TestSharedDecodedColumnTopNIsolation(t *testing.T) {
 			require.Equal(t, snapshot, backing)
 		})
 	}
+}
+
+func TestReadOneBlockScopedDecodePosition(t *testing.T) {
+	// Metadata is sufficient to prove opt-in before physical compaction; the
+	// read seam supplies tiny owned data and leaves synthetic-column expansion real.
+	meta := BuildMetaData(1, 3)
+	block := meta.GetBlockMeta(0)
+	block.BlockHeader().SetRows(1)
+	block.BlockHeader().SetMaxSeqnum(2)
+	block.BlockHeader().SetMetaColumnCount(3)
+	for i, typ := range []types.T{types.T_array_float32, types.T_int64, types.T_array_float64} {
+		block.ColumnMeta(uint16(i)).setDataType(uint8(typ))
+		block.ColumnMeta(uint16(i)).setLocation(NewExtent(1, uint32(i+1), 1, 1))
+	}
+	mp := mpool.MustNewZero()
+	t.Cleanup(func() { require.Zero(t, mp.CurrNB()); mpool.DeleteMPool(mp) })
+	for _, tc := range []struct {
+		name     string
+		columns  []uint16
+		typs     []types.Type
+		selected int
+		marked   int
+	}{
+		{"first", []uint16{0, 1, 2}, []types.Type{types.T_array_float32.ToType(), types.T_int64.ToType(), types.T_array_float64.ToType()}, 0, 0},
+		{"last", []uint16{0, 1, 2}, []types.Type{types.T_array_float32.ToType(), types.T_int64.ToType(), types.T_array_float64.ToType()}, 2, 2},
+		{"scalar", []uint16{0, 1, 2}, []types.Type{types.T_array_float32.ToType(), types.T_int64.ToType(), types.T_array_float64.ToType()}, 1, -1},
+		{"synthetic predecessor", []uint16{3, 0, 2}, []types.Type{types.T_int64.ToType(), types.T_array_float32.ToType(), types.T_array_float64.ToType()}, 1, 1},
+		{"selected missing", []uint16{3, 0}, []types.Type{types.T_array_float32.ToType(), types.T_array_float32.ToType()}, 0, -1},
+		{"selected special", []uint16{SEQNUM_COMMITTS, 0}, []types.Type{TSType, types.T_array_float32.ToType()}, 0, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := &scopedDescriptorFS{}
+			v, err := ReadOneBlockWithScopedDecode(t.Context(), &meta, "columns", 0, tc.columns, tc.typs, mp, fs, 0, tc.selected)
+			require.NoError(t, err)
+			defer v.Release()
+			require.Len(t, v.Entries, len(tc.columns))
+			for i := range v.Entries {
+				if i == tc.marked {
+					require.Equal(t, "objectio-validated-column-v1", v.Entries[i].DecodeSharing.Codec)
+					require.Equal(t, int64(tc.columns[i]+1), v.Entries[i].Offset)
+				} else {
+					require.Empty(t, v.Entries[i].DecodeSharing.Codec)
+				}
+			}
+			if tc.marked >= 0 {
+				require.Equal(t, 1, fs.marked)
+			} else {
+				require.Zero(t, fs.marked)
+			}
+		})
+	}
+	for _, pos := range []int{-1, 1, 2} {
+		t.Run(fmt.Sprintf("invalid %d", pos), func(t *testing.T) {
+			v, err := ReadOneBlockWithScopedDecode(t.Context(), nil, "", 0, []uint16{0, 1}, []types.Type{types.T_array_float32.ToType()}, mp, nil, 0, pos)
+			require.ErrorContains(t, err, "outside column/type lists")
+			require.Empty(t, v.Entries)
+		})
+	}
+	fs := &scopedDescriptorFS{}
+	v, err := ReadOneBlockWithMeta(t.Context(), &meta, "columns", 0, []uint16{0}, []types.Type{types.T_array_float32.ToType()}, mp, fs, constructorFactory, 0)
+	require.NoError(t, err)
+	v.Release()
+	require.Zero(t, fs.marked, "custom factories never opt in")
+}
+
+type scopedDescriptorFS struct {
+	fileservice.FileService
+	marked int
+}
+
+func (f *scopedDescriptorFS) Read(_ context.Context, v *fileservice.IOVector) error {
+	for i := range v.Entries {
+		if v.Entries[i].DecodeSharing.Codec != "" {
+			f.marked++
+		}
+		v.Entries[i].CachedData = fileservice.NewBytes([]byte{1})
+	}
+	return nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #24097. This does not close the umbrella performance issue.

## What this PR does / why we need it:

Extend scoped decoded-column sharing to the selected vector entry in fused INCLUDE reads. Overlapping readers of the same vector extent can reuse one immutable decoded result while filter, vector, and projected columns remain in the same I/O request.

Add a position-validated ObjectIO opt-in and mark only the Top-K column before physical-entry compaction. Keep sibling columns, including other vector columns, unmarked. Preserve ordinary reads, custom constructors, the existing single-column option, and chunk-native Top-K behavior.

Retain the existing registry limits and query-scoped ownership. Skip already-satisfied targets, restore the original converter on the final entry, and carry its sharing lease through entry replacement, synthetic-column expansion, and normal success/error cleanup. Filtering, ranking, thresholds, and projected results remain independent per query.

## Validation

- All three owning packages pass in normal and race modes: `pkg/fileservice`, `pkg/objectio`, and `pkg/objectio/ioutil`.
- Affected sharing/lifecycle tests pass 100 individually selected race repetitions, including Close during sibling conversion and independent fused consumers.
- Regression coverage includes first/middle/last target positions, partial memory hits in both directions, multiple-marker bypass, custom constructors, synthetic relocation, range/stream/per-entry reads, converter restoration, sibling/cache-update failures, and selector/materialization cleanup.
- Existing IVF INCLUDE `pre_post_modes`, `mode_paths`, and `end_to_end` SQL cases pass twice in normal comparison mode; database teardown is verified after each run.
- Full repository SCA passes.

### Matched performance evidence

Five alternating main/candidate samples of `BenchmarkSelectedDecode`, using identical three-entry requests and a 1 MiB LZ4 payload, Go 1.26.4 production SIMD mode, and eight CPUs. Overlap means eight live consumer scopes; this is a focused decode-sharing benchmark, not a SQL or Wiki-10M benchmark.

| Eight overlapping reads | Main | This PR |
|---|---:|---:|
| Median CPU time | 4.210 ms | 0.415 ms |
| Median elapsed time | 4.195 ms | 0.396 ms |
| Vector conversions | 8 | 1 |
| Decoded allocation | 8 MiB | 1 MiB |
| Storage reads / bytes | 8 / 58,936 | 8 / 58,936 |

Median CPU changes for controls: single-reader +0.68%, hot-cache +0.17%, unmarked approximately unchanged. Sharing adds a small Go bookkeeping cost: 449 to 496 allocations across eight requests. No buffer recycling, additional decoded cache, request splitting, new parallelism, or storage-format change is included.
