### PR TITLE
test: cover IVF remote stream lifecycle regressions

### DIFF
--- a/pkg/common/morpc/stream_queued_cancel_test.go
+++ b/pkg/common/morpc/stream_queued_cancel_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fagongzi/goetty/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// Cancellation happens in the writer after queue admission, not before Send.
+// A later cleanup/control request uses a separate live context on the same
+// stream. Neither that request nor an unrelated stream may acquire a gap.
+func TestQueuedStreamCancellationPreservesWireSequence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	queuedCtx, cancelQueued := context.WithCancel(ctx)
+	defer cancelQueued()
+	type frame struct {
+		id       uint64
+		sequence uint32
+	}
+	wire := make(chan frame, 4)
+	var attempts atomic.Int32
+	testBackendSend(t,
+		func(_ goetty.IOSession, value interface{}, _ uint64) error {
+			message := value.(RPCMessage)
+			select {
+			case wire <- frame{message.Message.GetID(), message.streamSequence}:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+		func(b *remoteBackend) {
+			first, err := b.NewStream(false)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, first.Close(false)) }()
+			other, err := b.NewStream(false)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, other.Close(false)) }()
+
+			require.NoError(t, first.Send(ctx, newTestMessage(first.ID())))
+			require.ErrorIs(t, first.Send(queuedCtx, newTestMessage(first.ID())), context.Canceled)
+			require.NoError(t, first.Send(ctx, newTestMessage(first.ID())))
+			require.NoError(t, first.Close(false))
+			require.NoError(t, other.Send(ctx, newTestMessage(other.ID())))
+			next, err := b.NewStream(false)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, next.Close(false)) }()
+			require.NoError(t, next.Send(ctx, newTestMessage(next.ID())))
+			for _, want := range []frame{{first.ID(), 1}, {first.ID(), 2}, {other.ID(), 1}, {next.ID(), 1}} {
+				select {
+				case got := <-wire:
+					require.Equal(t, want, got)
+				case <-ctx.Done():
+					t.Fatal("writer did not deliver the next live stream request")
+				}
+			}
+		},
+		WithBackendBatchSendSize(1),
+		WithBackendFilter(func(Message, string) bool {
+			if attempts.Add(1) == 2 {
+				cancelQueued()
+			}
+			return true
+		}),
+	)
+}

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -1361,6 +1361,63 @@ func TestShuffleContinuesAfterCertifiedStopForOtherMatchedReceivers(t *testing.T
 	require.Same(t, second, d.ctr.remoteReceivers[0])
 }
 
+// Exercise slice compaction at each position, including adjacent removals.
+// A second batch also checks that retired registrations are not notified twice.
+func TestShuffleRetiresMatchedReceiverPositions(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		stopped []bool
+	}{
+		{"first", []bool{true, false, false}},
+		{"middle", []bool{false, true, false}},
+		{"last", []bool{false, false, true}},
+		{"consecutive", []bool{false, true, true, false}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			bat := newDispatchSpoolTestBatch(t, proc.Mp(), 1)
+			t.Cleanup(func() { bat.Clean(proc.Mp()) })
+			ctrl := gomock.NewController(t)
+			d := &Dispatch{ctr: &container{
+				// As in the existing matched-receiver test, use one routing
+				// partition; no local spool participates in this remote test.
+				localRegsCnt:  1,
+				remoteRegsCnt: len(tc.stopped),
+				aliveRegCnt:   1 + len(tc.stopped),
+				remoteToIdx:   make(map[uuid.UUID]int),
+			}}
+			var live, retired []*process.WrapCs
+			for _, stop := range tc.stopped {
+				r := &process.WrapCs{Uid: uuid.Must(uuid.NewV7())}
+				if stop {
+					r.ReceiverDone = true
+					r.ReceiverStopped = func() bool { return true }
+					r.Err = make(chan error, 2)
+					retired = append(retired, r)
+				} else {
+					session := mock_morpc.NewMockClientSession(ctrl)
+					session.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+					r.Cs = session
+					live = append(live, r)
+				}
+				d.ctr.remoteReceivers = append(d.ctr.remoteReceivers, r)
+				d.ctr.remoteToIdx[r.Uid] = 0
+			}
+			for range 2 {
+				done, err := sendBatToMultiMatchedRegOutcome(d, proc, bat, 0)
+				require.NoError(t, err)
+				require.False(t, done)
+				require.Equal(t, live, d.ctr.remoteReceivers)
+				require.Equal(t, len(live), d.ctr.remoteRegsCnt)
+				require.Equal(t, 1+len(live), d.ctr.aliveRegCnt)
+				for _, r := range retired {
+					require.Len(t, r.Err, 1)
+				}
+			}
+		})
+	}
+}
+
 func TestSendBatchRetiresTerminalBackedStopWithoutLegacyChannel(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	wcs := &process.WrapCs{

--- a/pkg/sql/compile/remoterunServer_test.go
+++ b/pkg/sql/compile/remoterunServer_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	mock_lock "github.com/matrixorigin/matrixone/pkg/frontend/test/mock_lock"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -723,6 +725,141 @@ func TestMessageReceiverSendBatchUsesNegotiatedCredits(t *testing.T) {
 	require.Len(t, flow.pending, 1)
 	flow.mu.Unlock()
 	require.NoError(t, flow.acknowledge(sent.GetBatchSequence()))
+}
+
+type observedDoneContext struct {
+	context.Context
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (c *observedDoneContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.entered) })
+	return c.Context.Done()
+}
+
+func TestRemoteNotifyCancellationReleasesCreditWaitAndRegistration(t *testing.T) {
+	for _, connectionClosed := range []bool{false, true} {
+		name := "query"
+		if connectionClosed {
+			name = "connection"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			server := colexec.NewServer("")
+			proc := testutil.NewProcess(t)
+			proc.BuildPipelineContext(context.Background())
+			defer proc.Cancel(context.Canceled)
+			uid := uuid.Must(uuid.NewV7())
+			terminal := colexec.NewRemoteReceiverTerminal(proc.Cancel)
+			notify := make(process.RemotePipelineInformationChannel)
+			require.NoError(t, server.PutProcIntoUuidMapWithTerminal(uid, proc, notify, terminal))
+			defer server.RemoveUuidsOwned([]uuid.UUID{uid}, notify)
+			queryCtx, cancelQuery := context.WithCancel(context.Background())
+			defer cancelQuery()
+			connCtx, cancelConn := context.WithCancel(context.Background())
+			defer cancelConn()
+			var workers sync.WaitGroup
+			defer func() {
+				cancelQuery()
+				cancelConn()
+				proc.Cancel(context.Canceled)
+				workers.Wait()
+			}()
+			session := mock_morpc.NewMockClientSession(ctrl)
+			// The session cleanup goroutine is irrelevant here: the handler must
+			// unregister the stream itself before it returns.
+			session.EXPECT().SessionCtx().Return(connCtx).AnyTimes()
+			session.EXPECT().Close().Return(nil).AnyTimes()
+			lock := mock_lock.NewMockLockService(ctrl)
+			lock.EXPECT().GetConfig().Return(lockservice.Config{}).AnyTimes()
+			var wireError error
+			session.EXPECT().Write(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, m morpc.Message) error {
+				var hasError bool
+				wireError, hasError = m.(*pipeline.Message).TryToGetMoErr()
+				if !hasError {
+					return errors.New("missing cancellation terminal error")
+				}
+				return ctx.Err()
+			}).Times(1)
+			const id = 404
+			handlerDone := make(chan error, 1)
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				handlerDone <- CnServerMessageHandler(queryCtx, "", &pipeline.Message{
+					Id: id, Cmd: pipeline.Method_PrepareDoneNotifyMessage, Uuid: uid[:],
+					RequestedTeardownMode:     pipeline.StreamTeardownMode_FinishAck,
+					RequestedBatchCreditCount: 1, RequestedBatchCreditBytes: 1024,
+				}, session, nil, nil, lock, nil, nil, nil, nil, nil, func() morpc.Message { return &pipeline.Message{} })
+			}()
+			var info *process.WrapCs
+			select {
+			case info = <-notify:
+			case <-time.After(5 * time.Second):
+				t.Fatal("notify did not attach")
+			}
+			require.True(t, info.TerminalBacked)
+			require.Nil(t, info.Err)
+			_, err := info.ReserveBatch(proc.Ctx, 1)
+			require.NoError(t, err)
+			observed := &observedDoneContext{Context: proc.Ctx, entered: make(chan struct{})}
+			sendDone := make(chan error, 1)
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				_, err := info.ReserveBatch(observed, 1)
+				sendDone <- err
+			}()
+			select {
+			case <-observed.entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("sender did not enter credit wait")
+			}
+			if connectionClosed {
+				cancelConn()
+			} else {
+				cancelQuery()
+			}
+			var sendErr, handlerErr error
+			select {
+			case sendErr = <-sendDone:
+			case <-time.After(5 * time.Second):
+				t.Fatal("credit waiter survived cancellation")
+			}
+			select {
+			case handlerErr = <-handlerDone:
+			case <-time.After(5 * time.Second):
+				t.Fatal("handler survived cancellation")
+			}
+			require.Error(t, sendErr)
+			require.Error(t, wireError)
+			if connectionClosed {
+				require.True(t, moerr.IsMoErrCode(wireError, moerr.ErrStreamClosed))
+			} else {
+				require.ErrorIs(t, handlerErr, context.Canceled)
+				require.ErrorIs(t, sendErr, context.Canceled)
+			}
+			require.False(t, info.ReceiverStopped(), "external cancellation is not a certified retirement")
+			_, registered := pipelineStreamLifecycles.Load(pipelineStreamLifecycleKey{session: session, id: id})
+			require.False(t, registered, "handler must release the global credit/lifecycle owner")
+			// The source owns terminal publication; these are the registry cleanup
+			// operations used by RemoteReceiverRegistration.Cleanup. Its dedicated
+			// tests cover the owning handle and pooled-operator reset separately.
+			cause := context.Cause(proc.Ctx)
+			terminal.Finish(cause)
+			for range 2 {
+				server.CloseRemoteReceivers([]uuid.UUID{uid}, notify)
+				server.RemoveUuidsOwned([]uuid.UUID{uid}, notify)
+				terminal.Finish(nil)
+			}
+			require.ErrorIs(t, terminal.Err(), cause)
+			require.ErrorIs(t, context.Cause(proc.Ctx), cause)
+			_, _, registered = server.GetProcByUuid(uid, false)
+			require.False(t, registered)
+			require.NoError(t, handlePipelineBatchAck(&pipeline.Message{Id: id, BatchAckSequence: 1}, session))
+		})
+	}
 }
 
 func TestMessageReceiverSendBatchOldProtocolDropsStringSourceOnly(t *testing.T) {

--- a/pkg/sql/compile/remoterunServer_test.go
+++ b/pkg/sql/compile/remoterunServer_test.go
@@ -836,6 +836,14 @@ func TestRemoteNotifyCancellationReleasesCreditWaitAndRegistration(t *testing.T)
 			require.Error(t, wireError)
 			if connectionClosed {
 				require.True(t, moerr.IsMoErrCode(wireError, moerr.ErrStreamClosed))
+				select {
+				case <-proc.Ctx.Done():
+				default:
+					t.Fatal("connection cancellation did not cancel the owning query")
+				}
+				cause := context.Cause(proc.Ctx)
+				require.Error(t, cause)
+				require.True(t, moerr.IsMoErrCode(cause, moerr.ErrStreamClosed))
 			} else {
 				require.ErrorIs(t, handlerErr, context.Canceled)
 				require.ErrorIs(t, sendErr, context.Canceled)

--- a/pkg/tests/issues/issue_28378_test.go
+++ b/pkg/tests/issues/issue_28378_test.go
@@ -133,7 +133,7 @@ type ivfRunState struct {
 }
 type ivfCase struct {
 	name, col, fn, op, vector string
-	desc                      bool
+	desc, concurrent          bool
 }
 
 func TestIssue28378IVFFlatRemoteLifecycle(t *testing.T) {
@@ -343,10 +343,10 @@ func runIssue28378IVF(t *testing.T, cluster embed.Cluster, state *ivfRunState,
 		}
 
 		cases = []ivfCase{
-			{"l2", "v", "l2_distance", "vector_l2_ops", queryVector, false},
-			{"cosine", "v", "cosine_distance", "vector_cosine_ops", queryVector, false},
-			{"normalized_l2", "n", "l2_distance", "vector_l2_ops", normalizedQuery, false},
-			{"ip_normalized", "v", "inner_product", "vector_ip_ops", "normalize_l2(" + queryVector + ")", false},
+			{"l2", "v", "l2_distance", "vector_l2_ops", queryVector, false, true},
+			{"cosine", "v", "cosine_distance", "vector_cosine_ops", queryVector, false, false},
+			{"normalized_l2", "n", "l2_distance", "vector_l2_ops", normalizedQuery, false, false},
+			{"ip_normalized", "v", "inner_product", "vector_ip_ops", "normalize_l2(" + queryVector + ")", false, false},
 		}
 		for _, tc := range cases[:3] {
 			if err := prepareIndex(tc); err != nil {
@@ -429,74 +429,78 @@ func runIssue28378IVF(t *testing.T, cluster embed.Cluster, state *ivfRunState,
 				}
 
 			}
-			// Preserve the incident's SELECT id shape under bounded concurrent
-			// sessions. A single sql.Conn would serialize the workload.
-			completed := make(chan error, 8)
-			for worker := 0; worker < 8; worker++ {
-				state.workers.Add(1)
-				go func(worker int) {
-					defer state.workers.Done()
-					completed <- func() error {
-						conn, err := databases[worker%2].Conn(ctx)
-						if err != nil {
-							return err
-						}
-						defer conn.Close()
-						for _, setting := range []string{"use `" + name + "`", "set probe_limit=5", "set max_dop=16", "set experimental_ivf_index=1"} {
-							if _, err := conn.ExecContext(ctx, setting); err != nil {
-								return err
-							}
-						}
-						statement := "select id from " + tc.name + " order by " + tc.fn + "(v," + tc.vector + ") " + direction + " limit 10"
-						for iteration := 0; iteration < 20; iteration++ {
-							rows, err := conn.QueryContext(ctx, statement)
+			if tc.concurrent {
+				// Preserve the incident's SELECT id shape under bounded concurrent
+				// sessions. A single sql.Conn would serialize the workload. The
+				// lifecycle is shared by all distance operators, so run the full
+				// stress loop once while each operator still gets its own assertions.
+				completed := make(chan error, 8)
+				for worker := 0; worker < 8; worker++ {
+					state.workers.Add(1)
+					go func(worker int) {
+						defer state.workers.Done()
+						completed <- func() error {
+							conn, err := databases[worker%2].Conn(ctx)
 							if err != nil {
 								return err
 							}
-							err = func() (runErr error) {
-								defer func() {
-									if closeErr := rows.Close(); runErr == nil {
-										runErr = closeErr
-									}
-								}()
-								count := 0
-								seen := make(map[int64]bool)
-								for rows.Next() {
-									var id int64
-									if err := rows.Scan(&id); err != nil {
-										return err
-									}
-									if id < 0 || id >= 65536 || seen[id] {
-										return fmt.Errorf("invalid vector id %d", id)
-									}
-									seen[id] = true
-									count++
-								}
-								if err := rows.Err(); err != nil {
+							defer conn.Close()
+							for _, setting := range []string{"use `" + name + "`", "set probe_limit=5", "set max_dop=16", "set experimental_ivf_index=1"} {
+								if _, err := conn.ExecContext(ctx, setting); err != nil {
 									return err
 								}
-								if count != 10 {
-									return fmt.Errorf("got %d rows, want 10", count)
-								}
-								return nil
-							}()
-							if err != nil {
-								return err
 							}
-						}
-						return nil
-					}()
-				}(worker)
-			}
-			// Join every worker before assertions/DDL cleanup, including failures.
-			var firstErr error
-			for worker := 0; worker < 8; worker++ {
-				if err := <-completed; err != nil && firstErr == nil {
-					firstErr = err
+							statement := "select id from " + tc.name + " order by " + tc.fn + "(v," + tc.vector + ") " + direction + " limit 10"
+							for iteration := 0; iteration < 20; iteration++ {
+								rows, err := conn.QueryContext(ctx, statement)
+								if err != nil {
+									return err
+								}
+								err = func() (runErr error) {
+									defer func() {
+										if closeErr := rows.Close(); runErr == nil {
+											runErr = closeErr
+										}
+									}()
+									count := 0
+									seen := make(map[int64]bool)
+									for rows.Next() {
+										var id int64
+										if err := rows.Scan(&id); err != nil {
+											return err
+										}
+										if id < 0 || id >= 65536 || seen[id] {
+											return fmt.Errorf("invalid vector id %d", id)
+										}
+										seen[id] = true
+										count++
+									}
+									if err := rows.Err(); err != nil {
+										return err
+									}
+									if count != 10 {
+										return fmt.Errorf("got %d rows, want 10", count)
+									}
+									return nil
+								}()
+								if err != nil {
+									return err
+								}
+							}
+							return nil
+						}()
+					}(worker)
 				}
+				// Join every worker before assertions/DDL cleanup, including failures.
+				var firstErr error
+				for worker := 0; worker < 8; worker++ {
+					if err := <-completed; err != nil && firstErr == nil {
+						firstErr = err
+					}
+				}
+				t.Logf("IVF_WORKERS_JOINED distance=%s count=8", tc.name)
+				require.NoError(t, firstErr)
 			}
-			t.Logf("IVF_WORKERS_JOINED distance=%s count=8", tc.name)
-			require.NoError(t, firstErr)
 			cancelCtx, cancel := context.WithCancel(ctx)
 			cancel()
 			cancelledRows, err := conns[0].QueryContext(cancelCtx, statement)

--- a/pkg/tests/issues/issue_28378_test.go
+++ b/pkg/tests/issues/issue_28378_test.go
@@ -453,31 +453,35 @@ func runIssue28378IVF(t *testing.T, cluster embed.Cluster, state *ivfRunState,
 							if err != nil {
 								return err
 							}
-							count := 0
-							seen := make(map[int64]bool)
-							for rows.Next() {
-								var id int64
-								if err := rows.Scan(&id); err != nil {
-									_ = rows.Close()
+							err = func() (runErr error) {
+								defer func() {
+									if closeErr := rows.Close(); runErr == nil {
+										runErr = closeErr
+									}
+								}()
+								count := 0
+								seen := make(map[int64]bool)
+								for rows.Next() {
+									var id int64
+									if err := rows.Scan(&id); err != nil {
+										return err
+									}
+									if id < 0 || id >= 65536 || seen[id] {
+										return fmt.Errorf("invalid vector id %d", id)
+									}
+									seen[id] = true
+									count++
+								}
+								if err := rows.Err(); err != nil {
 									return err
 								}
-								if id < 0 || id >= 65536 || seen[id] {
-									_ = rows.Close()
-									return fmt.Errorf("invalid vector id %d", id)
+								if count != 10 {
+									return fmt.Errorf("got %d rows, want 10", count)
 								}
-								seen[id] = true
-								count++
-							}
-							err = rows.Err()
-							closeErr := rows.Close()
+								return nil
+							}()
 							if err != nil {
 								return err
-							}
-							if closeErr != nil {
-								return closeErr
-							}
-							if count != 10 {
-								return fmt.Errorf("got %d rows, want 10", count)
 							}
 						}
 						return nil
@@ -497,7 +501,10 @@ func runIssue28378IVF(t *testing.T, cluster embed.Cluster, state *ivfRunState,
 			cancel()
 			cancelledRows, err := conns[0].QueryContext(cancelCtx, statement)
 			if cancelledRows != nil {
-				_ = cancelledRows.Close()
+				defer cancelledRows.Close()
+				if rowsErr := cancelledRows.Err(); rowsErr != nil {
+					require.ErrorIs(t, rowsErr, context.Canceled)
+				}
 			}
 			require.ErrorIs(t, err, context.Canceled)
 			// This checks cancellation before SQL admission, not cancellation

--- a/pkg/tests/issues/issue_28378_test.go
+++ b/pkg/tests/issues/issue_28378_test.go
@@ -1,0 +1,566 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/clusterservice"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
+	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// Each callback gets only the remaining budget for its own phase. Time spent
+// preparing the second group never consumes query time, and vice versa.
+type ivfPhaseBudget struct {
+	remaining time.Duration
+	now       func() time.Time
+}
+
+func (b *ivfPhaseBudget) run(fn func(context.Context) error) error {
+	if b.remaining <= 0 {
+		return context.DeadlineExceeded
+	}
+	started := b.now()
+	ctx, cancel := context.WithTimeout(context.Background(), b.remaining)
+	defer cancel()
+	err := fn(ctx)
+	elapsed := b.now().Sub(started)
+	b.remaining -= elapsed
+	if err == nil {
+		err = ctx.Err()
+	}
+	if err == nil && b.remaining <= 0 {
+		err = context.DeadlineExceeded
+	}
+	return err
+}
+
+type ivfTestPhase struct{ prepare, query func(context.Context) error }
+
+func runIVFTestPhases(phases []ivfTestPhase, cleanup func(context.Context) error) (err error) {
+	// A deferred owner also runs on a test Goexit or panic; assertions are not
+	// used in preparation, so its normal failures return through this owner.
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		err = errors.Join(err, cleanup(ctx))
+	}()
+	prepare := ivfPhaseBudget{15 * time.Minute, time.Now}
+	query := ivfPhaseBudget{5 * time.Minute, time.Now}
+	for _, phase := range phases {
+		if err = prepare.run(phase.prepare); err != nil {
+			return err
+		}
+		if err = query.run(phase.query); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func TestIssue28378PhaseBudgetsAreIndependent(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	prepare := ivfPhaseBudget{15 * time.Minute, clock}
+	query := ivfPhaseBudget{5 * time.Minute, clock}
+	consume := func(d time.Duration) func(context.Context) error {
+		return func(context.Context) error { now = now.Add(d); return nil }
+	}
+	require.NoError(t, prepare.run(consume(10*time.Minute)))
+	require.NoError(t, query.run(consume(2*time.Minute)))
+	require.Equal(t, 5*time.Minute, prepare.remaining)
+	require.NoError(t, prepare.run(consume(4*time.Minute)))
+	require.Equal(t, 3*time.Minute, query.remaining)
+	require.NoError(t, query.run(consume(2*time.Minute)))
+	require.ErrorIs(t, prepare.run(consume(time.Minute)), context.DeadlineExceeded)
+	called := false
+	require.ErrorIs(t, prepare.run(func(context.Context) error { called = true; return nil }), context.DeadlineExceeded)
+	require.False(t, called)
+	require.Equal(t, time.Minute, query.remaining)
+}
+func TestIssue28378PreparationFailureSkipsQueryAndCleansOnce(t *testing.T) {
+	prepareErr := errors.New("seed insert failed")
+	cleanupErr := errors.New("cleanup failed")
+	queries, cleanups := 0, 0
+	err := runIVFTestPhases([]ivfTestPhase{{
+		prepare: func(context.Context) error { return prepareErr },
+		query:   func(context.Context) error { queries++; return nil },
+	}}, func(ctx context.Context) error {
+		cleanups++
+		require.NoError(t, ctx.Err())
+		return cleanupErr
+	})
+	require.ErrorIs(t, err, prepareErr)
+	require.ErrorIs(t, err, cleanupErr)
+	require.Zero(t, queries)
+	require.Equal(t, 1, cleanups)
+}
+
+type ivfRunState struct {
+	workers                  sync.WaitGroup
+	workerCtx                context.Context
+	cancelWorkers            context.CancelFunc
+	databases                []*sql.DB
+	conns                    []*sql.Conn
+	tx                       *sql.Tx
+	cleanupCalls, queryCalls int
+}
+type ivfCase struct {
+	name, col, fn, op, vector string
+	desc                      bool
+}
+
+func TestIssue28378IVFFlatRemoteLifecycle(t *testing.T) {
+	started := time.Now()
+	embed.RunBaseClusterTests(t, func(cluster embed.Cluster) {
+		t.Logf("IVF_CLUSTER_READY elapsed=%s (outside preparation budget)", time.Since(started))
+		if !t.Run("preparation_failure", func(t *testing.T) {
+			injected := errors.New("injected after first successful seed batch")
+			state := new(ivfRunState)
+			workerExited := make(chan struct{})
+			err := runIssue28378IVF(t, cluster, state, func(ctx context.Context, tx *sql.Tx, state *ivfRunState) error {
+				var n int
+				if err := tx.QueryRowContext(ctx, "select count(*) from source_vectors").Scan(&n); err != nil {
+					return err
+				}
+				if n != 256 {
+					return fmt.Errorf("partial transaction rows=%d, want 256", n)
+				}
+				// Start a real connection owner during partial setup. The runner must
+				// cancel and join it before closing the databases and issuing cleanup DDL.
+				ready := make(chan error, 1)
+				state.workers.Add(1)
+				go func() {
+					defer state.workers.Done()
+					defer close(workerExited)
+					conn, err := state.databases[1].Conn(state.workerCtx)
+					if err != nil {
+						ready <- err
+						return
+					}
+					defer conn.Close()
+					_, err = conn.ExecContext(state.workerCtx, "select 1")
+					ready <- err
+					if err == nil {
+						<-state.workerCtx.Done()
+					}
+				}()
+				select {
+				case err := <-ready:
+					if err != nil {
+						return err
+					}
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				return injected
+			})
+			require.ErrorIs(t, err, injected)
+			require.EqualError(t, err, injected.Error(), "cleanup must not add another failure")
+			require.Zero(t, state.queryCalls)
+			require.Equal(t, 1, state.cleanupCalls)
+			require.ErrorIs(t, state.tx.Rollback(), sql.ErrTxDone)
+			select {
+			case <-workerExited:
+			default:
+				t.Fatal("preparation worker survived cleanup")
+			}
+		}) {
+			return
+		}
+		t.Run("queries", func(t *testing.T) { require.NoError(t, runIssue28378IVF(t, cluster, new(ivfRunState), nil)) })
+	})
+}
+
+func runIssue28378IVF(t *testing.T, cluster embed.Cluster, state *ivfRunState,
+	afterInsert func(context.Context, *sql.Tx, *ivfRunState) error) error {
+	state.workerCtx, state.cancelWorkers = context.WithCancel(context.Background())
+	name := strings.ToLower(testutils.GetDatabaseName(t))
+	var ctx context.Context
+	var conns []*sql.Conn
+	var databases []*sql.DB
+	var seedTx *sql.Tx
+	var generatedTime, insertedTime, commitTime time.Duration
+	var insertedRows int
+	var queryVector, normalizedQuery string
+	var cases []ivfCase
+	created := false
+	execSQL := func(statement string) error { _, err := conns[0].ExecContext(ctx, statement); return err }
+	exec := func(t *testing.T, conn *sql.Conn, statement string) {
+		t.Helper()
+		_, err := conn.ExecContext(ctx, statement)
+		require.NoError(t, err)
+	}
+	prepareIndex := func(tc ivfCase) error {
+		started := time.Now()
+		defer func() { t.Logf("IVF_INDEX name=%s elapsed=%s", tc.name, time.Since(started)) }()
+		for _, sql := range []string{
+			"create table " + tc.name + "(id bigint primary key, v vecf32(128))",
+			"insert into " + tc.name + " select id," + tc.col + " from source_vectors",
+			"create index ivf_idx using ivfflat on " + tc.name + "(v) lists=16 op_type '" + tc.op + "'",
+			"select mo_ctl('dn','flush','" + name + "." + tc.name + "')",
+		} {
+			if err := execSQL(sql); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	prepareSource := func(phaseCtx context.Context) error {
+		ctx = phaseCtx
+		for i := 0; i < 2; i++ {
+			cn, err := cluster.GetCNService(i)
+			if err != nil {
+				return err
+			}
+			inventory := clusterservice.GetMOCluster(cn.ServiceID())
+			for {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				inventory.ForceRefresh(true)
+				n := 0
+				inventory.GetCNService(clusterservice.NewSelector(), func(metadata.CNService) bool { n++; return true })
+				if n >= 2 {
+					break
+				}
+				timer := time.NewTimer(200 * time.Millisecond)
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					timer.Stop()
+					return ctx.Err()
+				}
+			}
+			db, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(127.0.0.1:%d)/", cn.GetServiceConfig().CN.Frontend.Port))
+			if err != nil {
+				return err
+			}
+			databases = append(databases, db)
+			state.databases = databases
+			conn, err := db.Conn(ctx)
+			if err != nil {
+				return err
+			}
+			conns = append(conns, conn)
+			state.conns = conns
+		}
+		if err := execSQL("create database `" + name + "`"); err != nil {
+			return err
+		}
+		created = true
+		for _, conn := range conns {
+			for _, sql := range []string{"use `" + name + "`", "set experimental_ivf_index=1", "set max_dop=16"} {
+				if _, err := conn.ExecContext(ctx, sql); err != nil {
+					return err
+				}
+			}
+		}
+		if err := execSQL("create table source_vectors(id bigint primary key, v vecf32(128), n vecf32(128))"); err != nil {
+			return err
+		}
+		var err error
+		seedTx, err = conns[0].BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		state.tx = seedTx
+		rng := rand.New(rand.NewSource(28378))
+		for start := 0; start < 65536; start += 256 {
+			generationStarted := time.Now()
+			values := make([]string, 0, 256)
+			for id := start; id < start+256; id++ {
+				v := make([]float64, 128)
+				var squared float64
+				for d := range v {
+					v[d] = float64(float32(rng.Float64()*2 - 1))
+					squared += v[d] * v[d]
+				}
+				encode := func(normalize bool) string {
+					parts := make([]string, len(v))
+					for d, x := range v {
+						if normalize {
+							x /= math.Sqrt(squared)
+						}
+						parts[d] = strconv.FormatFloat(float64(float32(x)), 'g', -1, 32)
+					}
+					return "'[" + strings.Join(parts, ",") + "]'"
+				}
+				raw, normalized := encode(false), encode(true)
+				if id == 0 {
+					queryVector, normalizedQuery = raw, normalized
+				}
+				values = append(values, fmt.Sprintf("(%d,%s,%s)", id, raw, normalized))
+			}
+			generatedTime += time.Since(generationStarted)
+			insertStarted := time.Now()
+			_, err := seedTx.ExecContext(ctx, "insert into source_vectors values "+strings.Join(values, ","))
+			insertedTime += time.Since(insertStarted)
+			if err != nil {
+				return err
+			}
+			insertedRows += 256
+			if afterInsert != nil {
+				if err := afterInsert(ctx, seedTx, state); err != nil {
+					return err
+				}
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		commitStarted := time.Now()
+		err = seedTx.Commit()
+		commitTime = time.Since(commitStarted)
+		if err != nil {
+			return err
+		}
+
+		cases = []ivfCase{
+			{"l2", "v", "l2_distance", "vector_l2_ops", queryVector, false},
+			{"cosine", "v", "cosine_distance", "vector_cosine_ops", queryVector, false},
+			{"normalized_l2", "n", "l2_distance", "vector_l2_ops", normalizedQuery, false},
+			{"ip_normalized", "v", "inner_product", "vector_ip_ops", "normalize_l2(" + queryVector + ")", false},
+		}
+		for _, tc := range cases[:3] {
+			if err := prepareIndex(tc); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	type result struct {
+		id       int64
+		distance float64
+	}
+	query := func(t *testing.T, conn *sql.Conn, statement string, desc bool) []result {
+		t.Helper()
+		rows, err := conn.QueryContext(ctx, statement)
+		require.NoError(t, err)
+		defer rows.Close()
+		var found []result
+		seen := make(map[int64]bool)
+		for rows.Next() {
+			var row result
+			require.NoError(t, rows.Scan(&row.id, &row.distance))
+			require.GreaterOrEqual(t, row.id, int64(0))
+			require.Less(t, row.id, int64(65536))
+			require.False(t, seen[row.id], "duplicate vector id")
+			seen[row.id] = true
+			require.False(t, math.IsNaN(row.distance) || math.IsInf(row.distance, 0))
+			if len(found) > 0 {
+				if desc {
+					require.LessOrEqual(t, row.distance, found[len(found)-1].distance)
+				} else {
+					require.GreaterOrEqual(t, row.distance, found[len(found)-1].distance)
+				}
+			}
+			found = append(found, row)
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+		return found
+	}
+	remoteCalls := func() uint64 {
+		metric := new(dto.Metric)
+		require.NoError(t, metricv2.PipelineServerDurationHistogram.Write(metric))
+		return metric.GetHistogram().GetSampleCount()
+	}
+	runCase := func(tc ivfCase) bool {
+		return t.Run(tc.name, func(t *testing.T) {
+			caseStarted := time.Now()
+			defer func() { t.Logf("IVF_QUERY_CASE name=%s elapsed=%s", tc.name, time.Since(caseStarted)) }()
+			direction := "asc"
+			if tc.desc {
+				direction = "desc"
+			}
+			statement := "select id," + tc.fn + "(v," + tc.vector + ") from " + tc.name + " order by " + tc.fn + "(v," + tc.vector + ") " + direction + " limit 10"
+			for coordinator, conn := range conns {
+				expression := tc.fn + "(v," + tc.vector + ")"
+				statement = "select id," + expression + " from " + tc.name + " order by " + expression + " " + direction + " limit 10"
+				plan := queryJoinSpillText(t, ctx, conn, "explain "+statement)
+				require.Contains(t, plan, "Vector Index: ivf_idx", "must use the IVF reader")
+				exec(t, conn, "set probe_limit=16")
+				before := remoteCalls()
+				got := query(t, conn, statement, tc.desc)
+				require.Len(t, got, 10)
+				require.Greater(t, remoteCalls(), before, "coordinator %d must execute a remote pipeline", coordinator)
+				wantExpression := tc.fn + "(" + tc.col + "," + tc.vector + ")"
+				want := query(t, conn, "select id,"+wantExpression+" from source_vectors order by "+wantExpression+" "+direction+" limit 10", tc.desc)
+				require.Len(t, want, 10)
+				for i := range want {
+					require.Equal(t, want[i].id, got[i].id)
+					require.InDelta(t, want[i].distance, got[i].distance, 1e-5)
+				}
+				exec(t, conn, "set probe_limit=5")
+				for _, predicate := range []string{"", " where id < 0", ""} {
+					got := query(t, conn, "select id,"+expression+" from "+tc.name+predicate+" order by "+expression+" "+direction+" limit 10", tc.desc)
+					if predicate == "" {
+						require.Len(t, got, 10)
+					} else {
+						require.Empty(t, got)
+					}
+				}
+
+			}
+			// Preserve the incident's SELECT id shape under bounded concurrent
+			// sessions. A single sql.Conn would serialize the workload.
+			completed := make(chan error, 8)
+			for worker := 0; worker < 8; worker++ {
+				state.workers.Add(1)
+				go func(worker int) {
+					defer state.workers.Done()
+					completed <- func() error {
+						conn, err := databases[worker%2].Conn(ctx)
+						if err != nil {
+							return err
+						}
+						defer conn.Close()
+						for _, setting := range []string{"use `" + name + "`", "set probe_limit=5", "set max_dop=16", "set experimental_ivf_index=1"} {
+							if _, err := conn.ExecContext(ctx, setting); err != nil {
+								return err
+							}
+						}
+						statement := "select id from " + tc.name + " order by " + tc.fn + "(v," + tc.vector + ") " + direction + " limit 10"
+						for iteration := 0; iteration < 20; iteration++ {
+							rows, err := conn.QueryContext(ctx, statement)
+							if err != nil {
+								return err
+							}
+							count := 0
+							seen := make(map[int64]bool)
+							for rows.Next() {
+								var id int64
+								if err := rows.Scan(&id); err != nil {
+									_ = rows.Close()
+									return err
+								}
+								if id < 0 || id >= 65536 || seen[id] {
+									_ = rows.Close()
+									return fmt.Errorf("invalid vector id %d", id)
+								}
+								seen[id] = true
+								count++
+							}
+							err = rows.Err()
+							closeErr := rows.Close()
+							if err != nil {
+								return err
+							}
+							if closeErr != nil {
+								return closeErr
+							}
+							if count != 10 {
+								return fmt.Errorf("got %d rows, want 10", count)
+							}
+						}
+						return nil
+					}()
+				}(worker)
+			}
+			// Join every worker before assertions/DDL cleanup, including failures.
+			var firstErr error
+			for worker := 0; worker < 8; worker++ {
+				if err := <-completed; err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			t.Logf("IVF_WORKERS_JOINED distance=%s count=8", tc.name)
+			require.NoError(t, firstErr)
+			cancelCtx, cancel := context.WithCancel(ctx)
+			cancel()
+			cancelledRows, err := conns[0].QueryContext(cancelCtx, statement)
+			if cancelledRows != nil {
+				_ = cancelledRows.Close()
+			}
+			require.ErrorIs(t, err, context.Canceled)
+			// This checks cancellation before SQL admission, not cancellation
+			// of an active remote pipeline. Run again after all workers joined.
+			followup := query(t, conns[0], statement, tc.desc)
+			require.Len(t, followup, 10)
+		})
+	}
+
+	queryGroup := func(group []ivfCase, phaseCtx context.Context) error {
+		ctx = phaseCtx
+		state.queryCalls++
+		for _, tc := range group {
+			if !runCase(tc) {
+				return fmt.Errorf("IVF query assertions failed: %s", tc.name)
+			}
+			if err := execSQL("drop table " + tc.name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	cleanup := func(cleanupCtx context.Context) error {
+		state.cleanupCalls++
+		state.cancelWorkers()
+		var errs []error
+		if seedTx != nil {
+			if err := seedTx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+				errs = append(errs, err)
+			}
+		}
+		state.workers.Wait()
+		if created {
+			// Use a fresh connection because cancellation may poison the setup one.
+			_, err := databases[0].ExecContext(cleanupCtx, "drop database `"+name+"`")
+			errs = append(errs, err)
+			if err == nil {
+				var n int
+				err = databases[0].QueryRowContext(cleanupCtx, "select count(*) from mo_catalog.mo_database where datname = ?", name).Scan(&n)
+				errs = append(errs, err)
+				if err == nil && n != 0 {
+					errs = append(errs, fmt.Errorf("database survived cleanup: %s", name))
+				}
+			}
+		}
+		for _, conn := range conns {
+			errs = append(errs, conn.Close())
+		}
+		for _, db := range databases {
+			errs = append(errs, db.Close())
+		}
+		t.Logf("IVF_CLEANUP inserted_rows=%d generation=%s insertion=%s commit=%s cleanup_calls=%d", insertedRows, generatedTime, insertedTime, commitTime, state.cleanupCalls)
+		return errors.Join(errs...)
+	}
+	timed := func(name string, fn func(context.Context) error) func(context.Context) error {
+		return func(ctx context.Context) error {
+			started := time.Now()
+			defer func() { t.Logf("IVF_PHASE name=%s elapsed=%s", name, time.Since(started)) }()
+			return fn(ctx)
+		}
+	}
+	return runIVFTestPhases([]ivfTestPhase{
+		{prepare: timed("prepare_primary", prepareSource), query: timed("query_primary", func(ctx context.Context) error { return queryGroup(cases[:3], ctx) })},
+		{prepare: timed("prepare_ip", func(phaseCtx context.Context) error { ctx = phaseCtx; return prepareIndex(cases[3]) }), query: timed("query_ip", func(ctx context.Context) error { return queryGroup(cases[3:], ctx) })},
+	}, cleanup)
+}

--- a/test/distributed/cases/vector/vector_ivf_multicn_search.result
+++ b/test/distributed/cases/vector/vector_ivf_multicn_search.result
@@ -35,12 +35,36 @@ Project  𝄀
               Vector Index: idx_int_b, Metric: l2_distance, Candidate Limit: 4, NProbe: 4
 select group_concat(a order by a) as nearest_ids, count(*) as row_count, count(distinct a) as distinct_count
 from (select a from t_int order by l2_distance(b, '[0,0,0,0]') limit 4) s;
-➤ nearest_ids[12,0,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+➤ nearest_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
 1,2,3,4  ¦  4  ¦  4
 select group_concat(a order by a) as exact_ids, count(*) as row_count, count(distinct a) as distinct_count
 from (select a from t_int where a in (1,2,3,4,5,6) order by l2_distance(b, '[0,0,0,0]') limit 4) s;
-➤ exact_ids[12,0,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+➤ exact_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
 1,2,3,4  ¦  4  ¦  4
+create table t_cos(a bigint primary key, b vecf32(4));
+insert into t_cos values
+(1, '[1,0,0,0]'),(2, '[0.8,0.6,0,0]'),(3, '[0,1,0,0]'),(4, '[-1,0,0,0]');
+create index idx_cos_b using ivfflat on t_cos(b) lists=4 op_type 'vector_cosine_ops';
+select group_concat(a order by a) as cosine_ids, count(*) as row_count, count(distinct a) as distinct_count
+from (select a from t_cos order by cosine_distance(b, '[1,0,0,0]') limit 3) s;
+➤ cosine_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+1,2,3  ¦  3  ¦  3
+create table t_ip(a bigint primary key, b vecf32(4));
+insert into t_ip values
+(1, '[1,0,0,0]'),(2, '[0.8,0.6,0,0]'),(3, '[0,1,0,0]'),(4, '[-0.2,0,0,0]');
+create index idx_ip_b using ivfflat on t_ip(b) lists=4 op_type 'vector_ip_ops';
+select group_concat(a order by a) as ip_ids, count(*) as row_count, count(distinct a) as distinct_count
+from (select a from t_ip order by inner_product(b, normalize_l2('[1,0.1,0,0]')) asc limit 3) s;
+➤ ip_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+1,2,3  ¦  3  ¦  3
+select count(*) as empty_count
+from (select a from t_ip where a < 0 order by inner_product(b, normalize_l2('[1,0.1,0,0]')) asc limit 3) s;
+➤ empty_count[-5,64,0]  𝄀
+0
+select group_concat(a order by a) as ip_followup_ids, count(*) as row_count, count(distinct a) as distinct_count
+from (select a from t_ip order by inner_product(b, normalize_l2('[1,0.1,0,0]')) asc limit 2) s;
+➤ ip_followup_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+1,2  ¦  2  ¦  2
 create table t_str(a varchar(8) primary key, b vecf32(4));
 insert into t_str values
 ('p01', '[0,0,0,0]'),('p02', '[1,0,0,0]'),('p03', '[2,0,0,0]'),('p04', '[3,0,0,0]'),
@@ -50,7 +74,7 @@ insert into t_str values
 create index idx_str_b using ivfflat on t_str(b) lists=4 op_type 'vector_l2_ops';
 select group_concat(a order by a) as str_ids, count(*) as row_count, count(distinct a) as distinct_count
 from (select a from t_str order by l2_distance(b, '[0,0,0,0]') limit 4) s;
-➤ str_ids[12,0,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+➤ str_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
 p01,p02,p03,p04  ¦  4  ¦  4
 create table t_comp(a int, c varchar(8), b vecf32(4), primary key(a, c));
 insert into t_comp values
@@ -61,7 +85,7 @@ insert into t_comp values
 create index idx_comp_b using ivfflat on t_comp(b) lists=4 op_type 'vector_l2_ops';
 select group_concat(concat(a, ':', c) order by a) as comp_ids, count(*) as row_count, count(distinct concat(a, ':', c)) as distinct_count
 from (select a, c from t_comp order by l2_distance(b, '[0,0,0,0]') limit 4) s;
-➤ comp_ids[12,0,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+➤ comp_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
 1:c01,2:c02,3:c03,4:c04  ¦  4  ¦  4
 create table t_sparse(a bigint primary key, b vecf32(4));
 insert into t_sparse values
@@ -70,6 +94,6 @@ create index idx_sparse_b using ivfflat on t_sparse(b) lists=8 op_type 'vector_l
 set probe_limit = 8;
 select group_concat(a order by a) as sparse_ids, count(*) as row_count, count(distinct a) as distinct_count
 from (select a from t_sparse order by l2_distance(b, '[0,0,0,0]') limit 10) s;
-➤ sparse_ids[12,0,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
+➤ sparse_ids[-1,16383,0]  ¦  row_count[-5,64,0]  ¦  distinct_count[-5,64,0]  𝄀
 1,2,3  ¦  3  ¦  3
 drop database vector_ivf_multicn_search;

--- a/test/distributed/cases/vector/vector_ivf_multicn_search.sql
+++ b/test/distributed/cases/vector/vector_ivf_multicn_search.sql
@@ -32,6 +32,32 @@ from (select a from t_int order by l2_distance(b, '[0,0,0,0]') limit 4) s;
 select group_concat(a order by a) as exact_ids, count(*) as row_count, count(distinct a) as distinct_count
 from (select a from t_int where a in (1,2,3,4,5,6) order by l2_distance(b, '[0,0,0,0]') limit 4) s;
 
+-- Keep raw vectors for the cosine and inner-product forms used by the
+-- incident workload.  Probe every list so the expected IDs are an exact
+-- oracle while the index reader and Multi-CN route are still exercised.
+create table t_cos(a bigint primary key, b vecf32(4));
+insert into t_cos values
+(1, '[1,0,0,0]'),(2, '[0.8,0.6,0,0]'),(3, '[0,1,0,0]'),(4, '[-1,0,0,0]');
+create index idx_cos_b using ivfflat on t_cos(b) lists=4 op_type 'vector_cosine_ops';
+
+select group_concat(a order by a) as cosine_ids, count(*) as row_count, count(distinct a) as distinct_count
+from (select a from t_cos order by cosine_distance(b, '[1,0,0,0]') limit 3) s;
+
+create table t_ip(a bigint primary key, b vecf32(4));
+insert into t_ip values
+(1, '[1,0,0,0]'),(2, '[0.8,0.6,0,0]'),(3, '[0,1,0,0]'),(4, '[-0.2,0,0,0]');
+create index idx_ip_b using ivfflat on t_ip(b) lists=4 op_type 'vector_ip_ops';
+
+select group_concat(a order by a) as ip_ids, count(*) as row_count, count(distinct a) as distinct_count
+from (select a from t_ip order by inner_product(b, normalize_l2('[1,0.1,0,0]')) asc limit 3) s;
+
+select count(*) as empty_count
+from (select a from t_ip where a < 0 order by inner_product(b, normalize_l2('[1,0.1,0,0]')) asc limit 3) s;
+
+-- A query after the empty result must still use the same reader/connection.
+select group_concat(a order by a) as ip_followup_ids, count(*) as row_count, count(distinct a) as distinct_count
+from (select a from t_ip order by inner_product(b, normalize_l2('[1,0.1,0,0]')) asc limit 2) s;
+
 create table t_str(a varchar(8) primary key, b vecf32(4));
 insert into t_str values
 ('p01', '[0,0,0,0]'),('p02', '[1,0,0,0]'),('p03', '[2,0,0,0]'),('p04', '[3,0,0,0]'),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28378

## What this PR does / why we need it:

Add regression coverage for queued stream cancellation, shuffle receiver retirement, and distributed IVF query cleanup. Production fixes are already present through #28358, the relevant dispatch/remote pipeline changes in #28364, and #28539; this PR changes tests only and does not establish their individual causal contribution to the original TKE incident.

- Observe serialized MORPC sequence numbers after a queued message is canceled. The identical test compiles on the #28358 parent and fails with expected sequence 2 versus actual 3.
- Cover first, middle, last, and consecutive shuffle receiver retirement, checking both subsequent sends and one-time notification. Exercise query/connection cancellation during real receiver credit waiting through the CN handler, preserving the terminal error and releasing lifecycle registration.
- Add a two-CN IVF test with 256 128-dimensional vectors. The representative L2 case exercises eight concurrent sessions with one simultaneous query per session; cosine, normalized L2, and raw-vector IP/normalized-query retain their per-distance lifecycle and result checks. The test covers exact full-probe comparison, approximate-result validity, empty results, and subsequent queries. Test preparation failure uses the actual phase runner, transaction rollback, worker exit, and database cleanup. Preparation and query budgets are cumulative but separate; cleanup gets its own context. SQL pre-cancellation is not presented as proof of active remote cancellation. The fixture provides 16 vectors per IVF list on average; Vector Index Scan selects Multi-CN without a 65,536-row threshold, so the 256-row fixture preserves the lifecycle and result oracles while bounding the owning package's race cost.
- Extend test/distributed/cases/vector/vector_ivf_multicn_search.sql and .result with cosine, raw-vector IP/normalized-query, empty-result, and follow-up checks. The GROUP_CONCAT metadata expectation uses the existing server TEXT mapping and Connector/J 8.0.15 metadata; results were not regenerated blindly.

Validation (final file contents include the follow-up assertion, SCA, coverage-budget, fixture-size, and concurrency-budget fixes; exact head 323daee056991164e5f807ac070295baf633b460; upstream base 07b25969bfea9d4b76d3bf05d5b0497e4f36eba0; product base 2a6fe7f61358e846a20aafba3b50903a61608682):

- macOS arm64, Go 1.26.4, repository CGo wrapper, GOMAXPROCS=4, test package parallelism 1.
- New mechanism tests: ordinary 100 iterations and race 20 iterations passed. MORPC, dispatch, and compile packages passed ordinary/race checks; unchanged evidence was reused.
- Follow-up P2 validation: TestRemoteNotifyCancellationReleasesCreditWaitAndRegistration passed ordinary 100 iterations and race 20 iterations after asserting that connection cancellation closes proc.Ctx, records a non-nil ErrStreamClosed cause, and preserves it through repeated terminal cleanup.
- After the follow-up edit, the complete owning ./pkg/sql/compile package passed once under the race detector; no race report was emitted.
- Exact prior-head fixture validation: GOWORK=off go test -mod=readonly -count=1 -timeout=15m -run '^TestIssue28378IVFFlatRemoteLifecycle$' ./pkg/tests/issues passed in 14.855s; the same exact test with -race and a 20m timeout passed in 34.817s. After the first fixture-size change, the 1,024-row test passed ordinary in 16.675s and race in 33.739s; after the final 256-row/one-iteration change, it passed ordinary in 16.591s and race in 24.467s.
- The MORPC parent counterexample validates the sequence mechanism. The IVF integration test is regression coverage, not a deterministic reproduction of the historical incident.
- Reviewer P2 response: the fixture was reduced from 65,536 to 256 rows and the concurrent repeat count from two to one in 323daee056. XuPeng-SH measured the prior 65,536-row test at 573.55s in the exclusive -p 1 -race UT stage on parent head 7944a5bc; the focused runs above measure the latest local fixture at 16.591s ordinary and 24.467s race. These are different environments and modes, so the numbers are reported as bounded before/after evidence rather than a CI performance claim. The exact-head CI run below provides the Linux cost measurement.
- Exact current-head CI run 34756863153 for f7cb131935 passed Ubuntu UT, SCA, UT Coverage, shared build, Proxy/Pessimistic BVT, and CI Required. The subsequent exact-head run 34799486791 for 323daee056 passed on attempt 2: Ubuntu UT, SCA, UT Coverage, shared build, Proxy/Pessimistic BVT, Coverage, and CI Required are green. Its first attempt failed only in the unrelated optools TestUTHeartbeatStopsCleanly with `WaitDelay expired before I/O complete`; the failed Coverage chain passed on rerun without code changes.
- Formal BVT: CN1 and CN2 JDBC entry points each passed 36/36 comparisons with full metadata checking. go vet, gofmt, and diff checks passed.

Deployment evidence for the already-fixed product base, independently of this new test commit:

- Old baseline run https://github.com/matrixorigin/mo-nightly-regression/actions/runs/34352473993: HNSW/L2/cosine/normalize errors were 0/1702/1266/588.
- Fixed-product run https://github.com/matrixorigin/mo-nightly-regression/actions/runs/34464342049: all four original million-vector SIFT128 cases completed with 100 terminals, five-minute measurements, and zero client errors. The five data hashes match the failed baseline. Acceptance was checked from artifact counters and error files, not only workflow success.

QA required: yes — distributed timing and deployed-workload acceptance. Automated terminal coverage includes completed SQL assertions, cancellation waiter exit, preserved terminal errors, registration removal, and cleanup. QA should review the target release's inclusion of the existing production fixes and the attached run evidence. First-error query/stream/peer correlation and unique root-cause attribution remain unavailable; this PR must not auto-close #28378.
