### PR TITLE
fix(function): expand regexp replacement captures

### DIFF
--- a/pkg/sql/plan/function/func_builtin_regexp.go
+++ b/pkg/sql/plan/function/func_builtin_regexp.go
@@ -2231,6 +2231,34 @@ func (rs *regexpSet) regularReplaceWithMatchType(
 	if len(str) == 0 {
 		return str, nil
 	}
+	if regexpReplacementNeedsExpansion(repl) {
+		return rs.regularReplaceWithTemplate(
+			reg, pat, str, repl, startByte, occurrence, subjectIsBinary, pureMatchType,
+			regexpReplaceMaxResultBytes,
+		)
+	}
+	if len(repl) > 0 {
+		if upperBound, ok := regexpReplaceOutputUpperBound(len(str), len(repl)); !ok ||
+			upperBound > uint64(regexpReplaceMaxResultBytes/2) {
+			return rs.regexpReplaceLiteralWithLimit(
+				reg, pat, str, repl, startByte, occurrence, subjectIsBinary, pureMatchType,
+				regexpReplaceMaxResultBytes,
+			)
+		}
+	}
+	return rs.regularReplaceLiteralWithMatchType(
+		reg, pat, str, repl, startByte, occurrence, subjectIsBinary, pureMatchType, mayMatchEmpty)
+}
+
+func (rs *regexpSet) regularReplaceLiteralWithMatchType(
+	reg *regexp.Regexp,
+	pat, str, repl string,
+	startByte int,
+	occurrence int64,
+	subjectIsBinary bool,
+	pureMatchType string,
+	mayMatchEmpty bool,
+) (r string, err error) {
 	if startByte == 0 && occurrence == 0 && !mayMatchEmpty {
 		if !subjectIsBinary {
 			return reg.ReplaceAllLiteralString(str, repl), nil

--- a/pkg/sql/plan/function/func_builtin_regexp.go
+++ b/pkg/sql/plan/function/func_builtin_regexp.go
@@ -2583,7 +2583,7 @@ func (rs *regexpSet) regexpFindAtOrAfterWithMatchType(
 	if size < 1 {
 		contextStart = startByte - 1
 	}
-	wrappedPattern := "^(?s:.)(?s:.*?)(" + regexpPatternWithPureMatchType(pat, pureMatchType) + ")"
+	wrappedPattern := regexpPositionSearchPattern(pat, pureMatchType)
 	wrapped, _, err := rs.getRegularMatcherInfoWithBinaryCaseFold(
 		wrappedPattern,
 		subjectIsBinary,
@@ -2858,6 +2858,58 @@ func regexpPatternWithPureMatchType(pat, pureMatchType string) string {
 		return pat
 	}
 	return "(?" + pureMatchType + ")" + pat
+}
+
+// regexpPositionSearchPattern wraps a user pattern so matching can start at a
+// later subject position without changing the original anchor context. A
+// trailing \Q is valid RE2 syntax and quotes through end-of-pattern; close that
+// quote before adding wrapper syntax so the generated parenthesis stays syntax.
+func regexpPositionSearchPattern(pat, pureMatchType string) string {
+	const prefix = "^(?s:.)(?s:.*?)("
+	var wrapped strings.Builder
+	wrapped.Grow(len(prefix) + len(pat) + len(pureMatchType) + 5)
+	wrapped.WriteString(prefix)
+	if pureMatchType != "" {
+		wrapped.WriteString("(?")
+		wrapped.WriteString(pureMatchType)
+		wrapped.WriteByte(')')
+	}
+	quoted := false
+	for i := 0; i < len(pat); {
+		if pat[i] != '\\' || i+1 == len(pat) {
+			wrapped.WriteByte(pat[i])
+			i++
+			continue
+		}
+		if quoted {
+			if pat[i+1] == 'E' {
+				wrapped.WriteString(pat[i : i+2])
+				quoted = false
+				i += 2
+			} else {
+				// Inside \Q, only the first literal \E ends quoting. Do not
+				// treat a preceding backslash as escaping that terminator.
+				wrapped.WriteByte(pat[i])
+				i++
+			}
+			continue
+		}
+		_, size := utf8.DecodeRuneInString(pat[i+1:])
+		if size < 1 {
+			size = 1
+		}
+		end := i + 1 + size
+		wrapped.WriteString(pat[i:end])
+		if pat[i+1] == 'Q' {
+			quoted = true
+		}
+		i = end
+	}
+	if quoted {
+		wrapped.WriteString("\\E")
+	}
+	wrapped.WriteByte(')')
+	return wrapped.String()
 }
 
 func (rs *regexpSet) getRegularMatcherInfoWithMatchType(

--- a/pkg/sql/plan/function/func_builtin_regexp.go
+++ b/pkg/sql/plan/function/func_builtin_regexp.go
@@ -1156,9 +1156,13 @@ func (op *opBuiltInRegexp) builtInRegexpSubstr(parameters []*vector.Vector, resu
 			}
 		}
 
-	case 4:
+	case 4, 5:
 		positions := vector.GenerateFunctionFixedTypeParameter[int64](parameters[2])
 		occurrences := vector.GenerateFunctionFixedTypeParameter[int64](parameters[3])
+		var matchTypes vector.FunctionParameterWrapper[types.Varlena]
+		if len(parameters) == 5 {
+			matchTypes = vector.GenerateFunctionStrParameter(parameters[4])
+		}
 		for i := uint64(0); i < uint64(length); i++ {
 			if regexpRowMasked(selectList, i) {
 				if err := rs.AppendBytes(nil, true); err != nil {
@@ -1171,14 +1175,30 @@ func (op *opBuiltInRegexp) builtInRegexpSubstr(parameters []*vector.Vector, resu
 			pos, null3 := positions.GetValue(i)
 			ocur, null4 := occurrences.GetValue(i)
 			matchingIsBinary := regexpMatchUsesBinary(parameters, int(i))
+			pureMatchType := ""
+			if len(parameters) == 5 {
+				matchType, matchTypeNull := matchTypes.GetStrValue(i)
+				if matchTypeNull {
+					if err := rs.AppendBytes(nil, true); err != nil {
+						return err
+					}
+					continue
+				}
+				var err error
+				pureMatchType, err = getPureMatchType(functionUtil.QuickBytesToStr(matchType))
+				if err != nil {
+					return err
+				}
+			}
 			if null2 {
 				if err := rs.AppendBytes(nil, true); err != nil {
 					return err
 				}
-			} else if err := op.regMap.validateRegexpBeforeNullableResult(
+			} else if err := op.regMap.validateRegexpBeforeNullableResultWithMatchType(
 				functionUtil.QuickBytesToStr(v2),
 				matchingIsBinary,
 				"regexp_substr", null1 || null3 || null4,
+				pureMatchType,
 			); err != nil {
 				return err
 			} else if null1 || null3 || null4 {
@@ -1187,7 +1207,8 @@ func (op *opBuiltInRegexp) builtInRegexpSubstr(parameters []*vector.Vector, resu
 				}
 			} else {
 				expr, pat := functionUtil.QuickBytesToStr(v1), functionUtil.QuickBytesToStr(v2)
-				match, res, err := op.regMap.regularSubstrWithMode(pat, expr, pos, ocur, matchingIsBinary)
+				match, res, err := op.regMap.regularSubstrWithMatchType(
+					pat, expr, pos, ocur, matchingIsBinary, pureMatchType)
 				if err != nil {
 					return err
 				}
@@ -1333,10 +1354,14 @@ func (op *opBuiltInRegexp) builtInRegexpInstr(parameters []*vector.Vector, resul
 		}
 		return nil
 
-	case 5:
+	case 5, 6:
 		positions := vector.GenerateFunctionFixedTypeParameter[int64](parameters[2])
 		occurrences := vector.GenerateFunctionFixedTypeParameter[int64](parameters[3])
 		resultOption := vector.GenerateFunctionFixedTypeParameter[int8](parameters[4])
+		var matchTypes vector.FunctionParameterWrapper[types.Varlena]
+		if len(parameters) == 6 {
+			matchTypes = vector.GenerateFunctionStrParameter(parameters[5])
+		}
 		for i := uint64(0); i < uint64(length); i++ {
 			if regexpRowMasked(selectList, i) {
 				if err := rs.Append(0, true); err != nil {
@@ -1350,14 +1375,30 @@ func (op *opBuiltInRegexp) builtInRegexpInstr(parameters []*vector.Vector, resul
 			ocur, null4 := occurrences.GetValue(i)
 			resOp, null5 := resultOption.GetValue(i)
 			matchingIsBinary := regexpMatchUsesBinary(parameters, int(i))
+			pureMatchType := ""
+			if len(parameters) == 6 {
+				matchType, matchTypeNull := matchTypes.GetStrValue(i)
+				if matchTypeNull {
+					if err := rs.Append(0, true); err != nil {
+						return err
+					}
+					continue
+				}
+				var err error
+				pureMatchType, err = getPureMatchType(functionUtil.QuickBytesToStr(matchType))
+				if err != nil {
+					return err
+				}
+			}
 			if null2 {
 				if err := rs.Append(0, true); err != nil {
 					return err
 				}
-			} else if err := op.regMap.validateRegexpBeforeNullableResult(
+			} else if err := op.regMap.validateRegexpBeforeNullableResultWithMatchType(
 				functionUtil.QuickBytesToStr(v2),
 				matchingIsBinary,
 				"regexp_instr", null1 || null3 || null4 || null5,
+				pureMatchType,
 			); err != nil {
 				return err
 			} else if null1 || null3 || null4 || null5 {
@@ -1366,7 +1407,8 @@ func (op *opBuiltInRegexp) builtInRegexpInstr(parameters []*vector.Vector, resul
 				}
 			} else {
 				expr, pat := functionUtil.QuickBytesToStr(v1), functionUtil.QuickBytesToStr(v2)
-				index, err := op.regMap.regularInstrWithMode(pat, expr, pos, ocur, resOp, matchingIsBinary)
+				index, err := op.regMap.regularInstrWithMatchType(
+					pat, expr, pos, ocur, resOp, matchingIsBinary, pureMatchType)
 				if err != nil {
 					return err
 				}
@@ -1481,9 +1523,13 @@ func (op *opBuiltInRegexp) builtInRegexpReplace(parameters []*vector.Vector, res
 			}
 		}
 
-	case 5:
+	case 5, 6:
 		p4 := vector.GenerateFunctionFixedTypeParameter[int64](parameters[3])
 		p5 := vector.GenerateFunctionFixedTypeParameter[int64](parameters[4])
+		var matchTypes vector.FunctionParameterWrapper[types.Varlena]
+		if len(parameters) == 6 {
+			matchTypes = vector.GenerateFunctionStrParameter(parameters[5])
+		}
 		for i := uint64(0); i < uint64(length); i++ {
 			if regexpRowMasked(selectList, i) {
 				if err := rs.AppendBytes(nil, true); err != nil {
@@ -1497,14 +1543,30 @@ func (op *opBuiltInRegexp) builtInRegexpReplace(parameters []*vector.Vector, res
 			v4, null4 := p4.GetValue(i)
 			v5, null5 := p5.GetValue(i)
 			matchingIsBinary := regexpMatchUsesBinary(parameters, int(i))
+			pureMatchType := ""
+			if len(parameters) == 6 {
+				matchType, matchTypeNull := matchTypes.GetStrValue(i)
+				if matchTypeNull {
+					if err := rs.AppendBytes(nil, true); err != nil {
+						return err
+					}
+					continue
+				}
+				var err error
+				pureMatchType, err = getPureMatchType(functionUtil.QuickBytesToStr(matchType))
+				if err != nil {
+					return err
+				}
+			}
 			if null2 {
 				if err := rs.AppendBytes(nil, true); err != nil {
 					return err
 				}
-			} else if err := op.regMap.validateRegexpBeforeNullableResult(
+			} else if err := op.regMap.validateRegexpBeforeNullableResultWithMatchType(
 				functionUtil.QuickBytesToStr(v2),
 				matchingIsBinary,
 				"regexp_replace", null1 || null3 || null4 || null5,
+				pureMatchType,
 			); err != nil {
 				return err
 			} else if null1 || null3 || null4 || null5 {
@@ -1516,7 +1578,15 @@ func (op *opBuiltInRegexp) builtInRegexpReplace(parameters []*vector.Vector, res
 				if replacementConverter.mayBeBinary {
 					replacement = replacementConverter.forMatchDomain(replacement, int(i), matchingIsBinary)
 				}
-				val, err := op.regMap.regularReplaceWithMode(functionUtil.QuickBytesToStr(v2), functionUtil.QuickBytesToStr(v1), replacement, v4, v5, matchingIsBinary)
+				val, err := op.regMap.regularReplaceWithMatchType(
+					functionUtil.QuickBytesToStr(v2),
+					functionUtil.QuickBytesToStr(v1),
+					replacement,
+					v4,
+					v5,
+					matchingIsBinary,
+					pureMatchType,
+				)
 				if err != nil {
 					return err
 				}
@@ -1583,8 +1653,9 @@ func (c *regexpReplacementDomainConverter) forMatchDomain(
 
 // MySQL presents binary strings to its regexp library as Windows-1252 so that
 // each source byte has a stable character value. Replacement conversion uses
-// this when a binary replacement enters a text result; REGEXP_LIKE also uses
-// it while explicit case folding is active. Keep ASCII zero-copy.
+// this when a binary replacement enters a text result; case-insensitive
+// matching uses it to preserve one matcher character per source byte. Keep
+// ASCII zero-copy.
 func regexpBinaryBytesToText(value string) string {
 	firstHighByte := -1
 	for i := 0; i < len(value); i++ {
@@ -1609,6 +1680,121 @@ func regexpBinaryBytesToText(value string) string {
 		}
 	}
 	return converted.String()
+}
+
+// encodeBinaryRegexpText maps every binary byte to its Windows-1252 rune and
+// returns the corresponding UTF-8 byte offset for startByte. Each source byte
+// remains exactly one rune, so decoded match offsets still map to SQL byte
+// positions.
+func encodeBinaryRegexpText(value string, startByte int) (encoded string, encodedStart int) {
+	if startByte < 0 {
+		startByte = 0
+	} else if startByte > len(value) {
+		startByte = len(value)
+	}
+	if isASCIIBytes(value) {
+		return value, startByte
+	}
+
+	var converted strings.Builder
+	converted.Grow(len(value))
+	for i := 0; i < len(value); i++ {
+		if i == startByte {
+			encodedStart = converted.Len()
+		}
+		if value[i] < utf8.RuneSelf {
+			converted.WriteByte(value[i])
+		} else {
+			converted.WriteRune(regexpWindows1252Rune(value[i]))
+		}
+	}
+	if startByte == len(value) {
+		encodedStart = converted.Len()
+	}
+	return converted.String(), encodedStart
+}
+
+// decodeBinaryRegexpText is the inverse of regexpBinaryBytesToText for text
+// created from a binary operand. Non-Windows-1252 runes are preserved.
+func decodeBinaryRegexpText(encoded string) string {
+	if isASCIIBytes(encoded) {
+		return encoded
+	}
+
+	var decoded strings.Builder
+	decoded.Grow(len(encoded))
+	for _, r := range encoded {
+		if value, ok := regexpWindows1252Byte(r); ok {
+			decoded.WriteByte(value)
+		} else {
+			decoded.WriteRune(r)
+		}
+	}
+	return decoded.String()
+}
+
+func regexpWindows1252Byte(value rune) (byte, bool) {
+	switch value {
+	case 0x20ac:
+		return 0x80, true
+	case 0x201a:
+		return 0x82, true
+	case 0x0192:
+		return 0x83, true
+	case 0x201e:
+		return 0x84, true
+	case 0x2026:
+		return 0x85, true
+	case 0x2020:
+		return 0x86, true
+	case 0x2021:
+		return 0x87, true
+	case 0x02c6:
+		return 0x88, true
+	case 0x2030:
+		return 0x89, true
+	case 0x0160:
+		return 0x8a, true
+	case 0x2039:
+		return 0x8b, true
+	case 0x0152:
+		return 0x8c, true
+	case 0x017d:
+		return 0x8e, true
+	case 0x2018:
+		return 0x91, true
+	case 0x2019:
+		return 0x92, true
+	case 0x201c:
+		return 0x93, true
+	case 0x201d:
+		return 0x94, true
+	case 0x2022:
+		return 0x95, true
+	case 0x2013:
+		return 0x96, true
+	case 0x2014:
+		return 0x97, true
+	case 0x02dc:
+		return 0x98, true
+	case 0x2122:
+		return 0x99, true
+	case 0x0161:
+		return 0x9a, true
+	case 0x203a:
+		return 0x9b, true
+	case 0x0153:
+		return 0x9c, true
+	case 0x017e:
+		return 0x9e, true
+	case 0x0178:
+		return 0x9f, true
+	default:
+		if value >= 0x80 && value <= 0xff {
+			return byte(value), true
+		}
+		return 0, false
+	}
 }
 
 func regexpWindows1252Rune(value byte) rune {
@@ -1866,6 +2052,20 @@ func (rs *regexpSet) validateRegexpBeforeNullableResult(
 	return validateRegexpPattern(pat)
 }
 
+func (rs *regexpSet) validateRegexpBeforeNullableResultWithMatchType(
+	pat string,
+	binary bool,
+	functionName string,
+	laterArgumentIsNull bool,
+	pureMatchType string,
+) error {
+	if laterArgumentIsNull {
+		_, err := rs.getCompiledRegexpWithMatchType(pat, pureMatchType, binary, functionName)
+		return err
+	}
+	return validateRegexpPattern(pat)
+}
+
 func (rs *regexpSet) regularMatchWithMode(pat, str string, binary bool) (bool, error) {
 	reg, err := rs.getRegularMatcherForMatchWithMode(pat, binary)
 	if err != nil {
@@ -1956,7 +2156,18 @@ func (rs *regexpSet) regularSubstr(pat string, str string, pos, occurrence int64
 }
 
 func (rs *regexpSet) regularSubstrWithMode(pat string, str string, pos, occurrence int64, subjectIsBinary bool) (match bool, substr string, err error) {
-	reg, err := rs.getCompiledRegexpWithMode(pat, subjectIsBinary, "regexp_substr")
+	return rs.regularSubstrWithMatchType(pat, str, pos, occurrence, subjectIsBinary, "")
+}
+
+func (rs *regexpSet) regularSubstrWithMatchType(
+	pat string,
+	str string,
+	pos, occurrence int64,
+	subjectIsBinary bool,
+	pureMatchType string,
+) (match bool, substr string, err error) {
+	reg, err := rs.getCompiledRegexpWithMatchType(
+		pat, pureMatchType, subjectIsBinary, "regexp_substr")
 	if err != nil {
 		return false, "", err
 	}
@@ -1969,8 +2180,8 @@ func (rs *regexpSet) regularSubstrWithMode(pat string, str string, pos, occurren
 	if occurrence < 1 {
 		return false, "", moerr.NewInvalidInputNoCtxf("regexp_substr have Index out of bounds in regular expression search, return occurrence %d", occurrence)
 	}
-	selected, found, err := rs.regexpNthMatchAtOrAfter(
-		reg, pat, str, startByte, subjectIsBinary, occurrence)
+	selected, found, err := rs.regexpNthMatchAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, occurrence, pureMatchType)
 	if err != nil {
 		return false, "", err
 	}
@@ -1985,10 +2196,22 @@ func (rs *regexpSet) regularReplace(pat string, str string, repl string, pos, oc
 }
 
 func (rs *regexpSet) regularReplaceWithMode(pat string, str string, repl string, pos, occurrence int64, subjectIsBinary bool) (r string, err error) {
+	return rs.regularReplaceWithMatchType(pat, str, repl, pos, occurrence, subjectIsBinary, "")
+}
+
+func (rs *regexpSet) regularReplaceWithMatchType(
+	pat string,
+	str string,
+	repl string,
+	pos, occurrence int64,
+	subjectIsBinary bool,
+	pureMatchType string,
+) (r string, err error) {
 	if err = validateRegexpPattern(pat); err != nil {
 		return "", err
 	}
-	reg, mayMatchEmpty, err := rs.getRegularMatcherInfoWithMode(pat, subjectIsBinary)
+	reg, mayMatchEmpty, err := rs.getRegularMatcherInfoWithMatchType(
+		pat, pureMatchType, subjectIsBinary)
 	if err != nil {
 		return "", regexpCompileError("regexp_replace", pat, err)
 	}
@@ -2012,16 +2235,22 @@ func (rs *regexpSet) regularReplaceWithMode(pat string, str string, repl string,
 		if !subjectIsBinary {
 			return reg.ReplaceAllLiteralString(str, repl), nil
 		}
+		if strings.ContainsRune(pureMatchType, 'i') {
+			encodedSubject := regexpBinaryBytesToText(str)
+			encodedReplacement := regexpBinaryBytesToText(repl)
+			return decodeBinaryRegexpText(reg.ReplaceAllLiteralString(encodedSubject, encodedReplacement)), nil
+		}
 		encodedSubject, _ := encodeBinaryRegexpBytes(str, 0)
 		encodedReplacement, _ := encodeBinaryRegexpBytes(repl, 0)
 		return decodeBinaryRegexpBytes(reg.ReplaceAllLiteralString(encodedSubject, encodedReplacement)), nil
 	}
 
 	if occurrence == 0 {
-		return rs.regexpReplaceAllAtOrAfter(reg, pat, str, repl, startByte, subjectIsBinary)
+		return rs.regexpReplaceAllAtOrAfterWithMatchType(
+			reg, pat, str, repl, startByte, subjectIsBinary, pureMatchType)
 	}
-	match, found, err := rs.regexpNthMatchAtOrAfter(
-		reg, pat, str, startByte, subjectIsBinary, occurrence)
+	match, found, err := rs.regexpNthMatchAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, occurrence, pureMatchType)
 	if err != nil {
 		return "", err
 	}
@@ -2039,7 +2268,20 @@ func (rs *regexpSet) regularInstr(pat string, str string, pos, occurrence int64,
 }
 
 func (rs *regexpSet) regularInstrWithMode(pat string, str string, pos, occurrence int64, retOption int8, subjectIsBinary bool) (index int64, err error) {
-	reg, err := rs.getCompiledRegexpWithMode(pat, subjectIsBinary, "regexp_instr")
+	return rs.regularInstrWithMatchType(
+		pat, str, pos, occurrence, retOption, subjectIsBinary, "")
+}
+
+func (rs *regexpSet) regularInstrWithMatchType(
+	pat string,
+	str string,
+	pos, occurrence int64,
+	retOption int8,
+	subjectIsBinary bool,
+	pureMatchType string,
+) (index int64, err error) {
+	reg, err := rs.getCompiledRegexpWithMatchType(
+		pat, pureMatchType, subjectIsBinary, "regexp_instr")
 	if err != nil {
 		return 0, err
 	}
@@ -2066,8 +2308,8 @@ func (rs *regexpSet) regularInstrWithMode(pat string, str string, pos, occurrenc
 	// subject. Searching only the suffix also avoids encoding or scanning a
 	// discarded binary/text prefix.
 	searchSubject := str[startByte:]
-	match, found, err := rs.regexpNthMatchAtOrAfter(
-		reg, pat, searchSubject, 0, subjectIsBinary, occurrence)
+	match, found, err := rs.regexpNthMatchAtOrAfterWithMatchType(
+		reg, pat, searchSubject, 0, subjectIsBinary, occurrence, pureMatchType)
 	if err != nil {
 		return 0, err
 	}
@@ -2144,15 +2386,32 @@ func (rs *regexpSet) regexpNthMatchAtOrAfter(
 	subjectIsBinary bool,
 	occurrence int64,
 ) ([2]int, bool, error) {
+	return rs.regexpNthMatchAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, occurrence, "")
+}
+
+func (rs *regexpSet) regexpNthMatchAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str string,
+	startByte int,
+	subjectIsBinary bool,
+	occurrence int64,
+	pureMatchType string,
+) ([2]int, bool, error) {
 	searchSubject := str
 	searchStart := startByte
 	if subjectIsBinary {
-		searchSubject, searchStart = encodeBinaryRegexpBytes(str, startByte)
+		if strings.ContainsRune(pureMatchType, 'i') {
+			searchSubject, searchStart = encodeBinaryRegexpText(str, startByte)
+		} else {
+			searchSubject, searchStart = encodeBinaryRegexpBytes(str, startByte)
+		}
 	}
 
 	selected := [2]int{}
 	visited := int64(0)
-	err := rs.regexpVisitAtOrAfter(reg, pat, searchSubject, searchStart, subjectIsBinary, occurrence,
+	err := rs.regexpVisitAtOrAfterWithMatchType(
+		reg, pat, searchSubject, searchStart, subjectIsBinary, occurrence, pureMatchType,
 		func(start, end int) {
 			selected = [2]int{start, end}
 			visited++
@@ -2180,10 +2439,24 @@ func (rs *regexpSet) regexpVisitAtOrAfter(
 	limit int64,
 	visit func(start, end int),
 ) error {
+	return rs.regexpVisitAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, limit, "", visit)
+}
+
+func (rs *regexpSet) regexpVisitAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str string,
+	startByte int,
+	subjectIsBinary bool,
+	limit int64,
+	pureMatchType string,
+	visit func(start, end int),
+) error {
 	visited := int64(0)
 	nextStart := startByte
 	for nextStart <= len(str) {
-		start, end, found, err := rs.regexpFindAtOrAfter(reg, pat, str, nextStart, subjectIsBinary)
+		start, end, found, err := rs.regexpFindAtOrAfterWithMatchType(
+			reg, pat, str, nextStart, subjectIsBinary, pureMatchType)
 		if err != nil {
 			return err
 		}
@@ -2210,19 +2483,36 @@ func (rs *regexpSet) regexpReplaceAllAtOrAfter(
 	startByte int,
 	subjectIsBinary bool,
 ) (string, error) {
+	return rs.regexpReplaceAllAtOrAfterWithMatchType(
+		reg, pat, str, repl, startByte, subjectIsBinary, "")
+}
+
+func (rs *regexpSet) regexpReplaceAllAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str, repl string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+) (string, error) {
 	searchSubject := str
 	searchStart := startByte
 	replacement := repl
 	if subjectIsBinary {
-		searchSubject, searchStart = encodeBinaryRegexpBytes(str, startByte)
-		replacement, _ = encodeBinaryRegexpBytes(repl, 0)
+		if strings.ContainsRune(pureMatchType, 'i') {
+			searchSubject, searchStart = encodeBinaryRegexpText(str, startByte)
+			replacement = regexpBinaryBytesToText(repl)
+		} else {
+			searchSubject, searchStart = encodeBinaryRegexpBytes(str, startByte)
+			replacement, _ = encodeBinaryRegexpBytes(repl, 0)
+		}
 	}
 
 	var b strings.Builder
 	b.Grow(len(searchSubject))
 	last := 0
 	matched := false
-	err := rs.regexpVisitAtOrAfter(reg, pat, searchSubject, searchStart, subjectIsBinary, 0,
+	err := rs.regexpVisitAtOrAfterWithMatchType(
+		reg, pat, searchSubject, searchStart, subjectIsBinary, 0, pureMatchType,
 		func(start, end int) {
 			matched = true
 			b.WriteString(searchSubject[last:start])
@@ -2238,7 +2528,11 @@ func (rs *regexpSet) regexpReplaceAllAtOrAfter(
 	b.WriteString(searchSubject[last:])
 	result := b.String()
 	if subjectIsBinary {
-		result = decodeBinaryRegexpBytes(result)
+		if strings.ContainsRune(pureMatchType, 'i') {
+			result = decodeBinaryRegexpText(result)
+		} else {
+			result = decodeBinaryRegexpBytes(result)
+		}
 	}
 	return result, nil
 }
@@ -2249,6 +2543,16 @@ func (rs *regexpSet) regexpReplaceAllAtOrAfter(
 // boundaries relative to the original subject while excluding matches before
 // startByte. The wrapped matcher is cached with the ordinary pattern matchers.
 func (rs *regexpSet) regexpFindAtOrAfter(reg *regexp.Regexp, pat, str string, startByte int, subjectIsBinary bool) (start, end int, found bool, err error) {
+	return rs.regexpFindAtOrAfterWithMatchType(reg, pat, str, startByte, subjectIsBinary, "")
+}
+
+func (rs *regexpSet) regexpFindAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+) (start, end int, found bool, err error) {
 	if startByte <= 0 {
 		indices := reg.FindStringIndex(str)
 		if indices == nil {
@@ -2265,7 +2569,12 @@ func (rs *regexpSet) regexpFindAtOrAfter(reg *regexp.Regexp, pat, str string, st
 	if size < 1 {
 		contextStart = startByte - 1
 	}
-	wrapped, err := rs.getRegularMatcherWithMode("^(?s:.)(?s:.*?)("+pat+")", subjectIsBinary)
+	wrappedPattern := "^(?s:.)(?s:.*?)(" + regexpPatternWithPureMatchType(pat, pureMatchType) + ")"
+	wrapped, _, err := rs.getRegularMatcherInfoWithBinaryCaseFold(
+		wrappedPattern,
+		subjectIsBinary,
+		subjectIsBinary && strings.ContainsRune(pureMatchType, 'i'),
+	)
 	if err != nil {
 		return 0, 0, false, err
 	}
@@ -2526,10 +2835,47 @@ func (rs *regexpSet) getRegularLikeMatcherForPureMatchTypeWithMode(
 	if err := validateRegexpPattern(pat); err != nil {
 		return nil, err
 	}
-	rule := fmt.Sprintf("(?%s)%s", pureMatchType, pat)
-	binaryCaseFold := binary && strings.ContainsRune(pureMatchType, 'i')
-	reg, _, err := rs.getRegularMatcherInfoWithBinaryCaseFold(rule, binary, binaryCaseFold)
+	reg, _, err := rs.getRegularMatcherInfoWithMatchType(pat, pureMatchType, binary)
 	return reg, err
+}
+
+func regexpPatternWithPureMatchType(pat, pureMatchType string) string {
+	if pureMatchType == "" {
+		return pat
+	}
+	return "(?" + pureMatchType + ")" + pat
+}
+
+func (rs *regexpSet) getRegularMatcherInfoWithMatchType(
+	pat, pureMatchType string,
+	binary bool,
+) (*regexp.Regexp, bool, error) {
+	rule := regexpPatternWithPureMatchType(pat, pureMatchType)
+	binaryCaseFold := binary && strings.ContainsRune(pureMatchType, 'i')
+	return rs.getRegularMatcherInfoWithBinaryCaseFold(rule, binary, binaryCaseFold)
+}
+
+func (rs *regexpSet) getRegularMatcherWithMatchType(
+	pat, pureMatchType string,
+	binary bool,
+) (*regexp.Regexp, error) {
+	reg, _, err := rs.getRegularMatcherInfoWithMatchType(pat, pureMatchType, binary)
+	return reg, err
+}
+
+func (rs *regexpSet) getCompiledRegexpWithMatchType(
+	pat, pureMatchType string,
+	binary bool,
+	functionName string,
+) (*regexp.Regexp, error) {
+	if err := validateRegexpPattern(pat); err != nil {
+		return nil, err
+	}
+	reg, err := rs.getRegularMatcherWithMatchType(pat, pureMatchType, binary)
+	if err == nil {
+		return reg, nil
+	}
+	return nil, regexpCompileError(functionName, pat, err)
 }
 
 func regexpMatchCompiled(reg *regexp.Regexp, str string, binary, binaryCaseFold bool) bool {
@@ -2556,11 +2902,13 @@ func (rs *regexpSet) regularLikeWithMode(pat string, str string, matchType strin
 		reg, str, binary, binary && strings.ContainsRune(pureMatchType, 'i')), nil
 }
 
-// Support four arguments:
+// Parse MySQL match_type flags:
 // i: case insensitive.
 // c: case sensitive.
 // m: multiple line mode.
 // n: '.' can match line terminator.
+// u: Unix-only line endings. Go regexp already treats LF as its only line
+// terminator, so this flag does not require an additional engine option.
 // Binary operands default to case-sensitive matching, but an explicit i or c
 // still overrides that default.  The rightmost case flag wins in both domains;
 // high bytes use MySQL's Windows-1252 binary facade while explicit i is active.
@@ -2586,6 +2934,9 @@ func getPureMatchType(input string) (string, error) {
 				retstring += "s"
 				foundn = true
 			}
+		case 'u':
+			// Go regexp uses LF as its only line terminator, which is the
+			// Unix-lines behavior requested by MySQL's explicit u option.
 		default:
 			return "", moerr.NewInvalidInputNoCtx("regexp_like got invalid match_type input!")
 		}

--- a/pkg/sql/plan/function/func_builtin_regexp.go
+++ b/pkg/sql/plan/function/func_builtin_regexp.go
@@ -2477,16 +2477,6 @@ func (rs *regexpSet) regexpVisitAtOrAfterWithMatchType(
 	return nil
 }
 
-func (rs *regexpSet) regexpReplaceAllAtOrAfter(
-	reg *regexp.Regexp,
-	pat, str, repl string,
-	startByte int,
-	subjectIsBinary bool,
-) (string, error) {
-	return rs.regexpReplaceAllAtOrAfterWithMatchType(
-		reg, pat, str, repl, startByte, subjectIsBinary, "")
-}
-
 func (rs *regexpSet) regexpReplaceAllAtOrAfterWithMatchType(
 	reg *regexp.Regexp,
 	pat, str, repl string,
@@ -2537,15 +2527,11 @@ func (rs *regexpSet) regexpReplaceAllAtOrAfterWithMatchType(
 	return result, nil
 }
 
-// regexpFindAtOrAfter supplies the context that slicing at startByte would
-// lose. The wrapper consumes exactly the preceding text unit, then lazily
-// searches for the original pattern. This keeps ^, multiline ^, and word
-// boundaries relative to the original subject while excluding matches before
-// startByte. The wrapped matcher is cached with the ordinary pattern matchers.
-func (rs *regexpSet) regexpFindAtOrAfter(reg *regexp.Regexp, pat, str string, startByte int, subjectIsBinary bool) (start, end int, found bool, err error) {
-	return rs.regexpFindAtOrAfterWithMatchType(reg, pat, str, startByte, subjectIsBinary, "")
-}
-
+// regexpFindAtOrAfterWithMatchType supplies context lost by slicing at
+// startByte. It consumes exactly the preceding text unit, then lazily searches
+// for the original pattern. This keeps ^, multiline ^, and word boundaries
+// relative to the original subject while excluding matches before startByte.
+// The wrapped matcher is cached with the ordinary pattern matchers.
 func (rs *regexpSet) regexpFindAtOrAfterWithMatchType(
 	reg *regexp.Regexp,
 	pat, str string,

--- a/pkg/sql/plan/function/func_builtin_regexp_test.go
+++ b/pkg/sql/plan/function/func_builtin_regexp_test.go
@@ -145,6 +145,112 @@ func Test_BuiltIn_RegexpReplaceStartsAtRequestedPosition(t *testing.T) {
 	require.Empty(t, got, "MySQL leaves an empty REGEXP_REPLACE subject unchanged")
 }
 
+func Test_BuiltIn_RegexpReplaceCaptureTemplate(t *testing.T) {
+	op := newOpBuiltInRegexp()
+	tests := []struct {
+		name        string
+		pattern     string
+		subject     string
+		replacement string
+		position    int64
+		occurrence  int64
+		want        string
+	}{
+		{name: "swap_groups", pattern: "(a)(b)", subject: "ab", replacement: "$2$1", position: 1, occurrence: 0, want: "ba"},
+		{name: "whole_match", pattern: "(ab)", subject: "ab", replacement: "$0", position: 1, occurrence: 1, want: "ab"},
+		{name: "greedy_multi_digit", pattern: "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)", subject: "abcdefghijkl", replacement: "$12", position: 1, occurrence: 1, want: "l"},
+		{name: "greedy_fallback", pattern: "(a)", subject: "a", replacement: "$12", position: 1, occurrence: 1, want: "a2"},
+		{name: "leading_zero_group", pattern: "(a)", subject: "a", replacement: "$01", position: 1, occurrence: 1, want: "a"},
+		{name: "leading_zero_fallback", pattern: "(a)", subject: "a", replacement: "$09", position: 1, occurrence: 1, want: "a9"},
+		{name: "unmatched_optional_group", pattern: "(a)?b", subject: "b", replacement: "$1x", position: 1, occurrence: 1, want: "x"},
+		{name: "named_group", pattern: "(?P<word>[a-z]+)", subject: "matrix", replacement: "<$" + "{word}>", position: 1, occurrence: 1, want: "<matrix>"},
+		{name: "escaped_dollar", pattern: "(a)", subject: "a", replacement: "\\$1", position: 1, occurrence: 1, want: "$1"},
+		{name: "escaped_backslash", pattern: "(a)", subject: "a", replacement: "\\\\", position: 1, occurrence: 1, want: "\\"},
+		{name: "trailing_escape", pattern: "(a)", subject: "a", replacement: "tail\\", position: 1, occurrence: 1, want: "tail"},
+		{name: "position_all", pattern: "(a)", subject: "aab", replacement: "<$1>", position: 2, occurrence: 0, want: "a<a>b"},
+		{name: "selected_occurrence", pattern: "(a)", subject: "aab", replacement: "<$1>", position: 1, occurrence: 2, want: "a<a>b"},
+		{name: "boundary_overlapping_match", pattern: "(aa)", subject: "aaa", replacement: "<$1>", position: 2, occurrence: 1, want: "a<aa>"},
+		{name: "anchor_keeps_original_context", pattern: "^(a)", subject: "ab", replacement: "<$1>", position: 2, occurrence: 0, want: "ab"},
+		{name: "zero_width_empty_capture", pattern: "(?P<empty>)", subject: "ab", replacement: "[$1]", position: 1, occurrence: 0, want: "[]a[]b[]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := op.regMap.regularReplaceWithMatchType(
+				tc.pattern, tc.subject, tc.replacement, tc.position, tc.occurrence, false, "")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	for _, replacement := range []string{"$", "$$", "$x", "$" + "{}", "$" + "{missing}", "$2"} {
+		t.Run("invalid_"+replacement, func(t *testing.T) {
+			_, err := op.regMap.regularReplace("(a)", "a", replacement, 1, 0)
+			require.Error(t, err)
+
+			got, err := op.regMap.regularReplace("z", "a", replacement, 1, 0)
+			require.NoError(t, err, "replacement is not evaluated when no match is selected")
+			require.Equal(t, "a", got)
+		})
+	}
+	got, err := op.regMap.regularReplace("(a)", "a", "$9", 1, 2)
+	require.NoError(t, err, "an out-of-range occurrence does not evaluate the replacement")
+	require.Equal(t, "a", got)
+
+	binarySubject := string([]byte{0x00, 0xff, 0xc3, 0x28})
+	got, err = op.regMap.regularReplaceWithMatchType(
+		".", binarySubject, "[$0]", 1, 0, true, "")
+	require.NoError(t, err)
+	want := []byte{'[', 0x00, ']', '[', 0xff, ']', '[', 0xc3, ']', '[', 0x28, ']'}
+	require.Equal(t, string(want), got, "binary captures preserve NUL and invalid UTF-8 bytes")
+
+	pureMatchType, err := getPureMatchType("i")
+	require.NoError(t, err)
+	got, err = op.regMap.regularReplaceWithMatchType(
+		string([]byte{0xe9}), string([]byte{0xc9}), "<$0>", 1, 1, true, pureMatchType)
+	require.NoError(t, err)
+	require.Equal(t, string([]byte{'<', 0xc9, '>'}), got,
+		"binary case-folding must emit the original captured byte")
+
+	largeReplacement := strings.Repeat("$0", 10000)
+	got, err = op.regMap.regularReplace("(a)", "a", largeReplacement, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("a", 10000), got)
+}
+
+func Test_BuiltIn_RegexpReplaceOutputLimit(t *testing.T) {
+	op := newOpBuiltInRegexp()
+	reg, _, err := op.regMap.getRegularMatcherInfoWithMode("(a)", false)
+	require.NoError(t, err)
+	got, err := op.regMap.regularReplaceWithTemplate(
+		reg, "(a)", "a", "$1$1", 0, 0, false, "", 2)
+	require.NoError(t, err)
+	require.Equal(t, "aa", got, "exactly-at-limit output is accepted")
+	_, err = op.regMap.regularReplaceWithTemplate(
+		reg, "(a)", "a", "$1$1", 0, 0, false, "", 1)
+	require.Error(t, err, "one byte below the required output is rejected before construction")
+
+	regA, _, err := op.regMap.getRegularMatcherInfoWithMode("a", false)
+	require.NoError(t, err)
+	got, err = op.regMap.regexpReplaceLiteralWithLimit(
+		regA, "a", "aaaa", "aa", 0, 0, false, "", 8)
+	require.NoError(t, err)
+	require.Equal(t, "aaaaaaaa", got)
+	_, err = op.regMap.regexpReplaceLiteralWithLimit(
+		regA, "a", "aaaa", "aa", 0, 0, false, "", 7)
+	require.Error(t, err)
+
+	regZ, _, err := op.regMap.getRegularMatcherInfoWithMode("z", false)
+	require.NoError(t, err)
+	got, err = op.regMap.regularReplaceWithTemplate(
+		regZ, "z", "a", "$999", 0, 0, false, "", 1)
+	require.NoError(t, err, "a no-match result stays unchanged and does not parse an invalid template")
+	require.Equal(t, "a", got)
+
+	maxInt := int(^uint(0) >> 1)
+	_, ok := regexpReplaceOutputUpperBound(maxInt, maxInt)
+	require.False(t, ok, "the allocation bound must reject arithmetic overflow")
+}
+
 func Test_BuiltIn_RegexpValueFunctionsHonorMatchType(t *testing.T) {
 	op := newOpBuiltInRegexp()
 	pureMatchType := func(input string) string {

--- a/pkg/sql/plan/function/func_builtin_regexp_test.go
+++ b/pkg/sql/plan/function/func_builtin_regexp_test.go
@@ -145,6 +145,174 @@ func Test_BuiltIn_RegexpReplaceStartsAtRequestedPosition(t *testing.T) {
 	require.Empty(t, got, "MySQL leaves an empty REGEXP_REPLACE subject unchanged")
 }
 
+func Test_BuiltIn_RegexpValueFunctionsHonorMatchType(t *testing.T) {
+	op := newOpBuiltInRegexp()
+	pureMatchType := func(input string) string {
+		t.Helper()
+		pure, err := getPureMatchType(input)
+		require.NoError(t, err, input)
+		return pure
+	}
+
+	for _, tc := range []struct {
+		name string
+		mode string
+		want int64
+	}{
+		{name: "case_insensitive", mode: "i", want: 1},
+		{name: "case_sensitive", mode: "c", want: 5},
+		{name: "rightmost_c_wins", mode: "ic", want: 5},
+		{name: "rightmost_i_wins", mode: "ci", want: 1},
+	} {
+		t.Run("instr_"+tc.name, func(t *testing.T) {
+			got, err := op.regMap.regularInstrWithMatchType(
+				"abc", "Abc abc", 1, 1, 0, false, pureMatchType(tc.mode))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	instrGot, err := op.regMap.regularInstrWithMatchType(
+		"^b", "a\nb", 1, 1, 0, false, pureMatchType("m"))
+	require.NoError(t, err)
+	require.EqualValues(t, 3, instrGot)
+	instrGot, err = op.regMap.regularInstrWithMatchType(
+		"^b", "a\nb", 1, 1, 0, false, pureMatchType("c"))
+	require.NoError(t, err)
+	require.Zero(t, instrGot)
+	instrGot, err = op.regMap.regularInstrWithMatchType(
+		"^", "a\nb", 1, 2, 0, false, pureMatchType("m"))
+	require.NoError(t, err)
+	require.EqualValues(t, 3, instrGot, "the second multiline zero-width anchor is still a match")
+
+	for _, tc := range []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "case_insensitive", mode: "i", want: "Abc"},
+		{name: "case_sensitive", mode: "c", want: "abc"},
+		{name: "multiline_anchor_after_position", mode: "m", want: "b"},
+	} {
+		t.Run("substr_"+tc.name, func(t *testing.T) {
+			subject, pattern, pos := "Abc abc", "abc", int64(1)
+			if tc.mode == "m" {
+				subject, pattern, pos = "a\nb", "^b", 3
+			}
+			matched, got, err := op.regMap.regularSubstrWithMatchType(
+				pattern, subject, pos, 1, false, pureMatchType(tc.mode))
+			require.NoError(t, err)
+			require.True(t, matched)
+			require.Equal(t, tc.want, got)
+		})
+	}
+	matched, substrGot, err := op.regMap.regularSubstrWithMatchType(
+		"^b", "a\nb", 3, 1, false, pureMatchType("c"))
+	require.NoError(t, err)
+	require.False(t, matched)
+	require.Empty(t, substrGot)
+	matched, substrGot, err = op.regMap.regularSubstrWithMatchType(
+		"^", "a\nb", 3, 1, false, pureMatchType("m"))
+	require.NoError(t, err)
+	require.True(t, matched, "a zero-width match is distinct from no match")
+	require.Empty(t, substrGot)
+
+	for _, tc := range []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "case_insensitive", mode: "i", want: "X X"},
+		{name: "case_sensitive", mode: "c", want: "Abc X"},
+	} {
+		t.Run("replace_"+tc.name, func(t *testing.T) {
+			got, err := op.regMap.regularReplaceWithMatchType(
+				"abc", "Abc abc", "X", 1, 0, false, pureMatchType(tc.mode))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+	replaceGot, err := op.regMap.regularReplaceWithMatchType(
+		"^b", "a\nb", "X", 3, 1, false, pureMatchType("m"))
+	require.NoError(t, err)
+	require.Equal(t, "a\nX", replaceGot,
+		"the position-aware iterator must compile its wrapped matcher with match_type flags")
+	replaceGot, err = op.regMap.regularReplaceWithMatchType(
+		"aa", "aaa", "X", 2, 1, false, pureMatchType("c"))
+	require.NoError(t, err)
+	require.Equal(t, "aX", replaceGot, "a discarded overlap must not suppress a match starting at pos")
+	replaceGot, err = op.regMap.regularReplaceWithMatchType(
+		"^", "a\nb", "X", 3, 1, false, pureMatchType("m"))
+	require.NoError(t, err)
+	require.Equal(t, "a\nXb", replaceGot, "a zero-width multiline match at pos remains observable")
+
+	for _, tc := range []struct {
+		name string
+		mode string
+		want int64
+	}{
+		{name: "binary_i_folds_windows_1252_bytes", mode: "i", want: 2},
+		{name: "binary_c_preserves_byte_case", mode: "c", want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			subject := string([]byte{0x78, 0xc9})
+			pattern := string([]byte{0xe9})
+			got, err := op.regMap.regularInstrWithMatchType(
+				pattern, subject, 1, 1, 0, true, pureMatchType(tc.mode))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	binarySubject := string([]byte{0x78, 0xc9})
+	binaryPattern := string([]byte{0xe9})
+	matched, substrGot, err = op.regMap.regularSubstrWithMatchType(
+		binaryPattern, binarySubject, 1, 1, true, pureMatchType("i"))
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, string([]byte{0xc9}), substrGot)
+	replaceGot, err = op.regMap.regularReplaceWithMatchType(
+		binaryPattern, binarySubject, "X", 1, 0, true, pureMatchType("i"))
+	require.NoError(t, err)
+	require.Equal(t, "xX", replaceGot)
+
+	// UTF-8-looking bytes are still byte positions for binary operands, including
+	// a start position inside the first encoded character.
+	binarySubject, binaryPattern = "中中", "中"
+	instrGot, err = op.regMap.regularInstrWithMatchType(
+		binaryPattern, binarySubject, 2, 1, 0, true, pureMatchType("i"))
+	require.NoError(t, err)
+	require.EqualValues(t, 4, instrGot)
+	matched, substrGot, err = op.regMap.regularSubstrWithMatchType(
+		binaryPattern, binarySubject, 2, 1, true, pureMatchType("i"))
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, "中", substrGot)
+	replaceGot, err = op.regMap.regularReplaceWithMatchType(
+		binaryPattern, binarySubject, "X", 2, 1, true, pureMatchType("i"))
+	require.NoError(t, err)
+	require.Equal(t, "中X", replaceGot)
+}
+
+func TestRegexpMatchTypeParser(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{input: "u", want: ""},
+		{input: "mu", want: "m"},
+		{input: "nu", want: "s"},
+		{input: "ic", want: ""},
+		{input: "ci", want: "i"},
+	} {
+		got, err := getPureMatchType(tc.input)
+		require.NoError(t, err, tc.input)
+		require.Equal(t, tc.want, got, tc.input)
+	}
+	_, err := getPureMatchType("z")
+	require.Error(t, err)
+}
+
 func Test_BuiltIn_RegexpPositiveOccurrenceReturnsOnlyRequestedMatch(t *testing.T) {
 	op := newOpBuiltInRegexp()
 	const subject = "aaaaaaaaaaaaaaaa"
@@ -717,6 +885,20 @@ func TestRegexpBinaryBytesToText(t *testing.T) {
 	require.Equal(t, string(latin1Runes),
 		regexpBinaryBytesToText(string(latin1Bytes)))
 
+	allBytes := make([]byte, 256)
+	for i := range allBytes {
+		allBytes[i] = byte(i)
+	}
+	allBinary := string(allBytes)
+	encoded := regexpBinaryBytesToText(allBinary)
+	require.Equal(t, allBinary, decodeBinaryRegexpText(encoded),
+		"the binary i facade must round-trip every possible byte")
+	for start := 0; start <= len(allBinary); start++ {
+		encoded, encodedStart := encodeBinaryRegexpText(allBinary, start)
+		require.Equal(t, allBinary[:start], decodeBinaryRegexpText(encoded[:encodedStart]),
+			"position %d must map to an encoded rune boundary", start)
+	}
+
 	proc := testutil.NewProcess(t)
 	constantBinary, err := vector.NewConstBytes(types.T_blob.ToType(), []byte{0xff}, 2, proc.Mp())
 	require.NoError(t, err)
@@ -797,6 +979,44 @@ func Test_BuiltIn_RegexpHonorsSelectList(t *testing.T) {
 			expected: NewFunctionTestResult(types.T_bool.ToType(), false, []bool{true, false}, []bool{false, true}),
 			fn:       newOpBuiltInRegexp().builtInRegexpLike,
 		},
+		{
+			name: "regexp_instr_match_type",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"Abc abc", "a"}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"abc", "["}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{1, 1}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{1, 1}, nil),
+				NewFunctionTestInput(types.T_int8.ToType(), []int8{0, 0}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"i", "invalid"}, nil),
+			},
+			expected: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{1, 0}, []bool{false, true}),
+			fn:       newOpBuiltInRegexp().builtInRegexpInstr,
+		},
+		{
+			name: "regexp_substr_match_type",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"Abc abc", "a"}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"abc", "["}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{1, 1}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{1, 1}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"i", "invalid"}, nil),
+			},
+			expected: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"Abc", ""}, []bool{false, true}),
+			fn:       newOpBuiltInRegexp().builtInRegexpSubstr,
+		},
+		{
+			name: "regexp_replace_match_type",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"Abc abc", "a"}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"abc", "["}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"X", "X"}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{1, 1}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{0, 0}, nil),
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"i", "invalid"}, nil),
+			},
+			expected: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"X X", ""}, []bool{false, true}),
+			fn:       newOpBuiltInRegexp().builtInRegexpReplace,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ft := NewFunctionTestCase(proc, tc.inputs, tc.expected, tc.fn).WithSelectList(maskedSecond)
@@ -809,6 +1029,9 @@ func Test_BuiltIn_RegexpHonorsSelectList(t *testing.T) {
 func TestRegexpFunctionsPreserveBinaryOverloadDomain(t *testing.T) {
 	for _, oid := range []types.T{types.T_binary, types.T_varbinary, types.T_blob} {
 		subject := types.New(oid, 32, 0)
+		text := types.T_varchar.ToType()
+		int64Type := types.T_int64.ToType()
+		int8Type := types.T_int8.ToType()
 		for _, tc := range []struct {
 			name string
 			args []types.Type
@@ -817,6 +1040,9 @@ func TestRegexpFunctionsPreserveBinaryOverloadDomain(t *testing.T) {
 			{name: "regexp_instr", args: []types.Type{subject, subject}},
 			{name: "regexp_substr", args: []types.Type{subject, subject}},
 			{name: "regexp_replace", args: []types.Type{subject, subject, subject}},
+			{name: "regexp_instr", args: []types.Type{subject, subject, int64Type, int64Type, int8Type, text}},
+			{name: "regexp_substr", args: []types.Type{subject, subject, int64Type, int64Type, text}},
+			{name: "regexp_replace", args: []types.Type{subject, subject, subject, int64Type, int64Type, text}},
 		} {
 			resolved, err := GetFunctionByName(context.Background(), tc.name, tc.args)
 			require.NoError(t, err)
@@ -847,15 +1073,19 @@ func TestRegexpFunctionsRejectStaticMixedStringDomains(t *testing.T) {
 		{name: "not_reg_match_pattern", args: []types.Type{text, binary}},
 		{name: "regexp_like_subject", args: []types.Type{binary, text, text}},
 		{name: "regexp_instr_pattern", args: []types.Type{text, binary, int64Type, int64Type, int8Type}},
+		{name: "regexp_instr_match_type_pattern", args: []types.Type{text, binary, int64Type, int64Type, int8Type, text}},
 		{name: "regexp_substr_subject", args: []types.Type{binary, text, int64Type, int64Type}},
+		{name: "regexp_substr_match_type_pattern", args: []types.Type{text, binary, int64Type, int64Type, text}},
 		{name: "regexp_replace_subject", args: []types.Type{binary, text, text, int64Type, int64Type}},
 		{name: "regexp_replace_pattern", args: []types.Type{text, binary, text}},
 		{name: "regexp_replace_replacement", args: []types.Type{text, text, binary}},
+		{name: "regexp_replace_match_type_replacement", args: []types.Type{text, text, binary, int64Type, int64Type, text}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			functionName := strings.TrimSuffix(tc.name, "_subject")
 			functionName = strings.TrimSuffix(functionName, "_pattern")
 			functionName = strings.TrimSuffix(functionName, "_replacement")
+			functionName = strings.TrimSuffix(functionName, "_match_type")
 			_, err := GetFunctionByName(ctx, functionName, tc.args)
 			require.Error(t, err)
 			var moErr *moerr.Error
@@ -1444,12 +1674,15 @@ func Test_BuiltIn_RegexpValidatesPresentArgumentsBeforeNullableResult(t *testing
 		{name: "instr_3_null_position", fn: newOpBuiltInRegexp().builtInRegexpInstr, inputs: []FunctionTestInput{validText, invalidPattern, nullInt64}, resultType: int64Type},
 		{name: "instr_4_null_occurrence", fn: newOpBuiltInRegexp().builtInRegexpInstr, inputs: []FunctionTestInput{validText, invalidPattern, NewFunctionTestInput(int64Type, []int64{1}, nil), nullInt64}, resultType: int64Type},
 		{name: "instr_5_null_result_option", fn: newOpBuiltInRegexp().builtInRegexpInstr, inputs: []FunctionTestInput{validText, invalidPattern, NewFunctionTestInput(int64Type, []int64{1}, nil), NewFunctionTestInput(int64Type, []int64{1}, nil), nullInt8}, resultType: int64Type},
+		{name: "instr_6_invalid_match_type_before_null_subject", fn: newOpBuiltInRegexp().builtInRegexpInstr, inputs: []FunctionTestInput{nullText, validPattern, NewFunctionTestInput(int64Type, []int64{1}, nil), NewFunctionTestInput(int64Type, []int64{1}, nil), NewFunctionTestInput(int8Type, []int8{0}, nil), invalidMatchType}, resultType: int64Type},
 		{name: "substr_2_null_subject", fn: newOpBuiltInRegexp().builtInRegexpSubstr, inputs: []FunctionTestInput{nullText, invalidPattern}, resultType: text},
 		{name: "substr_3_null_position", fn: newOpBuiltInRegexp().builtInRegexpSubstr, inputs: []FunctionTestInput{validText, invalidPattern, nullInt64}, resultType: text},
 		{name: "substr_4_null_occurrence", fn: newOpBuiltInRegexp().builtInRegexpSubstr, inputs: []FunctionTestInput{validText, invalidPattern, NewFunctionTestInput(int64Type, []int64{1}, nil), nullInt64}, resultType: text},
+		{name: "substr_5_invalid_match_type_before_null_subject", fn: newOpBuiltInRegexp().builtInRegexpSubstr, inputs: []FunctionTestInput{nullText, validPattern, NewFunctionTestInput(int64Type, []int64{1}, nil), NewFunctionTestInput(int64Type, []int64{1}, nil), invalidMatchType}, resultType: text},
 		{name: "replace_3_null_replacement", fn: newOpBuiltInRegexp().builtInRegexpReplace, inputs: []FunctionTestInput{validText, invalidPattern, nullText}, resultType: text},
 		{name: "replace_4_null_position", fn: newOpBuiltInRegexp().builtInRegexpReplace, inputs: []FunctionTestInput{validText, invalidPattern, validText, nullInt64}, resultType: text},
 		{name: "replace_5_null_occurrence", fn: newOpBuiltInRegexp().builtInRegexpReplace, inputs: []FunctionTestInput{validText, invalidPattern, validText, NewFunctionTestInput(int64Type, []int64{1}, nil), nullInt64}, resultType: text},
+		{name: "replace_6_invalid_match_type_before_null_subject", fn: newOpBuiltInRegexp().builtInRegexpReplace, inputs: []FunctionTestInput{nullText, validPattern, validText, NewFunctionTestInput(int64Type, []int64{1}, nil), NewFunctionTestInput(int64Type, []int64{1}, nil), invalidMatchType}, resultType: text},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tcc := NewFunctionTestCase(
@@ -1461,14 +1694,66 @@ func Test_BuiltIn_RegexpValidatesPresentArgumentsBeforeNullableResult(t *testing
 	}
 
 	nullMatchType := NewFunctionTestInput(text, []string{""}, []bool{true})
-	control := NewFunctionTestCase(
-		proc,
-		[]FunctionTestInput{nullText, invalidPattern, nullMatchType},
-		NewFunctionTestResult(types.T_bool.ToType(), false, []bool{false}, []bool{true}),
-		newOpBuiltInRegexp().builtInRegexpLike,
-	)
-	ok, info := control.Run()
-	require.True(t, ok, info, "a NULL match_type remains the earlier NULL result boundary")
+	for _, tc := range []struct {
+		name       string
+		fn         fEvalFn
+		inputs     []FunctionTestInput
+		resultType types.Type
+		values     any
+	}{
+		{
+			name:       "regexp_like",
+			fn:         newOpBuiltInRegexp().builtInRegexpLike,
+			inputs:     []FunctionTestInput{nullText, invalidPattern, nullMatchType},
+			resultType: types.T_bool.ToType(),
+			values:     []bool{false},
+		},
+		{
+			name: "regexp_instr",
+			fn:   newOpBuiltInRegexp().builtInRegexpInstr,
+			inputs: []FunctionTestInput{
+				nullText, invalidPattern,
+				NewFunctionTestInput(int64Type, []int64{1}, nil),
+				NewFunctionTestInput(int64Type, []int64{1}, nil),
+				NewFunctionTestInput(int8Type, []int8{0}, nil),
+				nullMatchType,
+			},
+			resultType: int64Type,
+			values:     []int64{0},
+		},
+		{
+			name: "regexp_substr",
+			fn:   newOpBuiltInRegexp().builtInRegexpSubstr,
+			inputs: []FunctionTestInput{
+				nullText, invalidPattern,
+				NewFunctionTestInput(int64Type, []int64{1}, nil),
+				NewFunctionTestInput(int64Type, []int64{1}, nil),
+				nullMatchType,
+			},
+			resultType: text,
+			values:     []string{""},
+		},
+		{
+			name: "regexp_replace",
+			fn:   newOpBuiltInRegexp().builtInRegexpReplace,
+			inputs: []FunctionTestInput{
+				nullText, invalidPattern, validText,
+				NewFunctionTestInput(int64Type, []int64{1}, nil),
+				NewFunctionTestInput(int64Type, []int64{0}, nil),
+				nullMatchType,
+			},
+			resultType: text,
+			values:     []string{""},
+		},
+	} {
+		control := NewFunctionTestCase(
+			proc, tc.inputs,
+			NewFunctionTestResult(tc.resultType, false, tc.values, []bool{true}),
+			tc.fn,
+		)
+		ok, info := control.Run()
+		require.True(t, ok, "%s: %s", tc.name, info)
+	}
 }
 
 func Test_BuiltIn_RegexpLikeRejectsEmptyPattern(t *testing.T) {

--- a/pkg/sql/plan/function/func_builtin_regexp_test.go
+++ b/pkg/sql/plan/function/func_builtin_regexp_test.go
@@ -132,6 +132,14 @@ func Test_BuiltIn_RegexpReplaceStartsAtRequestedPosition(t *testing.T) {
 		{name: "zero_width_after_nonempty_match", pattern: "b*", subject: "ab", replacement: "X", position: 2, occurrence: 0, want: "aXX"},
 		{name: "zero_width_all_from_start", pattern: "a*", subject: "abc", replacement: "X", position: 1, occurrence: 0, want: "XXbXcX"},
 		{name: "zero_width_all_after_position", pattern: "a*", subject: "abc", replacement: "X", position: 2, occurrence: 0, want: "aXbXcX"},
+		{name: "open_quote_replace_all", pattern: "(a)\\Q.", subject: "a.a.", replacement: "$1", position: 1, occurrence: 0, want: "aa"},
+		{name: "open_quote_selected_after_position", pattern: "(a)\\Q.", subject: "xa.a.", replacement: "$1", position: 2, occurrence: 1, want: "xaa."},
+		{name: "open_quote_replace_all_after_position", pattern: "(a)\\Q.", subject: "xa.a.", replacement: "$1", position: 2, occurrence: 0, want: "xaa"},
+		{name: "explicit_quote_close", pattern: "(a)\\Q.\\E", subject: "a.a.", replacement: "$1", position: 1, occurrence: 0, want: "aa"},
+		{name: "escaped_backslash_before_open_quote", pattern: "(a)\\\\\\Q.", subject: "a\\.a\\.", replacement: "$1", position: 1, occurrence: 0, want: "aa"},
+		{name: "quoted_backslash_before_terminator", pattern: "(a)\\Q\\\\E", subject: "a\\a\\", replacement: "$1", position: 1, occurrence: 0, want: "aa"},
+		{name: "quoted_backslash_terminator_after_position", pattern: "(a)\\Q\\\\E", subject: "xa\\a\\", replacement: "X", position: 2, occurrence: 0, want: "xXX"},
+		{name: "escaped_backslash_two_byte_control", pattern: "(a)\\\\\\Q.", subject: "a\\\\.a\\\\.", replacement: "X", position: 2, occurrence: 0, want: "a\\\\.a\\\\."},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := op.regMap.regularReplace(tc.pattern, tc.subject, tc.replacement, tc.position, tc.occurrence)
@@ -139,6 +147,27 @@ func Test_BuiltIn_RegexpReplaceStartsAtRequestedPosition(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+
+	quotedPattern := "(a)\\Q."
+	position, err := op.regMap.regularInstr(quotedPattern, "xa.a.", 2, 2, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), position)
+	matched, part, err := op.regMap.regularSubstr(quotedPattern, "xa.a.", 2, 2)
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, "a.", part)
+	quotedBackslashPattern := "(a)\\Q\\\\E"
+	position, err = op.regMap.regularInstr(quotedBackslashPattern, "xa\\a\\", 2, 2, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), position)
+	matched, part, err = op.regMap.regularSubstr(quotedBackslashPattern, "xa\\a\\", 2, 2)
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, "a\\", part)
+	binaryResult, err := op.regMap.regularReplaceWithMode(
+		quotedBackslashPattern, "a\\a\\", "X", 1, 0, true)
+	require.NoError(t, err)
+	require.Equal(t, "XX", binaryResult)
 
 	got, err := op.regMap.regularReplace("^$", "", "X", 1, 0)
 	require.NoError(t, err)

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -3269,6 +3269,16 @@ var supportedStringBuiltIns = []FuncNew{
 					return newOpBuiltInRegexp().builtInRegexpInstr
 				},
 			},
+			{
+				overloadId: 4,
+				args:       []types.T{types.T_varchar, types.T_varchar, types.T_int64, types.T_int64, types.T_int8, types.T_varchar},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return newOpBuiltInRegexp().builtInRegexpInstr
+				},
+			},
 		},
 	},
 
@@ -3343,6 +3353,16 @@ var supportedStringBuiltIns = []FuncNew{
 					return newOpBuiltInRegexp().builtInRegexpReplace
 				},
 			},
+			{
+				overloadId: 3,
+				args:       []types.T{types.T_varchar, types.T_varchar, types.T_varchar, types.T_int64, types.T_int64, types.T_varchar},
+				retType: func(parameters []types.Type) types.Type {
+					return regexpReplaceReturnType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return newOpBuiltInRegexp().builtInRegexpReplace
+				},
+			},
 		},
 	},
 
@@ -3380,6 +3400,16 @@ var supportedStringBuiltIns = []FuncNew{
 			{
 				overloadId: 2,
 				args:       []types.T{types.T_varchar, types.T_varchar, types.T_int64, types.T_int64},
+				retType: func(parameters []types.Type) types.Type {
+					return regexpSubstrReturnType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return newOpBuiltInRegexp().builtInRegexpSubstr
+				},
+			},
+			{
+				overloadId: 3,
+				args:       []types.T{types.T_varchar, types.T_varchar, types.T_int64, types.T_int64, types.T_varchar},
 				retType: func(parameters []types.Type) types.Type {
 					return regexpSubstrReturnType(parameters)
 				},

--- a/pkg/sql/plan/function/regexp_replacement.go
+++ b/pkg/sql/plan/function/regexp_replacement.go
@@ -166,11 +166,11 @@ func parseRegexpReplacementGroup(replacement string, start int, reg *regexp.Rege
 	}
 
 	maxGroup := reg.NumSubexp()
-	group := int(replacement[start] - '0')
+	group = int(replacement[start] - '0')
 	if group > maxGroup {
 		return 0, start, moerr.NewInvalidInputNoCtx("regexp_replace: invalid replacement template")
 	}
-	next := start + 1
+	next = start + 1
 	for next < len(replacement) && replacement[next] >= '0' && replacement[next] <= '9' {
 		digit := int(replacement[next] - '0')
 		if digit > maxGroup || group > (maxGroup-digit)/10 {
@@ -338,7 +338,7 @@ func (rs *regexpSet) regexpFindSubmatchesAtOrAfterWithMatchType(
 	if size < 1 {
 		contextStart = startByte - 1
 	}
-	wrappedPattern := "^(?s:.)(?s:.*?)(" + regexpPatternWithPureMatchType(pat, pureMatchType) + ")"
+	wrappedPattern := regexpPositionSearchPattern(pat, pureMatchType)
 	wrapped, _, err := rs.getRegularMatcherInfoWithBinaryCaseFold(
 		wrappedPattern,
 		subjectIsBinary,

--- a/pkg/sql/plan/function/regexp_replacement.go
+++ b/pkg/sql/plan/function/regexp_replacement.go
@@ -1,0 +1,766 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"encoding/binary"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+)
+
+const regexpReplaceMaxResultBytes = int64(types.MaxBlobLen)
+
+type regexpReplacementTemplate struct {
+	program   []byte
+	groupMask []uint64
+	groupRefs []byte
+	hasGroups bool
+}
+
+func regexpReplacementNeedsExpansion(replacement string) bool {
+	return strings.ContainsAny(replacement, "$\\")
+}
+
+// regexpReplaceOutputUpperBound matches the conservative return-type bound:
+// source + (source+1)*replacement. False means the arithmetic overflowed.
+func regexpReplaceOutputUpperBound(sourceBytes, replacementBytes int) (uint64, bool) {
+	if sourceBytes < 0 || replacementBytes < 0 {
+		return 0, false
+	}
+	source := uint64(sourceBytes)
+	replacement := uint64(replacementBytes)
+	maxUint := ^uint64(0)
+	if source == maxUint {
+		return 0, false
+	}
+	matchSlots := source + 1
+	if replacement != 0 && matchSlots > (maxUint-source)/replacement {
+		return 0, false
+	}
+	return source + matchSlots*replacement, true
+}
+
+func parseRegexpReplacementTemplate(replacement string, reg *regexp.Regexp) (regexpReplacementTemplate, error) {
+	template := regexpReplacementTemplate{
+		program: make([]byte, 0, min(len(replacement), 64<<10)),
+	}
+	for i := 0; i < len(replacement); {
+		switch replacement[i] {
+		case '\\':
+			if i+1 == len(replacement) {
+				// ICU treats a trailing quote character as having no following
+				// character to quote; it contributes no output byte.
+				i = len(replacement)
+				continue
+			}
+			template.program = append(template.program, replacement[i+1])
+			i += 2
+		case '$':
+			if i+1 >= len(replacement) {
+				return regexpReplacementTemplate{}, invalidRegexpReplacementTemplate()
+			}
+			group, next, err := parseRegexpReplacementGroup(replacement, i+1, reg)
+			if err != nil {
+				return regexpReplacementTemplate{}, invalidRegexpReplacementTemplate()
+			}
+			template.appendGroup(group)
+			i = next
+		default:
+			template.program = append(template.program, replacement[i])
+			i++
+		}
+	}
+	return template, nil
+}
+
+func invalidRegexpReplacementTemplate() error {
+	return moerr.NewInvalidInputNoCtx("regexp_replace: invalid replacement template")
+}
+
+func (t *regexpReplacementTemplate) appendGroup(group int) {
+	position := len(t.program)
+	t.program = append(t.program, 0)
+	word := position / 64
+	for len(t.groupMask) <= word {
+		t.groupMask = append(t.groupMask, 0)
+	}
+	t.groupMask[word] |= uint64(1) << uint(position%64)
+	var encoded [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(encoded[:], uint64(group))
+	t.groupRefs = append(t.groupRefs, encoded[:n]...)
+	t.hasGroups = true
+}
+
+func (t *regexpReplacementTemplate) isGroup(position int) bool {
+	return position/64 < len(t.groupMask) &&
+		t.groupMask[position/64]&(uint64(1)<<uint(position%64)) != 0
+}
+
+func (t *regexpReplacementTemplate) visit(visit func(group int, literal []byte) error) error {
+	groupOffset := 0
+	literalStart := 0
+	for position := 0; position < len(t.program); position++ {
+		if !t.isGroup(position) {
+			continue
+		}
+		if literalStart < position {
+			if err := visit(-1, t.program[literalStart:position]); err != nil {
+				return err
+			}
+		}
+		if groupOffset >= len(t.groupRefs) {
+			return moerr.NewInternalErrorNoCtx("regexp_replace: invalid compiled replacement template")
+		}
+		group, n := binary.Uvarint(t.groupRefs[groupOffset:])
+		if n <= 0 {
+			return moerr.NewInternalErrorNoCtx("regexp_replace: invalid compiled replacement template")
+		}
+		groupOffset += n
+		if err := visit(int(group), nil); err != nil {
+			return err
+		}
+		literalStart = position + 1
+	}
+	if literalStart < len(t.program) {
+		return visit(-1, t.program[literalStart:])
+	}
+	return nil
+}
+
+func parseRegexpReplacementGroup(replacement string, start int, reg *regexp.Regexp) (group, next int, err error) {
+	if start >= len(replacement) {
+		return 0, start, moerr.NewInvalidInputNoCtx("regexp_replace: invalid replacement template")
+	}
+	if replacement[start] == '{' {
+		closeRelative := strings.IndexByte(replacement[start+1:], '}')
+		if closeRelative < 0 {
+			return 0, start, moerr.NewInvalidInputNoCtx("regexp_replace: invalid replacement template")
+		}
+		closeAt := start + 1 + closeRelative
+		name := replacement[start+1 : closeAt]
+		group := reg.SubexpIndex(name)
+		if name == "" || group < 0 {
+			return 0, start, moerr.NewInvalidInputNoCtx("regexp_replace: invalid replacement template")
+		}
+		return group, closeAt + 1, nil
+	}
+	if replacement[start] < '0' || replacement[start] > '9' {
+		return 0, start, moerr.NewInvalidInputNoCtx("regexp_replace: invalid replacement template")
+	}
+
+	maxGroup := reg.NumSubexp()
+	group := int(replacement[start] - '0')
+	if group > maxGroup {
+		return 0, start, moerr.NewInvalidInputNoCtx("regexp_replace: invalid replacement template")
+	}
+	next := start + 1
+	for next < len(replacement) && replacement[next] >= '0' && replacement[next] <= '9' {
+		digit := int(replacement[next] - '0')
+		if digit > maxGroup || group > (maxGroup-digit)/10 {
+			break
+		}
+		group = group*10 + digit
+		next++
+	}
+	return group, next, nil
+}
+
+func regexpReplacementSizeError(maxBytes int64) error {
+	return moerr.NewInvalidInputNoCtxf(
+		"regexp_replace result exceeds the maximum supported size of %d bytes", maxBytes)
+}
+
+func regexpAddReplacementSize(current uint64, size int, maxBytes int64) (uint64, error) {
+	if size < 0 || maxBytes < 0 || current > uint64(maxBytes) ||
+		uint64(size) > uint64(maxBytes)-current {
+		return current, regexpReplacementSizeError(maxBytes)
+	}
+	return current + uint64(size), nil
+}
+
+func regexpWriteReplacementString(b *strings.Builder, value string, maxBytes int64) error {
+	if maxBytes < 0 || int64(b.Len()) > maxBytes || int64(len(value)) > maxBytes-int64(b.Len()) {
+		return regexpReplacementSizeError(maxBytes)
+	}
+	b.WriteString(value)
+	return nil
+}
+
+func regexpWriteReplacementBytes(b *strings.Builder, value []byte, maxBytes int64) error {
+	if maxBytes < 0 || int64(b.Len()) > maxBytes || int64(len(value)) > maxBytes-int64(b.Len()) {
+		return regexpReplacementSizeError(maxBytes)
+	}
+	b.Write(value)
+	return nil
+}
+
+func regexpAddTemplateSize(
+	current uint64,
+	str string,
+	indices []int,
+	template regexpReplacementTemplate,
+	maxBytes int64,
+) (uint64, error) {
+	err := template.visit(func(group int, literal []byte) error {
+		if group < 0 {
+			var err error
+			current, err = regexpAddReplacementSize(current, len(literal), maxBytes)
+			return err
+		}
+		pair := group * 2
+		if pair+1 >= len(indices) {
+			return moerr.NewInternalErrorNoCtx("regexp_replace: capture index is out of range")
+		}
+		start, end := indices[pair], indices[pair+1]
+		if start < 0 || end < 0 {
+			return nil
+		}
+		var err error
+		current, err = regexpAddReplacementSize(current, end-start, maxBytes)
+		return err
+	})
+	if err != nil {
+		return current, err
+	}
+	return current, nil
+}
+
+func regexpWriteTemplate(
+	b *strings.Builder,
+	str string,
+	indices []int,
+	template regexpReplacementTemplate,
+	maxBytes int64,
+) error {
+	return template.visit(func(group int, literal []byte) error {
+		if group < 0 {
+			return regexpWriteReplacementBytes(b, literal, maxBytes)
+		}
+		pair := group * 2
+		if pair+1 >= len(indices) {
+			return moerr.NewInternalErrorNoCtx("regexp_replace: capture index is out of range")
+		}
+		start, end := indices[pair], indices[pair+1]
+		if start < 0 || end < 0 {
+			return nil
+		}
+		return regexpWriteReplacementString(b, str[start:end], maxBytes)
+	})
+}
+
+func regexpSearchSubjectAndStart(
+	str string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+) (string, int) {
+	if !subjectIsBinary {
+		return str, startByte
+	}
+	if strings.ContainsRune(pureMatchType, 'i') {
+		return encodeBinaryRegexpText(str, startByte)
+	}
+	return encodeBinaryRegexpBytes(str, startByte)
+}
+
+type regexpOffsetPosition struct {
+	offset int
+	index  int
+}
+
+// regexpBinaryOffsetMapper converts monotonically visited offsets in the
+// one-rune-per-source-byte matcher representation back to source byte offsets.
+type regexpBinaryOffsetMapper struct {
+	encoded       string
+	encodedOffset int
+	sourceOffset  int
+	positions     []regexpOffsetPosition
+}
+
+func (m *regexpBinaryOffsetMapper) byteOffset(encodedOffset int) int {
+	if encodedOffset > m.encodedOffset {
+		m.sourceOffset += utf8.RuneCountInString(m.encoded[m.encodedOffset:encodedOffset])
+		m.encodedOffset = encodedOffset
+	}
+	return m.sourceOffset
+}
+
+func (m *regexpBinaryOffsetMapper) mapSubmatches(indices []int) {
+	positions := m.positions[:0]
+	for i, offset := range indices {
+		if offset >= 0 {
+			positions = append(positions, regexpOffsetPosition{offset: offset, index: i})
+		}
+	}
+	sort.Slice(positions, func(i, j int) bool {
+		return positions[i].offset < positions[j].offset
+	})
+	for _, position := range positions {
+		indices[position.index] = m.byteOffset(position.offset)
+	}
+	m.positions = positions
+}
+
+func (rs *regexpSet) regexpFindSubmatchesAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+) ([]int, bool, error) {
+	if startByte <= 0 {
+		indices := reg.FindStringSubmatchIndex(str)
+		return indices, indices != nil, nil
+	}
+	if startByte > len(str) {
+		return nil, false, nil
+	}
+
+	_, size := utf8.DecodeLastRuneInString(str[:startByte])
+	contextStart := startByte - size
+	if size < 1 {
+		contextStart = startByte - 1
+	}
+	wrappedPattern := "^(?s:.)(?s:.*?)(" + regexpPatternWithPureMatchType(pat, pureMatchType) + ")"
+	wrapped, _, err := rs.getRegularMatcherInfoWithBinaryCaseFold(
+		wrappedPattern,
+		subjectIsBinary,
+		subjectIsBinary && strings.ContainsRune(pureMatchType, 'i'),
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	indices := wrapped.FindStringSubmatchIndex(str[contextStart:])
+	if len(indices) < 4 || indices[2] < 0 {
+		return nil, false, nil
+	}
+	for i := 2; i < len(indices); i++ {
+		if indices[i] >= 0 {
+			indices[i] += contextStart
+		}
+	}
+	return indices[2:], true, nil
+}
+
+func (rs *regexpSet) regexpVisitSubmatchesAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+	limit int64,
+	visit func([]int) error,
+) (int64, error) {
+	searchSubject, searchStart := regexpSearchSubjectAndStart(str, startByte, subjectIsBinary, pureMatchType)
+	mapper := regexpBinaryOffsetMapper{encoded: searchSubject}
+	visited := int64(0)
+	nextStart := searchStart
+	for nextStart <= len(searchSubject) {
+		indices, found, err := rs.regexpFindSubmatchesAtOrAfterWithMatchType(
+			reg, pat, searchSubject, nextStart, subjectIsBinary, pureMatchType)
+		if err != nil {
+			return visited, err
+		}
+		if !found {
+			break
+		}
+		start, end := indices[0], indices[1]
+		if subjectIsBinary {
+			mapper.mapSubmatches(indices)
+		}
+		if err := visit(indices); err != nil {
+			return visited, err
+		}
+		visited++
+		if limit > 0 && visited >= limit {
+			break
+		}
+		if start == end {
+			nextStart = regexpAdvancePosition(searchSubject, end)
+		} else {
+			nextStart = end
+		}
+	}
+	return visited, nil
+}
+
+func (rs *regexpSet) regexpNthSubmatchesAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+	occurrence int64,
+) ([]int, bool, error) {
+	if occurrence < 1 {
+		return nil, false, nil
+	}
+	var selected []int
+	visited, err := rs.regexpVisitSubmatchesAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, pureMatchType, occurrence,
+		func(indices []int) error {
+			selected = append(selected[:0], indices...)
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	return selected, visited >= occurrence, nil
+}
+
+func (rs *regexpSet) regexpVisitMatchesAtOrAfterWithMatchType(
+	reg *regexp.Regexp,
+	pat, str string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+	limit int64,
+	visit func(start, end int) error,
+) (int64, error) {
+	searchSubject, searchStart := regexpSearchSubjectAndStart(str, startByte, subjectIsBinary, pureMatchType)
+	mapper := regexpBinaryOffsetMapper{encoded: searchSubject}
+	visited := int64(0)
+	nextStart := searchStart
+	for nextStart <= len(searchSubject) {
+		start, end, found, err := rs.regexpFindAtOrAfterWithMatchType(
+			reg, pat, searchSubject, nextStart, subjectIsBinary, pureMatchType)
+		if err != nil {
+			return visited, err
+		}
+		if !found {
+			break
+		}
+		encodedStart, encodedEnd := start, end
+		if subjectIsBinary {
+			start = mapper.byteOffset(start)
+			end = mapper.byteOffset(end)
+		}
+		if err := visit(start, end); err != nil {
+			return visited, err
+		}
+		visited++
+		if limit > 0 && visited >= limit {
+			break
+		}
+		if encodedStart == encodedEnd {
+			nextStart = regexpAdvancePosition(searchSubject, encodedEnd)
+		} else {
+			nextStart = encodedEnd
+		}
+	}
+	return visited, nil
+}
+
+func (rs *regexpSet) regexpReplaceLiteralWithLimit(
+	reg *regexp.Regexp,
+	pat, str, repl string,
+	startByte int,
+	occurrence int64,
+	subjectIsBinary bool,
+	pureMatchType string,
+	maxBytes int64,
+) (string, error) {
+	if maxBytes < 0 {
+		return "", regexpReplacementSizeError(maxBytes)
+	}
+	if len(str) == 0 {
+		return str, nil
+	}
+	if occurrence > 0 {
+		match, found, err := rs.regexpNthMatchAtOrAfterWithMatchType(
+			reg, pat, str, startByte, subjectIsBinary, occurrence, pureMatchType)
+		if err != nil {
+			return "", err
+		}
+		if !found {
+			return str, nil
+		}
+		size, err := regexpAddReplacementSize(0, match[0], maxBytes)
+		if err != nil {
+			return "", err
+		}
+		size, err = regexpAddReplacementSize(size, len(repl), maxBytes)
+		if err != nil {
+			return "", err
+		}
+		size, err = regexpAddReplacementSize(size, len(str)-match[1], maxBytes)
+		if err != nil {
+			return "", err
+		}
+		var result strings.Builder
+		result.Grow(int(size))
+		if err := regexpWriteReplacementString(&result, str[:match[0]], maxBytes); err != nil {
+			return "", err
+		}
+		if err := regexpWriteReplacementString(&result, repl, maxBytes); err != nil {
+			return "", err
+		}
+		if err := regexpWriteReplacementString(&result, str[match[1]:], maxBytes); err != nil {
+			return "", err
+		}
+		return result.String(), nil
+	}
+
+	var size uint64
+	last := 0
+	matched := false
+	_, err := rs.regexpVisitMatchesAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, pureMatchType, 0,
+		func(start, end int) error {
+			var writeErr error
+			size, writeErr = regexpAddReplacementSize(size, start-last, maxBytes)
+			if writeErr != nil {
+				return writeErr
+			}
+			size, writeErr = regexpAddReplacementSize(size, len(repl), maxBytes)
+			if writeErr != nil {
+				return writeErr
+			}
+			last = end
+			matched = true
+			return nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if !matched {
+		return str, nil
+	}
+	size, err = regexpAddReplacementSize(size, len(str)-last, maxBytes)
+	if err != nil {
+		return "", err
+	}
+
+	var result strings.Builder
+	result.Grow(int(size))
+	last = 0
+	_, err = rs.regexpVisitMatchesAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, pureMatchType, 0,
+		func(start, end int) error {
+			if writeErr := regexpWriteReplacementString(&result, str[last:start], maxBytes); writeErr != nil {
+				return writeErr
+			}
+			if writeErr := regexpWriteReplacementString(&result, repl, maxBytes); writeErr != nil {
+				return writeErr
+			}
+			last = end
+			return nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if err := regexpWriteReplacementString(&result, str[last:], maxBytes); err != nil {
+		return "", err
+	}
+	if uint64(result.Len()) != size {
+		return "", moerr.NewInternalErrorNoCtx("regexp_replace: output size changed during replacement")
+	}
+	return result.String(), nil
+}
+
+func (rs *regexpSet) regularReplaceWithTemplate(
+	reg *regexp.Regexp,
+	pat, str, replacement string,
+	startByte int,
+	occurrence int64,
+	subjectIsBinary bool,
+	pureMatchType string,
+	maxBytes int64,
+) (string, error) {
+	if maxBytes < 0 {
+		return "", regexpReplacementSizeError(maxBytes)
+	}
+	if occurrence > 0 {
+		indices, found, err := rs.regexpNthSubmatchesAtOrAfterWithMatchType(
+			reg, pat, str, startByte, subjectIsBinary, pureMatchType, occurrence)
+		if err != nil {
+			return "", err
+		}
+		if !found {
+			return str, nil
+		}
+		template, err := parseRegexpReplacementTemplate(replacement, reg)
+		if err != nil {
+			return "", err
+		}
+		if !template.hasGroups {
+			return rs.regexpReplaceLiteralWithLimit(
+				reg, pat, str, regexpReplacementLiteral(template), startByte,
+				occurrence, subjectIsBinary, pureMatchType, maxBytes)
+		}
+		size, err := regexpAddReplacementSize(0, indices[0], maxBytes)
+		if err != nil {
+			return "", err
+		}
+		size, err = regexpAddTemplateSize(size, str, indices, template, maxBytes)
+		if err != nil {
+			return "", err
+		}
+		size, err = regexpAddReplacementSize(size, len(str)-indices[1], maxBytes)
+		if err != nil {
+			return "", err
+		}
+		var result strings.Builder
+		result.Grow(int(size))
+		if err := regexpWriteReplacementString(&result, str[:indices[0]], maxBytes); err != nil {
+			return "", err
+		}
+		if err := regexpWriteTemplate(&result, str, indices, template, maxBytes); err != nil {
+			return "", err
+		}
+		if err := regexpWriteReplacementString(&result, str[indices[1]:], maxBytes); err != nil {
+			return "", err
+		}
+		return result.String(), nil
+	}
+
+	upperBound, bounded := regexpReplaceOutputUpperBound(len(str), len(replacement))
+	if bounded && upperBound <= uint64(maxBytes/2) {
+		var result strings.Builder
+		last := 0
+		parsed := false
+		var template regexpReplacementTemplate
+		_, err := rs.regexpVisitSubmatchesAtOrAfterWithMatchType(
+			reg, pat, str, startByte, subjectIsBinary, pureMatchType, 0,
+			func(indices []int) error {
+				if !parsed {
+					var parseErr error
+					template, parseErr = parseRegexpReplacementTemplate(replacement, reg)
+					if parseErr != nil {
+						return parseErr
+					}
+					result.Grow(min(len(str), 64<<10))
+					parsed = true
+				}
+				if err := regexpWriteReplacementString(&result, str[last:indices[0]], maxBytes); err != nil {
+					return err
+				}
+				if err := regexpWriteTemplate(&result, str, indices, template, maxBytes); err != nil {
+					return err
+				}
+				last = indices[1]
+				return nil
+			},
+		)
+		if err != nil {
+			return "", err
+		}
+		if !parsed {
+			return str, nil
+		}
+		if err := regexpWriteReplacementString(&result, str[last:], maxBytes); err != nil {
+			return "", err
+		}
+		return result.String(), nil
+	}
+
+	template, size, found, err := rs.regexpMeasureAllTemplateOutput(
+		reg, pat, str, replacement, startByte, subjectIsBinary, pureMatchType, maxBytes)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return str, nil
+	}
+	var result strings.Builder
+	result.Grow(int(size))
+	last := 0
+	_, err = rs.regexpVisitSubmatchesAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, pureMatchType, 0,
+		func(indices []int) error {
+			if writeErr := regexpWriteReplacementString(&result, str[last:indices[0]], maxBytes); writeErr != nil {
+				return writeErr
+			}
+			if writeErr := regexpWriteTemplate(&result, str, indices, template, maxBytes); writeErr != nil {
+				return writeErr
+			}
+			last = indices[1]
+			return nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if err := regexpWriteReplacementString(&result, str[last:], maxBytes); err != nil {
+		return "", err
+	}
+	if uint64(result.Len()) != size {
+		return "", moerr.NewInternalErrorNoCtx("regexp_replace: output size changed during replacement")
+	}
+	return result.String(), nil
+}
+
+func regexpReplacementLiteral(template regexpReplacementTemplate) string {
+	return string(template.program)
+}
+
+func (rs *regexpSet) regexpMeasureAllTemplateOutput(
+	reg *regexp.Regexp,
+	pat, str, replacement string,
+	startByte int,
+	subjectIsBinary bool,
+	pureMatchType string,
+	maxBytes int64,
+) (regexpReplacementTemplate, uint64, bool, error) {
+	var template regexpReplacementTemplate
+	var size uint64
+	last := 0
+	parsed := false
+	matched := false
+	_, err := rs.regexpVisitSubmatchesAtOrAfterWithMatchType(
+		reg, pat, str, startByte, subjectIsBinary, pureMatchType, 0,
+		func(indices []int) error {
+			if !parsed {
+				var parseErr error
+				template, parseErr = parseRegexpReplacementTemplate(replacement, reg)
+				if parseErr != nil {
+					return parseErr
+				}
+				parsed = true
+			}
+			var addErr error
+			size, addErr = regexpAddReplacementSize(size, indices[0]-last, maxBytes)
+			if addErr != nil {
+				return addErr
+			}
+			size, addErr = regexpAddTemplateSize(size, str, indices, template, maxBytes)
+			if addErr != nil {
+				return addErr
+			}
+			last = indices[1]
+			matched = true
+			return nil
+		},
+	)
+	if err != nil {
+		return regexpReplacementTemplate{}, 0, matched, err
+	}
+	if !matched {
+		return regexpReplacementTemplate{}, 0, false, nil
+	}
+	size, err = regexpAddReplacementSize(size, len(str)-last, maxBytes)
+	if err != nil {
+		return regexpReplacementTemplate{}, 0, true, err
+	}
+	return template, size, true, nil
+}

--- a/test/distributed/cases/function/func_regular_instr.result
+++ b/test/distributed/cases/function/func_regular_instr.result
@@ -396,3 +396,22 @@ SELECT REGEXP_INSTR(CAST(X'FF' AS BINARY(1)), CAST(X'5C784646' AS BINARY(4))) AS
 REGEXP_INSTR(CAST(X'FF' AS BINARY(1)), CAST(X'5B5C7838302D5C7846465D' AS BINARY(11))) AS byte_range;
 hex_escape    byte_range
 1    1
+
+SELECT REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'i') AS insensitive,
+REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'c') AS sensitive,
+REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'ic') AS rightmost_c,
+REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'ci') AS rightmost_i;
+insensitive    sensitive    rightmost_c    rightmost_i
+1    5    5    1
+SELECT REGEXP_INSTR('a\nb', '^b', 1, 1, 0, 'mu') AS unix_lf,
+REGEXP_INSTR('a\rb', '^b', 1, 1, 0, 'mu') AS unix_cr;
+unix_lf    unix_cr
+3    0
+SELECT REGEXP_INSTR(CAST(X'78C9' AS BINARY(2)), CAST(X'E9' AS BINARY(1)), 1, 1, 0, 'i') AS binary_i,
+REGEXP_INSTR(CAST(X'78C9' AS VARBINARY(2)), CAST(X'E9' AS VARBINARY(1)), 1, 1, 0, 'i') AS varbinary_i;
+binary_i    varbinary_i
+2    2
+SELECT REGEXP_INSTR(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), 2, 1, 0, 'i') AS binary_byte_pos,
+REGEXP_INSTR(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), 2, 1, 0, 'i') AS varbinary_byte_pos;
+binary_byte_pos    varbinary_byte_pos
+4    4

--- a/test/distributed/cases/function/func_regular_instr.test
+++ b/test/distributed/cases/function/func_regular_instr.test
@@ -260,3 +260,18 @@ SELECT REGEXP_INSTR(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BIN
 # Binary regexp escape atoms and ranges operate on bytes, not Unicode code points.
 SELECT REGEXP_INSTR(CAST(X'FF' AS BINARY(1)), CAST(X'5C784646' AS BINARY(4))) AS hex_escape,
        REGEXP_INSTR(CAST(X'FF' AS BINARY(1)), CAST(X'5B5C7838302D5C7846465D' AS BINARY(11))) AS byte_range;
+
+# The optional match_type applies consistently to positioned REGEXP_INSTR.
+SELECT REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'i') AS insensitive,
+       REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'c') AS sensitive,
+       REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'ic') AS rightmost_c,
+       REGEXP_INSTR('Abc abc', 'abc', 1, 1, 0, 'ci') AS rightmost_i;
+SELECT REGEXP_INSTR('a\nb', '^b', 1, 1, 0, 'mu') AS unix_lf,
+       REGEXP_INSTR('a\rb', '^b', 1, 1, 0, 'mu') AS unix_cr;
+
+# Explicit binary case folding uses the Windows-1252 byte facade without
+# changing one-based byte positions. UTF-8-looking BINARY values are still bytes.
+SELECT REGEXP_INSTR(CAST(X'78C9' AS BINARY(2)), CAST(X'E9' AS BINARY(1)), 1, 1, 0, 'i') AS binary_i,
+       REGEXP_INSTR(CAST(X'78C9' AS VARBINARY(2)), CAST(X'E9' AS VARBINARY(1)), 1, 1, 0, 'i') AS varbinary_i;
+SELECT REGEXP_INSTR(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), 2, 1, 0, 'i') AS binary_byte_pos,
+       REGEXP_INSTR(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), 2, 1, 0, 'i') AS varbinary_byte_pos;

--- a/test/distributed/cases/function/func_regular_like.result
+++ b/test/distributed/cases/function/func_regular_like.result
@@ -106,6 +106,10 @@ r
 select regexp_like('CAT','cat','iiiiiiic') r;
 r
 0
+SELECT REGEXP_LIKE('a\nb', '^b', 'mu') AS unix_lf,
+REGEXP_LIKE('a\rb', '^b', 'mu') AS unix_cr;
+unix_lf    unix_cr
+1    0
 select regexp_like(cast(_binary'A' as varbinary(1)), cast(_binary'a' as varbinary(1)), 'i') binary_i,
 regexp_like(cast(_binary'A' as varbinary(1)), cast(_binary'a' as varbinary(1)), 'ci') binary_ci,
 regexp_like(cast(_binary'A' as varbinary(1)), cast(_binary'a' as varbinary(1)), 'ic') binary_ic,
@@ -154,3 +158,27 @@ abc reg_match a
 select 'abc' rlike '^a';
 abc reg_match ^a
 1
+DROP TABLE IF EXISTS t_regexp_match_type;
+CREATE TABLE t_regexp_match_type (
+id INT,
+s VARCHAR(40),
+p VARCHAR(20),
+r VARCHAR(8),
+mt VARCHAR(8)
+);
+INSERT INTO t_regexp_match_type VALUES
+(1, 'Abc', 'abc', 'X', 'i'),
+(2, 'Abc', 'abc', 'X', 'c'),
+(3, 'abc', 'abc', 'X', 'u');
+SELECT id,
+REGEXP_LIKE(s, p, mt) AS is_match,
+REGEXP_INSTR(s, p, 1, 1, 0, mt) AS start_pos,
+REGEXP_SUBSTR(s, p, 1, 1, mt) AS substr_value,
+REGEXP_REPLACE(s, p, r, 1, 0, mt) AS replaced
+FROM t_regexp_match_type
+ORDER BY id;
+id    is_match    start_pos    substr_value    replaced
+1    1    1    Abc    X
+2    0    0    null    Abc
+3    1    1    abc    X
+DROP TABLE t_regexp_match_type;

--- a/test/distributed/cases/function/func_regular_like.test
+++ b/test/distributed/cases/function/func_regular_like.test
@@ -64,6 +64,8 @@ select regexp_like('CAT','cat','i') r;
 select regexp_like('\n','.','n') r;
 select regexp_like('abc\ndef','^def','m') r;
 select regexp_like('CAT','cat','iiiiiiic') r;
+SELECT REGEXP_LIKE('a\nb', '^b', 'mu') AS unix_lf,
+       REGEXP_LIKE('a\rb', '^b', 'mu') AS unix_cr;
 
 # Binary operands default to case-sensitive matching, while explicit i/c flags
 # override the default and the rightmost flag wins. High bytes use the
@@ -98,3 +100,26 @@ select 'abc' rlike '';
 select 'abc' not regexp '';
 select 'abc' regexp 'a';
 select 'abc' rlike '^a';
+
+# match_type may vary by row; u is valid alongside case-specific modes and
+# must not abort the whole vectorized query.
+DROP TABLE IF EXISTS t_regexp_match_type;
+CREATE TABLE t_regexp_match_type (
+    id INT,
+    s VARCHAR(40),
+    p VARCHAR(20),
+    r VARCHAR(8),
+    mt VARCHAR(8)
+);
+INSERT INTO t_regexp_match_type VALUES
+    (1, 'Abc', 'abc', 'X', 'i'),
+    (2, 'Abc', 'abc', 'X', 'c'),
+    (3, 'abc', 'abc', 'X', 'u');
+SELECT id,
+       REGEXP_LIKE(s, p, mt) AS is_match,
+       REGEXP_INSTR(s, p, 1, 1, 0, mt) AS start_pos,
+       REGEXP_SUBSTR(s, p, 1, 1, mt) AS substr_value,
+       REGEXP_REPLACE(s, p, r, 1, 0, mt) AS replaced
+FROM t_regexp_match_type
+ORDER BY id;
+DROP TABLE t_regexp_match_type;

--- a/test/distributed/cases/function/func_regular_replace.result
+++ b/test/distributed/cases/function/func_regular_replace.result
@@ -131,3 +131,39 @@ EXECUTE regexp_replacement_charset USING @regexp_replacement;
 replacement_hex
 C3A4C2B8C2AD
 DEALLOCATE PREPARE regexp_replacement_charset;
+
+SELECT REGEXP_REPLACE('Abc abc', 'abc', 'X', 1, 0, 'i') AS insensitive,
+REGEXP_REPLACE('Abc abc', 'abc', 'X', 1, 0, 'c') AS sensitive;
+insensitive    sensitive
+X X    Abc X
+SELECT HEX(REGEXP_REPLACE('a\nb', '^b', 'X', 3, 1, 'm')) AS multiline,
+HEX(REGEXP_REPLACE('a\nb', '^b', 'X', 3, 1, 'c')) AS singleline;
+multiline    singleline
+610A58    610A62
+SELECT HEX(REGEXP_REPLACE(CAST(X'78C9' AS BINARY(2)), CAST(X'E9' AS BINARY(1)), CAST(X'58' AS BINARY(1)), 1, 0, 'i')) AS binary_i,
+HEX(REGEXP_REPLACE(CAST(X'78C9' AS VARBINARY(2)), CAST(X'E9' AS VARBINARY(1)), CAST(X'58' AS VARBINARY(1)), 1, 0, 'i')) AS varbinary_i;
+binary_i    varbinary_i
+7858    7858
+SELECT HEX(REGEXP_REPLACE(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), CAST(X'58' AS BINARY(1)), 2, 1, 'i')) AS binary_byte_pos,
+HEX(REGEXP_REPLACE(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), CAST(X'58' AS VARBINARY(1)), 2, 1, 'i')) AS varbinary_byte_pos;
+binary_byte_pos    varbinary_byte_pos
+E4B8AD58    E4B8AD58
+PREPARE regexp_value_match_type_rebind FROM
+'SELECT REGEXP_INSTR(?, ?, 1, 1, 0, ?) AS pos,
+REGEXP_SUBSTR(?, ?, 1, 1, ?) AS part,
+REGEXP_REPLACE(?, ?, ''X'', 1, 0, ?) AS replaced';
+SET @regexp_mode_subject = 'Abc abc';
+SET @regexp_mode_pattern = 'abc';
+SET @regexp_mode = 'i';
+EXECUTE regexp_value_match_type_rebind USING @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+@regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+@regexp_mode_subject, @regexp_mode_pattern, @regexp_mode;
+pos    part    replaced
+1    Abc    X X
+SET @regexp_mode = 'c';
+EXECUTE regexp_value_match_type_rebind USING @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+@regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+@regexp_mode_subject, @regexp_mode_pattern, @regexp_mode;
+pos    part    replaced
+5    abc    Abc X
+DEALLOCATE PREPARE regexp_value_match_type_rebind;

--- a/test/distributed/cases/function/func_regular_replace.result
+++ b/test/distributed/cases/function/func_regular_replace.result
@@ -167,3 +167,36 @@ EXECUTE regexp_value_match_type_rebind USING @regexp_mode_subject, @regexp_mode_
 pos    part    replaced
 5    abc    Abc X
 DEALLOCATE PREPARE regexp_value_match_type_rebind;
+
+SELECT REGEXP_REPLACE('ab', '(a)(b)', '$2$1') AS swapped,
+       REGEXP_REPLACE('matrix', '(matrix)', '<$1>') AS captured,
+       REGEXP_REPLACE('aab', '(a)', '<$1>', 2, 0) AS from_pos;
+swapped	captured	from_pos
+ba	<matrix>	a<a>b
+SELECT HEX(REGEXP_REPLACE(CAST(X'00FFC3' AS VARBINARY(3)),
+                          CAST(X'00' AS VARBINARY(1)),
+                          CAST(X'5B24305D' AS VARBINARY(4)), 1, 0)) AS binary_capture;
+binary_capture
+5B005DFFC3
+SELECT HEX(REGEXP_REPLACE(CAST(X'00FFC3' AS BINARY(3)),
+CAST(X'00' AS BINARY(1)),
+CAST(X'5B24305D' AS BINARY(4)), 1, 0)) AS binary_capture,
+HEX(REGEXP_REPLACE(CAST(X'00FFC3' AS VARBINARY(3)),
+CAST(X'00' AS VARBINARY(1)),
+CAST(X'5B24305D' AS VARBINARY(4)), 1, 0)) AS varbinary_capture;
+binary_capture	varbinary_capture
+5B005DFFC3	5B005DFFC3
+
+PREPARE regexp_capture_replacement FROM
+'SELECT REGEXP_REPLACE(?, ?, ?, 1, 0) AS replaced';
+SET @regexp_capture_subject = 'ab';
+SET @regexp_capture_pattern = '(a)(b)';
+SET @regexp_capture_value = '$2$1';
+EXECUTE regexp_capture_replacement USING @regexp_capture_subject, @regexp_capture_pattern, @regexp_capture_value;
+replaced
+ba
+SET @regexp_capture_value = '<$0>';
+EXECUTE regexp_capture_replacement USING @regexp_capture_subject, @regexp_capture_pattern, @regexp_capture_value;
+replaced
+<ab>
+DEALLOCATE PREPARE regexp_capture_replacement;

--- a/test/distributed/cases/function/func_regular_replace.result
+++ b/test/distributed/cases/function/func_regular_replace.result
@@ -108,6 +108,17 @@ HEX(REGEXP_REPLACE('abc', 'a*', 'X', 1, 0)) AS replace_zero_width,
 HEX(REGEXP_REPLACE('', '^$', 'X')) AS empty_subject;
 after_nonempty    after_nonempty_at_pos    replace_zero_width    empty_subject
 2    3    585862586358
+SELECT REGEXP_REPLACE('a.a.', '(a)\\Q.', '$1', 1, 0) AS quoted_all,
+REGEXP_REPLACE('xa.a.', '(a)\\Q.', '$1', 2, 1) AS quoted_one,
+REGEXP_REPLACE('xa.a.', '(a)\\Q.', '$1', 2, 0) AS quoted_after_pos,
+REGEXP_INSTR('xa.a.', '(a)\\Q.', 2, 2) AS quoted_instr,
+REGEXP_SUBSTR('xa.a.', '(a)\\Q.', 2, 2) AS quoted_substr;
+quoted_all    quoted_one    quoted_after_pos    quoted_instr    quoted_substr
+aa    xaa.    xaa    4    a.
+SELECT HEX(REGEXP_REPLACE(CAST(_binary'a\\a\\' AS VARBINARY(4)),
+                          CAST(_binary'(a)\\Q\\\\E' AS VARBINARY(8)), _binary'X', 1, 0)) AS binary_quoted_backslash;
+binary_quoted_backslash
+5858
 SELECT HEX(REGEXP_REPLACE(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), _binary'X', 2, 1)) AS binary_replace,
 HEX(REGEXP_REPLACE(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), _binary'X', 2, 1)) AS varbinary_replace;
 binary_replace    varbinary_replace

--- a/test/distributed/cases/function/func_regular_replace.test
+++ b/test/distributed/cases/function/func_regular_replace.test
@@ -67,6 +67,16 @@ SELECT REGEXP_INSTR('abc', 'a*', 1, 2, 0) AS after_nonempty,
        HEX(REGEXP_REPLACE('abc', 'a*', 'X', 1, 0)) AS replace_zero_width,
        HEX(REGEXP_REPLACE('', '^$', 'X')) AS empty_subject;
 
+# A trailing \Q quotes through pattern end; position wrappers must not
+# accidentally quote the wrapper's generated capture boundary.
+SELECT REGEXP_REPLACE('a.a.', '(a)\\Q.', '$1', 1, 0) AS quoted_all,
+       REGEXP_REPLACE('xa.a.', '(a)\\Q.', '$1', 2, 1) AS quoted_one,
+       REGEXP_REPLACE('xa.a.', '(a)\\Q.', '$1', 2, 0) AS quoted_after_pos,
+       REGEXP_INSTR('xa.a.', '(a)\\Q.', 2, 2) AS quoted_instr,
+       REGEXP_SUBSTR('xa.a.', '(a)\\Q.', 2, 2) AS quoted_substr;
+SELECT HEX(REGEXP_REPLACE(CAST(_binary'a\\a\\' AS VARBINARY(4)),
+                          CAST(_binary'(a)\\Q\\\\E' AS VARBINARY(8)), _binary'X', 1, 0)) AS binary_quoted_backslash;
+
 # Binary subjects interpret pos as a byte offset.
 SELECT HEX(REGEXP_REPLACE(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), _binary'X', 2, 1)) AS binary_replace,
        HEX(REGEXP_REPLACE(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), _binary'X', 2, 1)) AS varbinary_replace;

--- a/test/distributed/cases/function/func_regular_replace.test
+++ b/test/distributed/cases/function/func_regular_replace.test
@@ -85,3 +85,34 @@ EXECUTE regexp_replacement_charset USING @regexp_replacement;
 SET @regexp_replacement = _binary 0xe4b8ad;
 EXECUTE regexp_replacement_charset USING @regexp_replacement;
 DEALLOCATE PREPARE regexp_replacement_charset;
+
+# match_type controls matching and replacement consistently. The multiline
+# case also exercises flags in the position-aware wrapper's second compilation.
+SELECT REGEXP_REPLACE('Abc abc', 'abc', 'X', 1, 0, 'i') AS insensitive,
+       REGEXP_REPLACE('Abc abc', 'abc', 'X', 1, 0, 'c') AS sensitive;
+SELECT HEX(REGEXP_REPLACE('a\nb', '^b', 'X', 3, 1, 'm')) AS multiline,
+       HEX(REGEXP_REPLACE('a\nb', '^b', 'X', 3, 1, 'c')) AS singleline;
+
+# Binary case folding preserves the original byte representation and pos unit.
+SELECT HEX(REGEXP_REPLACE(CAST(X'78C9' AS BINARY(2)), CAST(X'E9' AS BINARY(1)), CAST(X'58' AS BINARY(1)), 1, 0, 'i')) AS binary_i,
+       HEX(REGEXP_REPLACE(CAST(X'78C9' AS VARBINARY(2)), CAST(X'E9' AS VARBINARY(1)), CAST(X'58' AS VARBINARY(1)), 1, 0, 'i')) AS varbinary_i;
+SELECT HEX(REGEXP_REPLACE(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), CAST(X'58' AS BINARY(1)), 2, 1, 'i')) AS binary_byte_pos,
+       HEX(REGEXP_REPLACE(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), CAST(X'58' AS VARBINARY(1)), 2, 1, 'i')) AS varbinary_byte_pos;
+
+# Reusing one prepared plan with changing match_type values must not retain the
+# previous case flags in any of the three value functions.
+PREPARE regexp_value_match_type_rebind FROM
+    'SELECT REGEXP_INSTR(?, ?, 1, 1, 0, ?) AS pos,
+            REGEXP_SUBSTR(?, ?, 1, 1, ?) AS part,
+            REGEXP_REPLACE(?, ?, ''X'', 1, 0, ?) AS replaced';
+SET @regexp_mode_subject = 'Abc abc';
+SET @regexp_mode_pattern = 'abc';
+SET @regexp_mode = 'i';
+EXECUTE regexp_value_match_type_rebind USING @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+       @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+       @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode;
+SET @regexp_mode = 'c';
+EXECUTE regexp_value_match_type_rebind USING @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+       @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
+       @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode;
+DEALLOCATE PREPARE regexp_value_match_type_rebind;

--- a/test/distributed/cases/function/func_regular_replace.test
+++ b/test/distributed/cases/function/func_regular_replace.test
@@ -116,3 +116,30 @@ EXECUTE regexp_value_match_type_rebind USING @regexp_mode_subject, @regexp_mode_
        @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode,
        @regexp_mode_subject, @regexp_mode_pattern, @regexp_mode;
 DEALLOCATE PREPARE regexp_value_match_type_rebind;
+
+# ICU-style capture references are expanded at the selected match; binary
+# captures append the original bytes, including NUL and invalid UTF-8.
+SELECT REGEXP_REPLACE('ab', '(a)(b)', '$2$1') AS swapped,
+       REGEXP_REPLACE('matrix', '(matrix)', '<$1>') AS captured,
+       REGEXP_REPLACE('aab', '(a)', '<$1>', 2, 0) AS from_pos;
+SELECT HEX(REGEXP_REPLACE(CAST(X'00FFC3' AS VARBINARY(3)),
+                          CAST(X'00' AS VARBINARY(1)),
+                          CAST(X'5B24305D' AS VARBINARY(4)), 1, 0)) AS binary_capture;
+SELECT HEX(REGEXP_REPLACE(CAST(X'00FFC3' AS BINARY(3)),
+                          CAST(X'00' AS BINARY(1)),
+                          CAST(X'5B24305D' AS BINARY(4)), 1, 0)) AS binary_capture,
+       HEX(REGEXP_REPLACE(CAST(X'00FFC3' AS VARBINARY(3)),
+                          CAST(X'00' AS VARBINARY(1)),
+                          CAST(X'5B24305D' AS VARBINARY(4)), 1, 0)) AS varbinary_capture;
+
+# Replacement markers supplied through a prepared parameter are interpreted
+# on each execution rather than retained from an earlier value.
+PREPARE regexp_capture_replacement FROM
+    'SELECT REGEXP_REPLACE(?, ?, ?, 1, 0) AS replaced';
+SET @regexp_capture_subject = 'ab';
+SET @regexp_capture_pattern = '(a)(b)';
+SET @regexp_capture_value = '$2$1';
+EXECUTE regexp_capture_replacement USING @regexp_capture_subject, @regexp_capture_pattern, @regexp_capture_value;
+SET @regexp_capture_value = '<$0>';
+EXECUTE regexp_capture_replacement USING @regexp_capture_subject, @regexp_capture_pattern, @regexp_capture_value;
+DEALLOCATE PREPARE regexp_capture_replacement;

--- a/test/distributed/cases/function/func_regular_substr.result
+++ b/test/distributed/cases/function/func_regular_substr.result
@@ -121,3 +121,20 @@ SELECT HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' A
 HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), 2)) AS varbinary_substr;
 binary_substr    varbinary_substr
 E4B8AD    E4B8AD
+
+SELECT REGEXP_SUBSTR('Abc abc', 'abc', 1, 1, 'i') AS insensitive,
+REGEXP_SUBSTR('Abc abc', 'abc', 1, 1, 'c') AS sensitive;
+insensitive    sensitive
+Abc    abc
+SELECT REGEXP_SUBSTR('a\nb', '^b', 3, 1, 'm') AS multiline,
+REGEXP_SUBSTR('a\nb', '^b', 3, 1, 'c') AS singleline;
+multiline    singleline
+b    null
+SELECT HEX(REGEXP_SUBSTR(CAST(X'78C9' AS BINARY(2)), CAST(X'E9' AS BINARY(1)), 1, 1, 'i')) AS binary_i,
+HEX(REGEXP_SUBSTR(CAST(X'78C9' AS VARBINARY(2)), CAST(X'E9' AS VARBINARY(1)), 1, 1, 'i')) AS varbinary_i;
+binary_i    varbinary_i
+C9    C9
+SELECT HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), 2, 1, 'i')) AS binary_byte_pos,
+HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), 2, 1, 'i')) AS varbinary_byte_pos;
+binary_byte_pos    varbinary_byte_pos
+E4B8AD    E4B8AD

--- a/test/distributed/cases/function/func_regular_substr.test
+++ b/test/distributed/cases/function/func_regular_substr.test
@@ -70,3 +70,16 @@ drop table t;
 # independent of client character rendering.
 SELECT HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), 2)) AS binary_substr,
        HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), 2)) AS varbinary_substr;
+
+# match_type is applied before position-aware matching, including the
+# recompiled iterator that preserves the full subject for multiline anchors.
+SELECT REGEXP_SUBSTR('Abc abc', 'abc', 1, 1, 'i') AS insensitive,
+       REGEXP_SUBSTR('Abc abc', 'abc', 1, 1, 'c') AS sensitive;
+SELECT REGEXP_SUBSTR('a\nb', '^b', 3, 1, 'm') AS multiline,
+       REGEXP_SUBSTR('a\nb', '^b', 3, 1, 'c') AS singleline;
+
+# Binary case folding changes character comparison, not byte indexing/results.
+SELECT HEX(REGEXP_SUBSTR(CAST(X'78C9' AS BINARY(2)), CAST(X'E9' AS BINARY(1)), 1, 1, 'i')) AS binary_i,
+       HEX(REGEXP_SUBSTR(CAST(X'78C9' AS VARBINARY(2)), CAST(X'E9' AS VARBINARY(1)), 1, 1, 'i')) AS varbinary_i;
+SELECT HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS BINARY(6)), CAST(_binary'中' AS BINARY(3)), 2, 1, 'i')) AS binary_byte_pos,
+       HEX(REGEXP_SUBSTR(CAST(_binary'中中' AS VARBINARY(6)), CAST(_binary'中' AS VARBINARY(3)), 2, 1, 'i')) AS varbinary_byte_pos;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [ ] API-change
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Partial follow-up for #28305 — capture replacement only. This PR targets `main`. It depends on the regexp match-type positioning support in #28787, so the current PR diff includes #28787's prerequisite commits as well. Once #28787 merges, rebase this branch onto updated `main` to remove those prerequisite commits from this PR's diff.

## What this PR does / why we need it:

REGEXP_REPLACE currently uses literal-replacement APIs and directly appends the replacement for occurrence-specific calls. Thus MySQL/ICU capture references such as $2$1 are returned literally rather than expanded (`REGEXP_REPLACE('ab', '(a)(b)', '$2$1')` should return `ba`).

This change adds a bounded replacement-template parser for whole-match, numeric and supported named capture references, and backslash quoting. It preserves unmatched captures as empty and defers template errors until a match is actually selected, so a no-match result remains the original subject. The position-aware matcher exposes captures from the original pattern, and binary match offsets are mapped back to source bytes before captured content is appended.

Ordinary replacements without dollar-sign or backslash markers retain the existing optimized literal path. Template execution keeps only the current match, does not cache row-specific templates, checks the final byte length against the engine's 64 MiB blob limit, and returns an error instead of truncating oversized output. Large conservative bounds use a size-only pass before allocating; the streaming path allocates only after its first match and starts with a bounded capacity.

## Scope and known limitations

This is intentionally only the capture-replacement part of #28305. It does not add ICU-only pattern constructs (lookaround, pattern backreferences, atomic groups, possessive quantifiers, or grapheme matching), does not replace RE2, and does not claim complete ICU replacement-template parity. Unicode-digit references and ICU-specific Unicode escape forms remain out of scope pending a pinned-version compatibility decision. #28305 should remain open until those pattern-dialect gaps are resolved or explicitly split/closed by the issue owner.

The runtime result limit is 64 MiB, matching MatrixOne's current maximum blob size. Results are never silently truncated. This PR does not alter the declared return-type formula.

## Validation and merge gates

- Added focused UT coverage for group swapping, whole match, greedy numeric references and fallback, leading zeroes, unmatched and named groups, escaping, invalid/lazy templates, occurrence/position/overlap/anchor/zero-width cases, binary NUL/invalid UTF-8 captures, binary case folding, and output-size boundaries.
- Added quote-boundary regressions for trailing open `\Q`, escaped backslashes, the first `\E` after a quoted literal backslash, and noninitial-position `REGEXP_INSTR`/`REGEXP_SUBSTR`/`REGEXP_REPLACE` in text and binary modes.
- Extended the existing func_regular_replace BVT with SQL-visible capture expansion, quote-boundary and position behavior, BINARY/VARBINARY byte preservation, and prepared replacement rebinding.
- `go test ./pkg/sql/plan/function -run '^Test_BuiltIn_Regexp' -count=1` passes on the current head; `git diff --check` passes.
- `golangci-lint run --timeout=10m ./pkg/sql/plan/function` passed on the same PR diff before the latest base-only rebase; the diff fingerprint is unchanged.
- The local distributed BVT and the full function-package UT were not run. Require exact-head full package UT, the func_regular_replace BVT, and incremental SCA before merge; no CI result is claimed here.
