### PR TITLE
fix(function): enforce TRADITIONAL division-by-zero errors

### DIFF
--- a/pkg/sql/plan/function/arithmetic_div_zero_test.go
+++ b/pkg/sql/plan/function/arithmetic_div_zero_test.go
@@ -503,6 +503,74 @@ func TestDivisionByZeroStrictMode(t *testing.T) {
 	// will return early if cache is set, which we've verified above
 }
 
+// TestDivisionByZeroSQLModes checks the shared mode semantics at the statement
+// boundary, including cache reuse and reset when the same process is reused.
+func TestDivisionByZeroSQLModes(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+	var mode any
+	var resolveErr error
+	calls := 0
+	proc.SetResolveVariableFunc(func(name string, system, global bool) (any, error) {
+		require.Equal(t, "sql_mode", name)
+		require.True(t, system)
+		require.False(t, global)
+		calls++
+		return mode, resolveErr
+	})
+	for _, tc := range []struct {
+		name string
+		mode any
+		want bool
+	}{
+		{"traditional", "TRADITIONAL", true},
+		{"traditional with division flag", "TRADITIONAL,ERROR_FOR_DIVISION_BY_ZERO", true},
+		{"traditional with strict flag", "STRICT_TRANS_TABLES,TRADITIONAL", true},
+		{"case whitespace duplicates", " traditional ,TRADITIONAL, ", true},
+		{"explicit trans", "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO", true},
+		{"explicit all", "error_for_division_by_zero, strict_all_tables", true},
+		{"strict only", "STRICT_TRANS_TABLES,STRICT_ALL_TABLES", false},
+		{"division only", "ERROR_FOR_DIVISION_BY_ZERO", false},
+		{"empty", "", false},
+		{"unrelated", "ANSI,NO_ZERO_DATE", false},
+		{"traditional exact token", "TRADITIONAL_EXTRA", false},
+		{"strict exact token", "NOT_STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO", false},
+		{"division exact token", "STRICT_ALL_TABLES,ERROR_FOR_DIVISION_BY_ZERO_EXTRA", false},
+		{"nil", nil, false},
+		{"non string", 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mode = tc.mode
+			for _, stmt := range []struct {
+				name, query string
+				ignore      bool
+				check       bool
+			}{
+				{"Insert", tree.QueryTypeDML, false, true},
+				{"Select", tree.QueryTypeDQL, false, false},
+				{"Update", tree.QueryTypeDML, false, true},
+				{"Insert", tree.QueryTypeDML, true, false},
+				{"Execute", tree.QueryTypeDML, false, true},
+			} {
+				profile := &process.StmtProfile{}
+				proc.SetStmtProfile(profile)
+				profile.SetDivByZeroRuntimeProfile(stmt.name, stmt.query, stmt.ignore)
+				want := tc.want && stmt.check
+				require.Equal(t, want, checkDivisionByZeroBehavior(proc, nil), stmt.name)
+				resolved := calls
+				require.Equal(t, want, checkDivisionByZeroBehavior(proc, nil), stmt.name)
+				require.Equal(t, resolved, calls, "cached check must not resolve again")
+			}
+		})
+	}
+	mode = "TRADITIONAL"
+	resolveErr = fmt.Errorf("mode lookup failed")
+	profile := &process.StmtProfile{}
+	proc.SetStmtProfile(profile)
+	profile.SetDivByZeroRuntimeProfile("Insert", tree.QueryTypeDML, false)
+	require.False(t, checkDivisionByZeroBehavior(proc, nil))
+}
+
 func TestDivisionByZeroInsertIgnoreStrictMode(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	defer proc.Free()

--- a/pkg/sql/plan/function/baseTemplate.go
+++ b/pkg/sql/plan/function/baseTemplate.go
@@ -1658,8 +1658,6 @@ func specialTemplateForModFunction[
 // - In SELECT: always return NULL (never raise error)
 // - In INSERT/UPDATE: raise error if strict mode + ERROR_FOR_DIVISION_BY_ZERO are enabled
 // - In INSERT IGNORE: always return NULL (never raise error, even in strict mode)
-// checkDivisionByZeroBehavior checks if division by zero should raise an error.
-// Returns true if should raise error, false if should return NULL.
 func checkDivisionByZeroBehavior(proc *process.Process, selectList *FunctionSelectList) (shouldError bool) {
 	if proc == nil {
 		return false
@@ -1704,19 +1702,9 @@ func checkDivisionByZeroBehavior(proc *process.Process, selectList *FunctionSele
 		return false
 	}
 
-	modeStr, ok := mode.(string)
-	if !ok {
-		atomic.StoreInt32(&proc.Base.DivByZeroErrorMode, 0)
-		return false
-	}
-
-	modeStr = strings.ToUpper(modeStr)
-	hasStrictMode := strings.Contains(modeStr, "STRICT_TRANS_TABLES") || strings.Contains(modeStr, "STRICT_ALL_TABLES")
-	hasErrorForDivByZero := strings.Contains(modeStr, "ERROR_FOR_DIVISION_BY_ZERO")
-
 	// Error only if both strict mode AND ERROR_FOR_DIVISION_BY_ZERO are enabled.
 	// INSERT IGNORE is handled through the statement ignore flag.
-	if hasStrictMode && hasErrorForDivByZero {
+	if process.IsStrictDivisionByZeroMode(mode) {
 		if ignore {
 			atomic.StoreInt32(&proc.Base.DivByZeroErrorMode, 0)
 			return false

--- a/pkg/vm/process/sql_mode.go
+++ b/pkg/vm/process/sql_mode.go
@@ -16,10 +16,10 @@ package process
 
 import "strings"
 
-func parseStrictSQLMode(mode any) (strict, noZeroDate bool) {
+func parseStrictSQLMode(mode any) (strict, noZeroDate, errorForDivisionByZero bool) {
 	modeStr, ok := mode.(string)
 	if !ok {
-		return false, false
+		return false, false, false
 	}
 
 	for token := range strings.SplitSeq(modeStr, ",") {
@@ -27,23 +27,34 @@ func parseStrictSQLMode(mode any) (strict, noZeroDate bool) {
 		case "TRADITIONAL":
 			strict = true
 			noZeroDate = true
+			errorForDivisionByZero = true
 		case "STRICT_TRANS_TABLES", "STRICT_ALL_TABLES":
 			strict = true
+		case "ERROR_FOR_DIVISION_BY_ZERO":
+			errorForDivisionByZero = true
 		case "NO_ZERO_DATE":
 			noZeroDate = true
 		}
 	}
-	return strict, noZeroDate
+	return strict, noZeroDate, errorForDivisionByZero
 }
 
 func IsStrictMode(mode any) bool {
-	strict, _ := parseStrictSQLMode(mode)
+	strict, _, _ := parseStrictSQLMode(mode)
 	return strict
 }
 
 func IsStrictNoZeroDateMode(mode any) bool {
-	strict, noZeroDate := parseStrictSQLMode(mode)
+	strict, noZeroDate, _ := parseStrictSQLMode(mode)
 	return strict && noZeroDate
+}
+
+// IsStrictDivisionByZeroMode reports whether sql_mode requires division by zero
+// to error in data-changing statements without IGNORE. TRADITIONAL enables both
+// strict mode and ERROR_FOR_DIVISION_BY_ZERO.
+func IsStrictDivisionByZeroMode(mode any) bool {
+	strict, _, errorForDivisionByZero := parseStrictSQLMode(mode)
+	return strict && errorForDivisionByZero
 }
 
 func IsPadCharToFullLengthMode(mode any) bool {

--- a/pkg/vm/process/sql_mode_test.go
+++ b/pkg/vm/process/sql_mode_test.go
@@ -21,6 +21,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The strict predicates share token interpretation, but require different flags.
+func TestStrictSQLModePredicates(t *testing.T) {
+	for _, tc := range []struct {
+		name                       string
+		mode                       any
+		strict, zeroDate, division bool
+	}{
+		{"traditional", "TRADITIONAL", true, true, true},
+		{"traditional combined", "ERROR_FOR_DIVISION_BY_ZERO, traditional ,TRADITIONAL", true, true, true},
+		{"strict trans", "STRICT_TRANS_TABLES", true, false, false},
+		{"strict all", "STRICT_ALL_TABLES", true, false, false},
+		{"division trans", "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO", true, false, true},
+		{"division all", " error_for_division_by_zero , strict_all_tables ", true, false, true},
+		{"date trans", "NO_ZERO_DATE,STRICT_TRANS_TABLES", true, true, false},
+		{"date all", "STRICT_ALL_TABLES,NO_ZERO_DATE", true, true, false},
+		{"all explicit", "STRICT_ALL_TABLES,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO", true, true, true},
+		{"no strict", "ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE", false, false, false},
+		{"traditional exact token", "TRADITIONAL_EXTRA", false, false, false},
+		{"strict exact token", "NOT_STRICT_TRANS_TABLES,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO", false, false, false},
+		{"component exact tokens", "STRICT_ALL_TABLES,NO_ZERO_DATE_EXTRA,ERROR_FOR_DIVISION_BY_ZERO_EXTRA", true, false, false},
+		{"unrelated", "ANSI,NO_ZERO_IN_DATE", false, false, false},
+		{"empty tokens", " , , ", false, false, false},
+		{"nil", nil, false, false, false},
+		{"non string", 1, false, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.strict, IsStrictMode(tc.mode))
+			require.Equal(t, tc.zeroDate, IsStrictNoZeroDateMode(tc.mode))
+			require.Equal(t, tc.division, IsStrictDivisionByZeroMode(tc.mode))
+		})
+	}
+}
+
 func TestIsPadCharToFullLengthMode(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/distributed/cases/function/func_div_by_zero_traditional.result
+++ b/test/distributed/cases/function/func_div_by_zero_traditional.result
@@ -1,0 +1,374 @@
+DROP DATABASE IF EXISTS div_zero_traditional;
+CREATE DATABASE div_zero_traditional;
+USE div_zero_traditional;
+CREATE TABLE t(id INT PRIMARY KEY, v DECIMAL(10,2));
+CREATE TABLE src(id INT PRIMARY KEY, n INT, d INT);
+INSERT INTO src VALUES (1,10,2),(2,10,0),(3,10,5);
+SET SESSION sql_mode = 'TRADITIONAL';
+SELECT 10/0 AS v;
+➤ v[8,53,31]  𝄀
+null
+INSERT INTO t VALUES(1,10/0);
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  42.00  ¦  0
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+Data truncation: division by zero
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+SET SESSION sql_mode = 'TRADITIONAL,ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+➤ v[8,53,31]  𝄀
+null
+INSERT INTO t VALUES(1,10/0);
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  42.00  ¦  0
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+Data truncation: division by zero
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+➤ v[8,53,31]  𝄀
+null
+INSERT INTO t VALUES(1,10/0);
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  42.00  ¦  0
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+Data truncation: division by zero
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+SET SESSION sql_mode = 'STRICT_ALL_TABLES,ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+➤ v[8,53,31]  𝄀
+null
+INSERT INTO t VALUES(1,10/0);
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  42.00  ¦  0
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+Data truncation: division by zero
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+Data truncation: division by zero
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]
+DELETE FROM t;
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES';
+SELECT 10/0 AS v;
+➤ v[8,53,31]  𝄀
+null
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+2  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  5.00  ¦  0  𝄀
+2  ¦  null  ¦  1  𝄀
+3  ¦  2.00  ¦  0
+DELETE FROM t;
+SET SESSION sql_mode = 'ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+➤ v[8,53,31]  𝄀
+null
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+2  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  5.00  ¦  0  𝄀
+2  ¦  null  ¦  1  𝄀
+3  ¦  2.00  ¦  0
+DELETE FROM t;
+SET SESSION sql_mode = '';
+SELECT 10/0 AS v;
+➤ v[8,53,31]  𝄀
+null
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+2  ¦  null  ¦  1
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  ¦  is_null[-7,1,0]  𝄀
+1  ¦  5.00  ¦  0  𝄀
+2  ¦  null  ¦  1  𝄀
+3  ¦  2.00  ¦  0
+DELETE FROM t;
+SET SESSION sql_mode = 'traditional';
+INSERT INTO t VALUES(1,10 DIV 0);
+Data truncation: division by zero
+INSERT INTO t VALUES(1,10 % 0);
+Data truncation: division by zero
+INSERT INTO t VALUES(1,MOD(10,0));
+Data truncation: division by zero
+INSERT INTO t VALUES(1,CAST(10 AS DECIMAL(10,2))/CAST(0 AS DECIMAL(10,2)));
+Data truncation: division by zero
+INSERT INTO t VALUES(1,CAST(10 AS DECIMAL(30,2))/CAST(0 AS DECIMAL(30,2)));
+Data truncation: division by zero
+INSERT INTO t VALUES(1,CAST(10 AS DOUBLE)/CAST(0 AS DOUBLE));
+Data truncation: division by zero
+SELECT COUNT(*) FROM t;
+➤ COUNT(*)[-5,64,0]  𝄀
+0
+SELECT 10 DIV 0 AS d,10 % 0 AS m,MOD(10,0) AS f;
+➤ d[-5,64,0]  ¦  m[-5,64,0]  ¦  f[-5,64,0]  𝄀
+null  ¦  null  ¦  null
+INSERT INTO t SELECT id,n DIV d FROM src;
+Data truncation: division by zero
+INSERT INTO t SELECT id,n % d FROM src;
+Data truncation: division by zero
+INSERT INTO t SELECT id,CAST(n AS DECIMAL(10,2))/CAST(d AS DECIMAL(10,2)) FROM src;
+Data truncation: division by zero
+INSERT INTO t SELECT id,CAST(n AS DECIMAL(30,2))/CAST(d AS DECIMAL(30,2)) FROM src;
+Data truncation: division by zero
+SELECT COUNT(*) FROM t;
+➤ COUNT(*)[-5,64,0]  𝄀
+0
+INSERT INTO t VALUES(1,10/2),(2,10/0),(3,10/5);
+Data truncation: division by zero
+SELECT COUNT(*) FROM t;
+➤ COUNT(*)[-5,64,0]  𝄀
+0
+INSERT INTO t VALUES(1,41),(2,42),(3,43);
+UPDATE t SET v=10/(id-2);
+Data truncation: division by zero
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  41.00  𝄀
+2  ¦  42.00  𝄀
+3  ¦  43.00
+DELETE FROM t;
+INSERT INTO t VALUES(1,NULL/0),(2,10/NULL),(3,NULL DIV 0),(4,NULL % 0);
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  null  𝄀
+2  ¦  null  𝄀
+3  ¦  null  𝄀
+4  ¦  null
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id < 0;
+SELECT COUNT(*) FROM t;
+➤ COUNT(*)[-5,64,0]  𝄀
+0
+INSERT INTO t SELECT id,n/d FROM src WHERE d <> 0;
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  5.00  𝄀
+3  ¦  2.00
+DELETE FROM t;
+INSERT INTO t SELECT id,CASE WHEN d=0 THEN 99 ELSE n/d END FROM src;
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  5.00  𝄀
+2  ¦  99.00  𝄀
+3  ¦  2.00
+DELETE FROM t;
+INSERT IGNORE INTO t VALUES(1,10/0),(2,10 DIV 0),(3,10 % 0);
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  null  𝄀
+2  ¦  null  𝄀
+3  ¦  null
+DELETE FROM t;
+INSERT IGNORE INTO t SELECT id,n/d FROM src;
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  5.00  𝄀
+2  ¦  null  𝄀
+3  ¦  2.00
+DELETE FROM t;
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES';
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+SET SESSION sql_mode = 'TRADITIONAL';
+EXECUTE p;
+Data truncation: division by zero
+SELECT COUNT(*) FROM t;
+➤ COUNT(*)[-5,64,0]  𝄀
+0
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES';
+EXECUTE p;
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  null
+DELETE FROM t;
+SET SESSION sql_mode = 'TRADITIONAL';
+EXECUTE p;
+Data truncation: division by zero
+SELECT COUNT(*) FROM t;
+➤ COUNT(*)[-5,64,0]  𝄀
+0
+DEALLOCATE PREPARE p;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/?)';
+SET @d=0;
+EXECUTE p USING @d;
+Data truncation: division by zero
+SELECT COUNT(*) FROM t;
+➤ COUNT(*)[-5,64,0]  𝄀
+0
+SET @d=2;
+EXECUTE p USING @d;
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+1  ¦  5.00
+DEALLOCATE PREPARE p;
+DELETE FROM t;
+BEGIN;
+INSERT INTO t VALUES(9,99);
+INSERT INTO t SELECT id,n/d FROM src;
+Data truncation: division by zero
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+9  ¦  99.00
+COMMIT;
+SELECT * FROM t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+9  ¦  99.00
+SELECT * FROM div_zero_traditional.t ORDER BY id;
+➤ id[4,32,0]  ¦  v[3,10,2]  𝄀
+9  ¦  99.00
+DROP DATABASE div_zero_traditional;
+SET SESSION sql_mode = DEFAULT;

--- a/test/distributed/cases/function/func_div_by_zero_traditional.sql
+++ b/test/distributed/cases/function/func_div_by_zero_traditional.sql
@@ -1,0 +1,248 @@
+-- TRADITIONAL must enforce the same division errors as its strict components.
+-- Use a primary-keyed DECIMAL target to observe both NULL writes and atomicity.
+DROP DATABASE IF EXISTS div_zero_traditional;
+CREATE DATABASE div_zero_traditional;
+USE div_zero_traditional;
+CREATE TABLE t(id INT PRIMARY KEY, v DECIMAL(10,2));
+CREATE TABLE src(id INT PRIMARY KEY, n INT, d INT);
+INSERT INTO src VALUES (1,10,2),(2,10,0),(3,10,5);
+
+-- Mode: TRADITIONAL; SELECT is NULL, while each DML uses the current mode.
+SET SESSION sql_mode = 'TRADITIONAL';
+SELECT 10/0 AS v;
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Mode: TRADITIONAL,ERROR_FOR_DIVISION_BY_ZERO; SELECT is NULL, while each DML uses the current mode.
+SET SESSION sql_mode = 'TRADITIONAL,ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Mode: STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO; SELECT is NULL, while each DML uses the current mode.
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Mode: STRICT_ALL_TABLES,ERROR_FOR_DIVISION_BY_ZERO; SELECT is NULL, while each DML uses the current mode.
+SET SESSION sql_mode = 'STRICT_ALL_TABLES,ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Mode: STRICT_TRANS_TABLES; SELECT is NULL, while each DML uses the current mode.
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES';
+SELECT 10/0 AS v;
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Mode: ERROR_FOR_DIVISION_BY_ZERO; SELECT is NULL, while each DML uses the current mode.
+SET SESSION sql_mode = 'ERROR_FOR_DIVISION_BY_ZERO';
+SELECT 10/0 AS v;
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Mode: empty; SELECT is NULL, while each DML uses the current mode.
+SET SESSION sql_mode = '';
+SELECT 10/0 AS v;
+INSERT INTO t VALUES(1,10/0);
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t VALUES(1,42);
+UPDATE t SET v=10/0;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+EXECUTE p;
+DEALLOCATE PREPARE p;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id=2;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT id,v,v IS NULL AS is_null FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Scalar operators and numeric kernels all interpret TRADITIONAL identically.
+SET SESSION sql_mode = 'traditional';
+INSERT INTO t VALUES(1,10 DIV 0);
+INSERT INTO t VALUES(1,10 % 0);
+INSERT INTO t VALUES(1,MOD(10,0));
+INSERT INTO t VALUES(1,CAST(10 AS DECIMAL(10,2))/CAST(0 AS DECIMAL(10,2)));
+INSERT INTO t VALUES(1,CAST(10 AS DECIMAL(30,2))/CAST(0 AS DECIMAL(30,2)));
+INSERT INTO t VALUES(1,CAST(10 AS DOUBLE)/CAST(0 AS DOUBLE));
+SELECT COUNT(*) FROM t;
+SELECT 10 DIV 0 AS d,10 % 0 AS m,MOD(10,0) AS f;
+
+-- Vector arithmetic shares the same error policy as scalar expressions.
+INSERT INTO t SELECT id,n DIV d FROM src;
+INSERT INTO t SELECT id,n % d FROM src;
+INSERT INTO t SELECT id,CAST(n AS DECIMAL(10,2))/CAST(d AS DECIMAL(10,2)) FROM src;
+INSERT INTO t SELECT id,CAST(n AS DECIMAL(30,2))/CAST(d AS DECIMAL(30,2)) FROM src;
+SELECT COUNT(*) FROM t;
+
+-- Multi-row VALUES and UPDATE must retain no partial changes.
+INSERT INTO t VALUES(1,10/2),(2,10/0),(3,10/5);
+SELECT COUNT(*) FROM t;
+INSERT INTO t VALUES(1,41),(2,42),(3,43);
+UPDATE t SET v=10/(id-2);
+SELECT * FROM t ORDER BY id;
+DELETE FROM t;
+
+-- NULL operands, an empty source, and guarded zero divisors do not error.
+INSERT INTO t VALUES(1,NULL/0),(2,10/NULL),(3,NULL DIV 0),(4,NULL % 0);
+SELECT * FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE id < 0;
+SELECT COUNT(*) FROM t;
+INSERT INTO t SELECT id,n/d FROM src WHERE d <> 0;
+SELECT * FROM t ORDER BY id;
+DELETE FROM t;
+INSERT INTO t SELECT id,CASE WHEN d=0 THEN 99 ELSE n/d END FROM src;
+SELECT * FROM t ORDER BY id;
+DELETE FROM t;
+
+-- IGNORE suppresses the error for scalar and multi-row DML.
+INSERT IGNORE INTO t VALUES(1,10/0),(2,10 DIV 0),(3,10 % 0);
+SELECT * FROM t ORDER BY id;
+DELETE FROM t;
+INSERT IGNORE INTO t SELECT id,n/d FROM src;
+SELECT * FROM t ORDER BY id;
+DELETE FROM t;
+
+-- Prepared plans must pick up mode changes at EXECUTE, including parameters.
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES';
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/0)';
+SET SESSION sql_mode = 'TRADITIONAL';
+EXECUTE p;
+SELECT COUNT(*) FROM t;
+SET SESSION sql_mode = 'STRICT_TRANS_TABLES';
+EXECUTE p;
+SELECT * FROM t ORDER BY id;
+DELETE FROM t;
+SET SESSION sql_mode = 'TRADITIONAL';
+EXECUTE p;
+SELECT COUNT(*) FROM t;
+DEALLOCATE PREPARE p;
+PREPARE p FROM 'INSERT INTO t VALUES(1,10/?)';
+SET @d=0;
+EXECUTE p USING @d;
+SELECT COUNT(*) FROM t;
+SET @d=2;
+EXECUTE p USING @d;
+SELECT * FROM t ORDER BY id;
+DEALLOCATE PREPARE p;
+DELETE FROM t;
+
+-- A failed statement in a transaction must not erase earlier successful work.
+BEGIN;
+INSERT INTO t VALUES(9,99);
+INSERT INTO t SELECT id,n/d FROM src;
+SELECT * FROM t ORDER BY id;
+COMMIT;
+SELECT * FROM t ORDER BY id;
+-- A fresh connection observes only the successfully committed row.
+-- @session:id=1{
+SELECT * FROM div_zero_traditional.t ORDER BY id;
+-- @session}
+
+DROP DATABASE div_zero_traditional;
+SET SESSION sql_mode = DEFAULT;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #28604. The issue remains open for manual validation.

## What this PR does / why we need it:

With `sql_mode='TRADITIONAL'`, division by zero in INSERT, UPDATE, prepared INSERT, and INSERT SELECT currently writes NULL. These statements must return error 1365 and preserve the target, as they already do with explicit strict mode plus `ERROR_FOR_DIVISION_BY_ZERO`.

The arithmetic policy independently searched the raw mode string for the two explicit component names. The shared strict-mode parser understood TRADITIONAL, but the arithmetic policy did not use it. Even `TRADITIONAL,ERROR_FOR_DIVISION_BY_ZERO` therefore missed the strict component.

This change extends the existing shared parser with the division-error flag and exposes `IsStrictDivisionByZeroMode`. Arithmetic uses that predicate, including exact token matching, case folding, and whitespace handling. Existing statement classification, IGNORE handling, cache/reset behavior, and strict/zero-date predicates retain their contracts.

**Issue-to-test proof (#28604)**

- `TestStrictSQLModePredicates`: TRADITIONAL and explicit components; strict/zero-date/division combinations; case, whitespace, duplicate and invalid tokens; nil/non-string inputs.
- `TestDivisionByZeroSQLModes`: INSERT, UPDATE, SELECT, IGNORE, and execution profiles across modes; cache reuse/reset and resolver-error behavior. Before the change, all four TRADITIONAL forms failed while explicit-mode controls passed.
- `func_div_by_zero_traditional.sql/.result`: exact DECIMAL/primary-key reproduction; INSERT, UPDATE, SQL PREPARE/EXECUTE, single-row and mixed-row INSERT SELECT across seven mode settings. Also covers scalar/vector `/`, `DIV`, `%`, `MOD`, decimal/double inputs, NULL/empty/guarded inputs, IGNORE, multi-row failure atomicity, prepared parameters and mode changes, and preservation of earlier transaction writes verified from another connection.

**Validation**

- Built baseline and candidate services with `make build` on macOS/arm64, Go 1.26.4.
- Direct SQL protocol assertions before/after: 16 DML and 4 SELECT checks per revision, including exact error 1365 and target contents. Baseline reproduced the reported NULL writes; candidate passed the corrected expectations.
- Focused named tests and complete owning packages passed using `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=300s ./pkg/vm/process ./pkg/sql/plan/function`.
- `go vet` and configured incremental `golangci-lint` passed for both changed packages; formatting and diff checks passed.
- Read-only mo-tester main artifacts, with task-local configuration/output, against a dedicated single-CN service: normal comparison of new and existing strict-mode cases passed **258/258**, with **0 ignored**. The final new case passed again **214/214** on the same instance. Database teardown was verified between/after runs. Generated results were reviewed individually, including all 36 expected division errors.
- Exact-head public-path validation on `504042f7ab`: built a binary reporting that commit, then ran normal mo-tester comparison of `func_div_by_zero_traditional.sql` twice against the same isolated single-CN instance. Run 1 passed 214/214 in 0.973s and run 2 passed 214/214 in 0.849s; both had 0 failed, 0 ignored, 0 abnormal, and empty error reports. Teardown removed `div_zero_traditional` (`information_schema` count 0), and the service shut down normally.
- Upstream CI on `504042f7ab` passed after one Ubuntu/x86 UT rerun. The first attempt reached the repository-wide 70-minute hard timeout while unrelated embedded-cluster tests were still progressing; no assertion, panic, OOM, or changed-package failure occurred. The rerun passed in 59m43s.
- Merged current `main` through `1d7d425f6c` without conflicts. On resulting head `cdf5c2d564`, complete focused owning-package tests passed again: `pkg/vm/process` and `pkg/sql/plan/function`.
- Exact-head public-path validation on `cdf5c2d564`: built a binary reporting that commit and ran normal mo-tester comparison twice on the same fresh isolated single-CN instance. Both runs passed 214/214 (1.325s and 1.010s), with 0 failed, 0 ignored, 0 abnormal, and empty error reports. Teardown removed `div_zero_traditional` (`information_schema` count 0), and the service shut down normally.
- Upstream CI on `cdf5c2d564` passed after one Ubuntu/x86 UT rerun. The first attempt failed only in unrelated embedded-cluster tests under severe runner saturation and then reached the repository-wide 70-minute hard timeout; the rerun passed in 51m41s.

Self-review found no unresolved correctness, ownership, resource, performance, or scope blockers. The functional diff remains limited to the original six files. Exact-head focused tests, public SQL BVT, and upstream CI have passed on `cdf5c2d564`.
