### PR TITLE
fix(function): preserve SET order in FIND_IN_SET

### DIFF
--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -3610,7 +3610,7 @@ func (b *baseBinder) bindFuncExprImplByAstExpr(name string, astArgs []tree.Expr,
 	if isFindInSetName(name) && len(args) == 2 && b.ctx != nil {
 		var err error
 		args, findInSetInternalArgs, err = rewriteFindInSetSetProvenance(
-			b.GetContext(), b.ctx, args)
+			b.GetContext(), b.builder, b.ctx, args)
 		if err != nil {
 			return nil, err
 		}
@@ -4279,7 +4279,7 @@ func rewriteFindInSetStoredOperand(args []*Expr) ([]*Expr, bool) {
 // this path is for derived tables/views, whose output is a VARCHAR ColRef but
 // whose BindContext still records the source SET definition.
 func rewriteFindInSetSetProvenance(
-	ctx context.Context, bindCtx *BindContext, args []*Expr,
+	ctx context.Context, builder *QueryBuilder, bindCtx *BindContext, args []*Expr,
 ) ([]*Expr, bool, error) {
 	if bindCtx == nil || len(args) != 2 || args[1] == nil || isSetDisplayValueExpr(args[1]) {
 		return args, false, nil
@@ -4288,6 +4288,14 @@ func rewriteFindInSetSetProvenance(
 	storageType := bindCtx.mysqlSpecialOrderTypeForExpr(args[1])
 	if !isSetPlanType(storageType) {
 		return args, false, nil
+	}
+	if builder != nil && setTypeHasEmptyMember(storageType) {
+		if bitmap, ok := builder.materializeProjectedSetBitmap(args[1], nil); ok {
+			rewritten := make([]*Expr, 0, 3)
+			rewritten = append(rewritten, args[0], bitmap)
+			rewritten = append(rewritten, makePlan2StringConstExprWithType(storageType.Enumvalues))
+			return rewritten, true, nil
+		}
 	}
 
 	_, valueToIndex, _, err := mysqlSpecialTypeFuncNames(storageType)

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -3599,6 +3599,22 @@ func (b *baseBinder) bindFuncExprImplByAstExpr(name string, astArgs []tree.Expr,
 			}
 		}
 	}
+	// FIND_IN_SET has two different SQL contracts for its second operand:
+	// ordinary strings are comma-separated lists, while a SET operand is a
+	// bitmap whose member position is defined by the SET declaration.  The
+	// display wrapper installed by BindColRef intentionally hides that bitmap
+	// from ordinary string functions, so retain the SET contract before the
+	// generic numeric-special-type rewrite gets a chance to discard the
+	// provenance.
+	findInSetInternalArgs := false
+	if isFindInSetName(name) && len(args) == 2 && b.ctx != nil {
+		var err error
+		args, findInSetInternalArgs, err = rewriteFindInSetSetProvenance(
+			b.GetContext(), b.ctx, args)
+		if err != nil {
+			return nil, err
+		}
+	}
 	args = useStoredMySQLSpecialTypesForNumericContract(b.GetContext(), name, args)
 	if b.builder != nil && b.builder.isPrepareStatement {
 		b.markPreparedStringDomainSubquerySources(name, args)
@@ -3679,7 +3695,14 @@ func (b *baseBinder) bindFuncExprImplByAstExpr(name string, astArgs []tree.Expr,
 	}
 
 	if b.builder != nil {
-		e, err := bindBoundFuncExprAndConstFold(b.GetContext(), b.builder.compCtx.GetProcess(), name, args)
+		var e *plan.Expr
+		var err error
+		if findInSetInternalArgs {
+			e, err = bindBoundFuncExprAndConstFoldWithInternalFunctionArgs(
+				b.GetContext(), b.builder.compCtx.GetProcess(), name, args)
+		} else {
+			e, err = bindBoundFuncExprAndConstFold(b.GetContext(), b.builder.compCtx.GetProcess(), name, args)
+		}
 		if err == nil {
 			if fn := e.GetF(); fn != nil {
 				for i, source := range preparedPeerSources {
@@ -3725,7 +3748,8 @@ func (b *baseBinder) bindFuncExprImplByAstExpr(name string, astArgs []tree.Expr,
 	} else {
 		// return bindFuncExprImplByPlanExpr(b.GetContext(), name, args)
 		// first look for builtin func
-		builtinExpr, err := bindFuncExprImplByPlanExpr(b.GetContext(), name, args, false, nil, false)
+		builtinExpr, err := bindFuncExprImplByPlanExpr(
+			b.GetContext(), name, args, false, nil, findInSetInternalArgs)
 		if err == nil {
 			if isIfNull {
 				builtinExpr.Typ.NotNullable = args[1].Typ.NotNullable || args[2].Typ.NotNullable
@@ -4211,12 +4235,94 @@ func (b *baseBinder) bindPythonUdf(udf *function.Udf, astArgs []tree.Expr, depth
 	return BindFuncExprImplByPlanExpr(b.GetContext(), "python_user_defined_function", args)
 }
 
+func isFindInSetName(name string) bool {
+	return strings.EqualFold(name, "find_in_set") || strings.EqualFold(name, "findinset")
+}
+
+func rewriteFindInSetStoredOperand(args []*Expr) ([]*Expr, bool) {
+	if len(args) != 2 || args[1] == nil {
+		return args, false
+	}
+
+	var (
+		bitmap     *Expr
+		storageTyp *plan.Type
+	)
+	if isSetDisplayValueExpr(args[1]) {
+		fn := args[1].GetF()
+		if len(fn.Args) != 2 || fn.Args[1] == nil || !isSetPlanType(&fn.Args[1].Typ) {
+			return args, false
+		}
+		storageTyp = DeepCopyType(&fn.Args[1].Typ)
+		var ok bool
+		bitmap, ok = storedSetBitmapExpr(args[1])
+		if !ok {
+			return args, false
+		}
+	} else if isSetPlanType(&args[1].Typ) {
+		storageTyp = DeepCopyType(&args[1].Typ)
+		bitmap = DeepCopyExpr(args[1])
+		bitmap.Typ.Enumvalues = ""
+	} else {
+		return args, false
+	}
+
+	rewritten := make([]*Expr, 0, 3)
+	rewritten = append(rewritten, args[0], bitmap)
+	rewritten = append(rewritten, makePlan2StringConstExprWithType(storageTyp.Enumvalues))
+	return rewritten, true
+}
+
+// rewriteFindInSetSetProvenance converts a visible SET value that crossed a
+// query boundary back to its stored bitmap before FIND_IN_SET is bound.  A
+// direct SET column is handled structurally by bindFuncExprImplByPlanExpr;
+// this path is for derived tables/views, whose output is a VARCHAR ColRef but
+// whose BindContext still records the source SET definition.
+func rewriteFindInSetSetProvenance(
+	ctx context.Context, bindCtx *BindContext, args []*Expr,
+) ([]*Expr, bool, error) {
+	if bindCtx == nil || len(args) != 2 || args[1] == nil || isSetDisplayValueExpr(args[1]) {
+		return args, false, nil
+	}
+
+	storageType := bindCtx.mysqlSpecialOrderTypeForExpr(args[1])
+	if !isSetPlanType(storageType) {
+		return args, false, nil
+	}
+
+	_, valueToIndex, _, err := mysqlSpecialTypeFuncNames(storageType)
+	if err != nil {
+		return nil, false, err
+	}
+	bitmap, err := BindFuncExprImplByPlanExpr(ctx, valueToIndex, []*Expr{
+		makePlan2StringConstExprWithType(storageType.Enumvalues),
+		DeepCopyExpr(args[1]),
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	// This is an ordinary physical bitmap inside the hidden overload.  Do not
+	// let a later SET-aware assignment/cast treat it as a display value again.
+	bitmap.Typ.Enumvalues = ""
+
+	rewritten := make([]*Expr, 0, 3)
+	rewritten = append(rewritten, args[0], bitmap)
+	rewritten = append(rewritten, makePlan2StringConstExprWithType(storageType.Enumvalues))
+	return rewritten, true, nil
+}
+
 func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name string, args []*Expr) (*plan.Expr, error) {
-	return bindFuncExprAndConstFoldInternal(ctx, proc, name, args, true)
+	return bindFuncExprAndConstFoldInternal(ctx, proc, name, args, true, false)
 }
 
 func bindBoundFuncExprAndConstFold(ctx context.Context, proc *process.Process, name string, args []*Expr) (*plan.Expr, error) {
-	return bindFuncExprAndConstFoldInternal(ctx, proc, name, args, false)
+	return bindFuncExprAndConstFoldInternal(ctx, proc, name, args, false, false)
+}
+
+func bindBoundFuncExprAndConstFoldWithInternalFunctionArgs(
+	ctx context.Context, proc *process.Process, name string, args []*Expr,
+) (*plan.Expr, error) {
+	return bindFuncExprAndConstFoldInternal(ctx, proc, name, args, false, true)
 }
 
 func bindFuncExprAndConstFoldInternal(
@@ -4225,11 +4331,13 @@ func bindFuncExprAndConstFoldInternal(
 	name string,
 	args []*Expr,
 	descendFunctions bool,
+	allowInternalFunctionArgs bool,
 ) (*plan.Expr, error) {
 	if err := foldDecimalStringComparisonConstants(ctx, proc, name, args); err != nil {
 		return nil, err
 	}
-	retExpr, err := bindFuncExprImplByPlanExpr(ctx, name, args, descendFunctions, nil, false)
+	retExpr, err := bindFuncExprImplByPlanExpr(
+		ctx, name, args, descendFunctions, nil, allowInternalFunctionArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -4816,7 +4924,7 @@ func bindFuncExprImplByPlanExpr(
 	args []*Expr,
 	descendFunctions bool,
 	stringDomainModes []function.StringDomainCheckMode,
-	allowInternalDateFunctionArgs bool,
+	allowInternalFunctionArgs bool,
 ) (*plan.Expr, error) {
 	var err error
 	rejectIntervalArgs := rejectBoundIntervalFunctionArgs
@@ -4867,6 +4975,22 @@ func bindFuncExprImplByPlanExpr(
 		args[0], err = appendCastBeforeExpr(ctx, args[0], makePlan2Type(&target))
 		if err != nil {
 			return nil, err
+		}
+	}
+	if isFindInSetName(name) {
+		switch len(args) {
+		case 2:
+			var rewritten bool
+			args, rewritten = rewriteFindInSetStoredOperand(args)
+			if rewritten {
+				allowInternalFunctionArgs = true
+			}
+		case 3:
+			if !allowInternalFunctionArgs {
+				return nil, moerr.NewInvalidArg(ctx, "function "+name, len(args))
+			}
+		default:
+			return nil, moerr.NewInvalidArg(ctx, "function "+name, len(args))
 		}
 	}
 	if name == "member of" {
@@ -4922,7 +5046,7 @@ func bindFuncExprImplByPlanExpr(
 		// form after replacing a parameter marker. Do not run the SQL-syntax
 		// two-argument rewrite a second time; ordinary callers still cannot bind
 		// the internal overload directly.
-		if allowInternalDateFunctionArgs && len(args) == 3 {
+		if allowInternalFunctionArgs && len(args) == 3 {
 			break
 		}
 		if len(args) != 2 {

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -1520,15 +1520,64 @@ func (builder *QueryBuilder) isProjectedDisplayValueAtNode(
 		if len(node.Children) == 0 {
 			return false
 		}
+		hasDisplayValue := false
 		for _, childID := range node.Children {
-			if !builder.isProjectedDisplayValueAtNode(childID, colPos, isDisplayValue, requireAllSetInputs, visited) {
-				return false
+			if builder.isProjectedDisplayValueAtNode(childID, colPos, isDisplayValue, requireAllSetInputs, visited) {
+				hasDisplayValue = true
+				continue
 			}
+			// A NULL branch is neutral only for a SET proof that has at least
+			// one real SET display branch. Do not let an all-NULL expression or
+			// an unrelated integer assignment enter the SET materializer.
+			if requireAllSetInputs && builder.isProjectedNullValueAtNode(childID, colPos, nil) {
+				continue
+			}
+			return false
 		}
-		return true
+		return hasDisplayValue
 	}
 
 	return builder.isProjectedDisplayValueExpr(node.ProjectList[colPos], isDisplayValue, requireAllSetInputs, visited)
+}
+
+// isProjectedNullValueAtNode follows a projection boundary to prove that an
+// output column is a NULL literal. It is used only to admit a neutral NULL
+// branch alongside a separately proven SET display branch; an all-NULL set
+// operation must not acquire SET provenance by itself.
+func (builder *QueryBuilder) isProjectedNullValueAtNode(
+	nodeID, colPos int32,
+	visited map[[2]int32]struct{},
+) bool {
+	if nodeID < 0 || int(nodeID) >= len(builder.qry.Nodes) {
+		return false
+	}
+	key := [2]int32{nodeID, colPos}
+	if visited == nil {
+		visited = make(map[[2]int32]struct{})
+	}
+	if _, ok := visited[key]; ok {
+		return false
+	}
+	visited[key] = struct{}{}
+	defer delete(visited, key)
+
+	node := builder.qry.Nodes[nodeID]
+	if colPos < 0 || int(colPos) >= len(node.ProjectList) {
+		return false
+	}
+	expr := node.ProjectList[colPos]
+	if isNullLiteralExpr(expr) {
+		return true
+	}
+	col := expr.GetCol()
+	if col == nil {
+		return false
+	}
+	childNodeID, ok := builder.tag2NodeID[col.RelPos]
+	if !ok {
+		return false
+	}
+	return builder.isProjectedNullValueAtNode(childNodeID, col.ColPos, visited)
 }
 
 // materializeProjectedSetBitmap carries a proven SET bitmap through projection
@@ -1604,7 +1653,22 @@ func (builder *QueryBuilder) materializeProjectedSetBitmapAtNode(
 		return GetColExpr(bitmapType, outputTag, pos), true
 	}
 
-	bitmap, found := builder.materializeProjectedSetBitmap(node.ProjectList[colPos], visited)
+	displayExpr := node.ProjectList[colPos]
+	// A pure NULL UNION branch has no stored SET bitmap, but it must still
+	// contribute a nullable hidden bitmap column so that the set operation keeps
+	// NULL rows NULL while non-NULL branches retain their original bitmaps.
+	if isNullLiteralExpr(displayExpr) {
+		bitmap := &plan.Expr{
+			Typ:  plan.Type{Id: int32(types.T_uint64)},
+			Expr: &plan.Expr_Lit{Lit: &plan.Literal{Isnull: true}},
+		}
+		pos := int32(len(node.ProjectList))
+		node.ProjectList = append(node.ProjectList, bitmap)
+		builder.setBitmapByDisplayNode[key] = pos
+		return GetColExpr(bitmap.Typ, outputTag, pos), true
+	}
+
+	bitmap, found := builder.materializeProjectedSetBitmap(displayExpr, visited)
 	if !found {
 		return nil, false
 	}

--- a/pkg/sql/plan/function/baseTemplate.go
+++ b/pkg/sql/plan/function/baseTemplate.go
@@ -1075,6 +1075,89 @@ func opBinaryStrFixedToFixedWithErrorCheck[
 	return nil
 }
 
+// opTernaryStrFixedStrToFixed is used by internal overloads whose third
+// argument carries immutable string metadata for a fixed-width value.  It
+// keeps the ordinary vector null/select-list contract while allowing the
+// caller to cache work derived from the metadata argument.
+func opTernaryStrFixedStrToFixed[
+	T2 types.FixedSizeTExceptStrType,
+	Tr types.FixedSizeTExceptStrType](parameters []*vector.Vector, result vector.FunctionResultWrapper, _ *process.Process, length int,
+	resultFn func(v1 string, v2 T2, v3 string) Tr, selectList *FunctionSelectList) error {
+	result.UseOptFunctionParamFrame(3)
+	rs := vector.MustFunctionResult[Tr](result)
+	p1 := vector.OptGetBytesParamFromWrapper(rs, 0, parameters[0])
+	p2 := vector.OptGetParamFromWrapper[T2](rs, 1, parameters[1])
+	p3 := vector.OptGetBytesParamFromWrapper(rs, 2, parameters[2])
+	rsVec := rs.GetResultVector()
+	rss := vector.MustFixedColNoTypeCheck[Tr](rsVec)
+	rsNull := rsVec.GetNulls()
+
+	if selectList != nil {
+		if selectList.IgnoreAllRow() {
+			nulls.AddRange(rsNull, 0, uint64(length))
+			return nil
+		}
+		if !selectList.ShouldEvalAllRow() {
+			for i := range selectList.SelectList {
+				if selectList.Contains(uint64(i)) {
+					rsNull.Add(uint64(i))
+				}
+			}
+		}
+	}
+
+	// A constant NULL represents NULL for every output row; a non-constant
+	// vector's null bitmap is already row-indexed.  Treat all three operands as
+	// strict, including the metadata argument, even though the planner emits a
+	// non-NULL constant for the internal overload.
+	if parameters[0].IsConst() {
+		_, isNull := p1.GetStrValue(0)
+		if isNull {
+			nulls.AddRange(rsNull, 0, uint64(length))
+		}
+	} else if p1.WithAnyNullValue() {
+		nulls.Or(rsNull, parameters[0].GetNulls(), rsNull)
+	}
+	if parameters[1].IsConst() {
+		_, isNull := p2.GetValue(0)
+		if isNull {
+			nulls.AddRange(rsNull, 0, uint64(length))
+		}
+	} else if p2.WithAnyNullValue() {
+		nulls.Or(rsNull, parameters[1].GetNulls(), rsNull)
+	}
+	if parameters[2].IsConst() {
+		_, isNull := p3.GetStrValue(0)
+		if isNull {
+			nulls.AddRange(rsNull, 0, uint64(length))
+		}
+	} else if p3.WithAnyNullValue() {
+		nulls.Or(rsNull, parameters[2].GetNulls(), rsNull)
+	}
+
+	for i := 0; i < length; i++ {
+		row := uint64(i)
+		if rsNull.Contains(row) {
+			continue
+		}
+		idx1, idx2, idx3 := row, row, row
+		if parameters[0].IsConst() {
+			idx1 = 0
+		}
+		if parameters[1].IsConst() {
+			idx2 = 0
+		}
+		if parameters[2].IsConst() {
+			idx3 = 0
+		}
+		v1, _ := p1.GetStrValue(idx1)
+		v2, _ := p2.GetValue(idx2)
+		v3, _ := p3.GetStrValue(idx3)
+		rss[i] = resultFn(functionUtil.QuickBytesToStr(v1), v2, functionUtil.QuickBytesToStr(v3))
+	}
+	return nil
+}
+
 func opBinaryStrFixedToStrWithErrorCheck[
 	T2 types.FixedSizeTExceptStrType](parameters []*vector.Vector, result vector.FunctionResultWrapper, _ *process.Process, length int,
 	resultFn func(v1 string, v2 T2) (string, error), selectList *FunctionSelectList) error {

--- a/pkg/sql/plan/function/base_template_null_test.go
+++ b/pkg/sql/plan/function/base_template_null_test.go
@@ -27,6 +27,103 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTernaryStrFixedStrToFixedPreservesNullAndSelectionSemantics(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	eval := func(
+		parameters []*vector.Vector,
+		result vector.FunctionResultWrapper,
+		proc *process.Process,
+		length int,
+		selectList *FunctionSelectList,
+	) error {
+		return opTernaryStrFixedStrToFixed[uint64, uint64](
+			parameters,
+			result,
+			proc,
+			length,
+			func(value string, bitmap uint64, definition string) uint64 {
+				return bitmap + uint64(len(value)+len(definition))
+			},
+			selectList,
+		)
+	}
+
+	t.Run("all operands constant", func(t *testing.T) {
+		caseData := NewFunctionTestCase(
+			proc,
+			[]FunctionTestInput{
+				NewFunctionTestConstInput(types.T_varchar.ToType(), []string{"a"}, nil),
+				NewFunctionTestConstInput(types.T_uint64.ToType(), []uint64{2}, nil),
+				NewFunctionTestConstInput(types.T_varchar.ToType(), []string{"xyz"}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{6}, []bool{false}),
+			eval,
+		)
+		succeed, info := caseData.Run()
+		require.True(t, succeed, info)
+	})
+
+	t.Run("operand nulls are merged by row", func(t *testing.T) {
+		caseData := NewFunctionTestCase(
+			proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"a", "b", "c"}, []bool{false, true, false}),
+				NewFunctionTestInput(types.T_uint64.ToType(), []uint64{2, 3, 4}, []bool{false, false, true}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"x", "y", "z"}, []bool{true, false, false}),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{0, 0, 0}, []bool{true, true, true}),
+			eval,
+		)
+		succeed, info := caseData.Run()
+		require.True(t, succeed, info)
+	})
+
+	t.Run("masked rows keep cardinality and are not evaluated", func(t *testing.T) {
+		caseData := NewFunctionTestCase(
+			proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"a", "b", "c"}, nil),
+				NewFunctionTestInput(types.T_uint64.ToType(), []uint64{2, 3, 4}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"x", "y", "z"}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{4, 0, 6}, []bool{false, true, false}),
+			eval,
+		).WithSelectList(&FunctionSelectList{AnyNull: true, SelectList: []bool{true, false, true}})
+		succeed, info := caseData.Run()
+		require.True(t, succeed, info)
+	})
+
+	t.Run("all rows masked", func(t *testing.T) {
+		caseData := NewFunctionTestCase(
+			proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"a", "b"}, nil),
+				NewFunctionTestInput(types.T_uint64.ToType(), []uint64{2, 3}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"x", "y"}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{0, 0}, []bool{true, true}),
+			eval,
+		).WithSelectList(&FunctionSelectList{AllNull: true})
+		succeed, info := caseData.Run()
+		require.True(t, succeed, info)
+	})
+
+	t.Run("constant null operand", func(t *testing.T) {
+		caseData := NewFunctionTestCase(
+			proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"a", "b"}, nil),
+				NewFunctionTestConstInput(types.T_uint64.ToType(), []uint64{0}, []bool{true}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"x", "y"}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{0, 0}, []bool{true, true}),
+			eval,
+		)
+		succeed, info := caseData.Run()
+		require.True(t, succeed, info)
+	})
+}
+
 func TestUnaryFixedToStrConstNullPreservesResultCardinality(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	testCase := NewFunctionTestCase(

--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -7834,6 +7834,34 @@ func extractUnitPrefersTime(unit string) bool {
 }
 
 func FindInSet(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) (err error) {
+	if len(ivecs) == 3 {
+		var (
+			cachedDefinition string
+			memberPositions  map[string]uint64
+		)
+		findSetMember := func(target string, bitmap uint64, definition string) uint64 {
+			// The definition is a hidden constant for planner-generated SET
+			// calls. Keep the fallback for direct executor tests and defensive
+			// callers that provide a row-wise metadata vector.
+			if memberPositions == nil || cachedDefinition != definition {
+				cachedDefinition = definition
+				memberPositions = make(map[string]uint64)
+				for i, member := range strings.Split(definition, ",") {
+					memberPositions[member] = uint64(i + 1)
+				}
+			}
+			position, ok := memberPositions[target]
+			if !ok || position == 0 || position > types.MaxSetMembers {
+				return 0
+			}
+			if bitmap&(uint64(1)<<uint(position-1)) == 0 {
+				return 0
+			}
+			return position
+		}
+		return opTernaryStrFixedStrToFixed[uint64, uint64](ivecs, result, proc, length, findSetMember, selectList)
+	}
+
 	findInStrList := func(str, strlist string) uint64 {
 		for j, s := range strings.Split(strlist, ",") {
 			if s == str {

--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -7847,10 +7847,20 @@ func FindInSet(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc
 				cachedDefinition = definition
 				memberPositions = make(map[string]uint64)
 				for i, member := range strings.Split(definition, ",") {
-					memberPositions[member] = uint64(i + 1)
+					// Match types.ParseSet: SET definitions are normalized by
+					// trimming trailing ASCII spaces and folding case.
+					key := strings.ToLower(strings.TrimRight(member, " "))
+					memberPositions[key] = uint64(i + 1)
 				}
 			}
-			position, ok := memberPositions[target]
+			// Most SET labels are already normalized at the SQL boundary. Try
+			// the allocation-free exact key first and fold only on a miss for
+			// mixed-case or padded needles.
+			targetKey := strings.TrimRight(target, " ")
+			position, ok := memberPositions[targetKey]
+			if !ok {
+				position, ok = memberPositions[strings.ToLower(targetKey)]
+			}
 			if !ok || position == 0 || position > types.MaxSetMembers {
 				return 0
 			}

--- a/pkg/sql/plan/function/func_binary_test.go
+++ b/pkg/sql/plan/function/func_binary_test.go
@@ -5081,16 +5081,32 @@ func TestFindInSetSetDefinition(t *testing.T) {
 		proc,
 		[]FunctionTestInput{
 			NewFunctionTestInput(types.T_varchar.ToType(),
-				[]string{"a", "m", "z", "a", "x", "", "", "a"},
-				[]bool{false, false, false, false, false, false, false, true}),
+				[]string{"a", "A", "m", "z", "a", "x", "", "", "a"},
+				[]bool{false, false, false, false, false, false, false, false, true}),
 			NewFunctionTestInput(types.T_uint64.ToType(),
-				[]uint64{2, 4, 7, 3, 7, 0, 2, 0},
-				[]bool{false, false, false, false, false, false, false, false}),
+				[]uint64{2, 2, 4, 7, 3, 7, 0, 2, 0},
+				[]bool{false, false, false, false, false, false, false, false, false}),
 			NewFunctionTestConstInput(types.T_varchar.ToType(), []string{"z,a,m"}, []bool{false}),
 		},
 		NewFunctionTestResult(types.T_uint64.ToType(), false,
-			[]uint64{2, 3, 1, 2, 0, 0, 0, 0},
-			[]bool{false, false, false, false, false, false, false, true}),
+			[]uint64{2, 2, 3, 1, 2, 0, 0, 0, 0},
+			[]bool{false, false, false, false, false, false, false, false, true}),
+		FindInSet,
+	)
+	succeed, info := caseData.Run()
+	require.True(t, succeed, info)
+}
+
+func TestFindInSetSetDefinitionEmptyMember(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	caseData := NewFunctionTestCase(
+		proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"", "", "", ""}, nil),
+			NewFunctionTestInput(types.T_uint64.ToType(), []uint64{0, 1, 2, 2}, nil),
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{",a", ",a", "a,", "a,,b"}, nil),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{0, 1, 2, 2}, nil),
 		FindInSet,
 	)
 	succeed, info := caseData.Run()

--- a/pkg/sql/plan/function/func_binary_test.go
+++ b/pkg/sql/plan/function/func_binary_test.go
@@ -5075,6 +5075,28 @@ func TestFindInSet(t *testing.T) {
 	}
 }
 
+func TestFindInSetSetDefinition(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	caseData := NewFunctionTestCase(
+		proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(),
+				[]string{"a", "m", "z", "a", "x", "", "", "a"},
+				[]bool{false, false, false, false, false, false, false, true}),
+			NewFunctionTestInput(types.T_uint64.ToType(),
+				[]uint64{2, 4, 7, 3, 7, 0, 2, 0},
+				[]bool{false, false, false, false, false, false, false, false}),
+			NewFunctionTestConstInput(types.T_varchar.ToType(), []string{"z,a,m"}, []bool{false}),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), false,
+			[]uint64{2, 3, 1, 2, 0, 0, 0, 0},
+			[]bool{false, false, false, false, false, false, false, true}),
+		FindInSet,
+	)
+	succeed, info := caseData.Run()
+	require.True(t, succeed, info)
+}
+
 // INSTR
 func initInstrTestCase() []tcTemp {
 	cases := []struct {

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -1162,6 +1162,20 @@ var supportedStringBuiltIns = []FuncNew{
 					return FindInSet
 				},
 			},
+			{
+				overloadId: 1,
+				// Internal form for a SET second operand:
+				// (search string, stored bitmap, SET definition). The
+				// definition is planner metadata and is never part of the
+				// public FIND_IN_SET SQL arity.
+				args: []types.T{types.T_varchar, types.T_uint64, types.T_varchar},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_uint64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return FindInSet
+				},
+			},
 		},
 	},
 

--- a/pkg/sql/plan/mysql_special_types.go
+++ b/pkg/sql/plan/mysql_special_types.go
@@ -532,6 +532,26 @@ func mysqlSpecialOrderTypeReversible(typ *plan.Type) bool {
 	}
 }
 
+// setTypeHasEmptyMember identifies a SET definition that has at least one
+// member whose display label is empty. Every bitmap containing only such a
+// member renders as the empty string, so display text alone cannot recover
+// the stored bitmap (the empty member may occur at any declaration position).
+func setTypeHasEmptyMember(typ *plan.Type) bool {
+	if !isSetPlanType(typ) {
+		return false
+	}
+	values, err := types.NormalizeSetValues(strings.Split(typ.Enumvalues, ","))
+	if err != nil {
+		return false
+	}
+	for _, value := range values {
+		if value == "" {
+			return true
+		}
+	}
+	return false
+}
+
 func newNonReversibleMySQLSpecialOrderError(ctx context.Context) error {
 	return moerr.NewNotSupported(ctx,
 		"definition-order sorting of projected ENUM/SET values with non-unique display labels or ambiguous SET display values")

--- a/pkg/sql/plan/mysql_special_types_test.go
+++ b/pkg/sql/plan/mysql_special_types_test.go
@@ -266,7 +266,6 @@ func TestFindInSetPlannerPreservesSetContractAcrossQueryBoundary(t *testing.T) {
 		{name: "union null then empty member", sql: "select find_in_set('', s) from (select null as s union all select s from set_empty_member_t) d", def: ",a", wantType: types.T_uint64},
 		{name: "ordered derived empty member", sql: "select find_in_set('', s) from (select s from set_empty_member_t order by s) d", def: ",a", wantType: types.T_uint64},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			logicPlan, err := runOneExprStmt(newMySQLSpecialOrderMock(), t, tc.sql)
 			require.NoError(t, err)

--- a/pkg/sql/plan/mysql_special_types_test.go
+++ b/pkg/sql/plan/mysql_special_types_test.go
@@ -132,6 +132,135 @@ func TestFindInSetSetBindingUsesStoredBitmap(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestFindInSetRewriteHelpersRejectInvalidProvenance(t *testing.T) {
+	search := makePlan2StringConstExprWithType("a")
+	plain := makePlan2StringConstExprWithType("a,b")
+	setType := plan.Type{Id: int32(types.T_uint64), Enumvalues: "z,a,m"}
+	rawSet := &plan.Expr{
+		Typ:  setType,
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 1, ColPos: 0}},
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []*plan.Expr
+	}{
+		{name: "wrong arity", args: []*plan.Expr{search}},
+		{name: "nil operand", args: []*plan.Expr{search, nil}},
+		{name: "ordinary string", args: []*plan.Expr{search, plain}},
+		{
+			name: "malformed display wrapper",
+			args: []*plan.Expr{search, {
+				Typ: plan.Type{Id: int32(types.T_varchar)},
+				Expr: &plan.Expr_F{F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: moSetCastIndexToValueFun},
+					Args: []*plan.Expr{makePlan2StringConstExprWithType(setType.Enumvalues)},
+				}},
+			}},
+		},
+		{
+			name: "display wrapper with non SET storage",
+			args: []*plan.Expr{search, {
+				Typ: plan.Type{Id: int32(types.T_varchar)},
+				Expr: &plan.Expr_F{F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: moSetCastIndexToValueFun},
+					Args: []*plan.Expr{
+						makePlan2StringConstExprWithType(setType.Enumvalues),
+						makePlan2StringConstExprWithType("a"),
+					},
+				}},
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, rewritten := rewriteFindInSetStoredOperand(tc.args)
+			require.False(t, rewritten)
+			require.Equal(t, tc.args, got)
+		})
+	}
+
+	rewritten, ok := rewriteFindInSetStoredOperand([]*plan.Expr{search, rawSet})
+	require.True(t, ok)
+	require.Len(t, rewritten, 3)
+	require.Equal(t, int32(types.T_uint64), rewritten[1].Typ.Id)
+	require.Empty(t, rewritten[1].Typ.Enumvalues)
+	require.Equal(t, setType.Enumvalues, rewritten[2].GetLit().GetSval())
+	require.Equal(t, setType.Enumvalues, rawSet.Typ.Enumvalues)
+}
+
+func TestFindInSetSetProvenanceThroughBindingBoundary(t *testing.T) {
+	ctx := context.Background()
+	setType := plan.Type{Id: int32(types.T_uint64), Enumvalues: "z,a,m"}
+	bindCtx := NewBindContext(nil, nil)
+	bindCtx.bindingByTag[7] = &Binding{
+		mysqlSpecialOrderTypes: []*plan.Type{&setType},
+	}
+	column := &plan.Expr{
+		Typ:  plan.Type{Id: int32(types.T_varchar)},
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: 7, ColPos: 0}},
+	}
+	args := []*plan.Expr{makePlan2StringConstExprWithType("a"), column}
+
+	rewritten, ok, err := rewriteFindInSetSetProvenance(ctx, bindCtx, args)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, rewritten, 3)
+	require.Equal(t, moSetCastValueToIndexFun, rewritten[1].GetF().GetFunc().GetObjName())
+	require.Empty(t, rewritten[1].Typ.Enumvalues)
+	require.Equal(t, setType.Enumvalues, rewritten[2].GetLit().GetSval())
+
+	unchanged, didRewrite, err := rewriteFindInSetSetProvenance(ctx, nil, args)
+	require.NoError(t, err)
+	require.False(t, didRewrite)
+	require.Equal(t, args, unchanged)
+
+	ordinaryContext := NewBindContext(nil, nil)
+	unchanged, didRewrite, err = rewriteFindInSetSetProvenance(ctx, ordinaryContext, args)
+	require.NoError(t, err)
+	require.False(t, didRewrite)
+	require.Equal(t, args, unchanged)
+}
+
+func TestFindInSetInternalArityIsPlannerOnly(t *testing.T) {
+	ctx := context.Background()
+	internalArgs := []*plan.Expr{
+		makePlan2StringConstExprWithType("a"),
+		makePlan2Uint64ConstExprWithType(2),
+		makePlan2StringConstExprWithType("z,a,m"),
+	}
+
+	_, err := BindFuncExprImplByPlanExpr(ctx, "find_in_set", internalArgs)
+	require.Error(t, err)
+
+	bound, err := bindFuncExprImplByPlanExpr(ctx, "find_in_set", internalArgs, true, nil, true)
+	require.NoError(t, err)
+	require.Len(t, bound.GetF().GetArgs(), 3)
+
+	bound, err = bindBoundFuncExprAndConstFoldWithInternalFunctionArgs(ctx, nil, "find_in_set", internalArgs)
+	require.NoError(t, err)
+	require.Len(t, bound.GetF().GetArgs(), 3)
+
+	_, err = BindFuncExprImplByPlanExpr(ctx, "find_in_set", []*plan.Expr{internalArgs[0]})
+	require.Error(t, err)
+}
+
+func TestFindInSetPlannerPreservesSetContractAcrossQueryBoundary(t *testing.T) {
+	for _, sql := range []string{
+		"select find_in_set('a', s) from enum_order_t",
+		"select find_in_set('a', s) from (select s from enum_order_t) d",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			logicPlan, err := runOneExprStmt(newMySQLSpecialOrderMock(), t, sql)
+			require.NoError(t, err)
+			findInSet := findPlanFunctionExpr(logicPlan, "find_in_set")
+			require.NotNil(t, findInSet, logicPlan.String())
+			require.Len(t, findInSet.GetF().GetArgs(), 3)
+			require.Empty(t, findInSet.GetF().GetArgs()[1].Typ.Enumvalues)
+			require.Equal(t, "red,green,blue", findInSet.GetF().GetArgs()[2].GetLit().GetSval())
+		})
+	}
+}
+
 // TestGeomFromTextSRIDInResultType verifies that a constant SRID argument to
 // ST_GeomFromText lands in the result type's Width (since geometry cells store
 // bare WKB and SRID lives in the type).

--- a/pkg/sql/plan/mysql_special_types_test.go
+++ b/pkg/sql/plan/mysql_special_types_test.go
@@ -107,6 +107,31 @@ func TestMySQLSpecialOrderTypeReversibility(t *testing.T) {
 	require.Error(t, newNonReversibleMySQLSpecialOrderError(context.Background()))
 }
 
+func TestFindInSetSetBindingUsesStoredBitmap(t *testing.T) {
+	ctx := context.Background()
+	setType := plan.Type{Id: int32(types.T_uint64), Enumvalues: "z,a,m"}
+	display, err := makeEnumOrSetDisplayValue(ctx, &plan.Expr{Typ: setType})
+	require.NoError(t, err)
+
+	bound, err := BindFuncExprImplByPlanExpr(ctx, "find_in_set", []*plan.Expr{
+		makePlan2StringConstExprWithType("a"), display,
+	})
+	require.NoError(t, err)
+	fn := bound.GetF()
+	require.NotNil(t, fn)
+	require.Len(t, fn.Args, 3)
+	require.Equal(t, int32(types.T_uint64), fn.Args[1].Typ.Id)
+	require.Empty(t, fn.Args[1].Typ.Enumvalues)
+	require.Equal(t, "z,a,m", fn.Args[2].GetLit().GetSval())
+
+	_, err = BindFuncExprImplByPlanExpr(ctx, "find_in_set", []*plan.Expr{
+		makePlan2StringConstExprWithType("a"),
+		makePlan2StringConstExprWithType("a,b"),
+		makePlan2StringConstExprWithType("not-public"),
+	})
+	require.Error(t, err)
+}
+
 // TestGeomFromTextSRIDInResultType verifies that a constant SRID argument to
 // ST_GeomFromText lands in the result type's Width (since geometry cells store
 // bare WKB and SRID lives in the type).

--- a/pkg/sql/plan/mysql_special_types_test.go
+++ b/pkg/sql/plan/mysql_special_types_test.go
@@ -95,11 +95,17 @@ func TestMySQLSpecialOrderTypeReversibility(t *testing.T) {
 	duplicateEnum := &plan.Type{Id: int32(types.T_enum), Enumvalues: "a,A"}
 	set := &plan.Type{Id: int32(types.T_uint64), Enumvalues: "x,y"}
 	ambiguousSet := &plan.Type{Id: int32(types.T_uint64), Enumvalues: "x,"}
+	emptyFirstSet := &plan.Type{Id: int32(types.T_uint64), Enumvalues: ",x"}
+	emptyMiddleSet := &plan.Type{Id: int32(types.T_uint64), Enumvalues: "x,,y"}
 
 	require.True(t, mysqlSpecialOrderTypeReversible(enum))
 	require.False(t, mysqlSpecialOrderTypeReversible(duplicateEnum))
 	require.True(t, mysqlSpecialOrderTypeReversible(set))
 	require.False(t, mysqlSpecialOrderTypeReversible(ambiguousSet))
+	require.True(t, setTypeHasEmptyMember(emptyFirstSet))
+	require.True(t, setTypeHasEmptyMember(emptyMiddleSet))
+	require.True(t, setTypeHasEmptyMember(ambiguousSet))
+	require.False(t, setTypeHasEmptyMember(set))
 	require.False(t, mysqlSpecialOrderTypeReversible(&plan.Type{Id: int32(types.T_varchar)}))
 	require.Equal(t, enumFoldKey("K"), enumFoldKey("K"))
 	require.True(t, mysqlSpecialOrderTypesCompatible(enum, DeepCopyType(enum)))
@@ -201,7 +207,7 @@ func TestFindInSetSetProvenanceThroughBindingBoundary(t *testing.T) {
 	}
 	args := []*plan.Expr{makePlan2StringConstExprWithType("a"), column}
 
-	rewritten, ok, err := rewriteFindInSetSetProvenance(ctx, bindCtx, args)
+	rewritten, ok, err := rewriteFindInSetSetProvenance(ctx, nil, bindCtx, args)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Len(t, rewritten, 3)
@@ -209,13 +215,13 @@ func TestFindInSetSetProvenanceThroughBindingBoundary(t *testing.T) {
 	require.Empty(t, rewritten[1].Typ.Enumvalues)
 	require.Equal(t, setType.Enumvalues, rewritten[2].GetLit().GetSval())
 
-	unchanged, didRewrite, err := rewriteFindInSetSetProvenance(ctx, nil, args)
+	unchanged, didRewrite, err := rewriteFindInSetSetProvenance(ctx, nil, nil, args)
 	require.NoError(t, err)
 	require.False(t, didRewrite)
 	require.Equal(t, args, unchanged)
 
 	ordinaryContext := NewBindContext(nil, nil)
-	unchanged, didRewrite, err = rewriteFindInSetSetProvenance(ctx, ordinaryContext, args)
+	unchanged, didRewrite, err = rewriteFindInSetSetProvenance(ctx, nil, ordinaryContext, args)
 	require.NoError(t, err)
 	require.False(t, didRewrite)
 	require.Equal(t, args, unchanged)
@@ -245,18 +251,34 @@ func TestFindInSetInternalArityIsPlannerOnly(t *testing.T) {
 }
 
 func TestFindInSetPlannerPreservesSetContractAcrossQueryBoundary(t *testing.T) {
-	for _, sql := range []string{
-		"select find_in_set('a', s) from enum_order_t",
-		"select find_in_set('a', s) from (select s from enum_order_t) d",
+	for _, tc := range []struct {
+		name     string
+		sql      string
+		def      string
+		wantType types.T
+	}{
+		{name: "direct", sql: "select find_in_set('a', s) from enum_order_t", def: "red,green,blue", wantType: types.T_uint64},
+		{name: "derived", sql: "select find_in_set('a', s) from (select s from enum_order_t) d", def: "red,green,blue", wantType: types.T_uint64},
+		{name: "derived empty member", sql: "select find_in_set('', s) from (select s from set_empty_member_t) d", def: ",a", wantType: types.T_uint64},
+		{name: "cte empty member", sql: "with c as (select s from set_empty_member_t) select find_in_set('', s) from c", def: ",a", wantType: types.T_uint64},
+		{name: "union empty member", sql: "select find_in_set('', s) from (select s from set_empty_member_t union all select s from set_empty_member_t) d", def: ",a", wantType: types.T_uint64},
+		{name: "ordered derived empty member", sql: "select find_in_set('', s) from (select s from set_empty_member_t order by s) d", def: ",a", wantType: types.T_uint64},
 	} {
-		t.Run(sql, func(t *testing.T) {
-			logicPlan, err := runOneExprStmt(newMySQLSpecialOrderMock(), t, sql)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			logicPlan, err := runOneExprStmt(newMySQLSpecialOrderMock(), t, tc.sql)
 			require.NoError(t, err)
 			findInSet := findPlanFunctionExpr(logicPlan, "find_in_set")
 			require.NotNil(t, findInSet, logicPlan.String())
 			require.Len(t, findInSet.GetF().GetArgs(), 3)
+			require.Equal(t, int32(tc.wantType), findInSet.GetF().GetArgs()[1].Typ.Id)
 			require.Empty(t, findInSet.GetF().GetArgs()[1].Typ.Enumvalues)
-			require.Equal(t, "red,green,blue", findInSet.GetF().GetArgs()[2].GetLit().GetSval())
+			require.Equal(t, tc.def, findInSet.GetF().GetArgs()[2].GetLit().GetSval())
+			if tc.name == "derived empty member" {
+				raw := findInSet.GetF().GetArgs()[1].GetCol()
+				require.NotNil(t, raw)
+				require.Equal(t, int32(0), raw.ColPos)
+			}
 		})
 	}
 }

--- a/pkg/sql/plan/mysql_special_types_test.go
+++ b/pkg/sql/plan/mysql_special_types_test.go
@@ -262,6 +262,8 @@ func TestFindInSetPlannerPreservesSetContractAcrossQueryBoundary(t *testing.T) {
 		{name: "derived empty member", sql: "select find_in_set('', s) from (select s from set_empty_member_t) d", def: ",a", wantType: types.T_uint64},
 		{name: "cte empty member", sql: "with c as (select s from set_empty_member_t) select find_in_set('', s) from c", def: ",a", wantType: types.T_uint64},
 		{name: "union empty member", sql: "select find_in_set('', s) from (select s from set_empty_member_t union all select s from set_empty_member_t) d", def: ",a", wantType: types.T_uint64},
+		{name: "union empty member then null", sql: "select find_in_set('', s) from (select s from set_empty_member_t union all select null as s) d", def: ",a", wantType: types.T_uint64},
+		{name: "union null then empty member", sql: "select find_in_set('', s) from (select null as s union all select s from set_empty_member_t) d", def: ",a", wantType: types.T_uint64},
 		{name: "ordered derived empty member", sql: "select find_in_set('', s) from (select s from set_empty_member_t order by s) d", def: ",a", wantType: types.T_uint64},
 	} {
 		tc := tc
@@ -274,6 +276,10 @@ func TestFindInSetPlannerPreservesSetContractAcrossQueryBoundary(t *testing.T) {
 			require.Equal(t, int32(tc.wantType), findInSet.GetF().GetArgs()[1].Typ.Id)
 			require.Empty(t, findInSet.GetF().GetArgs()[1].Typ.Enumvalues)
 			require.Equal(t, tc.def, findInSet.GetF().GetArgs()[2].GetLit().GetSval())
+			if strings.Contains(tc.name, "union") && strings.Contains(tc.name, "null") {
+				require.NotNil(t, findInSet.GetF().GetArgs()[1].GetCol(), logicPlan.String())
+				require.False(t, findInSet.GetF().GetArgs()[1].Typ.NotNullable)
+			}
 			if tc.name == "derived empty member" {
 				raw := findInSet.GetF().GetArgs()[1].GetCol()
 				require.NotNil(t, raw)

--- a/test/distributed/cases/function/func_string_findinset_set.result
+++ b/test/distributed/cases/function/func_string_findinset_set.result
@@ -100,4 +100,28 @@ FROM (SELECT id, v FROM find_in_set_set_empty_28221) AS d ORDER BY id;
 2  ¦  1  𝄀
 3  ¦  0  𝄀
 4  ¦  0
+SELECT id, src, v, FIND_IN_SET('', v) AS union_empty_pos
+FROM (
+SELECT id, 1 AS src, v
+FROM find_in_set_set_empty_28221
+WHERE id IN (1, 2)
+UNION ALL
+SELECT 0 AS id, 2 AS src, NULL AS v
+) AS u ORDER BY src, id;
+➤ id[-5,64,0]  ¦  src[-5,64,0]  ¦  v[12,65535,0]  ¦  union_empty_pos[-5,64,0]  𝄀
+1  ¦  1  ¦    ¦  0  𝄀
+2  ¦  1  ¦    ¦  1  𝄀
+0  ¦  2  ¦  null  ¦  null
+SELECT id, src, v, FIND_IN_SET('', v) AS union_empty_pos
+FROM (
+SELECT 0 AS id, 1 AS src, NULL AS v
+UNION ALL
+SELECT id, 2 AS src, v
+FROM find_in_set_set_empty_28221
+WHERE id IN (1, 2)
+) AS u ORDER BY src, id;
+➤ id[-5,64,0]  ¦  src[-5,64,0]  ¦  v[12,65535,0]  ¦  union_empty_pos[-5,64,0]  𝄀
+0  ¦  1  ¦  null  ¦  null  𝄀
+1  ¦  2  ¦    ¦  0  𝄀
+2  ¦  2  ¦    ¦  1
 DROP TABLE find_in_set_set_empty_28221;

--- a/test/distributed/cases/function/func_string_findinset_set.result
+++ b/test/distributed/cases/function/func_string_findinset_set.result
@@ -92,7 +92,7 @@ FROM find_in_set_set_empty_28221 ORDER BY id;
 1  ¦    ¦  0  ¦  0  𝄀
 2  ¦    ¦  1  ¦  0  𝄀
 3  ¦  a  ¦  0  ¦  2  𝄀
-4  ¦    ¦  0  ¦  0  𝄀
+4  ¦    ¦  0  ¦  0
 SELECT id, FIND_IN_SET('', v) AS derived_empty_pos
 FROM (SELECT id, v FROM find_in_set_set_empty_28221) AS d ORDER BY id;
 ➤ id[4,32,0]  ¦  derived_empty_pos[-5,64,0]  𝄀

--- a/test/distributed/cases/function/func_string_findinset_set.result
+++ b/test/distributed/cases/function/func_string_findinset_set.result
@@ -64,6 +64,40 @@ EXECUTE find_in_set_set_stmt_28221 USING @find_in_set_set_needle_28221;
 6  ¦  2  𝄀
 7  ¦  0  𝄀
 8  ¦  null
+SET @find_in_set_set_needle_28221 = 'A';
+EXECUTE find_in_set_set_stmt_28221 USING @find_in_set_set_needle_28221;
+➤ id[4,32,0]  ¦  prepared_pos[-5,64,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  2  𝄀
+3  ¦  0  𝄀
+4  ¦  2  𝄀
+5  ¦  2  𝄀
+6  ¦  2  𝄀
+7  ¦  0  𝄀
+8  ¦  null
 DEALLOCATE PREPARE find_in_set_set_stmt_28221;
 DROP VIEW find_in_set_set_view_28221;
 DROP TABLE find_in_set_set_28221;
+DROP TABLE IF EXISTS find_in_set_set_empty_28221;
+CREATE TABLE find_in_set_set_empty_28221 (
+id INT PRIMARY KEY,
+v SET('','a')
+);
+INSERT INTO find_in_set_set_empty_28221 VALUES
+(1, 0), (2, 1), (3, 'a'), (4, '');
+SELECT id, v, FIND_IN_SET('', v) AS empty_pos,
+FIND_IN_SET('A', v) AS a_pos
+FROM find_in_set_set_empty_28221 ORDER BY id;
+➤ id[4,32,0]  ¦  v[12,65535,0]  ¦  empty_pos[-5,64,0]  ¦  a_pos[-5,64,0]  𝄀
+1  ¦    ¦  0  ¦  0  𝄀
+2  ¦    ¦  1  ¦  0  𝄀
+3  ¦  a  ¦  0  ¦  2  𝄀
+4  ¦    ¦  0  ¦  0  𝄀
+SELECT id, FIND_IN_SET('', v) AS derived_empty_pos
+FROM (SELECT id, v FROM find_in_set_set_empty_28221) AS d ORDER BY id;
+➤ id[4,32,0]  ¦  derived_empty_pos[-5,64,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  1  𝄀
+3  ¦  0  𝄀
+4  ¦  0
+DROP TABLE find_in_set_set_empty_28221;

--- a/test/distributed/cases/function/func_string_findinset_set.result
+++ b/test/distributed/cases/function/func_string_findinset_set.result
@@ -1,0 +1,69 @@
+DROP TABLE IF EXISTS find_in_set_set_28221;
+CREATE TABLE find_in_set_set_28221 (
+id INT PRIMARY KEY,
+v SET('z','a','m')
+);
+INSERT INTO find_in_set_set_28221 VALUES
+(1, 'z'), (2, 'a'), (3, 'm'), (4, 'z,a'),
+(5, 'a,m'), (6, 'z,a,m'), (7, ''), (8, NULL);
+SELECT id, v, FIND_IN_SET('a', v) AS a_pos,
+FIND_IN_SET('m', v) AS m_pos
+FROM find_in_set_set_28221 ORDER BY id;
+➤ id[4,32,0]  ¦  v[12,65535,0]  ¦  a_pos[-5,64,0]  ¦  m_pos[-5,64,0]  𝄀
+1  ¦  z  ¦  0  ¦  0  𝄀
+2  ¦  a  ¦  2  ¦  0  𝄀
+3  ¦  m  ¦  0  ¦  3  𝄀
+4  ¦  z,a  ¦  2  ¦  0  𝄀
+5  ¦  a,m  ¦  2  ¦  3  𝄀
+6  ¦  z,a,m  ¦  2  ¦  3  𝄀
+7  ¦    ¦  0  ¦  0  𝄀
+8  ¦  null  ¦  null  ¦  null
+SELECT id, FIND_IN_SET('a', v) AS derived_pos
+FROM (SELECT id, v FROM find_in_set_set_28221) AS d ORDER BY id;
+➤ id[4,32,0]  ¦  derived_pos[-5,64,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  2  𝄀
+3  ¦  0  𝄀
+4  ¦  2  𝄀
+5  ¦  2  𝄀
+6  ¦  2  𝄀
+7  ¦  0  𝄀
+8  ¦  null
+DROP VIEW IF EXISTS find_in_set_set_view_28221;
+CREATE VIEW find_in_set_set_view_28221 AS
+SELECT id, v FROM find_in_set_set_28221;
+SELECT id, FIND_IN_SET('a', v) AS view_pos
+FROM find_in_set_set_view_28221 ORDER BY id;
+➤ id[4,32,0]  ¦  view_pos[-5,64,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  2  𝄀
+3  ¦  0  𝄀
+4  ¦  2  𝄀
+5  ¦  2  𝄀
+6  ¦  2  𝄀
+7  ¦  0  𝄀
+8  ¦  null
+SELECT id, FIND_IN_SET('a', CAST(v AS CHAR)) AS cast_pos
+FROM find_in_set_set_28221 WHERE id IN (2, 4, 5, 6) ORDER BY id;
+➤ id[4,32,0]  ¦  cast_pos[-5,64,0]  𝄀
+2  ¦  1  𝄀
+4  ¦  2  𝄀
+5  ¦  1  𝄀
+6  ¦  2
+PREPARE find_in_set_set_stmt_28221 FROM
+'SELECT id, FIND_IN_SET(?, v) AS prepared_pos
+FROM find_in_set_set_28221 ORDER BY id';
+SET @find_in_set_set_needle_28221 = 'a';
+EXECUTE find_in_set_set_stmt_28221 USING @find_in_set_set_needle_28221;
+➤ id[4,32,0]  ¦  prepared_pos[-5,64,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  2  𝄀
+3  ¦  0  𝄀
+4  ¦  2  𝄀
+5  ¦  2  𝄀
+6  ¦  2  𝄀
+7  ¦  0  𝄀
+8  ¦  null
+DEALLOCATE PREPARE find_in_set_set_stmt_28221;
+DROP VIEW find_in_set_set_view_28221;
+DROP TABLE find_in_set_set_28221;

--- a/test/distributed/cases/function/func_string_findinset_set.test
+++ b/test/distributed/cases/function/func_string_findinset_set.test
@@ -1,0 +1,36 @@
+#FIND_IN_SET on SET uses SET declaration order, not the rendered label order.
+DROP TABLE IF EXISTS find_in_set_set_28221;
+CREATE TABLE find_in_set_set_28221 (
+    id INT PRIMARY KEY,
+    v SET('z','a','m')
+);
+INSERT INTO find_in_set_set_28221 VALUES
+    (1, 'z'), (2, 'a'), (3, 'm'), (4, 'z,a'),
+    (5, 'a,m'), (6, 'z,a,m'), (7, ''), (8, NULL);
+
+SELECT id, v, FIND_IN_SET('a', v) AS a_pos,
+       FIND_IN_SET('m', v) AS m_pos
+FROM find_in_set_set_28221 ORDER BY id;
+
+SELECT id, FIND_IN_SET('a', v) AS derived_pos
+FROM (SELECT id, v FROM find_in_set_set_28221) AS d ORDER BY id;
+
+DROP VIEW IF EXISTS find_in_set_set_view_28221;
+CREATE VIEW find_in_set_set_view_28221 AS
+SELECT id, v FROM find_in_set_set_28221;
+SELECT id, FIND_IN_SET('a', v) AS view_pos
+FROM find_in_set_set_view_28221 ORDER BY id;
+
+# An explicit cast intentionally opts into ordinary comma-list semantics.
+SELECT id, FIND_IN_SET('a', CAST(v AS CHAR)) AS cast_pos
+FROM find_in_set_set_28221 WHERE id IN (2, 4, 5, 6) ORDER BY id;
+
+PREPARE find_in_set_set_stmt_28221 FROM
+    'SELECT id, FIND_IN_SET(?, v) AS prepared_pos
+     FROM find_in_set_set_28221 ORDER BY id';
+SET @find_in_set_set_needle_28221 = 'a';
+EXECUTE find_in_set_set_stmt_28221 USING @find_in_set_set_needle_28221;
+DEALLOCATE PREPARE find_in_set_set_stmt_28221;
+
+DROP VIEW find_in_set_set_view_28221;
+DROP TABLE find_in_set_set_28221;

--- a/test/distributed/cases/function/func_string_findinset_set.test
+++ b/test/distributed/cases/function/func_string_findinset_set.test
@@ -56,4 +56,25 @@ FROM find_in_set_set_empty_28221 ORDER BY id;
 SELECT id, FIND_IN_SET('', v) AS derived_empty_pos
 FROM (SELECT id, v FROM find_in_set_set_empty_28221) AS d ORDER BY id;
 
+# A bare NULL branch is neutral for SET provenance.  The empty member (bitmap
+# 1) must remain distinguishable from the empty bitmap (0), while NULL stays
+# NULL, in either UNION ALL order.
+SELECT id, src, v, FIND_IN_SET('', v) AS union_empty_pos
+FROM (
+    SELECT id, 1 AS src, v
+    FROM find_in_set_set_empty_28221
+    WHERE id IN (1, 2)
+    UNION ALL
+    SELECT 0 AS id, 2 AS src, NULL AS v
+) AS u ORDER BY src, id;
+
+SELECT id, src, v, FIND_IN_SET('', v) AS union_empty_pos
+FROM (
+    SELECT 0 AS id, 1 AS src, NULL AS v
+    UNION ALL
+    SELECT id, 2 AS src, v
+    FROM find_in_set_set_empty_28221
+    WHERE id IN (1, 2)
+) AS u ORDER BY src, id;
+
 DROP TABLE find_in_set_set_empty_28221;

--- a/test/distributed/cases/function/func_string_findinset_set.test
+++ b/test/distributed/cases/function/func_string_findinset_set.test
@@ -30,7 +30,30 @@ PREPARE find_in_set_set_stmt_28221 FROM
      FROM find_in_set_set_28221 ORDER BY id';
 SET @find_in_set_set_needle_28221 = 'a';
 EXECUTE find_in_set_set_stmt_28221 USING @find_in_set_set_needle_28221;
+-- SET labels follow the SET case-insensitive comparison contract even when
+-- the prepared needle changes case between executions.
+SET @find_in_set_set_needle_28221 = 'A';
+EXECUTE find_in_set_set_stmt_28221 USING @find_in_set_set_needle_28221;
 DEALLOCATE PREPARE find_in_set_set_stmt_28221;
 
 DROP VIEW find_in_set_set_view_28221;
 DROP TABLE find_in_set_set_28221;
+
+# An empty SET member is distinct from an empty SET bitmap.  Keep both rows so
+# FIND_IN_SET can prove it is using the stored bitmap rather than display text.
+DROP TABLE IF EXISTS find_in_set_set_empty_28221;
+CREATE TABLE find_in_set_set_empty_28221 (
+    id INT PRIMARY KEY,
+    v SET('','a')
+);
+INSERT INTO find_in_set_set_empty_28221 VALUES
+    (1, 0), (2, 1), (3, 'a'), (4, '');
+
+SELECT id, v, FIND_IN_SET('', v) AS empty_pos,
+       FIND_IN_SET('A', v) AS a_pos
+FROM find_in_set_set_empty_28221 ORDER BY id;
+
+SELECT id, FIND_IN_SET('', v) AS derived_empty_pos
+FROM (SELECT id, v FROM find_in_set_set_empty_28221) AS d ORDER BY id;
+
+DROP TABLE find_in_set_set_empty_28221;


### PR DESCRIPTION
## Summary

Fix `FIND_IN_SET` when the second operand is a MySQL `SET`. The result now uses the SET declaration order instead of the rendered comma-separated label order.

## Root cause

The existing implementation only exposed the ordinary `(VARCHAR, VARCHAR)` overload and split the rendered SET value at execution time. A SET value such as `SET('z','a','m')` renders `'a'` for the stored bitmap `2`, so the executor incorrectly returned position 1 instead of declaration position 2. The same information loss affected derived tables, views, and prepared statements.

## Design and behavior

- Add a planner-only internal overload `(search VARCHAR, stored SET bitmap UINT64, SET definition VARCHAR)`.
- Bind direct SET expressions from their stored bitmap and carry the immutable definition as hidden metadata.
- Recover the stored bitmap at derived-table/view boundaries using the existing SET provenance metadata.
- Keep ordinary two-argument string behavior unchanged; an explicit `CAST(set_col AS CHAR)` still intentionally uses rendered comma-list positions.
- Keep the hidden three-argument form unreachable from public SQL syntax.
- Preserve NULL, no-match, empty-set, prepared-statement, and select-list semantics.

## Performance and risk

The direct SET path no longer splits a rendered value for every row. It builds the definition-to-position map once per execution batch and checks the bitmap in O(1) per row. Ordinary string inputs retain the existing path. Derived/view values require one bitmap reconstruction at the boundary because only the display value crosses that boundary; subsequent matching remains bitmap-based. Valid SET values are limited to the engine's 64-member representation.

## Validation

- `go test ./pkg/sql/plan/function ./pkg/sql/plan -count=1`
- `go test -race ./pkg/sql/plan/function -run TestFindInSet -count=1`
- Dedicated distributed BVT: 25/25 passed twice on the 55 test machine, including direct/derived/view/prepared paths, explicit CAST behavior, a prepared needle whose case changes between executions, and an empty-member SET where bitmap 0 and bitmap 1 render identically.
- Targeted `golangci-lint` for `pkg/sql/plan` and `pkg/sql/plan/function`: 0 issues.
- `git diff --check` passed.

## Follow-up review fixes

- SET member lookup now follows `types.ParseSet` normalization (case folding and trailing-space trimming), so mixed-case needles retain declaration positions.
- Empty-member detection covers every declaration position, not only `SET('', ...)` prefixes.
- Derived/CTE/UNION/projection boundaries with an ambiguous empty member reuse the existing planner bitmap sidecar instead of reconstructing storage from display text; the ordinary conversion path remains unchanged for reversible definitions.
- The BVT checkpoint was generated from the 55 run and reviewed; no service, data directory, or process is retained after validation.

Full static-check analysis remains subject to the repository's existing local native dependency/baseline findings; no new targeted molint finding was introduced.

Fixes #28221