### PR TITLE
ci: consolidate required checks into one aggregate gate

### DIFF
--- a/.github/ci/change-scope.test.cjs
+++ b/.github/ci/change-scope.test.cjs
@@ -131,7 +131,7 @@ test('a successful eligibility job cannot hide skipped UT coverage', () => {
   }
 });
 
-test('entrypoint routes each scope and preserves every required check name', () => {
+test('entrypoint routes each scope through one required check', () => {
   const workflow = readFileSync(`${__dirname}/../workflows/entrypoint.yaml`, 'utf8');
   const blocks = Object.fromEntries([...workflow.matchAll(/^  ([\w-]+):\n([\s\S]*?)(?=^  [\w-]+:\n|$(?![\s\S]))/gm)]
     .map(match => [match[1], match[2]]));
@@ -159,14 +159,10 @@ test('entrypoint routes each scope and preserves every required check name', () 
   }
   const gates = blocks['ci-required'];
   assert.match(gates, /if: \$\{\{ always\(\)/);
-  for (const name of [
-    'Matrixone CI / UT Test on Ubuntu/x86',
-    'Matrixone CI / SCA Test on Linux/arm64',
-    'Matrixone UT Coverage / UT Coverage on Ubuntu/x86',
-    'Matrixone Compose CI / multi cn e2e bvt test docker compose(PROXY)',
-    'Matrixone Standlone CI / multi CN e2e BVT Test on Linux/x64(COMPOSE, PESSIMISTIC)',
-    'Matrixone Utils CI / Coverage',
-  ]) assert.ok(gates.includes(`- ${name}\n`), name);
+  assert.match(gates, /^    name: CI Required$/m);
+  assert.doesNotMatch(gates, /^    strategy:/m);
+  const gateNeeds = gates.match(/^    needs: \[(.*)\]$/m)[1].split(', ');
+  assert.deepEqual(gateNeeds.slice().sort(), Object.keys(results()).sort());
   for (const job of ['matrixone-ci', 'matrixone-ut-coverage', 'matrixone-compose-ci',
     'matrixone-standalone-ci', 'matrixone-coverage-merge']) {
     assert.match(blocks[job], /name: .* execution\n/);

--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -185,24 +185,13 @@ jobs:
       expected_bvt_generation: ${{ needs.bvt-group-plan.outputs.generation }}
     secrets: inherit
 
-  # Keep all six established required-check names present for every scope.
-  # Each checks the selected suite as an AND gate; failed/cancelled/missing
+  # One required check validates the selected suite as an AND gate; failed/cancelled/missing
   # prerequisites cannot become a green check through dependent-job skipping.
   ci-required:
-    name: ${{ matrix.check }}
+    name: CI Required
     if: ${{ always() && github.base_ref != '3.0-dev' }}
     needs: [check-pr-valid, change-scope, docs-check, bvt-group-plan, matrixone-ci, matrixone-ut-coverage, matrixone-compose-ci, matrixone-standalone-ci, matrixone-coverage-merge]
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        check:
-          - Matrixone CI / UT Test on Ubuntu/x86
-          - Matrixone CI / SCA Test on Linux/arm64
-          - Matrixone UT Coverage / UT Coverage on Ubuntu/x86
-          - Matrixone Compose CI / multi cn e2e bvt test docker compose(PROXY)
-          - Matrixone Standlone CI / multi CN e2e BVT Test on Linux/x64(COMPOSE, PESSIMISTIC)
-          - Matrixone Utils CI / Coverage
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/docs/ci-change-scope.md
+++ b/docs/ci-change-scope.md
@@ -23,13 +23,13 @@ PR base SHA, never the PR head. The documentation job reads the PR diff without
 running PR scripts. The separate scope contract workflow runs without secrets
 and tests changes to the classifier before they reach the trusted base.
 
-The six existing main-branch required-check names are retained by lightweight
-summary jobs. The actual reusable workflow calls are named `... execution` to
-avoid duplicate status names. Each summary requires every job selected by the
-scope to succeed, including classification and PR validation; a skipped,
-cancelled, failed or absent selected job is not a pass. Its summary explicitly
-states the scope and intentional omissions. These are aggregate gates, not
-claims that an omitted suite executed.
+One `CI Required` summary job checks the existing required prerequisites for the
+selected scope, including classification and PR validation. A skipped,
+cancelled, failed or absent required job is not a pass. Its summary explicitly
+states the scope and intentional omissions. Actual test results remain visible
+under the reusable workflow calls named `... execution`. This replaces six
+identical summary jobs with one runner allocation and gives the aggregate result
+a distinct name rather than labeling it as an individual test's result.
 
 The independent UT coverage and merged UT+BVT coverage jobs run only for full
 runs. Scoped runs explicitly report coverage as not evaluated; they do not
@@ -39,8 +39,14 @@ tests can still reduce coverage, so test-only exemptions do not establish that
 coverage has stayed constant. Use a full run when reviewing that risk.
 Existing 3.0-dev routing is unchanged.
 
-No branch-protection changes or CI-repository rollout are required. Because the
-entrypoint uses `pull_request_target`, this routing takes effect after the change
-is merged into the PR target branch, not when testing this PR itself.
+Branch protection must require `CI Required` from GitHub Actions in place of the
+six former aggregate check names. Preserve the existing strict/up-to-date setting
+and unrelated protection rules. Because the entrypoint uses `pull_request_target`,
+the new check appears on runs triggered after this change lands in the target
+branch. Verify a new run emits `CI Required`, then switch protection; until the
+switch, the old required names can remain pending. Old workflow runs do not emit
+the new name and need a new PR event after rollout. No CI-repository change is
+required. Test selection, prerequisite validation and cancellation behavior are
+unchanged.
 
 Local contract validation: `node --test .github/ci/change-scope.test.cjs`.


### PR DESCRIPTION
## What type of PR is this?

- [x] Test and CI

## Which issue(s) this PR fixes:

fix #28419 

## What this PR does / why we need it:

Replace the six identical aggregate jobs introduced by #28543 with one `CI Required` job. This removes five redundant runner allocations per run and stops presenting the aggregate result under individual UT/SCA/BVT/coverage names.

The existing dependency list, scope classifier, prerequisite verifier, trusted-base checkout and cancellation behavior are unchanged. Actual test jobs keep their current execution names. Contract tests enforce one aggregate job and the complete dependency list, while retaining failure/cancellation/skipping/missing-result and coverage-eligibility cases.

Rollout: after merging, verify a new Actions run emits `CI Required`, then replace the six former required contexts in main branch protection with `CI Required` from GitHub Actions (app ID 15368). Preserve strict/up-to-date and unrelated protections. The pull_request_target workflow uses the target branch, so this PR itself still runs the old gates. Until protection is switched, new runs may show the old required names as pending. No CI-repository changes are needed.

Validation: all seven Node contract test groups passed (`node --test .github/ci/change-scope.test.cjs`); `git diff --check` passed. No database tests were needed for this workflow-only consolidation. Live single-job check creation remains a post-merge rollout check.
