### PR TITLE
test: reduce hash-build fixture cost while preserving recovery coverage

### DIFF
--- a/pkg/tests/issues/isolated/hashbuild_recovery_test.go
+++ b/pkg/tests/issues/isolated/hashbuild_recovery_test.go
@@ -33,12 +33,14 @@ import (
 )
 
 const (
-	hashBuildRecoveryQueryCap = int64(28 << 20)
-	// Ninety-six full three-BIGINT batches contain 18 MiB of vector data. Hash
-	// cells then cross the original 28 MiB hard budget after batch retention,
+	hashBuildRecoveryQueryCap = int64(25 << 20)
+	// Eighty full three-BIGINT batches contain 15 MiB of vector data. Hash
+	// cells then cross the 25 MiB hard budget after batch retention,
 	// preserving the map-admission recovery path without a million-row fixture.
+	// Keep headroom for retained vectors and recovery scratch. Scaling the cap
+	// down proportionally would reject batch retention before map allocation.
 	// A small tail also exercises partial-batch recovery accounting.
-	hashBuildRecoveryRows = colexec.DefaultBatchSize*96 + colexec.DefaultBatchSize/16
+	hashBuildRecoveryRows = colexec.DefaultBatchSize*80 + colexec.DefaultBatchSize/16
 )
 
 // TestHashBuildSharedBudgetRecoverySQL is the SQL-protocol counterexample for

--- a/pkg/tests/issues/isolated/issue_25782_broadcast_budget_test.go
+++ b/pkg/tests/issues/isolated/issue_25782_broadcast_budget_test.go
@@ -110,7 +110,9 @@ func TestIssue25782BroadcastHashBuildFailsClosedUnderHardBudget(t *testing.T) {
 		"create table broadcast_probe (k bigint not null) cluster by k")
 	execJoinSpillSQL(t, ctx, conn,
 		"create table broadcast_build (k bigint not null, payload bigint not null) cluster by k")
-	execJoinSpillSQL(t, ctx, conn, "insert into broadcast_probe values (1)")
+	// Include an unmatched probe as well: COUNT(b.payload) must exclude the
+	// NULL-extended LEFT JOIN row in the admitted control.
+	execJoinSpillSQL(t, ctx, conn, "insert into broadcast_probe values (1),(65)")
 
 	// The outer aggregate is intentionally blocking: the SQL protocol may send
 	// SELECT metadata before execution, but it must not publish a result row
@@ -127,7 +129,7 @@ func TestIssue25782BroadcastHashBuildFailsClosedUnderHardBudget(t *testing.T) {
 	// result oracle under the same broadcast topology and hard budget.
 	execJoinSpillSQL(t, ctx, conn,
 		"insert into broadcast_build select mod(result, 64), result from generate_series(1, 64) g")
-	patchJoinSpillStats(t, ctx, conn, dbName, "broadcast_probe", 1)
+	patchJoinSpillStats(t, ctx, conn, dbName, "broadcast_probe", 2)
 	patchJoinSpillStatsWithNDV(t, ctx, conn, dbName, "broadcast_build", 64, 64)
 	controlPlan := queryJoinSpillText(t, ctx, conn, "explain "+query)
 	require.Contains(t, controlPlan, "Aggregate", "the public witness must retain the grouped build child:\n%s", controlPlan)


### PR DESCRIPTION
## What type of PR is this?

- [x] Test and CI

## Which issue(s) this PR fixes:

Related to #25782 (broadcast budget regression coverage).

## What this PR does / why we need it:

Reduce the shared-budget HashBuild recovery fixture from 96 full batches plus a partial tail to 80 plus the same tail (786,944 → 655,872 rows). Tune the hard query budget from 28 MiB to 25 MiB so it still exercises late map-allocation recovery rather than spilling during batch retention. Keep the expression keys, shuffle plan checks, DOP, 4,096-row result oracle, spill assertion, and post-recovery health check.

Add an unmatched probe to the broadcast control so NULL-extension is exercised explicitly. Keep its build size, hard budget, protocol error checks, and no-spill assertions.

Validation:
- Both modified SQL tests pass six final-version race repetitions (two runs of `-count=3`) with coverage instrumentation for `hashbuild`, `hashjoin`, and `process`. All baseline-covered HashBuild/HashJoin blocks remain covered.
- SQL-only coverage varies in process terminal-signal scheduling paths. Existing `TestPipelineEdge*` and `TestPipelineSignalReceiver*` tests pass under race and cover the remaining baseline blocks; combining these unchanged unit tests with the SQL runs leaves no baseline-covered blocks missing in the three measured packages. This is a targeted comparison, not a whole-repository coverage measurement.
- A half-size experiment was rejected because it lost late map-recovery coverage. A 64-batch experiment was also rejected because it lost the selection-allocation error branch.
- Final 80-batch fixture retains both branches. No production code, CI selection, test repetition count, or timeout changes.

This reduces fixture data by approximately 16.7%; it does not claim a measured end-to-end CI speedup. Local wall time varies with cluster startup, and the earlier 272-second CI sample included approximately 242 seconds of cluster admission waiting.
