### PR TITLE
fix(snapshot): order restore catalog locks

### DIFF
--- a/pkg/catalog/view_metadata.go
+++ b/pkg/catalog/view_metadata.go
@@ -35,6 +35,13 @@ const ViewMetadataLifecycleGateSQL = "select rel_id from mo_catalog.mo_tables " 
 const SnapshotLifecycleGateSQL = "select feature_code from mo_catalog.mo_feature_registry " +
 	"where feature_code = 'SNAPSHOT' for update"
 
+// FeatureRegistryCatalogGateSQL takes exclusive ownership of the catalog
+// identity that owns SnapshotLifecycleGateSQL. A cluster or system-account
+// restore can drop and recreate mo_feature_registry, so restore must acquire
+// this metadata row before taking the SNAPSHOT lifecycle row lock.
+const FeatureRegistryCatalogGateSQL = "select rel_id from mo_catalog.mo_tables " +
+	"where account_id=0 and reldatabase='mo_catalog' and relname='mo_feature_registry' for update"
+
 // LockViewMetadataLifecycle preserves SNAPSHOT -> View ordering across an
 // entire transaction, including CREATE followed by DROP in a later statement.
 // Keep the View lock as well: older CNs still use it during rolling upgrades.

--- a/pkg/frontend/data_branch_lineage_lock_test.go
+++ b/pkg/frontend/data_branch_lineage_lock_test.go
@@ -70,6 +70,7 @@ func (e *lineageLifecycleCommitSQLExecutor) ExecTxn(
 
 func TestLockRestoreLineageOwnerLifecycleCoversWholeCatalogRestore(t *testing.T) {
 	ctx := defines.AttachAccountId(context.Background(), 42)
+	featureRegistrySQL := catalog.FeatureRegistryCatalogGateSQL
 	gateSQL := databranchutils.LineageOwnerLifecycleLockSQL()
 
 	for _, level := range []tree.RestoreLevel{
@@ -79,8 +80,9 @@ func TestLockRestoreLineageOwnerLifecycleCoversWholeCatalogRestore(t *testing.T)
 		t.Run(level.String(), func(t *testing.T) {
 			bh := &lineagePublicationLockExec{}
 			bh.init()
+			bh.sql2result[featureRegistrySQL] = newMrsForSqlForShowDatabases([][]interface{}{{1}})
 			require.NoError(t, lockRestoreLineageOwnerLifecycle(ctx, bh, level))
-			require.Equal(t, []string{gateSQL}, bh.executedSQLs)
+			require.Equal(t, []string{featureRegistrySQL, gateSQL}, bh.executedSQLs)
 			require.Equal(t, uint32(catalog.System_Account), bh.accountID)
 		})
 	}
@@ -101,12 +103,34 @@ func TestLockRestoreLineageOwnerLifecycleCoversWholeCatalogRestore(t *testing.T)
 		bh := &lineagePublicationLockExec{}
 		bh.init()
 		wantErr := errors.New("lifecycle gate failed")
+		bh.sql2result[featureRegistrySQL] = newMrsForSqlForShowDatabases([][]interface{}{{1}})
 		bh.sql2err[gateSQL] = wantErr
 		require.ErrorIs(t,
 			lockRestoreLineageOwnerLifecycle(ctx, bh, tree.RESTORELEVELACCOUNT),
 			wantErr,
 		)
-		require.Equal(t, []string{gateSQL}, bh.executedSQLs)
+		require.Equal(t, []string{featureRegistrySQL, gateSQL}, bh.executedSQLs)
+	})
+
+	t.Run("feature registry gate error aborts before lineage barrier", func(t *testing.T) {
+		bh := &lineagePublicationLockExec{}
+		bh.init()
+		wantErr := errors.New("feature registry gate failed")
+		bh.sql2err[featureRegistrySQL] = wantErr
+		require.ErrorIs(t,
+			lockRestoreLineageOwnerLifecycle(ctx, bh, tree.RESTORELEVELCLUSTER),
+			wantErr,
+		)
+		require.Equal(t, []string{featureRegistrySQL}, bh.executedSQLs)
+	})
+
+	t.Run("missing feature registry fails closed", func(t *testing.T) {
+		bh := &lineagePublicationLockExec{}
+		bh.init()
+		require.Error(t,
+			lockRestoreLineageOwnerLifecycle(ctx, bh, tree.RESTORELEVELACCOUNT),
+		)
+		require.Equal(t, []string{featureRegistrySQL}, bh.executedSQLs)
 	})
 }
 

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -42,6 +42,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -51,6 +52,12 @@ type tableType string
 const view tableType = "VIEW"
 
 const clusterTable tableType = "CLUSTER TABLE"
+
+// restoreBeforeViewMetadataLifecycleFault pauses a whole-catalog restore after
+// it has taken the feature-registry catalog identity and before the remaining
+// lifecycle gates. It is inert unless a test explicitly installs the fault
+// point and observes the metadata lock ordering at this boundary.
+const restoreBeforeViewMetadataLifecycleFault = "restore-before-view-metadata-lifecycle"
 
 const (
 	insertIntoMoSnapshots = `insert into mo_catalog.mo_snapshots(
@@ -772,8 +779,9 @@ func doRestoreSnapshot(ctx context.Context, ses *Session, stmt *tree.RestoreSnap
 		return stats, err
 	}
 	// Serialize catalog restore with View metadata recovery before either path
-	// locks a target View. The gate row belongs to a preserved catalog table, so
-	// it remains stable while relation identities are rebuilt.
+	// locks a target View. The restore admission above owns the feature-registry
+	// catalog identity before its SNAPSHOT row can be retained while relation
+	// identities are rebuilt.
 	if err = lockViewMetadataLifecycle(ctx, bh); err != nil {
 		return stats, err
 	}
@@ -974,6 +982,25 @@ func lockRestoreLineageOwnerLifecycle(
 	if !restoreReplacesLineageOwnerCatalogs(level) {
 		return nil
 	}
+	// The feature-registry relation owns the SNAPSHOT lifecycle row below and
+	// is itself copied during cluster/system-account restore. Acquire its
+	// stable catalog identity before the SNAPSHOT row so a CN heartbeat cannot
+	// hold shared metadata for the relation while waiting on SNAPSHOT as
+	// restore later upgrades that metadata to replace the relation.
+	systemCtx := defines.AttachAccountId(ctx, catalog.System_Account)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(systemCtx, catalog.FeatureRegistryCatalogGateSQL); err != nil {
+		return err
+	}
+	results, err := getResultSet(systemCtx, bh)
+	bh.ClearExecResultSet()
+	if err != nil {
+		return err
+	}
+	if !execResultArrayHasData(results) {
+		return moerr.NewNoSuchTable(systemCtx, catalog.MO_CATALOG, catalog.MO_FEATURE_REGISTRY)
+	}
+	fault.TriggerFaultWithContext(ctx, restoreBeforeViewMetadataLifecycleFault)
 	return lockDataBranchLineageOwnerLifecycle(ctx, bh)
 }
 

--- a/pkg/tests/issues/isolated/issue_26640_cluster_restore_test.go
+++ b/pkg/tests/issues/isolated/issue_26640_cluster_restore_test.go
@@ -15,6 +15,7 @@
 package isolated
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -22,8 +23,15 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/cnservice"
 	"github.com/matrixorigin/matrixone/pkg/embed"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
+	pblock "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/sql/compile"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/stretchr/testify/require"
 )
 
@@ -129,7 +137,9 @@ func TestIssue26640ClusterRestoreRebindsSubscriptionPrivileges(t *testing.T) {
 	// in a deferred phase after the publication has been reconstructed.
 	execSQLRequire(t, ctx, sysDB, "drop account `"+subscriberAccount+"`")
 	execSQLRequire(t, ctx, sysDB, "drop account `"+publisherAccount+"`")
-	execSQLRequire(t, ctx, sysDB, "restore cluster{snapshot='"+snapshotName+"'}")
+	runIssue28742CanceledRestoreWithMetadataProbe(t, ctx, cluster, sysDB, snapshotName,
+		publisherAccount, subscriberAccount)
+	runIssue28742RestoreWithMetadataProbe(t, ctx, cluster, sysDB, snapshotName)
 	var targetPublisherID, targetSubscriberID uint64
 	require.NoError(t, sysDB.QueryRowContext(ctx,
 		"select account_id from mo_catalog.mo_account where account_name = ?", publisherAccount,
@@ -182,4 +192,283 @@ func TestIssue26640ClusterRestoreRebindsSubscriptionPrivileges(t *testing.T) {
 	require.NoError(t, readerDB.QueryRowContext(ctx,
 		"select count(*) from `"+subscriptionDB+"`.orders").Scan(&count))
 	require.Equal(t, 1, count)
+}
+
+func runIssue28742CanceledRestoreWithMetadataProbe(
+	t *testing.T,
+	parent context.Context,
+	cluster embed.Cluster,
+	sysDB *sql.DB,
+	snapshotName string,
+	publisherAccount string,
+	subscriberAccount string,
+) {
+	t.Helper()
+	const restoreGate = "restore-before-view-metadata-lifecycle"
+	const restoreGateWaiters = restoreGate + "-waiters"
+
+	cn1, err := cluster.GetCNService(1)
+	require.NoError(t, err)
+	cn1Service, ok := cn1.RawService().(cnservice.Service)
+	require.True(t, ok, "CN service does not expose the SQL executor")
+	probeExecutor := cn1Service.GetSQLExecutor()
+	require.NotNil(t, probeExecutor)
+	services := issue28742LockServices(cluster)
+	require.NotEmpty(t, services)
+
+	faultEnabledHere := fault.Enable()
+	if faultEnabledHere {
+		defer fault.Disable()
+	}
+	require.NoError(t, fault.AddFaultPoint(
+		parent, restoreGate, ":::", "wait", 0, "", false))
+	require.NoError(t, fault.AddFaultPoint(
+		parent, restoreGateWaiters, ":::", "getwaiters", 0, restoreGate, false))
+
+	restoreCtx, cancelRestore := context.WithTimeout(parent, 90*time.Second)
+	probeCtx, cancelProbe := context.WithCancel(restoreCtx)
+	defer cancelProbe()
+	defer cancelRestore()
+	restoreDone := make(chan error, 1)
+	probeDone := make(chan error, 1)
+	restoreStarted := false
+	probeStarted := false
+	defer func() {
+		_, _ = fault.RemoveFaultPoint(context.Background(), restoreGateWaiters)
+		_, _ = fault.RemoveFaultPoint(context.Background(), restoreGate)
+		cancelProbe()
+		cancelRestore()
+		if restoreStarted {
+			select {
+			case <-restoreDone:
+			case <-time.After(30 * time.Second):
+				t.Errorf("canceled restore goroutine did not exit during cleanup")
+			}
+		}
+		if probeStarted {
+			select {
+			case <-probeDone:
+			case <-time.After(30 * time.Second):
+				t.Errorf("canceled view-metadata fence goroutine did not exit during cleanup")
+			}
+		}
+	}()
+
+	go func() {
+		_, restoreErr := sysDB.ExecContext(restoreCtx,
+			"restore cluster{snapshot='"+snapshotName+"'}")
+		restoreDone <- restoreErr
+	}()
+	restoreStarted = true
+	require.Eventually(t, func() bool {
+		waiters, _, exists := fault.TriggerFault(restoreGateWaiters)
+		return exists && waiters == 1
+	}, 30*time.Second, 10*time.Millisecond,
+		"restore did not reach the cancellation barrier")
+
+	go func() {
+		probeDone <- compile.RequireViewMetadataRevalidation(probeCtx, probeExecutor)
+	}()
+	probeStarted = true
+	require.Eventually(t, func() bool {
+		return issue28742HasFeatureRegistryMetadataWaiter(services)
+	}, 20*time.Second, 10*time.Millisecond,
+		"feature-registry metadata probe did not wait before cancellation")
+
+	cancelProbe()
+	select {
+	case err = <-probeDone:
+		probeStarted = false
+		require.Error(t, err)
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "canceled view-metadata fence did not return")
+	}
+
+	cancelRestore()
+	_, err = fault.RemoveFaultPoint(parent, restoreGate)
+	require.NoError(t, err)
+	select {
+	case err = <-restoreDone:
+		restoreStarted = false
+		require.Error(t, err)
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "canceled restore did not return")
+	}
+
+	freshCtx, freshCancel := context.WithTimeout(parent, 15*time.Second)
+	defer freshCancel()
+	err = probeExecutor.ExecTxn(freshCtx, func(txn executor.TxnExecutor) error {
+		for _, sql := range []string{
+			catalog.FeatureRegistryCatalogGateSQL,
+			catalog.SnapshotLifecycleGateSQL,
+		} {
+			result, execErr := txn.Exec(sql, executor.StatementOption{})
+			if execErr != nil {
+				return execErr
+			}
+			result.Close()
+		}
+		return nil
+	}, executor.Options{}.WithAccountID(catalog.System_Account))
+	require.NoError(t, err)
+
+	var remaining int
+	require.NoError(t, sysDB.QueryRowContext(parent,
+		"select count(*) from mo_catalog.mo_account where account_name in (?, ?)",
+		publisherAccount, subscriberAccount).Scan(&remaining))
+	require.Zero(t, remaining)
+}
+
+func runIssue28742RestoreWithMetadataProbe(
+	t *testing.T,
+	parent context.Context,
+	cluster embed.Cluster,
+	sysDB *sql.DB,
+	snapshotName string,
+) {
+	t.Helper()
+	const restoreGate = "restore-before-view-metadata-lifecycle"
+	const restoreGateWaiters = restoreGate + "-waiters"
+
+	cn1, err := cluster.GetCNService(1)
+	require.NoError(t, err)
+	cn1Service, ok := cn1.RawService().(cnservice.Service)
+	require.True(t, ok, "CN service does not expose the SQL executor")
+	probeExecutor := cn1Service.GetSQLExecutor()
+	require.NotNil(t, probeExecutor)
+
+	services := issue28742LockServices(cluster)
+	require.NotEmpty(t, services)
+
+	faultEnabledHere := fault.Enable()
+	if faultEnabledHere {
+		defer fault.Disable()
+	}
+	require.NoError(t, fault.AddFaultPoint(
+		parent, restoreGate, ":::", "wait", 0, "", false))
+	require.NoError(t, fault.AddFaultPoint(
+		parent, restoreGateWaiters, ":::", "getwaiters", 0, restoreGate, false))
+
+	ctx, cancel := context.WithTimeout(parent, 180*time.Second)
+	defer cancel()
+	restoreDone := make(chan error, 1)
+	probeDone := make(chan error, 1)
+	restoreStarted := false
+	probeStarted := false
+	restoreConsumed := false
+	probeConsumed := false
+	defer func() {
+		_, _ = fault.RemoveFaultPoint(context.Background(), restoreGateWaiters)
+		_, _ = fault.RemoveFaultPoint(context.Background(), restoreGate)
+		cancel()
+		if restoreStarted && !restoreConsumed {
+			select {
+			case <-restoreDone:
+			case <-time.After(30 * time.Second):
+				t.Errorf("restore goroutine did not exit during cleanup")
+			}
+		}
+		if probeStarted && !probeConsumed {
+			select {
+			case <-probeDone:
+			case <-time.After(30 * time.Second):
+				t.Errorf("view-metadata fence goroutine did not exit during cleanup")
+			}
+		}
+	}()
+
+	go func() {
+		_, restoreErr := sysDB.ExecContext(ctx,
+			"restore cluster{snapshot='"+snapshotName+"'}")
+		restoreDone <- restoreErr
+	}()
+	restoreStarted = true
+
+	require.Eventually(t, func() bool {
+		waiters, _, exists := fault.TriggerFault(restoreGateWaiters)
+		return exists && waiters == 1
+	}, 30*time.Second, 10*time.Millisecond,
+		"restore did not reach the lifecycle coordination barrier")
+
+	probeCtx, cancelProbe := context.WithTimeout(ctx, 120*time.Second)
+	defer cancelProbe()
+	go func() {
+		probeDone <- compile.RequireViewMetadataRevalidation(probeCtx, probeExecutor)
+	}()
+	probeStarted = true
+
+	// The fixed path owns the feature-registry identity exclusively before it
+	// pauses at restoreGate. The probe therefore queues on that same metadata
+	// key instead of holding a shared key while waiting on SNAPSHOT. On the old
+	// path this condition cannot become true until the restore is released,
+	// which makes the regression discriminate the original lock order.
+	require.Eventually(t, func() bool {
+		return issue28742HasFeatureRegistryMetadataWaiter(services)
+	}, 15*time.Second, 10*time.Millisecond,
+		"feature-registry metadata probe did not wait behind restore admission")
+
+	_, err = fault.RemoveFaultPoint(parent, restoreGate)
+	require.NoError(t, err)
+
+	select {
+	case err = <-restoreDone:
+		restoreConsumed = true
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatalf("restore did not return: %v", ctx.Err())
+	}
+	select {
+	case err = <-probeDone:
+		probeConsumed = true
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatalf("feature-registry metadata probe did not return: %v", ctx.Err())
+	}
+
+	var generation uint64
+	require.NoError(t, sysDB.QueryRowContext(parent,
+		"select dependency_generation from mo_catalog.mo_view_dependencies "+
+			"where account_id=0 and target_relation_id=0 and dependency_ordinal=0",
+	).Scan(&generation))
+	require.Greater(t, generation, uint64(0))
+}
+
+func issue28742LockServices(cluster embed.Cluster) []lockservice.LockService {
+	var services []lockservice.LockService
+	cluster.ForeachServices(func(service embed.ServiceOperator) bool {
+		if service.ServiceType() == metadata.ServiceType_CN {
+			services = append(services, lockservice.GetLockServiceByServiceID(service.ServiceID()))
+		}
+		return true
+	})
+	return services
+}
+
+func issue28742HasFeatureRegistryMetadataWaiter(services []lockservice.LockService) bool {
+	for _, service := range services {
+		found := false
+		service.IterLocks(func(tableID uint64, keys [][]byte, lock lockservice.Lock) bool {
+			if tableID != catalog.MO_TABLES_ID || !issue28742HasKey(keys, []byte("mo_feature_registry")) {
+				return true
+			}
+			lock.IterWaiters(func(pblock.WaitTxn) bool {
+				found = true
+				return false
+			})
+			return !found
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+func issue28742HasKey(keys [][]byte, needle []byte) bool {
+	for _, key := range keys {
+		if bytes.Contains(key, needle) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #28742

## What this PR does / why we need it:

A cluster restore can hold the SNAPSHOT lifecycle row while a CN view-metadata fence has already acquired shared metadata for `mo_feature_registry`. The restore later needs exclusive metadata ownership to replace that catalog relation, creating a lock-order cycle.

This change makes cluster and account restore acquire the stable `mo_catalog.mo_tables` identity for `mo_feature_registry` with `FOR UPDATE` before the existing lineage, SNAPSHOT, and View lifecycle gates. A missing identity fails closed. Existing restore transaction lifetime, lineage barrier, SNAPSHOT/View protection, and rollback behavior remain in place.

The regression runs the real CN view-metadata fence transaction while restore is paused after metadata ownership, observes the metadata waiter, verifies durable revalidation state, cancels both operations and proves a fresh transaction can reacquire both lifecycle locks, then reruns the successful restore and subscription privilege checks.

Validation:

- Targeted restore regression passed normally and with race detection.
- Catalog and frontend tests passed.
- CN view-metadata admission tests passed.
- Restore admission test passed with race detection.
- `git diff --check` passed.
