### PR TITLE
fix(lockservice): keep owner discovery absence non-fatal

### DIFF
--- a/docs/design/evidence/27707_dn_inactive_expiry.md
+++ b/docs/design/evidence/27707_dn_inactive_expiry.md
@@ -17,7 +17,13 @@ inventory has no lock endpoint for the owner UUID, the cleaner stops network
 probes, backend resets and repeated missing-owner error logs. Each sweep checks
 the local periodically refreshed inventory again, so reappearance is not
 permanently suppressed. This is an unknown observation, not an authoritative
-negative response: admission fencing and cannot-commit state remain protected.
+negative response. It does not create a new admission fence: existing fences
+and cannot-commit state remain protected. The allocator creates a new fence
+only for an exact bind retirement, an explicit invalidation, or bounded
+connection-failure confirmation. For absent owners it records a separate
+cleanup-only first-observed timestamp; that marker never rejects admission,
+is cleared by positive owner evidence, and expires with the retained
+controller state.
 Generic connection errors for owners still in inventory retain the existing
 three-attempt recovery budget. No wire format or public configuration changes.
 
@@ -44,15 +50,20 @@ with `Valid`, `AddCannotCommit`, `FinishCommit`, and `Resume` as consumers.
 - Missing-owner detection uses raw membership, not public SQL admission, so a
   pending-admission CN is still reachable for recovery. It neither refreshes
   discovery nor resets a connection. An existing bounded-label recovery counter
-  gains `result="owner-absent"`; no per-owner series or growing cache is added.
-- The absent observation follows the same ctl/epoch validation as failed RPCs.
-  Resume racing this observation cannot be overwritten by stale re-fencing.
+  gains `result="owner-absent"`; a bounded per-service cleanup-only marker is
+  retained until positive evidence or expiry, without becoming a metric series.
+- A missing-owner observation never mutates admission state. Retirement fencing
+  is performed atomically with exact bind removal, while an existing marker and
+  its ctl/epoch protections remain subject to Resume and expiry.
+- Timeout retirement carries the controller identity and recovery epoch sampled
+  with the bind generation. Resume or controller replacement therefore wins
+  over a stale validation result.
 
 | Audit | Owner / termination |
 |---|---|
 | Q1 cleanup ownership | Allocator removes the exact ctl only when empty; stale snapshots cannot remove a replacement. |
 | Q2 waits | No network operation under cleanup locks; missing endpoints skip RPC/reset immediately. Other owners retain the existing three-attempt RPC budget and context cancellation. |
-| Q3 retained state | Stable disconnect timestamp makes retention reachable; transaction and persistent-Commit protections keep their independent terminal conditions. Sweep maps are temporary and proportional to service count. |
+| Q3 retained state | Stable disconnect/absence timestamps make retention reachable; transaction and persistent-Commit protections keep their independent terminal conditions. At most one cleanup-only marker is kept per observed service; it may outlive an emptied controller, but positive evidence or retention expiry removes it. |
 
 ## Deterministic evidence
 
@@ -90,9 +101,10 @@ repository analyzer completed. `git diff --check` passed.
 
 The supplemental missing-owner regressions cover 45 deterministic sweeps
 (equivalent to 15 minutes of default cadence): zero sends, zero resets, zero
-ERROR logs, one initial state-transition INFO log, with the cannot-commit
-tombstone still present and admission rejected. Membership reappearance allows
-the very next sweep to send; Resume permits new commits. Subsequent absence
+ERROR logs and no admission-state transition, with the cannot-commit
+tombstone still present without inventing a new admission fence. Membership
+reappearance allows the very next sweep to send; Resume permits new commits.
+Subsequent absence
 still allows local expiry. A separate callback interleaving verifies stale
 absence cannot re-fence a resumed owner. The pending-admission raw-inventory
 RPC regression also checks this preflight path.
@@ -107,6 +119,15 @@ selecting count=100 for each under the 30-second per-test budget. Each exact tes
 then passed its separate race-stress command (5.099/4.753/1.867s including harness
 overhead). A grouped 100-repeat run also passed (10.395s), but is supplemental
 rather than a substitute for the individual selections.
+
+This follow-up additionally covers the owner-discovery startup gap: absent
+membership leaves admission open while retaining a cleanup-only timestamp;
+positive admission/heartbeat clears it, and a later absent sweep expires a
+controller that has no allocator bind. Bind retirement tests cover generation
+zero and post-keepalive binds, and a validation/Resume interleaving proves that
+stale timeout evidence cannot remove or re-fence a resumed bind. These tests
+also verify that an existing inactive fence remains authoritative and that an
+absent observation does not clear its orphan tombstone.
 
 ## Real-service validation
 

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -45,9 +45,10 @@ const (
 	getActiveTxnRetryDelay  = 100 * time.Millisecond
 )
 
-// Local cleaner observation, never sent on the wire. An absent owner still
-// needs admission fencing and retained commit state, but has no endpoint to
-// probe/reset until the periodically refreshed membership view contains it.
+// Local cleaner observation, never sent on the wire. An absent owner has no
+// endpoint to probe/reset until the periodically refreshed membership view
+// contains it. Absence is not, by itself, proof that a newly admitted owner
+// has retired; the allocator's bind lifecycle supplies that evidence.
 var errActiveTxnOwnerAbsent = moerr.NewInternalErrorNoCtx("active txn owner absent from cluster inventory")
 
 type lockTableAllocator struct {
@@ -60,12 +61,16 @@ type lockTableAllocator struct {
 	server          Server
 	client          Client
 	inactiveService sync.Map // lock service id -> inactive time
-	inactiveMu      sync.RWMutex
-	ctl             sync.Map // lock service id -> *commitCtl
-	ctlMu           sync.RWMutex
-	allocatorID     string
-	closeOnce       sync.Once
-	closeErr        error
+	// ownerAbsentSince records a cleanup-only absence observation. It never
+	// participates in admission; unlike inactiveService, it cannot reject a
+	// commit. A positive bind/heartbeat or a resumed owner clears the marker.
+	ownerAbsentSince sync.Map // lock service id -> first observed absence time
+	inactiveMu       sync.RWMutex
+	ctl              sync.Map // lock service id -> *commitCtl
+	ctlMu            sync.RWMutex
+	allocatorID      string
+	closeOnce        sync.Once
+	closeErr         error
 	// version is the allocator process epoch. It is set once when the
 	// allocator is constructed; production code must not mutate it at runtime.
 	version uint64
@@ -149,6 +154,7 @@ func (l *lockTableAllocator) Get(
 	if binds == nil {
 		binds = l.registerService(serviceID)
 	}
+	l.markServicePresent(serviceID)
 	return l.registerBind(binds, group, tableID, originTableID, sharding)
 }
 
@@ -157,7 +163,11 @@ func (l *lockTableAllocator) KeepLockTableBind(serviceID string) bool {
 	if b == nil {
 		return false
 	}
-	return b.active()
+	active := b.active()
+	if active {
+		l.markServicePresent(serviceID)
+	}
+	return active
 }
 
 func (l *lockTableAllocator) AddCannotCommit(values []pb.OrphanTxn) [][]byte {
@@ -236,6 +246,57 @@ func (l *lockTableAllocator) markServiceInactive(
 	return true
 }
 
+// markServiceInactiveAtGenerationLocked records a retirement fence while the
+// allocator mutex is held by the caller. The lock order is l.mu -> ctlMu ->
+// inactiveMu, matching Valid's admission path. The controller identity and
+// recovery epoch are validation-time evidence: a timeout result captured before
+// Resume, controller replacement, or recovery-epoch rollover must not fence the
+// resumed incarnation. Keeping the check and fence in the same critical
+// section as bind removal prevents a commit from entering after retirement but
+// before the inactive marker is visible.
+func (l *lockTableAllocator) markServiceInactiveAtGenerationLocked(
+	serviceID string,
+	expectedCtl *commitCtl,
+	expectedRecoveryEpoch uint64,
+) bool {
+	l.ctlMu.Lock()
+	defer l.ctlMu.Unlock()
+	current, exists := l.ctl.Load(serviceID)
+	if expectedCtl == nil {
+		// No controller existed when the timeout was sampled. A controller
+		// created while the validation RPC was in flight is newer positive
+		// lifecycle evidence; leave the bind for the next timeout sweep.
+		if exists {
+			return false
+		}
+	} else if !exists || current != expectedCtl ||
+		expectedRecoveryEpoch == math.MaxUint64 ||
+		expectedCtl.currentRecoveryEpoch() != expectedRecoveryEpoch {
+		return false
+	}
+	l.inactiveMu.Lock()
+	defer l.inactiveMu.Unlock()
+	l.inactiveService.LoadOrStore(serviceID, time.Now())
+	return true
+}
+
+func (l *lockTableAllocator) markServiceAbsent(serviceID string) {
+	l.inactiveMu.Lock()
+	defer l.inactiveMu.Unlock()
+	l.ownerAbsentSince.LoadOrStore(serviceID, time.Now())
+}
+
+func (l *lockTableAllocator) markServicePresent(serviceID string) {
+	// Valid is on the commit-admission hot path. Avoid taking the mutex for the
+	// common case where no cleanup-only absence marker exists.
+	if _, ok := l.ownerAbsentSince.Load(serviceID); !ok {
+		return
+	}
+	l.inactiveMu.Lock()
+	defer l.inactiveMu.Unlock()
+	l.ownerAbsentSince.Delete(serviceID)
+}
+
 func (l *lockTableAllocator) resumeService(serviceID string) {
 	l.ctlMu.RLock()
 	defer l.ctlMu.RUnlock()
@@ -244,6 +305,7 @@ func (l *lockTableAllocator) resumeService(serviceID string) {
 	defer l.inactiveMu.Unlock()
 	ctl.advanceRecoveryEpoch()
 	l.inactiveService.Delete(serviceID)
+	l.ownerAbsentSince.Delete(serviceID)
 }
 
 func (l *lockTableAllocator) Valid(
@@ -274,6 +336,10 @@ func (l *lockTableAllocator) Valid(
 	if len(invalid) > 0 {
 		return invalid, nil
 	}
+	// A successful admission is positive lifecycle evidence even when this CN
+	// has not sent its first keepalive yet. Clear only the cleanup-only absence
+	// marker; an explicit/validated inactive fence remains authoritative below.
+	l.markServicePresent(serviceID)
 
 	// Admission and commit registration must be atomic with respect to fencing.
 	// Otherwise cleanup can mark the service inactive after this check but
@@ -429,12 +495,15 @@ func (l *lockTableAllocator) disableTableBindsLocked(b *serviceBinds) {
 }
 
 // disableTableBindsAtGeneration commits validation evidence only if it still
-// describes the serviceBinds object and keepalive generation sampled by
-// getTimeoutBinds. A successful keepalive after that snapshot is newer positive
+// describes the serviceBinds object, keepalive generation, and controller
+// recovery incarnation sampled by getTimeoutBinds. A successful keepalive,
+// Resume, or controller replacement after that snapshot is newer positive
 // evidence and must win over the stale validation result.
 func (l *lockTableAllocator) disableTableBindsAtGeneration(
 	b *serviceBinds,
 	keepaliveGeneration uint64,
+	expectedCtl *commitCtl,
+	expectedRecoveryEpoch uint64,
 ) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -444,6 +513,17 @@ func (l *lockTableAllocator) disableTableBindsAtGeneration(
 	b.Lock()
 	defer b.Unlock()
 	if b.keepaliveGeneration != keepaliveGeneration {
+		return false
+	}
+	// Validation has now confirmed that this exact allocator bind retired.
+	// Establish the service-level fence before deleting the bind, including for
+	// generation zero: a bind can be handed out before its first keepalive and
+	// its owner may already have admitted a transaction without a table list.
+	if !l.markServiceInactiveAtGenerationLocked(
+		b.serviceID,
+		expectedCtl,
+		expectedRecoveryEpoch,
+	) {
 		return false
 	}
 	b.disableLocked()
@@ -506,11 +586,15 @@ func (l *lockTableAllocator) getServiceBindsWithoutPrefix(serviceID string) *ser
 type timedOutServiceBinds struct {
 	binds               *serviceBinds
 	keepaliveGeneration uint64
+	ctl                 *commitCtl
+	recoveryEpoch       uint64
 }
 
 func (l *lockTableAllocator) getTimeoutBinds(now time.Time) []timedOutServiceBinds {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
+	l.ctlMu.RLock()
+	defer l.ctlMu.RUnlock()
 
 	var values []timedOutServiceBinds
 	for _, b := range l.mu.services {
@@ -518,9 +602,17 @@ func (l *lockTableAllocator) getTimeoutBinds(now time.Time) []timedOutServiceBin
 			now,
 			l.keepBindTimeout*keepBindGraceFactor,
 		); ok {
+			var ctl *commitCtl
+			var recoveryEpoch uint64
+			if value, exists := l.ctl.Load(b.serviceID); exists {
+				ctl = value.(*commitCtl)
+				recoveryEpoch = ctl.currentRecoveryEpoch()
+			}
 			values = append(values, timedOutServiceBinds{
 				binds:               b,
 				keepaliveGeneration: generation,
+				ctl:                 ctl,
+				recoveryEpoch:       recoveryEpoch,
 			})
 		}
 	}
@@ -708,6 +800,8 @@ func (l *lockTableAllocator) validateTimeoutBinds(
 			l.disableTableBindsAtGeneration(
 				b,
 				timeoutBind.keepaliveGeneration,
+				timeoutBind.ctl,
+				timeoutBind.recoveryEpoch,
 			)
 		}
 	}
@@ -801,6 +895,13 @@ func (l *lockTableAllocator) cleanCommitStateOnce(
 		snapshots[sid] = snapshot
 		return true
 	})
+	l.ownerAbsentSince.Range(func(key, value any) bool {
+		sid := key.(string)
+		snapshot := snapshots[sid]
+		snapshot.ownerAbsentAt = value.(time.Time)
+		snapshots[sid] = snapshot
+		return true
+	})
 	l.inactiveMu.RUnlock()
 	l.ctlMu.RUnlock()
 
@@ -831,12 +932,14 @@ func (l *lockTableAllocator) cleanCommitStateOnce(
 						break
 					}
 					activeTxnMap[sid] = nil
+					l.markServicePresent(sid)
 				} else {
 					m := make(map[string]struct{}, len(actives))
 					for _, txn := range actives {
 						m[util.UnsafeBytesToString(txn)] = struct{}{}
 					}
 					activeTxnMap[sid] = m
+					l.markServicePresent(sid)
 				}
 				break
 			}
@@ -848,11 +951,12 @@ func (l *lockTableAllocator) cleanCommitStateOnce(
 				return
 			}
 			if errors.Is(err, errActiveTxnOwnerAbsent) {
-				if l.markServiceInactive(sid, snapshot.ctl, snapshot.recoveryEpoch, true) &&
-					snapshot.inactiveAt.IsZero() {
-					l.logger.Info("active txn owner absent; retaining commit fences",
-						zap.String("serviceID", sid))
-				}
+				// Membership absence is an unknown observation. It may be the
+				// startup gap between allocator admission and HAKeeper's first
+				// inventory publication, so it must not create an inactive fence.
+				l.markServiceAbsent(sid)
+				// A confirmed bind retirement records the fence atomically in
+				// disableTableBindsAtGeneration; existing markers remain intact.
 				// Membership is checked again next sweep. Do not retry/reset an
 				// endpoint that does not exist, or emit the same error each sweep.
 				break
@@ -908,6 +1012,7 @@ type commitCleanupSnapshot struct {
 	generation    uint64
 	recoveryEpoch uint64
 	inactiveAt    time.Time
+	ownerAbsentAt time.Time
 }
 
 // applyCommitCleanup requires ctlMu exclusively. Expiry and state cleanup are
@@ -937,7 +1042,18 @@ func (l *lockTableAllocator) applyCommitCleanup(
 	if isInactive && inactive.(time.Time) != snapshot.inactiveAt {
 		return
 	}
-	expired := isInactive && time.Since(snapshot.inactiveAt) > retention
+	ownerAbsent, isOwnerAbsent := l.ownerAbsentSince.Load(sid)
+	// An absent-observation marker created after the snapshot is a newer
+	// lifecycle observation. Do not let an older RPC result reap its state.
+	if isOwnerAbsent && ownerAbsent.(time.Time) != snapshot.ownerAbsentAt {
+		return
+	}
+	// A disconnect fence and a cleanup-only absence marker each retain state for
+	// their own lifetime. Expiry is safe only after every marker currently
+	// protecting this controller has expired.
+	inactiveExpired := !isInactive || time.Since(snapshot.inactiveAt) > retention
+	ownerAbsentExpired := !isOwnerAbsent || time.Since(snapshot.ownerAbsentAt) > retention
+	expired := (isInactive || isOwnerAbsent) && inactiveExpired && ownerAbsentExpired
 	if c != nil {
 		// In-flight commits and persistent unknown-commit fences retain their
 		// independent lifetime protections in clean, even after disconnect expiry.
@@ -948,6 +1064,7 @@ func (l *lockTableAllocator) applyCommitCleanup(
 	}
 	if expired {
 		l.inactiveService.Delete(sid)
+		l.ownerAbsentSince.Delete(sid)
 		l.logger.Info("remove inactive service", zap.String("serviceID", sid))
 	}
 }

--- a/pkg/lockservice/lock_table_allocator_recovery_test.go
+++ b/pkg/lockservice/lock_table_allocator_recovery_test.go
@@ -81,19 +81,26 @@ func TestAbsentActiveTxnOwnerQuiescesUntilMembershipReturns(t *testing.T) {
 		require.Equal(t, 45, tracking.checks)
 		require.Zero(t, tracking.sends)
 		require.Zero(t, tracking.resets.Load())
-		require.Equal(t, 1, logs.FilterMessage("active txn owner absent; retaining commit fences").Len())
+		require.Zero(t, logs.FilterMessage("active txn owner absent; retaining commit fences").Len())
 		require.Zero(t, logs.FilterLevelExact(zap.ErrorLevel).Len())
-		require.True(t, a.HasInvalidService(sid))
+		require.False(t, a.HasInvalidService(sid), "membership absence is not retirement evidence")
+		_, absent := a.ownerAbsentSince.Load(sid)
+		require.True(t, absent, "absence still needs a bounded cleanup lifecycle")
 		_, exists := ctl.getCommitState("orphan")
 		require.True(t, exists, "absence must not stand in for a negative GetActiveTxn response")
 		_, err := a.Valid(sid, []byte("late"), nil)
-		require.True(t, moerr.IsMoErrCode(err, moerr.ErrCannotCommitOnInvalidCN))
+		require.NoError(t, err, "unknown membership must not fence a new owner")
+		_, absent = a.ownerAbsentSince.Load(sid)
+		require.False(t, absent, "admission itself is positive owner evidence")
+		a.FinishCommit(sid, []byte("late"))
 
 		tracking.inventory.cluster.AddCN(metadata.CNService{
 			ServiceID: "departed", LockServiceAddress: "restored:1234",
 		})
 		a.cleanCommitStateOnce(context.Background(), a.getActiveTxn, time.Hour)
 		require.Equal(t, 1, tracking.sends, "membership restoration must allow the next sweep to probe")
+		_, absent = a.ownerAbsentSince.Load(sid)
+		require.False(t, absent, "a successful owner probe clears cleanup-only absence")
 		_, exists = ctl.getCommitState("orphan")
 		require.True(t, exists)
 		a.resumeService(sid)
@@ -103,7 +110,10 @@ func TestAbsentActiveTxnOwnerQuiescesUntilMembershipReturns(t *testing.T) {
 
 		tracking.inventory.cluster.RemoveCN("departed")
 		a.inactiveService.Store(sid, time.Now().Add(-2*time.Hour))
-		a.cleanCommitStateOnce(context.Background(), a.getActiveTxn, time.Hour)
+		a.cleanCommitStateOnce(context.Background(), a.getActiveTxn, time.Nanosecond)
+		// The first absent observation starts the cleanup-only marker. The next
+		// sweep observes both old markers and performs their expiry transition.
+		a.cleanCommitStateOnce(context.Background(), a.getActiveTxn, time.Nanosecond)
 		_, exists = a.ctl.Load(sid)
 		require.False(t, exists, "skipping network probes must not skip local expiry")
 		require.False(t, a.HasInvalidService(sid))
@@ -319,6 +329,226 @@ func TestCleanCommitStateExpiryDoesNotRequireSuccessfulProbe(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAbsentActiveTxnOwnerKeepsPendingBindUnknown(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		for _, serviceID := range []string{"pending-owner", "live-owner"} {
+			a.Get(serviceID, 0, 1, 0, pb.Sharding_None)
+			if serviceID == "live-owner" {
+				require.True(t, a.KeepLockTableBind(serviceID))
+			}
+			ctl := a.getCtl(serviceID)
+			require.Equal(t, cannotCommitState, ctl.tryCannotCommit("orphan"))
+
+			a.cleanCommitStateOnce(context.Background(), func(context.Context, string) (bool, [][]byte, error) {
+				return false, nil, errActiveTxnOwnerAbsent
+			}, time.Hour)
+
+			require.False(t, a.HasInvalidService(serviceID),
+				"a bind without a published membership record is still pending")
+			_, err := a.Valid(serviceID, []byte("orphan"), nil)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrCannotCommitOrphan),
+				"absence must not erase the orphan tombstone")
+			_, err = a.Valid(serviceID, []byte("new"), nil)
+			require.NoError(t, err)
+			a.FinishCommit(serviceID, []byte("new"))
+		}
+	})
+}
+
+func TestAbsentActiveTxnOwnerPreservesExistingFence(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		const serviceID = "already-fenced"
+		ctl := a.getCtl(serviceID)
+		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("orphan"))
+		a.AddInvalidService(serviceID)
+
+		a.cleanCommitStateOnce(context.Background(), func(context.Context, string) (bool, [][]byte, error) {
+			return false, nil, errActiveTxnOwnerAbsent
+		}, time.Hour)
+
+		require.True(t, a.HasInvalidService(serviceID),
+			"an unknown observation must not clear an existing fence")
+		_, err := a.Valid(serviceID, []byte("new"), nil)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrCannotCommitOnInvalidCN))
+	})
+}
+
+func TestAbsentActiveTxnOwnerCleanupOnlyStateExpires(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		const serviceID = "never-published-owner"
+		ctl := a.getCtl(serviceID)
+		require.Equal(t, cannotCommitState, ctl.tryCannotCommit("orphan"))
+		probe := func(context.Context, string) (bool, [][]byte, error) {
+			return false, nil, errActiveTxnOwnerAbsent
+		}
+
+		// The first absent observation starts a cleanup-only retention window. It
+		// must not fence admission, and it is not eligible for same-sweep expiry.
+		a.cleanCommitStateOnce(context.Background(), probe, time.Hour)
+		require.False(t, a.HasInvalidService(serviceID))
+		_, exists := a.ownerAbsentSince.Load(serviceID)
+		require.True(t, exists)
+
+		// Backdate the marker created by the real absent transition instead of
+		// relying on a sub-microsecond sleep to cross the retention boundary.
+		a.inactiveMu.Lock()
+		a.ownerAbsentSince.Store(serviceID, time.Now().Add(-2*time.Hour))
+		a.inactiveMu.Unlock()
+		// The following sweep may reap the controller once the bounded retention
+		// has elapsed, even though no allocator bind was ever published.
+		a.cleanCommitStateOnce(context.Background(), probe, time.Hour)
+		_, exists = a.ctl.Load(serviceID)
+		require.False(t, exists)
+		_, exists = a.ownerAbsentSince.Load(serviceID)
+		require.False(t, exists)
+	})
+}
+
+type resumeDuringValidationClient struct {
+	Client
+	allocator *lockTableAllocator
+	serviceID string
+}
+
+func (c *resumeDuringValidationClient) Send(
+	context.Context,
+	*pb.Request,
+) (*pb.Response, error) {
+	resp := acquireResponse()
+	resp.ValidateService.OK = false
+	return resp, nil
+}
+
+func (c *resumeDuringValidationClient) ResetValidationBackend(
+	context.Context,
+	string,
+) error {
+	c.allocator.resumeService(c.serviceID)
+	return nil
+}
+
+func (c *resumeDuringValidationClient) Close() error { return nil }
+
+func TestTimeoutRetirementCannotRefenceAfterResume(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		const serviceID = "resume-during-retirement"
+		const tableID = uint64(1)
+		a.Get(serviceID, 0, tableID, 0, pb.Sharding_None)
+		binds := a.getServiceBinds(serviceID)
+		ctl := a.getCtl(serviceID)
+		ctl.tryCannotCommit("orphan")
+		binds.Lock()
+		binds.lastKeepaliveTime = time.Now().Add(-3 * time.Hour)
+		binds.Unlock()
+
+		client := &resumeDuringValidationClient{allocator: a, serviceID: serviceID}
+		require.NoError(t, a.client.Close())
+		a.client = client
+		timeoutBinds := a.getTimeoutBinds(time.Now())
+		require.Len(t, timeoutBinds, 1)
+		require.Same(t, ctl, timeoutBinds[0].ctl)
+		require.True(t, a.validateTimeoutBinds(context.Background(), timeoutBinds))
+		require.Same(t, binds, a.getServiceBinds(serviceID),
+			"a stale timeout result must not remove a resumed bind")
+		require.False(t, binds.disabled)
+		require.False(t, a.HasInvalidService(serviceID),
+			"a stale timeout result must not re-fence a resumed owner")
+	})
+}
+
+func TestTimeoutRetirementRejectsNewControllerEvidence(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		prepare := func(serviceID string, tableID uint64, createCtl, saturateEpoch bool) (timedOutServiceBinds, *serviceBinds) {
+			a.Get(serviceID, 0, tableID, 0, pb.Sharding_None)
+			var ctl *commitCtl
+			if createCtl {
+				ctl = a.getCtl(serviceID)
+				if saturateEpoch {
+					ctl.mu.Lock()
+					ctl.recoveryEpoch = ^uint64(0)
+					ctl.mu.Unlock()
+				}
+			}
+			binds := a.getServiceBinds(serviceID)
+			binds.Lock()
+			binds.lastKeepaliveTime = time.Now().Add(-3 * time.Hour)
+			binds.Unlock()
+			timeoutBinds := a.getTimeoutBinds(time.Now())
+			for _, timeoutBind := range timeoutBinds {
+				if timeoutBind.binds == binds {
+					return timeoutBind, binds
+				}
+			}
+			t.Fatalf("timed-out bind %q was not captured", serviceID)
+			return timedOutServiceBinds{}, binds
+		}
+
+		t.Run("controller-created-after-snapshot", func(t *testing.T) {
+			timedOut, binds := prepare("controller-created-after-snapshot", 1, false, false)
+			require.Nil(t, timedOut.ctl)
+			a.getCtl(binds.serviceID)
+			require.False(t, a.disableTableBindsAtGeneration(
+				binds, timedOut.keepaliveGeneration, timedOut.ctl, timedOut.recoveryEpoch))
+			require.Same(t, binds, a.getServiceBinds(binds.serviceID))
+			require.False(t, a.HasInvalidService(binds.serviceID))
+		})
+
+		t.Run("controller-replaced-after-snapshot", func(t *testing.T) {
+			timedOut, binds := prepare("controller-replaced-after-snapshot", 2, true, false)
+			oldCtl := timedOut.ctl
+			require.NotNil(t, oldCtl)
+			a.ctlMu.Lock()
+			a.ctl.Delete(binds.serviceID)
+			a.getCtl(binds.serviceID)
+			a.ctlMu.Unlock()
+			require.False(t, a.disableTableBindsAtGeneration(
+				binds, timedOut.keepaliveGeneration, oldCtl, timedOut.recoveryEpoch))
+			require.Same(t, binds, a.getServiceBinds(binds.serviceID))
+			require.False(t, a.HasInvalidService(binds.serviceID))
+		})
+
+		t.Run("recovery-epoch-saturated", func(t *testing.T) {
+			timedOut, binds := prepare("recovery-epoch-saturated", 3, true, true)
+			ctl := timedOut.ctl
+			require.NotNil(t, ctl)
+			require.Equal(t, ^uint64(0), timedOut.recoveryEpoch)
+			require.False(t, a.disableTableBindsAtGeneration(
+				binds, timedOut.keepaliveGeneration, timedOut.ctl, timedOut.recoveryEpoch))
+			require.Same(t, binds, a.getServiceBinds(binds.serviceID))
+			require.False(t, a.HasInvalidService(binds.serviceID))
+		})
+	})
+}
+
+func TestDisableTableBindsAtGenerationFencesRetiredOwner(t *testing.T) {
+	runLockTableAllocatorTest(t, time.Hour, func(a *lockTableAllocator) {
+		for _, serviceID := range []string{"retired-pending", "retired-live"} {
+			a.Get(serviceID, 0, 1, 0, pb.Sharding_None)
+			binds := a.getServiceBinds(serviceID)
+			if serviceID == "retired-live" {
+				require.True(t, a.KeepLockTableBind(serviceID))
+			}
+			ctl := a.getCtl(serviceID)
+			require.Equal(t, cannotCommitState, ctl.tryCannotCommit("orphan"))
+			generation, timedOut := binds.timeoutSnapshot(time.Now(), 0)
+			require.True(t, timedOut)
+
+			require.True(t, a.disableTableBindsAtGeneration(
+				binds, generation, ctl, ctl.currentRecoveryEpoch()))
+			require.True(t, a.HasInvalidService(serviceID),
+				"validated bind retirement must fence every bind generation")
+			require.Nil(t, a.getServiceBinds(serviceID))
+			_, err := a.Valid(serviceID, []byte("late"), nil)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrCannotCommitOnInvalidCN))
+
+			a.resumeService(serviceID)
+			_, err = a.Valid(serviceID, []byte("new"), nil)
+			require.NoError(t, err)
+			a.FinishCommit(serviceID, []byte("new"))
+		}
+	})
 }
 
 func TestCleanCommitStateExpiryPreservesFreshRecoveryEpoch(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related issue #27707 (follow-up to #28474; startup failure observed while validating #28459)

## What this PR does / why we need it:

The lockservice commit cleaner used a raw HAKeeper membership miss as proof
that a CN was inactive. During CN/HAKeeper startup ordering, the allocator can
already have admitted a bind while the first membership snapshot is not yet
published. The cleaner then installed `inactiveService`, and the next commit
returned `cannot commit an orphan transaction on invalid cn` even though the CN
was live. This is the root cause of the apparently flaky ArrowLoad UT failure;
#28459 itself does not touch this lifecycle code.

This change separates discovery uncertainty from retirement evidence:

* a missing owner is recorded only in a cleanup-only retention marker and never
  fences `Valid`; positive admission, bind keepalive, an authoritative probe,
  or `Resume` clears that marker;
* exact allocator-bind retirement still establishes an admission fence before
  deleting the bind, including generation zero;
* timeout retirement snapshots controller identity and recovery epoch, so a
  stale validation cannot remove or re-fence a bind after `Resume`, controller
  replacement, or epoch saturation;
* the cleanup-only marker gives controllers with no allocator bind a bounded
  expiry path, while existing inactive fences and orphan tombstones remain
  authoritative.

### Test plan

* `GOTMPDIR=/home/xupeng/go-tmp ./.agents/skills/mo-dev/scripts/mo-cgo-test -v -count=1 -timeout=180s -run '^TestArrowLoadRolloutRollbackDrain$' ./pkg/tests/arrowload`
* `GOTMPDIR=/home/xupeng/go-tmp ./.agents/skills/mo-dev/scripts/mo-cgo-test -short -count=1 -timeout=360s ./pkg/lockservice`
* `GOTMPDIR=/home/xupeng/go-tmp ./.agents/skills/mo-dev/scripts/mo-cgo-test -short -race -count=1 -timeout=420s ./pkg/lockservice`
* lifecycle and unhappy-path selections (absent owner, pending/live bind,
  orphan/fence preservation, cleanup expiry, Resume interleaving, controller
  creation/replacement, and epoch saturation) passed with `-race -count=100`;
* `golangci-lint run -c .golangci.yml ./pkg/lockservice/...` passed with 0
  issues; `git diff --check` passed.
