### PR TITLE
[Compatibility]: support BIT unary complement and DIV

### DIFF
--- a/pkg/sql/plan/function/arithmetic.go
+++ b/pkg/sql/plan/function/arithmetic.go
@@ -135,6 +135,29 @@ func integerDivOperatorSupports(typ1, typ2 types.Type) bool {
 	}
 }
 
+// integerDivBitTypes preserves BIT as the dividend's result-domain marker and
+// widens only the divisor. MySQL returns BIGINT UNSIGNED for BIT DIV integer,
+// so coercing the BIT dividend to int64 would lose values above MaxInt64.
+func integerDivBitTypes(left, right types.Type) (types.Type, types.Type, bool) {
+	if left.Oid != types.T_bit {
+		return types.Type{}, types.Type{}, false
+	}
+
+	switch {
+	case right.Oid.IsSignedInt():
+		return left, types.T_int64.ToType(), true
+	case right.Oid.IsUnsignedInt(), right.Oid == types.T_bit, right.Oid == types.T_any:
+		return left, types.T_uint64.ToType(), true
+	default:
+		return types.Type{}, types.Type{}, false
+	}
+}
+
+func integerDivBitResolvedTypes(left, right types.Type) bool {
+	return left.Oid == types.T_bit &&
+		(right.Oid == types.T_int64 || right.Oid == types.T_uint64)
+}
+
 // integerDivUnsignedMixedTypes preserves the unsigned domain of the left
 // operand for the mixed DIV cases that can otherwise be coerced to a signed
 // decimal or floating-point type. The executor consumes these canonical types
@@ -544,6 +567,13 @@ func divFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, pro
 }
 
 func integerDivFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	if integerDivBitResolvedTypes(*parameters[0].GetType(), *parameters[1].GetType()) {
+		if parameters[1].GetType().Oid == types.T_int64 {
+			return integerDivBitSigned(parameters, result, proc, length, selectList)
+		}
+		return integerDivBitUnsigned(parameters, result, proc, length, selectList)
+	}
+
 	if integerDivUnsignedMixedResolvedTypes(*parameters[0].GetType(), *parameters[1].GetType()) {
 		if parameters[1].GetType().Oid == types.T_int64 {
 			return integerDivUnsignedSigned(parameters, result, proc, length, selectList)
@@ -575,6 +605,112 @@ func integerDivFn(parameters []*vector.Vector, result vector.FunctionResultWrapp
 		return decimalBatchArith[types.Decimal256, int64](parameters, result, proc, length, d256IntDivKernel(proc, selectList), selectList)
 	}
 	panic("unreached code")
+}
+
+func integerDivBitSigned(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	if length == 0 {
+		return nil
+	}
+
+	result.UseOptFunctionParamFrame(2)
+	rs := vector.MustFunctionResult[uint64](result)
+	p1 := vector.OptGetParamFromWrapper[uint64](rs, 0, parameters[0])
+	p2 := vector.OptGetParamFromWrapper[int64](rs, 1, parameters[1])
+	rss := vector.MustFixedColNoTypeCheck[uint64](rs.GetResultVector())
+	rsNull := rs.GetResultVector().GetNulls()
+	done, skipMasked := maskUnselectedRows(rsNull, selectList, length)
+	if done {
+		return nil
+	}
+
+	constantLeft, constantRight := parameters[0].IsConst(), parameters[1].IsConst()
+	shouldError := checkDivisionByZeroBehavior(proc, selectList)
+	for i := uint64(0); i < uint64(length); i++ {
+		if skipMasked && rsNull.Contains(i) {
+			continue
+		}
+		leftIndex, rightIndex := i, i
+		if constantLeft {
+			leftIndex = 0
+		}
+		if constantRight {
+			rightIndex = 0
+		}
+		dividend, nullLeft := p1.GetValue(leftIndex)
+		divisor, nullRight := p2.GetValue(rightIndex)
+		if nullLeft || nullRight {
+			rsNull.Add(i)
+			continue
+		}
+		if divisor == 0 {
+			if shouldError {
+				return moerr.NewDivByZeroNoCtx()
+			}
+			rsNull.Add(i)
+			continue
+		}
+
+		if divisor > 0 {
+			rss[i] = dividend / uint64(divisor)
+			continue
+		}
+
+		// A non-zero negative quotient is outside BIGINT UNSIGNED. Form the
+		// divisor magnitude without overflowing for MinInt64.
+		absDivisor := uint64(-(divisor + 1)) + 1
+		if dividend/absDivisor != 0 {
+			return moerr.NewOutOfRangeNoCtx("BIGINT UNSIGNED", "")
+		}
+		rss[i] = 0
+	}
+	return nil
+}
+
+func integerDivBitUnsigned(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	if length == 0 {
+		return nil
+	}
+
+	result.UseOptFunctionParamFrame(2)
+	rs := vector.MustFunctionResult[uint64](result)
+	p1 := vector.OptGetParamFromWrapper[uint64](rs, 0, parameters[0])
+	p2 := vector.OptGetParamFromWrapper[uint64](rs, 1, parameters[1])
+	rss := vector.MustFixedColNoTypeCheck[uint64](rs.GetResultVector())
+	rsNull := rs.GetResultVector().GetNulls()
+	done, skipMasked := maskUnselectedRows(rsNull, selectList, length)
+	if done {
+		return nil
+	}
+
+	constantLeft, constantRight := parameters[0].IsConst(), parameters[1].IsConst()
+	shouldError := checkDivisionByZeroBehavior(proc, selectList)
+	for i := uint64(0); i < uint64(length); i++ {
+		if skipMasked && rsNull.Contains(i) {
+			continue
+		}
+		leftIndex, rightIndex := i, i
+		if constantLeft {
+			leftIndex = 0
+		}
+		if constantRight {
+			rightIndex = 0
+		}
+		dividend, nullLeft := p1.GetValue(leftIndex)
+		divisor, nullRight := p2.GetValue(rightIndex)
+		if nullLeft || nullRight {
+			rsNull.Add(i)
+			continue
+		}
+		if divisor == 0 {
+			if shouldError {
+				return moerr.NewDivByZeroNoCtx()
+			}
+			rsNull.Add(i)
+			continue
+		}
+		rss[i] = dividend / divisor
+	}
+	return nil
 }
 
 // maskUnselectedRows marks rows short-circuited by selectList (e.g. the

--- a/pkg/sql/plan/function/func_bitwise_bit_numeric_test.go
+++ b/pkg/sql/plan/function/func_bitwise_bit_numeric_test.go
@@ -1,0 +1,295 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitUnaryTildeUsesUnsigned64Domain(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct {
+		name   string
+		typ    types.Type
+		input  []uint64
+		result []uint64
+	}{
+		{
+			name:   "bit1",
+			typ:    types.New(types.T_bit, 1, 0),
+			input:  []uint64{0, 1},
+			result: []uint64{math.MaxUint64, math.MaxUint64 - 1},
+		},
+		{
+			name:   "bit8",
+			typ:    types.New(types.T_bit, 8, 0),
+			input:  []uint64{0, 0x80, 0xff},
+			result: []uint64{math.MaxUint64, math.MaxUint64 ^ 0x80, math.MaxUint64 ^ 0xff},
+		},
+		{
+			name:   "bit64",
+			typ:    types.New(types.T_bit, 64, 0),
+			input:  []uint64{0, uint64(1) << 63, math.MaxUint64},
+			result: []uint64{math.MaxUint64, math.MaxInt64, 0},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bound, err := GetFunctionByName(ctx, "unary_tilde", []types.Type{test.typ})
+			require.NoError(t, err)
+			require.Equal(t, int32(11), bound.overloadId)
+			targets, cast := bound.ShouldDoImplicitTypeCast()
+			require.False(t, cast)
+			require.Nil(t, targets)
+			require.Equal(t, types.T_uint64, bound.GetReturnType().Oid)
+			assertBitwiseExecFactory(t, bound)
+
+			proc := testutil.NewProcess(t)
+			tc := NewFunctionTestCase(proc,
+				[]FunctionTestInput{NewFunctionTestInput(test.typ, test.input, nil)},
+				NewFunctionTestResult(types.T_uint64.ToType(), false, test.result, nil),
+				operatorUnaryTilde[uint64])
+			cleanupBitwiseTestCase(t, &tc)
+			ok, info := tc.Run()
+			require.True(t, ok, info)
+		})
+	}
+}
+
+func TestResolveNumericBitIntegerDivDomains(t *testing.T) {
+	bit8 := types.New(types.T_bit, 8, 0)
+	bit64 := types.New(types.T_bit, 64, 0)
+	decimalContext := types.New(types.T_decimal128, 38, 0)
+	tests := []struct {
+		name      string
+		left      types.Type
+		right     types.Type
+		wantRight types.T
+		wantCast  bool
+		outer     *types.Type
+	}{
+		{name: "signed small divisor", left: bit8, right: types.T_int16.ToType(), wantRight: types.T_int64, wantCast: true},
+		{name: "signed bigint divisor", left: bit64, right: types.T_int64.ToType(), wantRight: types.T_int64},
+		{name: "unsigned divisor", left: bit8, right: types.T_uint32.ToType(), wantRight: types.T_uint64, wantCast: true},
+		{name: "bit divisor", left: bit8, right: types.New(types.T_bit, 1, 0), wantRight: types.T_uint64, wantCast: true},
+		{name: "untyped divisor", left: bit64, right: types.T_any.ToType(), wantRight: types.T_uint64, wantCast: true, outer: &decimalContext},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			left, right, ok := integerDivBitTypes(test.left, test.right)
+			require.True(t, ok)
+			require.Equal(t, test.left, left, "preserve the BIT width")
+			require.Equal(t, test.wantRight, right.Oid)
+			require.True(t, integerDivBitResolvedTypes(left, right))
+
+			resolved, ok := resolveNumericBinaryTypes(numericOpIntegerDiv, test.left, test.right, test.outer)
+			require.True(t, ok)
+			require.Equal(t, test.left, resolved.left)
+			require.Equal(t, test.wantRight, resolved.right.Oid)
+			require.Equal(t, types.T_uint64, resolved.result.Oid)
+
+			bound, err := GetFunctionByName(context.Background(), "div", []types.Type{test.left, test.right})
+			require.NoError(t, err)
+			targets, cast := bound.ShouldDoImplicitTypeCast()
+			require.Equal(t, test.wantCast, cast)
+			if test.wantCast {
+				require.Equal(t, test.left, targets[0])
+				require.Equal(t, test.wantRight, targets[1].Oid)
+			}
+			require.Equal(t, types.T_uint64, bound.GetReturnType().Oid)
+		})
+	}
+}
+
+func TestIntegerDivBitPreservesFullUnsignedRange(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+	tc := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(bit64, []uint64{0, uint64(1) << 63, math.MaxUint64}, nil),
+			NewFunctionTestInput(types.T_uint64.ToType(), []uint64{1, 1, 1}, nil),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), false,
+			[]uint64{0, uint64(1) << 63, math.MaxUint64}, nil),
+		integerDivFn)
+	cleanupBitwiseTestCase(t, &tc)
+	ok, info := tc.Run()
+	require.True(t, ok, info)
+
+	tc2 := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestConstInput(bit64, []uint64{uint64(1) << 63, uint64(1) << 63}, nil),
+			NewFunctionTestInput(types.T_uint64.ToType(), []uint64{1, 2}, nil),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), false,
+			[]uint64{uint64(1) << 63, uint64(1) << 62}, nil),
+		integerDivFn)
+	cleanupBitwiseTestCase(t, &tc2)
+	ok, info = tc2.Run()
+	require.True(t, ok, "constant BIT dividend broadcast: %s", info)
+}
+
+func TestIntegerDivBitSignedDivisorAndMinInt64(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+	tc1 := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(bit64, []uint64{0, 1, 1}, nil),
+			NewFunctionTestInput(types.T_int64.ToType(), []int64{-1, -2, math.MinInt64}, nil),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{0, 0, 0}, nil),
+		integerDivFn)
+	cleanupBitwiseTestCase(t, &tc1)
+	ok, info := tc1.Run()
+	require.True(t, ok, info)
+
+	tc2 := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(bit64, []uint64{math.MaxInt64, uint64(1) << 63}, nil),
+			NewFunctionTestInput(types.T_int64.ToType(), []int64{math.MinInt64, math.MinInt64}, nil),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), false, nil, nil),
+		integerDivFn)
+	cleanupBitwiseTestCase(t, &tc2)
+	require.NoError(t, tc2.result.PreExtendAndReset(2))
+	err := tc2.fn(tc2.parameters, tc2.result, proc, 2, nil)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrOutOfRange), "expected unsigned overflow, got %v", err)
+	require.Equal(t, uint64(0), vector.MustFixedColNoTypeCheck[uint64](tc2.GetResultVectorDirectly())[0])
+}
+
+func TestIntegerDivBitNullConstantAndMaskedRows(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+	t.Run("constant divisor and null propagation", func(t *testing.T) {
+		tc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(bit64, []uint64{uint64(1) << 63, 0}, []bool{false, true}),
+				NewFunctionTestConstInput(types.T_uint64.ToType(), []uint64{1}, []bool{false}),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false,
+				[]uint64{uint64(1) << 63, 0}, []bool{false, true}),
+			integerDivFn)
+		cleanupBitwiseTestCase(t, &tc)
+		ok, info := tc.Run()
+		require.True(t, ok, info)
+	})
+
+	t.Run("masked negative quotient is not evaluated", func(t *testing.T) {
+		selectList := &FunctionSelectList{AnyNull: true, SelectList: []bool{true, false}}
+		tc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(bit64, []uint64{0, uint64(1) << 63}, nil),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{-1, -1}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false, nil, nil),
+			integerDivFn).WithSelectList(selectList)
+		cleanupBitwiseTestCase(t, &tc)
+		require.NoError(t, tc.result.PreExtendAndReset(2))
+		require.NoError(t, tc.fn(tc.parameters, tc.result, proc, 2, selectList))
+		result := tc.GetResultVectorDirectly()
+		require.Equal(t, uint64(0), vector.MustFixedColNoTypeCheck[uint64](result)[0])
+		require.False(t, result.GetNulls().Contains(0))
+		require.True(t, result.GetNulls().Contains(1))
+	})
+}
+
+func TestIntegerDivBitZeroDivisorRespectsNullAndStrictMode(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+	atomic.StoreInt32(&proc.Base.DivByZeroErrorMode, 1)
+	defer atomic.StoreInt32(&proc.Base.DivByZeroErrorMode, -1)
+
+	tc := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(bit64, []uint64{0, 1}, []bool{true, false}),
+			NewFunctionTestConstInput(types.T_int64.ToType(), []int64{0}, []bool{false}),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), true, nil, nil),
+		integerDivFn)
+	cleanupBitwiseTestCase(t, &tc)
+	ok, info := tc.Run()
+	require.True(t, ok, "nonnull zero divisor should raise despite a NULL sibling: %s", info)
+
+	tc2 := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(bit64, []uint64{0, 1}, []bool{true, false}),
+			NewFunctionTestInput(types.T_int64.ToType(), []int64{0, 1}, nil),
+		},
+		NewFunctionTestResult(types.T_uint64.ToType(), false,
+			[]uint64{0, 1}, []bool{true, false}),
+		integerDivFn)
+	cleanupBitwiseTestCase(t, &tc2)
+	ok, info = tc2.Run()
+	require.True(t, ok, info)
+}
+
+func TestIntegerDivBitUnsignedZeroAndMaskedRows(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bit64 := types.New(types.T_bit, 64, 0)
+	atomic.StoreInt32(&proc.Base.DivByZeroErrorMode, 1)
+	defer atomic.StoreInt32(&proc.Base.DivByZeroErrorMode, -1)
+
+	t.Run("strict nonnull zero divisor errors", func(t *testing.T) {
+		tc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(bit64, []uint64{1}, nil),
+				NewFunctionTestInput(types.T_uint64.ToType(), []uint64{0}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false, nil, nil),
+			integerDivFn)
+		cleanupBitwiseTestCase(t, &tc)
+		require.NoError(t, tc.result.PreExtendAndReset(1))
+		err := tc.fn(tc.parameters, tc.result, proc, 1, nil)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrDivByZero), "expected division-by-zero error, got %v", err)
+	})
+
+	t.Run("null suppresses zero divisor", func(t *testing.T) {
+		tc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(bit64, []uint64{0, 4}, []bool{true, false}),
+				NewFunctionTestInput(types.T_uint64.ToType(), []uint64{0, 2}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false,
+				[]uint64{0, 2}, []bool{true, false}),
+			integerDivFn)
+		cleanupBitwiseTestCase(t, &tc)
+		ok, info := tc.Run()
+		require.True(t, ok, info)
+	})
+
+	t.Run("masked zero divisor is not evaluated", func(t *testing.T) {
+		selectList := &FunctionSelectList{AnyNull: true, SelectList: []bool{true, false}}
+		tc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(bit64, []uint64{8, 9}, nil),
+				NewFunctionTestInput(types.T_uint64.ToType(), []uint64{2, 0}, nil),
+			},
+			NewFunctionTestResult(types.T_uint64.ToType(), false,
+				[]uint64{4, 0}, []bool{false, true}),
+			integerDivFn).WithSelectList(selectList)
+		cleanupBitwiseTestCase(t, &tc)
+		ok, info := tc.Run()
+		require.True(t, ok, info)
+	})
+}

--- a/pkg/sql/plan/function/list_operator.go
+++ b/pkg/sql/plan/function/list_operator.go
@@ -2114,6 +2114,12 @@ var supportedOperators = []FuncNew{
 		layout:     BINARY_ARITHMETIC_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
 			if len(inputs) == 2 {
+				if t1, t2, ok := integerDivBitTypes(inputs[0], inputs[1]); ok {
+					if inputs[0].Eq(t1) && inputs[1].Eq(t2) {
+						return newCheckResultWithSuccess(0)
+					}
+					return newCheckResultWithCast(0, []types.Type{t1, t2})
+				}
 				// Keep same-domain operands unchanged where possible.
 				if integerDivOperatorSupports(inputs[0], inputs[1]) {
 					return newCheckResultWithSuccess(0)
@@ -2143,6 +2149,9 @@ var supportedOperators = []FuncNew{
 			{
 				overloadId: 0,
 				retType: func(parameters []types.Type) types.Type {
+					if len(parameters) > 0 && parameters[0].Oid == types.T_bit {
+						return types.T_uint64.ToType()
+					}
 					return types.T_int64.ToType()
 				},
 				newOp: func() executeLogicOfOverload {
@@ -2552,6 +2561,16 @@ var supportedOperators = []FuncNew{
 				},
 				newOp: func() executeLogicOfOverload {
 					return operatorOpBitwiseBinaryNotFn
+				},
+			},
+			{
+				overloadId: 11,
+				args:       []types.T{types.T_bit},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_uint64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return operatorUnaryTilde[uint64]
 				},
 			},
 		},

--- a/pkg/sql/plan/function/numeric_resolver.go
+++ b/pkg/sql/plan/function/numeric_resolver.go
@@ -278,6 +278,13 @@ func resolveNumericBinaryTypes(
 	right types.Type,
 	outer *types.Type,
 ) (numericTypeResolution, bool) {
+	// Resolve the BIT dividend before T_any inference and generic coercion so
+	// its unsigned result domain and declared width are not lost.
+	if op == numericOpIntegerDiv {
+		if bitLeft, bitRight, bitOperands := integerDivBitTypes(left, right); bitOperands {
+			left, right = bitLeft, bitRight
+		}
+	}
 	left, right, ok := resolveUnknownNumericOperands(left, right, outer)
 	if !ok {
 		return numericTypeResolution{}, false
@@ -287,7 +294,10 @@ func resolveNumericBinaryTypes(
 	var castLeft, castRight types.Type
 	switch op {
 	case numericOpIntegerDiv:
-		if integerDivOperatorSupports(left, right) {
+		if integerDivBitResolvedTypes(left, right) {
+			// BIT DIV preserves the left BIT column but computes in BIGINT
+			// UNSIGNED; the executor consumes this canonical signature.
+		} else if integerDivOperatorSupports(left, right) {
 			// Keep same-domain operands in their original physical type.
 		} else if mixedLeft, mixedRight, mixed := integerDivUnsignedMixedTypes(left, right); mixed {
 			left, right = mixedLeft, mixedRight
@@ -360,7 +370,8 @@ func numericOperatorSupports(op numericBinaryOp, left, right types.Type) bool {
 	case numericOpDiv:
 		return divOperatorSupports(left, right)
 	case numericOpIntegerDiv:
-		return integerDivOperatorSupports(left, right) || integerDivUnsignedMixedResolvedTypes(left, right)
+		return integerDivBitResolvedTypes(left, right) ||
+			integerDivOperatorSupports(left, right) || integerDivUnsignedMixedResolvedTypes(left, right)
 	case numericOpMod:
 		return modOperatorSupports(left, right)
 	default:
@@ -371,6 +382,9 @@ func numericOperatorSupports(op numericBinaryOp, left, right types.Type) bool {
 func numericBinaryResultType(op numericBinaryOp, left, right types.Type) types.Type {
 	switch op {
 	case numericOpIntegerDiv:
+		if integerDivBitResolvedTypes(left, right) {
+			return types.T_uint64.ToType()
+		}
 		return types.T_int64.ToType()
 	case numericOpAdd, numericOpSub:
 		if left.Oid.IsDecimal() || right.Oid.IsDecimal() {

--- a/test/distributed/cases/operator/mysql_compat_bitwise_expr.result
+++ b/test/distributed/cases/operator/mysql_compat_bitwise_expr.result
@@ -133,7 +133,7 @@ select column_name, column_type
 from information_schema.columns
 where table_schema = database() and table_name = 't_bit_div_meta';
 column_name    column_type
-quotient    BIGINT UNSIGNED
+quotient    BIGINT UNSIGNED(0)
 drop table t_bit_div_meta;
 drop table t_bit_numeric;
 drop database mysql_compat_bitwise_expr;

--- a/test/distributed/cases/operator/mysql_compat_bitwise_expr.result
+++ b/test/distributed/cases/operator/mysql_compat_bitwise_expr.result
@@ -94,4 +94,46 @@ id    blob_bytes    blob_not_bytes    blob_not_prefix    blob_not_suffix    blob
 1    2    2    FF00    00    2    01FE    FE    2
 2    512    512    0000    00    512    FFFF    FE    512
 3    null    null    null    null    null    null    null    null
+drop table if exists t_bit_numeric;
+create table t_bit_numeric (
+id int primary key,
+b1 bit(1),
+b8 bit(8),
+b64 bit(64)
+);
+insert into t_bit_numeric values
+(1, b'0', b'00000000', b'0000000000000000000000000000000000000000000000000000000000000000'),
+(2, b'1', b'10000000', b'1000000000000000000000000000000000000000000000000000000000000000'),
+(3, b'1', b'11111111', b'1111111111111111111111111111111111111111111111111111111111111111'),
+(4, null, null, null);
+select id,
+hex(~b1) as bit1_not,
+hex(~b8) as bit8_not,
+hex(~b64) as bit64_not,
+b1 div 1 as bit1_div_1,
+b8 div 1 as bit8_div_1,
+b64 div 1 as bit64_div_1
+from t_bit_numeric
+order by id;
+id    bit1_not    bit8_not    bit64_not    bit1_div_1    bit8_div_1    bit64_div_1
+1    FFFFFFFFFFFFFFFF    FFFFFFFFFFFFFFFF    FFFFFFFFFFFFFFFF    0    0    0
+2    FFFFFFFFFFFFFFFE    FFFFFFFFFFFFFF7F    7FFFFFFFFFFFFFFF    1    128    9223372036854775808
+3    FFFFFFFFFFFFFFFE    FFFFFFFFFFFFFF00    0    1    255    18446744073709551615
+4    null    null    null    null    null    null
+select id, b64 div b64 as bit64_self_div
+from t_bit_numeric
+where id in (2, 3)
+order by id;
+id    bit64_self_div
+2    1
+3    1
+create table t_bit_div_meta as
+select b64 div 1 as quotient from t_bit_numeric limit 0;
+select column_name, column_type
+from information_schema.columns
+where table_schema = database() and table_name = 't_bit_div_meta';
+column_name    column_type
+quotient    BIGINT UNSIGNED
+drop table t_bit_div_meta;
+drop table t_bit_numeric;
 drop database mysql_compat_bitwise_expr;

--- a/test/distributed/cases/operator/mysql_compat_bitwise_expr.sql
+++ b/test/distributed/cases/operator/mysql_compat_bitwise_expr.sql
@@ -96,4 +96,43 @@ from t_bitwise_binary
 where id in (1, 2, 3)
 order by id;
 
+-- BIT numeric operators use MySQL's full BIGINT UNSIGNED domain. In
+-- particular, unary complement is not masked to BIT(M)'s declared width.
+drop table if exists t_bit_numeric;
+create table t_bit_numeric (
+  id int primary key,
+  b1 bit(1),
+  b8 bit(8),
+  b64 bit(64)
+);
+
+insert into t_bit_numeric values
+  (1, b'0', b'00000000', b'0000000000000000000000000000000000000000000000000000000000000000'),
+  (2, b'1', b'10000000', b'1000000000000000000000000000000000000000000000000000000000000000'),
+  (3, b'1', b'11111111', b'1111111111111111111111111111111111111111111111111111111111111111'),
+  (4, null, null, null);
+
+select id,
+       hex(~b1) as bit1_not,
+       hex(~b8) as bit8_not,
+       hex(~b64) as bit64_not,
+       b1 div 1 as bit1_div_1,
+       b8 div 1 as bit8_div_1,
+       b64 div 1 as bit64_div_1
+from t_bit_numeric
+order by id;
+
+select id, b64 div b64 as bit64_self_div
+from t_bit_numeric
+where id in (2, 3)
+order by id;
+
+create table t_bit_div_meta as
+select b64 div 1 as quotient from t_bit_numeric limit 0;
+select column_name, column_type
+from information_schema.columns
+where table_schema = database() and table_name = 't_bit_div_meta';
+drop table t_bit_div_meta;
+drop table t_bit_numeric;
+
 drop database mysql_compat_bitwise_expr;


### PR DESCRIPTION
Fixes #28793.

- Implement MySQL-compatible BIT unary complement and BIT-left DIV with unsigned result handling.
- Add focused unit and distributed compatibility coverage for widths, boundaries, NULLs, constants, and result metadata.

Validation: gofmt and git diff checks pass. Local CGo UT and distributed BVT were not run because this worktree lacks cgo/libmo.so and required thirdparties; CI validation is required.