### PR TITLE
test: add JSON variant semantic BVT

### DIFF
--- a/test/distributed/cases/json_variant/json_variant_baseline.result
+++ b/test/distributed/cases/json_variant/json_variant_baseline.result
@@ -1,0 +1,176 @@
+drop database if exists json_variant_baseline_bvt;
+create database json_variant_baseline_bvt;
+use json_variant_baseline_bvt;
+set experimental_fulltext2_index = 1;
+create table observations (
+id bigint not null,
+trace_id varchar(128) not null,
+case_tag varchar(64) not null,
+payload json null,
+primary key (id)
+);
+create table sql_null_observations (
+id bigint primary key,
+payload json null
+);
+create table malformed_observations (
+raw_data json not null
+);
+insert into observations values
+(1, 'trace-edge-missing', 'missing_path',
+'{"kind":"edge","attr":{"present":"yes"}}'),
+(2, 'trace-edge-json-null', 'json_null',
+'{"kind":"edge","optional":null}'),
+(3, 'trace-edge-int', 'mixed_int',
+'{"kind":"mixed","value":42}'),
+(4, 'trace-edge-string', 'mixed_string',
+'{"kind":"mixed","value":"42","other":"deployment"}'),
+(5, 'trace-edge-bool', 'mixed_bool',
+'{"kind":"mixed","value":true}'),
+(6, 'trace-edge-array', 'array_object',
+'{"kind":"edge","items":[1,"two",{"name":"three"}],"attr":{"array_length":3}}'),
+(7, 'trace-edge-deep', 'deep_nesting',
+'{"kind":"edge","deep":{"level_1":{"level_2":{"level_3":{"level_4":{"level_5":{"level_6":{"level_7":{"level_8":"leaf"}}}}}}}}}'),
+(9, 'trace-edge-order-a', 'key_order_a',
+'{"kind":"order","first":1,"second":2,"nested":{"a":3,"b":4}}'),
+(10, 'trace-edge-order-b', 'key_order_b',
+'{"nested":{"b":4,"a":3},"second":2,"kind":"order","first":1}'),
+(11, 'trace-edge-evolution-old', 'path_evolution_old',
+'{"kind":"evolution","schema_version":1,"old_path":"old"}'),
+(12, 'trace-edge-evolution-new', 'path_evolution_new',
+'{"kind":"evolution","schema_version":2,"new_path":"new","old_path":"old"}'),
+(13, 'trace-generated-000013', 'generated',
+'{"kind":"generated","value":13,"message":"timeout retry deployment rollback","attr":{"tenant":"tenant_06","release_ring":"stable","version":2},"items":[2,{"rank":0}]}'),
+(14, 'trace-generated-000014', 'generated',
+'{"kind":"generated","value":14,"message":"deployment only","attr":{"tenant":"tenant_00","release_ring":"canary","version":3},"items":[3,{"rank":1}]}');
+insert into observations values
+(8, 'trace-edge-large', 'large_value',
+json_object('kind', 'edge', 'large', concat(repeat('L', 65535), 'L')));
+select count(*) as accepted_rows from observations;
+➤ accepted_rows[-5,64,0]  𝄀
+14
+select id,
+json_contains_path(payload, 'one', '$.optional') as path_present,
+json_type(json_extract(payload, '$.optional')) as optional_type,
+json_extract(payload, '$.optional') as optional_value
+from observations
+where id in (1, 2)
+order by id;
+➤ id[-5,64,0]  ¦  path_present[-5,64,0]  ¦  optional_type[12,65535,0]  ¦  optional_value[-1,2147483647,0]  𝄀
+1  ¦  0  ¦  null  ¦  null  𝄀
+2  ¦  1  ¦  NULL  ¦  null
+select id,
+json_type(json_extract(payload, '$.value')) as value_type,
+json_extract(payload, '$.value') as value
+from observations
+where id in (3, 4, 5)
+order by id;
+➤ id[-5,64,0]  ¦  value_type[12,65535,0]  ¦  value[-1,2147483647,0]  𝄀
+3  ¦  INTEGER  ¦  42  𝄀
+4  ¦  STRING  ¦  "42"  𝄀
+5  ¦  BOOLEAN  ¦  true
+select u.*
+from observations as t, unnest(t.payload, '$.items') as u
+where t.id = 6
+order by u.seq;
+➤ col[12,65535,0]  ¦  seq[4,32,0]  ¦  key[12,65535,0]  ¦  path[12,65535,0]  ¦  index[4,32,0]  ¦  value[-1,2147483647,0]  ¦  this[-1,2147483647,0]  𝄀
+t.payload  ¦  0  ¦  null  ¦  $.items[0]  ¦  0  ¦  1  ¦  [1, "two", {"name": "three"}]  𝄀
+t.payload  ¦  1  ¦  null  ¦  $.items[1]  ¦  1  ¦  "two"  ¦  [1, "two", {"name": "three"}]  𝄀
+t.payload  ¦  2  ¦  null  ¦  $.items[2]  ¦  2  ¦  {"name": "three"}  ¦  [1, "two", {"name": "three"}]
+select json_unquote(json_extract(payload,
+'$.deep.level_1.level_2.level_3.level_4.level_5.level_6.level_7.level_8')) as leaf
+from observations
+where id = 7;
+➤ leaf[12,65535,0]  𝄀
+leaf
+select char_length(json_unquote(json_extract(payload, '$.large'))) as value_length
+from observations
+where id = 8;
+➤ value_length[-5,64,0]  𝄀
+65536
+select id,
+json_extract(payload, '$.first') as first_value,
+json_extract(payload, '$.second') as second_value,
+json_extract(payload, '$.nested.a') as nested_a,
+json_extract(payload, '$.nested.b') as nested_b
+from observations
+where id in (9, 10)
+order by id;
+➤ id[-5,64,0]  ¦  first_value[-1,2147483647,0]  ¦  second_value[-1,2147483647,0]  ¦  nested_a[-1,2147483647,0]  ¦  nested_b[-1,2147483647,0]  𝄀
+9  ¦  1  ¦  2  ¦  3  ¦  4  𝄀
+10  ¦  1  ¦  2  ¦  3  ¦  4
+select id,
+json_extract(payload, '$.old_path') as old_path,
+json_extract(payload, '$.new_path') as new_path
+from observations
+where id in (11, 12)
+order by id;
+➤ id[-5,64,0]  ¦  old_path[-1,2147483647,0]  ¦  new_path[-1,2147483647,0]  𝄀
+11  ¦  "old"  ¦  null  𝄀
+12  ¦  "old"  ¦  "new"
+insert into sql_null_observations values
+(1, null),
+(2, cast('null' as json));
+select id,
+payload is null as is_sql_null,
+json_type(payload) as json_type
+from sql_null_observations
+order by id;
+➤ id[-5,64,0]  ¦  is_sql_null[-7,1,0]  ¦  json_type[12,65535,0]  𝄀
+1  ¦  1  ¦  null  𝄀
+2  ¦  0  ¦  NULL
+select count(*) as element_count
+from observations as t, unnest(t.payload, '$.items') as u
+where t.id = 6;
+➤ element_count[-5,64,0]  𝄀
+3
+select json_unquote(json_extract(payload, '$.kind')) as kind,
+count(*) as row_count
+from observations
+group by kind
+order by kind;
+➤ kind[12,65535,0]  ¦  row_count[-5,64,0]  𝄀
+edge  ¦  5  𝄀
+evolution  ¦  2  𝄀
+generated  ¦  2  𝄀
+mixed  ¦  3  𝄀
+order  ¦  2
+select count(*) as message_rows
+from observations
+where json_unquote(json_extract(payload, '$.message')) like '%deployment%rollback%';
+➤ message_rows[-5,64,0]  𝄀
+1
+create fulltext2 index ft_payload on observations(payload) with parser json;
+select count(*) as bare_match_rows
+from observations
+where match(payload) against('deployment' in boolean mode);
+➤ bare_match_rows[-5,64,0]  𝄀
+0
+select id
+from observations
+where json_extract_string(payload, '$.message') = 'timeout retry deployment rollback'
+order by id;
+➤ id[-5,64,0]  𝄀
+13
+select id
+from observations
+where json_extract_string(payload, '$.other') = 'deployment'
+order by id;
+➤ id[-5,64,0]  𝄀
+4
+insert into malformed_observations values ('{"id":"not-an-integer","payload":');
+invalid input: json text {"id":"not-an-integer","payload":
+select count(*) as accepted_rows from malformed_observations;
+➤ accepted_rows[-5,64,0]  𝄀
+0
+insert into observations (id, trace_id, case_tag, payload)
+values (20001, 'trace-direct-insert', 'direct_insert',
+cast('{"kind":"insert","value":123}' as json));
+select id,
+json_unquote(json_extract(payload, '$.kind')) as kind,
+json_extract(payload, '$.value') as value
+from observations
+where id = 20001;
+➤ id[-5,64,0]  ¦  kind[12,65535,0]  ¦  value[-1,2147483647,0]  𝄀
+20001  ¦  insert  ¦  123
+drop database json_variant_baseline_bvt;

--- a/test/distributed/cases/json_variant/json_variant_baseline.result
+++ b/test/distributed/cases/json_variant/json_variant_baseline.result
@@ -9,13 +9,35 @@ case_tag varchar(64) not null,
 payload json null,
 primary key (id)
 );
+create table load_observations (
+id bigint not null,
+trace_id varchar(128) not null,
+case_tag varchar(64) not null,
+payload json null,
+primary key (id)
+);
 create table sql_null_observations (
 id bigint primary key,
 payload json null
 );
 create table malformed_observations (
-raw_data json not null
+id bigint not null,
+trace_id varchar(128) not null,
+case_tag varchar(64) not null,
+payload json not null
 );
+load data infile {'filepath'='$resources/json_variant/json_variant_load_valid.jl','format'='jsonline','jsondata'='object'} into table load_observations;
+select count(*) as loaded_rows from load_observations;
+➤ loaded_rows[-5,64,0]  𝄀
+3
+select id,
+json_type(json_extract(payload, '$.value')) as value_type
+from load_observations
+order by id;
+➤ id[-5,64,0]  ¦  value_type[12,65535,0]  𝄀
+30001  ¦  INTEGER  𝄀
+30002  ¦  STRING  𝄀
+30003  ¦  BOOLEAN
 insert into observations values
 (1, 'trace-edge-missing', 'missing_path',
 '{"kind":"edge","attr":{"present":"yes"}}'),
@@ -158,8 +180,8 @@ where json_extract_string(payload, '$.other') = 'deployment'
 order by id;
 ➤ id[-5,64,0]  𝄀
 4
-insert into malformed_observations values ('{"id":"not-an-integer","payload":');
-invalid input: json text {"id":"not-an-integer","payload":
+load data infile {'filepath'='$resources/json_variant/json_variant_load_malformed.jl','format'='jsonline','jsondata'='object'} into table malformed_observations;
+invalid input: the line is not a well-formed json object
 select count(*) as accepted_rows from malformed_observations;
 ➤ accepted_rows[-5,64,0]  𝄀
 0

--- a/test/distributed/cases/json_variant/json_variant_baseline.sql
+++ b/test/distributed/cases/json_variant/json_variant_baseline.sql
@@ -1,0 +1,181 @@
+-- Public SQL conversion of the JSON/VARIANT semantic baseline from issue
+-- #27374. The workflow uses a generated 10K-row fixture; BVT keeps the same
+-- edge dimensions in a small deterministic fixture so it can run quickly.
+--
+-- JSON parser indexes (key, value) tuples. It is not a free-text MATCH index;
+-- JSON path comparisons are the supported indexed query surface.
+
+drop database if exists json_variant_baseline_bvt;
+create database json_variant_baseline_bvt;
+use json_variant_baseline_bvt;
+
+set experimental_fulltext2_index = 1;
+
+create table observations (
+    id bigint not null,
+    trace_id varchar(128) not null,
+    case_tag varchar(64) not null,
+    payload json null,
+    primary key (id)
+);
+
+create table sql_null_observations (
+    id bigint primary key,
+    payload json null
+);
+
+create table malformed_observations (
+    raw_data json not null
+);
+
+-- C001-C008: missing paths, JSON null, scalar types, arrays, deep paths,
+-- large values, key reordering, and path evolution.
+insert into observations values
+    (1, 'trace-edge-missing', 'missing_path',
+        '{"kind":"edge","attr":{"present":"yes"}}'),
+    (2, 'trace-edge-json-null', 'json_null',
+        '{"kind":"edge","optional":null}'),
+    (3, 'trace-edge-int', 'mixed_int',
+        '{"kind":"mixed","value":42}'),
+    (4, 'trace-edge-string', 'mixed_string',
+        '{"kind":"mixed","value":"42","other":"deployment"}'),
+    (5, 'trace-edge-bool', 'mixed_bool',
+        '{"kind":"mixed","value":true}'),
+    (6, 'trace-edge-array', 'array_object',
+        '{"kind":"edge","items":[1,"two",{"name":"three"}],"attr":{"array_length":3}}'),
+    (7, 'trace-edge-deep', 'deep_nesting',
+        '{"kind":"edge","deep":{"level_1":{"level_2":{"level_3":{"level_4":{"level_5":{"level_6":{"level_7":{"level_8":"leaf"}}}}}}}}}'),
+    (9, 'trace-edge-order-a', 'key_order_a',
+        '{"kind":"order","first":1,"second":2,"nested":{"a":3,"b":4}}'),
+    (10, 'trace-edge-order-b', 'key_order_b',
+        '{"nested":{"b":4,"a":3},"second":2,"kind":"order","first":1}'),
+    (11, 'trace-edge-evolution-old', 'path_evolution_old',
+        '{"kind":"evolution","schema_version":1,"old_path":"old"}'),
+    (12, 'trace-edge-evolution-new', 'path_evolution_new',
+        '{"kind":"evolution","schema_version":2,"new_path":"new","old_path":"old"}'),
+    (13, 'trace-generated-000013', 'generated',
+        '{"kind":"generated","value":13,"message":"timeout retry deployment rollback","attr":{"tenant":"tenant_06","release_ring":"stable","version":2},"items":[2,{"rank":0}]}'),
+    (14, 'trace-generated-000014', 'generated',
+        '{"kind":"generated","value":14,"message":"deployment only","attr":{"tenant":"tenant_00","release_ring":"canary","version":3},"items":[3,{"rank":1}]}');
+
+-- Keep the workflow's 64 KiB large-value boundary without checking in a
+-- generated fixture file.
+insert into observations values
+    (8, 'trace-edge-large', 'large_value',
+        json_object('kind', 'edge', 'large', concat(repeat('L', 65535), 'L')));
+
+-- C001: accepted row count.
+select count(*) as accepted_rows from observations;
+
+-- C002: a missing path and a present JSON null remain distinguishable.
+select id,
+       json_contains_path(payload, 'one', '$.optional') as path_present,
+       json_type(json_extract(payload, '$.optional')) as optional_type,
+       json_extract(payload, '$.optional') as optional_value
+from observations
+where id in (1, 2)
+order by id;
+
+-- C003: integer, string, and boolean JSON scalar types retain their type.
+select id,
+       json_type(json_extract(payload, '$.value')) as value_type,
+       json_extract(payload, '$.value') as value
+from observations
+where id in (3, 4, 5)
+order by id;
+
+-- C004: public array expansion through UNNEST.
+select u.*
+from observations as t, unnest(t.payload, '$.items') as u
+where t.id = 6
+order by u.seq;
+
+-- C005: deep path extraction.
+select json_unquote(json_extract(payload,
+       '$.deep.level_1.level_2.level_3.level_4.level_5.level_6.level_7.level_8')) as leaf
+from observations
+where id = 7;
+
+-- C006: large value preservation.
+select char_length(json_unquote(json_extract(payload, '$.large'))) as value_length
+from observations
+where id = 8;
+
+-- C007: key order does not change projected values.
+select id,
+       json_extract(payload, '$.first') as first_value,
+       json_extract(payload, '$.second') as second_value,
+       json_extract(payload, '$.nested.a') as nested_a,
+       json_extract(payload, '$.nested.b') as nested_b
+from observations
+where id in (9, 10)
+order by id;
+
+-- C008: old and new paths can coexist during schema evolution.
+select id,
+       json_extract(payload, '$.old_path') as old_path,
+       json_extract(payload, '$.new_path') as new_path
+from observations
+where id in (11, 12)
+order by id;
+
+-- C009: SQL NULL and JSON null are separate states.
+insert into sql_null_observations values
+    (1, null),
+    (2, cast('null' as json));
+select id,
+       payload is null as is_sql_null,
+       json_type(payload) as json_type
+from sql_null_observations
+order by id;
+
+-- C010: array cardinality through the same public UNNEST path.
+select count(*) as element_count
+from observations as t, unnest(t.payload, '$.items') as u
+where t.id = 6;
+
+-- C011: aggregation over an extracted JSON path.
+select json_unquote(json_extract(payload, '$.kind')) as kind,
+       count(*) as row_count
+from observations
+group by kind
+order by kind;
+
+-- C012: portable text retrieval remains available without a native text
+-- parser. Only row 13 contains the ordered deployment/rollback phrase.
+select count(*) as message_rows
+from observations
+where json_unquote(json_extract(payload, '$.message')) like '%deployment%rollback%';
+
+-- C014: a JSON tuple index is deliberately not a free-text MATCH index. The
+-- old benchmark expected this to equal C012, which is stale after #27821.
+create fulltext2 index ft_payload on observations(payload) with parser json;
+select count(*) as bare_match_rows
+from observations
+where match(payload) against('deployment' in boolean mode);
+
+-- JSON path equality is the indexed/native replacement and remains key-aware.
+select id
+from observations
+where json_extract_string(payload, '$.message') = 'timeout retry deployment rollback'
+order by id;
+select id
+from observations
+where json_extract_string(payload, '$.other') = 'deployment'
+order by id;
+
+-- C013: malformed JSON is rejected and cannot add a row.
+insert into malformed_observations values ('{"id":"not-an-integer","payload":');
+select count(*) as accepted_rows from malformed_observations;
+
+-- C015: direct JSON INSERT persists typed values.
+insert into observations (id, trace_id, case_tag, payload)
+values (20001, 'trace-direct-insert', 'direct_insert',
+        cast('{"kind":"insert","value":123}' as json));
+select id,
+       json_unquote(json_extract(payload, '$.kind')) as kind,
+       json_extract(payload, '$.value') as value
+from observations
+where id = 20001;
+
+drop database json_variant_baseline_bvt;

--- a/test/distributed/cases/json_variant/json_variant_baseline.sql
+++ b/test/distributed/cases/json_variant/json_variant_baseline.sql
@@ -19,14 +19,34 @@ create table observations (
     primary key (id)
 );
 
+create table load_observations (
+    id bigint not null,
+    trace_id varchar(128) not null,
+    case_tag varchar(64) not null,
+    payload json null,
+    primary key (id)
+);
+
 create table sql_null_observations (
     id bigint primary key,
     payload json null
 );
 
 create table malformed_observations (
-    raw_data json not null
+    id bigint not null,
+    trace_id varchar(128) not null,
+    case_tag varchar(64) not null,
+    payload json not null
 );
+
+-- C001 ingestion smoke: load JSON Lines through the public JSON loader and
+-- preserve scalar types in the target JSON column.
+load data infile {'filepath'='$resources/json_variant/json_variant_load_valid.jl','format'='jsonline','jsondata'='object'} into table load_observations;
+select count(*) as loaded_rows from load_observations;
+select id,
+       json_type(json_extract(payload, '$.value')) as value_type
+from load_observations
+order by id;
 
 -- C001-C008: missing paths, JSON null, scalar types, arrays, deep paths,
 -- large values, key reordering, and path evolution.
@@ -164,8 +184,8 @@ from observations
 where json_extract_string(payload, '$.other') = 'deployment'
 order by id;
 
--- C013: malformed JSON is rejected and cannot add a row.
-insert into malformed_observations values ('{"id":"not-an-integer","payload":');
+-- C013: malformed JSON Lines are rejected and cannot add a row.
+load data infile {'filepath'='$resources/json_variant/json_variant_load_malformed.jl','format'='jsonline','jsondata'='object'} into table malformed_observations;
 select count(*) as accepted_rows from malformed_observations;
 
 -- C015: direct JSON INSERT persists typed values.

--- a/test/distributed/resources/json_variant/json_variant_load_malformed.jl
+++ b/test/distributed/resources/json_variant/json_variant_load_malformed.jl
@@ -1,0 +1,1 @@
+not-json

--- a/test/distributed/resources/json_variant/json_variant_load_valid.jl
+++ b/test/distributed/resources/json_variant/json_variant_load_valid.jl
@@ -1,0 +1,3 @@
+{"id":30001,"trace_id":"trace-load-001","case_tag":"load_jsonline","payload":{"kind":"loaded","value":42}}
+{"id":30002,"trace_id":"trace-load-002","case_tag":"load_jsonline","payload":{"kind":"loaded","value":"42"}}
+{"id":30003,"trace_id":"trace-load-003","case_tag":"load_jsonline","payload":{"kind":"loaded","value":true}}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #27374

## What this PR does / why we need it:

This PR converts the JSON/VARIANT semantic dimensions from issue #27374 into a self-contained MatrixOne BVT case at `test/distributed/cases/json_variant/json_variant_baseline.sql` and its generated result file.

The deterministic fixture covers:

- public JSON Lines `LOAD DATA` ingestion with scalar-type preservation;
- malformed JSON Lines rejection with an explicit loader error and no inserted rows;
- direct JSON INSERT;
- missing paths versus JSON null and SQL NULL;
- JSON scalar type fidelity;
- arrays and `UNNEST`;
- deep paths and the 64 KiB value boundary;
- key ordering and path evolution;
- extracted-path aggregation and portable text retrieval; and
- the current `WITH PARSER json` FULLTEXT2 contract, including key-aware JSON path probes.

The BVT intentionally keeps a small deterministic fixture for per-commit execution. The workflow-only generated 10K/100K scale, independent oracle artifacts, performance runs, and restart/recovery orchestration remain in `mo-benchmark` and are not duplicated here. No production code is changed.

For the native JSON parser, bare `MATCH(payload)` is expected to return zero because the index stores key/value tuples rather than free-text terms; JSON path equality remains the supported indexed query surface. This reflects the parser contract introduced by #27821.

## Validation

- Ran mo-tester in an isolated Docker MatrixOne instance with an 8 GiB memory cap.
- Generated results with:
  `mo-tester/run.sh -m genrs -g -p test/distributed/cases/json_variant/json_variant_baseline.sql`
- Executed the case with metadata comparison enabled:
  `mo-tester/run.sh -m run -g -p test/distributed/cases/json_variant/json_variant_baseline.sql`
- Result: 35/35 statements passed in approximately 0.24 seconds.
