### PR TITLE
fix(sql): bound generate_series scopes to local partitions

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -5090,8 +5090,14 @@ func (c *Compile) compileGenerateSeriesParallel(node *plan.Node, ss []*Scope, pa
 		}
 
 		op.CanOpt = canOpt
-		op.GenerateSeriesCtrNumState(offset[0][0], offset[len(offset)-1][1], step, offset[0][0])
-		op.OffsetTotal = append(op.OffsetTotal, offset[startOffset:startOffset+currMcpu]...)
+		scopeOffsets := offset[startOffset : startOffset+currMcpu]
+		op.GenerateSeriesCtrNumState(
+			scopeOffsets[0][0],
+			scopeOffsets[len(scopeOffsets)-1][1],
+			step,
+			scopeOffsets[0][0],
+		)
+		op.OffsetTotal = append(op.OffsetTotal, scopeOffsets...)
 		startOffset += currMcpu
 
 		ds.NodeInfo = getEngineNode(c)

--- a/pkg/sql/compile/generate_series_partition_test.go
+++ b/pkg/sql/compile/generate_series_partition_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/table_function"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -152,21 +154,23 @@ func TestGenerateSeriesOffsetsPreserveSequence(t *testing.T) {
 
 func TestCompileGenerateSeriesParallelPartitionsOffsetsAcrossCNs(t *testing.T) {
 	offsets := [][2]int64{
-		{1, 100_000},
-		{100_001, 200_000},
-		{200_001, 300_000},
-		{300_001, 400_000},
+		{0, 4},
+		{6, 8},
+		{10, 12},
 	}
 	c := NewMockCompile(t)
 	c.addr = "ingress:6001"
 	c.anal = &AnalyzeModule{}
 	c.cnList = engine.Nodes{
 		{Addr: "cn-1:6001", Mcpu: 2},
-		{Addr: "cn-2:6001", Mcpu: 3},
+		{Addr: "cn-2:6001", Mcpu: 2},
 	}
 	c.pn = &plan.Plan{Plan: &plan.Plan_Query{Query: &plan.Query{}}}
 	node := &plan.Node{TableDef: &plan.TableDef{
-		Cols:    []*plan.ColDef{{Name: "result"}},
+		Cols: []*plan.ColDef{{
+			Name: "result",
+			Typ:  plan.Type{Id: int32(types.T_int64)},
+		}},
 		TblFunc: &plan.TableFunction{Name: "generate_series"},
 	}}
 
@@ -176,7 +180,7 @@ func TestCompileGenerateSeriesParallelPartitionsOffsetsAcrossCNs(t *testing.T) {
 		len(offsets),
 		true,
 		offsets,
-		1,
+		2,
 	)
 	require.NoError(t, err)
 	require.Len(t, scopes, 2)
@@ -188,4 +192,24 @@ func TestCompileGenerateSeriesParallelPartitionsOffsetsAcrossCNs(t *testing.T) {
 
 	require.Equal(t, offsets[:2], first.OffsetTotal)
 	require.Equal(t, offsets[2:], second.OffsetTotal)
+
+	tail, workers := newParallelScope(scopes[1])
+	require.Same(t, scopes[1], tail)
+	require.Empty(t, workers)
+
+	proc := tail.Proc
+	require.NoError(t, second.Prepare(proc))
+	defer second.Free(proc, false, nil)
+
+	var got []int64
+	for {
+		result, err := second.Call(proc)
+		require.NoError(t, err)
+		if result.Batch == nil {
+			break
+		}
+		values := vector.MustFixedColWithTypeCheck[int64](result.Batch.Vecs[0])
+		got = append(got, values...)
+	}
+	require.Equal(t, []int64{10, 12}, got)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Follow-up to #28723 for #28718 and #28712.

## What this PR does / why we need it:

PR #28723 fixed step-aware partition boundaries, but each compiled CN scope still initialized its original `generate_series` operator with the global range. Parallel scopes with `Mcpu > 1` clone the operator and replace those bounds from `OffsetTotal`; a trailing scope with `Mcpu == 1` executes the original operator directly and therefore could emit the complete series again.

This follow-up initializes every CN scope from that scope's assigned offset slice. It does not change partitioning, scheduling, or the generic parallel-scope lifecycle.

The regression uses two CN allocations with `Mcpu=[2,2]` and three partitions. It executes the trailing single-worker scope and requires only its assigned `[10,12]` values. With the code merged in #28723 but without this follow-up, the test returns the full `[0,2,4,6,8,10,12]` sequence.

Validation:

- old/new deterministic A/B for the `2+1` worker allocation
- `go test -mod=readonly ./pkg/sql/compile`
- `TYPECHECK=1 make dev-build`
- two-CN SQL validation: 1,680,002 rows, 1,680,002 distinct values, correct endpoints, and zero off-grid values
