### PR TITLE
test: add bounded UT overlap and timeout diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 !pkg/iceberg/metadata/testdata/generate_golden_vectors.py
 !optools/iceberg_external_runner.py
 !optools/summarize_ut_setup.py
+!optools/summarize_ut_slow_cases.py
 !suites/scenarios/14_issue_regression/issue_25599_proxy_disconnect_cancel.py
 !suites/scenarios/14_issue_regression/issue_25599_proxy_disconnect_cancel_test.py
 !optools/mongodb_changed_files.py

--- a/Makefile
+++ b/Makefile
@@ -532,10 +532,17 @@ UT_PREBUILD_EMBEDDED ?= 0
 # Reuse released engine slots for plan while resource-heavy work finishes.
 # The heavy process budget is unchanged; set 0 for a sequential A/B baseline.
 UT_OVERLAP_PLAN ?= 1
+# On the single CI runner, an A/B can overlap the dependency-disjoint light
+# wave with the exclusive issues package. HNSW remains an exclusive foreground
+# phase first; the overlap helper defaults to two package slots to leave memory
+# headroom. Keep the safe sequential baseline until a target-runner A/B proves
+# the concurrent path's wall-time and resource budget.
+UT_OVERLAP_LIGHT ?= 0
+UT_OVERLAP_LIGHT_PARALLEL ?= 2
 # Parent cancellation waits long enough for helper-owned child process groups
 # to receive TERM and bounded KILL cleanup in sequence.
 UT_HELPER_TERM_GRACE_TICKS ?= 60
-export UT_SHARD UT_HARD_TIMEOUT UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_HELPER_TERM_GRACE_TICKS
+export UT_SHARD UT_HARD_TIMEOUT UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_OVERLAP_LIGHT UT_OVERLAP_LIGHT_PARALLEL UT_HELPER_TERM_GRACE_TICKS
 # Native compilation runs before Go tests, so it can use an explicit UT CPU
 # budget without increasing peak race-test memory. With the default UT value,
 # omit -j and preserve recursive make's jobserver contract: a plain make stays

--- a/Makefile
+++ b/Makefile
@@ -524,6 +524,8 @@ UT_SHARD ?= all
 # The outer lifecycle budget is separate from each Go test's UT_TIMEOUT. Keep
 # enough time after TERM for checkpoint flushing and artifact upload.
 UT_HARD_TIMEOUT ?= 70m
+# Emit one bounded progress heartbeat per interval while UT is running.
+UT_HEARTBEAT_INTERVAL ?= 60
 # Build embedded test packages ahead of their execution while the issues
 # fixture is active. This is an explicit A/B knob: compile-only work still
 # consumes CPU, memory, and linker capacity, so it remains opt-in until a
@@ -542,7 +544,7 @@ UT_OVERLAP_LIGHT_PARALLEL ?= 2
 # Parent cancellation waits long enough for helper-owned child process groups
 # to receive TERM and bounded KILL cleanup in sequence.
 UT_HELPER_TERM_GRACE_TICKS ?= 60
-export UT_SHARD UT_HARD_TIMEOUT UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_OVERLAP_LIGHT UT_OVERLAP_LIGHT_PARALLEL UT_HELPER_TERM_GRACE_TICKS
+export UT_SHARD UT_HARD_TIMEOUT UT_HEARTBEAT_INTERVAL UT_PREBUILD_EMBEDDED UT_OVERLAP_PLAN UT_OVERLAP_LIGHT UT_OVERLAP_LIGHT_PARALLEL UT_HELPER_TERM_GRACE_TICKS
 # Native compilation runs before Go tests, so it can use an explicit UT CPU
 # budget without increasing peak race-test memory. With the default UT value,
 # omit -j and preserve recursive make's jobserver contract: a plain make stays

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -1,11 +1,33 @@
 # UT 执行模型与 fixture 生命周期优化设计
 
-- 状态：Accepted for this PR，revision 6
+- 状态：Proposed for this PR，revision 7
 - 适用范围：`optools/run_ut.sh`、Go test package 分组、embedded/shared cluster fixture、CI UT 资源预算
 - 约束：不增加 runner 数量；收益必须来自单 runner 的工作删除、fixture 复用或资源有界的阶段重叠
 - 设计 owner：UT runner 与测试基础设施；各测试 package 对自己的 fixture reset/cleanup 契约负责
 - 设计门禁：跨 package、跨进程 admission、runner 取消和集群生命周期，命中 execution、ownership、resource 和 public test-contract 多个边界
-- 决策记录：revision 2 接受本 PR 的 runner 账本、取消/报告所有权和有界分片；compile-only prebuild 保留为显式 opt-in，plan overlap 仍为显式 opt-in；两者都不改变默认资源预算。跨进程 cluster 共享和动态调度不在本 PR；本 revision 按兼容矩阵落地了一个同进程单 CN fixture 合并，并为后续专用 fixture 增加显式释放边界。
+- 决策记录：revision 2 接受本 PR 的 runner 账本、取消/报告所有权和有界分片；compile-only prebuild 保留为显式 opt-in，plan overlap 复用已释放 slot 并默认开启；两者都不扩大默认 heavy 资源预算。跨进程 cluster 共享和动态调度不在本 PR；本 revision 按兼容矩阵落地了一个同进程单 CN fixture 合并，并为后续专用 fixture 增加显式释放边界。
+
+## Revision 7: bounded light/issues overlap on one runner
+
+最近成功的单 runner UT 记录显示，`light race-test` 约占 10--20 分钟，
+`pkg/tests/issues` 的独占阶段约占 6--11 分钟；两者当前完全串行。依赖图分组已经把
+所有会启动 embedded cluster 的 package 从 light 组移除，因此可以在不增加 runner、
+不改变测试参数和不共享 fixture 的前提下，让两个阶段重叠。
+
+调度保持 HNSW 的 native worker pool 独占约束：先完成 HNSW，再启动 light helper，随后
+前台执行 issues。light helper 使用 `-race`、相同的 tags/timeout 和完整的 light scope，
+但将自己的 JSON 写入私有文件；issues 的 writer 结束后，父进程再原子合并 helper 报告。
+两条路径都执行完毕后才进入 embedded 阶段。helper 的 PID、进程组、退出状态和报告消费
+纳入同一 TERM 取消路径，任何一边失败都不会跳过另一边。
+
+并发是有界的：`UT_OVERLAP_LIGHT=0` 默认保持顺序基线，`UT_OVERLAP_LIGHT=1` 提供受限 A/B，
+`UT_OVERLAP_LIGHT_PARALLEL=2` 默认限制 light 的 package 并行度，并在小于该值的
+`UT_PARALLEL` 下自动收窄。开启 overlap 时不同时启动 compile-only embedded prebuild，
+避免叠加第二条编译通道。所有 package 仍只执行一次，测试函数、subtest、race detector、
+coverage 事件和失败断言都保持不变；这里改变的是阶段顺序和 package 调度，而不是测试
+强度。预期收益是被重叠的 issues wall time，约 6--11 分钟只是基于阶段长度的上限，
+必须在同资源 Linux runner 上用 cgroup memory/OOM、CPU throttling、长尾和失败率的 A/B
+结果确认净收益后再调整并行度。
 
 ## Revision 6: reuse released engine capacity on one runner
 

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -18,7 +18,10 @@ case 和 package 的耗时排行；仍在运行的 case 继续由 active-case �
 
 UT 运行期间默认每 60 秒写一条 heartbeat，记录最近 stage/label、active case 数、进程
 数、报告路径和 checkpoint；取消时再把原始 JSON、checkpoint、stderr 和排行复制到
-`ut-report/`。这些文件是诊断输入，不参与测试结论，解析失败也不能覆盖原始退出码。
+`ut-report/`。active-case 扫描会跳过不改变状态的 `output` 事件；主报告在同一文件
+系统上优先用 hard link 快照，避免失败时复制一份完整 JSON。CI artifact 只上传快照和
+尚未合并的 helper report，避免再次上传主报告。这些文件是诊断输入，不参与测试结论，
+解析失败也不能覆盖原始退出码。
 当前 reusable `matrixorigin/CI` workflow 只打印 `top.txt`，没有上传 `ut-report`；要在
 GitHub UI 下载原始现场，需要在该 workflow 增加 always-run 的 `actions/upload-artifact`
 步骤。这个上传步骤属于 CI 基础设施 PR，不能由 MatrixOne 的 `make ut` 单独完成。

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -33,6 +33,8 @@ case，结合 `ut-report/ut-checkpoint.log` 和 helper report 判断卡点。
 CI 上传副本设置 250 MiB 总预算和 5 分钟超时；超出预算的文件保留带截断标记的头尾，
 `manifest.txt` 记录原始与保存字节数。该预算只约束诊断 artifact，不改变测试输入、
 coverage 或失败结论。
+成功的 UT job 只上传 `top.txt` 和 checkpoint 作为 1 天的轻量 baseline；原始 JSON 和
+helper report 仅在失败或取消时上传，便于比较正常 run 的阶段耗时而不复制完整测试流。
 
 ## Revision 7: bounded light/issues overlap on one runner
 

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -30,6 +30,9 @@ CI PR 合并后，失败或取消的 job 会生成
 `gh run download <run-id> -n <artifact-name>` 下载，再运行
 `python3 optools/summarize_ut_slow_cases.py ut-report/ut-report.json` 查看已完成的慢
 case，结合 `ut-report/ut-checkpoint.log` 和 helper report 判断卡点。
+CI 上传副本设置 250 MiB 总预算和 5 分钟超时；超出预算的文件保留带截断标记的头尾，
+`manifest.txt` 记录原始与保存字节数。该预算只约束诊断 artifact，不改变测试输入、
+coverage 或失败结论。
 
 ## Revision 7: bounded light/issues overlap on one runner
 

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -22,6 +22,11 @@ UT 运行期间默认每 60 秒写一条 heartbeat，记录最近 stage/label、
 当前 reusable `matrixorigin/CI` workflow 只打印 `top.txt`，没有上传 `ut-report`；要在
 GitHub UI 下载原始现场，需要在该 workflow 增加 always-run 的 `actions/upload-artifact`
 步骤。这个上传步骤属于 CI 基础设施 PR，不能由 MatrixOne 的 `make ut` 单独完成。
+CI PR 合并后，失败或取消的 job 会生成
+`ut-diagnostics-<run-id>-<attempt>-<shard>` artifact；可用
+`gh run download <run-id> -n <artifact-name>` 下载，再运行
+`python3 optools/summarize_ut_slow_cases.py ut-report/ut-report.json` 查看已完成的慢
+case，结合 `ut-report/ut-checkpoint.log` 和 helper report 判断卡点。
 
 ## Revision 7: bounded light/issues overlap on one runner
 

--- a/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
+++ b/docs/design/UT_EXECUTION_AND_FIXTURE_OPTIMIZATION.md
@@ -1,11 +1,27 @@
 # UT 执行模型与 fixture 生命周期优化设计
 
-- 状态：Proposed for this PR，revision 7
+- 状态：Proposed for this PR，revision 8
 - 适用范围：`optools/run_ut.sh`、Go test package 分组、embedded/shared cluster fixture、CI UT 资源预算
 - 约束：不增加 runner 数量；收益必须来自单 runner 的工作删除、fixture 复用或资源有界的阶段重叠
 - 设计 owner：UT runner 与测试基础设施；各测试 package 对自己的 fixture reset/cleanup 契约负责
 - 设计门禁：跨 package、跨进程 admission、runner 取消和集群生命周期，命中 execution、ownership、resource 和 public test-contract 多个边界
 - 决策记录：revision 2 接受本 PR 的 runner 账本、取消/报告所有权和有界分片；compile-only prebuild 保留为显式 opt-in，plan overlap 复用已释放 slot 并默认开启；两者都不扩大默认 heavy 资源预算。跨进程 cluster 共享和动态调度不在本 PR；本 revision 按兼容矩阵落地了一个同进程单 CN fixture 合并，并为后续专用 fixture 增加显式释放边界。
+
+## Revision 8: timeout observability for partial UT runs
+
+超时现场必须同时回答“现在卡在哪里”和“此前哪些 case 已经异常慢”。`run_ut.sh` 在
+收到 TERM、停止并回收自己创建的进程组后，从已经写入的 Go `-json` 前缀生成已完成
+case 和 package 的耗时排行；仍在运行的 case 继续由 active-case 分析单独列出，不能
+把它误报成已完成结果。JSON 报告按二进制行读取，尾部截断的 UTF-8 或半行只计为损坏
+行，不影响此前完整事件的输出。排行写入 `ut-report/top.txt`，因此现有 CI 的 always-run
+“Print the Top 10 Time-Consuming Tests”步骤会在超时后直接打印它。
+
+UT 运行期间默认每 60 秒写一条 heartbeat，记录最近 stage/label、active case 数、进程
+数、报告路径和 checkpoint；取消时再把原始 JSON、checkpoint、stderr 和排行复制到
+`ut-report/`。这些文件是诊断输入，不参与测试结论，解析失败也不能覆盖原始退出码。
+当前 reusable `matrixorigin/CI` workflow 只打印 `top.txt`，没有上传 `ut-report`；要在
+GitHub UI 下载原始现场，需要在该 workflow 增加 always-run 的 `actions/upload-artifact`
+步骤。这个上传步骤属于 CI 基础设施 PR，不能由 MatrixOne 的 `make ut` 单独完成。
 
 ## Revision 7: bounded light/issues overlap on one runner
 

--- a/optools/active_ut_cases.awk
+++ b/optools/active_ut_cases.awk
@@ -28,6 +28,13 @@ function json_string_field(line, name,    marker, start, rest, i, ch, escaped) {
 }
 
 {
+    # Go's -json stream can contain a very large number of output events. They
+    # cannot change active package/test state, so avoid scanning their payload
+    # (which may contain megabytes of SQL/setup output) on every heartbeat.
+    if (index($0, "\"Action\":\"output\"") > 0) {
+        next
+    }
+
     action = json_string_field($0, "Action")
     package_name = json_string_field($0, "Package")
     test_name = json_string_field($0, "Test")

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -47,6 +47,12 @@ UT_PARALLEL=${UT_PARALLEL:-"1"}
 UT_SHARD=${UT_SHARD:-"all"}
 UT_PREBUILD_EMBEDDED=${UT_PREBUILD_EMBEDDED:-"0"}
 UT_OVERLAP_PLAN=${UT_OVERLAP_PLAN:-"1"}
+# The light package wave does not own embedded-cluster fixtures.  On CI's
+# single runner it can therefore overlap the exclusive issues package when
+# enabled, but it uses its own conservative package budget so the two waves do
+# not recreate the six-way race-test pressure that this scheduler removed.
+UT_OVERLAP_LIGHT=${UT_OVERLAP_LIGHT:-"0"}
+UT_OVERLAP_LIGHT_PARALLEL=${UT_OVERLAP_LIGHT_PARALLEL:-"2"}
 # A helper may own two independent child process groups. Its trap gives each
 # child a bounded TERM grace period, so the parent must retain the helper long
 # enough for both children to finish before escalating to KILL.
@@ -77,6 +83,8 @@ ENGINE_RACE_TEST_BINARY=""
 ENGINE_RACE_JOB_PID=""
 ENGINE_RACE_REPORT=""
 ENGINE_RACE_REPORT_READY=""
+LIGHT_RACE_JOB_PID=""
+LIGHT_RACE_REPORT=""
 CURRENT_UT_PID=""
 CURRENT_UT_COMMAND_STAGE=""
 CURRENT_UT_COMMAND_LABEL=""
@@ -201,6 +209,91 @@ function finish_ut_command(){
 function run_ut_command(){
     start_ut_command "$@" || return $?
     finish_ut_command
+}
+
+function start_light_race(){
+    if (( $# != 2 )); then
+        logger "ERR" "start_light_race requires package scope and parallelism"
+        return 2
+    fi
+    if [[ -n "${LIGHT_RACE_JOB_PID}" ]]; then
+        logger "ERR" "start_light_race cannot start while another light helper is active"
+        return 2
+    fi
+
+    local package_scope=$1
+    local package_parallel=$2
+    local saved_term_trap
+    local term_pending=0
+    LIGHT_RACE_REPORT="${G_WKSP}/${G_TS}-light-race-report.out"
+    : > "${LIGHT_RACE_REPORT}"
+    saved_term_trap=$(trap -p TERM)
+    trap 'term_pending=1' TERM
+    checkpoint_ut_event "start" "light" "light race-test packages" "" \
+        "parallel=${package_parallel} background=true"
+    set -m
+    env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+        CGO_CFLAGS="${CGO_CFLAGS}" \
+        CGO_LDFLAGS="${CGO_LDFLAGS}" \
+        go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json \
+        -tags "${TAGS}" -p "${package_parallel}" -timeout "${UT_TIMEOUT}m" \
+        -race ${package_scope} > "${LIGHT_RACE_REPORT}" 2>> "${UT_STDERR}" &
+    LIGHT_RACE_JOB_PID=$!
+    set +m
+    restore_ut_term_trap "${saved_term_trap}"
+    checkpoint_ut_event "pid-start" "light" "light race-test packages" "" \
+        "child_pid=${LIGHT_RACE_JOB_PID} parallel=${package_parallel}"
+    if (( term_pending != 0 )); then
+        handle_ut_termination
+    fi
+}
+
+function consume_light_race_report(){
+    if [[ -z "${LIGHT_RACE_REPORT}" ]]; then
+        return 0
+    fi
+
+    # The helper is the sole writer until its PID is reaped.  Hold this same
+    # boundary while publishing its private JSON so a TERM cannot append a
+    # prefix and then cause a second append from the cancellation path.
+    local saved_term_trap
+    local term_pending=0
+    local append_status=0
+    saved_term_trap=$(trap -p TERM)
+    trap 'term_pending=1' TERM
+    append_ut_report "${LIGHT_RACE_REPORT}" "${UT_REPORT}"
+    append_status=$?
+    if (( append_status != 0 )); then
+        logger "ERR" "failed to consume light race report; preserving ${LIGHT_RACE_REPORT}"
+        restore_ut_term_trap "${saved_term_trap}"
+        if (( term_pending != 0 && UT_TERMINATING == 0 )); then
+            handle_ut_termination
+        fi
+        return "${append_status}"
+    fi
+    rm -f "${LIGHT_RACE_REPORT}" "${LIGHT_RACE_REPORT}".*
+    LIGHT_RACE_REPORT=""
+    restore_ut_term_trap "${saved_term_trap}"
+    if (( term_pending != 0 && UT_TERMINATING == 0 )); then
+        handle_ut_termination
+    fi
+}
+
+function finish_light_race(){
+    local status=0
+    local report_status=0
+    if [[ -z "${LIGHT_RACE_JOB_PID}" ]]; then
+        return 0
+    fi
+    wait "${LIGHT_RACE_JOB_PID}" || status=$?
+    LIGHT_RACE_JOB_PID=""
+    checkpoint_ut_event "finish" "light" "light race-test packages" "${status}"
+    consume_light_race_report
+    report_status=$?
+    if (( report_status != 0 && status == 0 )); then
+        status=${report_status}
+    fi
+    return "${status}"
 }
 
 function start_plan_race(){
@@ -344,12 +437,12 @@ function handle_ut_termination(){
     fi
     UT_TERMINATING=1
     checkpoint_ut_event "cancel" "${CURRENT_UT_STAGE}" "${CURRENT_UT_LABEL}" "143" \
-        "current_pid=${CURRENT_UT_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
+        "current_pid=${CURRENT_UT_PID} light_pid=${LIGHT_RACE_JOB_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
 
     local pid
     # Notify every group before waiting, so the concurrent plan/helper cleanup
     # gets the same grace window as the foreground writer.
-    for pid in "${CURRENT_UT_PID}" "${ENGINE_RACE_JOB_PID}" "${PLAN_RACE_JOB_PID}" "${CLUSTER_PREBUILD_JOB_PID}"; do
+    for pid in "${CURRENT_UT_PID}" "${LIGHT_RACE_JOB_PID}" "${ENGINE_RACE_JOB_PID}" "${PLAN_RACE_JOB_PID}" "${CLUSTER_PREBUILD_JOB_PID}"; do
         [[ -n "${pid}" ]] && terminate_ut_process_group "${pid}" TERM
     done
 
@@ -361,6 +454,12 @@ function handle_ut_termination(){
         wait "${CURRENT_UT_PID}" 2>/dev/null || true
         CURRENT_UT_PID=""
     fi
+    if [[ -n "${LIGHT_RACE_JOB_PID}" ]]; then
+        wait_for_ut_process_group "${LIGHT_RACE_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
+        wait "${LIGHT_RACE_JOB_PID}" 2>/dev/null || true
+        LIGHT_RACE_JOB_PID=""
+    fi
+    consume_light_race_report
     if [[ -n "${ENGINE_RACE_JOB_PID}" ]]; then
         wait_for_ut_process_group "${ENGINE_RACE_JOB_PID}" "${UT_HELPER_TERM_GRACE_TICKS}"
         wait "${ENGINE_RACE_JOB_PID}" 2>/dev/null || true
@@ -920,6 +1019,7 @@ function run_tests(){
     echo "#  UT SHARD:        $UT_SHARD"
     echo "#  EMBEDDED PREBUILD: $UT_PREBUILD_EMBEDDED"
     echo "#  PLAN OVERLAP:    $UT_OVERLAP_PLAN"
+    echo "#  LIGHT OVERLAP:   $UT_OVERLAP_LIGHT (parallel $UT_OVERLAP_LIGHT_PARALLEL)"
     echo "#  HELPER TERM GRACE: $UT_HELPER_TERM_GRACE_TICKS ticks"
     echo "#  CLUSTER ADMISSION: process lifecycle"
     echo "#  UT CHECKPOINT:   $UT_CHECKPOINT"
@@ -960,6 +1060,19 @@ function run_tests(){
     fi
     if ! [[ "${UT_OVERLAP_PLAN}" =~ ^[01]$ ]]; then
         logger "ERR" "UT_OVERLAP_PLAN must be 0 or 1, got '${UT_OVERLAP_PLAN}'"
+        UT_TEST_STATUS=1
+        mark_ut_stage "routing" "validate shard and package partition" finish 1
+        return 0
+    fi
+    if ! [[ "${UT_OVERLAP_LIGHT}" =~ ^[01]$ ]]; then
+        logger "ERR" "UT_OVERLAP_LIGHT must be 0 or 1, got '${UT_OVERLAP_LIGHT}'"
+        UT_TEST_STATUS=1
+        mark_ut_stage "routing" "validate shard and package partition" finish 1
+        return 0
+    fi
+    if ! [[ "${UT_OVERLAP_LIGHT_PARALLEL}" =~ ^[1-9][0-9]*$ ]] ||
+        (( UT_OVERLAP_LIGHT_PARALLEL > 64 )); then
+        logger "ERR" "UT_OVERLAP_LIGHT_PARALLEL must be an integer from 1 through 64, got '${UT_OVERLAP_LIGHT_PARALLEL}'"
         UT_TEST_STATUS=1
         mark_ut_stage "routing" "validate shard and package partition" finish 1
         return 0
@@ -1061,6 +1174,19 @@ function run_tests(){
         local engine_race_parallel=1
         local shard_engine=1
         local engine_joined=0
+        local light_started=0
+        local overlap_light=0
+        local light_parallel=${UT_OVERLAP_LIGHT_PARALLEL}
+
+        if ! [[ "${UT_PARALLEL}" =~ ^[1-9][0-9]*$ ]]; then
+            logger "ERR" "UT_PARALLEL must be a positive integer, got '${UT_PARALLEL}'"
+            UT_TEST_STATUS=1
+            return 0
+        fi
+        if (( light_parallel > UT_PARALLEL )); then
+            light_parallel=${UT_PARALLEL}
+            logger "INF" "Cap overlapping light package parallelism to UT_PARALLEL=${UT_PARALLEL}"
+        fi
 
         if ! [[ "${HEAVY_RACE_PARALLEL}" =~ ^[1-9][0-9]*$ ]] ||
             (( HEAVY_RACE_PARALLEL > 64 )); then
@@ -1173,20 +1299,43 @@ function run_tests(){
         fi
 
         : > "${UT_REPORT}"
-        if should_run_ut_stage light && [[ -n "${light_test_scope}" ]]; then
-            logger "INF" "Run light race-test packages with parallelism ${UT_PARALLEL}"
-            run_ut_command "light" "light race-test packages" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p ${UT_PARALLEL} -timeout "${UT_TIMEOUT}m" -race $light_test_scope
-            light_status=$?
-        fi
+        # HNSW owns native worker pools inside its test binary. It must finish
+        # before another race wave starts. When the bounded light/issues
+        # overlap is eligible, run HNSW first, then let the low-budget light
+        # helper overlap only the exclusive issues package.
+        if (( UT_OVERLAP_LIGHT == 1 && UT_PARALLEL > 1 )) &&
+            should_run_ut_stage light && should_run_ut_stage serial &&
+            [[ -n "${light_test_scope}" ]]; then
+            overlap_light=1
+            if should_run_ut_stage hnsw; then
+                logger "INF" "Run HNSW race-test package with exclusive runner CPU before light/issues overlap"
+                run_ut_command "hnsw" "HNSW race-test package" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race "${hnsw_package}"
+                hnsw_status=$?
+            fi
+            logger "INF" "Start light race-test packages in background with parallelism ${light_parallel}; overlap only with exclusive issues"
+            if start_light_race "${light_test_scope}" "${light_parallel}"; then
+                light_started=1
+            else
+                # A launch failure must not silently remove the light group
+                # from the authoritative suite. Fall back to the original
+                # foreground command so the package scope still executes.
+                logger "ERR" "failed to start overlapping light race-test helper; retrying in foreground"
+                run_ut_command "light" "light race-test packages" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p ${UT_PARALLEL} -timeout "${UT_TIMEOUT}m" -race $light_test_scope
+                light_status=$?
+                overlap_light=0
+            fi
+        else
+            if should_run_ut_stage light && [[ -n "${light_test_scope}" ]]; then
+                logger "INF" "Run light race-test packages with parallelism ${UT_PARALLEL}"
+                run_ut_command "light" "light race-test packages" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p ${UT_PARALLEL} -timeout "${UT_TIMEOUT}m" -race $light_test_scope
+                light_status=$?
+            fi
 
-        # HNSW owns native worker pools inside its test binary. Running it as
-        # one package slot after the normal light wave preserves its full-batch
-        # and repeated-lifecycle targets without letting package concurrency
-        # turn CPU scheduling delay into a multi-minute light-stage straggler.
-        if should_run_ut_stage hnsw; then
-            logger "INF" "Run HNSW race-test package with exclusive runner CPU"
-            run_ut_command "hnsw" "HNSW race-test package" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race "${hnsw_package}"
-            hnsw_status=$?
+            if should_run_ut_stage hnsw; then
+                logger "INF" "Run HNSW race-test package with exclusive runner CPU"
+                run_ut_command "hnsw" "HNSW race-test package" env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go test ${GO_MODULE_MODE} ${GO_TEST_VET_FLAGS} -short -v -json -tags "${TAGS}" -p 1 -timeout "${UT_TIMEOUT}m" -race "${hnsw_package}"
+                hnsw_status=$?
+            fi
         fi
 
         # Compile the next embedded wave while the exclusive issues package is
@@ -1194,6 +1343,7 @@ function run_tests(){
         # compiles and links; it does not execute TestMain or any test, so this
         # overlaps build/link work without creating another active cluster.
         if (( UT_PREBUILD_EMBEDDED == 1 )) &&
+            (( overlap_light == 0 )) &&
             should_run_ut_stage serial && should_run_ut_stage embedded &&
             [[ -n "${cluster_test_scope}" ]]; then
             start_embedded_prebuild "${cluster_test_scope}" "${cluster_package_parallel}"
@@ -1210,6 +1360,12 @@ function run_tests(){
                     logger "ERR" "Exclusive race-test package ${package} failed with status ${package_status}"
                 fi
             done
+        fi
+
+        if (( light_started == 1 )); then
+            finish_light_race
+            light_status=$?
+            report_cgroup_memory_usage "Light/issues overlap"
         fi
 
         # These packages link embedded clusters with substantial race-detector

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -364,13 +364,13 @@ function report_slow_ut_cases(){
 function snapshot_ut_diagnostics(){
     local destination="${UT_DIAGNOSTIC_DIR}"
     mkdir -p "${destination}"
-    if [[ -f "${UT_REPORT}" ]]; then
+    if [[ -f "${UT_REPORT}" && "${UT_REPORT}" != "${destination}/ut-report.json" ]]; then
         cp "${UT_REPORT}" "${destination}/ut-report.json"
     fi
-    if [[ -f "${UT_CHECKPOINT}" ]]; then
+    if [[ -f "${UT_CHECKPOINT}" && "${UT_CHECKPOINT}" != "${destination}/ut-checkpoint.log" ]]; then
         cp "${UT_CHECKPOINT}" "${destination}/ut-checkpoint.log"
     fi
-    if [[ -f "${UT_STDERR}" ]]; then
+    if [[ -f "${UT_STDERR}" && "${UT_STDERR}" != "${destination}/ut-stderr.log" ]]; then
         cp "${UT_STDERR}" "${destination}/ut-stderr.log"
     fi
     logger "ERR" "UT diagnostic snapshot: ${destination}"
@@ -386,20 +386,48 @@ function start_ut_heartbeat(){
     fi
 
     (
-        trap 'exit 0' TERM INT
+        local heartbeat_sleep_pid=""
+        function stop_heartbeat_sleep(){
+            trap - TERM INT
+            if [[ -n "${heartbeat_sleep_pid}" ]]; then
+                kill -TERM "${heartbeat_sleep_pid}" 2>/dev/null || true
+            fi
+            exit 0
+        }
+        trap stop_heartbeat_sleep TERM INT
         while :; do
-            sleep "${interval}" || exit 0
+            sleep "${interval}" &
+            heartbeat_sleep_pid=$!
+            wait "${heartbeat_sleep_pid}" || exit 0
+            heartbeat_sleep_pid=""
             [[ "${UT_TERMINATING}" == 0 ]] || exit 0
 
-            local latest stage label active_cases active_detail process_count memory
+            local latest stage label active_cases active_detail active_records process_count memory report
+            local -a heartbeat_reports
             latest=$(tail -n 1 "${UT_CHECKPOINT}" 2>/dev/null || true)
             stage=$(sed -n 's/.* stage=\([^ ]*\).*/\1/p' <<< "${latest}")
             label=$(sed -n 's/.* label=\(.*\) status=.*/\1/p' <<< "${latest}")
             [[ -n "${stage}" ]] || stage="unknown"
             [[ -n "${label}" ]] || label="unknown"
-            active_detail=$(awk -f "${BUILD_WKSP}/optools/active_ut_cases.awk" "${UT_REPORT}" 2>/dev/null |
-                grep '^active UT case:' | head -n 3 | paste -sd ';' - || true)
-            active_cases=$(grep -o 'active UT case:' <<< "${active_detail}" | wc -l | tr -d ' ' || true)
+            # The heartbeat is forked before run_tests assigns the helper
+            # report variables. Discover reports from the immutable run
+            # workspace instead of relying on those later parent-shell values.
+            heartbeat_reports=(
+                "${UT_REPORT}"
+                "${G_WKSP}/${G_TS}-light-race-report.out"
+                "${G_WKSP}/${G_TS}-engine-race-report.out"
+                "${G_WKSP}/${G_TS}-engine-race-report.out".*
+                "${G_WKSP}/${G_TS}-plan-race-report.out"
+                "${G_WKSP}/${G_TS}-plan-race-report.out".*
+            )
+            active_records=""
+            for report in "${heartbeat_reports[@]}"; do
+                if [[ -s "${report}" ]]; then
+                    active_records+=$'\n'"$(awk -f "${BUILD_WKSP}/optools/active_ut_cases.awk" "${report}" 2>/dev/null || true)"
+                fi
+            done
+            active_cases=$(grep -c '^active UT case:' <<< "${active_records}" || true)
+            active_detail=$(grep '^active UT case:' <<< "${active_records}" | LC_ALL=C sort -u | head -n 3 | paste -sd ';' - || true)
             process_count=$(ps -e --no-headers 2>/dev/null | wc -l | tr -d ' ' || true)
             memory=$(cgroup_memory_metrics)
             logger "INF" "[ut_heartbeat] stage=${stage} label=${label} active_cases=${active_cases:-0} active=${active_detail:-none} processes=${process_count:-unknown} memory=${memory:-unknown} report=${UT_REPORT}"
@@ -417,6 +445,14 @@ function stop_ut_heartbeat(){
         return 0
     fi
     kill -TERM "${UT_HEARTBEAT_PID}" 2>/dev/null || true
+    local ticks=0
+    while kill -0 "${UT_HEARTBEAT_PID}" 2>/dev/null && (( ticks < 20 )); do
+        sleep 0.1
+        ticks=$((ticks + 1))
+    done
+    if kill -0 "${UT_HEARTBEAT_PID}" 2>/dev/null; then
+        kill -KILL "${UT_HEARTBEAT_PID}" 2>/dev/null || true
+    fi
     wait "${UT_HEARTBEAT_PID}" 2>/dev/null || true
     UT_HEARTBEAT_PID=""
 }
@@ -550,7 +586,6 @@ function handle_ut_termination(){
         exit 143
     fi
     UT_TERMINATING=1
-    stop_ut_heartbeat
     checkpoint_ut_event "cancel" "${CURRENT_UT_STAGE}" "${CURRENT_UT_LABEL}" "143" \
         "current_pid=${CURRENT_UT_PID} light_pid=${LIGHT_RACE_JOB_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
 
@@ -560,6 +595,7 @@ function handle_ut_termination(){
     for pid in "${CURRENT_UT_PID}" "${LIGHT_RACE_JOB_PID}" "${ENGINE_RACE_JOB_PID}" "${PLAN_RACE_JOB_PID}" "${CLUSTER_PREBUILD_JOB_PID}"; do
         [[ -n "${pid}" ]] && terminate_ut_process_group "${pid}" TERM
     done
+    stop_ut_heartbeat
 
     if [[ -n "${CURRENT_UT_PID}" ]]; then
         logger "ERR" "UT cancellation: stopping ${CURRENT_UT_LABEL} child ${CURRENT_UT_PID}"

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -365,13 +365,22 @@ function snapshot_ut_diagnostics(){
     local destination="${UT_DIAGNOSTIC_DIR}"
     mkdir -p "${destination}"
     if [[ -f "${UT_REPORT}" && "${UT_REPORT}" != "${destination}/ut-report.json" ]]; then
-        cp "${UT_REPORT}" "${destination}/ut-report.json"
+        if [[ ! -e "${destination}/ut-report.json" ]] &&
+            ! ln "${UT_REPORT}" "${destination}/ut-report.json" 2>/dev/null; then
+            cp "${UT_REPORT}" "${destination}/ut-report.json"
+        fi
     fi
     if [[ -f "${UT_CHECKPOINT}" && "${UT_CHECKPOINT}" != "${destination}/ut-checkpoint.log" ]]; then
-        cp "${UT_CHECKPOINT}" "${destination}/ut-checkpoint.log"
+        if [[ ! -e "${destination}/ut-checkpoint.log" ]] &&
+            ! ln "${UT_CHECKPOINT}" "${destination}/ut-checkpoint.log" 2>/dev/null; then
+            cp "${UT_CHECKPOINT}" "${destination}/ut-checkpoint.log"
+        fi
     fi
     if [[ -f "${UT_STDERR}" && "${UT_STDERR}" != "${destination}/ut-stderr.log" ]]; then
-        cp "${UT_STDERR}" "${destination}/ut-stderr.log"
+        if [[ ! -e "${destination}/ut-stderr.log" ]] &&
+            ! ln "${UT_STDERR}" "${destination}/ut-stderr.log" 2>/dev/null; then
+            cp "${UT_STDERR}" "${destination}/ut-stderr.log"
+        fi
     fi
     logger "ERR" "UT diagnostic snapshot: ${destination}"
 }

--- a/optools/run_ut.sh
+++ b/optools/run_ut.sh
@@ -91,6 +91,8 @@ CURRENT_UT_COMMAND_LABEL=""
 CURRENT_UT_STAGE="initializing"
 CURRENT_UT_LABEL="startup"
 UT_TERMINATING=0
+UT_HEARTBEAT_INTERVAL=${UT_HEARTBEAT_INTERVAL:-"60"}
+UT_HEARTBEAT_PID=""
 TAGS="matrixone_test"
 GO_MODULE_MODE="-mod=readonly"
 # Static analysis owns vet in the separate SCA job. Running it again for every
@@ -125,6 +127,10 @@ if [[ -f $UT_STDERR ]]; then rm $UT_STDERR; fi
 if [[ -f $UT_CHECKPOINT ]]; then rm $UT_CHECKPOINT; fi
 if [[ -f $UT_FILTER ]]; then rm $UT_FILTER; fi
 if [[ -f $UT_COUNT ]]; then rm $UT_COUNT; fi
+if [[ -f "${UT_DIAGNOSTIC_DIR}/top.txt" ]]; then rm "${UT_DIAGNOSTIC_DIR}/top.txt"; fi
+if [[ -f "${UT_DIAGNOSTIC_DIR}/ut-report.json" ]]; then rm "${UT_DIAGNOSTIC_DIR}/ut-report.json"; fi
+if [[ -f "${UT_DIAGNOSTIC_DIR}/ut-checkpoint.log" ]]; then rm "${UT_DIAGNOSTIC_DIR}/ut-checkpoint.log"; fi
+if [[ -f "${UT_DIAGNOSTIC_DIR}/ut-stderr.log" ]]; then rm "${UT_DIAGNOSTIC_DIR}/ut-stderr.log"; fi
 if ! mkdir -p "${BUILD_WKSP}/ut-report/failed/outputs"; then
     echo "failed to create UT diagnostic directory: ${BUILD_WKSP}/ut-report/failed/outputs" >&2
     exit 1
@@ -334,6 +340,114 @@ function report_active_ut_cases(){
         sed 's/^/[active_ut_cases] /'
 }
 
+function report_slow_ut_cases(){
+    if [[ ! -s "${UT_REPORT}" ]]; then
+        logger "ERR" "No Go test JSON is available to identify slow UT cases"
+        return 0
+    fi
+
+    local slow_report="${UT_DIAGNOSTIC_DIR}/top.txt"
+    local slow_output=""
+    if ! slow_output=$(python3 "${BUILD_WKSP}/optools/summarize_ut_slow_cases.py" "${UT_REPORT}" 2>&1); then
+        logger "ERR" "failed to summarize slow UT cases: ${slow_output}"
+        return 0
+    fi
+
+    mkdir -p "${UT_DIAGNOSTIC_DIR}"
+    printf '%s\n' "${slow_output}" > "${slow_report}"
+    logger "ERR" "Slow or completed UT cases from ${UT_REPORT}:"
+    while IFS= read -r line; do
+        [[ -n "${line}" ]] && logger "ERR" "${line}"
+    done <<< "${slow_output}"
+}
+
+function snapshot_ut_diagnostics(){
+    local destination="${UT_DIAGNOSTIC_DIR}"
+    mkdir -p "${destination}"
+    if [[ -f "${UT_REPORT}" ]]; then
+        cp "${UT_REPORT}" "${destination}/ut-report.json"
+    fi
+    if [[ -f "${UT_CHECKPOINT}" ]]; then
+        cp "${UT_CHECKPOINT}" "${destination}/ut-checkpoint.log"
+    fi
+    if [[ -f "${UT_STDERR}" ]]; then
+        cp "${UT_STDERR}" "${destination}/ut-stderr.log"
+    fi
+    logger "ERR" "UT diagnostic snapshot: ${destination}"
+}
+
+function start_ut_heartbeat(){
+    local interval="${UT_HEARTBEAT_INTERVAL}"
+    if ! [[ "${interval}" =~ ^[1-9][0-9]*$ ]]; then
+        interval=60
+    fi
+    if [[ -n "${UT_HEARTBEAT_PID}" ]]; then
+        return 0
+    fi
+
+    (
+        trap 'exit 0' TERM INT
+        while :; do
+            sleep "${interval}" || exit 0
+            [[ "${UT_TERMINATING}" == 0 ]] || exit 0
+
+            local latest stage label active_cases active_detail process_count memory
+            latest=$(tail -n 1 "${UT_CHECKPOINT}" 2>/dev/null || true)
+            stage=$(sed -n 's/.* stage=\([^ ]*\).*/\1/p' <<< "${latest}")
+            label=$(sed -n 's/.* label=\(.*\) status=.*/\1/p' <<< "${latest}")
+            [[ -n "${stage}" ]] || stage="unknown"
+            [[ -n "${label}" ]] || label="unknown"
+            active_detail=$(awk -f "${BUILD_WKSP}/optools/active_ut_cases.awk" "${UT_REPORT}" 2>/dev/null |
+                grep '^active UT case:' | head -n 3 | paste -sd ';' - || true)
+            active_cases=$(grep -o 'active UT case:' <<< "${active_detail}" | wc -l | tr -d ' ' || true)
+            process_count=$(ps -e --no-headers 2>/dev/null | wc -l | tr -d ' ' || true)
+            memory=$(cgroup_memory_metrics)
+            logger "INF" "[ut_heartbeat] stage=${stage} label=${label} active_cases=${active_cases:-0} active=${active_detail:-none} processes=${process_count:-unknown} memory=${memory:-unknown} report=${UT_REPORT}"
+            checkpoint_ut_event "heartbeat" "${stage}" "${label}" "" \
+                "active_cases=${active_cases:-0} active=${active_detail:-none} processes=${process_count:-unknown} memory=${memory:-unknown}"
+        done
+    ) &
+    UT_HEARTBEAT_PID=$!
+    checkpoint_ut_event "heartbeat-start" "${CURRENT_UT_STAGE}" "${CURRENT_UT_LABEL}" "" \
+        "pid=${UT_HEARTBEAT_PID} interval=${interval}s"
+}
+
+function stop_ut_heartbeat(){
+    if [[ -z "${UT_HEARTBEAT_PID}" ]]; then
+        return 0
+    fi
+    kill -TERM "${UT_HEARTBEAT_PID}" 2>/dev/null || true
+    wait "${UT_HEARTBEAT_PID}" 2>/dev/null || true
+    UT_HEARTBEAT_PID=""
+}
+
+function cgroup_memory_metrics(){
+    local relative_path=""
+    local cgroup_path=""
+    if [[ ! -r /proc/self/cgroup ]]; then
+        return 0
+    fi
+
+    relative_path=$(awk -F: '$1 == "0" { print $3; exit }' /proc/self/cgroup)
+    if [[ -n "${relative_path}" ]]; then
+        cgroup_path="/sys/fs/cgroup${relative_path}"
+        if [[ -r "${cgroup_path}/memory.current" ]]; then
+            printf 'current=%s peak=%s' \
+                "$(< "${cgroup_path}/memory.current")" \
+                "$(< "${cgroup_path}/memory.peak")"
+            return 0
+        fi
+    fi
+
+    relative_path=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' /proc/self/cgroup)
+    cgroup_path="/sys/fs/cgroup/memory${relative_path}"
+    if [[ -r "${cgroup_path}/memory.usage_in_bytes" ]]; then
+        printf 'current=%s peak=%s' \
+            "$(< "${cgroup_path}/memory.usage_in_bytes")" \
+            "$(< "${cgroup_path}/memory.max_usage_in_bytes")"
+    fi
+}
+
 function report_cgroup_memory_usage(){
     local label=$1
     local relative_path=""
@@ -436,6 +550,7 @@ function handle_ut_termination(){
         exit 143
     fi
     UT_TERMINATING=1
+    stop_ut_heartbeat
     checkpoint_ut_event "cancel" "${CURRENT_UT_STAGE}" "${CURRENT_UT_LABEL}" "143" \
         "current_pid=${CURRENT_UT_PID} light_pid=${LIGHT_RACE_JOB_PID} engine_pid=${ENGINE_RACE_JOB_PID} plan_pid=${PLAN_RACE_JOB_PID} prebuild_pid=${CLUSTER_PREBUILD_JOB_PID}"
 
@@ -500,6 +615,8 @@ function handle_ut_termination(){
     if [[ -s "${UT_STDERR}" ]]; then
         tail -n 40 "${UT_STDERR}" | sed 's/^/[ut_stderr] /' | tee -a "${LOG}"
     fi
+    snapshot_ut_diagnostics
+    report_slow_ut_cases
     report_active_ut_cases
     exit 143
 }
@@ -1491,6 +1608,8 @@ function run_tests(){
     # a report-parser failure can never replace the authoritative test result.
     if (( UT_TEST_STATUS != 0 )); then
         logger "ERR" "go test failed with status ${UT_TEST_STATUS}; raw report: ${UT_REPORT}"
+        snapshot_ut_diagnostics
+        report_slow_ut_cases
         report_active_ut_cases
     fi
 
@@ -1574,7 +1693,9 @@ elif [[ 'UT' == $TEST_TYPE ]]; then
     horiz_rule
     echo "# Running UT"
     horiz_rule
+    start_ut_heartbeat
     run_tests
+    stop_ut_heartbeat
 
     horiz_rule
     echo "# Post testing"

--- a/optools/summarize_ut_slow_cases.py
+++ b/optools/summarize_ut_slow_cases.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright 2026 Matrix Origin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report the slowest completed tests from a (possibly truncated) Go JSON log."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+TERMINAL_ACTIONS = {"pass", "fail", "skip"}
+TEST_START_ACTIONS = {"run", "pause", "cont"}
+
+
+def parse_time(value: object) -> Optional[datetime]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def event_elapsed(
+    event: Dict[str, object],
+    started: Optional[datetime],
+    ended: Optional[datetime],
+) -> Optional[float]:
+    elapsed = event.get("Elapsed")
+    if isinstance(elapsed, (int, float)) and elapsed >= 0:
+        return float(elapsed)
+    if started is not None and ended is not None:
+        seconds = (ended - started).total_seconds()
+        if seconds >= 0:
+            return seconds
+    return None
+
+
+def format_duration(seconds: float) -> str:
+    if seconds >= 3600:
+        return f"{seconds / 3600:.2f}h"
+    if seconds >= 60:
+        return f"{seconds / 60:.2f}m"
+    if seconds >= 1:
+        return f"{seconds:.2f}s"
+    if seconds >= 1e-3:
+        return f"{seconds * 1e3:.2f}ms"
+    return f"{seconds * 1e6:.2f}us"
+
+
+def summarize(
+    report_path: Path, limit: int = 20
+) -> Tuple[
+    List[Tuple[float, str, str, str, str]],
+    List[Tuple[float, str, str, str, str]],
+    int,
+]:
+    active_tests: Dict[Tuple[str, str], datetime] = {}
+    active_packages: Dict[str, datetime] = {}
+    completed_tests: List[Tuple[float, str, str, str, str]] = []
+    completed_packages: List[Tuple[float, str, str, str, str]] = []
+    malformed = 0
+
+    with report_path.open("rb") as report:
+        for raw_line in report:
+            try:
+                line = raw_line.decode("utf-8")
+            except UnicodeDecodeError:
+                # Cancellation can leave a partial multi-byte character in the
+                # final line.  Preserve all complete preceding events.
+                malformed += 1
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+            if not isinstance(event, dict):
+                continue
+
+            action = event.get("Action")
+            package = event.get("Package")
+            if not isinstance(action, str) or not isinstance(package, str) or not package:
+                continue
+            timestamp = parse_time(event.get("Time"))
+            test = event.get("Test")
+            if isinstance(test, str) and test:
+                key = (package, test)
+                if action in TEST_START_ACTIONS:
+                    if timestamp is not None:
+                        active_tests.setdefault(key, timestamp)
+                elif action in TERMINAL_ACTIONS:
+                    started = active_tests.pop(key, None)
+                    elapsed = event_elapsed(event, started, timestamp)
+                    if elapsed is not None:
+                        completed_tests.append(
+                            (
+                                elapsed,
+                                package,
+                                test,
+                                action,
+                                timestamp.isoformat() if timestamp else "?",
+                            )
+                        )
+                continue
+
+            if action == "start":
+                if timestamp is not None:
+                    active_packages.setdefault(package, timestamp)
+            elif action in TERMINAL_ACTIONS:
+                started = active_packages.pop(package, None)
+                elapsed = event_elapsed(event, started, timestamp)
+                if elapsed is not None:
+                    completed_packages.append(
+                        (
+                            elapsed,
+                            package,
+                            "",
+                            action,
+                            timestamp.isoformat() if timestamp else "?",
+                        )
+                    )
+
+    completed_tests.sort(key=lambda item: item[0], reverse=True)
+    completed_packages.sort(key=lambda item: item[0], reverse=True)
+    return completed_tests[:limit], completed_packages[:limit], malformed
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) not in (2, 3):
+        print(f"usage: {argv[0]} GO_TEST_JSON [LIMIT]", file=sys.stderr)
+        return 2
+    try:
+        limit = int(argv[2]) if len(argv) == 3 else 20
+    except ValueError:
+        print("LIMIT must be a positive integer", file=sys.stderr)
+        return 2
+    if limit <= 0:
+        print("LIMIT must be a positive integer", file=sys.stderr)
+        return 2
+
+    report_path = Path(argv[1])
+    if not report_path.is_file():
+        print(f"slow UT case report missing: {report_path}", file=sys.stderr)
+        return 1
+
+    tests, packages, malformed = summarize(report_path, limit)
+    print(f"[slow_ut_cases] completed test cases (top {limit}):")
+    if tests:
+        for elapsed, package, test, result, ended in tests:
+            print(
+                f"[slow_ut_cases] elapsed={format_duration(elapsed)} "
+                f"result={result} package={package} test={test} ended={ended}"
+            )
+    else:
+        print("[slow_ut_cases] none")
+
+    print(f"[slow_ut_cases] completed packages (top {limit}):")
+    if packages:
+        for elapsed, package, _, result, ended in packages:
+            print(
+                f"[slow_ut_cases] elapsed={format_duration(elapsed)} "
+                f"result={result} package={package} ended={ended}"
+            )
+    else:
+        print("[slow_ut_cases] none")
+
+    if malformed:
+        print(
+            f"[slow_ut_cases] ignored malformed JSON lines={malformed} "
+            "(report may be truncated by cancellation)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/optools/ut_schedule_test.go
+++ b/optools/ut_schedule_test.go
@@ -28,6 +28,20 @@ import (
 // Source the real runner in a private repository layout. Its startup clears
 // diagnostics, so sourcing it in the actual checkout would corrupt another UT.
 func scheduleHarness(t *testing.T, script string, variables ...string) ([]byte, error) {
+	return scheduleHarnessWithMock(t, script, `#!/bin/bash
+if [[ "$1" == version ]]; then exit 0; fi
+# The real env/go command must preserve both events around the report merge.
+printf 'heavy-start\n'
+printf started > "$CASE_DIR/heavy-started"
+if [[ "$EXPECT_OVERLAP" == 1 ]]; then
+ while [[ ! -e "$CASE_DIR/plan-started" ]]; do sleep 0.01; done
+fi
+printf 'heavy-end\n'
+exit "$HEAVY_STATUS"
+`, variables...)
+}
+
+func scheduleHarnessWithMock(t *testing.T, script, mock string, variables ...string) ([]byte, error) {
 	t.Helper()
 	root := t.TempDir()
 	dir := filepath.Join(root, "optools")
@@ -51,17 +65,6 @@ func scheduleHarness(t *testing.T, script string, variables ...string) ([]byte, 
 			t.Fatal(err)
 		}
 	}
-	mock := `#!/bin/bash
-if [[ "$1" == version ]]; then exit 0; fi
-# The real env/go command must preserve both events around the report merge.
-printf 'heavy-start\n'
-printf started > "$CASE_DIR/heavy-started"
-if [[ "$EXPECT_OVERLAP" == 1 ]]; then
- while [[ ! -e "$CASE_DIR/plan-started" ]]; do sleep 0.01; done
-fi
-printf 'heavy-end\n'
-exit "$HEAVY_STATUS"
-`
 	if err := os.WriteFile(filepath.Join(dir, "go"), []byte(mock), 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -150,6 +153,7 @@ cat "$UT_REPORT"
 func TestHeavyPlanCancellationStopsWritersBeforeMerge(t *testing.T) {
 	script := `source ./run_ut.sh UT
 function logger() { :; }
+UT_HELPER_TERM_GRACE_TICKS=4
 trap handle_ut_termination TERM
 trap 'printf "\nCANCEL_REPORT\n"; cat "$UT_REPORT"' EXIT
 ENGINE_RACE_REPORT="$CASE_DIR/engine-report"
@@ -177,5 +181,178 @@ kill -TERM "$$"
 	}
 	if !strings.HasSuffix(string(out), "CANCEL_REPORT\nheavy-start\nheavy-stopped\nplan-start\nplan-stopped\nengine\n") {
 		t.Fatalf("writer was not stopped before merging: %s", out)
+	}
+}
+
+func TestLightIssuesOverlapPreservesReportsAndFailures(t *testing.T) {
+	mock := `#!/bin/bash
+if [[ "$1" == version ]]; then exit 0; fi
+if [[ "$*" == *example/light-package* ]]; then
+ printf 'light-start\n'
+ touch "$CASE_DIR/light-started"
+ while [[ ! -e "$CASE_DIR/serial-started" ]]; do sleep 0.01; done
+ printf 'light-end\n'
+ exit "$LIGHT_STATUS"
+fi
+exit 99
+`
+	for _, tc := range []struct {
+		name, lightStatus, serialStatus string
+	}{
+		{name: "success", lightStatus: "0", serialStatus: "0"},
+		{name: "light-failure", lightStatus: "7", serialStatus: "0"},
+		{name: "serial-failure", lightStatus: "0", serialStatus: "9"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := `source ./run_ut.sh UT
+function logger() { :; }
+trap handle_ut_termination TERM
+start_light_race example/light-package 2
+start_ut_command serial 'exclusive issues package' bash -c '
+ printf "serial-start\n"
+ touch "$CASE_DIR/serial-started"
+ while [[ ! -e "$CASE_DIR/light-started" ]]; do sleep 0.01; done
+ printf "serial-end\n"
+ exit "$SERIAL_STATUS"
+'
+serial_status=0
+finish_ut_command || serial_status=$?
+light_status=0
+finish_light_race || light_status=$?
+[[ "$serial_status" == "$SERIAL_STATUS" ]] || exit 90
+[[ "$light_status" == "$LIGHT_STATUS" ]] || exit 91
+[[ -z "$CURRENT_UT_PID$LIGHT_RACE_JOB_PID$LIGHT_RACE_REPORT" ]] || exit 92
+report=$(cat "$UT_REPORT")
+[[ "$report" == $'serial-start\nserial-end\nlight-start\nlight-end' ]] || { printf 'REPORT=%q\n' "$report"; exit 93; }
+`
+			out, err := scheduleHarnessWithMock(t, script, mock,
+				"LIGHT_STATUS="+tc.lightStatus, "SERIAL_STATUS="+tc.serialStatus)
+			if err != nil {
+				t.Fatalf("overlap: %v\n%s", err, out)
+			}
+		})
+	}
+}
+
+func TestLightIssuesCancellationStopsWritersBeforeMerge(t *testing.T) {
+	mock := `#!/bin/bash
+if [[ "$1" == version ]]; then exit 0; fi
+if [[ "$*" == *example/light-package* ]]; then
+ trap 'printf "light-stopped\\n"; exit 143' TERM
+ printf 'light-start\n'
+ touch "$CASE_DIR/light-started"
+ while :; do sleep 0.01; done
+fi
+exit 99
+`
+	script := `source ./run_ut.sh UT
+function logger() { :; }
+UT_HELPER_TERM_GRACE_TICKS=4
+trap handle_ut_termination TERM
+trap 'printf "\nCANCEL_REPORT\n"; cat "$UT_REPORT"' EXIT
+start_light_race example/light-package 2
+start_ut_command serial 'exclusive issues package' bash -c '
+ trap '\''printf "serial-stopped\n"; exit 143'\'' TERM
+ printf "serial-start\n"
+ touch "$CASE_DIR/serial-started"
+ while :; do sleep 0.01; done
+'
+while [[ ! -e "$CASE_DIR/light-started" || ! -e "$CASE_DIR/serial-started" ]]; do sleep 0.01; done
+kill -TERM "$$"
+`
+	out, err := scheduleHarnessWithMock(t, script, mock)
+	exit, ok := err.(*exec.ExitError)
+	if !ok || exit.ExitCode() != 143 {
+		t.Fatalf("expected TERM exit 143: %v\n%s", err, out)
+	}
+	if !strings.HasSuffix(string(out), "CANCEL_REPORT\nserial-start\nserial-stopped\nlight-start\nlight-stopped\n") {
+		t.Fatalf("writer was not stopped before merging: %s", out)
+	}
+}
+
+func TestRunTestsPlacesHNSWBeforeLightIssuesOverlap(t *testing.T) {
+	mock := `#!/bin/bash
+if [[ "$1" == version ]]; then exit 0; fi
+if [[ "$*" == *pkg/vectorindex/hnsw* ]]; then
+ printf 'hnsw\n'
+ touch "$CASE_DIR/hnsw-done"
+ exit 0
+fi
+if [[ "$*" == *pkg/light-package* ]]; then
+ if [[ "$EXPECT_OVERLAP" == 1 ]]; then
+  [[ -e "$CASE_DIR/hnsw-done" ]] || exit 81
+ fi
+ printf 'light\n'
+ touch "$CASE_DIR/light-started"
+ if [[ "$EXPECT_OVERLAP" == 1 ]]; then
+  while [[ ! -e "$CASE_DIR/serial-started" ]]; do sleep 0.01; done
+ fi
+ printf 'light-end\n'
+ exit 0
+fi
+if [[ "$*" == *pkg/tests/issues* ]]; then
+ printf 'serial\n'
+ touch "$CASE_DIR/serial-started"
+ if [[ "$EXPECT_OVERLAP" == 1 ]]; then
+  while [[ ! -e "$CASE_DIR/light-started" ]]; do sleep 0.01; done
+ fi
+ printf 'serial-end\n'
+ exit 0
+fi
+if [[ "$*" == *pkg/tests/embedded* ]]; then printf 'embedded\n'; exit 0; fi
+if [[ "$*" == *pkg/backup* ]]; then printf 'heavy\n'; exit 0; fi
+exit 0
+`
+	for _, tc := range []struct {
+		name, parallel, overlap, expectOverlap, expected string
+	}{
+		{name: "overlap", parallel: "6", overlap: "1", expectOverlap: "1", expected: "hnsw\nserial\nserial-end\nlight\nlight-end"},
+		{name: "sequential-explicit-off", parallel: "6", overlap: "0", expectOverlap: "0", expected: "light\nlight-end\nhnsw\nserial\nserial-end"},
+		{name: "sequential-single-slot", parallel: "1", overlap: "0", expectOverlap: "0", expected: "light\nlight-end\nhnsw\nserial\nserial-end"},
+		{name: "single-slot-guard", parallel: "1", overlap: "1", expectOverlap: "0", expected: "light\nlight-end\nhnsw\nserial\nserial-end"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := `source ./run_ut.sh UT
+function logger() { :; }
+function make() { :; }
+function egrep() { echo fake.pb.go; }
+	MO_CL_CUDA=1
+	UT_SHARD=all
+UT_PARALLEL=${UT_PARALLEL_VALUE}
+UT_OVERLAP_LIGHT=${UT_OVERLAP_VALUE}
+UT_OVERLAP_LIGHT_PARALLEL=2
+UT_OVERLAP_PLAN=0
+UT_PREBUILD_EMBEDDED=0
+function go() {
+ if [[ "$1" == clean ]]; then return 0; fi
+ if [[ "$1" != list ]]; then return 0; fi
+ if [[ "$*" == *"./pkg/sql/plan"* ]]; then echo github.com/matrixorigin/matrixone/pkg/sql/plan; return 0; fi
+ if [[ "$*" == *"./pkg/vm/engine/test"* ]]; then echo github.com/matrixorigin/matrixone/pkg/vm/engine/test; return 0; fi
+ if [[ "$*" == *"./pkg/vectorindex/hnsw"* ]]; then echo github.com/matrixorigin/matrixone/pkg/vectorindex/hnsw; return 0; fi
+ if [[ "$*" == *"./pkg/tests/issues"* ]]; then echo github.com/matrixorigin/matrixone/pkg/tests/issues; return 0; fi
+ if [[ "$*" == *"./pkg/backup"* ]]; then echo github.com/matrixorigin/matrixone/pkg/backup; return 0; fi
+ if [[ "$*" == *"./..."* ]]; then
+  printf '%s\n' github.com/matrixorigin/matrixone/pkg/{sql/plan,vm/engine/test,vectorindex/hnsw,tests/issues,tests/embedded,light-package,backup}
+ fi
+}
+function list_embedded_cluster_test_packages() { echo github.com/matrixorigin/matrixone/pkg/tests/embedded; }
+function run_engine_race_shards() { printf 'engine\n' > "$ENGINE_RACE_REPORT"; return 0; }
+function run_plan_race_shards() { return 0; }
+trap handle_ut_termination TERM
+run_tests
+[[ "$UT_TEST_STATUS" == 0 ]] || exit 90
+[[ -z "$CURRENT_UT_PID$LIGHT_RACE_JOB_PID$ENGINE_RACE_JOB_PID$PLAN_RACE_JOB_PID" ]] || exit 91
+report=$(cat "$UT_REPORT")
+[[ "$report" == *"$EXPECTED_REPORT"* ]] || { printf 'REPORT=%q\n' "$report"; exit 92; }
+`
+			out, err := scheduleHarnessWithMock(t, script, mock,
+				"UT_PARALLEL_VALUE="+tc.parallel,
+				"UT_OVERLAP_VALUE="+tc.overlap,
+				"EXPECT_OVERLAP="+tc.expectOverlap,
+				"EXPECTED_REPORT="+tc.expected)
+			if err != nil {
+				t.Fatalf("scheduler: %v\n%s", err, out)
+			}
+		})
 	}
 }

--- a/optools/ut_schedule_test.go
+++ b/optools/ut_schedule_test.go
@@ -217,18 +217,36 @@ exit 0
 
 func TestUTHeartbeatStopsCleanly(t *testing.T) {
 	script := `source ./run_ut.sh UT
-function logger() { printf "%s\n" "$2"; }
+function logger() { printf "%s\n" "$2" >> "$CASE_DIR/ut.log"; }
+UT_HEARTBEAT_INTERVAL=60
+start_ut_heartbeat
+before=$(date +%s)
+stop_ut_heartbeat
+after=$(date +%s)
+[[ $((after - before)) -lt 3 ]] || exit 90
+
 UT_HEARTBEAT_INTERVAL=1
 start_ut_heartbeat
+LIGHT_RACE_REPORT="$G_WKSP/${G_TS}-light-race-report.out"
+cat > "$LIGHT_RACE_REPORT" <<'EOF'
+{"Time":"2026-09-10T01:00:01Z","Action":"run","Package":"example/light","Test":"TestPrivate"}
+EOF
+cat > "$G_WKSP/${G_TS}-engine-race-report.out.1" <<'EOF'
+{"Time":"2026-09-10T01:00:01Z","Action":"run","Package":"example/engine","Test":"TestShard"}
+EOF
 sleep 2
 stop_ut_heartbeat
-[[ -z "$UT_HEARTBEAT_PID" ]] || exit 90
+[[ -z "$UT_HEARTBEAT_PID" ]] || exit 91
 grep -q 'event=heartbeat' "$UT_CHECKPOINT"
+grep -q 'active_cases=2' "$CASE_DIR/ut.log"
+grep -q 'TestPrivate' "$CASE_DIR/ut.log"
+grep -q 'TestShard' "$CASE_DIR/ut.log"
 `
-	out, err := scheduleHarnessWithMock(t, script, `#!/bin/bash
+	mock := `#!/bin/bash
 if [[ "$1" == version ]]; then exit 0; fi
 exit 0
-`)
+	`
+	out, err := scheduleHarnessWithMock(t, script, mock)
 	if err != nil {
 		t.Fatalf("heartbeat lifecycle: %v\n%s", err, out)
 	}

--- a/optools/ut_schedule_test.go
+++ b/optools/ut_schedule_test.go
@@ -48,7 +48,7 @@ func scheduleHarnessWithMock(t *testing.T, script, mock string, variables ...str
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{"run_ut.sh", "utilities.sh", "ut_tools.bash", "ut_process.bash", "active_ut_cases.awk"} {
+	for _, name := range []string{"run_ut.sh", "utilities.sh", "ut_tools.bash", "ut_process.bash", "active_ut_cases.awk", "summarize_ut_slow_cases.py"} {
 		data, err := os.ReadFile(name)
 		if err != nil {
 			t.Fatal(err)
@@ -181,6 +181,56 @@ kill -TERM "$$"
 	}
 	if !strings.HasSuffix(string(out), "CANCEL_REPORT\nheavy-start\nheavy-stopped\nplan-start\nplan-stopped\nengine\n") {
 		t.Fatalf("writer was not stopped before merging: %s", out)
+	}
+}
+
+func TestCancellationReportsCompletedSlowCases(t *testing.T) {
+	script := `source ./run_ut.sh UT
+function logger() { printf "%s\n" "$2"; }
+UT_REPORT="$CASE_DIR/report.json"
+UT_DIAGNOSTIC_DIR="$CASE_DIR/diagnostics"
+mkdir -p "$UT_DIAGNOSTIC_DIR"
+cat > "$UT_REPORT" <<'EOF'
+{"Time":"2026-09-10T01:00:01Z","Action":"run","Package":"example/slow","Test":"TestSlow"}
+{"Time":"2026-09-10T01:00:04Z","Action":"pass","Package":"example/slow","Test":"TestSlow","Elapsed":3.5}
+{"Time":"2026-09-10T01:00:05Z","Action":"run","Package":"example/slow","Test":"TestBlocked"}
+EOF
+trap handle_ut_termination TERM
+set +e
+( handle_ut_termination )
+status=$?
+set -e
+[[ "$status" == 143 ]] || exit 90
+[[ -s "$UT_DIAGNOSTIC_DIR/top.txt" ]] || exit 91
+[[ -s "$UT_DIAGNOSTIC_DIR/ut-report.json" ]] || exit 92
+[[ -s "$UT_DIAGNOSTIC_DIR/ut-checkpoint.log" ]] || exit 93
+grep -q 'TestSlow' "$UT_DIAGNOSTIC_DIR/top.txt"
+`
+	out, err := scheduleHarnessWithMock(t, script, `#!/bin/bash
+if [[ "$1" == version ]]; then exit 0; fi
+exit 0
+`)
+	if err != nil {
+		t.Fatalf("cancellation diagnostics: %v\n%s", err, out)
+	}
+}
+
+func TestUTHeartbeatStopsCleanly(t *testing.T) {
+	script := `source ./run_ut.sh UT
+function logger() { printf "%s\n" "$2"; }
+UT_HEARTBEAT_INTERVAL=1
+start_ut_heartbeat
+sleep 2
+stop_ut_heartbeat
+[[ -z "$UT_HEARTBEAT_PID" ]] || exit 90
+grep -q 'event=heartbeat' "$UT_CHECKPOINT"
+`
+	out, err := scheduleHarnessWithMock(t, script, `#!/bin/bash
+if [[ "$1" == version ]]; then exit 0; fi
+exit 0
+`)
+	if err != nil {
+		t.Fatalf("heartbeat lifecycle: %v\n%s", err, out)
 	}
 }
 

--- a/optools/ut_tools_test.go
+++ b/optools/ut_tools_test.go
@@ -575,6 +575,43 @@ func TestSummarizeUTSetupReportsCumulativePhases(t *testing.T) {
 	}
 }
 
+func TestSummarizeUTSlowCasesReportsCompletedPrefix(t *testing.T) {
+	scriptPath, err := filepath.Abs("summarize_ut_slow_cases.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportPath := filepath.Join(t.TempDir(), "ut.json")
+	report := strings.Join([]string{
+		`{"Time":"2026-09-10T01:00:00Z","Action":"start","Package":"example/slow"}`,
+		`{"Time":"2026-09-10T01:00:01Z","Action":"run","Package":"example/slow","Test":"TestSlow"}`,
+		`{"Time":"2026-09-10T01:00:04Z","Action":"pass","Package":"example/slow","Test":"TestSlow","Elapsed":3.5}`,
+		`{"Time":"2026-09-10T01:00:05Z","Action":"run","Package":"example/slow","Test":"TestActive"}`,
+		`{"Time":"2026-09-10T01:00:06Z","Action":"pass","Package":"example/slow","Elapsed":6.0}`,
+		`not json`,
+	}, "\n")
+	reportBytes := append([]byte(report), '\n', 0xff, '\n')
+	if err := os.WriteFile(reportPath, reportBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command("python3", scriptPath, reportPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("summarize slow UT cases: %v\n%s", err, output)
+	}
+	text := string(output)
+	if !strings.Contains(text, "[slow_ut_cases] elapsed=3.50s result=pass package=example/slow test=TestSlow") {
+		t.Fatalf("completed case missing: %s", text)
+	}
+	if strings.Contains(text, "TestActive") {
+		t.Fatalf("incomplete case was reported as completed: %s", text)
+	}
+	if !strings.Contains(text, "[slow_ut_cases] elapsed=6.00s result=pass package=example/slow ended=2026-09-10T01:00:06+00:00") {
+		t.Fatalf("completed package missing: %s", text)
+	}
+	if !strings.Contains(text, "ignored malformed JSON lines=2") {
+		t.Fatalf("truncated report warning missing: %s", text)
+	}
+}
+
 func writeScopeFixture(t *testing.T, root, name, contents string) {
 	t.Helper()
 


### PR DESCRIPTION
## Problem

The single-runner race UT job can hit its outer timeout while the log only shows the last foreground line. A partial run needs to tell us which stage was active, which cases completed slowly, which cases were still active, and where the raw evidence is stored.

## Change

- Keep the bounded single-runner UT schedule: HNSW completes first, light runs in a private report helper, and the issues package may overlap only through the explicit opt-in path (`UT_OVERLAP_LIGHT=0` remains the default).
- Emit an append-only checkpoint for stage, package, process, admission, cancellation, and report ownership events.
- Emit a bounded heartbeat every 60 seconds with current stage/label, active cases discovered from foreground and helper/shard reports, process count, and cgroup memory current/peak.
- On timeout, cancellation, or test failure, preserve the partial Go JSON stream, checkpoint, stderr, and a top-20 summary of completed slow tests/packages. Active/incomplete cases are reported separately; truncated UTF-8/JSON lines do not discard the preceding events.
- Stop child process groups and the heartbeat with bounded waits before collecting diagnostics; preserve helper reports until their single-owner merge succeeds.
- Add scheduler, cancellation, parser, and heartbeat tests. A companion CI workflow change uploads `ut-report` and the raw `scratch/*-UT-Report.out` files on failed/cancelled jobs for download (matrixorigin/CI#449).

## Validation

- `bash -n optools/run_ut.sh`
- `python3 -m py_compile optools/summarize_ut_slow_cases.py`
- `go test ./optools -count=1`
- `go test -race ./optools -count=1`
- `git diff --check`

The scheduler change is opt-in until a same-runner A/B proves wall-time and resource benefit. The diagnostic path is active for all UT runs and does not change test coverage or the authoritative test result.
