### PR TITLE
fix(sql): preserve prepared numeric cast rounding

### DIFF
--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -334,16 +334,9 @@ func floatToUint64Explicit[T constraints.Float](
 			continue
 		}
 		floatValue := float64(value)
-		rounded := math.RoundToEven(floatValue)
-		if math.IsNaN(rounded) || math.IsInf(rounded, 0) ||
-			rounded < -math.Exp2(63) || rounded >= math.Exp2(64) {
-			return moerr.NewOutOfRangeNoCtxf("uint64", "value '%s'", strconv.FormatFloat(floatValue, 'g', -1, 64))
-		}
-		var converted uint64
-		if rounded < 0 {
-			converted = uint64(int64(rounded))
-		} else {
-			converted = uint64(rounded)
+		converted, err := explicitFloatToUint64(floatValue)
+		if err != nil {
+			return err
 		}
 		if err := to.Append(converted, false); err != nil {
 			return err
@@ -366,16 +359,68 @@ func floatToInt64Explicit[T constraints.Float](
 			continue
 		}
 		floatValue := float64(value)
-		rounded := math.RoundToEven(floatValue)
-		if math.IsNaN(rounded) || math.IsInf(rounded, 0) ||
-			rounded < -math.Exp2(63) || rounded >= math.Exp2(63) {
-			return moerr.NewOutOfRangeNoCtxf("int64", "value '%s'", strconv.FormatFloat(floatValue, 'g', -1, 64))
+		converted, err := explicitFloatToInt64(floatValue)
+		if err != nil {
+			return err
 		}
-		if err := to.Append(int64(rounded), false); err != nil {
+		if err := to.Append(converted, false); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func explicitFloatToUint64(value float64) (uint64, error) {
+	rounded := math.RoundToEven(value)
+	if math.IsNaN(rounded) || math.IsInf(rounded, 0) ||
+		rounded < -math.Exp2(63) || rounded >= math.Exp2(64) {
+		return 0, moerr.NewOutOfRangeNoCtxf("uint64", "value '%s'", strconv.FormatFloat(value, 'g', -1, 64))
+	}
+	if rounded < 0 {
+		return uint64(int64(rounded)), nil
+	}
+	return uint64(rounded), nil
+}
+
+func explicitFloatToInt64(value float64) (int64, error) {
+	rounded := math.RoundToEven(value)
+	if math.IsNaN(rounded) || math.IsInf(rounded, 0) ||
+		rounded < -math.Exp2(63) || rounded >= math.Exp2(63) {
+		return 0, moerr.NewOutOfRangeNoCtxf("int64", "value '%s'", strconv.FormatFloat(value, 'g', -1, 64))
+	}
+	return int64(rounded), nil
+}
+
+func preparedFloatToUint64(input string) (uint64, error) {
+	value, err := strconv.ParseFloat(input, 64)
+	if err != nil {
+		return 0, err
+	}
+	return explicitFloatToUint64(value)
+}
+
+func preparedFloatToInt64(input string) (int64, error) {
+	value, err := strconv.ParseFloat(input, 64)
+	if err != nil {
+		return 0, err
+	}
+	return explicitFloatToInt64(value)
+}
+
+func preparedDecimalToUint64(input string) (uint64, error) {
+	rounded, err := roundPreparedDecimalIntegerString(input)
+	if err != nil {
+		return 0, err
+	}
+	return explicitUint64FromIntegerString(rounded)
+}
+
+func preparedDecimalToInt64(input string) (int64, error) {
+	rounded, err := roundPreparedDecimalIntegerString(input)
+	if err != nil {
+		return 0, err
+	}
+	return decimalInt64Explicit(rounded)
 }
 
 func decimalToUint64Explicit[T types.FixedSizeTExceptStrType](
@@ -6558,6 +6603,27 @@ func strToSignedWithProc[T constraints.Signed](
 				result = T(r)
 			} else {
 				s := strings.TrimSpace(convertByteSliceToString(v))
+				kind := from.GetSourceVector().GetPrepareParamKindAt(int(i))
+				if len(explicit) > 0 && explicit[0] && bitSize == 64 &&
+					(kind == vector.PrepareParamFloat || kind == vector.PrepareParamDecimal) {
+					var r int64
+					var err error
+					if kind == vector.PrepareParamFloat {
+						r, err = preparedFloatToInt64(s)
+					} else {
+						r, err = preparedDecimalToInt64(s)
+					}
+					if err != nil {
+						if strings.Contains(err.Error(), "value out of range") || errors.Is(err, strconv.ErrRange) {
+							return moerr.NewOutOfRangef(ctx, "int64", "value '%s'", s)
+						}
+						return moerr.NewInvalidArg(ctx, "cast to int", s)
+					}
+					if err = to.Append(T(r), false); err != nil {
+						return err
+					}
+					continue
+				}
 				var r int64
 				var err error
 				var integerPrefix string
@@ -7164,6 +7230,26 @@ func strToUnsignedWithProc[T constraints.Unsigned](
 				val, tErr = strconv.ParseUint(s, 16, 64)
 			} else {
 				s := strings.TrimSpace(convertByteSliceToString(v))
+				kind := from.GetSourceVector().GetPrepareParamKindAt(int(i))
+				if len(explicit) > 0 && explicit[0] && bitSize == 64 &&
+					(kind == vector.PrepareParamFloat || kind == vector.PrepareParamDecimal) {
+					var value uint64
+					if kind == vector.PrepareParamFloat {
+						value, tErr = preparedFloatToUint64(s)
+					} else {
+						value, tErr = preparedDecimalToUint64(s)
+					}
+					if tErr != nil {
+						if strings.Contains(tErr.Error(), "value out of range") || errors.Is(tErr, strconv.ErrRange) {
+							return moerr.NewOutOfRangef(ctx, "uint64", "value '%s'", s)
+						}
+						return moerr.NewInvalidArg(ctx, "cast to uint64", s)
+					}
+					if tErr = to.Append(T(value), false); tErr != nil {
+						return tErr
+					}
+					continue
+				}
 				res = &s
 				if len(explicit) > 1 && explicit[1] {
 					val, integerPrefix, integerHasPrefix, integerOutOfRange, tErr =

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -407,6 +407,10 @@ func preparedFloatToInt64(input string) (int64, error) {
 	return explicitFloatToInt64(value)
 }
 
+func isPreparedNumericCastOutOfRange(err error) bool {
+	return moerr.IsMoErrCode(err, moerr.ErrOutOfRange) || errors.Is(err, strconv.ErrRange)
+}
+
 func preparedDecimalToUint64(input string) (uint64, error) {
 	rounded, err := roundPreparedDecimalIntegerString(input)
 	if err != nil {
@@ -6614,7 +6618,7 @@ func strToSignedWithProc[T constraints.Signed](
 						r, err = preparedDecimalToInt64(s)
 					}
 					if err != nil {
-						if strings.Contains(err.Error(), "value out of range") || errors.Is(err, strconv.ErrRange) {
+						if isPreparedNumericCastOutOfRange(err) {
 							return moerr.NewOutOfRangef(ctx, "int64", "value '%s'", s)
 						}
 						return moerr.NewInvalidArg(ctx, "cast to int", s)
@@ -7240,7 +7244,7 @@ func strToUnsignedWithProc[T constraints.Unsigned](
 						value, tErr = preparedDecimalToUint64(s)
 					}
 					if tErr != nil {
-						if strings.Contains(tErr.Error(), "value out of range") || errors.Is(tErr, strconv.ErrRange) {
+						if isPreparedNumericCastOutOfRange(tErr) {
 							return moerr.NewOutOfRangef(ctx, "uint64", "value '%s'", s)
 						}
 						return moerr.NewInvalidArg(ctx, "cast to uint64", s)

--- a/pkg/sql/plan/function/func_explicit_cast_test.go
+++ b/pkg/sql/plan/function/func_explicit_cast_test.go
@@ -334,6 +334,33 @@ func TestExplicitCastPreparedNumericTextUsesSourceKind(t *testing.T) {
 	})
 }
 
+func TestExplicitCastPreparedFloatOverflowKeepsRangeError(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	for _, test := range []struct {
+		name   string
+		target types.Type
+		zero   any
+	}{
+		{name: "signed", target: types.T_int64.ToType(), zero: []int64{}},
+		{name: "unsigned", target: types.T_uint64.ToType(), zero: []uint64{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testCase := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{"1e100"}, nil),
+					NewFunctionTestInput(test.target, test.zero, nil),
+				},
+				NewFunctionTestResult(test.target, true, test.zero, nil), NewExplicitCast)
+			testCase.parameters[0].SetPrepareParamKind(vector.PrepareParamFloat)
+			require.NoError(t, testCase.result.PreExtendAndReset(testCase.fnLength))
+			err := testCase.fn(testCase.parameters, testCase.result, testCase.proc,
+				testCase.fnLength, testCase.selectList)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrOutOfRange), err)
+		})
+	}
+}
+
 func TestExplicitCastFloatOverflowErrors(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	tests := []struct {

--- a/pkg/sql/plan/function/func_explicit_cast_test.go
+++ b/pkg/sql/plan/function/func_explicit_cast_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
@@ -266,6 +267,71 @@ func TestExplicitCastFloatRoundingToEven(t *testing.T) {
 			require.True(t, succeed, info)
 		})
 	}
+}
+
+func TestExplicitCastPreparedNumericTextUsesSourceKind(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	runSigned := func(name string, kind vector.PrepareParamKind, values []string, want []int64) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			testCase := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), values, nil),
+					NewFunctionTestInput(types.T_int64.ToType(), []int64{}, nil),
+				},
+				NewFunctionTestResult(types.T_int64.ToType(), false, want, nil), NewExplicitCast)
+			testCase.parameters[0].SetPrepareParamKind(kind)
+			succeed, info := testCase.Run()
+			require.True(t, succeed, info)
+		})
+	}
+
+	runUnsigned := func(name string, kind vector.PrepareParamKind, values []string, want []uint64) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			testCase := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), values, nil),
+					NewFunctionTestInput(types.T_uint64.ToType(), []uint64{}, nil),
+				},
+				NewFunctionTestResult(types.T_uint64.ToType(), false, want, nil), NewExplicitCast)
+			testCase.parameters[0].SetPrepareParamKind(kind)
+			succeed, info := testCase.Run()
+			require.True(t, succeed, info)
+		})
+	}
+
+	runSigned("float uses round-to-even", vector.PrepareParamFloat,
+		[]string{"0.5", "1.5", "2.5", "-0.5", "-1.5", "-2.5"},
+		[]int64{0, 2, 2, 0, -2, -2})
+	runSigned("decimal uses exact half-away-from-zero rounding", vector.PrepareParamDecimal,
+		[]string{"0.5", "1.5", "2.5", "-0.5", "-1.5", "-2.5", "9007199254740993.5"},
+		[]int64{1, 2, 3, -1, -2, -3, 9007199254740994})
+	runUnsigned("float uses round-to-even", vector.PrepareParamFloat,
+		[]string{"1.5", "2.5", "-1.5", "-2.5"},
+		[]uint64{2, 2, math.MaxUint64 - 1, math.MaxUint64 - 1})
+	runUnsigned("decimal uses exact half-away-from-zero rounding", vector.PrepareParamDecimal,
+		[]string{"1.5", "2.5", "-1.5", "-2.5"},
+		[]uint64{2, 3, math.MaxUint64 - 1, math.MaxUint64 - 2})
+	runSigned("ordinary string keeps integer-prefix semantics", vector.PrepareParamNone,
+		[]string{"1.5", "-1.5"}, []int64{1, -1})
+	runUnsigned("ordinary string keeps integer-prefix semantics", vector.PrepareParamNone,
+		[]string{"1.5", "-1.5"}, []uint64{1, math.MaxUint64})
+
+	t.Run("row-local kinds", func(t *testing.T) {
+		testCase := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"1.5", "1.5", "1.5"}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{}, nil),
+			},
+			NewFunctionTestResult(types.T_int64.ToType(), false, []int64{2, 2, 1}, nil), NewExplicitCast)
+		testCase.parameters[0].SetPrepareParamKinds([]vector.PrepareParamKind{
+			vector.PrepareParamFloat, vector.PrepareParamDecimal, vector.PrepareParamNone,
+		})
+		succeed, info := testCase.Run()
+		require.True(t, succeed, info)
+	})
 }
 
 func TestExplicitCastFloatOverflowErrors(t *testing.T) {

--- a/pkg/tests/issues/issue_28582_test.go
+++ b/pkg/tests/issues/issue_28582_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
+)
+
+func TestIssue28582PreparedNumericCastKeepsRuntimeKind(t *testing.T) {
+	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		db, err := sql.Open("mysql", fmt.Sprintf(
+			"dump:111@tcp(127.0.0.1:%d)/?interpolateParams=false", port))
+		require.NoError(t, err)
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		defer db.Close()
+
+		dbName := testutils.GetDatabaseName(t)
+		execSQLRequire(t, ctx, db, "create database `"+dbName+"`")
+		defer execSQLMaybe(t, ctx, db, "drop database if exists `"+dbName+"`")
+
+		execSQLRequire(t, ctx, db,
+			"prepare issue28582_cast from 'select cast(? as signed), cast(? as unsigned)'")
+		defer execSQLMaybe(t, ctx, db, "deallocate prepare issue28582_cast")
+
+		assertSQLExecute := func(name, value, wantSigned, wantUnsigned string) {
+			t.Helper()
+			t.Run(name, func(t *testing.T) {
+				execSQLRequire(t, ctx, db, "set @issue28582_a = "+value)
+				execSQLRequire(t, ctx, db, "set @issue28582_b = "+value)
+				var signed, unsigned string
+				require.NoError(t, db.QueryRowContext(ctx,
+					"execute issue28582_cast using @issue28582_a, @issue28582_b").Scan(&signed, &unsigned))
+				require.Equal(t, wantSigned, signed)
+				require.Equal(t, wantUnsigned, unsigned)
+			})
+		}
+		assertSQLExecute("decimal positive half", "1.5", "2", "2")
+		assertSQLExecute("decimal negative half", "-1.5", "-2", "18446744073709551614")
+		assertSQLExecute("decimal positive non-half", "1.6", "2", "2")
+		assertSQLExecute("decimal negative non-half", "-1.6", "-2", "18446744073709551614")
+
+		binaryStmt, err := db.PrepareContext(ctx, "select cast(? as signed), cast(? as unsigned)")
+		require.NoError(t, err)
+		defer binaryStmt.Close()
+		for _, test := range []struct {
+			name         string
+			value        float64
+			wantSigned   string
+			wantUnsigned string
+		}{
+			{name: "binary positive half", value: 1.5, wantSigned: "2", wantUnsigned: "2"},
+			{name: "binary negative half", value: -1.5, wantSigned: "-2", wantUnsigned: "18446744073709551614"},
+			{name: "binary positive non-half", value: 1.6, wantSigned: "2", wantUnsigned: "2"},
+			{name: "binary negative non-half", value: -1.6, wantSigned: "-2", wantUnsigned: "18446744073709551614"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				var signed, unsigned string
+				require.NoError(t, binaryStmt.QueryRowContext(ctx, test.value, test.value).Scan(&signed, &unsigned))
+				require.Equal(t, test.wantSigned, signed)
+				require.Equal(t, test.wantUnsigned, unsigned)
+			})
+		}
+
+		execSQLRequire(t, ctx, db,
+			"create table `"+dbName+"`.dst (id int primary key, d decimal(10,1))")
+		execSQLRequire(t, ctx, db,
+			"prepare issue28582_insert from 'insert into `"+dbName+"`.dst values (?, cast(? as signed))'")
+		defer execSQLMaybe(t, ctx, db, "deallocate prepare issue28582_insert")
+		execSQLRequire(t, ctx, db, "set @issue28582_id = 1")
+		execSQLRequire(t, ctx, db, "set @issue28582_d = 1.5")
+		execSQLRequire(t, ctx, db, "execute issue28582_insert using @issue28582_id, @issue28582_d")
+		execSQLRequire(t, ctx, db, "set @issue28582_id = 2")
+		execSQLRequire(t, ctx, db, "set @issue28582_d = -1.5")
+		execSQLRequire(t, ctx, db, "execute issue28582_insert using @issue28582_id, @issue28582_d")
+
+		rows, err := db.QueryContext(ctx, "select id, d from `"+dbName+"`.dst order by id")
+		require.NoError(t, err)
+		defer rows.Close()
+		for _, expected := range []struct {
+			id int64
+			d  string
+		}{
+			{id: 1, d: "2.0"},
+			{id: 2, d: "-2.0"},
+		} {
+			require.True(t, rows.Next())
+			var id int64
+			var d string
+			require.NoError(t, rows.Scan(&id, &d))
+			require.Equal(t, expected.id, id)
+			require.Equal(t, expected.d, d)
+		}
+		require.False(t, rows.Next())
+		require.NoError(t, rows.Err())
+	})
+}

--- a/test/distributed/cases/prepare/issue_28582_prepared_numeric_cast.result
+++ b/test/distributed/cases/prepare/issue_28582_prepared_numeric_cast.result
@@ -1,0 +1,53 @@
+drop database if exists issue_28582_prepared_numeric_cast;
+create database issue_28582_prepared_numeric_cast;
+use issue_28582_prepared_numeric_cast;
+prepare cast_numeric from
+'select cast(? as signed) as signed_value, cast(? as unsigned) as unsigned_value';
+set @decimal_value = 1.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+2  ¦  2
+set @decimal_value = -1.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+-2  ¦  18446744073709551614
+set @decimal_value = 2.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+3  ¦  3
+set @decimal_value = -2.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+-3  ¦  18446744073709551613
+set @float_value = 2.5e0;
+execute cast_numeric using @float_value, @float_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+2  ¦  2
+set @float_value = -2.5e0;
+execute cast_numeric using @float_value, @float_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+-2  ¦  18446744073709551614
+set @string_value = '1.5';
+execute cast_numeric using @string_value, @string_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+1  ¦  1
+set @string_value = '-1.5';
+execute cast_numeric using @string_value, @string_value;
+➤ signed_value[-5,64,0]  ¦  unsigned_value[-5,64,0]  𝄀
+-1  ¦  18446744073709551615
+deallocate prepare cast_numeric;
+create table cast_target (id int primary key, value decimal(10,1));
+prepare cast_insert from
+'insert into cast_target values (?, cast(? as signed))';
+set @id = 1;
+set @decimal_value = 1.5;
+execute cast_insert using @id, @decimal_value;
+set @id = 2;
+set @decimal_value = -1.5;
+execute cast_insert using @id, @decimal_value;
+deallocate prepare cast_insert;
+select id, value from cast_target order by id;
+➤ id[4,32,0]  ¦  value[3,10,1]  𝄀
+1  ¦  2.0  𝄀
+2  ¦  -2.0
+drop database issue_28582_prepared_numeric_cast;

--- a/test/distributed/cases/prepare/issue_28582_prepared_numeric_cast.sql
+++ b/test/distributed/cases/prepare/issue_28582_prepared_numeric_cast.sql
@@ -1,0 +1,49 @@
+-- @suit
+
+-- @case
+-- @desc: Issue #28582: prepared numeric CAST rounds according to its source type.
+-- @label:bvt
+drop database if exists issue_28582_prepared_numeric_cast;
+create database issue_28582_prepared_numeric_cast;
+use issue_28582_prepared_numeric_cast;
+
+prepare cast_numeric from
+    'select cast(? as signed) as signed_value, cast(? as unsigned) as unsigned_value';
+
+-- SQL numeric assignments preserve exact DECIMAL semantics.
+set @decimal_value = 1.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+set @decimal_value = -1.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+set @decimal_value = 2.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+set @decimal_value = -2.5;
+execute cast_numeric using @decimal_value, @decimal_value;
+
+-- Scientific notation is an approximate FLOAT parameter and keeps ties-to-even.
+set @float_value = 2.5e0;
+execute cast_numeric using @float_value, @float_value;
+set @float_value = -2.5e0;
+execute cast_numeric using @float_value, @float_value;
+
+-- Ordinary strings retain integer-prefix cast semantics.
+set @string_value = '1.5';
+execute cast_numeric using @string_value, @string_value;
+set @string_value = '-1.5';
+execute cast_numeric using @string_value, @string_value;
+
+deallocate prepare cast_numeric;
+
+create table cast_target (id int primary key, value decimal(10,1));
+prepare cast_insert from
+    'insert into cast_target values (?, cast(? as signed))';
+set @id = 1;
+set @decimal_value = 1.5;
+execute cast_insert using @id, @decimal_value;
+set @id = 2;
+set @decimal_value = -1.5;
+execute cast_insert using @id, @decimal_value;
+deallocate prepare cast_insert;
+select id, value from cast_target order by id;
+
+drop database issue_28582_prepared_numeric_cast;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28582

## What this PR does / why we need it:

fix(sql): preserve prepared numeric cast rounding