### PR TITLE
fix: preserve prepared binary bitwise semantics

### DIFF
--- a/pkg/sql/plan/function/func_bitwise_unsigned_test.go
+++ b/pkg/sql/plan/function/func_bitwise_unsigned_test.go
@@ -198,3 +198,21 @@ func TestBitwiseBinaryArgumentsKeepBytewiseOverloads(t *testing.T) {
 	require.Equal(t, int32(2), get.overloadId)
 	require.Equal(t, types.T_varbinary, get.GetReturnType().Oid)
 }
+
+func TestBitwiseBlobArgumentsSelectBytewiseOverloads(t *testing.T) {
+	ctx := context.Background()
+	for _, operator := range []string{"&", "|", "^"} {
+		t.Run(operator, func(t *testing.T) {
+			get, err := GetFunctionByName(ctx, operator,
+				[]types.Type{types.T_blob.ToType(), types.T_blob.ToType()})
+			require.NoError(t, err)
+			targets, cast := get.ShouldDoImplicitTypeCast()
+			require.False(t, cast)
+			require.Nil(t, targets)
+			require.Equal(t, int32(6), get.overloadId)
+			require.Equal(t, types.T_blob, get.GetReturnType().Oid)
+			require.Equal(t, types.CharsetBinary, get.GetReturnType().Charset)
+			assertBitwiseExecFactory(t, get)
+		})
+	}
+}

--- a/pkg/sql/plan/function/list_operator.go
+++ b/pkg/sql/plan/function/list_operator.go
@@ -3298,6 +3298,16 @@ var supportedOperators = []FuncNew{
 				retType:    func(parameters []types.Type) types.Type { return types.T_uint64.ToType() },
 				newOp:      func() executeLogicOfOverload { return operatorOpBitAndInt64Uint64Fn },
 			},
+			{
+				overloadId: 6,
+				args:       []types.T{types.T_blob, types.T_blob},
+				retType: func(parameters []types.Type) types.Type {
+					return bitwiseBinaryReturnType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return operatorOpBitAndStrFn
+				},
+			},
 		},
 	},
 
@@ -3357,6 +3367,16 @@ var supportedOperators = []FuncNew{
 				retType:    func(parameters []types.Type) types.Type { return types.T_uint64.ToType() },
 				newOp:      func() executeLogicOfOverload { return operatorOpBitOrInt64Uint64Fn },
 			},
+			{
+				overloadId: 6,
+				args:       []types.T{types.T_blob, types.T_blob},
+				retType: func(parameters []types.Type) types.Type {
+					return bitwiseBinaryReturnType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return operatorOpBitOrStrFn
+				},
+			},
 		},
 	},
 
@@ -3415,6 +3435,16 @@ var supportedOperators = []FuncNew{
 				args:       []types.T{types.T_int64, types.T_uint64},
 				retType:    func(parameters []types.Type) types.Type { return types.T_uint64.ToType() },
 				newOp:      func() executeLogicOfOverload { return operatorOpBitXorInt64Uint64Fn },
+			},
+			{
+				overloadId: 6,
+				args:       []types.T{types.T_blob, types.T_blob},
+				retType: func(parameters []types.Type) types.Type {
+					return bitwiseBinaryReturnType(parameters)
+				},
+				newOp: func() executeLogicOfOverload {
+					return operatorOpBitXorStrFn
+				},
 			},
 		},
 	},

--- a/pkg/sql/plan/issue_28791_prepared_bitwise_test.go
+++ b/pkg/sql/plan/issue_28791_prepared_bitwise_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue28791PreparedBinaryBitwisePlanRebindsProtocolDomain(t *testing.T) {
+	binaryParam := func(value string) ParamValue {
+		return ParamValue{
+			Value:            value,
+			IsBinaryString:   true,
+			IsBinaryProtocol: true,
+			RuntimeType:      types.T_blob.ToType(),
+			HasRuntimeType:   true,
+		}
+	}
+	integerParam := func(value string) ParamValue {
+		return ParamValue{
+			Value:            value,
+			IsBinaryProtocol: true,
+			RuntimeType:      types.T_int64.ToType(),
+			HasRuntimeType:   true,
+		}
+	}
+
+	for _, test := range []struct {
+		name       string
+		query      string
+		function   string
+		params     []any
+		argTypes   []types.T
+		resultType types.T
+	}{
+		{
+			name:       "and with two binary params",
+			query:      "select hex(? & ?) from nation",
+			function:   "&",
+			params:     []any{binaryParam(string([]byte{0x12})), binaryParam(string([]byte{0x34}))},
+			argTypes:   []types.T{types.T_blob, types.T_blob},
+			resultType: types.T_blob,
+		},
+		{
+			name:       "or with two binary params",
+			query:      "select hex(? | ?) from nation",
+			function:   "|",
+			params:     []any{binaryParam(string([]byte{0x12})), binaryParam(string([]byte{0x34}))},
+			argTypes:   []types.T{types.T_blob, types.T_blob},
+			resultType: types.T_blob,
+		},
+		{
+			name:       "xor with two binary params",
+			query:      "select hex(? ^ ?) from nation",
+			function:   "^",
+			params:     []any{binaryParam(string([]byte{0x12})), binaryParam(string([]byte{0x34}))},
+			argTypes:   []types.T{types.T_blob, types.T_blob},
+			resultType: types.T_blob,
+		},
+		{
+			name:       "complement binary param",
+			query:      "select hex(~?) from nation",
+			function:   "unary_tilde",
+			params:     []any{binaryParam(string([]byte{0x12, 0x34}))},
+			argTypes:   []types.T{types.T_blob},
+			resultType: types.T_blob,
+		},
+		{
+			name:       "right shift binary param by integer",
+			query:      "select hex(? >> ?) from nation",
+			function:   ">>",
+			params:     []any{binaryParam(string([]byte{0x80})), integerParam("1")},
+			argTypes:   []types.T{types.T_blob, types.T_int64},
+			resultType: types.T_blob,
+		},
+		{
+			name:       "left shift binary param by integer",
+			query:      "select hex(? << ?) from nation",
+			function:   "<<",
+			params:     []any{binaryParam(string([]byte{0x12, 0x34})), integerParam("8")},
+			argTypes:   []types.T{types.T_blob, types.T_int64},
+			resultType: types.T_blob,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			prepare := buildPreparedAggregatePlan(t, test.query)
+			require.True(t, PreparedPlanNeedsRuntimeSpecialization(prepare.Plan),
+				"prepared bitwise expression must rebind when a COM_STMT parameter can change its domain")
+
+			filled, specialized, err := FillValuesOfParamsInPlanWithSpecialization(
+				context.Background(), prepare.Plan, test.params)
+			require.NoError(t, err)
+			require.True(t, specialized)
+
+			operator := findPlanFunctionExpr(filled, test.function)
+			require.NotNil(t, operator)
+			require.Len(t, operator.GetF().Args, len(test.argTypes))
+			for i, want := range test.argTypes {
+				require.Equal(t, int32(want), operator.GetF().Args[i].Typ.Id,
+					"argument %d", i)
+			}
+			require.Equal(t, int32(test.resultType), operator.Typ.Id)
+			require.Equal(t, uint32(types.CharsetBinary), operator.Typ.Charset)
+		})
+	}
+
+	t.Run("numeric parameters retain numeric bitwise overload", func(t *testing.T) {
+		prepare := buildPreparedAggregatePlan(t, "select ? & ? from nation")
+		filled, _, err := FillValuesOfParamsInPlanWithSpecialization(
+			context.Background(), prepare.Plan,
+			[]any{integerParam("18"), integerParam("52")})
+		require.NoError(t, err)
+
+		operator := findPlanFunctionExpr(filled, "&")
+		require.NotNil(t, operator)
+		require.Len(t, operator.GetF().Args, 2)
+		require.Equal(t, int32(types.T_int64), operator.GetF().Args[0].Typ.Id)
+		require.Equal(t, int32(types.T_int64), operator.GetF().Args[1].Typ.Id)
+		require.Equal(t, int32(types.T_uint64), operator.Typ.Id)
+		require.Equal(t, types.StringDomainNone,
+			types.StaticStringDomain(makeTypeByPlan2Expr(operator)))
+	})
+
+	t.Run("explicit casts remain authoritative", func(t *testing.T) {
+		prepare := buildPreparedAggregatePlan(t,
+			"select CAST(? AS SIGNED) & CAST(? AS SIGNED) from nation")
+		preparedOperator := findPlanFunctionExpr(prepare.Plan, "&")
+		require.NotNil(t, preparedOperator)
+		for i, arg := range preparedOperator.GetF().Args {
+			require.True(t, isExplicitPreparedCast(arg), "prepared argument %d: %s", i, arg.String())
+		}
+		filled, _, err := FillValuesOfParamsInPlanWithSpecialization(
+			context.Background(), prepare.Plan,
+			[]any{binaryParam(string([]byte{0x12})), binaryParam(string([]byte{0x34}))})
+		require.NoError(t, err)
+
+		operator := findPlanFunctionExpr(filled, "&")
+		require.NotNil(t, operator)
+		require.Len(t, operator.GetF().Args, 2)
+		for i, arg := range operator.GetF().Args {
+			require.Equal(t, int32(types.T_int64), arg.Typ.Id, "argument %d", i)
+		}
+		require.Equal(t, int32(types.T_uint64), operator.Typ.Id)
+	})
+}

--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -1877,6 +1877,8 @@ func (rule *ResetParamRefRule) applyExpr(e *plan.Expr) (*plan.Expr, error) {
 				originalArgFuncObj = preparedExprFunctionObj(arg)
 			}
 			implicitParamCast := isImplicitPreparedParamCast(arg)
+			bitwiseParamCast := isPreparedBitwiseOperator(functionName) &&
+				isPreparedBitwiseParamCast(arg)
 			paramPos, hasParamPos := preparedParamPosition(arg)
 			if !hasParamPos && preparedFunctionArgUsesSQLExecuteNumericSource(
 				e, functionName, i, len(exprImpl.F.Args)) {
@@ -1940,11 +1942,10 @@ func (rule *ResetParamRefRule) applyExpr(e *plan.Expr) (*plan.Expr, error) {
 				needResetFunction = true
 				compareArgTypes = true
 			}
-			if implicitParamCast {
-				// The prepare-time TEXT marker may have been wrapped in an
-				// implicit numeric cast selected by overload resolution.  The
-				// cast is provisional; the execute-time value must participate in
-				// resolving the outer function again.
+			if implicitParamCast || bitwiseParamCast {
+				// The prepare-time parameter may have been wrapped in a provisional
+				// cast selected by overload resolution. The execute-time value must
+				// participate in resolving the outer function again.
 				needResetFunction = true
 			}
 			var rewrittenArg *plan.Expr
@@ -2037,6 +2038,12 @@ func (rule *ResetParamRefRule) applyExpr(e *plan.Expr) (*plan.Expr, error) {
 				// bound against the old child domain and must be resolved again.
 				needResetFunction = true
 				compareArgTypes = true
+			}
+			if bitwiseParamCast {
+				if unwrapped, ok := unwrapImplicitPreparedBinaryParamCast(rewrittenArg); ok {
+					boundArgs[i] = unwrapped
+					compareArgTypes = true
+				}
 			}
 			if implicitParamCast {
 				// Keep decimal casts: decimal arithmetic requires every operand to
@@ -3450,6 +3457,67 @@ func implicitPreparedParam(expr *plan.Expr) (*plan.ParamRef, bool) {
 		current = fn.Args[0]
 	}
 	return nil, false
+}
+
+func isPreparedBitwiseOperator(name string) bool {
+	switch name {
+	case "&", "|", "^", "<<", ">>", "unary_tilde":
+		return true
+	default:
+		return false
+	}
+}
+
+// isPreparedBitwiseParamCast recognizes a provisional cast chain around a
+// prepared marker when bitwise overload resolution used either the ordinary
+// cast or the comparison-cast overload. Explicit and set-operation casts stay
+// semantic boundaries.
+func isPreparedBitwiseParamCast(expr *plan.Expr) bool {
+	current := expr
+	seenCast := false
+	for current != nil {
+		if param := current.GetP(); param != nil {
+			return seenCast && param.Pos >= 0
+		}
+		fn := current.GetF()
+		if fn == nil || fn.Func == nil || fn.Func.GetObjName() != "cast" || len(fn.Args) == 0 ||
+			fn.GetSyntaxExplicitCast() {
+			return false
+		}
+		_, overload := planfunction.DecodeOverloadID(fn.Func.GetObj())
+		if overload != 0 && overload != 2 {
+			return false
+		}
+		seenCast = true
+		current = fn.Args[0]
+	}
+	return false
+}
+
+// unwrapImplicitPreparedBinaryParamCast removes the prepare-time overload
+// casts around a binary protocol value before rebinding a bitwise operator.
+// The caller has already verified that the original expression contains only
+// provisional casts, so explicit CAST remains authoritative.
+func unwrapImplicitPreparedBinaryParamCast(rewritten *plan.Expr) (*plan.Expr, bool) {
+	current := rewritten
+	for current != nil {
+		fn := current.GetF()
+		if fn == nil || fn.Func == nil || fn.Func.GetObjName() != "cast" || len(fn.Args) == 0 {
+			break
+		}
+		if fn.GetSyntaxExplicitCast() {
+			return nil, false
+		}
+		_, overload := planfunction.DecodeOverloadID(fn.Func.GetObj())
+		if overload != 0 && overload != 2 {
+			return nil, false
+		}
+		current = fn.Args[0]
+	}
+	if current == nil || types.StaticStringDomain(makeTypeByPlan2Expr(current)) != types.StringDomainBinary {
+		return nil, false
+	}
+	return current, true
 }
 
 // unwrapImplicitPreparedParamCast strips a provisional overload cast only when

--- a/pkg/tests/issues/issue_28791_test.go
+++ b/pkg/tests/issues/issue_28791_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issues
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	mysqlDriver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/embed"
+)
+
+const mysqlComStmtExecute byte = 0x17
+
+type issue28791BinaryProtocolConn struct {
+	net.Conn
+	mu                 sync.Mutex
+	executeParamCounts []int
+	nextExecution      int
+	patchedParamCounts []int
+}
+
+func (conn *issue28791BinaryProtocolConn) Write(packet []byte) (int, error) {
+	if len(packet) >= 5 && packet[4] == mysqlComStmtExecute {
+		conn.mu.Lock()
+		defer conn.mu.Unlock()
+		if conn.nextExecution >= len(conn.executeParamCounts) {
+			return 0, fmt.Errorf("unexpected COM_STMT_EXECUTE packet %d", conn.nextExecution+1)
+		}
+		paramCount := conn.executeParamCounts[conn.nextExecution]
+		typeOffset := 14 + (paramCount+7)/8 + 1 // header, null bitmap, new-params flag
+		if typeOffset+paramCount*2 > len(packet) {
+			return 0, fmt.Errorf("truncated COM_STMT_EXECUTE type table for %d params", paramCount)
+		}
+		patched := 0
+		for i := 0; i < paramCount; i++ {
+			if packet[typeOffset+2*i] == byte(defines.MYSQL_TYPE_STRING) {
+				// go-sql-driver encodes []byte as MYSQL_TYPE_STRING; Connector/J's
+				// setBytes uses the BLOB family. Preserve the payload and exercise
+				// the same COM_STMT_EXECUTE domain that MatrixOne receives from it.
+				packet[typeOffset+2*i] = byte(defines.MYSQL_TYPE_BLOB)
+				patched++
+			}
+		}
+		if patched == 0 {
+			return 0, fmt.Errorf("COM_STMT_EXECUTE packet %d contained no byte parameters", conn.nextExecution+1)
+		}
+		conn.patchedParamCounts = append(conn.patchedParamCounts, patched)
+		conn.nextExecution++
+	}
+	return conn.Conn.Write(packet)
+}
+
+func (conn *issue28791BinaryProtocolConn) patchedCounts() []int {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	return append([]int(nil), conn.patchedParamCounts...)
+}
+
+func TestIssue28791PreparedBinaryBitwiseOperators(t *testing.T) {
+	embed.RunBaseClusterTests(t, func(c embed.Cluster) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cn, err := c.GetCNService(0)
+		require.NoError(t, err)
+		port := cn.GetServiceConfig().CN.Frontend.Port
+		const testDialName = "mo_issue_28791_binary_protocol"
+		var binaryConn *issue28791BinaryProtocolConn
+		mysqlDriver.RegisterDialContext(testDialName, func(ctx context.Context, address string) (net.Conn, error) {
+			conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
+			if err != nil {
+				return nil, err
+			}
+			binaryConn = &issue28791BinaryProtocolConn{
+				Conn:               conn,
+				executeParamCounts: []int{12, 2},
+			}
+			return binaryConn, nil
+		})
+		t.Cleanup(func() { mysqlDriver.DeregisterDialContext(testDialName) })
+		db, err := sql.Open("mysql", fmt.Sprintf(
+			"dump:111@%s(127.0.0.1:%d)/?interpolateParams=false", testDialName, port))
+		require.NoError(t, err)
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		defer db.Close()
+
+		stmt, err := db.PrepareContext(ctx,
+			"select HEX(? & ?), HEX(? | ?), HEX(? ^ ?), HEX(~?), HEX(~?), HEX(? >> ?), HEX(? << ?)")
+		require.NoError(t, err)
+		defer stmt.Close()
+
+		rows, err := stmt.QueryContext(ctx,
+			[]byte{0x12}, []byte{0x34},
+			[]byte{0x12}, []byte{0x34},
+			[]byte{0x12}, []byte{0x34},
+			[]byte{0x80}, []byte{0x12, 0x34},
+			[]byte{0x80}, int64(1),
+			[]byte{0x12, 0x34}, int64(8))
+		require.NoError(t, err)
+		defer rows.Close()
+		require.True(t, rows.Next())
+		var got [7]string
+		require.NoError(t, rows.Scan(
+			&got[0], &got[1], &got[2], &got[3], &got[4], &got[5], &got[6]))
+		require.Equal(t, [7]string{"10", "36", "26", "7F", "EDCB", "40", "3400"}, got)
+		require.False(t, rows.Next())
+		require.NoError(t, rows.Err())
+
+		// Once both operands retain their BLOB domain, unequal byte lengths must
+		// be rejected by the bytewise overload instead of silently using integers.
+		mismatch, err := db.PrepareContext(ctx, "select HEX(? & ?)")
+		require.NoError(t, err)
+		defer mismatch.Close()
+		mismatchRows, err := mismatch.QueryContext(ctx, []byte{0x01}, []byte{0x00, 0x01})
+		if err == nil {
+			defer mismatchRows.Close()
+			require.False(t, mismatchRows.Next(), "unequal-length bytewise operands must fail")
+			err = mismatchRows.Err()
+		}
+		require.Error(t, err)
+		require.NotNil(t, binaryConn)
+		require.Equal(t, []int{10, 2}, binaryConn.patchedCounts(),
+			"the executed parameter type tables must carry MYSQL_TYPE_BLOB")
+	})
+}


### PR DESCRIPTION
Fixes #28791.\n\n## Summary\n- Rebind prepared bitwise operands from execute-time binary protocol types only when the prepare-time cast is provisional; preserve explicit casts and numeric behavior.\n- Add BLOB overloads for &, |, and ^ using the existing bytewise kernels.\n- Add planner controls and an isolated prepared-protocol regression covering all six bitwise operators.\n\n## Validation\n- Focused planner and overload tests; full pkg/sql/plan and pkg/sql/plan/function tests.\n- Embedded protocol integration test for BLOB values and unequal-length operands.\n- Package-scoped go vet and golangci-lint (0 issues).