### PR TITLE
test: reuse UT fixtures and observe SQL task scheduler cleanup

### DIFF
--- a/pkg/taskservice/sql_task_cron.go
+++ b/pkg/taskservice/sql_task_cron.go
@@ -119,6 +119,7 @@ func (s *taskService) loadSQLTasks(ctx context.Context) {
 			s.removeSQLTask(id)
 		}
 	}
+	notifySQLTaskRefreshForTest(s)
 }
 
 func (s *taskService) addSQLTask(sqlTask SQLTask) {
@@ -128,7 +129,16 @@ func (s *taskService) addSQLTask(sqlTask SQLTask) {
 		return
 	}
 	if sqlTask.NextFireTime > 0 && time.Now().After(time.UnixMilli(sqlTask.NextFireTime)) {
-		if err := s.sqlCrons.stopper.RunTask(func(context.Context) { job.Run() }); err != nil {
+		finished := observeSQLTaskCatchUpForTest(s, sqlTask.TaskID)
+		if err := s.sqlCrons.stopper.RunTask(func(context.Context) {
+			if finished != nil {
+				defer finished()
+			}
+			job.Run()
+		}); err != nil {
+			if finished != nil {
+				finished()
+			}
 			panic(err)
 		}
 	}

--- a/pkg/taskservice/sql_task_cron_test.go
+++ b/pkg/taskservice/sql_task_cron_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -212,4 +214,114 @@ func TestSQLTaskCronJobTaskSnapshotConcurrent(t *testing.T) {
 		require.Equal(t, uint64(1), taskID)
 	default:
 	}
+}
+
+// Exercise the real refresh/removal path: the observer must see deletion only
+// after reconciliation, never merely because storage has deleted the row.
+func TestSQLTaskRefreshObserver(t *testing.T) {
+	store := NewMemTaskStorage().(*memTaskStorage)
+	ts := NewTaskService(runtime.DefaultRuntime(), store).(*taskService)
+	defer func() { require.NoError(t, ts.Close()) }()
+	var snapshots [][]uint64
+	restore := SetSQLTaskRefreshHookForTest(func(serviceID string, ids []uint64) {
+		require.Equal(t, ts.rt.ServiceUUID(), serviceID)
+		snapshots = append(snapshots, ids)
+	}, nil)
+	defer restore()
+	sqlTask := newTestSQLTask("observer", 1)
+	sqlTask.CronExpr = "0 0 0 1 1 *"
+	sqlTask.Timezone = "UTC"
+	sqlTask.NextFireTime = time.Now().Add(24 * time.Hour).UnixMilli()
+	mustAddTestSQLTask(t, store, 1, sqlTask)
+	created := mustGetTestSQLTask(t, store, 1, WithTaskName(EQ, "observer"))[0]
+	// Drive refresh synchronously, avoiding a concurrent scheduler in this test.
+	ts.sqlCrons.jobs = make(map[uint64]*sqlTaskCronJob)
+	defer func() {
+		for id := range ts.sqlCrons.jobs {
+			ts.removeSQLTask(id)
+		}
+	}()
+	ts.loadSQLTasks(context.Background())
+	require.Equal(t, [][]uint64{{created.TaskID}}, snapshots)
+	_, err := store.DeleteSQLTask(context.Background(), WithTaskIDCond(EQ, created.TaskID))
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	ts.loadSQLTasks(context.Background())
+	require.Len(t, snapshots, 2)
+	require.Empty(t, snapshots[1])
+	require.Empty(t, ts.sqlCrons.jobs)
+	require.Equal(t, []uint64{created.TaskID}, snapshots[0], "snapshots must be independently owned")
+}
+
+// The overdue path is managed by the stopper, not cron.Stop. Hold it across
+// deletion and prove an empty refresh snapshot alone is insufficient.
+func TestSQLTaskRefreshObserverTracksOverdueExecution(t *testing.T) {
+	ctx := context.Background()
+	mem := NewMemTaskStorage().(*memTaskStorage)
+	release := make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	store := &blockedSQLTaskObserverStorage{TaskStorage: mem, entered: make(chan struct{}), release: release}
+	ts := NewTaskService(runtime.DefaultRuntime(), store).(*taskService)
+	ts.sqlCrons.stopper = stopper.NewStopper("observer-test")
+	ts.sqlCrons.jobs = make(map[uint64]*sqlTaskCronJob)
+	defer func() {
+		unblock()
+		ts.sqlCrons.stopper.Stop()
+		for id := range ts.sqlCrons.jobs {
+			ts.removeSQLTask(id)
+		}
+		require.NoError(t, ts.Close())
+	}()
+	var active atomic.Int64
+	snapshots := make(chan []uint64, 2)
+	restore := SetSQLTaskRefreshHookForTest(func(_ string, ids []uint64) { snapshots <- ids },
+		func(_ string, _ uint64, started bool) {
+			if started {
+				active.Add(1)
+			} else {
+				active.Add(-1)
+			}
+		})
+	defer restore()
+	item := newTestSQLTask("overdue-observer", 1)
+	item.CronExpr = "0 0 0 1 1 *"
+	item.Timezone = "UTC"
+	item.NextFireTime = time.Now().Add(-time.Minute).UnixMilli()
+	mustAddTestSQLTask(t, mem, 1, item)
+	created := mustGetTestSQLTask(t, mem, 1, WithTaskName(EQ, item.TaskName))[0]
+	ts.loadSQLTasks(ctx)
+	select {
+	case <-store.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("catch-up did not enter storage")
+	}
+	require.Equal(t, []uint64{created.TaskID}, <-snapshots)
+	require.Equal(t, int64(1), active.Load())
+	_, err := mem.DeleteSQLTask(ctx, WithTaskIDCond(EQ, created.TaskID))
+	require.NoError(t, err)
+	ts.loadSQLTasks(ctx)
+	require.Empty(t, <-snapshots)
+	require.Equal(t, int64(1), active.Load(), "cache removal must not hide an in-flight catch-up")
+	unblock()
+	require.Eventually(t, func() bool { return active.Load() == 0 }, 5*time.Second, time.Millisecond)
+}
+
+type blockedSQLTaskObserverStorage struct {
+	TaskStorage
+	queries atomic.Int64
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockedSQLTaskObserverStorage) QuerySQLTask(ctx context.Context, conds ...Condition) ([]SQLTask, error) {
+	if s.queries.Add(1) == 2 {
+		close(s.entered)
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return s.TaskStorage.QuerySQLTask(ctx, conds...)
 }

--- a/pkg/taskservice/sql_task_test_hooks.go
+++ b/pkg/taskservice/sql_task_test_hooks.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskservice
+
+import "sync/atomic"
+
+type sqlTaskRefreshHook struct {
+	refreshed func(serviceID string, taskIDs []uint64)
+	catchUp   func(serviceID string, taskID uint64, started bool)
+}
+
+var sqlTaskRefreshHookForTest atomic.Pointer[sqlTaskRefreshHook]
+
+// SetSQLTaskRefreshHookForTest observes successful scheduler reconciliation,
+// after removed cron jobs and their cron-managed callbacks have stopped. The
+// catchUp observer separately brackets stopper-managed overdue executions. The
+// callback receives an owned snapshot and must not block or call the scheduler.
+// Tests installing this process-wide observer must serialize its lifetime.
+func SetSQLTaskRefreshHookForTest(hook func(string, []uint64), catchUp func(string, uint64, bool)) func() {
+	previous := sqlTaskRefreshHookForTest.Load()
+	if hook == nil && catchUp == nil {
+		sqlTaskRefreshHookForTest.Store(nil)
+	} else {
+		value := sqlTaskRefreshHook{refreshed: hook, catchUp: catchUp}
+		sqlTaskRefreshHookForTest.Store(&value)
+	}
+	return func() { sqlTaskRefreshHookForTest.Store(previous) }
+}
+
+func notifySQLTaskRefreshForTest(s *taskService) {
+	hook := sqlTaskRefreshHookForTest.Load()
+	if hook == nil || hook.refreshed == nil {
+		return
+	}
+	ids := make([]uint64, 0, len(s.sqlCrons.jobs))
+	for id := range s.sqlCrons.jobs {
+		ids = append(ids, id)
+	}
+	hook.refreshed(s.rt.ServiceUUID(), ids)
+}
+
+// Capture the observer before enqueueing, so even a late callback pairs with
+// the same registration when the test has already restored its observer.
+func observeSQLTaskCatchUpForTest(s *taskService, taskID uint64) func() {
+	hook := sqlTaskRefreshHookForTest.Load()
+	if hook == nil || hook.catchUp == nil {
+		return nil
+	}
+	serviceID := s.rt.ServiceUUID()
+	hook.catchUp(serviceID, taskID, true)
+	return func() { hook.catchUp(serviceID, taskID, false) }
+}

--- a/pkg/tests/arrowload/arrow_load_rollout_test.go
+++ b/pkg/tests/arrowload/arrow_load_rollout_test.go
@@ -37,6 +37,8 @@ import (
 // be atomic and bounded.
 func TestArrowLoadRolloutRollbackDrain(t *testing.T) {
 	c := startArrowLoadCluster(t, 1, true, false, false)
+	// Both checks use the same policy; run the gate check before shutdown.
+	t.Run("S3GateDisabled", func(t *testing.T) { testArrowLoadGateS3Disabled(t, c) })
 	db := openArrowLoadDB(t, c, 0)
 	mustExec(t, db, "create database if not exists arrow_rollout")
 	mustExec(t, db, "use arrow_rollout")

--- a/pkg/tests/arrowload/arrow_load_test.go
+++ b/pkg/tests/arrowload/arrow_load_test.go
@@ -139,12 +139,12 @@ func TestArrowLoadGateDisabled(t *testing.T) {
 	require.Equal(t, int64(0), queryCount(t, db, "select count(*) from t"))
 }
 
-// TestArrowLoadGateS3Disabled proves the default S3 sub-gate fails closed before
+// testArrowLoadGateS3Disabled proves the default S3 sub-gate fails closed before
 // any network I/O. Dummy, unreachable credentials are sufficient proof of the
 // ordering: the statement must be rejected by configuration rather than
 // attempting HeadObject.
-func TestArrowLoadGateS3Disabled(t *testing.T) {
-	c := startArrowLoadCluster(t, 1, true, false, false)
+func testArrowLoadGateS3Disabled(t *testing.T, c embed.Cluster) {
+	t.Helper()
 	db := openArrowLoadDB(t, c, 0)
 	mustExec(t, db, "create database if not exists arrow_s3_gate_off")
 	mustExec(t, db, "use arrow_s3_gate_off")

--- a/pkg/tests/dml/pick_test.go
+++ b/pkg/tests/dml/pick_test.go
@@ -306,15 +306,18 @@ func runPickConflictMatrix(t *testing.T, parentCtx context.Context, db *sql.DB) 
 
 	for _, shape := range shapes {
 		t.Run(shape.name, func(t *testing.T) {
+			// PICK reads the source without mutating it. Share that immutable
+			// branch across policies, while each policy gets a fresh destination
+			// with the same common ancestor and conflict state.
+			src := fmt.Sprintf("src_%s", shape.name)
+			execSQLDB(t, ctx, db, fmt.Sprintf("data branch create table %s from conflict_base", src))
+			execSQLDB(t, ctx, db, fmt.Sprintf(shape.srcMutation, src))
+			sourceRows := queryStringRows(t, ctx, db, "select * from "+src+" order by a")
 			for _, policy := range []string{"skip", "accept", "fail"} {
 				t.Run(policy, func(t *testing.T) {
-					src := fmt.Sprintf("src_%s_%s", shape.name, policy)
 					dst := fmt.Sprintf("dst_%s_%s", shape.name, policy)
 					execSQLDB(t, ctx, db, fmt.Sprintf(
-						"data branch create table %s from conflict_base", src))
-					execSQLDB(t, ctx, db, fmt.Sprintf(
 						"data branch create table %s from conflict_base", dst))
-					execSQLDB(t, ctx, db, fmt.Sprintf(shape.srcMutation, src))
 					execSQLDB(t, ctx, db, fmt.Sprintf(shape.dstMutation, dst))
 
 					stmt := fmt.Sprintf(
@@ -327,6 +330,8 @@ func runPickConflictMatrix(t *testing.T, parentCtx context.Context, db *sql.DB) 
 						execSQLDB(t, ctx, db, stmt)
 					}
 					shape.verify(t, ctx, db, dst, policy)
+					require.Equal(t, sourceRows, queryStringRows(t, ctx, db,
+						"select * from "+src+" order by a"), "PICK must leave the source unchanged")
 				})
 			}
 		})

--- a/pkg/tests/issues/isolated/issue_27719_test.go
+++ b/pkg/tests/issues/isolated/issue_27719_test.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/taskservice"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +54,62 @@ func TestIssue27719DropAccountCleansSQLTaskLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	cn1Port := cn1.GetServiceConfig().CN.Frontend.Port
 	cn2Port := cn2.GetServiceConfig().CN.Frontend.Port
+
+	// HAKeeper owns cron scheduling; CNs execute the resulting tasks. Observe
+	// this cluster's single logservice rather than assuming CN-local cron caches.
+	var schedulerIDs []string
+	cluster.ForeachServices(func(service embed.ServiceOperator) bool {
+		if service.ServiceType() == metadata.ServiceType_LOG {
+			schedulerIDs = append(schedulerIDs, service.ServiceID())
+		}
+		return true
+	})
+	require.Len(t, schedulerIDs, 1)
+	var refreshMu sync.Mutex
+	refreshedTasks := make(map[string][]uint64)
+	catchUps := make(map[string]map[uint64]int)
+	restoreRefreshHook := taskservice.SetSQLTaskRefreshHookForTest(func(serviceID string, ids []uint64) {
+		refreshMu.Lock()
+		defer refreshMu.Unlock()
+		refreshedTasks[serviceID] = ids
+	}, func(serviceID string, taskID uint64, started bool) {
+		refreshMu.Lock()
+		defer refreshMu.Unlock()
+		if catchUps[serviceID] == nil {
+			catchUps[serviceID] = make(map[uint64]int)
+		}
+		if started {
+			catchUps[serviceID][taskID]++
+		} else {
+			catchUps[serviceID][taskID]--
+		}
+	})
+	defer restoreRefreshHook()
+	schedulersHaveTasks := func(taskIDs []uint64, want bool) bool {
+		refreshMu.Lock()
+		defer refreshMu.Unlock()
+		for _, serviceID := range schedulerIDs {
+			ids, observed := refreshedTasks[serviceID]
+			if !observed {
+				return false
+			}
+			for _, id := range taskIDs {
+				if !want && catchUps[serviceID][id] != 0 {
+					return false
+				}
+				found := false
+				for _, current := range ids {
+					if current == id {
+						found = true
+					}
+				}
+				if found != want {
+					return false
+				}
+			}
+		}
+		return true
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -120,6 +177,10 @@ func TestIssue27719DropAccountCleansSQLTaskLifecycle(t *testing.T) {
 			fmt.Sprintf("sql-task:%d", repeatingTaskID)) > 0
 	}, 20*time.Second, 100*time.Millisecond, "repeating task was not scheduled")
 
+	// Prove the stale-cache precondition before dropping the account.
+	require.Eventually(t, func() bool { return schedulersHaveTasks([]uint64{repeatingTaskID}, true) },
+		20*time.Second, 20*time.Millisecond, "HAKeeper scheduler must cache the repeating task")
+
 	runningDone := make(chan error, 1)
 	go func() {
 		_, executeErr := tenantDB.ExecContext(ctx, "execute task running_task")
@@ -154,9 +215,12 @@ func TestIssue27719DropAccountCleansSQLTaskLifecycle(t *testing.T) {
 
 	requireIssue27719AccountTaskResidue(t, ctx, sysDB, accountID, taskIDs, 0)
 
-	// Every CN refreshes its SQL-task cache independently. Wait beyond the
-	// fetch interval and prove stale cron jobs cannot recreate async work.
-	time.Sleep(12 * time.Second)
+	// A successful reconciliation removes the cached cron and joins its running
+	// callbacks. Also join the observed stopper-managed catch-up executions.
+	// Wait for both boundaries in the HAKeeper scheduler before checking durable
+	// residue, rather than sleeping through an assumed number of refreshes.
+	require.Eventually(t, func() bool { return schedulersHaveTasks(taskIDs, false) },
+		20*time.Second, 20*time.Millisecond, "HAKeeper scheduler must remove and drain the deleted tasks")
 	requireIssue27719AccountTaskResidue(t, ctx, sysDB, accountID, taskIDs, 0)
 	require.NoError(t, tenantDB.Close())
 	require.NoError(t, tenantRoot.Close())

--- a/pkg/tests/issues/issue_26095_test.go
+++ b/pkg/tests/issues/issue_26095_test.go
@@ -32,13 +32,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIssue26095ConcurrentDataBranchDeletion(t *testing.T) {
+func TestTenantCatalogRegressions(t *testing.T) {
 	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
-		runIssue26095ConcurrentDataBranchDeletion(t, c)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		rootDB := openIssue26095DB(t, ctx, fmt.Sprintf("sys#root#moadmin:111@tcp(127.0.0.1:%d)/", port))
+		defer rootDB.Close()
+		tenantName := fmt.Sprintf("catalog_fixture_%d", time.Now().UnixNano())
+		execSQLRequire(t, ctx, rootDB, fmt.Sprintf(
+			"create account `%s` admin_name 'admin' identified by '111'", tenantName))
+		defer cleanupIssue26095SQL(t, rootDB, fmt.Sprintf("drop account if exists `%s`", tenantName))
+		// These cases need a real ordinary tenant, but neither tests account
+		// creation or deletion. Each subtest cleans its own databases/catalog rows.
+		t.Run("Issue26095ConcurrentDataBranchDeletion", func(t *testing.T) {
+			runIssue26095ConcurrentDataBranchDeletion(t, c, tenantName)
+		})
+		t.Run("Issue26342MoSubsModernUpdate", func(t *testing.T) {
+			runIssue26342MoSubsModernUpdate(t, c, tenantName)
+		})
 	})
 }
 
-func runIssue26095ConcurrentDataBranchDeletion(t *testing.T, c embed.Cluster) {
+func runIssue26095ConcurrentDataBranchDeletion(t *testing.T, c embed.Cluster, tenantName string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -48,12 +66,6 @@ func runIssue26095ConcurrentDataBranchDeletion(t *testing.T, c embed.Cluster) {
 	rootDB := openIssue26095DB(t, ctx, fmt.Sprintf("sys#root#moadmin:111@tcp(127.0.0.1:%d)/", port))
 	defer rootDB.Close()
 
-	tenantName := fmt.Sprintf("issue26095_%d", time.Now().UnixNano())
-	execSQLRequire(t, ctx, rootDB, fmt.Sprintf(
-		"create account `%s` admin_name 'admin' identified by '111'", tenantName,
-	))
-	defer cleanupIssue26095SQL(t, rootDB,
-		fmt.Sprintf("drop account if exists `%s`", tenantName))
 	tenantID := queryIssue26095AccountID(t, ctx, rootDB, tenantName)
 	require.NotZero(t, tenantID)
 	tenantDB := openIssue26095DB(t, ctx, fmt.Sprintf(

--- a/pkg/tests/issues/issue_26342_test.go
+++ b/pkg/tests/issues/issue_26342_test.go
@@ -30,99 +30,89 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIssue26342MoSubsModernUpdate(t *testing.T) {
-	runAuthenticatedClusterTest(t, func(c embed.Cluster) {
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-		defer cancel()
+func runIssue26342MoSubsModernUpdate(t *testing.T, c embed.Cluster, tenantName string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
 
-		cn, err := c.GetCNService(0)
-		require.NoError(t, err)
-		port := cn.GetServiceConfig().CN.Frontend.Port
-		sysDB := openIssue26342DB(t, fmt.Sprintf("sys#root#moadmin:111@tcp(127.0.0.1:%d)/", port))
-		defer func() { require.NoError(t, sysDB.Close()) }()
+	cn, err := c.GetCNService(0)
+	require.NoError(t, err)
+	port := cn.GetServiceConfig().CN.Frontend.Port
+	sysDB := openIssue26342DB(t, fmt.Sprintf("sys#root#moadmin:111@tcp(127.0.0.1:%d)/", port))
+	defer func() { require.NoError(t, sysDB.Close()) }()
 
-		suffix := time.Now().UnixNano()
-		tenantName := fmt.Sprintf("acc26342_%d", suffix)
-		execSQLRequire(t, ctx, sysDB, fmt.Sprintf(
-			"create account `%s` admin_name 'admin' identified by '111'", tenantName,
-		))
-		defer func() {
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cleanupCancel()
-			execSQLMaybe(t, cleanupCtx, sysDB, fmt.Sprintf("drop account if exists `%s`", tenantName))
-		}()
+	suffix := time.Now().UnixNano()
 
-		tenantID := queryIssue26095AccountID(t, ctx, sysDB, tenantName)
-		require.NotZero(t, tenantID)
-		tenantDB := openIssue26342DB(t, fmt.Sprintf(
-			"%s#admin#accountadmin:111@tcp(127.0.0.1:%d)/", tenantName, port,
-		))
-		defer func() { require.NoError(t, tenantDB.Close()) }()
+	tenantID := queryIssue26095AccountID(t, ctx, sysDB, tenantName)
+	require.NotZero(t, tenantID)
+	tenantDB := openIssue26342DB(t, fmt.Sprintf(
+		"%s#admin#accountadmin:111@tcp(127.0.0.1:%d)/", tenantName, port,
+	))
+	defer func() { require.NoError(t, tenantDB.Close()) }()
 
-		prefix := fmt.Sprintf("p26342_%d", suffix)
-		pubAccount := prefix + "_publisher"
-		pubA := prefix + "_pub_a"
-		pubA2 := prefix + "_pub_a2"
-		pubB := prefix + "_pub_b"
-		subA := prefix + "_sub_a"
-		subA2 := prefix + "_sub_a2"
-		subB := prefix + "_sub_b"
-		defer func() {
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cleanupCancel()
-			_ = execIssue26342InternalSQL(cleanupCtx, cn, fmt.Sprintf(
-				"delete from mo_catalog.mo_subs where pub_account_name = '%s'", pubAccount))
-		}()
+	prefix := fmt.Sprintf("p26342_%d", suffix)
+	pubAccount := prefix + "_publisher"
+	pubA := prefix + "_pub_a"
+	pubA2 := prefix + "_pub_a2"
+	pubB := prefix + "_pub_b"
+	subA := prefix + "_sub_a"
+	subA2 := prefix + "_sub_a2"
+	subB := prefix + "_sub_b"
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = execIssue26342InternalSQL(cleanupCtx, cn, fmt.Sprintf(
+			"delete from mo_catalog.mo_subs where pub_account_name = '%s'", pubAccount))
+	}()
 
-		assertIssue26342MoSubsDDL(t, ctx, sysDB)
-		hiddenTable := queryIssue26342MoSubsUniqueIndexTable(t, ctx, sysDB)
-		hiddenBefore := queryIssue26342TableCount(t, ctx, sysDB, hiddenTable)
+	assertIssue26342MoSubsDDL(t, ctx, sysDB)
+	hiddenTable := queryIssue26342MoSubsUniqueIndexTable(t, ctx, sysDB)
+	hiddenBefore := queryIssue26342TableCount(t, ctx, sysDB, hiddenTable)
 
-		insertIssue26342MoSub(t, ctx, cn, tenantID, tenantName, subA, pubAccount, pubA)
-		insertIssue26342MoSub(t, ctx, cn, tenantID, tenantName, subB, pubAccount, pubB)
-		require.Equal(t, 2, queryIssue26342MoSubsCount(t, ctx, sysDB, tenantID, pubAccount))
-		require.Equal(t, hiddenBefore+2, queryIssue26342TableCount(t, ctx, sysDB, hiddenTable))
+	insertIssue26342MoSub(t, ctx, cn, tenantID, tenantName, subA, pubAccount, pubA)
+	insertIssue26342MoSub(t, ctx, cn, tenantID, tenantName, subB, pubAccount, pubB)
+	require.Equal(t, 2, queryIssue26342MoSubsCount(t, ctx, sysDB, tenantID, pubAccount))
+	require.Equal(t, hiddenBefore+2, queryIssue26342TableCount(t, ctx, sysDB, hiddenTable))
 
-		logicalPlan, err := execIssue26342InternalSQLWithPlan(ctx, cn, fmt.Sprintf(
-			"update mo_catalog.mo_subs set pub_name = '%s', sub_name = '%s' "+
-				"where pub_account_name = '%s' and pub_name = '%s' and sub_account_id = %d",
-			pubA2, subA2, pubAccount, pubA, tenantID,
-		))
-		require.NoError(t, err)
-		require.NotNil(t, logicalPlan)
-		assertIssue26342MultiUpdateContexts(t, logicalPlan, hiddenTable)
-		require.Equal(t, 0, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubA, subA))
-		require.Equal(t, 1, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubA2, subA2))
-		require.Equal(t, hiddenBefore+2, queryIssue26342TableCount(t, ctx, sysDB, hiddenTable))
+	logicalPlan, err := execIssue26342InternalSQLWithPlan(ctx, cn, fmt.Sprintf(
+		"update mo_catalog.mo_subs set pub_name = '%s', sub_name = '%s' "+
+			"where pub_account_name = '%s' and pub_name = '%s' and sub_account_id = %d",
+		pubA2, subA2, pubAccount, pubA, tenantID,
+	))
+	require.NoError(t, err)
+	require.NotNil(t, logicalPlan)
+	assertIssue26342MultiUpdateContexts(t, logicalPlan, hiddenTable)
+	require.Equal(t, 0, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubA, subA))
+	require.Equal(t, 1, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubA2, subA2))
+	require.Equal(t, hiddenBefore+2, queryIssue26342TableCount(t, ctx, sysDB, hiddenTable))
 
-		err = execIssue26342InternalSQL(ctx, cn, fmt.Sprintf(
-			"update mo_catalog.mo_subs set pub_name = '%s', sub_name = '%s' "+
-				"where pub_account_name = '%s' and pub_name = '%s' and sub_account_id = %d",
-			pubB, subB, pubAccount, pubA2, tenantID,
-		))
-		require.Error(t, err)
-		require.Equal(t, 1, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubA2, subA2))
-		require.Equal(t, 1, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubB, subB))
-		require.Equal(t, hiddenBefore+2, queryIssue26342TableCount(t, ctx, sysDB, hiddenTable))
+	err = execIssue26342InternalSQL(ctx, cn, fmt.Sprintf(
+		"update mo_catalog.mo_subs set pub_name = '%s', sub_name = '%s' "+
+			"where pub_account_name = '%s' and pub_name = '%s' and sub_account_id = %d",
+		pubB, subB, pubAccount, pubA2, tenantID,
+	))
+	require.Error(t, err)
+	require.Equal(t, 1, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubA2, subA2))
+	require.Equal(t, 1, queryIssue26342MoSubKeyCountInternal(t, ctx, cn, tenantID, pubAccount, pubB, subB))
+	require.Equal(t, hiddenBefore+2, queryIssue26342TableCount(t, ctx, sysDB, hiddenTable))
 
-		require.NoError(t, execIssue26342InternalSQL(ctx, cn, fmt.Sprintf(
-			"update mo_catalog.mo_subs set sub_account_name = 'stale' "+
-				"where pub_account_name = '%s' and sub_account_id = %d",
-			pubAccount, tenantID,
-		)))
-		require.NoError(t, execIssue26342InternalSQL(ctx, cn,
-			"update mo_catalog.mo_subs t1 inner join mo_catalog.mo_account t2 "+
-				"on t1.sub_account_id = t2.account_id set t1.sub_account_name = t2.account_name"))
-		require.Equal(t, tenantName, queryIssue26342SubAccountNameInternal(t, ctx, cn, tenantID, pubAccount, pubA2))
+	require.NoError(t, execIssue26342InternalSQL(ctx, cn, fmt.Sprintf(
+		"update mo_catalog.mo_subs set sub_account_name = 'stale' "+
+			"where pub_account_name = '%s' and sub_account_id = %d",
+		pubAccount, tenantID,
+	)))
+	require.NoError(t, execIssue26342InternalSQL(ctx, cn,
+		"update mo_catalog.mo_subs t1 inner join mo_catalog.mo_account t2 "+
+			"on t1.sub_account_id = t2.account_id set t1.sub_account_name = t2.account_name"))
+	require.Equal(t, tenantName, queryIssue26342SubAccountNameInternal(t, ctx, cn, tenantID, pubAccount, pubA2))
 
-		_, err = tenantDB.ExecContext(ctx, fmt.Sprintf(
-			"update mo_catalog.mo_subs set status = status + 1 "+
-				"where pub_account_name = '%s' and pub_name = '%s' and sub_account_id = %d",
-			pubAccount, pubA2, tenantID,
-		))
-		require.Error(t, err)
-		require.Equal(t, int64(1), queryIssue26342MoSubStatusInternal(t, ctx, cn, tenantID, pubAccount, pubA2))
-	})
+	_, err = tenantDB.ExecContext(ctx, fmt.Sprintf(
+		"update mo_catalog.mo_subs set status = status + 1 "+
+			"where pub_account_name = '%s' and pub_name = '%s' and sub_account_id = %d",
+		pubAccount, pubA2, tenantID,
+	))
+	require.Error(t, err)
+	require.Equal(t, int64(1), queryIssue26342MoSubStatusInternal(t, ctx, cn, tenantID, pubAccount, pubA2))
 }
 
 func queryIssue26342MoSubKeyCountInternal(


### PR DESCRIPTION
## What type of PR is this?

- [x] Improvement
- [x] Test and CI

## Which issue(s) this PR fixes:

https://github.com/matrixorigin/matrixone/issues/28419
Follow-up to #28568 and #28607; no separate issue.

## What this PR does / why we need it:

Repeated setup and fixed sleeps add time to the embedded UT lane. Reuse compatible fixtures and wait for actual SQL-task scheduler cleanup:

- Share one ordinary tenant between the concurrent branch-deletion and mo_subs update regressions. Keep their assertions and per-case data cleanup.
- Create four immutable PICK sources instead of twelve. Keep all 12 shape/policy cases, independent destinations, and add full source-row immutability assertions after each policy.
- Run the S3-disabled Arrow gate checks as a subtest in the identically configured rollback/drain fixture, avoiding one cluster startup. Keep rollout restarts and shutdown assertions.
- Replace the SQL-task lifecycle test's fixed 12-second sleep with observed HAKeeper reconciliation and completed overdue catch-up executions. Assert the repeating task entered the scheduler cache before deletion. Preserve cross-CN execution/drop and durable residue checks.

The scheduler observer is inactive unless installed by a test. Unit tests cover snapshot ownership, deletion before reconciliation, and reconciliation finishing while an overdue execution remains blocked. Cluster admission and test data sizes are unchanged.

### Validation

- All affected integration tests passed locally with `-race -count=3 -tags matrixone_test`.
- Both new scheduler observer tests passed with `-race -count=3`.
- golangci-lint: 0 issues across the five affected packages; molint passed. Rechecked the isolated package after the final scheduler-owner correction.
- License checks and `git diff --check` passed.
- Independent GPT-6 medium review completed; fixed its finding that overdue stopper-managed executions must also drain, then re-reviewed.

CI wall-time savings require a CI run; local timings do not predict runner contention or the job critical path.

### Local timing comparison

Same-machine `-race -count=1` on base `269d59addd` and this branch, selected packages run serially (`-p=1`). Baseline PICK and tenant cases encountered admission waits of 0.457s and 57.136s respectively; these waits are subtracted below, so they are not counted as optimization savings. Results are one sample, not a controlled CI benchmark.

| Selected cases | Base, excluding admission wait | Updated |
| --- | ---: | ---: |
| PICK | 24.91s | 23.03s |
| Two tenant regressions | 23.56s | 20.81s |
| Arrow rollout + S3 gate | 38.23s | 28.21s |
| SQL-task lifecycle | 41.06s | 31.30s |

Total selected test time: 127.77s → 103.35s (about 24.4s / 19% lower locally). Compilation and package teardown are excluded. The unchanged admission policy still serializes live embedded clusters.
