### PR TITLE
[4.2] fix(catalog): correct logical ID index primary column width

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -226,7 +226,7 @@ func GenMoTablesLogicalIdIndexTableDefs() []engine.TableDef {
 	priColDef := &engine.AttributeDef{
 		Attr: engine.Attribute{
 			Name:     IndexTablePrimaryColName,
-			Type:     types.New(types.T_varchar, 0, 65536), // composite primary key of main table
+			Type:     MoTablesTypes[MO_TABLES_CPKEY_IDX], // composite primary key of main table
 			Primary:  false,
 			IsHidden: false,
 			Alg:      compress.Lz4,

--- a/pkg/catalog/types_test.go
+++ b/pkg/catalog/types_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
 func TestTemporaryIndexTableNameClassification(t *testing.T) {
@@ -42,4 +43,19 @@ func TestTemporaryIndexTableNameClassification(t *testing.T) {
 	ordinaryName := defines.GenTempTableName(sessionID, uniqueName, "ordinary_table")
 	require.False(t, IsUniqueIndexTable(ordinaryName))
 	require.False(t, IsSecondaryIndexTable(ordinaryName))
+}
+
+func TestMoTablesLogicalIDIndexPrimaryColumnType(t *testing.T) {
+	defs := GenMoTablesLogicalIdIndexTableDefs()
+	sourceType := MoTablesTypes[MO_TABLES_CPKEY_IDX]
+
+	for _, def := range defs {
+		attrDef, ok := def.(*engine.AttributeDef)
+		if ok && attrDef.Attr.Name == IndexTablePrimaryColName {
+			require.Equal(t, sourceType, attrDef.Attr.Type)
+			return
+		}
+	}
+
+	t.Fatal("logical ID index primary column definition not found")
 }

--- a/pkg/vm/engine/tae/catalog/model_test.go
+++ b/pkg/vm/engine/tae/catalog/model_test.go
@@ -466,6 +466,9 @@ func TestCoverage_SystemSchemas_Init(t *testing.T) {
 	assert.NotNil(t, SystemTableSchema)
 	assert.NotNil(t, SystemColumnSchema)
 	assert.NotNil(t, SystemIndexTableSchema)
+	primaryColIdx := SystemIndexTableSchema.GetColIdx(pkgcatalog.IndexTablePrimaryColName)
+	require.NotEqual(t, -1, primaryColIdx)
+	assert.Equal(t, pkgcatalog.MoTablesTypes[pkgcatalog.MO_TABLES_CPKEY_IDX], SystemIndexTableSchema.ColDefs[primaryColIdx].Type)
 }
 
 func TestCoverage_Constants(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28527

## What this PR does / why we need it:

Backport commit 2cb5379d78a32fb1969ab68f8570104b6e0944f4 to 4.2-dev.

GenMoTablesLogicalIdIndexTableDefs used types.New(types.T_varchar, 0, 65536), incorrectly defining Width=0 and Scale=65536. The source mo_tables composite primary-key type is VARCHAR with Width=65535 and Scale=0. Reusing MoTablesTypes[MO_TABLES_CPKEY_IDX] keeps both definitions consistent.

- Correct the logical-ID index primary-column type.
- Add catalog type equality coverage and a TAE SystemIndexTableSchema assertion.
- Preserve the original author and source reference via cherry-pick -x; no conflicts or additional code changes.

### Validation

- Base: a33d3a1bbbfa507ef1efc7c3748ab70e07d3bcd9 (4.2-dev).
- Backport commit: c1ce00979c.
- git diff --check passed.
- Source and backport stable patch IDs match: 50941ab01d10fcd022752dbe765b3dad44345a95.
- Local UTs were not rerun for this mechanical backport; branch build and regression validation remain for CI.

This patch fixes the confirmed type-definition mismatch. No independently reproduced production corruption, panic or upgrade failure is claimed.