### PR TITLE
perf(ivfflat): fuse exact-membership Top-K reads

### DIFF
--- a/docs/design/ivf-exact-membership-topk.md
+++ b/docs/design/ivf-exact-membership-topk.md
@@ -1,0 +1,49 @@
+# Fused IVF exact-membership Top-K reads
+
+Status: approved for implementation
+
+Related issues: matrixorigin/matrixone#24097, matrixorigin/matrixone#27854
+
+## Problem and invariant
+
+The persisted IVF PRE path currently opens the same entries block separately to
+decode the centroid/source-key filter columns, score the surviving embedding
+chunks, and materialize winner columns.  The source key can also be decoded
+again even though membership already read it.
+
+Required membership must remain exact and must run before Top-K.  Deleted or
+invisible rows must never enter the distance heap, and the optimization must
+not replace sparse chunk reads with whole decoded embedding materialization.
+
+## Design
+
+An exact membership filter marks its storage filter as eligible for a fused
+persisted Top-K operation.  The operation loads object metadata once, pins the
+centroid/source-key columns while it computes sorted physical survivors,
+applies transaction tombstones, scores only embedding chunks intersecting
+those survivors through the existing distance implementation, and copies only
+block-local Top-K winner columns.  Output columns already present in the filter
+set are copied from the pinned filter entry instead of read again.
+
+The fast path is limited to non-appendable persisted blocks, exact membership,
+and supported ascending vector Top-K.  In-memory/appendable blocks, approximate
+filters, ordered or descending limits, and unsupported layouts retain the
+existing implementation.  There is no SQL, catalog, wire, or on-disk change.
+
+## Ownership and failures
+
+The block operation owns every IOVector and borrowed decoded view until it
+returns; output vectors own only copied winner data.  The membership filter and
+reader-wide distance heap remain reader-owned.  All error and cancellation
+paths release filter, vector-chunk, metadata, tombstone, and output-prefix
+resources exactly once.  Empty membership results perform no vector scoring.
+
+## Validation
+
+Unit tests compare the fused and legacy results for empty, sparse, and dense
+domains; centroid-prefix intersection; transaction tombstones; NULL and INCLUDE
+columns; chunked and legacy vectors; cache states; invalid contracts; errors;
+and cancellation.  Deterministic I/O assertions prove one metadata load, no
+source-key reread, and no vector-chunk reads without survivors.  Benchmarks
+report selective and dense cases without adding wall-clock assertions to UT or
+BVT.

--- a/pkg/objectio/block_topn.go
+++ b/pkg/objectio/block_topn.go
@@ -45,6 +45,157 @@ type BlockTopNRead struct {
 	released      bool
 }
 
+// ReadBlockBySearchAndTopN keeps exact storage-filter columns pinned while it
+// scores their selected vector rows and copies only winner output columns.
+// selectRows borrows the filter vectors for the duration of the callback and
+// must return sorted physical block offsets. Output destinations retain
+// ownership of any successfully copied prefix when an error is returned.
+func ReadBlockBySearchAndTopN(
+	ctx context.Context,
+	filterColumns []uint16,
+	filterTypes []types.Type,
+	outputColumns []uint16,
+	outputTypes []types.Type,
+	outputDestinations []*vector.Vector,
+	topColumn uint16,
+	topType types.Type,
+	selectRows func([]vector.Vector) ([]int64, error),
+	topReader *IndexReaderTopOp,
+	fs fileservice.FileService,
+	location Location,
+	mp *mpool.MPool,
+	policy fileservice.Policy,
+) (rows []int64, distances []float64, fromCache bool, err error) {
+	if len(filterColumns) == 0 || len(filterColumns) != len(filterTypes) {
+		return nil, nil, false, moerr.NewInvalidInputNoCtx("invalid exact-filter columns for block topn")
+	}
+	if len(outputColumns) != len(outputTypes) || len(outputColumns) != len(outputDestinations) {
+		return nil, nil, false, moerr.NewInvalidInputNoCtx("invalid exact-filter output columns for block topn")
+	}
+	if selectRows == nil || topReader == nil || mp == nil {
+		return nil, nil, false, moerr.NewInvalidInputNoCtx("nil exact-filter block topn input")
+	}
+	if topColumn >= SEQNUM_UPPER || !topType.Oid.IsArrayRelate() || topReader.Typ != topType.Oid ||
+		topReader.OrderedLimit || topReader.Desc {
+		return nil, nil, false, moerr.NewInvalidInputNoCtx("unsupported exact-filter vector topn input")
+	}
+	for i, column := range filterColumns {
+		if column >= SEQNUM_UPPER || column == topColumn {
+			return nil, nil, false, moerr.NewInvalidInputNoCtxf(
+				"invalid exact-filter column %d for vector column %d", column, topColumn,
+			)
+		}
+		if slices.Contains(filterColumns[:i], column) {
+			return nil, nil, false, moerr.NewInvalidInputNoCtxf("duplicate exact-filter column %d", column)
+		}
+	}
+	for i, column := range outputColumns {
+		if outputDestinations[i] == nil || column >= SEQNUM_UPPER || column == topColumn {
+			return nil, nil, false, moerr.NewInvalidInputNoCtxf("invalid exact-filter output column %d", column)
+		}
+		if slices.Contains(outputColumns[:i], column) {
+			return nil, nil, false, moerr.NewInvalidInputNoCtxf("duplicate exact-filter output column %d", column)
+		}
+	}
+
+	meta, err := FastLoadObjectMeta(ctx, &location, false, fs)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	dataMeta := meta.MustGetMeta(SchemaData)
+	name := location.Name().UnsafeString()
+	block := location.ID()
+	filterRead, err := ReadOneBlock(
+		ctx, &dataMeta, name, block, filterColumns, filterTypes, mp, fs, policy, ShareScopedDecodedColumn,
+	)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	defer filterRead.Release()
+	fromCache = len(filterRead.Entries) > 0
+	filterVectors := make([]vector.Vector, len(filterColumns))
+	defer func() {
+		for i := range filterVectors {
+			filterVectors[i].Free(nil)
+		}
+	}()
+	for i := range filterColumns {
+		fromCache = fromCache && filterRead.Entries[i].WasFromCache()
+		if err = MustVectorToCached(&filterVectors[i], filterRead.Entries[i].CachedData); err != nil {
+			return nil, nil, false, err
+		}
+	}
+
+	selectedRows, err := selectRows(filterVectors)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if selectedRows == nil {
+		return nil, nil, false, moerr.NewInvalidInputNoCtx("exact-filter block topn returned nil rows")
+	}
+	previous := int64(-1)
+	rowCount := filterVectors[0].Length()
+	for _, row := range selectedRows {
+		if row < 0 || row >= int64(rowCount) || row <= previous {
+			return nil, nil, false, moerr.NewInvalidInputNoCtx(
+				"exact-filter block topn rows must be sorted, unique, and in range",
+			)
+		}
+		previous = row
+	}
+	if len(selectedRows) == 0 {
+		return []int64{}, []float64{}, fromCache, nil
+	}
+	rows, distances, topFromCache, err := readColumnTopNWithMeta(
+		ctx, &dataMeta, name, block, topColumn, topType, selectedRows, topReader, mp, fs, policy,
+	)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	fromCache = fromCache && topFromCache
+
+	missingColumns := make([]uint16, 0, len(outputColumns))
+	missingTypes := make([]types.Type, 0, len(outputColumns))
+	missingDestinations := make([]*vector.Vector, 0, len(outputColumns))
+	for i, column := range outputColumns {
+		if filterPosition := slices.Index(filterColumns, column); filterPosition >= 0 {
+			if filterTypes[filterPosition] != outputTypes[i] {
+				return nil, nil, false, moerr.NewInvalidInputNoCtxf(
+					"exact-filter output column %d has inconsistent types", column,
+				)
+			}
+			if err = CopyCachedVectorRows(
+				outputDestinations[i], filterRead.Entries[filterPosition].CachedData, rows, mp,
+			); err != nil {
+				return nil, nil, false, err
+			}
+			continue
+		}
+		missingColumns = append(missingColumns, column)
+		missingTypes = append(missingTypes, outputTypes[i])
+		missingDestinations = append(missingDestinations, outputDestinations[i])
+	}
+	if len(missingColumns) == 0 {
+		return rows, distances, fromCache, nil
+	}
+	outputRead, readErr := ReadOneBlock(
+		ctx, &dataMeta, name, block, missingColumns, missingTypes, mp, fs, policy, ShareScopedDecodedColumn,
+	)
+	if readErr != nil {
+		return nil, nil, false, readErr
+	}
+	defer outputRead.Release()
+	for i := range missingColumns {
+		fromCache = fromCache && outputRead.Entries[i].WasFromCache()
+		if err = CopyCachedVectorRows(
+			missingDestinations[i], outputRead.Entries[i].CachedData, rows, mp,
+		); err != nil {
+			return nil, nil, false, err
+		}
+	}
+	return rows, distances, fromCache, nil
+}
+
 func (r *BlockTopNRead) Entry(position int) fileservice.IOEntry { return r.block.Entries[position] }
 func (r *BlockTopNRead) FromCache() bool                        { return r.fromCache }
 

--- a/pkg/objectio/block_topn_test.go
+++ b/pkg/objectio/block_topn_test.go
@@ -162,6 +162,173 @@ func TestBlockTopNSelections(t *testing.T) {
 	}
 }
 
+func TestReadBlockBySearchAndTopNReusesFilterColumns(t *testing.T) {
+	mp := newTopNTestMP(t)
+	source := newTopNTestVector(t, mp, []float32{4, 1, 3, 2, 6, 5})
+	payload, _ := encodeTopNTestChunks(t, source, 2, mp)
+	storage := newBlockTopNTestFS(t)
+	location, meta := persistBlockTopNTest(t, storage, source, payload, mp)
+	filterExtent := meta.GetBlockMeta(0).ColumnMeta(0).Location()
+	topExtent := meta.GetBlockMeta(0).ColumnMeta(1).Location()
+	storage.FlushCache(t.Context())
+	fs := &blockTopNTestFS{FileService: storage}
+
+	pk := vector.NewVec(types.T_int64.ToType())
+	payloadOut := vector.NewVec(types.T_array_float32.ToType())
+	defer pk.Free(mp)
+	defer payloadOut.Free(mp)
+	op := newTopNTestOp(2)
+	rows, distances, _, err := ReadBlockBySearchAndTopN(
+		t.Context(),
+		[]uint16{0},
+		[]types.Type{types.T_int64.ToType()},
+		[]uint16{0, 2},
+		[]types.Type{types.T_int64.ToType(), types.T_array_float32.ToType()},
+		[]*vector.Vector{pk, payloadOut},
+		1,
+		types.T_array_float32.ToType(),
+		func(filters []vector.Vector) ([]int64, error) {
+			require.Len(t, filters, 1)
+			require.Equal(t, []int64{0, 1, 2, 3, 4, 5}, vector.MustFixedColWithTypeCheck[int64](&filters[0]))
+			return []int64{0, 2, 4}, nil
+		},
+		op,
+		fs,
+		location,
+		mp,
+		fileservice.SkipFullFilePreloads,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int64{0, 2}, rows)
+	require.Equal(t, []float64{16, 9}, distances)
+	require.Equal(t, []int64{0, 2}, vector.MustFixedColWithTypeCheck[int64](pk))
+	require.Equal(t, []float32{10}, types.BytesToArray[float32](payloadOut.GetBytesAt(0)))
+	require.Equal(t, []float32{12}, types.BytesToArray[float32](payloadOut.GetBytesAt(1)))
+	require.Equal(t, 1, countTopNReadsWithin(fs.requests, filterExtent), "filter/output column must be read once")
+	require.Positive(t, countTopNReadsWithin(fs.requests, topExtent))
+}
+
+func TestReadBlockBySearchAndTopNEmptyFilterSkipsVector(t *testing.T) {
+	mp := newTopNTestMP(t)
+	source := newTopNTestVector(t, mp, []float32{4, 1, 3, 2})
+	payload, _ := encodeTopNTestChunks(t, source, 2, mp)
+	storage := newBlockTopNTestFS(t)
+	location, meta := persistBlockTopNTest(t, storage, source, payload, mp)
+	topExtent := meta.GetBlockMeta(0).ColumnMeta(1).Location()
+	storage.FlushCache(t.Context())
+	fs := &blockTopNTestFS{FileService: storage}
+	out := vector.NewVec(types.T_int64.ToType())
+	defer out.Free(mp)
+
+	rows, distances, _, err := ReadBlockBySearchAndTopN(
+		t.Context(),
+		[]uint16{0},
+		[]types.Type{types.T_int64.ToType()},
+		[]uint16{0},
+		[]types.Type{types.T_int64.ToType()},
+		[]*vector.Vector{out},
+		1,
+		types.T_array_float32.ToType(),
+		func([]vector.Vector) ([]int64, error) { return []int64{}, nil },
+		newTopNTestOp(2),
+		fs,
+		location,
+		mp,
+		fileservice.SkipFullFilePreloads,
+	)
+	require.NoError(t, err)
+	require.Empty(t, rows)
+	require.Empty(t, distances)
+	require.Zero(t, out.Length())
+	require.Zero(t, countTopNReadsWithin(fs.requests, topExtent), "empty membership must not read vector chunks")
+}
+
+func TestReadBlockBySearchAndTopNLegacyVector(t *testing.T) {
+	mp := newTopNTestMP(t)
+	source := newTopNTestVector(t, mp, []float32{4, 1, 3, 2})
+	storage := newBlockTopNTestFS(t)
+	location, _ := persistBlockTopNTest(t, storage, source, nil, mp)
+	storage.FlushCache(t.Context())
+	pk := vector.NewVec(types.T_int64.ToType())
+	defer pk.Free(mp)
+
+	rows, distances, _, err := ReadBlockBySearchAndTopN(
+		t.Context(),
+		[]uint16{0},
+		[]types.Type{types.T_int64.ToType()},
+		[]uint16{0},
+		[]types.Type{types.T_int64.ToType()},
+		[]*vector.Vector{pk},
+		1,
+		types.T_array_float32.ToType(),
+		func([]vector.Vector) ([]int64, error) { return []int64{0, 1, 3}, nil },
+		newTopNTestOp(2),
+		storage,
+		location,
+		mp,
+		fileservice.SkipFullFilePreloads,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 3}, rows)
+	require.Equal(t, []float64{1, 4}, distances)
+	require.Equal(t, []int64{1, 3}, vector.MustFixedColWithTypeCheck[int64](pk))
+}
+
+func TestReadBlockBySearchAndTopNRejectsInvalidSelections(t *testing.T) {
+	mp := newTopNTestMP(t)
+	source := newTopNTestVector(t, mp, []float32{4, 1, 3, 2})
+	payload, _ := encodeTopNTestChunks(t, source, 2, mp)
+	storage := newBlockTopNTestFS(t)
+	location, _ := persistBlockTopNTest(t, storage, source, payload, mp)
+	for _, test := range []struct {
+		name string
+		rows []int64
+	}{
+		{name: "nil", rows: nil},
+		{name: "duplicate", rows: []int64{1, 1}},
+		{name: "unsorted", rows: []int64{2, 1}},
+		{name: "negative", rows: []int64{-1}},
+		{name: "past end", rows: []int64{4}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			out := vector.NewVec(types.T_int64.ToType())
+			defer out.Free(mp)
+			_, _, _, err := ReadBlockBySearchAndTopN(
+				t.Context(),
+				[]uint16{0},
+				[]types.Type{types.T_int64.ToType()},
+				[]uint16{0},
+				[]types.Type{types.T_int64.ToType()},
+				[]*vector.Vector{out},
+				1,
+				types.T_array_float32.ToType(),
+				func([]vector.Vector) ([]int64, error) { return test.rows, nil },
+				newTopNTestOp(2),
+				storage,
+				location,
+				mp,
+				fileservice.SkipFullFilePreloads,
+			)
+			require.Error(t, err)
+			require.Zero(t, out.Length())
+		})
+	}
+}
+
+func countTopNReadsWithin(requests [][]topNReadRange, extent Extent) int {
+	count := 0
+	start := int64(extent.Offset())
+	end := start + int64(extent.Length())
+	for _, request := range requests {
+		for _, entry := range request {
+			if entry.offset >= start && entry.offset < end {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 func TestBlockTopNCacheInteroperability(t *testing.T) {
 	mp := newTopNTestMP(t)
 	source := newTopNTestVector(t, mp, []float32{4, 1, 3, 2, 6, 5})

--- a/pkg/objectio/block_topn_test.go
+++ b/pkg/objectio/block_topn_test.go
@@ -315,6 +315,84 @@ func TestReadBlockBySearchAndTopNRejectsInvalidSelections(t *testing.T) {
 	}
 }
 
+func TestReadBlockBySearchAndTopNValidatesContract(t *testing.T) {
+	type arguments struct {
+		filterColumns      []uint16
+		filterTypes        []types.Type
+		outputColumns      []uint16
+		outputTypes        []types.Type
+		outputDestinations []*vector.Vector
+		topColumn          uint16
+		topType            types.Type
+		selectRows         func([]vector.Vector) ([]int64, error)
+		topReader          *IndexReaderTopOp
+		mp                 *mpool.MPool
+	}
+
+	mp := newTopNTestMP(t)
+	out := vector.NewVec(types.T_int64.ToType())
+	defer out.Free(mp)
+	valid := func() arguments {
+		return arguments{
+			filterColumns:      []uint16{0},
+			filterTypes:        []types.Type{types.T_int64.ToType()},
+			outputColumns:      []uint16{0},
+			outputTypes:        []types.Type{types.T_int64.ToType()},
+			outputDestinations: []*vector.Vector{out},
+			topColumn:          1,
+			topType:            types.T_array_float32.ToType(),
+			selectRows:         func([]vector.Vector) ([]int64, error) { return []int64{}, nil },
+			topReader:          newTopNTestOp(1),
+			mp:                 mp,
+		}
+	}
+	for _, test := range []struct {
+		name    string
+		wantErr string
+		mutate  func(*arguments)
+	}{
+		{name: "empty filter", wantErr: "invalid exact-filter columns", mutate: func(a *arguments) {
+			a.filterColumns = nil
+			a.filterTypes = nil
+		}},
+		{name: "mismatched output", wantErr: "invalid exact-filter output columns", mutate: func(a *arguments) {
+			a.outputTypes = nil
+		}},
+		{name: "nil selector", wantErr: "nil exact-filter block topn input", mutate: func(a *arguments) {
+			a.selectRows = nil
+		}},
+		{name: "ordered topn", wantErr: "unsupported exact-filter vector topn input", mutate: func(a *arguments) {
+			a.topReader.OrderedLimit = true
+		}},
+		{name: "filter is vector column", wantErr: "invalid exact-filter column", mutate: func(a *arguments) {
+			a.filterColumns = []uint16{1}
+		}},
+		{name: "duplicate filter", wantErr: "duplicate exact-filter column", mutate: func(a *arguments) {
+			a.filterColumns = []uint16{0, 0}
+			a.filterTypes = []types.Type{types.T_int64.ToType(), types.T_int64.ToType()}
+		}},
+		{name: "nil output", wantErr: "invalid exact-filter output column", mutate: func(a *arguments) {
+			a.outputDestinations = []*vector.Vector{nil}
+		}},
+		{name: "duplicate output", wantErr: "duplicate exact-filter output column", mutate: func(a *arguments) {
+			a.outputColumns = []uint16{0, 0}
+			a.outputTypes = []types.Type{types.T_int64.ToType(), types.T_int64.ToType()}
+			a.outputDestinations = []*vector.Vector{out, out}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a := valid()
+			test.mutate(&a)
+			_, _, _, err := ReadBlockBySearchAndTopN(
+				t.Context(), a.filterColumns, a.filterTypes, a.outputColumns, a.outputTypes,
+				a.outputDestinations, a.topColumn, a.topType, a.selectRows, a.topReader,
+				nil, Location{}, a.mp, fileservice.SkipFullFilePreloads,
+			)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
 func countTopNReadsWithin(requests [][]topNReadRange, extent Extent) int {
 	count := 0
 	start := int64(extent.Offset())

--- a/pkg/objectio/types.go
+++ b/pkg/objectio/types.go
@@ -249,6 +249,7 @@ func CombineReadFilterSearch(searches ...*ReadFilterSearch) *ReadFilterSearch {
 type BlockReadFilter struct {
 	HasFakePK          bool
 	Valid              bool
+	ExactMembership    bool
 	SortedSearchFunc   ReadFilterSearchFuncType
 	UnSortedSearchFunc ReadFilterSearchFuncType
 	CachedSearch       *ReadFilterSearch

--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -3521,6 +3521,7 @@ func TestConstructBlockPKFilterWithBloomFilter(t *testing.T) {
 type testMembershipFilter struct {
 	hits  []uint8
 	calls int
+	exact bool
 }
 
 func (f *testMembershipFilter) Test([]byte) bool { return true }
@@ -3529,7 +3530,7 @@ func (f *testMembershipFilter) TestVector(*vector.Vector, func(bool, bool, int))
 	return f.hits
 }
 func (f *testMembershipFilter) Valid() bool { return true }
-func (f *testMembershipFilter) Exact() bool { return false }
+func (f *testMembershipFilter) Exact() bool { return f.exact }
 func (f *testMembershipFilter) Free()       {}
 
 func TestConstructBlockPKFilterBloomFailOpen(t *testing.T) {
@@ -3570,6 +3571,24 @@ func TestConstructBlockPKFilterBloomFailOpen(t *testing.T) {
 		require.Equal(t, []int64{0, 1, 2}, result)
 		require.Equal(t, 1, bf.calls)
 	})
+}
+
+func TestConstructBlockPKFilterMarksOnlyExactMembership(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		exact bool
+	}{
+		{name: "approximate"},
+		{name: "exact", exact: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			filter, err := ConstructBlockPKFilter(false, BasePKFilter{}, &testMembershipFilter{
+				hits: []uint8{1}, exact: test.exact,
+			})
+			require.NoError(t, err)
+			require.Equal(t, test.exact, filter.ExactMembership)
+		})
+	}
 }
 
 func TestConstructBlockPKFilterIntersectsPrimaryKeyAndBloomFilter(t *testing.T) {

--- a/pkg/vm/engine/readutil/pk_filter.go
+++ b/pkg/vm/engine/readutil/pk_filter.go
@@ -65,7 +65,10 @@ func ConstructBlockPKFilter(
 		return objectio.BlockReadFilter{}, nil
 	}
 
-	readFilter := objectio.BlockReadFilter{HasFakePK: isFakePK}
+	readFilter := objectio.BlockReadFilter{
+		HasFakePK:       isFakePK,
+		ExactMembership: bf != nil && bf.Exact(),
+	}
 	// The scoped cache search must preserve the exact routing contract of the
 	// existing callbacks. Fake PK columns are not physically sorted even when
 	// the block carries the sorted flag, and membership filters may use a

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -356,6 +356,41 @@ func blockDataRead(
 	)
 
 	searchFunc := filter.DecideSearchFunc(info.IsSorted())
+	if canFuseExactMembershipTopK(
+		info,
+		filter,
+		searchFunc,
+		filterSeqnums,
+		orderByLimit,
+		phyAddrColumnPos,
+		len(columns),
+		applyFilter,
+	) {
+		cacheVectors.Free(mp)
+		v2.TxnSelReadFilterTotal.Observe(1.0)
+		filterRows := 0
+		err = blockDataReadWithExactMembershipTopK(
+			ctx,
+			info,
+			ds,
+			columns,
+			colTypes,
+			phyAddrColumnPos,
+			filterSeqnums,
+			filterColTypes,
+			searchFunc,
+			orderByLimit,
+			policy,
+			bat,
+			mp,
+			fs,
+			&filterRows,
+		)
+		if err == nil && filterRows == 0 {
+			v2.TxnSelReadFilterFiltered.Observe(1.0)
+		}
+		return err
+	}
 
 	if searchFunc != nil {
 		if sels, err = ReadDataByFilter(
@@ -427,6 +462,140 @@ func blockDataRead(
 
 	if applyFilter == nil {
 		bat.SetRowCount(bat.Vecs[0].Length())
+	}
+	return nil
+}
+
+func canFuseExactMembershipTopK(
+	info *objectio.BlockInfo,
+	filter objectio.BlockReadFilter,
+	searchFunc objectio.ReadFilterSearchFuncType,
+	filterColumns []uint16,
+	top *objectio.IndexReaderTopOp,
+	phyAddrColumnPos int,
+	columnCount int,
+	applyFilter engine.ReaderFilter,
+) bool {
+	if info == nil || info.IsAppendable() || !filter.ExactMembership || filter.HasFakePK ||
+		filter.CachedSearch != nil || searchFunc == nil || len(filterColumns) == 0 ||
+		top == nil || top.OrderedLimit || top.Desc || !top.Typ.IsArrayRelate() || applyFilter != nil {
+		return false
+	}
+	topColumnPos := int(top.ColPos)
+	if topColumnPos < 0 || topColumnPos >= columnCount || topColumnPos == phyAddrColumnPos {
+		return false
+	}
+	for _, column := range filterColumns {
+		if column >= objectio.SEQNUM_UPPER {
+			return false
+		}
+	}
+	return true
+}
+
+func blockDataReadWithExactMembershipTopK(
+	ctx context.Context,
+	info *objectio.BlockInfo,
+	ds engine.DataSource,
+	columns []uint16,
+	colTypes []types.Type,
+	phyAddrColumnPos int,
+	filterColumns []uint16,
+	filterTypes []types.Type,
+	searchFunc objectio.ReadFilterSearchFuncType,
+	top *objectio.IndexReaderTopOp,
+	policy fileservice.Policy,
+	output *batch.Batch,
+	mp *mpool.MPool,
+	fs fileservice.FileService,
+	filterRows *int,
+) error {
+	if ds == nil {
+		return moerr.NewInvalidInputNoCtx("nil data source for exact-membership block topn")
+	}
+	if output == nil || len(columns) != len(colTypes) || len(output.Vecs) < len(columns) {
+		return moerr.NewInvalidInputNoCtx("invalid exact-membership block output")
+	}
+	topColumnPos := int(top.ColPos)
+	materializeColumns := make([]uint16, 0, len(columns)-1)
+	materializeTypes := make([]types.Type, 0, len(columns)-1)
+	materializeDestinations := make([]*vector.Vector, 0, len(columns)-1)
+	materializePositions := make([]int, 0, len(columns)-1)
+	for position, column := range columns {
+		if position == phyAddrColumnPos || position == topColumnPos {
+			continue
+		}
+		if column >= objectio.SEQNUM_UPPER {
+			return moerr.NewInvalidInputNoCtxf(
+				"unsupported exact-membership output column %d", column,
+			)
+		}
+		materializeColumns = append(materializeColumns, column)
+		materializeTypes = append(materializeTypes, colTypes[position])
+		materializeDestinations = append(materializeDestinations, output.Vecs[position])
+		materializePositions = append(materializePositions, position)
+	}
+
+	topRows, distances, _, err := objectio.ReadBlockBySearchAndTopN(
+		ctx,
+		filterColumns,
+		filterTypes,
+		materializeColumns,
+		materializeTypes,
+		materializeDestinations,
+		columns[topColumnPos],
+		colTypes[topColumnPos],
+		func(filterVectors []vector.Vector) ([]int64, error) {
+			selected := searchFunc(containers.Vectors(filterVectors))
+			if len(selected) == 0 {
+				if filterRows != nil {
+					*filterRows = 0
+				}
+				return []int64{}, nil
+			}
+			selected, err := ds.ApplyTombstones(ctx, &info.BlockID, selected, engine.Policy_CheckAll)
+			if err != nil {
+				return nil, err
+			}
+			if len(selected) == 0 {
+				if filterRows != nil {
+					*filterRows = 0
+				}
+				return []int64{}, nil
+			}
+			if filterRows != nil {
+				*filterRows = len(selected)
+			}
+			return selected, nil
+		},
+		top,
+		fs,
+		info.MetaLocation(),
+		mp,
+		policy,
+	)
+	if err != nil {
+		return err
+	}
+	output.Vecs[topColumnPos].CleanOnlyData()
+	if phyAddrColumnPos >= 0 {
+		if len(topRows) == 0 {
+			output.Vecs[phyAddrColumnPos].CleanOnlyData()
+		} else if err = buildRowidColumn(info, output.Vecs[phyAddrColumnPos], topRows, mp); err != nil {
+			return err
+		}
+	}
+	output.SetRowCount(len(topRows))
+	if err = appendVectorTopNDistances(output, len(columns), distances, mp); err != nil {
+		return err
+	}
+	for _, position := range materializePositions {
+		if output.Vecs[position].Length() != len(topRows) {
+			return moerr.NewInvalidStateNoCtxf(
+				"exact-membership output column %d has %d rows, expected %d",
+				position, output.Vecs[position].Length(), len(topRows),
+			)
+		}
 	}
 	return nil
 }

--- a/pkg/vm/engine/tae/blockio/read_test.go
+++ b/pkg/vm/engine/tae/blockio/read_test.go
@@ -414,7 +414,88 @@ func TestBlockDataReadInnerPersistedVectorTopN(t *testing.T) {
 	emptyTop.UpperBound = 0
 	run("bounds remove every row", &blockReadTestDataSource{}, nil, emptyTop,
 		[]int64{}, []float64{})
+	t.Run("exact membership fused before topk", func(t *testing.T) {
+		output := newOutput()
+		filter := objectio.BlockReadFilter{
+			Valid:           true,
+			ExactMembership: true,
+			UnSortedSearchFunc: func(vectors containers.Vectors) []int64 {
+				require.Equal(t, []int32{100, 101, 102, 103, 104},
+					vector.MustFixedColWithTypeCheck[int32](&vectors[0]))
+				return []int64{0, 2, 4}
+			},
+		}
+		require.NoError(t, BlockDataRead(
+			ctx,
+			&info,
+			&blockReadTestDataSource{deleted: []uint64{2}},
+			columns,
+			columnTypes,
+			1,
+			timestamp.Timestamp{},
+			[]uint16{0},
+			[]types.Type{typesByColumn[0]},
+			filter,
+			newTop(),
+			fileservice.Policy(0),
+			"entries",
+			output,
+			containers.NewVectors(len(columns)+1),
+			queryMP,
+			fs,
+		))
+		assertOutput(t, output, []int64{0, 4}, []float64{100, 9})
+		output.Clean(queryMP)
+	})
+	t.Run("exact membership all tombstoned", func(t *testing.T) {
+		output := newOutput()
+		filter := objectio.BlockReadFilter{
+			Valid:              true,
+			ExactMembership:    true,
+			UnSortedSearchFunc: func(containers.Vectors) []int64 { return []int64{0, 2, 4} },
+		}
+		require.NoError(t, BlockDataRead(
+			ctx,
+			&info,
+			&blockReadTestDataSource{deleted: []uint64{0, 2, 4}},
+			columns,
+			columnTypes,
+			1,
+			timestamp.Timestamp{},
+			[]uint16{0},
+			[]types.Type{typesByColumn[0]},
+			filter,
+			newTop(),
+			fileservice.Policy(0),
+			"entries",
+			output,
+			containers.NewVectors(len(columns)+1),
+			queryMP,
+			fs,
+		))
+		assertOutput(t, output, []int64{}, []float64{})
+		output.Clean(queryMP)
+	})
 	require.Zero(t, queryMP.CurrNB())
+}
+
+func TestCanFuseExactMembershipTopK(t *testing.T) {
+	info := &objectio.BlockInfo{}
+	top := &objectio.IndexReaderTopOp{Typ: types.T_array_float32, ColPos: 1}
+	search := func(containers.Vectors) []int64 { return []int64{0} }
+	filter := objectio.BlockReadFilter{ExactMembership: true}
+	require.True(t, canFuseExactMembershipTopK(info, filter, search, []uint16{0}, top, -1, 2, nil))
+
+	filter.ExactMembership = false
+	require.False(t, canFuseExactMembershipTopK(info, filter, search, []uint16{0}, top, -1, 2, nil))
+	filter.ExactMembership = true
+	top.Desc = true
+	require.False(t, canFuseExactMembershipTopK(info, filter, search, []uint16{0}, top, -1, 2, nil))
+	top.Desc = false
+	require.False(t, canFuseExactMembershipTopK(info, filter, search, []uint16{0}, top, -1, 2,
+		func(*batch.Batch, []int) (engine.ReaderFilterResult, error) {
+			return engine.ReaderFilterResult{}, nil
+		}))
 }
 
 func TestBlockDataReadInnerAppendableVectorTopNUsesLegacyPath(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI

## Which issue(s) this PR fixes:

Related to #24097
Related to #27854

## What this PR does / why we need it:

Fuse persisted exact-membership filtering with vector Top-K under one ObjectIO ownership scope, reuse pinned filter columns for winner output, share object metadata across phases, preserve sparse chunk reads, and materialize only block-local Top-K winners.

## Design and validation

- Design: docs/design/ivf-exact-membership-topk.md (design commit 4af737b8e1)
- Owning-package tests passed for ObjectIO, readutil, blockio, and IVFFlat after the newest-main merge.
- Tests cover exact versus approximate admission, empty/sparse/dense selections, transaction tombstones, chunked and legacy vectors, invalid selections, source-key reuse, and empty-domain vector-read avoidance.
- Full MatrixOne pre-push SCA passed with the repository-declared Go 1.26.4 toolchain.
