### PR TITLE
fix: align OCT compatibility and result metadata

### DIFF
--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -97,7 +97,8 @@ const (
 	MORPCVersion59     int64 = 59 // typed numeric FORMAT arguments in remote expressions
 	MORPCVersion60     int64 = 60 // row-dependent expression defaults
 	MORPCVersion61     int64 = 61 // index metadata provenance columns (nrow, build_ts)
-	MORPCLatestVersion       = MORPCVersion61
+	MORPCVersion62     int64 = 62 // VARCHAR OCT overload identities
+	MORPCLatestVersion       = MORPCVersion62
 )
 
 // DefaultLockWaitTimeoutSeconds is shared by the frontend default and by

--- a/pkg/sql/compile/compile2.go
+++ b/pkg/sql/compile/compile2.go
@@ -134,6 +134,9 @@ func (c *Compile) Compile(
 	execTopContext context.Context,
 	queryPlan *plan.Plan,
 	resultWriteBack func(batch *batch.Batch, crs *perfcounter.CounterSet) error) (err error) {
+	if err = validateOctStringProtocol(c.proc, queryPlan); err != nil {
+		return err
+	}
 	c.proc.BeginFoundRowsStatement(statementHasSQLCalcFoundRows(c.stmt))
 	c.beginSchedulingTraceAttempt()
 
@@ -388,6 +391,10 @@ func (c *Compile) Run(_ uint64) (queryResult *util2.RunResult, err error) {
 	warningsSucceeded := false
 	defer func() { warnings.finish(warningsSucceeded, warningDestination) }()
 
+	// Cached plans can outlive the negotiated cluster capability.
+	if err = validateOctStringProtocol(c.proc, c.pn); err != nil {
+		return nil, err
+	}
 	var txnOperator = c.proc.GetTxnOperator()
 
 	// init context for pipeline.

--- a/pkg/sql/compile/oct_protocol.go
+++ b/pkg/sql/compile/oct_protocol.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"reflect"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+// validateOctStringProtocol fences new OCT identities at both plan admission
+// (including expressions persisted by DDL) and remote pipeline boundaries.
+// Old DECIMAL128 identities remain executable during a rolling upgrade.
+func validateOctStringProtocol(proc *process.Process, value any) error {
+	if proc != nil {
+		if rt := moruntime.ServiceRuntime(proc.GetService()); rt != nil {
+			v, ok := rt.GetGlobalVariables(moruntime.MOProtocolVersion)
+			version, valid := v.(int64)
+			if ok && valid && version >= defines.MORPCVersion62 {
+				return nil
+			}
+		}
+	}
+	// Reuse the protobuf walker so nested CHECK/default/generated expressions
+	// and child pipelines cannot bypass the same admission rule.
+	if !containsFunctionInValue(reflect.ValueOf(value), nil, func(id, overload int32) bool {
+		return id == function.OCT && overload >= function.OctStringOverloadStart
+	}) {
+		return nil
+	}
+	return moerr.NewNotSupportedNoCtxf("VARCHAR OCT requires all CNs to support MORPC protocol version %d", defines.MORPCVersion62)
+}

--- a/pkg/sql/compile/oct_protocol_test.go
+++ b/pkg/sql/compile/oct_protocol_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"context"
+	"testing"
+
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/projection"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func octCompatibilityExpr(overload int32, arg *plan.Expr) *plan.Expr {
+	typ := types.T_decimal128.ToType()
+	if overload >= function.OctStringOverloadStart {
+		typ = types.New(types.T_varchar, 65, 0)
+	}
+	return &plan.Expr{Typ: plan2.MakePlan2Type(&typ), Expr: &plan.Expr_F{F: &plan.Function{
+		Func: &plan.ObjectRef{Obj: function.EncodeOverloadID(function.OCT, overload), ObjName: "oct"},
+		Args: []*plan.Expr{arg},
+	}}}
+}
+
+func TestOctLegacySerializedExpression(t *testing.T) {
+	// Explicit old Obj AND old Typ reproduce the catalog ABI. Resolving the
+	// return type from today's registry would hide the original wrapper panic.
+	for _, tc := range []struct {
+		name  string
+		id    int32
+		arg   *plan.Expr
+		want  string
+		fails bool
+	}{
+		{"integer", 7, plan2.MakePlan2Int64ConstExprWithType(-1), "1777777777777777777777", false},
+		{"float_rounding", 9, &plan.Expr{Typ: plan.Type{Id: int32(types.T_float64)}, Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_Dval{Dval: 12.6}}}}, "15", false},
+		{"date_string", 12, plan2.MakePlan2StringConstExprWithType("2007-08-02"), "3727", false},
+		{"invalid_string", 12, plan2.MakePlan2StringConstExprWithType("12tail"), "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			for _, null := range []bool{false, true} {
+				arg := plan2.DeepCopyExpr(tc.arg)
+				arg.GetLit().Isnull = null
+				if null {
+					arg.GetLit().LiteralForm = plan.StringLiteralForm_STRING_LITERAL_NONE
+				}
+				original := octCompatibilityExpr(tc.id, arg)
+				data, err := original.Marshal()
+				require.NoError(t, err)
+				restored := new(plan.Expr)
+				require.NoError(t, restored.Unmarshal(data))
+				executor, err := colexec.NewExpressionExecutor(proc, restored)
+				require.NoError(t, err)
+				func() {
+					defer executor.Free()
+					out, err := executor.Eval(proc, []*batch.Batch{batch.EmptyForConstFoldBatch}, nil)
+					if tc.fails && !null {
+						require.Error(t, err)
+						return
+					}
+					require.NoError(t, err)
+					value, isNull := vector.GenerateFunctionFixedTypeParameter[types.Decimal128](out).GetValue(0)
+					require.Equal(t, null, isNull)
+					if !null {
+						require.Equal(t, tc.want, value.Format(0))
+					}
+				}()
+			}
+		})
+	}
+}
+
+func TestOctProtocolPlanAdmissionAndCachedRun(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	rt := moruntime.ServiceRuntime(proc.GetService())
+	defer rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
+	expr := octCompatibilityExpr(function.OctStringOverloadStart+7, plan2.MakePlan2Int64ConstExprWithType(12))
+	for _, tc := range []struct {
+		name  string
+		table *plan.TableDef
+	}{
+		{"check", &plan.TableDef{Checks: []*plan.CheckDef{{Check: expr}}}},
+		{"default", &plan.TableDef{Cols: []*plan.ColDef{{Default: &plan.Default{Expr: expr}}}}},
+		{"generated", &plan.TableDef{Cols: []*plan.ColDef{{GeneratedCol: &plan.GeneratedCol{Expr: expr}}}}},
+		{"on_update", &plan.TableDef{Cols: []*plan.ColDef{{OnUpdate: &plan.OnUpdate{Expr: expr}}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pn := &plan.Plan{Plan: &plan.Plan_Ddl{Ddl: &plan.DataDefinition{Definition: &plan.DataDefinition_CreateTable{CreateTable: &plan.CreateTable{TableDef: tc.table}}}}}
+			rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion62)
+			require.NoError(t, validateOctStringProtocol(proc, pn))
+			rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion58)
+			c := &Compile{proc: proc, pn: pn}
+			require.ErrorContains(t, c.Compile(context.Background(), pn, nil), "protocol version 62")
+			_, err := c.Run(0)
+			require.ErrorContains(t, err, "protocol version 62")
+		})
+	}
+	for _, version := range []any{int64(58), defines.MORPCVersion59, defines.MORPCVersion60, defines.MORPCVersion61, nil, "61"} {
+		rt.SetGlobalVariables(moruntime.MOProtocolVersion, version)
+		require.ErrorContains(t, validateOctStringProtocol(proc, expr), "protocol version 62")
+		require.NoError(t, validateOctStringProtocol(proc, octCompatibilityExpr(7, plan2.MakePlan2Int64ConstExprWithType(12))))
+		require.NoError(t, validateOctStringProtocol(proc, plan2.MakePlan2Int64ConstExprWithType(12)))
+	}
+	require.ErrorContains(t, validateOctStringProtocol(nil, expr), "protocol version 62")
+	rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion62)
+	require.Zero(t, testing.AllocsPerRun(100, func() { require.NoError(t, validateOctStringProtocol(proc, expr)) }))
+}
+
+func TestOctRemoteProtocolSenderAndReceiver(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	rt := moruntime.ServiceRuntime(proc.GetService())
+	defer rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCLatestVersion)
+	for _, id := range []int32{7, function.OctStringOverloadStart + 7} {
+		project := projection.NewArgument()
+		project.ProjectList = []*plan.Expr{octCompatibilityExpr(id, plan2.MakePlan2Int64ConstExprWithType(12))}
+		scope := &Scope{Proc: proc, RootOp: project}
+		rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion62)
+		data, err := encodeRemoteScope(scope, proc)
+		require.NoError(t, err)
+		decoded, err := decodeScope(data, proc, true, nil)
+		require.NoError(t, err)
+		require.NotNil(t, decoded)
+		rt.SetGlobalVariables(moruntime.MOProtocolVersion, defines.MORPCVersion58)
+		_, sendErr := encodeRemoteScope(scope, proc)
+		_, localEncodeErr := encodeScope(scope)
+		_, receiveErr := decodeScope(data, proc, true, nil)
+		if id < function.OctStringOverloadStart {
+			require.NoError(t, sendErr)
+			require.NoError(t, localEncodeErr)
+			require.NoError(t, receiveErr)
+		} else {
+			require.ErrorContains(t, sendErr, "protocol version 62")
+			require.ErrorContains(t, localEncodeErr, "protocol version 62")
+			require.ErrorContains(t, receiveErr, "protocol version 62")
+			child := new(pipeline.Pipeline)
+			require.NoError(t, child.Unmarshal(data))
+			require.ErrorContains(t, validateOctStringProtocol(proc, &pipeline.Pipeline{Children: []*pipeline.Pipeline{child}}), "protocol version 62")
+		}
+	}
+}

--- a/pkg/sql/compile/remoterun.go
+++ b/pkg/sql/compile/remoterun.go
@@ -99,6 +99,9 @@ func encodeScope(s *Scope) ([]byte, error) {
 	if err = validateRemoteBinaryStringPipelineProtocol(s.Proc, p); err != nil {
 		return nil, err
 	}
+	if err = validateOctStringProtocol(s.Proc, p); err != nil {
+		return nil, err
+	}
 	return p.Marshal()
 }
 
@@ -123,6 +126,9 @@ func encodeRemoteScope(s *Scope, proc *process.Process) ([]byte, error) {
 		return nil, err
 	}
 	if err = validateRemoteBinaryStringPipelineProtocol(proc, p); err != nil {
+		return nil, err
+	}
+	if err = validateOctStringProtocol(proc, p); err != nil {
 		return nil, err
 	}
 	if err = validateRemoteGroupingSetPipelineProtocol(proc, p); err != nil {
@@ -229,6 +235,9 @@ func decodeScope(data []byte, proc *process.Process, isRemote bool, eng engine.E
 			return nil, err
 		}
 		if err = validateRemoteBinaryStringPipelineProtocol(proc, p); err != nil {
+			return nil, err
+		}
+		if err = validateOctStringProtocol(proc, p); err != nil {
 			return nil, err
 		}
 		if err = validateRemoteGroupingSetPipelineProtocol(proc, p); err != nil {

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -5177,7 +5177,8 @@ func bindFuncExprImplByPlanExpr(
 		} else if args[0].Typ.Id == int32(types.T_interval) && args[1].Typ.Id == int32(types.T_int64) && intervalUnitIsDayOrLarger(args[0]) {
 			name = "date_add"
 			args, err = resetDateFunctionArgs(ctx, args[1], args[0])
-		} else if isCollatedTextPlanType(args[0]) && isCollatedTextPlanType(args[1]) {
+		} else if isCollatedTextPlanType(args[0]) && isCollatedTextPlanType(args[1]) &&
+			!isOctFunctionPlanExpr(args[0]) && !isOctFunctionPlanExpr(args[1]) {
 			name = "concat"
 		}
 		if err != nil {
@@ -5258,9 +5259,18 @@ func bindFuncExprImplByPlanExpr(
 		if len(args) == 0 {
 			return nil, moerr.NewInvalidArg(ctx, name+" function have invalid input args length", len(args))
 		}
-		if args[0].Typ.Id == int32(types.T_decimal128) || args[0].Typ.Id == int32(types.T_decimal64) {
+		if args[0].Typ.Id == int32(types.T_decimal128) || args[0].Typ.Id == int32(types.T_decimal64) ||
+			(name == "oct" && args[0].Typ.Id == int32(types.T_decimal256)) {
+			target := types.T_float64
+			if name == "oct" {
+				// OCT reads the integer prefix of the decimal's exact text.
+				// Going through FLOAT64 loses digits above 2^53.
+				target = types.T_varchar
+			}
+			targetType := target.ToType()
 			args[0], err = appendCastBeforeExpr(ctx, args[0], plan.Type{
-				Id:          int32(types.T_float64),
+				Id:          int32(target),
+				Width:       targetType.Width,
 				NotNullable: args[0].Typ.NotNullable,
 			})
 			if err != nil {
@@ -5477,6 +5487,20 @@ func bindFuncExprImplByPlanExpr(
 	case "pow":
 		name = "power"
 	}
+
+	// OCT returns VARCHAR for compatibility with MySQL, but its result is still
+	// a numeric string when consumed by arithmetic.  The generic string-plus
+	// compatibility rule above intentionally rewrites VARCHAR + VARCHAR to
+	// CONCAT, so direct OCT operands must enter the numeric operator lattice
+	// explicitly.  Keep this narrow: ordinary text expressions must retain the
+	// existing MatrixOne string-plus behavior.
+	if isOctNumericContextFunction(name) {
+		args, err = castOctFunctionArgsForNumericContext(ctx, args)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if name == "convert" {
 		if err := bindConvertUsingCharset(ctx, args); err != nil {
 			return nil, err
@@ -6003,6 +6027,38 @@ func isCollatedTextPlanType(expr *plan.Expr) bool {
 	default:
 		return false
 	}
+}
+
+func isOctFunctionPlanExpr(expr *plan.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	fn := expr.GetF()
+	return fn != nil && fn.Func != nil && strings.EqualFold(fn.Func.GetObjName(), "oct")
+}
+
+func isOctNumericContextFunction(name string) bool {
+	switch name {
+	case "+", "-", "*", "/", "%", "div", "mod", "unary_minus":
+		return true
+	default:
+		return false
+	}
+}
+
+func castOctFunctionArgsForNumericContext(ctx context.Context, args []*plan.Expr) ([]*plan.Expr, error) {
+	floatType := types.T_float64.ToType()
+	for idx, arg := range args {
+		if !isOctFunctionPlanExpr(arg) {
+			continue
+		}
+		cast, err := appendCastBeforeExpr(ctx, arg, makePlan2Type(&floatType))
+		if err != nil {
+			return nil, err
+		}
+		args[idx] = cast
+	}
+	return args, nil
 }
 
 func refineRepeatLiteralReturnType(args []*plan.Expr, returnType *types.Type) {

--- a/pkg/sql/plan/base_binder_test.go
+++ b/pkg/sql/plan/base_binder_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -29,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,6 +114,88 @@ func TestBindFuncExprImplByPlanExpr_PowAlias(t *testing.T) {
 		require.NotNil(t, f)
 		require.Equal(t, "power", f.Func.GetObjName())
 	})
+}
+
+func TestBindFuncExprImplByPlanExpr_OctKeepsNumericConsumersNumeric(t *testing.T) {
+	ctx := context.Background()
+	makeOct := func(value int64) *plan.Expr {
+		oct, err := BindFuncExprImplByPlanExpr(ctx, "oct", []*plan.Expr{
+			makePlan2Int64ConstExprWithType(value),
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(types.T_varchar), oct.Typ.Id)
+		return oct
+	}
+
+	result, err := BindFuncExprImplByPlanExpr(ctx, "+", []*plan.Expr{
+		makeOct(8),
+		makeOct(1),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "+", result.GetF().GetFunc().GetObjName())
+	require.Equal(t, int32(types.T_float64), result.Typ.Id)
+	for _, arg := range result.GetF().Args {
+		require.Equal(t, "cast", arg.GetF().GetFunc().GetObjName())
+		require.Equal(t, int32(types.T_float64), arg.Typ.Id)
+	}
+
+	ordinaryText, err := BindFuncExprImplByPlanExpr(ctx, "+", []*plan.Expr{
+		makePlan2StringConstExprWithType("1"),
+		makePlan2StringConstExprWithType("2"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "concat", ordinaryText.GetF().GetFunc().GetObjName())
+}
+
+func TestOctExactDecimal(t *testing.T) {
+	ctx := context.Background()
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	for _, tc := range []struct{ input, want string }{
+		{"cast('9007199254740991' as decimal(18,0))", "377777777777777777"},
+		{"cast('9007199254740993' as decimal(18,0))", "400000000000000001"},
+		{"cast('9223372036854775807' as decimal(38,0))", "777777777777777777777"},
+		{"cast('9223372036854775808' as decimal(38,0))", "1000000000000000000000"},
+		{"cast('18446744073709551615' as decimal(38,0))", "1777777777777777777777"},
+		{"cast('18446744073709551616' as decimal(38,0))", "1777777777777777777777"},
+		{"cast('-18446744073709551615' as decimal(38,0))", "1"},
+		{"cast('-18446744073709551616' as decimal(38,0))", "0"},
+		{"cast('9007199254740993.9' as decimal(38,1))", "400000000000000001"},
+		{"cast('-1.9' as decimal(18,1))", "1777777777777777777777"},
+		{"cast('0.9' as decimal(18,1))", "0"},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			stmt, err := parsers.ParseOne(ctx, dialect.MYSQL, "select oct("+tc.input+")", 1)
+			require.NoError(t, err)
+			defer stmt.Free()
+			ast := stmt.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr
+			bound, err := NewDefaultBinder(ctx, nil, nil, plan.Type{}, nil).BindExpr(ast, 0, false)
+			require.NoError(t, err)
+			require.Equal(t, int32(types.T_varchar), bound.GetF().Args[0].Typ.Id)
+			folded, err := ConstantFold(batch.EmptyForConstFoldBatch, bound, proc, false, true)
+			require.NoError(t, err)
+			require.NotNil(t, folded.GetLit())
+			require.Equal(t, tc.want, folded.GetLit().GetSval())
+		})
+	}
+}
+
+func TestOctDecimalColumnBinding(t *testing.T) {
+	for _, oid := range []types.T{types.T_decimal64, types.T_decimal128, types.T_decimal256} {
+		for _, notNullable := range []bool{false, true} {
+			input := &plan.Expr{
+				Typ:  plan.Type{Id: int32(oid), Scale: 1, NotNullable: notNullable},
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{}},
+			}
+			bound, err := BindFuncExprImplByPlanExpr(context.Background(), "oct", []*plan.Expr{input})
+			require.NoError(t, err)
+			cast := bound.GetF().Args[0]
+			require.Equal(t, int32(types.T_varchar), cast.Typ.Id)
+			require.GreaterOrEqual(t, cast.Typ.Width, int32(78))
+			require.Equal(t, notNullable, cast.Typ.NotNullable)
+			require.Equal(t, input.Typ, cast.GetF().Args[0].Typ)
+		}
+	}
 }
 
 func TestIsPositiveIntegerLiteral(t *testing.T) {

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -2622,6 +2622,26 @@ func TestGroupingExtensionQueryOutputKeysAreNullable(t *testing.T) {
 	}
 }
 
+func TestOctNotNullSourceCTAS(t *testing.T) {
+	for _, typ := range []types.T{types.T_varchar, types.T_varbinary, types.T_int64} {
+		t.Run(typ.String(), func(t *testing.T) {
+			ctx := NewMockCompilerContext(false)
+			source := ctx.tables["nation"].Cols[0]
+			source.Typ = plan.Type{Id: int32(typ), Width: 10, NotNullable: true}
+			source.Default = &plan.Default{NullAbility: false}
+			stmt, err := parsers.ParseOne(t.Context(), dialect.MYSQL,
+				"create table oct_copy as select oct(n_nationkey) as o from nation", 1)
+			require.NoError(t, err)
+			defer stmt.Free()
+			p, err := BuildPlan(ctx, stmt, false)
+			require.NoError(t, err)
+			col := p.GetDdl().GetCreateTable().GetTableDef().GetCols()[0]
+			require.Equal(t, int32(types.T_varchar), col.Typ.Id)
+			require.Equal(t, typ != types.T_int64, col.GetDefault().GetNullAbility())
+		})
+	}
+}
+
 func TestBuildCTASFromViewUsesIndependentExecutableDefault(t *testing.T) {
 	ctx := NewMockCompilerContext(false)
 	sourceCol := ctx.tables["nation"].Cols[0]

--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -265,6 +265,47 @@ func parseLeadingInteger(s string) (int64, bool) {
 	return v, true
 }
 
+// parseLeadingUint64 extracts the decimal integer prefix used by OCT's
+// string-to-number conversion. MySQL parses OCT's string argument through an
+// unsigned longlong: a representable sign is applied modulo 2^64, positive
+// overflow saturates at ULLONG_MAX, and negative overflow converts to zero.
+//
+// Leading whitespace must already be stripped by the caller. The boolean is
+// false when there is no digit after an optional sign.
+func parseLeadingUint64(s string) (uint64, bool) {
+	if len(s) == 0 {
+		return 0, false
+	}
+	start := 0
+	negative := false
+	if s[0] == '+' || s[0] == '-' {
+		start = 1
+		negative = s[0] == '-'
+	}
+
+	end := start
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == start {
+		return 0, false
+	}
+
+	value, err := strconv.ParseUint(s[start:end], 10, 64)
+	if err != nil {
+		// MySQL's conversion clamps a positive overflow to ULLONG_MAX, but
+		// returns zero when the negative magnitude itself overflows.
+		if negative {
+			return 0, true
+		}
+		return ^uint64(0), true
+	}
+	if negative {
+		return 0 - value, true
+	}
+	return value, true
+}
+
 // encodeCharBytes converts an int64 argument for MySQL CHAR() into big-endian
 // bytes. MySQL treats CHAR(N) values as unsigned 32-bit integers and expands
 // values > 255 into multiple big-endian bytes:

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -7932,95 +7932,163 @@ func reverse(str string) string {
 }
 
 func Oct[T constraints.Unsigned | constraints.Signed](ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
-	return opUnaryFixedToFixedWithErrorCheck[T, types.Decimal128](ivecs, result, proc, length, oct[T], selectList)
-}
-
-func oct[T constraints.Unsigned | constraints.Signed](val T) (types.Decimal128, error) {
-	_val := uint64(val)
-	return types.ParseDecimal128(fmt.Sprintf("%o", _val), 38, 0)
+	return opUnaryFixedToStrWithErrorCheck[T](ivecs, result, proc, length, func(val T) (string, error) {
+		return strconv.FormatUint(uint64(val), 8), nil
+	}, selectList)
 }
 
 func OctFloat[T constraints.Float](ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
-	return opUnaryFixedToFixedWithErrorCheck[T, types.Decimal128](ivecs, result, proc, length, octFloat[T], selectList)
+	return opUnaryFixedToStrWithErrorCheck[T](ivecs, result, proc, length, octFloat[T], selectList)
 }
 
 func OctDate(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
-	return opUnaryFixedToFixedWithErrorCheck[types.Date, types.Decimal128](ivecs, result, proc, length, func(v types.Date) (types.Decimal128, error) {
+	return opUnaryFixedToStrWithErrorCheck[types.Date](ivecs, result, proc, length, func(v types.Date) (string, error) {
 		// MySQL behavior: OCT(DATE) returns octal of the year, not days since epoch
 		// Extract year from DATE and convert to octal
 		year, _, _, _ := v.Calendar(true)
-		val := int64(year)
-		return oct[int64](val)
+		return strconv.FormatUint(uint64(year), 8), nil
 	}, selectList)
 }
 
 func OctDatetime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
-	return opUnaryFixedToFixedWithErrorCheck[types.Datetime, types.Decimal128](ivecs, result, proc, length, func(v types.Datetime) (types.Decimal128, error) {
+	return opUnaryFixedToStrWithErrorCheck[types.Datetime](ivecs, result, proc, length, func(v types.Datetime) (string, error) {
 		// MySQL behavior: OCT(DATETIME) returns octal of the year, not days since epoch or microseconds
 		// Extract year from DATETIME and convert to octal
 		year, _, _, _ := v.ToDate().Calendar(true)
-		val := int64(year)
-		return oct[int64](val)
+		return strconv.FormatUint(uint64(year), 8), nil
 	}, selectList)
 }
 
-// OctString handles OCT function for string types (varchar, char, text)
-// It tries to parse the string as DATE or DATETIME, then converts to octal
+func OctTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryFixedToStrWithErrorCheck[types.Time](ivecs, result, proc, length, func(v types.Time) (string, error) {
+		// TIME is a duration, not a date.  Its numeric conversion starts with
+		// the signed hour component; routing it through DATE would introduce the
+		// current year and make OCT(TIME) time-dependent.
+		hour, _, _, _, isNeg := v.ClockFormat()
+		if isNeg {
+			return strconv.FormatUint(uint64(-int64(hour)), 8), nil
+		}
+		return strconv.FormatUint(hour, 8), nil
+	}, selectList)
+}
+
+// OctString handles OCT function for string types (varchar, char, text).
+// MySQL converts a string to its integer prefix before formatting it in base 8.
+// The empty string is NULL; a non-empty string without a numeric prefix is 0.
 func OctString(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
-	return opUnaryBytesToFixedWithErrorCheck[types.Decimal128](ivecs, result, proc, length, func(v []byte) (types.Decimal128, error) {
-		s := string(v)
-		// Try to parse as DATETIME first (more common for date_add/sub results)
-		dt, err := types.ParseDatetime(s, 6)
-		if err == nil {
-			// MySQL behavior: OCT(DATETIME string) returns octal of the year, not days since epoch or microseconds
-			// Extract year from DATETIME and convert to octal
-			year, _, _, _ := dt.ToDate().Calendar(true)
-			val := int64(year)
-			return oct[int64](val)
+	isBinaryLiteral := ivecs[0].GetIsBin()
+	resultNulls := result.GetResultVector().GetNulls()
+	err := opUnaryBytesToStrWithRowErrorCheck(ivecs, result, length, func(v []byte, row int) (string, error) {
+		if len(v) == 0 {
+			if ivecs[0].IsConst() {
+				nulls.AddRange(resultNulls, 0, uint64(length))
+			} else {
+				resultNulls.Add(uint64(row))
+			}
 		}
-		// Try to parse as DATE
-		d, err2 := types.ParseDateCast(s)
-		if err2 == nil {
-			// MySQL behavior: OCT(DATE string) returns octal of the year, not days since epoch
-			// Extract year from DATE and convert to octal
-			year, _, _, _ := d.Calendar(true)
-			val := int64(year)
-			return oct[int64](val)
+		if isBinaryLiteral {
+			return strconv.FormatUint(octBinaryLiteralValue(v), 8), nil
 		}
-		// If both parsing fail, try to parse as integer directly
-		// This handles cases where the string is already a number
-		val, err3 := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
-		if err3 == nil {
-			return oct[int64](val)
-		}
-		// If all parsing fails, return error (MySQL behavior: invalid input returns error)
-		return types.Decimal128{}, moerr.NewInvalidArgNoCtx("function oct", s)
+		s := trimASCIISpace(functionUtil.QuickBytesToStr(v))
+		value, _ := parseLeadingUint64(s)
+		return strconv.FormatUint(uint64(value), 8), nil
 	}, selectList)
+	return err
 }
 
-func octFloat[T constraints.Float](xs T) (types.Decimal128, error) {
-	var res types.Decimal128
+// octBinaryLiteralValue implements the integer conversion MySQL applies to
+// HEX/BIT literals before OCT formats the value. Leading zero bytes are
+// ignored; a non-zero value wider than uint64 is not representable and is
+// converted to zero by MySQL's binary-literal integer path.
+func octBinaryLiteralValue(v []byte) uint64 {
+	first := 0
+	for first < len(v) && v[first] == 0 {
+		first++
+	}
+	if len(v)-first > 8 {
+		return 0
+	}
 
-	if xs < 0 {
-		val, err := strconv.ParseInt(fmt.Sprintf("%1.0f", xs), 10, 64)
-		if err != nil {
-			return res, moerr.NewInternalErrorNoCtx("the input value is out of integer range")
+	var value uint64
+	for _, b := range v[first:] {
+		value = value<<8 | uint64(b)
+	}
+	return value
+}
+
+func octFloat[T constraints.Float](xs T) (string, error) {
+	// MySQL's OCT/CONV reads an integer prefix from the number's text, not
+	// from its integer cast. In scientific notation only the leading digit
+	// participates: OCT(1e308) is "1", as is OCT(1e-16).
+	value := float64(xs)
+	if value == 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return "0", nil
+	}
+	// Use expression formatting consistently for constants and columns.
+	// MySQL's Field_double uses a wider budget for some tiny values, but
+	// vector constness is not SQL expression provenance and must not alter OCT.
+	precision, width := -1, 22
+	if _, isFloat32 := any(xs).(float32); isFloat32 {
+		// FLOAT text has six significant digits and a 12-character budget.
+		precision, width = 5, 12
+	} else if magnitude := math.Abs(value); magnitude >= 1e-3 && magnitude < 1e15 {
+		// This DOUBLE range always fits fixed-point text and INT64, so its
+		// integer prefix is exactly truncation. Avoid temporary row strings.
+		return strconv.FormatUint(uint64(int64(value)), 8), nil
+	}
+	text := strconv.FormatFloat(value, 'e', precision, 64)
+	e := strings.IndexByte(text, 'e')
+	exponent, _ := strconv.Atoi(text[e+1:])
+	digits := strings.ReplaceAll(strings.TrimPrefix(text[:e], "-"), ".", "")
+	digits = strings.TrimRight(digits, "0")
+	decpt := exponent + 1
+	fixedWidth := decpt
+	if decpt <= 0 {
+		fixedWidth = len(digits) - decpt + 2
+	} else if decpt < len(digits) {
+		fixedWidth = len(digits) + 1
+	}
+	if value < 0 {
+		width--
+	}
+	// Match my_gcvt's fixed/scientific choice. For these type-specific
+	// budgets, a fixed representation that does not fit always favors 'e'.
+	if fixedWidth <= width && decpt >= -14 && (decpt <= 15 || len(digits) > decpt) {
+		if decpt <= 0 {
+			return "0", nil
 		}
-		res, err = oct(uint64(val))
-		if err != nil {
-			return res, err
+		if decpt < len(digits) {
+			digits = digits[:decpt]
+		} else {
+			digits += strings.Repeat("0", decpt-len(digits))
+		}
+		text = digits
+		if value < 0 {
+			text = "-" + text
 		}
 	} else {
-		val, err := strconv.ParseUint(fmt.Sprintf("%1.0f", xs), 10, 64)
-		if err != nil {
-			return res, moerr.NewInternalErrorNoCtx("the input value is out of integer range")
+		// Scientific output also obeys the character budget. Rounding can
+		// carry into the first digit that OCT reads (for example -9.999...e-100).
+		exponentWidth := 1
+		if exponent >= 10 || exponent <= -10 {
+			exponentWidth++
 		}
-		res, err = oct(val)
-		if err != nil {
-			return res, err
+		if exponent >= 100 || exponent <= -100 {
+			exponentWidth++
+		}
+		capacity := width - 1 - exponentWidth
+		if exponent < 0 {
+			capacity--
+		}
+		if len(digits) > 1 {
+			capacity--
+		}
+		if capacity < len(digits) {
+			text = strconv.FormatFloat(value, 'e', capacity-1, 64)
 		}
 	}
-	return res, nil
+	integer, _ := parseLeadingUint64(text)
+	return strconv.FormatUint(integer, 8), nil
 }
 
 func generateSHAKey(key []byte) []byte {

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -7182,616 +7182,366 @@ func TestReverse(t *testing.T) {
 
 // Oct
 
-func initOctUint8TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("14")
-	e2, _, _ := types.Parse128("143")
-	e3, _, _ := types.Parse128("144")
-	e4, _, _ := types.Parse128("377")
-
-	return []tcTemp{
-		{
-			info: "test oct uint8",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_uint8.ToType(),
-					[]uint8{12, 99, 100, 255},
-					[]bool{false, false, false, false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1, e2, e3, e4},
-				[]bool{false, false, false, false}),
-		},
-	}
-}
-
-func TestOctUint8(t *testing.T) {
-	testCases := initOctUint8TestCase()
-
+func TestOctInteger(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[uint8])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-}
-
-func initOctUint16TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("14")
-	e2, _, _ := types.Parse128("143")
-	e3, _, _ := types.Parse128("144")
-	e4, _, _ := types.Parse128("377")
-	e5, _, _ := types.Parse128("2000")
-	e6, _, _ := types.Parse128("23420")
-	e7, _, _ := types.Parse128("177777")
-
-	return []tcTemp{
-		{
-			info: "test oct uint16",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_uint16.ToType(),
-					[]uint16{12, 99, 100, 255, 1024, 10000, 65535},
-					[]bool{false, false, false, false, false, false, false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1, e2, e3, e4, e5, e6, e7},
-				[]bool{false, false, false, false, false, false, false}),
-		},
-	}
-}
-
-func TestOctUint16(t *testing.T) {
-	testCases := initOctUint16TestCase()
-
-	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[uint16])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-}
-
-func initOctUint32TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("14")
-	e2, _, _ := types.Parse128("143")
-	e3, _, _ := types.Parse128("144")
-	e4, _, _ := types.Parse128("377")
-	e5, _, _ := types.Parse128("2000")
-	e6, _, _ := types.Parse128("23420")
-	e7, _, _ := types.Parse128("177777")
-	e8, _, _ := types.Parse128("37777777777")
-
-	return []tcTemp{
-		{
-			info: "test oct uint32",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_uint32.ToType(),
-					[]uint32{12, 99, 100, 255, 1024, 10000, 65535, 4294967295},
-					[]bool{false, false, false, false, false, false, false, false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1, e2, e3, e4, e5, e6, e7, e8},
-				[]bool{false, false, false, false, false, false, false, false}),
-		},
-	}
-}
-
-func TestOctUint32(t *testing.T) {
-	testCases := initOctUint32TestCase()
-
-	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[uint32])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-}
-
-func initOctUint64TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("14")
-	e2, _, _ := types.Parse128("143")
-	e3, _, _ := types.Parse128("144")
-	e4, _, _ := types.Parse128("377")
-	e5, _, _ := types.Parse128("2000")
-	e6, _, _ := types.Parse128("23420")
-	e7, _, _ := types.Parse128("177777")
-	e8, _, _ := types.Parse128("37777777777")
-	e9, _, _ := types.Parse128("1777777777777777777777")
-
-	return []tcTemp{
-		{
-			info: "test oct uint64",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_uint64.ToType(),
-					[]uint64{12, 99, 100, 255, 1024, 10000, 65535, 4294967295, 18446744073709551615},
-					[]bool{false, false, false, false, false, false, false, false, false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1, e2, e3, e4, e5, e6, e7, e8, e9},
-				[]bool{false, false, false, false, false, false, false, false, false}),
-		},
-	}
-}
-
-func TestOctUint64(t *testing.T) {
-	testCases := initOctUint64TestCase()
-
-	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[uint64])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-}
-
-func initOctInt8TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("1777777777777777777600")
-	e2, _, _ := types.Parse128("1777777777777777777777")
-	e3, _, _ := types.Parse128("177")
-
-	return []tcTemp{
-		{
-			info: "test oct int8",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_int8.ToType(),
-					[]int8{-128, -1, 127},
-					[]bool{false, false, false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1, e2, e3},
-				[]bool{false, false, false}),
-		},
-	}
-}
-
-func TestOctInt8(t *testing.T) {
-	testCases := initOctInt8TestCase()
-
-	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[int8])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-}
-
-func initOctInt16TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("1777777777777777700000")
-
-	return []tcTemp{
-		{
-			info: "test oct int16",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_int16.ToType(),
-					[]int16{-32768},
-					[]bool{false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1},
-				[]bool{false}),
-		},
-	}
-}
-
-func TestOctInt16(t *testing.T) {
-	testCases := initOctInt16TestCase()
-
-	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[int16])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-}
-
-func initOctInt32TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("1777777777760000000000")
-
-	return []tcTemp{
-		{
-			info: "test oct int32",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_int32.ToType(),
-					[]int32{-2147483648},
-					[]bool{false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1},
-				[]bool{false}),
-		},
-	}
-}
-
-func TestOctInt32(t *testing.T) {
-	testCases := initOctInt32TestCase()
-
-	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[int32])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-}
-
-func initOctInt64TestCase() []tcTemp {
-	e1, _, _ := types.Parse128("1000000000000000000000")
-
-	return []tcTemp{
-		{
-			info: "test oct int64",
-			inputs: []FunctionTestInput{
-				NewFunctionTestInput(types.T_int64.ToType(),
-					[]int64{-9223372036854775808},
-					[]bool{false}),
-			},
-			expect: NewFunctionTestResult(types.T_decimal128.ToType(), false,
-				[]types.Decimal128{e1},
-				[]bool{false}),
-		},
-	}
-}
-
-func TestOctInt64(t *testing.T) {
-	testCases := initOctInt64TestCase()
-
-	proc := testutil.NewProcess(t)
-	for _, tc := range testCases {
-		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Oct[int64])
-		s, info := fcTC.Run()
-		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
-	}
-	//TODO: I am excluding scalar testcase, as per our last discussion on WeCom: https://github.com/m-schen/matrixone/blob/0a48ec5488caff6fd918ad558ebe054eba745be8/pkg/sql/plan/function/builtin/unary/oct_test.go#L176
-	//TODO: Previous OctFloat didn't have testcase. Should we add new testcases?
-}
-
-// TestOctDate tests OCT function with DATE type
-func TestOctDate(t *testing.T) {
-	proc := testutil.NewProcess(t)
-
-	// Test case: OCT(DATE_SUB('2007-08-03', INTERVAL 1 DAY))
-	// Expected: 3727 (octal representation of days since epoch)
-	testCases := []struct {
-		name     string
-		dateStr  string
-		expected string // Expected octal string representation
+	tests := []struct {
+		name   string
+		typ    types.Type
+		values any
+		want   []string
+		fn     fEvalFn
 	}{
 		{
-			name:     "OCT with DATE '2007-08-02'",
-			dateStr:  "2007-08-02",
-			expected: "3727", // This should match MySQL's OCT(DATE_SUB('2007-08-03', INTERVAL 1 DAY))
+			name:   "uint8",
+			typ:    types.T_uint8.ToType(),
+			values: []uint8{12, 99, 100, 255},
+			want:   []string{"14", "143", "144", "377"},
+			fn:     Oct[uint8],
 		},
 		{
-			name:     "OCT with DATE '2007-08-03'",
-			dateStr:  "2007-08-03",
-			expected: "3727", // This should match MySQL's OCT(DATE('2007-08-03')) - same year as 2007-08-02
+			name:   "uint16",
+			typ:    types.T_uint16.ToType(),
+			values: []uint16{12, 99, 100, 255, 1024, 10000, 65535},
+			want:   []string{"14", "143", "144", "377", "2000", "23420", "177777"},
+			fn:     Oct[uint16],
+		},
+		{
+			name:   "uint32",
+			typ:    types.T_uint32.ToType(),
+			values: []uint32{12, 99, 100, 255, 1024, 10000, 65535, 4294967295},
+			want:   []string{"14", "143", "144", "377", "2000", "23420", "177777", "37777777777"},
+			fn:     Oct[uint32],
+		},
+		{
+			name:   "uint64",
+			typ:    types.T_uint64.ToType(),
+			values: []uint64{12, 99, 100, 255, 1024, 10000, 65535, 4294967295, 18446744073709551615},
+			want:   []string{"14", "143", "144", "377", "2000", "23420", "177777", "37777777777", "1777777777777777777777"},
+			fn:     Oct[uint64],
+		},
+		{
+			name:   "int8",
+			typ:    types.T_int8.ToType(),
+			values: []int8{-128, -1, 127},
+			want:   []string{"1777777777777777777600", "1777777777777777777777", "177"},
+			fn:     Oct[int8],
+		},
+		{
+			name:   "int16",
+			typ:    types.T_int16.ToType(),
+			values: []int16{-32768},
+			want:   []string{"1777777777777777700000"},
+			fn:     Oct[int16],
+		},
+		{
+			name:   "int32",
+			typ:    types.T_int32.ToType(),
+			values: []int32{-2147483648},
+			want:   []string{"1777777777760000000000"},
+			fn:     Oct[int32],
+		},
+		{
+			name:   "int64",
+			typ:    types.T_int64.ToType(),
+			values: []int64{-9223372036854775808},
+			want:   []string{"1000000000000000000000"},
+			fn:     Oct[int64],
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Parse the date
-			date, err := types.ParseDateCast(tc.dateStr)
-			require.NoError(t, err)
+			fc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{NewFunctionTestInput(tc.typ, tc.values, nil)},
+				NewFunctionTestResult(types.T_varchar.ToType(), false, tc.want, nil), tc.fn)
+			s, info := fc.Run()
+			require.True(t, s, info)
+		})
+	}
+}
 
-			// Create input vector
-			ivecs := make([]*vector.Vector, 1)
-			ivecs[0], err = vector.NewConstFixed(types.T_date.ToType(), date, 1, proc.Mp())
-			require.NoError(t, err)
+func TestOctFloat(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	for _, tc := range []struct {
+		name   string
+		typ    types.Type
+		values any
+		want   []string
+		fn     fEvalFn
+	}{
+		{
+			name:   "double_text_boundaries",
+			typ:    types.T_float64.ToType(),
+			values: []float64{1e14, 1e15, 1e308, -1e308, 1e-15, 1e-16, -1e-16, 999999999999999.9, math.Inf(1), math.Inf(-1), math.NaN(), 1.234567890123456e-5, -1.234567890123456e-5, 1.234567890123456e-6, 1000000000000000.1},
+			want:   []string{"2657142036440000", "1", "1", "1777777777777777777777", "0", "1", "1777777777777777777777", "34327724461477777", "0", "0", "0", "0", "1777777777777777777777", "1", "34327724461500000"},
+			fn:     OctFloat[float64],
+		},
+		{
+			name:   "float_text_boundaries",
+			typ:    types.T_float32.ToType(),
+			values: []float32{999999.9, 123456789, 1e11, 1e12, 1e-10, 1e-11, 1e-15, 1e30, -1e30},
+			want:   []string{"3641100", "726746750", "1351035564000", "1", "0", "1", "1", "1", "1777777777777777777777"},
+			fn:     OctFloat[float32],
+		},
+		{
+			name:   "float32",
+			typ:    types.T_float32.ToType(),
+			values: []float32{12.4, -12.4, 12345.4, 0, 0.5, 0.6, 1.5, 1.6, -1.5, -1.6, 2.5, -2.5},
+			want:   []string{"14", "1777777777777777777764", "30071", "0", "0", "0", "1", "1", "1777777777777777777777", "1777777777777777777777", "2", "1777777777777777777776"},
+			fn:     OctFloat[float32],
+		},
+		{
+			name:   "float64",
+			typ:    types.T_float64.ToType(),
+			values: []float64{12.4, -12.4, 12345.4, 0, 0.5, 0.6, 1.5, 1.6, -1.5, -1.6, 2.5, -2.5},
+			want:   []string{"14", "1777777777777777777764", "30071", "0", "0", "0", "1", "1", "1777777777777777777777", "1777777777777777777777", "2", "1777777777777777777776"},
+			fn:     OctFloat[float64],
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{NewFunctionTestInput(tc.typ, tc.values, nil)},
+				NewFunctionTestResult(types.T_varchar.ToType(), false, tc.want, nil), tc.fn)
+			s, info := fc.Run()
+			require.True(t, s, info)
+		})
+	}
+}
 
-			// Create result vector
-			result := vector.NewFunctionResultWrapper(types.T_decimal128.ToType(), proc.Mp())
-
-			// Initialize result vector
-			err = result.PreExtendAndReset(1)
-			require.NoError(t, err)
-
-			// Call OctDate
-			err = OctDate(ivecs, result, proc, 1, nil)
-			require.NoError(t, err)
-
-			// Verify result
-			resultVec := result.GetResultVector()
-			require.False(t, resultVec.GetNulls().Contains(0), "Result should not be NULL")
-
-			decParam := vector.GenerateFunctionFixedTypeParameter[types.Decimal128](resultVec)
-			resultDec, null := decParam.GetValue(0)
-			require.False(t, null, "Result should not be null")
-
-			// Convert decimal128 to string and verify it matches expected octal
-			resultStr := resultDec.Format(0)
-			// FIXED: Now we verify the exact value matches MySQL's expected result
-			// MySQL behavior: OCT(DATE) returns octal of days since epoch
-			require.Equal(t, tc.expected, resultStr, "OCT result should match MySQL's expected value (octal of days)")
-
-			// Cleanup
-			for _, v := range ivecs {
-				if v != nil {
-					v.Free(proc.Mp())
+func BenchmarkOctFloat(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		value float64
+	}{
+		{"ordinary", 12345.4},
+		{"negative", -12345.4},
+		{"huge", 1e308},
+		{"tiny", 1e-16},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := octFloat(tc.value); err != nil {
+					b.Fatal(err)
 				}
-			}
-			if result != nil {
-				result.Free()
 			}
 		})
 	}
 }
 
-// TestOctDatetime tests OCT function with DATETIME type
-func TestOctDatetime(t *testing.T) {
+func TestOctBit(t *testing.T) {
 	proc := testutil.NewProcess(t)
+	fc := NewFunctionTestCase(proc,
+		[]FunctionTestInput{NewFunctionTestInput(types.T_bit.ToType(), []uint64{0, 1, 255}, nil)},
+		NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"0", "1", "377"}, nil), Oct[uint64])
+	s, info := fc.Run()
+	require.True(t, s, info)
+}
 
-	// Test case: OCT(DATE_SUB('2007-08-03 17:33:00', INTERVAL 1 MINUTE))
-	// Expected: 3727 (octal representation of microseconds since epoch)
-	testCases := []struct {
-		name     string
-		dtStr    string
-		expected string // Expected octal string representation (approximate)
-	}{
-		{
-			name:     "OCT with DATETIME '2007-08-02 23:59:00'",
-			dtStr:    "2007-08-02 23:59:00",
-			expected: "3727", // This should match MySQL's OCT(DATE_SUB('2007-08-03', INTERVAL 1 MINUTE))
-		},
-		{
-			name:     "OCT with DATETIME '2007-08-03 17:33:00'",
-			dtStr:    "2007-08-03 17:33:00",
-			expected: "3727", // This should match MySQL's OCT(DATETIME('2007-08-03')) - same year as 2007-08-02
-		},
+func TestOctBinaryLiteral(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	input := testutil.MakeVarlenaVector(
+		[][]byte{{0x00}, {}, {0xff}, {0x01, 0x02}, {0x00, 0xff}, {0x01, 0, 0, 0, 0, 0, 0, 0, 0}},
+		nil,
+		types.T_varchar.ToType(),
+		proc.Mp(),
+	)
+	defer input.Free(proc.Mp())
+	input.SetIsBin(true)
+
+	result := vector.NewFunctionResultWrapper(types.T_varchar.ToType(), proc.Mp())
+	defer result.Free()
+	require.NoError(t, result.PreExtendAndReset(input.Length()))
+	require.NoError(t, OctString([]*vector.Vector{input}, result, proc, input.Length(), nil))
+
+	parameter := vector.GenerateFunctionStrParameter(result.GetResultVector())
+	for i, want := range []string{"0", "", "377", "402", "377", "0"} {
+		got, isNull := parameter.GetStrValue(uint64(i))
+		if i == 1 {
+			require.True(t, isNull)
+			continue
+		}
+		require.False(t, isNull)
+		require.Equal(t, want, string(got))
 	}
+}
 
-	for _, tc := range testCases {
+func TestOctTemporal(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	date, err := types.ParseDateCast("2007-08-02")
+	require.NoError(t, err)
+	datetime, err := types.ParseDatetime("2007-08-02 23:59:00", 6)
+	require.NoError(t, err)
+	timeValue, err := types.ParseTime("12:34:56", 6)
+	require.NoError(t, err)
+	negativeTimeValue, err := types.ParseTime("-12:34:56", 6)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name   string
+		typ    types.Type
+		values any
+		want   []string
+		fn     fEvalFn
+	}{
+		{name: "date", typ: types.T_date.ToType(), values: []types.Date{date}, want: []string{"3727"}, fn: OctDate},
+		{name: "datetime", typ: types.T_datetime.ToType(), values: []types.Datetime{datetime}, want: []string{"3727"}, fn: OctDatetime},
+		{name: "time", typ: types.T_time.ToType(), values: []types.Time{timeValue, negativeTimeValue}, want: []string{"14", "1777777777777777777764"}, fn: OctTime},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// Parse the datetime
-			dt, err := types.ParseDatetime(tc.dtStr, 6)
-			require.NoError(t, err)
-
-			// Create input vector
-			ivecs := make([]*vector.Vector, 1)
-			ivecs[0], err = vector.NewConstFixed(types.T_datetime.ToType(), dt, 1, proc.Mp())
-			require.NoError(t, err)
-
-			// Create result vector
-			result := vector.NewFunctionResultWrapper(types.T_decimal128.ToType(), proc.Mp())
-
-			// Initialize result vector
-			err = result.PreExtendAndReset(1)
-			require.NoError(t, err)
-
-			// Call OctDatetime
-			err = OctDatetime(ivecs, result, proc, 1, nil)
-			require.NoError(t, err)
-
-			// Verify result
-			resultVec := result.GetResultVector()
-			require.False(t, resultVec.GetNulls().Contains(0), "Result should not be NULL")
-
-			decParam := vector.GenerateFunctionFixedTypeParameter[types.Decimal128](resultVec)
-			resultDec, null := decParam.GetValue(0)
-			require.False(t, null, "Result should not be null")
-
-			// Convert decimal128 to string and verify it matches expected octal
-			resultStr := resultDec.Format(0)
-			// FIXED: Now we verify the exact value matches MySQL's expected result
-			// MySQL behavior: OCT(DATETIME) returns octal of days since epoch, not microseconds
-			require.Equal(t, tc.expected, resultStr, "OCT result should match MySQL's expected value (octal of days, not microseconds)")
-
-			// Cleanup
-			for _, v := range ivecs {
-				if v != nil {
-					v.Free(proc.Mp())
-				}
-			}
-			if result != nil {
-				result.Free()
-			}
+			fc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{NewFunctionTestInput(tc.typ, tc.values, nil)},
+				NewFunctionTestResult(types.T_varchar.ToType(), false, tc.want, nil), tc.fn)
+			s, info := fc.Run()
+			require.True(t, s, info)
 		})
 	}
 }
 
-// TestOctString tests OCT function with string types (varchar, char, text)
-// This covers the case where DATE_SUB returns a string and OCT needs to parse it
 func TestOctString(t *testing.T) {
 	proc := testutil.NewProcess(t)
+	values := []string{
+		"12tail",
+		"12.5",
+		"abc",
+		"",
+		"20240506",
+		"20240101123456",
+		"9223372036854775808",
+		"18446744073709551615",
+		"18446744073709551616",
+		"  -12x",
+		"-9223372036854775809",
+		"-18446744073709551615",
+		"-18446744073709551616",
+		"   ",
+		"99rest",
+		"24",
+	}
+	want := []string{
+		"14",
+		"14",
+		"0",
+		"",
+		"115154172",
+		"446420402322600",
+		"1000000000000000000000",
+		"1777777777777777777777",
+		"1777777777777777777777",
+		"1777777777777777777764",
+		"777777777777777777777",
+		"1",
+		"0",
+		"0",
+		"143",
+		"30",
+	}
+	nullsForInput := []bool{
+		false, false, false, false, false, false, false, false,
+		false, false, false, false, false, false, false, true,
+	}
+	nullsForResult := []bool{
+		false, false, false, true, false, false, false, false,
+		false, false, false, false, false, false, false, true,
+	}
 
-	testCases := []struct {
-		name     string
-		inputStr string
-		expected string // Expected octal string representation
-		desc     string
+	for _, typ := range []types.Type{types.T_varchar.ToType(), types.T_char.ToType(), types.T_text.ToType()} {
+		t.Run(typ.Oid.String(), func(t *testing.T) {
+			fc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{NewFunctionTestInput(typ, values, nullsForInput)},
+				NewFunctionTestResult(types.T_varchar.ToType(), false, want, nullsForResult), OctString)
+			s, info := fc.Run()
+			require.True(t, s, info)
+		})
+	}
+
+	t.Run("constant empty string is NULL for every repeated row", func(t *testing.T) {
+		fc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{NewFunctionTestConstInput(types.T_varchar.ToType(), []string{""}, []bool{false})},
+			NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"", "", ""}, []bool{true, true, true}), OctString)
+		fc.fnLength = 3
+		s, info := fc.Run()
+		require.True(t, s, info)
+	})
+}
+
+func TestOctReturnType(t *testing.T) {
+	for _, typ := range []types.Type{
+		types.T_uint64.ToType(),
+		types.T_int64.ToType(),
+		types.T_float64.ToType(),
+		types.T_date.ToType(),
+		types.T_datetime.ToType(),
+		types.T_time.ToType(),
+		types.T_bit.ToType(),
+		types.T_varchar.ToType(),
+		types.T_char.ToType(),
+		types.T_text.ToType(),
+		types.T_binary.ToType(),
+		types.T_varbinary.ToType(),
+		types.T_blob.ToType(),
+	} {
+		resolved, err := GetFunctionByName(context.Background(), "oct", []types.Type{typ})
+		require.NoError(t, err, typ)
+		require.GreaterOrEqual(t, resolved.overloadId, int32(OctStringOverloadStart), typ)
+		require.Equal(t, types.T_varchar, resolved.retType.Oid, typ)
+		require.Equal(t, int32(65), resolved.retType.Width, typ)
+		if typ.Oid == types.T_time {
+			require.False(t, resolved.needCast, "TIME should use its dedicated OCT overload")
+		}
+		if typ.Oid == types.T_bit {
+			require.False(t, resolved.needCast, "BIT should use its dedicated OCT overload")
+		}
+	}
+}
+
+func TestOctRegistrationExecutes(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	date, err := types.ParseDateCast("2007-08-02")
+	require.NoError(t, err)
+	timeValue, err := types.ParseTime("12:34:56", 6)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name   string
+		typ    types.Type
+		values any
+		want   []string
 	}{
-		{
-			name:     "OCT with DATETIME string '2007-08-02 23:59:00'",
-			inputStr: "2007-08-02 23:59:00",
-			expected: "3727", // OCT(DATE_SUB('2007-08-03', INTERVAL 1 MINUTE)) should return 3727
-			desc:     "OCT(DATE_SUB('2007-08-03', INTERVAL 1 MINUTE)) returns string, OCT should parse it and return days octal",
-		},
-		{
-			name:     "OCT with DATE string '2007-08-02'",
-			inputStr: "2007-08-02",
-			expected: "3727", // OCT(DATE_SUB('2007-08-03', INTERVAL 1 DAY)) should return 3727
-			desc:     "OCT(DATE_SUB('2007-08-03', INTERVAL 1 DAY)) returns string, OCT should parse it and return days octal",
-		},
-		{
-			name:     "OCT with DATETIME string with microseconds '2007-08-02 23:59:00.123456'",
-			inputStr: "2007-08-02 23:59:00.123456",
-			expected: "3727", // Should return days octal, not microseconds octal
-			desc:     "OCT should handle datetime strings with fractional seconds and return days octal",
-		},
-		{
-			name:     "OCT with integer string '12345'",
-			inputStr: "12345",
-			expected: "30071", // Octal representation of 12345
-			desc:     "OCT should handle integer strings",
-		},
-	}
-
-	for _, tc := range testCases {
+		{name: "integer", typ: types.T_int64.ToType(), values: []int64{12}, want: []string{"14"}},
+		{name: "string", typ: types.T_varchar.ToType(), values: []string{"12tail", "abc", ""}, want: []string{"14", "0", ""}},
+		{name: "date", typ: types.T_date.ToType(), values: []types.Date{date}, want: []string{"3727"}},
+		{name: "time", typ: types.T_time.ToType(), values: []types.Time{timeValue}, want: []string{"14"}},
+		{name: "bit", typ: types.T_bit.ToType(), values: []uint64{255}, want: []string{"377"}},
+		{name: "varbinary", typ: types.T_varbinary.ToType(), values: []string{"255", "\xff", ""}, want: []string{"377", "0", ""}},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create input vector with string type
-			ivecs := make([]*vector.Vector, 1)
-			var err error
-			ivecs[0], err = vector.NewConstBytes(types.T_varchar.ToType(), []byte(tc.inputStr), 1, proc.Mp())
+			input := newVectorByType(proc.Mp(), tc.typ, tc.values, nil)
+			defer input.Free(proc.Mp())
+
+			resolved, err := GetFunctionByName(proc.Ctx, "oct", []types.Type{tc.typ})
 			require.NoError(t, err)
+			require.Equal(t, types.T_varchar, resolved.GetReturnType().Oid)
 
-			// Create result vector
-			result := vector.NewFunctionResultWrapper(types.T_decimal128.ToType(), proc.Mp())
-
-			// Initialize result vector
-			err = result.PreExtendAndReset(1)
+			out, err := RunFunctionDirectly(proc, resolved.GetEncodedOverloadID(), []*vector.Vector{input}, len(tc.want))
 			require.NoError(t, err)
+			defer out.Free(proc.Mp())
+			require.Equal(t, types.T_varchar, out.GetType().Oid)
+			require.Equal(t, int32(65), out.GetType().Width)
 
-			// Call OctString
-			err = OctString(ivecs, result, proc, 1, nil)
-			require.NoError(t, err, tc.desc)
-
-			// Verify result
-			resultVec := result.GetResultVector()
-			require.False(t, resultVec.GetNulls().Contains(0), "Result should not be NULL for valid input: %s", tc.desc)
-
-			decParam := vector.GenerateFunctionFixedTypeParameter[types.Decimal128](resultVec)
-			resultDec, null := decParam.GetValue(0)
-			require.False(t, null, "Result should not be null: %s", tc.desc)
-
-			// Convert decimal128 to string and verify it matches expected octal
-			resultStr := resultDec.Format(0)
-			// FIXED: Now we verify the exact value matches MySQL's expected result
-			require.Equal(t, tc.expected, resultStr, "OCT result should match MySQL's expected value: %s", tc.desc)
-
-			// Cleanup
-			for _, v := range ivecs {
-				if v != nil {
-					v.Free(proc.Mp())
+			parameter := vector.GenerateFunctionStrParameter(out)
+			for i, want := range tc.want {
+				got, isNull := parameter.GetStrValue(uint64(i))
+				if (tc.name == "string" || tc.name == "varbinary") && i == 2 {
+					require.True(t, isNull)
+					continue
 				}
-			}
-			if result != nil {
-				result.Free()
+				require.False(t, isNull)
+				require.Equal(t, want, string(got))
 			}
 		})
 	}
-
-	// Test error case: invalid string that can't be parsed
-	t.Run("OCT with invalid string", func(t *testing.T) {
-		ivecs := make([]*vector.Vector, 1)
-		var err error
-		ivecs[0], err = vector.NewConstBytes(types.T_varchar.ToType(), []byte("invalid-date-string"), 1, proc.Mp())
-		require.NoError(t, err)
-
-		result := vector.NewFunctionResultWrapper(types.T_decimal128.ToType(), proc.Mp())
-		err = result.PreExtendAndReset(1)
-		require.NoError(t, err)
-
-		// Call OctString - should return error for invalid input
-		err = OctString(ivecs, result, proc, 1, nil)
-		require.Error(t, err, "OCT should return error for invalid string input")
-		require.Contains(t, err.Error(), "function oct", "Error message should mention function oct")
-
-		// Cleanup
-		for _, v := range ivecs {
-			if v != nil {
-				v.Free(proc.Mp())
-			}
-		}
-		if result != nil {
-			result.Free()
-		}
-	})
-
-	// Test T_text type (overloadId: 14)
-	t.Run("OCT with T_text type", func(t *testing.T) {
-		testCases := []struct {
-			name     string
-			inputStr string
-			expected string
-			desc     string
-		}{
-			{
-				name:     "OCT with T_text DATETIME string",
-				inputStr: "2007-08-02 23:59:00",
-				expected: "3727",
-				desc:     "OCT should handle T_text type with DATETIME string",
-			},
-			{
-				name:     "OCT with T_text DATE string",
-				inputStr: "2007-08-02",
-				expected: "3727",
-				desc:     "OCT should handle T_text type with DATE string",
-			},
-			{
-				name:     "OCT with T_text integer string",
-				inputStr: "12345",
-				expected: "30071",
-				desc:     "OCT should handle T_text type with integer string",
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				// Create input vector with T_text type
-				ivecs := make([]*vector.Vector, 1)
-				var err error
-				ivecs[0], err = vector.NewConstBytes(types.T_text.ToType(), []byte(tc.inputStr), 1, proc.Mp())
-				require.NoError(t, err)
-
-				// Create result vector
-				result := vector.NewFunctionResultWrapper(types.T_decimal128.ToType(), proc.Mp())
-
-				// Initialize result vector
-				err = result.PreExtendAndReset(1)
-				require.NoError(t, err)
-
-				// Call OctString
-				err = OctString(ivecs, result, proc, 1, nil)
-				require.NoError(t, err, tc.desc)
-
-				// Verify result
-				resultVec := result.GetResultVector()
-				require.False(t, resultVec.GetNulls().Contains(0), "Result should not be NULL for valid input: %s", tc.desc)
-
-				decParam := vector.GenerateFunctionFixedTypeParameter[types.Decimal128](resultVec)
-				resultDec, null := decParam.GetValue(0)
-				require.False(t, null, "Result should not be null: %s", tc.desc)
-
-				// Convert decimal128 to string and verify it matches expected octal
-				resultStr := resultDec.Format(0)
-				require.Equal(t, tc.expected, resultStr, "OCT result should match expected value: %s", tc.desc)
-
-				// Cleanup
-				for _, v := range ivecs {
-					if v != nil {
-						v.Free(proc.Mp())
-					}
-				}
-				if result != nil {
-					result.Free()
-				}
-			})
-		}
-
-		// Test error case with T_text type
-		t.Run("OCT with T_text invalid string", func(t *testing.T) {
-			ivecs := make([]*vector.Vector, 1)
-			var err error
-			ivecs[0], err = vector.NewConstBytes(types.T_text.ToType(), []byte("invalid-date-string"), 1, proc.Mp())
-			require.NoError(t, err)
-
-			result := vector.NewFunctionResultWrapper(types.T_decimal128.ToType(), proc.Mp())
-			err = result.PreExtendAndReset(1)
-			require.NoError(t, err)
-
-			// Call OctString - should return error for invalid input
-			err = OctString(ivecs, result, proc, 1, nil)
-			require.Error(t, err, "OCT should return error for invalid T_text input")
-			require.Contains(t, err.Error(), "function oct", "Error message should mention function oct")
-
-			// Cleanup
-			for _, v := range ivecs {
-				if v != nil {
-					v.Free(proc.Mp())
-				}
-			}
-			if result != nil {
-				result.Free()
-			}
-		})
-	})
 }
 
 func TestDecode(t *testing.T) {
@@ -12709,4 +12459,34 @@ func TestLastQueryIDWithNoQueryHistoryReturnsNull(t *testing.T) {
 	testCase := NewFunctionTestCase(proc, input, expected, LastQueryID)
 	succeed, info := testCase.Run()
 	require.True(t, succeed, info)
+}
+
+func TestOctFloatScientificRoundingCarry(t *testing.T) {
+	for _, tc := range []struct {
+		value float64
+		want  string
+	}{
+		{-9.999999999999999e-100, "1777777777777777777777"},
+		{9.999999999999999e-100, "11"},
+	} {
+		got, err := octFloat(tc.value)
+		require.NoError(t, err)
+		require.Equal(t, tc.want, got)
+	}
+}
+
+// Overload identities are persisted in catalog expressions, independently of
+// the order used to resolve new SQL calls.
+func TestOctLegacyOverloadIdentities(t *testing.T) {
+	for id, oid := range []types.T{
+		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
+		types.T_int8, types.T_int16, types.T_int32, types.T_int64,
+		types.T_float32, types.T_float64, types.T_date, types.T_datetime,
+		types.T_varchar, types.T_char, types.T_text,
+	} {
+		old, err := GetFunctionById(context.Background(), EncodeOverloadID(OCT, int32(id)))
+		require.NoError(t, err)
+		require.Equal(t, []types.T{oid}, old.args)
+		require.Equal(t, types.T_decimal128.ToType(), old.retType([]types.Type{oid.ToType()}))
+	}
 }

--- a/pkg/sql/plan/function/function.go
+++ b/pkg/sql/plan/function/function.go
@@ -374,8 +374,18 @@ func GetAggFunctionNameByID(overloadID int64) string {
 // non-NULL. STRICT functions normally preserve an all-non-NULL argument
 // guarantee, except for functions that can synthesize NULL from valid values.
 func DeduceNotNullable(overloadID int64, args []*plan.Expr) bool {
-	fid, _ := DecodeOverloadID(overloadID)
+	fid, oid := DecodeOverloadID(overloadID)
 	switch fid {
+	case OCT:
+		// New string executors produce NULL for empty non-NULL input.
+		// Preserve the persisted legacy and numeric overload contracts.
+		if oid >= OctStringOverloadStart && len(args) == 1 {
+			switch types.T(args[0].Typ.Id) {
+			case types.T_char, types.T_varchar, types.T_text,
+				types.T_binary, types.T_varbinary, types.T_blob:
+				return false
+			}
+		}
 	case CASE:
 		if caseHasTemporalPromotion(args) {
 			return false

--- a/pkg/sql/plan/function/function_test.go
+++ b/pkg/sql/plan/function/function_test.go
@@ -1226,6 +1226,27 @@ func TestDeduceNotNullableKeepsNullSynthesizingFunctionsNullable(t *testing.T) {
 	}
 }
 
+func TestOctNullability(t *testing.T) {
+	for _, typ := range []types.T{types.T_char, types.T_varchar, types.T_text,
+		types.T_binary, types.T_varbinary, types.T_blob, types.T_int64, types.T_float64, types.T_time, types.T_bit} {
+		t.Run(typ.String(), func(t *testing.T) {
+			fn, err := GetFunctionByName(t.Context(), "oct", []types.Type{typ.ToType()})
+			require.NoError(t, err)
+			arg := &plan.Expr{Typ: plan.Type{Id: int32(typ), NotNullable: true}}
+			want := typ == types.T_int64 || typ == types.T_float64 || typ == types.T_time || typ == types.T_bit
+			require.Equal(t, want, DeduceNotNullable(fn.GetEncodedOverloadID(), []*plan.Expr{arg}))
+			arg.Typ.NotNullable = false
+			require.False(t, DeduceNotNullable(fn.GetEncodedOverloadID(), []*plan.Expr{arg}))
+		})
+	}
+	for id := int32(0); id < OctStringOverloadStart; id++ {
+		op, err := GetFunctionById(t.Context(), EncodeOverloadID(OCT, id))
+		require.NoError(t, err)
+		arg := &plan.Expr{Typ: plan.Type{Id: int32(op.args[0]), NotNullable: true}}
+		require.True(t, DeduceNotNullable(EncodeOverloadID(OCT, id), []*plan.Expr{arg}))
+	}
+}
+
 func TestDeduceNotNullablePreservesArgumentDependentContracts(t *testing.T) {
 	notNull := &plan.Expr{Typ: plan.Type{NotNullable: true}}
 	nullable := &plan.Expr{Typ: plan.Type{NotNullable: false}}

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -8846,14 +8846,14 @@ var supportedMathBuiltIns = []FuncNew{
 		functionId: OCT,
 		class:      plan.Function_STRICT,
 		layout:     STANDARD_FUNCTION,
-		checkFn:    fixedTypeMatch,
+		checkFn:    octTypeCheck,
 
-		Overloads: []overload{
+		Overloads: withLegacyOctOverloads([]overload{
 			{
 				overloadId: 0,
 				args:       []types.T{types.T_uint8},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[uint8]
@@ -8863,7 +8863,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 1,
 				args:       []types.T{types.T_uint16},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[uint16]
@@ -8873,7 +8873,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 2,
 				args:       []types.T{types.T_uint32},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[uint32]
@@ -8883,7 +8883,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 3,
 				args:       []types.T{types.T_uint64},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[uint64]
@@ -8893,7 +8893,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 4,
 				args:       []types.T{types.T_int8},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[int8]
@@ -8903,7 +8903,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 5,
 				args:       []types.T{types.T_int16},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[int16]
@@ -8913,7 +8913,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 6,
 				args:       []types.T{types.T_int32},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[int32]
@@ -8923,7 +8923,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 7,
 				args:       []types.T{types.T_int64},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return Oct[int64]
@@ -8933,7 +8933,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 8,
 				args:       []types.T{types.T_float32},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return OctFloat[float32]
@@ -8943,7 +8943,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 9,
 				args:       []types.T{types.T_float64},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return OctFloat[float64]
@@ -8953,7 +8953,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 10,
 				args:       []types.T{types.T_date},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return OctDate
@@ -8963,7 +8963,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 11,
 				args:       []types.T{types.T_datetime},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return OctDatetime
@@ -8973,7 +8973,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 12,
 				args:       []types.T{types.T_varchar},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return OctString
@@ -8983,7 +8983,7 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 13,
 				args:       []types.T{types.T_char},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return OctString
@@ -8993,13 +8993,63 @@ var supportedMathBuiltIns = []FuncNew{
 				overloadId: 14,
 				args:       []types.T{types.T_text},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_decimal128.ToType()
+					return octalResultType(parameters)
 				},
 				newOp: func() executeLogicOfOverload {
 					return OctString
 				},
 			},
-		},
+			{
+				overloadId: 15,
+				args:       []types.T{types.T_time},
+				retType: func(parameters []types.Type) types.Type {
+					return octalResultType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return OctTime
+				},
+			},
+			{
+				overloadId: 16,
+				args:       []types.T{types.T_bit},
+				retType: func(parameters []types.Type) types.Type {
+					return octalResultType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return Oct[uint64]
+				},
+			},
+			{
+				overloadId: 17,
+				args:       []types.T{types.T_binary},
+				retType: func(parameters []types.Type) types.Type {
+					return octalResultType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return OctString
+				},
+			},
+			{
+				overloadId: 18,
+				args:       []types.T{types.T_varbinary},
+				retType: func(parameters []types.Type) types.Type {
+					return octalResultType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return OctString
+				},
+			},
+			{
+				overloadId: 19,
+				args:       []types.T{types.T_blob},
+				retType: func(parameters []types.Type) types.Type {
+					return octalResultType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return OctString
+				},
+			},
+		}),
 	},
 
 	// function `PI`

--- a/pkg/sql/plan/function/oct_legacy.go
+++ b/pkg/sql/plan/function/oct_legacy.go
@@ -1,0 +1,138 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"golang.org/x/exp/constraints"
+)
+
+// OctStringOverloadStart separates persisted DECIMAL128 OCT identities from
+// the VARCHAR implementation. Existing catalog expressions retain their type
+// and overload ID and must continue to execute with the original semantics.
+const OctStringOverloadStart = 15
+
+func octTypeCheck(overloads []overload, inputs []types.Type) checkResult {
+	result := fixedTypeMatch(overloads[OctStringOverloadStart:], inputs)
+	if result.status == succeedMatched || result.status == succeedWithCast {
+		result.idx += OctStringOverloadStart
+	}
+	return result
+}
+
+func withLegacyOctOverloads(current []overload) []overload {
+	legacyOps := []executeLogicOfOverload{
+		legacyOct[uint8], legacyOct[uint16], legacyOct[uint32], legacyOct[uint64],
+		legacyOct[int8], legacyOct[int16], legacyOct[int32], legacyOct[int64],
+		legacyOctFloat[float32], legacyOctFloat[float64], legacyOctDate, legacyOctDatetime,
+		legacyOctString, legacyOctString, legacyOctString,
+	}
+	result := make([]overload, OctStringOverloadStart, OctStringOverloadStart+len(current))
+	for i, op := range legacyOps {
+		result[i] = current[i]
+		result[i].retType = func([]types.Type) types.Type { return types.T_decimal128.ToType() }
+		result[i].newOp = func() executeLogicOfOverload { return op }
+	}
+	for i := range current {
+		current[i].overloadId += OctStringOverloadStart
+	}
+	return append(result, current...)
+}
+
+// These executors intentionally preserve pre-VARCHAR OCT behavior, including
+// rounding and conversion errors, for already persisted expressions.
+func legacyOct[T constraints.Unsigned | constraints.Signed](ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryFixedToFixedWithErrorCheck[T, types.Decimal128](ivecs, result, proc, length, legacyOctValue[T], selectList)
+}
+
+func legacyOctValue[T constraints.Unsigned | constraints.Signed](val T) (types.Decimal128, error) {
+	_val := uint64(val)
+	return types.ParseDecimal128(fmt.Sprintf("%o", _val), 38, 0)
+}
+
+func legacyOctFloat[T constraints.Float](ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryFixedToFixedWithErrorCheck[T, types.Decimal128](ivecs, result, proc, length, legacyOctFloatValue[T], selectList)
+}
+
+func legacyOctDate(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryFixedToFixedWithErrorCheck[types.Date, types.Decimal128](ivecs, result, proc, length, func(v types.Date) (types.Decimal128, error) {
+		year, _, _, _ := v.Calendar(true)
+		val := int64(year)
+		return legacyOctValue[int64](val)
+	}, selectList)
+}
+
+func legacyOctDatetime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryFixedToFixedWithErrorCheck[types.Datetime, types.Decimal128](ivecs, result, proc, length, func(v types.Datetime) (types.Decimal128, error) {
+		year, _, _, _ := v.ToDate().Calendar(true)
+		val := int64(year)
+		return legacyOctValue[int64](val)
+	}, selectList)
+}
+
+func legacyOctString(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryBytesToFixedWithErrorCheck[types.Decimal128](ivecs, result, proc, length, func(v []byte) (types.Decimal128, error) {
+		s := string(v)
+		dt, err := types.ParseDatetime(s, 6)
+		if err == nil {
+			year, _, _, _ := dt.ToDate().Calendar(true)
+			val := int64(year)
+			return legacyOctValue[int64](val)
+		}
+		d, err2 := types.ParseDateCast(s)
+		if err2 == nil {
+			year, _, _, _ := d.Calendar(true)
+			val := int64(year)
+			return legacyOctValue[int64](val)
+		}
+		val, err3 := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+		if err3 == nil {
+			return legacyOctValue[int64](val)
+		}
+		return types.Decimal128{}, moerr.NewInvalidArgNoCtx("function oct", s)
+	}, selectList)
+}
+
+func legacyOctFloatValue[T constraints.Float](xs T) (types.Decimal128, error) {
+	var res types.Decimal128
+
+	if xs < 0 {
+		val, err := strconv.ParseInt(fmt.Sprintf("%1.0f", xs), 10, 64)
+		if err != nil {
+			return res, moerr.NewInternalErrorNoCtx("the input value is out of integer range")
+		}
+		res, err = legacyOctValue(uint64(val))
+		if err != nil {
+			return res, err
+		}
+	} else {
+		val, err := strconv.ParseUint(fmt.Sprintf("%1.0f", xs), 10, 64)
+		if err != nil {
+			return res, moerr.NewInternalErrorNoCtx("the input value is out of integer range")
+		}
+		res, err = legacyOctValue(val)
+		if err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}

--- a/pkg/sql/plan/function/string_result_domain.go
+++ b/pkg/sql/plan/function/string_result_domain.go
@@ -279,6 +279,14 @@ func textStringResultType(bound stringResultBound, charset uint8) types.Type {
 	return result
 }
 
+// octalResultType matches MySQL's OCT metadata. OCT returns a character
+// representation rather than a numeric value; 65 is the stable declared
+// VARCHAR width used by MySQL for this function, including the
+// sign/two's-complement representation of a BIGINT.
+func octalResultType(_ []types.Type) types.Type {
+	return types.New(types.T_varchar, 65, 0)
+}
+
 func concatTextResultBound(parameters []types.Type, start int) stringResultBound {
 	if start < 0 || start > len(parameters) {
 		return unknownStringResultBound()

--- a/test/distributed/cases/ddl/create_table_as_select.result
+++ b/test/distributed/cases/ddl/create_table_as_select.result
@@ -626,7 +626,7 @@ create table string04 as select oct(col2), empty(col3), length(col1) from string
 show create table string04;
 [unknown result because it is related to issue#24436]
 select * from string04;
-➤ oct(col2)[3,38,0]  ¦  empty(col3)[-7,1,0]  ¦  length(col1)[-5,64,0]  𝄀
+➤ oct(col2)[12,65,0]  ¦  empty(col3)[-7,1,0]  ¦  length(col1)[-5,64,0]  𝄀
 2  ¦  0  ¦  17  𝄀
 1  ¦  0  ¦  17  𝄀
 0  ¦  null  ¦  27

--- a/test/distributed/cases/function/func_string_oct.result
+++ b/test/distributed/cases/function/func_string_oct.result
@@ -1,6 +1,21 @@
 select oct(0b11111111);
 oct(0b11111111)
 377
+SELECT oct(X'FF') AS oct_hex_literal;
+oct_hex_literal
+377
+SELECT oct(X'0102') AS oct_multi_byte_hex_literal;
+oct_multi_byte_hex_literal
+402
+DROP TABLE IF EXISTS oct_binary_columns;
+CREATE TABLE oct_binary_columns (v VARBINARY(10), b BINARY(3), l BLOB);
+INSERT INTO oct_binary_columns VALUES (X'FF', X'0102FF', X'3132'), (X'0102', X'0001FF', X'FF'), (X'', X'000000', X'');
+SELECT HEX(v), OCT(v), HEX(b), OCT(b), OCT(l) FROM oct_binary_columns;
+HEX(v)    OCT(v)    HEX(b)    OCT(b)    OCT(l)
+FF    0    0102FF    0    14
+0102    0    0001FF    0    0
+    null    000000    0    null
+DROP TABLE oct_binary_columns;
 select oct(12);
 oct(12)
 14
@@ -23,9 +38,25 @@ select oct(-1);
 oct(-1)
 1777777777777777777777
 select oct(10e50);
-internal error: the input value is out of integer range
+oct(10e50)
+1
 select oct(-10e50);
-internal error: the input value is out of integer range
+oct(-10e50)
+1777777777777777777777
+SELECT OCT(1e308) AS positive_huge, OCT(-1e308) AS negative_huge, OCT(1e-15) AS fixed_tiny, OCT(1e-16) AS scientific_tiny;
+positive_huge	negative_huge	fixed_tiny	scientific_tiny
+1	1777777777777777777777	0	1
+CREATE TABLE oct_decimal_exact (id INT, d DECIMAL(38,1));
+INSERT INTO oct_decimal_exact VALUES (1, 9007199254740993.9), (2, 18446744073709551615), (3, 18446744073709551616), (4, -18446744073709551615), (5, -18446744073709551616), (6, NULL);
+SELECT id, OCT(d) AS oct_value FROM oct_decimal_exact ORDER BY id;
+id	oct_value
+1	400000000000000001
+2	1777777777777777777777
+3	1777777777777777777777
+4	1
+5	0
+6	null
+DROP TABLE oct_decimal_exact;
 select oct(0.00000000000000000000000001);
 oct(0.00000000000000000000000001)
 0
@@ -33,7 +64,40 @@ select oct(-0.00000000000000000000000001);
 oct(-0.00000000000000000000000001)
 0
 select oct("你好");
-invalid argument function oct, bad value 你好
+oct(你好)
+0
+SELECT oct('12tail') AS oct_prefix,
+oct('12.5') AS oct_fraction,
+oct('abc') AS oct_non_numeric,
+oct('') AS oct_empty;
+oct_prefix    oct_fraction    oct_non_numeric    oct_empty
+14    14    0    null
+SELECT oct('20240506') AS oct_compact,
+oct('20240101123456') AS oct_compact_datetime;
+oct_compact    oct_compact_datetime
+115154172    446420402322600
+SELECT oct(TIME '12:34:56') AS oct_time,
+oct(TIME '-12:34:56') AS oct_negative_time;
+oct_time    oct_negative_time
+14    1777777777777777777764
+SELECT oct(8) AS oct_text, oct(8) + 0 AS oct_numeric_context;
+oct_text    oct_numeric_context
+10    10
+SELECT oct(8) + oct(1) AS oct_add,
+oct(8) - oct(1) AS oct_subtract,
+oct(8) * oct(2) AS oct_multiply,
+oct(8) / oct(2) AS oct_divide,
+oct(8) % oct(3) AS oct_modulo,
+oct(8) DIV oct(2) AS oct_integer_divide,
+-oct(8) AS oct_unary_minus;
+oct_add    oct_subtract    oct_multiply    oct_divide    oct_modulo    oct_integer_divide    oct_unary_minus
+11.0    9.0    20.0    5.0    1.0    5    -10.0
+SELECT OCT(0.5) AS oct_half, OCT(0.6) AS oct_fraction_below_one, OCT(1.5) AS oct_one_half, OCT(1.6) AS oct_one_fraction, OCT(-1.5) AS oct_negative_one_half, OCT(-2.5) AS oct_negative_two_half;
+oct_half    oct_fraction_below_one    oct_one_half    oct_one_fraction    oct_negative_one_half    oct_negative_two_half
+0    0    1    1    1777777777777777777777    1777777777777777777776
+SELECT oct('-18446744073709551616') AS oct_negative_overflow;
+oct_negative_overflow
+0
 create table t1(a int);
 insert into t1 values();
 select oct(a) from t1;
@@ -46,7 +110,11 @@ insert into t1 values(1, 1, 2, 4, 5, 5.5, 31.13, 14.314, "2012-03-12", "2012-03-
 insert into t1 values(1, 1, 2, 4, 5, 5.5, 31.13, 14.314, "2012-03-12", "2012-03-12 10:03:12", "2012-03-12 13:03:12", "abc", "dcf");
 insert into t1 values(1, 1, 2, 4, 5, 5.5, 31.13, 14.314, "2012-03-12", "2012-03-12 10:03:12", "2012-03-12 13:03:12", "abc", "dcf");
 select oct(a),oct(b),oct(c),oct(d),oct(e),oct(f),oct(g),oct(h),oct(i),oct(k),oct(l),oct(m),oct(n) from t1;
-invalid argument function oct, bad value abc
+oct(a)    oct(b)    oct(c)    oct(d)    oct(e)    oct(f)    oct(g)    oct(h)    oct(i)    oct(k)    oct(l)    oct(m)    oct(n)
+1    1    2    4    5    5    37    16    3734    3734    3734    0    0
+1    1    2    4    5    5    37    16    3734    3734    3734    0    0
+1    1    2    4    5    5    37    16    3734    3734    3734    0    0
+1    1    2    4    5    5    37    16    3734    3734    3734    0    0
 drop table t1;
 CREATE TABLE t1(a char(255), b varchar(255));
 INSERT INTO t1 select oct(56), oct(234);
@@ -88,3 +156,27 @@ drop table t2;
 SELECT OCT(NULL) IS UNKNOWN;
 OCT(null) is unknown
 1
+SELECT OCT(-9.999999999999999e-100) AS rounded_negative, OCT(9.999999999999999e-100) AS positive_control;
+rounded_negative    positive_control
+1777777777777777777777    11
+DROP TABLE IF EXISTS oct_nn_copy;
+DROP TABLE IF EXISTS oct_nn_source;
+CREATE TABLE oct_nn_source (id INT NOT NULL, v VARCHAR(10) NOT NULL, b VARBINARY(10) NOT NULL, n BIGINT NOT NULL);
+INSERT INTO oct_nn_source VALUES (1, '', X'', 0), (2, '12', X'3132', 12);
+SELECT id, OCT(v) AS text_oct, OCT(b) AS binary_oct, OCT(n) AS numeric_oct FROM oct_nn_source ORDER BY id;
+id    text_oct    binary_oct    numeric_oct
+1    NULL    NULL    0
+2    14    14    14
+CREATE TABLE oct_nn_copy AS SELECT id, OCT(v) AS text_oct, OCT(b) AS binary_oct, OCT(n) AS numeric_oct FROM oct_nn_source;
+SELECT id, text_oct, binary_oct, numeric_oct FROM oct_nn_copy ORDER BY id;
+id    text_oct    binary_oct    numeric_oct
+1    NULL    NULL    0
+2    14    14    14
+SELECT COLUMN_NAME, IS_NULLABLE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'oct_nn_copy' ORDER BY ORDINAL_POSITION;
+COLUMN_NAME    IS_NULLABLE
+id    NO
+text_oct    YES
+binary_oct    YES
+numeric_oct    NO
+DROP TABLE oct_nn_copy;
+DROP TABLE oct_nn_source;

--- a/test/distributed/cases/function/func_string_oct.test
+++ b/test/distributed/cases/function/func_string_oct.test
@@ -2,6 +2,13 @@
 -- @bvt:issue#3156
 select oct(0b11111111);
 -- @bvt:issue
+SELECT oct(X'FF') AS oct_hex_literal;
+SELECT oct(X'0102') AS oct_multi_byte_hex_literal;
+DROP TABLE IF EXISTS oct_binary_columns;
+CREATE TABLE oct_binary_columns (v VARBINARY(10), b BINARY(3), l BLOB);
+INSERT INTO oct_binary_columns VALUES (X'FF', X'0102FF', X'3132'), (X'0102', X'0001FF', X'FF'), (X'', X'000000', X'');
+SELECT HEX(v), OCT(v), HEX(b), OCT(b), OCT(l) FROM oct_binary_columns;
+DROP TABLE oct_binary_columns;
 
 select oct(12);
 SELECT oct(1314);
@@ -21,9 +28,32 @@ select oct(-1);
 
 select oct(10e50);
 select oct(-10e50);
+SELECT OCT(1e308) AS positive_huge, OCT(-1e308) AS negative_huge, OCT(1e-15) AS fixed_tiny, OCT(1e-16) AS scientific_tiny;
+CREATE TABLE oct_decimal_exact (id INT, d DECIMAL(38,1));
+INSERT INTO oct_decimal_exact VALUES (1, 9007199254740993.9), (2, 18446744073709551615), (3, 18446744073709551616), (4, -18446744073709551615), (5, -18446744073709551616), (6, NULL);
+SELECT id, OCT(d) AS oct_value FROM oct_decimal_exact ORDER BY id;
+DROP TABLE oct_decimal_exact;
 select oct(0.00000000000000000000000001);
 select oct(-0.00000000000000000000000001);
 select oct("你好");
+SELECT oct('12tail') AS oct_prefix,
+       oct('12.5') AS oct_fraction,
+       oct('abc') AS oct_non_numeric,
+       oct('') AS oct_empty;
+SELECT oct('20240506') AS oct_compact,
+       oct('20240101123456') AS oct_compact_datetime;
+SELECT oct(TIME '12:34:56') AS oct_time,
+       oct(TIME '-12:34:56') AS oct_negative_time;
+SELECT oct(8) AS oct_text, oct(8) + 0 AS oct_numeric_context;
+SELECT oct(8) + oct(1) AS oct_add,
+       oct(8) - oct(1) AS oct_subtract,
+       oct(8) * oct(2) AS oct_multiply,
+       oct(8) / oct(2) AS oct_divide,
+       oct(8) % oct(3) AS oct_modulo,
+       oct(8) DIV oct(2) AS oct_integer_divide,
+       -oct(8) AS oct_unary_minus;
+SELECT OCT(0.5) AS oct_half, OCT(0.6) AS oct_fraction_below_one, OCT(1.5) AS oct_one_half, OCT(1.6) AS oct_one_fraction, OCT(-1.5) AS oct_negative_one_half, OCT(-2.5) AS oct_negative_two_half;
+SELECT oct('-18446744073709551616') AS oct_negative_overflow;
 
 create table t1(a int);
 insert into t1 values();
@@ -76,3 +106,16 @@ drop table t2;
 
 SELECT OCT(NULL) IS UNKNOWN;
 
+SELECT OCT(-9.999999999999999e-100) AS rounded_negative, OCT(9.999999999999999e-100) AS positive_control;
+
+# Empty NOT NULL string inputs still produce nullable OCT results, including CTAS.
+DROP TABLE IF EXISTS oct_nn_copy;
+DROP TABLE IF EXISTS oct_nn_source;
+CREATE TABLE oct_nn_source (id INT NOT NULL, v VARCHAR(10) NOT NULL, b VARBINARY(10) NOT NULL, n BIGINT NOT NULL);
+INSERT INTO oct_nn_source VALUES (1, '', X'', 0), (2, '12', X'3132', 12);
+SELECT id, OCT(v) AS text_oct, OCT(b) AS binary_oct, OCT(n) AS numeric_oct FROM oct_nn_source ORDER BY id;
+CREATE TABLE oct_nn_copy AS SELECT id, OCT(v) AS text_oct, OCT(b) AS binary_oct, OCT(n) AS numeric_oct FROM oct_nn_source;
+SELECT id, text_oct, binary_oct, numeric_oct FROM oct_nn_copy ORDER BY id;
+SELECT COLUMN_NAME, IS_NULLABLE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'oct_nn_copy' ORDER BY ORDINAL_POSITION;
+DROP TABLE oct_nn_copy;
+DROP TABLE oct_nn_source;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement
- [x] Test and CI

## Which issue(s) this PR fixes:

Fixes #28465
Fixes #28466

## What this PR does / why we need it:

This PR finalizes the OCT compatibility fix on the current `main` branch. PR
#28450 (expression defaults, MORPC v60) is already merged; the old stacked
expression-default implementation and duplicate history are not included here.

### Correctness

- New OCT overloads return `VARCHAR(65)`, matching MySQL metadata and allowing
  CTAS/view/client metadata to preserve the character result domain.
- Existing overload identities `0..14` retain their original `DECIMAL128`
  result and executors. This protects persisted expressions and mixed-version
  execution from passing a DECIMAL result wrapper to the new VARCHAR executor.
- String inputs use bounded MySQL-style decimal-prefix conversion: ASCII
  whitespace/signs, fractional and trailing text, invalid non-empty values,
  empty values (`NULL`), positive overflow, and negative overflow are handled
  without aborting a mixed-row query.
- DATE/DATETIME use the year, TIME uses its signed hour, and binary literals
  retain their byte-oriented conversion. BINARY/VARBINARY/BLOB columns use
  their ordinary string-byte contents rather than being mistaken for HEX
  literal provenance.
- DECIMAL64/128/256 values reach OCT through exact decimal text, avoiding the
  previous FLOAT64 precision loss above 2^53 and preserving unsigned/negative
  boundary behavior.
- Finite FLOAT/DOUBLE values no longer fail on ordinary large values. The
  common DOUBLE range uses a bounded integer fast path; scientific notation
  follows the numeric-expression formatting contract, including rounding
  carry at the first integer-prefix digit.
- Direct OCT operands in arithmetic are explicitly cast into the numeric
  operator lattice. The existing MatrixOne `text + text -> CONCAT` behavior
  is unchanged for ordinary text expressions.
- New string OCT results are conservatively nullable because a valid empty
  non-NULL string produces SQL `NULL`; numeric/temporal/bit and legacy
  nullability contracts remain unchanged.

### Rolling upgrade / protocol safety

The current main branch already uses MORPC v61 for index metadata provenance.
The new OCT overload identities therefore use MORPC v62. Admission is checked
at plan compilation, cached `Run`, and remote pipeline send/receive boundaries,
including nested persisted expressions (CHECK/default/generated/ON UPDATE).
Older persisted OCT identities remain executable; a newer OCT identity is
rejected with an explicit unsupported-version error when the negotiated
capability is below v62.

### Performance and unhappy paths

The hot string path is one bounded prefix scan plus octal formatting, with no
per-row logging, retry, goroutine, lock, or unbounded allocation. Large finite
float conversion avoids temporary strings in the common range. Empty strings,
NULLs, selection masks, mixed rows, overflow, invalid prefixes, old serialized
plans, cached plans, and remote boundaries are covered by tests.

## Validation

Passed locally on macOS arm64 / Go 1.26.4 using the repository CGo wrapper and
a freshly built matching native library:

- Focused OCT function, binder, protocol, cached-run, and remote-boundary
  tests.
- Full `pkg/sql/plan/function`, `pkg/sql/plan`, and `pkg/sql/compile` tests.
- Focused `-race` OCT tests for function and compile packages.
- `go vet -mod=readonly` for the changed packages.
- Package-scoped `golangci-lint` for the changed packages: 0 issues.
- `make build-with-prebuilt-native NATIVE_BUILD_JOBS=8`.
- `func_string_oct.test`: 76/76, 100%, in two clean reruns with metadata
  ignored and one run with metadata checking enabled; no table residue after
  execution.
- Independent SQL CTAS verification: OCT columns are `VARCHAR(65)`, nullable
  for empty string/binary inputs, and values read back correctly.
- `git diff --check`.

The full legacy `create_table_as_select.sql` fixture was also probed, but its
baseline result file has unrelated metadata drift in many existing cases
(DECIMAL/CHAR/TEXT widths and SHOW CREATE expectations), so its 86% result is
not attributed to this PR and no unrelated fixture changes are included.
The OCT-specific CTAS path was verified independently above. CI should provide
the authoritative Linux/multi-CN result for the final head.
