### PR TITLE
test: harden Arrow LOAD acceptance coverage

### DIFF
--- a/pkg/sql/colexec/external/reader_arrow_test.go
+++ b/pkg/sql/colexec/external/reader_arrow_test.go
@@ -327,6 +327,127 @@ func TestExternalArrowLoadFromLocalMinIOAndRejectsObjectChange(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExternalArrowLoadVersionedMinIOIdentity(t *testing.T) {
+	testExternalArrowLoadVersionedMinIOIdentity(t)
+}
+
+func testExternalArrowLoadVersionedMinIOIdentity(t *testing.T) {
+	server := startLocalArrowMinIO(t)
+	ctx := context.Background()
+	require.NoError(t, server.client.SetBucketVersioning(ctx, server.bucket,
+		minio.BucketVersioningConfiguration{Status: "Enabled"}))
+
+	fs, err := fileservice.NewS3FS(
+		ctx,
+		fileservice.ObjectStorageArguments{
+			Name: "etl", Endpoint: "http://" + server.endpoint,
+			Region: "us-east-1", Bucket: server.bucket,
+			KeyID: server.user, KeySecret: server.password, IsMinio: true,
+		},
+		fileservice.DisabledCacheConfig, nil, true, true,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { fs.Close(context.Background()) })
+
+	put := func(t *testing.T, key string, payload []byte) minio.UploadInfo {
+		t.Helper()
+		info, err := server.client.PutObject(ctx, server.bucket, key,
+			bytes.NewReader(payload), int64(len(payload)),
+			minio.PutObjectOptions{ContentType: "application/vnd.apache.arrow.file"})
+		require.NoError(t, err)
+		require.NotEmpty(t, info.VersionID)
+		return info
+	}
+	open := func(t *testing.T, path string, size int64, container string, identity fileservice.ObjectIdentity) (*ArrowReader, *process.Process, func()) {
+		t.Helper()
+		registry, err := mpool.NewAllocationAccountRegistry(1, 128)
+		require.NoError(t, err)
+		account, err := registry.Open(64 << 20)
+		require.NoError(t, err)
+		proc := newArrowLoadTestProc(t)
+		param := externalArrowParam(fs, path, size, container)
+		param.Fileparam.FileIndex = 1
+		param.Fileparam.Filepath = path
+		param.ArrowObjectIdentities = []*pipeline.ArrowObjectIdentity{{
+			FileIndex: 0, VersionId: identity.VersionID, Etag: identity.ETag,
+			Size: identity.Size, LastModifiedUnixNano: identity.LastModified.UnixNano(),
+		}}
+		reader, err := NewArrowReader(param, proc, account)
+		require.NoError(t, err)
+		empty, err := reader.Open(param, proc)
+		require.NoError(t, err)
+		require.False(t, empty)
+		return reader, proc, func() {
+			require.NoError(t, reader.Close())
+			require.Zero(t, account.Snapshot().Used)
+			account.Seal()
+			_, err := registry.Finalize(account)
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("file-v1-survives-v2", func(t *testing.T) {
+		payload := makeExternalArrowIPC(t, tree.ARROW_CONTAINER_FILE)
+		key := "versioned/file.arrow"
+		v1 := put(t, key, payload)
+		path := "etl:" + key
+		identity, err := fs.StatFileIdentity(ctx, path)
+		require.NoError(t, err)
+		require.Equal(t, v1.VersionID, identity.VersionID)
+
+		reader, proc, closeReader := open(t, path, int64(len(payload)), tree.ARROW_CONTAINER_FILE, identity)
+		defer closeReader()
+		replacement := append([]byte(nil), payload...)
+		replacement[len(replacement)/2] ^= 0xff
+		v2 := put(t, key, replacement)
+		require.NotEqual(t, v1.VersionID, v2.VersionID)
+
+		output := batch.NewOffHeap([]string{"id", "name"})
+		_, err = reader.ReadBatch(ctx, output, proc, nil)
+		require.NoError(t, err)
+		require.Equal(t, []int64{1, 2}, vector.MustFixedColNoTypeCheck[int64](output.Vecs[0]))
+		output.Clean(proc.Mp())
+	})
+
+	t.Run("deleted-v1-fails-closed", func(t *testing.T) {
+		payload := makeExternalArrowIPC(t, tree.ARROW_CONTAINER_FILE)
+		key := "versioned/deleted.arrow"
+		v1 := put(t, key, payload)
+		path := "etl:" + key
+		identity, err := fs.StatFileIdentity(ctx, path)
+		require.NoError(t, err)
+		require.Equal(t, v1.VersionID, identity.VersionID)
+
+		reader, proc, closeReader := open(t, path, int64(len(payload)), tree.ARROW_CONTAINER_FILE, identity)
+		defer closeReader()
+		require.NoError(t, server.client.RemoveObject(ctx, server.bucket, key,
+			minio.RemoveObjectOptions{VersionID: v1.VersionID}))
+		_, err = reader.ReadBatch(ctx, batch.NewWithSize(2), proc, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("stream-v1-survives-latest-update", func(t *testing.T) {
+		payload := makeExternalArrowIPC(t, tree.ARROW_CONTAINER_STREAM)
+		key := "versioned/stream.arrow"
+		v1 := put(t, key, payload)
+		path := "etl:" + key
+		identity, err := fs.StatFileIdentity(ctx, path)
+		require.NoError(t, err)
+		require.Equal(t, v1.VersionID, identity.VersionID)
+
+		reader, proc, closeReader := open(t, path, int64(len(payload)), tree.ARROW_CONTAINER_STREAM, identity)
+		defer closeReader()
+		replacement := append([]byte(nil), payload...)
+		replacement[len(replacement)/2] ^= 0xff
+		put(t, key, replacement)
+		output := batch.NewOffHeap([]string{"id", "name"})
+		_, err = reader.ReadBatch(ctx, output, proc, nil)
+		require.NoError(t, err)
+		require.Equal(t, []int64{1, 2}, vector.MustFixedColNoTypeCheck[int64](output.Vecs[0]))
+		output.Clean(proc.Mp())
+	})
+}
+
 type localArrowMinIO struct {
 	endpoint string
 	bucket   string

--- a/pkg/tests/arrowload/arrow_load_lifecycle_test.go
+++ b/pkg/tests/arrowload/arrow_load_lifecycle_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arrowload
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestArrowLoadFailedStatementKeepsEarlierTransactionWrite proves the documented
+// default transaction-error contract for Arrow LOAD: a failed statement rolls
+// back only its own writes, while preceding successful statements remain
+// committable and the same connection can execute a valid retry afterwards.
+func TestArrowLoadFailedStatementKeepsEarlierTransactionWrite(t *testing.T) {
+	c := startArrowLoadCluster(t, 1, true, false, false)
+	db := openArrowLoadDB(t, c, 0)
+	mustExec(t, db, "create database if not exists arrow_lifecycle")
+	mustExec(t, db, "use arrow_lifecycle")
+	mustExec(t, db, "create table txn_failed_load(id bigint not null, name varchar(50))")
+
+	dir := t.TempDir()
+	valid := fixtureIDName(t, dir, "valid.arrow", containerFile,
+		[][]idNameRow{{{id: 2, name: "loaded"}}})
+	corrupt := filepath.Join(dir, "corrupt.arrow")
+	require.NoError(t, os.WriteFile(corrupt, []byte("not an Arrow IPC file"), 0o600))
+
+	mustExec(t, db, "begin")
+	mustExec(t, db, "insert into txn_failed_load values (1, 'before-load')")
+	_, err := db.Exec(fmt.Sprintf(
+		"load data infile {'filepath'='%s','format'='arrow'} into table txn_failed_load", corrupt))
+	require.Error(t, err)
+	mustExec(t, db, "commit")
+
+	require.Equal(t, int64(1), queryCount(t, db, "select count(*) from txn_failed_load"))
+	require.Equal(t, int64(1), queryCount(t, db,
+		"select count(*) from txn_failed_load where id=1 and name='before-load'"))
+	mustExec(t, db, fmt.Sprintf(
+		"load data infile {'filepath'='%s','format'='arrow'} into table txn_failed_load", valid))
+	require.Equal(t, int64(2), queryCount(t, db, "select count(*) from txn_failed_load"))
+}
+
+// TestArrowLoadKillQueryRollsBackAndKeepsConnectionUsable holds a real,
+// conditional S3 range GET, kills that exact MySQL query from a second
+// connection, and proves the server propagates cancellation to the object
+// read. This avoids treating a test-only in-process wait hook as a client
+// cancellation boundary.
+func TestArrowLoadKillQueryRollsBackAndKeepsConnectionUsable(t *testing.T) {
+	c := startArrowLoadCluster(t, 1, true, true, false)
+	db := openArrowLoadDB(t, c, 0)
+	observer := openArrowLoadDB(t, c, 0)
+	server := startArrowLoadMinIO(t)
+
+	path := fixtureIDName(t, t.TempDir(), "kill.arrow", containerFile,
+		[][]idNameRow{{{id: 1, name: "must-not-commit"}}})
+	const key = "fault/kill-query.arrow"
+	server.put(t, key, mustReadFile(t, path))
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	var blocked atomic.Bool
+	proxyEndpoint := startArrowMinIOProxy(t, server.endpointURL,
+		func(w http.ResponseWriter, r *http.Request) bool {
+			if !isConditionalRangeGET(r) || !blocked.CompareAndSwap(false, true) {
+				return false
+			}
+			close(requestStarted)
+			select {
+			case <-r.Context().Done():
+				close(requestCanceled)
+			case <-time.After(30 * time.Second):
+				http.Error(w, "timed out waiting for KILL QUERY cancellation", http.StatusGatewayTimeout)
+			}
+			return true
+		})
+
+	mustExec(t, db, "create database if not exists arrow_lifecycle")
+	mustExec(t, db, "use arrow_lifecycle")
+	mustExec(t, db, "create table kill_query_load(id bigint not null, name varchar(50))")
+	mustExec(t, db, "insert into kill_query_load values (0, 'seed')")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.ExecContext(ctx, "use arrow_lifecycle")
+	require.NoError(t, err)
+	var connID int64
+	require.NoError(t, conn.QueryRowContext(ctx, "select connection_id()").Scan(&connID))
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, loadErr := conn.ExecContext(ctx,
+			minioLoadSQL(proxyEndpoint, server, key, "kill_query_load", "file", false))
+		errCh <- loadErr
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the conditional MinIO request")
+	}
+	waitUntilStatementRunning(t, observer, connID, "load data", 30*time.Second)
+	mustExec(t, observer, fmt.Sprintf("kill query %d", connID))
+
+	select {
+	case loadErr := <-errCh:
+		require.Error(t, loadErr)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for killed Arrow LOAD")
+	}
+	select {
+	case <-requestCanceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the in-flight MinIO range request did not observe KILL QUERY cancellation")
+	}
+	require.Equal(t, int64(1), queryCount(t, observer, "select count(*) from arrow_lifecycle.kill_query_load"))
+	var one int
+	require.NoError(t, conn.QueryRowContext(ctx, "select 1").Scan(&one))
+	require.Equal(t, 1, one)
+	_, err = conn.ExecContext(ctx, minioLoadSQL(server.endpointURL, server, key, "kill_query_load", "file", false))
+	require.NoError(t, err)
+	require.Equal(t, int64(2), queryCount(t, observer, "select count(*) from arrow_lifecycle.kill_query_load"))
+}
+
+// TestArrowLoadClientDisconnectRollsBackAndReleasesSession closes the physical
+// client connection during a real conditional object read. It verifies that a
+// client-disconnect path is distinct from KILL QUERY: the session disappears,
+// the reader request is canceled, and no LOAD rows are made durable.
+func TestArrowLoadClientDisconnectRollsBackAndReleasesSession(t *testing.T) {
+	c := startArrowLoadCluster(t, 1, true, true, false)
+	admin := openArrowLoadDB(t, c, 0)
+	observer := openArrowLoadDB(t, c, 0)
+	server := startArrowLoadMinIO(t)
+	path := fixtureIDName(t, t.TempDir(), "disconnect.arrow", containerFile,
+		[][]idNameRow{{{id: 1, name: "must-not-commit"}}})
+	const key = "fault/client-disconnect.arrow"
+	server.put(t, key, mustReadFile(t, path))
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	var blocked atomic.Bool
+	proxyEndpoint := startArrowMinIOProxy(t, server.endpointURL,
+		func(w http.ResponseWriter, r *http.Request) bool {
+			if !isConditionalRangeGET(r) || !blocked.CompareAndSwap(false, true) {
+				return false
+			}
+			close(requestStarted)
+			select {
+			case <-r.Context().Done():
+				close(requestCanceled)
+			case <-time.After(30 * time.Second):
+				http.Error(w, "timed out waiting for client disconnect", http.StatusGatewayTimeout)
+			}
+			return true
+		})
+
+	mustExec(t, admin, "create database if not exists arrow_lifecycle")
+	mustExec(t, admin, "create table arrow_lifecycle.client_disconnect_load(id bigint not null, name varchar(50))")
+	mustExec(t, admin, "insert into arrow_lifecycle.client_disconnect_load values (0, 'seed')")
+
+	rawConn, connID := openArrowLoadRawConn(t, c, 0)
+	t.Cleanup(func() { _ = rawConn.Close() })
+	execer, ok := rawConn.(driver.ExecerContext)
+	require.True(t, ok, "MySQL driver connection does not support ExecContext")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := execer.ExecContext(ctx, "use arrow_lifecycle", nil)
+	require.NoError(t, err)
+	errCh := make(chan error, 1)
+	go func() {
+		_, loadErr := execer.ExecContext(ctx,
+			minioLoadSQL(proxyEndpoint, server, key, "client_disconnect_load", "file", false), nil)
+		errCh <- loadErr
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(30 * time.Second):
+		_ = rawConn.Close()
+		t.Fatal("timed out waiting for the conditional MinIO request")
+	}
+	waitUntilStatementRunning(t, observer, connID, "load data", 30*time.Second)
+	require.NoError(t, rawConn.Close())
+	select {
+	case loadErr := <-errCh:
+		require.Error(t, loadErr)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the disconnected Arrow LOAD")
+	}
+	select {
+	case <-requestCanceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the in-flight MinIO range request did not observe client disconnect")
+	}
+	waitUntilConnectionGone(t, observer, connID, 30*time.Second)
+	require.Equal(t, int64(1), queryCount(t, observer,
+		"select count(*) from arrow_lifecycle.client_disconnect_load"))
+	mustExec(t, admin, minioLoadSQL(server.endpointURL, server, key, "arrow_lifecycle.client_disconnect_load", "file", false))
+	require.Equal(t, int64(2), queryCount(t, observer,
+		"select count(*) from arrow_lifecycle.client_disconnect_load"))
+}

--- a/pkg/tests/arrowload/arrow_load_lifecycle_test.go
+++ b/pkg/tests/arrowload/arrow_load_lifecycle_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +60,33 @@ func TestArrowLoadFailedStatementKeepsEarlierTransactionWrite(t *testing.T) {
 	mustExec(t, db, fmt.Sprintf(
 		"load data infile {'filepath'='%s','format'='arrow'} into table txn_failed_load", valid))
 	require.Equal(t, int64(2), queryCount(t, db, "select count(*) from txn_failed_load"))
+}
+
+// TestArrowLoadMetricsPublishBeforeTransactionCommit distinguishes reader
+// publication telemetry from transaction durability: the reader metrics must
+// record a successfully published batch even when the enclosing transaction is
+// explicitly rolled back and the target table remains empty.
+func TestArrowLoadMetricsPublishBeforeTransactionCommit(t *testing.T) {
+	c := startArrowLoadCluster(t, 1, true, false, false)
+	db := openArrowLoadDB(t, c, 0)
+	mustExec(t, db, "create database if not exists arrow_lifecycle")
+	mustExec(t, db, "use arrow_lifecycle")
+	mustExec(t, db, "create table metrics_before_commit(id bigint not null, name varchar(50))")
+	path := fixtureIDName(t, t.TempDir(), "metrics.arrow", containerFile,
+		[][]idNameRow{{{id: 1, name: "published-then-rolled-back"}}})
+
+	recordsBefore := promtestutil.ToFloat64(metric.ArrowLoadRecordCounter)
+	batchesBefore := promtestutil.ToFloat64(metric.ArrowLoadBatchCounter)
+	rowsBefore := promtestutil.ToFloat64(metric.ArrowLoadRowCounter)
+	mustExec(t, db, "begin")
+	mustExec(t, db, fmt.Sprintf(
+		"load data infile {'filepath'='%s','format'='arrow'} into table metrics_before_commit", path))
+	mustExec(t, db, "rollback")
+
+	require.Equal(t, int64(0), queryCount(t, db, "select count(*) from metrics_before_commit"))
+	require.Equal(t, recordsBefore+1, promtestutil.ToFloat64(metric.ArrowLoadRecordCounter))
+	require.Equal(t, batchesBefore+1, promtestutil.ToFloat64(metric.ArrowLoadBatchCounter))
+	require.Equal(t, rowsBefore+1, promtestutil.ToFloat64(metric.ArrowLoadRowCounter))
 }
 
 // TestArrowLoadKillQueryRollsBackAndKeepsConnectionUsable holds a real,

--- a/pkg/tests/arrowload/cluster_test.go
+++ b/pkg/tests/arrowload/cluster_test.go
@@ -17,12 +17,13 @@ package arrowload
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 	"github.com/matrixorigin/matrixone/pkg/embed"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/stretchr/testify/require"
@@ -146,6 +147,44 @@ func openArrowLoadDB(t testing.TB, c embed.Cluster, cnIndex int) *sql.DB {
 	return db
 }
 
+// openArrowLoadRawConn opens one physical MySQL connection for client-close
+// tests. database/sql intentionally retains an in-flight connection on DB.Close;
+// using driver.Conn here lets the test close the client TCP session while LOAD is
+// blocked in a real S3 request.
+func openArrowLoadRawConn(t testing.TB, c embed.Cluster, cnIndex int) (driver.Conn, int64) {
+	t.Helper()
+	cn, err := c.GetCNService(cnIndex)
+	require.NoError(t, err)
+	config := mysql.NewConfig()
+	config.User = "dump"
+	config.Passwd = "111"
+	config.Net = "tcp"
+	config.Addr = fmt.Sprintf("127.0.0.1:%d", cn.GetServiceConfig().CN.Frontend.Port)
+	connector, err := mysql.NewConnector(config)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := connector.Connect(ctx)
+	require.NoError(t, err)
+	queryer, ok := conn.(driver.QueryerContext)
+	require.True(t, ok, "MySQL driver connection does not support QueryContext")
+	rows, err := queryer.QueryContext(ctx, "select connection_id()", nil)
+	require.NoError(t, err)
+	defer rows.Close()
+	values := make([]driver.Value, 1)
+	require.NoError(t, rows.Next(values))
+	var connID int64
+	switch value := values[0].(type) {
+	case int64:
+		connID = value
+	case uint64:
+		connID = int64(value)
+	default:
+		require.FailNow(t, "unexpected connection_id type", "%T", values[0])
+	}
+	return conn, connID
+}
+
 func mustExec(t testing.TB, db *sql.DB, stmt string, args ...any) {
 	t.Helper()
 	_, err := db.Exec(stmt, args...)
@@ -181,6 +220,28 @@ func waitUntilStatementRunning(t testing.TB, observer *sql.DB, connID int64, nee
 		case <-ctx.Done():
 			t.Fatalf("timed out waiting for connection %d to run a statement containing %q (last info=%q, err=%v)",
 				connID, needle, info.String, err)
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitUntilConnectionGone(t testing.TB, observer *sql.DB, connID int64, deadline time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var n int
+		err := observer.QueryRowContext(ctx,
+			"select count(*) from information_schema.processlist where conn_id = ?", connID,
+		).Scan(&n)
+		if err == nil && n == 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for connection %d to disappear (last count=%d, err=%v)", connID, n, err)
 		case <-ticker.C:
 		}
 	}


### PR DESCRIPTION
## Summary

- add real MinIO VersionID controls for Arrow File and Stream readers
- add transaction, KILL QUERY, and client-disconnect recovery coverage through the MySQL protocol
- verify reader metrics publish before an outer transaction commits

## Verification

- `go test ./pkg/tests/arrowload -count=1` (pass, 132.832s)
- `go test ./pkg/sql/colexec/external -count=1` (pass, 39.213s)

## Related

- #23684
- #28618 is intentionally tracked separately: its permission-order regression is failing on current main and must land with the product fix.