### PR TITLE
fix: preserve exact decimals in JSON aggregates

### DIFF
--- a/pkg/sql/colexec/aggexec/jsonagg2.go
+++ b/pkg/sql/colexec/aggexec/jsonagg2.go
@@ -17,7 +17,6 @@ package aggexec
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/json"
 	"math"
 	"slices"
 
@@ -469,10 +468,13 @@ func jsonAggregateValueSize(vec *vector.Vector, row uint64) (int, error) {
 		return 9, nil
 	case types.T_decimal64:
 		value := vector.MustFixedColNoTypeCheck[types.Decimal64](vec)[row].Format(typ.Scale)
-		return jsonAggregateNumberSize(value)
+		return jsonAggregateDecimalSize(value), nil
 	case types.T_decimal128:
 		value := vector.MustFixedColNoTypeCheck[types.Decimal128](vec)[row].Format(typ.Scale)
-		return jsonAggregateNumberSize(value)
+		return jsonAggregateDecimalSize(value), nil
+	case types.T_decimal256:
+		value := vector.MustFixedColNoTypeCheck[types.Decimal256](vec)[row].Format(typ.Scale)
+		return jsonAggregateDecimalSize(value), nil
 	case types.T_date:
 		length := len(vector.MustFixedColNoTypeCheck[types.Date](vec)[row].String())
 		return 1 + jsonUvarintSize(uint64(length)) + length, nil
@@ -517,24 +519,20 @@ func jsonAggregateValueSize(vec *vector.Vector, row uint64) (int, error) {
 	}
 }
 
-func jsonAggregateNumberSize(value string) (int, error) {
-	var data [8]byte
-	_, encoded, err := bytejson.AppendBinaryNumber(data[:0], json.Number(value))
-	if err != nil {
-		return 0, err
-	}
-	return 1 + len(encoded), nil
+func jsonAggregateDecimalSize(value string) int {
+	return 1 + jsonUvarintSize(uint64(len(value))) + len(value)
 }
 
-func appendJSONAggregateNumber(dst []byte, value string) ([]byte, error) {
-	var data [8]byte
-	numberType, encoded, err := bytejson.AppendBinaryNumber(
-		data[:0], json.Number(value))
-	if err != nil {
-		return nil, err
+func appendJSONAggregateDecimal(dst []byte, value string) []byte {
+	dst = append(dst, bytejson.TpCodeDecimal)
+	return appendJSONBinaryString(dst, []byte(value))
+}
+
+func jsonAggregateDecimal(value string) bytejson.ByteJson {
+	return bytejson.ByteJson{
+		Type: bytejson.TpCodeDecimal,
+		Data: appendJSONBinaryString(nil, []byte(value)),
 	}
-	dst = append(dst, byte(numberType))
-	return append(dst, encoded...), nil
 }
 
 func jsonUvarintSize(value uint64) int {
@@ -621,10 +619,13 @@ func appendJSONAggregateValue(
 		return appendJSONFloat64(dst, vector.MustFixedColNoTypeCheck[float64](vec)[row]), nil
 	case types.T_decimal64:
 		value := vector.MustFixedColNoTypeCheck[types.Decimal64](vec)[row].Format(typ.Scale)
-		return appendJSONAggregateNumber(dst, value)
+		return appendJSONAggregateDecimal(dst, value), nil
 	case types.T_decimal128:
 		value := vector.MustFixedColNoTypeCheck[types.Decimal128](vec)[row].Format(typ.Scale)
-		return appendJSONAggregateNumber(dst, value)
+		return appendJSONAggregateDecimal(dst, value), nil
+	case types.T_decimal256:
+		value := vector.MustFixedColNoTypeCheck[types.Decimal256](vec)[row].Format(typ.Scale)
+		return appendJSONAggregateDecimal(dst, value), nil
 	case types.T_date:
 		value := vector.MustFixedColNoTypeCheck[types.Date](vec)[row].String()
 		dst = append(dst, bytejson.TpCodeString)
@@ -1069,10 +1070,13 @@ func buildValueByteJson(vec *vector.Vector, row uint64) (bytejson.ByteJson, erro
 		return bytejson.CreateByteJSONWithCheck(vector.MustFixedColNoTypeCheck[float64](vec)[int(row)])
 	case types.T_decimal64:
 		val := vector.MustFixedColNoTypeCheck[types.Decimal64](vec)[int(row)]
-		return bytejson.CreateByteJSONWithCheck(json.Number(val.Format(typ.Scale)))
+		return jsonAggregateDecimal(val.Format(typ.Scale)), nil
 	case types.T_decimal128:
 		val := vector.MustFixedColNoTypeCheck[types.Decimal128](vec)[int(row)]
-		return bytejson.CreateByteJSONWithCheck(json.Number(val.Format(typ.Scale)))
+		return jsonAggregateDecimal(val.Format(typ.Scale)), nil
+	case types.T_decimal256:
+		val := vector.MustFixedColNoTypeCheck[types.Decimal256](vec)[int(row)]
+		return jsonAggregateDecimal(val.Format(typ.Scale)), nil
 	case types.T_date:
 		val := vector.MustFixedColNoTypeCheck[types.Date](vec)[int(row)]
 		return bytejson.CreateByteJSONWithCheck(val.String())

--- a/pkg/sql/colexec/aggexec/jsonagg_test.go
+++ b/pkg/sql/colexec/aggexec/jsonagg_test.go
@@ -184,6 +184,11 @@ func TestAccountedJSONAggregatePreservesLegacyValueSemantics(t *testing.T) {
 				[]types.Decimal128{{B0_63: 456}}),
 		},
 		{
+			name: "decimal256",
+			vec: buildFixedVec(t, mp, types.New(types.T_decimal256, 50, 10),
+				[]types.Decimal256{{B0_63: 456}}),
+		},
+		{
 			name: "date",
 			vec:  buildFixedVec(t, mp, types.T_date.ToType(), []types.Date{types.Date(1)}),
 		},
@@ -279,6 +284,60 @@ func TestAccountedJSONAggregatePreservesLegacyValueSemantics(t *testing.T) {
 	require.Zero(t, mp.CurrNB())
 }
 
+func TestJSONAggregatesPreserveExactDecimals(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	d64, err := types.ParseDecimal64("0.12345678901234567", 18, 17)
+	require.NoError(t, err)
+	d128, err := types.ParseDecimal128("99999999999999999999999999999999999999", 38, 0)
+	require.NoError(t, err)
+	d256, err := types.ParseDecimal256("1234567890123456789012345678901234567890.1234567890", 50, 10)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		want string
+		vec  *vector.Vector
+	}{
+		{
+			name: "decimal64 fractional",
+			want: "0.12345678901234567",
+			vec:  buildFixedVec(t, mp, types.New(types.T_decimal64, 18, 17), []types.Decimal64{d64}),
+		},
+		{
+			name: "decimal128 adjacent-value boundary",
+			want: "99999999999999999999999999999999999999",
+			vec:  buildFixedVec(t, mp, types.New(types.T_decimal128, 38, 0), []types.Decimal128{d128}),
+		},
+		{
+			name: "decimal256",
+			want: "1234567890123456789012345678901234567890.1234567890",
+			vec:  buildFixedVec(t, mp, types.New(types.T_decimal256, 50, 10), []types.Decimal256{d256}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer test.vec.Free(mp)
+
+			array := runJSONArrayAggregate(t, mp, test.vec, nil)
+			arrayJSON, err := array.MarshalJSON()
+			require.NoError(t, err)
+			require.Equal(t, "["+test.want+"]", string(arrayJSON))
+			require.Equal(t, "DECIMAL", array.GetArrayElem(0).TYPE())
+
+			object := runJSONObjectAggregate(t, mp, test.vec)
+			objectJSON, err := object.MarshalJSON()
+			require.NoError(t, err)
+			require.Equal(t, "{\"v\": "+test.want+"}", string(objectJSON))
+			require.Equal(t, []byte("v"), object.GetObjectKey(0))
+			require.Equal(t, "DECIMAL", object.GetObjectVal(0).TYPE())
+		})
+	}
+	require.Zero(t, mp.CurrNB())
+}
+
 func runJSONArrayAggregate(
 	t *testing.T,
 	mp *mpool.MPool,
@@ -309,6 +368,28 @@ func runJSONArrayAggregate(
 	if allocation != nil {
 		require.NoError(t, owner.ClearAllocationAccount(allocation))
 	}
+	return result
+}
+
+func runJSONObjectAggregate(t *testing.T, mp *mpool.MPool, input *vector.Vector) bytejson.ByteJson {
+	t.Helper()
+	exec, err := MakeAgg(
+		mp,
+		AggIdOfJsonObjectAgg,
+		false,
+		types.T_varchar.ToType(),
+		*input.GetType(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, exec.GroupGrow(1))
+	keys := buildVarlenVec(t, mp, types.T_varchar.ToType(), []string{"v"})
+	require.NoError(t, exec.BatchFill(0, []uint64{1}, []*vector.Vector{keys, input}))
+	results, err := exec.Flush()
+	require.NoError(t, err)
+	result := types.DecodeJson(append([]byte(nil), results[0].GetBytesAt(0)...))
+	results[0].Free(mp)
+	keys.Free(mp)
+	exec.Free()
 	return result
 }
 
@@ -520,7 +601,7 @@ func TestBuildValueByteJsonCoversTypes(t *testing.T) {
 			return v
 		}(), 0, []any{float64(0), float64(255)}, ""},
 		{"binary-error", buildVarlenVec(t, mg, types.T_binary.ToType(), []string{"a"}), 0, "", "binary data not supported"},
-		{"unsupported", buildFixedVec(t, mg, types.T_decimal256.ToType(), []types.Decimal256{{}}), 0, "", "unsupported type"},
+		{"decimal256", buildFixedVec(t, mg, types.T_decimal256.ToType(), []types.Decimal256{{}}), 0, float64(0), ""},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28587
Fixes #28588

## What this PR does / why we need it:

- Encodes Decimal64 and Decimal128 aggregate values with the exact typed-decimal JSON representation.
- Adds Decimal256 support to JSON_ARRAYAGG and JSON_OBJECTAGG.
- Covers exact large integers, fractional decimals, NULLs, and grouped/object aggregate paths.
- Verified with go test ./pkg/sql/colexec/aggexec -count=1 and issue reproduction SQL against MatrixOne built and started in an isolated Linux Docker container.