### PR TITLE
fix(function): handle EXPORT_SET typed bit counts

### DIFF
--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -6117,7 +6117,132 @@ func exportSetCheck(overloads []overload, inputs []types.Type) checkResult {
 	return newCheckResultWithSuccess(0)
 }
 
+type exportSetInteger interface {
+	int8 | int16 | int32 | int64 | uint8 | uint16 | uint32 | uint64
+}
+
+func makeExportSetIntegerGetter[T exportSetInteger](vec *vector.Vector) func(uint64) (uint64, bool) {
+	param := vector.GenerateFunctionFixedTypeParameter[T](vec)
+	return func(i uint64) (uint64, bool) {
+		value, isNull := param.GetValue(i)
+		if isNull {
+			return 0, true
+		}
+		return uint64(value), false
+	}
+}
+
+func makeExportSetBitsGetter(vec *vector.Vector) (func(uint64) (uint64, bool), error) {
+	if vec.IsConstNull() {
+		return func(uint64) (uint64, bool) { return 0, true }, nil
+	}
+
+	switch vec.GetType().Oid {
+	case types.T_int8:
+		return makeExportSetIntegerGetter[int8](vec), nil
+	case types.T_int16:
+		return makeExportSetIntegerGetter[int16](vec), nil
+	case types.T_int32:
+		return makeExportSetIntegerGetter[int32](vec), nil
+	case types.T_int64:
+		return makeExportSetIntegerGetter[int64](vec), nil
+	case types.T_uint8:
+		return makeExportSetIntegerGetter[uint8](vec), nil
+	case types.T_uint16:
+		return makeExportSetIntegerGetter[uint16](vec), nil
+	case types.T_uint32:
+		return makeExportSetIntegerGetter[uint32](vec), nil
+	case types.T_uint64:
+		return makeExportSetIntegerGetter[uint64](vec), nil
+	case types.T_bit:
+		return makeExportSetIntegerGetter[uint64](vec), nil
+	case types.T_float32:
+		param := vector.GenerateFunctionFixedTypeParameter[float32](vec)
+		return func(i uint64) (uint64, bool) {
+			value, isNull := param.GetValue(i)
+			if isNull {
+				return 0, true
+			}
+			return uint64(int64(value)), false
+		}, nil
+	case types.T_float64:
+		param := vector.GenerateFunctionFixedTypeParameter[float64](vec)
+		return func(i uint64) (uint64, bool) {
+			value, isNull := param.GetValue(i)
+			if isNull {
+				return 0, true
+			}
+			return uint64(int64(value)), false
+		}, nil
+	case types.T_decimal64:
+		param := vector.GenerateFunctionFixedTypeParameter[types.Decimal64](vec)
+		scale := vec.GetType().Scale
+		return func(i uint64) (uint64, bool) {
+			value, isNull := param.GetValue(i)
+			if isNull {
+				return 0, true
+			}
+			return makeSetDecimalToBits(types.Decimal128FromInt64(int64(value)), scale), false
+		}, nil
+	case types.T_decimal128:
+		param := vector.GenerateFunctionFixedTypeParameter[types.Decimal128](vec)
+		scale := vec.GetType().Scale
+		return func(i uint64) (uint64, bool) {
+			value, isNull := param.GetValue(i)
+			if isNull {
+				return 0, true
+			}
+			return makeSetDecimalToBits(value, scale), false
+		}, nil
+	default:
+		return nil, moerr.NewInternalErrorNoCtxf("unsupported EXPORT_SET bits type %s", vec.GetType().Oid)
+	}
+}
+
+func makeExportSetNumberOfBitsGetter(vec *vector.Vector) (func(uint64) (uint64, bool), error) {
+	if vec.IsConstNull() {
+		return func(uint64) (uint64, bool) { return 0, true }, nil
+	}
+
+	switch vec.GetType().Oid {
+	case types.T_int8:
+		return makeExportSetIntegerGetter[int8](vec), nil
+	case types.T_int16:
+		return makeExportSetIntegerGetter[int16](vec), nil
+	case types.T_int32:
+		return makeExportSetIntegerGetter[int32](vec), nil
+	case types.T_int64:
+		return makeExportSetIntegerGetter[int64](vec), nil
+	case types.T_uint8:
+		return makeExportSetIntegerGetter[uint8](vec), nil
+	case types.T_uint16:
+		return makeExportSetIntegerGetter[uint16](vec), nil
+	case types.T_uint32:
+		return makeExportSetIntegerGetter[uint32](vec), nil
+	case types.T_uint64:
+		return makeExportSetIntegerGetter[uint64](vec), nil
+	case types.T_bit:
+		return makeExportSetIntegerGetter[uint64](vec), nil
+	default:
+		return nil, moerr.NewInternalErrorNoCtxf("unsupported EXPORT_SET number_of_bits type %s", vec.GetType().Oid)
+	}
+}
+
+func normalizeExportSetNumberOfBits(value uint64) int64 {
+	if value > 64 {
+		return 64
+	}
+	return int64(value)
+}
+
 func exportSetResultByteLength(bitsValue uint64, on, off, separator []byte, numberOfBits int64, maxResultLen int64) (int, bool) {
+	if numberOfBits < 0 || numberOfBits > 64 {
+		return 0, false
+	}
+	if numberOfBits == 0 {
+		return 0, true
+	}
+
 	size := int64(0)
 	add := func(count int64, width int) bool {
 		if count == 0 || width == 0 {
@@ -6161,114 +6286,9 @@ func writeExportSetResult(dst []byte, bitsValue uint64, on, off, separator []byt
 func ExportSet(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	rs := vector.MustFunctionResult[types.Varlena](result)
 
-	// First argument: bits (numeric) - handle different numeric types
-	bitsType := ivecs[0].GetType().Oid
-	var bitsUint uint64
-	var nullBits bool
-
-	// Create appropriate parameter wrapper based on type (once, outside loop)
-	var getBitsValue func(uint64) (uint64, bool)
-	switch bitsType {
-	case types.T_int8:
-		param := vector.GenerateFunctionFixedTypeParameter[int8](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
-	case types.T_int16:
-		param := vector.GenerateFunctionFixedTypeParameter[int16](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
-	case types.T_int32:
-		param := vector.GenerateFunctionFixedTypeParameter[int32](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
-	case types.T_int64:
-		param := vector.GenerateFunctionFixedTypeParameter[int64](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
-	case types.T_uint8:
-		param := vector.GenerateFunctionFixedTypeParameter[uint8](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
-	case types.T_uint16:
-		param := vector.GenerateFunctionFixedTypeParameter[uint16](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
-	case types.T_uint32:
-		param := vector.GenerateFunctionFixedTypeParameter[uint32](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
-	case types.T_uint64:
-		param := vector.GenerateFunctionFixedTypeParameter[uint64](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return val, false
-		}
-	case types.T_float32:
-		param := vector.GenerateFunctionFixedTypeParameter[float32](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(int64(val)), false
-		}
-	case types.T_float64:
-		param := vector.GenerateFunctionFixedTypeParameter[float64](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(int64(val)), false
-		}
-	default:
-		// Fallback to int64
-		param := vector.GenerateFunctionFixedTypeParameter[int64](ivecs[0])
-		getBitsValue = func(i uint64) (uint64, bool) {
-			val, null := param.GetValue(i)
-			if null {
-				return 0, true
-			}
-			return uint64(val), false
-		}
+	getBitsValue, err := makeExportSetBitsGetter(ivecs[0])
+	if err != nil {
+		return err
 	}
 
 	// Second argument: on (string)
@@ -6284,11 +6304,14 @@ func ExportSet(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc
 		separatorParam = vector.GenerateFunctionStrParameter(ivecs[3])
 	}
 
-	// Optional fifth argument: number_of_bits (int64, default 64)
-	var numberOfBitsParam vector.FunctionParameterWrapper[int64]
+	// Optional fifth argument: number_of_bits (integer, default 64)
+	var getNumberOfBits func(uint64) (uint64, bool)
 	numberOfBitsProvided := len(ivecs) > 4
 	if numberOfBitsProvided {
-		numberOfBitsParam = vector.GenerateFunctionFixedTypeParameter[int64](ivecs[4])
+		getNumberOfBits, err = makeExportSetNumberOfBitsGetter(ivecs[4])
+		if err != nil {
+			return err
+		}
 	}
 
 	for i := uint64(0); i < uint64(length); i++ {
@@ -6299,8 +6322,8 @@ func ExportSet(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc
 			continue
 		}
 
-		// Extract bits value using the appropriate getter
-		bitsUint, nullBits = getBitsValue(i)
+		// Extract bits value using the appropriate getter.
+		bitsUint, nullBits := getBitsValue(i)
 
 		if nullBits {
 			if err := rs.AppendBytes(nil, true); err != nil {
@@ -6318,32 +6341,36 @@ func ExportSet(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc
 			continue
 		}
 
-		// Get separator (default ',')
-		separator := ","
-		if separatorProvided && !ivecs[3].IsConstNull() {
-			sep, nullSep := separatorParam.GetStrValue(i)
-			if !nullSep {
-				separator = functionUtil.QuickBytesToStr(sep)
-			}
-		}
-
-		// Get number_of_bits (default 64, max 64)
-		numberOfBits := int64(64)
-		if numberOfBitsProvided && !ivecs[4].IsConstNull() {
-			nBits, nullNBits := numberOfBitsParam.GetValue(i)
-			if !nullNBits {
-				if nBits < 1 {
-					numberOfBits = 1
-				} else if nBits > 64 {
-					numberOfBits = 64
-				} else {
-					numberOfBits = nBits
+		// Get separator (default ','). A supplied NULL is distinct from an
+		// omitted argument and makes the result NULL.
+		separator := functionUtil.QuickStrToBytes(",")
+		if separatorProvided {
+			var nullSep bool
+			separator, nullSep = separatorParam.GetStrValue(i)
+			if nullSep {
+				if err := rs.AppendBytes(nil, true); err != nil {
+					return err
 				}
+				continue
 			}
 		}
 
-		separatorBytes := functionUtil.QuickStrToBytes(separator)
-		size, ok := exportSetResultByteLength(bitsUint, on, off, separatorBytes, numberOfBits,
+		// MySQL treats number_of_bits as an unsigned value and clips it to 64.
+		// Converting signed values to uint64 before clipping preserves the
+		// established -1 => 64 behavior without narrowing uint64 inputs.
+		numberOfBits := int64(64)
+		if numberOfBitsProvided {
+			nBits, nullNBits := getNumberOfBits(i)
+			if nullNBits {
+				if err := rs.AppendBytes(nil, true); err != nil {
+					return err
+				}
+				continue
+			}
+			numberOfBits = normalizeExportSetNumberOfBits(nBits)
+		}
+
+		size, ok := exportSetResultByteLength(bitsUint, on, off, separator, numberOfBits,
 			maxStringFunctionResultLength(result))
 		if !ok {
 			if err := rs.AppendBytes(nil, true); err != nil {
@@ -6352,7 +6379,7 @@ func ExportSet(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc
 			continue
 		}
 		if err := rs.AppendBytesWithWriter(size, func(dst []byte) error {
-			writeExportSetResult(dst, bitsUint, on, off, separatorBytes, numberOfBits)
+			writeExportSetResult(dst, bitsUint, on, off, separator, numberOfBits)
 			return nil
 		}); err != nil {
 			return err

--- a/pkg/sql/plan/function/func_export_set_test.go
+++ b/pkg/sql/plan/function/func_export_set_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func runExportSetTestCase(t *testing.T, inputs []FunctionTestInput, wanted []string, nullList []bool) {
+	t.Helper()
+	proc := testutil.NewProcess(t)
+	t.Cleanup(proc.Free)
+	testCase := NewFunctionTestCase(
+		proc,
+		inputs,
+		NewFunctionTestResult(types.T_varchar.ToType(), false, wanted, nullList),
+		ExportSet,
+	)
+	succeeded, errInfo := testCase.Run()
+	require.True(t, succeeded, errInfo)
+}
+
+func exportSetStringInput(values []string, nullList []bool) FunctionTestInput {
+	return NewFunctionTestInput(types.T_varchar.ToType(), values, nullList)
+}
+
+func exportSetCountInput(typ types.Type, values any, constant bool) FunctionTestInput {
+	if constant {
+		return NewFunctionTestConstInput(typ, values, nil)
+	}
+	return NewFunctionTestInput(typ, values, nil)
+}
+
+func TestExportSetNumberOfBitsIntegerTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  types.Type
+		val  any
+	}{
+		{"int8", types.T_int8.ToType(), []int8{4}},
+		{"int16", types.T_int16.ToType(), []int16{4}},
+		{"int32", types.T_int32.ToType(), []int32{4}},
+		{"int64", types.T_int64.ToType(), []int64{4}},
+		{"uint8", types.T_uint8.ToType(), []uint8{4}},
+		{"uint16", types.T_uint16.ToType(), []uint16{4}},
+		{"uint32", types.T_uint32.ToType(), []uint32{4}},
+		{"uint64", types.T_uint64.ToType(), []uint64{4}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, constant := range []bool{false, true} {
+				inputs := []FunctionTestInput{
+					NewFunctionTestInput(types.T_int64.ToType(), []int64{5}, nil),
+					exportSetStringInput([]string{"Y"}, nil),
+					exportSetStringInput([]string{"N"}, nil),
+					exportSetStringInput([]string{","}, nil),
+					exportSetCountInput(tc.typ, tc.val, constant),
+				}
+				runExportSetTestCase(t, inputs, []string{"Y,N,Y,N"}, nil)
+			}
+		})
+	}
+}
+
+func TestExportSetNumberOfBitsBoundaries(t *testing.T) {
+	allOnes := strings.Repeat("Y", 64)
+	runExportSetTestCase(t, []FunctionTestInput{
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{0, -1, 5}, nil),
+		exportSetStringInput([]string{"Y", "Y", "Y"}, nil),
+		exportSetStringInput([]string{"N", "N", "N"}, nil),
+		exportSetStringInput([]string{"", "", "-"}, nil),
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{0, -1, 65}, nil),
+	}, []string{"", allOnes, "Y-N-Y-N" + strings.Repeat("-N", 60)}, nil)
+
+	runExportSetTestCase(t, []FunctionTestInput{
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{-1}, nil),
+		exportSetStringInput([]string{"Y"}, nil),
+		exportSetStringInput([]string{"N"}, nil),
+		exportSetStringInput([]string{""}, nil),
+		NewFunctionTestInput(types.T_uint64.ToType(), []uint64{^uint64(0)}, nil),
+	}, []string{allOnes}, nil)
+}
+
+func TestExportSetExplicitNullOptionalArguments(t *testing.T) {
+	runExportSetTestCase(t, []FunctionTestInput{
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{5, 5}, nil),
+		exportSetStringInput([]string{"Y", "Y"}, nil),
+		exportSetStringInput([]string{"N", "N"}, nil),
+		exportSetStringInput([]string{",", "-"}, []bool{false, true}),
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{4, 4}, nil),
+	}, []string{"Y,N,Y,N", ""}, []bool{false, true})
+
+	runExportSetTestCase(t, []FunctionTestInput{
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{5, 5}, nil),
+		exportSetStringInput([]string{"Y", "Y"}, nil),
+		exportSetStringInput([]string{"N", "N"}, nil),
+		exportSetStringInput([]string{",", ","}, nil),
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{4, 4}, []bool{false, true}),
+	}, []string{"Y,N,Y,N", ""}, []bool{false, true})
+}
+
+func TestExportSetBitsBitAndDecimalTypes(t *testing.T) {
+	decimal64Five, err := types.ParseDecimal64("5.0", 18, 1)
+	require.NoError(t, err)
+	decimal64NegativeOne, err := types.ParseDecimal64("-1.0", 18, 1)
+	require.NoError(t, err)
+	decimal128Five, err := types.ParseDecimal128("5.0", 38, 1)
+	require.NoError(t, err)
+	decimal128NegativeOne, err := types.ParseDecimal128("-1.0", 38, 1)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name  string
+		input FunctionTestInput
+		want  []string
+	}{
+		{
+			name:  "bit",
+			input: NewFunctionTestInput(types.New(types.T_bit, 8, 0), []uint64{0x85}, nil),
+			want:  []string{"Y,N,Y,N,N,N,N,Y"},
+		},
+		{
+			name:  "decimal64",
+			input: NewFunctionTestInput(types.New(types.T_decimal64, 18, 1), []types.Decimal64{decimal64Five, decimal64NegativeOne}, nil),
+			want:  []string{"Y,N,Y,N", "Y,Y,Y,Y"},
+		},
+		{
+			name:  "decimal128",
+			input: NewFunctionTestInput(types.New(types.T_decimal128, 38, 1), []types.Decimal128{decimal128Five, decimal128NegativeOne}, nil),
+			want:  []string{"Y,N,Y,N", "Y,Y,Y,Y"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bits := tc.input
+			countValue := int64(4)
+			if tc.name == "bit" {
+				countValue = 8
+			}
+			countValues := make([]int64, len(tc.want))
+			for i := range countValues {
+				countValues[i] = countValue
+			}
+			inputs := []FunctionTestInput{
+				bits,
+				exportSetStringInput(make([]string, len(tc.want)), nil),
+				exportSetStringInput(make([]string, len(tc.want)), nil),
+				exportSetStringInput(make([]string, len(tc.want)), nil),
+				NewFunctionTestInput(types.T_int64.ToType(), countValues, nil),
+			}
+			for i := range tc.want {
+				inputs[1].values.([]string)[i] = "Y"
+				inputs[2].values.([]string)[i] = "N"
+				inputs[3].values.([]string)[i] = ","
+			}
+			runExportSetTestCase(t, inputs, tc.want, nil)
+
+			if tc.name == "bit" {
+				runExportSetTestCase(t, []FunctionTestInput{
+					NewFunctionTestConstInput(bits.typ, []uint64{0x85}, nil),
+					exportSetStringInput([]string{"Y"}, nil),
+					exportSetStringInput([]string{"N"}, nil),
+					exportSetStringInput([]string{","}, nil),
+					NewFunctionTestConstInput(types.T_int64.ToType(), []int64{8}, nil),
+				}, tc.want[:1], nil)
+			}
+		})
+	}
+}
+
+func TestExportSetDecimal128PreservesIntegerPrecision(t *testing.T) {
+	value, err := types.ParseDecimal128("9007199254740993", 38, 0)
+	require.NoError(t, err)
+	wanted := []string{"Y"}
+	parts := make([]string, 54)
+	for bit := range parts {
+		parts[bit] = "N"
+	}
+	parts[0] = "Y"
+	parts[53] = "Y"
+	wanted[0] = strings.Join(parts, ",")
+
+	runExportSetTestCase(t, []FunctionTestInput{
+		NewFunctionTestInput(types.New(types.T_decimal128, 38, 0), []types.Decimal128{value}, nil),
+		exportSetStringInput([]string{"Y"}, nil),
+		exportSetStringInput([]string{"N"}, nil),
+		exportSetStringInput([]string{","}, nil),
+		NewFunctionTestInput(types.T_int64.ToType(), []int64{54}, nil),
+	}, wanted, nil)
+}
+
+func TestExportSetResultByteLengthZeroAndInvalid(t *testing.T) {
+	size, ok := exportSetResultByteLength(0, []byte("Y"), []byte("N"), []byte(","), 0, 1024)
+	require.True(t, ok)
+	require.Zero(t, size)
+
+	_, ok = exportSetResultByteLength(0, []byte("Y"), []byte("N"), []byte(","), -1, 1024)
+	require.False(t, ok)
+	_, ok = exportSetResultByteLength(0, []byte("Y"), []byte("N"), []byte(","), 65, 1024)
+	require.False(t, ok)
+}

--- a/test/distributed/cases/function/func_string_export_set.result
+++ b/test/distributed/cases/function/func_string_export_set.result
@@ -75,18 +75,57 @@ export_set_null_off
 null
 SELECT EXPORT_SET(5, 'Y', 'N', NULL, 4) AS export_set_null_sep;
 export_set_null_sep
-Y,N,Y,N
+null
 SELECT EXPORT_SET(5, 'Y', 'N', ',', NULL) AS export_set_null_bits_count;
 export_set_null_bits_count
-Y,N,Y,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N
-CREATE TABLE t1(bits INT, on_str VARCHAR(10), off_str VARCHAR(10));
-INSERT INTO t1 VALUES (5, 'Y', 'N'), (10, 'ON', 'OFF'), (15, '1', '0');
-SELECT bits, EXPORT_SET(bits, on_str, off_str, ',', 4) AS result FROM t1;
+null
+CREATE TABLE t1(bits INT, on_str VARCHAR(10), off_str VARCHAR(10), number_of_bits INT);
+INSERT INTO t1 VALUES (5, 'Y', 'N', 4), (10, 'ON', 'OFF', 4), (15, '1', '0', 4);
+SELECT bits, EXPORT_SET(bits, on_str, off_str, ',', number_of_bits) AS result FROM t1;
 bits    result
 5    Y,N,Y,N
 10    OFF,ON,OFF,ON
 15    1,1,1,1
 DROP TABLE t1;
+CREATE TABLE t_number_of_bits(
+bits INT,
+n_int8 TINYINT,
+n_int16 SMALLINT,
+n_int32 INT,
+n_int64 BIGINT,
+n_uint8 TINYINT UNSIGNED,
+n_uint16 SMALLINT UNSIGNED,
+n_uint32 INT UNSIGNED,
+n_uint64 BIGINT UNSIGNED
+);
+INSERT INTO t_number_of_bits VALUES (5, 4, 4, 4, 4, 4, 4, 4, 4);
+SELECT
+EXPORT_SET(bits, 'Y', 'N', ',', n_int8) AS int8_result,
+EXPORT_SET(bits, 'Y', 'N', ',', n_int16) AS int16_result,
+EXPORT_SET(bits, 'Y', 'N', ',', n_int32) AS int32_result,
+EXPORT_SET(bits, 'Y', 'N', ',', n_int64) AS int64_result,
+EXPORT_SET(bits, 'Y', 'N', ',', n_uint8) AS uint8_result,
+EXPORT_SET(bits, 'Y', 'N', ',', n_uint16) AS uint16_result,
+EXPORT_SET(bits, 'Y', 'N', ',', n_uint32) AS uint32_result,
+EXPORT_SET(bits, 'Y', 'N', ',', n_uint64) AS uint64_result
+FROM t_number_of_bits;
+int8_result    int16_result    int32_result    int64_result    uint8_result    uint16_result    uint32_result    uint64_result
+Y,N,Y,N    Y,N,Y,N    Y,N,Y,N    Y,N,Y,N    Y,N,Y,N    Y,N,Y,N    Y,N,Y,N    Y,N,Y,N
+DROP TABLE t_number_of_bits;
+CREATE TABLE t_export_set_numeric(
+bits_bit BIT(8),
+bits_decimal64 DECIMAL(18, 1),
+bits_decimal128 DECIMAL(38, 1)
+);
+INSERT INTO t_export_set_numeric VALUES (b'10000101', 5.0, 5.0);
+SELECT
+EXPORT_SET(bits_bit, 'Y', 'N', ',', 8) AS bit_result,
+EXPORT_SET(bits_decimal64, 'Y', 'N', ',', 4) AS decimal64_result,
+EXPORT_SET(bits_decimal128, 'Y', 'N', ',', 4) AS decimal128_result
+FROM t_export_set_numeric;
+bit_result    decimal64_result    decimal128_result
+Y,N,Y,N,N,N,N,Y    Y,N,Y,N    Y,N,Y,N
+DROP TABLE t_export_set_numeric;
 CREATE TABLE t1(bits INT);
 INSERT INTO t1 VALUES (5), (10), (15);
 SELECT * FROM t1 WHERE EXPORT_SET(bits, 'Y', 'N', ',', 4) LIKE 'Y%';
@@ -96,7 +135,10 @@ bits
 DROP TABLE t1;
 SELECT EXPORT_SET(0, 'Y', 'N', ',', 0) AS export_set_zero_bits;
 export_set_zero_bits
-N
+
 SELECT EXPORT_SET(0, 'Y', 'N', ',', 1) AS export_set_one_bit_zero;
 export_set_one_bit_zero
 N
+SELECT LENGTH(EXPORT_SET(-1, 'Y', 'N', ',', -1)) AS export_set_negative_count_length;
+export_set_negative_count_length
+127

--- a/test/distributed/cases/function/func_string_export_set.test
+++ b/test/distributed/cases/function/func_string_export_set.test
@@ -44,11 +44,50 @@ SELECT EXPORT_SET(5, 'Y', NULL, ',', 4) AS export_set_null_off;
 SELECT EXPORT_SET(5, 'Y', 'N', NULL, 4) AS export_set_null_sep;
 SELECT EXPORT_SET(5, 'Y', 'N', ',', NULL) AS export_set_null_bits_count;
 
-# Table usage
-CREATE TABLE t1(bits INT, on_str VARCHAR(10), off_str VARCHAR(10));
-INSERT INTO t1 VALUES (5, 'Y', 'N'), (10, 'ON', 'OFF'), (15, '1', '0');
-SELECT bits, EXPORT_SET(bits, on_str, off_str, ',', 4) AS result FROM t1;
+# Table usage, including a concrete INT number_of_bits column.
+CREATE TABLE t1(bits INT, on_str VARCHAR(10), off_str VARCHAR(10), number_of_bits INT);
+INSERT INTO t1 VALUES (5, 'Y', 'N', 4), (10, 'ON', 'OFF', 4), (15, '1', '0', 4);
+SELECT bits, EXPORT_SET(bits, on_str, off_str, ',', number_of_bits) AS result FROM t1;
 DROP TABLE t1;
+
+# All supported integer widths for number_of_bits.
+CREATE TABLE t_number_of_bits(
+    bits INT,
+    n_int8 TINYINT,
+    n_int16 SMALLINT,
+    n_int32 INT,
+    n_int64 BIGINT,
+    n_uint8 TINYINT UNSIGNED,
+    n_uint16 SMALLINT UNSIGNED,
+    n_uint32 INT UNSIGNED,
+    n_uint64 BIGINT UNSIGNED
+);
+INSERT INTO t_number_of_bits VALUES (5, 4, 4, 4, 4, 4, 4, 4, 4);
+SELECT
+    EXPORT_SET(bits, 'Y', 'N', ',', n_int8) AS int8_result,
+    EXPORT_SET(bits, 'Y', 'N', ',', n_int16) AS int16_result,
+    EXPORT_SET(bits, 'Y', 'N', ',', n_int32) AS int32_result,
+    EXPORT_SET(bits, 'Y', 'N', ',', n_int64) AS int64_result,
+    EXPORT_SET(bits, 'Y', 'N', ',', n_uint8) AS uint8_result,
+    EXPORT_SET(bits, 'Y', 'N', ',', n_uint16) AS uint16_result,
+    EXPORT_SET(bits, 'Y', 'N', ',', n_uint32) AS uint32_result,
+    EXPORT_SET(bits, 'Y', 'N', ',', n_uint64) AS uint64_result
+FROM t_number_of_bits;
+DROP TABLE t_number_of_bits;
+
+# BIT and DECIMAL bits columns retain their native physical representation.
+CREATE TABLE t_export_set_numeric(
+    bits_bit BIT(8),
+    bits_decimal64 DECIMAL(18, 1),
+    bits_decimal128 DECIMAL(38, 1)
+);
+INSERT INTO t_export_set_numeric VALUES (b'10000101', 5.0, 5.0);
+SELECT
+    EXPORT_SET(bits_bit, 'Y', 'N', ',', 8) AS bit_result,
+    EXPORT_SET(bits_decimal64, 'Y', 'N', ',', 4) AS decimal64_result,
+    EXPORT_SET(bits_decimal128, 'Y', 'N', ',', 4) AS decimal128_result
+FROM t_export_set_numeric;
+DROP TABLE t_export_set_numeric;
 
 # WHERE clause
 CREATE TABLE t1(bits INT);
@@ -59,4 +98,4 @@ DROP TABLE t1;
 # Edge cases
 SELECT EXPORT_SET(0, 'Y', 'N', ',', 0) AS export_set_zero_bits;
 SELECT EXPORT_SET(0, 'Y', 'N', ',', 1) AS export_set_one_bit_zero;
-
+SELECT LENGTH(EXPORT_SET(-1, 'Y', 'N', ',', -1)) AS export_set_negative_count_length;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28210
Fixes #28211

## What this PR does / why we need it:

### Root cause

The binder accepts concrete integer vectors for EXPORT_SET(number_of_bits), but the executor unconditionally requested an int64 physical vector. INT and other narrow/signed/unsigned column vectors therefore reached a physical-type assertion and raised an internal error. The same accepted first-argument contract also had reachable BIT and DECIMAL64/DECIMAL128 column paths that fell through to the int64 reader.

The existing boundary normalization changed every number_of_bits below one to one. That made an explicit zero return one output token instead of a non-NULL empty string, and did not preserve MySQL's unsigned treatment of negative values.

### Fix

- Select a typed getter once per invocation for every accepted signed/unsigned integer width.
- Preserve native BIT and DECIMAL64/DECIMAL128 bits vectors; decimal conversion reuses the existing scale-aware MAKE_SET conversion.
- Read number_of_bits without narrowing, then clip its unsigned representation to 64. Omitted means 64, zero means zero, values above 64 and negative signed values become 64.
- Distinguish omitted optional arguments from supplied NULL. A supplied NULL separator or count now returns NULL.
- Make zero-length result sizing safe so separator-count arithmetic cannot underflow.
- Return an ordinary internal error for an unsupported physical type instead of falling through to a mismatched type assertion.

### Correctness and risk boundaries

Positive counts, bit order, separators, on/off NULL propagation, negative bit values, and the existing result-size limit are preserved. No retry, concurrency, storage, planner, or unrelated function behavior is changed. Floating-point bits conversion is intentionally unchanged; this PR does not claim to broaden that pre-existing compatibility surface.

The count is clipped before result sizing and writing, so user-controlled values cannot create work beyond 64 bit positions. Existing max-result checks still turn oversized output into NULL rather than allocating it. Getter selection is outside the row loop; the common omitted-separator path uses the existing zero-copy comma conversion and no new synchronization or unbounded buffering is introduced.

### Validation

- Added focused UT coverage for all eight integer count widths in vector and constant paths; zero, negative, 65, UINT64 max; row-level NULL; BIT; DECIMAL64/DECIMAL128; high-precision decimal; and result-size invalid/zero boundaries.
- Added public BVT coverage for an INT count column, all integer count widths, BIT/DECIMAL bits columns, explicit NULL, zero, and negative count behavior.
- Exact-main CN black-box validation passed for the reported reproductions and all added SQL cases.
- Normal mo-tester comparison passed 46/46 (100%) twice against the same CN instance, including cleanup and rerun.
- GOWORK=off go test -mod=readonly ./pkg/sql/plan/function -count=1 passed.
- GOWORK=off go vet -mod=readonly ./pkg/sql/plan/function passed.
- Incremental golangci-lint reported 0 issues.
- make build and git diff --check passed.

The change is based on commit 23b20ea909 (origin/main at task start); no rebase was performed after unrelated main advancement.