### PR TITLE
fix: retain widened GROUP_CONCAT metadata for prepared statements

### DIFF
--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -298,6 +298,10 @@ func columnsToMysqlColumns(ctx context.Context, cols []*plan2.ColDef) ([]interfa
 
 func (cwft *TxnComputationWrapper) getColumnsWithResultColumns(ctx context.Context) ([]interface{}, []*plan2.ColDef, error) {
 	cols := plan2.GetResultColumnsFromPlan(cwft.plan)
+	if cwft.preparedStmt != nil {
+		overlayPreparedGroupConcatResultMetadata(
+			cwft.plan.GetQuery(), cols, cwft.preparedStmt.groupConcatMaxLenFloor)
+	}
 	columns, err := columnsToMysqlColumns(ctx, cols)
 	return columns, cols, err
 }
@@ -357,6 +361,23 @@ func preparedStatementOwner(ctx context.Context, ses FeSession) (*Session, error
 		return backSes.upstream, nil
 	}
 	return nil, moerr.NewInternalError(ctx, "prepared statement session has no client owner")
+}
+
+func preparedGroupConcatMaxLenFloor(
+	ctx context.Context, owner *Session, prepareStmt *PrepareStmt,
+) (uint64, error) {
+	value, err := owner.GetSessionSysVar("group_concat_max_len")
+	if err != nil {
+		return 0, err
+	}
+	limit, ok := value.(int64)
+	if !ok || limit < 4 {
+		return 0, moerr.NewInternalErrorf(ctx, "invalid group_concat_max_len: %v", value)
+	}
+	if current := uint64(limit); current > prepareStmt.groupConcatMaxLenFloor {
+		return current, nil
+	}
+	return prepareStmt.groupConcatMaxLenFloor, nil
 }
 
 // Compile build logical plan and then build physical plan `Compile` object
@@ -576,6 +597,7 @@ func (cwft *TxnComputationWrapper) Compile(any any, fill func(*batch.Batch, *per
 		} else {
 			// retComp
 			cwft.proc.ReplaceTopCtx(execCtx.reqCtx)
+			retComp.SetGroupConcatMaxLenFloor(cwft.preparedStmt.groupConcatMaxLenFloor)
 			retComp.SetBuildPlanFunc(preparedExecutionBuildPlanFunc(
 				cwft.ses,
 				cwft.stmt,
@@ -1287,6 +1309,16 @@ func initExecuteStmtParamWithResolverInSession(
 	originSQL := prepareStmt.Sql
 	preparePlan := prepareStmt.PreparePlan.GetDcl().GetPrepare()
 	executionPlan := preparePlan.Plan
+	groupConcatMaxLenFloor := prepareStmt.groupConcatMaxLenFloor
+	hasPreparedGroupConcat := preparedPlanContainsGroupConcat(executionPlan)
+	if hasPreparedGroupConcat {
+		groupConcatMaxLenFloor, err = preparedGroupConcatMaxLenFloor(
+			reqCtx, owner, prepareStmt)
+		if err != nil {
+			return nil, nil, nil, "", false, err
+		}
+	}
+	previousGroupConcatMaxLenFloor := prepareStmt.groupConcatMaxLenFloor
 	currentNativeMode := owner.sqlModeHasMatrixOneNative()
 	currentOnlyFullGroupBy := owner.sqlModeHasOnlyFullGroupBy()
 	currentBoolSumAvg := owner.sqlModeHasEnableBoolSumAvg()
@@ -1345,6 +1377,20 @@ func initExecuteStmtParamWithResolverInSession(
 		preparePlanNeedsRebuild(change, modeMismatch, protocolMismatch) || rebuildEveryExecute ||
 		!reusablePlanGenerationSupported(cwft.proc)
 	cwft.planGenerationReused = !needRebuild
+	var pendingGroupConcatColDefData [][]byte
+	pendingGroupConcatColDefDataSet := false
+	rebuildCommitted := false
+	rebuildPublished := false
+	defer func() {
+		if rebuildCommitted && !rebuildPublished {
+			// A rebuilt plan may be visible before execute-time parameter binding
+			// finishes. Keep the generation dirty until its metadata and all
+			// execution state are published together, so a rejected execute cannot
+			// pair the new plan with the previous wire metadata.
+			prepareStmt.needsRebuild = true
+			prepareStmt.compileNeedsRebuild = true
+		}
+	}()
 
 	// Rebuild the plan when catalog schema, session temporary-table name
 	// resolution, FK-check state, protocol, or compatibility mode changed. The
@@ -1362,8 +1408,8 @@ func initExecuteStmtParamWithResolverInSession(
 		case *tree.ExplainStmt, *tree.ExplainAnalyze, *tree.ExplainPhyPlan:
 			txnHaveDDL = sessionTxnHaveDDL(executionSes)
 		}
-		columns := getPreparedResultColumnsFromPlan(
-			prepareStmt.PrepareStmt, newPlan, txnHaveDDL)
+		columns := getPreparedResultColumnsFromPlanWithGroupConcatMaxLen(
+			prepareStmt.PrepareStmt, newPlan, txnHaveDDL, groupConcatMaxLenFloor)
 		resper := execCtx.resper
 		if executionSes.IsBackgroundSession() {
 			resper = owner.GetResponser()
@@ -1376,6 +1422,7 @@ func initExecuteStmtParamWithResolverInSession(
 		preparePlan = newPreparePlan
 		executionPlan = preparePlan.Plan
 		prepareStmt.PreparePlan = newPlan
+		rebuildCommitted = true
 		prepareStmt.directResultParamPositions = plan2.PreparedPlanDirectResultParamPositions(executionPlan)
 		prepareStmt.directResultParamPositionsSet = true
 		prepareStmt.jsonComparisonParamPositions =
@@ -1395,9 +1442,14 @@ func initExecuteStmtParamWithResolverInSession(
 		// numeric BIT_COUNT category selected by the preceding generation.
 		prepareStmt.bitCountNumericParamTypes = nil
 		prepareStmt.refreshFixedIntegerParamPositions(newPreparePlan.Plan)
-		prepareStmt.ColDefData = newColDefData
-		if execCtx.input != nil && execCtx.input.isBinaryProtExecute {
-			execCtx.prepareColDef = newColDefData
+		if hasPreparedGroupConcat {
+			pendingGroupConcatColDefData = newColDefData
+			pendingGroupConcatColDefDataSet = true
+		} else {
+			prepareStmt.ColDefData = newColDefData
+			if execCtx.input != nil && execCtx.input.isBinaryProtExecute {
+				execCtx.prepareColDef = newColDefData
+			}
 		}
 		prepareStmt.NativeMode = currentNativeMode
 		prepareStmt.OnlyFullGroupBy = currentOnlyFullGroupBy
@@ -1411,6 +1463,26 @@ func initExecuteStmtParamWithResolverInSession(
 		prepareStmt.preparedMetadataCheckTS = preparedMetadataTS
 		prepareStmt.protocolVersion = protocolVersion
 		prepareStmt.needsRebuild = false
+	}
+	if !needRebuild && hasPreparedGroupConcat && groupConcatMaxLenFloor > previousGroupConcatMaxLenFloor {
+		// Keep the cached COM_STMT_PREPARE metadata in sync with the monotonic
+		// execution floor. The current execution gets the same bytes immediately;
+		// later executions start from the widened owner metadata.
+		if prepareStmt.ColDefData != nil && executionPlan.GetQuery() != nil {
+			columns := getPreparedResultColumnsForWithGroupConcatMaxLen(
+				prepareStmt.PrepareStmt, executionPlan, sessionTxnHaveDDL(executionSes),
+				groupConcatMaxLenFloor)
+			resper := execCtx.resper
+			if executionSes.IsBackgroundSession() {
+				resper = owner.GetResponser()
+			}
+			newColDefData, metadataErr := resper.MysqlRrWr().MakeColumnDefData(reqCtx, columns)
+			if metadataErr != nil {
+				return nil, nil, nil, "", false, metadataErr
+			}
+			pendingGroupConcatColDefData = newColDefData
+			pendingGroupConcatColDefDataSet = true
+		}
 	}
 
 	// Recreate the cached compile only when a plan dependency changed or an
@@ -1459,7 +1531,7 @@ func initExecuteStmtParamWithResolverInSession(
 					true,
 					nil,
 					nil,
-					prepareStmt.groupConcatMaxLenFloor,
+					groupConcatMaxLenFloor,
 				)
 				if err != nil {
 					if !moerr.IsMoErrCode(err, moerr.ErrCantCompileForPrepare) {
@@ -1774,8 +1846,9 @@ func initExecuteStmtParamWithResolverInSession(
 	if runtimePlanApplied {
 		executionPlan = runtimePlan
 		if binaryExecute {
-			columns := getPreparedResultColumnsFor(
-				prepareStmt.PrepareStmt, runtimePlan, sessionTxnHaveDDL(executionSes))
+			columns := getPreparedResultColumnsForWithGroupConcatMaxLen(
+				prepareStmt.PrepareStmt, runtimePlan, sessionTxnHaveDDL(executionSes),
+				groupConcatMaxLenFloor)
 			resper := execCtx.resper
 			if executionSes.IsBackgroundSession() {
 				resper = owner.GetResponser()
@@ -1823,6 +1896,19 @@ func initExecuteStmtParamWithResolverInSession(
 	if err != nil {
 		return nil, nil, nil, "", false, err
 	}
+	if hasPreparedGroupConcat {
+		if pendingGroupConcatColDefDataSet {
+			prepareStmt.ColDefData = pendingGroupConcatColDefData
+			if execCtx.input != nil && execCtx.input.isBinaryProtExecute && !runtimePlanApplied {
+				execCtx.prepareColDef = pendingGroupConcatColDefData
+			}
+		}
+		// Publish only after parameter binding, validation, specialization, and
+		// all execution metadata construction have succeeded. The caller then
+		// uses this value for a fresh Compile or cached Compile.Reset.
+		prepareStmt.groupConcatMaxLenFloor = groupConcatMaxLenFloor
+	}
+	rebuildPublished = true
 	return retComp, executionPlan, executionStmt, originSQL, owned, nil
 }
 

--- a/pkg/frontend/prepared_group_concat_metadata_test.go
+++ b/pkg/frontend/prepared_group_concat_metadata_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreparedGroupConcatResultMetadataFollowsMonotonicFloor(t *testing.T) {
+	_, _, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select group_concat(?) as gc")
+	defer prepareStmt.Close()
+
+	for _, test := range []struct {
+		name      string
+		requested uint64
+		effective uint64
+		mysqlType defines.MysqlType
+		length    uint32
+	}{
+		{name: "prepare floor", requested: 64, effective: 64, mysqlType: defines.MYSQL_TYPE_VAR_STRING, length: 256},
+		{name: "execution widened floor", requested: 1_000_000, effective: 1_000_000, mysqlType: defines.MYSQL_TYPE_LONG_BLOB, length: types.MaxLongTextLen},
+		{name: "later lower execution keeps widened floor", requested: 64, effective: 1_000_000, mysqlType: defines.MYSQL_TYPE_LONG_BLOB, length: types.MaxLongTextLen},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.requested > prepareStmt.groupConcatMaxLenFloor {
+				prepareStmt.groupConcatMaxLenFloor = test.requested
+			}
+			require.Equal(t, test.effective, prepareStmt.groupConcatMaxLenFloor)
+			columns := getPreparedResultColumns(prepareStmt, false)
+			require.Len(t, columns, 1)
+			column, err := colDef2MysqlColumn(t.Context(), columns[0])
+			require.NoError(t, err)
+			require.Equal(t, test.mysqlType, column.ColumnType())
+			require.Equal(t, test.length, column.Length())
+		})
+	}
+
+	query := prepareStmt.PreparePlan.GetDcl().GetPrepare().GetPlan().GetQuery()
+	for _, node := range query.Nodes {
+		for _, expr := range node.AggList {
+			if fn := expr.GetF(); fn != nil && fn.GetFunc() != nil && fn.GetFunc().GetObjName() == "group_concat" {
+				require.Equal(t, int32(types.T_text), expr.Typ.Id)
+			}
+		}
+	}
+}
+
+func TestPreparedGroupConcatExecutePublishesMetadataAfterSuccess(t *testing.T) {
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
+		t, 28676, "select group_concat('abcdef') as gc")
+	defer func() {
+		cw.proc.SetPrepareParams(nil)
+		prepareStmt.Close()
+	}()
+	prepareStmt.groupConcatMaxLenFloor = 64
+	oldColDefData := [][]byte{[]byte("prepare-time")}
+	prepareStmt.ColDefData = oldColDefData
+	execCtx.prepareColDef = oldColDefData
+
+	writer := execCtx.resper.MysqlRrWr().(*testMysqlWriter)
+	var metadataCalls int
+	var metadataColumn *MysqlColumn
+	writer.makeColumnDefDataFunc = func(ctx context.Context, columns []*plan.ColDef) ([][]byte, error) {
+		metadataCalls++
+		require.Len(t, columns, 1)
+		var err error
+		metadataColumn, err = colDef2MysqlColumn(ctx, columns[0])
+		require.NoError(t, err)
+		return [][]byte{[]byte(fmt.Sprintf("metadata-%d", metadataCalls))}, nil
+	}
+
+	require.NoError(t, ses.SetSessionSysVar(execCtx.reqCtx, "group_concat_max_len", int64(1_000_000)))
+	_, _, executionStmt, _, owned, err := initExecuteStmtParam(
+		execCtx, ses, cw, nil, prepareStmt.Name)
+	require.NoError(t, err)
+	if owned && executionStmt != nil {
+		executionStmt.Free()
+	}
+	require.Equal(t, 1, metadataCalls)
+	require.Equal(t, defines.MYSQL_TYPE_LONG_BLOB, metadataColumn.ColumnType())
+	require.Equal(t, uint32(types.MaxLongTextLen), metadataColumn.Length())
+	require.Equal(t, uint64(1_000_000), prepareStmt.groupConcatMaxLenFloor)
+	require.Equal(t, [][]byte{[]byte("metadata-1")}, prepareStmt.ColDefData)
+	require.Equal(t, prepareStmt.ColDefData, execCtx.prepareColDef)
+
+	columns, colDefs, err := getSelectColumnsAndResultColumns(execCtx.reqCtx, cw)
+	require.NoError(t, err)
+	require.Len(t, columns, 1)
+	require.Len(t, colDefs, 1)
+	require.Equal(t, defines.MYSQL_TYPE_LONG_BLOB, columns[0].(*MysqlColumn).ColumnType())
+	require.Equal(t, int32(types.T_text), colDefs[0].Typ.Id)
+	require.Equal(t, int32(types.MaxLongTextLen), colDefs[0].Typ.Width)
+
+	// A lower value in the same prepared lifetime must neither rebuild the
+	// protocol metadata nor narrow the result columns.
+	require.NoError(t, ses.SetSessionSysVar(execCtx.reqCtx, "group_concat_max_len", int64(64)))
+	_, _, executionStmt, _, owned, err = initExecuteStmtParam(
+		execCtx, ses, cw, nil, prepareStmt.Name)
+	require.NoError(t, err)
+	if owned && executionStmt != nil {
+		executionStmt.Free()
+	}
+	require.Equal(t, 1, metadataCalls)
+	require.Equal(t, uint64(1_000_000), prepareStmt.groupConcatMaxLenFloor)
+	require.Equal(t, [][]byte{[]byte("metadata-1")}, prepareStmt.ColDefData)
+	columns, colDefs, err = getSelectColumnsAndResultColumns(execCtx.reqCtx, cw)
+	require.NoError(t, err)
+	require.Equal(t, defines.MYSQL_TYPE_LONG_BLOB, columns[0].(*MysqlColumn).ColumnType())
+	require.Equal(t, int32(types.T_text), colDefs[0].Typ.Id)
+}
+
+func TestPreparedGroupConcatRejectedExecuteDoesNotPublishFloor(t *testing.T) {
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
+		t, 28677, "select group_concat(?) as gc")
+	defer func() {
+		cw.proc.SetPrepareParams(nil)
+		prepareStmt.Close()
+	}()
+	prepareStmt.groupConcatMaxLenFloor = 64
+	require.NoError(t, ses.SetSessionSysVar(execCtx.reqCtx, "group_concat_max_len", int64(1_000_000)))
+
+	_, _, _, _, _, err := initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
+	require.Error(t, err)
+	require.Equal(t, uint64(64), prepareStmt.groupConcatMaxLenFloor)
+}
+
+func TestPreparedGroupConcatMetadataFailureDoesNotPublishFloor(t *testing.T) {
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
+		t, 28678, "select group_concat('abcdef') as gc")
+	defer func() {
+		cw.proc.SetPrepareParams(nil)
+		prepareStmt.Close()
+	}()
+	prepareStmt.groupConcatMaxLenFloor = 64
+	oldColDefData := [][]byte{[]byte("old")}
+	prepareStmt.ColDefData = oldColDefData
+	execCtx.prepareColDef = oldColDefData
+	writer := execCtx.resper.MysqlRrWr().(*testMysqlWriter)
+	writer.makeColumnDefDataFunc = func(context.Context, []*plan.ColDef) ([][]byte, error) {
+		return nil, errors.New("injected metadata failure")
+	}
+	require.NoError(t, ses.SetSessionSysVar(execCtx.reqCtx, "group_concat_max_len", int64(1_000_000)))
+
+	_, _, _, _, _, err := initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
+	require.ErrorContains(t, err, "injected metadata failure")
+	require.Equal(t, uint64(64), prepareStmt.groupConcatMaxLenFloor)
+	require.Equal(t, oldColDefData, prepareStmt.ColDefData)
+	require.Equal(t, oldColDefData, execCtx.prepareColDef)
+}
+
+func TestPreparedGroupConcatRebuildRejectedExecuteRefreshesWireMetadata(t *testing.T) {
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
+		t, 28680, "select group_concat(?) as gc")
+	defer func() {
+		cw.proc.SetPrepareParams(nil)
+		prepareStmt.Close()
+	}()
+	prepareStmt.groupConcatMaxLenFloor = 64
+	require.NoError(t, ses.SetSessionSysVar(execCtx.reqCtx, "group_concat_max_len", int64(64)))
+	oldColDefData := [][]byte{[]byte("stale-int-column")}
+	prepareStmt.ColDefData = oldColDefData
+	execCtx.prepareColDef = oldColDefData
+
+	proto := &MysqlProtocolImpl{io: NewIOPackage(true)}
+	var generatedColumn *MysqlColumn
+	writer := execCtx.resper.MysqlRrWr().(*testMysqlWriter)
+	writer.makeColumnDefDataFunc = func(ctx context.Context, columns []*plan.ColDef) ([][]byte, error) {
+		require.Len(t, columns, 1)
+		var err error
+		generatedColumn, err = colDef2MysqlColumn(ctx, columns[0])
+		require.NoError(t, err)
+		return [][]byte{proto.makeColumnDefinition41Payload(generatedColumn, int(COM_STMT_EXECUTE))}, nil
+	}
+
+	// An unrelated temporary-table change forces the prepared plan through the
+	// same rebuild path as a schema refresh. Reject the execute after the rebuild
+	// has produced a new plan, but before its parameters are valid.
+	ses.AddTempTable("db1", "unrelated", "temp-unrelated")
+	_, _, _, _, _, err := initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
+	require.Error(t, err)
+	require.True(t, prepareStmt.needsRebuild)
+	require.True(t, prepareStmt.compileNeedsRebuild)
+	require.Equal(t, oldColDefData, prepareStmt.ColDefData)
+	require.Equal(t, oldColDefData, execCtx.prepareColDef)
+
+	// The next execution has the same metadata floor. It must rebuild and
+	// publish the wire metadata that belongs to that plan generation instead of
+	// reusing the stale same-count definition left by the rejected execution.
+	require.NoError(t, proto.ParseExecuteData(
+		execCtx.reqCtx, cw.proc, prepareStmt,
+		buildStringExecutePacket(proto, defines.MYSQL_TYPE_VAR_STRING, "abcdef"), 0))
+	_, _, _, _, _, err = initExecuteStmtParam(execCtx, ses, cw, nil, prepareStmt.Name)
+	require.NoError(t, err)
+	require.False(t, prepareStmt.needsRebuild)
+	require.False(t, prepareStmt.compileNeedsRebuild)
+	require.NotNil(t, generatedColumn)
+	require.Equal(t, defines.MYSQL_TYPE_VAR_STRING, generatedColumn.ColumnType())
+	require.NotEqual(t, oldColDefData, prepareStmt.ColDefData)
+	definition := parsePrepareColumnDefinition(t, prepareStmt.ColDefData[0][HeaderOffset:])
+	require.Equal(t, defines.MYSQL_TYPE_VAR_STRING, definition.typ)
+}
+
+func TestPreparedGroupConcatBinaryMetadataPreservesBinaryFlag(t *testing.T) {
+	_, _, prepareStmt := newBinaryPrepareProtocolTestCase(t,
+		"select group_concat(convert(? using binary)) as gc")
+	defer prepareStmt.Close()
+	proto := &MysqlProtocolImpl{io: NewIOPackage(true)}
+
+	for _, test := range []struct {
+		name      string
+		floor     uint64
+		mysqlType defines.MysqlType
+	}{
+		{name: "varchar boundary", floor: 64, mysqlType: defines.MYSQL_TYPE_VAR_STRING},
+		{name: "binary blob after boundary", floor: 1_000_000, mysqlType: defines.MYSQL_TYPE_BLOB},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			prepareStmt.groupConcatMaxLenFloor = test.floor
+			columns := getPreparedResultColumns(prepareStmt, false)
+			require.Len(t, columns, 1)
+			column, err := colDef2MysqlColumn(t.Context(), columns[0])
+			require.NoError(t, err)
+			require.Equal(t, test.mysqlType, column.ColumnType())
+			require.Equal(t, uint16(charsetBinary), column.Charset())
+			require.NotZero(t, column.Flag()&uint16(defines.BINARY_FLAG))
+
+			packet := proto.makeColumnDefinition41Payload(column, int(COM_STMT_PREPARE))
+			definition := parsePrepareColumnDefinition(t, packet[HeaderOffset:])
+			require.Equal(t, test.mysqlType, definition.typ)
+			require.Equal(t, uint16(charsetBinary), definition.charset)
+			require.NotZero(t, definition.flags&uint16(defines.BINARY_FLAG))
+		})
+	}
+}
+
+func TestPreparedGroupConcatMetadataStopsAtSetOperation(t *testing.T) {
+	for index, sql := range []string{
+		"select group_concat(?) union all select repeat('x', 1000)",
+		"select repeat('x', 1000) union all select group_concat(?)",
+	} {
+		t.Run(fmt.Sprintf("branch-%d", index), func(t *testing.T) {
+			_, _, prepareStmt := newBinaryPrepareProtocolTestCase(t, sql)
+			defer prepareStmt.Close()
+			prepareStmt.groupConcatMaxLenFloor = 64
+			columns := getPreparedResultColumns(prepareStmt, false)
+			require.Len(t, columns, 1)
+			column, err := colDef2MysqlColumn(t.Context(), columns[0])
+			require.NoError(t, err)
+			require.NotEqual(t, defines.MYSQL_TYPE_VAR_STRING, column.ColumnType())
+		})
+	}
+}
+
+func TestPreparedGroupConcatFloorAdvancesAtExecute(t *testing.T) {
+	ses, prepareStmt, cw, execCtx := newPreparedExecuteEnvForSQL(
+		t, 28679, "select group_concat('abcdef') as gc")
+	defer func() {
+		cw.proc.SetPrepareParams(nil)
+		prepareStmt.Close()
+	}()
+	prepareStmt.groupConcatMaxLenFloor = 64
+
+	for _, test := range []struct {
+		name      string
+		requested int64
+		effective uint64
+	}{
+		{name: "widen", requested: 1_000_000, effective: 1_000_000},
+		{name: "lower", requested: 64, effective: 1_000_000},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, ses.SetSessionSysVar(
+				execCtx.reqCtx, "group_concat_max_len", test.requested))
+			_, _, clonedStmt, _, owned, err := initExecuteStmtParam(
+				execCtx, ses, cw, nil, prepareStmt.Name)
+			require.NoError(t, err)
+			if owned && clonedStmt != nil {
+				clonedStmt.Free()
+			}
+			require.Equal(t, test.effective, prepareStmt.groupConcatMaxLenFloor)
+		})
+	}
+}

--- a/pkg/frontend/result_row_stmt.go
+++ b/pkg/frontend/result_row_stmt.go
@@ -58,10 +58,6 @@ func getPreparedResultColumns(stmt *PrepareStmt, txnHaveDDL bool) []*plan2.ColDe
 		stmt.PrepareStmt, stmt.PreparePlan, txnHaveDDL, stmt.groupConcatMaxLenFloor)
 }
 
-func getPreparedResultColumnsFromPlan(stmt tree.Statement, preparedPlan *plan2.Plan, txnHaveDDL bool) []*plan2.ColDef {
-	return getPreparedResultColumnsFromPlanWithGroupConcatMaxLen(stmt, preparedPlan, txnHaveDDL, 0)
-}
-
 func getPreparedResultColumnsFromPlanWithGroupConcatMaxLen(
 	stmt tree.Statement, preparedPlan *plan2.Plan, txnHaveDDL bool, groupConcatMaxLenFloor uint64,
 ) []*plan2.ColDef {

--- a/pkg/frontend/result_row_stmt.go
+++ b/pkg/frontend/result_row_stmt.go
@@ -54,19 +54,33 @@ func GetExplainColumn(ctx context.Context, explainColName string) ([]*plan2.ColD
 }
 
 func getPreparedResultColumns(stmt *PrepareStmt, txnHaveDDL bool) []*plan2.ColDef {
-	return getPreparedResultColumnsFromPlan(stmt.PrepareStmt, stmt.PreparePlan, txnHaveDDL)
+	return getPreparedResultColumnsFromPlanWithGroupConcatMaxLen(
+		stmt.PrepareStmt, stmt.PreparePlan, txnHaveDDL, stmt.groupConcatMaxLenFloor)
 }
 
 func getPreparedResultColumnsFromPlan(stmt tree.Statement, preparedPlan *plan2.Plan, txnHaveDDL bool) []*plan2.ColDef {
+	return getPreparedResultColumnsFromPlanWithGroupConcatMaxLen(stmt, preparedPlan, txnHaveDDL, 0)
+}
+
+func getPreparedResultColumnsFromPlanWithGroupConcatMaxLen(
+	stmt tree.Statement, preparedPlan *plan2.Plan, txnHaveDDL bool, groupConcatMaxLenFloor uint64,
+) []*plan2.ColDef {
 	plan := preparedPlan.GetDcl().GetPrepare().GetPlan()
-	return getPreparedResultColumnsFor(stmt, plan, txnHaveDDL)
+	return getPreparedResultColumnsForWithGroupConcatMaxLen(
+		stmt, plan, txnHaveDDL, groupConcatMaxLenFloor)
 }
 
 func getPreparedResultColumnsFor(stmt tree.Statement, plan *plan.Plan, txnHaveDDL bool) []*plan2.ColDef {
+	return getPreparedResultColumnsForWithGroupConcatMaxLen(stmt, plan, txnHaveDDL, 0)
+}
+
+func getPreparedResultColumnsForWithGroupConcatMaxLen(
+	stmt tree.Statement, preparedPlan *plan.Plan, txnHaveDDL bool, groupConcatMaxLenFloor uint64,
+) []*plan2.ColDef {
 	if isPerformStatement(stmt) {
 		return nil
 	}
-	if query := plan.GetQuery(); query != nil {
+	if query := preparedPlan.GetQuery(); query != nil {
 		var title string
 		switch stmt.(type) {
 		case *tree.ExplainStmt, *tree.ExplainAnalyze:
@@ -82,7 +96,192 @@ func getPreparedResultColumnsFor(stmt tree.Statement, plan *plan.Plan, txnHaveDD
 			}}
 		}
 	}
-	return plan2.GetResultColumnsFromPlan(plan)
+	columns := plan2.GetResultColumnsFromPlan(preparedPlan)
+	overlayPreparedGroupConcatResultMetadata(
+		preparedPlan.GetQuery(), columns, groupConcatMaxLenFloor)
+	return columns
+}
+
+const preparedGroupConcatVarcharMaxLen = 512
+
+type preparedGroupConcatResultColumnRef struct {
+	nodeID int32
+	colPos int32
+}
+
+func preparedPlanContainsGroupConcat(preparedPlan *plan.Plan) bool {
+	if preparedPlan == nil || preparedPlan.GetQuery() == nil {
+		return false
+	}
+	for _, node := range preparedPlan.GetQuery().Nodes {
+		if node == nil {
+			continue
+		}
+		for _, expr := range node.AggList {
+			if preparedExprContainsGroupConcat(expr) {
+				return true
+			}
+		}
+		for _, expr := range node.WinSpecList {
+			if preparedExprContainsGroupConcat(expr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func preparedExprContainsGroupConcat(expr *plan.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	if fn := expr.GetF(); fn != nil {
+		if fn.GetFunc() != nil && fn.GetFunc().GetObjName() == plan2.NameGroupConcat {
+			return true
+		}
+		for _, arg := range fn.Args {
+			if preparedExprContainsGroupConcat(arg) {
+				return true
+			}
+		}
+	}
+	if window := expr.GetW(); window != nil {
+		if preparedExprContainsGroupConcat(window.WindowFunc) {
+			return true
+		}
+		for _, arg := range window.PartitionBy {
+			if preparedExprContainsGroupConcat(arg) {
+				return true
+			}
+		}
+		for _, order := range window.OrderBy {
+			if order != nil && preparedExprContainsGroupConcat(order.Expr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// overlayPreparedGroupConcatResultMetadata applies the MySQL result-type rule
+// that depends on group_concat_max_len to prepared result metadata only. The
+// execution plan keeps the aggregate's engine type (T_text/T_blob); changing it
+// here would change vector allocation and aggregate execution semantics.
+func overlayPreparedGroupConcatResultMetadata(
+	query *plan.Query, columns []*plan2.ColDef, groupConcatMaxLen uint64,
+) {
+	if query == nil || groupConcatMaxLen == 0 || len(query.Steps) == 0 {
+		return
+	}
+	step := len(query.Steps) - 1
+	if query.HasReturning {
+		if query.ReturningStep < 0 || int(query.ReturningStep) >= len(query.Steps) {
+			return
+		}
+		step = int(query.ReturningStep)
+	}
+	rootID := query.Steps[step]
+	if rootID < 0 || int(rootID) >= len(query.Nodes) {
+		return
+	}
+	root := query.Nodes[rootID]
+	if root == nil || len(root.ProjectList) != len(columns) {
+		return
+	}
+
+	for idx, expr := range root.ProjectList {
+		if !isDirectPreparedGroupConcatResult(query, rootID, expr, make(map[preparedGroupConcatResultColumnRef]struct{})) {
+			continue
+		}
+		col := columns[idx]
+		if col == nil {
+			continue
+		}
+		isBinary := col.Typ.Id == int32(types.T_blob) ||
+			col.Typ.Charset == uint32(types.CharsetBinary)
+		if groupConcatMaxLen <= preparedGroupConcatVarcharMaxLen {
+			if isBinary {
+				col.Typ.Id = int32(types.T_varbinary)
+				col.Typ.Charset = uint32(types.CharsetBinary)
+			} else {
+				col.Typ.Id = int32(types.T_varchar)
+			}
+			col.Typ.Width = int32(groupConcatMaxLen)
+		} else if isBinary {
+			// MySQL exposes a binary GROUP_CONCAT as BLOB above the VARCHAR
+			// threshold. Keep the binary OID so colDef2MysqlColumn emits both
+			// the binary charset and BINARY_FLAG.
+			col.Typ.Id = int32(types.T_blob)
+			col.Typ.Charset = uint32(types.CharsetBinary)
+		} else {
+			col.Typ.Id = int32(types.T_text)
+			col.Typ.Width = types.MaxLongTextLen
+		}
+	}
+}
+
+func isDirectPreparedGroupConcatResult(
+	query *plan.Query, nodeID int32, expr *plan.Expr, seen map[preparedGroupConcatResultColumnRef]struct{},
+) bool {
+	if expr == nil {
+		return false
+	}
+	if query == nil || nodeID < 0 || int(nodeID) >= len(query.Nodes) {
+		return false
+	}
+	node := query.Nodes[nodeID]
+	if node == nil {
+		return false
+	}
+	switch node.NodeType {
+	case plan.Node_UNION, plan.Node_UNION_ALL,
+		plan.Node_INTERSECT, plan.Node_INTERSECT_ALL,
+		plan.Node_MINUS, plan.Node_MINUS_ALL:
+		// Set-operation output types are common to both branches. Following
+		// only the left projection could narrow a result whose right branch
+		// still produces a wider value.
+		return false
+	}
+	if fn := expr.GetF(); fn != nil && fn.GetFunc() != nil {
+		return fn.GetFunc().GetObjName() == plan2.NameGroupConcat
+	}
+	col := expr.GetCol()
+	if col == nil {
+		return false
+	}
+	switch {
+	case col.RelPos == -2:
+		if node.NodeType != plan.Node_AGG {
+			return false
+		}
+		aggPos := col.ColPos - int32(len(node.GroupBy))
+		if aggPos < 0 || int(aggPos) >= len(node.AggList) {
+			return false
+		}
+		return isDirectPreparedGroupConcatResult(
+			query, nodeID, node.AggList[aggPos], seen)
+	case col.RelPos >= 0:
+		if int(col.RelPos) >= len(node.Children) {
+			return false
+		}
+		childID := node.Children[col.RelPos]
+		if childID < 0 || int(childID) >= len(query.Nodes) {
+			return false
+		}
+		child := query.Nodes[childID]
+		if child == nil || col.ColPos < 0 || int(col.ColPos) >= len(child.ProjectList) {
+			return false
+		}
+		ref := preparedGroupConcatResultColumnRef{nodeID: childID, colPos: col.ColPos}
+		if _, ok := seen[ref]; ok {
+			return false
+		}
+		seen[ref] = struct{}{}
+		return isDirectPreparedGroupConcatResult(
+			query, childID, child.ProjectList[col.ColPos], seen)
+	default:
+		return false
+	}
 }
 
 func sessionTxnHaveDDL(ses FeSession) bool {

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -294,7 +294,8 @@ func (ec *engineColumnInfo) GetType() types.T {
 }
 
 type PrepareStmt struct {
-	// Captured once even when AP or specialization discards the physical compile.
+	// Monotonic high-water mark for GROUP_CONCAT across this prepared lifetime,
+	// including executions whose AP or specialization path discards the compile.
 	groupConcatMaxLenFloor uint64
 	Name                   string
 	Sql                    string

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -10395,6 +10395,7 @@ func (c *Compile) isCCPRTaskTransaction() bool {
 	return false
 }
 
-// SetGroupConcatMaxLenFloor binds the immutable prepared-statement value before
-// physical compilation. Zero keeps ordinary statements fully dynamic.
+// SetGroupConcatMaxLenFloor binds the prepared statement's execution floor
+// before physical compilation or Compile.Reset. Zero keeps ordinary statements
+// fully dynamic.
 func (c *Compile) SetGroupConcatMaxLenFloor(floor uint64) { c.groupConcatMaxLenFloor = floor }

--- a/test/distributed/cases/function/function_group_concat.result
+++ b/test/distributed/cases/function/function_group_concat.result
@@ -383,11 +383,19 @@ aabbcc
 set session group_concat_max_len = 5;
 execute group_concat_max_len_low_stmt;
 group_concat(s, ,order by s)
+aabbcc
+show warnings;
+➤ Level[12,0,0]  ¦  Code[5,0,0]  ¦  Message[12,0,0]
+deallocate prepare group_concat_max_len_low_stmt;
+set session group_concat_max_len = 5;
+prepare group_concat_max_len_reset_stmt from 'select group_concat(s order by s separator "") from group_concat_max_len_01';
+execute group_concat_max_len_reset_stmt;
+group_concat(s, ,order by s)
 aabbc
 show warnings;
 ➤ Level[12,0,0]  ¦  Code[5,0,0]  ¦  Message[12,0,0]  𝄀
 Warning  ¦  1260  ¦  Row 3 was cut by GROUP_CONCAT()
-deallocate prepare group_concat_max_len_low_stmt;
+deallocate prepare group_concat_max_len_reset_stmt;
 drop table group_concat_max_len_01;
 drop table if exists group_concat_warning_01;
 create table group_concat_warning_01 (id int primary key, s varchar(16));

--- a/test/distributed/cases/function/function_group_concat.sql
+++ b/test/distributed/cases/function/function_group_concat.sql
@@ -320,6 +320,11 @@ set session group_concat_max_len = 5;
 execute group_concat_max_len_low_stmt;
 show warnings;
 deallocate prepare group_concat_max_len_low_stmt;
+set session group_concat_max_len = 5;
+prepare group_concat_max_len_reset_stmt from 'select group_concat(s order by s separator "") from group_concat_max_len_01';
+execute group_concat_max_len_reset_stmt;
+show warnings;
+deallocate prepare group_concat_max_len_reset_stmt;
 drop table group_concat_max_len_01;
 
 -- A truncating GROUP_CONCAT must expose one MySQL-compatible warning per


### PR DESCRIPTION
## Summary

Fixes #28676.

`GROUP_CONCAT` result metadata for a prepared statement was derived from the
current `group_concat_max_len` on every execute, but the larger execute-time
value was not retained in the prepared statement. A later lower value could
therefore narrow the metadata and truncate the result.

This change:

- retains a monotonic per-prepared-statement high-water mark;
- passes that floor through fresh, cached, runtime-specialized, and retry
  compiles;
- overlays only direct prepared `GROUP_CONCAT` frontend metadata, without
  changing generic text/blob plan mapping;
- preserves binary metadata flags and stops the overlay at set-operation
  boundaries;
- publishes the floor and metadata only after execute binding/validation and
  metadata construction succeed, and keeps a rebuilt generation dirty if the
  execute is rejected before publication.

## Validation

- `go test -mod=readonly ./pkg/frontend -run 'TestPreparedGroupConcat' -count=1`
- `go test -mod=readonly ./pkg/frontend -count=1` on rebased head (23.934s)
- `go test -mod=readonly ./pkg/sql/compile -count=1` on rebased head (4.043s)
- native-CGo `go vet ./pkg/frontend ./pkg/sql/compile`
- native-CGo incremental golangci-lint against latest `origin/main`: 0 issues
- isolated mo-service BVT: `function_group_concat.sql`, 209/209, 100%
- GPT-6 medium final pre-submit review on `06de9811ea..cca9f0fa7c6`: APPROVE, no material findings/blockers

The sibling existing `function_group_concat_ctas.sql` has two unrelated
metadata baseline mismatches on this environment; it is unchanged.