### PR TITLE
fix: preserve BIT arithmetic unsigned range

### DIFF
--- a/pkg/sql/plan/function/function_test.go
+++ b/pkg/sql/plan/function/function_test.go
@@ -139,6 +139,78 @@ func Test_fixedTypeCastRule1(t *testing.T) {
 	}
 }
 
+func TestArithmeticTypeCastRule1BitSignedBigintUsesDecimal(t *testing.T) {
+	bit64 := types.New(types.T_bit, 64, 0)
+	signedBigint := types.T_int64.ToType()
+	want := types.New(types.T_decimal128, 38, 0)
+
+	for _, test := range []struct {
+		name  string
+		left  types.Type
+		right types.Type
+	}{
+		{name: "bit plus signed bigint", left: bit64, right: signedBigint},
+		{name: "signed bigint plus bit", left: signedBigint, right: bit64},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			hasCast, left, right := arithmeticTypeCastRule1(test.left, test.right)
+			require.True(t, hasCast)
+			require.Equal(t, want, left)
+			require.Equal(t, want, right)
+		})
+	}
+
+	// The generic rule remains the comparison contract; only arithmetic uses
+	// the widened mixed-integer domain.
+	hasCast, left, right := fixedTypeCastRule1(bit64, signedBigint)
+	require.True(t, hasCast)
+	require.Equal(t, signedBigint, left)
+	require.Equal(t, signedBigint, right)
+}
+
+func TestGetArithmeticFunctionBitSignedBigintUsesDecimal(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+	want := types.New(types.T_decimal128, 38, 0)
+
+	for _, operands := range []struct {
+		name        string
+		left, right types.Type
+	}{
+		{name: "bit-left", left: bit64, right: types.T_int64.ToType()},
+		{name: "bit-right", left: types.T_int64.ToType(), right: bit64},
+	} {
+		for _, name := range []string{"+", "-", "*", "%"} {
+			t.Run(operands.name+"/"+name, func(t *testing.T) {
+				get, err := GetFunctionByName(proc.Ctx, name, []types.Type{operands.left, operands.right})
+				require.NoError(t, err)
+				targets, shouldCast := get.ShouldDoImplicitTypeCast()
+				require.True(t, shouldCast)
+				require.Equal(t, []types.Type{want, want}, targets)
+				require.Equal(t, want, get.GetReturnType())
+			})
+		}
+	}
+}
+
+func TestArithmeticTypeCastRule1BitWidthsUseUnsignedDomain(t *testing.T) {
+	int64Type := types.T_int64.ToType()
+	want := types.New(types.T_decimal128, 38, 0)
+
+	// The result of an arithmetic subtree can exceed the declared BIT width, so
+	// use the full unsigned domain even for narrow BIT inputs.
+	for _, width := range []int32{1, 8, 63, 64} {
+		t.Run(fmt.Sprintf("bit-%d", width), func(t *testing.T) {
+			hasCast, left, right := arithmeticTypeCastRule1(
+				types.New(types.T_bit, width, 0), int64Type,
+			)
+			require.True(t, hasCast)
+			require.Equal(t, want, left)
+			require.Equal(t, want, right)
+		})
+	}
+}
+
 func TestComparisonTypeCastRulePreservesTextCharset(t *testing.T) {
 	for _, test := range []struct {
 		name     string

--- a/pkg/sql/plan/function/list_operator.go
+++ b/pkg/sql/plan/function/list_operator.go
@@ -1787,7 +1787,7 @@ var supportedOperators = []FuncNew{
 		layout:     BINARY_ARITHMETIC_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
 			if len(inputs) == 2 {
-				has, t1, t2 := fixedTypeCastRule1(inputs[0], inputs[1])
+				has, t1, t2 := arithmeticTypeCastRule1(inputs[0], inputs[1])
 				if has {
 					if plusOperatorSupportsVectorScalar(t1, t2) {
 						return newCheckResultWithCast(1, []types.Type{t1, t2})
@@ -1864,7 +1864,7 @@ var supportedOperators = []FuncNew{
 		layout:     BINARY_ARITHMETIC_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
 			if len(inputs) == 2 {
-				has, t1, t2 := fixedTypeCastRule1(inputs[0], inputs[1])
+				has, t1, t2 := arithmeticTypeCastRule1(inputs[0], inputs[1])
 				if has {
 					if minusOperatorSupportsVectorScalar(t1, t2) {
 						return newCheckResultWithCast(1, []types.Type{t1, t2})
@@ -1939,7 +1939,7 @@ var supportedOperators = []FuncNew{
 		layout:     BINARY_ARITHMETIC_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
 			if len(inputs) == 2 {
-				has, t1, t2 := fixedTypeCastRule1(inputs[0], inputs[1])
+				has, t1, t2 := arithmeticTypeCastRule1(inputs[0], inputs[1])
 				if has {
 					// Multiply-specific: when coercion promotes intN×D64 to
 					// D128×D128, downgrade to D64×D64. The d64Mul kernel produces
@@ -2147,7 +2147,7 @@ var supportedOperators = []FuncNew{
 		layout:     BINARY_ARITHMETIC_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
 			if len(inputs) == 2 {
-				has, t1, t2 := fixedTypeCastRule1(inputs[0], inputs[1])
+				has, t1, t2 := arithmeticTypeCastRule1(inputs[0], inputs[1])
 				if has {
 					if modOperatorSupports(t1, t2) {
 						return newCheckResultWithCast(0, []types.Type{t1, t2})

--- a/pkg/sql/plan/function/numeric_resolver.go
+++ b/pkg/sql/plan/function/numeric_resolver.go
@@ -289,7 +289,7 @@ func resolveNumericBinaryTypes(
 	case numericOpDiv, numericOpIntegerDiv:
 		cast, castLeft, castRight = fixedTypeCastRule2(left, right)
 	default:
-		cast, castLeft, castRight = fixedTypeCastRule1(left, right)
+		cast, castLeft, castRight = arithmeticTypeCastRule1(left, right)
 	}
 	if cast {
 		left, right = castLeft, castRight

--- a/pkg/sql/plan/function/numeric_resolver_test.go
+++ b/pkg/sql/plan/function/numeric_resolver_test.go
@@ -430,6 +430,32 @@ func TestResolveNumericBinaryTypesByName(t *testing.T) {
 	}
 }
 
+func TestResolveNumericBinaryTypesBitSignedBigintUsesDecimal(t *testing.T) {
+	bit64 := types.New(types.T_bit, 64, 0)
+	int64Type := types.New(types.T_int64, 64, 0)
+	want := types.New(types.T_decimal128, 38, 0)
+
+	for _, operator := range []string{"+", "-", "*", "%"} {
+		for _, operands := range []struct {
+			name        string
+			left, right types.Type
+		}{
+			{name: "bit-left", left: bit64, right: int64Type},
+			{name: "bit-right", left: int64Type, right: bit64},
+		} {
+			t.Run(operator+"/"+operands.name, func(t *testing.T) {
+				left, right, result, ok := ResolveNumericBinaryTypes(
+					operator, operands.left, operands.right, nil,
+				)
+				require.True(t, ok)
+				require.Equal(t, want, left)
+				require.Equal(t, want, right)
+				require.Equal(t, want, result)
+			})
+		}
+	}
+}
+
 func typePtr(typ types.Type) *types.Type {
 	return &typ
 }

--- a/pkg/sql/plan/function/type_check.go
+++ b/pkg/sql/plan/function/type_check.go
@@ -106,6 +106,20 @@ func fixedTypeCastRule1(s1, s2 types.Type) (bool, types.Type, types.Type) {
 	return false, s1, s2
 }
 
+// arithmeticTypeCastRule1 applies the fixed coercion rules used by the four
+// arithmetic operators. BIT values are stored and executed as uint64,
+// so pairing BIT with a signed bigint must use the same exact DECIMAL128
+// domain as UINT64 with a signed bigint. Keeping this adjustment here, rather
+// than changing fixedTypeCastRule1, leaves comparison coercion unchanged.
+func arithmeticTypeCastRule1(s1, s2 types.Type) (bool, types.Type, types.Type) {
+	if s1.Oid == types.T_bit && s2.Oid == types.T_int64 {
+		s1.Oid = types.T_uint64
+	} else if s1.Oid == types.T_int64 && s2.Oid == types.T_bit {
+		s2.Oid = types.T_uint64
+	}
+	return fixedTypeCastRule1(s1, s2)
+}
+
 // a fixed type cast rule for
 //  1. Div
 //  2. IntegerDiv

--- a/test/distributed/cases/dtype/bit.result
+++ b/test/distributed/cases/dtype/bit.result
@@ -252,3 +252,83 @@ FROM prepared_bit_null ORDER BY id;
 3  ¦  1  ¦  1  ¦  1  ¦  null  ¦  null  ¦  null
 DEALLOCATE PREPARE prepared_bit_insert;
 DROP TABLE prepared_bit_null;
+DROP TABLE IF EXISTS issue_28685_bit64;
+CREATE TABLE issue_28685_bit64 (id INT PRIMARY KEY, b BIT(64));
+INSERT INTO issue_28685_bit64 VALUES
+(1, 0),
+(2, 9223372036854775807),
+(3, 9223372036854775808),
+(4, 18446744073709551615),
+(5, NULL);
+SELECT b * b * b * b * b * b * b * b + 0 AS bit8_derived
+FROM (SELECT CAST(255 AS BIT(8)) AS b) AS bit8_source;
+➤ bit8_derived[3,38,0]  𝄀
+17878103347812890625
+SELECT (b + 0) * (b + 0) AS overflow_value
+FROM issue_28685_bit64 WHERE id = 4;
+Data truncation: data out of range: data type DECIMAL, invalid input: Decimal128 Mul overflow: 18446744073709551615*18446744073709551615
+SELECT 1 AS after_overflow;
+➤ after_overflow[-5,64,0]  𝄀
+1
+SELECT id,
+b + 0 AS plus_zero,
+0 + b AS reverse_plus,
+b - 1 AS minus_one,
+1 - b AS reverse_minus,
+b * 1 AS multiply_one,
+1 * b AS reverse_multiply,
+b % 2 AS mod_two
+FROM issue_28685_bit64 ORDER BY id;
+➤ id[4,32,0]  ¦  plus_zero[3,38,0]  ¦  reverse_plus[3,38,0]  ¦  minus_one[3,38,0]  ¦  reverse_minus[3,38,0]  ¦  multiply_one[3,38,0]  ¦  reverse_multiply[3,38,0]  ¦  mod_two[3,38,0]  𝄀
+1  ¦  0  ¦  0  ¦  -1  ¦  1  ¦  0  ¦  0  ¦  0  𝄀
+2  ¦  9223372036854775807  ¦  9223372036854775807  ¦  9223372036854775806  ¦  -9223372036854775806  ¦  9223372036854775807  ¦  9223372036854775807  ¦  1  𝄀
+3  ¦  9223372036854775808  ¦  9223372036854775808  ¦  9223372036854775807  ¦  -9223372036854775807  ¦  9223372036854775808  ¦  9223372036854775808  ¦  0  𝄀
+4  ¦  18446744073709551615  ¦  18446744073709551615  ¦  18446744073709551614  ¦  -18446744073709551614  ¦  18446744073709551615  ¦  18446744073709551615  ¦  1  𝄀
+5  ¦  null  ¦  null  ¦  null  ¦  null  ¦  null  ¦  null  ¦  null
+PREPARE issue_28685_bit64_stmt FROM
+'SELECT id, b + ? AS value FROM issue_28685_bit64 ORDER BY id';
+SET @issue_28685_bit64_param = 0;
+EXECUTE issue_28685_bit64_stmt USING @issue_28685_bit64_param;
+➤ id[4,32,0]  ¦  value[3,38,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  9223372036854775807  𝄀
+3  ¦  9223372036854775808  𝄀
+4  ¦  18446744073709551615  𝄀
+5  ¦  null
+SET @issue_28685_bit64_param = -1;
+EXECUTE issue_28685_bit64_stmt USING @issue_28685_bit64_param;
+➤ id[4,32,0]  ¦  value[3,38,0]  𝄀
+1  ¦  -1  𝄀
+2  ¦  9223372036854775806  𝄀
+3  ¦  9223372036854775807  𝄀
+4  ¦  18446744073709551614  𝄀
+5  ¦  null
+SET @issue_28685_bit64_param = 0;
+EXECUTE issue_28685_bit64_stmt USING @issue_28685_bit64_param;
+➤ id[4,32,0]  ¦  value[3,38,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  9223372036854775807  𝄀
+3  ¦  9223372036854775808  𝄀
+4  ¦  18446744073709551615  𝄀
+5  ¦  null
+DEALLOCATE PREPARE issue_28685_bit64_stmt;
+DROP TABLE IF EXISTS issue_28685_bit64_ctas;
+CREATE TABLE issue_28685_bit64_ctas AS
+SELECT id, b + 0 AS value FROM issue_28685_bit64;
+SELECT column_name, data_type, numeric_precision, numeric_scale
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+AND table_name = 'issue_28685_bit64_ctas'
+ORDER BY ordinal_position;
+➤ column_name[12,256,0]  ¦  data_type[12,65535,0]  ¦  numeric_precision[-5,64,0]  ¦  numeric_scale[-5,64,0]  𝄀
+id  ¦  int  ¦  10  ¦  0  𝄀
+value  ¦  decimal  ¦  38  ¦  0
+SELECT id, value FROM issue_28685_bit64_ctas ORDER BY id;
+➤ id[4,32,0]  ¦  value[3,38,0]  𝄀
+1  ¦  0  𝄀
+2  ¦  9223372036854775807  𝄀
+3  ¦  9223372036854775808  𝄀
+4  ¦  18446744073709551615  𝄀
+5  ¦  null
+DROP TABLE issue_28685_bit64_ctas;
+DROP TABLE issue_28685_bit64;

--- a/test/distributed/cases/dtype/bit.sql
+++ b/test/distributed/cases/dtype/bit.sql
@@ -110,3 +110,50 @@ SELECT id, b1 IS NULL, b8 IS NULL, b64 IS NULL, HEX(b1), HEX(b8), HEX(b64)
 FROM prepared_bit_null ORDER BY id;
 DEALLOCATE PREPARE prepared_bit_insert;
 DROP TABLE prepared_bit_null;
+
+-- BIT(64) arithmetic must preserve the unsigned upper half when paired with
+-- signed integer literals.
+DROP TABLE IF EXISTS issue_28685_bit64;
+CREATE TABLE issue_28685_bit64 (id INT PRIMARY KEY, b BIT(64));
+INSERT INTO issue_28685_bit64 VALUES
+    (1, 0),
+    (2, 9223372036854775807),
+    (3, 9223372036854775808),
+    (4, 18446744073709551615),
+    (5, NULL);
+SELECT b * b * b * b * b * b * b * b + 0 AS bit8_derived
+FROM (SELECT CAST(255 AS BIT(8)) AS b) AS bit8_source;
+SELECT (b + 0) * (b + 0) AS overflow_value
+FROM issue_28685_bit64 WHERE id = 4;
+SELECT 1 AS after_overflow;
+SELECT id,
+       b + 0 AS plus_zero,
+       0 + b AS reverse_plus,
+       b - 1 AS minus_one,
+       1 - b AS reverse_minus,
+       b * 1 AS multiply_one,
+       1 * b AS reverse_multiply,
+       b % 2 AS mod_two
+FROM issue_28685_bit64 ORDER BY id;
+
+PREPARE issue_28685_bit64_stmt FROM
+    'SELECT id, b + ? AS value FROM issue_28685_bit64 ORDER BY id';
+SET @issue_28685_bit64_param = 0;
+EXECUTE issue_28685_bit64_stmt USING @issue_28685_bit64_param;
+SET @issue_28685_bit64_param = -1;
+EXECUTE issue_28685_bit64_stmt USING @issue_28685_bit64_param;
+SET @issue_28685_bit64_param = 0;
+EXECUTE issue_28685_bit64_stmt USING @issue_28685_bit64_param;
+DEALLOCATE PREPARE issue_28685_bit64_stmt;
+
+DROP TABLE IF EXISTS issue_28685_bit64_ctas;
+CREATE TABLE issue_28685_bit64_ctas AS
+    SELECT id, b + 0 AS value FROM issue_28685_bit64;
+SELECT column_name, data_type, numeric_precision, numeric_scale
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'issue_28685_bit64_ctas'
+ORDER BY ordinal_position;
+SELECT id, value FROM issue_28685_bit64_ctas ORDER BY id;
+DROP TABLE issue_28685_bit64_ctas;
+DROP TABLE issue_28685_bit64;


### PR DESCRIPTION
## Summary

- Keep BIT/signed BIGINT arithmetic in the existing exact UINT64 + INT64 -> DECIMAL128 domain for `+`, `-`, `*`, and `%`.
- Keep comparison, index-related coercion, `/`, and `DIV` on their existing paths.
- Add boundary, both-order, negative, NULL, derived BIT, overflow-recovery, prepared, and CTAS precision/scale regressions.

Fixes #28685

## Root cause

The shared fixed coercion matrix mapped `BIT` + `INT64` to signed `INT64` before execution. The BIT executor already uses `uint64`, so values above `INT64_MAX` failed during the planner-inserted cast. The fix applies the existing unsigned/signed mixed-integer DECIMAL128 rule only to the four arithmetic operators.

## Validation

- `make config`
- `go test -mod=readonly -count=1 -timeout 300s ./pkg/sql/plan/function` — passed (`12.868s`, explicit CGo/native environment)
- Isolated fixed build and SQL replay on `10.222.1.55` — focused issue case `9/9` passed
- Full `dtype/bit.sql` on the isolated 55 service — `76/91`; the remaining 15 failures are pre-existing JDBC metadata mismatches in older statements, with no new failure in the added case
- GPT-6 medium final review — PASS
