### PR TITLE
Revert CI race-UT sharding change (#28575)

### DIFF
--- a/.github/ci/change-scope.test.cjs
+++ b/.github/ci/change-scope.test.cjs
@@ -96,12 +96,6 @@ function results() {
   return needs;
 }
 
-function entrypointJobs() {
-  const workflow = readFileSync(`${__dirname}/../workflows/entrypoint.yaml`, 'utf8');
-  return Object.fromEntries([...workflow.matchAll(/^  ([\w-]+):\n([\s\S]*?)(?=^  [\w-]+:\n|$(?![\s\S]))/gm)]
-    .map(match => [match[1], match[2]]));
-}
-
 test('gates accept intentional omissions but reject failed, cancelled, skipped or missing required work', () => {
   const jobs = {
     docs: ['docs-check'], ut: ['matrixone-ci'],
@@ -138,7 +132,9 @@ test('a successful eligibility job cannot hide skipped UT coverage', () => {
 });
 
 test('entrypoint routes each scope through one required check', () => {
-  const blocks = entrypointJobs();
+  const workflow = readFileSync(`${__dirname}/../workflows/entrypoint.yaml`, 'utf8');
+  const blocks = Object.fromEntries([...workflow.matchAll(/^  ([\w-]+):\n([\s\S]*?)(?=^  [\w-]+:\n|$(?![\s\S]))/gm)]
+    .map(match => [match[1], match[2]]));
   const routed = ['docs-check', 'bvt-group-plan', 'matrixone-shared-build', 'matrixone-ci',
     'matrixone-ut-coverage', 'matrixone-upgrade-ci', 'matrixone-compose-ci',
     'matrixone-standalone-ci', 'matrixone-coverage-merge'];
@@ -176,10 +172,4 @@ test('entrypoint routes each scope through one required check', () => {
     assert.match(blocks[job], /ref: \$\{\{ github.event.pull_request.base.sha \}\}/);
     assert.match(blocks[job], /persist-credentials: false/);
   }
-});
-
-test('entrypoint enables the complete race-UT shard contract', () => {
-  const caller = entrypointJobs()['matrixone-ci'];
-  assert.match(caller, /^    uses: matrixorigin\/CI\/\.github\/workflows\/ci\.yaml@main$/m);
-  assert.match(caller, /^    with:\n      ut_parallel: 6\n      ut_sharded: true$/m);
 });

--- a/.github/workflows/entrypoint.yaml
+++ b/.github/workflows/entrypoint.yaml
@@ -120,7 +120,6 @@ jobs:
     uses: matrixorigin/CI/.github/workflows/ci.yaml@main
     with:
       ut_parallel: 6
-      ut_sharded: true
     secrets: inherit
 
   matrixone-ut-coverage:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28538.

This PR reverts #28575.

## What this PR does / why we need it:

This PR fully reverts #28575 and restores the previous unsharded race-UT caller behavior while the four-way sharding change is being reconsidered.

The revert removes `ut_sharded: true` from `.github/workflows/entrypoint.yaml` and restores the prior structure of `.github/ci/change-scope.test.cjs`. No unrelated production or test files are changed.

## Tests

- `node --test .github/ci/change-scope.test.cjs`
- `GOWORK=off go test -mod=readonly -v -count=1 -timeout=120s ./optools`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/entrypoint.yaml`
- Ruby YAML parse
- `git diff --check`
