### PR TITLE
fix: format vectors in group_concat

### DIFF
--- a/pkg/container/types/array.go
+++ b/pkg/container/types/array.go
@@ -47,34 +47,55 @@ func ArrayToBase64[T ArrayElement](input []T) string {
 	return base64.StdEncoding.EncodeToString(EncodeSlice(input))
 }
 
-func ArrayToString[T ArrayElement](input []T) string {
-	var buffer bytes.Buffer
-	_, _ = io.WriteString(&buffer, "[")
+// WriteArrayTo writes the SQL text representation of an array to writer.
+func WriteArrayTo[T ArrayElement](writer io.Writer, input []T) error {
+	writeString := func(value string) error {
+		n, err := io.WriteString(writer, value)
+		if err == nil && n != len(value) {
+			return io.ErrShortWrite
+		}
+		return err
+	}
+
+	if err := writeString("["); err != nil {
+		return err
+	}
 	for i, value := range input {
 		if i > 0 {
-			_, _ = io.WriteString(&buffer, ", ")
+			if err := writeString(", "); err != nil {
+				return err
+			}
 		}
 
 		// following the similar logic of float32 and float64 from
 		// - output.go #extractRowFromVector()
 		// - mysql_protocol.go #makeResultSetTextRow() MYSQL_TYPE_FLOAT  & MYSQL_TYPE_DOUBLE
 		// NOTE: vector does not handle NaN and Inf.
+		var text string
 		switch value := any(value).(type) {
 		case float32:
-			_, _ = io.WriteString(&buffer, strconv.FormatFloat(float64(value), 'f', -1, 32))
+			text = strconv.FormatFloat(float64(value), 'f', -1, 32)
 		case float64:
-			_, _ = io.WriteString(&buffer, strconv.FormatFloat(value, 'f', -1, 64))
+			text = strconv.FormatFloat(value, 'f', -1, 64)
 		case BF16:
-			_, _ = io.WriteString(&buffer, strconv.FormatFloat(float64(value.ToFloat32()), 'f', -1, 32))
+			text = strconv.FormatFloat(float64(value.ToFloat32()), 'f', -1, 32)
 		case Float16:
-			_, _ = io.WriteString(&buffer, strconv.FormatFloat(float64(value.ToFloat32()), 'f', -1, 32))
+			text = strconv.FormatFloat(float64(value.ToFloat32()), 'f', -1, 32)
 		case int8:
-			_, _ = io.WriteString(&buffer, strconv.FormatInt(int64(value), 10))
+			text = strconv.FormatInt(int64(value), 10)
 		case uint8:
-			_, _ = io.WriteString(&buffer, strconv.FormatUint(uint64(value), 10))
+			text = strconv.FormatUint(uint64(value), 10)
+		}
+		if err := writeString(text); err != nil {
+			return err
 		}
 	}
-	_, _ = io.WriteString(&buffer, "]")
+	return writeString("]")
+}
+
+func ArrayToString[T ArrayElement](input []T) string {
+	var buffer bytes.Buffer
+	_ = WriteArrayTo(&buffer, input)
 	return buffer.String()
 }
 

--- a/pkg/container/types/array_test.go
+++ b/pkg/container/types/array_test.go
@@ -15,7 +15,9 @@
 package types
 
 import (
+	"bytes"
 	"encoding/base64"
+	"io"
 	"reflect"
 	"testing"
 
@@ -155,6 +157,75 @@ func TestArrayToString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteArrayTo(t *testing.T) {
+	cases := []struct {
+		name  string
+		write func(io.Writer) error
+		want  string
+	}{
+		{
+			name: "float32",
+			write: func(writer io.Writer) error {
+				return WriteArrayTo(writer, []float32{1.5, -2})
+			},
+			want: "[1.5, -2]",
+		},
+		{
+			name: "float64",
+			write: func(writer io.Writer) error {
+				return WriteArrayTo(writer, []float64{1.25, -2.5})
+			},
+			want: "[1.25, -2.5]",
+		},
+		{
+			name: "bf16",
+			write: func(writer io.Writer) error {
+				return WriteArrayTo(writer, Float32ToBF16Slice([]float32{-1, 0, 4}))
+			},
+			want: "[-1, 0, 4]",
+		},
+		{
+			name: "float16",
+			write: func(writer io.Writer) error {
+				return WriteArrayTo(writer, Float32ToFloat16Slice([]float32{1.5, -2, 4}))
+			},
+			want: "[1.5, -2, 4]",
+		},
+		{
+			name: "int8",
+			write: func(writer io.Writer) error {
+				return WriteArrayTo(writer, []int8{1, -2, 127, -128})
+			},
+			want: "[1, -2, 127, -128]",
+		},
+		{
+			name: "uint8",
+			write: func(writer io.Writer) error {
+				return WriteArrayTo(writer, []uint8{1, 2, 255})
+			},
+			want: "[1, 2, 255]",
+		},
+		{
+			name: "empty",
+			write: func(writer io.Writer) error {
+				return WriteArrayTo(writer, []float32(nil))
+			},
+			want: "[]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			require.NoError(t, tc.write(&buffer))
+			require.Equal(t, tc.want, buffer.String())
+		})
+	}
+
+	require.ErrorIs(t,
+		WriteArrayTo(shortWriter{}, []float32{1}), io.ErrShortWrite)
 }
 
 func TestArraysToString(t *testing.T) {

--- a/pkg/sql/colexec/aggexec/agg_payload.go
+++ b/pkg/sql/colexec/aggexec/agg_payload.go
@@ -205,9 +205,11 @@ func writeGroupConcatData(writer io.Writer, typ types.Type, data []byte) error {
 		return writeValue(util.UnsafeFromBytes[types.MoYear](data).String())
 	case types.T_uuid:
 		return writeValue(types.DecodeUuid(data).String())
+	case types.T_array_float32, types.T_array_float64, types.T_array_bf16,
+		types.T_array_float16, types.T_array_int8, types.T_array_uint8:
+		return writeGroupConcatArrayData(writer, typ, data)
 	case types.T_blob, types.T_text, types.T_datalink, types.T_varbinary, types.T_binary,
-		types.T_char, types.T_varchar, types.T_enum, types.T_array_float32, types.T_array_float64,
-		types.T_array_bf16, types.T_array_float16, types.T_array_int8, types.T_array_uint8:
+		types.T_char, types.T_varchar, types.T_enum:
 		if err := isValidGroupConcatUnit(data); err != nil {
 			return err
 		}
@@ -230,5 +232,33 @@ func writeGroupConcatData(writer io.Writer, typ types.Type, data []byte) error {
 	default:
 		return moerr.NewInternalErrorNoCtxf(
 			"unsupported type for group_concat payload: %s", typ.String())
+	}
+}
+
+func writeGroupConcatArrayData(writer io.Writer, typ types.Type, data []byte) error {
+	if err := isValidGroupConcatUnit(data); err != nil {
+		return err
+	}
+	if !typ.Oid.IsArrayRelate() || len(data)%typ.GetArrayElementSize() != 0 {
+		return moerr.NewInternalErrorNoCtxf(
+			"invalid group_concat array payload size for %s", typ.String())
+	}
+
+	switch typ.Oid {
+	case types.T_array_float32:
+		return types.WriteArrayTo(writer, types.BytesToArray[float32](data))
+	case types.T_array_float64:
+		return types.WriteArrayTo(writer, types.BytesToArray[float64](data))
+	case types.T_array_bf16:
+		return types.WriteArrayTo(writer, types.BytesToArray[types.BF16](data))
+	case types.T_array_float16:
+		return types.WriteArrayTo(writer, types.BytesToArray[types.Float16](data))
+	case types.T_array_int8:
+		return types.WriteArrayTo(writer, types.BytesToArray[int8](data))
+	case types.T_array_uint8:
+		return types.WriteArrayTo(writer, types.BytesToArray[uint8](data))
+	default:
+		return moerr.NewInternalErrorNoCtxf(
+			"unsupported array type for group_concat payload: %s", typ.String())
 	}
 }

--- a/pkg/sql/colexec/aggexec/agg_payload_test.go
+++ b/pkg/sql/colexec/aggexec/agg_payload_test.go
@@ -17,6 +17,7 @@ package aggexec
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"strings"
 	"testing"
@@ -83,6 +84,9 @@ func TestEncodeGroupConcatPayloadAndFieldBytes(t *testing.T) {
 	geometryVec := vector.NewVec(types.T_geometry.ToType())
 	geometryBytes := geo.WriteWKB(geo.Point{X: 1, Y: 2})
 	require.NoError(t, vector.AppendBytes(geometryVec, geometryBytes, false, mp))
+	arrayVec := vector.NewVec(types.T_array_float32.ToType())
+	arrayBytes := types.ArrayToBytes([]float32{1, 2, 3})
+	require.NoError(t, vector.AppendBytes(arrayVec, arrayBytes, false, mp))
 
 	payload, err := encodeGroupConcatPayload([]*vector.Vector{textVec, intVec}, 1, []types.Type{types.T_varchar.ToType(), types.T_int64.ToType()})
 	require.NoError(t, err)
@@ -137,10 +141,12 @@ func TestEncodeGroupConcatPayloadAndFieldBytes(t *testing.T) {
 	require.Equal(t, textVec.GetBytesAt(0), groupConcatFieldBytes(textVec, 0, types.T_varchar.ToType()))
 	require.Equal(t, intVec.GetRawBytesAt(0), groupConcatFieldBytes(intVec, 0, types.T_int64.ToType()))
 	require.Equal(t, geometryBytes, groupConcatFieldBytes(geometryVec, 0, types.T_geometry.ToType()))
+	require.Equal(t, arrayBytes, groupConcatFieldBytes(arrayVec, 0, types.T_array_float32.ToType()))
 
 	textVec.Free(mp)
 	intVec.Free(mp)
 	geometryVec.Free(mp)
+	arrayVec.Free(mp)
 	nullVec.Free(mp)
 }
 
@@ -203,6 +209,13 @@ func TestAppendGroupConcatDataCoversTypes(t *testing.T) {
 		{name: "year", typ: types.T_year.ToType(), data: types.EncodeInt16(ptr(int16(yearVal))), want: yearVal.String()},
 		{name: "uuid", typ: types.T_uuid.ToType(), data: types.EncodeUuid(&uuidVal), want: uuidVal.String()},
 		{name: "text", typ: types.T_text.ToType(), data: []byte("hello"), want: "hello"},
+		{name: "array-float32", typ: types.T_array_float32.ToType(), data: types.ArrayToBytes([]float32{1, -2, 0.5}), want: "[1, -2, 0.5]"},
+		{name: "array-float64", typ: types.T_array_float64.ToType(), data: types.ArrayToBytes([]float64{1.25, -2.5}), want: "[1.25, -2.5]"},
+		{name: "array-bf16", typ: types.T_array_bf16.ToType(), data: types.ArrayToBytes(types.Float32ToBF16Slice([]float32{-1, 0, 4})), want: "[-1, 0, 4]"},
+		{name: "array-float16", typ: types.T_array_float16.ToType(), data: types.ArrayToBytes(types.Float32ToFloat16Slice([]float32{1.5, -2, 4})), want: "[1.5, -2, 4]"},
+		{name: "array-int8", typ: types.T_array_int8.ToType(), data: types.ArrayToBytes([]int8{1, -2, 127, -128}), want: "[1, -2, 127, -128]"},
+		{name: "array-uint8", typ: types.T_array_uint8.ToType(), data: types.ArrayToBytes([]uint8{1, 2, 255}), want: "[1, 2, 255]"},
+		{name: "array-empty", typ: types.T_array_float32.ToType(), data: nil, want: "[]"},
 		{name: "geometry", typ: types.T_geometry.ToType(), data: geometryVal, want: string(geometryVal)},
 		{name: "geometry32", typ: types.T_geometry32.ToType(), data: geometry32Val, want: string(geometry32Val)},
 		{name: "json", typ: types.T_json.ToType(), data: jsonBytes, want: types.DecodeJson(jsonBytes).String()},
@@ -216,6 +229,8 @@ func TestAppendGroupConcatDataCoversTypes(t *testing.T) {
 		{name: "short-decimal256-payload", typ: types.T_decimal256.ToType(), data: []byte{1}, wantErr: "fixed payload size"},
 		{name: "short-year-payload", typ: types.T_year.ToType(), data: []byte{1}, wantErr: "fixed payload size"},
 		{name: "short-uuid-payload", typ: types.T_uuid.ToType(), data: []byte{1}, wantErr: "fixed payload size"},
+		{name: "misaligned-array-float32", typ: types.T_array_float32.ToType(), data: []byte{1}, wantErr: "invalid group_concat array payload size"},
+		{name: "misaligned-array-bf16", typ: types.T_array_bf16.ToType(), data: []byte{1}, wantErr: "invalid group_concat array payload size"},
 		{
 			name: "unsupported-objectid",
 			typ: types.Type{
@@ -241,6 +256,31 @@ func TestAppendGroupConcatDataCoversTypes(t *testing.T) {
 	got, err := appendGroupConcatData([]byte("prefix-"), types.T_varchar.ToType(), []byte("tail"))
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(string(got), "prefix-tail"))
+
+	arrayBytes := types.ArrayToBytes([]float32{1, 2})
+	writerErr := errors.New("array writer failed")
+	require.ErrorIs(t, writeGroupConcatData(
+		&groupConcatFailWriter{err: writerErr},
+		types.T_array_float32.ToType(), arrayBytes), writerErr)
+	require.ErrorIs(t, writeGroupConcatData(
+		groupConcatShortWriter{}, types.T_array_float32.ToType(), arrayBytes), io.ErrShortWrite)
+}
+
+type groupConcatFailWriter struct {
+	err error
+}
+
+func (w *groupConcatFailWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type groupConcatShortWriter struct{}
+
+func (groupConcatShortWriter) Write(value []byte) (int, error) {
+	if len(value) == 0 {
+		return 0, nil
+	}
+	return len(value) - 1, nil
 }
 
 func ptr[T any](v T) *T {

--- a/pkg/sql/colexec/aggexec/concat2_test.go
+++ b/pkg/sql/colexec/aggexec/concat2_test.go
@@ -786,6 +786,93 @@ func TestGroupConcatLargeGeometryAcrossFinalizers(t *testing.T) {
 	}
 }
 
+func TestGroupConcatVectorValuesAcrossFinalizers(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer func() {
+		require.Zero(t, mp.CurrNB())
+	}()
+
+	valueType := types.T_array_float32.ToType()
+	first := types.ArrayToBytes([]float32{1, 2, 3})
+	second := types.ArrayToBytes([]float32{-1, 0, 4})
+	cases := []struct {
+		name     string
+		distinct bool
+		ordered  bool
+		values   [][]byte
+		keys     []int64
+		want     string
+	}{
+		{
+			name:   "input order",
+			values: [][]byte{first, second},
+			want:   "[1, 2, 3]|[-1, 0, 4]",
+		},
+		{
+			name:    "ordered",
+			ordered: true,
+			values:  [][]byte{second, first, second},
+			keys:    []int64{3, 1, 2},
+			want:    "[1, 2, 3]|[-1, 0, 4]|[-1, 0, 4]",
+		},
+		{
+			name:     "ordered distinct",
+			distinct: true,
+			ordered:  true,
+			values:   [][]byte{second, first, first},
+			keys:     []int64{3, 1, 2},
+			want:     "[1, 2, 3]|[-1, 0, 4]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			argTypes := []types.Type{valueType}
+			if tc.ordered {
+				argTypes = append(argTypes, types.T_int64.ToType())
+			}
+			info := multiAggInfo{
+				aggID:     AggIdOfGroupConcat,
+				distinct:  tc.distinct,
+				argTypes:  argTypes,
+				retType:   GroupConcatReturnType([]types.Type{valueType}),
+				emptyNull: true,
+			}
+			exec := newGroupConcatExec(mp, info, "|").(*groupConcatExec)
+			defer exec.Free()
+			if tc.ordered {
+				require.NoError(t, exec.SetExtraInformation(
+					testGroupConcatOrderConfig(1, []byte{groupConcatOrderAsc}, "|"), 0))
+			}
+			require.NoError(t, exec.GroupGrow(1))
+
+			values := vector.NewVec(valueType)
+			defer values.Free(mp)
+			for _, value := range tc.values {
+				require.NoError(t, vector.AppendBytes(values, value, false, mp))
+			}
+			vectors := []*vector.Vector{values}
+			if tc.ordered {
+				orderKeys := vector.NewVec(types.T_int64.ToType())
+				defer orderKeys.Free(mp)
+				require.NoError(t, vector.AppendFixedList(orderKeys, tc.keys, nil, mp))
+				vectors = append(vectors, orderKeys)
+			}
+
+			groups := make([]uint64, len(tc.values))
+			for i := range groups {
+				groups[i] = 1
+			}
+			require.NoError(t, exec.BatchFill(0, groups, vectors))
+			results, err := exec.Flush()
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			defer results[0].Free(mp)
+			require.Equal(t, tc.want, string(results[0].GetBytesAt(0)))
+		})
+	}
+}
+
 func TestGroupConcatMaxLenPreservesOpaqueBinaryCharset(t *testing.T) {
 	mp := mpool.MustNewZero()
 	inputType := types.NewWithCharset(

--- a/test/distributed/cases/function/issue_28679_group_concat_vector.result
+++ b/test/distributed/cases/function/issue_28679_group_concat_vector.result
@@ -1,0 +1,76 @@
+drop table if exists issue_28679_group_concat_vector;
+create table issue_28679_group_concat_vector (
+id int primary key,
+v32 vecf32(3),
+v64 vecf64(3),
+vbf vecbf16(3),
+vf16 vecf16(3),
+vi8 vecint8(3),
+vu8 vecuint8(3)
+);
+insert into issue_28679_group_concat_vector values
+(1, '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[-1, 0, 4]', '[1, 2, 3]'),
+(2, '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[-1, 0, 4]', '[1, 2, 3]'),
+(3, '[-1, 0, 4]', '[-1, 0, 4]', '[-1, 0, 4]', '[-1, 0, 4]', '[-1, 0, 4]', '[4, 5, 6]'),
+(4, null, null, null, null, null, null);
+select v32, v64, vbf, vf16, vi8, vu8
+from issue_28679_group_concat_vector
+where id = 1;
+➤ v32[12,3,0]  ¦  v64[12,3,0]  ¦  vbf[12,3,0]  ¦  vf16[12,3,0]  ¦  vi8[12,3,0]  ¦  vu8[12,3,0]  𝄀
+[1, 2, 3]  ¦  [1, 2, 3]  ¦  [1, 2, 3]  ¦  [1, 2, 3]  ¦  [-1, 0, 4]  ¦  [1, 2, 3]
+select group_concat(v32 separator '|'),
+group_concat(v64 separator '|'),
+group_concat(vbf separator '|'),
+group_concat(vf16 separator '|'),
+group_concat(vi8 separator '|'),
+group_concat(vu8 separator '|')
+from issue_28679_group_concat_vector
+where id = 1;
+➤ group_concat(v32 separator |)[-1,16383,0]  ¦  group_concat(v64 separator |)[-1,16383,0]  ¦  group_concat(vbf separator |)[-1,16383,0]  ¦  group_concat(vf16 separator |)[-1,16383,0]  ¦  group_concat(vi8 separator |)[-1,16383,0]  ¦  group_concat(vu8 separator |)[-1,16383,0]  𝄀
+[1, 2, 3]  ¦  [1, 2, 3]  ¦  [1, 2, 3]  ¦  [1, 2, 3]  ¦  [-1, 0, 4]  ¦  [1, 2, 3]
+select group_concat(v32 order by id separator '|'),
+group_concat(v64 order by id separator '|'),
+group_concat(vbf order by id separator '|'),
+group_concat(vf16 order by id separator '|'),
+group_concat(vi8 order by id separator '|'),
+group_concat(vu8 order by id separator '|')
+from issue_28679_group_concat_vector
+where id <= 3;
+➤ group_concat(v32 order by id separator |)[-1,16383,0]  ¦  group_concat(v64 order by id separator |)[-1,16383,0]  ¦  group_concat(vbf order by id separator |)[-1,16383,0]  ¦  group_concat(vf16 order by id separator |)[-1,16383,0]  ¦  group_concat(vi8 order by id separator |)[-1,16383,0]  ¦  group_concat(vu8 order by id separator |)[-1,16383,0]  𝄀
+[1, 2, 3]|[1, 2, 3]|[-1, 0, 4]  ¦  [1, 2, 3]|[1, 2, 3]|[-1, 0, 4]  ¦  [1, 2, 3]|[1, 2, 3]|[-1, 0, 4]  ¦  [1, 2, 3]|[1, 2, 3]|[-1, 0, 4]  ¦  [-1, 0, 4]|[-1, 0, 4]|[-1, 0, 4]  ¦  [1, 2, 3]|[1, 2, 3]|[4, 5, 6]
+select group_concat(distinct v32 order by id separator '|'),
+group_concat(distinct v64 order by id separator '|'),
+group_concat(distinct vbf order by id separator '|'),
+group_concat(distinct vf16 order by id separator '|'),
+group_concat(distinct vi8 order by id separator '|'),
+group_concat(distinct vu8 order by id separator '|')
+from issue_28679_group_concat_vector
+where id <= 3;
+➤ group_concat(distinct v32 order by id separator |)[-1,16383,0]  ¦  group_concat(distinct v64 order by id separator |)[-1,16383,0]  ¦  group_concat(distinct vbf order by id separator |)[-1,16383,0]  ¦  group_concat(distinct vf16 order by id separator |)[-1,16383,0]  ¦  group_concat(distinct vi8 order by id separator |)[-1,16383,0]  ¦  group_concat(distinct vu8 order by id separator |)[-1,16383,0]  𝄀
+[1, 2, 3]|[-1, 0, 4]  ¦  [1, 2, 3]|[-1, 0, 4]  ¦  [1, 2, 3]|[-1, 0, 4]  ¦  [1, 2, 3]|[-1, 0, 4]  ¦  [-1, 0, 4]  ¦  [1, 2, 3]|[4, 5, 6]
+select group_concat(v32, ':', vu8 order by id separator '|')
+from issue_28679_group_concat_vector
+where id <= 3;
+➤ group_concat(v32, :, vu8 order by id separator |)[-1,16383,0]  𝄀
+[1, 2, 3]:[1, 2, 3]|[1, 2, 3]:[1, 2, 3]|[-1, 0, 4]:[4, 5, 6]
+select group_concat(v32 order by id separator '|')
+from issue_28679_group_concat_vector
+where id in (1, 4);
+➤ group_concat(v32 order by id separator |)[-1,16383,0]  𝄀
+[1, 2, 3]
+select group_concat(v32)
+from issue_28679_group_concat_vector
+where id = 4;
+➤ group_concat(v32 separator ,)[-1,16383,0]  𝄀
+null
+set session group_concat_max_len = 12;
+select group_concat(v32 order by id separator '|')
+from issue_28679_group_concat_vector
+where id in (1, 3);
+➤ group_concat(v32 order by id separator |)[-1,16383,0]  𝄀
+[1, 2, 3]|[-
+show warnings;
+➤ Level[12,0,0]  ¦  Code[5,0,0]  ¦  Message[12,0,0]  𝄀
+Warning  ¦  1260  ¦  Row 2 was cut by GROUP_CONCAT()
+set session group_concat_max_len = 1024;
+drop table issue_28679_group_concat_vector;

--- a/test/distributed/cases/function/issue_28679_group_concat_vector.sql
+++ b/test/distributed/cases/function/issue_28679_group_concat_vector.sql
@@ -1,0 +1,75 @@
+-- issue #28679: GROUP_CONCAT must use the public text representation for
+-- vector values instead of exposing their internal numeric bytes.
+drop table if exists issue_28679_group_concat_vector;
+create table issue_28679_group_concat_vector (
+    id int primary key,
+    v32 vecf32(3),
+    v64 vecf64(3),
+    vbf vecbf16(3),
+    vf16 vecf16(3),
+    vi8 vecint8(3),
+    vu8 vecuint8(3)
+);
+insert into issue_28679_group_concat_vector values
+    (1, '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[-1, 0, 4]', '[1, 2, 3]'),
+    (2, '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[1, 2, 3]', '[-1, 0, 4]', '[1, 2, 3]'),
+    (3, '[-1, 0, 4]', '[-1, 0, 4]', '[-1, 0, 4]', '[-1, 0, 4]', '[-1, 0, 4]', '[4, 5, 6]'),
+    (4, null, null, null, null, null, null);
+
+-- Direct SELECT is the public formatting control for every vector family.
+select v32, v64, vbf, vf16, vi8, vu8
+from issue_28679_group_concat_vector
+where id = 1;
+
+-- Ordinary GROUP_CONCAT must format each vector before joining it.
+select group_concat(v32 separator '|'),
+       group_concat(v64 separator '|'),
+       group_concat(vbf separator '|'),
+       group_concat(vf16 separator '|'),
+       group_concat(vi8 separator '|'),
+       group_concat(vu8 separator '|')
+from issue_28679_group_concat_vector
+where id = 1;
+
+-- ORDER BY must retain the raw payload for ordering and format at emission.
+select group_concat(v32 order by id separator '|'),
+       group_concat(v64 order by id separator '|'),
+       group_concat(vbf order by id separator '|'),
+       group_concat(vf16 order by id separator '|'),
+       group_concat(vi8 order by id separator '|'),
+       group_concat(vu8 order by id separator '|')
+from issue_28679_group_concat_vector
+where id <= 3;
+
+-- DISTINCT must deduplicate raw vector values, not their byte-buffer display.
+select group_concat(distinct v32 order by id separator '|'),
+       group_concat(distinct v64 order by id separator '|'),
+       group_concat(distinct vbf order by id separator '|'),
+       group_concat(distinct vf16 order by id separator '|'),
+       group_concat(distinct vi8 order by id separator '|'),
+       group_concat(distinct vu8 order by id separator '|')
+from issue_28679_group_concat_vector
+where id <= 3;
+
+-- Multiple arguments must format each vector independently.
+select group_concat(v32, ':', vu8 order by id separator '|')
+from issue_28679_group_concat_vector
+where id <= 3;
+
+-- NULL vector rows remain skipped, and an all-NULL group remains SQL NULL.
+select group_concat(v32 order by id separator '|')
+from issue_28679_group_concat_vector
+where id in (1, 4);
+select group_concat(v32)
+from issue_28679_group_concat_vector
+where id = 4;
+
+-- group_concat_max_len applies to the rendered text, not the raw bytes.
+set session group_concat_max_len = 12;
+select group_concat(v32 order by id separator '|')
+from issue_28679_group_concat_vector
+where id in (1, 3);
+show warnings;
+set session group_concat_max_len = 1024;
+
+drop table issue_28679_group_concat_vector;

--- a/test/distributed/cases/vector/vector_narrow_types_generic.result
+++ b/test/distributed/cases/vector/vector_narrow_types_generic.result
@@ -37,16 +37,16 @@ select mo_table_col_max('narrowgen', 'nv', 'u8');
 
 select hex(group_concat(i8 order by a)) from nv;
 ➤ hex(group_concat(i8, ,order by a))[12,-1,0]  𝄀
-0102032C0405062CFF0007
+5B312C20322C20335D2C5B342C20352C20365D2C5B2D312C20302C20375D
 select hex(group_concat(u8 order by a)) from nv;
 ➤ hex(group_concat(u8, ,order by a))[12,-1,0]  𝄀
-0102032C0405062C0A80FF
+5B312C20322C20335D2C5B342C20352C20365D2C5B31302C203132382C203235355D
 select hex(group_concat(bf order by a)) from nv where a = 1;
 ➤ hex(group_concat(bf, ,order by a))[12,-1,0]  𝄀
-803F00404040
+5B312C20322C20335D
 select hex(group_concat(f16 order by a)) from nv where a = 1;
 ➤ hex(group_concat(f16, ,order by a))[12,-1,0]  𝄀
-003C00400042
+5B312C20322C20335D
 select json_arrayagg(i8) from nv where a = 3;
 ➤ json_arrayagg(i8)[-1,2147483647,0]  𝄀
 [[-1, 0, 7]]

--- a/test/distributed/cases/vector/vector_narrow_types_generic.sql
+++ b/test/distributed/cases/vector/vector_narrow_types_generic.sql
@@ -35,9 +35,8 @@ select mo_table_col_max('narrowgen', 'nv', 'bf');
 select mo_table_col_max('narrowgen', 'nv', 'i8');
 select mo_table_col_max('narrowgen', 'nv', 'u8');
 
--- group_concat: failed with "unsupported type for group_concat payload".
--- Vectors concat as their raw storage bytes (this is also what vecf32 does), so
--- hex() keeps the expected output textual and stable.
+-- group_concat: vectors use their canonical SQL text representation. hex() keeps
+-- the expected text bytes stable while also guarding against raw storage output.
 select hex(group_concat(i8 order by a)) from nv;
 select hex(group_concat(u8 order by a)) from nv;
 select hex(group_concat(bf order by a)) from nv where a = 1;


### PR DESCRIPTION
Fixes #28679

## What type of PR is this?

- [x] BUG
- [ ] API-change
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28679

## What this PR does / why we need it:

`GROUP_CONCAT` previously emitted the internal little-endian storage bytes for vector values even though its result type is textual. This fix keeps raw vector payloads unchanged through collection, ordering, `DISTINCT`, spill, and merge, then formats all six supported vector families through the shared canonical SQL formatter at the final emission boundary. NULL filtering, separators, truncation, and warning behavior remain unchanged.

The existing narrow-vector BVT also contained four pre-fix raw-byte expectations. Those expectations now assert the canonical text bytes returned by `HEX(GROUP_CONCAT(...))`, including signed and unsigned boundary values; this is compatibility maintenance for the intentional public behavior change.

## Test plan

- After rebase onto `main` at `b731195780bd5bd5d4be7dd1d92b021d0726e441`:
  - `GOWORK=off .agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=600s ./pkg/container/types`
  - `GOWORK=off .agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=600s ./pkg/sql/colexec/aggexec`
  - Focused formatter and aggregate tests with `-race`: passed.
  - Incremental `golangci-lint` for `./pkg/container/types ./pkg/sql/colexec/aggexec` with repository CGo flags: `0 issues`.
  - `git diff --check`: passed; no obsolete raw-byte expectations remain in vector/function cases.
- Public regression `test/distributed/cases/function/issue_28679_group_concat_vector.sql` covers direct output, ordinary/ordered/ordered-DISTINCT aggregation, multiple arguments, NULLs, and truncation warnings.
- CI run `34619675248`, job `103333665155`, identified four stale raw-byte expectations in `vector_narrow_types_generic.sql`; the downstream coverage job only reported an incomplete producer after that BVT failure. The four `.result` rows were corrected and independently checked against the UTF-8 canonical strings. A corrected hosted BVT run is the remaining integration evidence.
- GPT-6 medium design gate: PASS (`gpt6-design-28741-oracle-fdf6588`). Final review after this rebase: PASS (`gpt6-final-review-28741-ef0b91d`).

Hosted CI is pending and is not being awaited.