### PR TITLE
perf(mpool): narrow on-heap teardown scans

### DIFF
--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -17,6 +17,7 @@ package mpool
 import (
 	"fmt"
 	"math"
+	"math/bits"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -422,6 +423,10 @@ type MPool struct {
 	resource resourceMemoryStats
 	epoch    atomic.Pointer[ResourcePeakEpoch]
 	details  *mpoolDetails
+	// onHeapShardHints is a conservative set of global registry shards this
+	// pool has published on-heap pointers into. It only narrows destroy-time
+	// diagnostics; the pointer registry remains authoritative.
+	onHeapShardHints [(numPtrShards + 63) / 64]atomic.Uint64
 
 	noLock bool
 	ptrs   map[unsafe.Pointer]memHdr
@@ -471,6 +476,9 @@ const (
 
 func (mp *MPool) recordPtrHdr(ptr unsafe.Pointer, pHdr memHdr) error {
 	if !mp.noLock {
+		if !pHdr.isOffHeap() {
+			return gRecordOnHeapPtr(ptr, pHdr, mp)
+		}
 		return gRecordPtr(ptr, pHdr)
 	}
 	if _, ok := mp.ptrs[ptr]; ok {
@@ -607,7 +615,12 @@ func (mp *MPool) Cap() int64 {
 }
 
 func (mp *MPool) destroy() {
-	onHeapBytes, onHeapObjects := mp.OnHeapOutstanding()
+	var onHeapBytes, onHeapObjects int64
+	if mp.noLock {
+		onHeapBytes, onHeapObjects = mp.OnHeapOutstanding()
+	} else {
+		onHeapBytes, onHeapObjects = mp.scanOnHeapOutstandingHinted()
+	}
 	if onHeapBytes != 0 {
 		logutil.Warn(
 			"mpool closed with outstanding on-heap ownership",
@@ -756,6 +769,40 @@ func (mp *MPool) OnHeapOutstanding() (bytes, objects int64) {
 	return bytes, objects
 }
 
+// scanOnHeapOutstandingHinted is used only at pool teardown. Allocation sets
+// a shard bit once, while frees leave it set, so every shard containing a
+// pointer owned by this pool is scanned and empty shards are merely false
+// positives. The pointer map remains authoritative for exact leak reporting.
+func (mp *MPool) scanOnHeapOutstandingHinted() (bytes, objects int64) {
+	for wordIndex := range mp.onHeapShardHints {
+		shards := mp.onHeapShardHints[wordIndex].Load()
+		for shards != 0 {
+			bit := bits.TrailingZeros64(shards)
+			shard := &globalPtrShards[wordIndex*64+bit]
+			shard.mu.Lock()
+			for _, hdr := range shard.m {
+				if hdr.poolId == mp.id && !hdr.isOffHeap() {
+					bytes += int64(hdr.allocSz)
+					objects++
+				}
+			}
+			shard.mu.Unlock()
+			shards &= shards - 1
+		}
+	}
+	return bytes, objects
+}
+
+func (mp *MPool) recordOnHeapShardHint(shardIndex int) {
+	word := &mp.onHeapShardHints[shardIndex/64]
+	mask := uint64(1) << (shardIndex % 64)
+	for current := word.Load(); current&mask == 0; current = word.Load() {
+		if word.CompareAndSwap(current, current|mask) {
+			return
+		}
+	}
+}
+
 // ResourcePeakLiveBytes returns the peak observed by token.  Ended tokens
 // remain readable so the owner can seal the statement after workers quiesce;
 // a token belonging to another open epoch is rejected.
@@ -882,7 +929,7 @@ type ptrShard struct {
 
 var globalPtrShards [numPtrShards]ptrShard
 
-func getPtrShard(ptr unsafe.Pointer) *ptrShard {
+func getPtrShardIndex(ptr unsafe.Pointer) int {
 	hash := uintptr(ptr) >> 4
 	// Better hash mixing to distribute load evenly
 	hash ^= hash >> 17
@@ -890,7 +937,11 @@ func getPtrShard(ptr unsafe.Pointer) *ptrShard {
 	hash ^= hash >> 13
 	hash *= 0xc2b2ae35
 	hash ^= hash >> 16
-	return &globalPtrShards[hash%numPtrShards]
+	return int(hash % numPtrShards)
+}
+
+func getPtrShard(ptr unsafe.Pointer) *ptrShard {
+	return &globalPtrShards[getPtrShardIndex(ptr)]
 }
 
 func InitCap(cap int64) {
@@ -1737,7 +1788,17 @@ func gRecordPtr(
 	ptr unsafe.Pointer,
 	hdr memHdr,
 ) error {
-	shard := getPtrShard(ptr)
+	shardIndex := getPtrShardIndex(ptr)
+	return gRecordPtrInShard(ptr, hdr, shardIndex, nil)
+}
+
+func gRecordOnHeapPtr(ptr unsafe.Pointer, hdr memHdr, owner *MPool) error {
+	shardIndex := getPtrShardIndex(ptr)
+	return gRecordPtrInShard(ptr, hdr, shardIndex, owner)
+}
+
+func gRecordPtrInShard(ptr unsafe.Pointer, hdr memHdr, shardIndex int, owner *MPool) error {
+	shard := &globalPtrShards[shardIndex]
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
 	if _, ok := shard.m[ptr]; ok {
@@ -1747,6 +1808,9 @@ func gRecordPtr(
 		return moerr.NewInternalErrorNoCtx("ptr already recorded")
 	}
 	shard.m[ptr] = hdr
+	if owner != nil {
+		owner.recordOnHeapShardHint(shardIndex)
+	}
 	return nil
 }
 

--- a/pkg/common/mpool/mpool_onheap_shard_hint_test.go
+++ b/pkg/common/mpool/mpool_onheap_shard_hint_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mpool
+
+import (
+	"fmt"
+	"math/bits"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type onHeapShardHintMask [(numPtrShards + 63) / 64]uint64
+
+func expectedOnHeapShardHints(mp *MPool) (expected onHeapShardHintMask) {
+	for shardIndex := range globalPtrShards {
+		shard := &globalPtrShards[shardIndex]
+		shard.mu.Lock()
+		for _, hdr := range shard.m {
+			if hdr.poolId == mp.id && !hdr.isOffHeap() {
+				expected[shardIndex/64] |= uint64(1) << (shardIndex % 64)
+				break
+			}
+		}
+		shard.mu.Unlock()
+	}
+	return expected
+}
+
+func onHeapShardHintsForTest(mp *MPool) (got onHeapShardHintMask) {
+	for i := range got {
+		got[i] = mp.onHeapShardHints[i].Load()
+	}
+	return got
+}
+
+func requireHintedOutstandingMatchesRegistry(t *testing.T, mp *MPool) {
+	t.Helper()
+	wantBytes, wantObjects := mp.OnHeapOutstanding()
+	gotBytes, gotObjects := mp.scanOnHeapOutstandingHinted()
+	require.Equal(t, wantBytes, gotBytes)
+	require.Equal(t, wantObjects, gotObjects)
+}
+
+func TestOnHeapShardHintsAreConservativeAndExact(t *testing.T) {
+	owner := MustNew("onheap-shard-hint-owner")
+	other := MustNew("onheap-shard-hint-other")
+	freeingPool := MustNew("onheap-shard-hint-free")
+	defer DeleteMPool(owner)
+	defer DeleteMPool(other)
+	defer DeleteMPool(freeingPool)
+
+	ownerBuffers := make([][]byte, 0, 3)
+	for _, size := range []int{64, 96, 128} {
+		buffer, err := owner.Alloc(size, false)
+		require.NoError(t, err)
+		ownerBuffers = append(ownerBuffers, buffer)
+	}
+	expected := expectedOnHeapShardHints(owner)
+	require.Equal(t, expected, onHeapShardHintsForTest(owner), "each on-heap pointer's shard must be hinted")
+	requireHintedOutstandingMatchesRegistry(t, owner)
+
+	// Off-heap allocations do not publish on-heap ownership hints.
+	offHeap, err := owner.Alloc(256, true)
+	require.NoError(t, err)
+	require.Equal(t, expected, onHeapShardHintsForTest(owner))
+
+	otherBuffer, err := other.Alloc(48, false)
+	require.NoError(t, err)
+	freeingPool.Free(ownerBuffers[0])
+	ownerBuffers[0] = nil
+	require.Equal(t, expected, onHeapShardHintsForTest(owner), "hints remain set after frees to avoid false negatives")
+	requireHintedOutstandingMatchesRegistry(t, owner)
+	requireHintedOutstandingMatchesRegistry(t, other)
+
+	freeingPool.Free(ownerBuffers[1])
+	ownerBuffers[1] = nil
+	owner.Free(ownerBuffers[2])
+	owner.Free(offHeap)
+	other.Free(otherBuffer)
+	requireHintedOutstandingMatchesRegistry(t, owner)
+	requireHintedOutstandingMatchesRegistry(t, other)
+	ownerBytes, ownerObjects := owner.scanOnHeapOutstandingHinted()
+	require.Zero(t, ownerBytes)
+	require.Zero(t, ownerObjects)
+	otherBytes, otherObjects := other.scanOnHeapOutstandingHinted()
+	require.Zero(t, otherBytes)
+	require.Zero(t, otherObjects)
+	require.Equal(t, expected, onHeapShardHintsForTest(owner), "empty owners retain only harmless conservative hints")
+}
+
+func TestOnHeapShardHintsConcurrentPublicationAndCrossPoolFree(t *testing.T) {
+	owner := MustNew("onheap-shard-hint-concurrent-owner")
+	freeingPool := MustNew("onheap-shard-hint-concurrent-free")
+	defer DeleteMPool(owner)
+	defer DeleteMPool(freeingPool)
+
+	const (
+		workers = 8
+		ops     = 64
+	)
+	buffers := make([][][]byte, workers)
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker := range workers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for range ops {
+				buffer, err := owner.Alloc(64, false)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				buffers[worker] = append(buffers[worker], buffer)
+			}
+		}(worker)
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	expected := expectedOnHeapShardHints(owner)
+	require.Equal(t, expected, onHeapShardHintsForTest(owner), "concurrent first publications must not lose bits")
+	requireHintedOutstandingMatchesRegistry(t, owner)
+
+	start = make(chan struct{})
+	for worker := range workers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for _, buffer := range buffers[worker] {
+				freeingPool.Free(buffer)
+			}
+		}(worker)
+	}
+	close(start)
+	wg.Wait()
+	requireHintedOutstandingMatchesRegistry(t, owner)
+	ownerBytes, ownerObjects := owner.scanOnHeapOutstandingHinted()
+	require.Zero(t, ownerBytes)
+	require.Zero(t, ownerObjects)
+	require.Equal(t, expected, onHeapShardHintsForTest(owner), "freeing must not clear a shard that may be reused")
+}
+
+func BenchmarkMPoolDestroyUnrelatedPointersByOwnerSize(b *testing.B) {
+	for _, unrelatedSize := range []int{0, 10_000, 100_000} {
+		for _, ownerSize := range []int{0, 1, 8, 32, 128} {
+			b.Run(fmt.Sprintf("unrelated=%d/owned=%d", unrelatedSize, ownerSize), func(b *testing.B) {
+				onHeapOwner := MustNew("shard-hint-bench-onheap")
+				offHeapOwner := MustNew("shard-hint-bench-offheap")
+				defer DeleteMPool(onHeapOwner)
+				defer DeleteMPool(offHeapOwner)
+				buffers := make([][]byte, 0, unrelatedSize)
+				for i := range unrelatedSize {
+					owner, offHeap := onHeapOwner, false
+					if i%2 == 1 {
+						owner, offHeap = offHeapOwner, true
+					}
+					buffer, err := owner.Alloc(64, offHeap)
+					if err != nil {
+						b.Fatal(err)
+					}
+					buffers = append(buffers, buffer)
+				}
+
+				sample := MustNew("shard-hint-bench-target-sample")
+				sampleBuffers := make([][]byte, ownerSize)
+				for i := range sampleBuffers {
+					buffer, err := sample.Alloc(64, false)
+					if err != nil {
+						b.Fatal(err)
+					}
+					sampleBuffers[i] = buffer
+				}
+				touchedShards := 0
+				sampleHintMask := expectedOnHeapShardHints(sample)
+				for _, word := range sampleHintMask {
+					touchedShards += bits.OnesCount64(word)
+				}
+				for _, buffer := range sampleBuffers {
+					sample.Free(buffer)
+				}
+				DeleteMPool(sample)
+
+				targetBuffers := make([][]byte, ownerSize)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					target := MustNew("shard-hint-bench-target")
+					for i := range targetBuffers {
+						buffer, err := target.Alloc(64, false)
+						if err != nil {
+							b.Fatal(err)
+						}
+						targetBuffers[i] = buffer
+					}
+					for _, buffer := range targetBuffers {
+						target.Free(buffer)
+					}
+					DeleteMPool(target)
+				}
+				b.StopTimer()
+				b.ReportMetric(float64(touchedShards), "touched-shards")
+				for i, buffer := range buffers {
+					if i%2 == 0 {
+						onHeapOwner.Free(buffer)
+					} else {
+						offHeapOwner.Free(buffer)
+					}
+				}
+			})
+		}
+	}
+}

--- a/pkg/common/mpool/mpool_onheap_shard_hint_test.go
+++ b/pkg/common/mpool/mpool_onheap_shard_hint_test.go
@@ -64,6 +64,21 @@ func TestOnHeapShardHintsAreConservativeAndExact(t *testing.T) {
 	defer DeleteMPool(freeingPool)
 
 	ownerBuffers := make([][]byte, 0, 3)
+	var offHeap, otherBuffer []byte
+	defer func() {
+		for _, buffer := range ownerBuffers {
+			if buffer != nil {
+				owner.Free(buffer)
+			}
+		}
+		if offHeap != nil {
+			owner.Free(offHeap)
+		}
+		if otherBuffer != nil {
+			other.Free(otherBuffer)
+		}
+	}()
+
 	for _, size := range []int{64, 96, 128} {
 		buffer, err := owner.Alloc(size, false)
 		require.NoError(t, err)
@@ -78,7 +93,7 @@ func TestOnHeapShardHintsAreConservativeAndExact(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, onHeapShardHintsForTest(owner))
 
-	otherBuffer, err := other.Alloc(48, false)
+	otherBuffer, err = other.Alloc(48, false)
 	require.NoError(t, err)
 	freeingPool.Free(ownerBuffers[0])
 	ownerBuffers[0] = nil
@@ -89,8 +104,11 @@ func TestOnHeapShardHintsAreConservativeAndExact(t *testing.T) {
 	freeingPool.Free(ownerBuffers[1])
 	ownerBuffers[1] = nil
 	owner.Free(ownerBuffers[2])
+	ownerBuffers[2] = nil
 	owner.Free(offHeap)
+	offHeap = nil
 	other.Free(otherBuffer)
+	otherBuffer = nil
 	requireHintedOutstandingMatchesRegistry(t, owner)
 	requireHintedOutstandingMatchesRegistry(t, other)
 	ownerBytes, ownerObjects := owner.scanOnHeapOutstandingHinted()
@@ -113,6 +131,16 @@ func TestOnHeapShardHintsConcurrentPublicationAndCrossPoolFree(t *testing.T) {
 		ops     = 64
 	)
 	buffers := make([][][]byte, workers)
+	defer func() {
+		for _, workerBuffers := range buffers {
+			for _, buffer := range workerBuffers {
+				if buffer != nil {
+					owner.Free(buffer)
+				}
+			}
+		}
+	}()
+
 	start := make(chan struct{})
 	errCh := make(chan error, workers)
 	var wg sync.WaitGroup
@@ -148,8 +176,9 @@ func TestOnHeapShardHintsConcurrentPublicationAndCrossPoolFree(t *testing.T) {
 		go func(worker int) {
 			defer wg.Done()
 			<-start
-			for _, buffer := range buffers[worker] {
+			for i, buffer := range buffers[worker] {
 				freeingPool.Free(buffer)
+				buffers[worker][i] = nil
 			}
 		}(worker)
 	}
@@ -171,6 +200,16 @@ func BenchmarkMPoolDestroyUnrelatedPointersByOwnerSize(b *testing.B) {
 				defer DeleteMPool(onHeapOwner)
 				defer DeleteMPool(offHeapOwner)
 				buffers := make([][]byte, 0, unrelatedSize)
+				defer func() {
+					b.StopTimer()
+					for i, buffer := range buffers {
+						if i%2 == 0 {
+							onHeapOwner.Free(buffer)
+						} else {
+							offHeapOwner.Free(buffer)
+						}
+					}
+				}()
 				for i := range unrelatedSize {
 					owner, offHeap := onHeapOwner, false
 					if i%2 == 1 {
@@ -188,6 +227,10 @@ func BenchmarkMPoolDestroyUnrelatedPointersByOwnerSize(b *testing.B) {
 				for i := range sampleBuffers {
 					buffer, err := sample.Alloc(64, false)
 					if err != nil {
+						for _, allocated := range sampleBuffers[:i] {
+							sample.Free(allocated)
+						}
+						DeleteMPool(sample)
 						b.Fatal(err)
 					}
 					sampleBuffers[i] = buffer
@@ -210,6 +253,10 @@ func BenchmarkMPoolDestroyUnrelatedPointersByOwnerSize(b *testing.B) {
 					for i := range targetBuffers {
 						buffer, err := target.Alloc(64, false)
 						if err != nil {
+							for _, allocated := range targetBuffers[:i] {
+								target.Free(allocated)
+							}
+							DeleteMPool(target)
 							b.Fatal(err)
 						}
 						targetBuffers[i] = buffer
@@ -221,13 +268,6 @@ func BenchmarkMPoolDestroyUnrelatedPointersByOwnerSize(b *testing.B) {
 				}
 				b.StopTimer()
 				b.ReportMetric(float64(touchedShards), "touched-shards")
-				for i, buffer := range buffers {
-					if i%2 == 0 {
-						onHeapOwner.Free(buffer)
-					} else {
-						offHeapOwner.Free(buffer)
-					}
-				}
 			})
 		}
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

References #28530. This is a scoped mitigation and intentionally does not close the issue: pools that touch many pointer shards still inspect most of the registry, and the reported QA workload profile has not yet been re-captured with this change.

## What this PR does / why we need it:

`MPool.destroy()` previously called `OnHeapOutstanding()` for locking pools, scanning and locking every process-wide pointer-registry shard even when the pool had allocated only a few on-heap objects.

Each locking pool now records a conservative bitset of shards into which successful on-heap pointer registrations were published. Teardown scans only those shards and still derives exact outstanding bytes and object counts from the authoritative pointer maps. Bits are monotonic and are not cleared on free, so stale bits can only cause extra scans; they cannot hide a still-live pointer. Off-heap registrations do not set the hints, noLock pools retain their local exact-map path, and the public `OnHeapOutstanding()` full-scan behavior is unchanged.

The hot path adds a bit-test on registration and a CAS only on first publication to a shard. The pool stores two atomic words (16 bytes at the current 128-shard configuration); it does not add per-allocation heap objects or change pointer-map ownership.

### Local benchmark evidence

Linux/amd64, Ryzen 9 7900X, `GOMAXPROCS=8`, 3 samples, 100ms each. Each operation creates a target pool, allocates/frees the listed number of on-heap objects, then deletes it while unrelated registry entries remain live. Candidate medians:

| Unrelated live entries | Target owned objects | Hinted shards | End-to-end pool lifecycle |
|---:|---:|---:|---:|
| 0 | 1 | 1 | 0.38 us/op |
| 10,000 | 1 | 1 | 0.90 us/op |
| 100,000 | 1 | 1 | 6.05 us/op |
| 100,000 | 8 | 8 | 44.2 us/op |
| 100,000 | 32 | 29 | 161.6 us/op |
| 100,000 | 128 | 80 | 464.5 us/op |

The benefit narrows as an owner touches more shards; the 128-object case is close to a full scan. A prior paired one-object microbenchmark on the same hint implementation measured about 5–8.5 us/op versus 501–737 us/op at the base. These are local microbenchmarks, not end-to-end SQL or the original QA workload. Please keep #28530 open until the same QA workload/profile is re-measured and the residual high-fanout cost is assessed.

### Test Plan

- Focused UT: `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -run "^TestOnHeapShardHints" ./pkg/common/mpool`
- Owning package UT and race: `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 ./pkg/common/mpool` and `.agents/skills/mo-dev/scripts/mo-cgo-test -race -count=1 ./pkg/common/mpool`
- New concurrency cases: run each exact test with `-race -count=100`.
- Scoped static checks: `golangci-lint run -c .golangci.yml ./pkg/common/mpool`, `go vet ./pkg/common/mpool`, and repository `molint` on the package.
- Scale benchmark: `.agents/skills/mo-dev/scripts/mo-cgo-test -run "^$" -bench "^BenchmarkMPoolDestroyUnrelatedPointersByOwnerSize$" -benchtime=100ms -count=3 ./pkg/common/mpool`.

BVT is not applicable: this changes internal allocator diagnostics only; SQL-visible results and ownership/free semantics are unchanged.