### PR TITLE
[4.2] fix(malloc): handle munmap ENOMEM with bounded recovery and diagnostics

### DIFF
--- a/docs/design/mmap-reclamation-review.md
+++ b/docs/design/mmap-reclamation-review.md
@@ -1,0 +1,72 @@
+# Mmap recovery design decision
+
+Date: 2026-09-11.
+Reviewer: Codex, in a distinct **design self-review** phase for this delivery.
+This is not an independent human review, GitHub APPROVE, or permission to bypass
+branch protection. Maintainer review of both implementation PRs remains required.
+
+Scope: shared controller in #28737 and #28739, incident #28736.
+Trigger: process-wide admission/resource controller, deferred cleanup ownership,
+retry lifecycle and a background reporting worker, with availability impact.
+Reviewed design: [v1 at 1c4858f0636362cfb0ace04d6d386fd066f14dd3](https://github.com/XuPeng-SH/matrixone/blob/1c4858f0636362cfb0ace04d6d386fd066f14dd3/docs/design/mmap-reclamation.md).
+
+## Design phase: PASS for implementation alignment review
+
+The initial ordinary-fix exemption was incorrect. The design was committed as a
+separate artifact before this decision; it does not retroactively assert that
+the first implementation followed the required order. No further implementation
+acceptance was made while the document was missing.
+
+The design was assessed against alternatives, rather than assuming the existing
+code was the only answer. Panic, lost ownership, and unrestricted retention each
+violate a goal. Arena allocation is credible long-term work but adds unrelated
+allocation geometry, fragmentation and performance decisions. The selected gate
+is accepted as bounded failure containment, not as a cure for map-count growth.
+
+| Review axis | Decision / accepted limitation |
+|---|---|
+| Q1 ownership | Exact failed slices have one cleanup owner through detached retry; not reused, dropped or forgotten |
+| Q2 waits | No queue/cache lock spans unmap or diagnostics; log sink independent. Kernel/proc latency is not a hard deadline |
+| Q3 growth | Admission bounds mapping identities relative to pre-existing/in-flight work; queue is not an absolute memory quota |
+| Availability | One failed mapping can gate the process's fresh mmap indefinitely; explicit, observable degradation is accepted over crash/leak |
+| Retry | Bounded work/rate and fair rotation, not bounded lifetime or universal recovery time; other releases/operations may be needed |
+| Performance | One atomic fresh-mmap check; no new hit/free-path allocation; source-matched microbench evidence, no universal zero-cost claim |
+| Diagnostics | Bounded storage/report rate; dropped reports and one blocked writer accepted; metrics retain pending/failure evidence |
+| Platform | Exact-slice unix wrapper contract retained; real Linux test covers the specific split-at-limit mechanism |
+| Compatibility | Process-local, no disk/wire migration; rollback restarts into the old panic risk |
+| Security/rollout | Restricted operational logs; no automatic sysctl changes; canary and persistent-pending intervention required |
+
+Resolved design questions: distinguish retry rate from lifetime; distinguish
+admission-relative retention from fixed capacity; state in-flight allowance and
+out-of-scope allocations; distinguish cooperative diagnostic work budget from
+blocking syscall latency; distinguish report submission limits from delayed sink
+output; document process-wide failure scope and non-guaranteed self-healing.
+
+Blocking design questions remaining: none for the documented containment scope.
+Deployment-specific alert thresholds and mapping-growth root-cause investigation
+remain maintainer/operations follow-up before broad rollout, not claimed solved.
+
+## Subsequent implementation alignment phase
+
+Reviewed 4.2 implementation `2e2a5b31e4e174a9251a0566befa0683180e3fd4`
+against base `4199b11c5c7bb24eccdb379cd6f68abcbd89e450`; main implementation
+`87fcca569d063240bcff1b00652353ff018291b4`, retained unchanged by the unrelated
+main merge `547ebfcb16a3764a21a851ef2a809e4ff8dfae0f`.
+
+Compared queue transitions, admission/reopen ordering, original-slice ownership,
+bounded retry/reporting and branch-specific release callers against v1. 4.2 has
+no HybridMmapAllocator, and intentionally does not add one. No material deviation
+or newly demonstrated runtime defect was found. The review comment itself did
+not establish another runtime defect, so no speculative runtime edits were made.
+
+Evidence: reuse the branch-specific malloc/mpool normal/race results, focused
+race x100 and actual-kernel 55 recovery x2 recorded in each PR. The delivered
+follow-up changes only these two documents; implementation, tests, module inputs
+and relevant dependency closure are unchanged. New checks: whitespace/delivery
+diff, versioned design reference, and both branches' document identity. No new
+UT, benchmark, static Go check or production experiment is claimed for docs.
+
+Decision: design self-review PASS; implementation alignment PASS within the
+stated scope. This record supplies a traceable design decision, not an external
+approval. Any material change to the accepted policy requires renewed design
+review; a maintainer can request a different availability tradeoff before merge.

--- a/docs/design/mmap-reclamation.md
+++ b/docs/design/mmap-reclamation.md
@@ -1,0 +1,192 @@
+# Recoverable mmap reclamation
+
+Revision: v1, 2026-09-11. Owner: malloc maintainers; delivery: XuPeng-SH.
+Incident: [#28736](https://github.com/matrixorigin/matrixone/issues/28736).
+Series: [main #28737](https://github.com/matrixorigin/matrixone/pull/28737),
+[4.2-dev #28739](https://github.com/matrixorigin/matrixone/pull/28739).
+Status: proposed; the exact reviewed commit and decision are recorded separately
+in `mmap-reclamation-review.md`. That record, not this label, controls acceptance.
+
+## Problem and decision boundary
+
+An ENOMEM from cached munmap currently terminates the service via panic.
+The fixed-size allocator instead discards the error and loses reclamation
+ownership. Neither response is appropriate for recoverable kernel pressure.
+Linux can merge adjacent anonymous mappings; removing an interior allocation
+may need another VMA and fail at max_map_count. This is documented in
+[munmap(2)](https://man7.org/linux/man-pages/man2/munmap.2.html).
+The incident reports a node limit of 65530, but the failed process's map count
+was not captured. VMA exhaustion is a hypothesis, not a measured incident fact.
+The isolated 55 experiment demonstrates this mechanism at a limit of 1048576.
+
+This is a resource-controller/lifecycle design, despite the bug-fix label.
+Process-wide admission, deferred ownership and background retry/logging trigger
+the design gate. This document repairs an omitted design phase; it does not
+claim that the original implementation was written after design approval.
+Implementation acceptance must follow the separately recorded design decision.
+
+Goals: preserve exclusive ownership after failed frees; recover without a
+process crash when kernel pressure permits; bound retry/log work; preserve
+normal-path performance; leave useful failure evidence.
+Non-goals: eliminate VMA fragmentation, cure memory exhaustion, guarantee
+request success during pressure, govern Go/libc/native allocations outside this
+package, change host sysctls, or add arena allocation in this patch.
+
+## Alternatives, independently of the current implementation
+
+| Choice | Correctness and availability | Cost / decision |
+|---|---|---|
+| Panic/restart | OS eventually reclaims memory, but one recoverable free kills all work | Existing failure; reject |
+| Log and forget | Keeps service running but permanently loses ownership | Reject regardless of logging limits |
+| Retry while allowing unlimited new mappings | Owns failures but can accumulate an unlimited stream of retained mappings | Reject |
+| Fixed queue cap, then drop/block/panic | Drop leaks; blocking can deadlock cleanup; panic restores the incident | Reject as a general ownership bound |
+| Bounded arenas / fewer mappings | Addresses mapping geometry more directly | Larger allocator redesign, fragmentation/RSS/performance/ownership changes; evaluate separately |
+| Retain failures and pause fresh package mmap | Preserves ownership and bounds new mapping identities during pressure | Selected; accepts process-wide degraded availability |
+
+The gate is process-wide because the kernel's map-count resource is per process,
+not per allocator or tenant. Keeping one allocator open can consume space needed
+to recover another. We intentionally do not retry EINVAL/other errors, which may
+signal ownership violations. The change does not hide invalid frees as pressure.
+
+## Ownership, states and concurrency
+
+Successful allocations keep their existing ownership contracts. After the caller
+has relinquished a mapping, exactly one release path attempts munmap. On success
+the mapping is gone. On ENOMEM it transfers to the process-lifetime reclaimer;
+its exact slice remains live and must never return to a reuse pool.
+
+| State / event | Transition and owner |
+|---|---|
+| Open, fresh mmap | Atomic admission check, then existing mmap syscall |
+| First failed free | Under queue mutex: close admission, append owned mapping, start one timer |
+| Pending, another failed free | Append under the same mutex; no additional timer |
+| Retry | Detach up to 256 entries; keep detached bytes/count accounted; unlock before diagnostics/syscalls |
+| Retry ENOMEM | Retain ownership; append behind queued arrivals for fair rotation |
+| Retry success | Drop slice reference; subtract successfully freed count/bytes under mutex |
+| Pending count zero | Under mutex: mark inactive and reopen admission |
+| Pending count nonzero | Schedule the next bounded pass; never open admission prematurely |
+
+The admission check is not a barrier waiting for all in-flight allocations.
+Calls that observed open before closure may complete afterward. The retained
+identity bound is existing live/cache/pool/channel mappings plus these admitted
+calls, not a fixed byte cap. Other allocators/runtime mappings are outside it.
+Each failed mapping creates one queue node; retries reuse that node. Severe Go
+heap exhaustion can still prevent allocating bookkeeping: this is not OOM-proof.
+
+Retry and enqueue serialize state transitions, not syscalls. Detached batches
+remain owned by the sole retry callback, so concurrent producers cannot free or
+reuse them. No per-request context owns deferred reclamation: cancellation must
+not discard a failed free. There is no in-process reset, close or replacement of
+the singleton. On process exit, the kernel owns final address-space cleanup;
+restart starts empty. No retry state is persisted or transferred between nodes.
+
+## Work, lifetime and diagnostic bounds
+
+- One scheduled/running retry owner; at most 256 munmap attempts per pass.
+- Initial delay 1s; no progress doubles delay to 2/4/8/16/30s, capped at 30s.
+  Progress resets delay to 1s. New arrivals do not reset it.
+- Retry lifetime is deliberately unbounded during persistent ENOMEM. Work per
+  pass and scheduling rate are bounded, not time to recovery. A large backlog
+  can take minutes or longer; even after pressure drops, recovery is not instant.
+- A report opportunity at most once per 30s, including across failure/recovery
+  episodes. Capture original failing stack/address/size, observed timestamp,
+  pending bytes/mappings and total failed attempts, not a stack per mapping.
+- Linux diagnostics count maps with bounded scanner storage, 128 MiB input cap
+  and a cooperative 250ms work deadline, checked every 1024 records. Proc reads
+  themselves are not interruptible deadlines; kernel/scheduler delay can exceed
+  250ms. Do not claim a hard wall-clock bound. Small proc files are capped at
+  16 KiB; no smaps/page-table walks. Non-Linux reports unavailable diagnostics.
+- Diagnostic capture precedes retry, outside queue/cache locks, so recovery does
+  not erase all map-count evidence. It can delay that retry but cannot block
+  enqueue or scrape through the queue mutex.
+- One lazy process-lifetime log writer, one in-flight and one buffered report.
+  Saturated submissions are dropped; blocked logging never blocks reclamation.
+  There is no flush guarantee on process exit. Rate limits govern submission;
+  a previously blocked sink may later emit its two retained reports together.
+- Three fixed-cardinality scrape-time metrics: `mo_mmap_reclaim_pending_bytes`,
+  `mo_mmap_reclaim_pending_mappings`, `mo_mmap_reclaim_failures_total`.
+  Detached batches count as pending; the total includes failed initial frees
+  and retries. No per-address metric labels and no normal-path metric updates.
+
+## Normal-path budget and platform assumptions
+
+Small libc allocation and cache/pool hits remain unchanged. A fresh mmap pays
+one atomic read; successful free makes its existing munmap call without queue
+locking, diagnostics or new allocation. Cold failure handling uses O(pending
+mapping count) nodes and bounded per-pass diagnostic storage/work.
+No benchmark can guarantee zero overhead for all workloads. Acceptance is no
+consistent material regression in same-host A/B allocator measurements, no extra
+normal-path allocations, and transparent reporting of noise/outliers.
+
+The design relies on the supported unix.Munmap wrapper retaining its mapping
+registration when the syscall fails. Exact original slices, not arbitrary merged
+address ranges, are retried. The Linux split-at-limit behavior is experimentally
+covered; portable ENOMEM handling does not assume every platform has that cause.
+
+## Operations, security and delivery
+
+A single stuck mapping can deny all fresh package-owned mmap allocations.
+This is an explicit availability tradeoff versus process death or unbounded
+retention, not a guarantee that the service remains healthy. Cached reuse and
+libc allocations can proceed; callers of fresh mmap may receive allocation errors.
+This controller limits its own logs/retries, not all upstream request-error logs.
+
+On sustained nonzero pending metrics, operators should inspect the first failure
+log, compare complete map counts with the host limit, and check node/cgroup
+memory pressure. Reduce new workload and let existing owners release mappings.
+If map-count pressure is confirmed and host headroom permits, an operator can
+raise the host limit; the service must not do so automatically. If pressure
+persists, preserve evidence and use role-appropriate drain/restart procedures.
+Do not force-drop pending ownership or reset the admission flag to restore traffic.
+The process will not self-heal merely because a timer runs: reclamation needs a
+successful syscall. VMA growth-source investigation remains owned by #28736.
+
+Canary rollout: compare allocator/query errors, pending duration/count/bytes,
+failure deltas and existing latency/throughput against the prior version. Alert
+on persistent pending state and growth, not every failed attempt. Exact paging
+thresholds belong to deployment SLOs; tune before broad rollout. Pause rollout
+if degraded state persists or previously healthy workload performance worsens.
+Rollback is a binary rollback/restart with normal service drain, not live
+controller removal; the old binary restores the original panic risk.
+
+No SQL/API signature, disk/catalog/wire format or persisted state changes.
+Mixed versions have independent process-local controllers; backup/restore and
+upgrade need no data migration. No new privileges or automatic system tuning.
+Addresses, stack symbols and cgroup paths are operationally sensitive: use the
+existing restricted service-log access controls, never user-facing SQL results.
+One tenant can contribute to shared process pressure; this is not tenant-isolated
+capacity or a substitute for workload admission control.
+
+## Branch adaptation
+
+4.2-dev covers SimpleCAllocator direct/cache frees and fixed-size mmap background
+frees. Its tests use the existing public fixed-size constructor; no hybrid
+allocator or allocator-selection change is imported. Main additionally routes
+its existing HybridMmapAllocator through the same owner. The controller and
+diagnostic contract are shared; no branch-specific thresholds or policies.
+
+## Acceptance and evidence reuse
+
+| Contract | Required evidence |
+|---|---|
+| Retain/retry/free exactly once, partial failure | Deterministic injected unmap tests and accounting assertions |
+| Concurrent arrivals / detached ownership | Phase-barrier test, focused repeated race, owning package race |
+| Backoff, batching, flapping limits | Fake clock/timer test; no scheduler sleeps |
+| Logging cannot block recovery | Blocked sink with many submissions and bounded queue oracle |
+| Admission scope and recovery | Fresh-mmap rejection alongside successful libc/cache/pool reuse |
+| Real kernel failure | Opt-in isolated Linux allocator test: actual ENOMEM, retained bytes, pressure removal, recovery |
+| Consumer compatibility | malloc and mpool normal/race suites on each branch |
+| Normal cost | Same-host base/candidate benchmark, allocations and contention; report limitations |
+
+Existing evidence: #28737 at 87fcca569d and #28739 at 2e2a5b31e4 report owning
+normal/race suites, focused repeated race, affected-package lint, and two final
+real-kernel episodes on 55 per branch. Main's A/B pinned medians were 2588 vs
+2603.5 ns/op direct and 5854 vs 5842 ns/op cached, with a reported direct outlier;
+do not relabel this as new 4.2 performance measurement. Pressure tests are not
+normal CI: up to 1.1M VMAs and ~4 GiB untouched virtual space require dedicated
+host headroom. No production service or sysctl is altered by those tests.
+
+Changes only to this document do not invalidate code/test evidence. A change to
+ownership, admission, retries, dependency behavior, fixture or mode does. No
+full-server workload/production-root-cause proof is claimed. Before broad rollout,
+maintainers/operations own validating deployment thresholds and workload impact.

--- a/pkg/common/malloc/fixed_size_mmap_allocator.go
+++ b/pkg/common/malloc/fixed_size_mmap_allocator.go
@@ -16,8 +16,6 @@ package malloc
 
 import (
 	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -66,7 +64,7 @@ func init() {
 	go func() {
 		for {
 			slice := <-unmapChan
-			_ = unix.Munmap(slice)
+			unmapMemory(slice)
 		}
 	}()
 }
@@ -146,12 +144,7 @@ func (f *fixedSizeMmapAllocator) Allocate(hints Hints, clearSize uint64) (slice 
 
 		default:
 			// allocate new
-			slice, err = unix.Mmap(
-				-1, 0,
-				int(f.size),
-				unix.PROT_READ|unix.PROT_WRITE,
-				unix.MAP_PRIVATE|unix.MAP_ANONYMOUS,
-			)
+			slice, err = mmapMemory(int(f.size))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/common/malloc/mmap_reclaim.go
+++ b/pkg/common/malloc/mmap_reclaim.go
@@ -1,0 +1,301 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+const mmapReclaimBatch = 256
+const mmapReclaimMaxDelay = 30 * time.Second
+
+var mmapReclaimer = newMmapReclaimer()
+
+// mmapMemory leaves pool hits and libc allocations untouched. Only a new mmap
+// pays one atomic load. During reclamation failure, stop creating more mappings
+// rather than silently accumulating an unbounded queue of failed frees.
+func mmapMemory(size int) ([]byte, error) {
+	if mmapReclaimer.blocked.Load() {
+		return nil, unix.ENOMEM
+	}
+	return unix.Mmap(-1, 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS)
+}
+
+func unmapMemory(data []byte) {
+	if err := unix.Munmap(data); err != nil {
+		mmapReclaimer.deferUnmap(data, err)
+	}
+}
+
+type pendingMmap struct {
+	data []byte
+	next *pendingMmap
+}
+
+// The queue owns failed mappings exclusively; they never return to a reuse pool.
+// Count/bytes include the batch currently in the syscall loop. A single timer
+// owns retries; enqueue never launches a worker while one is running. Admission
+// stops at the first failure, bounding retention by existing live/pool mappings
+// plus allocations already admitted concurrently. Frees must remain nonblocking
+// on queue capacity: dropping a failed mapping would permanently leak it.
+type mmapReclaim struct {
+	blocked                atomic.Bool
+	mu                     sync.Mutex
+	head, tail             *pendingMmap
+	count, bytes, failures uint64
+	active                 bool
+	started, lastReport    time.Time
+	delay                  time.Duration
+	sampleAddress          uintptr
+	sampleSize             int
+	sampleStack            [16]uintptr
+	sampleStackLen         int
+
+	// Immutable dependencies allow deterministic error, clock and timer tests.
+	unmap    func([]byte) error
+	schedule func(time.Duration, func())
+	now      func() time.Time
+	report   func(mmapReclaimReport)
+}
+
+type mmapReclaimReport struct {
+	Pending, Bytes, Failures uint64
+	Address                  uintptr
+	Size                     int
+	Elapsed                  time.Duration
+	Stack                    [16]uintptr
+	StackLen                 int
+	ObservedAt               time.Time
+}
+
+func newMmapReclaimer() *mmapReclaim {
+	return &mmapReclaim{
+		unmap:    unix.Munmap,
+		schedule: func(delay time.Duration, f func()) { time.AfterFunc(delay, f) },
+		now:      time.Now,
+		report:   reportMmapReclaim,
+	}
+}
+
+func (r *mmapReclaim) appendLocked(p *pendingMmap) {
+	if r.tail == nil {
+		r.head = p
+	} else {
+		r.tail.next = p
+	}
+	r.tail = p
+}
+
+func (r *mmapReclaim) deferUnmap(data []byte, err error) {
+	// EINVAL is an ownership/argument violation, not recoverable VMA pressure.
+	// Do not turn corruption into retries or make an invalid mapping reusable.
+	if err != unix.ENOMEM {
+		panic(err)
+	}
+	r.mu.Lock()
+	r.blocked.Store(true)
+	r.appendLocked(&pendingMmap{data: data})
+	r.bytes += uint64(len(data))
+	r.count++
+	r.failures++
+	if !r.active {
+		r.active = true
+		r.started = r.now()
+		r.delay = time.Second
+		r.sampleAddress = uintptr(unsafe.Pointer(unsafe.SliceData(data)))
+		r.sampleSize = len(data)
+		r.sampleStackLen = runtime.Callers(2, r.sampleStack[:])
+		r.schedule(r.delay, r.retry)
+	}
+	r.mu.Unlock()
+}
+
+func (r *mmapReclaim) retry() {
+	r.mu.Lock()
+	// Snapshot before retry so a quick recovery still leaves failure evidence.
+	now := r.now()
+	var report *mmapReclaimReport
+	if r.lastReport.IsZero() || now.Sub(r.lastReport) >= mmapReclaimMaxDelay {
+		report = &mmapReclaimReport{
+			Pending: r.count, Bytes: r.bytes, Failures: r.failures,
+			Address: r.sampleAddress, Size: r.sampleSize, Elapsed: now.Sub(r.started),
+			Stack: r.sampleStack, StackLen: r.sampleStackLen,
+			ObservedAt: now,
+		}
+		r.lastReport = now // retained across episodes to prevent flapping storms
+	}
+	batch := r.head
+	var last *pendingMmap
+	for n := 0; n < mmapReclaimBatch && r.head != nil; n++ {
+		last = r.head
+		r.head = r.head.next
+	}
+	if last != nil {
+		last.next = nil
+	}
+	if r.head == nil {
+		r.tail = nil
+	}
+	r.mu.Unlock()
+
+	// No diagnostics or syscalls under the queue/cache lock. Report before
+	// unmapping, otherwise the map-count evidence could disappear on recovery.
+	if report != nil {
+		r.report(*report)
+	}
+	var failedHead, failedTail *pendingMmap
+	var freed, freedBytes, failures uint64
+	for p := batch; p != nil; {
+		next := p.next
+		p.next = nil
+		if err := r.unmap(p.data); err != nil {
+			if err != unix.ENOMEM {
+				panic(err)
+			}
+			if failedTail == nil {
+				failedHead = p
+			} else {
+				failedTail.next = p
+			}
+			failedTail = p
+			failures++
+		} else {
+			freed++
+			freedBytes += uint64(len(p.data))
+			p.data = nil
+		}
+		p = next
+	}
+	r.mu.Lock()
+	r.count -= freed
+	r.bytes -= freedBytes
+	r.failures += failures
+	if failedHead != nil {
+		if r.tail == nil {
+			r.head = failedHead
+		} else {
+			r.tail.next = failedHead
+		}
+		r.tail = failedTail
+	}
+	if r.count == 0 {
+		r.active = false
+		r.blocked.Store(false)
+	} else {
+		if freed > 0 {
+			r.delay = time.Second
+		} else {
+			r.delay = min(r.delay*2, mmapReclaimMaxDelay)
+		}
+		r.schedule(r.delay, r.retry)
+	}
+	r.mu.Unlock()
+}
+
+// A stalled log sink must not stall reclamation or keep allocation admission
+// closed. Start one process-lifetime writer lazily on the first failure; retain
+// at most one additional report while it is blocked. Metrics remain available.
+var mmapReclaimLogWriter = reclaimLogWriter{
+	entries: make(chan mmapReclaimLog, 1), write: writeMmapReclaimLog,
+}
+
+type reclaimLogWriter struct {
+	once    sync.Once
+	entries chan mmapReclaimLog
+	write   func(mmapReclaimLog)
+}
+
+type mmapReclaimLog struct {
+	report      mmapReclaimReport
+	diagnostics string
+}
+
+func reportMmapReclaim(r mmapReclaimReport) {
+	mmapReclaimLogWriter.submit(mmapReclaimLog{r, mmapReclaimDiagnostics()})
+}
+
+func (w *reclaimLogWriter) submit(entry mmapReclaimLog) {
+	w.once.Do(func() {
+		go func() {
+			for entry := range w.entries {
+				w.write(entry)
+			}
+		}()
+	})
+	select {
+	case w.entries <- entry:
+	default:
+	}
+}
+
+func writeMmapReclaimLog(entry mmapReclaimLog) {
+	r := entry.report
+	var stack strings.Builder
+	frames := runtime.CallersFrames(r.Stack[:r.StackLen])
+	for {
+		frame, more := frames.Next()
+		stack.WriteString(frame.Function)
+		stack.WriteByte('\n')
+		if !more {
+			break
+		}
+	}
+	logutil.Warn("mmap reclamation deferred; new mappings paused",
+		zap.Time("observed_at", r.ObservedAt),
+		zap.String("errno", "ENOMEM"), zap.Uint64("pending_mappings", r.Pending),
+		zap.Uint64("pending_bytes", r.Bytes), zap.Uint64("failures_total", r.Failures),
+		zap.Uint64("sample_address", uint64(r.Address)), zap.Int("sample_bytes", r.Size),
+		zap.Duration("elapsed", r.Elapsed), zap.String("failure_stack", stack.String()),
+		zap.String("vm_diagnostics", entry.diagnostics))
+}
+
+func init() {
+	// Scrape-time snapshots: no metric operations on successful alloc/free.
+	for _, metric := range []struct {
+		name, help string
+		value      func() float64
+	}{
+		{"pending_bytes", "Bytes owned by deferred mmap reclamation", func() float64 { return float64(mmapReclaimer.bytes) }},
+		{"pending_mappings", "Mappings owned by deferred mmap reclamation", func() float64 { return float64(mmapReclaimer.count) }},
+		{"failures_total", "Failed munmap attempts including retries", func() float64 { return float64(mmapReclaimer.failures) }},
+	} {
+		value := metric.value
+		snapshot := func() float64 {
+			mmapReclaimer.mu.Lock()
+			defer mmapReclaimer.mu.Unlock()
+			return value()
+		}
+		if metric.name == "failures_total" {
+			v2.GetPrometheusRegistry().MustRegister(prometheus.NewCounterFunc(prometheus.CounterOpts{
+				Namespace: "mo", Subsystem: "mmap_reclaim", Name: metric.name, Help: metric.help,
+			}, snapshot))
+		} else {
+			v2.GetPrometheusRegistry().MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: "mo", Subsystem: "mmap_reclaim", Name: metric.name, Help: metric.help,
+			}, snapshot))
+		}
+	}
+}

--- a/pkg/common/malloc/mmap_reclaim_bench_test.go
+++ b/pkg/common/malloc/mmap_reclaim_bench_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package malloc
+
+import "testing"
+
+func BenchmarkSimpleCAllocatorReclaim(b *testing.B) {
+	for _, size := range []uint64{64, 344064} {
+		for _, cached := range []bool{false, true} {
+			name := testNameForSize(size)
+			if cached {
+				name += "/cached"
+			}
+			b.Run(name, func(b *testing.B) {
+				a := newTestSimpleCAllocator()
+				if cached {
+					a.EnableMmapCache(func() uint64 { return 16 << 20 }, nil)
+					b.Cleanup(a.mmapCache.drain)
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						data, err := a.Allocate(size)
+						if err != nil {
+							b.Error(err)
+							return
+						}
+						a.Deallocate(data, size)
+					}
+				})
+			})
+		}
+	}
+}

--- a/pkg/common/malloc/mmap_reclaim_diagnostics.go
+++ b/pkg/common/malloc/mmap_reclaim_diagnostics.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Only the rate-limited retry worker calls this. Never read smaps (page-table
+// walks) or allocate a maps-sized buffer under memory pressure. Counting maps
+// is best effort: bound bytes and elapsed work, explicitly label partial counts.
+func mmapReclaimDiagnostics() string {
+	if runtime.GOOS != "linux" {
+		return "proc diagnostics unavailable on " + runtime.GOOS
+	}
+	read := func(path string) string {
+		f, err := os.Open(path)
+		if err != nil {
+			return err.Error()
+		}
+		defer f.Close()
+		data, err := io.ReadAll(io.LimitReader(f, 16<<10))
+		if err != nil {
+			return err.Error()
+		}
+		return strings.TrimSpace(string(data))
+	}
+	count, complete := 0, false
+	f, err := os.Open("/proc/self/maps")
+	if err == nil {
+		defer f.Close()
+		reader := &io.LimitedReader{R: f, N: 128 << 20}
+		scanner := bufio.NewScanner(reader)
+		deadline := time.Now().Add(250 * time.Millisecond)
+		for scanner.Scan() {
+			count++
+			if count%1024 == 0 && time.Now().After(deadline) {
+				break
+			}
+		}
+		complete = scanner.Err() == nil && reader.N > 0 && time.Now().Before(deadline)
+	}
+	var memory strings.Builder
+	for _, line := range strings.Split(read("/proc/self/status"), "\n") {
+		if strings.HasPrefix(line, "Vm") || strings.HasPrefix(line, "Rss") || strings.HasPrefix(line, "Threads:") {
+			memory.WriteString(strings.TrimSpace(line))
+			memory.WriteString("; ")
+		}
+	}
+	return fmt.Sprintf("maps=%d maps_complete=%t max_map_count=%s kernel=%s memory=[%s] cgroup=[%s]",
+		count, complete, read("/proc/sys/vm/max_map_count"), read("/proc/sys/kernel/osrelease"),
+		memory.String(), read("/proc/self/cgroup"))
+}

--- a/pkg/common/malloc/mmap_reclaim_integration_test.go
+++ b/pkg/common/malloc/mmap_reclaim_integration_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux && mmap_reclaim_integration
+
+package malloc
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// Explicit opt-in pressure experiment, not an ordinary UT: up to 1.1M VMAs and
+// ~4GiB virtual (untouched) address space. Run in an isolated process on a test
+// host with kernel-memory headroom, never in a production service. No sysctl is
+// changed. The ordinary deterministic suite covers scheduling/error injection.
+func TestMmapReclaimRealVMAExhaustion(t *testing.T) {
+	limitRaw, err := os.ReadFile("/proc/sys/vm/max_map_count")
+	require.NoError(t, err)
+	limit, err := strconv.Atoi(strings.TrimSpace(string(limitRaw)))
+	require.NoError(t, err)
+	require.LessOrEqual(t, limit, 1100000, "experiment resource budget")
+	require.False(t, mmapReclaimer.blocked.Load())
+	mmapReclaimer.mu.Lock()
+	initialFailures := mmapReclaimer.failures
+	mmapReclaimer.mu.Unlock()
+	a := newCachedTestSimpleCAllocator(func() uint64 { return 1 << 20 }, time.Hour)
+	t.Cleanup(a.mmapCache.drain)
+	const block = 344064
+	var allocations [][]byte
+	t.Cleanup(func() {
+		for _, data := range allocations {
+			if data != nil {
+				a.Deallocate(data, block)
+			}
+		}
+	})
+	for range 3 {
+		data, err := a.Allocate(block)
+		require.NoError(t, err)
+		allocations = append(allocations, data)
+	}
+	slices.SortFunc(allocations, func(a, b []byte) int {
+		if uintptr(unsafe.Pointer(&a[0])) < uintptr(unsafe.Pointer(&b[0])) {
+			return -1
+		}
+		return 1
+	})
+	base := uintptr(unsafe.Pointer(&allocations[0][0]))
+	require.Equal(t, base+block, uintptr(unsafe.Pointer(&allocations[1][0])))
+	require.Equal(t, base+2*block, uintptr(unsafe.Pointer(&allocations[2][0])))
+	f, err := os.Open("/proc/self/maps")
+	require.NoError(t, err)
+	merged := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var start, end uintptr
+		if _, err := fmt.Sscanf(scanner.Text(), "%x-%x", &start, &end); err == nil && start <= base && end >= base+3*block {
+			merged = true
+			t.Log("three allocator mappings merged:", scanner.Text())
+		}
+	}
+	require.NoError(t, scanner.Err())
+	require.NoError(t, f.Close())
+	require.True(t, merged)
+	a.Deallocate(allocations[1], block)
+	allocations[1] = nil // ownership transferred to the cache
+	require.Equal(t, uint64(block), a.mmapCache.cachedBytes())
+
+	page := os.Getpagesize()
+	arena, err := unix.Mmap(-1, 0, (limit+128)*page, unix.PROT_NONE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS|unix.MAP_NORESERVE)
+	require.NoError(t, err)
+	// Always remove VMA pressure before assertion cleanup, including FailNow.
+	t.Cleanup(func() {
+		if arena != nil {
+			_ = unix.Munmap(arena)
+		}
+	})
+	for i := 1; i < limit+127; i += 2 {
+		err = unix.Mprotect(arena[i*page:(i+1)*page], unix.PROT_READ)
+		if err != nil {
+			break
+		}
+	}
+	require.ErrorIs(t, err, unix.ENOMEM)
+	a.mmapCache.mu.Lock()
+	generation := a.mmapCache.timerGeneration
+	a.mmapCache.timer.Stop() // manual expiry owns the test's timer invocation
+	a.mmapCache.lastPut = time.Now().Add(-2 * time.Hour)
+	a.mmapCache.mu.Unlock()
+	a.mmapCache.expire(generation)
+	require.True(t, mmapReclaimer.blocked.Load(), "real cached munmap must encounter ENOMEM")
+	mmapReclaimer.mu.Lock()
+	pending, bytes := mmapReclaimer.count, mmapReclaimer.bytes
+	mmapReclaimer.mu.Unlock()
+	require.Equal(t, uint64(1), pending)
+	require.Equal(t, uint64(block), bytes)
+	t.Logf("real ENOMEM retained: mappings=%d bytes=%d", pending, bytes)
+	_, err = mmapMemory(block)
+	require.ErrorIs(t, err, unix.ENOMEM)
+	// Wait for the real timer's first failed retry/report, not a scheduling
+	// assumption. Pressure remains until that observable transition occurs.
+	require.Eventually(t, func() bool {
+		mmapReclaimer.mu.Lock()
+		defer mmapReclaimer.mu.Unlock()
+		return mmapReclaimer.failures >= initialFailures+2
+	}, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, unix.Munmap(arena))
+	arena = nil
+	require.Eventually(t, func() bool { return !mmapReclaimer.blocked.Load() }, 10*time.Second, 10*time.Millisecond)
+	mmapReclaimer.mu.Lock()
+	pending, bytes = mmapReclaimer.count, mmapReclaimer.bytes
+	mmapReclaimer.mu.Unlock()
+	require.Zero(t, pending)
+	require.Zero(t, bytes)
+	a.mmapCache.drain()
+	a.mmapCache = nil
+	a.Deallocate(allocations[0], block)
+	a.Deallocate(allocations[2], block)
+	allocations[0], allocations[2] = nil, nil
+	require.Zero(t, a.currentInuse.Load())
+	data, err := a.Allocate(block)
+	require.NoError(t, err)
+	a.Deallocate(data, block)
+	t.Log("recovered: no pending mappings, allocator accepts fresh allocations")
+}

--- a/pkg/common/malloc/mmap_reclaim_test.go
+++ b/pkg/common/malloc/mmap_reclaim_test.go
@@ -1,0 +1,266 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+type reclaimHarness struct {
+	r        *mmapReclaim
+	now      time.Time
+	callback func()
+	delay    time.Duration
+	reports  []mmapReclaimReport
+}
+
+func newReclaimHarness(t *testing.T, unmap func([]byte) error) *reclaimHarness {
+	h := &reclaimHarness{r: newMmapReclaimer(), now: time.Unix(1000, 0)}
+	h.r.now = func() time.Time { return h.now }
+	h.r.unmap = unmap
+	h.r.schedule = func(delay time.Duration, f func()) {
+		require.Nil(t, h.callback, "only one scheduled retry owner")
+		h.callback, h.delay = f, delay
+	}
+	h.r.report = func(r mmapReclaimReport) { h.reports = append(h.reports, r) }
+	return h
+}
+
+func (h *reclaimHarness) tick(t *testing.T) {
+	t.Helper()
+	require.NotNil(t, h.callback)
+	f := h.callback
+	h.callback = nil
+	h.now = h.now.Add(h.delay)
+	f()
+}
+
+func TestMmapReclaimFailureRecovery(t *testing.T) {
+	fail := true
+	freed := make(map[*byte]int)
+	h := newReclaimHarness(t, func(data []byte) error {
+		if fail && data[0] == 1 {
+			return unix.ENOMEM
+		}
+		freed[&data[0]]++
+		return nil
+	})
+	a, b := []byte{1}, []byte{2, 2}
+	h.r.deferUnmap(a, unix.ENOMEM)
+	h.r.deferUnmap(b, unix.ENOMEM)
+	require.True(t, h.r.blocked.Load())
+	h.tick(t)
+	require.Equal(t, uint64(1), h.r.count)
+	require.Equal(t, uint64(1), h.r.bytes)
+	require.Equal(t, 1, freed[&b[0]])
+	require.Zero(t, freed[&a[0]])
+	require.Len(t, h.reports, 1)
+	require.Equal(t, uint64(2), h.reports[0].Pending)
+	require.Equal(t, uint64(3), h.reports[0].Bytes)
+	require.NotZero(t, h.reports[0].Address)
+	require.Positive(t, h.reports[0].StackLen)
+	fail = false
+	h.tick(t)
+	require.Equal(t, 1, freed[&a[0]])
+	require.Equal(t, 1, freed[&b[0]])
+	require.Zero(t, h.r.count)
+	require.Zero(t, h.r.bytes)
+	require.Nil(t, h.r.head)
+	require.Nil(t, h.r.tail)
+	require.Nil(t, h.callback)
+	require.False(t, h.r.blocked.Load())
+	require.Equal(t, uint64(3), h.r.failures)
+}
+
+func TestMmapReclaimBoundedRetriesAndLogs(t *testing.T) {
+	calls := 0
+	h := newReclaimHarness(t, func([]byte) error { calls++; return unix.ENOMEM })
+	for range mmapReclaimBatch + 1 {
+		h.r.deferUnmap([]byte{1}, unix.ENOMEM)
+	}
+	for _, delay := range []time.Duration{1, 2, 4, 8, 16, 30, 30} {
+		require.Equal(t, delay*time.Second, h.delay)
+		before := calls
+		h.tick(t)
+		require.Equal(t, mmapReclaimBatch, calls-before)
+		require.Equal(t, uint64(mmapReclaimBatch+1), h.r.count)
+	}
+	require.Len(t, h.reports, 4) // t=1,31,61,91, independent of block count
+	// New failures do not reset a running timer/backoff or spawn more workers.
+	h.r.deferUnmap([]byte{2}, unix.ENOMEM)
+	require.Equal(t, 30*time.Second, h.delay)
+	h.r.unmap = func([]byte) error { return nil }
+	h.tick(t)
+	require.Equal(t, time.Second, h.delay)
+	h.tick(t)
+	require.False(t, h.r.blocked.Load())
+	// Repeated short failure/recovery episodes share the same log budget.
+	reports := len(h.reports)
+	for range 10 {
+		h.r.deferUnmap([]byte{3}, unix.ENOMEM)
+		h.tick(t)
+	}
+	require.Len(t, h.reports, reports)
+}
+
+func TestMmapReclaimConcurrentOwnership(t *testing.T) {
+	entered, resume := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	defer once.Do(func() { close(resume) })
+	calls := 0
+	h := newReclaimHarness(t, func([]byte) error {
+		calls++
+		if calls == 1 {
+			close(entered)
+			<-resume
+		}
+		return nil
+	})
+	h.r.deferUnmap([]byte{1}, unix.ENOMEM)
+	done := make(chan struct{})
+	go func() { h.tick(t); close(done) }()
+	<-entered
+	// A detached batch remains accounted for and blocks new mmap admission.
+	h.r.mu.Lock()
+	require.Equal(t, uint64(1), h.r.count)
+	h.r.mu.Unlock()
+	require.True(t, h.r.blocked.Load())
+	var producers sync.WaitGroup
+	for range 16 {
+		producers.Go(func() { h.r.deferUnmap([]byte{2}, unix.ENOMEM) })
+	}
+	producers.Wait()
+	once.Do(func() { close(resume) })
+	<-done
+	require.Equal(t, uint64(16), h.r.count)
+	require.True(t, h.r.blocked.Load())
+	h.tick(t)
+	require.Equal(t, 17, calls)
+	require.False(t, h.r.blocked.Load())
+	require.Nil(t, h.callback)
+}
+
+func TestMmapReclaimInvalidOwnership(t *testing.T) {
+	h := newReclaimHarness(t, nil)
+	require.PanicsWithValue(t, unix.EINVAL, func() { h.r.deferUnmap([]byte{1}, unix.EINVAL) })
+	require.Nil(t, h.callback)
+	require.Zero(t, h.r.count)
+	require.False(t, h.r.blocked.Load())
+}
+
+func TestMmapReclaimAdmissionAndPoolReuse(t *testing.T) {
+	// This test changes only the atomic admission flag, never swaps the global
+	// reclaimer or its dependencies. The package's background workers keep their
+	// actual owner. No synthetic mapping is queued on the production singleton.
+	require.False(t, mmapReclaimer.blocked.Load())
+	a := newTestSimpleCAllocator()
+	a.EnableMmapCache(func() uint64 { return 1 << 20 }, nil)
+	a.mmapCache.idle = time.Hour
+	data, err := a.Allocate(simpleCAllocatorMmapThreshold)
+	require.NoError(t, err)
+	a.Deallocate(data, uint64(len(data)))
+	a.mmapCache.mu.Lock()
+	cached := a.mmapCache.bytes != 0
+	a.mmapCache.mu.Unlock()
+	t.Cleanup(func() {
+		a.mmapCache.mu.Lock()
+		if a.mmapCache.timer != nil {
+			a.mmapCache.timer.Stop()
+		}
+		a.mmapCache.timer = nil
+		a.mmapCache.timerGeneration++
+		entries := a.mmapCache.bySize
+		a.mmapCache.bySize = nil
+		a.mmapCache.bytes = 0
+		a.mmapCache.mu.Unlock()
+		unmapSimpleCAllocatorCacheEntries(entries)
+	})
+	f := NewFixedSizeMmapAllocator(4096)
+	_, dec, err := f.Allocate(0, 4096)
+	require.NoError(t, err)
+	dec.Deallocate()
+	mmapReclaimer.blocked.Store(true)
+	t.Cleanup(func() { mmapReclaimer.blocked.Store(false) })
+	_, err = mmapMemory(4096)
+	require.ErrorIs(t, err, unix.ENOMEM)
+	_, err = a.Allocate(simpleCAllocatorMmapThreshold + 1)
+	require.Error(t, err)
+	small, err := a.Allocate(32)
+	require.NoError(t, err)
+	a.Deallocate(small, 32)
+	if cached {
+		// Linux cache reuse remains possible even while fresh mappings are paused.
+		reused, err := a.Allocate(simpleCAllocatorMmapThreshold)
+		require.NoError(t, err)
+		require.Equal(t, &data[0], &reused[0])
+		a.Deallocate(reused, uint64(len(reused)))
+	}
+	_, dec, err = f.Allocate(0, 4096)
+	require.NoError(t, err)
+	_, _, err = f.Allocate(0, 4096)
+	require.ErrorIs(t, err, unix.ENOMEM)
+	dec.Deallocate()
+	unmapMemory(unsafe.Slice((*byte)(<-f.buffer1), 4096))
+	mmapReclaimer.blocked.Store(false)
+	data, err = mmapMemory(4096)
+	require.NoError(t, err)
+	unmapMemory(data)
+}
+
+func TestMmapReclaimDiagnostics(t *testing.T) {
+	diagnostic := mmapReclaimDiagnostics()
+	if runtime.GOOS == "linux" {
+		for _, field := range []string{"maps=", "maps_complete=", "max_map_count=", "kernel=", "memory=[", "cgroup=["} {
+			require.Contains(t, diagnostic, field)
+		}
+	} else {
+		require.Contains(t, diagnostic, "unavailable")
+	}
+}
+
+func TestMmapReclaimBlockedLogSink(t *testing.T) {
+	entered, release, done := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	defer once.Do(func() { close(release) })
+	writes := 0
+	w := &reclaimLogWriter{entries: make(chan mmapReclaimLog, 1)}
+	w.write = func(mmapReclaimLog) {
+		writes++
+		if writes == 1 {
+			close(entered)
+			<-release
+		}
+		if writes == 2 {
+			close(done)
+		}
+	}
+	defer close(w.entries)
+	w.submit(mmapReclaimLog{})
+	<-entered
+	for range 10000 {
+		w.submit(mmapReclaimLog{})
+	}
+	require.Len(t, w.entries, 1, "a blocked sink retains only one waiting report")
+	once.Do(func() { close(release) })
+	<-done
+	require.Equal(t, 2, writes)
+}

--- a/pkg/common/malloc/sane_allocator.go
+++ b/pkg/common/malloc/sane_allocator.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sys/unix"
 )
 
 /*
@@ -256,13 +255,7 @@ func (sca *SimpleCAllocator) allocateMemory(size uint64, clearMemory bool) ([]by
 				return slice, nil
 			}
 		}
-		slice, err := unix.Mmap(
-			-1,
-			0,
-			int(size),
-			unix.PROT_READ|unix.PROT_WRITE,
-			unix.MAP_PRIVATE|unix.MAP_ANONYMOUS,
-		)
+		slice, err := mmapMemory(int(size))
 		if err != nil {
 			return nil, moerr.NewOOMNoCtx()
 		}
@@ -293,9 +286,7 @@ func (sca *SimpleCAllocator) deallocateMemory(slice []byte, size uint64) {
 		if sca.mmapCache != nil && sca.mmapCache.put(fullAllocation) {
 			return
 		}
-		if err := unix.Munmap(fullAllocation); err != nil {
-			panic(moerr.NewInternalErrorNoCtxf("failed to unmap %d-byte allocation: %v", size, err))
-		}
+		unmapMemory(fullAllocation)
 		return
 	}
 	C.free(ptr)

--- a/pkg/common/malloc/sane_allocator_cache.go
+++ b/pkg/common/malloc/sane_allocator_cache.go
@@ -18,9 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sys/unix"
 )
 
 const simpleCAllocatorMmapCacheIdle = time.Second
@@ -154,13 +152,7 @@ func (c *simpleCAllocatorMmapCache) updateGaugeLocked() {
 func unmapSimpleCAllocatorCacheEntries(entries map[uint64][][]byte) {
 	for _, slices := range entries {
 		for _, slice := range slices {
-			if err := unix.Munmap(slice); err != nil {
-				panic(moerr.NewInternalErrorNoCtxf(
-					"failed to unmap cached %d-byte allocation: %v",
-					len(slice),
-					err,
-				))
-			}
+			unmapMemory(slice)
 		}
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

#28736

## What this PR does / why we need it:

Linux may coalesce independent mmap allocations. Unmapping an interior allocation can require a VMA split and return ENOMEM at `vm.max_map_count`. Retain exclusive ownership and retry instead of panicking or silently losing the failed mapping.

- Cover this branch's SimpleCAllocator direct/cache reclamation and fixed-size allocator background reclamation.
- One retry owner, 256 mappings per pass, fair rotation, bounded exponential backoff (up to 30 seconds).
- Pause fresh package-owned mmap admission while failures remain; preserve small libc allocation and cache/pool reuse. Resume fresh mmap only after the pending queue is drained. Retention is bounded by already-existing mappings plus concurrently admitted allocations, not a growing stream of fresh mappings. Persistent pressure can still cause new allocation requests to fail.
- Diagnostics include original reclamation stack, address/size, VMA count/completeness and limit, kernel, memory status, cgroup and cumulative/pending counters. One report per 30 seconds across flapping episodes; a single bounded asynchronous log writer prevents blocked logging from blocking recovery.
- Export scrape-time `mo_mmap_reclaim_pending_bytes`, `mo_mmap_reclaim_pending_mappings`, and `mo_mmap_reclaim_failures_total` metrics. No normal-path log, metric update, queue lock or allocation; fresh mmap adds only an atomic admission load.

### Branch adaptation / review

Base: `4199b11c5c7bb24eccdb379cd6f68abcbd89e450` (`4.2-dev`).

The recovery/diagnostics implementation and SimpleCAllocator changes are identical to #28737. This release branch has no HybridMmapAllocator: it is deliberately **not** introduced. The pool-reuse test uses the existing `NewFixedSizeMmapAllocator` constructor instead of main's internal configurable constructor, and the unavailable hybrid-only assertion is omitted. No allocator selection, dependencies, SQL semantics, wire/disk formats, or unrelated main changes are backported.

Self-review checked branch-specific constructors/callers, ownership transfer, detached-batch accounting, recovery/admission ordering, retry/log bounds and all delivered artifacts. The Q1/Q2/Q3 ownership/wait/growth analysis from the unchanged core is retained; no additional backport blocker was found.

### Test plan / QA

Newly run on the 4.2-dev patch, all passed:

- All seven `TestMmapReclaim*` deterministic tests, including fault recovery, partial success, retry/log limits, concurrent ownership, invalid ownership, admission versus cache/pool reuse, diagnostics and a blocked log sink.
- Normal and `-race -count=1` full suites for `./pkg/common/malloc ./pkg/common/mpool`.
- `TestMmapReclaimConcurrentOwnership` and `TestMmapReclaimBlockedLogSink`, each separately with `-race -count=100`.
- Incremental golangci-lint for the affected `./pkg/common/malloc` package: zero issues; `git diff --check` passed.
- Final 4.2-dev test binary on 55 (`10.222.1.55`), real allocator/cache expiry and kernel ENOMEM, `-count=2`: each episode retained exactly one 344064-byte mapping without panic, rejected fresh mmap under pressure, reclaimed it after pressure removal, reached zero pending bytes/mappings and accepted fresh allocation. One warning across both episodes included `maps=1048576`, `max_map_count=1048576` and the original cache expiry stack. Both episodes passed (3.85s / 3.76s).

Native CGo was rebuilt from this branch's CPU sources with matching third-party versions; Go 1.26.4 and this branch's module versions were used. The real kernel experiment was rerun rather than assuming main's result covers release dependencies.

Normal-path performance evidence is linked in #28737, not relabeled as a new release-branch A/B measurement. SimpleCAllocator, the recovery hot-path code, benchmark and the x/sys mmap bookkeeping source are unchanged across the relevant versions; no extra hot-path work was introduced by the adaptation. No full SQL/BVT run is claimed: the changed boundary is allocator/kernel ownership, with no SQL or protocol change.

```sh
.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=120s ./pkg/common/malloc ./pkg/common/mpool
.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 -timeout=180s ./pkg/common/malloc ./pkg/common/mpool
.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=120s -run '^TestMmapReclaimConcurrentOwnership$' ./pkg/common/malloc
.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=100 -timeout=120s -run '^TestMmapReclaimBlockedLogSink$' ./pkg/common/malloc
# Dedicated test host only, never a production service:
.agents/skills/mo-dev/scripts/mo-cgo-test -tags=mmap_reclaim_integration -count=2 -timeout=45s -v -run '^TestMmapReclaimRealVMAExhaustion$' ./pkg/common/malloc
```

The opt-in pressure experiment creates up to 1.1M VMAs and about 4 GiB untouched virtual address space; it requires kernel-memory headroom. It changes no sysctl and starts no MatrixOne service. Ordinary CI does not enable the integration build tag.


### Versioned design and review follow-up

Addresses [4.2 design-gate review](https://github.com/matrixorigin/matrixone/pull/28739#pullrequestreview-5179493250).

- Incident: #28736.
- Exact reviewed design: [v1 at 1c4858f063](https://github.com/XuPeng-SH/matrixone/blob/1c4858f0636362cfb0ace04d6d386fd066f14dd3/docs/design/mmap-reclamation.md).
- [Separate design decision and subsequent implementation-alignment record](https://github.com/XuPeng-SH/matrixone/blob/10979864f895eb7f6ad525e723b9ae3fb091d680/docs/design/mmap-reclamation-review.md).
- The record is explicitly a Codex design **self-review**, not independent human approval or a GitHub APPROVE. Maintainer review remains required. The original missing design phase is acknowledged rather than retroactively claimed.
- Accepted limits: process-wide fresh-mmap degradation can last indefinitely under persistent pressure; retention is admission-relative, not a fixed byte cap; retries have bounded work/rate, not lifetime; proc diagnostics have a cooperative work budget, not a hard syscall deadline; a blocked log sink can later emit its two retained reports together.
- Follow-up is docs-only. No runtime/test/dependency changes; existing branch-native UT/race/55 evidence is reused, not falsely reported as rerun. Both PRs carry identical design/decision documents.

