### PR TITLE
test(logservice): synchronize TestFailedBootstrap

### DIFF
--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -1203,10 +1203,10 @@ func testBootstrap(t *testing.T, fail bool, remoteRecoveryPending bool) {
 		assert.False(t, store.bootstrapMgr.CheckBootstrap(state.LogState))
 
 		if fail {
-			// Move the deadline into the past so this test does not spend the
-			// real multi-minute bootstrap budget.
-			store.bootstrapCheckDeadline = time.Now().Add(-time.Second)
-			store.checkBootstrap(state)
+			// Drive the elapsed-time check through its explicit-time seam rather
+			// than mutating the production-owned deadline.
+			expired := time.Now().Add(store.bootstrapCheckWindow())
+			require.NoError(t, store.checkBootstrapWithSetterAt(expired, state, store.setBootstrapState))
 
 			state, err = store.getCheckerState()
 			require.NoError(t, err)


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [ ] API-change
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28551

## What this PR does / why we need it:

### Root cause

Before the current `main` baseline, `TestFailedBootstrap` directly overwrote `bootstrapCheckDeadline` while the HAKeeper ticker could read it. The broader fixture race is now eliminated by #28554, which runs manual bootstrap tests with workers disabled. This test still bypassed the deadline owner to force expiry instead of using the existing explicit-time bootstrap-check seam.

### Changes

- Drive failure expiry through `checkBootstrapWithSetterAt` with a deliberately expired time.
- Use the production state setter and require that the replicated state transition succeeds.
- Preserve the failure oracle: incomplete bootstrap transitions to `HAKeeperBootstrapFailed`.

### Issue-to-test proof

`TestFailedBootstrap` exercises the same incomplete-bootstrap failure path without mutating the production-owned deadline. The normal bootstrap and remote WAL-recovery consumers of the shared helper remain covered as controls.

### Tests

- `.agents/skills/mo-dev/scripts/mo-cgo-test -list ^(TestFailedBootstrap|TestBootstrap|TestBootstrapWaitsForRemoteWALRecovery)$ ./pkg/logservice`
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=180s -run ^(TestFailedBootstrap|TestBootstrap|TestBootstrapWaitsForRemoteWALRecovery)$ ./pkg/logservice` (passed after rebase onto main@ac660ae56e, 1.545s)
- `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=240s -run ^TestFailedBootstrap$ ./pkg/logservice` (passed after rebase onto main@ac660ae56e, 19.269s)

BVT is not applicable: this is an internal Go test ownership and state-transition contract with no SQL or client-visible behavior.

### Residual risk

Production code is unchanged. #28554 in the base branch owns ticker isolation for manual bootstrap fixtures; this PR is limited to the deadline-driving seam. Fresh Linux CI is required after the rebase.