### PR TITLE
test(cdc): synchronize cross-CN watermark race fixture

### DIFF
--- a/pkg/tests/issues/cdc_txn_race_test.go
+++ b/pkg/tests/issues/cdc_txn_race_test.go
@@ -188,6 +188,21 @@ func TestCDCRaceTxn(t *testing.T) {
 }
 
 func TestCDCWaiterProbe(t *testing.T) {
+	t.Run("terminal probe errors return immediately", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		probeErr := errors.New("contender completed before lock wait")
+		calls := 0
+
+		observedTxnIDs, err := waitForCDCWaiter(ctx, func(context.Context) (bool, []string, error) {
+			calls++
+			return false, nil, &cdcWaiterTerminalError{cause: probeErr}
+		})
+		require.ErrorIs(t, err, probeErr)
+		require.Empty(t, observedTxnIDs)
+		require.Equal(t, 1, calls)
+	})
+
 	t.Run("requires the contender transaction", func(t *testing.T) {
 		found, observedTxnIDs := cdcWaiterMatches([]lockpb.WaitTxn{
 			{TxnID: []byte("unrelated")},

--- a/pkg/tests/issues/issue_27666_test.go
+++ b/pkg/tests/issues/issue_27666_test.go
@@ -18,11 +18,13 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/cdc"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
@@ -49,6 +51,7 @@ func TestIssue27666CDCWatermarkWriteSerializesWithDrop(t *testing.T) {
 			return db
 		}
 		queryDB := openDB(cn0.GetServiceConfig().CN.Frontend.Port)
+		writerDB := openDB(cn1.GetServiceConfig().CN.Frontend.Port)
 		dropExec := testutils.GetSQLExecutor(cn0)
 		writerExec := testutils.GetSQLExecutor(cn1)
 		dropLockService := lockservice.GetLockServiceByServiceID(cn0.ServiceID())
@@ -60,18 +63,27 @@ func TestIssue27666CDCWatermarkWriteSerializesWithDrop(t *testing.T) {
 			taskName    string
 			writerFirst bool
 		}{
-			{name: "drop wins", taskID: "27666000-0000-0000-0000-000000000001", taskName: "issue-27666-drop-first"},
-			{name: "writer wins", taskID: "27666000-0000-0000-0000-000000000002", taskName: "issue-27666-writer-first", writerFirst: true},
+			{name: "drop wins", taskID: uuid.NewString(), taskName: "issue-27666-drop-first"},
+			{name: "writer wins", taskID: uuid.NewString(), taskName: "issue-27666-writer-first", writerFirst: true},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				cleanupCDCFixture(t, ctx, dropExec, tc.taskID)
 				// Transaction cleanups registered below run first, including on FailNow.
 				t.Cleanup(func() { cleanupCDCFixture(t, context.Background(), dropExec, tc.taskID) })
 				require.NoError(t, execInternalSQL(ctx, dropExec, fmt.Sprintf(
 					"insert into mo_catalog.mo_cdc_task (account_id, task_id, task_name, source_uri, sink_uri, tables, task_create_time, state) "+
 						"values (0, '%s', '%s', 'source', 'sink', 'db.table', now(), 'running')",
 					tc.taskID, tc.taskName)))
+				// The fixture commit is acknowledged by CN0 before its logtail is
+				// necessarily applied on CN1. Both race arms use CN1, and the guarded
+				// watermark INSERT legitimately returns zero without requesting a lock
+				// if the task row is not visible there yet. Advance CN1's read frontier
+				// to the fixture row before asserting lock serialization.
+				visibilityCtx, visibilityCancel := context.WithTimeout(ctx, 30*time.Second)
+				defer visibilityCancel()
+				require.NoError(t, waitForCDCFixtureVisibility(
+					visibilityCtx, writerDB, tc.taskID, cn1.ServiceID(),
+				), "task fixture did not become visible on the writer CN")
 
 				writerSQL := cdc.CDCSQLBuilder.GuardedWatermarkInsertSQL(
 					fmt.Sprintf(
@@ -98,6 +110,42 @@ func TestIssue27666CDCWatermarkWriteSerializesWithDrop(t *testing.T) {
 			})
 		}
 	})
+}
+
+// waitForCDCFixtureVisibility waits for the committed task row to reach the
+// CN that executes the guarded write. The insert's commit acknowledgement only
+// covers the origin CN; a cross-CN logtail frontier is a separate transition.
+// Returning the last count/error keeps a visibility failure distinguishable
+// from a lock-service observation failure.
+func waitForCDCFixtureVisibility(ctx context.Context, db *sql.DB, taskID, cnServiceID string) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	var (
+		lastCount int
+		lastErr   error
+	)
+	for {
+		lastCount = 0
+		lastErr = db.QueryRowContext(ctx,
+			"select count(*) from mo_catalog.mo_cdc_task where account_id = 0 and task_id = ?",
+			taskID,
+		).Scan(&lastCount)
+		if lastErr == nil && lastCount == 1 {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("task %q did not become visible on CN %q: %w; last count=%d; last visibility probe error: %v",
+					taskID, cnServiceID, ctx.Err(), lastCount, lastErr)
+			}
+			return fmt.Errorf("task %q did not become visible on CN %q: %w; last count=%d",
+				taskID, cnServiceID, ctx.Err(), lastCount)
+		case <-ticker.C:
+		}
+	}
 }
 
 func testCDCWatermarkDropRace(
@@ -130,6 +178,20 @@ func testCDCWatermarkDropRace(
 	probeCtx, cancelProbe := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelProbe()
 	observedWaiterTxnIDs, err := waitForCDCWaiter(probeCtx, func(probeCtx context.Context) (bool, []string, error) {
+		select {
+		case <-contender.done:
+			if contender.err != nil {
+				return false, nil, &cdcWaiterTerminalError{cause: fmt.Errorf(
+					"contender transaction %x completed before entering the lock wait; last statement %q affected rows=%d: %w",
+					contender.txnID, contender.lastStatement, contender.lastAffectedRows, contender.err,
+				)}
+			}
+			return false, nil, &cdcWaiterTerminalError{cause: fmt.Errorf(
+				"contender transaction %x completed before entering the lock wait; last statement %q affected rows=%d",
+				contender.txnID, contender.lastStatement, contender.lastAffectedRows,
+			)}
+		default:
+		}
 		return holder.hasWaiter(probeCtx, holderLockService, contender.txnID)
 	})
 	require.NoError(t, err,
@@ -148,11 +210,13 @@ func testCDCWatermarkDropRace(
 // every ExecTxn return, including errors before the callback is entered.
 // Closing done publishes err and lets both the assertion and cleanup join it.
 type cdcRaceTxn struct {
-	started chan struct{}
-	ready   chan struct{}
-	done    chan struct{}
-	err     error
-	txnID   []byte
+	started          chan struct{}
+	ready            chan struct{}
+	done             chan struct{}
+	err              error
+	txnID            []byte
+	lastStatement    string
+	lastAffectedRows uint64
 }
 
 func startCDCRaceTxn(t *testing.T, parent context.Context, sqlExec executor.SQLExecutor, release <-chan struct{}, statements ...string) *cdcRaceTxn {
@@ -204,7 +268,10 @@ func startCDCRaceTxnInternal(
 			}
 			close(run.started)
 			for _, statement := range statements {
-				if err := execInternalTxnSQL(txn, statement); err != nil {
+				run.lastStatement = statement
+				var err error
+				run.lastAffectedRows, err = execInternalTxnSQLWithAffectedRows(txn, statement)
+				if err != nil {
 					return err
 				}
 			}
@@ -296,6 +363,18 @@ func cdcWaiterMatches(waiters []lockpb.WaitTxn, waiterTxnID []byte) (bool, []str
 	return false, observedTxnIDs
 }
 
+type cdcWaiterTerminalError struct {
+	cause error
+}
+
+func (e *cdcWaiterTerminalError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *cdcWaiterTerminalError) Unwrap() error {
+	return e.cause
+}
+
 // waitForCDCWaiter performs each lock-service query in the caller goroutine.
 // The probe context bounds both the retry window and any in-flight remote
 // query, so transaction cleanup cannot overlap an observation goroutine.
@@ -308,25 +387,31 @@ func waitForCDCWaiter(
 
 	var lastWaiterTxnIDs []string
 	var lastErr error
+	attempts := 0
 	for {
+		attempts++
 		found, waiterTxnIDs, err := probe(ctx)
 		lastWaiterTxnIDs = waiterTxnIDs
 		lastErr = err
 		if err == nil && found {
 			return waiterTxnIDs, nil
 		}
+		var terminalErr *cdcWaiterTerminalError
+		if errors.As(err, &terminalErr) {
+			return lastWaiterTxnIDs, terminalErr
+		}
 		if ctx.Err() != nil {
 			if lastErr != nil {
-				return lastWaiterTxnIDs, lastErr
+				return lastWaiterTxnIDs, fmt.Errorf("%w after %d probes; last probe error: %v", ctx.Err(), attempts, lastErr)
 			}
-			return lastWaiterTxnIDs, ctx.Err()
+			return lastWaiterTxnIDs, fmt.Errorf("%w after %d probes", ctx.Err(), attempts)
 		}
 		select {
 		case <-ctx.Done():
 			if lastErr != nil {
-				return lastWaiterTxnIDs, fmt.Errorf("%w (last probe error: %v)", ctx.Err(), lastErr)
+				return lastWaiterTxnIDs, fmt.Errorf("%w after %d probes; last probe error: %v", ctx.Err(), attempts, lastErr)
 			}
-			return lastWaiterTxnIDs, ctx.Err()
+			return lastWaiterTxnIDs, fmt.Errorf("%w after %d probes", ctx.Err(), attempts)
 		case <-ticker.C:
 		}
 	}
@@ -349,7 +434,13 @@ func execInternalSQL(ctx context.Context, sqlExec executor.SQLExecutor, statemen
 }
 
 func execInternalTxnSQL(txn executor.TxnExecutor, statement string) error {
-	result, err := txn.Exec(statement, executor.StatementOption{}.WithAccountID(0))
-	result.Close()
+	_, err := execInternalTxnSQLWithAffectedRows(txn, statement)
 	return err
+}
+
+func execInternalTxnSQLWithAffectedRows(txn executor.TxnExecutor, statement string) (uint64, error) {
+	result, err := txn.Exec(statement, executor.StatementOption{}.WithAccountID(0))
+	affectedRows := result.AffectedRows
+	result.Close()
+	return affectedRows, err
 }


### PR DESCRIPTION
## Summary

Fixes #28282.

The CDC watermark race regression test could fail before exercising the lock contract. The fixture task was committed through CN0, while CN1 had not necessarily consumed the corresponding logtail. In `drop_wins`, the guarded watermark INSERT on CN1 could therefore complete with `AffectedRows=0` without requesting the task-row lock; an empty holder wait graph was then reported as a 30-second flaky timeout.

This change:

- establishes a real CN1 visibility barrier with an independent autocommit read before starting either race ordering;
- uses a unique UUID task ID for each ordering so an older fixture generation cannot satisfy that barrier;
- reports contender completion before lock admission immediately, including transaction ID, last statement, affected rows, and error;
- preserves both lock orderings, exact waiter transaction-ID validation, transaction cleanup/join, and final zero task/watermark assertions.

No production CDC or lock-service code is changed.

## Validation

- focused two-CN regression: pass;
- focused regression with `-race`: pass;
- `TestCDCRaceTxn` and `TestCDCWaiterProbe` with `-race -count=3`: pass;
- full `pkg/tests/issues` with the known unrelated `TestIssue28313EmptyRemoteDispatch` flaky skipped: pass;
- `go vet ./pkg/tests/issues` with repository CGo headers/libs: pass;
- `git diff --check`: pass.

An unfiltered owning-package run still reproduced the pre-existing `TestIssue28313EmptyRemoteDispatch` / shuffle receiver lifecycle flaky tracked by #28447; it does not touch this change.
