### PR TITLE
ci: select test suites for test-only and documentation changes

### DIFF
--- a/.github/ci/change-scope.cjs
+++ b/.github/ci/change-scope.cjs
@@ -1,0 +1,94 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+// This allowlist is deliberately narrow: test helpers, fixtures, configuration,
+// dependencies, CI code and unknown paths all retain the complete test suite.
+function category(path) {
+  if (typeof path !== 'string' || path.split('/').some(p => !p || p === '.' || p === '..')) return 'full';
+  if (/^(README(?:_CN)?|CONTRIBUTING|CHANGELOG)\.md$/.test(path) ||
+      /^docs\/.*\.(md|png|jpg|jpeg|gif|svg)$/.test(path)) return 'docs';
+  if (/^pkg\/.*_test\.go$/.test(path)) return 'ut';
+  if (/^test\/distributed\/cases\/.*\.(sql|test|result)$/.test(path)) return 'bvt';
+  return 'full';
+}
+
+function classify(files, expectedCount, forceFull = false) {
+  if (forceFull || !Array.isArray(files) || files.length === 0 ||
+      files.length !== expectedCount || files.length >= 3000) return 'full';
+  const kinds = new Set();
+  const names = new Set();
+  for (const file of files) {
+    if (!file || !['added', 'modified', 'removed', 'renamed'].includes(file.status) ||
+        typeof file.filename !== 'string' || names.has(file.filename)) return 'full';
+    names.add(file.filename);
+    kinds.add(category(file.filename));
+    // Moving production code into a test/document path must still run full CI.
+    if (file.status === 'renamed') {
+      if (!file.previous_filename) return 'full';
+      kinds.add(category(file.previous_filename));
+    }
+  }
+  if (kinds.has('full')) return 'full';
+  kinds.delete('docs');
+  if (kinds.size === 0) return 'docs';
+  return kinds.size === 1 ? [...kinds][0] : 'full';
+}
+
+async function resolveScope({ github, context, forceFull }) {
+  const eventPR = context.payload.pull_request;
+  if (!eventPR) throw new Error('Missing pull request');
+  const params = { ...context.repo, pull_number: eventPR.number };
+  const sameRevision = pr => pr.head.sha === eventPR.head.sha && pr.base.sha === eventPR.base.sha;
+  const before = (await github.rest.pulls.get(params)).data;
+  if (!sameRevision(before)) throw new Error('PR revision changed; use the newer CI run');
+  let scope = 'full';
+  try {
+    const files = await github.paginate(github.rest.pulls.listFiles, { ...params, per_page: 100 });
+    scope = classify(files, before.changed_files, forceFull);
+  } catch {
+    // An unavailable or incomplete file list must never grant a test exemption.
+    scope = 'full';
+  }
+  const after = (await github.rest.pulls.get(params)).data;
+  if (!sameRevision(after)) throw new Error('PR revision changed while classifying');
+  return scope;
+}
+
+function verifyResults(scope, needs) {
+  if (needs['change-scope']?.result !== 'success' ||
+      needs['check-pr-valid']?.result !== 'success' ||
+      needs['check-pr-valid']?.outputs?.pr_valid !== 'true') {
+    throw new Error('PR validation or scope planning did not succeed');
+  }
+  const required = {
+    docs: ['docs-check'],
+    ut: ['matrixone-ci'],
+    bvt: ['bvt-group-plan', 'matrixone-compose-ci', 'matrixone-standalone-ci'],
+    full: ['bvt-group-plan', 'matrixone-ci', 'matrixone-ut-coverage',
+      'matrixone-compose-ci', 'matrixone-standalone-ci', 'matrixone-coverage-merge'],
+  }[scope];
+  if (!required) throw new Error(`Invalid CI scope: ${scope}`);
+  for (const job of required) {
+    if (needs[job]?.result !== 'success') throw new Error(`${job}: ${needs[job]?.result || 'missing'}`);
+  }
+  if (required.includes('matrixone-ut-coverage') &&
+      needs['matrixone-ut-coverage']?.outputs?.coverage_ready !== 'true') {
+    throw new Error('UT coverage was not eligible to execute');
+  }
+  return `CI scope ${scope}: all required jobs passed; other suites intentionally omitted.` +
+    (scope === 'full' ? '' : ' Coverage was not evaluated for this test/document-only change.');
+}
+
+module.exports = { category, classify, resolveScope, verifyResults };

--- a/.github/ci/change-scope.test.cjs
+++ b/.github/ci/change-scope.test.cjs
@@ -1,0 +1,179 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { runInNewContext } = require('node:vm');
+const { classify, resolveScope, verifyResults } = require('./change-scope.cjs');
+
+const modified = filename => ({ filename, status: 'modified' });
+test('only narrow test and documentation paths receive exemptions', () => {
+  for (const [paths, expected] of [
+    [['README.md', 'docs/design/a.md'], 'docs'],
+    [['pkg/sql/plan/a_test.go'], 'ut'],
+    [['pkg/tests/upgrade/a_test.go', 'docs/a.md'], 'ut'],
+    [['test/distributed/cases/a.test', 'test/distributed/cases/a.result'], 'bvt'],
+    [['test/distributed/cases/a.sql', 'README_CN.md'], 'bvt'],
+    [['pkg/a_test.go', 'test/distributed/cases/a.test'], 'full'],
+    [['pkg/a_test.go', 'pkg/a.go'], 'full'],
+    [['pkg/tests/testutils/helper.go'], 'full'],
+    [['pkg/embed/testing.go'], 'full'],
+    [['pkg/a/testdata/input.json'], 'full'],
+    [['go.mod'], 'full'], [['Makefile'], 'full'],
+    [['.github/workflows/entrypoint.yaml'], 'full'],
+    [['test/distributed/run.sh'], 'full'],
+    [['docs/example.sh'], 'full'], [['etc/cn.toml'], 'full'],
+    [['pkg/../main_test.go'], 'full'],
+  ]) assert.equal(classify(paths.map(modified), paths.length), expected, paths.join(','));
+});
+
+test('renames consider the old path, including production-to-doc and production-to-test', () => {
+  for (const filename of ['docs/a.md', 'pkg/a_test.go']) {
+    assert.equal(classify([{ filename, previous_filename: 'pkg/a.go', status: 'renamed' }], 1), 'full');
+  }
+  assert.equal(classify([{ filename: 'pkg/b_test.go', previous_filename: 'pkg/a_test.go', status: 'renamed' }], 1), 'ut');
+  assert.equal(classify([{ filename: 'pkg/a_test.go', status: 'removed' }], 1), 'ut');
+});
+
+test('empty, capped, incomplete, duplicate and malformed lists fail closed', () => {
+  const file = modified('pkg/a_test.go');
+  for (const [files, count] of [
+    [[], 0], [[file], 2], [[file, file], 2], [null, 1],
+    [[{ ...file, status: 'renamed' }], 1], [[{ ...file, status: 'unknown' }], 1],
+    [[null], 1], [[modified(null)], 1],
+    [Array.from({ length: 3000 }, (_, i) => modified(`pkg/a${i}_test.go`)), 3000],
+  ]) assert.equal(classify(files, count), 'full');
+  assert.equal(classify([file], 1, true), 'full');
+});
+
+function client({ files = [modified('pkg/a_test.go')], revisions, error = false } = {}) {
+  const pr = { number: 1, head: { sha: 'head' }, base: { sha: 'base' }, changed_files: 1 };
+  let calls = 0;
+  return {
+    context: { repo: { owner: 'owner', repo: 'repo' }, payload: { pull_request: pr } },
+    github: {
+      rest: { pulls: { get: async () => ({ data: revisions ? revisions[calls++] : pr }), listFiles: 'listFiles' } },
+      paginate: async (method, params) => {
+        assert.equal(method, 'listFiles');
+        assert.equal(params.per_page, 100);
+        if (error) throw new Error('API unavailable');
+        return files;
+      },
+    },
+    pr,
+  };
+}
+
+test('API failure falls back to full and both sides of pagination check the revision', async () => {
+  assert.equal(await resolveScope(client()), 'ut');
+  assert.equal(await resolveScope(client({ error: true })), 'full');
+  const { pr } = client();
+  const movedHead = { ...pr, head: { sha: 'new' } };
+  const movedBase = { ...pr, base: { sha: 'new' } };
+  for (const revisions of [[movedHead], [pr, movedHead], [pr, movedBase]]) {
+    await assert.rejects(resolveScope(client({ revisions })), /revision changed/);
+  }
+});
+
+function results() {
+  const needs = Object.fromEntries(['change-scope', 'docs-check', 'bvt-group-plan', 'matrixone-ci',
+    'matrixone-ut-coverage', 'matrixone-compose-ci', 'matrixone-standalone-ci',
+    'matrixone-coverage-merge'].map(job => [job, { result: 'success' }]));
+  needs['check-pr-valid'] = { result: 'success', outputs: { pr_valid: 'true' } };
+  needs['matrixone-ut-coverage'].outputs = { coverage_ready: 'true' };
+  return needs;
+}
+
+test('gates accept intentional omissions but reject failed, cancelled, skipped or missing required work', () => {
+  const jobs = {
+    docs: ['docs-check'], ut: ['matrixone-ci'],
+    bvt: ['bvt-group-plan', 'matrixone-compose-ci', 'matrixone-standalone-ci'],
+    full: ['bvt-group-plan', 'matrixone-ci', 'matrixone-ut-coverage', 'matrixone-compose-ci',
+      'matrixone-standalone-ci', 'matrixone-coverage-merge'],
+  };
+  for (const [scope, required] of Object.entries(jobs)) {
+    const needs = results();
+    for (const job of Object.keys(needs)) {
+      if (!['change-scope', 'check-pr-valid', ...required].includes(job)) needs[job].result = 'skipped';
+    }
+    assert.match(verifyResults(scope, needs), /passed/);
+    for (const job of ['change-scope', 'check-pr-valid', ...required]) {
+      for (const result of ['failure', 'cancelled', 'skipped', undefined]) {
+        assert.throws(() => verifyResults(scope, { ...needs, [job]: { result } }));
+      }
+    }
+  }
+  assert.throws(() => verifyResults('', results()));
+  const needs = results();
+  needs['check-pr-valid'].outputs.pr_valid = 'false';
+  assert.throws(() => verifyResults('docs', needs));
+});
+
+test('a successful eligibility job cannot hide skipped UT coverage', () => {
+  for (const scope of ['full']) {
+    for (const ready of ['false', '', undefined]) {
+      const needs = results();
+      needs['matrixone-ut-coverage'].outputs.coverage_ready = ready;
+      assert.throws(() => verifyResults(scope, needs), /not eligible/);
+    }
+  }
+});
+
+test('entrypoint routes each scope and preserves every required check name', () => {
+  const workflow = readFileSync(`${__dirname}/../workflows/entrypoint.yaml`, 'utf8');
+  const blocks = Object.fromEntries([...workflow.matchAll(/^  ([\w-]+):\n([\s\S]*?)(?=^  [\w-]+:\n|$(?![\s\S]))/gm)]
+    .map(match => [match[1], match[2]]));
+  const routed = ['docs-check', 'bvt-group-plan', 'matrixone-shared-build', 'matrixone-ci',
+    'matrixone-ut-coverage', 'matrixone-upgrade-ci', 'matrixone-compose-ci',
+    'matrixone-standalone-ci', 'matrixone-coverage-merge'];
+  const expected = {
+    docs: ['docs-check'], ut: ['matrixone-ci'],
+    bvt: ['bvt-group-plan', 'matrixone-shared-build', 'matrixone-compose-ci', 'matrixone-standalone-ci'],
+    full: routed.filter(job => job !== 'docs-check'),
+  };
+  for (const [scope, wanted] of Object.entries(expected)) {
+    const needs = results();
+    needs['change-scope'].outputs = { scope };
+    needs['matrixone-shared-build'] = { result: 'success' };
+    const selected = routed.filter(job => {
+      const expression = blocks[job].match(/^    if: \$\{\{ (.*) \}\}$/m)[1]
+        .replace(/needs\.([\w-]+)/g, "needs['$1']");
+      return runInNewContext(expression, {
+        needs, github: { base_ref: 'main' }, cancelled: () => false,
+        contains: (values, value) => values.includes(value), fromJSON: JSON.parse,
+      });
+    });
+    assert.deepEqual(selected, wanted, scope);
+  }
+  const gates = blocks['ci-required'];
+  assert.match(gates, /if: \$\{\{ always\(\)/);
+  for (const name of [
+    'Matrixone CI / UT Test on Ubuntu/x86',
+    'Matrixone CI / SCA Test on Linux/arm64',
+    'Matrixone UT Coverage / UT Coverage on Ubuntu/x86',
+    'Matrixone Compose CI / multi cn e2e bvt test docker compose(PROXY)',
+    'Matrixone Standlone CI / multi CN e2e BVT Test on Linux/x64(COMPOSE, PESSIMISTIC)',
+    'Matrixone Utils CI / Coverage',
+  ]) assert.ok(gates.includes(`- ${name}\n`), name);
+  for (const job of ['matrixone-ci', 'matrixone-ut-coverage', 'matrixone-compose-ci',
+    'matrixone-standalone-ci', 'matrixone-coverage-merge']) {
+    assert.match(blocks[job], /name: .* execution\n/);
+    assert.ok(gates.match(/^    needs: (.*)$/m)[1].includes(job));
+  }
+  for (const job of ['change-scope', 'ci-required']) {
+    assert.match(blocks[job], /ref: \$\{\{ github.event.pull_request.base.sha \}\}/);
+    assert.match(blocks[job], /persist-credentials: false/);
+  }
+});

--- a/.github/workflows/ci-scope-check.yml
+++ b/.github/workflows/ci-scope-check.yml
@@ -1,0 +1,20 @@
+name: CI scope contract
+
+on:
+  pull_request:
+    paths:
+      - '.github/ci/**'
+      - '.github/workflows/entrypoint.yaml'
+      - '.github/workflows/ci-scope-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - run: node --test .github/ci/change-scope.test.cjs

--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -26,10 +26,54 @@ jobs:
           title_for_find_issue: "Which issue(s) this PR fixes:"
           title_for_find_content: "What this PR does / why we need it:"
 
+  change-scope:
+    name: Classify CI changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      scope: ${{ steps.scope.outputs.scope }}
+    steps:
+      # pull_request_target must execute only the trusted base's classifier.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/ci
+      - uses: actions/github-script@v7
+        id: scope
+        env:
+          FORCE_FULL: ${{ vars.CI_FORCE_FULL }}
+        with:
+          script: |
+            const { resolveScope } = require('./.github/ci/change-scope.cjs');
+            const scope = await resolveScope({ github, context, forceFull: process.env.FORCE_FULL === 'true' });
+            core.setOutput('scope', scope);
+            await core.summary.addHeading('CI change scope').addRaw(`Selected: ${scope}`).write();
+
+  docs-check:
+    name: Documentation whitespace check
+    needs: change-scope
+    if: ${{ needs.change-scope.outputs.scope == 'docs' && github.base_ref != '3.0-dev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          sparse-checkout: docs
+          persist-credentials: false
+      - name: Check documentation diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git -c core.whitespace=blank-at-eof,space-before-tab diff --no-ext-diff --no-textconv --check "${BASE_SHA}...${HEAD_SHA}"
+
   bvt-group-plan:
     name: Plan complementary BVT groups
-    needs: check-pr-valid
-    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
+    needs: [check-pr-valid, change-scope]
+    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && contains(fromJSON('["full","bvt"]'), needs.change-scope.outputs.scope) && github.base_ref != '3.0-dev' }}
     runs-on: ubuntu-latest
     outputs:
       compose_group: ${{ steps.plan.outputs.compose_group }}
@@ -64,24 +108,24 @@ jobs:
   # workflow caps its token to contents: read and pulls images anonymously.
   matrixone-shared-build:
     name: Matrixone Shared Build
-    needs: check-pr-valid
-    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
+    needs: [check-pr-valid, change-scope]
+    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && contains(fromJSON('["full","bvt"]'), needs.change-scope.outputs.scope) && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/build-mo.yaml@main
 
   # ============ 非 3.0-dev 分支使用 @main ============
   matrixone-ci:
-    name: Matrixone CI
-    needs: check-pr-valid
-    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
+    name: Matrixone CI execution
+    needs: [check-pr-valid, change-scope]
+    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && contains(fromJSON('["full","ut"]'), needs.change-scope.outputs.scope) && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/ci.yaml@main
     with:
       ut_parallel: 6
     secrets: inherit
 
   matrixone-ut-coverage:
-    name: Matrixone UT Coverage
-    needs: [check-pr-valid, bvt-group-plan]
-    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
+    name: Matrixone UT Coverage execution
+    needs: [check-pr-valid, change-scope, bvt-group-plan]
+    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && needs.change-scope.outputs.scope == 'full' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/coverage-ut.yaml@main
     with:
       bvt_generation: ${{ needs.bvt-group-plan.outputs.generation }}
@@ -89,8 +133,8 @@ jobs:
 
   matrixone-upgrade-ci:
     name: Matrixone Upgrade CI
-    needs: check-pr-valid
-    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
+    needs: [check-pr-valid, change-scope]
+    if: ${{ needs.check-pr-valid.outputs.pr_valid == 'true' && needs.change-scope.outputs.scope == 'full' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/e2e-upgrade.yaml@main
     secrets: inherit
 
@@ -103,9 +147,9 @@ jobs:
   # genuine compile failure therefore costs two duplicate failures instead of
   # silently skipping both BVT suites.
   matrixone-compose-ci:
-    name: Matrixone Compose CI
-    needs: [check-pr-valid, bvt-group-plan, matrixone-shared-build]
-    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
+    name: Matrixone Compose CI execution
+    needs: [check-pr-valid, change-scope, bvt-group-plan, matrixone-shared-build]
+    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && contains(fromJSON('["full","bvt"]'), needs.change-scope.outputs.scope) && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/e2e-compose-parallel.yaml@main
     with:
       bvt_group: ${{ needs.bvt-group-plan.outputs.compose_group }}
@@ -114,9 +158,9 @@ jobs:
     secrets: inherit
 
   matrixone-standalone-ci:
-    name: Matrixone Standlone CI
-    needs: [check-pr-valid, bvt-group-plan, matrixone-shared-build]
-    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
+    name: Matrixone Standlone CI execution
+    needs: [check-pr-valid, change-scope, bvt-group-plan, matrixone-shared-build]
+    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && contains(fromJSON('["full","bvt"]'), needs.change-scope.outputs.scope) && needs.bvt-group-plan.result == 'success' && needs.matrixone-shared-build.result != 'cancelled' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/e2e-standalone-parallel.yaml@main
     with:
       bvt_group: ${{ needs.bvt-group-plan.outputs.launch_group }}
@@ -132,14 +176,48 @@ jobs:
     secrets: inherit
 
   matrixone-coverage-merge:
-    name: Matrixone Utils CI
-    needs: [check-pr-valid, bvt-group-plan, matrixone-ut-coverage, matrixone-compose-ci, matrixone-standalone-ci]
-    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && github.base_ref != '3.0-dev' }}
+    name: Matrixone Coverage execution
+    needs: [check-pr-valid, change-scope, bvt-group-plan, matrixone-ut-coverage, matrixone-compose-ci, matrixone-standalone-ci]
+    if: ${{ !cancelled() && needs.check-pr-valid.outputs.pr_valid == 'true' && needs.change-scope.outputs.scope == 'full' && github.base_ref != '3.0-dev' }}
     uses: matrixorigin/CI/.github/workflows/coverage-merge.yaml@main
     with:
       prerequisites_ready: ${{ needs.bvt-group-plan.result == 'success' && needs.matrixone-ut-coverage.result == 'success' && needs.matrixone-ut-coverage.outputs.coverage_ready == 'true' && needs.matrixone-compose-ci.result == 'success' && needs.matrixone-standalone-ci.result == 'success' }}
       expected_bvt_generation: ${{ needs.bvt-group-plan.outputs.generation }}
     secrets: inherit
+
+  # Keep all six established required-check names present for every scope.
+  # Each checks the selected suite as an AND gate; failed/cancelled/missing
+  # prerequisites cannot become a green check through dependent-job skipping.
+  ci-required:
+    name: ${{ matrix.check }}
+    if: ${{ always() && github.base_ref != '3.0-dev' }}
+    needs: [check-pr-valid, change-scope, docs-check, bvt-group-plan, matrixone-ci, matrixone-ut-coverage, matrixone-compose-ci, matrixone-standalone-ci, matrixone-coverage-merge]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - Matrixone CI / UT Test on Ubuntu/x86
+          - Matrixone CI / SCA Test on Linux/arm64
+          - Matrixone UT Coverage / UT Coverage on Ubuntu/x86
+          - Matrixone Compose CI / multi cn e2e bvt test docker compose(PROXY)
+          - Matrixone Standlone CI / multi CN e2e BVT Test on Linux/x64(COMPOSE, PESSIMISTIC)
+          - Matrixone Utils CI / Coverage
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/ci
+      - uses: actions/github-script@v7
+        env:
+          SCOPE: ${{ needs.change-scope.outputs.scope }}
+          JOB_RESULTS: ${{ toJSON(needs) }}
+        with:
+          script: |
+            const { verifyResults } = require('./.github/ci/change-scope.cjs');
+            const message = verifyResults(process.env.SCOPE, JSON.parse(process.env.JOB_RESULTS));
+            await core.summary.addRaw(message).write();
 
   # ============ 3.0-dev 分支使用 @release/3.0-dev ============
   matrixone-ci-30:

--- a/docs/ci-change-scope.md
+++ b/docs/ci-change-scope.md
@@ -1,0 +1,46 @@
+# Pull request CI scope
+
+The PR entrypoint classifies the complete file list before scheduling expensive
+jobs. Tests still run as complete suites; this does not shard or select individual
+test cases.
+
+| Changed files | Scope | Work performed |
+| --- | --- | --- |
+| Root README/README_CN/CONTRIBUTING/CHANGELOG Markdown, or Markdown/images under `docs/` | docs | Documentation whitespace check and PR metadata checks |
+| Only `pkg/**/*_test.go`, optionally with the documentation above | ut | Existing race UT and static analysis |
+| Only `.test`/`.sql`/`.result` under `test/distributed/cases/`, optionally with documentation | bvt | Shared build and both complementary BVT jobs |
+| Everything else, including mixed UT+BVT changes | full | Existing complete CI pipeline, including merged coverage |
+
+Go helpers, test fixtures, build scripts, dependencies, runtime configuration and
+workflow changes deliberately retain full CI. Deleted paths are classified too;
+renames consider both names. Missing/incomplete/capped file lists fall back to
+full CI. A PR head or base that moves during classification fails that old run.
+Set the repository Actions variable `CI_FORCE_FULL=true` and rerun CI to disable
+all scope exemptions.
+
+The classifier and required-check gates execute code checked out from the trusted
+PR base SHA, never the PR head. The documentation job reads the PR diff without
+running PR scripts. The separate scope contract workflow runs without secrets
+and tests changes to the classifier before they reach the trusted base.
+
+The six existing main-branch required-check names are retained by lightweight
+summary jobs. The actual reusable workflow calls are named `... execution` to
+avoid duplicate status names. Each summary requires every job selected by the
+scope to succeed, including classification and PR validation; a skipped,
+cancelled, failed or absent selected job is not a pass. Its summary explicitly
+states the scope and intentional omissions. These are aggregate gates, not
+claims that an omitted suite executed.
+
+The independent UT coverage and merged UT+BVT coverage jobs run only for full
+runs. Scoped runs explicitly report coverage as not evaluated; they do not
+fabricate missing profiles or reuse profiles from a different commit. BVT's
+existing instrumented build and incidental profiles are unchanged. Removing
+tests can still reduce coverage, so test-only exemptions do not establish that
+coverage has stayed constant. Use a full run when reviewing that risk.
+Existing 3.0-dev routing is unchanged.
+
+No branch-protection changes or CI-repository rollout are required. Because the
+entrypoint uses `pull_request_target`, this routing takes effect after the change
+is merged into the PR target branch, not when testing this PR itself.
+
+Local contract validation: `node --test .github/ci/change-scope.test.cjs`.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fix #28419

## What this PR does / why we need it:

This PR makes the MatrixOne PR entrypoint select the smallest complete CI scope for test-only and documentation-only changes, while failing closed for every ambiguous or unsafe case.

- `pkg/**/*_test.go` only: run the existing UT/SCA workflow.
- Distributed case `.sql`, `.test`, and `.result` files only: run the shared build and both complementary BVT workflows.
- A narrow allowlist of documentation-only changes: run documentation whitespace and PR validation checks.
- Production code, helpers, fixtures, configuration, dependencies, CI/workflow changes, mixed UT+BVT changes, deletions with unsafe classification, and unknown paths: run the full CI pipeline.

Renames inspect both old and new paths. Empty, incomplete, capped, duplicated, malformed, or unavailable file lists fall back to full CI. The PR head/base revision is checked before and after classification; a revision change fails the old run. `CI_FORCE_FULL=true` is supported as a repository Actions variable override.

The classification and aggregate gates execute trusted code from the PR base SHA. The documentation job checks the PR diff without executing PR code. Existing 3.0-dev routing is preserved. No branch-protection or CI-repository change is required.

The established required-check names remain present through six lightweight aggregate gates. Each gate requires PR validation, classification, and every suite selected for its scope to succeed; failed, cancelled, skipped, missing, or ineligible selected jobs cannot become a pass. Reusable workflow callers use distinct execution names to avoid duplicate status names.

Coverage is intentionally evaluated only for full-scope changes. Scoped test/documentation runs explicitly report that coverage was not evaluated and do not reuse or fabricate profiles from another commit. Existing BVT instrumentation is unchanged. Test deletion can still reduce coverage and should be reviewed with `CI_FORCE_FULL=true`.

The classifier and routing contract are covered by Node tests for path classification, rename/deletion handling, malformed and incomplete API results, revision races, failed/cancelled/skipped gates, coverage eligibility, workflow routing, and required-check names.

## Validation

- `node --test .github/ci/change-scope.test.cjs`
- `actionlint 1.7.12`
- `git diff --check`

Full MatrixOne UT/BVT was not run locally because this PR changes CI routing rather than MatrixOne production code. The actual Actions routing must be verified after rollout to the target branch; this PR itself is classified as `full` because it changes workflow and CI files.
