### PR TITLE
fix: install prepared Boolean precision rewrites

### DIFF
--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -436,9 +436,9 @@ type ResetParamRefRule struct {
 	// different execute-time overload.
 	preserveRoots        map[*plan.Expr]struct{}
 	validateFunctionArgs func(string, []*Expr) error
-	// specialized is set only when execute-time rebinding changes a function
-	// overload/result type. Literal replacement alone is not enough to require
-	// rebuilding a cached prepared compile.
+	// specialized is set when execute-time rebinding changes the cached plan's
+	// execution semantics, including value-only rewrites whose overload and
+	// result type remain stable.
 	specialized bool
 	// inferTextParamPositions records only the COM_STMT text parameters that may
 	// carry numeric payloads.  Keep this per parameter: enabling inference for
@@ -1958,6 +1958,12 @@ func (rule *ResetParamRefRule) applyExpr(e *plan.Expr) (*plan.Expr, error) {
 			if useSQLExecuteNumericSource {
 				needResetFunction = true
 				compareArgTypes = true
+				// The execute-time source may change only an argument literal while
+				// the selected overload and result type remain stable (for example,
+				// the precision argument of `ROUND(decimal, ?)`).  The copied plan still
+				// contains a different value and must be installed for this execute;
+				// functionBindingChanged cannot observe that value-only change.
+				rule.specialized = true
 				// SourceType already represents the SQL value's numeric contract.
 				// Do not also reinterpret the same argument through the text-prefix
 				// specialization selected for comparisons and common-value peers.

--- a/pkg/sql/plan/visit_plan_rule_test.go
+++ b/pkg/sql/plan/visit_plan_rule_test.go
@@ -1516,6 +1516,33 @@ func TestFillValuesOfParamsInPlanUsesSQLExecuteSourceTypeOnlyInNumericConsumers(
 	require.Equal(t, types.T_int64, types.T(signResult.GetF().Args[0].Typ.Id), signResult.String())
 }
 
+func TestFillValuesOfParamsInstallsValueOnlyNumericSourceRewrite(t *testing.T) {
+	ctx := context.Background()
+	for _, name := range []string{"round", "truncate"} {
+		t.Run(name, func(t *testing.T) {
+			prepared, err := runOneStmt(NewMockOptimizer(false), t,
+				"prepare stmt_precision from 'select "+name+"(1.25, ?)'")
+			require.NoError(t, err)
+			filled, specialized, err := FillValuesOfParamsInPlanWithSpecialization(
+				ctx, prepared.GetDcl().GetPrepare().Plan, []any{ParamValue{
+					Value: "true", SourceType: types.T_bool.ToType(), HasSourceType: true,
+				}})
+			require.NoError(t, err)
+			require.True(t, specialized, filled.String())
+			result := findPlanFunctionExpr(filled, name)
+			require.NotNil(t, result, filled.String())
+			require.Len(t, result.GetF().Args, 2, result.String())
+			require.Equal(t, int32(types.T_int64), result.GetF().Args[1].Typ.Id, result.String())
+			precisionCast := result.GetF().Args[1].GetF()
+			require.NotNil(t, precisionCast, result.String())
+			require.Equal(t, "cast", precisionCast.GetFunc().GetObjName(), result.String())
+			precisionLiteral := precisionCast.Args[0].GetLit()
+			require.NotNil(t, precisionLiteral, result.String())
+			require.True(t, precisionLiteral.GetBval(), result.String())
+		})
+	}
+}
+
 func TestFillValuesOfParamsInPlanUsesSQLExecuteSourceTypeInPreparedResultConsumers(t *testing.T) {
 	ctx := context.Background()
 	for _, test := range []struct {

--- a/pkg/tests/issues/issue_27088_common_type_test.go
+++ b/pkg/tests/issues/issue_27088_common_type_test.go
@@ -67,6 +67,23 @@ func TestIssue27088PreparedDecimalCommonType(t *testing.T) {
 				require.NoError(t, conn.QueryRowContext(ctx, strings.ReplaceAll(integerQuery, "?", value)).Scan(&expected[0], &expected[1], &expected[2], &expected[3], &expected[4]))
 				require.Equal(t, expected, got, value)
 			}
+			for index, query := range []string{
+				"SELECT ROUND(1.25, ?), TRUNCATE(1.25, ?)",
+				"SELECT ROUND(?, 2), TRUNCATE(?, 2)",
+			} {
+				name := fmt.Sprintf("bool_precision_%d", index)
+				mustExec(t, ctx, conn, "PREPARE "+name+" FROM '"+query+"'")
+				for _, value := range []string{"TRUE", "FALSE", "NULL", "1", "0"} {
+					mustExec(t, ctx, conn, "SET @bool_precision = "+value)
+					var got, expected [2]sql.NullFloat64
+					require.NoError(t, conn.QueryRowContext(ctx,
+						"EXECUTE "+name+" USING @bool_precision, @bool_precision").Scan(&got[0], &got[1]))
+					require.NoError(t, conn.QueryRowContext(ctx,
+						strings.ReplaceAll(query, "?", value)).Scan(&expected[0], &expected[1]))
+					require.Equal(t, expected, got, name+" "+value)
+				}
+				mustExec(t, ctx, conn, "DEALLOCATE PREPARE "+name)
+			}
 			mustExec(t, ctx, conn, `PREPARE bool_json FROM 'SELECT ?, JSON_TYPE(JSON_EXTRACT(JSON_ARRAY(?), "$[0]"))'`)
 			defer mustExec(t, ctx, conn, "DEALLOCATE PREPARE bool_json")
 			var direct, jsonKind string


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28484

## What this PR does / why we need it:

SQL `PREPARE`/`EXECUTE` already materializes a Boolean user-variable source for generic numeric functions, but the runtime specialization signal only tracked overload or result-type changes. For `ROUND(1.25, ?)` and `TRUNCATE(1.25, ?)`, the precision argument changes while the selected overload and result type stay stable, so the copied plan was discarded and the cached text-to-integer cast rejected `TRUE`/`FALSE`.

This change marks every SQL-EXECUTE numeric-source rewrite as requiring installation of the copied runtime plan at the shared rebinding boundary. It fixes both argument positions without changing ordinary literal SQL, explicit casts, string-backed parameters, or COM_STMT behavior.

## Test plan

- Added planner coverage proving the value-only rewrite is marked specialized and contains the Boolean-to-int64 precision cast for both `ROUND` and `TRUNCATE`.
- Added embedded-cluster SQL coverage for both marker positions and `TRUE`, `FALSE`, `NULL`, `1`, and `0`; each `EXECUTE ... USING` result is compared with the equivalent direct SQL expression.
- Focused planner test: normal and `-race`.
- Focused issue regression test: normal and `-race`.
- Full `pkg/sql/plan` and `pkg/tests/issues` suites.
- Incremental `go vet` and `golangci-lint` for the owning packages with the repository CGo build environment.
