### PR TITLE
perf(plan): reduce redundant scans with scalar fusion and bounded runtime filters

### DIFF
--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -3793,6 +3793,12 @@ func (builder *QueryBuilder) createQuery() (*Query, error) {
 		colRefCnt := make(map[[2]int32]int)
 		builder.countColRefs(rootID, colRefCnt)
 		builder.removeSimpleProjections(rootID, plan.Node_UNKNOWN, false, colRefCnt)
+		var fusedScalarAggs bool
+		rootID, fusedScalarAggs = builder.fuseScalarAggregates(rootID)
+		if fusedScalarAggs {
+			colRefCnt = make(map[[2]int32]int)
+			builder.countColRefs(rootID, colRefCnt)
+		}
 		// Removing a proof-eliminated aggregate can expose a direct Project ->
 		// TableScan edge only after the first limit-pushdown pass. Re-run the
 		// idempotent rule so the newly streaming path can honor source demand.

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -663,7 +663,6 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 	}
 
 	if len(probeExprs) == 1 {
-		convertToCPKey := false
 		tableDef := leftChild.TableDef
 		if tableDef == nil || tableDef.Pkey == nil {
 			return
@@ -673,6 +672,7 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 			return
 		}
 		sortOrder := GetSortOrder(tableDef, probeCol.ColPos)
+		componentFilter := false
 		// LOCAL_COLOCATED gives up multi-CN scan bandwidth.  In phase 1 only
 		// enable right-SINGLE on the leading PK/cluster key, where exact IN can
 		// prune ranges predictably.  A scattered non-key filter may still scan
@@ -694,8 +694,11 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 					return
 				}
 			} else {
-				if len(tableDef.Pkey.Names) > 1 && probeCol.Name != catalog.CPrimaryKeyColName {
-					convertToCPKey = true
+				componentFilter = len(tableDef.Pkey.Names) > 1 && probeCol.Name != catalog.CPrimaryKeyColName
+				// Newly admit component filtering only without a placement
+				// downgrade or suppressing fallible/volatile scan predicates.
+				if componentFilter && (policy.requiresLocalDelivery || !areTruncationSafePredicates(leftChild.FilterList)) {
+					return
 				}
 			}
 			//todo: need to fix this in the future
@@ -708,10 +711,20 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 			return
 		}
 
+		// A leading composite-key component can use its own zonemap and an
+		// ordinary column IN predicate. It is not the serialized full key:
+		// keep NotOnPk so the scan also applies exact row filtering, without
+		// routing this partial key through primary-key lookup or prefix IN.
 		notOnPk := probeCol.Name != tableDef.Pkey.PkeyColName
 		inLimit := GetInFilterCardLimit(sid)
-		if sortOrder == 0 {
+		if sortOrder == 0 && !componentFilter {
 			inLimit = GetInFilterCardLimitOnPK(sid, leftChild.Stats.TableCnt)
+		}
+		// Components need ordinary-column row filtering, not full-PK lookup.
+		// Keep its configured budget; a wrong low estimate still falls back to
+		// PASS when HashBuild observes more actual keys than this limit.
+		if componentFilter && node.Stats.HashmapStats.HashmapSize > float64(inLimit) {
+			return
 		}
 		// Placement is decided before hashbuild knows the actual number of
 		// unique keys.  If the planner already knows the build cannot fit in an
@@ -720,10 +733,6 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 		if !builder.rightSingleLocalDeliveryIsSafe(node, rightChild, inLimit) {
 			return
 		}
-		if convertToCPKey {
-			return
-		}
-
 		buildExpr := &plan.Expr{
 			Typ: buildExprs[0].Typ,
 			Expr: &plan.Expr_Col{

--- a/pkg/sql/plan/runtime_filter_test.go
+++ b/pkg/sql/plan/runtime_filter_test.go
@@ -154,18 +154,12 @@ func TestCompositeLeadingColumnRuntimeFilter(t *testing.T) {
 		mutate func(*QueryBuilder)
 		want   bool
 	}{
-		{name: "leading component uses ordinary column IN", want: true},
+		{name: "leading component at ordinary-column budget", want: true},
 		{name: "below ordinary-column budget", want: true, mutate: func(b *QueryBuilder) {
 			b.qry.Nodes[2].Stats.HashmapStats.HashmapSize = 2
 		}},
 		{name: "above ordinary-column budget", mutate: func(b *QueryBuilder) {
 			b.qry.Nodes[2].Stats.HashmapStats.HashmapSize = 4
-		}},
-		{name: "semi join", want: true, mutate: func(b *QueryBuilder) {
-			b.qry.Nodes[2].JoinType = planpb.Node_SEMI
-		}},
-		{name: "left join preserves probe", mutate: func(b *QueryBuilder) {
-			b.qry.Nodes[2].JoinType = planpb.Node_LEFT
 		}},
 		{name: "right semi retains distributed placement", mutate: func(b *QueryBuilder) {
 			b.qry.Nodes[2].JoinType = planpb.Node_SEMI

--- a/pkg/sql/plan/runtime_filter_test.go
+++ b/pkg/sql/plan/runtime_filter_test.go
@@ -136,6 +136,116 @@ func configureRuntimeFilterCompositePK(builder *QueryBuilder) (*planpb.Node, *pl
 	return probe, build
 }
 
+func TestCompositeLeadingColumnRuntimeFilter(t *testing.T) {
+	// Use a small configured budget to test the boundary without large data or
+	// inventing statistics for an actual table. Restore the shared mock runtime.
+	rt := moruntime.ServiceRuntime(newRuntimeFilterSingleTestBuilder(false).compCtx.GetProcess().GetService())
+	originalLimit, hadLimit := rt.GetGlobalVariables("runtime_filter_limit_in")
+	rt.SetGlobalVariables("runtime_filter_limit_in", int64(3))
+	t.Cleanup(func() {
+		if hadLimit {
+			rt.SetGlobalVariables("runtime_filter_limit_in", originalLimit)
+		} else {
+			rt.CompareAndDeleteGlobalVariables("runtime_filter_limit_in", int64(3))
+		}
+	})
+	tests := []struct {
+		name   string
+		mutate func(*QueryBuilder)
+		want   bool
+	}{
+		{name: "leading component uses ordinary column IN", want: true},
+		{name: "below ordinary-column budget", want: true, mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[2].Stats.HashmapStats.HashmapSize = 2
+		}},
+		{name: "above ordinary-column budget", mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[2].Stats.HashmapStats.HashmapSize = 4
+		}},
+		{name: "semi join", want: true, mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[2].JoinType = planpb.Node_SEMI
+		}},
+		{name: "left join preserves probe", mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[2].JoinType = planpb.Node_LEFT
+		}},
+		{name: "right semi retains distributed placement", mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[2].JoinType = planpb.Node_SEMI
+			b.qry.Nodes[2].IsRightJoin = true
+		}},
+		{name: "fallible scan predicate is not truncated", mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[0].FilterList = []*planpb.Expr{
+				makeMixedSideRuntimeFilterResidual(b.qry.Nodes[0].TableDef.Cols[0].Typ, 1, 1),
+			}
+		}},
+		{name: "nonleading component retains cost gate", mutate: func(b *QueryBuilder) {
+			col := b.qry.Nodes[2].OnList[0].GetF().Args[0].GetCol()
+			col.ColPos, col.Name = 1, "b"
+		}},
+		{name: "unselective build retains cost gate", mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[2].Stats.HashmapStats.HashmapSize = 100
+		}},
+		{name: "incompatible equality representation", mutate: func(b *QueryBuilder) {
+			b.qry.Nodes[2].OnList[0].GetF().Args[1].Typ.Id = int32(types.T_uint64)
+		}},
+		{name: "disabled by optimizer hint", mutate: func(b *QueryBuilder) {
+			b.optimizerHints = &OptimizerHints{runtimeFilter: 1}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder := newRuntimeFilterSingleTestBuilder(false)
+			probe, _ := configureRuntimeFilterCompositePK(builder)
+			join := builder.qry.Nodes[2]
+			join.JoinType = planpb.Node_INNER
+			join.OnList = join.OnList[:1]
+			join.OnList[0].GetF().Args[0].GetCol().Name = "a"
+			if test.mutate != nil {
+				test.mutate(builder)
+			}
+			builder.generateRuntimeFilters(2)
+			if !test.want {
+				require.Empty(t, join.RuntimeFilterBuildList)
+				require.Empty(t, probe.RuntimeFilterProbeList)
+				return
+			}
+			require.Len(t, join.RuntimeFilterBuildList, 1)
+			require.Len(t, probe.RuntimeFilterProbeList, 1)
+			buildSpec, probeSpec := join.RuntimeFilterBuildList[0], probe.RuntimeFilterProbeList[0]
+			require.Equal(t, buildSpec.Tag, probeSpec.Tag)
+			require.True(t, probeSpec.NotOnPk, "a component must not use full primary-key lookup")
+			require.True(t, buildSpec.NotOnPk)
+			require.False(t, probeSpec.MatchPrefix)
+			require.Equal(t, int32(0), probeSpec.Expr.GetCol().ColPos)
+			require.Equal(t, int32(types.T_int64), probeSpec.Expr.Typ.Id)
+			require.Equal(t, planpb.RuntimeFilterKeyEncoding_RUNTIME_FILTER_KEY_RAW_V1, buildSpec.KeyEncoding)
+			require.Equal(t, int32(3), buildSpec.UpperLimit)
+		})
+	}
+}
+
+func TestCompositeRuntimeFilterResolvesHiddenKeyBeforeAdmission(t *testing.T) {
+	builder := newRuntimeFilterSingleTestBuilder(false)
+	probe, build := configureRuntimeFilterCompositePK(builder)
+	builder.compCtx = &statsCacheCompilerContext{
+		MockCompilerContext: builder.compCtx.(*MockCompilerContext),
+		statsCache:          NewStatsCache(),
+	}
+	builder.tag2Table = map[int32]*TableDef{1: probe.TableDef, 2: build.TableDef}
+	join := builder.qry.Nodes[2]
+	join.JoinType = planpb.Node_INNER
+	keyType := probe.TableDef.Cols[2].Typ
+	build.TableDef.Cols[0].Typ = keyType
+	join.OnList = []*planpb.Expr{makeRuntimeFilterTestEq(keyType, 1, 2, 2, 0)}
+	// Resolving NDV also supplies the initially absent column name. This is
+	// the full serialized key, not a component subject to the new admission.
+	probe.FilterList = []*planpb.Expr{makeMixedSideRuntimeFilterResidual(probe.TableDef.Cols[0].Typ, 1, 1)}
+	builder.generateRuntimeFilters(2)
+	require.Equal(t, catalog.CPrimaryKeyColName, join.OnList[0].GetF().Args[0].GetCol().Name)
+	require.Len(t, join.RuntimeFilterBuildList, 1)
+	require.Len(t, probe.RuntimeFilterProbeList, 1)
+	require.False(t, probe.RuntimeFilterProbeList[0].NotOnPk)
+	require.Equal(t, GetInFilterCardLimitOnPK(builder.compCtx.GetProcess().GetService(), probe.Stats.TableCnt), join.RuntimeFilterBuildList[0].UpperLimit)
+}
+
 func TestRightSingleRuntimeFilterSemanticAndDeliveryContract(t *testing.T) {
 	t.Run("right single filters only the discardable probe and is colocated", func(t *testing.T) {
 		builder := newRuntimeFilterSingleTestBuilder(true)
@@ -1487,7 +1597,7 @@ func TestRightSingleRuntimeFilterConservativeEligibility(t *testing.T) {
 			join.RuntimeFilterBuildList[0].KeyComponentProbeTypes)
 	})
 
-	t.Run("leading composite prefix is omitted until HashBuild can materialize it", func(t *testing.T) {
+	t.Run("leading composite component does not introduce local-only placement", func(t *testing.T) {
 		builder := newRuntimeFilterSingleTestBuilder(true)
 		probe, _ := configureRuntimeFilterCompositePK(builder)
 		builder.qry.Nodes[2].OnList = builder.qry.Nodes[2].OnList[:1]

--- a/pkg/sql/plan/scalar_agg_fusion.go
+++ b/pkg/sql/plan/scalar_agg_fusion.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"github.com/gogo/protobuf/proto"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+)
+
+// fuseScalarAggregates combines adjacent scalar aggregates over the same bag
+// input. Global aggregates without HAVING always emit exactly one row, even on
+// empty input. Thus (X LEFT JOIN agg1(R) ON true) LEFT JOIN agg2(R) ON true
+// needs only one aggregate carrying both sets of results. The same holds for
+// an unconditional INNER join of the two singleton relations.
+//
+// This is input equality, not semi-join containment: matching only the set of
+// keys would lose multiplicity. Keep the first version to identical filtered
+// base scans and fixed-state numeric aggregates; do not broaden predicates or
+// introduce a materialized producer. No cardinality estimate proves legality.
+func (builder *QueryBuilder) fuseScalarAggregates(nodeID int32) (int32, bool) {
+	remap := make(map[[2]int32]*planpb.Expr)
+	var visit func(int32) int32
+	visit = func(id int32) int32 {
+		node := builder.qry.Nodes[id]
+		for i, child := range node.Children {
+			node.Children[i] = visit(child)
+		}
+		if !scalarAggUnconditionalJoin(node) {
+			return id
+		}
+		leftID := node.Children[0]
+		left := builder.qry.Nodes[leftID]
+		keep := left
+		if scalarAggUnconditionalJoin(left) {
+			keep = builder.qry.Nodes[left.Children[1]]
+		}
+		drop := builder.qry.Nodes[node.Children[1]]
+		keepScan, ok := builder.scalarAggInput(keep)
+		if !ok {
+			return id
+		}
+		dropScan, ok := builder.scalarAggInput(drop)
+		if !ok || keep.BindingTags[1] == drop.BindingTags[1] ||
+			!sameScalarAggInput(keepScan, dropScan) {
+			return id
+		}
+		mapping := map[int32]int32{dropScan.BindingTags[0]: keepScan.BindingTags[0]}
+		for i, agg := range drop.AggList {
+			mapped, _ := remapSemiContainmentExpr(agg, mapping, true)
+			pos := int32(len(keep.AggList))
+			keep.AggList = append(keep.AggList, mapped)
+			remap[[2]int32{drop.BindingTags[1], int32(i)}] =
+				GetColExpr(agg.Typ, keep.BindingTags[1], pos)
+		}
+		return leftID
+	}
+	root := visit(nodeID)
+	if len(remap) == 0 {
+		return root, false
+	}
+	// A previously fused right subtree may itself be fused into a left one.
+	// Resolve the complete output map before visiting consumers, so references
+	// to the first eliminated aggregate cannot stop at another eliminated tag.
+	var resolve func([2]int32) *planpb.Expr
+	resolve = func(key [2]int32) *planpb.Expr {
+		expr := remap[key]
+		col := expr.GetCol()
+		next := [2]int32{col.RelPos, col.ColPos}
+		if remap[next] != nil {
+			expr = resolve(next)
+			remap[key] = expr
+		}
+		return expr
+	}
+	for key := range remap {
+		resolve(key)
+	}
+	builder.applyEffectlessAggRemap(root, remap)
+	return root, true
+}
+
+func scalarAggUnconditionalJoin(node *planpb.Node) bool {
+	if node.NodeType != planpb.Node_JOIN || len(node.Children) != 2 ||
+		(node.JoinType != planpb.Node_INNER && node.JoinType != planpb.Node_LEFT) ||
+		!scalarAggPlainNode(node) || len(node.BindingTags) != 0 || len(node.FilterList) != 0 {
+		return false
+	}
+	for _, expr := range node.OnList {
+		lit := expr.GetLit()
+		if lit == nil || lit.Isnull || !lit.GetBval() || lit.Src != nil ||
+			types.T(expr.Typ.Id) != types.T_bool {
+			return false
+		}
+	}
+	return true
+}
+
+func scalarAggPlainNode(node *planpb.Node) bool {
+	return len(node.ProjectList) == 0 && node.Limit == nil && node.Offset == nil &&
+		len(node.OrderBy) == 0 && len(node.RuntimeFilterProbeList) == 0 &&
+		len(node.RuntimeFilterBuildList) == 0 && len(node.SendMsgList) == 0 &&
+		len(node.RecvMsgList) == 0 && !node.IsEnd && !node.NotCacheable &&
+		node.SampleFunc == nil && node.ExtraOptions == ""
+}
+
+func (builder *QueryBuilder) scalarAggInput(agg *planpb.Node) (*planpb.Node, bool) {
+	if agg.NodeType != planpb.Node_AGG || len(agg.Children) != 1 ||
+		len(agg.BindingTags) != 2 || len(agg.GroupBy) != 0 || len(agg.GroupingFlag) != 0 ||
+		len(agg.FilterList) != 0 || len(agg.AggList) == 0 || !scalarAggPlainNode(agg) {
+		return nil, false
+	}
+	scan := builder.qry.Nodes[agg.Children[0]]
+	if scan.NodeType != planpb.Node_TABLE_SCAN || len(scan.Children) != 0 ||
+		len(scan.BindingTags) != 1 || scan.ObjRef == nil || scan.TableDef == nil ||
+		!scalarAggPlainNode(scan) || scan.ParentObjRef != nil ||
+		scan.IndexReaderParam != nil || scan.ClusterTable != nil || scan.ExternScan != nil ||
+		(scan.TableDef.TableType != "" && scan.TableDef.TableType != catalog.SystemOrdinaryRel) ||
+		scan.ObjRef.SchemaName == catalog.MO_CATALOG {
+		return nil, false
+	}
+	for _, filter := range scan.FilterList {
+		if !isTruncationSafePredicateExpr(filter) ||
+			!scalarAggLocalExpr(filter, scan.BindingTags[0]) {
+			return nil, false
+		}
+	}
+	for _, expr := range agg.AggList {
+		fn := expr.GetF()
+		if fn == nil || fn.Func == nil || uint64(fn.Func.Obj)&function.Distinct != 0 || len(fn.Args) != 1 {
+			return nil, false
+		}
+		id, _ := function.DecodeOverloadID(fn.Func.Obj)
+		switch id {
+		case function.COUNT, function.STARCOUNT, function.SUM, function.AVG, function.MIN, function.MAX:
+		default:
+			return nil, false
+		}
+		arg := fn.Args[0]
+		typ := types.T(arg.Typ.Id)
+		if (!typ.IsInteger() && !typ.IsFloat() && !typ.IsDecimal()) ||
+			(arg.GetCol() == nil && arg.GetLit() == nil) ||
+			!scalarAggLocalExpr(arg, scan.BindingTags[0]) {
+			return nil, false
+		}
+	}
+	return scan, true
+}
+
+// Require every column to belong to the admitted base scan. In particular an
+// equal-looking correlated expression or a prepared literal with executable
+// provenance must not become an input-equality proof.
+func scalarAggLocalExpr(expr *planpb.Expr, tag int32) bool {
+	if expr == nil || expr.AuxId < 0 {
+		return false
+	}
+	switch v := expr.Expr.(type) {
+	case *planpb.Expr_Col:
+		return v.Col != nil && v.Col.RelPos == tag
+	case *planpb.Expr_Lit:
+		return v.Lit != nil && v.Lit.Src == nil
+	case *planpb.Expr_F:
+		for _, arg := range v.F.Args {
+			if !scalarAggLocalExpr(arg, tag) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func sameScalarAggInput(left, right *planpb.Node) bool {
+	if !sameSemiContainmentScan(left, right) || !proto.Equal(left.TableDef, right.TableDef) ||
+		!proto.Equal(&left.IndexScanInfo, &right.IndexScanInfo) ||
+		len(left.FilterList) != len(right.FilterList) {
+		return false
+	}
+	mapping := map[int32]int32{right.BindingTags[0]: left.BindingTags[0]}
+	for i, filter := range right.FilterList {
+		mapped, ok := remapSemiContainmentExpr(filter, mapping, true)
+		if !ok || !scalarAggExprEqual(left.FilterList[i], mapped) {
+			return false
+		}
+	}
+	return true
+}
+
+func scalarAggExprEqual(left, right *planpb.Expr) bool {
+	if !sameSemiContainmentType(left.Typ, right.Typ) || !exprStructuralEqual(left, right) {
+		return false
+	}
+	if fn := left.GetF(); fn != nil {
+		for i, arg := range fn.Args {
+			if !scalarAggExprEqual(arg, right.GetF().Args[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/sql/plan/scalar_agg_fusion_test.go
+++ b/pkg/sql/plan/scalar_agg_fusion_test.go
@@ -34,16 +34,9 @@ func TestFuseScalarAggregatesPlan(t *testing.T) {
 		 (select avg(b.l_extendedprice) from lineitem b where b.l_quantity > 1),
 		 (select avg(c.l_discount) from lineitem c where c.l_quantity > 1)
 		 from nation where n_nationkey = 1`, 1},
-		{"derived scalar cross join", `select a.c, b.s from
-		 (select count(*) c from lineitem where l_quantity > 1) a,
-		 (select sum(l_extendedprice) s from lineitem where l_quantity > 1) b`, 1},
 		{"different filters", `select
 		 (select count(*) from lineitem where l_quantity > 1),
 		 (select avg(l_extendedprice) from lineitem where l_quantity > 2)`, 2},
-		{"nested right aggregate references", `select a.c, b.s, b.m from
-		 (select count(*) c from lineitem) a,
-		 (select s, m from (select sum(l_extendedprice) s from lineitem) c,
-		                  (select max(l_quantity) m from lineitem) d) b`, 1},
 		{"having can remove scalar row", `select
 		 (select count(*) from lineitem having count(*) > 0),
 		 (select avg(l_extendedprice) from lineitem)`, 2},

--- a/pkg/sql/plan/scalar_agg_fusion_test.go
+++ b/pkg/sql/plan/scalar_agg_fusion_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuseScalarAggregatesPlan(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		sql   string
+		scans int
+	}{
+		{"same filtered input", `select
+		 (select count(*) from lineitem a where a.l_quantity > 1),
+		 (select avg(b.l_extendedprice) from lineitem b where b.l_quantity > 1),
+		 (select avg(c.l_discount) from lineitem c where c.l_quantity > 1)
+		 from nation where n_nationkey = 1`, 1},
+		{"derived scalar cross join", `select a.c, b.s from
+		 (select count(*) c from lineitem where l_quantity > 1) a,
+		 (select sum(l_extendedprice) s from lineitem where l_quantity > 1) b`, 1},
+		{"different filters", `select
+		 (select count(*) from lineitem where l_quantity > 1),
+		 (select avg(l_extendedprice) from lineitem where l_quantity > 2)`, 2},
+		{"nested right aggregate references", `select a.c, b.s, b.m from
+		 (select count(*) c from lineitem) a,
+		 (select s, m from (select sum(l_extendedprice) s from lineitem) c,
+		                  (select max(l_quantity) m from lineitem) d) b`, 1},
+		{"having can remove scalar row", `select
+		 (select count(*) from lineitem having count(*) > 0),
+		 (select avg(l_extendedprice) from lineitem)`, 2},
+		{"grouped subquery", `select
+		 (select count(*) from lineitem group by l_orderkey),
+		 (select avg(l_extendedprice) from lineitem)`, 2},
+		{"distinct has a separate state contract", `select
+		 (select count(distinct l_orderkey) from lineitem),
+		 (select avg(l_extendedprice) from lineitem)`, 2},
+		{"fallible aggregate argument", `select
+		 (select count(*) from lineitem),
+		 (select sum(1 / l_quantity) from lineitem)`, 2},
+		{"volatile predicate", `select
+		 (select count(*) from lineitem where rand() > 0.5),
+		 (select avg(l_extendedprice) from lineitem where rand() > 0.5)`, 2},
+		{"correlated subquery", `select
+		 (select count(*) from lineitem where l_orderkey = n_nationkey),
+		 (select avg(l_extendedprice) from lineitem where l_orderkey = n_nationkey)
+		 from nation`, 2},
+		{"join condition observes both scalar rows", `select a.c, b.s from
+		 (select count(*) c from lineitem) a left join
+		 (select sum(l_extendedprice) s from lineitem) b on a.c = b.s`, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := runOneStmt(NewMockOptimizer(false), t, tc.sql)
+			require.NoError(t, err)
+			require.Equal(t, tc.scans, countReachableTableScans(p.GetQuery(), "lineitem"))
+		})
+	}
+}
+
+func TestFuseScalarAggregatesBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*planpb.Node, *planpb.Node)
+	}{
+		{"different snapshot", func(_, scan *planpb.Node) { scan.ScanSnapshot = &planpb.Snapshot{} }},
+		{"limited input", func(_, scan *planpb.Node) { scan.Limit = makePlan2Int64ConstExprWithType(1) }},
+		{"zero limit on aggregate", func(agg, _ *planpb.Node) { agg.Limit = makePlan2Int64ConstExprWithType(0) }},
+		{"offset removes singleton", func(agg, _ *planpb.Node) { agg.Offset = makePlan2Int64ConstExprWithType(1) }},
+		{"sample is not identical input", func(_, scan *planpb.Node) { scan.SampleFunc = &planpb.SampleFuncSpec{} }},
+		{"different table", func(_, scan *planpb.Node) { scan.ObjRef.Obj++ }},
+		{"external relation", func(_, scan *planpb.Node) { scan.TableDef.TableType = "e" }},
+		{"unbound argument", func(agg, _ *planpb.Node) { agg.AggList[0].GetF().Args[0].GetCol().RelPos = 100 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := scalarFusionTestBuilder()
+			tc.mutate(builder.qry.Nodes[3], builder.qry.Nodes[2])
+			root, changed := builder.fuseScalarAggregates(4)
+			require.False(t, changed)
+			require.Equal(t, int32(4), root)
+			require.Len(t, builder.qry.Nodes[1].AggList, 1)
+		})
+	}
+}
+
+func TestFuseScalarAggregatesTransitiveOutputRemap(t *testing.T) {
+	builder := scalarFusionTestBuilder()
+	query := builder.qry
+	// (A CROSS B) is itself the right child of C CROSS (A CROSS B).
+	scan := DeepCopyNode(query.Nodes[0])
+	scan.NodeId = 5
+	scan.BindingTags = []int32{30}
+	agg := DeepCopyNode(query.Nodes[1])
+	agg.NodeId = 6
+	agg.Children = []int32{5}
+	agg.BindingTags = []int32{31, 32}
+	agg.AggList[0].GetF().Args[0].GetCol().RelPos = 30
+	query.Nodes = append(query.Nodes, scan, agg,
+		&planpb.Node{NodeId: 7, NodeType: planpb.Node_JOIN, JoinType: planpb.Node_INNER, Children: []int32{6, 4}},
+		&planpb.Node{NodeId: 8, NodeType: planpb.Node_PROJECT, Children: []int32{7}, ProjectList: []*planpb.Expr{
+			GetColExpr(agg.AggList[0].Typ, 32, 0),
+			GetColExpr(agg.AggList[0].Typ, 12, 0),
+			GetColExpr(agg.AggList[0].Typ, 22, 0),
+		}})
+	root, changed := builder.fuseScalarAggregates(8)
+	require.True(t, changed)
+	require.Equal(t, int32(8), root)
+	require.Equal(t, []int32{6}, query.Nodes[8].Children)
+	require.Len(t, agg.AggList, 3)
+	for i, expr := range query.Nodes[8].ProjectList {
+		require.Equal(t, int32(32), expr.GetCol().RelPos)
+		require.Equal(t, int32(i), expr.GetCol().ColPos)
+		require.Equal(t, int32(30), agg.AggList[i].GetF().Args[0].GetCol().RelPos)
+	}
+	_, changed = builder.fuseScalarAggregates(root)
+	require.False(t, changed, "the pass must be idempotent")
+}
+
+func scalarFusionTestBuilder() *QueryBuilder {
+	query := &planpb.Query{}
+	for _, tag := range []int32{10, 20} {
+		scanID := int32(len(query.Nodes))
+		typ := planpb.Type{Id: int32(types.T_int32)}
+		query.Nodes = append(query.Nodes, &planpb.Node{
+			NodeId: scanID, NodeType: planpb.Node_TABLE_SCAN, BindingTags: []int32{tag},
+			ObjRef:   &planpb.ObjectRef{Obj: 1, ObjName: "t"},
+			TableDef: &planpb.TableDef{Name: "t", Cols: []*planpb.ColDef{{Name: "v", Typ: typ}}},
+		}, &planpb.Node{
+			NodeId: scanID + 1, NodeType: planpb.Node_AGG, Children: []int32{scanID},
+			BindingTags: []int32{tag + 1, tag + 2},
+			AggList:     []*planpb.Expr{distinctAggTestExpr(function.SUM, false, typ, GetColExpr(typ, tag, 0))},
+		})
+	}
+	query.Nodes = append(query.Nodes, &planpb.Node{
+		NodeId: 4, NodeType: planpb.Node_JOIN, JoinType: planpb.Node_INNER, Children: []int32{1, 3},
+	})
+	return &QueryBuilder{qry: query}
+}

--- a/test/distributed/cases/optimizer/index.result
+++ b/test/distributed/cases/optimizer/index.result
@@ -40,7 +40,9 @@ Project  𝄀
   ->  Join  𝄀
         Join Type: INNER   hashOnPK  𝄀
         Join Cond: (t2.c0 = t1.c1)  𝄀
+        Runtime Filter Build: #[-1,0]  𝄀
         ->  Table Scan on d1.t2  𝄀
+              Runtime Filter Probe: t2.c0  𝄀
         ->  Join  𝄀
               Join Type: INDEX  𝄀
               Join Cond: (t1.c1 = __mo_index_pri_col)  𝄀

--- a/test/distributed/cases/subquery/right_single_runtime_filter.result
+++ b/test/distributed/cases/subquery/right_single_runtime_filter.result
@@ -80,6 +80,32 @@ select s.id, (select b.v from big_composite b where b.a = s.a) as scalar_v
 from small_composite s
 where s.id = 1;
 Subquery returns more than 1 row
+select s.id, b.a, b.b, b.v
+from big_composite b join small_lookup s on b.a = s.lookup_id
+order by s.id, b.b;
+➤ id[-5,64,0]  ¦  a[-5,64,0]  ¦  b[-5,64,0]  ¦  v[-5,64,0]  𝄀
+1  ¦  1  ¦  2  ¦  100  𝄀
+1  ¦  1  ¦  3  ¦  101  𝄀
+2  ¦  5000  ¦  5001  ¦  500000
+select b.a, b.b from big_composite b
+where b.a in (select lookup_id from small_lookup)
+order by b.a, b.b;
+➤ a[-5,64,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+1  ¦  3  𝄀
+5000  ¦  5001
+select s.id, b.b from small_lookup s
+left join big_composite b on b.a = s.lookup_id
+order by s.id, b.b;
+➤ id[-5,64,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+1  ¦  3  𝄀
+2  ¦  5001  𝄀
+3  ¦  null  𝄀
+4  ¦  null
+select count(*) from big_composite b join empty_lookup e on b.a = e.lookup_id;
+➤ count(*)[-5,64,0]  𝄀
+0
 create table update_target(id bigint primary key, lookup_id bigint, v bigint);
 insert into update_target values (1, 1, -1), (2, 5000, -1), (3, 30000, -1);
 update update_target t

--- a/test/distributed/cases/subquery/right_single_runtime_filter.sql
+++ b/test/distributed/cases/subquery/right_single_runtime_filter.sql
@@ -91,6 +91,32 @@ from small_composite s
 where s.id = 1;
 
 -- @case
+-- @desc: a component IN is not a full-key lookup; keep every matching suffix
+-- @label:bvt
+select s.id, b.a, b.b, b.v
+from big_composite b join small_lookup s on b.a = s.lookup_id
+order by s.id, b.b;
+
+-- @case
+-- @desc: leading-key membership preserves duplicate probe values
+-- @label:bvt
+select b.a, b.b from big_composite b
+where b.a in (select lookup_id from small_lookup)
+order by b.a, b.b;
+
+-- @case
+-- @desc: partial-key filtering must not remove unmatched preserved rows
+-- @label:bvt
+select s.id, b.b from small_lookup s
+left join big_composite b on b.a = s.lookup_id
+order by s.id, b.b;
+
+-- @case
+-- @desc: empty component-key build returns no matches
+-- @label:bvt
+select count(*) from big_composite b join empty_lookup e on b.a = e.lookup_id;
+
+-- @case
 -- @desc: UPDATE SET correlated scalar preserves affected rows and missing NULL
 -- @label:bvt
 create table update_target(id bigint primary key, lookup_id bigint, v bigint);

--- a/test/distributed/cases/subquery/scalar_agg_fusion.result
+++ b/test/distributed/cases/subquery/scalar_agg_fusion.result
@@ -1,0 +1,63 @@
+drop database if exists scalar_agg_fusion;
+create database scalar_agg_fusion;
+use scalar_agg_fusion;
+create table t(k int, v decimal(10,2));
+create table x(id int);
+insert into x values (1),(1),(2);
+insert into t values (1,10),(1,10),(1,null),(2,40),(null,90);
+select id, (select count(*) from t a where a.k=1) c,
+(select count(b.v) from t b where b.k=1) n,
+(select avg(d.v) from t d where d.k=1) av
+from x order by id;
+id    c    n    av
+1    3    2    10.000000
+1    3    2    10.000000
+2    3    2    10.000000
+select id, c, n, av from x cross join
+(select count(*) c, count(v) n, avg(v) av from t where k=1) a order by id;
+id    c    n    av
+1    3    2    10.000000
+1    3    2    10.000000
+2    3    2    10.000000
+select a.c, b.s from (select count(*) c from t where k=1) a,
+(select sum(v) s from t where k=1) b;
+c    s
+3    20.00
+select a.c, b.s, b.m from (select count(*) c from t) a,
+(select s,m from (select sum(v) s from t) c, (select max(k) m from t) d) b;
+c    s    m
+5    150.00    2
+select (select count(*) from t where k=1) c,
+(select avg(v) from t where k=2) av;
+c    av
+3    40.000000
+select (select count(*) from t having count(*) > 10) c,
+(select count(v) from t) n;
+c    n
+null    4
+select a.c, b.s from (select count(*) c from t) a left join
+(select sum(v) s from t) b on a.c=b.s;
+c    s
+5    null
+prepare p from 'select (select count(*) from t where k=?) c, (select avg(v) from t where k=?) av';
+set @a=1;
+set @b=2;
+execute p using @a,@a;
+c    av
+3    10.000000
+execute p using @a,@b;
+c    av
+3    40.000000
+deallocate prepare p;
+delete from t;
+select (select count(*) from t) c, (select count(v) from t) n,
+(select avg(v) from t) av, (select sum(v) from t) s;
+c    n    av    s
+0    0    null    null
+select count(*) c, count(v) n, avg(v) av, sum(v) s from t;
+c    n    av    s
+0    0    null    null
+delete from x;
+select id, (select count(*) from t) c, (select avg(v) from t) av from x;
+id    c    av
+drop database scalar_agg_fusion;

--- a/test/distributed/cases/subquery/scalar_agg_fusion.sql
+++ b/test/distributed/cases/subquery/scalar_agg_fusion.sql
@@ -1,0 +1,55 @@
+-- @suite
+-- @case
+-- @desc: identical scalar aggregate inputs preserve empty, NULL and bag semantics
+-- @label:bvt
+drop database if exists scalar_agg_fusion;
+create database scalar_agg_fusion;
+use scalar_agg_fusion;
+create table t(k int, v decimal(10,2));
+create table x(id int);
+insert into x values (1),(1),(2);
+insert into t values (1,10),(1,10),(1,null),(2,40),(null,90);
+
+-- Same filtered bag: COUNT(*)=3, COUNT(v)=2, AVG(v)=10; preserve outer duplicates.
+select id, (select count(*) from t a where a.k=1) c,
+           (select count(b.v) from t b where b.k=1) n,
+           (select avg(d.v) from t d where d.k=1) av
+from x order by id;
+select id, c, n, av from x cross join
+  (select count(*) c, count(v) n, avg(v) av from t where k=1) a order by id;
+
+-- A second public shape: scalar derived tables joined without a predicate.
+select a.c, b.s from (select count(*) c from t where k=1) a,
+                    (select sum(v) s from t where k=1) b;
+
+-- Nested fusion must remap references through every eliminated aggregate.
+select a.c, b.s, b.m from (select count(*) c from t) a,
+  (select s,m from (select sum(v) s from t) c, (select max(k) m from t) d) b;
+
+-- Different predicates are not equivalent: the second AVG must remain 40.
+select (select count(*) from t where k=1) c,
+       (select avg(v) from t where k=2) av;
+
+-- HAVING can remove the singleton row; its scalar value is NULL, not 0.
+select (select count(*) from t having count(*) > 10) c,
+       (select count(v) from t) n;
+
+-- A scalar join condition is not disposable even when its inputs match.
+select a.c, b.s from (select count(*) c from t) a left join
+                    (select sum(v) s from t) b on a.c=b.s;
+
+prepare p from 'select (select count(*) from t where k=?) c, (select avg(v) from t where k=?) av';
+set @a=1;
+set @b=2;
+execute p using @a,@a;
+execute p using @a,@b;
+deallocate prepare p;
+
+-- Empty input still emits the one global aggregate row, including AVG(NULL).
+delete from t;
+select (select count(*) from t) c, (select count(v) from t) n,
+       (select avg(v) from t) av, (select sum(v) from t) s;
+select count(*) c, count(v) n, avg(v) av, sum(v) s from t;
+delete from x;
+select id, (select count(*) from t) c, (select avg(v) from t) av from x;
+drop database scalar_agg_fusion;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #26768; this implements two bounded optimizations, not the entire roadmap.

## What this PR does / why we need it:

Reduce redundant scan work with two independent planner commits:

1. **Leading-component runtime filters.** Admit an existing typed column IN on
   the leading sort column of a composite-PK table. Retain ordinary-column key
   limits, exact encoding/type checks and existing PASS fallback; do not introduce
   local-only placement or truncate unsafe probe predicates. The full join still
   owns duplicates and residual conditions. A component does not get the larger
   full-PK lookup budget.
2. **Identical-input scalar aggregate fusion.** Combine adjacent unconditional
   scalar aggregate joins over strictly identical filtered base-table inputs.
   Preserve empty/NULL/bag semantics, aggregate types and transitive output
   references. Limit eligibility to fixed-state numeric aggregates; exclude
   DISTINCT, grouping/HAVING, limits, correlation and unsafe expressions.

Fusion runs before costing/distribution and RF generation. Neither change adds
an executor, materialization layer, configuration, schema or wire format. No
query/table names or benchmark-specific thresholds are used. Fusion legality
does not depend on stats; RF still uses estimates for admission, while its actual
key budget and correctness fallback do not require accurate estimates.

[Reviewed design, revision 1](https://gist.github.com/aptend/5099f97eed3751762411de5bf6598467/e71d4808d9947aebe2196bbffefd1d7e89dca9c9)
records the contracts, rejected alternatives, ownership, bounds, rollback and
composition decision. Documentation and benchmark artifacts remain outside this PR;
the diff contains production changes and small UT/BVT regression cases only.

Observed 1T benefits: Q3 and Q19 baseline client times were 26s and 56s;
the combined candidate completes them in 3.7s and 26.8s with identical results.
Q9 fact-table scans fall from 15 to 5; the isolated fusion A/B was 339s to 154s,
and the combined candidate completes in 159s with the same output.
These are focused observations, not guaranteed speedups or a full-suite result.

The combined head passes the full planner unit suite and both SQL regression
cases twice. All TPC-DS ordinary EXPLAIN statements succeed. TPC-H 1G/100G plans
match the RF-only candidate; relative to baseline, only 1G Q2/Q18 add filters,
and all 100G plans remain unchanged. TPC-H 1G all 22 queries run three times with
identical results and comparable warm total time; 100G Q18 also matches and
finishes within the previously measured baseline variation. Earlier repeated
controls show small-query noise, so this does not claim literal zero overhead.
