### PR TITLE
[Bug]: preserve DECIMAL division range and rounding

### DIFF
--- a/pkg/container/types/decimal.go
+++ b/pkg/container/types/decimal.go
@@ -1106,49 +1106,92 @@ func (x Decimal128) Div128(y Decimal128) (Decimal128, error) {
 			}
 		}
 	} else {
-		if x.Less(y) {
-			x.B64_127 = 0
-			x.B0_63 = 0
-		} else {
-			n := bits.LeadingZeros64(y.B64_127)
-			v, _ := bits.Div64(x.B64_127, x.B0_63, y.Right(64-n).B0_63)
-			v >>= 63 - n
-			if v&1 == 0 {
-				x.B0_63 = v >> 1
-			} else {
-				z, _ := y.Mul128(Decimal128{v, 0})
-				if x.Left(1).Less(z) {
-					x.B0_63 = v >> 1
-				} else {
-					x.B0_63 = (v >> 1) + 1
-				}
-			}
-			x.B64_127 = 0
+		// Avoid doubling x and y*q to decide rounding: either intermediate can
+		// overflow even when x, y, and the rounded quotient all fit in D128.
+		q, remainder, err := x.div128TruncQuoRem(y)
+		if err != nil {
+			return x, err
 		}
+
+		// Round half-up iff remainder >= ceil(y/2), without forming 2*remainder.
+		threshold := y.Right(1)
+		if y.B0_63&1 != 0 {
+			threshold, err = threshold.Add128(Decimal128{B0_63: 1})
+			if err != nil {
+				return x, err
+			}
+		}
+		if remainder.Compare(threshold) >= 0 {
+			q, err = q.Add128(Decimal128{B0_63: 1})
+			if err != nil {
+				return x, err
+			}
+		}
+		return q, nil
 	}
 	return x, nil
 }
 
 func (x Decimal128) div128Trunc(y Decimal128) (Decimal128, error) {
+	q, _, err := x.div128TruncQuoRem(y)
+	return q, err
+}
+
+// div128TruncQuoRem returns an exact quotient and remainder for positive
+// operands. The normalized high-limb estimate can be one too large because
+// normalization discards low divisor bits; correct it before multiplying so
+// an otherwise representable quotient is not mistaken for overflow.
+func (x Decimal128) div128TruncQuoRem(y Decimal128) (Decimal128, Decimal128, error) {
 	if y.B0_63 == 0 && y.B64_127 == 0 {
-		return x, moerr.NewInvalidInputNoCtxf("Decimal128 Div by Zero: %s/%s", x.Format(0), y.Format(0))
+		return x, Decimal128{}, moerr.NewInvalidInputNoCtxf("Decimal128 Div by Zero: %s/%s", x.Format(0), y.Format(0))
 	}
 	if y.B64_127 == 0 {
-		x.B64_127, y.B64_127 = bits.Div64(0, x.B64_127, y.B0_63)
-		x.B0_63, _ = bits.Div64(y.B64_127, x.B0_63, y.B0_63)
-	} else {
-		if x.Less(y) {
-			x.B64_127 = 0
-			x.B0_63 = 0
-		} else {
-			n := bits.LeadingZeros64(y.B64_127)
-			v, _ := bits.Div64(x.B64_127, x.B0_63, y.Right(64-n).B0_63)
-			v >>= 63 - n
-			x.B0_63 = v >> 1
-			x.B64_127 = 0
+		qHi, remainderHi := bits.Div64(0, x.B64_127, y.B0_63)
+		qLo, remainder := bits.Div64(remainderHi, x.B0_63, y.B0_63)
+		return Decimal128{B0_63: qLo, B64_127: qHi}, Decimal128{B0_63: remainder}, nil
+	}
+	if x.Less(y) {
+		return Decimal128{}, x, nil
+	}
+
+	n := bits.LeadingZeros64(y.B64_127)
+	v, _ := bits.Div64(x.B64_127, x.B0_63, y.Right(64-n).B0_63)
+	v >>= 63 - n
+	q := Decimal128{B0_63: v >> 1}
+	product, mulErr := y.Mul128(q)
+	if mulErr != nil || product.Compare(x) > 0 {
+		var err error
+		q, err = q.Sub128(Decimal128{B0_63: 1})
+		if err != nil {
+			return Decimal128{}, Decimal128{}, err
+		}
+		product, err = y.Mul128(q)
+		if err != nil {
+			return Decimal128{}, Decimal128{}, err
+		}
+		if product.Compare(x) > 0 {
+			return Decimal128{}, Decimal128{}, moerr.NewInternalErrorNoCtx("Decimal128 division quotient correction failed")
 		}
 	}
-	return x, nil
+
+	remainder, err := x.Sub128(product)
+	if err != nil {
+		return Decimal128{}, Decimal128{}, err
+	}
+	if remainder.Compare(y) >= 0 {
+		q, err = q.Add128(Decimal128{B0_63: 1})
+		if err != nil {
+			return Decimal128{}, Decimal128{}, err
+		}
+		remainder, err = remainder.Sub128(y)
+		if err != nil {
+			return Decimal128{}, Decimal128{}, err
+		}
+		if remainder.Compare(y) >= 0 {
+			return Decimal128{}, Decimal128{}, moerr.NewInternalErrorNoCtx("Decimal128 division quotient correction failed")
+		}
+	}
+	return q, remainder, nil
 }
 
 // Div128Trunc is the exported version of div128Trunc for integer division (DIV)

--- a/pkg/container/types/decimal.go
+++ b/pkg/container/types/decimal.go
@@ -1116,16 +1116,13 @@ func (x Decimal128) Div128(y Decimal128) (Decimal128, error) {
 		// Round half-up iff remainder >= ceil(y/2), without forming 2*remainder.
 		threshold := y.Right(1)
 		if y.B0_63&1 != 0 {
-			threshold, err = threshold.Add128(Decimal128{B0_63: 1})
-			if err != nil {
-				return x, err
-			}
+			var carry uint64
+			threshold.B0_63, carry = bits.Add64(threshold.B0_63, 1, 0)
+			threshold.B64_127 += carry
 		}
 		if remainder.Compare(threshold) >= 0 {
-			q, err = q.Add128(Decimal128{B0_63: 1})
-			if err != nil {
-				return x, err
-			}
+			// Here y >= 2^64 and x < 2^127, so the rounded quotient fits in B0_63.
+			q.B0_63++
 		}
 		return q, nil
 	}
@@ -1178,18 +1175,10 @@ func (x Decimal128) div128TruncQuoRem(y Decimal128) (Decimal128, Decimal128, err
 	if err != nil {
 		return Decimal128{}, Decimal128{}, err
 	}
+	// The normalized divisor is rounded down, so the quotient estimate cannot
+	// undershoot. After the optional decrement above, remainder must be < y.
 	if remainder.Compare(y) >= 0 {
-		q, err = q.Add128(Decimal128{B0_63: 1})
-		if err != nil {
-			return Decimal128{}, Decimal128{}, err
-		}
-		remainder, err = remainder.Sub128(y)
-		if err != nil {
-			return Decimal128{}, Decimal128{}, err
-		}
-		if remainder.Compare(y) >= 0 {
-			return Decimal128{}, Decimal128{}, moerr.NewInternalErrorNoCtx("Decimal128 division quotient correction failed")
-		}
+		return Decimal128{}, Decimal128{}, moerr.NewInternalErrorNoCtx("Decimal128 division quotient correction failed")
 	}
 	return q, remainder, nil
 }

--- a/pkg/container/types/decimal_test.go
+++ b/pkg/container/types/decimal_test.go
@@ -535,6 +535,14 @@ func TestDecimal128Div128HalfUpLargeDivisor(t *testing.T) {
 		}
 	}
 
+	t.Run("odd half threshold carries into high limb", func(t *testing.T) {
+		x := new(big.Int).Lsh(big.NewInt(1), 64)
+		y := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 65), big.NewInt(1))
+		got, err := fromBig(x).Div128(fromBig(y))
+		require.NoError(t, err)
+		require.Equal(t, big.NewInt(1), toBig(got))
+	})
+
 	t.Run("corrects high quotient estimate at signed limit", func(t *testing.T) {
 		x := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
 		y := new(big.Int).Add(new(big.Int).Lsh(big.NewInt(1), 64), big.NewInt(3))
@@ -556,6 +564,21 @@ func TestDecimal128Div128HalfUpLargeDivisor(t *testing.T) {
 		require.Equal(t, big.NewInt(9223372036854775807), want)
 		require.Equal(t, want, toBig(got))
 	})
+
+	t.Run("rounded quotient reaches the high bit of the low limb", func(t *testing.T) {
+		x := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+		y := new(big.Int).Lsh(big.NewInt(1), 64)
+		got, err := fromBig(x).Div128(fromBig(y))
+		require.NoError(t, err)
+		want := new(big.Int).Lsh(big.NewInt(1), 63)
+		require.Equal(t, want, toBig(got))
+	})
+}
+
+func TestDecimal128Div128TruncByZero(t *testing.T) {
+	_, err := (Decimal128{B0_63: 1}).Div128Trunc(Decimal128{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Decimal128 Div by Zero")
 }
 
 func TestParseFormat(t *testing.T) {

--- a/pkg/container/types/decimal_test.go
+++ b/pkg/container/types/decimal_test.go
@@ -487,6 +487,77 @@ func TestDecimal128OverDiv(t *testing.T) {
 	}
 }
 
+func TestDecimal128Div128HalfUpLargeDivisor(t *testing.T) {
+	fromBig := func(value *big.Int) Decimal128 {
+		t.Helper()
+		if value.Sign() < 0 || value.BitLen() > 127 {
+			t.Fatalf("value does not fit a positive Decimal128: %s", value)
+		}
+		hi := new(big.Int).Rsh(new(big.Int).Set(value), 64).Uint64()
+		return Decimal128{B0_63: value.Uint64(), B64_127: hi}
+	}
+	toBig := func(value Decimal128) *big.Int {
+		result := new(big.Int).SetUint64(value.B64_127)
+		result.Lsh(result, 64)
+		return result.Or(result, new(big.Int).SetUint64(value.B0_63))
+	}
+
+	for _, divisorCase := range []struct {
+		name  string
+		value string
+	}{
+		{name: "even", value: "100000000000000000000"},
+		{name: "odd", value: "100000000000000000001"},
+	} {
+		divisor, ok := new(big.Int).SetString(divisorCase.value, 10)
+		require.True(t, ok)
+		half := new(big.Int).Rsh(new(big.Int).Set(divisor), 1)
+		for _, quotient := range []int64{0, 1, 123456, 850705917302346158} {
+			for _, delta := range []int64{-1, 0, 1} {
+				t.Run(fmt.Sprintf("%s_q_%d_delta_%d", divisorCase.name, quotient, delta), func(t *testing.T) {
+					x := new(big.Int).Mul(big.NewInt(quotient), divisor)
+					x.Add(x, half)
+					x.Add(x, big.NewInt(delta))
+					input := fromBig(x)
+					divisor128 := fromBig(divisor)
+
+					got, err := input.Div128(divisor128)
+					require.NoError(t, err)
+
+					want, remainder := new(big.Int), new(big.Int)
+					want.QuoRem(x, divisor, remainder)
+					if new(big.Int).Lsh(remainder, 1).Cmp(divisor) >= 0 {
+						want.Add(want, big.NewInt(1))
+					}
+					require.Equal(t, want, toBig(got))
+				})
+			}
+		}
+	}
+
+	t.Run("corrects high quotient estimate at signed limit", func(t *testing.T) {
+		x := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 127), big.NewInt(1))
+		y := new(big.Int).Add(new(big.Int).Lsh(big.NewInt(1), 64), big.NewInt(3))
+		input, divisor := fromBig(x), fromBig(y)
+
+		truncated, err := input.Div128Trunc(divisor)
+		require.NoError(t, err)
+		wantTruncated := new(big.Int).Quo(new(big.Int).Set(x), y)
+		require.Equal(t, wantTruncated, toBig(truncated))
+
+		got, err := input.Div128(divisor)
+		require.NoError(t, err)
+
+		want, remainder := new(big.Int), new(big.Int)
+		want.QuoRem(x, y, remainder)
+		if new(big.Int).Lsh(remainder, 1).Cmp(y) >= 0 {
+			want.Add(want, big.NewInt(1))
+		}
+		require.Equal(t, big.NewInt(9223372036854775807), want)
+		require.Equal(t, want, toBig(got))
+	})
+}
+
 func TestParseFormat(t *testing.T) {
 	x := Decimal128{0, 1}
 	c := x.Format(5)

--- a/pkg/sql/plan/function/arith_decimal_fast.go
+++ b/pkg/sql/plan/function/arith_decimal_fast.go
@@ -1024,6 +1024,57 @@ func d128DivOne(x, y types.Decimal128, dst *types.Decimal128, scaleAdj int32, rs
 	return nil
 }
 
+// d128DivOneToD256 keeps the fast D128 path when the scaled numerator fits,
+// but preserves the full D256 quotient when called by a D256 result path.
+func d128DivOneToD256(x, y types.Decimal128, dst *types.Decimal256, scaleAdj int32,
+	rsnull *nulls.Nulls, idx uint64, shouldError bool, scale1, scale2 int32) error {
+	if d128IsZero(y) {
+		if shouldError {
+			return moerr.NewDivByZeroNoCtx()
+		}
+		rsnull.Add(idx)
+		return nil
+	}
+
+	// The existing D128 implementation is safe only when both absolute
+	// operands fit in the positive D128 domain. In particular, abs(MinInt128)
+	// is 2^127 and cannot be represented as a positive D128. Probe on copies
+	// because the helpers mutate their arguments.
+	scaled := x
+	d128Abs(&scaled)
+	numeratorFits := d128MulPow10(&scaled, scaleAdj) && scaled.B64_127>>63 == 0
+	absY := y
+	d128Abs(&absY)
+	divisorFits := absY.B64_127>>63 == 0
+	if numeratorFits && divisorFits {
+		var result128 types.Decimal128
+		if err := d128DivOne(x, y, &result128, scaleAdj, rsnull, idx, shouldError, scale1, scale2); err != nil {
+			return err
+		}
+		signExt := ^uint64(0) * (result128.B64_127 >> 63)
+		*dst = types.Decimal256{
+			B0_63: result128.B0_63, B64_127: result128.B64_127,
+			B128_191: signExt, B192_255: signExt,
+		}
+		return nil
+	}
+
+	signX := d128Abs(&x)
+	signY := d128Abs(&y)
+	x256 := types.Decimal256{B0_63: x.B0_63, B64_127: x.B64_127}
+	y256 := types.Decimal256{B0_63: y.B0_63, B64_127: y.B64_127}
+	if !d256MulPow10(&x256, scaleAdj) {
+		return moerr.NewInvalidInputNoCtxf("Decimal256 Div overflow: %s/%s", x.Format(scale1), y.Format(scale2))
+	}
+	result, err := x256.Div256(y256)
+	if err != nil {
+		return moerr.NewInvalidInputNoCtxf("Decimal256 Div overflow: %s/%s", x.Format(scale1), y.Format(scale2))
+	}
+	d256Negate(&result, signX^signY)
+	*dst = result
+	return nil
+}
+
 // d128DivInline is the fast inline path for D128 division.
 // Pre-conditions: absY > 0, absY fits in 64 bits (absY64 > 0),
 // scaleAdj ≤ 19. x is a signed D128. signy is the sign of the divisor.
@@ -3065,11 +3116,12 @@ func d256DivViaD128(v1, v2 []types.Decimal256, rs []types.Decimal256, scaleAdj i
 				signy := d128Abs(&y)
 				var r128 types.Decimal128
 				if !d128DivInline(d256toD128(v1[i]), y.B0_63, signy, scaleFactor, &r128) {
-					if err := d128DivOne(d256toD128(v1[i]), d256toD128(v2[i]), &r128, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+					if err := d128DivOneToD256(d256toD128(v1[i]), d256toD128(v2[i]), &rs[i], scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
+				} else {
+					rs[i] = d128toD256(r128)
 				}
-				rs[i] = d128toD256(r128)
 			}
 			return nil
 		}
@@ -3085,11 +3137,9 @@ func d256DivViaD128(v1, v2 []types.Decimal256, rs []types.Decimal256, scaleAdj i
 				rsnull.Add(uint64(i))
 				continue
 			}
-			var r128 types.Decimal128
-			if err := d128DivOne(d256toD128(v1[i]), y, &r128, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if err := d128DivOneToD256(d256toD128(v1[i]), y, &rs[i], scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
-			rs[i] = d128toD256(r128)
 		}
 	} else if len1 == 1 {
 		x := d256toD128(v1[0])
@@ -3109,11 +3159,12 @@ func d256DivViaD128(v1, v2 []types.Decimal256, rs []types.Decimal256, scaleAdj i
 				signy := d128Abs(&y)
 				var r128 types.Decimal128
 				if !d128DivInline(x, y.B0_63, signy, scaleFactor, &r128) {
-					if err := d128DivOne(x, d256toD128(v2[i]), &r128, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+					if err := d128DivOneToD256(x, d256toD128(v2[i]), &rs[i], scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
+				} else {
+					rs[i] = d128toD256(r128)
 				}
-				rs[i] = d128toD256(r128)
 			}
 			return nil
 		}
@@ -3129,11 +3180,9 @@ func d256DivViaD128(v1, v2 []types.Decimal256, rs []types.Decimal256, scaleAdj i
 				rsnull.Add(uint64(i))
 				continue
 			}
-			var r128 types.Decimal128
-			if err := d128DivOne(x, y, &r128, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if err := d128DivOneToD256(x, y, &rs[i], scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
-			rs[i] = d128toD256(r128)
 		}
 	} else {
 		y := d256toD128(v2[0])
@@ -3156,11 +3205,12 @@ func d256DivViaD128(v1, v2 []types.Decimal256, rs []types.Decimal256, scaleAdj i
 					}
 					var r128 types.Decimal128
 					if !d128DivInline(d256toD128(v1[i]), absY64, signyU, scaleFactor, &r128) {
-						if err := d128DivOne(d256toD128(v1[i]), y, &r128, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+						if err := d128DivOneToD256(d256toD128(v1[i]), y, &rs[i], scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 							return err
 						}
+					} else {
+						rs[i] = d128toD256(r128)
 					}
-					rs[i] = d128toD256(r128)
 				}
 				return nil
 			}
@@ -3169,11 +3219,9 @@ func d256DivViaD128(v1, v2 []types.Decimal256, rs []types.Decimal256, scaleAdj i
 			if hasNull && bmp.Contains(uint64(i)) {
 				continue
 			}
-			var r128 types.Decimal128
-			if err := d128DivOne(d256toD128(v1[i]), y, &r128, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if err := d128DivOneToD256(d256toD128(v1[i]), y, &rs[i], scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
-			rs[i] = d128toD256(r128)
 		}
 	}
 	return nil

--- a/pkg/sql/plan/function/arith_decimal_fast_test.go
+++ b/pkg/sql/plan/function/arith_decimal_fast_test.go
@@ -2764,6 +2764,81 @@ func TestD256Div(t *testing.T) {
 	})
 }
 
+func TestD256DivViaD128PreservesWideQuotient(t *testing.T) {
+	x, err := types.ParseDecimal256("1", 65, 30)
+	require.NoError(t, err)
+	y, err := types.ParseDecimal256("0.000000000000000003", 65, 18)
+	require.NoError(t, err)
+
+	got := make([]types.Decimal256, 1)
+	resultNulls := nulls.NewWithSize(1)
+	err = d256Div([]types.Decimal256{x}, []types.Decimal256{y}, got, 30, 18, resultNulls, true)
+	require.NoError(t, err)
+	require.Equal(t, "333333333333333333.333333333333333333333333333333", got[0].Format(30))
+
+	// The same quotient cannot fit a Decimal128 result and must remain an
+	// overflow for callers whose declared result domain is Decimal128.
+	x128, err := types.ParseDecimal128("1", 38, 30)
+	require.NoError(t, err)
+	y128, err := types.ParseDecimal128("0.000000000000000003", 38, 18)
+	require.NoError(t, err)
+	got128 := make([]types.Decimal128, 1)
+	err = d128Div([]types.Decimal128{x128}, []types.Decimal128{y128}, got128, 30, 18, nulls.NewWithSize(1), true)
+	require.Error(t, err)
+}
+
+func TestD256DivViaD128MinInt128Divisor(t *testing.T) {
+	const numerator = "85070591730234615865843651857943"
+	const divisor = "-170141183460469231731687303715884105728"
+
+	for _, negativeNumerator := range []bool{false, true} {
+		leftText := numerator
+		want := "-0.000001"
+		if negativeNumerator {
+			leftText = "-" + leftText
+			want = "0.000001"
+		}
+
+		left, err := types.ParseDecimal256(leftText, 65, 0)
+		require.NoError(t, err)
+		right, err := types.ParseDecimal256(divisor, 65, 0)
+		require.NoError(t, err)
+
+		got := make([]types.Decimal256, 1)
+		err = d256Div([]types.Decimal256{left}, []types.Decimal256{right}, got, 0, 0, nulls.NewWithSize(1), true)
+		require.NoError(t, err, "negativeNumerator=%t", negativeNumerator)
+		require.Equal(t, want, got[0].Format(6), "negativeNumerator=%t", negativeNumerator)
+	}
+}
+
+func TestD128DivLargeDivisorHalfUp(t *testing.T) {
+	x, err := types.ParseDecimal128("123456789012345", 38, 0)
+	require.NoError(t, err)
+	y, err := types.ParseDecimal128("999999999999999.999999999999999999", 38, 18)
+	require.NoError(t, err)
+
+	for _, negativeX := range []bool{false, true} {
+		for _, negativeY := range []bool{false, true} {
+			left, right := x, y
+			if negativeX {
+				left = left.Minus()
+			}
+			if negativeY {
+				right = right.Minus()
+			}
+
+			got := make([]types.Decimal128, 1)
+			err := d128Div([]types.Decimal128{left}, []types.Decimal128{right}, got, 0, 18, nulls.NewWithSize(1), true)
+			require.NoError(t, err)
+			want := "0.123457"
+			if negativeX != negativeY {
+				want = "-" + want
+			}
+			require.Equal(t, want, got[0].Format(6), "negativeX=%t negativeY=%t", negativeX, negativeY)
+		}
+	}
+}
+
 func TestD256Div_LargeValues(t *testing.T) {
 	v1 := make([]types.Decimal256, 4)
 	v2 := make([]types.Decimal256, 4)

--- a/pkg/sql/plan/function/arith_decimal_fast_test.go
+++ b/pkg/sql/plan/function/arith_decimal_fast_test.go
@@ -2839,6 +2839,35 @@ func TestD128DivLargeDivisorHalfUp(t *testing.T) {
 	}
 }
 
+func TestD128DivOneToD256FailurePaths(t *testing.T) {
+	x := types.Decimal128{B0_63: 1}
+	zero := types.Decimal128{}
+
+	t.Run("zero divisor returns error", func(t *testing.T) {
+		nul := nulls.NewWithSize(1)
+		var dst types.Decimal256
+		err := d128DivOneToD256(x, zero, &dst, 0, nul, 0, true, 0, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("zero divisor sets null", func(t *testing.T) {
+		nul := nulls.NewWithSize(1)
+		var dst types.Decimal256
+		err := d128DivOneToD256(x, zero, &dst, 0, nul, 0, false, 0, 0)
+		require.NoError(t, err)
+		require.True(t, nul.Contains(0))
+	})
+
+	t.Run("D256 scale-up overflow", func(t *testing.T) {
+		numerator := []types.Decimal256{{B0_63: 20}}
+		divisor := []types.Decimal256{{B0_63: 1}}
+		result := make([]types.Decimal256, 1)
+		err := d256Div(numerator, divisor, result, 0, 76, nulls.NewWithSize(1), true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Decimal256 Div overflow")
+	})
+}
+
 func TestD256Div_LargeValues(t *testing.T) {
 	v1 := make([]types.Decimal256, 4)
 	v2 := make([]types.Decimal256, 4)

--- a/test/distributed/cases/dtype/decimal_256.result
+++ b/test/distributed/cases/dtype/decimal_256.result
@@ -61,4 +61,32 @@ cast('999999999999999999999999999999.999999999999999999999999999999' as decimal(
 ➤ zero_div[-5,64,0]  ¦  scale_up_fit[-5,64,0]  ¦  truncate_div[-5,64,0]  𝄀
 0  ¦  1000000000000  ¦  1
 
+select cast('1' as decimal(65,30)) / cast('0.000000000000000003' as decimal(65,18)) as issue_28774_wide_quotient;
+➤ issue_28774_wide_quotient[3,65,30]  𝄀
+333333333333333333.333333333333333333333333333333
+
+select cast(
+cast('123456789012345' as decimal(38,0)) /
+cast('999999999999999.999999999999999999' as decimal(38,18))
+as decimal(65,6)
+) as issue_28775_d128_rounding;
+➤ issue_28775_d128_rounding[3,65,6]  𝄀
+0.123457
+
+select cast(
+cast('1234567890123450000000000000000000000000' as decimal(65,0)) /
+cast('9999999999999999999999999999999999999999' as decimal(65,0))
+as decimal(65,6)
+) as issue_28775_d256_control;
+➤ issue_28775_d256_control[3,65,6]  𝄀
+0.123457
+
+select
+cast(cast('85070591730234615865843651857943' as decimal(65,0)) /
+cast('-170141183460469231731687303715884105728' as decimal(65,0)) as decimal(65,6)) as issue_28774_min_d128_divisor_positive_numerator,
+cast(cast('-85070591730234615865843651857943' as decimal(65,0)) /
+cast('-170141183460469231731687303715884105728' as decimal(65,0)) as decimal(65,6)) as issue_28774_min_d128_divisor_negative_numerator;
+➤ issue_28774_min_d128_divisor_positive_numerator[3,65,6]  ¦  issue_28774_min_d128_divisor_negative_numerator[3,65,6]  𝄀
+-0.000001  ¦  0.000001
+
 drop table decimal_256_t;

--- a/test/distributed/cases/dtype/decimal_256.test
+++ b/test/distributed/cases/dtype/decimal_256.test
@@ -47,5 +47,24 @@ select
     cast('99999999999999999999999999999999999999999999999999999999999999999' as decimal(65,0)) div cast('99999999999999999999999999999999999999999999999999999.999999999999' as decimal(65,12)) as scale_up_fit,
     cast('999999999999999999999999999999.999999999999999999999999999999' as decimal(65,30)) div cast('500000000000000000000000000000' as decimal(65,0)) as truncate_div;
 
+select cast('1' as decimal(65,30)) / cast('0.000000000000000003' as decimal(65,18)) as issue_28774_wide_quotient;
+
+select cast(
+    cast('123456789012345' as decimal(38,0)) /
+    cast('999999999999999.999999999999999999' as decimal(38,18))
+    as decimal(65,6)
+) as issue_28775_d128_rounding;
+
+select cast(
+    cast('1234567890123450000000000000000000000000' as decimal(65,0)) /
+    cast('9999999999999999999999999999999999999999' as decimal(65,0))
+    as decimal(65,6)
+) as issue_28775_d256_control;
+
+select
+    cast(cast('85070591730234615865843651857943' as decimal(65,0)) /
+        cast('-170141183460469231731687303715884105728' as decimal(65,0)) as decimal(65,6)) as issue_28774_min_d128_divisor_positive_numerator,
+    cast(cast('-85070591730234615865843651857943' as decimal(65,0)) /
+        cast('-170141183460469231731687303715884105728' as decimal(65,0)) as decimal(65,6)) as issue_28774_min_d128_divisor_negative_numerator;
 
 drop table decimal_256_t;


### PR DESCRIPTION
Fixes #28774 and #28775.

- Preserve full Decimal256 quotients when the D128 fast path is used for eligible inputs.
- Correct D128 quotient/remainder estimation and half-up rounding for large divisors.
- Fall back to D256 when a D128 absolute operand is not representable as positive D128, including MinInt128.
- Add focused UT and distributed regressions for wide results, rounding, and signed minimum boundaries.

Validation: gofmt and git diff checks pass. Local CGo UT and distributed BVT were not run because this worktree lacks cgo/libmo.so and required thirdparties; CI validation is required.