### PR TITLE
ci: shard race UT across runners

### DIFF
--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -76,6 +76,11 @@ jobs:
     uses: matrixorigin/CI/.github/workflows/ci.yaml@main
     with:
       ut_parallel: 8
+      # The race UT runner already defines a complete, disjoint partition.
+      # Run those partitions concurrently so embedded-cluster admission in one
+      # shard cannot serialize the light/issues/heavy-plan work on one runner.
+      # The reusable workflow keeps the established UT check as an AND gate.
+      ut_sharded: true
     secrets: inherit
 
   matrixone-ut-coverage:


### PR DESCRIPTION
## What this PR does

Enable the existing four-way race UT partition in the MatrixOne ALL CI entrypoint:

- light + hnsw
- issues
- embedded
- heavy + plan

The reusable CI workflow already validates that the partitions are complete and disjoint, runs them with `fail-fast: false`, and keeps `Matrixone CI / UT Test on Ubuntu/x86` as the aggregate AND gate.

## Why

Recent successful CI runs show the single-runner race UT critical path at 50:17–51:50 for the test runner, with the embedded-cluster stage alone taking about 20 minutes and accumulating up to 16.92 minutes of admission wait across 33 cluster lifecycles. Static shard fan-out removes cross-stage serialization while preserving the same test scope.

## Validation

- `git diff --check`
- YAML parse
- `bash -n optools/run_ut.sh optools/ut_tools.bash`
- targeted `go test ./optools` shard-partition tests
- GPT-6 medium review: no blocker/major findings

This PR intentionally changes only the CI UT scheduling flag; no test cases or coverage scope are changed.
