### PR TITLE
ci: shard race UT suite

### DIFF
--- a/.github/ci/change-scope.test.cjs
+++ b/.github/ci/change-scope.test.cjs
@@ -96,6 +96,12 @@ function results() {
   return needs;
 }
 
+function entrypointJobs() {
+  const workflow = readFileSync(`${__dirname}/../workflows/entrypoint.yaml`, 'utf8');
+  return Object.fromEntries([...workflow.matchAll(/^  ([\w-]+):\n([\s\S]*?)(?=^  [\w-]+:\n|$(?![\s\S]))/gm)]
+    .map(match => [match[1], match[2]]));
+}
+
 test('gates accept intentional omissions but reject failed, cancelled, skipped or missing required work', () => {
   const jobs = {
     docs: ['docs-check'], ut: ['matrixone-ci'],
@@ -132,9 +138,7 @@ test('a successful eligibility job cannot hide skipped UT coverage', () => {
 });
 
 test('entrypoint routes each scope through one required check', () => {
-  const workflow = readFileSync(`${__dirname}/../workflows/entrypoint.yaml`, 'utf8');
-  const blocks = Object.fromEntries([...workflow.matchAll(/^  ([\w-]+):\n([\s\S]*?)(?=^  [\w-]+:\n|$(?![\s\S]))/gm)]
-    .map(match => [match[1], match[2]]));
+  const blocks = entrypointJobs();
   const routed = ['docs-check', 'bvt-group-plan', 'matrixone-shared-build', 'matrixone-ci',
     'matrixone-ut-coverage', 'matrixone-upgrade-ci', 'matrixone-compose-ci',
     'matrixone-standalone-ci', 'matrixone-coverage-merge'];
@@ -172,4 +176,10 @@ test('entrypoint routes each scope through one required check', () => {
     assert.match(blocks[job], /ref: \$\{\{ github.event.pull_request.base.sha \}\}/);
     assert.match(blocks[job], /persist-credentials: false/);
   }
+});
+
+test('entrypoint enables the complete race-UT shard contract', () => {
+  const caller = entrypointJobs()['matrixone-ci'];
+  assert.match(caller, /^    uses: matrixorigin\/CI\/\.github\/workflows\/ci\.yaml@main$/m);
+  assert.match(caller, /^    with:\n      ut_parallel: 6\n      ut_sharded: true$/m);
 });

--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -120,6 +120,7 @@ jobs:
     uses: matrixorigin/CI/.github/workflows/ci.yaml@main
     with:
       ut_parallel: 6
+      ut_sharded: true
     secrets: inherit
 
   matrixone-ut-coverage:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28538

## What this PR does / why we need it:

### Root cause

The MatrixOne workflow called the reusable CI workflow without its existing `ut_sharded` input. The reusable workflow therefore executed `UT_SHARD=all`: light, issues, embedded, heavy, and plan stages shared one 70-minute outer deadline. Three observed runs exhausted that aggregate deadline in different stages without a terminal test failure or race report.

### Changes

Enable the reusable workflow four-way race-UT contract. It runs the complete, disjoint `light`, `issues`, `embedded`, and `heavy-plan` stage groups in separate jobs and retains the existing aggregate required check. Add a workflow-contract unit test that locks the caller input; refactor the existing job parser so both workflow tests share it.

### Issue-to-test proof

`entrypoint enables the complete race-UT shard contract` proves the caller supplies `ut_sharded: true` with the established per-runner parallelism. `TestUTShardStagesFormCompleteDisjointMap` proves those target groups are a complete, non-overlapping partition; its negative companion rejects unknown routing values.

### Tests

Rebased onto `269d59addd032d20897cc4d86f58de3e387a6d76` and reran:

- `node --test .github/ci/change-scope.test.cjs`
- `GOWORK=off go test -mod=readonly -v -count=1 -timeout=120s ./optools`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/entrypoint.yaml`
- Ruby YAML parse and `git diff --check`\n- MatrixOne ALL CI run 34446145941 completed successfully, including `CI Required` and the Ubuntu/x86 race-UT check; as documented below, `pull_request_target` ran the trusted base caller, not this changed caller input.

### Residual risk

The change uses four runners rather than one, as designed by the reusable workflow. This repository uses `pull_request_target`, so the CI run for this Draft PR evaluates the trusted base caller and cannot exercise the changed `ut_sharded` input. Target-runner confirmation therefore requires the first post-merge CI run or a CI-owner-dispatched sharded run; the change preserves per-test and timeout diagnostics instead of masking failures.