### PR TITLE
fix(function): reject invalid CBC initialization vectors

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -126,6 +126,10 @@ const (
 	// Keep this distinct from ErrInvalidJSONCharset and ErrCharacterSetMismatch
 	// because all three errors are serialized through the internal error code.
 	ErrInvalidBitwiseAggregateOperandsSize uint16 = 20332
+	// These function errors preserve the native MySQL error contract when the
+	// required argument depends on a runtime system variable.
+	ErrWrongParamCountToNativeFct uint16 = 20333
+	ErrAESInvalidIV               uint16 = 20334
 
 	// Group 4: unexpected state and io errors
 	ErrInvalidState                             uint16 = 20400
@@ -480,6 +484,8 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrMultiUpdateKeyConflict:              {ER_MULTI_UPDATE_KEY_CONFLICT, []string{MySQLDefaultSqlState}, "Primary key/partition key update is not allowed since the table is updated both as '%-.192s' and '%-.192s'."},
 	ErrCharacterSetMismatch:                {ER_CHARACTER_SET_MISMATCH, []string{"HY000"}, "Character set '%s' cannot be used in conjunction with '%s' in call to %s."},
 	ErrInvalidBitwiseAggregateOperandsSize: {ER_INVALID_BITWISE_AGGREGATE_OPERANDS_SIZE, []string{MySQLDefaultSqlState}, "Aggregate bitwise functions cannot accept arguments longer than 511 bytes; consider using the SUBSTRING() function"},
+	ErrWrongParamCountToNativeFct:          {ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, []string{"42000"}, "Incorrect parameter count in the call to native function '%-.192s'"},
+	ErrAESInvalidIV:                        {ER_AES_INVALID_IV, []string{"HY000"}, "The initialization vector supplied to %s is too short. Must be at least %d bytes long"},
 
 	// Group 4: unexpected state or file io error
 	ErrInvalidState:                             {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "invalid state %s"},
@@ -1125,6 +1131,14 @@ func NewFtMatchingKeyNotFound(ctx context.Context) *Error {
 
 func NewWrongArguments(ctx context.Context, function string) *Error {
 	return newError(ctx, ErrWrongArguments, function)
+}
+
+func NewWrongParamCountToNativeFct(ctx context.Context, function string) *Error {
+	return newError(ctx, ErrWrongParamCountToNativeFct, function)
+}
+
+func NewAESInvalidIV(ctx context.Context, function string, minLength int) *Error {
+	return newError(ctx, ErrAESInvalidIV, function, minLength)
 }
 
 func NewWrongUsage(ctx context.Context, first, second string) *Error {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -109,6 +109,14 @@ func NewInvalidBitwiseAggregateOperandsSizeNoCtx() *Error {
 	return newError(Context(), ErrInvalidBitwiseAggregateOperandsSize)
 }
 
+func NewWrongParamCountToNativeFctNoCtx(function string) *Error {
+	return newError(Context(), ErrWrongParamCountToNativeFct, function)
+}
+
+func NewAESInvalidIVNoCtx(function string, minLength int) *Error {
+	return newError(Context(), ErrAESInvalidIV, function, minLength)
+}
+
 func NewArrayInvalidOpNoCtx(expected, actual int) *Error {
 	xmsg := fmt.Sprintf("vector ops between different dimensions (%v, %v) is not permitted.", expected, actual)
 	return newError(Context(), ErrInvalidInput, xmsg)

--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -13505,6 +13505,19 @@ type aesModeInfo struct {
 	useCBC  bool
 }
 
+func validateAESIV(functionName string, modeInfo aesModeInfo, hasIV, nullIV bool, iv []byte) error {
+	if !modeInfo.needsIV {
+		return nil
+	}
+	if !hasIV {
+		return moerr.NewWrongParamCountToNativeFctNoCtx(functionName)
+	}
+	if nullIV || len(iv) < aes.BlockSize {
+		return moerr.NewAESInvalidIVNoCtx(functionName, aes.BlockSize)
+	}
+	return nil
+}
+
 func getAESMode(proc *process.Process) (aesModeInfo, error) {
 	mode := "aes-128-ecb"
 	if proc != nil && proc.GetResolveVariableFunc() != nil {
@@ -13560,11 +13573,8 @@ func AESEncrypt(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pro
 			}
 			continue
 		}
-		if modeInfo.needsIV && (!hasIV || nullIV || len(iv) < aes.BlockSize) {
-			if err := rs.AppendBytes(nil, true); err != nil {
-				return err
-			}
-			continue
+		if err := validateAESIV("aes_encrypt", modeInfo, hasIV, nullIV, iv); err != nil {
+			return err
 		}
 
 		aesKey, keyErr := generateAESKey(key, modeInfo.keyLen)
@@ -13633,11 +13643,8 @@ func AESDecrypt(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pro
 			}
 			continue
 		}
-		if modeInfo.needsIV && (!hasIV || nullIV || len(iv) < aes.BlockSize) {
-			if err := rs.AppendBytes(nil, true); err != nil {
-				return err
-			}
-			continue
+		if err := validateAESIV("aes_decrypt", modeInfo, hasIV, nullIV, iv); err != nil {
+			return err
 		}
 
 		aesKey, keyErr := generateAESKey(key, modeInfo.keyLen)

--- a/pkg/sql/plan/function/func_binary_aes_test.go
+++ b/pkg/sql/plan/function/func_binary_aes_test.go
@@ -15,9 +15,11 @@
 package function
 
 import (
+	"crypto/aes"
 	"fmt"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -114,11 +116,25 @@ func TestAESEncryptCBCMissingIV(t *testing.T) {
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{plain}, []bool{false}),
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{key}, []bool{false}),
 		},
-		NewFunctionTestResult(types.T_blob.ToType(), false, []string{""}, []bool{true}),
+		NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil),
 		AESEncrypt,
 	)
 	ok, info := encryptCase.Run()
 	require.True(t, ok, fmt.Sprintf("encrypt cbc missing iv failed: %s", info))
+}
+
+func TestAESDecryptCBCMissingIV(t *testing.T) {
+	proc := newAESProcess(t, "aes-256-cbc")
+	decryptCase := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_blob.ToType(), []string{string(make([]byte, aes.BlockSize))}, []bool{false}),
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"secret-key-for-cbc"}, []bool{false}),
+		},
+		NewFunctionTestResult(types.T_varchar.ToType(), true, nil, nil),
+		AESDecrypt,
+	)
+	ok, info := decryptCase.Run()
+	require.True(t, ok, fmt.Sprintf("decrypt cbc missing iv failed: %s", info))
 }
 
 func TestAESInvalidModeReturnsNull(t *testing.T) {
@@ -163,7 +179,7 @@ func TestAESDecryptInvalidCiphertextReturnsNull(t *testing.T) {
 	require.True(t, ok, fmt.Sprintf("decrypt invalid ciphertext failed: %s", info))
 }
 
-func TestAESCBCIVTooShortReturnsNull(t *testing.T) {
+func TestAESCBCIVTooShortReturnsError(t *testing.T) {
 	proc := newAESProcess(t, "aes-256-cbc")
 	iv := "short"
 
@@ -173,7 +189,7 @@ func TestAESCBCIVTooShortReturnsNull(t *testing.T) {
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{"key"}, []bool{false}),
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{iv}, []bool{false}),
 		},
-		NewFunctionTestResult(types.T_blob.ToType(), false, []string{""}, []bool{true}),
+		NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil),
 		AESEncrypt,
 	)
 	ok, info := encryptCase.Run()
@@ -185,11 +201,107 @@ func TestAESCBCIVTooShortReturnsNull(t *testing.T) {
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{"key"}, []bool{false}),
 			NewFunctionTestInput(types.T_varchar.ToType(), []string{iv}, []bool{false}),
 		},
-		NewFunctionTestResult(types.T_varchar.ToType(), false, []string{""}, []bool{true}),
+		NewFunctionTestResult(types.T_varchar.ToType(), true, nil, nil),
 		AESDecrypt,
 	)
 	ok, info = decryptCase.Run()
 	require.True(t, ok, fmt.Sprintf("decrypt short iv failed: %s", info))
+}
+
+func TestAESCBCInvalidIVErrorCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		fn         fEvalFn
+		proc       *process.Process
+		inputs     []FunctionTestInput
+		resultType types.Type
+		wantCode   uint16
+		wantMySQL  uint16
+	}{
+		{
+			name: "encrypt missing",
+			fn:   AESEncrypt,
+			proc: newAESProcess(t, "aes-256-cbc"),
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"hello"}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"key"}, []bool{false}),
+			},
+			resultType: types.T_blob.ToType(),
+			wantCode:   moerr.ErrWrongParamCountToNativeFct,
+			wantMySQL:  moerr.ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT,
+		},
+		{
+			name: "encrypt null iv",
+			fn:   AESEncrypt,
+			proc: newAESProcess(t, "aes-256-cbc"),
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"hello"}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"key"}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{""}, []bool{true}),
+			},
+			resultType: types.T_blob.ToType(),
+			wantCode:   moerr.ErrAESInvalidIV,
+			wantMySQL:  moerr.ER_AES_INVALID_IV,
+		},
+		{
+			name: "decrypt short",
+			fn:   AESDecrypt,
+			proc: newAESProcess(t, "aes-256-cbc"),
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_blob.ToType(), []string{string(make([]byte, aes.BlockSize))}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"key"}, []bool{false}),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"short"}, []bool{false}),
+			},
+			resultType: types.T_varchar.ToType(),
+			wantCode:   moerr.ErrAESInvalidIV,
+			wantMySQL:  moerr.ER_AES_INVALID_IV,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caseData := NewFunctionTestCase(tt.proc, tt.inputs,
+				NewFunctionTestResult(tt.resultType, true, nil, nil), tt.fn)
+			require.NoError(t, caseData.result.PreExtendAndReset(caseData.fnLength))
+			err := caseData.fn(caseData.parameters, caseData.result, caseData.proc, caseData.fnLength, nil)
+			require.Error(t, err)
+			code, ok := moerr.GetMoErrCode(err)
+			require.True(t, ok)
+			require.Equal(t, tt.wantCode, code)
+			moErr, ok := err.(*moerr.Error)
+			require.True(t, ok)
+			require.Equal(t, tt.wantMySQL, moErr.MySQLCode())
+		})
+	}
+}
+
+func TestAESCBCInvalidIVInMaskedRowIsIgnored(t *testing.T) {
+	proc := newAESProcess(t, "aes-256-cbc")
+	plain := "active row"
+	key := "key"
+	validIV := "0123456789abcdef"
+	aesKey, err := generateAESKey([]byte(key), 32)
+	require.NoError(t, err)
+	wantCiphertext, err := encryptCBC([]byte(plain), aesKey, []byte(validIV))
+	require.NoError(t, err)
+
+	caseData := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"masked row", plain}, nil),
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{key, key}, nil),
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"short", validIV}, nil),
+		},
+		NewFunctionTestResult(types.T_blob.ToType(), false,
+			[]string{"", string(wantCiphertext)}, []bool{true, false}),
+		AESEncrypt).WithSelectList(&FunctionSelectList{
+		AnyNull: true,
+		SelectList: []bool{
+			false,
+			true,
+		},
+	})
+	ok, info := caseData.Run()
+	require.True(t, ok, info)
 }
 
 func TestGenerateAESKeyEdgeCases(t *testing.T) {

--- a/test/distributed/cases/function/func_string_aes_cbc_iv.result
+++ b/test/distributed/cases/function/func_string_aes_cbc_iv.result
@@ -1,0 +1,28 @@
+SET block_encryption_mode = 'aes-256-cbc';
+SELECT AES_ENCRYPT('hello', 'key');
+Incorrect parameter count in the call to native function 'aes_encrypt'
+SELECT AES_ENCRYPT('hello', 'key', NULL);
+The initialization vector supplied to aes_encrypt is too short. Must be at least 16 bytes long
+SELECT AES_ENCRYPT('hello', 'key', 'short');
+The initialization vector supplied to aes_encrypt is too short. Must be at least 16 bytes long
+SELECT AES_DECRYPT(UNHEX('00112233445566778899aabbccddeeff'), 'key');
+Incorrect parameter count in the call to native function 'aes_decrypt'
+SELECT AES_DECRYPT(UNHEX('00112233445566778899aabbccddeeff'), 'key', NULL);
+The initialization vector supplied to aes_decrypt is too short. Must be at least 16 bytes long
+SELECT AES_DECRYPT(UNHEX('00112233445566778899aabbccddeeff'), 'key', 'short');
+The initialization vector supplied to aes_decrypt is too short. Must be at least 16 bytes long
+SELECT AES_ENCRYPT(NULL, 'key') AS null_plaintext_missing_iv;
+➤ null_plaintext_missing_iv[-4,2147483647,0]  𝄀
+null
+SELECT AES_DECRYPT(NULL, 'key') AS null_ciphertext_missing_iv;
+➤ null_ciphertext_missing_iv[-4,2147483647,0]  𝄀
+null
+SELECT LENGTH(AES_ENCRYPT('hello', 'key', '0123456789abcdef')) AS valid_ciphertext_length;
+➤ valid_ciphertext_length[-5,64,0]  𝄀
+16
+SELECT AES_DECRYPT(
+AES_ENCRYPT('hello', 'key', '0123456789abcdef'),
+'key', '0123456789abcdef') AS valid_plaintext;
+➤ valid_plaintext[-4,2147483647,0]  𝄀
+hello
+SET block_encryption_mode = 'aes-128-ecb';

--- a/test/distributed/cases/function/func_string_aes_cbc_iv.test
+++ b/test/distributed/cases/function/func_string_aes_cbc_iv.test
@@ -1,0 +1,29 @@
+# CBC requires an IV at runtime even though both AES functions also expose a
+# two-argument form for ECB. Keep each error statement isolated so the exact
+# MySQL error contract is covered without hiding later cases.
+SET block_encryption_mode = 'aes-256-cbc';
+
+#error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT AES_ENCRYPT('hello', 'key');
+#error ER_AES_INVALID_IV
+SELECT AES_ENCRYPT('hello', 'key', NULL);
+#error ER_AES_INVALID_IV
+SELECT AES_ENCRYPT('hello', 'key', 'short');
+
+#error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT AES_DECRYPT(UNHEX('00112233445566778899aabbccddeeff'), 'key');
+#error ER_AES_INVALID_IV
+SELECT AES_DECRYPT(UNHEX('00112233445566778899aabbccddeeff'), 'key', NULL);
+#error ER_AES_INVALID_IV
+SELECT AES_DECRYPT(UNHEX('00112233445566778899aabbccddeeff'), 'key', 'short');
+
+# NULL input still propagates NULL before CBC IV validation.
+SELECT AES_ENCRYPT(NULL, 'key') AS null_plaintext_missing_iv;
+SELECT AES_DECRYPT(NULL, 'key') AS null_ciphertext_missing_iv;
+
+SELECT LENGTH(AES_ENCRYPT('hello', 'key', '0123456789abcdef')) AS valid_ciphertext_length;
+SELECT AES_DECRYPT(
+    AES_ENCRYPT('hello', 'key', '0123456789abcdef'),
+    'key', '0123456789abcdef') AS valid_plaintext;
+
+SET block_encryption_mode = 'aes-128-ecb';


### PR DESCRIPTION
## Summary

Fix `AES_ENCRYPT()` and `AES_DECRYPT()` silently returning `NULL` for invalid initialization vectors when `block_encryption_mode` is CBC.

## Root cause

The function registry must keep the two-argument AES form because ECB does not need an IV and the active `block_encryption_mode` is a runtime session variable. At execution time, the CBC path detected a missing, NULL, or short IV but appended a NULL result and continued. This collapsed invalid input into a valid nullable result and could hide a configuration/data error.

## Correctness contract

- CBC with no IV returns MySQL `ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT` (1582).
- CBC with a NULL or fewer-than-16-byte IV returns `ER_AES_INVALID_IV` (1882).
- SQL NULL in the plaintext/ciphertext or key still propagates NULL before IV validation, matching MySQL.
- A 16-byte-or-longer IV, ECB mode, and existing invalid-ciphertext NULL behavior remain unchanged.
- A row masked by expression short-circuit/select-list evaluation is not evaluated and cannot raise an IV error.

## Implementation

- Add dedicated MatrixOne error mappings for MySQL 1582 and 1882 so the contract survives the normal error serialization path.
- Centralize the runtime IV validation shared by encryption and decryption.
- Return the typed error from the active row instead of appending a NULL result.

The implementation intentionally does not broaden the currently supported block-mode set or change unrelated AES/KDF behavior.

## Performance and unhappy paths

The valid hot path adds one small mode/length check per active row and allocates nothing. Invalid input returns immediately, avoiding cipher setup and output allocation. The validation remains after normal NULL propagation and select-list masking, preventing false errors from inactive rows.

## Validation

- Compared against MySQL 8.4.10: missing IV produced 1582; NULL/short IV produced 1882.
- MatrixOne baseline reproduced NULL for all six invalid CBC calls; the fixed binary produced the expected errors and retained valid round-trip behavior.
- `go test ./pkg/common/moerr -count=1`
- `go test ./pkg/sql/plan/function ./pkg/sql/plan -count=1`
- `go test -race ./pkg/sql/plan/function -run 'TestAES|TestAESCBC' -count=1`
- Dedicated distributed BVT: 12/12 passed, including both functions, all invalid-IV classes, NULL propagation, and valid CBC round-trip.
- Targeted golangci-lint: 0 issues; targeted molint found no new issue; `git diff --check` passed.

MySQL reference: https://dev.mysql.com/doc/refman/8.4/en/encryption-functions.html

Fixes #28393