### PR TITLE
test: reuse single-CN fixtures in executor and upgrade tests

### DIFF
--- a/pkg/tests/txnexecutor/txn_executor_test.go
+++ b/pkg/tests/txnexecutor/txn_executor_test.go
@@ -26,27 +26,24 @@ import (
 )
 
 func Test_TxnExecutorExec(t *testing.T) {
-	c, err := embed.StartTestCluster(embed.WithCNCount(1))
-	if c != nil {
-		t.Cleanup(func() { require.NoError(t, c.Close()) })
-	}
-	require.NoError(t, err)
-
-	svc, err := c.GetCNService(0)
-	require.NoError(t, err)
-
-	exec := testutils.GetSQLExecutor(svc)
-	require.NotNil(t, exec)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
-	defer cancel()
-
-	err = exec.ExecTxn(ctx, func(txn executor.TxnExecutor) error {
-		_, err = txn.Exec("select count(*) from mo_catalog.mo_tables", executor.StatementOption{}.WithAccountID(1).WithUserID(2).WithRoleID(2))
+	// Reuse the single-CN fixture used by TestPreparedParams; this case only reads the catalog.
+	embed.RunSingleCNBaseClusterTests(t, func(c embed.Cluster) {
+		svc, err := c.GetCNService(0)
 		require.NoError(t, err)
-		return nil
-	}, executor.Options{}.WithWaitCommittedLogApplied())
-	require.NoError(t, err)
+
+		exec := testutils.GetSQLExecutor(svc)
+		require.NotNil(t, exec)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+		defer cancel()
+
+		err = exec.ExecTxn(ctx, func(txn executor.TxnExecutor) error {
+			_, err = txn.Exec("select count(*) from mo_catalog.mo_tables", executor.StatementOption{}.WithAccountID(1).WithUserID(2).WithRoleID(2))
+			require.NoError(t, err)
+			return nil
+		}, executor.Options{}.WithWaitCommittedLogApplied())
+		require.NoError(t, err)
+	})
 }
 
 func TestPreparedParams(t *testing.T) {

--- a/pkg/tests/upgrade/upgrade_v1_2_3_test.go
+++ b/pkg/tests/upgrade/upgrade_v1_2_3_test.go
@@ -27,29 +27,26 @@ import (
 )
 
 func Test_UpgradeEntry(t *testing.T) {
-	c, err := embed.StartTestCluster(embed.WithCNCount(1))
-	if c != nil {
-		t.Cleanup(func() { require.NoError(t, c.Close()) })
-	}
-	require.NoError(t, err)
-
-	svc, err := c.GetCNService(0)
-	require.NoError(t, err)
-
-	exec := testutils.GetSQLExecutor(svc)
-	require.NotNil(t, exec)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
-	defer cancel()
-
-	err = exec.ExecTxn(ctx, func(txn executor.TxnExecutor) error {
-		err = v1_2_3.Handler.HandleClusterUpgrade(ctx, txn)
+	// These handlers run against the current catalog and need no separate legacy cluster.
+	embed.RunSingleCNBaseClusterTests(t, func(c embed.Cluster) {
+		svc, err := c.GetCNService(0)
 		require.NoError(t, err)
 
-		err = v1_2_3.Handler.HandleTenantUpgrade(ctx, 0, txn)
-		require.NoError(t, err)
+		exec := testutils.GetSQLExecutor(svc)
+		require.NotNil(t, exec)
 
-		return nil
-	}, executor.Options{}.WithWaitCommittedLogApplied())
-	require.NoError(t, err)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+		defer cancel()
+
+		err = exec.ExecTxn(ctx, func(txn executor.TxnExecutor) error {
+			err = v1_2_3.Handler.HandleClusterUpgrade(ctx, txn)
+			require.NoError(t, err)
+
+			err = v1_2_3.Handler.HandleTenantUpgrade(ctx, 0, txn)
+			require.NoError(t, err)
+
+			return nil
+		}, executor.Options{}.WithWaitCommittedLogApplied())
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
`Test_TxnExecutorExec` and `Test_UpgradeEntry` each start a dedicated single-CN cluster even though their packages already use a shared single-CN fixture. Reuse `RunSingleCNBaseClusterTests` for both cases, removing two cluster startups during a full run of these packages and avoiding a second active cluster when tests run in a different order.

The executor case only reads the catalog. The upgrade case invokes the 1.2.3 handlers against the current catalog; it does not set up a legacy cluster. Existing assertions and transaction options are retained. The shared helper also supplies the existing test startup tuning and readiness checks.

Validation: formatted with gofmt and passed `git diff --check`. Local UT execution was not performed as requested. Runtime compatibility and timing savings still need CI validation. No sharding, parallelism, or timeout changes.
