### PR TITLE
test(arrowload): reduce fanout fixture cost

### DIFF
--- a/pkg/tests/arrowload/arrow_load_minio_test.go
+++ b/pkg/tests/arrowload/arrow_load_minio_test.go
@@ -234,6 +234,135 @@ type arrowLoadMinIO struct {
 	client      *minio.Client
 }
 
+func arrowLoadBucketCreateComplete(err error) bool {
+	return err == nil || minio.ToErrorResponse(err).Code == minio.BucketAlreadyOwnedByYou
+}
+
+func TestArrowLoadBucketCreateComplete(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "created", want: true},
+		{name: "bucket already owned after retry", err: minio.ErrorResponse{Code: minio.BucketAlreadyOwnedByYou}, want: true},
+		{name: "bucket exists but is not owned", err: minio.ErrorResponse{Code: minio.BucketAlreadyExists}},
+		{name: "access denied", err: minio.ErrorResponse{Code: minio.AccessDenied}},
+		{name: "transport error", err: errors.New("connection refused")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, arrowLoadBucketCreateComplete(tt.err))
+		})
+	}
+}
+
+type arrowLoadLoseFirstCreateResponse struct {
+	base http.RoundTripper
+	lost atomic.Bool
+}
+
+func (t *arrowLoadLoseFirstCreateResponse) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if req.Method == http.MethodPut && t.lost.CompareAndSwap(false, true) {
+		_ = resp.Body.Close()
+		return nil, errors.New("injected lost bucket-create response")
+	}
+	return resp, nil
+}
+
+func TestArrowLoadBucketRetryAfterLostCreateResponse(t *testing.T) {
+	const bucket = "arrow-load-retry"
+	var (
+		requests     atomic.Int32
+		bucketExists atomic.Bool
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || strings.TrimSuffix(r.URL.Path, "/") != "/"+bucket {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		requests.Add(1)
+		if bucketExists.CompareAndSwap(false, true) {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte("<Error><Code>BucketAlreadyOwnedByYou</Code><Message>already owned</Message></Error>"))
+	}))
+	defer server.Close()
+
+	endpoint, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport.Proxy = nil
+	t.Cleanup(baseTransport.CloseIdleConnections)
+	transport := &arrowLoadLoseFirstCreateResponse{base: baseTransport}
+	client, err := minio.New(endpoint.Host, &minio.Options{
+		Creds:     credentials.NewStaticV4("arrowtest", "arrowtest-secret", ""),
+		Region:    "us-east-1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err = retryArrowLoadBucket(ctx, 0, func(attemptCtx context.Context) error {
+		return client.MakeBucket(attemptCtx, bucket, minio.MakeBucketOptions{Region: "us-east-1"})
+	})
+	require.NoError(t, err)
+	require.True(t, transport.lost.Load(), "the first successful create response must be dropped")
+	require.True(t, bucketExists.Load(), "the first request must create server-side state")
+	require.GreaterOrEqual(t, requests.Load(), int32(2), "the retry must observe the existing bucket")
+}
+
+func TestRetryArrowLoadBucketStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	attempts := 0
+	err := retryArrowLoadBucket(ctx, 0, func(ctx context.Context) error {
+		attempts++
+		return ctx.Err()
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
+}
+
+func retryArrowLoadBucket(ctx context.Context, retryInterval time.Duration, makeBucket func(context.Context) error) error {
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		attemptCtx, cancel := context.WithTimeout(ctx, time.Second)
+		err := makeBucket(attemptCtx)
+		cancel()
+		if arrowLoadBucketCreateComplete(err) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return err
+		}
+		if retryInterval > 0 {
+			timer := time.NewTimer(retryInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return err
+			case <-timer.C:
+			}
+		} else {
+			select {
+			case <-ctx.Done():
+				return err
+			default:
+			}
+		}
+	}
+}
+
 func startArrowLoadMinIO(t *testing.T) arrowLoadMinIO {
 	t.Helper()
 	executable, err := exec.LookPath("minio")
@@ -273,19 +402,12 @@ func startArrowLoadMinIO(t *testing.T) arrowLoadMinIO {
 	})
 	require.NoError(t, err)
 	bucket := "matrixone-arrow-load"
-	deadline := time.Now().Add(15 * time.Second)
-	for {
-		attemptCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-		err = client.MakeBucket(attemptCtx, bucket, minio.MakeBucketOptions{Region: "us-east-1"})
-		cancel()
-		if err == nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			logBytes, _ := os.ReadFile(logPath)
-			t.Fatalf("start local MinIO: %v\n%s", err, logBytes)
-		}
-		time.Sleep(100 * time.Millisecond)
+	err = retryArrowLoadBucket(context.Background(), 100*time.Millisecond, func(attemptCtx context.Context) error {
+		return client.MakeBucket(attemptCtx, bucket, minio.MakeBucketOptions{Region: "us-east-1"})
+	})
+	if err != nil {
+		logBytes, _ := os.ReadFile(logPath)
+		t.Fatalf("start local MinIO: %v\n%s", err, logBytes)
 	}
 	return arrowLoadMinIO{
 		endpoint: endpoint, endpointURL: "http://" + endpoint,

--- a/pkg/tests/arrowload/arrow_load_multicn_test.go
+++ b/pkg/tests/arrowload/arrow_load_multicn_test.go
@@ -17,24 +17,32 @@ package arrowload
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/stretchr/testify/require"
 )
 
-// testArrowMultiCNFanout loads the "large" multi-record-batch fixture with
-// `PARALLEL 'true'` against the 2-CN cluster and checks full row-count and content
-// correctness. Shard-routing internals are already unit-tested in
-// pkg/sql/compile's arrow_scope_test.go; this test's job is proving the whole thing
-// produces correct data on a real multi-CN cluster, not re-deriving that routing.
-func testArrowMultiCNFanout(t *testing.T, db *sql.DB, path, ddl string) {
+// testArrowRecordBatchFanout loads a multi-batch local Arrow file with
+// `PARALLEL 'true'` and checks row identity and content. The local file is split
+// into worker scopes on the connected CN; separate MinIO cases cover object-store
+// inputs. Planner routing is independently checked in
+// pkg/sql/compile/arrow_scope_test.go.
+func testArrowRecordBatchFanout(t *testing.T, db *sql.DB, path, ddl string) {
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(plan.LoadWriteS3MinSize), "fixture must retain the LoadWriteS3 path")
+
 	mustExec(t, db, "drop table if exists large_fanout")
 	mustExec(t, db, fmt.Sprintf("create table large_fanout(%s)", ddl))
 	mustExec(t, db, fmt.Sprintf(
 		"load data infile {'filepath'='%s','format'='arrow'} into table large_fanout parallel 'true'", path))
 
-	require.Equal(t, int64(largeFixtureRows), queryCount(t, db, "select count(*) from large_fanout"))
-	require.Equal(t, int64(largeFixtureRows), queryCount(t, db, "select count(distinct id) from large_fanout"))
-	require.Equal(t, int64(0), queryCount(t, db,
-		fmt.Sprintf("select count(*) from large_fanout where id < 0 or id >= %d", largeFixtureRows)))
+	require.Equal(t, int64(fanoutFixtureRows), queryCount(t, db, "select count(*) from large_fanout"))
+	require.Equal(t, int64(fanoutFixtureRows), queryCount(t, db, "select count(distinct id) from large_fanout"))
+	require.Equal(t, int64(0), queryCount(t, db, fmt.Sprintf(
+		"select count(*) from large_fanout where id < 0 or id >= %d or payload is null or payload <> concat('payload-row-', lpad(cast(id as char), 8, '0'), '-', repeat('x', 32))",
+		fanoutFixtureRows,
+	)))
 }

--- a/pkg/tests/arrowload/arrow_load_test.go
+++ b/pkg/tests/arrowload/arrow_load_test.go
@@ -46,15 +46,15 @@ func TestArrowLoadBVT(t *testing.T) {
 	mustExec(t, db, "create database if not exists arrow_bvt")
 	mustExec(t, db, "use arrow_bvt")
 
-	// The multi-CN fan-out test uses the same default-path cluster. It runs before
+	// Keep the established DistributedRecordBatchFanout selector. It runs before
 	// ClusterRestartPersistence, which deliberately invalidates every connection
 	// and must remain the final subtest in this lifecycle.
 	t.Run("DistributedRecordBatchFanout", func(t *testing.T) {
 		multiDB := openArrowLoadDB(t, c, 0)
 		mustExec(t, multiDB, "create database if not exists arrow_multicn")
 		mustExec(t, multiDB, "use arrow_multicn")
-		path, ddl := fixtureLarge(t)
-		testArrowMultiCNFanout(t, multiDB, path, ddl)
+		path, ddl := fixtureFanout(t)
+		testArrowRecordBatchFanout(t, multiDB, path, ddl)
 	})
 	t.Run("TypeMatrixNumeric", func(t *testing.T) { testArrowTypeMatrixNumeric(t, db) })
 	t.Run("TypeMatrixTimestampDict", func(t *testing.T) { testArrowTypeMatrixTimestampDict(t, db) })

--- a/pkg/tests/arrowload/fixtures_test.go
+++ b/pkg/tests/arrowload/fixtures_test.go
@@ -390,47 +390,65 @@ func fixtureInt64Overflow(t *testing.T, dir, filename, container string, values 
 	})
 }
 
-// --- large fixture: many record batches, for multi-CN parallel fan-out and the ---
-// --- KILL-QUERY cancellation test --------------------------------------------------
+// --- large fixture: end-to-end throughput benchmark -------------------------------
 
 const (
 	largeFixtureBatches   = 100
 	largeFixtureBatchRows = 1000
 	largeFixtureRows      = largeFixtureBatches * largeFixtureBatchRows
+	// Keep the fanout BVT above LOAD's 1 MiB LoadWriteS3 threshold while reducing
+	// row work. The separate benchmark retains the full 100,000-row workload.
+	fanoutFixtureBatchRows = 256
+	fanoutFixtureRows      = largeFixtureBatches * fanoutFixtureBatchRows
 	// The ownership-policy test only needs several batches to exercise Arrow
-	// conversion. Keep the 100-batch fixture for tests that actually prove
-	// distributed fan-out or mid-load cancellation.
+	// conversion; it does not need the fanout workload.
 	forceMaterializeFixtureBatches = 4
 	forceMaterializeFixtureRows    = forceMaterializeFixtureBatches * largeFixtureBatchRows
 )
 
-// fixtureLarge writes an IPC File (so record-batch parallel shard fan-out applies)
-// with largeFixtureRows rows of `id BIGINT NOT NULL, payload VARCHAR(64) NOT NULL`
-// spread across largeFixtureBatches record batches, giving both the multi-CN
-// parallel-shard test and the cancel-mid-LOAD test enough real decode/insert work to
-// observe or interrupt without relying on a sleep.
+// fixtureLarge writes an IPC File with largeFixtureRows rows of
+// `id BIGINT NOT NULL, payload VARCHAR(128) NOT NULL` spread across
+// largeFixtureBatches record batches. The throughput benchmark retains this
+// volume; the functional fanout BVT uses fewer rows but keeps every batch.
 func fixtureLarge(t testing.TB) (path string, schemaDDL string) {
 	t.Helper()
 	return fixtureLargeWithBatches(t, largeFixtureBatches)
 }
 
-// fixtureLargeWithBatches keeps the schema and row construction identical for
-// the large fan-out fixture and the smaller single-CN ownership-policy fixture.
-// A separate batch count prevents a policy check from accidentally carrying the
-// fan-out workload while retaining multiple record-batch conversion.
+// fixtureLargeWithBatches keeps schema and row construction shared by the large
+// throughput benchmark and the forced-materialization BVT. A separate batch
+// count prevents the ownership-policy check from carrying the benchmark workload.
 func fixtureLargeWithBatches(t testing.TB, batches int) (path string, schemaDDL string) {
+	t.Helper()
+	return fixtureArrowBatches(t, "large.arrow", batches, largeFixtureBatchRows)
+}
+
+// fixtureFanout retains all record batches while reducing row work. Its file
+// remains above the LOAD 1 MiB threshold so the public BVT still exercises the
+// LoadWriteS3 insertion path; the benchmark retains the original 100k rows.
+func fixtureFanout(t testing.TB) (path string, schemaDDL string) {
+	t.Helper()
+	return fixtureArrowBatches(t, "fanout.arrow", largeFixtureBatches, fanoutFixtureBatchRows)
+}
+
+func fixtureArrowBatches(
+	t testing.TB,
+	filename string,
+	batches int,
+	rowsPerBatch int,
+) (path string, schemaDDL string) {
 	t.Helper()
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 		{Name: "payload", Type: arrow.BinaryTypes.String, Nullable: false},
 	}, nil)
-	path = writeArrowFile(t, t.TempDir(), "large.arrow", containerFile, schema, func(alloc memory.Allocator, write func(arrow.RecordBatch) error) {
+	path = writeArrowFile(t, t.TempDir(), filename, containerFile, schema, func(alloc memory.Allocator, write func(arrow.RecordBatch) error) {
 		for b := 0; b < batches; b++ {
 			builder := array.NewRecordBuilder(alloc, schema)
-			ids := make([]int64, largeFixtureBatchRows)
-			payloads := make([]string, largeFixtureBatchRows)
-			for r := 0; r < largeFixtureBatchRows; r++ {
-				id := int64(b*largeFixtureBatchRows + r)
+			ids := make([]int64, rowsPerBatch)
+			payloads := make([]string, rowsPerBatch)
+			for r := 0; r < rowsPerBatch; r++ {
+				id := int64(b*rowsPerBatch + r)
 				ids[r] = id
 				payloads[r] = fmt.Sprintf("payload-row-%08d-%s", id, strings.Repeat("x", 32))
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28781

## What this PR does / why we need it:

- Reduce the functional Arrow record-batch fanout fixture from 100,000 to 25,600 rows while retaining all 100 IPC record batches. A runtime size assertion keeps it above the 1 MiB LOAD threshold, and the full row identity/payload checks remain. The 100,000-row benchmark fixture is unchanged.
- Make LocalMinIO bucket setup idempotent only for `BucketAlreadyOwnedByYou`, which can follow a server-side bucket create whose response was lost. Other errors remain failures.
- Add a deterministic lost-response test using the MinIO SDK and an in-process HTTP server.
- No production SQL behavior changes.

## Test Plan

- On the 55 Linux/x86 host: full `TestArrowLoadBVT` (including `DistributedRecordBatchFanout` and `LocalMinIO`) passed; `TestArrowLoadForceMaterializeFallback` passed.
- `TestArrowLoadBucketCreateComplete`, `TestArrowLoadBucketRetryAfterLostCreateResponse`, and `TestRetryArrowLoadBucketStopsOnCancellation` passed normally and under `-race`.
- `go vet -mod=readonly ./pkg/tests/arrowload`, gofmt, and `git diff --check` passed.
- The 55-host test evidence used the unchanged source diff before rebasing; the rebase added only upstream #28751 and #28760, which do not touch the Arrow LOAD test paths. CI on the final head has not been awaited.
- Local golangci-lint could not run because the installed binary targets Go 1.24.4 while this repository requires Go 1.26.4; CI static analysis remains the final check.
- The fanout case is smaller by row count while preserving its batch count and LOAD path. Timing samples varied, so this PR does not claim a statistically established end-to-end suite speedup.