### PR TITLE
fix: preserve prepared Boolean math semantics

### DIFF
--- a/.agents/skills/mo-dev/SKILL.md
+++ b/.agents/skills/mo-dev/SKILL.md
@@ -129,12 +129,13 @@ merge_base=$(git merge-base HEAD "$base_ref")
 tracked_go=$(git diff --name-only "$merge_base" -- '*.go')
 untracked_go=$(git ls-files --others --exclude-standard -- '*.go')
 changed_go=$(printf '%s\n%s\n' "$tracked_go" "$untracked_go" |
-  sort -u | while IFS= read -r file; do
-    if [ -f "$file" ]; then printf '%s\n' "$file"; fi
-  done)
+  sort -u | sed '/^$/d')
+existing_go=$(printf '%s\n' "$changed_go" | while IFS= read -r file; do
+  if [ -n "$file" ] && [ -f "$file" ]; then printf '%s\n' "$file"; fi
+done)
 
-if [ -n "$changed_go" ]; then
-  format_files=$(printf '%s\n' "$changed_go" | xargs -r gofmt -l)
+if [ -n "$existing_go" ]; then
+  format_files=$(printf '%s\n' "$existing_go" | xargs -r gofmt -l)
   if [ -n "$format_files" ]; then
     printf 'gofmt required for:\n%s\n' "$format_files" >&2
     exit 1
@@ -142,12 +143,19 @@ if [ -n "$changed_go" ]; then
 fi
 
 changed_dirs=$(printf '%s\n' "$changed_go" | while IFS= read -r file; do
-  [ -n "$file" ] && dirname -- "$file"
+  if [ -n "$file" ]; then dirname -- "$file"; fi
 done | sort -u)
 changed_pkgs=$(printf '%s\n' "$changed_dirs" | while IFS= read -r dir; do
-  if [ -n "$dir" ] && [ -d "$dir" ]; then
-    go list -mod=readonly "./${dir#./}"
+  if [ -z "$dir" ]; then continue; fi
+  if [ ! -d "$dir" ]; then
+    printf 'changed Go directory was removed; select affected consumers explicitly: %s\n' "$dir" >&2
+    exit 1
   fi
+  if ! find "$dir" -maxdepth 1 -type f -name '*.go' -print -quit | grep -q .; then
+    printf 'changed Go directory has no current Go files; select affected consumers explicitly: %s\n' "$dir" >&2
+    exit 1
+  fi
+  GOWORK=off go list -mod=readonly "./${dir#./}" || exit 1
 done | sort -u)
 if [ -n "$changed_go" ] && [ -z "$changed_pkgs" ]; then
   printf 'changed Go files exist, but no package was discovered\n' >&2
@@ -156,7 +164,7 @@ fi
 
 if [ -n "$changed_pkgs" ]; then
   GOWORK=off go vet -mod=readonly $changed_pkgs
-  golangci-lint run -c .golangci.yml --new-from-rev "$merge_base" $changed_pkgs
+  GOWORK=off golangci-lint run -c .golangci.yml --new-from-rev "$merge_base" $changed_pkgs
 fi
 ```
 
@@ -164,8 +172,10 @@ Use the CGo setup and wrapper from
 [cgo-build-test.md](references/cgo-build-test.md) when the selected closure is
 CGo-direct/transitive. Add directly affected consumers when an exported/API,
 protocol, generated-code, or shared lifecycle contract changed; the package
-list must not be a guessed single leaf. If no Go file changed, run the smallest
-checker for the changed artifact.
+list must not be a guessed single leaf. A deleted-only package directory must
+stop this helper and be handled by explicitly selecting its existing consumers;
+do not replace that decision with `./...`. If no Go file changed, run the
+smallest checker for the changed artifact.
 
 `make static-check-analysis`, `make static-check`, `golangci-lint run ./...`,
 and equivalent whole-repository commands are the CI/full-scan path, not the

--- a/.agents/skills/mo-dev/SKILL.md
+++ b/.agents/skills/mo-dev/SKILL.md
@@ -35,6 +35,13 @@ or repeated full-suite runs.
 7. **Review and deliver.** Run `mo-self-review` on the final scope, resolve every
    blocker, inspect the delivery diff, and report the compact evidence record.
 
+For tests and diagnostic probes, acquire each resource only after its preceding
+step succeeds and schedule its cleanup immediately in the same lexical scope.
+When a loop performs repeated queries or opens rows/statements, use a small
+helper or per-iteration closure so `defer` releases the resource before the
+next iteration; a cleanup call at the bottom of a test is not equivalent on an
+early assertion failure.
+
 For diagnosis-only requests, stop after proving and explaining the cause; do not
 turn diagnosis into an implementation without authorization.
 
@@ -64,6 +71,8 @@ Read a reference when its trigger applies:
 | **G-OPERATOR** | Editing/reviewing `colexec`, process signals, pipeline spool/protocol, or a distributed pipeline hang | Read the operator/pipeline reference before editing or concluding. Trace sender and receiver plus reset/cleanup terminal paths. |
 | **G-COUNTEREXAMPLE** | Planner/explain/rewrite correctness or scenario-overfit risk | Read the counterexample reference. Define invariant/negation/reachability and use independent public and typed oracles where each proves a distinct claim. |
 | **G-INDEXPLUGIN** | Index algorithm dispatch/plugin/registry/ISCP paths change | Read the index-plugin reference and its review section. New SQL/catalog per-algorithm dispatch is forbidden. |
+| **G-STATIC-INCREMENTAL** | Any Go source/test edit or SCA failure | Derive the changed package closure from the merge base (including local staged/unstaged files), run gofmt/vet/lint only for that closure first, and escalate to the full repository scan only under the rules below. |
+| **G-CI-TRIAGE** | A CI job fails, hangs, is cancelled, or is unexpectedly skipped | Capture the exact job step, SHA, platform/toolchain, and terminal result; classify code/static/test failure separately from network/cache/quota/disk/runner failure before changing code or deciding to rerun. |
 | **G-EVIDENCE** | Before claiming pass/done or attributing a failure | Apply semantic evidence validity. Pending/empty selection/partial output is not a pass; a “pre-existing” claim requires the same failure at the verified clean baseline. |
 
 ## First-principles change rules
@@ -106,6 +115,74 @@ truth. In particular:
   are unchanged; unrelated docs or PR metadata do not invalidate it;
 - retain real terminal status and diagnose silence by polling the existing
   process, not by launching duplicates.
+
+### Incremental static checks (default)
+
+Do not run a repository-wide SCA for every edit. Resolve the merge base once,
+include committed and local tracked/untracked Go files, inspect the resulting
+package list, and run the configured checks only on that list:
+
+```bash
+base_ref=${REVIEW_BASE:-origin/main}
+merge_base=$(git merge-base HEAD "$base_ref")
+changed_go=$( {
+  git diff --name-only "$merge_base" -- '*.go'
+  git ls-files --others --exclude-standard -- '*.go'
+} | sort -u )
+changed_dirs=$(printf '%s\n' "$changed_go" |
+  sed '/^$/d' | xargs -r -n1 dirname | sort -u)
+changed_pkgs=$(printf '%s\n' "$changed_dirs" |
+  sed '/^$/d; s#^\./##; s#^#./#' | xargs -r go list)
+
+test -z "$changed_go" || printf '%s\n' "$changed_go" | xargs -r gofmt -d
+test -z "$changed_pkgs" || GOWORK=off go vet -mod=readonly $changed_pkgs
+test -z "$changed_pkgs" || golangci-lint run -c .golangci.yml \
+  --new-from-rev "$merge_base" $changed_pkgs
+```
+
+Use the CGo setup and wrapper from
+[cgo-build-test.md](references/cgo-build-test.md) when the selected closure is
+CGo-direct/transitive. Add directly affected consumers when an exported/API,
+protocol, generated-code, or shared lifecycle contract changed; the package
+list must not be a guessed single leaf. If no Go file changed, run the smallest
+checker for the changed artifact.
+
+`make static-check-analysis`, `make static-check`, `golangci-lint run ./...`,
+and equivalent whole-repository commands are the CI/full-scan path, not the
+default edit loop. Escalate to one only when SCA configuration/toolchain or
+workflow files changed, the affected consumer closure cannot be bounded, a
+release/pre-push gate explicitly requires it, or a CI failure must be
+reproduced. Record incremental and full results separately; a focused pass is
+not evidence that full CI SCA is green. Never suppress a finding or delete
+cleanup merely to make a static check pass.
+
+### CI and environment diagnosis
+
+When a CI check is red or silent, do not infer the cause from the check name or
+partial output. Inspect the failing step and terminal log at the exact checked
+SHA, then classify it before editing:
+
+- **Code/static/test:** reproduce the smallest affected package/test locally
+  with the same mode (race, coverage, tags, CGo, platform where possible), and
+  fix the violated contract. Run static checks before an expensive cluster or
+  end-to-end test.
+- **Infrastructure:** network/API fetch failures, rate limits, unavailable
+  caches, runner/toolchain setup, disk exhaustion, or a cancelled/evicted job
+  are not product failures. Preserve the log, rerun only a clearly transient
+  job when authorized, and do not add sleeps, retries, skips, or product
+  workarounds to hide it.
+- **Ambiguous/hung:** keep the existing run as the source of truth; poll for a
+  terminal result, inspect the process/stack and resource state, and avoid
+  launching a duplicate service or test that can contend for ports, native
+  artifacts, or global state. A timeout is evidence of a liveness failure until
+  the wait-for path is explained.
+
+For local native/integration work, preflight the selected toolchain, disk and
+temporary directory, active test-owned processes/ports, and CGo artifact
+provenance. Use the repository wrapper and an explicit temporary directory;
+clean only artifacts owned by the test. Report environment failures separately
+from code evidence, and never claim CI green from a pending, skipped, cancelled,
+or unrelated check.
 
 Ordinary pure-Go examples:
 

--- a/.agents/skills/mo-dev/SKILL.md
+++ b/.agents/skills/mo-dev/SKILL.md
@@ -123,21 +123,41 @@ include committed and local tracked/untracked Go files, inspect the resulting
 package list, and run the configured checks only on that list:
 
 ```bash
+set -euo pipefail
 base_ref=${REVIEW_BASE:-origin/main}
 merge_base=$(git merge-base HEAD "$base_ref")
-changed_go=$( {
-  git diff --name-only "$merge_base" -- '*.go'
-  git ls-files --others --exclude-standard -- '*.go'
-} | sort -u )
-changed_dirs=$(printf '%s\n' "$changed_go" |
-  sed '/^$/d' | xargs -r -n1 dirname | sort -u)
-changed_pkgs=$(printf '%s\n' "$changed_dirs" |
-  sed '/^$/d; s#^\./##; s#^#./#' | xargs -r go list)
+tracked_go=$(git diff --name-only "$merge_base" -- '*.go')
+untracked_go=$(git ls-files --others --exclude-standard -- '*.go')
+changed_go=$(printf '%s\n%s\n' "$tracked_go" "$untracked_go" |
+  sort -u | while IFS= read -r file; do
+    if [ -f "$file" ]; then printf '%s\n' "$file"; fi
+  done)
 
-test -z "$changed_go" || printf '%s\n' "$changed_go" | xargs -r gofmt -d
-test -z "$changed_pkgs" || GOWORK=off go vet -mod=readonly $changed_pkgs
-test -z "$changed_pkgs" || golangci-lint run -c .golangci.yml \
-  --new-from-rev "$merge_base" $changed_pkgs
+if [ -n "$changed_go" ]; then
+  format_files=$(printf '%s\n' "$changed_go" | xargs -r gofmt -l)
+  if [ -n "$format_files" ]; then
+    printf 'gofmt required for:\n%s\n' "$format_files" >&2
+    exit 1
+  fi
+fi
+
+changed_dirs=$(printf '%s\n' "$changed_go" | while IFS= read -r file; do
+  [ -n "$file" ] && dirname -- "$file"
+done | sort -u)
+changed_pkgs=$(printf '%s\n' "$changed_dirs" | while IFS= read -r dir; do
+  if [ -n "$dir" ] && [ -d "$dir" ]; then
+    go list -mod=readonly "./${dir#./}"
+  fi
+done | sort -u)
+if [ -n "$changed_go" ] && [ -z "$changed_pkgs" ]; then
+  printf 'changed Go files exist, but no package was discovered\n' >&2
+  exit 1
+fi
+
+if [ -n "$changed_pkgs" ]; then
+  GOWORK=off go vet -mod=readonly $changed_pkgs
+  golangci-lint run -c .golangci.yml --new-from-rev "$merge_base" $changed_pkgs
+fi
 ```
 
 Use the CGo setup and wrapper from
@@ -168,9 +188,10 @@ SHA, then classify it before editing:
   end-to-end test.
 - **Infrastructure:** network/API fetch failures, rate limits, unavailable
   caches, runner/toolchain setup, disk exhaustion, or a cancelled/evicted job
-  are not product failures. Preserve the log, rerun only a clearly transient
-  job when authorized, and do not add sleeps, retries, skips, or product
-  workarounds to hide it.
+  do not by themselves prove a product failure. Preserve the log and classify
+  the cancellation/eviction reason; rerun only a clearly transient job when
+  authorized, and do not add sleeps, retries, skips, or product workarounds to
+  hide it.
 - **Ambiguous/hung:** keep the existing run as the source of truth; poll for a
   terminal result, inspect the process/stack and resource state, and avoid
   launching a duplicate service or test that can contend for ports, native

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -2758,10 +2758,12 @@ func buildExecuteUserParamsWithMemberOfPositions(
 			EnableNumericPrefix: currentProtocolVersion(proc) >= defines.MORPCVersion30,
 		}
 		if paramKinds[i] == vector.PrepareParamBoolean {
-			// Like binary-protocol Boolean parameters, SQL EXECUTE needs the
-			// semantic type for numeric overload selection, not its text carrier.
-			paramValue.RuntimeType = types.T_bool.ToType()
-			paramValue.HasRuntimeType = true
+			// SQL EXECUTE keeps its historical text transport for a bare result
+			// parameter.  Carry the logical source type so numeric consumers can
+			// rebind Boolean values as 0/1, but do not advertise a runtime result
+			// type here: that metadata is reserved for COM_STMT packets and would
+			// turn an unrelated direct `?` projection into a BOOL literal whenever
+			// another expression in the same statement is specialized.
 			paramValue.SourceType = types.T_bool.ToType()
 			paramValue.HasSourceType = true
 		} else if paramBinaryString[i] && sourceType.Id != 0 {

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -2757,7 +2757,14 @@ func buildExecuteUserParamsWithMemberOfPositions(
 			RuntimeStringDomain: paramDomains[i],
 			EnableNumericPrefix: currentProtocolVersion(proc) >= defines.MORPCVersion30,
 		}
-		if paramBinaryString[i] && sourceType.Id != 0 {
+		if paramKinds[i] == vector.PrepareParamBoolean {
+			// Like binary-protocol Boolean parameters, SQL EXECUTE needs the
+			// semantic type for numeric overload selection, not its text carrier.
+			paramValue.RuntimeType = types.T_bool.ToType()
+			paramValue.HasRuntimeType = true
+			paramValue.SourceType = types.T_bool.ToType()
+			paramValue.HasSourceType = true
+		} else if paramBinaryString[i] && sourceType.Id != 0 {
 			paramValue.SourceType = executeArgumentSourceType(sourceType)
 			paramValue.HasSourceType = true
 		} else if paramBinaryString[i] {

--- a/pkg/frontend/computation_wrapper_test.go
+++ b/pkg/frontend/computation_wrapper_test.go
@@ -3522,6 +3522,7 @@ func TestBuildExecuteUserParamsRetainsExecuteArgumentSourceType(t *testing.T) {
 	require.NoError(t, ses.setUserDefinedVarWithTypeAndKind(
 		"runtime_decimal", "2.500", "", false, decimalType, vector.PrepareParamDecimal))
 	require.NoError(t, ses.SetUserDefinedVar("runtime_text", "2.500", ""))
+	require.NoError(t, ses.SetUserDefinedVar("runtime_bool", true, ""))
 	binaryTextType := plan.Type{
 		Id: int32(types.T_varchar), Width: 8, Charset: uint32(types.CharsetBinary),
 	}
@@ -3539,6 +3540,10 @@ func TestBuildExecuteUserParamsRetainsExecuteArgumentSourceType(t *testing.T) {
 		{
 			Typ:  binaryTextType,
 			Expr: &plan.Expr_V{V: &plan.VarRef{Name: "runtime_binary"}},
+		},
+		{
+			Typ:  plan.Type{Id: int32(types.T_text)},
+			Expr: &plan.Expr_V{V: &plan.VarRef{Name: "runtime_bool"}},
 		},
 	}
 	params, paramVals, _, _, _, _, err := buildExecuteUserParams(cw.proc, args, nil)
@@ -3561,6 +3566,13 @@ func TestBuildExecuteUserParamsRetainsExecuteArgumentSourceType(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, binaryParam.HasSourceType)
 	require.Equal(t, types.NewWithCharset(types.T_varbinary, 8, 0, types.CharsetBinary), binaryParam.SourceType)
+	boolParam := paramVals[3].(plan2.ParamValue)
+	require.Equal(t, "true", params.GetStringAt(3), "do not rewrite the transport value")
+	require.Equal(t, vector.PrepareParamBoolean, boolParam.PrepareParamKind)
+	require.True(t, boolParam.HasSourceType)
+	require.Equal(t, types.T_bool.ToType(), boolParam.SourceType)
+	require.True(t, boolParam.HasRuntimeType)
+	require.Equal(t, types.T_bool.ToType(), boolParam.RuntimeType)
 }
 
 // A nil cached compile means the statement was rejected for prepare-time

--- a/pkg/frontend/computation_wrapper_test.go
+++ b/pkg/frontend/computation_wrapper_test.go
@@ -1466,6 +1466,120 @@ func TestInitExecuteStmtParamDirectTextIgnoresNestedNumericMarker(t *testing.T) 
 		"the direct VAR_STRING result must retain TEXT metadata")
 }
 
+func TestSQLPreparedBooleanDirectResultKeepsTextWithNumericSibling(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		paramCount  int
+		directIndex int
+		numeric     []int
+	}{
+		{name: "direct_before_numeric", sql: "select ?, round(?)", paramCount: 2, directIndex: 0, numeric: []int{1}},
+		{name: "direct_after_numeric", sql: "select round(?), ?", paramCount: 2, directIndex: 1, numeric: []int{0}},
+		{name: "direct_between_numeric", sql: "select round(?), ?, sign(?)", paramCount: 3, directIndex: 1, numeric: []int{0, 2}},
+	}
+	for testIndex, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
+				t, uint32(215+testIndex), test.sql)
+			defer func() {
+				cw.proc.SetPrepareParams(nil)
+				prepareStmt.Close()
+			}()
+			execCtx.input.isBinaryProtExecute = false
+			cw.binaryPrepare = false
+			execPlan := &plan.Execute{Name: prepareStmt.Name, Args: make([]*plan.Expr, test.paramCount)}
+			for i := range execPlan.Args {
+				execPlan.Args[i] = &plan.Expr{Expr: &plan.Expr_V{V: &plan.VarRef{
+					Name: fmt.Sprintf("bool_param_%d", i),
+				}}}
+			}
+			cachedPlan, err := prepareStmt.PreparePlan.GetDcl().GetPrepare().Plan.Marshal()
+			require.NoError(t, err)
+			originalQuery := prepareStmt.PreparePlan.GetDcl().GetPrepare().Plan.GetQuery()
+			originalRoot := originalQuery.Nodes[originalQuery.Steps[len(originalQuery.Steps)-1]]
+			require.Len(t, prepareStmt.directResultParamPositions, 1)
+			require.Equal(t, int32(test.directIndex), prepareStmt.directResultParamPositions[0])
+			originalDirectType := originalRoot.ProjectList[test.directIndex].Typ
+
+			type execution struct {
+				value    any
+				wantText string
+				wantNum  int64
+			}
+			for index, execution := range []execution{
+				{value: true, wantText: "true", wantNum: 1},
+				{value: false, wantText: "false"},
+				{value: true, wantText: "true", wantNum: 1},
+			} {
+				t.Run(fmt.Sprintf("execution-%d", index), func(t *testing.T) {
+					for i := range execPlan.Args {
+						require.NoError(t, ses.SetUserDefinedVar(
+							fmt.Sprintf("bool_param_%d", i), execution.value, ""))
+					}
+					_, runtimePlan, executionStmt, _, owned, err := initExecuteStmtParam(
+						execCtx, ses, cw, execPlan, "")
+					require.NoError(t, err)
+					if owned && executionStmt != nil {
+						defer executionStmt.Free()
+					}
+
+					query := runtimePlan.GetQuery()
+					root := query.Nodes[query.Steps[len(query.Steps)-1]]
+					require.Len(t, root.ProjectList, test.paramCount)
+					require.Equal(t, originalDirectType, root.ProjectList[test.directIndex].Typ,
+						"an independent numeric sibling must not change a direct SQL result")
+					for _, numericIndex := range test.numeric {
+						require.True(t, types.T(root.ProjectList[numericIndex].Typ.Id).IsInteger(),
+							"numeric consumer %d must use an integer overload", numericIndex)
+					}
+
+					evaluate := func(expr *plan.Expr) (*vector.Vector, colexec.ExpressionExecutor, *batch.Batch) {
+						t.Helper()
+						executor, err := colexec.NewExpressionExecutor(cw.proc, expr)
+						require.NoError(t, err)
+						input := batch.New(nil)
+						input.SetRowCount(1)
+						result, err := executor.Eval(cw.proc, []*batch.Batch{input}, nil)
+						require.NoError(t, err)
+						return result, executor, input
+					}
+					direct, directExecutor, directInput := evaluate(root.ProjectList[test.directIndex])
+					t.Cleanup(func() {
+						direct.Free(cw.proc.Mp())
+						directExecutor.Free()
+						directInput.Clean(cw.proc.Mp())
+					})
+					require.True(t, direct.GetType().Oid.IsMySQLString())
+					require.False(t, direct.GetNulls().Contains(0))
+					require.Equal(t, execution.wantText, direct.GetStringAt(0))
+					for _, numericIndex := range test.numeric {
+						numeric, numericExecutor, numericInput := evaluate(root.ProjectList[numericIndex])
+						t.Cleanup(func() {
+							numeric.Free(cw.proc.Mp())
+							numericExecutor.Free()
+							numericInput.Clean(cw.proc.Mp())
+						})
+						require.True(t, numeric.GetType().Oid.IsInteger())
+						require.False(t, numeric.GetNulls().Contains(0))
+						switch numeric.GetType().Oid {
+						case types.T_uint64:
+							require.Equal(t, uint64(execution.wantNum), vector.GetFixedAtNoTypeCheck[uint64](numeric, 0))
+						case types.T_int64:
+							require.Equal(t, execution.wantNum, vector.GetFixedAtNoTypeCheck[int64](numeric, 0))
+						default:
+							require.Failf(t, "unexpected numeric result type", "%s", numeric.GetType().Oid)
+						}
+					}
+					after, err := prepareStmt.PreparePlan.GetDcl().GetPrepare().Plan.Marshal()
+					require.NoError(t, err)
+					require.Equal(t, cachedPlan, after, "SQL EXECUTE must not mutate the cached plan")
+				})
+			}
+		})
+	}
+}
+
 func TestInitExecuteStmtParamDirectNumericPreservesTextSibling(t *testing.T) {
 	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
 		t, 214, "select ? as direct_number, ? as direct_text")
@@ -3571,8 +3685,8 @@ func TestBuildExecuteUserParamsRetainsExecuteArgumentSourceType(t *testing.T) {
 	require.Equal(t, vector.PrepareParamBoolean, boolParam.PrepareParamKind)
 	require.True(t, boolParam.HasSourceType)
 	require.Equal(t, types.T_bool.ToType(), boolParam.SourceType)
-	require.True(t, boolParam.HasRuntimeType)
-	require.Equal(t, types.T_bool.ToType(), boolParam.RuntimeType)
+	require.False(t, boolParam.HasRuntimeType,
+		"SQL EXECUTE keeps a bare direct parameter's text result domain")
 }
 
 // A nil cached compile means the statement was rejected for prepare-time

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -2020,7 +2020,7 @@ func supportsGenericNumericFunctionContext(name string) bool {
 	// result. A numeric return type alone is insufficient: FIELD, LENGTH and
 	// similar functions return numbers while their arguments belong to another
 	// domain.
-	case "abs", "ceil", "ceiling", "floor", "round", "truncate",
+	case "abs", "ceil", "ceiling", "floor", "round", "truncate", "sign",
 		"sqrt", "power", "pow", "exp", "ln", "log", "log2", "log10":
 		return true
 	default:

--- a/pkg/sql/plan/function/bool_math_test.go
+++ b/pkg/sql/plan/function/bool_math_test.go
@@ -24,6 +24,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPreparedBooleanFloatCast(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	for _, target := range []types.T{types.T_float32, types.T_float64} {
+		t.Run(target.String(), func(t *testing.T) {
+			var empty, want any = []float64{}, []float64{1, 0, 0, 1, 0, 0}
+			if target == types.T_float32 {
+				empty, want = []float32{}, []float32{1, 0, 0, 1, 0, 0}
+			}
+			tc := NewFunctionTestCase(proc, []FunctionTestInput{
+				NewFunctionTestInput(types.T_text.ToType(), []string{"true", "false", "true", "1", "0", "bad"}, []bool{false, false, false, false, false, true}),
+				NewFunctionTestInput(target.ToType(), empty, nil),
+			}, NewFunctionTestResult(target.ToType(), false, want, []bool{false, false, false, false, false, true}), NewCast)
+			tc.parameters[0].SetPrepareParamKinds([]vector.PrepareParamKind{
+				vector.PrepareParamBoolean, vector.PrepareParamBoolean, vector.PrepareParamNone,
+				vector.PrepareParamBoolean, vector.PrepareParamBoolean, vector.PrepareParamBoolean,
+			})
+			ok, info := tc.Run()
+			require.True(t, ok, info)
+		})
+	}
+}
+
+func TestPreparedBooleanFloatCastInactiveRows(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	input := newVectorByType(proc.Mp(), types.T_text.ToType(), []string{"true", "invalid"}, nil)
+	defer input.Free(proc.Mp())
+	input.SetPrepareParamKind(vector.PrepareParamBoolean)
+	result := vector.NewFunctionResultWrapper(types.T_float64.ToType(), proc.Mp()).(*vector.FunctionResult[float64])
+	defer result.Free()
+	for _, mode := range []SQLCompatibilityMode{SQLCompatibilityMySQL, SQLCompatibilityMatrixOne} {
+		require.NoError(t, result.PreExtendAndReset(2))
+		err := strToFloat(context.Background(), mode, vector.GenerateFunctionStrParameter(input), result, 64, 2,
+			&FunctionSelectList{AnyNull: true, SelectList: []bool{true, false}})
+		require.NoError(t, err)
+		require.Equal(t, float64(1), vector.GetFixedAtNoTypeCheck[float64](result.GetResultVector(), 0))
+		require.True(t, result.GetResultVector().GetNulls().Contains(1))
+
+		require.NoError(t, result.PreExtendAndReset(2))
+		require.NoError(t, strToFloat(context.Background(), mode, vector.GenerateFunctionStrParameter(input), result, 64, 2,
+			&FunctionSelectList{AllNull: true}))
+		require.True(t, result.GetResultVector().GetNulls().Contains(0))
+		require.True(t, result.GetResultVector().GetNulls().Contains(1))
+
+		require.NoError(t, result.PreExtendAndReset(2))
+		require.Error(t, strToFloat(context.Background(), mode, vector.GenerateFunctionStrParameter(input), result, 64, 2, nil))
+	}
+}
+
 func TestMathFunctionsAcceptBoolInNumericContext(t *testing.T) {
 	ctx := context.Background()
 	boolType := types.T_bool.ToType()

--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -7239,12 +7239,25 @@ func strToFloatWithProc[T constraints.Float](
 			if !isBinary && bitSize == 32 && to.GetType().Width > 0 && to.GetType().Scale >= 0 {
 				parseBitSize = 64
 			}
-			r2, tErr = parseBytesToFloat(v, isBinary, parseBitSize, mode)
-			if tErr != nil {
-				return tErr
-			}
-			if !isBinary && mode == SQLCompatibilityMySQL {
-				appendNumericCoercionWarning(proc, convertByteSliceToString(v))
+			if from.GetSourceVector().GetPrepareParamKindAt(int(i)) == vector.PrepareParamBoolean {
+				// Prepared Boolean values travel as canonical text. Restore their
+				// numeric category without changing ordinary SQL string coercion.
+				b, err := strconv.ParseBool(convertByteSliceToString(v))
+				if err != nil {
+					return moerr.NewInvalidArg(ctx, "prepared Boolean", convertByteSliceToString(v))
+				}
+				r2 = 0
+				if b {
+					r2 = 1
+				}
+			} else {
+				r2, tErr = parseBytesToFloat(v, isBinary, parseBitSize, mode)
+				if tErr != nil {
+					return tErr
+				}
+				if !isBinary && mode == SQLCompatibilityMySQL {
+					appendNumericCoercionWarning(proc, convertByteSliceToString(v))
+				}
 			}
 			if to.GetType().Scale < 0 || to.GetType().Width == 0 {
 				result = T(r2)

--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -913,8 +913,20 @@ func (rule *ResetParamRefRule) runtimeParamType(pos int) (types.Type, bool) {
 		return types.Type{}, false
 	}
 	if pos < len(rule.paramValues) {
-		if param, ok := rule.paramValues[pos].(ParamValue); ok && param.HasRuntimeType {
-			return param.RuntimeType, true
+		if param, ok := rule.paramValues[pos].(ParamValue); ok {
+			// SQL EXECUTE values are transported through a text vector, so their
+			// logical source type must drive overload rebinding without becoming
+			// the visible type of a bare result marker.  An explicit RuntimeType
+			// (for protocol values or a latched specialization) remains authoritative;
+			// a SQL source is only a fallback when no such type is present.
+			if param.HasRuntimeType {
+				return param.RuntimeType, true
+			}
+			if !param.IsBinaryProtocol && param.HasSourceType &&
+				(param.SourceType.IsNumeric() || param.SourceType.Oid == types.T_bool ||
+					param.SourceType.Oid == types.T_year) {
+				return param.SourceType, true
+			}
 		}
 	}
 	switch kind {

--- a/pkg/sql/plan/visit_plan_rule_test.go
+++ b/pkg/sql/plan/visit_plan_rule_test.go
@@ -1503,6 +1503,17 @@ func TestFillValuesOfParamsInPlanUsesSQLExecuteSourceTypeOnlyInNumericConsumers(
 	comparisonResult := comparisonFilled.GetQuery().Nodes[0].ProjectList[0]
 	require.Equal(t, int32(types.T_int32), comparisonResult.GetF().Args[1].Typ.Id,
 		"a SQL source type must not replace the comparison domain")
+
+	sign, err := BindFuncExprImplByPlanExpr(ctx, "sign", []*planpb.Expr{makeParam()})
+	require.NoError(t, err)
+	signFilled, _, err := FillValuesOfParamsInPlanWithSpecialization(
+		ctx, makeQuery(t, sign), []any{ParamValue{
+			Value: "true", SourceType: types.T_bool.ToType(), HasSourceType: true,
+		}})
+	require.NoError(t, err)
+	signResult := signFilled.GetQuery().Nodes[0].ProjectList[0]
+	require.Equal(t, types.T_int64, types.T(signResult.Typ.Id), signResult.String())
+	require.Equal(t, types.T_int64, types.T(signResult.GetF().Args[0].Typ.Id), signResult.String())
 }
 
 func TestFillValuesOfParamsInPlanUsesSQLExecuteSourceTypeInPreparedResultConsumers(t *testing.T) {

--- a/pkg/tests/issues/issue_27088_common_type_test.go
+++ b/pkg/tests/issues/issue_27088_common_type_test.go
@@ -115,6 +115,41 @@ func TestIssue27088PreparedDecimalCommonType(t *testing.T) {
 					}
 				}()
 			}
+			const mixedAroundQuery = "SELECT ? AS before_value, ROUND(?) AS numeric_value, ? AS after_value"
+			mustExec(t, ctx, conn, "PREPARE bool_mixed_around FROM '"+mixedAroundQuery+"'")
+			defer mustExec(t, ctx, conn, "DEALLOCATE PREPARE bool_mixed_around")
+			for _, value := range []string{"TRUE", "FALSE", "NULL", "TRUE"} {
+				mustExec(t, ctx, conn, "SET @bool_mixed = "+value)
+				rows, err := conn.QueryContext(ctx,
+					"EXECUTE bool_mixed_around USING @bool_mixed, @bool_mixed, @bool_mixed")
+				require.NoError(t, err)
+				columns, err := rows.ColumnTypes()
+				require.NoError(t, err)
+				require.Len(t, columns, 3)
+				require.Equal(t, "TEXT", columns[0].DatabaseTypeName(), "direct parameter before numeric sibling")
+				require.Equal(t, "TEXT", columns[2].DatabaseTypeName(), "direct parameter after numeric sibling")
+				require.True(t, rows.Next())
+				var before, after sql.NullString
+				var numeric sql.NullFloat64
+				require.NoError(t, rows.Scan(&before, &numeric, &after))
+				require.False(t, rows.Next())
+				require.NoError(t, rows.Err())
+				require.Equal(t, value == "NULL", !before.Valid, value)
+				require.Equal(t, value == "NULL", !after.Valid, value)
+				if value != "NULL" {
+					require.Equal(t, strings.ToLower(value), before.String, value)
+					require.Equal(t, strings.ToLower(value), after.String, value)
+				}
+				require.Equal(t, value == "NULL", !numeric.Valid, value)
+				if value != "NULL" {
+					want := float64(0)
+					if value == "TRUE" {
+						want = 1
+					}
+					require.Equal(t, want, numeric.Float64, value)
+				}
+				require.NoError(t, rows.Close())
+			}
 			stmt, err := conn.PrepareContext(ctx, query)
 			require.NoError(t, err)
 			defer stmt.Close()

--- a/pkg/tests/issues/issue_27088_common_type_test.go
+++ b/pkg/tests/issues/issue_27088_common_type_test.go
@@ -45,6 +45,60 @@ func TestIssue27088PreparedDecimalCommonType(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
+		t.Run("issue 28484 prepared Boolean math", func(t *testing.T) {
+			const query = "SELECT CAST(? AS DOUBLE), SIN(?), ACOS(?)"
+			mustExec(t, ctx, conn, "PREPARE bool_math FROM '"+query+"'")
+			defer mustExec(t, ctx, conn, "DEALLOCATE PREPARE bool_math")
+			for _, value := range []string{"TRUE", "FALSE", "NULL", "TRUE", "'true'", "TRUE"} {
+				mustExec(t, ctx, conn, "SET @bool_math = "+value)
+				var got, expected [3]sql.NullFloat64
+				require.NoError(t, conn.QueryRowContext(ctx, "EXECUTE bool_math USING @bool_math, @bool_math, @bool_math").Scan(&got[0], &got[1], &got[2]))
+				reference := strings.ReplaceAll(query, "?", value)
+				require.NoError(t, conn.QueryRowContext(ctx, reference).Scan(&expected[0], &expected[1], &expected[2]))
+				require.Equal(t, expected, got, value)
+			}
+			const integerQuery = "SELECT ABS(?), ROUND(?), SIGN(?), POWER(?,?), SQRT(?)"
+			mustExec(t, ctx, conn, "PREPARE bool_numeric FROM '"+integerQuery+"'")
+			defer mustExec(t, ctx, conn, "DEALLOCATE PREPARE bool_numeric")
+			for _, value := range []string{"TRUE", "FALSE", "NULL", "TRUE"} {
+				mustExec(t, ctx, conn, "SET @bool_math = "+value)
+				var got, expected [5]sql.NullFloat64
+				require.NoError(t, conn.QueryRowContext(ctx, "EXECUTE bool_numeric USING @bool_math, @bool_math, @bool_math, @bool_math, @bool_math, @bool_math").Scan(&got[0], &got[1], &got[2], &got[3], &got[4]))
+				require.NoError(t, conn.QueryRowContext(ctx, strings.ReplaceAll(integerQuery, "?", value)).Scan(&expected[0], &expected[1], &expected[2], &expected[3], &expected[4]))
+				require.Equal(t, expected, got, value)
+			}
+			mustExec(t, ctx, conn, `PREPARE bool_json FROM 'SELECT ?, JSON_TYPE(JSON_EXTRACT(JSON_ARRAY(?), "$[0]"))'`)
+			defer mustExec(t, ctx, conn, "DEALLOCATE PREPARE bool_json")
+			var direct, jsonKind string
+			require.NoError(t, conn.QueryRowContext(ctx, "EXECUTE bool_json USING @bool_math, @bool_math").Scan(&direct, &jsonKind))
+			require.Equal(t, "true", direct)
+			require.Equal(t, "BOOLEAN", jsonKind)
+			stmt, err := conn.PrepareContext(ctx, query)
+			require.NoError(t, err)
+			defer stmt.Close()
+			for _, value := range []any{true, false, nil, true} {
+				var got [3]sql.NullFloat64
+				require.NoError(t, stmt.QueryRowContext(ctx, value, value, value).Scan(&got[0], &got[1], &got[2]))
+				if value == nil {
+					require.Equal(t, [3]sql.NullFloat64{}, got)
+				} else if value == true {
+					for _, result := range got {
+						require.True(t, result.Valid)
+					}
+					require.Equal(t, float64(1), got[0].Float64)
+					require.InDelta(t, 0.8414709848078965, got[1].Float64, 1e-15)
+					require.Equal(t, float64(0), got[2].Float64)
+				} else {
+					for _, result := range got {
+						require.True(t, result.Valid)
+					}
+					require.Equal(t, float64(0), got[0].Float64)
+					require.Equal(t, float64(0), got[1].Float64)
+					require.InDelta(t, 1.5707963267948966, got[2].Float64, 1e-15)
+				}
+			}
+		})
+
 		dbName := testutils.GetDatabaseName(t)
 		mustExec(t, ctx, conn, fmt.Sprintf("create database `%s`", dbName))
 		mustExec(t, ctx, conn, fmt.Sprintf("use `%s`", dbName))

--- a/pkg/tests/issues/issue_27088_common_type_test.go
+++ b/pkg/tests/issues/issue_27088_common_type_test.go
@@ -73,6 +73,46 @@ func TestIssue27088PreparedDecimalCommonType(t *testing.T) {
 			require.NoError(t, conn.QueryRowContext(ctx, "EXECUTE bool_json USING @bool_math, @bool_math").Scan(&direct, &jsonKind))
 			require.Equal(t, "true", direct)
 			require.Equal(t, "BOOLEAN", jsonKind)
+			const mixedQuery = "SELECT ?, ROUND(?)"
+			mustExec(t, ctx, conn, "PREPARE bool_mixed FROM '"+mixedQuery+"'")
+			defer mustExec(t, ctx, conn, "DEALLOCATE PREPARE bool_mixed")
+			for _, test := range []struct {
+				value       string
+				wantDirect  string
+				wantDirectN bool
+				wantRound   float64
+				wantRoundN  bool
+			}{
+				{value: "TRUE", wantDirect: "true", wantRound: 1},
+				{value: "FALSE", wantDirect: "false"},
+				{value: "NULL", wantDirectN: true, wantRoundN: true},
+				{value: "TRUE", wantDirect: "true", wantRound: 1},
+			} {
+				mustExec(t, ctx, conn, "SET @bool_mixed = "+test.value)
+				rows, err := conn.QueryContext(ctx,
+					"EXECUTE bool_mixed USING @bool_mixed, @bool_mixed")
+				require.NoError(t, err)
+				columns, err := rows.ColumnTypes()
+				require.NoError(t, err)
+				require.Len(t, columns, 2)
+				require.Equal(t, "TEXT", columns[0].DatabaseTypeName(),
+					"a direct SQL EXECUTE parameter keeps its text result contract")
+				require.True(t, rows.Next())
+				var gotDirect sql.NullString
+				var gotRound sql.NullFloat64
+				require.NoError(t, rows.Scan(&gotDirect, &gotRound))
+				require.False(t, rows.Next())
+				require.NoError(t, rows.Err())
+				require.Equal(t, test.wantDirectN, !gotDirect.Valid, test.value)
+				if !test.wantDirectN {
+					require.Equal(t, test.wantDirect, gotDirect.String, test.value)
+				}
+				require.Equal(t, test.wantRoundN, !gotRound.Valid, test.value)
+				if !test.wantRoundN {
+					require.Equal(t, test.wantRound, gotRound.Float64, test.value)
+				}
+				rows.Close()
+			}
 			stmt, err := conn.PrepareContext(ctx, query)
 			require.NoError(t, err)
 			defer stmt.Close()

--- a/pkg/tests/issues/issue_27088_common_type_test.go
+++ b/pkg/tests/issues/issue_27088_common_type_test.go
@@ -120,35 +120,37 @@ func TestIssue27088PreparedDecimalCommonType(t *testing.T) {
 			defer mustExec(t, ctx, conn, "DEALLOCATE PREPARE bool_mixed_around")
 			for _, value := range []string{"TRUE", "FALSE", "NULL", "TRUE"} {
 				mustExec(t, ctx, conn, "SET @bool_mixed = "+value)
-				rows, err := conn.QueryContext(ctx,
-					"EXECUTE bool_mixed_around USING @bool_mixed, @bool_mixed, @bool_mixed")
-				require.NoError(t, err)
-				columns, err := rows.ColumnTypes()
-				require.NoError(t, err)
-				require.Len(t, columns, 3)
-				require.Equal(t, "TEXT", columns[0].DatabaseTypeName(), "direct parameter before numeric sibling")
-				require.Equal(t, "TEXT", columns[2].DatabaseTypeName(), "direct parameter after numeric sibling")
-				require.True(t, rows.Next())
-				var before, after sql.NullString
-				var numeric sql.NullFloat64
-				require.NoError(t, rows.Scan(&before, &numeric, &after))
-				require.False(t, rows.Next())
-				require.NoError(t, rows.Err())
-				require.Equal(t, value == "NULL", !before.Valid, value)
-				require.Equal(t, value == "NULL", !after.Valid, value)
-				if value != "NULL" {
-					require.Equal(t, strings.ToLower(value), before.String, value)
-					require.Equal(t, strings.ToLower(value), after.String, value)
-				}
-				require.Equal(t, value == "NULL", !numeric.Valid, value)
-				if value != "NULL" {
-					want := float64(0)
-					if value == "TRUE" {
-						want = 1
+				func() {
+					rows, err := conn.QueryContext(ctx,
+						"EXECUTE bool_mixed_around USING @bool_mixed, @bool_mixed, @bool_mixed")
+					require.NoError(t, err)
+					defer rows.Close()
+					columns, err := rows.ColumnTypes()
+					require.NoError(t, err)
+					require.Len(t, columns, 3)
+					require.Equal(t, "TEXT", columns[0].DatabaseTypeName(), "direct parameter before numeric sibling")
+					require.Equal(t, "TEXT", columns[2].DatabaseTypeName(), "direct parameter after numeric sibling")
+					require.True(t, rows.Next())
+					var before, after sql.NullString
+					var numeric sql.NullFloat64
+					require.NoError(t, rows.Scan(&before, &numeric, &after))
+					require.False(t, rows.Next())
+					require.NoError(t, rows.Err())
+					require.Equal(t, value == "NULL", !before.Valid, value)
+					require.Equal(t, value == "NULL", !after.Valid, value)
+					if value != "NULL" {
+						require.Equal(t, strings.ToLower(value), before.String, value)
+						require.Equal(t, strings.ToLower(value), after.String, value)
 					}
-					require.Equal(t, want, numeric.Float64, value)
-				}
-				require.NoError(t, rows.Close())
+					require.Equal(t, value == "NULL", !numeric.Valid, value)
+					if value != "NULL" {
+						want := float64(0)
+						if value == "TRUE" {
+							want = 1
+						}
+						require.Equal(t, want, numeric.Float64, value)
+					}
+				}()
 			}
 			stmt, err := conn.PrepareContext(ctx, query)
 			require.NoError(t, err)

--- a/pkg/tests/issues/issue_27088_common_type_test.go
+++ b/pkg/tests/issues/issue_27088_common_type_test.go
@@ -89,29 +89,31 @@ func TestIssue27088PreparedDecimalCommonType(t *testing.T) {
 				{value: "TRUE", wantDirect: "true", wantRound: 1},
 			} {
 				mustExec(t, ctx, conn, "SET @bool_mixed = "+test.value)
-				rows, err := conn.QueryContext(ctx,
-					"EXECUTE bool_mixed USING @bool_mixed, @bool_mixed")
-				require.NoError(t, err)
-				columns, err := rows.ColumnTypes()
-				require.NoError(t, err)
-				require.Len(t, columns, 2)
-				require.Equal(t, "TEXT", columns[0].DatabaseTypeName(),
-					"a direct SQL EXECUTE parameter keeps its text result contract")
-				require.True(t, rows.Next())
-				var gotDirect sql.NullString
-				var gotRound sql.NullFloat64
-				require.NoError(t, rows.Scan(&gotDirect, &gotRound))
-				require.False(t, rows.Next())
-				require.NoError(t, rows.Err())
-				require.Equal(t, test.wantDirectN, !gotDirect.Valid, test.value)
-				if !test.wantDirectN {
-					require.Equal(t, test.wantDirect, gotDirect.String, test.value)
-				}
-				require.Equal(t, test.wantRoundN, !gotRound.Valid, test.value)
-				if !test.wantRoundN {
-					require.Equal(t, test.wantRound, gotRound.Float64, test.value)
-				}
-				rows.Close()
+				func() {
+					rows, err := conn.QueryContext(ctx,
+						"EXECUTE bool_mixed USING @bool_mixed, @bool_mixed")
+					require.NoError(t, err)
+					defer rows.Close()
+					columns, err := rows.ColumnTypes()
+					require.NoError(t, err)
+					require.Len(t, columns, 2)
+					require.Equal(t, "TEXT", columns[0].DatabaseTypeName(),
+						"a direct SQL EXECUTE parameter keeps its text result contract")
+					require.True(t, rows.Next())
+					var gotDirect sql.NullString
+					var gotRound sql.NullFloat64
+					require.NoError(t, rows.Scan(&gotDirect, &gotRound))
+					require.False(t, rows.Next())
+					require.NoError(t, rows.Err())
+					require.Equal(t, test.wantDirectN, !gotDirect.Valid, test.value)
+					if !test.wantDirectN {
+						require.Equal(t, test.wantDirect, gotDirect.String, test.value)
+					}
+					require.Equal(t, test.wantRoundN, !gotRound.Valid, test.value)
+					if !test.wantRoundN {
+						require.Equal(t, test.wantRound, gotRound.Float64, test.value)
+					}
+				}()
 			}
 			stmt, err := conn.PrepareContext(ctx, query)
 			require.NoError(t, err)

--- a/test/distributed/cases/prepare/numeric_context.result
+++ b/test/distributed/cases/prepare/numeric_context.result
@@ -49,4 +49,43 @@ EXECUTE p_mod USING @a;
 ➤ cast(MOD(?, 2) as signed)[-5,64,0]  𝄀
 1
 DEALLOCATE PREPARE p_mod;
+PREPARE p_bool FROM 'SELECT CAST(? AS DOUBLE) AS d, ROUND(SIN(?),12) AS s, ROUND(ACOS(?),12) AS a';
+SET @bool_math = TRUE;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+➤ d[8,64,0]  ¦  s[8,64,0]  ¦  a[8,64,0]  𝄀
+1  ¦  0.841470984808  ¦  0
+SET @bool_math = FALSE;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+➤ d[8,64,0]  ¦  s[8,64,0]  ¦  a[8,64,0]  𝄀
+0  ¦  0  ¦  1.570796326795
+SET @bool_math = NULL;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+➤ d[8,64,0]  ¦  s[8,64,0]  ¦  a[8,64,0]  𝄀
+null  ¦  null  ¦  null
+SET @bool_math = 'true';
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+➤ d[8,64,0]  ¦  s[8,64,0]  ¦  a[8,64,0]  𝄀
+0  ¦  0  ¦  1.570796326795
+SET @bool_math = TRUE;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+➤ d[8,64,0]  ¦  s[8,64,0]  ¦  a[8,64,0]  𝄀
+1  ¦  0.841470984808  ¦  0
+DEALLOCATE PREPARE p_bool;
+PREPARE p_bool_int FROM 'SELECT ABS(?) AS a, ROUND(?) AS r, SIGN(?) AS s';
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+➤ a[-5,64,0]  ¦  r[-5,64,0]  ¦  s[-5,64,0]  𝄀
+1  ¦  1  ¦  1
+SET @bool_math = FALSE;
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+➤ a[-5,64,0]  ¦  r[-5,64,0]  ¦  s[-5,64,0]  𝄀
+0  ¦  0  ¦  0
+SET @bool_math = NULL;
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+➤ a[-5,64,0]  ¦  r[-5,64,0]  ¦  s[-5,64,0]  𝄀
+null  ¦  null  ¦  null
+SET @bool_math = TRUE;
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+➤ a[-5,64,0]  ¦  r[-5,64,0]  ¦  s[-5,64,0]  𝄀
+1  ¦  1  ¦  1
+DEALLOCATE PREPARE p_bool_int;
 DROP DATABASE numeric_context_test;

--- a/test/distributed/cases/prepare/numeric_context.sql
+++ b/test/distributed/cases/prepare/numeric_context.sql
@@ -33,4 +33,29 @@ PREPARE p_mod FROM 'SELECT CAST(MOD(?, 2) AS SIGNED)';
 EXECUTE p_mod USING @a;
 DEALLOCATE PREPARE p_mod;
 
+-- Issue #28484: Boolean provenance must survive SQL EXECUTE's text transport.
+-- Reuse one prepared plan across Boolean, NULL and ordinary string values.
+PREPARE p_bool FROM 'SELECT CAST(? AS DOUBLE) AS d, ROUND(SIN(?),12) AS s, ROUND(ACOS(?),12) AS a';
+SET @bool_math = TRUE;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+SET @bool_math = FALSE;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+SET @bool_math = NULL;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+SET @bool_math = 'true';
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+SET @bool_math = TRUE;
+EXECUTE p_bool USING @bool_math, @bool_math, @bool_math;
+DEALLOCATE PREPARE p_bool;
+
+PREPARE p_bool_int FROM 'SELECT ABS(?) AS a, ROUND(?) AS r, SIGN(?) AS s';
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+SET @bool_math = FALSE;
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+SET @bool_math = NULL;
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+SET @bool_math = TRUE;
+EXECUTE p_bool_int USING @bool_math, @bool_math, @bool_math;
+DEALLOCATE PREPARE p_bool_int;
+
 DROP DATABASE numeric_context_test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28484

Follow-up to #28513: fixes the SQL PREPARE/EXECUTE Boolean acceptance failure
reported after that change merged.

## What this PR does / why we need it:

SQL `EXECUTE` transports user-variable values through a text-shaped vector but
retains their logical prepare-time category.  The planner must use that
provenance for numeric consumers without changing the historical result domain
of a bare SQL `?` projection.

Before this fix, `TRUE` in `CAST(? AS DOUBLE)`, `SIN(?)`, or `ACOS(?)` could be
parsed as an ordinary nonnumeric string and become zero in MySQL mode.  Integer
consumers such as `ABS(?)`, `ROUND(?)`, and `SIGN(?)` could reject the same
Boolean with an invalid cast.  A Boolean value can also be reused across
executions, NULLs, ordinary strings, and direct-result/numeric sibling
expressions.

## Design and implementation

- SQL EXECUTE carries Boolean `SourceType` metadata for overload rebinding;
  `HasRuntimeType` remains unset for a bare SQL result marker, preserving its
  TEXT result metadata.  Explicit COM_STMT runtime types remain authoritative.
- Numeric consumers use the source type to select the existing integer/float
  overloads.  The shared string-to-float conversion consults row-local
  Boolean provenance and maps canonical Boolean transport values to `0`/`1`.
- NULLs and inactive selection rows are handled before conversion.  Ordinary
  SQL strings such as `'true'` stay on the existing string-coercion and warning
  path; malformed values marked as Boolean fail explicitly.
- The integration regression closes each query's `Rows` in a per-iteration
  scope, so assertion failures cannot retain server-side result resources.
- The repository's `.agents/skills/mo-dev` now documents changed-package
  static checks and evidence-based CI/environment triage instead of requiring a
  whole-repository SCA in every edit loop.
- No wire-format, persistence, planner-cache, synchronization, I/O, or
  background-work change is introduced.  Runtime plan copies remain isolated
  from the cached prepared plan.

## Test plan

Validated from a clean worktree rebased onto `origin/main` commit
`44b7f90ee1695831663c55288a537c03c15c00e0`:

- `pkg/sql/plan/function`: Boolean FLOAT/DOUBLE casts, inactive rows, and
  numeric math consumers; focused `-race` passed.
- `pkg/sql/plan`: numeric overload/source-type rebinding, direct-result domain
  isolation, cache-plan immutability, and existing prepared parameter tests;
  focused `-race` passed.
- `pkg/frontend`: prepared execution/metadata and related reuse tests;
  focused `-race` passed.
- `TestIssue27088PreparedDecimalCommonType`: real embedded SQL PREPARE/EXECUTE
  coverage for TRUE/FALSE/NULL/string/reuse, integer targets, JSON controls,
  and the direct-parameter-before/after-numeric-sibling case passed in 9.5s
  after the SCA cleanup fix.
- `prepare/numeric_context` changes add the reported CAST/SIN/ACOS and
  ABS/ROUND/SIGN reuse cases.
- Incremental `golangci-lint` `sqlclosecheck` on `pkg/tests/issues`, with the
  repository CGo include paths, passed with `0 issues`.
- `quick_validate.py .agents/skills/mo-dev` and `git diff --check` passed.

CI was not awaited.  The current PR's historical compose information-schema
  failure and resource-heavy UT cancellation are outside the changed paths;
  no unrelated test or catalog behavior was modified here.

## Review status

The complete final diff was reviewed with GPT-6 medium after implementation.
No remaining P0/P1/P2 semantic, metadata, NULL/mask, reuse, lifecycle, or
performance blocker was identified.

Final head: `cec5ce0bc645f3d4a52450312a540541cb703e18`.