### PR TITLE
test: overlap plan UT within the single-runner budget

### DIFF
--- a/.github/ci/change-scope.test.cjs
+++ b/.github/ci/change-scope.test.cjs
@@ -178,8 +178,8 @@ test('entrypoint routes each scope through one required check', () => {
   }
 });
 
-test('entrypoint enables the complete race-UT shard contract', () => {
+test('entrypoint runs the complete race-UT suite on one runner', () => {
   const caller = entrypointJobs()['matrixone-ci'];
   assert.match(caller, /^    uses: matrixorigin\/CI\/\.github\/workflows\/ci\.yaml@main$/m);
-  assert.match(caller, /^    with:\n      ut_parallel: 6\n      ut_sharded: true$/m);
+  assert.match(caller, /^    with:\n      ut_parallel: 6\n      ut_sharded: false$/m);
 });

--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -120,7 +120,7 @@ jobs:
     uses: matrixorigin/CI/.github/workflows/ci.yaml@main
     with:
       ut_parallel: 6
-      ut_sharded: true
+      ut_sharded: false
     secrets: inherit
 
   matrixone-ut-coverage:

--- a/Makefile
+++ b/Makefile
@@ -532,10 +532,15 @@ UT_PREBUILD_EMBEDDED ?= 0
 # Plan overlap is an explicit A/B knob; it consumes one heavy process slot and
 # remains off until the runner's resource budget proves a gain.
 UT_OVERLAP_PLAN ?= 0
+# Run pkg/logservice in a private process while the serial issues package is
+# active. This is an explicit A/B knob: it is enabled only for UT_SHARD=all,
+# after dependency ownership validation, and remains off until same-runner
+# measurements prove a wall-time gain without resource contention.
+UT_OVERLAP_LOGSERVICE ?= 0
 # Parent cancellation waits long enough for helper-owned child process groups
 # to receive TERM and bounded KILL cleanup in sequence.
 UT_HELPER_TERM_GRACE_TICKS ?= 60
-export UT_SHARD UT_HARD_TIMEOUT UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_HELPER_TERM_GRACE_TICKS
+export UT_SHARD UT_HARD_TIMEOUT UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_OVERLAP_LOGSERVICE UT_HELPER_TERM_GRACE_TICKS
 # Native compilation runs before Go tests, so it can use an explicit UT CPU
 # budget without increasing peak race-test memory. With the default UT value,
 # omit -j and preserve recursive make's jobserver contract: a plain make stays

--- a/Makefile
+++ b/Makefile
@@ -529,18 +529,13 @@ UT_HARD_TIMEOUT ?= 70m
 # consumes CPU, memory, and linker capacity, so it remains opt-in until a
 # same-resource measurement proves a critical-path gain.
 UT_PREBUILD_EMBEDDED ?= 0
-# Plan overlap is an explicit A/B knob; it consumes one heavy process slot and
-# remains off until the runner's resource budget proves a gain.
-UT_OVERLAP_PLAN ?= 0
-# Run pkg/logservice in a private process while the serial issues package is
-# active. This is an explicit A/B knob: it is enabled only for UT_SHARD=all,
-# after dependency ownership validation, and remains off until same-runner
-# measurements prove a wall-time gain without resource contention.
-UT_OVERLAP_LOGSERVICE ?= 0
+# Reuse released engine slots for plan while resource-heavy work finishes.
+# The heavy process budget is unchanged; set 0 for a sequential A/B baseline.
+UT_OVERLAP_PLAN ?= 1
 # Parent cancellation waits long enough for helper-owned child process groups
 # to receive TERM and bounded KILL cleanup in sequence.
 UT_HELPER_TERM_GRACE_TICKS ?= 60
-export UT_SHARD UT_HARD_TIMEOUT UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_OVERLAP_LOGSERVICE UT_HELPER_TERM_GRACE_TICKS
+export UT_SHARD UT_HARD_TIMEOUT UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_HELPER_TERM_GRACE_TICKS
 # Native compilation runs before Go tests, so it can use an explicit UT CPU
 # budget without increasing peak race-test memory. With the default UT value,
 # omit -j and preserve recursive make's jobserver contract: a plain make stays

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -1,11 +1,11 @@
 # UT 执行模型与 fixture 生命周期优化设计
 
-- 状态：Accepted for this PR，revision 4
+- 状态：Accepted for this PR，revision 5
 - 适用范围：`optools/run_ut.sh`、Go test package 分组、embedded/shared cluster fixture、CI UT 资源预算
 - 约束：不增加 runner 数量；收益必须来自单 runner 的工作删除、fixture 复用或资源有界的阶段重叠
 - 设计 owner：UT runner 与测试基础设施；各测试 package 对自己的 fixture reset/cleanup 契约负责
 - 设计门禁：跨 package、跨进程 admission、runner 取消和集群生命周期，命中 execution、ownership、resource 和 public test-contract 多个边界
-- 决策记录：revision 2 接受本 PR 的 runner 账本、取消/报告所有权和有界分片；compile-only prebuild 保留为显式 opt-in，plan overlap 仍为显式 opt-in；两者都不改变默认资源预算。跨进程 cluster 共享和动态调度不在本 PR；本 revision 按兼容矩阵落地了一个同进程单 CN fixture 合并，并为后续专用 fixture 增加显式释放边界。
+- 决策记录：revision 2 接受本 PR 的 runner 账本、取消/报告所有权和有界分片；compile-only prebuild 保留为显式 opt-in，plan overlap 仍为显式 opt-in；两者都不改变默认资源预算。revision 5 将 CI race-UT 恢复为一个完整 suite、一个 runner，保留相同的 package partition、race 和失败门禁；`pkg/logservice` 的独立进程 companion 仅作为 `UT_OVERLAP_LOGSERVICE=1` 的显式 A/B。跨进程 cluster 共享和动态调度不在本 PR；本 revision 按兼容矩阵落地了一个同进程单 CN fixture 合并，并为后续专用 fixture 增加显式释放边界。
 
 ## 1. 问题与不变量
 
@@ -65,6 +65,8 @@ fixture，避免同时持有两个 complete cluster，且不改变现有 admissi
 
 复用现有完整且不重叠的 UT shard partition。单 runner 内可以先用 `go test -c` 做不执行测试 binary 的预编译，把 embedded 包的 build/link 与 issues 的共享 cluster body 重叠；预编译失败仍由正式测试命令给出权威结果，预编译进程必须接受同一取消路径。本 PR 提供这个路径，但 `UT_PREBUILD_EMBEDDED=0` 是默认值；只有同一 checkout、race/tags、CPU/memory 和缓存模式的 A/B 证明关键路径收益后，才可在 CI 显式打开。再在相同条件下 A/B embedded `-p1` 与 `-p2`，决定是否扩大 package 并发。plan shards 只有在显式消耗一个 heavy 进程 slot、证明非空、全集覆盖、不重复和可清理后才并行；`UT_OVERLAP_PLAN=0` 默认保持顺序。每个 runner 默认一个 active complete cluster。
 
+CI 的默认路径使用 `UT_SHARD=all` 在一个 runner 上顺序执行这些阶段。这样会删除四个 shard 重复的 checkout、native build、Go cache 和 setup，降低 runner-minutes；它不会把旧的四 runner wall time 直接当成单 runner wall time。`pkg/logservice` 不依赖 embedded cluster，也不持有共享 issues fixture，因此可以在 HNSW 完成后以 `-p1` 私有进程与 issues body 重叠。设置 `UT_OVERLAP_LOGSERVICE=1` 时，脚本先验证该 package 仍在完整 scope、没有进入 dependency-derived embedded scope，并把它从 light group 移入 companion group；companion 在 serial issues 结束后等待、合并报告，之后才进入 embedded 阶段。分片路径和 `UT_PREBUILD_EMBEDDED=1` 会禁用该 companion 并把 package 留在 light group，避免遗漏或重复执行。该开关默认关闭，须在同一 runner、同一 race/tags、同一 cgroup 的至少三次交替 A/B 中确认 wall time、CPU throttling、memory peak、flaky rate 和报告完整性后才适合开启。
+
 只有当同进程合并、reset 和静态分片后仍有实测的 cluster startup 瓶颈，才另行设计跨进程 cluster service。那时必须补租约、generation、失联、reset、server crash、内部 hook 不可复用和权限隔离契约；本设计不把 daemon、动态 scheduler 或无界 admission slot 作为第一批改动。
 
 ## 4. 观测与度量
@@ -95,7 +97,7 @@ fixture，避免同时持有两个 complete cluster，且不改变现有 admissi
 ## 7. 交付拆分
 
 1. 本 revision：runner checkpoint、报告早创建、取消进程组清理、`run_ut.sh` 执行阶段的 70 分钟外层兜底、helper 报告所有权和诊断测试。`make ut` 的 `cgo/config` prerequisites 在该 timeout 之前运行；它们仍由各自命令负责失败和重试，不把 70 分钟描述成整个 make job 的硬上限。
-2. 本 revision 提供 compile-only embedded prebuild，但默认关闭（`UT_PREBUILD_EMBEDDED=0`）；plan overlap 同样默认关闭（`UT_OVERLAP_PLAN=0`）。打开任一开关前必须补同资源 A/B 和负向取消证据。
+2. 本 revision 提供 compile-only embedded prebuild，但默认关闭（`UT_PREBUILD_EMBEDDED=0`）；plan overlap 同样默认关闭（`UT_OVERLAP_PLAN=0`），logservice companion 也默认关闭（`UT_OVERLAP_LOGSERVICE=0`）。打开任一开关前必须补同资源 A/B 和负向取消证据。
 3. 本 revision：按兼容矩阵迁移一小批可复用 fixture，并提供 fixture/关键路径 before-after；后续继续逐组验证，不跨越不同 topology 或 global hook 合并。
 4. 后续 PR：清理慢测试的重复 setup、无契约等待和过大数据，逐项保留 oracle 证明。
 5. 后续 PR：静态 shard/runner 资源 A/B；只有证据支持时再考虑跨进程共享 cluster。

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -1,11 +1,46 @@
 # UT 执行模型与 fixture 生命周期优化设计
 
-- 状态：Accepted for this PR，revision 5
+- 状态：Accepted for this PR，revision 6
 - 适用范围：`optools/run_ut.sh`、Go test package 分组、embedded/shared cluster fixture、CI UT 资源预算
 - 约束：不增加 runner 数量；收益必须来自单 runner 的工作删除、fixture 复用或资源有界的阶段重叠
 - 设计 owner：UT runner 与测试基础设施；各测试 package 对自己的 fixture reset/cleanup 契约负责
 - 设计门禁：跨 package、跨进程 admission、runner 取消和集群生命周期，命中 execution、ownership、resource 和 public test-contract 多个边界
-- 决策记录：revision 2 接受本 PR 的 runner 账本、取消/报告所有权和有界分片；compile-only prebuild 保留为显式 opt-in，plan overlap 仍为显式 opt-in；两者都不改变默认资源预算。revision 5 将 CI race-UT 恢复为一个完整 suite、一个 runner，保留相同的 package partition、race 和失败门禁；`pkg/logservice` 的独立进程 companion 仅作为 `UT_OVERLAP_LOGSERVICE=1` 的显式 A/B。跨进程 cluster 共享和动态调度不在本 PR；本 revision 按兼容矩阵落地了一个同进程单 CN fixture 合并，并为后续专用 fixture 增加显式释放边界。
+- 决策记录：revision 2 接受本 PR 的 runner 账本、取消/报告所有权和有界分片；compile-only prebuild 保留为显式 opt-in，plan overlap 仍为显式 opt-in；两者都不改变默认资源预算。跨进程 cluster 共享和动态调度不在本 PR；本 revision 按兼容矩阵落地了一个同进程单 CN fixture 合并，并为后续专用 fixture 增加显式释放边界。
+
+## Revision 6: reuse released engine capacity on one runner
+
+The CI caller selects `ut_sharded: false`. Returning to one runner is a resource
+constraint, not a speedup relative to the earlier single-runner baseline.
+
+The measured single-runner trace has resource-heavy work from 06:19:04 to
+06:26:04, while both engine processes finish by 06:22:22. Plan then extends the
+critical path by about 2m20s. The runner now starts plan after joining engine,
+while the existing resource-heavy command continues. With the default budget
+of three, `engine(2) + resource(1)` becomes `plan(1) + resource(1)`. Plan compilation
+retains `-p1`; cases, data, race flags, cluster admission, and coverage jobs are
+unchanged. This scheduling change is enabled by default (`UT_OVERLAP_PLAN=1`);
+`0` provides the previous sequential baseline. Budgets of one or two retain
+sequential execution, as do paths without a concurrent engine helper.
+
+The foreground command retains one parent-owned PID and stage/label. Engine's
+status is saved even on failure, and plan still runs. Engine JSON is merged only
+after the foreground writer has exited: renaming the report before that barrier
+would discard later writes to the old inode. Plan retains its private report.
+Cancellation signals every owned group before bounded waits and report merging.
+
+The scheduling contract tests use a blocked heavy writer that only plan can
+release, prove engine is joined first, and require every report exactly once.
+They also exercise failures of each stage, low budgets, sequential mode, and
+TERM during overlap. No public SQL behavior changes, so new BVT cases are not
+needed. Actual CI savings depend on the remaining heavy tail and resource
+contention; the historical 2m20s is potential overlap, not a measured improvement.
+
+The earlier proposed logservice companion was removed. That package finished
+several minutes before light completed in the observed trace; its own elapsed
+time was not evidence of critical-path savings.
+
+The sections below record the earlier fixture/runner design. Revision 6 replaces
+the earlier opt-in, extra-slot plan-overlap policy with released-slot scheduling.
 
 ## 1. 问题与不变量
 
@@ -65,8 +100,6 @@ fixture，避免同时持有两个 complete cluster，且不改变现有 admissi
 
 复用现有完整且不重叠的 UT shard partition。单 runner 内可以先用 `go test -c` 做不执行测试 binary 的预编译，把 embedded 包的 build/link 与 issues 的共享 cluster body 重叠；预编译失败仍由正式测试命令给出权威结果，预编译进程必须接受同一取消路径。本 PR 提供这个路径，但 `UT_PREBUILD_EMBEDDED=0` 是默认值；只有同一 checkout、race/tags、CPU/memory 和缓存模式的 A/B 证明关键路径收益后，才可在 CI 显式打开。再在相同条件下 A/B embedded `-p1` 与 `-p2`，决定是否扩大 package 并发。plan shards 只有在显式消耗一个 heavy 进程 slot、证明非空、全集覆盖、不重复和可清理后才并行；`UT_OVERLAP_PLAN=0` 默认保持顺序。每个 runner 默认一个 active complete cluster。
 
-CI 的默认路径使用 `UT_SHARD=all` 在一个 runner 上顺序执行这些阶段。这样会删除四个 shard 重复的 checkout、native build、Go cache 和 setup，降低 runner-minutes；它不会把旧的四 runner wall time 直接当成单 runner wall time。`pkg/logservice` 不依赖 embedded cluster，也不持有共享 issues fixture，因此可以在 HNSW 完成后以 `-p1` 私有进程与 issues body 重叠。设置 `UT_OVERLAP_LOGSERVICE=1` 时，脚本先验证该 package 仍在完整 scope、没有进入 dependency-derived embedded scope，并把它从 light group 移入 companion group；companion 在 serial issues 结束后等待、合并报告，之后才进入 embedded 阶段。分片路径和 `UT_PREBUILD_EMBEDDED=1` 会禁用该 companion 并把 package 留在 light group，避免遗漏或重复执行。该开关默认关闭，须在同一 runner、同一 race/tags、同一 cgroup 的至少三次交替 A/B 中确认 wall time、CPU throttling、memory peak、flaky rate 和报告完整性后才适合开启。
-
 只有当同进程合并、reset 和静态分片后仍有实测的 cluster startup 瓶颈，才另行设计跨进程 cluster service。那时必须补租约、generation、失联、reset、server crash、内部 hook 不可复用和权限隔离契约；本设计不把 daemon、动态 scheduler 或无界 admission slot 作为第一批改动。
 
 ## 4. 观测与度量
@@ -97,7 +130,7 @@ CI 的默认路径使用 `UT_SHARD=all` 在一个 runner 上顺序执行这些�
 ## 7. 交付拆分
 
 1. 本 revision：runner checkpoint、报告早创建、取消进程组清理、`run_ut.sh` 执行阶段的 70 分钟外层兜底、helper 报告所有权和诊断测试。`make ut` 的 `cgo/config` prerequisites 在该 timeout 之前运行；它们仍由各自命令负责失败和重试，不把 70 分钟描述成整个 make job 的硬上限。
-2. 本 revision 提供 compile-only embedded prebuild，但默认关闭（`UT_PREBUILD_EMBEDDED=0`）；plan overlap 同样默认关闭（`UT_OVERLAP_PLAN=0`），logservice companion 也默认关闭（`UT_OVERLAP_LOGSERVICE=0`）。打开任一开关前必须补同资源 A/B 和负向取消证据。
+2. 本 revision 提供 compile-only embedded prebuild，但默认关闭（`UT_PREBUILD_EMBEDDED=0`）；plan overlap 同样默认关闭（`UT_OVERLAP_PLAN=0`）。打开任一开关前必须补同资源 A/B 和负向取消证据。
 3. 本 revision：按兼容矩阵迁移一小批可复用 fixture，并提供 fixture/关键路径 before-after；后续继续逐组验证，不跨越不同 topology 或 global hook 合并。
 4. 后续 PR：清理慢测试的重复 setup、无契约等待和过大数据，逐项保留 oracle 证明。
 5. 后续 PR：静态 shard/runner 资源 A/B；只有证据支持时再考虑跨进程共享 cluster。

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -46,11 +46,7 @@ UT_HARD_TIMEOUT=${UT_HARD_TIMEOUT:-"70m"}
 UT_PARALLEL=${UT_PARALLEL:-"1"}
 UT_SHARD=${UT_SHARD:-"all"}
 UT_PREBUILD_EMBEDDED=${UT_PREBUILD_EMBEDDED:-"0"}
-UT_OVERLAP_PLAN=${UT_OVERLAP_PLAN:-"0"}
-# Keep the logservice companion as an explicit A/B knob.  It is only selected
-# for the complete single-runner suite after package ownership is revalidated;
-# shard jobs must never silently drop it from the light wave.
-UT_OVERLAP_LOGSERVICE=${UT_OVERLAP_LOGSERVICE:-"0"}
+UT_OVERLAP_PLAN=${UT_OVERLAP_PLAN:-"1"}
 # A helper may own two independent child process groups. Its trap gives each
 # child a bounded TERM grace period, so the parent must retain the helper long
 # enough for both children to finish before escalating to KILL.
@@ -77,14 +73,13 @@ PLAN_RACE_JOB_PID=""
 PLAN_RACE_REPORT=""
 CLUSTER_PREBUILD_JOB_PID=""
 CLUSTER_PREBUILD_REPORT=""
-LOGSERVICE_RACE_JOB_PID=""
-LOGSERVICE_RACE_REPORT=""
-LOGSERVICE_RACE_STDERR=""
 ENGINE_RACE_TEST_BINARY=""
 ENGINE_RACE_JOB_PID=""
 ENGINE_RACE_REPORT=""
 ENGINE_RACE_REPORT_READY=""
 CURRENT_UT_PID=""
+CURRENT_UT_COMMAND_STAGE=""
+CURRENT_UT_COMMAND_LABEL=""
 CURRENT_UT_STAGE="initializing"
 CURRENT_UT_LABEL="startup"
 UT_TERMINATING=0
@@ -166,26 +161,64 @@ function mark_ut_stage(){
     checkpoint_ut_event "${event}" "${stage}" "${label}" "${status}" "${detail}"
 }
 
-function run_ut_command(){
-    if (( $# < 3 )); then
-        echo "Usage: run_ut_command STAGE LABEL COMMAND [ARG...]" >&2
+# The parent retains the foreground command's PID even while joining another
+# helper. Only this command writes UT_REPORT; helper reports are consumed after
+# finish_ut_command has reaped it.
+function start_ut_command(){
+    if (( $# < 3 )) || [[ -n "${CURRENT_UT_PID}" ]]; then
+        logger "ERR" "start_ut_command requires stage, label, command and no active writer"
         return 2
     fi
-
     local stage=$1
     local label=$2
     shift 2
-    local status=0
+    local saved_term_trap
+    local term_pending=0
+    CURRENT_UT_COMMAND_STAGE=${stage}
+    CURRENT_UT_COMMAND_LABEL=${label}
     mark_ut_stage "${stage}" "${label}" start "" "${*}"
+    saved_term_trap=$(trap -p TERM)
+    trap 'term_pending=1' TERM
     set -m
     "$@" >> "${UT_REPORT}" 2>> "${UT_STDERR}" &
     CURRENT_UT_PID=$!
+    set +m
+    restore_ut_term_trap "${saved_term_trap}"
     checkpoint_ut_event "pid-start" "${stage}" "${label}" "" "child_pid=${CURRENT_UT_PID}"
+    if (( term_pending != 0 )); then
+        handle_ut_termination
+    fi
+}
+
+function finish_ut_command(){
+    local status=0
     wait "${CURRENT_UT_PID}" || status=$?
     CURRENT_UT_PID=""
-    set +m
-    mark_ut_stage "${stage}" "${label}" finish "${status}"
+    mark_ut_stage "${CURRENT_UT_COMMAND_STAGE}" "${CURRENT_UT_COMMAND_LABEL}" finish "${status}"
     return "${status}"
+}
+
+function run_ut_command(){
+    start_ut_command "$@" || return $?
+    finish_ut_command
+}
+
+function start_plan_race(){
+    local package=$1
+    local saved_term_trap
+    local term_pending=0
+    PLAN_RACE_TEST_BINARY="${G_WKSP}/${G_TS}-plan-race.test"
+    PLAN_RACE_REPORT="${G_WKSP}/${G_TS}-plan-race-report.out"
+    saved_term_trap=$(trap -p TERM)
+    trap 'term_pending=1' TERM
+    set -m
+    run_plan_race_shards "${package}" &
+    PLAN_RACE_JOB_PID=$!
+    set +m
+    restore_ut_term_trap "${saved_term_trap}"
+    if (( term_pending != 0 )); then
+        handle_ut_termination
+    fi
 }
 
 
@@ -304,114 +337,6 @@ function consume_plan_race_report(){
     fi
 }
 
-function consume_logservice_race_report(){
-    if [[ -z "${LOGSERVICE_RACE_REPORT}" ]]; then
-        return 0
-    fi
-
-    # The companion owns a private JSON report while it overlaps the serial
-    # issues process.  Transfer it only after the process has stopped, under
-    # the same TERM-pending guard used by the other helper reports.
-    local saved_term_trap
-    local term_pending=0
-    local append_status=0
-    saved_term_trap=$(trap -p TERM)
-    trap 'term_pending=1' TERM
-    if [[ -s "${LOGSERVICE_RACE_STDERR}" ]]; then
-        local stderr_source="${LOGSERVICE_RACE_STDERR}"
-        append_ut_report "${stderr_source}" "${UT_STDERR}"
-        if (( $? != 0 )); then
-            logger "ERR" "failed to consume logservice race stderr; preserving ${stderr_source}"
-            restore_ut_term_trap "${saved_term_trap}"
-            if (( term_pending != 0 && UT_TERMINATING == 0 )); then
-                handle_ut_termination
-            fi
-            return 1
-        fi
-        # Clear ownership as soon as the atomic append commits. Cleanup is
-        # best-effort; leaving an already-consumed source cannot cause a retry
-        # to duplicate diagnostics.
-        LOGSERVICE_RACE_STDERR=""
-        remove_ut_report_file "${stderr_source}"
-    fi
-    append_ut_report "${LOGSERVICE_RACE_REPORT}" "${UT_REPORT}"
-    append_status=$?
-    if (( append_status != 0 )); then
-        logger "ERR" "failed to consume logservice race report; preserving ${LOGSERVICE_RACE_REPORT}"
-        restore_ut_term_trap "${saved_term_trap}"
-        if (( term_pending != 0 && UT_TERMINATING == 0 )); then
-            handle_ut_termination
-        fi
-        return "${append_status}"
-    fi
-    rm -f "${LOGSERVICE_RACE_REPORT}"
-    LOGSERVICE_RACE_REPORT=""
-    LOGSERVICE_RACE_STDERR=""
-    restore_ut_term_trap "${saved_term_trap}"
-    if (( term_pending != 0 && UT_TERMINATING == 0 )); then
-        handle_ut_termination
-    fi
-}
-
-function start_logservice_race(){
-    local logservice_package=$1
-    local saved_term_trap=""
-    local term_pending=0
-
-    if [[ -z "${logservice_package}" ]]; then
-        return 2
-    fi
-    LOGSERVICE_RACE_REPORT="${G_WKSP}/${G_TS}-logservice-race-report.out"
-    LOGSERVICE_RACE_STDERR="${G_WKSP}/${G_TS}-logservice-race-stderr.out"
-    : > "${LOGSERVICE_RACE_REPORT}"
-    : > "${LOGSERVICE_RACE_STDERR}"
-    mark_ut_stage "logservice" "logservice race-test package" start \
-        "" "package=${logservice_package} parallel=1 companion=true"
-    logger "INF" "Start ${logservice_package} as a bounded companion race-test process"
-    # Keep TERM observable while the shell creates the process group and
-    # publishes its pid. Without this small ownership transaction a signal
-    # between `&` and `$!` could leave an untracked go test descendant behind.
-    saved_term_trap=$(trap -p TERM)
-    trap 'term_pending=1' TERM
-    set -m
-    env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
-        CGO_CFLAGS="${CGO_CFLAGS}" \
-        CGO_LDFLAGS="${CGO_LDFLAGS}" \
-        go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json \
-        -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race \
-        "${logservice_package}" > "${LOGSERVICE_RACE_REPORT}" \
-        2> "${LOGSERVICE_RACE_STDERR}" &
-    LOGSERVICE_RACE_JOB_PID=$!
-    set +m
-    restore_ut_term_trap "${saved_term_trap}"
-    checkpoint_ut_event "pid-start" "logservice" "logservice race-test package" "" \
-        "child_pid=${LOGSERVICE_RACE_JOB_PID} package=${logservice_package} parallel=1 companion=true"
-    if (( term_pending != 0 && UT_TERMINATING == 0 )); then
-        handle_ut_termination
-    fi
-}
-
-function finish_logservice_race(){
-    local logservice_status=0
-    local report_status=0
-
-    if [[ -z "${LOGSERVICE_RACE_JOB_PID}" ]]; then
-        return 0
-    fi
-    wait "${LOGSERVICE_RACE_JOB_PID}" || logservice_status=$?
-    LOGSERVICE_RACE_JOB_PID=""
-    mark_ut_stage "logservice" "logservice race-test package" finish "${logservice_status}"
-    consume_logservice_race_report
-    report_status=$?
-    if (( report_status != 0 )); then
-        logservice_status=1
-    fi
-    if (( logservice_status != 0 )); then
-        logger "ERR" "logservice race-test package failed with status ${logservice_status}"
-    fi
-    return "${logservice_status}"
-}
-
 function handle_ut_termination(){
     trap - TERM
     if (( UT_TERMINATING != 0 )); then
@@ -419,30 +344,17 @@ function handle_ut_termination(){
     fi
     UT_TERMINATING=1
     checkpoint_ut_event "cancel" "${CURRENT_UT_STAGE}" "${CURRENT_UT_LABEL}" "143" \
-        "current_pid=${CURRENT_UT_PID} logservice_pid=${LOGSERVICE_RACE_JOB_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
+        "current_pid=${CURRENT_UT_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
 
-    # Notify every owner before waiting on any one group.  A helper that is
-    # finishing a build or report transfer must see TERM at the same boundary
-    # as the foreground command; otherwise a long foreground wait can consume
-    # the entire cancellation budget before the helper is even signalled.
+    local pid
+    # Notify every group before waiting, so the concurrent plan/helper cleanup
+    # gets the same grace window as the foreground writer.
+    for pid in "${CURRENT_UT_PID}" "${ENGINE_RACE_JOB_PID}" "${PLAN_RACE_JOB_PID}" "${CLUSTER_PREBUILD_JOB_PID}"; do
+        [[ -n "${pid}" ]] && terminate_ut_process_group "${pid}" TERM
+    done
+
     if [[ -n "${CURRENT_UT_PID}" ]]; then
         logger "ERR" "UT cancellation: stopping ${CURRENT_UT_LABEL} child ${CURRENT_UT_PID}"
-        terminate_ut_process_group "${CURRENT_UT_PID}" TERM
-    fi
-    if [[ -n "${ENGINE_RACE_JOB_PID}" ]]; then
-        terminate_ut_process_group "${ENGINE_RACE_JOB_PID}" TERM
-    fi
-    if [[ -n "${PLAN_RACE_JOB_PID}" ]]; then
-        terminate_ut_process_group "${PLAN_RACE_JOB_PID}" TERM
-    fi
-    if [[ -n "${LOGSERVICE_RACE_JOB_PID}" ]]; then
-        terminate_ut_process_group "${LOGSERVICE_RACE_JOB_PID}" TERM
-    fi
-    if [[ -n "${CLUSTER_PREBUILD_JOB_PID}" ]]; then
-        terminate_ut_process_group "${CLUSTER_PREBUILD_JOB_PID}" TERM
-    fi
-
-    if [[ -n "${CURRENT_UT_PID}" ]]; then
         # Leave the outer timeout's kill-after budget for descendants that do
         # not honour TERM; do not block the diagnostic path indefinitely.
         wait_for_ut_process_group "${CURRENT_UT_PID}" 20
@@ -459,17 +371,12 @@ function handle_ut_termination(){
         wait "${PLAN_RACE_JOB_PID}" 2>/dev/null || true
         PLAN_RACE_JOB_PID=""
     fi
-    if [[ -n "${LOGSERVICE_RACE_JOB_PID}" ]]; then
-        wait_for_ut_process_group "${LOGSERVICE_RACE_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
-        wait "${LOGSERVICE_RACE_JOB_PID}" 2>/dev/null || true
-        LOGSERVICE_RACE_JOB_PID=""
-    fi
+    consume_plan_race_report
     if [[ -n "${CLUSTER_PREBUILD_JOB_PID}" ]]; then
         wait_for_ut_process_group "${CLUSTER_PREBUILD_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
         wait "${CLUSTER_PREBUILD_JOB_PID}" 2>/dev/null || true
         CLUSTER_PREBUILD_JOB_PID=""
     fi
-    consume_plan_race_report
     if [[ -n "${CLUSTER_PREBUILD_REPORT}" ]]; then
         if [[ -s "${CLUSTER_PREBUILD_REPORT}" ]]; then
             cat "${CLUSTER_PREBUILD_REPORT}" >> "${UT_STDERR}"
@@ -478,7 +385,6 @@ function handle_ut_termination(){
             "${G_WKSP}/${G_TS}-embedded-prebuild-"*.test
         CLUSTER_PREBUILD_REPORT=""
     fi
-    consume_logservice_race_report
     consume_engine_race_report
     if [[ -n "${ENGINE_RACE_TEST_BINARY}" ]]; then
         rm -f "${ENGINE_RACE_TEST_BINARY}"
@@ -1014,7 +920,6 @@ function run_tests(){
     echo "#  UT SHARD:        $UT_SHARD"
     echo "#  EMBEDDED PREBUILD: $UT_PREBUILD_EMBEDDED"
     echo "#  PLAN OVERLAP:    $UT_OVERLAP_PLAN"
-    echo "#  LOGSERVICE OVERLAP: $UT_OVERLAP_LOGSERVICE"
     echo "#  HELPER TERM GRACE: $UT_HELPER_TERM_GRACE_TICKS ticks"
     echo "#  CLUSTER ADMISSION: process lifecycle"
     echo "#  UT CHECKPOINT:   $UT_CHECKPOINT"
@@ -1055,12 +960,6 @@ function run_tests(){
     fi
     if ! [[ "${UT_OVERLAP_PLAN}" =~ ^[01]$ ]]; then
         logger "ERR" "UT_OVERLAP_PLAN must be 0 or 1, got '${UT_OVERLAP_PLAN}'"
-        UT_TEST_STATUS=1
-        mark_ut_stage "routing" "validate shard and package partition" finish 1
-        return 0
-    fi
-    if ! [[ "${UT_OVERLAP_LOGSERVICE}" =~ ^[01]$ ]]; then
-        logger "ERR" "UT_OVERLAP_LOGSERVICE must be 0 or 1, got '${UT_OVERLAP_LOGSERVICE}'"
         UT_TEST_STATUS=1
         mark_ut_stage "routing" "validate shard and package partition" finish 1
         return 0
@@ -1147,24 +1046,21 @@ function run_tests(){
         local cluster_test_scope
         local resource_heavy_test_scope
         local light_test_scope
-        local logservice_package=""
-        local logservice_companion_scope=""
         local package
         local cluster_package_parallel=2
         local package_status=0
         local light_status=0
         local hnsw_status=0
         local serial_status=0
-        local logservice_status=0
         local cluster_status=0
         local resource_heavy_status=0
         local engine_status=0
         local plan_status=0
         local report_status=0
-        local logservice_companion_enabled=0
         local resource_heavy_parallel=1
         local engine_race_parallel=1
         local shard_engine=1
+        local engine_joined=0
 
         if ! [[ "${HEAVY_RACE_PARALLEL}" =~ ^[1-9][0-9]*$ ]] ||
             (( HEAVY_RACE_PARALLEL > 64 )); then
@@ -1261,41 +1157,6 @@ function run_tests(){
             ${cluster_test_scope} \
             ${resource_heavy_test_scope})
 
-        # logservice starts independent local services and does not depend on
-        # the embedded cluster fixture.  Keep it in the ordinary light wave
-        # unless the caller explicitly requests the complete-suite A/B.  The
-        # companion is never selected for a shard or alongside the compile
-        # prebuild, so every selected shard still executes its full package
-        # scope exactly once.
-        if (( UT_OVERLAP_LOGSERVICE == 1 )); then
-            if [[ "${UT_SHARD}" != "all" ]]; then
-                logger "WRN" "UT_OVERLAP_LOGSERVICE is only valid for UT_SHARD=all; keeping pkg/logservice in light wave"
-            elif (( UT_PREBUILD_EMBEDDED == 1 )); then
-                logger "WRN" "UT_OVERLAP_LOGSERVICE disabled while UT_PREBUILD_EMBEDDED=1; keeping pkg/logservice in light wave"
-            else
-                if ! logservice_package=$(go list ${GO_MODULE_MODE} ./pkg/logservice); then
-                    logger "ERR" "Failed to resolve ./pkg/logservice for the companion race-test"
-                    UT_TEST_STATUS=1
-                    return 0
-                fi
-                if ! printf '%s\n' "${test_scope}" | grep -Fqx "${logservice_package}"; then
-                    logger "ERR" "Resolved ${logservice_package} is outside the complete UT package scope"
-                    UT_TEST_STATUS=1
-                    return 0
-                fi
-                if printf '%s\n' "${cluster_test_scope}" | grep -Fqx "${logservice_package}"; then
-                    logger "ERR" "Refusing logservice companion: ${logservice_package} owns an embedded-cluster dependency"
-                    UT_TEST_STATUS=1
-                    return 0
-                fi
-                logservice_companion_scope="${logservice_package}"
-                light_test_scope=$(remove_packages_from_scope \
-                    "${light_test_scope}" "${logservice_companion_scope}")
-                logservice_companion_enabled=1
-                logger "INF" "Reserve ${logservice_companion_scope} for the serial-issues companion wave"
-            fi
-        fi
-
         if ! validate_complete_partition \
             "UT package" \
             "${test_scope}" \
@@ -1305,8 +1166,7 @@ function run_tests(){
             "${cluster_test_scope}" \
             "${resource_heavy_test_scope}" \
             "${engine_test_scope}" \
-            "${plan_package}" \
-            "${logservice_companion_scope}"; then
+            "${plan_package}"; then
             logger "ERR" "Race-UT package groups are not a complete disjoint partition"
             UT_TEST_STATUS=1
             return 0
@@ -1327,14 +1187,6 @@ function run_tests(){
             logger "INF" "Run HNSW race-test package with exclusive runner CPU"
             run_ut_command "hnsw" "HNSW race-test package" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race "${hnsw_package}"
             hnsw_status=$?
-        fi
-
-        # HNSW is deliberately CPU-exclusive.  Once it has finished, the
-        # independent logservice package can overlap only the serial issues
-        # body; its private report is joined before embedded-cluster work
-        # begins, keeping at most one additional test process alive.
-        if (( logservice_companion_enabled == 1 )); then
-            start_logservice_race "${logservice_companion_scope}"
         fi
 
         # Compile the next embedded wave while the exclusive issues package is
@@ -1358,11 +1210,6 @@ function run_tests(){
                     logger "ERR" "Exclusive race-test package ${package} failed with status ${package_status}"
                 fi
             done
-        fi
-
-        if (( logservice_companion_enabled == 1 )); then
-            finish_logservice_race
-            logservice_status=$?
         fi
 
         # These packages link embedded clusters with substantial race-detector
@@ -1407,30 +1254,26 @@ function run_tests(){
             resource_heavy_parallel=${HEAVY_RACE_PARALLEL}
         fi
 
-        # The plan package has no embedded cluster and its shards are already
-        # sequential inside one prebuilt binary. Start it while the heavy
-        # resource wave is running, but keep its JSON in a private report so
-        # concurrent writers cannot interleave malformed lines.
-        # Plan overlap consumes one additional process slot. It is disabled by
-        # default and only allowed when the heavy budget has room for engine
-        # shards (two), one resource package slot, and the plan child itself.
-        if (( UT_OVERLAP_PLAN == 1 && HEAVY_RACE_PARALLEL >= ENGINE_RACE_SHARDS + 2 && shard_engine == 1 )) &&
-            should_run_ut_stage plan && should_run_ut_stage heavy; then
-            resource_heavy_parallel=$((resource_heavy_parallel - 1))
-            PLAN_RACE_TEST_BINARY="${G_WKSP}/${G_TS}-plan-race.test"
-            PLAN_RACE_REPORT="${G_WKSP}/${G_TS}-plan-race-report.out"
-            logger "INF" "Start plan race shards concurrently with the heavy stage"
-            set -m
-            run_plan_race_shards "${plan_package}" &
-            PLAN_RACE_JOB_PID=$!
-            set +m
-        elif (( UT_OVERLAP_PLAN == 1 )) && should_run_ut_stage plan && should_run_ut_stage heavy; then
-            logger "WRN" "Plan overlap requested but disabled: HEAVY_RACE_PARALLEL=${HEAVY_RACE_PARALLEL}, engine_shards=${ENGINE_RACE_SHARDS}, shard_engine=${shard_engine}"
-        fi
-
         if should_run_ut_stage heavy; then
             logger "INF" "Run remaining resource-heavy race-test packages with parallelism ${resource_heavy_parallel}"
-            run_ut_command "heavy" "resource-heavy race-test packages" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p ${resource_heavy_parallel} -timeout "${UT_TIMEOUT}m" -race $resource_heavy_test_scope
+            start_ut_command "heavy" "resource-heavy race-test packages" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p ${resource_heavy_parallel} -timeout "${UT_TIMEOUT}m" -race $resource_heavy_test_scope
+
+            # Reuse the engine slots only after its helper has exited. At the
+            # default budget, engine(2)+resource(1) becomes plan(1)+resource(1).
+            # A failed engine still releases capacity: all tests must run and
+            # its status remains authoritative. Defer report transfer until the
+            # foreground writer stops; an atomic rename during its writes would
+            # otherwise lose subsequent events written to the old inode.
+            if [[ -n "${ENGINE_RACE_JOB_PID}" ]] &&
+                (( UT_OVERLAP_PLAN == 1 )) && should_run_ut_stage plan; then
+                wait "${ENGINE_RACE_JOB_PID}"
+                engine_status=$?
+                ENGINE_RACE_JOB_PID=""
+                engine_joined=1
+                logger "INF" "Engine finished; reuse released capacity for plan race tests"
+                start_plan_race "${plan_package}"
+            fi
+            finish_ut_command
             resource_heavy_status=$?
 
             if (( shard_engine == 1 )); then
@@ -1438,7 +1281,7 @@ function run_tests(){
                     wait "${ENGINE_RACE_JOB_PID}"
                     engine_status=$?
                     ENGINE_RACE_JOB_PID=""
-                else
+                elif (( engine_joined == 0 )); then
                     # Keep the helper's process-group TERM trap scoped to a
                     # subshell even when a low budget requires sequential waves.
                     set -m
@@ -1468,15 +1311,7 @@ function run_tests(){
                 plan_status=$?
                 PLAN_RACE_JOB_PID=""
             else
-                PLAN_RACE_TEST_BINARY="${G_WKSP}/${G_TS}-plan-race.test"
-                PLAN_RACE_REPORT="${G_WKSP}/${G_TS}-plan-race-report.out"
-                # Keep the sequential plan path in its own helper process too.
-                # The parent remains the cancellation/report owner, while the
-                # helper owns metadata, build, list, and shard descendants.
-                set -m
-                run_plan_race_shards "${plan_package}" &
-                PLAN_RACE_JOB_PID=$!
-                set +m
+                start_plan_race "${plan_package}"
                 wait "${PLAN_RACE_JOB_PID}"
                 plan_status=$?
                 PLAN_RACE_JOB_PID=""
@@ -1490,7 +1325,7 @@ function run_tests(){
             PLAN_RACE_TEST_BINARY=""
         fi
 
-        if (( UT_SHARD_ROUTING_ERROR != 0 || light_status != 0 || hnsw_status != 0 || serial_status != 0 || logservice_status != 0 || cluster_status != 0 || resource_heavy_status != 0 || engine_status != 0 || plan_status != 0 )); then
+        if (( UT_SHARD_ROUTING_ERROR != 0 || light_status != 0 || hnsw_status != 0 || serial_status != 0 || cluster_status != 0 || resource_heavy_status != 0 || engine_status != 0 || plan_status != 0 )); then
             UT_TEST_STATUS=1
         fi
     fi

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -47,6 +47,10 @@ UT_PARALLEL=${UT_PARALLEL:-"1"}
 UT_SHARD=${UT_SHARD:-"all"}
 UT_PREBUILD_EMBEDDED=${UT_PREBUILD_EMBEDDED:-"0"}
 UT_OVERLAP_PLAN=${UT_OVERLAP_PLAN:-"0"}
+# Keep the logservice companion as an explicit A/B knob.  It is only selected
+# for the complete single-runner suite after package ownership is revalidated;
+# shard jobs must never silently drop it from the light wave.
+UT_OVERLAP_LOGSERVICE=${UT_OVERLAP_LOGSERVICE:-"0"}
 # A helper may own two independent child process groups. Its trap gives each
 # child a bounded TERM grace period, so the parent must retain the helper long
 # enough for both children to finish before escalating to KILL.
@@ -73,6 +77,9 @@ PLAN_RACE_JOB_PID=""
 PLAN_RACE_REPORT=""
 CLUSTER_PREBUILD_JOB_PID=""
 CLUSTER_PREBUILD_REPORT=""
+LOGSERVICE_RACE_JOB_PID=""
+LOGSERVICE_RACE_REPORT=""
+LOGSERVICE_RACE_STDERR=""
 ENGINE_RACE_TEST_BINARY=""
 ENGINE_RACE_JOB_PID=""
 ENGINE_RACE_REPORT=""
@@ -297,6 +304,114 @@ function consume_plan_race_report(){
     fi
 }
 
+function consume_logservice_race_report(){
+    if [[ -z "${LOGSERVICE_RACE_REPORT}" ]]; then
+        return 0
+    fi
+
+    # The companion owns a private JSON report while it overlaps the serial
+    # issues process.  Transfer it only after the process has stopped, under
+    # the same TERM-pending guard used by the other helper reports.
+    local saved_term_trap
+    local term_pending=0
+    local append_status=0
+    saved_term_trap=$(trap -p TERM)
+    trap 'term_pending=1' TERM
+    if [[ -s "${LOGSERVICE_RACE_STDERR}" ]]; then
+        local stderr_source="${LOGSERVICE_RACE_STDERR}"
+        append_ut_report "${stderr_source}" "${UT_STDERR}"
+        if (( $? != 0 )); then
+            logger "ERR" "failed to consume logservice race stderr; preserving ${stderr_source}"
+            restore_ut_term_trap "${saved_term_trap}"
+            if (( term_pending != 0 && UT_TERMINATING == 0 )); then
+                handle_ut_termination
+            fi
+            return 1
+        fi
+        # Clear ownership as soon as the atomic append commits. Cleanup is
+        # best-effort; leaving an already-consumed source cannot cause a retry
+        # to duplicate diagnostics.
+        LOGSERVICE_RACE_STDERR=""
+        remove_ut_report_file "${stderr_source}"
+    fi
+    append_ut_report "${LOGSERVICE_RACE_REPORT}" "${UT_REPORT}"
+    append_status=$?
+    if (( append_status != 0 )); then
+        logger "ERR" "failed to consume logservice race report; preserving ${LOGSERVICE_RACE_REPORT}"
+        restore_ut_term_trap "${saved_term_trap}"
+        if (( term_pending != 0 && UT_TERMINATING == 0 )); then
+            handle_ut_termination
+        fi
+        return "${append_status}"
+    fi
+    rm -f "${LOGSERVICE_RACE_REPORT}"
+    LOGSERVICE_RACE_REPORT=""
+    LOGSERVICE_RACE_STDERR=""
+    restore_ut_term_trap "${saved_term_trap}"
+    if (( term_pending != 0 && UT_TERMINATING == 0 )); then
+        handle_ut_termination
+    fi
+}
+
+function start_logservice_race(){
+    local logservice_package=$1
+    local saved_term_trap=""
+    local term_pending=0
+
+    if [[ -z "${logservice_package}" ]]; then
+        return 2
+    fi
+    LOGSERVICE_RACE_REPORT="${G_WKSP}/${G_TS}-logservice-race-report.out"
+    LOGSERVICE_RACE_STDERR="${G_WKSP}/${G_TS}-logservice-race-stderr.out"
+    : > "${LOGSERVICE_RACE_REPORT}"
+    : > "${LOGSERVICE_RACE_STDERR}"
+    mark_ut_stage "logservice" "logservice race-test package" start \
+        "" "package=${logservice_package} parallel=1 companion=true"
+    logger "INF" "Start ${logservice_package} as a bounded companion race-test process"
+    # Keep TERM observable while the shell creates the process group and
+    # publishes its pid. Without this small ownership transaction a signal
+    # between `&` and `$!` could leave an untracked go test descendant behind.
+    saved_term_trap=$(trap -p TERM)
+    trap 'term_pending=1' TERM
+    set -m
+    env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+        CGO_CFLAGS="${CGO_CFLAGS}" \
+        CGO_LDFLAGS="${CGO_LDFLAGS}" \
+        go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json \
+        -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race \
+        "${logservice_package}" > "${LOGSERVICE_RACE_REPORT}" \
+        2> "${LOGSERVICE_RACE_STDERR}" &
+    LOGSERVICE_RACE_JOB_PID=$!
+    set +m
+    restore_ut_term_trap "${saved_term_trap}"
+    checkpoint_ut_event "pid-start" "logservice" "logservice race-test package" "" \
+        "child_pid=${LOGSERVICE_RACE_JOB_PID} package=${logservice_package} parallel=1 companion=true"
+    if (( term_pending != 0 && UT_TERMINATING == 0 )); then
+        handle_ut_termination
+    fi
+}
+
+function finish_logservice_race(){
+    local logservice_status=0
+    local report_status=0
+
+    if [[ -z "${LOGSERVICE_RACE_JOB_PID}" ]]; then
+        return 0
+    fi
+    wait "${LOGSERVICE_RACE_JOB_PID}" || logservice_status=$?
+    LOGSERVICE_RACE_JOB_PID=""
+    mark_ut_stage "logservice" "logservice race-test package" finish "${logservice_status}"
+    consume_logservice_race_report
+    report_status=$?
+    if (( report_status != 0 )); then
+        logservice_status=1
+    fi
+    if (( logservice_status != 0 )); then
+        logger "ERR" "logservice race-test package failed with status ${logservice_status}"
+    fi
+    return "${logservice_status}"
+}
+
 function handle_ut_termination(){
     trap - TERM
     if (( UT_TERMINATING != 0 )); then
@@ -304,11 +419,30 @@ function handle_ut_termination(){
     fi
     UT_TERMINATING=1
     checkpoint_ut_event "cancel" "${CURRENT_UT_STAGE}" "${CURRENT_UT_LABEL}" "143" \
-        "current_pid=${CURRENT_UT_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
+        "current_pid=${CURRENT_UT_PID} logservice_pid=${LOGSERVICE_RACE_JOB_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
 
+    # Notify every owner before waiting on any one group.  A helper that is
+    # finishing a build or report transfer must see TERM at the same boundary
+    # as the foreground command; otherwise a long foreground wait can consume
+    # the entire cancellation budget before the helper is even signalled.
     if [[ -n "${CURRENT_UT_PID}" ]]; then
         logger "ERR" "UT cancellation: stopping ${CURRENT_UT_LABEL} child ${CURRENT_UT_PID}"
         terminate_ut_process_group "${CURRENT_UT_PID}" TERM
+    fi
+    if [[ -n "${ENGINE_RACE_JOB_PID}" ]]; then
+        terminate_ut_process_group "${ENGINE_RACE_JOB_PID}" TERM
+    fi
+    if [[ -n "${PLAN_RACE_JOB_PID}" ]]; then
+        terminate_ut_process_group "${PLAN_RACE_JOB_PID}" TERM
+    fi
+    if [[ -n "${LOGSERVICE_RACE_JOB_PID}" ]]; then
+        terminate_ut_process_group "${LOGSERVICE_RACE_JOB_PID}" TERM
+    fi
+    if [[ -n "${CLUSTER_PREBUILD_JOB_PID}" ]]; then
+        terminate_ut_process_group "${CLUSTER_PREBUILD_JOB_PID}" TERM
+    fi
+
+    if [[ -n "${CURRENT_UT_PID}" ]]; then
         # Leave the outer timeout's kill-after budget for descendants that do
         # not honour TERM; do not block the diagnostic path indefinitely.
         wait_for_ut_process_group "${CURRENT_UT_PID}" 20
@@ -316,24 +450,26 @@ function handle_ut_termination(){
         CURRENT_UT_PID=""
     fi
     if [[ -n "${ENGINE_RACE_JOB_PID}" ]]; then
-        terminate_ut_process_group "${ENGINE_RACE_JOB_PID}" TERM
         wait_for_ut_process_group "${ENGINE_RACE_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
         wait "${ENGINE_RACE_JOB_PID}" 2>/dev/null || true
         ENGINE_RACE_JOB_PID=""
     fi
     if [[ -n "${PLAN_RACE_JOB_PID}" ]]; then
-        terminate_ut_process_group "${PLAN_RACE_JOB_PID}" TERM
         wait_for_ut_process_group "${PLAN_RACE_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
         wait "${PLAN_RACE_JOB_PID}" 2>/dev/null || true
         PLAN_RACE_JOB_PID=""
     fi
-    consume_plan_race_report
+    if [[ -n "${LOGSERVICE_RACE_JOB_PID}" ]]; then
+        wait_for_ut_process_group "${LOGSERVICE_RACE_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
+        wait "${LOGSERVICE_RACE_JOB_PID}" 2>/dev/null || true
+        LOGSERVICE_RACE_JOB_PID=""
+    fi
     if [[ -n "${CLUSTER_PREBUILD_JOB_PID}" ]]; then
-        terminate_ut_process_group "${CLUSTER_PREBUILD_JOB_PID}" TERM
         wait_for_ut_process_group "${CLUSTER_PREBUILD_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
         wait "${CLUSTER_PREBUILD_JOB_PID}" 2>/dev/null || true
         CLUSTER_PREBUILD_JOB_PID=""
     fi
+    consume_plan_race_report
     if [[ -n "${CLUSTER_PREBUILD_REPORT}" ]]; then
         if [[ -s "${CLUSTER_PREBUILD_REPORT}" ]]; then
             cat "${CLUSTER_PREBUILD_REPORT}" >> "${UT_STDERR}"
@@ -342,6 +478,7 @@ function handle_ut_termination(){
             "${G_WKSP}/${G_TS}-embedded-prebuild-"*.test
         CLUSTER_PREBUILD_REPORT=""
     fi
+    consume_logservice_race_report
     consume_engine_race_report
     if [[ -n "${ENGINE_RACE_TEST_BINARY}" ]]; then
         rm -f "${ENGINE_RACE_TEST_BINARY}"
@@ -877,6 +1014,7 @@ function run_tests(){
     echo "#  UT SHARD:        $UT_SHARD"
     echo "#  EMBEDDED PREBUILD: $UT_PREBUILD_EMBEDDED"
     echo "#  PLAN OVERLAP:    $UT_OVERLAP_PLAN"
+    echo "#  LOGSERVICE OVERLAP: $UT_OVERLAP_LOGSERVICE"
     echo "#  HELPER TERM GRACE: $UT_HELPER_TERM_GRACE_TICKS ticks"
     echo "#  CLUSTER ADMISSION: process lifecycle"
     echo "#  UT CHECKPOINT:   $UT_CHECKPOINT"
@@ -917,6 +1055,12 @@ function run_tests(){
     fi
     if ! [[ "${UT_OVERLAP_PLAN}" =~ ^[01]$ ]]; then
         logger "ERR" "UT_OVERLAP_PLAN must be 0 or 1, got '${UT_OVERLAP_PLAN}'"
+        UT_TEST_STATUS=1
+        mark_ut_stage "routing" "validate shard and package partition" finish 1
+        return 0
+    fi
+    if ! [[ "${UT_OVERLAP_LOGSERVICE}" =~ ^[01]$ ]]; then
+        logger "ERR" "UT_OVERLAP_LOGSERVICE must be 0 or 1, got '${UT_OVERLAP_LOGSERVICE}'"
         UT_TEST_STATUS=1
         mark_ut_stage "routing" "validate shard and package partition" finish 1
         return 0
@@ -1003,17 +1147,21 @@ function run_tests(){
         local cluster_test_scope
         local resource_heavy_test_scope
         local light_test_scope
+        local logservice_package=""
+        local logservice_companion_scope=""
         local package
         local cluster_package_parallel=2
         local package_status=0
         local light_status=0
         local hnsw_status=0
         local serial_status=0
+        local logservice_status=0
         local cluster_status=0
         local resource_heavy_status=0
         local engine_status=0
         local plan_status=0
         local report_status=0
+        local logservice_companion_enabled=0
         local resource_heavy_parallel=1
         local engine_race_parallel=1
         local shard_engine=1
@@ -1113,6 +1261,41 @@ function run_tests(){
             ${cluster_test_scope} \
             ${resource_heavy_test_scope})
 
+        # logservice starts independent local services and does not depend on
+        # the embedded cluster fixture.  Keep it in the ordinary light wave
+        # unless the caller explicitly requests the complete-suite A/B.  The
+        # companion is never selected for a shard or alongside the compile
+        # prebuild, so every selected shard still executes its full package
+        # scope exactly once.
+        if (( UT_OVERLAP_LOGSERVICE == 1 )); then
+            if [[ "${UT_SHARD}" != "all" ]]; then
+                logger "WRN" "UT_OVERLAP_LOGSERVICE is only valid for UT_SHARD=all; keeping pkg/logservice in light wave"
+            elif (( UT_PREBUILD_EMBEDDED == 1 )); then
+                logger "WRN" "UT_OVERLAP_LOGSERVICE disabled while UT_PREBUILD_EMBEDDED=1; keeping pkg/logservice in light wave"
+            else
+                if ! logservice_package=$(go list ${GO_MODULE_MODE} ./pkg/logservice); then
+                    logger "ERR" "Failed to resolve ./pkg/logservice for the companion race-test"
+                    UT_TEST_STATUS=1
+                    return 0
+                fi
+                if ! printf '%s\n' "${test_scope}" | grep -Fqx "${logservice_package}"; then
+                    logger "ERR" "Resolved ${logservice_package} is outside the complete UT package scope"
+                    UT_TEST_STATUS=1
+                    return 0
+                fi
+                if printf '%s\n' "${cluster_test_scope}" | grep -Fqx "${logservice_package}"; then
+                    logger "ERR" "Refusing logservice companion: ${logservice_package} owns an embedded-cluster dependency"
+                    UT_TEST_STATUS=1
+                    return 0
+                fi
+                logservice_companion_scope="${logservice_package}"
+                light_test_scope=$(remove_packages_from_scope \
+                    "${light_test_scope}" "${logservice_companion_scope}")
+                logservice_companion_enabled=1
+                logger "INF" "Reserve ${logservice_companion_scope} for the serial-issues companion wave"
+            fi
+        fi
+
         if ! validate_complete_partition \
             "UT package" \
             "${test_scope}" \
@@ -1122,7 +1305,8 @@ function run_tests(){
             "${cluster_test_scope}" \
             "${resource_heavy_test_scope}" \
             "${engine_test_scope}" \
-            "${plan_package}"; then
+            "${plan_package}" \
+            "${logservice_companion_scope}"; then
             logger "ERR" "Race-UT package groups are not a complete disjoint partition"
             UT_TEST_STATUS=1
             return 0
@@ -1143,6 +1327,14 @@ function run_tests(){
             logger "INF" "Run HNSW race-test package with exclusive runner CPU"
             run_ut_command "hnsw" "HNSW race-test package" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race "${hnsw_package}"
             hnsw_status=$?
+        fi
+
+        # HNSW is deliberately CPU-exclusive.  Once it has finished, the
+        # independent logservice package can overlap only the serial issues
+        # body; its private report is joined before embedded-cluster work
+        # begins, keeping at most one additional test process alive.
+        if (( logservice_companion_enabled == 1 )); then
+            start_logservice_race "${logservice_companion_scope}"
         fi
 
         # Compile the next embedded wave while the exclusive issues package is
@@ -1166,6 +1358,11 @@ function run_tests(){
                     logger "ERR" "Exclusive race-test package ${package} failed with status ${package_status}"
                 fi
             done
+        fi
+
+        if (( logservice_companion_enabled == 1 )); then
+            finish_logservice_race
+            logservice_status=$?
         fi
 
         # These packages link embedded clusters with substantial race-detector
@@ -1293,7 +1490,7 @@ function run_tests(){
             PLAN_RACE_TEST_BINARY=""
         fi
 
-        if (( UT_SHARD_ROUTING_ERROR != 0 || light_status != 0 || hnsw_status != 0 || serial_status != 0 || cluster_status != 0 || resource_heavy_status != 0 || engine_status != 0 || plan_status != 0 )); then
+        if (( UT_SHARD_ROUTING_ERROR != 0 || light_status != 0 || hnsw_status != 0 || serial_status != 0 || logservice_status != 0 || cluster_status != 0 || resource_heavy_status != 0 || engine_status != 0 || plan_status != 0 )); then
             UT_TEST_STATUS=1
         fi
     fi

--- a/optools/ut_schedule_test.go
+++ b/optools/ut_schedule_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optools
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Source the real runner in a private repository layout. Its startup clears
+// diagnostics, so sourcing it in the actual checkout would corrupt another UT.
+func scheduleHarness(t *testing.T, script string, variables ...string) ([]byte, error) {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "optools")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"run_ut.sh", "utilities.sh", "ut_tools.bash", "ut_process.bash", "active_ut_cases.awk"} {
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if name == "run_ut.sh" {
+			text := string(data)
+			index := strings.Index(text, "if [[ 'SCA' == $TEST_TYPE ]]; then")
+			if index < 0 {
+				t.Fatal("missing runner dispatch")
+			}
+			data = []byte(text[:index])
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mock := `#!/bin/bash
+if [[ "$1" == version ]]; then exit 0; fi
+# The real env/go command must preserve both events around the report merge.
+printf 'heavy-start\n'
+printf started > "$CASE_DIR/heavy-started"
+if [[ "$EXPECT_OVERLAP" == 1 ]]; then
+ while [[ ! -e "$CASE_DIR/plan-started" ]]; do sleep 0.01; done
+fi
+printf 'heavy-end\n'
+exit "$HEAVY_STATUS"
+`
+	if err := os.WriteFile(filepath.Join(dir, "go"), []byte(mock), 0755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-c", script)
+	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
+	cmd.WaitDelay = 3 * time.Second
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"), "UT_WORKDIR="+root, "CASE_DIR="+root)
+	cmd.Env = append(cmd.Env, variables...)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("runner harness timed out: %s", out)
+	}
+	return out, err
+}
+
+func TestHeavyPlanReusesReleasedEngineCapacity(t *testing.T) {
+	for _, tc := range []struct{ name, budget, overlap, engine, heavy, plan, expected string }{
+		{"default", "3", "", "0", "0", "0", "0"},
+		{"overlap", "3", "1", "0", "0", "0", "0"},
+		{"engine-failure", "3", "1", "7", "0", "0", "1"},
+		{"heavy-failure", "3", "1", "0", "8", "0", "1"},
+		{"plan-failure", "3", "1", "0", "0", "9", "1"},
+		{"sequential-baseline", "3", "0", "0", "0", "0", "0"},
+		{"one-slot", "1", "1", "0", "0", "0", "0"},
+		{"two-slots", "2", "1", "0", "0", "0", "0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedOverlap := "0"
+			if tc.budget == "3" && tc.overlap != "0" {
+				expectedOverlap = "1"
+			}
+			script := `source ./run_ut.sh UT
+trap handle_ut_termination TERM
+function logger() { :; }
+function report_cgroup_memory_usage() { :; }
+function make() { :; }
+function egrep() { echo fake.pb.go; }
+# Skip the unrelated native smoke, while retaining the real race scheduler.
+MO_CL_CUDA=1
+UT_SHARD=heavy-plan
+function list_embedded_cluster_test_packages() { echo example/embed; }
+function go() {
+ if [[ "$1" == clean ]]; then return 0; fi
+ shift 2
+ if [[ "$1" == ./... ]]; then
+  printf '%s\n' example/embed github.com/matrixorigin/matrixone/pkg/{sql/plan,vm/engine/test,vectorindex/hnsw,tests/issues,backup,fileservice,sql/plan/function,vm/engine/tae/db/test}
+ else
+  for package in "$@"; do echo "github.com/matrixorigin/matrixone/${package#./}"; done
+ fi
+}
+function run_engine_race_shards() {
+ mkdir "$CASE_DIR/engine-once" || return 90
+ while [[ ! -e "$CASE_DIR/heavy-started" ]]; do sleep 0.01; done
+ printf 'engine\n' > "$ENGINE_RACE_REPORT"
+ touch "$CASE_DIR/engine-finished"
+ return "$ENGINE_STATUS"
+}
+function run_plan_race_shards() {
+ mkdir "$CASE_DIR/plan-once" || return 91
+ [[ -e "$CASE_DIR/engine-finished" ]] || return 92
+ printf 'plan\n' > "$PLAN_RACE_REPORT"
+ touch "$CASE_DIR/plan-started"
+ return "$PLAN_STATUS"
+}
+run_tests
+[[ "$UT_TEST_STATUS" == "$EXPECTED_STATUS" ]] || exit 93
+[[ -d "$CASE_DIR/engine-once" && -d "$CASE_DIR/plan-once" ]] || exit 94
+[[ -z "$CURRENT_UT_PID$ENGINE_RACE_JOB_PID$PLAN_RACE_JOB_PID" ]] || exit 95
+printf '\nREPORT\n'
+cat "$UT_REPORT"
+`
+			out, err := scheduleHarness(t, script, "HEAVY_RACE_PARALLEL="+tc.budget, "UT_OVERLAP_PLAN="+tc.overlap, "ENGINE_STATUS="+tc.engine, "HEAVY_STATUS="+tc.heavy, "PLAN_STATUS="+tc.plan, "EXPECTED_STATUS="+tc.expected, "EXPECT_OVERLAP="+expectedOverlap)
+			if err != nil {
+				t.Fatalf("schedule: %v\n%s", err, out)
+			}
+			if !strings.HasSuffix(string(out), "REPORT\nheavy-start\nheavy-end\nengine\nplan\n") {
+				t.Fatalf("lost or duplicated report events:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestHeavyPlanCancellationStopsWritersBeforeMerge(t *testing.T) {
+	script := `source ./run_ut.sh UT
+function logger() { :; }
+trap handle_ut_termination TERM
+trap 'printf "\nCANCEL_REPORT\n"; cat "$UT_REPORT"' EXIT
+ENGINE_RACE_REPORT="$CASE_DIR/engine-report"
+printf 'engine\n' > "$ENGINE_RACE_REPORT"
+start_ut_command heavy 'heavy writer' bash -c '
+ trap '\''printf "heavy-stopped\n"; exit 143'\'' TERM
+ printf "heavy-start\n"
+ touch "$CASE_DIR/heavy-ready"
+ while :; do sleep 0.01; done
+'
+function run_plan_race_shards() {
+ trap 'printf "plan-stopped\n" >> "$PLAN_RACE_REPORT"; exit 143' TERM
+ printf 'plan-start\n' > "$PLAN_RACE_REPORT"
+ touch "$CASE_DIR/plan-ready"
+ while :; do sleep 0.01; done
+}
+start_plan_race example/plan
+while [[ ! -e "$CASE_DIR/heavy-ready" || ! -e "$CASE_DIR/plan-ready" ]]; do sleep 0.01; done
+kill -TERM "$$"
+`
+	out, err := scheduleHarness(t, script)
+	exit, ok := err.(*exec.ExitError)
+	if !ok || exit.ExitCode() != 143 {
+		t.Fatalf("expected TERM exit 143: %v\n%s", err, out)
+	}
+	if !strings.HasSuffix(string(out), "CANCEL_REPORT\nheavy-start\nheavy-stopped\nplan-start\nplan-stopped\nengine\n") {
+		t.Fatalf("writer was not stopped before merging: %s", out)
+	}
+}

--- a/optools/ut_tools_test.go
+++ b/optools/ut_tools_test.go
@@ -15,41 +15,15 @@
 package optools
 
 import (
-	"bytes"
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 )
 
 const goUTAnalysisModule = "github.com/matrixorigin/go-ut-analysis@v0.0.0-20250711025253-f31acb12d3b1"
-
-func writeRunUTPrelude(t *testing.T) string {
-	t.Helper()
-
-	path, err := filepath.Abs("run_ut.sh")
-	if err != nil {
-		t.Fatal(err)
-	}
-	contents, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	marker := []byte("if [[ 'SCA' == $TEST_TYPE ]]; then")
-	index := bytes.Index(contents, marker)
-	if index < 0 {
-		t.Fatal("run_ut.sh main dispatch marker not found")
-	}
-	prelude := filepath.Join(t.TempDir(), "run_ut-prelude.sh")
-	if err := os.WriteFile(prelude, contents[:index], 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return prelude
-}
 
 func writeMockGo(t *testing.T) string {
 	t.Helper()
@@ -505,113 +479,6 @@ link_after_creation_interruption "$test_dir/engine-after-link.out" "$test_dir/en
 	cmd := exec.Command("bash", "-c", script, "bash", processPath)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("interrupted report transfer harness failed: %v\n%s", err, output)
-	}
-}
-
-func TestLogserviceCompanionTracksPIDBeforeCancellation(t *testing.T) {
-	prelude := writeRunUTPrelude(t)
-	runUTDir, err := filepath.Abs(".")
-	if err != nil {
-		t.Fatal(err)
-	}
-	mockGoDir := t.TempDir()
-	mockGo := filepath.Join(mockGoDir, "go")
-	if err := os.WriteFile(mockGo, []byte(`#!/bin/bash
-if [[ "${1:-}" == version ]]; then exit 0; fi
-if [[ "${1:-}" == test ]]; then
-    trap 'printf terminated > "${MOCK_GO_TERM}"; exit 143' TERM
-    printf started > "${MOCK_GO_STARTED}"
-    kill -TERM "${PPID}"
-	( sleep 4; kill -TERM "$$" 2>/dev/null || true ) &
-    while :; do sleep 1; done
-fi
-exit 0
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	startedPath := filepath.Join(t.TempDir(), "companion.started")
-	termPath := filepath.Join(t.TempDir(), "companion.term")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "bash", "-c", `source "$1" UT race; trap handle_ut_termination TERM; trap 'if [[ "${LOGSERVICE_RACE_JOB_PID:-}" =~ ^[1-9][0-9]*$ ]]; then terminate_ut_process_group "$LOGSERVICE_RACE_JOB_PID" TERM; fi' EXIT; start_logservice_race example.com/logservice; while [[ ! -s "$MOCK_GO_TERM" ]]; do sleep 0.01; done`, "bash", prelude)
-	cmd.Dir = runUTDir
-	env := os.Environ()
-	for index, value := range env {
-		if strings.HasPrefix(value, "PATH=") {
-			env[index] = "PATH=" + mockGoDir + string(os.PathListSeparator) + os.Getenv("PATH")
-		}
-	}
-	cmd.Env = append(env,
-		"MOCK_GO_STARTED="+startedPath,
-		"MOCK_GO_TERM="+termPath,
-		"UT_WORKDIR="+t.TempDir(),
-	)
-	output, err := cmd.CombinedOutput()
-	if ctx.Err() != nil {
-		t.Fatalf("companion cancellation harness timed out: %v\n%s", ctx.Err(), output)
-	}
-	if err == nil {
-		t.Fatalf("expected cancellation exit, got success: %s", output)
-	}
-	exitError, ok := err.(*exec.ExitError)
-	if !ok || exitError.ExitCode() != 143 {
-		t.Fatalf("expected cancellation status 143, got %v\n%s", err, output)
-	}
-	if _, err := os.Stat(startedPath); err != nil {
-		t.Fatalf("companion did not start before cancellation: %v\n%s", err, output)
-	}
-	if _, err := os.Stat(termPath); err != nil {
-		t.Fatalf("companion did not receive cancellation after pid registration: %v\n%s", err, output)
-	}
-}
-
-func TestLogserviceCompanionStderrConsumeIsIdempotent(t *testing.T) {
-	prelude := writeRunUTPrelude(t)
-	runUTDir, err := filepath.Abs(".")
-	if err != nil {
-		t.Fatal(err)
-	}
-	testDir := t.TempDir()
-	script := `
-set -o nounset
-source "$1" UT race
-function logger() { :; }
-function handle_ut_termination() { :; }
-test_dir="$2"
-UT_REPORT="$test_dir/all.out"
-UT_STDERR="$test_dir/stderr.out"
-LOGSERVICE_RACE_REPORT="$test_dir/companion.json"
-LOGSERVICE_RACE_STDERR="$test_dir/companion.err"
-printf 'existing\n' > "$UT_REPORT"
-printf 'companion-error\n' > "$LOGSERVICE_RACE_STDERR"
-printf '{"Action":"pass"}\n' > "$LOGSERVICE_RACE_REPORT"
-function remove_ut_report_file() { return 1; }
-consume_logservice_race_report
-if [[ "$(cat "$UT_STDERR")" != 'companion-error' ]]; then
-    echo "stderr was not atomically consumed" >&2
-    exit 1
-fi
-if [[ "$(cat "$UT_REPORT")" != $'existing\n{"Action":"pass"}' ]]; then
-    echo "JSON report was not consumed" >&2
-    exit 1
-fi
-if [[ -n "$LOGSERVICE_RACE_STDERR" || -n "$LOGSERVICE_RACE_REPORT" ]]; then
-    echo "consumed report ownership was not cleared" >&2
-    exit 1
-fi
-# A second consume must be a no-op even though the injected cleanup failure
-# left the private stderr source on disk.
-consume_logservice_race_report
-if [[ "$(cat "$UT_STDERR")" != 'companion-error' ]]; then
-    echo "stderr was duplicated after cleanup retry" >&2
-    exit 1
-fi
-`
-	cmd := exec.Command("bash", "-c", script, "bash", prelude, testDir)
-	cmd.Dir = runUTDir
-	cmd.Env = append(os.Environ(), "UT_WORKDIR="+t.TempDir())
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("companion stderr ownership harness failed: %v\n%s", err, output)
 	}
 }
 

--- a/optools/ut_tools_test.go
+++ b/optools/ut_tools_test.go
@@ -15,15 +15,41 @@
 package optools
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 const goUTAnalysisModule = "github.com/matrixorigin/go-ut-analysis@v0.0.0-20250711025253-f31acb12d3b1"
+
+func writeRunUTPrelude(t *testing.T) string {
+	t.Helper()
+
+	path, err := filepath.Abs("run_ut.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := []byte("if [[ 'SCA' == $TEST_TYPE ]]; then")
+	index := bytes.Index(contents, marker)
+	if index < 0 {
+		t.Fatal("run_ut.sh main dispatch marker not found")
+	}
+	prelude := filepath.Join(t.TempDir(), "run_ut-prelude.sh")
+	if err := os.WriteFile(prelude, contents[:index], 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return prelude
+}
 
 func writeMockGo(t *testing.T) string {
 	t.Helper()
@@ -479,6 +505,113 @@ link_after_creation_interruption "$test_dir/engine-after-link.out" "$test_dir/en
 	cmd := exec.Command("bash", "-c", script, "bash", processPath)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("interrupted report transfer harness failed: %v\n%s", err, output)
+	}
+}
+
+func TestLogserviceCompanionTracksPIDBeforeCancellation(t *testing.T) {
+	prelude := writeRunUTPrelude(t)
+	runUTDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mockGoDir := t.TempDir()
+	mockGo := filepath.Join(mockGoDir, "go")
+	if err := os.WriteFile(mockGo, []byte(`#!/bin/bash
+if [[ "${1:-}" == version ]]; then exit 0; fi
+if [[ "${1:-}" == test ]]; then
+    trap 'printf terminated > "${MOCK_GO_TERM}"; exit 143' TERM
+    printf started > "${MOCK_GO_STARTED}"
+    kill -TERM "${PPID}"
+	( sleep 4; kill -TERM "$$" 2>/dev/null || true ) &
+    while :; do sleep 1; done
+fi
+exit 0
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	startedPath := filepath.Join(t.TempDir(), "companion.started")
+	termPath := filepath.Join(t.TempDir(), "companion.term")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-c", `source "$1" UT race; trap handle_ut_termination TERM; trap 'if [[ "${LOGSERVICE_RACE_JOB_PID:-}" =~ ^[1-9][0-9]*$ ]]; then terminate_ut_process_group "$LOGSERVICE_RACE_JOB_PID" TERM; fi' EXIT; start_logservice_race example.com/logservice; while [[ ! -s "$MOCK_GO_TERM" ]]; do sleep 0.01; done`, "bash", prelude)
+	cmd.Dir = runUTDir
+	env := os.Environ()
+	for index, value := range env {
+		if strings.HasPrefix(value, "PATH=") {
+			env[index] = "PATH=" + mockGoDir + string(os.PathListSeparator) + os.Getenv("PATH")
+		}
+	}
+	cmd.Env = append(env,
+		"MOCK_GO_STARTED="+startedPath,
+		"MOCK_GO_TERM="+termPath,
+		"UT_WORKDIR="+t.TempDir(),
+	)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("companion cancellation harness timed out: %v\n%s", ctx.Err(), output)
+	}
+	if err == nil {
+		t.Fatalf("expected cancellation exit, got success: %s", output)
+	}
+	exitError, ok := err.(*exec.ExitError)
+	if !ok || exitError.ExitCode() != 143 {
+		t.Fatalf("expected cancellation status 143, got %v\n%s", err, output)
+	}
+	if _, err := os.Stat(startedPath); err != nil {
+		t.Fatalf("companion did not start before cancellation: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(termPath); err != nil {
+		t.Fatalf("companion did not receive cancellation after pid registration: %v\n%s", err, output)
+	}
+}
+
+func TestLogserviceCompanionStderrConsumeIsIdempotent(t *testing.T) {
+	prelude := writeRunUTPrelude(t)
+	runUTDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDir := t.TempDir()
+	script := `
+set -o nounset
+source "$1" UT race
+function logger() { :; }
+function handle_ut_termination() { :; }
+test_dir="$2"
+UT_REPORT="$test_dir/all.out"
+UT_STDERR="$test_dir/stderr.out"
+LOGSERVICE_RACE_REPORT="$test_dir/companion.json"
+LOGSERVICE_RACE_STDERR="$test_dir/companion.err"
+printf 'existing\n' > "$UT_REPORT"
+printf 'companion-error\n' > "$LOGSERVICE_RACE_STDERR"
+printf '{"Action":"pass"}\n' > "$LOGSERVICE_RACE_REPORT"
+function remove_ut_report_file() { return 1; }
+consume_logservice_race_report
+if [[ "$(cat "$UT_STDERR")" != 'companion-error' ]]; then
+    echo "stderr was not atomically consumed" >&2
+    exit 1
+fi
+if [[ "$(cat "$UT_REPORT")" != $'existing\n{"Action":"pass"}' ]]; then
+    echo "JSON report was not consumed" >&2
+    exit 1
+fi
+if [[ -n "$LOGSERVICE_RACE_STDERR" || -n "$LOGSERVICE_RACE_REPORT" ]]; then
+    echo "consumed report ownership was not cleared" >&2
+    exit 1
+fi
+# A second consume must be a no-op even though the injected cleanup failure
+# left the private stderr source on disk.
+consume_logservice_race_report
+if [[ "$(cat "$UT_STDERR")" != 'companion-error' ]]; then
+    echo "stderr was duplicated after cleanup retry" >&2
+    exit 1
+fi
+`
+	cmd := exec.Command("bash", "-c", script, "bash", prelude, testDir)
+	cmd.Dir = runUTDir
+	cmd.Env = append(os.Environ(), "UT_WORKDIR="+t.TempDir())
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("companion stderr ownership harness failed: %v\n%s", err, output)
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Improvement
- [x] Test and CI

## Which issue(s) this PR fixes:

Related to #28419 and #28538.

## What this PR does / why we need it:

Keep the complete race-UT suite on one runner and reuse engine capacity to run plan tests while the remaining resource-heavy tests finish. A historical single-runner trace left engine slots idle from 06:22:22 to 06:26:04, then ran plan for about another 2m20s.

With the default budget of three, execution changes from `engine(2) + resource(1)` to `plan(1) + resource(1)` after engine exits. Plan compilation retains `-p1`. `UT_OVERLAP_PLAN=1` enables this by default; `0` provides the sequential baseline. Budgets of one/two and paths without a concurrent engine helper keep sequential execution. The CI caller restores `ut_sharded: false`, undoing #28575's multi-runner topology; that restoration itself is not counted as a speedup against the previous single-runner baseline.

The parent keeps the foreground PID and independent command metadata while joining engine. Engine failure remains a failure and does not skip plan. Report merging waits for the heavy writer to exit, avoiding data loss from renaming an open output file. Cancellation signals all owned groups before bounded waits and merges stopped writers only.

No test cases, data sizes, assertions, race flags, timeouts, cluster admission, or coverage jobs are weakened. The logservice companion experiment was removed: package elapsed time alone did not demonstrate critical-path savings.

### Validation

- `go test -race ./optools -count=1`
- Both new scheduling/cancellation tests passed individually with `-race -count=3`; scheduling covers defaults, overlap, each stage failing, sequential mode, and budgets 1/2.
- `go vet ./optools`
- `node --test .github/ci/change-scope.test.cjs`
- `bash -n optools/run_ut.sh` and `git diff --check`
- Independent GPT-6 medium review: no blocking or medium findings.
- Real heavy/plan runs passed with the repository CGo wrapper, `-race`, `matrixone_test`, and the unchanged three-slot budget. The warm sequential baseline took 303.11s; overlap took 229.19s: 73.92s (24.4%) less elapsed time for this local stage sample. Both runs had exactly the same 16,013 test/subtest start events and terminal statuses, with zero failures.
- A first cold baseline took 440.04s and is excluded from the claimed gain. Measurement order was cold sequential, warm overlap, then warm sequential. This is one local macOS comparison, not a controlled Linux CI benchmark. The heavy/plan scheduler was invoked directly, with existing native artifacts verified by the official wrapper; checkout, native prerequisite rebuild, and full-suite setup were excluded equally from both measurements. External-service eligibility remains environment-dependent.
- The historical CI trace suggests roughly 2m20s of potential overlap; this is not a measured CI saving. Target Linux CI still needs to confirm peak memory and net elapsed time.

This repository uses `pull_request_target`, so this PR still uses the base workflow's four-job caller until merged. Its heavy-plan job does execute the updated scheduler from the PR head; the single-runner caller is covered by the workflow contract test.
