### PR TITLE
test(logservice): isolate manual HAKeeper bootstrap fixtures

### DIFF
--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -403,10 +403,24 @@ func TestCheckBootstrapWaitsForReplicatedLogServiceRecovery(t *testing.T) {
 }
 
 func runHAKeeperStoreTest(t *testing.T, startLogReplica bool, fn func(*testing.T, *store)) {
+	runHAKeeperStoreTestWithWorkers(t, startLogReplica, true, fn)
+}
+
+func runManualHAKeeperStoreTest(t *testing.T, startLogReplica bool, fn func(*testing.T, *store)) {
+	runHAKeeperStoreTestWithWorkers(t, startLogReplica, false, fn)
+}
+
+func runHAKeeperStoreTestWithWorkers(
+	t *testing.T,
+	startLogReplica bool,
+	workers bool,
+	fn func(*testing.T, *store),
+) {
 	defer leaktest.AfterTest(t)()
 	var cfg Config
 	genCfg := func() Config {
 		cfg = getStoreTestConfig()
+		cfg.DisableWorkers = !workers
 		return cfg
 	}
 	defer vfs.ReportLeakedFD(cfg.FS, t)
@@ -969,7 +983,7 @@ func TestSetInitialClusterInfo(t *testing.T) {
 		assert.Equal(t, uint64(2), state.NextIDByKey["b"])
 		assert.Zero(t, state.NextIDByKey["c"])
 	}
-	runHAKeeperStoreTest(t, false, fn)
+	runManualHAKeeperStoreTest(t, false, fn)
 }
 
 func TestRestoreIDWatermarksRejectsLateLogServiceRecovery(t *testing.T) {
@@ -995,7 +1009,7 @@ func TestRestoreIDWatermarksRejectsLateLogServiceRecovery(t *testing.T) {
 		require.Empty(t, state.NextIDByKey)
 		require.False(t, state.LogServiceRecoveryPending)
 	}
-	runHAKeeperStoreTest(t, false, fn)
+	runManualHAKeeperStoreTest(t, false, fn)
 }
 
 func TestCNAllocateIDRejectsUninitializedHAKeeper(t *testing.T) {
@@ -1009,7 +1023,7 @@ func TestCNAllocateIDRejectsUninitializedHAKeeper(t *testing.T) {
 }
 
 func TestHAKeeperBootstrapErrorUsesConfiguredCadence(t *testing.T) {
-	runHAKeeperStoreTest(t, false, func(t *testing.T, s *store) {
+	runManualHAKeeperStoreTest(t, false, func(t *testing.T, s *store) {
 		require.NoError(t, s.setInitialClusterInfo(1, 1, 1, hakeeper.K8SIDRangeEnd+10, nil, nil))
 		// No LogStore heartbeat: bootstrap cannot place its replica yet. Exercise
 		// the real checker result consumed by the ticker, not a synthetic nil.
@@ -1128,7 +1142,7 @@ func TestRecoveryBootstrapDefersTNUntilCompletion(t *testing.T) {
 		require.Equal(t, pb.TNService, cb.Commands[0].ServiceType)
 		require.False(t, cb.Commands[0].Bootstrapping)
 	}
-	runHAKeeperStoreTest(t, false, fn)
+	runManualHAKeeperStoreTest(t, false, fn)
 }
 
 func testBootstrap(t *testing.T, fail bool, remoteRecoveryPending bool) {
@@ -1259,7 +1273,7 @@ func testBootstrap(t *testing.T, fail bool, remoteRecoveryPending bool) {
 			}
 		}
 	}
-	runHAKeeperStoreTest(t, false, fn)
+	runManualHAKeeperStoreTest(t, false, fn)
 }
 
 func TestTaskSchedulerCanScheduleTasksToCNs(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28550

## What this PR does / why we need it:

### Root cause

`runHAKeeperStoreTest` started the production HAKeeper ticker while several tests directly drove bootstrap transitions on the same `store`. After the ticker cadence was shortened, the two owners could concurrently allocate IDs and advance the replicated state. This caused the reported `idAllocator.Set`/`Next` race, the test callback race, and nondeterministic initial-cluster watermarks.

### Changes

- Split the HAKeeper store fixture into ticker-enabled and manual-bootstrap modes.
- Run tests that directly call bootstrap/checker transitions in manual mode (`DisableWorkers=true`), leaving ticker-dependent task fixtures unchanged.
- Apply manual mode to initial-cluster, restore, bootstrap-cadence, recovery-bootstrap, and shared bootstrap tests.

### Issue-to-test proof

Related to #28550:

- `TestSetInitialClusterInfo` asserts that repeated initial-cluster proposals and rejected watermark restore leave the initial ID watermarks unchanged.
- `TestBootstrapWaitsForRemoteWALRecovery` drives bootstrap through the remote WAL-recovery gate and verifies it remains deterministic.
- Each reported test passed independently under `-race -count=100`; no race was reported.

### Tests

- `mo-cgo-test -race -count=100 -run ^TestSetInitialClusterInfo$ ./pkg/logservice` — PASS (19.430s)
- `mo-cgo-test -race -count=100 -run ^TestBootstrapWaitsForRemoteWALRecovery$ ./pkg/logservice` — PASS (26.378s)
- Focused manual-bootstrap consumer group, normal and `-race` — PASS.
- `GOWORK=off go vet -mod=readonly ./pkg/logservice` with repository CGo include/library paths — PASS.
- Full `pkg/logservice` normal run was attempted but is not a green result: a user-owned local `minio` process occupies `127.0.0.1:9001`, causing the unrelated fixed-port `TestNotHAKeeperErrorIsHandled` startup failure and subsequent suite contamination. The process was not modified.

### Residual risks

This is test-only fixture isolation. Production ticker behavior and ticker-dependent task fixture behavior are unchanged. Linux CI remains the final cross-platform validation.