### PR TITLE
ci: use Quay for MinIO test images

### DIFF
--- a/etc/launch-tae-compose/compose.yaml
+++ b/etc/launch-tae-compose/compose.yaml
@@ -242,7 +242,7 @@ services:
     entrypoint: ["java","-jar","/jstfu-out/jstfu.jar","/config/jstfu-compose.json"]
 
   minio:
-    image: minio/minio:RELEASE.2023-11-01T18-37-25Z
+    image: quay.io/minio/minio:RELEASE.2023-11-01T18-37-25Z
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -268,7 +268,7 @@ services:
   # mc client: https://github.com/minio/mc/blob/master/docs/minio-client-complete-guide.md
   # mc anonymous set: https://min.io/docs/minio/linux/reference/minio-mc/mc-anonymous-set.html
   createbuckets:
-    image: minio/mc:RELEASE.2023-10-30T18-43-32Z
+    image: quay.io/minio/mc:RELEASE.2023-10-30T18-43-32Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28748

## What this PR does / why we need it:

Use Quay for the MinIO server and client images in the Compose CI setup, keeping the existing pinned version tags. This avoids the Docker Hub pull-denied failures during multi-CN setup without changing the test image versions.

Verification: pulled both exact Quay image tags locally for linux/amd64. No CI/BVT workflow was run locally.
