### PR TITLE
fix(function): accept boolean values in math functions

### DIFF
--- a/pkg/sql/plan/function/bool_math_test.go
+++ b/pkg/sql/plan/function/bool_math_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,7 @@ func TestMathFunctionsAcceptBoolInNumericContext(t *testing.T) {
 	floatType := types.T_float64.ToType()
 
 	for _, name := range []string{
-		"abs", "sign", "ceil", "floor", "round", "truncate",
+		"abs", "sign", "round", "truncate",
 	} {
 		resolved, err := GetFunctionByName(ctx, name, []types.Type{boolType})
 		require.NoError(t, err, name)
@@ -57,8 +58,6 @@ func TestMathFunctionsAcceptBoolInNumericContext(t *testing.T) {
 		{name: "atan2", args: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
 		{name: "log", args: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
 		{name: "power", args: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
-		{name: "ceil", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
-		{name: "floor", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
 		{name: "round", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
 		{name: "truncate", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
 	} {
@@ -69,6 +68,16 @@ func TestMathFunctionsAcceptBoolInNumericContext(t *testing.T) {
 		for i, want := range tc.want {
 			require.Equal(t, want, resolved.targetTypes[i].Oid, tc.name)
 		}
+	}
+}
+
+func TestMathBooleanCeilFloorKeepExistingStringFallback(t *testing.T) {
+	for _, name := range []string{"ceil", "floor"} {
+		resolved, err := GetFunctionByName(context.Background(), name, []types.Type{types.T_bool.ToType()})
+		require.NoError(t, err, name)
+		require.True(t, resolved.needCast, name)
+		require.Equal(t, types.T_varchar, resolved.targetTypes[0].Oid, name)
+		require.Equal(t, types.T_float64, resolved.retType.Oid, name)
 	}
 }
 
@@ -108,16 +117,86 @@ func TestMathPreparedMarkersKeepNumericTargetsForBooleanValues(t *testing.T) {
 
 func TestMathBoolCastTargetsPreserveValuesAndNulls(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	caseTest := NewFunctionTestCase(proc,
-		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_bool.ToType(), []bool{true, false, true}, []bool{false, true, false}),
-			NewFunctionTestInput(types.T_float64.ToType(), []float64{}, nil),
-		},
-		NewFunctionTestResult(types.T_float64.ToType(), false, []float64{1, 0, 1}, []bool{false, true, false}),
-		NewCast)
+	for _, tc := range []struct {
+		name       string
+		targetType types.Type
+		target     any
+		want       any
+	}{
+		{name: "int64", targetType: types.T_int64.ToType(), target: []int64{}, want: []int64{1, 0, 1}},
+		{name: "float32", targetType: types.T_float32.ToType(), target: []float32{}, want: []float32{1, 0, 1}},
+		{name: "float64", targetType: types.T_float64.ToType(), target: []float64{}, want: []float64{1, 0, 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caseTest := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_bool.ToType(), []bool{true, false, true}, []bool{false, true, false}),
+					NewFunctionTestInput(tc.targetType, tc.target, nil),
+				},
+				NewFunctionTestResult(tc.targetType, false, tc.want, []bool{false, true, false}),
+				NewCast)
 
-	succeed, info := caseTest.Run()
-	require.True(t, succeed, info)
+			succeed, info := caseTest.Run()
+			require.True(t, succeed, info)
+		})
+	}
+}
+
+func TestMathBoolCastsHonorMaskedRows(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	input := newVectorByType(proc.Mp(), types.T_bool.ToType(), []bool{true, false}, nil)
+	target := newVectorByType(proc.Mp(), types.T_float64.ToType(), []float64{0, 0}, nil)
+	result := vector.NewFunctionResultWrapper(types.T_float64.ToType(), proc.Mp())
+	defer input.Free(proc.Mp())
+	defer target.Free(proc.Mp())
+	defer result.Free()
+	require.NoError(t, result.PreExtendAndReset(2))
+	require.NoError(t, NewCast([]*vector.Vector{input, target}, result, proc, 2,
+		&FunctionSelectList{AnyNull: true, SelectList: []bool{true, false}}))
+
+	got := result.GetResultVector()
+	require.Equal(t, float64(1), vector.GetFixedAtNoTypeCheck[float64](got, 0))
+	require.False(t, got.GetNulls().Contains(0))
+	require.True(t, got.GetNulls().Contains(1))
+}
+
+func TestMathBooleanValuesReachMathExecutors(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	castInput := func(t *testing.T, values []bool, targetType types.Type, targetValues []float64) (*vector.Vector, func()) {
+		t.Helper()
+		input := newVectorByType(proc.Mp(), types.T_bool.ToType(), values, nil)
+		target := newVectorByType(proc.Mp(), targetType, targetValues, nil)
+		castResult := vector.NewFunctionResultWrapper(targetType, proc.Mp())
+		require.NoError(t, castResult.PreExtendAndReset(len(values)))
+		require.NoError(t, NewCast([]*vector.Vector{input, target}, castResult, proc, len(values), nil))
+		return castResult.GetResultVector(), func() {
+			castResult.Free()
+			input.Free(proc.Mp())
+			target.Free(proc.Mp())
+		}
+	}
+
+	sin, err := GetFunctionByName(ctx, "sin", []types.Type{types.T_bool.ToType()})
+	require.NoError(t, err)
+	sinInput, releaseSinInput := castInput(t, []bool{true, false}, types.T_float64.ToType(), []float64{0, 0})
+	defer releaseSinInput()
+	sinOutput, err := RunFunctionDirectly(proc, sin.GetEncodedOverloadID(), []*vector.Vector{sinInput}, 2)
+	require.NoError(t, err)
+	require.Equal(t, []float64{0.8414709848078965, 0}, vector.MustFixedColNoTypeCheck[float64](sinOutput))
+	sinOutput.Free(proc.Mp())
+
+	power, err := GetFunctionByName(ctx, "power", []types.Type{types.T_bool.ToType(), types.T_bool.ToType()})
+	require.NoError(t, err)
+	left, releaseLeft := castInput(t, []bool{true, false}, types.T_float64.ToType(), []float64{0, 0})
+	right, releaseRight := castInput(t, []bool{false, true}, types.T_float64.ToType(), []float64{0, 0})
+	defer releaseLeft()
+	defer releaseRight()
+	powerOutput, err := RunFunctionDirectly(proc, power.GetEncodedOverloadID(), []*vector.Vector{left, right}, 2)
+	require.NoError(t, err)
+	require.Equal(t, []float64{1, 0}, vector.MustFixedColNoTypeCheck[float64](powerOutput))
+	powerOutput.Free(proc.Mp())
 }
 
 func TestFixedTypeMatchWithBoolNumericCastKeepsNonNumericFallback(t *testing.T) {

--- a/pkg/sql/plan/function/bool_math_test.go
+++ b/pkg/sql/plan/function/bool_math_test.go
@@ -1,0 +1,129 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMathFunctionsAcceptBoolInNumericContext(t *testing.T) {
+	ctx := context.Background()
+	boolType := types.T_bool.ToType()
+	intType := types.T_int64.ToType()
+	floatType := types.T_float64.ToType()
+
+	for _, name := range []string{
+		"abs", "sign", "ceil", "floor", "round", "truncate",
+	} {
+		resolved, err := GetFunctionByName(ctx, name, []types.Type{boolType})
+		require.NoError(t, err, name)
+		require.True(t, resolved.needCast, name)
+		require.Equal(t, intType.Oid, resolved.targetTypes[0].Oid, name)
+	}
+
+	for _, name := range []string{
+		"sqrt", "acos", "asin", "atan", "degrees", "radians", "cos",
+		"cot", "exp", "ln", "log", "log2", "log10", "sin", "sinh", "tan",
+	} {
+		resolved, err := GetFunctionByName(ctx, name, []types.Type{boolType})
+		require.NoError(t, err, name)
+		require.True(t, resolved.needCast, name)
+		require.Equal(t, floatType.Oid, resolved.targetTypes[0].Oid, name)
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []types.Type
+		want []types.T
+	}{
+		{name: "atan", args: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
+		{name: "atan2", args: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
+		{name: "log", args: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
+		{name: "power", args: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
+		{name: "ceil", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
+		{name: "floor", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
+		{name: "round", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
+		{name: "truncate", args: []types.Type{boolType, boolType}, want: []types.T{types.T_int64, types.T_int64}},
+	} {
+		resolved, err := GetFunctionByName(ctx, tc.name, tc.args)
+		require.NoError(t, err, tc.name)
+		require.True(t, resolved.needCast, tc.name)
+		require.Len(t, resolved.targetTypes, len(tc.want), tc.name)
+		for i, want := range tc.want {
+			require.Equal(t, want, resolved.targetTypes[i].Oid, tc.name)
+		}
+	}
+}
+
+func TestMathPreparedMarkersKeepNumericTargetsForBooleanValues(t *testing.T) {
+	ctx := context.Background()
+	floatType := types.T_float64.ToType()
+	anyType := types.T_any.ToType()
+	boolType := types.T_bool.ToType()
+
+	for _, tc := range []struct {
+		name     string
+		prepared []types.Type
+		bound    []types.Type
+		want     []types.T
+	}{
+		{name: "sin", prepared: []types.Type{anyType}, bound: []types.Type{boolType}, want: []types.T{types.T_float64}},
+		{name: "power", prepared: []types.Type{anyType, anyType}, bound: []types.Type{boolType, boolType}, want: []types.T{types.T_float64, types.T_float64}},
+		{name: "round", prepared: []types.Type{anyType, anyType}, bound: []types.Type{boolType, boolType}, want: []types.T{types.T_uint64, types.T_int64}},
+	} {
+		prepared, err := GetFunctionByName(ctx, tc.name, tc.prepared)
+		require.NoError(t, err, tc.name)
+		require.True(t, prepared.needCast, tc.name)
+		require.Len(t, prepared.targetTypes, len(tc.want), tc.name)
+		for i, want := range tc.want {
+			require.Equal(t, want, prepared.targetTypes[i].Oid, tc.name)
+		}
+
+		bound, err := GetFunctionByName(ctx, tc.name, tc.bound)
+		require.NoError(t, err, tc.name)
+		require.True(t, bound.needCast, tc.name)
+		if tc.name == "sin" {
+			require.Equal(t, floatType.Oid, prepared.targetTypes[0].Oid, tc.name)
+			require.Equal(t, bound.targetTypes[0].Oid, prepared.targetTypes[0].Oid, tc.name)
+		}
+	}
+}
+
+func TestMathBoolCastTargetsPreserveValuesAndNulls(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	caseTest := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_bool.ToType(), []bool{true, false, true}, []bool{false, true, false}),
+			NewFunctionTestInput(types.T_float64.ToType(), []float64{}, nil),
+		},
+		NewFunctionTestResult(types.T_float64.ToType(), false, []float64{1, 0, 1}, []bool{false, true, false}),
+		NewCast)
+
+	succeed, info := caseTest.Run()
+	require.True(t, succeed, info)
+}
+
+func TestFixedTypeMatchWithBoolNumericCastKeepsNonNumericFallback(t *testing.T) {
+	overloads := []overload{{args: []types.T{types.T_varchar}}}
+	result := fixedTypeMatchWithBoolNumericCast(overloads, []types.Type{types.T_bool.ToType()})
+
+	require.Equal(t, succeedWithCast, result.status)
+	require.Equal(t, types.T_varchar, result.finalType[0].Oid)
+}

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -452,6 +452,7 @@ var supportedTypeCast = map[types.T][]types.T{
 		types.T_bit,
 		types.T_int8, types.T_int16, types.T_int32, types.T_int64,
 		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
+		types.T_float32, types.T_float64,
 		types.T_year,
 		types.T_char, types.T_varchar, types.T_blob, types.T_text,
 		types.T_binary, types.T_varbinary,
@@ -1327,6 +1328,12 @@ func boolToOthers(ctx context.Context,
 	case types.T_uint64:
 		rs := vector.MustFunctionResult[uint64](result)
 		return boolToInteger(source, rs, length, selectList)
+	case types.T_float32:
+		rs := vector.MustFunctionResult[float32](result)
+		return boolToFloat(source, rs, length)
+	case types.T_float64:
+		rs := vector.MustFunctionResult[float64](result)
+		return boolToFloat(source, rs, length)
 	case types.T_year:
 		rs := vector.MustFunctionResult[types.MoYear](result)
 		return boolToYear(source, rs, length, selectList)
@@ -3576,6 +3583,30 @@ func boolToInteger[T constraints.Integer](
 					return err
 				}
 			}
+		}
+	}
+	return nil
+}
+
+func boolToFloat[T constraints.Float](
+	from vector.FunctionParameterWrapper[bool],
+	to *vector.FunctionResult[T], length int) error {
+	var i uint64
+	l := uint64(length)
+	for i = 0; i < l; i++ {
+		v, null := from.GetValue(i)
+		if null {
+			if err := to.Append(0, true); err != nil {
+				return err
+			}
+			continue
+		}
+		if v {
+			if err := to.Append(1, false); err != nil {
+				return err
+			}
+		} else if err := to.Append(0, false); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -1330,10 +1330,10 @@ func boolToOthers(ctx context.Context,
 		return boolToInteger(source, rs, length, selectList)
 	case types.T_float32:
 		rs := vector.MustFunctionResult[float32](result)
-		return boolToFloat(source, rs, length)
+		return boolToFloat(source, rs, length, selectList)
 	case types.T_float64:
 		rs := vector.MustFunctionResult[float64](result)
-		return boolToFloat(source, rs, length)
+		return boolToFloat(source, rs, length, selectList)
 	case types.T_year:
 		rs := vector.MustFunctionResult[types.MoYear](result)
 		return boolToYear(source, rs, length, selectList)
@@ -3564,10 +3564,14 @@ func boolToStr(
 func boolToInteger[T constraints.Integer](
 	from vector.FunctionParameterWrapper[bool],
 	to *vector.FunctionResult[T], length int, selectList *FunctionSelectList) error {
-	var i uint64
-	l := uint64(length)
 	var dft T
-	for i = 0; i < l; i++ {
+	for i := uint64(0); i < uint64(length); i++ {
+		if functionRowSkipped(selectList, i) {
+			if err := to.Append(dft, true); err != nil {
+				return err
+			}
+			continue
+		}
 		v, null := from.GetValue(i)
 		if null {
 			if err := to.Append(dft, true); err != nil {
@@ -3590,13 +3594,18 @@ func boolToInteger[T constraints.Integer](
 
 func boolToFloat[T constraints.Float](
 	from vector.FunctionParameterWrapper[bool],
-	to *vector.FunctionResult[T], length int) error {
-	var i uint64
-	l := uint64(length)
-	for i = 0; i < l; i++ {
+	to *vector.FunctionResult[T], length int, selectList *FunctionSelectList) error {
+	var dft T
+	for i := uint64(0); i < uint64(length); i++ {
+		if functionRowSkipped(selectList, i) {
+			if err := to.Append(dft, true); err != nil {
+				return err
+			}
+			continue
+		}
 		v, null := from.GetValue(i)
 		if null {
-			if err := to.Append(0, true); err != nil {
+			if err := to.Append(dft, true); err != nil {
 				return err
 			}
 			continue
@@ -3605,7 +3614,7 @@ func boolToFloat[T constraints.Float](
 			if err := to.Append(1, false); err != nil {
 				return err
 			}
-		} else if err := to.Append(0, false); err != nil {
+		} else if err := to.Append(dft, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -7585,7 +7585,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: ABS,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7675,7 +7675,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: SQRT,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7715,7 +7715,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: SIGN,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7785,7 +7785,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: ACOS,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7806,7 +7806,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: ASIN,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7827,7 +7827,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: ATAN,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7859,7 +7859,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: ATAN2,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7880,7 +7880,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: DEGREES,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -7901,7 +7901,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: RADIANS,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8221,7 +8221,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: CEIL,
 		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8362,7 +8362,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: COS,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8383,7 +8383,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: COT,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8427,7 +8427,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: EXP,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8448,7 +8448,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: FLOOR,
 		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8742,7 +8742,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: LN,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8763,7 +8763,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: LOG,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8794,7 +8794,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: LOG2,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -8815,7 +8815,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: LOG10,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -9018,7 +9018,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: POW,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -9074,7 +9074,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: ROUND,
 		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -9205,7 +9205,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: TRUNCATE,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -9336,7 +9336,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: SIN,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -9357,7 +9357,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: SINH,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{
@@ -9378,7 +9378,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: TAN,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    fixedTypeMatchWithBoolNumericCast,
 
 		Overloads: []overload{
 			{

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -8221,7 +8221,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: CEIL,
 		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatchWithBoolNumericCast,
+		checkFn:    fixedTypeMatch,
 
 		Overloads: []overload{
 			{
@@ -8448,7 +8448,7 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: FLOOR,
 		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatchWithBoolNumericCast,
+		checkFn:    fixedTypeMatch,
 
 		Overloads: []overload{
 			{

--- a/pkg/sql/plan/function/type_check.go
+++ b/pkg/sql/plan/function/type_check.go
@@ -254,6 +254,76 @@ func binTypeMatch(overloads []overload, inputs []types.Type) checkResult {
 	return fixedTypeMatchExcept(overloads, inputs, stringOverload)
 }
 
+// fixedTypeMatchWithBoolNumericCast applies MySQL's numeric-context rule for
+// BOOL only to callers that explicitly opt in.  BOOL is intentionally not
+// added to fixedCanImplicitCastRule globally: that table is shared by
+// unrelated functions where changing overload resolution would be a silent
+// compatibility regression (for example string/bit and binary functions).
+//
+// The matcher first resolves BOOL as INT64 so overload ordering remains the
+// same as for an integer literal.  It then returns the selected overload's
+// actual target type, forcing a real BOOL cast at execution time.  This keeps
+// direct BOOL expressions and prepared parameters on the same path while
+// preserving the existing string fallback for functions that do not opt in.
+func fixedTypeMatchWithBoolNumericCast(overloads []overload, inputs []types.Type) checkResult {
+	hasBool := false
+	for _, input := range inputs {
+		if input.Oid == types.T_bool {
+			hasBool = true
+			break
+		}
+	}
+	if !hasBool {
+		return fixedTypeMatch(overloads, inputs)
+	}
+
+	normalized := append([]types.Type(nil), inputs...)
+	for i := range normalized {
+		if normalized[i].Oid == types.T_bool {
+			normalized[i] = types.T_int64.ToType()
+		}
+	}
+
+	matched := fixedTypeMatch(overloads, normalized)
+	if matched.status != succeedMatched && matched.status != succeedWithCast {
+		// Preserve the ordinary checker's behavior when this overload set has a
+		// non-numeric BOOL-compatible path.
+		return fixedTypeMatch(overloads, inputs)
+	}
+
+	selected := overloads[matched.idx]
+	for i, input := range inputs {
+		if input.Oid != types.T_bool {
+			continue
+		}
+		target := selected.args[i]
+		if !target.ToType().IsNumeric() || !IfTypeCastSupported(types.T_bool, target) {
+			return fixedTypeMatch(overloads, inputs)
+		}
+	}
+
+	if matched.status == succeedWithCast {
+		finalTypes := append([]types.Type(nil), matched.finalType...)
+		for i, input := range inputs {
+			if input.Oid == types.T_bool {
+				finalTypes[i] = selected.args[i].ToType()
+				SetTargetScaleFromSource(&normalized[i], &finalTypes[i])
+			}
+		}
+		return newCheckResultWithCast(matched.idx, finalTypes)
+	}
+
+	finalTypes := make([]types.Type, len(inputs))
+	for i, input := range inputs {
+		finalTypes[i] = input
+		if input.Oid == types.T_bool {
+			finalTypes[i] = selected.args[i].ToType()
+			SetTargetScaleFromSource(&normalized[i], &finalTypes[i])
+		}
+	}
+	return newCheckResultWithCast(matched.idx, finalTypes)
+}
+
 // stringDomainFixedTypeMatch keeps every MySQL string input in its original
 // OID/width/charset while applying the ordinary fixed matcher to control
 // arguments. Varlena string executors can consume every string family; casting

--- a/test/distributed/cases/function/func_math_abs.result
+++ b/test/distributed/cases/function/func_math_abs.result
@@ -25,7 +25,10 @@ abs(cast(-2 as unsigned))	abs(18446744073709551614)	abs(-2)
 CREATE TABLE t(u TINYINT UNSIGNED NOT NULL);
 INSERT INTO t VALUES (0), (3), (255);
 SELECT * FROM t WHERE ABS(u=256)=0;
-invalid argument function abs, bad value [BOOL]
+➤ u[-6,8,0]  𝄀
+0  𝄀
+3  𝄀
+255
 DROP TABLE t;
 create table t1(a int, b int, c int);
 insert into t1 values(100,1,2),(200,1,1),(300,2,1),(400,2,2);


### PR DESCRIPTION
## Summary

Fixes #28484.

MatrixOne rejected or mis-evaluated Boolean expressions in mathematical
functions. In MySQL numeric context, `TRUE` is `1`, `FALSE` is `0`, and `NULL`
remains `NULL`, consistently for direct expressions, predicates, columns, and
prepared parameters.

## Root cause

The affected overload sets used `fixedTypeMatch`, while the global implicit
cast table intentionally did not admit BOOL-to-numeric casts. Prepared markers
could still select a floating-point target, but the runtime BOOL cast
dispatcher had no FLOAT32/FLOAT64 implementation, so execution could reject or
misread a bound Boolean.

## Changes

- Added an opt-in numeric-context matcher that resolves BOOL as INT64 for
  overload selection and then emits a real cast to the selected numeric type.
- Applied it to the affected integer and floating-point math functions,
  including ABS, SQRT, SIGN, ACOS, ASIN, ATAN/ATAN2, COS, COT, SIN/SINH, TAN,
  DEGREES, RADIANS, EXP, LN, LOG/LOG2/LOG10, POWER/POW, ROUND, and TRUNCATE.
- Added BOOL-to-FLOAT32/FLOAT64 conversion with TRUE/FALSE and NULL
  preservation. BOOL-to-integer conversion now also respects expression row
  masks, so a short-circuited row cannot be materialized as a non-NULL value.
- Kept the global implicit-cast table unchanged and left CEIL/FLOOR on their
  existing VARCHAR fallback because those direct Boolean forms already worked;
  this avoids an unrelated return-type change.

## Test plan

- Added overload-resolution coverage for direct and prepared-marker paths,
  binary math arguments, aliases, and non-numeric fallback behavior.
- Added dispatcher tests for BOOL to INT64/FLOAT32/FLOAT64, NULL propagation,
  masked rows, and end-to-end SIN/POWER execution after implicit casts.
- Passed:

  ```text
  ./.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=240s ./pkg/sql/plan/function
  git diff --check
  ```

The branch was rebased onto the latest `main` before updating this PR. CI was
not waited on after the push.