### PR TITLE
fix(geo): reject out-of-range geodetic coordinates

### DIFF
--- a/pkg/geo/geodetic.go
+++ b/pkg/geo/geodetic.go
@@ -14,7 +14,12 @@
 
 package geo
 
-import "github.com/golang/geo/s2"
+import (
+	"math"
+
+	"github.com/golang/geo/s2"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+)
 
 // geodetic.go implements spherical (SRID 4326, WGS 84 lon/lat) measures and
 // predicates using the S2 geometry library. Distances are returned in meters
@@ -31,6 +36,98 @@ const EarthRadiusMeters = 6371008.8
 
 func s2Point(c Coord) s2.Point {
 	return s2.PointFromLatLng(s2.LatLngFromDegrees(c.Y, c.X))
+}
+
+// ValidateGeodeticCoordinates verifies that every non-empty coordinate is a
+// finite WGS 84 longitude/latitude pair. Call it at the effective SRID-4326
+// measurement boundary before invoking the kernels below: S2 normalizes
+// out-of-range coordinates instead of rejecting them. SRID-0 Cartesian callers
+// must not apply this check.
+func ValidateGeodeticCoordinates(g Geometry) error {
+	return validateGeodeticCoordinates(g, 0)
+}
+
+func validateGeodeticCoordinates(g Geometry, depth int) error {
+	if g == nil {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	if depth > maxGeometryNestingDepth {
+		return moerr.NewInvalidInputNoCtxf("geometry collection nesting depth exceeds %d", maxGeometryNestingDepth)
+	}
+	switch v := g.(type) {
+	case Point:
+		if v.IsEmpty {
+			return nil
+		}
+		return validateGeodeticCoordinate(Coord{X: v.X, Y: v.Y})
+	case LineString:
+		return validateGeodeticCoordinatesInSlice(v.Points)
+	case Polygon:
+		for _, ring := range v.Rings {
+			if err := validateGeodeticCoordinatesInSlice(ring); err != nil {
+				return err
+			}
+		}
+	case MultiPoint:
+		for _, point := range v.Points {
+			if point.IsEmpty {
+				continue
+			}
+			if err := validateGeodeticCoordinate(Coord{X: point.X, Y: point.Y}); err != nil {
+				return err
+			}
+		}
+	case MultiLineString:
+		for _, line := range v.Lines {
+			if err := validateGeodeticCoordinatesInSlice(line.Points); err != nil {
+				return err
+			}
+		}
+	case MultiPolygon:
+		for _, polygon := range v.Polygons {
+			for _, ring := range polygon.Rings {
+				if err := validateGeodeticCoordinatesInSlice(ring); err != nil {
+					return err
+				}
+			}
+		}
+	case GeometryCollection:
+		for _, sub := range v.Geometries {
+			if err := validateGeodeticCoordinates(sub, depth+1); err != nil {
+				return err
+			}
+		}
+	default:
+		// Avoid formatting the interface value here: retaining a %T diagnostic
+		// makes otherwise-valid concrete geometries escape to the heap.
+		return moerr.NewInvalidInputNoCtx("unsupported geometry type for geodetic calculation")
+	}
+	return nil
+}
+
+func validateGeodeticCoordinatesInSlice(coords []Coord) error {
+	for _, coord := range coords {
+		if err := validateGeodeticCoordinate(coord); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateGeodeticCoordinate(coord Coord) error {
+	if math.IsNaN(coord.X) || math.IsInf(coord.X, 0) {
+		return moerr.NewInvalidInputNoCtx("SRID 4326 longitude must be finite")
+	}
+	if coord.X < -180 || coord.X > 180 {
+		return moerr.NewInvalidInputNoCtxf("SRID 4326 longitude %v is out of range [-180, 180]", coord.X)
+	}
+	if math.IsNaN(coord.Y) || math.IsInf(coord.Y, 0) {
+		return moerr.NewInvalidInputNoCtx("SRID 4326 latitude must be finite")
+	}
+	if coord.Y < -90 || coord.Y > 90 {
+		return moerr.NewInvalidInputNoCtxf("SRID 4326 latitude %v is out of range [-90, 90]", coord.Y)
+	}
+	return nil
 }
 
 // geomEmpty reports whether g has no coordinates.
@@ -50,6 +147,9 @@ func polylineMeters(pts []Coord) float64 {
 }
 
 // LengthMeters returns the geodesic length of all line components of g.
+// Callers must validate effective-SRID-4326 coordinates with
+// ValidateGeodeticCoordinates first; this numeric-only kernel does not return
+// coordinate-validation errors.
 func LengthMeters(g Geometry) float64 {
 	switch v := g.(type) {
 	case LineString:
@@ -118,6 +218,9 @@ func polygonMeters2(p Polygon) float64 {
 }
 
 // AreaSquareMeters returns the geodesic area of all areal components of g.
+// Callers must validate effective-SRID-4326 coordinates with
+// ValidateGeodeticCoordinates first; this numeric-only kernel does not return
+// coordinate-validation errors.
 func AreaSquareMeters(g Geometry) float64 {
 	switch v := g.(type) {
 	case Polygon:
@@ -201,7 +304,11 @@ func polygonsOf(g Geometry) []Polygon {
 
 // DistanceMeters returns the minimum geodesic distance in meters between g1 and
 // g2. ok is false when either geometry is empty. The distance is 0 when the
-// geometries intersect or one contains a point of the other.
+// geometries intersect or one contains a point of the other. Callers must
+// validate both geometries according to their operation's coordinate
+// contract first (for effective SRID 4326, use
+// ValidateGeodeticCoordinates); this kernel's boolean reports emptiness, not
+// coordinate-validation errors.
 func DistanceMeters(g1, g2 Geometry) (dist float64, ok bool) {
 	if geomEmpty(g1) || geomEmpty(g2) {
 		return 0, false

--- a/pkg/geo/geodetic_test.go
+++ b/pkg/geo/geodetic_test.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,6 +85,88 @@ func TestAreaSquareMeters(t *testing.T) {
 	require.InEpsilon(t, want, got, 0.01)
 
 	require.Equal(t, 0.0, AreaSquareMeters(mustParse(t, "LINESTRING(0 0,1 1)")))
+}
+
+func TestValidateGeodeticCoordinates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		g    Geometry
+		want string
+	}{
+		{name: "point", g: Point{X: 181, Y: 0}, want: "longitude 181"},
+		{name: "line string", g: LineString{Points: []Coord{{X: 0, Y: 0}, {X: 0, Y: 91}}}, want: "latitude 91"},
+		{name: "polygon hole", g: Polygon{Rings: [][]Coord{{{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1}, {X: 0, Y: 0}}, {{X: -181, Y: 0}}}}, want: "longitude -181"},
+		{name: "later multipoint member", g: MultiPoint{Points: []Point{{X: 0, Y: 0}, {X: 0, Y: -91}}}, want: "latitude -91"},
+		{name: "later multiline member", g: MultiLineString{Lines: []LineString{{Points: []Coord{{X: 0, Y: 0}}}, {Points: []Coord{{X: 181, Y: 0}}}}}, want: "longitude 181"},
+		{name: "later multipolygon member", g: MultiPolygon{Polygons: []Polygon{{Rings: [][]Coord{{{X: 0, Y: 0}}}}, {Rings: [][]Coord{{{X: 0, Y: 91}}}}}}, want: "latitude 91"},
+		{name: "nested geometry collection", g: GeometryCollection{Geometries: []Geometry{GeometryCollection{Geometries: []Geometry{Point{X: 0, Y: 90.1}}}}}, want: "latitude 90.1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGeodeticCoordinates(tc.g)
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+
+	for _, coord := range []Coord{
+		{X: -180, Y: -90},
+		{X: 180, Y: 90},
+	} {
+		require.NoError(t, ValidateGeodeticCoordinates(Point{X: coord.X, Y: coord.Y}))
+	}
+
+	for _, tc := range []struct {
+		name  string
+		coord Coord
+		want  string
+	}{
+		{name: "longitude above maximum", coord: Coord{X: 180.0001}, want: "longitude 180.0001"},
+		{name: "longitude below minimum", coord: Coord{X: -180.0001}, want: "longitude -180.0001"},
+		{name: "latitude above maximum", coord: Coord{Y: 90.0001}, want: "latitude 90.0001"},
+		{name: "latitude below minimum", coord: Coord{Y: -90.0001}, want: "latitude -90.0001"},
+		{name: "NaN longitude", coord: Coord{X: math.NaN()}, want: "longitude must be finite"},
+		{name: "positive infinity longitude", coord: Coord{X: math.Inf(1)}, want: "longitude must be finite"},
+		{name: "negative infinity longitude", coord: Coord{X: math.Inf(-1)}, want: "longitude must be finite"},
+		{name: "NaN latitude", coord: Coord{Y: math.NaN()}, want: "latitude must be finite"},
+		{name: "positive infinity latitude", coord: Coord{Y: math.Inf(1)}, want: "latitude must be finite"},
+		{name: "negative infinity latitude", coord: Coord{Y: math.Inf(-1)}, want: "latitude must be finite"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGeodeticCoordinates(Point{X: tc.coord.X, Y: tc.coord.Y})
+			require.Error(t, err)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+
+	t.Run("empty point has no coordinate to validate", func(t *testing.T) {
+		g := GeometryCollection{Geometries: []Geometry{
+			Point{X: math.NaN(), Y: math.Inf(1), IsEmpty: true},
+			MultiPoint{Points: []Point{{X: math.Inf(-1), IsEmpty: true}}},
+		}}
+		require.NoError(t, ValidateGeodeticCoordinates(g))
+	})
+	t.Run("nil geometry", func(t *testing.T) {
+		err := ValidateGeodeticCoordinates(nil)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+	})
+	t.Run("unsupported geometry", func(t *testing.T) {
+		err := ValidateGeodeticCoordinates(unsupportedGeometry{})
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+	})
+	t.Run("excessive collection nesting", func(t *testing.T) {
+		var g Geometry = Point{X: 0, Y: 0}
+		for range maxGeometryNestingDepth + 1 {
+			g = GeometryCollection{Geometries: []Geometry{g}}
+		}
+		err := ValidateGeodeticCoordinates(g)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+		require.Contains(t, err.Error(), "geometry collection nesting depth")
+	})
 }
 
 func TestGeodeticContainsPoint(t *testing.T) {

--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -11419,6 +11419,12 @@ func geodeticDistance(left, right []byte) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if err := geo.ValidateGeodeticCoordinates(lg); err != nil {
+		return 0, err
+	}
+	if err := geo.ValidateGeodeticCoordinates(rg); err != nil {
+		return 0, err
+	}
 	d, ok := geo.DistanceMeters(lg, rg)
 	if !ok {
 		return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")

--- a/pkg/sql/plan/function/func_binary_test.go
+++ b/pkg/sql/plan/function/func_binary_test.go
@@ -7091,6 +7091,263 @@ func TestStMeasuresGeodetic(t *testing.T) {
 	require.True(t, ok, info)
 }
 
+func TestStMeasuresGeodeticRejectInvalidCoordinates(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	geom0 := types.T_geometry.ToType()
+	geom4326 := geom0
+	geom4326.Width = 4327 // SRID 4326
+	wantError := NewFunctionTestResult(types.T_float64.ToType(), true, nil, nil)
+
+	// Confirm the short-circuit regression fixture is valid WKT and that its
+	// error comes from range validation, not parsing or geometry dispatch.
+	multiPoint, err := geo.ParseWKT("MULTIPOINT((0 0),(181 0))")
+	require.NoError(t, err)
+	container, err := geo.ParseWKT("POLYGON((-1 -1,1 -1,1 1,-1 1,-1 -1))")
+	require.NoError(t, err)
+	_, err = geodeticDistance(geo.WriteWKB(multiPoint), geo.WriteWKB(container))
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+	require.Contains(t, err.Error(), "SRID 4326 longitude 181 is out of range")
+
+	for _, tc := range []struct {
+		name   string
+		inputs []FunctionTestInput
+		fn     fEvalFn
+	}{
+		{
+			name: "ST_Distance longitude",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"POINT(181 0)"}, []bool{false}),
+				NewFunctionTestInput(geom4326, []string{"POINT(0 0)"}, []bool{false}),
+			},
+			fn: StDistance,
+		},
+		{
+			name: "ST_Distance invalid right operand",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"POINT(0 0)"}, []bool{false}),
+				NewFunctionTestInput(geom4326, []string{"POINT(0 91)"}, []bool{false}),
+			},
+			fn: StDistance,
+		},
+		{
+			name: "ST_Distance validates coordinates after a containment candidate",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"MULTIPOINT((0 0),(181 0))"}, []bool{false}),
+				NewFunctionTestInput(geom4326, []string{"POLYGON((-1 -1,1 -1,1 1,-1 1,-1 -1))"}, []bool{false}),
+			},
+			fn: StDistance,
+		},
+		{
+			name: "ST_Length longitude",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"LINESTRING(0 0,181 0)"}, []bool{false}),
+			},
+			fn: StLength,
+		},
+		{
+			name: "ST_Area latitude",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"POLYGON((0 0,1 0,1 91,0 91,0 0))"}, []bool{false}),
+			},
+			fn: StArea,
+		},
+		{
+			name: "ST_Distance explicit SRID 4326",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom0, []string{"POINT(0 0)"}, []bool{false}),
+				NewFunctionTestInput(geom0, []string{"POINT(181 0)"}, []bool{false}),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{4326}, []bool{false}),
+			},
+			fn: StDistanceWithSRID,
+		},
+		{
+			name: "ST_Length explicit SRID 4326",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom0, []string{"LINESTRING(0 0,0 91)"}, []bool{false}),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{4326}, []bool{false}),
+			},
+			fn: StLengthWithSRID,
+		},
+		{
+			name: "ST_Area explicit SRID 4326",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom0, []string{"POLYGON((0 0,1 0,1 91,0 91,0 0))"}, []bool{false}),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{4326}, []bool{false}),
+			},
+			fn: StAreaWithSRID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := NewFunctionTestCase(proc, tc.inputs, wantError, tc.fn)
+			ok, info := fc.Run()
+			require.True(t, ok, info)
+		})
+	}
+}
+
+func TestStMeasuresGeodeticEmptyGeometryBehavior(t *testing.T) {
+	emptyLine := encodeGeometryPayload("LINESTRING EMPTY", 0, false)
+	length, err := geodeticLength(emptyLine)
+	require.NoError(t, err)
+	require.Zero(t, length)
+
+	emptyPolygon := encodeGeometryPayload("POLYGON EMPTY", 0, false)
+	area, err := geometryAreaBySRID(emptyPolygon, geo.SRIDWGS84)
+	require.NoError(t, err)
+	require.Zero(t, area)
+
+	emptyPoint := encodeGeometryPayload("POINT EMPTY", 0, false)
+	validPoint := encodeGeometryPayload("POINT(0 0)", 0, false)
+	_, err = geometryDistanceBySRID(emptyPoint, validPoint, geo.SRIDWGS84)
+	require.Error(t, err)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput), err)
+	require.Contains(t, err.Error(), "invalid geometry payload")
+}
+
+func TestStMeasuresGeodeticGeometry32RejectInvalidCoordinates(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	geom32SRID4326 := types.T_geometry32.ToType()
+	geom32SRID4326.Width = 4327 // SRID 4326
+	encode32 := func(wkt string) string {
+		g, err := geo.ParseWKT(wkt)
+		require.NoError(t, err)
+		payload, err := geo.WriteWKBFloat32(g)
+		require.NoError(t, err)
+		return string(payload)
+	}
+	wantError := NewFunctionTestResult(types.T_float32.ToType(), true, nil, nil)
+	for _, tc := range []struct {
+		name   string
+		inputs []FunctionTestInput
+		fn     fEvalFn
+	}{
+		{
+			name: "ST_Distance",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom32SRID4326, []string{encode32("POINT(0 0)")}, []bool{false}),
+				NewFunctionTestInput(geom32SRID4326, []string{encode32("POINT(181 0)")}, []bool{false}),
+			},
+			fn: StDistance32,
+		},
+		{
+			name: "ST_Length",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom32SRID4326, []string{encode32("LINESTRING(0 0,0 91)")}, []bool{false}),
+			},
+			fn: StLength32,
+		},
+		{
+			name: "ST_Area",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom32SRID4326, []string{encode32("POLYGON((0 0,1 0,1 91,0 91,0 0))")}, []bool{false}),
+			},
+			fn: StArea32,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := NewFunctionTestCase(proc, tc.inputs, wantError, tc.fn)
+			ok, info := fc.Run()
+			require.True(t, ok, info)
+		})
+	}
+}
+
+func TestStMeasuresGeodeticSRID0Compatibility(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	geom0 := types.T_geometry.ToType()
+	geom4326 := geom0
+	geom4326.Width = 4327
+	wantDistance := NewFunctionTestResult(types.T_float64.ToType(), false, []float64{181}, []bool{false})
+	wantLength := NewFunctionTestResult(types.T_float64.ToType(), false, []float64{181}, []bool{false})
+	wantArea := NewFunctionTestResult(types.T_float64.ToType(), false, []float64{91}, []bool{false})
+	for _, tc := range []struct {
+		name   string
+		inputs []FunctionTestInput
+		want   FunctionTestResult
+		fn     fEvalFn
+	}{
+		{
+			name: "default SRID 0 ST_Distance",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom0, []string{"POINT(0 0)"}, []bool{false}),
+				NewFunctionTestInput(geom0, []string{"POINT(181 0)"}, []bool{false}),
+			},
+			want: wantDistance,
+			fn:   StDistance,
+		},
+		{
+			name: "default SRID 0 ST_Length",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom0, []string{"LINESTRING(0 0,181 0)"}, []bool{false}),
+			},
+			want: wantLength,
+			fn:   StLength,
+		},
+		{
+			name: "default SRID 0 ST_Area",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom0, []string{"POLYGON((0 0,1 0,1 91,0 91,0 0))"}, []bool{false}),
+			},
+			want: wantArea,
+			fn:   StArea,
+		},
+		{
+			name: "explicit SRID 0 overrides typed SRID 4326 for ST_Distance",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"POINT(0 0)"}, []bool{false}),
+				NewFunctionTestInput(geom4326, []string{"POINT(181 0)"}, []bool{false}),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{0}, []bool{false}),
+			},
+			want: wantDistance,
+			fn:   StDistanceWithSRID,
+		},
+		{
+			name: "explicit SRID 0 overrides typed SRID 4326 for ST_Length",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"LINESTRING(0 0,181 0)"}, []bool{false}),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{0}, []bool{false}),
+			},
+			want: wantLength,
+			fn:   StLengthWithSRID,
+		},
+		{
+			name: "explicit SRID 0 overrides typed SRID 4326 for ST_Area",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(geom4326, []string{"POLYGON((0 0,1 0,1 91,0 91,0 0))"}, []bool{false}),
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{0}, []bool{false}),
+			},
+			want: wantArea,
+			fn:   StAreaWithSRID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := NewFunctionTestCase(proc, tc.inputs, tc.want, tc.fn)
+			ok, info := fc.Run()
+			require.True(t, ok, info)
+		})
+	}
+
+	// A SQL NULL and a row masked by a preceding expression must not expose an
+	// invalid coordinate in another lane to the geodetic validator.
+	const oneDegreeMeters = 111195.0802335329
+	masked := NewFunctionTestCase(proc,
+		[]FunctionTestInput{NewFunctionTestInput(geom4326,
+			[]string{"LINESTRING(0 0,1 0)", "", "LINESTRING(0 0,181 0)"},
+			[]bool{false, true, false})},
+		NewFunctionTestResult(types.T_float64.ToType(), false,
+			[]float64{oneDegreeMeters, 0, 0}, []bool{false, true, true}), StLength).
+		WithSelectList(&FunctionSelectList{AnyNull: true, SelectList: []bool{true, true, false}})
+	ok, info := masked.Run()
+	require.True(t, ok, info)
+
+	zeroRows := NewFunctionTestCase(proc,
+		[]FunctionTestInput{NewFunctionTestInput(geom4326, []string{}, []bool{})},
+		NewFunctionTestResult(types.T_float64.ToType(), false, []float64{}, []bool{}), StLength)
+	ok, info = zeroRows.Run()
+	require.True(t, ok, info)
+}
+
 func TestGeometry32Distances(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	g32 := func(wkt string) string {

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -1958,6 +1958,9 @@ func geodeticArea(payload []byte) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if err := geo.ValidateGeodeticCoordinates(g); err != nil {
+		return 0, err
+	}
 	return geo.AreaSquareMeters(g), nil
 }
 
@@ -1973,6 +1976,9 @@ func geodeticLength(payload []byte) (float64, error) {
 	}
 	g, err := decodeGeoGeometry(payload)
 	if err != nil {
+		return 0, err
+	}
+	if err := geo.ValidateGeodeticCoordinates(g); err != nil {
 		return 0, err
 	}
 	return geo.LengthMeters(g), nil

--- a/test/distributed/cases/geo/geo_geodetic.result
+++ b/test/distributed/cases/geo/geo_geodetic.result
@@ -28,14 +28,79 @@ forced_geodesic_dist_m
 select st_area(st_geomfromtext('POLYGON((0 0,3 0,3 4,0 4,0 0))', 4326), 0) as forced_cartesian_area;
 forced_cartesian_area
 12.0
+select st_distance(st_geomfromtext('POINT(181 0)', 4326), st_geomfromtext('POINT(0 0)', 4326));
+invalid input: SRID 4326 longitude 181 is out of range [-180, 180]
+select st_distance(st_geomfromtext('POINT(0 0)', 4326), st_geomfromtext('POINT(0 91)', 4326));
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_distance(st_geomfromtext('MULTIPOINT((0 0),(181 0))', 4326), st_geomfromtext('POLYGON((-1 -1,1 -1,1 1,-1 1,-1 -1))', 4326));
+invalid input: SRID 4326 longitude 181 is out of range [-180, 180]
+select st_length(st_geomfromtext('LINESTRING(0 0,181 0)', 4326));
+invalid input: SRID 4326 longitude 181 is out of range [-180, 180]
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))', 4326));
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_distance(st_geomfromtext('POINT(0 0)'), st_geomfromtext('POINT(181 0)'), 4326);
+invalid input: SRID 4326 longitude 181 is out of range [-180, 180]
+select st_length(st_geomfromtext('LINESTRING(0 0,0 91)'), 4326);
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))'), 4326);
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_distance(st_geomfromtext('POINT(0 0)'), st_geomfromtext('POINT(181 0)')) as cartesian_distance_out_of_range;
+cartesian_distance_out_of_range
+181.0
+select st_length(st_geomfromtext('LINESTRING(0 0,181 0)')) as cartesian_length_out_of_range;
+cartesian_length_out_of_range
+181.0
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))')) as cartesian_area_out_of_range;
+cartesian_area_out_of_range
+91.0
+select st_distance(st_geomfromtext('POINT(0 0)', 4326), st_geomfromtext('POINT(181 0)', 4326), 0) as forced_cartesian_distance_out_of_range;
+forced_cartesian_distance_out_of_range
+181.0
+select st_length(st_geomfromtext('LINESTRING(0 0,181 0)', 4326), 0) as forced_cartesian_length_out_of_range;
+forced_cartesian_length_out_of_range
+181.0
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))', 4326), 0) as forced_cartesian_area_out_of_range;
+forced_cartesian_area_out_of_range
+91.0
 drop database if exists geo_geodetic;
 create database geo_geodetic;
 use geo_geodetic;
 drop table if exists places;
-create table places(id int, g geography);
-insert into places values (1, st_geomfromtext('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326));
-select id, st_srid(g) as srid, st_area(g) as area_m2 from places order by id;
+create table places(id int, g geography, g32 geography32);
+insert into places values (1, st_geomfromtext('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326), cast('POLYGON((0 0,1 0,1 1,0 1,0 0))' as geography32)), (2, st_geomfromtext('POINT(181 0)', 4326), cast('POINT(181 0)' as geography32)), (3, st_geomfromtext('LINESTRING(0 0,0 91)', 4326), cast('LINESTRING(0 0,0 91)' as geography32)), (4, st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))', 4326), cast('POLYGON((0 0,1 0,1 91,0 91,0 0))' as geography32)), (5, st_geomfromtext('POINT(180 90)', 4326), cast('POINT(180 90)' as geography32));
+prepare geo_measure_reuse from 'select st_distance(g, g) as distance_m from places where id = ?';
+set @geo_measure_id = 1;
+execute geo_measure_reuse using @geo_measure_id;
+distance_m
+0.0
+set @geo_measure_id = 2;
+execute geo_measure_reuse using @geo_measure_id;
+invalid input: SRID 4326 longitude 181 is out of range [-180, 180]
+set @geo_measure_id = 5;
+execute geo_measure_reuse using @geo_measure_id;
+distance_m
+0.0
+deallocate prepare geo_measure_reuse;
+select id, st_srid(g) as srid, st_area(g) as area_m2 from places where id = 1;
 id    srid    area_m2
 1    4326    1.236403190946562E10
+select st_distance(g, g) from places where id = 2;
+invalid input: SRID 4326 longitude 181 is out of range [-180, 180]
+select st_length(g) from places where id = 3;
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_area(g) from places where id = 4;
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_distance(g32, g32) from places where id = 2;
+invalid input: SRID 4326 longitude 181 is out of range [-180, 180]
+select st_length(g32) from places where id = 3;
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_area(g32) from places where id = 4;
+invalid input: SRID 4326 latitude 91 is out of range [-90, 90]
+select st_distance(g, g) as inclusive_geodetic_boundary from places where id = 5;
+inclusive_geodetic_boundary
+0.0
+select st_distance(g32, g32) as inclusive_geodetic_boundary32 from places where id = 5;
+inclusive_geodetic_boundary32
+0.0
 drop table places;
 drop database geo_geodetic;

--- a/test/distributed/cases/geo/geo_geodetic.sql
+++ b/test/distributed/cases/geo/geo_geodetic.sql
@@ -20,14 +20,54 @@ select st_length(st_geomfromtext('LINESTRING(0 0,1 0)'), 4326) as forced_geodesi
 select st_distance(st_geomfromtext('POINT(0 0)'), st_geomfromtext('POINT(1 0)'), 4326) as forced_geodesic_dist_m;
 select st_area(st_geomfromtext('POLYGON((0 0,3 0,3 4,0 4,0 0))', 4326), 0) as forced_cartesian_area;
 
+-- S2 normalizes finite out-of-range coordinates. SRID-4326 measurement
+-- functions must reject them before entering the S2 kernels; validate both
+-- operands and every coordinate, even when distance could return early.
+select st_distance(st_geomfromtext('POINT(181 0)', 4326), st_geomfromtext('POINT(0 0)', 4326));
+select st_distance(st_geomfromtext('POINT(0 0)', 4326), st_geomfromtext('POINT(0 91)', 4326));
+select st_distance(st_geomfromtext('MULTIPOINT((0 0),(181 0))', 4326), st_geomfromtext('POLYGON((-1 -1,1 -1,1 1,-1 1,-1 -1))', 4326));
+select st_length(st_geomfromtext('LINESTRING(0 0,181 0)', 4326));
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))', 4326));
+
+-- The explicit-SRID overload selects the effective coordinate system. These
+-- must reject invalid coordinates for 4326, but preserve SRID-0 Cartesian
+-- behavior even when the geometry value itself is typed as 4326.
+select st_distance(st_geomfromtext('POINT(0 0)'), st_geomfromtext('POINT(181 0)'), 4326);
+select st_length(st_geomfromtext('LINESTRING(0 0,0 91)'), 4326);
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))'), 4326);
+select st_distance(st_geomfromtext('POINT(0 0)'), st_geomfromtext('POINT(181 0)')) as cartesian_distance_out_of_range;
+select st_length(st_geomfromtext('LINESTRING(0 0,181 0)')) as cartesian_length_out_of_range;
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))')) as cartesian_area_out_of_range;
+select st_distance(st_geomfromtext('POINT(0 0)', 4326), st_geomfromtext('POINT(181 0)', 4326), 0) as forced_cartesian_distance_out_of_range;
+select st_length(st_geomfromtext('LINESTRING(0 0,181 0)', 4326), 0) as forced_cartesian_length_out_of_range;
+select st_area(st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))', 4326), 0) as forced_cartesian_area_out_of_range;
+
 -- A GEOGRAPHY column (generic geometry defaulting to SRID 4326) computes
 -- geodesically.
 drop database if exists geo_geodetic;
 create database geo_geodetic;
 use geo_geodetic;
 drop table if exists places;
-create table places(id int, g geography);
-insert into places values (1, st_geomfromtext('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326));
-select id, st_srid(g) as srid, st_area(g) as area_m2 from places order by id;
+create table places(id int, g geography, g32 geography32);
+insert into places values (1, st_geomfromtext('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326), cast('POLYGON((0 0,1 0,1 1,0 1,0 0))' as geography32)), (2, st_geomfromtext('POINT(181 0)', 4326), cast('POINT(181 0)' as geography32)), (3, st_geomfromtext('LINESTRING(0 0,0 91)', 4326), cast('LINESTRING(0 0,0 91)' as geography32)), (4, st_geomfromtext('POLYGON((0 0,1 0,1 91,0 91,0 0))', 4326), cast('POLYGON((0 0,1 0,1 91,0 91,0 0))' as geography32)), (5, st_geomfromtext('POINT(180 90)', 4326), cast('POINT(180 90)' as geography32));
+-- Reusing a prepared plan around an error must revalidate each execution and
+-- must not poison a later valid row.
+prepare geo_measure_reuse from 'select st_distance(g, g) as distance_m from places where id = ?';
+set @geo_measure_id = 1;
+execute geo_measure_reuse using @geo_measure_id;
+set @geo_measure_id = 2;
+execute geo_measure_reuse using @geo_measure_id;
+set @geo_measure_id = 5;
+execute geo_measure_reuse using @geo_measure_id;
+deallocate prepare geo_measure_reuse;
+select id, st_srid(g) as srid, st_area(g) as area_m2 from places where id = 1;
+select st_distance(g, g) from places where id = 2;
+select st_length(g) from places where id = 3;
+select st_area(g) from places where id = 4;
+select st_distance(g32, g32) from places where id = 2;
+select st_length(g32) from places where id = 3;
+select st_area(g32) from places where id = 4;
+select st_distance(g, g) as inclusive_geodetic_boundary from places where id = 5;
+select st_distance(g32, g32) as inclusive_geodetic_boundary32 from places where id = 5;
 drop table places;
 drop database geo_geodetic;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [ ] API-change
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #28191

## What this PR does / why we need it:

SRID-4326 `ST_Distance`, `ST_Length`, and `ST_Area` previously passed finite out-of-range longitude/latitude values to S2, which normalizes them and can return plausible but incorrect measurements. Add one allocation-free coordinate validator and invoke it at the geodetic measurement boundary. Distance validates both operands before containment/zero-distance shortcuts, so an invalid later vertex cannot be hidden by an earlier match.

The effective SRID determines validation: typed or explicit SRID 4326 enforces finite longitude `[-180,180]` and latitude `[-90,90]`; SRID 0 remains Cartesian, including explicit SRID-0 overrides on values typed as 4326. Constructors/storage and the separate `ST_DISTANCE_SPHERE` contract are unchanged. `GEOGRAPHY` and `GEOGRAPHY32` use the same guard.

### Risks and performance

- Each effective SRID-4326 measurement adds one O(n) coordinate scan (O(n+m) for distance); kernel complexity is unchanged. On Apple M4, a temporary microbenchmark measured approximately +1% for point distance, +5.3% for a 4096-coordinate line, and +2% for a 4096-vertex polygon, with zero additional allocations. These measurements are local directional evidence, not a production workload benchmark.
- The numeric-only `geo.LengthMeters`, `geo.AreaSquareMeters`, and `geo.DistanceMeters` APIs retain their signatures and cannot return validation errors. Their precondition is now documented; all in-repository production call sites either validate here or use `ST_DISTANCE_SPHERE`'s separate Point/MultiPoint validator.
- Out-of-range geometry can still be constructed/stored and used under SRID 0; it is rejected when measured using effective SRID 4326. This preserves explicit-SRID override behavior.

### Validation

- Verified the four issue reproducers fail on the unchanged base (`67a9a4b130388956971888a67fc626784deade48`) because each previously returned success; the same evaluator regressions pass with the fix.
- `GOWORK=off go test -mod=readonly -count=1 -timeout=180s ./pkg/geo` — PASS.
- `.agents/skills/mo-dev/scripts/mo-cgo-test -count=1 -timeout=10m ./pkg/sql/plan/function` — PASS.
- `GOWORK=off go vet -mod=readonly ./pkg/geo ./pkg/sql/plan/function` — PASS.
- `golangci-lint run --config .golangci.yml --new-from-rev=67a9a4b130388956971888a67fc626784deade48 ./pkg/geo ./pkg/sql/plan/function` — PASS, 0 issues.
- `test/distributed/cases/geo/geo_geodetic.sql/.result` now covers invalid constants, explicit/default SRID controls, `GEOGRAPHY`/`GEOGRAPHY32` columns, inclusive boundaries, and prepared-query valid → invalid → valid reuse. The BVT was not run against a local service; its result is pending the PR's BVT CI.
