### PR TITLE
test: speed up HAKeeper bootstrap in embedded UT

### DIFF
--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -373,6 +373,15 @@ func (c *Config) Validate() error {
 	if c.HAKeeperConfig.TNStoreTimeout.Duration == 0 {
 		return moerr.NewBadConfigNoCtx("DNStoreTimeout not set")
 	}
+	if c.HAKeeperTickInterval.Duration <= 0 {
+		return moerr.NewBadConfigNoCtx("HAKeeperTickInterval must be positive")
+	}
+	if c.HAKeeperCheckInterval.Duration <= 0 {
+		return moerr.NewBadConfigNoCtx("HAKeeperCheckInterval must be positive")
+	}
+	if c.HAKeeperCheckInterval.Duration > time.Duration(1<<63-1)/checkBootstrapCycles {
+		return moerr.NewBadConfigNoCtx("HAKeeperCheckInterval is too large")
+	}
 	if c.GossipProbeInterval.Duration == 0 {
 		return moerr.NewBadConfigNoCtx("GossipProbeInterval not set")
 	}

--- a/pkg/logservice/config_test.go
+++ b/pkg/logservice/config_test.go
@@ -113,7 +113,7 @@ func TestConfigCanBeValidated(t *testing.T) {
 	c3 := c
 	c3.RaftAddress = ""
 	c3.RaftPort = 0
-	err = c2.Validate()
+	err = c3.Validate()
 	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
 
 	c4 := c
@@ -135,6 +135,26 @@ func TestConfigCanBeValidated(t *testing.T) {
 	c7 := c
 	c7.HAKeeperBootstrapRetryInterval.Duration = -time.Second
 	err = c7.Validate()
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+
+	c8 := c
+	c8.HAKeeperCheckInterval.Duration = 0
+	err = c8.Validate()
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+
+	c9 := c
+	c9.HAKeeperCheckInterval.Duration = -time.Second
+	err = c9.Validate()
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+
+	c10 := c
+	c10.HAKeeperTickInterval.Duration = -time.Second
+	err = c10.Validate()
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+
+	c11 := c
+	c11.HAKeeperCheckInterval.Duration = time.Duration(1<<63 - 1)
+	err = c11.Validate()
 	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
 }
 

--- a/pkg/logservice/service.go
+++ b/pkg/logservice/service.go
@@ -74,6 +74,7 @@ type Service struct {
 	stopper     *stopper.Stopper
 	haClient    LogHAKeeperClient
 	fileService fileservice.FileService
+	heartbeatC  chan struct{}
 	shutdownC   chan struct{}
 
 	options struct {
@@ -116,6 +117,7 @@ func NewService(
 		cfg:         cfg,
 		stopper:     stopper.NewStopper("log-service"),
 		fileService: fileService,
+		heartbeatC:  make(chan struct{}, 1),
 		shutdownC:   shutdownC,
 	}
 	for _, opt := range opts {
@@ -136,6 +138,7 @@ func NewService(
 		service.runtime.Logger().Error("failed to create log store", zap.Error(err))
 		return nil, err
 	}
+	store.bootstrapCommandsAdded = service.requestHeartbeat
 	if err := store.loadMetadata(); err != nil {
 		_ = store.close()
 		return nil, err

--- a/pkg/logservice/service_bootstrap.go
+++ b/pkg/logservice/service_bootstrap.go
@@ -153,6 +153,16 @@ func (s *Service) BootstrapHAKeeper(ctx context.Context, cfg Config) error {
 			return nil
 		default:
 		}
+		ready, err := s.store.waitHAKeeperLeaderReady(ctx, hakeeperDefaultTimeout)
+		if err != nil {
+			if restoreConfigured {
+				return err
+			}
+			return nil
+		}
+		if !ready {
+			continue
+		}
 		s.runtime.SubLogger(runtime.SystemInit).Info("before initial cluster info")
 		applied, err := s.store.setInitialClusterInfoWithRecoveryResult(
 			numOfLogShards,
@@ -184,6 +194,7 @@ func (s *Service) BootstrapHAKeeper(ctx context.Context, cfg Config) error {
 		initialClusterProposed = true
 		s.runtime.SubLogger(runtime.SystemInit).Info("initial cluster info set",
 			zap.Bool("applied", applied))
+		s.requestHeartbeat()
 		break
 	}
 	if backup != nil {

--- a/pkg/logservice/service_bootstrap.go
+++ b/pkg/logservice/service_bootstrap.go
@@ -155,10 +155,12 @@ func (s *Service) BootstrapHAKeeper(ctx context.Context, cfg Config) error {
 		}
 		ready, err := s.store.waitHAKeeperLeaderReady(ctx, hakeeperDefaultTimeout)
 		if err != nil {
-			if restoreConfigured {
-				return err
+			// Preserve the ordinary bootstrap's cancellation/removed-shard policy,
+			// but do not report success for a failed NodeHost (for example ErrClosed).
+			if !restoreConfigured && (ctx.Err() != nil || errors.Is(err, dragonboat.ErrShardNotFound)) {
+				return nil
 			}
-			return nil
+			return err
 		}
 		if !ready {
 			continue

--- a/pkg/logservice/service_commands.go
+++ b/pkg/logservice/service_commands.go
@@ -182,6 +182,8 @@ func (s *Service) heartbeatWorker(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-s.heartbeatC:
+			s.heartbeat(ctx)
 		case <-ticker.C:
 			s.heartbeat(ctx)
 			// I'd call this an ugly hack to just workaround select's
@@ -192,6 +194,16 @@ func (s *Service) heartbeatWorker(ctx context.Context) {
 			default:
 			}
 		}
+	}
+}
+
+func (s *Service) requestHeartbeat() {
+	if s.heartbeatC == nil {
+		return
+	}
+	select {
+	case s.heartbeatC <- struct{}{}:
+	default:
 	}
 }
 

--- a/pkg/logservice/service_commands_test.go
+++ b/pkg/logservice/service_commands_test.go
@@ -37,6 +37,23 @@ import (
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 )
 
+func TestRequestHeartbeatCoalescesBeforeWorker(t *testing.T) {
+	service := &Service{heartbeatC: make(chan struct{}, 1)}
+	service.requestHeartbeat()
+	service.requestHeartbeat()
+
+	select {
+	case <-service.heartbeatC:
+	default:
+		t.Fatal("heartbeat request was not retained")
+	}
+	select {
+	case <-service.heartbeatC:
+		t.Fatal("heartbeat requests were not coalesced")
+	default:
+	}
+}
+
 func TestBackgroundTickAndHeartbeat(t *testing.T) {
 	runtime.RunTest(
 		"",

--- a/pkg/logservice/store.go
+++ b/pkg/logservice/store.go
@@ -1584,7 +1584,14 @@ func (l *store) isLeaderHAKeeper() (bool, uint64, error) {
 }
 
 func (l *store) waitHAKeeperLeaderReady(ctx context.Context, maxWait time.Duration) (bool, error) {
-	if leaderID, _, ok, err := l.nh.GetLeaderID(hakeeper.DefaultHAKeeperShardID); err == nil && ok && leaderID != 0 {
+	if err := ctx.Err(); err != nil {
+		return false, moerr.AttachCause(ctx, err)
+	}
+	leaderID, _, ok, err := l.nh.GetLeaderID(hakeeper.DefaultHAKeeperShardID)
+	if err != nil {
+		return false, err
+	}
+	if ok && leaderID != 0 {
 		return true, nil
 	}
 	if maxWait <= 0 {
@@ -1596,16 +1603,19 @@ func (l *store) waitHAKeeperLeaderReady(ctx context.Context, maxWait time.Durati
 	timer := time.NewTimer(maxWait)
 	defer timer.Stop()
 	for {
-		leaderID, _, ok, err := l.nh.GetLeaderID(hakeeper.DefaultHAKeeperShardID)
-		if err == nil && ok && leaderID != 0 {
-			return true, nil
-		}
 		select {
 		case <-ctx.Done():
 			return false, moerr.AttachCause(ctx, ctx.Err())
 		case <-timer.C:
 			return false, nil
 		case <-ticker.C:
+		}
+		leaderID, _, ok, err := l.nh.GetLeaderID(hakeeper.DefaultHAKeeperShardID)
+		if err != nil {
+			return false, err
+		}
+		if ok && leaderID != 0 {
+			return true, nil
 		}
 	}
 }

--- a/pkg/logservice/store.go
+++ b/pkg/logservice/store.go
@@ -140,7 +140,7 @@ type store struct {
 	tickerStopper          *stopper.Stopper
 	runtime                runtime.Runtime
 
-	bootstrapCheckCycles   uint64
+	bootstrapCheckDeadline time.Time
 	bootstrapMgr           *bootstrap.Manager
 	lastBootstrapLogTime   time.Time
 	bootstrapCommandsAdded func()
@@ -1521,7 +1521,7 @@ func (l *store) startTaskScheduleTicker(
 }
 
 func (l *store) ticker(ctx context.Context) {
-	if l.cfg.HAKeeperTickInterval.Duration == 0 {
+	if l.cfg.HAKeeperTickInterval.Duration <= 0 {
 		panic("invalid HAKeeperTickInterval")
 	}
 	l.runtime.Logger().Info("Hakeeper interval configs",
@@ -1529,7 +1529,7 @@ func (l *store) ticker(ctx context.Context) {
 		zap.Int64("HAKeeperCheckInterval", int64(l.cfg.HAKeeperCheckInterval.Duration)))
 	ticker := time.NewTicker(l.cfg.HAKeeperTickInterval.Duration)
 	defer ticker.Stop()
-	if l.cfg.HAKeeperCheckInterval.Duration == 0 {
+	if l.cfg.HAKeeperCheckInterval.Duration <= 0 {
 		panic("invalid HAKeeperCheckInterval")
 	}
 	defer func() {

--- a/pkg/logservice/store.go
+++ b/pkg/logservice/store.go
@@ -1543,8 +1543,9 @@ func (l *store) ticker(ctx context.Context) {
 	if initialCheckInterval > bootstrapHAKeeperCheckInterval {
 		initialCheckInterval = bootstrapHAKeeperCheckInterval
 	}
-	haTimer := time.NewTimer(initialCheckInterval)
-	defer haTimer.Stop()
+	haTicker := time.NewTicker(initialCheckInterval)
+	defer haTicker.Stop()
+	checkInterval := initialCheckInterval
 
 	// moving task schedule from the ticker normal routine to a
 	// separate goroutine can avoid the hakeeper's health check and tick update
@@ -1558,9 +1559,9 @@ func (l *store) ticker(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			l.hakeeperTick()
-		case <-haTimer.C:
+		case <-haTicker.C:
 			state := l.hakeeperCheck()
-			haTimer.Reset(l.nextHAKeeperCheckInterval(state))
+			checkInterval = l.updateHAKeeperCheckTicker(haTicker.Reset, checkInterval, state)
 		case <-ctx.Done():
 			return
 		}

--- a/pkg/logservice/store.go
+++ b/pkg/logservice/store.go
@@ -140,8 +140,10 @@ type store struct {
 	tickerStopper          *stopper.Stopper
 	runtime                runtime.Runtime
 
-	bootstrapCheckCycles uint64
-	bootstrapMgr         *bootstrap.Manager
+	bootstrapCheckCycles   uint64
+	bootstrapMgr           *bootstrap.Manager
+	lastBootstrapLogTime   time.Time
+	bootstrapCommandsAdded func()
 
 	taskScheduler hakeeper.TaskScheduler
 
@@ -1533,8 +1535,16 @@ func (l *store) ticker(ctx context.Context) {
 	defer func() {
 		l.runtime.Logger().Info("HAKeeper ticker stopped")
 	}()
-	haTicker := time.NewTicker(l.cfg.HAKeeperCheckInterval.Duration)
-	defer haTicker.Stop()
+	// Probe once quickly so a newly elected leader can bootstrap without
+	// waiting for the normal health-check interval. Subsequent follower/error
+	// polls use the configured interval, while explicit bootstrap states use
+	// the fast interval.
+	initialCheckInterval := l.cfg.HAKeeperCheckInterval.Duration
+	if initialCheckInterval > bootstrapHAKeeperCheckInterval {
+		initialCheckInterval = bootstrapHAKeeperCheckInterval
+	}
+	haTimer := time.NewTimer(initialCheckInterval)
+	defer haTimer.Stop()
 
 	// moving task schedule from the ticker normal routine to a
 	// separate goroutine can avoid the hakeeper's health check and tick update
@@ -1548,8 +1558,9 @@ func (l *store) ticker(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			l.hakeeperTick()
-		case <-haTicker.C:
-			l.hakeeperCheck()
+		case <-haTimer.C:
+			state := l.hakeeperCheck()
+			haTimer.Reset(l.nextHAKeeperCheckInterval(state))
 		case <-ctx.Done():
 			return
 		}
@@ -1569,6 +1580,33 @@ func (l *store) isLeaderHAKeeper() (bool, uint64, error) {
 	}
 	replicaID := atomic.LoadUint64(&l.haKeeperReplicaID)
 	return ok && replicaID != 0 && leaderID == replicaID, term, nil
+}
+
+func (l *store) waitHAKeeperLeaderReady(ctx context.Context, maxWait time.Duration) (bool, error) {
+	if leaderID, _, ok, err := l.nh.GetLeaderID(hakeeper.DefaultHAKeeperShardID); err == nil && ok && leaderID != 0 {
+		return true, nil
+	}
+	if maxWait <= 0 {
+		return false, nil
+	}
+
+	ticker := time.NewTicker(time.Millisecond * 20)
+	defer ticker.Stop()
+	timer := time.NewTimer(maxWait)
+	defer timer.Stop()
+	for {
+		leaderID, _, ok, err := l.nh.GetLeaderID(hakeeper.DefaultHAKeeperShardID)
+		if err == nil && ok && leaderID != 0 {
+			return true, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, moerr.AttachCause(ctx, ctx.Err())
+		case <-timer.C:
+			return false, nil
+		case <-ticker.C:
+		}
+	}
 }
 
 // TODO: add test for this

--- a/pkg/logservice/store_hakeeper_check.go
+++ b/pkg/logservice/store_hakeeper_check.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -31,9 +32,10 @@ import (
 )
 
 const (
-	minIDAllocCapacity   uint64 = 1024
-	defaultIDBatchSize   uint64 = 1024 * 10
-	checkBootstrapCycles        = 100
+	minIDAllocCapacity             uint64 = 1024
+	defaultIDBatchSize             uint64 = 1024 * 10
+	checkBootstrapCycles                  = 100
+	bootstrapHAKeeperCheckInterval        = 100 * time.Millisecond
 )
 
 var (
@@ -252,14 +254,33 @@ func (l *store) getCheckerStateFromLeader() (*pb.CheckerState, uint64) {
 
 var debugPrintHAKeeperState atomic.Bool
 
-func (l *store) hakeeperCheck() {
+func (l *store) nextHAKeeperCheckInterval(state *pb.CheckerState) time.Duration {
+	interval := l.cfg.HAKeeperCheckInterval.Duration
+	if state != nil && state.State != pb.HAKeeperRunning {
+		if interval > bootstrapHAKeeperCheckInterval {
+			return bootstrapHAKeeperCheckInterval
+		}
+	}
+	return interval
+}
+
+func (l *store) bootstrapCheckCyclesLimit() uint64 {
+	interval := l.cfg.HAKeeperCheckInterval.Duration
+	if interval <= bootstrapHAKeeperCheckInterval {
+		return checkBootstrapCycles
+	}
+	return uint64((time.Duration(checkBootstrapCycles)*interval +
+		bootstrapHAKeeperCheckInterval - 1) / bootstrapHAKeeperCheckInterval)
+}
+
+func (l *store) hakeeperCheck() *pb.CheckerState {
 	state, term := l.getCheckerStateFromLeader()
 	if state == nil {
-		return
+		return nil
 	}
 	if state.State == pb.HAKeeperCreated {
 		l.runtime.Logger().Warn("waiting for initial cluster info to be set, check skipped")
-		return
+		return state
 	}
 
 	// Establish the replicated protocol barrier before this checker pass can
@@ -296,6 +317,7 @@ func (l *store) hakeeperCheck() {
 	default:
 		panic("unknown HAKeeper state")
 	}
+	return state
 }
 
 func (l *store) assertHAKeeperState(s pb.HAKeeperState) {
@@ -377,6 +399,13 @@ func (l *store) bootstrap(term uint64, state *pb.CheckerState) {
 	}
 	cmds, err := l.getScheduleCommand(false, term, state)
 	if err != nil {
+		if isBootstrapWaitingForLogStores(err) {
+			if time.Since(l.lastBootstrapLogTime) >= time.Second {
+				l.runtime.Logger().Info("waiting for log stores before bootstrap", zap.Error(err))
+				l.lastBootstrapLogTime = time.Now()
+			}
+			return
+		}
 		l.runtime.Logger().Error("failed to get bootstrap schedule commands", zap.Error(err))
 		return
 	}
@@ -414,10 +443,22 @@ func (l *store) bootstrap(term uint64, state *pb.CheckerState) {
 			}
 		}
 
-		l.bootstrapCheckCycles = checkBootstrapCycles
+		// Bootstrap checks run more frequently while the cluster is coming up.
+		// Keep the failure window equivalent to the configured check interval;
+		// otherwise 100 fast polls would turn the original multi-minute window
+		// into a few seconds on a slow or remote cluster.
+		l.bootstrapCheckCycles = l.bootstrapCheckCyclesLimit()
 		l.bootstrapMgr = bootstrap.NewBootstrapManager(state.ClusterInfo)
 		l.assertHAKeeperState(pb.HAKeeperBootstrapCommandsReceived)
+		if l.bootstrapCommandsAdded != nil {
+			l.bootstrapCommandsAdded()
+		}
 	}
+}
+
+func isBootstrapWaitingForLogStores(err error) bool {
+	return moerr.IsMoErrCode(err, moerr.ErrInternal) &&
+		strings.Contains(err.Error(), "not enough log stores")
 }
 
 func (l *store) checkBootstrap(state *pb.CheckerState) {

--- a/pkg/logservice/store_hakeeper_check.go
+++ b/pkg/logservice/store_hakeeper_check.go
@@ -253,6 +253,21 @@ func (l *store) getCheckerStateFromLeader() (*pb.CheckerState, uint64) {
 
 var debugPrintHAKeeperState atomic.Bool
 
+// Only reset on cadence changes. Resetting after every synchronous check adds
+// the check's execution time to the configured interval, delaying health checks
+// and repair commands on a busy HAKeeper leader.
+func (l *store) updateHAKeeperCheckTicker(
+	reset func(time.Duration),
+	current time.Duration,
+	state *pb.CheckerState,
+) time.Duration {
+	next := l.nextHAKeeperCheckInterval(state)
+	if next != current {
+		reset(next)
+	}
+	return next
+}
+
 func (l *store) nextHAKeeperCheckInterval(state *pb.CheckerState) time.Duration {
 	interval := l.cfg.HAKeeperCheckInterval.Duration
 	if interval <= 0 {

--- a/pkg/logservice/store_hakeeper_check.go
+++ b/pkg/logservice/store_hakeeper_check.go
@@ -338,9 +338,13 @@ func (l *store) hakeeperCheck() *pb.CheckerState {
 
 	switch state.State {
 	case pb.HAKeeperBootstrapping:
-		l.bootstrap(term, state)
+		if err := l.bootstrap(term, state); err != nil {
+			return nil // Retry failures at the configured cadence, not the fast bootstrap cadence.
+		}
 	case pb.HAKeeperBootstrapCommandsReceived:
-		l.checkBootstrap(state)
+		if err := l.checkBootstrap(state); err != nil {
+			return nil
+		}
 	case pb.HAKeeperBootstrapFailed:
 		l.handleBootstrapFailure()
 	case pb.HAKeeperRunning:
@@ -427,19 +431,19 @@ func (l *store) registerTaskUser() {
 	}
 }
 
-func (l *store) bootstrap(term uint64, state *pb.CheckerState) {
+func (l *store) bootstrap(term uint64, state *pb.CheckerState) error {
 	if state.LogServiceRecoveryPending && !state.LogServiceRecoveryPrepared {
 		if l.bootstrapStatusLogAllowed() {
 			l.runtime.Logger().Info("waiting for LogService recovery ID watermarks before bootstrap")
 		}
-		return
+		return nil
 	}
 	cmds, err := l.getScheduleCommand(false, term, state)
 	if err != nil {
 		if l.bootstrapStatusLogAllowed() {
 			l.runtime.Logger().Error("failed to get bootstrap schedule commands", zap.Error(err))
 		}
-		return
+		return err
 	}
 	if len(cmds) > 0 {
 		for _, c := range cmds {
@@ -486,24 +490,25 @@ func (l *store) bootstrap(term uint64, state *pb.CheckerState) {
 			l.bootstrapCommandsAdded()
 		}
 	}
+	return nil
 }
 
-func (l *store) checkBootstrap(state *pb.CheckerState) {
-	l.checkBootstrapWithSetter(state, l.setBootstrapState)
+func (l *store) checkBootstrap(state *pb.CheckerState) error {
+	return l.checkBootstrapWithSetter(state, l.setBootstrapState)
 }
 
 func (l *store) checkBootstrapWithSetter(
 	state *pb.CheckerState,
 	setState func(bool) error,
-) {
-	l.checkBootstrapWithSetterAt(time.Now(), state, setState)
+) error {
+	return l.checkBootstrapWithSetterAt(time.Now(), state, setState)
 }
 
 func (l *store) checkBootstrapWithSetterAt(
 	now time.Time,
 	state *pb.CheckerState,
 	setState func(bool) error,
-) {
+) error {
 	if l.bootstrapCheckDeadline.IsZero() {
 		// A leader can change after bootstrap commands are replicated. The new
 		// leader has no local start timestamp, so establish a bounded budget when
@@ -517,7 +522,7 @@ func (l *store) checkBootstrapWithSetterAt(
 		if !now.Before(l.bootstrapCheckDeadline) {
 			if err := setState(false); err != nil {
 				l.logSetBootstrapStateFailure(false, err)
-				return
+				return err
 			}
 			l.assertHAKeeperState(pb.HAKeeperBootstrapFailed)
 		}
@@ -529,14 +534,15 @@ func (l *store) checkBootstrapWithSetterAt(
 			if l.runtime != nil && l.bootstrapStatusLogAllowed() {
 				l.runtime.Logger().Info("bootstrap complete but WAL recovery is pending")
 			}
-			return
+			return nil
 		}
 		if err := setState(true); err != nil {
 			l.logSetBootstrapStateFailure(true, err)
-			return
+			return err
 		}
 		l.assertHAKeeperState(pb.HAKeeperRunning)
 	}
+	return nil
 }
 
 func (l *store) logSetBootstrapStateFailure(success bool, err error) {

--- a/pkg/logservice/store_hakeeper_check.go
+++ b/pkg/logservice/store_hakeeper_check.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -256,7 +255,12 @@ var debugPrintHAKeeperState atomic.Bool
 
 func (l *store) nextHAKeeperCheckInterval(state *pb.CheckerState) time.Duration {
 	interval := l.cfg.HAKeeperCheckInterval.Duration
-	if state != nil && state.State != pb.HAKeeperRunning {
+	if interval <= 0 {
+		panic("invalid HAKeeperCheckInterval")
+	}
+	if state != nil &&
+		(state.State == pb.HAKeeperBootstrapping ||
+			state.State == pb.HAKeeperBootstrapCommandsReceived) {
 		if interval > bootstrapHAKeeperCheckInterval {
 			return bootstrapHAKeeperCheckInterval
 		}
@@ -264,13 +268,29 @@ func (l *store) nextHAKeeperCheckInterval(state *pb.CheckerState) time.Duration 
 	return interval
 }
 
-func (l *store) bootstrapCheckCyclesLimit() uint64 {
+func (l *store) bootstrapCheckWindow() time.Duration {
 	interval := l.cfg.HAKeeperCheckInterval.Duration
-	if interval <= bootstrapHAKeeperCheckInterval {
-		return checkBootstrapCycles
+	if interval <= 0 {
+		panic("invalid HAKeeperCheckInterval")
 	}
-	return uint64((time.Duration(checkBootstrapCycles)*interval +
-		bootstrapHAKeeperCheckInterval - 1) / bootstrapHAKeeperCheckInterval)
+	if interval > (time.Duration(1<<63-1) / checkBootstrapCycles) {
+		panic("HAKeeperCheckInterval is too large")
+	}
+	return time.Duration(checkBootstrapCycles) * interval
+}
+
+func (l *store) startBootstrapCheckBudget() {
+	l.bootstrapCheckDeadline = time.Now().Add(l.bootstrapCheckWindow())
+}
+
+func (l *store) bootstrapStatusLogAllowed() bool {
+	now := time.Now()
+	if !l.lastBootstrapLogTime.IsZero() &&
+		now.Sub(l.lastBootstrapLogTime) < time.Second {
+		return false
+	}
+	l.lastBootstrapLogTime = now
+	return true
 }
 
 func (l *store) hakeeperCheck() *pb.CheckerState {
@@ -394,19 +414,16 @@ func (l *store) registerTaskUser() {
 
 func (l *store) bootstrap(term uint64, state *pb.CheckerState) {
 	if state.LogServiceRecoveryPending && !state.LogServiceRecoveryPrepared {
-		l.runtime.Logger().Info("waiting for LogService recovery ID watermarks before bootstrap")
+		if l.bootstrapStatusLogAllowed() {
+			l.runtime.Logger().Info("waiting for LogService recovery ID watermarks before bootstrap")
+		}
 		return
 	}
 	cmds, err := l.getScheduleCommand(false, term, state)
 	if err != nil {
-		if isBootstrapWaitingForLogStores(err) {
-			if time.Since(l.lastBootstrapLogTime) >= time.Second {
-				l.runtime.Logger().Info("waiting for log stores before bootstrap", zap.Error(err))
-				l.lastBootstrapLogTime = time.Now()
-			}
-			return
+		if l.bootstrapStatusLogAllowed() {
+			l.runtime.Logger().Error("failed to get bootstrap schedule commands", zap.Error(err))
 		}
-		l.runtime.Logger().Error("failed to get bootstrap schedule commands", zap.Error(err))
 		return
 	}
 	if len(cmds) > 0 {
@@ -444,21 +461,16 @@ func (l *store) bootstrap(term uint64, state *pb.CheckerState) {
 		}
 
 		// Bootstrap checks run more frequently while the cluster is coming up.
-		// Keep the failure window equivalent to the configured check interval;
-		// otherwise 100 fast polls would turn the original multi-minute window
-		// into a few seconds on a slow or remote cluster.
-		l.bootstrapCheckCycles = l.bootstrapCheckCyclesLimit()
+		// Keep the failure window based on elapsed time, rather than on the number
+		// of polls. Each check performs synchronous raft and checker work, so a
+		// poll-count budget would stretch when that work is slow.
+		l.startBootstrapCheckBudget()
 		l.bootstrapMgr = bootstrap.NewBootstrapManager(state.ClusterInfo)
 		l.assertHAKeeperState(pb.HAKeeperBootstrapCommandsReceived)
 		if l.bootstrapCommandsAdded != nil {
 			l.bootstrapCommandsAdded()
 		}
 	}
-}
-
-func isBootstrapWaitingForLogStores(err error) bool {
-	return moerr.IsMoErrCode(err, moerr.ErrInternal) &&
-		strings.Contains(err.Error(), "not enough log stores")
 }
 
 func (l *store) checkBootstrap(state *pb.CheckerState) {
@@ -469,26 +481,37 @@ func (l *store) checkBootstrapWithSetter(
 	state *pb.CheckerState,
 	setState func(bool) error,
 ) {
-	if l.bootstrapCheckCycles == 0 {
-		if err := setState(false); err != nil {
-			l.logSetBootstrapStateFailure(false, err)
-			return
-		}
-		l.assertHAKeeperState(pb.HAKeeperBootstrapFailed)
-		return
-	}
+	l.checkBootstrapWithSetterAt(time.Now(), state, setState)
+}
 
+func (l *store) checkBootstrapWithSetterAt(
+	now time.Time,
+	state *pb.CheckerState,
+	setState func(bool) error,
+) {
+	if l.bootstrapCheckDeadline.IsZero() {
+		// A leader can change after bootstrap commands are replicated. The new
+		// leader has no local start timestamp, so establish a bounded budget when
+		// it first observes the state instead of failing immediately.
+		l.bootstrapCheckDeadline = now.Add(l.bootstrapCheckWindow())
+	}
 	if l.bootstrapMgr == nil {
 		l.bootstrapMgr = bootstrap.NewBootstrapManager(state.ClusterInfo)
 	}
 	if !l.bootstrapMgr.CheckBootstrap(state.LogState) {
-		l.bootstrapCheckCycles--
+		if !now.Before(l.bootstrapCheckDeadline) {
+			if err := setState(false); err != nil {
+				l.logSetBootstrapStateFailure(false, err)
+				return
+			}
+			l.assertHAKeeperState(pb.HAKeeperBootstrapFailed)
+		}
 	} else {
 		// Recovery status is replicated through LogStore heartbeats. Do not use
 		// the leader process's local flag here: the recovery coordinator and the
 		// HAKeeper leader are not guaranteed to be the same LogService pod.
 		if walRecoveryPending(state) {
-			if l.runtime != nil {
+			if l.runtime != nil && l.bootstrapStatusLogAllowed() {
 				l.runtime.Logger().Info("bootstrap complete but WAL recovery is pending")
 			}
 			return

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 )
 
 func TestIDAllocatorDefaultState(t *testing.T) {
@@ -44,6 +45,37 @@ func TestIDAllocatorDefaultState(t *testing.T) {
 	v, ok := alloc.Next()
 	assert.False(t, ok)
 	assert.Equal(t, uint64(0), v)
+}
+
+func TestNextHAKeeperCheckIntervalUsesFastBootstrapInterval(t *testing.T) {
+	s := &store{
+		cfg: Config{
+			HAKeeperCheckInterval: toml.Duration{Duration: 3 * time.Second},
+		},
+	}
+
+	require.Equal(t, 3*time.Second, s.nextHAKeeperCheckInterval(nil))
+	require.Equal(t, bootstrapHAKeeperCheckInterval, s.nextHAKeeperCheckInterval(&pb.CheckerState{
+		State: pb.HAKeeperBootstrapping,
+	}))
+	require.Equal(t, bootstrapHAKeeperCheckInterval, s.nextHAKeeperCheckInterval(&pb.CheckerState{
+		State: pb.HAKeeperBootstrapCommandsReceived,
+	}))
+	require.Equal(t, 3*time.Second, s.nextHAKeeperCheckInterval(&pb.CheckerState{
+		State: pb.HAKeeperRunning,
+	}))
+}
+
+func TestBootstrapCheckCyclesLimitPreservesFailureWindow(t *testing.T) {
+	fast := &store{cfg: Config{
+		HAKeeperCheckInterval: toml.Duration{Duration: bootstrapHAKeeperCheckInterval},
+	}}
+	require.Equal(t, uint64(checkBootstrapCycles), fast.bootstrapCheckCyclesLimit())
+
+	defaultInterval := &store{cfg: Config{
+		HAKeeperCheckInterval: toml.Duration{Duration: 3 * time.Second},
+	}}
+	require.Equal(t, uint64(30*checkBootstrapCycles), defaultInterval.bootstrapCheckCyclesLimit())
 }
 
 func TestIDAllocatorCapacity(t *testing.T) {
@@ -470,7 +502,7 @@ func TestHAKeeperCanBootstrapAndRepairShards(t *testing.T) {
 		state, err = leaderStore.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
-		assert.Equal(t, uint64(checkBootstrapCycles), leaderStore.bootstrapCheckCycles)
+		assert.Equal(t, leaderStore.bootstrapCheckCyclesLimit(), leaderStore.bootstrapCheckCycles)
 		require.NotNil(t, leaderStore.bootstrapMgr)
 		assert.False(t, leaderStore.bootstrapMgr.CheckBootstrap(state.LogState))
 
@@ -948,18 +980,24 @@ func testBootstrap(t *testing.T, fail bool, remoteRecoveryPending bool) {
 
 		state, err = store.getCheckerState()
 		require.NoError(t, err)
+		bootstrapCommandsAdded := false
+		store.bootstrapCommandsAdded = func() {
+			bootstrapCommandsAdded = true
+		}
 		store.bootstrap(term, state)
 
 		state, err = store.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
-		assert.Equal(t, uint64(checkBootstrapCycles), store.bootstrapCheckCycles)
+		assert.True(t, bootstrapCommandsAdded)
+		assert.Equal(t, store.bootstrapCheckCyclesLimit(), store.bootstrapCheckCycles)
 		require.NotNil(t, store.bootstrapMgr)
 		assert.False(t, store.bootstrapMgr.CheckBootstrap(state.LogState))
 
 		if fail {
 			// keep checking, bootstrap will eventually be set as failed
-			for i := 0; i <= checkBootstrapCycles; i++ {
+			cycles := store.bootstrapCheckCycles
+			for i := uint64(0); i <= cycles; i++ {
 				store.checkBootstrap(state)
 			}
 
@@ -1072,7 +1110,7 @@ func TestTaskSchedulerCanScheduleTasksToCNs(t *testing.T) {
 		state, err = store.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
-		assert.Equal(t, uint64(checkBootstrapCycles), store.bootstrapCheckCycles)
+		assert.Equal(t, store.bootstrapCheckCyclesLimit(), store.bootstrapCheckCycles)
 		require.NotNil(t, store.bootstrapMgr)
 		assert.False(t, store.bootstrapMgr.CheckBootstrap(state.LogState))
 
@@ -1180,7 +1218,7 @@ func TestTaskSchedulerCanReScheduleExpiredTasks(t *testing.T) {
 		state, err = store.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
-		assert.Equal(t, uint64(checkBootstrapCycles), store.bootstrapCheckCycles)
+		assert.Equal(t, store.bootstrapCheckCyclesLimit(), store.bootstrapCheckCycles)
 		require.NotNil(t, store.bootstrapMgr)
 		assert.False(t, store.bootstrapMgr.CheckBootstrap(state.LogState))
 

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -70,6 +70,32 @@ func TestNextHAKeeperCheckIntervalUsesFastBootstrapInterval(t *testing.T) {
 	}))
 }
 
+func TestHAKeeperCheckTickerPreservesPeriodicSchedule(t *testing.T) {
+	s := &store{cfg: Config{
+		HAKeeperCheckInterval: toml.Duration{Duration: 3 * time.Second},
+	}}
+	interval := bootstrapHAKeeperCheckInterval
+	var resets []time.Duration
+	reset := func(next time.Duration) { resets = append(resets, next) }
+	// A ticker retains its next scheduled tick while the synchronous checker
+	// runs. A reset at check completion would discard that tick and charge the
+	// check's execution time again, even when the configured cadence is unchanged.
+	for _, tc := range []struct {
+		state *pb.CheckerState
+		want  []time.Duration
+	}{
+		{&pb.CheckerState{State: pb.HAKeeperBootstrapping}, nil},
+		{&pb.CheckerState{State: pb.HAKeeperBootstrapCommandsReceived}, nil},
+		{&pb.CheckerState{State: pb.HAKeeperRunning}, []time.Duration{3 * time.Second}},
+		{&pb.CheckerState{State: pb.HAKeeperRunning}, []time.Duration{3 * time.Second}},
+		{nil, []time.Duration{3 * time.Second}},
+		{&pb.CheckerState{State: pb.HAKeeperBootstrapping}, []time.Duration{3 * time.Second, bootstrapHAKeeperCheckInterval}},
+	} {
+		interval = s.updateHAKeeperCheckTicker(reset, interval, tc.state)
+		require.Equal(t, tc.want, resets)
+	}
+}
+
 func TestBootstrapCheckWindowUsesConfiguredInterval(t *testing.T) {
 	fast := &store{cfg: Config{
 		HAKeeperCheckInterval: toml.Duration{Duration: bootstrapHAKeeperCheckInterval},

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
+	"github.com/matrixorigin/matrixone/pkg/hakeeper/bootstrap"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper/checkers/tnservice"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
@@ -64,18 +65,136 @@ func TestNextHAKeeperCheckIntervalUsesFastBootstrapInterval(t *testing.T) {
 	require.Equal(t, 3*time.Second, s.nextHAKeeperCheckInterval(&pb.CheckerState{
 		State: pb.HAKeeperRunning,
 	}))
+	require.Equal(t, 3*time.Second, s.nextHAKeeperCheckInterval(&pb.CheckerState{
+		State: pb.HAKeeperCreated,
+	}))
 }
 
-func TestBootstrapCheckCyclesLimitPreservesFailureWindow(t *testing.T) {
+func TestBootstrapCheckWindowUsesConfiguredInterval(t *testing.T) {
 	fast := &store{cfg: Config{
 		HAKeeperCheckInterval: toml.Duration{Duration: bootstrapHAKeeperCheckInterval},
 	}}
-	require.Equal(t, uint64(checkBootstrapCycles), fast.bootstrapCheckCyclesLimit())
+	require.Equal(t, checkBootstrapCycles*bootstrapHAKeeperCheckInterval, fast.bootstrapCheckWindow())
 
 	defaultInterval := &store{cfg: Config{
 		HAKeeperCheckInterval: toml.Duration{Duration: 3 * time.Second},
 	}}
-	require.Equal(t, uint64(30*checkBootstrapCycles), defaultInterval.bootstrapCheckCyclesLimit())
+	require.Equal(t, checkBootstrapCycles*3*time.Second, defaultInterval.bootstrapCheckWindow())
+}
+
+func TestBootstrapCheckWindowRejectsInvalidInterval(t *testing.T) {
+	for _, interval := range []time.Duration{0, -time.Second, time.Duration(1<<63 - 1)} {
+		t.Run(interval.String(), func(t *testing.T) {
+			s := &store{cfg: Config{
+				HAKeeperCheckInterval: toml.Duration{Duration: interval},
+			}}
+			require.Panics(t, func() { s.bootstrapCheckWindow() })
+		})
+	}
+}
+
+func bootstrapCheckTestState(complete, recoveryPending bool) *pb.CheckerState {
+	state := &pb.CheckerState{
+		State:                     pb.HAKeeperBootstrapCommandsReceived,
+		LogServiceRecoveryPending: recoveryPending,
+		ClusterInfo: pb.ClusterInfo{
+			LogShards: []metadata.LogShardRecord{{
+				ShardID:          1,
+				NumberOfReplicas: 1,
+			}},
+		},
+	}
+	if complete {
+		state.LogState.Shards = map[uint64]pb.LogShardInfo{
+			1: {ShardID: 1, Replicas: map[uint64]string{1: "log-1", 2: "log-2"}},
+		}
+	}
+	return state
+}
+
+func TestCheckBootstrapDeadlineBoundaries(t *testing.T) {
+	start := time.Unix(100, 0)
+	deadline := start.Add(checkBootstrapCycles * 3 * time.Second)
+	for _, tc := range []struct {
+		name        string
+		now         time.Time
+		state       *pb.CheckerState
+		wantCalls   int
+		wantSuccess bool
+	}{
+		{name: "incomplete before deadline", now: deadline.Add(-time.Nanosecond), state: bootstrapCheckTestState(false, false)},
+		{name: "incomplete at deadline", now: deadline, state: bootstrapCheckTestState(false, false), wantCalls: 1},
+		{name: "incomplete after deadline", now: deadline.Add(time.Nanosecond), state: bootstrapCheckTestState(false, false), wantCalls: 1},
+		{name: "complete at deadline", now: deadline, state: bootstrapCheckTestState(true, false), wantCalls: 1, wantSuccess: true},
+		{name: "recovery pending after deadline", now: deadline.Add(time.Second), state: bootstrapCheckTestState(true, true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &store{
+				cfg:                    Config{HAKeeperCheckInterval: toml.Duration{Duration: 3 * time.Second}},
+				bootstrapMgr:           bootstrap.NewBootstrapManager(tc.state.ClusterInfo),
+				bootstrapCheckDeadline: deadline,
+			}
+			var calls []bool
+			s.checkBootstrapWithSetterAt(tc.now, tc.state, func(success bool) error {
+				calls = append(calls, success)
+				return moerr.NewInternalErrorNoCtx("stop after deadline assertion")
+			})
+			require.Len(t, calls, tc.wantCalls)
+			if tc.wantCalls > 0 {
+				require.Equal(t, tc.wantSuccess, calls[0])
+			}
+		})
+	}
+}
+
+func TestCheckBootstrapDeadlineIncludesSlowCheckCost(t *testing.T) {
+	start := time.Unix(100, 0)
+	deadline := start.Add(checkBootstrapCycles * 3 * time.Second)
+	for _, checkCost := range []time.Duration{0, 200 * time.Millisecond} {
+		t.Run(checkCost.String(), func(t *testing.T) {
+			state := bootstrapCheckTestState(false, false)
+			s := &store{
+				cfg:                    Config{HAKeeperCheckInterval: toml.Duration{Duration: 3 * time.Second}},
+				bootstrapMgr:           bootstrap.NewBootstrapManager(state.ClusterInfo),
+				bootstrapCheckDeadline: deadline,
+			}
+			var calls []bool
+			setter := func(success bool) error {
+				calls = append(calls, success)
+				return moerr.NewInternalErrorNoCtx("stop after deadline assertion")
+			}
+			// The first check starts before the deadline. Its synchronous cost is
+			// then charged to the same absolute deadline instead of extending it.
+			if checkCost > 0 {
+				s.checkBootstrapWithSetterAt(deadline.Add(-checkCost), state, setter)
+				require.Empty(t, calls)
+			}
+			s.checkBootstrapWithSetterAt(deadline, state, setter)
+			require.Equal(t, []bool{false}, calls)
+		})
+	}
+}
+
+func TestCheckBootstrapLeaderTakeoverInitializesDeadlineOnce(t *testing.T) {
+	start := time.Unix(100, 0)
+	state := bootstrapCheckTestState(false, false)
+	s := &store{
+		cfg:          Config{HAKeeperCheckInterval: toml.Duration{Duration: 3 * time.Second}},
+		bootstrapMgr: bootstrap.NewBootstrapManager(state.ClusterInfo),
+	}
+	var calls []bool
+	setter := func(success bool) error {
+		calls = append(calls, success)
+		return moerr.NewInternalErrorNoCtx("stop after deadline assertion")
+	}
+	s.checkBootstrapWithSetterAt(start, state, setter)
+	wantDeadline := start.Add(checkBootstrapCycles * 3 * time.Second)
+	require.Equal(t, wantDeadline, s.bootstrapCheckDeadline)
+	s.checkBootstrapWithSetterAt(start.Add(time.Second), state, setter)
+	require.Empty(t, calls)
+	require.Equal(t, wantDeadline, s.bootstrapCheckDeadline)
+	s.checkBootstrapWithSetterAt(wantDeadline, state, setter)
+	require.Equal(t, []bool{false}, calls)
 }
 
 func TestIDAllocatorCapacity(t *testing.T) {
@@ -177,7 +296,10 @@ func TestHandleBootstrapFailure(t *testing.T) {
 }
 
 func TestCheckBootstrapRetriesSetBootstrapStateFailure(t *testing.T) {
-	s := &store{bootstrapCheckCycles: checkBootstrapCycles}
+	s := &store{cfg: Config{
+		HAKeeperCheckInterval: toml.Duration{Duration: time.Second},
+	}}
+	s.startBootstrapCheckBudget()
 	state := &pb.CheckerState{
 		State: pb.HAKeeperBootstrapCommandsReceived,
 		ClusterInfo: pb.ClusterInfo{
@@ -197,6 +319,7 @@ func TestCheckBootstrapRetriesSetBootstrapStateFailure(t *testing.T) {
 	}
 
 	calls := 0
+	deadline := s.bootstrapCheckDeadline
 	s.checkBootstrapWithSetter(state, func(success bool) error {
 		calls++
 		require.True(t, success)
@@ -204,11 +327,21 @@ func TestCheckBootstrapRetriesSetBootstrapStateFailure(t *testing.T) {
 	})
 
 	require.Equal(t, 1, calls)
-	require.Equal(t, uint64(checkBootstrapCycles), s.bootstrapCheckCycles)
+	require.Equal(t, deadline, s.bootstrapCheckDeadline)
+	s.checkBootstrapWithSetter(state, func(success bool) error {
+		calls++
+		require.True(t, success)
+		return moerr.NewInternalErrorNoCtx("injected bootstrap state timeout")
+	})
+	require.Equal(t, 2, calls)
+	require.Equal(t, deadline, s.bootstrapCheckDeadline)
 }
 
 func TestCheckBootstrapWaitsForReplicatedLogServiceRecovery(t *testing.T) {
-	s := &store{bootstrapCheckCycles: checkBootstrapCycles}
+	s := &store{cfg: Config{
+		HAKeeperCheckInterval: toml.Duration{Duration: time.Second},
+	}}
+	s.startBootstrapCheckBudget()
 	state := &pb.CheckerState{
 		State:                     pb.HAKeeperBootstrapCommandsReceived,
 		LogServiceRecoveryPending: true,
@@ -234,7 +367,7 @@ func TestCheckBootstrapWaitsForReplicatedLogServiceRecovery(t *testing.T) {
 		return nil
 	})
 	require.Equal(t, 0, calls)
-	require.Equal(t, uint64(checkBootstrapCycles), s.bootstrapCheckCycles)
+	require.False(t, s.bootstrapCheckDeadline.IsZero())
 }
 
 func runHAKeeperStoreTest(t *testing.T, startLogReplica bool, fn func(*testing.T, *store)) {
@@ -502,7 +635,7 @@ func TestHAKeeperCanBootstrapAndRepairShards(t *testing.T) {
 		state, err = leaderStore.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
-		assert.Equal(t, leaderStore.bootstrapCheckCyclesLimit(), leaderStore.bootstrapCheckCycles)
+		assert.False(t, leaderStore.bootstrapCheckDeadline.IsZero())
 		require.NotNil(t, leaderStore.bootstrapMgr)
 		assert.False(t, leaderStore.bootstrapMgr.CheckBootstrap(state.LogState))
 
@@ -990,16 +1123,15 @@ func testBootstrap(t *testing.T, fail bool, remoteRecoveryPending bool) {
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
 		assert.True(t, bootstrapCommandsAdded)
-		assert.Equal(t, store.bootstrapCheckCyclesLimit(), store.bootstrapCheckCycles)
+		assert.False(t, store.bootstrapCheckDeadline.IsZero())
 		require.NotNil(t, store.bootstrapMgr)
 		assert.False(t, store.bootstrapMgr.CheckBootstrap(state.LogState))
 
 		if fail {
-			// keep checking, bootstrap will eventually be set as failed
-			cycles := store.bootstrapCheckCycles
-			for i := uint64(0); i <= cycles; i++ {
-				store.checkBootstrap(state)
-			}
+			// Move the deadline into the past so this test does not spend the
+			// real multi-minute bootstrap budget.
+			store.bootstrapCheckDeadline = time.Now().Add(-time.Second)
+			store.checkBootstrap(state)
 
 			state, err = store.getCheckerState()
 			require.NoError(t, err)
@@ -1110,7 +1242,7 @@ func TestTaskSchedulerCanScheduleTasksToCNs(t *testing.T) {
 		state, err = store.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
-		assert.Equal(t, store.bootstrapCheckCyclesLimit(), store.bootstrapCheckCycles)
+		assert.False(t, store.bootstrapCheckDeadline.IsZero())
 		require.NotNil(t, store.bootstrapMgr)
 		assert.False(t, store.bootstrapMgr.CheckBootstrap(state.LogState))
 
@@ -1218,7 +1350,7 @@ func TestTaskSchedulerCanReScheduleExpiredTasks(t *testing.T) {
 		state, err = store.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
-		assert.Equal(t, store.bootstrapCheckCyclesLimit(), store.bootstrapCheckCycles)
+		assert.False(t, store.bootstrapCheckDeadline.IsZero())
 		require.NotNil(t, store.bootstrapMgr)
 		assert.False(t, store.bootstrapMgr.CheckBootstrap(state.LogState))
 

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -161,13 +161,17 @@ func TestCheckBootstrapDeadlineBoundaries(t *testing.T) {
 				bootstrapCheckDeadline: deadline,
 			}
 			var calls []bool
-			s.checkBootstrapWithSetterAt(tc.now, tc.state, func(success bool) error {
+			injected := moerr.NewInternalErrorNoCtx("stop after deadline assertion")
+			err := s.checkBootstrapWithSetterAt(tc.now, tc.state, func(success bool) error {
 				calls = append(calls, success)
-				return moerr.NewInternalErrorNoCtx("stop after deadline assertion")
+				return injected
 			})
 			require.Len(t, calls, tc.wantCalls)
 			if tc.wantCalls > 0 {
+				require.ErrorIs(t, err, injected)
 				require.Equal(t, tc.wantSuccess, calls[0])
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -346,19 +350,21 @@ func TestCheckBootstrapRetriesSetBootstrapStateFailure(t *testing.T) {
 
 	calls := 0
 	deadline := s.bootstrapCheckDeadline
-	s.checkBootstrapWithSetter(state, func(success bool) error {
+	err := s.checkBootstrapWithSetter(state, func(success bool) error {
 		calls++
 		require.True(t, success)
 		return moerr.NewInternalErrorNoCtx("injected bootstrap state timeout")
 	})
+	require.Error(t, err)
 
 	require.Equal(t, 1, calls)
 	require.Equal(t, deadline, s.bootstrapCheckDeadline)
-	s.checkBootstrapWithSetter(state, func(success bool) error {
+	err = s.checkBootstrapWithSetter(state, func(success bool) error {
 		calls++
 		require.True(t, success)
 		return moerr.NewInternalErrorNoCtx("injected bootstrap state timeout")
 	})
+	require.Error(t, err)
 	require.Equal(t, 2, calls)
 	require.Equal(t, deadline, s.bootstrapCheckDeadline)
 }
@@ -1000,6 +1006,29 @@ func TestCNAllocateIDRejectsUninitializedHAKeeper(t *testing.T) {
 		require.ErrorContains(t, err, "not ready for ID allocation")
 	}
 	runHAKeeperStoreTest(t, false, fn)
+}
+
+func TestHAKeeperBootstrapErrorUsesConfiguredCadence(t *testing.T) {
+	runHAKeeperStoreTest(t, false, func(t *testing.T, s *store) {
+		require.NoError(t, s.setInitialClusterInfo(1, 1, 1, hakeeper.K8SIDRangeEnd+10, nil, nil))
+		// No LogStore heartbeat: bootstrap cannot place its replica yet. Exercise
+		// the real checker result consumed by the ticker, not a synthetic nil.
+		state := s.hakeeperCheck()
+		require.Nil(t, state)
+		require.Equal(t, s.cfg.HAKeeperCheckInterval.Duration, s.nextHAKeeperCheckInterval(state))
+
+		ctx, cancel := context.WithTimeout(context.Background(), testIOTimeout)
+		defer cancel()
+		_, err := s.addLogStoreHeartbeat(ctx, s.getHeartbeatMessage())
+		require.NoError(t, err)
+		state = s.hakeeperCheck()
+		require.NotNil(t, state)
+		require.Equal(t, pb.HAKeeperBootstrapping, state.State)
+		require.Equal(t, bootstrapHAKeeperCheckInterval, s.nextHAKeeperCheckInterval(state))
+		actual, err := s.getCheckerState()
+		require.NoError(t, err)
+		require.Equal(t, pb.HAKeeperBootstrapCommandsReceived, actual.State)
+	})
 }
 
 func TestFailedBootstrap(t *testing.T) {

--- a/pkg/logservice/store_test.go
+++ b/pkg/logservice/store_test.go
@@ -1298,6 +1298,55 @@ func TestRequiredLsn(t *testing.T) {
 	runStoreTest(t, fn)
 }
 
+func TestWaitHAKeeperLeaderReady(t *testing.T) {
+	runStoreTest(t, func(t *testing.T, store *store) {
+		// runStoreTest closes the real NodeHost before test cleanups run.
+		t.Cleanup(func() {
+			ready, err := store.waitHAKeeperLeaderReady(context.Background(), 0)
+			require.ErrorIs(t, err, dragonboat.ErrClosed)
+			require.False(t, ready)
+		})
+		// A missing local shard is an error, not an election to wait for.
+		ready, err := store.waitHAKeeperLeaderReady(context.Background(), 0)
+		require.ErrorIs(t, err, dragonboat.ErrShardNotFound)
+		require.False(t, ready)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		ready, err = store.waitHAKeeperLeaderReady(ctx, 0)
+		require.ErrorIs(t, err, context.Canceled)
+		require.False(t, ready)
+
+		peers := map[uint64]dragonboat.Target{1: store.id()}
+		require.NoError(t, store.startHAKeeperReplica(1, peers, false))
+		ctx, cancel = context.WithTimeout(context.Background(), testIOTimeout)
+		defer cancel()
+		ready, err = store.waitHAKeeperLeaderReady(ctx, testIOTimeout)
+		require.NoError(t, err)
+		require.True(t, ready)
+		// Once elected, a zero wait budget still observes the ready leader.
+		ready, err = store.waitHAKeeperLeaderReady(ctx, 0)
+		require.NoError(t, err)
+		require.True(t, ready)
+	})
+}
+
+func TestWaitHAKeeperLeaderReadyWithoutQuorum(t *testing.T) {
+	runStoreTest(t, func(t *testing.T, s *store) {
+		// Only one of three members runs: no scheduling timing can elect it.
+		peers := map[uint64]dragonboat.Target{1: s.id(), 2: uuid.NewString(), 3: uuid.NewString()}
+		require.NoError(t, s.startHAKeeperReplica(1, peers, false))
+		ready, err := s.waitHAKeeperLeaderReady(context.Background(), time.Millisecond)
+		require.NoError(t, err)
+		require.False(t, ready)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		ready, err = s.waitHAKeeperLeaderReady(ctx, testIOTimeout)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.False(t, ready)
+	})
+}
+
 func TestGetLeaderID(t *testing.T) {
 	fn := func(t *testing.T, store *store) {
 		ctx, cancel := context.WithTimeout(context.Background(), testIOTimeout)

--- a/pkg/logservice/store_test.go
+++ b/pkg/logservice/store_test.go
@@ -475,7 +475,8 @@ func proceedHAKeeperToRunning(t *testing.T, store *store) {
 	service := &Service{store: store}
 	service.handleStartReplica(cmd.Commands[0])
 
-	for state.State != pb.HAKeeperRunning && store.bootstrapCheckCycles > 0 {
+	deadline := time.Now().Add(10 * time.Second)
+	for state.State != pb.HAKeeperRunning && time.Now().Before(deadline) {
 		func() {
 			ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 			defer cancel()

--- a/pkg/tests/service/logservice.go
+++ b/pkg/tests/service/logservice.go
@@ -15,6 +15,7 @@
 package service
 
 import (
+	"context"
 	"path/filepath"
 	"sync"
 
@@ -226,7 +227,7 @@ func (c *testCluster) startHAKeeperReplica() error {
 }
 
 // setInitialClusterInfo initializes cluster information.
-func (c *testCluster) setInitialClusterInfo() error {
+func (c *testCluster) setInitialClusterInfo(ctx context.Context) error {
 	errChan := make(chan error, 1)
 
 	initialize := func() {
@@ -240,7 +241,8 @@ func (c *testCluster) setInitialClusterInfo() error {
 
 		c.logger.Info("initialize cluster information")
 
-		err = selected[0].SetInitialClusterInfo(
+		leader := c.WaitHAKeeperLeader(ctx)
+		err = leader.SetInitialClusterInfo(
 			c.opt.initial.logShardNum,
 			c.opt.initial.tnShardNum,
 			c.opt.initial.logReplicaNum,

--- a/pkg/tests/service/logservice.go
+++ b/pkg/tests/service/logservice.go
@@ -228,36 +228,26 @@ func (c *testCluster) startHAKeeperReplica() error {
 
 // setInitialClusterInfo initializes cluster information.
 func (c *testCluster) setInitialClusterInfo(ctx context.Context) error {
-	errChan := make(chan error, 1)
-
-	initialize := func() {
-		var err error
-		defer func() {
-			errChan <- err
-		}()
-
+	c.log.once.Do(func() {
 		selected := c.selectHAkeeperServices()
 		assert.NotZero(c.t, len(selected))
 
 		c.logger.Info("initialize cluster information")
 
 		leader := c.WaitHAKeeperLeader(ctx)
-		err = leader.SetInitialClusterInfo(
+		c.log.initialClusterInfoErr = leader.SetInitialClusterInfo(
 			c.opt.initial.logShardNum,
 			c.opt.initial.tnShardNum,
 			c.opt.initial.logReplicaNum,
 		)
-		if err != nil {
-			c.logger.Error("fail to initialize cluster", zap.Error(err))
+		if c.log.initialClusterInfoErr != nil {
+			c.logger.Error("fail to initialize cluster", zap.Error(c.log.initialClusterInfoErr))
 			return
 		}
 
 		c.logger.Info("cluster information initialized")
-	}
-
-	// initialize cluster only once
-	c.log.once.Do(initialize)
-	return <-errChan
+	})
+	return c.log.initialClusterInfoErr
 }
 
 // listHAKeeperService lists all log services that start hakeeper.

--- a/pkg/tests/service/service.go
+++ b/pkg/tests/service/service.go
@@ -257,7 +257,8 @@ type testCluster struct {
 	}
 
 	log struct {
-		once sync.Once
+		once                  sync.Once
+		initialClusterInfoErr error
 
 		sync.Mutex
 		cfgs []logservice.Config
@@ -644,7 +645,12 @@ func (c *testCluster) IsClusterHealthy() bool {
 // The following are implements for interface `ClusterWaitState`.
 // --------------------------------------------------------------
 func (c *testCluster) WaitHAKeeperLeader(ctx context.Context) LogService {
+	ticker := time.NewTicker(defaultWaitInterval)
+	defer ticker.Stop()
 	for {
+		if leader := c.getHAKeeperLeader(); leader != nil {
+			return leader
+		}
 		select {
 		case <-ctx.Done():
 			assert.FailNow(
@@ -652,13 +658,7 @@ func (c *testCluster) WaitHAKeeperLeader(ctx context.Context) LogService {
 				"terminated when waiting for hakeeper leader",
 				"error: %s cause: %s ", ctx.Err(), context.Cause(ctx),
 			)
-		default:
-			time.Sleep(defaultWaitInterval)
-
-			leader := c.getHAKeeperLeader()
-			if leader != nil {
-				return leader
-			}
+		case <-ticker.C:
 		}
 	}
 }

--- a/pkg/tests/service/service.go
+++ b/pkg/tests/service/service.go
@@ -1510,7 +1510,7 @@ func (c *testCluster) startLogServices(ctx context.Context) error {
 	}
 
 	// initialize cluster information
-	if err := c.setInitialClusterInfo(); err != nil {
+	if err := c.setInitialClusterInfo(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/tests/service/service_test.go
+++ b/pkg/tests/service/service_test.go
@@ -17,7 +17,9 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/lni/dragonboat/v4"
 	"github.com/lni/goutils/leaktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	logpb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"github.com/matrixorigin/matrixone/pkg/taskservice"
 )
 
 const (
@@ -44,6 +47,63 @@ func TestClusterAdmissionCoversServiceClusterLifecycle(t *testing.T) {
 	c.mu.running = true
 	require.NoError(t, c.Close())
 	require.Nil(t, c.mu.admission)
+}
+
+func TestSetInitialClusterInfoUsesHAKeeperLeader(t *testing.T) {
+	follower := &initialClusterInfoLogService{id: "follower"}
+	leader := &initialClusterInfoLogService{id: "leader", leader: true}
+	c := &testCluster{
+		t:      t,
+		logger: zap.NewNop(),
+	}
+	c.opt.initial.logServiceNum = 2
+	c.opt.initial.logShardNum = 3
+	c.opt.initial.tnShardNum = 4
+	c.opt.initial.logReplicaNum = 5
+	c.log.svcs = []LogService{follower, leader}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, c.setInitialClusterInfo(ctx))
+
+	require.Equal(t, 0, follower.initialClusterInfoCalls)
+	require.Equal(t, 1, leader.initialClusterInfoCalls)
+	require.Equal(t, [3]uint64{3, 4, 5}, leader.initialClusterInfoArgs)
+}
+
+type initialClusterInfoLogService struct {
+	id                      string
+	leader                  bool
+	initialClusterInfoCalls int
+	initialClusterInfoArgs  [3]uint64
+}
+
+func (s *initialClusterInfoLogService) Start() error { return nil }
+func (s *initialClusterInfoLogService) Close() error { return nil }
+func (s *initialClusterInfoLogService) Status() ServiceStatus {
+	return ServiceStarted
+}
+func (s *initialClusterInfoLogService) ID() string { return s.id }
+func (s *initialClusterInfoLogService) IsLeaderHakeeper() (bool, error) {
+	return s.leader, nil
+}
+func (s *initialClusterInfoLogService) GetClusterState() (*logpb.CheckerState, error) {
+	return nil, nil
+}
+func (s *initialClusterInfoLogService) SetInitialClusterInfo(
+	numOfLogShards, numOfTNShards, numOfLogReplicas uint64,
+) error {
+	s.initialClusterInfoCalls++
+	s.initialClusterInfoArgs = [3]uint64{numOfLogShards, numOfTNShards, numOfLogReplicas}
+	return nil
+}
+func (s *initialClusterInfoLogService) StartHAKeeperReplica(
+	replicaID uint64, initialReplicas map[uint64]dragonboat.Target, join bool,
+) error {
+	return nil
+}
+func (s *initialClusterInfoLogService) GetTaskService() (taskservice.TaskService, bool) {
+	return nil, false
 }
 
 func TestClusterStart(t *testing.T) {

--- a/pkg/tests/service/service_test.go
+++ b/pkg/tests/service/service_test.go
@@ -65,6 +65,7 @@ func TestSetInitialClusterInfoUsesHAKeeperLeader(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	require.NoError(t, c.setInitialClusterInfo(ctx))
+	require.NoError(t, c.setInitialClusterInfo(ctx))
 
 	require.Equal(t, 0, follower.initialClusterInfoCalls)
 	require.Equal(t, 1, leader.initialClusterInfoCalls)


### PR DESCRIPTION
## Summary

- Poll HAKeeper bootstrap states at 100ms while retaining the configured elapsed-time bootstrap check budget.
- Trigger a coalesced immediate heartbeat after initial cluster information and bootstrap commands are accepted.
- Select the elected HAKeeper leader in embedded tests before proposing initial cluster information.
- Preserve periodic ticker scheduling: reset only when the cadence changes, not after every synchronous check.
- Return bootstrap scheduling/state-transition errors to the ticker owner so failed checks use the configured interval. Healthy bootstrap polling remains fast.
- Distinguish an election in progress from an absent shard or closed NodeHost; honor cancellation and surface terminal errors promptly. Ordinary bootstrap retains its existing cancellation/removed-shard policy; restore continues to return failures.

## Motivation and performance scope

Recent race UT runs start about 30 embedded clusters; the embedded service-start phase was reported to account for about 9 minutes of aggregate time. The previous 1–3s HAKeeper/heartbeat cadence leaves avoidable startup gaps. This change removes those gaps without increasing runner parallelism or weakening assertions.

No new goroutine, unbounded queue, wire format, or configuration is introduced. The heartbeat notification is capacity-one/nonblocking. Running-state checks keep their configured periodic schedule. Bootstrap errors fall back to that schedule instead of repeatedly issuing work and error logs at 100ms. A configured interval below 100ms remains the operator's choice.

An end-to-end CI wall-time speedup has **not** been established by a controlled A/B measurement; the targeted test times below are validation costs, not a speedup claim.

## Timeout semantics and accepted boundaries

The deadline is local to a store, not a replicated cluster-wide deadline. A new leader with no local timestamp initializes its own budget once; repeated checks do not renew it. Leadership changes can therefore extend the overall cluster bootstrap duration. This PR does not add a new replicated timeout protocol.

Once shard bootstrap is complete, pending WAL recovery continues to gate Running without consuming the incomplete-shard timeout, preserving existing recovery behavior. Existing command-proposal retry policies remain unchanged.

## Latest follow-up validation (macOS)

- Focused leader readiness/cancellation and bootstrap boundary tests: PASS (0.740s).
- Final focused race suite: PASS (34.261s), including real NodeHost missing/closed/no-quorum cases, election success, timeout/cancellation, real checker failure-to-success cadence recovery, bootstrap deadline/error propagation, ordinary bootstrap, and HAKeeper/WAL restore. No race reported.
- `GOWORK=off golangci-lint run ./pkg/logservice/...`: **0 issues** on final code.
- `git diff --check`: PASS.
- Full logservice package diagnostic at preceding head `9cd8e8d1de`: failed only in `TestGossipInSimulatedCluster` at `service_test.go:1265` (leader/gossip readiness assertion). The exact PR base `53c2aa274e1d7b7b9d073a7a9f1a2879655c224b` reproduces the same assertion with the same Go test mode (52.247s). This is a baseline failure, not a green full-suite claim or proof that the failure is probabilistic.
- Local tests above used `GOWORK=off go test -mod=readonly` (plus `-race` where stated). The controlled native wrapper rejected this worktree because `cgo/libmo.dylib` is absent and primary-worktree native inputs differ; no native provenance checks were bypassed or artifacts copied. These runs do **not** claim a fresh controlled-CGo full-suite pass. Final Linux CI remains required.

Earlier author validation reported a full CGo logservice PASS (120.587s), targeted CGo race PASS, and build/vet for embed/logservice/tests-service. Those are historical results, not measurements of this final follow-up.
