### PR TITLE
test: remove unused CDC transaction helper

### DIFF
--- a/pkg/tests/issues/issue_27666_test.go
+++ b/pkg/tests/issues/issue_27666_test.go
@@ -433,11 +433,6 @@ func execInternalSQL(ctx context.Context, sqlExec executor.SQLExecutor, statemen
 	return err
 }
 
-func execInternalTxnSQL(txn executor.TxnExecutor, statement string) error {
-	_, err := execInternalTxnSQLWithAffectedRows(txn, statement)
-	return err
-}
-
 func execInternalTxnSQLWithAffectedRows(txn executor.TxnExecutor, statement string) (uint64, error) {
 	result, err := txn.Exec(statement, executor.StatementOption{}.WithAccountID(0))
 	affectedRows := result.AffectedRows


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28487

## What this PR does / why we need it:

Remove the unused `execInternalTxnSQL` test helper. After #28542 switched its caller to `execInternalTxnSQLWithAffectedRows`, the wrapper had no callers and caused golangci-lint's `unused` check to fail, including on unrelated PRs.

The existing affected-row helper and all test assertions remain unchanged. This PR deletes only five lines from one test file.

Validation: repository-wide exact-symbol search confirms the removed function had no callers; formatting and `git diff --check` pass. The reported failure is recorded in [the SCA job](https://github.com/matrixorigin/matrixone/actions/runs/34404948785/job/102645619965). A prior local package lint attempt was blocked by missing native `jemalloc.h`; full SCA is pending CI, not claimed as locally passing.
