### PR TITLE
fix(objectio): compact multi-term read filter marks

### DIFF
--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/bits"
 	"slices"
 	"sort"
 
@@ -510,18 +511,29 @@ func (s *ReadFilterSearch) search(source *vector.Vector, sorted bool) []int64 {
 	if len(s.terms) == 1 {
 		return s.terms[0].search(source, sorted)
 	}
-	marks := make([]int64, source.Length())
+	// Keep one bit per source row while unioning the term matches. The old
+	// int64-per-row mark array dominated allocations for large object blocks;
+	// a bitset preserves the same row-order semantics at 1/64 of the size.
+	marks := make([]uint64, (source.Length()+63)/64)
 	for i := range s.terms {
 		for _, row := range s.terms[i].search(source, sorted) {
-			if row >= 0 && row < int64(len(marks)) {
-				marks[row] = 1
+			if row >= 0 && row < int64(source.Length()) {
+				index := uint64(row)
+				marks[index>>6] |= uint64(1) << (index & 63)
 			}
 		}
 	}
-	rows := marks[:0]
-	for row, matched := range marks {
-		if matched != 0 {
-			rows = append(rows, int64(row))
+
+	matchedRows := 0
+	for _, word := range marks {
+		matchedRows += bits.OnesCount64(word)
+	}
+	rows := make([]int64, 0, matchedRows)
+	for wordIndex, word := range marks {
+		for word != 0 {
+			bit := bits.TrailingZeros64(word)
+			rows = append(rows, int64(wordIndex*64+bit))
+			word &= word - 1
 		}
 	}
 	return rows

--- a/pkg/objectio/funcs_test.go
+++ b/pkg/objectio/funcs_test.go
@@ -1020,6 +1020,41 @@ func TestReadFilterPrefixSearchDoesNotAllocatePerBlockRow(t *testing.T) {
 	)
 }
 
+func TestCombinedReadFilterSearchDoesNotAllocatePerBlockRow(t *testing.T) {
+	const rowCount = 8192
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+	source := vector.NewVec(types.T_varchar.ToType())
+	for row := 0; row < rowCount; row++ {
+		require.NoError(t, vector.AppendBytes(
+			source,
+			[]byte(fmt.Sprintf("key-%05d", row)),
+			false,
+			mp,
+		))
+	}
+	defer source.Free(mp)
+	search := CombineReadFilterSearch(
+		NewReadFilterSearch(types.T_varchar, [][]byte{[]byte("key-00123")}),
+		NewReadFilterSearch(types.T_varchar, [][]byte{[]byte("key-07111")}),
+	)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rows := search.search(source, true)
+			if len(rows) != 2 || rows[0] != 123 || rows[1] != 7111 {
+				b.Fatalf("unexpected exact hits: %v", rows)
+			}
+		}
+	})
+	require.Less(
+		t,
+		result.AllocedBytesPerOp(),
+		int64(16<<10),
+		"combined exact search must not allocate an int64 mark per source row",
+	)
+}
+
 func TestColumnCacheConstructorRejectsInvalidV2BeforeAdmission(t *testing.T) {
 	mp := mpool.MustNewZero()
 	source := vector.NewVec(types.T_varchar.ToType())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28609

## What this PR does / why we need it:

`ReadFilterSearch` used one `int64` marker per source row when merging multiple filter terms. For large object blocks this created substantial allocation churn and GC CPU. This PR replaces the row marker array with a compact bitset, preserves ascending row-order output, and allocates the result slice to its exact match count. It also adds a regression test that checks combined searches do not allocate a block-sized marker array.

Tests:

- `go test ./pkg/objectio -count=1`
