### PR TITLE
test: fence optimistic snapshot commits before fixture cleanup

### DIFF
--- a/pkg/tests/issues/issue_27718_test.go
+++ b/pkg/tests/issues/issue_27718_test.go
@@ -17,14 +17,17 @@ package issues
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/cnservice"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	pbtxn "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 	"github.com/stretchr/testify/require"
@@ -40,6 +43,10 @@ func TestIssue27718ConcurrentSnapshotQuota(t *testing.T) {
 		cn1, err := c.GetCNService(1)
 		require.NoError(t, err)
 		cns := []embed.ServiceOperator{cn0, cn1}
+		commitClients := make([]issue27718CommitClient, 0, len(cns))
+		for _, cn := range cns {
+			commitClients = append(commitClients, cn.RawService().(cnservice.Service).GetTxnClient())
+		}
 		ports := []int64{
 			cn0.GetServiceConfig().CN.Frontend.Port,
 			cn1.GetServiceConfig().CN.Frontend.Port,
@@ -52,9 +59,11 @@ func TestIssue27718ConcurrentSnapshotQuota(t *testing.T) {
 
 		const accountName = "issue_27718"
 		defer func() {
+			checkIssue27718RegistryRows(t, sysDB, "before account cleanup")
 			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cleanupCancel()
 			execSQLMaybe(t, cleanupCtx, sysDB, "drop account if exists "+accountName)
+			checkIssue27718RegistryRows(t, sysDB, "after account cleanup attempt")
 		}()
 		execSQLRequire(t, ctx, sysDB, "drop account if exists "+accountName)
 		accountID := testutils.CreateAccount(t, c, accountName, "111")
@@ -83,11 +92,141 @@ func TestIssue27718ConcurrentSnapshotQuota(t *testing.T) {
 			t.Run(mode.name, func(t *testing.T) {
 				restore := setIssue27718TxnConfig(cns, mode.mode, mode.isolation)
 				defer restore()
+				if mode.mode == pbtxn.TxnMode_Optimistic {
+					defer func() {
+						// The shared clients were constructed with pessimistic
+						// freshness settings. Changing the runtime mode does not
+						// enable CN-based consistency. Drain completed optimistic
+						// commits before parent cleanup opens a new RC transaction
+						// in the independent sys session. Restore still runs if
+						// this bounded barrier fails.
+						fenceCtx, fenceCancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer fenceCancel()
+						require.NoError(t, waitIssue27718Commits(fenceCtx, commitClients))
+					}()
+				}
 				runIssue27718SnapshotQuotaMode(
 					t, ctx, sysDB, tenantDB, accountName, accountID, ports, mode.name)
 			})
 		}
 	})
+}
+
+type issue27718CommitClient interface {
+	GetLatestCommitTS() timestamp.Timestamp
+	WaitLogTailAppliedAt(context.Context, timestamp.Timestamp) (timestamp.Timestamp, error)
+}
+
+type issue27718CommitProbe struct {
+	latest func() timestamp.Timestamp
+	wait   func(context.Context, timestamp.Timestamp) (timestamp.Timestamp, error)
+}
+
+func (p issue27718CommitProbe) GetLatestCommitTS() timestamp.Timestamp { return p.latest() }
+func (p issue27718CommitProbe) WaitLogTailAppliedAt(ctx context.Context, ts timestamp.Timestamp) (timestamp.Timestamp, error) {
+	return p.wait(ctx, ts)
+}
+
+func TestIssue27718CommitFence(t *testing.T) {
+	for _, failFirst := range []bool{false, true} {
+		t.Run(fmt.Sprintf("first_wait_fails=%v", failFirst), func(t *testing.T) {
+			var events []string
+			frontier := timestamp.Timestamp{PhysicalTime: 9}
+			waitErr := errors.New("apply failed")
+			clients := make([]issue27718CommitClient, 0, 2)
+			for i, committed := range []int64{9, 3} {
+				clients = append(clients, issue27718CommitProbe{
+					latest: func() timestamp.Timestamp {
+						events = append(events, fmt.Sprintf("read%d", i))
+						return timestamp.Timestamp{PhysicalTime: committed}
+					},
+					wait: func(_ context.Context, ts timestamp.Timestamp) (timestamp.Timestamp, error) {
+						events = append(events, fmt.Sprintf("wait%d", i))
+						require.Equal(t, frontier, ts)
+						if failFirst && i == 0 {
+							return timestamp.Timestamp{}, waitErr
+						}
+						return ts.Next(), nil
+					},
+				})
+			}
+			err := waitIssue27718Commits(t.Context(), clients)
+			if failFirst {
+				require.ErrorIs(t, err, waitErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, []string{"read0", "read1", "wait0", "wait1"}, events)
+		})
+	}
+	t.Run("no commits", func(t *testing.T) {
+		require.NoError(t, waitIssue27718Commits(t.Context(), []issue27718CommitClient{
+			issue27718CommitProbe{latest: func() timestamp.Timestamp { return timestamp.Timestamp{} }},
+		}))
+	})
+	t.Run("cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		err := waitIssue27718Commits(ctx, []issue27718CommitClient{issue27718CommitProbe{
+			latest: func() timestamp.Timestamp { return timestamp.Timestamp{PhysicalTime: 1} },
+			wait: func(ctx context.Context, _ timestamp.Timestamp) (timestamp.Timestamp, error) {
+				return timestamp.Timestamp{}, ctx.Err()
+			},
+		}})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func waitIssue27718Commits(ctx context.Context, clients []issue27718CommitClient) error {
+	var frontier timestamp.Timestamp
+	for _, client := range clients {
+		if committed := client.GetLatestCommitTS(); committed.Greater(frontier) {
+			frontier = committed
+		}
+	}
+	if frontier.IsEmpty() {
+		return nil
+	}
+	var err error
+	for i, client := range clients {
+		if _, waitErr := client.WaitLogTailAppliedAt(ctx, frontier); waitErr != nil {
+			err = errors.Join(err, fmt.Errorf("CN %d apply completed optimistic commits: %w", i, waitErr))
+		}
+	}
+	return err
+}
+
+// Observe the registry from separate statements without inserting a statement
+// into DROP ACCOUNT's background transaction. In particular, do not flush or
+// advance that transaction's workspace while diagnosing a visibility failure.
+func checkIssue27718RegistryRows(t *testing.T, db *sql.DB, phase string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rows, err := db.QueryContext(ctx,
+		"select __mo_rowid from mo_catalog.mo_feature_registry where feature_code = 'SNAPSHOT' limit 3")
+	if err != nil {
+		t.Errorf("%s: registry probe: %v", phase, err)
+		return
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Errorf("%s: scan registry row: %v", phase, err)
+			return
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Errorf("%s: read registry rows: %v", phase, err)
+		return
+	}
+	t.Logf("%s: SNAPSHOT registry row IDs: %v", phase, ids)
+	if len(ids) != 1 {
+		t.Errorf("%s: expected one SNAPSHOT registry row, got %d (probe limited to 3)", phase, len(ids))
+	}
 }
 
 func setIssue27718TxnConfig(
@@ -174,43 +313,51 @@ func runIssue27718SnapshotQuotaMode(
 		}
 		start := make(chan struct{})
 		results := make(chan createResult, creators)
+		createCtx, createCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer createCancel()
 		for i := 1; i <= creators; i++ {
 			name := fmt.Sprintf("%s_%d", prefix, i)
 			conn := connections[i-1]
 			go func() {
 				<-start
-				_, createErr := conn.ExecContext(ctx, fmt.Sprintf(
+				_, createErr := conn.ExecContext(createCtx, fmt.Sprintf(
 					"create snapshot %s for table issue_27718_db t", name))
 				results <- createResult{name: name, err: createErr}
 			}()
 		}
 		close(start)
 
-		successes := make([]string, 0, creators)
+		// Collect every creator before assertions can unwind the mode and
+		// capture its commit frontier. A timeout cancels the actual SQL too.
+		completed := make([]createResult, 0, creators)
 		for i := 0; i < creators; i++ {
 			select {
 			case result := <-results:
-				if quota < 0 {
-					require.NoError(t, result.err,
-						"unlimited quota must admit snapshot %s", result.name)
-					successes = append(successes, result.name)
-					continue
-				}
-				if result.err == nil {
-					successes = append(successes, result.name)
-					continue
-				}
-				if quota == 0 {
-					require.Contains(t, result.err.Error(),
-						"feature SNAPSHOT with scope table has disabled for account "+accountName)
-				} else {
-					require.Contains(t, result.err.Error(), fmt.Sprintf(
-						"feature SNAPSHOT with scope table has reached the limit of %d", quota))
-				}
-				require.NotContains(t, strings.ToLower(result.err.Error()), "txn need retry")
-			case <-time.After(30 * time.Second):
+				completed = append(completed, result)
+			case <-createCtx.Done():
 				t.Fatal("concurrent snapshot creator did not finish")
 			}
+		}
+		successes := make([]string, 0, creators)
+		for _, result := range completed {
+			if quota < 0 {
+				require.NoError(t, result.err,
+					"unlimited quota must admit snapshot %s", result.name)
+				successes = append(successes, result.name)
+				continue
+			}
+			if result.err == nil {
+				successes = append(successes, result.name)
+				continue
+			}
+			if quota == 0 {
+				require.Contains(t, result.err.Error(),
+					"feature SNAPSHOT with scope table has disabled for account "+accountName)
+			} else {
+				require.Contains(t, result.err.Error(), fmt.Sprintf(
+					"feature SNAPSHOT with scope table has reached the limit of %d", quota))
+			}
+			require.NotContains(t, strings.ToLower(result.err.Error()), "txn need retry")
 		}
 		require.Len(t, successes, expectedSuccesses)
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Addresses #28259's shared-fixture CI failure. Keep the issue open pending CI/manual validation.

## What this PR does / why we need it:

### Root cause and scope

The quota test reuses a cluster initialized with pessimistic transaction-client defaults, then changes only runtime transaction mode/isolation to Optimistic/SI. It does not change the client's construction-time freshness policy. Pessimistic defaults sacrifice freshness without CN-based consistency; normally initialized optimistic clients enable CN-based consistency.

DROP SNAPSHOT's background transaction inherits the temporary optimistic mode. Its commit can return before that write is applied on CN readers, and it does not advance the pessimistic lock-service commit timestamp. Returning from the subtest and restoring runtime mode did not establish a cross-session visibility boundary for the subsequent DROP ACCOUNT, which opens a Pessimistic/RC background transaction through the independent sys session.

This permits the following stale-write mechanism:

1. An optimistic registry replacement commits but is not yet visible at the reader frontier.
2. A new pessimistic cleanup reads the preceding version. The optimistic commit is not represented by the lock timestamp used to detect a stale read.
3. Cleanup writes its replacement using that older row ID.
4. A later RC statement advances the snapshot and can see the newer committed row plus cleanup's own insertion.

This is not evidence that no-op UPDATE itself is intrinsically invalid, nor justification to remove the write-conflict barriers.

### Evidence

Three retained CI artifacts first log a registry gate UPDATE with `AffectedRows=2` during the quota test's account cleanup, followed by snapshot-test failures:

- [run 34382186709 / PR #28450](https://github.com/matrixorigin/matrixone/actions/runs/34382186709/job/102570044807), first anomaly 2026-09-09 17:38:46.882859 UTC.
- [run 34338613927 / PR #28272](https://github.com/matrixorigin/matrixone/actions/runs/34338613927/job/102424080218), first anomaly 2026-09-09 10:28:38.765051 UTC.
- [run 34006770056, attempt 2 / PR #28145](https://github.com/matrixorigin/matrixone/actions/runs/34006770056/job/101422120263), first anomaly 2026-09-06 03:51:34.820578 UTC.

The original quota test with added external row-ID probes also failed locally, without any kernel change: before cleanup it returned one row ending `-34`; afterward it returned two distinct rows ending `-37` and `-36`. The first internal cleanup gate already affected two rows.

A separate controlled experiment reproduced the mechanism with an older pessimistic transaction, an intervening optimistic UPDATE, a no-op UPDATE at the older snapshot, and an explicit snapshot advance: the read returned two rows instead of one. That experiment also hit an unrelated internal-DROP cleanup error afterward; it is not presented as a passing test or included as a permanent test of unsupported mixed configuration. The historical CI artifacts do not contain the row-level timestamp trace needed to independently establish every step for each historical occurrence.

### Fix

- After optimistic scenario operations finish, capture one maximum committed timestamp across both CN clients. Wait for both CNs to apply that fixed frontier **before** restoring runtime mode and opening parent cleanup transactions.
- Give the fence a fresh ten-second cancellation bound; attempt both waits and aggregate failures. Mode restoration remains independently deferred even if the fence fails.
- Collect all concurrent creator results before assertions can unwind the mode. Use a bounded context for the actual SQL requests instead of timers that only stop the observer.
- Retain bounded, SQL-visible singleton checks before and after the existing cleanup attempt. Observe actual row IDs without deduplicating them; collect at most three rows. Probe deadlines cannot consume the original DROP ACCOUNT cleanup deadline.

All original quota cases remain: quotas 1/2, disabled/unlimited, concurrent contenders, replacement, rejected creation without persisted residue, and absence of leaked retry errors.

### Risk / performance / unhappy paths

Only the test file changes. No production transaction, lock, MVCC, DDL, or snapshot policy changes; no new cluster, sleeps, retries, or flushes. The new wait is a completion condition for already-committed work, not a delay chosen to make a test pass.

| Check | Closure |
| --- | --- |
| Ownership | Scenario connections retain their original cleanup owners; probe and fence contexts each have a deferred cancellation. |
| Waiting | SQL requests and the fixed-frontier fence are bounded; wait failure does not bypass mode restoration. |
| Growth | Four creator results, two clients, at most three diagnostic rows; no unbounded work or logging. |

A timed-out SQL client is not proof that every disconnected server transaction has terminated; that path fails the test and does not claim a successful transition. The existing account-cleanup helper ignores DROP errors, so the post-probe is explicitly after the cleanup **attempt**, not independent proof that DROP committed.

The fix closes this test's transition after completed optimistic work. It does **not** repair arbitrary concurrently mixed optimistic/pessimistic transactions or refresh a transaction already opened before another CN commits. The controlled experiment remains evidence for that separate protocol question; production immunity is not claimed.

### Validation

Base: `5f598e70bb8be8fea970faa36c500e6b2a9bb2d3` (main). Local platform: macOS/arm64, Go 1.26.4, matching native artifacts.

- Focused quota + fence tests passed: package 14.197s; both modes and all pure fence cases selected.
- Pure fence cases cover capture-before-wait ordering, the maximum frontier applied on both CNs, first-wait failure without skipping the second, cancellation, and no commits.
- Focused quota + fence race tests passed once: package 21.003s, no race report.
- The quota + fence selection passed **20 consecutive `-race` runs**: package 128.356s, 20/20 quota cases passed, no `DATA RACE`, exit code 0.
- `go vet -mod=readonly -tags matrixone_test ./pkg/tests/issues` and `git diff --check` passed.
- Covered owning-package run (`-covermode=set -coverpkg=./pkg/...`, GOMAXPROCS=7) **failed**, package 110.716s: `TestIssue27666CDCWatermarkWriteSerializesWithDrop/drop_wins` timed out waiting for the expected lock waiter. This failure occurred before the modified quota test ran. The quota test subsequently passed (1.07s), with exactly one registry row both before and after cleanup, and the fence tests passed. This is not reported as an all-green package run; the separate CDC failure is outside this patch.
- Independent gpt-6-astra medium review found no blocker in the harness-only diff; the diagnostic deadline issue found earlier was corrected.

Passing local runs do not replace Linux CI or prove every historical failure is resolved.
