### PR TITLE
fix(function): coerce random bytes length arguments

### DIFF
--- a/pkg/sql/plan/function/func_random_bytes_test.go
+++ b/pkg/sql/plan/function/func_random_bytes_test.go
@@ -69,7 +69,7 @@ func TestRandomBytesCoercesBoolTextFloatAndDecimalLengths(t *testing.T) {
 		want   []int
 	}{
 		{name: "bool", typ: types.T_bool.ToType(), values: []bool{true, false}, nulls: []bool{false, true}, want: []int{1, -1}},
-		{name: "numeric_text", typ: types.T_varchar.ToType(), values: []string{"2tail", "1.5"}, want: []int{2, 1}},
+		{name: "numeric_text", typ: types.T_varchar.ToType(), values: []string{"2tail", "1.5", "\t+2tail"}, want: []int{2, 1, 2}},
 		{name: "binary_integer", typ: types.T_binary.ToType(), values: []string{"\x02"}, want: []int{2}},
 		{name: "float", typ: types.T_float64.ToType(), values: []float64{1.5, 2.5}, want: []int{2, 2}},
 		{name: "decimal", typ: types.New(types.T_decimal64, 10, 1), values: []types.Decimal64{decimalValue}, want: []int{2}},
@@ -127,16 +127,20 @@ func TestRandomBytesUsesPreparedSourceKindForTextTransport(t *testing.T) {
 
 func TestRandomBytesTreatsInvalidNumericTextAsRangeError(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	caseTest := NewFunctionTestCase(proc,
-		[]FunctionTestInput{
-			NewFunctionTestInput(types.T_varchar.ToType(), []string{"abc"}, nil),
-		},
-		NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
+	for _, value := range []string{"abc", "\u00a02"} {
+		t.Run(fmt.Sprintf("%q", value), func(t *testing.T) {
+			caseTest := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{value}, nil),
+				},
+				NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
 
-	require.NoError(t, caseTest.result.PreExtendAndReset(1))
-	err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
-	require.Error(t, err)
-	require.True(t, moerr.IsMoErrCode(err, moerr.ErrPreparedParamOutOfRange), err)
+			require.NoError(t, caseTest.result.PreExtendAndReset(1))
+			err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrPreparedParamOutOfRange), err)
+		})
+	}
 }
 
 func TestRandomBytesRejectsInvalidFloatLengths(t *testing.T) {

--- a/pkg/sql/plan/function/func_random_bytes_test.go
+++ b/pkg/sql/plan/function/func_random_bytes_test.go
@@ -106,7 +106,8 @@ func TestRandomBytesUsesPreparedSourceKindForTextTransport(t *testing.T) {
 		want  int
 	}{
 		{name: "float", kind: vector.PrepareParamFloat, value: "1.5", want: 2},
-		{name: "decimal", kind: vector.PrepareParamDecimal, value: "2.5", want: 2},
+		{name: "decimal", kind: vector.PrepareParamDecimal, value: "2.5", want: 3},
+		{name: "decimal_exact_precision", kind: vector.PrepareParamDecimal, value: "2.5000000000000001", want: 3},
 		{name: "boolean", kind: vector.PrepareParamBoolean, value: "true", want: 1},
 		{name: "long_integer_prefix", kind: vector.PrepareParamNone, value: "0000000000000000000000000000001024tail", want: 1024},
 	} {
@@ -125,6 +126,238 @@ func TestRandomBytesUsesPreparedSourceKindForTextTransport(t *testing.T) {
 	}
 }
 
+func TestRandomBytesDecimalUsesExactSQLRounding(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	run := func(t *testing.T, typ types.Type, values any, want []int) {
+		t.Helper()
+		caseTest := NewFunctionTestCase(proc,
+			[]FunctionTestInput{NewFunctionTestInput(typ, values, nil)},
+			NewFunctionTestResult(types.T_blob.ToType(), false, nil, nil), RandomBytes)
+		require.NoError(t, caseTest.result.PreExtendAndReset(caseTest.fnLength))
+		require.NoError(t, RandomBytes(caseTest.parameters, caseTest.result, proc, caseTest.fnLength, nil))
+		result := caseTest.GetResultVectorDirectly()
+		for row, length := range want {
+			require.False(t, result.IsNull(uint64(row)))
+			require.Len(t, result.GetBytesAt(row), length)
+		}
+	}
+	runOutOfRange := func(t *testing.T, typ types.Type, value any) {
+		t.Helper()
+		caseTest := NewFunctionTestCase(proc,
+			[]FunctionTestInput{NewFunctionTestInput(typ, value, nil)},
+			NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
+		require.NoError(t, caseTest.result.PreExtendAndReset(1))
+		err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrPreparedParamOutOfRange), err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		typ  types.Type
+		make func(string) any
+	}{
+		{
+			name: "decimal64",
+			typ:  types.New(types.T_decimal64, 18, 1),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal64(value, 18, 1)
+				require.NoError(t, err)
+				return []types.Decimal64{parsed}
+			},
+		},
+		{
+			name: "decimal128",
+			typ:  types.New(types.T_decimal128, 38, 1),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal128(value, 38, 1)
+				require.NoError(t, err)
+				return []types.Decimal128{parsed}
+			},
+		},
+		{
+			name: "decimal256",
+			typ:  types.New(types.T_decimal256, 76, 1),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal256(value, 76, 1)
+				require.NoError(t, err)
+				return []types.Decimal256{parsed}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc.typ, tc.make("0.5"), []int{1})
+			run(t, tc.typ, tc.make("2.5"), []int{3})
+			runOutOfRange(t, tc.typ, tc.make("1024.5"))
+		})
+	}
+
+	// This value is exactly representable as a DECIMAL but not as a float64.
+	// Keep the scale high enough to ensure a float conversion cannot silently
+	// change the rounded integer.
+	for _, tc := range []struct {
+		name string
+		typ  types.Type
+		make func(string) any
+	}{
+		{
+			name: "decimal64_precision",
+			typ:  types.New(types.T_decimal64, 18, 16),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal64(value, 18, 16)
+				require.NoError(t, err)
+				return []types.Decimal64{parsed}
+			},
+		},
+		{
+			name: "decimal128_precision",
+			typ:  types.New(types.T_decimal128, 38, 16),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal128(value, 38, 16)
+				require.NoError(t, err)
+				return []types.Decimal128{parsed}
+			},
+		},
+		{
+			name: "decimal256_precision",
+			typ:  types.New(types.T_decimal256, 76, 16),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal256(value, 76, 16)
+				require.NoError(t, err)
+				return []types.Decimal256{parsed}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc.typ, tc.make("2.5000000000000001"), []int{3})
+		})
+	}
+}
+
+func TestRandomBytesHonorsRuntimeTextOverrideForBinaryCommonType(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	t.Run("constant text override", func(t *testing.T) {
+		input, err := vector.NewConstBytes(types.T_varbinary.ToType(), []byte("2"), 1, proc.Mp())
+		require.NoError(t, err)
+		defer input.Free(proc.Mp())
+		require.NoError(t, input.SetRuntimeStringDomainWithMP(types.RuntimeStringText, proc.Mp()))
+
+		result := vector.NewFunctionResultWrapper(types.T_blob.ToType(), proc.Mp())
+		defer result.Free()
+		require.NoError(t, result.PreExtendAndReset(1))
+		require.NoError(t, RandomBytes([]*vector.Vector{input}, result, proc, 1, nil))
+		require.Len(t, result.GetResultVector().GetBytesAt(0), 2)
+	})
+
+	t.Run("mixed prepared text and masked binary", func(t *testing.T) {
+		input := vector.NewVec(types.T_varbinary.ToType())
+		defer input.Free(proc.Mp())
+		require.NoError(t, vector.AppendBytes(input, []byte("2.5"), false, proc.Mp()))
+		require.NoError(t, vector.AppendBytes(input, []byte{0}, false, proc.Mp()))
+		require.NoError(t, input.SetSelectedValueBinaryStringRowsWithMP([]bool{false, true}, proc.Mp()))
+		input.SetPrepareParamKinds([]vector.PrepareParamKind{
+			vector.PrepareParamDecimal,
+			vector.PrepareParamNone,
+		})
+
+		result := vector.NewFunctionResultWrapper(types.T_blob.ToType(), proc.Mp())
+		defer result.Free()
+		require.NoError(t, result.PreExtendAndReset(2))
+		selectList := &FunctionSelectList{AnyNull: true, SelectList: []bool{true, false}}
+		require.NoError(t, RandomBytes([]*vector.Vector{input}, result, proc, 2, selectList))
+		require.Len(t, result.GetResultVector().GetBytesAt(0), 3)
+		require.True(t, result.GetResultVector().IsNull(1))
+	})
+}
+
+func TestRandomBytesCoversAllAcceptedScalarGetterTypes(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	year, err := types.ParseMoYearFromInt(1)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		typ     types.Type
+		values  any
+		want    int
+		wantErr bool
+	}{
+		{name: "bit", typ: types.T_bit.ToType(), values: []uint64{1}, want: 1},
+		{name: "int8", typ: types.T_int8.ToType(), values: []int8{1}, want: 1},
+		{name: "int16", typ: types.T_int16.ToType(), values: []int16{1}, want: 1},
+		{name: "int32", typ: types.T_int32.ToType(), values: []int32{1}, want: 1},
+		{name: "int64", typ: types.T_int64.ToType(), values: []int64{1}, want: 1},
+		{name: "uint8", typ: types.T_uint8.ToType(), values: []uint8{1}, want: 1},
+		{name: "uint16", typ: types.T_uint16.ToType(), values: []uint16{1}, want: 1},
+		{name: "uint32", typ: types.T_uint32.ToType(), values: []uint32{1}, want: 1},
+		{name: "uint64", typ: types.T_uint64.ToType(), values: []uint64{1}, want: 1},
+		{name: "float32", typ: types.T_float32.ToType(), values: []float32{1.5}, want: 2},
+		{name: "float64", typ: types.T_float64.ToType(), values: []float64{1.5}, want: 2},
+		{name: "year", typ: types.T_year.ToType(), values: []types.MoYear{year}, wantErr: true},
+		{name: "char", typ: types.T_char.ToType(), values: []string{"2"}, want: 2},
+		{name: "text", typ: types.T_text.ToType(), values: []string{"2"}, want: 2},
+		{name: "blob", typ: types.T_blob.ToType(), values: []string{"\x02"}, want: 2},
+		{name: "binary", typ: types.T_binary.ToType(), values: []string{"\x02"}, want: 2},
+		{name: "varbinary", typ: types.T_varbinary.ToType(), values: []string{"\x02"}, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caseTest := NewFunctionTestCase(proc,
+				[]FunctionTestInput{NewFunctionTestInput(tt.typ, tt.values, nil)},
+				NewFunctionTestResult(types.T_blob.ToType(), false, nil, nil), RandomBytes)
+			require.NoError(t, caseTest.result.PreExtendAndReset(1))
+			err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, caseTest.GetResultVectorDirectly().GetBytesAt(0), tt.want)
+		})
+	}
+}
+
+func TestRandomBytesRejectsInvalidBinaryLengths(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "too_wide", value: "123456789"},
+		{name: "signed_overflow", value: "\x80\x00\x00\x00\x00\x00\x00\x00"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caseTest := NewFunctionTestCase(proc,
+				[]FunctionTestInput{NewFunctionTestInput(types.T_binary.ToType(), []string{tc.value}, nil)},
+				NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
+			require.NoError(t, caseTest.result.PreExtendAndReset(1))
+			err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRandomBytesRejectsInvalidParameterShapeAndType(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	result := vector.NewFunctionResultWrapper(types.T_blob.ToType(), proc.Mp())
+	defer result.Free()
+	require.NoError(t, result.PreExtendAndReset(1))
+	require.Error(t, randomBytesWithReader(nil, result, proc, 1, nil, func([]byte) (int, error) {
+		return 0, nil
+	}))
+	require.Error(t, randomBytesWithReader([]*vector.Vector{nil}, result, proc, 1, nil, func([]byte) (int, error) {
+		return 0, nil
+	}))
+
+	unsupported := vector.NewVec(types.T_date.ToType())
+	defer unsupported.Free(proc.Mp())
+	_, err := makeRandomBytesLengthGetter(unsupported, proc)
+	require.Error(t, err)
+}
+
 func TestRandomBytesTreatsInvalidNumericTextAsRangeError(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	for _, value := range []string{"abc", "\u00a02"} {
@@ -134,6 +367,25 @@ func TestRandomBytesTreatsInvalidNumericTextAsRangeError(t *testing.T) {
 					NewFunctionTestInput(types.T_varchar.ToType(), []string{value}, nil),
 				},
 				NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
+
+			require.NoError(t, caseTest.result.PreExtendAndReset(1))
+			err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrPreparedParamOutOfRange), err)
+		})
+	}
+}
+
+func TestRandomBytesTreatsInvalidPreparedDecimalAsRangeError(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	for _, value := range []string{"1/2", "1e999", "1.2.3"} {
+		t.Run(value, func(t *testing.T) {
+			caseTest := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_text.ToType(), []string{value}, nil),
+				},
+				NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
+			caseTest.parameters[0].SetPrepareParamKind(vector.PrepareParamDecimal)
 
 			require.NoError(t, caseTest.result.PreExtendAndReset(1))
 			err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)

--- a/pkg/sql/plan/function/func_random_bytes_test.go
+++ b/pkg/sql/plan/function/func_random_bytes_test.go
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -22,9 +23,162 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRandomBytesTypeCheckAcceptsMysqlCoercibleArguments(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		typ      types.Type
+		overload int32
+	}{
+		{typ: types.T_any.ToType(), overload: 2},
+		{typ: types.T_bool.ToType(), overload: 2},
+		{typ: types.T_int8.ToType(), overload: 2},
+		{typ: types.T_int64.ToType(), overload: 0},
+		{typ: types.T_uint64.ToType(), overload: 1},
+		{typ: types.T_float64.ToType(), overload: 2},
+		{typ: types.T_decimal64.ToType(), overload: 2},
+		{typ: types.T_varchar.ToType(), overload: 2},
+		{typ: types.T_binary.ToType(), overload: 2},
+		{typ: types.T_year.ToType(), overload: 2},
+	} {
+		resolved, err := GetFunctionByName(ctx, "random_bytes", []types.Type{tc.typ})
+		require.NoError(t, err, tc.typ)
+		require.Equal(t, tc.overload, resolved.overloadId, tc.typ)
+		require.False(t, resolved.needCast, tc.typ)
+		require.Equal(t, types.T_blob, resolved.retType.Oid, tc.typ)
+	}
+
+	_, err := GetFunctionByName(ctx, "random_bytes", []types.Type{types.T_date.ToType()})
+	require.Error(t, err)
+}
+
+func TestRandomBytesCoercesBoolTextFloatAndDecimalLengths(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	decimalValue, err := types.Decimal64FromFloat64(1.5, 10, 1)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		typ    types.Type
+		values any
+		nulls  []bool
+		want   []int
+	}{
+		{name: "bool", typ: types.T_bool.ToType(), values: []bool{true, false}, nulls: []bool{false, true}, want: []int{1, -1}},
+		{name: "numeric_text", typ: types.T_varchar.ToType(), values: []string{"2tail", "1.5"}, want: []int{2, 1}},
+		{name: "binary_integer", typ: types.T_binary.ToType(), values: []string{"\x02"}, want: []int{2}},
+		{name: "float", typ: types.T_float64.ToType(), values: []float64{1.5, 2.5}, want: []int{2, 2}},
+		{name: "decimal", typ: types.New(types.T_decimal64, 10, 1), values: []types.Decimal64{decimalValue}, want: []int{2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{NewFunctionTestInput(tt.typ, tt.values, tt.nulls)}
+			caseTest := NewFunctionTestCase(proc, inputs,
+				NewFunctionTestResult(types.T_blob.ToType(), false, nil, nil), RandomBytes)
+			require.NoError(t, caseTest.result.PreExtendAndReset(caseTest.fnLength))
+			require.NoError(t, RandomBytes(caseTest.parameters, caseTest.result, proc, caseTest.fnLength, nil))
+
+			result := caseTest.GetResultVectorDirectly()
+			require.Equal(t, len(tt.want), result.Length())
+			for i, want := range tt.want {
+				if want < 0 {
+					require.True(t, result.IsNull(uint64(i)))
+					continue
+				}
+				require.False(t, result.IsNull(uint64(i)))
+				require.Len(t, result.GetBytesAt(i), want)
+			}
+		})
+	}
+}
+
+func TestRandomBytesUsesPreparedSourceKindForTextTransport(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	for _, tc := range []struct {
+		name  string
+		kind  vector.PrepareParamKind
+		value string
+		want  int
+	}{
+		{name: "float", kind: vector.PrepareParamFloat, value: "1.5", want: 2},
+		{name: "decimal", kind: vector.PrepareParamDecimal, value: "2.5", want: 2},
+		{name: "boolean", kind: vector.PrepareParamBoolean, value: "true", want: 1},
+		{name: "long_integer_prefix", kind: vector.PrepareParamNone, value: "0000000000000000000000000000001024tail", want: 1024},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caseTest := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_text.ToType(), []string{tc.value}, nil),
+				},
+				NewFunctionTestResult(types.T_blob.ToType(), false, nil, nil), RandomBytes)
+			caseTest.parameters[0].SetPrepareParamKind(tc.kind)
+
+			require.NoError(t, caseTest.result.PreExtendAndReset(1))
+			require.NoError(t, RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil))
+			require.Len(t, caseTest.GetResultVectorDirectly().GetBytesAt(0), tc.want)
+		})
+	}
+}
+
+func TestRandomBytesTreatsInvalidNumericTextAsRangeError(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	caseTest := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"abc"}, nil),
+		},
+		NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
+
+	require.NoError(t, caseTest.result.PreExtendAndReset(1))
+	err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrPreparedParamOutOfRange), err)
+}
+
+func TestRandomBytesRejectsInvalidFloatLengths(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	for _, value := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), 0.5, 1024.6, -1.5} {
+		t.Run(fmt.Sprintf("%v", value), func(t *testing.T) {
+			caseTest := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_float64.ToType(), []float64{value}, nil),
+				},
+				NewFunctionTestResult(types.T_blob.ToType(), true, nil, nil), RandomBytes)
+
+			require.NoError(t, caseTest.result.PreExtendAndReset(1))
+			err := RandomBytes(caseTest.parameters, caseTest.result, proc, 1, nil)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrPreparedParamOutOfRange), err)
+		})
+	}
+}
+
+func TestRandomBytesPreservesUntypedNullAndSkipsMaskedRows(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	input := vector.NewConstNull(types.T_any.ToType(), 2, proc.Mp())
+	defer input.Free(proc.Mp())
+	result := vector.NewFunctionResultWrapper(types.T_blob.ToType(), proc.Mp())
+	defer result.Free()
+	require.NoError(t, result.PreExtendAndReset(2))
+	require.NoError(t, RandomBytes([]*vector.Vector{input}, result, proc, 2, nil))
+	require.True(t, result.GetResultVector().IsNull(0))
+	require.True(t, result.GetResultVector().IsNull(1))
+
+	caseTest := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_varchar.ToType(), []string{"2", "not-a-number"}, nil),
+		},
+		NewFunctionTestResult(types.T_blob.ToType(), false, nil, nil), RandomBytes)
+	selectList := &FunctionSelectList{AnyNull: true, SelectList: []bool{true, false}}
+	require.NoError(t, caseTest.result.PreExtendAndReset(2))
+	require.NoError(t, RandomBytes(caseTest.parameters, caseTest.result, proc, 2, selectList))
+	require.Len(t, caseTest.GetResultVectorDirectly().GetBytesAt(0), 2)
+	require.True(t, caseTest.GetResultVectorDirectly().IsNull(1))
+}
 
 func TestRandomBytesAcceptsBoundsAndNull(t *testing.T) {
 	proc := testutil.NewProcess(t)

--- a/pkg/sql/plan/function/func_random_bytes_test.go
+++ b/pkg/sql/plan/function/func_random_bytes_test.go
@@ -232,6 +232,68 @@ func TestRandomBytesDecimalUsesExactSQLRounding(t *testing.T) {
 			run(t, tc.typ, tc.make("2.5000000000000001"), []int{3})
 		})
 	}
+
+	// Decimal128 and Decimal256 use multiple 19-digit division chunks in
+	// Decimal.Scale. RANDOM_BYTES must round the original decimal once rather
+	// than round an intermediate chunk (for example, 0.49 must not become 1).
+	for _, tc := range []struct {
+		name string
+		typ  types.Type
+		make func(string) any
+	}{
+		{
+			name: "decimal128_high_scale",
+			typ:  types.New(types.T_decimal128, 38, 20),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal128(value, 38, 20)
+				require.NoError(t, err)
+				return []types.Decimal128{parsed}
+			},
+		},
+		{
+			name: "decimal256_high_scale",
+			typ:  types.New(types.T_decimal256, 76, 40),
+			make: func(value string) any {
+				parsed, err := types.ParseDecimal256(value, 76, 40)
+				require.NoError(t, err)
+				return []types.Decimal256{parsed}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc.typ, tc.make("2.49"), []int{2})
+			run(t, tc.typ, tc.make("1024.49"), []int{1024})
+			runOutOfRange(t, tc.typ, tc.make("0.49"))
+			runOutOfRange(t, tc.typ, tc.make("1024.5"))
+		})
+	}
+}
+
+func TestRandomBytesDecimalHighScalePathsAgree(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	typ := types.New(types.T_decimal128, 38, 20)
+	value, err := types.ParseDecimal128("2.49", 38, 20)
+	require.NoError(t, err)
+
+	run := func(t *testing.T, input FunctionTestInput) int {
+		t.Helper()
+		caseTest := NewFunctionTestCase(proc, []FunctionTestInput{input},
+			NewFunctionTestResult(types.T_blob.ToType(), false, nil, nil), RandomBytes)
+		require.NoError(t, caseTest.result.PreExtendAndReset(caseTest.fnLength))
+		require.NoError(t, RandomBytes(caseTest.parameters, caseTest.result, proc, caseTest.fnLength, nil))
+		return len(caseTest.GetResultVectorDirectly().GetBytesAt(0))
+	}
+
+	require.Equal(t, 2, run(t, NewFunctionTestInput(typ, []types.Decimal128{value}, nil)))
+	require.Equal(t, 2, run(t, NewFunctionTestConstInput(typ, []types.Decimal128{value}, nil)))
+
+	prepared := NewFunctionTestCase(proc,
+		[]FunctionTestInput{NewFunctionTestInput(types.T_text.ToType(), []string{"2.49"}, nil)},
+		NewFunctionTestResult(types.T_blob.ToType(), false, nil, nil), RandomBytes)
+	prepared.parameters[0].SetPrepareParamKind(vector.PrepareParamDecimal)
+	require.NoError(t, prepared.result.PreExtendAndReset(1))
+	require.NoError(t, RandomBytes(prepared.parameters, prepared.result, proc, 1, nil))
+	require.Len(t, prepared.GetResultVectorDirectly().GetBytesAt(0), 2)
 }
 
 func TestRandomBytesHonorsRuntimeTextOverrideForBinaryCommonType(t *testing.T) {

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -8211,6 +8211,13 @@ func randomBytesRoundedDecimalIntegerString(integer string, proc *process.Proces
 }
 
 func randomBytesRoundedDecimal64(value types.Decimal64, scale int32, proc *process.Process) (int64, error) {
+	// Decimal64 normally has at most 18 fractional digits, so keep the
+	// allocation-free fixed-width path for the common case. Scale splits a
+	// larger divisor into 19-digit chunks and rounds each chunk; use the exact
+	// decimal conversion helper whenever that split would be needed.
+	if scale > 19 {
+		return randomBytesRoundedDecimalIntegerString(decimal64RoundedIntegerString(value, scale), proc)
+	}
 	rounded, err := value.Scale(-scale)
 	if err != nil || rounded.Sign() || uint64(rounded) < 1 || uint64(rounded) > randomBytesMaxLength {
 		return 0, randomBytesRangeError(proc)
@@ -8219,6 +8226,9 @@ func randomBytesRoundedDecimal64(value types.Decimal64, scale int32, proc *proce
 }
 
 func randomBytesRoundedDecimal128(value types.Decimal128, scale int32, proc *process.Process) (int64, error) {
+	if scale > 19 {
+		return randomBytesRoundedDecimalIntegerString(decimal128RoundedIntegerString(value, scale), proc)
+	}
 	rounded, err := value.Scale(-scale)
 	if err != nil || rounded.Sign() || rounded.B64_127 != 0 || rounded.B0_63 < 1 || rounded.B0_63 > randomBytesMaxLength {
 		return 0, randomBytesRangeError(proc)
@@ -8227,6 +8237,9 @@ func randomBytesRoundedDecimal128(value types.Decimal128, scale int32, proc *pro
 }
 
 func randomBytesRoundedDecimal256(value types.Decimal256, scale int32, proc *process.Process) (int64, error) {
+	if scale > 19 {
+		return randomBytesRoundedDecimalIntegerString(decimal256RoundedIntegerString(value, scale), proc)
+	}
 	rounded, err := value.Scale(-scale)
 	if err != nil || rounded.Sign() || rounded.B192_255 != 0 || rounded.B128_191 != 0 || rounded.B64_127 != 0 || rounded.B0_63 < 1 || rounded.B0_63 > randomBytesMaxLength {
 		return 0, randomBytesRangeError(proc)

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -8145,11 +8145,313 @@ func UncompressedLength(parameters []*vector.Vector, result vector.FunctionResul
 
 const randomBytesMaxLength = 1024
 
+func randomBytesCheck(_ []overload, inputs []types.Type) checkResult {
+	if len(inputs) != 1 {
+		return newCheckResultWithFailure(failedFunctionParametersWrong)
+	}
+
+	switch inputs[0].Oid {
+	case types.T_int64:
+		return newCheckResultWithSuccess(0)
+	case types.T_uint64:
+		return newCheckResultWithSuccess(1)
+	case types.T_any,
+		types.T_bool, types.T_bit,
+		types.T_int8, types.T_int16, types.T_int32,
+		types.T_uint8, types.T_uint16, types.T_uint32,
+		types.T_float32, types.T_float64,
+		types.T_decimal64, types.T_decimal128, types.T_decimal256,
+		types.T_year,
+		types.T_char, types.T_varchar, types.T_blob, types.T_text,
+		types.T_binary, types.T_varbinary:
+		// Keep the source domain intact. Numeric values are rounded while
+		// strings consume a leading integer prefix, and prepared parameters
+		// must retain the type that was bound at execution time.
+		return newCheckResultWithSuccess(2)
+	default:
+		return newCheckResultWithFailure(failedFunctionParametersWrong)
+	}
+}
+
 // RandomBytes: RANDOM_BYTES(len) - Returns a binary string of len random bytes
 // Uses crypto/rand for cryptographically secure random bytes
-// Handles both int64 and uint64 parameter types.
+// Handles MySQL numeric and numeric-string argument coercions.
 func RandomBytes(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	return randomBytesWithReader(parameters, result, proc, length, selectList, rand.Read)
+}
+
+type randomBytesLengthGetter func(uint64) (int64, bool, error)
+
+func randomBytesRangeError(proc *process.Process) error {
+	return moerr.NewPreparedParamOutOfRange(proc.Ctx, "length", "random_bytes")
+}
+
+func randomBytesRoundedFloat(value float64, proc *process.Process) (int64, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, randomBytesRangeError(proc)
+	}
+	rounded := math.RoundToEven(value)
+	if rounded < 1 || rounded > randomBytesMaxLength {
+		return 0, randomBytesRangeError(proc)
+	}
+	return int64(rounded), nil
+}
+
+// parseRandomBytesIntegerPrefix follows MySQL's integer conversion for string
+// arguments, but only retains the range that RANDOM_BYTES can accept. Capping
+// as soon as the value exceeds 1024 avoids int64 overflow and still accepts
+// arbitrarily many leading zeroes (for example, "000...1024").
+func parseRandomBytesIntegerPrefix(s string) int64 {
+	if len(s) == 0 {
+		return 0
+	}
+	start := 0
+	negative := false
+	if s[0] == '+' || s[0] == '-' {
+		negative = s[0] == '-'
+		start = 1
+	}
+
+	value := int64(0)
+	hasDigit := false
+	for i := start; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			break
+		}
+		hasDigit = true
+		digit := int64(s[i] - '0')
+		if value > (randomBytesMaxLength-digit)/10 {
+			if negative {
+				return -1
+			}
+			return randomBytesMaxLength + 1
+		}
+		value = value*10 + digit
+	}
+	if !hasDigit || value == 0 {
+		return 0
+	}
+	if negative {
+		return -value
+	}
+	return value
+}
+
+func randomBytesTextLength(
+	param *vector.Vector,
+	value []byte,
+	row uint64,
+	proc *process.Process,
+) (int64, error) {
+	text := strings.TrimSpace(functionUtil.QuickBytesToStr(value))
+	switch param.GetPrepareParamKindAt(int(row)) {
+	case vector.PrepareParamFloat, vector.PrepareParamDecimal:
+		// SQL PREPARE stores the value in a text transport vector. The source
+		// kind is the distinction between a string literal (integer prefix) and
+		// a numeric value (round-to-even).
+		floating, err := strconv.ParseFloat(text, 64)
+		if err != nil {
+			return 0, randomBytesRangeError(proc)
+		}
+		return randomBytesRoundedFloat(floating, proc)
+	case vector.PrepareParamBoolean:
+		boolean, err := strconv.ParseBool(text)
+		if err != nil {
+			return 0, randomBytesRangeError(proc)
+		}
+		if boolean {
+			return 1, nil
+		}
+		return 0, nil
+	default:
+		return parseRandomBytesIntegerPrefix(text), nil
+	}
+}
+
+func makeRandomBytesLengthGetter(param *vector.Vector, proc *process.Process) (randomBytesLengthGetter, error) {
+	if param == nil {
+		return nil, moerr.NewInvalidArg(proc.Ctx, "function random_bytes", "nil argument")
+	}
+
+	rangeError := func() error { return randomBytesRangeError(proc) }
+	switch param.GetType().Oid {
+	case types.T_any:
+		return func(i uint64) (int64, bool, error) {
+			if param.IsNull(i) {
+				return 0, true, nil
+			}
+			return 0, false, moerr.NewInvalidArg(proc.Ctx, "function random_bytes", "untyped non-NULL argument")
+		}, nil
+	case types.T_bool:
+		p := vector.GenerateFunctionFixedTypeParameter[bool](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			if value {
+				return 1, false, nil
+			}
+			return 0, false, nil
+		}, nil
+	case types.T_bit:
+		p := vector.GenerateFunctionFixedTypeParameter[uint64](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			if value > randomBytesMaxLength {
+				return 0, false, rangeError()
+			}
+			return int64(value), false, nil
+		}, nil
+	case types.T_int8:
+		p := vector.GenerateFunctionFixedTypeParameter[int8](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return int64(value), null, nil
+		}, nil
+	case types.T_int16:
+		p := vector.GenerateFunctionFixedTypeParameter[int16](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return int64(value), null, nil
+		}, nil
+	case types.T_int32:
+		p := vector.GenerateFunctionFixedTypeParameter[int32](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return int64(value), null, nil
+		}, nil
+	case types.T_int64:
+		p := vector.GenerateFunctionFixedTypeParameter[int64](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return value, null, nil
+		}, nil
+	case types.T_uint8:
+		p := vector.GenerateFunctionFixedTypeParameter[uint8](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return int64(value), null, nil
+		}, nil
+	case types.T_uint16:
+		p := vector.GenerateFunctionFixedTypeParameter[uint16](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return int64(value), null, nil
+		}, nil
+	case types.T_uint32:
+		p := vector.GenerateFunctionFixedTypeParameter[uint32](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return int64(value), null, nil
+		}, nil
+	case types.T_uint64:
+		p := vector.GenerateFunctionFixedTypeParameter[uint64](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			if value > randomBytesMaxLength {
+				return 0, false, rangeError()
+			}
+			return int64(value), false, nil
+		}, nil
+	case types.T_float32:
+		p := vector.GenerateFunctionFixedTypeParameter[float32](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			converted, err := randomBytesRoundedFloat(float64(value), proc)
+			return converted, false, err
+		}, nil
+	case types.T_float64:
+		p := vector.GenerateFunctionFixedTypeParameter[float64](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			converted, err := randomBytesRoundedFloat(value, proc)
+			return converted, false, err
+		}, nil
+	case types.T_decimal64:
+		p := vector.GenerateFunctionFixedTypeParameter[types.Decimal64](param)
+		scale := param.GetType().Scale
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			converted, err := randomBytesRoundedFloat(types.Decimal64ToFloat64(value, scale), proc)
+			return converted, false, err
+		}, nil
+	case types.T_decimal128:
+		p := vector.GenerateFunctionFixedTypeParameter[types.Decimal128](param)
+		scale := param.GetType().Scale
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			converted, err := randomBytesRoundedFloat(types.Decimal128ToFloat64(value, scale), proc)
+			return converted, false, err
+		}, nil
+	case types.T_decimal256:
+		p := vector.GenerateFunctionFixedTypeParameter[types.Decimal256](param)
+		scale := param.GetType().Scale
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			if null {
+				return 0, true, nil
+			}
+			converted, err := randomBytesRoundedFloat(types.Decimal256ToFloat64(value, scale), proc)
+			return converted, false, err
+		}, nil
+	case types.T_year:
+		p := vector.GenerateFunctionFixedTypeParameter[types.MoYear](param)
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetValue(i)
+			return value.ToInt64(), null, nil
+		}, nil
+	case types.T_char, types.T_varchar, types.T_blob, types.T_text,
+		types.T_binary, types.T_varbinary:
+		p := vector.GenerateFunctionStrParameter(param)
+		isBinary := param.GetIsBin() ||
+			types.StaticStringDomain(*param.GetType()) == types.StringDomainBinary ||
+			param.GetIsBinaryString()
+		return func(i uint64) (int64, bool, error) {
+			value, null := p.GetStrValue(i)
+			if null {
+				return 0, true, nil
+			}
+			if isBinary || param.GetIsBinaryStringAt(int(i)) {
+				if len(value) == 0 {
+					return 0, false, moerr.NewInvalidArg(proc.Ctx, "cast to int", value)
+				}
+				if len(value) > 8 {
+					return 0, false, moerr.NewOutOfRange(proc.Ctx, "int", "")
+				}
+				var parsed uint64
+				for _, b := range value {
+					parsed = (parsed << 8) | uint64(b)
+					if parsed > math.MaxInt64 {
+						return 0, false, moerr.NewOutOfRange(proc.Ctx, "int", "")
+					}
+				}
+				return int64(parsed), false, nil
+			}
+			parsed, err := randomBytesTextLength(param, value, i, proc)
+			return parsed, false, err
+		}, nil
+	default:
+		return nil, moerr.NewInvalidArg(proc.Ctx, "function random_bytes", param.GetType().Oid.String())
+	}
 }
 
 // randomBytesWithReader contains the execution logic behind RandomBytes and
@@ -8164,8 +8466,14 @@ func randomBytesWithReader(
 	selectList *FunctionSelectList,
 	read func([]byte) (int, error),
 ) error {
+	if len(parameters) != 1 {
+		return moerr.NewInvalidArg(proc.Ctx, "function random_bytes", fmt.Sprintf("expected 1 argument, got %d", len(parameters)))
+	}
 	rs := vector.MustFunctionResult[types.Varlena](result)
-	paramType := parameters[0].GetType().Oid
+	getLength, err := makeRandomBytesLengthGetter(parameters[0], proc)
+	if err != nil {
+		return err
+	}
 
 	rowCount := uint64(length)
 	for i := uint64(0); i < rowCount; i++ {
@@ -8176,30 +8484,9 @@ func randomBytesWithReader(
 			continue
 		}
 
-		var lenVal int64
-		var null bool
-
-		// Handle different numeric types
-		switch paramType {
-		case types.T_int64:
-			lenParam := vector.GenerateFunctionFixedTypeParameter[int64](parameters[0])
-			val, nullVal := lenParam.GetValue(i)
-			lenVal = val
-			null = nullVal
-		case types.T_uint64:
-			lenParam := vector.GenerateFunctionFixedTypeParameter[uint64](parameters[0])
-			val, nullVal := lenParam.GetValue(i)
-			if !nullVal && val > randomBytesMaxLength {
-				return moerr.NewPreparedParamOutOfRange(proc.Ctx, "length", "random_bytes")
-			}
-			lenVal = int64(val)
-			null = nullVal
-		default:
-			// Fallback to int64
-			lenParam := vector.GenerateFunctionFixedTypeParameter[int64](parameters[0])
-			val, nullVal := lenParam.GetValue(i)
-			lenVal = val
-			null = nullVal
+		lenVal, null, err := getLength(i)
+		if err != nil {
+			return err
 		}
 
 		if null {
@@ -8214,12 +8501,12 @@ func randomBytesWithReader(
 		// result; otherwise a query can silently return a wrong value or a
 		// partial result for a column containing an invalid length.
 		if lenVal < 1 || lenVal > randomBytesMaxLength {
-			return moerr.NewPreparedParamOutOfRange(proc.Ctx, "length", "random_bytes")
+			return randomBytesRangeError(proc)
 		}
 
 		// Generate random bytes using crypto/rand
 		randomBytes := make([]byte, lenVal)
-		_, err := read(randomBytes)
+		_, err = read(randomBytes)
 		if err != nil {
 			return moerr.NewInternalErrorf(proc.Ctx, "random_bytes failed to generate %d bytes: %v", lenVal, err)
 		}

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -8197,55 +8197,15 @@ func randomBytesRoundedFloat(value float64, proc *process.Process) (int64, error
 	return int64(rounded), nil
 }
 
-// parseRandomBytesIntegerPrefix follows MySQL's integer conversion for string
-// arguments, but only retains the range that RANDOM_BYTES can accept. Capping
-// as soon as the value exceeds 1024 avoids int64 overflow and still accepts
-// arbitrarily many leading zeroes (for example, "000...1024").
-func parseRandomBytesIntegerPrefix(s string) int64 {
-	if len(s) == 0 {
-		return 0
-	}
-	start := 0
-	negative := false
-	if s[0] == '+' || s[0] == '-' {
-		negative = s[0] == '-'
-		start = 1
-	}
-
-	value := int64(0)
-	hasDigit := false
-	for i := start; i < len(s); i++ {
-		if s[i] < '0' || s[i] > '9' {
-			break
-		}
-		hasDigit = true
-		digit := int64(s[i] - '0')
-		if value > (randomBytesMaxLength-digit)/10 {
-			if negative {
-				return -1
-			}
-			return randomBytesMaxLength + 1
-		}
-		value = value*10 + digit
-	}
-	if !hasDigit || value == 0 {
-		return 0
-	}
-	if negative {
-		return -value
-	}
-	return value
-}
-
 func randomBytesTextLength(
 	param *vector.Vector,
 	value []byte,
 	row uint64,
 	proc *process.Process,
 ) (int64, error) {
-	text := strings.TrimSpace(functionUtil.QuickBytesToStr(value))
 	switch param.GetPrepareParamKindAt(int(row)) {
 	case vector.PrepareParamFloat, vector.PrepareParamDecimal:
+		text := strings.TrimSpace(functionUtil.QuickBytesToStr(value))
 		// SQL PREPARE stores the value in a text transport vector. The source
 		// kind is the distinction between a string literal (integer prefix) and
 		// a numeric value (round-to-even).
@@ -8255,6 +8215,7 @@ func randomBytesTextLength(
 		}
 		return randomBytesRoundedFloat(floating, proc)
 	case vector.PrepareParamBoolean:
+		text := strings.TrimSpace(functionUtil.QuickBytesToStr(value))
 		boolean, err := strconv.ParseBool(text)
 		if err != nil {
 			return 0, randomBytesRangeError(proc)
@@ -8264,7 +8225,10 @@ func randomBytesTextLength(
 		}
 		return 0, nil
 	default:
-		return parseRandomBytesIntegerPrefix(text), nil
+		// Keep ordinary character values byte-oriented. In particular, MySQL
+		// only ignores ASCII whitespace before the numeric prefix; using
+		// strings.TrimSpace here would incorrectly accept Unicode whitespace.
+		return parseMySQLIntegerPrefix(value), nil
 	}
 }
 

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -34,6 +34,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math"
+	"math/big"
 	"math/bits"
 	"net"
 	"runtime"
@@ -8197,18 +8198,147 @@ func randomBytesRoundedFloat(value float64, proc *process.Process) (int64, error
 	return int64(rounded), nil
 }
 
+// randomBytesRoundedDecimalIntegerString validates an already rounded,
+// decimal-domain integer. decimalInt64Explicit clamps values outside int64,
+// which is sufficient because every value outside [1, 1024] is rejected below
+// anyway.
+func randomBytesRoundedDecimalIntegerString(integer string, proc *process.Process) (int64, error) {
+	length, err := decimalInt64Explicit(integer)
+	if err != nil || length < 1 || length > randomBytesMaxLength {
+		return 0, randomBytesRangeError(proc)
+	}
+	return length, nil
+}
+
+func randomBytesRoundedDecimal64(value types.Decimal64, scale int32, proc *process.Process) (int64, error) {
+	rounded, err := value.Scale(-scale)
+	if err != nil || rounded.Sign() || uint64(rounded) < 1 || uint64(rounded) > randomBytesMaxLength {
+		return 0, randomBytesRangeError(proc)
+	}
+	return int64(rounded), nil
+}
+
+func randomBytesRoundedDecimal128(value types.Decimal128, scale int32, proc *process.Process) (int64, error) {
+	rounded, err := value.Scale(-scale)
+	if err != nil || rounded.Sign() || rounded.B64_127 != 0 || rounded.B0_63 < 1 || rounded.B0_63 > randomBytesMaxLength {
+		return 0, randomBytesRangeError(proc)
+	}
+	return int64(rounded.B0_63), nil
+}
+
+func randomBytesRoundedDecimal256(value types.Decimal256, scale int32, proc *process.Process) (int64, error) {
+	rounded, err := value.Scale(-scale)
+	if err != nil || rounded.Sign() || rounded.B192_255 != 0 || rounded.B128_191 != 0 || rounded.B64_127 != 0 || rounded.B0_63 < 1 || rounded.B0_63 > randomBytesMaxLength {
+		return 0, randomBytesRangeError(proc)
+	}
+	return int64(rounded.B0_63), nil
+}
+
+// roundPreparedDecimalIntegerString keeps a decimal value in the exact
+// arithmetic domain while it is still represented by the text transport
+// vector used for prepared parameters.  big.Rat accepts the canonical decimal
+// spelling emitted by the MySQL protocol (including an optional exponent),
+// and the quotient/remainder step implements the engine's half-up, away from
+// zero tie rule without converting through float64.
+func roundPreparedDecimalIntegerString(value string) (string, error) {
+	if !isPreparedDecimalLiteral(value) {
+		return "", strconv.ErrSyntax
+	}
+	rational, ok := new(big.Rat).SetString(value)
+	if !ok {
+		return "", strconv.ErrSyntax
+	}
+	numerator := rational.Num()
+	denominator := rational.Denom()
+	quotient, remainder := new(big.Int), new(big.Int)
+	quotient.QuoRem(numerator, denominator, remainder)
+	if remainder.Sign() != 0 {
+		if new(big.Int).Lsh(new(big.Int).Abs(remainder), 1).Cmp(denominator) >= 0 {
+			if numerator.Sign() < 0 {
+				quotient.Sub(quotient, big.NewInt(1))
+			} else {
+				quotient.Add(quotient, big.NewInt(1))
+			}
+		}
+	}
+	return quotient.String(), nil
+}
+
+func isPreparedDecimalLiteral(value string) bool {
+	const (
+		maxLiteralLength = 256
+		maxExponent      = 256
+	)
+	if value == "" || len(value) > maxLiteralLength {
+		return false
+	}
+	pos := 0
+	if value[pos] == '+' || value[pos] == '-' {
+		pos++
+		if pos == len(value) {
+			return false
+		}
+	}
+	digits := 0
+	for pos < len(value) && value[pos] >= '0' && value[pos] <= '9' {
+		pos++
+		digits++
+	}
+	if pos < len(value) && value[pos] == '.' {
+		pos++
+		for pos < len(value) && value[pos] >= '0' && value[pos] <= '9' {
+			pos++
+			digits++
+		}
+	}
+	if digits == 0 {
+		return false
+	}
+	if pos < len(value) && (value[pos] == 'e' || value[pos] == 'E') {
+		pos++
+		if pos < len(value) && (value[pos] == '+' || value[pos] == '-') {
+			pos++
+		}
+		exponentDigits := 0
+		exponent := 0
+		for pos < len(value) && value[pos] >= '0' && value[pos] <= '9' {
+			pos++
+			exponentDigits++
+			if exponent > maxExponent/10 {
+				return false
+			}
+			exponent = exponent*10 + int(value[pos-1]-'0')
+			if exponent > maxExponent {
+				return false
+			}
+		}
+		if exponentDigits == 0 {
+			return false
+		}
+	}
+	return pos == len(value)
+}
+
 func randomBytesTextLength(
 	param *vector.Vector,
 	value []byte,
 	row uint64,
 	proc *process.Process,
 ) (int64, error) {
-	switch param.GetPrepareParamKindAt(int(row)) {
+	kind := param.GetPrepareParamKindAt(int(row))
+	switch kind {
 	case vector.PrepareParamFloat, vector.PrepareParamDecimal:
 		text := strings.TrimSpace(functionUtil.QuickBytesToStr(value))
 		// SQL PREPARE stores the value in a text transport vector. The source
 		// kind is the distinction between a string literal (integer prefix) and
-		// a numeric value (round-to-even).
+		// a numeric value (round-to-even for FLOAT, exact half-up for DECIMAL).
+		if kind == vector.PrepareParamDecimal {
+			integer, err := roundPreparedDecimalIntegerString(text)
+			if err != nil {
+				return 0, randomBytesRangeError(proc)
+			}
+			return randomBytesRoundedDecimalIntegerString(integer, proc)
+		}
 		floating, err := strconv.ParseFloat(text, 64)
 		if err != nil {
 			return 0, randomBytesRangeError(proc)
@@ -8352,7 +8482,7 @@ func makeRandomBytesLengthGetter(param *vector.Vector, proc *process.Process) (r
 			if null {
 				return 0, true, nil
 			}
-			converted, err := randomBytesRoundedFloat(types.Decimal64ToFloat64(value, scale), proc)
+			converted, err := randomBytesRoundedDecimal64(value, scale, proc)
 			return converted, false, err
 		}, nil
 	case types.T_decimal128:
@@ -8363,7 +8493,7 @@ func makeRandomBytesLengthGetter(param *vector.Vector, proc *process.Process) (r
 			if null {
 				return 0, true, nil
 			}
-			converted, err := randomBytesRoundedFloat(types.Decimal128ToFloat64(value, scale), proc)
+			converted, err := randomBytesRoundedDecimal128(value, scale, proc)
 			return converted, false, err
 		}, nil
 	case types.T_decimal256:
@@ -8374,7 +8504,7 @@ func makeRandomBytesLengthGetter(param *vector.Vector, proc *process.Process) (r
 			if null {
 				return 0, true, nil
 			}
-			converted, err := randomBytesRoundedFloat(types.Decimal256ToFloat64(value, scale), proc)
+			converted, err := randomBytesRoundedDecimal256(value, scale, proc)
 			return converted, false, err
 		}, nil
 	case types.T_year:
@@ -8386,15 +8516,27 @@ func makeRandomBytesLengthGetter(param *vector.Vector, proc *process.Process) (r
 	case types.T_char, types.T_varchar, types.T_blob, types.T_text,
 		types.T_binary, types.T_varbinary:
 		p := vector.GenerateFunctionStrParameter(param)
-		isBinary := param.GetIsBin() ||
-			types.StaticStringDomain(*param.GetType()) == types.StringDomainBinary ||
-			param.GetIsBinaryString()
+		staticBinary := param.GetIsBin() ||
+			types.StaticStringDomain(*param.GetType()) == types.StringDomainBinary
 		return func(i uint64) (int64, bool, error) {
 			value, null := p.GetStrValue(i)
 			if null {
 				return 0, true, nil
 			}
-			if isBinary || param.GetIsBinaryStringAt(int(i)) {
+			isBinary := staticBinary
+			switch param.GetRuntimeStringDomainAt(int(i)) {
+			case types.RuntimeStringText:
+				// A selected CASE/IF/COALESCE value can explicitly restore
+				// character semantics even when the common vector type is
+				// VARBINARY/BLOB.  The row-level override must win over the
+				// static type and any conservative vector summary.
+				isBinary = false
+			case types.RuntimeStringBinary:
+				isBinary = true
+			default:
+				isBinary = isBinary || param.GetIsBinaryStringAt(int(i))
+			}
+			if isBinary {
 				if len(value) == 0 {
 					return 0, false, moerr.NewInvalidArg(proc.Ctx, "cast to int", value)
 				}

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -4136,7 +4136,7 @@ var supportedStringBuiltIns = []FuncNew{
 		functionId: RANDOM_BYTES,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    randomBytesCheck,
 
 		Overloads: []overload{
 			{
@@ -4152,6 +4152,16 @@ var supportedStringBuiltIns = []FuncNew{
 			{
 				overloadId: 1,
 				args:       []types.T{types.T_uint64},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_blob.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return RandomBytes
+				},
+			},
+			{
+				overloadId: 2,
+				args:       []types.T{types.T_any},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_blob.ToType()
 				},

--- a/test/distributed/cases/function/random_bytes_coercion.result
+++ b/test/distributed/cases/function/random_bytes_coercion.result
@@ -1,0 +1,53 @@
+SELECT LENGTH(RANDOM_BYTES(TRUE)) AS bool_true;
+bool_true
+1
+SELECT LENGTH(RANDOM_BYTES('2tail')) AS string_prefix;
+string_prefix
+2
+SELECT LENGTH(RANDOM_BYTES('1.5')) AS string_fraction;
+string_fraction
+1
+SELECT LENGTH(RANDOM_BYTES(1.5)) AS numeric_fraction;
+numeric_fraction
+2
+CREATE TABLE random_bytes_coercion_28483(
+    id INT PRIMARY KEY,
+    text_len VARCHAR(20),
+    numeric_len DOUBLE,
+    bool_len BOOLEAN
+);
+INSERT INTO random_bytes_coercion_28483 VALUES
+    (1, '2tail', 1.5, TRUE),
+    (2, '1.5', 2.5, NULL),
+    (3, NULL, NULL, NULL);
+SELECT id,
+       LENGTH(RANDOM_BYTES(text_len)) AS text_result,
+       LENGTH(RANDOM_BYTES(numeric_len)) AS numeric_result,
+       LENGTH(RANDOM_BYTES(bool_len)) AS bool_result
+FROM random_bytes_coercion_28483
+WHERE id IN (1, 2, 3)
+ORDER BY id;
+id    text_result    numeric_result    bool_result
+1    2    2    1
+2    1    2    null
+3    null    null    null
+DROP TABLE random_bytes_coercion_28483;
+PREPARE random_bytes_coercion_28483_stmt FROM
+    'SELECT LENGTH(RANDOM_BYTES(?)) AS random_length';
+SET @random_bytes_coercion_28483_value = '2tail';
+EXECUTE random_bytes_coercion_28483_stmt USING @random_bytes_coercion_28483_value;
+random_length
+2
+SET @random_bytes_coercion_28483_value = 1.5;
+EXECUTE random_bytes_coercion_28483_stmt USING @random_bytes_coercion_28483_value;
+random_length
+2
+SET @random_bytes_coercion_28483_value = TRUE;
+EXECUTE random_bytes_coercion_28483_stmt USING @random_bytes_coercion_28483_value;
+random_length
+1
+DEALLOCATE PREPARE random_bytes_coercion_28483_stmt;
+SELECT RANDOM_BYTES(FALSE);
+length value is out of range in 'random_bytes'
+SELECT RANDOM_BYTES('not-a-number');
+length value is out of range in 'random_bytes'

--- a/test/distributed/cases/function/random_bytes_coercion.result
+++ b/test/distributed/cases/function/random_bytes_coercion.result
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS random_bytes_coercion_28483;
 SELECT LENGTH(RANDOM_BYTES(TRUE)) AS bool_true;
 bool_true
 1
@@ -11,19 +12,19 @@ SELECT LENGTH(RANDOM_BYTES(1.5)) AS numeric_fraction;
 numeric_fraction
 2
 CREATE TABLE random_bytes_coercion_28483(
-    id INT PRIMARY KEY,
-    text_len VARCHAR(20),
-    numeric_len DOUBLE,
-    bool_len BOOLEAN
+id INT PRIMARY KEY,
+text_len VARCHAR(20),
+numeric_len DOUBLE,
+bool_len BOOLEAN
 );
 INSERT INTO random_bytes_coercion_28483 VALUES
-    (1, '2tail', 1.5, TRUE),
-    (2, '1.5', 2.5, NULL),
-    (3, NULL, NULL, NULL);
+(1, '2tail', 1.5, TRUE),
+(2, '1.5', 2.5, NULL),
+(3, NULL, NULL, NULL);
 SELECT id,
-       LENGTH(RANDOM_BYTES(text_len)) AS text_result,
-       LENGTH(RANDOM_BYTES(numeric_len)) AS numeric_result,
-       LENGTH(RANDOM_BYTES(bool_len)) AS bool_result
+LENGTH(RANDOM_BYTES(text_len)) AS text_result,
+LENGTH(RANDOM_BYTES(numeric_len)) AS numeric_result,
+LENGTH(RANDOM_BYTES(bool_len)) AS bool_result
 FROM random_bytes_coercion_28483
 WHERE id IN (1, 2, 3)
 ORDER BY id;
@@ -33,7 +34,7 @@ id    text_result    numeric_result    bool_result
 3    null    null    null
 DROP TABLE random_bytes_coercion_28483;
 PREPARE random_bytes_coercion_28483_stmt FROM
-    'SELECT LENGTH(RANDOM_BYTES(?)) AS random_length';
+'SELECT LENGTH(RANDOM_BYTES(?)) AS random_length';
 SET @random_bytes_coercion_28483_value = '2tail';
 EXECUTE random_bytes_coercion_28483_stmt USING @random_bytes_coercion_28483_value;
 random_length

--- a/test/distributed/cases/function/random_bytes_coercion.test
+++ b/test/distributed/cases/function/random_bytes_coercion.test
@@ -1,0 +1,42 @@
+# RANDOM_BYTES accepts MySQL numeric and numeric-string coercions.
+SELECT LENGTH(RANDOM_BYTES(TRUE)) AS bool_true;
+SELECT LENGTH(RANDOM_BYTES('2tail')) AS string_prefix;
+SELECT LENGTH(RANDOM_BYTES('1.5')) AS string_fraction;
+SELECT LENGTH(RANDOM_BYTES(1.5)) AS numeric_fraction;
+
+CREATE TABLE random_bytes_coercion_28483(
+    id INT PRIMARY KEY,
+    text_len VARCHAR(20),
+    numeric_len DOUBLE,
+    bool_len BOOLEAN
+);
+INSERT INTO random_bytes_coercion_28483 VALUES
+    (1, '2tail', 1.5, TRUE),
+    (2, '1.5', 2.5, NULL),
+    (3, NULL, NULL, NULL);
+SELECT id,
+       LENGTH(RANDOM_BYTES(text_len)) AS text_result,
+       LENGTH(RANDOM_BYTES(numeric_len)) AS numeric_result,
+       LENGTH(RANDOM_BYTES(bool_len)) AS bool_result
+FROM random_bytes_coercion_28483
+WHERE id IN (1, 2, 3)
+ORDER BY id;
+DROP TABLE random_bytes_coercion_28483;
+
+PREPARE random_bytes_coercion_28483_stmt FROM
+    'SELECT LENGTH(RANDOM_BYTES(?)) AS random_length';
+SET @random_bytes_coercion_28483_value = '2tail';
+EXECUTE random_bytes_coercion_28483_stmt USING @random_bytes_coercion_28483_value;
+SET @random_bytes_coercion_28483_value = 1.5;
+EXECUTE random_bytes_coercion_28483_stmt USING @random_bytes_coercion_28483_value;
+SET @random_bytes_coercion_28483_value = TRUE;
+EXECUTE random_bytes_coercion_28483_stmt USING @random_bytes_coercion_28483_value;
+DEALLOCATE PREPARE random_bytes_coercion_28483_stmt;
+
+-- FALSE coerces to zero and must fail the [1, 1024] range check.
+-- @regex("length value is out of range in 'random_bytes'",true)
+SELECT RANDOM_BYTES(FALSE);
+
+-- Nonnumeric text consumes no digits and therefore fails the same range check.
+-- @regex("length value is out of range in 'random_bytes'",true)
+SELECT RANDOM_BYTES('not-a-number');

--- a/test/distributed/cases/function/random_bytes_coercion.test
+++ b/test/distributed/cases/function/random_bytes_coercion.test
@@ -1,4 +1,5 @@
 # RANDOM_BYTES accepts MySQL numeric and numeric-string coercions.
+DROP TABLE IF EXISTS random_bytes_coercion_28483;
 SELECT LENGTH(RANDOM_BYTES(TRUE)) AS bool_true;
 SELECT LENGTH(RANDOM_BYTES('2tail')) AS string_prefix;
 SELECT LENGTH(RANDOM_BYTES('1.5')) AS string_fraction;


### PR DESCRIPTION
## Summary

Fixes #28483.

`RANDOM_BYTES(len)` now accepts the MySQL-compatible Boolean, integer, floating-point, decimal, numeric-string, and `YEAR` argument domains while preserving the existing `[1, 1024]` validation and binary-string behavior from #28440.

## Root cause

The function registry exposed only `INT64` and `UINT64` overloads. Other values were forced through generic casts: Boolean values were rejected, numeric text was parsed strictly instead of using MySQL's leading integer conversion, and SQL `PREPARE` transported numeric values through a text vector without preserving the numeric rounding domain at execution.

## Changes

- Keep the existing signed/unsigned overload IDs and add one source-preserving overload for the other accepted domains.
- Select one typed length getter per input vector, so the hot loop does not perform a type switch or allocate conversion wrappers per row.
- Apply MySQL-compatible coercion:
  - `TRUE`/`FALSE` become `1`/`0`.
  - Integer values remain exact.
  - FLOAT values use IEEE round-to-even; DECIMAL values use exact decimal half-up rounding (ties away from zero).
  - Text values consume a leading integer prefix (`'2tail'` -> `2`, `'1.5'` -> `1`).
  - SQL PREPARE text transport uses its `PrepareParamKind` sidecar, so a bound numeric `1.5` remains numeric and becomes `2` rather than being treated as string text.
  - BINARY/VARBINARY/BLOB values retain byte-oriented integer conversion, including static and runtime binary metadata.
- Saturate overflowing signed text prefixes before conversion, avoiding integer wraparound while preserving MySQL prefix semantics.
- For high-scale DECIMAL128/DECIMAL256 values, use one exact decimal rounding operation instead of multiple rounded 19-digit `Scale` chunks.
- Preserve SQL NULL and masked rows. Invalid non-NULL lengths still abort evaluation with the existing out-of-range error; entropy-source failures are still propagated.

## Correctness and unhappy paths

- Unsupported SQL types are rejected during function resolution.
- `0`, negative values, values above `1024`, NaN, infinities, invalid numeric text, empty text, and `FALSE` reach the range/error path without random allocation.
- Large unsigned and binary values cannot wrap into a valid signed length.
- A failed row cannot silently produce a successful partial result; the expression executor owns result cleanup on error.
- No goroutine, lock, retry, network, persistent state, or logging behavior is introduced.

## Performance

The valid path remains one pass over the input and retains the existing random-byte allocation and cryptographic reader call. Type dispatch is performed once per vector; ordinary integer/float/normal-scale decimal paths stay allocation-free, while exact big-number arithmetic is limited to high-scale decimal values. Invalid inputs avoid random-byte allocation.

## Tests

- Function-level coverage for overload resolution, Boolean/text/float/decimal/binary coercion, prepared text transport, long leading-zero prefixes, NULL/masked rows, high-scale decimal boundaries and direct/constant/PREPARE equivalence, invalid floats, bounds, overflow, and entropy failure.
- Distributed BVT coverage for direct, column, and SQL PREPARE forms, including valid and error cases.
- `mo-cgo-test -v -count=1 -timeout 180s -run '^TestRandomBytes' ./pkg/sql/plan/function`
- `mo-cgo-test -race -v -count=1 -timeout 240s -run '^TestRandomBytes' ./pkg/sql/plan/function`
- `go vet`, `go vet -vettool=molint`, `golangci-lint run -c .golangci.yml ./pkg/sql/plan/function/...`
- `git diff --check`

The distributed BVT was not executed locally because a MatrixOne server is unavailable in this environment. CI is not being awaited for this change.