### PR TITLE
test: remove unused CDC transaction helper to fix SCA

### DIFF
--- a/pkg/tests/issues/issue_27666_test.go
+++ b/pkg/tests/issues/issue_27666_test.go
@@ -433,11 +433,6 @@ func execInternalSQL(ctx context.Context, sqlExec executor.SQLExecutor, statemen
 	return err
 }
 
-func execInternalTxnSQL(txn executor.TxnExecutor, statement string) error {
-	_, err := execInternalTxnSQLWithAffectedRows(txn, statement)
-	return err
-}
-
 func execInternalTxnSQLWithAffectedRows(txn executor.TxnExecutor, statement string) (uint64, error) {
 	result, err := txn.Exec(statement, executor.StatementOption{}.WithAccountID(0))
 	affectedRows := result.AffectedRows


### PR DESCRIPTION
## What type of PR is this?

- [x] Test and CI

## Which issue(s) this PR fixes:

N/A

## What this PR does / why we need it:

Remove the unused `execInternalTxnSQL` wrapper left by #28542 after its caller switched to `execInternalTxnSQLWithAffectedRows`. The unused declaration fails SCA on main, including the run for #28508: https://github.com/matrixorigin/matrixone/actions/runs/34390127385/job/102596166106.

Only five dead lines are removed. The active transaction helper, assertions, cleanup and test coverage are unchanged.

Validation: repository-wide exact-symbol search confirmed the old function had no callers; the replacement helper retains its caller. `gofmt -l` produced no output and `git diff --check` passed. Full SCA and cluster tests were not rerun locally for this unused-function deletion.
