### PR TITLE
test(frontend): stabilize statement timeout recovery

### DIFF
--- a/pkg/tests/issues/issue_26678_test.go
+++ b/pkg/tests/issues/issue_26678_test.go
@@ -49,8 +49,7 @@ func TestIssue26678MaxExecutionTime(t *testing.T) {
 		require.NoError(t, err)
 		defer defaultConn.Close()
 
-		_, err = timedConn.ExecContext(ctx, "set @@session.max_execution_time=100")
-		require.NoError(t, err)
+		setSessionMaxExecutionTime(t, ctx, timedConn, 100)
 		var timeout int64
 		require.NoError(t, timedConn.QueryRowContext(
 			ctx,
@@ -70,21 +69,20 @@ func TestIssue26678MaxExecutionTime(t *testing.T) {
 		require.Less(t, time.Since(started), time.Second,
 			"max_execution_time did not stop SELECT near its deadline")
 
-		// A statement timeout must not cancel the session or its explicit
-		// transaction. MatrixOne rolls back only the failed statement here.
-		require.NoError(t, timedConn.QueryRowContext(ctx, "select 1").Scan(&slept))
-		require.Equal(t, 1, slept)
+		requireSessionUsableAfterTimeout(t, ctx, timedConn)
+
+		setSessionMaxExecutionTime(t, ctx, timedConn, 100)
 		_, err = timedConn.ExecContext(ctx, "begin")
 		require.NoError(t, err)
 		err = timedConn.QueryRowContext(ctx, "select sleep(2)").Scan(&slept)
 		requireQueryTimeout(t, err)
-		require.NoError(t, timedConn.QueryRowContext(ctx, "select 1").Scan(&slept))
-		require.Equal(t, 1, slept)
+		requireSessionUsableAfterTimeout(t, ctx, timedConn)
 		_, err = timedConn.ExecContext(ctx, "rollback")
 		require.NoError(t, err)
 
 		// COM_STMT_EXECUTE follows the prepared SELECT, not the outer EXECUTE
 		// command, when deciding whether the timeout applies.
+		setSessionMaxExecutionTime(t, ctx, timedConn, 100)
 		prepared, err := timedConn.PrepareContext(ctx, "select sleep(?)")
 		require.NoError(t, err)
 		defer func() {
@@ -93,11 +91,29 @@ func TestIssue26678MaxExecutionTime(t *testing.T) {
 		err = prepared.QueryRowContext(ctx, 2).Scan(&slept)
 		requireQueryTimeout(t, err)
 
-		_, err = timedConn.ExecContext(ctx, "set @@session.max_execution_time=0")
-		require.NoError(t, err)
+		requireSessionUsableAfterTimeout(t, ctx, timedConn)
 		require.NoError(t, timedConn.QueryRowContext(ctx, "select sleep(0.05)").Scan(&slept))
 		require.Zero(t, slept)
 	})
+}
+
+func setSessionMaxExecutionTime(t *testing.T, ctx context.Context, conn *sql.Conn, milliseconds int) {
+	t.Helper()
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("set @@session.max_execution_time=%d", milliseconds))
+	require.NoError(t, err)
+}
+
+func requireSessionUsableAfterTimeout(t *testing.T, ctx context.Context, conn *sql.Conn) {
+	t.Helper()
+
+	// max_execution_time applies to each eligible SELECT. Disable it before
+	// checking session recovery so a slow test runner cannot time out SELECT 1
+	// under a new, valid 100 ms deadline.
+	setSessionMaxExecutionTime(t, ctx, conn, 0)
+
+	var result int
+	require.NoError(t, conn.QueryRowContext(ctx, "select 1").Scan(&result))
+	require.Equal(t, 1, result)
 }
 
 func requireQueryTimeout(t *testing.T, err error) {

--- a/test/distributed/cases/function/issue_28516_max_execution_time.result
+++ b/test/distributed/cases/function/issue_28516_max_execution_time.result
@@ -1,0 +1,26 @@
+set @@session.max_execution_time = 100;
+select sleep(2);
+Query execution was interrupted, maximum statement execution time exceeded
+set @@session.max_execution_time = 0;
+select 1;
+➤ 1[-5,64,0]  𝄀
+1
+set @@session.max_execution_time = 100;
+begin;
+select sleep(2);
+Query execution was interrupted, maximum statement execution time exceeded
+set @@session.max_execution_time = 0;
+select 1;
+➤ 1[-5,64,0]  𝄀
+1
+rollback;
+set @@session.max_execution_time = 100;
+prepare issue_28516 from 'select sleep(?)';
+set @duration = 2;
+execute issue_28516 using @duration;
+Query execution was interrupted, maximum statement execution time exceeded
+set @@session.max_execution_time = 0;
+select 1;
+➤ 1[-5,64,0]  𝄀
+1
+deallocate prepare issue_28516;

--- a/test/distributed/cases/function/issue_28516_max_execution_time.sql
+++ b/test/distributed/cases/function/issue_28516_max_execution_time.sql
@@ -1,0 +1,21 @@
+-- issue #28516: a timed-out statement must leave its session reusable once
+-- the per-statement limit is disabled.
+set @@session.max_execution_time = 100;
+select sleep(2);
+set @@session.max_execution_time = 0;
+select 1;
+
+set @@session.max_execution_time = 100;
+begin;
+select sleep(2);
+set @@session.max_execution_time = 0;
+select 1;
+rollback;
+
+set @@session.max_execution_time = 100;
+prepare issue_28516 from 'select sleep(?)';
+set @duration = 2;
+execute issue_28516 using @duration;
+set @@session.max_execution_time = 0;
+select 1;
+deallocate prepare issue_28516;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28516

## What this PR does / why we need it:

### Root cause

The previous integration assertion ran `SELECT 1` while `@@session.max_execution_time` was still 100 ms. The limit applies independently to every eligible SELECT. The Ubuntu/x86 CI trace shows the expected `SELECT sleep(2)` timeout, followed about 160 ms later by a separate timeout for `SELECT 1`; it does not establish cross-statement cancellation leakage.

### Changes

- Make the existing regression disable the session limit before checking that the same connection remains usable, then re-enable it before each timeout path.
- Cover text SELECTs in autocommit and an explicit transaction, plus prepared execution; retain the session-scope and zero-disables assertions.
- Add a BVT that validates the same three SQL paths and records each expected timeout followed by `SELECT 1` returning `1`.

### Issue-to-test proof

- #28516: `TestIssue26678MaxExecutionTime` asserts `ER_QUERY_TIMEOUT` for each timed statement and, after disabling the per-statement session limit, proves the same connection remains usable.
- #28516: `test/distributed/cases/function/issue_28516_max_execution_time.sql` exercises the public SQL behavior for autocommit, explicit transaction, and prepared paths.

### Tests

- `make cgo`
- `make build`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=300s -run TestStartMaxExecutionTimer ./pkg/frontend`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=10 -timeout=300s -run TestIssue26678MaxExecutionTime ./pkg/tests/issues`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -v -count=2 -timeout=600s -run TestIssue26678MaxExecutionTime ./pkg/tests/issues`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=900s ./pkg/tests/issues`
- `mo-tester: ./run.sh -p <worktree>/test/distributed/cases/ -m genrs -i issue_28516_max_execution_time`
- `mo-tester: ./run.sh -p <worktree>/test/distributed/cases/ -m run -i issue_28516_max_execution_time` (17/17)

### Residual risks

No production timeout code changes. Scheduling can still make any separately limited short SELECT exceed its own configured deadline; the recovery checks therefore disable that session limit before asserting connection usability. Ubuntu/x86 CI remains the final environment validation.